### PR TITLE
Modify localised strings to have reorderable subsitutions.

### DIFF
--- a/gaf/config.c
+++ b/gaf/config.c
@@ -60,7 +60,7 @@ config_usage (void)
 "store for the current directory). If no GROUP and KEY were provided,\n"
 "outputs the filename of the selected configuration store.\n"
 "\n"
-"Please report bugs to %s.\n"),
+"Please report bugs to %1$s.\n"),
           PACKAGE_BUGREPORT);
   exit (0);
 }
@@ -155,7 +155,9 @@ cmd_config_impl (void *data, int argc, char **argv)
 
     if (!eda_config_load (parent, &err)) {
       if (!g_error_matches (err, G_IO_ERROR, G_IO_ERROR_NOT_FOUND)) {
-        fprintf (stderr, _("WARNING: Could not load '%s': %s.\n"),
+        /* TRANSLATORS: The first string is the filename, the second is
+         * the detailed error message */
+        fprintf (stderr, _("WARNING: Could not load '%1$s': %2$s.\n"),
                  eda_config_get_filename (parent),
                  err->message);
       }
@@ -179,7 +181,7 @@ cmd_config_impl (void *data, int argc, char **argv)
     GError *err = NULL;
     gchar *value = eda_config_get_string (cfg, group, key, &err);
     if (value == NULL) {
-      fprintf (stderr, _("ERROR: %s.\n"), err->message);
+      fprintf (stderr, _("ERROR: %1$s.\n"), err->message);
       exit (1);
     }
     printf ("%s\n", value);
@@ -193,7 +195,7 @@ cmd_config_impl (void *data, int argc, char **argv)
     const gchar *value = argv[optind++];
     eda_config_set_string (cfg, group, key, value);
     if (!eda_config_save (cfg, &err)) {
-      fprintf (stderr, _("ERROR: %s.\n"), err->message);
+      fprintf (stderr, _("ERROR: %1$s.\n"), err->message);
       exit (1);
     }
     exit (0);

--- a/gaf/export.c
+++ b/gaf/export.c
@@ -147,7 +147,7 @@ static struct ExportSettings settings = {
   NULL,
 };
 
-#define bad_arg_msg _("ERROR: Bad argument '%s' to %s option.\n")
+#define bad_arg_msg _("ERROR: Bad argument '%1$s' to %2$s option.\n")
 #define see_help_msg _("\nRun `gaf export --help' for more information.\n")
 
 static void
@@ -188,7 +188,7 @@ cmd_export_impl (void *data, int argc, char **argv)
       out_suffix++; /* Skip '.' */
     } else {
       fprintf (stderr,
-               _("ERROR: Cannot infer output format from filename '%s'.\n"),
+               _("ERROR: Cannot infer output format from filename '%1$s'.\n"),
                settings.outfile);
       exit (1);
     }
@@ -205,12 +205,12 @@ cmd_export_impl (void *data, int argc, char **argv)
   if (exporter == NULL) {
     if (settings.format == NULL) {
       fprintf (stderr,
-               _("ERROR: Cannot find supported format for filename '%s'.\n"),
+               _("ERROR: Cannot find supported format for filename '%1$s'.\n"),
                settings.outfile);
       exit (1);
     } else {
       fprintf (stderr,
-               _("ERROR: Unsupported output format '%s'.\n"),
+               _("ERROR: Unsupported output format '%1$s'.\n"),
                settings.format);
       fprintf (stderr, see_help_msg);
       exit (1);
@@ -234,13 +234,15 @@ cmd_export_impl (void *data, int argc, char **argv)
     page = s_page_new (toplevel, tmp);
     if (!f_open (toplevel, page, tmp, &err)) {
       fprintf (stderr,
-               _("ERROR: Failed to load '%s': %s\n"), tmp,
+               /* TRANSLATORS: The first string is the filename, the second
+                * is the detailed error message */
+               _("ERROR: Failed to load '%1$s': %2$s\n"), tmp,
                err->message);
       exit (1);
     }
     if (g_chdir (original_cwd) != 0) {
       fprintf (stderr,
-               _("ERROR: Failed to change directory to '%s': %s\n"),
+               _("ERROR: Failed to change directory to '%1$s': %2$s\n"),
                original_cwd, g_strerror (errno));
       exit (1);
     }
@@ -928,7 +930,7 @@ export_usage (void)
 "  -F, --font=NAME        set font family for printing text\n"
 "  -h, --help     display usage information and exit\n"
 "\n"
-"Please report bugs to %s.\n"),
+"Please report bugs to %1$s.\n"),
           PACKAGE_BUGREPORT);
   exit (0);
 }

--- a/gaf/gaf.c
+++ b/gaf/gaf.c
@@ -77,7 +77,7 @@ usage (void)
 "  config         Edit gEDA configuration\n"
 "  export         Export gEDA files in various image formats.\n"
 "\n"
-"Please report bugs to %s.\n"),
+"Please report bugs to %1$s.\n"),
 PACKAGE_BUGREPORT);
   exit (0);
 }
