### PR TITLE
Enable build for all tools but gattrib in C++ mode

### DIFF
--- a/gschem/include/globals.h
+++ b/gschem/include/globals.h
@@ -26,9 +26,6 @@
 /* window list */
 extern GList *global_window_list;
 
-/* Manager for recently used files */
-GtkRecentManager *recent_manager;
-
 /* colors */
 extern GdkColor white;
 extern GdkColor black;

--- a/gschem/include/gschem_toplevel.h
+++ b/gschem/include/gschem_toplevel.h
@@ -100,6 +100,11 @@ struct st_gschem_toplevel {
   /* ----------------------------------------- */
   GschemSelectionAdapter *selection_adapter;
 
+  /* --------------------------------- */
+  /* Manager for "Open Recent..." menu */
+  /* --------------------------------- */
+  GtkRecentManager *recent_manager;
+
   /* ----------------- */
   /* Picture placement */
   /* ----------------- */

--- a/gschem/src/gschem_toplevel.c
+++ b/gschem/src/gschem_toplevel.c
@@ -193,6 +193,11 @@ GschemToplevel *gschem_toplevel_new ()
   w_current->coord_world  = NULL;
   w_current->coord_screen = NULL;
 
+  /* ------------------------------- */
+  /* Manager for recently used files */
+  /* ------------------------------- */
+  w_current->recent_manager = NULL;
+
   /* -------------------------------------- */
   /* Models for widgets inside dialog boxes */
   /* -------------------------------------- */

--- a/gschem/src/x_menus.c
+++ b/gschem/src/x_menus.c
@@ -371,7 +371,9 @@ recent_chooser_item_activated (GtkRecentChooser *chooser, GschemToplevel *w_curr
 
   uri = gtk_recent_chooser_get_current_uri (chooser);
   filename = g_filename_from_uri(uri, NULL, NULL);
-  gtk_recent_manager_add_item(recent_manager, uri);
+  if (w_current->recent_manager != NULL) {
+    gtk_recent_manager_add_item (w_current->recent_manager, uri);
+  }
   page = x_window_open_page(w_current, (char *)filename);
   x_window_set_current_page(w_current, page);
 
@@ -389,9 +391,11 @@ void x_menu_attach_recent_files_submenu(GschemToplevel *w_current)
   GtkWidget* menuitem_to_append_to = NULL;
   GtkRecentFilter *recent_filter;
   GtkWidget *menuitem_file_recent_items;
-  recent_manager = gtk_recent_manager_get_default();
 
-  menuitem_file_recent_items = gtk_recent_chooser_menu_new_for_manager(recent_manager);
+  w_current->recent_manager = gtk_recent_manager_get_default ();
+
+  menuitem_file_recent_items =
+    gtk_recent_chooser_menu_new_for_manager (w_current->recent_manager);
 
   /* Show only schematic- and symbol-files (*.sch and *.sym) in list */
   recent_filter = gtk_recent_filter_new();

--- a/gschem/src/x_stroke.c
+++ b/gschem/src/x_stroke.c
@@ -22,7 +22,12 @@
 #include "gschem.h"
 
 #ifdef HAVE_LIBSTROKE
+
+/* libstroke seems to not have C++ support declarations so we add
+   them explicitly here */
+G_BEGIN_DECLS
 #include <stroke.h>
+G_END_DECLS
 
 /*
  * <B>stroke_points</B> is an array of points for the stroke

--- a/gschem/src/x_window.c
+++ b/gschem/src/x_window.c
@@ -936,7 +936,10 @@ x_window_open_page (GschemToplevel *w_current, const gchar *filename)
       gtk_widget_destroy (dialog);
       g_error_free (err);
     } else {
-      gtk_recent_manager_add_item (recent_manager, g_filename_to_uri(fn, NULL, NULL));
+      if (w_current->recent_manager != NULL) {
+        gtk_recent_manager_add_item (w_current->recent_manager,
+                                     g_filename_to_uri(fn, NULL, NULL));
+      }
     }
   } else {
     if (!quiet_mode)
@@ -1049,7 +1052,10 @@ x_window_save_page (GschemToplevel *w_current, PAGE *page, const gchar *filename
     page->CHANGED = 0;
 
     /* add to recent file list */
-    gtk_recent_manager_add_item (recent_manager, g_filename_to_uri(filename, NULL, NULL));
+    if (w_current->recent_manager != NULL) {
+      gtk_recent_manager_add_item (w_current->recent_manager,
+                                   g_filename_to_uri (filename, NULL, NULL));
+    }
 
     /* i_set_filename (w_current, page->page_filename); */
     x_pagesel_update (w_current);

--- a/liblepton/include/liblepton/geda_arc_object.h
+++ b/liblepton/include/liblepton/geda_arc_object.h
@@ -22,6 +22,8 @@
  *  \brief Functions operating on arc drawing objects
  */
 
+G_BEGIN_DECLS
+
 #define ARC_CENTER      0
 #define ARC_RADIUS      1
 #define ARC_START_ANGLE 2
@@ -123,3 +125,5 @@ o_arc_read (TOPLEVEL *toplevel,
             unsigned int release_ver,
             unsigned int fileformat_ver,
             GError **err);
+
+G_END_DECLS

--- a/liblepton/include/liblepton/geda_bounds.h
+++ b/liblepton/include/liblepton/geda_bounds.h
@@ -20,6 +20,8 @@
 /*! \file geda_bounds.h
  */
 
+G_BEGIN_DECLS
+
 typedef struct _GedaBounds GedaBounds;
 
 struct _GedaBounds
@@ -56,3 +58,5 @@ geda_bounds_union (GedaBounds *r, const GedaBounds *a, const GedaBounds *b);
 
 int
 inside_region (int xmin, int ymin, int xmax, int ymax, int x, int y);
+
+G_END_DECLS

--- a/liblepton/include/liblepton/geda_box_object.h
+++ b/liblepton/include/liblepton/geda_box_object.h
@@ -22,6 +22,8 @@
  *  \brief Functions operating on box drawing objects
  */
 
+G_BEGIN_DECLS
+
 #define BOX_UPPER_LEFT  0
 #define BOX_LOWER_RIGHT 1
 #define BOX_UPPER_RIGHT 2
@@ -98,3 +100,5 @@ o_box_read (TOPLEVEL *toplevel,
             unsigned int release_ver,
             unsigned int fileformat_ver,
             GError **err);
+
+G_END_DECLS

--- a/liblepton/include/liblepton/geda_bus_object.h
+++ b/liblepton/include/liblepton/geda_bus_object.h
@@ -22,6 +22,8 @@
  *  \brief Functions operating on bus objects
  */
 
+G_BEGIN_DECLS
+
 /* construction, destruction */
 
 GedaObject*
@@ -111,3 +113,5 @@ o_bus_read (TOPLEVEL *toplevel,
             unsigned int release_ver,
             unsigned int fileformat_ver,
             GError **err);
+
+G_END_DECLS

--- a/liblepton/include/liblepton/geda_circle_object.h
+++ b/liblepton/include/liblepton/geda_circle_object.h
@@ -22,6 +22,8 @@
  *  \brief Functions operating on circle drawing objects
  */
 
+G_BEGIN_DECLS
+
 #define CIRCLE_CENTER 0
 #define CIRCLE_RADIUS 1
 
@@ -104,3 +106,5 @@ o_circle_read (TOPLEVEL *toplevel,
                unsigned int release_ver,
                unsigned int fileformat_ver,
                GError **err);
+
+G_END_DECLS

--- a/liblepton/include/liblepton/geda_color.h
+++ b/liblepton/include/liblepton/geda_color.h
@@ -20,6 +20,8 @@
 /*! \file geda_color.h
  */
 
+G_BEGIN_DECLS
+
 typedef struct st_color GedaColor;
 //typedef struct st_color COLOR;
 
@@ -46,3 +48,5 @@ s_color_rgba_decode (const gchar *rgba, guchar *r, guchar *g, guchar *b, guchar 
 
 gchar*
 s_color_rgba_encode (guint8 r, guint8 g, guint8 b, guint8 a);
+
+G_END_DECLS

--- a/liblepton/include/liblepton/geda_color_map.h
+++ b/liblepton/include/liblepton/geda_color_map.h
@@ -26,6 +26,8 @@
 #ifndef _COLORS_H_INCL
 #define _COLORS_H_INCL
 
+G_BEGIN_DECLS
+
 #define BACKGROUND_COLOR                0
 #define PIN_COLOR                       1
 #define NET_ENDPOINT_COLOR              2
@@ -74,5 +76,7 @@ s_color_map_from_scm (GedaColor *map, SCM lst, const char *scheme_proc_name);
 
 SCM
 s_color_map_to_scm (const GedaColor *map);
+
+G_END_DECLS
 
 #endif

--- a/liblepton/include/liblepton/geda_complex_object.h
+++ b/liblepton/include/liblepton/geda_complex_object.h
@@ -22,6 +22,8 @@
  *  \brief Functions operating on complex objects
  */
 
+G_BEGIN_DECLS
+
 int world_get_object_glist_bounds(TOPLEVEL *toplevel, const GList *o_list,
 			     int *left, int *top,
 			     int *right, int *bottom);
@@ -78,4 +80,4 @@ geda_complex_object_get_position (const GedaObject *object, gint *x, gint *y);
 GList*
 o_complex_get_promotable (TOPLEVEL *toplevel, OBJECT *object, int detach);
 
-
+G_END_DECLS

--- a/liblepton/include/liblepton/geda_coord.h
+++ b/liblepton/include/liblepton/geda_coord.h
@@ -22,5 +22,9 @@
  *  \brief Functions for working with coordinates
  */
 
+G_BEGIN_DECLS
+
 gint
 geda_coord_snap (gint coord, gint grid);
+
+G_END_DECLS

--- a/liblepton/include/liblepton/geda_fill_type.h
+++ b/liblepton/include/liblepton/geda_fill_type.h
@@ -20,6 +20,8 @@
 /*! \file geda_fill_type.h
  */
 
+G_BEGIN_DECLS
+
 /*! \brief The fill type of objects like box, circle, and path
  *
  *  The numeric values of this enumeration are used inside files and must be
@@ -42,3 +44,5 @@ geda_fill_type_draw_first_hatch (int fill_type);
 
 gboolean
 geda_fill_type_draw_second_hatch (int fill_type);
+
+G_END_DECLS

--- a/liblepton/include/liblepton/geda_line_object.h
+++ b/liblepton/include/liblepton/geda_line_object.h
@@ -22,6 +22,8 @@
  *  \brief Functions operating on line objects
  */
 
+G_BEGIN_DECLS
+
 #define LINE_END1 0
 #define LINE_END2 1
 
@@ -114,3 +116,5 @@ o_line_read (TOPLEVEL *toplevel,
              unsigned int release_ver,
              unsigned int fileformat_ver,
              GError **err);
+
+G_END_DECLS

--- a/liblepton/include/liblepton/geda_net_object.h
+++ b/liblepton/include/liblepton/geda_net_object.h
@@ -22,6 +22,8 @@
  *  \brief Functions operating on net drawing objects
  */
 
+G_BEGIN_DECLS
+
 /* for geda_net_object_orientation */
 #define NEITHER    0
 #define HORIZONTAL 1
@@ -113,3 +115,5 @@ o_net_read (TOPLEVEL *toplevel,
             unsigned int release_ver,
             unsigned int fileformat_ver,
             GError **err);
+
+G_END_DECLS

--- a/liblepton/include/liblepton/geda_object.h
+++ b/liblepton/include/liblepton/geda_object.h
@@ -20,6 +20,8 @@
 /*! \file geda_object.h
  */
 
+G_BEGIN_DECLS
+
 struct st_object
 {
   int type;				/* Basic information */
@@ -234,3 +236,5 @@ s_object_add_weak_ptr (OBJECT *object, void *weak_pointer_loc);
 
 void
 s_object_remove_weak_ptr (OBJECT *object, void *weak_pointer_loc);
+
+G_END_DECLS

--- a/liblepton/include/liblepton/geda_object_list.h
+++ b/liblepton/include/liblepton/geda_object_list.h
@@ -20,6 +20,8 @@
 /*! \file geda_object_list.h
  */
 
+G_BEGIN_DECLS
+
 void
 geda_object_list_delete (TOPLEVEL *toplevel, GList *list);
 
@@ -46,3 +48,5 @@ geda_object_list_translate (const GList *objects, int dx, int dy);
 
 GList*
 o_glist_copy_all (TOPLEVEL *toplevel, const GList *src_list, GList *dest_list);
+
+G_END_DECLS

--- a/liblepton/include/liblepton/geda_page.h
+++ b/liblepton/include/liblepton/geda_page.h
@@ -20,6 +20,8 @@
 /*! \file geda_page.h
  */
 
+G_BEGIN_DECLS
+
 struct st_page
 {
   TOPLEVEL* toplevel;
@@ -137,3 +139,5 @@ s_page_objects_in_regions (TOPLEVEL *toplevel, PAGE *page, BOX *rects, int n_rec
 const gchar *s_page_get_filename (const PAGE *page);
 
 void s_page_set_filename (PAGE *page, const char *filename);
+
+G_END_DECLS

--- a/liblepton/include/liblepton/geda_path_object.h
+++ b/liblepton/include/liblepton/geda_path_object.h
@@ -22,6 +22,8 @@
  *  \brief Functions operating on path drawing objects
  */
 
+G_BEGIN_DECLS
+
 OBJECT*
 geda_path_object_new (TOPLEVEL *toplevel, char type, int color, const char *path_string);
 
@@ -59,3 +61,5 @@ geda_path_object_shortest_distance (TOPLEVEL *toplevel, OBJECT *object, int x, i
 
 gboolean
 geda_path_object_get_position (const GedaObject *object, gint *x, gint *y);
+
+G_END_DECLS

--- a/liblepton/include/liblepton/geda_picture_object.h
+++ b/liblepton/include/liblepton/geda_picture_object.h
@@ -22,6 +22,8 @@
  *  \brief Functions operating on picture drawing objects
  */
 
+G_BEGIN_DECLS
+
 #define PICTURE_UPPER_LEFT  0
 #define PICTURE_LOWER_RIGHT 1
 #define PICTURE_UPPER_RIGHT 2
@@ -98,3 +100,5 @@ o_picture_embed(TOPLEVEL *toplevel, OBJECT *object);
 
 void
 o_picture_unembed(TOPLEVEL *toplevel, OBJECT *object);
+
+G_END_DECLS

--- a/liblepton/include/liblepton/geda_pin_object.h
+++ b/liblepton/include/liblepton/geda_pin_object.h
@@ -22,6 +22,8 @@
  *  \brief Functions operating on pin drawing objects
  */
 
+G_BEGIN_DECLS
+
 /* construction, destruction */
 
 OBJECT*
@@ -114,3 +116,5 @@ o_pin_read (TOPLEVEL *toplevel,
             unsigned int release_ver,
             unsigned int fileformat_ver,
             GError **err);
+
+G_END_DECLS

--- a/liblepton/include/liblepton/geda_string.h
+++ b/liblepton/include/liblepton/geda_string.h
@@ -20,6 +20,8 @@
 /*! \file geda_string.h
  */
 
+G_BEGIN_DECLS
+
 int
 o_text_num_lines(const char *string);
 
@@ -31,3 +33,5 @@ geda_string_get_first_line (gchar *string);
 
 char*
 u_basic_breakup_string (char *string, char delimiter, int count);
+
+G_END_DECLS

--- a/liblepton/include/liblepton/geda_text_object.h
+++ b/liblepton/include/liblepton/geda_text_object.h
@@ -22,6 +22,8 @@
  *  \brief Functions operating on text drawing objects
  */
 
+G_BEGIN_DECLS
+
 #define DEFAULT_TEXT_SIZE 10
 #define MINIMUM_TEXT_SIZE 1
 
@@ -134,3 +136,5 @@ o_text_read (TOPLEVEL *toplevel,
              unsigned int release_ver,
              unsigned int fileformat_ver,
              GError **err);
+
+G_END_DECLS

--- a/liblepton/include/liblepton/geda_toplevel.h
+++ b/liblepton/include/liblepton/geda_toplevel.h
@@ -21,6 +21,8 @@
 /*! \file geda_toplevel.h
  */
 
+G_BEGIN_DECLS
+
 struct st_toplevel
 {
   /* have to decided on component list stuff */
@@ -111,3 +113,5 @@ s_toplevel_weak_ref (TOPLEVEL *toplevel, void (*notify_func)(void *, void *), vo
 
 void
 s_toplevel_weak_unref (TOPLEVEL *toplevel, void (*notify_func)(void *, void *), void *user_data);
+
+G_END_DECLS

--- a/liblepton/include/liblepton/geda_undo.h
+++ b/liblepton/include/liblepton/geda_undo.h
@@ -20,6 +20,8 @@
 /*! \file geda_undo.h
  */
 
+G_BEGIN_DECLS
+
 struct st_undo
 {
   /* one of these is used, depending on if you are doing in-memory */
@@ -78,3 +80,5 @@ s_undo_init (PAGE *p_current);
 
 void
 s_undo_free_all (TOPLEVEL *toplevel, PAGE *p_current);
+
+G_END_DECLS

--- a/liblepton/include/liblepton/prototype.h
+++ b/liblepton/include/liblepton/prototype.h
@@ -1,3 +1,5 @@
+G_BEGIN_DECLS
+
 /* a_basic.c */
 int o_save (TOPLEVEL *toplevel, const GList *object_list, const char *filename, GError **err);
 GList *o_read_buffer(TOPLEVEL *toplevel, GList *object_list, char *buffer, const int size, const char *name, GError **err);
@@ -152,3 +154,5 @@ TextBuffer *s_textbuffer_new (const gchar *data, const gint size);
 TextBuffer *s_textbuffer_free (TextBuffer *tb);
 const gchar *s_textbuffer_next (TextBuffer *tb, const gssize count);
 const gchar *s_textbuffer_next_line (TextBuffer *tb);
+
+G_END_DECLS


### PR DESCRIPTION
Together with two previous unclosed PR's (#97 and #98) these commits ensure `gschem`, `gaf`, `gnetlist` and others (all but `gattrib`) compile without errors (and the first two without warnings on my machine) with *g++* and even work :-)
To ensure the build I replace `-std=gnu99` in *configure.ac* with `std=gnu++03` and do `./autogen.sh && ./configure --prefix=/my/home/dir/lepton CC=g++ && make -k CC=g++ all && make install`. Separate `make install` is to ensure the built programs are installed even if `gattrib` has not been built. Without `CC` on `configure` stage I have warnings from snarfing tools.