### PR TITLE
schematic: Fix: preserve zoom in tabbed GUI.

### DIFF
--- a/schematic/src/x_event.c
+++ b/schematic/src/x_event.c
@@ -579,12 +579,20 @@ x_event_configure (GschemPageView    *page_view,
   page_view->previous_allocation = current_allocation;
 
 
-  /* tabbed GUI: mark page_view as configured, zoom and return,
-   * so that new pages are zoomed correctly
+  /* tabbed GUI: zoom/pan, mark page_view as configured and return:
+   * there is only one page per page view.
   */
   if (x_tabs_enabled())
   {
-    gschem_page_view_zoom_extents (page_view, NULL);
+    if (page_view->configured)
+    {
+      gschem_page_view_pan_mouse (page_view, 0, 0);
+    }
+    else
+    {
+      gschem_page_view_zoom_extents (page_view, NULL);
+    }
+
     page_view->configured = TRUE;
     return FALSE;
   }

--- a/schematic/src/x_tabs.c
+++ b/schematic/src/x_tabs.c
@@ -1357,6 +1357,10 @@ x_tabs_page_set_cur (GschemToplevel* w_current, PAGE* page)
       */
       while (gtk_events_pending())
         gtk_main_iteration();
+
+      /* new page view is created for existing page => zoom it:
+      */
+      gschem_page_view_zoom_extents (x_tabs_tl_pview_cur (w_current), NULL);
   }
 
 } /* x_tabs_page_set_cur() */


### PR DESCRIPTION
Zoom level is preserved when the main window is resized.
Also preserve zoom level for already opened pages.