### PR TITLE
Add missing casts for various flags

### DIFF
--- a/gattrib/src/gtksheet_2_2.c
+++ b/gattrib/src/gtksheet_2_2.c
@@ -689,8 +689,10 @@ gtk_sheet_get_type ()
         NULL,
       };
       sheet_type =
-        g_type_register_static (GTK_TYPE_CONTAINER, "GtkSheet",
-                                &sheet_info, 0);
+        g_type_register_static (GTK_TYPE_CONTAINER,
+                                "GtkSheet",
+                                &sheet_info,
+                                (GTypeFlags) 0);
     }
   return sheet_type;
 }

--- a/gattrib/src/x_dialog.c
+++ b/gattrib/src/x_dialog.c
@@ -219,8 +219,8 @@ void x_dialog_unsaved_data()
   str = g_strconcat (str, "\n\n", tmp, NULL);
 
   dialog = gtk_message_dialog_new (GTK_WINDOW (window),
-                                   GTK_DIALOG_MODAL |
-                                     GTK_DIALOG_DESTROY_WITH_PARENT,
+                                   (GtkDialogFlags) (GTK_DIALOG_MODAL |
+                                                     GTK_DIALOG_DESTROY_WITH_PARENT),
                                      GTK_MESSAGE_WARNING,
                                    GTK_BUTTONS_NONE, NULL);
   gtk_message_dialog_set_markup (GTK_MESSAGE_DIALOG (dialog), str);

--- a/gschem/src/gschem_action.c
+++ b/gschem/src/gschem_action.c
@@ -198,7 +198,8 @@ GType gschem_action_get_type ()
 
     gschem_action_type = g_type_register_static (GTK_TYPE_ACTION,
                                                  "GschemAction",
-                                                 &gschem_action_info, 0);
+                                                 &gschem_action_info,
+                                                 (GTypeFlags) 0);
   }
 
   return gschem_action_type;

--- a/gschem/src/gschem_bin.c
+++ b/gschem/src/gschem_bin.c
@@ -65,7 +65,7 @@ gschem_bin_get_type ()
     type = g_type_register_static (GTK_TYPE_BIN,
                                    "GschemBin",
                                    &info,
-                                   0);
+                                   (GTypeFlags) 0);
   }
 
   return type;

--- a/gschem/src/gschem_binding.c
+++ b/gschem/src/gschem_binding.c
@@ -93,7 +93,7 @@ gschem_binding_get_type()
     type = g_type_register_static (G_TYPE_OBJECT,
                                    "GschemBinding",
                                    &info,
-                                   0);
+                                   (GTypeFlags) 0);
   }
 
   return type;

--- a/gschem/src/gschem_binding_integer.c
+++ b/gschem/src/gschem_binding_integer.c
@@ -99,7 +99,7 @@ gschem_binding_integer_get_type()
     type = g_type_register_static (GSCHEM_TYPE_BINDING,
                                    "GschemBindingInteger",
                                    &info,
-                                   0);
+                                   (GTypeFlags) 0);
   }
 
   return type;

--- a/gschem/src/gschem_bottom_widget.c
+++ b/gschem/src/gschem_bottom_widget.c
@@ -190,7 +190,8 @@ gschem_bottom_widget_class_init (GschemBottomWidgetClass *klass)
                                                      0,
                                                      (GRID_MODE_COUNT - 1),
                                                      GRID_MODE_NONE,
-                                                     G_PARAM_READWRITE | G_PARAM_CONSTRUCT));
+                                                     (GParamFlags) (G_PARAM_READWRITE
+                                                                    | G_PARAM_CONSTRUCT)));
 
   g_object_class_install_property (G_OBJECT_CLASS (klass),
                                    PROP_GRID_SIZE,
@@ -200,7 +201,8 @@ gschem_bottom_widget_class_init (GschemBottomWidgetClass *klass)
                                                      G_MININT,
                                                      G_MAXINT,
                                                      0,
-                                                     G_PARAM_READWRITE | G_PARAM_CONSTRUCT));
+                                                     (GParamFlags) (G_PARAM_READWRITE
+                                                                    | G_PARAM_CONSTRUCT)));
 
   g_object_class_install_property (G_OBJECT_CLASS (klass),
                                    PROP_LEFT_BUTTON_TEXT,
@@ -208,7 +210,8 @@ gschem_bottom_widget_class_init (GschemBottomWidgetClass *klass)
                                                         "Left Button Text",
                                                         "Left Button Text",
                                                         "none",
-                                                        G_PARAM_READWRITE | G_PARAM_CONSTRUCT));
+                                                        (GParamFlags) (G_PARAM_READWRITE
+                                                                       | G_PARAM_CONSTRUCT)));
 
   g_object_class_install_property (G_OBJECT_CLASS (klass),
                                    PROP_MIDDLE_BUTTON_TEXT,
@@ -216,7 +219,8 @@ gschem_bottom_widget_class_init (GschemBottomWidgetClass *klass)
                                                         "Middle Button Text",
                                                         "Middle Button Text",
                                                         "none",
-                                                        G_PARAM_READWRITE | G_PARAM_CONSTRUCT));
+                                                        (GParamFlags) (G_PARAM_READWRITE
+                                                                       | G_PARAM_CONSTRUCT)));
 
   g_object_class_install_property (G_OBJECT_CLASS (klass),
                                    PROP_RIGHT_BUTTON_TEXT,
@@ -224,7 +228,8 @@ gschem_bottom_widget_class_init (GschemBottomWidgetClass *klass)
                                                         "Right Button Text",
                                                         "Right Button Text",
                                                         "none",
-                                                        G_PARAM_READWRITE | G_PARAM_CONSTRUCT));
+                                                        (GParamFlags) (G_PARAM_READWRITE
+                                                                       | G_PARAM_CONSTRUCT)));
 
   g_object_class_install_property (G_OBJECT_CLASS (klass),
                                    PROP_SNAP_MODE,
@@ -234,7 +239,8 @@ gschem_bottom_widget_class_init (GschemBottomWidgetClass *klass)
                                                      G_MININT,
                                                      G_MAXINT,
                                                      0,
-                                                     G_PARAM_READWRITE | G_PARAM_CONSTRUCT));
+                                                     (GParamFlags) (G_PARAM_READWRITE
+                                                                    | G_PARAM_CONSTRUCT)));
 
   g_object_class_install_property (G_OBJECT_CLASS (klass),
                                    PROP_SNAP_SIZE,
@@ -244,7 +250,8 @@ gschem_bottom_widget_class_init (GschemBottomWidgetClass *klass)
                                                      G_MININT,
                                                      G_MAXINT,
                                                      0,
-                                                     G_PARAM_READWRITE | G_PARAM_CONSTRUCT));
+                                                     (GParamFlags) (G_PARAM_READWRITE
+                                                                    | G_PARAM_CONSTRUCT)));
 
   g_object_class_install_property (G_OBJECT_CLASS (klass),
                                    PROP_STATUS_TEXT,
@@ -252,7 +259,8 @@ gschem_bottom_widget_class_init (GschemBottomWidgetClass *klass)
                                                         "Status Text",
                                                         "Status Text",
                                                         "none",
-                                                        G_PARAM_READWRITE | G_PARAM_CONSTRUCT));
+                                                        (GParamFlags) (G_PARAM_READWRITE
+                                                                       | G_PARAM_CONSTRUCT)));
 
   g_object_class_install_property (G_OBJECT_CLASS (klass),
                                    PROP_STATUS_TEXT_COLOR,
@@ -260,7 +268,8 @@ gschem_bottom_widget_class_init (GschemBottomWidgetClass *klass)
                                                          "Status State",
                                                          "Status State",
                                                          FALSE,
-                                                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT));
+                                                         (GParamFlags) (G_PARAM_READWRITE
+                                                                        | G_PARAM_CONSTRUCT)));
 }
 
 

