### PR TITLE
build: Fix libleptonrenderer version.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -185,7 +185,7 @@ AX_PCB_DIRS
 # Set up liblepton with the correct ld version number
 AX_LIBLEPTON([2:0:0])
 # Set up libleptonrenderer with the correct ld version number
-AX_LIBLEPTONRENDERER([1:0:1])
+AX_LIBLEPTONRENDERER([1:1:0])
 
 #####################################################################
 # Generate output


### PR DESCRIPTION
The version has been mistakenly changed in 1.9.4 where I changed
the `age' (3rd) field instead of the `revision' (2nd) field.