### PR TITLE
Statusbar: new configurable indicators, tooltips

### DIFF
--- a/schematic/include/gschem_bottom_widget.h
+++ b/schematic/include/gschem_bottom_widget.h
@@ -53,6 +53,8 @@ struct _GschemBottomWidget
   GtkWidget *rubber_band_label;
   gboolean  magnetic_net_mode;
   GtkWidget *magnetic_net_label;
+  GdkColor  status_inactive_color;
+  GdkColor  status_active_color;
 };
 
 

--- a/schematic/include/gschem_bottom_widget.h
+++ b/schematic/include/gschem_bottom_widget.h
@@ -55,6 +55,7 @@ struct _GschemBottomWidget
   GtkWidget *magnetic_net_label;
   GdkColor  status_inactive_color;
   GdkColor  status_active_color;
+  gboolean  status_bold_font;
 };
 
 

--- a/schematic/include/gschem_bottom_widget.h
+++ b/schematic/include/gschem_bottom_widget.h
@@ -49,6 +49,10 @@ struct _GschemBottomWidget
   int       snap_mode;
   int       snap_size;
   GtkWidget *status_label;
+  gboolean  rubber_band_mode;
+  GtkWidget *rubber_band_label;
+  gboolean  magnetic_net_mode;
+  GtkWidget *magnetic_net_label;
 };
 
 
@@ -76,6 +80,12 @@ gschem_bottom_widget_get_snap_size (GschemBottomWidget *widget);
 
 const char*
 gschem_bottom_widget_get_status_text (GschemBottomWidget *widget);
+
+gboolean
+gschem_bottom_widget_get_rubber_band_mode (GschemBottomWidget *widget);
+
+gboolean
+gschem_bottom_widget_get_magnetic_net_mode (GschemBottomWidget *widget);
 
 GType
 gschem_bottom_widget_get_type ();
