### PR TITLE
Font selection widget

### DIFF
--- a/schematic/include/Makefile.am
+++ b/schematic/include/Makefile.am
@@ -39,7 +39,8 @@ noinst_HEADERS = \
 	gschem_text_properties_widget.h \
 	gschem_translate_widget.h \
 	gschem_toplevel.h \
-    color_edit_widget.h
+    color_edit_widget.h \
+    font_select_widget.h
 
 MOSTLYCLEANFILES = *.log core FILE *~
 CLEANFILES = *.log core FILE *~

--- a/schematic/include/font_select_widget.h
+++ b/schematic/include/font_select_widget.h
@@ -1,0 +1,66 @@
+/* Lepton EDA Schematic Capture
+ * Copyright (C) 2018 dmn <graahnul.grom@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/*!
+ * \file font_select_widget.h
+ *
+ * \brief Font selection widget
+ *
+ */
+
+#ifndef LEPTON_FONT_SELECT_WIDGET_H_
+#define LEPTON_FONT_SELECT_WIDGET_H_
+
+
+#define FONT_SELECT_WIDGET_TYPE (font_select_widget_get_type())
+/* cast [obj] to FontSelectWidget: */
+#define FONT_SELECT_WIDGET(obj) (G_TYPE_CHECK_INSTANCE_CAST ((obj), FONT_SELECT_WIDGET_TYPE, FontSelectWidget))
+/* cast [cls] to FontSelectWidgetClass: */
+#define FONT_SELECT_WIDGET_CLASS(cls) (G_TYPE_CHECK_CLASS_CAST ((cls), FONT_SELECT_WIDGET_TYPE, FontSelectWidgetClass))
+#define IS_FONT_SELECT_WIDGET(obj)        (G_TYPE_CHECK_INSTANCE_TYPE ((obj), FONT_SELECT_WIDGET_TYPE))
+#define FONT_SELECT_WIDGET_GET_CLASS(obj) (G_TYPE_INSTANCE_GET_CLASS ((obj), FONT_SELECT_WIDGET_TYPE, FontSelectWidgetClass))
+
+
+struct _FontSelectWidgetClass
+{
+  GschemBinClass parent_class;
+};
+
+struct _FontSelectWidget
+{
+  GschemBin parent_instance;
+
+  GschemToplevel* toplevel_;
+
+  GtkFontSelection* font_sel_;
+  GtkWidget*        font_label_;
+};
+
+typedef struct _FontSelectWidgetClass FontSelectWidgetClass;
+typedef struct _FontSelectWidget      FontSelectWidget;
+
+
+GtkWidget*
+font_select_widget_new (GschemToplevel* w_current);
+
+GType
+font_select_widget_get_type();
+
+
+#endif /* LEPTON_FONT_SELECT_WIDGET_H_ */
+

--- a/schematic/include/gschem.h
+++ b/schematic/include/gschem.h
@@ -53,6 +53,7 @@ typedef void (*i_callback_func) (gpointer, guint, GtkWidget*);
 #include "gschem_translate_widget.h"
 
 #include "color_edit_widget.h"
+#include "font_select_widget.h"
 
 /* Gettext translation */
 #include "gettext.h"

