### PR TITLE
build: Fix lepton multi-guile installation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,13 @@ packages:
 If you're having problems, make sure that you have all of the
 necessary `dev` or `devel` packages installed.
 
+> "I have installed two versions of guile, but `./configure`
+> uses a wrong one!"
+
+Specify right `guile` binary on the `configure` stage, e.g.:
+
+    ./configure GUILE=/usr/bin/guile-2.0
+
 Installation from a source archive
 ----------------------------------
 

--- a/netlist/scheme/Makefile.am
+++ b/netlist/scheme/Makefile.am
@@ -2,7 +2,7 @@
 ##
 bin_SCRIPTS = lepton-netlist
 
-do_subst = sed -e 's,[@]libdir[@],$(libdir),g'
+do_subst = sed -e 's,[@]libdir[@],$(libdir),g' -e 's,[@]GUILE[@],$(GUILE),g'
 
 lepton-netlist: lepton-netlist.in Makefile
 	$(do_subst) < $(srcdir)/$@.in > $@

--- a/netlist/scheme/lepton-netlist.in
+++ b/netlist/scheme/lepton-netlist.in
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-exec guile -s "$0" "$@"
+exec @GUILE@ -s "$0" "$@"
 !#
 ;;; Lepton EDA Netlister
 ;;; Scheme API

--- a/symcheck/scheme/Makefile.am
+++ b/symcheck/scheme/Makefile.am
@@ -3,7 +3,7 @@
 bin_SCRIPTS = lepton-symcheck
 EXTRA_DIST = lepton-symcheck.in
 
-do_subst = sed -e 's,[@]libdir[@],$(libdir),g'
+do_subst = sed -e 's,[@]libdir[@],$(libdir),g' -e 's,[@]GUILE[@],$(GUILE),g'
 
 lepton-symcheck: lepton-symcheck.in Makefile
 	$(do_subst) < $(srcdir)/$@.in > $@

--- a/symcheck/scheme/lepton-symcheck.in
+++ b/symcheck/scheme/lepton-symcheck.in
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-exec guile -s "$0" "$@"
+exec @GUILE@ -s "$0" "$@"
 !#
 ;;; Lepton EDA Symbol Checker
 ;;; Scheme API


### PR DESCRIPTION
This allows lepton-netlist and lepton-symcheck to work in
installation where several guile versions are installed. This is
required on such systems like Debian experimental where guile-2.2
and guile-2.0 could be installed together, while guile-2.2 is
still not supported by lepton.