### PR TITLE
gnetlist: Optimise net rename tracking

### DIFF
--- a/gnetlist/scheme/gnetlist/rename.scm
+++ b/gnetlist/scheme/gnetlist/rename.scm
@@ -8,7 +8,7 @@
   #:export (search-rename
             add-rename
             get-rename-list
-            set-rename-list!
+            reset-rename!
             rename-all))
 
 ;;; List of renamings
@@ -34,6 +34,9 @@
         (lambda (ls) (set! rename-ls ls) rename-ls))
   (set! %get-rename-list
         (lambda () rename-ls)))
+
+;;; Reset the list of renamings to empty
+(define (reset-rename!) (set-rename-list! '()))
 
 ;;; Getters for rename pairs
 (define source car)

--- a/gnetlist/scheme/gnetlist/rename.scm
+++ b/gnetlist/scheme/gnetlist/rename.scm
@@ -1,5 +1,5 @@
 (define-module (gnetlist rename)
-  #:use-module (srfi srfi-26)
+  #:use-module (srfi srfi-69)
   #:use-module (gnetlist core gettext)
   #:use-module (gnetlist verbose)
   #:use-module (gnetlist package)
@@ -9,132 +9,90 @@
             add-rename
             get-rename-list
             reset-rename!
-            rename-all))
+            rename-all
+            get-rename-list))
 
