### PR TITLE
Remove logging newlines

### DIFF
--- a/gattrib/src/f_export.c
+++ b/gattrib/src/f_export.c
@@ -79,7 +79,7 @@ void f_export_components(gchar *filename)
 #endif
   fp = fopen(filename, "wb");
   if (fp == NULL) {
-    s_log_message(_("o_save: Could not open [%1$s]\n"), filename);
+    s_log_message(_("o_save: Could not open [%1$s]"), filename);
     /* XXXXX Throw up error message  in window */
     return;
   }

--- a/gattrib/src/gattrib.c
+++ b/gattrib/src/gattrib.c
@@ -149,7 +149,7 @@ void gattrib_main(void *closure, int argc, char *argv[])
   s_log_init ("gattrib");
 
   s_log_message
-    (_("gEDA/gattrib version %1$s%2$s.%3$s\ngEDA/gattrib comes with ABSOLUTELY NO WARRANTY; see COPYING for more details.\nThis is free software, and you are welcome to redistribute it under certain\nconditions; please see the COPYING file for more details.\n\n"),
+    (_("gEDA/gattrib version %1$s%2$s.%3$s\ngEDA/gattrib comes with ABSOLUTELY NO WARRANTY; see COPYING for more details.\nThis is free software, and you are welcome to redistribute it under certain\nconditions; please see the COPYING file for more details.\n"),
      PREPEND_VERSION_STRING, PACKAGE_DOTTED_VERSION,
      PACKAGE_DATE_VERSION);
 

--- a/gattrib/src/x_fileselect.c
+++ b/gattrib/src/x_fileselect.c
@@ -131,7 +131,7 @@ x_fileselect_load_files (GSList *filenames)
     gchar *string = (gchar*)filename->data;
     
     if (!quiet_mode) {
-      s_log_message(_("Loading file [%1$s]\n"), string);
+      s_log_message(_("Loading file [%1$s]"), string);
     }
 
     s_page_goto (pr_current, s_page_new (pr_current, string));
@@ -301,7 +301,7 @@ x_fileselect_save (void)
     /* try saving current page of toplevel to file filename */
     if (filename != NULL &&
         f_save (pr_current, pr_current->page_current, filename, NULL)) {
-      s_log_message (_("Saved As [%1$s]\n"), filename);
+      s_log_message (_("Saved As [%1$s]"), filename);
 
       /* replace page filename with new one */
       s_page_set_filename (pr_current->page_current, filename);
@@ -311,7 +311,7 @@ x_fileselect_save (void)
 
     } else {
       /* report error in log and status bar */
-      s_log_message (_("Could NOT save [%1$s]\n"),
+      s_log_message (_("Could NOT save [%1$s]"),
                      s_page_get_filename (pr_current->page_current));
 
     }

--- a/gnetlist/src/gnetlist.c
+++ b/gnetlist/src/gnetlist.c
@@ -187,7 +187,7 @@ void main_prog(void *closure, int argc, char *argv[])
         "gEDA/gnetlist version %s%s.%s\n"
         "gEDA/gnetlist comes with ABSOLUTELY NO WARRANTY; see COPYING for more details.\n"
         "This is free software, and you are welcome to redistribute it under certain\n"
-        "conditions; please see the COPYING file for more details.\n\n"),
+        "conditions; please see the COPYING file for more details.\n"),
         PREPEND_VERSION_STRING, PACKAGE_DOTTED_VERSION, PACKAGE_DATE_VERSION);
 
     /* register guile (scheme) functions */

--- a/gnetlist/src/s_hierarchy.c
+++ b/gnetlist/src/s_hierarchy.c
@@ -82,7 +82,7 @@ s_hierarchy_traverse(TOPLEVEL * pr_current, OBJECT * o_current,
 	/* loop over all filenames */
 	while (current_filename != NULL) {
 
-	    s_log_message(_("Going to traverse source [%1$s]\n"),
+	    s_log_message(_("Going to traverse source [%1$s]"),
 			  current_filename);
 
 	    /* guts here */

--- a/gschem/src/a_zoom.c
+++ b/gschem/src/a_zoom.c
@@ -153,7 +153,7 @@ a_zoom_box(GschemToplevel *w_current)
   /*test if there is really a box*/
   if (w_current->first_wx == w_current->second_wx ||
       w_current->first_wy == w_current->second_wy) {
-    s_log_message(_("Zoom too small!  Cannot zoom further.\n"));
+    s_log_message(_("Zoom too small!  Cannot zoom further."));
     return;
   }
 

--- a/gschem/src/gschem.c
+++ b/gschem/src/gschem.c
@@ -161,7 +161,7 @@ void main_prog(void *closure, int argc, char *argv[])
   s_log_message(
                 _("This is free software, and you are welcome to redistribute it under certain\n"));
   s_log_message(
-                _("conditions; please see the COPYING file for more details.\n\n"));
+                _("conditions; please see the COPYING file for more details.\n"));
 
 #if defined(__MINGW32__) && defined(DEBUG)
   fprintf(stderr, _("This is the MINGW32 port.\n"));
@@ -199,16 +199,16 @@ void main_prog(void *closure, int argc, char *argv[])
    * we can take advantage of that.  */
   scm_tmp = scm_sys_search_load_path (scm_from_utf8_string ("gschem.scm"));
   if (scm_is_false (scm_tmp)) {
-    s_log_message (_("Couldn't find init scm file [%1$s]\n"), "gschem.scm");
+    s_log_message (_("Couldn't find init scm file [%1$s]"), "gschem.scm");
   }
   input_str = scm_to_utf8_string (scm_tmp);
   toplevel = s_toplevel_new ();
   if (g_read_file(toplevel, input_str, NULL)) {
-    s_log_message(_("Read init scm file [%1$s]\n"), input_str);
+    s_log_message(_("Read init scm file [%1$s]"), input_str);
   } else {
     /*! \todo These two messages are the same. Should be
      * integrated. */
-    s_log_message(_("Failed to read init scm file [%1$s]\n"),
+    s_log_message(_("Failed to read init scm file [%1$s]"),
                   input_str);
   }
   free (input_str); /* M'allocated by scm_to_utf8_string() */

--- a/gschem/src/gschem_about_dialog.c
+++ b/gschem/src/gschem_about_dialog.c
@@ -61,7 +61,7 @@ void about_dialog (GschemToplevel *w_current)
 
   if (error != NULL) {
     g_assert (logo == NULL);
-    s_log_message ("Could not load image at file: %1$s\n%2$s\n",
+    s_log_message ("Could not load image at file: %1$s\n%2$s",
                    logo_file, error->message);
     g_error_free (error);
   }

--- a/gschem/src/i_callbacks.c
+++ b/gschem/src/i_callbacks.c
@@ -71,7 +71,7 @@ DEFINE_I_CALLBACK(file_new)
   g_return_if_fail (page != NULL);
 
   x_window_set_current_page (w_current, page);
-  s_log_message (_("New page created [%1$s]\n"), s_page_get_filename (page));
+  s_log_message (_("New page created [%1$s]"), s_page_get_filename (page));
 }
 
 /*! \todo Finish function documentation!!!
@@ -105,7 +105,7 @@ DEFINE_I_CALLBACK(file_new_window)
 
   x_window_set_current_page (w_current, page);
 
-  s_log_message (_("New Window created [%1$s]\n"), s_page_get_filename (page));
+  s_log_message (_("New Window created [%1$s]"), s_page_get_filename (page));
 }
 
 /*! \todo Finish function documentation!!!
@@ -284,7 +284,7 @@ DEFINE_I_CALLBACK(file_close)
 
   g_return_if_fail (w_current != NULL);
 
-  s_log_message(_("Closing Window\n"));
+  s_log_message(_("Closing Window"));
   x_window_close(w_current);
 }
 
@@ -804,19 +804,19 @@ DEFINE_I_CALLBACK(edit_translate)
   snap_mode = gschem_options_get_snap_mode (w_current->options);
 
   if (snap_mode == SNAP_OFF) {
-    s_log_message(_("WARNING: Do not translate with snap off!\n"));
+    s_log_message(_("WARNING: Do not translate with snap off!"));
     s_log_message(_("WARNING: Turning snap on and continuing "
-                  "with translate.\n"));
+                  "with translate."));
     gschem_options_set_snap_mode (w_current->options, SNAP_GRID);
     i_show_state(w_current, NULL); /* update status on screen */
   }
 
   if (gschem_options_get_snap_size (w_current->options) != 100) {
     s_log_message(_("WARNING: Snap grid size is "
-                  "not equal to 100!\n"));
+                  "not equal to 100!"));
     s_log_message(_("WARNING: If you are translating a symbol "
                   "to the origin, the snap grid size should be "
-                  "set to 100\n"));
+                  "set to 100"));
   }
 
   gtk_widget_show (w_current->translate_widget);
