### PR TITLE
Leptonize man pages

### DIFF
--- a/cli/lepton-cli.1.in
+++ b/cli/lepton-cli.1.in
@@ -7,7 +7,7 @@ lepton-cli - Lepton EDA Command-Line Utility
 .SH "DESCRIPTION"
 .PP
 .B lepton-cli
-is part of the gEDA (GPL Electronic Design Automation) toolset.
+is part of the Lepton EDA (Electronic Design Automation) toolset.
 It provides a number of small command-line utilities for working
 with schematic and symbol files, and is designed to be used for
 batch processing of designs created using the schematic editor
@@ -19,7 +19,7 @@ is used to create SVG, PDF, PNG, PS and EPS files from schematic and
 symbol files, for printing or embedding in other documents.
 
 .B lepton-cli config
-allows reading and writing settings in gEDA project, user and system
+allows reading and writing settings in Lepton EDA project, user and system
 configuration stores.
 
 .B lepton-cli shell
@@ -158,7 +158,7 @@ the system configuration store may be read-only.
 .B lepton-cli shell
 provides a Scheme Read-Eval-Print Loop (REPL) for automating
 processing of schematic and symbol files.  It is designed to be used
-with the gEDA Scheme API.
+with the Lepton EDA Scheme API.
 
 .TP 8
 \fB-s\fR \fIFILE\fR