--- a/gschem/src/gschem_bottom_widget.c
+++ b/gschem/src/gschem_bottom_widget.c
@@ -414,7 +414,10 @@ gschem_bottom_widget_get_type ()
       (GInstanceInitFunc) gschem_bottom_widget_init,
     };
 
-    type = g_type_register_static (GTK_TYPE_HBOX, "GschemBottomWidget", &info, 0);
+    type = g_type_register_static (GTK_TYPE_HBOX,
+                                   "GschemBottomWidget",
+                                   &info,
+                                   (GTypeFlags) 0);
   }
 
   return type;

--- a/gschem/src/gschem_close_confirmation_dialog.c
+++ b/gschem/src/gschem_close_confirmation_dialog.c
@@ -118,7 +118,8 @@ close_confirmation_dialog_get_type ()
     close_confirmation_dialog_type =
       g_type_register_static (GTK_TYPE_DIALOG,
                               "CloseConfirmationDialog",
-                              &close_confirmation_dialog_info, 0);
+                              &close_confirmation_dialog_info,
+                              (GTypeFlags) 0);
   }
 
   return close_confirmation_dialog_type;

--- a/gschem/src/gschem_close_confirmation_dialog.c
+++ b/gschem/src/gschem_close_confirmation_dialog.c
@@ -140,13 +140,15 @@ close_confirmation_dialog_class_init (CloseConfirmationDialogClass *klass)
     g_param_spec_pointer ("unsaved-page",
                           "",
                           "",
-                          G_PARAM_CONSTRUCT_ONLY | G_PARAM_WRITABLE));
+                          (GParamFlags) (G_PARAM_CONSTRUCT_ONLY
+                                         | G_PARAM_WRITABLE)));
   g_object_class_install_property (
     gobject_class, PROP_UNSAVED_PAGES,
     g_param_spec_pointer ("unsaved-pages",
                           "",
                           "",
-                          G_PARAM_CONSTRUCT_ONLY | G_PARAM_WRITABLE));
+                          (GParamFlags) (G_PARAM_CONSTRUCT_ONLY
+                                         | G_PARAM_WRITABLE)));
   g_object_class_install_property (
     gobject_class, PROP_SELECTED_PAGES,
     g_param_spec_pointer ("selected-pages",

--- a/gschem/src/gschem_coord_dialog.c
+++ b/gschem/src/gschem_coord_dialog.c
@@ -86,7 +86,7 @@ void coord_dialog (GschemToplevel *w_current, int x, int y)
   if (!w_current->cowindow) {
     w_current->cowindow = gschem_dialog_new_with_buttons(_("Coords"),
                                                          GTK_WINDOW(w_current->main_window),
-                                                         0, /* Not modal GTK_DIALOG_MODAL */
+                                                         (GtkDialogFlags) 0, /* Not modal GTK_DIALOG_MODAL */
                                                          "coord", w_current,
                                                          GTK_STOCK_CLOSE,
                                                          GTK_RESPONSE_REJECT,

--- a/gschem/src/gschem_dialog.c
+++ b/gschem/src/gschem_dialog.c
@@ -329,13 +329,15 @@ static void gschem_dialog_class_init (GschemDialogClass *klass)
                          "",
                          "",
                          NULL,
-                         G_PARAM_CONSTRUCT_ONLY | G_PARAM_READWRITE));
+                         (GParamFlags) (G_PARAM_CONSTRUCT_ONLY
+                                        | G_PARAM_READWRITE)));
   g_object_class_install_property (
     gobject_class, PROP_GSCHEM_TOPLEVEL,
     g_param_spec_pointer ("gschem-toplevel",
                           "",
                           "",
-                          G_PARAM_CONSTRUCT_ONLY | G_PARAM_READWRITE));
+                          (GParamFlags) (G_PARAM_CONSTRUCT_ONLY
+                                         | G_PARAM_READWRITE)));
 }
 
 

--- a/gschem/src/gschem_dialog.c
+++ b/gschem/src/gschem_dialog.c
@@ -369,7 +369,8 @@ GType gschem_dialog_get_type ()
 
     gschem_dialog_type = g_type_register_static (GTK_TYPE_DIALOG,
                                                  "GschemDialog",
-                                                 &gschem_dialog_info, 0);
+                                                 &gschem_dialog_info,
+                                                 (GTypeFlags) 0);
   }
 
   return gschem_dialog_type;

--- a/gschem/src/gschem_fill_swatch_cell_renderer.c
+++ b/gschem/src/gschem_fill_swatch_cell_renderer.c
@@ -104,7 +104,7 @@ gschem_fill_swatch_cell_renderer_get_type ()
     type = g_type_register_static (GTK_TYPE_CELL_RENDERER_TEXT,
                                    "GschemFillSwatchCellRenderer",
                                    &info,
-                                   0);
+                                   (GTypeFlags) 0);
   }
 
   return type;

--- a/gschem/src/gschem_find_text_state.c
+++ b/gschem/src/gschem_find_text_state.c
@@ -172,7 +172,7 @@ gschem_find_text_state_get_type ()
     type = g_type_register_static (GSCHEM_TYPE_BIN,
                                    "GschemFindTextState",
                                    &info,
-                                   0);
+                                   (GTypeFlags) 0);
   }
 
   return type;

--- a/gschem/src/gschem_find_text_state.c
+++ b/gschem/src/gschem_find_text_state.c
@@ -449,8 +449,8 @@ find_objects_using_regex (GSList *pages, const char *text, GError **error)
   g_return_val_if_fail (text != NULL, NULL);
 
   regex = g_regex_new (text,
-                       0,
-                       0,
+                       (GRegexCompileFlags) 0,
+                       (GRegexMatchFlags) 0,
                        &ierror);
 
   if (ierror != NULL) {
@@ -497,7 +497,7 @@ find_objects_using_regex (GSList *pages, const char *text, GError **error)
         continue;
       }
 
-      if (g_regex_match (regex, str, 0, NULL)) {
+      if (g_regex_match (regex, str, (GRegexMatchFlags) 0, NULL)) {
         object_list = g_slist_prepend (object_list, object);
       }
     }

--- a/gschem/src/gschem_find_text_state.c
+++ b/gschem/src/gschem_find_text_state.c
@@ -279,7 +279,7 @@ class_init (GschemFindTextStateClass *klass)
 
   g_signal_new ("select-object",                     /* signal_name  */
                 G_OBJECT_CLASS_TYPE (klass),         /* itype        */
-                0,                                   /* signal_flags */
+                (GSignalFlags) 0,                    /* signal_flags */
                 0,                                   /* class_offset */
                 NULL,                                /* accumulator  */
                 NULL,                                /* accu_data    */

--- a/gschem/src/gschem_find_text_widget.c
+++ b/gschem/src/gschem_find_text_widget.c
@@ -245,7 +245,8 @@ gschem_find_text_widget_class_init (GschemFindTextWidgetClass *klass)
                                                          "Descend",
                                                          "Descend",
                                                          FALSE,
-                                                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT));
+                                                         (GParamFlags) (G_PARAM_READWRITE
+                                                                        | G_PARAM_CONSTRUCT)));
 
   g_object_class_install_property (G_OBJECT_CLASS (klass),
                                    PROP_FIND_TYPE,
@@ -255,7 +256,8 @@ gschem_find_text_widget_class_init (GschemFindTextWidgetClass *klass)
                                                      0,
                                                      2,
                                                      FIND_TYPE_SUBSTRING,
-                                                     G_PARAM_READWRITE | G_PARAM_CONSTRUCT));
+                                                     (GParamFlags) (G_PARAM_READWRITE
+                                                                    | G_PARAM_CONSTRUCT)));
 
   g_object_class_install_property (G_OBJECT_CLASS (klass),
                                    PROP_FIND_TEXT_STRING,
@@ -263,7 +265,8 @@ gschem_find_text_widget_class_init (GschemFindTextWidgetClass *klass)
                                                         "Find Text String",
                                                         "Find Text String",
                                                         "",
-                                                        G_PARAM_READWRITE | G_PARAM_CONSTRUCT));
+                                                        (GParamFlags) (G_PARAM_READWRITE
+                                                                       | G_PARAM_CONSTRUCT)));
 }
 
 