@@ -2119,7 +2119,7 @@ DEFINE_I_CALLBACK(hierarchy_down_schematic)
     /* loop over all filenames */
     while(current_filename != NULL) {
       GError *err = NULL;
-      s_log_message(_("Searching for source [%1$s]\n"), current_filename);
+      s_log_message(_("Searching for source [%1$s]"), current_filename);
       child = s_hierarchy_down_schematic_single(gschem_toplevel_get_toplevel (w_current),
                                                 current_filename,
                                                 parent,
@@ -2152,7 +2152,7 @@ DEFINE_I_CALLBACK(hierarchy_down_schematic)
                              "The gschem log may contain more information."),
                            current_filename, msg);
 
-        s_log_message(_("Failed to descend into '%1$s': %2$s\n"),
+        s_log_message(_("Failed to descend into '%1$s': %2$s"),
                       current_filename, msg);
 
         GtkWidget *dialog =
@@ -2228,14 +2228,14 @@ DEFINE_I_CALLBACK(hierarchy_down_symbol)
   if (object != NULL) {
     /* only allow going into symbols */
     if (object->type == OBJ_COMPLEX) {
-      s_log_message(_("Searching for symbol [%1$s]\n"),
+      s_log_message(_("Searching for symbol [%1$s]"),
 		    object->complex_basename);
       sym = s_clib_get_symbol_by_name (object->complex_basename);
       if (sym == NULL)
 	return;
       if (s_clib_symbol_get_filename(sym) == NULL) {
 	s_log_message(_("Symbol is not a real file."
-			" Symbol cannot be loaded.\n"));
+			" Symbol cannot be loaded."));
 	return;
       }
       s_hierarchy_down_symbol(gschem_toplevel_get_toplevel (w_current), sym,
@@ -2272,7 +2272,7 @@ DEFINE_I_CALLBACK(hierarchy_up)
 
   up_page = s_hierarchy_find_up_page (gschem_toplevel_get_toplevel (w_current)->pages, page);
   if (up_page == NULL) {
-    s_log_message(_("Cannot find any schematics above the current one!\n"));
+    s_log_message(_("Cannot find any schematics above the current one!"));
   } else {
     if (page->CHANGED && !x_dialog_close_changed_page (w_current, page))
       return;
@@ -2626,10 +2626,10 @@ DEFINE_I_CALLBACK(options_afeedback)
 
   if (w_current->actionfeedback_mode == BOUNDINGBOX) {
     w_current->actionfeedback_mode = OUTLINE;
-    s_log_message(_("Action feedback mode set to OUTLINE\n"));
+    s_log_message(_("Action feedback mode set to OUTLINE"));
   } else {
     w_current->actionfeedback_mode = BOUNDINGBOX;
-    s_log_message(_("Action feedback mode set to BOUNDINGBOX\n"));
+    s_log_message(_("Action feedback mode set to BOUNDINGBOX"));
   }
   if (w_current->inside_action &&
       gschem_toplevel_get_toplevel (w_current)->page_current->place_list != NULL)
@@ -2653,10 +2653,10 @@ DEFINE_I_CALLBACK(options_grid)
   grid_mode = gschem_options_get_grid_mode (w_current->options);
 
   switch (grid_mode) {
-    case GRID_MODE_NONE: s_log_message (_("Grid OFF\n"));           break;
-    case GRID_MODE_DOTS: s_log_message (_("Dot grid selected\n"));  break;
-    case GRID_MODE_MESH: s_log_message (_("Mesh grid selected\n")); break;
-    default:             s_log_message (_("Invalid grid mode\n"));
+    case GRID_MODE_NONE: s_log_message (_("Grid OFF"));           break;
+    case GRID_MODE_DOTS: s_log_message (_("Dot grid selected"));  break;
+    case GRID_MODE_MESH: s_log_message (_("Mesh grid selected")); break;
+    default:             s_log_message (_("Invalid grid mode"));
   }
 }
 
@@ -2678,13 +2678,13 @@ DEFINE_I_CALLBACK(options_snap)
 
   switch (snap_mode) {
   case SNAP_OFF:
-    s_log_message(_("Snap OFF (CAUTION!)\n"));
+    s_log_message(_("Snap OFF (CAUTION!)"));
     break;
   case SNAP_GRID:
-    s_log_message(_("Snap ON\n"));
+    s_log_message(_("Snap ON"));
     break;
   case SNAP_RESNAP:
-    s_log_message(_("Snap back to the grid (CAUTION!)\n"));
+    s_log_message(_("Snap back to the grid (CAUTION!)"));
     break;
   default:
     g_critical("options_snap: toplevel->snap out of range: %1$d\n",
@@ -2713,9 +2713,9 @@ DEFINE_I_CALLBACK(options_rubberband)
   gschem_options_cycle_net_rubber_band_mode (w_current->options);
 
   if (gschem_options_get_net_rubber_band_mode (w_current->options)) {
-    s_log_message(_("Rubber band ON\n"));
+    s_log_message(_("Rubber band ON"));
   } else {
-    s_log_message(_("Rubber band OFF \n"));
+    s_log_message(_("Rubber band OFF"));
   }
 }
 
@@ -2734,10 +2734,10 @@ DEFINE_I_CALLBACK(options_magneticnet)
   gschem_options_cycle_magnetic_net_mode (w_current->options);
 
   if (gschem_options_get_magnetic_net_mode (w_current->options)) {
-    s_log_message(_("magnetic net mode: ON\n"));
+    s_log_message(_("magnetic net mode: ON"));
   }
   else {
-    s_log_message(_("magnetic net mode: OFF\n"));
+    s_log_message(_("magnetic net mode: OFF"));
   }
 
   i_show_state(w_current, NULL);

--- a/gschem/src/o_complex.c
+++ b/gschem/src/o_complex.c
@@ -190,10 +190,10 @@ void o_complex_translate_all(GschemToplevel *w_current, int offset)
   }
 
   if (offset == 0) {
-    s_log_message(_("Translating schematic [%1$d %2$d]\n"), -x, -y);
+    s_log_message(_("Translating schematic [%1$d %2$d]"), -x, -y);
     geda_object_list_translate (s_page_objects (toplevel->page_current), -x, -y);
   } else {
-    s_log_message(_("Translating schematic [%1$d %2$d]\n"),
+    s_log_message(_("Translating schematic [%1$d %2$d]"),
                   offset, offset);
     geda_object_list_translate (s_page_objects (toplevel->page_current), offset, offset);
   }

--- a/gschem/src/o_misc.c
+++ b/gschem/src/o_misc.c
@@ -312,9 +312,9 @@ void o_edit_show_hidden (GschemToplevel *w_current, const GList *o_list)
   gschem_page_view_invalidate_all (gschem_toplevel_get_current_page_view (w_current));
 
   if (w_current->toplevel->show_hidden_text) {
-    s_log_message(_("Hidden text is now visible\n"));
+    s_log_message(_("Hidden text is now visible"));
   } else {
-    s_log_message(_("Hidden text is now invisible\n"));
+    s_log_message(_("Hidden text is now invisible"));
   }
 }
 
@@ -422,7 +422,7 @@ o_update_component (GschemToplevel *w_current, OBJECT *o_current)
   s_clib_symbol_invalidate_data (clib);
 
   if (clib == NULL) {
-    s_log_message (_("Could not find symbol [%1$s] in library. Update failed.\n"),
+    s_log_message (_("Could not find symbol [%1$s] in library. Update failed."),
                    o_current->complex_basename);
     return NULL;
   }
@@ -582,7 +582,7 @@ void o_autosave_backups(GschemToplevel *w_current)
           saved_umask = umask(0);
           if (chmod(backup_filename, (S_IWRITE|S_IWGRP|S_IWOTH) &
                     ((~saved_umask) & 0777)) != 0) {
-            s_log_message (_("Could NOT set previous backup file [%1$s] read-write\n"),
+            s_log_message (_("Could NOT set previous backup file [%1$s] read-write"),
                            backup_filename);
           }
           umask(saved_umask);
@@ -602,12 +602,12 @@ void o_autosave_backups(GschemToplevel *w_current)
           mask = (~mask)&0777;
           mask &= ((~saved_umask) & 0777);
           if (chmod(backup_filename,mask) != 0) {
-            s_log_message (_("Could NOT set backup file [%1$s] readonly\n"),
+            s_log_message (_("Could NOT set backup file [%1$s] readonly"),
                            backup_filename);
           }
           umask(saved_umask);
         } else {
-          s_log_message (_("Could NOT save backup file [%1$s]\n"),
+          s_log_message (_("Could NOT save backup file [%1$s]"),
                          backup_filename);
         }
         g_free (backup_filename);

--- a/gschem/src/o_net.c
+++ b/gschem/src/o_net.c
@@ -442,7 +442,7 @@ void o_net_start(GschemToplevel *w_current, int w_x, int w_y)
 
   if (w_current->first_wx != snap_grid (w_current, w_current->first_wx)
       || w_current->first_wy != snap_grid (w_current, w_current->first_wy))
-      s_log_message(_("Warning: Starting net at off grid coordinate\n"));
+      s_log_message(_("Warning: Starting net at off grid coordinate"));
 
   if (w_current->net_direction_mode)
     o_net_guess_direction(w_current, w_current->first_wx, w_current->first_wy);
@@ -506,7 +506,7 @@ void o_net_end(GschemToplevel *w_current, int w_x, int w_y)
 
   if (w_current->third_wx != snap_grid (w_current, w_current->third_wx)
       || w_current->third_wy != snap_grid (w_current, w_current->third_wy))
-      s_log_message(_("Warning: Ending net at off grid coordinate\n"));
+      s_log_message(_("Warning: Ending net at off grid coordinate"));
 
   if (!primary_zero_length ) {
   /* create primary net */
@@ -1066,7 +1066,7 @@ int o_net_add_busrippers(GschemToplevel *w_current, OBJECT *net_obj,
                               o_complex_promote_attribs (page->toplevel, new_obj));
           s_page_append (page->toplevel, page, new_obj);
         } else {
-          s_log_message(_("Bus ripper symbol [%1$s] was not found in any component library\n"),
+          s_log_message(_("Bus ripper symbol [%1$s] was not found in any component library"),
                         page->toplevel->bus_ripper_symname);
         }
       }

--- a/gschem/src/o_slot.c
+++ b/gschem/src/o_slot.c
@@ -78,7 +78,7 @@ void o_slot_end(GschemToplevel *w_current, OBJECT *object, const char *string)
 
   status = o_attrib_string_get_name_value (string, NULL, &value);
   if (!status) {
-    s_log_message (_("Slot attribute malformed\n"));
+    s_log_message (_("Slot attribute malformed"));
     return;
   }
 
@@ -86,8 +86,8 @@ void o_slot_end(GschemToplevel *w_current, OBJECT *object, const char *string)
     o_attrib_search_object_attribs_by_name (object, "numslots", 0);
 
   if (!numslots_value) {
-    s_log_message (_("numslots attribute missing\n"));
-    s_log_message (_("Slotting not allowed for this component\n"));
+    s_log_message (_("numslots attribute missing"));
+    s_log_message (_("Slotting not allowed for this component"));
     g_free (value);
     return;
   }
@@ -102,7 +102,7 @@ void o_slot_end(GschemToplevel *w_current, OBJECT *object, const char *string)
 #endif
 
   if (new_slot_number > numslots || new_slot_number <=0 ) {
-    s_log_message (_("New slot number out of range\n"));
+    s_log_message (_("New slot number out of range"));
     g_free (value);
     return;
   }

--- a/gschem/src/o_undo.c
+++ b/gschem/src/o_undo.c
@@ -342,7 +342,7 @@ o_undo_callback (GschemToplevel *w_current, PAGE *page, int type)
   g_return_if_fail (page != NULL);
 
   if (w_current->undo_control == FALSE) {
-    s_log_message(_("Undo/Redo disabled in rc file\n"));
+    s_log_message(_("Undo/Redo disabled in rc file"));
     return;
   }
 

--- a/gschem/src/x_autonumber.c
+++ b/gschem/src/x_autonumber.c
@@ -409,7 +409,7 @@ void autonumber_get_used(GschemToplevel *w_current, AUTONUMBER_TEXT *autotext)
 	    slot_str = o_attrib_search_object_attribs_by_name (o_parent, "slot", 0);
 	    if (slot_str == NULL) {
 	      s_log_message(_("slotted object without slot attribute may cause "
-			      "problems when autonumbering slots\n"));
+			      "problems when autonumbering slots"));
 	    }
 	    else {
 	      sscanf(slot_str, " %d", &slotnr);
@@ -424,7 +424,7 @@ void autonumber_get_used(GschemToplevel *w_current, AUTONUMBER_TEXT *autotext)
 						 (GCompareFunc) freeslot_compare);
 	      if (slot_item != NULL) { /* duplicate slot in used_slots */
 		s_log_message(_("duplicate slot may cause problems: "
-				"[symbolname=%1$s, number=%2$d, slot=%3$d]\n"),
+				"[symbolname=%1$s, number=%2$d, slot=%3$d]"),
 				slot->symbolname, slot->number, slot->slotnr);
 		g_free(slot);
 	      }
@@ -670,7 +670,7 @@ void autonumber_text_autonumber(AUTONUMBER_TEXT *autotext)
      in the searchtext list */
 
   if (strlen(scope_text) == 0) {
-    s_log_message(_("No searchstring given in autonumber text.\n"));
+    s_log_message(_("No searchstring given in autonumber text."));
     return; /* error */
   }
   else if (g_str_has_suffix(scope_text,"?") == TRUE) {
@@ -723,7 +723,7 @@ void autonumber_text_autonumber(AUTONUMBER_TEXT *autotext)
     g_free(searchtext);
   }
   else {
-    s_log_message(_("No '*' or '?' given at the end of the autonumber text.\n"));
+    s_log_message(_("No '*' or '?' given at the end of the autonumber text."));
     return;
   }
 

--- a/gschem/src/x_fileselect.c
+++ b/gschem/src/x_fileselect.c
@@ -292,7 +292,7 @@ x_fileselect_save (GschemToplevel *w_current)
                                 filename);
       gtk_window_set_title (GTK_WINDOW (checkdialog), _("Overwrite file?"));
       if (gtk_dialog_run (GTK_DIALOG (checkdialog)) != GTK_RESPONSE_YES) {
-        s_log_message (_("Save cancelled on user request\n"));
+        s_log_message (_("Save cancelled on user request"));
         g_free (filename);
         filename = NULL;
       }

--- a/gschem/src/x_image.c
+++ b/gschem/src/x_image.c
@@ -205,7 +205,7 @@ static void x_image_update_dialog_filename(GtkComboBox *combo,
     gtk_file_chooser_set_current_name(GTK_FILE_CHOOSER(file_chooser),
         new_image_filename);
   } else {
-    s_log_message("x_image_update_dialog_filename: No parent file chooser found!.\n");
+    s_log_message("x_image_update_dialog_filename: No parent file chooser found!.");
   }
 
   g_free(file_name);
@@ -273,7 +273,7 @@ void x_image_lowlevel(GschemToplevel *w_current, const char* filename,
     pixbuf = x_image_get_pixbuf(w_current, width, height);
     if (pixbuf != NULL) {
       if (!gdk_pixbuf_save(pixbuf, filename, filetype, &gerror, NULL)) {
-        s_log_message(_("x_image_lowlevel: Unable to write %1$s file %2$s.\n"),
+        s_log_message(_("x_image_lowlevel: Unable to write %1$s file %2$s."),
             filetype, filename);
         s_log_message("%s", gerror->message);
 
@@ -302,9 +302,9 @@ void x_image_lowlevel(GschemToplevel *w_current, const char* filename,
       }
       else {
         if (toplevel->image_color == TRUE) {
-          s_log_message(_("Wrote color image to [%1$s] [%2$d x %3$d]\n"), filename, width, height);
+          s_log_message(_("Wrote color image to [%1$s] [%2$d x %3$d]"), filename, width, height);
         } else {
-          s_log_message(_("Wrote black and white image to [%1$s] [%2$d x %3$d]\n"), filename, width, height);
+          s_log_message(_("Wrote black and white image to [%1$s] [%2$d x %3$d]"), filename, width, height);
         }
       }
       g_free(filetype);
@@ -312,7 +312,7 @@ void x_image_lowlevel(GschemToplevel *w_current, const char* filename,
         g_object_unref(pixbuf);
     }
     else {
-      s_log_message(_("x_image_lowlevel: Unable to get pixbuf from gschem's window.\n"));
+      s_log_message(_("x_image_lowlevel: Unable to get pixbuf from gschem's window."));
     }
   }
 

--- a/gschem/src/x_menus.c
+++ b/gschem/src/x_menus.c
@@ -328,7 +328,7 @@ void x_menus_sensitivity (GschemToplevel *w_current, const char *buf, int flag)
     gtk_widget_set_sensitive(GTK_WIDGET(item), flag);
     /* free(item); */ /* Why doesn't this need to be freed?  */
   } else {
-    s_log_message(_("Tried to set the sensitivity on non-existent menu item '%1$s'\n"), buf);
+    s_log_message(_("Tried to set the sensitivity on non-existent menu item '%1$s'"), buf);
   }
  
 }

--- a/gschem/src/x_rc.c
+++ b/gschem/src/x_rc.c
@@ -37,7 +37,7 @@ x_rc_parse_gschem_error (GError **err)
   if (*err == NULL) {
     /* Log message */
     s_log_message (_("ERROR: An unknown error occurred while parsing "
-                     "configuration files.\n"));
+                     "configuration files."));
 
     /* Dialog message */
     msg2 =
@@ -53,7 +53,7 @@ x_rc_parse_gschem_error (GError **err)
     }
 
     /* Log message */
-    s_log_message (_("ERROR: %1$s\n"), (*err)->message);
+    s_log_message (_("ERROR: %1$s"), (*err)->message);
 
     /* Dialog message */
     msg2 = g_strdup_printf (_("%1$s\n\n"

--- a/gschem/src/x_script.c
+++ b/gschem/src/x_script.c
@@ -59,7 +59,7 @@ void setup_script_selector (GschemToplevel *w_current)
     filename = gtk_file_chooser_get_filename (GTK_FILE_CHOOSER (w_current->sowindow));
 
     if (!(g_file_test(filename, G_FILE_TEST_IS_DIR))) {
-      s_log_message(_("Executing guile script [%1$s]\n"), filename);
+      s_log_message(_("Executing guile script [%1$s]"), filename);
       g_read_file(w_current->toplevel, filename, NULL);
     }
     g_free (filename);

--- a/gschem/src/x_window.c
+++ b/gschem/src/x_window.c
@@ -918,7 +918,7 @@ x_window_open_page (GschemToplevel *w_current, const gchar *filename)
   if (filename != NULL) {
     GError *err = NULL;
     if (!quiet_mode)
-      s_log_message (_("Loading schematic [%1$s]\n"), fn);
+      s_log_message (_("Loading schematic [%1$s]"), fn);
 
     if (!f_open (toplevel, page, (gchar *) fn, &err)) {
       GtkWidget *dialog;
@@ -940,7 +940,7 @@ x_window_open_page (GschemToplevel *w_current, const gchar *filename)
     }
   } else {
     if (!quiet_mode)
-      s_log_message (_("New file [%s]\n"),
+      s_log_message (_("New file [%s]"),
                      s_page_get_filename (toplevel->page_current));
 
     g_run_hook_page (w_current, "%new-page-hook", toplevel->page_current);
@@ -1114,7 +1114,7 @@ x_window_close_page (GschemToplevel *w_current, PAGE *page)
   }
 
   s_log_message (page->CHANGED ?
-                 _("Discarding page [%1$s]\n") : _("Closing [%1$s]\n"),
+                 _("Discarding page [%1$s]") : _("Closing [%1$s]"),
                  s_page_get_filename (page));
   /* remove page from toplevel list of page and free */
   s_page_delete (toplevel, page);

--- a/liblepton/src/a_basic.c
+++ b/liblepton/src/a_basic.c
@@ -327,7 +327,7 @@ GList *o_read_buffer (TOPLEVEL *toplevel, GList *object_list,
 
         if (fileformat_ver == 0) {
           s_log_message(_("Read an old format sym/sch file!\n"
-                          "Please run g[sym|sch]update on:\n[%1$s]\n"), name);
+                          "Please run g[sym|sch]update on:\n[%1$s]"), name);
         }
         break;
 

--- a/liblepton/src/f_basic.c
+++ b/liblepton/src/f_basic.c
@@ -236,7 +236,7 @@ int f_open_flags(TOPLEVEL *toplevel, PAGE *page,
        * this. */
       if (!g_error_matches (tmp_err, G_FILE_ERROR, G_FILE_ERROR_NOENT) &&
           !g_error_matches (tmp_err, EDA_ERROR, EDA_ERROR_RC_TWICE)) {
-        s_log_message ("%s\n", tmp_err->message);
+        s_log_message ("%s", tmp_err->message);
       }
       g_error_free (tmp_err);
       tmp_err = NULL;
@@ -389,7 +389,7 @@ int f_save(TOPLEVEL *toplevel, PAGE *page, const char *filename, GError **err)
       if ( g_file_test (backup_filename, G_FILE_TEST_EXISTS) && 
 	   (! g_file_test (backup_filename, G_FILE_TEST_IS_DIR))) {
 	if (chmod(backup_filename, S_IREAD|S_IWRITE) != 0) {
-	  s_log_message (_("Could NOT set previous backup file [%1$s] read-write\n"),
+	  s_log_message (_("Could NOT set previous backup file [%1$s] read-write."),
 			 backup_filename);
 	}
       }
@@ -405,7 +405,7 @@ int f_save(TOPLEVEL *toplevel, PAGE *page, const char *filename, GError **err)
 	mask = (~mask)&0777;
 	mask &= ((~saved_umask) & 0777);
 	if (chmod(backup_filename, mask) != 0) {
-	  s_log_message (_("Could NOT set backup file [%1$s] readonly\n"),
+	  s_log_message (_("Could NOT set backup file [%1$s] readonly."),
                          backup_filename);
 	}
 	umask(saved_umask);

--- a/liblepton/src/g_rc.c
+++ b/liblepton/src/g_rc.c
@@ -204,7 +204,7 @@ g_rc_parse_file (TOPLEVEL *toplevel, const gchar *rcfile,
   scm_dynwind_end ();
 
   if (status) {
-    s_log_message (_("Loaded RC file [%1$s]\n"), name_norm);
+    s_log_message (_("Loaded RC file [%1$s]"), name_norm);
   } else {
     /* Copy tmp_err into err, with a prefixed message. */
     g_propagate_prefixed_error (err, tmp_err,
@@ -339,7 +339,7 @@ g_rc_parse__process_error (GError **err, const gchar *pname)
   if (*err == NULL) {
     const gchar *msgl =
       _("ERROR: An unknown error occurred while parsing configuration files.");
-    s_log_message ("%1$s\n", msgl);
+    s_log_message ("%1$s", msgl);
     fprintf(stderr, "%1$s\n", msgl);
 
   } else {
@@ -350,7 +350,7 @@ g_rc_parse__process_error (GError **err, const gchar *pname)
       return;
     }
 
-    s_log_message (_("ERROR: %1$s\n"), (*err)->message);
+    s_log_message (_("ERROR: %1$s"), (*err)->message);
     fprintf (stderr, _("ERROR: %1$s\n"), (*err)->message);
   }
 
@@ -824,7 +824,7 @@ SCM g_rc_always_promote_attributes(SCM attrlist)
 
   if (scm_is_string (attrlist)) {
     s_log_message(_("WARNING: using a string for 'always-promote-attributes'"
-        " is deprecated. Use a list of strings instead\n"));
+        " is deprecated. Use a list of strings instead."));
 
     /* convert the space separated strings into a GList */
     char *attr_string = scm_to_utf8_string (attrlist);

--- a/liblepton/src/geda_arc_object.c
+++ b/liblepton/src/geda_arc_object.c
@@ -426,14 +426,14 @@ OBJECT *o_arc_read (TOPLEVEL *toplevel, const char buf[],
   /* Error check */
   if (radius <= 0) {
     s_log_message (_("Found a zero radius arc "
-                     "[ %1$c %2$d, %3$d, %4$d, %5$d, %6$d, %7$d ]\n"),
+                     "[ %1$c %2$d, %3$d, %4$d, %5$d, %6$d, %7$d ]"),
                    type, x1, y1, radius, start_angle, sweep_angle, color);
     radius = 0;
   }
 
   if (color < 0 || color > MAX_COLORS) {
-    s_log_message(_("Found an invalid color [ %1$s ]\n"), buf);
-    s_log_message(_("Setting color to default color\n"));
+    s_log_message(_("Found an invalid color [ %1$s ]"), buf);
+    s_log_message(_("Setting color to default color."));
     color = DEFAULT_COLOR;
   }
 

--- a/liblepton/src/geda_box_object.c
+++ b/liblepton/src/geda_box_object.c
@@ -320,13 +320,13 @@ OBJECT *o_box_read (TOPLEVEL *toplevel, const char buf[],
 
   if (width == 0 || height == 0) {
     s_log_message (_("Found a zero width/height box "
-                     "[ %1$c %2$d %3$d %4$d %5$d %6$d ]\n"),
+                     "[ %1$c %2$d %3$d %4$d %5$d %6$d ]"),
                    type, x1, y1, width, height, color);
   }
 
   if (color < 0 || color > MAX_COLORS) {
-    s_log_message (_("Found an invalid color [ %1$s ]\n"), buf);
-    s_log_message (_("Setting color to default color\n"));
+    s_log_message (_("Found an invalid color [ %1$s ]"), buf);
+    s_log_message (_("Setting color to default color."));
     color = DEFAULT_COLOR;
   }
 

--- a/liblepton/src/geda_bus_object.c
+++ b/liblepton/src/geda_bus_object.c
@@ -356,19 +356,19 @@ o_bus_read (TOPLEVEL *toplevel,
 
   if (x1 == x2 && y1 == y2) {
     s_log_message (_("Found a zero length bus "
-                     "[ %1$c %2$d %3$d %4$d %5$d %6$d ]\n"),
+                     "[ %1$c %2$d %3$d %4$d %5$d %6$d ]"),
                     type, x1, y1, x2, y2, color);
   }
 
   if (color < 0 || color > MAX_COLORS) {
-    s_log_message (_("Found an invalid color [ %1$s ]\n"), buf);
-    s_log_message (_("Setting color to default color\n"));
+    s_log_message (_("Found an invalid color [ %1$s ]"), buf);
+    s_log_message (_("Setting color to default color."));
     color = DEFAULT_COLOR;
   }
 
   if (ripper_dir < -1 || ripper_dir > 1) {
-    s_log_message (_("Found an invalid bus ripper direction [ %1$s ]\n"), buf);
-    s_log_message (_("Resetting direction to neutral (no direction)\n"));
+    s_log_message (_("Found an invalid bus ripper direction [ %1$s ]"), buf);
+    s_log_message (_("Resetting direction to neutral (no direction)."));
     ripper_dir = 0;
   }
 

--- a/liblepton/src/geda_circle_object.c
+++ b/liblepton/src/geda_circle_object.c
@@ -377,15 +377,15 @@ o_circle_read (TOPLEVEL *toplevel,
 
   if (radius <= 0) {
     s_log_message(_("Found a zero or negative radius circle "
-                    "[ %1$c %2$d %3$d %4$d %5$d ]\n"),
+                    "[ %1$c %2$d %3$d %4$d %5$d ]"),
                   type, x1, y1, radius, color);
-    s_log_message (_("Setting radius to 0\n"));
+    s_log_message (_("Setting radius to 0."));
     radius = 0;
   }
 
   if (color < 0 || color > MAX_COLORS) {
-    s_log_message(_("Found an invalid color [ %1$s ]\n"), buf);
-    s_log_message(_("Setting color to default color\n"));
+    s_log_message(_("Found an invalid color [ %1$s ]"), buf);
+    s_log_message(_("Setting color to default color."));
     color = DEFAULT_COLOR;
   }
 

--- a/liblepton/src/geda_complex_object.c
+++ b/liblepton/src/geda_complex_object.c
@@ -590,9 +590,9 @@ OBJECT *o_complex_read (TOPLEVEL *toplevel,
 
     default:
       s_log_message(_("Found a component with an invalid rotation "
-                      "[ %1$c %2$d %3$d %4$d %5$d %6$d %7$s ]\n"),
+                      "[ %1$c %2$d %3$d %4$d %5$d %6$d %7$s ]"),
                     type, x1, y1, selectable, angle, mirror, basename);
-      s_log_message (_("Setting angle to 0\n"));
+      s_log_message (_("Setting angle to 0."));
       angle = 0;
   }
 
@@ -605,9 +605,9 @@ OBJECT *o_complex_read (TOPLEVEL *toplevel,
 
     default:
       s_log_message(_("Found a component with an invalid mirror flag "
-                      "[ %1$c %2$d %3$d %4$d %5$d %6$d %7$s ]\n"),
+                      "[ %1$c %2$d %3$d %4$d %5$d %6$d %7$s ]"),
                     type, x1, y1, selectable, angle, mirror, basename);
-      s_log_message (_("Setting mirror to 0\n"));
+      s_log_message (_("Setting mirror to 0."));
       mirror = 0;
   }
   if (strncmp(basename, "EMBEDDED", 8) == 0) {
@@ -931,11 +931,11 @@ o_complex_check_symversion(TOPLEVEL* toplevel, OBJECT* object)
       if (inside)
       {
         s_log_message(_("WARNING: Symbol version parse error on refdes %1$s:\n"
-                        "\tCould not parse symbol file symversion=%2$s\n"),
+                        "\tCould not parse symbol file symversion=%2$s"),
                       refdes, inside);
       } else {
         s_log_message(_("WARNING: Symbol version parse error on refdes %1$s:\n"
-                        "\tCould not parse symbol file symversion=\n"),
+                        "\tCould not parse symbol file symversion="),
                       refdes);
       }
       goto done;
@@ -951,7 +951,7 @@ o_complex_check_symversion(TOPLEVEL* toplevel, OBJECT* object)
     if (outside_value == 0 && outside == err_check)
     {
       s_log_message(_("WARNING: Symbol version parse error on refdes %1$s:\n"
-                      "\tCould not parse attached symversion=%2$s\n"),
+                      "\tCould not parse attached symversion=%2$s"),
                     refdes, outside);
       goto done;
     }
@@ -977,7 +977,7 @@ o_complex_check_symversion(TOPLEVEL* toplevel, OBJECT* object)
   {
     s_log_message(_("WARNING: Symbol version oddity on refdes %1$s:\n"
                     "\tsymversion=%2$s attached to instantiated symbol, "
-                    "but no symversion= inside symbol file\n"),
+                    "but no symversion= inside symbol file."),
                   refdes, outside);
     goto done;
   }
@@ -991,7 +991,7 @@ o_complex_check_symversion(TOPLEVEL* toplevel, OBJECT* object)
 
     s_log_message(_("WARNING: Symbol version mismatch on refdes %1$s (%2$s):\n"
                     "\tSymbol in library is newer than "
-                    "instantiated symbol\n"),
+                    "instantiated symbol."),
                   refdes, object->complex_basename);
 
     /* break up the version values into major.minor numbers */
@@ -1018,7 +1018,7 @@ o_complex_check_symversion(TOPLEVEL* toplevel, OBJECT* object)
     {
       char* refdes_copy;
       s_log_message(_("\tMAJOR VERSION CHANGE (file %1$.3f, "
-                      "instantiated %2$.3f, %3$s)!\n"),
+                      "instantiated %2$.3f, %3$s)!"),
                     inside_value, outside_value, refdes);
 
       /* add the refdes to the major_changed_refdes GList */
@@ -1036,7 +1036,7 @@ o_complex_check_symversion(TOPLEVEL* toplevel, OBJECT* object)
     if (inside_minor > outside_minor)
     {
       s_log_message(_("\tMinor version change (file %1$.3f, "
-                      "instantiated %2$.3f)\n"),
+                      "instantiated %2$.3f)"),
                     inside_value, outside_value);
     }
 
