### PR TITLE
Fix compiler warnings

### DIFF
--- a/attrib/include/prototype.h
+++ b/attrib/include/prototype.h
@@ -163,7 +163,7 @@ void x_dialog_delattrib();
 void x_dialog_missing_sym();
 void x_dialog_unsaved_data();
 void x_dialog_unimplemented_feature();
-void x_dialog_fatal_error(gchar *string, gint return_code);
+void x_dialog_fatal_error(const gchar *string, gint return_code);
 void x_dialog_about_dialog();
 void x_dialog_export_file();
 

--- a/attrib/src/gtksheet_2_2.c
+++ b/attrib/src/gtksheet_2_2.c
@@ -106,6 +106,12 @@ static inline guint DEFAULT_ROW_HEIGHT(GtkWidget *widget)
     return PANGO_PIXELS(val)+2*CELLOFFSET;
   }
 }
+
+
+
+/* DEFAULT_FONT_ASCENT() function is currently unused.
+ * Comment it out to suppress compiler warnings.
+
 static inline guint DEFAULT_FONT_ASCENT(GtkWidget *widget) 
 { 
   if(!widget->style->font_desc) return 12;
@@ -119,6 +125,11 @@ static inline guint DEFAULT_FONT_ASCENT(GtkWidget *widget)
     return PANGO_PIXELS(val);
   }
 }
+
+*/
+
+
+
 static inline guint STRING_WIDTH(GtkWidget *widget,
                                  PangoFontDescription *font, const gchar *text)
 {
@@ -3409,7 +3420,7 @@ gtk_sheet_range_draw(GtkSheet *sheet, const GtkSheetRange *range)
         sheet->data[i] && sheet->data[i][j])
                   gtk_sheet_cell_draw_label (sheet, i, j); 
 
-  gtk_sheet_draw_backing_pixmap(sheet, drawing_range);
+ gtk_sheet_draw_backing_pixmap(sheet, drawing_range);
 
   if(sheet->state != GTK_SHEET_NORMAL && gtk_sheet_range_isvisible(sheet, sheet->range))
        gtk_sheet_range_draw_selection(sheet, drawing_range);
@@ -5248,10 +5259,25 @@ gtk_sheet_button_release (GtkWidget * widget,
                                      sheet->active_cell.col);
   }
 
-  if(GTK_SHEET_IN_SELECTION)
+
+
+  /* \note In original code this "if" expression looks like:
+   *
+   *  if(GTK_SHEET_IN_SELECTION)
+   *
+   * and generates a compiler warning. "GTK_SHEET_IN_SELECTION" name
+   * is used as both macro name and a name of enum member (a bad idea).
+   * In this context using of enum value instead of a macro is most
+   * probably an error (maybe just a typo):
+  */
+  if(GTK_SHEET_IN_SELECTION(sheet))
          gdk_pointer_ungrab (event->time);
+
+
+
   if(sheet->timer)
          g_source_remove (sheet->timer);
+
   gtk_grab_remove(GTK_WIDGET(sheet));
 
   GTK_SHEET_UNSET_FLAGS(sheet, GTK_SHEET_IN_SELECTION);

