### PR TITLE
gsymcheck: add newlines to logging, fix warning pluralisation

### DIFF
--- a/gsymcheck/src/s_check.c
+++ b/gsymcheck/src/s_check.c
@@ -126,33 +126,21 @@ s_check_symbol (TOPLEVEL *pr_current, PAGE *p_current, const GList *obj_list)
     s_symstruct_print(s_symcheck);
     
     if (s_symcheck->warning_count > 0) {
-      s_log_message(_("%1$d warnings found "),
+      s_log_message(ngettext(_("%2$d warning found %1$s"),
+                             _("%2$d warnings found %1$s"),
+                             s_symcheck->warning_count),
+                    (verbose_mode < 2) ? _("(use -vv to view details)") : "",
                     s_symcheck->warning_count);
-      if (verbose_mode < 2) {
-        s_log_message(_("(use -vv to view details)\n"));
-      } else {
-        s_log_message("\n");
-      }
     }
   
     if (s_symcheck->error_count == 0) {
-      s_log_message(_("No errors found\n"));
-    } else if (s_symcheck->error_count == 1) {
-      s_log_message(_("1 ERROR found "));
-      if (verbose_mode < 1) {
-        s_log_message(_("(use -v to view details)\n"));
-      } else {
-        s_log_message("\n");
-      }
-
-    } else if (s_symcheck->error_count > 1) {
-      s_log_message(_("%1$d ERRORS found "),
+      s_log_message(_("No errors found"));
+    } else {
+      s_log_message(ngettext(_("%2$d ERROR found %1$s"),
+                             _("%2$d ERRORS found %1$s"),
+                             s_symcheck->error_count),
+                    (verbose_mode < 1) ? _("(use -v to view details)") : "",
                     s_symcheck->error_count);
-      if (verbose_mode < 1) {
-        s_log_message(_("(use -v to view details)\n"));
-      } else {
-        s_log_message("\n");
-      }
     }
   }
 

--- a/gsymcheck/src/s_log.c
+++ b/gsymcheck/src/s_log.c
@@ -34,6 +34,7 @@ void s_log_update (const gchar *log_domain, GLogLevelFlags log_level,
   switch (logging_dest) {
     case STDOUT_TTY:
       fputs (buf, stdout);
+      fputs ("\n", stdout);
       break;
 
     default:

--- a/gsymcheck/tests/duplicate_net.output
+++ b/gsymcheck/tests/duplicate_net.output
@@ -1,5 +1,5 @@
 Warning: Found the same number in a pinnumber attribute and in a net attribute [1]
 ERROR: Found duplicate pin in net= attributes [5]
 ERROR: Found duplicate pin in net= attributes [6]
-1 warnings found 
+1 warning found 
 2 ERRORS found 

--- a/gsymcheck/tests/graphical_incorrect.output
+++ b/gsymcheck/tests/graphical_incorrect.output
@@ -1,3 +1,3 @@
 Warning: Found graphical symbol, device= should be set to none
-1 warnings found 
+1 warning found 
 No errors found

--- a/gsymcheck/tests/labelinside.output
+++ b/gsymcheck/tests/labelinside.output
@@ -1,3 +1,3 @@
 Warning: Found obsolete label= attribute: [label=this obsolete]
-1 warnings found 
+1 warning found 
 No errors found

--- a/gsymcheck/tests/missing_footprint.output
+++ b/gsymcheck/tests/missing_footprint.output
@@ -1,3 +1,3 @@
 Warning: Missing footprint= attribute
-1 warnings found 
+1 warning found 
 No errors found

--- a/gsymcheck/tests/missing_pinlabel.output
+++ b/gsymcheck/tests/missing_pinlabel.output
@@ -1,3 +1,3 @@
 Warning: Missing pinlabel= attribute
-1 warnings found 
+1 warning found 
 No errors found


### PR DESCRIPTION
Make the log handler in gsymcheck follow the liblepton behaviour
by adding a newline to the end of each message. Change some of the
end of check messaging to correctly build single line strings and
fix the pluralisation of the total number of warnings. Update the
tests that have a single warning to the new format.

I think the code is a bit less clear now but it maintains the same behaviour as before when newlines were not automatically added.