### PR TITLE
Fix lepton-schematic -q command line option

### DIFF
--- a/schematic/src/parsecmd.c
+++ b/schematic/src/parsecmd.c
@@ -27,7 +27,7 @@
 
 #include "gschem.h"
 
-#define GETOPT_OPTIONS "c:hL:o:pq:s:vV"
+#define GETOPT_OPTIONS "c:hL:o:pqs:vV"
 
 extern char *optarg;
 extern int optind;


### PR DESCRIPTION
-q (--quiet) command line option does not take an argument.