### PR TITLE
Get rid of links to the gEDA launchpad bug tracker.

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -10,9 +10,9 @@ to contribute to gEDA.
 How to submit patches
 =====================
 
-Please submit patches to the bug tracker on Launchpad:
+Please submit patches to the lepton-eda bug tracker:
 
-  <https://bugs.launchpad.net/geda>
+  <https://github.com/lepton-eda/lepton-eda/issues>
 
 Once you've submitted your patches, you may wish to also e-mail the
 `gEDA-user' mailing list [1] to announce that you've done so and to ask
@@ -44,7 +44,7 @@ integrate them, please try to follow the following guidelines:
         Sometimes, the commit message will be considerably longer than
         the patch itself.
 
-      * If the patch is related to another bug in the Launchpad
+      * If the patch is related to another bug in the lepton-eda bug
         tracker, include its bug number.
 
       * If your patch fixes a regression, and you know which commit

--- a/README
+++ b/README
@@ -247,12 +247,10 @@ There are several ways to get help with installing and using gEDA:
    `geda-user' mailing list.
    <http://wiki.geda-project.org/geda:mailinglists>
 
- - Alternatively, you can add your question to the gEDA Answers page
-   on Launchpad. <https://answers.launchpad.net/geda>
-
  - If you have discovered a bug, have a feature request, or have
-   written a patch to gEDA, please create an item on the gEDA Bugs
-   page on Launchpad. <http://bugs.launchpad.net/geda>
+   written a patch to lepton-eda, please create an item on the
+   lepton-eda bug tracker page:
+   <https://github.com/lepton-eda/lepton-eda/issues>
 
 License
 =======

--- a/docs/scheme-api/geda-scheme.texi
+++ b/docs/scheme-api/geda-scheme.texi
@@ -98,8 +98,8 @@ embedded Scheme.  For more information about Guile, please visit
 @section Getting Additional Help
 @cindex Reporting bugs
 
