### PR TITLE
Fix g++ build errors for several utility tools

### DIFF
--- a/contrib/smash_megafile/smash_megafile.c
+++ b/contrib/smash_megafile/smash_megafile.c
@@ -98,7 +98,7 @@ int main(int argc, char **argv)
        */
 
       /* allocate some memory to hold the file */
-      extracted_file = malloc(len);
+      extracted_file = (char*) malloc(len);
 
       fread(extracted_file, len, 1, megafile);
 

--- a/gnetlist/src/s_traverse.c
+++ b/gnetlist/src/s_traverse.c
@@ -357,7 +357,7 @@ s_traverse_net (NET *nets, int starting, OBJECT *object, char *hierarchy_tag, in
 
   if (object->type == OBJ_PIN) {
 
-    verbose_print (starting ? "p" : "P");
+    starting ? verbose_print ("p") : verbose_print ("P");
 
     new_net->connected_to =
       s_net_return_connected_string (object, hierarchy_tag);

--- a/utils/src/gsch2pcb.c
+++ b/utils/src/gsch2pcb.c
@@ -574,9 +574,9 @@ insert_element (FILE * f_out, gchar * element_file,
     for (s = buf; *s == ' ' || *s == '\t'; ++s);
     if ((el = pcb_element_line_parse (s)) != NULL) {
       simple_translate (el);
-      fmt = el->quoted_flags ?
-        "Element%c\"%s\" \"%s\" \"%s\" \"%s\" %s %s%s\n" :
-        "Element%c%s \"%s\" \"%s\" \"%s\" %s %s%s\n";
+      fmt = (gchar*) (el->quoted_flags ?
+                      "Element%c\"%s\" \"%s\" \"%s\" \"%s\" %s %s%s\n" :
+                      "Element%c%s \"%s\" \"%s\" \"%s\" %s %s%s\n");
 
       fprintf (f_out, fmt,
                el->res_char, el->flags, footprint, refdes, value,
@@ -945,9 +945,9 @@ update_element_descriptions (gchar * pcb_file, gchar * bak)
     if ((el = pcb_element_line_parse (s)) != NULL
         && (el_exists = pcb_element_exists (el, FALSE)) != NULL
         && el_exists->changed_description) {
-      fmt = el->quoted_flags ?
-        "Element%c\"%s\" \"%s\" \"%s\" \"%s\" %s %s%s\n" :
-        "Element%c%s \"%s\" \"%s\" \"%s\" %s %s%s\n";
+      fmt = (gchar*) (el->quoted_flags ?
+                      "Element%c\"%s\" \"%s\" \"%s\" \"%s\" %s %s%s\n" :
+                      "Element%c%s \"%s\" \"%s\" \"%s\" %s %s%s\n");
       fprintf (f_out, fmt,
                el->res_char,
                el->flags, el_exists->changed_description,
@@ -1026,9 +1026,9 @@ prune_elements (gchar * pcb_file, gchar * bak)
       continue;
     }
     if (el_exists && el_exists->changed_value) {
-      fmt = el->quoted_flags ?
-        "Element%c\"%s\" \"%s\" \"%s\" \"%s\" %s %s%s\n" :
-        "Element%c%s \"%s\" \"%s\" \"%s\" %s %s%s\n";
+      fmt = (gchar*) (el->quoted_flags ?
+                      "Element%c\"%s\" \"%s\" \"%s\" \"%s\" %s %s%s\n" :
+                      "Element%c%s \"%s\" \"%s\" \"%s\" %s %s%s\n");
       fprintf (f_out, fmt,
                el->res_char, el->flags, el->description, el->refdes,
                el_exists->changed_value, el->x, el->y, el->tail);

--- a/utils/src/gsch2pcb.c
+++ b/utils/src/gsch2pcb.c
@@ -240,7 +240,7 @@ run_gnetlist (gchar * pins_file, gchar * net_file, gchar * pcb_file,
     gnetlist = "gnetlist";
 
   if (!verbose)
-    verboseList = g_list_append (verboseList, "-q");
+    verboseList = g_list_append (verboseList, (gpointer) "-q");
 
   if (!build_and_run_command ("%s %l -g pcbpins -o %s %l %l",
 			      gnetlist,
@@ -260,7 +260,7 @@ run_gnetlist (gchar * pins_file, gchar * net_file, gchar * pcb_file,
   create_m4_override_file ();
 
   if (m4_override_file) {
-    args1 = g_list_append (args1, "-m");
+    args1 = g_list_append (args1, (gpointer) "-m");
     args1 = g_list_append (args1, m4_override_file);
   }
 
@@ -1422,7 +1422,7 @@ main (gint argc, gchar ** argv)
 
   /* Defaults for the search path if not configured in the project file */
   if (g_file_test ("packages", G_FILE_TEST_IS_DIR))
-    element_directory_list = g_list_append (element_directory_list, "packages");
+    element_directory_list = g_list_append (element_directory_list, (gpointer) "packages");
 
 #define PCB_PATH_DELIMETER ":"
   if (verbose)


### PR DESCRIPTION
Another C++ compatibility patchset fixing g++ reported errors in gsch2pcb, gnetlist, and smash_megafile.