### PR TITLE
Remove config groups through liblepton configuration API

### DIFF
--- a/docs/scheme-api/.gitignore
+++ b/docs/scheme-api/.gitignore
@@ -2,3 +2,4 @@
 lepton-scheme.info
 stamp-vti
 version.texi
+lepton-scheme.html/*

--- a/docs/scheme-api/lepton-scheme.texi
+++ b/docs/scheme-api/lepton-scheme.texi
@@ -1876,6 +1876,12 @@ and @var{key} in the configuration context @var{cfg}.
 
 @end defun
 
+@defun config-remove-group! cfg group
+Removes the configuration group identified by @var{group}
+and all its parameters in the configuration context @var{cfg}.
+
+@end defun
+
 @subsubsection Configuration inheritance
 
 If a configuration context does not directly specify a value for a
@@ -2001,6 +2007,9 @@ handler cfg group key
 @var{cfg} is always the configuration context that received the event,
 and the @var{group} and @var{key} identify the configuration parameter
 that changed.
+When a configuration group is deleted, @var{group} argument is set to
+the name of the deleted group and @var{key} argument is set to an empty
+string.
 
 @defun add-config-event! cfg handler
 Registers @var{handler} to be called when configuration changes in the

--- a/liblepton/include/liblepton/edaconfig.h
+++ b/liblepton/include/liblepton/edaconfig.h
@@ -147,6 +147,7 @@ void eda_config_set_int_list (EdaConfig *cfg, const char *group, const char *key
 void eda_config_set_double_list (EdaConfig *cfg, const char *group, const char *key, gdouble list[], gsize length);
 
 gboolean eda_config_remove_key (EdaConfig *cfg, const char *group, const char *key, GError **error);
+gboolean eda_config_remove_group (EdaConfig *cfg, const char *group, GError **error);
 
 G_END_DECLS
 

--- a/liblepton/scheme/geda/config.scm
+++ b/liblepton/scheme/geda/config.scm
@@ -71,4 +71,5 @@
 (define-public remove-config-event! %remove-config-event!)
 
 (define-public config-remove-key! %config-remove-key!)
+(define-public config-remove-group! %config-remove-group!)
 

--- a/liblepton/scheme/unit-tests/t0402-config.scm
+++ b/liblepton/scheme/unit-tests/t0402-config.scm
@@ -345,5 +345,55 @@
   ( assert-thrown 'config-error (config-remove-key! cfg "group" "key") )
 
 ) ; let
-) ; config-remove-key()
+) ; 'config-remove-key()
+
+
+
+; Unit test for config-remove-group! function:
+;
+( begin-config-test 'config-remove-group
+( let*
+  (
+  ( cfg   (path-config-context *testdir*) )
+  ( group #f )
+  ( key   #f )
+  ( handler
+    ( lambda( c g k ) ; config, group, key
+      ( set! group g )
+      ( set! key   k )
+    )
+  )
+  )
+
+  ; load configuration file from *testdir* directory:
+  ;
+  ( config-load! cfg )
+
+  ; add group::key, set it to "value":
+  ;
+  ( set-config! cfg "group" "key" "value" )
+
+  ; setup config event handler for cfg:
+  ;
+  ( add-config-event! cfg handler )
+
+  ; remove group::key:
+  ;
+  ( assert-true (config-remove-group! cfg "group" ) )
+
+  ; check if event handler was called:
+  ;
+  ( assert-equal group "group" )
+  ( assert-equal key   ""      )
+
+  ; check if group still exists:
+  ;
+  ( assert-false (config-has-group? cfg "group" ) )
+
+  ; exception should be thrown if group is not found:
+  ;
+  ( assert-thrown 'config-error (config-remove-group! cfg "group") )
+
+) ; let
+) ; 'config-remove-group()
 

--- a/liblepton/src/edaconfig.c
+++ b/liblepton/src/edaconfig.c
@@ -1694,6 +1694,36 @@ eda_config_remove_key (EdaConfig *cfg, const char *group,
 
 
 
+/*! \public \memberof EdaConfig
+ * \brief Remove a configuration group and all its parameters.
+ *
+ * Remove the configuration group specified by \a group
+ * and all its parameters in the configuration context \a cfg.
+ *
+ * \param cfg    Configuration context.
+ * \param group  Configuration group name.
+ * \param error  Return location for error information.
+ *
+ * \return       TRUE on success, FALSE otherwise.
+ */
+gboolean
+eda_config_remove_group (EdaConfig *cfg, const char *group,
+                         GError **error)
+{
+  GError* tmp_err = NULL;
+  gboolean result =
+    g_key_file_remove_group (cfg->priv->keyfile, group, &tmp_err);
+
+  propagate_key_file_error (tmp_err, error);
+
+  if (result)
+    g_signal_emit_by_name (cfg, "config-changed", group, "");
+
+  return result;
+}
+
+
+
 /*! \brief Callback marshal function for config-changed signals.
  * \par Function Description
  * Based heavily on g_cclosure_marshal_VOID__STRING() from GObject.

--- a/liblepton/src/scheme_config.c
+++ b/liblepton/src/scheme_config.c
@@ -1175,6 +1175,50 @@ SCM_DEFINE (config_remove_key, "%config-remove-key!", 3, 0, 0,
 
 
 
+/*! \brief Remove a configuration group and all its parameters.
+ *
+ * \par Function Description
+ * Remove the configuration group specified by \a group_s
+ * and all its parameters in the configuration context \a cfg_s.
+ *
+ * \see eda_config_remove_group().
+ *
+ * \note Scheme API: Implements the \%config-remove-group!
+ * procedure in the (geda core config) module.
+ *
+ * \param cfg_s    #EdaConfig smob of configuration context.
+ * \param group_s  Group name as a string.
+ *
+ * \return         Boolean value indicating success or failure.
+ */
+SCM_DEFINE (config_remove_group, "%config-remove-group!", 2, 0, 0,
+            (SCM  cfg_s, SCM group_s),
+            "Remove a configuration group and all its parameters.")
+{
+  SCM_ASSERT (EDASCM_CONFIGP (cfg_s), cfg_s, SCM_ARG1, s_config_remove_group);
+  SCM_ASSERT (scm_is_string (group_s), group_s, SCM_ARG2, s_config_remove_group);
+
+  scm_dynwind_begin ((scm_t_dynwind_flags) 0);
+
+  EdaConfig* cfg = edascm_to_config (cfg_s);
+
+  char* group = scm_to_utf8_string (group_s);
+  scm_dynwind_free (group);
+
+  GError* error = NULL;
+  gboolean result = eda_config_remove_group (cfg, group, &error);
+
+  if (!result)
+  {
+    error_from_gerror (s_config_remove_group, &error);
+  }
+
+  scm_dynwind_end ();
+  return result ? SCM_BOOL_T : SCM_BOOL_F;
+}
+
+
+
 /*!
  * \brief Create the (geda core config) Scheme module.
  * \par Function Description
@@ -1217,6 +1261,7 @@ init_module_geda_core_config (void *unused)
                 s_add_config_event_x,
                 s_remove_config_event_x,
                 s_config_remove_key,
+                s_config_remove_group,
                 NULL);
 }
 


### PR DESCRIPTION
Extend `liblepton` configuration API by adding `eda_config_remove_group()`
function (`config-remove-group!` in Scheme).
The `group` parameter of the `config-changed` signal is set to the group name
deleted and the `key` parameter is set to an empty string.

Related to PR #294 where `eda_config_remove_key()` and `config-remove-key!`
functions were added.