--- a/gschem/src/gschem_find_text_widget.c
+++ b/gschem/src/gschem_find_text_widget.c
@@ -361,7 +361,10 @@ gschem_find_text_widget_get_type ()
       (GInstanceInitFunc) gschem_find_text_widget_init,
     };
 
-    type = g_type_register_static (GTK_TYPE_INFO_BAR, "GschemFindTextWidget", &info, 0);
+    type = g_type_register_static (GTK_TYPE_INFO_BAR,
+                                   "GschemFindTextWidget",
+                                   &info,
+                                   (GTypeFlags) 0);
   }
 
   return type;

--- a/gschem/src/gschem_hotkey_dialog.c
+++ b/gschem/src/gschem_hotkey_dialog.c
@@ -129,7 +129,7 @@ void x_dialog_hotkeys (GschemToplevel *w_current)
   if (!w_current->hkwindow) {
     w_current->hkwindow = gschem_dialog_new_with_buttons(_("Hotkeys"),
                                                          GTK_WINDOW(w_current->main_window),
-                                                         0, /* not modal */
+                                                         (GtkDialogFlags) 0, /* not modal */
                                                          "hotkeys", w_current,
                                                          GTK_STOCK_CLOSE,
                                                          GTK_RESPONSE_REJECT,

--- a/gschem/src/gschem_integer_combo_box.c
+++ b/gschem/src/gschem_integer_combo_box.c
@@ -121,7 +121,7 @@ gschem_integer_combo_box_class_init (GschemIntegerComboBoxClass *klass)
 
   g_signal_new ("apply",                          /* signal_name  */
                 G_OBJECT_CLASS_TYPE (klass),      /* itype        */
-                0,                                /* signal_flags */
+                (GSignalFlags) 0,                 /* signal_flags */
                 0,                                /* class_offset */
                 NULL,                             /* accumulator  */
                 NULL,                             /* accu_data    */

--- a/gschem/src/gschem_integer_combo_box.c
+++ b/gschem/src/gschem_integer_combo_box.c
@@ -156,7 +156,10 @@ gschem_integer_combo_box_get_type()
     };
 
 #if GTK_CHECK_VERSION (2, 24, 0)
-    type = g_type_register_static (GTK_TYPE_COMBO_BOX, "GschemIntegerComboBox", &info, 0);
+    type = g_type_register_static (GTK_TYPE_COMBO_BOX,
+                                   "GschemIntegerComboBox",
+                                   &info,
+                                   (GTypeFlags) 0);
 #else
     type = g_type_register_static (GTK_TYPE_COMBO_BOX_ENTRY, "GschemIntegerComboBox", &info, 0);
 #endif

--- a/gschem/src/gschem_log_widget.c
+++ b/gschem/src/gschem_log_widget.c
@@ -90,7 +90,7 @@ gschem_log_widget_get_type ()
     type = g_type_register_static (GSCHEM_TYPE_BIN,
                                    "GschemLogWidget",
                                    &info,
-                                   0);
+                                   (GTypeFlags) 0);
   }
 
   return type;

--- a/gschem/src/gschem_macro_widget.c
+++ b/gschem/src/gschem_macro_widget.c
@@ -282,7 +282,10 @@ gschem_macro_widget_get_type ()
       (GInstanceInitFunc) gschem_macro_widget_init,
     };
 
-    type = g_type_register_static (GTK_TYPE_INFO_BAR, "GschemMacroWidget", &info, 0);
+    type = g_type_register_static (GTK_TYPE_INFO_BAR,
+                                   "GschemMacroWidget",
+                                   &info,
+                                   (GTypeFlags)  0);
   }
 
   return type;

--- a/gschem/src/gschem_macro_widget.c
+++ b/gschem/src/gschem_macro_widget.c
@@ -202,7 +202,8 @@ gschem_macro_widget_class_init (GschemMacroWidgetClass *klass)
                                                         "Label Text",
                                                         "Label Text",
                                                         _("Macro:"),
-                                                        G_PARAM_READWRITE | G_PARAM_CONSTRUCT));
+                                                        (GParamFlags) (G_PARAM_READWRITE
+                                                                       | G_PARAM_CONSTRUCT)));
 
   g_object_class_install_property (G_OBJECT_CLASS (klass),
                                    PROP_MACRO_STRING,
@@ -210,7 +211,8 @@ gschem_macro_widget_class_init (GschemMacroWidgetClass *klass)
                                                         "Macro String",
                                                         "Macro String",
                                                         "",
-                                                        G_PARAM_READWRITE | G_PARAM_CONSTRUCT));
+                                                        (GParamFlags) (G_PARAM_READWRITE
+                                                                       | G_PARAM_CONSTRUCT)));
 }
 
 

--- a/gschem/src/gschem_main_window.c
+++ b/gschem/src/gschem_main_window.c
@@ -103,7 +103,10 @@ gschem_main_window_get_type ()
       (GInstanceInitFunc) gschem_main_window_init,
     };
 
-    type = g_type_register_static (GTK_TYPE_WINDOW, "GschemMainWindow", &info, 0);
+    type = g_type_register_static (GTK_TYPE_WINDOW,
+                                   "GschemMainWindow",
+                                   &info,
+                                   (GTypeFlags) 0);
   }
 
   return type;

--- a/gschem/src/gschem_object_properties_widget.c
+++ b/gschem/src/gschem_object_properties_widget.c
@@ -245,7 +245,8 @@ class_init (GschemObjectPropertiesWidgetClass *klass)
     g_param_spec_pointer ("gschem-toplevel",
                           "",
                           "",
-                          G_PARAM_CONSTRUCT_ONLY | G_PARAM_READWRITE));
+                          (GParamFlags) (G_PARAM_CONSTRUCT_ONLY
+                                         | G_PARAM_READWRITE)));
 }
 
 

--- a/gschem/src/gschem_object_properties_widget.c
+++ b/gschem/src/gschem_object_properties_widget.c
@@ -127,7 +127,10 @@ gschem_object_properties_widget_get_type()
       (GInstanceInitFunc) instance_init,
     };
 
-    type = g_type_register_static (GSCHEM_TYPE_BIN, "GschemObjectPropertiesWidget", &info, 0);
+    type = g_type_register_static (GSCHEM_TYPE_BIN,
+                                   "GschemObjectPropertiesWidget",
+                                   &info,
+                                   (GTypeFlags) 0);
   }
 
   return type;

--- a/gschem/src/gschem_options.c
+++ b/gschem/src/gschem_options.c
@@ -410,7 +410,9 @@ class_init (GschemOptionsClass *klass)
                                                      0,
                                                      (GRID_MODE_COUNT - 1),
                                                      DEFAULT_GRID_MODE,
