### PR TITLE
Use cache directory to store program-specific settings

### DIFF
--- a/docs/specifications/config-api.txt
+++ b/docs/specifications/config-api.txt
@@ -21,6 +21,7 @@
         3.1.1  Default context
         3.1.2  System context
         3.1.3  User context
+        3.1.4  Cache context
       3.2  Loading configuration files
       3.3  Saving configuration files
       3.4  Context parents
@@ -127,10 +128,10 @@ Configuration contexts are reference counted.  You can increment and
 decrement their reference counters using ``g_object_ref()`` and
 ``g_object_unref()`` [GOBJECT]_.
 
-Three special contexts are always automatically defined: the `default
-context`_, the `system context`_, and the `user context`_.  The user
-context is the default parent context for newly-created configuration
-contexts.
+Four special contexts are always automatically defined: the `default
+context`_, the `system context`_, the `user context`_ and the
+`cache context`_.  The user context is the default parent context for
+newly-created configuration contexts.
 
 Obtaining a Context
 -------------------
@@ -228,6 +229,25 @@ Its parent context is the `system context`_.
 
 The configuration context returned by
 ``eda_config_get_user_context()`` is owned by the library, and should
+not be disposed of with ``g_object_unref()``.
+
+Cache context
+~~~~~~~~~~~~
+
+C function::
+
+  EdaConfig *eda_config_get_cache_context ()
+
+Scheme function::
+
+  None yet
+
+The cache context is used for program-specific configuration, and is
+loaded from ``${XDG_CACHE_HOME}/lepton-eda/gui.conf`` [XDGDIRS]_.
+It has no parent context.
+
+The configuration context returned by
+``eda_config_get_cache_context()`` is owned by the library, and should
 not be disposed of with ``g_object_unref()``.
 
 Loading configuration files
@@ -341,8 +361,8 @@ Configuration contexts can be flagged as being 'trusted'.  This allows
 code that needs to access such dangerous parameters to determine
 whether the value has been obtained from a safe source.
 
-By default, the `default context`_, `system context`_ and `user
-context`_ are trusted, and all other contexts untrusted.
+By default, the `default context`_, `system context`_, `user
+context`_ and `cache context`_ are trusted, and all other contexts untrusted.
 
 C function::
 

--- a/liblepton/include/liblepton/edaconfig.h
+++ b/liblepton/include/liblepton/edaconfig.h
@@ -96,6 +96,7 @@ GType eda_config_get_type (void) G_GNUC_CONST;
 EdaConfig *eda_config_get_context_for_file (GFile *path) G_GNUC_WARN_UNUSED_RESULT;
 EdaConfig *eda_config_get_context_for_path (const gchar *path) G_GNUC_WARN_UNUSED_RESULT;
 
+EdaConfig *eda_config_get_cache_context (void);
 EdaConfig *eda_config_get_default_context (void);
 EdaConfig *eda_config_get_system_context (void);
 EdaConfig *eda_config_get_user_context (void);

--- a/liblepton/include/liblepton/edapaths.h
+++ b/liblepton/include/liblepton/edapaths.h
@@ -30,6 +30,7 @@ const gchar * const *eda_get_system_data_dirs(void);
 const gchar * const *eda_get_system_config_dirs(void);
 const gchar *eda_get_user_data_dir(void);
 const gchar *eda_get_user_config_dir(void);
+const gchar *eda_get_user_cache_dir(void);
 
 /* ----------------------------------------------------------------
  * Initialisation

--- a/liblepton/include/liblepton/prototype.h
+++ b/liblepton/include/liblepton/prototype.h
@@ -28,6 +28,7 @@ SCM g_rc_mode_general(SCM scmmode, const char *rc_name, int *mode_var,
 gboolean g_rc_parse_system (TOPLEVEL *toplevel, const gchar *rcname, GError **err);
 gboolean g_rc_parse_user (TOPLEVEL *toplevel, const gchar *rcname, GError **err);
 gboolean g_rc_parse_local (TOPLEVEL *toplevel, const gchar *rcname, const gchar *path, GError **err);
+gboolean g_rc_load_cache_config (TOPLEVEL* toplevel, GError** err);
 void g_rc_parse(TOPLEVEL *toplevel, const gchar* pname, const gchar* rcname, const gchar* rcfile);
 void g_rc_parse_handler (TOPLEVEL *toplevel, const gchar *rcname, const gchar *rcfile, ConfigParseErrorFunc handler, void *user_data);
 SCM g_rc_rc_filename();

--- a/liblepton/src/edaconfig.c
+++ b/liblepton/src/edaconfig.c
@@ -54,6 +54,8 @@ struct _EdaConfigPrivate
 #define USER_CONFIG_NAME "geda-user.conf"
 /*! Filename for gEDA local configuration files */
 #define LOCAL_CONFIG_NAME "geda.conf"
+/*! Filename for gEDA configuration files in cache dir*/
+#define CACHE_CONFIG_NAME "gui.conf"
 
 static void eda_config_dispose (GObject *object);
 static void eda_config_finalize (GObject *object);
@@ -274,6 +276,45 @@ eda_config_get_property (GObject *object, guint property_id,
     G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
     break;
   }
