### PR TITLE
schematic: Fix "unbound variable" error in builtins.scm.

### DIFF
--- a/schematic/scheme/gschem/builtins.scm
+++ b/schematic/scheme/gschem/builtins.scm
@@ -395,7 +395,7 @@ found, shows a dialog with an error message."
        (and component (show-component-documentation component))))
 
    (lambda (key subr msg args . rest)
-     (gschem-msg (string-append
+     ((@@ (guile-user) gschem-msg) (string-append
                   (_ "Could not show documentation for selected component:\n\n")
                   (apply format #f msg args))))))
 


### PR DESCRIPTION
This guile module uses gschem-msg function from g_funcs.c.
Functions defined in that file are not properly exported,
so we need to use '@@'-syntax in order to call them
from modules.