-                                                     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_CONSTRUCT));
+                                                     (GParamFlags) (G_PARAM_READWRITE
+                                                                    | G_PARAM_STATIC_STRINGS
+                                                                    | G_PARAM_CONSTRUCT)));
 
   g_object_class_install_property (G_OBJECT_CLASS (klass),
                                    PROP_MAGNETIC_NET_MODE,
@@ -418,7 +420,9 @@ class_init (GschemOptionsClass *klass)
                                                          "Magnetic Net Mode",
                                                          "magnetic Net Mode",
                                                          DEFAULT_MAGNETIC_NET_MODE,
-                                                         G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_CONSTRUCT));
+                                                         (GParamFlags) (G_PARAM_READWRITE
+                                                                        | G_PARAM_STATIC_STRINGS
+                                                                        | G_PARAM_CONSTRUCT)));
 
   g_object_class_install_property (G_OBJECT_CLASS (klass),
                                    PROP_NET_RUBBER_BAND_MODE,
@@ -426,7 +430,9 @@ class_init (GschemOptionsClass *klass)
                                                          "Net Rubber Band Mode",
                                                          "Net Rubber Band Mode",
                                                          DEFAULT_NET_RUBBER_BAND_MODE,
-                                                         G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_CONSTRUCT));
+                                                         (GParamFlags) (G_PARAM_READWRITE
+                                                                        | G_PARAM_STATIC_STRINGS
+                                                                        | G_PARAM_CONSTRUCT)));
 
   g_object_class_install_property (G_OBJECT_CLASS (klass),
                                    PROP_SNAP_MODE,
@@ -436,7 +442,9 @@ class_init (GschemOptionsClass *klass)
                                                      0,
                                                      SNAP_STATE_COUNT - 1,
                                                      SNAP_GRID,
-                                                     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_CONSTRUCT));
+                                                     (GParamFlags) (G_PARAM_READWRITE
+                                                                    | G_PARAM_STATIC_STRINGS
+                                                                    | G_PARAM_CONSTRUCT)));
 
   g_object_class_install_property (G_OBJECT_CLASS (klass),
                                    PROP_SNAP_SIZE,
@@ -446,7 +454,9 @@ class_init (GschemOptionsClass *klass)
                                                      MINIMUM_SNAP_SIZE,
                                                      MAXIMUM_SNAP_SIZE,
                                                      DEFAULT_SNAP_SIZE,
-                                                     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_CONSTRUCT));
+                                                     (GParamFlags) (G_PARAM_READWRITE
+                                                                    | G_PARAM_STATIC_STRINGS
+                                                                    | G_PARAM_CONSTRUCT)));
 }
 
 

--- a/gschem/src/gschem_options.c
+++ b/gschem/src/gschem_options.c
@@ -233,7 +233,10 @@ gschem_options_get_type ()
       (GInstanceInitFunc) instance_init,
     };
 
-    type = g_type_register_static (G_TYPE_OBJECT, "GschemOptions", &info, 0);
+    type = g_type_register_static (G_TYPE_OBJECT,
+                                   "GschemOptions",
+                                   &info,
+                                   (GTypeFlags) 0);
   }
 
   return type;

--- a/gschem/src/gschem_options_widget.c
+++ b/gschem/src/gschem_options_widget.c
@@ -151,7 +151,7 @@ gschem_options_widget_get_type ()
     type = g_type_register_static (GSCHEM_TYPE_BIN,
                                    "GschemOptionsWidget",
                                    &info,
-                                   0);
+                                   (GTypeFlags) 0);
   }
 
   return type;

--- a/gschem/src/gschem_options_widget.c
+++ b/gschem/src/gschem_options_widget.c
@@ -228,7 +228,8 @@ class_init (GschemOptionsWidgetClass *klass)
                                    g_param_spec_pointer ("gschem-toplevel",
                                                          "",
                                                          "",
-                                                         G_PARAM_CONSTRUCT_ONLY | G_PARAM_READWRITE));
+                                                         (GParamFlags) (G_PARAM_CONSTRUCT_ONLY
+                                                                        | G_PARAM_READWRITE)));
 }
 
 

--- a/gschem/src/gschem_page_view.c
+++ b/gschem/src/gschem_page_view.c
@@ -453,7 +453,10 @@ gschem_page_view_get_type ()
       (GInstanceInitFunc) gschem_page_view_init,
     };
 
-    type = g_type_register_static (GTK_TYPE_DRAWING_AREA, "GschemPageView", &info, 0);
+    type = g_type_register_static (GTK_TYPE_DRAWING_AREA,
+                                   "GschemPageView",
+                                   &info,
+                                   (GTypeFlags) 0);
   }
 
   return type;

--- a/gschem/src/gschem_page_view.c
+++ b/gschem/src/gschem_page_view.c
@@ -315,7 +315,7 @@ gschem_page_view_class_init (GschemPageViewClass *klass)
   GTK_WIDGET_CLASS (klass)->set_scroll_adjustments_signal = g_signal_new (
     "set-scroll-adjustments",
     G_OBJECT_CLASS_TYPE (klass),
-    G_SIGNAL_RUN_LAST | G_SIGNAL_ACTION,
+    (GSignalFlags) (G_SIGNAL_RUN_LAST | G_SIGNAL_ACTION),
     0,
     NULL,
     NULL,
@@ -328,7 +328,7 @@ gschem_page_view_class_init (GschemPageViewClass *klass)
   g_signal_new (
     "update-grid-info",
     G_OBJECT_CLASS_TYPE (klass),
-    G_SIGNAL_RUN_LAST | G_SIGNAL_ACTION,
+    (GSignalFlags) (G_SIGNAL_RUN_LAST | G_SIGNAL_ACTION),
     0,
     NULL,
     NULL,

--- a/gschem/src/gschem_page_view.c
+++ b/gschem/src/gschem_page_view.c
@@ -283,14 +283,16 @@ gschem_page_view_class_init (GschemPageViewClass *klass)
                                                         "Horizontal adjustment",
                                                         "Horizontal adjustment",
                                                         GTK_TYPE_ADJUSTMENT,
-                                                        G_PARAM_READWRITE | G_PARAM_CONSTRUCT));
+                                                        (GParamFlags) (G_PARAM_READWRITE
+                                                                       | G_PARAM_CONSTRUCT)));
 
   g_object_class_install_property (G_OBJECT_CLASS (klass),
                                    PROP_PAGE,
                                    g_param_spec_pointer ("page",
                                                          "Page",
                                                          "Page",
-                                                         G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+                                                         (GParamFlags) (G_PARAM_READWRITE
+                                                                        | G_PARAM_STATIC_STRINGS)));
 
   g_object_class_install_property (G_OBJECT_CLASS (klass),
                                    PROP_PAGE_GEOMETRY,
@@ -298,7 +300,8 @@ gschem_page_view_class_init (GschemPageViewClass *klass)
                                                        "Page Geometry",
                                                        "Page Geometry",
                                                        GSCHEM_TYPE_PAGE_GEOMETRY,
-                                                       G_PARAM_READABLE | G_PARAM_STATIC_STRINGS));
+                                                       (GParamFlags) (G_PARAM_READABLE
+                                                                      | G_PARAM_STATIC_STRINGS)));
 
   g_object_class_install_property (G_OBJECT_CLASS (klass),
                                    PROP_VADJUSTMENT,
@@ -306,7 +309,8 @@ gschem_page_view_class_init (GschemPageViewClass *klass)
                                                         "Vertical adjustment",
                                                         "Vertical adjustment",
                                                         GTK_TYPE_ADJUSTMENT,
-                                                        G_PARAM_READWRITE | G_PARAM_CONSTRUCT));
+                                                        (GParamFlags) (G_PARAM_READWRITE
+                                                                       | G_PARAM_CONSTRUCT)));
 
   GTK_WIDGET_CLASS (klass)->set_scroll_adjustments_signal = g_signal_new (
     "set-scroll-adjustments",

--- a/gschem/src/gschem_preview.c
+++ b/gschem/src/gschem_preview.c
@@ -258,7 +258,8 @@ gschem_preview_get_type ()
 
     preview_type = g_type_register_static (GSCHEM_TYPE_PAGE_VIEW,
                                            "GschemPreview",
-                                           &preview_info, 0);
+                                           &preview_info,
+                                           (GTypeFlags) 0);
   }
 
   return preview_type;