@@ -106,3 +116,10 @@ gschem_bottom_widget_set_status_text (GschemBottomWidget *widget, const char *te
 
 void
 gschem_bottom_widget_set_status_text_color (GschemBottomWidget *widget, gboolean active);
+
+void
+gschem_bottom_widget_set_rubber_band_mode (GschemBottomWidget *widget, gboolean mode);
+
+void
+gschem_bottom_widget_set_magnetic_net_mode (GschemBottomWidget *widget, gboolean mode);
+

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -247,6 +247,7 @@ void i_update_menus(GschemToplevel *w_current);
 void i_set_filename(GschemToplevel *w_current, const gchar *string, const gchar *changed);
 void i_update_grid_info(GschemToplevel *w_current);
 void i_update_grid_info_callback (GschemPageView *view, GschemToplevel *w_current);
+void i_update_net_options_status (GschemToplevel* w_current);
 /* i_callbacks.c */
 void i_callback_file_new(gpointer data, guint callback_action, GtkWidget *widget);
 void i_callback_toolbar_file_new(GtkWidget *widget, gpointer data);

--- a/schematic/src/gschem_bottom_widget.c
+++ b/schematic/src/gschem_bottom_widget.c
@@ -501,12 +501,15 @@ gschem_bottom_widget_init (GschemBottomWidget *widget)
   g_return_if_fail (widget != NULL);
 
   widget->left_button_label = gtk_label_new (NULL);
+  gtk_widget_set_tooltip_text (widget->left_button_label, _("Left mouse button"));
   gtk_misc_set_padding (GTK_MISC (widget->left_button_label), LABEL_XPAD, LABEL_YPAD);
 
   widget->middle_button_label = gtk_label_new (NULL);
+  gtk_widget_set_tooltip_text (widget->middle_button_label, _("Middle mouse button"));
   gtk_misc_set_padding (GTK_MISC (widget->middle_button_label), LABEL_XPAD, LABEL_YPAD);
 
   widget->right_button_label = gtk_label_new (NULL);
+  gtk_widget_set_tooltip_text (widget->right_button_label, _("Right mouse button"));
   gtk_misc_set_padding (GTK_MISC (widget->right_button_label), LABEL_XPAD, LABEL_YPAD);
 
 
@@ -542,6 +545,7 @@ gschem_bottom_widget_init (GschemBottomWidget *widget)
 
 
   widget->grid_label = gtk_label_new (NULL);
+  gtk_widget_set_tooltip_text (widget->grid_label, _("(Snap size, Grid size)"));
   gtk_misc_set_padding (GTK_MISC (widget->grid_label), LABEL_XPAD, LABEL_YPAD);
   gtk_box_pack_start (GTK_BOX (widget), widget->grid_label, FALSE, FALSE, 0);
 
@@ -549,6 +553,7 @@ gschem_bottom_widget_init (GschemBottomWidget *widget)
   gtk_box_pack_start (GTK_BOX (widget), separator, FALSE, FALSE, 0);
 
   widget->rubber_band_label = gtk_label_new (NULL);
+  gtk_widget_set_tooltip_text (widget->rubber_band_label, _("Net rubber band mode"));
   gtk_misc_set_padding (GTK_MISC (widget->rubber_band_label), LABEL_XPAD, LABEL_YPAD);
   gtk_box_pack_start (GTK_BOX (widget), widget->rubber_band_label, FALSE, FALSE, 0);
 
@@ -556,10 +561,12 @@ gschem_bottom_widget_init (GschemBottomWidget *widget)
   gtk_box_pack_start (GTK_BOX (widget), separator, FALSE, FALSE, 0);
 
   widget->magnetic_net_label = gtk_label_new (NULL);
+  gtk_widget_set_tooltip_text (widget->magnetic_net_label, _("Magnetic net mode"));
   gtk_misc_set_padding (GTK_MISC (widget->magnetic_net_label), LABEL_XPAD, LABEL_YPAD);
   gtk_box_pack_start (GTK_BOX (widget), widget->magnetic_net_label, FALSE, FALSE, 0);
 
   widget->status_label = gtk_label_new (NULL);
+  gtk_widget_set_tooltip_text (widget->status_label, _("Current action mode"));
   gtk_misc_set_padding (GTK_MISC (widget->status_label), LABEL_XPAD, LABEL_YPAD);
   gtk_box_pack_end (GTK_BOX (widget), widget->status_label, FALSE, FALSE, 0);
 

--- a/schematic/src/gschem_bottom_widget.c
+++ b/schematic/src/gschem_bottom_widget.c
@@ -513,8 +513,10 @@ gschem_bottom_widget_init (GschemBottomWidget *widget)
   gtk_misc_set_padding (GTK_MISC (widget->right_button_label), LABEL_XPAD, LABEL_YPAD);
 
 
-  /* show mouse buttons indicators by default: */
-  gboolean show_mouse_indicators = TRUE;
+  /* default values for configuration settings: */
+  gboolean show_mouse_indicators       = TRUE;
+  gboolean show_rubber_band_indicator  = FALSE;
+  gboolean show_magnetic_net_indicator = FALSE;
 
   gchar* cwd = g_get_current_dir();
   EdaConfig* cfg = eda_config_get_context_for_path (cwd);
@@ -522,16 +524,37 @@ gschem_bottom_widget_init (GschemBottomWidget *widget)
 
   if (cfg != NULL)
   {
-    GError* err = NULL;
-    gboolean val = eda_config_get_boolean (cfg,
-                                           "schematic.status-bar",
-                                           "show-mouse-buttons",
-                                           &err);
+    GError*  err = NULL;
+    gboolean val = FALSE;
+
+    /* mouse indicators: */
+    val = eda_config_get_boolean (cfg,
+                                  "schematic.status-bar",
+                                  "show-mouse-buttons",
+                                  &err);
     if (err == NULL)
       show_mouse_indicators = val;
+    g_clear_error (&err);
 
+    /* net rubber band indicator: */
+    val = eda_config_get_boolean (cfg,
+                                  "schematic.status-bar",
+                                  "show-rubber-band",
+                                  &err);
+    if (err == NULL)
+      show_rubber_band_indicator = val;
+    g_clear_error (&err);
+
+    /* magnetic net indicator: */
+    val = eda_config_get_boolean (cfg,
+                                  "schematic.status-bar",
+                                  "show-magnetic-net",
+                                  &err);
+    if (err == NULL)
+      show_magnetic_net_indicator = val;
     g_clear_error (&err);
   }
+
 
   if (show_mouse_indicators)
   {
@@ -555,7 +578,10 @@ gschem_bottom_widget_init (GschemBottomWidget *widget)
   widget->rubber_band_label = gtk_label_new (NULL);
   gtk_widget_set_tooltip_text (widget->rubber_band_label, _("Net rubber band mode"));
   gtk_misc_set_padding (GTK_MISC (widget->rubber_band_label), LABEL_XPAD, LABEL_YPAD);
-  gtk_box_pack_start (GTK_BOX (widget), widget->rubber_band_label, FALSE, FALSE, 0);
+  if (show_rubber_band_indicator)
+  {
+    gtk_box_pack_start (GTK_BOX (widget), widget->rubber_band_label, FALSE, FALSE, 0);
+  }
 
   separator = gtk_vseparator_new ();
   gtk_box_pack_start (GTK_BOX (widget), separator, FALSE, FALSE, 0);
@@ -563,7 +589,10 @@ gschem_bottom_widget_init (GschemBottomWidget *widget)
   widget->magnetic_net_label = gtk_label_new (NULL);
   gtk_widget_set_tooltip_text (widget->magnetic_net_label, _("Magnetic net mode"));
   gtk_misc_set_padding (GTK_MISC (widget->magnetic_net_label), LABEL_XPAD, LABEL_YPAD);
-  gtk_box_pack_start (GTK_BOX (widget), widget->magnetic_net_label, FALSE, FALSE, 0);
+  if (show_magnetic_net_indicator)
+  {
+    gtk_box_pack_start (GTK_BOX (widget), widget->magnetic_net_label, FALSE, FALSE, 0);
+  }
 
   widget->status_label = gtk_label_new (NULL);
   gtk_widget_set_tooltip_text (widget->status_label, _("Current action mode"));

--- a/schematic/src/gschem_bottom_widget.c
+++ b/schematic/src/gschem_bottom_widget.c
@@ -519,6 +519,7 @@ gschem_bottom_widget_init (GschemBottomWidget *widget)
   gboolean show_magnetic_net_indicator = FALSE;
   gdk_color_parse ("black", &widget->status_inactive_color);
   gdk_color_parse ("green", &widget->status_active_color);
+  widget->status_bold_font = FALSE;
 
   gchar* cwd = g_get_current_dir();
   EdaConfig* cfg = eda_config_get_context_for_path (cwd);
@@ -566,6 +567,15 @@ gschem_bottom_widget_init (GschemBottomWidget *widget)
       gdk_color_parse (color, &widget->status_active_color);
       g_free (color);
     }
+    g_clear_error (&err);
+
+    /* status line bold font: */
+    val = eda_config_get_boolean (cfg,
+                                  "schematic.status-bar",
+                                  "status-bold-font",
+                                  &err);
+    if (err == NULL)
+      widget->status_bold_font = val;
     g_clear_error (&err);
   }
 
