### PR TITLE
Don't forward-declare enumerations in libleptonrenderer.

### DIFF
--- a/libleptonrenderer/edacairo.h
+++ b/libleptonrenderer/edacairo.h
@@ -22,11 +22,11 @@
 
 G_BEGIN_DECLS
 
-typedef enum _EdaCairoFlags EdaCairoFlags;
-
 enum _EdaCairoFlags {
   EDA_CAIRO_ENABLE_HINTS = 1,
 };
+
+typedef enum _EdaCairoFlags EdaCairoFlags;
 
 void eda_cairo_set_source_color (cairo_t *cr, int color, GArray *map);
 

--- a/libleptonrenderer/edarenderer.h
+++ b/libleptonrenderer/edarenderer.h
@@ -56,8 +56,6 @@ struct _EdaRenderer
 
 #define EDA_TYPE_RENDERER_FLAGS (eda_renderer_flags_get_type ())
 
-typedef enum _EdaRendererFlags EdaRendererFlags;
-
 enum _EdaRendererFlags
 {
   /* Should hinting be enabled? */
@@ -71,6 +69,8 @@ enum _EdaRendererFlags
   /* Should text origin markers be drawn? */
   EDA_RENDERER_FLAG_TEXT_ORIGIN = 1 << 4,
 };
+
+typedef enum _EdaRendererFlags EdaRendererFlags;
 
 GType eda_renderer_get_type (void) G_GNUC_CONST;
 GType eda_renderer_flags_get_type (void) G_GNUC_CONST;


### PR DESCRIPTION
This eliminates a lot of errors when compiling with g++.