### PR TITLE
Ensure libgeda headers can be compiled by C++ compilers

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -41,6 +41,7 @@ AX_WINDOWS_FLAGS
 #####################################################################
 
 AC_PROG_CC
+AC_PROG_CXX
 AC_PROG_CPP
 m4_ifdef([AM_PROG_AR], [AM_PROG_AR]) dnl Workaround for Automake 1.11
 

--- a/gschem/src/gschem_page_geometry.c
+++ b/gschem/src/gschem_page_geometry.c
@@ -346,7 +346,7 @@ gschem_page_geometry_new_with_values (int screen_width,
   GschemPageGeometry *geometry = g_new0 (GschemPageGeometry, 1);
 
   gschem_page_geometry_set_values (geometry,
-                                   max (abs ((double)(viewport_right - viewport_left) / screen_width), (abs ((double)(viewport_top - viewport_bottom) / screen_height))),
+                                   MAX (abs ((double)(viewport_right - viewport_left) / screen_width), (abs ((double)(viewport_top - viewport_bottom) / screen_height))),
                                    screen_width,
                                    screen_height,
                                    viewport_left,

--- a/gschem/src/gschem_page_view.c
+++ b/gschem/src/gschem_page_view.c
@@ -415,7 +415,7 @@ gschem_page_view_get_page_geometry (GschemPageView *view)
   }
   else {
     gschem_page_geometry_set_values (geometry,
-                                     max (abs ((double)(gschem_page_geometry_get_viewport_right (geometry) - gschem_page_geometry_get_viewport_left (geometry)) / screen_width), (abs ((double)(gschem_page_geometry_get_viewport_top (geometry) - gschem_page_geometry_get_viewport_bottom (geometry)) / screen_height))),
+                                     MAX (abs ((double)(gschem_page_geometry_get_viewport_right (geometry) - gschem_page_geometry_get_viewport_left (geometry)) / screen_width), (abs ((double)(gschem_page_geometry_get_viewport_top (geometry) - gschem_page_geometry_get_viewport_bottom (geometry)) / screen_height))),
                                      screen_width,
                                      screen_height,
                                      gschem_page_geometry_get_viewport_left (geometry),

--- a/gschem/src/o_arc.c
+++ b/gschem/src/o_arc.c
@@ -218,7 +218,7 @@ void o_arc_motion (GschemToplevel *w_current, int w_x, int w_y, int whichone)
      */
     diff_x = abs(w_current->first_wx - snap_grid (w_current, w_x));
     diff_y = abs(w_current->first_wy - snap_grid (w_current, w_y));
-    w_current->distance = max(diff_x, diff_y);
+    w_current->distance = MAX(diff_x, diff_y);
   }
   else if((whichone == ARC_START_ANGLE) || (whichone == ARC_SWEEP_ANGLE)) {
     /* compute the angle */

--- a/gschem/src/o_box.c
+++ b/gschem/src/o_box.c
@@ -28,9 +28,9 @@
 #define GET_BOX_HEIGHT(w)			\
 	abs((w)->second_wy - (w)->first_wy)
 #define GET_BOX_LEFT(w)				\
-	min((w)->first_wx, (w)->second_wx)
+	MIN((w)->first_wx, (w)->second_wx)
 #define GET_BOX_TOP(w)				\
-        max((w)->first_wy, (w)->second_wy)
+        MAX((w)->first_wy, (w)->second_wy)
 
 /*! \todo Finish function documentation!!!
  *  \brief

--- a/gschem/src/o_circle.c
+++ b/gschem/src/o_circle.c
@@ -172,7 +172,7 @@ void o_circle_motion (GschemToplevel *w_current, int w_x, int w_y)
    */
   diff_x = abs(w_current->first_wx - w_x);
   diff_y = abs(w_current->first_wy - w_y);
-  w_current->distance = max(diff_x, diff_y);
+  w_current->distance = MAX(diff_x, diff_y);
 
   /* draw the new temporary circle */
   o_circle_invalidate_rubber (w_current);

--- a/gschem/src/o_grips.c
+++ b/gschem/src/o_grips.c
@@ -32,7 +32,7 @@
 #define GET_PICTURE_HEIGHT(w)						\
   (w)->pixbuf_wh_ratio == 0 ? 0 : abs((w)->second_wx - (w)->first_wx)/(w)->pixbuf_wh_ratio
 #define GET_PICTURE_LEFT(w)			\
-  min((w)->first_wx, (w)->second_wx)
+  MIN((w)->first_wx, (w)->second_wx)
 #define GET_PICTURE_TOP(w)						\
   (w)->first_wy > (w)->second_wy ? (w)->first_wy  :			\
   (w)->first_wy+abs((w)->second_wx - (w)->first_wx)/(w)->pixbuf_wh_ratio

--- a/gschem/src/o_net.c
+++ b/gschem/src/o_net.c
@@ -129,29 +129,29 @@ void o_net_guess_direction(GschemToplevel *w_current,
       y1 = o_current->line->y[0];
       y2 = o_current->line->y[1];
 
-      xmin = min(x1, x2);
-      ymin = min(y1, y2);
-      xmax = max(x1, x2);
-      ymax = max(y1, y2);
+      xmin = MIN(x1, x2);
+      ymin = MIN(y1, y2);
+      xmax = MAX(x1, x2);
+      ymax = MAX(y1, y2);
 
       if (orientation == HORIZONTAL && wy == y1) {
 	if (wx == xmin) {
-	  up = max(up, current_rules[1]);
-	  down = max(down, current_rules[1]);
-	  right = max(right, current_rules[0]);
-	  left = max(left, current_rules[2]);
+	  up = MAX(up, current_rules[1]);
+	  down = MAX(down, current_rules[1]);
+	  right = MAX(right, current_rules[0]);
+	  left = MAX(left, current_rules[2]);
 	}
 	else if (wx == xmax) {
-	  up = max(up, current_rules[1]);
-	  down = max(down, current_rules[1]);
-	  right = max(right, current_rules[2]);
-	  left = max(left, current_rules[0]);
+	  up = MAX(up, current_rules[1]);
+	  down = MAX(down, current_rules[1]);
+	  right = MAX(right, current_rules[2]);
+	  left = MAX(left, current_rules[0]);
 	}
 	else if (xmin < wx && wx < xmax) {
-	  up = max(up, current_rules[1]);
-	  down = max(down, current_rules[1]);
-	  right = max(right, current_rules[0]);
-	  left = max(left, current_rules[0]);
+	  up = MAX(up, current_rules[1]);
+	  down = MAX(down, current_rules[1]);
+	  right = MAX(right, current_rules[0]);
+	  left = MAX(left, current_rules[0]);
 	}
 	else {
 	  continue;
@@ -159,22 +159,22 @@ void o_net_guess_direction(GschemToplevel *w_current,
       }
       if (orientation == VERTICAL && wx == x1) {
 	if (wy == ymin) {
-	  up = max(up, current_rules[0]);
-	  down = max(down, current_rules[2]);
-	  right = max(right, current_rules[1]);
-	  left = max(left, current_rules[1]);
+	  up = MAX(up, current_rules[0]);
+	  down = MAX(down, current_rules[2]);
+	  right = MAX(right, current_rules[1]);
+	  left = MAX(left, current_rules[1]);
 	}
 	else if (wy == ymax) {
-	  up = max(up, current_rules[2]);
-	  down = max(down, current_rules[0]);
-	  right = max(right, current_rules[1]);
-	  left = max(left, current_rules[1]);
+	  up = MAX(up, current_rules[2]);
+	  down = MAX(down, current_rules[0]);
+	  right = MAX(right, current_rules[1]);
+	  left = MAX(left, current_rules[1]);
 	}
 	else if (ymin < wy && wy < ymax) {
-	  up = max(up, current_rules[0]);
-	  down = max(down, current_rules[0]);
-	  right = max(right, current_rules[1]);
-	  left = max(left, current_rules[1]);
+	  up = MAX(up, current_rules[0]);
+	  down = MAX(down, current_rules[0]);
+	  right = MAX(right, current_rules[1]);
+	  left = MAX(left, current_rules[1]);
 	}
 	else {
 	  continue;
@@ -227,8 +227,8 @@ void o_net_find_magnetic(GschemToplevel *w_current,
   min_weight = 0;
 
   /* max distance of all the different reaches */
-  magnetic_reach = max(MAGNETIC_PIN_REACH, MAGNETIC_NET_REACH);
-  magnetic_reach = max(magnetic_reach, MAGNETIC_BUS_REACH);
+  magnetic_reach = MAX(MAGNETIC_PIN_REACH, MAGNETIC_NET_REACH);
+  magnetic_reach = MAX(magnetic_reach, MAGNETIC_BUS_REACH);
 
   object_list = g_list_append (NULL, page->connectible_list);
 
@@ -673,7 +673,7 @@ o_net_draw_rubber(GschemToplevel *w_current, EdaRenderer *renderer)
 
   if (magnetic_net_mode) {
     if (w_current->magnetic_wx != -1 && w_current->magnetic_wy != -1) {
-      w_magnetic_halfsize = max (4 * size,
+      w_magnetic_halfsize = MAX (4 * size,
                                  gschem_page_view_WORLDabs (page_view, MAGNETIC_HALFSIZE));
       eda_cairo_arc (cr, flags, size,
                      w_current->magnetic_wx, w_current->magnetic_wy,
@@ -721,7 +721,7 @@ void o_net_invalidate_rubber (GschemToplevel *w_current)
 
   if (magnetic_net_mode) {
     if (w_current->magnetic_wx != -1 && w_current->magnetic_wy != -1) {
-      magnetic_halfsize = max (4 * size, MAGNETIC_HALFSIZE);
+      magnetic_halfsize = MAX (4 * size, MAGNETIC_HALFSIZE);
 
       o_invalidate_rect (w_current, magnetic_x - magnetic_halfsize,
                                     magnetic_y - magnetic_halfsize,

--- a/gschem/src/o_picture.c
+++ b/gschem/src/o_picture.c
@@ -29,7 +29,7 @@
 #define GET_PICTURE_HEIGHT(w)						\
   (w)->pixbuf_wh_ratio == 0 ? 0 : abs((w)->second_wx - (w)->first_wx)/(w)->pixbuf_wh_ratio
 #define GET_PICTURE_LEFT(w)			\
-  min((w)->first_wx, (w)->second_wx)
+  MIN((w)->first_wx, (w)->second_wx)
 #define GET_PICTURE_TOP(w)						\
   (w)->first_wy > (w)->second_wy ? (w)->first_wy  :			\
   (w)->first_wy+abs((w)->second_wx - (w)->first_wx)/(w)->pixbuf_wh_ratio

--- a/gschem/src/o_select.c
+++ b/gschem/src/o_select.c
@@ -301,7 +301,7 @@ void o_select_box_start(GschemToplevel *w_current, int w_x, int w_y)
 
   /* if we are still close to the button press location,
      then don't enter the selection box mode */
-  dist = gschem_page_view_SCREENabs (page_view, max(diff_x, diff_y));
+  dist = gschem_page_view_SCREENabs (page_view, MAX(diff_x, diff_y));
 
   if (dist >= 10) {
     w_current->second_wx = w_x;
@@ -392,10 +392,10 @@ void o_select_box_search(GschemToplevel *w_current)
   int left, right, top, bottom;
   const GList *iter;
 
-  left = min(w_current->first_wx, w_current->second_wx);
-  right = max(w_current->first_wx, w_current->second_wx);
-  top = min(w_current->first_wy, w_current->second_wy);
-  bottom = max(w_current->first_wy, w_current->second_wy);
+  left = MIN(w_current->first_wx, w_current->second_wx);
+  right = MAX(w_current->first_wx, w_current->second_wx);
+  top = MIN(w_current->first_wy, w_current->second_wy);
+  bottom = MAX(w_current->first_wy, w_current->second_wy);
 
   iter = s_page_objects (toplevel->page_current);
   while (iter != NULL) {

--- a/gschem/src/o_undo.c
+++ b/gschem/src/o_undo.c
@@ -146,7 +146,7 @@ o_undo_savestate (GschemToplevel *w_current, PAGE *page, int flag)
                                 (geometry->viewport_left + geometry->viewport_right) / 2,
                                 (geometry->viewport_top + geometry->viewport_bottom) / 2,
                                 /* scale */
-                                max (((double) abs (geometry->viewport_right - geometry->viewport_left) / geometry->screen_width),
+                                MAX (((double) abs (geometry->viewport_right - geometry->viewport_left) / geometry->screen_width),
                                   ((double) abs (geometry->viewport_top - geometry->viewport_bottom) / geometry->screen_height)),
                                 page->page_control,
                                 page->up);

--- a/gschem/src/x_event.c
+++ b/gschem/src/x_event.c
@@ -764,7 +764,7 @@ gint x_event_scroll (GtkWidget *widget, GdkEventScroll *event,
   if (pan_xaxis) {
     adj = gschem_page_view_get_hadjustment (GSCHEM_PAGE_VIEW (widget));
     g_return_val_if_fail (adj != NULL, TRUE);
-    gtk_adjustment_set_value(adj, min(adj->value + pan_direction *
+    gtk_adjustment_set_value(adj, MIN(adj->value + pan_direction *
                                         (adj->page_increment /
                                          w_current->scrollpan_steps),
                                       adj->upper - adj->page_size));
@@ -773,7 +773,7 @@ gint x_event_scroll (GtkWidget *widget, GdkEventScroll *event,
   if (pan_yaxis) {
     adj = gschem_page_view_get_vadjustment (GSCHEM_PAGE_VIEW (widget));
     g_return_val_if_fail (adj != NULL, TRUE);
-    gtk_adjustment_set_value(adj, min(adj->value + pan_direction *
+    gtk_adjustment_set_value(adj, MIN(adj->value + pan_direction *
                                         (adj->page_increment /
                                          w_current->scrollpan_steps),
                                       adj->upper - adj->page_size));

--- a/gschem/src/x_grid.c
+++ b/gschem/src/x_grid.c
@@ -101,7 +101,7 @@ draw_dots_grid_region (GschemToplevel *w_current, cairo_t *cr, int x, int y, int
   if (incr == -1)
     return;
 
-  int dot_size = min (w_current->dots_grid_dot_size, 5);
+  int dot_size = MIN (w_current->dots_grid_dot_size, 5);
 
   GedaColor *color = x_color_lookup (w_current, DOTS_GRID_COLOR);
   cairo_set_source_rgba (cr,

--- a/gschem/src/x_stroke.c
+++ b/gschem/src/x_stroke.c
@@ -165,10 +165,10 @@ x_stroke_translate_and_execute (GschemToplevel *w_current)
 
   for (i = 1; i < stroke_points->len; i++) {
     point = &g_array_index (stroke_points, StrokePoint, i);
-    min_x = min (min_x, point->x);
-    min_y = min (min_y, point->y);
-    max_x = max (max_x, point->x);
-    max_y = max (max_y, point->y);
+    min_x = MIN (min_x, point->x);
+    min_y = MIN (min_y, point->y);
+    max_x = MAX (max_x, point->x);
+    max_y = MAX (max_y, point->y);
   }
 
   o_invalidate_rect (w_current, min_x, min_y, max_x + 1, max_y + 1);

--- a/liblepton/include/liblepton/defines.h
+++ b/liblepton/include/liblepton/defines.h
@@ -73,12 +73,6 @@
 #define NOT_FOUND_TEXT_X	100
 #define NOT_FOUND_TEXT_Y	100
 
-#undef max
-#define max(a,b) ((a) > (b) ? (a) : (b))
-
-#undef min
-#define min(a,b) ((a) < (b) ? (a) : (b))
-
 /* for s_clib_getfilename() */
 #define OPEN_DIR	0
 #define READ_DIR	1

--- a/liblepton/include/liblepton/geda_fill_type.h
+++ b/liblepton/include/liblepton/geda_fill_type.h
@@ -20,9 +20,6 @@
 /*! \file geda_fill_type.h
  */
 
-typedef enum _GedaFillType GedaFillType;
-typedef enum _GedaFillType OBJECT_FILLING;
-
 /*! \brief The fill type of objects like box, circle, and path
  *
  *  The numeric values of this enumeration are used inside files and must be
@@ -36,6 +33,9 @@ enum _GedaFillType
   FILLING_HATCH,
   FILLING_VOID
 };
+
+typedef enum _GedaFillType GedaFillType;
+typedef enum _GedaFillType OBJECT_FILLING;
 
 gboolean
 geda_fill_type_draw_first_hatch (int fill_type);

--- a/liblepton/include/liblepton/geda_line_cap_type.h
+++ b/liblepton/include/liblepton/geda_line_cap_type.h
@@ -22,9 +22,6 @@
  *  \brief line end style for an open line of an object
  */
 
-typedef enum _GedaLineCapType GedaLineCapType;
-typedef enum _GedaLineCapType OBJECT_END;
-
 enum _GedaLineCapType
 {
   END_NONE,
@@ -32,3 +29,6 @@ enum _GedaLineCapType
   END_ROUND,
   END_VOID
 };
+
+typedef enum _GedaLineCapType GedaLineCapType;
+typedef enum _GedaLineCapType OBJECT_END;

--- a/liblepton/include/liblepton/geda_line_type.h
+++ b/liblepton/include/liblepton/geda_line_type.h
@@ -20,9 +20,6 @@
 /*! \file geda_line_type.h
  */
 
-typedef enum _GedaLineType GedaLineType;
-typedef enum _GedaLineType OBJECT_TYPE;
-
 /*! \brief The line type of objects such as arcs, boxes, circles, and lines
  *
  *  The numeric values of this enumeration are used inside files and must be
@@ -37,3 +34,6 @@ enum _GedaLineType
   TYPE_PHANTOM,
   TYPE_ERASE
 };
+
+typedef enum _GedaLineType GedaLineType;
+typedef enum _GedaLineType OBJECT_TYPE;

--- a/liblepton/include/liblepton/libgedaguile.h
+++ b/liblepton/include/liblepton/libgedaguile.h
@@ -20,6 +20,8 @@
 #include <liblepton/edascmvaluetypes.h>
 #include <liblepton/edascmhookproxy.h>
 
+G_BEGIN_DECLS
+
 /*!
  * \file libgedaguile.h
  * \ingroup guile_c_iface
@@ -73,3 +75,5 @@ void edascm_c_set_gc (SCM smob, int gc);
 
 /* Create a Scheme closure around a C function. */
 SCM edascm_c_make_closure (SCM (*func)(SCM, gpointer), gpointer user_data);
+
+G_END_DECLS

--- a/liblepton/include/liblepton/liblepton.h
+++ b/liblepton/include/liblepton/liblepton.h
@@ -27,6 +27,8 @@
 #include <libguile.h>
 #include <gdk-pixbuf/gdk-pixbuf.h>
 
+G_BEGIN_DECLS
+
 #include <liblepton/defines.h>
 
 #include <liblepton/geda_color.h>
@@ -76,6 +78,9 @@
 #include <liblepton/o_types.h>
 #include <liblepton/funcs.h>
 #include <liblepton/prototype.h>
+
+G_END_DECLS
+
 #include <liblepton/edaconfig.h>
 #include <liblepton/edaerrors.h>
 #include <liblepton/edapaths.h>

--- a/liblepton/include/liblepton/prototype.h
+++ b/liblepton/include/liblepton/prototype.h
@@ -1,5 +1,3 @@
-G_BEGIN_DECLS
-
 /* a_basic.c */
 int o_save (TOPLEVEL *toplevel, const GList *object_list, const char *filename, GError **err);
 GList *o_read_buffer(TOPLEVEL *toplevel, GList *object_list, char *buffer, const int size, const char *name, GError **err);
@@ -156,5 +154,3 @@ TextBuffer *s_textbuffer_new (const gchar *data, const gint size);
 TextBuffer *s_textbuffer_free (TextBuffer *tb);
 const gchar *s_textbuffer_next (TextBuffer *tb, const gssize count);
 const gchar *s_textbuffer_next_line (TextBuffer *tb);
-
-G_END_DECLS

--- a/liblepton/src/geda_arc_object.c
+++ b/liblepton/src/geda_arc_object.c
@@ -777,7 +777,7 @@ geda_arc_object_shortest_distance (TOPLEVEL *toplevel, OBJECT *object,
 
     distance_to_end1 = hypot (dx, dy);
 
-    shortest_distance = min (distance_to_end0, distance_to_end1);
+    shortest_distance = MIN (distance_to_end0, distance_to_end1);
   }
 
   return shortest_distance;

--- a/liblepton/src/geda_bounds.c
+++ b/liblepton/src/geda_bounds.c
@@ -117,10 +117,10 @@ geda_bounds_init_with_points (GedaBounds *bounds, gint x0, gint y0, gint x1, gin
 {
   g_return_if_fail (bounds != NULL);
 
-  bounds->min_x = min (x0, x1);
-  bounds->min_y = min (y0, y1);
-  bounds->max_x = max (x0, x1);
-  bounds->max_y = max (y0, y1);
+  bounds->min_x = MIN (x0, x1);
+  bounds->min_y = MIN (y0, y1);
+  bounds->max_x = MAX (x0, x1);
+  bounds->max_y = MAX (y0, y1);
 }
 
 /*! \brief Check if the point lies inside the bounds
@@ -194,10 +194,10 @@ geda_bounds_union (GedaBounds *r, const GedaBounds *a, const GedaBounds *b)
   g_return_if_fail (r != NULL);
 
   if ((a != NULL) && (b != NULL)) {
-    r->min_x = min (a->min_x, b->min_x);
-    r->min_y = min (a->min_y, b->min_y);
-    r->max_x = max (a->max_x, b->max_x);
-    r->max_y = max (a->max_y, b->max_y);
+    r->min_x = MIN (a->min_x, b->min_x);
+    r->min_y = MIN (a->min_y, b->min_y);
+    r->max_x = MAX (a->max_x, b->max_x);
+    r->max_y = MAX (a->max_y, b->max_y);
   }
   else if (a != NULL) {
     *r = *a;

--- a/liblepton/src/geda_box.c
+++ b/liblepton/src/geda_box.c
@@ -93,17 +93,17 @@ geda_box_shortest_distance (GedaBox *box, int x, int y, int solid)
 
   g_return_val_if_fail (box != NULL, G_MAXDOUBLE);
 
-  x1 = (double) min (box->upper_x, box->lower_x);
-  y1 = (double) min (box->upper_y, box->lower_y);
-  x2 = (double) max (box->upper_x, box->lower_x);
-  y2 = (double) max (box->upper_y, box->lower_y);
+  x1 = (double) MIN (box->upper_x, box->lower_x);
+  y1 = (double) MIN (box->upper_y, box->lower_y);
+  x2 = (double) MAX (box->upper_x, box->lower_x);
+  y2 = (double) MAX (box->upper_y, box->lower_y);
 
-  dx = min (((double)x) - x1, x2 - ((double)x));
-  dy = min (((double)y) - y1, y2 - ((double)y));
+  dx = MIN (((double)x) - x1, x2 - ((double)x));
+  dy = MIN (((double)y) - y1, y2 - ((double)y));
 
   if (solid) {
-    dx = min (dx, 0);
-    dy = min (dy, 0);
+    dx = MIN (dx, 0);
+    dy = MIN (dy, 0);
   }
 
   if (dx < 0) {
@@ -116,7 +116,7 @@ geda_box_shortest_distance (GedaBox *box, int x, int y, int solid)
     if (dy < 0) {
       shortest_distance = fabs (dy);
     } else {
-      shortest_distance = min (dx, dy);
+      shortest_distance = MIN (dx, dy);
     }
   }
 

--- a/liblepton/src/geda_box_object.c
+++ b/liblepton/src/geda_box_object.c
@@ -510,10 +510,10 @@ void geda_box_object_rotate (TOPLEVEL *toplevel,
 		  &newx2, &newy2);
 
   /* reorder the corners after rotation */
-  object->box->upper_x = min(newx1,newx2);
-  object->box->upper_y = max(newy1,newy2);
-  object->box->lower_x = max(newx1,newx2);
-  object->box->lower_y = min(newy1,newy2);
+  object->box->upper_x = MIN(newx1,newx2);
+  object->box->upper_y = MAX(newy1,newy2);
+  object->box->lower_x = MAX(newx1,newx2);
+  object->box->lower_y = MIN(newy1,newy2);
 
   /* translate object back to normal position */
   object->box->upper_x += world_centerx;
@@ -562,10 +562,10 @@ void geda_box_object_mirror (TOPLEVEL *toplevel,
   newy2 = object->box->lower_y;
 
   /* reorder the corners */
-  object->box->upper_x = min(newx1,newx2);
-  object->box->upper_y = max(newy1,newy2);
-  object->box->lower_x = max(newx1,newx2);
-  object->box->lower_y = min(newy1,newy2);
+  object->box->upper_x = MIN(newx1,newx2);
+  object->box->upper_y = MAX(newy1,newy2);
+  object->box->lower_x = MAX(newx1,newx2);
+  object->box->lower_y = MIN(newy1,newy2);
 
   /* translate back in position */
   object->box->upper_x += world_centerx;
@@ -629,11 +629,11 @@ geda_box_object_get_position (const GedaObject *object, gint *x, gint *y)
   g_return_val_if_fail (object->box != NULL, FALSE);
 
   if (x != NULL) {
-    *x = min (object->box->lower_x, object->box->upper_x);
+    *x = MIN (object->box->lower_x, object->box->upper_x);
   }
 
   if (y != NULL) {
-    *y = min (object->box->lower_y, object->box->upper_y);
+    *y = MIN (object->box->lower_y, object->box->upper_y);
   }
 
   return TRUE;

--- a/liblepton/src/geda_circle.c
+++ b/liblepton/src/geda_circle.c
@@ -103,7 +103,7 @@ geda_circle_shortest_distance (const GedaCircle *circle,
   distance_to_center = hypot (dx, dy);
 
   if (solid) {
-    shortest_distance = max (distance_to_center - circle->radius, 0);
+    shortest_distance = MAX (distance_to_center - circle->radius, 0);
   } else {
     shortest_distance = fabs (distance_to_center - circle->radius);
   }

--- a/liblepton/src/geda_complex_object.c
+++ b/liblepton/src/geda_complex_object.c
@@ -68,10 +68,10 @@ int world_get_object_glist_bounds(TOPLEVEL *toplevel, const GList *head,
 
     if ( geda_object_calculate_visible_bounds( toplevel, o_current, &rleft, &rtop, &rright, &rbottom) ) {
       if ( found ) {
-        *left = min( *left, rleft );
-        *top = min( *top, rtop );
-        *right = max( *right, rright );
-        *bottom = max( *bottom, rbottom );
+        *left = MIN( *left, rleft );
+        *top = MIN( *top, rtop );
+        *right = MAX( *right, rright );
+        *bottom = MAX( *bottom, rbottom );
       } else {
         *left = rleft;
         *top = rtop;
@@ -1096,10 +1096,10 @@ geda_complex_object_shortest_distance (TOPLEVEL *toplevel, OBJECT *object,
         geda_object_calculate_visible_bounds(toplevel, obj,
                                        &left, &top, &right, &bottom)) {
       if (found_line_bounds) {
-        line_bounds.lower_x = min (line_bounds.lower_x, left);
-        line_bounds.lower_y = min (line_bounds.lower_y, top);
-        line_bounds.upper_x = max (line_bounds.upper_x, right);
-        line_bounds.upper_y = max (line_bounds.upper_y, bottom);
+        line_bounds.lower_x = MIN (line_bounds.lower_x, left);
+        line_bounds.lower_y = MIN (line_bounds.lower_y, top);
+        line_bounds.upper_x = MAX (line_bounds.upper_x, right);
+        line_bounds.upper_y = MAX (line_bounds.upper_y, bottom);
       } else {
         line_bounds.lower_x = left;
         line_bounds.lower_y = top;
@@ -1109,7 +1109,7 @@ geda_complex_object_shortest_distance (TOPLEVEL *toplevel, OBJECT *object,
       }
     } else {
       distance = geda_object_shortest_distance_full (toplevel, obj, x, y, TRUE);
-      shortest_distance = min (shortest_distance, distance);
+      shortest_distance = MIN (shortest_distance, distance);
     }
 
     if (shortest_distance == 0.0)
@@ -1118,7 +1118,7 @@ geda_complex_object_shortest_distance (TOPLEVEL *toplevel, OBJECT *object,
 
   if (found_line_bounds) {
     distance = geda_box_shortest_distance (&line_bounds, x, y, TRUE);
-    shortest_distance = min (shortest_distance, distance);
+    shortest_distance = MIN (shortest_distance, distance);
   }
 
   return shortest_distance;

--- a/liblepton/src/geda_line.c
+++ b/liblepton/src/geda_line.c
@@ -119,8 +119,8 @@ geda_line_shortest_distance (const GedaLine *line, gint x, gint y)
     t = (dx0 + dy0) / (ldx * ldx + ldy * ldy);
 
     /* constrain the parametric value to a point on the line */
-    t = max (t, 0);
-    t = min (t, 1);
+    t = MAX (t, 0);
+    t = MIN (t, 1);
 
     /* calculate closest point on the line */
     cx = t * ldx + lx0;

--- a/liblepton/src/geda_net_object.c
+++ b/liblepton/src/geda_net_object.c
@@ -513,15 +513,15 @@ static void o_net_consolidate_lowlevel (OBJECT *object,
 
   if (orient == HORIZONTAL) {
 
-    temp1 = min(object->line->x[0], del_object->line->x[0]);
-    temp2 = min(object->line->x[1], del_object->line->x[1]);
+    temp1 = MIN(object->line->x[0], del_object->line->x[0]);
+    temp2 = MIN(object->line->x[1], del_object->line->x[1]);
 
-    final1 = min(temp1, temp2);
+    final1 = MIN(temp1, temp2);
 
-    temp1 = max(object->line->x[0], del_object->line->x[0]);
-    temp2 = max(object->line->x[1], del_object->line->x[1]);
+    temp1 = MAX(object->line->x[0], del_object->line->x[0]);
+    temp2 = MAX(object->line->x[1], del_object->line->x[1]);
 
-    final2 = max(temp1, temp2);
+    final2 = MAX(temp1, temp2);
 
     object->line->x[0] = final1;
     object->line->x[1] = final2;
@@ -529,15 +529,15 @@ static void o_net_consolidate_lowlevel (OBJECT *object,
   }
 
   if (orient == VERTICAL) {
-    temp1 = min(object->line->y[0], del_object->line->y[0]);
-    temp2 = min(object->line->y[1], del_object->line->y[1]);
+    temp1 = MIN(object->line->y[0], del_object->line->y[0]);
+    temp2 = MIN(object->line->y[1], del_object->line->y[1]);
 
-    final1 = min(temp1, temp2);
+    final1 = MIN(temp1, temp2);
 
-    temp1 = max(object->line->y[0], del_object->line->y[0]);
-    temp2 = max(object->line->y[1], del_object->line->y[1]);
+    temp1 = MAX(object->line->y[0], del_object->line->y[0]);
+    temp2 = MAX(object->line->y[1], del_object->line->y[1]);
 
-    final2 = max(temp1, temp2);
+    final2 = MAX(temp1, temp2);
 
     object->line->y[0] = final1;
     object->line->y[1] = final2;

--- a/liblepton/src/geda_picture_object.c
+++ b/liblepton/src/geda_picture_object.c
@@ -374,11 +374,11 @@ geda_picture_object_get_position (const GedaObject *object, gint *x, gint *y)
   g_return_val_if_fail (object->picture != NULL, FALSE);
 
   if (x != NULL) {
-    *x = min (object->picture->lower_x, object->picture->upper_x);
+    *x = MIN (object->picture->lower_x, object->picture->upper_x);
   }
 
   if (y != NULL) {
-    *y = min (object->picture->lower_y, object->picture->upper_y);
+    *y = MIN (object->picture->lower_y, object->picture->upper_y);
   }
 
   return TRUE;
@@ -593,10 +593,10 @@ void geda_picture_object_rotate (TOPLEVEL *toplevel,
                   &newx2, &newy2);
 
   /* reorder the corners after rotation */
-  object->picture->upper_x = min(newx1,newx2);
-  object->picture->upper_y = max(newy1,newy2);
-  object->picture->lower_x = max(newx1,newx2);
-  object->picture->lower_y = min(newy1,newy2);
+  object->picture->upper_x = MIN(newx1,newx2);
+  object->picture->upper_y = MAX(newy1,newy2);
+  object->picture->lower_x = MAX(newx1,newx2);
+  object->picture->lower_y = MIN(newy1,newy2);
 
   /* translate object back to normal position */
   object->picture->upper_x += world_centerx;
@@ -658,10 +658,10 @@ void geda_picture_object_mirror(TOPLEVEL *toplevel,
   newy2 = object->picture->lower_y;
 
   /* reorder the corners */
-  object->picture->upper_x = min(newx1,newx2);
-  object->picture->upper_y = max(newy1,newy2);
-  object->picture->lower_x = max(newx1,newx2);
-  object->picture->lower_y = min(newy1,newy2);
+  object->picture->upper_x = MIN(newx1,newx2);
+  object->picture->upper_y = MAX(newy1,newy2);
+  object->picture->lower_x = MAX(newx1,newx2);
+  object->picture->lower_y = MIN(newy1,newy2);
 
   /* translate back in position */
   object->picture->upper_x += world_centerx;
@@ -837,16 +837,16 @@ geda_picture_object_shortest_distance (TOPLEVEL *toplevel, OBJECT *object,
 
   g_return_val_if_fail (object->picture != NULL, G_MAXDOUBLE);
 
-  x1 = (double)min (object->picture->upper_x, object->picture->lower_x);
-  y1 = (double)min (object->picture->upper_y, object->picture->lower_y);
-  x2 = (double)max (object->picture->upper_x, object->picture->lower_x);
-  y2 = (double)max (object->picture->upper_y, object->picture->lower_y);
+  x1 = (double)MIN (object->picture->upper_x, object->picture->lower_x);
+  y1 = (double)MIN (object->picture->upper_y, object->picture->lower_y);
+  x2 = (double)MAX (object->picture->upper_x, object->picture->lower_x);
+  y2 = (double)MAX (object->picture->upper_y, object->picture->lower_y);
 
-  dx = min (((double)x) - x1, x2 - ((double)x));
-  dy = min (((double)y) - y1, y2 - ((double)y));
+  dx = MIN (((double)x) - x1, x2 - ((double)x));
+  dy = MIN (((double)y) - y1, y2 - ((double)y));
 
-  dx = min (dx, 0);
-  dy = min (dy, 0);
+  dx = MIN (dx, 0);
+  dy = MIN (dy, 0);
 
   return hypot (dx, dy);
 }

--- a/liblepton/src/geda_pin_object.c
+++ b/liblepton/src/geda_pin_object.c
@@ -610,10 +610,10 @@ geda_pin_object_update_whichend (TOPLEVEL *toplevel,
             toplevel, o_current, &rleft, &rtop, &rright, &rbottom);
 
           if ( found ) {
-            left = min( left, rleft );
-            top = min( top, rtop );
-            right = max( right, rright );
-            bottom = max( bottom, rbottom );
+            left = MIN( left, rleft );
+            top = MIN( top, rtop );
+            right = MAX( right, rright );
+            bottom = MAX( bottom, rbottom );
           } else {
             left = rleft;
             top = rtop;

--- a/liblepton/src/geda_text_object.c
+++ b/liblepton/src/geda_text_object.c
@@ -883,11 +883,11 @@ geda_text_object_shortest_distance (TOPLEVEL *toplevel,
                                       &left, &top, &right, &bottom))
     return G_MAXDOUBLE;
 
-  dx = min (x - left, right - x);
-  dy = min (y - top, bottom - y);
+  dx = MIN (x - left, right - x);
+  dy = MIN (y - top, bottom - y);
 
-  dx = min (dx, 0);
-  dy = min (dy, 0);
+  dx = MIN (dx, 0);
+  dy = MIN (dy, 0);
 
   return hypot (dx, dy);
 }

--- a/liblepton/src/m_hatch.c
+++ b/liblepton/src/m_hatch.c
@@ -268,8 +268,8 @@ void m_hatch_polygon(GArray *points, gint angle, gint pitch, GArray *lines)
       sPOINT *p1 = &g_array_index(points2, sPOINT, index);
       if ( p0->y != p1->y ) {
         SWEEP_EVENT event;
-        event.y0 = min(p0->y, p1->y);
-        event.status.y1 = max(p0->y, p1->y);
+        event.y0 = MIN(p0->y, p1->y);
+        event.status.y1 = MAX(p0->y, p1->y);
         event.status.m1 = (gdouble)( p1->x - p0->x ) / (gdouble)( p1->y - p0->y );
         event.status.b1 = p0->x - event.status.m1 * p0->y;
         g_array_append_val(events, event);

--- a/liblepton/src/m_polygon.c
+++ b/liblepton/src/m_polygon.c
@@ -180,7 +180,7 @@ double m_polygon_shortest_distance (GArray *points, int x, int y, gboolean close
 
       distance = geda_line_shortest_distance (&line, x, y);
 
-      shortest = min (shortest, distance);
+      shortest = MIN (shortest, distance);
     }
   }
 

--- a/liblepton/src/s_conn.c
+++ b/liblepton/src/s_conn.c
@@ -221,9 +221,9 @@ OBJECT *s_conn_check_midpoint(OBJECT *o_current, int x, int y)
     case(OBJ_NET):
     case(OBJ_PIN):
     case(OBJ_BUS):
-      min_y = min(o_current->line->y[0], 
+      min_y = MIN(o_current->line->y[0], 
                   o_current->line->y[1]);
-      max_y = max(o_current->line->y[0], 
+      max_y = MAX(o_current->line->y[0], 
                   o_current->line->y[1]);
 
 				/* vertical */
@@ -237,9 +237,9 @@ OBJECT *s_conn_check_midpoint(OBJECT *o_current, int x, int y)
         return(o_current);
       }
 
-      min_x = min(o_current->line->x[0], 
+      min_x = MIN(o_current->line->x[0], 
                   o_current->line->x[1]);
-      max_x = max(o_current->line->x[0], 
+      max_x = MAX(o_current->line->x[0], 
                   o_current->line->x[1]);
 
 				/* horizontal */

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -315,10 +315,10 @@ SCM_DEFINE (object_bounds, "%object-bounds", 0, 0, 1,
 
   SCM result = SCM_BOOL_F;
   if (success) {
-    result = scm_cons (scm_cons (scm_from_int (min(left, right)),
-                                 scm_from_int (max(top, bottom))),
-                       scm_cons (scm_from_int (max(left, right)),
-                                 scm_from_int (min(top, bottom))));
+    result = scm_cons (scm_cons (scm_from_int (MIN(left, right)),
+                                 scm_from_int (MAX(top, bottom))),
+                       scm_cons (scm_from_int (MAX(left, right)),
+                                 scm_from_int (MIN(top, bottom))));
   }
 
   scm_remember_upto_here_1 (rst_s);

--- a/liblepton/tests/Makefile.am
+++ b/liblepton/tests/Makefile.am
@@ -9,6 +9,7 @@ check_PROGRAMS = \
 	test_circle \
 	test_circle_object \
 	test_coord \
+	test_cpp \
 	test_line \
 	test_line_object \
 	test_net_object \
@@ -17,32 +18,20 @@ check_PROGRAMS = \
 	test_string \
 	test_text_object
 
-TESTS = \
-	test_angle \
-	test_arc \
-	test_arc_object \
-	test_bounds \
-	test_box \
-	test_bus_object \
-	test_circle \
-	test_circle_object \
-	test_coord \
-	test_line \
-	test_line_object \
-	test_net_object \
-	test_pin_object \
-	test_point \
-	test_string \
-	test_text_object
+test_cpp_SOURCES = test_cpp.cc
 
-AM_CPPFLAGS = -DLOCALEDIR=\"$(localedir)\"  $(DATADIR_DEFS) \
+TESTS = $(check_PROGRAMS)
+
+AM_CPPFLAGS = -DWOW -DLOCALEDIR=\"$(localedir)\"  $(DATADIR_DEFS) \
 	-I$(srcdir)/../include -I$(srcdir)/../include/liblepton -I$(top_srcdir)
 
-AM_CFLAGS = -DWOW \
+AM_CFLAGS = \
 	$(GCC_CFLAGS) $(MINGW_CFLAGS) $(GUILE_CFLAGS) $(GLIB_CFLAGS) \
 	$(GDK_PIXBUF_CFLAGS)
+AM_CXXFLAGS =  $(MINGW_CLAGS) $(GUILE_CFLAGS) $(GLIB_CFLAGS) \
+	$(GDK_PIXBUF_CFLAGS)
 
-AM_LDFLAGS = -version-info $(LIBLEPTON_SHLIB_VERSION) \
+AM_LDFLAGS = \
 	$(WINDOWS_LIBTOOL_FLAGS) $(MINGW_LDFLAGS) $(GUILE_LIBS) \
 	$(GLIB_LIBS) $(GDK_PIXBUF_LIBS) \
 	$(top_builddir)/libgedacairo/libgedacairo.la \

--- a/liblepton/tests/test_cpp.cc
+++ b/liblepton/tests/test_cpp.cc
@@ -1,0 +1,10 @@
+#include <liblepton.h>
+
+#include <memory>
+#include <utility>
+
+int
+main ()
+{
+  return 0;
+}


### PR DESCRIPTION
These patches close #52 by:

- removing `min()` and `max()` macros from the libgeda headers; GLib's `MIN()` and `MAX()` macros are used throughout the source code instead
- not forward-declaring enumerations, because that is not permitted in C++

They also add a minimal testcase that the libgeda headers can be compiled by a C++ compiler.