### PR TITLE
liblepton: Fix two compilation warnings.

### DIFF
--- a/liblepton/src/a_basic.c
+++ b/liblepton/src/a_basic.c
@@ -364,7 +364,7 @@ GList *o_read_buffer (TOPLEVEL *toplevel, GList *object_list,
 error:
   geda_object_list_delete (toplevel, new_object_list);
 
-  gsize linenum = s_textbuffer_linenum (tb);
+  unsigned long linenum = s_textbuffer_linenum (tb);
   g_prefix_error (err, "Parsing stopped at line %lu:\n", linenum);
 
   return NULL;

--- a/liblepton/src/s_textbuffer.c
+++ b/liblepton/src/s_textbuffer.c
@@ -229,7 +229,7 @@ s_textbuffer_next_line (TextBuffer *tb)
 
     if (verbose_loading)
     {
-      fprintf (stderr, "%-4lu: %s", tb->linenum, line);
+      fprintf (stderr, "%-4lu: %s", (unsigned long) tb->linenum, line);
     }
   }
 


### PR DESCRIPTION
Fixes warnings by gcc as follows:

  warning: format ‘%lu’ expects argument of type ‘long unsigned
  int’, but argument 3 has type ‘gsize {aka unsigned int}’
  [-Wformat=]