### PR TITLE
Add (netlist page) module

### DIFF
--- a/docs/scheme-api/lepton-scheme.texi
+++ b/docs/scheme-api/lepton-scheme.texi
@@ -49,6 +49,7 @@ must provide the URL for the original version.
 * Schematic Document Model::
 * Core API Reference::
 * lepton-schematic API Reference::
+* lepton-netlist API Reference::
 
 * Concept Index::
 * Function Index::
@@ -2767,6 +2768,30 @@ that type. @var{filename} should be the absolute path and filename of
 a local file.  Convenience function which calls
 @code{(show-uri "file://@var{filename}")}
 @end defun
+
+@node lepton-netlist API Reference
+@chapter lepton-netlist API Reference
+
+The Scheme modules and functions described in this chapter are
+available in the Lepton netlister application lepton-netlist.
+
+@menu
+* Files and pages::
+@end menu
+
+@node Files and pages
+@section Files and pages
+
+To use the functions described in this section, you will need to load
+the @code{(netlist page)} module.
+
+@defun filename->page filename [new-page?]
+Return a @code{page} for @var{filename} which must be a string. If
+such a page has been already opened, that page is returned, otherwise
+a new page is created.  If @var{new-page?} is not @samp{#f}, new page
+creation is forced.  Returns the resulting @code{page}.
+@end defun
+
 
 @node Concept Index
 @unnumbered Concept Index

--- a/netlist/scheme/Makefile.am
+++ b/netlist/scheme/Makefile.am
@@ -53,6 +53,7 @@ DIST_SCM = gnet-PCB.scm gnet-allegro.scm gnet-bom.scm gnet-ewnet.scm \
 	   netlist/option.scm \
 	   netlist/package-pin.scm \
 	   netlist/package.scm \
+	   netlist/page.scm \
 	   netlist/partlist.scm \
 	   netlist/partlist/common.scm \
 	   netlist/pin-net.scm \

--- a/netlist/scheme/netlist/page.scm
+++ b/netlist/scheme/netlist/page.scm
@@ -1,0 +1,60 @@
+;;; Lepton EDA netlister
+;;; Copyright (C) 2016-2017 gEDA Contributors
+;;; Copyright (C) 2017-2019 Lepton EDA Contributors
+;;;
+;;; This program is free software; you can redistribute it and/or modify
+;;; it under the terms of the GNU General Public License as published by
+;;; the Free Software Foundation; either version 2 of the License, or
+;;; (at your option) any later version.
+;;;
+;;; This program is distributed in the hope that it will be useful,
+;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;; GNU General Public License for more details.
+;;;
+;;; You should have received a copy of the GNU General Public License
+;;; along with this program; if not, write to the Free Software
+;;; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+;;; MA 02111-1301 USA.
+
+(define-module (netlist page)
+  ; Import C procedures and variables
+  #:use-module (netlist core gettext)
+
+  #:use-module ((ice-9 rdelim)
+                #:select (read-string)
+                #:prefix rdelim:)
+  #:use-module (geda log)
+  #:use-module (geda page)
+  #:use-module (netlist option)
+
+  #:export (filename->page))
+
+
+(define quiet-mode (netlist-option-ref 'quiet))
+
+;;; Reads file FILENAME and outputs a page with the same name.
+(define (file-contents->page filename)
+  (with-input-from-file filename
+    (lambda ()
+      (when (not quiet-mode)
+        (log! 'message (_ "Loading schematic ~S\n") filename))
+      (string->page filename (rdelim:read-string)))))
+
+;;; Returns an opened page from PAGES by FILENAME. If no
+;;; corresponding page found, returns #f.
+(define (page-by-filename filename pages)
+  (and (not (null? pages))
+       (let ((page (car pages)))
+         (if (string= filename (page-filename page))
+             page
+             (page-by-filename filename (cdr pages))))))
+
+(define* (filename->page filename #:optional new-page?)
+  "Given FILENAME, returns an opened page for it, or a new page if
+none exists. Optional argument NEW-PAGE? can be used to force
+creation of a new page for given filename."
+  (if new-page?
+      (file-contents->page filename)
+      (or (page-by-filename filename (active-pages))
+          (file-contents->page filename))))

--- a/netlist/scheme/netlist/schematic.scm
+++ b/netlist/scheme/netlist/schematic.scm
@@ -25,6 +25,7 @@
   #:use-module (srfi srfi-9 gnu)
   #:use-module (netlist attrib compare)
   #:use-module (netlist config)
+  #:use-module (netlist page)
   #:use-module (netlist sort)
   #:use-module (netlist traverse)
   #:use-module (netlist package)
@@ -211,7 +212,7 @@ must be a list of pages."
          (not (schematic-component-nc? x))))
 
   (let* ((id (next-schematic-id))
-         (toplevel-pages (map file->page files))
+         (toplevel-pages (map filename->page files))
          (toplevel-attribs (get-toplevel-attributes toplevel-pages))
          (toplevel-netlist (traverse toplevel-pages netlist-mode))
          (full-netlist (map compat-refdes toplevel-netlist))

--- a/netlist/scheme/netlist/traverse.scm
+++ b/netlist/scheme/netlist/traverse.scm
@@ -23,9 +23,6 @@
   #:use-module (netlist core gettext)
 
   #:use-module ((ice-9 match))
-  #:use-module ((ice-9 rdelim)
-                #:select (read-string)
-                #:prefix rdelim:)
   #:use-module (srfi srfi-1)
   #:use-module (srfi srfi-26)
   #:use-module (geda attrib)
@@ -39,14 +36,14 @@
   #:use-module (netlist net)
   #:use-module (netlist option)
   #:use-module (netlist package-pin)
+  #:use-module (netlist page)
   #:use-module (netlist pin-net)
   #:use-module (netlist schematic-component)
   #:use-module (netlist schematic-connection)
   #:use-module (netlist verbose)
   #:use-module (symbol check net-attrib)
 
-  #:export (traverse
-            file->page))
+  #:export (traverse))
 
 
 ;;; Tracks which objects have been visited so far, and how many
@@ -341,21 +338,10 @@
                   (non-null* (assq-ref inherited-attribs 'source)))))
          (and=> sources comma-separated->list))))
 
-(define quiet-mode (netlist-option-ref 'quiet))
-
-;;; Reads file NAME and outputs a page named NAME
-(define (file->page name)
-  (with-input-from-file name
-    (lambda ()
-      (when (not quiet-mode)
-        (log! 'message (_ "Loading schematic ~S\n") name))
-      (string->page name (rdelim:read-string)))))
-
-
 (define (hierarchy-down-schematic name)
   (let ((filename (get-source-library-file name)))
     (if filename
-        (file->page filename)
+        (filename->page filename 'new-page)
         (log! 'error (_ "Failed to load subcircuit ~S.") name))))
 
 (define (traverse-page page hierarchy-tag netlist-mode)


### PR DESCRIPTION
The new module contains now an only procedure, `filename->page`, which is an improved version of undocumented `file->page`. I think the new name more accurately describes the procedure. The procedure functionality is extended so it can now return an already opened page for a filename, as well as a new page, if the user so desires.