### PR TITLE
Add support for REPL readline history in gnetlist and gschem.

### DIFF
--- a/gnetlist/scheme/Makefile.am
+++ b/gnetlist/scheme/Makefile.am
@@ -28,7 +28,8 @@ DIST_SCM = gnet-PCB.scm gnet-allegro.scm gnet-bom.scm gnet-ewnet.scm \
 	   gnetlist/option.scm gnetlist/sort.scm gnetlist/verbose.scm \
 	   gnetlist/package.scm gnetlist/package-pin.scm gnetlist/pin-net.scm \
 	   gnetlist/traverse.scm gnetlist/schematic.scm gnetlist/config.scm \
-	   gnetlist/core/gettext.scm gnetlist/rename.scm gnetlist/port.scm
+	   gnetlist/core/gettext.scm gnetlist/rename.scm gnetlist/port.scm \
+	   gnetlist/repl.scm
 
 TESTS = unit-tests/test-gnetlist-partlist.scm \
 	unit-tests/test-gnetlist-attrib.scm

--- a/gnetlist/scheme/gnetlist.scm
+++ b/gnetlist/scheme/gnetlist.scm
@@ -18,9 +18,7 @@
 ;;; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
 ;;; MA 02111-1301 USA.
 
-(use-modules (system repl repl)
-             (system repl common)
-             (srfi srfi-1)
+(use-modules (srfi srfi-1)
              (srfi srfi-26)
              (ice-9 match)
              ((ice-9 rdelim)
@@ -33,6 +31,7 @@
              (geda page)
              (geda deprecated)
              (geda log)
+             (geda repl)
              (gnetlist core gettext)
              (gnetlist config)
              (gnetlist schematic)
@@ -303,25 +302,6 @@ REFDES. As a result, slots may be repeated in the returned list."
   )
 
 (define toplevel-schematic #f)
-(define (gnetlist-repl)
-  (let ((repl (make-repl (current-language) #f)))
-    (repl-eval repl
-               '(begin
-                  (display (_ "Welcome to Gnetlist REPL!\n")
-                           (current-error-port))
-                  (resolve-module '(ice-9 readline))
-                  ;; After resolving that module the variable
-                  ;; *features* should contain 'readline.
-                  (if (provided? 'readline)
-                      (begin
-                        ;; It is not loaded automatically from
-                        ;; this module, so let's force its
-                        ;; loading.
-                        (use-modules (ice-9 readline))
-                        (activate-readline))
-                      (display (_ "Could not load module (ice-9 readline).\n")
-                               (current-error-port)))))
-    (run-repl repl)))
 
 
 ;;; Helper function for sorting connections.
@@ -837,7 +817,7 @@ Run `~A --list-backends' for a full list of available backends.
               (print-gnetlist-config))
             (verbose-print-netlist (schematic-netlist toplevel-schematic))
             (if (gnetlist-option-ref 'interactive)
-                (gnetlist-repl)
+                (lepton-repl)
                 (if backend
                     (let ((backend-proc (primitive-eval (string->symbol backend))))
                       (if output-filename

--- a/gnetlist/scheme/gnetlist/repl.scm
+++ b/gnetlist/scheme/gnetlist/repl.scm
@@ -1,0 +1,27 @@
+;;; Lepton EDA
+;;; gnetlist - Lepton EDA netlister
+;;; Copyright (C) 2017 Lepton EDA Contributors
+;;;
+;;; This program is free software; you can redistribute it and/or modify
+;;; it under the terms of the GNU General Public License as published by
+;;; the Free Software Foundation; either version 2 of the License, or
+;;; (at your option) any later version.
+;;;
+;;; This program is distributed in the hope that it will be useful,
+;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;; GNU General Public License for more details.
+;;;
+;;; You should have received a copy of the GNU General Public License
+;;; along with this program; if not, write to the Free Software
+;;; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+;;; MA 02111-1301 USA.
+
+(define-module (gnetlist repl)
+  #:use-module (geda repl)
+
+  #:export (gnetlist-repl))
+
+(define (gnetlist-repl)
+  "Runs REPL in gnetlist interactive mode."
+  (lepton-repl ".lepton_netlist_history"))

--- a/gschem/scheme/gschem/builtins.scm
+++ b/gschem/scheme/gschem/builtins.scm
@@ -1,6 +1,7 @@
-;; gEDA - GPL Electronic Design Automation
+;; Lepton EDA
 ;; gschem - gEDA Schematic Capture - Scheme API
 ;; Copyright (C) 2013 Peter Brett <peter@peter-b.co.uk>
+;; Copyright (C) 2017 Lepton EDA Contributors
 ;;
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -19,6 +20,7 @@
 
 (define-module (gschem builtins)
   #:use-module (geda object)
+  #:use-module (geda repl)
   #:use-module (gschem core gettext)
   #:use-module (gschem core builtins)
   #:use-module (gschem action)
@@ -78,6 +80,7 @@
   (%file-close-window))
 
 (define-action-public (&file-quit #:label (_ "Quit") #:icon "gtk-quit")
+  (lepton-repl-save-history)
   (%file-quit))
 
 (define-action-public (&file-repl #:label (_ "Terminal REPL") #:icon "gtk-execute")

--- a/gschem/scheme/gschem/repl.scm
+++ b/gschem/scheme/gschem/repl.scm
@@ -1,6 +1,7 @@
-;; gEDA - GPL Electronic Design Automation
+;; Lepton EDA
 ;; gschem - gEDA Schematic Capture - Scheme API
 ;; Copyright (C) 2015 gEDA Contributors
+;; Copyright (C) 2017 Lepton EDA Contributors
 ;;
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -18,9 +19,8 @@
 ;;
 
 (define-module (gschem repl)
-
-  #:use-module (system repl repl)
+  #:use-module (geda repl)
   #:use-module (ice-9 threads))
 
 (define-public (start-repl-in-background-terminal)
-  (make-thread (start-repl)))
+  (begin-thread (lepton-repl)))

--- a/liblepton/po/POTFILES.in
+++ b/liblepton/po/POTFILES.in
@@ -36,3 +36,4 @@ liblepton/src/edascmhookproxy.c
 
 liblepton/scheme/geda/attrib.scm
 liblepton/scheme/geda/library.scm
+liblepton/scheme/geda/repl.scm

--- a/liblepton/scheme/Makefile.am
+++ b/liblepton/scheme/Makefile.am
@@ -4,7 +4,7 @@ nobase_dist_scmdata_DATA = \
 	geda.scm geda-deprecated-config.scm color-map.scm \
 	geda/object.scm geda/page.scm geda/attrib.scm geda/deprecated.scm \
 	geda/os.scm geda/config.scm geda/log-rotate.scm geda/log.scm \
-	geda/library.scm
+	geda/library.scm geda/repl.scm
 nobase_scmdata_DATA = geda/core/gettext.scm
 
 check-am: update-gaf-tool

--- a/liblepton/scheme/geda/repl.scm
+++ b/liblepton/scheme/geda/repl.scm
@@ -1,0 +1,78 @@
+;;; Lepton EDA
+;;; liblepton - Lepton's library - Scheme API
+;;; Copyright (C) 2017 Lepton EDA Contributors
+;;;
+;;; This program is free software; you can redistribute it and/or modify
+;;; it under the terms of the GNU General Public License as published by
+;;; the Free Software Foundation; either version 2 of the License, or
+;;; (at your option) any later version.
+;;;
+;;; This program is distributed in the hope that it will be useful,
+;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;; GNU General Public License for more details.
+;;;
+;;; You should have received a copy of the GNU General Public License
+;;; along with this program; if not, write to the Free Software
+;;; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+;;; MA 02111-1301 USA.
+
+;;; Lepton REPL with readline support
+
+(define-module (geda repl)
+  #:use-module (system repl repl)
+  #:use-module (system repl common)
+  #:use-module (geda core gettext)
+  #:use-module ((geda os) #:select (user-config-dir))
+
+  #:export (lepton-repl
+            lepton-repl-save-history
+            lepton-repl-welcome
+            lepton-repl-readline-warning))
+
+;;; The current user's readline history file.
+(define %default-history-filename ".lepton_history")
+
+;;; Absolute name of history file.
+(define history-filename (string-append (user-config-dir)
+                                        file-name-separator-string
+                                        %default-history-filename))
+
+(define (lepton-repl-save-history)
+  "Saves readline history of the current REPL."
+  (and (provided? 'readline)
+       ((@ (ice-9 readline) write-history) history-filename)))
+
+;;; Outputs Lepton REPL greeting.
+(define (lepton-repl-welcome)
+  (display (_ "Welcome to Lepton REPL!\n")))
+
+;;; Warning on systems where the 'readline feature is not
+;;; supported.
+(define (lepton-repl-readline-warning)
+  (display (_ "WARNING: Readline library is not supported in your configuration.\n")))
+
+(define* (lepton-repl)
+  "Runs interactive REPL in a terminal."
+  (let ((repl (make-repl (current-language) #f)))
+    (repl-eval repl
+               `(begin
+                  (use-modules (ice-9 session) ; help, apropos and such
+                               (system repl command) ; guile meta-commands
+                               (geda repl)) ; this module
+                  (lepton-repl-welcome)
+                  (resolve-module '(ice-9 readline))
+                  ;; After resolving that module the variable
+                  ;; *features* should contain 'readline.
+                  (if (provided? 'readline)
+                      (begin
+                        ;; Readline is not loaded automatically,
+                        ;; so let's force its loading.
+                        (use-modules (ice-9 readline))
+                        ((@ (ice-9 readline) activate-readline))
+                        ((@ (ice-9 readline) clear-history))
+                        ((@ (ice-9 readline) read-history) ,history-filename))
+                      (lepton-repl-readline-warning))))
+    (run-repl repl)
+    ;; Save history on normal REPL exit.
+    (lepton-repl-save-history)))


### PR DESCRIPTION
New module (geda repl) has been introduced, which is used both by
gnetlist and gschem.  The same readline history file
".lepton_history" residing in the user configuration directory is
used for all tools using this module.

The REPL history is saved if the user quits the REPL explicitly,
or, in gschem, if it closes gschem. The latter is not recommended
though, since it garbles terminal settings and the user needs to
`reset` the terminal to make it functional again.

Loading the module (ice-9 session) in REPL adds support for such
procedures as `apropos' and `help'. Loading (system repl command)
adds support for guile metacommands.