### PR TITLE
Netlister improvements

### DIFF
--- a/netlist/scheme/gnet-allegro.scm
+++ b/netlist/scheme/gnet-allegro.scm
@@ -128,7 +128,7 @@
 
 (define (allegro output-filename)
   (let ((use-stdout? (not output-filename))
-        (packages (schematic-packages toplevel-schematic))
+        (packages (schematic-package-names toplevel-schematic))
         (nets (schematic-nets toplevel-schematic)))
     (display "(Allegro netlister by M. Ettus)\n")
     (display "$PACKAGES\n")

--- a/netlist/scheme/gnet-bae.scm
+++ b/netlist/scheme/gnet-bae.scm
@@ -70,7 +70,7 @@
 (define (bae output-filename)
   (display "LAYOUT board;\n")
   (display "PARTS\n")
-  (bae:components (schematic-packages toplevel-schematic))
+  (bae:components (schematic-package-names toplevel-schematic))
   (display "CONNECT\n")
   (bae:nets (schematic-nets toplevel-schematic))
   (display "END.\n"))

--- a/netlist/scheme/gnet-bom.scm
+++ b/netlist/scheme/gnet-bom.scm
@@ -128,7 +128,7 @@ An error will be displayed, if no attribute name source is found."
          (option-attribs (backend-option-ref options 'attribs))
          (attriblist (bom:parseconfig option-filename option-attribs)))
     (bom:printlist (cons "refdes" attriblist))
-    (bom:components (schematic-packages toplevel-schematic)
+    (bom:components (schematic-package-names toplevel-schematic)
                     attriblist)))
 
 ;;

--- a/netlist/scheme/gnet-bom2.scm
+++ b/netlist/scheme/gnet-bom2.scm
@@ -62,7 +62,7 @@
            (begin
              (bom2:printlist (append (cons 'refdes attriblist) (list "qty")) #\:)
              (newline)
-             (bom2:printbom (bom2:components (schematic-packages toplevel-schematic)
+             (bom2:printbom (bom2:components (schematic-package-names toplevel-schematic)
                                              attriblist)
                             0))))))
 

--- a/netlist/scheme/gnet-cascade.scm
+++ b/netlist/scheme/gnet-cascade.scm
@@ -128,7 +128,7 @@ Writing to ~S...
                   "stdout")))
 
      (let ((first_block #f)
-           (packages (schematic-packages toplevel-schematic)))
+           (packages (schematic-package-names toplevel-schematic)))
 
         ;; write the header
         (display "# Cascade (http://rfcascade.sourceforge.net)\n")

--- a/netlist/scheme/gnet-drc.scm
+++ b/netlist/scheme/gnet-drc.scm
@@ -71,7 +71,7 @@
 
 
 (define (drc output-filename)
-  (drc:device-rules drc:attriblist (schematic-packages toplevel-schematic))
+  (drc:device-rules drc:attriblist (schematic-package-names toplevel-schematic))
   (drc:net-rules (schematic-nets toplevel-schematic)))
 
 ;;

--- a/netlist/scheme/gnet-drc2.scm
+++ b/netlist/scheme/gnet-drc2.scm
@@ -740,7 +740,8 @@
 (define (drc2 output-filename)
   (let ((nets (schematic-nets toplevel-schematic))
         (nc-nets (schematic-nc-nets toplevel-schematic))
-        (non-unique-packages (schematic-non-unique-packages toplevel-schematic))
+        (non-unique-packages (schematic-non-unique-package-names
+                              (schematic-netlist toplevel-schematic)))
         (packages (schematic-package-names toplevel-schematic))
         (netlist (schematic-netlist toplevel-schematic)))
 

--- a/netlist/scheme/gnet-drc2.scm
+++ b/netlist/scheme/gnet-drc2.scm
@@ -741,7 +741,7 @@
   (let ((nets (schematic-nets toplevel-schematic))
         (nc-nets (schematic-nc-nets toplevel-schematic))
         (non-unique-packages (schematic-non-unique-packages toplevel-schematic))
-        (packages (schematic-packages toplevel-schematic))
+        (packages (schematic-package-names toplevel-schematic))
         (netlist (schematic-netlist toplevel-schematic)))
 
     ;; Perform DRC-matrix sanity checks.

--- a/netlist/scheme/gnet-eagle.scm
+++ b/netlist/scheme/gnet-eagle.scm
@@ -84,7 +84,7 @@
 
 (define (eagle output-filename)
   (let ((nets (schematic-nets toplevel-schematic))
-        (packages (schematic-packages toplevel-schematic)))
+        (packages (schematic-package-names toplevel-schematic)))
     ;; initialize the net-name aliasing
     (gnetlist:build-net-aliases eagle:map-net-names nets)
 

--- a/netlist/scheme/gnet-ewnet.scm
+++ b/netlist/scheme/gnet-ewnet.scm
@@ -274,7 +274,7 @@
     (message "--------------------------------------\n\n")
 
     (let ((all-nets (schematic-nets toplevel-schematic))
-          (packages (schematic-packages toplevel-schematic)))
+          (packages (schematic-package-names toplevel-schematic)))
 
       ;; initialize the net-name aliasing
       (gnetlist:build-net-aliases ewnet:map-net-names all-nets)

--- a/netlist/scheme/gnet-futurenet2.scm
+++ b/netlist/scheme/gnet-futurenet2.scm
@@ -214,7 +214,7 @@
   (message "-------------------------------------------\n\n")
 
   (let ((all-nets (schematic-nets toplevel-schematic))
-        (packages (schematic-packages toplevel-schematic)))
+        (packages (schematic-package-names toplevel-schematic)))
 
     ;; initialize the net-name aliasing
     (gnetlist:build-net-aliases futurenet2:map-net-names all-nets)

--- a/netlist/scheme/gnet-geda.scm
+++ b/netlist/scheme/gnet-geda.scm
@@ -150,7 +150,7 @@ END \"no-connect\" nets
 (define (geda output-filename)
   (geda:write-top-header)
   (geda:graphicals (schematic-graphicals toplevel-schematic))
-  (geda:components (schematic-packages toplevel-schematic))
+  (geda:components (schematic-package-names toplevel-schematic))
   (no-connect-nets (schematic-nc-nets toplevel-schematic))
   (geda:renamed-nets (gnetlist:get-renamed-nets "dummy"))
   (geda:nets (schematic-nets toplevel-schematic)))

--- a/netlist/scheme/gnet-gossip.scm
+++ b/netlist/scheme/gnet-gossip.scm
@@ -106,7 +106,7 @@
 
 (define (gossip output-filename)
   (let ((nets (schematic-nets toplevel-schematic))
-        (packages (schematic-packages toplevel-schematic))
+        (packages (schematic-package-names toplevel-schematic))
         (blockname (or (schematic-toplevel-attrib toplevel-schematic 'blockname)
                        "not found")))
     (gossip:write-top-header)

--- a/netlist/scheme/gnet-gsch2pcb.scm.in
+++ b/netlist/scheme/gnet-gsch2pcb.scm.in
@@ -288,7 +288,7 @@ gsch2pcb backend configuration:
           (if gsch2pcb:use-m4 "yes" "no")
           (gsch2pcb:build-m4-command-line))
 
-  (let ((packages (schematic-packages toplevel-schematic)))
+  (let ((packages (schematic-package-names toplevel-schematic)))
     ;; If we have defined gsch2pcb:use-m4 then run the footprints
     ;; through the pcb m4 setup.  Otherwise skip m4 entirely
     (if gsch2pcb:use-m4

--- a/netlist/scheme/gnet-mathematica.scm
+++ b/netlist/scheme/gnet-mathematica.scm
@@ -106,7 +106,7 @@
 
 (define (mathematica output-filename)
   (let ((nets (schematic-nets toplevel-schematic))
-        (packages (schematic-packages toplevel-schematic)))
+        (packages (schematic-package-names toplevel-schematic)))
     (display (netnames->pin-voltages nets))
     (display "nodeEquations={\n")
     (display (netnames->current-string nets))

--- a/netlist/scheme/gnet-maxascii.scm
+++ b/netlist/scheme/gnet-maxascii.scm
@@ -81,7 +81,7 @@
 (define (maxascii output-filename)
   (display "*OrCAD\n*START\n")
 
-  (maxascii:components (schematic-packages toplevel-schematic))
+  (maxascii:components (schematic-package-names toplevel-schematic))
 
   (maxascii:write-net (schematic-nets toplevel-schematic))
   (display "\n*END\n"))

--- a/netlist/scheme/gnet-osmond.scm
+++ b/netlist/scheme/gnet-osmond.scm
@@ -24,7 +24,7 @@
 (use-modules (netlist schematic))
 
 (define (osmond output-filename)
-        (for-each osmond:part (schematic-packages toplevel-schematic))
+        (for-each osmond:part (schematic-package-names toplevel-schematic))
         (for-each osmond:signal (schematic-nets toplevel-schematic)))
 
 

--- a/netlist/scheme/gnet-pads.scm
+++ b/netlist/scheme/gnet-pads.scm
@@ -100,7 +100,7 @@
 
 (define (pads output-filename)
   (let ((nets (schematic-nets toplevel-schematic))
-        (packages (schematic-packages toplevel-schematic)))
+        (packages (schematic-package-names toplevel-schematic)))
     ;; initialize the net-name aliasing
     (gnetlist:build-net-aliases pads:map-net-names nets)
 

--- a/netlist/scheme/gnet-partslist1.scm
+++ b/netlist/scheme/gnet-partslist1.scm
@@ -23,7 +23,7 @@
 (define (partslist1 output-filename)
   (display
    (partlist->string
-    (make-partlist (schematic-packages toplevel-schematic)
+    (make-partlist (schematic-package-names toplevel-schematic)
                    '(refdes device value footprint))
     #:sort-order '(refdes device value footprint)
     #:output-order '(refdes device value footprint #{}#)

--- a/netlist/scheme/gnet-partslist2.scm
+++ b/netlist/scheme/gnet-partslist2.scm
@@ -24,7 +24,7 @@
 (define (partslist2 output-filename)
   (display
    (partlist->string
-    (make-partlist (schematic-packages toplevel-schematic)
+    (make-partlist (schematic-package-names toplevel-schematic)
                    '(device value footprint refdes))
     #:sort-order `((device . ,string-ci<?)
                    (value . ,value<?)

--- a/netlist/scheme/gnet-partslist3.scm
+++ b/netlist/scheme/gnet-partslist3.scm
@@ -24,7 +24,7 @@
 (define (partslist3 output-filename)
   (display
    (partlist->string
-    (make-partlist (schematic-packages toplevel-schematic)
+    (make-partlist (schematic-package-names toplevel-schematic)
                    '(device value footprint refdes))
     #:sort-order `((device . ,string-ci<?)
                    (value . ,value<?)

--- a/netlist/scheme/gnet-pcbpins.scm
+++ b/netlist/scheme/gnet-pcbpins.scm
@@ -99,4 +99,4 @@
   (display "# Pin name action command file\n")
 
   ;; write the components
-  (pcbpins:components (schematic-packages toplevel-schematic) 1))
+  (pcbpins:components (schematic-package-names toplevel-schematic) 1))

--- a/netlist/scheme/gnet-protelII.scm
+++ b/netlist/scheme/gnet-protelII.scm
@@ -247,7 +247,7 @@ LIBRARYFIELD8\r
 ;;;
 (define (protelII output-filename)
   (protelII:write-top-header)
-  (protelII:components (schematic-packages toplevel-schematic))
+  (protelII:components (schematic-package-names toplevel-schematic))
   (protelII:nets (schematic-nets toplevel-schematic)))
 
 ;;

--- a/netlist/scheme/gnet-spice-sdb.scm
+++ b/netlist/scheme/gnet-spice-sdb.scm
@@ -941,7 +941,7 @@ the name is changed to canonical."
 
   ;; First find out if this is a .SUBCKT lower level,
   ;; or if it is a regular schematic.
-  (let* ((packages (schematic-packages toplevel-schematic))
+  (let* ((packages (schematic-package-names toplevel-schematic))
          (subckt? (spice-sdb:get-schematic-type packages)))
 
     (if subckt?

--- a/netlist/scheme/gnet-spice.scm
+++ b/netlist/scheme/gnet-spice.scm
@@ -112,7 +112,7 @@
 ;;
 (define (spice output-filename)
   (spice:write-top-header)
-  (spice:write-netlist (schematic-packages toplevel-schematic))
+  (spice:write-netlist (schematic-package-names toplevel-schematic))
   (spice:write-bottom-footer))
 
 

--- a/netlist/scheme/gnet-switcap.scm
+++ b/netlist/scheme/gnet-switcap.scm
@@ -476,7 +476,7 @@
 ;; ----------------------------------------------------------------------------
 (define (switcap output-filename)
   (let ((nets (schematic-nets toplevel-schematic))
-        (packages (schematic-packages toplevel-schematic)))
+        (packages (schematic-package-names toplevel-schematic)))
 
     ;; initialize the net-name aliasing
     (gnetlist:build-net-aliases switcap:map-net-names nets)

--- a/netlist/scheme/gnet-systemc.scm
+++ b/netlist/scheme/gnet-systemc.scm
@@ -489,7 +489,7 @@ SC_CTOR(~A):
 ;;;
 (define (systemc output-filename)
   (let ((nets (schematic-nets toplevel-schematic))
-        (packages (schematic-packages toplevel-schematic))
+        (packages (schematic-package-names toplevel-schematic))
         ;; top level block name for the module
         (module-name (or (schematic-toplevel-attrib toplevel-schematic
                                                     'module_name)

--- a/netlist/scheme/gnet-tEDAx.scm
+++ b/netlist/scheme/gnet-tEDAx.scm
@@ -102,7 +102,7 @@
 ;;;
 (define (tEDAx output-filename)
   (let ((nets (schematic-nets toplevel-schematic))
-        (packages (schematic-packages toplevel-schematic)))
+        (packages (schematic-package-names toplevel-schematic)))
     (tEDAx:header)
     (tEDAx:components packages)
     (tEDAx:nets nets)

--- a/netlist/scheme/gnet-tango.scm
+++ b/netlist/scheme/gnet-tango.scm
@@ -99,7 +99,7 @@
 ;;;
 (define (tango output-filename)
   (let ((nets (schematic-nets toplevel-schematic))
-        (packages (schematic-packages toplevel-schematic)))
+        (packages (schematic-package-names toplevel-schematic)))
     (tango:components packages)
     (tango:nets nets)))
 

--- a/netlist/scheme/gnet-vams.scm
+++ b/netlist/scheme/gnet-vams.scm
@@ -91,7 +91,7 @@
     (cond ((= generate-mode 1)
            (let ((thunk (lambda () (vams:write-secondary-unit architecture
                                                          entity
-                                                         (schematic-packages toplevel-schematic)))))
+                                                         (schematic-package-names toplevel-schematic)))))
              (if output-filename
                  ;; generate output-filename, like
                  ;; (<entity>_arc.<output-file-extension>)

--- a/netlist/scheme/gnet-verilog.scm
+++ b/netlist/scheme/gnet-verilog.scm
@@ -541,7 +541,7 @@
 ;;;
 (define (verilog output-filename)
   (let ((nets (schematic-nets toplevel-schematic))
-        (packages (schematic-packages toplevel-schematic))
+        (packages (schematic-package-names toplevel-schematic))
         ;; top level block name for the module
         (module-name (or (schematic-toplevel-attrib toplevel-schematic
                                                     'module_name)

--- a/netlist/scheme/gnet-vhdl.scm
+++ b/netlist/scheme/gnet-vhdl.scm
@@ -717,7 +717,7 @@ use IEEE.Std_Logic_1164.all;
 ;;;
 (define (vhdl output-filename)
   (let ((nets (schematic-nets toplevel-schematic))
-        (packages (schematic-packages toplevel-schematic))
+        (packages (schematic-package-names toplevel-schematic))
         ;; top level block name for the module
         (module-name (or (schematic-toplevel-attrib toplevel-schematic
                                                     'module_name)

--- a/netlist/scheme/gnet-vipec.scm
+++ b/netlist/scheme/gnet-vipec.scm
@@ -179,7 +179,7 @@
 
 (define (vipec output-filename)
   (let ((netnumbers (number-nets (schematic-nets toplevel-schematic) 1))
-        (packages (schematic-packages toplevel-schematic)))
+        (packages (schematic-package-names toplevel-schematic)))
     (vipec:header)
     (display "CKT\n")
     (vipec:component-writing packages netnumbers)

--- a/netlist/scheme/lepton-netlist.in
+++ b/netlist/scheme/lepton-netlist.in
@@ -37,4 +37,8 @@ exec @GUILE@ -s "$0" "$@"
 ;;; Using of primitive-eval() here avoids Scheme errors when this
 ;;; program is compiled by Guile. See comments above.
 (primitive-eval '(use-modules (netlist)))
-(with-toplevel (make-toplevel) main)
+(with-toplevel (make-toplevel)
+  (lambda ()
+    ;; Init log domain once.
+    ((@@ (geda log) init-log) "netlist")
+    (main)))

--- a/netlist/scheme/lepton-netlist.in
+++ b/netlist/scheme/lepton-netlist.in
@@ -36,9 +36,13 @@ exec @GUILE@ -s "$0" "$@"
 
 ;;; Using of primitive-eval() here avoids Scheme errors when this
 ;;; program is compiled by Guile. See comments above.
-(primitive-eval '(use-modules (netlist)))
+(primitive-eval '(use-modules (geda log)
+                              (netlist)))
+
 (with-toplevel (make-toplevel)
   (lambda ()
-    ;; Init log domain once.
-    ((@@ (geda log) init-log) "netlist")
+    ;; Init log domain and create log file right away even if
+    ;; logging is enabled.
+    (init-log "netlist")
+    (lepton-netlist-version 'log)
     (main)))

--- a/netlist/scheme/netlist.scm
+++ b/netlist/scheme/netlist.scm
@@ -77,9 +77,6 @@
 
   #:re-export (source-library))
 
-;;; Create log file right away even if logging is enabled.
-(init-log "netlist")
-
 (match (lepton-version)
   ((prepend-string dotted-version date-version git-commit)
    (log! 'message

--- a/netlist/scheme/netlist.scm
+++ b/netlist/scheme/netlist.scm
@@ -46,6 +46,7 @@
 
   #:export (lepton-netlist-version
             main
+            set-toplevel-schematic!
             toplevel-schematic
             calling-flag?
             get-device
@@ -903,8 +904,10 @@ Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>
   ((@@ (guile-user) parse-rc) "lepton-netlist" "gnetlistrc")
   (if (gnetlist-option-ref 'list-backends)
       (gnetlist-backends)
-      (let ((files (gnetlist-option-ref '())))
-        (if (null? files)
+      (let ((files (gnetlist-option-ref '()))
+            (interactive-mode? (gnetlist-option-ref 'interactive))
+            (verbose-mode? (gnetlist-option-ref 'verbose)))
+        (if (and (null? files) (not interactive-mode?))
             (netlist-error 1
                            (_ "No schematic files specified for processing.
 Run `~A --help' for more information.
@@ -921,9 +924,7 @@ Run `~A --help' for more information.
                                       (%search-load-path (format #f
                                                                  "gnet-~A.scm"
                                                                  backend))))
-                   (output-filename (get-output-filename))
-                   (interactive-mode? (gnetlist-option-ref 'interactive))
-                   (verbose-mode? (gnetlist-option-ref 'verbose)))
+                   (output-filename (get-output-filename)))
 
               ;; Evaluate the first set of Scheme expressions.
               (for-each primitive-load (gnetlist-option-ref 'pre-load))

--- a/netlist/scheme/netlist.scm
+++ b/netlist/scheme/netlist.scm
@@ -522,7 +522,7 @@ PACKAGE."
 (define (gnetlist:get-packages level)
   (schematic-package-names toplevel-schematic))
 (define (gnetlist:get-non-unique-packages level)
-  (schematic-non-unique-packages toplevel-schematic))
+  (schematic-non-unique-package-names toplevel-schematic))
 (define (gnetlist:get-all-unique-nets level)
   (schematic-nets toplevel-schematic))
 (define (gnetlist:get-all-nets level)

--- a/netlist/scheme/netlist.scm
+++ b/netlist/scheme/netlist.scm
@@ -75,7 +75,12 @@
             gnetlist:wrap
             known?
             unknown?
-            pair<?)
+            pair<?
+            ;; Legacy variables
+            packages
+            all-unique-nets
+            all-nets
+            all-pins)
 
   #:re-export (source-library))
 

--- a/netlist/scheme/netlist.scm
+++ b/netlist/scheme/netlist.scm
@@ -520,7 +520,7 @@ PACKAGE."
 (define (gnetlist:get-command-line)
   (string-join (command-line) " "))
 (define (gnetlist:get-packages level)
-  (schematic-packages toplevel-schematic))
+  (schematic-package-names toplevel-schematic))
 (define (gnetlist:get-non-unique-packages level)
   (schematic-non-unique-packages toplevel-schematic))
 (define (gnetlist:get-all-unique-nets level)
@@ -862,7 +862,7 @@ Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>
         (make-toplevel-schematic (map file->page files)
                                  netlist-mode))
   ;; Backward compatibility variables. Don't use them in your code!!!
-  (set! packages (schematic-packages toplevel-schematic))
+  (set! packages (schematic-package-names toplevel-schematic))
   (set! all-unique-nets (schematic-nets toplevel-schematic))
   (set! all-nets (schematic-non-unique-nets toplevel-schematic))
   (set! all-pins (map gnetlist:get-pins packages))

--- a/netlist/scheme/netlist.scm
+++ b/netlist/scheme/netlist.scm
@@ -44,7 +44,8 @@
   #:use-module (netlist verbose)
   #:use-module ((netlist rename) #:select (get-rename-list))
 
-  #:export (main
+  #:export (lepton-netlist-version
+            main
             toplevel-schematic
             calling-flag?
             get-device
@@ -77,34 +78,29 @@
 
   #:re-export (source-library))
 
-(match (lepton-version)
-  ((prepend-string dotted-version date-version git-commit)
-   (log! 'message
-         (_
-          "Lepton EDA/lepton-netlist version ~A~A.~A git: ~A
-")
-         prepend-string
-         dotted-version
-         date-version
-         (string-take git-commit 7)))
-  (_ #f))
 
-;;; Print version info and exit.
-;;; Print gEDA version, and copyright/warranty notices, and exit with
-;;; exit status 0.
-(define (version)
-  (match (lepton-version)
-    ((prepend dotted date commit)
-     (format #t (_ "Lepton EDA ~A (git: ~A)
-Copyright (C) 1998-2016 gEDA developers
+(define* (lepton-netlist-version #:optional output-to-log? exit?)
+  "Print lepton-netlist version, and copyright/warranty
+notices. If OUTPUT-TO-LOG? is requested, just output the version
+to log file, omitting copyright. Otherwise, output the full info
+to current standard output port and exit with exit status 0."
+
+  (define version-msg "Lepton EDA/lepton-netlist ~A~A.~A (git: ~A)\n")
+
+  (define copyright-msg (_ "Copyright (C) 1998-2016 gEDA developers
 Copyright (C) 2017-2018 Lepton EDA Contributors
 This is free software, and you are welcome to redistribute it under
 certain conditions. For details, see the file `COPYING', which is
 included in the Lepton EDA distribution.
-There is NO WARRANTY, to the extent permitted by law.
-")
-             dotted (string-take commit 7))))
-  (primitive-exit 0))
+There is NO WARRANTY, to the extent permitted by law.\n"))
+
+  (match (lepton-version)
+    ((prepend dotted date commit)
+     (if output-to-log?
+         (log! 'message version-msg prepend dotted date (string-take commit 7))
+         (begin
+           (format #t version-msg prepend dotted date (string-take commit 7))
+           (format #t copyright-msg))))))
 
 
 ;;----------------------------------------------------------------------
@@ -901,7 +897,8 @@ Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>
     (usage))
 
   (when (gnetlist-option-ref 'version)
-    (version))
+    (lepton-netlist-version)
+    (primitive-exit 0))
 
   ((@@ (guile-user) parse-rc) "lepton-netlist" "gnetlistrc")
   (if (gnetlist-option-ref 'list-backends)

--- a/netlist/scheme/netlist/package.scm
+++ b/netlist/scheme/netlist/package.scm
@@ -21,16 +21,17 @@
   #:use-module (ice-9 match)
   #:use-module (srfi srfi-9)
   #:use-module (srfi srfi-9 gnu)
-  #:export (make-package package?
-            package-id set-package-id!
-            package-refdes set-package-refdes!
-            package-tag set-package-tag!
-            package-composite? set-package-composite!
-            package-object set-package-object!
-            package-iattribs set-package-iattribs!
-            package-attribs set-package-attribs!
-            package-pins set-package-pins!
-            package-attributes
+  #:export-syntax (make-package package?
+                   package-id set-package-id!
+                   package-refdes set-package-refdes!
+                   package-tag set-package-tag!
+                   package-composite? set-package-composite!
+                   package-object set-package-object!
+                   package-iattribs set-package-iattribs!
+                   package-attribs set-package-attribs!
+                   package-pins set-package-pins!)
+
+  #:export (package-attributes
             package-attribute
             package-attribute-string=?
             package-graphical?

--- a/netlist/scheme/netlist/schematic.scm
+++ b/netlist/scheme/netlist/schematic.scm
@@ -181,17 +181,15 @@
 (define (make-toplevel-schematic toplevel-pages netlist-mode)
   "Creates a new schematic record based on TOPLEVEL-PAGES which
 must be a list of pages."
+  (define (plain-package? x)
+    (and (not (package-graphical? x))
+         (not (package-nc? x))))
+
   (let* ((id (next-schematic-id))
          (toplevel-attribs (get-toplevel-attributes toplevel-pages))
          (full-netlist (traverse toplevel-pages netlist-mode))
-         (netlist (filter-map
-                   (lambda (x) (and (not (package-graphical? x))
-                               (not (package-nc? x))
-                               x))
-                   full-netlist))
-         (graphicals (filter-map
-                      (lambda (x) (and (package-graphical? x) x))
-                      full-netlist))
+         (netlist (filter plain-package? full-netlist))
+         (graphicals (filter package-graphical? full-netlist))
          (tree (schematic->sxml netlist toplevel-pages))
          (nu-nets (get-all-nets netlist))
          (unique-nets (get-nets netlist)))

--- a/netlist/scheme/netlist/schematic.scm
+++ b/netlist/scheme/netlist/schematic.scm
@@ -38,7 +38,7 @@
             schematic-netlist set-schematic-netlist!
             schematic-graphicals set-schematic-graphicals!
             schematic-non-unique-packages set-schematic-non-unique-packages!
-            schematic-packages set-schematic-packages!
+            schematic-package-names set-schematic-package-names!
             schematic-non-unique-nets set-schematic-non-unique-nets!
             schematic-nets set-schematic-nets!
             schematic-nc-nets set-schematic-nc-nets!
@@ -53,7 +53,7 @@
                   netlist
                   graphicals
                   non-unique-packages
-                  packages
+                  package-names
                   non-unique-nets
                   nets
                   nc-nets)
@@ -65,7 +65,7 @@
   (netlist schematic-netlist set-schematic-netlist!)
   (graphicals schematic-graphicals set-schematic-graphicals!)
   (non-unique-packages schematic-non-unique-packages set-schematic-non-unique-packages!)
-  (packages schematic-packages set-schematic-packages!)
+  (package-names schematic-package-names set-schematic-package-names!)
   (non-unique-nets schematic-non-unique-nets set-schematic-non-unique-nets!)
   (nets schematic-nets set-schematic-nets!)
   (nc-nets schematic-nc-nets set-schematic-nc-nets!))

--- a/netlist/scheme/netlist/schematic.scm
+++ b/netlist/scheme/netlist/schematic.scm
@@ -30,19 +30,21 @@
   #:use-module (geda page)
   #:use-module (geda attrib)
   #:use-module (geda object)
-  #:export (make-schematic schematic?
-            schematic-id set-schematic-id!
-            schematic-toplevel-pages set-schematic-toplevel-pages!
-            schematic-toplevel-attribs set-schematic-toplevel-attribs!
-            schematic-tree set-schematic-tree!
-            schematic-netlist set-schematic-netlist!
-            schematic-graphicals set-schematic-graphicals!
-            schematic-non-unique-packages set-schematic-non-unique-packages!
-            schematic-package-names set-schematic-package-names!
-            schematic-non-unique-nets set-schematic-non-unique-nets!
-            schematic-nets set-schematic-nets!
-            schematic-nc-nets set-schematic-nc-nets!
-            make-toplevel-schematic
+
+  #:export-syntax (make-schematic schematic?
+                   schematic-id set-schematic-id!
+                   schematic-toplevel-pages set-schematic-toplevel-pages!
+                   schematic-toplevel-attribs set-schematic-toplevel-attribs!
+                   schematic-tree set-schematic-tree!
+                   schematic-netlist set-schematic-netlist!
+                   schematic-graphicals set-schematic-graphicals!
+                   schematic-non-unique-packages set-schematic-non-unique-packages!
+                   schematic-package-names set-schematic-package-names!
+                   schematic-non-unique-nets set-schematic-non-unique-nets!
+                   schematic-nets set-schematic-nets!
+                   schematic-nc-nets set-schematic-nc-nets!)
+
+  #:export (make-toplevel-schematic
             schematic-toplevel-attrib))
 
 (define-record-type <schematic>

--- a/netlist/scheme/netlist/schematic.scm
+++ b/netlist/scheme/netlist/schematic.scm
@@ -38,14 +38,14 @@
                    schematic-tree set-schematic-tree!
                    schematic-netlist set-schematic-netlist!
                    schematic-graphicals set-schematic-graphicals!
-                   schematic-non-unique-packages set-schematic-non-unique-packages!
                    schematic-package-names set-schematic-package-names!
                    schematic-non-unique-nets set-schematic-non-unique-nets!
                    schematic-nets set-schematic-nets!
                    schematic-nc-nets set-schematic-nc-nets!)
 
   #:export (make-toplevel-schematic
-            schematic-toplevel-attrib))
+            schematic-toplevel-attrib
+            schematic-non-unique-package-names))
 
 (define-record-type <schematic>
   (make-schematic id
@@ -54,7 +54,6 @@
                   tree
                   netlist
                   graphicals
-                  non-unique-packages
                   package-names
                   non-unique-nets
                   nets
@@ -66,7 +65,6 @@
   (tree schematic-tree set-schematic-tree!)
   (netlist schematic-netlist set-schematic-netlist!)
   (graphicals schematic-graphicals set-schematic-graphicals!)
-  (non-unique-packages schematic-non-unique-packages set-schematic-non-unique-packages!)
   (package-names schematic-package-names set-schematic-package-names!)
   (non-unique-nets schematic-non-unique-nets set-schematic-non-unique-nets!)
   (nets schematic-nets set-schematic-nets!)
@@ -125,7 +123,7 @@
 
 ;;; Gets non unique set of package refdeses.
 ;;; Backward compatibility procedure for old backends.
-(define (non-unique-packages netlist)
+(define (schematic-non-unique-package-names netlist)
   (sort (filter-map package-refdes netlist) refdes<?))
 
 ;;; Returns a sorted list of unique packages in NETLIST.
@@ -194,8 +192,7 @@ must be a list of pages."
                       (lambda (x) (and (package-graphical? x) x))
                       full-netlist))
          (tree (schematic->sxml netlist toplevel-pages))
-         (nu-packages (non-unique-packages netlist))
-         (packages (get-packages nu-packages))
+         (packages (get-packages (schematic-non-unique-package-names netlist)))
          (nu-nets (get-all-nets netlist))
          (unique-nets (get-nets netlist)))
     ;; Partition all unique net names into 'no-connection' nets
@@ -210,7 +207,6 @@ must be a list of pages."
                       tree
                       netlist
                       graphicals
-                      nu-packages
                       packages
                       nu-nets
                       nets


### PR DESCRIPTION
The patch-set introduces following improvements and features:
- separated syntax and procedures in some netlist modules;
- log initialisation has been moved to the `lepton-netlist` executable file to prevent repetition of the initialisation on every loading of the `(netlist)` module; it also prevents logging into wrong domain when `(netlist)` is loaded in other program, for example, in `lepton-schematic`;
- output of `lepton-netlist` version has been unified and placed into one procedure, `lepton-netlist-version()`, which can now be used interactively in lepton-netlist REPL;
- `lepton-netlist` interactive mode can now be used without specifying any file name on command line; the user can load and traverse arbitrary schematic using, e.g. `(set-toplevel-schematic! '("filename1.sch" "filename2.sch") 'geda)` in REPL, and work with the resulted `toplevel-schematic` data;
- `schematic-packages` and `schematic-non-unique-packages` fields have been removed from the `<schematic>` record, there is no point to hold strings, not real data structures, in the record; compatibility procedures to get the data contained in the fields have been provided, those are `schematic-package-names` and `schematic-non-unique-package-names`;
- backward compatibility variables have been provided to ensure facilities mentioned [here](http://wiki.geda-project.org/geda:gnetlist_scheme_tutorial) and [here](http://wiki.geda-project.org/geda:gnetlist_scheme_tutorial) are still available (well, we could add tests to prove that at least for ourselves...);
- simplified the `make-toplevel-schematic()` function.