### PR TITLE
Fix netlisting for graphical components.

### DIFF
--- a/netlist/scheme/gnetlist.scm
+++ b/netlist/scheme/gnetlist.scm
@@ -368,12 +368,22 @@ NETNAME."
     (and x
          (string=? x netname)))
 
+  (define netlist
+    (schematic-netlist toplevel-schematic))
+
+  (define non-graphical-refdeses
+    (filter-map package-refdes netlist))
+
+  (define (non-graphical? refdes)
+    (member refdes non-graphical-refdeses))
+
   (define (get-found-pin-connections pin)
     (if (found? (package-pin-name pin))
         (filter-map
          (lambda (net) (let ((package (pin-net-connection-package net))
                         (pinnumber (pin-net-connection-pinnumber net)))
                     (and package
+                         (non-graphical? package)
                          pinnumber
                          (cons package pinnumber))))
          (package-pin-nets pin))
@@ -385,7 +395,7 @@ NETNAME."
        (append-map get-found-pin-connections (package-pins package)))
      netlist))
 
-  (sort-remove-duplicates (get-netlist-connections (schematic-netlist toplevel-schematic))
+  (sort-remove-duplicates (get-netlist-connections netlist)
                           pair<?))
 
 


### PR DESCRIPTION
The lepton-netlist function `get-all-connections` doesn't any more
ignore the fact that components connected to nets are graphical,
which led to outputting of wrong netlists previously.

Closes #250