@@ -1048,7 +1048,7 @@ o_complex_check_symversion(TOPLEVEL* toplevel, OBJECT* object)
   {
     s_log_message(_("WARNING: Symbol version oddity on refdes %1$s:\n"
                     "\tInstantiated symbol is newer than "
-                    "symbol in library\n"),
+                    "symbol in library."),
                   refdes);
     goto done;
   }

--- a/liblepton/src/geda_line_object.c
+++ b/liblepton/src/geda_line_object.c
@@ -419,13 +419,13 @@ OBJECT *o_line_read (TOPLEVEL *toplevel, const char buf[],
    */
   if (x1 == x2 && y1 == y2) {
     s_log_message (_("Found a zero length line "
-                     "[ %1$c %2$d %3$d %4$d %5$d %6$d ]\n"),
+                     "[ %1$c %2$d %3$d %4$d %5$d %6$d ]"),
                    type, x1, y1, x2, y2, color);
   }
 
   if (color < 0 || color > MAX_COLORS) {
-    s_log_message (_("Found an invalid color [ %1$s ]\n"), buf);
-    s_log_message (_("Setting color to default color\n"));
+    s_log_message (_("Found an invalid color [ %1$s ]"), buf);
+    s_log_message (_("Setting color to default color."));
     color = DEFAULT_COLOR;
   }
 

