### PR TITLE
Fix doc searching bug in lepton-schematic's module `gschemdoc'

### DIFF
--- a/schematic/scheme/gschem/gschemdoc.scm
+++ b/schematic/scheme/gschem/gschemdoc.scm
@@ -49,14 +49,14 @@ Get the directory where gEDA documentation is stored."
 
      (lambda (dir)
        (let ((docdir
-              (string-join (list (guess-prefix dir)
+              (string-join (list dir
                                  "share" "doc" "lepton-eda")
                            file-name-separator-string)))
          (and (false-if-exception
                (eq? 'directory (stat:type (stat docdir))))
               docdir)))
 
-     (sys-data-dirs)))
+     (filter-map guess-prefix (sys-data-dirs))))
 
   (or (guess-docdir)
       (if (platform? 'win32-native)


### PR DESCRIPTION
Sometimes, when `gschemdoc' tried to "guess" the doc path, it
failed due to using #f in constructing of resulting strings.
Now the results of guessing are filtered so this possibility is
eliminated. The bug appeared on some systems when the user chose
an entry from the Help menu.

Affects #285