### PR TITLE
Tidy up gattrib messaging

### DIFF
--- a/gattrib/src/gattrib.c
+++ b/gattrib/src/gattrib.c
@@ -149,7 +149,10 @@ void gattrib_main(void *closure, int argc, char *argv[])
   s_log_init ("gattrib");
 
   s_log_message
-    (_("gEDA/gattrib version %1$s%2$s.%3$s\ngEDA/gattrib comes with ABSOLUTELY NO WARRANTY; see COPYING for more details.\nThis is free software, and you are welcome to redistribute it under certain\nconditions; please see the COPYING file for more details.\n"),
+    (_("gEDA/gattrib version %1$s%2$s.%3$s\n"
+       "gEDA/gattrib comes with ABSOLUTELY NO WARRANTY; see COPYING for more details.\n"
+       "This is free software, and you are welcome to redistribute it under certain\n"
+       "conditions; please see the COPYING file for more details.\n"),
      PREPEND_VERSION_STRING, PACKAGE_DOTTED_VERSION,
      PACKAGE_DATE_VERSION);
 

--- a/gattrib/src/parsecmd.c
+++ b/gattrib/src/parsecmd.c
@@ -72,31 +72,33 @@ extern int optind;
 
 void usage(char *cmd)
 {
-    printf(_(
-"\n"
-"Gattrib:  The gEDA project\'s attribute editor.\n"
-"Presents schematic attributes in easy-to-edit spreadsheet format.\n"
-"\n"
-"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
-"  -q, --quiet            Quiet mode\n"
-"  -v, --verbose          Verbose mode on\n"
-"  -h, --help             This help menu\n"
-"\n"
-"  FAQ:\n"
-"  *  What do the colors of the cell text mean?\n"
-"     The cell colors indicate the visibility of the attribute.\n"
-"     Black = Visible attribute, value displayed only.\n"
-"     Grey  = Invisible attribute.\n"
-"     Red   = Visible attribute, name displayed only.\n"
-"     Blue  = Visible attribute, both name and value displayed.\n"
-"\n"
-"  *  What does the period (\".\") at the end of some component refdeses mean?\n"
-"     The period is placed after the refdeses of slotted components.\n"
-"     If slots are present on the component, then the different slots appear\n"
-"     in different rows with the slot number after the period.  Example:  C101.2.\n"
-"\n"
-"Copyright (C) 2003 -- 2006 Stuart D. Brorson.  E-mail: sdb (AT) cloud9 (DOT) net.\n"
-"\n"), cmd);
+    printf(_("\n"
+             "Gattrib:  The gEDA project\'s attribute editor.\n"
+             "Presents schematic attributes in easy-to-edit spreadsheet format.\n"
+             "\n"
+             "Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
+             "  -q, --quiet            Quiet mode\n"
+             "  -v, --verbose          Verbose mode on\n"
+             "  -h, --help             This help menu\n"
+             "\n"
+             "  FAQ:\n"
+             "  *  What do the colors of the cell text mean?\n"
+             "     The cell colors indicate the visibility of the attribute.\n"
+             "     Black = Visible attribute, value displayed only.\n"
+             "     Grey  = Invisible attribute.\n"
+             "     Red   = Visible attribute, name displayed only.\n"
+             "     Blue  = Visible attribute, both name and value displayed.\n"
+             "\n"
+             "  *  What does the period (\".\") at the end of some component refdeses mean?\n"
+             "     The period is placed after the refdeses of slotted components.\n"
+             "     If slots are present on the component, then the different slots appear\n"
+             "     in different rows with the slot number after the period.  Example:  C101.2.\n"
+             "\n"
+             "Copyright (C) 2003 -- 2006 Stuart D. Brorson.\n"
+             "\n"
+             "Please report bugs to %2$s.\n"),
+             cmd,
+             PACKAGE_BUGREPORT);
     exit(0);
 }
 


### PR DESCRIPTION
Fix up line lengths and indentation for gattrib's banner and help
text, remove SDB's obfuscated email address and replace with
lepton-eda issue tracker.