--- a/gschem/src/gschem_selection_adapter.c
+++ b/gschem/src/gschem_selection_adapter.c
@@ -958,7 +958,10 @@ gschem_selection_adapter_get_type ()
       (GInstanceInitFunc) instance_init,
     };
 
-    type = g_type_register_static (G_TYPE_OBJECT, "GschemSelectionAdapter", &info, 0);
+    type = g_type_register_static (G_TYPE_OBJECT,
+                                   "GschemSelectionAdapter",
+                                   &info,
+                                   (GTypeFlags) 0);
   }
 
   return type;

--- a/gschem/src/gschem_selection_adapter.c
+++ b/gschem/src/gschem_selection_adapter.c
@@ -2155,7 +2155,7 @@ class_init (GschemSelectionAdapterClass *klass)
 
   g_signal_new ("handle-undo",                    /* signal_name  */
                 G_OBJECT_CLASS_TYPE (klass),      /* itype        */
-                0,                                /* signal_flags */
+                (GSignalFlags) 0,                 /* signal_flags */
                 0,                                /* class_offset */
                 NULL,                             /* accumulator  */
                 NULL,                             /* accu_data    */

--- a/gschem/src/gschem_selection_adapter.c
+++ b/gschem/src/gschem_selection_adapter.c
@@ -1957,7 +1957,8 @@ class_init (GschemSelectionAdapterClass *klass)
                                                      G_MININT,
                                                      G_MAXINT,
                                                      NO_SELECTION,
-                                                     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+                                                     (GParamFlags) (G_PARAM_READWRITE
+                                                                    | G_PARAM_STATIC_STRINGS)));
 
   g_object_class_install_property (G_OBJECT_CLASS (klass),
                                    PROP_DASH_LENGTH,
@@ -1967,7 +1968,8 @@ class_init (GschemSelectionAdapterClass *klass)
                                                      G_MININT,
                                                      G_MAXINT,
                                                      NO_SELECTION,
-                                                     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+                                                     (GParamFlags) (G_PARAM_READWRITE
+                                                                    | G_PARAM_STATIC_STRINGS)));
 
   g_object_class_install_property (G_OBJECT_CLASS (klass),
                                    PROP_DASH_SPACE,
@@ -1977,7 +1979,8 @@ class_init (GschemSelectionAdapterClass *klass)
                                                      G_MININT,
                                                      G_MAXINT,
                                                      NO_SELECTION,
-                                                     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+                                                     (GParamFlags) (G_PARAM_READWRITE
+                                                                    | G_PARAM_STATIC_STRINGS)));
 
   g_object_class_install_property (G_OBJECT_CLASS (klass),
                                    PROP_FILL_ANGLE1,
@@ -1987,7 +1990,8 @@ class_init (GschemSelectionAdapterClass *klass)
                                                      G_MININT,
                                                      G_MAXINT,
                                                      NO_SELECTION,
-                                                     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+                                                     (GParamFlags) (G_PARAM_READWRITE
+                                                                    | G_PARAM_STATIC_STRINGS)));
 
   g_object_class_install_property (G_OBJECT_CLASS (klass),
                                    PROP_FILL_ANGLE2,
@@ -1997,7 +2001,8 @@ class_init (GschemSelectionAdapterClass *klass)
                                                      G_MININT,
                                                      G_MAXINT,
                                                      NO_SELECTION,
-                                                     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+                                                     (GParamFlags) (G_PARAM_READWRITE
+                                                                    | G_PARAM_STATIC_STRINGS)));
 
   g_object_class_install_property (G_OBJECT_CLASS (klass),
                                    PROP_FILL_PITCH1,
@@ -2007,7 +2012,8 @@ class_init (GschemSelectionAdapterClass *klass)
                                                      G_MININT,
                                                      G_MAXINT,
                                                      NO_SELECTION,
-                                                     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+                                                     (GParamFlags) (G_PARAM_READWRITE
+                                                                    | G_PARAM_STATIC_STRINGS)));
 
   g_object_class_install_property (G_OBJECT_CLASS (klass),
                                    PROP_FILL_PITCH2,
@@ -2017,7 +2023,8 @@ class_init (GschemSelectionAdapterClass *klass)
                                                      G_MININT,
                                                      G_MAXINT,
                                                      NO_SELECTION,
-                                                     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+                                                     (GParamFlags) (G_PARAM_READWRITE
+                                                                    | G_PARAM_STATIC_STRINGS)));
 
   g_object_class_install_property (G_OBJECT_CLASS (klass),
                                    PROP_FILL_TYPE,
@@ -2027,7 +2034,8 @@ class_init (GschemSelectionAdapterClass *klass)
                                                      G_MININT,
                                                      G_MAXINT,
                                                      NO_SELECTION,
-                                                     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+                                                     (GParamFlags) (G_PARAM_READWRITE
+                                                                    | G_PARAM_STATIC_STRINGS)));
 
   g_object_class_install_property (G_OBJECT_CLASS (klass),
                                    PROP_FILL_WIDTH,
@@ -2037,7 +2045,8 @@ class_init (GschemSelectionAdapterClass *klass)
                                                      G_MININT,
                                                      G_MAXINT,
                                                      NO_SELECTION,
-                                                     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+                                                     (GParamFlags) (G_PARAM_READWRITE
+                                                                    | G_PARAM_STATIC_STRINGS)));
 
   g_object_class_install_property (G_OBJECT_CLASS (klass),
                                    PROP_LINE_TYPE,
@@ -2047,7 +2056,8 @@ class_init (GschemSelectionAdapterClass *klass)
                                                      G_MININT,
                                                      G_MAXINT,
                                                      NO_SELECTION,
-                                                     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+                                                     (GParamFlags) (G_PARAM_READWRITE
+                                                                    | G_PARAM_STATIC_STRINGS)));
 
 
   g_object_class_install_property (G_OBJECT_CLASS (klass),
@@ -2058,7 +2068,8 @@ class_init (GschemSelectionAdapterClass *klass)
                                                      G_MININT,
                                                      G_MAXINT,
                                                      NO_SELECTION,
-                                                     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+                                                     (GParamFlags) (G_PARAM_READWRITE
+                                                                    | G_PARAM_STATIC_STRINGS)));
 
   g_object_class_install_property (G_OBJECT_CLASS (klass),
                                    PROP_OBJECT_COLOR,
@@ -2068,7 +2079,8 @@ class_init (GschemSelectionAdapterClass *klass)
                                                      G_MININT,
                                                      G_MAXINT,
                                                      NO_SELECTION,
-                                                     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+                                                     (GParamFlags) (G_PARAM_READWRITE
+                                                                    | G_PARAM_STATIC_STRINGS)));
 
   g_object_class_install_property (G_OBJECT_CLASS (klass),
                                    PROP_PIN_TYPE,
@@ -2078,7 +2090,8 @@ class_init (GschemSelectionAdapterClass *klass)
                                                      G_MININT,
                                                      G_MAXINT,
                                                      NO_SELECTION,
-                                                     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+                                                     (GParamFlags) (G_PARAM_READWRITE
+                                                                    | G_PARAM_STATIC_STRINGS)));
 
   g_object_class_install_property (G_OBJECT_CLASS (klass),
                                    PROP_TEXT_ALIGNMENT,
@@ -2088,7 +2101,8 @@ class_init (GschemSelectionAdapterClass *klass)
                                                      G_MININT,
                                                      G_MAXINT,
                                                      NO_SELECTION,
-                                                     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+                                                     (GParamFlags) (G_PARAM_READWRITE
+                                                                    | G_PARAM_STATIC_STRINGS)));
 
   g_object_class_install_property (G_OBJECT_CLASS (klass),
                                    PROP_TEXT_COLOR,
@@ -2098,7 +2112,8 @@ class_init (GschemSelectionAdapterClass *klass)
                                                      G_MININT,
                                                      G_MAXINT,
                                                      NO_SELECTION,
-                                                     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+                                                     (GParamFlags) (G_PARAM_READWRITE
+                                                                    | G_PARAM_STATIC_STRINGS)));
 
   g_object_class_install_property (G_OBJECT_CLASS (klass),
                                    PROP_TEXT_ROTATION,
@@ -2108,7 +2123,8 @@ class_init (GschemSelectionAdapterClass *klass)
                                                      G_MININT,
                                                      G_MAXINT,
                                                      NO_SELECTION,
-                                                     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+                                                     (GParamFlags) (G_PARAM_READWRITE
+                                                                    | G_PARAM_STATIC_STRINGS)));
 
   g_object_class_install_property (G_OBJECT_CLASS (klass),
                                    PROP_TEXT_SIZE,
@@ -2118,7 +2134,8 @@ class_init (GschemSelectionAdapterClass *klass)
                                                      G_MININT,
                                                      G_MAXINT,
                                                      NO_SELECTION,
-                                                     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+                                                     (GParamFlags) (G_PARAM_READWRITE
+                                                                    | G_PARAM_STATIC_STRINGS)));
 
   g_object_class_install_property (G_OBJECT_CLASS (klass),
                                    PROP_TEXT_STRING,
@@ -2126,7 +2143,8 @@ class_init (GschemSelectionAdapterClass *klass)
                                                         "Text String",
                                                         "Text String",
                                                         NULL,
-                                                        G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+                                                        (GParamFlags) (G_PARAM_READWRITE
+                                                                       | G_PARAM_STATIC_STRINGS)));
 
   /* This signal indicates changes to the selection that requires the undo
    * manager save the state.

--- a/gschem/src/gschem_show_hide_text_widget.c
+++ b/gschem/src/gschem_show_hide_text_widget.c
@@ -252,7 +252,7 @@ gschem_show_hide_text_widget_get_type ()
     type = g_type_register_static (GTK_TYPE_INFO_BAR,
                                    "GschemShowHideTextWidget",
                                    &info,
-                                   0);
+                                   (GTypeFlags) 0);
   }
 
   return type;

--- a/gschem/src/gschem_show_hide_text_widget.c
+++ b/gschem/src/gschem_show_hide_text_widget.c
@@ -147,7 +147,8 @@ gschem_show_hide_text_widget_class_init (GschemShowHideTextWidgetClass *klass)
                                                         "Button Text",
                                                         "Button Text",
                                                         _("Hide"),
-                                                        G_PARAM_READWRITE | G_PARAM_CONSTRUCT));
+                                                        (GParamFlags) (G_PARAM_READWRITE
+                                                                       | G_PARAM_CONSTRUCT)));
 
   g_object_class_install_property (G_OBJECT_CLASS (klass),
                                    PROP_LABEL_TEXT,
@@ -155,7 +156,8 @@ gschem_show_hide_text_widget_class_init (GschemShowHideTextWidgetClass *klass)
                                                         "Label Text",
                                                         "Label Text",
                                                         _("Hide text starting with:"),
-                                                        G_PARAM_READWRITE | G_PARAM_CONSTRUCT));
+                                                        (GParamFlags) (G_PARAM_READWRITE
+                                                                       | G_PARAM_CONSTRUCT)));
 
   g_object_class_install_property (G_OBJECT_CLASS (klass),
                                    PROP_TEXT_STRING,
@@ -163,7 +165,8 @@ gschem_show_hide_text_widget_class_init (GschemShowHideTextWidgetClass *klass)
                                                         "Text String",
                                                         "Text String",
                                                         "",
-                                                        G_PARAM_READWRITE | G_PARAM_CONSTRUCT));
+                                                        (GParamFlags) (G_PARAM_READWRITE
+                                                                       | G_PARAM_CONSTRUCT)));
 }
 
 

--- a/gschem/src/gschem_swatch_column_renderer.c
+++ b/gschem/src/gschem_swatch_column_renderer.c
@@ -300,7 +300,10 @@ gschem_swatch_column_renderer_get_type()
       (GInstanceInitFunc) swatchcr_init,
     };
 
-    type = g_type_register_static (GTK_TYPE_CELL_RENDERER_TEXT, "GschemSwatchColumnRenderer", &info, 0);
+    type = g_type_register_static (GTK_TYPE_CELL_RENDERER_TEXT,
+                                   "GschemSwatchColumnRenderer",
+                                   &info,
+                                   (GTypeFlags) 0);
   }
 
   return type;

--- a/gschem/src/gschem_text_properties_widget.c
+++ b/gschem/src/gschem_text_properties_widget.c
@@ -229,7 +229,8 @@ class_init (GschemTextPropertiesWidgetClass *klass)
     g_param_spec_pointer ("gschem-toplevel",
                           "",
                           "",
-                          G_PARAM_CONSTRUCT_ONLY | G_PARAM_READWRITE));
+                          (GParamFlags) (G_PARAM_CONSTRUCT_ONLY
+                                         | G_PARAM_READWRITE)));
 }
 
 

--- a/gschem/src/gschem_text_properties_widget.c
+++ b/gschem/src/gschem_text_properties_widget.c
@@ -146,7 +146,7 @@ gschem_text_properties_widget_get_type ()
     type = g_type_register_static (GSCHEM_TYPE_BIN,
                                    "GschemTextPropertiesWidget",
                                    &info,
-                                   0);
+                                   (GTypeFlags) 0);
   }
 
   return type;

--- a/gschem/src/gschem_translate_widget.c
+++ b/gschem/src/gschem_translate_widget.c
@@ -237,7 +237,8 @@ class_init (GschemTranslateWidgetClass *klass)
                                                         "Label Text",
                                                         "Label Text",
                                                         _("Coordinate:"),
-                                                        G_PARAM_READWRITE | G_PARAM_CONSTRUCT));
+                                                        (GParamFlags) (G_PARAM_READWRITE
+                                                                       | G_PARAM_CONSTRUCT)));
 
   g_object_class_install_property (G_OBJECT_CLASS (klass),
                                    PROP_VALUE,
@@ -247,7 +248,8 @@ class_init (GschemTranslateWidgetClass *klass)
                                                      0,
                                                      G_MAXINT,
                                                      0,
-                                                     G_PARAM_READWRITE | G_PARAM_CONSTRUCT));
+                                                     (GParamFlags) (G_PARAM_READWRITE
+                                                                    | G_PARAM_CONSTRUCT)));
 }
 
 

--- a/gschem/src/gschem_translate_widget.c
+++ b/gschem/src/gschem_translate_widget.c
@@ -132,7 +132,7 @@ gschem_translate_widget_get_type ()
     type = g_type_register_static (GTK_TYPE_INFO_BAR,
                                    "GschemTranslateWidget",
                                    &info,
-                                   0);
+                                   (GTypeFlags) 0);
   }
 
   return type;

--- a/gschem/src/o_delete.c
+++ b/gschem/src/o_delete.c
@@ -74,11 +74,15 @@ void o_delete_selected (GschemToplevel *w_current)
   if (locked_num > 0) {
     GList *non_locked = NULL;
     gint resp;
-    GtkWidget *dialog = gtk_message_dialog_new (NULL,
-        GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT,
-        GTK_MESSAGE_QUESTION, GTK_BUTTONS_NONE,
-        ngettext ("Delete locked object?", "Delete %1$u locked objects?",
-          locked_num), locked_num);
+    GtkWidget *dialog =
+      gtk_message_dialog_new (NULL,
+                              (GtkDialogFlags) (GTK_DIALOG_MODAL
+                                                | GTK_DIALOG_DESTROY_WITH_PARENT),
+                              GTK_MESSAGE_QUESTION,
+                              GTK_BUTTONS_NONE,
+                              ngettext ("Delete locked object?",
+                                        "Delete %1$u locked objects?",                                                                                        locked_num),
+                              locked_num);
     gtk_dialog_add_buttons (GTK_DIALOG (dialog),
         GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL,
         GTK_STOCK_YES, GTK_RESPONSE_YES,

--- a/gschem/src/x_autonumber.c
+++ b/gschem/src/x_autonumber.c
@@ -1202,7 +1202,7 @@ GtkWidget* autonumber_create_dialog(GschemToplevel *w_current)
 
   autonumber_text = gschem_dialog_new_with_buttons(_("Autonumber text"),
                                                    GTK_WINDOW(w_current->main_window),
-                                                   0, /* not modal */
+                                                   (GtkDialogFlags) 0, /* not modal */
                                                    "autonumber", w_current,
                                                    GTK_STOCK_CLOSE,
                                                    GTK_RESPONSE_REJECT,

