### PR TITLE
Fix for 910663

### DIFF
--- a/gschem/src/g_rc.c
+++ b/gschem/src/g_rc.c
@@ -74,29 +74,38 @@ SCM g_rc_gschem_version(SCM scm_version)
 {
   SCM ret;
   char *version;
+  SCM rc_filename;
+  char *sourcefile;
   
   SCM_ASSERT (scm_is_string (scm_version), scm_version,
               SCM_ARG1, "gschem-version");
 
+  scm_dynwind_begin (0);
   version = scm_to_utf8_string (scm_version);
+  scm_dynwind_free (version);
+
   if (g_strcasecmp (version, PACKAGE_DATE_VERSION) != 0) {
+    sourcefile = NULL;
+    rc_filename = g_rc_rc_filename ();
+    sourcefile = scm_to_utf8_string (rc_filename);
+    scm_dynwind_free (sourcefile);
     fprintf(stderr,
             "You are running gEDA/gaf version [%s%s.%s],\n",
             PREPEND_VERSION_STRING, PACKAGE_DOTTED_VERSION,
             PACKAGE_DATE_VERSION);
     fprintf(stderr,
             "but you have a version [%s] gschemrc file:\n[%s]\n",
-            version, rc_filename);
+            version, sourcefile);
     fprintf(stderr,
             "Please be sure that you have the latest rc file.\n");
     ret = SCM_BOOL_F;
   } else {
     ret = SCM_BOOL_T;
   }
-
-  free(version);
+  scm_dynwind_end();
   return ret;
 }
+
 
 /*! \todo Finish function documentation!!!
  *  \brief

--- a/libgeda/include/libgeda/prototype.h
+++ b/libgeda/include/libgeda/prototype.h
@@ -40,6 +40,7 @@ gboolean g_rc_parse_local (TOPLEVEL *toplevel, const gchar *rcname, const gchar 
 gboolean g_rc_parse_file (TOPLEVEL *toplevel, const gchar *rcfile, GError **err);
 void g_rc_parse(TOPLEVEL *toplevel, const gchar* pname, const gchar* rcname, const gchar* rcfile);
 void g_rc_parse_handler (TOPLEVEL *toplevel, const gchar *rcname, const gchar *rcfile, ConfigParseErrorFunc handler, void *user_data);
+SCM g_rc_rc_filename();
 
 /* i_vars.c */
 void i_vars_libgeda_set(TOPLEVEL *toplevel);

--- a/libgeda/src/g_rc.c
+++ b/libgeda/src/g_rc.c
@@ -661,6 +661,39 @@ SCM g_rc_source_library_search(SCM path)
   return SCM_BOOL_T;
 }
 
+/*!
+ * \brief Get the name of the RC filename being evaluated.
+ * \par Function Description
+ *
+ * Creates a Guile stack object, extracts the topmost frame from that
+ * stack and gets the sourcefile name.
+ *
+ * \returns If the interpreter can resolve the filename, returns a
+ * Scheme object with the full path to the RC file, otherwise #f
+ */
+SCM
+g_rc_rc_filename()
+{
+  SCM stack, frame, source;
+
+  stack = scm_make_stack (SCM_BOOL_T, SCM_EOL);
+  if (scm_is_false (stack)) {
+    return SCM_BOOL_F;
+  }
+
+  frame = scm_stack_ref (stack, scm_from_int(0));
+  if (scm_is_false (frame)) {
+    return SCM_BOOL_F;
+  }
+
+  source = scm_frame_source (frame);
+  if (scm_is_false (source)) {
+    return SCM_BOOL_F;
+  }
+
+  return scm_source_property (source, scm_sym_filename);
+}
+
 /*! \todo Finish function description!!!
  *  \brief
  *  \par Function Description

--- a/libgeda/src/g_register.c
+++ b/libgeda/src/g_register.c
@@ -72,6 +72,7 @@ static struct gsubr_t libgeda_funcs[] = {
   { "always-promote-attributes",1, 0, 0, g_rc_always_promote_attributes },
   { "make-backup-files",        1, 0, 0, g_rc_make_backup_files },
   { "print-color-map", 0, 1, 0, g_rc_print_color_map },
+  { "rc-filename",              0, 0, 0, g_rc_rc_filename },
   { NULL,                       0, 0, 0, NULL } };
 
 /*! \brief Register all libgeda functions with scheme.


### PR DESCRIPTION
Add a new Scheme function "rc-filename" to libgeda to extract the
filename of the Scheme file under evaluation, and use this in the
"gschem-version" Scheme function in gschem to show which file is
wrong.

Closes-bug: lp-910663
