### PR TITLE
Add change action mode hooks in gschem

### DIFF
--- a/docs/scheme-api/geda-scheme.texi
+++ b/docs/scheme-api/geda-scheme.texi
@@ -2481,6 +2481,67 @@ superior keymap.
 Since 1.10.
 @end defvar
 
+@defvar switch-action-mode-hook
+Called when GUI switches to a new action mode. The argument is the new
+mode.
+
+The action mode may be one of the following symbols:
+
+@itemize
+@item
+@samp{select-mode}
+@item
+@samp{grips-mode}
+@item
+@samp{arc-mode}
+@item
+@samp{box-mode}
+@item
+@samp{bus-mode}
+@item
+@samp{circle-mode}
+@item
+@samp{line-mode}
+@item
+@samp{net-mode}
+@item
+@samp{path-mode}
+@item
+@samp{picture-mode}
+@item
+@samp{pin-mode}
+@item
+@samp{component-mode}
+@item
+@samp{copy-mode}
+@item
+@samp{multiple-copy-mode}
+@item
+@samp{move-mode}
+@item
+@samp{paste-mode}
+@item
+@samp{text-mode}
+@item
+@samp{box-select-mode}
+@item
+@samp{zoom-box-mode}
+@item
+@samp{pan-mode}
+@item
+@samp{mirror-mode}
+@item
+@samp{rotate-mode}
+@end itemize
+
+@example
+(add-hook! switch-action-mode-hook
+           (lambda (mode) (display mode) (newline)))
+@end example
+
+Since 1.10.
+@end defvar
+
 @node Actions
 @section Actions
 @cindex Actions

--- a/docs/scheme-api/geda-scheme.texi
+++ b/docs/scheme-api/geda-scheme.texi
@@ -2638,7 +2638,7 @@ The special symbol @samp{repeat-last-command} is interpreted as a
 request to repeat the last action evaluated via @code{eval-action!}.
 
 @strong{Note}: If you have an action object @code{&action}, then the
-following to calls are equivalent and interchangeable:
+following two calls are equivalent and interchangeable:
 
 @example
 (eval-action! &action)

--- a/gschem/include/prototype.h
+++ b/gschem/include/prototype.h
@@ -29,6 +29,7 @@ void g_init_hook ();
 void g_run_hook_object (GschemToplevel *w_current, const char *name, OBJECT *obj);
 void g_run_hook_object_list (GschemToplevel *w_current, const char *name, GList *obj_lst);
 void g_run_hook_page (GschemToplevel *w_current, const char *name, PAGE *page);
+void g_run_hook_action_mode (GschemToplevel *w_current, const char *name, const gchar *action_mode);
 EdascmHookProxy *g_hook_new_proxy_by_name (const char *name);
 /* g_keys.c */
 void g_keys_reset (GschemToplevel *w_current);

--- a/gschem/scheme/gschem/hook.scm
+++ b/gschem/scheme/gschem/hook.scm
@@ -49,3 +49,5 @@
 (define-public action-property-hook %action-property-hook)
 
 (define-public bind-keys-hook %bind-keys-hook)
+
+(define-public switch-action-mode-hook %switch-action-mode-hook)

--- a/gschem/src/g_hook.c
+++ b/gschem/src/g_hook.c
@@ -132,6 +132,32 @@ g_run_hook_page (GschemToplevel *w_current, const char *name, PAGE *page)
   scm_remember_upto_here_1 (expr);
 }
 
+/*! \brief Runs a change action mode hook.
+ * \par Function Description
+ * Runs a hook called \a name, which should expect the single #MODE \a
+ * mode as its argument.
+ *
+ * \param name name of hook to run
+ * \param mode #MODE argument for hook.
+ */
+void
+g_run_hook_action_mode (GschemToplevel *w_current,
+                        const gchar *name,
+                        const gchar *action_mode)
+{
+  scm_dynwind_begin ((scm_t_dynwind_flags) 0);
+  g_dynwind_window (w_current);
+
+  SCM expr = scm_list_3 (run_hook_sym,
+                         g_get_hook_by_name (name),
+                         scm_list_2 (scm_from_utf8_symbol ("quote"),
+                                     scm_from_utf8_symbol (action_mode)));
+
+  g_scm_eval_protected (expr, scm_interaction_environment ());
+  scm_dynwind_end ();
+  scm_remember_upto_here_1 (expr);
+}
+
 /*! \brief Creates an EdascmHookProxy for a named hook.
  * Return a newly-created hook proxy object for the hook called \a
  * name.
@@ -179,6 +205,7 @@ init_module_gschem_core_hook (void *unused)
   DEFINE_HOOK ("%new-page-hook",1);
   DEFINE_HOOK ("%action-property-hook",3);
   DEFINE_HOOK ("%bind-keys-hook",3);
+  DEFINE_HOOK ("%switch-action-mode-hook",1);
 }
 
 /*!

--- a/gschem/src/i_basic.c
+++ b/gschem/src/i_basic.c
@@ -198,7 +198,8 @@ void i_action_update_status (GschemToplevel *w_current, gboolean inside_action)
 /*! \brief Set new state, then show state field
  *
  *  \par Function Description
- *  Set new state, then show state field.
+ *  Set new state and show it in the state field. Then run change
+ *  action mode hook to notify Scheme code about the change.
  *
  *  \param [in] w_current GschemToplevel structure
  *  \param [in] newstate The new state
@@ -207,6 +208,34 @@ void i_action_update_status (GschemToplevel *w_current, gboolean inside_action)
 void i_set_state(GschemToplevel *w_current, enum x_states newstate)
 {
   i_set_state_msg(w_current, newstate, NULL);
+
+  const gchar* mode = "select-mode";
+    switch (newstate) {
+      case SELECT: mode="select-mode"; break;
+      case GRIPS: mode="grips-mode"; break;
+      case ARCMODE: mode="arc-mode"; break;
+      case BOXMODE: mode="box-mode"; break;
+      case BUSMODE: mode="bus-mode"; break;
+      case CIRCLEMODE: mode="circle-mode"; break;
+      case LINEMODE: mode="line-mode"; break;
+      case NETMODE: mode="net-mode"; break;
+      case PATHMODE: mode="path-mode"; break;
+      case PICTUREMODE: mode="picture-mode"; break;
+      case PINMODE: mode="pin-mode"; break;
+      case COMPMODE: mode="component-mode"; break;
+      case COPYMODE: mode="copy-mode"; break;
+      case MCOPYMODE: mode="multiple-copy-mode"; break;
+      case MOVEMODE: mode="move-mode"; break;
+      case PASTEMODE: mode="paste-mode"; break;
+      case TEXTMODE: mode="text-mode"; break;
+      case SBOX: mode="box-select-mode"; break;
+      case ZOOMBOX: mode="zoom-box-mode"; break;
+      case PAN: mode="pan-mode"; break;
+      case MIRRORMODE: mode="mirror-mode"; break;
+      case ROTATEMODE: mode="rotate-mode"; break;
+    }
+
+  g_run_hook_action_mode (w_current, "%switch-action-mode-hook", mode);
 }
 
 /*! \brief Set new state, then show state field including some


### PR DESCRIPTION
The hooks are run when the gschem action mode changes.
For example, if the user wants to show which mode is switched on, she can use:
> (add-hook! switch-action-mode (lambda (mode) (display mode) (newline)))