--- a/gschem/src/x_compselect.c
+++ b/gschem/src/x_compselect.c
@@ -1309,7 +1309,8 @@ compselect_get_type ()
 
     compselect_type = g_type_register_static (GSCHEM_TYPE_DIALOG,
                                               "Compselect",
-                                              &compselect_info, 0);
+                                              &compselect_info,
+                                              (GTypeFlags) 0);
   }
 
   return compselect_type;

--- a/gschem/src/x_dialog.c
+++ b/gschem/src/x_dialog.c
@@ -84,8 +84,8 @@ void generic_msg_dialog (const char *msg)
   GtkWidget *dialog;
 
   dialog = gtk_message_dialog_new (NULL,
-                                   GTK_DIALOG_MODAL |
-                                     GTK_DIALOG_DESTROY_WITH_PARENT,
+                                   (GtkDialogFlags) (GTK_DIALOG_MODAL |
+                                                     GTK_DIALOG_DESTROY_WITH_PARENT),
                                    GTK_MESSAGE_INFO,
                                    GTK_BUTTONS_OK,
                                    "%s", msg);
@@ -110,8 +110,8 @@ int generic_confirm_dialog (const char *msg)
   gint r;
 
   dialog = gtk_message_dialog_new (NULL,
-                                   GTK_DIALOG_MODAL |
-                                     GTK_DIALOG_DESTROY_WITH_PARENT,
+                                   (GtkDialogFlags) (GTK_DIALOG_MODAL |
+                                                     GTK_DIALOG_DESTROY_WITH_PARENT),
                                    GTK_MESSAGE_INFO,
                                    GTK_BUTTONS_OK_CANCEL,
                                    "%s", msg);

