### PR TITLE
Path object improvements

### DIFF
--- a/libleptonrenderer/edacairo.c
+++ b/libleptonrenderer/edacairo.c
@@ -363,6 +363,7 @@ eda_cairo_stroke (cairo_t *cr, int flags, int line_type, int line_end,
   double dummy = 0;
   cairo_line_cap_t cap;
   cairo_line_cap_t round_cap_if_legible = CAIRO_LINE_CAP_ROUND;
+  cairo_line_join_t join = CAIRO_LINE_JOIN_MITER;
   int num_dashes;
   int iwidth;
   double width = wwidth, length = wlength, space = wspace;
@@ -381,18 +382,28 @@ eda_cairo_stroke (cairo_t *cr, int flags, int line_type, int line_end,
       (iwidth <= 1) ? CAIRO_LINE_CAP_SQUARE : CAIRO_LINE_CAP_ROUND;
   }
 
-  cairo_set_line_width (cr, width);
-  cairo_set_line_join (cr, CAIRO_LINE_JOIN_MITER);
-
   switch (line_end) {
-    case END_NONE:   cap = CAIRO_LINE_CAP_BUTT;   break;
-    case END_SQUARE: cap = CAIRO_LINE_CAP_SQUARE; break;
-    case END_ROUND:  cap = round_cap_if_legible;  break;
+    case END_NONE:
+      cap = CAIRO_LINE_CAP_BUTT;
+      join = CAIRO_LINE_JOIN_BEVEL;
+      break;
+    case END_SQUARE:
+      cap = CAIRO_LINE_CAP_SQUARE;
+      join = CAIRO_LINE_JOIN_MITER;
+      break;
+    case END_ROUND:
+      cap = round_cap_if_legible;
+      join = CAIRO_LINE_JOIN_ROUND;
+      break;
     default:
       g_warn_if_reached ();
       cap = CAIRO_LINE_CAP_BUTT;
+      join = CAIRO_LINE_JOIN_MITER;
     break;
   }
+
+  cairo_set_line_width (cr, width);
+  cairo_set_line_join (cr, join);
 
   switch (line_type) {
 

--- a/libleptonrenderer/edacairo.c
+++ b/libleptonrenderer/edacairo.c
@@ -503,7 +503,11 @@ eda_cairo_path (cairo_t *cr, int flags, double line_width,
   double dummy = 0;
 
   if (flags & EDA_CAIRO_ENABLE_HINTS) {
-    s_line_width = screen_width (cr, line_width);
+    if (line_width == 0) {
+      s_line_width = 1;
+    } else {
+      s_line_width = screen_width (cr, line_width);
+    }
   } else {
     cairo_user_to_device (cr, &line_width, &dummy);
     s_line_width = line_width;

--- a/libleptonrenderer/edarenderer.c
+++ b/libleptonrenderer/edarenderer.c
@@ -103,6 +103,12 @@ EDA_RENDERER_STROKE_WIDTH (EdaRenderer *r, double width) {
   /* For now, the minimum line width possible is half the net width. */
   return fmax (width, NET_WIDTH / 2);
 }
+/* The same as above, but returns 0 if width is 0. Especially
+   added to allow (filled) paths with zero width line. */
+static inline double
+EDA_RENDERER_STROKE_WIDTH0 (EdaRenderer *r, double width) {
+  return (width == 0) ? 0 : EDA_RENDERER_STROKE_WIDTH (r, width);
+}
 
 #define DEFAULT_FONT_NAME "Arial"
 #define GRIP_STROKE_COLOR SELECT_COLOR
@@ -774,7 +780,7 @@ eda_renderer_draw_path (EdaRenderer *renderer, OBJECT *object)
   if (fill_solid) cairo_fill_preserve (renderer->priv->cr);
   eda_cairo_stroke (renderer->priv->cr, EDA_RENDERER_CAIRO_FLAGS (renderer),
                     object->line_type, object->line_end,
-                    EDA_RENDERER_STROKE_WIDTH (renderer, object->line_width),
+                    EDA_RENDERER_STROKE_WIDTH0 (renderer, object->line_width),
                     object->line_length, object->line_space);
 }
 


### PR DESCRIPTION
Feature request by Karl Hammar:

> Possible not ASAP, but, for paths (^H), to be able to have
> round join styles instead of default miter style. See e.g.
> http://www.delorie.com/archives/browse.cgi?p=geda-user/2018/07/12/13:25:11

> And in the same vein, for filled paths with line width = 0, to really
> have zero width, not some default width which will enlargen the
> triangle (mostly arrow heads, but filled polygons in general).

I decided to not modify the schematic/symbol file format and do
the latter change in the simple way. Now, when line width of a
path is set to zero, the stroke is not rendered, thus allowing
drawing of filled figures without increasing their size by a half
of the line width, so the object sizes strongly correspond to what
the user wanted.

Attached is a
[test symbol](https://github.com/lepton-eda/lepton-eda/files/2756153/test.sym.txt)
by Karl Hammar.