### PR TITLE
Prevent most build warnings in libraries & gschem

### DIFF
--- a/gschem/src/gschem_binding_integer.c
+++ b/gschem/src/gschem_binding_integer.c
@@ -66,10 +66,10 @@ static void
 set_widget (GschemBindingInteger *binding, GtkWidget *widget);
 
 static gboolean
-update_model (GschemBindingInteger *binding);
+update_model (GschemBinding *binding);
 
 static gboolean
-update_widget (GschemBindingInteger *binding);
+update_widget (GschemBinding *binding);
 
 static void
 widget_apply (GtkWidget *widget, GschemBindingInteger *binding);
@@ -205,7 +205,7 @@ model_notify (GObject *object, GParamSpec *pspec, GschemBindingInteger *binding)
   const gchar *param_name = g_intern_string (pspec->name);
 
   if (param_name == binding->model_param) {
-    update_widget (binding);
+    update_widget (GSCHEM_BINDING (binding));
   }
 }
 
@@ -232,7 +232,7 @@ set_model_object (GschemBindingInteger *binding, GObject *object)
                       binding);
   }
 
-  update_widget (binding);
+  update_widget (GSCHEM_BINDING (binding));
 }
 
 
@@ -315,8 +315,9 @@ set_widget (GschemBindingInteger *binding, GtkWidget *widget)
  *  \return TRUE, if successful
  */
 static gboolean
-update_model (GschemBindingInteger *binding)
+update_model (GschemBinding *obj)
 {
+  GschemBindingInteger *binding = GSCHEM_BINDING_INTEGER (obj);
   int number;
   gboolean success = FALSE;
 
@@ -357,8 +358,9 @@ update_model (GschemBindingInteger *binding)
  *  \return TRUE, if successful
  */
 static gboolean
-update_widget (GschemBindingInteger *binding)
+update_widget (GschemBinding *obj)
 {
+  GschemBindingInteger *binding = GSCHEM_BINDING_INTEGER (obj);
   gboolean success = FALSE;
 
   if (binding->model_object != NULL) {
@@ -397,5 +399,5 @@ update_widget (GschemBindingInteger *binding)
 static void
 widget_apply (GtkWidget *widget, GschemBindingInteger *binding)
 {
-  update_model (binding);
+  update_model (GSCHEM_BINDING (binding));
 }

--- a/libgedacairo/edarenderer.c
+++ b/libgedacairo/edarenderer.c
@@ -135,7 +135,7 @@ static void eda_renderer_draw_picture (EdaRenderer *renderer, OBJECT *object);
 static void eda_renderer_draw_complex (EdaRenderer *renderer, OBJECT *object);
 
 static void eda_renderer_default_draw_grips (EdaRenderer *renderer, OBJECT *object);
-static void eda_renderer_draw_grips_list (EdaRenderer *renderer, GList *objects);
+static void eda_renderer_draw_grips_list (EdaRenderer *renderer, GList *objects) G_GNUC_UNUSED;
 static void eda_renderer_draw_grips_impl (EdaRenderer *renderer, int type, int n_grips, ...);
 static void eda_renderer_draw_arc_grips (EdaRenderer *renderer, OBJECT *object);
 static void eda_renderer_draw_path_grips (EdaRenderer *renderer, OBJECT *object);

--- a/liblepton/include/liblepton/prototype.h
+++ b/liblepton/include/liblepton/prototype.h
@@ -76,8 +76,6 @@ SELECTION *o_selection_new( void );
 void o_selection_add(TOPLEVEL *toplevel, SELECTION *selection, OBJECT *o_selected);
 void o_selection_print_all(const SELECTION *selection);
 void o_selection_remove(TOPLEVEL *toplevel, SELECTION *selection, OBJECT *o_selected);
-void o_selection_select(TOPLEVEL *toplevel, OBJECT *object) G_GNUC_DEPRECATED;
-void o_selection_unselect(TOPLEVEL *toplevel, OBJECT *object) G_GNUC_DEPRECATED;
 
 /* s_attrib.c */
 int s_attrib_add_entry(char *new_attrib);

--- a/liblepton/include/prototype_priv.h
+++ b/liblepton/include/prototype_priv.h
@@ -40,6 +40,10 @@ void o_bounds_invalidate(TOPLEVEL *toplevel, OBJECT *object);
 void o_emit_pre_change_notify(TOPLEVEL *toplevel, OBJECT *object);
 void o_emit_change_notify(TOPLEVEL *toplevel, OBJECT *object);
 
+/* o_selection.c */
+void o_selection_select(TOPLEVEL *toplevel, OBJECT *object);
+void o_selection_unselect(TOPLEVEL *toplevel, OBJECT *object);
+
 /* s_clib.c */
 void s_clib_init (void);
 

--- a/liblepton/src/f_basic.c
+++ b/liblepton/src/f_basic.c
@@ -224,7 +224,10 @@ int f_open_flags(TOPLEVEL *toplevel, PAGE *page,
   if (file_directory) { 
     if (chdir (file_directory)) {
       /* Error occurred with chdir */
-#warning FIXME: What do we do?
+      /* FIXME[2017-02-21] Libraries should not be changing the
+       * current working directory.  If it is not possible to avoid a
+       * chdir() call, then the error needs to be handled and/or
+       * reported. */
     }
   }
 
@@ -311,7 +314,10 @@ int f_open_flags(TOPLEVEL *toplevel, PAGE *page,
   if (flags & F_OPEN_RESTORE_CWD) {
     if (chdir (saved_cwd)) {
       /* Error occurred with chdir */
-#warning FIXME: What do we do?
+      /* FIXME[2017-02-21] Libraries should not be changing the
+       * current working directory.  If it is not possible to avoid a
+       * chdir() call, then the error needs to be handled and/or
+       * reported. */
     }
     g_free(saved_cwd);
   }

--- a/liblepton/src/geda_page.c
+++ b/liblepton/src/geda_page.c
@@ -380,7 +380,10 @@ void s_page_goto (TOPLEVEL *toplevel, PAGE *p_new)
   dirname = g_path_get_dirname (s_page_get_filename(p_new));
   if (chdir (dirname)) {
     /* An error occured with chdir */
-#warning FIXME: What do we do?
+    /* FIXME[2017-02-21] Libraries should not be changing the
+     * current working directory.  If it is not possible to avoid a
+     * chdir() call, then the error needs to be handled and/or
+     * reported. */
   }
   g_free (dirname);
 


### PR DESCRIPTION
This PR resolves and/or silences most build warnings in `liblepton`, `libgedacairo` and `gschem`.

- An unused-but-possibly-useful function in `libgedacairo` has been annotated with `G_GNUC_UNUSED`
- Two deprecated functions in `liblepton` that are not used outside the library have had their deprecation annotations removed and have been removed from the public API
- Preprocessor warnings due to unchecked result of `chdir()` have been replaced with **FIXME** comments.
- In `gschem`, some vtable overridden functions have been changed to have exactly the correct prototypes.