### PR TITLE
docs/wiki: Allow out-of-source build and install

### DIFF
--- a/docs/wiki/Makefile.am
+++ b/docs/wiki/Makefile.am
@@ -4,7 +4,7 @@ wikidir = $(docdir)/wiki
 dist-hook:
 	@for dir in $$(cd $(srcdir) && find . -type d -print | sed -e's:^\./::' ); do \
 	  $(MKDIR_P) $(distdir)/$$dir; \
-	  list=`(cd $(srcdir)/$$dir && find . -maxdepth 1 -type f \! -name 'Makefile*' \! -name '.gitignore' -print | sed -e 's:^\./::')`; \
+	  list=`(cd $(srcdir)/$$dir && find . -maxdepth 1 \( -type f -o -type l \) \! -name 'Makefile*' \! -name '.gitignore' -print | sed -e 's:^\./::')`; \
 	  for file in $$list; do \
 	    cp -p $(srcdir)/$$dir/$$file $(distdir)/$$dir || exit $$?; \
 	  done; \
@@ -15,7 +15,7 @@ install-data-local:
 	@for dir in $$(cd $(srcdir) && find . -type d -print | sed -e's:^\./::' ); do \
 	  d="$(DESTDIR)$(wikidir)/$$dir"; \
 	  $(MKDIR_P) $$d; \
-	  list=`(cd $(srcdir)/$$dir && find . -maxdepth 1 -type f \! -name 'Makefile*' \! -name '.gitignore' -print | sed -e 's:^\./::')`; \
+	  list=`(cd $(srcdir)/$$dir && find . -maxdepth 1 \( -type f -o -type l \) \! -name 'Makefile*' \! -name '.gitignore' -print | sed -e 's:^\./::')`; \
 	  if test -n "$$list"; then \
 	    echo " ( cd $(srcdir)/$$dir && $(INSTALL_DATA)" $$list "'$$d' )"; \
 	    (cd $(srcdir)/$$dir && $(INSTALL_DATA) $$list "$$d") || exit $$?; \
@@ -26,7 +26,7 @@ install-data-local:
 uninstall-local:
 	@for dir in $$(cd $(srcdir) && find . -type d -print | sed -e's:^\./::' ); do \
 	  d="$(DESTDIR)$(wikidir)/$$dir"; \
-	  list=`(cd $(srcdir)/$$dir && find . -maxdepth 1 -type f \! -name 'Makefile*' \! -name '.gitignore' -print | sed -e 's:^\./::')`; \
+	  list=`(cd $(srcdir)/$$dir && find . -maxdepth 1 \( -type f -o -type l \) \! -name 'Makefile*' \! -name '.gitignore' -print | sed -e 's:^\./::')`; \
 	  if test -n "$$list"; then \
 	    echo " ( cd '$$d' && rm -f" $$list ")"; \
 	    (cd "$$d" && rm -f $$list) || exit $$?; \


### PR DESCRIPTION
Lepton EDA can be built out-of-source without
problems, but 'make install' does not install
files from the docs/wiki/ subdir, because it's
assumed that it contains regular files (-type f
switch for the 'find' command). When building
out of the source tree, they most likely will be
symbolic links.