### PR TITLE
liblepton Scheme API functions to lock/unlock objects

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,6 +110,10 @@ When writing Scheme code:
   names ending in `?`, e.g. `object?`; destructive functions, that
   modify one of their arguments or global state, should have names
   ending in `!`, e.g. `set-config!`.
+  When implementing such a functions in `C`, please follow the naming
+  convention: for Scheme names with `?`, corresponding C functions'
+  names should have `_p` suffix (e.g. `object_p`), for Scheme names with
+  `!` - `_x` suffix (e.g. `set_config_x`).
 
 - When defining a function please use the
   ["implicit `define`" form](http://www.schemers.org/Documents/Standards/R5RS/HTML/r5rs-Z-H-8.html#%_sec_5.2):

--- a/docs/scheme-api/lepton-scheme.texi
+++ b/docs/scheme-api/lepton-scheme.texi
@@ -537,6 +537,16 @@ intersects the net, then @code{(object-connections <net>)} will return
 a list containing the pin @code{object}, and @emph{not} the component.
 @end defun
 
+@defun object-locked? object
+Returns true (@samp{#t}) if @var{object} is locked (i.e. non-selectable).
+@end defun
+
+@defun set-object-locked! object state
+Sets the locked (i.e. non-selectable) flag for @var{object}.
+If @var{state} is @samp{#f}, clears the locked flag; if @var{state}
+is @samp{#t}, sets it. Returns @var{object}.
+@end defun
+
 @menu
 * Object sub-types::
 * Object transformations::

--- a/docs/scheme-api/lepton-scheme.texi
+++ b/docs/scheme-api/lepton-scheme.texi
@@ -537,13 +537,13 @@ intersects the net, then @code{(object-connections <net>)} will return
 a list containing the pin @code{object}, and @emph{not} the component.
 @end defun
 
-@defun object-locked? object
-Returns true (@samp{#t}) if @var{object} is locked (i.e. non-selectable).
+@defun object-selectable? object
+Returns true (@samp{#t}) if @var{object} is selectable (i.e. not locked).
 @end defun
 
-@defun set-object-locked! object state
-Sets the locked (i.e. non-selectable) flag for @var{object}.
-If @var{state} is @samp{#f}, clears the locked flag; if @var{state}
+@defun set-object-selectable! object state
+Sets the selectable flag for @var{object}.
+If @var{state} is @samp{#f}, clears the selectable flag; if @var{state}
 is @samp{#t}, sets it. Returns @var{object}.
 @end defun
 

--- a/liblepton/scheme/Makefile.am
+++ b/liblepton/scheme/Makefile.am
@@ -33,7 +33,7 @@ TESTS = unit-tests/t0001-geda-conf-lib.scm \
 	unit-tests/t0110-object-transform.scm \
 	unit-tests/t0111-object-path.scm \
 	unit-tests/t0112-object-picture.scm \
-	unit-tests/t0113-object-locked.scm \
+	unit-tests/t0113-object-selectable.scm \
 	unit-tests/t0200-page.scm \
 	unit-tests/t0201-page-dirty.scm \
 	unit-tests/t0202-page-string.scm \

--- a/liblepton/scheme/Makefile.am
+++ b/liblepton/scheme/Makefile.am
@@ -33,6 +33,7 @@ TESTS = unit-tests/t0001-geda-conf-lib.scm \
 	unit-tests/t0110-object-transform.scm \
 	unit-tests/t0111-object-path.scm \
 	unit-tests/t0112-object-picture.scm \
+	unit-tests/t0113-object-locked.scm \
 	unit-tests/t0200-page.scm \
 	unit-tests/t0201-page-dirty.scm \
 	unit-tests/t0202-page-string.scm \

--- a/liblepton/scheme/geda/object.scm
+++ b/liblepton/scheme/geda/object.scm
@@ -1,6 +1,8 @@
-;; gEDA - GPL Electronic Design Automation
-;; libgeda - gEDA's library - Scheme API
+;; Lepton EDA
+;; liblepton - Lepton's library - Scheme API
 ;; Copyright (C) 2010-2011 Peter Brett <peter@peter-b.co.uk>
+;; Copyright (C) 2012-2016 gEDA Contributors
+;; Copyright (C) 2017-2018 Lepton EDA Contributors
 ;;
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -466,3 +468,9 @@
    (lambda (obj) (%mirror-object! obj x))
    objects)
   objects)
+
+
+
+( define-public object-locked?     %object-locked? )
+( define-public set-object-locked! %set-object-locked! )
+

--- a/liblepton/scheme/geda/object.scm
+++ b/liblepton/scheme/geda/object.scm
@@ -2,7 +2,7 @@
 ;; liblepton - Lepton's library - Scheme API
 ;; Copyright (C) 2010-2011 Peter Brett <peter@peter-b.co.uk>
 ;; Copyright (C) 2012-2016 gEDA Contributors
-;; Copyright (C) 2017-2018 Lepton EDA Contributors
+;; Copyright (C) 2017-2019 Lepton EDA Contributors
 ;;
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -469,8 +469,5 @@
    objects)
   objects)
 
-
-
 ( define-public object-locked?     %object-locked? )
-( define-public set-object-locked! %set-object-locked! )
-
+( define-public set-object-selectable! %set-object-selectable! )

--- a/liblepton/scheme/geda/object.scm
+++ b/liblepton/scheme/geda/object.scm
@@ -469,5 +469,5 @@
    objects)
   objects)
 
-( define-public object-locked?     %object-locked? )
+( define-public object-selectable?     %object-selectable? )
 ( define-public set-object-selectable! %set-object-selectable! )

--- a/liblepton/scheme/unit-tests/t0113-object-locked.scm
+++ b/liblepton/scheme/unit-tests/t0113-object-locked.scm
@@ -30,7 +30,7 @@
   ; clear the page modification flag and lock the object:
   ;
   ( set-page-dirty! page #f )
-  ( set! tmp (set-object-locked! obj #t) )
+  ( set! tmp (set-object-selectable! obj #f) )
 
   ; set-object-locked!() should return the object:
   ;
@@ -48,7 +48,7 @@
   ; clear the page modification flag and lock the object again:
   ;
   ( set-page-dirty! page #f )
-  ( set-object-locked! obj #t )
+  ( set-object-selectable! obj #f )
 
   ; ensure the page modification flag is NOT set (obj is not modified):
   ;
@@ -58,7 +58,7 @@
   ; clear the page modification flag and unlock the object:
   ;
   ( set-page-dirty! page #f )
-  ( set! tmp (set-object-locked! obj #f) )
+  ( set! tmp (set-object-selectable! obj #t) )
 
   ; set-object-locked!() should return the object:
   ;

--- a/liblepton/scheme/unit-tests/t0113-object-locked.scm
+++ b/liblepton/scheme/unit-tests/t0113-object-locked.scm
@@ -1,0 +1,80 @@
+;; Test Scheme procedures for object-locked? and set-object-locked! functions
+
+( use-modules ( unit-test ) )
+
+( use-modules ( geda object ) )
+( use-modules ( geda page   ) )
+
+
+
+( begin-test 'object-locked
+( let
+  (
+  ( page #f )
+  ( obj  #f )
+  ( tmp  #f )
+  )
+
+  ; create a page and an object:
+  ;
+  ( set! page (make-page "/test/page/A") )
+  ( set! obj  (make-box  '(1 . 4) '(3 . 2)) )
+  ( page-append! page obj )
+
+
+  ; obj should be initially unlocked:
+  ;
+  ( assert-false (object-locked? obj) )
+
+
+  ; clear the page modification flag and lock the object:
+  ;
+  ( set-page-dirty! page #f )
+  ( set! tmp (set-object-locked! obj #t) )
+
+  ; set-object-locked!() should return the object:
+  ;
+  ( assert-equal tmp obj )
+
+  ; ensure obj is now locked:
+  ;
+  ( assert-true (object-locked? obj) )
+
+  ; ensure the page modification flag is set:
+  ;
+  ( assert-true (page-dirty? page) )
+
+
+  ; clear the page modification flag and lock the object again:
+  ;
+  ( set-page-dirty! page #f )
+  ( set-object-locked! obj #t )
+
+  ; ensure the page modification flag is NOT set (obj is not modified):
+  ;
+  ( assert-false (page-dirty? page) )
+
+
+  ; clear the page modification flag and unlock the object:
+  ;
+  ( set-page-dirty! page #f )
+  ( set! tmp (set-object-locked! obj #f) )
+
+  ; set-object-locked!() should return the object:
+  ;
+  ( assert-equal tmp obj )
+
+  ; ensure obj is now unlocked:
+  ;
+  ( assert-false (object-locked? obj) )
+
+  ; ensure the page modification flag is set:
+  ;
+  ( assert-true (page-dirty? page) )
+
+
+  ( close-page! page )
+
+) ; let
+) ; 'object-locked()
+

--- a/liblepton/scheme/unit-tests/t0113-object-locked.scm
+++ b/liblepton/scheme/unit-tests/t0113-object-locked.scm
@@ -1,4 +1,6 @@
-;; Test Scheme procedures for object-locked? and set-object-locked! functions
+;; Test procedures for Scheme functions:
+;; - object-selectable?
+;; - set-object-selectable!
 
 ( use-modules ( unit-test ) )
 
@@ -22,9 +24,9 @@
   ( page-append! page obj )
 
 
-  ; obj should be initially unlocked:
+  ; obj should be initially unlocked (i.e. selectable):
   ;
-  ( assert-false (object-locked? obj) )
+  ( assert-true (object-selectable? obj) )
 
 
   ; clear the page modification flag and lock the object:
@@ -38,7 +40,7 @@
 
   ; ensure obj is now locked:
   ;
-  ( assert-true (object-locked? obj) )
+  ( assert-false (object-selectable? obj) )
 
   ; ensure the page modification flag is set:
   ;
@@ -66,7 +68,7 @@
 
   ; ensure obj is now unlocked:
   ;
-  ( assert-false (object-locked? obj) )
+  ( assert-true (object-selectable? obj) )
 
   ; ensure the page modification flag is set:
   ;

--- a/liblepton/scheme/unit-tests/t0113-object-selectable.scm
+++ b/liblepton/scheme/unit-tests/t0113-object-selectable.scm
@@ -9,7 +9,7 @@
 
 
 
-( begin-test 'object-locked
+( begin-test 'object-selectable
 ( let
   (
   ( page #f )
@@ -78,5 +78,5 @@
   ( close-page! page )
 
 ) ; let
-) ; 'object-locked()
+) ; 'object-selectable()
 

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -744,7 +744,7 @@ SCM_DEFINE (object_locked_p, "%object-locked?", 1, 0, 0,
 
   OBJECT* obj = edascm_to_object (obj_s);
 
-  return obj->selectable ? SCM_BOOL_F : SCM_BOOL_T;
+  return scm_from_bool (obj->selectable == 0);
 
 } /* object_locked_x() */
 
@@ -773,7 +773,7 @@ SCM_DEFINE (set_object_locked_x, "%set-object-locked!", 2, 0, 0,
 
   OBJECT* obj = edascm_to_object (obj_s);
 
-  int locked = locked_s == SCM_BOOL_T;
+  int locked = scm_is_true (locked_s);
 
   /* do not allow locked objects to be selected:
   */

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -755,29 +755,25 @@ SCM_DEFINE (object_locked_p, "%object-locked?", 1, 0, 0,
  * \par Function Description
  * Set object's selectable flag: locked objects cannot be selected.
  *
- * \note Scheme API: Implements the %set-object-locked! procedure in
+ * \note Scheme API: Implements the %set-object-selectable! procedure in
  * the (geda core object) module.
  *
- * \param obj_s     #OBJECT smob to modify.
- * \param locked_s  boolean: whether the object should be locked.
+ * \param obj_s         #OBJECT smob to modify.
+ * \param selectable_s  boolean: object's selectable flag.
  *
  * \return          the object (\a obj_s).
  */
-SCM_DEFINE (set_object_locked_x, "%set-object-locked!", 2, 0, 0,
-            (SCM obj_s, SCM locked_s), "Lock or unlock an object.")
+SCM_DEFINE (set_object_selectable_x, "%set-object-selectable!", 2, 0, 0,
+            (SCM obj_s, SCM selectable_s), "Lock or unlock an object.")
 {
   SCM_ASSERT (EDASCM_OBJECTP (obj_s), obj_s,
-              SCM_ARG1, s_set_object_locked_x);
-  SCM_ASSERT (scm_is_bool (locked_s), locked_s,
-              SCM_ARG2, s_set_object_locked_x);
+              SCM_ARG1, s_set_object_selectable_x);
+  SCM_ASSERT (scm_is_bool (selectable_s), selectable_s,
+              SCM_ARG2, s_set_object_selectable_x);
 
   OBJECT* obj = edascm_to_object (obj_s);
 
-  int locked = scm_is_true (locked_s);
-
-  /* do not allow locked objects to be selected:
-  */
-  int selectable = !locked;
+  int selectable = scm_is_true (selectable_s);
 
   if (obj->selectable != selectable)
   {
@@ -2338,7 +2334,7 @@ init_module_geda_core_object (void *unused)
                 s_set_picture_data_vector_x,
                 s_translate_object_x, s_rotate_object_x,
                 s_mirror_object_x,
-                s_object_locked_p, s_set_object_locked_x,
+                s_object_locked_p, s_set_object_selectable_x,
                 NULL);
 }
 

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -2,7 +2,7 @@
  * liblepton - Lepton's library - Scheme API
  * Copyright (C) 2010-2012 Peter Brett <peter@peter-b.co.uk>
  * Copyright (C) 2011-2016 gEDA Contributors
- * Copyright (C) 2017-2018 Lepton EDA Contributors
+ * Copyright (C) 2017-2019 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -736,11 +736,11 @@ SCM_DEFINE (set_object_color_x, "%set-object-color!", 2, 0, 0,
  *
  * \return       Boolean value indicating whether \a obj_s is locked.
  */
-SCM_DEFINE (object_locked_x, "%object-locked?", 1, 0, 0,
+SCM_DEFINE (object_locked_p, "%object-locked?", 1, 0, 0,
             (SCM obj_s), "Check whether an object is locked.")
 {
   SCM_ASSERT (EDASCM_OBJECTP (obj_s), obj_s,
-              SCM_ARG1, s_object_locked_x);
+              SCM_ARG1, s_object_locked_p);
 
   OBJECT* obj = edascm_to_object (obj_s);
 
@@ -2338,7 +2338,7 @@ init_module_geda_core_object (void *unused)
                 s_set_picture_data_vector_x,
                 s_translate_object_x, s_rotate_object_x,
                 s_mirror_object_x,
-                s_object_locked_x, s_set_object_locked_x,
+                s_object_locked_p, s_set_object_locked_x,
                 NULL);
 }
 

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -729,24 +729,24 @@ SCM_DEFINE (set_object_color_x, "%set-object-color!", 2, 0, 0,
  * Check the state of an object's selectable flag: if it's true, the
  * object is considered to be unlocked, otherwise it is locked.
  *
- * \note Scheme API: Implements the %object-locked? procedure in the
+ * \note Scheme API: Implements the %object-selectable? procedure in the
  * (geda core object) module.
  *
  * \param obj_s  #OBJECT smob to inspect.
  *
- * \return       Boolean value indicating whether \a obj_s is locked.
+ * \return       Boolean value indicating whether \a obj_s is selectable.
  */
-SCM_DEFINE (object_locked_p, "%object-locked?", 1, 0, 0,
+SCM_DEFINE (object_selectable_p, "%object-selectable?", 1, 0, 0,
             (SCM obj_s), "Check whether an object is locked.")
 {
   SCM_ASSERT (EDASCM_OBJECTP (obj_s), obj_s,
-              SCM_ARG1, s_object_locked_p);
+              SCM_ARG1, s_object_selectable_p);
 
   OBJECT* obj = edascm_to_object (obj_s);
 
-  return scm_from_bool (obj->selectable == 0);
+  return scm_from_bool (obj->selectable);
 
-} /* object_locked_x() */
+} /* object_selectable_x() */
 
 
 
@@ -787,7 +787,7 @@ SCM_DEFINE (set_object_selectable_x, "%set-object-selectable!", 2, 0, 0,
 
   return obj_s;
 
-} /* set_object_locked_x() */
+} /* set_object_selectable_x() */
 
 
 
@@ -2334,7 +2334,7 @@ init_module_geda_core_object (void *unused)
                 s_set_picture_data_vector_x,
                 s_translate_object_x, s_rotate_object_x,
                 s_mirror_object_x,
-                s_object_locked_p, s_set_object_selectable_x,
+                s_object_selectable_p, s_set_object_selectable_x,
                 NULL);
 }
 


### PR DESCRIPTION
`liblepton`:  Add two new functions to the `(geda object)` module
to work with object's `locked` status: `object-locked?` and `set-object-locked!`.
They read and set the `selectable` flag in the `OBJECT` structure.
Now it's possible to programmatically lock/unlock arbitrary objects on a page.

For example, a feature requested in this launchpad [bug report](https://bugs.launchpad.net/geda/+bug/698790) can easily be implemented using these new functions (e.g. in conjunction with the `open-page-hook`).