### PR TITLE
Rewrite rc attribute promotion procedures in Scheme

### DIFF
--- a/liblepton/include/i_vars_priv.h
+++ b/liblepton/include/i_vars_priv.h
@@ -5,7 +5,6 @@ extern int default_init_bottom;
 extern char *default_bitmap_directory;
 extern char *default_bus_ripper_symname;
 
-extern int default_attribute_promotion;
 extern int default_keep_invisible;
 
 extern int default_make_backup_files;

--- a/liblepton/include/i_vars_priv.h
+++ b/liblepton/include/i_vars_priv.h
@@ -5,8 +5,6 @@ extern int default_init_bottom;
 extern char *default_bitmap_directory;
 extern char *default_bus_ripper_symname;
 
-extern GPtrArray *default_always_promote_attributes;
-
 extern int default_attribute_promotion;
 extern int default_promote_invisible;
 extern int default_keep_invisible;

--- a/liblepton/include/i_vars_priv.h
+++ b/liblepton/include/i_vars_priv.h
@@ -6,7 +6,6 @@ extern char *default_bitmap_directory;
 extern char *default_bus_ripper_symname;
 
 extern int default_attribute_promotion;
-extern int default_promote_invisible;
 extern int default_keep_invisible;
 
 extern int default_make_backup_files;

--- a/liblepton/include/liblepton/geda_toplevel.h
+++ b/liblepton/include/liblepton/geda_toplevel.h
@@ -59,9 +59,6 @@ struct st_toplevel
   /* controls if the net consolidation code is used */
   int net_consolidate;
 
-  /*controls if attribute promotion happens */
-  int attribute_promotion;
-
   /* controls if invisible attribs are kept and not deleted */
   int keep_invisible;
 

--- a/liblepton/include/liblepton/geda_toplevel.h
+++ b/liblepton/include/liblepton/geda_toplevel.h
@@ -1,8 +1,8 @@
-/* gEDA - GPL Electronic Design Automation
- * libgeda - gEDA's library
+/* Lepton EDA library
  * Copyright (C) 1998, 1999, 2000 Kazu Hirata / Ales Hvezda
  * Copyright (C) 1998-2010 Ales Hvezda
- * Copyright (C) 1998-2013 gEDA Contributors (see ChangeLog for details)
+ * Copyright (C) 1998-2017 gEDA Contributors
+ * Copyright (C) 2017-2018 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/liblepton/include/liblepton/geda_toplevel.h
+++ b/liblepton/include/liblepton/geda_toplevel.h
@@ -62,9 +62,6 @@ struct st_toplevel
   /*controls if attribute promotion happens */
   int attribute_promotion;
 
-  /* controls if invisible attribs are promoted */
-  int promote_invisible;
-
   /* controls if invisible attribs are kept and not deleted */
   int keep_invisible;
 

--- a/liblepton/include/liblepton/geda_toplevel.h
+++ b/liblepton/include/liblepton/geda_toplevel.h
@@ -77,9 +77,6 @@ struct st_toplevel
   /* controls if the whole bounding box is used in the auto whichend code */
   int force_boundingbox;
 
-  /* List of attributes to always promote */
-  GPtrArray *always_promote_attributes;
-
   /* Callback function for calculating text bounds */
   RenderedBoundsFunc rendered_text_bounds_func;
   void *rendered_text_bounds_data;

--- a/liblepton/include/prototype_priv.h
+++ b/liblepton/include/prototype_priv.h
@@ -9,7 +9,6 @@ SCM g_rc_bitmap_directory(SCM path);
 SCM g_rc_scheme_directory(SCM path);
 SCM g_rc_bus_ripper_symname(SCM scmsymname);
 SCM g_rc_map_font_character_to_file(SCM character_param, SCM file_param);
-SCM g_rc_attribute_promotion(SCM mode);
 SCM g_rc_keep_invisible(SCM mode);
 SCM g_rc_make_backup_files(SCM mode);
 SCM g_rc_print_color_map (SCM scm_map);

--- a/liblepton/include/prototype_priv.h
+++ b/liblepton/include/prototype_priv.h
@@ -12,7 +12,6 @@ SCM g_rc_map_font_character_to_file(SCM character_param, SCM file_param);
 SCM g_rc_attribute_promotion(SCM mode);
 SCM g_rc_promote_invisible(SCM mode);
 SCM g_rc_keep_invisible(SCM mode);
-SCM g_rc_always_promote_attributes(SCM scmsymname);
 SCM g_rc_make_backup_files(SCM mode);
 SCM g_rc_print_color_map (SCM scm_map);
 

