### PR TITLE
Fix duplicates in 'lepton-netlist --list-backends' output

### DIFF
--- a/netlist/scheme/gnetlist.scm
+++ b/netlist/scheme/gnetlist.scm
@@ -815,7 +815,7 @@ begins with \"gnet-\" and ends with \".scm\"."
           (log! 'warning (_ "Can't open directory ~S.\n") path)
           '())))
 
-  (let ((backend-files (append-map path-backends %load-path)))
+  (let ((backend-files (append-map path-backends (delete-duplicates %load-path))))
     (display (_ "List of available backends: \n\n"))
     (display (string-join
               (sort! (map backend-name backend-files) string-locale<?)


### PR DESCRIPTION
Do not list each backend multiple times if guile
`%load-path` contains duplicated entries.
Why `GEDADATADIR/scheme` appears twice (or thrice) in `%load-path`
is another matter and needs further investigation. Duplicated
`%load-path` dirs may be as well accidentally set by the user.
Anyway, 'lepton-netlist --list-backends' should behave correctly:
do not print duplicated names of backends.