### PR TITLE
Improve diagnostics of input file errors

### DIFF
--- a/liblepton/include/liblepton/globals.h
+++ b/liblepton/include/liblepton/globals.h
@@ -25,6 +25,8 @@
 #ifndef _GLOBALS_H_INCL
 #define _GLOBALS_H_INCL
 
+extern int verbose_loading;
+
 extern int do_logging;
 extern int logging_dest;
 

--- a/liblepton/include/liblepton/prototype.h
+++ b/liblepton/include/liblepton/prototype.h
@@ -156,5 +156,6 @@ TextBuffer *s_textbuffer_new (const gchar *data, const gint size, const gchar* n
 TextBuffer *s_textbuffer_free (TextBuffer *tb);
 const gchar *s_textbuffer_next (TextBuffer *tb, const gssize count);
 const gchar *s_textbuffer_next_line (TextBuffer *tb);
+gsize s_textbuffer_linenum (TextBuffer* tb);
 
 G_END_DECLS

--- a/liblepton/include/liblepton/prototype.h
+++ b/liblepton/include/liblepton/prototype.h
@@ -152,7 +152,7 @@ char *s_slot_search_slot(OBJECT *object, OBJECT **return_found);
 void s_slot_update_object(TOPLEVEL *toplevel, OBJECT *object);
 
 /* s_textbuffer.c */
-TextBuffer *s_textbuffer_new (const gchar *data, const gint size);
+TextBuffer *s_textbuffer_new (const gchar *data, const gint size, const gchar* name);
 TextBuffer *s_textbuffer_free (TextBuffer *tb);
 const gchar *s_textbuffer_next (TextBuffer *tb, const gssize count);
 const gchar *s_textbuffer_next_line (TextBuffer *tb);

--- a/liblepton/src/a_basic.c
+++ b/liblepton/src/a_basic.c
@@ -360,8 +360,13 @@ GList *o_read_buffer (TOPLEVEL *toplevel, GList *object_list,
   object_list = g_list_concat (object_list, new_object_list);
 
   return(object_list);
- error:
+
+error:
   geda_object_list_delete (toplevel, new_object_list);
+
+  gsize linenum = s_textbuffer_linenum (tb);
+  g_prefix_error (err, "Parsing stopped at line %lu:\n", linenum);
+
   return NULL;
 }
 

--- a/liblepton/src/a_basic.c
+++ b/liblepton/src/a_basic.c
@@ -115,7 +115,7 @@ GList *o_read_buffer (TOPLEVEL *toplevel, GList *object_list,
     return NULL;
   }
 
-  tb = s_textbuffer_new (buffer, size);
+  tb = s_textbuffer_new (buffer, size, name);
 
   while (1) {
 

--- a/liblepton/src/s_clib.c
+++ b/liblepton/src/s_clib.c
@@ -666,7 +666,7 @@ static void refresh_command (CLibSource *source)
   if (cmdout == NULL) return;
 
   /* Use a TextBuffer to help reading out the lines of the output */
-  tb = s_textbuffer_new (cmdout, -1);
+  tb = s_textbuffer_new (cmdout, -1, "s_clib.c::refresh_command()");
 
   while (1) {
     line = s_textbuffer_next_line (tb);

--- a/liblepton/src/s_textbuffer.c
+++ b/liblepton/src/s_textbuffer.c
@@ -65,9 +65,10 @@ struct _TextBuffer
  *
  *  \param data The address of the buffer to be managed.
  *  \param size The length of the buffer.
+ *  \param name Buffer name to display in verbose output
  *  \retval Pointer to a new TextBuffer struct.
  */
-TextBuffer *s_textbuffer_new (const gchar *data, const gint size)
+TextBuffer *s_textbuffer_new (const gchar *data, const gint size, const gchar* name)
 {
   TextBuffer *result;
   gsize realsize;

--- a/liblepton/src/s_textbuffer.c
+++ b/liblepton/src/s_textbuffer.c
@@ -47,6 +47,9 @@ struct _TextBuffer
   gsize linesize;
 
   gsize offset;
+
+  gsize linenum; /*!< incremented each time s_textbuffer_next_line() is called */
+
 };
 
 #define TEXT_BUFFER_LINE_SIZE 1024
@@ -84,6 +87,8 @@ TextBuffer *s_textbuffer_new (const gchar *data, const gint size)
 
   result->linesize = TEXT_BUFFER_LINE_SIZE;
   result->line = (gchar*) g_malloc(result->linesize);
+
+  result->linenum = 0;
 
   return result;
 }
@@ -197,5 +202,14 @@ s_textbuffer_next (TextBuffer *tb, const gssize count)
 const gchar *
 s_textbuffer_next_line (TextBuffer *tb)
 {
-  return s_textbuffer_next (tb, -1);
+  g_return_val_if_fail (tb != NULL, 0);
+
+  const gchar* line = s_textbuffer_next (tb, -1);
+
+  if (line != NULL)
+  {
+    ++tb->linenum;
+  }
+
+  return line;
 }

--- a/liblepton/src/s_textbuffer.c
+++ b/liblepton/src/s_textbuffer.c
@@ -91,6 +91,13 @@ TextBuffer *s_textbuffer_new (const gchar *data, const gint size, const gchar* n
 
   result->linenum = 0;
 
+  if (verbose_loading)
+  {
+    fprintf (stderr, "\n");
+    fprintf (stderr, "vvvvvvvvvvvvvvvvvvvv s_textbuffer_new(): [%s]\n", name);
+    fprintf (stderr, "\n");
+  }
+
   return result;
 }
 
@@ -112,6 +119,14 @@ TextBuffer *s_textbuffer_free (TextBuffer *tb)
   g_free (tb->line);
   tb->line = NULL;
   g_free (tb);
+
+  if (verbose_loading)
+  {
+    fprintf (stderr, "\n");
+    fprintf (stderr, "^^^^^^^^^^^^^^^^^^^^ s_textbuffer_free()\n");
+    fprintf (stderr, "\n");
+  }
+
   return NULL;
 }
 
@@ -210,6 +225,11 @@ s_textbuffer_next_line (TextBuffer *tb)
   if (line != NULL)
   {
     ++tb->linenum;
+
+    if (verbose_loading)
+    {
+      fprintf (stderr, "%-4lu: %s", tb->linenum, line);
+    }
   }
 
   return line;

--- a/liblepton/src/s_textbuffer.c
+++ b/liblepton/src/s_textbuffer.c
@@ -29,6 +29,15 @@
 
 #include "libgeda_priv.h"
 
+
+/*!
+ * When loading sch/sym files, print each line of the
+ * file while parsing it. 1 => enabled.
+ */
+int verbose_loading = 0;
+
+
+
 struct _TextBuffer
 {
   const gchar *buffer;

--- a/liblepton/src/s_textbuffer.c
+++ b/liblepton/src/s_textbuffer.c
@@ -201,6 +201,7 @@ s_textbuffer_next (TextBuffer *tb, const gssize count)
 
   return tb->line;
 }
+
 /*! \brief Fetch the next line from a text buffer
  *
  *  \par Function description
@@ -234,3 +235,19 @@ s_textbuffer_next_line (TextBuffer *tb)
 
   return line;
 }
+
+
+
+/*! \brief Get current line number of a text buffer
+ *
+ *  \param  tb TextBuffer.
+ *  \retval    Current line number.
+ */
+gsize
+s_textbuffer_linenum (TextBuffer* tb)
+{
+  g_return_val_if_fail (tb != NULL, 0);
+
+  return tb->linenum;
+}
+

--- a/liblepton/tests/test_text_object.c
+++ b/liblepton/tests/test_text_object.c
@@ -188,7 +188,8 @@ check_serialization ()
     s_delete_object (toplevel, object0);
     g_assert (buffer0 != NULL);
 
-    TextBuffer *tb = s_textbuffer_new (buffer0, -1);
+    TextBuffer *tb = s_textbuffer_new (buffer0, -1,
+                                       "test_text_object.c::check_serialization()");
     gchar *line = s_textbuffer_next_line (tb);
 
     GedaObject *object1 = o_text_read (toplevel,

--- a/schematic/src/parsecmd.c
+++ b/schematic/src/parsecmd.c
@@ -145,6 +145,7 @@ parse_commandline(int argc, char *argv[])
     switch (ch) {
       case 'v':
         verbose_mode = TRUE;
+        verbose_loading = TRUE; /* defined in liblepton: globals.h s_textbuffer.c */
         break;
 
       case 'q':

--- a/schematic/src/x_window.c
+++ b/schematic/src/x_window.c
@@ -771,7 +771,15 @@ x_window_open_page_impl (GschemToplevel *w_current, const gchar *filename)
          GTK_DIALOG_DESTROY_WITH_PARENT,
          GTK_MESSAGE_ERROR,
          GTK_BUTTONS_CLOSE,
-         _("<b>An error occurred while loading the requested file.</b>\n\nLoading from '%1$s' failed: %2$s. The gschem log may contain more information."),
+         _("<b>An error occurred while loading the requested file.</b>"
+           "\n\n"
+           "Loading from '%1$s' failed. Error message:"
+           "\n\n"
+           "%2$s."
+           "\n\n"
+           "The lepton-schematic log may contain more information.\n"
+           "You may also launch lepton-schematic with --verbose command"
+           " line switch and monitor program's output in terminal window."),
          fn, err->message);
       gtk_window_set_title (GTK_WINDOW (dialog), _("Failed to load file"));
       gtk_dialog_run (GTK_DIALOG (dialog));


### PR DESCRIPTION
- make `lepton-schematic` print input file line by line when invoked with `-v` (`--verbose`) flag
- better `"Failed to load file"` error message (include line number where the parser was stopped)

![tb_083_parse_verb_screenshot](https://user-images.githubusercontent.com/26083750/47798204-f39f2380-dd38-11e8-8ab6-81c4ec22f9c7.png)