--- a/liblepton/src/geda_net_object.c
+++ b/liblepton/src/geda_net_object.c
@@ -300,13 +300,13 @@ OBJECT *o_net_read (TOPLEVEL *toplevel, const char buf[],
 
   if (x1 == x2 && y1 == y2) {
     s_log_message (_("Found a zero length net "
-                     "[ %1$c %2$d %3$d %4$d %5$d %6$d ]\n"),
+                     "[ %1$c %2$d %3$d %4$d %5$d %6$d ]"),
                    type, x1, y1, x2, y2, color);
   }
 
   if (color < 0 || color > MAX_COLORS) {
-    s_log_message (_("Found an invalid color [ %1$s ]\n"), buf);
-    s_log_message (_("Setting color to default color\n"));
+    s_log_message (_("Found an invalid color [ %1$s ]"), buf);
+    s_log_message (_("Setting color to default color."));
     color = DEFAULT_COLOR;
   }
 

--- a/liblepton/src/geda_page.c
+++ b/liblepton/src/geda_page.c
@@ -483,13 +483,13 @@ gint s_page_save_all (TOPLEVEL *toplevel)
 
     if (f_save (toplevel, p_current,
                 s_page_get_filename (p_current), NULL)) {
-      s_log_message (_("Saved [%1$s]\n"),
+      s_log_message (_("Saved [%1$s]"),
                      s_page_get_filename (p_current));
       /* reset the CHANGED flag of p_current */
       p_current->CHANGED = 0;
 
     } else {
-      s_log_message (_("Could NOT save [%1$s]\n"),
+      s_log_message (_("Could NOT save [%1$s]"),
                      s_page_get_filename (p_current));
       /* increase the error counter */
       status++;

--- a/liblepton/src/geda_path_object.c
+++ b/liblepton/src/geda_path_object.c
@@ -211,8 +211,8 @@ OBJECT *o_path_read (TOPLEVEL *toplevel,
    * Checks if the required color is valid.
    */
   if (color < 0 || color > MAX_COLORS) {
-    s_log_message (_("Found an invalid color [ %1$s ]\n"), first_line);
-    s_log_message (_("Setting color to default color\n"));
+    s_log_message (_("Found an invalid color [ %1$s ]"), first_line);
+    s_log_message (_("Setting color to default color."));
     color = DEFAULT_COLOR;
   }
 

--- a/liblepton/src/geda_picture_object.c
+++ b/liblepton/src/geda_picture_object.c
@@ -74,21 +74,21 @@ OBJECT *o_picture_read (TOPLEVEL *toplevel,
 
   if (width == 0 || height == 0) {
     s_log_message(_("Found a zero width/height picture "
-                    "[ %1$c %2$d %3$d %4$d %5$d ]\n"),
+                    "[ %1$c %2$d %3$d %4$d %5$d ]"),
                   type, x1, y1, width, height);
   }
 
   if ( (mirrored > 1) || (mirrored < 0)) {
-    s_log_message(_("Found a picture with a wrong 'mirrored' parameter: %1$d.\n"),
+    s_log_message(_("Found a picture with a wrong 'mirrored' parameter: %1$d."),
                   mirrored);
-    s_log_message(_("Setting mirrored to 0\n"));
+    s_log_message(_("Setting mirrored to 0."));
     mirrored = 0;
   }
 
   if ( (embedded > 1) || (embedded < 0)) {
-    s_log_message(_("Found a picture with a wrong 'embedded' parameter: %1$d.\n"),
+    s_log_message(_("Found a picture with a wrong 'embedded' parameter: %1$d."),
                   embedded);
-    s_log_message(_("Setting embedded to 0\n"));
+    s_log_message(_("Setting embedded to 0."));
     embedded = 0;
   }
 
@@ -101,8 +101,8 @@ OBJECT *o_picture_read (TOPLEVEL *toplevel,
     break;
 
     default:
-      s_log_message(_("Found an unsupported picture angle [ %1$d ]\n"), angle);
-      s_log_message(_("Setting angle to 0\n"));
+      s_log_message(_("Found an unsupported picture angle [ %1$d ]"), angle);
+      s_log_message(_("Setting angle to 0."));
       angle=0;
       break;
 
@@ -144,9 +144,9 @@ OBJECT *o_picture_read (TOPLEVEL *toplevel,
     }
 
     if (file_content == NULL) {
-      s_log_message (_("Failed to load image from embedded data [%1$s]: %2$s\n"),
+      s_log_message (_("Failed to load image from embedded data [%1$s]: %2$s"),
                      filename, _("Base64 decoding failed."));
-      s_log_message (_("Falling back to file loading. Picture unembedded.\n"));
+      s_log_message (_("Falling back to file loading. Picture unembedded."));
       embedded = 0;
     }
   }
@@ -205,7 +205,7 @@ geda_picture_object_to_buffer (const GedaObject *object)
                                 &encoded_picture_length,
                                 TRUE);
     if (encoded_picture == NULL) {
-      s_log_message(_("ERROR: o_picture_save: unable to encode the picture.\n"));
+      s_log_message(_("ERROR: o_picture_save: unable to encode the picture."));
     }
   }
 
@@ -305,7 +305,7 @@ OBJECT *o_picture_new (TOPLEVEL *toplevel,
     GError *error = NULL;
     if (!o_picture_set_from_buffer (toplevel, new_node, filename,
                                     file_content, file_length, &error)) {
-      s_log_message (_("Failed to load buffer image [%1$s]: %2$s\n"),
+      s_log_message (_("Failed to load buffer image [%1$s]: %2$s"),
                      filename, error->message);
       g_error_free (error);
 
@@ -318,7 +318,7 @@ OBJECT *o_picture_new (TOPLEVEL *toplevel,
   if (picture->pixbuf == NULL && filename != NULL) {
     GError *error = NULL;
     if (!o_picture_set_from_file (toplevel, new_node, filename, &error)) {
-      s_log_message (_("Failed to load image from [%1$s]: %2$s\n"),
+      s_log_message (_("Failed to load image from [%1$s]: %2$s"),
                      filename, error->message);
       g_error_free (error);
       /* picture not found; try to open a fall back pixbuf */
@@ -769,8 +769,8 @@ void o_picture_embed (TOPLEVEL *toplevel, OBJECT *object)
   if (o_picture_is_embedded (object)) return;
 
   if (object->picture->file_content == NULL) {
-    s_log_message (_("Picture [%1$s] has no image data.\n"), filename);
-    s_log_message (_("Falling back to file loading. Picture is still unembedded.\n"));
+    s_log_message (_("Picture [%1$s] has no image data."), filename);
+    s_log_message (_("Falling back to file loading. Picture is still unembedded."));
     object->picture->embedded = 0;
     return;
   }
@@ -778,7 +778,7 @@ void o_picture_embed (TOPLEVEL *toplevel, OBJECT *object)
   object->picture->embedded = 1;
 
   basename = g_path_get_basename (filename);
-  s_log_message (_("Picture [%1$s] has been embedded\n"), basename);
+  s_log_message (_("Picture [%1$s] has been embedded."), basename);
   g_free (basename);
 }
 
@@ -802,9 +802,9 @@ void o_picture_unembed (TOPLEVEL *toplevel, OBJECT *object)
   o_picture_set_from_file (toplevel, object, filename, &err);
 
   if (err != NULL) {
-    s_log_message (_("Failed to load image from file [%1$s]: %2$s\n"),
+    s_log_message (_("Failed to load image from file [%1$s]: %2$s"),
                    filename, err->message);
-    s_log_message (_("Picture is still embedded.\n"));
+    s_log_message (_("Picture is still embedded."));
     g_error_free (err);
     return;
   }
@@ -812,7 +812,7 @@ void o_picture_unembed (TOPLEVEL *toplevel, OBJECT *object)
   object->picture->embedded = 0;
 
   basename = g_path_get_basename(filename);
-  s_log_message (_("Picture [%1$s] has been unembedded\n"), basename);
+  s_log_message (_("Picture [%1$s] has been unembedded."), basename);
   g_free(basename);
 }
 

--- a/liblepton/src/geda_pin_object.c
+++ b/liblepton/src/geda_pin_object.c
@@ -358,16 +358,16 @@ OBJECT *o_pin_read (TOPLEVEL *toplevel, const char buf[],
 
   if (whichend == -1) {
     s_log_message (_("Found a pin which did not have the whichend field set.\n"
-                     "Verify and correct manually.\n"));
+                     "Verify and correct manually."));
   } else if (whichend < -1 || whichend > 1) {
-    s_log_message (_("Found an invalid whichend on a pin (reseting to zero): %d\n"),
+    s_log_message (_("Found an invalid whichend on a pin (reseting to zero): %d"),
                    whichend);
     whichend = 0;
   }
 
   if (color < 0 || color > MAX_COLORS) {
-    s_log_message (_("Found an invalid color [ %1$s ]\n"), buf);
-    s_log_message (_("Setting color to default color\n"));
+    s_log_message (_("Found an invalid color [ %1$s ]"), buf);
+    s_log_message (_("Setting color to default color."));
     color = DEFAULT_COLOR;
   }
 

--- a/liblepton/src/geda_text_object.c
+++ b/liblepton/src/geda_text_object.c
@@ -517,15 +517,15 @@ o_text_read (TOPLEVEL *toplevel,
   }
 
   if (size < MINIMUM_TEXT_SIZE) {
-    s_log_message (_("Found an invalid text size [ %1$s ]\n"), first_line);
+    s_log_message (_("Found an invalid text size [ %1$s ]"), first_line);
     size = DEFAULT_TEXT_SIZE;
-    s_log_message (_("Setting text size to %1$d\n"), size);
+    s_log_message (_("Setting text size to %1$d."), size);
   }
 
   if (!geda_angle_is_ortho (angle)) {
-    s_log_message (_("Found an unsupported text angle [ %1$s ]\n"), first_line);
+    s_log_message (_("Found an unsupported text angle [ %1$s ]"), first_line);
     angle = geda_angle_make_ortho (angle);
-    s_log_message (_("Setting angle to %1$d\n"), angle);
+    s_log_message (_("Setting angle to %1$d."), angle);
   }
 
   switch(alignment) {
@@ -542,17 +542,17 @@ o_text_read (TOPLEVEL *toplevel,
     break;
 
     default:
-      s_log_message (_("Found an unsupported text alignment [ %1$s ]\n"),
+      s_log_message (_("Found an unsupported text alignment [ %1$s ]"),
                      first_line);
       alignment = LOWER_LEFT;
-      s_log_message(_("Setting alignment to LOWER_LEFT\n"));
+      s_log_message(_("Setting alignment to LOWER_LEFT."));
       break;
   }
 
   if (color < 0 || color > MAX_COLORS) {
-    s_log_message(_("Found an invalid color [ %1$s ]\n"), first_line);
+    s_log_message(_("Found an invalid color [ %1$s ]"), first_line);
     color = DEFAULT_COLOR;
-    s_log_message(_("Setting color to default color\n"));
+    s_log_message(_("Setting color to default color."));
   }
 
   g_assert(num_lines && num_lines > 0);

--- a/liblepton/src/o_embed.c
+++ b/liblepton/src/o_embed.c
@@ -51,7 +51,7 @@ void o_embed(TOPLEVEL *toplevel, OBJECT *o_current)
     /* set the embedded flag */
     o_current->complex_embedded = TRUE;
 
-    s_log_message (_("Component [%1$s] has been embedded\n"),
+    s_log_message (_("Component [%1$s] has been embedded."),
                    o_current->complex_basename);
     page_modified = 1;
   }
@@ -96,14 +96,14 @@ void o_unembed(TOPLEVEL *toplevel, OBJECT *o_current)
     if (sym == NULL) {
       /* symbol not found in the symbol library: signal an error */
       s_log_message (_("Could not find component [%1$s], while trying to "
-                       "unembed. Component is still embedded\n"),
+                       "unembed. Component is still embedded."),
                      o_current->complex_basename);
 
     } else {
       /* clear the embedded flag */
       o_current->complex_embedded = FALSE;
 
-      s_log_message (_("Component [%1$s] has been successfully unembedded\n"),
+      s_log_message (_("Component [%1$s] has been successfully unembedded."),
                      o_current->complex_basename);
 
       page_modified = 1;

--- a/liblepton/src/s_clib.c
+++ b/liblepton/src/s_clib.c
@@ -457,17 +457,17 @@ static gchar *run_source_command (const gchar *command)
                              &e);
 
   if (e != NULL) {
-    s_log_message (_("Library command failed [%1$s]: %2$s\n"), command,
+    s_log_message (_("Library command failed [%1$s]: %2$s"), command,
 		   e->message);
     g_error_free (e);
 
   } else if (WIFSIGNALED(exit_status)) {
-    s_log_message (_("Library command failed [%1$s]: Uncaught signal %2$i.\n"),
+    s_log_message (_("Library command failed [%1$s]: Uncaught signal %2$i."),
                    command, WTERMSIG(exit_status));
 
   } else if (WIFEXITED(exit_status) && WEXITSTATUS(exit_status)) {
-    s_log_message (_("Library command failed [%1$s]\n"), command);
-    s_log_message(_("Error output was:\n%1$s\n"), standard_error);
+    s_log_message (_("Library command failed [%1$s]"), command);
+    s_log_message(_("Error output was:\n%1$s"), standard_error);
 
   } else {
     success = TRUE;
@@ -553,7 +553,7 @@ static gchar *uniquify_source_name (const gchar *name)
     newname = g_strdup_printf ("%s<%i>", name, i);
   } while (s_clib_get_source_by_name (newname) != NULL);
 
-  s_log_message (_("Library name [%1$s] already in use.  Using [%2$s].\n"),
+  s_log_message (_("Library name [%1$s] already in use.  Using [%2$s]."),
                  name, newname);
 
   return newname;
@@ -590,7 +590,7 @@ static void refresh_directory (CLibSource *source)
   dir = g_dir_open (source->directory, 0, &e);
 
   if (e != NULL) {
-    s_log_message (_("Failed to open directory [%1$s]: %2$s\n"),
+    s_log_message (_("Failed to open directory [%1$s]: %2$s"),
 		   source->directory, e->message);
     g_error_free (e);
     return;
@@ -726,7 +726,7 @@ static void refresh_scm (CLibSource *source)
   symlist = scm_call_0 (source->list_fn);
 
   if (scm_is_false (scm_list_p (symlist))) {
-    s_log_message (_("Failed to scan library [%1$s]: Scheme function returned non-list\n"),
+    s_log_message (_("Failed to scan library [%1$s]: Scheme function returned non-list."),
 		   source->name);
     return;
   }
@@ -734,7 +734,7 @@ static void refresh_scm (CLibSource *source)
   while (!scm_is_null (symlist)) {
     symname = SCM_CAR (symlist);
     if (!scm_is_string (symname)) {
-      s_log_message (_("Non-string symbol name while scanning library [%1$s]\n"),
+      s_log_message (_("Non-string symbol name while scanning library [%1$s]"),
 		     source->name);
     } else {
       symbol = g_new0 (CLibSymbol, 1);
@@ -890,7 +890,7 @@ const CLibSource *s_clib_add_command (const gchar *list_cmd,
   gchar *realname;
 
   if (name == NULL) {
-    s_log_message (_("Cannot add library: name not specified\n"));
+    s_log_message (_("Cannot add library: name not specified."));
     return NULL;
   }
 
@@ -898,7 +898,7 @@ const CLibSource *s_clib_add_command (const gchar *list_cmd,
 
   if (list_cmd == NULL || get_cmd == NULL) {
     s_log_message (_("Cannot add library [%1$s]: both 'list' and "
-                     "'get' commands must be specified.\n"),
+                     "'get' commands must be specified."),
 		   realname);
   }
 
@@ -937,7 +937,7 @@ const CLibSource *s_clib_add_scm (SCM listfunc, SCM getfunc, const gchar *name)
   gchar *realname;
 
   if (name == NULL) {
-    s_log_message (_("Cannot add library: name not specified\n"));
+    s_log_message (_("Cannot add library: name not specified."));
     return NULL;
   }
 
@@ -945,8 +945,8 @@ const CLibSource *s_clib_add_scm (SCM listfunc, SCM getfunc, const gchar *name)
 
   if (scm_is_false (scm_procedure_p (listfunc))
       && scm_is_false (scm_procedure_p (getfunc))) {
-    s_log_message (_("Cannot add Scheme-library [%1$s]: callbacks must be closures\n"),
-		   realname);
+    s_log_message (_("Cannot add Scheme-library [%1$s]: callbacks must be closures."),
+                   realname);
     return NULL;
   }
 
@@ -1072,8 +1072,8 @@ static gchar *get_data_directory (const CLibSymbol *symbol)
   g_file_get_contents (filename, &data, NULL, &e);
 
   if (e != NULL) {
-    s_log_message (_("Failed to load symbol from file [%1$s]: %2$s\n"),
-		   filename, e->message);
+    s_log_message (_("Failed to load symbol from file [%1$s]: %2$s"),
+                   filename, e->message);
     g_error_free (e);
   }
 
@@ -1132,8 +1132,8 @@ static gchar *get_data_scm (const CLibSymbol *symbol)
 			scm_from_utf8_string (symbol->name));
 
   if (!scm_is_string (symdata)) {
-    s_log_message (_("Failed to load symbol data [%1$s] from source [%2$s]\n"),
-		   symbol->name, symbol->source->name);
+    s_log_message (_("Failed to load symbol data [%1$s] from source [%2$s]"),
+                   symbol->name, symbol->source->name);
     return NULL;
   }
 
@@ -1374,13 +1374,13 @@ const CLibSymbol *s_clib_get_symbol_by_name (const gchar *name)
   symlist = s_clib_search (name, CLIB_EXACT);
 
   if (symlist == NULL) {
-    s_log_message (_("Component [%1$s] was not found in the component library\n"),
+    s_log_message (_("Component [%1$s] was not found in the component library."),
                    name);
     return NULL;
   }
 
   if (g_list_next (symlist) != NULL) { /* More than one symbol */
-    s_log_message (_("More than one component found with name [%1$s]\n"),
+    s_log_message (_("More than one component found with name [%1$s]."),
                    name);
   }
 

--- a/liblepton/src/s_hierarchy.c
+++ b/liblepton/src/s_hierarchy.c
@@ -197,7 +197,7 @@ s_hierarchy_find_up_page (GedaPageList *page_list, PAGE *current_page)
 {
   g_return_val_if_fail (current_page != NULL, NULL);
   if (current_page->up < 0) {
-    s_log_message(_("There are no schematics above the current one!\n"));
+    s_log_message(_("There are no schematics above the current one!"));
     return NULL;
   }
 
@@ -338,7 +338,7 @@ s_hierarchy_traversepages (TOPLEVEL *toplevel, PAGE *p_current, gint flags)
       /* call the recursive function */
       s_hierarchy_traversepages (toplevel, child_page, flags | HIERARCHY_INNERLOOP);
     } else {
-      s_log_message (_("Failed to descend hierarchy into '%1$s': %2$s\n"),
+      s_log_message (_("Failed to descend hierarchy into '%1$s': %2$s"),
                      filename, err->message);
       g_error_free (err);
     }

--- a/liblepton/src/s_slot.c
+++ b/liblepton/src/s_slot.c
@@ -155,13 +155,13 @@ void s_slot_update_object (TOPLEVEL *toplevel, OBJECT *object)
 
   if (slotdef == NULL) {
     if (slot_string) /* only an error if there's a slot string */
-      s_log_message (_("Did not find slotdef=#:#,#,#... attribute\n"));
+      s_log_message (_("Did not find slotdef=#:#,#,#... attribute."));
     return;
   }
 
   if (!strstr (slotdef, ":")) {
     /* Didn't find proper slotdef=#:... put warning into log */
-    s_log_message (_("Improper slotdef syntax: missing \":\".\n"));
+    s_log_message (_("Improper slotdef syntax: missing \":\"."));
     g_free (slotdef);
     return;
   }
@@ -176,7 +176,7 @@ void s_slot_update_object (TOPLEVEL *toplevel, OBJECT *object)
   cptr++; /* skip colon */
 
   if (*cptr == '\0') {
-    s_log_message (_("Did not find proper slotdef=#:#,#,#... attribute\n"));
+    s_log_message (_("Did not find proper slotdef=#:#,#,#... attribute."));
     g_free (slotdef);
     return;
   }
@@ -206,7 +206,7 @@ void s_slot_update_object (TOPLEVEL *toplevel, OBJECT *object)
 
       pin_counter++;
     } else {
-      s_log_message (_("component missing pinseq= attribute\n"));
+      s_log_message (_("component missing pinseq= attribute."));
     }
 
     current_pin = strtok (NULL, DELIMITERS);


### PR DESCRIPTION
Completes the work of PR #48 by removing the final newlines from all calls to `s_log_message()`. I also added some full stops where this made sense.

Closes #51 