### PR TITLE
Add netlist export menu in `lepton-schematic` (for now, for the allegro backend)

### DIFF
--- a/netlist/scheme/gnet-allegro.scm
+++ b/netlist/scheme/gnet-allegro.scm
@@ -118,7 +118,7 @@ PINCOUNT ~A
             (connections->string (get-connections netname schematic))))
   (map net->string netnames))
 
-(define (allegro-netlist schematic output-filename)
+(define* (allegro* schematic #:key output-filename)
   (let ((use-stdout? (not output-filename))
         (packages (schematic-packages schematic))
         (nets (schematic-nets schematic)))
@@ -131,5 +131,5 @@ PINCOUNT ~A
     (display "$END\n")
     (allegro:write-device-files packages '() use-stdout?)))
 
-(define (allegro output-filename)
-  (allegro-netlist (toplevel-schematic) output-filename))
+(define (allegro filename)
+  (allegro* (toplevel-schematic) #:output-filename filename))

--- a/netlist/scheme/gnet-allegro.scm
+++ b/netlist/scheme/gnet-allegro.scm
@@ -111,11 +111,11 @@ PINCOUNT ~A
     (format #f " ~A.~A" (package connection) (pinnumber connection)))
   (string-join (map connection->string connections) ",\n"))
 
-(define (nets->allegro-netlist netnames)
+(define (nets->allegro-netlist netnames schematic)
   (define (net->string netname)
     (format #f "~A;~A\n"
             netname
-            (connections->string (get-all-connections netname))))
+            (connections->string (get-connections netname schematic))))
   (map net->string netnames))
 
 (define (allegro-netlist schematic output-filename)
@@ -127,7 +127,7 @@ PINCOUNT ~A
     (allegro:components packages)
     (display "$NETS\n")
     (for-each display
-              (nets->allegro-netlist nets))
+              (nets->allegro-netlist nets schematic))
     (display "$END\n")
     (allegro:write-device-files packages '() use-stdout?)))
 

--- a/netlist/scheme/netlist.scm
+++ b/netlist/scheme/netlist.scm
@@ -50,6 +50,7 @@
             main
             calling-flag?
             get-device
+            get-connections
             get-all-connections
             get-all-package-attributes
             get-component-text
@@ -347,14 +348,14 @@ REFDES. As a result, slots may be repeated in the returned list."
 
 
 
-(define (get-all-connections netname)
+(define (get-connections netname schematic)
   "Returns all connections in the form of ((refdes pin) ...) for
-NETNAME."
+NETNAME in SCHEMATIC."
   (define (found? x)
     (and x
          (string=? x netname)))
 
-  (define netlist (schematic-components (toplevel-schematic)))
+  (define netlist (schematic-components schematic))
 
   (define non-graphical-refdeses
     (filter-map schematic-component-refdes netlist))
@@ -382,6 +383,11 @@ NETNAME."
 
   (sort-remove-duplicates (get-netlist-connections netlist)
                           pair<?))
+
+(define (get-all-connections netname)
+  "Returns all connections in the form of ((refdes pin) ...) for
+NETNAME."
+  (get-connections netname (toplevel-schematic)))
 
 
 (define (get-pins-nets package)

--- a/schematic/lib/system-gschemrc.scm
+++ b/schematic/lib/system-gschemrc.scm
@@ -3,7 +3,8 @@
 ; Init file for gschem
 ;
 
-(use-modules (gschem deprecated))
+(use-modules (gschem deprecated)
+             (schematic netlist))
 
 ;  ;'s are comments
 ;  keywords are case sensitive (guile feature)
@@ -1289,6 +1290,13 @@
            (,(N_ "_Coord Window") &options-show-coord-window)
            (,(N_ "_Log Window")   &options-show-log-window)))
 
+(define netlist-menu-items
+  ;; Format of list items is:
+  ;; name action icon
+  `(
+    (,(N_ "_1 allegro") &netlist-allegro #f))
+  )
+
 (define help-menu-items
 ;;
 ;;          menu item name                menu action               menu stock icon
@@ -1317,6 +1325,7 @@
 (add-menu (N_ "Hie_rarchy") hierarchy-menu-items)
 (add-menu (N_ "A_ttributes") attributes-menu-items)
 (add-menu (N_ "_Options") options-menu-items)
+(add-menu (N_ "_Netlist") netlist-menu-items)
 (add-menu (N_ "_Help") help-menu-items)
 
 ;

--- a/schematic/scheme/Makefile.am
+++ b/schematic/scheme/Makefile.am
@@ -24,6 +24,7 @@ nobase_dist_scmdata_DATA = \
 	gschem/action.scm \
 	gschem/builtins.scm \
 	gschem/symbol/check.scm \
+	schematic/netlist.scm \
 	schematic/undo.scm
 
 MOSTLYCLEANFILES = *.log *~

--- a/schematic/scheme/schematic/netlist.scm
+++ b/schematic/scheme/schematic/netlist.scm
@@ -1,0 +1,44 @@
+;;; Lepton EDA Schematic Capture
+;;; Scheme API
+;;; Copyright (C) 2018 Lepton EDA Contributors
+;;;
+;;; This program is free software; you can redistribute it and/or modify
+;;; it under the terms of the GNU General Public License as published by
+;;; the Free Software Foundation; either version 2 of the License, or
+;;; (at your option) any later version.
+;;;
+;;; This program is distributed in the hope that it will be useful,
+;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;; GNU General Public License for more details.
+;;;
+;;; You should have received a copy of the GNU General Public License
+;;; along with this program; if not, write to the Free Software
+;;; Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111 USA
+
+;;; Netlist export actions in schematic editor.
+
+(define-module (schematic netlist)
+  #:use-module (geda page)
+  #:use-module (netlist)
+  #:use-module (netlist schematic)
+
+  #:export (&netlist-allegro))
+
+
+;;; FIXME: We have either to somehow define schematic using given
+;;; pages, or get schematic files using `lepton-schematic' options
+;;; (that is, file names on the command line).
+(define (%schematic)
+  ;; FIXME: Just now only 'geda mode is used.
+  (make-toplevel-schematic (map page-filename (active-pages))
+                           'geda))
+
+;;; First load allegro backend code in order to use `allegro*'
+;;; below.
+(primitive-load (%search-load-path "gnet-allegro.scm"))
+
+;;; Allegro backend
+(define (&netlist-allegro)
+  (with-output-to-file "allegro.out"
+    (lambda () (allegro* (%schematic)))))


### PR DESCRIPTION
This is the first step to make all netlister functionality available in `lepton-schematic`.