### PR TITLE
Replace a function deprecated in GTK 2.24 with two new ones.

### DIFF
--- a/schematic/src/gschem_page_view.c
+++ b/schematic/src/gschem_page_view.c
@@ -395,8 +395,8 @@ gschem_page_view_get_page_geometry (GschemPageView *view)
 
   geometry = geometry_cache_lookup (view, page);
 
-  /* \todo The following line is deprecated in GDK 2.24 */
-  gdk_drawable_get_size (GTK_WIDGET (view)->window, &screen_width, &screen_height);
+  screen_width  = gdk_window_get_width  (GTK_WIDGET (view)->window);
+  screen_height = gdk_window_get_height (GTK_WIDGET (view)->window);
 
   if (geometry == NULL) {
     geometry = gschem_page_geometry_new_with_values (screen_width,


### PR DESCRIPTION
This is a cherry-pick from the commit series in #168. Should be applied after #177.