@@ -195,9 +195,10 @@ See the `AUTHORS' file included with this program.
 
 .SH COPYRIGHT
 .nf
-Copyright \(co 2012-@YEAR@ gEDA Contributors.  License GPLv2+: GNU GPL
-version 2 or later.  Please see the `COPYING' file included with this
-program for full details.
+Copyright \(co 1998-2017 by Ales Hvezda and the respective original authors.
+Copyright \(co 2017-2018 Lepton Developers.
+License GPLv2+: GNU GPL version 2 or later. Please see the `COPYING'
+file included with this program for full details.
 .PP
 This is free software: you are free to change and redistribute it.
 There is NO WARRANTY, to the extent permitted by law.

--- a/cli/lepton-cli.1.in
+++ b/cli/lepton-cli.1.in
@@ -195,8 +195,7 @@ See the `AUTHORS' file included with this program.
 
 .SH COPYRIGHT
 .nf
-Copyright \(co 1998-2017 by Ales Hvezda and the respective original authors.
-Copyright \(co 2017-2018 Lepton Developers.
+Copyright \(co 2012-@YEAR@ gEDA Contributors.
 License GPLv2+: GNU GPL version 2 or later. Please see the `COPYING'
 file included with this program for full details.
 .PP

--- a/gnetlist/docs/.gitignore
+++ b/gnetlist/docs/.gitignore
@@ -2,8 +2,8 @@ Makefile
 Makefile.in
 html
 latex
-gnetlist.1
-gnetlist.html
+lepton-netlist.1
+lepton-netlist.html
 mk_verilog_syms.1
 mk_verilog_syms.html
 *~

--- a/gnetlist/docs/Makefile.am
+++ b/gnetlist/docs/Makefile.am
@@ -3,14 +3,14 @@ SUBDIRS = vams
 
 EXTRA_DIST = $(html_man_files) logo.png \
 	     gnetlist-main.txt what-is-geda.html what-is-gnetlist.html \
-	     gnetlist.dox gnetlist.1.in mk_verilog_syms.1.in
+	     gnetlist.dox lepton-netlist.1.in mk_verilog_syms.1.in
 
 docsreadmedir = $(docdir)/readmes
 dist_docsreadme_DATA = \
 	README.bom README.pcb README.switcap README.verilog \
 	README.vhdl README.sysc README.eagle
 
-dist_man_MANS = gnetlist.1
+dist_man_MANS = lepton-netlist.1
 noinst_MANS = mk_verilog_syms.1
 
 .1.in.1:

--- a/gnetlist/docs/lepton-netlist.1.in
+++ b/gnetlist/docs/lepton-netlist.1.in
@@ -1,28 +1,28 @@
-.TH gnetlist 1 "@DATE@" "Lepton EDA" @VERSION@
+.TH lepton-netlist 1 "@DATE@" "Lepton EDA" @VERSION@
 .SH NAME
-gnetlist - gEDA/gaf Netlist Extraction and Generation
+lepton-netlist - Lepton EDA Netlist Extraction and Generation
 .SH SYNOPSIS
-.B gnetlist
+.B lepton-netlist
 [\fIOPTION\fR ...] [\fB-g\fR \fIBACKEND\fR] [\fI--\fR] \fIFILE\fR ...
 
 .SH DESCRIPTION
 .PP
 
-\fBgnetlist\fR is a netlist extraction and generation tool, and is
-part of the gEDA (GPL Electronic Design Automation) toolset.  It takes
+\fBlepton-netlist\fR is a netlist extraction and generation tool, and is
+part of the Lepton EDA (Electronic Design Automation) toolset.  It takes
 one or electronic schematics as input, and outputs a netlist.  A
 netlist is a machine-interpretable description of the way that
 components in an electronic circuit are connected together, and is
 commonly used as the input to a PCB layout program such as
 \fBpcb\fR(1) or to a simulator such as \fBgnucap\fR(1).
 
-A normal \fBgnetlist\fR run is carried out in two steps.  First, the
-\fBgnetlist\fR frontend loads the specified human-readable schematic
+A normal \fBlepton-netlist\fR run is carried out in two steps.  First, the
+\fBlepton-netlist\fR frontend loads the specified human-readable schematic
 \fIFILE\fRs, and compiles them to an in-memory netlist description.
 Next, a `backend' is used to export the connection and component data
 to one of many supported netlist formats.
 
-\fBgnetlist\fR is extensible, using the Scheme programming language.
+\fBlepton-netlist\fR is extensible, using the Scheme programming language.
 
 .SH GENERAL OPTIONS
 .TP 8
@@ -60,7 +60,7 @@ Specify a Scheme file to be loaded between loading the backend and
 executing it.  This option can be specified multiple times.
 .TP 8
 \fB-c\fR \fIEXPR\fR
-Specify a Scheme expression to be executed during \fBgnetlist\fR
+Specify a Scheme expression to be executed during \fBlepton-netlist\fR
 startup.  This option can be specified multiple times.
 .TP 8
 \fB-i\fR
@@ -72,7 +72,7 @@ Scheme read-eval-print loop.
 Print a help message.
 .TP 8
 \fB-V\fR, \fB--version\fR
-Print \fBgnetlist\fR version information.
+Print \fBlepton-netlist\fR version information.
 .TP 8
 \fB--\fR
 Treat all remaining arguments as schematic filenames.  Use this if you
@@ -80,7 +80,7 @@ have a schematic filename which begins with `-'.
 
 .SH BACKENDS
 .PP
-Currently, \fBgnetlist\fR includes the following backends:
+Currently, \fBlepton-netlist\fR includes the following backends:
 
 .TP 8
 \fBallegro\fR
@@ -183,22 +183,22 @@ ViPEC Network Analyser netlist format.
 .PP
 These examples assume that you have a `stack_1.sch' in the current directory.
 .PP
-\fBgnetlist\fR requires that at least one schematic to be specified on the
+\fBlepton-netlist\fR requires that at least one schematic to be specified on the
 command line:
 
 .nf
-	./gnetlist stack_1.sch
+	./lepton-netlist stack_1.sch
 .ad b
 
 .PP
-This is not very useful since it does not direct \fBgnetlist\fR to do
+This is not very useful since it does not direct \fBlepton-netlist\fR to do
 anything.
 .PP
-Specify a backend name with `\-g' to get \fBgnetlist\fR to output a
+Specify a backend name with `\-g' to get \fBlepton-netlist\fR to output a
 netlist:
 
 .nf
-	./gnetlist \-g geda stack_1.sch
+	./lepton-netlist \-g geda stack_1.sch
 .ad b
 
 .PP
@@ -209,7 +209,7 @@ in the current working directory.
 You can specify the output filename by using the `\-o' option:
 
 .nf
-	./gnetlist \-g geda stack_1.sch \-o /tmp/stack.netlist
+	./lepton-netlist \-g geda stack_1.sch \-o /tmp/stack.netlist
 .ad b
 
 .PP
@@ -225,11 +225,11 @@ To obtain a Scheme prompt to run Scheme expressions directly, you can
 use the `\-i' option.
 
 .nf
-	./gnetlist \-i stack_1.sch
+	./lepton-netlist \-i stack_1.sch
 .ad b
 
 .PP
-\fBgnetlist\fR will load `stack_1.sh', and then enter an interactive
+\fBlepton-netlist\fR will load `stack_1.sh', and then enter an interactive
 Scheme read-eval-print loop.
 
 .SH ENVIRONMENT
@@ -246,12 +246,13 @@ See the `AUTHORS' file included with this program.
 
 .SH COPYRIGHT
 .nf
-Copyright \(co 1999-@YEAR@ gEDA Contributors.  License GPLv2+: GNU GPL
-version 2 or later.  Please see the `COPYING' file included with this
-program for full details.
+Copyright \(co 1998-2017 by Ales Hvezda and the respective original authors.
+Copyright \(co 2017-2018 Lepton Developers.
+License GPLv2+: GNU GPL version 2 or later. Please see the `COPYING'
+file included with this program for full details.
 .PP
 This is free software: you are free to change and redistribute it.
 There is NO WARRANTY, to the extent permitted by law.
 
 .SH SEE ALSO
-\fBgschem\fR(1), \fBlepton-symcheck\fR(1), \fBpcb\fR(1), \fBgnucap\fR(1)
+\fBlepton-schematic\fR(1), \fBlepton-symcheck\fR(1), \fBpcb\fR(1), \fBgnucap\fR(1)

--- a/gnetlist/docs/lepton-netlist.1.in
+++ b/gnetlist/docs/lepton-netlist.1.in
@@ -246,8 +246,7 @@ See the `AUTHORS' file included with this program.
 
 .SH COPYRIGHT
 .nf
-Copyright \(co 1998-2017 by Ales Hvezda and the respective original authors.
-Copyright \(co 2017-2018 Lepton Developers.
+Copyright \(co 2012-@YEAR@ gEDA Contributors.
 License GPLv2+: GNU GPL version 2 or later. Please see the `COPYING'
 file included with this program for full details.
 .PP

--- a/schematic/docs/lepton-schematic.1.in
+++ b/schematic/docs/lepton-schematic.1.in
@@ -1,23 +1,23 @@
-.TH gschem 1 "@DATE@" "Lepton EDA" @VERSION@
+.TH lepton-schematic 1 "@DATE@" "Lepton EDA" @VERSION@
 .SH NAME
-gschem - gEDA/gaf Schematic Capture
+lepton-schematic - Lepton EDA Schematic Capture
 .SH SYNOPSIS
-.B gschem
+.B lepton-schematic
 [\fIOPTION\fR ...] [\fI--\fR] [\fIFILE\fR ...]
 .SH DESCRIPTION
 .PP
-.B gschem
+.B lepton-schematic
 is a schematic capture application, and is part of the
-gEDA (GPL Electronic Design Automation) toolset.  It is used to draw
+Lepton EDA (Electronic Design Automation) toolset. It is used to draw
 electronic schematics, which describe the logical structure of an
-circuit.  Schematics are made up of symbols, which represent the
+circuit. Schematics are made up of symbols, which represent the
 various components in the circuit, and are obtained either from a
-standard library or created by the user.  The connections between
-components represented by nets (wires).  Schematics may be printed to
+standard library or created by the user. The connections between
+components represented by nets (wires). Schematics may be printed to
 a PostScript file for printing or further conversion to other output
 formats.  Output to various image formats is also supported.
 
-.B gschem
+.B lepton-schematic
 can also be used for editing symbols for use in
 schematics.
 
@@ -27,7 +27,7 @@ schematics.
 Quiet mode. Turn off all warnings/notes/messages.
 .TP 8
 \fB-v\fR, \fB--verbose\fR
-Verbose mode.  Output all diagnostic information.
+Verbose mode. Output all diagnostic information.
 .TP 8
 \fB-L\fR \fIDIRECTORY\fR
 Prepend \fIDIRECTORY\fR to the list of directories to be searched for
@@ -40,28 +40,28 @@ Specify a Scheme script to be executed at startup.
 Specify a Scheme expression to be evaluated at startup.
 .TP 8
 \fB-o\fR, \fB--output\fR=\fIFILE\fR
-Specify a filename for PostScript output.  This command line argument
-is useful when running \fBgschem\fR from a shell script and with a
-Scheme script.  The filename can be changed through the print dialog
+Specify a filename for PostScript output. This command line argument
+is useful when running \fBlepton-schematic\fR from a shell script and with a
+Scheme script. The filename can be changed through the print dialog
 box.
 .TP 8
 \fB-p\fR
-Automatically place the window. This may be useful if running \fBgschem\fR
+Automatically place the window. This may be useful if running \fBlepton-schematic\fR
 from the command line and generating output.
 .TP 8
 \fB-h\fR, \fB--help\fR
 Print a help message.
 .TP 8
 \fB-V\fR, \fB--version\fR
-Print \fBgschem\fR version information.
+Print \fBlepton-schematic\fR version information.
 .TP 8
 \fB--\fR
-Treat all remaining arguments as schematic or symbol filenames.  Use
+Treat all remaining arguments as schematic or symbol filenames. Use
 this if you have a schematic or symbol filename which begins with `-'.
 
 .SH SCHEMATIC AND SYMBOL FILES
 Optionally, schematic or symbol \fIFILE\fRs may be specified on the
-command line.  Any schematic or symbols specified are loaded at
+command line. Any schematic or symbols specified are loaded at
 startup as separate documents in the schematic editor.
 .PP
 If no \fIFILE\fRs are specified, a blank schematic is created for
@@ -70,28 +70,30 @@ editing.
 .SH ENVIRONMENT
 .TP 8
 .B GEDADATA
-specifies the search directory for Scheme and rc files.  The default
-is `${prefix}/share/gEDA'.
+specifies the search directory for Scheme and rc files.
+The default is `${prefix}/share/gEDA'.
 .TP 8
 .B GEDADATARC
-specifies the search directory for rc files.  The default is `$GEDADATA'.
+specifies the search directory for rc files.
+The default is `$GEDADATA'.
 
 .SH AUTHORS
 See the `AUTHORS' file included with this program.
 
 .SH COPYRIGHT
 .nf
-Copyright \(co 1999-@YEAR@ gEDA Contributors.  License GPLv2+: GNU GPL
-version 2 or later.  Please see the `COPYING' file included with this
-program for full details.
+Copyright \(co 1998-2017 by Ales Hvezda and the respective original authors.
+Copyright \(co 2017-2018 Lepton Developers.
+License GPLv2+: GNU GPL version 2 or later. Please see the `COPYING'
+file included with this program for full details.
 .PP
 This is free software: you are free to change and redistribute it.
 There is NO WARRANTY, to the extent permitted by law.
 
 .SH SEE ALSO
-\fBgnetlist\fR(1), \fBlepton-symcheck\fR(1)
+\fBlepton-netlist\fR(1), \fBlepton-symcheck\fR(1)
 .PP
 The full documentation for
-.B gschem
-is available from within the program by selecting the `gEDA
-Documentation' option from the program's `Help' menu.
+.B lepton-schematic
+is available from within the program by selecting the
+`Documentation' option from the program's `Help' menu.

--- a/schematic/docs/lepton-schematic.1.in
+++ b/schematic/docs/lepton-schematic.1.in
@@ -8,12 +8,12 @@ lepton-schematic - Lepton EDA Schematic Capture
 .PP
 .B lepton-schematic
 is a schematic capture application, and is part of the
-Lepton EDA (Electronic Design Automation) toolset. It is used to draw
+Lepton EDA (Electronic Design Automation) toolset.  It is used to draw
 electronic schematics, which describe the logical structure of an
 circuit. Schematics are made up of symbols, which represent the
 various components in the circuit, and are obtained either from a
-standard library or created by the user. The connections between
-components represented by nets (wires). Schematics may be printed to
+standard library or created by the user.  The connections between
+components represented by nets (wires).  Schematics may be printed to
 a PostScript file for printing or further conversion to other output
 formats.  Output to various image formats is also supported.
 
@@ -27,7 +27,7 @@ schematics.
 Quiet mode. Turn off all warnings/notes/messages.
 .TP 8
 \fB-v\fR, \fB--verbose\fR
-Verbose mode. Output all diagnostic information.
+Verbose mode.  Output all diagnostic information.
 .TP 8
 \fB-L\fR \fIDIRECTORY\fR
 Prepend \fIDIRECTORY\fR to the list of directories to be searched for
@@ -40,9 +40,9 @@ Specify a Scheme script to be executed at startup.
 Specify a Scheme expression to be evaluated at startup.
 .TP 8
 \fB-o\fR, \fB--output\fR=\fIFILE\fR
-Specify a filename for PostScript output. This command line argument
+Specify a filename for PostScript output.  This command line argument
 is useful when running \fBlepton-schematic\fR from a shell script and with a
-Scheme script. The filename can be changed through the print dialog
+Scheme script.  The filename can be changed through the print dialog
 box.
 .TP 8
 \fB-p\fR
@@ -56,12 +56,12 @@ Print a help message.
 Print \fBlepton-schematic\fR version information.
 .TP 8
 \fB--\fR
-Treat all remaining arguments as schematic or symbol filenames. Use
+Treat all remaining arguments as schematic or symbol filenames.  Use
 this if you have a schematic or symbol filename which begins with `-'.
 
 .SH SCHEMATIC AND SYMBOL FILES
 Optionally, schematic or symbol \fIFILE\fRs may be specified on the
-command line. Any schematic or symbols specified are loaded at
+command line.  Any schematic or symbols specified are loaded at
 startup as separate documents in the schematic editor.
 .PP
 If no \fIFILE\fRs are specified, a blank schematic is created for
@@ -82,8 +82,7 @@ See the `AUTHORS' file included with this program.
 
 .SH COPYRIGHT
 .nf
-Copyright \(co 1998-2017 by Ales Hvezda and the respective original authors.
-Copyright \(co 2017-2018 Lepton Developers.
+Copyright \(co 2012-@YEAR@ gEDA Contributors.
 License GPLv2+: GNU GPL version 2 or later. Please see the `COPYING'
 file included with this program for full details.
 .PP

--- a/symcheck/docs/lepton-symcheck.1.in
+++ b/symcheck/docs/lepton-symcheck.1.in
@@ -112,17 +112,19 @@ specifies where the various required scheme and rc files are located
 not need to be set by the end user unless they are moving the executables
 to a new install ${prefix}.
 
-.SH "AUTHOR"
-Ales Hvezda and many others
+.SH AUTHORS
+See the `AUTHORS' file included with this program.
+
+.SH COPYRIGHT
+.nf
+Copyright \(co 1998-2017 by Ales Hvezda and the respective original authors.
+Copyright \(co 2017-2018 Lepton Developers.
+License GPLv2+: GNU GPL version 2 or later. Please see the `COPYING'
+file included with this program for full details.
+.PP
+This is free software: you are free to change and redistribute it.
+There is NO WARRANTY, to the extent permitted by law.
 
 .SH SEE ALSO
-.BR gschem (1),
-.BR gnetlist (1)
-.SH COPYRIGHT
-Copyright \(co 1999-2008 Ales Hvezda
-.nf
-Copyright \(co 1999-2017 gEDA Contributors.
-.nf
-Copyright \(co @YEAR@ Lepton EDA Contributors.
-This document can be freely redistributed according to the terms of the
-GNU General Public License version 2.0
+.BR lepton-schematic (1),
+.BR lepton-netlist (1)

--- a/symcheck/docs/lepton-symcheck.1.in
+++ b/symcheck/docs/lepton-symcheck.1.in
@@ -117,8 +117,7 @@ See the `AUTHORS' file included with this program.
 
 .SH COPYRIGHT
 .nf
-Copyright \(co 1998-2017 by Ales Hvezda and the respective original authors.
-Copyright \(co 2017-2018 Lepton Developers.
+Copyright \(co 2012-@YEAR@ gEDA Contributors.
 License GPLv2+: GNU GPL version 2 or later. Please see the `COPYING'
 file included with this program for full details.
 .PP

--- a/utils/docs/lepton-sch2pcb.1.in
+++ b/utils/docs/lepton-sch2pcb.1.in
@@ -1,26 +1,26 @@
-.TH gsch2pcb 1 "@DATE@" "Lepton EDA" @VERSION@
+.TH lepton-sch2pcb 1 "@DATE@" "Lepton EDA" @VERSION@
 .SH NAME
-gsch2pcb - Update PCB layouts from gEDA/gaf schematics
+lepton-sch2pcb - Update PCB layouts from Lepton EDA schematics
 .SH SYNOPSIS
-\fBgsch2pcb\fR [\fIOPTION\fR ...] {\fIPROJECT\fR | \fIFILE\fR ...}
+\fBlepton-sch2pcb\fR [\fIOPTION\fR ...] {\fIPROJECT\fR | \fIFILE\fR ...}
 .SH DESCRIPTION
 .PP
-\fBgsch2pcb\fR is a frontend to \fBgnetlist\fR(1) which aids in
+\fBlepton-sch2pcb\fR is a frontend to \fBlepton-netlist\fR(1) which aids in
 creating and updating \fBpcb\fR(1) printed circuit board layouts based
-on a set of electronic schematics created with \fBgschem\fR(1).
+on a set of electronic schematics created with \fBlepton-schematic\fR(1).
 
 .PP
-Instead of specifying all options and input gEDA schematic \fIFILE\fRs
-on the command line, \fBgsch2pcb\fR can use a \fIPROJECT\fR file
+Instead of specifying all options and input schematic \fIFILE\fRs
+on the command line, \fBlepton-sch2pcb\fR can use a \fIPROJECT\fR file
 instead.
 
 .PP
-\fBgsch2pcb\fR first runs \fBgnetlist\fR(1) with the `PCB' backend (or
+\fBlepton-sch2pcb\fR first runs \fBlepton-netlist\fR(1) with the `PCB' backend (or
 backend specified by --backend-net) to create a `<name>.net' file
 containing a \fBpcb\fR(1) formatted netlist for the design.
 
 .PP
-The second step is to run \fBgnetlist\fR(1) again with the `gsch2pcb'
+The second step is to run \fBlepton-netlist\fR(1) again with the `gsch2pcb'
 backend (or backend specified by --backend-pcb) to find any \fBM4\fR(1)
 elements required by the schematics.
 Any missing elements are found by searching a set of file element
@@ -35,7 +35,7 @@ elements are removed from the `<name>.pcb' file, with a backup in a
 `<name>.pcb.bak' file.
 
 .PP
-Finally, \fBgnetlist\fR(1) is run a third time with the `pcbpins'
+Finally, \fBlepton-netlist\fR(1) is run a third time with the `pcbpins'
 backend (or backend specified by --backend-cmd) to create a
 `<name>.cmd' file.  This can be loaded into \fBpcb\fR(1) to rename
 all pin names in the PCB layout to match the schematic.
@@ -66,7 +66,7 @@ Use the \fBM4\fR(1) file \fIFILE\fR in addition to the default M4
 files `./pcb.inc' and `~/.pcb/pcb.inc'.
 .TP 8
 \fB--m4-pcbdir\fR \fIDIRECTORY\fR
-Set \fIDIRECTORY\fR as the directory where \fBgsch2pcb\fR should look
+Set \fIDIRECTORY\fR as the directory where \fBlepton-sch2pcb\fR should look
 for \fBM4\fR(1) files installed by \fBpcb\fR(1).
 .TP 8
 \fB-r\fR, \fB--remove-unfound\fR
@@ -97,14 +97,14 @@ Use \fIBACKEND\fR to generate `<name>.pcb' file instead of
 the default one (`gsch2pcb').
 .TP 8
 \fB--gnetlist\fR \fIBACKEND\fR
-In addition to the default backends, run \fBgnetlist\fR(1) with `\-g
+In addition to the default backends, run \fBlepton-netlist\fR(1) with `\-g
 \fIBACKEND\fR', with output to `<name>.\fIBACKEND\fR'.
 .TP 8
 \fB--gnetlist-arg\fR \fIARG\fR
-Pass \fIARG\fR as an additional argument to \fBgnetlist\fR(1).
+Pass \fIARG\fR as an additional argument to \fBlepton-netlist\fR(1).
 .TP 8
 \fB--empty-footprint\fR \fINAME\fR
-If \fINAME\fR is not `none', \fBgsch2pcb\fR will not add elements for
+If \fINAME\fR is not `none', \fBlepton-sch2pcb\fR will not add elements for
 components with that name to the PCB file.  Note that if the omitted
 components have net connections, they will still appear in the netlist
 and \fBpcb\fR(1) will warn that they are missing.
@@ -115,7 +115,7 @@ If a schematic component's `footprint' attribute is not equal to the
 `Description' instead of replacing the element.
 .TP 8
 \fB-q\fR, \fB--quiet\fR
-Don't output information on steps to take after running \fBgsch2pcb\fR.
+Don't output information on steps to take after running \fBlepton-sch2pcb\fR.
 .TP 8
 \fB-v\fR, \fB--verbose\fR
 Output extra debugging information.  This option can be specified
@@ -125,11 +125,11 @@ twice (`\-v \-v') to obtain additional debugging for file elements.
 Print a help message.
 .TP 8
 \fB-V\fR, \fB--version\fR
-Print \fBgsch2pcb\fR version information.
+Print \fBlepton-sch2pcb\fR version information.
 
 .SH PROJECT FILES
 .PP
-A \fBgsch2pcb\fR project file is a file (not ending in `.sch')
+A \fBlepton-sch2pcb\fR project file is a file (not ending in `.sch')
 containing a list of schematics to process and some options.  Any
 long-form command line option can appear in the project file with the
 leading `\-\-' removed, with the exception of `\-\-gnetlist-arg',
@@ -145,21 +145,22 @@ An example project file might look like:
 
 .SH ENVIRONMENT
 .TP 8
-.B GNETLIST
-specifies the \fBgnetlist\fR(1) program to run.  The default is
-`gnetlist'.
+.B NETLISTER
+specifies the \fBnetlister\fR(1) program to run.  The default is
+`lepton-netlist'.
 
 .SH AUTHORS
 See the `AUTHORS' file included with this program.
 
 .SH COPYRIGHT
 .nf
-Copyright \(co 1999-@YEAR@ gEDA Contributors.  License GPLv2+: GNU GPL
-version 2 or later.  Please see the `COPYING' file included with this
-program for full details.
+Copyright \(co 1998-2017 by Ales Hvezda and the respective original authors.
+Copyright \(co 2017-2018 Lepton Developers.
+License GPLv2+: GNU GPL version 2 or later. Please see the `COPYING'
+file included with this program for full details.
 .PP
 This is free software: you are free to change and redistribute it.
 There is NO WARRANTY, to the extent permitted by law.
 
 .SH SEE ALSO
-\fBgschem\fR(1), \fBgnetlist\fR(1), \fBpcb\fR(1)
+\fBlepton-schematic\fR(1), \fBlepton-netlist\fR(1), \fBpcb\fR(1)

--- a/utils/docs/lepton-sch2pcb.1.in
+++ b/utils/docs/lepton-sch2pcb.1.in
@@ -154,8 +154,7 @@ See the `AUTHORS' file included with this program.
 
 .SH COPYRIGHT
 .nf
-Copyright \(co 1998-2017 by Ales Hvezda and the respective original authors.
-Copyright \(co 2017-2018 Lepton Developers.
+Copyright \(co 2012-@YEAR@ gEDA Contributors.
 License GPLv2+: GNU GPL version 2 or later. Please see the `COPYING'
 file included with this program for full details.
 .PP


### PR DESCRIPTION
Years in `COPYRIGHT` sections were entered by hand, since replacement
script in `Makefile.am` substitutes all of them with the date of last release
(26 Feb. 2017). Maybe it's better to modify that script, so that it insert the current date?