### PR TITLE
gschem: add zero termination to invalid keycode list.

### DIFF
--- a/gschem/src/g_keys.c
+++ b/gschem/src/g_keys.c
@@ -274,6 +274,7 @@ g_key_is_valid (guint keyval, GdkModifierType modifiers)
     GDK_First_Virtual_Screen, GDK_Prev_Virtual_Screen,
     GDK_Next_Virtual_Screen, GDK_Last_Virtual_Screen,
     GDK_Terminate_Server, GDK_AudibleBell_Enable,
+    0
   };
   const guint *val;
 


### PR DESCRIPTION
A loop in g_key_is_valid() scans a list of keycodes to see if the current
one matches. Add a zero to the end of the list so that the search terminates
correctly.
