### PR TITLE
build: Use the correct text domain for liblepton

### DIFF
--- a/m4/geda-liblepton.m4
+++ b/m4/geda-liblepton.m4
@@ -1,7 +1,7 @@
-# geda-libgeda.m4                                       -*-Autoconf-*-
+# geda-liblepton.m4                                       -*-Autoconf-*-
 # serial 1.0
 
-dnl libgeda-specific setup
+dnl liblepton-specific setup
 dnl Copyright (C) 2009  Peter Brett <peter@peter-b.co.uk>
 dnl
 dnl This program is free software; you can redistribute it and/or modify
@@ -18,22 +18,22 @@ dnl You should have received a copy of the GNU General Public License
 dnl along with this program; if not, write to the Free Software
 dnl Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-# Work out the gettext domain that libgeda should use
+# Work out the gettext domain that liblepton should use
 AC_DEFUN([AX_LIBLEPTON],
 [
   AC_PREREQ([2.60])dnl
 
   # First argument is the shared library version to use.
-  AC_MSG_CHECKING([libgeda shared library version])
+  AC_MSG_CHECKING([liblepton shared library version])
   AC_MSG_RESULT($1)
   AC_SUBST([LIBLEPTON_SHLIB_VERSION], $1)
 
   # Work out the gettext domain to use
-  AC_MSG_CHECKING([libgeda gettext domain])
+  AC_MSG_CHECKING([liblepton gettext domain])
   so_major=`echo $LIBLEPTON_SHLIB_VERSION | sed -e "s/:.*//"`
-  LIBLEPTON_GETTEXT_DOMAIN="libgeda$so_major"
+  LIBLEPTON_GETTEXT_DOMAIN="liblepton$so_major"
   AC_MSG_RESULT([$LIBLEPTON_GETTEXT_DOMAIN])
   AC_SUBST([LIBLEPTON_GETTEXT_DOMAIN])
   AC_DEFINE_UNQUOTED([LIBLEPTON_GETTEXT_DOMAIN], ["$LIBLEPTON_GETTEXT_DOMAIN"],
-    "Name of libgeda's gettext domain.")
+    "Name of liblepton's gettext domain.")
 ])


### PR DESCRIPTION
Ensure that we install `liblepton` gettext files, rather than
`libgeda` ones.