--- a/schematic/include/gschem_toplevel.h
+++ b/schematic/include/gschem_toplevel.h
@@ -72,6 +72,8 @@ struct st_gschem_toplevel {
   /* color scheme editor widget: */
   GtkWidget *color_edit_widget;
 
+  /* font selection widget: */
+  GtkWidget *font_select_widget;
 
   /* dialogs for widgets */
   GtkWidget *options_widget_dialog;
@@ -80,6 +82,7 @@ struct st_gschem_toplevel {
   GtkWidget *log_widget_dialog;
   GtkWidget *find_text_state_dialog;
   GtkWidget *color_edit_dialog;
+  GtkWidget *font_select_dialog;
 
 
   gchar *keyaccel_string;               /* visual feedback when pressing

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -775,6 +775,7 @@ void x_widgets_show_object_properties (GschemToplevel* w_current);
 void x_widgets_show_log (GschemToplevel* w_current);
 void x_widgets_show_find_text_state (GschemToplevel* w_current);
 void x_widgets_show_color_edit (GschemToplevel* w_current);
+void x_widgets_show_font_select (GschemToplevel* w_current);
 
 /* x_tabs.c */
 gboolean x_tabs_enabled();

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -151,6 +151,7 @@ SCM g_keys_options_rubberband(SCM rest);
 SCM g_keys_options_magneticnet(SCM rest);
 SCM g_keys_options_show_log_window(SCM rest);
 SCM g_keys_options_show_coord_window(SCM rest);
+SCM g_keys_options_select_font(SCM rest);
 SCM g_keys_help_about(SCM rest);
 SCM g_keys_help_hotkeys(SCM rest);
 SCM g_keys_cancel(SCM rest);
@@ -380,6 +381,7 @@ void i_callback_cancel(gpointer data, guint callback_action, GtkWidget *widget);
 void i_callback_help_about(gpointer data, guint callback_action, GtkWidget *widget);
 void i_callback_help_hotkeys(gpointer data, guint callback_action, GtkWidget *widget);
 void i_callback_options_show_coord_window(gpointer data, guint callback_action, GtkWidget *widget);
+void i_callback_options_select_font(gpointer data, guint callback_action, GtkWidget *widget);
 gboolean i_callback_close_wm(GtkWidget *widget, GdkEvent *event, gpointer data);
 /* i_vars.c */
 void i_vars_set(GschemToplevel *w_current);

--- a/schematic/lib/system-gschemrc.scm
+++ b/schematic/lib/system-gschemrc.scm
@@ -1268,7 +1268,8 @@
 ;;
 ;;          menu item name      menu action             menu stock icon
 ;;
-        `( (,(N_ "_Text Size...")            &options-text-size)
+        `( (,(N_ "_Font...")                 &options-select-font)
+           (,(N_ "Text Size...")             &options-text-size)
            (,(N_ "Cycle _grid styles")       &options-grid)
            (,(N_ "Toggle _Snap On/Off")      &options-snap)
            (,(N_ "Snap Grid S_pacing...")    &options-snap-size)

--- a/schematic/scheme/gschem/builtins.scm
+++ b/schematic/scheme/gschem/builtins.scm
@@ -383,6 +383,9 @@
 (define-action-public (&options-show-coord-window #:label (_ "Show Coordinate Window"))
   (%options-show-coord-window))
 
+(define-action-public (&options-select-font #:label (_ "Select Schematic Font"))
+  (%options-select-font))
+
 ;; -------------------------------------------------------------------
 ;;;; Documentation-related actions
 

--- a/schematic/src/Makefile.am
+++ b/schematic/src/Makefile.am
@@ -121,7 +121,8 @@ lepton_schematic_SOURCES = \
 	x_widgets.c \
 	scheme_undo.c \
 	x_tabs.c \
-	color_edit_widget.c
+	color_edit_widget.c \
+	font_select_widget.c
 
 lepton_schematic_CPPFLAGS = -I$(top_srcdir)/liblepton/include  -I$(srcdir)/../include \
 	-I$(top_srcdir) -I$(includedir)

--- a/schematic/src/font_select_widget.c
+++ b/schematic/src/font_select_widget.c
@@ -1,0 +1,506 @@
+/* Lepton EDA Schematic Capture
+ * Copyright (C) 2018 dmn <graahnul.grom@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/*!
+ * \file font_select_widget.c
+ *
+ * \brief Schematic font selection widget
+ *
+ */
+
+#include "gschem.h"
+
+
+/* convenience macro - gobject type implementation:
+*/
+G_DEFINE_TYPE (FontSelectWidget, font_select_widget, GSCHEM_TYPE_BIN);
+
+
+/* widget's property IDs:
+*/
+typedef enum
+{
+
+  PROP_0,       /* placeholder */
+  PROP_TOPLEVEL
+
+} FontSelectWidgetProps;
+
+
+/* --------------------------------------------------------
+ *
+ * forward declarations:
+ *
+ */
+
+static void
+font_select_widget_create (FontSelectWidget* widget);
+
+static void
+font_select_widget_on_show (GtkWidget* w);
+
+static void
+update_font_label (FontSelectWidget* widget, const gchar* font);
+
+static gchar*
+get_schematic_font (GschemToplevel* toplevel);
+
+static void
+set_schematic_font (GschemToplevel* toplevel, const gchar* font);
+
+static void
+save_schematic_font (GschemToplevel* toplevel, EdaConfig* cfg);
+
+static void
+on_btn_apply(GtkWidget* btn, gpointer p);
+
+static void
+on_btn_save(GtkWidget* btn, gpointer p);
+
+static gchar*
+font_sel_get_font (GtkFontSelection* sel);
+
+static void
+fontsel_set_font (FontSelectWidget* widget, const gchar* font);
+
+static EdaConfig*
+save_settings_dlg (FontSelectWidget* widget);
+
+
+
+
+/* --------------------------------------------------------
+ *
+ * object construction:
+ *
+ */
+
+GtkWidget*
+font_select_widget_new (GschemToplevel* w_current)
+{
+  gpointer obj = g_object_new (FONT_SELECT_WIDGET_TYPE,
+                               "toplevel", w_current,
+                               NULL);
+  return GTK_WIDGET (obj);
+}
+
+
+
+
+/* --------------------------------------------------------
+ *
+ * gobject stuff:
+ *
+ */
+
+static void
+get_property (GObject* obj, guint id, GValue* val, GParamSpec* spec)
+{
+  FontSelectWidget* widget = FONT_SELECT_WIDGET (obj);
+
+  if (id == PROP_TOPLEVEL)
+  {
+    g_value_set_pointer (val, widget->toplevel_);
+  }
+  else
+  {
+    G_OBJECT_WARN_INVALID_PROPERTY_ID (obj, id, spec);
+  }
+}
+
+
+
+static void
+set_property (GObject* obj, guint id, const GValue* val, GParamSpec* spec)
+{
+  FontSelectWidget* widget = FONT_SELECT_WIDGET (obj);
+
+  if (id == PROP_TOPLEVEL)
+  {
+    gpointer ptr = g_value_get_pointer (val);
+    widget->toplevel_ = GSCHEM_TOPLEVEL (ptr);
+  }
+  else
+  {
+    G_OBJECT_WARN_INVALID_PROPERTY_ID (obj, id, spec);
+  }
+}
+
+
+
+static void
+dispose (GObject* obj)
+{
+  FontSelectWidgetClass* cls = FONT_SELECT_WIDGET_GET_CLASS (obj);
+  GObjectClass* parent_cls = (GObjectClass*) g_type_class_peek_parent (cls);
+
+  parent_cls->dispose (obj);
+}
+
+
+
+static void
+font_select_widget_class_init (FontSelectWidgetClass* cls)
+{
+  GObjectClass* gcls = G_OBJECT_CLASS (cls);
+
+  gcls->dispose      = &dispose;
+  gcls->get_property = &get_property;
+  gcls->set_property = &set_property;
+
+  GParamFlags flags = (GParamFlags) (G_PARAM_CONSTRUCT_ONLY | G_PARAM_READWRITE);
+  GParamSpec* spec = g_param_spec_pointer ("toplevel", "", "", flags);
+  g_object_class_install_property (gcls, PROP_TOPLEVEL, spec);
+
+  GtkWidgetClass* wcls = GTK_WIDGET_CLASS( cls );
+
+  wcls->show = &font_select_widget_on_show;
+}
+
+
+
+static void
+font_select_widget_init (FontSelectWidget* widget)
+{
+  font_select_widget_create (widget);
+}
+
+
+
+
+/* --------------------------------------------------------
+ *
+ * implementation:
+ *
+ */
+
+static void
+font_select_widget_create (FontSelectWidget* widget)
+{
+  GtkWidget* vbox = gtk_vbox_new (FALSE, 0);
+  gtk_container_add (GTK_CONTAINER (widget), vbox);
+
+  /* GTK font selection widget: */
+  widget->font_sel_ = GTK_FONT_SELECTION (gtk_font_selection_new());
+  gtk_box_pack_start (GTK_BOX (vbox), GTK_WIDGET (widget->font_sel_), TRUE, TRUE, 0);
+
+  /* separator */
+  gtk_box_pack_start (GTK_BOX (vbox), gtk_hseparator_new(), FALSE, FALSE, 5);
+
+  /* horizontal container */
+  GtkWidget* hbox = gtk_hbox_new (FALSE, 0);
+  gtk_box_pack_start (GTK_BOX (vbox), hbox, FALSE, TRUE, 0);
+
+
+  /* apply button */
+  GtkWidget* btn_apply = gtk_button_new_with_mnemonic (_("_Apply"));
+  gtk_box_pack_start (GTK_BOX (hbox), btn_apply, FALSE, FALSE, 3);
+
+  /* save button */
+  GtkWidget* btn_save = gtk_button_new_with_mnemonic (_("Sa_ve..."));
+  gtk_box_pack_start (GTK_BOX (hbox), btn_save, FALSE, FALSE, 3);
+
+  /* horizontal container for the current schematic font label */
+  GtkWidget* hbox_lab = gtk_hbox_new (TRUE, 0);
+  gtk_box_pack_start (GTK_BOX (hbox), hbox_lab, TRUE, TRUE, 0);
+
+  /* current font label */
+  widget->font_label_ = gtk_label_new (NULL);
+  gtk_label_set_selectable(GTK_LABEL (widget->font_label_), TRUE);
+  gtk_box_pack_start (GTK_BOX (hbox_lab), widget->font_label_, FALSE, FALSE, 3);
+
+  /* separator */
+  gtk_box_pack_start (GTK_BOX (vbox), gtk_hseparator_new(), FALSE, FALSE, 5);
+
+  g_signal_connect (G_OBJECT (btn_apply),
+                    "clicked",
+                    G_CALLBACK (&on_btn_apply),
+                    widget);
+
+  g_signal_connect (G_OBJECT (btn_save),
+                    "clicked",
+                    G_CALLBACK (&on_btn_save),
+                    widget);
+
+  gtk_widget_show_all (GTK_WIDGET (widget));
+
+} /* font_select_widget_create() */
+
+
+
+static void
+font_select_widget_on_show (GtkWidget* w)
+{
+  FontSelectWidget* widget = FONT_SELECT_WIDGET (w);
+
+  g_return_if_fail (widget != NULL);
+
+  if (widget->toplevel_ == NULL)
+    return;
+
+  gchar* font = get_schematic_font (widget->toplevel_);
+
+  update_font_label (widget, font);
+  fontsel_set_font (widget, font);
+
+  g_free (font);
+
+  GTK_WIDGET_CLASS (font_select_widget_parent_class)->show (w);
+}
+
+
+
+/*! \brief Update label that displays current schematic font
+ *
+ *  \param widget Pointer to a FontSelectWidget
+ *  \param font   Font name to display
+ */
+static void
+update_font_label (FontSelectWidget* widget, const gchar* font)
+{
+  g_return_if_fail (widget != NULL);
+
+  gchar* str = g_strdup_printf (_("<b>Current:</b> %s"), font);
+  gtk_label_set_markup (GTK_LABEL (widget->font_label_), str);
+  g_free (str);
+}
+
+
+
+/*! \brief Get current renderer's \a font
+ *  \note  Caller must g_free() return value
+ *
+ *  \param toplevel Current gschem toplevel structure
+ *
+ *  \return Current schematic font name
+ */
+static gchar*
+get_schematic_font (GschemToplevel* toplevel)
+{
+  g_return_val_if_fail (toplevel != NULL, NULL);
+  g_return_val_if_fail (toplevel->renderer != NULL, NULL);
+
+  gchar* font = NULL;
+  g_object_get (toplevel->renderer, "font-name", &font, NULL);
+
+  return font;
+}
+
+
+
+/*! \brief Use specified \a font to render schematic's text
+ *
+ *  \param toplevel Current gschem toplevel structure
+ *  \param font     Font name
+ */
+static void
+set_schematic_font (GschemToplevel* toplevel, const gchar* font)
+{
+  g_return_if_fail (toplevel != NULL);
+  g_return_if_fail (toplevel->renderer != NULL);
+
+  g_object_set (toplevel->renderer, "font-name", font, NULL);
+
+  GschemPageView* view = gschem_toplevel_get_current_page_view (toplevel);
+  gschem_page_view_invalidate_all (view);
+}
+
+
+
+/*! \brief Save current schematic font to the configuration file
+ *
+ * *  \param toplevel Current gschem toplevel structure
+ * *  \param cfg      Configuration context to save settings to
+ */
+static void
+save_schematic_font (GschemToplevel* toplevel, EdaConfig* cfg)
+{
+  g_return_if_fail (toplevel != NULL);
+  g_return_if_fail (cfg != NULL);
+
+  gchar* font = get_schematic_font (toplevel);
+
+  if (cfg != NULL && font != NULL)
+  {
+    eda_config_set_string (cfg, "schematic.gui", "font", font);
+    eda_config_save (cfg, NULL);
+  }
+
+  g_free (font);
+}
+
+
+
+/*! \brief Select \a font in the GtkFontSelection widget, if possible
+ *
+ *  \param widget Pointer to a FontSelectWidget
+ *  \param font   Font name to select in GtkFontSelection widget
+ */
+static void
+fontsel_set_font (FontSelectWidget* widget, const gchar* font)
+{
+  g_return_if_fail (widget != NULL);
+
+  gtk_font_selection_set_font_name (widget->font_sel_, font);
+}
+
+
+
+
+/* --------------------------------------------------------
+ *
+ * signal handlers:
+ *
+ */
+
+static void
+on_btn_apply (GtkWidget* btn, gpointer p)
+{
+  FontSelectWidget* widget = (FontSelectWidget*) p;
+
+  g_return_if_fail (widget != NULL);
+  g_return_if_fail (widget->toplevel_ != NULL);
+
+  gchar* font = font_sel_get_font (widget->font_sel_);
+
+  set_schematic_font (widget->toplevel_, font);
+  update_font_label (widget, font);
+
+  g_free (font);
+
+} /* on_btn_apply() */
+
+
+
+static void
+on_btn_save (GtkWidget* btn, gpointer p)
+{
+  FontSelectWidget* widget = (FontSelectWidget*) p;
+
+  g_return_if_fail (widget != NULL);
+  g_return_if_fail (widget->toplevel_ != NULL);
+
+  EdaConfig* cfg = save_settings_dlg (widget);
+
+  if (cfg != NULL)
+  {
+    save_schematic_font (widget->toplevel_, cfg);
+  }
+
+} /* on_btn_save() */
+
+
+
+
+/* --------------------------------------------------------
+ *
+ * helpers:
+ *
+ */
+
+/*! \brief Get selected font as a string composed of family and face
+ *  \note  Caller must g_free() return value
+ *
+ *  \param sel Pointer to a GtkFontSelection widget
+ *
+ *  \return string in the form "family face"
+ */
+static gchar*
+font_sel_get_font (GtkFontSelection* sel)
+{
+  g_return_val_if_fail (sel != NULL, NULL);
+
+  PangoFontFamily* family = gtk_font_selection_get_family (sel);
+  const char* family_name = pango_font_family_get_name (family);
+
+  PangoFontFace* face = gtk_font_selection_get_face (sel);
+  const char* face_name = pango_font_face_get_face_name (face);
+
+  return g_strdup_printf ("%s %s", family_name, face_name);
+}
+
+
+
+/*! \brief Open save settings dialog
+ *
+ *  \param widget Pointer to a FontSelectWidget
+ *
+ *  \return configuration context to save settings to or NULL
+ */
+static EdaConfig*
+save_settings_dlg (FontSelectWidget* widget)
+{
+  g_return_val_if_fail (widget != NULL, FALSE);
+  g_return_val_if_fail (widget->toplevel_ != NULL, FALSE);
+
+  /* create dialog: */
+  GtkWidget* dlg = gtk_dialog_new_with_buttons(
+    _("Save configuration"),
+    GTK_WINDOW (widget->toplevel_->main_window),
+    GTK_DIALOG_MODAL,
+    GTK_STOCK_OK,     GTK_RESPONSE_ACCEPT,
+    GTK_STOCK_CANCEL, GTK_RESPONSE_REJECT,
+    NULL);
+
+  /* label: */
+  GtkWidget* lab = gtk_label_new (_("Save settings to:"));
+
+  /* radio buttons: */
+  GtkWidget* btn1 = gtk_radio_button_new_with_label (
+    NULL, _("Local configuration file (in current directory)"));
+  GtkWidget* btn2 = gtk_radio_button_new_with_label_from_widget(
+    GTK_RADIO_BUTTON (btn1), _("User configuration file (geda-user.conf)"));
+
+  /* pack to vbox: */
+  GtkWidget* vbox = gtk_vbox_new (TRUE, 0);
+  gtk_box_pack_start (GTK_BOX (vbox), lab,  TRUE, TRUE, 0);
+  gtk_box_pack_start (GTK_BOX (vbox), btn1, TRUE, TRUE, 0);
+  gtk_box_pack_start (GTK_BOX (vbox), btn2, TRUE, TRUE, 0);
+
+  /* pack vbox to dialog's content area: */
+  GtkWidget* ca = gtk_dialog_get_content_area (GTK_DIALOG (dlg));
+  gtk_box_pack_start (GTK_BOX (ca), vbox, TRUE, TRUE, 0);
+
+  /* show dialog: */
+  gtk_widget_show_all (dlg);
+  gint res = gtk_dialog_run (GTK_DIALOG (dlg));
+
+
+  EdaConfig* ctx = NULL;
+
+  if (res == GTK_RESPONSE_ACCEPT)
+  {
+    if (gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (btn1)))
+    {
+      gchar* cwd = g_get_current_dir();
+      ctx = eda_config_get_context_for_path (cwd);
+      g_free (cwd);
+    }
+    else
+    if (gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (btn2)))
+    {
+      ctx = eda_config_get_user_context();
+    }
+  }
+
+  gtk_widget_destroy (dlg);
+
+  return ctx;
+
+} /* save_settings_dlg() */
+

--- a/schematic/src/g_builtins.c
+++ b/schematic/src/g_builtins.c
@@ -150,6 +150,7 @@ static struct BuiltinInfo builtins[] = {
   { "%options-magneticnet",          0, 0, 0, (SCM (*) ()) g_keys_options_magneticnet },
   { "%options-show-log-window",      0, 0, 0, (SCM (*) ()) g_keys_options_show_log_window },
   { "%options-show-coord-window",    0, 0, 0, (SCM (*) ()) g_keys_options_show_coord_window },
+  { "%options-select-font",          0, 0, 0, (SCM (*) ()) g_keys_options_select_font },
   { "%help-about",                   0, 0, 0, (SCM (*) ()) g_keys_help_about },
   { "%help-hotkeys",                 0, 0, 0, (SCM (*) ()) g_keys_help_hotkeys },
   { "%cancel",                       0, 0, 0, (SCM (*) ()) g_keys_cancel },

--- a/schematic/src/g_keys.c
+++ b/schematic/src/g_keys.c
@@ -199,6 +199,7 @@ DEFINE_G_KEYS(options_rubberband)
 DEFINE_G_KEYS(options_magneticnet)
 DEFINE_G_KEYS(options_show_log_window)
 DEFINE_G_KEYS(options_show_coord_window)
+DEFINE_G_KEYS(options_select_font)
 
 DEFINE_G_KEYS(help_about)
 DEFINE_G_KEYS(help_hotkeys)

--- a/schematic/src/g_register.c
+++ b/schematic/src/g_register.c
@@ -240,6 +240,7 @@ static struct gsubr_t gschem_funcs[] = {
   { "options-magneticnet",          0, 0, 0, (SCM (*) ()) g_keys_options_magneticnet },
   { "options-show-log-window",      0, 0, 0, (SCM (*) ()) g_keys_options_show_log_window },
   { "options-show-coord-window",    0, 0, 0, (SCM (*) ()) g_keys_options_show_coord_window },
+  { "options-select-font",          0, 0, 0, (SCM (*) ()) g_keys_options_select_font },
   { "help-about",                   0, 0, 0, (SCM (*) ()) g_keys_help_about },
   { "help-hotkeys",                 0, 0, 0, (SCM (*) ()) g_keys_help_hotkeys },
   { "cancel",                       0, 0, 0, (SCM (*) ()) g_keys_cancel },

--- a/schematic/src/gschem_toplevel.c
+++ b/schematic/src/gschem_toplevel.c
@@ -194,6 +194,8 @@ GschemToplevel *gschem_toplevel_new ()
   /* color scheme editor widget: */
   w_current->color_edit_widget = NULL;
 
+  /* font selection widget: */
+  w_current->font_select_widget = NULL;
 
   /* dialogs for widgets */
   w_current->options_widget_dialog    = NULL;
@@ -202,6 +204,7 @@ GschemToplevel *gschem_toplevel_new ()
   w_current->log_widget_dialog        = NULL;
   w_current->find_text_state_dialog   = NULL;
   w_current->color_edit_dialog        = NULL;
+  w_current->font_select_dialog       = NULL;
 
 
   w_current->keyaccel_string = NULL;

--- a/schematic/src/i_callbacks.c
+++ b/schematic/src/i_callbacks.c
@@ -1419,6 +1419,8 @@ DEFINE_I_CALLBACK (view_color_edit)
 {
   GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
 
+  g_return_if_fail (w_current != NULL);
+
   x_widgets_show_color_edit (w_current);
 }
 
@@ -2981,6 +2983,15 @@ DEFINE_I_CALLBACK(options_show_coord_window)
 
   g_return_if_fail (w_current != NULL);
   coord_dialog (w_current, 0, 0);
+}
+
+DEFINE_I_CALLBACK(options_select_font)
+{
+  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
+
+  g_return_if_fail (w_current != NULL);
+
+  x_widgets_show_font_select (w_current);
 }
 
 /* these is a special wrapper function which cannot use the above */

--- a/schematic/src/x_widgets.c
+++ b/schematic/src/x_widgets.c
@@ -135,6 +135,8 @@ void x_widgets_create (GschemToplevel* w_current)
 
   w_current->color_edit_widget = color_edit_widget_new (w_current);
 
+  w_current->font_select_widget = font_select_widget_new (w_current);
+
 } /* x_widgets_create() */
 
 
@@ -256,6 +258,19 @@ void x_widgets_show_color_edit (GschemToplevel* w_current)
                             &w_current->color_edit_dialog,
                             _("Color Scheme Editor"),
                             "colored");
+}
+
+
+
+void x_widgets_show_font_select (GschemToplevel* w_current)
+{
+  g_return_if_fail (w_current != NULL);
+
+  x_widgets_show_in_dialog (w_current,
+                            GTK_WIDGET (w_current->font_select_widget),
+                            &w_current->font_select_dialog,
+                            _("Select Schematic Font"),
+                            "fontsel");
 }
 
 


### PR DESCRIPTION
Add widget that allow user to interactively select font
for rendering text in schematics. Settings for selected font 
can also be saved in either local or user configuration file.

![2018_06_30 19 34 24](https://user-images.githubusercontent.com/26083750/42127792-72204d6c-7ca7-11e8-9696-b28017540bc1.png)
