### PR TITLE
netlist: Create internally hierarchical refdes as a list.

### DIFF
--- a/netlist/scheme/netlist/net.scm
+++ b/netlist/scheme/netlist/net.scm
@@ -17,6 +17,7 @@
 ;;; MA 02111-1301 USA.
 
 (define-module (netlist net)
+  #:use-module (ice-9 match)
   #:use-module (srfi srfi-1)
   #:use-module (geda attrib)
   #:use-module (geda log)
@@ -34,27 +35,41 @@
             check-net-maps
             attrib-value-by-name))
 
+(define (hierarchy-tag->string hierarchy-tag separator reverse-order?)
+  (match hierarchy-tag
+    ;; Hierarchy tag is already reversed, so we have to reverse it
+    ;; again if no reverse-order? is set.
+    ((? list? tag) (string-join (if reverse-order? tag (reverse tag))
+                                (or separator "")))
+    (tag tag)))
+
 (define (create-netattrib basename hierarchy-tag)
   (define mangle? (gnetlist-config-ref 'mangle-net))
   (define reverse-order?  (gnetlist-config-ref 'reverse-net-order))
   (define separator (gnetlist-config-ref 'net-separator))
 
-  (if (and hierarchy-tag mangle? basename)
-      (if reverse-order?
-          (string-append basename (or separator "") hierarchy-tag)
-          (string-append hierarchy-tag (or separator "") basename))
-      basename))
+  (let ((hierarchy-tag (hierarchy-tag->string hierarchy-tag
+                                              separator
+                                              reverse-order?)))
+   (if (and hierarchy-tag mangle? basename)
+       (if reverse-order?
+           (string-append basename (or separator "") hierarchy-tag)
+           (string-append hierarchy-tag (or separator "") basename))
+       basename)))
 
 (define (create-netname basename hierarchy-tag)
   (define mangle? (gnetlist-config-ref 'mangle-netname))
   (define reverse-order?  (gnetlist-config-ref 'reverse-netname-order))
   (define separator (gnetlist-config-ref 'netname-separator))
 
-  (if (and hierarchy-tag mangle? basename)
-      (if reverse-order?
-          (string-append basename (or separator "") hierarchy-tag)
-          (string-append hierarchy-tag (or separator "") basename))
-      basename))
+  (let ((hierarchy-tag (hierarchy-tag->string hierarchy-tag
+                                              separator
+                                              reverse-order?)))
+   (if (and hierarchy-tag mangle? basename)
+       (if reverse-order?
+           (string-append basename (or separator "") hierarchy-tag)
+           (string-append hierarchy-tag (or separator "") basename))
+       basename)))
 
 (define (attrib-value-by-name object name)
   (define (has-appropriate-name? attrib)

--- a/netlist/tests/hierarchy-config_mangle_refdes_attribute_false_2.out
+++ b/netlist/tests/hierarchy-config_mangle_refdes_attribute_false_2.out
@@ -19,17 +19,17 @@ No "no-connect" nets found
 
 START renamed-nets
 
-Umiddle/Utop/rockA -> U1_2_to_B
-Umiddle/Uunder/rockA -> U1_2_to_B
-Urock/Umiddle/Utop/unnamed_net2 -> U1_2_to_B
-Urock/Umiddle/Uunder/unnamed_net4 -> U1_2_to_B
+Utop/Umiddle/Urock/unnamed_net2 -> U1_2_to_B
+Utop/Umiddle/rockA -> U1_2_to_B
 Utop/middleA -> U1_2_to_B
+Uunder/Umiddle/Urock/unnamed_net4 -> U1_2_to_B
+Uunder/Umiddle/rockA -> U1_2_to_B
 Uunder/middleA -> U1_2_to_B
-Umiddle/Utop/rockB -> U2_1_to_E
-Umiddle/Uunder/rockB -> U2_1_to_E
-Urock/Umiddle/Utop/unnamed_net1 -> U2_1_to_E
-Urock/Umiddle/Uunder/unnamed_net3 -> U2_1_to_E
+Utop/Umiddle/Urock/unnamed_net1 -> U2_1_to_E
+Utop/Umiddle/rockB -> U2_1_to_E
 Utop/middleB -> U2_1_to_E
+Uunder/Umiddle/Urock/unnamed_net3 -> U2_1_to_E
+Uunder/Umiddle/rockB -> U2_1_to_E
 Uunder/middleB -> U2_1_to_E
 U2_1_to_E -> U2_1_to_E-net
 
@@ -40,10 +40,10 @@ START nets
 GND : U1 7, U2 7
 U1_2_to_B : Qrock B, U1 2
 U2_1_to_E-net : Qrock E, U2 1
-Urock/Umiddle/Utop/-12V : Qrock C
-Urock/Umiddle/Utop/BUGA : Qrock D
-Urock/Umiddle/Uunder/-12V : Qrock C
-Urock/Umiddle/Uunder/BUGA : Qrock D
+Utop/Umiddle/Urock/-12V : Qrock C
+Utop/Umiddle/Urock/BUGA : Qrock D
+Uunder/Umiddle/Urock/-12V : Qrock C
+Uunder/Umiddle/Urock/BUGA : Qrock D
 Vcc : U1 14, U2 14
 same_for_all : U2 2
 

--- a/netlist/tests/hierarchy-config_net_attribute_order_true.out
+++ b/netlist/tests/hierarchy-config_net_attribute_order_true.out
@@ -38,10 +38,10 @@ END renamed-nets
 
 START nets
 
--12V/Utop/Umiddle/Urock : Utop/Umiddle/Urock/Qrock C
--12V/Uunder/Umiddle/Urock : Uunder/Umiddle/Urock/Qrock C
-BUGA/Utop/Umiddle/Urock : Utop/Umiddle/Urock/Qrock D
-BUGA/Uunder/Umiddle/Urock : Uunder/Umiddle/Urock/Qrock D
+-12V/Urock/Umiddle/Utop : Utop/Umiddle/Urock/Qrock C
+-12V/Urock/Umiddle/Uunder : Uunder/Umiddle/Urock/Qrock C
+BUGA/Urock/Umiddle/Utop : Utop/Umiddle/Urock/Qrock D
+BUGA/Urock/Umiddle/Uunder : Uunder/Umiddle/Urock/Qrock D
 GND : U1 7, U2 7
 U1_2_to_B : U1 2, Utop/Umiddle/Urock/Qrock B, Uunder/Umiddle/Urock/Qrock B
 U2_1_to_E-net : U2 1, Utop/Umiddle/Urock/Qrock E, Uunder/Umiddle/Urock/Qrock E

--- a/netlist/tests/hierarchy-config_net_attribute_separator_1.out
+++ b/netlist/tests/hierarchy-config_net_attribute_separator_1.out
@@ -41,10 +41,10 @@ START nets
 GND : U1 7, U2 7
 U1_2_to_B : U1 2, Utop/Umiddle/Urock/Qrock B, Uunder/Umiddle/Urock/Qrock B
 U2_1_to_E-net : U2 1, Utop/Umiddle/Urock/Qrock E, Uunder/Umiddle/Urock/Qrock E
-Utop/Umiddle/Urock:-12V : Utop/Umiddle/Urock/Qrock C
-Utop/Umiddle/Urock:BUGA : Utop/Umiddle/Urock/Qrock D
-Uunder/Umiddle/Urock:-12V : Uunder/Umiddle/Urock/Qrock C
-Uunder/Umiddle/Urock:BUGA : Uunder/Umiddle/Urock/Qrock D
+Utop:Umiddle:Urock:-12V : Utop/Umiddle/Urock/Qrock C
+Utop:Umiddle:Urock:BUGA : Utop/Umiddle/Urock/Qrock D
+Uunder:Umiddle:Urock:-12V : Uunder/Umiddle/Urock/Qrock C
+Uunder:Umiddle:Urock:BUGA : Uunder/Umiddle/Urock/Qrock D
 Vcc : U1 14, U2 14
 same_for_all : U2 2
 

--- a/netlist/tests/hierarchy-config_netname_attribute_order_true.out
+++ b/netlist/tests/hierarchy-config_netname_attribute_order_true.out
@@ -22,16 +22,16 @@ START renamed-nets
 
 middleA/Utop -> U1_2_to_B
 middleA/Uunder -> U1_2_to_B
-rockA/Utop/Umiddle -> U1_2_to_B
-rockA/Uunder/Umiddle -> U1_2_to_B
-unnamed_net2/Utop/Umiddle/Urock -> U1_2_to_B
-unnamed_net4/Uunder/Umiddle/Urock -> U1_2_to_B
+rockA/Umiddle/Utop -> U1_2_to_B
+rockA/Umiddle/Uunder -> U1_2_to_B
+unnamed_net2/Urock/Umiddle/Utop -> U1_2_to_B
+unnamed_net4/Urock/Umiddle/Uunder -> U1_2_to_B
 middleB/Utop -> U2_1_to_E
 middleB/Uunder -> U2_1_to_E
-rockB/Utop/Umiddle -> U2_1_to_E
-rockB/Uunder/Umiddle -> U2_1_to_E
-unnamed_net1/Utop/Umiddle/Urock -> U2_1_to_E
-unnamed_net3/Uunder/Umiddle/Urock -> U2_1_to_E
+rockB/Umiddle/Utop -> U2_1_to_E
+rockB/Umiddle/Uunder -> U2_1_to_E
+unnamed_net1/Urock/Umiddle/Utop -> U2_1_to_E
+unnamed_net3/Urock/Umiddle/Uunder -> U2_1_to_E
 U2_1_to_E -> U2_1_to_E-net
 
 END renamed-nets

--- a/netlist/tests/hierarchy-config_netname_attribute_separator_1.out
+++ b/netlist/tests/hierarchy-config_netname_attribute_separator_1.out
@@ -20,17 +20,17 @@ No "no-connect" nets found
 
 START renamed-nets
 
-Utop/Umiddle/Urock:unnamed_net2 -> U1_2_to_B
-Utop/Umiddle:rockA -> U1_2_to_B
+Utop:Umiddle:Urock:unnamed_net2 -> U1_2_to_B
+Utop:Umiddle:rockA -> U1_2_to_B
 Utop:middleA -> U1_2_to_B
-Uunder/Umiddle/Urock:unnamed_net4 -> U1_2_to_B
-Uunder/Umiddle:rockA -> U1_2_to_B
+Uunder:Umiddle:Urock:unnamed_net4 -> U1_2_to_B
+Uunder:Umiddle:rockA -> U1_2_to_B
 Uunder:middleA -> U1_2_to_B
-Utop/Umiddle/Urock:unnamed_net1 -> U2_1_to_E
-Utop/Umiddle:rockB -> U2_1_to_E
+Utop:Umiddle:Urock:unnamed_net1 -> U2_1_to_E
+Utop:Umiddle:rockB -> U2_1_to_E
 Utop:middleB -> U2_1_to_E
-Uunder/Umiddle/Urock:unnamed_net3 -> U2_1_to_E
-Uunder/Umiddle:rockB -> U2_1_to_E
+Uunder:Umiddle:Urock:unnamed_net3 -> U2_1_to_E
+Uunder:Umiddle:rockB -> U2_1_to_E
 Uunder:middleB -> U2_1_to_E
 U2_1_to_E -> U2_1_to_E-net
 

--- a/netlist/tests/hierarchy-config_refdes_attribute_order_true.out
+++ b/netlist/tests/hierarchy-config_refdes_attribute_order_true.out
@@ -20,17 +20,17 @@ No "no-connect" nets found
 
 START renamed-nets
 
-Umiddle/Utop/rockA -> U1_2_to_B
-Umiddle/Uunder/rockA -> U1_2_to_B
-Urock/Umiddle/Utop/unnamed_net2 -> U1_2_to_B
-Urock/Umiddle/Uunder/unnamed_net4 -> U1_2_to_B
+Utop/Umiddle/Urock/unnamed_net2 -> U1_2_to_B
+Utop/Umiddle/rockA -> U1_2_to_B
 Utop/middleA -> U1_2_to_B
+Uunder/Umiddle/Urock/unnamed_net4 -> U1_2_to_B
+Uunder/Umiddle/rockA -> U1_2_to_B
 Uunder/middleA -> U1_2_to_B
-Umiddle/Utop/rockB -> U2_1_to_E
-Umiddle/Uunder/rockB -> U2_1_to_E
-Urock/Umiddle/Utop/unnamed_net1 -> U2_1_to_E
-Urock/Umiddle/Uunder/unnamed_net3 -> U2_1_to_E
+Utop/Umiddle/Urock/unnamed_net1 -> U2_1_to_E
+Utop/Umiddle/rockB -> U2_1_to_E
 Utop/middleB -> U2_1_to_E
+Uunder/Umiddle/Urock/unnamed_net3 -> U2_1_to_E
+Uunder/Umiddle/rockB -> U2_1_to_E
 Uunder/middleB -> U2_1_to_E
 U2_1_to_E -> U2_1_to_E-net
 
@@ -41,10 +41,10 @@ START nets
 GND : U1 7, U2 7
 U1_2_to_B : Qrock/Urock/Umiddle/Utop B, Qrock/Urock/Umiddle/Uunder B, U1 2
 U2_1_to_E-net : Qrock/Urock/Umiddle/Utop E, Qrock/Urock/Umiddle/Uunder E, U2 1
-Urock/Umiddle/Utop/-12V : Qrock/Urock/Umiddle/Utop C
-Urock/Umiddle/Utop/BUGA : Qrock/Urock/Umiddle/Utop D
-Urock/Umiddle/Uunder/-12V : Qrock/Urock/Umiddle/Uunder C
-Urock/Umiddle/Uunder/BUGA : Qrock/Urock/Umiddle/Uunder D
+Utop/Umiddle/Urock/-12V : Qrock/Urock/Umiddle/Utop C
+Utop/Umiddle/Urock/BUGA : Qrock/Urock/Umiddle/Utop D
+Uunder/Umiddle/Urock/-12V : Qrock/Urock/Umiddle/Uunder C
+Uunder/Umiddle/Urock/BUGA : Qrock/Urock/Umiddle/Uunder D
 Vcc : U1 14, U2 14
 same_for_all : U2 2
 


### PR DESCRIPTION
Using of lists instead of strings allows various transformations
of refdeses and fixes the following bugs (as can be seen from the
changed tests):

- Reverse order setting for refdes attribute affected
  netnames (see changes in output of tests
  'hierarchy-config_mangle_refdes_attribute_false_2.out' and
  'hierarchy-config_refdes_attribute_order_true.out' where the
  reverse refdes order is set).

- Now netnames are formed using true reversed hierarchical name,
  before they were formed from hierarchy-tag string and local
  netnames. Since the tag might be not reversed depending of the
  reverse order setting for refdes, the resulting strings did not
  reflect hierarchy (see, e.g., changes in
  'hierarchy-config_net_attribute_order_true.out').

- For the same reason, the separator for "net=" attributes did not
  affect resulting net names (see, e.g.,
  'hierarchy-config_net_attribute_separator_1.out').

- The same was true for "netname=" attributes (see, e.g.,
  'hierarchy-config_netname_attribute_separator_1.out').

- Removing of refdes mangling was possible only if the refdes
  separator was "/". See changes in the procedure
  remove-refdes-mangling().