### PR TITLE
Remove config keys through liblepton configuration API

### DIFF
--- a/docs/scheme-api/lepton-scheme.texi
+++ b/docs/scheme-api/lepton-scheme.texi
@@ -1870,6 +1870,12 @@ in the specified @var{group}.
 Since 1.10.
 @end defun
 
+@defun config-remove-key! cfg group key
+Removes the configuration parameter identified by the given @var{group}
+and @var{key} in the configuration context @var{cfg}.
+
+@end defun
+
 @subsubsection Configuration inheritance
 
 If a configuration context does not directly specify a value for a

--- a/liblepton/include/liblepton/edaconfig.h
+++ b/liblepton/include/liblepton/edaconfig.h
@@ -1,6 +1,7 @@
-/* gEDA - GPL Electronic Design Automation
- * libgeda - gEDA's Library
- * Copyright (C) 2011-2012 gEDA Contributors (see ChangeLog for details)
+/* Lepton EDA
+ * liblepton - Lepton's library
+ * Copyright (C) 2011-2012 gEDA Contributors
+ * Copyright (C) 2017-2018 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -144,6 +145,8 @@ void eda_config_set_string_list (EdaConfig *cfg, const char *group, const char *
 void eda_config_set_boolean_list (EdaConfig *cfg, const char *group, const char *key, gboolean list[], gsize length);
 void eda_config_set_int_list (EdaConfig *cfg, const char *group, const char *key, gint list[], gsize length);
 void eda_config_set_double_list (EdaConfig *cfg, const char *group, const char *key, gdouble list[], gsize length);
+
+gboolean eda_config_remove_key (EdaConfig *cfg, const char *group, const char *key, GError **error);
 
 G_END_DECLS
 

--- a/liblepton/scheme/geda/config.scm
+++ b/liblepton/scheme/geda/config.scm
@@ -1,6 +1,7 @@
-;; gEDA - GPL Electronic Design Automation
-;; libgeda - gEDA's library - Scheme API
+;; Lepton EDA
+;; liblepton - Lepton's library - Scheme API
 ;; Copyright (C) 2011-2012 Peter Brett <peter@peter-b.co.uk>
+;; Copyright (C) 2017-2018 Lepton EDA Contributors
 ;;
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -68,3 +69,6 @@
 (define-public set-config! %set-config!)
 (define-public add-config-event! %add-config-event!)
 (define-public remove-config-event! %remove-config-event!)
+
+(define-public config-remove-key! %config-remove-key!)
+

--- a/liblepton/scheme/unit-test.scm
+++ b/liblepton/scheme/unit-test.scm
@@ -1,5 +1,6 @@
 ;; Minimal Scheme unit-test framework
-;; Copyright (C) 2010 Peter Brett <peter@peter-b.co.uk>
+;; Copyright (C) 2010-2011 Peter Brett <peter@peter-b.co.uk>
+;; Copyright (C) 2018 Lepton EDA Contributors
 ;;
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -43,6 +44,7 @@
 (define-module (unit-test)
   #:use-module (ice-9 pretty-print)
   #:export (assert-true
+            assert-false
             assert-equal
             %assert-thrown
             tests-passed?
@@ -64,6 +66,12 @@
       #t
       (throw 'test-failed-exception
              (simple-format #f "  assert-true: got: ~S" result))))
+
+(define (assert-false result)
+  (if (not result)
+      #t
+      (throw 'test-failed-exception
+             (simple-format #f "  assert-false: got: ~S" result))))
 
 (define (assert-equal expected result)
   (if (equal? expected result)

--- a/liblepton/scheme/unit-tests/t0402-config.scm
+++ b/liblepton/scheme/unit-tests/t0402-config.scm
@@ -296,3 +296,54 @@
     (assert-equal a (remove-config-event! a handler))
     (set-config! a "foo" "bar" #t)
     (assert-equal 2 call-count)))
+
+
+
+; Unit test for config-remove-key! function:
+;
+( begin-config-test 'config-remove-key
+( let*
+  (
+  ( cfg   (path-config-context *testdir*) )
+  ( group #f )
+  ( key   #f )
+  ( handler
+    ( lambda( c g k ) ; config, group, key
+      ( set! group g )
+      ( set! key   k )
+    )
+  )
+  )
+
+  ; load configuration file from *testdir* directory:
+  ;
+  ( config-load! cfg )
+
+  ; add group::key, set it to "value":
+  ;
+  ( set-config! cfg "group" "key" "value" )
+
+  ; setup config event handler for cfg:
+  ;
+  ( add-config-event! cfg handler )
+
+  ; remove group::key:
+  ;
+  ( assert-true (config-remove-key! cfg "group" "key") )
+
+  ; check if event handler was called:
+  ;
+  ( assert-equal group "group" )
+  ( assert-equal key   "key"   )
+
+  ; check if group::key still exists:
+  ;
+  ( assert-false (config-has-key? cfg "group" "key") )
+
+  ; exception should be thrown if group::key is not found:
+  ;
+  ( assert-thrown 'config-error (config-remove-key! cfg "group" "key") )
+
+) ; let
+) ; config-remove-key()
+

--- a/liblepton/src/edaconfig.c
+++ b/liblepton/src/edaconfig.c
@@ -1,7 +1,8 @@
-/* gEDA - GPL Electronic Design Automation
- * libgeda - gEDA's Library
- * Copyright (C) 2011-2012 gEDA Contributors (see ChangeLog for details)
+/* Lepton EDA
+ * liblepton - Lepton's library
+ * Copyright (C) 2011-2012 gEDA Contributors
  * Copyright (C) 2016 Peter Brett <peter@peter-b.co.uk>
+ * Copyright (C) 2017-2018 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1145,7 +1146,7 @@ eda_config_has_key (EdaConfig *cfg, const gchar *group,
  * Returns the configuration context (either \a cfg or one of its
  * parent contexts) in which the configuration parameter with the
  * given \a group and \a key has a value specified.  If the group or
- * key cannot be found, returns FALSE and sets \a error.
+ * key cannot be found, returns NULL and sets \a error.
  *
  * \see eda_config_is_inherited().
  *
@@ -1659,6 +1660,39 @@ eda_config_set_double_list (EdaConfig *cfg, const char *group,
                               list, length);
   g_signal_emit_by_name (cfg, "config-changed", group, key);
 }
+
+
+
+/*! \public \memberof EdaConfig
+ * \brief Remove a configuration parameter.
+ *
+ * Remove the configuration parameter specified by \a group
+ * and \a key in the configuration context \a cfg.
+ *
+ * \param cfg    Configuration context.
+ * \param group  Configuration group name.
+ * \param key    Configuration key name.
+ * \param error  Return location for error information.
+ *
+ * \return       TRUE on success, FALSE otherwise.
+ */
+gboolean
+eda_config_remove_key (EdaConfig *cfg, const char *group,
+                       const char *key, GError **error)
+{
+  GError* tmp_err = NULL;
+  gboolean result =
+    g_key_file_remove_key (cfg->priv->keyfile, group, key, &tmp_err);
+
+  propagate_key_file_error (tmp_err, error);
+
+  if (result)
+    g_signal_emit_by_name (cfg, "config-changed", group, key);
+
+  return result;
+}
+
+
 
 /*! \brief Callback marshal function for config-changed signals.
  * \par Function Description

--- a/liblepton/src/scheme_config.c
+++ b/liblepton/src/scheme_config.c
@@ -1,6 +1,7 @@
-/* gEDA - GPL Electronic Design Automation
- * libgeda - gEDA's library - Scheme API
+/* Lepton EDA
+ * liblepton - Lepton's library - Scheme API
  * Copyright (C) 2011-2012 Peter Brett <peter@peter-b.co.uk>
+ * Copyright (C) 2017-2018 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1125,6 +1126,55 @@ SCM_DEFINE (remove_config_event_x, "%remove-config-event!", 2, 0, 0,
   return cfg_s;
 }
 
+
+
+/*! \brief Remove a configuration parameter.
+ *
+ * \par Function Description
+ * Remove the configuration parameter specified by \a group_s
+ * and \a key_s in the configuration context \a cfg_s.
+ *
+ * \see eda_config_remove_key().
+ *
+ * \note Scheme API: Implements the \%config-remove-key!
+ * procedure in the (geda core config) module.
+ *
+ * \param cfg_s    #EdaConfig smob of configuration context.
+ * \param group_s  Group name as a string.
+ * \param key_s    Key name as a string.
+ *
+ * \return         Boolean value indicating success or failure.
+ */
+SCM_DEFINE (config_remove_key, "%config-remove-key!", 3, 0, 0,
+            (SCM  cfg_s, SCM group_s, SCM key_s),
+            "Remove a configuration key.")
+{
+  ASSERT_CFG_GROUP_KEY (s_config_remove_key);
+
+  scm_dynwind_begin ((scm_t_dynwind_flags) 0);
+
+  EdaConfig* cfg = edascm_to_config (cfg_s);
+
+  char* group = scm_to_utf8_string (group_s);
+  scm_dynwind_free (group);
+
+  char* key = scm_to_utf8_string (key_s);
+  scm_dynwind_free (key);
+
+  GError* error = NULL;
+  gboolean result = eda_config_remove_key (cfg, group, key, &error);
+
+  if (!result)
+  {
+    error_from_gerror (s_config_remove_key, &error);
+  }
+
+  scm_dynwind_end ();
+  return result ? SCM_BOOL_T : SCM_BOOL_F;
+}
+
+
+
 /*!
  * \brief Create the (geda core config) Scheme module.
  * \par Function Description
@@ -1166,6 +1216,7 @@ init_module_geda_core_config (void *unused)
                 s_set_config_x,
                 s_add_config_event_x,
                 s_remove_config_event_x,
+                s_config_remove_key,
                 NULL);
 }
 


### PR DESCRIPTION
Extend `liblepton` configuration API by adding `eda_config_remove_key()`
function (`config-remove-key!` in Scheme).
I'd also add a function that deletes config groups, too, but it's not clear
what signal should be raised in that case. There's `config-changed` signal
with two parameters (`group`, `key`). If we reuse it for a "group removed"
event, what values those parameters should take? Or do we have to introduce
a new signal?