### PR TITLE
schematic: User-defined font for the log window.

### DIFF
--- a/schematic/src/gschem_log_widget.c
+++ b/schematic/src/gschem_log_widget.c
@@ -297,6 +297,48 @@ instance_init (GschemLogWidget *widget)
                                                 "editable", FALSE,
                                                 NULL));
 
+
+  /*
+  * Set custom font for the log window
+  *
+  * Configuration setting description:
+  * key:           font
+  * group:         schematic.log-window
+  * type:          string
+  * default value: not set
+  *
+  * Example:
+  * [schematic.log-window]
+  * font=Droid Sans Mono 11
+  *
+  */
+
+  gchar* cwd = g_get_current_dir();
+  EdaConfig* cfg = eda_config_get_context_for_path (cwd);
+  g_free (cwd);
+
+  if (cfg != NULL)
+  {
+    GError* err = NULL;
+    gchar* font = eda_config_get_string (cfg,
+                                         "schematic.log-window",
+                                         "font",
+                                         &err);
+
+    if (err == NULL)
+    {
+      PangoFontDescription* fdesc = pango_font_description_from_string (font);
+
+      gtk_widget_modify_font (GTK_WIDGET (widget->viewer), fdesc);
+
+      pango_font_description_free (fdesc);
+      g_free (font);
+    }
+
+    g_clear_error (&err);
+  }
+
+
   gtk_container_add (GTK_CONTAINER (scrolled), GTK_WIDGET (widget->viewer));
 
   g_signal_connect (klass->buffer,


### PR DESCRIPTION
Add "font" configuration key (string, [schematic.log-window] group).
It specifies a font that will be used to display text
in the log window. For example:
[schematic.log-window]
font=Monospace 12

Closes #166