### PR TITLE
Remove deprecated gtk & gdk functions and macros

### DIFF
--- a/attrib/src/gtksheet_2_2.c
+++ b/attrib/src/gtksheet_2_2.c
@@ -980,7 +980,7 @@ gtk_sheet_init (GtkSheet *sheet)
   sheet->state = GTK_SHEET_NORMAL;
 
   GTK_WIDGET_UNSET_FLAGS (sheet, GTK_NO_WINDOW);
-  GTK_WIDGET_SET_FLAGS (sheet, GTK_CAN_FOCUS);
+  gtk_widget_set_can_focus (GTK_WIDGET (sheet), TRUE);
 
   sheet->maxrow = 0;
   sheet->maxcol = 0;
@@ -2667,7 +2667,7 @@ gtk_sheet_realize (GtkWidget * widget)
 
   sheet = GTK_SHEET (widget);
 
-  GTK_WIDGET_SET_FLAGS (widget, GTK_REALIZED);
+  gtk_widget_set_realized (widget, TRUE);
 
   attributes.window_type = GDK_WINDOW_CHILD;
   attributes.x = widget->allocation.x;
@@ -2901,7 +2901,7 @@ gtk_sheet_map (GtkWidget * widget)
 
   if (!GTK_WIDGET_MAPPED (widget))
     {
-      GTK_WIDGET_SET_FLAGS (widget, GTK_MAPPED);
+      gtk_widget_set_mapped (widget, TRUE);
 
       if(!sheet->cursor_drag) sheet->cursor_drag=gdk_cursor_new(GDK_PLUS);
 
@@ -4081,7 +4081,6 @@ gtk_sheet_hide_active_cell(GtkSheet *sheet)
                    sheet->row[row].height+4);   
 
  GTK_WIDGET_UNSET_FLAGS(sheet->sheet_entry, GTK_HAS_FOCUS);
- GTK_WIDGET_SET_FLAGS(GTK_WIDGET(sheet), GTK_HAS_FOCUS);
  gtk_widget_grab_focus(GTK_WIDGET(sheet));
 
  GTK_WIDGET_UNSET_FLAGS(GTK_WIDGET(sheet->sheet_entry), GTK_VISIBLE);
@@ -4154,7 +4153,7 @@ gtk_sheet_show_active_cell(GtkSheet *sheet)
  if(sheet->state != GTK_SHEET_NORMAL) return;
  if(GTK_SHEET_IN_SELECTION(sheet)) return;
 
- GTK_WIDGET_SET_FLAGS(GTK_WIDGET(sheet->sheet_entry), GTK_VISIBLE);
+ gtk_widget_set_visible (GTK_WIDGET (sheet->sheet_entry), TRUE);
 
  sheet_entry = GTK_ENTRY(gtk_sheet_get_entry(sheet));
 
@@ -4190,7 +4189,6 @@ gtk_sheet_show_active_cell(GtkSheet *sheet)
  gtk_sheet_draw_active_cell(sheet);
 
  gtk_widget_grab_focus(GTK_WIDGET(sheet_entry));
- GTK_WIDGET_SET_FLAGS(GTK_WIDGET(sheet_entry), GTK_HAS_FOCUS);
  GTK_WIDGET_UNSET_FLAGS(GTK_WIDGET(sheet), GTK_HAS_FOCUS);
 
  g_free(text);