-If you think you have found a bug, please file a bug report in
-Launchpad: @uref{http://bugs.launchpad.net/geda}. Please add the tag
+If you think you have found a bug, please file a bug report:
+@uref{https://github.com/lepton-eda/lepton-eda/issues}. Please add the tag
 @samp{scheme-api}.  It will help us to fix your bug quickly if you can
 describe in detail how to reproduce the bug.
 
@@ -115,8 +115,8 @@ website: @uref{http://www.geda-project.org/}.
 
 If you find a typographical error in this manual, or if you have
 thought of a way to make this manual better, we would love to hear
-from you! Please submit a report in Launchpad:
-@uref{http://bugs.launchpad.net/geda}, with the tag @samp{scheme-api}.
+from you! Please submit a bug report:
+@uref{https://github.com/lepton-eda/lepton-eda/issues}, with the tag @samp{scheme-api}.
 
 @node Schematic Document Model
 @chapter The Schematic Document Model
@@ -2513,7 +2513,7 @@ properties can be specified for the action by providing pairs of
 
 @example
 (define-action (&report-bug #:label ``Report Bug'' #:icon ``web-browser'')
-  (show-uri ``http://bugs.launchpad.net/geda/+reportbug''))
+  (show-uri ``https://github.com/lepton-eda/lepton-eda/issues/new''))
 @end example
 
 Since 1.10.

--- a/gaf/po/Makevars
+++ b/gaf/po/Makevars
@@ -34,7 +34,7 @@ COPYRIGHT_HOLDER = gEDA Developers
 # It can be your email address, or a mailing list address where translators
 # can write to without being subscribed, or the URL of a web page through
 # which the translators can contact you.
-MSGID_BUGS_ADDRESS = https://bugs.launchpad.net/geda
+MSGID_BUGS_ADDRESS = https://github.com/lepton-eda/lepton-eda/issues
 
 # This is the list of locale categories, beyond LC_MESSAGES, for which the
 # message catalogs shall be used.  It is usually empty.

--- a/gattrib/po/Makevars
+++ b/gattrib/po/Makevars
@@ -34,7 +34,7 @@ COPYRIGHT_HOLDER = gEDA Developers
 # It can be your email address, or a mailing list address where translators
 # can write to without being subscribed, or the URL of a web page through
 # which the translators can contact you.
-MSGID_BUGS_ADDRESS = https://bugs.launchpad.net/geda
+MSGID_BUGS_ADDRESS = https://github.com/lepton-eda/lepton-eda/issues
 
 # This is the list of locale categories, beyond LC_MESSAGES, for which the
 # message catalogs shall be used.  It is usually empty.

--- a/gnetlist/po/Makevars
+++ b/gnetlist/po/Makevars
@@ -34,7 +34,7 @@ COPYRIGHT_HOLDER = gEDA Developers
 # It can be your email address, or a mailing list address where translators
 # can write to without being subscribed, or the URL of a web page through
 # which the translators can contact you.
-MSGID_BUGS_ADDRESS = https://bugs.launchpad.net/geda
+MSGID_BUGS_ADDRESS = https://github.com/lepton-eda/lepton-eda/issues
 
 # This is the list of locale categories, beyond LC_MESSAGES, for which the
 # message catalogs shall be used.  It is usually empty.

--- a/gnetlist/src/parsecmd.c
+++ b/gnetlist/src/parsecmd.c
@@ -84,7 +84,7 @@ void usage(char *cmd)
 "  -V, --version   Show version information.\n"
 "  --              Treat all remaining arguments as filenames.\n"
 "\n"
-"Report bugs at <https://bugs.launchpad.net/geda>\n"
+"Report bugs at <https://github.com/lepton-eda/lepton-eda/issues>\n"
 "gEDA/gaf homepage: <http://www.geda-project.org/>\n"),
           cmd);
   exit (0);

--- a/gschem/po/Makevars
+++ b/gschem/po/Makevars
@@ -34,7 +34,7 @@ COPYRIGHT_HOLDER = gEDA Developers
 # It can be your email address, or a mailing list address where translators
 # can write to without being subscribed, or the URL of a web page through
 # which the translators can contact you.
-MSGID_BUGS_ADDRESS = https://bugs.launchpad.net/geda
+MSGID_BUGS_ADDRESS = https://github.com/lepton-eda/lepton-eda/issues
 
 # This is the list of locale categories, beyond LC_MESSAGES, for which the
 # message catalogs shall be used.  It is usually empty.

--- a/gschem/src/parsecmd.c
+++ b/gschem/src/parsecmd.c
@@ -93,7 +93,7 @@ usage(char *cmd)
 "  -h, --help               Help; this message.\n"
 "  --                       Treat all remaining arguments as filenames.\n"
 "\n"
-"Report bugs at <https://bugs.launchpad.net/geda>\n"
+"Report bugs at <https://github.com/lepton-eda/lepton-eda/issues>\n"
 "gEDA/gaf homepage: <http://www.geda-project.org/>\n"),
          cmd);
   exit(0);

--- a/gsymcheck/po/Makevars
+++ b/gsymcheck/po/Makevars
@@ -34,7 +34,7 @@ COPYRIGHT_HOLDER = gEDA Developers
 # It can be your email address, or a mailing list address where translators
 # can write to without being subscribed, or the URL of a web page through
 # which the translators can contact you.
-MSGID_BUGS_ADDRESS = https://bugs.launchpad.net/geda
+MSGID_BUGS_ADDRESS = https://github.com/lepton-eda/lepton-eda/issues
 
 # This is the list of locale categories, beyond LC_MESSAGES, for which the
 # message catalogs shall be used.  It is usually empty.

--- a/libgeda/po/Makevars
+++ b/libgeda/po/Makevars
@@ -41,7 +41,7 @@ COPYRIGHT_HOLDER = gEDA Developers
 # It can be your email address, or a mailing list address where translators
 # can write to without being subscribed, or the URL of a web page through
 # which the translators can contact you.
-MSGID_BUGS_ADDRESS = https://bugs.launchpad.net/geda
+MSGID_BUGS_ADDRESS = https://github.com/lepton-eda/lepton-eda/issues
 
 # This is the list of locale categories, beyond LC_MESSAGES, for which the
 # message catalogs shall be used.  It is usually empty.

--- a/libgedacairo/README
+++ b/libgedacairo/README
@@ -20,7 +20,7 @@ The library is based on Peter Clifton's preexisting gschem rendering
 code.
 
 Please submit bug reports and patches to
-<http://bugs.launchpad.net/geda>, using the `libgedacairo' tag.
+<https://github.com/lepton-eda/lepton-eda/issues>, using the `libgedacairo' tag.
 
 Using libgedacairo in your programs
 -----------------------------------


### PR DESCRIPTION
All links have been replaced with link to lepton issue tracker.