### PR TITLE
Add open-page-hook to the lepton-schematic Scheme API

### DIFF
--- a/docs/scheme-api/lepton-scheme.texi
+++ b/docs/scheme-api/lepton-scheme.texi
@@ -2478,6 +2478,10 @@ a list of objects that were deselected.
 Called when a new page is created. The argument is the new page.
 @end defvar
 
+@defvar open-page-hook
+Called when an existing page is loaded. The argument is the loaded page.
+@end defvar
+
 @defvar action-property-hook
 Called when an action property is set.  The arguments are the action,
 the property key and the property value. @xref{Actions}.

--- a/schematic/scheme/gschem/hook.scm
+++ b/schematic/scheme/gschem/hook.scm
@@ -46,6 +46,8 @@
 
 (define-public new-page-hook %new-page-hook)
 
+(define-public open-page-hook %open-page-hook)
+
 (define-public action-property-hook %action-property-hook)
 
 (define-public bind-keys-hook %bind-keys-hook)

--- a/schematic/src/g_hook.c
+++ b/schematic/src/g_hook.c
@@ -202,6 +202,7 @@ init_module_gschem_core_hook (void *unused)
   DEFINE_HOOK ("%select-objects-hook",1);
   DEFINE_HOOK ("%deselect-objects-hook",1);
   DEFINE_HOOK ("%new-page-hook",1);
+  DEFINE_HOOK ("%open-page-hook",1);
   DEFINE_HOOK ("%action-property-hook",3);
   DEFINE_HOOK ("%bind-keys-hook",3);
   DEFINE_HOOK ("%switch-action-mode-hook",1);

--- a/schematic/src/x_window.c
+++ b/schematic/src/x_window.c
@@ -777,6 +777,9 @@ x_window_open_page_impl (GschemToplevel *w_current, const gchar *filename)
   }
 
 
+  /* Run hook: */
+  g_run_hook_page (w_current, "%open-page-hook", page);
+
   /* Add page file name to the recent file list: */
   recent_manager_add (w_current, filename);
 


### PR DESCRIPTION
The `open-page-hook` hook is called when an existing schematic page is loaded.