+}
+
+/*! \public \memberof EdaConfig
+ * \brief Return the cache configuration context.
+ *
+ * This context is used for application-specific configuration,
+ * and is loaded from the cache directory: $XDG_CACHE_HOME,
+ * usually $HOME/.cache/lepton-eda
+ * It has no parent context.
+ *
+ * \return the cache #EdaConfig configuration context.
+ */
+EdaConfig*
+eda_config_get_cache_context()
+{
+  static gsize initialized = 0;
+  static EdaConfig* config = NULL;
+
+  if (g_once_init_enter (&initialized))
+  {
+    gchar* filename = NULL;
+    GFile* file;
+
+    filename = g_build_filename (eda_get_user_cache_dir(),
+                                 CACHE_CONFIG_NAME, NULL);
+
+    file = g_file_new_for_path (filename);
+
+    config = EDA_CONFIG (g_object_new (EDA_TYPE_CONFIG,
+                                       "file",    file,
+                                       "trusted", TRUE,
+                                       NULL));
+
+    g_free (filename);
+    g_object_unref (file);
+
+    g_once_init_leave (&initialized, 1);
+  }
+  return config;
 }
 
 /*! \public \memberof EdaConfig

--- a/liblepton/src/edapaths.c
+++ b/liblepton/src/edapaths.c
@@ -384,6 +384,22 @@ eda_get_user_config_dir(void)
 	return user_config_dir;
 }
 
+const gchar*
+eda_get_user_cache_dir()
+{
+  static gchar* user_cache_dir = NULL;
+
+  if (g_once_init_enter (&user_cache_dir))
+  {
+    gchar* dir = g_build_filename (g_get_user_cache_dir(),
+                                   DATA_XDG_SUBDIR, NULL);
+
+    g_once_init_leave (&user_cache_dir, dir);
+  }
+
+  return user_cache_dir;
+}
+
 /* ================================================================
  * Module initialisation
  * ================================================================ */
@@ -403,6 +419,7 @@ eda_paths_init(void)
 	eda_get_system_config_dirs();
 	eda_get_user_data_dir();
 	eda_get_user_config_dir();
+	eda_get_user_cache_dir();
 
 	eda_paths_init_env();
 }

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -386,6 +386,7 @@ void i_vars_set(GschemToplevel *w_current);
 void i_vars_freenames();
 void i_vars_init_gschem_defaults (void);
 void i_vars_atexit_save_user_config (gpointer user_data);
+void i_vars_atexit_save_cache_config (gpointer user_data);
  /* m_basic.c */
 int snap_grid(GschemToplevel *w_current, int input);
 int clip_nochange(GschemPageGeometry *geometry, int x1, int y1, int x2, int y2);

--- a/schematic/src/gschem_dialog.c
+++ b/schematic/src/gschem_dialog.c
@@ -148,7 +148,7 @@ static void geometry_restore (GschemDialog *dialog, EdaConfig *cfg, gchar* group
 static void show_handler (GtkWidget *widget)
 {
   gchar *group_name;
-  EdaConfig *cfg = eda_config_get_user_context ();
+  EdaConfig *cfg = eda_config_get_cache_context ();
   GschemDialog *dialog = GSCHEM_DIALOG( widget );
 
   if (dialog->settings_name != NULL) {
@@ -182,7 +182,7 @@ static void show_handler (GtkWidget *widget)
 static void unmap_handler (GtkWidget *widget)
 {
   gchar *group_name;
-  EdaConfig *cfg = eda_config_get_user_context ();
+  EdaConfig *cfg = eda_config_get_cache_context ();
   GschemDialog *dialog = GSCHEM_DIALOG (widget);
 
   if (dialog->settings_name != NULL) {

--- a/schematic/src/i_vars.c
+++ b/schematic/src/i_vars.c
@@ -227,3 +227,25 @@ i_vars_atexit_save_user_config (gpointer user_data)
     g_clear_error (&err);
   }
 }
+
+
+
+/*! \brief Save cache config on exit.
+ */
+void
+i_vars_atexit_save_cache_config (gpointer user_data)
+{
+  EdaConfig* cfg = eda_config_get_cache_context();
+
+  GError* err = NULL;
+  eda_config_save (cfg, &err);
+
+  if (err != NULL)
+  {
+    g_warning ("Failed to save cache configuration to '%1$s': %2$s.",
+               eda_config_get_filename (cfg),
+               err->message);
+    g_clear_error (&err);
+  }
+}
+

--- a/schematic/src/lepton-schematic.c
+++ b/schematic/src/lepton-schematic.c
@@ -214,7 +214,12 @@ void main_prog(void *closure, int argc, char *argv[])
 
   /* Set up default configuration */
   i_vars_init_gschem_defaults ();
+
+  /* Set up atexit handlers */
+  gschem_atexit (i_vars_atexit_save_cache_config, NULL);
+  /* Do no save user config:
   gschem_atexit (i_vars_atexit_save_user_config, NULL);
+  */
 
   /* Now read in RC files. */
   g_rc_parse_gtkrc();


### PR DESCRIPTION
Closes #214.
Now dialog geometry data is loaded from/saved to `~/.cache/lepton-eda/gui.conf` and `lepton-schematic` does not write to `geda-user.conf`.