### PR TITLE
Simplify drc2 code

### DIFF
--- a/netlist/scheme/gnet-drc2.scm
+++ b/netlist/scheme/gnet-drc2.scm
@@ -747,6 +747,7 @@
 ;;; Write my special testing netlist format
 (define (drc2 output-filename)
   (let ((nets (schematic-nets toplevel-schematic))
+        (nc-nets (schematic-nc-nets toplevel-schematic))
         (non-unique-packages (schematic-non-unique-packages toplevel-schematic))
         (packages (schematic-packages toplevel-schematic))
         (netlist (schematic-netlist toplevel-schematic)))
@@ -769,7 +770,7 @@
 
     ;; Check for NoConnection nets with more than one pin connected.
     (not-defined? 'dont-check-connected-noconnects
-                  => (drc2:check-connected-noconnects (schematic-nc-nets toplevel-schematic)))
+                  => (drc2:check-connected-noconnects nc-nets))
 
     ;; Check nets with only one connection
     (not-defined? 'dont-check-one-connection-nets

--- a/netlist/scheme/gnet-drc2.scm
+++ b/netlist/scheme/gnet-drc2.scm
@@ -474,20 +474,13 @@
 ;; Example of all-nets: (net1 net2 net3 net4)
 (define (drc2:check-single-nets nets)
   (define (check-net netname)
-    (let ((directives (gnetlist:graphical-objs-in-net-with-attrib-get-attrib
+    (let ((connections (get-all-connections netname)))
+      (and (= (length connections) 0)
+           (drc2:error "Net '~A' has no connections." netname))
+      (and (= (length connections) 1)
+           (drc2:error "Net '~A' is connected to only one pin: ~A."
                        netname
-                       "device=DRC_Directive"
-                       "value"))
-          (connections (get-all-connections netname)))
-      ;; If one of the directives is NoConnection,
-      ;; then it shouldn't be checked.
-      (when (not (member "NoConnection" directives))
-        (and (= (length connections) 0)
-             (drc2:error "Net '~A' has no connections." netname))
-        (and (= (length connections) 1)
-             (drc2:error "Net '~A' is connected to only one pin: ~A."
-                         netname
-                         (pins-of-type->string 'all connections))))))
+                       (pins-of-type->string 'all connections)))))
 
   (display "Checking nets with only one connection...\n")
   (for-each check-net nets)
@@ -668,7 +661,6 @@
                                               netname))
       (and (not (defined? 'dont-check-not-driven-nets))
            (not (member "DontCheckIfDriven" directives))
-           (not (member "NoConnection" directives))
            (not (drc2:check-if-net-is-driven pintype-count 0))
            (drc2:error "Net ~A is not driven." netname))))
   (display "Checking type of pins connected to a net...\n")


### PR DESCRIPTION
Get rid of superfluous checks for "NoConnection" directives, as the fixed functions already work with filtered nets.
Affects #172.