### PR TITLE
Script-friendly lepton-netlist --list-backends output

### DIFF
--- a/netlist/scheme/gnetlist.scm
+++ b/netlist/scheme/gnetlist.scm
@@ -826,7 +826,6 @@ begins with \"gnet-\" and ends with \".scm\"."
           '())))
 
   (let ((backend-files (append-map path-backends (delete-duplicates %load-path))))
-    (display (_ "List of available backends: \n\n"))
     (display (string-join
               (sort! (map backend-name backend-files) string-locale<?)
               "\n"


### PR DESCRIPTION
Do not print "List of available backends:" message.