### PR TITLE
Automatically add newlines to log messages

### DIFF
--- a/gschem/src/gschem_log_widget.c
+++ b/gschem/src/gschem_log_widget.c
@@ -182,6 +182,7 @@ log_message (GschemLogWidgetClass *klass, const gchar *message, const gchar *sty
   if (g_utf8_validate (message, -1, NULL)) {
     gtk_text_buffer_insert_with_tags_by_name (klass->buffer, &iter, message, -1,
                                               "plain", style, NULL);
+    gtk_text_buffer_insert (klass->buffer, &iter, "\n", -1);
   } else {
     /* If UTF-8 wasn't valid (due to a system locale encoded filename or
      * other string being included by mistake), log a warning, and print

--- a/liblepton/src/s_log.c
+++ b/liblepton/src/s_log.c
@@ -250,14 +250,17 @@ static void s_log_handler (const gchar *log_domain,
 			   const gchar *message,
 			   gpointer user_data)
 {
-  int status;
-
   if (do_logging == FALSE) {
     return;
   }
   g_return_if_fail (logfile_fd != -1);
-  
-  status = write (logfile_fd, message, strlen (message));
+
+  size_t len = strlen (message);
+  int status = 0;
+  if (status >= 0)
+    status = write (logfile_fd, message, len);
+  if (status >= 0)
+    status = write (logfile_fd, "\n", 1);
   if (status == -1) {
     fprintf(stderr, "Could not write message to log file\n");
   }


### PR DESCRIPTION
When we log messages, we do so via `g_log_default_handler()`, which
always adds a newline to the message.  This makes the newlines at the
end of message a bit redundant.  Conceptually, it makes good sense to
leave the newlines off the ends of log messages, because the newline
character doesn't really contain any information.

This patch makes the log paths inside Lepton (both for logging to disk
and for display to gschem's log window) also automatically add
newlines, so they behave the same as the GLib default log handler.

The immediate effect of this is to add lots of extra whitespace to the
log files.  This patch should be followed up by going through our
loggable strings to remove trailing newline characters, possibly using
a regular expression to do most of the heavy lifting.