### PR TITLE
gnetlist: Fix a couple of missing format idx specifiers

### DIFF
--- a/gnetlist/src/s_hierarchy.c
+++ b/gnetlist/src/s_hierarchy.c
@@ -101,9 +101,9 @@ s_hierarchy_traverse(TOPLEVEL * pr_current, OBJECT * o_current,
                                                   &err);
 
 	    if (child_page == NULL) {
-              g_warning (_("Failed to load subcircuit '%1$s': %s\n"),
+              g_warning (_("Failed to load subcircuit '%1$s': %2$s\n"),
                          current_filename, err->message);
-              fprintf(stderr, _("ERROR: Failed to load subcircuit '%1$s': %s\n"),
+              fprintf(stderr, _("ERROR: Failed to load subcircuit '%1$s': %2$s\n"),
                       current_filename, err->message);
               g_error_free (err);
               exit (2);


### PR DESCRIPTION
In commit 8bd7a38f764a, most translatable strings in Lepton were
changed to use explicit parameter indices for their substitutions.
This fixes a couple of places where the strings were left partially
converted, leading to `-Wformat` compile warnings.