### PR TITLE
Several lepton-netlist unit-test suite and option processing improvements

### DIFF
--- a/netlist/scheme/Makefile.am
+++ b/netlist/scheme/Makefile.am
@@ -73,7 +73,15 @@ TEST_EXTENSIONS = .scm
 # $(srcdir) and $(builddir) are added here and not in
 # AM_SCM_LOG_FLAGS below because guile must know where to find
 # netlist modules before it runs tests
-SCM_LOG_DRIVER = $(GUILE) -L $(srcdir) -L $(builddir) --no-auto-compile -e main -s unit-test.scm
+SCM_LOG_DRIVER = $(GUILE) \
+	-L $(srcdir) \
+	-L $(builddir) \
+	-L $(abs_top_srcdir)/liblepton/scheme \
+	-L $(abs_top_builddir)/liblepton/scheme \
+	-L $(abs_top_srcdir)/symcheck/scheme \
+	-L $(abs_top_builddir)/symcheck/scheme \
+	--no-auto-compile -e main -s unit-test.scm
+
 AM_SCM_LOG_FLAGS = --
 AM_TESTS_ENVIRONMENT = GUILE_AUTO_COMPILE=0
 

--- a/netlist/scheme/Makefile.am
+++ b/netlist/scheme/Makefile.am
@@ -80,7 +80,7 @@ SCM_LOG_DRIVER = $(GUILE) \
 	-L $(abs_top_builddir)/liblepton/scheme \
 	-L $(abs_top_srcdir)/symcheck/scheme \
 	-L $(abs_top_builddir)/symcheck/scheme \
-	--no-auto-compile -e main -s unit-test.scm
+	--no-auto-compile -e main/with-toplevel -s unit-test.scm
 
 AM_SCM_LOG_FLAGS = --
 AM_TESTS_ENVIRONMENT = GUILE_AUTO_COMPILE=0

--- a/netlist/scheme/lepton-netlist.in
+++ b/netlist/scheme/lepton-netlist.in
@@ -3,7 +3,7 @@ exec @GUILE@ -s "$0" "$@"
 !#
 ;;; Lepton EDA netlister
 ;;; Scheme API
-;;; Copyright (C) 2017-2018 Lepton EDA Contributors
+;;; Copyright (C) 2017-2019 Lepton EDA Contributors
 ;;;
 ;;; This program is free software; you can redistribute it and/or modify
 ;;; it under the terms of the GNU General Public License as published by
@@ -19,27 +19,62 @@ exec @GUILE@ -s "$0" "$@"
 ;;; along with this program; if not, write to the Free Software
 ;;; Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111 USA
 
+;;; Load and initialize liblepton library.
 (load-extension (or (getenv "LIBLEPTON") "@libdir@/liblepton")
                 "libgeda_init")
 