--- a/gschem/src/x_fileselect.c
+++ b/gschem/src/x_fileselect.c
@@ -283,8 +283,8 @@ x_fileselect_save (GschemToplevel *w_current)
     if ((filename != NULL) && g_file_test (filename, G_FILE_TEST_EXISTS)) {
       GtkWidget *checkdialog =
         gtk_message_dialog_new (GTK_WINDOW(dialog),
-                                (GTK_DIALOG_MODAL |
-                                 GTK_DIALOG_DESTROY_WITH_PARENT),
+                                (GtkDialogFlags) (GTK_DIALOG_MODAL |
+                                                  GTK_DIALOG_DESTROY_WITH_PARENT),
                                 GTK_MESSAGE_QUESTION,
                                 GTK_BUTTONS_YES_NO,
                                 _("The selected file `%1$s' already exists.\n\n"

--- a/gschem/src/x_image.c
+++ b/gschem/src/x_image.c
@@ -279,13 +279,14 @@ void x_image_lowlevel(GschemToplevel *w_current, const char* filename,
 
         /* Warn the user */
         dialog = gtk_message_dialog_new (GTK_WINDOW(w_current->main_window),
-            GTK_DIALOG_MODAL
-            | GTK_DIALOG_DESTROY_WITH_PARENT,
-            GTK_MESSAGE_ERROR,
-            GTK_BUTTONS_OK,
-            _("There was the following error when saving image with type %1$s to filename:\n%2$s\n\n%3$s.\n"),
-            filetype, filename, gerror->message
-            );
+                                         (GtkDialogFlags) (GTK_DIALOG_MODAL
+                                                           | GTK_DIALOG_DESTROY_WITH_PARENT),
+                                         GTK_MESSAGE_ERROR,
+                                         GTK_BUTTONS_OK,
+                                         _("There was the following error when saving image with type %1$s to filename:\n%2$s\n\n%3$s.\n"),
+                                         filetype,
+                                         filename,
+                                         gerror->message);
 
         gtk_dialog_run (GTK_DIALOG (dialog));
         gtk_widget_destroy (dialog);

--- a/gschem/src/x_multiattrib.c
+++ b/gschem/src/x_multiattrib.c
@@ -264,7 +264,8 @@ celltextview_get_type ()
 
     celltextview_type = g_type_register_static (GTK_TYPE_TEXT_VIEW,
                                                 "CellTextView",
-                                                &celltextview_info, 0);
+                                                &celltextview_info,
+                                                (GTypeFlags) 0);
     g_type_add_interface_static (celltextview_type,
                                  GTK_TYPE_CELL_EDITABLE,
                                  &cell_editable_info);
@@ -472,7 +473,8 @@ cellrenderermultilinetext_get_type ()
     cellrenderermultilinetext_type = g_type_register_static (
       GTK_TYPE_CELL_RENDERER_TEXT,
       "CellRendererMultiLineText",
-      &cellrenderermultilinetext_info, 0);
+      &cellrenderermultilinetext_info,
+      (GTypeFlags) 0);
   }
 
   return cellrenderermultilinetext_type;
@@ -1791,7 +1793,8 @@ multiattrib_get_type ()
 
     multiattrib_type = g_type_register_static (GSCHEM_TYPE_DIALOG,
                                                "Multiattrib",
-                                               &multiattrib_info, 0);
+                                               &multiattrib_info,
+                                               (GTypeFlags) 0);
   }
 
   return multiattrib_type;

--- a/gschem/src/x_newtext.c
+++ b/gschem/src/x_newtext.c
@@ -348,7 +348,10 @@ GType newtext_get_type()
       (GInstanceInitFunc) newtext_init,
     };
 
-    type = g_type_register_static (GSCHEM_TYPE_DIALOG, "NewText", &info, 0);
+    type = g_type_register_static (GSCHEM_TYPE_DIALOG,
+                                   "NewText",
+                                   &info,
+                                   (GTypeFlags) 0);
   }
 
   return type;

--- a/gschem/src/x_pagesel.c
+++ b/gschem/src/x_pagesel.c
@@ -335,7 +335,8 @@ GType pagesel_get_type()
 		
     pagesel_type = g_type_register_static (GSCHEM_TYPE_DIALOG,
                                            "Pagesel",
-                                           &pagesel_info, 0);
+                                           &pagesel_info,
+                                           (GTypeFlags) 0);
   }
   
   return pagesel_type;