--- a/liblepton/include/prototype_priv.h
+++ b/liblepton/include/prototype_priv.h
@@ -10,7 +10,6 @@ SCM g_rc_scheme_directory(SCM path);
 SCM g_rc_bus_ripper_symname(SCM scmsymname);
 SCM g_rc_map_font_character_to_file(SCM character_param, SCM file_param);
 SCM g_rc_attribute_promotion(SCM mode);
-SCM g_rc_promote_invisible(SCM mode);
 SCM g_rc_keep_invisible(SCM mode);
 SCM g_rc_make_backup_files(SCM mode);
 SCM g_rc_print_color_map (SCM scm_map);

--- a/liblepton/scheme/Makefile.am
+++ b/liblepton/scheme/Makefile.am
@@ -5,6 +5,7 @@ nobase_dist_scmdata_DATA = \
 	geda/object.scm geda/page.scm geda/attrib.scm geda/deprecated.scm \
 	geda/os.scm geda/config.scm geda/log-rotate.scm geda/log.scm \
 	geda/library.scm geda/repl.scm \
+	lepton/rc.scm \
 	lepton/version.scm
 nobase_scmdata_DATA = geda/core/gettext.scm
 

--- a/liblepton/scheme/geda.scm
+++ b/liblepton/scheme/geda.scm
@@ -1,5 +1,9 @@
 ; -*-Scheme-*-
-(use-modules (geda os) (ice-9 optargs) (ice-9 ftw) (geda library))
+(use-modules (ice-9 optargs)
+             (ice-9 ftw)
+             (geda os)
+             (geda library)
+             (lepton rc))
 
 (define path-sep file-name-separator-string)
 

--- a/liblepton/scheme/lepton/rc.scm
+++ b/liblepton/scheme/lepton/rc.scm
@@ -28,11 +28,12 @@
             promotable-attribute?))
 
 ;;; List of attributes to always promote.
-(define %attribs-to-promote '())
+(define %attribs-to-promote '("symversion"))
 
 ;;; Redefine the list of attribs to promote. Returns the new list.
 (define (set-attribs-to-promote! ls)
-  (set! %attribs-to-promote ls)
+  ;; Always promote "symversion" attribute, even if it is invisible.
+  (set! %attribs-to-promote (delete-duplicates (append ls "symversion")))
   %attribs-to-promote)
 
 ;;; Checks the list of ATTRIBS that will be promoted on symbol

--- a/liblepton/scheme/lepton/rc.scm
+++ b/liblepton/scheme/lepton/rc.scm
@@ -36,8 +36,8 @@
 
   #:export (always-promote-attributes
             attribute-promotion
-            eligible-attribute?
             promotable-attrib-name?
+            promotable-attribute?
             promote-attributes?
             promote-invisible
             promote-invisible-attribs?))
@@ -99,7 +99,7 @@ otherwise returns #f."
   "Returns #t if attrib NAME is promotable, otherwise returns #f."
   (not (not (member name %promotable-attrib-names))))
 
-(define (eligible-attribute? object)
+(define (promotable-attribute? object)
   "Returns #t if OBJECT is eligible attribute for promotion,
 otherwise returns #f."
   (and (attribute? object)

--- a/liblepton/scheme/lepton/rc.scm
+++ b/liblepton/scheme/lepton/rc.scm
@@ -27,8 +27,10 @@
   #:use-module (geda log)
 
   #:export (always-promote-attributes
+            attribute-promotion
             eligible-attribute?
             promotable-attribute?
+            promote-attributes?
             promote-invisible
             promote-invisible-attribs?))
 
@@ -97,3 +99,24 @@ otherwise returns #f."
        ;; promote invisible text.
        (or (text-visible? object)
            (promote-invisible-attribs?))))
