### PR TITLE
Fix lepton-symcheck startup script

### DIFF
--- a/symcheck/scheme/lepton-symcheck.in
+++ b/symcheck/scheme/lepton-symcheck.in
@@ -3,7 +3,7 @@ exec @GUILE@ -s "$0" "$@"
 !#
 ;;; Lepton EDA Symbol Checker
 ;;; Scheme API
-;;; Copyright (C) 2017 Lepton EDA Contributors
+;;; Copyright (C) 2017-2019 Lepton EDA Contributors
 ;;;
 ;;; This program is free software; you can redistribute it and/or modify
 ;;; it under the terms of the GNU General Public License as published by
@@ -27,6 +27,7 @@ exec @GUILE@ -s "$0" "$@"
 ;;; extension. Let's make it quiet here.
 (define with-toplevel (@@ (geda core toplevel) %with-toplevel))
 (define make-toplevel (@@ (geda core toplevel) %make-toplevel))
-(define check-all (@@ (symcheck check) check-all-symbols))
 
-(with-toplevel (make-toplevel) check-all)
+(primitive-eval '(use-modules (symcheck check)))
+
+(with-toplevel (make-toplevel) check-all-symbols)


### PR DESCRIPTION
Unless this script is arranged like the
`lepton-netlist.in`, *precompilation* produce
object code that fails at runtime,
complaining about missing modules.