@@ -803,7 +813,10 @@ gschem_bottom_widget_set_status_text (GschemBottomWidget *widget, const char *te
 {
   g_return_if_fail (widget != NULL);
 
-  gtk_label_set_text (GTK_LABEL (widget->status_label), text);
+  gchar* str = g_strdup_printf (widget->status_bold_font ? "<b>%s</b>" : "%s",
+                                text);
+  gtk_label_set_markup (GTK_LABEL (widget->status_label), str);
+  g_free (str);
 
   g_object_notify (G_OBJECT (widget), "status-text");
 }

--- a/schematic/src/gschem_bottom_widget.c
+++ b/schematic/src/gschem_bottom_widget.c
@@ -517,6 +517,8 @@ gschem_bottom_widget_init (GschemBottomWidget *widget)
   gboolean show_mouse_indicators       = TRUE;
   gboolean show_rubber_band_indicator  = FALSE;
   gboolean show_magnetic_net_indicator = FALSE;
+  gdk_color_parse ("black", &widget->status_inactive_color);
+  gdk_color_parse ("green", &widget->status_active_color);
 
   gchar* cwd = g_get_current_dir();
   EdaConfig* cfg = eda_config_get_context_for_path (cwd);
@@ -552,6 +554,18 @@ gschem_bottom_widget_init (GschemBottomWidget *widget)
                                   &err);
     if (err == NULL)
       show_magnetic_net_indicator = val;