+
+;;; Controls if attribute promotion happens.
+(define %promote-attributes? #t)
+
+(define (set-attribute-promotion! allow?)
+  (set! %promote-attributes? allow?)
+  %promote-attributes?)
+
+(define (attribute-promotion allow?)
+  "Checks ALLOW? and determines if attribute promotion should be
+enabled. Returns #t if ALLOW? is equal to \"enabled\" or #t,
+otherwise returns #f."
+  (set-attribute-promotion!
+   (match allow?
+     ((or "enabled" #t) #t)
+     (_ #f))))
+
+(define (promote-attributes?)
+  "Returns #t if promotion of attribs is enabled, otherwise
+returns #f."
+  %promote-attributes?)

--- a/liblepton/scheme/lepton/rc.scm
+++ b/liblepton/scheme/lepton/rc.scm
@@ -37,7 +37,7 @@
   #:export (always-promote-attributes
             attribute-promotion
             eligible-attribute?
-            promotable-attribute?
+            promotable-attrib-name?
             promote-attributes?
             promote-invisible
             promote-invisible-attribs?))
@@ -64,13 +64,13 @@ otherwise returns #f."
   %promote-invisible?)
 
 ;;; List of attributes to always promote.
-(define %attribs-to-promote '("symversion"))
+(define %promotable-attrib-names '("symversion"))
 
 ;;; Redefine the list of attribs to promote. Returns the new list.
-(define (set-attribs-to-promote! ls)
+(define (set-promotable-attrib-names! ls)
   ;; Always promote "symversion" attribute, even if it is invisible.
-  (set! %attribs-to-promote (delete-duplicates (append ls "symversion")))
-  %attribs-to-promote)
+  (set! %promotable-attrib-names (delete-duplicates (append ls "symversion")))
+  %promotable-attrib-names)
 
 ;;; Checks the list of ATTRIBS that will be promoted on symbol
 ;;; insertion. Returns #f if ATTRIBS is neither a space separated
@@ -88,21 +88,22 @@ otherwise returns #f."
            (_ "WARNING: 'always-promote-attributes' must be a list of strings."))
      #f)))
 
-(define (always-promote-attributes attribs)
-  "Checks and sets the list of ATTRIBS to promote for new symbols
-in schematic. Returns the list if ATTRIBS is a valid list,
+(define (always-promote-attributes names)
+  "Checks and sets the list of attrib NAMES to promote for new
+symbols in schematic. Returns the list if NAMES is a valid list,
 otherwise returns #f."
-  (and=> (check-attribs-to-promote attribs) set-attribs-to-promote!))
+  (and=> (check-attribs-to-promote names)
+         set-promotable-attrib-names!))
 
-(define (promotable-attribute? attrib)
-  "Returns #t if ATTRIB is promotable, otherwise returns #f."
-  (not (not (member attrib %attribs-to-promote))))
+(define (promotable-attrib-name? name)
+  "Returns #t if attrib NAME is promotable, otherwise returns #f."
+  (not (not (member name %promotable-attrib-names))))
 
 (define (eligible-attribute? object)
   "Returns #t if OBJECT is eligible attribute for promotion,
 otherwise returns #f."
   (and (attribute? object)
-       (promotable-attribute? (attrib-name object))
+       (promotable-attrib-name? (attrib-name object))
        ;; Return #f if object is invisible and we do not want to
        ;; promote invisible text.
        (or (text-visible? object)

--- a/liblepton/scheme/lepton/rc.scm
+++ b/liblepton/scheme/lepton/rc.scm
@@ -19,6 +19,14 @@
 
 ;;; Lepton rc files processing procedures.
 
+;;; FIXME: Eventually, the following legacy rc procedures should
+;;; go to geda-deprecated-config.scm:
+;;;
+;;;     always-promote-attributes
+;;;
+;;; Please see netlist/config.scm for an example of how to define
+;;; new substitution configuration key-groups for them.
+
 (define-module (lepton rc)
   #:use-module (ice-9 match)
   #:use-module (geda attrib)

--- a/liblepton/scheme/lepton/rc.scm
+++ b/liblepton/scheme/lepton/rc.scm
@@ -51,12 +51,9 @@
 
 (define (promote-invisible allow?)
   "Checks ALLOW? and determines if invisible attribs should be
-promoted. Returns #t if ALLOW? is equal to \"enabled\" or #t,
-otherwise returns #f."
-  (set-promote-invisible!
-   (match allow?
-     ((or "enabled" #t) #t)
-     (_ #f))))
+promoted. Returns #t if ALLOW? is equal to \"enabled\", otherwise
+returns #f."
+  (set-promote-invisible! (string= allow? "enabled")))
 
 (define (promote-invisible-attribs?)
   "Returns #t if promotion of invisible attribs is enabled,
@@ -118,12 +115,9 @@ otherwise returns #f."
 
 (define (attribute-promotion allow?)
   "Checks ALLOW? and determines if attribute promotion should be
-enabled. Returns #t if ALLOW? is equal to \"enabled\" or #t,
-otherwise returns #f."
-  (set-attribute-promotion!
-   (match allow?
-     ((or "enabled" #t) #t)
-     (_ #f))))
+enabled. Returns #t if ALLOW? is equal to \"enabled\", otherwise
+returns #f."
+  (set-attribute-promotion! (string= allow? "enabled")))
 
 (define (promote-attributes?)
   "Returns #t if promotion of attribs is enabled, otherwise

--- a/liblepton/scheme/lepton/rc.scm
+++ b/liblepton/scheme/lepton/rc.scm
@@ -25,7 +25,30 @@
   #:use-module (geda log)
 
   #:export (always-promote-attributes
-            promotable-attribute?))
+            promotable-attribute?
+            promote-invisible
+            promote-invisible-attribs?))
+
+;;; Controls if invisible attribs are promoted.
+(define %promote-invisible? #f)
+
+(define (set-promote-invisible! allow?)
+  (set! %promote-invisible? allow?)
+  %promote-invisible?)
+
+(define (promote-invisible allow?)
+  "Checks ALLOW? and determines if invisible attribs should be
+promoted. Returns #t if ALLOW? is equal to \"enabled\" or #t,
+otherwise returns #f."
+  (set-promote-invisible!
+   (match allow?
+     ((or "enabled" #t) #t)
+     (_ #f))))
+
+(define (promote-invisible-attribs?)
+  "Returns #t if promotion of invisible attribs is enabled,
+otherwise returns #f."
+  %promote-invisible?)
 
 ;;; List of attributes to always promote.
 (define %attribs-to-promote '("symversion"))

--- a/liblepton/scheme/lepton/rc.scm
+++ b/liblepton/scheme/lepton/rc.scm
@@ -1,0 +1,62 @@
+;;; Lepton EDA library - Scheme API
+;;; Copyright (C) 1998-2017 gEDA Contributors
+;;; Copyright (C) 2018 Lepton EDA Contributors
+;;;
+;;; This program is free software; you can redistribute it and/or modify
+;;; it under the terms of the GNU General Public License as published by
+;;; the Free Software Foundation; either version 2 of the License, or
+;;; (at your option) any later version.
+;;;
+;;; This program is distributed in the hope that it will be useful,
+;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;; GNU General Public License for more details.
+;;;
+;;; You should have received a copy of the GNU General Public License
+;;; along with this program; if not, write to the Free Software
+;;; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+;;; MA 02111-1301 USA.
+
+;;; Lepton rc files processing procedures.
+
+(define-module (lepton rc)
+  #:use-module (ice-9 match)
+  #:use-module (geda core gettext)
+  #:use-module (geda log)
+
+  #:export (always-promote-attributes
+            promotable-attribute?))
+
+;;; List of attributes to always promote.
+(define %attribs-to-promote '())
+
+;;; Redefine the list of attribs to promote. Returns the new list.
+(define (set-attribs-to-promote! ls)
+  (set! %attribs-to-promote ls)
+  %attribs-to-promote)
+
+;;; Checks the list of ATTRIBS that will be promoted on symbol
+;;; insertion. Returns #f if ATTRIBS is neither a space separated
+;;; string (deprecated), nor a list of strings. Otherwise returns
+;;; the list of the attribs given.
+(define (check-attribs-to-promote attribs)
+  (define delimiters
+    (string->char-set " \n\t"))
+
+  (match attribs
+    (((? string? x) ...)
+     x)
+    (_
+     (log! 'warning
+           (_ "WARNING: 'always-promote-attributes' must be a list of strings."))
+     #f)))
+
+(define (always-promote-attributes attribs)
+  "Checks and sets the list of ATTRIBS to promote for new symbols
+in schematic. Returns the list if ATTRIBS is a valid list,
+otherwise returns #f."
+  (and=> (check-attribs-to-promote attribs) set-attribs-to-promote!))
+
+(define (promotable-attribute? attrib)
+  "Returns #t if ATTRIB is promotable, otherwise returns #f."
+  (not (not (member attrib %attribs-to-promote))))

--- a/liblepton/scheme/lepton/rc.scm
+++ b/liblepton/scheme/lepton/rc.scm
@@ -21,10 +21,13 @@
 
 (define-module (lepton rc)
   #:use-module (ice-9 match)
+  #:use-module (geda attrib)
   #:use-module (geda core gettext)
+  #:use-module (geda object)
   #:use-module (geda log)
 
   #:export (always-promote-attributes
+            eligible-attribute?
             promotable-attribute?
             promote-invisible
             promote-invisible-attribs?))
@@ -84,3 +87,13 @@ otherwise returns #f."
 (define (promotable-attribute? attrib)
   "Returns #t if ATTRIB is promotable, otherwise returns #f."
   (not (not (member attrib %attribs-to-promote))))
+
+(define (eligible-attribute? object)
+  "Returns #t if OBJECT is eligible attribute for promotion,
+otherwise returns #f."
+  (and (attribute? object)
+       (promotable-attribute? (attrib-name object))
+       ;; Return #f if object is invisible and we do not want to
+       ;; promote invisible text.
+       (or (text-visible? object)
+           (promote-invisible-attribs?))))

--- a/liblepton/src/g_rc.c
+++ b/liblepton/src/g_rc.c
@@ -1,8 +1,8 @@
-/* gEDA - GPL Electronic Design Automation
- * libgeda - gEDA's library
+/* Lepton EDA library
  * Copyright (C) 1998-2010 Ales Hvezda
- * Copyright (C) 1998-2010 gEDA Contributors (see ChangeLog for details)
+ * Copyright (C) 1998-2017 gEDA Contributors
  * Copyright (C) 2016 Peter Brett <peter@peter-b.co.uk>
+ * Copyright (C) 2017-2018 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/liblepton/src/g_rc.c
+++ b/liblepton/src/g_rc.c
@@ -805,23 +805,6 @@ SCM g_rc_attribute_promotion(SCM mode)
  *  \par Function Description
  *
  */
-SCM g_rc_promote_invisible(SCM mode)
-{
-  static const vstbl_entry mode_table[] = {
-    {TRUE , "enabled" },
-    {FALSE, "disabled"},
-  };
-
-  RETURN_G_RC_MODE("promote-invisible",
-		   default_promote_invisible,
-		   2);
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
 SCM g_rc_keep_invisible(SCM mode)
 {
   static const vstbl_entry mode_table[] = {

--- a/liblepton/src/g_rc.c
+++ b/liblepton/src/g_rc.c
@@ -788,23 +788,6 @@ SCM g_rc_reset_component_library(void)
  *  \par Function Description
  *
  */
-SCM g_rc_attribute_promotion(SCM mode)
-{
-  static const vstbl_entry mode_table[] = {
-    {TRUE , "enabled" },
-    {FALSE, "disabled"},
-  };
-
-  RETURN_G_RC_MODE("attribute-promotion",
-		   default_attribute_promotion,
-		   2);
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
 SCM g_rc_keep_invisible(SCM mode)
 {
   static const vstbl_entry mode_table[] = {

--- a/liblepton/src/g_rc.c
+++ b/liblepton/src/g_rc.c
@@ -834,56 +834,6 @@ SCM g_rc_keep_invisible(SCM mode)
 		   2);
 }
 
-/*! \todo Finish function description!!!
- *  \brief
- *  \par Function Description
- *
- *  \param [in] attrlist
- *  \return SCM_BOOL_T always.
- */
-SCM g_rc_always_promote_attributes(SCM attrlist)
-{
-  SCM_ASSERT(scm_is_true (scm_list_p (attrlist)), attrlist, SCM_ARG1,
-             "always-promote-attributes");
-
-  if (default_always_promote_attributes) {
-    g_ptr_array_unref (default_always_promote_attributes);
-  }
-
-  GPtrArray *promote = g_ptr_array_new ();
-
-  scm_dynwind_begin ((scm_t_dynwind_flags) 0);
-  scm_dynwind_unwind_handler ((void (*)(void *)) g_ptr_array_unref,
-                              promote,
-                              (scm_t_wind_flags) 0);
-
-  for (SCM iter = attrlist; !scm_is_null(iter); iter = scm_cdr(iter))
-  {
-    SCM car = scm_car (iter);
-
-    if (scm_is_string (car))
-    {
-      char* attr = scm_to_utf8_string (car);
-
-      /* Only accept non-empty strings:
-      */
-      if (strlen (attr) > 0)
-      {
-        g_ptr_array_add (promote, (gpointer) g_intern_string (attr));
-      }
-
-      free (attr);
-    }
-
-  }
-
-  scm_dynwind_end();
-
-  default_always_promote_attributes = promote;
-
-  return SCM_BOOL_T;
-}
-
 /*! \brief Enable the creation of backup files when saving
  *  \par Function Description
  *  If enabled then a backup file, of the form 'example.sch~', is created when

--- a/liblepton/src/g_register.c
+++ b/liblepton/src/g_register.c
@@ -56,7 +56,6 @@ static struct gsubr_t libgeda_funcs[] = {
   { "bitmap-directory",          1, 0, 0, (SCM (*) ()) g_rc_bitmap_directory },
   { "bus-ripper-symname",        1, 0, 0, (SCM (*) ()) g_rc_bus_ripper_symname },
   { "attribute-promotion",       1, 0, 0, (SCM (*) ()) g_rc_attribute_promotion },
-  { "promote-invisible",         1, 0, 0, (SCM (*) ()) g_rc_promote_invisible },
   { "keep-invisible",            1, 0, 0, (SCM (*) ()) g_rc_keep_invisible },
   { "make-backup-files",         1, 0, 0, (SCM (*) ()) g_rc_make_backup_files },
   { "print-color-map",           0, 1, 0, (SCM (*) ()) g_rc_print_color_map },

--- a/liblepton/src/g_register.c
+++ b/liblepton/src/g_register.c
@@ -1,8 +1,8 @@
-/* gEDA - GPL Electronic Design Automation
- * libgeda - gEDA's library
+/* Lepton EDA library
  * Copyright (C) 1998-2010 Ales Hvezda
- * Copyright (C) 1998-2010 gEDA Contributors (see ChangeLog for details)
+ * Copyright (C) 1998-2017 gEDA Contributors
  * Copyright (C) 2016 Peter Brett <peter@peter-b.co.uk>
+ * Copyright (C) 2017-2018 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/liblepton/src/g_register.c
+++ b/liblepton/src/g_register.c
@@ -58,7 +58,6 @@ static struct gsubr_t libgeda_funcs[] = {
   { "attribute-promotion",       1, 0, 0, (SCM (*) ()) g_rc_attribute_promotion },
   { "promote-invisible",         1, 0, 0, (SCM (*) ()) g_rc_promote_invisible },
   { "keep-invisible",            1, 0, 0, (SCM (*) ()) g_rc_keep_invisible },
-  { "always-promote-attributes", 1, 0, 0, (SCM (*) ()) g_rc_always_promote_attributes },
   { "make-backup-files",         1, 0, 0, (SCM (*) ()) g_rc_make_backup_files },
   { "print-color-map",           0, 1, 0, (SCM (*) ()) g_rc_print_color_map },
   { "rc-filename",               0, 0, 0, (SCM (*) ()) g_rc_rc_filename },

--- a/liblepton/src/g_register.c
+++ b/liblepton/src/g_register.c
@@ -55,7 +55,6 @@ static struct gsubr_t libgeda_funcs[] = {
   { "scheme-directory",          1, 0, 0, (SCM (*) ()) g_rc_scheme_directory },
   { "bitmap-directory",          1, 0, 0, (SCM (*) ()) g_rc_bitmap_directory },
   { "bus-ripper-symname",        1, 0, 0, (SCM (*) ()) g_rc_bus_ripper_symname },
-  { "attribute-promotion",       1, 0, 0, (SCM (*) ()) g_rc_attribute_promotion },
   { "keep-invisible",            1, 0, 0, (SCM (*) ()) g_rc_keep_invisible },
   { "make-backup-files",         1, 0, 0, (SCM (*) ()) g_rc_make_backup_files },
   { "print-color-map",           0, 1, 0, (SCM (*) ()) g_rc_print_color_map },

--- a/liblepton/src/geda_complex_object.c
+++ b/liblepton/src/geda_complex_object.c
@@ -157,10 +157,6 @@ static int o_complex_is_eligible_attribute (TOPLEVEL *toplevel, OBJECT *object)
   const gchar *name = o_attrib_get_name (object);
   if (!name) return FALSE;
 
-  /* always promote symversion= attribute, even if it is invisible */
-  if (strncmp(o_attrib_get_name(object), "symversion", 10) == 0)
-    return TRUE;
-
   /* check list against attributes which can be promoted */
   if scm_is_true (scm_call_1 (scm_c_public_ref ("lepton rc", "promotable-attribute?"),
                               scm_from_utf8_string (name)))

--- a/liblepton/src/geda_complex_object.c
+++ b/liblepton/src/geda_complex_object.c
@@ -164,7 +164,8 @@ static int o_complex_is_eligible_attribute (TOPLEVEL *toplevel, OBJECT *object)
 
   /* object is invisible and we do not want to promote invisible text */
   if ((!o_is_visible (toplevel, object)) &&
-      (toplevel->promote_invisible == FALSE))
+      scm_is_false (scm_call_0 (scm_c_public_ref ("lepton rc",
+                                                  "promote-invisible-attribs?"))))
     return FALSE; /* attribute not eligible for promotion */
 
   /* yup, attribute can be promoted */

--- a/liblepton/src/geda_complex_object.c
+++ b/liblepton/src/geda_complex_object.c
@@ -162,14 +162,9 @@ static int o_complex_is_eligible_attribute (TOPLEVEL *toplevel, OBJECT *object)
     return TRUE;
 
   /* check list against attributes which can be promoted */
-  if (toplevel->always_promote_attributes != NULL) {
-    for (guint i = 0; i < toplevel->always_promote_attributes->len; ++i) {
-      gconstpointer promote =
-        g_ptr_array_index(toplevel->always_promote_attributes, i);
-      if (name == promote)
-        return TRUE;
-    }
-  }
+  if scm_is_true (scm_call_1 (scm_c_public_ref ("lepton rc", "promotable-attribute?"),
+                              scm_from_utf8_string (name)))
+    return TRUE;
 
   /* object is invisible and we do not want to promote invisible text */
   if ((!o_is_visible (toplevel, object)) &&

--- a/liblepton/src/geda_complex_object.c
+++ b/liblepton/src/geda_complex_object.c
@@ -194,7 +194,7 @@ GList *o_complex_get_promotable (TOPLEVEL *toplevel, OBJECT *object, int detach)
     tmp = (OBJECT*) iter->data;
 
     /* Is it an attribute we want to promote? */
-    if scm_is_false (scm_call_1 (scm_c_public_ref ("lepton rc", "eligible-attribute?"),
+    if scm_is_false (scm_call_1 (scm_c_public_ref ("lepton rc", "promotable-attribute?"),
                                  edascm_from_object (tmp)))
       continue;
 

--- a/liblepton/src/geda_complex_object.c
+++ b/liblepton/src/geda_complex_object.c
@@ -183,7 +183,9 @@ GList *o_complex_get_promotable (TOPLEVEL *toplevel, OBJECT *object, int detach)
   GList *iter;
   OBJECT *tmp;
 
-  if (!toplevel->attribute_promotion) /* controlled through rc file */
+  /* controlled through rc file */
+  if scm_is_false (scm_call_0 (scm_c_public_ref ("lepton rc",
+                                                 "promote-attributes?")))
     return NULL;
 
   attribs = o_attrib_find_floating_attribs (object->complex->prim_objs);

--- a/liblepton/src/geda_complex_object.c
+++ b/liblepton/src/geda_complex_object.c
@@ -1,7 +1,7 @@
-/* gEDA - GPL Electronic Design Automation
- * libgeda - gEDA's library
+/* Lepton EDA library
  * Copyright (C) 1998-2010 Ales Hvezda
- * Copyright (C) 1998-2017 gEDA Contributors (see ChangeLog for details)
+ * Copyright (C) 1998-2017 gEDA Contributors
+ * Copyright (C) 2017-2018 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/liblepton/src/geda_toplevel.c
+++ b/liblepton/src/geda_toplevel.c
@@ -74,7 +74,6 @@ TOPLEVEL *s_toplevel_new (void)
 
   /* The following is an attempt at getting (deterministic) defaults */
   /* for the following variables */
-  toplevel->attribute_promotion = FALSE;
   toplevel->keep_invisible      = FALSE;
 
   toplevel->make_backup_files = TRUE;

--- a/liblepton/src/geda_toplevel.c
+++ b/liblepton/src/geda_toplevel.c
@@ -84,8 +84,6 @@ TOPLEVEL *s_toplevel_new (void)
 
   toplevel->force_boundingbox = FALSE;
 
-  toplevel->always_promote_attributes = NULL;
-
   toplevel->rendered_text_bounds_func = NULL;
   toplevel->rendered_text_bounds_data = NULL;
 

--- a/liblepton/src/geda_toplevel.c
+++ b/liblepton/src/geda_toplevel.c
@@ -1,8 +1,8 @@
-/* gEDA - GPL Electronic Design Automation
- * libgeda - gEDA's library
+/* Lepton EDA library
  * Copyright (C) 1998, 1999, 2000 Kazu Hirata / Ales Hvezda
  * Copyright (C) 1998-2010 Ales Hvezda
- * Copyright (C) 1998-2017 gEDA Contributors (see ChangeLog for details)
+ * Copyright (C) 1998-2017 gEDA Contributors
+ * Copyright (C) 2017-2018 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/liblepton/src/geda_toplevel.c
+++ b/liblepton/src/geda_toplevel.c
@@ -75,7 +75,6 @@ TOPLEVEL *s_toplevel_new (void)
   /* The following is an attempt at getting (deterministic) defaults */
   /* for the following variables */
   toplevel->attribute_promotion = FALSE;
-  toplevel->promote_invisible   = FALSE;
   toplevel->keep_invisible      = FALSE;
 
   toplevel->make_backup_files = TRUE;

--- a/liblepton/src/i_vars.c
+++ b/liblepton/src/i_vars.c
@@ -39,7 +39,6 @@
 char *default_bitmap_directory = NULL;
 char *default_bus_ripper_symname = NULL;
 
-int   default_attribute_promotion = TRUE;
 int   default_keep_invisible = TRUE;
 
 int   default_make_backup_files = TRUE;
@@ -54,7 +53,6 @@ int   default_make_backup_files = TRUE;
 void i_vars_libgeda_set(TOPLEVEL *toplevel)
 {
 
-  toplevel->attribute_promotion = default_attribute_promotion;
   toplevel->keep_invisible = default_keep_invisible;
 
   toplevel->make_backup_files = default_make_backup_files;

--- a/liblepton/src/i_vars.c
+++ b/liblepton/src/i_vars.c
@@ -38,7 +38,6 @@
 
 char *default_bitmap_directory = NULL;
 char *default_bus_ripper_symname = NULL;
-GPtrArray *default_always_promote_attributes = NULL;
 
 int   default_attribute_promotion = TRUE;
 int   default_promote_invisible = FALSE;
@@ -62,16 +61,6 @@ void i_vars_libgeda_set(TOPLEVEL *toplevel)
 
   toplevel->make_backup_files = default_make_backup_files;
 
-  /* copy the always_promote_attributes list from the default */
-  if (toplevel->always_promote_attributes) {
-    g_ptr_array_unref (toplevel->always_promote_attributes);
-    toplevel->always_promote_attributes = NULL;
-  }
-  if (default_always_promote_attributes) {
-    toplevel->always_promote_attributes =
-      g_ptr_array_ref (default_always_promote_attributes);
-  }
-
   /* you cannot free the default* strings here since new windows */
   /* need them */
   INIT_STR(toplevel, bitmap_directory, DEFAULT_BITMAP_DIRECTORY);
@@ -88,7 +77,4 @@ void i_vars_libgeda_freenames()
 {
   g_free(default_bitmap_directory);
   g_free(default_bus_ripper_symname);
-
-  g_ptr_array_unref (default_always_promote_attributes);
-  default_always_promote_attributes = NULL;
 }

--- a/liblepton/src/i_vars.c
+++ b/liblepton/src/i_vars.c
@@ -40,7 +40,6 @@ char *default_bitmap_directory = NULL;
 char *default_bus_ripper_symname = NULL;
 
 int   default_attribute_promotion = TRUE;
-int   default_promote_invisible = FALSE;
 int   default_keep_invisible = TRUE;
 
 int   default_make_backup_files = TRUE;
@@ -56,7 +55,6 @@ void i_vars_libgeda_set(TOPLEVEL *toplevel)
 {
 
   toplevel->attribute_promotion = default_attribute_promotion;
-  toplevel->promote_invisible = default_promote_invisible;
   toplevel->keep_invisible = default_keep_invisible;
 
   toplevel->make_backup_files = default_make_backup_files;

--- a/liblepton/src/i_vars.c
+++ b/liblepton/src/i_vars.c
@@ -1,7 +1,7 @@
-/* gEDA - GPL Electronic Design Automation
- * libgeda - gEDA's library
+/* Lepton EDA library
  * Copyright (C) 1998-2010 Ales Hvezda
- * Copyright (C) 1998-2017 gEDA Contributors (see ChangeLog for details)
+ * Copyright (C) 1998-2017 gEDA Contributors
+ * Copyright (C) 2017-2018 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/netlist/docs/vams/vams_mode.txt
+++ b/netlist/docs/vams/vams_mode.txt
@@ -334,8 +334,8 @@ CONTENT:
 	- set in .gEDA/gschemrc or wherever you want, but place it
 	  right.
 
-	   	(attribute-promotion "enable")
-		(promote-invisible "enable")
+	   	(attribute-promotion "enabled")
+		(promote-invisible "enabled")
 		(enforce-hierarchy "disabled")
 
 		(attribute-name "port_object")


### PR DESCRIPTION
This patchset makes legacy `liblepton` procedures related to attribute promotion available in Scheme by replaces old `g_rc_*` functions by new Scheme procedures in the `(lepton rc)` module.

What has not been fixed yet:

- unit tests
- support by new config system
- NEWS :-)

Affects #306