### PR TITLE
Fix postscript output in landscape orientation

### DIFF
--- a/gaf/export.c
+++ b/gaf/export.c
@@ -440,9 +440,21 @@ export_layout_page (PAGE *page, cairo_rectangle_t *extents, cairo_matrix_t *mtx)
 
   /* Finally, create and set a cairo transformation matrix that
    * centres the drawing into the drawable area. */
-  cairo_matrix_init (mtx, s, 0, 0, -s,
-                     - wx_min * s + drawable.x + slack[0],
-                     (wy_min + w_height) * s + drawable.y + slack[1]);
+
+  /* Create an initial matrix */
+  cairo_matrix_init_identity (mtx);
+
+  /* To understand how the following transformations work, read
+   * them from bottom to top. */
+  /* Align the matrix accounting for margins and 'slack' space. */
+  cairo_matrix_translate (mtx, drawable.x + slack[0], drawable.y + slack[1]);
+  /* Reverse the Y axis since the drawable origin is top-left
+   * while the schematic origin is bottom-left, and scale the
+   * matrix using the optimum scale factor found above. */
+  cairo_matrix_scale (mtx, s, -s);
+  /* Translate matrix to the drawable origin (its left-top
+     point) */
+  cairo_matrix_translate (mtx, -wx_min, -(wy_min + w_height));
 }
 
 /* Actually draws a page.  If page is NULL, uses the first open page. */


### PR DESCRIPTION
Reported by Karl Hammar. `gaf export` trimmed Postscript output for landscape pages since there were no special handing for it in code. 

For more details on why the previous code worked incorrectly, please see [this link](https://www.cairographics.org/documentation/using_the_postscript_surface/)

Since proposed PR's commits affect output in other formats,
and we have no automated tests for `gaf export` yet, testing is
much appreciated. The more the better :-) I tested only output for all formats on
several schematic files with or without margins and using a different scale. As for plain PS, `gs`, `gv` and `gv -nodsc` showed correct output (`evince` segfaulted on landscaped PS pages, though it looks like a bug in it or in its libraries).