--- a/liblepton/src/edaconfig.c
+++ b/liblepton/src/edaconfig.c
@@ -125,7 +125,9 @@ eda_config_class_init (EdaConfigClass *klass)
   /* Create signals */
   g_signal_new ("config-changed", /* signal name */
                 G_TYPE_FROM_CLASS (gobject_class), /* type */
-                G_SIGNAL_RUN_FIRST | G_SIGNAL_NO_RECURSE | G_SIGNAL_NO_HOOKS, /* flags */
+                (GSignalFlags) (G_SIGNAL_RUN_FIRST
+                                | G_SIGNAL_NO_RECURSE
+                                | G_SIGNAL_NO_HOOKS), /* flags */
                 G_STRUCT_OFFSET(EdaConfigClass, config_changed), /* class offset */
                 NULL, /* accumulator */
                 NULL, /* accumulator data */

--- a/liblepton/src/edaconfig.c
+++ b/liblepton/src/edaconfig.c
@@ -96,7 +96,8 @@ eda_config_class_init (EdaConfigClass *klass)
                                "Configuration file",
                                "Set underlying file for EdaConfig",
                                G_TYPE_FILE,
-                               G_PARAM_CONSTRUCT_ONLY | G_PARAM_READWRITE);
+                               (GParamFlags) (G_PARAM_CONSTRUCT_ONLY
+                                              | G_PARAM_READWRITE));
   g_object_class_install_property (gobject_class,
                                    PROP_CONFIG_FILE,
                                    pspec);
@@ -105,7 +106,8 @@ eda_config_class_init (EdaConfigClass *klass)
                                "Configuration context parent",
                                "Set parent configuration context for EdaConfig",
                                EDA_TYPE_CONFIG,
-                               G_PARAM_CONSTRUCT | G_PARAM_READWRITE);
+                               (GParamFlags) (G_PARAM_CONSTRUCT
+                                              | G_PARAM_READWRITE));
   g_object_class_install_property (gobject_class,
                                    PROP_CONFIG_PARENT,
                                    pspec);
@@ -114,7 +116,8 @@ eda_config_class_init (EdaConfigClass *klass)
                                 "Whether context is trusted",
                                 "Set whether configuration context is trusted config source.",
                                 FALSE /* default value */,
-                                G_PARAM_CONSTRUCT | G_PARAM_READWRITE);
+                                (GParamFlags) (G_PARAM_CONSTRUCT
+                                               | G_PARAM_READWRITE));
   g_object_class_install_property (gobject_class,
                                    PROP_CONFIG_TRUSTED,
                                    pspec);

--- a/liblepton/src/edaconfig.c
+++ b/liblepton/src/edaconfig.c
@@ -669,8 +669,8 @@ eda_config_load (EdaConfig *cfg, GError **error)
   GError *tmp_err = NULL;
   if (len != 0) { /* Don't load zero-length keyfiles */
     status = g_key_file_load_from_data (newkeyfile, buf, len,
-                                        (G_KEY_FILE_KEEP_COMMENTS
-                                         | G_KEY_FILE_KEEP_TRANSLATIONS),
+                                        (GKeyFileFlags) (G_KEY_FILE_KEEP_COMMENTS
+                                                         | G_KEY_FILE_KEEP_TRANSLATIONS),
                                         &tmp_err);
   } else {
     status = TRUE;

--- a/liblepton/src/edascmhookproxy.c
+++ b/liblepton/src/edascmhookproxy.c
@@ -73,8 +73,10 @@ edascm_hook_proxy_class_init (EdascmHookProxyClass *klass)
   klass->run = edascm_hook_proxy_default_run_handler;
 
   /* Install properties */
-  param_flags = (G_PARAM_READWRITE | G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
-                 G_PARAM_STATIC_BLURB);
+  param_flags = (GParamFlags) (G_PARAM_READWRITE
+                               | G_PARAM_STATIC_NAME
+                               | G_PARAM_STATIC_NICK
+                               | G_PARAM_STATIC_BLURB);
 
   g_object_class_install_property (gobject_class, PROP_HOOK,
                                    edascm_param_spec_scm ("hook",

--- a/liblepton/src/edascmvaluetypes.c
+++ b/liblepton/src/edascmvaluetypes.c
@@ -207,7 +207,7 @@ edascm_scm_get_type (void)
                                         g_intern_static_string ("SCM"), /* type_name */
                                         &info,  /* info */
                                         &finfo, /* finfo */
-                                        0);    /* type_flags */
+                                        (GTypeFlags) 0); /* type_flags */
 
     g_once_init_leave (&edascm_scm_type, type);
   }

--- a/liblepton/src/edascmvaluetypes.c
+++ b/liblepton/src/edascmvaluetypes.c
@@ -200,7 +200,7 @@ edascm_scm_get_type (void)
     };
 
     static const GTypeFundamentalInfo finfo = {
-      0, /* type_flags */
+      (GTypeFundamentalFlags) 0, /* type_flags */
     };
 
     type = g_type_register_fundamental (g_type_fundamental_next (),

--- a/liblepton/src/geda_list.c
+++ b/liblepton/src/geda_list.c
@@ -130,7 +130,10 @@ GType geda_list_get_type(void)
       0,                            /* n_preallocs */
       geda_list_instance_init       /* instance_init */
     };
-    type = g_type_register_static (G_TYPE_OBJECT, "GedaList", &info, 0);
+    type = g_type_register_static (G_TYPE_OBJECT,
+                                   "GedaList",
+                                   &info,
+                                   (GTypeFlags) 0);
   }
   return type;
 }

--- a/liblepton/src/geda_list.c
+++ b/liblepton/src/geda_list.c
@@ -95,7 +95,7 @@ static void geda_list_class_init( gpointer g_class, gpointer g_class_data )
   geda_list_signals[ CHANGED ] =
     g_signal_new ("changed",
                   G_OBJECT_CLASS_TYPE( gobject_class ),
-                  0     /*signal_flags */,
+                  (GSignalFlags) 0     /*signal_flags */,
                   0     /*class_offset */,
                   NULL, /* accumulator */
                   NULL, /* accu_data */

--- a/libleptonrenderer/edapangorenderer.c
+++ b/libleptonrenderer/edapangorenderer.c
@@ -111,11 +111,11 @@ eda_pango_renderer_class_init (EdaPangoRendererClass *klass)
                                    g_param_spec_pointer ("cairo-context",
                                                          _("Cairo context"),
                                                          _("The Cairo context for rendering"),
-                                                         G_PARAM_READWRITE
-                                                         | G_PARAM_CONSTRUCT_ONLY
-                                                         | G_PARAM_STATIC_NAME
-                                                         | G_PARAM_STATIC_NICK
-                                                         | G_PARAM_STATIC_BLURB));
+                                                         (GParamFlags) (G_PARAM_READWRITE
+                                                                        | G_PARAM_CONSTRUCT_ONLY
+                                                                        | G_PARAM_STATIC_NAME
+                                                                        | G_PARAM_STATIC_NICK
+                                                                        | G_PARAM_STATIC_BLURB)));
 }
 
 static void

--- a/libleptonrenderer/edarenderer.c
+++ b/libleptonrenderer/edarenderer.c
@@ -208,8 +208,10 @@ eda_renderer_class_init (EdaRendererClass *klass)
   klass->user_bounds = eda_renderer_default_get_user_bounds;
 
   /* Install properties */
-  param_flags = (G_PARAM_READWRITE | G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK |
-                 G_PARAM_STATIC_BLURB);
+  param_flags = (GParamFlags) (G_PARAM_READWRITE
+                               | G_PARAM_STATIC_NAME
+                               | G_PARAM_STATIC_NICK
+                               | G_PARAM_STATIC_BLURB);
 
   g_object_class_install_property (gobject_class, PROP_CAIRO_CONTEXT,
                                    g_param_spec_pointer ("cairo-context",


### PR DESCRIPTION
The branch fixes another set of cast errors found when building using g++. Basically, it just adds casts for cases when flags were not defined using G_* variables or when they were logically combined together.