### PR TITLE
Add menu item to show the find text state window

### DIFF
--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -95,6 +95,7 @@ SCM g_keys_buffer_paste4(SCM rest);
 SCM g_keys_buffer_paste5(SCM rest);
 SCM g_keys_view_sidebar(SCM rest);
 SCM g_keys_view_status(SCM rest);
+SCM g_keys_view_find_text_state(SCM rest);
 SCM g_keys_view_redraw(SCM rest);
 SCM g_keys_view_zoom_full(SCM rest);
 SCM g_keys_view_zoom_extents(SCM rest);
@@ -300,6 +301,7 @@ void i_callback_edit_linetype(gpointer data, guint callback_action, GtkWidget *w
 void i_callback_edit_filltype(gpointer data, guint callback_action, GtkWidget *widget);
 void i_callback_view_sidebar(gpointer data, guint callback_action, GtkWidget *widget);
 void i_callback_view_status(gpointer data, guint callback_action, GtkWidget *widget);
+void i_callback_view_find_text_state(gpointer data, guint callback_action, GtkWidget *widget);
 void i_callback_view_redraw(gpointer data, guint callback_action, GtkWidget *widget);
 void i_callback_view_zoom_full(gpointer data, guint callback_action, GtkWidget *widget);
 void i_callback_view_zoom_extents(gpointer data, guint callback_action, GtkWidget *widget);

--- a/schematic/lib/system-gschemrc.scm
+++ b/schematic/lib/system-gschemrc.scm
@@ -1192,6 +1192,8 @@
         `( (,(N_ "Sidebar")             &view-sidebar           #f)
            (,(N_ "Status")              &view-status            #f)
            ("SEPARATOR"                 #f                      #f)
+           (,(N_ "Find Text State")     &view-find-text-state   #f)
+           ("SEPARATOR"                 #f                      #f)
            (,(N_ "_Redraw")             &view-redraw            "gtk-refresh")
            (,(N_ "_Pan")                &view-pan               #f)
            (,(N_ "Zoom _Box")           &view-zoom-box          #f)

--- a/schematic/scheme/gschem/builtins.scm
+++ b/schematic/scheme/gschem/builtins.scm
@@ -188,6 +188,9 @@
 (define-action-public (&view-status #:label (_ "Status"))
   (%view-status))
 
+(define-action-public (&view-find-text-state #:label (_ "Find Text State"))
+  (%view-find-text-state))
+
 (define-action-public (&view-redraw #:label (_ "Redraw") #:icon "gtk-refresh")
   (%view-redraw))
 

--- a/schematic/src/g_builtins.c
+++ b/schematic/src/g_builtins.c
@@ -95,6 +95,7 @@ static struct BuiltinInfo builtins[] = {
 
   { "%view-sidebar",                 0, 0, 0, (SCM (*) ()) g_keys_view_sidebar },
   { "%view-status",                  0, 0, 0, (SCM (*) ()) g_keys_view_status },
+  { "%view-find-text-state",         0, 0, 0, (SCM (*) ()) g_keys_view_find_text_state },
   { "%view-redraw",                  0, 0, 0, (SCM (*) ()) g_keys_view_redraw },
   { "%view-zoom-full",               0, 0, 0, (SCM (*) ()) g_keys_view_zoom_full },
   { "%view-zoom-extents",            0, 0, 0, (SCM (*) ()) g_keys_view_zoom_extents },

--- a/schematic/src/g_keys.c
+++ b/schematic/src/g_keys.c
@@ -128,6 +128,7 @@ DEFINE_G_KEYS(buffer_paste5)
 
 DEFINE_G_KEYS(view_sidebar)
 DEFINE_G_KEYS(view_status)
+DEFINE_G_KEYS(view_find_text_state)
 
 /* repeat middle shortcut doesn't make sense on redraw, just hit right
  * button */

--- a/schematic/src/g_register.c
+++ b/schematic/src/g_register.c
@@ -185,6 +185,7 @@ static struct gsubr_t gschem_funcs[] = {
 
   { "view-sidebar",                 0, 0, 0, (SCM (*) ()) g_keys_view_sidebar },
   { "view-status",                  0, 0, 0, (SCM (*) ()) g_keys_view_status },
+  { "view-find-text-state",         0, 0, 0, (SCM (*) ()) g_keys_view_find_text_state },
   { "view-redraw",                  0, 0, 0, (SCM (*) ()) g_keys_view_redraw },
   { "view-zoom-full",               0, 0, 0, (SCM (*) ()) g_keys_view_zoom_full },
   { "view-zoom-extents",            0, 0, 0, (SCM (*) ()) g_keys_view_zoom_extents },

--- a/schematic/src/i_callbacks.c
+++ b/schematic/src/i_callbacks.c
@@ -1128,6 +1128,18 @@ DEFINE_I_CALLBACK(view_status)
   gtk_widget_set_visible (GTK_WIDGET (w_current->bottom_notebook), !visible);
 }
 
+/*! \brief Show the find text state window
+ */
+DEFINE_I_CALLBACK(view_find_text_state)
+{
+  gboolean visible;
+  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
+
+  g_return_if_fail (w_current != NULL);
+
+  x_widgets_show_find_text_state (w_current);
+}
+
 /*! \todo Finish function documentation!!!
  *  \brief
  *  \par Function Description


### PR DESCRIPTION
When `lepton-schematic` is used with tabbed GUI, there is no way to reopen
the `find text state` window to see the search results: once closed, it's gone,
and the only option is to perform the search again.