### PR TITLE
gschem: Do not warn about missing menu by default.

### DIFF
--- a/schematic/src/x_menus.c
+++ b/schematic/src/x_menus.c
@@ -331,9 +331,7 @@ void x_menus_sensitivity (GschemToplevel *w_current, const char *buf, int flag)
     gtk_widget_set_sensitive(GTK_WIDGET(item), flag);
     /* free(item); */ /* Why doesn't this need to be freed?  */
   } else {
-#ifdef DEBUG
-    s_log_message(_("Tried to set the sensitivity on non-existent menu item '%1$s'"), buf);
-#endif
+    g_debug(_("Tried to set the sensitivity on non-existent menu item '%1$s'"), buf);
   }
  
 }

--- a/schematic/src/x_menus.c
+++ b/schematic/src/x_menus.c
@@ -331,7 +331,9 @@ void x_menus_sensitivity (GschemToplevel *w_current, const char *buf, int flag)
     gtk_widget_set_sensitive(GTK_WIDGET(item), flag);
     /* free(item); */ /* Why doesn't this need to be freed?  */
   } else {
+#ifdef DEBUG
     s_log_message(_("Tried to set the sensitivity on non-existent menu item '%1$s'"), buf);
+#endif
   }
  
 }


### PR DESCRIPTION
Log window is cluttered with 'Tried to set the
sensitivity on non-existent menu item' messages
when one of the standard menus in system-gschemrc
is commented out. Do log only when DEBUG is defined.