### PR TITLE
Remove obsolete options-text-size action

### DIFF
--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -138,7 +138,6 @@ SCM g_keys_attributes_show_value(SCM rest);
 SCM g_keys_attributes_show_both(SCM rest);
 SCM g_keys_attributes_visibility_toggle(SCM rest);
 SCM g_keys_script_console(SCM rest);
-SCM g_keys_options_text_size(SCM rest);
 SCM g_keys_options_afeedback(SCM rest);
 SCM g_keys_options_grid(SCM rest);
 SCM g_keys_options_snap(SCM rest);

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -363,7 +363,6 @@ void i_callback_attributes_show_value(gpointer data, guint callback_action, GtkW
 void i_callback_attributes_show_both(gpointer data, guint callback_action, GtkWidget *widget);
 void i_callback_attributes_visibility_toggle(gpointer data, guint callback_action, GtkWidget *widget);
 void i_callback_script_console(gpointer data, guint callback_action, GtkWidget *widget);
-void i_callback_options_text_size(gpointer data, guint callback_action, GtkWidget *widget);
 void i_callback_options_snap_size(gpointer data, guint callback_action, GtkWidget *widget);
 void i_callback_options_scale_up_snap_size(gpointer data, guint callback_action, GtkWidget *widget);
 void i_callback_options_scale_down_snap_size(gpointer data, guint callback_action, GtkWidget *widget);

--- a/schematic/lib/system-gschemrc.scm
+++ b/schematic/lib/system-gschemrc.scm
@@ -1000,7 +1000,6 @@
 (global-set-key "M" '&edit-move)
 (global-set-key "N" '&add-net)
 
-(global-set-key "O T" '&options-text-size)
 (global-set-key "O A" '&options-action-feedback)
 (global-set-key "O G" '&options-grid)
 (global-set-key "O S" '&options-snap)
@@ -1265,7 +1264,6 @@
 ;;          menu item name      menu action             menu stock icon
 ;;
         `( (,(N_ "_Font...")                 &options-select-font)
-           (,(N_ "Text Size...")             &options-text-size)
            (,(N_ "Cycle _grid styles")       &options-grid)
            (,(N_ "Toggle _Snap On/Off")      &options-snap)
            (,(N_ "Snap Grid S_pacing...")    &options-snap-size)

--- a/schematic/scheme/gschem/builtins.scm
+++ b/schematic/scheme/gschem/builtins.scm
@@ -344,9 +344,6 @@
 (define-action-public (&help-hotkeys #:label (_ "Show Hotkeys") #:icon "preferences-desktop-keyboard-shortcuts")
   (%help-hotkeys))
 
-(define-action-public (&options-text-size #:label (_ "Set Default Text Size"))
-  (%options-text-size))
-
 (define-action-public (&options-grid #:label (_ "Switch Grid Style"))
   (%options-grid))
 

--- a/schematic/src/g_builtins.c
+++ b/schematic/src/g_builtins.c
@@ -137,7 +137,6 @@ static struct BuiltinInfo builtins[] = {
   { "%attributes-show-value",        0, 0, 0, (SCM (*) ()) g_keys_attributes_show_value },
   { "%attributes-show-both",         0, 0, 0, (SCM (*) ()) g_keys_attributes_show_both },
   { "%attributes-visibility-toggle", 0, 0, 0, (SCM (*) ()) g_keys_attributes_visibility_toggle },
-  { "%options-text-size",            0, 0, 0, (SCM (*) ()) g_keys_options_text_size },
   { "%options-snap-size",            0, 0, 0, (SCM (*) ()) g_keys_options_snap_size },
   { "%options-scale-up-snap-size",   0, 0, 0, (SCM (*) ()) g_keys_options_scale_up_snap_size },
   { "%options-scale-down-snap-size", 0, 0, 0, (SCM (*) ()) g_keys_options_scale_down_snap_size },

--- a/schematic/src/g_keys.c
+++ b/schematic/src/g_keys.c
@@ -183,10 +183,6 @@ DEFINE_G_KEYS(script_console)
 
 /* repeat last command doesn't make sense on options either??? (does
  * it?) */
-DEFINE_G_KEYS(options_text_size)
-
-/* repeat last command doesn't make sense on options either??? (does
- * it?) */
 DEFINE_G_KEYS(options_afeedback)
 DEFINE_G_KEYS(options_grid)
 DEFINE_G_KEYS(options_snap)

--- a/schematic/src/g_register.c
+++ b/schematic/src/g_register.c
@@ -227,7 +227,6 @@ static struct gsubr_t gschem_funcs[] = {
   { "attributes-show-value",        0, 0, 0, (SCM (*) ()) g_keys_attributes_show_value },
   { "attributes-show-both",         0, 0, 0, (SCM (*) ()) g_keys_attributes_show_both },
   { "attributes-visibility-toggle", 0, 0, 0, (SCM (*) ()) g_keys_attributes_visibility_toggle },
-  { "options-text-size",            0, 0, 0, (SCM (*) ()) g_keys_options_text_size },
   { "options-snap-size",            0, 0, 0, (SCM (*) ()) g_keys_options_snap_size },
   { "options-scale-up-snap-size",   0, 0, 0, (SCM (*) ()) g_keys_options_scale_up_snap_size },
   { "options-scale-down-snap-size", 0, 0, 0, (SCM (*) ()) g_keys_options_scale_down_snap_size },

--- a/schematic/src/i_callbacks.c
+++ b/schematic/src/i_callbacks.c
@@ -2628,24 +2628,6 @@ DEFINE_I_CALLBACK(script_console)
   printf(_("Sorry but this is a non-functioning menu option\n"));
 }
 
-/*! \section layers-menu Layers Menu Callback Functions */
-
-/*! \section options-menu Options Menu Callback Functions */
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- *  \note
- *  repeat last command doesn't make sense on options either??? (does it?)
- */
-DEFINE_I_CALLBACK(options_text_size)
-{
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-
-  g_return_if_fail (w_current != NULL);
-  text_edit_dialog (w_current);
-}
-
 /*! \todo Finish function documentation!!!
  *  \brief
  *  \par Function Description


### PR DESCRIPTION
This obsolete action was used to invoke
"Text Size" dialog, which was removed
in revision 150c850 (back in 2014).