+    g_clear_error (&err);
+
+    /* status line active color: */
+    gchar* color = eda_config_get_string (cfg,
+                                          "schematic.status-bar",
+                                          "status-active-color",
+                                          &err);
+    if (color != NULL)
+    {
+      gdk_color_parse (color, &widget->status_active_color);
+      g_free (color);
+    }
     g_clear_error (&err);
   }
 
@@ -767,15 +781,15 @@ gschem_bottom_widget_set_status_text_color (GschemBottomWidget *widget, gboolean
 {
   g_return_if_fail (widget != NULL);
 
-  GdkColor color;
+  const GdkColor* color = NULL;
 
   if (active) {
-    gdk_color_parse ("green", &color);
+    color = &widget->status_active_color;
   } else {
-    gdk_color_parse ("black", &color);
+    color = &widget->status_inactive_color;
   }
 
-  gtk_widget_modify_fg (GTK_WIDGET (widget->status_label), GTK_STATE_NORMAL, &color);
+  gtk_widget_modify_fg (GTK_WIDGET (widget->status_label), GTK_STATE_NORMAL, color);
 }
 
 

--- a/schematic/src/gschem_bottom_widget.c
+++ b/schematic/src/gschem_bottom_widget.c
@@ -502,24 +502,44 @@ gschem_bottom_widget_init (GschemBottomWidget *widget)
 
   widget->left_button_label = gtk_label_new (NULL);
   gtk_misc_set_padding (GTK_MISC (widget->left_button_label), LABEL_XPAD, LABEL_YPAD);
-  gtk_box_pack_start (GTK_BOX (widget), widget->left_button_label, FALSE, FALSE, 0);
-
-  separator = gtk_vseparator_new ();
-  gtk_box_pack_start (GTK_BOX (widget), separator, FALSE, FALSE, 0);
 
   widget->middle_button_label = gtk_label_new (NULL);
   gtk_misc_set_padding (GTK_MISC (widget->middle_button_label), LABEL_XPAD, LABEL_YPAD);
-  gtk_box_pack_start (GTK_BOX (widget), widget->middle_button_label, FALSE, FALSE, 0);
-
-  separator = gtk_vseparator_new ();
-  gtk_box_pack_start (GTK_BOX (widget), separator, FALSE, FALSE, 0);
 
   widget->right_button_label = gtk_label_new (NULL);
   gtk_misc_set_padding (GTK_MISC (widget->right_button_label), LABEL_XPAD, LABEL_YPAD);
-  gtk_box_pack_start (GTK_BOX (widget), widget->right_button_label, FALSE, FALSE, 0);
 
-  separator = gtk_vseparator_new ();
-  gtk_box_pack_start (GTK_BOX (widget), separator, FALSE, FALSE, 0);
+
+  /* show mouse buttons indicators by default: */
+  gboolean show_mouse_indicators = TRUE;
+
+  gchar* cwd = g_get_current_dir();
+  EdaConfig* cfg = eda_config_get_context_for_path (cwd);
+  g_free (cwd);
+
+  if (cfg != NULL)
+  {
+    GError* err = NULL;
+    gboolean val = eda_config_get_boolean (cfg,
+                                           "schematic.status-bar",
+                                           "show-mouse-buttons",
+                                           &err);
+    if (err == NULL)
+      show_mouse_indicators = val;
+
+    g_clear_error (&err);
+  }
+
+  if (show_mouse_indicators)
+  {
+    gtk_box_pack_start (GTK_BOX (widget), widget->left_button_label, FALSE, FALSE, 0);
+    gtk_box_pack_start (GTK_BOX (widget), gtk_vseparator_new(), FALSE, FALSE, 0);
+    gtk_box_pack_start (GTK_BOX (widget), widget->middle_button_label, FALSE, FALSE, 0);
+    gtk_box_pack_start (GTK_BOX (widget), gtk_vseparator_new(), FALSE, FALSE, 0);
+    gtk_box_pack_start (GTK_BOX (widget), widget->right_button_label, FALSE, FALSE, 0);
+    gtk_box_pack_start (GTK_BOX (widget), gtk_vseparator_new(), FALSE, FALSE, 0);
+  }
+
 
   widget->grid_label = gtk_label_new (NULL);
   gtk_misc_set_padding (GTK_MISC (widget->grid_label), LABEL_XPAD, LABEL_YPAD);

--- a/schematic/src/gschem_options_widget.c
+++ b/schematic/src/gschem_options_widget.c
@@ -629,6 +629,11 @@ update_magnetic_net_mode_model (GschemOptionsWidget *widget)
 
   gschem_options_set_magnetic_net_mode (w_current->options,
                                         gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (widget->magnetic_net_widget)));