--- a/attrib/src/x_dialog.c
+++ b/attrib/src/x_dialog.c
@@ -209,14 +209,13 @@ void x_dialog_missing_sym()
 void x_dialog_unsaved_data()
 {
   GtkWidget *dialog;
-  gchar *tmp;
   gchar *str;
 
-  tmp = _("Save the changes before closing?");
-  str = g_strconcat (N_("<big><b>"), tmp, N_("</b></big>"), NULL);
+  const gchar* tmp1 = _("Save the changes before closing?");
+  str = g_strconcat (N_("<big><b>"), tmp1, N_("</b></big>"), NULL);
 
-  tmp = _("If you don't save, all your changes will be permanently lost.");
-  str = g_strconcat (str, "\n\n", tmp, NULL);
+  const gchar* tmp2 = _("If you don't save, all your changes will be permanently lost.");
+  str = g_strconcat (str, "\n\n", tmp2, NULL);
 
   dialog = gtk_message_dialog_new (GTK_WINDOW (window),
                                    (GtkDialogFlags) (GTK_DIALOG_MODAL |
@@ -295,7 +294,7 @@ void x_dialog_unimplemented_feature()
  *  \param [in] return_code the exit code
  *  \todo Is the GPOINTER_TO_INT() call needed in exit()?
  */
-void x_dialog_fatal_error(gchar *string, gint return_code)
+void x_dialog_fatal_error(const gchar *string, gint return_code)
 {
   GtkWidget *dialog;
   

--- a/attrib/src/x_gtksheet.c
+++ b/attrib/src/x_gtksheet.c
@@ -67,9 +67,9 @@ void
 x_gtksheet_init()
 {
   gint i;
-  gchar *folder[]= {_("Components"),
-                   _("Nets"),
-                   _("Pins")};
+  const gchar *folder[]= {_("Components"),
+                          _("Nets"),
+                          _("Pins")};
   GtkWidget **scrolled_windows = NULL;
 
   /* ---  Create three new sheets.   were malloc'ed in x_window_init  --- */

--- a/attrib/src/x_window.c
+++ b/attrib/src/x_window.c
@@ -328,7 +328,8 @@ x_window_add_items()
 {
   gint i, j;
   gint num_rows, num_cols;
-  gchar *text, *error_string;
+  gchar *text;
+  const gchar *error_string;
   gint visibility, show_name_value;
   
   /* Do these sanity check to prevent later segfaults */

--- a/liblepton/src/edapaths.c
+++ b/liblepton/src/edapaths.c
@@ -33,19 +33,11 @@
 #	define GEDARCDIR GEDADATADIR
 #endif
 
-#ifdef __cplusplus
-static const gchar DATA_ENV[] = "GEDADATA";
-static const gchar CONFIG_ENV[] = "GEDADATARC";
-static const gchar DATA_XDG_SUBDIR[] = "lepton-eda";
-static const gchar DATA_GUESS_FILE[] = "scheme/geda.scm";
-static const gchar USER_DOTDIR[] = ".gEDA";
-#else
-static const gchar const DATA_ENV[] = "GEDADATA";
-static const gchar const CONFIG_ENV[] = "GEDADATARC";
-static const gchar const DATA_XDG_SUBDIR[] = "lepton-eda";
-static const gchar const DATA_GUESS_FILE[] = "scheme/geda.scm";
-static const gchar const USER_DOTDIR[] = ".gEDA";
-#endif
+static const gchar* const DATA_ENV        = "GEDADATA";
+static const gchar* const CONFIG_ENV      = "GEDADATARC";
+static const gchar* const DATA_XDG_SUBDIR = "lepton-eda";
+static const gchar* const DATA_GUESS_FILE = "scheme/geda.scm";
+static const gchar* const USER_DOTDIR     = ".gEDA";
 
 /* ================================================================
  * Private initialisation functions

--- a/libleptonrenderer/edarenderer.c
+++ b/libleptonrenderer/edarenderer.c
@@ -79,10 +79,21 @@ static inline gboolean
 EDA_RENDERER_CHECK_FLAG (EdaRenderer *r, int f) {
   return r->priv->flags & f;
 }
+
+
+
+/* EDA_RENDERER_SET_FLAG() function is currently unused.
+ * Comment it out to suppress compiler warnings.
+
 static inline void
 EDA_RENDERER_SET_FLAG (EdaRenderer *r, int f, gboolean e) {
   if (e) { r->priv->flags |= f; } else { r->priv->flags &= ~f; }
 }
+
+*/
+
+
+
 static inline unsigned int
 EDA_RENDERER_CAIRO_FLAGS (EdaRenderer *r) {
   return EDA_RENDERER_CHECK_FLAG (r, FLAG_HINTING) ? EDA_CAIRO_ENABLE_HINTS : 0;

--- a/netlist/utils/mk_verilog_syms.c
+++ b/netlist/utils/mk_verilog_syms.c
@@ -57,7 +57,7 @@ int AndBody(FILE *fp, int x, int y, unsigned int pins, unsigned int colour);
 int OrBody(FILE *fp, int x, int y, unsigned int pins, unsigned int colour);
 int XorBody(FILE *fp, int x, int y, unsigned int pins, unsigned int colour);
 int Pin(FILE *fp, int x1, int y1, int x2, int y2, int bubble);
-int PinAttribute(FILE *fp, int x, int y, unsigned int n, char *value);
+int PinAttribute(FILE *fp, int x, int y, unsigned int n, const char *value);
 int WidenBody(FILE *fp, int x, int y, unsigned int pins, unsigned int colour);
 
 /* globals */
@@ -66,7 +66,7 @@ unsigned int PinLength  = 300;
 
 struct Table
 {
-  char         *name;     /* base name of part */
+  const char         *name;     /* base name of part */
   unsigned int suffix;    /* suffix for part, 1 for normal, 2 for deMorgan.. */
   int (*body)(FILE *, int, int, unsigned int, unsigned int);  /* body style */
   int          inputBubbles;  /* where to draw bubbles */
@@ -92,7 +92,7 @@ unsigned int nGenerate = sizeof(generate)/sizeof(struct Table);
 int
 main(int argc, char **argv)
 {
-  int i,j;
+  unsigned int i,j;
   int rc;
   char name[127];
 
@@ -468,7 +468,7 @@ Pin(FILE *fp, int x1, int y1, int x2, int y2, int bubble)
 }
 
 int
-PinAttribute(FILE *fp, int x, int y, unsigned int n, char *value)
+PinAttribute(FILE *fp, int x, int y, unsigned int n, const char *value)
 {
   if(fp == NULL)
     {

--- a/schematic/src/color_edit_widget.c
+++ b/schematic/src/color_edit_widget.c
@@ -51,8 +51,12 @@ typedef enum
 static void
 color_edit_widget_create (ColorEditWidget* widget);
 
+/* \todo Currently unused; see todo in commented out function implementation
+ *
 static void
 mk_opacity_box (GtkWidget* vbox);
+ *
+ */
 
 static void
 color_sel_update (ColorEditWidget* widget);
@@ -490,11 +494,13 @@ dlg_confirm_overwrite (GtkWidget* parent, const gchar* fname)
 
 
 
-/*! \brief: Create GUI for transparenct control
- *  \note   Currently unused
+/*! \brief Create GUI for transparency control
+ *  \note  Currently unused
+ *  \todo  Implement transparency for outline color map
  *
  *  \param vbox Parent widget
- */
+ *
+
 static void
 mk_opacity_box (GtkWidget* vbox)
 {
@@ -512,8 +518,9 @@ mk_opacity_box (GtkWidget* vbox)
   gtk_box_pack_start (GTK_BOX (hbox2), label, TRUE, TRUE, 0);
   gtk_box_pack_start (GTK_BOX (hbox2), scale, TRUE, TRUE, 0);
 
-  /* separator: */
   gtk_box_pack_start (GTK_BOX (vbox), gtk_hseparator_new(), FALSE, FALSE, 5);
 
-} /* mk_opacity_box() */
+}
+
+*/
 

--- a/schematic/src/x_menus.c
+++ b/schematic/src/x_menus.c
@@ -30,12 +30,11 @@
 
 #define DEFAULT_MAX_RECENT_FILES 10
 
-struct PopupEntry {
-  #ifdef __cplusplus
-  const gchar *name, *action, *stock_id;
-  #else
-  const gchar const *name, *action, *stock_id;
-  #endif
+struct PopupEntry
+{
+  const gchar* name;
+  const gchar* action;
+  const gchar* stock_id;
 };
 
 static struct PopupEntry popup_items[] = {

--- a/schematic/src/x_misc.c
+++ b/schematic/src/x_misc.c
@@ -129,7 +129,7 @@ x_show_uri (GschemToplevel *w_current, const gchar *uri,
 
   g_assert (uri);
 
-  argv[0] = SHOW_URI_COMMAND;
+  argv[0] = (gchar *) SHOW_URI_COMMAND;
   argv[1] = (gchar *) uri;
   argv[2] = NULL; /* Null-terminated */
 

--- a/utils/src/lepton-renum.c
+++ b/utils/src/lepton-renum.c
@@ -342,7 +342,7 @@ int parse_refdes(struct refdes_ *refdes, char *ref_str)
 	printf("Prefix=%s\n",&buff[0]);
 #endif
 	strcpy(&refdes->prefix[0],&buff[0]);	/*Copy to refdes structure*/
-	for(i=0,cp;(*cp != '\n' && *cp>='0' && *cp<='9');++cp,++i)
+	for(i=0;(*cp != '\n' && *cp>='0' && *cp<='9');++cp,++i)
 		buff[i]=*cp;	/*Fill the buffer from char to char*/
 	buff[i]='\0';	/*Terminate with NULL to be a string*/
 #ifdef DEBUG

--- a/utils/src/lepton-sch2pcb.c
+++ b/utils/src/lepton-sch2pcb.c
@@ -83,7 +83,8 @@ static gchar *sch_basename;
 
 static GList *schematics;
 
-static gchar *m4_pcbdir, *default_m4_pcbdir, *m4_files, *m4_override_file;
+static const gchar* m4_override_file;
+static gchar *m4_pcbdir, *default_m4_pcbdir, *m4_files;
 
 static gboolean use_m4 = TRUE;
 
@@ -283,7 +284,7 @@ run_gnetlist (gchar * pins_file, gchar * net_file, gchar * pcb_file,
 
   if (m4_override_file) {
     args1 = g_list_append (args1, (gpointer) "-m");
-    args1 = g_list_append (args1, m4_override_file);
+    args1 = g_list_append (args1, (gpointer) m4_override_file);
   }
 
   mtime = (stat (pcb_file, &st) == 0) ? st.st_mtime : 0;
@@ -1078,7 +1079,7 @@ prune_elements (gchar * pcb_file, gchar * bak)
 }
 
 static void
-add_m4_file (gchar * arg)
+add_m4_file (const gchar * arg)
 {
   gchar *s;
 
@@ -1239,7 +1240,7 @@ parse_config (gchar * config, gchar * arg)
 }
 
 static void
-load_project (gchar * path)
+load_project (const gchar * path)
 {
   FILE *f;
   gchar *s, buf[1024], config[32], arg[768];
@@ -1280,7 +1281,7 @@ load_extra_project_files (void)
   done = TRUE;
 }
 
-static gchar *usage_string0 =
+static const gchar *usage_string0 =
   "usage: gsch2pcb [options] {project | foo.sch [foo1.sch ...]}\n"
   "\n"
   "Generate a PCB layout file from a set of gschem schematics.\n"
@@ -1338,7 +1339,7 @@ static gchar *usage_string0 =
   "       --m4-pcbdir D       Use D as the PCB m4 files install directory\n"
   "                           instead of the default:\n";
 
-static gchar *usage_string1 =
+static const gchar *usage_string1 =
   "   --backend-cmd backend   Backend that generates pins file (.cmd)\n"
   "   --backend-net backend   Backend that generates netlist file (.net)\n"
   "   --backend-pcb backend   Backend that generates board files (.pcb, .pcb.new)\n"


### PR DESCRIPTION
Now `lepton-eda` compiles without warnings at least on the following platforms:
- `Ubuntu` 18.04 ("Bionic") amd64
  - `gcc/g++ 4.8`
  - `gcc/g++ 7.3`
- `FreeBSD` 11.2-STABLE amd64
  - `gcc/g++ 7.3`

`clang` compiler (the default on FreeBSD, included in the base system) seems to be much more helpful in detecting potential problems than `gcc` (which sometimes happily swallows an utterly nonsensical gibberish code - when programmer clearly doesn't understand what he's doing).
So, there are some warnings left, they will be addressed in another PR.