### PR TITLE
Rename libgedacairo to libleptonrenderer.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,7 @@
 if ENABLE_GATTRIB
 GATTRIB_DIR=gattrib
 endif
-SUBDIRS = liblepton libgedacairo gaf gschem ${GATTRIB_DIR} \
+SUBDIRS = liblepton libleptonrenderer gaf gschem ${GATTRIB_DIR} \
 	gsymcheck gnetlist utils symbols docs examples contrib
 
 ACLOCAL_AMFLAGS = -I m4

--- a/configure.ac
+++ b/configure.ac
@@ -182,8 +182,8 @@ AX_DATA_DIRS
 AX_PCB_DIRS
 # Set up liblepton with the correct ld version number
 AX_LIBLEPTON([1:0:0])
-# Set up libgedacairo with the correct ld version number
-AX_LIBGEDACAIRO([1:1:0])
+# Set up libleptonrenderer with the correct ld version number
+AX_LIBLEPTONRENDERER([1:0:0])
 
 #####################################################################
 # Generate output
@@ -204,8 +204,8 @@ AC_CONFIG_FILES([Makefile
                  liblepton/src/Makefile
                  liblepton/tests/Makefile
 
-                 libgedacairo/Makefile
-                 libgedacairo/libgedacairo.pc
+                 libleptonrenderer/Makefile
+                 libleptonrenderer/libleptonrenderer.pc
 
                  gaf/Makefile
                  gaf/po/Makefile.in

--- a/gaf/Makefile.am
+++ b/gaf/Makefile.am
@@ -32,7 +32,7 @@ gaf_CFLAGS = \
 gaf_LDFLAGS = $(GUILE_LIBS) $(GTK_LIBS) $(GDK_PIXBUF_LIBS) $(CAIRO_LIBS) \
 	$(CAIRO_PNG_LIBS) $(CAIRO_PDF_CLAGS) $(CAIRO_PS_LIBS) $(CAIRO_SVG_LIBS)
 gaf_LDADD = \
-	$(top_builddir)/libgedacairo/libgedacairo.la \
+	$(top_builddir)/libleptonrenderer/libleptonrenderer.la \
 	$(top_builddir)/liblepton/src/liblepton.la
 
 localedir = @datadir@/locale

--- a/gaf/export.c
+++ b/gaf/export.c
@@ -33,7 +33,7 @@
 
 #include <liblepton/liblepton.h>
 #include <liblepton/libgedaguile.h>
-#include <libgedacairo/libgedacairo.h>
+#include <libleptonrenderer/libleptonrenderer.h>
 
 #include <gtk/gtk.h>
 #include <glib/gstdio.h>

--- a/gschem/include/gschem.h
+++ b/gschem/include/gschem.h
@@ -4,7 +4,7 @@
 #include <libguile.h>
 #include <liblepton/liblepton.h>
 #include <liblepton/libgedaguile.h>
-#include <libgedacairo/libgedacairo.h>
+#include <libleptonrenderer/libleptonrenderer.h>
 
 /* forward declaration, until everyone stops referencing it */
 typedef struct st_gschem_toplevel GschemToplevel;

--- a/gschem/src/Makefile.am
+++ b/gschem/src/Makefile.am
@@ -126,7 +126,7 @@ gschem_CFLAGS = $(GCC_CFLAGS) $(LIBSTROKE_CFLAGS) \
 gschem_LDFLAGS = $(LIBSTROKE_LDFLAGS) $(GLIB_LIBS) $(GTK_LIBS) \
 	$(GTHREAD_LIBS) $(GUILE_LIBS) $(MINGW_GUI_LDFLAGS)
 gschem_LDADD = \
-	$(top_builddir)/libgedacairo/libgedacairo.la \
+	$(top_builddir)/libleptonrenderer/libleptonrenderer.la \
 	$(top_builddir)/liblepton/src/liblepton.la
 
 

--- a/liblepton/scheme/Makefile.am
+++ b/liblepton/scheme/Makefile.am
@@ -65,7 +65,7 @@ geda/core/gettext.scm: $(srcdir)/geda/core/gettext.scm.in Makefile
 	fi
 
 update-gaf-tool:
-	for d in liblepton/src libgedacairo gaf; do \
+	for d in liblepton/src libleptonrenderer gaf; do \
 	  (cd $(top_builddir)/$$d && $(MAKE) $(AM_MAKEFLAGS) all-am); \
 	done
 

--- a/liblepton/tests/Makefile.am
+++ b/liblepton/tests/Makefile.am
@@ -34,5 +34,5 @@ AM_CXXFLAGS =  $(MINGW_CLAGS) $(GUILE_CFLAGS) $(GLIB_CFLAGS) \
 AM_LDFLAGS = \
 	$(WINDOWS_LIBTOOL_FLAGS) $(MINGW_LDFLAGS) $(GUILE_LIBS) \
 	$(GLIB_LIBS) $(GDK_PIXBUF_LIBS) \
-	$(top_builddir)/libgedacairo/libgedacairo.la \
+	$(top_builddir)/libleptonrenderer/libleptonrenderer.la \
 	$(top_builddir)/liblepton/src/liblepton.la

--- a/libleptonrenderer/.gitignore
+++ b/libleptonrenderer/.gitignore
@@ -3,4 +3,4 @@
 *.la
 *.lo
 ChangeLog
-libgedacairo.pc
+libleptonrenderer.pc

--- a/libleptonrenderer/Makefile.am
+++ b/libleptonrenderer/Makefile.am
@@ -1,14 +1,14 @@
-lib_LTLIBRARIES = libgedacairo.la
+lib_LTLIBRARIES = libleptonrenderer.la
 
-libgedacairo_la_SOURCES = \
+libleptonrenderer_la_SOURCES = \
 	edacairo.c \
 	edapangorenderer.c \
 	edarenderer.c
 
-libgedacairoincludedir = $(includedir)/libgedacairo
+libleptonrendererincludedir = $(includedir)/libleptonrenderer
 
-libgedacairoinclude_HEADERS = \
-	libgedacairo.h \
+libleptonrendererinclude_HEADERS = \
+	libleptonrenderer.h \
 	edacairo.h \
 	edarenderer.h
 
@@ -18,18 +18,18 @@ noinst_HEADERS = \
 EXTRA_DIST = README ChangeLog
 
 AM_CPPFLAGS = \
-	-DLOCALEDIR=\"$(localedir)\" -DG_LOG_DOMAIN=\"libgedacairo\" \
+	-DLOCALEDIR=\"$(localedir)\" -DG_LOG_DOMAIN=\"libleptonrenderer\" \
 	-I$(top_srcdir)/liblepton/include -I$(top_srcdir)
 AM_CFLAGS = \
 	$(GCC_CFLAGS) $(MINGW_CFLAGS) $(GUILE_CFLAGS) $(GLIB_CFLAGS) \
 	$(GDK_CFLAGS) $(CAIRO_CFLAGS) $(PANGO_CFLAGS) $(GDK_PIXBUF_CFLAGS)
-AM_LDFLAGS = -version-info $(LIBGEDACAIRO_SHLIB_VERSION) \
+AM_LDFLAGS = -version-info $(LIBLEPTONRENDERER_SHLIB_VERSION) \
 	$(WINDOWS_LIBTOOL_FLAGS) $(MINGW_LDFLAGS) $(GUILE_LIBS) \
 	$(GDK_LIBS) $(GLIB_LIBS) $(CAIRO_LIBS) $(PANGO_LIBS) $(GDK_PIXBUF_LIBS)
 LIBTOOL=@LIBTOOL@ --silent
 
 pkgconfigdir = $(libdir)/pkgconfig
-pkgconfig_DATA = libgedacairo.pc
+pkgconfig_DATA = libleptonrenderer.pc
 
 if HAVE_GIT_REPO
 ChangeLog: $(top_builddir)/stamp-git

--- a/libleptonrenderer/README
+++ b/libleptonrenderer/README
@@ -7,7 +7,7 @@ Copyright (C) 1998-2012 gEDA Developers
 Cairo-based schematic and symbol renderer
 =========================================
 
-The libgedacairo library provides a renderer for schematics and
+The libleptonrenderer library provides a renderer for schematics and
 symbols based on the Cairo vector graphics library and the Pango font
 library.  Data for rendering is loaded using libgeda.
 
@@ -20,32 +20,34 @@ The library is based on Peter Clifton's preexisting gschem rendering
 code.
 
 Please submit bug reports and patches to
-<https://github.com/lepton-eda/lepton-eda/issues>, using the `libgedacairo' tag.
+<https://github.com/lepton-eda/lepton-eda/issues>, using the
+`libleptonrenderer' tag.
 
-Using libgedacairo in your programs
+Using libleptonrenderer in your programs
 -----------------------------------
 
 To use the library in your GNU Autotools-based program, add:
 
   PKG_PROG_PKG_CONFIG
-  PKG_CHECK_MODULES([GEDACAIRO], [libgedacairo], [], [])
+  PKG_CHECK_MODULES([LEPTONRENDERER], [libleptonrenderer], [], [])
 
 to your `configure.ac', and then add:
 
-  AM_CFLAGS = $(GEDACAIRO_CFLAGS
-  AM_LDFLAGS = $(GEDACAIRO_LDFLAGS)
+  AM_CFLAGS = $(LEPTONRENDERER_CFLAGS
+  AM_LDFLAGS = $(LEPTONRENDERER_LDFLAGS)
 
 to your `Makefile.am'.
 
 To compile a very simple program without using a GNU Autotools, you
 could use a command like:
 
-  cc `pkg-config --cflags --libs libgedacairo` -o myprog myprog.c
+  cc `pkg-config --cflags --libs libleptonrenderer` -o myprog myprog.c
 
 Header files
 ------------
 
-The main header file for the library is `libgedacairo/libgedacairo.h'.
+The main header file for the library is
+`libleptonrenderer/libleptonrenderer.h'.
 
 It makes two main groups of API functions and and types available: the
 main EdaRenderer class (based on GObject), and a set of hinted
@@ -58,9 +60,9 @@ An important concept to understand when using an EdaRenderer is the
 distinction between Cairo's "device coordinates" and "user
 coordinates".  (Yes, go and look it up now).
 
-Before calling any libgedacairo drawing functions, you must set up the
-Cairo context's transformation matrix so that user coordinates match
-coordinates on the schematic or symbol page.
+Before calling any libleptonrenderer drawing functions, you must
+set up the Cairo context's transformation matrix so that user
+coordinates match coordinates on the schematic or symbol page.
 
 The EdaRenderer class
 ---------------------
@@ -135,8 +137,8 @@ These four methods all can be overridden from subclasses.
 Lower-level drawing
 -------------------
 
-Sometimes EdaRenderer is not enough!  libgedacairo provides a bunch of
-functions for doing lower-level drawing.
+Sometimes EdaRenderer is not enough!  libleptonrenderer provides a
+bunch of functions for doing lower-level drawing.
 
 Several of these drawing functions take a `flags' argument.  At the
 moment, the only flag that may be applied is `EDA_CAIRO_ENABLE_HINTS'.

--- a/libleptonrenderer/edacairo.c
+++ b/libleptonrenderer/edacairo.c
@@ -1,5 +1,5 @@
 /* gEDA - GPL Electronic Design Automation
- * libgedacairo - Rendering gEDA schematics with Cairo
+ * libleptonrenderer - Rendering Lepton EDA schematics with Cairo
  * Copyright (C) 1998-2012 gEDA Contributors (see ChangeLog for details)
  *
  * This program is free software; you can redistribute it and/or modify

--- a/libleptonrenderer/edacairo.h
+++ b/libleptonrenderer/edacairo.h
@@ -1,5 +1,5 @@
 /* gEDA - GPL Electronic Design Automation
- * libgedacairo - Rendering gEDA schematics with Cairo
+ * libleptonrenderer - Rendering Lepton EDA schematics with Cairo
  * Copyright (C) 2010-2012 gEDA Contributors (see ChangeLog for details)
  *
  * This library is free software; you can redistribute it and/or

--- a/libleptonrenderer/edapangorenderer.c
+++ b/libleptonrenderer/edapangorenderer.c
@@ -1,5 +1,5 @@
 /* gEDA - GPL Electronic Design Automation
- * libgedacairo - Rendering gEDA schematics with Cairo
+ * libleptonrenderer - Rendering Lepton EDA schematics with Cairo
  * Copyright (C) 2010-2012 gEDA Contributors (see ChangeLog for details)
  *
  * This library is free software; you can redistribute it and/or

--- a/libleptonrenderer/edapangorenderer.h
+++ b/libleptonrenderer/edapangorenderer.h
@@ -1,5 +1,5 @@
 /* gEDA - GPL Electronic Design Automation
- * libgedacairo - Rendering gEDA schematics with Cairo
+ * libleptonrenderer - Rendering Lepton EDA schematics with Cairo
  * Copyright (C) 2010-2012 gEDA Contributors (see ChangeLog for details)
  *
  * This library is free software; you can redistribute it and/or

--- a/libleptonrenderer/edarenderer.c
+++ b/libleptonrenderer/edarenderer.c
@@ -1,5 +1,5 @@
 /* gEDA - GPL Electronic Design Automation
- * libgedacairo - Rendering gEDA schematics with Cairo
+ * libleptonrenderer - Rendering Lepton EDA schematics with Cairo
  * Copyright (C) 2010-2012 gEDA Contributors (see ChangeLog for details)
  *
  * This library is free software; you can redistribute it and/or

--- a/libleptonrenderer/edarenderer.h
+++ b/libleptonrenderer/edarenderer.h
@@ -1,5 +1,5 @@
 /* gEDA - GPL Electronic Design Automation
- * libgedacairo - Rendering gEDA schematics with Cairo
+ * libleptonrenderer - Rendering Lepton EDA schematics with Cairo
  * Copyright (C) 2010-2012 gEDA Contributors (see ChangeLog for details)
  *
  * This library is free software; you can redistribute it and/or

--- a/libleptonrenderer/libleptonrenderer.h
+++ b/libleptonrenderer/libleptonrenderer.h
@@ -1,5 +1,5 @@
 /* gEDA - GPL Electronic Design Automation
- * libgedacairo - Rendering gEDA schematics with Cairo
+ * libleptonrenderer - Rendering Lepton EDA schematics with Cairo
  * Copyright (C) 2010-2012 gEDA Contributors (see ChangeLog for details)
  *
  * This library is free software; you can redistribute it and/or
@@ -17,14 +17,14 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
-#ifndef __LIBGEDACAIRO_H__
-#define __LIBGEDACAIRO_H__
+#ifndef __LIBLEPTONRENDERER_H__
+#define __LIBLEPTONRENDERER_H__
 
 #include <liblepton/liblepton.h>
 #include <cairo.h>
 #include <pango/pangocairo.h>
 
-#include <libgedacairo/edarenderer.h>
-#include <libgedacairo/edacairo.h>
+#include <libleptonrenderer/edarenderer.h>
+#include <libleptonrenderer/edacairo.h>
 
-#endif /* !__LIBGEDACAIRO_H__ */
+#endif /* !__LIBLEPTONRENDERER_H__ */

--- a/libleptonrenderer/libleptonrenderer.pc.in
+++ b/libleptonrenderer/libleptonrenderer.pc.in
@@ -3,11 +3,11 @@ exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@
 
-Name: libgedacairo
-Description: gEDA/gaf schematic renderer library
+Name: libleptonrenderer
+Description: Lepton EDA schematic renderer library
 Requires: liblepton glib-2.0 gobject-2.0 gdk-2.0 gdk-pixbuf-2.0 cairo pangocairo
 Requires.private:
 Version: @DATE_VERSION@
-Libs: -L${libdir} -lgedacairo -lm
+Libs: -L${libdir} -lleptonrenderer -lm
 Libs.private:
 Cflags: -I${includedir}

--- a/m4/geda-libleptonrenderer.m4
+++ b/m4/geda-libleptonrenderer.m4
@@ -1,7 +1,7 @@
-# geda-libgedacairo.m4                                  -*-Autoconf-*-
+# geda-libleptonrenderer.m4                             -*-Autoconf-*-
 # serial 1
 
-dnl libgedacairo-specific setup
+dnl libleptonrenderer-specific setup
 dnl Copyright (C) 2010  Peter Brett <peter@peter-b.co.uk>
 dnl
 dnl This program is free software; you can redistribute it and/or modify
@@ -19,12 +19,12 @@ dnl along with this program; if not, write to the Free Software
 dnl Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 # Work out the gettext domain that libgeda should use
-AC_DEFUN([AX_LIBGEDACAIRO],
+AC_DEFUN([AX_LIBLEPTONRENDERER],
 [
   AC_PREREQ([2.60])dnl
 
   # First argument is the shared library version to use.
-  AC_MSG_CHECKING([libgedacairo shared library version])
+  AC_MSG_CHECKING([libleptonrenderer shared library version])
   AC_MSG_RESULT($1)
-  AC_SUBST([LIBGEDACAIRO_SHLIB_VERSION], $1)
+  AC_SUBST([LIBLEPTONRENDERER_SHLIB_VERSION], $1)
 ])


### PR DESCRIPTION
This branch is to close #54 and to address renaming of core libraries in #39.
The version number of the renamed library has been reset to 1.0.0.