### PR TITLE
Bump required version of GTK+.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ In order to compile gEDA from the distributed source archives, you
 - Guile ("GNU's Ubiquitous Intelligent Language for Extensions"),
   version 2.0.0 or later.  <http://www.gnu.org/software/guile/>
 
-- GTK+ (the Gimp Toolkit), version 2.18.0 or later.
+- GTK+ (the Gimp Toolkit), version 2.24.0 or later.
   <http://www.gtk.org/>
 
 - GNU `gettext`, version 0.18 or newer.

--- a/configure.ac
+++ b/configure.ac
@@ -75,21 +75,21 @@ PKG_PROG_PKG_CONFIG
 
 AX_CHECK_GUILE([2.0.0])
 
-PKG_CHECK_MODULES(GLIB, [glib-2.0 >= 2.20.0], ,
-  AC_MSG_ERROR([GLib 2.20.0 or later is required.]))
+PKG_CHECK_MODULES(GLIB, [glib-2.0 >= 2.25.0], ,
+  AC_MSG_ERROR([GLib 2.25.0 or later is required.]))
 AC_DEFINE([G_DISABLE_DEPRECATED], [1], [Disable deprecated GLib features])
 
-PKG_CHECK_MODULES(GIO, [gio-2.0 >= 2.20.0], ,
-  AC_MSG_ERROR([GIO 2.20.0 or later is required.]))
+PKG_CHECK_MODULES(GIO, [gio-2.0 >= 2.25.0], ,
+  AC_MSG_ERROR([GIO 2.25.0 or later is required.]))
 
-PKG_CHECK_MODULES(GTK, [gtk+-2.0 >= 2.18.0], ,
-  AC_MSG_ERROR([GTK+ 2.18.0 or later is required.]))
+PKG_CHECK_MODULES(GTK, [gtk+-2.0 >= 2.24.0], ,
+  AC_MSG_ERROR([GTK+ 2.24.0 or later is required.]))
 
-PKG_CHECK_MODULES(GDK, [gdk-2.0 >= 2.18.0], ,
-  AC_MSG_ERROR([GDK 2.18.0 or later is required.]))
+PKG_CHECK_MODULES(GDK, [gdk-2.0 >= 2.24.0], ,
+  AC_MSG_ERROR([GDK 2.24.0 or later is required.]))
 
-PKG_CHECK_MODULES(GDK_PIXBUF, [gdk-pixbuf-2.0 >= 2.18.0], ,
-  AC_MSG_ERROR([GDK_PIXBUF 2.18.0 or later is required.]))
+PKG_CHECK_MODULES(GDK_PIXBUF, [gdk-pixbuf-2.0 >= 2.21.0], ,
+  AC_MSG_ERROR([GDK_PIXBUF 2.21.0 or later is required.]))
 
 AX_CHECK_CAIRO
 


### PR DESCRIPTION
This is safe for most distributions these days.