+
+  if (w_current->bottom_widget != NULL)
+  {
+    i_update_net_options_status (w_current);
+  }
 }
 
 
@@ -674,6 +679,11 @@ update_net_rubber_band_mode_model (GschemOptionsWidget *widget)
 
   gschem_options_set_net_rubber_band_mode (w_current->options,
                                            gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (widget->net_rubber_band_widget)));
+
+  if (w_current->bottom_widget != NULL)
+  {
+    i_update_net_options_status (w_current);
+  }
 }
 
 

--- a/schematic/src/i_basic.c
+++ b/schematic/src/i_basic.c
@@ -575,3 +575,22 @@ i_update_grid_info_callback (GschemPageView *view, GschemToplevel *w_current)
 {
   i_update_grid_info (w_current);
 }
+
+
+
+/*! \brief Update the status bar: rubber band, magnetic net modes
+ *
+ *  \param [in] w_current GschemToplevel structure
+ */
+void
+i_update_net_options_status (GschemToplevel* w_current)
+{
+  gschem_bottom_widget_set_rubber_band_mode(
+    GSCHEM_BOTTOM_WIDGET (w_current->bottom_widget),
+    gschem_options_get_net_rubber_band_mode (w_current->options));
+
+  gschem_bottom_widget_set_magnetic_net_mode(
+    GSCHEM_BOTTOM_WIDGET (w_current->bottom_widget),
+    gschem_options_get_magnetic_net_mode (w_current->options));
+}
+

--- a/schematic/src/x_window.c
+++ b/schematic/src/x_window.c
@@ -1350,7 +1350,7 @@ create_translate_widget (GschemToplevel *w_current, GtkWidget *work_box)
 static void
 create_bottom_widget (GschemToplevel *w_current, GtkWidget *main_box)
 {
-  char *right_button_text = NULL;
+  const char *right_button_text = NULL;
 
   if (default_third_button == POPUP_ENABLED)
   {
@@ -1379,6 +1379,10 @@ create_bottom_widget (GschemToplevel *w_current, GtkWidget *main_box)
                                gschem_options_get_snap_size (w_current->options),
                                "status-text",
                                _("Select Mode"),
+                               "net-rubber-band-mode",
+                               gschem_options_get_net_rubber_band_mode (w_current->options),
+                               "magnetic-net-mode",
+                               gschem_options_get_magnetic_net_mode (w_current->options),
                                NULL);
 
   w_current->bottom_widget = GTK_WIDGET (obj);


### PR DESCRIPTION
Closes #202 
- show tooltips for the status bar indicators
- new configuration settings, `[schematic.status-bar]` group:
  - `show-mouse-buttons`: on/off mouse buttons assignment indicators
  - `show-rubber-band`: on/off net rubber band mode indicator
  - `show-magnetic-net`: on/off magnetic net mode indicator
  - `status-active-color`: set color for the status line text when some mode is activated
  - `status-bold-font`: on/off display status line with bolder font weight

By default the status bar appearance does not change. 