### PR TITLE
Let the user set `lepton-netlist` options

### DIFF
--- a/netlist/scheme/lepton-netlist.in
+++ b/netlist/scheme/lepton-netlist.in
@@ -27,12 +27,12 @@ exec @GUILE@ -s "$0" "$@"
 ;;; extension. Let's make it quiet here.
 (define with-toplevel (@@ (geda core toplevel) %with-toplevel))
 (define make-toplevel (@@ (geda core toplevel) %make-toplevel))
-(define gnetlist-option-ref* (@@ (netlist option) gnetlist-option-ref))
+(define netlist-option-ref* (@@ (netlist option) netlist-option-ref))
 
 ;;; Evaluate Scheme expressions that need to be run before rc
 ;;; files are loaded.
 (for-each (lambda (dir) (add-to-load-path dir))
-          (reverse (gnetlist-option-ref* 'load-path)))
+          (reverse (netlist-option-ref* 'load-path)))
 
 ;;; Using of primitive-eval() here avoids Scheme errors when this
 ;;; program is compiled by Guile. See comments above.

--- a/netlist/scheme/netlist.scm
+++ b/netlist/scheme/netlist.scm
@@ -486,13 +486,13 @@ PACKAGE."
 (define gnetlist:get-nets get-nets)
 (define gnetlist:get-pins-nets get-pins-nets)
 (define (gnetlist:get-verbosity)
-  (if (gnetlist-option-ref 'verbose)
+  (if (netlist-option-ref 'verbose)
       1
-      (if (gnetlist-option-ref 'quiet)
+      (if (netlist-option-ref 'quiet)
           -1
           0)))
 (define (gnetlist:get-input-files)
-  (gnetlist-option-ref '()))
+  (netlist-option-ref '()))
 (define (gnetlist:get-command-line)
   (string-join (command-line) " "))
 (define (gnetlist:get-packages level)
@@ -507,7 +507,7 @@ PACKAGE."
   (map (lambda (pair) (list (car pair) (cdr pair)))
        (get-all-connections netname)))
 (define (gnetlist:get-backend-arguments)
-  (gnetlist-option-ref 'backend-option))
+  (netlist-option-ref 'backend-option))
 (define (gnetlist:get-renamed-nets level)
   (map
    (lambda (rename)
@@ -743,7 +743,7 @@ other limitations imposed by this netlist format.
 
 (define (get-output-filename)
   ;; Name is file name or "-" which means stdout.
-  (let ((name (gnetlist-option-ref 'output)))
+  (let ((name (netlist-option-ref 'output)))
     (and (not (string=? name "-"))
          name)))
 
@@ -854,16 +854,16 @@ Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>
 ( let
   (
   ( output-filename   (get-output-filename) )
-  ( files             (gnetlist-option-ref '()) )            ; schematics
-  ( opt-backend       (gnetlist-option-ref 'backend) )       ; -g
-  ( opt-interactive   (gnetlist-option-ref 'interactive) )   ; -i
-  ( opt-verbose       (gnetlist-option-ref 'verbose) )       ; --verbose (-v)
-  ( opt-code-to-eval  (gnetlist-option-ref 'eval-code) )     ; -c
-  ( opt-help          (gnetlist-option-ref 'help) )          ; --help (-h)
-  ( opt-version       (gnetlist-option-ref 'version) )       ; --version (-V)
-  ( opt-list-backends (gnetlist-option-ref 'list-backends) ) ; --list-backends
-  ( opt-pre-load      (gnetlist-option-ref 'pre-load) )      ; -l
-  ( opt-post-load     (gnetlist-option-ref 'post-load) )     ; -m
+  ( files             (netlist-option-ref '()) )            ; schematics
+  ( opt-backend       (netlist-option-ref 'backend) )       ; -g
+  ( opt-interactive   (netlist-option-ref 'interactive) )   ; -i
+  ( opt-verbose       (netlist-option-ref 'verbose) )       ; --verbose (-v)
+  ( opt-code-to-eval  (netlist-option-ref 'eval-code) )     ; -c
+  ( opt-help          (netlist-option-ref 'help) )          ; --help (-h)
+  ( opt-version       (netlist-option-ref 'version) )       ; --version (-V)
+  ( opt-list-backends (netlist-option-ref 'list-backends) ) ; --list-backends
+  ( opt-pre-load      (netlist-option-ref 'pre-load) )      ; -l
+  ( opt-post-load     (netlist-option-ref 'post-load) )     ; -m
   ( netlist-mode      'geda )
   ( backend-path      #f )
   ( schematic         #f )

--- a/netlist/scheme/netlist/config.scm
+++ b/netlist/scheme/netlist/config.scm
@@ -104,7 +104,7 @@
 (define (try-load-config cfg)
 (let*
     (
-    (nowarn (gnetlist-option-ref 'no-warn-cfg))
+    (nowarn (netlist-option-ref 'no-warn-cfg))
     (level (if nowarn 'info 'warning))
     )
 

--- a/netlist/scheme/netlist/deprecated.scm
+++ b/netlist/scheme/netlist/deprecated.scm
@@ -22,6 +22,7 @@
 (define-module (netlist deprecated)
   #:use-module (srfi srfi-1)
   #:use-module (netlist attrib compare)
+  #:use-module (netlist option)
   #:use-module (netlist package-pin)
   #:use-module (netlist schematic-component)
   #:use-module (netlist schematic)
@@ -31,6 +32,7 @@
   #:export (;; deprecated procedures
             get-pins
             gnetlist:get-pins
+            gnetlist-option-ref
             ;; deprecated variables
             non-unique-packages
             packages
@@ -41,6 +43,8 @@
             set-deprecated-schematic-variables!))
 
 ;;; Backward compatibility procedures.
+(define gnetlist-option-ref netlist-option-ref)
+
 (define (get-pins refdes)
   (define (found? x)
     (and x

--- a/netlist/scheme/netlist/option.scm
+++ b/netlist/scheme/netlist/option.scm
@@ -20,7 +20,8 @@
   #:use-module (ice-9 getopt-long)
   #:use-module ((srfi srfi-1) #:select (filter-map))
   #:export (%default-gnetlist-options
-            gnetlist-option-ref))
+            gnetlist-option-ref
+            set-netlist-option!))
 
 ;;; Empty lists are default values for the keys which may repeat
 ;;; on command line.
@@ -79,3 +80,12 @@
   (let ((default (assq-ref %default-gnetlist-options key))
         (is-list-key? (memq key %list-keys)))
     ((if is-list-key? list-option-ref option-ref) %gnetlist-options key default)))
+
+(define (set-netlist-option! key value)
+  "Sets lepton-netlist option KEY to VALUE. Returns the new value
+if the key is available, otherwise returns #f."
+  (and (assq key %default-gnetlist-options)
+       (begin
+         (set! %gnetlist-options
+               (assq-set! %gnetlist-options key value))
+         value)))

--- a/netlist/scheme/netlist/option.scm
+++ b/netlist/scheme/netlist/option.scm
@@ -19,13 +19,13 @@
 (define-module (netlist option)
   #:use-module (ice-9 getopt-long)
   #:use-module ((srfi srfi-1) #:select (filter-map))
-  #:export (%default-gnetlist-options
-            gnetlist-option-ref
+  #:export (%default-netlist-options
+            netlist-option-ref
             set-netlist-option!))
 
 ;;; Empty lists are default values for the keys which may repeat
 ;;; on command line.
-(define %default-gnetlist-options
+(define %default-netlist-options
   '((quiet . #f)
     (verbose . #f)
     (load-path . ())
@@ -45,10 +45,10 @@
 (define %list-keys
   (filter-map
    (lambda (x) (and (eq? (cdr x) '()) (car x)))
-   %default-gnetlist-options))
+   %default-netlist-options))
 
-;;; getopt-long compatible gnetlist options.
-(define %gnetlist-options
+;;; getopt-long compatible lepton-netlist options.
+(define %netlist-options
   (getopt-long (program-arguments)
                ;; option spec
                '((quiet (single-char #\q))
@@ -75,17 +75,17 @@
        options)
       default))
 
-(define (gnetlist-option-ref key)
-  "Returns value of gnetlist option KEY. Use '() to request schematics."
-  (let ((default (assq-ref %default-gnetlist-options key))
+(define (netlist-option-ref key)
+  "Returns value of netlister option KEY. Use '() to request schematics."
+  (let ((default (assq-ref %default-netlist-options key))
         (is-list-key? (memq key %list-keys)))
-    ((if is-list-key? list-option-ref option-ref) %gnetlist-options key default)))
+    ((if is-list-key? list-option-ref option-ref) %netlist-options key default)))
 
 (define (set-netlist-option! key value)
   "Sets lepton-netlist option KEY to VALUE. Returns the new value
 if the key is available, otherwise returns #f."
-  (and (assq key %default-gnetlist-options)
+  (and (assq key %default-netlist-options)
        (begin
-         (set! %gnetlist-options
-               (assq-set! %gnetlist-options key value))
+         (set! %netlist-options
+               (assq-set! %netlist-options key value))
          value)))

--- a/netlist/scheme/netlist/traverse.scm
+++ b/netlist/scheme/netlist/traverse.scm
@@ -341,7 +341,7 @@
                   (non-null* (assq-ref inherited-attribs 'source)))))
          (and=> sources comma-separated->list))))
 
-(define quiet-mode (gnetlist-option-ref 'quiet))
+(define quiet-mode (netlist-option-ref 'quiet))
 
 ;;; Reads file NAME and outputs a page named NAME
 (define (file->page name)


### PR DESCRIPTION
Request by @graahnul-grom in #304:

> Now (schematic netlist) module (and hence netlist) is loaded from
> system-gschemrc, and every time lepton-schematic starts,
> Failed to load config from... messages are printed to the log.
> It would be nice to have an ability to (programmatically) disable this
> (i.e. have an access to the netlist options, - set by -w in this case).

The code here allows the user setting of arbitrary netlister options in order to change the behaviour of its modules if they're used by other tools (e.g., in `lepton-schematic` GUI). For example, the following lines in `gafrc` prevents warnings on missing xdg system conf files:
```
(use-modules (netlist option))
(set-netlist-option! 'no-warn-cfg #t)
```