@@ -86,7 +86,7 @@ PACKAGE_BUGREPORT);
 static void
 version (void)
 {
-  printf(_("gEDA/gaf %s (g%.7s)\n"
+  printf(_("gEDA/gaf %1$s (g%2$.7s)\n"
 "Copyright (C) 1998-2012 gEDA developers\n"
 "This is free software, and you are welcome to redistribute it under\n"
 "certain conditions. For details, see the file `COPYING', which is\n"
@@ -164,7 +164,7 @@ main (int argc, char **argv)
   }
   if (cmd_func == NULL) {
     fprintf (stderr,
-             _("ERROR: Unrecognised command `%s'.\n"
+             _("ERROR: Unrecognised command `%1$s'.\n"
                "\n"
                "Run `gaf --help' for more information.\n"),
              cmd);

--- a/gaf/shell.c
+++ b/gaf/shell.c
@@ -58,7 +58,7 @@ shell_usage (void)
 "  -l FILE        load Scheme source code from FILE\n"
 "  -h, --help     display usage information and exit\n"
 "\n"
-"Please report bugs to %s.\n"),
+"Please report bugs to %1$s.\n"),
 PACKAGE_BUGREPORT);
   exit (0);
 }

--- a/gattrib/src/f_export.c
+++ b/gattrib/src/f_export.c
@@ -79,7 +79,7 @@ void f_export_components(gchar *filename)
 #endif
   fp = fopen(filename, "wb");
   if (fp == NULL) {
-    s_log_message(_("o_save: Could not open [%s]\n"), filename);
+    s_log_message(_("o_save: Could not open [%1$s]\n"), filename);
     /* XXXXX Throw up error message  in window */
     return;
   }

--- a/gattrib/src/g_rc.c
+++ b/gattrib/src/g_rc.c
@@ -67,7 +67,7 @@ SCM g_rc_gattrib_version(SCM scm_version)
   version = scm_to_utf8_string (scm_version);
   if (g_ascii_strcasecmp (version, PACKAGE_DATE_VERSION) != 0) {
     fprintf(stderr,
-            _("You are running gEDA/gaf version [%s%s.%s],\nbut you have a version [%s] gattribrc file.\nPlease be sure that you have the latest rc file.\n"),
+            _("You are running gEDA/gaf version [%1$s%2$s.%3$s],\nbut you have a version [%4$s] gattribrc file.\nPlease be sure that you have the latest rc file.\n"),
             PREPEND_VERSION_STRING, PACKAGE_DOTTED_VERSION,
             PACKAGE_DATE_VERSION, version);
     ret = SCM_BOOL_F;

--- a/gattrib/src/gattrib.c
+++ b/gattrib/src/gattrib.c
@@ -149,7 +149,7 @@ void gattrib_main(void *closure, int argc, char *argv[])
   s_log_init ("gattrib");
 
   s_log_message
-    (_("gEDA/gattrib version %s%s.%s\ngEDA/gattrib comes with ABSOLUTELY NO WARRANTY; see COPYING for more details.\nThis is free software, and you are welcome to redistribute it under certain\nconditions; please see the COPYING file for more details.\n\n"),
+    (_("gEDA/gattrib version %1$s%2$s.%3$s\ngEDA/gattrib comes with ABSOLUTELY NO WARRANTY; see COPYING for more details.\nThis is free software, and you are welcome to redistribute it under certain\nconditions; please see the COPYING file for more details.\n\n"),
      PREPEND_VERSION_STRING, PACKAGE_DOTTED_VERSION,
      PACKAGE_DATE_VERSION);
 
@@ -185,7 +185,7 @@ void gattrib_main(void *closure, int argc, char *argv[])
         if (filename != NULL) {
             file_list = g_slist_append(file_list, filename);
         } else {
-            fprintf(stderr, _("Couldn't find file [%s]\n"), argv[argv_index]);
+            fprintf(stderr, _("Couldn't find file [%1$s]\n"), argv[argv_index]);
             exit(1);
         }
         argv_index++;

--- a/gattrib/src/parsecmd.c
+++ b/gattrib/src/parsecmd.c
@@ -77,7 +77,7 @@ void usage(char *cmd)
 "Gattrib:  The gEDA project\'s attribute editor.\n"
 "Presents schematic attributes in easy-to-edit spreadsheet format.\n"
 "\n"
-"Usage: %s [OPTIONS] filename1 ... filenameN\n"
+"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
 "  -q, --quiet            Quiet mode\n"
 "  -v, --verbose          Verbose mode on\n"
 "  -h, --help             This help menu\n"

--- a/gattrib/src/s_attrib.c
+++ b/gattrib/src/s_attrib.c
@@ -98,7 +98,7 @@ char *s_attrib_get_refdes(OBJECT *object)
   if (!temp_uref) {
     temp_uref = o_attrib_search_object_attribs_by_name (object, "uref", 0); // deprecated
     if (temp_uref) {
-      printf(_("WARNING: Found uref=%s, uref= is deprecated, please use refdes=\n"), temp_uref);
+      printf(_("WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"), temp_uref);
     } else {        /* didn't find refdes.  Report error to log. */
 #ifdef DEBUG
       printf("In s_attrib_get_refdes, found non-graphical component with no refdes.\n");

--- a/gattrib/src/s_object.c
+++ b/gattrib/src/s_object.c
@@ -214,7 +214,7 @@ void s_object_replace_attrib_in_object(TOPLEVEL *toplevel,
   /* if we get here, it's because we have failed to find the attrib on the component.
    * This is an error condition. */
   fprintf(stderr,
-	 _("In s_object_replace_attrib_in_object, we have failed to find the attrib %s on the component.  Exiting . . .\n"),
+	 _("In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s on the component.  Exiting . . .\n"),
 	 new_attrib_name);
   exit(-1);
 }
@@ -254,7 +254,7 @@ s_object_remove_attrib_in_object (TOPLEVEL *toplevel,
 	/* We've found the attrib.  Delete it and then return. */
 
 #ifdef DEBUG
-	printf("In s_object_remove_attrib_in_object, removing attrib with name = %s\n", old_attrib_name);
+	printf("In s_object_remove_attrib_in_object, removing attrib with name = %1$s\n", old_attrib_name);
 #endif
 
 	attribute_object = a_current;
@@ -273,7 +273,7 @@ s_object_remove_attrib_in_object (TOPLEVEL *toplevel,
   /* if we get here, it's because we have failed to find the attrib on the component.
    * This is an error condition. */
   fprintf(stderr,
-	 _("In s_object_remove_attrib_in_object, we have failed to find the attrib %s on the component.  Exiting . . .\n"),
+	 _("In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s on the component.  Exiting . . .\n"),
 	 new_attrib_name);
   exit(-1);
 }

--- a/gattrib/src/x_dialog.c
+++ b/gattrib/src/x_dialog.c
@@ -322,7 +322,7 @@ void x_dialog_fatal_error(gchar *string, gint return_code)
 void x_dialog_about_dialog()
 {
   GtkWidget *dialog;
-  const char *string = _("gEDA : GPL Electronic Design Automation\n\nThis is gattrib -- gEDA's attribute editor\n\nGattrib version: %s%s.%s\n\nGattrib is written by: Stuart Brorson (sdb@cloud9.net)\nwith generous helpings of code from gschem, gnetlist, \nand gtkextra, as well as support from the gEDA community.");
+  const char *string = _("gEDA : GPL Electronic Design Automation\n\nThis is gattrib -- gEDA's attribute editor\n\nGattrib version: %1$s%2$s.%3$s\n\nGattrib is written by: Stuart Brorson (sdb@cloud9.net)\nwith generous helpings of code from gschem, gnetlist, \nand gtkextra, as well as support from the gEDA community.");
 
 
   /* Create the dialog */

--- a/gattrib/src/x_fileselect.c
+++ b/gattrib/src/x_fileselect.c
@@ -131,13 +131,13 @@ x_fileselect_load_files (GSList *filenames)
     gchar *string = (gchar*)filename->data;
     
     if (!quiet_mode) {
-      s_log_message(_("Loading file [%s]\n"), string);
+      s_log_message(_("Loading file [%1$s]\n"), string);
     }
 
     s_page_goto (pr_current, s_page_new (pr_current, string));
 
     if(s_toplevel_read_page(pr_current, string) == 0) {
-       fprintf(stderr, _("Couldn't load schematic [%s]\n"), string);
+       fprintf(stderr, _("Couldn't load schematic [%1$s]\n"), string);
        return FALSE;
     }
 
@@ -301,7 +301,7 @@ x_fileselect_save (void)
     /* try saving current page of toplevel to file filename */
     if (filename != NULL &&
         f_save (pr_current, pr_current->page_current, filename, NULL)) {
-      s_log_message (_("Saved As [%s]\n"), filename);
+      s_log_message (_("Saved As [%1$s]\n"), filename);
 
       /* replace page filename with new one */
       s_page_set_filename (pr_current->page_current, filename);
@@ -311,7 +311,7 @@ x_fileselect_save (void)
 
     } else {
       /* report error in log and status bar */
-      s_log_message (_("Could NOT save [%s]\n"),
+      s_log_message (_("Could NOT save [%1$s]\n"),
                      s_page_get_filename (pr_current->page_current));
 
     }

--- a/gattrib/src/x_window.c
+++ b/gattrib/src/x_window.c
@@ -296,7 +296,7 @@ x_window_create_menu(GtkWindow *window, GtkWidget **menubar)
   gtk_ui_manager_add_ui_from_file(ui, menu_file, &error);
   if(error != NULL) {
     /* An error occured, terminate */
-    fprintf(stderr, _("Error loading %s:\n%s\n"), menu_file, error->message);
+    fprintf(stderr, _("Error loading %1$s:\n%2$s\n"), menu_file, error->message);
     exit(1);
   }
 

--- a/gnetlist/src/s_hierarchy.c
+++ b/gnetlist/src/s_hierarchy.c
@@ -82,7 +82,7 @@ s_hierarchy_traverse(TOPLEVEL * pr_current, OBJECT * o_current,
 	/* loop over all filenames */
 	while (current_filename != NULL) {
 
-	    s_log_message(_("Going to traverse source [%s]\n"),
+	    s_log_message(_("Going to traverse source [%1$s]\n"),
 			  current_filename);
 
 	    /* guts here */
@@ -101,9 +101,9 @@ s_hierarchy_traverse(TOPLEVEL * pr_current, OBJECT * o_current,
                                                   &err);
 
 	    if (child_page == NULL) {
-              g_warning (_("Failed to load subcircuit '%s': %s\n"),
+              g_warning (_("Failed to load subcircuit '%1$s': %s\n"),
                          current_filename, err->message);
-              fprintf(stderr, _("ERROR: Failed to load subcircuit '%s': %s\n"),
+              fprintf(stderr, _("ERROR: Failed to load subcircuit '%1$s': %s\n"),
                       current_filename, err->message);
               g_error_free (err);
               exit (2);
@@ -203,7 +203,7 @@ s_hierarchy_post_process (NETLIST * head)
 
 		    if (pl_current->pin_label == NULL) {
 			fprintf(stderr,
-				_("Found a pin [%s] on component [%s] which does not have a label!\n"),
+				_("Found a pin [%1$s] on component [%2$s] which does not have a label!\n"),
 				nl_current->component_uref,
 				pl_current->pin_number);
 		    } else {
@@ -227,7 +227,7 @@ s_hierarchy_post_process (NETLIST * head)
                                            source_net_name);
 			if (!did_work) {
 			    fprintf(stderr,
-				    _("Missing I/O symbol with refdes [%s] inside schematic for symbol [%s]\n"),
+				    _("Missing I/O symbol with refdes [%1$s] inside schematic for symbol [%2$s]\n"),
 				    pl_current->pin_label,
 				    nl_current->component_uref);
 
@@ -256,7 +256,7 @@ s_hierarchy_setup_rename (NETLIST *head, char *uref, char *label, char *new_name
     wanted_uref = s_hierarchy_create_uref (label, uref);
 
 #if DEBUG
-    printf("label: %s, uref: %s, wanted_uref: %s\n", label, uref,
+    printf("label: %1$s, uref: %2$s, wanted_uref: %3$s\n", label, uref,
 	   wanted_uref);
 #endif
 

--- a/gnetlist/src/s_net.c
+++ b/gnetlist/src/s_net.c
@@ -206,7 +206,7 @@ s_net_name_search (NET * net_head)
 			if (!s_rename_search
 			    (name, n_current->net_name, TRUE)) {
 			    fprintf(stderr,
-				    _("Found duplicate net name, renaming [%s] to [%s]\n"),
+				    _("Found duplicate net name, renaming [%1$s] to [%2$s]\n"),
 				    name, n_current->net_name);
 			    s_rename_add(name, n_current->net_name);
 			    name = n_current->net_name;
@@ -243,7 +243,7 @@ s_net_name_search (NET * net_head)
 			if (!s_rename_search
 			    (name, n_current->net_name, TRUE)) {
 			    fprintf(stderr,
-				    _("Found duplicate net name, renaming [%s] to [%s]\n"),
+				    _("Found duplicate net name, renaming [%1$s] to [%2$s]\n"),
 				    name, n_current->net_name);
 
 			    s_rename_add(name, n_current->net_name);
@@ -351,7 +351,7 @@ s_net_name (NETLIST *netlist_head, NET *net_head, char *hierarchy_tag, int type,
         unnamed_string = default_bus_name;
         break;
       default:
-        g_critical (_("s_net_name: incorrect connectivity type %i\n"), type);
+        g_critical (_("s_net_name: incorrect connectivity type %1$i\n"), type);
         return NULL;
     }
 

--- a/gnetlist/src/s_netattrib.c
+++ b/gnetlist/src/s_netattrib.c
@@ -69,7 +69,7 @@ s_netattrib_check_connected_string (const gchar *str)
   if (s_netattrib_connected_string_get_pinnum (str) == NULL) return;
 
   fprintf (stderr,
-           _("ERROR: `%s' is reserved for internal use."), PIN_NET_PREFIX);
+           _("ERROR: `%1$s' is reserved for internal use."), PIN_NET_PREFIX);
   exit (1); /*! \bug Use appropriate exit code */
 }
 
@@ -147,7 +147,7 @@ s_netattrib_create_pins (OBJECT *o_current,
 
 		if (old_cpin->nets->net_name) {
 		    fprintf(stderr,
-			    _("Found a cpinlist head with a netname! [%s]\n"),
+			    _("Found a cpinlist head with a netname! [%1$s]\n"),
 			    old_cpin->nets->net_name);
 		    g_free(old_cpin->nets->net_name);
 		}
@@ -260,7 +260,7 @@ char *s_netattrib_net_search (OBJECT * o_current, const gchar *wanted_pin)
 
     char_ptr = strchr (value, ':');
     if (char_ptr == NULL) {
-      fprintf (stderr, _("Got an invalid net= attrib [net=%s]\n"
+      fprintf (stderr, _("Got an invalid net= attrib [net=%1$s]\n"
                        "Missing : in net= attrib\n"), value);
       g_free (value);
       return NULL;
@@ -291,7 +291,7 @@ char *s_netattrib_net_search (OBJECT * o_current, const gchar *wanted_pin)
 
     char_ptr = strchr (value, ':');
     if (char_ptr == NULL) {
-      fprintf (stderr, _("Got an invalid net= attrib [net=%s]\n"
+      fprintf (stderr, _("Got an invalid net= attrib [net=%1$s]\n"
                        "Missing : in net= attrib\n"), value);
       g_free (value);
       return NULL;

--- a/gnetlist/src/s_traverse.c
+++ b/gnetlist/src/s_traverse.c
@@ -162,7 +162,7 @@ s_traverse_sheet (TOPLEVEL * pr_current, const GList *obj_list, char *hierarchy_
     netlist = s_netlist_return_tail(netlist_head);
 
     if (o_current->type == OBJ_PLACEHOLDER) {
-      printf(_("WARNING: Found a placeholder/missing component, are you missing a symbol file? [%s]\n"), o_current->complex_basename);
+      printf(_("WARNING: Found a placeholder/missing component, are you missing a symbol file? [%1$s]\n"), o_current->complex_basename);
     }
 
     if (o_current->type == OBJ_COMPLEX) {
@@ -345,7 +345,7 @@ s_traverse_net (NET *nets, int starting, OBJECT *object, char *hierarchy_tag, in
       /* search for the old label= attribute on nets */
       temp = o_attrib_search_object_attribs_by_name (object, "label", 0);
       if (temp) {
-        printf(_("WARNING: Found label=%s. label= is deprecated, please use netname=\n"), temp);
+        printf(_("WARNING: Found label=%1$s. label= is deprecated, please use netname=\n"), temp);
         new_net->net_name = s_hierarchy_create_netname (temp, hierarchy_tag);
         g_free(temp);
       }

--- a/gschem/src/g_rc.c
+++ b/gschem/src/g_rc.c
@@ -104,11 +104,11 @@ SCM g_rc_gschem_version(SCM scm_version)
     sourcefile = scm_to_utf8_string (rc_filename);
     scm_dynwind_free (sourcefile);
     fprintf(stderr,
-            _("You are running gEDA/gaf version [%s%s.%s],\n"),
+            _("You are running gEDA/gaf version [%1$s%2$s.%3$s],\n"),
             PREPEND_VERSION_STRING, PACKAGE_DOTTED_VERSION,
             PACKAGE_DATE_VERSION);
     fprintf(stderr,
-            _("but you have a version [%s] gschemrc file:\n[%s]\n"),
+            _("but you have a version [%1$s] gschemrc file:\n[%2$s]\n"),
             version, sourcefile);
     fprintf(stderr,
             _("Please be sure that you have the latest rc file.\n"));
@@ -237,7 +237,7 @@ SCM g_rc_text_size(SCM size)
   val = scm_to_int (size);
   if (val == 0) {
     fprintf(stderr,
-            _("Invalid size [%d] passed to text-size\n"),
+            _("Invalid size [%1$d] passed to text-size\n"),
             val);
     val = 10; /* absolute default */
   }
@@ -280,7 +280,7 @@ SCM g_rc_snap_size(SCM size)
 
   val = scm_to_int (size);
   if (val == 0) {
-    fprintf(stderr, _("Invalid size [%d] passed to snap-size\n"),
+    fprintf(stderr, _("Invalid size [%1$d] passed to snap-size\n"),
             val);
     val = 100; /* absolute default */
   }
@@ -616,7 +616,7 @@ SCM g_rc_undo_levels(SCM levels)
   val = scm_to_int (levels);
 
   if (val == 0) {
-    fprintf(stderr, _("Invalid num levels [%d] passed to undo-levels\n"),
+    fprintf(stderr, _("Invalid num levels [%1$d] passed to undo-levels\n"),
             val);
     val = 10; /* absolute default */
   }
@@ -827,7 +827,7 @@ SCM g_rc_bus_ripper_size(SCM size)
   val = scm_to_int (size);
 
   if (val == 0) {
-    fprintf(stderr, _("Invalid size [%d] passed to bus-ripper-size\n"),
+    fprintf(stderr, _("Invalid size [%1$d] passed to bus-ripper-size\n"),
             val);
     val = 200; /* absolute default */
   }
@@ -927,7 +927,7 @@ SCM g_rc_dots_grid_dot_size (SCM dotsize)
   val = scm_to_int (dotsize);
 
   if (val <= 0) {
-    fprintf(stderr, _("Invalid dot size [%d] passed to dots-grid-dot-size\n"),
+    fprintf(stderr, _("Invalid dot size [%1$d] passed to dots-grid-dot-size\n"),
             val);
     val = 1; /* absolute default */
   }
@@ -968,7 +968,7 @@ SCM g_rc_dots_grid_fixed_threshold (SCM spacing)
   val = scm_to_int (spacing);
 
   if (val <= 0) {
-    fprintf(stderr, _("Invalid pixel spacing [%d] passed to dots-grid-fixed-threshold\n"),
+    fprintf(stderr, _("Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"),
             val);
     val = 10; /* absolute default */
   }
@@ -994,7 +994,7 @@ SCM g_rc_mesh_grid_display_threshold (SCM spacing)
   val = scm_to_int (spacing);
 
   if (val <= 0) {
-    fprintf (stderr, _("Invalid pixel spacing [%d] passed to "
+    fprintf (stderr, _("Invalid pixel spacing [%1$d] passed to "
                        "mesh-grid-display-threshold\n"), val);
     val = 3; /* absolute default */
   }
@@ -1019,7 +1019,7 @@ SCM g_rc_add_attribute_offset(SCM offset)
   val = scm_to_int (offset);
 
   if (val < 0) {
-    fprintf(stderr, _("Invalid offset [%d] passed to add-attribute-offset\n"),
+    fprintf(stderr, _("Invalid offset [%1$d] passed to add-attribute-offset\n"),
             val);
     val = 50; /* absolute default */
   }
@@ -1043,7 +1043,7 @@ SCM g_rc_auto_save_interval(SCM seconds)
   val = scm_to_int (seconds);
 
   if (val < 0) {
-    fprintf(stderr, _("Invalid number of seconds [%d] passed to auto-save-interval\n"),
+    fprintf(stderr, _("Invalid number of seconds [%1$d] passed to auto-save-interval\n"),
             val);
     val = 120; /* absolute default */
   }
@@ -1067,7 +1067,7 @@ SCM g_rc_mousepan_gain(SCM gain)
   val = scm_to_int (gain);
 
   if (val <= 0) {
-    fprintf(stderr, _("Invalid gain [%d] passed to mousepan-gain\n"),
+    fprintf(stderr, _("Invalid gain [%1$d] passed to mousepan-gain\n"),
             val);
     val = 5; /* absolute default */
   }
@@ -1090,7 +1090,7 @@ SCM g_rc_keyboardpan_gain(SCM gain)
   val = scm_to_int (gain);
 
   if (val <= 0) {
-    fprintf(stderr, _("Invalid gain [%d] passed to keyboardpan-gain\n"),
+    fprintf(stderr, _("Invalid gain [%1$d] passed to keyboardpan-gain\n"),
             val);
     val = 20; /* absolute default */
   }
@@ -1114,7 +1114,7 @@ SCM g_rc_select_slack_pixels(SCM pixels)
   val = scm_to_int (pixels);
 
   if (val <= 0) {
-    fprintf(stderr, _("Invalid number of pixels [%d] passed to select-slack-pixels\n"),
+    fprintf(stderr, _("Invalid number of pixels [%1$d] passed to select-slack-pixels\n"),
             val);
     val = 4; /* absolute default */
   }
@@ -1140,7 +1140,7 @@ SCM g_rc_zoom_gain(SCM gain)
   /* Allow -ve numbers in case the user wishes to reverse zoom direction,
    * but don't allow zero gain as this would disable the zoom action */
   if (val == 0) {
-    fprintf(stderr, _("Invalid gain [%d] passed to zoom-gain\n"), val);
+    fprintf(stderr, _("Invalid gain [%1$d] passed to zoom-gain\n"), val);
     val = 20; /* absolute default */
   }
 
@@ -1165,7 +1165,7 @@ SCM g_rc_scrollpan_steps(SCM steps)
   /* Allow -ve numbers in case the user wishes to reverse scroll direction,
    * but don't allow zero steps as this would cause a division by zero error */
   if (val == 0) {
-    fprintf(stderr, _("Invalid number of steps [%d] scrollpan-steps\n"), val);
+    fprintf(stderr, _("Invalid number of steps [%1$d] scrollpan-steps\n"), val);
     val = 8; /* absolute default */
   }
 

--- a/gschem/src/gschem.c
+++ b/gschem/src/gschem.c
@@ -154,7 +154,7 @@ void main_prog(void *closure, int argc, char *argv[])
   s_log_init ("gschem");
 
   s_log_message(
-                _("gEDA/gschem version %s%s.%s\n"), PREPEND_VERSION_STRING,
+                _("gEDA/gschem version %1$s%2$s.%3$s\n"), PREPEND_VERSION_STRING,
                 PACKAGE_DOTTED_VERSION, PACKAGE_DATE_VERSION);
   s_log_message(
                 _("gEDA/gschem comes with ABSOLUTELY NO WARRANTY; see COPYING for more details.\n"));
@@ -168,7 +168,7 @@ void main_prog(void *closure, int argc, char *argv[])
 #endif
 
 #if DEBUG
-  fprintf(stderr, _("Current locale settings: %s\n"), setlocale(LC_ALL, NULL));
+  fprintf(stderr, _("Current locale settings: %1$s\n"), setlocale(LC_ALL, NULL));
 #endif
 
   /* init global buffers */
@@ -199,16 +199,16 @@ void main_prog(void *closure, int argc, char *argv[])
    * we can take advantage of that.  */
   scm_tmp = scm_sys_search_load_path (scm_from_utf8_string ("gschem.scm"));
   if (scm_is_false (scm_tmp)) {
-    s_log_message (_("Couldn't find init scm file [%s]\n"), "gschem.scm");
+    s_log_message (_("Couldn't find init scm file [%1$s]\n"), "gschem.scm");
   }
   input_str = scm_to_utf8_string (scm_tmp);
   toplevel = s_toplevel_new ();
   if (g_read_file(toplevel, input_str, NULL)) {
-    s_log_message(_("Read init scm file [%s]\n"), input_str);
+    s_log_message(_("Read init scm file [%1$s]\n"), input_str);
   } else {
     /*! \todo These two messages are the same. Should be
      * integrated. */
-    s_log_message(_("Failed to read init scm file [%s]\n"),
+    s_log_message(_("Failed to read init scm file [%1$s]\n"),
                   input_str);
   }
   free (input_str); /* M'allocated by scm_to_utf8_string() */

--- a/gschem/src/gschem_about_dialog.c
+++ b/gschem/src/gschem_about_dialog.c
@@ -61,7 +61,7 @@ void about_dialog (GschemToplevel *w_current)
 
   if (error != NULL) {
     g_assert (logo == NULL);
-    s_log_message ("Could not load image at file: %s\n%s\n",
+    s_log_message ("Could not load image at file: %1$s\n%2$s\n",
                    logo_file, error->message);
     g_error_free (error);
   }

--- a/gschem/src/gschem_bottom_widget.c
+++ b/gschem/src/gschem_bottom_widget.c
@@ -732,7 +732,7 @@ update_grid_label (GschemBottomWidget *widget, GParamSpec *pspec, gpointer unuse
       }
     }
 
-    label_text = g_strdup_printf (_("Grid(%s, %s)"), snap_text, grid_text);
+    label_text = g_strdup_printf (_("Grid(%1$s, %2$s)"), snap_text, grid_text);
 
     gtk_label_set_text (GTK_LABEL (widget->grid_label), label_text);
 

--- a/gschem/src/gschem_close_confirmation_dialog.c
+++ b/gschem/src/gschem_close_confirmation_dialog.c
@@ -462,13 +462,13 @@ close_confirmation_dialog_constructor (GType type,
     page_name = get_page_name (GTK_TREE_MODEL (dialog->store_unsaved_pages),
                                NULL);
     tmp = g_strdup_printf (
-      _("Save the changes to schematic \"%s\" before closing?"),
+      _("Save the changes to schematic \"%1$s\" before closing?"),
       page_name);
     g_free (page_name);
   } else {
     /* multi page */
     tmp = g_strdup_printf (
-      _("There are %d schematics with unsaved changes. "
+      _("There are %1$d schematics with unsaved changes. "
         "Save changes before closing?"),
       count_pages (GTK_TREE_MODEL (dialog->store_unsaved_pages)));
   }

--- a/gschem/src/gschem_dialog_misc.c
+++ b/gschem/src/gschem_dialog_misc.c
@@ -181,7 +181,7 @@ gschem_dialog_misc_response_non_modal (GtkDialog *dialog, gint response, gpointe
        break;
 
     default:
-      printf("gtk_dialog_misc_response_non_modal(): strange signal %d\n", response);
+      printf("gtk_dialog_misc_response_non_modal(): strange signal %1$d\n", response);
   }
 
   gtk_widget_destroy (GTK_WIDGET (dialog));

--- a/gschem/src/gschem_hotkey_dialog.c
+++ b/gschem/src/gschem_hotkey_dialog.c
@@ -52,7 +52,7 @@ void x_dialog_hotkeys_response(GtkWidget *w, gint response,
     /* void */
     break;
   default:
-    printf("x_dialog_hotkeys_response(): strange signal %d\n", response);
+    printf("x_dialog_hotkeys_response(): strange signal %1$d\n", response);
   }
   /* clean up */
   gtk_widget_destroy(w_current->hkwindow);

--- a/gschem/src/gschem_page_view.c
+++ b/gschem/src/gschem_page_view.c
@@ -740,7 +740,7 @@ gschem_page_view_pan_mouse (GschemPageView *view, int diff_x, int diff_y)
   g_return_if_fail (geometry != NULL);
 
 #if DEBUG
-  printf("gschem_page_view_pan_mouse(): diff_x=%d, diff_y=%d\n", diff_x, diff_y);
+  printf("gschem_page_view_pan_mouse(): diff_x=%1$d, diff_y=%2$d\n", diff_x, diff_y);
 #endif
 
   page_cx = (gschem_page_geometry_get_viewport_left (geometry) + gschem_page_geometry_get_viewport_right (geometry)) / 2.0;
@@ -750,7 +750,7 @@ gschem_page_view_pan_mouse (GschemPageView *view, int diff_x, int diff_y)
   world_cy = page_cy + gschem_page_view_WORLDabs (view, diff_y);
 
 #if DEBUG
-  printf("  world_cx=%f, world_cy=%f\n", world_cx, world_cy);
+  printf("  world_cx=%1$f, world_cy=%2$f\n", world_cx, world_cy);
 #endif
 
   gschem_page_view_pan_general (view, world_cx, world_cy, 1);
@@ -1094,8 +1094,8 @@ gschem_page_view_update_hadjustment (GschemPageView *view)
                                geometry->viewport_left);
 
 #if DEBUG
-    printf("H %f %f\n", view->hadjustment->lower, view->hadjustment->upper);
-    printf("Hp %f\n", view->hadjustment->page_size);
+    printf("H %1$f %2$f\n", view->hadjustment->lower, view->hadjustment->upper);
+    printf("Hp %1$f\n", view->hadjustment->page_size);
 #endif
 
     gtk_adjustment_changed(view->hadjustment);
@@ -1139,8 +1139,8 @@ gschem_page_view_update_vadjustment (GschemPageView *view)
                              geometry->world_bottom - geometry->viewport_bottom);
 
 #if DEBUG
-    printf("V %f %f\n", view->vadjustment->lower, view->vadjustment->upper);
-    printf("Vp %f\n", view->vadjustment->page_size);
+    printf("V %1$f %2$f\n", view->vadjustment->lower, view->vadjustment->upper);
+    printf("Vp %1$f\n", view->vadjustment->page_size);
 #endif
 
     gtk_adjustment_changed(view->vadjustment);

--- a/gschem/src/gschem_slot_edit_dialog.c
+++ b/gschem/src/gschem_slot_edit_dialog.c
@@ -68,7 +68,7 @@ void slot_edit_dialog_response(GtkWidget *widget, gint response, GschemToplevel 
     }
     break;
   default:
-    printf("slot_edit_dialog_response(): strange signal %d\n",response);
+    printf("slot_edit_dialog_response(): strange signal %1$d\n",response);
   }
   i_set_state(w_current, SELECT);
   gtk_widget_destroy(w_current->sewindow);

--- a/gschem/src/i_callbacks.c
+++ b/gschem/src/i_callbacks.c
@@ -71,7 +71,7 @@ DEFINE_I_CALLBACK(file_new)
   g_return_if_fail (page != NULL);
 
   x_window_set_current_page (w_current, page);
-  s_log_message (_("New page created [%s]\n"), s_page_get_filename (page));
+  s_log_message (_("New page created [%1$s]\n"), s_page_get_filename (page));
 }
 
 /*! \todo Finish function documentation!!!
@@ -105,7 +105,7 @@ DEFINE_I_CALLBACK(file_new_window)
 
   x_window_set_current_page (w_current, page);
 
-  s_log_message (_("New Window created [%s]\n"), s_page_get_filename (page));
+  s_log_message (_("New Window created [%1$s]\n"), s_page_get_filename (page));
 }
 
 /*! \todo Finish function documentation!!!
@@ -2119,7 +2119,7 @@ DEFINE_I_CALLBACK(hierarchy_down_schematic)
     /* loop over all filenames */
     while(current_filename != NULL) {
       GError *err = NULL;
-      s_log_message(_("Searching for source [%s]\n"), current_filename);
+      s_log_message(_("Searching for source [%1$s]\n"), current_filename);
       child = s_hierarchy_down_schematic_single(gschem_toplevel_get_toplevel (w_current),
                                                 current_filename,
                                                 parent,
@@ -2148,11 +2148,11 @@ DEFINE_I_CALLBACK(hierarchy_down_schematic)
       if (child == NULL) {
         const char *msg = (err != NULL) ? err->message : "Unknown error.";
         char *secondary =
-          g_strdup_printf (_("Failed to descend hierarchy into '%s': %s\n\n"
+          g_strdup_printf (_("Failed to descend hierarchy into '%1$s': %2$s\n\n"
                              "The gschem log may contain more information."),
                            current_filename, msg);
 
-        s_log_message(_("Failed to descend into '%s': %s\n"),
+        s_log_message(_("Failed to descend into '%1$s': %2$s\n"),
                       current_filename, msg);
 
         GtkWidget *dialog =
@@ -2228,7 +2228,7 @@ DEFINE_I_CALLBACK(hierarchy_down_symbol)
   if (object != NULL) {
     /* only allow going into symbols */
     if (object->type == OBJ_COMPLEX) {
-      s_log_message(_("Searching for symbol [%s]\n"),
+      s_log_message(_("Searching for symbol [%1$s]\n"),
 		    object->complex_basename);
       sym = s_clib_get_symbol_by_name (object->complex_basename);
       if (sym == NULL)
@@ -2687,7 +2687,7 @@ DEFINE_I_CALLBACK(options_snap)
     s_log_message(_("Snap back to the grid (CAUTION!)\n"));
     break;
   default:
-    g_critical("options_snap: toplevel->snap out of range: %d\n",
+    g_critical("options_snap: toplevel->snap out of range: %1$d\n",
                snap_mode);
   }
 

--- a/gschem/src/i_vars.c
+++ b/gschem/src/i_vars.c
@@ -222,7 +222,7 @@ i_vars_atexit_save_user_config (gpointer user_data)
 
   eda_config_save (cfg, &err);
   if (err != NULL) {
-    g_warning ("Failed to save user configuration to '%s': %s.",
+    g_warning ("Failed to save user configuration to '%1$s': %2$s.",
                eda_config_get_filename (cfg),
                err->message);
     g_clear_error (&err);

--- a/gschem/src/o_complex.c
+++ b/gschem/src/o_complex.c
@@ -190,10 +190,10 @@ void o_complex_translate_all(GschemToplevel *w_current, int offset)
   }
 
   if (offset == 0) {
-    s_log_message(_("Translating schematic [%d %d]\n"), -x, -y);
+    s_log_message(_("Translating schematic [%1$d %2$d]\n"), -x, -y);
     geda_object_list_translate (s_page_objects (toplevel->page_current), -x, -y);
   } else {
-    s_log_message(_("Translating schematic [%d %d]\n"),
+    s_log_message(_("Translating schematic [%1$d %2$d]\n"),
                   offset, offset);
     geda_object_list_translate (s_page_objects (toplevel->page_current), offset, offset);
   }

--- a/gschem/src/o_delete.c
+++ b/gschem/src/o_delete.c
@@ -77,7 +77,7 @@ void o_delete_selected (GschemToplevel *w_current)
     GtkWidget *dialog = gtk_message_dialog_new (NULL,
         GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT,
         GTK_MESSAGE_QUESTION, GTK_BUTTONS_NONE,
-        ngettext ("Delete locked object?", "Delete %u locked objects?",
+        ngettext ("Delete locked object?", "Delete %1$u locked objects?",
           locked_num), locked_num);
     gtk_dialog_add_buttons (GTK_DIALOG (dialog),
         GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL,

--- a/gschem/src/o_misc.c
+++ b/gschem/src/o_misc.c
@@ -422,7 +422,7 @@ o_update_component (GschemToplevel *w_current, OBJECT *o_current)
   s_clib_symbol_invalidate_data (clib);
 
   if (clib == NULL) {
-    s_log_message (_("Could not find symbol [%s] in library. Update failed.\n"),
+    s_log_message (_("Could not find symbol [%1$s] in library. Update failed.\n"),
                    o_current->complex_basename);
     return NULL;
   }
@@ -538,7 +538,7 @@ void o_autosave_backups(GschemToplevel *w_current)
       real_filename = follow_symlinks (s_page_get_filename (p_current), NULL);
 
       if (real_filename == NULL) {
-        s_log_message (_("o_autosave_backups: Can't get the real filename of %s."), s_page_get_filename (p_current));
+        s_log_message (_("o_autosave_backups: Can't get the real filename of %1$s."), s_page_get_filename (p_current));
       } else {
         /* Get the directory in which the real filename lives */
         dirname = g_path_get_dirname (real_filename);
@@ -582,7 +582,7 @@ void o_autosave_backups(GschemToplevel *w_current)
           saved_umask = umask(0);
           if (chmod(backup_filename, (S_IWRITE|S_IWGRP|S_IWOTH) &
                     ((~saved_umask) & 0777)) != 0) {
-            s_log_message (_("Could NOT set previous backup file [%s] read-write\n"),
+            s_log_message (_("Could NOT set previous backup file [%1$s] read-write\n"),
                            backup_filename);
           }
           umask(saved_umask);
@@ -602,12 +602,12 @@ void o_autosave_backups(GschemToplevel *w_current)
           mask = (~mask)&0777;
           mask &= ((~saved_umask) & 0777);
           if (chmod(backup_filename,mask) != 0) {
-            s_log_message (_("Could NOT set backup file [%s] readonly\n"),
+            s_log_message (_("Could NOT set backup file [%1$s] readonly\n"),
                            backup_filename);
           }
           umask(saved_umask);
         } else {
-          s_log_message (_("Could NOT save backup file [%s]\n"),
+          s_log_message (_("Could NOT save backup file [%1$s]\n"),
                          backup_filename);
         }
         g_free (backup_filename);

--- a/gschem/src/o_net.c
+++ b/gschem/src/o_net.c
@@ -1066,7 +1066,7 @@ int o_net_add_busrippers(GschemToplevel *w_current, OBJECT *net_obj,
                               o_complex_promote_attribs (page->toplevel, new_obj));
           s_page_append (page->toplevel, page, new_obj);
         } else {
-          s_log_message(_("Bus ripper symbol [%s] was not found in any component library\n"),
+          s_log_message(_("Bus ripper symbol [%1$s] was not found in any component library\n"),
                         page->toplevel->bus_ripper_symname);
         }
       }

--- a/gschem/src/o_picture.c
+++ b/gschem/src/o_picture.c
@@ -164,7 +164,7 @@ void picture_selection_dialog (GschemToplevel *w_current)
 				       GTK_DIALOG_DESTROY_WITH_PARENT,
 				       GTK_MESSAGE_ERROR,
 				       GTK_BUTTONS_CLOSE,
-				       _("Failed to load picture: %s"),
+				       _("Failed to load picture: %1$s"),
 				       error->message);
       /* Wait for any user response */
       gtk_dialog_run (GTK_DIALOG (dialog));

--- a/gschem/src/parsecmd.c
+++ b/gschem/src/parsecmd.c
@@ -74,7 +74,7 @@ static void
 usage(char *cmd)
 {
   printf(_(
-"Usage: %s [OPTION ...] [--] [FILE ...]\n"
+"Usage: %1$s [OPTION ...] [--] [FILE ...]\n"
 "\n"
 "Interactively edit gEDA schematics or symbols.  If one or more FILEs\n"
 "are specified, open them for editing; otherwise, create a new, empty\n"
@@ -108,7 +108,7 @@ static void
 version ()
 {
   printf(_(
-"gEDA %s (g%.7s)\n"
+"gEDA %1$s (g%2$.7s)\n"
 "Copyright (C) 1998-2012 gEDA developers\n"
 "This is free software, and you are welcome to redistribute it under\n"
 "certain conditions. For details, see the file `COPYING', which is\n"

--- a/gschem/src/x_autonumber.c
+++ b/gschem/src/x_autonumber.c
@@ -424,7 +424,7 @@ void autonumber_get_used(GschemToplevel *w_current, AUTONUMBER_TEXT *autotext)
 						 (GCompareFunc) freeslot_compare);
 	      if (slot_item != NULL) { /* duplicate slot in used_slots */
 		s_log_message(_("duplicate slot may cause problems: "
-				"[symbolname=%s, number=%d, slot=%d]\n"),
+				"[symbolname=%1$s, number=%2$d, slot=%3$d]\n"),
 				slot->symbolname, slot->number, slot->slotnr);
 		g_free(slot);
 	      }

--- a/gschem/src/x_color.c
+++ b/gschem/src/x_color.c
@@ -87,7 +87,7 @@ void x_color_allocate (void)
                                  &black,
                                  FALSE,
                                  TRUE)) {
-    fprintf (stderr, _("Could not allocate the color %s!\n"), _("black"));
+    fprintf (stderr, _("Could not allocate the color %1$s!\n"), _("black"));
     exit (-1);
   }
 
@@ -96,7 +96,7 @@ void x_color_allocate (void)
                                  &white,
                                  FALSE,
                                  TRUE)) {
-    fprintf (stderr, _("Could not allocate the color %s!\n"), _("white"));
+    fprintf (stderr, _("Could not allocate the color %1$s!\n"), _("white"));
     exit (-1);
   }
 
@@ -118,7 +118,7 @@ void x_color_allocate (void)
       error = gdk_color_alloc(colormap, gdk_colors[i]);
 
       if (error == FALSE) {
-        g_error (_("Could not allocate display color %i!\n"), i);
+        g_error (_("Could not allocate display color %1$i!\n"), i);
       }
     } else {
       gdk_colors[i] = NULL;
@@ -140,7 +140,7 @@ void x_color_allocate (void)
       error = gdk_color_alloc(colormap, gdk_outline_colors[i]);
 
       if (error == FALSE) {
-        g_error (_("Could not allocate outline color %i!\n"), i);
+        g_error (_("Could not allocate outline color %1$i!\n"), i);
       }
     } else {
       gdk_outline_colors[i] = NULL;
@@ -157,7 +157,7 @@ GdkColor *x_get_color(int color)
 {
   if ((color < 0) || (color >= MAX_COLORS)
       || (gdk_colors[color] == NULL)) {
-    g_warning (_("Tried to get an invalid color: %d\n"), color);
+    g_warning (_("Tried to get an invalid color: %1$d\n"), color);
     return(&white);
   } else {
     return(gdk_colors[color]);

--- a/gschem/src/x_fileselect.c
+++ b/gschem/src/x_fileselect.c
@@ -287,7 +287,7 @@ x_fileselect_save (GschemToplevel *w_current)
                                  GTK_DIALOG_DESTROY_WITH_PARENT),
                                 GTK_MESSAGE_QUESTION,
                                 GTK_BUTTONS_YES_NO,
-                                _("The selected file `%s' already exists.\n\n"
+                                _("The selected file `%1$s' already exists.\n\n"
                                   "Would you like to overwrite it?"),
                                 filename);
       gtk_window_set_title (GTK_WINDOW (checkdialog), _("Overwrite file?"));

--- a/gschem/src/x_image.c
+++ b/gschem/src/x_image.c
@@ -273,7 +273,7 @@ void x_image_lowlevel(GschemToplevel *w_current, const char* filename,
     pixbuf = x_image_get_pixbuf(w_current, width, height);
     if (pixbuf != NULL) {
       if (!gdk_pixbuf_save(pixbuf, filename, filetype, &gerror, NULL)) {
-        s_log_message(_("x_image_lowlevel: Unable to write %s file %s.\n"),
+        s_log_message(_("x_image_lowlevel: Unable to write %1$s file %2$s.\n"),
             filetype, filename);
         s_log_message("%s", gerror->message);
 
@@ -283,7 +283,7 @@ void x_image_lowlevel(GschemToplevel *w_current, const char* filename,
             | GTK_DIALOG_DESTROY_WITH_PARENT,
             GTK_MESSAGE_ERROR,
             GTK_BUTTONS_OK,
-            _("There was the following error when saving image with type %s to filename:\n%s\n\n%s.\n"),
+            _("There was the following error when saving image with type %1$s to filename:\n%2$s\n\n%3$s.\n"),
             filetype, filename, gerror->message
             );
 
@@ -302,9 +302,9 @@ void x_image_lowlevel(GschemToplevel *w_current, const char* filename,
       }
       else {
         if (toplevel->image_color == TRUE) {
-          s_log_message(_("Wrote color image to [%s] [%d x %d]\n"), filename, width, height);
+          s_log_message(_("Wrote color image to [%1$s] [%2$d x %3$d]\n"), filename, width, height);
         } else {
-          s_log_message(_("Wrote black and white image to [%s] [%d x %d]\n"), filename, width, height);
+          s_log_message(_("Wrote black and white image to [%1$s] [%2$d x %3$d]\n"), filename, width, height);
         }
       }
       g_free(filetype);

--- a/gschem/src/x_menus.c
+++ b/gschem/src/x_menus.c
@@ -328,7 +328,7 @@ void x_menus_sensitivity (GschemToplevel *w_current, const char *buf, int flag)
     gtk_widget_set_sensitive(GTK_WIDGET(item), flag);
     /* free(item); */ /* Why doesn't this need to be freed?  */
   } else {
-    s_log_message(_("Tried to set the sensitivity on non-existent menu item '%s'\n"), buf); 
+    s_log_message(_("Tried to set the sensitivity on non-existent menu item '%1$s'\n"), buf);
   }
  
 }

--- a/gschem/src/x_misc.c
+++ b/gschem/src/x_misc.c
@@ -148,7 +148,7 @@ x_show_uri (GschemToplevel *w_current, const gchar *uri,
 
   if (exit_status != 0) {
     g_set_error (error, G_SPAWN_ERROR, G_SPAWN_ERROR_FAILED,
-                 _("%s failed to launch URI"), argv[0]);
+                 _("%1$s failed to launch URI"), argv[0]);
     return FALSE;
   }
 

--- a/gschem/src/x_multiattrib.c
+++ b/gschem/src/x_multiattrib.c
@@ -2579,33 +2579,44 @@ update_dialog_title (Multiattrib *multiattrib, char *complex_title_name)
   GString *title_string = g_string_new (_("Edit Attributes"));
   int num_title_extras = 0;
 
+  /*
+   * Unusual ordering of substitution parameters in the next
+   * ngettext call is to allow translators to use an explicit word
+   * in the singular case.
+   *
+   * See
+   *
+   *   https://www.gnu.org/software/gettext/manual/html_node/Plural-forms.html
+   *
+   * for more information.
+   */
   if (multiattrib->num_complex_in_list > 0) {
     append_dialog_title_extra (title_string, &num_title_extras,
-                               ngettext ("%i symbol (%s)", "%i symbols (%s)", multiattrib->num_complex_in_list),
-                               multiattrib->num_complex_in_list, complex_title_name);
+                               ngettext ("%2$i symbol (%1$s)", "%2$i symbols (%1$s)", multiattrib->num_complex_in_list),
+                               complex_title_name, multiattrib->num_complex_in_list);
   }
 
   if (multiattrib->num_pins_in_list > 0) {
     append_dialog_title_extra (title_string, &num_title_extras,
-                               ngettext ("%i pin", "%i pins", multiattrib->num_pins_in_list),
+                               ngettext ("%1$i pin", "%1$i pins", multiattrib->num_pins_in_list),
                                multiattrib->num_pins_in_list);
   }
 
   if (multiattrib->num_nets_in_list > 0) {
     append_dialog_title_extra (title_string, &num_title_extras,
-                               ngettext ("%i net", "%i nets", multiattrib->num_nets_in_list),
+                               ngettext ("%1$i net", "%1$i nets", multiattrib->num_nets_in_list),
                                multiattrib->num_nets_in_list);
   }
 
   if (multiattrib->num_buses_in_list > 0) {
     append_dialog_title_extra (title_string, &num_title_extras,
-                               ngettext ("%i bus", "%i buses", multiattrib->num_buses_in_list),
+                               ngettext ("%1$i bus", "%1$i buses", multiattrib->num_buses_in_list),
                                multiattrib->num_buses_in_list);
   }
 
   if (multiattrib->num_lone_attribs_in_list > 0) {
     append_dialog_title_extra (title_string, &num_title_extras,
-                               ngettext ("%i attribute", "%i attributes", multiattrib->num_lone_attribs_in_list),
+                               ngettext ("%1$i attribute", "%1$i attributes", multiattrib->num_lone_attribs_in_list),
                                multiattrib->num_lone_attribs_in_list);
   }
 

--- a/gschem/src/x_print.c
+++ b/gschem/src/x_print.c
@@ -362,7 +362,7 @@ x_print_export_pdf (GschemToplevel *w_current,
 
   cr_status = cairo_surface_status (surface);
   if (cr_status != CAIRO_STATUS_SUCCESS) {
-    g_warning (_("Failed to write PDF to '%s': %s\n"),
+    g_warning (_("Failed to write PDF to '%1$s': %2$s\n"),
                filename,
                cairo_status_to_string (cr_status));
     return FALSE;
@@ -416,7 +416,7 @@ x_print (GschemToplevel *w_current)
                               GTK_DIALOG_DESTROY_WITH_PARENT,
                               GTK_MESSAGE_ERROR,
                               GTK_BUTTONS_CLOSE,
-                              _("Error printing file:\n%s"),
+                              _("Error printing file:\n%1$s"),
                               err->message);
     g_signal_connect (error_dialog, "response",
                       G_CALLBACK (gtk_widget_destroy), NULL);

--- a/gschem/src/x_rc.c
+++ b/gschem/src/x_rc.c
@@ -53,10 +53,10 @@ x_rc_parse_gschem_error (GError **err)
     }
 
     /* Log message */
-    s_log_message (_("ERROR: %s\n"), (*err)->message);
+    s_log_message (_("ERROR: %1$s\n"), (*err)->message);
 
     /* Dialog message */
-    msg2 = g_strdup_printf (_("%s\n\n"
+    msg2 = g_strdup_printf (_("%1$s\n\n"
                               "The gschem log may contain more information."),
                             (*err)->message);
   }

--- a/gschem/src/x_script.c
+++ b/gschem/src/x_script.c
@@ -59,7 +59,7 @@ void setup_script_selector (GschemToplevel *w_current)
     filename = gtk_file_chooser_get_filename (GTK_FILE_CHOOSER (w_current->sowindow));
 
     if (!(g_file_test(filename, G_FILE_TEST_IS_DIR))) {
-      s_log_message(_("Executing guile script [%s]\n"), filename);
+      s_log_message(_("Executing guile script [%1$s]\n"), filename);
       g_read_file(w_current->toplevel, filename, NULL);
     }
     g_free (filename);

--- a/gschem/src/x_window.c
+++ b/gschem/src/x_window.c
@@ -918,7 +918,7 @@ x_window_open_page (GschemToplevel *w_current, const gchar *filename)
   if (filename != NULL) {
     GError *err = NULL;
     if (!quiet_mode)
-      s_log_message (_("Loading schematic [%s]\n"), fn);
+      s_log_message (_("Loading schematic [%1$s]\n"), fn);
 
     if (!f_open (toplevel, page, (gchar *) fn, &err)) {
       GtkWidget *dialog;
@@ -929,7 +929,7 @@ x_window_open_page (GschemToplevel *w_current, const gchar *filename)
          GTK_DIALOG_DESTROY_WITH_PARENT,
          GTK_MESSAGE_ERROR,
          GTK_BUTTONS_CLOSE,
-         _("<b>An error occurred while loading the requested file.</b>\n\nLoading from '%s' failed: %s. The gschem log may contain more information."),
+         _("<b>An error occurred while loading the requested file.</b>\n\nLoading from '%1$s' failed: %2$s. The gschem log may contain more information."),
          fn, err->message);
       gtk_window_set_title (GTK_WINDOW (dialog), _("Failed to load file"));
       gtk_dialog_run (GTK_DIALOG (dialog));
@@ -1018,7 +1018,7 @@ x_window_save_page (GschemToplevel *w_current, PAGE *page, const gchar *filename
   ret = (gint)f_save (toplevel, page, filename, &err);
 
   if (ret != 1) {
-    log_msg   = _("Could NOT save page [%s]\n");
+    log_msg   = _("Could NOT save page [%1$s]\n");
     state_msg = _("Error while trying to save");
 
     GtkWidget *dialog;
@@ -1039,9 +1039,9 @@ x_window_save_page (GschemToplevel *w_current, PAGE *page, const gchar *filename
     if (g_ascii_strcasecmp (s_page_get_filename (page), filename) != 0) {
       s_page_set_filename (page, filename);
 
-      log_msg = _("Saved as [%s]\n");
+      log_msg = _("Saved as [%1$s]\n");
     } else {
-      log_msg = _("Saved [%s]\n");
+      log_msg = _("Saved [%1$s]\n");
     }
     state_msg = _("Saved");
 
@@ -1114,7 +1114,7 @@ x_window_close_page (GschemToplevel *w_current, PAGE *page)
   }
 
   s_log_message (page->CHANGED ?
-                 _("Discarding page [%s]\n") : _("Closing [%s]\n"),
+                 _("Discarding page [%1$s]\n") : _("Closing [%1$s]\n"),
                  s_page_get_filename (page));
   /* remove page from toplevel list of page and free */
   s_page_delete (toplevel, page);

--- a/gsymcheck/src/g_rc.c
+++ b/gsymcheck/src/g_rc.c
@@ -54,8 +54,8 @@ SCM g_rc_gsymcheck_version(SCM scm_version)
   version = scm_to_utf8_string (scm_version);
   if (g_ascii_strcasecmp (version, PACKAGE_DATE_VERSION) != 0) {
     fprintf(stderr, _(
-            "You are running gEDA/gaf version [%s%s.%s],\n"
-            "but you have a version [%s] gsymcheckrc file:\n[%s]\n"
+            "You are running gEDA/gaf version [%1$s%2$s.%3$s],\n"
+            "but you have a version [%4$s] gsymcheckrc file:\n[%5$s]\n"
             "Please be sure that you have the latest rc file.\n"),
             PREPEND_VERSION_STRING, PACKAGE_DOTTED_VERSION, PACKAGE_DATE_VERSION,
             version, rc_filename);

--- a/gsymcheck/src/gsymcheck.c
+++ b/gsymcheck/src/gsymcheck.c
@@ -109,7 +109,7 @@ main_prog(void *closure, int argc, char *argv[])
       g_error_free (err);
       exit(2);
     } else {
-      g_message (_("Loaded file [%s]\n"), filename);
+      g_message (_("Loaded file [%1$s]\n"), filename);
     }
     i++;
     g_free (filename);

--- a/gsymcheck/src/parsecmd.c
+++ b/gsymcheck/src/parsecmd.c
@@ -57,7 +57,7 @@ void
 usage(char *cmd)
 {
   printf(_(
-"Usage: %s [OPTIONS] filename1 ... filenameN\n"
+"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
 "  -h, --help        Print usage\n"
 "  -q, --quiet       Quiet mode\n"
 "  -v, --verbose     Verbose mode (cumulative: errors, warnings, info)\n"

--- a/gsymcheck/src/s_check.c
+++ b/gsymcheck/src/s_check.c
@@ -74,7 +74,7 @@ s_check_symbol (TOPLEVEL *pr_current, PAGE *p_current, const GList *obj_list)
   s_symcheck = s_symstruct_init();
   
   if (!quiet_mode) {
-    s_log_message(_("Checking: %s\n"), s_page_get_filename (p_current));
+    s_log_message(_("Checking: %1$s\n"), s_page_get_filename (p_current));
   }
   
   /* overal symbol structure test */
@@ -126,7 +126,7 @@ s_check_symbol (TOPLEVEL *pr_current, PAGE *p_current, const GList *obj_list)
     s_symstruct_print(s_symcheck);
     
     if (s_symcheck->warning_count > 0) {
-      s_log_message(_("%d warnings found "),
+      s_log_message(_("%1$d warnings found "),
                     s_symcheck->warning_count);
       if (verbose_mode < 2) {
         s_log_message(_("(use -vv to view details)\n"));
@@ -146,7 +146,7 @@ s_check_symbol (TOPLEVEL *pr_current, PAGE *p_current, const GList *obj_list)
       }
 
     } else if (s_symcheck->error_count > 1) {
-      s_log_message(_("%d ERRORS found "),
+      s_log_message(_("%1$d ERRORS found "),
                     s_symcheck->error_count);
       if (verbose_mode < 1) {
         s_log_message(_("(use -v to view details)\n"));
@@ -210,14 +210,14 @@ s_check_symbol_structure (const GList *obj_list, SYMCHECK *s_current)
       tokens = g_strsplit(geda_text_object_get_string (o_current),"=", 2);
       if (tokens[0] != NULL && tokens[1] != NULL) {
 	if (s_check_list_has_item(forbidden_attributes, tokens[0])) {
-	  message = g_strdup_printf (_("Found forbidden %s= attribute: [%s=%s]\n"),
+	  message = g_strdup_printf (_("Found forbidden %1$s= attribute: [%2$s=%3$s]\n"),
 				     tokens[0], tokens[0], tokens[1]);
 	  s_current->error_messages =
 	    g_list_append(s_current->error_messages, message);
 	  s_current->error_count++;
 	}
 	else if (s_check_list_has_item(obsolete_attributes, tokens[0])) {
-	  message = g_strdup_printf (_("Found obsolete %s= attribute: [%s=%s]\n"),
+	  message = g_strdup_printf (_("Found obsolete %1$s= attribute: [%2$s=%3$s]\n"),
 				     tokens[0], tokens[0], tokens[1]);
 	  s_current->warning_messages =
 	    g_list_append(s_current->warning_messages, message);
@@ -227,14 +227,14 @@ s_check_symbol_structure (const GList *obj_list, SYMCHECK *s_current)
 	  if (o_current->attached_to == NULL 
 	      || o_current->attached_to->type != OBJ_PIN) {
 	    message = g_strdup_printf (_("Found misplaced pin attribute:"
-				       " [%s=%s]\n"), tokens[0], tokens[1]);
+				       " [%1$s=%2$s]\n"), tokens[0], tokens[1]);
 	    s_current->error_messages =
 	      g_list_append(s_current->error_messages, message);
 	    s_current->error_count++;
 	  }
 	}
 	else if (!s_check_list_has_item(valid_attributes, tokens[0])) {
-	  message = g_strdup_printf (_("Found unknown %s= attribute: [%s=%s]\n"),
+	  message = g_strdup_printf (_("Found unknown %1$s= attribute: [%2$s=%3$s]\n"),
 				     tokens[0], tokens[0], tokens[1]);
 	  s_current->warning_messages =
 	    g_list_append(s_current->warning_messages, message);
@@ -242,7 +242,7 @@ s_check_symbol_structure (const GList *obj_list, SYMCHECK *s_current)
 	}
 	else if (o_current->attached_to != NULL) {
 	  message = g_strdup_printf (_("Found wrongly attached attribute: "
-				     "[%s=%s]\n"),
+				     "[%1$s=%2$s]\n"),
 				     tokens[0], tokens[1]);
 	  s_current->error_messages =
 	    g_list_append(s_current->error_messages, message);
@@ -251,7 +251,7 @@ s_check_symbol_structure (const GList *obj_list, SYMCHECK *s_current)
       } else { /* object is not an attribute */
         if (o_current->show_name_value != SHOW_NAME_VALUE) {
           message = g_strdup_printf (_("Found a simple text object with only SHOW_NAME"
-                                     " or SHOW_VALUE set [%s]\n"),
+                                     " or SHOW_VALUE set [%1$s]\n"),
                                      geda_text_object_get_string (o_current));
           s_current->warning_messages =
             g_list_append(s_current->warning_messages, message);
@@ -317,7 +317,7 @@ s_check_text (const GList *obj_list, SYMCHECK *s_current)
       default:
         if (escape == TRUE) {
           message = g_strdup_printf (_("Found text with a '\\' in it: consider"
-                                     " to escape it with '\\\\' [%s]\n"),
+                                     " to escape it with '\\\\' [%1$s]\n"),
                                      text_string);
           s_current->warning_messages = g_list_append(s_current->warning_messages,
                                                       message);
@@ -329,7 +329,7 @@ s_check_text (const GList *obj_list, SYMCHECK *s_current)
 
     if (escape == TRUE) {
       message = g_strdup_printf (_("Found text with a trailing '\': consider to "
-                                 "escape it with '\\\\' [%s]\n"),
+                                 "escape it with '\\\\' [%1$s]\n"),
                                  text_string);
       s_current->warning_messages = g_list_append(s_current->warning_messages,
                                                   message);
@@ -338,7 +338,7 @@ s_check_text (const GList *obj_list, SYMCHECK *s_current)
 
     if (overbar_started == TRUE) {
       message = g_strdup_printf (_("Found text with unbalanced overbar "
-                                 "markers '\\_' in it' [%s]\n"),
+                                 "markers '\\_' in it' [%1$s]\n"),
                                  text_string);
       s_current->warning_messages = g_list_append(s_current->warning_messages,
                                                   message);
@@ -380,7 +380,7 @@ s_check_device (const GList *obj_list, SYMCHECK *s_current)
     /* found device= attribute */
     s_current->missing_device_attrib=FALSE;
     s_current->device_attribute = g_strdup (temp);
-    message = g_strdup_printf (_("Found device=%s\n"), temp);
+    message = g_strdup_printf (_("Found device=%1$s\n"), temp);
     s_current->info_messages = g_list_append(s_current->info_messages,
 		                             message);
   }
@@ -443,7 +443,7 @@ s_check_pinseq (const GList *obj_list, SYMCHECK *s_current)
       while (string)
       {
         
-        message = g_strdup_printf (_("Found pinseq=%s attribute\n"), string); 
+        message = g_strdup_printf (_("Found pinseq=%1$s attribute\n"), string);
         s_current->info_messages = g_list_append(s_current->info_messages,
 	 	    			         message);
 
@@ -458,7 +458,7 @@ s_check_pinseq (const GList *obj_list, SYMCHECK *s_current)
 
         if (found_first) {
           message = g_strdup_printf (
-            _("Found multiple pinseq=%s attributes on one pin\n"),
+            _("Found multiple pinseq=%1$s attributes on one pin\n"),
             string);
           s_current->error_messages = g_list_append(s_current->error_messages,
 	 	    			            message);
@@ -508,7 +508,7 @@ s_check_pinseq (const GList *obj_list, SYMCHECK *s_current)
     if (found > 1)
     {
       message = g_strdup_printf (
-        _("Found duplicate pinseq=%s attribute in the symbol\n"),
+        _("Found duplicate pinseq=%1$s attribute in the symbol\n"),
         string);
       s_current->error_messages = g_list_append(s_current->error_messages,
                                                 message);
@@ -553,21 +553,21 @@ s_check_pinnumber (const GList *obj_list, SYMCHECK *s_current)
   for (counter = 0;
        (net = o_attrib_search_floating_attribs_by_name (obj_list, "net", counter)) != NULL;
        counter++) {
-    message = g_strdup_printf (_("Found net=%s attribute\n"), net);
+    message = g_strdup_printf (_("Found net=%1$s attribute\n"), net);
     s_current->info_messages = g_list_append(s_current->info_messages,
 					     message);
 
     net_tokens = g_strsplit(net,":", -1);
     /* length of net tokens have to be 2 */
     if (net_tokens[1] == NULL) {
-      message = g_strdup_printf (_("Bad net= attribute [net=%s]\n"), net);
+      message = g_strdup_printf (_("Bad net= attribute [net=%1$s]\n"), net);
       s_current->error_messages = g_list_append(s_current->error_messages,
 						message);
       s_current->error_count++;
       g_strfreev(net_tokens);
       continue;
     } else if (net_tokens[2] != NULL) { /* more than 2 tokens */
-      message = g_strdup_printf (_("Bad net= attribute [net=%s]\n"), net);
+      message = g_strdup_printf (_("Bad net= attribute [net=%1$s]\n"), net);
       s_current->error_messages = g_list_append(s_current->error_messages,
 						message);
       s_current->error_count++;
@@ -579,7 +579,7 @@ s_check_pinnumber (const GList *obj_list, SYMCHECK *s_current)
     
     for (i = 0; pin_tokens[i] != NULL; i++) {
       net_numbers = g_list_append(net_numbers, g_strdup(pin_tokens[i]));
-      message = g_strdup_printf (_("Found pin number %s in net attribute\n"),
+      message = g_strdup_printf (_("Found pin number %1$s in net attribute\n"),
                                  pin_tokens[i]);
       s_current->info_messages = g_list_append(s_current->info_messages,
 					       message);
@@ -598,7 +598,7 @@ s_check_pinnumber (const GList *obj_list, SYMCHECK *s_current)
        cur = g_list_next(cur)) {
     if (strcmp((gchar*)cur->data, (gchar*) cur->next->data) == 0) {
       message = g_strdup_printf (_("Found duplicate pin in net= "
-				 "attributes [%s]\n"), (gchar*) cur->data);
+				 "attributes [%1$s]\n"), (gchar*) cur->data);
       s_current->error_messages = g_list_append(s_current->error_messages,
 						message);
       s_current->error_count++;
@@ -626,7 +626,7 @@ s_check_pinnumber (const GList *obj_list, SYMCHECK *s_current)
 	                                                     counter)) != NULL;
 	   counter++) {
 	
-        message = g_strdup_printf (_("Found pinnumber=%s attribute\n"), string);
+        message = g_strdup_printf (_("Found pinnumber=%1$s attribute\n"), string);
         s_current->info_messages = g_list_append(s_current->info_messages,
 	 	    			         message);
 
@@ -634,7 +634,7 @@ s_check_pinnumber (const GList *obj_list, SYMCHECK *s_current)
 	  pin_numbers = g_list_append(pin_numbers, string);
 	}
         if (counter >= 1) {
-          message = g_strdup_printf (_("Found multiple pinnumber=%s attributes"
+          message = g_strdup_printf (_("Found multiple pinnumber=%1$s attributes"
 				     " on one pin\n"), string);
           s_current->error_messages = g_list_append(s_current->error_messages,
 	 	    			            message);
@@ -663,7 +663,7 @@ s_check_pinnumber (const GList *obj_list, SYMCHECK *s_current)
        cur != NULL && g_list_next(cur) != NULL;
        cur = g_list_next(cur)) { 
     if (strcmp((gchar*)cur->data, (gchar*) cur->next->data) == 0) {
-      message = g_strdup_printf (_("Found duplicate pinnumber=%s attribute "
+      message = g_strdup_printf (_("Found duplicate pinnumber=%1$s attribute "
 				 "in the symbol\n"), (gchar*) cur->data);
       s_current->error_messages = g_list_append(s_current->error_messages,
 						message);
@@ -690,7 +690,7 @@ s_check_pinnumber (const GList *obj_list, SYMCHECK *s_current)
 
     if (i == 0) {
       message = g_strdup_printf (_("Found the same number in a pinnumber "
-				 "attribute and in a net attribute [%s]\n"),
+				 "attribute and in a net attribute [%1$s]\n"),
 				 (gchar*) cur->data);
       s_current->warning_messages = g_list_append(s_current->warning_messages,
 						  message);
@@ -707,7 +707,7 @@ s_check_pinnumber (const GList *obj_list, SYMCHECK *s_current)
 
   /* FIXME: this is not correct if a pinnumber is defined as pinnumber and
      inside a net. We have to calculate the union set */
-  message = g_strdup_printf (_("Found %d pins inside symbol\n"), 
+  message = g_strdup_printf (_("Found %1$d pins inside symbol\n"),
 			     s_current->numpins + s_current->numnetpins);
   s_current->info_messages = g_list_append(s_current->info_messages,
                                            message);
@@ -736,7 +736,7 @@ s_check_pin_ongrid (const GList *obj_list, SYMCHECK *s_current)
       
       if (x1 % 100 != 0 || y1 % 100 != 0) {
 	message = g_strdup_printf(_("Found offgrid pin at location"
-				  " (x1=%d,y1=%d)\n"), x1, y1);
+				  " (x1=%1$d,y1=%2$d)\n"), x1, y1);
 	/* error if it is the whichend, warning if not */
 	if (o_current->whichend == 0) {
 	  s_current->error_messages = g_list_append(s_current->error_messages,
@@ -751,7 +751,7 @@ s_check_pin_ongrid (const GList *obj_list, SYMCHECK *s_current)
       }
       if (x2 % 100 != 0 || y2 % 100 != 0) {
 	message = g_strdup_printf(_("Found offgrid pin at location"
-				  " (x2=%d,y2=%d)\n"), x2, y2);
+				  " (x2=%1$d,y2=%2$d)\n"), x2, y2);
 	/* error when whichend, warning if not */
 	if (o_current-> whichend != 0) {
 	  s_current->error_messages = g_list_append(s_current->error_messages,
@@ -804,7 +804,7 @@ s_check_slotdef (const GList *obj_list, SYMCHECK *s_current)
   sprintf(numslots_str, "%d", s_current->numslots);
   g_free(value);
 
-  message = g_strdup_printf (_("Found numslots=%s attribute\n"), numslots_str);
+  message = g_strdup_printf (_("Found numslots=%1$s attribute\n"), numslots_str);
   s_current->info_messages = g_list_append(s_current->info_messages,
 	 	    			   message);
 
@@ -828,7 +828,7 @@ s_check_slotdef (const GList *obj_list, SYMCHECK *s_current)
 
       sprintf(tempstr1, "%d", i+1); /* i starts at zero */
       message = g_strdup_printf (
-        _("Found %s slotdef= attributes.  Expecting %s slotdef= attributes\n"),
+        _("Found %1$s slotdef= attributes.  Expecting %2$s slotdef= attributes\n"),
         tempstr1, numslots_str); 
       s_current->error_messages = g_list_append(s_current->error_messages,
                                                 message);
@@ -837,7 +837,7 @@ s_check_slotdef (const GList *obj_list, SYMCHECK *s_current)
       s_current->slotting_errors++;
     }
     
-    message = g_strdup_printf (_("Found slotdef=%s attribute\n"), slotdef);
+    message = g_strdup_printf (_("Found slotdef=%1$s attribute\n"), slotdef);
     s_current->info_messages = g_list_append(s_current->info_messages,
 	 	    			     message);
 
@@ -845,7 +845,7 @@ s_check_slotdef (const GList *obj_list, SYMCHECK *s_current)
     if (!slotnum)
     {
       message = g_strdup_printf (
-        _("Invalid slotdef=%s attributes, not continuing\n"),
+        _("Invalid slotdef=%1$s attributes, not continuing\n"),
         slotdef);
       s_current->error_messages = g_list_append(s_current->error_messages,
                                                 message);
@@ -857,7 +857,7 @@ s_check_slotdef (const GList *obj_list, SYMCHECK *s_current)
 
     if (strcmp(slotnum, "0") == 0) {
       message = g_strdup_printf (
-        _("Found a zero slot in slotdef=%s\n"),
+        _("Found a zero slot in slotdef=%1$s\n"),
         slotdef);
       s_current->error_messages = g_list_append(s_current->error_messages,
                                                 message);
@@ -871,7 +871,7 @@ s_check_slotdef (const GList *obj_list, SYMCHECK *s_current)
     if (slot > s_current->numslots) {
       sprintf(tempstr1, "%d", slot);
       message = g_strdup_printf (
-        _("Slot %s is larger then the maximum number (%s) of slots\n"),
+        _("Slot %1$s is larger then the maximum number (%2$s) of slots\n"),
         tempstr1, numslots_str);
       s_current->error_messages = g_list_append(s_current->error_messages,
 		      			        message);
@@ -884,7 +884,7 @@ s_check_slotdef (const GList *obj_list, SYMCHECK *s_current)
     pins = strchr(slotdef, ':');
     if (!pins) {
       message = g_strdup_printf (
-        _("Invalid slotdef=%s attributes, not continuing\n"),
+        _("Invalid slotdef=%1$s attributes, not continuing\n"),
         slotdef);
       s_current->error_messages = g_list_append(s_current->error_messages,
                                                 message);
@@ -896,7 +896,7 @@ s_check_slotdef (const GList *obj_list, SYMCHECK *s_current)
     pins++;  /* get past that : */
     if (!pins) {
       message = g_strdup_printf (
-        _("Invalid slotdef=%s attributes, not continuing\n"),
+        _("Invalid slotdef=%1$s attributes, not continuing\n"),
         slotdef);
       s_current->error_messages = g_list_append(s_current->error_messages,
                                                 message);
@@ -908,7 +908,7 @@ s_check_slotdef (const GList *obj_list, SYMCHECK *s_current)
 
     if (*pins == '\0') {
       message = g_strdup_printf (
-        _("Invalid slotdef=%s attributes, not continuing\n"),
+        _("Invalid slotdef=%1$s attributes, not continuing\n"),
         slotdef);
       s_current->error_messages = g_list_append(s_current->error_messages,
                                                 message);
@@ -920,7 +920,7 @@ s_check_slotdef (const GList *obj_list, SYMCHECK *s_current)
 
     if ((slot > 0) && (slot <= s_current->numslots)) {
       if (pinlist[slot-1]) {
-        message = g_strdup_printf (_("Duplicate slot number in slotdef=%s\n"),
+        message = g_strdup_printf (_("Duplicate slot number in slotdef=%1$s\n"),
 				   slotdef);
         s_current->error_messages = g_list_append(s_current->error_messages,
 	    			                  message);
@@ -942,7 +942,7 @@ s_check_slotdef (const GList *obj_list, SYMCHECK *s_current)
 
       if (!temp && j < s_current->numpins) {
         message = g_strdup_printf (
-          _("Not enough pins in slotdef=%s\n"),
+          _("Not enough pins in slotdef=%1$s\n"),
           slotdef);
         s_current->error_messages = g_list_append(s_current->error_messages,
 	    			                  message);
@@ -953,7 +953,7 @@ s_check_slotdef (const GList *obj_list, SYMCHECK *s_current)
 
       if (j > s_current->numpins) {
         message = g_strdup_printf (
-          _("Too many pins in slotdef=%s\n"),
+          _("Too many pins in slotdef=%1$s\n"),
           slotdef);
         s_current->error_messages = g_list_append(s_current->error_messages,
 	    			                  message);
@@ -966,7 +966,7 @@ s_check_slotdef (const GList *obj_list, SYMCHECK *s_current)
       
       if (temp && strcmp(temp, "0") == 0) {
         message = g_strdup_printf (
-          _("Found a zero pin in slotdef=%s\n"),
+          _("Found a zero pin in slotdef=%1$s\n"),
           slotdef);
         s_current->error_messages = g_list_append(s_current->error_messages,
                                                   message);
@@ -987,7 +987,7 @@ s_check_slotdef (const GList *obj_list, SYMCHECK *s_current)
 
   if (!slotdef && i < s_current->numslots) {
     message = g_strdup_printf (
-      _("Missing slotdef= (there should be %s slotdef= attributes)\n"),
+      _("Missing slotdef= (there should be %1$s slotdef= attributes)\n"),
       numslots_str);
     s_current->error_messages = g_list_append(s_current->error_messages,
 			                      message);
@@ -1038,7 +1038,7 @@ s_check_slotdef (const GList *obj_list, SYMCHECK *s_current)
           }
         }
       }
-      message = g_strdup_printf (_("Found %d distinct pins in slots\n"), 
+      message = g_strdup_printf (_("Found %1$d distinct pins in slots\n"),
                                  s_current->numslotpins);
       s_current->info_messages = g_list_append(s_current->info_messages,
                                                message);
@@ -1114,7 +1114,7 @@ s_check_oldpin (const GList *obj_list, SYMCHECK *s_current)
         if (found_old == 2)
         {
           message = g_strdup_printf (
-            _("Found old pin#=# attribute: %s\n"),
+            _("Found old pin#=# attribute: %1$s\n"),
             geda_text_object_get_string (o_current));
           s_current->error_messages = g_list_append(s_current->error_messages,
                                                     message);
@@ -1186,7 +1186,7 @@ s_check_oldslot (const GList *obj_list, SYMCHECK *s_current)
         if (found_old == 2)
         {
           message = g_strdup_printf (
-            _("Found old slot#=# attribute: %s\n"),
+            _("Found old slot#=# attribute: %1$s\n"),
             geda_text_object_get_string (o_current));
           s_current->error_messages = g_list_append(s_current->error_messages,
                                                     message);
@@ -1268,7 +1268,7 @@ s_check_missing_attribute(OBJECT *object, char *attribute, SYMCHECK *s_current)
   if (!string)
   {
     message = g_strdup_printf (
-      _("Missing %s= attribute\n"),
+      _("Missing %1$s= attribute\n"),
       attribute);
     s_current->warning_messages = g_list_append(s_current->warning_messages,
                                                 message);
@@ -1280,7 +1280,7 @@ s_check_missing_attribute(OBJECT *object, char *attribute, SYMCHECK *s_current)
 
     if (found_first) {
       message = g_strdup_printf (
-        _("Found multiple %s=%s attributes on one pin\n"),
+        _("Found multiple %1$s=%2$s attributes on one pin\n"),
         attribute, string);
       s_current->error_messages = g_list_append(s_current->error_messages,
                                                 message);
@@ -1291,7 +1291,7 @@ s_check_missing_attribute(OBJECT *object, char *attribute, SYMCHECK *s_current)
     if (!found_first) {
 
       message = g_strdup_printf (
-        _("Found %s=%s attribute\n"),
+        _("Found %1$s=%2$s attribute\n"),
         attribute, string);
       s_current->info_messages = g_list_append(s_current->info_messages,
                                                message);
@@ -1325,7 +1325,7 @@ s_check_missing_attributes (const GList *obj_list, SYMCHECK *s_current)
     {
       if (strstr(geda_text_object_get_string (o_current), "footprint=")) {
         message = g_strdup_printf (
-          _("Found %s attribute\n"),
+          _("Found %1$s attribute\n"),
           geda_text_object_get_string (o_current));
         s_current->info_messages = g_list_append(s_current->info_messages,
                                                message);
@@ -1334,7 +1334,7 @@ s_check_missing_attributes (const GList *obj_list, SYMCHECK *s_current)
 
       if (strstr(geda_text_object_get_string (o_current), "refdes=")) {
         message = g_strdup_printf (
-          _("Found %s attribute\n"),
+          _("Found %1$s attribute\n"),
           geda_text_object_get_string (o_current));
         s_current->info_messages = g_list_append(s_current->info_messages,
                                                message);
@@ -1396,12 +1396,12 @@ void s_check_pintype (const GList *obj_list, SYMCHECK *s_current)
                                                               counter)) != NULL;
            counter++) {
 
-        message = g_strdup_printf(_("Found pintype=%s attribute\n"), pintype);
+        message = g_strdup_printf(_("Found pintype=%1$s attribute\n"), pintype);
         s_current->info_messages = g_list_append(s_current->info_messages,
 	 	    			         message);
 
 	if ( ! s_check_list_has_item(pintypes, pintype)) {
-	  message = g_strdup_printf (_("Invalid pintype=%s attribute\n"), pintype);
+	  message = g_strdup_printf (_("Invalid pintype=%1$s attribute\n"), pintype);
 	  s_current->error_messages = g_list_append(s_current->error_messages, 
 						    message); 
 	  s_current->error_count++; 

--- a/gsymcheck/src/s_symstruct.c
+++ b/gsymcheck/src/s_symstruct.c
@@ -95,7 +95,7 @@ s_symstruct_print(SYMCHECK *s_current)
       msg = (char *) list->data;     
       /* printf("found info: %s\n", msg); */
       if (msg) { 
-        s_log_message(_("Info: %s"), msg);
+        s_log_message(_("Info: %1$s"), msg);
         g_free(msg);
       }
 
@@ -110,7 +110,7 @@ s_symstruct_print(SYMCHECK *s_current)
      
       /* printf("found warning: %s\n", msg); */
       if (msg) { 
-        s_log_message(_("Warning: %s"), msg);
+        s_log_message(_("Warning: %1$s"), msg);
         g_free(msg);
       }
 
@@ -125,7 +125,7 @@ s_symstruct_print(SYMCHECK *s_current)
      
       /* printf("found error: %s\n", msg); */
       if (msg && verbose_mode) { 
-        s_log_message(_("ERROR: %s"), msg);
+        s_log_message(_("ERROR: %1$s"), msg);
         g_free(msg);
       }
 

--- a/liblepton/src/a_basic.c
+++ b/liblepton/src/a_basic.c
@@ -54,7 +54,7 @@ int o_save (TOPLEVEL *toplevel, const GList *object_list,
   if (g_file_test(filename, G_FILE_TEST_EXISTS) &&
       g_access(filename, W_OK) != 0) {
     g_set_error (err, G_FILE_ERROR, G_FILE_ERROR_PERM,
-                 _("File %s is read-only"), filename);
+                 _("File %1$s is read-only"), filename);
     return 0;
   }
 
@@ -244,7 +244,7 @@ GList *o_read_buffer (TOPLEVEL *toplevel, GList *object_list,
         }
         else {
           g_set_error (err, EDA_ERROR, EDA_ERROR_PARSE, _("Read unexpected attach "
-                                                                 "symbol start marker in [%s] :\n>>\n%s<<\n"),
+                                                                 "symbol start marker in [%1$s] :\n>>\n%2$s<<\n"),
                        name, line);
           goto error;
         }
@@ -261,7 +261,7 @@ GList *o_read_buffer (TOPLEVEL *toplevel, GList *object_list,
           embedded_level++;
         } else {
           g_set_error (err, EDA_ERROR, EDA_ERROR_PARSE, _("Read unexpected embedded "
-                                                                 "symbol start marker in [%s] :\n>>\n%s<<\n"),
+                                                                 "symbol start marker in [%1$s] :\n>>\n%2$s<<\n"),
                        name, line);
           goto error;
         }
@@ -327,12 +327,12 @@ GList *o_read_buffer (TOPLEVEL *toplevel, GList *object_list,
 
         if (fileformat_ver == 0) {
           s_log_message(_("Read an old format sym/sch file!\n"
-                          "Please run g[sym|sch]update on:\n[%s]\n"), name);
+                          "Please run g[sym|sch]update on:\n[%1$s]\n"), name);
         }
         break;
 
       default:
-        g_set_error (err, EDA_ERROR, EDA_ERROR_PARSE, _("Read garbage in [%s] :\n>>\n%s<<\n"), name, line);
+        g_set_error (err, EDA_ERROR, EDA_ERROR_PARSE, _("Read garbage in [%1$s] :\n>>\n%2$s<<\n"), name, line);
         new_obj = NULL;
         goto error;
     }

--- a/liblepton/src/f_basic.c
+++ b/liblepton/src/f_basic.c
@@ -116,7 +116,7 @@ gboolean f_has_active_autosave (const gchar *filename, GError **err)
   if (auto_err) {
     g_errcode = g_file_error_from_errno (auto_err);
     g_set_error (err, G_FILE_ERROR, g_errcode,
-                 _("Failed to stat [%s]: %s"),
+                 _("Failed to stat [%1$s]: %2$s"),
                  auto_filename, g_strerror (auto_err));
     result = TRUE;
     goto check_autosave_finish;
@@ -129,7 +129,7 @@ gboolean f_has_active_autosave (const gchar *filename, GError **err)
   if (file_err) {
     g_errcode = g_file_error_from_errno (file_err);
     g_set_error (err, G_FILE_ERROR, g_errcode,
-                 _("Failed to stat [%s]: %s"),
+                 _("Failed to stat [%1$s]: %2$s"),
                  auto_filename, g_strerror (file_err));
     result = TRUE;
     goto check_autosave_finish;
@@ -208,7 +208,7 @@ int f_open_flags(TOPLEVEL *toplevel, PAGE *page,
   full_filename = f_normalize_filename (filename, &tmp_err);
   if (full_filename == NULL) {
     g_set_error (err, G_FILE_ERROR, tmp_err->code,
-                 _("Cannot find file %s: %s"),
+                 _("Cannot find file %1$s: %2$s"),
                  filename, tmp_err->message);
     g_error_free(tmp_err);
     return 0;
@@ -254,7 +254,7 @@ int f_open_flags(TOPLEVEL *toplevel, PAGE *page,
     if (tmp_err != NULL) g_warning ("%s\n", tmp_err->message);
     if (active_backup) {
       message = g_string_new ("");
-      g_string_append_printf(message, _("\nWARNING: Found an autosave backup file:\n  %s.\n\n"), backup_filename);
+      g_string_append_printf(message, _("\nWARNING: Found an autosave backup file:\n  %1$s.\n\n"), backup_filename);
       if (tmp_err != NULL) {
         g_string_append(message, _("I could not guess if it is newer, so you have to do it manually.\n"));
       } else {
@@ -358,7 +358,7 @@ int f_save(TOPLEVEL *toplevel, PAGE *page, const char *filename, GError **err)
 
   if (real_filename == NULL) {
     g_set_error (err, tmp_err->domain, tmp_err->code,
-                 _("Can't get the real filename of %s: %s"),
+                 _("Can't get the real filename of %1$s: %2$s"),
                  filename,
                  tmp_err->message);
     return 0;
@@ -368,7 +368,7 @@ int f_save(TOPLEVEL *toplevel, PAGE *page, const char *filename, GError **err)
   if (g_file_test(filename, G_FILE_TEST_EXISTS) && 
       g_access(filename, W_OK) != 0) {
     g_set_error (err, G_FILE_ERROR, G_FILE_ERROR_PERM,
-                 _("File %s is read-only"), filename);
+                 _("File %1$s is read-only"), filename);
     return 0;      
   }
   
@@ -389,13 +389,13 @@ int f_save(TOPLEVEL *toplevel, PAGE *page, const char *filename, GError **err)
       if ( g_file_test (backup_filename, G_FILE_TEST_EXISTS) && 
 	   (! g_file_test (backup_filename, G_FILE_TEST_IS_DIR))) {
 	if (chmod(backup_filename, S_IREAD|S_IWRITE) != 0) {
-	  s_log_message (_("Could NOT set previous backup file [%s] read-write\n"),
+	  s_log_message (_("Could NOT set previous backup file [%1$s] read-write\n"),
 			 backup_filename);
 	}
       }
 	
       if (rename(real_filename, backup_filename) != 0) {
-	s_log_message (_("Can't save backup file: %s."), backup_filename);
+	s_log_message (_("Can't save backup file: %1$s."), backup_filename);
       }
       else {
 	/* Make the backup file readonly so a 'rm *' command will ask 
@@ -405,7 +405,7 @@ int f_save(TOPLEVEL *toplevel, PAGE *page, const char *filename, GError **err)
 	mask = (~mask)&0777;
 	mask &= ((~saved_umask) & 0777);
 	if (chmod(backup_filename, mask) != 0) {
-	  s_log_message (_("Could NOT set backup file [%s] readonly\n"),
+	  s_log_message (_("Could NOT set backup file [%1$s] readonly\n"),
                          backup_filename);
 	}
 	umask(saved_umask);
@@ -454,12 +454,12 @@ int f_save(TOPLEVEL *toplevel, PAGE *page, const char *filename, GError **err)
        best-effort basis; rather than treating failure as an error, we
        just log a warning. */
     if (chmod (real_filename, st.st_mode)) {
-      g_warning (_("Failed to restore permissions on '%s': %s\n"),
+      g_warning (_("Failed to restore permissions on '%1$s': %2$s\n"),
                  real_filename, g_strerror (errno));
     }
 #ifdef HAVE_CHOWN
     if (chown (real_filename, st.st_uid, st.st_gid)) {
-      g_warning (_("Failed to restore ownership on '%s': %s\n"),
+      g_warning (_("Failed to restore ownership on '%1$s': %2$s\n"),
                  real_filename, g_strerror (errno));
     }
 #endif
@@ -469,7 +469,7 @@ int f_save(TOPLEVEL *toplevel, PAGE *page, const char *filename, GError **err)
   }
   else {
     g_set_error (err, tmp_err->domain, tmp_err->code,
-                 _("Could NOT save file: %s"), tmp_err->message);
+                 _("Could NOT save file: %1$s"), tmp_err->message);
     g_clear_error (&tmp_err);
     g_free (real_filename);
     return 0;

--- a/liblepton/src/g_rc.c
+++ b/liblepton/src/g_rc.c
@@ -96,7 +96,7 @@ SCM g_rc_mode_general(SCM scmmode,
   /* no match? */
   if(index == table_size) {
     fprintf(stderr,
-            _("Invalid mode [%s] passed to %s\n"),
+            _("Invalid mode [%1$s] passed to %2$s\n"),
             mode,
             rc_name);
     ret = SCM_BOOL_F;
@@ -180,7 +180,7 @@ g_rc_parse_file (TOPLEVEL *toplevel, const gchar *rcfile,
     eda_config_load (cfg, &tmp_err);
     if (tmp_err != NULL &&
         !g_error_matches (tmp_err, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))
-      g_warning (_("Failed to load config from '%s': %s\n"),
+      g_warning (_("Failed to load config from '%1$s': %2$s\n"),
                  eda_config_get_filename (cfg), tmp_err->message);
     g_clear_error (&tmp_err);
   }
@@ -204,11 +204,11 @@ g_rc_parse_file (TOPLEVEL *toplevel, const gchar *rcfile,
   scm_dynwind_end ();
 
   if (status) {
-    s_log_message (_("Loaded RC file [%s]\n"), name_norm);
+    s_log_message (_("Loaded RC file [%1$s]\n"), name_norm);
   } else {
     /* Copy tmp_err into err, with a prefixed message. */
     g_propagate_prefixed_error (err, tmp_err,
-                                _("Failed to load RC file [%s]: "),
+                                _("Failed to load RC file [%2$s]: "),
                                 name_norm);
     g_free (name_norm);
   }
@@ -339,8 +339,8 @@ g_rc_parse__process_error (GError **err, const gchar *pname)
   if (*err == NULL) {
     const gchar *msgl =
       _("ERROR: An unknown error occurred while parsing configuration files.");
-    s_log_message ("%s\n", msgl);
-    fprintf(stderr, "%s\n", msgl);
+    s_log_message ("%1$s\n", msgl);
+    fprintf(stderr, "%1$s\n", msgl);
 
   } else {
     /* RC files are allowed to be missing or skipped; check for
@@ -350,14 +350,14 @@ g_rc_parse__process_error (GError **err, const gchar *pname)
       return;
     }
 
-    s_log_message (_("ERROR: %s\n"), (*err)->message);
-    fprintf (stderr, _("ERROR: %s\n"), (*err)->message);
+    s_log_message (_("ERROR: %1$s\n"), (*err)->message);
+    fprintf (stderr, _("ERROR: %1$s\n"), (*err)->message);
   }
 
   /* g_path_get_basename() allocates memory, but we don't care
    * because we're about to exit. */
   pbase = g_path_get_basename (pname);
-  fprintf (stderr, _("ERROR: The %s log may contain more information.\n"),
+  fprintf (stderr, _("ERROR: The %1$s log may contain more information.\n"),
            pbase);
   exit (1);
 }
@@ -478,7 +478,7 @@ SCM g_rc_component_library(SCM path, SCM name)
   /* invalid path? */
   if (!g_file_test (string, G_FILE_TEST_IS_DIR)) {
     fprintf(stderr,
-            _("Invalid path [%s] passed to component-library\n"),
+            _("Invalid path [%1$s] passed to component-library\n"),
             string);
     scm_dynwind_end();
     return SCM_BOOL_F;
@@ -704,7 +704,7 @@ SCM g_rc_bitmap_directory(SCM path)
   /* invalid path? */
   if (!g_file_test (string, G_FILE_TEST_IS_DIR)) {
     fprintf (stderr,
-             _("Invalid path [%s] passed to bitmap-directory\n"),
+             _("Invalid path [%1$s] passed to bitmap-directory\n"),
              string);
     g_free(string);
     return SCM_BOOL_F;

--- a/liblepton/src/geda_arc_object.c
+++ b/liblepton/src/geda_arc_object.c
@@ -425,13 +425,14 @@ OBJECT *o_arc_read (TOPLEVEL *toplevel, const char buf[],
 
   /* Error check */
   if (radius <= 0) {
-    s_log_message (_("Found a zero radius arc [ %c %d, %d, %d, %d, %d, %d ]\n"),
+    s_log_message (_("Found a zero radius arc "
+                     "[ %1$c %2$d, %3$d, %4$d, %5$d, %6$d, %7$d ]\n"),
                    type, x1, y1, radius, start_angle, sweep_angle, color);
     radius = 0;
   }
 
   if (color < 0 || color > MAX_COLORS) {
-    s_log_message(_("Found an invalid color [ %s ]\n"), buf);
+    s_log_message(_("Found an invalid color [ %1$s ]\n"), buf);
     s_log_message(_("Setting color to default color\n"));
     color = DEFAULT_COLOR;
   }

--- a/liblepton/src/geda_box_object.c
+++ b/liblepton/src/geda_box_object.c
@@ -319,12 +319,13 @@ OBJECT *o_box_read (TOPLEVEL *toplevel, const char buf[],
   }
 
   if (width == 0 || height == 0) {
-    s_log_message (_("Found a zero width/height box [ %c %d %d %d %d %d ]\n"),
+    s_log_message (_("Found a zero width/height box "
+                     "[ %1$c %2$d %3$d %4$d %5$d %6$d ]\n"),
                    type, x1, y1, width, height, color);
   }
 
   if (color < 0 || color > MAX_COLORS) {
-    s_log_message (_("Found an invalid color [ %s ]\n"), buf);
+    s_log_message (_("Found an invalid color [ %1$s ]\n"), buf);
     s_log_message (_("Setting color to default color\n"));
     color = DEFAULT_COLOR;
   }

--- a/liblepton/src/geda_bus_object.c
+++ b/liblepton/src/geda_bus_object.c
@@ -355,18 +355,19 @@ o_bus_read (TOPLEVEL *toplevel,
   }
 
   if (x1 == x2 && y1 == y2) {
-    s_log_message (_("Found a zero length bus [ %c %d %d %d %d %d ]\n"),
+    s_log_message (_("Found a zero length bus "
+                     "[ %1$c %2$d %3$d %4$d %5$d %6$d ]\n"),
                     type, x1, y1, x2, y2, color);
   }
 
   if (color < 0 || color > MAX_COLORS) {
-    s_log_message (_("Found an invalid color [ %s ]\n"), buf);
+    s_log_message (_("Found an invalid color [ %1$s ]\n"), buf);
     s_log_message (_("Setting color to default color\n"));
     color = DEFAULT_COLOR;
   }
 
   if (ripper_dir < -1 || ripper_dir > 1) {
-    s_log_message (_("Found an invalid bus ripper direction [ %s ]\n"), buf);
+    s_log_message (_("Found an invalid bus ripper direction [ %1$s ]\n"), buf);
     s_log_message (_("Resetting direction to neutral (no direction)\n"));
     ripper_dir = 0;
   }

--- a/liblepton/src/geda_circle_object.c
+++ b/liblepton/src/geda_circle_object.c
@@ -376,14 +376,15 @@ o_circle_read (TOPLEVEL *toplevel,
 
 
   if (radius <= 0) {
-    s_log_message(_("Found a zero or negative radius circle [ %c %d %d %d %d ]\n"),
+    s_log_message(_("Found a zero or negative radius circle "
+                    "[ %1$c %2$d %3$d %4$d %5$d ]\n"),
                   type, x1, y1, radius, color);
     s_log_message (_("Setting radius to 0\n"));
     radius = 0;
   }
 
   if (color < 0 || color > MAX_COLORS) {
-    s_log_message(_("Found an invalid color [ %s ]\n"), buf);
+    s_log_message(_("Found an invalid color [ %1$s ]\n"), buf);
     s_log_message(_("Setting color to default color\n"));
     color = DEFAULT_COLOR;
   }

--- a/liblepton/src/geda_color.c
+++ b/liblepton/src/geda_color.c
@@ -233,7 +233,7 @@ s_color_map_from_scm (GedaColor *map, SCM lst, const char *scheme_proc_name)
      * FIXME one day we will have dynamically-expanding colorspace.
      * One day. */
     if ((i < 0) || (i >= MAX_COLORS)) {
-      g_critical ("Color map index out of bounds: %i\n", i);
+      g_critical ("Color map index out of bounds: %1$i\n", i);
       goto color_map_next;
     }
 
@@ -257,7 +257,7 @@ s_color_map_from_scm (GedaColor *map, SCM lst, const char *scheme_proc_name)
 
     /* FIXME should we generate a Guile error if there's a problem here? */
     if (!result) {
-      g_critical ("Invalid color map value: %s\n", rgba);
+      g_critical ("Invalid color map value: %1$s\n", rgba);
     } else {
       map[i] = c;
       map[i].enabled = TRUE;

--- a/liblepton/src/geda_complex_object.c
+++ b/liblepton/src/geda_complex_object.c
@@ -364,7 +364,7 @@ static void create_placeholder(TOPLEVEL * toplevel, OBJECT * new_node, int x, in
 
     /* Add some useful text */
     not_found_text =
-      g_strdup_printf (_("Component not found:\n %s"),
+      g_strdup_printf (_("Component not found:\n %1$s"),
            new_node->complex_basename);
     new_prim_obj = geda_text_object_new (toplevel,
                                          DETACHED_ATTRIBUTE_COLOR,
@@ -589,7 +589,9 @@ OBJECT *o_complex_read (TOPLEVEL *toplevel,
       break;
 
     default:
-      s_log_message(_("Found a component with an invalid rotation [ %c %d %d %d %d %d %s ]\n"), type, x1, y1, selectable, angle, mirror, basename);
+      s_log_message(_("Found a component with an invalid rotation "
+                      "[ %1$c %2$d %3$d %4$d %5$d %6$d %7$s ]\n"),
+                    type, x1, y1, selectable, angle, mirror, basename);
       s_log_message (_("Setting angle to 0\n"));
       angle = 0;
   }
@@ -602,7 +604,9 @@ OBJECT *o_complex_read (TOPLEVEL *toplevel,
       break;
 
     default:
-      s_log_message(_("Found a component with an invalid mirror flag [ %c %d %d %d %d %d %s ]\n"), type, x1, y1, selectable, angle, mirror, basename);
+      s_log_message(_("Found a component with an invalid mirror flag "
+                      "[ %1$c %2$d %3$d %4$d %5$d %6$d %7$s ]\n"),
+                    type, x1, y1, selectable, angle, mirror, basename);
       s_log_message (_("Setting mirror to 0\n"));
       mirror = 0;
   }
@@ -926,11 +930,11 @@ o_complex_check_symversion(TOPLEVEL* toplevel, OBJECT* object)
     {
       if (inside)
       {
-        s_log_message(_("WARNING: Symbol version parse error on refdes %s:\n"
-                        "\tCould not parse symbol file symversion=%s\n"),
+        s_log_message(_("WARNING: Symbol version parse error on refdes %1$s:\n"
+                        "\tCould not parse symbol file symversion=%2$s\n"),
                       refdes, inside);
       } else {
-        s_log_message(_("WARNING: Symbol version parse error on refdes %s:\n"
+        s_log_message(_("WARNING: Symbol version parse error on refdes %1$s:\n"
                         "\tCould not parse symbol file symversion=\n"),
                       refdes);
       }
@@ -946,8 +950,8 @@ o_complex_check_symversion(TOPLEVEL* toplevel, OBJECT* object)
     outside_value = strtod(outside, &err_check);
     if (outside_value == 0 && outside == err_check)
     {
-      s_log_message(_("WARNING: Symbol version parse error on refdes %s:\n"
-                      "\tCould not parse attached symversion=%s\n"),
+      s_log_message(_("WARNING: Symbol version parse error on refdes %1$s:\n"
+                      "\tCould not parse attached symversion=%2$s\n"),
                     refdes, outside);
       goto done;
     }
@@ -971,8 +975,8 @@ o_complex_check_symversion(TOPLEVEL* toplevel, OBJECT* object)
   /* No symversion inside, but a version is outside, this is a weird case */
   if (!inside_present && outside_present)
   {
-    s_log_message(_("WARNING: Symbol version oddity on refdes %s:\n"
-                    "\tsymversion=%s attached to instantiated symbol, "
+    s_log_message(_("WARNING: Symbol version oddity on refdes %1$s:\n"
+                    "\tsymversion=%2$s attached to instantiated symbol, "
                     "but no symversion= inside symbol file\n"),
                   refdes, outside);
     goto done;
@@ -985,7 +989,7 @@ o_complex_check_symversion(TOPLEVEL* toplevel, OBJECT* object)
       ((inside_present && outside_present) && (inside_value > outside_value)))
   {
 
-    s_log_message(_("WARNING: Symbol version mismatch on refdes %s (%s):\n"
+    s_log_message(_("WARNING: Symbol version mismatch on refdes %1$s (%2$s):\n"
                     "\tSymbol in library is newer than "
                     "instantiated symbol\n"),
                   refdes, object->complex_basename);
@@ -1013,8 +1017,8 @@ o_complex_check_symversion(TOPLEVEL* toplevel, OBJECT* object)
     if (inside_major > outside_major)
     {
       char* refdes_copy;
-      s_log_message(_("\tMAJOR VERSION CHANGE (file %.3f, "
-                      "instantiated %.3f, %s)!\n"),
+      s_log_message(_("\tMAJOR VERSION CHANGE (file %1$.3f, "
+                      "instantiated %2$.3f, %3$s)!\n"),
                     inside_value, outside_value, refdes);
 
       /* add the refdes to the major_changed_refdes GList */
@@ -1031,8 +1035,8 @@ o_complex_check_symversion(TOPLEVEL* toplevel, OBJECT* object)
 
     if (inside_minor > outside_minor)
     {
-      s_log_message(_("\tMinor version change (file %.3f, "
-                      "instantiated %.3f)\n"),
+      s_log_message(_("\tMinor version change (file %1$.3f, "
+                      "instantiated %2$.3f)\n"),
                     inside_value, outside_value);
     }
 
@@ -1042,7 +1046,7 @@ o_complex_check_symversion(TOPLEVEL* toplevel, OBJECT* object)
   /* outside value is greater than inside value, this is weird case */
   if ((inside_present && outside_present) && (outside_value > inside_value))
   {
-    s_log_message(_("WARNING: Symbol version oddity on refdes %s:\n"
+    s_log_message(_("WARNING: Symbol version oddity on refdes %1$s:\n"
                     "\tInstantiated symbol is newer than "
                     "symbol in library\n"),
                   refdes);

--- a/liblepton/src/geda_line_object.c
+++ b/liblepton/src/geda_line_object.c
@@ -418,12 +418,13 @@ OBJECT *o_line_read (TOPLEVEL *toplevel, const char buf[],
    * It also checks is the required color is valid.
    */
   if (x1 == x2 && y1 == y2) {
-    s_log_message (_("Found a zero length line [ %c %d %d %d %d %d ]\n"),
+    s_log_message (_("Found a zero length line "
+                     "[ %1$c %2$d %3$d %4$d %5$d %6$d ]\n"),
                    type, x1, y1, x2, y2, color);
   }
 
   if (color < 0 || color > MAX_COLORS) {
-    s_log_message (_("Found an invalid color [ %s ]\n"), buf);
+    s_log_message (_("Found an invalid color [ %1$s ]\n"), buf);
     s_log_message (_("Setting color to default color\n"));
     color = DEFAULT_COLOR;
   }

--- a/liblepton/src/geda_net_object.c
+++ b/liblepton/src/geda_net_object.c
@@ -299,12 +299,13 @@ OBJECT *o_net_read (TOPLEVEL *toplevel, const char buf[],
   }
 
   if (x1 == x2 && y1 == y2) {
-    s_log_message (_("Found a zero length net [ %c %d %d %d %d %d ]\n"),
+    s_log_message (_("Found a zero length net "
+                     "[ %1$c %2$d %3$d %4$d %5$d %6$d ]\n"),
                    type, x1, y1, x2, y2, color);
   }
 
   if (color < 0 || color > MAX_COLORS) {
-    s_log_message (_("Found an invalid color [ %s ]\n"), buf);
+    s_log_message (_("Found an invalid color [ %1$s ]\n"), buf);
     s_log_message (_("Setting color to default color\n"));
     color = DEFAULT_COLOR;
   }

--- a/liblepton/src/geda_object.c
+++ b/liblepton/src/geda_object.c
@@ -218,7 +218,7 @@ OBJECT *o_object_copy (TOPLEVEL *toplevel,
       break;
 
     default:
-      g_critical ("o_list_copy_to: object %p has bad type '%c'\n",
+      g_critical ("o_list_copy_to: object %1$p has bad type '%2$c'\n",
                   selected, selected->type);
       return NULL;
   }
@@ -630,7 +630,7 @@ geda_object_get_position (const GedaObject *object, gint *x, gint *y)
       case OBJ_PIN:     func = geda_pin_object_get_position;     break;
       case OBJ_ARC:     func = geda_arc_object_get_position;     break;
       default:
-        g_critical ("geda_object_get_position: object %p has bad type '%c'\n",
+        g_critical ("geda_object_get_position: object %1$p has bad type '%2$c'\n",
                     object, object->type);
   }
 
@@ -669,7 +669,7 @@ geda_object_translate (GedaObject *object, gint dx, gint dy)
       case OBJ_PIN:     func = geda_pin_object_translate;     break;
       case OBJ_ARC:     func = geda_arc_object_translate;     break;
       default:
-        g_critical ("geda_object_translate: object %p has bad type '%c'\n",
+        g_critical ("geda_object_translate: object %1$p has bad type '%2$c'\n",
                     object, object->type);
   }
 
@@ -708,7 +708,7 @@ void geda_object_rotate (TOPLEVEL *toplevel, int world_centerx, int world_center
       case OBJ_PIN:     func = geda_pin_object_rotate;     break;
       case OBJ_ARC:     func = geda_arc_object_rotate;     break;
       default:
-        g_critical ("geda_object_rotate: object %p has bad type '%c'\n",
+        g_critical ("geda_object_rotate: object %1$p has bad type '%2$c'\n",
                     object, object->type);
   }
 
@@ -746,7 +746,7 @@ void geda_object_mirror (TOPLEVEL *toplevel, int world_centerx, int world_center
       case OBJ_PIN:     func = geda_pin_object_mirror;     break;
       case OBJ_ARC:     func = geda_arc_object_mirror;     break;
       default:
-        g_critical ("geda_object_mirror: object %p has bad type '%c'\n",
+        g_critical ("geda_object_mirror: object %1$p has bad type '%2$c'\n",
                     object, object->type);
   }
 
@@ -810,7 +810,7 @@ geda_object_shortest_distance_full (TOPLEVEL *toplevel, OBJECT *object,
     case OBJ_PATH:        func = geda_path_object_shortest_distance;     break;
     case OBJ_ARC:         func = geda_arc_object_shortest_distance;      break;
     default:
-      g_critical ("geda_object_shortest_distance: object %p has bad type '%c'\n",
+      g_critical ("geda_object_shortest_distance: object %1$p has bad type '%2$c'\n",
                   object, object->type);
   }
 

--- a/liblepton/src/geda_object_list.c
+++ b/liblepton/src/geda_object_list.c
@@ -438,7 +438,7 @@ o_save_objects (const GList *object_list, gboolean save_attribs)
            *  completely? In any case, failing gracefully is better
            *  than killing the program, which is what this used to
            *  do... */
-          g_critical (_("o_save_objects: object %p has unknown type '%c'\n"),
+          g_critical (_("o_save_objects: object %1$p has unknown type '%2$c'\n"),
                       o_current, o_current->type);
           /* Dump string built so far */
           g_string_free (acc, TRUE);

--- a/liblepton/src/geda_page.c
+++ b/liblepton/src/geda_page.c
@@ -62,7 +62,7 @@ object_added (TOPLEVEL *toplevel, PAGE *page, OBJECT *object)
   /* Set up object parent pointer */
 #ifndef NDEBUG
   if (object->page != NULL) {
-    g_critical ("Object %p already has parent page %p!", object, object->page);
+    g_critical ("Object %1$p already has parent page %2$p!", object, object->page);
   }
 #endif
   object->page = page;
@@ -85,7 +85,7 @@ pre_object_removed (TOPLEVEL *toplevel, PAGE *page, OBJECT *object)
   /* Clear object parent pointer */
 #ifndef NDEBUG
   if (object->page == NULL) {
-    g_critical ("Object %p has NULL parent page!", object);
+    g_critical ("Object %1$p has NULL parent page!", object);
   }
 #endif
   object->page = NULL;
@@ -194,7 +194,7 @@ void s_page_delete (TOPLEVEL *toplevel, PAGE *page)
   real_filename = follow_symlinks (s_page_get_filename(page), NULL);
 
   if (real_filename == NULL) {
-    s_log_message (_("s_page_delete: Can't get the real filename of %s."),
+    s_log_message (_("s_page_delete: Can't get the real filename of %1$s."),
                    s_page_get_filename (page));
   }
   else {
@@ -205,7 +205,7 @@ void s_page_delete (TOPLEVEL *toplevel, PAGE *page)
 	 (!g_file_test(backup_filename, G_FILE_TEST_IS_DIR)) )
     {
       if (unlink(backup_filename) != 0) {
-	s_log_message(_("s_page_delete: Unable to delete backup file %s."),
+	s_log_message(_("s_page_delete: Unable to delete backup file %1$s."),
                       backup_filename);
       }
     }
@@ -228,7 +228,7 @@ void s_page_delete (TOPLEVEL *toplevel, PAGE *page)
   if (g_list_length (page->connectible_list) != 0) {
     fprintf (stderr,
             "OOPS! page->connectible_list had something in it when it was freed!\n");
-    fprintf (stderr, "Length: %d\n", g_list_length (page->connectible_list));
+    fprintf (stderr, "Length: %1$d\n", g_list_length (page->connectible_list));
   }
 
   g_list_free (page->connectible_list);
@@ -457,7 +457,7 @@ void s_page_print_all (TOPLEVEL *toplevel)
         iter = g_list_next( iter ) ) {
 
     page = (PAGE *)iter->data;
-    printf ("FILENAME: %s\n", s_page_get_filename (page));
+    printf ("FILENAME: %1$s\n", s_page_get_filename (page));
     geda_object_list_print (page->_object_list);
   }
 }
@@ -483,13 +483,13 @@ gint s_page_save_all (TOPLEVEL *toplevel)
 
     if (f_save (toplevel, p_current,
                 s_page_get_filename (p_current), NULL)) {
-      s_log_message (_("Saved [%s]\n"),
+      s_log_message (_("Saved [%1$s]\n"),
                      s_page_get_filename (p_current));
       /* reset the CHANGED flag of p_current */
       p_current->CHANGED = 0;
 
     } else {
-      s_log_message (_("Could NOT save [%s]\n"),
+      s_log_message (_("Could NOT save [%1$s]\n"),
                      s_page_get_filename (p_current));
       /* increase the error counter */
       status++;

--- a/liblepton/src/geda_path_object.c
+++ b/liblepton/src/geda_path_object.c
@@ -211,7 +211,7 @@ OBJECT *o_path_read (TOPLEVEL *toplevel,
    * Checks if the required color is valid.
    */
   if (color < 0 || color > MAX_COLORS) {
-    s_log_message (_("Found an invalid color [ %s ]\n"), first_line);
+    s_log_message (_("Found an invalid color [ %1$s ]\n"), first_line);
     s_log_message (_("Setting color to default color\n"));
     color = DEFAULT_COLOR;
   }

--- a/liblepton/src/geda_picture_object.c
+++ b/liblepton/src/geda_picture_object.c
@@ -73,19 +73,20 @@ OBJECT *o_picture_read (TOPLEVEL *toplevel,
   }
 
   if (width == 0 || height == 0) {
-    s_log_message(_("Found a zero width/height picture [ %c %d %d %d %d ]\n"),
+    s_log_message(_("Found a zero width/height picture "
+                    "[ %1$c %2$d %3$d %4$d %5$d ]\n"),
                   type, x1, y1, width, height);
   }
 
   if ( (mirrored > 1) || (mirrored < 0)) {
-    s_log_message(_("Found a picture with a wrong 'mirrored' parameter: %d.\n"),
+    s_log_message(_("Found a picture with a wrong 'mirrored' parameter: %1$d.\n"),
                   mirrored);
     s_log_message(_("Setting mirrored to 0\n"));
     mirrored = 0;
   }
 
   if ( (embedded > 1) || (embedded < 0)) {
-    s_log_message(_("Found a picture with a wrong 'embedded' parameter: %d.\n"),
+    s_log_message(_("Found a picture with a wrong 'embedded' parameter: %1$d.\n"),
                   embedded);
     s_log_message(_("Setting embedded to 0\n"));
     embedded = 0;
@@ -100,7 +101,7 @@ OBJECT *o_picture_read (TOPLEVEL *toplevel,
     break;
 
     default:
-      s_log_message(_("Found an unsupported picture angle [ %d ]\n"), angle);
+      s_log_message(_("Found an unsupported picture angle [ %1$d ]\n"), angle);
       s_log_message(_("Setting angle to 0\n"));
       angle=0;
       break;
@@ -143,7 +144,7 @@ OBJECT *o_picture_read (TOPLEVEL *toplevel,
     }
 
     if (file_content == NULL) {
-      s_log_message (_("Failed to load image from embedded data [%s]: %s\n"),
+      s_log_message (_("Failed to load image from embedded data [%1$s]: %2$s\n"),
                      filename, _("Base64 decoding failed."));
       s_log_message (_("Falling back to file loading. Picture unembedded.\n"));
       embedded = 0;
@@ -304,7 +305,7 @@ OBJECT *o_picture_new (TOPLEVEL *toplevel,
     GError *error = NULL;
     if (!o_picture_set_from_buffer (toplevel, new_node, filename,
                                     file_content, file_length, &error)) {
-      s_log_message (_("Failed to load buffer image [%s]: %s\n"),
+      s_log_message (_("Failed to load buffer image [%1$s]: %2$s\n"),
                      filename, error->message);
       g_error_free (error);
 
@@ -317,7 +318,7 @@ OBJECT *o_picture_new (TOPLEVEL *toplevel,
   if (picture->pixbuf == NULL && filename != NULL) {
     GError *error = NULL;
     if (!o_picture_set_from_file (toplevel, new_node, filename, &error)) {
-      s_log_message (_("Failed to load image from [%s]: %s\n"),
+      s_log_message (_("Failed to load image from [%1$s]: %2$s\n"),
                      filename, error->message);
       g_error_free (error);
       /* picture not found; try to open a fall back pixbuf */
@@ -411,7 +412,7 @@ o_picture_get_ratio (TOPLEVEL *toplevel, OBJECT *object)
   case 270:
     return 1.0 / object->picture->ratio;
   default:
-    g_critical (_("Picture %p has invalid angle %i\n"), object,
+    g_critical (_("Picture %1$p has invalid angle %2$i\n"), object,
                 object->picture->angle);
   }
   return 0;
@@ -768,7 +769,7 @@ void o_picture_embed (TOPLEVEL *toplevel, OBJECT *object)
   if (o_picture_is_embedded (object)) return;
 
   if (object->picture->file_content == NULL) {
-    s_log_message (_("Picture [%s] has no image data.\n"), filename);
+    s_log_message (_("Picture [%1$s] has no image data.\n"), filename);
     s_log_message (_("Falling back to file loading. Picture is still unembedded.\n"));
     object->picture->embedded = 0;
     return;
@@ -777,7 +778,7 @@ void o_picture_embed (TOPLEVEL *toplevel, OBJECT *object)
   object->picture->embedded = 1;
 
   basename = g_path_get_basename (filename);
-  s_log_message (_("Picture [%s] has been embedded\n"), basename);
+  s_log_message (_("Picture [%1$s] has been embedded\n"), basename);
   g_free (basename);
 }
 
@@ -801,7 +802,7 @@ void o_picture_unembed (TOPLEVEL *toplevel, OBJECT *object)
   o_picture_set_from_file (toplevel, object, filename, &err);
 
   if (err != NULL) {
-    s_log_message (_("Failed to load image from file [%s]: %s\n"),
+    s_log_message (_("Failed to load image from file [%1$s]: %2$s\n"),
                    filename, err->message);
     s_log_message (_("Picture is still embedded.\n"));
     g_error_free (err);
@@ -811,7 +812,7 @@ void o_picture_unembed (TOPLEVEL *toplevel, OBJECT *object)
   object->picture->embedded = 0;
 
   basename = g_path_get_basename(filename);
-  s_log_message (_("Picture [%s] has been unembedded\n"), basename);
+  s_log_message (_("Picture [%1$s] has been unembedded\n"), basename);
   g_free(basename);
 }
 
@@ -1048,7 +1049,7 @@ o_picture_get_fallback_pixbuf (TOPLEVEL *toplevel)
     pixbuf = gdk_pixbuf_new_from_file (filename, &error);
 
     if (pixbuf == NULL) {
-      g_warning ( _("Failed to load fallback image %s: %s.\n"),
+      g_warning ( _("Failed to load fallback image %1$s: %2$s.\n"),
                   filename, error->message);
       g_error_free (error);
       failed = TRUE;

--- a/liblepton/src/geda_pin_object.c
+++ b/liblepton/src/geda_pin_object.c
@@ -366,7 +366,7 @@ OBJECT *o_pin_read (TOPLEVEL *toplevel, const char buf[],
   }
 
   if (color < 0 || color > MAX_COLORS) {
-    s_log_message (_("Found an invalid color [ %s ]\n"), buf);
+    s_log_message (_("Found an invalid color [ %1$s ]\n"), buf);
     s_log_message (_("Setting color to default color\n"));
     color = DEFAULT_COLOR;
   }
@@ -719,7 +719,7 @@ geda_pin_object_set_type (TOPLEVEL *toplevel, OBJECT *o_current, int pin_type)
   o_emit_pre_change_notify (toplevel, o_current);
   switch (pin_type) {
     default:
-      g_critical ("geda_pin_object_set_type: Got invalid pin type %i\n", pin_type);
+      g_critical ("geda_pin_object_set_type: Got invalid pin type %1$i\n", pin_type);
       /* Fall through */
     case PIN_TYPE_NET:
       o_current->line_width = PIN_WIDTH_NET;

--- a/liblepton/src/geda_text_object.c
+++ b/liblepton/src/geda_text_object.c
@@ -356,7 +356,7 @@ update_disp_string (OBJECT *object)
         if (name[0] != '\0') {
           text->disp_string = g_strdup (name);
         } else {
-          g_critical ("Got an improper attribute: %s\n",
+          g_critical ("Got an improper attribute: %1$s\n",
                       text->string);
           text->disp_string = g_strdup ("invalid");
         }
@@ -366,7 +366,7 @@ update_disp_string (OBJECT *object)
         if (value[0] != '\0') {
           text->disp_string = g_strdup(value);
         } else {
-          g_critical ("Got an improper attribute: %s\n",
+          g_critical ("Got an improper attribute: %1$s\n",
                       text->string);
           text->disp_string = g_strdup ("invalid");
         }
@@ -517,15 +517,15 @@ o_text_read (TOPLEVEL *toplevel,
   }
 
   if (size < MINIMUM_TEXT_SIZE) {
-    s_log_message (_("Found an invalid text size [ %s ]\n"), first_line);
+    s_log_message (_("Found an invalid text size [ %1$s ]\n"), first_line);
     size = DEFAULT_TEXT_SIZE;
-    s_log_message (_("Setting text size to %d\n"), size);
+    s_log_message (_("Setting text size to %1$d\n"), size);
   }
 
   if (!geda_angle_is_ortho (angle)) {
-    s_log_message (_("Found an unsupported text angle [ %s ]\n"), first_line);
+    s_log_message (_("Found an unsupported text angle [ %1$s ]\n"), first_line);
     angle = geda_angle_make_ortho (angle);
-    s_log_message (_("Setting angle to %d\n"), angle);
+    s_log_message (_("Setting angle to %1$d\n"), angle);
   }
 
   switch(alignment) {
@@ -542,7 +542,7 @@ o_text_read (TOPLEVEL *toplevel,
     break;
 
     default:
-      s_log_message (_("Found an unsupported text alignment [ %s ]\n"),
+      s_log_message (_("Found an unsupported text alignment [ %1$s ]\n"),
                      first_line);
       alignment = LOWER_LEFT;
       s_log_message(_("Setting alignment to LOWER_LEFT\n"));
@@ -550,7 +550,7 @@ o_text_read (TOPLEVEL *toplevel,
   }
 
   if (color < 0 || color > MAX_COLORS) {
-    s_log_message(_("Found an invalid color [ %s ]\n"), first_line);
+    s_log_message(_("Found an invalid color [ %1$s ]\n"), first_line);
     color = DEFAULT_COLOR;
     s_log_message(_("Setting color to default color\n"));
   }
@@ -565,7 +565,7 @@ o_text_read (TOPLEVEL *toplevel,
 
     if (line == NULL) {
       g_string_free (textstr, TRUE);
-      g_set_error(err, EDA_ERROR, EDA_ERROR_PARSE, _("Unexpected end-of-file after %d lines"), i);
+      g_set_error(err, EDA_ERROR, EDA_ERROR_PARSE, _("Unexpected end-of-file after %1$d lines"), i);
       return NULL;
     }
 
@@ -583,7 +583,7 @@ o_text_read (TOPLEVEL *toplevel,
                             "UTF-8", "ISO_8859-15",
                             NULL, NULL, NULL);
     if (tmp == NULL) {
-      fprintf (stderr, "Failed to convert text string to UTF-8: %s.\n",
+      fprintf (stderr, "Failed to convert text string to UTF-8: %1$s.\n",
                string);
     } else {
       /* successfully converted string, now use tmp as string */

--- a/liblepton/src/o_attrib.c
+++ b/liblepton/src/o_attrib.c
@@ -108,7 +108,7 @@ void o_attrib_attach (TOPLEVEL *toplevel, OBJECT *attrib, OBJECT *object,
 
   /* is the object already part of the list ? */
   if (g_list_find (object->attribs, attrib)) {
-    g_warning (_("Attribute [%s] already attached\n"),
+    g_warning (_("Attribute [%1$s] already attached\n"),
                geda_text_object_get_string (attrib));
     return;
   }
@@ -119,7 +119,7 @@ void o_attrib_attach (TOPLEVEL *toplevel, OBJECT *attrib, OBJECT *object,
   }
 
   if (attrib->attached_to != NULL) {
-    g_warning (_("Attempt to attach attribute [%s] to more than one object\n"),
+    g_warning (_("Attempt to attach attribute [%1$s] to more than one object\n"),
                 attrib->text->string);
     return;
   }
@@ -189,9 +189,9 @@ void o_attrib_print(GList *attributes)
 
   while (a_iter != NULL) {
     a_current = a_iter->data;
-    printf("Attribute points to: %s\n", a_current->name);
+    printf("Attribute points to: %1$s\n", a_current->name);
     if (a_current->text) {
-      printf("\tText is: %s\n", geda_text_object_get_string (a_current));
+      printf("\tText is: %1$s\n", geda_text_object_get_string (a_current));
     }
 
     a_iter = g_list_next (a_iter);

--- a/liblepton/src/o_embed.c
+++ b/liblepton/src/o_embed.c
@@ -51,7 +51,7 @@ void o_embed(TOPLEVEL *toplevel, OBJECT *o_current)
     /* set the embedded flag */
     o_current->complex_embedded = TRUE;
 
-    s_log_message (_("Component [%s] has been embedded\n"),
+    s_log_message (_("Component [%1$s] has been embedded\n"),
                    o_current->complex_basename);
     page_modified = 1;
   }
@@ -95,7 +95,7 @@ void o_unembed(TOPLEVEL *toplevel, OBJECT *o_current)
 
     if (sym == NULL) {
       /* symbol not found in the symbol library: signal an error */
-      s_log_message (_("Could not find component [%s], while trying to "
+      s_log_message (_("Could not find component [%1$s], while trying to "
                        "unembed. Component is still embedded\n"),
                      o_current->complex_basename);
 
@@ -103,7 +103,7 @@ void o_unembed(TOPLEVEL *toplevel, OBJECT *o_current)
       /* clear the embedded flag */
       o_current->complex_embedded = FALSE;
 
-      s_log_message (_("Component [%s] has been successfully unembedded\n"),
+      s_log_message (_("Component [%1$s] has been successfully unembedded\n"),
                      o_current->complex_basename);
 
       page_modified = 1;

--- a/liblepton/src/o_selection.c
+++ b/liblepton/src/o_selection.c
@@ -92,7 +92,7 @@ void o_selection_print_all(const SELECTION *selection)
   printf("START printing selection ********************\n");
   while(s_current != NULL) {
     if (s_current->data) {
-      printf("Selected object: %d\n", ((OBJECT *)s_current->data)->sid );
+      printf("Selected object: %1$d\n", ((OBJECT *)s_current->data)->sid );
     }
     s_current = g_list_next( s_current );
   }

--- a/liblepton/src/s_basic.c
+++ b/liblepton/src/s_basic.c
@@ -81,7 +81,7 @@ s_expand_env_variables (const gchar *string)
           if (string[i] == '\0') {
             /* problem: no closing '}' to variable */
             fprintf (stderr,
-                     "Found malformed environment variable in '%s'\n",
+                     "Found malformed environment variable in '%1$s'\n",
                      string);
             g_string_append (gstring, "$");
             g_string_append_len (gstring, string + start, i - start + 1);
@@ -97,7 +97,7 @@ s_expand_env_variables (const gchar *string)
             if (i != j) {
               /* illegal character detected in variable name */
               fprintf (stderr,
-                       "Found bad character [%c] in variable name.\n",
+                       "Found bad character [%1$c] in variable name.\n",
                        string[j]);
               g_string_append (gstring, "${");
               g_string_append_len (gstring, string + start, i - start + 1);

--- a/liblepton/src/s_clib.c
+++ b/liblepton/src/s_clib.c
@@ -457,17 +457,17 @@ static gchar *run_source_command (const gchar *command)
                              &e);
 
   if (e != NULL) {
-    s_log_message (_("Library command failed [%s]: %s\n"), command,
+    s_log_message (_("Library command failed [%1$s]: %2$s\n"), command,
 		   e->message);
     g_error_free (e);
 
   } else if (WIFSIGNALED(exit_status)) {
-    s_log_message (_("Library command failed [%s]: Uncaught signal %i.\n"),
+    s_log_message (_("Library command failed [%1$s]: Uncaught signal %2$i.\n"),
                    command, WTERMSIG(exit_status));
 
   } else if (WIFEXITED(exit_status) && WEXITSTATUS(exit_status)) {
-    s_log_message (_("Library command failed [%s]\n"), command);
-    s_log_message(_("Error output was:\n%s\n"), standard_error);
+    s_log_message (_("Library command failed [%1$s]\n"), command);
+    s_log_message(_("Error output was:\n%1$s\n"), standard_error);
 
   } else {
     success = TRUE;
@@ -553,7 +553,7 @@ static gchar *uniquify_source_name (const gchar *name)
     newname = g_strdup_printf ("%s<%i>", name, i);
   } while (s_clib_get_source_by_name (newname) != NULL);
 
-  s_log_message (_("Library name [%s] already in use.  Using [%s].\n"),
+  s_log_message (_("Library name [%1$s] already in use.  Using [%2$s].\n"),
                  name, newname);
 
   return newname;
@@ -590,7 +590,7 @@ static void refresh_directory (CLibSource *source)
   dir = g_dir_open (source->directory, 0, &e);
 
   if (e != NULL) {
-    s_log_message (_("Failed to open directory [%s]: %s\n"),
+    s_log_message (_("Failed to open directory [%1$s]: %2$s\n"),
 		   source->directory, e->message);
     g_error_free (e);
     return;
@@ -726,7 +726,7 @@ static void refresh_scm (CLibSource *source)
   symlist = scm_call_0 (source->list_fn);
 
   if (scm_is_false (scm_list_p (symlist))) {
-    s_log_message (_("Failed to scan library [%s]: Scheme function returned non-list\n"),
+    s_log_message (_("Failed to scan library [%1$s]: Scheme function returned non-list\n"),
 		   source->name);
     return;
   }
@@ -734,7 +734,7 @@ static void refresh_scm (CLibSource *source)
   while (!scm_is_null (symlist)) {
     symname = SCM_CAR (symlist);
     if (!scm_is_string (symname)) {
-      s_log_message (_("Non-string symbol name while scanning library [%s]\n"),
+      s_log_message (_("Non-string symbol name while scanning library [%1$s]\n"),
 		     source->name);
     } else {
       symbol = g_new0 (CLibSymbol, 1);
@@ -790,7 +790,7 @@ void s_clib_refresh ()
 	refresh_scm (source);
 	break;
       default:
-	g_critical("s_clib_refresh: source %p has bad source type %i\n",
+	g_critical("s_clib_refresh: source %1$p has bad source type %2$i\n",
                    source, (gint) source->type);
         break;
       }
@@ -897,7 +897,7 @@ const CLibSource *s_clib_add_command (const gchar *list_cmd,
   realname = uniquify_source_name (name);
 
   if (list_cmd == NULL || get_cmd == NULL) {
-    s_log_message (_("Cannot add library [%s]: both 'list' and "
+    s_log_message (_("Cannot add library [%1$s]: both 'list' and "
                      "'get' commands must be specified.\n"),
 		   realname);
   }
@@ -945,7 +945,7 @@ const CLibSource *s_clib_add_scm (SCM listfunc, SCM getfunc, const gchar *name)
 
   if (scm_is_false (scm_procedure_p (listfunc))
       && scm_is_false (scm_procedure_p (getfunc))) {
-    s_log_message (_("Cannot add Scheme-library [%s]: callbacks must be closures\n"),
+    s_log_message (_("Cannot add Scheme-library [%1$s]: callbacks must be closures\n"),
 		   realname);
     return NULL;
   }
@@ -1072,7 +1072,7 @@ static gchar *get_data_directory (const CLibSymbol *symbol)
   g_file_get_contents (filename, &data, NULL, &e);
 
   if (e != NULL) {
-    s_log_message (_("Failed to load symbol from file [%s]: %s\n"),
+    s_log_message (_("Failed to load symbol from file [%1$s]: %2$s\n"),
 		   filename, e->message);
     g_error_free (e);
   }
@@ -1132,7 +1132,7 @@ static gchar *get_data_scm (const CLibSymbol *symbol)
 			scm_from_utf8_string (symbol->name));
 
   if (!scm_is_string (symdata)) {
-    s_log_message (_("Failed to load symbol data [%s] from source [%s]\n"),
+    s_log_message (_("Failed to load symbol data [%1$s] from source [%2$s]\n"),
 		   symbol->name, symbol->source->name);
     return NULL;
   }
@@ -1190,7 +1190,7 @@ gchar *s_clib_symbol_get_data (const CLibSymbol *symbol)
       data = get_data_scm (symbol);
       break;
     default:
-      g_critical("s_clib_symbol_get_data: source %p has bad source type %i\n",
+      g_critical("s_clib_symbol_get_data: source %1$p has bad source type %2$i\n",
                  symbol->source, (gint) symbol->source->type);
       return NULL;
     }
@@ -1263,7 +1263,7 @@ GList *s_clib_search (const gchar *pattern, const CLibSearchMode mode)
       keytype = 's';
       break;
     default:
-      g_critical ("s_clib_search: Bad search mode %i\n", mode);
+      g_critical ("s_clib_search: Bad search mode %1$i\n", mode);
       return NULL;
     }
   key = g_strdup_printf("%c%s", keytype, pattern);
@@ -1374,13 +1374,13 @@ const CLibSymbol *s_clib_get_symbol_by_name (const gchar *name)
   symlist = s_clib_search (name, CLIB_EXACT);
 
   if (symlist == NULL) {
-    s_log_message (_("Component [%s] was not found in the component library\n"),
+    s_log_message (_("Component [%1$s] was not found in the component library\n"),
                    name);
     return NULL;
   }
 
   if (g_list_next (symlist) != NULL) { /* More than one symbol */
-    s_log_message (_("More than one component found with name [%s]\n"),
+    s_log_message (_("More than one component found with name [%1$s]\n"),
                    name);
   }
 

--- a/liblepton/src/s_hierarchy.c
+++ b/liblepton/src/s_hierarchy.c
@@ -338,7 +338,7 @@ s_hierarchy_traversepages (TOPLEVEL *toplevel, PAGE *p_current, gint flags)
       /* call the recursive function */
       s_hierarchy_traversepages (toplevel, child_page, flags | HIERARCHY_INNERLOOP);
     } else {
-      s_log_message (_("Failed to descend hierarchy into '%s': %s\n"),
+      s_log_message (_("Failed to descend hierarchy into '%1$s': %2$s\n"),
                      filename, err->message);
       g_error_free (err);
     }

--- a/liblepton/src/s_log.c
+++ b/liblepton/src/s_log.c
@@ -112,7 +112,7 @@ void s_log_init (const gchar *prefix)
   if (s != 0) {
     /* It's okay to use the logging functions from here, because
      * there's already a default handler. */
-    g_warning ("Could not create log directory %s: %s\n",
+    g_warning ("Could not create log directory %1$s: %2$s\n",
                dir_path, strerror (errno));
     g_free (dir_path);
     g_free (full_prefix);
@@ -156,10 +156,10 @@ void s_log_init (const gchar *prefix)
     /* It's okay to use the logging functions from here, because
      * there's already a default handler. */
     if (errno == EEXIST) {
-      g_warning ("Could not create unique log filename in %s\n",
+      g_warning ("Could not create unique log filename in %1$s\n",
                  dir_path);
     } else {
-      g_warning ("Could not create log file in %s: %s\n",
+      g_warning ("Could not create log file in %1$s: %2$s\n",
                  dir_path, strerror (errno));
     }
   }


### PR DESCRIPTION
Add positional param-no indices to string substitions in localized
strings, even if there is only one substitution.

Only interesting edit is one to  `gschem/src/x_multiattrib.c` which reorders a call to `ngettext()` to allow a textual substitution for the singular case

Closes #49 