@@ -4940,7 +4938,6 @@ gtk_sheet_button_press (GtkWidget * widget,
      gtk_grab_add(GTK_WIDGET(sheet));
      sheet->timer = g_timeout_add (TIMEOUT_SCROLL, (GSourceFunc) gtk_sheet_scroll, sheet);
      GTK_WIDGET_UNSET_FLAGS(sheet->sheet_entry, GTK_HAS_FOCUS);
-     GTK_WIDGET_SET_FLAGS(GTK_SHEET(sheet), GTK_HAS_FOCUS);
      gtk_widget_grab_focus(GTK_WIDGET(sheet));
 
      if(sheet->selection_mode != GTK_SELECTION_SINGLE &&
@@ -5006,7 +5003,6 @@ gtk_sheet_button_press (GtkWidget * widget,
        gtk_grab_add(GTK_WIDGET(sheet));
        sheet->timer = g_timeout_add (TIMEOUT_SCROLL, (GSourceFunc) gtk_sheet_scroll, sheet);
        GTK_WIDGET_UNSET_FLAGS(sheet->sheet_entry, GTK_HAS_FOCUS);
-       GTK_WIDGET_SET_FLAGS(GTK_SHEET(sheet), GTK_HAS_FOCUS);
        gtk_widget_grab_focus(GTK_WIDGET(sheet));
        GTK_SHEET_SET_FLAGS(sheet, GTK_SHEET_IN_SELECTION);
      }
@@ -5020,7 +5016,6 @@ gtk_sheet_button_press (GtkWidget * widget,
        gtk_grab_add(GTK_WIDGET(sheet));
        sheet->timer = g_timeout_add (TIMEOUT_SCROLL, (GSourceFunc) gtk_sheet_scroll, sheet);
        GTK_WIDGET_UNSET_FLAGS(sheet->sheet_entry, GTK_HAS_FOCUS);
-       GTK_WIDGET_SET_FLAGS(GTK_SHEET(sheet), GTK_HAS_FOCUS);
        gtk_widget_grab_focus(GTK_WIDGET(sheet));
        GTK_SHEET_SET_FLAGS(sheet, GTK_SHEET_IN_SELECTION);
      }

--- a/attrib/src/gtksheet_2_2.c
+++ b/attrib/src/gtksheet_2_2.c
@@ -1264,8 +1264,9 @@ gtk_sheet_set_selection_mode(GtkSheet *sheet, gint mode)
   g_return_if_fail (sheet != NULL);
   g_return_if_fail (GTK_IS_SHEET (sheet));
 
-  if(GTK_WIDGET_REALIZED(sheet))
+  if (gtk_widget_get_realized (GTK_WIDGET (sheet))) {
    gtk_sheet_real_unselect_range(sheet, NULL);
+  }
 
   sheet->selection_mode = (GtkSelectionMode) mode;
 }
@@ -1375,7 +1376,9 @@ gtk_sheet_set_title(GtkSheet *sheet, const gchar *title)
 
   sheet->name = g_strdup (title);
 
-  if(!GTK_WIDGET_REALIZED(GTK_WIDGET(sheet)) || !title) return;
+  if (!gtk_widget_get_realized (GTK_WIDGET (sheet)) || !title) {
+    return;
+  }
 
   if(GTK_BIN(sheet->button)->child)
            label = GTK_BIN(sheet->button)->child;
@@ -1472,7 +1475,7 @@ gtk_sheet_show_column_titles(GtkSheet *sheet)
  sheet->column_titles_visible = TRUE;
  gtk_sheet_recalc_top_ypixels(sheet, 0);
  gtk_sheet_recalc_left_xpixels(sheet, 0);
- if(GTK_WIDGET_REALIZED(GTK_WIDGET(sheet))){
+ if (gtk_widget_get_realized (GTK_WIDGET (sheet))) {
   gdk_window_show(sheet->column_title_window);
   gdk_window_move_resize (sheet->column_title_window,
                           sheet->column_title_area.x,
@@ -1507,7 +1510,7 @@ gtk_sheet_show_row_titles(GtkSheet *sheet)
  sheet->row_titles_visible = TRUE;
  gtk_sheet_recalc_top_ypixels(sheet, 0);
  gtk_sheet_recalc_left_xpixels(sheet, 0);
- if(GTK_WIDGET_REALIZED(GTK_WIDGET(sheet))){
+ if (gtk_widget_get_realized (GTK_WIDGET (sheet))) {
   gdk_window_show(sheet->row_title_window);
   gdk_window_move_resize (sheet->row_title_window,
                           sheet->row_title_area.x,
@@ -1542,7 +1545,7 @@ gtk_sheet_hide_column_titles(GtkSheet *sheet)
  sheet->column_titles_visible = FALSE;
  gtk_sheet_recalc_top_ypixels(sheet, 0);
  gtk_sheet_recalc_left_xpixels(sheet, 0);
- if(GTK_WIDGET_REALIZED(GTK_WIDGET(sheet))){
+ if (gtk_widget_get_realized (GTK_WIDGET (sheet))) {
   if(sheet->column_title_window) 
     gdk_window_hide(sheet->column_title_window);
   if (gtk_widget_get_visible (sheet->button)) {
@@ -1575,7 +1578,7 @@ gtk_sheet_hide_row_titles(GtkSheet *sheet)
  sheet->row_titles_visible = FALSE;
  gtk_sheet_recalc_top_ypixels(sheet, 0);
  gtk_sheet_recalc_left_xpixels(sheet, 0);
- if(GTK_WIDGET_REALIZED(GTK_WIDGET(sheet))){
+ if (gtk_widget_get_realized (GTK_WIDGET (sheet))) {
   if(sheet->row_title_window) 
     gdk_window_hide(sheet->row_title_window);
   if (gtk_widget_get_visible (sheet->button)) {
@@ -1957,8 +1960,9 @@ gtk_sheet_column_set_sensitivity(GtkSheet *sheet, gint column, gboolean sensitiv
   else
      sheet->column[column].button.state=GTK_STATE_NORMAL;
 
-  if(GTK_WIDGET_REALIZED(sheet) && !GTK_SHEET_IS_FROZEN(sheet))
+  if (gtk_widget_get_realized (GTK_WIDGET (sheet)) && !GTK_SHEET_IS_FROZEN (sheet)) {
       gtk_sheet_button_draw(sheet, -1, column);
+  }
 }
 
 
@@ -2007,8 +2011,9 @@ gtk_sheet_row_set_sensitivity(GtkSheet *sheet, gint row,  gboolean sensitive)
   else
      sheet->row[row].button.state=GTK_STATE_NORMAL;
 
-  if(GTK_WIDGET_REALIZED(sheet) && !GTK_SHEET_IS_FROZEN(sheet))
+  if (gtk_widget_get_realized (GTK_WIDGET (sheet)) && !GTK_SHEET_IS_FROZEN (sheet)) {
       gtk_sheet_button_draw(sheet, row, -1);
+  }
 }
 
 void
@@ -2206,7 +2211,7 @@ gtk_sheet_flash(gpointer data)
 
   sheet=GTK_SHEET(data);
 
-  if(!GTK_WIDGET_REALIZED(GTK_WIDGET(sheet))) return TRUE;
+  if (!gtk_widget_get_realized (GTK_WIDGET (sheet))) return TRUE;
   if (!gtk_widget_is_drawable (GTK_WIDGET (sheet))) return TRUE;
   if(!gtk_sheet_range_isvisible(sheet, sheet->clip_range)) return TRUE;
   if(GTK_SHEET_IN_XDRAG(sheet)) return TRUE; 
@@ -2641,7 +2646,7 @@ gtk_sheet_style_set (GtkWidget *widget,
   if (GTK_WIDGET_CLASS (gtk_sheet_parent_class)->style_set)
     (*GTK_WIDGET_CLASS (gtk_sheet_parent_class)->style_set) (widget, previous_style);
 
-  if(GTK_WIDGET_REALIZED(widget))
+  if (gtk_widget_get_realized (widget))
      {
        gtk_style_set_background (widget->style,
                                  widget->window,
@@ -3295,7 +3300,7 @@ gtk_sheet_range_draw(GtkSheet *sheet, const GtkSheetRange *range)
  g_return_if_fail(GTK_SHEET(sheet));
  
  if (!gtk_widget_is_drawable (GTK_WIDGET (sheet))) return;
- if(!GTK_WIDGET_REALIZED(GTK_WIDGET(sheet))) return;
+ if (!gtk_widget_get_realized (GTK_WIDGET (sheet))) return;
  if(!GTK_WIDGET_MAPPED(GTK_WIDGET(sheet))) return;
 
  if(range == NULL)
@@ -3425,7 +3430,7 @@ gtk_sheet_range_draw_selection(GtkSheet *sheet, GtkSheetRange range)
      return;
 
   if(!gtk_sheet_range_isvisible(sheet, range)) return;
-  if(!GTK_WIDGET_REALIZED(GTK_WIDGET(sheet))) return;
+  if (!gtk_widget_get_realized (GTK_WIDGET (sheet))) return;
 
   range.col0=MAX(sheet->range.col0, range.col0);
   range.coli=MIN(sheet->range.coli, range.coli);
@@ -3483,7 +3488,7 @@ gtk_sheet_draw_backing_pixmap(GtkSheet *sheet, GtkSheetRange range)
 {
   gint x,y,width,height;
 
-  if(!GTK_WIDGET_REALIZED(GTK_WIDGET(sheet))) return;
+  if (!gtk_widget_get_realized (GTK_WIDGET (sheet))) return;
  
   x=COLUMN_LEFT_XPIXEL(sheet,range.col0);
   y=ROW_TOP_YPIXEL(sheet, range.row0);  
@@ -3922,7 +3927,7 @@ gtk_sheet_set_active_cell (GtkSheet *sheet, gint row, gint column)
  if(row < 0 || column < 0) return FALSE;
  if(row > sheet->maxrow || column > sheet->maxcol) return FALSE;
 
- if(GTK_WIDGET_REALIZED(GTK_WIDGET(sheet)))
+ if (gtk_widget_get_realized (GTK_WIDGET (sheet)))
    {
        if(!gtk_sheet_deactivate_cell(sheet)) return FALSE;
    }
@@ -4004,7 +4009,7 @@ gtk_sheet_deactivate_cell(GtkSheet *sheet)
  g_return_val_if_fail (sheet != NULL, FALSE);
  g_return_val_if_fail (GTK_IS_SHEET (sheet), FALSE);
 
- if(!GTK_WIDGET_REALIZED(GTK_WIDGET(sheet))) return FALSE;
+ if (!gtk_widget_get_realized (GTK_WIDGET (sheet))) return FALSE;
  if(sheet->state != GTK_SHEET_NORMAL) return FALSE;
 
  _gtkextra_signal_emit(GTK_OBJECT(sheet),sheet_signals[DEACTIVATE], 
@@ -4037,7 +4042,7 @@ gtk_sheet_hide_active_cell(GtkSheet *sheet)
  GtkJustification justification;
  GtkSheetCellAttr attributes;
 
- if(!GTK_WIDGET_REALIZED(GTK_WIDGET(sheet))) return;
+ if (!gtk_widget_get_realized (GTK_WIDGET (sheet))) return;
 
  row=sheet->active_cell.row;
  col=sheet->active_cell.col;
@@ -4149,7 +4154,7 @@ gtk_sheet_show_active_cell(GtkSheet *sheet)
  if(!(row >= 0 && col >= 0)) /* e.g row or coll == -1. */
    return;
   
- if(!GTK_WIDGET_REALIZED(GTK_WIDGET(sheet))) return;
+ if (!gtk_widget_get_realized (GTK_WIDGET (sheet))) return;
  if(sheet->state != GTK_SHEET_NORMAL) return;
  if(GTK_SHEET_IN_SELECTION(sheet)) return;
 
@@ -4200,7 +4205,7 @@ gtk_sheet_draw_active_cell(GtkSheet *sheet)
     gint row, col;
 
     if (!gtk_widget_is_drawable (GTK_WIDGET (sheet))) return;
-    if(!GTK_WIDGET_REALIZED(GTK_WIDGET(sheet))) return;
+    if (!gtk_widget_get_realized (GTK_WIDGET (sheet))) return;
 
     row = sheet->active_cell.row;
     col = sheet->active_cell.col;
@@ -4223,7 +4228,7 @@ gtk_sheet_make_backing_pixmap (GtkSheet *sheet, guint width, guint height)
 {
   gint pixmap_width, pixmap_height;
 
-  if(!GTK_WIDGET_REALIZED(GTK_WIDGET(sheet))) return;
+  if (!gtk_widget_get_realized (GTK_WIDGET (sheet))) return;
 
   if(width == 0 && height == 0){
      width=sheet->sheet_window_width+80;
@@ -4762,7 +4767,7 @@ gtk_sheet_real_unselect_range (GtkSheet * sheet,
   gint i;
  
   g_return_if_fail (sheet != NULL);
-  g_return_if_fail (GTK_WIDGET_REALIZED(GTK_WIDGET(sheet)));
+  g_return_if_fail (gtk_widget_get_realized (GTK_WIDGET (sheet)));
 
   if(range==NULL){
      range=&sheet->range;
@@ -5941,12 +5946,13 @@ gtk_sheet_size_allocate (GtkWidget * widget,
   widget->allocation = *allocation;
   border_width = GTK_CONTAINER(widget)->border_width;
 
-  if (GTK_WIDGET_REALIZED (widget))
+  if (gtk_widget_get_realized (widget)) {
     gdk_window_move_resize (widget->window,
 	      	  	    allocation->x + border_width,
 	                    allocation->y + border_width,
                             allocation->width - 2*border_width,
 	                    allocation->height - 2*border_width);
+  }
 
   /* use internal allocation structure for all the math
    * because it's easier than always subtracting the container
@@ -5964,12 +5970,13 @@ gtk_sheet_size_allocate (GtkWidget * widget,
   sheet->sheet_window_width = sheet_allocation.width;
   sheet->sheet_window_height = sheet_allocation.height;
 
-  if (GTK_WIDGET_REALIZED (widget))
+  if (gtk_widget_get_realized (widget)) {
     gdk_window_move_resize (sheet->sheet_window,
 			    sheet_allocation.x,
 			    sheet_allocation.y,
 			    sheet_allocation.width,
 			    sheet_allocation.height);
+  }
 
     /* position the window which holds the column title buttons */
   sheet->column_title_area.x = 0;
@@ -5978,12 +5985,13 @@ gtk_sheet_size_allocate (GtkWidget * widget,
        sheet->column_title_area.x = sheet->row_title_area.width;
   sheet->column_title_area.width = sheet_allocation.width - 
                                      sheet->column_title_area.x;
-  if(GTK_WIDGET_REALIZED(widget) && sheet->column_titles_visible)
+  if (gtk_widget_get_realized (widget) && sheet->column_titles_visible) {
       gdk_window_move_resize (sheet->column_title_window,
 			      sheet->column_title_area.x,
 			      sheet->column_title_area.y,
 			      sheet->column_title_area.width,
 			      sheet->column_title_area.height);
+  }
 
   sheet->sheet_window_width = sheet_allocation.width;
   sheet->sheet_window_height = sheet_allocation.height;
@@ -5999,12 +6007,13 @@ gtk_sheet_size_allocate (GtkWidget * widget,
   sheet->row_title_area.height = sheet_allocation.height -
                                    sheet->row_title_area.y;
 
-  if(GTK_WIDGET_REALIZED(widget) && sheet->row_titles_visible)
+  if (gtk_widget_get_realized (widget) && sheet->row_titles_visible) {
       gdk_window_move_resize (sheet->row_title_window,
 			      sheet->row_title_area.x,
 			      sheet->row_title_area.y,
 			      sheet->row_title_area.width,
 			      sheet->row_title_area.height);
+  }
 
 
   /* row button allocation */
@@ -6039,8 +6048,9 @@ size_allocate_column_title_buttons (GtkSheet * sheet)
   gint x,width;
 
   if (!sheet->column_titles_visible) return;
-  if (!GTK_WIDGET_REALIZED (sheet))
+  if (!gtk_widget_get_realized (GTK_WIDGET (sheet))) {
     return;
+  }
 
   width = sheet->sheet_window_width;
   x = 0;
@@ -6082,8 +6092,9 @@ size_allocate_row_title_buttons (GtkSheet * sheet)
   gint y, height;
 
   if (!sheet->row_titles_visible) return;
-  if (!GTK_WIDGET_REALIZED (sheet))
+  if (!gtk_widget_get_realized (GTK_WIDGET (sheet))) {
     return;
+  }
 
   height = sheet->sheet_window_height;
   y = 0;
@@ -6154,14 +6165,14 @@ gtk_sheet_size_allocate_entry(GtkSheet *sheet)
  gint size, max_size, text_size, column_width;
  const gchar *text;
 
- if(!GTK_WIDGET_REALIZED(GTK_WIDGET(sheet))) return;
+ if (!gtk_widget_get_realized (GTK_WIDGET (sheet))) return;
  if(!GTK_WIDGET_MAPPED(GTK_WIDGET(sheet))) return;
 
  sheet_entry = GTK_ENTRY(gtk_sheet_get_entry(sheet));
 
  gtk_sheet_get_attributes(sheet, sheet->active_cell.row, sheet->active_cell.col, &attributes); 
 
- if(GTK_WIDGET_REALIZED(sheet->sheet_entry)){
+ if (gtk_widget_get_realized (sheet->sheet_entry)) {
 
   if(!GTK_WIDGET(sheet_entry)->style) 
         gtk_widget_ensure_style(GTK_WIDGET(sheet_entry));
@@ -6278,7 +6289,7 @@ create_sheet_entry(GtkSheet *sheet)
  
  gtk_widget_size_request(sheet->sheet_entry, NULL);
  
- if(GTK_WIDGET_REALIZED(sheet))
+ if (gtk_widget_get_realized (GTK_WIDGET (sheet)))
    {
       gtk_widget_set_parent_window (sheet->sheet_entry, sheet->sheet_window);
       gtk_widget_set_parent(sheet->sheet_entry, GTK_WIDGET(sheet));
@@ -6404,7 +6415,7 @@ gtk_sheet_button_draw (GtkSheet *sheet, gint row, gint column)
   gchar *words = 0;
   gchar label[10];
 
-  if(!GTK_WIDGET_REALIZED(GTK_WIDGET(sheet))) return;
+  if (!gtk_widget_get_realized (GTK_WIDGET (sheet))) return;
 
   if(row >= 0 && !sheet->row[row].is_visible) return;
   if(column >= 0 && !sheet->column[column].is_visible) return;
@@ -6584,7 +6595,7 @@ gtk_sheet_button_draw (GtkSheet *sheet, gint row, gint column)
 
       gtk_widget_set_state(child->widget, button->state);
 
-      if(GTK_WIDGET_REALIZED(GTK_WIDGET(sheet)) &&
+      if (gtk_widget_get_realized (GTK_WIDGET (sheet)) &&
          GTK_WIDGET_MAPPED(child->widget))
             {
               gtk_widget_size_allocate(child->widget, 
@@ -6734,7 +6745,7 @@ vadjustment_value_changed (GtkAdjustment * adjustment,
   if(!sheet->column_titles_visible)
      sheet->view.row0=ROW_FROM_YPIXEL(sheet, 1);
 
-  if(GTK_WIDGET_REALIZED(sheet->sheet_entry) &&
+  if (gtk_widget_get_realized (sheet->sheet_entry) &&
      sheet->state == GTK_SHEET_NORMAL && 
      sheet->active_cell.row >= 0 && sheet->active_cell.col >= 0 &&
      !gtk_sheet_cell_isvisible(sheet, sheet->active_cell.row,
@@ -6827,7 +6838,7 @@ hadjustment_value_changed (GtkAdjustment * adjustment,
   if(!sheet->row_titles_visible)
     sheet->view.col0=COLUMN_FROM_XPIXEL(sheet, 1);
 
-  if(GTK_WIDGET_REALIZED(sheet->sheet_entry) &&
+  if (gtk_widget_get_realized (sheet->sheet_entry) &&
      sheet->state == GTK_SHEET_NORMAL && 
      sheet->active_cell.row >= 0 && sheet->active_cell.col >= 0 &&
      !gtk_sheet_cell_isvisible(sheet, sheet->active_cell.row,
@@ -7049,7 +7060,7 @@ gtk_sheet_set_column_width (GtkSheet * sheet,
 
   gtk_sheet_recalc_left_xpixels(sheet, column+1);
 
-  if(GTK_WIDGET_REALIZED(GTK_WIDGET(sheet)) && !GTK_SHEET_IS_FROZEN(sheet)){
+  if (gtk_widget_get_realized (GTK_WIDGET (sheet)) && !GTK_SHEET_IS_FROZEN (sheet)) {
     size_allocate_column_title_buttons (sheet);
     adjust_scrollbars (sheet);
     gtk_sheet_size_allocate_entry(sheet);
@@ -7081,7 +7092,7 @@ gtk_sheet_set_row_height (GtkSheet * sheet,
 
   gtk_sheet_recalc_top_ypixels(sheet, row+1);
 
-  if(GTK_WIDGET_REALIZED(GTK_WIDGET(sheet)) && !GTK_SHEET_IS_FROZEN(sheet)){
+  if (gtk_widget_get_realized (GTK_WIDGET(sheet)) && !GTK_SHEET_IS_FROZEN (sheet)) {
     size_allocate_row_title_buttons (sheet);
     adjust_scrollbars (sheet);
     gtk_sheet_size_allocate_entry(sheet);
@@ -7103,7 +7114,9 @@ gtk_sheet_add_column(GtkSheet *sheet, guint ncols)
 
  AddColumn(sheet, ncols);
 
- if(!GTK_WIDGET_REALIZED(sheet)) return;
+ if (!gtk_widget_get_realized (GTK_WIDGET (sheet))) {
+   return;
+ }
 
  adjust_scrollbars(sheet);
 
@@ -7124,7 +7137,9 @@ gtk_sheet_add_row(GtkSheet *sheet, guint nrows)
 
  AddRow(sheet, nrows);
 
- if(!GTK_WIDGET_REALIZED(sheet)) return;
+ if (!gtk_widget_get_realized (GTK_WIDGET (sheet))) {
+   return;
+ }
 
  if(sheet->state==GTK_SHEET_COLUMN_SELECTED) sheet->range.rowi+=nrows;
 
@@ -7145,8 +7160,9 @@ gtk_sheet_insert_rows(GtkSheet *sheet, guint row, guint nrows)
  g_return_if_fail (sheet != NULL);
  g_return_if_fail (GTK_IS_SHEET (sheet));
 
- if(GTK_WIDGET_REALIZED(sheet))
+ if (gtk_widget_get_realized (GTK_WIDGET (sheet))) {
    gtk_sheet_real_unselect_range(sheet, NULL);
+ }
 
  InsertRow(sheet, row, nrows);
 
@@ -7162,7 +7178,9 @@ gtk_sheet_insert_rows(GtkSheet *sheet, guint row, guint nrows)
      children = g_list_next(children);
    }
 
- if(!GTK_WIDGET_REALIZED(sheet)) return;
+ if (!gtk_widget_get_realized (GTK_WIDGET (sheet))) {
+   return;
+ }
 
  if(sheet->state==GTK_SHEET_COLUMN_SELECTED) sheet->range.rowi+=nrows;
  adjust_scrollbars(sheet);
@@ -7183,8 +7201,9 @@ gtk_sheet_insert_columns(GtkSheet *sheet, guint col, guint ncols)
  g_return_if_fail (sheet != NULL);
  g_return_if_fail (GTK_IS_SHEET (sheet));
 
- if(GTK_WIDGET_REALIZED(sheet))
+ if (gtk_widget_get_realized (GTK_WIDGET (sheet))) {
    gtk_sheet_real_unselect_range(sheet, NULL);
+ }
 
  InsertColumn(sheet, col, ncols);
 
@@ -7200,7 +7219,9 @@ gtk_sheet_insert_columns(GtkSheet *sheet, guint col, guint ncols)
      children = g_list_next(children);
    }
 
- if(!GTK_WIDGET_REALIZED(sheet)) return;
+ if (!gtk_widget_get_realized (GTK_WIDGET (sheet))) {
+   return;
+ }
 
  if(sheet->state==GTK_SHEET_ROW_SELECTED) sheet->range.coli+=ncols;
  adjust_scrollbars(sheet);
@@ -7225,8 +7246,9 @@ gtk_sheet_delete_rows(GtkSheet *sheet, guint row, guint nrows)
 
  nrows = MIN(nrows, sheet->maxrow-row+1);
 
- if(GTK_WIDGET_REALIZED(sheet))
+ if (gtk_widget_get_realized (GTK_WIDGET (sheet))) {
    gtk_sheet_real_unselect_range(sheet, NULL);
+ }
 
  DeleteRow(sheet, row, nrows);
 
@@ -7255,7 +7277,9 @@ gtk_sheet_delete_rows(GtkSheet *sheet, guint row, guint nrows)
      children = g_list_next(children);
    }
 
- if(!GTK_WIDGET_REALIZED(sheet)) return;
+ if (!gtk_widget_get_realized (GTK_WIDGET (sheet))) {
+   return;
+ }
 
  irow = sheet->active_cell.row;
  icol = sheet->active_cell.col;
@@ -7295,8 +7319,9 @@ gtk_sheet_delete_columns(GtkSheet *sheet, guint col, guint ncols)
 
  ncols = MIN(ncols, sheet->maxcol-col+1);
 
- if(GTK_WIDGET_REALIZED(sheet))
+ if (gtk_widget_get_realized (GTK_WIDGET (sheet))) {
    gtk_sheet_real_unselect_range(sheet, NULL);
+ }
 
  DeleteColumn(sheet, col, ncols);
 
@@ -7323,7 +7348,9 @@ gtk_sheet_delete_columns(GtkSheet *sheet, guint col, guint ncols)
      children = g_list_next(children);
    }
 
- if(!GTK_WIDGET_REALIZED(sheet)) return;
+ if (!gtk_widget_get_realized (GTK_WIDGET (sheet))) {
+   return;
+ }
 
  irow = sheet->active_cell.row;
  icol = sheet->active_cell.col;
@@ -7460,7 +7487,7 @@ gtk_sheet_column_set_justification(GtkSheet *sheet, gint col,
 
   sheet->column[col].justification = justification;
   
-  if(GTK_WIDGET_REALIZED(sheet) && !GTK_SHEET_IS_FROZEN(sheet) &&
+  if (gtk_widget_get_realized (GTK_WIDGET (sheet)) && !GTK_SHEET_IS_FROZEN (sheet) &&
      col >= MIN_VISIBLE_COLUMN(sheet) && col <= MAX_VISIBLE_COLUMN(sheet))
           gtk_sheet_range_draw(sheet, NULL);
 
@@ -7692,7 +7719,7 @@ init_attributes(GtkSheet *sheet, gint col, GtkSheetCellAttr *attributes)
  /* DEFAULT VALUES */    
  attributes->foreground = GTK_WIDGET(sheet)->style->black;
  attributes->background = sheet->bg_color;
- if(!GTK_WIDGET_REALIZED(GTK_WIDGET(sheet))){
+ if (!gtk_widget_get_realized (GTK_WIDGET (sheet))) {
    GdkColormap *colormap;
    colormap=gdk_colormap_get_system();
    gdk_color_black(colormap, &attributes->foreground);
@@ -8092,8 +8119,8 @@ gtk_sheet_put(GtkSheet *sheet, GtkWidget *child, gint x, gint y)
 
   if (gtk_widget_get_visible (GTK_WIDGET (sheet)))
     {
-       if(GTK_WIDGET_REALIZED(GTK_WIDGET(sheet)) && 
-          (!GTK_WIDGET_REALIZED(child) || !gtk_widget_get_has_window (child))) {
+       if (gtk_widget_get_realized (GTK_WIDGET (sheet)) &&
+           (!gtk_widget_get_realized (child) || !gtk_widget_get_has_window (child))) {
         gtk_sheet_realize_child(sheet, child_info);
        }
 
@@ -8106,7 +8133,7 @@ gtk_sheet_put(GtkSheet *sheet, GtkWidget *child, gint x, gint y)
 
 /* This will avoid drawing on the titles */
 
-  if(GTK_WIDGET_REALIZED(GTK_WIDGET(sheet)))
+  if (gtk_widget_get_realized (GTK_WIDGET (sheet)))
    {
       if(sheet->row_titles_visible)
              gdk_window_show(sheet->row_title_window);
@@ -8191,8 +8218,8 @@ gtk_sheet_attach        (GtkSheet *sheet,
 
   if (gtk_widget_get_visible (GTK_WIDGET (sheet)))
     {
-       if(GTK_WIDGET_REALIZED(GTK_WIDGET(sheet)) &&
-          (!GTK_WIDGET_REALIZED(widget) || !gtk_widget_get_has_window (widget))) {
+       if (gtk_widget_get_realized (GTK_WIDGET (sheet)) &&
+           (!gtk_widget_get_realized (widget) || !gtk_widget_get_has_window (widget))) {
         gtk_sheet_realize_child(sheet, child);
        }
 
@@ -8205,7 +8232,7 @@ gtk_sheet_attach        (GtkSheet *sheet,
 
 /* This will avoid drawing on the titles */
 
-  if(GTK_WIDGET_REALIZED(GTK_WIDGET(sheet)))
+  if (gtk_widget_get_realized (GTK_WIDGET (sheet)))
    {
       if(GTK_SHEET_ROW_TITLES_VISIBLE(sheet))
              gdk_window_show(sheet->row_title_window);
@@ -8269,8 +8296,8 @@ gtk_sheet_button_attach		(GtkSheet *sheet,
 
   if (gtk_widget_get_visible (GTK_WIDGET (sheet)))
     {
-       if(GTK_WIDGET_REALIZED(GTK_WIDGET(sheet)) && 
-          (!GTK_WIDGET_REALIZED(widget) || !gtk_widget_get_has_window (widget))) {
+       if (gtk_widget_get_realized (GTK_WIDGET (sheet)) &&
+           (!gtk_widget_get_realized (widget) || !gtk_widget_get_has_window (widget))) {
         gtk_sheet_realize_child(sheet, child);
        }
 
@@ -8642,7 +8669,7 @@ gtk_sheet_realize_child(GtkSheet *sheet, GtkSheetChild *child)
 
   widget = GTK_WIDGET(sheet);
 
-  if(GTK_WIDGET_REALIZED(widget)){
+  if (gtk_widget_get_realized (widget)) {
     if(child->row == -1)
       gtk_widget_set_parent_window(child->widget, sheet->column_title_window);
     else if(child->col == -1)

--- a/attrib/src/gtksheet_2_2.c
+++ b/attrib/src/gtksheet_2_2.c
@@ -1421,7 +1421,7 @@ gtk_sheet_thaw(GtkSheet *sheet)
   }
 
   if(sheet->state == GTK_STATE_NORMAL)
-     if(sheet->sheet_entry && GTK_WIDGET_MAPPED(sheet->sheet_entry)){
+     if (sheet->sheet_entry && gtk_widget_get_mapped (sheet->sheet_entry)) {
         gtk_sheet_activate_cell(sheet, sheet->active_cell.row, sheet->active_cell.col);
      }
 
@@ -2904,7 +2904,7 @@ gtk_sheet_map (GtkWidget * widget)
 
   sheet = GTK_SHEET (widget);
 
-  if (!GTK_WIDGET_MAPPED (widget))
+  if (!gtk_widget_get_mapped (widget))
     {
       gtk_widget_set_mapped (widget, TRUE);
 
@@ -2921,21 +2921,22 @@ gtk_sheet_map (GtkWidget * widget)
            gdk_window_show (sheet->row_title_window);
       }
 
-      if(!GTK_WIDGET_MAPPED (sheet->sheet_entry)){
+      if (!gtk_widget_get_mapped (sheet->sheet_entry)) {
       	          gtk_widget_show (sheet->sheet_entry);
    	          gtk_widget_map (sheet->sheet_entry);
       }
 
       if (gtk_widget_get_visible (sheet->button) &&
-	  !GTK_WIDGET_MAPPED (sheet->button)){
+          !gtk_widget_get_mapped (sheet->button)) {
                   gtk_widget_show(sheet->button);
 	          gtk_widget_map (sheet->button);
       }
 
       if(GTK_BIN(sheet->button)->child)
         if (gtk_widget_get_visible (GTK_BIN (sheet->button)->child) &&
-  	   !GTK_WIDGET_MAPPED (GTK_BIN(sheet->button)->child))
+            !gtk_widget_get_mapped (GTK_BIN (sheet->button)->child)) {
   	          gtk_widget_map (GTK_BIN(sheet->button)->child);
+        }
 
       gtk_sheet_range_draw(sheet, NULL);
       gtk_sheet_activate_cell(sheet, 
@@ -2949,7 +2950,7 @@ gtk_sheet_map (GtkWidget * widget)
         children = g_list_next(children);
 
         if (gtk_widget_get_visible (child->widget) &&
-    	    !GTK_WIDGET_MAPPED (child->widget)){
+            !gtk_widget_get_mapped (child->widget)) {
 	  gtk_widget_map (child->widget);
           gtk_sheet_position_child(sheet, child);
         }
@@ -2970,7 +2971,7 @@ gtk_sheet_unmap (GtkWidget * widget)
 
   sheet = GTK_SHEET (widget);
 
-  if (GTK_WIDGET_MAPPED (widget))
+  if (gtk_widget_get_mapped (widget))
     {
       GTK_WIDGET_UNSET_FLAGS (widget, GTK_MAPPED);
 
@@ -2981,10 +2982,10 @@ gtk_sheet_unmap (GtkWidget * widget)
           gdk_window_hide (sheet->row_title_window);
       gdk_window_hide (widget->window);
 
-      if (GTK_WIDGET_MAPPED (sheet->sheet_entry))
+      if (gtk_widget_get_mapped (sheet->sheet_entry))
 	gtk_widget_unmap (sheet->sheet_entry);
 
-      if (GTK_WIDGET_MAPPED (sheet->button))
+      if (gtk_widget_get_mapped (sheet->button))
 	gtk_widget_unmap (sheet->button);
 
       children = sheet->children;
@@ -2994,7 +2995,7 @@ gtk_sheet_unmap (GtkWidget * widget)
           children = g_list_next(children);
 
           if (gtk_widget_get_visible (child->widget) &&
-	      GTK_WIDGET_MAPPED (child->widget))
+              gtk_widget_get_mapped (child->widget))
                 {
   	             gtk_widget_unmap (child->widget);
                 }
@@ -3301,7 +3302,7 @@ gtk_sheet_range_draw(GtkSheet *sheet, const GtkSheetRange *range)
  
  if (!gtk_widget_is_drawable (GTK_WIDGET (sheet))) return;
  if (!gtk_widget_get_realized (GTK_WIDGET (sheet))) return;
- if(!GTK_WIDGET_MAPPED(GTK_WIDGET(sheet))) return;
+ if (!gtk_widget_get_mapped (GTK_WIDGET (sheet))) return;
 
  if(range == NULL)
  {
@@ -6166,7 +6167,7 @@ gtk_sheet_size_allocate_entry(GtkSheet *sheet)
  const gchar *text;
 
  if (!gtk_widget_get_realized (GTK_WIDGET (sheet))) return;
- if(!GTK_WIDGET_MAPPED(GTK_WIDGET(sheet))) return;
+ if (!gtk_widget_get_mapped (GTK_WIDGET (sheet))) return;
 
  sheet_entry = GTK_ENTRY(gtk_sheet_get_entry(sheet));
 
@@ -6596,7 +6597,7 @@ gtk_sheet_button_draw (GtkSheet *sheet, gint row, gint column)
       gtk_widget_set_state(child->widget, button->state);
 
       if (gtk_widget_get_realized (GTK_WIDGET (sheet)) &&
-         GTK_WIDGET_MAPPED(child->widget))
+          gtk_widget_get_mapped (child->widget))
             {
               gtk_widget_size_allocate(child->widget, 
                                        &allocation);
@@ -8124,9 +8125,10 @@ gtk_sheet_put(GtkSheet *sheet, GtkWidget *child, gint x, gint y)
         gtk_sheet_realize_child(sheet, child_info);
        }
 
-       if(GTK_WIDGET_MAPPED(GTK_WIDGET(sheet)) && 
-          !GTK_WIDGET_MAPPED(child))
+       if (gtk_widget_get_mapped (GTK_WIDGET (sheet)) &&
+           !gtk_widget_get_mapped (child)) {
         gtk_widget_map(child);
+       }
     }
 
   gtk_sheet_position_child(sheet, child_info);
@@ -8223,9 +8225,10 @@ gtk_sheet_attach        (GtkSheet *sheet,
         gtk_sheet_realize_child(sheet, child);
        }
 
-       if(GTK_WIDGET_MAPPED(GTK_WIDGET(sheet)) &&
-          !GTK_WIDGET_MAPPED(widget))
+       if (gtk_widget_get_mapped (GTK_WIDGET (sheet)) &&
+           !gtk_widget_get_mapped (widget)) {
         gtk_widget_map(widget);
+       }
     }
 
   gtk_sheet_position_child(sheet, child);
@@ -8301,9 +8304,10 @@ gtk_sheet_button_attach		(GtkSheet *sheet,
         gtk_sheet_realize_child(sheet, child);
        }
 
-       if(GTK_WIDGET_MAPPED(GTK_WIDGET(sheet)) && 
-          !GTK_WIDGET_MAPPED(widget))
+       if (gtk_widget_get_mapped (GTK_WIDGET (sheet)) &&
+           !gtk_widget_get_mapped (widget)) {
         gtk_widget_map(widget);
+       }
     }
 
   if(row == -1) size_allocate_column_title_buttons(sheet);

--- a/attrib/src/gtksheet_2_2.c
+++ b/attrib/src/gtksheet_2_2.c
@@ -2430,7 +2430,13 @@ gtk_sheet_set_vadjustment (GtkSheet      *sheet,
 
   if (sheet->vadjustment)
     {
-      gtk_signal_disconnect_by_data (GTK_OBJECT (sheet->vadjustment), sheet);
+      g_signal_handlers_disconnect_matched (sheet->vadjustment,  /* instance  */
+                                            G_SIGNAL_MATCH_DATA, /* mask      */
+                                            0,                   /* signal_id */
+                                            0,                   /* detail    */
+                                            NULL,                /* closure   */
+                                            NULL,                /* func      */
+                                            sheet);              /* data      */
       g_object_unref (sheet->vadjustment);
     }
 
@@ -2474,7 +2480,13 @@ gtk_sheet_set_hadjustment (GtkSheet      *sheet,
 
   if (sheet->hadjustment)
     {
-      gtk_signal_disconnect_by_data (GTK_OBJECT (sheet->hadjustment), sheet);
+      g_signal_handlers_disconnect_matched (sheet->hadjustment,  /* instance  */
+                                            G_SIGNAL_MATCH_DATA, /* mask      */
+                                            0,                   /* signal_id */
+                                            0,                   /* detail    */
+                                            NULL,                /* closure   */
+                                            NULL,                /* func      */
+                                            sheet);              /* data      */
       g_object_unref (sheet->hadjustment);
     }
 
@@ -2583,13 +2595,25 @@ gtk_sheet_destroy (GtkObject * object)
   /* unref adjustments */
   if (sheet->hadjustment)
     {
-      gtk_signal_disconnect_by_data (GTK_OBJECT (sheet->hadjustment), sheet);
+      g_signal_handlers_disconnect_matched (sheet->hadjustment,  /* instance  */
+                                            G_SIGNAL_MATCH_DATA, /* mask      */
+                                            0,                   /* signal_id */
+                                            0,                   /* detail    */
+                                            NULL,                /* closure   */
+                                            NULL,                /* func      */
+                                            sheet);              /* data      */
       g_object_unref (sheet->hadjustment);
       sheet->hadjustment = NULL;
     }
   if (sheet->vadjustment)
     {
-      gtk_signal_disconnect_by_data (GTK_OBJECT (sheet->vadjustment), sheet);
+      g_signal_handlers_disconnect_matched (sheet->vadjustment,  /* instance  */
+                                            G_SIGNAL_MATCH_DATA, /* mask      */
+                                            0,                   /* signal_id */
+                                            0,                   /* detail    */
+                                            NULL,                /* closure   */
+                                            NULL,                /* func      */
+                                            sheet);              /* data      */
       g_object_unref (sheet->vadjustment);
       sheet->vadjustment = NULL;
     }

--- a/schematic/src/gschem_page_view.c
+++ b/schematic/src/gschem_page_view.c
@@ -514,7 +514,7 @@ gschem_page_view_invalidate_object (GschemPageView *view, OBJECT *object)
   g_return_if_fail (object != NULL);
   g_return_if_fail (view != NULL);
 
-  if (!GTK_WIDGET_REALIZED (GTK_WIDGET (view))) {
+  if (!gtk_widget_get_realized (GTK_WIDGET (view))) {
     return;
   }
 

--- a/schematic/src/x_event.c
+++ b/schematic/src/x_event.c
@@ -849,8 +849,8 @@ x_event_get_pointer_position (GschemToplevel *w_current, gboolean snapped, gint 
 
   g_return_val_if_fail (GTK_WIDGET (page_view)->window != NULL, FALSE);
 
-  /* \todo The following line is depricated in GDK 2.24 */
-  gdk_drawable_get_size (GTK_WIDGET (page_view)->window, &width, &height);
+  width = gdk_window_get_width (GTK_WIDGET (page_view)->window);
+  height = gdk_window_get_height (GTK_WIDGET (page_view)->window);
 
   gtk_widget_get_pointer(GTK_WIDGET (page_view), &sx, &sy);
 

--- a/schematic/src/x_window.c
+++ b/schematic/src/x_window.c
@@ -133,7 +133,7 @@ void x_window_create_drawing(GtkWidget *scrolled, GschemToplevel *w_current)
 
   gtk_container_add(GTK_CONTAINER(scrolled), w_current->drawing_area);
 
-  GTK_WIDGET_SET_FLAGS (w_current->drawing_area, GTK_CAN_FOCUS );
+  gtk_widget_set_can_focus (w_current->drawing_area, TRUE);
   gtk_widget_grab_focus (w_current->drawing_area);
   gtk_widget_show (w_current->drawing_area);
 }


### PR DESCRIPTION
Since we upgraded to gtk 2.24, I rebased the rest of the branch by Riccardo Lucchese he did a few years ago for geda-gaf. The branch contains fixes inappropriate at that time since the required version of gtk was 2.18.