### PR TITLE
Change bugtracker link to point to lepton-eda GitHub issue tracker

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@ dnl directory.
 # Set up configuration system
 #####################################################################
 
-AC_INIT([gEDA/gaf], [1.9.2], [https://bugs.launchpad.net/geda], [geda-gaf])
+AC_INIT([gEDA/gaf], [1.9.2], [https://github.com/lepton-eda/lepton-eda/issues], [geda-gaf])
 AC_PREREQ([2.60])
 
 AC_CONFIG_SRCDIR([libgeda/src/libgeda.c])


### PR DESCRIPTION
Change the bugtracker parameter in the call in AC_INIT() so that the
help messages printed by the tool suite have the leptop-eda
issue tracker URL.

This is a supplementary commit to 92b534e2.