### PR TITLE
ci: Enable test builds using Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,17 @@ env:
 
 # Before setting up the source tree, install necessary development
 # headers
-before_install: >
-  sudo apt-get update && 
-  sudo apt-get install -y \
-    libgtk2.0-dev autopoint libgettextpo-dev libstroke0-dev \
-    guile-2.0-dev flex bison groff \
-    texinfo texlive-base texlive-generic-recommended texlive-latex-base
+before_install:
+  - sudo apt-get update
+  - sudo apt-get install -y libgtk2.0-dev autopoint libgettextpo-dev
+    libstroke0-dev guile-2.0-dev flex bison groff texinfo texlive-base
+    texlive-generic-recommended texlive-latex-base
+
+  # FIXME[2017-02-15] This is required because Ubuntu Trusty only has
+  # Guile-2.0.9, which doesn't include SRFI-64
+  - sudo mkdir -p /usr/share/guile/2.0/srfi/srfi-64
+  - sudo curl http://git.savannah.gnu.org/cgit/guile.git/plain/module/srfi/srfi-64.scm -o /usr/share/guile/2.0/srfi/srfi-64.scm 
+  - sudo curl http://git.savannah.gnu.org/cgit/guile.git/plain/module/srfi/srfi-64/testing.scm -o /usr/share/guile/2.0/srfi/srfi-64/testing.scm
 
 # Set up the source tree by running autotools
 install: ./autogen.sh && ./configure --disable-update-xdg-database CFLAGS='-DSCM_DEBUG_TYPING_STRICTNESS=0'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,42 @@
 # Very basic Travis CI (http://travis-ci.org) control file that allows
 # some basic Linux-based continuous integration testing (for free).
 
+sudo: required
+dist: trusty
+
 language: c
+
+env:
+  global:
+    # COVERITY_SCAN_TOKEN
+    - secure: "BIl7HDdWo2EpK63Nta2Sjy/V2rMYt4E5Jl+tWEkWR3be+s61oRg2DoIqdTTntvo8os8gq90Fb8WJJWZQ2806BfsNF+Z+DZqN59iNQOEB2aiA0BhggyOHnF+OoZZfgv7q4Eq0XOS7KLSrnCu18E0qQKxJSjnBrO9k1cLS3QnKDCA="
 
 # Before setting up the source tree, install necessary development
 # headers
 before_install: >
+  sudo apt-get update && 
   sudo apt-get install -y \
     libgtk2.0-dev autopoint libgettextpo-dev libstroke0-dev \
-    guile-2.0-dev flex bison groff texinfo
+    guile-2.0-dev flex bison groff \
+    texinfo texlive-base texlive-generic-recommended texlive-latex-base
 
-# Set up the source tree by fetching Linux-specific prebuilt objects
+# Set up the source tree by running autotools
 install: ./autogen.sh && ./configure --disable-update-xdg-database
 
-# Bootstrap the LCB compiler, build the default target set and run a
-# the default test suite.
-script: make -s all check
+# Compile gEDA and run its tests
+script: >
+  if test "${COVERITY_SCAN_BRANCH}" != "1"; then
+    make -kj4 distcheck
+  fi
+
+addons:
+  # In order to trigger static analysis with Coverity Scan, push to
+  # the coverity_scan branch.  You should only usually scan the tip of
+  # "master-ng".
+  coverity_scan:
+    project:
+      name: peter-b/geda-gaf
+      description: Build submitted via Travis CI
+    notification_email: peter@peter-b.co.uk
+    build_command: make all
+    branch_pattern: coverity_scan

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,12 +36,17 @@ script: >
 
 addons:
   # In order to trigger static analysis with Coverity Scan, push to
-  # the coverity_scan branch.  You should only usually scan the tip of
-  # "master-ng".
+  # the "coverity_scan" branch.  You should only usually scan the tip of
+  # "master".
   coverity_scan:
     project:
+      # FIXME[Issue #43] Figure out how to rename the Coverity Scan
+      # project from this historical name
       name: peter-b/geda-gaf
       description: Build submitted via Travis CI
+
+    # FIXME[Issue #44] Replace this e-mail address once there's a
+    # mailing list or e-mail alias set up for Lepton developers
     notification_email: peter@peter-b.co.uk
     build_command: make all
     branch_pattern: coverity_scan

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,20 @@ before_install:
   - sudo curl http://git.savannah.gnu.org/cgit/guile.git/plain/module/srfi/srfi-64/testing.scm -o /usr/share/guile/2.0/srfi/srfi-64/testing.scm
 
 # Set up the source tree by running autotools
-install: ./autogen.sh && ./configure --disable-update-xdg-database CFLAGS='-DSCM_DEBUG_TYPING_STRICTNESS=0'
+#
+# The SCM_DEBUG_TYPING_STRICTNESS macro determines how C code that
+# uses Guile Scheme values is compiled.  We set it to 0 for Coverity
+# Scan builds, because with a non-zero value libguile's macros
+# generate code that Coverity correctly identifies as undefined
+# behaviour in C.
+install:
+  - ./autogen.sh
+  - >
+      if test "${COVERITY_SCAN_BRANCH}" = "1"; then
+        ./configure --disable-update-xdg-database
+      else
+        ./configure --disable-update-xdg-database CFLAGS='-DSCM_DEBUG_TYPING_STRICTNESS=2'
+      fi
 
 # Compile gEDA and run its tests
 script: >

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install: ./autogen.sh && ./configure --disable-update-xdg-database CFLAGS='-DSCM
 # Compile gEDA and run its tests
 script: >
   if test "${COVERITY_SCAN_BRANCH}" != "1"; then
-    make -kj4 distcheck
+    make -sj4 distcheck
   fi
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install: >
     texinfo texlive-base texlive-generic-recommended texlive-latex-base
 
 # Set up the source tree by running autotools
-install: ./autogen.sh && ./configure --disable-update-xdg-database
+install: ./autogen.sh && ./configure --disable-update-xdg-database CFLAGS='-DSCM_DEBUG_TYPING_STRICTNESS=0'
 
 # Compile gEDA and run its tests
 script: >


### PR DESCRIPTION
[Travis CI](https://travis-ci.org/) is a continuous integration service that is free to use for open source software hosted on github.

This pull request configures the lepton repository to automatically run `make distcheck` for all pull requests, in order to verify that changes don't break the distributed build. This will easily catch common problems like adding a new file and forgetting to commit it, or forgetting to update a `Makefile.am` after removing a file.