-;;; At compile time of this program guile won't be aware of these
-;;; modules, since it compiles the code before loading the above
-;;; extension. Let's make it quiet here.
-(define with-toplevel (@@ (geda core toplevel) %with-toplevel))
-(define make-toplevel (@@ (geda core toplevel) %make-toplevel))
-(define netlist-option-ref* (@@ (netlist option) netlist-option-ref))
+;;; Process lepton-netlist options.
+
+(use-modules (ice-9 getopt-long))
+
+;;; Specification.
+(define %option-spec
+  '((quiet (single-char #\q))
+    (verbose (single-char #\v))
+    (load-path (single-char #\L) (value #t))
+    (backend (single-char #\g) (value #t))
+    (backend-option (single-char #\O) (value #t))
+    (list-backends)
+    (output (single-char #\o) (value #t))
+    (pre-load (single-char #\l) (value #t))
+    (post-load (single-char #\m) (value #t))
+    (eval-code (single-char #\c) (value #t))
+    (interactive (single-char #\i))
+    (help (single-char #\h))
+    (no-warn-cfg (single-char #\w))
+    (version (single-char #\V))))
+
+;;; Options.
+(define %options
+  (getopt-long (program-arguments) %option-spec))
+
+;;; Initialize netlister options.
+
+;;; Using of primitive-eval() here avoids Scheme errors when this
+;;; program is compiled by Guile.
+(primitive-eval '(use-modules (netlist option)))
+
+;;; Actual initialization.
+(init-netlist-options! %options)
 
 ;;; Evaluate Scheme expressions that need to be run before rc
 ;;; files are loaded.
-(for-each (lambda (dir) (add-to-load-path dir))
-          (reverse (netlist-option-ref* 'load-path)))
+(for-each
+ (lambda (dir) (add-to-load-path dir))
+ (reverse (netlist-option-ref/toplevel %options 'load-path '())))
+
+
+;;; Run netlister.
 
 ;;; Using of primitive-eval() here avoids Scheme errors when this
-;;; program is compiled by Guile. See comments above.
-(primitive-eval '(use-modules (geda log)
+;;; program is compiled by Guile. The following modules are
+;;; necessary to actually run the code below.
+(primitive-eval '(use-modules (geda core toplevel)
+                              (geda log)
                               (netlist)))
 
-(with-toplevel (make-toplevel)
+;;; Run netlister in new toplevel environment.
+(%with-toplevel (%make-toplevel)
   (lambda ()
     ;; Init log domain and create log file right away even if
     ;; logging is enabled.

--- a/netlist/scheme/lepton-netlist.in
+++ b/netlist/scheme/lepton-netlist.in
@@ -61,7 +61,7 @@ exec @GUILE@ -s "$0" "$@"
 ;;; files are loaded.
 (for-each
  (lambda (dir) (add-to-load-path dir))
- (reverse (netlist-option-ref/toplevel %options 'load-path '())))
+ (netlist-option-ref/toplevel %options 'load-path '()))
 
 
 ;;; Run netlister.

--- a/netlist/scheme/lepton-netlist.in
+++ b/netlist/scheme/lepton-netlist.in
@@ -25,7 +25,8 @@ exec @GUILE@ -s "$0" "$@"
 
 ;;; Process lepton-netlist options.
 
-(use-modules (ice-9 getopt-long))
+(use-modules (ice-9 getopt-long)
+             (srfi srfi-26))
 
 ;;; Specification.
 (define %option-spec
@@ -59,9 +60,8 @@ exec @GUILE@ -s "$0" "$@"
 
 ;;; Evaluate Scheme expressions that need to be run before rc
 ;;; files are loaded.
-(for-each
- (lambda (dir) (add-to-load-path dir))
- (netlist-option-ref/toplevel %options 'load-path '()))
+(for-each (cut add-to-load-path <>)
+          (netlist-option-ref/toplevel %options 'load-path '()))
 
 
 ;;; Run netlister.

--- a/netlist/scheme/netlist.scm
+++ b/netlist/scheme/netlist.scm
@@ -903,7 +903,7 @@ Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>
   ( unless ( null? opt-code-to-eval )
     ( catch #t
       ( lambda()
-        ( apply eval-string opt-code-to-eval )
+        (for-each eval-string opt-code-to-eval)
       )
       ( lambda( tag . args )
         ( catch-handler tag args )

--- a/netlist/scheme/netlist/option.scm
+++ b/netlist/scheme/netlist/option.scm
@@ -59,9 +59,9 @@
 ;;; repeat on command line, it returns their value as value lists
 ;;; (e.g. "cmd -x a -x b" produces '("a" "b") for the key 'x).
 (define (list-option-ref options key default)
-  (or (filter-map
-       (lambda (x) (and (eq? (car x) key) (cdr x)))
-       options)
+  (or (reverse (filter-map
+                (lambda (x) (and (eq? (car x) key) (cdr x)))
+                options))
       default))
 
 ;;; Custom function to account for list keys.

--- a/netlist/scheme/unit-test.scm
+++ b/netlist/scheme/unit-test.scm
@@ -168,11 +168,11 @@ Actual error:
                 (report (format #f
                                 "ERROR:\n Unexpected exception on loading file ~S:\n~S\n"
                                 name
-                                (display-backtrace
-                                 captured-stack
-                                 (current-output-port)
-                                 6
-                                 5))
+                                (with-output-to-string
+                                  (lambda ()
+                                    (display-backtrace
+                                     captured-stack
+                                     (current-output-port)))))
                         log-port))
               (lambda (key . args)
                 ;; Capture the stack here:

--- a/netlist/scheme/unit-test.scm
+++ b/netlist/scheme/unit-test.scm
@@ -59,6 +59,12 @@
              (ice-9 getopt-long)
              (ice-9 pretty-print))
 
+;;; Initialize liblepton variables and functions.
+(load-extension "../../liblepton/src/liblepton" "libgeda_init")
+(define with-toplevel (@@ (geda core toplevel) %with-toplevel))
+(define make-toplevel (@@ (geda core toplevel) %make-toplevel))
+
+
 (define (report s port)
   (display s port)
   (display s (current-error-port)))
@@ -188,3 +194,9 @@ Actual error:
           (close-port log-port)
           (close-port trs-port))
         (display "Use 'make check' to run tests.\n"))))
+
+;;; Wrapper for the main() function allowing using of liblepton
+;;; variables, procedures, and modules.
+(define (main/with-toplevel args)
+  (with-toplevel (make-toplevel)
+   (lambda () (main args))))

--- a/netlist/scheme/unit-test.scm
+++ b/netlist/scheme/unit-test.scm
@@ -166,7 +166,7 @@ Actual error:
                 (load-from-path name))
               (lambda (key . args) 
                 (report (format #f
-                                "ERROR:\n Unexpected exception on loading file ~S:\n~S\n"
+                                "ERROR:\n Unexpected exception on loading file ~S:\n~A\n"
                                 name
                                 (with-output-to-string
                                   (lambda ()


### PR DESCRIPTION
The branch fixes bugs / adds features as follows:

- There is no more limit for backtrace length if an error occurs,
  the unit-test script uses default stack size which makes
  debugging a bit more convenient.

- Backtrace output is now formatted properly without newline
  mangling.

- Directories containing modules lepton-netlist depends on have
  been added to the unit-test script load-path. Modules depending on
  liblepton and symcheck can now be used with the script.

- Getopt-long functions are no more directly used inside
  lepton-netlist modules, so the modules can now be included in
  other programs having other options, which affects unit testing
  as well, as srfi-64 testing framework uses its own set of
  options.

- `-c` option processing has been fixed.

- Processing of some options yielding lists when several of such
  options are used, no more results in reversed lists.
