### PR TITLE
schematic: Add support for showing widgets as dialogs.

### DIFF
--- a/schematic/include/gschem_toplevel.h
+++ b/schematic/include/gschem_toplevel.h
@@ -62,6 +62,14 @@ struct st_gschem_toplevel {
   GtkWidget *text_properties;
 
 
+  /* dialogs for widgets */
+  GtkWidget *options_widget_dialog;
+  GtkWidget *text_properties_dialog;
+  GtkWidget *object_properties_dialog;
+  GtkWidget *log_widget_dialog;
+  GtkWidget *find_text_state_dialog;
+
+
   gchar *keyaccel_string;               /* visual feedback when pressing
                                            keyboard accelerators */
   gboolean keyaccel_string_source_id;   /* event source ID used by above */

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -735,8 +735,12 @@ void x_window_close_page (GschemToplevel *w_current, PAGE *page);
 void x_window_set_default_icon (void);
 void x_window_init_icons (void);
 GschemToplevel* x_window_new (TOPLEVEL *toplevel);
+void x_window_select_object (GschemFindTextState *state, OBJECT *object, GschemToplevel *w_current);
 
 /* x_widgets.c */
+gboolean x_widgets_use_docks();
+void x_widgets_init();
+void x_widgets_create (GschemToplevel* w_current);
 void x_widgets_show_options (GschemToplevel* w_current);
 void x_widgets_show_text_properties (GschemToplevel* w_current);
 void x_widgets_show_object_properties (GschemToplevel* w_current);

--- a/schematic/src/gschem_toplevel.c
+++ b/schematic/src/gschem_toplevel.c
@@ -182,6 +182,14 @@ GschemToplevel *gschem_toplevel_new ()
   w_current->options_widget    = NULL;
 
 
+  /* dialogs for widgets */
+  w_current->options_widget_dialog    = NULL;
+  w_current->text_properties_dialog   = NULL;
+  w_current->object_properties_dialog = NULL;
+  w_current->log_widget_dialog        = NULL;
+  w_current->find_text_state_dialog   = NULL;
+
+
   w_current->keyaccel_string = NULL;
   w_current->keyaccel_string_source_id = FALSE;
 

--- a/schematic/src/x_widgets.c
+++ b/schematic/src/x_widgets.c
@@ -1,6 +1,4 @@
 /* Lepton EDA Schematic Capture
- * Copyright (C) 1998-2010 Ales Hvezda
- * Copyright (C) 1998-2016 gEDA Contributors (see ChangeLog for details)
  * Copyright (C) 2017 dmn <graahnul.grom@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
@@ -68,17 +66,17 @@ gboolean x_widgets_use_docks()
  * Initialize widgets management.
  * Call this before any other functions from this file.
  * This function reads the value of "use-docks" configuration
- * setting in "gschem.gui" group, which determines
+ * setting in "schematic.gui" group, which determines
  * if widgets will be shown in docks (if true) or as
- * a dialog boxes (if false).
+ * dialog boxes (if false).
  *
  * Configuration setting description:
  * key:   use-docks
- * group: gschem.gui
+ * group: schematic.gui
  * type:  boolean
  * default value: true
  *
- * \return TRUE if use-docks options is set to true, FALSE otherwise.
+ * \return TRUE if use-docks option is set to true, FALSE otherwise.
  */
 void x_widgets_init()
 {
@@ -92,7 +90,7 @@ void x_widgets_init()
   {
     GError* err = NULL;
     gboolean val = eda_config_get_boolean (cfg,
-                                           "gschem.gui",
+                                           "schematic.gui",
                                            "use-docks",
                                            &err);
     if (err == NULL)
@@ -291,7 +289,7 @@ x_widgets_show_in_dialog (GschemToplevel* w_current,
   GtkWidget* dlg = gschem_dialog_new_with_buttons(
     title,
     GTK_WINDOW (w_current->main_window),
-    0,
+    (GtkDialogFlags) 0,
     ini_group,
     w_current,
     GTK_STOCK_CLOSE, GTK_RESPONSE_NONE,

--- a/schematic/src/x_widgets.c
+++ b/schematic/src/x_widgets.c
@@ -1,5 +1,4 @@
 /* Lepton EDA Schematic Capture
- * gschem - gEDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2016 gEDA Contributors (see ChangeLog for details)
  * Copyright (C) 2017 dmn <graahnul.grom@gmail.com>
@@ -39,9 +38,103 @@
 
 
 
+static gboolean
+g_x_widgets_use_docks = TRUE;
+
+
+
 static void
 x_widgets_show_in_dock (GtkWidget* wbook, GtkWidget* widget);
 
+
+static void
+x_widgets_show_in_dialog (GschemToplevel* w_current,
+                          GtkWidget*      widget,
+                          GtkWidget**     dialog,
+                          const gchar*    title,
+                          const gchar*    ini_group);
+
+
+
+gboolean x_widgets_use_docks()
+{
+  return g_x_widgets_use_docks;
+}
+
+
+
+/*! \par Function Description
+ *
+ * Initialize widgets management.
+ * Call this before any other functions from this file.
+ * This function reads the value of "use-docks" configuration
+ * setting in "gschem.gui" group, which determines
+ * if widgets will be shown in docks (if true) or as
+ * a dialog boxes (if false).
+ *
+ * Configuration setting description:
+ * key:   use-docks
+ * group: gschem.gui
+ * type:  boolean
+ * default value: true
+ *
+ * \return TRUE if use-docks options is set to true, FALSE otherwise.
+ */
+void x_widgets_init()
+{
+  gchar* cwd = g_get_current_dir();
+
+  EdaConfig* cfg = eda_config_get_context_for_path (cwd);
+
+  g_free (cwd);
+
+  if (cfg != NULL)
+  {
+    GError* err = NULL;
+    gboolean val = eda_config_get_boolean (cfg,
+                                           "gschem.gui",
+                                           "use-docks",
+                                           &err);
+    if (err == NULL)
+    {
+      g_x_widgets_use_docks = val;
+    }
+
+    g_clear_error (&err);
+  }
+}
+
+
+
+void x_widgets_create (GschemToplevel* w_current)
+{
+  g_return_if_fail (w_current != NULL);
+
+  w_current->object_properties =
+      gschem_object_properties_widget_new (w_current);
+
+  w_current->text_properties =
+      gschem_text_properties_widget_new (w_current);
+
+  w_current->options_widget =
+      gschem_options_widget_new (w_current);
+
+
+  w_current->log_widget =
+      gschem_log_widget_new();
+
+  w_current->find_text_state =
+      gschem_find_text_state_new();
+
+  g_signal_connect (w_current->find_text_state, "select-object",
+                    G_CALLBACK (&x_window_select_object), w_current);
+
+  if (x_widgets_use_docks())
+  {
+    gtk_widget_set_size_request (GTK_WIDGET (w_current->find_text_state),
+                                 default_width, default_height / 4);
+  }
+}
 
 
 
@@ -49,8 +142,19 @@ void x_widgets_show_options (GschemToplevel* w_current)
 {
   g_return_if_fail (w_current != NULL);
 
-  x_widgets_show_in_dock (w_current->right_notebook,
-                          w_current->options_widget);
+  if (x_widgets_use_docks())
+  {
+    x_widgets_show_in_dock (w_current->right_notebook,
+                            w_current->options_widget);
+  }
+  else
+  {
+    x_widgets_show_in_dialog (w_current,
+                              w_current->options_widget,
+                              &w_current->options_widget_dialog,
+                              _("Options"),
+                              "options");
+  }
 }
 
 
@@ -59,8 +163,19 @@ void x_widgets_show_text_properties (GschemToplevel* w_current)
 {
   g_return_if_fail (w_current != NULL);
 
-  x_widgets_show_in_dock (w_current->right_notebook,
-                          w_current->text_properties);
+  if (x_widgets_use_docks())
+  {
+    x_widgets_show_in_dock (w_current->right_notebook,
+                            w_current->text_properties);
+  }
+  else
+  {
+    x_widgets_show_in_dialog (w_current,
+                              w_current->text_properties,
+                              &w_current->text_properties_dialog,
+                              _("Text"),
+                              "txtprops");
+  }
 
   gschem_text_properties_widget_adjust_focus(
     GSCHEM_TEXT_PROPERTIES_WIDGET (w_current->text_properties));
@@ -72,8 +187,19 @@ void x_widgets_show_object_properties (GschemToplevel* w_current)
 {
   g_return_if_fail (w_current != NULL);
 
-  x_widgets_show_in_dock (w_current->right_notebook,
-                          w_current->object_properties);
+  if (x_widgets_use_docks())
+  {
+    x_widgets_show_in_dock (w_current->right_notebook,
+                            w_current->object_properties);
+  }
+  else
+  {
+    x_widgets_show_in_dialog (w_current,
+                              w_current->object_properties,
+                              &w_current->object_properties_dialog,
+                              _("Object"),
+                              "objprops");
+  }
 }
 
 
@@ -82,8 +208,19 @@ void x_widgets_show_log (GschemToplevel* w_current)
 {
   g_return_if_fail (w_current != NULL);
 
-  x_widgets_show_in_dock (w_current->bottom_notebook,
-                          w_current->log_widget);
+  if (x_widgets_use_docks())
+  {
+    x_widgets_show_in_dock (w_current->bottom_notebook,
+                            w_current->log_widget);
+  }
+  else
+  {
+    x_widgets_show_in_dialog (w_current,
+                              GTK_WIDGET (w_current->log_widget),
+                              &w_current->log_widget_dialog,
+                              _("Log"),
+                              "log");
+  }
 }
 
 
@@ -92,8 +229,19 @@ void x_widgets_show_find_text_state (GschemToplevel* w_current)
 {
   g_return_if_fail (w_current != NULL);
 
-  x_widgets_show_in_dock (w_current->bottom_notebook,
-                          w_current->find_text_state);
+  if (x_widgets_use_docks())
+  {
+    x_widgets_show_in_dock (w_current->bottom_notebook,
+                            w_current->find_text_state);
+  }
+  else
+  {
+    x_widgets_show_in_dialog (w_current,
+                              GTK_WIDGET (w_current->find_text_state),
+                              &w_current->find_text_state_dialog,
+                              _("Find Text"),
+                              "findtext");
+  }
 }
 
 
@@ -114,3 +262,57 @@ x_widgets_show_in_dock (GtkWidget* wbook, GtkWidget* widget)
     gtk_widget_set_visible (wbook, TRUE);
   }
 }
+
+
+
+/*! \brief Shows a widget as a dialog box
+ *
+ *  \param [in]     w_current The toplevel environment.
+ *  \param [in]     widget Widget to show
+ *  \param [in,out] dialog Dialog which will be a parent of the widget
+ *  \param [in]     title  Dialog's title
+ *  \param [in]     ini_group Config file section for dialog geometry
+ */
+static void
+x_widgets_show_in_dialog (GschemToplevel* w_current,
+                          GtkWidget*      widget,
+                          GtkWidget**     dialog,
+                          const gchar*    title,
+                          const gchar*    ini_group)
+{
+  g_return_if_fail (widget != NULL);
+
+  if (*dialog != NULL)
+  {
+    gtk_window_present (GTK_WINDOW (*dialog));
+    return;
+  }
+
+  GtkWidget* dlg = gschem_dialog_new_with_buttons(
+    title,
+    GTK_WINDOW (w_current->main_window),
+    0,
+    ini_group,
+    w_current,
+    GTK_STOCK_CLOSE, GTK_RESPONSE_NONE,
+    NULL);
+
+  g_signal_connect (G_OBJECT (dlg),
+                    "response",
+                    G_CALLBACK (&gtk_widget_hide),
+                    NULL);
+
+  g_signal_connect (G_OBJECT (dlg),
+                    "delete-event",
+                    G_CALLBACK (&gtk_widget_hide_on_delete),
+                    NULL);
+
+  GtkWidget* content_area = gtk_dialog_get_content_area (GTK_DIALOG (dlg));
+  gtk_container_add (GTK_CONTAINER (content_area), widget);
+
+  gtk_widget_show_all (dlg);
+  gtk_window_present (GTK_WINDOW (dlg));
+
+  *dialog = dlg;
+
+} /* x_widgets_show_in_dialog() */

--- a/schematic/src/x_window.c
+++ b/schematic/src/x_window.c
@@ -327,7 +327,7 @@ x_window_invoke_macro (GschemMacroWidget *widget, int response, GschemToplevel *
   gtk_widget_hide (GTK_WIDGET (widget));
 }
 
-static void
+void
 x_window_select_object (GschemFindTextState *state, OBJECT *object, GschemToplevel *w_current)
 {
   GschemPageView *view = gschem_toplevel_get_current_page_view (w_current);
@@ -460,6 +460,13 @@ void x_window_create_main(GschemToplevel *w_current)
 
 
   /*
+  *  widgets:
+  */
+  x_widgets_init();
+  x_widgets_create (w_current);
+
+
+  /*
   *  windows layout:
   */
   vpaned = gtk_vpaned_new ();
@@ -494,6 +501,13 @@ void x_window_create_main(GschemToplevel *w_current)
 
   /* show all widgets: */
   gtk_widget_show_all (w_current->main_window);
+
+
+  if ( !x_widgets_use_docks() )
+  {
+    gtk_widget_set_visible (GTK_WIDGET (w_current->right_notebook),  FALSE);
+    gtk_widget_set_visible (GTK_WIDGET (w_current->bottom_notebook), FALSE);
+  }
 
 
   /* focus page view: */
@@ -1338,31 +1352,25 @@ create_notebook_right (GschemToplevel* w_current)
 {
   GtkWidget *notebook = gtk_notebook_new ();
 
-  w_current->object_properties =
-      gschem_object_properties_widget_new (w_current);
+  if ( x_widgets_use_docks() )
+  {
+    gtk_notebook_append_page (GTK_NOTEBOOK (notebook),
+                              GTK_WIDGET (w_current->object_properties),
+                              gtk_label_new(_("Object")));
 
-  w_current->text_properties =
-      gschem_text_properties_widget_new (w_current);
+    gtk_notebook_append_page (GTK_NOTEBOOK (notebook),
+                              GTK_WIDGET (w_current->text_properties),
+                              gtk_label_new(_("Text")));
 
-  w_current->options_widget =
-      gschem_options_widget_new (w_current);
-
-  gtk_notebook_append_page (GTK_NOTEBOOK (notebook),
-                            GTK_WIDGET (w_current->object_properties),
-                            gtk_label_new(_("Object")));
-
-  gtk_notebook_append_page (GTK_NOTEBOOK (notebook),
-                            GTK_WIDGET (w_current->text_properties),
-                            gtk_label_new(_("Text")));
-
-  gtk_notebook_append_page (GTK_NOTEBOOK (notebook),
-                            GTK_WIDGET (w_current->options_widget),
-                            gtk_label_new(_("Options")));
+    gtk_notebook_append_page (GTK_NOTEBOOK (notebook),
+                              GTK_WIDGET (w_current->options_widget),
+                              gtk_label_new(_("Options")));
 
 
 
-  gtk_container_set_border_width (GTK_CONTAINER (notebook),
-                                  DIALOG_BORDER_SPACING);
+    gtk_container_set_border_width (GTK_CONTAINER (notebook),
+                                    DIALOG_BORDER_SPACING);
+  }
 
   return notebook;
 }
@@ -1374,28 +1382,20 @@ create_notebook_bottom (GschemToplevel* w_current)
 {
   GtkWidget *notebook = gtk_notebook_new ();
 
-  w_current->find_text_state =
-      gschem_find_text_state_new ();
+  if ( x_widgets_use_docks() )
+  {
+    gtk_notebook_append_page (GTK_NOTEBOOK (notebook),
+                              GTK_WIDGET (w_current->find_text_state),
+                              gtk_label_new(_("Find Text")));
 
-  w_current->log_widget =
-      gschem_log_widget_new ();
+    gtk_notebook_append_page (GTK_NOTEBOOK (notebook),
+                              GTK_WIDGET (w_current->log_widget),
+                              gtk_label_new(_("Status")));
 
-  gtk_notebook_append_page (GTK_NOTEBOOK (notebook),
-                            GTK_WIDGET (w_current->find_text_state),
-                            gtk_label_new(_("Find Text")));
 
-  gtk_notebook_append_page (GTK_NOTEBOOK (notebook),
-                            GTK_WIDGET (w_current->log_widget),
-                            gtk_label_new(_("Status")));
-
-  g_signal_connect (w_current->find_text_state, "select-object",
-                    G_CALLBACK (&x_window_select_object), w_current);
-
-  gtk_widget_set_size_request (GTK_WIDGET (w_current->find_text_state),
-                               default_width, default_height / 4);
-
-  gtk_container_set_border_width (GTK_CONTAINER (notebook),
-                                  DIALOG_BORDER_SPACING);
+    gtk_container_set_border_width (GTK_CONTAINER (notebook),
+                                    DIALOG_BORDER_SPACING);
+  }
 
   return notebook;
 }


### PR DESCRIPTION
Now that we have the code for widgets management
refactored, it would be nice (and easy) to make a
one more step: at last, let the users decide,
what type of GUI they prefer to use, dialog boxes
(as it was before 1.9.2) or docking widgets.

Sorry to say that, but for me, as a user,
introduction of docking widgets was a complete show-stopper;
since then I have to maintain the local fork
(now extremely outdated). I would be more than happy
(and, I think, not only me) if we could make such a change. :-)
What do you think?