### PR TITLE
Fix errors in search-rename() function and add inline documentation for it

### DIFF
--- a/gnetlist/scheme/gnetlist/rename.scm
+++ b/gnetlist/scheme/gnetlist/rename.scm
@@ -57,10 +57,11 @@
 (define-public (add-rename from to)
   (and from to (update-rename from to)))
 
-;;; if the src is found, return true
-;;; if the dest is found, also return true, but warn user
-;;; If quiet flag is true than don't print anything
 (define (search-rename from to quiet)
+  "Searches rename source FROM and rename destination TO in the
+internal netlist rename list. Returns #t if either FROM or TO is
+found. In the latter case, if QUIET is not #f warns the user that
+the net in question has been renamed several times."
   ;; FIXME[2017-02-20] This warning message is very unhelpful
   (define (warn)
     (when (not quiet)

--- a/gnetlist/scheme/gnetlist/rename.scm
+++ b/gnetlist/scheme/gnetlist/rename.scm
@@ -70,8 +70,8 @@
 are both a src and dest name
 This warning is okay if you have multiple levels of hierarchy!
 ")
-                  dest
-                  dest)))
+                  to
+                  to)))
 
   (cond
    ((renamed? from) #t)


### PR DESCRIPTION
The regression which has been fixed here is present in 1.9.3.