### PR TITLE
liblepton: Fix warnings on tests.

### DIFF
--- a/liblepton/tests/test_point.c
+++ b/liblepton/tests/test_point.c
@@ -32,7 +32,7 @@ check_rotate ()
     if (d0 > 100.0) {
       gdouble a0 = atan2 (y0, x0);
       gdouble a1 = atan2 (y1, x1);
-      gint normalized = geda_angle_normalize (angle);
+      /* gint normalized = geda_angle_normalize (angle); */
 
       gdouble dd = 180.0 * (a1 - a0) / G_PI;
       while (dd < 0) {
@@ -76,7 +76,7 @@ check_rotate_90 ()
     if (d0 > 100.0) {
       gdouble a0 = atan2 (y0, x0);
       gdouble a1 = atan2 (y1, x1);
-      gint normalized = geda_angle_normalize (angle);
+      /* gint normalized = geda_angle_normalize (angle); */
 
       gdouble dd = 180.0 * (a1 - a0) / G_PI;
       while (dd < 0) {

--- a/liblepton/tests/test_text_object.c
+++ b/liblepton/tests/test_text_object.c
@@ -190,7 +190,7 @@ check_serialization ()
 
     TextBuffer *tb = s_textbuffer_new (buffer0, -1,
                                        "test_text_object.c::check_serialization()");
-    gchar *line = s_textbuffer_next_line (tb);
+    const gchar *line = s_textbuffer_next_line (tb);
 
     GedaObject *object1 = o_text_read (toplevel,
                                       line,


### PR DESCRIPTION
The patch fixes the following warnings:
- warning: unused variable ‘normalized’ [-Wunused-variable]
- warning: initialization discards ‘const’ qualifier from pointer
target type [-Wdiscarded-qualifiers]