-;;; List of renamings
-(define %rename-list '())
+(define (rename-lowlevel netlist from to)
 
-;;; Setter for the list of renamings
-(define (set-rename-list! ls)
-  (set! %rename-list ls)
-  %rename-list)
+  (define (rename-in-pin pin)
+    (if (string=? from (package-pin-name pin))
+        (set-package-pin-name! pin to)))
 
-;;; Getter for the list of renamings
-;;
-;; Returns the rename alist sorted by rename destination, then by
-;; rename source.
-(define (%get-rename-list)
-  %rename-list)
+  (define (rename-in-package package)
+    (for-each rename-in-pin (package-pins package)))
 
-(define (get-rename-list)
-  (sort (%get-rename-list) rename<?))
+  (for-each rename-in-package netlist)
+  netlist)
 
-(let ((rename-ls '()))
-  (set! set-rename-list!
-        (lambda (ls) (set! rename-ls ls) rename-ls))
-  (set! %get-rename-list
-        (lambda () rename-ls)))
+(define %renames (make-hash-table))
 
-;;; Reset the list of renamings to empty
-(define (reset-rename!) (set-rename-list! '()))
+(define (renamed? from)
+  (hash-table-ref/default %renames from #f))
 
-;;; Getters for rename pairs
-(define source car)
-(define destination cdr)
+(define (set-rename! from to)
+  (hash-table-set! %renames from to))
 
-;;; Comparison function for renames
-(define (rename<? left right)
-  (or
-   (string<? (destination left) (destination right))
-   (and (string=? (destination left) (destination right))
-        (string<? (source left) (source right)))))
+(define-public (reset-rename!)
+  (set! %renames (make-hash-table)))
+
+(define (update-rename from to)
+  (let ((from-rename (renamed? from))
+        (to-rename   (renamed? to)))
+    (cond
+     ;; Forward rename already exists
+     ((and from-rename (equal? to from-rename)) #t)
+     ;; Reverse rename already exists
+     ((and to-rename (equal? from to-rename)) #t)
+     ;; we found a -> b, while adding c -> a.
+     ;; hence we would have c -> a -> b, so add c -> b.
+     ;; avoid renaming if b is same as c!
+     (to-rename (set-rename! from to-rename))
+     ;; we found a -> b, while adding a -> c.
+     ;; hence b <==> c, so add c -> b.
+     ;; avoid renaming if b is same as c!
+     (from-rename (set-rename! to from-rename))
+     ;; No pre-existing renames
+     (else (set-rename! from to)))))
+
+(define-public (add-rename from to)
+  (and from to (update-rename from to)))
 
 ;;; if the src is found, return true
 ;;; if the dest is found, also return true, but warn user
 ;;; If quiet flag is true than don't print anything
-(define (search-rename src dest quiet)
-  (let loop ((ls (%get-rename-list)))
-    (and (not (null? ls))
-         (let* ((rename (car ls))
-                (current-source (source rename)))
-           (or (string=? src current-source)
-               (and (string=? dest current-source)
-                    (when (not quiet)
-                      (format (current-error-port)
-                              (_ "WARNING: Trying to rename something twice:
+(define (search-rename from to quiet)
+  ;; FIXME[2017-02-20] This warning message is very unhelpful
+  (define (warn)
+    (when (not quiet)
+          (format (current-error-port)
+                  (_ "WARNING: Trying to rename something twice:
 \t~A and ~A
 are both a src and dest name
 This warning is okay if you have multiple levels of hierarchy!
 ")
-                              dest
-                              current-source))
-                    #t)
-               (loop (cdr ls)))))))
+                  dest
+                  dest)))
 
-(define (update-rename-list rename-list dest src)
-  (define (get-new-rename src dest rename)
-    (or (and (string=? dest (source rename))
-             (not (string=? src (destination rename)))
-             ;; we found a -> b, while adding c -> a.
-             ;; hence we would have c -> a -> b, so add c -> b.
-             ;; avoid renaming if b is same as c!
-             (cons src (destination rename)))
-        (and (string=? src (source rename))
-             (not (string=? dest (destination rename)))
-             ;; we found a -> b, while adding a -> c.
-             ;; hence b <==> c, so add c -> b.
-             ;; avoid renaming if b is same as c!
-             (cons dest (destination rename)))))
+  (cond
+   ((renamed? from) #t)
+   ((renamed? to) (begin (warn) #t))
+   (else #f)))
 
-  (let loop ((ls rename-list)
-             (new-ls '()))
-    (if (null? ls)
-        (append new-ls rename-list)
-        (loop (cdr ls)
-              (let ((rename (get-new-rename src dest (car ls))))
-                (if rename
-                    (cons rename new-ls)
-                    new-ls))))))
-
-(define (add-rename src dest)
-  (and src
-       dest
-       (set-rename-list!
-        (if (search-rename src dest #f)
-            (update-rename-list (%get-rename-list) src dest)
-            `((,src . ,dest) . ,(%get-rename-list))))))
-
-
-(define (rename-lowlevel netlist rename)
-  (define (rename-it net-name rename)
-    (if (and net-name
-             (string=? net-name (source rename)))
-        (destination rename)
-        net-name))
-
-  (define (rename-in-pin pin rename)
-    (set-package-pin-name! pin (rename-it (package-pin-name pin) rename)))
-
-  (define (rename-in-pin-list pins rename)
-    (for-each (cut rename-in-pin <> rename) pins))
-
-  (define (rename-in-package package rename)
-    (rename-in-pin-list (package-pins package) rename))
-
-  (for-each (cut rename-in-package <> rename) netlist)
+(define-public (rename-all netlist)
+  (verbose-print "- Renaming nets:\n")
+  (hash-table-walk %renames
+    (lambda (from to)
+      (verbose-print "R")
+      (rename-lowlevel netlist from to)))
+  (verbose-done)
   netlist)
 
-
-(define (rename-all netlist)
-  (verbose-print "- Renaming nets:\n")
-  (let loop ((rename-list (%get-rename-list))
-             (netlist netlist))
-    (if (null? rename-list)
-        (begin
-          (verbose-done)
-          netlist)
-        (begin
-          (verbose-print "R")
-          (loop (cdr rename-list)
-                (rename-lowlevel netlist
-                                 (car rename-list)))))))
+;; Return the alist of renames.  Sort it so that it's in a canonical
+;; order no matter what the internal implementation of the hash table
+;; is.
+(define-public (get-rename-list)
+  (sort! (hash-table->alist %renames)
+         (lambda (left right)
+           (or (string<? (cdr left) (cdr right))
+               (and (string= (cdr left) (cdr right))
+                    (string<? (car left) (car right)))))))

--- a/gnetlist/src/s_rename.c
+++ b/gnetlist/src/s_rename.c
@@ -46,8 +46,7 @@
 
 static SCM search_rename_proc;
 static SCM add_rename_proc;
-static SCM get_rename_list_proc;
-static SCM set_rename_list_x_proc;
+static SCM reset_rename_x_proc;
 
 
 void init_rename_procs (void)
@@ -56,15 +55,13 @@ void init_rename_procs (void)
                                              "search-rename");
   add_rename_proc =        scm_c_public_ref ("gnetlist rename",
                                              "add-rename");
-  get_rename_list_proc =   scm_c_public_ref ("gnetlist rename",
-                                             "get-rename-list");
-  set_rename_list_x_proc = scm_c_public_ref ("gnetlist rename",
-                                             "set-rename-list!");
+  reset_rename_x_proc =    scm_c_public_ref ("gnetlist rename",
+                                             "reset-rename!");
 }
 
 void s_rename_init(void)
 {
-  scm_call_1 (set_rename_list_x_proc, SCM_EOL);
+  scm_call_0 (reset_rename_x_proc);
 }
 
 int s_rename_search(char *src, char *dest, int quiet_flag)

--- a/gnetlist/tests/hierarchy-config_mangle_refdes_attribute_false_1.out
+++ b/gnetlist/tests/hierarchy-config_mangle_refdes_attribute_false_1.out
@@ -15,18 +15,18 @@ END components
 
 START renamed-nets
 
-Uunder/Umiddle/Urock/unnamed_net4 -> U1_2_to_B
-Uunder/Umiddle/Urock/unnamed_net3 -> U2_1_to_E
-Uunder/Umiddle/rockA -> U1_2_to_B
-Uunder/Umiddle/rockB -> U2_1_to_E
-Uunder/middleA -> U1_2_to_B
-Uunder/middleB -> U2_1_to_E
 Utop/Umiddle/Urock/unnamed_net2 -> U1_2_to_B
-Utop/Umiddle/Urock/unnamed_net1 -> U2_1_to_E
 Utop/Umiddle/rockA -> U1_2_to_B
-Utop/Umiddle/rockB -> U2_1_to_E
 Utop/middleA -> U1_2_to_B
+Uunder/Umiddle/Urock/unnamed_net4 -> U1_2_to_B
+Uunder/Umiddle/rockA -> U1_2_to_B
+Uunder/middleA -> U1_2_to_B
+Utop/Umiddle/Urock/unnamed_net1 -> U2_1_to_E
+Utop/Umiddle/rockB -> U2_1_to_E
 Utop/middleB -> U2_1_to_E
+Uunder/Umiddle/Urock/unnamed_net3 -> U2_1_to_E
+Uunder/Umiddle/rockB -> U2_1_to_E
+Uunder/middleB -> U2_1_to_E
 
 END renamed-nets
 

--- a/gnetlist/tests/hierarchy-config_mangle_refdes_attribute_false_2.out
+++ b/gnetlist/tests/hierarchy-config_mangle_refdes_attribute_false_2.out
@@ -15,18 +15,18 @@ END components
 
 START renamed-nets
 
-Urock/Umiddle/Uunder/unnamed_net4 -> U1_2_to_B
-Urock/Umiddle/Uunder/unnamed_net3 -> U2_1_to_E
-Umiddle/Uunder/rockA -> U1_2_to_B
-Umiddle/Uunder/rockB -> U2_1_to_E
-Uunder/middleA -> U1_2_to_B
-Uunder/middleB -> U2_1_to_E
-Urock/Umiddle/Utop/unnamed_net2 -> U1_2_to_B
-Urock/Umiddle/Utop/unnamed_net1 -> U2_1_to_E
 Umiddle/Utop/rockA -> U1_2_to_B
-Umiddle/Utop/rockB -> U2_1_to_E
+Umiddle/Uunder/rockA -> U1_2_to_B
+Urock/Umiddle/Utop/unnamed_net2 -> U1_2_to_B
+Urock/Umiddle/Uunder/unnamed_net4 -> U1_2_to_B
 Utop/middleA -> U1_2_to_B
+Uunder/middleA -> U1_2_to_B
+Umiddle/Utop/rockB -> U2_1_to_E
+Umiddle/Uunder/rockB -> U2_1_to_E
+Urock/Umiddle/Utop/unnamed_net1 -> U2_1_to_E
+Urock/Umiddle/Uunder/unnamed_net3 -> U2_1_to_E
 Utop/middleB -> U2_1_to_E
+Uunder/middleB -> U2_1_to_E
 
 END renamed-nets
 

--- a/gnetlist/tests/hierarchy-config_mangle_refdes_attribute_true.out
+++ b/gnetlist/tests/hierarchy-config_mangle_refdes_attribute_true.out
@@ -16,18 +16,18 @@ END components
 
 START renamed-nets
 
-Uunder/Umiddle/Urock/unnamed_net4 -> U1_2_to_B
-Uunder/Umiddle/Urock/unnamed_net3 -> U2_1_to_E
-Uunder/Umiddle/rockA -> U1_2_to_B
-Uunder/Umiddle/rockB -> U2_1_to_E
-Uunder/middleA -> U1_2_to_B
-Uunder/middleB -> U2_1_to_E
 Utop/Umiddle/Urock/unnamed_net2 -> U1_2_to_B
-Utop/Umiddle/Urock/unnamed_net1 -> U2_1_to_E
 Utop/Umiddle/rockA -> U1_2_to_B
-Utop/Umiddle/rockB -> U2_1_to_E
 Utop/middleA -> U1_2_to_B
+Uunder/Umiddle/Urock/unnamed_net4 -> U1_2_to_B
+Uunder/Umiddle/rockA -> U1_2_to_B
+Uunder/middleA -> U1_2_to_B
+Utop/Umiddle/Urock/unnamed_net1 -> U2_1_to_E
+Utop/Umiddle/rockB -> U2_1_to_E
 Utop/middleB -> U2_1_to_E
+Uunder/Umiddle/Urock/unnamed_net3 -> U2_1_to_E
+Uunder/Umiddle/rockB -> U2_1_to_E
+Uunder/middleB -> U2_1_to_E
 
 END renamed-nets
 

--- a/gnetlist/tests/hierarchy-config_refdes_attribute_order_false.out
+++ b/gnetlist/tests/hierarchy-config_refdes_attribute_order_false.out
@@ -16,18 +16,18 @@ END components
 
 START renamed-nets
 
-Uunder/Umiddle/Urock/unnamed_net4 -> U1_2_to_B
-Uunder/Umiddle/Urock/unnamed_net3 -> U2_1_to_E
-Uunder/Umiddle/rockA -> U1_2_to_B
-Uunder/Umiddle/rockB -> U2_1_to_E
-Uunder/middleA -> U1_2_to_B
-Uunder/middleB -> U2_1_to_E
 Utop/Umiddle/Urock/unnamed_net2 -> U1_2_to_B
-Utop/Umiddle/Urock/unnamed_net1 -> U2_1_to_E
 Utop/Umiddle/rockA -> U1_2_to_B
-Utop/Umiddle/rockB -> U2_1_to_E
 Utop/middleA -> U1_2_to_B
+Uunder/Umiddle/Urock/unnamed_net4 -> U1_2_to_B
+Uunder/Umiddle/rockA -> U1_2_to_B
+Uunder/middleA -> U1_2_to_B
+Utop/Umiddle/Urock/unnamed_net1 -> U2_1_to_E
+Utop/Umiddle/rockB -> U2_1_to_E
 Utop/middleB -> U2_1_to_E
+Uunder/Umiddle/Urock/unnamed_net3 -> U2_1_to_E
+Uunder/Umiddle/rockB -> U2_1_to_E
+Uunder/middleB -> U2_1_to_E
 
 END renamed-nets
 

--- a/gnetlist/tests/hierarchy-config_refdes_attribute_order_true.out
+++ b/gnetlist/tests/hierarchy-config_refdes_attribute_order_true.out
@@ -16,18 +16,18 @@ END components
 
 START renamed-nets
 
-Urock/Umiddle/Uunder/unnamed_net4 -> U1_2_to_B
-Urock/Umiddle/Uunder/unnamed_net3 -> U2_1_to_E
-Umiddle/Uunder/rockA -> U1_2_to_B
-Umiddle/Uunder/rockB -> U2_1_to_E
-Uunder/middleA -> U1_2_to_B
-Uunder/middleB -> U2_1_to_E
-Urock/Umiddle/Utop/unnamed_net2 -> U1_2_to_B
-Urock/Umiddle/Utop/unnamed_net1 -> U2_1_to_E
 Umiddle/Utop/rockA -> U1_2_to_B
-Umiddle/Utop/rockB -> U2_1_to_E
+Umiddle/Uunder/rockA -> U1_2_to_B
+Urock/Umiddle/Utop/unnamed_net2 -> U1_2_to_B
+Urock/Umiddle/Uunder/unnamed_net4 -> U1_2_to_B
 Utop/middleA -> U1_2_to_B
+Uunder/middleA -> U1_2_to_B
+Umiddle/Utop/rockB -> U2_1_to_E
+Umiddle/Uunder/rockB -> U2_1_to_E
+Urock/Umiddle/Utop/unnamed_net1 -> U2_1_to_E
+Urock/Umiddle/Uunder/unnamed_net3 -> U2_1_to_E
 Utop/middleB -> U2_1_to_E
+Uunder/middleB -> U2_1_to_E
 
 END renamed-nets
 

--- a/gnetlist/tests/hierarchy-geda.out
+++ b/gnetlist/tests/hierarchy-geda.out
@@ -16,18 +16,18 @@ END components
 
 START renamed-nets
 
-Uunder/Umiddle/Urock/unnamed_net4 -> U1_2_to_B
-Uunder/Umiddle/Urock/unnamed_net3 -> U2_1_to_E
-Uunder/Umiddle/rockA -> U1_2_to_B
-Uunder/Umiddle/rockB -> U2_1_to_E
-Uunder/middleA -> U1_2_to_B
-Uunder/middleB -> U2_1_to_E
 Utop/Umiddle/Urock/unnamed_net2 -> U1_2_to_B
-Utop/Umiddle/Urock/unnamed_net1 -> U2_1_to_E
 Utop/Umiddle/rockA -> U1_2_to_B
-Utop/Umiddle/rockB -> U2_1_to_E
 Utop/middleA -> U1_2_to_B
+Uunder/Umiddle/Urock/unnamed_net4 -> U1_2_to_B
+Uunder/Umiddle/rockA -> U1_2_to_B
+Uunder/middleA -> U1_2_to_B
+Utop/Umiddle/Urock/unnamed_net1 -> U2_1_to_E
+Utop/Umiddle/rockB -> U2_1_to_E
 Utop/middleB -> U2_1_to_E
+Uunder/Umiddle/Urock/unnamed_net3 -> U2_1_to_E
+Uunder/Umiddle/rockB -> U2_1_to_E
+Uunder/middleB -> U2_1_to_E
 
 END renamed-nets
 

--- a/gnetlist/tests/hierarchy2-geda.out
+++ b/gnetlist/tests/hierarchy2-geda.out
@@ -14,10 +14,10 @@ END components
 
 START renamed-nets
 
-U102/unnamed_net3 -> two
-U102/unnamed_net4 -> two
 U100/unnamed_net1 -> one
 U100/unnamed_net2 -> one
+U102/unnamed_net3 -> two
+U102/unnamed_net4 -> two
 
 END renamed-nets
 

--- a/gnetlist/tests/hierarchy3-geda.out
+++ b/gnetlist/tests/hierarchy3-geda.out
@@ -18,16 +18,16 @@ END components
 START renamed-nets
 
 Utop/Umiddle/Urock/unnamed_net4 -> U1_2_to_B
-Utop/Umiddle/Urock/unnamed_net3 -> U2_1_to_E
 Utop/Umiddle/rockA -> U1_2_to_B
-Utop/Umiddle/rockB -> U2_1_to_E
 Utop/middleA -> U1_2_to_B
-Utop/middleB -> U2_1_to_E
 Uunder/Umiddle/Urock/unnamed_net2 -> U1_2_to_B
-Uunder/Umiddle/Urock/unnamed_net1 -> U2_1_to_E
 Uunder/Umiddle/rockA -> U1_2_to_B
-Uunder/Umiddle/rockB -> U2_1_to_E
 Uunder/middleA -> U1_2_to_B
+Utop/Umiddle/Urock/unnamed_net3 -> U2_1_to_E
+Utop/Umiddle/rockB -> U2_1_to_E
+Utop/middleB -> U2_1_to_E
+Uunder/Umiddle/Urock/unnamed_net1 -> U2_1_to_E
+Uunder/Umiddle/rockB -> U2_1_to_E
 Uunder/middleB -> U2_1_to_E
 
 END renamed-nets

--- a/gnetlist/tests/run-test
+++ b/gnetlist/tests/run-test
@@ -239,19 +239,19 @@ else
     if ! diff "${out}.tmp1" "${out}.tmp2" >/dev/null; then
         echo "FAILED: Wrong plain output. See diff ${ref} ${out}"
         echo "--------------------------------8<--------------------------------"
-        diff ${ref} ${out}
+        diff -u ${ref} ${out}
         echo "-------------------------------->8--------------------------------"
         status=1
     elif ! diff "${out}.tmp1" "${out}.tmp3" >/dev/null; then
         echo "FAILED: Wrong stdout output. See diff ${ref} ${std}"
         echo "--------------------------------8<--------------------------------"
-        diff ${ref} ${std}
+        diff -u ${ref} ${std}
         echo "-------------------------------->8--------------------------------"
         status=1
     elif ! diff "${out}.tmp1" "${out}.tmp4" >/dev/null; then
         echo "FAILED: Wrong verbose output. See diff ${ref} ${vrb}"
         echo "--------------------------------8<--------------------------------"
-        diff ${ref} ${vrb}
+        diff -u ${ref} ${vrb}
         echo "-------------------------------->8--------------------------------"
         status=1
     else


### PR DESCRIPTION
This PR converts rename tracking from using an alist to using a hashtable.  This improves the time spent on rename creation from O(N^2) in the number of renames to O(1).

The PR is in two parts:

1. Changing the rename alists provided by the `(get-rename-list)` function to be sorted in a canonical ordering, and updating the testsuite
2. Changing the rename implementation to using a hashtable

This proves that the change in rename implementation has no effect on the testsuite results other than the order renames appear in the result of `(get-rename-list)`.