### PR TITLE
Prevent unintentional updates of PO files

### DIFF
--- a/schematic/po/.gitignore
+++ b/schematic/po/.gitignore
@@ -9,7 +9,6 @@ POTFILES
 *.sin
 Rules-quot
 Makevars.template
-lepton-schematic.pot
 stamp-po
 stamp-it
 stamp-i18n

--- a/schematic/po/Makevars
+++ b/schematic/po/Makevars
@@ -10,6 +10,10 @@ top_builddir = ../..
 # These options get passed to xgettext.
 XGETTEXT_OPTIONS = --keyword=_ --keyword=N_ --from-code=UTF-8
 
+MSGMERGE_OPTIONS = --no-location
+
+PO_DEPENDS_ON_POT = no
+
 # This is the copyright holder that gets inserted into the header of the
 # $(DOMAIN).pot file.  Set this to the copyright holder of the surrounding
 # package.  (Note that the msgstr strings, extracted from the package's

--- a/schematic/po/af.po
+++ b/schematic/po/af.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda-gschem\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-15 15:13+0300\n"
+"POT-Creation-Date: 2019-02-22 14:08+0300\n"
 "PO-Revision-Date: 2010-02-14 01:03+0000\n"
 "Last-Translator: Bernd Jendrissek <Unknown>\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -17,24 +17,20 @@ msgstr ""
 "X-Launchpad-Export-Date: 2010-02-14 12:56+0000\n"
 "X-Generator: Launchpad (build Unknown)\n"
 
-#: schematic/src/a_zoom.c:155
 #, fuzzy
 msgid "Zoom too small!  Cannot zoom further."
 msgstr "Zoem is te klein!  Kan nie verder zoem nie.\n"
 
-#: schematic/src/color_edit_widget.c:399
 #, fuzzy, c-format
 msgid ""
 "Could not save file [%s]:\n"
 "%s"
 msgstr "Kon nie lêer %s oopmaak nie\n"
 
-#: schematic/src/color_edit_widget.c:434
 #, fuzzy
 msgid "Save Color Scheme As..."
 msgstr "Kleurbewerking"
 
-#: schematic/src/color_edit_widget.c:482 schematic/src/x_fileselect.c:292
 #, c-format
 msgid ""
 "The selected file `%1$s' already exists.\n"
@@ -42,179 +38,141 @@ msgid ""
 "Would you like to overwrite it?"
 msgstr ""
 
-#: schematic/src/color_edit_widget.c:486 schematic/src/x_fileselect.c:295
 msgid "Overwrite file?"
 msgstr "Vervang lêer?"
 
-#: schematic/src/font_select_widget.c:211
 msgid "_Apply"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:215
 msgid "Sa_ve..."
 msgstr ""
 
-#: schematic/src/font_select_widget.c:278
 #, c-format
 msgid "<b>Current:</b> %s"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:453
 msgid "Save configuration"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:461
 #, fuzzy
 msgid "Save settings to:"
 msgstr "Instellinge"
 
-#: schematic/src/font_select_widget.c:465
 msgid "Local configuration file (in current directory)"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:467
 msgid "User configuration file (geda-user.conf)"
 msgstr ""
 
-#: schematic/src/g_attrib.c:90
 msgid "Object ~A is not included in the current gschem page."
 msgstr ""
 
-#: schematic/src/g_attrib.c:110
 msgid "Invalid text name/value visibility ~A."
 msgstr ""
 
-#: schematic/src/g_rc.c:107
 #, fuzzy, c-format
 msgid "You are running gEDA/gaf version [%1$s%2$s.%3$s],\n"
 msgstr "gEDA/gschem uitgawe %s%s.%s\n"
 
-#: schematic/src/g_rc.c:111
 #, c-format
 msgid ""
 "but you have a version [%1$s] gschemrc file:\n"
 "[%2$s]\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:114
 #, c-format
 msgid "Please be sure that you have the latest rc file.\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:240
 #, fuzzy, c-format
 msgid "Invalid size [%1$d] passed to text-size\n"
 msgstr "Ongeldige grootte [%d] gegee aan text-size\n"
 
-#: schematic/src/g_rc.c:283
 #, fuzzy, c-format
 msgid "Invalid size [%1$d] passed to snap-size\n"
 msgstr "Ongeldige grootte [%d] aan snap-size gegee\n"
 
-#: schematic/src/g_rc.c:620
 #, fuzzy, c-format
 msgid "Invalid num levels [%1$d] passed to undo-levels\n"
 msgstr "Ongeldige getal vlakke [%d] gegee aan undo-levels\n"
 
-#: schematic/src/g_rc.c:831
 #, fuzzy, c-format
 msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
 msgstr "Ongeldige grootte [%d] gegee aan bus-ripper-size\n"
 
-#: schematic/src/g_rc.c:931
 #, fuzzy, c-format
 msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
 msgstr "Ongeldige puntgrootte [%d] gegee aan dots-grid-dot-size\n"
 
-#: schematic/src/g_rc.c:972
 #, fuzzy, c-format
 msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
 msgstr "Ongeldige puntgrootte [%d] gegee aan dots-grid-dot-size\n"
 
-#: schematic/src/g_rc.c:998
 #, fuzzy, c-format
 msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
 msgstr "Ongeldige puntgrootte [%d] gegee aan dots-grid-dot-size\n"
 
-#: schematic/src/g_rc.c:1023
 #, fuzzy, c-format
 msgid "Invalid offset [%1$d] passed to add-attribute-offset\n"
 msgstr "Ongeldige verkuiwing [%d] gegee aan add-attribute-offset\n"
 
-#: schematic/src/g_rc.c:1047
 #, fuzzy, c-format
 msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
 msgstr "Ongeldige hoeveelheid sekondes [%d] gegee aan auto-save-interval\n"
 
-#: schematic/src/g_rc.c:1071
 #, fuzzy, c-format
 msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
 msgstr "Ongeldige versterking [%d] gegee aan mousepan-gain\n"
 
-#: schematic/src/g_rc.c:1094
 #, fuzzy, c-format
 msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
 msgstr "Ongeldige versterking [%d] gegee aan keyboardpan-gain\n"
 
-#: schematic/src/g_rc.c:1118
 #, fuzzy, c-format
 msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
 msgstr "Ongeldige hoeveelheid sekondes [%d] gegee aan auto-save-interval\n"
 
-#: schematic/src/g_rc.c:1144
 #, fuzzy, c-format
 msgid "Invalid gain [%1$d] passed to zoom-gain\n"
 msgstr "Ongeldige versterking [%d] gegee aan zoom-gain\n"
 
-#: schematic/src/g_rc.c:1169
 #, fuzzy, c-format
 msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
 msgstr "Ongeldige hoeveelheid sekondes [%d] gegee aan auto-save-interval\n"
 
-#: schematic/src/g_select.c:78 schematic/src/g_select.c:115
-#: schematic/src/g_select.c:151
 msgid "Object ~A is not directly included in a page."
 msgstr ""
 
-#: schematic/src/g_util.c:54
 msgid "Could not launch URI ~S: ~A"
 msgstr ""
 
-#: schematic/src/g_window.c:139
 msgid "Found invalid gschem window smob ~S"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:156
 #, fuzzy, c-format
 msgid "Lepton EDA/lepton-schematic version %1$s%2$s.%3$s git: %4$.7s"
 msgstr "gEDA/gschem uitgawe %s%s.%s\n"
 
-#: schematic/src/lepton-schematic.c:163
 #, c-format
 msgid "This is the MINGW32 port.\n"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:167
 #, c-format
 msgid "Current locale settings: %1$s\n"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:201
 #, fuzzy, c-format
 msgid "Couldn't find init scm file [%1$s]"
 msgstr "Het misluk of scm-aanvangslêer [%s] te lees\n"
 
-#: schematic/src/lepton-schematic.c:206
 #, fuzzy, c-format
 msgid "Read init scm file [%1$s]"
 msgstr "Het scm-aanvangslêer [%s] gelees\n"
 
-#: schematic/src/lepton-schematic.c:210
 #, fuzzy, c-format
 msgid "Failed to read init scm file [%1$s]"
 msgstr "Het misluk of scm-aanvangslêer [%s] te lees\n"
 
-#: schematic/src/lepton-schematic.c:290
 #, c-format
 msgid ""
 "ERROR: Failed to load or evaluate startup script.\n"
@@ -222,140 +180,108 @@ msgid ""
 "The lepton-schematic log may contain more information.\n"
 msgstr ""
 
-#: schematic/src/gschem_about_dialog.c:51
 #, c-format
 msgid "%s (git: %.7s)"
 msgstr ""
 
-#: schematic/src/gschem_about_dialog.c:75
 #, fuzzy
 msgid "Lepton Electronic Design Automation"
 msgstr "gEDA: GPL Elektroniese Ontwerp Outomatisering"
 
-#: schematic/src/gschem_about_dialog.c:83
 msgid ""
 "Copyright © 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright © 2017-2018 Lepton Developers.\n"
-"See AUTHORS and ChangeLog files for details."
+"Copyright © 2017-2019 Lepton Developers.\n"
+"See AUTHORS, ChangeLog files and consult 'git log' history for details."
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:69
 msgid "Upper Left"
 msgstr "Links Bo"
 
-#: schematic/src/gschem_alignment_combo.c:71
 msgid "Upper Middle"
 msgstr "Middel Bo"
 
-#: schematic/src/gschem_alignment_combo.c:73
 #, fuzzy
 msgid "Upper Right"
 msgstr "Regs Onder"
 
-#: schematic/src/gschem_alignment_combo.c:78
 msgid "Middle Left"
 msgstr "Middel Links"
 
-#: schematic/src/gschem_alignment_combo.c:80
 msgid "Middle Middle"
 msgstr "Middel Middel"
 
-#: schematic/src/gschem_alignment_combo.c:82
 msgid "Middle Right"
 msgstr "Middel Regs"
 
-#: schematic/src/gschem_alignment_combo.c:87
 msgid "Lower Left"
 msgstr "Links Onder"
 
-#: schematic/src/gschem_alignment_combo.c:89
 msgid "Lower Middle"
 msgstr "Middel Onder"
 
-#: schematic/src/gschem_alignment_combo.c:91
 msgid "Lower Right"
 msgstr "Regs Onder"
 
-#: schematic/src/gschem_arc_dialog.c:104
 msgid "Arc Params"
 msgstr "Boogparameters"
 
-#: schematic/src/gschem_arc_dialog.c:140
 msgid "Arc _Radius:"
 msgstr ""
 
-#: schematic/src/gschem_arc_dialog.c:141
 #, fuzzy
 msgid "Start _Angle:"
 msgstr "Beginhoek:"
 
-#: schematic/src/gschem_arc_dialog.c:142
 #, fuzzy
 msgid "_Degrees of Sweep:"
 msgstr "Grade van Kromming:"
 
-#: schematic/src/gschem_bottom_widget.c:504
 msgid "Left mouse button"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:508
 #, fuzzy
 msgid "Middle mouse button"
 msgstr "Middel Links"
 
-#: schematic/src/gschem_bottom_widget.c:512
 msgid "Right mouse button"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:595
 msgid "(Snap size, Grid size)"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:603
 #, fuzzy
 msgid "Net rubber band mode"
 msgstr "Rubberband AAN\n"
 
-#: schematic/src/gschem_bottom_widget.c:614
 #, fuzzy
 msgid "Magnetic net mode"
 msgstr "Netmodus"
 
-#: schematic/src/gschem_bottom_widget.c:622
 #, fuzzy
 msgid "Current action mode"
 msgstr "Lopende bladsy"
 
-#: schematic/src/gschem_bottom_widget.c:935
-#: schematic/src/gschem_bottom_widget.c:951
 msgid "OFF"
 msgstr "AF"
 
-#: schematic/src/gschem_bottom_widget.c:954
 msgid "NONE"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:960
 #, fuzzy, c-format
 msgid "Grid(%1$s, %2$s)"
 msgstr "Rooster(%s, %s)"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:350
-#: schematic/src/x_compselect.c:1236 schematic/src/x_multiattrib.c:2068
 msgid "Name"
 msgstr "Naam"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:372
 msgid "S_elect the schematics you want to save:"
 msgstr "Kies die stroombaandiagramme wat jy wil bewaar:"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:467
 #, fuzzy, c-format
 msgid "Save the changes to schematic \"%1$s\" before closing?"
 msgstr ""
 "Wil jy veranderinge aan stroombaandiagram \"%s\" bewaar voor jy afsluit?"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:473
 #, fuzzy, c-format
 msgid ""
 "There are %1$d schematics with unsaved changes. Save changes before closing?"
@@ -363,584 +289,431 @@ msgstr ""
 "Daar is %d stroombaandiagramme met onbewaarde veranderinge.  Wil jy die "
 "veranderinge bewaar voor jy afsluit?"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:502
 msgid "If you don't save, all your changes will be permanently lost."
 msgstr "As jy nie bewaar nie, sal al jou veranderinge permanent verloregaan."
 
-#: schematic/src/gschem_close_confirmation_dialog.c:522
 #, fuzzy
 msgid "Close _without saving"
 msgstr "Sluit sonder om te bewaar"
 
 # FIXME: May need to have a deëlteken on second 'o'.
-#: schematic/src/gschem_coord_dialog.c:86
 msgid "Coords"
 msgstr "Koordinate"
 
-#: schematic/src/gschem_coord_dialog.c:106
 msgid "Screen"
 msgstr "Skerm"
 
-#: schematic/src/gschem_coord_dialog.c:115
 msgid "World"
 msgstr "Wêreld"
 
-#: schematic/src/gschem_find_text_state.c:809 schematic/src/x_pagesel.c:432
 msgid "Filename"
 msgstr "Lêernaam"
 
-#: schematic/src/gschem_find_text_state.c:821 schematic/src/i_callbacks.c:1970
-#: schematic/src/x_colorcb.c:154 schematic/src/x_widgets.c:179
-#: schematic/src/x_window.c:1226 schematic/src/x_window.c:1440
 msgid "Text"
 msgstr "Teks"
 
-#: schematic/src/gschem_find_text_widget.c:427
 msgid "descend into hierarchy"
 msgstr "daal in hierargie af"
 
-#: schematic/src/gschem_find_text_widget.c:435
 #, fuzzy
 msgid "Find"
 msgstr "Vind Teks"
 
-#: schematic/src/gschem_find_text_widget.c:557
 #, fuzzy
 msgid "Find Text:"
 msgstr "Vind Teks"
 
-#: schematic/src/gschem_find_text_widget.c:564
 msgid "Find Pattern:"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:571
 #, fuzzy
 msgid "Find Regex:"
 msgstr "Vind Teks"
 
-#: schematic/src/gschem_find_text_widget.c:578
 msgid "Check symbol:"
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:200
 msgid "Hotkeys"
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:229
 msgid ""
 "Start typing action name or keystroke to filter the list.\n"
 "Type hotkeys as they are displayed in \"Keystroke(s)\" column."
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:233 schematic/src/x_compselect.c:1124
 #, fuzzy
 msgid "_Filter:"
 msgstr "Deursyfer:"
 
-#: schematic/src/gschem_hotkey_dialog.c:259 schematic/src/i_basic.c:280
 msgid "Action"
 msgstr "Handeling"
 
-#: schematic/src/gschem_hotkey_dialog.c:277
 msgid "Keystroke(s)"
 msgstr "Sleutelslae"
 
-#: schematic/src/gschem_log_widget.c:177
 msgid "** Invalid UTF-8 in log message. See stderr or gschem.log.\n"
 msgstr ""
 
-#: schematic/src/gschem_log_widget.c:434
 #, fuzzy
 msgid "Clear log window?"
 msgstr "Sluit Venster\n"
 
-#: schematic/src/gschem_log_widget.c:477
 #, fuzzy
 msgid "Clear Log _Window"
 msgstr "Nuwe Venster"
 
-#: schematic/src/gschem_macro_widget.c:231
 msgid "Macro:"
 msgstr ""
 
-#: schematic/src/gschem_macro_widget.c:387
 msgid "Evaluate"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:172
 #, fuzzy
 msgid "_Fill Type:"
 msgstr "Vultipe:"
 
-#: schematic/src/gschem_object_properties_widget.c:173
 #, fuzzy
 msgid "Lin_e Width:"
 msgstr "Lynwydte:"
 
-#: schematic/src/gschem_object_properties_widget.c:174
 #, fuzzy
 msgid "Angle _1:"
 msgstr "Hoek 1:"
 
-#: schematic/src/gschem_object_properties_widget.c:175
 #, fuzzy
 msgid "P_itch 1:"
 msgstr "Steek 1:"
 
-#: schematic/src/gschem_object_properties_widget.c:176
 #, fuzzy
 msgid "Angle _2:"
 msgstr "Hoek 2:"
 
-#: schematic/src/gschem_object_properties_widget.c:177
 #, fuzzy
 msgid "Pitc_h 2:"
 msgstr "Steek 2:"
 
-#: schematic/src/gschem_object_properties_widget.c:237
 #, fuzzy
 msgid "<b>Fill Properties</b>"
 msgstr "<b>Tekseienskappe</b>"
 
-#: schematic/src/gschem_object_properties_widget.c:255
-#: schematic/src/gschem_text_properties_widget.c:258
-#: schematic/src/x_newtext.c:271
 #, fuzzy
 msgid "Colo_r:"
 msgstr "Kleur:"
 
-#: schematic/src/gschem_object_properties_widget.c:266
 #, fuzzy
 msgid "<b>General Properties</b>"
 msgstr "<b>Tekseienskappe</b>"
 
-#: schematic/src/gschem_object_properties_widget.c:284
 #, fuzzy
 msgid "_Type:"
 msgstr "Styl:"
 
-#: schematic/src/gschem_object_properties_widget.c:285
 #, fuzzy
 msgid "_Width:"
 msgstr "Wydte:"
 
-#: schematic/src/gschem_object_properties_widget.c:286
 #, fuzzy
 msgid "Dash _Length:"
 msgstr "Streeplengte"
 
-#: schematic/src/gschem_object_properties_widget.c:287
 #, fuzzy
 msgid "Dash _Space:"
 msgstr "Streepspasie"
 
-#: schematic/src/gschem_object_properties_widget.c:288
 msgid "C_ap style:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:333
 #, fuzzy
 msgid "<b>Line Properties</b>"
 msgstr "<b>Tekseienskappe</b>"
 
-#: schematic/src/gschem_object_properties_widget.c:351
 #, fuzzy
 msgid "_Pin Type:"
 msgstr "Vultipe"
 
-#: schematic/src/gschem_object_properties_widget.c:362
 #, fuzzy
 msgid "<b>Pin Properties</b>"
 msgstr "<b>Tekseienskappe</b>"
 
-#: schematic/src/gschem_options_widget.c:217
 msgid "_Off"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:220
 msgid "_Dots"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:223
 msgid "M_esh"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:245
 #, fuzzy
 msgid "Net R_ubber Band Mode:"
 msgstr "Rubberband AAN\n"
 
-#: schematic/src/gschem_options_widget.c:246
 #, fuzzy
 msgid "_Magnetic Net Mode:"
 msgstr "Netmodus"
 
-#: schematic/src/gschem_options_widget.c:250
-#: schematic/src/gschem_options_widget.c:251
 msgid "Enabled"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:265
 #, fuzzy
 msgid "<b>Net Options</b>"
 msgstr "<b>Opsies</b>"
 
-#: schematic/src/gschem_options_widget.c:282
 #, fuzzy
 msgid "Grid Mode:"
 msgstr "Boogmodus"
 
-#: schematic/src/gschem_options_widget.c:283
 #, fuzzy
 msgid "Snap Mode:"
 msgstr "Aansigskuifmodus"
 
-#: schematic/src/gschem_options_widget.c:284
 #, fuzzy
 msgid "_Snap Size:"
 msgstr "Grootte:"
 
-#: schematic/src/gschem_options_widget.c:301
 #, fuzzy
 msgid "<b>Snap Options</b>"
 msgstr "<b>Opsies</b>"
 
-#: schematic/src/gschem_options_widget.c:340
 msgid "O_ff"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:343
 #, fuzzy
 msgid "_Grid"
 msgstr "Rooster AAN\n"
 
-#: schematic/src/gschem_options_widget.c:346
 msgid "_Resnap"
 msgstr ""
 
-#: schematic/src/gschem_pin_type_combo.c:73
 msgid "Net pin"
 msgstr ""
 
-#: schematic/src/gschem_pin_type_combo.c:80
 msgid "Bus pin (graphical)"
 msgstr ""
 
-#: schematic/src/gschem_preview.c:195
 msgid "Preview Buffer"
 msgstr ""
 
-#: schematic/src/gschem_show_hide_text_widget.c:148
-#: schematic/src/x_window.c:1268
 #, fuzzy
 msgid "Hide"
 msgstr "Verskuil Teks"
 
-#: schematic/src/gschem_show_hide_text_widget.c:157
-#: schematic/src/x_window.c:1269
 msgid "Hide text starting with:"
 msgstr "Verskuil teks beginnende met:"
 
-#: schematic/src/gschem_slot_edit_dialog.c:91
 msgid "Edit slot number"
 msgstr "Bewerk gleufnommer"
 
-#: schematic/src/gschem_slot_edit_dialog.c:121
 msgid "Number of Slots:"
 msgstr ""
 
-#: schematic/src/gschem_slot_edit_dialog.c:122
 #, fuzzy
 msgid "Slot Number:"
 msgstr "Bewerk gleufnommer:"
 
-#: schematic/src/gschem_text_properties_widget.c:240
-#: schematic/src/x_newtext.c:265
 msgid "<b>Text Content</b>"
 msgstr "<b>Teksinhoud</b>"
 
-#: schematic/src/gschem_text_properties_widget.c:259
-#: schematic/src/x_newtext.c:291
 #, fuzzy
 msgid "_Size:"
 msgstr "Grootte:"
 
-#: schematic/src/gschem_text_properties_widget.c:260
-#: schematic/src/x_newtext.c:310
 #, fuzzy
 msgid "Ali_gnment:"
 msgstr "Sporing:"
 
-#: schematic/src/gschem_text_properties_widget.c:261
-#: schematic/src/x_newtext.c:330
 #, fuzzy
 msgid "Ro_tation:"
 msgstr "Orientasie"
 
-#: schematic/src/gschem_text_properties_widget.c:294
-#: schematic/src/x_newtext.c:253
 msgid "<b>Text Properties</b>"
 msgstr "<b>Tekseienskappe</b>"
 
-#: schematic/src/gschem_translate_widget.c:238
 #, fuzzy
 msgid "Coordinate:"
 msgstr "Huidige Venster"
 
-#: schematic/src/gschem_translate_widget.c:405 schematic/src/i_callbacks.c:800
 msgid "Translate"
 msgstr "Verskuif"
 
-#: schematic/src/i_basic.c:64 schematic/src/x_window.c:1369
-#: schematic/scheme/conf/schematic/menu.scm:59
-#: schematic/scheme/gschem/builtins.scm:99
 msgid "Select Mode"
 msgstr "Uitsoekmodus"
 
-#: schematic/src/i_basic.c:65
 #, fuzzy
 msgid "Select Box Mode"
 msgstr "Uitsoekmodus"
 
-#: schematic/src/i_basic.c:66
 msgid "Text Mode"
 msgstr "Teksmodues"
 
-#: schematic/src/i_basic.c:67
 msgid "Pan Mode"
 msgstr "Aansigskuifmodus"
 
-#: schematic/src/i_basic.c:70
 #, c-format
 msgid "Paste %d Mode"
 msgstr "Plak %d Modus"
 
-#: schematic/src/i_basic.c:74
 msgid "Magnetic Net Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:76
 msgid "Net Mode"
 msgstr "Netmodus"
 
-#: schematic/src/i_basic.c:77
 msgid "Arc Mode"
 msgstr "Boogmodus"
 
-#: schematic/src/i_basic.c:78
 msgid "Box Mode"
 msgstr "Reghoekmodus"
 
-#: schematic/src/i_basic.c:79
 msgid "Bus Mode"
 msgstr "Busmodus"
 
-#: schematic/src/i_basic.c:80
 msgid "Circle Mode"
 msgstr "Sirkelmodus"
 
-#: schematic/src/i_basic.c:81
 msgid "Component Mode"
 msgstr "Komponentmodus"
 
-#: schematic/src/i_basic.c:82 schematic/scheme/conf/schematic/menu.scm:62
-#: schematic/scheme/gschem/builtins.scm:114
 msgid "Copy Mode"
 msgstr "Kopieermodus"
 
-#: schematic/src/i_basic.c:83 schematic/scheme/conf/schematic/menu.scm:63
-#: schematic/scheme/gschem/builtins.scm:117
 msgid "Multiple Copy Mode"
 msgstr "Meervoudige Kopieermodus"
 
-#: schematic/src/i_basic.c:84
 msgid "Line Mode"
 msgstr "Lynmodus"
 
-#: schematic/src/i_basic.c:85 schematic/scheme/conf/schematic/menu.scm:66
-#: schematic/scheme/gschem/builtins.scm:123
 msgid "Mirror Mode"
 msgstr "Weerkaatsmodus"
 
-#: schematic/src/i_basic.c:86 schematic/scheme/conf/schematic/menu.scm:64
-#: schematic/scheme/gschem/builtins.scm:111
 msgid "Move Mode"
 msgstr "Skuifmodus"
 
-#: schematic/src/i_basic.c:87
 #, fuzzy
 msgid "Path Mode"
 msgstr "Aansigskuifmodus"
 
-#: schematic/src/i_basic.c:88
 msgid "Picture Mode"
 msgstr "Afbeeldingmodus"
 
-#: schematic/src/i_basic.c:89
 msgid "Pin Mode"
 msgstr "Penmodus"
 
-#: schematic/src/i_basic.c:90 schematic/scheme/gschem/builtins.scm:120
 msgid "Rotate Mode"
 msgstr "Roteermodus"
 
-#: schematic/src/i_basic.c:91
 #, fuzzy
 msgid "Modify Mode"
 msgstr "Kopieermodus"
 
-#: schematic/src/i_basic.c:92 schematic/src/x_menus.c:49
-#: schematic/scheme/gschem/builtins.scm:204
 msgid "Zoom Box"
 msgstr "Zoem Reghoek"
 
-#: schematic/src/i_basic.c:121
 msgid "Show Hidden"
 msgstr "Toon Verskuilde"
 
-#: schematic/src/i_basic.c:124
 msgid "Snap Off"
 msgstr ""
 
-#: schematic/src/i_basic.c:126
 msgid "Resnap Active"
 msgstr ""
 
-#: schematic/src/i_basic.c:288 schematic/src/x_colorcb.c:159
 msgid "Stroke"
 msgstr "Wyserslag"
 
-#: schematic/src/i_basic.c:296 schematic/src/i_basic.c:330
-#: schematic/src/x_window.c:1361
 msgid "none"
 msgstr "geen"
 
-#: schematic/src/i_basic.c:304
 msgid "Repeat/"
 msgstr "Herhaal/"
 
-#: schematic/src/i_basic.c:315
 msgid "Repeat/none"
 msgstr "Herhaal/geen"
 
-#: schematic/src/i_basic.c:323 schematic/src/i_callbacks.c:1239
-#: schematic/scheme/gschem/builtins.scm:189
 msgid "Pan"
 msgstr "Skuif Aansig"
 
-#: schematic/src/i_callbacks.c:74
 #, fuzzy, c-format
 msgid "New page created [%1$s]"
 msgstr "Nuwe bladsy geskep [%s]\n"
 
-#: schematic/src/i_callbacks.c:108
 #, fuzzy, c-format
 msgid "New Window created [%1$s]"
 msgstr "Nuwe Venster geskep [%s]\n"
 
-#: schematic/src/i_callbacks.c:245
 msgid "Failed to Save All"
 msgstr "Misluk om alles te bewaar"
 
-#: schematic/src/i_callbacks.c:247
 msgid "Saved All"
 msgstr "Alles Bewaar"
 
-#: schematic/src/i_callbacks.c:308
 #, fuzzy
 msgid "Closing Window"
 msgstr "Sluit Venster\n"
 
-#: schematic/src/i_callbacks.c:505 schematic/src/x_menus.c:55
-#: schematic/scheme/gschem/builtins.scm:168
 msgid "Copy"
 msgstr "Kopieer"
 
-#: schematic/src/i_callbacks.c:514 schematic/src/i_callbacks.c:539
-#: schematic/src/i_callbacks.c:564
 msgid "Select objs first"
 msgstr "Kies eers voorwerpe"
 
-#: schematic/src/i_callbacks.c:530
 msgid "Multiple Copy"
 msgstr "Veelvoudige Kopieer"
 
-#: schematic/src/i_callbacks.c:555 schematic/src/x_menus.c:56
 msgid "Move"
 msgstr "Beweeg"
 
-#: schematic/src/i_callbacks.c:579 schematic/src/x_menus.c:57
-#: schematic/src/x_multiattrib.c:1656 schematic/scheme/gschem/builtins.scm:108
 msgid "Delete"
 msgstr "Verwyder"
 
-#: schematic/src/i_callbacks.c:603
 msgid "Edit"
 msgstr "Bewerk"
 
-#: schematic/src/i_callbacks.c:618 schematic/scheme/gschem/builtins.scm:129
 msgid "Edit Text"
 msgstr "Bewerk Teks"
 
-#: schematic/src/i_callbacks.c:637
 msgid "Slot"
 msgstr "Gleuf"
 
-#: schematic/src/i_callbacks.c:688 schematic/src/i_callbacks.c:698
 msgid "Rotate"
 msgstr "Roteer"
 
-#: schematic/src/i_callbacks.c:736 schematic/src/i_callbacks.c:746
 msgid "Mirror"
 msgstr "Weerkaats"
 
-#: schematic/src/i_callbacks.c:763 schematic/src/x_colorcb.c:160
-#: schematic/scheme/conf/schematic/menu.scm:73
-#: schematic/scheme/gschem/builtins.scm:141
 msgid "Lock"
 msgstr "Sluit"
 
-#: schematic/src/i_callbacks.c:781 schematic/scheme/conf/schematic/menu.scm:74
-#: schematic/scheme/gschem/builtins.scm:144
 msgid "Unlock"
 msgstr "Ontsluit"
 
-#: schematic/src/i_callbacks.c:805
 msgid "WARNING: Do not translate with snap off!"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:806
 msgid "WARNING: Turning snap on and continuing with translate."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:813
 msgid "WARNING: Snap grid size is not equal to 100!"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:815
 msgid ""
 "WARNING: If you are translating a symbol to the origin, the snap grid size "
 "should be set to 100"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:847
 msgid "Embed"
 msgstr "Lê In"
 
 # FIXME: too klunky!
-#: schematic/src/i_callbacks.c:886
 msgid "Unembed"
 msgstr "Ont-lê In"
 
-#: schematic/src/i_callbacks.c:928
 msgid "Update"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:970
 msgid "ShowHidden"
 msgstr "ToonVerskuil"
 
-#: schematic/src/i_callbacks.c:1537
 #, c-format
 msgid ""
 "<b>Revert page:</b>\n"
@@ -951,99 +724,77 @@ msgid ""
 "discarded and page file will be reloaded from disk."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1555
 #, fuzzy
 msgid "Revert"
 msgstr "Gaan Bladsy Terug"
 
-#: schematic/src/i_callbacks.c:1647
 msgid "Copy to clipboard"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1664
 msgid "Cut to clipboard"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1686
 msgid "Paste from clipboard"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1694
 msgid "Empty clipboard"
 msgstr ""
 
 #. TRANSLATORS: The number is the number of the buffer that the
 #. * selection is being copied to.
-#: schematic/src/i_callbacks.c:1719
 #, fuzzy, c-format
 msgid "Copy %i"
 msgstr "Kopieer 1"
 
 #. TRANSLATORS: The number is the number of the buffer that the
 #. * selection is being cut to.
-#: schematic/src/i_callbacks.c:1746
 #, fuzzy, c-format
 msgid "Cut %i"
 msgstr "Sny 1"
 
 #. TRANSLATORS: The number is the number of the buffer that is being
 #. * pasted to the schematic.
-#: schematic/src/i_callbacks.c:1776
 #, fuzzy, c-format
 msgid "Paste %i"
 msgstr "Plak 1"
 
-#: schematic/src/i_callbacks.c:1785
 msgid "Empty buffer"
 msgstr "Maak buffer leeg"
 
-#: schematic/src/i_callbacks.c:1833 schematic/src/x_window.c:1203
 msgid "Component"
 msgstr "Komponent"
 
-#: schematic/src/i_callbacks.c:1865 schematic/src/x_colorcb.c:150
 msgid "Attribute"
 msgstr "Eienskap"
 
-#: schematic/src/i_callbacks.c:1885 schematic/src/x_colorcb.c:149
 msgid "Net"
 msgstr "Skakeling"
 
-#: schematic/src/i_callbacks.c:1928 schematic/src/x_colorcb.c:155
-#: schematic/src/x_window.c:1222
 msgid "Bus"
 msgstr "Bus"
 
-#: schematic/src/i_callbacks.c:2004
 msgid "Line"
 msgstr "Lyn"
 
-#: schematic/src/i_callbacks.c:2021
 msgid "Path"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2043
 msgid "Box"
 msgstr "Reghoek"
 
-#: schematic/src/i_callbacks.c:2085
 msgid "Circle"
 msgstr "Sirkel"
 
-#: schematic/src/i_callbacks.c:2108
 msgid "Arc"
 msgstr "Boog"
 
-#: schematic/src/i_callbacks.c:2131 schematic/src/x_colorcb.c:146
 msgid "Pin"
 msgstr "Pen"
 
-#: schematic/src/i_callbacks.c:2191
 #, fuzzy, c-format
 msgid "Searching for source [%1$s]"
 msgstr "Soek vir bron [%s]\n"
 
-#: schematic/src/i_callbacks.c:2223
 #, c-format
 msgid ""
 "Failed to descend hierarchy into '%1$s': %2$s\n"
@@ -1051,114 +802,89 @@ msgid ""
 "The lepton-schematic log may contain more information."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2227
 #, fuzzy, c-format
 msgid "Failed to descend into '%1$s': %2$s"
 msgstr "Kon nie afbeelding laai nie: %s"
 
-#: schematic/src/i_callbacks.c:2234
 #, fuzzy
 msgid "Failed to descend hierarchy."
 msgstr "daal in hierargie af"
 
-#: schematic/src/i_callbacks.c:2312
 #, fuzzy, c-format
 msgid "Searching for symbol [%1$s]"
 msgstr "Soek vir simbool [%s]\n"
 
-#: schematic/src/i_callbacks.c:2320
 msgid "Symbol is not a real file. Symbol cannot be loaded."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2367 schematic/src/x_tabs.c:1060
 msgid "Cannot find any schematics above the current one!"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2400
 msgid "Attach"
 msgstr "Heg aan"
 
-#: schematic/src/i_callbacks.c:2456
 msgid "Detach"
 msgstr "Heg af"
 
-#: schematic/src/i_callbacks.c:2500
 msgid "ShowN"
 msgstr "ToonN"
 
-#: schematic/src/i_callbacks.c:2537
 msgid "ShowV"
 msgstr "ToonW"
 
-#: schematic/src/i_callbacks.c:2574
 msgid "ShowB"
 msgstr "ToonB"
 
-#: schematic/src/i_callbacks.c:2612
 msgid "VisToggle"
 msgstr "SigSkakel"
 
-#: schematic/src/i_callbacks.c:2643
 #, c-format
 msgid "Sorry but this is a non-functioning menu option\n"
 msgstr "Jammer, maar hierdie opsie werk nie\n"
 
-#: schematic/src/i_callbacks.c:2703
 #, fuzzy
 msgid "Action feedback mode set to OUTLINE"
 msgstr "Handelingsterugvoermodus na SKETS gestel\n"
 
-#: schematic/src/i_callbacks.c:2706
 #, fuzzy
 msgid "Action feedback mode set to BOUNDINGBOX"
 msgstr "Handelingsterugvoermodus na OMTREKREGHOEK\n"
 
-#: schematic/src/i_callbacks.c:2730
 #, fuzzy
 msgid "Grid OFF"
 msgstr "Rooster AF\n"
 
-#: schematic/src/i_callbacks.c:2731
 msgid "Dot grid selected"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2732
 msgid "Mesh grid selected"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2733
 #, fuzzy
 msgid "Invalid grid mode"
 msgstr "Ongeldige Eienskap"
 
-#: schematic/src/i_callbacks.c:2755
 msgid "Snap OFF (CAUTION!)"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2758
 msgid "Snap ON"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2761
 msgid "Snap back to the grid (CAUTION!)"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2790
 #, fuzzy
 msgid "Rubber band ON"
 msgstr "Rubberband AAN\n"
 
-#: schematic/src/i_callbacks.c:2792
 #, fuzzy
 msgid "Rubber band OFF"
 msgstr "Rubberband AF \n"
 
-#: schematic/src/i_callbacks.c:2811
 #, fuzzy
 msgid "magnetic net mode: ON"
 msgstr "Netmodus"
 
-#: schematic/src/i_callbacks.c:2814
 #, fuzzy
 msgid "magnetic net mode: OFF"
 msgstr "Netmodus"
@@ -1168,143 +894,114 @@ msgstr "Netmodus"
 #. the form "untitled_N.sch", where N is a number.  Please make
 #. sure that the translation contains characters suitable for use
 #. in a filename.
-#: schematic/src/i_vars.c:209
 msgid "untitled"
 msgstr ""
 
-#: schematic/src/o_complex.c:192 schematic/src/o_complex.c:195
 #, fuzzy, c-format
 msgid "Translating schematic [%1$d %2$d]"
 msgstr "Verskuif stroombaandiagram [%d %d]\n"
 
-#: schematic/src/o_delete.c:82
 #, c-format
 msgid "Delete locked object?"
 msgid_plural "Delete %1$u locked objects?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/o_misc.c:55
 #, c-format
 msgid "Got an unexpected NULL in o_edit\n"
 msgstr "Het 'n onverwagte NULL in o_edit gekry\n"
 
-#: schematic/src/o_misc.c:315
 #, fuzzy
 msgid "Hidden text is now visible"
 msgstr "Verskuilde teks is nou sigbaar\n"
 
-#: schematic/src/o_misc.c:317
 #, fuzzy
 msgid "Hidden text is now invisible"
 msgstr "Verskuilde teks is nou onsigbaar\n"
 
-#: schematic/src/o_misc.c:425
 #, c-format
 msgid "Could not find symbol [%1$s] in library. Update failed."
 msgstr ""
 
-#: schematic/src/o_misc.c:541
 #, fuzzy, c-format
 msgid "o_autosave_backups: Can't get the real filename of %1$s."
 msgstr "o_autosave_backups: Kan nie die egte lêernaam van %s kry nie."
 
-#: schematic/src/o_misc.c:585
 #, fuzzy, c-format
 msgid "Could NOT set previous backup file [%1$s] read-write"
 msgstr "Kon NIE vorige bestandlêer [%s] lees-skryf stel nie\n"
 
-#: schematic/src/o_misc.c:605
 #, fuzzy, c-format
 msgid "Could NOT set backup file [%1$s] readonly"
 msgstr "Kon NIE bestandlêer [%s] lees-slegs stel nie\n"
 
-#: schematic/src/o_misc.c:610
 #, fuzzy, c-format
 msgid "Could NOT save backup file [%1$s]"
 msgstr "Kon NIE bestandlêer [%s] bewaar nie\n"
 
-#: schematic/src/o_move.c:192
 #, c-format
 msgid "ERROR: NULL object in o_move_end!\n"
 msgstr "FOUT: NULL voorwerp in o_move_end!\n"
 
 # Thanks to Frank Shearar for reminding me of BLIKSEM!
-#: schematic/src/o_move.c:519
 #, c-format
 msgid "DOH! tried to find the whichone, but didn't find it!\n"
 msgstr ""
 "BLIKSEM!  Het probeer om die whichone te vind, maar kon dit nie kry nie!\n"
 
-#: schematic/src/o_move.c:546
 #, c-format
 msgid "Got a non line object in o_move_check_endpoint\n"
 msgstr "Het 'n voorwerp wat nie 'n lyn is nie in o_move_check_endpoint gekry\n"
 
-#: schematic/src/o_net.c:444
 msgid "Warning: Starting net at off grid coordinate"
 msgstr ""
 
-#: schematic/src/o_net.c:508
 msgid "Warning: Ending net at off grid coordinate"
 msgstr ""
 
-#: schematic/src/o_net.c:856 schematic/src/o_net.c:893
-#: schematic/src/o_net.c:964 schematic/src/o_net.c:1000
 #, c-format
 msgid "Tried to add more than two bus rippers. Internal gschem error.\n"
 msgstr ""
 "Het probeer om meer as twee busrippers bytevoeg.  Interne gschem fout.\n"
 
-#: schematic/src/o_net.c:1068
 #, fuzzy, c-format
 msgid "Bus ripper symbol [%1$s] was not found in any component library"
 msgstr "Busrippersimbool [%s] is nie in enige komponentbiblioteek gevind nie\n"
 
-#: schematic/src/o_picture.c:133 schematic/src/o_picture.c:343
 #, fuzzy
 msgid "Select a picture file..."
 msgstr "Kies PostScript Lêernaam"
 
-#: schematic/src/o_picture.c:166
 #, fuzzy, c-format
 msgid "Failed to load picture: %1$s"
 msgstr "Kon nie afbeelding laai nie: %s"
 
-#: schematic/src/o_picture.c:182
 msgid "Picture"
 msgstr "Afbeelding"
 
-#: schematic/src/o_picture.c:378
 #, fuzzy, c-format
 msgid "Failed to replace pictures: %s"
 msgstr "Kon nie afbeelding laai nie: %s"
 
-#: schematic/src/o_slot.c:80
 #, fuzzy
 msgid "Slot attribute malformed"
 msgstr "\"slot\" eienskap is misvorm\n"
 
-#: schematic/src/o_slot.c:88
 #, fuzzy
 msgid "numslots attribute missing"
 msgstr "\"numslots\" eienskap bestaan nie\n"
 
-#: schematic/src/o_slot.c:89
 #, fuzzy
 msgid "Slotting not allowed for this component"
 msgstr "Gleuwe is nie toegelaat vir hierdie komponent nie\n"
 
-#: schematic/src/o_slot.c:104
 #, fuzzy
 msgid "New slot number out of range"
 msgstr "Nuwe gleufnommer buite bereik\n"
 
-#: schematic/src/o_undo.c:397
 msgid "Undo/Redo disabled in rc file"
 msgstr ""
 
-#: schematic/src/parsecmd.c:77
 #, c-format
 msgid ""
 "Usage: %1$s [OPTION ...] [--] [FILE ...]\n"
@@ -1329,192 +1026,148 @@ msgid ""
 "gEDA/gaf homepage: <http://www.geda-project.org/>\n"
 msgstr ""
 
-#: schematic/src/parsecmd.c:110
 #, c-format
 msgid ""
 "Lepton EDA %1$s (git: %2$.7s)\n"
 "Copyright (C) 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright (C) 2017-2018 Lepton Developers.\n"
+"Copyright (C) 2017-2019 Lepton Developers.\n"
 "This is free software, and you are welcome to redistribute it under\n"
 "certain conditions. For details, see the file `COPYING', which is\n"
 "included in the Lepton EDA distribution.\n"
 "There is NO WARRANTY, to the extent permitted by law.\n"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:125
 #, c-format
 msgid "Got invalid show option; defaulting to show both\n"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:139
 #, c-format
 msgid "ERROR: NULL object!\n"
 msgstr "FOUT: NULL voorwerp!\n"
 
-#: schematic/src/x_attribedit.c:328
 msgid "Single Attribute Editor"
 msgstr "Enkeleienskap-Bewerker"
 
-#: schematic/src/x_attribedit.c:358
 msgid "<b>Edit Attribute</b>"
 msgstr "<b>Bewerk Eienskap</b>"
 
-#: schematic/src/x_attribedit.c:360
 msgid "<b>Add Attribute</b>"
 msgstr "<b>Voeg Eienskap By</b>"
 
-#: schematic/src/x_attribedit.c:376
 #, fuzzy
 msgid "N_ame:"
 msgstr "Naam:"
 
-#: schematic/src/x_attribedit.c:396 schematic/src/x_multiattrib.c:2222
 #, fuzzy
 msgid "_Value:"
 msgstr "Waarde:"
 
-#: schematic/src/x_attribedit.c:415 schematic/src/x_multiattrib.c:2281
 #, fuzzy
 msgid "Vi_sible"
 msgstr "Sigbaar"
 
-#: schematic/src/x_attribedit.c:434
 msgid "Show Value Only"
 msgstr "Toon Slegs Waarde"
 
-#: schematic/src/x_attribedit.c:436
 msgid "Show Name Only"
 msgstr "Toon Slegs Naam"
 
-#: schematic/src/x_attribedit.c:438 schematic/src/x_multiattrib.c:1620
-#: schematic/scheme/gschem/builtins.scm:324
 msgid "Show Name & Value"
 msgstr "Toon Naam & Waarde"
 
-#: schematic/src/x_attribedit.c:445
 msgid "<b>Attach Options</b>"
 msgstr "<b>AAnhegopsies</b>"
 
-#: schematic/src/x_attribedit.c:460
 msgid "All"
 msgstr "Alles"
 
-#: schematic/src/x_attribedit.c:476 schematic/src/x_compselect.c:986
-#: schematic/src/x_compselect.c:1100
 msgid "Components"
 msgstr "Komponente"
 
 # FIXME: "Nette"
-#: schematic/src/x_attribedit.c:492 schematic/src/x_window.c:1214
 msgid "Nets"
 msgstr "Nette"
 
-#: schematic/src/x_attribedit.c:508
 msgid "Replace existing attributes"
 msgstr "Vervang bestaande eienskappe"
 
-#: schematic/src/x_autonumber.c:412
 msgid ""
 "slotted object without slot attribute may cause problems when autonumbering "
 "slots"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:427
 #, fuzzy, c-format
 msgid ""
 "duplicate slot may cause problems: [symbolname=%1$s, number=%2$d, slot=%3$d]"
 msgstr ""
 "duplikaatgleuf mag probleme veroorsaak: [symbolname=%s, number=%d, slot=%d]\n"
 
-#: schematic/src/x_autonumber.c:675
 msgid "No searchstring given in autonumber text."
 msgstr ""
 
-#: schematic/src/x_autonumber.c:728
 msgid "No '*' or '?' given at the end of the autonumber text."
 msgstr ""
 
-#: schematic/src/x_autonumber.c:873
 msgid "Diagonal"
 msgstr "Diagonaal"
 
-#: schematic/src/x_autonumber.c:874
 msgid "Top to bottom"
 msgstr "Bo to onder"
 
-#: schematic/src/x_autonumber.c:875
 msgid "Bottom to top"
 msgstr "Onder tot bo"
 
-#: schematic/src/x_autonumber.c:876
 msgid "Left to right"
 msgstr "Links tot regs"
 
-#: schematic/src/x_autonumber.c:877
 msgid "Right to left"
 msgstr "Regs tot links"
 
-#: schematic/src/x_autonumber.c:878
 msgid "File order"
 msgstr "Lêerorde"
 
-#: schematic/src/x_autonumber.c:1214
 msgid "Autonumber text"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1237
 msgid "<b>Scope</b>"
 msgstr "<b>Bestek</b>"
 
-#: schematic/src/x_autonumber.c:1259
 msgid "Search for:"
 msgstr "Soek vir:"
 
-#: schematic/src/x_autonumber.c:1273
 msgid "Autonumber text in:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1280
 msgid "Skip numbers found in:"
 msgstr "Slaan nommers oor in:"
 
-#: schematic/src/x_autonumber.c:1292 schematic/src/x_autonumber.c:1301
 msgid "Selected objects"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1293 schematic/src/x_autonumber.c:1302
 msgid "Current page"
 msgstr "Lopende bladsy"
 
-#: schematic/src/x_autonumber.c:1294 schematic/src/x_autonumber.c:1303
 msgid "Whole hierarchy"
 msgstr "Hele hierargie"
 
-#: schematic/src/x_autonumber.c:1305
 msgid "Overwrite existing numbers"
 msgstr "Vervang bestaande nommers"
 
-#: schematic/src/x_autonumber.c:1310
 msgid "<b>Options</b>"
 msgstr "<b>Opsies</b>"
 
-#: schematic/src/x_autonumber.c:1332
 msgid "Starting number:"
 msgstr "Begin by nommer:"
 
-#: schematic/src/x_autonumber.c:1339
 msgid "Sort order:"
 msgstr "Rangskikkingsorde:"
 
-#: schematic/src/x_autonumber.c:1371
 msgid "Remove numbers"
 msgstr "Verwyder syfers"
 
-#: schematic/src/x_autonumber.c:1375
 msgid "Automatic slotting"
 msgstr "Outomatiese begleuwing"
 
-#: schematic/src/x_clipboard.c:245
 #, c-format
 msgid ""
 "<b>Invalid schematic on clipboard.</b>\n"
@@ -1522,177 +1175,137 @@ msgid ""
 "An error occurred while inserting clipboard data: %s."
 msgstr ""
 
-#: schematic/src/x_clipboard.c:247
 msgid "Clipboard insertion failed"
 msgstr ""
 
-#: schematic/src/x_color.c:89 schematic/src/x_color.c:98
 #, fuzzy, c-format
 msgid "Could not allocate the color %1$s!\n"
 msgstr "Kon nie aanspraak maak op die kleur %s nie!\n"
 
-#: schematic/src/x_color.c:89
 msgid "black"
 msgstr "swart"
 
-#: schematic/src/x_color.c:98
 msgid "white"
 msgstr "wit"
 
-#: schematic/src/x_color.c:120
 #, fuzzy, c-format
 msgid "Could not allocate display color %1$i!\n"
 msgstr "Kon nie aanspraak maak op die kleur %s nie!\n"
 
-#: schematic/src/x_color.c:142
 #, fuzzy, c-format
 msgid "Could not allocate outline color %1$i!\n"
 msgstr "Kon nie aanspraak maak op die kleur %s nie!\n"
 
-#: schematic/src/x_color.c:159
 #, fuzzy, c-format
 msgid "Tried to get an invalid color: %1$d\n"
 msgstr "Het probeer om 'n ongeldige kleur te kry: %d\n"
 
-#: schematic/src/x_colorcb.c:145
 msgid "Background"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:147
 msgid "Net endpoint"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:148
 msgid "Graphic"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:151
 msgid "Logic bubble"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:152
 msgid "Grid point"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:153
 #, fuzzy
 msgid "Detached attribute"
 msgstr "Bewerk Eienskappe"
 
-#: schematic/src/x_colorcb.c:156
 #, fuzzy
 msgid "Selection"
 msgstr "Kies"
 
-#: schematic/src/x_colorcb.c:157
 msgid "Bounding box"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:158
 msgid "Zoom box"
 msgstr "Zoem Reghoek"
 
-#: schematic/src/x_colorcb.c:161
 msgid "Output background"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:162
 msgid "Freestyle 1"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:163
 msgid "Freestyle 2"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:164
 msgid "Freestyle 3"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:165
 msgid "Freestyle 4"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:166
 #, fuzzy
 msgid "Net junction"
 msgstr "Funksie"
 
-#: schematic/src/x_colorcb.c:167
 msgid "Mesh grid major"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:168
 msgid "Mesh grid minor"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:172
 msgid "Unknown"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1169
 #, fuzzy
 msgid "Reset filter"
 msgstr "Onlangse lêers"
 
-#: schematic/src/x_compselect.c:1192
 msgid "Reload all libraries"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1245 schematic/src/x_multiattrib.c:2092
 msgid "Value"
 msgstr "Waarde"
 
-#: schematic/src/x_compselect.c:1284
 msgid "Default behavior - reference component"
 msgstr "Verstekgedrag - verwys na komponent"
 
-#: schematic/src/x_compselect.c:1287
 msgid "Embed component in schematic"
 msgstr "Lê komponent in stroombaandiagram in"
 
-#: schematic/src/x_compselect.c:1290
 msgid "Include component as individual objects"
 msgstr "Sluit komponent as afsonderlike voorwerpe in"
 
-#: schematic/src/x_compselect.c:1448
 msgid "Select Component..."
 msgstr "Kies Komponent..."
 
-#: schematic/src/x_compselect.c:1471
 #, fuzzy
 msgid "In Us_e"
 msgstr "In Gebruik"
 
-#: schematic/src/x_compselect.c:1475
 #, fuzzy
 msgid "Lib_raries"
 msgstr "Biblioteke"
 
-#: schematic/src/x_compselect.c:1484 schematic/src/x_fileselect.c:119
 msgid "Preview"
 msgstr "Voorskou"
 
-#: schematic/src/x_compselect.c:1510
 msgid "Attributes"
 msgstr "Eienskappe"
 
-#: schematic/src/x_dialog.c:325
 msgid "Major symbol changes detected."
 msgstr ""
 
-#: schematic/src/x_dialog.c:349
 msgid ""
 "Changes have occurred to the symbols shown below.\n"
 "\n"
 "Be sure to verify each of these symbols."
 msgstr ""
 
-#: schematic/src/x_dialog.c:369
 #, fuzzy
 msgid "Symbol"
 msgstr "Simbole"
 
-#: schematic/src/x_dialog.c:406
 #, c-format
 msgid ""
 "<span weight=\"bold\" size=\"larger\">The input attribute \"%s\" is invalid\n"
@@ -1710,39 +1323,30 @@ msgstr ""
 "Die naam mag nie met 'n spasie eindig nie.\n"
 "Die waarde mag nie met 'n spasie begin nie."
 
-#: schematic/src/x_dialog.c:408
 msgid "Invalid Attribute"
 msgstr "Ongeldige Eienskap"
 
-#: schematic/src/x_fileselect.c:37
 msgid "Schematics"
 msgstr "Stroombaandiagramme"
 
-#: schematic/src/x_fileselect.c:42
 msgid "Symbols"
 msgstr "Simbole"
 
-#: schematic/src/x_fileselect.c:47
 msgid "Schematics and symbols"
 msgstr "Stroombaandiagramme en simbole"
 
-#: schematic/src/x_fileselect.c:53
 msgid "All files"
 msgstr "Alle lêers"
 
-#: schematic/src/x_fileselect.c:169
 msgid "Open..."
 msgstr "Open..."
 
-#: schematic/src/x_fileselect.c:233
 msgid "Save as..."
 msgstr "Bewaar as..."
 
-#: schematic/src/x_fileselect.c:297
 msgid "Save cancelled on user request"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:334
 msgid ""
 "\n"
 "If you load the original file, the backup file will be overwritten in the "
@@ -1751,28 +1355,22 @@ msgid ""
 "Do you want to load the backup file?\n"
 msgstr ""
 
-#: schematic/src/x_fstylecb.c:73
 msgid "Hollow"
 msgstr "Hol"
 
-#: schematic/src/x_fstylecb.c:80
 msgid "Filled"
 msgstr "Gevul"
 
-#: schematic/src/x_fstylecb.c:87
 msgid "Mesh"
 msgstr "Rooster"
 
-#: schematic/src/x_fstylecb.c:94
 msgid "Hatch"
 msgstr "Arseer"
 
-#: schematic/src/x_image.c:279
 #, fuzzy, c-format
 msgid "x_image_lowlevel: Unable to write %1$s file %2$s."
 msgstr "x_image_lowlevel: Kon nie %s-lêer %s skryf nie.\n"
 
-#: schematic/src/x_image.c:289
 #, fuzzy, c-format
 msgid ""
 "There was the following error when saving image with type %1$s to filename:\n"
@@ -1785,308 +1383,241 @@ msgstr ""
 "\n"
 "%s.\n"
 
-#: schematic/src/x_image.c:309
 #, fuzzy, c-format
 msgid "Wrote color image to [%1$s] [%2$d x %3$d]"
 msgstr "Het kleurafbeelding na [%s] [%d x %d] geskryf\n"
 
-#: schematic/src/x_image.c:311
 #, fuzzy, c-format
 msgid "Wrote black and white image to [%1$s] [%2$d x %3$d]"
 msgstr "Het swart-en-witafbeelding na [%s] [%d x %d] geskryf\n"
 
-#: schematic/src/x_image.c:319
 #, fuzzy
 msgid "x_image_lowlevel: Unable to get pixbuf from gschem's window."
 msgstr "x_image_lowlevel: Kon nie pixbuf van gschem se venster kry nie.\n"
 
-#: schematic/src/x_image.c:358
 msgid "Width x Height"
 msgstr "Wydte x Hoogte"
 
-#: schematic/src/x_image.c:374
 msgid "Image type"
 msgstr "Afbeeldingsoort"
 
-#: schematic/src/x_image.c:395
 msgid "Write image..."
 msgstr "Skryf afbeelding..."
 
-#: schematic/src/x_linecapcb.c:74
 msgid "Butt"
 msgstr ""
 
-#: schematic/src/x_linecapcb.c:81
 msgid "Square"
 msgstr ""
 
-#: schematic/src/x_linecapcb.c:88
 msgid "Round"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:74
 msgid "Solid"
 msgstr "Solied"
 
-#: schematic/src/x_linetypecb.c:81
 msgid "Dotted"
 msgstr "Gestippeld"
 
-#: schematic/src/x_linetypecb.c:88
 msgid "Dashed"
 msgstr "Gebroke"
 
-#: schematic/src/x_linetypecb.c:95
 msgid "Center"
 msgstr "Sentreer"
 
-#: schematic/src/x_linetypecb.c:102
 msgid "Phantom"
 msgstr "Spook"
 
-#: schematic/src/x_menus.c:41 schematic/scheme/gschem/builtins.scm:267
 #, fuzzy
 msgid "Add Net"
 msgstr "/Voeg Net By"
 
-#: schematic/src/x_menus.c:42 schematic/src/x_multiattrib.c:2187
-#: schematic/scheme/gschem/builtins.scm:264
 msgid "Add Attribute"
 msgstr "Voeg Eienskap By"
 
-#: schematic/src/x_menus.c:43 schematic/scheme/gschem/builtins.scm:261
 #, fuzzy
 msgid "Add Component"
 msgstr "/Voeg Komponent By"
 
-#: schematic/src/x_menus.c:44 schematic/scheme/gschem/builtins.scm:270
 #, fuzzy
 msgid "Add Bus"
 msgstr "/Voeg Bus By"
 
-#: schematic/src/x_menus.c:45 schematic/scheme/gschem/builtins.scm:273
 #, fuzzy
 msgid "Add Text"
 msgstr "/Voeg Teks By"
 
-#: schematic/src/x_menus.c:47 schematic/scheme/gschem/builtins.scm:210
 #, fuzzy
 msgid "Zoom In"
 msgstr "/Zoem In"
 
-#: schematic/src/x_menus.c:48 schematic/scheme/gschem/builtins.scm:213
 #, fuzzy
 msgid "Zoom Out"
 msgstr "/Zoem Uit"
 
-#: schematic/src/x_menus.c:50 schematic/scheme/gschem/builtins.scm:207
 #, fuzzy
 msgid "Zoom Extents"
 msgstr "/Zoem Uitmate"
 
-#: schematic/src/x_menus.c:52 schematic/src/x_window.c:1233
 msgid "Select"
 msgstr "Kies"
 
-#: schematic/src/x_menus.c:53 schematic/scheme/conf/schematic/menu.scm:69
-#: schematic/scheme/gschem/builtins.scm:126
 msgid "Edit..."
 msgstr "Bewerk..."
 
-#: schematic/src/x_menus.c:54 schematic/scheme/conf/schematic/menu.scm:68
 #, fuzzy
 msgid "Object Properties..."
 msgstr "<b>Tekseienskappe</b>"
 
-#: schematic/src/x_menus.c:59 schematic/scheme/gschem/builtins.scm:300
 #, fuzzy
 msgid "Down Schematic"
 msgstr "/Stroombaandiagram Af"
 
-#: schematic/src/x_menus.c:60 schematic/scheme/gschem/builtins.scm:303
 #, fuzzy
 msgid "Down Symbol"
 msgstr "/Simbool Af"
 
-#: schematic/src/x_menus.c:61
 #, fuzzy
 msgid "Up"
 msgstr "/Op"
 
-#: schematic/src/x_menus.c:336
 #, fuzzy, c-format
 msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
 msgstr "Het probeer om gevoeligheid op nie-bestaande menu-artikel '%s'\n"
 
-#: schematic/src/x_menus.c:360
 #, c-format
 msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
 msgstr "Het probeer om gevoeligheid op nie-bestaande menu-artikel '%s'\n"
 
-#: schematic/src/x_misc.c:70
 msgid "The operating system is out of memory or resources."
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:798 schematic/src/x_multiattrib.c:2704
 msgid "<various>"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:930
 msgid "Attributes with empty name are not allowed. Please set a name."
 msgstr "Eienskappe met 'n leë naam word verbied.  Kies asseblief 'n naam."
 
-#: schematic/src/x_multiattrib.c:1622
 msgid "Show Value only"
 msgstr "Toon slegs waarde"
 
-#: schematic/src/x_multiattrib.c:1624
 msgid "Show Name only"
 msgstr "Toon slegs naam"
 
-#: schematic/src/x_multiattrib.c:1651
 msgid "Promote"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1655
 msgid "Duplicate"
 msgstr "Dupliseer"
 
-#: schematic/src/x_multiattrib.c:1657
 #, fuzzy
 msgid "Copy to all"
 msgstr "Kopieer in 1 in"
 
-#: schematic/src/x_multiattrib.c:1986 schematic/src/x_multiattrib.c:2602
 msgid "Edit Attributes"
 msgstr "Bewerk Eienskappe"
 
-#: schematic/src/x_multiattrib.c:2112
 msgid "Vis?"
 msgstr "Sig?"
 
-#: schematic/src/x_multiattrib.c:2130
 msgid "N"
 msgstr "N"
 
-#: schematic/src/x_multiattrib.c:2148
 msgid "V"
 msgstr "W"
 
-#: schematic/src/x_multiattrib.c:2170
 #, fuzzy
 msgid "Sho_w inherited attributes"
 msgstr "Bewerk Eienskappe"
 
-#: schematic/src/x_multiattrib.c:2197
 #, fuzzy
 msgid "_Name:"
 msgstr "Naam:"
 
-#: schematic/src/x_multiattrib.c:2241
 msgid "Ctrl+Enter inserts new line; Ctrl+Tab inserts Tab"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2618
 #, c-format
 msgid "%2$i symbol (%1$s)"
 msgid_plural "%2$i symbols (%1$s)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2624
 #, c-format
 msgid "%1$i pin"
 msgid_plural "%1$i pins"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2630
 #, c-format
 msgid "%1$i net"
 msgid_plural "%1$i nets"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2636
 #, c-format
 msgid "%1$i bus"
 msgid_plural "%1$i buses"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2642
 #, fuzzy, c-format
 msgid "%1$i attribute"
 msgid_plural "%1$i attributes"
 msgstr[0] "Eienskap"
 msgstr[1] "Eienskap"
 
-#: schematic/src/x_newtext.c:433
 msgid "Text Entry..."
 msgstr "Teksaantekening..."
 
-#: schematic/src/x_pagesel.c:253
 msgid "New Page"
 msgstr "Nuwe Bladsy"
 
-#: schematic/src/x_pagesel.c:254
 msgid "Open Page..."
 msgstr "Maak Bladsy Oop..."
 
-#: schematic/src/x_pagesel.c:256
 msgid "Save Page"
 msgstr "Bewaar Bladsy"
 
-#: schematic/src/x_pagesel.c:257 schematic/scheme/gschem/builtins.scm:246
 msgid "Close Page"
 msgstr "Sluit Bladsy"
 
-#: schematic/src/x_pagesel.c:376 schematic/scheme/gschem/builtins.scm:237
 msgid "Page Manager"
 msgstr "Bladsybestuurder"
 
-#: schematic/src/x_pagesel.c:448
 msgid "Changed"
 msgstr "Veranderd"
 
-#: schematic/src/x_pagesel.c:468
 msgid "Right click on the filename for more options..."
 msgstr "Regs-klik op die lêernaam vir meer opsies..."
 
-#: schematic/src/x_print.c:306
 #, fuzzy, c-format
 msgid "Failed to write PDF to '%s': %s\n"
 msgstr "Kon nie afbeelding laai nie: %s"
 
-#: schematic/src/x_print.c:364
 #, fuzzy, c-format
 msgid "Failed to write PDF to '%1$s': %2$s\n"
 msgstr "Kon nie afbeelding laai nie: %s"
 
-#: schematic/src/x_print.c:449
 #, c-format
 msgid ""
 "Error printing file:\n"
 "%1$s"
 msgstr ""
 
-#: schematic/src/x_rc.c:39
 msgid "ERROR: An unknown error occurred while parsing configuration files."
 msgstr ""
 
-#: schematic/src/x_rc.c:44
 msgid ""
 "An unknown error occurred while parsing configuration files.\n"
 "\n"
 "The lepton-schematic log may contain more information."
 msgstr ""
 
-#: schematic/src/x_rc.c:56
 #, c-format
 msgid "ERROR: %1$s"
 msgstr ""
 
-#: schematic/src/x_rc.c:59
 #, c-format
 msgid ""
 "%1$s\n"
@@ -2094,141 +1625,110 @@ msgid ""
 "The lepton-schematic log may contain more information."
 msgstr ""
 
-#: schematic/src/x_rc.c:67
 msgid "Cannot load lepton-schematic configuration."
 msgstr ""
 
-#: schematic/src/x_script.c:42 schematic/scheme/conf/schematic/menu.scm:40
 msgid "Execute Script..."
 msgstr "Voer Script Uit..."
 
-#: schematic/src/x_script.c:61
 #, fuzzy, c-format
 msgid "Executing guile script [%1$s]"
 msgstr "Voer guile script [%s] uit\n"
 
-#: schematic/src/x_tabs.c:860
 #, fuzzy, c-format
 msgid "Hierarchy up: %s"
 msgstr "Hierargie"
 
-#: schematic/src/x_tabs.c:863
 #, fuzzy
 msgid "Hierarchy up"
 msgstr "Hierargie"
 
-#: schematic/src/x_widgets.c:158 schematic/src/x_window.c:1444
 msgid "Options"
 msgstr "Opsies"
 
-#: schematic/src/x_widgets.c:203 schematic/src/x_window.c:1436
 #, fuzzy
 msgid "Object"
 msgstr "Voorwerpkleur:"
 
-#: schematic/src/x_widgets.c:224
 msgid "Log"
 msgstr ""
 
-#: schematic/src/x_widgets.c:245 schematic/src/x_window.c:1466
 msgid "Find Text"
 msgstr "Vind Teks"
 
-#: schematic/src/x_widgets.c:259
 #, fuzzy
 msgid "Color Scheme Editor"
 msgstr "Kleurbewerking"
 
-#: schematic/src/x_widgets.c:272 schematic/scheme/gschem/builtins.scm:378
 #, fuzzy
 msgid "Select Schematic Font"
 msgstr "Kies die stroombaandiagramme wat jy wil bewaar:"
 
-#: schematic/src/x_window.c:763
 #, fuzzy, c-format
 msgid "Loading schematic [%1$s]"
 msgstr "Laai stroombaandiagram [%s]\n"
 
-#: schematic/src/x_window.c:864
 #, fuzzy, c-format
 msgid "Could NOT save page [%1$s]\n"
 msgstr "Kon nie bladsy [%s] bewaar nie\n"
 
-#: schematic/src/x_window.c:865
 msgid "Error while trying to save"
 msgstr "Fout gedurende poging om te bewaar"
 
-#: schematic/src/x_window.c:875
 #, fuzzy
 msgid "Failed to save file"
 msgstr "Misluk om lêer te laai"
 
-#: schematic/src/x_window.c:885
 #, fuzzy, c-format
 msgid "Saved as [%1$s]"
 msgstr "Bewaar as [%s]\n"
 
-#: schematic/src/x_window.c:887
 #, fuzzy, c-format
 msgid "Saved [%1$s]"
 msgstr "Bewaar [%s]\n"
 
-#: schematic/src/x_window.c:889
 msgid "Saved"
 msgstr "Bewaar"
 
-#: schematic/src/x_window.c:966
 #, fuzzy, c-format
 msgid "Discarding page [%1$s]"
 msgstr "Werp bladsy [%s] weg\n"
 
-#: schematic/src/x_window.c:966
 #, fuzzy, c-format
 msgid "Closing [%1$s]"
 msgstr "Sluit [%s]\n"
 
-#: schematic/src/x_window.c:1175
 msgid "New"
 msgstr "Nuwe"
 
-#: schematic/src/x_window.c:1175
 msgid "New file"
 msgstr "Nuwe lêer"
 
-#: schematic/src/x_window.c:1179
 msgid "Open"
 msgstr "Maak Oop"
 
-#: schematic/src/x_window.c:1179
 #, fuzzy
 msgid "Open file"
 msgstr "Maak lêer oop..."
 
-#: schematic/src/x_window.c:1183 schematic/scheme/gschem/builtins.scm:59
 msgid "Save"
 msgstr "Bewaar"
 
-#: schematic/src/x_window.c:1183
 msgid "Save file"
 msgstr "Bewaar lêer"
 
-#: schematic/src/x_window.c:1189 schematic/scheme/gschem/builtins.scm:93
 msgid "Undo"
 msgstr "Maak Ongedaan"
 
-#: schematic/src/x_window.c:1189
 msgid "Undo last operation"
 msgstr "Maak laaste handeling ongedaan"
 
-#: schematic/src/x_window.c:1193 schematic/scheme/gschem/builtins.scm:96
 msgid "Redo"
 msgstr "Herstel"
 
-#: schematic/src/x_window.c:1193
 msgid "Redo last undo"
 msgstr "Herhaal laas-ongedane handeling"
 
-#: schematic/src/x_window.c:1198
 msgid ""
 "Add component...\n"
 "Select library and component from list, move the mouse into main window, "
@@ -2236,57 +1736,45 @@ msgid ""
 "Right mouse button to cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1209
 msgid ""
 "Add nets mode\n"
 "Right mouse button to cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1217
 msgid ""
 "Add buses mode\n"
 "Right mouse button to cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1226
 msgid "Add Text..."
 msgstr "Voeg Teks By..."
 
-#: schematic/src/x_window.c:1233
 msgid "Select mode"
 msgstr "Kiesmodus"
 
-#: schematic/src/x_window.c:1288
 #, fuzzy
 msgid "Show"
 msgstr "ToonN"
 
-#: schematic/src/x_window.c:1289
 msgid "Show text starting with:"
 msgstr "Toon Teks beginnende met:"
 
-#: schematic/src/x_window.c:1345
 msgid "Menu/Cancel"
 msgstr "Menu/Kanselleer"
 
-#: schematic/src/x_window.c:1349
 msgid "Pan/Cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1359
 msgid "Pick"
 msgstr "Kies"
 
-#: schematic/src/x_window.c:1470 schematic/scheme/gschem/builtins.scm:180
 msgid "Status"
 msgstr "Stand"
 
-#: schematic/src/x_window.c:1568
 #, fuzzy, c-format
 msgid "New file [%s]"
 msgstr "Nuwe lêer [%s]\n"
 
-#: schematic/src/x_window.c:1598
 #, c-format
 msgid ""
 "<b>An error occurred while loading the requested file.</b>\n"
@@ -2300,883 +1788,673 @@ msgid ""
 "monitor program's output in terminal window."
 msgstr ""
 
-#: schematic/src/x_window.c:1617
 msgid "Failed to load file"
 msgstr "Misluk om lêer te laai"
 
-#: schematic/data/lepton-schematic.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Schematic Editor"
 msgstr "gEDA Stroombaandiagram Bewerker"
 
-#: schematic/data/lepton-schematic.desktop.in:4
 #, fuzzy
 msgid "Create and edit electrical schematics and symbols with lepton-schematic"
 msgstr "Skep en bewerk stroombaandiagramme en simbole met gschem"
 
-#: schematic/scheme/conf/schematic/menu.scm:27
 msgid "_New"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:28
 msgid "_Open..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:30
 msgid "Open Recen_t"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:32
 msgid "_Save"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:33
 msgid "Save _As..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:34
-#: schematic/scheme/gschem/builtins.scm:65
 msgid "Save All"
 msgstr "Bewaar Alles"
 
-#: schematic/scheme/conf/schematic/menu.scm:36
 msgid "_Print..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:37
 #, fuzzy
 msgid "Write _Image..."
 msgstr "Skryf afbeelding..."
 
-#: schematic/scheme/conf/schematic/menu.scm:39
 msgid "Invoke Macro..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:41
 msgid "REPL..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:43
-#: schematic/scheme/gschem/builtins.scm:77
 msgid "New Window"
 msgstr "Nuwe Venster"
 
-#: schematic/scheme/conf/schematic/menu.scm:44
 #, fuzzy
 msgid "_Close Window"
 msgstr "Sluit Venster"
 
-#: schematic/scheme/conf/schematic/menu.scm:45
 msgid "_Quit"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:51
 msgid "_Undo"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:52
 msgid "_Redo"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:54
 msgid "Cu_t"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:55
 msgid "_Copy"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:56
 msgid "_Paste"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:57
 msgid "_Delete"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:60
-#: schematic/scheme/gschem/builtins.scm:102
 #, fuzzy
 msgid "Select All"
 msgstr "Kies"
 
-#: schematic/scheme/conf/schematic/menu.scm:61
-#: schematic/scheme/gschem/builtins.scm:105
 #, fuzzy
 msgid "Deselect"
 msgstr "Kies"
 
-#: schematic/scheme/conf/schematic/menu.scm:65
 msgid "Rotate 90 Mode"
 msgstr "Roteer-90-modus"
 
-#: schematic/scheme/conf/schematic/menu.scm:70
 msgid "Edit Text..."
 msgstr "Bewerk Teks..."
 
-#: schematic/scheme/conf/schematic/menu.scm:71
 msgid "Slot..."
 msgstr "Gleuf..."
 
-#: schematic/scheme/conf/schematic/menu.scm:76
-#: schematic/scheme/gschem/builtins.scm:150
 msgid "Embed Component/Picture"
 msgstr "Lê Komponent/Afbeelding In"
 
 # FIXME: too klunky!
-#: schematic/scheme/conf/schematic/menu.scm:77
-#: schematic/scheme/gschem/builtins.scm:153
 msgid "Unembed Component/Picture"
 msgstr "Ont-lê Komponent/Afbeelding In"
 
-#: schematic/scheme/conf/schematic/menu.scm:78
-#: schematic/scheme/gschem/builtins.scm:156
 msgid "Update Component"
 msgstr "Vernuwe Komponent"
 
-#: schematic/scheme/conf/schematic/menu.scm:79
 msgid "Symbol Translate..."
 msgstr "Simboolverskuiwing..."
 
-#: schematic/scheme/conf/schematic/menu.scm:85
 msgid "Copy into 1"
 msgstr "Kopieer in 1 in"
 
-#: schematic/scheme/conf/schematic/menu.scm:86
 msgid "Copy into 2"
 msgstr "Kopieer in 2 in"
 
-#: schematic/scheme/conf/schematic/menu.scm:87
 msgid "Copy into 3"
 msgstr "Kopieer in 3 in"
 
-#: schematic/scheme/conf/schematic/menu.scm:88
 msgid "Copy into 4"
 msgstr "Kopieer in 4 in"
 
-#: schematic/scheme/conf/schematic/menu.scm:89
 msgid "Copy into 5"
 msgstr "Kopieer in 5 in"
 
-#: schematic/scheme/conf/schematic/menu.scm:90
 msgid "Cut into 1"
 msgstr "Sny in 1 in"
 
-#: schematic/scheme/conf/schematic/menu.scm:91
 msgid "Cut into 2"
 msgstr "Sny in 2 in"
 
-#: schematic/scheme/conf/schematic/menu.scm:92
 msgid "Cut into 3"
 msgstr "Sny in 3 in"
 
-#: schematic/scheme/conf/schematic/menu.scm:93
 msgid "Cut into 4"
 msgstr "Sny in 4 in"
 
-#: schematic/scheme/conf/schematic/menu.scm:94
 msgid "Cut into 5"
 msgstr "Sny in 5 in"
 
-#: schematic/scheme/conf/schematic/menu.scm:95
 msgid "Paste from 1"
 msgstr "Plak vanuit 1"
 
-#: schematic/scheme/conf/schematic/menu.scm:96
 msgid "Paste from 2"
 msgstr "Plak vanuit 2"
 
-#: schematic/scheme/conf/schematic/menu.scm:97
 msgid "Paste from 3"
 msgstr "Plak vanuit 3"
 
-#: schematic/scheme/conf/schematic/menu.scm:98
 msgid "Paste from 4"
 msgstr "Plak vanuit 4"
 
-#: schematic/scheme/conf/schematic/menu.scm:99
 msgid "Paste from 5"
 msgstr "Plak vanuit 5"
 
-#: schematic/scheme/conf/schematic/menu.scm:105
 msgid "Side Dock"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:106
 #, fuzzy
 msgid "Bottom Dock"
 msgstr "Onder tot bo"
 
-#: schematic/scheme/conf/schematic/menu.scm:108
 #, fuzzy
 msgid "Find Text Results"
 msgstr "Vind Teks"
 
-#: schematic/scheme/conf/schematic/menu.scm:110
 msgid "_Redraw"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:111
 msgid "_Pan"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:112
 msgid "Zoom _Box"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:113
 msgid "Zoom _Extents"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:114
 msgid "Zoom _In"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:115
 msgid "Zoom _Out"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:116
 msgid "Zoom _Full"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:118
 msgid "_Dark Color Scheme"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:119
 msgid "_Light Color Scheme"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:120
 msgid "B_W Color Scheme"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:122
 #, fuzzy
 msgid "Color Scheme Editor..."
 msgstr "Kleurbewerking"
 
-#: schematic/scheme/conf/schematic/menu.scm:129
 msgid "_Manager..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:131
 msgid "_Previous"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:132
 msgid "_Next"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:133
 msgid "_Close"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:135
 msgid "_Revert..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:137
-#: schematic/scheme/gschem/builtins.scm:249
 #, fuzzy
 msgid "Next Tab"
 msgstr "Nuwe Bladsy"
 
-#: schematic/scheme/conf/schematic/menu.scm:138
-#: schematic/scheme/gschem/builtins.scm:252
 #, fuzzy
 msgid "Previous Tab"
 msgstr "Sluit Bladsy"
 
-#: schematic/scheme/conf/schematic/menu.scm:146
 msgid "_Component..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:148
 msgid "_Net"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:149
 msgid "B_us"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:151
 msgid "_Attribute..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:152
 msgid "_Text..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:154
 msgid "_Line"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:155
 msgid "Pat_h"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:156
 msgid "_Box"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:157
 msgid "C_ircle"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:158
 msgid "A_rc"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:159
 msgid "_Pin"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:161
 msgid "Pictu_re..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:167
 msgid "_Up"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:169
 msgid "_Down Schematic"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:170
 msgid "Down _Symbol"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:176
 msgid "_Attach"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:177
 msgid "_Detach"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:179
 msgid "Show _Value"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:180
 msgid "Show _Name"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:181
 msgid "Show _Both"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:182
 msgid "_Toggle Visibility"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:184
 msgid "_Hide Specific Text..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:185
 msgid "_Show Specific Text..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:186
 #, fuzzy
 msgid "Show/Hide Hidden Text"
 msgstr "Toon/Verberg Onsigbare Teks"
 
-#: schematic/scheme/conf/schematic/menu.scm:188
 msgid "_Find Text/Check Symbol..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:189
 msgid "A_utonumber Text..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:195
 #, fuzzy
 msgid "_Options..."
 msgstr "Opsies"
 
-#: schematic/scheme/conf/schematic/menu.scm:196
 #, fuzzy
 msgid "_Font..."
 msgstr "Gleuf..."
 
-#: schematic/scheme/conf/schematic/menu.scm:198
 #, fuzzy
 msgid "Grid +"
 msgstr "Rooster AAN\n"
 
-#: schematic/scheme/conf/schematic/menu.scm:199
 #, fuzzy
 msgid "Grid -"
 msgstr "Rooster AAN\n"
 
-#: schematic/scheme/conf/schematic/menu.scm:201
 msgid "Grid Style: Cycle Dots/Mesh/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:202
 msgid "Grid Snap: Cycle Grid/Resnap/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:204
 msgid "Feedback Mode: Outline/Box"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:205
 #, fuzzy
 msgid "Net: Rubberband On/Off"
 msgstr "Rubberband AAN\n"
 
-#: schematic/scheme/conf/schematic/menu.scm:206
 msgid "Net: Magnetic On/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:208
 #, fuzzy
 msgid "_Coord Window"
 msgstr "Sluit Venster"
 
-#: schematic/scheme/conf/schematic/menu.scm:209
 #, fuzzy
 msgid "_Log Window"
 msgstr "Nuwe Venster"
 
-#: schematic/scheme/conf/schematic/menu.scm:215
 msgid "_1 allegro"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:223
 msgid "User _Guide"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:224
 msgid "_FAQ"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:225
 #, fuzzy
 msgid "Docu_mentation"
 msgstr "Komponentmodus"
 
-#: schematic/scheme/conf/schematic/menu.scm:226
 msgid "_Wiki"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:228
 #, fuzzy
 msgid "Find Component D_ocumentation"
 msgstr "Komponentmodus"
 
-#: schematic/scheme/conf/schematic/menu.scm:230
 msgid "_Hotkeys..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:231
 #, fuzzy
 msgid "_About"
 msgstr "Omtrent..."
 
-#: schematic/scheme/conf/schematic/menu.scm:237
 msgid "_File"
 msgstr "Lêer"
 
-#: schematic/scheme/conf/schematic/menu.scm:238
 msgid "_Edit"
 msgstr "Bewerk"
 
-#: schematic/scheme/conf/schematic/menu.scm:240
 msgid "_View"
 msgstr "Aansig"
 
-#: schematic/scheme/conf/schematic/menu.scm:241
 msgid "_Page"
 msgstr "Bladsy"
 
-#: schematic/scheme/conf/schematic/menu.scm:242
 msgid "_Add"
 msgstr "Voeg By"
 
-#: schematic/scheme/conf/schematic/menu.scm:243
 msgid "Hie_rarchy"
 msgstr "Hierargie"
 
-#: schematic/scheme/conf/schematic/menu.scm:244
 msgid "A_ttributes"
 msgstr "Eienskappe"
 
-#: schematic/scheme/conf/schematic/menu.scm:245
 msgid "_Options"
 msgstr "Opsies"
 
-#: schematic/scheme/conf/schematic/menu.scm:246
 msgid "_Netlist"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:247
 msgid "_Help"
 msgstr "Help"
 
-#: schematic/scheme/gschem/action.scm:43
 #, scheme-format
 msgid "~S is not a valid gschem action."
 msgstr ""
 
-#: schematic/scheme/gschem/action.scm:158
 msgid "Repeat Last Action"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:47
 #, fuzzy
 msgid "Cancel"
 msgstr "Menu/Kanselleer"
 
-#: schematic/scheme/gschem/builtins.scm:53
 #, fuzzy
 msgid "New File"
 msgstr "Nuwe lêer"
 
-#: schematic/scheme/gschem/builtins.scm:56
 #, fuzzy
 msgid "Open File"
 msgstr "Maak lêer oop..."
 
-#: schematic/scheme/gschem/builtins.scm:62
 #, fuzzy
 msgid "Save As"
 msgstr "Bewaar Alles"
 
-#: schematic/scheme/gschem/builtins.scm:68
 #, fuzzy
 msgid "Print"
 msgstr "Druk..."
 
-#: schematic/scheme/gschem/builtins.scm:71
 msgid "Export Image"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:74
 msgid "Run Script"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:80
 #, fuzzy
 msgid "Close Window"
 msgstr "Sluit Venster"
 
-#: schematic/scheme/gschem/builtins.scm:83
 msgid "Quit"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:87
 msgid "Terminal REPL"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:132
 msgid "Choose Slot"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:135
 #, fuzzy
 msgid "Edit Object Properties"
 msgstr "Bewerk Tekseienskappe"
 
-#: schematic/scheme/gschem/builtins.scm:138
 #, fuzzy
 msgid "Translate Symbol"
 msgstr "Verskuif"
 
-#: schematic/scheme/gschem/builtins.scm:147
 msgid "Invoke Macro"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:159
 #, fuzzy
 msgid "Show/Hide Invisible Text"
 msgstr "Toon/Verberg Onsigbare Teks"
 
-#: schematic/scheme/gschem/builtins.scm:165
 #, fuzzy
 msgid "Cut"
 msgstr "Sny 2"
 
-#: schematic/scheme/gschem/builtins.scm:171
 #, fuzzy
 msgid "Paste"
 msgstr "Plak 2"
 
-#: schematic/scheme/gschem/builtins.scm:177
 msgid "Sidebar"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:183
 #, fuzzy
 msgid "Find Text State"
 msgstr "Vind Teks"
 
-#: schematic/scheme/gschem/builtins.scm:186
 msgid "Redraw"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:192
 #, fuzzy
 msgid "Pan Left"
 msgstr "Aansigskuifmodus"
 
-#: schematic/scheme/gschem/builtins.scm:195
 #, fuzzy
 msgid "Pan Right"
 msgstr "Regs Bo"
 
-#: schematic/scheme/gschem/builtins.scm:198
 msgid "Pan Up"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:201
 #, fuzzy
 msgid "Pan Down"
 msgstr "Aansigskuifmodus"
 
-#: schematic/scheme/gschem/builtins.scm:216
 #, fuzzy
 msgid "Zoom Full"
 msgstr "/Zoem Uit"
 
-#: schematic/scheme/gschem/builtins.scm:219
 msgid "Dark Color Scheme"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:222
 msgid "Light Color Scheme"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:225
 msgid "Monochrome Color Scheme"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:228
 msgid "Show Color Scheme Editor"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:234
 #, fuzzy
 msgid "Revert Changes"
 msgstr "Gaan Bladsy Terug"
 
-#: schematic/scheme/gschem/builtins.scm:240
 #, fuzzy
 msgid "Previous Page"
 msgstr "Sluit Bladsy"
 
-#: schematic/scheme/gschem/builtins.scm:243
 #, fuzzy
 msgid "Next Page"
 msgstr "Nuwe Bladsy"
 
-#: schematic/scheme/gschem/builtins.scm:255
 #, fuzzy
 msgid "Print Page"
 msgstr "Sluit Bladsy"
 
-#: schematic/scheme/gschem/builtins.scm:276
 #, fuzzy
 msgid "Add Line"
 msgstr "Lyn"
 
-#: schematic/scheme/gschem/builtins.scm:279
 #, fuzzy
 msgid "Add Path"
 msgstr "/Voeg Net By"
 
-#: schematic/scheme/gschem/builtins.scm:282
 #, fuzzy
 msgid "Add Box"
 msgstr "/Voeg Bus By"
 
-#: schematic/scheme/gschem/builtins.scm:285
 #, fuzzy
 msgid "Add Circle"
 msgstr "Sirkel"
 
-#: schematic/scheme/gschem/builtins.scm:288
 #, fuzzy
 msgid "Add Arc"
 msgstr "Voeg Eienskap By"
 
-#: schematic/scheme/gschem/builtins.scm:291
 msgid "Add Pin"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:294
 #, fuzzy
 msgid "Add Picture"
 msgstr "Afbeelding"
 
-#: schematic/scheme/gschem/builtins.scm:306
 #, fuzzy
 msgid "Up Hierarchy"
 msgstr "Hierargie"
 
-#: schematic/scheme/gschem/builtins.scm:312
 #, fuzzy
 msgid "Attach Attributes"
 msgstr "Bewerk Eienskappe"
 
-#: schematic/scheme/gschem/builtins.scm:315
 #, fuzzy
 msgid "Detach Attributes"
 msgstr "Bewerk Eienskappe"
 
-#: schematic/scheme/gschem/builtins.scm:318
 #, fuzzy
 msgid "Show Attribute Value"
 msgstr "\"slot\" eienskap is misvorm\n"
 
-#: schematic/scheme/gschem/builtins.scm:321
 #, fuzzy
 msgid "Show Attribute Name"
 msgstr "\"slot\" eienskap is misvorm\n"
 
-#: schematic/scheme/gschem/builtins.scm:327
 msgid "Toggle Text Visibility"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:330
 #, fuzzy
 msgid "Find Specific Text"
 msgstr "Vind Teks"
 
-#: schematic/scheme/gschem/builtins.scm:333
 #, fuzzy
 msgid "Hide Specific Text"
 msgstr "Verskuil Teks"
 
-#: schematic/scheme/gschem/builtins.scm:336
 #, fuzzy
 msgid "Show Specific Text"
 msgstr "Toon Teks"
 
-#: schematic/scheme/gschem/builtins.scm:339
 msgid "Autonumber Text"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:345
 #, fuzzy
 msgid "Show Hotkeys"
 msgstr "Toon Verskuilde"
 
-#: schematic/scheme/gschem/builtins.scm:348
 msgid "Switch Grid Style"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:351
 msgid "Switch Snap Mode"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:354
 msgid "Set Grid Spacing"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:357
 msgid "Increase Grid Spacing"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:360
 msgid "Decrease Grid Spacing"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:363
 msgid "Toggle Outline Drawing"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:366
 msgid "Toggle Net Rubber Band"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:369
 msgid "Toggle Magnetic Nets"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:372
 #, fuzzy
 msgid "Show Log Window"
 msgstr "Nuwe Venster"
 
-#: schematic/scheme/gschem/builtins.scm:375
 #, fuzzy
 msgid "Show Coordinate Window"
 msgstr "Huidige Venster"
 
-#: schematic/scheme/gschem/builtins.scm:385
 #, fuzzy
 msgid "Component Documentation"
 msgstr "Komponentmodus"
 
-#: schematic/scheme/gschem/builtins.scm:387
 msgid "View documentation for selected component"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:403
 msgid ""
 "Could not show documentation for selected component:\n"
 "\n"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:408
 #, fuzzy
 msgid "gEDA Manuals"
 msgstr "Handleiding"
 
-#: schematic/scheme/gschem/builtins.scm:409
 msgid "View the front page of the gEDA documentation in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:414
 msgid "gschem User Guide"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:415
 msgid "View the gschem User Guide in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:420
 msgid "gschem FAQ"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:421
 msgid "Frequently Asked Questions about using gschem."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:426
 msgid "gEDA wiki"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:427
 msgid "View the front page of the gEDA wiki in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:431
 msgid "About gschem"
 msgstr "Oor gschem"
 
-#: schematic/scheme/gschem/deprecated.scm:102
 #, scheme-format
 msgid "Invalid text alignment ~A."
 msgstr ""
 
-#: schematic/scheme/gschem/gschemdoc.scm:241
 msgid "No documentation found"
 msgstr ""
 
-#: schematic/scheme/gschem/keymap.scm:40
 #, scheme-format
 msgid "~S is not a valid key combination."
 msgstr ""
 
-#: schematic/scheme/gschem/keymap.scm:157
 #, scheme-format
 msgid "~S is not a prefix key sequence."
 msgstr ""

--- a/schematic/po/ar.po
+++ b/schematic/po/ar.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-15 15:13+0300\n"
+"POT-Creation-Date: 2019-02-22 14:08+0300\n"
 "PO-Revision-Date: 2010-02-14 06:08+0000\n"
 "Last-Translator: عبدالله شلي (Abdellah Chelli) <Unknown>\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -19,24 +19,20 @@ msgstr ""
 "X-Poedit-Language: Arabic\n"
 "X-Poedit-SourceCharset: utf-8\n"
 
-#: schematic/src/a_zoom.c:155
 #, fuzzy
 msgid "Zoom too small!  Cannot zoom further."
 msgstr "التبعيد كبير جدا! لا يمكن التبعيد أكثر.\n"
 
-#: schematic/src/color_edit_widget.c:399
 #, fuzzy, c-format
 msgid ""
 "Could not save file [%s]:\n"
 "%s"
 msgstr "تعذر فتح الملف %s\n"
 
-#: schematic/src/color_edit_widget.c:434
 #, fuzzy
 msgid "Save Color Scheme As..."
 msgstr "مخطط ألوان _فاتحة"
 
-#: schematic/src/color_edit_widget.c:482 schematic/src/x_fileselect.c:292
 #, fuzzy, c-format
 msgid ""
 "The selected file `%1$s' already exists.\n"
@@ -47,179 +43,141 @@ msgstr ""
 "\n"
 "هل تريد الكتابة فوقه؟"
 
-#: schematic/src/color_edit_widget.c:486 schematic/src/x_fileselect.c:295
 msgid "Overwrite file?"
 msgstr "اكتب على الملف؟"
 
-#: schematic/src/font_select_widget.c:211
 msgid "_Apply"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:215
 msgid "Sa_ve..."
 msgstr ""
 
-#: schematic/src/font_select_widget.c:278
 #, c-format
 msgid "<b>Current:</b> %s"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:453
 msgid "Save configuration"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:461
 #, fuzzy
 msgid "Save settings to:"
 msgstr "إعدادات"
 
-#: schematic/src/font_select_widget.c:465
 msgid "Local configuration file (in current directory)"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:467
 msgid "User configuration file (geda-user.conf)"
 msgstr ""
 
-#: schematic/src/g_attrib.c:90
 msgid "Object ~A is not included in the current gschem page."
 msgstr ""
 
-#: schematic/src/g_attrib.c:110
 msgid "Invalid text name/value visibility ~A."
 msgstr ""
 
-#: schematic/src/g_rc.c:107
 #, fuzzy, c-format
 msgid "You are running gEDA/gaf version [%1$s%2$s.%3$s],\n"
 msgstr "إصدار gEDA/gschem‫ %s%s.%s\n"
 
-#: schematic/src/g_rc.c:111
 #, c-format
 msgid ""
 "but you have a version [%1$s] gschemrc file:\n"
 "[%2$s]\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:114
 #, c-format
 msgid "Please be sure that you have the latest rc file.\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:240
 #, fuzzy, c-format
 msgid "Invalid size [%1$d] passed to text-size\n"
 msgstr "مرّر حجم غير صالح [%d] إلى 'حجم النص'\n"
 
-#: schematic/src/g_rc.c:283
 #, fuzzy, c-format
 msgid "Invalid size [%1$d] passed to snap-size\n"
 msgstr "مرّر حجم غير صالح [%d] إلى 'حجم الجذب'\n"
 
-#: schematic/src/g_rc.c:620
 #, fuzzy, c-format
 msgid "Invalid num levels [%1$d] passed to undo-levels\n"
 msgstr "مرّر عدد مستويات غير صالح [%d] إلى 'مستويات التراجع'\n"
 
-#: schematic/src/g_rc.c:831
 #, fuzzy, c-format
 msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
 msgstr "مرّر حجم غير صالح [%d] إلى 'حجم كسار الناقل'\n"
 
-#: schematic/src/g_rc.c:931
 #, fuzzy, c-format
 msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
 msgstr "مرّر حجم نقط غير صالح [%d] إلى 'حجم النقط للشبيكة النقطية'\n"
 
-#: schematic/src/g_rc.c:972
 #, fuzzy, c-format
 msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
 msgstr "مرّر تباعد بكسل غير صالح [%d] إلى 'العتبة الثابتة للشبيكة النقطية'\n"
 
-#: schematic/src/g_rc.c:998
 #, fuzzy, c-format
 msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
 msgstr "مرّر تباعد بكسل غير صالح [%d] إلى 'عتبة العرض لشبيكة الشُرَط'\n"
 
-#: schematic/src/g_rc.c:1023
 #, fuzzy, c-format
 msgid "Invalid offset [%1$d] passed to add-attribute-offset\n"
 msgstr "مرّرت قيمة إزاحة غير صالحة [%d] إلى 'إزاحة إضافة السمة'\n"
 
-#: schematic/src/g_rc.c:1047
 #, fuzzy, c-format
 msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
 msgstr "مرّر عدد ثواني غير صالح [%d] إلى 'مدّة الحفظ الآلي'\n"
 
-#: schematic/src/g_rc.c:1071
 #, fuzzy, c-format
 msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
 msgstr "مرّر معامل ربح غير صالح [%d] إلى 'معامل ربح الفأرة'\n"
 
-#: schematic/src/g_rc.c:1094
 #, fuzzy, c-format
 msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
 msgstr "مرّر معامل ربح غير صالح [%d] إلى 'معامل ربح لوحة المفاتيح'\n"
 
-#: schematic/src/g_rc.c:1118
 #, fuzzy, c-format
 msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
 msgstr "مرّر عدد بكسلات غير صالح [%d] إلى 'بكسلات مهملة للانتقاء'\n"
 
-#: schematic/src/g_rc.c:1144
 #, fuzzy, c-format
 msgid "Invalid gain [%1$d] passed to zoom-gain\n"
 msgstr "مرّر معامل ربح غير صالح [%d] إلى 'معامل ربح التقريب'\n"
 
-#: schematic/src/g_rc.c:1169
 #, fuzzy, c-format
 msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
 msgstr "مرّر عدد خطوات غير صالح [%d] إلى 'خطوات شريط التمرير'\n"
 
-#: schematic/src/g_select.c:78 schematic/src/g_select.c:115
-#: schematic/src/g_select.c:151
 msgid "Object ~A is not directly included in a page."
 msgstr ""
 
-#: schematic/src/g_util.c:54
 msgid "Could not launch URI ~S: ~A"
 msgstr ""
 
-#: schematic/src/g_window.c:139
 msgid "Found invalid gschem window smob ~S"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:156
 #, fuzzy, c-format
 msgid "Lepton EDA/lepton-schematic version %1$s%2$s.%3$s git: %4$.7s"
 msgstr "إصدار gEDA/gschem‫ %s%s.%s\n"
 
-#: schematic/src/lepton-schematic.c:163
 #, c-format
 msgid "This is the MINGW32 port.\n"
 msgstr "هذا نقل(Port) عن طريق MINGW32.\n"
 
-#: schematic/src/lepton-schematic.c:167
 #, fuzzy, c-format
 msgid "Current locale settings: %1$s\n"
 msgstr "الإعدادات المحلية الحالية: %s\n"
 
-#: schematic/src/lepton-schematic.c:201
 #, fuzzy, c-format
 msgid "Couldn't find init scm file [%1$s]"
 msgstr "تعذّر العثور على ملف الاستهلال [‎%s‬]\n"
 
-#: schematic/src/lepton-schematic.c:206
 #, fuzzy, c-format
 msgid "Read init scm file [%1$s]"
 msgstr "قراءة ملف الاستهلال [‎%s‬]\n"
 
-#: schematic/src/lepton-schematic.c:210
 #, fuzzy, c-format
 msgid "Failed to read init scm file [%1$s]"
 msgstr "فشل قراءة ملف الاستهلال [‎%s‬]\n"
 
-#: schematic/src/lepton-schematic.c:290
 #, c-format
 msgid ""
 "ERROR: Failed to load or evaluate startup script.\n"
@@ -227,706 +185,526 @@ msgid ""
 "The lepton-schematic log may contain more information.\n"
 msgstr ""
 
-#: schematic/src/gschem_about_dialog.c:51
 #, c-format
 msgid "%s (git: %.7s)"
 msgstr ""
 
-#: schematic/src/gschem_about_dialog.c:75
 #, fuzzy
 msgid "Lepton Electronic Design Automation"
 msgstr "gEDA: GPL Electronic Design Automation (أتمتة التصميم الإلكتروني)"
 
-#: schematic/src/gschem_about_dialog.c:83
 msgid ""
 "Copyright © 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright © 2017-2018 Lepton Developers.\n"
-"See AUTHORS and ChangeLog files for details."
+"Copyright © 2017-2019 Lepton Developers.\n"
+"See AUTHORS, ChangeLog files and consult 'git log' history for details."
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:69
 msgid "Upper Left"
 msgstr "اليسار العلوي"
 
-#: schematic/src/gschem_alignment_combo.c:71
 msgid "Upper Middle"
 msgstr "الوسط العلوي"
 
-#: schematic/src/gschem_alignment_combo.c:73
 #, fuzzy
 msgid "Upper Right"
 msgstr "اليمين السفلي"
 
-#: schematic/src/gschem_alignment_combo.c:78
 msgid "Middle Left"
 msgstr "اليسار الوسطي"
 
-#: schematic/src/gschem_alignment_combo.c:80
 msgid "Middle Middle"
 msgstr "الوسط الوسطي"
 
-#: schematic/src/gschem_alignment_combo.c:82
 msgid "Middle Right"
 msgstr "اليمين الوسطي"
 
-#: schematic/src/gschem_alignment_combo.c:87
 msgid "Lower Left"
 msgstr "اليسار السفلي"
 
-#: schematic/src/gschem_alignment_combo.c:89
 msgid "Lower Middle"
 msgstr "الوسط السفلي"
 
-#: schematic/src/gschem_alignment_combo.c:91
 msgid "Lower Right"
 msgstr "اليمين السفلي"
 
-#: schematic/src/gschem_arc_dialog.c:104
 msgid "Arc Params"
 msgstr "معاملات القوس"
 
-#: schematic/src/gschem_arc_dialog.c:140
 #, fuzzy
 msgid "Arc _Radius:"
 msgstr "﻿شعاع القوس:"
 
-#: schematic/src/gschem_arc_dialog.c:141
 #, fuzzy
 msgid "Start _Angle:"
 msgstr "زاوية البدأ:"
 
-#: schematic/src/gschem_arc_dialog.c:142
 #, fuzzy
 msgid "_Degrees of Sweep:"
 msgstr "درجات الاجتياح:"
 
-#: schematic/src/gschem_bottom_widget.c:504
 msgid "Left mouse button"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:508
 #, fuzzy
 msgid "Middle mouse button"
 msgstr "اليسار الوسطي"
 
-#: schematic/src/gschem_bottom_widget.c:512
 #, fuzzy
 msgid "Right mouse button"
 msgstr ""
 "وضع إضافة شبكات\n"
 "الزر الأيمن للفارة للإلغاء"
 
-#: schematic/src/gschem_bottom_widget.c:595
 msgid "(Snap size, Grid size)"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:603
 #, fuzzy
 msgid "Net rubber band mode"
 msgstr "بدّل الشريط الم_طاطي للشبكة"
 
-#: schematic/src/gschem_bottom_widget.c:614
 #, fuzzy
 msgid "Magnetic net mode"
 msgstr "وضع الشبكة المغناطيسية"
 
-#: schematic/src/gschem_bottom_widget.c:622
 #, fuzzy
 msgid "Current action mode"
 msgstr "النافذة الحالية"
 
-#: schematic/src/gschem_bottom_widget.c:935
-#: schematic/src/gschem_bottom_widget.c:951
 msgid "OFF"
 msgstr "إيقاف"
 
-#: schematic/src/gschem_bottom_widget.c:954
 msgid "NONE"
 msgstr "لا شيئ"
 
-#: schematic/src/gschem_bottom_widget.c:960
 #, fuzzy, c-format
 msgid "Grid(%1$s, %2$s)"
 msgstr "شبيكة(%s, %s)"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:350
-#: schematic/src/x_compselect.c:1236 schematic/src/x_multiattrib.c:2068
 msgid "Name"
 msgstr "اسم"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:372
 msgid "S_elect the schematics you want to save:"
 msgstr "انتق المخططات التي تريد حفظها:"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:467
 #, fuzzy, c-format
 msgid "Save the changes to schematic \"%1$s\" before closing?"
 msgstr "﻿هل تريد حفظ التغييرات إلى المخطط \"%s\" قبل الإغلاق؟"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:473
 #, fuzzy, c-format
 msgid ""
 "There are %1$d schematics with unsaved changes. Save changes before closing?"
 msgstr "﻿هناك %d مخطط مع تغييرات غير محفوظة. هل تريد حفظ التغييرات قبل الإغلاق؟"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:502
 msgid "If you don't save, all your changes will be permanently lost."
 msgstr "ستضيع جميع التّغييرات للأبد إذا لم تحفظ."
 
-#: schematic/src/gschem_close_confirmation_dialog.c:522
 #, fuzzy
 msgid "Close _without saving"
 msgstr "أ_غلق دون حفظ"
 
-#: schematic/src/gschem_coord_dialog.c:86
 msgid "Coords"
 msgstr "إحداثيات"
 
-#: schematic/src/gschem_coord_dialog.c:106
 msgid "Screen"
 msgstr "شاشة"
 
-#: schematic/src/gschem_coord_dialog.c:115
 msgid "World"
 msgstr "عالم"
 
-#: schematic/src/gschem_find_text_state.c:809 schematic/src/x_pagesel.c:432
 msgid "Filename"
 msgstr "اسم الملف"
 
-#: schematic/src/gschem_find_text_state.c:821 schematic/src/i_callbacks.c:1970
-#: schematic/src/x_colorcb.c:154 schematic/src/x_widgets.c:179
-#: schematic/src/x_window.c:1226 schematic/src/x_window.c:1440
 msgid "Text"
 msgstr "نص"
 
-#: schematic/src/gschem_find_text_widget.c:427
 msgid "descend into hierarchy"
 msgstr "﻿انحدر في التسلسل الهرمي"
 
-#: schematic/src/gschem_find_text_widget.c:435
 #, fuzzy
 msgid "Find"
 msgstr "ابحث عن نص"
 
-#: schematic/src/gschem_find_text_widget.c:557
 #, fuzzy
 msgid "Find Text:"
 msgstr "ابحث عن نص"
 
-#: schematic/src/gschem_find_text_widget.c:564
 msgid "Find Pattern:"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:571
 #, fuzzy
 msgid "Find Regex:"
 msgstr "ابحث عن نص"
 
-#: schematic/src/gschem_find_text_widget.c:578
 msgid "Check symbol:"
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:200
 msgid "Hotkeys"
 msgstr "مفاتيح ساخنة"
 
-#: schematic/src/gschem_hotkey_dialog.c:229
 msgid ""
 "Start typing action name or keystroke to filter the list.\n"
 "Type hotkeys as they are displayed in \"Keystroke(s)\" column."
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:233 schematic/src/x_compselect.c:1124
 #, fuzzy
 msgid "_Filter:"
 msgstr "المرشح:"
 
-#: schematic/src/gschem_hotkey_dialog.c:259 schematic/src/i_basic.c:280
 msgid "Action"
 msgstr "إجراء"
 
-#: schematic/src/gschem_hotkey_dialog.c:277
 msgid "Keystroke(s)"
 msgstr "ضغطة مفاتيح"
 
-#: schematic/src/gschem_log_widget.c:177
 msgid "** Invalid UTF-8 in log message. See stderr or gschem.log.\n"
 msgstr "‏﻿** UTF-8 غير صالح في رسالة سجل. راجع stderr أو gschem.log.\n"
 
-#: schematic/src/gschem_log_widget.c:434
 #, fuzzy
 msgid "Clear log window?"
 msgstr "إغلاق النافذة\n"
 
-#: schematic/src/gschem_log_widget.c:477
 #, fuzzy
 msgid "Clear Log _Window"
 msgstr "أظهر نافذة ال_سجل..."
 
-#: schematic/src/gschem_macro_widget.c:231
 msgid "Macro:"
 msgstr ""
 
-#: schematic/src/gschem_macro_widget.c:387
 msgid "Evaluate"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:172
 #, fuzzy
 msgid "_Fill Type:"
 msgstr "نوع الملء:"
 
-#: schematic/src/gschem_object_properties_widget.c:173
 #, fuzzy
 msgid "Lin_e Width:"
 msgstr "عرض الخط:"
 
-#: schematic/src/gschem_object_properties_widget.c:174
 #, fuzzy
 msgid "Angle _1:"
 msgstr "الزاوية 1:"
 
-#: schematic/src/gschem_object_properties_widget.c:175
 #, fuzzy
 msgid "P_itch 1:"
 msgstr "الإنحدار 1:"
 
-#: schematic/src/gschem_object_properties_widget.c:176
 #, fuzzy
 msgid "Angle _2:"
 msgstr "الزاوية 2:"
 
-#: schematic/src/gschem_object_properties_widget.c:177
 #, fuzzy
 msgid "Pitc_h 2:"
 msgstr "الإنحدار 2:"
 
-#: schematic/src/gschem_object_properties_widget.c:237
 #, fuzzy
 msgid "<b>Fill Properties</b>"
 msgstr "<b>خصائص النص</b>"
 
-#: schematic/src/gschem_object_properties_widget.c:255
-#: schematic/src/gschem_text_properties_widget.c:258
-#: schematic/src/x_newtext.c:271
 #, fuzzy
 msgid "Colo_r:"
 msgstr "اللون:"
 
-#: schematic/src/gschem_object_properties_widget.c:266
 #, fuzzy
 msgid "<b>General Properties</b>"
 msgstr "<b>خصائص النص</b>"
 
-#: schematic/src/gschem_object_properties_widget.c:284
 #, fuzzy
 msgid "_Type:"
 msgstr "النّوع:"
 
-#: schematic/src/gschem_object_properties_widget.c:285
 #, fuzzy
 msgid "_Width:"
 msgstr "العرض:"
 
-#: schematic/src/gschem_object_properties_widget.c:286
 #, fuzzy
 msgid "Dash _Length:"
 msgstr "طول الشرطة:"
 
-#: schematic/src/gschem_object_properties_widget.c:287
 #, fuzzy
 msgid "Dash _Space:"
 msgstr "فراغ الشرطة:"
 
-#: schematic/src/gschem_object_properties_widget.c:288
 msgid "C_ap style:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:333
 #, fuzzy
 msgid "<b>Line Properties</b>"
 msgstr "<b>خصائص النص</b>"
 
-#: schematic/src/gschem_object_properties_widget.c:351
 #, fuzzy
 msgid "_Pin Type:"
 msgstr "نوع الدبوس"
 
-#: schematic/src/gschem_object_properties_widget.c:362
 #, fuzzy
 msgid "<b>Pin Properties</b>"
 msgstr "<b>خصائص النص</b>"
 
-#: schematic/src/gschem_options_widget.c:217
 msgid "_Off"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:220
 msgid "_Dots"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:223
 msgid "M_esh"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:245
 #, fuzzy
 msgid "Net R_ubber Band Mode:"
 msgstr "بدّل الشريط الم_طاطي للشبكة"
 
-#: schematic/src/gschem_options_widget.c:246
 #, fuzzy
 msgid "_Magnetic Net Mode:"
 msgstr "وضع الشبكة المغناطيسية"
 
-#: schematic/src/gschem_options_widget.c:250
-#: schematic/src/gschem_options_widget.c:251
 msgid "Enabled"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:265
 #, fuzzy
 msgid "<b>Net Options</b>"
 msgstr "<b>الخيارات</b>"
 
-#: schematic/src/gschem_options_widget.c:282
 #, fuzzy
 msgid "Grid Mode:"
 msgstr "وضع القوس"
 
-#: schematic/src/gschem_options_widget.c:283
 #, fuzzy
 msgid "Snap Mode:"
 msgstr "وضع الإنتقال الإختياري"
 
-#: schematic/src/gschem_options_widget.c:284
 #, fuzzy
 msgid "_Snap Size:"
 msgstr "حجم الجذب"
 
-#: schematic/src/gschem_options_widget.c:301
 #, fuzzy
 msgid "<b>Snap Options</b>"
 msgstr "<b>الخيارات</b>"
 
-#: schematic/src/gschem_options_widget.c:340
 msgid "O_ff"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:343
 #, fuzzy
 msgid "_Grid"
 msgstr "شبيكة موقفة\n"
 
-#: schematic/src/gschem_options_widget.c:346
 #, fuzzy
 msgid "_Resnap"
 msgstr "تفعيل إعادة الجذب"
 
-#: schematic/src/gschem_pin_type_combo.c:73
 msgid "Net pin"
 msgstr "دبوس لشبكة"
 
-#: schematic/src/gschem_pin_type_combo.c:80
 msgid "Bus pin (graphical)"
 msgstr "دبوس لناقل (رسومي)"
 
-#: schematic/src/gschem_preview.c:195
 msgid "Preview Buffer"
 msgstr "معاينة المخزن"
 
-#: schematic/src/gschem_show_hide_text_widget.c:148
-#: schematic/src/x_window.c:1268
 #, fuzzy
 msgid "Hide"
 msgstr "أخف النص"
 
-#: schematic/src/gschem_show_hide_text_widget.c:157
-#: schematic/src/x_window.c:1269
 msgid "Hide text starting with:"
 msgstr "أخف النص البادئ بـ:"
 
-#: schematic/src/gschem_slot_edit_dialog.c:91
 msgid "Edit slot number"
 msgstr "﻿حرّر عدد الشقّ"
 
-#: schematic/src/gschem_slot_edit_dialog.c:121
 msgid "Number of Slots:"
 msgstr ""
 
-#: schematic/src/gschem_slot_edit_dialog.c:122
 #, fuzzy
 msgid "Slot Number:"
 msgstr "﻿تحرير عدد الشقّ:"
 
-#: schematic/src/gschem_text_properties_widget.c:240
-#: schematic/src/x_newtext.c:265
 msgid "<b>Text Content</b>"
 msgstr "<b>محتوى النص</b>"
 
-#: schematic/src/gschem_text_properties_widget.c:259
-#: schematic/src/x_newtext.c:291
 #, fuzzy
 msgid "_Size:"
 msgstr "الحجم:"
 
-#: schematic/src/gschem_text_properties_widget.c:260
-#: schematic/src/x_newtext.c:310
 #, fuzzy
 msgid "Ali_gnment:"
 msgstr "المحاذاة:"
 
-#: schematic/src/gschem_text_properties_widget.c:261
-#: schematic/src/x_newtext.c:330
 #, fuzzy
 msgid "Ro_tation:"
 msgstr "الاتّجاه:"
 
-#: schematic/src/gschem_text_properties_widget.c:294
-#: schematic/src/x_newtext.c:253
 msgid "<b>Text Properties</b>"
 msgstr "<b>خصائص النص</b>"
 
-#: schematic/src/gschem_translate_widget.c:238
 #, fuzzy
 msgid "Coordinate:"
 msgstr "أظهر نافذة الم_علم..."
 
-#: schematic/src/gschem_translate_widget.c:405 schematic/src/i_callbacks.c:800
 msgid "Translate"
 msgstr "اسحب"
 
-#: schematic/src/i_basic.c:64 schematic/src/x_window.c:1369
-#: schematic/scheme/conf/schematic/menu.scm:59
-#: schematic/scheme/gschem/builtins.scm:99
 msgid "Select Mode"
 msgstr "وضع الانتقاء"
 
-#: schematic/src/i_basic.c:65
 #, fuzzy
 msgid "Select Box Mode"
 msgstr "وضع الانتقاء"
 
-#: schematic/src/i_basic.c:66
 msgid "Text Mode"
 msgstr "وضع النص"
 
-#: schematic/src/i_basic.c:67
 msgid "Pan Mode"
 msgstr "وضع الإنتقال الإختياري"
 
-#: schematic/src/i_basic.c:70
 #, c-format
 msgid "Paste %d Mode"
 msgstr "وضع اللصق %d"
 
-#: schematic/src/i_basic.c:74
 msgid "Magnetic Net Mode"
 msgstr "وضع الشبكة المغناطيسية"
 
-#: schematic/src/i_basic.c:76
 msgid "Net Mode"
 msgstr "وضع الشبكة"
 
-#: schematic/src/i_basic.c:77
 msgid "Arc Mode"
 msgstr "وضع القوس"
 
-#: schematic/src/i_basic.c:78
 msgid "Box Mode"
 msgstr "وضع الإطار"
 
-#: schematic/src/i_basic.c:79
 msgid "Bus Mode"
 msgstr "وضع الناقل"
 
-#: schematic/src/i_basic.c:80
 msgid "Circle Mode"
 msgstr "وضع الدائرة"
 
-#: schematic/src/i_basic.c:81
 msgid "Component Mode"
 msgstr "وضع المكون"
 
-#: schematic/src/i_basic.c:82 schematic/scheme/conf/schematic/menu.scm:62
-#: schematic/scheme/gschem/builtins.scm:114
 msgid "Copy Mode"
 msgstr "وضع النسخ"
 
-#: schematic/src/i_basic.c:83 schematic/scheme/conf/schematic/menu.scm:63
-#: schematic/scheme/gschem/builtins.scm:117
 msgid "Multiple Copy Mode"
 msgstr "وضع النسخ المتعدد"
 
-#: schematic/src/i_basic.c:84
 msgid "Line Mode"
 msgstr "وضع الخط"
 
-#: schematic/src/i_basic.c:85 schematic/scheme/conf/schematic/menu.scm:66
-#: schematic/scheme/gschem/builtins.scm:123
 msgid "Mirror Mode"
 msgstr "وضع المرآة"
 
-#: schematic/src/i_basic.c:86 schematic/scheme/conf/schematic/menu.scm:64
-#: schematic/scheme/gschem/builtins.scm:111
 msgid "Move Mode"
 msgstr "وضع التّحريك"
 
-#: schematic/src/i_basic.c:87
 #, fuzzy
 msgid "Path Mode"
 msgstr "وضع الإنتقال الإختياري"
 
-#: schematic/src/i_basic.c:88
 msgid "Picture Mode"
 msgstr "وضع الصورة"
 
-#: schematic/src/i_basic.c:89
 msgid "Pin Mode"
 msgstr "وضع الدبوس"
 
-#: schematic/src/i_basic.c:90 schematic/scheme/gschem/builtins.scm:120
 msgid "Rotate Mode"
 msgstr "وضع الإستدارة"
 
-#: schematic/src/i_basic.c:91
 #, fuzzy
 msgid "Modify Mode"
 msgstr "وضع النسخ"
 
-#: schematic/src/i_basic.c:92 schematic/src/x_menus.c:49
-#: schematic/scheme/gschem/builtins.scm:204
 msgid "Zoom Box"
 msgstr "قرّب المربع"
 
-#: schematic/src/i_basic.c:121
 msgid "Show Hidden"
 msgstr "أظهر المخفي"
 
-#: schematic/src/i_basic.c:124
 msgid "Snap Off"
 msgstr "إيقاف الجذب"
 
-#: schematic/src/i_basic.c:126
 msgid "Resnap Active"
 msgstr "تفعيل إعادة الجذب"
 
-#: schematic/src/i_basic.c:288 schematic/src/x_colorcb.c:159
 msgid "Stroke"
 msgstr "جرة (Stroke)"
 
-#: schematic/src/i_basic.c:296 schematic/src/i_basic.c:330
-#: schematic/src/x_window.c:1361
 msgid "none"
 msgstr "لا شيء"
 
-#: schematic/src/i_basic.c:304
 msgid "Repeat/"
 msgstr "كرّر/"
 
-#: schematic/src/i_basic.c:315
 msgid "Repeat/none"
 msgstr "كرّر/لا شيء"
 
-#: schematic/src/i_basic.c:323 schematic/src/i_callbacks.c:1239
-#: schematic/scheme/gschem/builtins.scm:189
 msgid "Pan"
 msgstr "انتقل"
 
-#: schematic/src/i_callbacks.c:74
 #, fuzzy, c-format
 msgid "New page created [%1$s]"
 msgstr "أنشئت صفحة جديدة [‎%s‬]\n"
 
-#: schematic/src/i_callbacks.c:108
 #, fuzzy, c-format
 msgid "New Window created [%1$s]"
 msgstr "أنشئت نافذة جديدة [‎%s‬]\n"
 
-#: schematic/src/i_callbacks.c:245
 msgid "Failed to Save All"
 msgstr "فشل حفظ الكل"
 
-#: schematic/src/i_callbacks.c:247
 msgid "Saved All"
 msgstr "حفظ الكل"
 
-#: schematic/src/i_callbacks.c:308
 #, fuzzy
 msgid "Closing Window"
 msgstr "إغلاق النافذة\n"
 
-#: schematic/src/i_callbacks.c:505 schematic/src/x_menus.c:55
-#: schematic/scheme/gschem/builtins.scm:168
 msgid "Copy"
 msgstr "انسخ"
 
-#: schematic/src/i_callbacks.c:514 schematic/src/i_callbacks.c:539
-#: schematic/src/i_callbacks.c:564
 msgid "Select objs first"
 msgstr "انتق الكائنات أولا"
 
-#: schematic/src/i_callbacks.c:530
 msgid "Multiple Copy"
 msgstr "نسخ متعدد"
 
-#: schematic/src/i_callbacks.c:555 schematic/src/x_menus.c:56
 msgid "Move"
 msgstr "حرّك"
 
-#: schematic/src/i_callbacks.c:579 schematic/src/x_menus.c:57
-#: schematic/src/x_multiattrib.c:1656 schematic/scheme/gschem/builtins.scm:108
 msgid "Delete"
 msgstr "احذف"
 
-#: schematic/src/i_callbacks.c:603
 msgid "Edit"
 msgstr "تحرير"
 
-#: schematic/src/i_callbacks.c:618 schematic/scheme/gschem/builtins.scm:129
 msgid "Edit Text"
 msgstr "حرّر النص"
 
-#: schematic/src/i_callbacks.c:637
 msgid "Slot"
 msgstr "شقّ"
 
-#: schematic/src/i_callbacks.c:688 schematic/src/i_callbacks.c:698
 msgid "Rotate"
 msgstr "أدر"
 
-#: schematic/src/i_callbacks.c:736 schematic/src/i_callbacks.c:746
 msgid "Mirror"
 msgstr "مرآة"
 
-#: schematic/src/i_callbacks.c:763 schematic/src/x_colorcb.c:160
-#: schematic/scheme/conf/schematic/menu.scm:73
-#: schematic/scheme/gschem/builtins.scm:141
 msgid "Lock"
 msgstr "أقفل"
 
-#: schematic/src/i_callbacks.c:781 schematic/scheme/conf/schematic/menu.scm:74
-#: schematic/scheme/gschem/builtins.scm:144
 msgid "Unlock"
 msgstr "فكّ القفل"
 
-#: schematic/src/i_callbacks.c:805
 #, fuzzy
 msgid "WARNING: Do not translate with snap off!"
 msgstr "تحذير: لا تسحب مع جذب موقف!\n"
 
-#: schematic/src/i_callbacks.c:806
 #, fuzzy
 msgid "WARNING: Turning snap on and continuing with translate."
 msgstr "تحذير: تشغيل الجذب و المتابعة مع السحب.\n"
 
-#: schematic/src/i_callbacks.c:813
 #, fuzzy
 msgid "WARNING: Snap grid size is not equal to 100!"
 msgstr "تحذير: حجم شبيكة الجذب لا يساوي 100!\n"
 
-#: schematic/src/i_callbacks.c:815
 #, fuzzy
 msgid ""
 "WARNING: If you are translating a symbol to the origin, the snap grid size "
@@ -934,23 +712,18 @@ msgid ""
 msgstr ""
 "تحذير: إذا كنت تسحب رمزا إلى المبدأ، يجب أن يعيّن حجم شبيكة الجذب إلى 100\n"
 
-#: schematic/src/i_callbacks.c:847
 msgid "Embed"
 msgstr "ضمّن"
 
-#: schematic/src/i_callbacks.c:886
 msgid "Unembed"
 msgstr "لا تضمّن"
 
-#: schematic/src/i_callbacks.c:928
 msgid "Update"
 msgstr "حدّث"
 
-#: schematic/src/i_callbacks.c:970
 msgid "ShowHidden"
 msgstr "أظهر المخفي"
 
-#: schematic/src/i_callbacks.c:1537
 #, c-format
 msgid ""
 "<b>Revert page:</b>\n"
@@ -961,100 +734,78 @@ msgid ""
 "discarded and page file will be reloaded from disk."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1555
 #, fuzzy
 msgid "Revert"
 msgstr "ت_راجع"
 
-#: schematic/src/i_callbacks.c:1647
 msgid "Copy to clipboard"
 msgstr "انسخ إلى الحافظة"
 
-#: schematic/src/i_callbacks.c:1664
 msgid "Cut to clipboard"
 msgstr "قصّ إلى الحافظة"
 
-#: schematic/src/i_callbacks.c:1686
 msgid "Paste from clipboard"
 msgstr "ألصق من الحافظة"
 
-#: schematic/src/i_callbacks.c:1694
 #, fuzzy
 msgid "Empty clipboard"
 msgstr "انسخ إلى الحافظة"
 
 #. TRANSLATORS: The number is the number of the buffer that the
 #. * selection is being copied to.
-#: schematic/src/i_callbacks.c:1719
 #, fuzzy, c-format
 msgid "Copy %i"
 msgstr "انسخ 1"
 
 #. TRANSLATORS: The number is the number of the buffer that the
 #. * selection is being cut to.
-#: schematic/src/i_callbacks.c:1746
 #, fuzzy, c-format
 msgid "Cut %i"
 msgstr "قص 1"
 
 #. TRANSLATORS: The number is the number of the buffer that is being
 #. * pasted to the schematic.
-#: schematic/src/i_callbacks.c:1776
 #, fuzzy, c-format
 msgid "Paste %i"
 msgstr "ألصق 1"
 
-#: schematic/src/i_callbacks.c:1785
 msgid "Empty buffer"
 msgstr "أفرغ المخزن"
 
-#: schematic/src/i_callbacks.c:1833 schematic/src/x_window.c:1203
 msgid "Component"
 msgstr "مكوّن"
 
-#: schematic/src/i_callbacks.c:1865 schematic/src/x_colorcb.c:150
 msgid "Attribute"
 msgstr "سمة"
 
-#: schematic/src/i_callbacks.c:1885 schematic/src/x_colorcb.c:149
 msgid "Net"
 msgstr "شبكة"
 
-#: schematic/src/i_callbacks.c:1928 schematic/src/x_colorcb.c:155
-#: schematic/src/x_window.c:1222
 msgid "Bus"
 msgstr "ناقل"
 
-#: schematic/src/i_callbacks.c:2004
 msgid "Line"
 msgstr "خط"
 
-#: schematic/src/i_callbacks.c:2021
 msgid "Path"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2043
 msgid "Box"
 msgstr "إطار"
 
-#: schematic/src/i_callbacks.c:2085
 msgid "Circle"
 msgstr "دائرة"
 
-#: schematic/src/i_callbacks.c:2108
 msgid "Arc"
 msgstr "قوس"
 
-#: schematic/src/i_callbacks.c:2131 schematic/src/x_colorcb.c:146
 msgid "Pin"
 msgstr "دبوس"
 
-#: schematic/src/i_callbacks.c:2191
 #, fuzzy, c-format
 msgid "Searching for source [%1$s]"
 msgstr "البحث عن المنبع [%s]\n"
 
-#: schematic/src/i_callbacks.c:2223
 #, c-format
 msgid ""
 "Failed to descend hierarchy into '%1$s': %2$s\n"
@@ -1062,121 +813,96 @@ msgid ""
 "The lepton-schematic log may contain more information."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2227
 #, fuzzy, c-format
 msgid "Failed to descend into '%1$s': %2$s"
 msgstr "فشل تحميل الصورة: %s"
 
-#: schematic/src/i_callbacks.c:2234
 #, fuzzy
 msgid "Failed to descend hierarchy."
 msgstr "﻿انحدر في التسلسل الهرمي"
 
-#: schematic/src/i_callbacks.c:2312
 #, fuzzy, c-format
 msgid "Searching for symbol [%1$s]"
 msgstr "البحث عن الرمز [%s]\n"
 
-#: schematic/src/i_callbacks.c:2320
 #, fuzzy
 msgid "Symbol is not a real file. Symbol cannot be loaded."
 msgstr "الرمز ليس ملفا حقيقيا. يتعذر تحميل الرمز.\n"
 
-#: schematic/src/i_callbacks.c:2367 schematic/src/x_tabs.c:1060
 #, fuzzy
 msgid "Cannot find any schematics above the current one!"
 msgstr "يتعذر إيجاد أي مخطط فوق الحالي!\n"
 
-#: schematic/src/i_callbacks.c:2400
 msgid "Attach"
 msgstr "أرفق"
 
-#: schematic/src/i_callbacks.c:2456
 msgid "Detach"
 msgstr "افصل"
 
-#: schematic/src/i_callbacks.c:2500
 msgid "ShowN"
 msgstr "أظهرN"
 
-#: schematic/src/i_callbacks.c:2537
 msgid "ShowV"
 msgstr "أظهرV"
 
-#: schematic/src/i_callbacks.c:2574
 msgid "ShowB"
 msgstr "أظهرB"
 
-#: schematic/src/i_callbacks.c:2612
 msgid "VisToggle"
 msgstr "تبديل الرؤية"
 
-#: schematic/src/i_callbacks.c:2643
 #, c-format
 msgid "Sorry but this is a non-functioning menu option\n"
 msgstr "عذرا خيار القائمة هذا غير فعّال\n"
 
-#: schematic/src/i_callbacks.c:2703
 #, fuzzy
 msgid "Action feedback mode set to OUTLINE"
 msgstr "وضع ردود الإجراء معيّن إلى حد الخارجي\n"
 
-#: schematic/src/i_callbacks.c:2706
 #, fuzzy
 msgid "Action feedback mode set to BOUNDINGBOX"
 msgstr "وضع ردود الإجراء معيّن إلى الإطار المحيط\n"
 
-#: schematic/src/i_callbacks.c:2730
 #, fuzzy
 msgid "Grid OFF"
 msgstr "شبيكة موقفة\n"
 
-#: schematic/src/i_callbacks.c:2731
 #, fuzzy
 msgid "Dot grid selected"
 msgstr "انتقيت الشبيكة النقطية\n"
 
-#: schematic/src/i_callbacks.c:2732
 #, fuzzy
 msgid "Mesh grid selected"
 msgstr "انتقيت شبيكة الشرط\n"
 
-#: schematic/src/i_callbacks.c:2733
 #, fuzzy
 msgid "Invalid grid mode"
 msgstr "﻿سمة غير صالحة"
 
-#: schematic/src/i_callbacks.c:2755
 #, fuzzy
 msgid "Snap OFF (CAUTION!)"
 msgstr "الجذب موقف (تنبيه)\n"
 
-#: schematic/src/i_callbacks.c:2758
 #, fuzzy
 msgid "Snap ON"
 msgstr "الجذب مشغّل\n"
 
-#: schematic/src/i_callbacks.c:2761
 #, fuzzy
 msgid "Snap back to the grid (CAUTION!)"
 msgstr "جذب نحو الشبيكة (تنبيه!)\n"
 
-#: schematic/src/i_callbacks.c:2790
 #, fuzzy
 msgid "Rubber band ON"
 msgstr "الشريط المطاطي مشغل\n"
 
-#: schematic/src/i_callbacks.c:2792
 #, fuzzy
 msgid "Rubber band OFF"
 msgstr "الشريط المطاطي موقف \n"
 
-#: schematic/src/i_callbacks.c:2811
 #, fuzzy
 msgid "magnetic net mode: ON"
 msgstr "وضع الشبكة المغناطيسية: مشغل\n"
 
-#: schematic/src/i_callbacks.c:2814
 #, fuzzy
 msgid "magnetic net mode: OFF"
 msgstr "وضع الشبكة المغناطيسية: موقف\n"
@@ -1186,143 +912,114 @@ msgstr "وضع الشبكة المغناطيسية: موقف\n"
 #. the form "untitled_N.sch", where N is a number.  Please make
 #. sure that the translation contains characters suitable for use
 #. in a filename.
-#: schematic/src/i_vars.c:209
 msgid "untitled"
 msgstr ""
 
-#: schematic/src/o_complex.c:192 schematic/src/o_complex.c:195
 #, fuzzy, c-format
 msgid "Translating schematic [%1$d %2$d]"
 msgstr "سحب المخطط [%d %d]\n"
 
-#: schematic/src/o_delete.c:82
 #, fuzzy, c-format
 msgid "Delete locked object?"
 msgid_plural "Delete %1$u locked objects?"
 msgstr[0] "الكائنات المنتقاة"
 msgstr[1] "الكائنات المنتقاة"
 
-#: schematic/src/o_misc.c:55
 #, c-format
 msgid "Got an unexpected NULL in o_edit\n"
 msgstr "حصلت على NULL غير متوقع في o_edit\n"
 
-#: schematic/src/o_misc.c:315
 #, fuzzy
 msgid "Hidden text is now visible"
 msgstr "أصبح الآن النص المخفي ظاهرا\n"
 
-#: schematic/src/o_misc.c:317
 #, fuzzy
 msgid "Hidden text is now invisible"
 msgstr "أصبح الآن النص المخفي مستترا\n"
 
-#: schematic/src/o_misc.c:425
 #, fuzzy, c-format
 msgid "Could not find symbol [%1$s] in library. Update failed."
 msgstr "﻿تعذر العثور على الرمز [%s] في المكتبة. فشل التحديث.\n"
 
-#: schematic/src/o_misc.c:541
 #, fuzzy, c-format
 msgid "o_autosave_backups: Can't get the real filename of %1$s."
 msgstr "﻿‏o_autosave_backups: تعذر الحصول على اسم الحقيقي للملف %s."
 
-#: schematic/src/o_misc.c:585
 #, fuzzy, c-format
 msgid "Could NOT set previous backup file [%1$s] read-write"
 msgstr "تعذر تعيين الملف الاحتياطي السابق [‎%s‬] للقراءة والكتابة\n"
 
-#: schematic/src/o_misc.c:605
 #, fuzzy, c-format
 msgid "Could NOT set backup file [%1$s] readonly"
 msgstr "تعذر تعيين الملف الاحتياطي [‎%s‬] للقراءة فقط\n"
 
-#: schematic/src/o_misc.c:610
 #, fuzzy, c-format
 msgid "Could NOT save backup file [%1$s]"
 msgstr "تعذر حفظ الملف الاحتياطي [‎%s‬]\n"
 
-#: schematic/src/o_move.c:192
 #, c-format
 msgid "ERROR: NULL object in o_move_end!\n"
 msgstr "﻿خطأ: كائن فارغ (NULL) في o_move_end!\n"
 
-#: schematic/src/o_move.c:519
 #, c-format
 msgid "DOH! tried to find the whichone, but didn't find it!\n"
 msgstr "عجبا! حاولت العثور على أيّ-واحد ولكن لم أعثر عليه!\n"
 
-#: schematic/src/o_move.c:546
 #, c-format
 msgid "Got a non line object in o_move_check_endpoint\n"
 msgstr "﻿حصلت على كائن غير مشكّل من خط في o_move_check_endpoint\n"
 
-#: schematic/src/o_net.c:444
 #, fuzzy
 msgid "Warning: Starting net at off grid coordinate"
 msgstr "﻿تحذير: بدء الشبكة خارج إحداثيات الشبيكة\n"
 
-#: schematic/src/o_net.c:508
 #, fuzzy
 msgid "Warning: Ending net at off grid coordinate"
 msgstr "﻿تحذير: إنهاء الشبكة خارج إحداثيات الشبيكة\n"
 
-#: schematic/src/o_net.c:856 schematic/src/o_net.c:893
-#: schematic/src/o_net.c:964 schematic/src/o_net.c:1000
 #, c-format
 msgid "Tried to add more than two bus rippers. Internal gschem error.\n"
 msgstr "﻿حاولت إضافة أكثر من اثنين من كسارات الناقل. خطأ داخلي ل‍ gschem.\n"
 
-#: schematic/src/o_net.c:1068
 #, fuzzy, c-format
 msgid "Bus ripper symbol [%1$s] was not found in any component library"
 msgstr "﻿لم يتم العثور على رمز كسار الناقل [%s] في أي مكتبة مكون\n"
 
-#: schematic/src/o_picture.c:133 schematic/src/o_picture.c:343
 #, fuzzy
 msgid "Select a picture file..."
 msgstr "انتق اسم ملف بوست-سكريبت..."
 
-#: schematic/src/o_picture.c:166
 #, fuzzy, c-format
 msgid "Failed to load picture: %1$s"
 msgstr "فشل تحميل الصورة: %s"
 
-#: schematic/src/o_picture.c:182
 msgid "Picture"
 msgstr "صورة"
 
-#: schematic/src/o_picture.c:378
 #, fuzzy, c-format
 msgid "Failed to replace pictures: %s"
 msgstr "فشل تحميل الصورة: %s"
 
-#: schematic/src/o_slot.c:80
 #, fuzzy
 msgid "Slot attribute malformed"
 msgstr "سمة ﻿الشقّ تالفة\n"
 
-#: schematic/src/o_slot.c:88
 #, fuzzy
 msgid "numslots attribute missing"
 msgstr "السمة numslots (عدد الشقوق) مفقودة\n"
 
-#: schematic/src/o_slot.c:89
 #, fuzzy
 msgid "Slotting not allowed for this component"
 msgstr "التقسيم (الشقّ) غير مسموح لهذا المكون\n"
 
-#: schematic/src/o_slot.c:104
 #, fuzzy
 msgid "New slot number out of range"
 msgstr "عدد شق جديد خارج النطاق\n"
 
-#: schematic/src/o_undo.c:397
 #, fuzzy
 msgid "Undo/Redo disabled in rc file"
 msgstr "التراجع/الإعادة معطلين في الملف rc\n"
 
-#: schematic/src/parsecmd.c:77
 #, c-format
 msgid ""
 "Usage: %1$s [OPTION ...] [--] [FILE ...]\n"
@@ -1347,90 +1044,70 @@ msgid ""
 "gEDA/gaf homepage: <http://www.geda-project.org/>\n"
 msgstr ""
 
-#: schematic/src/parsecmd.c:110
 #, c-format
 msgid ""
 "Lepton EDA %1$s (git: %2$.7s)\n"
 "Copyright (C) 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright (C) 2017-2018 Lepton Developers.\n"
+"Copyright (C) 2017-2019 Lepton Developers.\n"
 "This is free software, and you are welcome to redistribute it under\n"
 "certain conditions. For details, see the file `COPYING', which is\n"
 "included in the Lepton EDA distribution.\n"
 "There is NO WARRANTY, to the extent permitted by law.\n"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:125
 #, c-format
 msgid "Got invalid show option; defaulting to show both\n"
 msgstr "﻿حصلت على خيار عرض غير صحيح ؛تعيين الافتراضي لإظهار كليهما\n"
 
-#: schematic/src/x_attribedit.c:139
 #, c-format
 msgid "ERROR: NULL object!\n"
 msgstr "﻿خطأ: كائن فارغ (NULL)!\n"
 
-#: schematic/src/x_attribedit.c:328
 msgid "Single Attribute Editor"
 msgstr "محرّر سمة منفردة"
 
-#: schematic/src/x_attribedit.c:358
 msgid "<b>Edit Attribute</b>"
 msgstr "<b>حرّر السّمة</b>"
 
-#: schematic/src/x_attribedit.c:360
 msgid "<b>Add Attribute</b>"
 msgstr "<b>أضف سمة</b>"
 
-#: schematic/src/x_attribedit.c:376
 #, fuzzy
 msgid "N_ame:"
 msgstr "الاسم:"
 
-#: schematic/src/x_attribedit.c:396 schematic/src/x_multiattrib.c:2222
 #, fuzzy
 msgid "_Value:"
 msgstr "القيمة:"
 
-#: schematic/src/x_attribedit.c:415 schematic/src/x_multiattrib.c:2281
 #, fuzzy
 msgid "Vi_sible"
 msgstr "مرئي"
 
-#: schematic/src/x_attribedit.c:434
 msgid "Show Value Only"
 msgstr "أظهر القيمة فقط"
 
-#: schematic/src/x_attribedit.c:436
 msgid "Show Name Only"
 msgstr "أظهر الاسم فقط"
 
-#: schematic/src/x_attribedit.c:438 schematic/src/x_multiattrib.c:1620
-#: schematic/scheme/gschem/builtins.scm:324
 msgid "Show Name & Value"
 msgstr "أظهر الاسم و القيمة"
 
-#: schematic/src/x_attribedit.c:445
 msgid "<b>Attach Options</b>"
 msgstr "﻿<b>أرفق الخيارات</b>"
 
-#: schematic/src/x_attribedit.c:460
 msgid "All"
 msgstr "الكل"
 
-#: schematic/src/x_attribedit.c:476 schematic/src/x_compselect.c:986
-#: schematic/src/x_compselect.c:1100
 msgid "Components"
 msgstr "مكونات"
 
-#: schematic/src/x_attribedit.c:492 schematic/src/x_window.c:1214
 msgid "Nets"
 msgstr "شبكات"
 
-#: schematic/src/x_attribedit.c:508
 msgid "Replace existing attributes"
 msgstr "﻿استبدل السمات الموجودة"
 
-#: schematic/src/x_autonumber.c:412
 #, fuzzy
 msgid ""
 "slotted object without slot attribute may cause problems when autonumbering "
@@ -1438,103 +1115,79 @@ msgid ""
 msgstr ""
 "﻿كائن مقسم (مشقوق) بدون سمة الشقّ قد يسبب مشاكل عند الترقيم الآلي للشقوق\n"
 
-#: schematic/src/x_autonumber.c:427
 #, fuzzy, c-format
 msgid ""
 "duplicate slot may cause problems: [symbolname=%1$s, number=%2$d, slot=%3$d]"
 msgstr "﻿شقّ مكرر قد يسبب مشاكل: [اسم​الرمز=%s، العدد=%d، الشقّ=%d]\n"
 
-#: schematic/src/x_autonumber.c:675
 #, fuzzy
 msgid "No searchstring given in autonumber text."
 msgstr "لا يوجد نص بحث في نص الترقيم الآلي.\n"
 
-#: schematic/src/x_autonumber.c:728
 #, fuzzy
 msgid "No '*' or '?' given at the end of the autonumber text."
 msgstr "لا توجد '*' و لا '؟' في نهاية نص الترقيم الآلي.\n"
 
-#: schematic/src/x_autonumber.c:873
 msgid "Diagonal"
 msgstr "قطري"
 
-#: schematic/src/x_autonumber.c:874
 msgid "Top to bottom"
 msgstr "من الأعلى للأسفل"
 
-#: schematic/src/x_autonumber.c:875
 msgid "Bottom to top"
 msgstr "من الأسفل للأعلى"
 
-#: schematic/src/x_autonumber.c:876
 msgid "Left to right"
 msgstr "من اليسار لليمين"
 
-#: schematic/src/x_autonumber.c:877
 msgid "Right to left"
 msgstr "من اليمين لليسار"
 
-#: schematic/src/x_autonumber.c:878
 msgid "File order"
 msgstr "ترتيب الملف"
 
-#: schematic/src/x_autonumber.c:1214
 msgid "Autonumber text"
 msgstr "نص تعداد آلي"
 
-#: schematic/src/x_autonumber.c:1237
 msgid "<b>Scope</b>"
 msgstr "<b>المجال</b>"
 
-#: schematic/src/x_autonumber.c:1259
 msgid "Search for:"
 msgstr "البحث عن:"
 
-#: schematic/src/x_autonumber.c:1273
 msgid "Autonumber text in:"
 msgstr "نص تعداد آلي في:"
 
-#: schematic/src/x_autonumber.c:1280
 msgid "Skip numbers found in:"
 msgstr "﻿تخطي الأرقام الموجودة في:"
 
-#: schematic/src/x_autonumber.c:1292 schematic/src/x_autonumber.c:1301
 msgid "Selected objects"
 msgstr "الكائنات المنتقاة"
 
-#: schematic/src/x_autonumber.c:1293 schematic/src/x_autonumber.c:1302
 msgid "Current page"
 msgstr "الصفحة الحالية"
 
-#: schematic/src/x_autonumber.c:1294 schematic/src/x_autonumber.c:1303
 msgid "Whole hierarchy"
 msgstr "التسلسل الهرمي الكامل"
 
-#: schematic/src/x_autonumber.c:1305
 msgid "Overwrite existing numbers"
 msgstr "أكتب فوق الأرقام الموجودة"
 
-#: schematic/src/x_autonumber.c:1310
 msgid "<b>Options</b>"
 msgstr "<b>الخيارات</b>"
 
-#: schematic/src/x_autonumber.c:1332
 msgid "Starting number:"
 msgstr "رقم البدأ:"
 
-#: schematic/src/x_autonumber.c:1339
 msgid "Sort order:"
 msgstr "الترتيب:"
 
-#: schematic/src/x_autonumber.c:1371
 msgid "Remove numbers"
 msgstr "أزل الأعداد"
 
-#: schematic/src/x_autonumber.c:1375
 msgid "Automatic slotting"
 msgstr "شقّ آلي"
 
-#: schematic/src/x_clipboard.c:245
 #, c-format
 msgid ""
 "<b>Invalid schematic on clipboard.</b>\n"
@@ -1542,175 +1195,135 @@ msgid ""
 "An error occurred while inserting clipboard data: %s."
 msgstr ""
 
-#: schematic/src/x_clipboard.c:247
 msgid "Clipboard insertion failed"
 msgstr ""
 
-#: schematic/src/x_color.c:89 schematic/src/x_color.c:98
 #, fuzzy, c-format
 msgid "Could not allocate the color %1$s!\n"
 msgstr "﻿تعذر تعيين اللون %s!\n"
 
-#: schematic/src/x_color.c:89
 msgid "black"
 msgstr "أسود"
 
-#: schematic/src/x_color.c:98
 msgid "white"
 msgstr "أبيض"
 
-#: schematic/src/x_color.c:120
 #, fuzzy, c-format
 msgid "Could not allocate display color %1$i!\n"
 msgstr "﻿تعذر تعيين لون العرض %i!\n"
 
-#: schematic/src/x_color.c:142
 #, fuzzy, c-format
 msgid "Could not allocate outline color %1$i!\n"
 msgstr "﻿تعذر تعيين لون الخط الخارجي %i!\n"
 
-#: schematic/src/x_color.c:159
 #, fuzzy, c-format
 msgid "Tried to get an invalid color: %1$d\n"
 msgstr "حاول الحصول على لون غير صالح: %d\n"
 
-#: schematic/src/x_colorcb.c:145
 msgid "Background"
 msgstr "خلفيّة"
 
-#: schematic/src/x_colorcb.c:147
 msgid "Net endpoint"
 msgstr "﻿نقطة النهاية للشبكة"
 
-#: schematic/src/x_colorcb.c:148
 msgid "Graphic"
 msgstr "رسم"
 
-#: schematic/src/x_colorcb.c:151
 msgid "Logic bubble"
 msgstr "﻿فقاعة المنطق"
 
-#: schematic/src/x_colorcb.c:152
 msgid "Grid point"
 msgstr "﻿نقطة شبيكة"
 
-#: schematic/src/x_colorcb.c:153
 #, fuzzy
 msgid "Detached attribute"
 msgstr "سمة مفصولة"
 
-#: schematic/src/x_colorcb.c:156
 msgid "Selection"
 msgstr "منتقى"
 
-#: schematic/src/x_colorcb.c:157
 msgid "Bounding box"
 msgstr "مربع إحاطة"
 
-#: schematic/src/x_colorcb.c:158
 msgid "Zoom box"
 msgstr "قرّب المربع"
 
-#: schematic/src/x_colorcb.c:161
 msgid "Output background"
 msgstr "﻿خلفية الإخراج"
 
-#: schematic/src/x_colorcb.c:162
 msgid "Freestyle 1"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:163
 msgid "Freestyle 2"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:164
 msgid "Freestyle 3"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:165
 msgid "Freestyle 4"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:166
 msgid "Net junction"
 msgstr "وصلة شبكة"
 
-#: schematic/src/x_colorcb.c:167
 msgid "Mesh grid major"
 msgstr "أساسي - خيط الشبيكة"
 
-#: schematic/src/x_colorcb.c:168
 msgid "Mesh grid minor"
 msgstr "ثانوي - خيط الشبيكة"
 
-#: schematic/src/x_colorcb.c:172
 msgid "Unknown"
 msgstr "مجهول"
 
-#: schematic/src/x_compselect.c:1169
 #, fuzzy
 msgid "Reset filter"
 msgstr "آخر الملفات"
 
-#: schematic/src/x_compselect.c:1192
 msgid "Reload all libraries"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1245 schematic/src/x_multiattrib.c:2092
 msgid "Value"
 msgstr "قيمة"
 
-#: schematic/src/x_compselect.c:1284
 msgid "Default behavior - reference component"
 msgstr "﻿السلوك الافتراضي - العنصر المرجعي"
 
-#: schematic/src/x_compselect.c:1287
 msgid "Embed component in schematic"
 msgstr "﻿ضمّن المكون في المخطط"
 
-#: schematic/src/x_compselect.c:1290
 msgid "Include component as individual objects"
 msgstr "ضمّن المكون ككائنات فردية"
 
-#: schematic/src/x_compselect.c:1448
 msgid "Select Component..."
 msgstr "انتق مكونا..."
 
-#: schematic/src/x_compselect.c:1471
 #, fuzzy
 msgid "In Us_e"
 msgstr "قيد الاستخدام"
 
-#: schematic/src/x_compselect.c:1475
 #, fuzzy
 msgid "Lib_raries"
 msgstr "مكتبات"
 
-#: schematic/src/x_compselect.c:1484 schematic/src/x_fileselect.c:119
 msgid "Preview"
 msgstr "معاينة"
 
-#: schematic/src/x_compselect.c:1510
 msgid "Attributes"
 msgstr "سمات"
 
-#: schematic/src/x_dialog.c:325
 msgid "Major symbol changes detected."
 msgstr ""
 
-#: schematic/src/x_dialog.c:349
 msgid ""
 "Changes have occurred to the symbols shown below.\n"
 "\n"
 "Be sure to verify each of these symbols."
 msgstr ""
 
-#: schematic/src/x_dialog.c:369
 #, fuzzy
 msgid "Symbol"
 msgstr "رموز"
 
-#: schematic/src/x_dialog.c:406
 #, c-format
 msgid ""
 "<span weight=\"bold\" size=\"larger\">The input attribute \"%s\" is invalid\n"
@@ -1727,40 +1340,31 @@ msgstr ""
 "لا يمكن أن ينتهي الاسم بمسافة.\n"
 "لا يمكن بدء القيمة بمسافة."
 
-#: schematic/src/x_dialog.c:408
 msgid "Invalid Attribute"
 msgstr "﻿سمة غير صالحة"
 
-#: schematic/src/x_fileselect.c:37
 msgid "Schematics"
 msgstr "مخططات"
 
-#: schematic/src/x_fileselect.c:42
 msgid "Symbols"
 msgstr "رموز"
 
-#: schematic/src/x_fileselect.c:47
 msgid "Schematics and symbols"
 msgstr "مخططات و رموز"
 
-#: schematic/src/x_fileselect.c:53
 msgid "All files"
 msgstr "كل الملفات"
 
-#: schematic/src/x_fileselect.c:169
 msgid "Open..."
 msgstr "افتح..."
 
-#: schematic/src/x_fileselect.c:233
 msgid "Save as..."
 msgstr "احفظ كـ..."
 
-#: schematic/src/x_fileselect.c:297
 #, fuzzy
 msgid "Save cancelled on user request"
 msgstr "ألغي الحفظ بناء على طلب المستخدم\n"
 
-#: schematic/src/x_fileselect.c:334
 msgid ""
 "\n"
 "If you load the original file, the backup file will be overwritten in the "
@@ -1769,28 +1373,22 @@ msgid ""
 "Do you want to load the backup file?\n"
 msgstr ""
 
-#: schematic/src/x_fstylecb.c:73
 msgid "Hollow"
 msgstr "مجوّف"
 
-#: schematic/src/x_fstylecb.c:80
 msgid "Filled"
 msgstr "مملوء"
 
-#: schematic/src/x_fstylecb.c:87
 msgid "Mesh"
 msgstr "خيط الشبكة"
 
-#: schematic/src/x_fstylecb.c:94
 msgid "Hatch"
 msgstr "تهشير"
 
-#: schematic/src/x_image.c:279
 #, fuzzy, c-format
 msgid "x_image_lowlevel: Unable to write %1$s file %2$s."
 msgstr "‏﻿x_image_lowlevel: غير قادر على كتابة ملف ‬%s %s.\n"
 
-#: schematic/src/x_image.c:289
 #, fuzzy, c-format
 msgid ""
 "There was the following error when saving image with type %1$s to filename:\n"
@@ -1803,308 +1401,241 @@ msgstr ""
 "\n"
 "%s.\n"
 
-#: schematic/src/x_image.c:309
 #, fuzzy, c-format
 msgid "Wrote color image to [%1$s] [%2$d x %3$d]"
 msgstr "كتب صورة ملونة إلى [%s] [%d x %d]\n"
 
-#: schematic/src/x_image.c:311
 #, fuzzy, c-format
 msgid "Wrote black and white image to [%1$s] [%2$d x %3$d]"
 msgstr "﻿كتب صورة بالأبيض والأسود إلى [%s] [%d x %d]\n"
 
-#: schematic/src/x_image.c:319
 #, fuzzy
 msgid "x_image_lowlevel: Unable to get pixbuf from gschem's window."
 msgstr "﻿‏x_image_lowlevel: تعذر الحصول على pixbuf من نافذة gschem.\n"
 
-#: schematic/src/x_image.c:358
 msgid "Width x Height"
 msgstr "عرض × ارتفاع"
 
-#: schematic/src/x_image.c:374
 msgid "Image type"
 msgstr "نوع الصورة"
 
-#: schematic/src/x_image.c:395
 msgid "Write image..."
 msgstr "أكتب صورة..."
 
-#: schematic/src/x_linecapcb.c:74
 msgid "Butt"
 msgstr ""
 
-#: schematic/src/x_linecapcb.c:81
 msgid "Square"
 msgstr ""
 
-#: schematic/src/x_linecapcb.c:88
 msgid "Round"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:74
 msgid "Solid"
 msgstr "متواصل"
 
-#: schematic/src/x_linetypecb.c:81
 msgid "Dotted"
 msgstr "منقط"
 
-#: schematic/src/x_linetypecb.c:88
 msgid "Dashed"
 msgstr "شُرَط"
 
-#: schematic/src/x_linetypecb.c:95
 msgid "Center"
 msgstr "وسط"
 
-#: schematic/src/x_linetypecb.c:102
 msgid "Phantom"
 msgstr "وهم"
 
-#: schematic/src/x_menus.c:41 schematic/scheme/gschem/builtins.scm:267
 #, fuzzy
 msgid "Add Net"
 msgstr "/أضف شبكة"
 
-#: schematic/src/x_menus.c:42 schematic/src/x_multiattrib.c:2187
-#: schematic/scheme/gschem/builtins.scm:264
 msgid "Add Attribute"
 msgstr "أضف سمة"
 
-#: schematic/src/x_menus.c:43 schematic/scheme/gschem/builtins.scm:261
 #, fuzzy
 msgid "Add Component"
 msgstr "/أضف مكونا..."
 
-#: schematic/src/x_menus.c:44 schematic/scheme/gschem/builtins.scm:270
 #, fuzzy
 msgid "Add Bus"
 msgstr "/أضف ناقلا"
 
-#: schematic/src/x_menus.c:45 schematic/scheme/gschem/builtins.scm:273
 #, fuzzy
 msgid "Add Text"
 msgstr "/أضف نصا"
 
-#: schematic/src/x_menus.c:47 schematic/scheme/gschem/builtins.scm:210
 #, fuzzy
 msgid "Zoom In"
 msgstr "/قرّب"
 
-#: schematic/src/x_menus.c:48 schematic/scheme/gschem/builtins.scm:213
 #, fuzzy
 msgid "Zoom Out"
 msgstr "/بعّد"
 
-#: schematic/src/x_menus.c:50 schematic/scheme/gschem/builtins.scm:207
 #, fuzzy
 msgid "Zoom Extents"
 msgstr "/قرّب مع شمل الامتدادات"
 
-#: schematic/src/x_menus.c:52 schematic/src/x_window.c:1233
 msgid "Select"
 msgstr "انتق"
 
-#: schematic/src/x_menus.c:53 schematic/scheme/conf/schematic/menu.scm:69
-#: schematic/scheme/gschem/builtins.scm:126
 msgid "Edit..."
 msgstr "حرّر..."
 
-#: schematic/src/x_menus.c:54 schematic/scheme/conf/schematic/menu.scm:68
 #, fuzzy
 msgid "Object Properties..."
 msgstr "<b>خصائص النص</b>"
 
-#: schematic/src/x_menus.c:59 schematic/scheme/gschem/builtins.scm:300
 #, fuzzy
 msgid "Down Schematic"
 msgstr "/انزل إلى المخطط"
 
-#: schematic/src/x_menus.c:60 schematic/scheme/gschem/builtins.scm:303
 #, fuzzy
 msgid "Down Symbol"
 msgstr "/انزل إلى الرمز"
 
-#: schematic/src/x_menus.c:61
 #, fuzzy
 msgid "Up"
 msgstr "/اصعد"
 
-#: schematic/src/x_menus.c:336
 #, fuzzy, c-format
 msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
 msgstr "محاولة تعيين الحساسية على عنصر قائمة غير موجود '%s'\n"
 
-#: schematic/src/x_menus.c:360
 #, c-format
 msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
 msgstr "محاولة تعيين الحساسية على عنصر قائمة غير موجود '%s'\n"
 
-#: schematic/src/x_misc.c:70
 msgid "The operating system is out of memory or resources."
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:798 schematic/src/x_multiattrib.c:2704
 msgid "<various>"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:930
 msgid "Attributes with empty name are not allowed. Please set a name."
 msgstr "غير مسموح بسمات مع اسم فارغ. الرجاء تعيين اسم."
 
-#: schematic/src/x_multiattrib.c:1622
 msgid "Show Value only"
 msgstr "أظهر القيمة فقط"
 
-#: schematic/src/x_multiattrib.c:1624
 msgid "Show Name only"
 msgstr "أظهر الاسم فقط"
 
-#: schematic/src/x_multiattrib.c:1651
 msgid "Promote"
 msgstr "رَقِّ"
 
-#: schematic/src/x_multiattrib.c:1655
 msgid "Duplicate"
 msgstr "ضاعف"
 
-#: schematic/src/x_multiattrib.c:1657
 #, fuzzy
 msgid "Copy to all"
 msgstr "انسخ إلى 1"
 
-#: schematic/src/x_multiattrib.c:1986 schematic/src/x_multiattrib.c:2602
 msgid "Edit Attributes"
 msgstr "حرّر المواصفات"
 
-#: schematic/src/x_multiattrib.c:2112
 msgid "Vis?"
 msgstr "ظاهر؟"
 
-#: schematic/src/x_multiattrib.c:2130
 msgid "N"
 msgstr "N"
 
-#: schematic/src/x_multiattrib.c:2148
 msgid "V"
 msgstr "V"
 
-#: schematic/src/x_multiattrib.c:2170
 #, fuzzy
 msgid "Sho_w inherited attributes"
 msgstr "أظهر السمات الموروثة"
 
-#: schematic/src/x_multiattrib.c:2197
 #, fuzzy
 msgid "_Name:"
 msgstr "الاسم:"
 
-#: schematic/src/x_multiattrib.c:2241
 msgid "Ctrl+Enter inserts new line; Ctrl+Tab inserts Tab"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2618
 #, c-format
 msgid "%2$i symbol (%1$s)"
 msgid_plural "%2$i symbols (%1$s)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2624
 #, fuzzy, c-format
 msgid "%1$i pin"
 msgid_plural "%1$i pins"
 msgstr[0] "دبوس لشبكة"
 msgstr[1] "دبوس لشبكة"
 
-#: schematic/src/x_multiattrib.c:2630
 #, c-format
 msgid "%1$i net"
 msgid_plural "%1$i nets"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2636
 #, c-format
 msgid "%1$i bus"
 msgid_plural "%1$i buses"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2642
 #, fuzzy, c-format
 msgid "%1$i attribute"
 msgid_plural "%1$i attributes"
 msgstr[0] "سمة"
 msgstr[1] "سمة"
 
-#: schematic/src/x_newtext.c:433
 msgid "Text Entry..."
 msgstr "مدخل نص..."
 
-#: schematic/src/x_pagesel.c:253
 msgid "New Page"
 msgstr "صفحة جديدة"
 
-#: schematic/src/x_pagesel.c:254
 msgid "Open Page..."
 msgstr "افتح صفحة..."
 
-#: schematic/src/x_pagesel.c:256
 msgid "Save Page"
 msgstr "احفظ الصفحة"
 
-#: schematic/src/x_pagesel.c:257 schematic/scheme/gschem/builtins.scm:246
 msgid "Close Page"
 msgstr "أغلق الصفحة"
 
-#: schematic/src/x_pagesel.c:376 schematic/scheme/gschem/builtins.scm:237
 msgid "Page Manager"
 msgstr "مدير الصفحات"
 
-#: schematic/src/x_pagesel.c:448
 msgid "Changed"
 msgstr "غُيّر"
 
-#: schematic/src/x_pagesel.c:468
 msgid "Right click on the filename for more options..."
 msgstr "نقرة يمنى فوق اسم الملف للحصول على المزيد من الخيارات..."
 
-#: schematic/src/x_print.c:306
 #, fuzzy, c-format
 msgid "Failed to write PDF to '%s': %s\n"
 msgstr "فشل تحميل الصورة: %s"
 
-#: schematic/src/x_print.c:364
 #, fuzzy, c-format
 msgid "Failed to write PDF to '%1$s': %2$s\n"
 msgstr "فشل تحميل الصورة: %s"
 
-#: schematic/src/x_print.c:449
 #, c-format
 msgid ""
 "Error printing file:\n"
 "%1$s"
 msgstr ""
 
-#: schematic/src/x_rc.c:39
 msgid "ERROR: An unknown error occurred while parsing configuration files."
 msgstr ""
 
-#: schematic/src/x_rc.c:44
 msgid ""
 "An unknown error occurred while parsing configuration files.\n"
 "\n"
 "The lepton-schematic log may contain more information."
 msgstr ""
 
-#: schematic/src/x_rc.c:56
 #, c-format
 msgid "ERROR: %1$s"
 msgstr ""
 
-#: schematic/src/x_rc.c:59
 #, c-format
 msgid ""
 "%1$s\n"
@@ -2112,141 +1643,110 @@ msgid ""
 "The lepton-schematic log may contain more information."
 msgstr ""
 
-#: schematic/src/x_rc.c:67
 msgid "Cannot load lepton-schematic configuration."
 msgstr ""
 
-#: schematic/src/x_script.c:42 schematic/scheme/conf/schematic/menu.scm:40
 msgid "Execute Script..."
 msgstr "نفذ مخطوطا (سكربت)..."
 
-#: schematic/src/x_script.c:61
 #, fuzzy, c-format
 msgid "Executing guile script [%1$s]"
 msgstr "تنفيذ مخطوط guile [‎%s‬]\n"
 
-#: schematic/src/x_tabs.c:860
 #, fuzzy, c-format
 msgid "Hierarchy up: %s"
 msgstr "تسلسل​_هرمي"
 
-#: schematic/src/x_tabs.c:863
 #, fuzzy
 msgid "Hierarchy up"
 msgstr "تسلسل​_هرمي"
 
-#: schematic/src/x_widgets.c:158 schematic/src/x_window.c:1444
 msgid "Options"
 msgstr "خيارات"
 
-#: schematic/src/x_widgets.c:203 schematic/src/x_window.c:1436
 #, fuzzy
 msgid "Object"
 msgstr "لون الكائن:"
 
-#: schematic/src/x_widgets.c:224
 msgid "Log"
 msgstr ""
 
-#: schematic/src/x_widgets.c:245 schematic/src/x_window.c:1466
 msgid "Find Text"
 msgstr "ابحث عن نص"
 
-#: schematic/src/x_widgets.c:259
 #, fuzzy
 msgid "Color Scheme Editor"
 msgstr "مخطط ألوان _فاتحة"
 
-#: schematic/src/x_widgets.c:272 schematic/scheme/gschem/builtins.scm:378
 #, fuzzy
 msgid "Select Schematic Font"
 msgstr "انتق المخططات التي تريد حفظها:"
 
-#: schematic/src/x_window.c:763
 #, fuzzy, c-format
 msgid "Loading schematic [%1$s]"
 msgstr "تحميل المخطط [‎%s‬]\n"
 
-#: schematic/src/x_window.c:864
 #, fuzzy, c-format
 msgid "Could NOT save page [%1$s]\n"
 msgstr "تعذّر حفظ الصفحة [‎%s‬]\n"
 
-#: schematic/src/x_window.c:865
 msgid "Error while trying to save"
 msgstr "خطا عند محاولة الحفظ"
 
-#: schematic/src/x_window.c:875
 #, fuzzy
 msgid "Failed to save file"
 msgstr "فشل تحميل الملف"
 
-#: schematic/src/x_window.c:885
 #, fuzzy, c-format
 msgid "Saved as [%1$s]"
 msgstr "حُفظ كـ [‎%s‬]\n"
 
-#: schematic/src/x_window.c:887
 #, fuzzy, c-format
 msgid "Saved [%1$s]"
 msgstr "‏حُفظ [‎%s‬]\n"
 
-#: schematic/src/x_window.c:889
 msgid "Saved"
 msgstr "محفوظ"
 
-#: schematic/src/x_window.c:966
 #, fuzzy, c-format
 msgid "Discarding page [%1$s]"
 msgstr "إهمال الصفحة [‎%s‬]\n"
 
-#: schematic/src/x_window.c:966
 #, fuzzy, c-format
 msgid "Closing [%1$s]"
 msgstr "غلق [‎%s‬]\n"
 
-#: schematic/src/x_window.c:1175
 msgid "New"
 msgstr "جديد"
 
-#: schematic/src/x_window.c:1175
 msgid "New file"
 msgstr "ملف جديد"
 
-#: schematic/src/x_window.c:1179
 msgid "Open"
 msgstr "افتح"
 
-#: schematic/src/x_window.c:1179
 #, fuzzy
 msgid "Open file"
 msgstr "افتح ملفا..."
 
-#: schematic/src/x_window.c:1183 schematic/scheme/gschem/builtins.scm:59
 msgid "Save"
 msgstr "احفظ"
 
-#: schematic/src/x_window.c:1183
 msgid "Save file"
 msgstr "احفظ الملف"
 
-#: schematic/src/x_window.c:1189 schematic/scheme/gschem/builtins.scm:93
 msgid "Undo"
 msgstr "تراجع"
 
-#: schematic/src/x_window.c:1189
 msgid "Undo last operation"
 msgstr "تراجع عن العملية الأخيرة"
 
-#: schematic/src/x_window.c:1193 schematic/scheme/gschem/builtins.scm:96
 msgid "Redo"
 msgstr "كرّر"
 
-#: schematic/src/x_window.c:1193
 msgid "Redo last undo"
 msgstr "أعد آخر عملية متراجع عنها"
 
-#: schematic/src/x_window.c:1198
 msgid ""
 "Add component...\n"
 "Select library and component from list, move the mouse into main window, "
@@ -2258,7 +1758,6 @@ msgstr ""
 "لوضعه\n"
 "الزر الأيمن للفارة للإلغاء"
 
-#: schematic/src/x_window.c:1209
 msgid ""
 "Add nets mode\n"
 "Right mouse button to cancel"
@@ -2266,7 +1765,6 @@ msgstr ""
 "وضع إضافة شبكات\n"
 "الزر الأيمن للفارة للإلغاء"
 
-#: schematic/src/x_window.c:1217
 msgid ""
 "Add buses mode\n"
 "Right mouse button to cancel"
@@ -2274,45 +1772,35 @@ msgstr ""
 "وضع إضافة النواقل\n"
 "الزر الأيمن للفارة للإلغاء"
 
-#: schematic/src/x_window.c:1226
 msgid "Add Text..."
 msgstr "أضف نصا..."
 
-#: schematic/src/x_window.c:1233
 msgid "Select mode"
 msgstr "وضع الإنتقاء"
 
-#: schematic/src/x_window.c:1288
 #, fuzzy
 msgid "Show"
 msgstr "أظهرN"
 
-#: schematic/src/x_window.c:1289
 msgid "Show text starting with:"
 msgstr "أظهر النص البادئ بـ:"
 
-#: schematic/src/x_window.c:1345
 msgid "Menu/Cancel"
 msgstr "قائمة/ألغِ"
 
-#: schematic/src/x_window.c:1349
 msgid "Pan/Cancel"
 msgstr "انتقل/ألغِ"
 
-#: schematic/src/x_window.c:1359
 msgid "Pick"
 msgstr "التقط"
 
-#: schematic/src/x_window.c:1470 schematic/scheme/gschem/builtins.scm:180
 msgid "Status"
 msgstr "الحالة"
 
-#: schematic/src/x_window.c:1568
 #, fuzzy, c-format
 msgid "New file [%s]"
 msgstr "ملف جديد [‎%s‬]\n"
 
-#: schematic/src/x_window.c:1598
 #, c-format
 msgid ""
 "<b>An error occurred while loading the requested file.</b>\n"
@@ -2326,907 +1814,697 @@ msgid ""
 "monitor program's output in terminal window."
 msgstr ""
 
-#: schematic/src/x_window.c:1617
 msgid "Failed to load file"
 msgstr "فشل تحميل الملف"
 
-#: schematic/data/lepton-schematic.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Schematic Editor"
 msgstr "محرّر المخططات gEDA"
 
-#: schematic/data/lepton-schematic.desktop.in:4
 #, fuzzy
 msgid "Create and edit electrical schematics and symbols with lepton-schematic"
 msgstr "أنشء و حرّر المخططات الكهربائية والرموز مع gschem"
 
-#: schematic/scheme/conf/schematic/menu.scm:27
 msgid "_New"
 msgstr "_جديد"
 
-#: schematic/scheme/conf/schematic/menu.scm:28
 msgid "_Open..."
 msgstr "ا_فتح..."
 
-#: schematic/scheme/conf/schematic/menu.scm:30
 msgid "Open Recen_t"
 msgstr "افتح الأح_دث"
 
-#: schematic/scheme/conf/schematic/menu.scm:32
 msgid "_Save"
 msgstr "ا_حفظ"
 
-#: schematic/scheme/conf/schematic/menu.scm:33
 msgid "Save _As..."
 msgstr "احفظ _ك‍..."
 
-#: schematic/scheme/conf/schematic/menu.scm:34
-#: schematic/scheme/gschem/builtins.scm:65
 msgid "Save All"
 msgstr "احفظ الكل"
 
-#: schematic/scheme/conf/schematic/menu.scm:36
 msgid "_Print..."
 msgstr "ا_طبع..."
 
-#: schematic/scheme/conf/schematic/menu.scm:37
 #, fuzzy
 msgid "Write _Image..."
 msgstr "أكتب _صورة..."
 
-#: schematic/scheme/conf/schematic/menu.scm:39
 #, fuzzy
 msgid "Invoke Macro..."
 msgstr "استدع ماكرو"
 
-#: schematic/scheme/conf/schematic/menu.scm:41
 msgid "REPL..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:43
-#: schematic/scheme/gschem/builtins.scm:77
 msgid "New Window"
 msgstr "نافذة جديدة"
 
-#: schematic/scheme/conf/schematic/menu.scm:44
 #, fuzzy
 msgid "_Close Window"
 msgstr "أغلق النافذة"
 
-#: schematic/scheme/conf/schematic/menu.scm:45
 msgid "_Quit"
 msgstr "أ_خرج"
 
-#: schematic/scheme/conf/schematic/menu.scm:51
 msgid "_Undo"
 msgstr "ت_راجع"
 
-#: schematic/scheme/conf/schematic/menu.scm:52
 msgid "_Redo"
 msgstr "_كرّر"
 
-#: schematic/scheme/conf/schematic/menu.scm:54
 msgid "Cu_t"
 msgstr "_قصّ"
 
-#: schematic/scheme/conf/schematic/menu.scm:55
 msgid "_Copy"
 msgstr "ا_نسخ"
 
-#: schematic/scheme/conf/schematic/menu.scm:56
 msgid "_Paste"
 msgstr "أ_لصق"
 
-#: schematic/scheme/conf/schematic/menu.scm:57
 msgid "_Delete"
 msgstr "ا_حذف"
 
-#: schematic/scheme/conf/schematic/menu.scm:60
-#: schematic/scheme/gschem/builtins.scm:102
 #, fuzzy
 msgid "Select All"
 msgstr "انتق"
 
-#: schematic/scheme/conf/schematic/menu.scm:61
-#: schematic/scheme/gschem/builtins.scm:105
 #, fuzzy
 msgid "Deselect"
 msgstr "انتق"
 
-#: schematic/scheme/conf/schematic/menu.scm:65
 msgid "Rotate 90 Mode"
 msgstr "وضع الاستدارة 90"
 
-#: schematic/scheme/conf/schematic/menu.scm:70
 msgid "Edit Text..."
 msgstr "حرّر النص..."
 
-#: schematic/scheme/conf/schematic/menu.scm:71
 msgid "Slot..."
 msgstr "شقّ..."
 
-#: schematic/scheme/conf/schematic/menu.scm:76
-#: schematic/scheme/gschem/builtins.scm:150
 msgid "Embed Component/Picture"
 msgstr "ضمّن المكون/الصورة"
 
-#: schematic/scheme/conf/schematic/menu.scm:77
-#: schematic/scheme/gschem/builtins.scm:153
 msgid "Unembed Component/Picture"
 msgstr "لا تضمّن المكون/الصورة"
 
-#: schematic/scheme/conf/schematic/menu.scm:78
-#: schematic/scheme/gschem/builtins.scm:156
 msgid "Update Component"
 msgstr "حدّث المكون"
 
-#: schematic/scheme/conf/schematic/menu.scm:79
 msgid "Symbol Translate..."
 msgstr "سحب الرمز..."
 
-#: schematic/scheme/conf/schematic/menu.scm:85
 msgid "Copy into 1"
 msgstr "انسخ إلى 1"
 
-#: schematic/scheme/conf/schematic/menu.scm:86
 msgid "Copy into 2"
 msgstr "انسخ إلى 2"
 
-#: schematic/scheme/conf/schematic/menu.scm:87
 msgid "Copy into 3"
 msgstr "انسخ إلى 3"
 
-#: schematic/scheme/conf/schematic/menu.scm:88
 msgid "Copy into 4"
 msgstr "انسخ إلى 4"
 
-#: schematic/scheme/conf/schematic/menu.scm:89
 msgid "Copy into 5"
 msgstr "انسخ إلى 5"
 
-#: schematic/scheme/conf/schematic/menu.scm:90
 msgid "Cut into 1"
 msgstr "قص إلى 1"
 
-#: schematic/scheme/conf/schematic/menu.scm:91
 msgid "Cut into 2"
 msgstr "قص إلى 2"
 
-#: schematic/scheme/conf/schematic/menu.scm:92
 msgid "Cut into 3"
 msgstr "قص إلى 3"
 
-#: schematic/scheme/conf/schematic/menu.scm:93
 msgid "Cut into 4"
 msgstr "قص إلى 4"
 
-#: schematic/scheme/conf/schematic/menu.scm:94
 msgid "Cut into 5"
 msgstr "قص إلى 5"
 
-#: schematic/scheme/conf/schematic/menu.scm:95
 msgid "Paste from 1"
 msgstr "ألصق من 1"
 
-#: schematic/scheme/conf/schematic/menu.scm:96
 msgid "Paste from 2"
 msgstr "ألصق من 2"
 
-#: schematic/scheme/conf/schematic/menu.scm:97
 msgid "Paste from 3"
 msgstr "ألصق من 3"
 
-#: schematic/scheme/conf/schematic/menu.scm:98
 msgid "Paste from 4"
 msgstr "ألصق من 4"
 
-#: schematic/scheme/conf/schematic/menu.scm:99
 msgid "Paste from 5"
 msgstr "ألصق من 5"
 
-#: schematic/scheme/conf/schematic/menu.scm:105
 msgid "Side Dock"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:106
 #, fuzzy
 msgid "Bottom Dock"
 msgstr "من الأسفل للأعلى"
 
-#: schematic/scheme/conf/schematic/menu.scm:108
 #, fuzzy
 msgid "Find Text Results"
 msgstr "ابحث عن نص"
 
-#: schematic/scheme/conf/schematic/menu.scm:110
 msgid "_Redraw"
 msgstr "أ_عد الرسم"
 
-#: schematic/scheme/conf/schematic/menu.scm:111
 msgid "_Pan"
 msgstr "ا_نتقل"
 
-#: schematic/scheme/conf/schematic/menu.scm:112
 msgid "Zoom _Box"
 msgstr "قرّب الم_ربع"
 
-#: schematic/scheme/conf/schematic/menu.scm:113
 msgid "Zoom _Extents"
 msgstr "قرّب مع شمل الا_متدادات"
 
-#: schematic/scheme/conf/schematic/menu.scm:114
 msgid "Zoom _In"
 msgstr "_قرّب"
 
-#: schematic/scheme/conf/schematic/menu.scm:115
 msgid "Zoom _Out"
 msgstr "_بعّد"
 
-#: schematic/scheme/conf/schematic/menu.scm:116
 msgid "Zoom _Full"
 msgstr "بعّد لل_حد الأقصى"
 
-#: schematic/scheme/conf/schematic/menu.scm:118
 #, fuzzy
 msgid "_Dark Color Scheme"
 msgstr "مخطط ألوان _داكنة"
 
-#: schematic/scheme/conf/schematic/menu.scm:119
 #, fuzzy
 msgid "_Light Color Scheme"
 msgstr "مخطط ألوان _فاتحة"
 
-#: schematic/scheme/conf/schematic/menu.scm:120
 #, fuzzy
 msgid "B_W Color Scheme"
 msgstr "مخطط ألوان _داكنة"
 
-#: schematic/scheme/conf/schematic/menu.scm:122
 #, fuzzy
 msgid "Color Scheme Editor..."
 msgstr "مخطط ألوان _فاتحة"
 
-#: schematic/scheme/conf/schematic/menu.scm:129
 msgid "_Manager..."
 msgstr "م_دير..."
 
-#: schematic/scheme/conf/schematic/menu.scm:131
 msgid "_Previous"
 msgstr "ال_سّابقة"
 
-#: schematic/scheme/conf/schematic/menu.scm:132
 msgid "_Next"
 msgstr "ال_تّالية"
 
-#: schematic/scheme/conf/schematic/menu.scm:133
 msgid "_Close"
 msgstr "أ_غلق"
 
-#: schematic/scheme/conf/schematic/menu.scm:135
 #, fuzzy
 msgid "_Revert..."
 msgstr "ت_راجع"
 
-#: schematic/scheme/conf/schematic/menu.scm:137
-#: schematic/scheme/gschem/builtins.scm:249
 #, fuzzy
 msgid "Next Tab"
 msgstr "صفحة جديدة"
 
-#: schematic/scheme/conf/schematic/menu.scm:138
-#: schematic/scheme/gschem/builtins.scm:252
 #, fuzzy
 msgid "Previous Tab"
 msgstr "ال_سّابقة"
 
-#: schematic/scheme/conf/schematic/menu.scm:146
 msgid "_Component..."
 msgstr "م_كون..."
 
-#: schematic/scheme/conf/schematic/menu.scm:148
 msgid "_Net"
 msgstr "_شبكة"
 
-#: schematic/scheme/conf/schematic/menu.scm:149
 msgid "B_us"
 msgstr "نا_قل"
 
-#: schematic/scheme/conf/schematic/menu.scm:151
 msgid "_Attribute..."
 msgstr "_سمة..."
 
-#: schematic/scheme/conf/schematic/menu.scm:152
 msgid "_Text..."
 msgstr "_نص..."
 
-#: schematic/scheme/conf/schematic/menu.scm:154
 msgid "_Line"
 msgstr "_خط"
 
-#: schematic/scheme/conf/schematic/menu.scm:155
 msgid "Pat_h"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:156
 msgid "_Box"
 msgstr "_إطار"
 
-#: schematic/scheme/conf/schematic/menu.scm:157
 msgid "C_ircle"
 msgstr "_دائرة"
 
-#: schematic/scheme/conf/schematic/menu.scm:158
 msgid "A_rc"
 msgstr "ق_وس"
 
-#: schematic/scheme/conf/schematic/menu.scm:159
 msgid "_Pin"
 msgstr "د_بوس"
 
-#: schematic/scheme/conf/schematic/menu.scm:161
 msgid "Pictu_re..."
 msgstr "_صورة..."
 
-#: schematic/scheme/conf/schematic/menu.scm:167
 msgid "_Up"
 msgstr "ا_صعد"
 
-#: schematic/scheme/conf/schematic/menu.scm:169
 msgid "_Down Schematic"
 msgstr "ا_نزل إلى المخطّط"
 
-#: schematic/scheme/conf/schematic/menu.scm:170
 msgid "Down _Symbol"
 msgstr "انزل إلى ال_رمز"
 
-#: schematic/scheme/conf/schematic/menu.scm:176
 msgid "_Attach"
 msgstr "أ_رفق"
 
-#: schematic/scheme/conf/schematic/menu.scm:177
 msgid "_Detach"
 msgstr "ا_فصل"
 
-#: schematic/scheme/conf/schematic/menu.scm:179
 msgid "Show _Value"
 msgstr "أظهر ال_قيمة"
 
-#: schematic/scheme/conf/schematic/menu.scm:180
 msgid "Show _Name"
 msgstr "أظهر ال_اسم"
 
-#: schematic/scheme/conf/schematic/menu.scm:181
 msgid "Show _Both"
 msgstr "أظهر الإ_ثنين"
 
-#: schematic/scheme/conf/schematic/menu.scm:182
 msgid "_Toggle Visibility"
 msgstr "_بدل الرؤية"
 
-#: schematic/scheme/conf/schematic/menu.scm:184
 msgid "_Hide Specific Text..."
 msgstr "أ_خف نصا معينا..."
 
-#: schematic/scheme/conf/schematic/menu.scm:185
 msgid "_Show Specific Text..."
 msgstr "أ_ظهر نصا معينا..."
 
-#: schematic/scheme/conf/schematic/menu.scm:186
 #, fuzzy
 msgid "Show/Hide Hidden Text"
 msgstr "أظهر/أخف النص الخفي"
 
-#: schematic/scheme/conf/schematic/menu.scm:188
 msgid "_Find Text/Check Symbol..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:189
 msgid "A_utonumber Text..."
 msgstr "_نص الترقيم الآلي..."
 
-#: schematic/scheme/conf/schematic/menu.scm:195
 #, fuzzy
 msgid "_Options..."
 msgstr "_خيارات"
 
-#: schematic/scheme/conf/schematic/menu.scm:196
 #, fuzzy
 msgid "_Font..."
 msgstr "ا_طبع..."
 
-#: schematic/scheme/conf/schematic/menu.scm:198
 #, fuzzy
 msgid "Grid +"
 msgstr "شبيكة موقفة\n"
 
-#: schematic/scheme/conf/schematic/menu.scm:199
 #, fuzzy
 msgid "Grid -"
 msgstr "شبيكة موقفة\n"
 
-#: schematic/scheme/conf/schematic/menu.scm:201
 msgid "Grid Style: Cycle Dots/Mesh/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:202
 msgid "Grid Snap: Cycle Grid/Resnap/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:204
 #, fuzzy
 msgid "Feedback Mode: Outline/Box"
 msgstr "بدّل ال_حد الخارجي/الإطار"
 
-#: schematic/scheme/conf/schematic/menu.scm:205
 #, fuzzy
 msgid "Net: Rubberband On/Off"
 msgstr "الشريط المطاطي مشغل\n"
 
-#: schematic/scheme/conf/schematic/menu.scm:206
 msgid "Net: Magnetic On/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:208
 #, fuzzy
 msgid "_Coord Window"
 msgstr "أغلق النافذة"
 
-#: schematic/scheme/conf/schematic/menu.scm:209
 #, fuzzy
 msgid "_Log Window"
 msgstr "أظهر نافذة ال_سجل..."
 
-#: schematic/scheme/conf/schematic/menu.scm:215
 msgid "_1 allegro"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:223
 #, fuzzy
 msgid "User _Guide"
 msgstr "الأ_سئلة الأكثر شيوعا لـ gschem"
 
-#: schematic/scheme/conf/schematic/menu.scm:224
 msgid "_FAQ"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:225
 #, fuzzy
 msgid "Docu_mentation"
 msgstr "ت_وثيق"
 
-#: schematic/scheme/conf/schematic/menu.scm:226
 msgid "_Wiki"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:228
 #, fuzzy
 msgid "Find Component D_ocumentation"
 msgstr "توثيق الم_كونات"
 
-#: schematic/scheme/conf/schematic/menu.scm:230
 msgid "_Hotkeys..."
 msgstr "مفاتيح _ساخنة"
 
-#: schematic/scheme/conf/schematic/menu.scm:231
 #, fuzzy
 msgid "_About"
 msgstr "_عن..."
 
-#: schematic/scheme/conf/schematic/menu.scm:237
 msgid "_File"
 msgstr "_ملف"
 
-#: schematic/scheme/conf/schematic/menu.scm:238
 msgid "_Edit"
 msgstr "_تحرير"
 
-#: schematic/scheme/conf/schematic/menu.scm:240
 msgid "_View"
 msgstr "_عرض"
 
-#: schematic/scheme/conf/schematic/menu.scm:241
 msgid "_Page"
 msgstr "_صفحة"
 
-#: schematic/scheme/conf/schematic/menu.scm:242
 msgid "_Add"
 msgstr "_أضف"
 
-#: schematic/scheme/conf/schematic/menu.scm:243
 msgid "Hie_rarchy"
 msgstr "تسلسل​_هرمي"
 
-#: schematic/scheme/conf/schematic/menu.scm:244
 msgid "A_ttributes"
 msgstr "_سمات"
 
-#: schematic/scheme/conf/schematic/menu.scm:245
 msgid "_Options"
 msgstr "_خيارات"
 
-#: schematic/scheme/conf/schematic/menu.scm:246
 #, fuzzy
 msgid "_Netlist"
 msgstr "_شبكة"
 
-#: schematic/scheme/conf/schematic/menu.scm:247
 msgid "_Help"
 msgstr "مساع_دة"
 
-#: schematic/scheme/gschem/action.scm:43
 #, scheme-format
 msgid "~S is not a valid gschem action."
 msgstr ""
 
-#: schematic/scheme/gschem/action.scm:158
 msgid "Repeat Last Action"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:47
 #, fuzzy
 msgid "Cancel"
 msgstr "انتقل/ألغِ"
 
-#: schematic/scheme/gschem/builtins.scm:53
 #, fuzzy
 msgid "New File"
 msgstr "ملف جديد"
 
-#: schematic/scheme/gschem/builtins.scm:56
 #, fuzzy
 msgid "Open File"
 msgstr "افتح ملفا..."
 
-#: schematic/scheme/gschem/builtins.scm:62
 #, fuzzy
 msgid "Save As"
 msgstr "احفظ الكل"
 
-#: schematic/scheme/gschem/builtins.scm:68
 #, fuzzy
 msgid "Print"
 msgstr "اطبع..."
 
-#: schematic/scheme/gschem/builtins.scm:71
 msgid "Export Image"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:74
 msgid "Run Script"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:80
 #, fuzzy
 msgid "Close Window"
 msgstr "أغلق النافذة"
 
-#: schematic/scheme/gschem/builtins.scm:83
 #, fuzzy
 msgid "Quit"
 msgstr "أ_خرج"
 
-#: schematic/scheme/gschem/builtins.scm:87
 msgid "Terminal REPL"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:132
 msgid "Choose Slot"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:135
 #, fuzzy
 msgid "Edit Object Properties"
 msgstr "حرّر خصائص النص"
 
-#: schematic/scheme/gschem/builtins.scm:138
 #, fuzzy
 msgid "Translate Symbol"
 msgstr "اسحب"
 
-#: schematic/scheme/gschem/builtins.scm:147
 msgid "Invoke Macro"
 msgstr "استدع ماكرو"
 
-#: schematic/scheme/gschem/builtins.scm:159
 #, fuzzy
 msgid "Show/Hide Invisible Text"
 msgstr "أظهر/أخف النص الخفي"
 
-#: schematic/scheme/gschem/builtins.scm:165
 #, fuzzy
 msgid "Cut"
 msgstr "_قصّ"
 
-#: schematic/scheme/gschem/builtins.scm:171
 #, fuzzy
 msgid "Paste"
 msgstr "أ_لصق"
 
-#: schematic/scheme/gschem/builtins.scm:177
 msgid "Sidebar"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:183
 #, fuzzy
 msgid "Find Text State"
 msgstr "ابحث عن نص"
 
-#: schematic/scheme/gschem/builtins.scm:186
 #, fuzzy
 msgid "Redraw"
 msgstr "أ_عد الرسم"
 
-#: schematic/scheme/gschem/builtins.scm:192
 #, fuzzy
 msgid "Pan Left"
 msgstr "وضع الإنتقال الإختياري"
 
-#: schematic/scheme/gschem/builtins.scm:195
 #, fuzzy
 msgid "Pan Right"
 msgstr "اليمين العلوي"
 
-#: schematic/scheme/gschem/builtins.scm:198
 msgid "Pan Up"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:201
 #, fuzzy
 msgid "Pan Down"
 msgstr "وضع الإنتقال الإختياري"
 
-#: schematic/scheme/gschem/builtins.scm:216
 #, fuzzy
 msgid "Zoom Full"
 msgstr "بعّد لل_حد الأقصى"
 
-#: schematic/scheme/gschem/builtins.scm:219
 #, fuzzy
 msgid "Dark Color Scheme"
 msgstr "مخطط ألوان _داكنة"
 
-#: schematic/scheme/gschem/builtins.scm:222
 #, fuzzy
 msgid "Light Color Scheme"
 msgstr "مخطط ألوان _فاتحة"
 
-#: schematic/scheme/gschem/builtins.scm:225
 msgid "Monochrome Color Scheme"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:228
 #, fuzzy
 msgid "Show Color Scheme Editor"
 msgstr "مخطط ألوان _فاتحة"
 
-#: schematic/scheme/gschem/builtins.scm:234
 #, fuzzy
 msgid "Revert Changes"
 msgstr "أعد الصفحة"
 
-#: schematic/scheme/gschem/builtins.scm:240
 #, fuzzy
 msgid "Previous Page"
 msgstr "ال_سّابقة"
 
-#: schematic/scheme/gschem/builtins.scm:243
 #, fuzzy
 msgid "Next Page"
 msgstr "صفحة جديدة"
 
-#: schematic/scheme/gschem/builtins.scm:255
 #, fuzzy
 msgid "Print Page"
 msgstr "ال_سّابقة"
 
-#: schematic/scheme/gschem/builtins.scm:276
 #, fuzzy
 msgid "Add Line"
 msgstr "خط"
 
-#: schematic/scheme/gschem/builtins.scm:279
 #, fuzzy
 msgid "Add Path"
 msgstr "/أضف شبكة"
 
-#: schematic/scheme/gschem/builtins.scm:282
 #, fuzzy
 msgid "Add Box"
 msgstr "/أضف ناقلا"
 
-#: schematic/scheme/gschem/builtins.scm:285
 #, fuzzy
 msgid "Add Circle"
 msgstr "دائرة"
 
-#: schematic/scheme/gschem/builtins.scm:288
 #, fuzzy
 msgid "Add Arc"
 msgstr "أضف سمة"
 
-#: schematic/scheme/gschem/builtins.scm:291
 msgid "Add Pin"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:294
 #, fuzzy
 msgid "Add Picture"
 msgstr "صورة"
 
-#: schematic/scheme/gschem/builtins.scm:306
 #, fuzzy
 msgid "Up Hierarchy"
 msgstr "تسلسل هرمي"
 
-#: schematic/scheme/gschem/builtins.scm:312
 #, fuzzy
 msgid "Attach Attributes"
 msgstr "حرّر المواصفات"
 
-#: schematic/scheme/gschem/builtins.scm:315
 #, fuzzy
 msgid "Detach Attributes"
 msgstr "سمة مفصولة"
 
-#: schematic/scheme/gschem/builtins.scm:318
 #, fuzzy
 msgid "Show Attribute Value"
 msgstr "سمة ﻿الشقّ تالفة\n"
 
-#: schematic/scheme/gschem/builtins.scm:321
 #, fuzzy
 msgid "Show Attribute Name"
 msgstr "سمة ﻿الشقّ تالفة\n"
 
-#: schematic/scheme/gschem/builtins.scm:327
 #, fuzzy
 msgid "Toggle Text Visibility"
 msgstr "_بدل الرؤية"
 
-#: schematic/scheme/gschem/builtins.scm:330
 #, fuzzy
 msgid "Find Specific Text"
 msgstr "اب_حث عن نص معين..."
 
-#: schematic/scheme/gschem/builtins.scm:333
 #, fuzzy
 msgid "Hide Specific Text"
 msgstr "أ_خف نصا معينا..."
 
-#: schematic/scheme/gschem/builtins.scm:336
 #, fuzzy
 msgid "Show Specific Text"
 msgstr "أ_ظهر نصا معينا..."
 
-#: schematic/scheme/gschem/builtins.scm:339
 #, fuzzy
 msgid "Autonumber Text"
 msgstr "نص تعداد آلي"
 
-#: schematic/scheme/gschem/builtins.scm:345
 #, fuzzy
 msgid "Show Hotkeys"
 msgstr "مفاتيح ساخنة"
 
-#: schematic/scheme/gschem/builtins.scm:348
 msgid "Switch Grid Style"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:351
 msgid "Switch Snap Mode"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:354
 #, fuzzy
 msgid "Set Grid Spacing"
 msgstr "_كبّر تباعد الشبيكة"
 
-#: schematic/scheme/gschem/builtins.scm:357
 #, fuzzy
 msgid "Increase Grid Spacing"
 msgstr "_كبّر تباعد الشبيكة"
 
-#: schematic/scheme/gschem/builtins.scm:360
 #, fuzzy
 msgid "Decrease Grid Spacing"
 msgstr "_كبّر تباعد الشبيكة"
 
-#: schematic/scheme/gschem/builtins.scm:363
 #, fuzzy
 msgid "Toggle Outline Drawing"
 msgstr "بدّل ال_حد الخارجي/الإطار"
 
-#: schematic/scheme/gschem/builtins.scm:366
 #, fuzzy
 msgid "Toggle Net Rubber Band"
 msgstr "بدّل الشريط الم_طاطي للشبكة"
 
-#: schematic/scheme/gschem/builtins.scm:369
 #, fuzzy
 msgid "Toggle Magnetic Nets"
 msgstr "وضع الشبكة الم_غناطيسية"
 
-#: schematic/scheme/gschem/builtins.scm:372
 #, fuzzy
 msgid "Show Log Window"
 msgstr "أظهر نافذة ال_سجل..."
 
-#: schematic/scheme/gschem/builtins.scm:375
 #, fuzzy
 msgid "Show Coordinate Window"
 msgstr "أظهر نافذة الم_علم..."
 
-#: schematic/scheme/gschem/builtins.scm:385
 #, fuzzy
 msgid "Component Documentation"
 msgstr "توثيق الم_كونات"
 
-#: schematic/scheme/gschem/builtins.scm:387
 msgid "View documentation for selected component"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:403
 msgid ""
 "Could not show documentation for selected component:\n"
 "\n"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:408
 #, fuzzy
 msgid "gEDA Manuals"
 msgstr "يدوي"
 
-#: schematic/scheme/gschem/builtins.scm:409
 msgid "View the front page of the gEDA documentation in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:414
 #, fuzzy
 msgid "gschem User Guide"
 msgstr "الأ_سئلة الأكثر شيوعا لـ gschem"
 
-#: schematic/scheme/gschem/builtins.scm:415
 msgid "View the gschem User Guide in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:420
 #, fuzzy
 msgid "gschem FAQ"
 msgstr "الأ_سئلة الأكثر شيوعا لـ gschem"
 
-#: schematic/scheme/gschem/builtins.scm:421
 msgid "Frequently Asked Questions about using gschem."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:426
 #, fuzzy
 msgid "gEDA wiki"
 msgstr "_ويكي gEDA..."
 
-#: schematic/scheme/gschem/builtins.scm:427
 msgid "View the front page of the gEDA wiki in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:431
 msgid "About gschem"
 msgstr "عن gschem"
 
-#: schematic/scheme/gschem/deprecated.scm:102
 #, scheme-format
 msgid "Invalid text alignment ~A."
 msgstr ""
 
-#: schematic/scheme/gschem/gschemdoc.scm:241
 #, fuzzy
 msgid "No documentation found"
 msgstr "ت_وثيق"
 
-#: schematic/scheme/gschem/keymap.scm:40
 #, scheme-format
 msgid "~S is not a valid key combination."
 msgstr ""
 
-#: schematic/scheme/gschem/keymap.scm:157
 #, scheme-format
 msgid "~S is not a prefix key sequence."
 msgstr ""

--- a/schematic/po/bg.po
+++ b/schematic/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-15 15:13+0300\n"
+"POT-Creation-Date: 2019-02-22 14:08+0300\n"
 "PO-Revision-Date: 2012-01-27 14:23+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -18,22 +18,18 @@ msgstr ""
 "X-Launchpad-Export-Date: 2012-11-14 16:52+0000\n"
 "X-Generator: Launchpad (build 16265)\n"
 
-#: schematic/src/a_zoom.c:155
 msgid "Zoom too small!  Cannot zoom further."
 msgstr ""
 
-#: schematic/src/color_edit_widget.c:399
 #, c-format
 msgid ""
 "Could not save file [%s]:\n"
 "%s"
 msgstr ""
 
-#: schematic/src/color_edit_widget.c:434
 msgid "Save Color Scheme As..."
 msgstr ""
 
-#: schematic/src/color_edit_widget.c:482 schematic/src/x_fileselect.c:292
 #, c-format
 msgid ""
 "The selected file `%1$s' already exists.\n"
@@ -41,178 +37,140 @@ msgid ""
 "Would you like to overwrite it?"
 msgstr ""
 
-#: schematic/src/color_edit_widget.c:486 schematic/src/x_fileselect.c:295
 msgid "Overwrite file?"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:211
 msgid "_Apply"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:215
 msgid "Sa_ve..."
 msgstr ""
 
-#: schematic/src/font_select_widget.c:278
 #, c-format
 msgid "<b>Current:</b> %s"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:453
 msgid "Save configuration"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:461
 msgid "Save settings to:"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:465
 msgid "Local configuration file (in current directory)"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:467
 msgid "User configuration file (geda-user.conf)"
 msgstr ""
 
-#: schematic/src/g_attrib.c:90
 msgid "Object ~A is not included in the current gschem page."
 msgstr ""
 
-#: schematic/src/g_attrib.c:110
 msgid "Invalid text name/value visibility ~A."
 msgstr ""
 
-#: schematic/src/g_rc.c:107
 #, c-format
 msgid "You are running gEDA/gaf version [%1$s%2$s.%3$s],\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:111
 #, c-format
 msgid ""
 "but you have a version [%1$s] gschemrc file:\n"
 "[%2$s]\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:114
 #, c-format
 msgid "Please be sure that you have the latest rc file.\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:240
 #, c-format
 msgid "Invalid size [%1$d] passed to text-size\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:283
 #, c-format
 msgid "Invalid size [%1$d] passed to snap-size\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:620
 #, c-format
 msgid "Invalid num levels [%1$d] passed to undo-levels\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:831
 #, c-format
 msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:931
 #, c-format
 msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:972
 #, c-format
 msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:998
 #, c-format
 msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1023
 #, c-format
 msgid "Invalid offset [%1$d] passed to add-attribute-offset\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1047
 #, c-format
 msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1071
 #, c-format
 msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1094
 #, c-format
 msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1118
 #, c-format
 msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1144
 #, c-format
 msgid "Invalid gain [%1$d] passed to zoom-gain\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1169
 #, c-format
 msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
 msgstr ""
 
-#: schematic/src/g_select.c:78 schematic/src/g_select.c:115
-#: schematic/src/g_select.c:151
 msgid "Object ~A is not directly included in a page."
 msgstr ""
 
-#: schematic/src/g_util.c:54
 msgid "Could not launch URI ~S: ~A"
 msgstr ""
 
-#: schematic/src/g_window.c:139
 msgid "Found invalid gschem window smob ~S"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:156
 #, c-format
 msgid "Lepton EDA/lepton-schematic version %1$s%2$s.%3$s git: %4$.7s"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:163
 #, c-format
 msgid "This is the MINGW32 port.\n"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:167
 #, c-format
 msgid "Current locale settings: %1$s\n"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:201
 #, c-format
 msgid "Couldn't find init scm file [%1$s]"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:206
 #, c-format
 msgid "Read init scm file [%1$s]"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:210
 #, c-format
 msgid "Failed to read init scm file [%1$s]"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:290
 #, c-format
 msgid ""
 "ERROR: Failed to load or evaluate startup script.\n"
@@ -220,687 +178,502 @@ msgid ""
 "The lepton-schematic log may contain more information.\n"
 msgstr ""
 
-#: schematic/src/gschem_about_dialog.c:51
 #, c-format
 msgid "%s (git: %.7s)"
 msgstr ""
 
-#: schematic/src/gschem_about_dialog.c:75
 msgid "Lepton Electronic Design Automation"
 msgstr ""
 
-#: schematic/src/gschem_about_dialog.c:83
 msgid ""
 "Copyright © 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright © 2017-2018 Lepton Developers.\n"
-"See AUTHORS and ChangeLog files for details."
+"Copyright © 2017-2019 Lepton Developers.\n"
+"See AUTHORS, ChangeLog files and consult 'git log' history for details."
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:69
 msgid "Upper Left"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:71
 msgid "Upper Middle"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:73
 msgid "Upper Right"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:78
 msgid "Middle Left"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:80
 msgid "Middle Middle"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:82
 msgid "Middle Right"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:87
 msgid "Lower Left"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:89
 msgid "Lower Middle"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:91
 msgid "Lower Right"
 msgstr ""
 
-#: schematic/src/gschem_arc_dialog.c:104
 msgid "Arc Params"
 msgstr ""
 
-#: schematic/src/gschem_arc_dialog.c:140
 msgid "Arc _Radius:"
 msgstr ""
 
-#: schematic/src/gschem_arc_dialog.c:141
 msgid "Start _Angle:"
 msgstr ""
 
-#: schematic/src/gschem_arc_dialog.c:142
 msgid "_Degrees of Sweep:"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:504
 msgid "Left mouse button"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:508
 msgid "Middle mouse button"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:512
 msgid "Right mouse button"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:595
 msgid "(Snap size, Grid size)"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:603
 msgid "Net rubber band mode"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:614
 msgid "Magnetic net mode"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:622
 msgid "Current action mode"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:935
-#: schematic/src/gschem_bottom_widget.c:951
 msgid "OFF"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:954
 msgid "NONE"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:960
 #, c-format
 msgid "Grid(%1$s, %2$s)"
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:350
-#: schematic/src/x_compselect.c:1236 schematic/src/x_multiattrib.c:2068
 msgid "Name"
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:372
 msgid "S_elect the schematics you want to save:"
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:467
 #, c-format
 msgid "Save the changes to schematic \"%1$s\" before closing?"
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:473
 #, c-format
 msgid ""
 "There are %1$d schematics with unsaved changes. Save changes before closing?"
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:502
 msgid "If you don't save, all your changes will be permanently lost."
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:522
 msgid "Close _without saving"
 msgstr ""
 
-#: schematic/src/gschem_coord_dialog.c:86
 msgid "Coords"
 msgstr ""
 
-#: schematic/src/gschem_coord_dialog.c:106
 msgid "Screen"
 msgstr ""
 
-#: schematic/src/gschem_coord_dialog.c:115
 msgid "World"
 msgstr ""
 
-#: schematic/src/gschem_find_text_state.c:809 schematic/src/x_pagesel.c:432
 msgid "Filename"
 msgstr ""
 
-#: schematic/src/gschem_find_text_state.c:821 schematic/src/i_callbacks.c:1970
-#: schematic/src/x_colorcb.c:154 schematic/src/x_widgets.c:179
-#: schematic/src/x_window.c:1226 schematic/src/x_window.c:1440
 msgid "Text"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:427
 msgid "descend into hierarchy"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:435
 msgid "Find"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:557
 #, fuzzy
 msgid "Find Text:"
 msgstr "Редактирай Текст..."
 
-#: schematic/src/gschem_find_text_widget.c:564
 msgid "Find Pattern:"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:571
 msgid "Find Regex:"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:578
 msgid "Check symbol:"
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:200
 msgid "Hotkeys"
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:229
 msgid ""
 "Start typing action name or keystroke to filter the list.\n"
 "Type hotkeys as they are displayed in \"Keystroke(s)\" column."
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:233 schematic/src/x_compselect.c:1124
 #, fuzzy
 msgid "_Filter:"
 msgstr "Файл"
 
-#: schematic/src/gschem_hotkey_dialog.c:259 schematic/src/i_basic.c:280
 msgid "Action"
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:277
 msgid "Keystroke(s)"
 msgstr ""
 
-#: schematic/src/gschem_log_widget.c:177
 msgid "** Invalid UTF-8 in log message. See stderr or gschem.log.\n"
 msgstr ""
 
-#: schematic/src/gschem_log_widget.c:434
 #, fuzzy
 msgid "Clear log window?"
 msgstr "Нов Прозорец"
 
-#: schematic/src/gschem_log_widget.c:477
 #, fuzzy
 msgid "Clear Log _Window"
 msgstr "Нов Прозорец"
 
-#: schematic/src/gschem_macro_widget.c:231
 msgid "Macro:"
 msgstr ""
 
-#: schematic/src/gschem_macro_widget.c:387
 msgid "Evaluate"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:172
 #, fuzzy
 msgid "_Fill Type:"
 msgstr "Широчина на Линията & Тип"
 
-#: schematic/src/gschem_object_properties_widget.c:173
 #, fuzzy
 msgid "Lin_e Width:"
 msgstr "Широчина на Линията & Тип"
 
-#: schematic/src/gschem_object_properties_widget.c:174
 msgid "Angle _1:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:175
 msgid "P_itch 1:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:176
 msgid "Angle _2:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:177
 msgid "Pitc_h 2:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:237
 msgid "<b>Fill Properties</b>"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:255
-#: schematic/src/gschem_text_properties_widget.c:258
-#: schematic/src/x_newtext.c:271
 #, fuzzy
 msgid "Colo_r:"
 msgstr "Цвят..."
 
-#: schematic/src/gschem_object_properties_widget.c:266
 msgid "<b>General Properties</b>"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:284
 #, fuzzy
 msgid "_Type:"
 msgstr "Широчина на Линията & Тип"
 
-#: schematic/src/gschem_object_properties_widget.c:285
 #, fuzzy
 msgid "_Width:"
 msgstr "Широчина на Линията & Тип"
 
-#: schematic/src/gschem_object_properties_widget.c:286
 msgid "Dash _Length:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:287
 msgid "Dash _Space:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:288
 msgid "C_ap style:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:333
 msgid "<b>Line Properties</b>"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:351
 #, fuzzy
 msgid "_Pin Type:"
 msgstr "Широчина на Линията & Тип"
 
-#: schematic/src/gschem_object_properties_widget.c:362
 msgid "<b>Pin Properties</b>"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:217
 msgid "_Off"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:220
 msgid "_Dots"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:223
 msgid "M_esh"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:245
 msgid "Net R_ubber Band Mode:"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:246
 msgid "_Magnetic Net Mode:"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:250
-#: schematic/src/gschem_options_widget.c:251
 msgid "Enabled"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:265
 msgid "<b>Net Options</b>"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:282
 msgid "Grid Mode:"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:283
 #, fuzzy
 msgid "Snap Mode:"
 msgstr "Копирен Режим"
 
-#: schematic/src/gschem_options_widget.c:284
 #, fuzzy
 msgid "_Snap Size:"
 msgstr "Копирен Режим"
 
-#: schematic/src/gschem_options_widget.c:301
 msgid "<b>Snap Options</b>"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:340
 msgid "O_ff"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:343
 msgid "_Grid"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:346
 msgid "_Resnap"
 msgstr ""
 
-#: schematic/src/gschem_pin_type_combo.c:73
 msgid "Net pin"
 msgstr ""
 
-#: schematic/src/gschem_pin_type_combo.c:80
 msgid "Bus pin (graphical)"
 msgstr ""
 
-#: schematic/src/gschem_preview.c:195
 msgid "Preview Buffer"
 msgstr ""
 
-#: schematic/src/gschem_show_hide_text_widget.c:148
-#: schematic/src/x_window.c:1268
 msgid "Hide"
 msgstr ""
 
-#: schematic/src/gschem_show_hide_text_widget.c:157
-#: schematic/src/x_window.c:1269
 msgid "Hide text starting with:"
 msgstr ""
 
-#: schematic/src/gschem_slot_edit_dialog.c:91
 msgid "Edit slot number"
 msgstr ""
 
-#: schematic/src/gschem_slot_edit_dialog.c:121
 msgid "Number of Slots:"
 msgstr ""
 
-#: schematic/src/gschem_slot_edit_dialog.c:122
 msgid "Slot Number:"
 msgstr ""
 
-#: schematic/src/gschem_text_properties_widget.c:240
-#: schematic/src/x_newtext.c:265
 msgid "<b>Text Content</b>"
 msgstr ""
 
-#: schematic/src/gschem_text_properties_widget.c:259
-#: schematic/src/x_newtext.c:291
 msgid "_Size:"
 msgstr ""
 
-#: schematic/src/gschem_text_properties_widget.c:260
-#: schematic/src/x_newtext.c:310
 msgid "Ali_gnment:"
 msgstr ""
 
-#: schematic/src/gschem_text_properties_widget.c:261
-#: schematic/src/x_newtext.c:330
 msgid "Ro_tation:"
 msgstr ""
 
-#: schematic/src/gschem_text_properties_widget.c:294
-#: schematic/src/x_newtext.c:253
 msgid "<b>Text Properties</b>"
 msgstr ""
 
-#: schematic/src/gschem_translate_widget.c:238
 msgid "Coordinate:"
 msgstr ""
 
-#: schematic/src/gschem_translate_widget.c:405 schematic/src/i_callbacks.c:800
 msgid "Translate"
 msgstr ""
 
-#: schematic/src/i_basic.c:64 schematic/src/x_window.c:1369
-#: schematic/scheme/conf/schematic/menu.scm:59
-#: schematic/scheme/gschem/builtins.scm:99
 msgid "Select Mode"
 msgstr "Избери режим"
 
-#: schematic/src/i_basic.c:65
 #, fuzzy
 msgid "Select Box Mode"
 msgstr "Избери режим"
 
-#: schematic/src/i_basic.c:66
 msgid "Text Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:67
 msgid "Pan Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:70
 #, c-format
 msgid "Paste %d Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:74
 msgid "Magnetic Net Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:76
 msgid "Net Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:77
 msgid "Arc Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:78
 msgid "Box Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:79
 msgid "Bus Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:80
 msgid "Circle Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:81
 msgid "Component Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:82 schematic/scheme/conf/schematic/menu.scm:62
-#: schematic/scheme/gschem/builtins.scm:114
 msgid "Copy Mode"
 msgstr "Копирен Режим"
 
-#: schematic/src/i_basic.c:83 schematic/scheme/conf/schematic/menu.scm:63
-#: schematic/scheme/gschem/builtins.scm:117
 msgid "Multiple Copy Mode"
 msgstr "Многокопирен Режим"
 
-#: schematic/src/i_basic.c:84
 msgid "Line Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:85 schematic/scheme/conf/schematic/menu.scm:66
-#: schematic/scheme/gschem/builtins.scm:123
 msgid "Mirror Mode"
 msgstr "Огледален Режим"
 
-#: schematic/src/i_basic.c:86 schematic/scheme/conf/schematic/menu.scm:64
-#: schematic/scheme/gschem/builtins.scm:111
 msgid "Move Mode"
 msgstr "Режим Местене"
 
-#: schematic/src/i_basic.c:87
 #, fuzzy
 msgid "Path Mode"
 msgstr "Завърти 90 Режим"
 
-#: schematic/src/i_basic.c:88
 msgid "Picture Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:89
 msgid "Pin Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:90 schematic/scheme/gschem/builtins.scm:120
 msgid "Rotate Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:91
 #, fuzzy
 msgid "Modify Mode"
 msgstr "Копирен Режим"
 
-#: schematic/src/i_basic.c:92 schematic/src/x_menus.c:49
-#: schematic/scheme/gschem/builtins.scm:204
 msgid "Zoom Box"
 msgstr ""
 
-#: schematic/src/i_basic.c:121
 msgid "Show Hidden"
 msgstr ""
 
-#: schematic/src/i_basic.c:124
 msgid "Snap Off"
 msgstr ""
 
-#: schematic/src/i_basic.c:126
 msgid "Resnap Active"
 msgstr ""
 
-#: schematic/src/i_basic.c:288 schematic/src/x_colorcb.c:159
 msgid "Stroke"
 msgstr ""
 
-#: schematic/src/i_basic.c:296 schematic/src/i_basic.c:330
-#: schematic/src/x_window.c:1361
 msgid "none"
 msgstr ""
 
-#: schematic/src/i_basic.c:304
 msgid "Repeat/"
 msgstr ""
 
-#: schematic/src/i_basic.c:315
 msgid "Repeat/none"
 msgstr ""
 
-#: schematic/src/i_basic.c:323 schematic/src/i_callbacks.c:1239
-#: schematic/scheme/gschem/builtins.scm:189
 msgid "Pan"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:74
 #, c-format
 msgid "New page created [%1$s]"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:108
 #, c-format
 msgid "New Window created [%1$s]"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:245
 msgid "Failed to Save All"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:247
 msgid "Saved All"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:308
 #, fuzzy
 msgid "Closing Window"
 msgstr "Нов Прозорец"
 
-#: schematic/src/i_callbacks.c:505 schematic/src/x_menus.c:55
-#: schematic/scheme/gschem/builtins.scm:168
 msgid "Copy"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:514 schematic/src/i_callbacks.c:539
-#: schematic/src/i_callbacks.c:564
 msgid "Select objs first"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:530
 msgid "Multiple Copy"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:555 schematic/src/x_menus.c:56
 msgid "Move"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:579 schematic/src/x_menus.c:57
-#: schematic/src/x_multiattrib.c:1656 schematic/scheme/gschem/builtins.scm:108
 msgid "Delete"
 msgstr "Изтрий"
 
-#: schematic/src/i_callbacks.c:603
 msgid "Edit"
 msgstr "Редактирай"
 
-#: schematic/src/i_callbacks.c:618 schematic/scheme/gschem/builtins.scm:129
 msgid "Edit Text"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:637
 msgid "Slot"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:688 schematic/src/i_callbacks.c:698
 msgid "Rotate"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:736 schematic/src/i_callbacks.c:746
 msgid "Mirror"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:763 schematic/src/x_colorcb.c:160
-#: schematic/scheme/conf/schematic/menu.scm:73
-#: schematic/scheme/gschem/builtins.scm:141
 msgid "Lock"
 msgstr "Заключване"
 
-#: schematic/src/i_callbacks.c:781 schematic/scheme/conf/schematic/menu.scm:74
-#: schematic/scheme/gschem/builtins.scm:144
 msgid "Unlock"
 msgstr "Отключване"
 
-#: schematic/src/i_callbacks.c:805
 msgid "WARNING: Do not translate with snap off!"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:806
 msgid "WARNING: Turning snap on and continuing with translate."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:813
 msgid "WARNING: Snap grid size is not equal to 100!"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:815
 msgid ""
 "WARNING: If you are translating a symbol to the origin, the snap grid size "
 "should be set to 100"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:847
 msgid "Embed"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:886
 msgid "Unembed"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:928
 msgid "Update"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:970
 msgid "ShowHidden"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1537
 #, c-format
 msgid ""
 "<b>Revert page:</b>\n"
@@ -911,98 +684,76 @@ msgid ""
 "discarded and page file will be reloaded from disk."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1555
 msgid "Revert"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1647
 msgid "Copy to clipboard"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1664
 msgid "Cut to clipboard"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1686
 msgid "Paste from clipboard"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1694
 msgid "Empty clipboard"
 msgstr ""
 
 #. TRANSLATORS: The number is the number of the buffer that the
 #. * selection is being copied to.
-#: schematic/src/i_callbacks.c:1719
 #, fuzzy, c-format
 msgid "Copy %i"
 msgstr "Копирен Режим"
 
 #. TRANSLATORS: The number is the number of the buffer that the
 #. * selection is being cut to.
-#: schematic/src/i_callbacks.c:1746
 #, c-format
 msgid "Cut %i"
 msgstr ""
 
 #. TRANSLATORS: The number is the number of the buffer that is being
 #. * pasted to the schematic.
-#: schematic/src/i_callbacks.c:1776
 #, c-format
 msgid "Paste %i"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1785
 msgid "Empty buffer"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1833 schematic/src/x_window.c:1203
 msgid "Component"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1865 schematic/src/x_colorcb.c:150
 msgid "Attribute"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1885 schematic/src/x_colorcb.c:149
 msgid "Net"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1928 schematic/src/x_colorcb.c:155
-#: schematic/src/x_window.c:1222
 msgid "Bus"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2004
 msgid "Line"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2021
 msgid "Path"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2043
 msgid "Box"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2085
 msgid "Circle"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2108
 msgid "Arc"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2131 schematic/src/x_colorcb.c:146
 msgid "Pin"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2191
 #, c-format
 msgid "Searching for source [%1$s]"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2223
 #, c-format
 msgid ""
 "Failed to descend hierarchy into '%1$s': %2$s\n"
@@ -1010,106 +761,81 @@ msgid ""
 "The lepton-schematic log may contain more information."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2227
 #, c-format
 msgid "Failed to descend into '%1$s': %2$s"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2234
 msgid "Failed to descend hierarchy."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2312
 #, c-format
 msgid "Searching for symbol [%1$s]"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2320
 msgid "Symbol is not a real file. Symbol cannot be loaded."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2367 schematic/src/x_tabs.c:1060
 msgid "Cannot find any schematics above the current one!"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2400
 msgid "Attach"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2456
 msgid "Detach"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2500
 msgid "ShowN"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2537
 msgid "ShowV"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2574
 msgid "ShowB"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2612
 msgid "VisToggle"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2643
 #, c-format
 msgid "Sorry but this is a non-functioning menu option\n"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2703
 msgid "Action feedback mode set to OUTLINE"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2706
 msgid "Action feedback mode set to BOUNDINGBOX"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2730
 msgid "Grid OFF"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2731
 msgid "Dot grid selected"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2732
 msgid "Mesh grid selected"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2733
 msgid "Invalid grid mode"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2755
 msgid "Snap OFF (CAUTION!)"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2758
 msgid "Snap ON"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2761
 msgid "Snap back to the grid (CAUTION!)"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2790
 msgid "Rubber band ON"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2792
 msgid "Rubber band OFF"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2811
 msgid "magnetic net mode: ON"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2814
 msgid "magnetic net mode: OFF"
 msgstr ""
 
@@ -1118,133 +844,104 @@ msgstr ""
 #. the form "untitled_N.sch", where N is a number.  Please make
 #. sure that the translation contains characters suitable for use
 #. in a filename.
-#: schematic/src/i_vars.c:209
 msgid "untitled"
 msgstr ""
 
-#: schematic/src/o_complex.c:192 schematic/src/o_complex.c:195
 #, c-format
 msgid "Translating schematic [%1$d %2$d]"
 msgstr ""
 
-#: schematic/src/o_delete.c:82
 #, c-format
 msgid "Delete locked object?"
 msgid_plural "Delete %1$u locked objects?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/o_misc.c:55
 #, c-format
 msgid "Got an unexpected NULL in o_edit\n"
 msgstr ""
 
-#: schematic/src/o_misc.c:315
 msgid "Hidden text is now visible"
 msgstr ""
 
-#: schematic/src/o_misc.c:317
 msgid "Hidden text is now invisible"
 msgstr ""
 
-#: schematic/src/o_misc.c:425
 #, c-format
 msgid "Could not find symbol [%1$s] in library. Update failed."
 msgstr ""
 
-#: schematic/src/o_misc.c:541
 #, c-format
 msgid "o_autosave_backups: Can't get the real filename of %1$s."
 msgstr ""
 
-#: schematic/src/o_misc.c:585
 #, c-format
 msgid "Could NOT set previous backup file [%1$s] read-write"
 msgstr ""
 
-#: schematic/src/o_misc.c:605
 #, c-format
 msgid "Could NOT set backup file [%1$s] readonly"
 msgstr ""
 
-#: schematic/src/o_misc.c:610
 #, c-format
 msgid "Could NOT save backup file [%1$s]"
 msgstr ""
 
-#: schematic/src/o_move.c:192
 #, c-format
 msgid "ERROR: NULL object in o_move_end!\n"
 msgstr ""
 
-#: schematic/src/o_move.c:519
 #, c-format
 msgid "DOH! tried to find the whichone, but didn't find it!\n"
 msgstr ""
 
-#: schematic/src/o_move.c:546
 #, c-format
 msgid "Got a non line object in o_move_check_endpoint\n"
 msgstr ""
 
-#: schematic/src/o_net.c:444
 msgid "Warning: Starting net at off grid coordinate"
 msgstr ""
 
-#: schematic/src/o_net.c:508
 msgid "Warning: Ending net at off grid coordinate"
 msgstr ""
 
-#: schematic/src/o_net.c:856 schematic/src/o_net.c:893
-#: schematic/src/o_net.c:964 schematic/src/o_net.c:1000
 #, c-format
 msgid "Tried to add more than two bus rippers. Internal gschem error.\n"
 msgstr ""
 
-#: schematic/src/o_net.c:1068
 #, c-format
 msgid "Bus ripper symbol [%1$s] was not found in any component library"
 msgstr ""
 
-#: schematic/src/o_picture.c:133 schematic/src/o_picture.c:343
 msgid "Select a picture file..."
 msgstr ""
 
-#: schematic/src/o_picture.c:166
 #, c-format
 msgid "Failed to load picture: %1$s"
 msgstr ""
 
-#: schematic/src/o_picture.c:182
 msgid "Picture"
 msgstr ""
 
-#: schematic/src/o_picture.c:378
 #, c-format
 msgid "Failed to replace pictures: %s"
 msgstr ""
 
-#: schematic/src/o_slot.c:80
 msgid "Slot attribute malformed"
 msgstr ""
 
-#: schematic/src/o_slot.c:88
 msgid "numslots attribute missing"
 msgstr ""
 
-#: schematic/src/o_slot.c:89
 msgid "Slotting not allowed for this component"
 msgstr ""
 
-#: schematic/src/o_slot.c:104
 msgid "New slot number out of range"
 msgstr ""
 
-#: schematic/src/o_undo.c:397
 msgid "Undo/Redo disabled in rc file"
 msgstr ""
 
-#: schematic/src/parsecmd.c:77
 #, c-format
 msgid ""
 "Usage: %1$s [OPTION ...] [--] [FILE ...]\n"
@@ -1269,187 +966,143 @@ msgid ""
 "gEDA/gaf homepage: <http://www.geda-project.org/>\n"
 msgstr ""
 
-#: schematic/src/parsecmd.c:110
 #, c-format
 msgid ""
 "Lepton EDA %1$s (git: %2$.7s)\n"
 "Copyright (C) 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright (C) 2017-2018 Lepton Developers.\n"
+"Copyright (C) 2017-2019 Lepton Developers.\n"
 "This is free software, and you are welcome to redistribute it under\n"
 "certain conditions. For details, see the file `COPYING', which is\n"
 "included in the Lepton EDA distribution.\n"
 "There is NO WARRANTY, to the extent permitted by law.\n"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:125
 #, c-format
 msgid "Got invalid show option; defaulting to show both\n"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:139
 #, c-format
 msgid "ERROR: NULL object!\n"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:328
 msgid "Single Attribute Editor"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:358
 msgid "<b>Edit Attribute</b>"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:360
 msgid "<b>Add Attribute</b>"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:376
 msgid "N_ame:"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:396 schematic/src/x_multiattrib.c:2222
 msgid "_Value:"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:415 schematic/src/x_multiattrib.c:2281
 msgid "Vi_sible"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:434
 msgid "Show Value Only"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:436
 msgid "Show Name Only"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:438 schematic/src/x_multiattrib.c:1620
-#: schematic/scheme/gschem/builtins.scm:324
 msgid "Show Name & Value"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:445
 msgid "<b>Attach Options</b>"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:460
 msgid "All"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:476 schematic/src/x_compselect.c:986
-#: schematic/src/x_compselect.c:1100
 msgid "Components"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:492 schematic/src/x_window.c:1214
 msgid "Nets"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:508
 msgid "Replace existing attributes"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:412
 msgid ""
 "slotted object without slot attribute may cause problems when autonumbering "
 "slots"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:427
 #, c-format
 msgid ""
 "duplicate slot may cause problems: [symbolname=%1$s, number=%2$d, slot=%3$d]"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:675
 msgid "No searchstring given in autonumber text."
 msgstr ""
 
-#: schematic/src/x_autonumber.c:728
 msgid "No '*' or '?' given at the end of the autonumber text."
 msgstr ""
 
-#: schematic/src/x_autonumber.c:873
 msgid "Diagonal"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:874
 msgid "Top to bottom"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:875
 msgid "Bottom to top"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:876
 msgid "Left to right"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:877
 msgid "Right to left"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:878
 msgid "File order"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1214
 msgid "Autonumber text"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1237
 msgid "<b>Scope</b>"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1259
 msgid "Search for:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1273
 msgid "Autonumber text in:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1280
 msgid "Skip numbers found in:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1292 schematic/src/x_autonumber.c:1301
 msgid "Selected objects"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1293 schematic/src/x_autonumber.c:1302
 msgid "Current page"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1294 schematic/src/x_autonumber.c:1303
 msgid "Whole hierarchy"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1305
 msgid "Overwrite existing numbers"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1310
 msgid "<b>Options</b>"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1332
 msgid "Starting number:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1339
 msgid "Sort order:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1371
 msgid "Remove numbers"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1375
 msgid "Automatic slotting"
 msgstr ""
 
-#: schematic/src/x_clipboard.c:245
 #, c-format
 msgid ""
 "<b>Invalid schematic on clipboard.</b>\n"
@@ -1457,171 +1110,131 @@ msgid ""
 "An error occurred while inserting clipboard data: %s."
 msgstr ""
 
-#: schematic/src/x_clipboard.c:247
 msgid "Clipboard insertion failed"
 msgstr ""
 
-#: schematic/src/x_color.c:89 schematic/src/x_color.c:98
 #, c-format
 msgid "Could not allocate the color %1$s!\n"
 msgstr ""
 
-#: schematic/src/x_color.c:89
 msgid "black"
 msgstr ""
 
-#: schematic/src/x_color.c:98
 msgid "white"
 msgstr ""
 
-#: schematic/src/x_color.c:120
 #, c-format
 msgid "Could not allocate display color %1$i!\n"
 msgstr ""
 
-#: schematic/src/x_color.c:142
 #, c-format
 msgid "Could not allocate outline color %1$i!\n"
 msgstr ""
 
-#: schematic/src/x_color.c:159
 #, c-format
 msgid "Tried to get an invalid color: %1$d\n"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:145
 msgid "Background"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:147
 msgid "Net endpoint"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:148
 msgid "Graphic"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:151
 msgid "Logic bubble"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:152
 msgid "Grid point"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:153
 msgid "Detached attribute"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:156
 #, fuzzy
 msgid "Selection"
 msgstr "Избери режим"
 
-#: schematic/src/x_colorcb.c:157
 msgid "Bounding box"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:158
 msgid "Zoom box"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:161
 msgid "Output background"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:162
 msgid "Freestyle 1"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:163
 msgid "Freestyle 2"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:164
 msgid "Freestyle 3"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:165
 msgid "Freestyle 4"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:166
 msgid "Net junction"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:167
 msgid "Mesh grid major"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:168
 msgid "Mesh grid minor"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:172
 msgid "Unknown"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1169
 msgid "Reset filter"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1192
 msgid "Reload all libraries"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1245 schematic/src/x_multiattrib.c:2092
 msgid "Value"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1284
 msgid "Default behavior - reference component"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1287
 msgid "Embed component in schematic"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1290
 msgid "Include component as individual objects"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1448
 msgid "Select Component..."
 msgstr ""
 
-#: schematic/src/x_compselect.c:1471
 msgid "In Us_e"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1475
 msgid "Lib_raries"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1484 schematic/src/x_fileselect.c:119
 msgid "Preview"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1510
 msgid "Attributes"
 msgstr ""
 
-#: schematic/src/x_dialog.c:325
 msgid "Major symbol changes detected."
 msgstr ""
 
-#: schematic/src/x_dialog.c:349
 msgid ""
 "Changes have occurred to the symbols shown below.\n"
 "\n"
 "Be sure to verify each of these symbols."
 msgstr ""
 
-#: schematic/src/x_dialog.c:369
 msgid "Symbol"
 msgstr ""
 
-#: schematic/src/x_dialog.c:406
 #, c-format
 msgid ""
 "<span weight=\"bold\" size=\"larger\">The input attribute \"%s\" is invalid\n"
@@ -1632,39 +1245,30 @@ msgid ""
 "The value cannot start with a space."
 msgstr ""
 
-#: schematic/src/x_dialog.c:408
 msgid "Invalid Attribute"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:37
 msgid "Schematics"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:42
 msgid "Symbols"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:47
 msgid "Schematics and symbols"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:53
 msgid "All files"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:169
 msgid "Open..."
 msgstr ""
 
-#: schematic/src/x_fileselect.c:233
 msgid "Save as..."
 msgstr ""
 
-#: schematic/src/x_fileselect.c:297
 msgid "Save cancelled on user request"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:334
 msgid ""
 "\n"
 "If you load the original file, the backup file will be overwritten in the "
@@ -1673,28 +1277,22 @@ msgid ""
 "Do you want to load the backup file?\n"
 msgstr ""
 
-#: schematic/src/x_fstylecb.c:73
 msgid "Hollow"
 msgstr ""
 
-#: schematic/src/x_fstylecb.c:80
 msgid "Filled"
 msgstr ""
 
-#: schematic/src/x_fstylecb.c:87
 msgid "Mesh"
 msgstr ""
 
-#: schematic/src/x_fstylecb.c:94
 msgid "Hatch"
 msgstr ""
 
-#: schematic/src/x_image.c:279
 #, c-format
 msgid "x_image_lowlevel: Unable to write %1$s file %2$s."
 msgstr ""
 
-#: schematic/src/x_image.c:289
 #, c-format
 msgid ""
 "There was the following error when saving image with type %1$s to filename:\n"
@@ -1703,296 +1301,229 @@ msgid ""
 "%3$s.\n"
 msgstr ""
 
-#: schematic/src/x_image.c:309
 #, c-format
 msgid "Wrote color image to [%1$s] [%2$d x %3$d]"
 msgstr ""
 
-#: schematic/src/x_image.c:311
 #, c-format
 msgid "Wrote black and white image to [%1$s] [%2$d x %3$d]"
 msgstr ""
 
-#: schematic/src/x_image.c:319
 msgid "x_image_lowlevel: Unable to get pixbuf from gschem's window."
 msgstr ""
 
-#: schematic/src/x_image.c:358
 msgid "Width x Height"
 msgstr ""
 
-#: schematic/src/x_image.c:374
 msgid "Image type"
 msgstr ""
 
-#: schematic/src/x_image.c:395
 msgid "Write image..."
 msgstr "Запиши Снимката..."
 
-#: schematic/src/x_linecapcb.c:74
 msgid "Butt"
 msgstr ""
 
-#: schematic/src/x_linecapcb.c:81
 msgid "Square"
 msgstr ""
 
-#: schematic/src/x_linecapcb.c:88
 msgid "Round"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:74
 msgid "Solid"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:81
 msgid "Dotted"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:88
 msgid "Dashed"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:95
 msgid "Center"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:102
 msgid "Phantom"
 msgstr ""
 
-#: schematic/src/x_menus.c:41 schematic/scheme/gschem/builtins.scm:267
 msgid "Add Net"
 msgstr ""
 
-#: schematic/src/x_menus.c:42 schematic/src/x_multiattrib.c:2187
-#: schematic/scheme/gschem/builtins.scm:264
 msgid "Add Attribute"
 msgstr ""
 
-#: schematic/src/x_menus.c:43 schematic/scheme/gschem/builtins.scm:261
 #, fuzzy
 msgid "Add Component"
 msgstr "Обнови Компонент"
 
-#: schematic/src/x_menus.c:44 schematic/scheme/gschem/builtins.scm:270
 msgid "Add Bus"
 msgstr ""
 
-#: schematic/src/x_menus.c:45 schematic/scheme/gschem/builtins.scm:273
 #, fuzzy
 msgid "Add Text"
 msgstr "Редактирай Текст..."
 
-#: schematic/src/x_menus.c:47 schematic/scheme/gschem/builtins.scm:210
 msgid "Zoom In"
 msgstr ""
 
-#: schematic/src/x_menus.c:48 schematic/scheme/gschem/builtins.scm:213
 msgid "Zoom Out"
 msgstr ""
 
-#: schematic/src/x_menus.c:50 schematic/scheme/gschem/builtins.scm:207
 msgid "Zoom Extents"
 msgstr ""
 
-#: schematic/src/x_menus.c:52 schematic/src/x_window.c:1233
 msgid "Select"
 msgstr ""
 
-#: schematic/src/x_menus.c:53 schematic/scheme/conf/schematic/menu.scm:69
-#: schematic/scheme/gschem/builtins.scm:126
 msgid "Edit..."
 msgstr "Редактирай..."
 
-#: schematic/src/x_menus.c:54 schematic/scheme/conf/schematic/menu.scm:68
 msgid "Object Properties..."
 msgstr ""
 
-#: schematic/src/x_menus.c:59 schematic/scheme/gschem/builtins.scm:300
 msgid "Down Schematic"
 msgstr ""
 
-#: schematic/src/x_menus.c:60 schematic/scheme/gschem/builtins.scm:303
 msgid "Down Symbol"
 msgstr ""
 
-#: schematic/src/x_menus.c:61
 msgid "Up"
 msgstr ""
 
-#: schematic/src/x_menus.c:336
 #, c-format
 msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
 msgstr ""
 
-#: schematic/src/x_menus.c:360
 #, c-format
 msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
 msgstr ""
 
-#: schematic/src/x_misc.c:70
 msgid "The operating system is out of memory or resources."
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:798 schematic/src/x_multiattrib.c:2704
 msgid "<various>"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:930
 msgid "Attributes with empty name are not allowed. Please set a name."
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1622
 msgid "Show Value only"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1624
 msgid "Show Name only"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1651
 msgid "Promote"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1655
 msgid "Duplicate"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1657
 #, fuzzy
 msgid "Copy to all"
 msgstr "Копирен Режим"
 
-#: schematic/src/x_multiattrib.c:1986 schematic/src/x_multiattrib.c:2602
 msgid "Edit Attributes"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2112
 msgid "Vis?"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2130
 msgid "N"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2148
 msgid "V"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2170
 msgid "Sho_w inherited attributes"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2197
 msgid "_Name:"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2241
 msgid "Ctrl+Enter inserts new line; Ctrl+Tab inserts Tab"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2618
 #, c-format
 msgid "%2$i symbol (%1$s)"
 msgid_plural "%2$i symbols (%1$s)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2624
 #, c-format
 msgid "%1$i pin"
 msgid_plural "%1$i pins"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2630
 #, c-format
 msgid "%1$i net"
 msgid_plural "%1$i nets"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2636
 #, c-format
 msgid "%1$i bus"
 msgid_plural "%1$i buses"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2642
 #, c-format
 msgid "%1$i attribute"
 msgid_plural "%1$i attributes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_newtext.c:433
 msgid "Text Entry..."
 msgstr ""
 
-#: schematic/src/x_pagesel.c:253
 msgid "New Page"
 msgstr "Нова Страница"
 
-#: schematic/src/x_pagesel.c:254
 msgid "Open Page..."
 msgstr "Отвори Страница..."
 
-#: schematic/src/x_pagesel.c:256
 msgid "Save Page"
 msgstr "Съхрани Страницата"
 
-#: schematic/src/x_pagesel.c:257 schematic/scheme/gschem/builtins.scm:246
 msgid "Close Page"
 msgstr "Затвори Страницата"
 
-#: schematic/src/x_pagesel.c:376 schematic/scheme/gschem/builtins.scm:237
 msgid "Page Manager"
 msgstr ""
 
-#: schematic/src/x_pagesel.c:448
 msgid "Changed"
 msgstr ""
 
-#: schematic/src/x_pagesel.c:468
 msgid "Right click on the filename for more options..."
 msgstr ""
 
-#: schematic/src/x_print.c:306
 #, c-format
 msgid "Failed to write PDF to '%s': %s\n"
 msgstr ""
 
-#: schematic/src/x_print.c:364
 #, c-format
 msgid "Failed to write PDF to '%1$s': %2$s\n"
 msgstr ""
 
-#: schematic/src/x_print.c:449
 #, c-format
 msgid ""
 "Error printing file:\n"
 "%1$s"
 msgstr ""
 
-#: schematic/src/x_rc.c:39
 msgid "ERROR: An unknown error occurred while parsing configuration files."
 msgstr ""
 
-#: schematic/src/x_rc.c:44
 msgid ""
 "An unknown error occurred while parsing configuration files.\n"
 "\n"
 "The lepton-schematic log may contain more information."
 msgstr ""
 
-#: schematic/src/x_rc.c:56
 #, c-format
 msgid "ERROR: %1$s"
 msgstr ""
 
-#: schematic/src/x_rc.c:59
 #, c-format
 msgid ""
 "%1$s\n"
@@ -2000,136 +1531,105 @@ msgid ""
 "The lepton-schematic log may contain more information."
 msgstr ""
 
-#: schematic/src/x_rc.c:67
 msgid "Cannot load lepton-schematic configuration."
 msgstr ""
 
-#: schematic/src/x_script.c:42 schematic/scheme/conf/schematic/menu.scm:40
 msgid "Execute Script..."
 msgstr "Изпълни Скрипт"
 
-#: schematic/src/x_script.c:61
 #, c-format
 msgid "Executing guile script [%1$s]"
 msgstr ""
 
-#: schematic/src/x_tabs.c:860
 #, c-format
 msgid "Hierarchy up: %s"
 msgstr ""
 
-#: schematic/src/x_tabs.c:863
 msgid "Hierarchy up"
 msgstr ""
 
-#: schematic/src/x_widgets.c:158 schematic/src/x_window.c:1444
 msgid "Options"
 msgstr ""
 
-#: schematic/src/x_widgets.c:203 schematic/src/x_window.c:1436
 msgid "Object"
 msgstr ""
 
-#: schematic/src/x_widgets.c:224
 msgid "Log"
 msgstr ""
 
-#: schematic/src/x_widgets.c:245 schematic/src/x_window.c:1466
 msgid "Find Text"
 msgstr ""
 
-#: schematic/src/x_widgets.c:259
 msgid "Color Scheme Editor"
 msgstr ""
 
-#: schematic/src/x_widgets.c:272 schematic/scheme/gschem/builtins.scm:378
 #, fuzzy
 msgid "Select Schematic Font"
 msgstr "Избери режим"
 
-#: schematic/src/x_window.c:763
 #, c-format
 msgid "Loading schematic [%1$s]"
 msgstr ""
 
-#: schematic/src/x_window.c:864
 #, c-format
 msgid "Could NOT save page [%1$s]\n"
 msgstr ""
 
-#: schematic/src/x_window.c:865
 msgid "Error while trying to save"
 msgstr ""
 
-#: schematic/src/x_window.c:875
 msgid "Failed to save file"
 msgstr ""
 
-#: schematic/src/x_window.c:885
 #, fuzzy, c-format
 msgid "Saved as [%1$s]"
 msgstr "Съхрани Всичко"
 
-#: schematic/src/x_window.c:887
 #, fuzzy, c-format
 msgid "Saved [%1$s]"
 msgstr "Съхрани Всичко"
 
-#: schematic/src/x_window.c:889
 msgid "Saved"
 msgstr ""
 
-#: schematic/src/x_window.c:966
 #, c-format
 msgid "Discarding page [%1$s]"
 msgstr ""
 
-#: schematic/src/x_window.c:966
 #, c-format
 msgid "Closing [%1$s]"
 msgstr ""
 
-#: schematic/src/x_window.c:1175
 msgid "New"
 msgstr ""
 
-#: schematic/src/x_window.c:1175
 msgid "New file"
 msgstr ""
 
-#: schematic/src/x_window.c:1179
 msgid "Open"
 msgstr ""
 
-#: schematic/src/x_window.c:1179
 msgid "Open file"
 msgstr ""
 
-#: schematic/src/x_window.c:1183 schematic/scheme/gschem/builtins.scm:59
 msgid "Save"
 msgstr ""
 
-#: schematic/src/x_window.c:1183
 msgid "Save file"
 msgstr ""
 
-#: schematic/src/x_window.c:1189 schematic/scheme/gschem/builtins.scm:93
 msgid "Undo"
 msgstr "Върни"
 
-#: schematic/src/x_window.c:1189
 msgid "Undo last operation"
 msgstr ""
 
-#: schematic/src/x_window.c:1193 schematic/scheme/gschem/builtins.scm:96
 msgid "Redo"
 msgstr "Направи отново"
 
-#: schematic/src/x_window.c:1193
 msgid "Redo last undo"
 msgstr ""
 
-#: schematic/src/x_window.c:1198
 msgid ""
 "Add component...\n"
 "Select library and component from list, move the mouse into main window, "
@@ -2137,56 +1637,44 @@ msgid ""
 "Right mouse button to cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1209
 msgid ""
 "Add nets mode\n"
 "Right mouse button to cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1217
 msgid ""
 "Add buses mode\n"
 "Right mouse button to cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1226
 msgid "Add Text..."
 msgstr ""
 
-#: schematic/src/x_window.c:1233
 msgid "Select mode"
 msgstr ""
 
-#: schematic/src/x_window.c:1288
 msgid "Show"
 msgstr ""
 
-#: schematic/src/x_window.c:1289
 msgid "Show text starting with:"
 msgstr ""
 
-#: schematic/src/x_window.c:1345
 msgid "Menu/Cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1349
 msgid "Pan/Cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1359
 msgid "Pick"
 msgstr ""
 
-#: schematic/src/x_window.c:1470 schematic/scheme/gschem/builtins.scm:180
 msgid "Status"
 msgstr ""
 
-#: schematic/src/x_window.c:1568
 #, fuzzy, c-format
 msgid "New file [%s]"
 msgstr "Нова Страница"
 
-#: schematic/src/x_window.c:1598
 #, c-format
 msgid ""
 "<b>An error occurred while loading the requested file.</b>\n"
@@ -2200,836 +1688,626 @@ msgid ""
 "monitor program's output in terminal window."
 msgstr ""
 
-#: schematic/src/x_window.c:1617
 msgid "Failed to load file"
 msgstr ""
 
-#: schematic/data/lepton-schematic.desktop.in:3
 msgid "Lepton EDA Schematic Editor"
 msgstr ""
 
-#: schematic/data/lepton-schematic.desktop.in:4
 msgid "Create and edit electrical schematics and symbols with lepton-schematic"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:27
 msgid "_New"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:28
 msgid "_Open..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:30
 msgid "Open Recen_t"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:32
 msgid "_Save"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:33
 msgid "Save _As..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:34
-#: schematic/scheme/gschem/builtins.scm:65
 msgid "Save All"
 msgstr "Съхрани Всичко"
 
-#: schematic/scheme/conf/schematic/menu.scm:36
 msgid "_Print..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:37
 #, fuzzy
 msgid "Write _Image..."
 msgstr "Запиши Снимката..."
 
-#: schematic/scheme/conf/schematic/menu.scm:39
 msgid "Invoke Macro..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:41
 msgid "REPL..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:43
-#: schematic/scheme/gschem/builtins.scm:77
 msgid "New Window"
 msgstr "Нов Прозорец"
 
-#: schematic/scheme/conf/schematic/menu.scm:44
 msgid "_Close Window"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:45
 msgid "_Quit"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:51
 msgid "_Undo"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:52
 msgid "_Redo"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:54
 msgid "Cu_t"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:55
 msgid "_Copy"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:56
 msgid "_Paste"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:57
 msgid "_Delete"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:60
-#: schematic/scheme/gschem/builtins.scm:102
 msgid "Select All"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:61
-#: schematic/scheme/gschem/builtins.scm:105
 msgid "Deselect"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:65
 msgid "Rotate 90 Mode"
 msgstr "Завърти 90 Режим"
 
-#: schematic/scheme/conf/schematic/menu.scm:70
 msgid "Edit Text..."
 msgstr "Редактирай Текст..."
 
-#: schematic/scheme/conf/schematic/menu.scm:71
 msgid "Slot..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:76
-#: schematic/scheme/gschem/builtins.scm:150
 msgid "Embed Component/Picture"
 msgstr "Вграден Компонент/Картина"
 
-#: schematic/scheme/conf/schematic/menu.scm:77
-#: schematic/scheme/gschem/builtins.scm:153
 msgid "Unembed Component/Picture"
 msgstr "Невграден Компонент/Картина"
 
-#: schematic/scheme/conf/schematic/menu.scm:78
-#: schematic/scheme/gschem/builtins.scm:156
 msgid "Update Component"
 msgstr "Обнови Компонент"
 
-#: schematic/scheme/conf/schematic/menu.scm:79
 msgid "Symbol Translate..."
 msgstr "Превеждане на Символ"
 
-#: schematic/scheme/conf/schematic/menu.scm:85
 msgid "Copy into 1"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:86
 msgid "Copy into 2"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:87
 msgid "Copy into 3"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:88
 msgid "Copy into 4"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:89
 msgid "Copy into 5"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:90
 msgid "Cut into 1"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:91
 msgid "Cut into 2"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:92
 msgid "Cut into 3"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:93
 msgid "Cut into 4"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:94
 msgid "Cut into 5"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:95
 msgid "Paste from 1"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:96
 msgid "Paste from 2"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:97
 msgid "Paste from 3"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:98
 msgid "Paste from 4"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:99
 msgid "Paste from 5"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:105
 msgid "Side Dock"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:106
 msgid "Bottom Dock"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:108
 #, fuzzy
 msgid "Find Text Results"
 msgstr "Редактирай Текст..."
 
-#: schematic/scheme/conf/schematic/menu.scm:110
 msgid "_Redraw"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:111
 msgid "_Pan"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:112
 msgid "Zoom _Box"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:113
 msgid "Zoom _Extents"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:114
 msgid "Zoom _In"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:115
 msgid "Zoom _Out"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:116
 msgid "Zoom _Full"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:118
 msgid "_Dark Color Scheme"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:119
 msgid "_Light Color Scheme"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:120
 msgid "B_W Color Scheme"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:122
 msgid "Color Scheme Editor..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:129
 msgid "_Manager..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:131
 msgid "_Previous"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:132
 msgid "_Next"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:133
 msgid "_Close"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:135
 msgid "_Revert..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:137
-#: schematic/scheme/gschem/builtins.scm:249
 #, fuzzy
 msgid "Next Tab"
 msgstr "Нова Страница"
 
-#: schematic/scheme/conf/schematic/menu.scm:138
-#: schematic/scheme/gschem/builtins.scm:252
 #, fuzzy
 msgid "Previous Tab"
 msgstr "Затвори Страницата"
 
-#: schematic/scheme/conf/schematic/menu.scm:146
 msgid "_Component..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:148
 msgid "_Net"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:149
 msgid "B_us"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:151
 msgid "_Attribute..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:152
 msgid "_Text..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:154
 msgid "_Line"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:155
 msgid "Pat_h"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:156
 msgid "_Box"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:157
 msgid "C_ircle"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:158
 msgid "A_rc"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:159
 msgid "_Pin"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:161
 msgid "Pictu_re..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:167
 msgid "_Up"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:169
 msgid "_Down Schematic"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:170
 msgid "Down _Symbol"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:176
 msgid "_Attach"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:177
 msgid "_Detach"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:179
 msgid "Show _Value"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:180
 msgid "Show _Name"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:181
 msgid "Show _Both"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:182
 msgid "_Toggle Visibility"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:184
 msgid "_Hide Specific Text..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:185
 msgid "_Show Specific Text..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:186
 msgid "Show/Hide Hidden Text"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:188
 msgid "_Find Text/Check Symbol..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:189
 msgid "A_utonumber Text..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:195
 msgid "_Options..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:196
 msgid "_Font..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:198
 msgid "Grid +"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:199
 msgid "Grid -"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:201
 msgid "Grid Style: Cycle Dots/Mesh/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:202
 msgid "Grid Snap: Cycle Grid/Resnap/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:204
 msgid "Feedback Mode: Outline/Box"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:205
 msgid "Net: Rubberband On/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:206
 msgid "Net: Magnetic On/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:208
 #, fuzzy
 msgid "_Coord Window"
 msgstr "Нов Прозорец"
 
-#: schematic/scheme/conf/schematic/menu.scm:209
 #, fuzzy
 msgid "_Log Window"
 msgstr "Нов Прозорец"
 
-#: schematic/scheme/conf/schematic/menu.scm:215
 msgid "_1 allegro"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:223
 msgid "User _Guide"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:224
 msgid "_FAQ"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:225
 msgid "Docu_mentation"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:226
 msgid "_Wiki"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:228
 msgid "Find Component D_ocumentation"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:230
 msgid "_Hotkeys..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:231
 msgid "_About"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:237
 msgid "_File"
 msgstr "Файл"
 
-#: schematic/scheme/conf/schematic/menu.scm:238
 msgid "_Edit"
 msgstr "Редактирай"
 
-#: schematic/scheme/conf/schematic/menu.scm:240
 msgid "_View"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:241
 msgid "_Page"
 msgstr "Нова Страница"
 
-#: schematic/scheme/conf/schematic/menu.scm:242
 msgid "_Add"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:243
 msgid "Hie_rarchy"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:244
 msgid "A_ttributes"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:245
 msgid "_Options"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:246
 msgid "_Netlist"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:247
 msgid "_Help"
 msgstr ""
 
-#: schematic/scheme/gschem/action.scm:43
 #, scheme-format
 msgid "~S is not a valid gschem action."
 msgstr ""
 
-#: schematic/scheme/gschem/action.scm:158
 msgid "Repeat Last Action"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:47
 msgid "Cancel"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:53
 #, fuzzy
 msgid "New File"
 msgstr "Нова Страница"
 
-#: schematic/scheme/gschem/builtins.scm:56
 msgid "Open File"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:62
 #, fuzzy
 msgid "Save As"
 msgstr "Съхрани Всичко"
 
-#: schematic/scheme/gschem/builtins.scm:68
 #, fuzzy
 msgid "Print"
 msgstr "Принтирай..."
 
-#: schematic/scheme/gschem/builtins.scm:71
 msgid "Export Image"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:74
 msgid "Run Script"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:80
 #, fuzzy
 msgid "Close Window"
 msgstr "Нов Прозорец"
 
-#: schematic/scheme/gschem/builtins.scm:83
 msgid "Quit"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:87
 msgid "Terminal REPL"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:132
 msgid "Choose Slot"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:135
 msgid "Edit Object Properties"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:138
 msgid "Translate Symbol"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:147
 msgid "Invoke Macro"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:159
 msgid "Show/Hide Invisible Text"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:165
 msgid "Cut"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:171
 msgid "Paste"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:177
 msgid "Sidebar"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:183
 #, fuzzy
 msgid "Find Text State"
 msgstr "Редактирай Текст..."
 
-#: schematic/scheme/gschem/builtins.scm:186
 msgid "Redraw"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:192
 msgid "Pan Left"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:195
 msgid "Pan Right"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:198
 msgid "Pan Up"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:201
 msgid "Pan Down"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:216
 msgid "Zoom Full"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:219
 msgid "Dark Color Scheme"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:222
 msgid "Light Color Scheme"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:225
 msgid "Monochrome Color Scheme"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:228
 msgid "Show Color Scheme Editor"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:234
 msgid "Revert Changes"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:240
 #, fuzzy
 msgid "Previous Page"
 msgstr "Затвори Страницата"
 
-#: schematic/scheme/gschem/builtins.scm:243
 #, fuzzy
 msgid "Next Page"
 msgstr "Нова Страница"
 
-#: schematic/scheme/gschem/builtins.scm:255
 #, fuzzy
 msgid "Print Page"
 msgstr "Затвори Страницата"
 
-#: schematic/scheme/gschem/builtins.scm:276
 msgid "Add Line"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:279
 msgid "Add Path"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:282
 msgid "Add Box"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:285
 msgid "Add Circle"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:288
 msgid "Add Arc"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:291
 msgid "Add Pin"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:294
 msgid "Add Picture"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:306
 msgid "Up Hierarchy"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:312
 msgid "Attach Attributes"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:315
 msgid "Detach Attributes"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:318
 msgid "Show Attribute Value"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:321
 msgid "Show Attribute Name"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:327
 msgid "Toggle Text Visibility"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:330
 msgid "Find Specific Text"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:333
 msgid "Hide Specific Text"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:336
 msgid "Show Specific Text"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:339
 msgid "Autonumber Text"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:345
 msgid "Show Hotkeys"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:348
 msgid "Switch Grid Style"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:351
 msgid "Switch Snap Mode"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:354
 msgid "Set Grid Spacing"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:357
 msgid "Increase Grid Spacing"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:360
 msgid "Decrease Grid Spacing"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:363
 msgid "Toggle Outline Drawing"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:366
 msgid "Toggle Net Rubber Band"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:369
 msgid "Toggle Magnetic Nets"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:372
 #, fuzzy
 msgid "Show Log Window"
 msgstr "Нов Прозорец"
 
-#: schematic/scheme/gschem/builtins.scm:375
 msgid "Show Coordinate Window"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:385
 msgid "Component Documentation"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:387
 msgid "View documentation for selected component"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:403
 msgid ""
 "Could not show documentation for selected component:\n"
 "\n"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:408
 msgid "gEDA Manuals"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:409
 msgid "View the front page of the gEDA documentation in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:414
 msgid "gschem User Guide"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:415
 msgid "View the gschem User Guide in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:420
 msgid "gschem FAQ"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:421
 msgid "Frequently Asked Questions about using gschem."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:426
 msgid "gEDA wiki"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:427
 msgid "View the front page of the gEDA wiki in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:431
 msgid "About gschem"
 msgstr ""
 
-#: schematic/scheme/gschem/deprecated.scm:102
 #, scheme-format
 msgid "Invalid text alignment ~A."
 msgstr ""
 
-#: schematic/scheme/gschem/gschemdoc.scm:241
 msgid "No documentation found"
 msgstr ""
 
-#: schematic/scheme/gschem/keymap.scm:40
 #, scheme-format
 msgid "~S is not a valid key combination."
 msgstr ""
 
-#: schematic/scheme/gschem/keymap.scm:157
 #, scheme-format
 msgid "~S is not a prefix key sequence."
 msgstr ""

--- a/schematic/po/bs.po
+++ b/schematic/po/bs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-15 15:13+0300\n"
+"POT-Creation-Date: 2019-02-22 14:08+0300\n"
 "PO-Revision-Date: 2012-01-27 14:18+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: Bosnian <bs@li.org>\n"
@@ -18,22 +18,18 @@ msgstr ""
 "X-Launchpad-Export-Date: 2012-11-14 16:52+0000\n"
 "X-Generator: Launchpad (build 16265)\n"
 
-#: schematic/src/a_zoom.c:155
 msgid "Zoom too small!  Cannot zoom further."
 msgstr ""
 
-#: schematic/src/color_edit_widget.c:399
 #, c-format
 msgid ""
 "Could not save file [%s]:\n"
 "%s"
 msgstr ""
 
-#: schematic/src/color_edit_widget.c:434
 msgid "Save Color Scheme As..."
 msgstr ""
 
-#: schematic/src/color_edit_widget.c:482 schematic/src/x_fileselect.c:292
 #, c-format
 msgid ""
 "The selected file `%1$s' already exists.\n"
@@ -41,178 +37,140 @@ msgid ""
 "Would you like to overwrite it?"
 msgstr ""
 
-#: schematic/src/color_edit_widget.c:486 schematic/src/x_fileselect.c:295
 msgid "Overwrite file?"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:211
 msgid "_Apply"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:215
 msgid "Sa_ve..."
 msgstr ""
 
-#: schematic/src/font_select_widget.c:278
 #, c-format
 msgid "<b>Current:</b> %s"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:453
 msgid "Save configuration"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:461
 msgid "Save settings to:"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:465
 msgid "Local configuration file (in current directory)"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:467
 msgid "User configuration file (geda-user.conf)"
 msgstr ""
 
-#: schematic/src/g_attrib.c:90
 msgid "Object ~A is not included in the current gschem page."
 msgstr ""
 
-#: schematic/src/g_attrib.c:110
 msgid "Invalid text name/value visibility ~A."
 msgstr ""
 
-#: schematic/src/g_rc.c:107
 #, fuzzy, c-format
 msgid "You are running gEDA/gaf version [%1$s%2$s.%3$s],\n"
 msgstr "gEDA/gschem verzija %s%s.%s\n"
 
-#: schematic/src/g_rc.c:111
 #, c-format
 msgid ""
 "but you have a version [%1$s] gschemrc file:\n"
 "[%2$s]\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:114
 #, c-format
 msgid "Please be sure that you have the latest rc file.\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:240
 #, c-format
 msgid "Invalid size [%1$d] passed to text-size\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:283
 #, c-format
 msgid "Invalid size [%1$d] passed to snap-size\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:620
 #, c-format
 msgid "Invalid num levels [%1$d] passed to undo-levels\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:831
 #, c-format
 msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:931
 #, c-format
 msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:972
 #, c-format
 msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:998
 #, c-format
 msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1023
 #, c-format
 msgid "Invalid offset [%1$d] passed to add-attribute-offset\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1047
 #, c-format
 msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1071
 #, c-format
 msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1094
 #, c-format
 msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1118
 #, c-format
 msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1144
 #, c-format
 msgid "Invalid gain [%1$d] passed to zoom-gain\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1169
 #, c-format
 msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
 msgstr ""
 
-#: schematic/src/g_select.c:78 schematic/src/g_select.c:115
-#: schematic/src/g_select.c:151
 msgid "Object ~A is not directly included in a page."
 msgstr ""
 
-#: schematic/src/g_util.c:54
 msgid "Could not launch URI ~S: ~A"
 msgstr ""
 
-#: schematic/src/g_window.c:139
 msgid "Found invalid gschem window smob ~S"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:156
 #, fuzzy, c-format
 msgid "Lepton EDA/lepton-schematic version %1$s%2$s.%3$s git: %4$.7s"
 msgstr "gEDA/gschem verzija %s%s.%s\n"
 
-#: schematic/src/lepton-schematic.c:163
 #, c-format
 msgid "This is the MINGW32 port.\n"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:167
 #, c-format
 msgid "Current locale settings: %1$s\n"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:201
 #, c-format
 msgid "Couldn't find init scm file [%1$s]"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:206
 #, c-format
 msgid "Read init scm file [%1$s]"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:210
 #, c-format
 msgid "Failed to read init scm file [%1$s]"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:290
 #, c-format
 msgid ""
 "ERROR: Failed to load or evaluate startup script.\n"
@@ -220,686 +178,501 @@ msgid ""
 "The lepton-schematic log may contain more information.\n"
 msgstr ""
 
-#: schematic/src/gschem_about_dialog.c:51
 #, c-format
 msgid "%s (git: %.7s)"
 msgstr ""
 
-#: schematic/src/gschem_about_dialog.c:75
 msgid "Lepton Electronic Design Automation"
 msgstr ""
 
-#: schematic/src/gschem_about_dialog.c:83
 msgid ""
 "Copyright © 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright © 2017-2018 Lepton Developers.\n"
-"See AUTHORS and ChangeLog files for details."
+"Copyright © 2017-2019 Lepton Developers.\n"
+"See AUTHORS, ChangeLog files and consult 'git log' history for details."
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:69
 msgid "Upper Left"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:71
 msgid "Upper Middle"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:73
 msgid "Upper Right"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:78
 msgid "Middle Left"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:80
 msgid "Middle Middle"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:82
 msgid "Middle Right"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:87
 msgid "Lower Left"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:89
 msgid "Lower Middle"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:91
 msgid "Lower Right"
 msgstr ""
 
-#: schematic/src/gschem_arc_dialog.c:104
 msgid "Arc Params"
 msgstr ""
 
-#: schematic/src/gschem_arc_dialog.c:140
 msgid "Arc _Radius:"
 msgstr ""
 
-#: schematic/src/gschem_arc_dialog.c:141
 msgid "Start _Angle:"
 msgstr ""
 
-#: schematic/src/gschem_arc_dialog.c:142
 msgid "_Degrees of Sweep:"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:504
 msgid "Left mouse button"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:508
 msgid "Middle mouse button"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:512
 msgid "Right mouse button"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:595
 msgid "(Snap size, Grid size)"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:603
 msgid "Net rubber band mode"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:614
 msgid "Magnetic net mode"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:622
 msgid "Current action mode"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:935
-#: schematic/src/gschem_bottom_widget.c:951
 msgid "OFF"
 msgstr "ISKLJ"
 
-#: schematic/src/gschem_bottom_widget.c:954
 msgid "NONE"
 msgstr "NIŠTA"
 
-#: schematic/src/gschem_bottom_widget.c:960
 #, c-format
 msgid "Grid(%1$s, %2$s)"
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:350
-#: schematic/src/x_compselect.c:1236 schematic/src/x_multiattrib.c:2068
 msgid "Name"
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:372
 msgid "S_elect the schematics you want to save:"
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:467
 #, c-format
 msgid "Save the changes to schematic \"%1$s\" before closing?"
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:473
 #, c-format
 msgid ""
 "There are %1$d schematics with unsaved changes. Save changes before closing?"
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:502
 msgid "If you don't save, all your changes will be permanently lost."
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:522
 msgid "Close _without saving"
 msgstr ""
 
-#: schematic/src/gschem_coord_dialog.c:86
 msgid "Coords"
 msgstr ""
 
-#: schematic/src/gschem_coord_dialog.c:106
 msgid "Screen"
 msgstr ""
 
-#: schematic/src/gschem_coord_dialog.c:115
 msgid "World"
 msgstr ""
 
-#: schematic/src/gschem_find_text_state.c:809 schematic/src/x_pagesel.c:432
 msgid "Filename"
 msgstr ""
 
-#: schematic/src/gschem_find_text_state.c:821 schematic/src/i_callbacks.c:1970
-#: schematic/src/x_colorcb.c:154 schematic/src/x_widgets.c:179
-#: schematic/src/x_window.c:1226 schematic/src/x_window.c:1440
 msgid "Text"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:427
 msgid "descend into hierarchy"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:435
 msgid "Find"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:557
 #, fuzzy
 msgid "Find Text:"
 msgstr "Izmijeni tekst"
 
-#: schematic/src/gschem_find_text_widget.c:564
 msgid "Find Pattern:"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:571
 msgid "Find Regex:"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:578
 msgid "Check symbol:"
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:200
 msgid "Hotkeys"
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:229
 msgid ""
 "Start typing action name or keystroke to filter the list.\n"
 "Type hotkeys as they are displayed in \"Keystroke(s)\" column."
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:233 schematic/src/x_compselect.c:1124
 #, fuzzy
 msgid "_Filter:"
 msgstr "_Datoteka"
 
-#: schematic/src/gschem_hotkey_dialog.c:259 schematic/src/i_basic.c:280
 msgid "Action"
 msgstr "Akcija"
 
-#: schematic/src/gschem_hotkey_dialog.c:277
 msgid "Keystroke(s)"
 msgstr ""
 
-#: schematic/src/gschem_log_widget.c:177
 msgid "** Invalid UTF-8 in log message. See stderr or gschem.log.\n"
 msgstr ""
 
-#: schematic/src/gschem_log_widget.c:434
 #, fuzzy
 msgid "Clear log window?"
 msgstr "Novi prozor"
 
-#: schematic/src/gschem_log_widget.c:477
 #, fuzzy
 msgid "Clear Log _Window"
 msgstr "Novi prozor"
 
-#: schematic/src/gschem_macro_widget.c:231
 msgid "Macro:"
 msgstr ""
 
-#: schematic/src/gschem_macro_widget.c:387
 msgid "Evaluate"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:172
 #, fuzzy
 msgid "_Fill Type:"
 msgstr "Izmijeni tekst"
 
-#: schematic/src/gschem_object_properties_widget.c:173
 msgid "Lin_e Width:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:174
 msgid "Angle _1:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:175
 msgid "P_itch 1:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:176
 msgid "Angle _2:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:177
 msgid "Pitc_h 2:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:237
 msgid "<b>Fill Properties</b>"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:255
-#: schematic/src/gschem_text_properties_widget.c:258
-#: schematic/src/x_newtext.c:271
 #, fuzzy
 msgid "Colo_r:"
 msgstr "Boja"
 
-#: schematic/src/gschem_object_properties_widget.c:266
 msgid "<b>General Properties</b>"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:284
 #, fuzzy
 msgid "_Type:"
 msgstr "Izmijeni tekst"
 
-#: schematic/src/gschem_object_properties_widget.c:285
 msgid "_Width:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:286
 msgid "Dash _Length:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:287
 msgid "Dash _Space:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:288
 msgid "C_ap style:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:333
 msgid "<b>Line Properties</b>"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:351
 #, fuzzy
 msgid "_Pin Type:"
 msgstr "Izmijeni tekst"
 
-#: schematic/src/gschem_object_properties_widget.c:362
 msgid "<b>Pin Properties</b>"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:217
 msgid "_Off"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:220
 msgid "_Dots"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:223
 msgid "M_esh"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:245
 msgid "Net R_ubber Band Mode:"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:246
 msgid "_Magnetic Net Mode:"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:250
-#: schematic/src/gschem_options_widget.c:251
 msgid "Enabled"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:265
 msgid "<b>Net Options</b>"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:282
 msgid "Grid Mode:"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:283
 #, fuzzy
 msgid "Snap Mode:"
 msgstr "Režim kopiranja"
 
-#: schematic/src/gschem_options_widget.c:284
 #, fuzzy
 msgid "_Snap Size:"
 msgstr "Režim kopiranja"
 
-#: schematic/src/gschem_options_widget.c:301
 msgid "<b>Snap Options</b>"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:340
 msgid "O_ff"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:343
 msgid "_Grid"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:346
 msgid "_Resnap"
 msgstr ""
 
-#: schematic/src/gschem_pin_type_combo.c:73
 msgid "Net pin"
 msgstr ""
 
-#: schematic/src/gschem_pin_type_combo.c:80
 msgid "Bus pin (graphical)"
 msgstr ""
 
-#: schematic/src/gschem_preview.c:195
 msgid "Preview Buffer"
 msgstr ""
 
-#: schematic/src/gschem_show_hide_text_widget.c:148
-#: schematic/src/x_window.c:1268
 msgid "Hide"
 msgstr ""
 
-#: schematic/src/gschem_show_hide_text_widget.c:157
-#: schematic/src/x_window.c:1269
 msgid "Hide text starting with:"
 msgstr ""
 
-#: schematic/src/gschem_slot_edit_dialog.c:91
 msgid "Edit slot number"
 msgstr ""
 
-#: schematic/src/gschem_slot_edit_dialog.c:121
 msgid "Number of Slots:"
 msgstr ""
 
-#: schematic/src/gschem_slot_edit_dialog.c:122
 msgid "Slot Number:"
 msgstr ""
 
-#: schematic/src/gschem_text_properties_widget.c:240
-#: schematic/src/x_newtext.c:265
 msgid "<b>Text Content</b>"
 msgstr ""
 
-#: schematic/src/gschem_text_properties_widget.c:259
-#: schematic/src/x_newtext.c:291
 msgid "_Size:"
 msgstr ""
 
-#: schematic/src/gschem_text_properties_widget.c:260
-#: schematic/src/x_newtext.c:310
 msgid "Ali_gnment:"
 msgstr ""
 
-#: schematic/src/gschem_text_properties_widget.c:261
-#: schematic/src/x_newtext.c:330
 #, fuzzy
 msgid "Ro_tation:"
 msgstr "Rotiraj"
 
-#: schematic/src/gschem_text_properties_widget.c:294
-#: schematic/src/x_newtext.c:253
 msgid "<b>Text Properties</b>"
 msgstr ""
 
-#: schematic/src/gschem_translate_widget.c:238
 msgid "Coordinate:"
 msgstr ""
 
-#: schematic/src/gschem_translate_widget.c:405 schematic/src/i_callbacks.c:800
 msgid "Translate"
 msgstr "Translacija"
 
-#: schematic/src/i_basic.c:64 schematic/src/x_window.c:1369
-#: schematic/scheme/conf/schematic/menu.scm:59
-#: schematic/scheme/gschem/builtins.scm:99
 msgid "Select Mode"
 msgstr "Režim izabiranja"
 
-#: schematic/src/i_basic.c:65
 #, fuzzy
 msgid "Select Box Mode"
 msgstr "Režim izabiranja"
 
-#: schematic/src/i_basic.c:66
 msgid "Text Mode"
 msgstr "Tekstualni režim"
 
-#: schematic/src/i_basic.c:67
 msgid "Pan Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:70
 #, c-format
 msgid "Paste %d Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:74
 msgid "Magnetic Net Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:76
 msgid "Net Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:77
 msgid "Arc Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:78
 msgid "Box Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:79
 msgid "Bus Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:80
 msgid "Circle Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:81
 msgid "Component Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:82 schematic/scheme/conf/schematic/menu.scm:62
-#: schematic/scheme/gschem/builtins.scm:114
 msgid "Copy Mode"
 msgstr "Režim kopiranja"
 
-#: schematic/src/i_basic.c:83 schematic/scheme/conf/schematic/menu.scm:63
-#: schematic/scheme/gschem/builtins.scm:117
 msgid "Multiple Copy Mode"
 msgstr "Režim višestrukog kopiranja"
 
-#: schematic/src/i_basic.c:84
 msgid "Line Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:85 schematic/scheme/conf/schematic/menu.scm:66
-#: schematic/scheme/gschem/builtins.scm:123
 msgid "Mirror Mode"
 msgstr "Režim ogledala"
 
-#: schematic/src/i_basic.c:86 schematic/scheme/conf/schematic/menu.scm:64
-#: schematic/scheme/gschem/builtins.scm:111
 msgid "Move Mode"
 msgstr "Režim pomjeranja"
 
-#: schematic/src/i_basic.c:87
 #, fuzzy
 msgid "Path Mode"
 msgstr "Tekstualni režim"
 
-#: schematic/src/i_basic.c:88
 msgid "Picture Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:89
 msgid "Pin Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:90 schematic/scheme/gschem/builtins.scm:120
 msgid "Rotate Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:91
 #, fuzzy
 msgid "Modify Mode"
 msgstr "Režim kopiranja"
 
-#: schematic/src/i_basic.c:92 schematic/src/x_menus.c:49
-#: schematic/scheme/gschem/builtins.scm:204
 msgid "Zoom Box"
 msgstr "Okvir zooma"
 
-#: schematic/src/i_basic.c:121
 msgid "Show Hidden"
 msgstr "Prikaži skriveno"
 
-#: schematic/src/i_basic.c:124
 msgid "Snap Off"
 msgstr ""
 
-#: schematic/src/i_basic.c:126
 msgid "Resnap Active"
 msgstr ""
 
-#: schematic/src/i_basic.c:288 schematic/src/x_colorcb.c:159
 msgid "Stroke"
 msgstr "Potez"
 
-#: schematic/src/i_basic.c:296 schematic/src/i_basic.c:330
-#: schematic/src/x_window.c:1361
 msgid "none"
 msgstr "ništa"
 
-#: schematic/src/i_basic.c:304
 msgid "Repeat/"
 msgstr "Ponovi/"
 
-#: schematic/src/i_basic.c:315
 msgid "Repeat/none"
 msgstr ""
 
-#: schematic/src/i_basic.c:323 schematic/src/i_callbacks.c:1239
-#: schematic/scheme/gschem/builtins.scm:189
 msgid "Pan"
 msgstr "Paniraj"
 
-#: schematic/src/i_callbacks.c:74
 #, fuzzy, c-format
 msgid "New page created [%1$s]"
 msgstr "Nova strana kreirana [%s]\n"
 
-#: schematic/src/i_callbacks.c:108
 #, fuzzy, c-format
 msgid "New Window created [%1$s]"
 msgstr "Novi prozor keriran [%s]\n"
 
-#: schematic/src/i_callbacks.c:245
 msgid "Failed to Save All"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:247
 msgid "Saved All"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:308
 #, fuzzy
 msgid "Closing Window"
 msgstr "Novi prozor"
 
-#: schematic/src/i_callbacks.c:505 schematic/src/x_menus.c:55
-#: schematic/scheme/gschem/builtins.scm:168
 msgid "Copy"
 msgstr "Kopiraj"
 
-#: schematic/src/i_callbacks.c:514 schematic/src/i_callbacks.c:539
-#: schematic/src/i_callbacks.c:564
 msgid "Select objs first"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:530
 msgid "Multiple Copy"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:555 schematic/src/x_menus.c:56
 msgid "Move"
 msgstr "Premjesti"
 
-#: schematic/src/i_callbacks.c:579 schematic/src/x_menus.c:57
-#: schematic/src/x_multiattrib.c:1656 schematic/scheme/gschem/builtins.scm:108
 msgid "Delete"
 msgstr "Obriši"
 
-#: schematic/src/i_callbacks.c:603
 msgid "Edit"
 msgstr "Izmijeni"
 
-#: schematic/src/i_callbacks.c:618 schematic/scheme/gschem/builtins.scm:129
 msgid "Edit Text"
 msgstr "Izmijeni tekst"
 
-#: schematic/src/i_callbacks.c:637
 msgid "Slot"
 msgstr "Slot"
 
-#: schematic/src/i_callbacks.c:688 schematic/src/i_callbacks.c:698
 msgid "Rotate"
 msgstr "Rotiraj"
 
-#: schematic/src/i_callbacks.c:736 schematic/src/i_callbacks.c:746
 msgid "Mirror"
 msgstr "Ogledalo"
 
-#: schematic/src/i_callbacks.c:763 schematic/src/x_colorcb.c:160
-#: schematic/scheme/conf/schematic/menu.scm:73
-#: schematic/scheme/gschem/builtins.scm:141
 msgid "Lock"
 msgstr "Zaključaj"
 
-#: schematic/src/i_callbacks.c:781 schematic/scheme/conf/schematic/menu.scm:74
-#: schematic/scheme/gschem/builtins.scm:144
 msgid "Unlock"
 msgstr "Otključaj"
 
-#: schematic/src/i_callbacks.c:805
 msgid "WARNING: Do not translate with snap off!"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:806
 msgid "WARNING: Turning snap on and continuing with translate."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:813
 msgid "WARNING: Snap grid size is not equal to 100!"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:815
 msgid ""
 "WARNING: If you are translating a symbol to the origin, the snap grid size "
 "should be set to 100"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:847
 msgid "Embed"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:886
 msgid "Unembed"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:928
 msgid "Update"
 msgstr "Ažuriraj"
 
-#: schematic/src/i_callbacks.c:970
 msgid "ShowHidden"
 msgstr "Prikaz skrivenih objekata"
 
-#: schematic/src/i_callbacks.c:1537
 #, c-format
 msgid ""
 "<b>Revert page:</b>\n"
@@ -910,100 +683,78 @@ msgid ""
 "discarded and page file will be reloaded from disk."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1555
 #, fuzzy
 msgid "Revert"
 msgstr "_Vrati"
 
-#: schematic/src/i_callbacks.c:1647
 msgid "Copy to clipboard"
 msgstr "Kopiraj na međuspremnik"
 
-#: schematic/src/i_callbacks.c:1664
 msgid "Cut to clipboard"
 msgstr "Isijeci u međuspremnik"
 
-#: schematic/src/i_callbacks.c:1686
 msgid "Paste from clipboard"
 msgstr "Umetni iz međuspremnika"
 
-#: schematic/src/i_callbacks.c:1694
 #, fuzzy
 msgid "Empty clipboard"
 msgstr "Kopiraj na međuspremnik"
 
 #. TRANSLATORS: The number is the number of the buffer that the
 #. * selection is being copied to.
-#: schematic/src/i_callbacks.c:1719
 #, fuzzy, c-format
 msgid "Copy %i"
 msgstr "Kopiraj 1"
 
 #. TRANSLATORS: The number is the number of the buffer that the
 #. * selection is being cut to.
-#: schematic/src/i_callbacks.c:1746
 #, fuzzy, c-format
 msgid "Cut %i"
 msgstr "Isijeci 1"
 
 #. TRANSLATORS: The number is the number of the buffer that is being
 #. * pasted to the schematic.
-#: schematic/src/i_callbacks.c:1776
 #, fuzzy, c-format
 msgid "Paste %i"
 msgstr "Umetni"
 
-#: schematic/src/i_callbacks.c:1785
 msgid "Empty buffer"
 msgstr "Isprazni bafer"
 
-#: schematic/src/i_callbacks.c:1833 schematic/src/x_window.c:1203
 msgid "Component"
 msgstr "Komponenta"
 
-#: schematic/src/i_callbacks.c:1865 schematic/src/x_colorcb.c:150
 msgid "Attribute"
 msgstr "Atribut"
 
-#: schematic/src/i_callbacks.c:1885 schematic/src/x_colorcb.c:149
 msgid "Net"
 msgstr "Mreža"
 
-#: schematic/src/i_callbacks.c:1928 schematic/src/x_colorcb.c:155
-#: schematic/src/x_window.c:1222
 msgid "Bus"
 msgstr "Sabirnica"
 
-#: schematic/src/i_callbacks.c:2004
 msgid "Line"
 msgstr "Linija"
 
-#: schematic/src/i_callbacks.c:2021
 msgid "Path"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2043
 msgid "Box"
 msgstr "Okvir"
 
-#: schematic/src/i_callbacks.c:2085
 msgid "Circle"
 msgstr "Krug"
 
-#: schematic/src/i_callbacks.c:2108
 msgid "Arc"
 msgstr "Luk"
 
-#: schematic/src/i_callbacks.c:2131 schematic/src/x_colorcb.c:146
 msgid "Pin"
 msgstr "Pin"
 
-#: schematic/src/i_callbacks.c:2191
 #, fuzzy, c-format
 msgid "Searching for source [%1$s]"
 msgstr "Tražim izvor [%s]\n"
 
-#: schematic/src/i_callbacks.c:2223
 #, c-format
 msgid ""
 "Failed to descend hierarchy into '%1$s': %2$s\n"
@@ -1011,106 +762,81 @@ msgid ""
 "The lepton-schematic log may contain more information."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2227
 #, c-format
 msgid "Failed to descend into '%1$s': %2$s"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2234
 msgid "Failed to descend hierarchy."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2312
 #, fuzzy, c-format
 msgid "Searching for symbol [%1$s]"
 msgstr "Tražim izvor [%s]\n"
 
-#: schematic/src/i_callbacks.c:2320
 msgid "Symbol is not a real file. Symbol cannot be loaded."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2367 schematic/src/x_tabs.c:1060
 msgid "Cannot find any schematics above the current one!"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2400
 msgid "Attach"
 msgstr "Priloži"
 
-#: schematic/src/i_callbacks.c:2456
 msgid "Detach"
 msgstr "Odvoji"
 
-#: schematic/src/i_callbacks.c:2500
 msgid "ShowN"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2537
 msgid "ShowV"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2574
 msgid "ShowB"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2612
 msgid "VisToggle"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2643
 #, c-format
 msgid "Sorry but this is a non-functioning menu option\n"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2703
 msgid "Action feedback mode set to OUTLINE"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2706
 msgid "Action feedback mode set to BOUNDINGBOX"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2730
 msgid "Grid OFF"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2731
 msgid "Dot grid selected"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2732
 msgid "Mesh grid selected"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2733
 msgid "Invalid grid mode"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2755
 msgid "Snap OFF (CAUTION!)"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2758
 msgid "Snap ON"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2761
 msgid "Snap back to the grid (CAUTION!)"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2790
 msgid "Rubber band ON"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2792
 msgid "Rubber band OFF"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2811
 msgid "magnetic net mode: ON"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2814
 msgid "magnetic net mode: OFF"
 msgstr ""
 
@@ -1119,134 +845,105 @@ msgstr ""
 #. the form "untitled_N.sch", where N is a number.  Please make
 #. sure that the translation contains characters suitable for use
 #. in a filename.
-#: schematic/src/i_vars.c:209
 msgid "untitled"
 msgstr ""
 
-#: schematic/src/o_complex.c:192 schematic/src/o_complex.c:195
 #, c-format
 msgid "Translating schematic [%1$d %2$d]"
 msgstr ""
 
-#: schematic/src/o_delete.c:82
 #, c-format
 msgid "Delete locked object?"
 msgid_plural "Delete %1$u locked objects?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/o_misc.c:55
 #, c-format
 msgid "Got an unexpected NULL in o_edit\n"
 msgstr ""
 
-#: schematic/src/o_misc.c:315
 msgid "Hidden text is now visible"
 msgstr ""
 
-#: schematic/src/o_misc.c:317
 msgid "Hidden text is now invisible"
 msgstr ""
 
-#: schematic/src/o_misc.c:425
 #, c-format
 msgid "Could not find symbol [%1$s] in library. Update failed."
 msgstr ""
 
-#: schematic/src/o_misc.c:541
 #, c-format
 msgid "o_autosave_backups: Can't get the real filename of %1$s."
 msgstr ""
 
-#: schematic/src/o_misc.c:585
 #, c-format
 msgid "Could NOT set previous backup file [%1$s] read-write"
 msgstr ""
 
-#: schematic/src/o_misc.c:605
 #, c-format
 msgid "Could NOT set backup file [%1$s] readonly"
 msgstr ""
 
-#: schematic/src/o_misc.c:610
 #, c-format
 msgid "Could NOT save backup file [%1$s]"
 msgstr ""
 
-#: schematic/src/o_move.c:192
 #, c-format
 msgid "ERROR: NULL object in o_move_end!\n"
 msgstr ""
 
-#: schematic/src/o_move.c:519
 #, c-format
 msgid "DOH! tried to find the whichone, but didn't find it!\n"
 msgstr ""
 
-#: schematic/src/o_move.c:546
 #, c-format
 msgid "Got a non line object in o_move_check_endpoint\n"
 msgstr ""
 
-#: schematic/src/o_net.c:444
 msgid "Warning: Starting net at off grid coordinate"
 msgstr ""
 
-#: schematic/src/o_net.c:508
 msgid "Warning: Ending net at off grid coordinate"
 msgstr ""
 
-#: schematic/src/o_net.c:856 schematic/src/o_net.c:893
-#: schematic/src/o_net.c:964 schematic/src/o_net.c:1000
 #, c-format
 msgid "Tried to add more than two bus rippers. Internal gschem error.\n"
 msgstr ""
 
-#: schematic/src/o_net.c:1068
 #, c-format
 msgid "Bus ripper symbol [%1$s] was not found in any component library"
 msgstr ""
 
-#: schematic/src/o_picture.c:133 schematic/src/o_picture.c:343
 msgid "Select a picture file..."
 msgstr ""
 
-#: schematic/src/o_picture.c:166
 #, c-format
 msgid "Failed to load picture: %1$s"
 msgstr ""
 
-#: schematic/src/o_picture.c:182
 msgid "Picture"
 msgstr ""
 
-#: schematic/src/o_picture.c:378
 #, c-format
 msgid "Failed to replace pictures: %s"
 msgstr ""
 
-#: schematic/src/o_slot.c:80
 #, fuzzy
 msgid "Slot attribute malformed"
 msgstr "Atribut"
 
-#: schematic/src/o_slot.c:88
 msgid "numslots attribute missing"
 msgstr ""
 
-#: schematic/src/o_slot.c:89
 msgid "Slotting not allowed for this component"
 msgstr ""
 
-#: schematic/src/o_slot.c:104
 msgid "New slot number out of range"
 msgstr ""
 
-#: schematic/src/o_undo.c:397
 msgid "Undo/Redo disabled in rc file"
 msgstr ""
 
-#: schematic/src/parsecmd.c:77
 #, c-format
 msgid ""
 "Usage: %1$s [OPTION ...] [--] [FILE ...]\n"
@@ -1271,187 +968,143 @@ msgid ""
 "gEDA/gaf homepage: <http://www.geda-project.org/>\n"
 msgstr ""
 
-#: schematic/src/parsecmd.c:110
 #, c-format
 msgid ""
 "Lepton EDA %1$s (git: %2$.7s)\n"
 "Copyright (C) 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright (C) 2017-2018 Lepton Developers.\n"
+"Copyright (C) 2017-2019 Lepton Developers.\n"
 "This is free software, and you are welcome to redistribute it under\n"
 "certain conditions. For details, see the file `COPYING', which is\n"
 "included in the Lepton EDA distribution.\n"
 "There is NO WARRANTY, to the extent permitted by law.\n"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:125
 #, c-format
 msgid "Got invalid show option; defaulting to show both\n"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:139
 #, c-format
 msgid "ERROR: NULL object!\n"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:328
 msgid "Single Attribute Editor"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:358
 msgid "<b>Edit Attribute</b>"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:360
 msgid "<b>Add Attribute</b>"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:376
 msgid "N_ame:"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:396 schematic/src/x_multiattrib.c:2222
 msgid "_Value:"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:415 schematic/src/x_multiattrib.c:2281
 msgid "Vi_sible"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:434
 msgid "Show Value Only"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:436
 msgid "Show Name Only"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:438 schematic/src/x_multiattrib.c:1620
-#: schematic/scheme/gschem/builtins.scm:324
 msgid "Show Name & Value"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:445
 msgid "<b>Attach Options</b>"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:460
 msgid "All"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:476 schematic/src/x_compselect.c:986
-#: schematic/src/x_compselect.c:1100
 msgid "Components"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:492 schematic/src/x_window.c:1214
 msgid "Nets"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:508
 msgid "Replace existing attributes"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:412
 msgid ""
 "slotted object without slot attribute may cause problems when autonumbering "
 "slots"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:427
 #, c-format
 msgid ""
 "duplicate slot may cause problems: [symbolname=%1$s, number=%2$d, slot=%3$d]"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:675
 msgid "No searchstring given in autonumber text."
 msgstr ""
 
-#: schematic/src/x_autonumber.c:728
 msgid "No '*' or '?' given at the end of the autonumber text."
 msgstr ""
 
-#: schematic/src/x_autonumber.c:873
 msgid "Diagonal"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:874
 msgid "Top to bottom"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:875
 msgid "Bottom to top"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:876
 msgid "Left to right"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:877
 msgid "Right to left"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:878
 msgid "File order"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1214
 msgid "Autonumber text"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1237
 msgid "<b>Scope</b>"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1259
 msgid "Search for:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1273
 msgid "Autonumber text in:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1280
 msgid "Skip numbers found in:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1292 schematic/src/x_autonumber.c:1301
 msgid "Selected objects"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1293 schematic/src/x_autonumber.c:1302
 msgid "Current page"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1294 schematic/src/x_autonumber.c:1303
 msgid "Whole hierarchy"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1305
 msgid "Overwrite existing numbers"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1310
 msgid "<b>Options</b>"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1332
 msgid "Starting number:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1339
 msgid "Sort order:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1371
 msgid "Remove numbers"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1375
 msgid "Automatic slotting"
 msgstr ""
 
-#: schematic/src/x_clipboard.c:245
 #, c-format
 msgid ""
 "<b>Invalid schematic on clipboard.</b>\n"
@@ -1459,174 +1112,134 @@ msgid ""
 "An error occurred while inserting clipboard data: %s."
 msgstr ""
 
-#: schematic/src/x_clipboard.c:247
 msgid "Clipboard insertion failed"
 msgstr ""
 
-#: schematic/src/x_color.c:89 schematic/src/x_color.c:98
 #, c-format
 msgid "Could not allocate the color %1$s!\n"
 msgstr ""
 
-#: schematic/src/x_color.c:89
 msgid "black"
 msgstr ""
 
-#: schematic/src/x_color.c:98
 msgid "white"
 msgstr ""
 
-#: schematic/src/x_color.c:120
 #, c-format
 msgid "Could not allocate display color %1$i!\n"
 msgstr ""
 
-#: schematic/src/x_color.c:142
 #, c-format
 msgid "Could not allocate outline color %1$i!\n"
 msgstr ""
 
-#: schematic/src/x_color.c:159
 #, c-format
 msgid "Tried to get an invalid color: %1$d\n"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:145
 msgid "Background"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:147
 msgid "Net endpoint"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:148
 msgid "Graphic"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:151
 msgid "Logic bubble"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:152
 msgid "Grid point"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:153
 #, fuzzy
 msgid "Detached attribute"
 msgstr "Atribut"
 
-#: schematic/src/x_colorcb.c:156
 #, fuzzy
 msgid "Selection"
 msgstr "Režim izabiranja"
 
-#: schematic/src/x_colorcb.c:157
 msgid "Bounding box"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:158
 #, fuzzy
 msgid "Zoom box"
 msgstr "Okvir zooma"
 
-#: schematic/src/x_colorcb.c:161
 msgid "Output background"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:162
 msgid "Freestyle 1"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:163
 msgid "Freestyle 2"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:164
 msgid "Freestyle 3"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:165
 msgid "Freestyle 4"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:166
 msgid "Net junction"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:167
 msgid "Mesh grid major"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:168
 msgid "Mesh grid minor"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:172
 msgid "Unknown"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1169
 msgid "Reset filter"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1192
 msgid "Reload all libraries"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1245 schematic/src/x_multiattrib.c:2092
 msgid "Value"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1284
 msgid "Default behavior - reference component"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1287
 msgid "Embed component in schematic"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1290
 msgid "Include component as individual objects"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1448
 msgid "Select Component..."
 msgstr ""
 
-#: schematic/src/x_compselect.c:1471
 msgid "In Us_e"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1475
 msgid "Lib_raries"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1484 schematic/src/x_fileselect.c:119
 msgid "Preview"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1510
 msgid "Attributes"
 msgstr ""
 
-#: schematic/src/x_dialog.c:325
 msgid "Major symbol changes detected."
 msgstr ""
 
-#: schematic/src/x_dialog.c:349
 msgid ""
 "Changes have occurred to the symbols shown below.\n"
 "\n"
 "Be sure to verify each of these symbols."
 msgstr ""
 
-#: schematic/src/x_dialog.c:369
 #, fuzzy
 msgid "Symbol"
 msgstr "Doljen _Simbol"
 
-#: schematic/src/x_dialog.c:406
 #, c-format
 msgid ""
 "<span weight=\"bold\" size=\"larger\">The input attribute \"%s\" is invalid\n"
@@ -1637,39 +1250,30 @@ msgid ""
 "The value cannot start with a space."
 msgstr ""
 
-#: schematic/src/x_dialog.c:408
 msgid "Invalid Attribute"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:37
 msgid "Schematics"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:42
 msgid "Symbols"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:47
 msgid "Schematics and symbols"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:53
 msgid "All files"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:169
 msgid "Open..."
 msgstr ""
 
-#: schematic/src/x_fileselect.c:233
 msgid "Save as..."
 msgstr ""
 
-#: schematic/src/x_fileselect.c:297
 msgid "Save cancelled on user request"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:334
 msgid ""
 "\n"
 "If you load the original file, the backup file will be overwritten in the "
@@ -1678,28 +1282,22 @@ msgid ""
 "Do you want to load the backup file?\n"
 msgstr ""
 
-#: schematic/src/x_fstylecb.c:73
 msgid "Hollow"
 msgstr ""
 
-#: schematic/src/x_fstylecb.c:80
 msgid "Filled"
 msgstr ""
 
-#: schematic/src/x_fstylecb.c:87
 msgid "Mesh"
 msgstr ""
 
-#: schematic/src/x_fstylecb.c:94
 msgid "Hatch"
 msgstr ""
 
-#: schematic/src/x_image.c:279
 #, c-format
 msgid "x_image_lowlevel: Unable to write %1$s file %2$s."
 msgstr ""
 
-#: schematic/src/x_image.c:289
 #, c-format
 msgid ""
 "There was the following error when saving image with type %1$s to filename:\n"
@@ -1708,304 +1306,237 @@ msgid ""
 "%3$s.\n"
 msgstr ""
 
-#: schematic/src/x_image.c:309
 #, c-format
 msgid "Wrote color image to [%1$s] [%2$d x %3$d]"
 msgstr ""
 
-#: schematic/src/x_image.c:311
 #, c-format
 msgid "Wrote black and white image to [%1$s] [%2$d x %3$d]"
 msgstr ""
 
-#: schematic/src/x_image.c:319
 msgid "x_image_lowlevel: Unable to get pixbuf from gschem's window."
 msgstr ""
 
-#: schematic/src/x_image.c:358
 msgid "Width x Height"
 msgstr ""
 
-#: schematic/src/x_image.c:374
 msgid "Image type"
 msgstr ""
 
-#: schematic/src/x_image.c:395
 msgid "Write image..."
 msgstr ""
 
-#: schematic/src/x_linecapcb.c:74
 msgid "Butt"
 msgstr ""
 
-#: schematic/src/x_linecapcb.c:81
 msgid "Square"
 msgstr ""
 
-#: schematic/src/x_linecapcb.c:88
 msgid "Round"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:74
 msgid "Solid"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:81
 msgid "Dotted"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:88
 msgid "Dashed"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:95
 msgid "Center"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:102
 msgid "Phantom"
 msgstr ""
 
-#: schematic/src/x_menus.c:41 schematic/scheme/gschem/builtins.scm:267
 msgid "Add Net"
 msgstr ""
 
-#: schematic/src/x_menus.c:42 schematic/src/x_multiattrib.c:2187
-#: schematic/scheme/gschem/builtins.scm:264
 msgid "Add Attribute"
 msgstr ""
 
-#: schematic/src/x_menus.c:43 schematic/scheme/gschem/builtins.scm:261
 #, fuzzy
 msgid "Add Component"
 msgstr "Komponenta"
 
-#: schematic/src/x_menus.c:44 schematic/scheme/gschem/builtins.scm:270
 msgid "Add Bus"
 msgstr ""
 
-#: schematic/src/x_menus.c:45 schematic/scheme/gschem/builtins.scm:273
 #, fuzzy
 msgid "Add Text"
 msgstr "Izmijeni tekst"
 
-#: schematic/src/x_menus.c:47 schematic/scheme/gschem/builtins.scm:210
 #, fuzzy
 msgid "Zoom In"
 msgstr "_Uvećaj"
 
-#: schematic/src/x_menus.c:48 schematic/scheme/gschem/builtins.scm:213
 #, fuzzy
 msgid "Zoom Out"
 msgstr "U_manji"
 
-#: schematic/src/x_menus.c:50 schematic/scheme/gschem/builtins.scm:207
 #, fuzzy
 msgid "Zoom Extents"
 msgstr "Okvir zooma"
 
-#: schematic/src/x_menus.c:52 schematic/src/x_window.c:1233
 msgid "Select"
 msgstr ""
 
-#: schematic/src/x_menus.c:53 schematic/scheme/conf/schematic/menu.scm:69
-#: schematic/scheme/gschem/builtins.scm:126
 msgid "Edit..."
 msgstr "Izmijeni..."
 
-#: schematic/src/x_menus.c:54 schematic/scheme/conf/schematic/menu.scm:68
 msgid "Object Properties..."
 msgstr ""
 
-#: schematic/src/x_menus.c:59 schematic/scheme/gschem/builtins.scm:300
 #, fuzzy
 msgid "Down Schematic"
 msgstr "_Dolje Shemu"
 
-#: schematic/src/x_menus.c:60 schematic/scheme/gschem/builtins.scm:303
 #, fuzzy
 msgid "Down Symbol"
 msgstr "Doljen _Simbol"
 
-#: schematic/src/x_menus.c:61
 #, fuzzy
 msgid "Up"
 msgstr "_Gore"
 
-#: schematic/src/x_menus.c:336
 #, c-format
 msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
 msgstr ""
 
-#: schematic/src/x_menus.c:360
 #, c-format
 msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
 msgstr ""
 
-#: schematic/src/x_misc.c:70
 msgid "The operating system is out of memory or resources."
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:798 schematic/src/x_multiattrib.c:2704
 msgid "<various>"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:930
 msgid "Attributes with empty name are not allowed. Please set a name."
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1622
 msgid "Show Value only"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1624
 msgid "Show Name only"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1651
 msgid "Promote"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1655
 msgid "Duplicate"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1657
 #, fuzzy
 msgid "Copy to all"
 msgstr "Kopiraj u 1"
 
-#: schematic/src/x_multiattrib.c:1986 schematic/src/x_multiattrib.c:2602
 msgid "Edit Attributes"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2112
 msgid "Vis?"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2130
 msgid "N"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2148
 msgid "V"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2170
 #, fuzzy
 msgid "Sho_w inherited attributes"
 msgstr "Atribut"
 
-#: schematic/src/x_multiattrib.c:2197
 msgid "_Name:"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2241
 msgid "Ctrl+Enter inserts new line; Ctrl+Tab inserts Tab"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2618
 #, c-format
 msgid "%2$i symbol (%1$s)"
 msgid_plural "%2$i symbols (%1$s)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2624
 #, c-format
 msgid "%1$i pin"
 msgid_plural "%1$i pins"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2630
 #, c-format
 msgid "%1$i net"
 msgid_plural "%1$i nets"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2636
 #, c-format
 msgid "%1$i bus"
 msgid_plural "%1$i buses"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2642
 #, fuzzy, c-format
 msgid "%1$i attribute"
 msgid_plural "%1$i attributes"
 msgstr[0] "Atribut"
 msgstr[1] "Atribut"
 
-#: schematic/src/x_newtext.c:433
 #, fuzzy
 msgid "Text Entry..."
 msgstr "_Tekst..."
 
-#: schematic/src/x_pagesel.c:253
 msgid "New Page"
 msgstr ""
 
-#: schematic/src/x_pagesel.c:254
 msgid "Open Page..."
 msgstr ""
 
-#: schematic/src/x_pagesel.c:256
 msgid "Save Page"
 msgstr ""
 
-#: schematic/src/x_pagesel.c:257 schematic/scheme/gschem/builtins.scm:246
 msgid "Close Page"
 msgstr ""
 
-#: schematic/src/x_pagesel.c:376 schematic/scheme/gschem/builtins.scm:237
 msgid "Page Manager"
 msgstr ""
 
-#: schematic/src/x_pagesel.c:448
 msgid "Changed"
 msgstr ""
 
-#: schematic/src/x_pagesel.c:468
 msgid "Right click on the filename for more options..."
 msgstr ""
 
-#: schematic/src/x_print.c:306
 #, c-format
 msgid "Failed to write PDF to '%s': %s\n"
 msgstr ""
 
-#: schematic/src/x_print.c:364
 #, c-format
 msgid "Failed to write PDF to '%1$s': %2$s\n"
 msgstr ""
 
-#: schematic/src/x_print.c:449
 #, c-format
 msgid ""
 "Error printing file:\n"
 "%1$s"
 msgstr ""
 
-#: schematic/src/x_rc.c:39
 msgid "ERROR: An unknown error occurred while parsing configuration files."
 msgstr ""
 
-#: schematic/src/x_rc.c:44
 msgid ""
 "An unknown error occurred while parsing configuration files.\n"
 "\n"
 "The lepton-schematic log may contain more information."
 msgstr ""
 
-#: schematic/src/x_rc.c:56
 #, c-format
 msgid "ERROR: %1$s"
 msgstr ""
 
-#: schematic/src/x_rc.c:59
 #, c-format
 msgid ""
 "%1$s\n"
@@ -2013,138 +1544,107 @@ msgid ""
 "The lepton-schematic log may contain more information."
 msgstr ""
 
-#: schematic/src/x_rc.c:67
 msgid "Cannot load lepton-schematic configuration."
 msgstr ""
 
-#: schematic/src/x_script.c:42 schematic/scheme/conf/schematic/menu.scm:40
 msgid "Execute Script..."
 msgstr "Izvrši Skriptu..."
 
-#: schematic/src/x_script.c:61
 #, c-format
 msgid "Executing guile script [%1$s]"
 msgstr ""
 
-#: schematic/src/x_tabs.c:860
 #, fuzzy, c-format
 msgid "Hierarchy up: %s"
 msgstr "Hije_rarhija"
 
-#: schematic/src/x_tabs.c:863
 #, fuzzy
 msgid "Hierarchy up"
 msgstr "Hije_rarhija"
 
-#: schematic/src/x_widgets.c:158 schematic/src/x_window.c:1444
 #, fuzzy
 msgid "Options"
 msgstr "_Opcije"
 
-#: schematic/src/x_widgets.c:203 schematic/src/x_window.c:1436
 msgid "Object"
 msgstr ""
 
-#: schematic/src/x_widgets.c:224
 msgid "Log"
 msgstr ""
 
-#: schematic/src/x_widgets.c:245 schematic/src/x_window.c:1466
 msgid "Find Text"
 msgstr ""
 
-#: schematic/src/x_widgets.c:259
 msgid "Color Scheme Editor"
 msgstr ""
 
-#: schematic/src/x_widgets.c:272 schematic/scheme/gschem/builtins.scm:378
 #, fuzzy
 msgid "Select Schematic Font"
 msgstr "Režim izabiranja"
 
-#: schematic/src/x_window.c:763
 #, c-format
 msgid "Loading schematic [%1$s]"
 msgstr ""
 
-#: schematic/src/x_window.c:864
 #, c-format
 msgid "Could NOT save page [%1$s]\n"
 msgstr ""
 
-#: schematic/src/x_window.c:865
 msgid "Error while trying to save"
 msgstr ""
 
-#: schematic/src/x_window.c:875
 msgid "Failed to save file"
 msgstr ""
 
-#: schematic/src/x_window.c:885
 #, fuzzy, c-format
 msgid "Saved as [%1$s]"
 msgstr "Snimi sve"
 
-#: schematic/src/x_window.c:887
 #, fuzzy, c-format
 msgid "Saved [%1$s]"
 msgstr "Snimi sve"
 
-#: schematic/src/x_window.c:889
 msgid "Saved"
 msgstr ""
 
-#: schematic/src/x_window.c:966
 #, c-format
 msgid "Discarding page [%1$s]"
 msgstr ""
 
-#: schematic/src/x_window.c:966
 #, c-format
 msgid "Closing [%1$s]"
 msgstr ""
 
-#: schematic/src/x_window.c:1175
 msgid "New"
 msgstr ""
 
-#: schematic/src/x_window.c:1175
 msgid "New file"
 msgstr ""
 
-#: schematic/src/x_window.c:1179
 msgid "Open"
 msgstr ""
 
-#: schematic/src/x_window.c:1179
 msgid "Open file"
 msgstr ""
 
-#: schematic/src/x_window.c:1183 schematic/scheme/gschem/builtins.scm:59
 msgid "Save"
 msgstr ""
 
-#: schematic/src/x_window.c:1183
 msgid "Save file"
 msgstr ""
 
-#: schematic/src/x_window.c:1189 schematic/scheme/gschem/builtins.scm:93
 msgid "Undo"
 msgstr ""
 
-#: schematic/src/x_window.c:1189
 msgid "Undo last operation"
 msgstr ""
 
-#: schematic/src/x_window.c:1193 schematic/scheme/gschem/builtins.scm:96
 msgid "Redo"
 msgstr ""
 
-#: schematic/src/x_window.c:1193
 msgid "Redo last undo"
 msgstr ""
 
-#: schematic/src/x_window.c:1198
 msgid ""
 "Add component...\n"
 "Select library and component from list, move the mouse into main window, "
@@ -2152,56 +1652,44 @@ msgid ""
 "Right mouse button to cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1209
 msgid ""
 "Add nets mode\n"
 "Right mouse button to cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1217
 msgid ""
 "Add buses mode\n"
 "Right mouse button to cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1226
 msgid "Add Text..."
 msgstr ""
 
-#: schematic/src/x_window.c:1233
 msgid "Select mode"
 msgstr ""
 
-#: schematic/src/x_window.c:1288
 msgid "Show"
 msgstr ""
 
-#: schematic/src/x_window.c:1289
 msgid "Show text starting with:"
 msgstr ""
 
-#: schematic/src/x_window.c:1345
 msgid "Menu/Cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1349
 msgid "Pan/Cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1359
 msgid "Pick"
 msgstr ""
 
-#: schematic/src/x_window.c:1470 schematic/scheme/gschem/builtins.scm:180
 msgid "Status"
 msgstr ""
 
-#: schematic/src/x_window.c:1568
 #, fuzzy, c-format
 msgid "New file [%s]"
 msgstr "_Datoteka"
 
-#: schematic/src/x_window.c:1598
 #, c-format
 msgid ""
 "<b>An error occurred while loading the requested file.</b>\n"
@@ -2215,857 +1703,647 @@ msgid ""
 "monitor program's output in terminal window."
 msgstr ""
 
-#: schematic/src/x_window.c:1617
 msgid "Failed to load file"
 msgstr ""
 
-#: schematic/data/lepton-schematic.desktop.in:3
 msgid "Lepton EDA Schematic Editor"
 msgstr ""
 
-#: schematic/data/lepton-schematic.desktop.in:4
 msgid "Create and edit electrical schematics and symbols with lepton-schematic"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:27
 msgid "_New"
 msgstr "_Nova"
 
-#: schematic/scheme/conf/schematic/menu.scm:28
 msgid "_Open..."
 msgstr "_Otvori..."
 
-#: schematic/scheme/conf/schematic/menu.scm:30
 msgid "Open Recen_t"
 msgstr "O_tvori ranije"
 
-#: schematic/scheme/conf/schematic/menu.scm:32
 msgid "_Save"
 msgstr "_Snimi"
 
-#: schematic/scheme/conf/schematic/menu.scm:33
 msgid "Save _As..."
 msgstr "Snimi _kao..."
 
-#: schematic/scheme/conf/schematic/menu.scm:34
-#: schematic/scheme/gschem/builtins.scm:65
 msgid "Save All"
 msgstr "Snimi sve"
 
-#: schematic/scheme/conf/schematic/menu.scm:36
 msgid "_Print..."
 msgstr "_Štampaj..."
 
-#: schematic/scheme/conf/schematic/menu.scm:37
 #, fuzzy
 msgid "Write _Image..."
 msgstr "Piši sl_iku..."
 
-#: schematic/scheme/conf/schematic/menu.scm:39
 msgid "Invoke Macro..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:41
 msgid "REPL..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:43
-#: schematic/scheme/gschem/builtins.scm:77
 msgid "New Window"
 msgstr "Novi prozor"
 
-#: schematic/scheme/conf/schematic/menu.scm:44
 msgid "_Close Window"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:45
 msgid "_Quit"
 msgstr "_Izlaz"
 
-#: schematic/scheme/conf/schematic/menu.scm:51
 msgid "_Undo"
 msgstr "_Poništi"
 
-#: schematic/scheme/conf/schematic/menu.scm:52
 msgid "_Redo"
 msgstr "_Vrati"
 
-#: schematic/scheme/conf/schematic/menu.scm:54
 msgid "Cu_t"
 msgstr "_Isijeci"
 
-#: schematic/scheme/conf/schematic/menu.scm:55
 msgid "_Copy"
 msgstr "_Kopiraj"
 
-#: schematic/scheme/conf/schematic/menu.scm:56
 msgid "_Paste"
 msgstr "_Umetni"
 
-#: schematic/scheme/conf/schematic/menu.scm:57
 msgid "_Delete"
 msgstr "_Obriši"
 
-#: schematic/scheme/conf/schematic/menu.scm:60
-#: schematic/scheme/gschem/builtins.scm:102
 msgid "Select All"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:61
-#: schematic/scheme/gschem/builtins.scm:105
 msgid "Deselect"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:65
 msgid "Rotate 90 Mode"
 msgstr "Režim rotacije 90 stepeni"
 
-#: schematic/scheme/conf/schematic/menu.scm:70
 msgid "Edit Text..."
 msgstr "Izmijeni tekst..."
 
-#: schematic/scheme/conf/schematic/menu.scm:71
 msgid "Slot..."
 msgstr "Slot..."
 
-#: schematic/scheme/conf/schematic/menu.scm:76
-#: schematic/scheme/gschem/builtins.scm:150
 msgid "Embed Component/Picture"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:77
-#: schematic/scheme/gschem/builtins.scm:153
 msgid "Unembed Component/Picture"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:78
-#: schematic/scheme/gschem/builtins.scm:156
 msgid "Update Component"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:79
 msgid "Symbol Translate..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:85
 msgid "Copy into 1"
 msgstr "Kopiraj u 1"
 
-#: schematic/scheme/conf/schematic/menu.scm:86
 msgid "Copy into 2"
 msgstr "Kopiraj u 2"
 
-#: schematic/scheme/conf/schematic/menu.scm:87
 msgid "Copy into 3"
 msgstr "Kopiraj u 3"
 
-#: schematic/scheme/conf/schematic/menu.scm:88
 msgid "Copy into 4"
 msgstr "Kopiraj u 4"
 
-#: schematic/scheme/conf/schematic/menu.scm:89
 msgid "Copy into 5"
 msgstr "Kopiraj u 5"
 
-#: schematic/scheme/conf/schematic/menu.scm:90
 msgid "Cut into 1"
 msgstr "Isijeci u 1"
 
-#: schematic/scheme/conf/schematic/menu.scm:91
 msgid "Cut into 2"
 msgstr "Isijeci u 2"
 
-#: schematic/scheme/conf/schematic/menu.scm:92
 msgid "Cut into 3"
 msgstr "Isijeci u 3"
 
-#: schematic/scheme/conf/schematic/menu.scm:93
 msgid "Cut into 4"
 msgstr "Isijeci u 4"
 
-#: schematic/scheme/conf/schematic/menu.scm:94
 msgid "Cut into 5"
 msgstr "Isijeci u 5"
 
-#: schematic/scheme/conf/schematic/menu.scm:95
 msgid "Paste from 1"
 msgstr "Umetni iz 1"
 
-#: schematic/scheme/conf/schematic/menu.scm:96
 msgid "Paste from 2"
 msgstr "Umetni iz 2"
 
-#: schematic/scheme/conf/schematic/menu.scm:97
 msgid "Paste from 3"
 msgstr "Umetni iz 3"
 
-#: schematic/scheme/conf/schematic/menu.scm:98
 msgid "Paste from 4"
 msgstr "Umetni iz 4"
 
-#: schematic/scheme/conf/schematic/menu.scm:99
 msgid "Paste from 5"
 msgstr "Umetni iz 5"
 
-#: schematic/scheme/conf/schematic/menu.scm:105
 msgid "Side Dock"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:106
 msgid "Bottom Dock"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:108
 #, fuzzy
 msgid "Find Text Results"
 msgstr "Izmijeni tekst"
 
-#: schematic/scheme/conf/schematic/menu.scm:110
 msgid "_Redraw"
 msgstr "_Reiscrtaj"
 
-#: schematic/scheme/conf/schematic/menu.scm:111
 msgid "_Pan"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:112
 msgid "Zoom _Box"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:113
 msgid "Zoom _Extents"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:114
 msgid "Zoom _In"
 msgstr "_Uvećaj"
 
-#: schematic/scheme/conf/schematic/menu.scm:115
 msgid "Zoom _Out"
 msgstr "U_manji"
 
-#: schematic/scheme/conf/schematic/menu.scm:116
 msgid "Zoom _Full"
 msgstr "Puna _veličina"
 
-#: schematic/scheme/conf/schematic/menu.scm:118
 msgid "_Dark Color Scheme"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:119
 msgid "_Light Color Scheme"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:120
 msgid "B_W Color Scheme"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:122
 msgid "Color Scheme Editor..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:129
 msgid "_Manager..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:131
 msgid "_Previous"
 msgstr "_Prethodna"
 
-#: schematic/scheme/conf/schematic/menu.scm:132
 msgid "_Next"
 msgstr "_Naredna"
 
-#: schematic/scheme/conf/schematic/menu.scm:133
 msgid "_Close"
 msgstr "_Zatvori"
 
-#: schematic/scheme/conf/schematic/menu.scm:135
 #, fuzzy
 msgid "_Revert..."
 msgstr "_Vrati"
 
-#: schematic/scheme/conf/schematic/menu.scm:137
-#: schematic/scheme/gschem/builtins.scm:249
 #, fuzzy
 msgid "Next Tab"
 msgstr "_Naredna"
 
-#: schematic/scheme/conf/schematic/menu.scm:138
-#: schematic/scheme/gschem/builtins.scm:252
 #, fuzzy
 msgid "Previous Tab"
 msgstr "_Prethodna"
 
-#: schematic/scheme/conf/schematic/menu.scm:146
 msgid "_Component..."
 msgstr "_Kmponenta..."
 
-#: schematic/scheme/conf/schematic/menu.scm:148
 msgid "_Net"
 msgstr "_Mreža"
 
-#: schematic/scheme/conf/schematic/menu.scm:149
 msgid "B_us"
 msgstr "Sab_irnica"
 
-#: schematic/scheme/conf/schematic/menu.scm:151
 msgid "_Attribute..."
 msgstr "_Atribut..."
 
-#: schematic/scheme/conf/schematic/menu.scm:152
 msgid "_Text..."
 msgstr "_Tekst..."
 
-#: schematic/scheme/conf/schematic/menu.scm:154
 msgid "_Line"
 msgstr "_Linija"
 
-#: schematic/scheme/conf/schematic/menu.scm:155
 msgid "Pat_h"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:156
 msgid "_Box"
 msgstr "_Kvadrat"
 
-#: schematic/scheme/conf/schematic/menu.scm:157
 msgid "C_ircle"
 msgstr "Krug"
 
-#: schematic/scheme/conf/schematic/menu.scm:158
 msgid "A_rc"
 msgstr "L_uk"
 
-#: schematic/scheme/conf/schematic/menu.scm:159
 msgid "_Pin"
 msgstr "_Pin"
 
-#: schematic/scheme/conf/schematic/menu.scm:161
 msgid "Pictu_re..."
 msgstr "Sli_ka..."
 
-#: schematic/scheme/conf/schematic/menu.scm:167
 msgid "_Up"
 msgstr "_Gore"
 
-#: schematic/scheme/conf/schematic/menu.scm:169
 msgid "_Down Schematic"
 msgstr "_Dolje Shemu"
 
-#: schematic/scheme/conf/schematic/menu.scm:170
 msgid "Down _Symbol"
 msgstr "Doljen _Simbol"
 
-#: schematic/scheme/conf/schematic/menu.scm:176
 msgid "_Attach"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:177
 msgid "_Detach"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:179
 msgid "Show _Value"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:180
 msgid "Show _Name"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:181
 msgid "Show _Both"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:182
 msgid "_Toggle Visibility"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:184
 msgid "_Hide Specific Text..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:185
 msgid "_Show Specific Text..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:186
 #, fuzzy
 msgid "Show/Hide Hidden Text"
 msgstr "Prikaži skriveno"
 
-#: schematic/scheme/conf/schematic/menu.scm:188
 msgid "_Find Text/Check Symbol..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:189
 msgid "A_utonumber Text..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:195
 #, fuzzy
 msgid "_Options..."
 msgstr "_Opcije"
 
-#: schematic/scheme/conf/schematic/menu.scm:196
 #, fuzzy
 msgid "_Font..."
 msgstr "_Štampaj..."
 
-#: schematic/scheme/conf/schematic/menu.scm:198
 msgid "Grid +"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:199
 msgid "Grid -"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:201
 msgid "Grid Style: Cycle Dots/Mesh/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:202
 msgid "Grid Snap: Cycle Grid/Resnap/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:204
 msgid "Feedback Mode: Outline/Box"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:205
 msgid "Net: Rubberband On/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:206
 msgid "Net: Magnetic On/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:208
 #, fuzzy
 msgid "_Coord Window"
 msgstr "Novi prozor"
 
-#: schematic/scheme/conf/schematic/menu.scm:209
 #, fuzzy
 msgid "_Log Window"
 msgstr "Novi prozor"
 
-#: schematic/scheme/conf/schematic/menu.scm:215
 msgid "_1 allegro"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:223
 msgid "User _Guide"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:224
 msgid "_FAQ"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:225
 #, fuzzy
 msgid "Docu_mentation"
 msgstr "Rotiraj"
 
-#: schematic/scheme/conf/schematic/menu.scm:226
 msgid "_Wiki"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:228
 msgid "Find Component D_ocumentation"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:230
 msgid "_Hotkeys..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:231
 #, fuzzy
 msgid "_About"
 msgstr "_O programu..."
 
-#: schematic/scheme/conf/schematic/menu.scm:237
 msgid "_File"
 msgstr "_Datoteka"
 
-#: schematic/scheme/conf/schematic/menu.scm:238
 msgid "_Edit"
 msgstr "_Izmijeni"
 
-#: schematic/scheme/conf/schematic/menu.scm:240
 msgid "_View"
 msgstr "_Pogled"
 
-#: schematic/scheme/conf/schematic/menu.scm:241
 msgid "_Page"
 msgstr "_Strana"
 
-#: schematic/scheme/conf/schematic/menu.scm:242
 msgid "_Add"
 msgstr "_Dodaj"
 
-#: schematic/scheme/conf/schematic/menu.scm:243
 msgid "Hie_rarchy"
 msgstr "Hije_rarhija"
 
-#: schematic/scheme/conf/schematic/menu.scm:244
 msgid "A_ttributes"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:245
 msgid "_Options"
 msgstr "_Opcije"
 
-#: schematic/scheme/conf/schematic/menu.scm:246
 #, fuzzy
 msgid "_Netlist"
 msgstr "_Mreža"
 
-#: schematic/scheme/conf/schematic/menu.scm:247
 msgid "_Help"
 msgstr "_Pomoć"
 
-#: schematic/scheme/gschem/action.scm:43
 #, scheme-format
 msgid "~S is not a valid gschem action."
 msgstr ""
 
-#: schematic/scheme/gschem/action.scm:158
 msgid "Repeat Last Action"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:47
 msgid "Cancel"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:53
 #, fuzzy
 msgid "New File"
 msgstr "_Datoteka"
 
-#: schematic/scheme/gschem/builtins.scm:56
 msgid "Open File"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:62
 #, fuzzy
 msgid "Save As"
 msgstr "Snimi sve"
 
-#: schematic/scheme/gschem/builtins.scm:68
 #, fuzzy
 msgid "Print"
 msgstr "_Štampaj..."
 
-#: schematic/scheme/gschem/builtins.scm:71
 msgid "Export Image"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:74
 msgid "Run Script"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:80
 #, fuzzy
 msgid "Close Window"
 msgstr "Novi prozor"
 
-#: schematic/scheme/gschem/builtins.scm:83
 #, fuzzy
 msgid "Quit"
 msgstr "_Izlaz"
 
-#: schematic/scheme/gschem/builtins.scm:87
 msgid "Terminal REPL"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:132
 msgid "Choose Slot"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:135
 msgid "Edit Object Properties"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:138
 #, fuzzy
 msgid "Translate Symbol"
 msgstr "Translacija"
 
-#: schematic/scheme/gschem/builtins.scm:147
 msgid "Invoke Macro"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:159
 msgid "Show/Hide Invisible Text"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:165
 #, fuzzy
 msgid "Cut"
 msgstr "_Isijeci"
 
-#: schematic/scheme/gschem/builtins.scm:171
 #, fuzzy
 msgid "Paste"
 msgstr "_Umetni"
 
-#: schematic/scheme/gschem/builtins.scm:177
 msgid "Sidebar"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:183
 #, fuzzy
 msgid "Find Text State"
 msgstr "Izmijeni tekst"
 
-#: schematic/scheme/gschem/builtins.scm:186
 #, fuzzy
 msgid "Redraw"
 msgstr "_Reiscrtaj"
 
-#: schematic/scheme/gschem/builtins.scm:192
 msgid "Pan Left"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:195
 msgid "Pan Right"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:198
 msgid "Pan Up"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:201
 msgid "Pan Down"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:216
 #, fuzzy
 msgid "Zoom Full"
 msgstr "Puna _veličina"
 
-#: schematic/scheme/gschem/builtins.scm:219
 msgid "Dark Color Scheme"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:222
 msgid "Light Color Scheme"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:225
 msgid "Monochrome Color Scheme"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:228
 msgid "Show Color Scheme Editor"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:234
 msgid "Revert Changes"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:240
 #, fuzzy
 msgid "Previous Page"
 msgstr "_Prethodna"
 
-#: schematic/scheme/gschem/builtins.scm:243
 msgid "Next Page"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:255
 #, fuzzy
 msgid "Print Page"
 msgstr "_Prethodna"
 
-#: schematic/scheme/gschem/builtins.scm:276
 #, fuzzy
 msgid "Add Line"
 msgstr "Linija"
 
-#: schematic/scheme/gschem/builtins.scm:279
 msgid "Add Path"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:282
 msgid "Add Box"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:285
 #, fuzzy
 msgid "Add Circle"
 msgstr "Krug"
 
-#: schematic/scheme/gschem/builtins.scm:288
 msgid "Add Arc"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:291
 msgid "Add Pin"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:294
 #, fuzzy
 msgid "Add Picture"
 msgstr "Sli_ka..."
 
-#: schematic/scheme/gschem/builtins.scm:306
 #, fuzzy
 msgid "Up Hierarchy"
 msgstr "Hije_rarhija"
 
-#: schematic/scheme/gschem/builtins.scm:312
 #, fuzzy
 msgid "Attach Attributes"
 msgstr "Atribut"
 
-#: schematic/scheme/gschem/builtins.scm:315
 #, fuzzy
 msgid "Detach Attributes"
 msgstr "Atribut"
 
-#: schematic/scheme/gschem/builtins.scm:318
 #, fuzzy
 msgid "Show Attribute Value"
 msgstr "Atribut"
 
-#: schematic/scheme/gschem/builtins.scm:321
 #, fuzzy
 msgid "Show Attribute Name"
 msgstr "Atribut"
 
-#: schematic/scheme/gschem/builtins.scm:327
 msgid "Toggle Text Visibility"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:330
 msgid "Find Specific Text"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:333
 msgid "Hide Specific Text"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:336
 msgid "Show Specific Text"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:339
 msgid "Autonumber Text"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:345
 #, fuzzy
 msgid "Show Hotkeys"
 msgstr "Prikaži skriveno"
 
-#: schematic/scheme/gschem/builtins.scm:348
 msgid "Switch Grid Style"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:351
 msgid "Switch Snap Mode"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:354
 msgid "Set Grid Spacing"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:357
 msgid "Increase Grid Spacing"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:360
 msgid "Decrease Grid Spacing"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:363
 msgid "Toggle Outline Drawing"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:366
 msgid "Toggle Net Rubber Band"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:369
 msgid "Toggle Magnetic Nets"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:372
 #, fuzzy
 msgid "Show Log Window"
 msgstr "Novi prozor"
 
-#: schematic/scheme/gschem/builtins.scm:375
 msgid "Show Coordinate Window"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:385
 msgid "Component Documentation"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:387
 msgid "View documentation for selected component"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:403
 msgid ""
 "Could not show documentation for selected component:\n"
 "\n"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:408
 msgid "gEDA Manuals"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:409
 msgid "View the front page of the gEDA documentation in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:414
 msgid "gschem User Guide"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:415
 msgid "View the gschem User Guide in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:420
 msgid "gschem FAQ"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:421
 msgid "Frequently Asked Questions about using gschem."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:426
 msgid "gEDA wiki"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:427
 msgid "View the front page of the gEDA wiki in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:431
 msgid "About gschem"
 msgstr ""
 
-#: schematic/scheme/gschem/deprecated.scm:102
 #, scheme-format
 msgid "Invalid text alignment ~A."
 msgstr ""
 
-#: schematic/scheme/gschem/gschemdoc.scm:241
 msgid "No documentation found"
 msgstr ""
 
-#: schematic/scheme/gschem/keymap.scm:40
 #, scheme-format
 msgid "~S is not a valid key combination."
 msgstr ""
 
-#: schematic/scheme/gschem/keymap.scm:157
 #, scheme-format
 msgid "~S is not a prefix key sequence."
 msgstr ""

--- a/schematic/po/de.po
+++ b/schematic/po/de.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-15 15:13+0300\n"
+"POT-Creation-Date: 2019-02-22 14:08+0300\n"
 "PO-Revision-Date: 2012-04-12 22:09+0000\n"
 "Last-Translator: Dennis Baudys <Unknown>\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -19,24 +19,20 @@ msgstr ""
 "X-Launchpad-Export-Date: 2012-11-14 16:52+0000\n"
 "X-Generator: Launchpad (build 16265)\n"
 
-#: schematic/src/a_zoom.c:155
 #, fuzzy
 msgid "Zoom too small!  Cannot zoom further."
 msgstr "Bereich zu klein! Eine weitere Vergrößerung ist nicht möglich.\n"
 
-#: schematic/src/color_edit_widget.c:399
 #, fuzzy, c-format
 msgid ""
 "Could not save file [%s]:\n"
 "%s"
 msgstr "Die Seite [%s] konnte nicht gespeichert werden.\n"
 
-#: schematic/src/color_edit_widget.c:434
 #, fuzzy
 msgid "Save Color Scheme As..."
 msgstr "_Helles Farbschema"
 
-#: schematic/src/color_edit_widget.c:482 schematic/src/x_fileselect.c:292
 #, fuzzy, c-format
 msgid ""
 "The selected file `%1$s' already exists.\n"
@@ -47,187 +43,149 @@ msgstr ""
 "\n"
 "Soll die Datei überschrieben werden?"
 
-#: schematic/src/color_edit_widget.c:486 schematic/src/x_fileselect.c:295
 msgid "Overwrite file?"
 msgstr "Datei überschreiben?"
 
-#: schematic/src/font_select_widget.c:211
 msgid "_Apply"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:215
 msgid "Sa_ve..."
 msgstr ""
 
-#: schematic/src/font_select_widget.c:278
 #, c-format
 msgid "<b>Current:</b> %s"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:453
 msgid "Save configuration"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:461
 #, fuzzy
 msgid "Save settings to:"
 msgstr "Einstellungen"
 
-#: schematic/src/font_select_widget.c:465
 msgid "Local configuration file (in current directory)"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:467
 msgid "User configuration file (geda-user.conf)"
 msgstr ""
 
-#: schematic/src/g_attrib.c:90
 msgid "Object ~A is not included in the current gschem page."
 msgstr "Das Objekt ~A ist im aktuellen Schaltplan nicht enthalten."
 
-#: schematic/src/g_attrib.c:110
 msgid "Invalid text name/value visibility ~A."
 msgstr "Ungültiger Wert für das Sichtbarkeitsattribut von  ~A."
 
-#: schematic/src/g_rc.c:107
 #, fuzzy, c-format
 msgid "You are running gEDA/gaf version [%1$s%2$s.%3$s],\n"
 msgstr "gEDA/gschem Version %s%s.%s\n"
 
-#: schematic/src/g_rc.c:111
 #, c-format
 msgid ""
 "but you have a version [%1$s] gschemrc file:\n"
 "[%2$s]\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:114
 #, c-format
 msgid "Please be sure that you have the latest rc file.\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:240
 #, fuzzy, c-format
 msgid "Invalid size [%1$d] passed to text-size\n"
 msgstr "Eine ungültige Größe [%d] wurde an text-size übergeben.\n"
 
-#: schematic/src/g_rc.c:283
 #, fuzzy, c-format
 msgid "Invalid size [%1$d] passed to snap-size\n"
 msgstr "Eine ungültige Größe [%d] wurde an snap-size übergeben.\n"
 
-#: schematic/src/g_rc.c:620
 #, fuzzy, c-format
 msgid "Invalid num levels [%1$d] passed to undo-levels\n"
 msgstr "Eine ungültige Ebenenanzahl [%d] wurde an undo-levels übergeben.\n"
 
-#: schematic/src/g_rc.c:831
 #, fuzzy, c-format
 msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
 msgstr "Eine ungültige Größe [%d] wurde an bus-ripper-size übergeben.\n"
 
-#: schematic/src/g_rc.c:931
 #, fuzzy, c-format
 msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
 msgstr "An \"grid-dot-size\" wurde eine falsche Punktgröße [%d] übergeben\n"
 
-#: schematic/src/g_rc.c:972
 #, fuzzy, c-format
 msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
 msgstr ""
 "An \"grid-fixed-threshold\" wurde ein falscher Punktabstand [%d] übergeben\n"
 
-#: schematic/src/g_rc.c:998
 #, fuzzy, c-format
 msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
 msgstr ""
 "An \"mesh-grid-display-treshold\" wurde ein falscher Punktabstand [%d] "
 "übergeben.\n"
 
-#: schematic/src/g_rc.c:1023
 #, fuzzy, c-format
 msgid "Invalid offset [%1$d] passed to add-attribute-offset\n"
 msgstr "Ein ungültiger Offset [%d] wurde an add-attribute-offset übergeben.\n"
 
-#: schematic/src/g_rc.c:1047
 #, fuzzy, c-format
 msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
 msgstr ""
 "An \"auto-save-interval\" wurde eine ungültige Sekundenanzahl [%d] "
 "übergeben\n"
 
-#: schematic/src/g_rc.c:1071
 #, fuzzy, c-format
 msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
 msgstr "Ein ungültiger Werte [%d] wurde an mousepan-gain übergeben.\n"
 
-#: schematic/src/g_rc.c:1094
 #, fuzzy, c-format
 msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
 msgstr "Ein ungültiger Wert [%d] wurde an keyboardpan-gain übergeben.\n"
 
-#: schematic/src/g_rc.c:1118
 #, fuzzy, c-format
 msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
 msgstr ""
 "An \"select-slack-pixels\" wurde eine ungültige Pixelzahl [%d] übergeben\n"
 
-#: schematic/src/g_rc.c:1144
 #, fuzzy, c-format
 msgid "Invalid gain [%1$d] passed to zoom-gain\n"
 msgstr "Ein unzulässiger Wert [%d] wurde an zoom-gain übergeben\n"
 
-#: schematic/src/g_rc.c:1169
 #, fuzzy, c-format
 msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
 msgstr ""
 "Eine unzulässige Anzahl von Schritten [%d] wurde an scrollpan-steps "
 "übergeben\n"
 
-#: schematic/src/g_select.c:78 schematic/src/g_select.c:115
-#: schematic/src/g_select.c:151
 msgid "Object ~A is not directly included in a page."
 msgstr "Das Objekt ~A ist in keiner Schaltplanseite direkt eingebunden."
 
-#: schematic/src/g_util.c:54
 msgid "Could not launch URI ~S: ~A"
 msgstr "Die URI ~S konnte nicht geladen werden: ~A"
 
-#: schematic/src/g_window.c:139
 msgid "Found invalid gschem window smob ~S"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:156
 #, fuzzy, c-format
 msgid "Lepton EDA/lepton-schematic version %1$s%2$s.%3$s git: %4$.7s"
 msgstr "gEDA/gschem Version %s%s.%s\n"
 
-#: schematic/src/lepton-schematic.c:163
 #, c-format
 msgid "This is the MINGW32 port.\n"
 msgstr "Dies ist die MINGW32 Portierung.\n"
 
-#: schematic/src/lepton-schematic.c:167
 #, fuzzy, c-format
 msgid "Current locale settings: %1$s\n"
 msgstr "Aktuelle Spracheinstellungen: %s\n"
 
-#: schematic/src/lepton-schematic.c:201
 #, fuzzy, c-format
 msgid "Couldn't find init scm file [%1$s]"
 msgstr "Die init scm Datei wurde nicht gefunden [%s]\n"
 
-#: schematic/src/lepton-schematic.c:206
 #, fuzzy, c-format
 msgid "Read init scm file [%1$s]"
 msgstr "Lese init scm Datei [%s]\n"
 
-#: schematic/src/lepton-schematic.c:210
 #, fuzzy, c-format
 msgid "Failed to read init scm file [%1$s]"
 msgstr "Die Datei init scm [%s] konnte nicht gelesen werden.\n"
 
-#: schematic/src/lepton-schematic.c:290
 #, fuzzy, c-format
 msgid ""
 "ERROR: Failed to load or evaluate startup script.\n"
@@ -238,148 +196,116 @@ msgstr ""
 "\n"
 "Das Log-Fenster von gschem sind eventuell Details eingetragen."
 
-#: schematic/src/gschem_about_dialog.c:51
 #, fuzzy, c-format
 msgid "%s (git: %.7s)"
 msgstr "%s (g%.7s)"
 
-#: schematic/src/gschem_about_dialog.c:75
 #, fuzzy
 msgid "Lepton Electronic Design Automation"
 msgstr "gEDA: GPL Electronic Design Automation"
 
-#: schematic/src/gschem_about_dialog.c:83
 #, fuzzy
 msgid ""
 "Copyright © 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright © 2017-2018 Lepton Developers.\n"
-"See AUTHORS and ChangeLog files for details."
+"Copyright © 2017-2019 Lepton Developers.\n"
+"See AUTHORS, ChangeLog files and consult 'git log' history for details."
 msgstr ""
 "Copyright © 1998-2012 Ales Hvezda <ahvezda@geda.seul.org>\n"
 "Copyright © 1998-2012 gEDA Contributors (siehe ChangeLog )"
 
-#: schematic/src/gschem_alignment_combo.c:69
 msgid "Upper Left"
 msgstr "Oben Links"
 
-#: schematic/src/gschem_alignment_combo.c:71
 msgid "Upper Middle"
 msgstr "Oben Mitte"
 
-#: schematic/src/gschem_alignment_combo.c:73
 #, fuzzy
 msgid "Upper Right"
 msgstr "Unten Rechts"
 
-#: schematic/src/gschem_alignment_combo.c:78
 msgid "Middle Left"
 msgstr "Mitte Links"
 
-#: schematic/src/gschem_alignment_combo.c:80
 msgid "Middle Middle"
 msgstr "Mitte Mitte"
 
-#: schematic/src/gschem_alignment_combo.c:82
 msgid "Middle Right"
 msgstr "Mitte Rechts"
 
-#: schematic/src/gschem_alignment_combo.c:87
 msgid "Lower Left"
 msgstr "Unten Links"
 
-#: schematic/src/gschem_alignment_combo.c:89
 msgid "Lower Middle"
 msgstr "Unten Mitte"
 
-#: schematic/src/gschem_alignment_combo.c:91
 msgid "Lower Right"
 msgstr "Unten Rechts"
 
-#: schematic/src/gschem_arc_dialog.c:104
 msgid "Arc Params"
 msgstr "Bogen Parameter"
 
-#: schematic/src/gschem_arc_dialog.c:140
 #, fuzzy
 msgid "Arc _Radius:"
 msgstr "Bogen Radius:"
 
-#: schematic/src/gschem_arc_dialog.c:141
 #, fuzzy
 msgid "Start _Angle:"
 msgstr "Start Winkel:"
 
-#: schematic/src/gschem_arc_dialog.c:142
 #, fuzzy
 msgid "_Degrees of Sweep:"
 msgstr "Öffnungswinkel:"
 
-#: schematic/src/gschem_bottom_widget.c:504
 msgid "Left mouse button"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:508
 #, fuzzy
 msgid "Middle mouse button"
 msgstr "Mitte Links"
 
-#: schematic/src/gschem_bottom_widget.c:512
 #, fuzzy
 msgid "Right mouse button"
 msgstr ""
 "Netz einfügen\n"
 "mit rechter Maustaste abbrechen"
 
-#: schematic/src/gschem_bottom_widget.c:595
 msgid "(Snap size, Grid size)"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:603
 #, fuzzy
 msgid "Net rubber band mode"
 msgstr "_Netzgummifäden umschalten"
 
-#: schematic/src/gschem_bottom_widget.c:614
 #, fuzzy
 msgid "Magnetic net mode"
 msgstr "Magnetischer Netzmodus"
 
-#: schematic/src/gschem_bottom_widget.c:622
 #, fuzzy
 msgid "Current action mode"
 msgstr "Aktuelles Fenster"
 
-#: schematic/src/gschem_bottom_widget.c:935
-#: schematic/src/gschem_bottom_widget.c:951
 msgid "OFF"
 msgstr "AUS"
 
-#: schematic/src/gschem_bottom_widget.c:954
 msgid "NONE"
 msgstr "NICHTS"
 
-#: schematic/src/gschem_bottom_widget.c:960
 #, fuzzy, c-format
 msgid "Grid(%1$s, %2$s)"
 msgstr "Raster (%s, %s)"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:350
-#: schematic/src/x_compselect.c:1236 schematic/src/x_multiattrib.c:2068
 msgid "Name"
 msgstr "Name"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:372
 msgid "S_elect the schematics you want to save:"
 msgstr "_Wählen Sie die zu speichernden Seiten:"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:467
 #, fuzzy, c-format
 msgid "Save the changes to schematic \"%1$s\" before closing?"
 msgstr ""
 "Sollen die Änderungen am Schaltplan \"%s\" vor dem Schließen gespeichert "
 "werden?"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:473
 #, fuzzy, c-format
 msgid ""
 "There are %1$d schematics with unsaved changes. Save changes before closing?"
@@ -387,570 +313,422 @@ msgstr ""
 "Es gibt %d ungesicherte Schaltpläne. Sollen die Änderungen vor dem Schließen "
 "gespeichert werden?"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:502
 msgid "If you don't save, all your changes will be permanently lost."
 msgstr "Wenn Sie nicht speichern, werden alle Änderungen verworfen."
 
-#: schematic/src/gschem_close_confirmation_dialog.c:522
 #, fuzzy
 msgid "Close _without saving"
 msgstr "Schließen _ohne Speichern"
 
-#: schematic/src/gschem_coord_dialog.c:86
 msgid "Coords"
 msgstr "Koordinaten"
 
-#: schematic/src/gschem_coord_dialog.c:106
 msgid "Screen"
 msgstr "Bildschirm (Pixel)"
 
-#: schematic/src/gschem_coord_dialog.c:115
 msgid "World"
 msgstr "Global (0.001\")"
 
-#: schematic/src/gschem_find_text_state.c:809 schematic/src/x_pagesel.c:432
 msgid "Filename"
 msgstr "Dateiname"
 
-#: schematic/src/gschem_find_text_state.c:821 schematic/src/i_callbacks.c:1970
-#: schematic/src/x_colorcb.c:154 schematic/src/x_widgets.c:179
-#: schematic/src/x_window.c:1226 schematic/src/x_window.c:1440
 msgid "Text"
 msgstr "Text"
 
-#: schematic/src/gschem_find_text_widget.c:427
 msgid "descend into hierarchy"
 msgstr "In der Hierachie hinabsteigen"
 
-#: schematic/src/gschem_find_text_widget.c:435
 #, fuzzy
 msgid "Find"
 msgstr "Text suchen"
 
-#: schematic/src/gschem_find_text_widget.c:557
 #, fuzzy
 msgid "Find Text:"
 msgstr "Text suchen"
 
-#: schematic/src/gschem_find_text_widget.c:564
 msgid "Find Pattern:"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:571
 #, fuzzy
 msgid "Find Regex:"
 msgstr "Text suchen"
 
-#: schematic/src/gschem_find_text_widget.c:578
 msgid "Check symbol:"
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:200
 msgid "Hotkeys"
 msgstr "Tastenbelegungen"
 
-#: schematic/src/gschem_hotkey_dialog.c:229
 msgid ""
 "Start typing action name or keystroke to filter the list.\n"
 "Type hotkeys as they are displayed in \"Keystroke(s)\" column."
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:233 schematic/src/x_compselect.c:1124
 #, fuzzy
 msgid "_Filter:"
 msgstr "Filter:"
 
-#: schematic/src/gschem_hotkey_dialog.c:259 schematic/src/i_basic.c:280
 msgid "Action"
 msgstr "Aktion"
 
-#: schematic/src/gschem_hotkey_dialog.c:277
 msgid "Keystroke(s)"
 msgstr "Tastenabfolge"
 
-#: schematic/src/gschem_log_widget.c:177
 msgid "** Invalid UTF-8 in log message. See stderr or gschem.log.\n"
 msgstr ""
 "** Diese Fehlermeldung enthält eine ungültige UTF-8 Kodierung. Siehe gschem."
 "log und stderr.\n"
 
-#: schematic/src/gschem_log_widget.c:434
 #, fuzzy
 msgid "Clear log window?"
 msgstr "Schließe Fenster\n"
 
-#: schematic/src/gschem_log_widget.c:477
 #, fuzzy
 msgid "Clear Log _Window"
 msgstr "Protoko_llfenster anzeigen …"
 
-#: schematic/src/gschem_macro_widget.c:231
 msgid "Macro:"
 msgstr ""
 
-#: schematic/src/gschem_macro_widget.c:387
 #, fuzzy
 msgid "Evaluate"
 msgstr "Auswerten:"
 
-#: schematic/src/gschem_object_properties_widget.c:172
 #, fuzzy
 msgid "_Fill Type:"
 msgstr "Füllung:"
 
-#: schematic/src/gschem_object_properties_widget.c:173
 #, fuzzy
 msgid "Lin_e Width:"
 msgstr "Linienbreite:"
 
-#: schematic/src/gschem_object_properties_widget.c:174
 #, fuzzy
 msgid "Angle _1:"
 msgstr "Winkel 1:"
 
-#: schematic/src/gschem_object_properties_widget.c:175
 #, fuzzy
 msgid "P_itch 1:"
 msgstr "Abstand 1:"
 
-#: schematic/src/gschem_object_properties_widget.c:176
 #, fuzzy
 msgid "Angle _2:"
 msgstr "Winkel 2:"
 
-#: schematic/src/gschem_object_properties_widget.c:177
 #, fuzzy
 msgid "Pitc_h 2:"
 msgstr "Abstand 2:"
 
-#: schematic/src/gschem_object_properties_widget.c:237
 #, fuzzy
 msgid "<b>Fill Properties</b>"
 msgstr "<b>Texteigenschaften</b>"
 
-#: schematic/src/gschem_object_properties_widget.c:255
-#: schematic/src/gschem_text_properties_widget.c:258
-#: schematic/src/x_newtext.c:271
 #, fuzzy
 msgid "Colo_r:"
 msgstr "Farbe:"
 
-#: schematic/src/gschem_object_properties_widget.c:266
 #, fuzzy
 msgid "<b>General Properties</b>"
 msgstr "<b>Texteigenschaften</b>"
 
-#: schematic/src/gschem_object_properties_widget.c:284
 #, fuzzy
 msgid "_Type:"
 msgstr "Umfang:"
 
-#: schematic/src/gschem_object_properties_widget.c:285
 #, fuzzy
 msgid "_Width:"
 msgstr "Breite:"
 
-#: schematic/src/gschem_object_properties_widget.c:286
 #, fuzzy
 msgid "Dash _Length:"
 msgstr "Linienlänge:"
 
-#: schematic/src/gschem_object_properties_widget.c:287
 #, fuzzy
 msgid "Dash _Space:"
 msgstr "Linienlücke:"
 
-#: schematic/src/gschem_object_properties_widget.c:288
 msgid "C_ap style:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:333
 #, fuzzy
 msgid "<b>Line Properties</b>"
 msgstr "<b>Texteigenschaften</b>"
 
-#: schematic/src/gschem_object_properties_widget.c:351
 #, fuzzy
 msgid "_Pin Type:"
 msgstr "Pin-Typ"
 
-#: schematic/src/gschem_object_properties_widget.c:362
 #, fuzzy
 msgid "<b>Pin Properties</b>"
 msgstr "<b>Texteigenschaften</b>"
 
-#: schematic/src/gschem_options_widget.c:217
 msgid "_Off"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:220
 msgid "_Dots"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:223
 msgid "M_esh"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:245
 #, fuzzy
 msgid "Net R_ubber Band Mode:"
 msgstr "_Netzgummifäden umschalten"
 
-#: schematic/src/gschem_options_widget.c:246
 #, fuzzy
 msgid "_Magnetic Net Mode:"
 msgstr "Magnetischer Netzmodus"
 
-#: schematic/src/gschem_options_widget.c:250
-#: schematic/src/gschem_options_widget.c:251
 msgid "Enabled"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:265
 #, fuzzy
 msgid "<b>Net Options</b>"
 msgstr "<b>Optionen</b>"
 
-#: schematic/src/gschem_options_widget.c:282
 #, fuzzy
 msgid "Grid Mode:"
 msgstr "Bogenmodus"
 
-#: schematic/src/gschem_options_widget.c:283
 #, fuzzy
 msgid "Snap Mode:"
 msgstr "Ausschnittmodus"
 
-#: schematic/src/gschem_options_widget.c:284
 #, fuzzy
 msgid "_Snap Size:"
 msgstr "Rasterabstand"
 
-#: schematic/src/gschem_options_widget.c:301
 #, fuzzy
 msgid "<b>Snap Options</b>"
 msgstr "<b>Optionen</b>"
 
-#: schematic/src/gschem_options_widget.c:340
 msgid "O_ff"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:343
 #, fuzzy
 msgid "_Grid"
 msgstr "Raster AUS\n"
 
-#: schematic/src/gschem_options_widget.c:346
 #, fuzzy
 msgid "_Resnap"
 msgstr "Neu Ausrichen"
 
-#: schematic/src/gschem_pin_type_combo.c:73
 msgid "Net pin"
 msgstr "Netz-Pin"
 
-#: schematic/src/gschem_pin_type_combo.c:80
 msgid "Bus pin (graphical)"
 msgstr "Bus-Pin (grafisch)"
 
-#: schematic/src/gschem_preview.c:195
 msgid "Preview Buffer"
 msgstr "Vorschau"
 
-#: schematic/src/gschem_show_hide_text_widget.c:148
-#: schematic/src/x_window.c:1268
 #, fuzzy
 msgid "Hide"
 msgstr "Text verbergen"
 
-#: schematic/src/gschem_show_hide_text_widget.c:157
-#: schematic/src/x_window.c:1269
 msgid "Hide text starting with:"
 msgstr "Text verbergen, der beginnt mit:"
 
-#: schematic/src/gschem_slot_edit_dialog.c:91
 msgid "Edit slot number"
 msgstr "Slot-Nummer bearbeiten"
 
-#: schematic/src/gschem_slot_edit_dialog.c:121
 msgid "Number of Slots:"
 msgstr ""
 
-#: schematic/src/gschem_slot_edit_dialog.c:122
 #, fuzzy
 msgid "Slot Number:"
 msgstr "Slot-Nummer bearbeiten:"
 
-#: schematic/src/gschem_text_properties_widget.c:240
-#: schematic/src/x_newtext.c:265
 msgid "<b>Text Content</b>"
 msgstr "<b>Textinhalt</b>"
 
-#: schematic/src/gschem_text_properties_widget.c:259
-#: schematic/src/x_newtext.c:291
 #, fuzzy
 msgid "_Size:"
 msgstr "Größe:"
 
-#: schematic/src/gschem_text_properties_widget.c:260
-#: schematic/src/x_newtext.c:310
 #, fuzzy
 msgid "Ali_gnment:"
 msgstr "Ausrichtung:"
 
-#: schematic/src/gschem_text_properties_widget.c:261
-#: schematic/src/x_newtext.c:330
 #, fuzzy
 msgid "Ro_tation:"
 msgstr "Ausrichtung:"
 
-#: schematic/src/gschem_text_properties_widget.c:294
-#: schematic/src/x_newtext.c:253
 msgid "<b>Text Properties</b>"
 msgstr "<b>Texteigenschaften</b>"
 
-#: schematic/src/gschem_translate_widget.c:238
 #, fuzzy
 msgid "Coordinate:"
 msgstr "K_oordinatenfenster anzeigen …"
 
-#: schematic/src/gschem_translate_widget.c:405 schematic/src/i_callbacks.c:800
 msgid "Translate"
 msgstr "Verschieben nach"
 
-#: schematic/src/i_basic.c:64 schematic/src/x_window.c:1369
-#: schematic/scheme/conf/schematic/menu.scm:59
-#: schematic/scheme/gschem/builtins.scm:99
 msgid "Select Mode"
 msgstr "Auswahlmodus"
 
-#: schematic/src/i_basic.c:65
 #, fuzzy
 msgid "Select Box Mode"
 msgstr "Auswahlmodus"
 
-#: schematic/src/i_basic.c:66
 msgid "Text Mode"
 msgstr "Textmodus"
 
-#: schematic/src/i_basic.c:67
 msgid "Pan Mode"
 msgstr "Ausschnittmodus"
 
-#: schematic/src/i_basic.c:70
 #, c-format
 msgid "Paste %d Mode"
 msgstr "%d-Einfügemodus"
 
-#: schematic/src/i_basic.c:74
 msgid "Magnetic Net Mode"
 msgstr "Magnetischer Netzmodus"
 
-#: schematic/src/i_basic.c:76
 msgid "Net Mode"
 msgstr "Netzmodus"
 
-#: schematic/src/i_basic.c:77
 msgid "Arc Mode"
 msgstr "Bogenmodus"
 
-#: schematic/src/i_basic.c:78
 msgid "Box Mode"
 msgstr "Rechteckmodus"
 
-#: schematic/src/i_basic.c:79
 msgid "Bus Mode"
 msgstr "Busmodus"
 
-#: schematic/src/i_basic.c:80
 msgid "Circle Mode"
 msgstr "Kreismodus"
 
-#: schematic/src/i_basic.c:81
 msgid "Component Mode"
 msgstr "Bauteilmodus"
 
-#: schematic/src/i_basic.c:82 schematic/scheme/conf/schematic/menu.scm:62
-#: schematic/scheme/gschem/builtins.scm:114
 msgid "Copy Mode"
 msgstr "Kopiermodus"
 
-#: schematic/src/i_basic.c:83 schematic/scheme/conf/schematic/menu.scm:63
-#: schematic/scheme/gschem/builtins.scm:117
 msgid "Multiple Copy Mode"
 msgstr "Mehrfach-Kopiermodus"
 
-#: schematic/src/i_basic.c:84
 msgid "Line Mode"
 msgstr "Linienmodus"
 
-#: schematic/src/i_basic.c:85 schematic/scheme/conf/schematic/menu.scm:66
-#: schematic/scheme/gschem/builtins.scm:123
 msgid "Mirror Mode"
 msgstr "Spiegelmodus"
 
-#: schematic/src/i_basic.c:86 schematic/scheme/conf/schematic/menu.scm:64
-#: schematic/scheme/gschem/builtins.scm:111
 msgid "Move Mode"
 msgstr "Verschiebemodus"
 
-#: schematic/src/i_basic.c:87
 #, fuzzy
 msgid "Path Mode"
 msgstr "Ausschnittmodus"
 
-#: schematic/src/i_basic.c:88
 msgid "Picture Mode"
 msgstr "Bildmodus"
 
-#: schematic/src/i_basic.c:89
 msgid "Pin Mode"
 msgstr "Anschlußmodus"
 
-#: schematic/src/i_basic.c:90 schematic/scheme/gschem/builtins.scm:120
 msgid "Rotate Mode"
 msgstr "Drehmodus"
 
-#: schematic/src/i_basic.c:91
 #, fuzzy
 msgid "Modify Mode"
 msgstr "Kopiermodus"
 
-#: schematic/src/i_basic.c:92 schematic/src/x_menus.c:49
-#: schematic/scheme/gschem/builtins.scm:204
 msgid "Zoom Box"
 msgstr "Ausschnitt wählen"
 
-#: schematic/src/i_basic.c:121
 msgid "Show Hidden"
 msgstr "Verborgenes anzeigen"
 
-#: schematic/src/i_basic.c:124
 msgid "Snap Off"
 msgstr "Am Raster ausrichten aus"
 
-#: schematic/src/i_basic.c:126
 msgid "Resnap Active"
 msgstr "Neu Ausrichen"
 
-#: schematic/src/i_basic.c:288 schematic/src/x_colorcb.c:159
 msgid "Stroke"
 msgstr "Taste"
 
-#: schematic/src/i_basic.c:296 schematic/src/i_basic.c:330
-#: schematic/src/x_window.c:1361
 msgid "none"
 msgstr "nichts"
 
-#: schematic/src/i_basic.c:304
 msgid "Repeat/"
 msgstr "Wiederhole/"
 
-#: schematic/src/i_basic.c:315
 msgid "Repeat/none"
 msgstr "Wiederholen/Nichts"
 
-#: schematic/src/i_basic.c:323 schematic/src/i_callbacks.c:1239
-#: schematic/scheme/gschem/builtins.scm:189
 msgid "Pan"
 msgstr "Ausschnitt verschieben"
 
-#: schematic/src/i_callbacks.c:74
 #, fuzzy, c-format
 msgid "New page created [%1$s]"
 msgstr "Neue Seite erzeugt [%s]\n"
 
-#: schematic/src/i_callbacks.c:108
 #, fuzzy, c-format
 msgid "New Window created [%1$s]"
 msgstr "Neues Fenster geöffnet [%s]\n"
 
-#: schematic/src/i_callbacks.c:245
 msgid "Failed to Save All"
 msgstr "Alles speichern gescheitert"
 
-#: schematic/src/i_callbacks.c:247
 msgid "Saved All"
 msgstr "Alles gespeichert"
 
-#: schematic/src/i_callbacks.c:308
 #, fuzzy
 msgid "Closing Window"
 msgstr "Schließe Fenster\n"
 
-#: schematic/src/i_callbacks.c:505 schematic/src/x_menus.c:55
-#: schematic/scheme/gschem/builtins.scm:168
 msgid "Copy"
 msgstr "Kopieren"
 
-#: schematic/src/i_callbacks.c:514 schematic/src/i_callbacks.c:539
-#: schematic/src/i_callbacks.c:564
 msgid "Select objs first"
 msgstr "Zuerst Objekte auswählen"
 
-#: schematic/src/i_callbacks.c:530
 msgid "Multiple Copy"
 msgstr "Mehrfaches Kopieren"
 
-#: schematic/src/i_callbacks.c:555 schematic/src/x_menus.c:56
 msgid "Move"
 msgstr "Verschieben"
 
-#: schematic/src/i_callbacks.c:579 schematic/src/x_menus.c:57
-#: schematic/src/x_multiattrib.c:1656 schematic/scheme/gschem/builtins.scm:108
 msgid "Delete"
 msgstr "Löschen"
 
-#: schematic/src/i_callbacks.c:603
 msgid "Edit"
 msgstr "Bearbeiten"
 
-#: schematic/src/i_callbacks.c:618 schematic/scheme/gschem/builtins.scm:129
 msgid "Edit Text"
 msgstr "Text bearbeiten"
 
-#: schematic/src/i_callbacks.c:637
 msgid "Slot"
 msgstr "Slot"
 
-#: schematic/src/i_callbacks.c:688 schematic/src/i_callbacks.c:698
 msgid "Rotate"
 msgstr "Drehen"
 
-#: schematic/src/i_callbacks.c:736 schematic/src/i_callbacks.c:746
 msgid "Mirror"
 msgstr "Spiegeln"
 
-#: schematic/src/i_callbacks.c:763 schematic/src/x_colorcb.c:160
-#: schematic/scheme/conf/schematic/menu.scm:73
-#: schematic/scheme/gschem/builtins.scm:141
 msgid "Lock"
 msgstr "Sperren"
 
-#: schematic/src/i_callbacks.c:781 schematic/scheme/conf/schematic/menu.scm:74
-#: schematic/scheme/gschem/builtins.scm:144
 msgid "Unlock"
 msgstr "Entsperren"
 
-#: schematic/src/i_callbacks.c:805
 #, fuzzy
 msgid "WARNING: Do not translate with snap off!"
 msgstr ""
 "ACHTUNG: Keine Transformation mit ausgeschalteter Ausrichtung am Raster!\n"
 
-#: schematic/src/i_callbacks.c:806
 #, fuzzy
 msgid "WARNING: Turning snap on and continuing with translate."
 msgstr ""
 "ACHTUNG:\"am Raster ausrichten\" wird aktiviert und mit der Transformation "
 "fortgefahren.\n"
 
-#: schematic/src/i_callbacks.c:813
 #, fuzzy
 msgid "WARNING: Snap grid size is not equal to 100!"
 msgstr "ACHTUNG: Das Raster ist ungleich 100!\n"
 
-#: schematic/src/i_callbacks.c:815
 #, fuzzy
 msgid ""
 "WARNING: If you are translating a symbol to the origin, the snap grid size "
@@ -959,23 +737,18 @@ msgstr ""
 "ACHTUNG: Wenn ein Symbol transformiert wird, sollte das Raster auf 100 "
 "gesetzt sein.\n"
 
-#: schematic/src/i_callbacks.c:847
 msgid "Embed"
 msgstr "Einbetten"
 
-#: schematic/src/i_callbacks.c:886
 msgid "Unembed"
 msgstr "Ausbetten"
 
-#: schematic/src/i_callbacks.c:928
 msgid "Update"
 msgstr "Aktualisieren"
 
-#: schematic/src/i_callbacks.c:970
 msgid "ShowHidden"
 msgstr "Verborgenes anzeigen"
 
-#: schematic/src/i_callbacks.c:1537
 #, c-format
 msgid ""
 "<b>Revert page:</b>\n"
@@ -986,100 +759,78 @@ msgid ""
 "discarded and page file will be reloaded from disk."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1555
 #, fuzzy
 msgid "Revert"
 msgstr "Neu _laden"
 
-#: schematic/src/i_callbacks.c:1647
 msgid "Copy to clipboard"
 msgstr "Kopieren"
 
-#: schematic/src/i_callbacks.c:1664
 msgid "Cut to clipboard"
 msgstr "Einfügen"
 
-#: schematic/src/i_callbacks.c:1686
 msgid "Paste from clipboard"
 msgstr "Einfügen"
 
-#: schematic/src/i_callbacks.c:1694
 #, fuzzy
 msgid "Empty clipboard"
 msgstr "Kopieren"
 
 #. TRANSLATORS: The number is the number of the buffer that the
 #. * selection is being copied to.
-#: schematic/src/i_callbacks.c:1719
 #, fuzzy, c-format
 msgid "Copy %i"
 msgstr "Kopie 1"
 
 #. TRANSLATORS: The number is the number of the buffer that the
 #. * selection is being cut to.
-#: schematic/src/i_callbacks.c:1746
 #, fuzzy, c-format
 msgid "Cut %i"
 msgstr "Ausschneiden 1"
 
 #. TRANSLATORS: The number is the number of the buffer that is being
 #. * pasted to the schematic.
-#: schematic/src/i_callbacks.c:1776
 #, fuzzy, c-format
 msgid "Paste %i"
 msgstr "Einfügen 1"
 
-#: schematic/src/i_callbacks.c:1785
 msgid "Empty buffer"
 msgstr "Leerer Zwischenspeicher"
 
-#: schematic/src/i_callbacks.c:1833 schematic/src/x_window.c:1203
 msgid "Component"
 msgstr "Bauteil"
 
-#: schematic/src/i_callbacks.c:1865 schematic/src/x_colorcb.c:150
 msgid "Attribute"
 msgstr "Attribut"
 
-#: schematic/src/i_callbacks.c:1885 schematic/src/x_colorcb.c:149
 msgid "Net"
 msgstr "Netz"
 
-#: schematic/src/i_callbacks.c:1928 schematic/src/x_colorcb.c:155
-#: schematic/src/x_window.c:1222
 msgid "Bus"
 msgstr "Bus"
 
-#: schematic/src/i_callbacks.c:2004
 msgid "Line"
 msgstr "Linie"
 
-#: schematic/src/i_callbacks.c:2021
 msgid "Path"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2043
 msgid "Box"
 msgstr "Rechteck"
 
-#: schematic/src/i_callbacks.c:2085
 msgid "Circle"
 msgstr "Kreis"
 
-#: schematic/src/i_callbacks.c:2108
 msgid "Arc"
 msgstr "Bogen"
 
-#: schematic/src/i_callbacks.c:2131 schematic/src/x_colorcb.c:146
 msgid "Pin"
 msgstr "Anschluß"
 
-#: schematic/src/i_callbacks.c:2191
 #, fuzzy, c-format
 msgid "Searching for source [%1$s]"
 msgstr "Nach der Quelle suchen [%s]\n"
 
-#: schematic/src/i_callbacks.c:2223
 #, fuzzy, c-format
 msgid ""
 "Failed to descend hierarchy into '%1$s': %2$s\n"
@@ -1090,121 +841,96 @@ msgstr ""
 "\n"
 "Das Log-Fenster von gschem sind eventuell Details eingetragen."
 
-#: schematic/src/i_callbacks.c:2227
 #, fuzzy, c-format
 msgid "Failed to descend into '%1$s': %2$s"
 msgstr "Die folgenden Bilder konnten nicht überschrieben werden: %s"
 
-#: schematic/src/i_callbacks.c:2234
 #, fuzzy
 msgid "Failed to descend hierarchy."
 msgstr "In der Hierachie hinabsteigen"
 
-#: schematic/src/i_callbacks.c:2312
 #, fuzzy, c-format
 msgid "Searching for symbol [%1$s]"
 msgstr "Nach dem Symbol suchen [%s]\n"
 
-#: schematic/src/i_callbacks.c:2320
 #, fuzzy
 msgid "Symbol is not a real file. Symbol cannot be loaded."
 msgstr "Das Symbol ist keine reale Datei. Symbol kann nicht geöffnet werden.\n"
 
-#: schematic/src/i_callbacks.c:2367 schematic/src/x_tabs.c:1060
 #, fuzzy
 msgid "Cannot find any schematics above the current one!"
 msgstr "Konnte keinen übergeordneten Schaltplan finden!\n"
 
-#: schematic/src/i_callbacks.c:2400
 msgid "Attach"
 msgstr "Anbringen"
 
-#: schematic/src/i_callbacks.c:2456
 msgid "Detach"
 msgstr "Ablösen"
 
-#: schematic/src/i_callbacks.c:2500
 msgid "ShowN"
 msgstr "ShowN"
 
-#: schematic/src/i_callbacks.c:2537
 msgid "ShowV"
 msgstr "ShowV"
 
-#: schematic/src/i_callbacks.c:2574
 msgid "ShowB"
 msgstr "ShowB"
 
-#: schematic/src/i_callbacks.c:2612
 msgid "VisToggle"
 msgstr "VisToggle"
 
-#: schematic/src/i_callbacks.c:2643
 #, c-format
 msgid "Sorry but this is a non-functioning menu option\n"
 msgstr "Dieser Menupunkt funktioniert nicht. Sorry.\n"
 
-#: schematic/src/i_callbacks.c:2703
 #, fuzzy
 msgid "Action feedback mode set to OUTLINE"
 msgstr "Aktions-Rückmeldemodus wurde auf OUTLINE festgelegt.\n"
 
-#: schematic/src/i_callbacks.c:2706
 #, fuzzy
 msgid "Action feedback mode set to BOUNDINGBOX"
 msgstr "Aktions-Rückmeldemodus wurde auf BOUNDINGBOX festgelegt.\n"
 
-#: schematic/src/i_callbacks.c:2730
 #, fuzzy
 msgid "Grid OFF"
 msgstr "Raster AUS\n"
 
-#: schematic/src/i_callbacks.c:2731
 #, fuzzy
 msgid "Dot grid selected"
 msgstr "Punktraster ausgewählt\n"
 
-#: schematic/src/i_callbacks.c:2732
 #, fuzzy
 msgid "Mesh grid selected"
 msgstr "Linienraster ausgewählt\n"
 
-#: schematic/src/i_callbacks.c:2733
 #, fuzzy
 msgid "Invalid grid mode"
 msgstr "Fehlerhaftes Attribut"
 
-#: schematic/src/i_callbacks.c:2755
 #, fuzzy
 msgid "Snap OFF (CAUTION!)"
 msgstr "Freihandmodus (ACHTUNG! Ausrichten am Raster abgeschaltet)\n"
 
-#: schematic/src/i_callbacks.c:2758
 #, fuzzy
 msgid "Snap ON"
 msgstr "Am Raster ausrichten\n"
 
-#: schematic/src/i_callbacks.c:2761
 #, fuzzy
 msgid "Snap back to the grid (CAUTION!)"
 msgstr "Objekte neu am Raster ausrichten (Achtung!)\n"
 
-#: schematic/src/i_callbacks.c:2790
 #, fuzzy
 msgid "Rubber band ON"
 msgstr "Gummifäden EIN\n"
 
-#: schematic/src/i_callbacks.c:2792
 #, fuzzy
 msgid "Rubber band OFF"
 msgstr "Gummifäden AUS \n"
 
-#: schematic/src/i_callbacks.c:2811
 #, fuzzy
 msgid "magnetic net mode: ON"
 msgstr "Magnetischer Netzmodus: EIN\n"
 
-#: schematic/src/i_callbacks.c:2814
 #, fuzzy
 msgid "magnetic net mode: OFF"
 msgstr "Magnetischer Netzmodus: AUS\n"
@@ -1214,153 +940,124 @@ msgstr "Magnetischer Netzmodus: AUS\n"
 #. the form "untitled_N.sch", where N is a number.  Please make
 #. sure that the translation contains characters suitable for use
 #. in a filename.
-#: schematic/src/i_vars.c:209
 msgid "untitled"
 msgstr ""
 
-#: schematic/src/o_complex.c:192 schematic/src/o_complex.c:195
 #, fuzzy, c-format
 msgid "Translating schematic [%1$d %2$d]"
 msgstr "Verschiebe Schaltplan [%d %d]\n"
 
-#: schematic/src/o_delete.c:82
 #, fuzzy, c-format
 msgid "Delete locked object?"
 msgid_plural "Delete %1$u locked objects?"
 msgstr[0] "Ausgewählte Objekte"
 msgstr[1] "Ausgewählte Objekte"
 
-#: schematic/src/o_misc.c:55
 #, c-format
 msgid "Got an unexpected NULL in o_edit\n"
 msgstr "Der Rückgabewert von o_edit war unerwartet NULL\n"
 
-#: schematic/src/o_misc.c:315
 #, fuzzy
 msgid "Hidden text is now visible"
 msgstr "Verborgener Text ist jetzt sichtbar.\n"
 
-#: schematic/src/o_misc.c:317
 #, fuzzy
 msgid "Hidden text is now invisible"
 msgstr "Verborgener Text ist jetzt unsichbar.\n"
 
-#: schematic/src/o_misc.c:425
 #, fuzzy, c-format
 msgid "Could not find symbol [%1$s] in library. Update failed."
 msgstr ""
 "Das Symbol [%s] konnte nicht gefunden werden. Aktualisierung "
 "fehlgeschlagen.\n"
 
-#: schematic/src/o_misc.c:541
 #, fuzzy, c-format
 msgid "o_autosave_backups: Can't get the real filename of %1$s."
 msgstr ""
 "o_autosave_backups: Konnte den tatsächlichen Dateinamen von %s nicht "
 "ermitteln."
 
-#: schematic/src/o_misc.c:585
 #, fuzzy, c-format
 msgid "Could NOT set previous backup file [%1$s] read-write"
 msgstr ""
 "Die vorherige Backup-Datei [%s] konnte nicht auf read-write gesetzt werden.\n"
 
-#: schematic/src/o_misc.c:605
 #, fuzzy, c-format
 msgid "Could NOT set backup file [%1$s] readonly"
 msgstr "Die Backup-Datei [%s] konnte nicht auf readonly gesetzt werden.\n"
 
-#: schematic/src/o_misc.c:610
 #, fuzzy, c-format
 msgid "Could NOT save backup file [%1$s]"
 msgstr "Die Backup-Datei [%s] konnte nicht gespeichert werden.\n"
 
-#: schematic/src/o_move.c:192
 #, c-format
 msgid "ERROR: NULL object in o_move_end!\n"
 msgstr "FEHLER: NULL Objekt innerhalb von o_move_end.\n"
 
-#: schematic/src/o_move.c:519
 #, c-format
 msgid "DOH! tried to find the whichone, but didn't find it!\n"
 msgstr ""
 "Versuchte vergebens das Objekt innerhalb von o_move_return_whichone zu "
 "finden.\n"
 
-#: schematic/src/o_move.c:546
 #, c-format
 msgid "Got a non line object in o_move_check_endpoint\n"
 msgstr "Da ist ein Objekt in o_move_check_endpoint, welches keine Linie ist.\n"
 
-#: schematic/src/o_net.c:444
 #, fuzzy
 msgid "Warning: Starting net at off grid coordinate"
 msgstr ""
 "Achtung: Der Startpunkt des Netzes befindet sich nicht auf dem Raster\n"
 
-#: schematic/src/o_net.c:508
 #, fuzzy
 msgid "Warning: Ending net at off grid coordinate"
 msgstr "Achtung: Das Ende des Netzes befindet sich nicht auf dem Raster\n"
 
-#: schematic/src/o_net.c:856 schematic/src/o_net.c:893
-#: schematic/src/o_net.c:964 schematic/src/o_net.c:1000
 #, c-format
 msgid "Tried to add more than two bus rippers. Internal gschem error.\n"
 msgstr ""
 "Interner gschem Fehler: Versuchte mehr als zwei Bus Abzweigungen "
 "hinzuzufügen\n"
 
-#: schematic/src/o_net.c:1068
 #, fuzzy, c-format
 msgid "Bus ripper symbol [%1$s] was not found in any component library"
 msgstr "Das Busripper Symbol [%s] wurde in keiner Bauteilbibliothek gefunden\n"
 
-#: schematic/src/o_picture.c:133 schematic/src/o_picture.c:343
 #, fuzzy
 msgid "Select a picture file..."
 msgstr "PostScript-Dateinamen auswählen …"
 
-#: schematic/src/o_picture.c:166
 #, fuzzy, c-format
 msgid "Failed to load picture: %1$s"
 msgstr "Das Bild [%s] konnte nicht geladen werden"
 
-#: schematic/src/o_picture.c:182
 msgid "Picture"
 msgstr "Bild"
 
-#: schematic/src/o_picture.c:378
 #, c-format
 msgid "Failed to replace pictures: %s"
 msgstr "Die folgenden Bilder konnten nicht überschrieben werden: %s"
 
-#: schematic/src/o_slot.c:80
 #, fuzzy
 msgid "Slot attribute malformed"
 msgstr "Slot Attribut ist fehlerhaft.\n"
 
-#: schematic/src/o_slot.c:88
 #, fuzzy
 msgid "numslots attribute missing"
 msgstr "Das numslots Attribut fehlt\n"
 
-#: schematic/src/o_slot.c:89
 #, fuzzy
 msgid "Slotting not allowed for this component"
 msgstr "Bei diesem Bauteil ist nur ein slot erlaubt.\n"
 
-#: schematic/src/o_slot.c:104
 #, fuzzy
 msgid "New slot number out of range"
 msgstr "Neue slot Nummer außerhalb des gültigen Wertebereichs\n"
 
-#: schematic/src/o_undo.c:397
 #, fuzzy
 msgid "Undo/Redo disabled in rc file"
 msgstr "Rückgängig/Wiederherstellen wurde in der rc Datei deaktiviert.\n"
 
-#: schematic/src/parsecmd.c:77
 #, c-format
 msgid ""
 "Usage: %1$s [OPTION ...] [--] [FILE ...]\n"
@@ -1385,90 +1082,70 @@ msgid ""
 "gEDA/gaf homepage: <http://www.geda-project.org/>\n"
 msgstr ""
 
-#: schematic/src/parsecmd.c:110
 #, c-format
 msgid ""
 "Lepton EDA %1$s (git: %2$.7s)\n"
 "Copyright (C) 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright (C) 2017-2018 Lepton Developers.\n"
+"Copyright (C) 2017-2019 Lepton Developers.\n"
 "This is free software, and you are welcome to redistribute it under\n"
 "certain conditions. For details, see the file `COPYING', which is\n"
 "included in the Lepton EDA distribution.\n"
 "There is NO WARRANTY, to the extent permitted by law.\n"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:125
 #, c-format
 msgid "Got invalid show option; defaulting to show both\n"
 msgstr "Ungültige Anzeigeoption; »Beide anzeigen« wird zur Vorgabe\n"
 
-#: schematic/src/x_attribedit.c:139
 #, c-format
 msgid "ERROR: NULL object!\n"
 msgstr "FEHLER: NULL Objekt!\n"
 
-#: schematic/src/x_attribedit.c:328
 msgid "Single Attribute Editor"
 msgstr "Einzel-Attributebearbeitung"
 
-#: schematic/src/x_attribedit.c:358
 msgid "<b>Edit Attribute</b>"
 msgstr "<b>Attribut bearbeiten</b>"
 
-#: schematic/src/x_attribedit.c:360
 msgid "<b>Add Attribute</b>"
 msgstr "<b>Attribut hinzufügen</b>"
 
-#: schematic/src/x_attribedit.c:376
 #, fuzzy
 msgid "N_ame:"
 msgstr "Name:"
 
-#: schematic/src/x_attribedit.c:396 schematic/src/x_multiattrib.c:2222
 #, fuzzy
 msgid "_Value:"
 msgstr "Wert:"
 
-#: schematic/src/x_attribedit.c:415 schematic/src/x_multiattrib.c:2281
 #, fuzzy
 msgid "Vi_sible"
 msgstr "Sichtbar"
 
-#: schematic/src/x_attribedit.c:434
 msgid "Show Value Only"
 msgstr "Nur Wert anzeigen"
 
-#: schematic/src/x_attribedit.c:436
 msgid "Show Name Only"
 msgstr "Nur Name anzeigen"
 
-#: schematic/src/x_attribedit.c:438 schematic/src/x_multiattrib.c:1620
-#: schematic/scheme/gschem/builtins.scm:324
 msgid "Show Name & Value"
 msgstr "Name & Wert anzeigen"
 
-#: schematic/src/x_attribedit.c:445
 msgid "<b>Attach Options</b>"
 msgstr "<b>Optionen</b>"
 
-#: schematic/src/x_attribedit.c:460
 msgid "All"
 msgstr "Alle"
 
-#: schematic/src/x_attribedit.c:476 schematic/src/x_compselect.c:986
-#: schematic/src/x_compselect.c:1100
 msgid "Components"
 msgstr "Bauteile"
 
-#: schematic/src/x_attribedit.c:492 schematic/src/x_window.c:1214
 msgid "Nets"
 msgstr "Netz"
 
-#: schematic/src/x_attribedit.c:508
 msgid "Replace existing attributes"
 msgstr "Vorhandene Attribute ersetzen"
 
-#: schematic/src/x_autonumber.c:412
 #, fuzzy
 msgid ""
 "slotted object without slot attribute may cause problems when autonumbering "
@@ -1477,7 +1154,6 @@ msgstr ""
 "Objekte mit \"numslot\" Attribut und ohne \"slot\" Attribut können beim "
 "automatischen Nummerieren von Bauteilen Probleme verursachen.\n"
 
-#: schematic/src/x_autonumber.c:427
 #, fuzzy, c-format
 msgid ""
 "duplicate slot may cause problems: [symbolname=%1$s, number=%2$d, slot=%3$d]"
@@ -1485,97 +1161,74 @@ msgstr ""
 "Doppelt vergebener slot kann Probleme verursachen: [Symbolname=%s, Number="
 "%d, slot=%d]\n"
 
-#: schematic/src/x_autonumber.c:675
 #, fuzzy
 msgid "No searchstring given in autonumber text."
 msgstr "Es wurde kein Suchstring im Dialog eingegeben.\n"
 
-#: schematic/src/x_autonumber.c:728
 #, fuzzy
 msgid "No '*' or '?' given at the end of the autonumber text."
 msgstr "Am Ende des Suchstrings fehlt ein '*' oder ein '?'.\n"
 
-#: schematic/src/x_autonumber.c:873
 msgid "Diagonal"
 msgstr "Diagonal"
 
-#: schematic/src/x_autonumber.c:874
 msgid "Top to bottom"
 msgstr "Von oben nach unten"
 
-#: schematic/src/x_autonumber.c:875
 msgid "Bottom to top"
 msgstr "Von unten nach oben"
 
-#: schematic/src/x_autonumber.c:876
 msgid "Left to right"
 msgstr "Von links nach rechts"
 
-#: schematic/src/x_autonumber.c:877
 msgid "Right to left"
 msgstr "Von rechts nach links"
 
-#: schematic/src/x_autonumber.c:878
 msgid "File order"
 msgstr "Dateireihenfolge"
 
-#: schematic/src/x_autonumber.c:1214
 msgid "Autonumber text"
 msgstr "Nummeriere Text automatisch"
 
-#: schematic/src/x_autonumber.c:1237
 msgid "<b>Scope</b>"
 msgstr "<b>Suchbereich</b>"
 
-#: schematic/src/x_autonumber.c:1259
 msgid "Search for:"
 msgstr "Suchen nach:"
 
-#: schematic/src/x_autonumber.c:1273
 msgid "Autonumber text in:"
 msgstr "Nummeriere Text in:"
 
-#: schematic/src/x_autonumber.c:1280
 msgid "Skip numbers found in:"
 msgstr "Überspringe Nummern:"
 
-#: schematic/src/x_autonumber.c:1292 schematic/src/x_autonumber.c:1301
 msgid "Selected objects"
 msgstr "Ausgewählte Objekte"
 
-#: schematic/src/x_autonumber.c:1293 schematic/src/x_autonumber.c:1302
 msgid "Current page"
 msgstr "Aktuelle Seite"
 
-#: schematic/src/x_autonumber.c:1294 schematic/src/x_autonumber.c:1303
 msgid "Whole hierarchy"
 msgstr "Gesamte Hierarchie"
 
-#: schematic/src/x_autonumber.c:1305
 msgid "Overwrite existing numbers"
 msgstr "Vorhandene Nummern überschreiben"
 
-#: schematic/src/x_autonumber.c:1310
 msgid "<b>Options</b>"
 msgstr "<b>Optionen</b>"
 
-#: schematic/src/x_autonumber.c:1332
 msgid "Starting number:"
 msgstr "Startnummer:"
 
-#: schematic/src/x_autonumber.c:1339
 msgid "Sort order:"
 msgstr "Sortierung:"
 
-#: schematic/src/x_autonumber.c:1371
 msgid "Remove numbers"
 msgstr "Nummern entfernen"
 
-#: schematic/src/x_autonumber.c:1375
 msgid "Automatic slotting"
 msgstr "Automatische Nummerierung von Slots"
 
-#: schematic/src/x_clipboard.c:245
 #, c-format
 msgid ""
 "<b>Invalid schematic on clipboard.</b>\n"
@@ -1586,175 +1239,135 @@ msgstr ""
 "\n"
 "Fehler beim Einfügen eines Objekts aus der Ablage: %s."
 
-#: schematic/src/x_clipboard.c:247
 msgid "Clipboard insertion failed"
 msgstr "Einfügen von der Ablage scheiterte."
 
-#: schematic/src/x_color.c:89 schematic/src/x_color.c:98
 #, fuzzy, c-format
 msgid "Could not allocate the color %1$s!\n"
 msgstr "Konnte die Farbe %s nicht zuteilen!\n"
 
-#: schematic/src/x_color.c:89
 msgid "black"
 msgstr "schwarz"
 
-#: schematic/src/x_color.c:98
 msgid "white"
 msgstr "weiss"
 
-#: schematic/src/x_color.c:120
 #, fuzzy, c-format
 msgid "Could not allocate display color %1$i!\n"
 msgstr "Konnte die Bildschirmfarbe %i nicht allokieren!\n"
 
-#: schematic/src/x_color.c:142
 #, fuzzy, c-format
 msgid "Could not allocate outline color %1$i!\n"
 msgstr "Konnte die Umrissfarbe %i nicht allokieren!\n"
 
-#: schematic/src/x_color.c:159
 #, fuzzy, c-format
 msgid "Tried to get an invalid color: %1$d\n"
 msgstr "Versuchte eine ungültige Farbe zuzuteilen: %d\n"
 
-#: schematic/src/x_colorcb.c:145
 msgid "Background"
 msgstr "Hintergrund"
 
-#: schematic/src/x_colorcb.c:147
 msgid "Net endpoint"
 msgstr "Netz-Endemarkierung"
 
-#: schematic/src/x_colorcb.c:148
 msgid "Graphic"
 msgstr "Grafik"
 
-#: schematic/src/x_colorcb.c:151
 msgid "Logic bubble"
 msgstr "Logikmarkierung"
 
-#: schematic/src/x_colorcb.c:152
 msgid "Grid point"
 msgstr "Rasterpunkt"
 
-#: schematic/src/x_colorcb.c:153
 #, fuzzy
 msgid "Detached attribute"
 msgstr "Attribut ablösen"
 
-#: schematic/src/x_colorcb.c:156
 msgid "Selection"
 msgstr "Auswahl"
 
-#: schematic/src/x_colorcb.c:157
 msgid "Bounding box"
 msgstr "Randmarkierung"
 
-#: schematic/src/x_colorcb.c:158
 msgid "Zoom box"
 msgstr "Ausschnitt wählen"
 
-#: schematic/src/x_colorcb.c:161
 msgid "Output background"
 msgstr "Ausgabehintergrund"
 
-#: schematic/src/x_colorcb.c:162
 msgid "Freestyle 1"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:163
 msgid "Freestyle 2"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:164
 msgid "Freestyle 3"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:165
 msgid "Freestyle 4"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:166
 msgid "Net junction"
 msgstr "Netzverbindung"
 
-#: schematic/src/x_colorcb.c:167
 msgid "Mesh grid major"
 msgstr "Grobes Gitternetz"
 
-#: schematic/src/x_colorcb.c:168
 msgid "Mesh grid minor"
 msgstr "Feines Gitternetz"
 
-#: schematic/src/x_colorcb.c:172
 msgid "Unknown"
 msgstr "Unbekannt"
 
-#: schematic/src/x_compselect.c:1169
 #, fuzzy
 msgid "Reset filter"
 msgstr "Neue Datei"
 
-#: schematic/src/x_compselect.c:1192
 msgid "Reload all libraries"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1245 schematic/src/x_multiattrib.c:2092
 msgid "Value"
 msgstr "Wert"
 
-#: schematic/src/x_compselect.c:1284
 msgid "Default behavior - reference component"
 msgstr "Bauteil referenzieren (Voreinstellung)"
 
-#: schematic/src/x_compselect.c:1287
 msgid "Embed component in schematic"
 msgstr "Bauteil in den Schaltplan einbetten"
 
-#: schematic/src/x_compselect.c:1290
 msgid "Include component as individual objects"
 msgstr "Bauteil als Einzelkomponenten einfügen"
 
-#: schematic/src/x_compselect.c:1448
 msgid "Select Component..."
 msgstr "Bauteil auswählen …"
 
-#: schematic/src/x_compselect.c:1471
 #, fuzzy
 msgid "In Us_e"
 msgstr "In Verwendung"
 
-#: schematic/src/x_compselect.c:1475
 #, fuzzy
 msgid "Lib_raries"
 msgstr "Bibliotheken"
 
-#: schematic/src/x_compselect.c:1484 schematic/src/x_fileselect.c:119
 msgid "Preview"
 msgstr "Vorschau"
 
-#: schematic/src/x_compselect.c:1510
 msgid "Attributes"
 msgstr "Attribut"
 
-#: schematic/src/x_dialog.c:325
 msgid "Major symbol changes detected."
 msgstr ""
 
-#: schematic/src/x_dialog.c:349
 msgid ""
 "Changes have occurred to the symbols shown below.\n"
 "\n"
 "Be sure to verify each of these symbols."
 msgstr ""
 
-#: schematic/src/x_dialog.c:369
 #, fuzzy
 msgid "Symbol"
 msgstr "Symbole"
 
-#: schematic/src/x_dialog.c:406
 #, c-format
 msgid ""
 "<span weight=\"bold\" size=\"larger\">The input attribute \"%s\" is invalid\n"
@@ -1772,40 +1385,31 @@ msgstr ""
 "Der Name darf nicht mit einem Leerzeichen enden.\n"
 "Der Wert darf nicht mit einem Leerzeichen beginnen."
 
-#: schematic/src/x_dialog.c:408
 msgid "Invalid Attribute"
 msgstr "Fehlerhaftes Attribut"
 
-#: schematic/src/x_fileselect.c:37
 msgid "Schematics"
 msgstr "Schaltpläne"
 
-#: schematic/src/x_fileselect.c:42
 msgid "Symbols"
 msgstr "Symbole"
 
-#: schematic/src/x_fileselect.c:47
 msgid "Schematics and symbols"
 msgstr "Schaltpläne und Symbole"
 
-#: schematic/src/x_fileselect.c:53
 msgid "All files"
 msgstr "Alle Dateien"
 
-#: schematic/src/x_fileselect.c:169
 msgid "Open..."
 msgstr "Öffnen …"
 
-#: schematic/src/x_fileselect.c:233
 msgid "Save as..."
 msgstr "Speichern unter …"
 
-#: schematic/src/x_fileselect.c:297
 #, fuzzy
 msgid "Save cancelled on user request"
 msgstr "Das Speichern wurde durch den Anwender abgebrochen\n"
 
-#: schematic/src/x_fileselect.c:334
 msgid ""
 "\n"
 "If you load the original file, the backup file will be overwritten in the "
@@ -1814,28 +1418,22 @@ msgid ""
 "Do you want to load the backup file?\n"
 msgstr ""
 
-#: schematic/src/x_fstylecb.c:73
 msgid "Hollow"
 msgstr "Leer"
 
-#: schematic/src/x_fstylecb.c:80
 msgid "Filled"
 msgstr "Gefüllt"
 
-#: schematic/src/x_fstylecb.c:87
 msgid "Mesh"
 msgstr "Gitter"
 
-#: schematic/src/x_fstylecb.c:94
 msgid "Hatch"
 msgstr "Schraffiert"
 
-#: schematic/src/x_image.c:279
 #, fuzzy, c-format
 msgid "x_image_lowlevel: Unable to write %1$s file %2$s."
 msgstr "x_image_lowlevel: Konnte %s-Datei %s nicht schreiben.\n"
 
-#: schematic/src/x_image.c:289
 #, fuzzy, c-format
 msgid ""
 "There was the following error when saving image with type %1$s to filename:\n"
@@ -1848,302 +1446,237 @@ msgstr ""
 "\n"
 "%s.\n"
 
-#: schematic/src/x_image.c:309
 #, fuzzy, c-format
 msgid "Wrote color image to [%1$s] [%2$d x %3$d]"
 msgstr "Farbiges Bild als [%s] gespeichert. Größe [%d x %d]\n"
 
-#: schematic/src/x_image.c:311
 #, fuzzy, c-format
 msgid "Wrote black and white image to [%1$s] [%2$d x %3$d]"
 msgstr "Schwarz & weiß Bild als [%s] gespeichert. Größe [%d x %d]\n"
 
-#: schematic/src/x_image.c:319
 #, fuzzy
 msgid "x_image_lowlevel: Unable to get pixbuf from gschem's window."
 msgstr "x_image_lowlevel: konnte kein Bild vom gschem-Fenster bekommen.\n"
 
-#: schematic/src/x_image.c:358
 msgid "Width x Height"
 msgstr "Breite × Höhe"
 
-#: schematic/src/x_image.c:374
 msgid "Image type"
 msgstr "Bildformat"
 
-#: schematic/src/x_image.c:395
 msgid "Write image..."
 msgstr "Bild exportieren …"
 
-#: schematic/src/x_linecapcb.c:74
 msgid "Butt"
 msgstr ""
 
-#: schematic/src/x_linecapcb.c:81
 msgid "Square"
 msgstr ""
 
-#: schematic/src/x_linecapcb.c:88
 msgid "Round"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:74
 msgid "Solid"
 msgstr "Durchgehend"
 
-#: schematic/src/x_linetypecb.c:81
 msgid "Dotted"
 msgstr "Gepunktet"
 
-#: schematic/src/x_linetypecb.c:88
 msgid "Dashed"
 msgstr "Gestrichelt"
 
-#: schematic/src/x_linetypecb.c:95
 msgid "Center"
 msgstr "Strich-Punkt"
 
-#: schematic/src/x_linetypecb.c:102
 msgid "Phantom"
 msgstr "Strich-Zwei-Punkt"
 
-#: schematic/src/x_menus.c:41 schematic/scheme/gschem/builtins.scm:267
 #, fuzzy
 msgid "Add Net"
 msgstr "/Netz einfügen"
 
-#: schematic/src/x_menus.c:42 schematic/src/x_multiattrib.c:2187
-#: schematic/scheme/gschem/builtins.scm:264
 msgid "Add Attribute"
 msgstr "Attribut hinzufügen"
 
-#: schematic/src/x_menus.c:43 schematic/scheme/gschem/builtins.scm:261
 #, fuzzy
 msgid "Add Component"
 msgstr "/Bauteil hinzufügen …"
 
-#: schematic/src/x_menus.c:44 schematic/scheme/gschem/builtins.scm:270
 #, fuzzy
 msgid "Add Bus"
 msgstr "/Bus einfügen"
 
-#: schematic/src/x_menus.c:45 schematic/scheme/gschem/builtins.scm:273
 #, fuzzy
 msgid "Add Text"
 msgstr "/Text einfügen"
 
-#: schematic/src/x_menus.c:47 schematic/scheme/gschem/builtins.scm:210
 #, fuzzy
 msgid "Zoom In"
 msgstr "/Vergrößern"
 
-#: schematic/src/x_menus.c:48 schematic/scheme/gschem/builtins.scm:213
 #, fuzzy
 msgid "Zoom Out"
 msgstr "/Verkleinern"
 
-#: schematic/src/x_menus.c:50 schematic/scheme/gschem/builtins.scm:207
 #, fuzzy
 msgid "Zoom Extents"
 msgstr "/Automatisch"
 
-#: schematic/src/x_menus.c:52 schematic/src/x_window.c:1233
 msgid "Select"
 msgstr "Auswählen"
 
-#: schematic/src/x_menus.c:53 schematic/scheme/conf/schematic/menu.scm:69
-#: schematic/scheme/gschem/builtins.scm:126
 msgid "Edit..."
 msgstr "Bearbeiten …"
 
-#: schematic/src/x_menus.c:54 schematic/scheme/conf/schematic/menu.scm:68
 #, fuzzy
 msgid "Object Properties..."
 msgstr "<b>Texteigenschaften</b>"
 
-#: schematic/src/x_menus.c:59 schematic/scheme/gschem/builtins.scm:300
 #, fuzzy
 msgid "Down Schematic"
 msgstr "/Zum Schaltplan hinab"
 
-#: schematic/src/x_menus.c:60 schematic/scheme/gschem/builtins.scm:303
 #, fuzzy
 msgid "Down Symbol"
 msgstr "/Zum Symbol hinab"
 
-#: schematic/src/x_menus.c:61
 #, fuzzy
 msgid "Up"
 msgstr "/Hinauf"
 
-#: schematic/src/x_menus.c:336
 #, fuzzy, c-format
 msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
 msgstr ""
 "Es wurde versucht die Empfindlichkeit des nicht existenten Menueintrags '%s' "
 "zu setzen\n"
 
-#: schematic/src/x_menus.c:360
 #, c-format
 msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
 msgstr ""
 "Es wurde versucht die Empfindlichkeit des nicht existenten Menueintrags '%s' "
 "zu setzen\n"
 
-#: schematic/src/x_misc.c:70
 msgid "The operating system is out of memory or resources."
 msgstr "Zu wenig Speicher, oder andere Resoucen."
 
-#: schematic/src/x_multiattrib.c:798 schematic/src/x_multiattrib.c:2704
 msgid "<various>"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:930
 msgid "Attributes with empty name are not allowed. Please set a name."
 msgstr ""
 "Attribute mit leerem Namen sind nicht erlaubt. Gib bitte einen Namen ein."
 
-#: schematic/src/x_multiattrib.c:1622
 msgid "Show Value only"
 msgstr "Nur Wert anzeigen"
 
-#: schematic/src/x_multiattrib.c:1624
 msgid "Show Name only"
 msgstr "Nur Name anzeigen"
 
-#: schematic/src/x_multiattrib.c:1651
 msgid "Promote"
 msgstr "Einsetzen"
 
-#: schematic/src/x_multiattrib.c:1655
 msgid "Duplicate"
 msgstr "Duplizieren"
 
-#: schematic/src/x_multiattrib.c:1657
 #, fuzzy
 msgid "Copy to all"
 msgstr "Kopieren in 1"
 
-#: schematic/src/x_multiattrib.c:1986 schematic/src/x_multiattrib.c:2602
 msgid "Edit Attributes"
 msgstr "Attribute bearbeiten"
 
-#: schematic/src/x_multiattrib.c:2112
 msgid "Vis?"
 msgstr "Sichtbar?"
 
-#: schematic/src/x_multiattrib.c:2130
 msgid "N"
 msgstr "Name"
 
-#: schematic/src/x_multiattrib.c:2148
 msgid "V"
 msgstr "Wert"
 
-#: schematic/src/x_multiattrib.c:2170
 #, fuzzy
 msgid "Sho_w inherited attributes"
 msgstr "Geerbte Attribute anzeigen"
 
-#: schematic/src/x_multiattrib.c:2197
 #, fuzzy
 msgid "_Name:"
 msgstr "Name:"
 
-#: schematic/src/x_multiattrib.c:2241
 msgid "Ctrl+Enter inserts new line; Ctrl+Tab inserts Tab"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2618
 #, c-format
 msgid "%2$i symbol (%1$s)"
 msgid_plural "%2$i symbols (%1$s)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2624
 #, fuzzy, c-format
 msgid "%1$i pin"
 msgid_plural "%1$i pins"
 msgstr[0] "Netz-Pin"
 msgstr[1] "Netz-Pin"
 
-#: schematic/src/x_multiattrib.c:2630
 #, c-format
 msgid "%1$i net"
 msgid_plural "%1$i nets"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2636
 #, c-format
 msgid "%1$i bus"
 msgid_plural "%1$i buses"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2642
 #, fuzzy, c-format
 msgid "%1$i attribute"
 msgid_plural "%1$i attributes"
 msgstr[0] "Attribut"
 msgstr[1] "Attribut"
 
-#: schematic/src/x_newtext.c:433
 msgid "Text Entry..."
 msgstr "Texteingabe …"
 
-#: schematic/src/x_pagesel.c:253
 msgid "New Page"
 msgstr "Neue Seite"
 
-#: schematic/src/x_pagesel.c:254
 msgid "Open Page..."
 msgstr "Seite öffnen …"
 
-#: schematic/src/x_pagesel.c:256
 msgid "Save Page"
 msgstr "Seite speichern"
 
-#: schematic/src/x_pagesel.c:257 schematic/scheme/gschem/builtins.scm:246
 msgid "Close Page"
 msgstr "Seite schließen"
 
-#: schematic/src/x_pagesel.c:376 schematic/scheme/gschem/builtins.scm:237
 msgid "Page Manager"
 msgstr "Seitenverwaltung"
 
-#: schematic/src/x_pagesel.c:448
 msgid "Changed"
 msgstr "Geändert"
 
-#: schematic/src/x_pagesel.c:468
 msgid "Right click on the filename for more options..."
 msgstr "Rechtsklick auf den Dateinamen zeigt mehr Optionen …"
 
-#: schematic/src/x_print.c:306
 #, fuzzy, c-format
 msgid "Failed to write PDF to '%s': %s\n"
 msgstr "Die folgenden Bilder konnten nicht überschrieben werden: %s"
 
-#: schematic/src/x_print.c:364
 #, fuzzy, c-format
 msgid "Failed to write PDF to '%1$s': %2$s\n"
 msgstr "Die folgenden Bilder konnten nicht überschrieben werden: %s"
 
-#: schematic/src/x_print.c:449
 #, c-format
 msgid ""
 "Error printing file:\n"
 "%1$s"
 msgstr ""
 
-#: schematic/src/x_rc.c:39
 #, fuzzy
 msgid "ERROR: An unknown error occurred while parsing configuration files."
 msgstr "FEHLER: Beim Einlesen der Konfigurationsdateien trat ein Fehler auf.\n"
 
-#: schematic/src/x_rc.c:44
 #, fuzzy
 msgid ""
 "An unknown error occurred while parsing configuration files.\n"
@@ -2151,12 +1684,10 @@ msgid ""
 "The lepton-schematic log may contain more information."
 msgstr "Beim Einlesen der Konfigurationsdateien trat ein Fehler auf."
 
-#: schematic/src/x_rc.c:56
 #, fuzzy, c-format
 msgid "ERROR: %1$s"
 msgstr "FEHLER: %s\n"
 
-#: schematic/src/x_rc.c:59
 #, fuzzy, c-format
 msgid ""
 "%1$s\n"
@@ -2167,142 +1698,111 @@ msgstr ""
 "\n"
 "Das Log-Fenster von gschem sind eventuell Details eingetragen."
 
-#: schematic/src/x_rc.c:67
 #, fuzzy
 msgid "Cannot load lepton-schematic configuration."
 msgstr "Konfigurationsdateien konnte nicht eingelesen werden."
 
-#: schematic/src/x_script.c:42 schematic/scheme/conf/schematic/menu.scm:40
 msgid "Execute Script..."
 msgstr "Skript ausführen …"
 
-#: schematic/src/x_script.c:61
 #, fuzzy, c-format
 msgid "Executing guile script [%1$s]"
 msgstr "Führe guile scipt aus [%s]\n"
 
-#: schematic/src/x_tabs.c:860
 #, fuzzy, c-format
 msgid "Hierarchy up: %s"
 msgstr "Hie_rarchie"
 
-#: schematic/src/x_tabs.c:863
 #, fuzzy
 msgid "Hierarchy up"
 msgstr "Hie_rarchie"
 
-#: schematic/src/x_widgets.c:158 schematic/src/x_window.c:1444
 #, fuzzy
 msgid "Options"
 msgstr "_Optionen"
 
-#: schematic/src/x_widgets.c:203 schematic/src/x_window.c:1436
 #, fuzzy
 msgid "Object"
 msgstr "Objektfarbe:"
 
-#: schematic/src/x_widgets.c:224
 msgid "Log"
 msgstr ""
 
-#: schematic/src/x_widgets.c:245 schematic/src/x_window.c:1466
 msgid "Find Text"
 msgstr "Text suchen"
 
-#: schematic/src/x_widgets.c:259
 #, fuzzy
 msgid "Color Scheme Editor"
 msgstr "_Helles Farbschema"
 
-#: schematic/src/x_widgets.c:272 schematic/scheme/gschem/builtins.scm:378
 #, fuzzy
 msgid "Select Schematic Font"
 msgstr "_Wählen Sie die zu speichernden Seiten:"
 
-#: schematic/src/x_window.c:763
 #, fuzzy, c-format
 msgid "Loading schematic [%1$s]"
 msgstr "Lade Schaltplan [%s]\n"
 
-#: schematic/src/x_window.c:864
 #, fuzzy, c-format
 msgid "Could NOT save page [%1$s]\n"
 msgstr "Die Seite [%s] konnte nicht gespeichert werden.\n"
 
-#: schematic/src/x_window.c:865
 msgid "Error while trying to save"
 msgstr "Fehler während des Speicherns"
 
-#: schematic/src/x_window.c:875
 msgid "Failed to save file"
 msgstr "Datei konnte nicht gespeichert werden"
 
-#: schematic/src/x_window.c:885
 #, fuzzy, c-format
 msgid "Saved as [%1$s]"
 msgstr "Gespeichert unter [%s]\n"
 
-#: schematic/src/x_window.c:887
 #, fuzzy, c-format
 msgid "Saved [%1$s]"
 msgstr "Gespeichert [%s]\n"
 
-#: schematic/src/x_window.c:889
 msgid "Saved"
 msgstr "Gespeichert"
 
-#: schematic/src/x_window.c:966
 #, fuzzy, c-format
 msgid "Discarding page [%1$s]"
 msgstr "Schließe Schaltplan [%s]\n"
 
-#: schematic/src/x_window.c:966
 #, fuzzy, c-format
 msgid "Closing [%1$s]"
 msgstr "Schließe [%s]\n"
 
-#: schematic/src/x_window.c:1175
 msgid "New"
 msgstr "Neu"
 
-#: schematic/src/x_window.c:1175
 msgid "New file"
 msgstr "Neue Datei"
 
-#: schematic/src/x_window.c:1179
 msgid "Open"
 msgstr "Öffnen"
 
-#: schematic/src/x_window.c:1179
 #, fuzzy
 msgid "Open file"
 msgstr "Datei öffnen …"
 
-#: schematic/src/x_window.c:1183 schematic/scheme/gschem/builtins.scm:59
 msgid "Save"
 msgstr "Speichern"
 
-#: schematic/src/x_window.c:1183
 msgid "Save file"
 msgstr "Datei speichern"
 
-#: schematic/src/x_window.c:1189 schematic/scheme/gschem/builtins.scm:93
 msgid "Undo"
 msgstr "Rückgängig"
 
-#: schematic/src/x_window.c:1189
 msgid "Undo last operation"
 msgstr "Letzte Aktion rückgängig machen"
 
-#: schematic/src/x_window.c:1193 schematic/scheme/gschem/builtins.scm:96
 msgid "Redo"
 msgstr "Wiederherstellen"
 
-#: schematic/src/x_window.c:1193
 msgid "Redo last undo"
 msgstr "Letzte Aktion wiederherstellen"
 
-#: schematic/src/x_window.c:1198
 msgid ""
 "Add component...\n"
 "Select library and component from list, move the mouse into main window, "
@@ -2314,7 +1814,6 @@ msgstr ""
 "Hauptfenster,\n"
 "klicken, um es zu platzieren. Rechtsklick zum abbrechen"
 
-#: schematic/src/x_window.c:1209
 msgid ""
 "Add nets mode\n"
 "Right mouse button to cancel"
@@ -2322,7 +1821,6 @@ msgstr ""
 "Netz einfügen\n"
 "mit rechter Maustaste abbrechen"
 
-#: schematic/src/x_window.c:1217
 msgid ""
 "Add buses mode\n"
 "Right mouse button to cancel"
@@ -2330,45 +1828,35 @@ msgstr ""
 "Bus einfügen\n"
 "mit rechter Maustaste abbrechen"
 
-#: schematic/src/x_window.c:1226
 msgid "Add Text..."
 msgstr "Text hinzufügen …"
 
-#: schematic/src/x_window.c:1233
 msgid "Select mode"
 msgstr "Auswahlmodus"
 
-#: schematic/src/x_window.c:1288
 #, fuzzy
 msgid "Show"
 msgstr "ShowN"
 
-#: schematic/src/x_window.c:1289
 msgid "Show text starting with:"
 msgstr "Text anzeigen, der beginnt mit:"
 
-#: schematic/src/x_window.c:1345
 msgid "Menu/Cancel"
 msgstr "Menü/Abbrechen"
 
-#: schematic/src/x_window.c:1349
 msgid "Pan/Cancel"
 msgstr "Ausschnitt/Abbrechen"
 
-#: schematic/src/x_window.c:1359
 msgid "Pick"
 msgstr "Auswählen"
 
-#: schematic/src/x_window.c:1470 schematic/scheme/gschem/builtins.scm:180
 msgid "Status"
 msgstr "Status"
 
-#: schematic/src/x_window.c:1568
 #, fuzzy, c-format
 msgid "New file [%s]"
 msgstr "Neue Datei [%s]\n"
 
-#: schematic/src/x_window.c:1598
 #, fuzzy, c-format
 msgid ""
 "<b>An error occurred while loading the requested file.</b>\n"
@@ -2386,904 +1874,694 @@ msgstr ""
 "Laden von '%s' ist gescheitert: %s. Das gschem log enthält eventuell mehr "
 "Details."
 
-#: schematic/src/x_window.c:1617
 msgid "Failed to load file"
 msgstr "Eine Datei konnte nicht geladen werden"
 
-#: schematic/data/lepton-schematic.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Schematic Editor"
 msgstr "gEDA – Schaltplanbearbeitung"
 
-#: schematic/data/lepton-schematic.desktop.in:4
 #, fuzzy
 msgid "Create and edit electrical schematics and symbols with lepton-schematic"
 msgstr ""
 "Erstellen oder editieren eines elektrischen Schaltplans oder Symbols mit "
 "gschem"
 
-#: schematic/scheme/conf/schematic/menu.scm:27
 msgid "_New"
 msgstr "_Neu"
 
-#: schematic/scheme/conf/schematic/menu.scm:28
 msgid "_Open..."
 msgstr "Ö_ffnen …"
 
-#: schematic/scheme/conf/schematic/menu.scm:30
 msgid "Open Recen_t"
 msgstr "_Zuletzt  geöffnet"
 
-#: schematic/scheme/conf/schematic/menu.scm:32
 msgid "_Save"
 msgstr "_Speichern"
 
-#: schematic/scheme/conf/schematic/menu.scm:33
 msgid "Save _As..."
 msgstr "Speichern _unter …"
 
-#: schematic/scheme/conf/schematic/menu.scm:34
-#: schematic/scheme/gschem/builtins.scm:65
 msgid "Save All"
 msgstr "_Alles speichern"
 
-#: schematic/scheme/conf/schematic/menu.scm:36
 msgid "_Print..."
 msgstr "_Drucken …"
 
-#: schematic/scheme/conf/schematic/menu.scm:37
 #, fuzzy
 msgid "Write _Image..."
 msgstr "Bild e_xportieren …"
 
-#: schematic/scheme/conf/schematic/menu.scm:39
 #, fuzzy
 msgid "Invoke Macro..."
 msgstr "Makro ausführen"
 
-#: schematic/scheme/conf/schematic/menu.scm:41
 msgid "REPL..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:43
-#: schematic/scheme/gschem/builtins.scm:77
 msgid "New Window"
 msgstr "Neues _Fenster"
 
-#: schematic/scheme/conf/schematic/menu.scm:44
 msgid "_Close Window"
 msgstr "Fenster s_chließen"
 
-#: schematic/scheme/conf/schematic/menu.scm:45
 msgid "_Quit"
 msgstr "_Beenden"
 
-#: schematic/scheme/conf/schematic/menu.scm:51
 msgid "_Undo"
 msgstr "_Rückgängig"
 
-#: schematic/scheme/conf/schematic/menu.scm:52
 msgid "_Redo"
 msgstr "_Wiederherstellen"
 
-#: schematic/scheme/conf/schematic/menu.scm:54
 msgid "Cu_t"
 msgstr "_Ausschneiden"
 
-#: schematic/scheme/conf/schematic/menu.scm:55
 msgid "_Copy"
 msgstr "_Kopieren"
 
-#: schematic/scheme/conf/schematic/menu.scm:56
 msgid "_Paste"
 msgstr "E_infügen"
 
-#: schematic/scheme/conf/schematic/menu.scm:57
 msgid "_Delete"
 msgstr "_Löschen"
 
-#: schematic/scheme/conf/schematic/menu.scm:60
-#: schematic/scheme/gschem/builtins.scm:102
 msgid "Select All"
 msgstr "Alles auswählen"
 
-#: schematic/scheme/conf/schematic/menu.scm:61
-#: schematic/scheme/gschem/builtins.scm:105
 msgid "Deselect"
 msgstr "Auswahl aufheben"
 
-#: schematic/scheme/conf/schematic/menu.scm:65
 msgid "Rotate 90 Mode"
 msgstr "Drehmodus (90°)"
 
-#: schematic/scheme/conf/schematic/menu.scm:70
 msgid "Edit Text..."
 msgstr "Text bearbeiten …"
 
-#: schematic/scheme/conf/schematic/menu.scm:71
 msgid "Slot..."
 msgstr "Slot …"
 
-#: schematic/scheme/conf/schematic/menu.scm:76
-#: schematic/scheme/gschem/builtins.scm:150
 msgid "Embed Component/Picture"
 msgstr "Bauteil/Bild einbetten"
 
-#: schematic/scheme/conf/schematic/menu.scm:77
-#: schematic/scheme/gschem/builtins.scm:153
 msgid "Unembed Component/Picture"
 msgstr "Bauteil/Bild ausbetten"
 
-#: schematic/scheme/conf/schematic/menu.scm:78
-#: schematic/scheme/gschem/builtins.scm:156
 msgid "Update Component"
 msgstr "Bauteil aktualisieren"
 
-#: schematic/scheme/conf/schematic/menu.scm:79
 msgid "Symbol Translate..."
 msgstr "Symbol transferieren …"
 
-#: schematic/scheme/conf/schematic/menu.scm:85
 msgid "Copy into 1"
 msgstr "Kopieren in 1"
 
-#: schematic/scheme/conf/schematic/menu.scm:86
 msgid "Copy into 2"
 msgstr "Kopieren in 2"
 
-#: schematic/scheme/conf/schematic/menu.scm:87
 msgid "Copy into 3"
 msgstr "Kopieren in 3"
 
-#: schematic/scheme/conf/schematic/menu.scm:88
 msgid "Copy into 4"
 msgstr "Kopieren in 4"
 
-#: schematic/scheme/conf/schematic/menu.scm:89
 msgid "Copy into 5"
 msgstr "Kopieren in 5"
 
-#: schematic/scheme/conf/schematic/menu.scm:90
 msgid "Cut into 1"
 msgstr "Ausschneiden in 1"
 
-#: schematic/scheme/conf/schematic/menu.scm:91
 msgid "Cut into 2"
 msgstr "Ausschneiden in 2"
 
-#: schematic/scheme/conf/schematic/menu.scm:92
 msgid "Cut into 3"
 msgstr "Ausschneiden in 3"
 
-#: schematic/scheme/conf/schematic/menu.scm:93
 msgid "Cut into 4"
 msgstr "Ausschneiden in 4"
 
-#: schematic/scheme/conf/schematic/menu.scm:94
 msgid "Cut into 5"
 msgstr "Ausschneiden in 5"
 
-#: schematic/scheme/conf/schematic/menu.scm:95
 msgid "Paste from 1"
 msgstr "Einfügen aus 1"
 
-#: schematic/scheme/conf/schematic/menu.scm:96
 msgid "Paste from 2"
 msgstr "Einfügen aus 2"
 
-#: schematic/scheme/conf/schematic/menu.scm:97
 msgid "Paste from 3"
 msgstr "Einfügen aus 3"
 
-#: schematic/scheme/conf/schematic/menu.scm:98
 msgid "Paste from 4"
 msgstr "Einfügen aus 4"
 
-#: schematic/scheme/conf/schematic/menu.scm:99
 msgid "Paste from 5"
 msgstr "Einfügen aus 5"
 
-#: schematic/scheme/conf/schematic/menu.scm:105
 msgid "Side Dock"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:106
 #, fuzzy
 msgid "Bottom Dock"
 msgstr "Von unten nach oben"
 
-#: schematic/scheme/conf/schematic/menu.scm:108
 #, fuzzy
 msgid "Find Text Results"
 msgstr "Text suchen"
 
-#: schematic/scheme/conf/schematic/menu.scm:110
 msgid "_Redraw"
 msgstr "Akt_ualisieren"
 
-#: schematic/scheme/conf/schematic/menu.scm:111
 msgid "_Pan"
 msgstr "Ausschnitt _wechseln"
 
-#: schematic/scheme/conf/schematic/menu.scm:112
 msgid "Zoom _Box"
 msgstr "_Rechteck auswählen"
 
-#: schematic/scheme/conf/schematic/menu.scm:113
 msgid "Zoom _Extents"
 msgstr "_Alles anzeigen"
 
-#: schematic/scheme/conf/schematic/menu.scm:114
 msgid "Zoom _In"
 msgstr "Ver_größern"
 
-#: schematic/scheme/conf/schematic/menu.scm:115
 msgid "Zoom _Out"
 msgstr "Ver_kleinern"
 
-#: schematic/scheme/conf/schematic/menu.scm:116
 msgid "Zoom _Full"
 msgstr "Gesamte _Zeichenfläche"
 
-#: schematic/scheme/conf/schematic/menu.scm:118
 #, fuzzy
 msgid "_Dark Color Scheme"
 msgstr "_Dunkles Farbschema"
 
-#: schematic/scheme/conf/schematic/menu.scm:119
 #, fuzzy
 msgid "_Light Color Scheme"
 msgstr "_Helles Farbschema"
 
-#: schematic/scheme/conf/schematic/menu.scm:120
 #, fuzzy
 msgid "B_W Color Scheme"
 msgstr "Schwarz/Weiß"
 
-#: schematic/scheme/conf/schematic/menu.scm:122
 #, fuzzy
 msgid "Color Scheme Editor..."
 msgstr "_Helles Farbschema"
 
-#: schematic/scheme/conf/schematic/menu.scm:129
 msgid "_Manager..."
 msgstr "Ver_waltung …"
 
-#: schematic/scheme/conf/schematic/menu.scm:131
 msgid "_Previous"
 msgstr "_Vorherige"
 
-#: schematic/scheme/conf/schematic/menu.scm:132
 msgid "_Next"
 msgstr "_Nächste"
 
-#: schematic/scheme/conf/schematic/menu.scm:133
 msgid "_Close"
 msgstr "S_chließen"
 
-#: schematic/scheme/conf/schematic/menu.scm:135
 #, fuzzy
 msgid "_Revert..."
 msgstr "Neu _laden"
 
-#: schematic/scheme/conf/schematic/menu.scm:137
-#: schematic/scheme/gschem/builtins.scm:249
 #, fuzzy
 msgid "Next Tab"
 msgstr "Neue Seite"
 
-#: schematic/scheme/conf/schematic/menu.scm:138
-#: schematic/scheme/gschem/builtins.scm:252
 #, fuzzy
 msgid "Previous Tab"
 msgstr "_Vorherige"
 
-#: schematic/scheme/conf/schematic/menu.scm:146
 msgid "_Component..."
 msgstr "_Bauteil …"
 
-#: schematic/scheme/conf/schematic/menu.scm:148
 msgid "_Net"
 msgstr "_Netz"
 
-#: schematic/scheme/conf/schematic/menu.scm:149
 msgid "B_us"
 msgstr "B_us"
 
-#: schematic/scheme/conf/schematic/menu.scm:151
 msgid "_Attribute..."
 msgstr "_Attribut …"
 
-#: schematic/scheme/conf/schematic/menu.scm:152
 msgid "_Text..."
 msgstr "_Text …"
 
-#: schematic/scheme/conf/schematic/menu.scm:154
 msgid "_Line"
 msgstr "_Linie"
 
-#: schematic/scheme/conf/schematic/menu.scm:155
 msgid "Pat_h"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:156
 msgid "_Box"
 msgstr "_Rechteck"
 
-#: schematic/scheme/conf/schematic/menu.scm:157
 msgid "C_ircle"
 msgstr "_Kreis"
 
-#: schematic/scheme/conf/schematic/menu.scm:158
 msgid "A_rc"
 msgstr "Kreisb_ogen"
 
-#: schematic/scheme/conf/schematic/menu.scm:159
 msgid "_Pin"
 msgstr "_Pin"
 
-#: schematic/scheme/conf/schematic/menu.scm:161
 msgid "Pictu_re..."
 msgstr "B_ild …"
 
-#: schematic/scheme/conf/schematic/menu.scm:167
 msgid "_Up"
 msgstr "_Hinauf"
 
-#: schematic/scheme/conf/schematic/menu.scm:169
 msgid "_Down Schematic"
 msgstr "Zum _Schaltplan hinab"
 
-#: schematic/scheme/conf/schematic/menu.scm:170
 msgid "Down _Symbol"
 msgstr "Zum S_ymbol hinab"
 
-#: schematic/scheme/conf/schematic/menu.scm:176
 msgid "_Attach"
 msgstr "_Anbringen"
 
-#: schematic/scheme/conf/schematic/menu.scm:177
 msgid "_Detach"
 msgstr "_Loslösen"
 
-#: schematic/scheme/conf/schematic/menu.scm:179
 msgid "Show _Value"
 msgstr "_Wert anzeigen"
 
-#: schematic/scheme/conf/schematic/menu.scm:180
 msgid "Show _Name"
 msgstr "_Name anzeigen"
 
-#: schematic/scheme/conf/schematic/menu.scm:181
 msgid "Show _Both"
 msgstr "_Beide anzeigen"
 
-#: schematic/scheme/conf/schematic/menu.scm:182
 msgid "_Toggle Visibility"
 msgstr "Sichtbarkeit _umschalten"
 
-#: schematic/scheme/conf/schematic/menu.scm:184
 msgid "_Hide Specific Text..."
 msgstr "Text _verbergen …"
 
-#: schematic/scheme/conf/schematic/menu.scm:185
 msgid "_Show Specific Text..."
 msgstr "Text an_zeigen …"
 
-#: schematic/scheme/conf/schematic/menu.scm:186
 #, fuzzy
 msgid "Show/Hide Hidden Text"
 msgstr "Unsichtbaren Text anzeigen/verbergen"
 
-#: schematic/scheme/conf/schematic/menu.scm:188
 msgid "_Find Text/Check Symbol..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:189
 msgid "A_utonumber Text..."
 msgstr "Text _durchnummerieren …"
 
-#: schematic/scheme/conf/schematic/menu.scm:195
 #, fuzzy
 msgid "_Options..."
 msgstr "_Optionen"
 
-#: schematic/scheme/conf/schematic/menu.scm:196
 #, fuzzy
 msgid "_Font..."
 msgstr "_Drucken …"
 
-#: schematic/scheme/conf/schematic/menu.scm:198
 #, fuzzy
 msgid "Grid +"
 msgstr "Raster AUS\n"
 
-#: schematic/scheme/conf/schematic/menu.scm:199
 #, fuzzy
 msgid "Grid -"
 msgstr "Raster AUS\n"
 
-#: schematic/scheme/conf/schematic/menu.scm:201
 msgid "Grid Style: Cycle Dots/Mesh/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:202
 msgid "Grid Snap: Cycle Grid/Resnap/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:204
 #, fuzzy
 msgid "Feedback Mode: Outline/Box"
 msgstr "_Umrissanzeige umschalten"
 
-#: schematic/scheme/conf/schematic/menu.scm:205
 #, fuzzy
 msgid "Net: Rubberband On/Off"
 msgstr "Gummifäden EIN\n"
 
-#: schematic/scheme/conf/schematic/menu.scm:206
 msgid "Net: Magnetic On/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:208
 #, fuzzy
 msgid "_Coord Window"
 msgstr "Fenster s_chließen"
 
-#: schematic/scheme/conf/schematic/menu.scm:209
 #, fuzzy
 msgid "_Log Window"
 msgstr "Protoko_llfenster anzeigen …"
 
-#: schematic/scheme/conf/schematic/menu.scm:215
 msgid "_1 allegro"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:223
 #, fuzzy
 msgid "User _Guide"
 msgstr "gschem-_FAQ …"
 
-#: schematic/scheme/conf/schematic/menu.scm:224
 msgid "_FAQ"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:225
 #, fuzzy
 msgid "Docu_mentation"
 msgstr "_Dokumentation …"
 
-#: schematic/scheme/conf/schematic/menu.scm:226
 msgid "_Wiki"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:228
 #, fuzzy
 msgid "Find Component D_ocumentation"
 msgstr "Bauteil-D_okumentation …"
 
-#: schematic/scheme/conf/schematic/menu.scm:230
 msgid "_Hotkeys..."
 msgstr "_Tastenbelegungen …"
 
-#: schematic/scheme/conf/schematic/menu.scm:231
 #, fuzzy
 msgid "_About"
 msgstr "_Info …"
 
-#: schematic/scheme/conf/schematic/menu.scm:237
 msgid "_File"
 msgstr "_Datei"
 
-#: schematic/scheme/conf/schematic/menu.scm:238
 msgid "_Edit"
 msgstr "_Bearbeiten"
 
-#: schematic/scheme/conf/schematic/menu.scm:240
 msgid "_View"
 msgstr "_Ansicht"
 
-#: schematic/scheme/conf/schematic/menu.scm:241
 msgid "_Page"
 msgstr "_Seite"
 
-#: schematic/scheme/conf/schematic/menu.scm:242
 msgid "_Add"
 msgstr "_Einfügen"
 
-#: schematic/scheme/conf/schematic/menu.scm:243
 msgid "Hie_rarchy"
 msgstr "Hie_rarchie"
 
-#: schematic/scheme/conf/schematic/menu.scm:244
 msgid "A_ttributes"
 msgstr "A_ttribut"
 
-#: schematic/scheme/conf/schematic/menu.scm:245
 msgid "_Options"
 msgstr "_Optionen"
 
-#: schematic/scheme/conf/schematic/menu.scm:246
 #, fuzzy
 msgid "_Netlist"
 msgstr "_Netz"
 
-#: schematic/scheme/conf/schematic/menu.scm:247
 msgid "_Help"
 msgstr "_Hilfe"
 
-#: schematic/scheme/gschem/action.scm:43
 #, fuzzy, scheme-format
 msgid "~S is not a valid gschem action."
 msgstr "~S ist keine gültige Tasten-Kombination."
 
-#: schematic/scheme/gschem/action.scm:158
 msgid "Repeat Last Action"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:47
 #, fuzzy
 msgid "Cancel"
 msgstr "Ausschnitt/Abbrechen"
 
-#: schematic/scheme/gschem/builtins.scm:53
 #, fuzzy
 msgid "New File"
 msgstr "Neue Datei"
 
-#: schematic/scheme/gschem/builtins.scm:56
 #, fuzzy
 msgid "Open File"
 msgstr "Datei öffnen …"
 
-#: schematic/scheme/gschem/builtins.scm:62
 #, fuzzy
 msgid "Save As"
 msgstr "_Alles speichern"
 
-#: schematic/scheme/gschem/builtins.scm:68
 #, fuzzy
 msgid "Print"
 msgstr "Drucken …"
 
-#: schematic/scheme/gschem/builtins.scm:71
 msgid "Export Image"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:74
 msgid "Run Script"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:80
 #, fuzzy
 msgid "Close Window"
 msgstr "Fenster s_chließen"
 
-#: schematic/scheme/gschem/builtins.scm:83
 #, fuzzy
 msgid "Quit"
 msgstr "_Beenden"
 
-#: schematic/scheme/gschem/builtins.scm:87
 msgid "Terminal REPL"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:132
 msgid "Choose Slot"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:135
 #, fuzzy
 msgid "Edit Object Properties"
 msgstr "Text Eigenschaften bearbeiten"
 
-#: schematic/scheme/gschem/builtins.scm:138
 #, fuzzy
 msgid "Translate Symbol"
 msgstr "Verschieben nach"
 
-#: schematic/scheme/gschem/builtins.scm:147
 msgid "Invoke Macro"
 msgstr "Makro ausführen"
 
-#: schematic/scheme/gschem/builtins.scm:159
 #, fuzzy
 msgid "Show/Hide Invisible Text"
 msgstr "Unsichtbaren Text anzeigen/verbergen"
 
-#: schematic/scheme/gschem/builtins.scm:165
 #, fuzzy
 msgid "Cut"
 msgstr "_Ausschneiden"
 
-#: schematic/scheme/gschem/builtins.scm:171
 #, fuzzy
 msgid "Paste"
 msgstr "E_infügen"
 
-#: schematic/scheme/gschem/builtins.scm:177
 msgid "Sidebar"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:183
 #, fuzzy
 msgid "Find Text State"
 msgstr "Text suchen"
 
-#: schematic/scheme/gschem/builtins.scm:186
 #, fuzzy
 msgid "Redraw"
 msgstr "Akt_ualisieren"
 
-#: schematic/scheme/gschem/builtins.scm:192
 #, fuzzy
 msgid "Pan Left"
 msgstr "Ausschnittmodus"
 
-#: schematic/scheme/gschem/builtins.scm:195
 #, fuzzy
 msgid "Pan Right"
 msgstr "0ben Rechts"
 
-#: schematic/scheme/gschem/builtins.scm:198
 msgid "Pan Up"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:201
 #, fuzzy
 msgid "Pan Down"
 msgstr "Ausschnittmodus"
 
-#: schematic/scheme/gschem/builtins.scm:216
 #, fuzzy
 msgid "Zoom Full"
 msgstr "Gesamte _Zeichenfläche"
 
-#: schematic/scheme/gschem/builtins.scm:219
 #, fuzzy
 msgid "Dark Color Scheme"
 msgstr "_Dunkles Farbschema"
 
-#: schematic/scheme/gschem/builtins.scm:222
 #, fuzzy
 msgid "Light Color Scheme"
 msgstr "_Helles Farbschema"
 
-#: schematic/scheme/gschem/builtins.scm:225
 msgid "Monochrome Color Scheme"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:228
 #, fuzzy
 msgid "Show Color Scheme Editor"
 msgstr "_Helles Farbschema"
 
-#: schematic/scheme/gschem/builtins.scm:234
 #, fuzzy
 msgid "Revert Changes"
 msgstr "Seite wirklich wiederherstellen?"
 
-#: schematic/scheme/gschem/builtins.scm:240
 #, fuzzy
 msgid "Previous Page"
 msgstr "_Vorherige"
 
-#: schematic/scheme/gschem/builtins.scm:243
 #, fuzzy
 msgid "Next Page"
 msgstr "Neue Seite"
 
-#: schematic/scheme/gschem/builtins.scm:255
 #, fuzzy
 msgid "Print Page"
 msgstr "_Vorherige"
 
-#: schematic/scheme/gschem/builtins.scm:276
 #, fuzzy
 msgid "Add Line"
 msgstr "Linie"
 
-#: schematic/scheme/gschem/builtins.scm:279
 #, fuzzy
 msgid "Add Path"
 msgstr "/Netz einfügen"
 
-#: schematic/scheme/gschem/builtins.scm:282
 #, fuzzy
 msgid "Add Box"
 msgstr "/Bus einfügen"
 
-#: schematic/scheme/gschem/builtins.scm:285
 #, fuzzy
 msgid "Add Circle"
 msgstr "Kreis"
 
-#: schematic/scheme/gschem/builtins.scm:288
 #, fuzzy
 msgid "Add Arc"
 msgstr "Attribut hinzufügen"
 
-#: schematic/scheme/gschem/builtins.scm:291
 msgid "Add Pin"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:294
 #, fuzzy
 msgid "Add Picture"
 msgstr "Bild"
 
-#: schematic/scheme/gschem/builtins.scm:306
 #, fuzzy
 msgid "Up Hierarchy"
 msgstr "Hie_rarchie"
 
-#: schematic/scheme/gschem/builtins.scm:312
 #, fuzzy
 msgid "Attach Attributes"
 msgstr "Attribute bearbeiten"
 
-#: schematic/scheme/gschem/builtins.scm:315
 #, fuzzy
 msgid "Detach Attributes"
 msgstr "Attribut ablösen"
 
-#: schematic/scheme/gschem/builtins.scm:318
 #, fuzzy
 msgid "Show Attribute Value"
 msgstr "Slot Attribut ist fehlerhaft.\n"
 
-#: schematic/scheme/gschem/builtins.scm:321
 #, fuzzy
 msgid "Show Attribute Name"
 msgstr "Slot Attribut ist fehlerhaft.\n"
 
-#: schematic/scheme/gschem/builtins.scm:327
 #, fuzzy
 msgid "Toggle Text Visibility"
 msgstr "Sichtbarkeit _umschalten"
 
-#: schematic/scheme/gschem/builtins.scm:330
 #, fuzzy
 msgid "Find Specific Text"
 msgstr "Text _suchen …"
 
-#: schematic/scheme/gschem/builtins.scm:333
 #, fuzzy
 msgid "Hide Specific Text"
 msgstr "Text _verbergen …"
 
-#: schematic/scheme/gschem/builtins.scm:336
 #, fuzzy
 msgid "Show Specific Text"
 msgstr "Text an_zeigen …"
 
-#: schematic/scheme/gschem/builtins.scm:339
 #, fuzzy
 msgid "Autonumber Text"
 msgstr "Nummeriere Text automatisch"
 
-#: schematic/scheme/gschem/builtins.scm:345
 #, fuzzy
 msgid "Show Hotkeys"
 msgstr "Tastenbelegungen"
 
-#: schematic/scheme/gschem/builtins.scm:348
 msgid "Switch Grid Style"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:351
 msgid "Switch Snap Mode"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:354
 #, fuzzy
 msgid "Set Grid Spacing"
 msgstr "Rasterabstand ver_größern"
 
-#: schematic/scheme/gschem/builtins.scm:357
 #, fuzzy
 msgid "Increase Grid Spacing"
 msgstr "Rasterabstand ver_größern"
 
-#: schematic/scheme/gschem/builtins.scm:360
 #, fuzzy
 msgid "Decrease Grid Spacing"
 msgstr "Rasterabstand ver_größern"
 
-#: schematic/scheme/gschem/builtins.scm:363
 #, fuzzy
 msgid "Toggle Outline Drawing"
 msgstr "_Umrissanzeige umschalten"
 
-#: schematic/scheme/gschem/builtins.scm:366
 #, fuzzy
 msgid "Toggle Net Rubber Band"
 msgstr "_Netzgummifäden umschalten"
 
-#: schematic/scheme/gschem/builtins.scm:369
 #, fuzzy
 msgid "Toggle Magnetic Nets"
 msgstr "_Magnetischen Netzmodus umschalten"
 
-#: schematic/scheme/gschem/builtins.scm:372
 #, fuzzy
 msgid "Show Log Window"
 msgstr "Protoko_llfenster anzeigen …"
 
-#: schematic/scheme/gschem/builtins.scm:375
 #, fuzzy
 msgid "Show Coordinate Window"
 msgstr "K_oordinatenfenster anzeigen …"
 
-#: schematic/scheme/gschem/builtins.scm:385
 #, fuzzy
 msgid "Component Documentation"
 msgstr "Bauteil-D_okumentation …"
 
-#: schematic/scheme/gschem/builtins.scm:387
 msgid "View documentation for selected component"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:403
 msgid ""
 "Could not show documentation for selected component:\n"
 "\n"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:408
 msgid "gEDA Manuals"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:409
 msgid "View the front page of the gEDA documentation in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:414
 #, fuzzy
 msgid "gschem User Guide"
 msgstr "gschem-_FAQ …"
 
-#: schematic/scheme/gschem/builtins.scm:415
 msgid "View the gschem User Guide in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:420
 #, fuzzy
 msgid "gschem FAQ"
 msgstr "gschem-_FAQ …"
 
-#: schematic/scheme/gschem/builtins.scm:421
 msgid "Frequently Asked Questions about using gschem."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:426
 #, fuzzy
 msgid "gEDA wiki"
 msgstr "gEDA-_Wiki …"
 
-#: schematic/scheme/gschem/builtins.scm:427
 msgid "View the front page of the gEDA wiki in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:431
 msgid "About gschem"
 msgstr "Über gschem"
 
-#: schematic/scheme/gschem/deprecated.scm:102
 #, scheme-format
 msgid "Invalid text alignment ~A."
 msgstr "Ungültige Ausrichtung: ~A."
 
-#: schematic/scheme/gschem/gschemdoc.scm:241
 msgid "No documentation found"
 msgstr "Dokumentation konnte nicht gefunden werden"
 
-#: schematic/scheme/gschem/keymap.scm:40
 #, scheme-format
 msgid "~S is not a valid key combination."
 msgstr "~S ist keine gültige Tasten-Kombination."
 
-#: schematic/scheme/gschem/keymap.scm:157
 #, scheme-format
 msgid "~S is not a prefix key sequence."
 msgstr "~S ist kein gültiger erster Teil einer Tastenkombination."

--- a/schematic/po/el.po
+++ b/schematic/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-15 15:13+0300\n"
+"POT-Creation-Date: 2019-02-22 14:08+0300\n"
 "PO-Revision-Date: 2012-09-01 20:41+0000\n"
 "Last-Translator: Panos Bouklis <panos@echidna-band.com>\n"
 "Language-Team: Greek <el@li.org>\n"
@@ -18,23 +18,19 @@ msgstr ""
 "X-Launchpad-Export-Date: 2012-11-14 16:52+0000\n"
 "X-Generator: Launchpad (build 16265)\n"
 
-#: schematic/src/a_zoom.c:155
 msgid "Zoom too small!  Cannot zoom further."
 msgstr ""
 
-#: schematic/src/color_edit_widget.c:399
 #, fuzzy, c-format
 msgid ""
 "Could not save file [%s]:\n"
 "%s"
 msgstr "ΔΕΝ ήταν δυνατή η αποθήκευση της σελίδας [%s]\n"
 
-#: schematic/src/color_edit_widget.c:434
 #, fuzzy
 msgid "Save Color Scheme As..."
 msgstr "Σχήμα _φωτεινών χρωμάτων"
 
-#: schematic/src/color_edit_widget.c:482 schematic/src/x_fileselect.c:292
 #, fuzzy, c-format
 msgid ""
 "The selected file `%1$s' already exists.\n"
@@ -45,187 +41,149 @@ msgstr ""
 "\n"
 "Θέλετε να το αντικαταστήσετε;"
 
-#: schematic/src/color_edit_widget.c:486 schematic/src/x_fileselect.c:295
 msgid "Overwrite file?"
 msgstr "Αντικατάσταση αρχείου;"
 
-#: schematic/src/font_select_widget.c:211
 msgid "_Apply"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:215
 msgid "Sa_ve..."
 msgstr ""
 
-#: schematic/src/font_select_widget.c:278
 #, c-format
 msgid "<b>Current:</b> %s"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:453
 msgid "Save configuration"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:461
 #, fuzzy
 msgid "Save settings to:"
 msgstr "Ρυθμίσεις"
 
-#: schematic/src/font_select_widget.c:465
 msgid "Local configuration file (in current directory)"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:467
 msgid "User configuration file (geda-user.conf)"
 msgstr ""
 
-#: schematic/src/g_attrib.c:90
 msgid "Object ~A is not included in the current gschem page."
 msgstr "Το αντικείμενο ~A δεν περιλαμβάνεται στην τρέχουσα gschem."
 
-#: schematic/src/g_attrib.c:110
 msgid "Invalid text name/value visibility ~A."
 msgstr "Μη έγκυρο όνομα/τιμή ορατότητας ~A."
 
-#: schematic/src/g_rc.c:107
 #, fuzzy, c-format
 msgid "You are running gEDA/gaf version [%1$s%2$s.%3$s],\n"
 msgstr "gEDA/gschem έκδοση %s%s.%s\n"
 
-#: schematic/src/g_rc.c:111
 #, c-format
 msgid ""
 "but you have a version [%1$s] gschemrc file:\n"
 "[%2$s]\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:114
 #, c-format
 msgid "Please be sure that you have the latest rc file.\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:240
 #, fuzzy, c-format
 msgid "Invalid size [%1$d] passed to text-size\n"
 msgstr "Δόθηκε μη έγκυρο μέγεθος [%d] στο μέγεθος κειμένου\n"
 
-#: schematic/src/g_rc.c:283
 #, fuzzy, c-format
 msgid "Invalid size [%1$d] passed to snap-size\n"
 msgstr "Δόθηκε μη έγκυρο μέγεθος [%d] στο μέγεθος κειμένου\n"
 
-#: schematic/src/g_rc.c:620
 #, fuzzy, c-format
 msgid "Invalid num levels [%1$d] passed to undo-levels\n"
 msgstr ""
 "Δόθηκε μη έγκυρος αριθμός δευτερολέπτων [%d] στο διάστημα αυτόματης "
 "αποθήκευσης\n"
 
-#: schematic/src/g_rc.c:831
 #, fuzzy, c-format
 msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
 msgstr "Δόθηκε μη έγκυρο μέγεθος [%d] στο μέγεθος κειμένου\n"
 
-#: schematic/src/g_rc.c:931
 #, fuzzy, c-format
 msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
 msgstr "Δόθηκε μη έγκυρο μέγεθος [%d] στο μέγεθος κειμένου\n"
 
-#: schematic/src/g_rc.c:972
 #, fuzzy, c-format
 msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
 msgstr "Δόθηκε μη έγκυρο μέγεθος [%d] στο μέγεθος κειμένου\n"
 
-#: schematic/src/g_rc.c:998
 #, c-format
 msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1023
 #, fuzzy, c-format
 msgid "Invalid offset [%1$d] passed to add-attribute-offset\n"
 msgstr "Δόθηκε μη έγκυρο μέγεθος [%d] στο μέγεθος κειμένου\n"
 
-#: schematic/src/g_rc.c:1047
 #, fuzzy, c-format
 msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
 msgstr ""
 "Δόθηκε μη έγκυρος αριθμός δευτερολέπτων [%d] στο διάστημα αυτόματης "
 "αποθήκευσης\n"
 
-#: schematic/src/g_rc.c:1071
 #, fuzzy, c-format
 msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
 msgstr "Δόθηκε μη έγκυρο μέγεθος [%d] στο μέγεθος κειμένου\n"
 
-#: schematic/src/g_rc.c:1094
 #, fuzzy, c-format
 msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
 msgstr "Δόθηκε μη έγκυρο μέγεθος [%d] στο μέγεθος κειμένου\n"
 
-#: schematic/src/g_rc.c:1118
 #, fuzzy, c-format
 msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
 msgstr ""
 "Δόθηκε μη έγκυρος αριθμός δευτερολέπτων [%d] στο διάστημα αυτόματης "
 "αποθήκευσης\n"
 
-#: schematic/src/g_rc.c:1144
 #, fuzzy, c-format
 msgid "Invalid gain [%1$d] passed to zoom-gain\n"
 msgstr "Δόθηκε μη έγκυρο μέγεθος [%d] στο μέγεθος κειμένου\n"
 
-#: schematic/src/g_rc.c:1169
 #, fuzzy, c-format
 msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
 msgstr ""
 "Δόθηκε μη έγκυρος αριθμός δευτερολέπτων [%d] στο διάστημα αυτόματης "
 "αποθήκευσης\n"
 
-#: schematic/src/g_select.c:78 schematic/src/g_select.c:115
-#: schematic/src/g_select.c:151
 msgid "Object ~A is not directly included in a page."
 msgstr "Το αντικείμενο ~A δεν περιλαμβάνεται άμεσα σε μια σελίδα."
 
-#: schematic/src/g_util.c:54
 msgid "Could not launch URI ~S: ~A"
 msgstr "Αδυναμία εκτέλεσης URI ~S: ~A"
 
-#: schematic/src/g_window.c:139
 msgid "Found invalid gschem window smob ~S"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:156
 #, fuzzy, c-format
 msgid "Lepton EDA/lepton-schematic version %1$s%2$s.%3$s git: %4$.7s"
 msgstr "gEDA/gschem έκδοση %s%s.%s\n"
 
-#: schematic/src/lepton-schematic.c:163
 #, c-format
 msgid "This is the MINGW32 port.\n"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:167
 #, fuzzy, c-format
 msgid "Current locale settings: %1$s\n"
 msgstr "Τρέχουσες ρυθμίσεις τοπικότητας: %s\n"
 
-#: schematic/src/lepton-schematic.c:201
 #, c-format
 msgid "Couldn't find init scm file [%1$s]"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:206
 #, c-format
 msgid "Read init scm file [%1$s]"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:210
 #, fuzzy, c-format
 msgid "Failed to read init scm file [%1$s]"
 msgstr "Αποτυχία φορτώματος αρχείου"
 
-#: schematic/src/lepton-schematic.c:290
 #, fuzzy, c-format
 msgid ""
 "ERROR: Failed to load or evaluate startup script.\n"
@@ -236,145 +194,113 @@ msgstr ""
 "\n"
 "Η καταγραφή του gschem μπορεί να περιέχει περισσότερες πληροφορίες."
 
-#: schematic/src/gschem_about_dialog.c:51
 #, fuzzy, c-format
 msgid "%s (git: %.7s)"
 msgstr "%s (g%.7s)"
 
-#: schematic/src/gschem_about_dialog.c:75
 #, fuzzy
 msgid "Lepton Electronic Design Automation"
 msgstr "gEDA: Ηλεκτρονικός Αυτοματισμός Σχεδίασης GPL"
 
-#: schematic/src/gschem_about_dialog.c:83
 #, fuzzy
 msgid ""
 "Copyright © 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright © 2017-2018 Lepton Developers.\n"
-"See AUTHORS and ChangeLog files for details."
+"Copyright © 2017-2019 Lepton Developers.\n"
+"See AUTHORS, ChangeLog files and consult 'git log' history for details."
 msgstr ""
 "Πνευματικά δικαιώματα © 1998-2012 Ales Hvezda <ahvezda@geda.seul.org>\n"
 "Πνευματικά δικαιώματα © 1998-2012 προγραμματιστές του gEDA (δείτε το "
 "ChangeLog για λεπτομέρειες)"
 
-#: schematic/src/gschem_alignment_combo.c:69
 msgid "Upper Left"
 msgstr "Πάνω αριστερά"
 
-#: schematic/src/gschem_alignment_combo.c:71
 msgid "Upper Middle"
 msgstr "Πάνω μέση"
 
-#: schematic/src/gschem_alignment_combo.c:73
 #, fuzzy
 msgid "Upper Right"
 msgstr "Κάτω δεξιά"
 
-#: schematic/src/gschem_alignment_combo.c:78
 msgid "Middle Left"
 msgstr "Μέση αριστερά"
 
-#: schematic/src/gschem_alignment_combo.c:80
 msgid "Middle Middle"
 msgstr "Μέση μέση"
 
-#: schematic/src/gschem_alignment_combo.c:82
 msgid "Middle Right"
 msgstr "Μέση δεξιά"
 
-#: schematic/src/gschem_alignment_combo.c:87
 msgid "Lower Left"
 msgstr "Κάτω αριστερά"
 
-#: schematic/src/gschem_alignment_combo.c:89
 msgid "Lower Middle"
 msgstr "Κάτω μέση"
 
-#: schematic/src/gschem_alignment_combo.c:91
 msgid "Lower Right"
 msgstr "Κάτω δεξιά"
 
-#: schematic/src/gschem_arc_dialog.c:104
 msgid "Arc Params"
 msgstr "Παράμετροι τόξου"
 
-#: schematic/src/gschem_arc_dialog.c:140
 #, fuzzy
 msgid "Arc _Radius:"
 msgstr "Διάμετρος τόξου:"
 
-#: schematic/src/gschem_arc_dialog.c:141
 #, fuzzy
 msgid "Start _Angle:"
 msgstr "Γωνία εκκίνησης:"
 
-#: schematic/src/gschem_arc_dialog.c:142
 msgid "_Degrees of Sweep:"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:504
 msgid "Left mouse button"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:508
 #, fuzzy
 msgid "Middle mouse button"
 msgstr "Μέση αριστερά"
 
-#: schematic/src/gschem_bottom_widget.c:512
 #, fuzzy
 msgid "Right mouse button"
 msgstr ""
 "Λειτουργία προσθήκης δικτύου\n"
 "Δεξί κλικ για ακύρωση"
 
-#: schematic/src/gschem_bottom_widget.c:595
 msgid "(Snap size, Grid size)"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:603
 msgid "Net rubber band mode"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:614
 #, fuzzy
 msgid "Magnetic net mode"
 msgstr "Λειτουργία μαγνητικού δικτύου"
 
-#: schematic/src/gschem_bottom_widget.c:622
 #, fuzzy
 msgid "Current action mode"
 msgstr "Τρέχον παράθυρο"
 
-#: schematic/src/gschem_bottom_widget.c:935
-#: schematic/src/gschem_bottom_widget.c:951
 msgid "OFF"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:954
 msgid "NONE"
 msgstr "ΚΑΝΕΝΑ"
 
-#: schematic/src/gschem_bottom_widget.c:960
 #, c-format
 msgid "Grid(%1$s, %2$s)"
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:350
-#: schematic/src/x_compselect.c:1236 schematic/src/x_multiattrib.c:2068
 msgid "Name"
 msgstr "Όνομα"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:372
 msgid "S_elect the schematics you want to save:"
 msgstr "_Επιλέξετε τα σχεδιαγράμματα που θέλετε να αποθηκεύσετε:"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:467
 #, fuzzy, c-format
 msgid "Save the changes to schematic \"%1$s\" before closing?"
 msgstr "Αποθήκευση αλλαγών στο σχεδιάγραμμα \"%s\" πριν το κλείσιμο;"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:473
 #, fuzzy, c-format
 msgid ""
 "There are %1$d schematics with unsaved changes. Save changes before closing?"
@@ -382,582 +308,429 @@ msgstr ""
 "Υπάρχουν %d σχεδιαγράμματα χωρίς αποθηκευμένες αλλαγές. Να αποθηκευτούν οι "
 "αλλαγές πριν το κλείσιμο;"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:502
 msgid "If you don't save, all your changes will be permanently lost."
 msgstr "Αν δεν αποθηκεύσετε, όλες οι αλλαγές θα χαθούν μόνιμα."
 
-#: schematic/src/gschem_close_confirmation_dialog.c:522
 #, fuzzy
 msgid "Close _without saving"
 msgstr "_Κλείσιμο χωρίς αποθήκευση"
 
-#: schematic/src/gschem_coord_dialog.c:86
 msgid "Coords"
 msgstr "Συντεταγμένες"
 
-#: schematic/src/gschem_coord_dialog.c:106
 msgid "Screen"
 msgstr "Οθόνη"
 
-#: schematic/src/gschem_coord_dialog.c:115
 msgid "World"
 msgstr ""
 
-#: schematic/src/gschem_find_text_state.c:809 schematic/src/x_pagesel.c:432
 msgid "Filename"
 msgstr "Όνομα αρχείου"
 
-#: schematic/src/gschem_find_text_state.c:821 schematic/src/i_callbacks.c:1970
-#: schematic/src/x_colorcb.c:154 schematic/src/x_widgets.c:179
-#: schematic/src/x_window.c:1226 schematic/src/x_window.c:1440
 msgid "Text"
 msgstr "Κείμενο"
 
-#: schematic/src/gschem_find_text_widget.c:427
 msgid "descend into hierarchy"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:435
 #, fuzzy
 msgid "Find"
 msgstr "Εύρεση κειμένου"
 
-#: schematic/src/gschem_find_text_widget.c:557
 #, fuzzy
 msgid "Find Text:"
 msgstr "Εύρεση κειμένου"
 
-#: schematic/src/gschem_find_text_widget.c:564
 msgid "Find Pattern:"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:571
 #, fuzzy
 msgid "Find Regex:"
 msgstr "Εύρεση κειμένου"
 
-#: schematic/src/gschem_find_text_widget.c:578
 msgid "Check symbol:"
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:200
 msgid "Hotkeys"
 msgstr "Γρήγορα Πλήκτρα"
 
-#: schematic/src/gschem_hotkey_dialog.c:229
 msgid ""
 "Start typing action name or keystroke to filter the list.\n"
 "Type hotkeys as they are displayed in \"Keystroke(s)\" column."
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:233 schematic/src/x_compselect.c:1124
 #, fuzzy
 msgid "_Filter:"
 msgstr "Φίλτρο:"
 
-#: schematic/src/gschem_hotkey_dialog.c:259 schematic/src/i_basic.c:280
 msgid "Action"
 msgstr "Ενέργεια"
 
-#: schematic/src/gschem_hotkey_dialog.c:277
 msgid "Keystroke(s)"
 msgstr ""
 
-#: schematic/src/gschem_log_widget.c:177
 msgid "** Invalid UTF-8 in log message. See stderr or gschem.log.\n"
 msgstr ""
 "** Μη έγκυρο UTF-8 σε μήνυμα καταγραφής. Δείτε την καταγραφή του stderr ή "
 "του gschem.\n"
 
-#: schematic/src/gschem_log_widget.c:434
 #, fuzzy
 msgid "Clear log window?"
 msgstr "Κλείσιμο παραθύρου\n"
 
-#: schematic/src/gschem_log_widget.c:477
 #, fuzzy
 msgid "Clear Log _Window"
 msgstr "Εμφάνιση παραθύρου καταγραφής..."
 
-#: schematic/src/gschem_macro_widget.c:231
 msgid "Macro:"
 msgstr ""
 
-#: schematic/src/gschem_macro_widget.c:387
 #, fuzzy
 msgid "Evaluate"
 msgstr "Εκτίμηση:"
 
-#: schematic/src/gschem_object_properties_widget.c:172
 #, fuzzy
 msgid "_Fill Type:"
 msgstr "Τύπος γεμίσματος"
 
-#: schematic/src/gschem_object_properties_widget.c:173
 #, fuzzy
 msgid "Lin_e Width:"
 msgstr "Πλάτος γραμμής:"
 
-#: schematic/src/gschem_object_properties_widget.c:174
 #, fuzzy
 msgid "Angle _1:"
 msgstr "Γωνία 1:"
 
-#: schematic/src/gschem_object_properties_widget.c:175
 msgid "P_itch 1:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:176
 #, fuzzy
 msgid "Angle _2:"
 msgstr "Γωνία 2:"
 
-#: schematic/src/gschem_object_properties_widget.c:177
 msgid "Pitc_h 2:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:237
 #, fuzzy
 msgid "<b>Fill Properties</b>"
 msgstr "<b>Ιδιότητες κειμένου</b>"
 
-#: schematic/src/gschem_object_properties_widget.c:255
-#: schematic/src/gschem_text_properties_widget.c:258
-#: schematic/src/x_newtext.c:271
 #, fuzzy
 msgid "Colo_r:"
 msgstr "Χρώμα:"
 
-#: schematic/src/gschem_object_properties_widget.c:266
 #, fuzzy
 msgid "<b>General Properties</b>"
 msgstr "<b>Ιδιότητες κειμένου</b>"
 
-#: schematic/src/gschem_object_properties_widget.c:284
 #, fuzzy
 msgid "_Type:"
 msgstr "Τύπος:"
 
-#: schematic/src/gschem_object_properties_widget.c:285
 #, fuzzy
 msgid "_Width:"
 msgstr "Πλάτος:"
 
-#: schematic/src/gschem_object_properties_widget.c:286
 #, fuzzy
 msgid "Dash _Length:"
 msgstr "Μήκος παύλας:"
 
-#: schematic/src/gschem_object_properties_widget.c:287
 #, fuzzy
 msgid "Dash _Space:"
 msgstr "Κενό παύλας:"
 
-#: schematic/src/gschem_object_properties_widget.c:288
 msgid "C_ap style:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:333
 #, fuzzy
 msgid "<b>Line Properties</b>"
 msgstr "<b>Ιδιότητες κειμένου</b>"
 
-#: schematic/src/gschem_object_properties_widget.c:351
 #, fuzzy
 msgid "_Pin Type:"
 msgstr "Τύπος ακροδέκτη"
 
-#: schematic/src/gschem_object_properties_widget.c:362
 #, fuzzy
 msgid "<b>Pin Properties</b>"
 msgstr "<b>Ιδιότητες κειμένου</b>"
 
-#: schematic/src/gschem_options_widget.c:217
 msgid "_Off"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:220
 msgid "_Dots"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:223
 msgid "M_esh"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:245
 msgid "Net R_ubber Band Mode:"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:246
 #, fuzzy
 msgid "_Magnetic Net Mode:"
 msgstr "Λειτουργία μαγνητικού δικτύου"
 
-#: schematic/src/gschem_options_widget.c:250
-#: schematic/src/gschem_options_widget.c:251
 msgid "Enabled"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:265
 #, fuzzy
 msgid "<b>Net Options</b>"
 msgstr "<b>Επιλογές</b>"
 
-#: schematic/src/gschem_options_widget.c:282
 #, fuzzy
 msgid "Grid Mode:"
 msgstr "Λειτουργία τόξου"
 
-#: schematic/src/gschem_options_widget.c:283
 #, fuzzy
 msgid "Snap Mode:"
 msgstr "Λειτουργία ακροδεκτών"
 
-#: schematic/src/gschem_options_widget.c:284
 #, fuzzy
 msgid "_Snap Size:"
 msgstr "Μέγεθος:"
 
-#: schematic/src/gschem_options_widget.c:301
 #, fuzzy
 msgid "<b>Snap Options</b>"
 msgstr "<b>Επιλογές</b>"
 
-#: schematic/src/gschem_options_widget.c:340
 msgid "O_ff"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:343
 #, fuzzy
 msgid "_Grid"
 msgstr "Λειτουργία τόξου"
 
-#: schematic/src/gschem_options_widget.c:346
 msgid "_Resnap"
 msgstr ""
 
-#: schematic/src/gschem_pin_type_combo.c:73
 msgid "Net pin"
 msgstr "Ακροδέκτης δικτύου"
 
-#: schematic/src/gschem_pin_type_combo.c:80
 msgid "Bus pin (graphical)"
 msgstr "Ακροδέκτης διαύλου (γραφικός)"
 
-#: schematic/src/gschem_preview.c:195
 msgid "Preview Buffer"
 msgstr "Ενδιάμεση μνήμη προεπισκόπησης"
 
-#: schematic/src/gschem_show_hide_text_widget.c:148
-#: schematic/src/x_window.c:1268
 #, fuzzy
 msgid "Hide"
 msgstr "Απόκρυψη κειμένου"
 
-#: schematic/src/gschem_show_hide_text_widget.c:157
-#: schematic/src/x_window.c:1269
 msgid "Hide text starting with:"
 msgstr "Απόκρυψη κειμένου που ξεκινάει με:"
 
-#: schematic/src/gschem_slot_edit_dialog.c:91
 msgid "Edit slot number"
 msgstr "Επεξεργασία αριθμού υποδοχής"
 
-#: schematic/src/gschem_slot_edit_dialog.c:121
 msgid "Number of Slots:"
 msgstr ""
 
-#: schematic/src/gschem_slot_edit_dialog.c:122
 #, fuzzy
 msgid "Slot Number:"
 msgstr "Επεξεργασία αριθμού υποδοχής:"
 
-#: schematic/src/gschem_text_properties_widget.c:240
-#: schematic/src/x_newtext.c:265
 msgid "<b>Text Content</b>"
 msgstr "<b>Περιεχόμενο κειμένου</b>"
 
-#: schematic/src/gschem_text_properties_widget.c:259
-#: schematic/src/x_newtext.c:291
 #, fuzzy
 msgid "_Size:"
 msgstr "Μέγεθος:"
 
-#: schematic/src/gschem_text_properties_widget.c:260
-#: schematic/src/x_newtext.c:310
 #, fuzzy
 msgid "Ali_gnment:"
 msgstr "Στοίχιση:"
 
-#: schematic/src/gschem_text_properties_widget.c:261
-#: schematic/src/x_newtext.c:330
 #, fuzzy
 msgid "Ro_tation:"
 msgstr "Προσανατολισμός:"
 
-#: schematic/src/gschem_text_properties_widget.c:294
-#: schematic/src/x_newtext.c:253
 msgid "<b>Text Properties</b>"
 msgstr "<b>Ιδιότητες κειμένου</b>"
 
-#: schematic/src/gschem_translate_widget.c:238
 #, fuzzy
 msgid "Coordinate:"
 msgstr "Εμφάνιση παραθύρου συντεταγμένων..."
 
-#: schematic/src/gschem_translate_widget.c:405 schematic/src/i_callbacks.c:800
 msgid "Translate"
 msgstr "Μετάφραση"
 
-#: schematic/src/i_basic.c:64 schematic/src/x_window.c:1369
-#: schematic/scheme/conf/schematic/menu.scm:59
-#: schematic/scheme/gschem/builtins.scm:99
 msgid "Select Mode"
 msgstr "Λειτουργία Επιλογής"
 
-#: schematic/src/i_basic.c:65
 #, fuzzy
 msgid "Select Box Mode"
 msgstr "Λειτουργία Επιλογής"
 
-#: schematic/src/i_basic.c:66
 msgid "Text Mode"
 msgstr "Λειτουργία κειμένου"
 
-#: schematic/src/i_basic.c:67
 msgid "Pan Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:70
 #, c-format
 msgid "Paste %d Mode"
 msgstr "Λειτουργία επικόλλησης %d"
 
-#: schematic/src/i_basic.c:74
 msgid "Magnetic Net Mode"
 msgstr "Λειτουργία μαγνητικού δικτύου"
 
-#: schematic/src/i_basic.c:76
 msgid "Net Mode"
 msgstr "Λειτουργία δικτύου"
 
-#: schematic/src/i_basic.c:77
 msgid "Arc Mode"
 msgstr "Λειτουργία τόξου"
 
-#: schematic/src/i_basic.c:78
 msgid "Box Mode"
 msgstr "Λειτουργία κουτιού"
 
-#: schematic/src/i_basic.c:79
 msgid "Bus Mode"
 msgstr "Λειτουργία διαύλου"
 
-#: schematic/src/i_basic.c:80
 msgid "Circle Mode"
 msgstr "Λειτουργία κύκλου"
 
-#: schematic/src/i_basic.c:81
 msgid "Component Mode"
 msgstr "Λειτουργία στοιχείων"
 
-#: schematic/src/i_basic.c:82 schematic/scheme/conf/schematic/menu.scm:62
-#: schematic/scheme/gschem/builtins.scm:114
 msgid "Copy Mode"
 msgstr "Λειτουργία αντιγραφής"
 
-#: schematic/src/i_basic.c:83 schematic/scheme/conf/schematic/menu.scm:63
-#: schematic/scheme/gschem/builtins.scm:117
 msgid "Multiple Copy Mode"
 msgstr "Λειτουργία πολλαπλής αντιγραφής"
 
-#: schematic/src/i_basic.c:84
 msgid "Line Mode"
 msgstr "Λειτουργία γραμμής"
 
-#: schematic/src/i_basic.c:85 schematic/scheme/conf/schematic/menu.scm:66
-#: schematic/scheme/gschem/builtins.scm:123
 msgid "Mirror Mode"
 msgstr "Λειτουργία καθρεπτισμού"
 
-#: schematic/src/i_basic.c:86 schematic/scheme/conf/schematic/menu.scm:64
-#: schematic/scheme/gschem/builtins.scm:111
 msgid "Move Mode"
 msgstr "Λειτουργία μετακίνησης"
 
-#: schematic/src/i_basic.c:87
 #, fuzzy
 msgid "Path Mode"
 msgstr "Λειτουργία επικόλλησης %d"
 
-#: schematic/src/i_basic.c:88
 msgid "Picture Mode"
 msgstr "Λειτουργία εικόνας"
 
-#: schematic/src/i_basic.c:89
 msgid "Pin Mode"
 msgstr "Λειτουργία ακροδεκτών"
 
-#: schematic/src/i_basic.c:90 schematic/scheme/gschem/builtins.scm:120
 msgid "Rotate Mode"
 msgstr "Λειτουργία περιστροφής"
 
-#: schematic/src/i_basic.c:91
 #, fuzzy
 msgid "Modify Mode"
 msgstr "Λειτουργία αντιγραφής"
 
-#: schematic/src/i_basic.c:92 schematic/src/x_menus.c:49
-#: schematic/scheme/gschem/builtins.scm:204
 msgid "Zoom Box"
 msgstr ""
 
-#: schematic/src/i_basic.c:121
 msgid "Show Hidden"
 msgstr "Εμφάνιση κρυφών"
 
-#: schematic/src/i_basic.c:124
 msgid "Snap Off"
 msgstr ""
 
-#: schematic/src/i_basic.c:126
 msgid "Resnap Active"
 msgstr ""
 
-#: schematic/src/i_basic.c:288 schematic/src/x_colorcb.c:159
 msgid "Stroke"
 msgstr ""
 
-#: schematic/src/i_basic.c:296 schematic/src/i_basic.c:330
-#: schematic/src/x_window.c:1361
 msgid "none"
 msgstr "κανένα"
 
-#: schematic/src/i_basic.c:304
 msgid "Repeat/"
 msgstr "Επανάληψη/"
 
-#: schematic/src/i_basic.c:315
 msgid "Repeat/none"
 msgstr "Επανάληψη/κανένα"
 
-#: schematic/src/i_basic.c:323 schematic/src/i_callbacks.c:1239
-#: schematic/scheme/gschem/builtins.scm:189
 msgid "Pan"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:74
 #, fuzzy, c-format
 msgid "New page created [%1$s]"
 msgstr "Δημιουργήθηκε νέα σελίδα [%s]\n"
 
-#: schematic/src/i_callbacks.c:108
 #, fuzzy, c-format
 msgid "New Window created [%1$s]"
 msgstr "Δημιουργήθηκε νέο παράθυρο [%s]\n"
 
-#: schematic/src/i_callbacks.c:245
 msgid "Failed to Save All"
 msgstr "Απέτυχε η αποθήκευση όλων"
 
-#: schematic/src/i_callbacks.c:247
 msgid "Saved All"
 msgstr "Αποθήκευση όλων"
 
-#: schematic/src/i_callbacks.c:308
 #, fuzzy
 msgid "Closing Window"
 msgstr "Κλείσιμο παραθύρου\n"
 
-#: schematic/src/i_callbacks.c:505 schematic/src/x_menus.c:55
-#: schematic/scheme/gschem/builtins.scm:168
 msgid "Copy"
 msgstr "Αντιγραφή"
 
-#: schematic/src/i_callbacks.c:514 schematic/src/i_callbacks.c:539
-#: schematic/src/i_callbacks.c:564
 msgid "Select objs first"
 msgstr "Επιλέξτε αντικείμενα πρώτα"
 
-#: schematic/src/i_callbacks.c:530
 msgid "Multiple Copy"
 msgstr "Πολλαπλή αντιγραφή"
 
-#: schematic/src/i_callbacks.c:555 schematic/src/x_menus.c:56
 msgid "Move"
 msgstr "Μετακίνηση"
 
-#: schematic/src/i_callbacks.c:579 schematic/src/x_menus.c:57
-#: schematic/src/x_multiattrib.c:1656 schematic/scheme/gschem/builtins.scm:108
 msgid "Delete"
 msgstr "Διαγραφή"
 
-#: schematic/src/i_callbacks.c:603
 msgid "Edit"
 msgstr "Επεξεργασία"
 
-#: schematic/src/i_callbacks.c:618 schematic/scheme/gschem/builtins.scm:129
 msgid "Edit Text"
 msgstr "Επεξεργασία κειμένου"
 
-#: schematic/src/i_callbacks.c:637
 msgid "Slot"
 msgstr "Υποδοχή"
 
-#: schematic/src/i_callbacks.c:688 schematic/src/i_callbacks.c:698
 msgid "Rotate"
 msgstr "Περιστροφή"
 
-#: schematic/src/i_callbacks.c:736 schematic/src/i_callbacks.c:746
 msgid "Mirror"
 msgstr "Καθρεπτισμός"
 
-#: schematic/src/i_callbacks.c:763 schematic/src/x_colorcb.c:160
-#: schematic/scheme/conf/schematic/menu.scm:73
-#: schematic/scheme/gschem/builtins.scm:141
 msgid "Lock"
 msgstr "Κλείδωμα"
 
-#: schematic/src/i_callbacks.c:781 schematic/scheme/conf/schematic/menu.scm:74
-#: schematic/scheme/gschem/builtins.scm:144
 msgid "Unlock"
 msgstr "Ξεκλείδωμα"
 
-#: schematic/src/i_callbacks.c:805
 msgid "WARNING: Do not translate with snap off!"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:806
 msgid "WARNING: Turning snap on and continuing with translate."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:813
 msgid "WARNING: Snap grid size is not equal to 100!"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:815
 msgid ""
 "WARNING: If you are translating a symbol to the origin, the snap grid size "
 "should be set to 100"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:847
 msgid "Embed"
 msgstr "Ενσωμάτωση"
 
-#: schematic/src/i_callbacks.c:886
 msgid "Unembed"
 msgstr "Αποενσωμάτωση"
 
-#: schematic/src/i_callbacks.c:928
 msgid "Update"
 msgstr "Ενημέρωση"
 
-#: schematic/src/i_callbacks.c:970
 msgid "ShowHidden"
 msgstr "ΕμφάνισηΚρυφών"
 
-#: schematic/src/i_callbacks.c:1537
 #, c-format
 msgid ""
 "<b>Revert page:</b>\n"
@@ -968,100 +741,78 @@ msgid ""
 "discarded and page file will be reloaded from disk."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1555
 #, fuzzy
 msgid "Revert"
 msgstr "_Επαναφορά"
 
-#: schematic/src/i_callbacks.c:1647
 msgid "Copy to clipboard"
 msgstr "Αντιγραφή στο πρόχειρο"
 
-#: schematic/src/i_callbacks.c:1664
 msgid "Cut to clipboard"
 msgstr "Αποκοπή στο πρόχειρο"
 
-#: schematic/src/i_callbacks.c:1686
 msgid "Paste from clipboard"
 msgstr "Επικόλληση από το πρόχειρο"
 
-#: schematic/src/i_callbacks.c:1694
 #, fuzzy
 msgid "Empty clipboard"
 msgstr "Αντιγραφή στο πρόχειρο"
 
 #. TRANSLATORS: The number is the number of the buffer that the
 #. * selection is being copied to.
-#: schematic/src/i_callbacks.c:1719
 #, fuzzy, c-format
 msgid "Copy %i"
 msgstr "Αντιγραφή 1"
 
 #. TRANSLATORS: The number is the number of the buffer that the
 #. * selection is being cut to.
-#: schematic/src/i_callbacks.c:1746
 #, fuzzy, c-format
 msgid "Cut %i"
 msgstr "Αποκοπή 1"
 
 #. TRANSLATORS: The number is the number of the buffer that is being
 #. * pasted to the schematic.
-#: schematic/src/i_callbacks.c:1776
 #, fuzzy, c-format
 msgid "Paste %i"
 msgstr "Επικόλληση 1"
 
-#: schematic/src/i_callbacks.c:1785
 msgid "Empty buffer"
 msgstr "Άδειασμα ενδιάμεσης μνήμης"
 
-#: schematic/src/i_callbacks.c:1833 schematic/src/x_window.c:1203
 msgid "Component"
 msgstr "Στοιχείο"
 
-#: schematic/src/i_callbacks.c:1865 schematic/src/x_colorcb.c:150
 msgid "Attribute"
 msgstr "Γνώρισμα"
 
-#: schematic/src/i_callbacks.c:1885 schematic/src/x_colorcb.c:149
 msgid "Net"
 msgstr "Δίκτυο"
 
-#: schematic/src/i_callbacks.c:1928 schematic/src/x_colorcb.c:155
-#: schematic/src/x_window.c:1222
 msgid "Bus"
 msgstr "Δίαυλος"
 
-#: schematic/src/i_callbacks.c:2004
 msgid "Line"
 msgstr "Γραμμή"
 
-#: schematic/src/i_callbacks.c:2021
 msgid "Path"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2043
 msgid "Box"
 msgstr "Κουτί"
 
-#: schematic/src/i_callbacks.c:2085
 msgid "Circle"
 msgstr "Κύκλος"
 
-#: schematic/src/i_callbacks.c:2108
 msgid "Arc"
 msgstr "Τόξο"
 
-#: schematic/src/i_callbacks.c:2131 schematic/src/x_colorcb.c:146
 msgid "Pin"
 msgstr "Ακροδέκτης"
 
-#: schematic/src/i_callbacks.c:2191
 #, fuzzy, c-format
 msgid "Searching for source [%1$s]"
 msgstr "Αναζήτηση πηγής [%s]\n"
 
-#: schematic/src/i_callbacks.c:2223
 #, fuzzy, c-format
 msgid ""
 "Failed to descend hierarchy into '%1$s': %2$s\n"
@@ -1072,112 +823,87 @@ msgstr ""
 "\n"
 "Η καταγραφή του gschem μπορεί να περιέχει περισσότερες πληροφορίες."
 
-#: schematic/src/i_callbacks.c:2227
 #, fuzzy, c-format
 msgid "Failed to descend into '%1$s': %2$s"
 msgstr "Αδυναμία αντικατάστασης εικόνων: %s"
 
-#: schematic/src/i_callbacks.c:2234
 #, fuzzy
 msgid "Failed to descend hierarchy."
 msgstr "Αποτυχία αποθήκευσης αρχείου"
 
-#: schematic/src/i_callbacks.c:2312
 #, fuzzy, c-format
 msgid "Searching for symbol [%1$s]"
 msgstr "Αναζήτηση συμβόλου [%s]\n"
 
-#: schematic/src/i_callbacks.c:2320
 #, fuzzy
 msgid "Symbol is not a real file. Symbol cannot be loaded."
 msgstr ""
 "Το σύμβολο δεν είναι πραγματικό αρχείο. Το σύμβολο δεν μπορεί να φορτωθεί.\n"
 
-#: schematic/src/i_callbacks.c:2367 schematic/src/x_tabs.c:1060
 #, fuzzy
 msgid "Cannot find any schematics above the current one!"
 msgstr "Δεν μπορούν να βρεθούν σχεδιαγράμματα πάνω από το τρέχον!\n"
 
-#: schematic/src/i_callbacks.c:2400
 msgid "Attach"
 msgstr "Σύνδεση"
 
-#: schematic/src/i_callbacks.c:2456
 msgid "Detach"
 msgstr "Αποσύνδεση"
 
-#: schematic/src/i_callbacks.c:2500
 msgid "ShowN"
 msgstr "ΕμβάνισηΝ"
 
-#: schematic/src/i_callbacks.c:2537
 msgid "ShowV"
 msgstr "ΕμφάνισηV"
 
-#: schematic/src/i_callbacks.c:2574
 msgid "ShowB"
 msgstr "ΕμφάνισηΒ"
 
-#: schematic/src/i_callbacks.c:2612
 msgid "VisToggle"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2643
 #, c-format
 msgid "Sorry but this is a non-functioning menu option\n"
 msgstr "Λυπούμαστε αλλά αυτή είναι μία μη λειτουργική επιλογή μενού\n"
 
-#: schematic/src/i_callbacks.c:2703
 msgid "Action feedback mode set to OUTLINE"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2706
 msgid "Action feedback mode set to BOUNDINGBOX"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2730
 msgid "Grid OFF"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2731
 msgid "Dot grid selected"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2732
 msgid "Mesh grid selected"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2733
 #, fuzzy
 msgid "Invalid grid mode"
 msgstr "Μη έγκυρο γνώρισμα"
 
-#: schematic/src/i_callbacks.c:2755
 msgid "Snap OFF (CAUTION!)"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2758
 msgid "Snap ON"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2761
 msgid "Snap back to the grid (CAUTION!)"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2790
 msgid "Rubber band ON"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2792
 msgid "Rubber band OFF"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2811
 #, fuzzy
 msgid "magnetic net mode: ON"
 msgstr "Λειτουργία μαγνητικού δικτύου"
 
-#: schematic/src/i_callbacks.c:2814
 #, fuzzy
 msgid "magnetic net mode: OFF"
 msgstr "Λειτουργία μαγνητικού δικτύου"
@@ -1187,146 +913,117 @@ msgstr "Λειτουργία μαγνητικού δικτύου"
 #. the form "untitled_N.sch", where N is a number.  Please make
 #. sure that the translation contains characters suitable for use
 #. in a filename.
-#: schematic/src/i_vars.c:209
 msgid "untitled"
 msgstr ""
 
-#: schematic/src/o_complex.c:192 schematic/src/o_complex.c:195
 #, fuzzy, c-format
 msgid "Translating schematic [%1$d %2$d]"
 msgstr "Μετάφραση σχεδιαγράμματος [%d %d]\n"
 
-#: schematic/src/o_delete.c:82
 #, fuzzy, c-format
 msgid "Delete locked object?"
 msgid_plural "Delete %1$u locked objects?"
 msgstr[0] "Επιλεγμένα αντικείμενα"
 msgstr[1] "Επιλεγμένα αντικείμενα"
 
-#: schematic/src/o_misc.c:55
 #, c-format
 msgid "Got an unexpected NULL in o_edit\n"
 msgstr "Λήφθηκε απροσδόκητο NULL στο o_edit\n"
 
-#: schematic/src/o_misc.c:315
 #, fuzzy
 msgid "Hidden text is now visible"
 msgstr "Το κρυφό κείμενο είναι πλέον ορατό\n"
 
-#: schematic/src/o_misc.c:317
 #, fuzzy
 msgid "Hidden text is now invisible"
 msgstr "Το κρυφό κείμενο είναι πλέον αόρατο\n"
 
-#: schematic/src/o_misc.c:425
 #, fuzzy, c-format
 msgid "Could not find symbol [%1$s] in library. Update failed."
 msgstr "Αδυναμία εύρεσης συμβόλου [%s] στη βιβλιοθήκη. Η ενημέρωση απέτυχε.\n"
 
-#: schematic/src/o_misc.c:541
 #, fuzzy, c-format
 msgid "o_autosave_backups: Can't get the real filename of %1$s."
 msgstr ""
 "o_autosave_backups: Αδυναμία λήψης του πραγματικού ονόματος αρχείου για το "
 "%s."
 
-#: schematic/src/o_misc.c:585
 #, fuzzy, c-format
 msgid "Could NOT set previous backup file [%1$s] read-write"
 msgstr ""
 "ΔΕΝ ήταν δυνατός ο ορισμός ανάγνωσης-εγγραφής για το προηγούμενο αντίγραφο "
 "ασφαλείας [%s]\n"
 
-#: schematic/src/o_misc.c:605
 #, fuzzy, c-format
 msgid "Could NOT set backup file [%1$s] readonly"
 msgstr ""
 "ΔΕΝ ήταν δυνατός ο ορισμός μόνο-ανάγνωσης για το αντίγραφο ασφαλείας [%s]\n"
 
-#: schematic/src/o_misc.c:610
 #, fuzzy, c-format
 msgid "Could NOT save backup file [%1$s]"
 msgstr "ΔΕΝ ήταν δυνατή η αποθήκευση του αντιγράφου ασφαλείας [%s]\n"
 
-#: schematic/src/o_move.c:192
 #, c-format
 msgid "ERROR: NULL object in o_move_end!\n"
 msgstr "ERROR: Αντικείμενο NULL στο o_move_end!\n"
 
-#: schematic/src/o_move.c:519
 #, c-format
 msgid "DOH! tried to find the whichone, but didn't find it!\n"
 msgstr ""
 
-#: schematic/src/o_move.c:546
 #, c-format
 msgid "Got a non line object in o_move_check_endpoint\n"
 msgstr ""
 
-#: schematic/src/o_net.c:444
 #, fuzzy
 msgid "Warning: Starting net at off grid coordinate"
 msgstr "Προειδοποίηση: Το δίκτυο ξεκινάει από συντεταγμένη εκτός πλέγματος.\n"
 
-#: schematic/src/o_net.c:508
 #, fuzzy
 msgid "Warning: Ending net at off grid coordinate"
 msgstr "Προειδοποίηση: Το δίκτυο τελειώνει σε συντεταγμένη εκτός πλέγματος.\n"
 
-#: schematic/src/o_net.c:856 schematic/src/o_net.c:893
-#: schematic/src/o_net.c:964 schematic/src/o_net.c:1000
 #, c-format
 msgid "Tried to add more than two bus rippers. Internal gschem error.\n"
 msgstr ""
 
-#: schematic/src/o_net.c:1068
 #, c-format
 msgid "Bus ripper symbol [%1$s] was not found in any component library"
 msgstr ""
 
-#: schematic/src/o_picture.c:133 schematic/src/o_picture.c:343
 #, fuzzy
 msgid "Select a picture file..."
 msgstr "Επιλογή ονόματος αρχείου PostScript..."
 
-#: schematic/src/o_picture.c:166
 #, fuzzy, c-format
 msgid "Failed to load picture: %1$s"
 msgstr "Αδυναμία φορτώματος εικόνας: %s"
 
-#: schematic/src/o_picture.c:182
 msgid "Picture"
 msgstr "Εικόνα"
 
-#: schematic/src/o_picture.c:378
 #, c-format
 msgid "Failed to replace pictures: %s"
 msgstr "Αδυναμία αντικατάστασης εικόνων: %s"
 
-#: schematic/src/o_slot.c:80
 #, fuzzy
 msgid "Slot attribute malformed"
 msgstr "Το γνώρισμα υποδοχής είναι παραμορφωμένο\n"
 
-#: schematic/src/o_slot.c:88
 msgid "numslots attribute missing"
 msgstr ""
 
-#: schematic/src/o_slot.c:89
 #, fuzzy
 msgid "Slotting not allowed for this component"
 msgstr "Οι υποδοχές δεν επιτρέπονται σε αυτό το στοιχείο\n"
 
-#: schematic/src/o_slot.c:104
 #, fuzzy
 msgid "New slot number out of range"
 msgstr "Νέος αριθμός υποδοχής εκτός εύρους\n"
 
-#: schematic/src/o_undo.c:397
 msgid "Undo/Redo disabled in rc file"
 msgstr ""
 
-#: schematic/src/parsecmd.c:77
 #, c-format
 msgid ""
 "Usage: %1$s [OPTION ...] [--] [FILE ...]\n"
@@ -1351,12 +1048,11 @@ msgid ""
 "gEDA/gaf homepage: <http://www.geda-project.org/>\n"
 msgstr ""
 
-#: schematic/src/parsecmd.c:110
 #, fuzzy, c-format
 msgid ""
 "Lepton EDA %1$s (git: %2$.7s)\n"
 "Copyright (C) 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright (C) 2017-2018 Lepton Developers.\n"
+"Copyright (C) 2017-2019 Lepton Developers.\n"
 "This is free software, and you are welcome to redistribute it under\n"
 "certain conditions. For details, see the file `COPYING', which is\n"
 "included in the Lepton EDA distribution.\n"
@@ -1369,85 +1065,65 @@ msgstr ""
 "συμπεριλαμβάνεται στη διανομή του gEDA.\n"
 "Δεν υπάρχει ΚΑΜΙΑ ΕΓΓΥΗΣΗ, στα πλαίσια που επιτρέπει ο νόμος.\n"
 
-#: schematic/src/x_attribedit.c:125
 #, c-format
 msgid "Got invalid show option; defaulting to show both\n"
 msgstr ""
 "Λήφθηκε μη έγκυρη επιλογή εμφάνισης. Προεπιλεγμένη εμφάνιση και των δύο\n"
 
-#: schematic/src/x_attribedit.c:139
 #, c-format
 msgid "ERROR: NULL object!\n"
 msgstr "ΣΦΑΛΜΑ: Αντικείμενο NULL!\n"
 
-#: schematic/src/x_attribedit.c:328
 msgid "Single Attribute Editor"
 msgstr "Επεξεργαστής ενός γνωρίσματος"
 
-#: schematic/src/x_attribedit.c:358
 msgid "<b>Edit Attribute</b>"
 msgstr "<b>Επεξεργασία γνωρίσματος</b>"
 
-#: schematic/src/x_attribedit.c:360
 msgid "<b>Add Attribute</b>"
 msgstr "<b>Προσθήκη γνωρίσματος</b>"
 
-#: schematic/src/x_attribedit.c:376
 #, fuzzy
 msgid "N_ame:"
 msgstr "Όνομα:"
 
-#: schematic/src/x_attribedit.c:396 schematic/src/x_multiattrib.c:2222
 #, fuzzy
 msgid "_Value:"
 msgstr "Τιμή:"
 
-#: schematic/src/x_attribedit.c:415 schematic/src/x_multiattrib.c:2281
 #, fuzzy
 msgid "Vi_sible"
 msgstr "Ορατό"
 
-#: schematic/src/x_attribedit.c:434
 msgid "Show Value Only"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:436
 msgid "Show Name Only"
 msgstr "Εμφάνιση τιμής μόνο"
 
-#: schematic/src/x_attribedit.c:438 schematic/src/x_multiattrib.c:1620
-#: schematic/scheme/gschem/builtins.scm:324
 msgid "Show Name & Value"
 msgstr "Εμφάνιση ονόματος & τιμής"
 
-#: schematic/src/x_attribedit.c:445
 msgid "<b>Attach Options</b>"
 msgstr "<b>Επιλογές σύνδεσης</b>"
 
-#: schematic/src/x_attribedit.c:460
 msgid "All"
 msgstr "Όλα"
 
-#: schematic/src/x_attribedit.c:476 schematic/src/x_compselect.c:986
-#: schematic/src/x_compselect.c:1100
 msgid "Components"
 msgstr "Στοιχεία"
 
-#: schematic/src/x_attribedit.c:492 schematic/src/x_window.c:1214
 msgid "Nets"
 msgstr "Δίκτυα"
 
-#: schematic/src/x_attribedit.c:508
 msgid "Replace existing attributes"
 msgstr "Αντικατάσταση υπαρχόνων γνωρισμάτων"
 
-#: schematic/src/x_autonumber.c:412
 msgid ""
 "slotted object without slot attribute may cause problems when autonumbering "
 "slots"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:427
 #, fuzzy, c-format
 msgid ""
 "duplicate slot may cause problems: [symbolname=%1$s, number=%2$d, slot=%3$d]"
@@ -1455,95 +1131,72 @@ msgstr ""
 "οι διπλές υποδοχές μπορεί να προκαλέσουν προβλήματα: [σύμβολο=%s, αριθμός="
 "%d, υποδοχή=%d]\n"
 
-#: schematic/src/x_autonumber.c:675
 msgid "No searchstring given in autonumber text."
 msgstr ""
 
-#: schematic/src/x_autonumber.c:728
 msgid "No '*' or '?' given at the end of the autonumber text."
 msgstr ""
 
-#: schematic/src/x_autonumber.c:873
 msgid "Diagonal"
 msgstr "Διαγώνια"
 
-#: schematic/src/x_autonumber.c:874
 msgid "Top to bottom"
 msgstr "Πάνω προς κάτω"
 
-#: schematic/src/x_autonumber.c:875
 msgid "Bottom to top"
 msgstr "Κάτω προς πάνω"
 
-#: schematic/src/x_autonumber.c:876
 msgid "Left to right"
 msgstr "Αριστερά προς δεξιά"
 
-#: schematic/src/x_autonumber.c:877
 msgid "Right to left"
 msgstr "Δεξιά προς αριστερά"
 
-#: schematic/src/x_autonumber.c:878
 msgid "File order"
 msgstr "Σειρά αρχείων"
 
-#: schematic/src/x_autonumber.c:1214
 msgid "Autonumber text"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1237
 msgid "<b>Scope</b>"
 msgstr "<b>Σκοπός</b>"
 
-#: schematic/src/x_autonumber.c:1259
 msgid "Search for:"
 msgstr "Αναζήτηση για:"
 
-#: schematic/src/x_autonumber.c:1273
 msgid "Autonumber text in:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1280
 msgid "Skip numbers found in:"
 msgstr "Παράβλεψη αριθμών που βρίσκονται σε:"
 
-#: schematic/src/x_autonumber.c:1292 schematic/src/x_autonumber.c:1301
 msgid "Selected objects"
 msgstr "Επιλεγμένα αντικείμενα"
 
-#: schematic/src/x_autonumber.c:1293 schematic/src/x_autonumber.c:1302
 msgid "Current page"
 msgstr "Τρέχουσα σελίδα"
 
-#: schematic/src/x_autonumber.c:1294 schematic/src/x_autonumber.c:1303
 msgid "Whole hierarchy"
 msgstr "Ολόκληρη η ιεραρχία"
 
-#: schematic/src/x_autonumber.c:1305
 msgid "Overwrite existing numbers"
 msgstr "Αντικατάσταση υπαρχόντων αριθμών"
 
-#: schematic/src/x_autonumber.c:1310
 msgid "<b>Options</b>"
 msgstr "<b>Επιλογές</b>"
 
-#: schematic/src/x_autonumber.c:1332
 msgid "Starting number:"
 msgstr "Αριθμός έναρξης:"
 
-#: schematic/src/x_autonumber.c:1339
 msgid "Sort order:"
 msgstr "Σειρά ταξινόμησης:"
 
-#: schematic/src/x_autonumber.c:1371
 msgid "Remove numbers"
 msgstr "Αφαίρεση αριθμών"
 
-#: schematic/src/x_autonumber.c:1375
 msgid "Automatic slotting"
 msgstr ""
 
-#: schematic/src/x_clipboard.c:245
 #, c-format
 msgid ""
 "<b>Invalid schematic on clipboard.</b>\n"
@@ -1554,176 +1207,136 @@ msgstr ""
 "\n"
 "Συνέβη ένα σφάλμα κατά τη διάρκεια εισαγωγής τω δεδομένων προχείρου: %s."
 
-#: schematic/src/x_clipboard.c:247
 msgid "Clipboard insertion failed"
 msgstr "Η εισαγωγή από το πρόχειρο απέτυχε"
 
-#: schematic/src/x_color.c:89 schematic/src/x_color.c:98
 #, fuzzy, c-format
 msgid "Could not allocate the color %1$s!\n"
 msgstr "Αδυναμία εντοπισμού χρώματος %s!\n"
 
-#: schematic/src/x_color.c:89
 msgid "black"
 msgstr "μαύρο"
 
-#: schematic/src/x_color.c:98
 msgid "white"
 msgstr "άσπρο"
 
-#: schematic/src/x_color.c:120
 #, fuzzy, c-format
 msgid "Could not allocate display color %1$i!\n"
 msgstr "Αδυναμία εντοπισμού χρώματος εμφάνισης %i!\n"
 
-#: schematic/src/x_color.c:142
 #, fuzzy, c-format
 msgid "Could not allocate outline color %1$i!\n"
 msgstr "Αδυναμία εντοπισμού χρώματος περιγράμματος %i!\n"
 
-#: schematic/src/x_color.c:159
 #, fuzzy, c-format
 msgid "Tried to get an invalid color: %1$d\n"
 msgstr "Προσπάθεια εισαγωγής μη έγκυρου χρώματος: %d\n"
 
-#: schematic/src/x_colorcb.c:145
 msgid "Background"
 msgstr "Παρασκήνιο"
 
-#: schematic/src/x_colorcb.c:147
 msgid "Net endpoint"
 msgstr "Τερματικό σημείο δικτύου"
 
-#: schematic/src/x_colorcb.c:148
 msgid "Graphic"
 msgstr "Γραφικό"
 
-#: schematic/src/x_colorcb.c:151
 msgid "Logic bubble"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:152
 #, fuzzy
 msgid "Grid point"
 msgstr "Σημείο πλέγματος"
 
-#: schematic/src/x_colorcb.c:153
 #, fuzzy
 msgid "Detached attribute"
 msgstr "Αποσυνδεδεμένο γνώρισμα"
 
-#: schematic/src/x_colorcb.c:156
 msgid "Selection"
 msgstr "Επιλογή"
 
-#: schematic/src/x_colorcb.c:157
 msgid "Bounding box"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:158
 msgid "Zoom box"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:161
 msgid "Output background"
 msgstr "Παρασκήνιο εξόδου"
 
-#: schematic/src/x_colorcb.c:162
 msgid "Freestyle 1"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:163
 msgid "Freestyle 2"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:164
 msgid "Freestyle 3"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:165
 msgid "Freestyle 4"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:166
 msgid "Net junction"
 msgstr "Διασταύρωση δικτύου"
 
-#: schematic/src/x_colorcb.c:167
 msgid "Mesh grid major"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:168
 msgid "Mesh grid minor"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:172
 msgid "Unknown"
 msgstr "'Αγνωστο"
 
-#: schematic/src/x_compselect.c:1169
 #, fuzzy
 msgid "Reset filter"
 msgstr "Νέο αρχείο"
 
-#: schematic/src/x_compselect.c:1192
 msgid "Reload all libraries"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1245 schematic/src/x_multiattrib.c:2092
 msgid "Value"
 msgstr "Τιμή"
 
-#: schematic/src/x_compselect.c:1284
 msgid "Default behavior - reference component"
 msgstr "Προκαθορισμένη συμπεριφορά - στοιχείο αναφοράς"
 
-#: schematic/src/x_compselect.c:1287
 msgid "Embed component in schematic"
 msgstr "Ενσωμάτωση στοιχείου στο σχεδιάγραμμα"
 
-#: schematic/src/x_compselect.c:1290
 msgid "Include component as individual objects"
 msgstr "Συμπερίληψη του στοιχείου ως ξεχωριστά αντικείμενα"
 
-#: schematic/src/x_compselect.c:1448
 msgid "Select Component..."
 msgstr "Επιλογή στοιχείου..."
 
-#: schematic/src/x_compselect.c:1471
 #, fuzzy
 msgid "In Us_e"
 msgstr "Σε χρήση"
 
-#: schematic/src/x_compselect.c:1475
 #, fuzzy
 msgid "Lib_raries"
 msgstr "Βιβλιοθήκες"
 
-#: schematic/src/x_compselect.c:1484 schematic/src/x_fileselect.c:119
 msgid "Preview"
 msgstr "Προεπισκόπηση"
 
-#: schematic/src/x_compselect.c:1510
 msgid "Attributes"
 msgstr "Γνωρίσματα"
 
-#: schematic/src/x_dialog.c:325
 msgid "Major symbol changes detected."
 msgstr ""
 
-#: schematic/src/x_dialog.c:349
 msgid ""
 "Changes have occurred to the symbols shown below.\n"
 "\n"
 "Be sure to verify each of these symbols."
 msgstr ""
 
-#: schematic/src/x_dialog.c:369
 #, fuzzy
 msgid "Symbol"
 msgstr "Σύμβολα"
 
-#: schematic/src/x_dialog.c:406
 #, c-format
 msgid ""
 "<span weight=\"bold\" size=\"larger\">The input attribute \"%s\" is invalid\n"
@@ -1741,40 +1354,31 @@ msgstr ""
 "Το όνομα δεν μπορεί να τελειώνει με κενό.\n"
 "Η τιμή δεν μπορεί να ξεκινάει με κενό."
 
-#: schematic/src/x_dialog.c:408
 msgid "Invalid Attribute"
 msgstr "Μη έγκυρο γνώρισμα"
 
-#: schematic/src/x_fileselect.c:37
 msgid "Schematics"
 msgstr "Σχεδιαγράμματα"
 
-#: schematic/src/x_fileselect.c:42
 msgid "Symbols"
 msgstr "Σύμβολα"
 
-#: schematic/src/x_fileselect.c:47
 msgid "Schematics and symbols"
 msgstr "Σχεδιαγράμματα και σύμβολα"
 
-#: schematic/src/x_fileselect.c:53
 msgid "All files"
 msgstr "Όλα τα αρχεία"
 
-#: schematic/src/x_fileselect.c:169
 msgid "Open..."
 msgstr "Άνοιγμα..."
 
-#: schematic/src/x_fileselect.c:233
 msgid "Save as..."
 msgstr "Αποθήκευση ως..."
 
-#: schematic/src/x_fileselect.c:297
 #, fuzzy
 msgid "Save cancelled on user request"
 msgstr "Αποθήκευση ακυρώθηκε με αίτημα του χρήστη\n"
 
-#: schematic/src/x_fileselect.c:334
 msgid ""
 "\n"
 "If you load the original file, the backup file will be overwritten in the "
@@ -1783,28 +1387,22 @@ msgid ""
 "Do you want to load the backup file?\n"
 msgstr ""
 
-#: schematic/src/x_fstylecb.c:73
 msgid "Hollow"
 msgstr "Κοίλωμα"
 
-#: schematic/src/x_fstylecb.c:80
 msgid "Filled"
 msgstr "Γεμισμένο"
 
-#: schematic/src/x_fstylecb.c:87
 msgid "Mesh"
 msgstr ""
 
-#: schematic/src/x_fstylecb.c:94
 msgid "Hatch"
 msgstr ""
 
-#: schematic/src/x_image.c:279
 #, fuzzy, c-format
 msgid "x_image_lowlevel: Unable to write %1$s file %2$s."
 msgstr "x_image_lowlevel: Αδυναμία εγγραφής του αρχείου %s %s.\n"
 
-#: schematic/src/x_image.c:289
 #, fuzzy, c-format
 msgid ""
 "There was the following error when saving image with type %1$s to filename:\n"
@@ -1818,294 +1416,229 @@ msgstr ""
 "\n"
 "%s.\n"
 
-#: schematic/src/x_image.c:309
 #, fuzzy, c-format
 msgid "Wrote color image to [%1$s] [%2$d x %3$d]"
 msgstr "Εγγράφηκε έγχρωμη εικόνα στο [%s] [%d x %d]\n"
 
-#: schematic/src/x_image.c:311
 #, fuzzy, c-format
 msgid "Wrote black and white image to [%1$s] [%2$d x %3$d]"
 msgstr "Εγγράφηκε ασπρόμαυρη εικόνα στο [%s] [%d x %d]\n"
 
-#: schematic/src/x_image.c:319
 #, fuzzy
 msgid "x_image_lowlevel: Unable to get pixbuf from gschem's window."
 msgstr "x_image_lowlevel: Αδυναμία λήψης pixbuf από το παράθυρο του gschem.\n"
 
-#: schematic/src/x_image.c:358
 msgid "Width x Height"
 msgstr "Πλάτος x Ύψος"
 
-#: schematic/src/x_image.c:374
 msgid "Image type"
 msgstr "Τύπος εικόνας"
 
-#: schematic/src/x_image.c:395
 msgid "Write image..."
 msgstr "Εγγραφή εικόνας..."
 
-#: schematic/src/x_linecapcb.c:74
 msgid "Butt"
 msgstr ""
 
-#: schematic/src/x_linecapcb.c:81
 msgid "Square"
 msgstr ""
 
-#: schematic/src/x_linecapcb.c:88
 msgid "Round"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:74
 msgid "Solid"
 msgstr "Συμπαγές"
 
-#: schematic/src/x_linetypecb.c:81
 msgid "Dotted"
 msgstr "Με τελείες"
 
-#: schematic/src/x_linetypecb.c:88
 msgid "Dashed"
 msgstr "Με παύλες"
 
-#: schematic/src/x_linetypecb.c:95
 msgid "Center"
 msgstr "Κέντρο"
 
-#: schematic/src/x_linetypecb.c:102
 msgid "Phantom"
 msgstr "Φάντασμα"
 
-#: schematic/src/x_menus.c:41 schematic/scheme/gschem/builtins.scm:267
 #, fuzzy
 msgid "Add Net"
 msgstr "/Προσθήκη δικτύου"
 
-#: schematic/src/x_menus.c:42 schematic/src/x_multiattrib.c:2187
-#: schematic/scheme/gschem/builtins.scm:264
 msgid "Add Attribute"
 msgstr "Προσθήκη γνωρίσματος"
 
-#: schematic/src/x_menus.c:43 schematic/scheme/gschem/builtins.scm:261
 #, fuzzy
 msgid "Add Component"
 msgstr "/Προσθήκη στοιχείου..."
 
-#: schematic/src/x_menus.c:44 schematic/scheme/gschem/builtins.scm:270
 #, fuzzy
 msgid "Add Bus"
 msgstr "/Προσθήκη διαύλου"
 
-#: schematic/src/x_menus.c:45 schematic/scheme/gschem/builtins.scm:273
 #, fuzzy
 msgid "Add Text"
 msgstr "/Προσθήκη κειμένου"
 
-#: schematic/src/x_menus.c:47 schematic/scheme/gschem/builtins.scm:210
 msgid "Zoom In"
 msgstr ""
 
-#: schematic/src/x_menus.c:48 schematic/scheme/gschem/builtins.scm:213
 msgid "Zoom Out"
 msgstr ""
 
-#: schematic/src/x_menus.c:50 schematic/scheme/gschem/builtins.scm:207
 msgid "Zoom Extents"
 msgstr ""
 
-#: schematic/src/x_menus.c:52 schematic/src/x_window.c:1233
 msgid "Select"
 msgstr "Επιλογή"
 
-#: schematic/src/x_menus.c:53 schematic/scheme/conf/schematic/menu.scm:69
-#: schematic/scheme/gschem/builtins.scm:126
 msgid "Edit..."
 msgstr "Επεξεργασία..."
 
-#: schematic/src/x_menus.c:54 schematic/scheme/conf/schematic/menu.scm:68
 #, fuzzy
 msgid "Object Properties..."
 msgstr "<b>Ιδιότητες κειμένου</b>"
 
-#: schematic/src/x_menus.c:59 schematic/scheme/gschem/builtins.scm:300
 #, fuzzy
 msgid "Down Schematic"
 msgstr "/Κάτω σχεδιάγραμμα"
 
-#: schematic/src/x_menus.c:60 schematic/scheme/gschem/builtins.scm:303
 #, fuzzy
 msgid "Down Symbol"
 msgstr "/Κάτω σύμβολο"
 
-#: schematic/src/x_menus.c:61
 #, fuzzy
 msgid "Up"
 msgstr "/Πάνω"
 
-#: schematic/src/x_menus.c:336
 #, fuzzy, c-format
 msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
 msgstr "Προσπάθεια ρύθμισης ευαισθησίας σε ανύπαρκτο αντικείμενο μενού '%s'\n"
 
-#: schematic/src/x_menus.c:360
 #, c-format
 msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
 msgstr "Προσπάθεια ρύθμισης ευαισθησίας σε ανύπαρκτο αντικείμενο μενού '%s'\n"
 
-#: schematic/src/x_misc.c:70
 msgid "The operating system is out of memory or resources."
 msgstr "Το λειτουργικό σύστημα είναι εκτός ορίων μνήμης ή πηγών."
 
-#: schematic/src/x_multiattrib.c:798 schematic/src/x_multiattrib.c:2704
 msgid "<various>"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:930
 msgid "Attributes with empty name are not allowed. Please set a name."
 msgstr ""
 "Γνωρίσματα με κενό όνομα δεν επιτρέπονται. Παρακαλούμε ορίστε ένα όνομα."
 
-#: schematic/src/x_multiattrib.c:1622
 msgid "Show Value only"
 msgstr "Εμφάνιση τιμής μόνο"
 
-#: schematic/src/x_multiattrib.c:1624
 msgid "Show Name only"
 msgstr "Εμφάνιση ονόματος μόνο"
 
-#: schematic/src/x_multiattrib.c:1651
 msgid "Promote"
 msgstr "Προώθηση"
 
-#: schematic/src/x_multiattrib.c:1655
 msgid "Duplicate"
 msgstr "Αντίγραφο"
 
-#: schematic/src/x_multiattrib.c:1657
 #, fuzzy
 msgid "Copy to all"
 msgstr "Αντιγραφή σε 1"
 
-#: schematic/src/x_multiattrib.c:1986 schematic/src/x_multiattrib.c:2602
 msgid "Edit Attributes"
 msgstr "Επεξεργασία γνωρισμάτων"
 
-#: schematic/src/x_multiattrib.c:2112
 msgid "Vis?"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2130
 msgid "N"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2148
 msgid "V"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2170
 #, fuzzy
 msgid "Sho_w inherited attributes"
 msgstr "Εμφάνιση κληρονομημένων γνωρισμάτων"
 
-#: schematic/src/x_multiattrib.c:2197
 #, fuzzy
 msgid "_Name:"
 msgstr "Όνομα:"
 
-#: schematic/src/x_multiattrib.c:2241
 msgid "Ctrl+Enter inserts new line; Ctrl+Tab inserts Tab"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2618
 #, c-format
 msgid "%2$i symbol (%1$s)"
 msgid_plural "%2$i symbols (%1$s)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2624
 #, fuzzy, c-format
 msgid "%1$i pin"
 msgid_plural "%1$i pins"
 msgstr[0] "Ακροδέκτης δικτύου"
 msgstr[1] "Ακροδέκτης δικτύου"
 
-#: schematic/src/x_multiattrib.c:2630
 #, c-format
 msgid "%1$i net"
 msgid_plural "%1$i nets"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2636
 #, c-format
 msgid "%1$i bus"
 msgid_plural "%1$i buses"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2642
 #, fuzzy, c-format
 msgid "%1$i attribute"
 msgid_plural "%1$i attributes"
 msgstr[0] "Γνώρισμα"
 msgstr[1] "Γνώρισμα"
 
-#: schematic/src/x_newtext.c:433
 msgid "Text Entry..."
 msgstr "Εισαγωγή κειμένου..."
 
-#: schematic/src/x_pagesel.c:253
 msgid "New Page"
 msgstr "Νέα σελίδα"
 
-#: schematic/src/x_pagesel.c:254
 msgid "Open Page..."
 msgstr "Άνοιγμα σελίδας..."
 
-#: schematic/src/x_pagesel.c:256
 msgid "Save Page"
 msgstr "Αποθήκευση σελίδας"
 
-#: schematic/src/x_pagesel.c:257 schematic/scheme/gschem/builtins.scm:246
 msgid "Close Page"
 msgstr "Κλείσιμο σελίδας"
 
-#: schematic/src/x_pagesel.c:376 schematic/scheme/gschem/builtins.scm:237
 msgid "Page Manager"
 msgstr "Διαχειριστής σελίδων"
 
-#: schematic/src/x_pagesel.c:448
 msgid "Changed"
 msgstr "Τροποποιήθηκε"
 
-#: schematic/src/x_pagesel.c:468
 msgid "Right click on the filename for more options..."
 msgstr "Δεξί κλικ στο όνομα αρχείου για περισσότερες επιλογές..."
 
-#: schematic/src/x_print.c:306
 #, fuzzy, c-format
 msgid "Failed to write PDF to '%s': %s\n"
 msgstr "Αδυναμία αντικατάστασης εικόνων: %s"
 
-#: schematic/src/x_print.c:364
 #, fuzzy, c-format
 msgid "Failed to write PDF to '%1$s': %2$s\n"
 msgstr "Αδυναμία αντικατάστασης εικόνων: %s"
 
-#: schematic/src/x_print.c:449
 #, c-format
 msgid ""
 "Error printing file:\n"
 "%1$s"
 msgstr ""
 
-#: schematic/src/x_rc.c:39
 msgid "ERROR: An unknown error occurred while parsing configuration files."
 msgstr ""
 
-#: schematic/src/x_rc.c:44
 #, fuzzy
 msgid ""
 "An unknown error occurred while parsing configuration files.\n"
@@ -2117,12 +1650,10 @@ msgstr ""
 "Το φόρτωμα από '%s' απέτυχε: %s. Η καταγραφή του gschem μπορεί να περιέχει "
 "περισσότερες πληροφορίες."
 
-#: schematic/src/x_rc.c:56
 #, fuzzy, c-format
 msgid "ERROR: %1$s"
 msgstr "ΣΦΑΛΜΑ: %s\n"
 
-#: schematic/src/x_rc.c:59
 #, fuzzy, c-format
 msgid ""
 "%1$s\n"
@@ -2133,142 +1664,111 @@ msgstr ""
 "\n"
 "Η καταγραφή του gschem μπορεί να περιέχει περισσότερες πληροφορίες."
 
-#: schematic/src/x_rc.c:67
 #, fuzzy
 msgid "Cannot load lepton-schematic configuration."
 msgstr "Δεν είναι δυνατό το φόρτωμα των ρυθμίσεων του gschem."
 
-#: schematic/src/x_script.c:42 schematic/scheme/conf/schematic/menu.scm:40
 msgid "Execute Script..."
 msgstr "Εκτέλεση σεναρίου..."
 
-#: schematic/src/x_script.c:61
 #, c-format
 msgid "Executing guile script [%1$s]"
 msgstr ""
 
-#: schematic/src/x_tabs.c:860
 #, fuzzy, c-format
 msgid "Hierarchy up: %s"
 msgstr "_Ιεραρχία"
 
-#: schematic/src/x_tabs.c:863
 #, fuzzy
 msgid "Hierarchy up"
 msgstr "_Ιεραρχία"
 
-#: schematic/src/x_widgets.c:158 schematic/src/x_window.c:1444
 #, fuzzy
 msgid "Options"
 msgstr "_Επιλογές"
 
-#: schematic/src/x_widgets.c:203 schematic/src/x_window.c:1436
 #, fuzzy
 msgid "Object"
 msgstr "Χρώμα αντικειμένου:"
 
-#: schematic/src/x_widgets.c:224
 msgid "Log"
 msgstr ""
 
-#: schematic/src/x_widgets.c:245 schematic/src/x_window.c:1466
 msgid "Find Text"
 msgstr "Εύρεση κειμένου"
 
-#: schematic/src/x_widgets.c:259
 #, fuzzy
 msgid "Color Scheme Editor"
 msgstr "Σχήμα _φωτεινών χρωμάτων"
 
-#: schematic/src/x_widgets.c:272 schematic/scheme/gschem/builtins.scm:378
 #, fuzzy
 msgid "Select Schematic Font"
 msgstr "_Επιλέξετε τα σχεδιαγράμματα που θέλετε να αποθηκεύσετε:"
 
-#: schematic/src/x_window.c:763
 #, fuzzy, c-format
 msgid "Loading schematic [%1$s]"
 msgstr "Φόρτωμα σχεδιαγράμματος [%s]\n"
 
-#: schematic/src/x_window.c:864
 #, fuzzy, c-format
 msgid "Could NOT save page [%1$s]\n"
 msgstr "ΔΕΝ ήταν δυνατή η αποθήκευση της σελίδας [%s]\n"
 
-#: schematic/src/x_window.c:865
 msgid "Error while trying to save"
 msgstr "Σφάλμα κατά την προσπάθεια αποθήκευσης"
 
-#: schematic/src/x_window.c:875
 msgid "Failed to save file"
 msgstr "Αποτυχία αποθήκευσης αρχείου"
 
-#: schematic/src/x_window.c:885
 #, fuzzy, c-format
 msgid "Saved as [%1$s]"
 msgstr "Αποθηκεύτηκε ως [%s]\n"
 
-#: schematic/src/x_window.c:887
 #, fuzzy, c-format
 msgid "Saved [%1$s]"
 msgstr "Αποθηκεύτηκε [%s]\n"
 
-#: schematic/src/x_window.c:889
 msgid "Saved"
 msgstr "Αποθηκεύτηκε"
 
-#: schematic/src/x_window.c:966
 #, c-format
 msgid "Discarding page [%1$s]"
 msgstr ""
 
-#: schematic/src/x_window.c:966
 #, fuzzy, c-format
 msgid "Closing [%1$s]"
 msgstr "Κλείσιμο [%s]\n"
 
-#: schematic/src/x_window.c:1175
 msgid "New"
 msgstr "Νέο"
 
-#: schematic/src/x_window.c:1175
 msgid "New file"
 msgstr "Νέο αρχείο"
 
-#: schematic/src/x_window.c:1179
 msgid "Open"
 msgstr "Άνοιγμα"
 
-#: schematic/src/x_window.c:1179
 #, fuzzy
 msgid "Open file"
 msgstr "Άνοιγμα αρχείου..."
 
-#: schematic/src/x_window.c:1183 schematic/scheme/gschem/builtins.scm:59
 msgid "Save"
 msgstr "Αποθήκευση"
 
-#: schematic/src/x_window.c:1183
 msgid "Save file"
 msgstr "Αποθήκευση αρχείου"
 
-#: schematic/src/x_window.c:1189 schematic/scheme/gschem/builtins.scm:93
 msgid "Undo"
 msgstr "Αναίρεση"
 
-#: schematic/src/x_window.c:1189
 msgid "Undo last operation"
 msgstr "Αναίρεση τελευταίας ενέργειας"
 
-#: schematic/src/x_window.c:1193 schematic/scheme/gschem/builtins.scm:96
 msgid "Redo"
 msgstr "Επαναφορά"
 
-#: schematic/src/x_window.c:1193
 msgid "Redo last undo"
 msgstr "Ακύρωση τελευταίας αναίρεσης"
 
-#: schematic/src/x_window.c:1198
 msgid ""
 "Add component...\n"
 "Select library and component from list, move the mouse into main window, "
@@ -2280,7 +1780,6 @@ msgstr ""
 "βασικό παράθυρο, κάντε κλικ για τοποθέτηση\n"
 "Δεξί κλικ για ακύρωση"
 
-#: schematic/src/x_window.c:1209
 msgid ""
 "Add nets mode\n"
 "Right mouse button to cancel"
@@ -2288,7 +1787,6 @@ msgstr ""
 "Λειτουργία προσθήκης δικτύου\n"
 "Δεξί κλικ για ακύρωση"
 
-#: schematic/src/x_window.c:1217
 msgid ""
 "Add buses mode\n"
 "Right mouse button to cancel"
@@ -2296,45 +1794,35 @@ msgstr ""
 "Λειτουργία προσθήκης διαύλου\n"
 "Δεξί κλικ για ακύρωση"
 
-#: schematic/src/x_window.c:1226
 msgid "Add Text..."
 msgstr "Προσθήκη κειμένου..."
 
-#: schematic/src/x_window.c:1233
 msgid "Select mode"
 msgstr "Λειτουργία επιλογής"
 
-#: schematic/src/x_window.c:1288
 #, fuzzy
 msgid "Show"
 msgstr "ΕμβάνισηΝ"
 
-#: schematic/src/x_window.c:1289
 msgid "Show text starting with:"
 msgstr "Εμφάνιση κειμένου που ξεκινάει με:"
 
-#: schematic/src/x_window.c:1345
 msgid "Menu/Cancel"
 msgstr "Μενού/Άκυρο"
 
-#: schematic/src/x_window.c:1349
 msgid "Pan/Cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1359
 msgid "Pick"
 msgstr ""
 
-#: schematic/src/x_window.c:1470 schematic/scheme/gschem/builtins.scm:180
 msgid "Status"
 msgstr "Κατάσταση"
 
-#: schematic/src/x_window.c:1568
 #, fuzzy, c-format
 msgid "New file [%s]"
 msgstr "Νέο αρχείο [%s]\n"
 
-#: schematic/src/x_window.c:1598
 #, fuzzy, c-format
 msgid ""
 "<b>An error occurred while loading the requested file.</b>\n"
@@ -2352,894 +1840,684 @@ msgstr ""
 "Το φόρτωμα από '%s' απέτυχε: %s. Η καταγραφή του gschem μπορεί να περιέχει "
 "περισσότερες πληροφορίες."
 
-#: schematic/src/x_window.c:1617
 msgid "Failed to load file"
 msgstr "Αποτυχία φορτώματος αρχείου"
 
-#: schematic/data/lepton-schematic.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Schematic Editor"
 msgstr "Επεξεργαστής Σχεδιαγραμμάτων gEDA"
 
-#: schematic/data/lepton-schematic.desktop.in:4
 #, fuzzy
 msgid "Create and edit electrical schematics and symbols with lepton-schematic"
 msgstr ""
 "Δημιουργείστε και επεξεργαστείτε ηλεκτρικά σχεδιαγράμματα και σύμβολα με το "
 "gschem"
 
-#: schematic/scheme/conf/schematic/menu.scm:27
 msgid "_New"
 msgstr "_Νέο"
 
-#: schematic/scheme/conf/schematic/menu.scm:28
 msgid "_Open..."
 msgstr "_Άνοιγμα..."
 
-#: schematic/scheme/conf/schematic/menu.scm:30
 msgid "Open Recen_t"
 msgstr "Άνοιγμα _προσφάτου"
 
-#: schematic/scheme/conf/schematic/menu.scm:32
 msgid "_Save"
 msgstr "_Αποθήκευση"
 
-#: schematic/scheme/conf/schematic/menu.scm:33
 msgid "Save _As..."
 msgstr "Αποθήκευση _ως..."
 
-#: schematic/scheme/conf/schematic/menu.scm:34
-#: schematic/scheme/gschem/builtins.scm:65
 msgid "Save All"
 msgstr "Αποθήκευση όλων"
 
-#: schematic/scheme/conf/schematic/menu.scm:36
 msgid "_Print..."
 msgstr "Ε_κτύπωση..."
 
-#: schematic/scheme/conf/schematic/menu.scm:37
 #, fuzzy
 msgid "Write _Image..."
 msgstr "Ε_γγραφή εικόνας..."
 
-#: schematic/scheme/conf/schematic/menu.scm:39
 msgid "Invoke Macro..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:41
 msgid "REPL..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:43
-#: schematic/scheme/gschem/builtins.scm:77
 msgid "New Window"
 msgstr "Νέο παράθυρο"
 
-#: schematic/scheme/conf/schematic/menu.scm:44
 msgid "_Close Window"
 msgstr "_Κλείσιμο παραθύρου"
 
-#: schematic/scheme/conf/schematic/menu.scm:45
 msgid "_Quit"
 msgstr "Έ_ξοδος"
 
-#: schematic/scheme/conf/schematic/menu.scm:51
 msgid "_Undo"
 msgstr "_Αναίρεση"
 
-#: schematic/scheme/conf/schematic/menu.scm:52
 msgid "_Redo"
 msgstr "Ε_παναφορά"
 
-#: schematic/scheme/conf/schematic/menu.scm:54
 msgid "Cu_t"
 msgstr "Α_ποκοπή"
 
-#: schematic/scheme/conf/schematic/menu.scm:55
 msgid "_Copy"
 msgstr "Α_ντιγραφή"
 
-#: schematic/scheme/conf/schematic/menu.scm:56
 msgid "_Paste"
 msgstr "Ε_πικόλληση"
 
-#: schematic/scheme/conf/schematic/menu.scm:57
 msgid "_Delete"
 msgstr "_Διαγραφή"
 
-#: schematic/scheme/conf/schematic/menu.scm:60
-#: schematic/scheme/gschem/builtins.scm:102
 msgid "Select All"
 msgstr "Επιλογή όλων"
 
-#: schematic/scheme/conf/schematic/menu.scm:61
-#: schematic/scheme/gschem/builtins.scm:105
 msgid "Deselect"
 msgstr "Αποεπιλογή"
 
-#: schematic/scheme/conf/schematic/menu.scm:65
 msgid "Rotate 90 Mode"
 msgstr "Λειτουργία περιστροφής 90"
 
-#: schematic/scheme/conf/schematic/menu.scm:70
 msgid "Edit Text..."
 msgstr "Επεξεργασία κειμένου..."
 
-#: schematic/scheme/conf/schematic/menu.scm:71
 msgid "Slot..."
 msgstr "Υποδοχή..."
 
-#: schematic/scheme/conf/schematic/menu.scm:76
-#: schematic/scheme/gschem/builtins.scm:150
 msgid "Embed Component/Picture"
 msgstr "Ενσωμάτωση στοιχείου/εικόνας"
 
-#: schematic/scheme/conf/schematic/menu.scm:77
-#: schematic/scheme/gschem/builtins.scm:153
 msgid "Unembed Component/Picture"
 msgstr "Αποενσωμάτωση στοιχείου/εικόνας"
 
-#: schematic/scheme/conf/schematic/menu.scm:78
-#: schematic/scheme/gschem/builtins.scm:156
 msgid "Update Component"
 msgstr "Ενημέρωση στοιχείου"
 
-#: schematic/scheme/conf/schematic/menu.scm:79
 msgid "Symbol Translate..."
 msgstr "Μετάφραση συμβόλου..."
 
-#: schematic/scheme/conf/schematic/menu.scm:85
 msgid "Copy into 1"
 msgstr "Αντιγραφή σε 1"
 
-#: schematic/scheme/conf/schematic/menu.scm:86
 msgid "Copy into 2"
 msgstr "Αντιγραφή σε 2"
 
-#: schematic/scheme/conf/schematic/menu.scm:87
 msgid "Copy into 3"
 msgstr "Αντιγραφή σε 3"
 
-#: schematic/scheme/conf/schematic/menu.scm:88
 msgid "Copy into 4"
 msgstr "Αντιγραφή σε 4"
 
-#: schematic/scheme/conf/schematic/menu.scm:89
 msgid "Copy into 5"
 msgstr "Αντιγραφή σε 5"
 
-#: schematic/scheme/conf/schematic/menu.scm:90
 msgid "Cut into 1"
 msgstr "Αποκοπή σε 1"
 
-#: schematic/scheme/conf/schematic/menu.scm:91
 msgid "Cut into 2"
 msgstr "Αποκοπή σε 2"
 
-#: schematic/scheme/conf/schematic/menu.scm:92
 msgid "Cut into 3"
 msgstr "Αποκοπή σε 3"
 
-#: schematic/scheme/conf/schematic/menu.scm:93
 msgid "Cut into 4"
 msgstr "Αποκοπή σε 4"
 
-#: schematic/scheme/conf/schematic/menu.scm:94
 msgid "Cut into 5"
 msgstr "Αποκοπή σε 5"
 
-#: schematic/scheme/conf/schematic/menu.scm:95
 msgid "Paste from 1"
 msgstr "Επικόλληση από 1"
 
-#: schematic/scheme/conf/schematic/menu.scm:96
 msgid "Paste from 2"
 msgstr "Επικόλληση από 2"
 
-#: schematic/scheme/conf/schematic/menu.scm:97
 msgid "Paste from 3"
 msgstr "Επικόλληση από 3"
 
-#: schematic/scheme/conf/schematic/menu.scm:98
 msgid "Paste from 4"
 msgstr "Επικόλληση από 4"
 
-#: schematic/scheme/conf/schematic/menu.scm:99
 msgid "Paste from 5"
 msgstr "Επικόλληση από 5"
 
-#: schematic/scheme/conf/schematic/menu.scm:105
 msgid "Side Dock"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:106
 #, fuzzy
 msgid "Bottom Dock"
 msgstr "Κάτω προς πάνω"
 
-#: schematic/scheme/conf/schematic/menu.scm:108
 #, fuzzy
 msgid "Find Text Results"
 msgstr "Εύρεση κειμένου"
 
-#: schematic/scheme/conf/schematic/menu.scm:110
 msgid "_Redraw"
 msgstr "_Επανασχεδίαση"
 
-#: schematic/scheme/conf/schematic/menu.scm:111
 msgid "_Pan"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:112
 msgid "Zoom _Box"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:113
 msgid "Zoom _Extents"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:114
 msgid "Zoom _In"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:115
 msgid "Zoom _Out"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:116
 msgid "Zoom _Full"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:118
 #, fuzzy
 msgid "_Dark Color Scheme"
 msgstr "Σχήμα _σκοτεινών χρωμάτων"
 
-#: schematic/scheme/conf/schematic/menu.scm:119
 #, fuzzy
 msgid "_Light Color Scheme"
 msgstr "Σχήμα _φωτεινών χρωμάτων"
 
-#: schematic/scheme/conf/schematic/menu.scm:120
 #, fuzzy
 msgid "B_W Color Scheme"
 msgstr "Σχήμα _σκοτεινών χρωμάτων"
 
-#: schematic/scheme/conf/schematic/menu.scm:122
 #, fuzzy
 msgid "Color Scheme Editor..."
 msgstr "Σχήμα _φωτεινών χρωμάτων"
 
-#: schematic/scheme/conf/schematic/menu.scm:129
 msgid "_Manager..."
 msgstr "_Διαχειριστής..."
 
-#: schematic/scheme/conf/schematic/menu.scm:131
 msgid "_Previous"
 msgstr "_Προηγούμενο"
 
-#: schematic/scheme/conf/schematic/menu.scm:132
 msgid "_Next"
 msgstr "_Επόμενο"
 
-#: schematic/scheme/conf/schematic/menu.scm:133
 msgid "_Close"
 msgstr "_Κλείσιμο"
 
-#: schematic/scheme/conf/schematic/menu.scm:135
 #, fuzzy
 msgid "_Revert..."
 msgstr "_Επαναφορά"
 
-#: schematic/scheme/conf/schematic/menu.scm:137
-#: schematic/scheme/gschem/builtins.scm:249
 #, fuzzy
 msgid "Next Tab"
 msgstr "Νέα σελίδα"
 
-#: schematic/scheme/conf/schematic/menu.scm:138
-#: schematic/scheme/gschem/builtins.scm:252
 #, fuzzy
 msgid "Previous Tab"
 msgstr "_Προηγούμενο"
 
-#: schematic/scheme/conf/schematic/menu.scm:146
 msgid "_Component..."
 msgstr "_Στοιχείο..."
 
-#: schematic/scheme/conf/schematic/menu.scm:148
 msgid "_Net"
 msgstr "_Δίκτυο"
 
-#: schematic/scheme/conf/schematic/menu.scm:149
 msgid "B_us"
 msgstr "Δ_ίαυλος"
 
-#: schematic/scheme/conf/schematic/menu.scm:151
 msgid "_Attribute..."
 msgstr "_Γνώρισμα..."
 
-#: schematic/scheme/conf/schematic/menu.scm:152
 msgid "_Text..."
 msgstr "_Κείμενο..."
 
-#: schematic/scheme/conf/schematic/menu.scm:154
 msgid "_Line"
 msgstr "_Γραμμή"
 
-#: schematic/scheme/conf/schematic/menu.scm:155
 msgid "Pat_h"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:156
 msgid "_Box"
 msgstr "_Κουτί"
 
-#: schematic/scheme/conf/schematic/menu.scm:157
 msgid "C_ircle"
 msgstr "_Κύκλος"
 
-#: schematic/scheme/conf/schematic/menu.scm:158
 msgid "A_rc"
 msgstr "_Τόξο"
 
-#: schematic/scheme/conf/schematic/menu.scm:159
 msgid "_Pin"
 msgstr "_Ακροδέκτης"
 
-#: schematic/scheme/conf/schematic/menu.scm:161
 msgid "Pictu_re..."
 msgstr "_Εικόνα..."
 
-#: schematic/scheme/conf/schematic/menu.scm:167
 msgid "_Up"
 msgstr "_Πάνω"
 
-#: schematic/scheme/conf/schematic/menu.scm:169
 msgid "_Down Schematic"
 msgstr "_Κάτω σχεδιάγραμμα"
 
-#: schematic/scheme/conf/schematic/menu.scm:170
 msgid "Down _Symbol"
 msgstr "Κάτω _σύμβολο"
 
-#: schematic/scheme/conf/schematic/menu.scm:176
 msgid "_Attach"
 msgstr "_Σύνδεση"
 
-#: schematic/scheme/conf/schematic/menu.scm:177
 msgid "_Detach"
 msgstr "_Αποσύνδεση"
 
-#: schematic/scheme/conf/schematic/menu.scm:179
 msgid "Show _Value"
 msgstr "Εμφάνιση _τιμής"
 
-#: schematic/scheme/conf/schematic/menu.scm:180
 msgid "Show _Name"
 msgstr "Εμφάνιση _ονόματος"
 
-#: schematic/scheme/conf/schematic/menu.scm:181
 msgid "Show _Both"
 msgstr "Εμφάνιση _και των δύο"
 
-#: schematic/scheme/conf/schematic/menu.scm:182
 msgid "_Toggle Visibility"
 msgstr "Εναλλαγή ορατότητας"
 
-#: schematic/scheme/conf/schematic/menu.scm:184
 msgid "_Hide Specific Text..."
 msgstr "_Απόκρυψη συγκεκριμένου κειμένου..."
 
-#: schematic/scheme/conf/schematic/menu.scm:185
 msgid "_Show Specific Text..."
 msgstr "_Εμφάνιση συγκεκριμένου κειμένου..."
 
-#: schematic/scheme/conf/schematic/menu.scm:186
 #, fuzzy
 msgid "Show/Hide Hidden Text"
 msgstr "Εμφάνιση κρυφών"
 
-#: schematic/scheme/conf/schematic/menu.scm:188
 msgid "_Find Text/Check Symbol..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:189
 msgid "A_utonumber Text..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:195
 #, fuzzy
 msgid "_Options..."
 msgstr "_Επιλογές"
 
-#: schematic/scheme/conf/schematic/menu.scm:196
 #, fuzzy
 msgid "_Font..."
 msgstr "Ε_κτύπωση..."
 
-#: schematic/scheme/conf/schematic/menu.scm:198
 #, fuzzy
 msgid "Grid +"
 msgstr "Λειτουργία τόξου"
 
-#: schematic/scheme/conf/schematic/menu.scm:199
 #, fuzzy
 msgid "Grid -"
 msgstr "Λειτουργία τόξου"
 
-#: schematic/scheme/conf/schematic/menu.scm:201
 msgid "Grid Style: Cycle Dots/Mesh/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:202
 msgid "Grid Snap: Cycle Grid/Resnap/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:204
 #, fuzzy
 msgid "Feedback Mode: Outline/Box"
 msgstr "Εναλλαγή _περιγράμματος/κουτιού"
 
-#: schematic/scheme/conf/schematic/menu.scm:205
 msgid "Net: Rubberband On/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:206
 msgid "Net: Magnetic On/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:208
 #, fuzzy
 msgid "_Coord Window"
 msgstr "_Κλείσιμο παραθύρου"
 
-#: schematic/scheme/conf/schematic/menu.scm:209
 #, fuzzy
 msgid "_Log Window"
 msgstr "Εμφάνιση παραθύρου καταγραφής..."
 
-#: schematic/scheme/conf/schematic/menu.scm:215
 msgid "_1 allegro"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:223
 #, fuzzy
 msgid "User _Guide"
 msgstr "_Συχνές ερωτήσεις gschem..."
 
-#: schematic/scheme/conf/schematic/menu.scm:224
 msgid "_FAQ"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:225
 #, fuzzy
 msgid "Docu_mentation"
 msgstr "_Τεκμηρίωση..."
 
-#: schematic/scheme/conf/schematic/menu.scm:226
 msgid "_Wiki"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:228
 #, fuzzy
 msgid "Find Component D_ocumentation"
 msgstr "Τεκμηρίωση _στοιχείων"
 
-#: schematic/scheme/conf/schematic/menu.scm:230
 msgid "_Hotkeys..."
 msgstr "_Γρήγορα πλήκτρα"
 
-#: schematic/scheme/conf/schematic/menu.scm:231
 #, fuzzy
 msgid "_About"
 msgstr "_Σχετικά..."
 
-#: schematic/scheme/conf/schematic/menu.scm:237
 msgid "_File"
 msgstr "_Αρχείο"
 
-#: schematic/scheme/conf/schematic/menu.scm:238
 msgid "_Edit"
 msgstr "_Επεξεργασία"
 
-#: schematic/scheme/conf/schematic/menu.scm:240
 msgid "_View"
 msgstr "_Προβολή"
 
-#: schematic/scheme/conf/schematic/menu.scm:241
 msgid "_Page"
 msgstr "_Σελίδα"
 
-#: schematic/scheme/conf/schematic/menu.scm:242
 msgid "_Add"
 msgstr "_Προσθήκη"
 
-#: schematic/scheme/conf/schematic/menu.scm:243
 msgid "Hie_rarchy"
 msgstr "_Ιεραρχία"
 
-#: schematic/scheme/conf/schematic/menu.scm:244
 msgid "A_ttributes"
 msgstr "_Γνωρίσματα"
 
-#: schematic/scheme/conf/schematic/menu.scm:245
 msgid "_Options"
 msgstr "_Επιλογές"
 
-#: schematic/scheme/conf/schematic/menu.scm:246
 #, fuzzy
 msgid "_Netlist"
 msgstr "_Δίκτυο"
 
-#: schematic/scheme/conf/schematic/menu.scm:247
 msgid "_Help"
 msgstr "_Βοήθεια"
 
-#: schematic/scheme/gschem/action.scm:43
 #, fuzzy, scheme-format
 msgid "~S is not a valid gschem action."
 msgstr "Το ~S δεν είναι έγκυρος συνδιασμός πλήκτρων."
 
-#: schematic/scheme/gschem/action.scm:158
 msgid "Repeat Last Action"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:47
 #, fuzzy
 msgid "Cancel"
 msgstr "Μενού/Άκυρο"
 
-#: schematic/scheme/gschem/builtins.scm:53
 #, fuzzy
 msgid "New File"
 msgstr "Νέο αρχείο"
 
-#: schematic/scheme/gschem/builtins.scm:56
 #, fuzzy
 msgid "Open File"
 msgstr "Άνοιγμα αρχείου..."
 
-#: schematic/scheme/gschem/builtins.scm:62
 #, fuzzy
 msgid "Save As"
 msgstr "Αποθήκευση όλων"
 
-#: schematic/scheme/gschem/builtins.scm:68
 #, fuzzy
 msgid "Print"
 msgstr "Εκτύπωση..."
 
-#: schematic/scheme/gschem/builtins.scm:71
 msgid "Export Image"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:74
 msgid "Run Script"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:80
 #, fuzzy
 msgid "Close Window"
 msgstr "_Κλείσιμο παραθύρου"
 
-#: schematic/scheme/gschem/builtins.scm:83
 #, fuzzy
 msgid "Quit"
 msgstr "Έ_ξοδος"
 
-#: schematic/scheme/gschem/builtins.scm:87
 msgid "Terminal REPL"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:132
 msgid "Choose Slot"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:135
 #, fuzzy
 msgid "Edit Object Properties"
 msgstr "Επεξεργασία ιδιοτήτων κειμένου"
 
-#: schematic/scheme/gschem/builtins.scm:138
 #, fuzzy
 msgid "Translate Symbol"
 msgstr "Μετάφραση"
 
-#: schematic/scheme/gschem/builtins.scm:147
 msgid "Invoke Macro"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:159
 msgid "Show/Hide Invisible Text"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:165
 #, fuzzy
 msgid "Cut"
 msgstr "Α_ποκοπή"
 
-#: schematic/scheme/gschem/builtins.scm:171
 #, fuzzy
 msgid "Paste"
 msgstr "Ε_πικόλληση"
 
-#: schematic/scheme/gschem/builtins.scm:177
 msgid "Sidebar"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:183
 #, fuzzy
 msgid "Find Text State"
 msgstr "Εύρεση κειμένου"
 
-#: schematic/scheme/gschem/builtins.scm:186
 #, fuzzy
 msgid "Redraw"
 msgstr "_Επανασχεδίαση"
 
-#: schematic/scheme/gschem/builtins.scm:192
 msgid "Pan Left"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:195
 #, fuzzy
 msgid "Pan Right"
 msgstr "Πάνω δεξιά"
 
-#: schematic/scheme/gschem/builtins.scm:198
 msgid "Pan Up"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:201
 msgid "Pan Down"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:216
 msgid "Zoom Full"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:219
 #, fuzzy
 msgid "Dark Color Scheme"
 msgstr "Σχήμα _σκοτεινών χρωμάτων"
 
-#: schematic/scheme/gschem/builtins.scm:222
 #, fuzzy
 msgid "Light Color Scheme"
 msgstr "Σχήμα _φωτεινών χρωμάτων"
 
-#: schematic/scheme/gschem/builtins.scm:225
 msgid "Monochrome Color Scheme"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:228
 #, fuzzy
 msgid "Show Color Scheme Editor"
 msgstr "Σχήμα _φωτεινών χρωμάτων"
 
-#: schematic/scheme/gschem/builtins.scm:234
 #, fuzzy
 msgid "Revert Changes"
 msgstr "Σίγουρα επαναφορά σελίδας;"
 
-#: schematic/scheme/gschem/builtins.scm:240
 #, fuzzy
 msgid "Previous Page"
 msgstr "_Προηγούμενο"
 
-#: schematic/scheme/gschem/builtins.scm:243
 #, fuzzy
 msgid "Next Page"
 msgstr "Νέα σελίδα"
 
-#: schematic/scheme/gschem/builtins.scm:255
 #, fuzzy
 msgid "Print Page"
 msgstr "_Προηγούμενο"
 
-#: schematic/scheme/gschem/builtins.scm:276
 #, fuzzy
 msgid "Add Line"
 msgstr "Γραμμή"
 
-#: schematic/scheme/gschem/builtins.scm:279
 #, fuzzy
 msgid "Add Path"
 msgstr "/Προσθήκη δικτύου"
 
-#: schematic/scheme/gschem/builtins.scm:282
 #, fuzzy
 msgid "Add Box"
 msgstr "/Προσθήκη διαύλου"
 
-#: schematic/scheme/gschem/builtins.scm:285
 #, fuzzy
 msgid "Add Circle"
 msgstr "Κύκλος"
 
-#: schematic/scheme/gschem/builtins.scm:288
 #, fuzzy
 msgid "Add Arc"
 msgstr "Προσθήκη γνωρίσματος"
 
-#: schematic/scheme/gschem/builtins.scm:291
 msgid "Add Pin"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:294
 #, fuzzy
 msgid "Add Picture"
 msgstr "Εικόνα"
 
-#: schematic/scheme/gschem/builtins.scm:306
 #, fuzzy
 msgid "Up Hierarchy"
 msgstr "_Ιεραρχία"
 
-#: schematic/scheme/gschem/builtins.scm:312
 #, fuzzy
 msgid "Attach Attributes"
 msgstr "Επεξεργασία γνωρισμάτων"
 
-#: schematic/scheme/gschem/builtins.scm:315
 #, fuzzy
 msgid "Detach Attributes"
 msgstr "Αποσυνδεδεμένο γνώρισμα"
 
-#: schematic/scheme/gschem/builtins.scm:318
 #, fuzzy
 msgid "Show Attribute Value"
 msgstr "Το γνώρισμα υποδοχής είναι παραμορφωμένο\n"
 
-#: schematic/scheme/gschem/builtins.scm:321
 #, fuzzy
 msgid "Show Attribute Name"
 msgstr "Το γνώρισμα υποδοχής είναι παραμορφωμένο\n"
 
-#: schematic/scheme/gschem/builtins.scm:327
 #, fuzzy
 msgid "Toggle Text Visibility"
 msgstr "Εναλλαγή ορατότητας"
 
-#: schematic/scheme/gschem/builtins.scm:330
 #, fuzzy
 msgid "Find Specific Text"
 msgstr "_Εύρεση συγκεκριμένου κειμένου..."
 
-#: schematic/scheme/gschem/builtins.scm:333
 #, fuzzy
 msgid "Hide Specific Text"
 msgstr "_Απόκρυψη συγκεκριμένου κειμένου..."
 
-#: schematic/scheme/gschem/builtins.scm:336
 #, fuzzy
 msgid "Show Specific Text"
 msgstr "_Εμφάνιση συγκεκριμένου κειμένου..."
 
-#: schematic/scheme/gschem/builtins.scm:339
 msgid "Autonumber Text"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:345
 #, fuzzy
 msgid "Show Hotkeys"
 msgstr "Γρήγορα Πλήκτρα"
 
-#: schematic/scheme/gschem/builtins.scm:348
 msgid "Switch Grid Style"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:351
 msgid "Switch Snap Mode"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:354
 #, fuzzy
 msgid "Set Grid Spacing"
 msgstr "Σημείο πλέγματος"
 
-#: schematic/scheme/gschem/builtins.scm:357
 msgid "Increase Grid Spacing"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:360
 msgid "Decrease Grid Spacing"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:363
 #, fuzzy
 msgid "Toggle Outline Drawing"
 msgstr "Εναλλαγή _περιγράμματος/κουτιού"
 
-#: schematic/scheme/gschem/builtins.scm:366
 msgid "Toggle Net Rubber Band"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:369
 #, fuzzy
 msgid "Toggle Magnetic Nets"
 msgstr "Εναλλαγή _μαγνητικού δικτύου"
 
-#: schematic/scheme/gschem/builtins.scm:372
 #, fuzzy
 msgid "Show Log Window"
 msgstr "Εμφάνιση παραθύρου καταγραφής..."
 
-#: schematic/scheme/gschem/builtins.scm:375
 #, fuzzy
 msgid "Show Coordinate Window"
 msgstr "Εμφάνιση παραθύρου συντεταγμένων..."
 
-#: schematic/scheme/gschem/builtins.scm:385
 #, fuzzy
 msgid "Component Documentation"
 msgstr "Τεκμηρίωση _στοιχείων"
 
-#: schematic/scheme/gschem/builtins.scm:387
 msgid "View documentation for selected component"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:403
 msgid ""
 "Could not show documentation for selected component:\n"
 "\n"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:408
 msgid "gEDA Manuals"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:409
 msgid "View the front page of the gEDA documentation in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:414
 #, fuzzy
 msgid "gschem User Guide"
 msgstr "_Συχνές ερωτήσεις gschem..."
 
-#: schematic/scheme/gschem/builtins.scm:415
 msgid "View the gschem User Guide in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:420
 #, fuzzy
 msgid "gschem FAQ"
 msgstr "_Συχνές ερωτήσεις gschem..."
 
-#: schematic/scheme/gschem/builtins.scm:421
 msgid "Frequently Asked Questions about using gschem."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:426
 #, fuzzy
 msgid "gEDA wiki"
 msgstr "gEDA _Wiki..."
 
-#: schematic/scheme/gschem/builtins.scm:427
 msgid "View the front page of the gEDA wiki in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:431
 msgid "About gschem"
 msgstr "Σχετικά με το gschem"
 
-#: schematic/scheme/gschem/deprecated.scm:102
 #, scheme-format
 msgid "Invalid text alignment ~A."
 msgstr "Μη έγκυρη στοίχιση κειμένου ~A."
 
-#: schematic/scheme/gschem/gschemdoc.scm:241
 msgid "No documentation found"
 msgstr "Δε βρέθηκε τεκμηρίωση"
 
-#: schematic/scheme/gschem/keymap.scm:40
 #, scheme-format
 msgid "~S is not a valid key combination."
 msgstr "Το ~S δεν είναι έγκυρος συνδιασμός πλήκτρων."
 
-#: schematic/scheme/gschem/keymap.scm:157
 #, scheme-format
 msgid "~S is not a prefix key sequence."
 msgstr ""

--- a/schematic/po/en_GB.po
+++ b/schematic/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-15 15:13+0300\n"
+"POT-Creation-Date: 2019-02-22 14:08+0300\n"
 "PO-Revision-Date: 2012-01-31 12:14+0000\n"
 "Last-Translator: Peter TB Brett <Unknown>\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -18,24 +18,20 @@ msgstr ""
 "X-Launchpad-Export-Date: 2012-11-14 16:52+0000\n"
 "X-Generator: Launchpad (build 16265)\n"
 
-#: schematic/src/a_zoom.c:155
 #, fuzzy
 msgid "Zoom too small!  Cannot zoom further."
 msgstr "Zoom too small!  Cannot zoom further.\n"
 
-#: schematic/src/color_edit_widget.c:399
 #, fuzzy, c-format
 msgid ""
 "Could not save file [%s]:\n"
 "%s"
 msgstr "Could NOT save page [%s]\n"
 
-#: schematic/src/color_edit_widget.c:434
 #, fuzzy
 msgid "Save Color Scheme As..."
 msgstr "_Light colour scheme"
 
-#: schematic/src/color_edit_widget.c:482 schematic/src/x_fileselect.c:292
 #, fuzzy, c-format
 msgid ""
 "The selected file `%1$s' already exists.\n"
@@ -46,179 +42,141 @@ msgstr ""
 "\n"
 "Would you like to overwrite it?"
 
-#: schematic/src/color_edit_widget.c:486 schematic/src/x_fileselect.c:295
 msgid "Overwrite file?"
 msgstr "Overwrite file?"
 
-#: schematic/src/font_select_widget.c:211
 msgid "_Apply"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:215
 msgid "Sa_ve..."
 msgstr ""
 
-#: schematic/src/font_select_widget.c:278
 #, c-format
 msgid "<b>Current:</b> %s"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:453
 msgid "Save configuration"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:461
 #, fuzzy
 msgid "Save settings to:"
 msgstr "Settings"
 
-#: schematic/src/font_select_widget.c:465
 msgid "Local configuration file (in current directory)"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:467
 msgid "User configuration file (geda-user.conf)"
 msgstr ""
 
-#: schematic/src/g_attrib.c:90
 msgid "Object ~A is not included in the current gschem page."
 msgstr "Object ~A is not included in the current gschem page."
 
-#: schematic/src/g_attrib.c:110
 msgid "Invalid text name/value visibility ~A."
 msgstr "Invalid text name/value visibility ~A."
 
-#: schematic/src/g_rc.c:107
 #, fuzzy, c-format
 msgid "You are running gEDA/gaf version [%1$s%2$s.%3$s],\n"
 msgstr "gEDA/gschem version %s%s.%s\n"
 
-#: schematic/src/g_rc.c:111
 #, c-format
 msgid ""
 "but you have a version [%1$s] gschemrc file:\n"
 "[%2$s]\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:114
 #, c-format
 msgid "Please be sure that you have the latest rc file.\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:240
 #, fuzzy, c-format
 msgid "Invalid size [%1$d] passed to text-size\n"
 msgstr "Invalid size [%d] passed to text-size\n"
 
-#: schematic/src/g_rc.c:283
 #, fuzzy, c-format
 msgid "Invalid size [%1$d] passed to snap-size\n"
 msgstr "Invalid size [%d] passed to snap-size\n"
 
-#: schematic/src/g_rc.c:620
 #, fuzzy, c-format
 msgid "Invalid num levels [%1$d] passed to undo-levels\n"
 msgstr "Invalid num levels [%d] passed to undo-levels\n"
 
-#: schematic/src/g_rc.c:831
 #, fuzzy, c-format
 msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
 msgstr "Invalid size [%d] passed to bus-ripper-size\n"
 
-#: schematic/src/g_rc.c:931
 #, fuzzy, c-format
 msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
 msgstr "Invalid dot size [%d] passed to dots-grid-dot-size\n"
 
-#: schematic/src/g_rc.c:972
 #, fuzzy, c-format
 msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
 msgstr "Invalid pixel spacing [%d] passed to dots-grid-fixed-threshold\n"
 
-#: schematic/src/g_rc.c:998
 #, fuzzy, c-format
 msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
 msgstr "Invalid pixel spacing [%d] passed to mesh-grid-display-threshold\n"
 
-#: schematic/src/g_rc.c:1023
 #, fuzzy, c-format
 msgid "Invalid offset [%1$d] passed to add-attribute-offset\n"
 msgstr "Invalid offset [%d] passed to add-attribute-offset\n"
 
-#: schematic/src/g_rc.c:1047
 #, fuzzy, c-format
 msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
 msgstr "Invalid number of seconds [%d] passed to auto-save-interval\n"
 
-#: schematic/src/g_rc.c:1071
 #, fuzzy, c-format
 msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
 msgstr "Invalid gain [%d] passed to mousepan-gain\n"
 
-#: schematic/src/g_rc.c:1094
 #, fuzzy, c-format
 msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
 msgstr "Invalid gain [%d] passed to keyboardpan-gain\n"
 
-#: schematic/src/g_rc.c:1118
 #, fuzzy, c-format
 msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
 msgstr "Invalid number of pixels [%d] passed to select-slack-pixels\n"
 
-#: schematic/src/g_rc.c:1144
 #, fuzzy, c-format
 msgid "Invalid gain [%1$d] passed to zoom-gain\n"
 msgstr "Invalid gain [%d] passed to zoom-gain\n"
 
-#: schematic/src/g_rc.c:1169
 #, fuzzy, c-format
 msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
 msgstr "Invalid number of steps [%d] scrollpan-steps\n"
 
-#: schematic/src/g_select.c:78 schematic/src/g_select.c:115
-#: schematic/src/g_select.c:151
 msgid "Object ~A is not directly included in a page."
 msgstr "Object ~A is not directly included in a page."
 
-#: schematic/src/g_util.c:54
 msgid "Could not launch URI ~S: ~A"
 msgstr "Could not launch URI ~S: ~A"
 
-#: schematic/src/g_window.c:139
 msgid "Found invalid gschem window smob ~S"
 msgstr "Found invalid gschem window smob ~S"
 
-#: schematic/src/lepton-schematic.c:156
 #, fuzzy, c-format
 msgid "Lepton EDA/lepton-schematic version %1$s%2$s.%3$s git: %4$.7s"
 msgstr "gEDA/gschem version %s%s.%s\n"
 
-#: schematic/src/lepton-schematic.c:163
 #, c-format
 msgid "This is the MINGW32 port.\n"
 msgstr "This is the MINGW32 port.\n"
 
-#: schematic/src/lepton-schematic.c:167
 #, fuzzy, c-format
 msgid "Current locale settings: %1$s\n"
 msgstr "Current locale settings: %s\n"
 
-#: schematic/src/lepton-schematic.c:201
 #, fuzzy, c-format
 msgid "Couldn't find init scm file [%1$s]"
 msgstr "Couldn't find init scm file [%s]\n"
 
-#: schematic/src/lepton-schematic.c:206
 #, fuzzy, c-format
 msgid "Read init scm file [%1$s]"
 msgstr "Read init scm file [%s]\n"
 
-#: schematic/src/lepton-schematic.c:210
 #, fuzzy, c-format
 msgid "Failed to read init scm file [%1$s]"
 msgstr "Failed to read init scm file [%s]\n"
 
-#: schematic/src/lepton-schematic.c:290
 #, fuzzy, c-format
 msgid ""
 "ERROR: Failed to load or evaluate startup script.\n"
@@ -229,711 +187,531 @@ msgstr ""
 "\n"
 "The gschem log may contain more information."
 
-#: schematic/src/gschem_about_dialog.c:51
 #, fuzzy, c-format
 msgid "%s (git: %.7s)"
 msgstr "%s (g%.7s)"
 
-#: schematic/src/gschem_about_dialog.c:75
 #, fuzzy
 msgid "Lepton Electronic Design Automation"
 msgstr "gEDA: GPL Electronic Design Automation"
 
-#: schematic/src/gschem_about_dialog.c:83
 #, fuzzy
 msgid ""
 "Copyright © 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright © 2017-2018 Lepton Developers.\n"
-"See AUTHORS and ChangeLog files for details."
+"Copyright © 2017-2019 Lepton Developers.\n"
+"See AUTHORS, ChangeLog files and consult 'git log' history for details."
 msgstr ""
 "Copyright © 1998-2012 Ales Hvezda <ahvezda@geda.seul.org>\n"
 "Copyright © 1998-2012 gEDA Contributors (see ChangeLog for details)"
 
-#: schematic/src/gschem_alignment_combo.c:69
 msgid "Upper Left"
 msgstr "Upper Left"
 
-#: schematic/src/gschem_alignment_combo.c:71
 msgid "Upper Middle"
 msgstr "Upper Middle"
 
-#: schematic/src/gschem_alignment_combo.c:73
 #, fuzzy
 msgid "Upper Right"
 msgstr "Lower Right"
 
-#: schematic/src/gschem_alignment_combo.c:78
 msgid "Middle Left"
 msgstr "Middle Left"
 
-#: schematic/src/gschem_alignment_combo.c:80
 msgid "Middle Middle"
 msgstr "Middle Middle"
 
-#: schematic/src/gschem_alignment_combo.c:82
 msgid "Middle Right"
 msgstr "Middle Right"
 
-#: schematic/src/gschem_alignment_combo.c:87
 msgid "Lower Left"
 msgstr "Lower Left"
 
-#: schematic/src/gschem_alignment_combo.c:89
 msgid "Lower Middle"
 msgstr "Lower Middle"
 
-#: schematic/src/gschem_alignment_combo.c:91
 msgid "Lower Right"
 msgstr "Lower Right"
 
-#: schematic/src/gschem_arc_dialog.c:104
 msgid "Arc Params"
 msgstr "Arc Params"
 
-#: schematic/src/gschem_arc_dialog.c:140
 #, fuzzy
 msgid "Arc _Radius:"
 msgstr "Arc Radius:"
 
-#: schematic/src/gschem_arc_dialog.c:141
 #, fuzzy
 msgid "Start _Angle:"
 msgstr "Start Angle:"
 
-#: schematic/src/gschem_arc_dialog.c:142
 #, fuzzy
 msgid "_Degrees of Sweep:"
 msgstr "Degrees of Sweep:"
 
-#: schematic/src/gschem_bottom_widget.c:504
 msgid "Left mouse button"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:508
 #, fuzzy
 msgid "Middle mouse button"
 msgstr "Middle Left"
 
-#: schematic/src/gschem_bottom_widget.c:512
 #, fuzzy
 msgid "Right mouse button"
 msgstr ""
 "Add nets mode\n"
 "Right mouse button to cancel"
 
-#: schematic/src/gschem_bottom_widget.c:595
 msgid "(Snap size, Grid size)"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:603
 #, fuzzy
 msgid "Net rubber band mode"
 msgstr "Toggle Net _Rubberband"
 
-#: schematic/src/gschem_bottom_widget.c:614
 #, fuzzy
 msgid "Magnetic net mode"
 msgstr "Magnetic Net Mode"
 
-#: schematic/src/gschem_bottom_widget.c:622
 #, fuzzy
 msgid "Current action mode"
 msgstr "Current Window"
 
-#: schematic/src/gschem_bottom_widget.c:935
-#: schematic/src/gschem_bottom_widget.c:951
 msgid "OFF"
 msgstr "OFF"
 
-#: schematic/src/gschem_bottom_widget.c:954
 msgid "NONE"
 msgstr "NONE"
 
-#: schematic/src/gschem_bottom_widget.c:960
 #, fuzzy, c-format
 msgid "Grid(%1$s, %2$s)"
 msgstr "Grid(%s, %s)"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:350
-#: schematic/src/x_compselect.c:1236 schematic/src/x_multiattrib.c:2068
 msgid "Name"
 msgstr "Name"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:372
 msgid "S_elect the schematics you want to save:"
 msgstr "S_elect the schematics you want to save:"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:467
 #, fuzzy, c-format
 msgid "Save the changes to schematic \"%1$s\" before closing?"
 msgstr "Save the changes to schematic \"%s\" before closing?"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:473
 #, fuzzy, c-format
 msgid ""
 "There are %1$d schematics with unsaved changes. Save changes before closing?"
 msgstr ""
 "There are %d schematics with unsaved changes. Save changes before closing?"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:502
 msgid "If you don't save, all your changes will be permanently lost."
 msgstr "If you don't save, all your changes will be permanently lost."
 
-#: schematic/src/gschem_close_confirmation_dialog.c:522
 #, fuzzy
 msgid "Close _without saving"
 msgstr "_Close without saving"
 
-#: schematic/src/gschem_coord_dialog.c:86
 msgid "Coords"
 msgstr "Coords"
 
-#: schematic/src/gschem_coord_dialog.c:106
 msgid "Screen"
 msgstr "Screen"
 
-#: schematic/src/gschem_coord_dialog.c:115
 msgid "World"
 msgstr "World"
 
-#: schematic/src/gschem_find_text_state.c:809 schematic/src/x_pagesel.c:432
 msgid "Filename"
 msgstr "Filename"
 
-#: schematic/src/gschem_find_text_state.c:821 schematic/src/i_callbacks.c:1970
-#: schematic/src/x_colorcb.c:154 schematic/src/x_widgets.c:179
-#: schematic/src/x_window.c:1226 schematic/src/x_window.c:1440
 msgid "Text"
 msgstr "Text"
 
-#: schematic/src/gschem_find_text_widget.c:427
 msgid "descend into hierarchy"
 msgstr "descend into hierarchy"
 
-#: schematic/src/gschem_find_text_widget.c:435
 #, fuzzy
 msgid "Find"
 msgstr "Find Text"
 
-#: schematic/src/gschem_find_text_widget.c:557
 #, fuzzy
 msgid "Find Text:"
 msgstr "Find Text"
 
-#: schematic/src/gschem_find_text_widget.c:564
 msgid "Find Pattern:"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:571
 #, fuzzy
 msgid "Find Regex:"
 msgstr "Find Text"
 
-#: schematic/src/gschem_find_text_widget.c:578
 msgid "Check symbol:"
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:200
 msgid "Hotkeys"
 msgstr "Hotkeys"
 
-#: schematic/src/gschem_hotkey_dialog.c:229
 msgid ""
 "Start typing action name or keystroke to filter the list.\n"
 "Type hotkeys as they are displayed in \"Keystroke(s)\" column."
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:233 schematic/src/x_compselect.c:1124
 #, fuzzy
 msgid "_Filter:"
 msgstr "Filter:"
 
-#: schematic/src/gschem_hotkey_dialog.c:259 schematic/src/i_basic.c:280
 msgid "Action"
 msgstr "Action"
 
-#: schematic/src/gschem_hotkey_dialog.c:277
 msgid "Keystroke(s)"
 msgstr "Keystroke(s)"
 
-#: schematic/src/gschem_log_widget.c:177
 msgid "** Invalid UTF-8 in log message. See stderr or gschem.log.\n"
 msgstr "** Invalid UTF-8 in log message. See stderr or gschem.log.\n"
 
-#: schematic/src/gschem_log_widget.c:434
 #, fuzzy
 msgid "Clear log window?"
 msgstr "Closing Window\n"
 
-#: schematic/src/gschem_log_widget.c:477
 #, fuzzy
 msgid "Clear Log _Window"
 msgstr "Show _Log Window..."
 
-#: schematic/src/gschem_macro_widget.c:231
 msgid "Macro:"
 msgstr ""
 
-#: schematic/src/gschem_macro_widget.c:387
 #, fuzzy
 msgid "Evaluate"
 msgstr "Evaluate:"
 
-#: schematic/src/gschem_object_properties_widget.c:172
 #, fuzzy
 msgid "_Fill Type:"
 msgstr "Fill Type:"
 
-#: schematic/src/gschem_object_properties_widget.c:173
 #, fuzzy
 msgid "Lin_e Width:"
 msgstr "Line Width:"
 
-#: schematic/src/gschem_object_properties_widget.c:174
 #, fuzzy
 msgid "Angle _1:"
 msgstr "Angle 1:"
 
-#: schematic/src/gschem_object_properties_widget.c:175
 #, fuzzy
 msgid "P_itch 1:"
 msgstr "Pitch 1:"
 
-#: schematic/src/gschem_object_properties_widget.c:176
 #, fuzzy
 msgid "Angle _2:"
 msgstr "Angle 2:"
 
-#: schematic/src/gschem_object_properties_widget.c:177
 #, fuzzy
 msgid "Pitc_h 2:"
 msgstr "Pitch 2:"
 
-#: schematic/src/gschem_object_properties_widget.c:237
 #, fuzzy
 msgid "<b>Fill Properties</b>"
 msgstr "<b>Text Properties</b>"
 
-#: schematic/src/gschem_object_properties_widget.c:255
-#: schematic/src/gschem_text_properties_widget.c:258
-#: schematic/src/x_newtext.c:271
 #, fuzzy
 msgid "Colo_r:"
 msgstr "Colour:"
 
-#: schematic/src/gschem_object_properties_widget.c:266
 #, fuzzy
 msgid "<b>General Properties</b>"
 msgstr "<b>Text Properties</b>"
 
-#: schematic/src/gschem_object_properties_widget.c:284
 #, fuzzy
 msgid "_Type:"
 msgstr "Type:"
 
-#: schematic/src/gschem_object_properties_widget.c:285
 #, fuzzy
 msgid "_Width:"
 msgstr "Width:"
 
-#: schematic/src/gschem_object_properties_widget.c:286
 #, fuzzy
 msgid "Dash _Length:"
 msgstr "Dash Length:"
 
-#: schematic/src/gschem_object_properties_widget.c:287
 #, fuzzy
 msgid "Dash _Space:"
 msgstr "Dash Space:"
 
-#: schematic/src/gschem_object_properties_widget.c:288
 msgid "C_ap style:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:333
 #, fuzzy
 msgid "<b>Line Properties</b>"
 msgstr "<b>Text Properties</b>"
 
-#: schematic/src/gschem_object_properties_widget.c:351
 #, fuzzy
 msgid "_Pin Type:"
 msgstr "Pin type"
 
-#: schematic/src/gschem_object_properties_widget.c:362
 #, fuzzy
 msgid "<b>Pin Properties</b>"
 msgstr "<b>Text Properties</b>"
 
-#: schematic/src/gschem_options_widget.c:217
 msgid "_Off"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:220
 msgid "_Dots"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:223
 msgid "M_esh"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:245
 #, fuzzy
 msgid "Net R_ubber Band Mode:"
 msgstr "Toggle Net _Rubberband"
 
-#: schematic/src/gschem_options_widget.c:246
 #, fuzzy
 msgid "_Magnetic Net Mode:"
 msgstr "Magnetic Net Mode"
 
-#: schematic/src/gschem_options_widget.c:250
-#: schematic/src/gschem_options_widget.c:251
 msgid "Enabled"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:265
 #, fuzzy
 msgid "<b>Net Options</b>"
 msgstr "<b>Options</b>"
 
-#: schematic/src/gschem_options_widget.c:282
 #, fuzzy
 msgid "Grid Mode:"
 msgstr "Arc Mode"
 
-#: schematic/src/gschem_options_widget.c:283
 #, fuzzy
 msgid "Snap Mode:"
 msgstr "Pan Mode"
 
-#: schematic/src/gschem_options_widget.c:284
 #, fuzzy
 msgid "_Snap Size:"
 msgstr "Snap Size"
 
-#: schematic/src/gschem_options_widget.c:301
 #, fuzzy
 msgid "<b>Snap Options</b>"
 msgstr "<b>Options</b>"
 
-#: schematic/src/gschem_options_widget.c:340
 msgid "O_ff"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:343
 #, fuzzy
 msgid "_Grid"
 msgstr "Grid OFF\n"
 
-#: schematic/src/gschem_options_widget.c:346
 #, fuzzy
 msgid "_Resnap"
 msgstr "Resnap Active"
 
-#: schematic/src/gschem_pin_type_combo.c:73
 msgid "Net pin"
 msgstr "Net pin"
 
-#: schematic/src/gschem_pin_type_combo.c:80
 msgid "Bus pin (graphical)"
 msgstr "Bus pin (graphical)"
 
-#: schematic/src/gschem_preview.c:195
 msgid "Preview Buffer"
 msgstr "Preview Buffer"
 
-#: schematic/src/gschem_show_hide_text_widget.c:148
-#: schematic/src/x_window.c:1268
 #, fuzzy
 msgid "Hide"
 msgstr "Hide Text"
 
-#: schematic/src/gschem_show_hide_text_widget.c:157
-#: schematic/src/x_window.c:1269
 msgid "Hide text starting with:"
 msgstr "Hide text starting with:"
 
-#: schematic/src/gschem_slot_edit_dialog.c:91
 msgid "Edit slot number"
 msgstr "Edit slot number"
 
-#: schematic/src/gschem_slot_edit_dialog.c:121
 msgid "Number of Slots:"
 msgstr ""
 
-#: schematic/src/gschem_slot_edit_dialog.c:122
 #, fuzzy
 msgid "Slot Number:"
 msgstr "Edit slot number:"
 
-#: schematic/src/gschem_text_properties_widget.c:240
-#: schematic/src/x_newtext.c:265
 msgid "<b>Text Content</b>"
 msgstr "<b>Text Content</b>"
 
-#: schematic/src/gschem_text_properties_widget.c:259
-#: schematic/src/x_newtext.c:291
 #, fuzzy
 msgid "_Size:"
 msgstr "Size:"
 
-#: schematic/src/gschem_text_properties_widget.c:260
-#: schematic/src/x_newtext.c:310
 #, fuzzy
 msgid "Ali_gnment:"
 msgstr "Alignment:"
 
-#: schematic/src/gschem_text_properties_widget.c:261
-#: schematic/src/x_newtext.c:330
 #, fuzzy
 msgid "Ro_tation:"
 msgstr "Orientation:"
 
-#: schematic/src/gschem_text_properties_widget.c:294
-#: schematic/src/x_newtext.c:253
 msgid "<b>Text Properties</b>"
 msgstr "<b>Text Properties</b>"
 
-#: schematic/src/gschem_translate_widget.c:238
 #, fuzzy
 msgid "Coordinate:"
 msgstr "Show _Coord Window..."
 
-#: schematic/src/gschem_translate_widget.c:405 schematic/src/i_callbacks.c:800
 msgid "Translate"
 msgstr "Translate"
 
-#: schematic/src/i_basic.c:64 schematic/src/x_window.c:1369
-#: schematic/scheme/conf/schematic/menu.scm:59
-#: schematic/scheme/gschem/builtins.scm:99
 msgid "Select Mode"
 msgstr "Select Mode"
 
-#: schematic/src/i_basic.c:65
 #, fuzzy
 msgid "Select Box Mode"
 msgstr "Select Mode"
 
-#: schematic/src/i_basic.c:66
 msgid "Text Mode"
 msgstr "Text Mode"
 
-#: schematic/src/i_basic.c:67
 msgid "Pan Mode"
 msgstr "Pan Mode"
 
-#: schematic/src/i_basic.c:70
 #, c-format
 msgid "Paste %d Mode"
 msgstr "Paste %d Mode"
 
-#: schematic/src/i_basic.c:74
 msgid "Magnetic Net Mode"
 msgstr "Magnetic Net Mode"
 
-#: schematic/src/i_basic.c:76
 msgid "Net Mode"
 msgstr "Net Mode"
 
-#: schematic/src/i_basic.c:77
 msgid "Arc Mode"
 msgstr "Arc Mode"
 
-#: schematic/src/i_basic.c:78
 msgid "Box Mode"
 msgstr "Box Mode"
 
-#: schematic/src/i_basic.c:79
 msgid "Bus Mode"
 msgstr "Bus Mode"
 
-#: schematic/src/i_basic.c:80
 msgid "Circle Mode"
 msgstr "Circle Mode"
 
-#: schematic/src/i_basic.c:81
 msgid "Component Mode"
 msgstr "Component Mode"
 
-#: schematic/src/i_basic.c:82 schematic/scheme/conf/schematic/menu.scm:62
-#: schematic/scheme/gschem/builtins.scm:114
 msgid "Copy Mode"
 msgstr "Copy Mode"
 
-#: schematic/src/i_basic.c:83 schematic/scheme/conf/schematic/menu.scm:63
-#: schematic/scheme/gschem/builtins.scm:117
 msgid "Multiple Copy Mode"
 msgstr "Multiple Copy Mode"
 
-#: schematic/src/i_basic.c:84
 msgid "Line Mode"
 msgstr "Line Mode"
 
-#: schematic/src/i_basic.c:85 schematic/scheme/conf/schematic/menu.scm:66
-#: schematic/scheme/gschem/builtins.scm:123
 msgid "Mirror Mode"
 msgstr "Mirror Mode"
 
-#: schematic/src/i_basic.c:86 schematic/scheme/conf/schematic/menu.scm:64
-#: schematic/scheme/gschem/builtins.scm:111
 msgid "Move Mode"
 msgstr "Move Mode"
 
-#: schematic/src/i_basic.c:87
 #, fuzzy
 msgid "Path Mode"
 msgstr "Pan Mode"
 
-#: schematic/src/i_basic.c:88
 msgid "Picture Mode"
 msgstr "Picture Mode"
 
-#: schematic/src/i_basic.c:89
 msgid "Pin Mode"
 msgstr "Pin Mode"
 
-#: schematic/src/i_basic.c:90 schematic/scheme/gschem/builtins.scm:120
 msgid "Rotate Mode"
 msgstr "Rotate Mode"
 
-#: schematic/src/i_basic.c:91
 #, fuzzy
 msgid "Modify Mode"
 msgstr "Copy Mode"
 
-#: schematic/src/i_basic.c:92 schematic/src/x_menus.c:49
-#: schematic/scheme/gschem/builtins.scm:204
 msgid "Zoom Box"
 msgstr "Zoom Box"
 
-#: schematic/src/i_basic.c:121
 msgid "Show Hidden"
 msgstr "Show Hidden"
 
-#: schematic/src/i_basic.c:124
 msgid "Snap Off"
 msgstr "Snap Off"
 
-#: schematic/src/i_basic.c:126
 msgid "Resnap Active"
 msgstr "Resnap Active"
 
-#: schematic/src/i_basic.c:288 schematic/src/x_colorcb.c:159
 msgid "Stroke"
 msgstr "Stroke"
 
-#: schematic/src/i_basic.c:296 schematic/src/i_basic.c:330
-#: schematic/src/x_window.c:1361
 msgid "none"
 msgstr "none"
 
-#: schematic/src/i_basic.c:304
 msgid "Repeat/"
 msgstr "Repeat/"
 
-#: schematic/src/i_basic.c:315
 msgid "Repeat/none"
 msgstr "Repeat/none"
 
-#: schematic/src/i_basic.c:323 schematic/src/i_callbacks.c:1239
-#: schematic/scheme/gschem/builtins.scm:189
 msgid "Pan"
 msgstr "Pan"
 
-#: schematic/src/i_callbacks.c:74
 #, fuzzy, c-format
 msgid "New page created [%1$s]"
 msgstr "New page created [%s]\n"
 
-#: schematic/src/i_callbacks.c:108
 #, fuzzy, c-format
 msgid "New Window created [%1$s]"
 msgstr "New Window created [%s]\n"
 
-#: schematic/src/i_callbacks.c:245
 msgid "Failed to Save All"
 msgstr "Failed to Save All"
 
-#: schematic/src/i_callbacks.c:247
 msgid "Saved All"
 msgstr "Saved All"
 
-#: schematic/src/i_callbacks.c:308
 #, fuzzy
 msgid "Closing Window"
 msgstr "Closing Window\n"
 
-#: schematic/src/i_callbacks.c:505 schematic/src/x_menus.c:55
-#: schematic/scheme/gschem/builtins.scm:168
 msgid "Copy"
 msgstr "Copy"
 
-#: schematic/src/i_callbacks.c:514 schematic/src/i_callbacks.c:539
-#: schematic/src/i_callbacks.c:564
 msgid "Select objs first"
 msgstr "Select objs first"
 
-#: schematic/src/i_callbacks.c:530
 msgid "Multiple Copy"
 msgstr "Multiple Copy"
 
-#: schematic/src/i_callbacks.c:555 schematic/src/x_menus.c:56
 msgid "Move"
 msgstr "Move"
 
-#: schematic/src/i_callbacks.c:579 schematic/src/x_menus.c:57
-#: schematic/src/x_multiattrib.c:1656 schematic/scheme/gschem/builtins.scm:108
 msgid "Delete"
 msgstr "Delete"
 
-#: schematic/src/i_callbacks.c:603
 msgid "Edit"
 msgstr "Edit"
 
-#: schematic/src/i_callbacks.c:618 schematic/scheme/gschem/builtins.scm:129
 msgid "Edit Text"
 msgstr "Edit Text"
 
-#: schematic/src/i_callbacks.c:637
 msgid "Slot"
 msgstr "Slot"
 
-#: schematic/src/i_callbacks.c:688 schematic/src/i_callbacks.c:698
 msgid "Rotate"
 msgstr "Rotate"
 
-#: schematic/src/i_callbacks.c:736 schematic/src/i_callbacks.c:746
 msgid "Mirror"
 msgstr "Mirror"
 
-#: schematic/src/i_callbacks.c:763 schematic/src/x_colorcb.c:160
-#: schematic/scheme/conf/schematic/menu.scm:73
-#: schematic/scheme/gschem/builtins.scm:141
 msgid "Lock"
 msgstr "Lock"
 
-#: schematic/src/i_callbacks.c:781 schematic/scheme/conf/schematic/menu.scm:74
-#: schematic/scheme/gschem/builtins.scm:144
 msgid "Unlock"
 msgstr "Unlock"
 
-#: schematic/src/i_callbacks.c:805
 #, fuzzy
 msgid "WARNING: Do not translate with snap off!"
 msgstr "WARNING: Do not translate with snap off!\n"
 
-#: schematic/src/i_callbacks.c:806
 #, fuzzy
 msgid "WARNING: Turning snap on and continuing with translate."
 msgstr "WARNING: Turning snap on and continuing with translate.\n"
 
-#: schematic/src/i_callbacks.c:813
 #, fuzzy
 msgid "WARNING: Snap grid size is not equal to 100!"
 msgstr "WARNING: Snap grid size is not equal to 100!\n"
 
-#: schematic/src/i_callbacks.c:815
 #, fuzzy
 msgid ""
 "WARNING: If you are translating a symbol to the origin, the snap grid size "
@@ -942,23 +720,18 @@ msgstr ""
 "WARNING: If you are translating a symbol to the origin, the snap grid size "
 "should be set to 100\n"
 
-#: schematic/src/i_callbacks.c:847
 msgid "Embed"
 msgstr "Embed"
 
-#: schematic/src/i_callbacks.c:886
 msgid "Unembed"
 msgstr "Unembed"
 
-#: schematic/src/i_callbacks.c:928
 msgid "Update"
 msgstr "Update"
 
-#: schematic/src/i_callbacks.c:970
 msgid "ShowHidden"
 msgstr "ShowHidden"
 
-#: schematic/src/i_callbacks.c:1537
 #, c-format
 msgid ""
 "<b>Revert page:</b>\n"
@@ -969,100 +742,78 @@ msgid ""
 "discarded and page file will be reloaded from disk."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1555
 #, fuzzy
 msgid "Revert"
 msgstr "_Revert"
 
-#: schematic/src/i_callbacks.c:1647
 msgid "Copy to clipboard"
 msgstr "Copy to clipboard"
 
-#: schematic/src/i_callbacks.c:1664
 msgid "Cut to clipboard"
 msgstr "Cut to clipboard"
 
-#: schematic/src/i_callbacks.c:1686
 msgid "Paste from clipboard"
 msgstr "Paste from clipboard"
 
-#: schematic/src/i_callbacks.c:1694
 #, fuzzy
 msgid "Empty clipboard"
 msgstr "Copy to clipboard"
 
 #. TRANSLATORS: The number is the number of the buffer that the
 #. * selection is being copied to.
-#: schematic/src/i_callbacks.c:1719
 #, fuzzy, c-format
 msgid "Copy %i"
 msgstr "Copy 1"
 
 #. TRANSLATORS: The number is the number of the buffer that the
 #. * selection is being cut to.
-#: schematic/src/i_callbacks.c:1746
 #, fuzzy, c-format
 msgid "Cut %i"
 msgstr "Cut 1"
 
 #. TRANSLATORS: The number is the number of the buffer that is being
 #. * pasted to the schematic.
-#: schematic/src/i_callbacks.c:1776
 #, fuzzy, c-format
 msgid "Paste %i"
 msgstr "Paste 1"
 
-#: schematic/src/i_callbacks.c:1785
 msgid "Empty buffer"
 msgstr "Empty buffer"
 
-#: schematic/src/i_callbacks.c:1833 schematic/src/x_window.c:1203
 msgid "Component"
 msgstr "Component"
 
-#: schematic/src/i_callbacks.c:1865 schematic/src/x_colorcb.c:150
 msgid "Attribute"
 msgstr "Attribute"
 
-#: schematic/src/i_callbacks.c:1885 schematic/src/x_colorcb.c:149
 msgid "Net"
 msgstr "Net"
 
-#: schematic/src/i_callbacks.c:1928 schematic/src/x_colorcb.c:155
-#: schematic/src/x_window.c:1222
 msgid "Bus"
 msgstr "Bus"
 
-#: schematic/src/i_callbacks.c:2004
 msgid "Line"
 msgstr "Line"
 
-#: schematic/src/i_callbacks.c:2021
 msgid "Path"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2043
 msgid "Box"
 msgstr "Box"
 
-#: schematic/src/i_callbacks.c:2085
 msgid "Circle"
 msgstr "Circle"
 
-#: schematic/src/i_callbacks.c:2108
 msgid "Arc"
 msgstr "Arc"
 
-#: schematic/src/i_callbacks.c:2131 schematic/src/x_colorcb.c:146
 msgid "Pin"
 msgstr "Pin"
 
-#: schematic/src/i_callbacks.c:2191
 #, fuzzy, c-format
 msgid "Searching for source [%1$s]"
 msgstr "Searching for source [%s]\n"
 
-#: schematic/src/i_callbacks.c:2223
 #, fuzzy, c-format
 msgid ""
 "Failed to descend hierarchy into '%1$s': %2$s\n"
@@ -1073,121 +824,96 @@ msgstr ""
 "\n"
 "The gschem log may contain more information."
 
-#: schematic/src/i_callbacks.c:2227
 #, fuzzy, c-format
 msgid "Failed to descend into '%1$s': %2$s"
 msgstr "Failed to replace pictures: %s"
 
-#: schematic/src/i_callbacks.c:2234
 #, fuzzy
 msgid "Failed to descend hierarchy."
 msgstr "descend into hierarchy"
 
-#: schematic/src/i_callbacks.c:2312
 #, fuzzy, c-format
 msgid "Searching for symbol [%1$s]"
 msgstr "Searching for symbol [%s]\n"
 
-#: schematic/src/i_callbacks.c:2320
 #, fuzzy
 msgid "Symbol is not a real file. Symbol cannot be loaded."
 msgstr "Symbol is not a real file. Symbol cannot be loaded.\n"
 
-#: schematic/src/i_callbacks.c:2367 schematic/src/x_tabs.c:1060
 #, fuzzy
 msgid "Cannot find any schematics above the current one!"
 msgstr "Cannot find any schematics above the current one!\n"
 
-#: schematic/src/i_callbacks.c:2400
 msgid "Attach"
 msgstr "Attach"
 
-#: schematic/src/i_callbacks.c:2456
 msgid "Detach"
 msgstr "Detach"
 
-#: schematic/src/i_callbacks.c:2500
 msgid "ShowN"
 msgstr "ShowN"
 
-#: schematic/src/i_callbacks.c:2537
 msgid "ShowV"
 msgstr "ShowV"
 
-#: schematic/src/i_callbacks.c:2574
 msgid "ShowB"
 msgstr "ShowB"
 
-#: schematic/src/i_callbacks.c:2612
 msgid "VisToggle"
 msgstr "VisToggle"
 
-#: schematic/src/i_callbacks.c:2643
 #, c-format
 msgid "Sorry but this is a non-functioning menu option\n"
 msgstr "Sorry but this is a non-functioning menu option\n"
 
-#: schematic/src/i_callbacks.c:2703
 #, fuzzy
 msgid "Action feedback mode set to OUTLINE"
 msgstr "Action feedback mode set to OUTLINE\n"
 
-#: schematic/src/i_callbacks.c:2706
 #, fuzzy
 msgid "Action feedback mode set to BOUNDINGBOX"
 msgstr "Action feedback mode set to BOUNDINGBOX\n"
 
-#: schematic/src/i_callbacks.c:2730
 #, fuzzy
 msgid "Grid OFF"
 msgstr "Grid OFF\n"
 
-#: schematic/src/i_callbacks.c:2731
 #, fuzzy
 msgid "Dot grid selected"
 msgstr "Dot grid selected\n"
 
-#: schematic/src/i_callbacks.c:2732
 #, fuzzy
 msgid "Mesh grid selected"
 msgstr "Mesh grid selected\n"
 
-#: schematic/src/i_callbacks.c:2733
 #, fuzzy
 msgid "Invalid grid mode"
 msgstr "Invalid Attribute"
 
-#: schematic/src/i_callbacks.c:2755
 #, fuzzy
 msgid "Snap OFF (CAUTION!)"
 msgstr "Snap OFF (CAUTION!)\n"
 
-#: schematic/src/i_callbacks.c:2758
 #, fuzzy
 msgid "Snap ON"
 msgstr "Snap ON\n"
 
-#: schematic/src/i_callbacks.c:2761
 #, fuzzy
 msgid "Snap back to the grid (CAUTION!)"
 msgstr "Snap back to the grid (CAUTION!)\n"
 
-#: schematic/src/i_callbacks.c:2790
 #, fuzzy
 msgid "Rubber band ON"
 msgstr "Rubber band ON\n"
 
-#: schematic/src/i_callbacks.c:2792
 #, fuzzy
 msgid "Rubber band OFF"
 msgstr "Rubber band OFF \n"
 
-#: schematic/src/i_callbacks.c:2811
 #, fuzzy
 msgid "magnetic net mode: ON"
 msgstr "magnetic net mode: ON\n"
 
-#: schematic/src/i_callbacks.c:2814
 #, fuzzy
 msgid "magnetic net mode: OFF"
 msgstr "magnetic net mode: OFF\n"
@@ -1197,143 +923,114 @@ msgstr "magnetic net mode: OFF\n"
 #. the form "untitled_N.sch", where N is a number.  Please make
 #. sure that the translation contains characters suitable for use
 #. in a filename.
-#: schematic/src/i_vars.c:209
 msgid "untitled"
 msgstr ""
 
-#: schematic/src/o_complex.c:192 schematic/src/o_complex.c:195
 #, fuzzy, c-format
 msgid "Translating schematic [%1$d %2$d]"
 msgstr "Translating schematic [%d %d]\n"
 
-#: schematic/src/o_delete.c:82
 #, fuzzy, c-format
 msgid "Delete locked object?"
 msgid_plural "Delete %1$u locked objects?"
 msgstr[0] "Selected objects"
 msgstr[1] "Selected objects"
 
-#: schematic/src/o_misc.c:55
 #, c-format
 msgid "Got an unexpected NULL in o_edit\n"
 msgstr "Got an unexpected NULL in o_edit\n"
 
-#: schematic/src/o_misc.c:315
 #, fuzzy
 msgid "Hidden text is now visible"
 msgstr "Hidden text is now visible\n"
 
-#: schematic/src/o_misc.c:317
 #, fuzzy
 msgid "Hidden text is now invisible"
 msgstr "Hidden text is now invisible\n"
 
-#: schematic/src/o_misc.c:425
 #, fuzzy, c-format
 msgid "Could not find symbol [%1$s] in library. Update failed."
 msgstr "Could not find symbol [%s] in library. Update failed.\n"
 
-#: schematic/src/o_misc.c:541
 #, fuzzy, c-format
 msgid "o_autosave_backups: Can't get the real filename of %1$s."
 msgstr "o_autosave_backups: Can't get the real filename of %s."
 
-#: schematic/src/o_misc.c:585
 #, fuzzy, c-format
 msgid "Could NOT set previous backup file [%1$s] read-write"
 msgstr "Could NOT set previous backup file [%s] read-write\n"
 
-#: schematic/src/o_misc.c:605
 #, fuzzy, c-format
 msgid "Could NOT set backup file [%1$s] readonly"
 msgstr "Could NOT set backup file [%s] readonly\n"
 
-#: schematic/src/o_misc.c:610
 #, fuzzy, c-format
 msgid "Could NOT save backup file [%1$s]"
 msgstr "Could NOT save backup file [%s]\n"
 
-#: schematic/src/o_move.c:192
 #, c-format
 msgid "ERROR: NULL object in o_move_end!\n"
 msgstr "ERROR: NULL object in o_move_end!\n"
 
-#: schematic/src/o_move.c:519
 #, c-format
 msgid "DOH! tried to find the whichone, but didn't find it!\n"
 msgstr "DOH! tried to find the whichone, but didn't find it!\n"
 
-#: schematic/src/o_move.c:546
 #, c-format
 msgid "Got a non line object in o_move_check_endpoint\n"
 msgstr "Got a non line object in o_move_check_endpoint\n"
 
-#: schematic/src/o_net.c:444
 #, fuzzy
 msgid "Warning: Starting net at off grid coordinate"
 msgstr "Warning: Starting net at off grid coordinate\n"
 
-#: schematic/src/o_net.c:508
 #, fuzzy
 msgid "Warning: Ending net at off grid coordinate"
 msgstr "Warning: Ending net at off grid coordinate\n"
 
-#: schematic/src/o_net.c:856 schematic/src/o_net.c:893
-#: schematic/src/o_net.c:964 schematic/src/o_net.c:1000
 #, c-format
 msgid "Tried to add more than two bus rippers. Internal gschem error.\n"
 msgstr "Tried to add more than two bus rippers. Internal gschem error.\n"
 
-#: schematic/src/o_net.c:1068
 #, fuzzy, c-format
 msgid "Bus ripper symbol [%1$s] was not found in any component library"
 msgstr "Bus ripper symbol [%s] was not found in any component library\n"
 
-#: schematic/src/o_picture.c:133 schematic/src/o_picture.c:343
 #, fuzzy
 msgid "Select a picture file..."
 msgstr "Select PostScript Filename..."
 
-#: schematic/src/o_picture.c:166
 #, fuzzy, c-format
 msgid "Failed to load picture: %1$s"
 msgstr "Failed to load picture: %s"
 
-#: schematic/src/o_picture.c:182
 msgid "Picture"
 msgstr "Picture"
 
-#: schematic/src/o_picture.c:378
 #, c-format
 msgid "Failed to replace pictures: %s"
 msgstr "Failed to replace pictures: %s"
 
-#: schematic/src/o_slot.c:80
 #, fuzzy
 msgid "Slot attribute malformed"
 msgstr "Slot attribute malformed\n"
 
-#: schematic/src/o_slot.c:88
 #, fuzzy
 msgid "numslots attribute missing"
 msgstr "numslots attribute missing\n"
 
-#: schematic/src/o_slot.c:89
 #, fuzzy
 msgid "Slotting not allowed for this component"
 msgstr "Slotting not allowed for this component\n"
 
-#: schematic/src/o_slot.c:104
 #, fuzzy
 msgid "New slot number out of range"
 msgstr "New slot number out of range\n"
 
-#: schematic/src/o_undo.c:397
 #, fuzzy
 msgid "Undo/Redo disabled in rc file"
 msgstr "Undo/Redo disabled in rc file\n"
 
-#: schematic/src/parsecmd.c:77
 #, fuzzy, c-format
 msgid ""
 "Usage: %1$s [OPTION ...] [--] [FILE ...]\n"
@@ -1379,12 +1076,11 @@ msgstr ""
 "Report bugs at <https://bugs.launchpad.net/geda>\n"
 "gEDA/gaf homepage: <http://www.geda-project.org/>\n"
 
-#: schematic/src/parsecmd.c:110
 #, fuzzy, c-format
 msgid ""
 "Lepton EDA %1$s (git: %2$.7s)\n"
 "Copyright (C) 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright (C) 2017-2018 Lepton Developers.\n"
+"Copyright (C) 2017-2019 Lepton Developers.\n"
 "This is free software, and you are welcome to redistribute it under\n"
 "certain conditions. For details, see the file `COPYING', which is\n"
 "included in the Lepton EDA distribution.\n"
@@ -1397,78 +1093,59 @@ msgstr ""
 "included in the gEDA distribution.\n"
 "There is NO WARRANTY, to the extent permitted by law.\n"
 
-#: schematic/src/x_attribedit.c:125
 #, c-format
 msgid "Got invalid show option; defaulting to show both\n"
 msgstr "Got invalid show option; defaulting to show both\n"
 
-#: schematic/src/x_attribedit.c:139
 #, c-format
 msgid "ERROR: NULL object!\n"
 msgstr "ERROR: NULL object!\n"
 
-#: schematic/src/x_attribedit.c:328
 msgid "Single Attribute Editor"
 msgstr "Single Attribute Editor"
 
-#: schematic/src/x_attribedit.c:358
 msgid "<b>Edit Attribute</b>"
 msgstr "<b>Edit Attribute</b>"
 
-#: schematic/src/x_attribedit.c:360
 msgid "<b>Add Attribute</b>"
 msgstr "<b>Add Attribute</b>"
 
-#: schematic/src/x_attribedit.c:376
 #, fuzzy
 msgid "N_ame:"
 msgstr "Name:"
 
-#: schematic/src/x_attribedit.c:396 schematic/src/x_multiattrib.c:2222
 #, fuzzy
 msgid "_Value:"
 msgstr "Value:"
 
-#: schematic/src/x_attribedit.c:415 schematic/src/x_multiattrib.c:2281
 #, fuzzy
 msgid "Vi_sible"
 msgstr "Visible"
 
-#: schematic/src/x_attribedit.c:434
 msgid "Show Value Only"
 msgstr "Show Value Only"
 
-#: schematic/src/x_attribedit.c:436
 msgid "Show Name Only"
 msgstr "Show Name Only"
 
-#: schematic/src/x_attribedit.c:438 schematic/src/x_multiattrib.c:1620
-#: schematic/scheme/gschem/builtins.scm:324
 msgid "Show Name & Value"
 msgstr "Show Name & Value"
 
-#: schematic/src/x_attribedit.c:445
 msgid "<b>Attach Options</b>"
 msgstr "<b>Attach Options</b>"
 
-#: schematic/src/x_attribedit.c:460
 msgid "All"
 msgstr "All"
 
-#: schematic/src/x_attribedit.c:476 schematic/src/x_compselect.c:986
-#: schematic/src/x_compselect.c:1100
 msgid "Components"
 msgstr "Components"
 
-#: schematic/src/x_attribedit.c:492 schematic/src/x_window.c:1214
 msgid "Nets"
 msgstr "Nets"
 
-#: schematic/src/x_attribedit.c:508
 msgid "Replace existing attributes"
 msgstr "Replace existing attributes"
 
-#: schematic/src/x_autonumber.c:412
 #, fuzzy
 msgid ""
 "slotted object without slot attribute may cause problems when autonumbering "
@@ -1477,104 +1154,80 @@ msgstr ""
 "slotted object without slot attribute may cause problems when autonumbering "
 "slots\n"
 
-#: schematic/src/x_autonumber.c:427
 #, fuzzy, c-format
 msgid ""
 "duplicate slot may cause problems: [symbolname=%1$s, number=%2$d, slot=%3$d]"
 msgstr ""
 "duplicate slot may cause problems: [symbolname=%s, number=%d, slot=%d]\n"
 
-#: schematic/src/x_autonumber.c:675
 #, fuzzy
 msgid "No searchstring given in autonumber text."
 msgstr "No searchstring given in autonumber text.\n"
 
-#: schematic/src/x_autonumber.c:728
 #, fuzzy
 msgid "No '*' or '?' given at the end of the autonumber text."
 msgstr "No '*' or '?' given at the end of the autonumber text.\n"
 
-#: schematic/src/x_autonumber.c:873
 msgid "Diagonal"
 msgstr "Diagonal"
 
-#: schematic/src/x_autonumber.c:874
 msgid "Top to bottom"
 msgstr "Top to bottom"
 
-#: schematic/src/x_autonumber.c:875
 msgid "Bottom to top"
 msgstr "Bottom to top"
 
-#: schematic/src/x_autonumber.c:876
 msgid "Left to right"
 msgstr "Left to right"
 
-#: schematic/src/x_autonumber.c:877
 msgid "Right to left"
 msgstr "Right to left"
 
-#: schematic/src/x_autonumber.c:878
 msgid "File order"
 msgstr "File order"
 
-#: schematic/src/x_autonumber.c:1214
 msgid "Autonumber text"
 msgstr "Autonumber text"
 
-#: schematic/src/x_autonumber.c:1237
 msgid "<b>Scope</b>"
 msgstr "<b>Scope</b>"
 
-#: schematic/src/x_autonumber.c:1259
 msgid "Search for:"
 msgstr "Search for:"
 
-#: schematic/src/x_autonumber.c:1273
 msgid "Autonumber text in:"
 msgstr "Autonumber text in:"
 
-#: schematic/src/x_autonumber.c:1280
 msgid "Skip numbers found in:"
 msgstr "Skip numbers found in:"
 
-#: schematic/src/x_autonumber.c:1292 schematic/src/x_autonumber.c:1301
 msgid "Selected objects"
 msgstr "Selected objects"
 
-#: schematic/src/x_autonumber.c:1293 schematic/src/x_autonumber.c:1302
 msgid "Current page"
 msgstr "Current page"
 
-#: schematic/src/x_autonumber.c:1294 schematic/src/x_autonumber.c:1303
 msgid "Whole hierarchy"
 msgstr "Whole hierarchy"
 
-#: schematic/src/x_autonumber.c:1305
 msgid "Overwrite existing numbers"
 msgstr "Overwrite existing numbers"
 
-#: schematic/src/x_autonumber.c:1310
 msgid "<b>Options</b>"
 msgstr "<b>Options</b>"
 
-#: schematic/src/x_autonumber.c:1332
 msgid "Starting number:"
 msgstr "Starting number:"
 
-#: schematic/src/x_autonumber.c:1339
 msgid "Sort order:"
 msgstr "Sort order:"
 
-#: schematic/src/x_autonumber.c:1371
 msgid "Remove numbers"
 msgstr "Remove numbers"
 
-#: schematic/src/x_autonumber.c:1375
 msgid "Automatic slotting"
 msgstr "Automatic slotting"
 
-#: schematic/src/x_clipboard.c:245
 #, c-format
 msgid ""
 "<b>Invalid schematic on clipboard.</b>\n"
@@ -1585,175 +1238,135 @@ msgstr ""
 "\n"
 "An error occurred while inserting clipboard data: %s."
 
-#: schematic/src/x_clipboard.c:247
 msgid "Clipboard insertion failed"
 msgstr "Clipboard insertion failed"
 
-#: schematic/src/x_color.c:89 schematic/src/x_color.c:98
 #, fuzzy, c-format
 msgid "Could not allocate the color %1$s!\n"
 msgstr "Could not allocate the colour %s!\n"
 
-#: schematic/src/x_color.c:89
 msgid "black"
 msgstr "black"
 
-#: schematic/src/x_color.c:98
 msgid "white"
 msgstr "white"
 
-#: schematic/src/x_color.c:120
 #, fuzzy, c-format
 msgid "Could not allocate display color %1$i!\n"
 msgstr "Could not allocate display colour %i!\n"
 
-#: schematic/src/x_color.c:142
 #, fuzzy, c-format
 msgid "Could not allocate outline color %1$i!\n"
 msgstr "Could not allocate outline colour %i!\n"
 
-#: schematic/src/x_color.c:159
 #, fuzzy, c-format
 msgid "Tried to get an invalid color: %1$d\n"
 msgstr "Tried to get an invalid colour: %d\n"
 
-#: schematic/src/x_colorcb.c:145
 msgid "Background"
 msgstr "Background"
 
-#: schematic/src/x_colorcb.c:147
 msgid "Net endpoint"
 msgstr "Net endpoint"
 
-#: schematic/src/x_colorcb.c:148
 msgid "Graphic"
 msgstr "Graphic"
 
-#: schematic/src/x_colorcb.c:151
 msgid "Logic bubble"
 msgstr "Logic bubble"
 
-#: schematic/src/x_colorcb.c:152
 msgid "Grid point"
 msgstr "Grid point"
 
-#: schematic/src/x_colorcb.c:153
 #, fuzzy
 msgid "Detached attribute"
 msgstr "Detached attribute"
 
-#: schematic/src/x_colorcb.c:156
 msgid "Selection"
 msgstr "Selection"
 
-#: schematic/src/x_colorcb.c:157
 msgid "Bounding box"
 msgstr "Bounding box"
 
-#: schematic/src/x_colorcb.c:158
 msgid "Zoom box"
 msgstr "Zoom box"
 
-#: schematic/src/x_colorcb.c:161
 msgid "Output background"
 msgstr "Output background"
 
-#: schematic/src/x_colorcb.c:162
 msgid "Freestyle 1"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:163
 msgid "Freestyle 2"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:164
 msgid "Freestyle 3"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:165
 msgid "Freestyle 4"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:166
 msgid "Net junction"
 msgstr "Net junction"
 
-#: schematic/src/x_colorcb.c:167
 msgid "Mesh grid major"
 msgstr "Mesh grid major"
 
-#: schematic/src/x_colorcb.c:168
 msgid "Mesh grid minor"
 msgstr "Mesh grid minor"
 
-#: schematic/src/x_colorcb.c:172
 msgid "Unknown"
 msgstr "Unknown"
 
-#: schematic/src/x_compselect.c:1169
 #, fuzzy
 msgid "Reset filter"
 msgstr "New file"
 
-#: schematic/src/x_compselect.c:1192
 msgid "Reload all libraries"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1245 schematic/src/x_multiattrib.c:2092
 msgid "Value"
 msgstr "Value"
 
-#: schematic/src/x_compselect.c:1284
 msgid "Default behavior - reference component"
 msgstr "Default behavior - reference component"
 
-#: schematic/src/x_compselect.c:1287
 msgid "Embed component in schematic"
 msgstr "Embed component in schematic"
 
-#: schematic/src/x_compselect.c:1290
 msgid "Include component as individual objects"
 msgstr "Include component as individual objects"
 
-#: schematic/src/x_compselect.c:1448
 msgid "Select Component..."
 msgstr "Select Component..."
 
-#: schematic/src/x_compselect.c:1471
 #, fuzzy
 msgid "In Us_e"
 msgstr "In Use"
 
-#: schematic/src/x_compselect.c:1475
 #, fuzzy
 msgid "Lib_raries"
 msgstr "Libraries"
 
-#: schematic/src/x_compselect.c:1484 schematic/src/x_fileselect.c:119
 msgid "Preview"
 msgstr "Preview"
 
-#: schematic/src/x_compselect.c:1510
 msgid "Attributes"
 msgstr "Attributes"
 
-#: schematic/src/x_dialog.c:325
 msgid "Major symbol changes detected."
 msgstr ""
 
-#: schematic/src/x_dialog.c:349
 msgid ""
 "Changes have occurred to the symbols shown below.\n"
 "\n"
 "Be sure to verify each of these symbols."
 msgstr ""
 
-#: schematic/src/x_dialog.c:369
 #, fuzzy
 msgid "Symbol"
 msgstr "Symbols"
 
-#: schematic/src/x_dialog.c:406
 #, c-format
 msgid ""
 "<span weight=\"bold\" size=\"larger\">The input attribute \"%s\" is invalid\n"
@@ -1770,40 +1383,31 @@ msgstr ""
 "The name cannot end with a space.\n"
 "The value cannot start with a space."
 
-#: schematic/src/x_dialog.c:408
 msgid "Invalid Attribute"
 msgstr "Invalid Attribute"
 
-#: schematic/src/x_fileselect.c:37
 msgid "Schematics"
 msgstr "Schematics"
 
-#: schematic/src/x_fileselect.c:42
 msgid "Symbols"
 msgstr "Symbols"
 
-#: schematic/src/x_fileselect.c:47
 msgid "Schematics and symbols"
 msgstr "Schematics and symbols"
 
-#: schematic/src/x_fileselect.c:53
 msgid "All files"
 msgstr "All files"
 
-#: schematic/src/x_fileselect.c:169
 msgid "Open..."
 msgstr "Open..."
 
-#: schematic/src/x_fileselect.c:233
 msgid "Save as..."
 msgstr "Save as..."
 
-#: schematic/src/x_fileselect.c:297
 #, fuzzy
 msgid "Save cancelled on user request"
 msgstr "Save cancelled on user request\n"
 
-#: schematic/src/x_fileselect.c:334
 msgid ""
 "\n"
 "If you load the original file, the backup file will be overwritten in the "
@@ -1812,28 +1416,22 @@ msgid ""
 "Do you want to load the backup file?\n"
 msgstr ""
 
-#: schematic/src/x_fstylecb.c:73
 msgid "Hollow"
 msgstr "Hollow"
 
-#: schematic/src/x_fstylecb.c:80
 msgid "Filled"
 msgstr "Filled"
 
-#: schematic/src/x_fstylecb.c:87
 msgid "Mesh"
 msgstr "Mesh"
 
-#: schematic/src/x_fstylecb.c:94
 msgid "Hatch"
 msgstr "Hatch"
 
-#: schematic/src/x_image.c:279
 #, fuzzy, c-format
 msgid "x_image_lowlevel: Unable to write %1$s file %2$s."
 msgstr "x_image_lowlevel: Unable to write %s file %s.\n"
 
-#: schematic/src/x_image.c:289
 #, fuzzy, c-format
 msgid ""
 "There was the following error when saving image with type %1$s to filename:\n"
@@ -1846,297 +1444,232 @@ msgstr ""
 "\n"
 "%s.\n"
 
-#: schematic/src/x_image.c:309
 #, fuzzy, c-format
 msgid "Wrote color image to [%1$s] [%2$d x %3$d]"
 msgstr "Wrote colour image to [%s] [%d x %d]\n"
 
-#: schematic/src/x_image.c:311
 #, fuzzy, c-format
 msgid "Wrote black and white image to [%1$s] [%2$d x %3$d]"
 msgstr "Wrote black and white image to [%s] [%d x %d]\n"
 
-#: schematic/src/x_image.c:319
 #, fuzzy
 msgid "x_image_lowlevel: Unable to get pixbuf from gschem's window."
 msgstr "x_image_lowlevel: Unable to get pixbuf from gschem's window.\n"
 
-#: schematic/src/x_image.c:358
 msgid "Width x Height"
 msgstr "Width x Height"
 
-#: schematic/src/x_image.c:374
 msgid "Image type"
 msgstr "Image type"
 
-#: schematic/src/x_image.c:395
 msgid "Write image..."
 msgstr "Write image..."
 
-#: schematic/src/x_linecapcb.c:74
 msgid "Butt"
 msgstr ""
 
-#: schematic/src/x_linecapcb.c:81
 msgid "Square"
 msgstr ""
 
-#: schematic/src/x_linecapcb.c:88
 msgid "Round"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:74
 msgid "Solid"
 msgstr "Solid"
 
-#: schematic/src/x_linetypecb.c:81
 msgid "Dotted"
 msgstr "Dotted"
 
-#: schematic/src/x_linetypecb.c:88
 msgid "Dashed"
 msgstr "Dashed"
 
-#: schematic/src/x_linetypecb.c:95
 msgid "Center"
 msgstr "Center"
 
-#: schematic/src/x_linetypecb.c:102
 msgid "Phantom"
 msgstr "Phantom"
 
-#: schematic/src/x_menus.c:41 schematic/scheme/gschem/builtins.scm:267
 #, fuzzy
 msgid "Add Net"
 msgstr "/Add Net"
 
-#: schematic/src/x_menus.c:42 schematic/src/x_multiattrib.c:2187
-#: schematic/scheme/gschem/builtins.scm:264
 msgid "Add Attribute"
 msgstr "Add Attribute"
 
-#: schematic/src/x_menus.c:43 schematic/scheme/gschem/builtins.scm:261
 #, fuzzy
 msgid "Add Component"
 msgstr "/Add Component..."
 
-#: schematic/src/x_menus.c:44 schematic/scheme/gschem/builtins.scm:270
 #, fuzzy
 msgid "Add Bus"
 msgstr "/Add Bus"
 
-#: schematic/src/x_menus.c:45 schematic/scheme/gschem/builtins.scm:273
 #, fuzzy
 msgid "Add Text"
 msgstr "/Add Text"
 
-#: schematic/src/x_menus.c:47 schematic/scheme/gschem/builtins.scm:210
 #, fuzzy
 msgid "Zoom In"
 msgstr "/Zoom In"
 
-#: schematic/src/x_menus.c:48 schematic/scheme/gschem/builtins.scm:213
 #, fuzzy
 msgid "Zoom Out"
 msgstr "/Zoom Out"
 
-#: schematic/src/x_menus.c:50 schematic/scheme/gschem/builtins.scm:207
 #, fuzzy
 msgid "Zoom Extents"
 msgstr "/Zoom Extents"
 
-#: schematic/src/x_menus.c:52 schematic/src/x_window.c:1233
 msgid "Select"
 msgstr "Select"
 
-#: schematic/src/x_menus.c:53 schematic/scheme/conf/schematic/menu.scm:69
-#: schematic/scheme/gschem/builtins.scm:126
 msgid "Edit..."
 msgstr "Edit..."
 
-#: schematic/src/x_menus.c:54 schematic/scheme/conf/schematic/menu.scm:68
 #, fuzzy
 msgid "Object Properties..."
 msgstr "<b>Text Properties</b>"
 
-#: schematic/src/x_menus.c:59 schematic/scheme/gschem/builtins.scm:300
 #, fuzzy
 msgid "Down Schematic"
 msgstr "/Down Schematic"
 
-#: schematic/src/x_menus.c:60 schematic/scheme/gschem/builtins.scm:303
 #, fuzzy
 msgid "Down Symbol"
 msgstr "/Down Symbol"
 
-#: schematic/src/x_menus.c:61
 #, fuzzy
 msgid "Up"
 msgstr "/Up"
 
-#: schematic/src/x_menus.c:336
 #, fuzzy, c-format
 msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
 msgstr "Tried to set the sensitivity on non-existent menu item '%s'\n"
 
-#: schematic/src/x_menus.c:360
 #, c-format
 msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
 msgstr "Tried to set the sensitivity on non-existent menu item '%s'\n"
 
-#: schematic/src/x_misc.c:70
 msgid "The operating system is out of memory or resources."
 msgstr "The operating system is out of memory or resources."
 
-#: schematic/src/x_multiattrib.c:798 schematic/src/x_multiattrib.c:2704
 msgid "<various>"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:930
 msgid "Attributes with empty name are not allowed. Please set a name."
 msgstr "Attributes with empty name are not allowed. Please set a name."
 
-#: schematic/src/x_multiattrib.c:1622
 msgid "Show Value only"
 msgstr "Show Value only"
 
-#: schematic/src/x_multiattrib.c:1624
 msgid "Show Name only"
 msgstr "Show Name only"
 
-#: schematic/src/x_multiattrib.c:1651
 msgid "Promote"
 msgstr "Promote"
 
-#: schematic/src/x_multiattrib.c:1655
 msgid "Duplicate"
 msgstr "Duplicate"
 
-#: schematic/src/x_multiattrib.c:1657
 #, fuzzy
 msgid "Copy to all"
 msgstr "Copy into 1"
 
-#: schematic/src/x_multiattrib.c:1986 schematic/src/x_multiattrib.c:2602
 msgid "Edit Attributes"
 msgstr "Edit Attributes"
 
-#: schematic/src/x_multiattrib.c:2112
 msgid "Vis?"
 msgstr "Vis?"
 
-#: schematic/src/x_multiattrib.c:2130
 msgid "N"
 msgstr "N"
 
-#: schematic/src/x_multiattrib.c:2148
 msgid "V"
 msgstr "V"
 
-#: schematic/src/x_multiattrib.c:2170
 #, fuzzy
 msgid "Sho_w inherited attributes"
 msgstr "Show inherited attributes"
 
-#: schematic/src/x_multiattrib.c:2197
 #, fuzzy
 msgid "_Name:"
 msgstr "Name:"
 
-#: schematic/src/x_multiattrib.c:2241
 msgid "Ctrl+Enter inserts new line; Ctrl+Tab inserts Tab"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2618
 #, c-format
 msgid "%2$i symbol (%1$s)"
 msgid_plural "%2$i symbols (%1$s)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2624
 #, fuzzy, c-format
 msgid "%1$i pin"
 msgid_plural "%1$i pins"
 msgstr[0] "Net pin"
 msgstr[1] "Net pin"
 
-#: schematic/src/x_multiattrib.c:2630
 #, c-format
 msgid "%1$i net"
 msgid_plural "%1$i nets"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2636
 #, c-format
 msgid "%1$i bus"
 msgid_plural "%1$i buses"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2642
 #, fuzzy, c-format
 msgid "%1$i attribute"
 msgid_plural "%1$i attributes"
 msgstr[0] "Attribute"
 msgstr[1] "Attribute"
 
-#: schematic/src/x_newtext.c:433
 msgid "Text Entry..."
 msgstr "Text Entry..."
 
-#: schematic/src/x_pagesel.c:253
 msgid "New Page"
 msgstr "New Page"
 
-#: schematic/src/x_pagesel.c:254
 msgid "Open Page..."
 msgstr "Open Page..."
 
-#: schematic/src/x_pagesel.c:256
 msgid "Save Page"
 msgstr "Save Page"
 
-#: schematic/src/x_pagesel.c:257 schematic/scheme/gschem/builtins.scm:246
 msgid "Close Page"
 msgstr "Close Page"
 
-#: schematic/src/x_pagesel.c:376 schematic/scheme/gschem/builtins.scm:237
 msgid "Page Manager"
 msgstr "Page Manager"
 
-#: schematic/src/x_pagesel.c:448
 msgid "Changed"
 msgstr "Changed"
 
-#: schematic/src/x_pagesel.c:468
 msgid "Right click on the filename for more options..."
 msgstr "Right click on the filename for more options..."
 
-#: schematic/src/x_print.c:306
 #, fuzzy, c-format
 msgid "Failed to write PDF to '%s': %s\n"
 msgstr "Failed to replace pictures: %s"
 
-#: schematic/src/x_print.c:364
 #, fuzzy, c-format
 msgid "Failed to write PDF to '%1$s': %2$s\n"
 msgstr "Failed to replace pictures: %s"
 
-#: schematic/src/x_print.c:449
 #, c-format
 msgid ""
 "Error printing file:\n"
 "%1$s"
 msgstr ""
 
-#: schematic/src/x_rc.c:39
 #, fuzzy
 msgid "ERROR: An unknown error occurred while parsing configuration files."
 msgstr "ERROR: An unknown error occurred while parsing configuration files.\n"
 
-#: schematic/src/x_rc.c:44
 #, fuzzy
 msgid ""
 "An unknown error occurred while parsing configuration files.\n"
@@ -2147,12 +1680,10 @@ msgstr ""
 "\n"
 "The gschem log may contain more information."
 
-#: schematic/src/x_rc.c:56
 #, fuzzy, c-format
 msgid "ERROR: %1$s"
 msgstr "ERROR: %s\n"
 
-#: schematic/src/x_rc.c:59
 #, fuzzy, c-format
 msgid ""
 "%1$s\n"
@@ -2163,142 +1694,111 @@ msgstr ""
 "\n"
 "The gschem log may contain more information."
 
-#: schematic/src/x_rc.c:67
 #, fuzzy
 msgid "Cannot load lepton-schematic configuration."
 msgstr "Cannot load gschem configuration."
 
-#: schematic/src/x_script.c:42 schematic/scheme/conf/schematic/menu.scm:40
 msgid "Execute Script..."
 msgstr "Execute Script..."
 
-#: schematic/src/x_script.c:61
 #, fuzzy, c-format
 msgid "Executing guile script [%1$s]"
 msgstr "Executing guile script [%s]\n"
 
-#: schematic/src/x_tabs.c:860
 #, fuzzy, c-format
 msgid "Hierarchy up: %s"
 msgstr "Hie_rarchy"
 
-#: schematic/src/x_tabs.c:863
 #, fuzzy
 msgid "Hierarchy up"
 msgstr "Hie_rarchy"
 
-#: schematic/src/x_widgets.c:158 schematic/src/x_window.c:1444
 #, fuzzy
 msgid "Options"
 msgstr "_Options"
 
-#: schematic/src/x_widgets.c:203 schematic/src/x_window.c:1436
 #, fuzzy
 msgid "Object"
 msgstr "Object colour:"
 
-#: schematic/src/x_widgets.c:224
 msgid "Log"
 msgstr ""
 
-#: schematic/src/x_widgets.c:245 schematic/src/x_window.c:1466
 msgid "Find Text"
 msgstr "Find Text"
 
-#: schematic/src/x_widgets.c:259
 #, fuzzy
 msgid "Color Scheme Editor"
 msgstr "_Light colour scheme"
 
-#: schematic/src/x_widgets.c:272 schematic/scheme/gschem/builtins.scm:378
 #, fuzzy
 msgid "Select Schematic Font"
 msgstr "S_elect the schematics you want to save:"
 
-#: schematic/src/x_window.c:763
 #, fuzzy, c-format
 msgid "Loading schematic [%1$s]"
 msgstr "Loading schematic [%s]\n"
 
-#: schematic/src/x_window.c:864
 #, fuzzy, c-format
 msgid "Could NOT save page [%1$s]\n"
 msgstr "Could NOT save page [%s]\n"
 
-#: schematic/src/x_window.c:865
 msgid "Error while trying to save"
 msgstr "Error while trying to save"
 
-#: schematic/src/x_window.c:875
 msgid "Failed to save file"
 msgstr "Failed to save file"
 
-#: schematic/src/x_window.c:885
 #, fuzzy, c-format
 msgid "Saved as [%1$s]"
 msgstr "Saved as [%s]\n"
 
-#: schematic/src/x_window.c:887
 #, fuzzy, c-format
 msgid "Saved [%1$s]"
 msgstr "Saved [%s]\n"
 
-#: schematic/src/x_window.c:889
 msgid "Saved"
 msgstr "Saved"
 
-#: schematic/src/x_window.c:966
 #, fuzzy, c-format
 msgid "Discarding page [%1$s]"
 msgstr "Discarding page [%s]\n"
 
-#: schematic/src/x_window.c:966
 #, fuzzy, c-format
 msgid "Closing [%1$s]"
 msgstr "Closing [%s]\n"
 
-#: schematic/src/x_window.c:1175
 msgid "New"
 msgstr "New"
 
-#: schematic/src/x_window.c:1175
 msgid "New file"
 msgstr "New file"
 
-#: schematic/src/x_window.c:1179
 msgid "Open"
 msgstr "Open"
 
-#: schematic/src/x_window.c:1179
 #, fuzzy
 msgid "Open file"
 msgstr "Open file..."
 
-#: schematic/src/x_window.c:1183 schematic/scheme/gschem/builtins.scm:59
 msgid "Save"
 msgstr "Save"
 
-#: schematic/src/x_window.c:1183
 msgid "Save file"
 msgstr "Save file"
 
-#: schematic/src/x_window.c:1189 schematic/scheme/gschem/builtins.scm:93
 msgid "Undo"
 msgstr "Undo"
 
-#: schematic/src/x_window.c:1189
 msgid "Undo last operation"
 msgstr "Undo last operation"
 
-#: schematic/src/x_window.c:1193 schematic/scheme/gschem/builtins.scm:96
 msgid "Redo"
 msgstr "Redo"
 
-#: schematic/src/x_window.c:1193
 msgid "Redo last undo"
 msgstr "Redo last undo"
 
-#: schematic/src/x_window.c:1198
 msgid ""
 "Add component...\n"
 "Select library and component from list, move the mouse into main window, "
@@ -2310,7 +1810,6 @@ msgstr ""
 "click to place\n"
 "Right mouse button to cancel"
 
-#: schematic/src/x_window.c:1209
 msgid ""
 "Add nets mode\n"
 "Right mouse button to cancel"
@@ -2318,7 +1817,6 @@ msgstr ""
 "Add nets mode\n"
 "Right mouse button to cancel"
 
-#: schematic/src/x_window.c:1217
 msgid ""
 "Add buses mode\n"
 "Right mouse button to cancel"
@@ -2326,45 +1824,35 @@ msgstr ""
 "Add buses mode\n"
 "Right mouse button to cancel"
 
-#: schematic/src/x_window.c:1226
 msgid "Add Text..."
 msgstr "Add Text..."
 
-#: schematic/src/x_window.c:1233
 msgid "Select mode"
 msgstr "Select mode"
 
-#: schematic/src/x_window.c:1288
 #, fuzzy
 msgid "Show"
 msgstr "ShowN"
 
-#: schematic/src/x_window.c:1289
 msgid "Show text starting with:"
 msgstr "Show text starting with:"
 
-#: schematic/src/x_window.c:1345
 msgid "Menu/Cancel"
 msgstr "Menu/Cancel"
 
-#: schematic/src/x_window.c:1349
 msgid "Pan/Cancel"
 msgstr "Pan/Cancel"
 
-#: schematic/src/x_window.c:1359
 msgid "Pick"
 msgstr "Pick"
 
-#: schematic/src/x_window.c:1470 schematic/scheme/gschem/builtins.scm:180
 msgid "Status"
 msgstr "Status"
 
-#: schematic/src/x_window.c:1568
 #, fuzzy, c-format
 msgid "New file [%s]"
 msgstr "New file [%s]\n"
 
-#: schematic/src/x_window.c:1598
 #, fuzzy, c-format
 msgid ""
 "<b>An error occurred while loading the requested file.</b>\n"
@@ -2381,902 +1869,692 @@ msgstr ""
 "\n"
 "Loading from '%s' failed: %s. The gschem log may contain more information."
 
-#: schematic/src/x_window.c:1617
 msgid "Failed to load file"
 msgstr "Failed to load file"
 
-#: schematic/data/lepton-schematic.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Schematic Editor"
 msgstr "gEDA Schematic Editor"
 
-#: schematic/data/lepton-schematic.desktop.in:4
 #, fuzzy
 msgid "Create and edit electrical schematics and symbols with lepton-schematic"
 msgstr "Create and edit electrical schematics and symbols with gschem"
 
-#: schematic/scheme/conf/schematic/menu.scm:27
 msgid "_New"
 msgstr "_New"
 
-#: schematic/scheme/conf/schematic/menu.scm:28
 msgid "_Open..."
 msgstr "_Open..."
 
-#: schematic/scheme/conf/schematic/menu.scm:30
 msgid "Open Recen_t"
 msgstr "Open Recen_t"
 
-#: schematic/scheme/conf/schematic/menu.scm:32
 msgid "_Save"
 msgstr "_Save"
 
-#: schematic/scheme/conf/schematic/menu.scm:33
 msgid "Save _As..."
 msgstr "Save _As..."
 
-#: schematic/scheme/conf/schematic/menu.scm:34
-#: schematic/scheme/gschem/builtins.scm:65
 msgid "Save All"
 msgstr "Save All"
 
-#: schematic/scheme/conf/schematic/menu.scm:36
 msgid "_Print..."
 msgstr "_Print..."
 
-#: schematic/scheme/conf/schematic/menu.scm:37
 #, fuzzy
 msgid "Write _Image..."
 msgstr "Write _image..."
 
-#: schematic/scheme/conf/schematic/menu.scm:39
 #, fuzzy
 msgid "Invoke Macro..."
 msgstr "Invoke Macro"
 
-#: schematic/scheme/conf/schematic/menu.scm:41
 msgid "REPL..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:43
-#: schematic/scheme/gschem/builtins.scm:77
 msgid "New Window"
 msgstr "New Window"
 
-#: schematic/scheme/conf/schematic/menu.scm:44
 msgid "_Close Window"
 msgstr "_Close Window"
 
-#: schematic/scheme/conf/schematic/menu.scm:45
 msgid "_Quit"
 msgstr "_Quit"
 
-#: schematic/scheme/conf/schematic/menu.scm:51
 msgid "_Undo"
 msgstr "_Undo"
 
-#: schematic/scheme/conf/schematic/menu.scm:52
 msgid "_Redo"
 msgstr "_Redo"
 
-#: schematic/scheme/conf/schematic/menu.scm:54
 msgid "Cu_t"
 msgstr "Cu_t"
 
-#: schematic/scheme/conf/schematic/menu.scm:55
 msgid "_Copy"
 msgstr "_Copy"
 
-#: schematic/scheme/conf/schematic/menu.scm:56
 msgid "_Paste"
 msgstr "_Paste"
 
-#: schematic/scheme/conf/schematic/menu.scm:57
 msgid "_Delete"
 msgstr "_Delete"
 
-#: schematic/scheme/conf/schematic/menu.scm:60
-#: schematic/scheme/gschem/builtins.scm:102
 msgid "Select All"
 msgstr "Select All"
 
-#: schematic/scheme/conf/schematic/menu.scm:61
-#: schematic/scheme/gschem/builtins.scm:105
 msgid "Deselect"
 msgstr "Deselect"
 
-#: schematic/scheme/conf/schematic/menu.scm:65
 msgid "Rotate 90 Mode"
 msgstr "Rotate 90 Mode"
 
-#: schematic/scheme/conf/schematic/menu.scm:70
 msgid "Edit Text..."
 msgstr "Edit Text..."
 
-#: schematic/scheme/conf/schematic/menu.scm:71
 msgid "Slot..."
 msgstr "Slot..."
 
-#: schematic/scheme/conf/schematic/menu.scm:76
-#: schematic/scheme/gschem/builtins.scm:150
 msgid "Embed Component/Picture"
 msgstr "Embed Component/Picture"
 
-#: schematic/scheme/conf/schematic/menu.scm:77
-#: schematic/scheme/gschem/builtins.scm:153
 msgid "Unembed Component/Picture"
 msgstr "Unembed Component/Picture"
 
-#: schematic/scheme/conf/schematic/menu.scm:78
-#: schematic/scheme/gschem/builtins.scm:156
 msgid "Update Component"
 msgstr "Update Component"
 
-#: schematic/scheme/conf/schematic/menu.scm:79
 msgid "Symbol Translate..."
 msgstr "Symbol Translate..."
 
-#: schematic/scheme/conf/schematic/menu.scm:85
 msgid "Copy into 1"
 msgstr "Copy into 1"
 
-#: schematic/scheme/conf/schematic/menu.scm:86
 msgid "Copy into 2"
 msgstr "Copy into 2"
 
-#: schematic/scheme/conf/schematic/menu.scm:87
 msgid "Copy into 3"
 msgstr "Copy into 3"
 
-#: schematic/scheme/conf/schematic/menu.scm:88
 msgid "Copy into 4"
 msgstr "Copy into 4"
 
-#: schematic/scheme/conf/schematic/menu.scm:89
 msgid "Copy into 5"
 msgstr "Copy into 5"
 
-#: schematic/scheme/conf/schematic/menu.scm:90
 msgid "Cut into 1"
 msgstr "Cut into 1"
 
-#: schematic/scheme/conf/schematic/menu.scm:91
 msgid "Cut into 2"
 msgstr "Cut into 2"
 
-#: schematic/scheme/conf/schematic/menu.scm:92
 msgid "Cut into 3"
 msgstr "Cut into 3"
 
-#: schematic/scheme/conf/schematic/menu.scm:93
 msgid "Cut into 4"
 msgstr "Cut into 4"
 
-#: schematic/scheme/conf/schematic/menu.scm:94
 msgid "Cut into 5"
 msgstr "Cut into 5"
 
-#: schematic/scheme/conf/schematic/menu.scm:95
 msgid "Paste from 1"
 msgstr "Paste from 1"
 
-#: schematic/scheme/conf/schematic/menu.scm:96
 msgid "Paste from 2"
 msgstr "Paste from 2"
 
-#: schematic/scheme/conf/schematic/menu.scm:97
 msgid "Paste from 3"
 msgstr "Paste from 3"
 
-#: schematic/scheme/conf/schematic/menu.scm:98
 msgid "Paste from 4"
 msgstr "Paste from 4"
 
-#: schematic/scheme/conf/schematic/menu.scm:99
 msgid "Paste from 5"
 msgstr "Paste from 5"
 
-#: schematic/scheme/conf/schematic/menu.scm:105
 msgid "Side Dock"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:106
 #, fuzzy
 msgid "Bottom Dock"
 msgstr "Bottom to top"
 
-#: schematic/scheme/conf/schematic/menu.scm:108
 #, fuzzy
 msgid "Find Text Results"
 msgstr "Find Text"
 
-#: schematic/scheme/conf/schematic/menu.scm:110
 msgid "_Redraw"
 msgstr "_Redraw"
 
-#: schematic/scheme/conf/schematic/menu.scm:111
 msgid "_Pan"
 msgstr "_Pan"
 
-#: schematic/scheme/conf/schematic/menu.scm:112
 msgid "Zoom _Box"
 msgstr "Zoom _Box"
 
-#: schematic/scheme/conf/schematic/menu.scm:113
 msgid "Zoom _Extents"
 msgstr "Zoom _Extents"
 
-#: schematic/scheme/conf/schematic/menu.scm:114
 msgid "Zoom _In"
 msgstr "Zoom _In"
 
-#: schematic/scheme/conf/schematic/menu.scm:115
 msgid "Zoom _Out"
 msgstr "Zoom _Out"
 
-#: schematic/scheme/conf/schematic/menu.scm:116
 msgid "Zoom _Full"
 msgstr "Zoom _Full"
 
-#: schematic/scheme/conf/schematic/menu.scm:118
 #, fuzzy
 msgid "_Dark Color Scheme"
 msgstr "_Dark colour scheme"
 
-#: schematic/scheme/conf/schematic/menu.scm:119
 #, fuzzy
 msgid "_Light Color Scheme"
 msgstr "_Light colour scheme"
 
-#: schematic/scheme/conf/schematic/menu.scm:120
 #, fuzzy
 msgid "B_W Color Scheme"
 msgstr "B_W color scheme"
 
-#: schematic/scheme/conf/schematic/menu.scm:122
 #, fuzzy
 msgid "Color Scheme Editor..."
 msgstr "_Light colour scheme"
 
-#: schematic/scheme/conf/schematic/menu.scm:129
 msgid "_Manager..."
 msgstr "_Manager..."
 
-#: schematic/scheme/conf/schematic/menu.scm:131
 msgid "_Previous"
 msgstr "_Previous"
 
-#: schematic/scheme/conf/schematic/menu.scm:132
 msgid "_Next"
 msgstr "_Next"
 
-#: schematic/scheme/conf/schematic/menu.scm:133
 msgid "_Close"
 msgstr "_Close"
 
-#: schematic/scheme/conf/schematic/menu.scm:135
 #, fuzzy
 msgid "_Revert..."
 msgstr "_Revert"
 
-#: schematic/scheme/conf/schematic/menu.scm:137
-#: schematic/scheme/gschem/builtins.scm:249
 #, fuzzy
 msgid "Next Tab"
 msgstr "New Page"
 
-#: schematic/scheme/conf/schematic/menu.scm:138
-#: schematic/scheme/gschem/builtins.scm:252
 #, fuzzy
 msgid "Previous Tab"
 msgstr "_Previous"
 
-#: schematic/scheme/conf/schematic/menu.scm:146
 msgid "_Component..."
 msgstr "_Component..."
 
-#: schematic/scheme/conf/schematic/menu.scm:148
 msgid "_Net"
 msgstr "_Net"
 
-#: schematic/scheme/conf/schematic/menu.scm:149
 msgid "B_us"
 msgstr "B_us"
 
-#: schematic/scheme/conf/schematic/menu.scm:151
 msgid "_Attribute..."
 msgstr "_Attribute..."
 
-#: schematic/scheme/conf/schematic/menu.scm:152
 msgid "_Text..."
 msgstr "_Text..."
 
-#: schematic/scheme/conf/schematic/menu.scm:154
 msgid "_Line"
 msgstr "_Line"
 
-#: schematic/scheme/conf/schematic/menu.scm:155
 msgid "Pat_h"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:156
 msgid "_Box"
 msgstr "_Box"
 
-#: schematic/scheme/conf/schematic/menu.scm:157
 msgid "C_ircle"
 msgstr "C_ircle"
 
-#: schematic/scheme/conf/schematic/menu.scm:158
 msgid "A_rc"
 msgstr "A_rc"
 
-#: schematic/scheme/conf/schematic/menu.scm:159
 msgid "_Pin"
 msgstr "_Pin"
 
-#: schematic/scheme/conf/schematic/menu.scm:161
 msgid "Pictu_re..."
 msgstr "Pictu_re..."
 
-#: schematic/scheme/conf/schematic/menu.scm:167
 msgid "_Up"
 msgstr "_Up"
 
-#: schematic/scheme/conf/schematic/menu.scm:169
 msgid "_Down Schematic"
 msgstr "_Down Schematic"
 
-#: schematic/scheme/conf/schematic/menu.scm:170
 msgid "Down _Symbol"
 msgstr "Down _Symbol"
 
-#: schematic/scheme/conf/schematic/menu.scm:176
 msgid "_Attach"
 msgstr "_Attach"
 
-#: schematic/scheme/conf/schematic/menu.scm:177
 msgid "_Detach"
 msgstr "_Detach"
 
-#: schematic/scheme/conf/schematic/menu.scm:179
 msgid "Show _Value"
 msgstr "Show _Value"
 
-#: schematic/scheme/conf/schematic/menu.scm:180
 msgid "Show _Name"
 msgstr "Show _Name"
 
-#: schematic/scheme/conf/schematic/menu.scm:181
 msgid "Show _Both"
 msgstr "Show _Both"
 
-#: schematic/scheme/conf/schematic/menu.scm:182
 msgid "_Toggle Visibility"
 msgstr "_Toggle Visibility"
 
-#: schematic/scheme/conf/schematic/menu.scm:184
 msgid "_Hide Specific Text..."
 msgstr "_Hide Specific Text..."
 
-#: schematic/scheme/conf/schematic/menu.scm:185
 msgid "_Show Specific Text..."
 msgstr "_Show Specific Text..."
 
-#: schematic/scheme/conf/schematic/menu.scm:186
 #, fuzzy
 msgid "Show/Hide Hidden Text"
 msgstr "Show/Hide Inv Text"
 
-#: schematic/scheme/conf/schematic/menu.scm:188
 msgid "_Find Text/Check Symbol..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:189
 msgid "A_utonumber Text..."
 msgstr "A_utonumber Text..."
 
-#: schematic/scheme/conf/schematic/menu.scm:195
 #, fuzzy
 msgid "_Options..."
 msgstr "_Options"
 
-#: schematic/scheme/conf/schematic/menu.scm:196
 #, fuzzy
 msgid "_Font..."
 msgstr "_Print..."
 
-#: schematic/scheme/conf/schematic/menu.scm:198
 #, fuzzy
 msgid "Grid +"
 msgstr "Grid OFF\n"
 
-#: schematic/scheme/conf/schematic/menu.scm:199
 #, fuzzy
 msgid "Grid -"
 msgstr "Grid OFF\n"
 
-#: schematic/scheme/conf/schematic/menu.scm:201
 msgid "Grid Style: Cycle Dots/Mesh/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:202
 msgid "Grid Snap: Cycle Grid/Resnap/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:204
 #, fuzzy
 msgid "Feedback Mode: Outline/Box"
 msgstr "Toggle _Outline/Box"
 
-#: schematic/scheme/conf/schematic/menu.scm:205
 #, fuzzy
 msgid "Net: Rubberband On/Off"
 msgstr "Rubber band ON\n"
 
-#: schematic/scheme/conf/schematic/menu.scm:206
 msgid "Net: Magnetic On/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:208
 #, fuzzy
 msgid "_Coord Window"
 msgstr "_Close Window"
 
-#: schematic/scheme/conf/schematic/menu.scm:209
 #, fuzzy
 msgid "_Log Window"
 msgstr "Show _Log Window..."
 
-#: schematic/scheme/conf/schematic/menu.scm:215
 msgid "_1 allegro"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:223
 #, fuzzy
 msgid "User _Guide"
 msgstr "gschem _FAQ"
 
-#: schematic/scheme/conf/schematic/menu.scm:224
 msgid "_FAQ"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:225
 #, fuzzy
 msgid "Docu_mentation"
 msgstr "D_ocumentation"
 
-#: schematic/scheme/conf/schematic/menu.scm:226
 msgid "_Wiki"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:228
 #, fuzzy
 msgid "Find Component D_ocumentation"
 msgstr "Component D_ocumentation"
 
-#: schematic/scheme/conf/schematic/menu.scm:230
 msgid "_Hotkeys..."
 msgstr "_Hotkeys"
 
-#: schematic/scheme/conf/schematic/menu.scm:231
 #, fuzzy
 msgid "_About"
 msgstr "_About..."
 
-#: schematic/scheme/conf/schematic/menu.scm:237
 msgid "_File"
 msgstr "_File"
 
-#: schematic/scheme/conf/schematic/menu.scm:238
 msgid "_Edit"
 msgstr "_Edit"
 
-#: schematic/scheme/conf/schematic/menu.scm:240
 msgid "_View"
 msgstr "_View"
 
-#: schematic/scheme/conf/schematic/menu.scm:241
 msgid "_Page"
 msgstr "_Page"
 
-#: schematic/scheme/conf/schematic/menu.scm:242
 msgid "_Add"
 msgstr "_Add"
 
-#: schematic/scheme/conf/schematic/menu.scm:243
 msgid "Hie_rarchy"
 msgstr "Hie_rarchy"
 
-#: schematic/scheme/conf/schematic/menu.scm:244
 msgid "A_ttributes"
 msgstr "A_ttributes"
 
-#: schematic/scheme/conf/schematic/menu.scm:245
 msgid "_Options"
 msgstr "_Options"
 
-#: schematic/scheme/conf/schematic/menu.scm:246
 #, fuzzy
 msgid "_Netlist"
 msgstr "_Net"
 
-#: schematic/scheme/conf/schematic/menu.scm:247
 msgid "_Help"
 msgstr "_Help"
 
-#: schematic/scheme/gschem/action.scm:43
 #, fuzzy, scheme-format
 msgid "~S is not a valid gschem action."
 msgstr "~S is not a valid key combination."
 
-#: schematic/scheme/gschem/action.scm:158
 msgid "Repeat Last Action"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:47
 #, fuzzy
 msgid "Cancel"
 msgstr "Pan/Cancel"
 
-#: schematic/scheme/gschem/builtins.scm:53
 #, fuzzy
 msgid "New File"
 msgstr "New file"
 
-#: schematic/scheme/gschem/builtins.scm:56
 #, fuzzy
 msgid "Open File"
 msgstr "Open file..."
 
-#: schematic/scheme/gschem/builtins.scm:62
 #, fuzzy
 msgid "Save As"
 msgstr "Save All"
 
-#: schematic/scheme/gschem/builtins.scm:68
 #, fuzzy
 msgid "Print"
 msgstr "Print..."
 
-#: schematic/scheme/gschem/builtins.scm:71
 msgid "Export Image"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:74
 msgid "Run Script"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:80
 #, fuzzy
 msgid "Close Window"
 msgstr "_Close Window"
 
-#: schematic/scheme/gschem/builtins.scm:83
 #, fuzzy
 msgid "Quit"
 msgstr "_Quit"
 
-#: schematic/scheme/gschem/builtins.scm:87
 msgid "Terminal REPL"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:132
 msgid "Choose Slot"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:135
 #, fuzzy
 msgid "Edit Object Properties"
 msgstr "Edit Text Properties"
 
-#: schematic/scheme/gschem/builtins.scm:138
 #, fuzzy
 msgid "Translate Symbol"
 msgstr "Translate"
 
-#: schematic/scheme/gschem/builtins.scm:147
 msgid "Invoke Macro"
 msgstr "Invoke Macro"
 
-#: schematic/scheme/gschem/builtins.scm:159
 #, fuzzy
 msgid "Show/Hide Invisible Text"
 msgstr "Show/Hide Inv Text"
 
-#: schematic/scheme/gschem/builtins.scm:165
 #, fuzzy
 msgid "Cut"
 msgstr "Cu_t"
 
-#: schematic/scheme/gschem/builtins.scm:171
 #, fuzzy
 msgid "Paste"
 msgstr "_Paste"
 
-#: schematic/scheme/gschem/builtins.scm:177
 msgid "Sidebar"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:183
 #, fuzzy
 msgid "Find Text State"
 msgstr "Find Text"
 
-#: schematic/scheme/gschem/builtins.scm:186
 #, fuzzy
 msgid "Redraw"
 msgstr "_Redraw"
 
-#: schematic/scheme/gschem/builtins.scm:192
 #, fuzzy
 msgid "Pan Left"
 msgstr "Pan Mode"
 
-#: schematic/scheme/gschem/builtins.scm:195
 #, fuzzy
 msgid "Pan Right"
 msgstr "Upper Right"
 
-#: schematic/scheme/gschem/builtins.scm:198
 msgid "Pan Up"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:201
 #, fuzzy
 msgid "Pan Down"
 msgstr "Pan Mode"
 
-#: schematic/scheme/gschem/builtins.scm:216
 #, fuzzy
 msgid "Zoom Full"
 msgstr "Zoom _Full"
 
-#: schematic/scheme/gschem/builtins.scm:219
 #, fuzzy
 msgid "Dark Color Scheme"
 msgstr "_Dark colour scheme"
 
-#: schematic/scheme/gschem/builtins.scm:222
 #, fuzzy
 msgid "Light Color Scheme"
 msgstr "_Light colour scheme"
 
-#: schematic/scheme/gschem/builtins.scm:225
 msgid "Monochrome Color Scheme"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:228
 #, fuzzy
 msgid "Show Color Scheme Editor"
 msgstr "_Light colour scheme"
 
-#: schematic/scheme/gschem/builtins.scm:234
 #, fuzzy
 msgid "Revert Changes"
 msgstr "Really revert page?"
 
-#: schematic/scheme/gschem/builtins.scm:240
 #, fuzzy
 msgid "Previous Page"
 msgstr "_Previous"
 
-#: schematic/scheme/gschem/builtins.scm:243
 #, fuzzy
 msgid "Next Page"
 msgstr "New Page"
 
-#: schematic/scheme/gschem/builtins.scm:255
 #, fuzzy
 msgid "Print Page"
 msgstr "_Previous"
 
-#: schematic/scheme/gschem/builtins.scm:276
 #, fuzzy
 msgid "Add Line"
 msgstr "Line"
 
-#: schematic/scheme/gschem/builtins.scm:279
 #, fuzzy
 msgid "Add Path"
 msgstr "/Add Net"
 
-#: schematic/scheme/gschem/builtins.scm:282
 #, fuzzy
 msgid "Add Box"
 msgstr "/Add Bus"
 
-#: schematic/scheme/gschem/builtins.scm:285
 #, fuzzy
 msgid "Add Circle"
 msgstr "Circle"
 
-#: schematic/scheme/gschem/builtins.scm:288
 #, fuzzy
 msgid "Add Arc"
 msgstr "Add Attribute"
 
-#: schematic/scheme/gschem/builtins.scm:291
 msgid "Add Pin"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:294
 #, fuzzy
 msgid "Add Picture"
 msgstr "Picture"
 
-#: schematic/scheme/gschem/builtins.scm:306
 #, fuzzy
 msgid "Up Hierarchy"
 msgstr "Hie_rarchy"
 
-#: schematic/scheme/gschem/builtins.scm:312
 #, fuzzy
 msgid "Attach Attributes"
 msgstr "Edit Attributes"
 
-#: schematic/scheme/gschem/builtins.scm:315
 #, fuzzy
 msgid "Detach Attributes"
 msgstr "Detached attribute"
 
-#: schematic/scheme/gschem/builtins.scm:318
 #, fuzzy
 msgid "Show Attribute Value"
 msgstr "Slot attribute malformed\n"
 
-#: schematic/scheme/gschem/builtins.scm:321
 #, fuzzy
 msgid "Show Attribute Name"
 msgstr "Slot attribute malformed\n"
 
-#: schematic/scheme/gschem/builtins.scm:327
 #, fuzzy
 msgid "Toggle Text Visibility"
 msgstr "_Toggle Visibility"
 
-#: schematic/scheme/gschem/builtins.scm:330
 #, fuzzy
 msgid "Find Specific Text"
 msgstr "_Find Specific Text..."
 
-#: schematic/scheme/gschem/builtins.scm:333
 #, fuzzy
 msgid "Hide Specific Text"
 msgstr "_Hide Specific Text..."
 
-#: schematic/scheme/gschem/builtins.scm:336
 #, fuzzy
 msgid "Show Specific Text"
 msgstr "_Show Specific Text..."
 
-#: schematic/scheme/gschem/builtins.scm:339
 #, fuzzy
 msgid "Autonumber Text"
 msgstr "Autonumber text"
 
-#: schematic/scheme/gschem/builtins.scm:345
 #, fuzzy
 msgid "Show Hotkeys"
 msgstr "Hotkeys"
 
-#: schematic/scheme/gschem/builtins.scm:348
 msgid "Switch Grid Style"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:351
 msgid "Switch Snap Mode"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:354
 #, fuzzy
 msgid "Set Grid Spacing"
 msgstr "Scale _up Grid Spacing"
 
-#: schematic/scheme/gschem/builtins.scm:357
 #, fuzzy
 msgid "Increase Grid Spacing"
 msgstr "Scale _up Grid Spacing"
 
-#: schematic/scheme/gschem/builtins.scm:360
 #, fuzzy
 msgid "Decrease Grid Spacing"
 msgstr "Scale _up Grid Spacing"
 
-#: schematic/scheme/gschem/builtins.scm:363
 #, fuzzy
 msgid "Toggle Outline Drawing"
 msgstr "Toggle _Outline/Box"
 
-#: schematic/scheme/gschem/builtins.scm:366
 #, fuzzy
 msgid "Toggle Net Rubber Band"
 msgstr "Toggle Net _Rubberband"
 
-#: schematic/scheme/gschem/builtins.scm:369
 #, fuzzy
 msgid "Toggle Magnetic Nets"
 msgstr "Toggle _Magnetic Net"
 
-#: schematic/scheme/gschem/builtins.scm:372
 #, fuzzy
 msgid "Show Log Window"
 msgstr "Show _Log Window..."
 
-#: schematic/scheme/gschem/builtins.scm:375
 #, fuzzy
 msgid "Show Coordinate Window"
 msgstr "Show _Coord Window..."
 
-#: schematic/scheme/gschem/builtins.scm:385
 #, fuzzy
 msgid "Component Documentation"
 msgstr "Component D_ocumentation"
 
-#: schematic/scheme/gschem/builtins.scm:387
 msgid "View documentation for selected component"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:403
 msgid ""
 "Could not show documentation for selected component:\n"
 "\n"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:408
 msgid "gEDA Manuals"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:409
 msgid "View the front page of the gEDA documentation in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:414
 #, fuzzy
 msgid "gschem User Guide"
 msgstr "gschem _FAQ"
 
-#: schematic/scheme/gschem/builtins.scm:415
 msgid "View the gschem User Guide in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:420
 #, fuzzy
 msgid "gschem FAQ"
 msgstr "gschem _FAQ"
 
-#: schematic/scheme/gschem/builtins.scm:421
 msgid "Frequently Asked Questions about using gschem."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:426
 #, fuzzy
 msgid "gEDA wiki"
 msgstr "gEDA _Wiki..."
 
-#: schematic/scheme/gschem/builtins.scm:427
 msgid "View the front page of the gEDA wiki in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:431
 msgid "About gschem"
 msgstr "About gschem"
 
-#: schematic/scheme/gschem/deprecated.scm:102
 #, scheme-format
 msgid "Invalid text alignment ~A."
 msgstr "Invalid text alignment ~A."
 
-#: schematic/scheme/gschem/gschemdoc.scm:241
 msgid "No documentation found"
 msgstr "No documentation found"
 
-#: schematic/scheme/gschem/keymap.scm:40
 #, scheme-format
 msgid "~S is not a valid key combination."
 msgstr "~S is not a valid key combination."
 
-#: schematic/scheme/gschem/keymap.scm:157
 #, scheme-format
 msgid "~S is not a prefix key sequence."
 msgstr "~S is not a prefix key sequence."

--- a/schematic/po/es.po
+++ b/schematic/po/es.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gschem VERSION\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-15 15:13+0300\n"
+"POT-Creation-Date: 2019-02-22 14:08+0300\n"
 "PO-Revision-Date: 2012-03-23 03:04+0000\n"
 "Last-Translator: Adolfo Jayme Barrientos <fitoschido@gmail.com>\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -19,24 +19,20 @@ msgstr ""
 "X-Launchpad-Export-Date: 2012-11-14 16:52+0000\n"
 "X-Generator: Launchpad (build 16265)\n"
 
-#: schematic/src/a_zoom.c:155
 #, fuzzy
 msgid "Zoom too small!  Cannot zoom further."
 msgstr "¡Vista demasiado ampliada! No se puede ampliar más.\n"
 
-#: schematic/src/color_edit_widget.c:399
 #, fuzzy, c-format
 msgid ""
 "Could not save file [%s]:\n"
 "%s"
 msgstr "NO se ha podido guardar la página [%s]\n"
 
-#: schematic/src/color_edit_widget.c:434
 #, fuzzy
 msgid "Save Color Scheme As..."
 msgstr "Configuración de co_lores claros"
 
-#: schematic/src/color_edit_widget.c:482 schematic/src/x_fileselect.c:292
 #, fuzzy, c-format
 msgid ""
 "The selected file `%1$s' already exists.\n"
@@ -47,196 +43,158 @@ msgstr ""
 "\n"
 "¿Quiere sobreescribirlo?"
 
-#: schematic/src/color_edit_widget.c:486 schematic/src/x_fileselect.c:295
 msgid "Overwrite file?"
 msgstr "¿Sobreescribir el archivo?"
 
-#: schematic/src/font_select_widget.c:211
 msgid "_Apply"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:215
 msgid "Sa_ve..."
 msgstr ""
 
-#: schematic/src/font_select_widget.c:278
 #, c-format
 msgid "<b>Current:</b> %s"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:453
 msgid "Save configuration"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:461
 #, fuzzy
 msgid "Save settings to:"
 msgstr "Opciones"
 
-#: schematic/src/font_select_widget.c:465
 msgid "Local configuration file (in current directory)"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:467
 msgid "User configuration file (geda-user.conf)"
 msgstr ""
 
-#: schematic/src/g_attrib.c:90
 msgid "Object ~A is not included in the current gschem page."
 msgstr "El objeto ~A no está en la página actual de gschem."
 
-#: schematic/src/g_attrib.c:110
 msgid "Invalid text name/value visibility ~A."
 msgstr "Visibilidad de nombre/valor de texto inválida ~A"
 
-#: schematic/src/g_rc.c:107
 #, fuzzy, c-format
 msgid "You are running gEDA/gaf version [%1$s%2$s.%3$s],\n"
 msgstr "Versión de gEDA/gschem %s%s.%s\n"
 
-#: schematic/src/g_rc.c:111
 #, c-format
 msgid ""
 "but you have a version [%1$s] gschemrc file:\n"
 "[%2$s]\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:114
 #, c-format
 msgid "Please be sure that you have the latest rc file.\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:240
 #, fuzzy, c-format
 msgid "Invalid size [%1$d] passed to text-size\n"
 msgstr "Se ha especificado un tamaño no válido [%d] a la función text-size\n"
 
-#: schematic/src/g_rc.c:283
 #, fuzzy, c-format
 msgid "Invalid size [%1$d] passed to snap-size\n"
 msgstr "Se ha especificado un tamaño no válido [%d] a la función snap-size\n"
 
-#: schematic/src/g_rc.c:620
 #, fuzzy, c-format
 msgid "Invalid num levels [%1$d] passed to undo-levels\n"
 msgstr ""
 "Número de niveles [%d] no válidos especificados a la función undo-levels\n"
 
-#: schematic/src/g_rc.c:831
 #, fuzzy, c-format
 msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
 msgstr "Tamaño no válido [%d] especificado a la función bus-ripper-size\n"
 
-#: schematic/src/g_rc.c:931
 #, fuzzy, c-format
 msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
 msgstr ""
 "Tamaño de punto no válido [%d] especificado a la función dots-grid-dot-size\n"
 
-#: schematic/src/g_rc.c:972
 #, fuzzy, c-format
 msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
 msgstr ""
 "Espaciado de punto no válido [%d] especificado a la función dots-grid-fixed-"
 "threshold\n"
 
-#: schematic/src/g_rc.c:998
 #, fuzzy, c-format
 msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
 msgstr ""
 "Espaciado de punto no válido [%d] especificado a la función mesh-grid-"
 "display-threshold\n"
 
-#: schematic/src/g_rc.c:1023
 #, fuzzy, c-format
 msgid "Invalid offset [%1$d] passed to add-attribute-offset\n"
 msgstr ""
 "Se ha especificado un desplazamiento no válido [%d] a la función add-"
 "attribute-offset\n"
 
-#: schematic/src/g_rc.c:1047
 #, fuzzy, c-format
 msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
 msgstr ""
 "Se ha especificado un número de segundos no válido [%d] a la función auto-"
 "save-interval\n"
 
-#: schematic/src/g_rc.c:1071
 #, fuzzy, c-format
 msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
 msgstr ""
 "Se ha especificado un aumento no válido [%d] a la función mousepan-gain\n"
 
-#: schematic/src/g_rc.c:1094
 #, fuzzy, c-format
 msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
 msgstr ""
 "Se ha especificado un aumento no válido [%d] a la función keyboardpan-gain\n"
 
-#: schematic/src/g_rc.c:1118
 #, fuzzy, c-format
 msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
 msgstr ""
 "Se ha especificado un número de pixels no válido [%d] a la función select-"
 "slack-pixels\n"
 
-#: schematic/src/g_rc.c:1144
 #, fuzzy, c-format
 msgid "Invalid gain [%1$d] passed to zoom-gain\n"
 msgstr ""
 "Se ha llamado a la función zoom-gain con un nivel de aumento [%d] no válido\n"
 
-#: schematic/src/g_rc.c:1169
 #, fuzzy, c-format
 msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
 msgstr ""
 "Se ha llamado a la función scrollpan-steps con un número de pasos no válido "
 "[%d]\n"
 
-#: schematic/src/g_select.c:78 schematic/src/g_select.c:115
-#: schematic/src/g_select.c:151
 msgid "Object ~A is not directly included in a page."
 msgstr "El objeto ~A no está incluído directamente en una página."
 
-#: schematic/src/g_util.c:54
 msgid "Could not launch URI ~S: ~A"
 msgstr "No se puede abrir la URI ~S: ~A"
 
-#: schematic/src/g_window.c:139
 msgid "Found invalid gschem window smob ~S"
 msgstr "Se encontró `smob' de ventana de gschem inválido ~S"
 
-#: schematic/src/lepton-schematic.c:156
 #, fuzzy, c-format
 msgid "Lepton EDA/lepton-schematic version %1$s%2$s.%3$s git: %4$.7s"
 msgstr "Versión de gEDA/gschem %s%s.%s\n"
 
-#: schematic/src/lepton-schematic.c:163
 #, c-format
 msgid "This is the MINGW32 port.\n"
 msgstr "Ésta es la adaptación MINGW32.\n"
 
-#: schematic/src/lepton-schematic.c:167
 #, fuzzy, c-format
 msgid "Current locale settings: %1$s\n"
 msgstr "Entorno actual de locale: %s\n"
 
-#: schematic/src/lepton-schematic.c:201
 #, fuzzy, c-format
 msgid "Couldn't find init scm file [%1$s]"
 msgstr "No se ha podido encontrar el fichero de inicialización scm [%s]\n"
 
-#: schematic/src/lepton-schematic.c:206
 #, fuzzy, c-format
 msgid "Read init scm file [%1$s]"
 msgstr "Leído fichero de inicialización scm [%s]\n"
 
-#: schematic/src/lepton-schematic.c:210
 #, fuzzy, c-format
 msgid "Failed to read init scm file [%1$s]"
 msgstr "Fallo al leer fichero de inicialización scm [%s]\n"
 
-#: schematic/src/lepton-schematic.c:290
 #, fuzzy, c-format
 msgid ""
 "ERROR: Failed to load or evaluate startup script.\n"
@@ -247,718 +205,538 @@ msgstr ""
 "\n"
 "El log (registro) de gschem puede tener más información."
 
-#: schematic/src/gschem_about_dialog.c:51
 #, fuzzy, c-format
 msgid "%s (git: %.7s)"
 msgstr "%s (g%.7s)"
 
-#: schematic/src/gschem_about_dialog.c:75
 #, fuzzy
 msgid "Lepton Electronic Design Automation"
 msgstr "gEDA: Automatización de Diseño Electrónico GPL"
 
-#: schematic/src/gschem_about_dialog.c:83
 #, fuzzy
 msgid ""
 "Copyright © 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright © 2017-2018 Lepton Developers.\n"
-"See AUTHORS and ChangeLog files for details."
+"Copyright © 2017-2019 Lepton Developers.\n"
+"See AUTHORS, ChangeLog files and consult 'git log' history for details."
 msgstr ""
 "Todos los derechos reservados © 1998-2012 Ales Hvezda <ahvezda@geda.seul."
 "org>\n"
 "Todos los derechos reservados © 1998-2012 Contribuyentes de gEDA (revisar el "
 "ChangeLog para más detalles)"
 
-#: schematic/src/gschem_alignment_combo.c:69
 msgid "Upper Left"
 msgstr "Arriba a la izquierda"
 
-#: schematic/src/gschem_alignment_combo.c:71
 msgid "Upper Middle"
 msgstr "Arriba centrado"
 
-#: schematic/src/gschem_alignment_combo.c:73
 #, fuzzy
 msgid "Upper Right"
 msgstr "Abajo a la derecha"
 
-#: schematic/src/gschem_alignment_combo.c:78
 msgid "Middle Left"
 msgstr "Centrado a la izquierda"
 
-#: schematic/src/gschem_alignment_combo.c:80
 msgid "Middle Middle"
 msgstr "Centrado Centrado"
 
-#: schematic/src/gschem_alignment_combo.c:82
 msgid "Middle Right"
 msgstr "Centrado a la derecha"
 
-#: schematic/src/gschem_alignment_combo.c:87
 msgid "Lower Left"
 msgstr "Abajo a la izquierda"
 
-#: schematic/src/gschem_alignment_combo.c:89
 msgid "Lower Middle"
 msgstr "Abajo centrado"
 
-#: schematic/src/gschem_alignment_combo.c:91
 msgid "Lower Right"
 msgstr "Abajo a la derecha"
 
-#: schematic/src/gschem_arc_dialog.c:104
 msgid "Arc Params"
 msgstr "Parámetros de arco"
 
-#: schematic/src/gschem_arc_dialog.c:140
 #, fuzzy
 msgid "Arc _Radius:"
 msgstr "Radio de arco:"
 
-#: schematic/src/gschem_arc_dialog.c:141
 #, fuzzy
 msgid "Start _Angle:"
 msgstr "Ángulo de comienzo:"
 
-#: schematic/src/gschem_arc_dialog.c:142
 #, fuzzy
 msgid "_Degrees of Sweep:"
 msgstr "Grados de barrido:"
 
-#: schematic/src/gschem_bottom_widget.c:504
 msgid "Left mouse button"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:508
 #, fuzzy
 msgid "Middle mouse button"
 msgstr "Centrado a la izquierda"
 
-#: schematic/src/gschem_bottom_widget.c:512
 #, fuzzy
 msgid "Right mouse button"
 msgstr ""
 "Añadir conexión\n"
 "Botón derecho del ratón para cancelar"
 
-#: schematic/src/gschem_bottom_widget.c:595
 msgid "(Snap size, Grid size)"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:603
 #, fuzzy
 msgid "Net rubber band mode"
 msgstr "Act/Desact conserva_r conexiones"
 
-#: schematic/src/gschem_bottom_widget.c:614
 #, fuzzy
 msgid "Magnetic net mode"
 msgstr "Modo Ayuda a la conexión"
 
-#: schematic/src/gschem_bottom_widget.c:622
 #, fuzzy
 msgid "Current action mode"
 msgstr "Ventana actual"
 
-#: schematic/src/gschem_bottom_widget.c:935
-#: schematic/src/gschem_bottom_widget.c:951
 msgid "OFF"
 msgstr "○"
 
-#: schematic/src/gschem_bottom_widget.c:954
 msgid "NONE"
 msgstr "NINGUNO"
 
-#: schematic/src/gschem_bottom_widget.c:960
 #, fuzzy, c-format
 msgid "Grid(%1$s, %2$s)"
 msgstr "Rejilla(%s, %s)"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:350
-#: schematic/src/x_compselect.c:1236 schematic/src/x_multiattrib.c:2068
 msgid "Name"
 msgstr "Nombre"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:372
 msgid "S_elect the schematics you want to save:"
 msgstr "S_eleccione los esquemas que quiere guardar:"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:467
 #, fuzzy, c-format
 msgid "Save the changes to schematic \"%1$s\" before closing?"
 msgstr "¿Guardar cambios del esquema \"%s\" antes de salir?"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:473
 #, fuzzy, c-format
 msgid ""
 "There are %1$d schematics with unsaved changes. Save changes before closing?"
 msgstr ""
 "Hay %d esquemas con cambios sin guardar. ¿Guardar cambios antes de cerrar?"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:502
 msgid "If you don't save, all your changes will be permanently lost."
 msgstr "Si no los guarda, todos los cambios se perderán definitivamente."
 
-#: schematic/src/gschem_close_confirmation_dialog.c:522
 #, fuzzy
 msgid "Close _without saving"
 msgstr "_Cerrar sin guardar"
 
-#: schematic/src/gschem_coord_dialog.c:86
 msgid "Coords"
 msgstr "Coordenadas"
 
-#: schematic/src/gschem_coord_dialog.c:106
 msgid "Screen"
 msgstr "Pantalla"
 
-#: schematic/src/gschem_coord_dialog.c:115
 msgid "World"
 msgstr "Mundo"
 
-#: schematic/src/gschem_find_text_state.c:809 schematic/src/x_pagesel.c:432
 msgid "Filename"
 msgstr "Nombre de archivo"
 
-#: schematic/src/gschem_find_text_state.c:821 schematic/src/i_callbacks.c:1970
-#: schematic/src/x_colorcb.c:154 schematic/src/x_widgets.c:179
-#: schematic/src/x_window.c:1226 schematic/src/x_window.c:1440
 msgid "Text"
 msgstr "Texto"
 
-#: schematic/src/gschem_find_text_widget.c:427
 msgid "descend into hierarchy"
 msgstr "Descender en la jerarquía"
 
-#: schematic/src/gschem_find_text_widget.c:435
 #, fuzzy
 msgid "Find"
 msgstr "Encontrar texto:"
 
-#: schematic/src/gschem_find_text_widget.c:557
 #, fuzzy
 msgid "Find Text:"
 msgstr "Encontrar texto:"
 
-#: schematic/src/gschem_find_text_widget.c:564
 msgid "Find Pattern:"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:571
 #, fuzzy
 msgid "Find Regex:"
 msgstr "Encontrar texto:"
 
-#: schematic/src/gschem_find_text_widget.c:578
 msgid "Check symbol:"
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:200
 msgid "Hotkeys"
 msgstr "Teclas rápidas"
 
-#: schematic/src/gschem_hotkey_dialog.c:229
 msgid ""
 "Start typing action name or keystroke to filter the list.\n"
 "Type hotkeys as they are displayed in \"Keystroke(s)\" column."
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:233 schematic/src/x_compselect.c:1124
 #, fuzzy
 msgid "_Filter:"
 msgstr "Filtro:"
 
-#: schematic/src/gschem_hotkey_dialog.c:259 schematic/src/i_basic.c:280
 msgid "Action"
 msgstr "Acción"
 
-#: schematic/src/gschem_hotkey_dialog.c:277
 msgid "Keystroke(s)"
 msgstr "Pulsación(es)"
 
-#: schematic/src/gschem_log_widget.c:177
 msgid "** Invalid UTF-8 in log message. See stderr or gschem.log.\n"
 msgstr ""
 "** mensaje sin codificación UTF-8 en la ventana de registro. Véase la "
 "ventana de registro de gschem o la salida de errores.\n"
 
-#: schematic/src/gschem_log_widget.c:434
 #, fuzzy
 msgid "Clear log window?"
 msgstr "Cerrando ventana\n"
 
-#: schematic/src/gschem_log_widget.c:477
 #, fuzzy
 msgid "Clear Log _Window"
 msgstr "Mostrar ventana de re_gistro..."
 
-#: schematic/src/gschem_macro_widget.c:231
 msgid "Macro:"
 msgstr ""
 
-#: schematic/src/gschem_macro_widget.c:387
 #, fuzzy
 msgid "Evaluate"
 msgstr "Evaluar:"
 
-#: schematic/src/gschem_object_properties_widget.c:172
 #, fuzzy
 msgid "_Fill Type:"
 msgstr "Tipo de relleno:"
 
-#: schematic/src/gschem_object_properties_widget.c:173
 #, fuzzy
 msgid "Lin_e Width:"
 msgstr "Ancho de línea:"
 
-#: schematic/src/gschem_object_properties_widget.c:174
 #, fuzzy
 msgid "Angle _1:"
 msgstr "Ángulo 1:"
 
-#: schematic/src/gschem_object_properties_widget.c:175
 #, fuzzy
 msgid "P_itch 1:"
 msgstr "Separación 1:"
 
-#: schematic/src/gschem_object_properties_widget.c:176
 #, fuzzy
 msgid "Angle _2:"
 msgstr "Ángulo 2:"
 
-#: schematic/src/gschem_object_properties_widget.c:177
 #, fuzzy
 msgid "Pitc_h 2:"
 msgstr "Separación 2:"
 
-#: schematic/src/gschem_object_properties_widget.c:237
 #, fuzzy
 msgid "<b>Fill Properties</b>"
 msgstr "<b>Propiedades del texto</b>"
 
-#: schematic/src/gschem_object_properties_widget.c:255
-#: schematic/src/gschem_text_properties_widget.c:258
-#: schematic/src/x_newtext.c:271
 #, fuzzy
 msgid "Colo_r:"
 msgstr "Color:"
 
-#: schematic/src/gschem_object_properties_widget.c:266
 #, fuzzy
 msgid "<b>General Properties</b>"
 msgstr "<b>Propiedades del texto</b>"
 
-#: schematic/src/gschem_object_properties_widget.c:284
 #, fuzzy
 msgid "_Type:"
 msgstr "Tipo:"
 
-#: schematic/src/gschem_object_properties_widget.c:285
 #, fuzzy
 msgid "_Width:"
 msgstr "Ancho:"
 
-#: schematic/src/gschem_object_properties_widget.c:286
 #, fuzzy
 msgid "Dash _Length:"
 msgstr "Longitud de la línea en la discontinuidad:"
 
-#: schematic/src/gschem_object_properties_widget.c:287
 #, fuzzy
 msgid "Dash _Space:"
 msgstr "Espaciado de la discontinuidad:"
 
-#: schematic/src/gschem_object_properties_widget.c:288
 msgid "C_ap style:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:333
 #, fuzzy
 msgid "<b>Line Properties</b>"
 msgstr "<b>Propiedades del texto</b>"
 
-#: schematic/src/gschem_object_properties_widget.c:351
 #, fuzzy
 msgid "_Pin Type:"
 msgstr "Tipo de Pin"
 
-#: schematic/src/gschem_object_properties_widget.c:362
 #, fuzzy
 msgid "<b>Pin Properties</b>"
 msgstr "<b>Propiedades del texto</b>"
 
-#: schematic/src/gschem_options_widget.c:217
 msgid "_Off"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:220
 msgid "_Dots"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:223
 msgid "M_esh"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:245
 #, fuzzy
 msgid "Net R_ubber Band Mode:"
 msgstr "Act/Desact conserva_r conexiones"
 
-#: schematic/src/gschem_options_widget.c:246
 #, fuzzy
 msgid "_Magnetic Net Mode:"
 msgstr "Modo Ayuda a la conexión"
 
-#: schematic/src/gschem_options_widget.c:250
-#: schematic/src/gschem_options_widget.c:251
 msgid "Enabled"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:265
 #, fuzzy
 msgid "<b>Net Options</b>"
 msgstr "<b>Opciones</b>"
 
-#: schematic/src/gschem_options_widget.c:282
 #, fuzzy
 msgid "Grid Mode:"
 msgstr "Modo Arco"
 
-#: schematic/src/gschem_options_widget.c:283
 #, fuzzy
 msgid "Snap Mode:"
 msgstr "Modo Centrar"
 
-#: schematic/src/gschem_options_widget.c:284
 #, fuzzy
 msgid "_Snap Size:"
 msgstr "Tamaño de la rejilla"
 
-#: schematic/src/gschem_options_widget.c:301
 #, fuzzy
 msgid "<b>Snap Options</b>"
 msgstr "<b>Opciones</b>"
 
-#: schematic/src/gschem_options_widget.c:340
 msgid "O_ff"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:343
 #, fuzzy
 msgid "_Grid"
 msgstr "Rejilla DESACTIVADA\n"
 
-#: schematic/src/gschem_options_widget.c:346
 #, fuzzy
 msgid "_Resnap"
 msgstr "Reajuste a la rejilla activado"
 
-#: schematic/src/gschem_pin_type_combo.c:73
 msgid "Net pin"
 msgstr "Pin para conexión simple"
 
-#: schematic/src/gschem_pin_type_combo.c:80
 msgid "Bus pin (graphical)"
 msgstr "Pin para conexión a bus (gráfico)"
 
-#: schematic/src/gschem_preview.c:195
 msgid "Preview Buffer"
 msgstr "Previsualizar memoria intermedia"
 
-#: schematic/src/gschem_show_hide_text_widget.c:148
-#: schematic/src/x_window.c:1268
 #, fuzzy
 msgid "Hide"
 msgstr "Ocultar texto:"
 
-#: schematic/src/gschem_show_hide_text_widget.c:157
-#: schematic/src/x_window.c:1269
 msgid "Hide text starting with:"
 msgstr "Ocultar texto que comienza por:"
 
-#: schematic/src/gschem_slot_edit_dialog.c:91
 msgid "Edit slot number"
 msgstr "Editar número de elemento"
 
-#: schematic/src/gschem_slot_edit_dialog.c:121
 msgid "Number of Slots:"
 msgstr ""
 
-#: schematic/src/gschem_slot_edit_dialog.c:122
 #, fuzzy
 msgid "Slot Number:"
 msgstr "Editar número de elemento:"
 
-#: schematic/src/gschem_text_properties_widget.c:240
-#: schematic/src/x_newtext.c:265
 msgid "<b>Text Content</b>"
 msgstr "<b>Contenido del texto</b>"
 
-#: schematic/src/gschem_text_properties_widget.c:259
-#: schematic/src/x_newtext.c:291
 #, fuzzy
 msgid "_Size:"
 msgstr "Tamaño:"
 
-#: schematic/src/gschem_text_properties_widget.c:260
-#: schematic/src/x_newtext.c:310
 #, fuzzy
 msgid "Ali_gnment:"
 msgstr "Alineación:"
 
-#: schematic/src/gschem_text_properties_widget.c:261
-#: schematic/src/x_newtext.c:330
 #, fuzzy
 msgid "Ro_tation:"
 msgstr "Orientación:"
 
-#: schematic/src/gschem_text_properties_widget.c:294
-#: schematic/src/x_newtext.c:253
 msgid "<b>Text Properties</b>"
 msgstr "<b>Propiedades del texto</b>"
 
-#: schematic/src/gschem_translate_widget.c:238
 #, fuzzy
 msgid "Coordinate:"
 msgstr "Mostrar ventana de _coordenadas..."
 
-#: schematic/src/gschem_translate_widget.c:405 schematic/src/i_callbacks.c:800
 msgid "Translate"
 msgstr "Mover"
 
-#: schematic/src/i_basic.c:64 schematic/src/x_window.c:1369
-#: schematic/scheme/conf/schematic/menu.scm:59
-#: schematic/scheme/gschem/builtins.scm:99
 msgid "Select Mode"
 msgstr "Seleccionar"
 
-#: schematic/src/i_basic.c:65
 #, fuzzy
 msgid "Select Box Mode"
 msgstr "Seleccionar"
 
-#: schematic/src/i_basic.c:66
 msgid "Text Mode"
 msgstr "Modo Texto"
 
-#: schematic/src/i_basic.c:67
 msgid "Pan Mode"
 msgstr "Modo Centrar"
 
-#: schematic/src/i_basic.c:70
 #, c-format
 msgid "Paste %d Mode"
 msgstr "Modo Pegar %d"
 
-#: schematic/src/i_basic.c:74
 msgid "Magnetic Net Mode"
 msgstr "Modo Ayuda a la conexión"
 
-#: schematic/src/i_basic.c:76
 msgid "Net Mode"
 msgstr "Modo Conexión"
 
-#: schematic/src/i_basic.c:77
 msgid "Arc Mode"
 msgstr "Modo Arco"
 
-#: schematic/src/i_basic.c:78
 msgid "Box Mode"
 msgstr "Modo Rectángulo"
 
-#: schematic/src/i_basic.c:79
 msgid "Bus Mode"
 msgstr "Modo Bus"
 
-#: schematic/src/i_basic.c:80
 msgid "Circle Mode"
 msgstr "Modo Círculo"
 
-#: schematic/src/i_basic.c:81
 msgid "Component Mode"
 msgstr "Modo Componentes"
 
-#: schematic/src/i_basic.c:82 schematic/scheme/conf/schematic/menu.scm:62
-#: schematic/scheme/gschem/builtins.scm:114
 msgid "Copy Mode"
 msgstr "Copiar"
 
-#: schematic/src/i_basic.c:83 schematic/scheme/conf/schematic/menu.scm:63
-#: schematic/scheme/gschem/builtins.scm:117
 msgid "Multiple Copy Mode"
 msgstr "Modo de copia múltiple"
 
-#: schematic/src/i_basic.c:84
 msgid "Line Mode"
 msgstr "Modo Línea"
 
-#: schematic/src/i_basic.c:85 schematic/scheme/conf/schematic/menu.scm:66
-#: schematic/scheme/gschem/builtins.scm:123
 msgid "Mirror Mode"
 msgstr "Voltear"
 
-#: schematic/src/i_basic.c:86 schematic/scheme/conf/schematic/menu.scm:64
-#: schematic/scheme/gschem/builtins.scm:111
 msgid "Move Mode"
 msgstr "Mover"
 
-#: schematic/src/i_basic.c:87
 #, fuzzy
 msgid "Path Mode"
 msgstr "Modo Centrar"
 
-#: schematic/src/i_basic.c:88
 msgid "Picture Mode"
 msgstr "Modo Imagen"
 
-#: schematic/src/i_basic.c:89
 msgid "Pin Mode"
 msgstr "Modo Pin"
 
-#: schematic/src/i_basic.c:90 schematic/scheme/gschem/builtins.scm:120
 msgid "Rotate Mode"
 msgstr "Rotar"
 
-#: schematic/src/i_basic.c:91
 #, fuzzy
 msgid "Modify Mode"
 msgstr "Copiar"
 
-#: schematic/src/i_basic.c:92 schematic/src/x_menus.c:49
-#: schematic/scheme/gschem/builtins.scm:204
 msgid "Zoom Box"
 msgstr "Ampliar"
 
-#: schematic/src/i_basic.c:121
 msgid "Show Hidden"
 msgstr "Mostrar ocultos"
 
-#: schematic/src/i_basic.c:124
 msgid "Snap Off"
 msgstr "Desactivado el ajuste a la rejilla"
 
-#: schematic/src/i_basic.c:126
 msgid "Resnap Active"
 msgstr "Reajuste a la rejilla activado"
 
-#: schematic/src/i_basic.c:288 schematic/src/x_colorcb.c:159
 msgid "Stroke"
 msgstr "Gesto"
 
-#: schematic/src/i_basic.c:296 schematic/src/i_basic.c:330
-#: schematic/src/x_window.c:1361
 msgid "none"
 msgstr "ninguno"
 
-#: schematic/src/i_basic.c:304
 msgid "Repeat/"
 msgstr "Repetir/"
 
-#: schematic/src/i_basic.c:315
 msgid "Repeat/none"
 msgstr "Repetir/ninguno"
 
-#: schematic/src/i_basic.c:323 schematic/src/i_callbacks.c:1239
-#: schematic/scheme/gschem/builtins.scm:189
 msgid "Pan"
 msgstr "Centrar respecto al cursor"
 
-#: schematic/src/i_callbacks.c:74
 #, fuzzy, c-format
 msgid "New page created [%1$s]"
 msgstr "Se ha creado una página nueva [%s]\n"
 
-#: schematic/src/i_callbacks.c:108
 #, fuzzy, c-format
 msgid "New Window created [%1$s]"
 msgstr "Se ha creado una nueva ventana [%s]\n"
 
-#: schematic/src/i_callbacks.c:245
 msgid "Failed to Save All"
 msgstr "No se ha podido guardar todo"
 
-#: schematic/src/i_callbacks.c:247
 msgid "Saved All"
 msgstr "Guardado todo"
 
-#: schematic/src/i_callbacks.c:308
 #, fuzzy
 msgid "Closing Window"
 msgstr "Cerrando ventana\n"
 
-#: schematic/src/i_callbacks.c:505 schematic/src/x_menus.c:55
-#: schematic/scheme/gschem/builtins.scm:168
 msgid "Copy"
 msgstr "Copiar"
 
-#: schematic/src/i_callbacks.c:514 schematic/src/i_callbacks.c:539
-#: schematic/src/i_callbacks.c:564
 msgid "Select objs first"
 msgstr "Antes seleccione objetos"
 
-#: schematic/src/i_callbacks.c:530
 msgid "Multiple Copy"
 msgstr "Copia múltiple"
 
-#: schematic/src/i_callbacks.c:555 schematic/src/x_menus.c:56
 msgid "Move"
 msgstr "Mover"
 
-#: schematic/src/i_callbacks.c:579 schematic/src/x_menus.c:57
-#: schematic/src/x_multiattrib.c:1656 schematic/scheme/gschem/builtins.scm:108
 msgid "Delete"
 msgstr "Borrar"
 
-#: schematic/src/i_callbacks.c:603
 msgid "Edit"
 msgstr "Editar"
 
-#: schematic/src/i_callbacks.c:618 schematic/scheme/gschem/builtins.scm:129
 msgid "Edit Text"
 msgstr "Editar texto"
 
-#: schematic/src/i_callbacks.c:637
 msgid "Slot"
 msgstr "Elemento"
 
-#: schematic/src/i_callbacks.c:688 schematic/src/i_callbacks.c:698
 msgid "Rotate"
 msgstr "Rotar"
 
-#: schematic/src/i_callbacks.c:736 schematic/src/i_callbacks.c:746
 msgid "Mirror"
 msgstr "Voltear"
 
-#: schematic/src/i_callbacks.c:763 schematic/src/x_colorcb.c:160
-#: schematic/scheme/conf/schematic/menu.scm:73
-#: schematic/scheme/gschem/builtins.scm:141
 msgid "Lock"
 msgstr "Fijar"
 
-#: schematic/src/i_callbacks.c:781 schematic/scheme/conf/schematic/menu.scm:74
-#: schematic/scheme/gschem/builtins.scm:144
 msgid "Unlock"
 msgstr "Desfijar"
 
-#: schematic/src/i_callbacks.c:805
 #, fuzzy
 msgid "WARNING: Do not translate with snap off!"
 msgstr ""
 "ADVERTENCIA: ¡No mueva objetos con el ajuste a la rejilla desactivado!\n"
 
-#: schematic/src/i_callbacks.c:806
 #, fuzzy
 msgid "WARNING: Turning snap on and continuing with translate."
 msgstr ""
 "ADVERTENCIA: Activando el ajuste a la rejilla y continuando con el "
 "movimiento.\n"
 
-#: schematic/src/i_callbacks.c:813
 #, fuzzy
 msgid "WARNING: Snap grid size is not equal to 100!"
 msgstr "ADVERTENCIA: ¡El tamaño de la rejilla no es 100!\n"
 
-#: schematic/src/i_callbacks.c:815
 #, fuzzy
 msgid ""
 "WARNING: If you are translating a symbol to the origin, the snap grid size "
@@ -967,23 +745,18 @@ msgstr ""
 "ADVERTENCIA: Si está moviendo un símbolo al origen, el tamaño de la "
 "rejilladebe ser de 100\n"
 
-#: schematic/src/i_callbacks.c:847
 msgid "Embed"
 msgstr "Incrustar"
 
-#: schematic/src/i_callbacks.c:886
 msgid "Unembed"
 msgstr "Desincrustar"
 
-#: schematic/src/i_callbacks.c:928
 msgid "Update"
 msgstr "Actualizar"
 
-#: schematic/src/i_callbacks.c:970
 msgid "ShowHidden"
 msgstr "Mostrar ocultos"
 
-#: schematic/src/i_callbacks.c:1537
 #, c-format
 msgid ""
 "<b>Revert page:</b>\n"
@@ -994,100 +767,78 @@ msgid ""
 "discarded and page file will be reloaded from disk."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1555
 #, fuzzy
 msgid "Revert"
 msgstr "_Recargar"
 
-#: schematic/src/i_callbacks.c:1647
 msgid "Copy to clipboard"
 msgstr "Copiar al portapapeles"
 
-#: schematic/src/i_callbacks.c:1664
 msgid "Cut to clipboard"
 msgstr "Cortar al portapapeles"
 
-#: schematic/src/i_callbacks.c:1686
 msgid "Paste from clipboard"
 msgstr "Pegar desde el portapapeles"
 
-#: schematic/src/i_callbacks.c:1694
 #, fuzzy
 msgid "Empty clipboard"
 msgstr "Copiar al portapapeles"
 
 #. TRANSLATORS: The number is the number of the buffer that the
 #. * selection is being copied to.
-#: schematic/src/i_callbacks.c:1719
 #, fuzzy, c-format
 msgid "Copy %i"
 msgstr "Copiar 1"
 
 #. TRANSLATORS: The number is the number of the buffer that the
 #. * selection is being cut to.
-#: schematic/src/i_callbacks.c:1746
 #, fuzzy, c-format
 msgid "Cut %i"
 msgstr "Cortar 1"
 
 #. TRANSLATORS: The number is the number of the buffer that is being
 #. * pasted to the schematic.
-#: schematic/src/i_callbacks.c:1776
 #, fuzzy, c-format
 msgid "Paste %i"
 msgstr "Pegar 1"
 
-#: schematic/src/i_callbacks.c:1785
 msgid "Empty buffer"
 msgstr "Buffer vacío"
 
-#: schematic/src/i_callbacks.c:1833 schematic/src/x_window.c:1203
 msgid "Component"
 msgstr "Componente"
 
-#: schematic/src/i_callbacks.c:1865 schematic/src/x_colorcb.c:150
 msgid "Attribute"
 msgstr "Propiedad"
 
-#: schematic/src/i_callbacks.c:1885 schematic/src/x_colorcb.c:149
 msgid "Net"
 msgstr "Conexión"
 
-#: schematic/src/i_callbacks.c:1928 schematic/src/x_colorcb.c:155
-#: schematic/src/x_window.c:1222
 msgid "Bus"
 msgstr "Bus"
 
-#: schematic/src/i_callbacks.c:2004
 msgid "Line"
 msgstr "Línea"
 
-#: schematic/src/i_callbacks.c:2021
 msgid "Path"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2043
 msgid "Box"
 msgstr "Rectángulo"
 
-#: schematic/src/i_callbacks.c:2085
 msgid "Circle"
 msgstr "Círculo"
 
-#: schematic/src/i_callbacks.c:2108
 msgid "Arc"
 msgstr "Arco"
 
-#: schematic/src/i_callbacks.c:2131 schematic/src/x_colorcb.c:146
 msgid "Pin"
 msgstr "Pin"
 
-#: schematic/src/i_callbacks.c:2191
 #, fuzzy, c-format
 msgid "Searching for source [%1$s]"
 msgstr "Buscando origen [%s]\n"
 
-#: schematic/src/i_callbacks.c:2223
 #, fuzzy, c-format
 msgid ""
 "Failed to descend hierarchy into '%1$s': %2$s\n"
@@ -1098,121 +849,96 @@ msgstr ""
 "\n"
 "El log (registro) de gschem puede tener más información."
 
-#: schematic/src/i_callbacks.c:2227
 #, fuzzy, c-format
 msgid "Failed to descend into '%1$s': %2$s"
 msgstr "Falló al reemplazar las imágenes: %s"
 
-#: schematic/src/i_callbacks.c:2234
 #, fuzzy
 msgid "Failed to descend hierarchy."
 msgstr "Descender en la jerarquía"
 
-#: schematic/src/i_callbacks.c:2312
 #, fuzzy, c-format
 msgid "Searching for symbol [%1$s]"
 msgstr "Buscando símbolo [%s]\n"
 
-#: schematic/src/i_callbacks.c:2320
 #, fuzzy
 msgid "Symbol is not a real file. Symbol cannot be loaded."
 msgstr "El símbolo no es un archivo físico. No se puede cargar el símbolo.\n"
 
-#: schematic/src/i_callbacks.c:2367 schematic/src/x_tabs.c:1060
 #, fuzzy
 msgid "Cannot find any schematics above the current one!"
 msgstr "¡No se ha podido encontrar ningún esquema jerárquico superior!\n"
 
-#: schematic/src/i_callbacks.c:2400
 msgid "Attach"
 msgstr "Adjuntar"
 
-#: schematic/src/i_callbacks.c:2456
 msgid "Detach"
 msgstr "No adjuntar"
 
-#: schematic/src/i_callbacks.c:2500
 msgid "ShowN"
 msgstr "Mostrar nombre"
 
-#: schematic/src/i_callbacks.c:2537
 msgid "ShowV"
 msgstr "Mostrar valor"
 
-#: schematic/src/i_callbacks.c:2574
 msgid "ShowB"
 msgstr "Mostrar ambos"
 
-#: schematic/src/i_callbacks.c:2612
 msgid "VisToggle"
 msgstr "Cambiar visibilidad"
 
-#: schematic/src/i_callbacks.c:2643
 #, c-format
 msgid "Sorry but this is a non-functioning menu option\n"
 msgstr "Disculpe. Esta opción del menú no funciona\n"
 
-#: schematic/src/i_callbacks.c:2703
 #, fuzzy
 msgid "Action feedback mode set to OUTLINE"
 msgstr "Modo de realimentación seleccionado: SILUETA\n"
 
-#: schematic/src/i_callbacks.c:2706
 #, fuzzy
 msgid "Action feedback mode set to BOUNDINGBOX"
 msgstr "Modo de realimentación seleccionado: CONTENEDOR\n"
 
-#: schematic/src/i_callbacks.c:2730
 #, fuzzy
 msgid "Grid OFF"
 msgstr "Rejilla DESACTIVADA\n"
 
-#: schematic/src/i_callbacks.c:2731
 #, fuzzy
 msgid "Dot grid selected"
 msgstr "Seleccionada rejilla de puntos\n"
 
-#: schematic/src/i_callbacks.c:2732
 #, fuzzy
 msgid "Mesh grid selected"
 msgstr "Seleccionada rejilla de malla\n"
 
-#: schematic/src/i_callbacks.c:2733
 #, fuzzy
 msgid "Invalid grid mode"
 msgstr "Propiedad incorrecta"
 
-#: schematic/src/i_callbacks.c:2755
 #, fuzzy
 msgid "Snap OFF (CAUTION!)"
 msgstr "¡PRECAUCIÓN!: Ajuste a la rejilla DESACTIVADO\n"
 
-#: schematic/src/i_callbacks.c:2758
 #, fuzzy
 msgid "Snap ON"
 msgstr "Ajuste a la rejilla ACTIVADO\n"
 
-#: schematic/src/i_callbacks.c:2761
 #, fuzzy
 msgid "Snap back to the grid (CAUTION!)"
 msgstr "Reajuste a la rejilla (¡PRECAUCIÓN!)\n"
 
-#: schematic/src/i_callbacks.c:2790
 #, fuzzy
 msgid "Rubber band ON"
 msgstr "Goma de borrar ACT\n"
 
-#: schematic/src/i_callbacks.c:2792
 #, fuzzy
 msgid "Rubber band OFF"
 msgstr "Goma de borrar DESACT \n"
 
-#: schematic/src/i_callbacks.c:2811
 #, fuzzy
 msgid "magnetic net mode: ON"
 msgstr "Modo de Ayuda a la conexión: ACTIVADO\n"
 
-#: schematic/src/i_callbacks.c:2814
 #, fuzzy
 msgid "magnetic net mode: OFF"
 msgstr "Modo de Ayuda a la conexión: DESACTIVADO\n"
@@ -1222,159 +948,130 @@ msgstr "Modo de Ayuda a la conexión: DESACTIVADO\n"
 #. the form "untitled_N.sch", where N is a number.  Please make
 #. sure that the translation contains characters suitable for use
 #. in a filename.
-#: schematic/src/i_vars.c:209
 msgid "untitled"
 msgstr ""
 
-#: schematic/src/o_complex.c:192 schematic/src/o_complex.c:195
 #, fuzzy, c-format
 msgid "Translating schematic [%1$d %2$d]"
 msgstr "Convirtiendo esquema [%d %d]\n"
 
-#: schematic/src/o_delete.c:82
 #, fuzzy, c-format
 msgid "Delete locked object?"
 msgid_plural "Delete %1$u locked objects?"
 msgstr[0] "Objetos seleccionados"
 msgstr[1] "Objetos seleccionados"
 
-#: schematic/src/o_misc.c:55
 #, c-format
 msgid "Got an unexpected NULL in o_edit\n"
 msgstr "Se ha recibido NULL (no esperado) en la función o_edit\n"
 
-#: schematic/src/o_misc.c:315
 #, fuzzy
 msgid "Hidden text is now visible"
 msgstr "El texto oculto es ahora visible\n"
 
-#: schematic/src/o_misc.c:317
 #, fuzzy
 msgid "Hidden text is now invisible"
 msgstr "El texto oculto es ahora invisible\n"
 
-#: schematic/src/o_misc.c:425
 #, fuzzy, c-format
 msgid "Could not find symbol [%1$s] in library. Update failed."
 msgstr ""
 "No se pudo encontrar el símbolo [%s] en la librería. Error al actualizar.\n"
 
-#: schematic/src/o_misc.c:541
 #, fuzzy, c-format
 msgid "o_autosave_backups: Can't get the real filename of %1$s."
 msgstr ""
 "o_autosave_backups: Imposible averiguar el nombre de archivo real de %s."
 
-#: schematic/src/o_misc.c:585
 #, fuzzy, c-format
 msgid "Could NOT set previous backup file [%1$s] read-write"
 msgstr ""
 "NO se han podido cambiar los permisos de la copia de seguridad anterior [%s] "
 "a lectura-escritura\n"
 
-#: schematic/src/o_misc.c:605
 #, fuzzy, c-format
 msgid "Could NOT set backup file [%1$s] readonly"
 msgstr ""
 "NO se han podido cambiar los permisos de la copia de seguridad anterior [%s] "
 "a sólo lectura\n"
 
-#: schematic/src/o_misc.c:610
 #, fuzzy, c-format
 msgid "Could NOT save backup file [%1$s]"
 msgstr "NO se ha podido guardar la copia de seguridad [%s]\n"
 
-#: schematic/src/o_move.c:192
 #, c-format
 msgid "ERROR: NULL object in o_move_end!\n"
 msgstr "ERROR: en la función o_move_end, ¡el objeto es NULL!\n"
 
-#: schematic/src/o_move.c:519
 #, c-format
 msgid "DOH! tried to find the whichone, but didn't find it!\n"
 msgstr ""
 "¡Eh! Se ha intentado encontrar el parámetro \"whichone\", pero ¡no se ha "
 "encontrado!\n"
 
-#: schematic/src/o_move.c:546
 #, c-format
 msgid "Got a non line object in o_move_check_endpoint\n"
 msgstr ""
 "Se ha recibido un objeto que no es una línea en la función "
 "o_move_check_endpoint\n"
 
-#: schematic/src/o_net.c:444
 #, fuzzy
 msgid "Warning: Starting net at off grid coordinate"
 msgstr ""
 "Advertencia: se ha iniciado la conexión en una coordenada fuera de la "
 "rejilla\n"
 
-#: schematic/src/o_net.c:508
 #, fuzzy
 msgid "Warning: Ending net at off grid coordinate"
 msgstr ""
 "Advertencia: se ha finalizado la conexión en una coordenada fuera de la "
 "rejilla\n"
 
-#: schematic/src/o_net.c:856 schematic/src/o_net.c:893
-#: schematic/src/o_net.c:964 schematic/src/o_net.c:1000
 #, c-format
 msgid "Tried to add more than two bus rippers. Internal gschem error.\n"
 msgstr ""
 "Se ha intentado añadir más de dos conexiones a bus. Error interno de "
 "gschem.\n"
 
-#: schematic/src/o_net.c:1068
 #, fuzzy, c-format
 msgid "Bus ripper symbol [%1$s] was not found in any component library"
 msgstr "No se ha encontrado el símbolo %s en ninguna librería de componentes\n"
 
-#: schematic/src/o_picture.c:133 schematic/src/o_picture.c:343
 #, fuzzy
 msgid "Select a picture file..."
 msgstr "Seleccionar archivo PostScript..."
 
-#: schematic/src/o_picture.c:166
 #, fuzzy, c-format
 msgid "Failed to load picture: %1$s"
 msgstr "Fallo al cargar la imagen: %s"
 
-#: schematic/src/o_picture.c:182
 msgid "Picture"
 msgstr "Imagen"
 
-#: schematic/src/o_picture.c:378
 #, c-format
 msgid "Failed to replace pictures: %s"
 msgstr "Falló al reemplazar las imágenes: %s"
 
-#: schematic/src/o_slot.c:80
 #, fuzzy
 msgid "Slot attribute malformed"
 msgstr "El atributo del elemento está mal especificado\n"
 
-#: schematic/src/o_slot.c:88
 #, fuzzy
 msgid "numslots attribute missing"
 msgstr "La propiedad \"numslots\" no está definida\n"
 
-#: schematic/src/o_slot.c:89
 #, fuzzy
 msgid "Slotting not allowed for this component"
 msgstr "No se permiten múltiples elementos para este componente\n"
 
-#: schematic/src/o_slot.c:104
 #, fuzzy
 msgid "New slot number out of range"
 msgstr "El nuevo número de elemento está fuera de rango\n"
 
-#: schematic/src/o_undo.c:397
 #, fuzzy
 msgid "Undo/Redo disabled in rc file"
 msgstr "¡Deshacer/Rehacer deshabilitado en el fichero rc!\n"
 
-#: schematic/src/parsecmd.c:77
 #, fuzzy, c-format
 msgid ""
 "Usage: %1$s [OPTION ...] [--] [FILE ...]\n"
@@ -1421,12 +1118,11 @@ msgstr ""
 "Reportar errores a <https://bugs.launchpad.net/geda>\n"
 "Sitio Web de gEDA/gaf: <http://www.geda-project.org/>\n"
 
-#: schematic/src/parsecmd.c:110
 #, fuzzy, c-format
 msgid ""
 "Lepton EDA %1$s (git: %2$.7s)\n"
 "Copyright (C) 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright (C) 2017-2018 Lepton Developers.\n"
+"Copyright (C) 2017-2019 Lepton Developers.\n"
 "This is free software, and you are welcome to redistribute it under\n"
 "certain conditions. For details, see the file `COPYING', which is\n"
 "included in the Lepton EDA distribution.\n"
@@ -1439,79 +1135,60 @@ msgstr ""
 "incluye en la distribución de gEDA.\n"
 "NO EXISTEN GARANTIAS, dentro de lo que la ley permite.\n"
 
-#: schematic/src/x_attribedit.c:125
 #, c-format
 msgid "Got invalid show option; defaulting to show both\n"
 msgstr ""
 "Se ha recibido una opción de mostrar no válida; mostrando ambos por defecto\n"
 
-#: schematic/src/x_attribedit.c:139
 #, c-format
 msgid "ERROR: NULL object!\n"
 msgstr "ERROR: ¡objeto vacío (NULL)!\n"
 
-#: schematic/src/x_attribedit.c:328
 msgid "Single Attribute Editor"
 msgstr "Editor de una única propiedad"
 
-#: schematic/src/x_attribedit.c:358
 msgid "<b>Edit Attribute</b>"
 msgstr "<b>Editar propiedades</b>"
 
-#: schematic/src/x_attribedit.c:360
 msgid "<b>Add Attribute</b>"
 msgstr "<b>Añadir propiedad</b>"
 
-#: schematic/src/x_attribedit.c:376
 #, fuzzy
 msgid "N_ame:"
 msgstr "Nombre:"
 
-#: schematic/src/x_attribedit.c:396 schematic/src/x_multiattrib.c:2222
 #, fuzzy
 msgid "_Value:"
 msgstr "Valor:"
 
-#: schematic/src/x_attribedit.c:415 schematic/src/x_multiattrib.c:2281
 #, fuzzy
 msgid "Vi_sible"
 msgstr "Visible"
 
-#: schematic/src/x_attribedit.c:434
 msgid "Show Value Only"
 msgstr "Mostrar sólo valor"
 
-#: schematic/src/x_attribedit.c:436
 msgid "Show Name Only"
 msgstr "Mostrar sólo nombre"
 
-#: schematic/src/x_attribedit.c:438 schematic/src/x_multiattrib.c:1620
-#: schematic/scheme/gschem/builtins.scm:324
 msgid "Show Name & Value"
 msgstr "Mostrar nombre y valor"
 
-#: schematic/src/x_attribedit.c:445
 msgid "<b>Attach Options</b>"
 msgstr "<b>Opciones de asociación</b>"
 
-#: schematic/src/x_attribedit.c:460
 msgid "All"
 msgstr "Todo"
 
-#: schematic/src/x_attribedit.c:476 schematic/src/x_compselect.c:986
-#: schematic/src/x_compselect.c:1100
 msgid "Components"
 msgstr "Componentes"
 
-#: schematic/src/x_attribedit.c:492 schematic/src/x_window.c:1214
 msgid "Nets"
 msgstr "Conexiones"
 
-#: schematic/src/x_attribedit.c:508
 msgid "Replace existing attributes"
 msgstr "Reemplazar las propiedades existentes"
 
-#: schematic/src/x_autonumber.c:412
 #, fuzzy
 msgid ""
 "slotted object without slot attribute may cause problems when autonumbering "
@@ -1520,7 +1197,6 @@ msgstr ""
 "Un componente con varios elementos sin la propiedad 'slot' puede causar "
 "problemas al autonumerar los números de elemento\n"
 
-#: schematic/src/x_autonumber.c:427
 #, fuzzy, c-format
 msgid ""
 "duplicate slot may cause problems: [symbolname=%1$s, number=%2$d, slot=%3$d]"
@@ -1528,97 +1204,74 @@ msgstr ""
 "La duplicidad de la propiedad 'slot' puede causar problemas: [nombre del "
 "símbolo=%s, número=%d, slot=%d]\n"
 
-#: schematic/src/x_autonumber.c:675
 #, fuzzy
 msgid "No searchstring given in autonumber text."
 msgstr "No se ha especificado una cadena de búsqueda para autonumerar texto.\n"
 
-#: schematic/src/x_autonumber.c:728
 #, fuzzy
 msgid "No '*' or '?' given at the end of the autonumber text."
 msgstr "No se ha especificado '*' o '?' al final del texto a autonumerar.\n"
 
-#: schematic/src/x_autonumber.c:873
 msgid "Diagonal"
 msgstr "Diagonal"
 
-#: schematic/src/x_autonumber.c:874
 msgid "Top to bottom"
 msgstr "De arriba hacia abajo"
 
-#: schematic/src/x_autonumber.c:875
 msgid "Bottom to top"
 msgstr "De abajo hacia arriba"
 
-#: schematic/src/x_autonumber.c:876
 msgid "Left to right"
 msgstr "De izquierda hacia derecha"
 
-#: schematic/src/x_autonumber.c:877
 msgid "Right to left"
 msgstr "De derecha hacia izquierda"
 
-#: schematic/src/x_autonumber.c:878
 msgid "File order"
 msgstr "Orden de archivos:"
 
-#: schematic/src/x_autonumber.c:1214
 msgid "Autonumber text"
 msgstr "Autoenumerar texto"
 
-#: schematic/src/x_autonumber.c:1237
 msgid "<b>Scope</b>"
 msgstr "<b>Ámbito</b>"
 
-#: schematic/src/x_autonumber.c:1259
 msgid "Search for:"
 msgstr "Buscar:"
 
-#: schematic/src/x_autonumber.c:1273
 msgid "Autonumber text in:"
 msgstr "Autoenumerar texto en:"
 
-#: schematic/src/x_autonumber.c:1280
 msgid "Skip numbers found in:"
 msgstr "Ignorar números encontrados en:"
 
-#: schematic/src/x_autonumber.c:1292 schematic/src/x_autonumber.c:1301
 msgid "Selected objects"
 msgstr "Objetos seleccionados"
 
-#: schematic/src/x_autonumber.c:1293 schematic/src/x_autonumber.c:1302
 msgid "Current page"
 msgstr "Hoja actual"
 
-#: schematic/src/x_autonumber.c:1294 schematic/src/x_autonumber.c:1303
 msgid "Whole hierarchy"
 msgstr "Jerarquía completa"
 
-#: schematic/src/x_autonumber.c:1305
 msgid "Overwrite existing numbers"
 msgstr "Sobreescribir los números existentes"
 
-#: schematic/src/x_autonumber.c:1310
 msgid "<b>Options</b>"
 msgstr "<b>Opciones</b>"
 
-#: schematic/src/x_autonumber.c:1332
 msgid "Starting number:"
 msgstr "Número inicial:"
 
-#: schematic/src/x_autonumber.c:1339
 msgid "Sort order:"
 msgstr "Método de ordenación:"
 
-#: schematic/src/x_autonumber.c:1371
 msgid "Remove numbers"
 msgstr "Borrar los números"
 
-#: schematic/src/x_autonumber.c:1375
 msgid "Automatic slotting"
 msgstr "Asignar números de elemento automáticamente"
 
-#: schematic/src/x_clipboard.c:245
 #, c-format
 msgid ""
 "<b>Invalid schematic on clipboard.</b>\n"
@@ -1629,175 +1282,135 @@ msgstr ""
 "\n"
 "Ocurrió un error al insertar el contenido del portapapeles: %s."
 
-#: schematic/src/x_clipboard.c:247
 msgid "Clipboard insertion failed"
 msgstr "Fallo al insertar el contenido del portapapeles"
 
-#: schematic/src/x_color.c:89 schematic/src/x_color.c:98
 #, fuzzy, c-format
 msgid "Could not allocate the color %1$s!\n"
 msgstr "¡No se puede reservar memoria para el color %s!\n"
 
-#: schematic/src/x_color.c:89
 msgid "black"
 msgstr "negro"
 
-#: schematic/src/x_color.c:98
 msgid "white"
 msgstr "blanco"
 
-#: schematic/src/x_color.c:120
 #, fuzzy, c-format
 msgid "Could not allocate display color %1$i!\n"
 msgstr "¡No se puede reservar memoria para el color %i!\n"
 
-#: schematic/src/x_color.c:142
 #, fuzzy, c-format
 msgid "Could not allocate outline color %1$i!\n"
 msgstr "¡No se puede reservar memoria para el color del contorno %i!\n"
 
-#: schematic/src/x_color.c:159
 #, fuzzy, c-format
 msgid "Tried to get an invalid color: %1$d\n"
 msgstr "Se ha intentado obtener un color no válido: %d\n"
 
-#: schematic/src/x_colorcb.c:145
 msgid "Background"
 msgstr "Fondo"
 
-#: schematic/src/x_colorcb.c:147
 msgid "Net endpoint"
 msgstr "Punto final de conexión"
 
-#: schematic/src/x_colorcb.c:148
 msgid "Graphic"
 msgstr "Gráfico"
 
-#: schematic/src/x_colorcb.c:151
 msgid "Logic bubble"
 msgstr "Negación lógica"
 
-#: schematic/src/x_colorcb.c:152
 msgid "Grid point"
 msgstr "Punto de rejilla"
 
-#: schematic/src/x_colorcb.c:153
 #, fuzzy
 msgid "Detached attribute"
 msgstr "Desvincular propiedad"
 
-#: schematic/src/x_colorcb.c:156
 msgid "Selection"
 msgstr "Selección"
 
-#: schematic/src/x_colorcb.c:157
 msgid "Bounding box"
 msgstr "Envolvente"
 
-#: schematic/src/x_colorcb.c:158
 msgid "Zoom box"
 msgstr "Ventana de ampliado"
 
-#: schematic/src/x_colorcb.c:161
 msgid "Output background"
 msgstr "Fondo de salida"
 
-#: schematic/src/x_colorcb.c:162
 msgid "Freestyle 1"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:163
 msgid "Freestyle 2"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:164
 msgid "Freestyle 3"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:165
 msgid "Freestyle 4"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:166
 msgid "Net junction"
 msgstr "Unión de conexiones"
 
-#: schematic/src/x_colorcb.c:167
 msgid "Mesh grid major"
 msgstr "Rejilla de malla mayor"
 
-#: schematic/src/x_colorcb.c:168
 msgid "Mesh grid minor"
 msgstr "Rejilla de malla menor"
 
-#: schematic/src/x_colorcb.c:172
 msgid "Unknown"
 msgstr "Desconocido"
 
-#: schematic/src/x_compselect.c:1169
 #, fuzzy
 msgid "Reset filter"
 msgstr "Nuevo archivo"
 
-#: schematic/src/x_compselect.c:1192
 msgid "Reload all libraries"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1245 schematic/src/x_multiattrib.c:2092
 msgid "Value"
 msgstr "Valor"
 
-#: schematic/src/x_compselect.c:1284
 msgid "Default behavior - reference component"
 msgstr "Comportamiento por defecto - designar componente"
 
-#: schematic/src/x_compselect.c:1287
 msgid "Embed component in schematic"
 msgstr "Incrustar componente en el esquema"
 
-#: schematic/src/x_compselect.c:1290
 msgid "Include component as individual objects"
 msgstr "Incluir componentes como objetos individuales"
 
-#: schematic/src/x_compselect.c:1448
 msgid "Select Component..."
 msgstr "Seleccionar componente..."
 
-#: schematic/src/x_compselect.c:1471
 #, fuzzy
 msgid "In Us_e"
 msgstr "En uso"
 
-#: schematic/src/x_compselect.c:1475
 #, fuzzy
 msgid "Lib_raries"
 msgstr "Librerías"
 
-#: schematic/src/x_compselect.c:1484 schematic/src/x_fileselect.c:119
 msgid "Preview"
 msgstr "Vista preliminar"
 
-#: schematic/src/x_compselect.c:1510
 msgid "Attributes"
 msgstr "Propiedades"
 
-#: schematic/src/x_dialog.c:325
 msgid "Major symbol changes detected."
 msgstr ""
 
-#: schematic/src/x_dialog.c:349
 msgid ""
 "Changes have occurred to the symbols shown below.\n"
 "\n"
 "Be sure to verify each of these symbols."
 msgstr ""
 
-#: schematic/src/x_dialog.c:369
 #, fuzzy
 msgid "Symbol"
 msgstr "Símbolos"
 
-#: schematic/src/x_dialog.c:406
 #, c-format
 msgid ""
 "<span weight=\"bold\" size=\"larger\">The input attribute \"%s\" is invalid\n"
@@ -1815,40 +1428,31 @@ msgstr ""
 "El nombre no puede finalizar en un espacio.\n"
 "El valor no puede empezar con un espacio."
 
-#: schematic/src/x_dialog.c:408
 msgid "Invalid Attribute"
 msgstr "Propiedad incorrecta"
 
-#: schematic/src/x_fileselect.c:37
 msgid "Schematics"
 msgstr "Esquemas"
 
-#: schematic/src/x_fileselect.c:42
 msgid "Symbols"
 msgstr "Símbolos"
 
-#: schematic/src/x_fileselect.c:47
 msgid "Schematics and symbols"
 msgstr "Esquemas y símbolos"
 
-#: schematic/src/x_fileselect.c:53
 msgid "All files"
 msgstr "Todos los archivos"
 
-#: schematic/src/x_fileselect.c:169
 msgid "Open..."
 msgstr "Abrir..."
 
-#: schematic/src/x_fileselect.c:233
 msgid "Save as..."
 msgstr "Guardar como..."
 
-#: schematic/src/x_fileselect.c:297
 #, fuzzy
 msgid "Save cancelled on user request"
 msgstr "El usuario ha cancelado la operación de guardar los cambios\n"
 
-#: schematic/src/x_fileselect.c:334
 msgid ""
 "\n"
 "If you load the original file, the backup file will be overwritten in the "
@@ -1857,28 +1461,22 @@ msgid ""
 "Do you want to load the backup file?\n"
 msgstr ""
 
-#: schematic/src/x_fstylecb.c:73
 msgid "Hollow"
 msgstr "Hueco"
 
-#: schematic/src/x_fstylecb.c:80
 msgid "Filled"
 msgstr "Relleno"
 
-#: schematic/src/x_fstylecb.c:87
 msgid "Mesh"
 msgstr "Malla"
 
-#: schematic/src/x_fstylecb.c:94
 msgid "Hatch"
 msgstr "Trama"
 
-#: schematic/src/x_image.c:279
 #, fuzzy, c-format
 msgid "x_image_lowlevel: Unable to write %1$s file %2$s."
 msgstr "x_image_lowlevel: Imposible escribir archivo %s: %s.\n"
 
-#: schematic/src/x_image.c:289
 #, fuzzy, c-format
 msgid ""
 "There was the following error when saving image with type %1$s to filename:\n"
@@ -1891,304 +1489,239 @@ msgstr ""
 "\n"
 "%s.\n"
 
-#: schematic/src/x_image.c:309
 #, fuzzy, c-format
 msgid "Wrote color image to [%1$s] [%2$d x %3$d]"
 msgstr "Se ha guardado la imagen en color en [%s] [%d x %d]\n"
 
-#: schematic/src/x_image.c:311
 #, fuzzy, c-format
 msgid "Wrote black and white image to [%1$s] [%2$d x %3$d]"
 msgstr "Se ha guardado la imagen en blanco y negro en [%s] [%d x %d]\n"
 
-#: schematic/src/x_image.c:319
 #, fuzzy
 msgid "x_image_lowlevel: Unable to get pixbuf from gschem's window."
 msgstr "x_image_lowlevel: Imposible obtener pixbuf de la ventana de gschem.\n"
 
-#: schematic/src/x_image.c:358
 msgid "Width x Height"
 msgstr "Anchura x Altura"
 
-#: schematic/src/x_image.c:374
 msgid "Image type"
 msgstr "Tipo de imagen"
 
-#: schematic/src/x_image.c:395
 msgid "Write image..."
 msgstr "Guardar imagen..."
 
-#: schematic/src/x_linecapcb.c:74
 msgid "Butt"
 msgstr ""
 
-#: schematic/src/x_linecapcb.c:81
 msgid "Square"
 msgstr ""
 
-#: schematic/src/x_linecapcb.c:88
 msgid "Round"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:74
 msgid "Solid"
 msgstr "Sólido"
 
-#: schematic/src/x_linetypecb.c:81
 msgid "Dotted"
 msgstr "Punteado"
 
-#: schematic/src/x_linetypecb.c:88
 msgid "Dashed"
 msgstr "Guión"
 
-#: schematic/src/x_linetypecb.c:95
 msgid "Center"
 msgstr "Centrar"
 
-#: schematic/src/x_linetypecb.c:102
 msgid "Phantom"
 msgstr "Fantasma"
 
-#: schematic/src/x_menus.c:41 schematic/scheme/gschem/builtins.scm:267
 #, fuzzy
 msgid "Add Net"
 msgstr "/Añadir conexión..."
 
-#: schematic/src/x_menus.c:42 schematic/src/x_multiattrib.c:2187
-#: schematic/scheme/gschem/builtins.scm:264
 msgid "Add Attribute"
 msgstr "Añadir propiedad"
 
-#: schematic/src/x_menus.c:43 schematic/scheme/gschem/builtins.scm:261
 #, fuzzy
 msgid "Add Component"
 msgstr "/Añadir componente..."
 
-#: schematic/src/x_menus.c:44 schematic/scheme/gschem/builtins.scm:270
 #, fuzzy
 msgid "Add Bus"
 msgstr "/Añadir bus"
 
-#: schematic/src/x_menus.c:45 schematic/scheme/gschem/builtins.scm:273
 #, fuzzy
 msgid "Add Text"
 msgstr "/Añadir texto"
 
-#: schematic/src/x_menus.c:47 schematic/scheme/gschem/builtins.scm:210
 #, fuzzy
 msgid "Zoom In"
 msgstr "/Aumentar ampliación"
 
-#: schematic/src/x_menus.c:48 schematic/scheme/gschem/builtins.scm:213
 #, fuzzy
 msgid "Zoom Out"
 msgstr "/Disminuir ampliación"
 
-#: schematic/src/x_menus.c:50 schematic/scheme/gschem/builtins.scm:207
 #, fuzzy
 msgid "Zoom Extents"
 msgstr "/Mostrar todo"
 
-#: schematic/src/x_menus.c:52 schematic/src/x_window.c:1233
 msgid "Select"
 msgstr "Seleccionar"
 
-#: schematic/src/x_menus.c:53 schematic/scheme/conf/schematic/menu.scm:69
-#: schematic/scheme/gschem/builtins.scm:126
 msgid "Edit..."
 msgstr "Editar..."
 
-#: schematic/src/x_menus.c:54 schematic/scheme/conf/schematic/menu.scm:68
 #, fuzzy
 msgid "Object Properties..."
 msgstr "<b>Propiedades del texto</b>"
 
-#: schematic/src/x_menus.c:59 schematic/scheme/gschem/builtins.scm:300
 #, fuzzy
 msgid "Down Schematic"
 msgstr "/Descender en esquema"
 
-#: schematic/src/x_menus.c:60 schematic/scheme/gschem/builtins.scm:303
 #, fuzzy
 msgid "Down Symbol"
 msgstr "/Descender en símbolo"
 
-#: schematic/src/x_menus.c:61
 #, fuzzy
 msgid "Up"
 msgstr "/Arriba"
 
-#: schematic/src/x_menus.c:336
 #, fuzzy, c-format
 msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
 msgstr ""
 "Se ha intentado modificar la sensibilidad de una opción de menú que no "
 "existe '%s'\n"
 
-#: schematic/src/x_menus.c:360
 #, c-format
 msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
 msgstr ""
 "Se ha intentado modificar la sensibilidad de una opción de menú que no "
 "existe '%s'\n"
 
-#: schematic/src/x_misc.c:70
 msgid "The operating system is out of memory or resources."
 msgstr "El sistema se encuentra sin memoria o recursos suficientes."
 
-#: schematic/src/x_multiattrib.c:798 schematic/src/x_multiattrib.c:2704
 msgid "<various>"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:930
 msgid "Attributes with empty name are not allowed. Please set a name."
 msgstr ""
 "No se permiten las propiedades sin nombre. Por favor, introduzca un nombre."
 
-#: schematic/src/x_multiattrib.c:1622
 msgid "Show Value only"
 msgstr "Mostrar sólo valor"
 
-#: schematic/src/x_multiattrib.c:1624
 msgid "Show Name only"
 msgstr "Mostrar sólo nombre"
 
-#: schematic/src/x_multiattrib.c:1651
 msgid "Promote"
 msgstr "Promocionar"
 
-#: schematic/src/x_multiattrib.c:1655
 msgid "Duplicate"
 msgstr "Duplicar"
 
-#: schematic/src/x_multiattrib.c:1657
 #, fuzzy
 msgid "Copy to all"
 msgstr "Copiar en memoria intermedia 1"
 
-#: schematic/src/x_multiattrib.c:1986 schematic/src/x_multiattrib.c:2602
 msgid "Edit Attributes"
 msgstr "Editar propiedades"
 
-#: schematic/src/x_multiattrib.c:2112
 msgid "Vis?"
 msgstr "Visible?"
 
-#: schematic/src/x_multiattrib.c:2130
 msgid "N"
 msgstr "N"
 
-#: schematic/src/x_multiattrib.c:2148
 msgid "V"
 msgstr "V"
 
-#: schematic/src/x_multiattrib.c:2170
 #, fuzzy
 msgid "Sho_w inherited attributes"
 msgstr "Mostrar propiedades heredadas"
 
-#: schematic/src/x_multiattrib.c:2197
 #, fuzzy
 msgid "_Name:"
 msgstr "Nombre:"
 
-#: schematic/src/x_multiattrib.c:2241
 msgid "Ctrl+Enter inserts new line; Ctrl+Tab inserts Tab"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2618
 #, c-format
 msgid "%2$i symbol (%1$s)"
 msgid_plural "%2$i symbols (%1$s)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2624
 #, fuzzy, c-format
 msgid "%1$i pin"
 msgid_plural "%1$i pins"
 msgstr[0] "Pin para conexión simple"
 msgstr[1] "Pin para conexión simple"
 
-#: schematic/src/x_multiattrib.c:2630
 #, c-format
 msgid "%1$i net"
 msgid_plural "%1$i nets"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2636
 #, c-format
 msgid "%1$i bus"
 msgid_plural "%1$i buses"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2642
 #, fuzzy, c-format
 msgid "%1$i attribute"
 msgid_plural "%1$i attributes"
 msgstr[0] "Propiedad"
 msgstr[1] "Propiedad"
 
-#: schematic/src/x_newtext.c:433
 msgid "Text Entry..."
 msgstr "Introducción de texto..."
 
-#: schematic/src/x_pagesel.c:253
 msgid "New Page"
 msgstr "Nueva página"
 
-#: schematic/src/x_pagesel.c:254
 msgid "Open Page..."
 msgstr "Abrir página"
 
-#: schematic/src/x_pagesel.c:256
 msgid "Save Page"
 msgstr "Guardar página"
 
-#: schematic/src/x_pagesel.c:257 schematic/scheme/gschem/builtins.scm:246
 msgid "Close Page"
 msgstr "Cerrar página"
 
-#: schematic/src/x_pagesel.c:376 schematic/scheme/gschem/builtins.scm:237
 msgid "Page Manager"
 msgstr "Administrador de páginas"
 
-#: schematic/src/x_pagesel.c:448
 msgid "Changed"
 msgstr "Modificado"
 
-#: schematic/src/x_pagesel.c:468
 msgid "Right click on the filename for more options..."
 msgstr "Pulse con el botón derecho para ver más opciones..."
 
-#: schematic/src/x_print.c:306
 #, fuzzy, c-format
 msgid "Failed to write PDF to '%s': %s\n"
 msgstr "Falló al reemplazar las imágenes: %s"
 
-#: schematic/src/x_print.c:364
 #, fuzzy, c-format
 msgid "Failed to write PDF to '%1$s': %2$s\n"
 msgstr "Falló al reemplazar las imágenes: %s"
 
-#: schematic/src/x_print.c:449
 #, c-format
 msgid ""
 "Error printing file:\n"
 "%1$s"
 msgstr ""
 
-#: schematic/src/x_rc.c:39
 #, fuzzy
 msgid "ERROR: An unknown error occurred while parsing configuration files."
 msgstr ""
 "ERROR: Ocurrió un error desconocido al interpretar los archivos de "
 "configuración.\n"
 
-#: schematic/src/x_rc.c:44
 #, fuzzy
 msgid ""
 "An unknown error occurred while parsing configuration files.\n"
@@ -2199,12 +1732,10 @@ msgstr ""
 "\n"
 "El log de gschem debería tener mas información."
 
-#: schematic/src/x_rc.c:56
 #, fuzzy, c-format
 msgid "ERROR: %1$s"
 msgstr "ERROR: %s\n"
 
-#: schematic/src/x_rc.c:59
 #, fuzzy, c-format
 msgid ""
 "%1$s\n"
@@ -2215,142 +1746,111 @@ msgstr ""
 "\n"
 "El log (registro) de gschem puede tener más información."
 
-#: schematic/src/x_rc.c:67
 #, fuzzy
 msgid "Cannot load lepton-schematic configuration."
 msgstr "No se puede cargar la configuración de gschem."
 
-#: schematic/src/x_script.c:42 schematic/scheme/conf/schematic/menu.scm:40
 msgid "Execute Script..."
 msgstr "Ejecutar subprograma..."
 
-#: schematic/src/x_script.c:61
 #, fuzzy, c-format
 msgid "Executing guile script [%1$s]"
 msgstr "Ejecutando programa de guile [%s]\n"
 
-#: schematic/src/x_tabs.c:860
 #, fuzzy, c-format
 msgid "Hierarchy up: %s"
 msgstr "Je_rarquía"
 
-#: schematic/src/x_tabs.c:863
 #, fuzzy
 msgid "Hierarchy up"
 msgstr "Je_rarquía"
 
-#: schematic/src/x_widgets.c:158 schematic/src/x_window.c:1444
 #, fuzzy
 msgid "Options"
 msgstr "_Opciones"
 
-#: schematic/src/x_widgets.c:203 schematic/src/x_window.c:1436
 #, fuzzy
 msgid "Object"
 msgstr "Color del componente:"
 
-#: schematic/src/x_widgets.c:224
 msgid "Log"
 msgstr ""
 
-#: schematic/src/x_widgets.c:245 schematic/src/x_window.c:1466
 msgid "Find Text"
 msgstr "Encontrar texto:"
 
-#: schematic/src/x_widgets.c:259
 #, fuzzy
 msgid "Color Scheme Editor"
 msgstr "Configuración de co_lores claros"
 
-#: schematic/src/x_widgets.c:272 schematic/scheme/gschem/builtins.scm:378
 #, fuzzy
 msgid "Select Schematic Font"
 msgstr "S_eleccione los esquemas que quiere guardar:"
 
-#: schematic/src/x_window.c:763
 #, fuzzy, c-format
 msgid "Loading schematic [%1$s]"
 msgstr "Cargando esquema [%s]\n"
 
-#: schematic/src/x_window.c:864
 #, fuzzy, c-format
 msgid "Could NOT save page [%1$s]\n"
 msgstr "NO se ha podido guardar la página [%s]\n"
 
-#: schematic/src/x_window.c:865
 msgid "Error while trying to save"
 msgstr "Error al intentar guardar"
 
-#: schematic/src/x_window.c:875
 msgid "Failed to save file"
 msgstr "Error al guardar archivo"
 
-#: schematic/src/x_window.c:885
 #, fuzzy, c-format
 msgid "Saved as [%1$s]"
 msgstr "Guardado como [%s]\n"
 
-#: schematic/src/x_window.c:887
 #, fuzzy, c-format
 msgid "Saved [%1$s]"
 msgstr "Guardado [%s]\n"
 
-#: schematic/src/x_window.c:889
 msgid "Saved"
 msgstr "Guardado"
 
-#: schematic/src/x_window.c:966
 #, fuzzy, c-format
 msgid "Discarding page [%1$s]"
 msgstr "Descartando página [%s]\n"
 
-#: schematic/src/x_window.c:966
 #, fuzzy, c-format
 msgid "Closing [%1$s]"
 msgstr "Cerrando [%s]\n"
 
-#: schematic/src/x_window.c:1175
 msgid "New"
 msgstr "Nuevo"
 
-#: schematic/src/x_window.c:1175
 msgid "New file"
 msgstr "Nuevo archivo"
 
-#: schematic/src/x_window.c:1179
 msgid "Open"
 msgstr "Abrir"
 
-#: schematic/src/x_window.c:1179
 #, fuzzy
 msgid "Open file"
 msgstr "Abrir archivo"
 
-#: schematic/src/x_window.c:1183 schematic/scheme/gschem/builtins.scm:59
 msgid "Save"
 msgstr "Guardar"
 
-#: schematic/src/x_window.c:1183
 msgid "Save file"
 msgstr "Guardar archivo"
 
-#: schematic/src/x_window.c:1189 schematic/scheme/gschem/builtins.scm:93
 msgid "Undo"
 msgstr "Deshacer"
 
-#: schematic/src/x_window.c:1189
 msgid "Undo last operation"
 msgstr "Deshacer última operación"
 
-#: schematic/src/x_window.c:1193 schematic/scheme/gschem/builtins.scm:96
 msgid "Redo"
 msgstr "Rehacer"
 
-#: schematic/src/x_window.c:1193
 msgid "Redo last undo"
 msgstr "Rehacer el último deshacer"
 
-#: schematic/src/x_window.c:1198
 msgid ""
 "Add component...\n"
 "Select library and component from list, move the mouse into main window, "
@@ -2362,7 +1862,6 @@ msgstr ""
 "ventana principal, y presione el botón izq. del ratón para colocarlo.\n"
 "Botón derecho del ratón para cancelar"
 
-#: schematic/src/x_window.c:1209
 msgid ""
 "Add nets mode\n"
 "Right mouse button to cancel"
@@ -2370,7 +1869,6 @@ msgstr ""
 "Añadir conexión\n"
 "Botón derecho del ratón para cancelar"
 
-#: schematic/src/x_window.c:1217
 msgid ""
 "Add buses mode\n"
 "Right mouse button to cancel"
@@ -2378,45 +1876,35 @@ msgstr ""
 "Añadir bus\n"
 "Botón derecho del ratón para cancelar"
 
-#: schematic/src/x_window.c:1226
 msgid "Add Text..."
 msgstr "Añadir texto..."
 
-#: schematic/src/x_window.c:1233
 msgid "Select mode"
 msgstr "Seleccionar"
 
-#: schematic/src/x_window.c:1288
 #, fuzzy
 msgid "Show"
 msgstr "Mostrar nombre"
 
-#: schematic/src/x_window.c:1289
 msgid "Show text starting with:"
 msgstr "Mostrar texto que comienza por:"
 
-#: schematic/src/x_window.c:1345
 msgid "Menu/Cancel"
 msgstr "Menú/Cancelar"
 
-#: schematic/src/x_window.c:1349
 msgid "Pan/Cancel"
 msgstr "Panorámica/Cancelar"
 
-#: schematic/src/x_window.c:1359
 msgid "Pick"
 msgstr "Coger"
 
-#: schematic/src/x_window.c:1470 schematic/scheme/gschem/builtins.scm:180
 msgid "Status"
 msgstr "Estado"
 
-#: schematic/src/x_window.c:1568
 #, fuzzy, c-format
 msgid "New file [%s]"
 msgstr "Nuevo archivo [%s]\n"
 
-#: schematic/src/x_window.c:1598
 #, fuzzy, c-format
 msgid ""
 "<b>An error occurred while loading the requested file.</b>\n"
@@ -2434,902 +1922,692 @@ msgstr ""
 "\n"
 "Cargar desde '%s' falló: %s. El log de gschem puede tener mas información."
 
-#: schematic/src/x_window.c:1617
 msgid "Failed to load file"
 msgstr "Fallo al cargar el archivo"
 
-#: schematic/data/lepton-schematic.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Schematic Editor"
 msgstr "Editor de esquemas gEDA"
 
-#: schematic/data/lepton-schematic.desktop.in:4
 #, fuzzy
 msgid "Create and edit electrical schematics and symbols with lepton-schematic"
 msgstr "Crear y modificar esquemas y símbolos con gschem"
 
-#: schematic/scheme/conf/schematic/menu.scm:27
 msgid "_New"
 msgstr "_Nuevo"
 
-#: schematic/scheme/conf/schematic/menu.scm:28
 msgid "_Open..."
 msgstr "_Abrir..."
 
-#: schematic/scheme/conf/schematic/menu.scm:30
 msgid "Open Recen_t"
 msgstr "Abrir recien_te"
 
-#: schematic/scheme/conf/schematic/menu.scm:32
 msgid "_Save"
 msgstr "_Guardar"
 
-#: schematic/scheme/conf/schematic/menu.scm:33
 msgid "Save _As..."
 msgstr "Guardar _como..."
 
-#: schematic/scheme/conf/schematic/menu.scm:34
-#: schematic/scheme/gschem/builtins.scm:65
 msgid "Save All"
 msgstr "Guardar todo"
 
-#: schematic/scheme/conf/schematic/menu.scm:36
 msgid "_Print..."
 msgstr "Im_primir..."
 
-#: schematic/scheme/conf/schematic/menu.scm:37
 #, fuzzy
 msgid "Write _Image..."
 msgstr "Guardar _imagen..."
 
-#: schematic/scheme/conf/schematic/menu.scm:39
 #, fuzzy
 msgid "Invoke Macro..."
 msgstr "Ejecutar macro"
 
-#: schematic/scheme/conf/schematic/menu.scm:41
 msgid "REPL..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:43
-#: schematic/scheme/gschem/builtins.scm:77
 msgid "New Window"
 msgstr "Nueva ventana"
 
-#: schematic/scheme/conf/schematic/menu.scm:44
 msgid "_Close Window"
 msgstr "_Cerrar ventana"
 
-#: schematic/scheme/conf/schematic/menu.scm:45
 msgid "_Quit"
 msgstr "_Salir"
 
-#: schematic/scheme/conf/schematic/menu.scm:51
 msgid "_Undo"
 msgstr "_Deshacer"
 
-#: schematic/scheme/conf/schematic/menu.scm:52
 msgid "_Redo"
 msgstr "_Rehacer"
 
-#: schematic/scheme/conf/schematic/menu.scm:54
 msgid "Cu_t"
 msgstr "Cor_tar"
 
-#: schematic/scheme/conf/schematic/menu.scm:55
 msgid "_Copy"
 msgstr "_Copiar"
 
-#: schematic/scheme/conf/schematic/menu.scm:56
 msgid "_Paste"
 msgstr "_Pegar"
 
-#: schematic/scheme/conf/schematic/menu.scm:57
 msgid "_Delete"
 msgstr "_Borrar"
 
-#: schematic/scheme/conf/schematic/menu.scm:60
-#: schematic/scheme/gschem/builtins.scm:102
 msgid "Select All"
 msgstr "Seleccionar todo"
 
-#: schematic/scheme/conf/schematic/menu.scm:61
-#: schematic/scheme/gschem/builtins.scm:105
 msgid "Deselect"
 msgstr "Deseleccionar"
 
-#: schematic/scheme/conf/schematic/menu.scm:65
 msgid "Rotate 90 Mode"
 msgstr "Rotar 90º"
 
-#: schematic/scheme/conf/schematic/menu.scm:70
 msgid "Edit Text..."
 msgstr "Editar texto..."
 
-#: schematic/scheme/conf/schematic/menu.scm:71
 msgid "Slot..."
 msgstr "Elemento..."
 
-#: schematic/scheme/conf/schematic/menu.scm:76
-#: schematic/scheme/gschem/builtins.scm:150
 msgid "Embed Component/Picture"
 msgstr "Incrustar componente/imagen"
 
-#: schematic/scheme/conf/schematic/menu.scm:77
-#: schematic/scheme/gschem/builtins.scm:153
 msgid "Unembed Component/Picture"
 msgstr "Desincrustar componente/imagen"
 
-#: schematic/scheme/conf/schematic/menu.scm:78
-#: schematic/scheme/gschem/builtins.scm:156
 msgid "Update Component"
 msgstr "Actualizar componente"
 
-#: schematic/scheme/conf/schematic/menu.scm:79
 msgid "Symbol Translate..."
 msgstr "Mover símbolo..."
 
-#: schematic/scheme/conf/schematic/menu.scm:85
 msgid "Copy into 1"
 msgstr "Copiar en memoria intermedia 1"
 
-#: schematic/scheme/conf/schematic/menu.scm:86
 msgid "Copy into 2"
 msgstr "Copiar en memoria intermedia 2"
 
-#: schematic/scheme/conf/schematic/menu.scm:87
 msgid "Copy into 3"
 msgstr "Copiar en memoria intermedia 3"
 
-#: schematic/scheme/conf/schematic/menu.scm:88
 msgid "Copy into 4"
 msgstr "Copiar en memoria intermedia 4"
 
-#: schematic/scheme/conf/schematic/menu.scm:89
 msgid "Copy into 5"
 msgstr "Copiar en memoria intermedia 5"
 
-#: schematic/scheme/conf/schematic/menu.scm:90
 msgid "Cut into 1"
 msgstr "Cortar en memoria intermedia 1"
 
-#: schematic/scheme/conf/schematic/menu.scm:91
 msgid "Cut into 2"
 msgstr "Cortar en memoria intermedia 2"
 
-#: schematic/scheme/conf/schematic/menu.scm:92
 msgid "Cut into 3"
 msgstr "Cortar en memoria intermedia 3"
 
-#: schematic/scheme/conf/schematic/menu.scm:93
 msgid "Cut into 4"
 msgstr "Cortar en memoria intermedia 4"
 
-#: schematic/scheme/conf/schematic/menu.scm:94
 msgid "Cut into 5"
 msgstr "Cortar en memoria intermedia 5"
 
-#: schematic/scheme/conf/schematic/menu.scm:95
 msgid "Paste from 1"
 msgstr "Pegar memoria intermedia 1"
 
-#: schematic/scheme/conf/schematic/menu.scm:96
 msgid "Paste from 2"
 msgstr "Pegar memoria intermedia 2"
 
-#: schematic/scheme/conf/schematic/menu.scm:97
 msgid "Paste from 3"
 msgstr "Pegar memoria intermedia 3"
 
-#: schematic/scheme/conf/schematic/menu.scm:98
 msgid "Paste from 4"
 msgstr "Pegar memoria intermedia 4"
 
-#: schematic/scheme/conf/schematic/menu.scm:99
 msgid "Paste from 5"
 msgstr "Pegar memoria intermedia 5"
 
-#: schematic/scheme/conf/schematic/menu.scm:105
 msgid "Side Dock"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:106
 #, fuzzy
 msgid "Bottom Dock"
 msgstr "De abajo hacia arriba"
 
-#: schematic/scheme/conf/schematic/menu.scm:108
 #, fuzzy
 msgid "Find Text Results"
 msgstr "Encontrar texto:"
 
-#: schematic/scheme/conf/schematic/menu.scm:110
 msgid "_Redraw"
 msgstr "_Redibujar"
 
-#: schematic/scheme/conf/schematic/menu.scm:111
 msgid "_Pan"
 msgstr "Centrar res_pecto al cursor"
 
-#: schematic/scheme/conf/schematic/menu.scm:112
 msgid "Zoom _Box"
 msgstr "Ampliar z_ona"
 
-#: schematic/scheme/conf/schematic/menu.scm:113
 msgid "Zoom _Extents"
 msgstr "Mostrar _todo"
 
-#: schematic/scheme/conf/schematic/menu.scm:114
 msgid "Zoom _In"
 msgstr "_Aumentar ampliación"
 
-#: schematic/scheme/conf/schematic/menu.scm:115
 msgid "Zoom _Out"
 msgstr "_Disminuir ampliación"
 
-#: schematic/scheme/conf/schematic/menu.scm:116
 msgid "Zoom _Full"
 msgstr "Vista co_mpleta"
 
-#: schematic/scheme/conf/schematic/menu.scm:118
 #, fuzzy
 msgid "_Dark Color Scheme"
 msgstr "Configuración de colores os_curos"
 
-#: schematic/scheme/conf/schematic/menu.scm:119
 #, fuzzy
 msgid "_Light Color Scheme"
 msgstr "Configuración de co_lores claros"
 
-#: schematic/scheme/conf/schematic/menu.scm:120
 #, fuzzy
 msgid "B_W Color Scheme"
 msgstr "Esquema de colores en blanco y negro."
 
-#: schematic/scheme/conf/schematic/menu.scm:122
 #, fuzzy
 msgid "Color Scheme Editor..."
 msgstr "Configuración de co_lores claros"
 
-#: schematic/scheme/conf/schematic/menu.scm:129
 msgid "_Manager..."
 msgstr "Ad_ministrador..."
 
-#: schematic/scheme/conf/schematic/menu.scm:131
 msgid "_Previous"
 msgstr "_Anterior"
 
-#: schematic/scheme/conf/schematic/menu.scm:132
 msgid "_Next"
 msgstr "_Siguiente"
 
-#: schematic/scheme/conf/schematic/menu.scm:133
 msgid "_Close"
 msgstr "C_errar"
 
-#: schematic/scheme/conf/schematic/menu.scm:135
 #, fuzzy
 msgid "_Revert..."
 msgstr "_Recargar"
 
-#: schematic/scheme/conf/schematic/menu.scm:137
-#: schematic/scheme/gschem/builtins.scm:249
 #, fuzzy
 msgid "Next Tab"
 msgstr "Nueva página"
 
-#: schematic/scheme/conf/schematic/menu.scm:138
-#: schematic/scheme/gschem/builtins.scm:252
 #, fuzzy
 msgid "Previous Tab"
 msgstr "_Anterior"
 
-#: schematic/scheme/conf/schematic/menu.scm:146
 msgid "_Component..."
 msgstr "_Componente..."
 
-#: schematic/scheme/conf/schematic/menu.scm:148
 msgid "_Net"
 msgstr "Co_nexión"
 
-#: schematic/scheme/conf/schematic/menu.scm:149
 msgid "B_us"
 msgstr "B_us"
 
-#: schematic/scheme/conf/schematic/menu.scm:151
 msgid "_Attribute..."
 msgstr "Propied_ad..."
 
-#: schematic/scheme/conf/schematic/menu.scm:152
 msgid "_Text..."
 msgstr "_Texto..."
 
-#: schematic/scheme/conf/schematic/menu.scm:154
 msgid "_Line"
 msgstr "_Línea"
 
-#: schematic/scheme/conf/schematic/menu.scm:155
 msgid "Pat_h"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:156
 msgid "_Box"
 msgstr "Rectán_gulo"
 
-#: schematic/scheme/conf/schematic/menu.scm:157
 msgid "C_ircle"
 msgstr "Círcul_o"
 
-#: schematic/scheme/conf/schematic/menu.scm:158
 msgid "A_rc"
 msgstr "A_rco"
 
-#: schematic/scheme/conf/schematic/menu.scm:159
 msgid "_Pin"
 msgstr "_Pin"
 
-#: schematic/scheme/conf/schematic/menu.scm:161
 msgid "Pictu_re..."
 msgstr "I_magen..."
 
-#: schematic/scheme/conf/schematic/menu.scm:167
 msgid "_Up"
 msgstr "A_rriba"
 
-#: schematic/scheme/conf/schematic/menu.scm:169
 msgid "_Down Schematic"
 msgstr "_Descender en esquema"
 
-#: schematic/scheme/conf/schematic/menu.scm:170
 msgid "Down _Symbol"
 msgstr "Descender en _símbolo"
 
-#: schematic/scheme/conf/schematic/menu.scm:176
 msgid "_Attach"
 msgstr "_Adjuntar"
 
-#: schematic/scheme/conf/schematic/menu.scm:177
 msgid "_Detach"
 msgstr "No a_djuntar"
 
-#: schematic/scheme/conf/schematic/menu.scm:179
 msgid "Show _Value"
 msgstr "Mostrar _valor"
 
-#: schematic/scheme/conf/schematic/menu.scm:180
 msgid "Show _Name"
 msgstr "Mostrar _nombre"
 
-#: schematic/scheme/conf/schematic/menu.scm:181
 msgid "Show _Both"
 msgstr "Mostrar am_bos"
 
-#: schematic/scheme/conf/schematic/menu.scm:182
 msgid "_Toggle Visibility"
 msgstr "Cambiar v_isibilidad"
 
-#: schematic/scheme/conf/schematic/menu.scm:184
 msgid "_Hide Specific Text..."
 msgstr "_Ocultar texto específico..."
 
-#: schematic/scheme/conf/schematic/menu.scm:185
 msgid "_Show Specific Text..."
 msgstr "Mo_strar texto específico..."
 
-#: schematic/scheme/conf/schematic/menu.scm:186
 #, fuzzy
 msgid "Show/Hide Hidden Text"
 msgstr "Mostrar/Ocultar texto oculto"
 
-#: schematic/scheme/conf/schematic/menu.scm:188
 msgid "_Find Text/Check Symbol..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:189
 msgid "A_utonumber Text..."
 msgstr "A_utonumerar texto..."
 
-#: schematic/scheme/conf/schematic/menu.scm:195
 #, fuzzy
 msgid "_Options..."
 msgstr "_Opciones"
 
-#: schematic/scheme/conf/schematic/menu.scm:196
 #, fuzzy
 msgid "_Font..."
 msgstr "Im_primir..."
 
-#: schematic/scheme/conf/schematic/menu.scm:198
 #, fuzzy
 msgid "Grid +"
 msgstr "Rejilla DESACTIVADA\n"
 
-#: schematic/scheme/conf/schematic/menu.scm:199
 #, fuzzy
 msgid "Grid -"
 msgstr "Rejilla DESACTIVADA\n"
 
-#: schematic/scheme/conf/schematic/menu.scm:201
 msgid "Grid Style: Cycle Dots/Mesh/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:202
 msgid "Grid Snap: Cycle Grid/Resnap/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:204
 #, fuzzy
 msgid "Feedback Mode: Outline/Box"
 msgstr "Cambiar Silueta/Rectángul_o"
 
-#: schematic/scheme/conf/schematic/menu.scm:205
 #, fuzzy
 msgid "Net: Rubberband On/Off"
 msgstr "Goma de borrar ACT\n"
 
-#: schematic/scheme/conf/schematic/menu.scm:206
 msgid "Net: Magnetic On/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:208
 #, fuzzy
 msgid "_Coord Window"
 msgstr "_Cerrar ventana"
 
-#: schematic/scheme/conf/schematic/menu.scm:209
 #, fuzzy
 msgid "_Log Window"
 msgstr "Mostrar ventana de re_gistro..."
 
-#: schematic/scheme/conf/schematic/menu.scm:215
 msgid "_1 allegro"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:223
 #, fuzzy
 msgid "User _Guide"
 msgstr "PU_F de gschem"
 
-#: schematic/scheme/conf/schematic/menu.scm:224
 msgid "_FAQ"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:225
 #, fuzzy
 msgid "Docu_mentation"
 msgstr "D_ocumentación"
 
-#: schematic/scheme/conf/schematic/menu.scm:226
 msgid "_Wiki"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:228
 #, fuzzy
 msgid "Find Component D_ocumentation"
 msgstr "D_ocumentación del componente..."
 
-#: schematic/scheme/conf/schematic/menu.scm:230
 msgid "_Hotkeys..."
 msgstr "_Teclas rápidas"
 
-#: schematic/scheme/conf/schematic/menu.scm:231
 #, fuzzy
 msgid "_About"
 msgstr "_Acerca de..."
 
-#: schematic/scheme/conf/schematic/menu.scm:237
 msgid "_File"
 msgstr "_Archivo"
 
-#: schematic/scheme/conf/schematic/menu.scm:238
 msgid "_Edit"
 msgstr "_Editar"
 
-#: schematic/scheme/conf/schematic/menu.scm:240
 msgid "_View"
 msgstr "_Ver"
 
-#: schematic/scheme/conf/schematic/menu.scm:241
 msgid "_Page"
 msgstr "_Página"
 
-#: schematic/scheme/conf/schematic/menu.scm:242
 msgid "_Add"
 msgstr "Aña_dir"
 
-#: schematic/scheme/conf/schematic/menu.scm:243
 msgid "Hie_rarchy"
 msgstr "Je_rarquía"
 
-#: schematic/scheme/conf/schematic/menu.scm:244
 msgid "A_ttributes"
 msgstr "Prop_iedades"
 
-#: schematic/scheme/conf/schematic/menu.scm:245
 msgid "_Options"
 msgstr "_Opciones"
 
-#: schematic/scheme/conf/schematic/menu.scm:246
 #, fuzzy
 msgid "_Netlist"
 msgstr "Co_nexión"
 
-#: schematic/scheme/conf/schematic/menu.scm:247
 msgid "_Help"
 msgstr "Ay_uda"
 
-#: schematic/scheme/gschem/action.scm:43
 #, fuzzy, scheme-format
 msgid "~S is not a valid gschem action."
 msgstr "~S no es una combinación de teclas válida."
 
-#: schematic/scheme/gschem/action.scm:158
 msgid "Repeat Last Action"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:47
 #, fuzzy
 msgid "Cancel"
 msgstr "Panorámica/Cancelar"
 
-#: schematic/scheme/gschem/builtins.scm:53
 #, fuzzy
 msgid "New File"
 msgstr "Nuevo archivo"
 
-#: schematic/scheme/gschem/builtins.scm:56
 #, fuzzy
 msgid "Open File"
 msgstr "Abrir archivo"
 
-#: schematic/scheme/gschem/builtins.scm:62
 #, fuzzy
 msgid "Save As"
 msgstr "Guardar todo"
 
-#: schematic/scheme/gschem/builtins.scm:68
 #, fuzzy
 msgid "Print"
 msgstr "Imprimir..."
 
-#: schematic/scheme/gschem/builtins.scm:71
 msgid "Export Image"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:74
 msgid "Run Script"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:80
 #, fuzzy
 msgid "Close Window"
 msgstr "_Cerrar ventana"
 
-#: schematic/scheme/gschem/builtins.scm:83
 #, fuzzy
 msgid "Quit"
 msgstr "_Salir"
 
-#: schematic/scheme/gschem/builtins.scm:87
 msgid "Terminal REPL"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:132
 msgid "Choose Slot"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:135
 #, fuzzy
 msgid "Edit Object Properties"
 msgstr "Editar las propiedades del texto"
 
-#: schematic/scheme/gschem/builtins.scm:138
 #, fuzzy
 msgid "Translate Symbol"
 msgstr "Mover"
 
-#: schematic/scheme/gschem/builtins.scm:147
 msgid "Invoke Macro"
 msgstr "Ejecutar macro"
 
-#: schematic/scheme/gschem/builtins.scm:159
 #, fuzzy
 msgid "Show/Hide Invisible Text"
 msgstr "Mostrar/Ocultar texto oculto"
 
-#: schematic/scheme/gschem/builtins.scm:165
 #, fuzzy
 msgid "Cut"
 msgstr "Cor_tar"
 
-#: schematic/scheme/gschem/builtins.scm:171
 #, fuzzy
 msgid "Paste"
 msgstr "_Pegar"
 
-#: schematic/scheme/gschem/builtins.scm:177
 msgid "Sidebar"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:183
 #, fuzzy
 msgid "Find Text State"
 msgstr "Encontrar texto:"
 
-#: schematic/scheme/gschem/builtins.scm:186
 #, fuzzy
 msgid "Redraw"
 msgstr "_Redibujar"
 
-#: schematic/scheme/gschem/builtins.scm:192
 #, fuzzy
 msgid "Pan Left"
 msgstr "Modo Centrar"
 
-#: schematic/scheme/gschem/builtins.scm:195
 #, fuzzy
 msgid "Pan Right"
 msgstr "Arriba a la derecha"
 
-#: schematic/scheme/gschem/builtins.scm:198
 msgid "Pan Up"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:201
 #, fuzzy
 msgid "Pan Down"
 msgstr "Modo Centrar"
 
-#: schematic/scheme/gschem/builtins.scm:216
 #, fuzzy
 msgid "Zoom Full"
 msgstr "Vista co_mpleta"
 
-#: schematic/scheme/gschem/builtins.scm:219
 #, fuzzy
 msgid "Dark Color Scheme"
 msgstr "Configuración de colores os_curos"
 
-#: schematic/scheme/gschem/builtins.scm:222
 #, fuzzy
 msgid "Light Color Scheme"
 msgstr "Configuración de co_lores claros"
 
-#: schematic/scheme/gschem/builtins.scm:225
 msgid "Monochrome Color Scheme"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:228
 #, fuzzy
 msgid "Show Color Scheme Editor"
 msgstr "Configuración de co_lores claros"
 
-#: schematic/scheme/gschem/builtins.scm:234
 #, fuzzy
 msgid "Revert Changes"
 msgstr "¿Seguro que quiere recargar la página?"
 
-#: schematic/scheme/gschem/builtins.scm:240
 #, fuzzy
 msgid "Previous Page"
 msgstr "_Anterior"
 
-#: schematic/scheme/gschem/builtins.scm:243
 #, fuzzy
 msgid "Next Page"
 msgstr "Nueva página"
 
-#: schematic/scheme/gschem/builtins.scm:255
 #, fuzzy
 msgid "Print Page"
 msgstr "_Anterior"
 
-#: schematic/scheme/gschem/builtins.scm:276
 #, fuzzy
 msgid "Add Line"
 msgstr "Línea"
 
-#: schematic/scheme/gschem/builtins.scm:279
 #, fuzzy
 msgid "Add Path"
 msgstr "/Añadir conexión..."
 
-#: schematic/scheme/gschem/builtins.scm:282
 #, fuzzy
 msgid "Add Box"
 msgstr "/Añadir bus"
 
-#: schematic/scheme/gschem/builtins.scm:285
 #, fuzzy
 msgid "Add Circle"
 msgstr "Círculo"
 
-#: schematic/scheme/gschem/builtins.scm:288
 #, fuzzy
 msgid "Add Arc"
 msgstr "Añadir propiedad"
 
-#: schematic/scheme/gschem/builtins.scm:291
 msgid "Add Pin"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:294
 #, fuzzy
 msgid "Add Picture"
 msgstr "Imagen"
 
-#: schematic/scheme/gschem/builtins.scm:306
 #, fuzzy
 msgid "Up Hierarchy"
 msgstr "Je_rarquía"
 
-#: schematic/scheme/gschem/builtins.scm:312
 #, fuzzy
 msgid "Attach Attributes"
 msgstr "Editar propiedades"
 
-#: schematic/scheme/gschem/builtins.scm:315
 #, fuzzy
 msgid "Detach Attributes"
 msgstr "Desvincular propiedad"
 
-#: schematic/scheme/gschem/builtins.scm:318
 #, fuzzy
 msgid "Show Attribute Value"
 msgstr "El atributo del elemento está mal especificado\n"
 
-#: schematic/scheme/gschem/builtins.scm:321
 #, fuzzy
 msgid "Show Attribute Name"
 msgstr "El atributo del elemento está mal especificado\n"
 
-#: schematic/scheme/gschem/builtins.scm:327
 #, fuzzy
 msgid "Toggle Text Visibility"
 msgstr "Cambiar v_isibilidad"
 
-#: schematic/scheme/gschem/builtins.scm:330
 #, fuzzy
 msgid "Find Specific Text"
 msgstr "_Encontrar texto específico..."
 
-#: schematic/scheme/gschem/builtins.scm:333
 #, fuzzy
 msgid "Hide Specific Text"
 msgstr "_Ocultar texto específico..."
 
-#: schematic/scheme/gschem/builtins.scm:336
 #, fuzzy
 msgid "Show Specific Text"
 msgstr "Mo_strar texto específico..."
 
-#: schematic/scheme/gschem/builtins.scm:339
 #, fuzzy
 msgid "Autonumber Text"
 msgstr "Autoenumerar texto"
 
-#: schematic/scheme/gschem/builtins.scm:345
 #, fuzzy
 msgid "Show Hotkeys"
 msgstr "Teclas rápidas"
 
-#: schematic/scheme/gschem/builtins.scm:348
 msgid "Switch Grid Style"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:351
 msgid "Switch Snap Mode"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:354
 #, fuzzy
 msgid "Set Grid Spacing"
 msgstr "A_umentar espaciado de la rejilla..."
 
-#: schematic/scheme/gschem/builtins.scm:357
 #, fuzzy
 msgid "Increase Grid Spacing"
 msgstr "A_umentar espaciado de la rejilla..."
 
-#: schematic/scheme/gschem/builtins.scm:360
 #, fuzzy
 msgid "Decrease Grid Spacing"
 msgstr "A_umentar espaciado de la rejilla..."
 
-#: schematic/scheme/gschem/builtins.scm:363
 #, fuzzy
 msgid "Toggle Outline Drawing"
 msgstr "Cambiar Silueta/Rectángul_o"
 
-#: schematic/scheme/gschem/builtins.scm:366
 #, fuzzy
 msgid "Toggle Net Rubber Band"
 msgstr "Act/Desact conserva_r conexiones"
 
-#: schematic/scheme/gschem/builtins.scm:369
 #, fuzzy
 msgid "Toggle Magnetic Nets"
 msgstr "Modo ayuda _magnética a la conexión"
 
-#: schematic/scheme/gschem/builtins.scm:372
 #, fuzzy
 msgid "Show Log Window"
 msgstr "Mostrar ventana de re_gistro..."
 
-#: schematic/scheme/gschem/builtins.scm:375
 #, fuzzy
 msgid "Show Coordinate Window"
 msgstr "Mostrar ventana de _coordenadas..."
 
-#: schematic/scheme/gschem/builtins.scm:385
 #, fuzzy
 msgid "Component Documentation"
 msgstr "D_ocumentación del componente..."
 
-#: schematic/scheme/gschem/builtins.scm:387
 msgid "View documentation for selected component"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:403
 msgid ""
 "Could not show documentation for selected component:\n"
 "\n"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:408
 msgid "gEDA Manuals"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:409
 msgid "View the front page of the gEDA documentation in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:414
 #, fuzzy
 msgid "gschem User Guide"
 msgstr "PU_F de gschem"
 
-#: schematic/scheme/gschem/builtins.scm:415
 msgid "View the gschem User Guide in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:420
 #, fuzzy
 msgid "gschem FAQ"
 msgstr "PU_F de gschem"
 
-#: schematic/scheme/gschem/builtins.scm:421
 msgid "Frequently Asked Questions about using gschem."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:426
 #, fuzzy
 msgid "gEDA wiki"
 msgstr "_Wiki de gEDA..."
 
-#: schematic/scheme/gschem/builtins.scm:427
 msgid "View the front page of the gEDA wiki in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:431
 msgid "About gschem"
 msgstr "Acerca de gschem"
 
-#: schematic/scheme/gschem/deprecated.scm:102
 #, scheme-format
 msgid "Invalid text alignment ~A."
 msgstr "Alineación de texto inválida ~A"
 
-#: schematic/scheme/gschem/gschemdoc.scm:241
 msgid "No documentation found"
 msgstr "No se encontró la documentación"
 
-#: schematic/scheme/gschem/keymap.scm:40
 #, scheme-format
 msgid "~S is not a valid key combination."
 msgstr "~S no es una combinación de teclas válida."
 
-#: schematic/scheme/gschem/keymap.scm:157
 #, scheme-format
 msgid "~S is not a prefix key sequence."
 msgstr "~S no es una secuencia de teclas válida como prefijo."

--- a/schematic/po/fa.po
+++ b/schematic/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-15 15:13+0300\n"
+"POT-Creation-Date: 2019-02-22 14:08+0300\n"
 "PO-Revision-Date: 2012-01-27 14:22+0000\n"
 "Last-Translator: Sasan Jafarnejad <Unknown>\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -18,22 +18,18 @@ msgstr ""
 "X-Launchpad-Export-Date: 2012-11-14 16:52+0000\n"
 "X-Generator: Launchpad (build 16265)\n"
 
-#: schematic/src/a_zoom.c:155
 msgid "Zoom too small!  Cannot zoom further."
 msgstr ""
 
-#: schematic/src/color_edit_widget.c:399
 #, c-format
 msgid ""
 "Could not save file [%s]:\n"
 "%s"
 msgstr ""
 
-#: schematic/src/color_edit_widget.c:434
 msgid "Save Color Scheme As..."
 msgstr ""
 
-#: schematic/src/color_edit_widget.c:482 schematic/src/x_fileselect.c:292
 #, c-format
 msgid ""
 "The selected file `%1$s' already exists.\n"
@@ -41,178 +37,140 @@ msgid ""
 "Would you like to overwrite it?"
 msgstr ""
 
-#: schematic/src/color_edit_widget.c:486 schematic/src/x_fileselect.c:295
 msgid "Overwrite file?"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:211
 msgid "_Apply"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:215
 msgid "Sa_ve..."
 msgstr ""
 
-#: schematic/src/font_select_widget.c:278
 #, c-format
 msgid "<b>Current:</b> %s"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:453
 msgid "Save configuration"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:461
 msgid "Save settings to:"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:465
 msgid "Local configuration file (in current directory)"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:467
 msgid "User configuration file (geda-user.conf)"
 msgstr ""
 
-#: schematic/src/g_attrib.c:90
 msgid "Object ~A is not included in the current gschem page."
 msgstr ""
 
-#: schematic/src/g_attrib.c:110
 msgid "Invalid text name/value visibility ~A."
 msgstr ""
 
-#: schematic/src/g_rc.c:107
 #, c-format
 msgid "You are running gEDA/gaf version [%1$s%2$s.%3$s],\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:111
 #, c-format
 msgid ""
 "but you have a version [%1$s] gschemrc file:\n"
 "[%2$s]\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:114
 #, c-format
 msgid "Please be sure that you have the latest rc file.\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:240
 #, c-format
 msgid "Invalid size [%1$d] passed to text-size\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:283
 #, c-format
 msgid "Invalid size [%1$d] passed to snap-size\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:620
 #, c-format
 msgid "Invalid num levels [%1$d] passed to undo-levels\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:831
 #, c-format
 msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:931
 #, c-format
 msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:972
 #, c-format
 msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:998
 #, c-format
 msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1023
 #, c-format
 msgid "Invalid offset [%1$d] passed to add-attribute-offset\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1047
 #, c-format
 msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1071
 #, c-format
 msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1094
 #, c-format
 msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1118
 #, c-format
 msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1144
 #, c-format
 msgid "Invalid gain [%1$d] passed to zoom-gain\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1169
 #, c-format
 msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
 msgstr ""
 
-#: schematic/src/g_select.c:78 schematic/src/g_select.c:115
-#: schematic/src/g_select.c:151
 msgid "Object ~A is not directly included in a page."
 msgstr ""
 
-#: schematic/src/g_util.c:54
 msgid "Could not launch URI ~S: ~A"
 msgstr ""
 
-#: schematic/src/g_window.c:139
 msgid "Found invalid gschem window smob ~S"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:156
 #, c-format
 msgid "Lepton EDA/lepton-schematic version %1$s%2$s.%3$s git: %4$.7s"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:163
 #, c-format
 msgid "This is the MINGW32 port.\n"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:167
 #, c-format
 msgid "Current locale settings: %1$s\n"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:201
 #, c-format
 msgid "Couldn't find init scm file [%1$s]"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:206
 #, c-format
 msgid "Read init scm file [%1$s]"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:210
 #, c-format
 msgid "Failed to read init scm file [%1$s]"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:290
 #, c-format
 msgid ""
 "ERROR: Failed to load or evaluate startup script.\n"
@@ -220,686 +178,501 @@ msgid ""
 "The lepton-schematic log may contain more information.\n"
 msgstr ""
 
-#: schematic/src/gschem_about_dialog.c:51
 #, c-format
 msgid "%s (git: %.7s)"
 msgstr ""
 
-#: schematic/src/gschem_about_dialog.c:75
 msgid "Lepton Electronic Design Automation"
 msgstr ""
 
-#: schematic/src/gschem_about_dialog.c:83
 msgid ""
 "Copyright © 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright © 2017-2018 Lepton Developers.\n"
-"See AUTHORS and ChangeLog files for details."
+"Copyright © 2017-2019 Lepton Developers.\n"
+"See AUTHORS, ChangeLog files and consult 'git log' history for details."
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:69
 msgid "Upper Left"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:71
 msgid "Upper Middle"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:73
 msgid "Upper Right"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:78
 msgid "Middle Left"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:80
 msgid "Middle Middle"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:82
 msgid "Middle Right"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:87
 msgid "Lower Left"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:89
 msgid "Lower Middle"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:91
 msgid "Lower Right"
 msgstr ""
 
-#: schematic/src/gschem_arc_dialog.c:104
 msgid "Arc Params"
 msgstr ""
 
-#: schematic/src/gschem_arc_dialog.c:140
 msgid "Arc _Radius:"
 msgstr ""
 
-#: schematic/src/gschem_arc_dialog.c:141
 msgid "Start _Angle:"
 msgstr ""
 
-#: schematic/src/gschem_arc_dialog.c:142
 msgid "_Degrees of Sweep:"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:504
 msgid "Left mouse button"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:508
 msgid "Middle mouse button"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:512
 msgid "Right mouse button"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:595
 msgid "(Snap size, Grid size)"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:603
 msgid "Net rubber band mode"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:614
 msgid "Magnetic net mode"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:622
 msgid "Current action mode"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:935
-#: schematic/src/gschem_bottom_widget.c:951
 msgid "OFF"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:954
 msgid "NONE"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:960
 #, c-format
 msgid "Grid(%1$s, %2$s)"
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:350
-#: schematic/src/x_compselect.c:1236 schematic/src/x_multiattrib.c:2068
 msgid "Name"
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:372
 msgid "S_elect the schematics you want to save:"
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:467
 #, c-format
 msgid "Save the changes to schematic \"%1$s\" before closing?"
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:473
 #, c-format
 msgid ""
 "There are %1$d schematics with unsaved changes. Save changes before closing?"
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:502
 msgid "If you don't save, all your changes will be permanently lost."
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:522
 msgid "Close _without saving"
 msgstr ""
 
-#: schematic/src/gschem_coord_dialog.c:86
 msgid "Coords"
 msgstr ""
 
-#: schematic/src/gschem_coord_dialog.c:106
 msgid "Screen"
 msgstr ""
 
-#: schematic/src/gschem_coord_dialog.c:115
 msgid "World"
 msgstr ""
 
-#: schematic/src/gschem_find_text_state.c:809 schematic/src/x_pagesel.c:432
 msgid "Filename"
 msgstr ""
 
-#: schematic/src/gschem_find_text_state.c:821 schematic/src/i_callbacks.c:1970
-#: schematic/src/x_colorcb.c:154 schematic/src/x_widgets.c:179
-#: schematic/src/x_window.c:1226 schematic/src/x_window.c:1440
 msgid "Text"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:427
 msgid "descend into hierarchy"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:435
 msgid "Find"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:557
 #, fuzzy
 msgid "Find Text:"
 msgstr "Edit Text..."
 
-#: schematic/src/gschem_find_text_widget.c:564
 msgid "Find Pattern:"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:571
 msgid "Find Regex:"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:578
 msgid "Check symbol:"
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:200
 msgid "Hotkeys"
 msgstr "Hotkeys"
 
-#: schematic/src/gschem_hotkey_dialog.c:229
 msgid ""
 "Start typing action name or keystroke to filter the list.\n"
 "Type hotkeys as they are displayed in \"Keystroke(s)\" column."
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:233 schematic/src/x_compselect.c:1124
 msgid "_Filter:"
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:259 schematic/src/i_basic.c:280
 msgid "Action"
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:277
 msgid "Keystroke(s)"
 msgstr ""
 
-#: schematic/src/gschem_log_widget.c:177
 msgid "** Invalid UTF-8 in log message. See stderr or gschem.log.\n"
 msgstr ""
 
-#: schematic/src/gschem_log_widget.c:434
 #, fuzzy
 msgid "Clear log window?"
 msgstr "New Window"
 
-#: schematic/src/gschem_log_widget.c:477
 #, fuzzy
 msgid "Clear Log _Window"
 msgstr "New Window"
 
-#: schematic/src/gschem_macro_widget.c:231
 msgid "Macro:"
 msgstr ""
 
-#: schematic/src/gschem_macro_widget.c:387
 msgid "Evaluate"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:172
 #, fuzzy
 msgid "_Fill Type:"
 msgstr "Fill Type..."
 
-#: schematic/src/gschem_object_properties_widget.c:173
 #, fuzzy
 msgid "Lin_e Width:"
 msgstr "Line Width & Type..."
 
-#: schematic/src/gschem_object_properties_widget.c:174
 msgid "Angle _1:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:175
 msgid "P_itch 1:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:176
 msgid "Angle _2:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:177
 msgid "Pitc_h 2:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:237
 msgid "<b>Fill Properties</b>"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:255
-#: schematic/src/gschem_text_properties_widget.c:258
-#: schematic/src/x_newtext.c:271
 #, fuzzy
 msgid "Colo_r:"
 msgstr "Color..."
 
-#: schematic/src/gschem_object_properties_widget.c:266
 msgid "<b>General Properties</b>"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:284
 #, fuzzy
 msgid "_Type:"
 msgstr "Fill Type..."
 
-#: schematic/src/gschem_object_properties_widget.c:285
 #, fuzzy
 msgid "_Width:"
 msgstr "Line Width & Type..."
 
-#: schematic/src/gschem_object_properties_widget.c:286
 msgid "Dash _Length:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:287
 msgid "Dash _Space:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:288
 msgid "C_ap style:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:333
 msgid "<b>Line Properties</b>"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:351
 #, fuzzy
 msgid "_Pin Type:"
 msgstr "Fill Type..."
 
-#: schematic/src/gschem_object_properties_widget.c:362
 msgid "<b>Pin Properties</b>"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:217
 msgid "_Off"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:220
 msgid "_Dots"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:223
 msgid "M_esh"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:245
 msgid "Net R_ubber Band Mode:"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:246
 msgid "_Magnetic Net Mode:"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:250
-#: schematic/src/gschem_options_widget.c:251
 msgid "Enabled"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:265
 msgid "<b>Net Options</b>"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:282
 msgid "Grid Mode:"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:283
 #, fuzzy
 msgid "Snap Mode:"
 msgstr "Copy Mode"
 
-#: schematic/src/gschem_options_widget.c:284
 #, fuzzy
 msgid "_Snap Size:"
 msgstr "Copy Mode"
 
-#: schematic/src/gschem_options_widget.c:301
 msgid "<b>Snap Options</b>"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:340
 msgid "O_ff"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:343
 msgid "_Grid"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:346
 msgid "_Resnap"
 msgstr ""
 
-#: schematic/src/gschem_pin_type_combo.c:73
 msgid "Net pin"
 msgstr ""
 
-#: schematic/src/gschem_pin_type_combo.c:80
 msgid "Bus pin (graphical)"
 msgstr ""
 
-#: schematic/src/gschem_preview.c:195
 msgid "Preview Buffer"
 msgstr ""
 
-#: schematic/src/gschem_show_hide_text_widget.c:148
-#: schematic/src/x_window.c:1268
 msgid "Hide"
 msgstr ""
 
-#: schematic/src/gschem_show_hide_text_widget.c:157
-#: schematic/src/x_window.c:1269
 msgid "Hide text starting with:"
 msgstr ""
 
-#: schematic/src/gschem_slot_edit_dialog.c:91
 msgid "Edit slot number"
 msgstr ""
 
-#: schematic/src/gschem_slot_edit_dialog.c:121
 msgid "Number of Slots:"
 msgstr ""
 
-#: schematic/src/gschem_slot_edit_dialog.c:122
 msgid "Slot Number:"
 msgstr ""
 
-#: schematic/src/gschem_text_properties_widget.c:240
-#: schematic/src/x_newtext.c:265
 msgid "<b>Text Content</b>"
 msgstr ""
 
-#: schematic/src/gschem_text_properties_widget.c:259
-#: schematic/src/x_newtext.c:291
 msgid "_Size:"
 msgstr ""
 
-#: schematic/src/gschem_text_properties_widget.c:260
-#: schematic/src/x_newtext.c:310
 msgid "Ali_gnment:"
 msgstr ""
 
-#: schematic/src/gschem_text_properties_widget.c:261
-#: schematic/src/x_newtext.c:330
 msgid "Ro_tation:"
 msgstr ""
 
-#: schematic/src/gschem_text_properties_widget.c:294
-#: schematic/src/x_newtext.c:253
 msgid "<b>Text Properties</b>"
 msgstr ""
 
-#: schematic/src/gschem_translate_widget.c:238
 msgid "Coordinate:"
 msgstr ""
 
-#: schematic/src/gschem_translate_widget.c:405 schematic/src/i_callbacks.c:800
 msgid "Translate"
 msgstr ""
 
-#: schematic/src/i_basic.c:64 schematic/src/x_window.c:1369
-#: schematic/scheme/conf/schematic/menu.scm:59
-#: schematic/scheme/gschem/builtins.scm:99
 msgid "Select Mode"
 msgstr "Select Mode"
 
-#: schematic/src/i_basic.c:65
 #, fuzzy
 msgid "Select Box Mode"
 msgstr "Select Mode"
 
-#: schematic/src/i_basic.c:66
 msgid "Text Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:67
 msgid "Pan Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:70
 #, c-format
 msgid "Paste %d Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:74
 msgid "Magnetic Net Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:76
 msgid "Net Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:77
 msgid "Arc Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:78
 msgid "Box Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:79
 msgid "Bus Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:80
 msgid "Circle Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:81
 msgid "Component Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:82 schematic/scheme/conf/schematic/menu.scm:62
-#: schematic/scheme/gschem/builtins.scm:114
 msgid "Copy Mode"
 msgstr "Copy Mode"
 
-#: schematic/src/i_basic.c:83 schematic/scheme/conf/schematic/menu.scm:63
-#: schematic/scheme/gschem/builtins.scm:117
 msgid "Multiple Copy Mode"
 msgstr "Multiple Copy Mode"
 
-#: schematic/src/i_basic.c:84
 msgid "Line Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:85 schematic/scheme/conf/schematic/menu.scm:66
-#: schematic/scheme/gschem/builtins.scm:123
 msgid "Mirror Mode"
 msgstr "Mirror Mode"
 
-#: schematic/src/i_basic.c:86 schematic/scheme/conf/schematic/menu.scm:64
-#: schematic/scheme/gschem/builtins.scm:111
 msgid "Move Mode"
 msgstr "Move Mode"
 
-#: schematic/src/i_basic.c:87
 #, fuzzy
 msgid "Path Mode"
 msgstr "Rotate 90 Mode"
 
-#: schematic/src/i_basic.c:88
 msgid "Picture Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:89
 msgid "Pin Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:90 schematic/scheme/gschem/builtins.scm:120
 msgid "Rotate Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:91
 #, fuzzy
 msgid "Modify Mode"
 msgstr "Copy Mode"
 
-#: schematic/src/i_basic.c:92 schematic/src/x_menus.c:49
-#: schematic/scheme/gschem/builtins.scm:204
 msgid "Zoom Box"
 msgstr "Zoom Box"
 
-#: schematic/src/i_basic.c:121
 msgid "Show Hidden"
 msgstr ""
 
-#: schematic/src/i_basic.c:124
 msgid "Snap Off"
 msgstr ""
 
-#: schematic/src/i_basic.c:126
 msgid "Resnap Active"
 msgstr ""
 
-#: schematic/src/i_basic.c:288 schematic/src/x_colorcb.c:159
 msgid "Stroke"
 msgstr ""
 
-#: schematic/src/i_basic.c:296 schematic/src/i_basic.c:330
-#: schematic/src/x_window.c:1361
 msgid "none"
 msgstr ""
 
-#: schematic/src/i_basic.c:304
 msgid "Repeat/"
 msgstr ""
 
-#: schematic/src/i_basic.c:315
 msgid "Repeat/none"
 msgstr ""
 
-#: schematic/src/i_basic.c:323 schematic/src/i_callbacks.c:1239
-#: schematic/scheme/gschem/builtins.scm:189
 msgid "Pan"
 msgstr "Pan"
 
-#: schematic/src/i_callbacks.c:74
 #, c-format
 msgid "New page created [%1$s]"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:108
 #, c-format
 msgid "New Window created [%1$s]"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:245
 msgid "Failed to Save All"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:247
 msgid "Saved All"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:308
 #, fuzzy
 msgid "Closing Window"
 msgstr "New Window"
 
-#: schematic/src/i_callbacks.c:505 schematic/src/x_menus.c:55
-#: schematic/scheme/gschem/builtins.scm:168
 msgid "Copy"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:514 schematic/src/i_callbacks.c:539
-#: schematic/src/i_callbacks.c:564
 msgid "Select objs first"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:530
 msgid "Multiple Copy"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:555 schematic/src/x_menus.c:56
 msgid "Move"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:579 schematic/src/x_menus.c:57
-#: schematic/src/x_multiattrib.c:1656 schematic/scheme/gschem/builtins.scm:108
 msgid "Delete"
 msgstr "Delete"
 
-#: schematic/src/i_callbacks.c:603
 msgid "Edit"
 msgstr "Edit"
 
-#: schematic/src/i_callbacks.c:618 schematic/scheme/gschem/builtins.scm:129
 msgid "Edit Text"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:637
 msgid "Slot"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:688 schematic/src/i_callbacks.c:698
 msgid "Rotate"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:736 schematic/src/i_callbacks.c:746
 msgid "Mirror"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:763 schematic/src/x_colorcb.c:160
-#: schematic/scheme/conf/schematic/menu.scm:73
-#: schematic/scheme/gschem/builtins.scm:141
 msgid "Lock"
 msgstr "Lock"
 
-#: schematic/src/i_callbacks.c:781 schematic/scheme/conf/schematic/menu.scm:74
-#: schematic/scheme/gschem/builtins.scm:144
 msgid "Unlock"
 msgstr "Unlock"
 
-#: schematic/src/i_callbacks.c:805
 msgid "WARNING: Do not translate with snap off!"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:806
 msgid "WARNING: Turning snap on and continuing with translate."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:813
 msgid "WARNING: Snap grid size is not equal to 100!"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:815
 msgid ""
 "WARNING: If you are translating a symbol to the origin, the snap grid size "
 "should be set to 100"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:847
 msgid "Embed"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:886
 msgid "Unembed"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:928
 msgid "Update"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:970
 msgid "ShowHidden"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1537
 #, c-format
 msgid ""
 "<b>Revert page:</b>\n"
@@ -910,98 +683,76 @@ msgid ""
 "discarded and page file will be reloaded from disk."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1555
 msgid "Revert"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1647
 msgid "Copy to clipboard"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1664
 msgid "Cut to clipboard"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1686
 msgid "Paste from clipboard"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1694
 msgid "Empty clipboard"
 msgstr ""
 
 #. TRANSLATORS: The number is the number of the buffer that the
 #. * selection is being copied to.
-#: schematic/src/i_callbacks.c:1719
 #, fuzzy, c-format
 msgid "Copy %i"
 msgstr "Copy into 1"
 
 #. TRANSLATORS: The number is the number of the buffer that the
 #. * selection is being cut to.
-#: schematic/src/i_callbacks.c:1746
 #, fuzzy, c-format
 msgid "Cut %i"
 msgstr "Cut into 1"
 
 #. TRANSLATORS: The number is the number of the buffer that is being
 #. * pasted to the schematic.
-#: schematic/src/i_callbacks.c:1776
 #, fuzzy, c-format
 msgid "Paste %i"
 msgstr "Paste from 1"
 
-#: schematic/src/i_callbacks.c:1785
 msgid "Empty buffer"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1833 schematic/src/x_window.c:1203
 msgid "Component"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1865 schematic/src/x_colorcb.c:150
 msgid "Attribute"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1885 schematic/src/x_colorcb.c:149
 msgid "Net"
 msgstr "Net"
 
-#: schematic/src/i_callbacks.c:1928 schematic/src/x_colorcb.c:155
-#: schematic/src/x_window.c:1222
 msgid "Bus"
 msgstr "Bus"
 
-#: schematic/src/i_callbacks.c:2004
 msgid "Line"
 msgstr "Line"
 
-#: schematic/src/i_callbacks.c:2021
 msgid "Path"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2043
 msgid "Box"
 msgstr "Box"
 
-#: schematic/src/i_callbacks.c:2085
 msgid "Circle"
 msgstr "Circle"
 
-#: schematic/src/i_callbacks.c:2108
 msgid "Arc"
 msgstr "Arc"
 
-#: schematic/src/i_callbacks.c:2131 schematic/src/x_colorcb.c:146
 msgid "Pin"
 msgstr "Pin"
 
-#: schematic/src/i_callbacks.c:2191
 #, c-format
 msgid "Searching for source [%1$s]"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2223
 #, c-format
 msgid ""
 "Failed to descend hierarchy into '%1$s': %2$s\n"
@@ -1009,106 +760,81 @@ msgid ""
 "The lepton-schematic log may contain more information."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2227
 #, c-format
 msgid "Failed to descend into '%1$s': %2$s"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2234
 msgid "Failed to descend hierarchy."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2312
 #, c-format
 msgid "Searching for symbol [%1$s]"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2320
 msgid "Symbol is not a real file. Symbol cannot be loaded."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2367 schematic/src/x_tabs.c:1060
 msgid "Cannot find any schematics above the current one!"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2400
 msgid "Attach"
 msgstr "Attach"
 
-#: schematic/src/i_callbacks.c:2456
 msgid "Detach"
 msgstr "Detach"
 
-#: schematic/src/i_callbacks.c:2500
 msgid "ShowN"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2537
 msgid "ShowV"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2574
 msgid "ShowB"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2612
 msgid "VisToggle"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2643
 #, c-format
 msgid "Sorry but this is a non-functioning menu option\n"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2703
 msgid "Action feedback mode set to OUTLINE"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2706
 msgid "Action feedback mode set to BOUNDINGBOX"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2730
 msgid "Grid OFF"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2731
 msgid "Dot grid selected"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2732
 msgid "Mesh grid selected"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2733
 msgid "Invalid grid mode"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2755
 msgid "Snap OFF (CAUTION!)"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2758
 msgid "Snap ON"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2761
 msgid "Snap back to the grid (CAUTION!)"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2790
 msgid "Rubber band ON"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2792
 msgid "Rubber band OFF"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2811
 msgid "magnetic net mode: ON"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2814
 msgid "magnetic net mode: OFF"
 msgstr ""
 
@@ -1117,134 +843,105 @@ msgstr ""
 #. the form "untitled_N.sch", where N is a number.  Please make
 #. sure that the translation contains characters suitable for use
 #. in a filename.
-#: schematic/src/i_vars.c:209
 msgid "untitled"
 msgstr ""
 
-#: schematic/src/o_complex.c:192 schematic/src/o_complex.c:195
 #, c-format
 msgid "Translating schematic [%1$d %2$d]"
 msgstr ""
 
-#: schematic/src/o_delete.c:82
 #, c-format
 msgid "Delete locked object?"
 msgid_plural "Delete %1$u locked objects?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/o_misc.c:55
 #, c-format
 msgid "Got an unexpected NULL in o_edit\n"
 msgstr ""
 
-#: schematic/src/o_misc.c:315
 msgid "Hidden text is now visible"
 msgstr ""
 
-#: schematic/src/o_misc.c:317
 msgid "Hidden text is now invisible"
 msgstr ""
 
-#: schematic/src/o_misc.c:425
 #, c-format
 msgid "Could not find symbol [%1$s] in library. Update failed."
 msgstr ""
 
-#: schematic/src/o_misc.c:541
 #, c-format
 msgid "o_autosave_backups: Can't get the real filename of %1$s."
 msgstr ""
 
-#: schematic/src/o_misc.c:585
 #, c-format
 msgid "Could NOT set previous backup file [%1$s] read-write"
 msgstr ""
 
-#: schematic/src/o_misc.c:605
 #, c-format
 msgid "Could NOT set backup file [%1$s] readonly"
 msgstr ""
 
-#: schematic/src/o_misc.c:610
 #, c-format
 msgid "Could NOT save backup file [%1$s]"
 msgstr ""
 
-#: schematic/src/o_move.c:192
 #, c-format
 msgid "ERROR: NULL object in o_move_end!\n"
 msgstr ""
 
-#: schematic/src/o_move.c:519
 #, c-format
 msgid "DOH! tried to find the whichone, but didn't find it!\n"
 msgstr ""
 
-#: schematic/src/o_move.c:546
 #, c-format
 msgid "Got a non line object in o_move_check_endpoint\n"
 msgstr ""
 
-#: schematic/src/o_net.c:444
 msgid "Warning: Starting net at off grid coordinate"
 msgstr ""
 
-#: schematic/src/o_net.c:508
 msgid "Warning: Ending net at off grid coordinate"
 msgstr ""
 
-#: schematic/src/o_net.c:856 schematic/src/o_net.c:893
-#: schematic/src/o_net.c:964 schematic/src/o_net.c:1000
 #, c-format
 msgid "Tried to add more than two bus rippers. Internal gschem error.\n"
 msgstr ""
 
-#: schematic/src/o_net.c:1068
 #, c-format
 msgid "Bus ripper symbol [%1$s] was not found in any component library"
 msgstr ""
 
-#: schematic/src/o_picture.c:133 schematic/src/o_picture.c:343
 msgid "Select a picture file..."
 msgstr ""
 
-#: schematic/src/o_picture.c:166
 #, c-format
 msgid "Failed to load picture: %1$s"
 msgstr ""
 
-#: schematic/src/o_picture.c:182
 msgid "Picture"
 msgstr ""
 
-#: schematic/src/o_picture.c:378
 #, c-format
 msgid "Failed to replace pictures: %s"
 msgstr ""
 
-#: schematic/src/o_slot.c:80
 #, fuzzy
 msgid "Slot attribute malformed"
 msgstr "Attributes"
 
-#: schematic/src/o_slot.c:88
 msgid "numslots attribute missing"
 msgstr ""
 
-#: schematic/src/o_slot.c:89
 msgid "Slotting not allowed for this component"
 msgstr ""
 
-#: schematic/src/o_slot.c:104
 msgid "New slot number out of range"
 msgstr ""
 
-#: schematic/src/o_undo.c:397
 msgid "Undo/Redo disabled in rc file"
 msgstr ""
 
-#: schematic/src/parsecmd.c:77
 #, c-format
 msgid ""
 "Usage: %1$s [OPTION ...] [--] [FILE ...]\n"
@@ -1269,187 +966,143 @@ msgid ""
 "gEDA/gaf homepage: <http://www.geda-project.org/>\n"
 msgstr ""
 
-#: schematic/src/parsecmd.c:110
 #, c-format
 msgid ""
 "Lepton EDA %1$s (git: %2$.7s)\n"
 "Copyright (C) 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright (C) 2017-2018 Lepton Developers.\n"
+"Copyright (C) 2017-2019 Lepton Developers.\n"
 "This is free software, and you are welcome to redistribute it under\n"
 "certain conditions. For details, see the file `COPYING', which is\n"
 "included in the Lepton EDA distribution.\n"
 "There is NO WARRANTY, to the extent permitted by law.\n"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:125
 #, c-format
 msgid "Got invalid show option; defaulting to show both\n"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:139
 #, c-format
 msgid "ERROR: NULL object!\n"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:328
 msgid "Single Attribute Editor"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:358
 msgid "<b>Edit Attribute</b>"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:360
 msgid "<b>Add Attribute</b>"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:376
 msgid "N_ame:"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:396 schematic/src/x_multiattrib.c:2222
 msgid "_Value:"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:415 schematic/src/x_multiattrib.c:2281
 msgid "Vi_sible"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:434
 msgid "Show Value Only"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:436
 msgid "Show Name Only"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:438 schematic/src/x_multiattrib.c:1620
-#: schematic/scheme/gschem/builtins.scm:324
 msgid "Show Name & Value"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:445
 msgid "<b>Attach Options</b>"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:460
 msgid "All"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:476 schematic/src/x_compselect.c:986
-#: schematic/src/x_compselect.c:1100
 msgid "Components"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:492 schematic/src/x_window.c:1214
 msgid "Nets"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:508
 msgid "Replace existing attributes"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:412
 msgid ""
 "slotted object without slot attribute may cause problems when autonumbering "
 "slots"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:427
 #, c-format
 msgid ""
 "duplicate slot may cause problems: [symbolname=%1$s, number=%2$d, slot=%3$d]"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:675
 msgid "No searchstring given in autonumber text."
 msgstr ""
 
-#: schematic/src/x_autonumber.c:728
 msgid "No '*' or '?' given at the end of the autonumber text."
 msgstr ""
 
-#: schematic/src/x_autonumber.c:873
 msgid "Diagonal"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:874
 msgid "Top to bottom"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:875
 msgid "Bottom to top"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:876
 msgid "Left to right"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:877
 msgid "Right to left"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:878
 msgid "File order"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1214
 msgid "Autonumber text"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1237
 msgid "<b>Scope</b>"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1259
 msgid "Search for:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1273
 msgid "Autonumber text in:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1280
 msgid "Skip numbers found in:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1292 schematic/src/x_autonumber.c:1301
 msgid "Selected objects"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1293 schematic/src/x_autonumber.c:1302
 msgid "Current page"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1294 schematic/src/x_autonumber.c:1303
 msgid "Whole hierarchy"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1305
 msgid "Overwrite existing numbers"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1310
 msgid "<b>Options</b>"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1332
 msgid "Starting number:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1339
 msgid "Sort order:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1371
 msgid "Remove numbers"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1375
 msgid "Automatic slotting"
 msgstr ""
 
-#: schematic/src/x_clipboard.c:245
 #, c-format
 msgid ""
 "<b>Invalid schematic on clipboard.</b>\n"
@@ -1457,173 +1110,133 @@ msgid ""
 "An error occurred while inserting clipboard data: %s."
 msgstr ""
 
-#: schematic/src/x_clipboard.c:247
 msgid "Clipboard insertion failed"
 msgstr ""
 
-#: schematic/src/x_color.c:89 schematic/src/x_color.c:98
 #, c-format
 msgid "Could not allocate the color %1$s!\n"
 msgstr ""
 
-#: schematic/src/x_color.c:89
 msgid "black"
 msgstr ""
 
-#: schematic/src/x_color.c:98
 msgid "white"
 msgstr ""
 
-#: schematic/src/x_color.c:120
 #, c-format
 msgid "Could not allocate display color %1$i!\n"
 msgstr ""
 
-#: schematic/src/x_color.c:142
 #, c-format
 msgid "Could not allocate outline color %1$i!\n"
 msgstr ""
 
-#: schematic/src/x_color.c:159
 #, c-format
 msgid "Tried to get an invalid color: %1$d\n"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:145
 msgid "Background"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:147
 msgid "Net endpoint"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:148
 msgid "Graphic"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:151
 msgid "Logic bubble"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:152
 msgid "Grid point"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:153
 #, fuzzy
 msgid "Detached attribute"
 msgstr "Attributes"
 
-#: schematic/src/x_colorcb.c:156
 #, fuzzy
 msgid "Selection"
 msgstr "Select Mode"
 
-#: schematic/src/x_colorcb.c:157
 msgid "Bounding box"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:158
 #, fuzzy
 msgid "Zoom box"
 msgstr "Zoom Box"
 
-#: schematic/src/x_colorcb.c:161
 msgid "Output background"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:162
 msgid "Freestyle 1"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:163
 msgid "Freestyle 2"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:164
 msgid "Freestyle 3"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:165
 msgid "Freestyle 4"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:166
 msgid "Net junction"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:167
 msgid "Mesh grid major"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:168
 msgid "Mesh grid minor"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:172
 msgid "Unknown"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1169
 msgid "Reset filter"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1192
 msgid "Reload all libraries"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1245 schematic/src/x_multiattrib.c:2092
 msgid "Value"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1284
 msgid "Default behavior - reference component"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1287
 msgid "Embed component in schematic"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1290
 msgid "Include component as individual objects"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1448
 msgid "Select Component..."
 msgstr ""
 
-#: schematic/src/x_compselect.c:1471
 msgid "In Us_e"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1475
 msgid "Lib_raries"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1484 schematic/src/x_fileselect.c:119
 msgid "Preview"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1510
 msgid "Attributes"
 msgstr "Attributes"
 
-#: schematic/src/x_dialog.c:325
 msgid "Major symbol changes detected."
 msgstr ""
 
-#: schematic/src/x_dialog.c:349
 msgid ""
 "Changes have occurred to the symbols shown below.\n"
 "\n"
 "Be sure to verify each of these symbols."
 msgstr ""
 
-#: schematic/src/x_dialog.c:369
 msgid "Symbol"
 msgstr ""
 
-#: schematic/src/x_dialog.c:406
 #, c-format
 msgid ""
 "<span weight=\"bold\" size=\"larger\">The input attribute \"%s\" is invalid\n"
@@ -1634,39 +1247,30 @@ msgid ""
 "The value cannot start with a space."
 msgstr ""
 
-#: schematic/src/x_dialog.c:408
 msgid "Invalid Attribute"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:37
 msgid "Schematics"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:42
 msgid "Symbols"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:47
 msgid "Schematics and symbols"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:53
 msgid "All files"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:169
 msgid "Open..."
 msgstr ""
 
-#: schematic/src/x_fileselect.c:233
 msgid "Save as..."
 msgstr ""
 
-#: schematic/src/x_fileselect.c:297
 msgid "Save cancelled on user request"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:334
 msgid ""
 "\n"
 "If you load the original file, the backup file will be overwritten in the "
@@ -1675,28 +1279,22 @@ msgid ""
 "Do you want to load the backup file?\n"
 msgstr ""
 
-#: schematic/src/x_fstylecb.c:73
 msgid "Hollow"
 msgstr ""
 
-#: schematic/src/x_fstylecb.c:80
 msgid "Filled"
 msgstr ""
 
-#: schematic/src/x_fstylecb.c:87
 msgid "Mesh"
 msgstr ""
 
-#: schematic/src/x_fstylecb.c:94
 msgid "Hatch"
 msgstr ""
 
-#: schematic/src/x_image.c:279
 #, c-format
 msgid "x_image_lowlevel: Unable to write %1$s file %2$s."
 msgstr ""
 
-#: schematic/src/x_image.c:289
 #, c-format
 msgid ""
 "There was the following error when saving image with type %1$s to filename:\n"
@@ -1705,300 +1303,233 @@ msgid ""
 "%3$s.\n"
 msgstr ""
 
-#: schematic/src/x_image.c:309
 #, c-format
 msgid "Wrote color image to [%1$s] [%2$d x %3$d]"
 msgstr ""
 
-#: schematic/src/x_image.c:311
 #, c-format
 msgid "Wrote black and white image to [%1$s] [%2$d x %3$d]"
 msgstr ""
 
-#: schematic/src/x_image.c:319
 msgid "x_image_lowlevel: Unable to get pixbuf from gschem's window."
 msgstr ""
 
-#: schematic/src/x_image.c:358
 msgid "Width x Height"
 msgstr ""
 
-#: schematic/src/x_image.c:374
 msgid "Image type"
 msgstr ""
 
-#: schematic/src/x_image.c:395
 msgid "Write image..."
 msgstr "Write image..."
 
-#: schematic/src/x_linecapcb.c:74
 msgid "Butt"
 msgstr ""
 
-#: schematic/src/x_linecapcb.c:81
 msgid "Square"
 msgstr ""
 
-#: schematic/src/x_linecapcb.c:88
 msgid "Round"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:74
 msgid "Solid"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:81
 msgid "Dotted"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:88
 msgid "Dashed"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:95
 msgid "Center"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:102
 msgid "Phantom"
 msgstr ""
 
-#: schematic/src/x_menus.c:41 schematic/scheme/gschem/builtins.scm:267
 msgid "Add Net"
 msgstr ""
 
-#: schematic/src/x_menus.c:42 schematic/src/x_multiattrib.c:2187
-#: schematic/scheme/gschem/builtins.scm:264
 msgid "Add Attribute"
 msgstr ""
 
-#: schematic/src/x_menus.c:43 schematic/scheme/gschem/builtins.scm:261
 #, fuzzy
 msgid "Add Component"
 msgstr "Update Component"
 
-#: schematic/src/x_menus.c:44 schematic/scheme/gschem/builtins.scm:270
 msgid "Add Bus"
 msgstr ""
 
-#: schematic/src/x_menus.c:45 schematic/scheme/gschem/builtins.scm:273
 #, fuzzy
 msgid "Add Text"
 msgstr "Edit Text..."
 
-#: schematic/src/x_menus.c:47 schematic/scheme/gschem/builtins.scm:210
 #, fuzzy
 msgid "Zoom In"
 msgstr "Zoom Box"
 
-#: schematic/src/x_menus.c:48 schematic/scheme/gschem/builtins.scm:213
 #, fuzzy
 msgid "Zoom Out"
 msgstr "Zoom Box"
 
-#: schematic/src/x_menus.c:50 schematic/scheme/gschem/builtins.scm:207
 #, fuzzy
 msgid "Zoom Extents"
 msgstr "Zoom Box"
 
-#: schematic/src/x_menus.c:52 schematic/src/x_window.c:1233
 msgid "Select"
 msgstr ""
 
-#: schematic/src/x_menus.c:53 schematic/scheme/conf/schematic/menu.scm:69
-#: schematic/scheme/gschem/builtins.scm:126
 msgid "Edit..."
 msgstr "Edit..."
 
-#: schematic/src/x_menus.c:54 schematic/scheme/conf/schematic/menu.scm:68
 msgid "Object Properties..."
 msgstr ""
 
-#: schematic/src/x_menus.c:59 schematic/scheme/gschem/builtins.scm:300
 msgid "Down Schematic"
 msgstr ""
 
-#: schematic/src/x_menus.c:60 schematic/scheme/gschem/builtins.scm:303
 msgid "Down Symbol"
 msgstr ""
 
-#: schematic/src/x_menus.c:61
 msgid "Up"
 msgstr ""
 
-#: schematic/src/x_menus.c:336
 #, c-format
 msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
 msgstr ""
 
-#: schematic/src/x_menus.c:360
 #, c-format
 msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
 msgstr ""
 
-#: schematic/src/x_misc.c:70
 msgid "The operating system is out of memory or resources."
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:798 schematic/src/x_multiattrib.c:2704
 msgid "<various>"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:930
 msgid "Attributes with empty name are not allowed. Please set a name."
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1622
 msgid "Show Value only"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1624
 msgid "Show Name only"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1651
 msgid "Promote"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1655
 msgid "Duplicate"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1657
 #, fuzzy
 msgid "Copy to all"
 msgstr "Copy into 1"
 
-#: schematic/src/x_multiattrib.c:1986 schematic/src/x_multiattrib.c:2602
 msgid "Edit Attributes"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2112
 msgid "Vis?"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2130
 msgid "N"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2148
 msgid "V"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2170
 #, fuzzy
 msgid "Sho_w inherited attributes"
 msgstr "Attributes"
 
-#: schematic/src/x_multiattrib.c:2197
 msgid "_Name:"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2241
 msgid "Ctrl+Enter inserts new line; Ctrl+Tab inserts Tab"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2618
 #, c-format
 msgid "%2$i symbol (%1$s)"
 msgid_plural "%2$i symbols (%1$s)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2624
 #, c-format
 msgid "%1$i pin"
 msgid_plural "%1$i pins"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2630
 #, c-format
 msgid "%1$i net"
 msgid_plural "%1$i nets"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2636
 #, c-format
 msgid "%1$i bus"
 msgid_plural "%1$i buses"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2642
 #, fuzzy, c-format
 msgid "%1$i attribute"
 msgid_plural "%1$i attributes"
 msgstr[0] "Attributes"
 msgstr[1] "Attributes"
 
-#: schematic/src/x_newtext.c:433
 msgid "Text Entry..."
 msgstr ""
 
-#: schematic/src/x_pagesel.c:253
 msgid "New Page"
 msgstr "New Page"
 
-#: schematic/src/x_pagesel.c:254
 msgid "Open Page..."
 msgstr "Open Page..."
 
-#: schematic/src/x_pagesel.c:256
 msgid "Save Page"
 msgstr "Save Page"
 
-#: schematic/src/x_pagesel.c:257 schematic/scheme/gschem/builtins.scm:246
 msgid "Close Page"
 msgstr "Close Page"
 
-#: schematic/src/x_pagesel.c:376 schematic/scheme/gschem/builtins.scm:237
 msgid "Page Manager"
 msgstr ""
 
-#: schematic/src/x_pagesel.c:448
 msgid "Changed"
 msgstr ""
 
-#: schematic/src/x_pagesel.c:468
 msgid "Right click on the filename for more options..."
 msgstr ""
 
-#: schematic/src/x_print.c:306
 #, c-format
 msgid "Failed to write PDF to '%s': %s\n"
 msgstr ""
 
-#: schematic/src/x_print.c:364
 #, c-format
 msgid "Failed to write PDF to '%1$s': %2$s\n"
 msgstr ""
 
-#: schematic/src/x_print.c:449
 #, c-format
 msgid ""
 "Error printing file:\n"
 "%1$s"
 msgstr ""
 
-#: schematic/src/x_rc.c:39
 msgid "ERROR: An unknown error occurred while parsing configuration files."
 msgstr ""
 
-#: schematic/src/x_rc.c:44
 msgid ""
 "An unknown error occurred while parsing configuration files.\n"
 "\n"
 "The lepton-schematic log may contain more information."
 msgstr ""
 
-#: schematic/src/x_rc.c:56
 #, c-format
 msgid "ERROR: %1$s"
 msgstr ""
 
-#: schematic/src/x_rc.c:59
 #, c-format
 msgid ""
 "%1$s\n"
@@ -2006,136 +1537,105 @@ msgid ""
 "The lepton-schematic log may contain more information."
 msgstr ""
 
-#: schematic/src/x_rc.c:67
 msgid "Cannot load lepton-schematic configuration."
 msgstr ""
 
-#: schematic/src/x_script.c:42 schematic/scheme/conf/schematic/menu.scm:40
 msgid "Execute Script..."
 msgstr "Execute Script..."
 
-#: schematic/src/x_script.c:61
 #, c-format
 msgid "Executing guile script [%1$s]"
 msgstr ""
 
-#: schematic/src/x_tabs.c:860
 #, c-format
 msgid "Hierarchy up: %s"
 msgstr ""
 
-#: schematic/src/x_tabs.c:863
 msgid "Hierarchy up"
 msgstr ""
 
-#: schematic/src/x_widgets.c:158 schematic/src/x_window.c:1444
 msgid "Options"
 msgstr ""
 
-#: schematic/src/x_widgets.c:203 schematic/src/x_window.c:1436
 msgid "Object"
 msgstr ""
 
-#: schematic/src/x_widgets.c:224
 msgid "Log"
 msgstr ""
 
-#: schematic/src/x_widgets.c:245 schematic/src/x_window.c:1466
 msgid "Find Text"
 msgstr ""
 
-#: schematic/src/x_widgets.c:259
 msgid "Color Scheme Editor"
 msgstr ""
 
-#: schematic/src/x_widgets.c:272 schematic/scheme/gschem/builtins.scm:378
 #, fuzzy
 msgid "Select Schematic Font"
 msgstr "Select Mode"
 
-#: schematic/src/x_window.c:763
 #, c-format
 msgid "Loading schematic [%1$s]"
 msgstr ""
 
-#: schematic/src/x_window.c:864
 #, c-format
 msgid "Could NOT save page [%1$s]\n"
 msgstr ""
 
-#: schematic/src/x_window.c:865
 msgid "Error while trying to save"
 msgstr ""
 
-#: schematic/src/x_window.c:875
 msgid "Failed to save file"
 msgstr ""
 
-#: schematic/src/x_window.c:885
 #, fuzzy, c-format
 msgid "Saved as [%1$s]"
 msgstr "Save All"
 
-#: schematic/src/x_window.c:887
 #, fuzzy, c-format
 msgid "Saved [%1$s]"
 msgstr "Save All"
 
-#: schematic/src/x_window.c:889
 msgid "Saved"
 msgstr ""
 
-#: schematic/src/x_window.c:966
 #, c-format
 msgid "Discarding page [%1$s]"
 msgstr ""
 
-#: schematic/src/x_window.c:966
 #, c-format
 msgid "Closing [%1$s]"
 msgstr ""
 
-#: schematic/src/x_window.c:1175
 msgid "New"
 msgstr "New"
 
-#: schematic/src/x_window.c:1175
 msgid "New file"
 msgstr ""
 
-#: schematic/src/x_window.c:1179
 msgid "Open"
 msgstr ""
 
-#: schematic/src/x_window.c:1179
 msgid "Open file"
 msgstr ""
 
-#: schematic/src/x_window.c:1183 schematic/scheme/gschem/builtins.scm:59
 msgid "Save"
 msgstr ""
 
-#: schematic/src/x_window.c:1183
 msgid "Save file"
 msgstr ""
 
-#: schematic/src/x_window.c:1189 schematic/scheme/gschem/builtins.scm:93
 msgid "Undo"
 msgstr "Undo"
 
-#: schematic/src/x_window.c:1189
 msgid "Undo last operation"
 msgstr ""
 
-#: schematic/src/x_window.c:1193 schematic/scheme/gschem/builtins.scm:96
 msgid "Redo"
 msgstr "Redo"
 
-#: schematic/src/x_window.c:1193
 msgid "Redo last undo"
 msgstr ""
 
-#: schematic/src/x_window.c:1198
 msgid ""
 "Add component...\n"
 "Select library and component from list, move the mouse into main window, "
@@ -2143,56 +1643,44 @@ msgid ""
 "Right mouse button to cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1209
 msgid ""
 "Add nets mode\n"
 "Right mouse button to cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1217
 msgid ""
 "Add buses mode\n"
 "Right mouse button to cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1226
 msgid "Add Text..."
 msgstr ""
 
-#: schematic/src/x_window.c:1233
 msgid "Select mode"
 msgstr ""
 
-#: schematic/src/x_window.c:1288
 msgid "Show"
 msgstr ""
 
-#: schematic/src/x_window.c:1289
 msgid "Show text starting with:"
 msgstr ""
 
-#: schematic/src/x_window.c:1345
 msgid "Menu/Cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1349
 msgid "Pan/Cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1359
 msgid "Pick"
 msgstr ""
 
-#: schematic/src/x_window.c:1470 schematic/scheme/gschem/builtins.scm:180
 msgid "Status"
 msgstr ""
 
-#: schematic/src/x_window.c:1568
 #, fuzzy, c-format
 msgid "New file [%s]"
 msgstr "New Page"
 
-#: schematic/src/x_window.c:1598
 #, c-format
 msgid ""
 "<b>An error occurred while loading the requested file.</b>\n"
@@ -2206,848 +1694,638 @@ msgid ""
 "monitor program's output in terminal window."
 msgstr ""
 
-#: schematic/src/x_window.c:1617
 msgid "Failed to load file"
 msgstr ""
 
-#: schematic/data/lepton-schematic.desktop.in:3
 msgid "Lepton EDA Schematic Editor"
 msgstr ""
 
-#: schematic/data/lepton-schematic.desktop.in:4
 msgid "Create and edit electrical schematics and symbols with lepton-schematic"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:27
 msgid "_New"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:28
 msgid "_Open..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:30
 msgid "Open Recen_t"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:32
 msgid "_Save"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:33
 msgid "Save _As..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:34
-#: schematic/scheme/gschem/builtins.scm:65
 msgid "Save All"
 msgstr "Save All"
 
-#: schematic/scheme/conf/schematic/menu.scm:36
 msgid "_Print..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:37
 #, fuzzy
 msgid "Write _Image..."
 msgstr "Write image..."
 
-#: schematic/scheme/conf/schematic/menu.scm:39
 msgid "Invoke Macro..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:41
 msgid "REPL..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:43
-#: schematic/scheme/gschem/builtins.scm:77
 msgid "New Window"
 msgstr "New Window"
 
-#: schematic/scheme/conf/schematic/menu.scm:44
 msgid "_Close Window"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:45
 msgid "_Quit"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:51
 msgid "_Undo"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:52
 msgid "_Redo"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:54
 msgid "Cu_t"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:55
 msgid "_Copy"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:56
 msgid "_Paste"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:57
 msgid "_Delete"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:60
-#: schematic/scheme/gschem/builtins.scm:102
 msgid "Select All"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:61
-#: schematic/scheme/gschem/builtins.scm:105
 msgid "Deselect"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:65
 msgid "Rotate 90 Mode"
 msgstr "Rotate 90 Mode"
 
-#: schematic/scheme/conf/schematic/menu.scm:70
 msgid "Edit Text..."
 msgstr "Edit Text..."
 
-#: schematic/scheme/conf/schematic/menu.scm:71
 msgid "Slot..."
 msgstr "Slot..."
 
-#: schematic/scheme/conf/schematic/menu.scm:76
-#: schematic/scheme/gschem/builtins.scm:150
 msgid "Embed Component/Picture"
 msgstr "Embed Component/Picture"
 
-#: schematic/scheme/conf/schematic/menu.scm:77
-#: schematic/scheme/gschem/builtins.scm:153
 msgid "Unembed Component/Picture"
 msgstr "Unembed Component/Picture"
 
-#: schematic/scheme/conf/schematic/menu.scm:78
-#: schematic/scheme/gschem/builtins.scm:156
 msgid "Update Component"
 msgstr "Update Component"
 
-#: schematic/scheme/conf/schematic/menu.scm:79
 msgid "Symbol Translate..."
 msgstr "Symbol Translate..."
 
-#: schematic/scheme/conf/schematic/menu.scm:85
 msgid "Copy into 1"
 msgstr "Copy into 1"
 
-#: schematic/scheme/conf/schematic/menu.scm:86
 msgid "Copy into 2"
 msgstr "Copy into 2"
 
-#: schematic/scheme/conf/schematic/menu.scm:87
 msgid "Copy into 3"
 msgstr "Copy into 3"
 
-#: schematic/scheme/conf/schematic/menu.scm:88
 msgid "Copy into 4"
 msgstr "Copy into 4"
 
-#: schematic/scheme/conf/schematic/menu.scm:89
 msgid "Copy into 5"
 msgstr "Copy into 5"
 
-#: schematic/scheme/conf/schematic/menu.scm:90
 msgid "Cut into 1"
 msgstr "Cut into 1"
 
-#: schematic/scheme/conf/schematic/menu.scm:91
 msgid "Cut into 2"
 msgstr "Cut into 2"
 
-#: schematic/scheme/conf/schematic/menu.scm:92
 msgid "Cut into 3"
 msgstr "Cut into 3"
 
-#: schematic/scheme/conf/schematic/menu.scm:93
 msgid "Cut into 4"
 msgstr "Cut into 4"
 
-#: schematic/scheme/conf/schematic/menu.scm:94
 msgid "Cut into 5"
 msgstr "Cut into 5"
 
-#: schematic/scheme/conf/schematic/menu.scm:95
 msgid "Paste from 1"
 msgstr "Paste from 1"
 
-#: schematic/scheme/conf/schematic/menu.scm:96
 msgid "Paste from 2"
 msgstr "Paste from 2"
 
-#: schematic/scheme/conf/schematic/menu.scm:97
 msgid "Paste from 3"
 msgstr "Paste from 3"
 
-#: schematic/scheme/conf/schematic/menu.scm:98
 msgid "Paste from 4"
 msgstr "Paste from 4"
 
-#: schematic/scheme/conf/schematic/menu.scm:99
 msgid "Paste from 5"
 msgstr "Paste from 5"
 
-#: schematic/scheme/conf/schematic/menu.scm:105
 msgid "Side Dock"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:106
 msgid "Bottom Dock"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:108
 #, fuzzy
 msgid "Find Text Results"
 msgstr "Edit Text..."
 
-#: schematic/scheme/conf/schematic/menu.scm:110
 msgid "_Redraw"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:111
 msgid "_Pan"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:112
 msgid "Zoom _Box"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:113
 msgid "Zoom _Extents"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:114
 msgid "Zoom _In"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:115
 msgid "Zoom _Out"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:116
 msgid "Zoom _Full"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:118
 msgid "_Dark Color Scheme"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:119
 msgid "_Light Color Scheme"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:120
 msgid "B_W Color Scheme"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:122
 msgid "Color Scheme Editor..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:129
 msgid "_Manager..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:131
 msgid "_Previous"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:132
 msgid "_Next"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:133
 msgid "_Close"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:135
 msgid "_Revert..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:137
-#: schematic/scheme/gschem/builtins.scm:249
 #, fuzzy
 msgid "Next Tab"
 msgstr "New Page"
 
-#: schematic/scheme/conf/schematic/menu.scm:138
-#: schematic/scheme/gschem/builtins.scm:252
 #, fuzzy
 msgid "Previous Tab"
 msgstr "Close Page"
 
-#: schematic/scheme/conf/schematic/menu.scm:146
 msgid "_Component..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:148
 msgid "_Net"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:149
 msgid "B_us"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:151
 msgid "_Attribute..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:152
 msgid "_Text..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:154
 msgid "_Line"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:155
 msgid "Pat_h"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:156
 msgid "_Box"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:157
 msgid "C_ircle"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:158
 msgid "A_rc"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:159
 msgid "_Pin"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:161
 msgid "Pictu_re..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:167
 msgid "_Up"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:169
 msgid "_Down Schematic"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:170
 msgid "Down _Symbol"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:176
 msgid "_Attach"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:177
 msgid "_Detach"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:179
 msgid "Show _Value"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:180
 msgid "Show _Name"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:181
 msgid "Show _Both"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:182
 msgid "_Toggle Visibility"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:184
 msgid "_Hide Specific Text..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:185
 msgid "_Show Specific Text..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:186
 #, fuzzy
 msgid "Show/Hide Hidden Text"
 msgstr "Show/Hide Inv Text"
 
-#: schematic/scheme/conf/schematic/menu.scm:188
 msgid "_Find Text/Check Symbol..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:189
 msgid "A_utonumber Text..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:195
 msgid "_Options..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:196
 #, fuzzy
 msgid "_Font..."
 msgstr "Slot..."
 
-#: schematic/scheme/conf/schematic/menu.scm:198
 msgid "Grid +"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:199
 msgid "Grid -"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:201
 msgid "Grid Style: Cycle Dots/Mesh/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:202
 msgid "Grid Snap: Cycle Grid/Resnap/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:204
 msgid "Feedback Mode: Outline/Box"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:205
 msgid "Net: Rubberband On/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:206
 msgid "Net: Magnetic On/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:208
 #, fuzzy
 msgid "_Coord Window"
 msgstr "New Window"
 
-#: schematic/scheme/conf/schematic/menu.scm:209
 #, fuzzy
 msgid "_Log Window"
 msgstr "New Window"
 
-#: schematic/scheme/conf/schematic/menu.scm:215
 msgid "_1 allegro"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:223
 msgid "User _Guide"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:224
 msgid "_FAQ"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:225
 msgid "Docu_mentation"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:226
 msgid "_Wiki"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:228
 msgid "Find Component D_ocumentation"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:230
 msgid "_Hotkeys..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:231
 msgid "_About"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:237
 msgid "_File"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:238
 msgid "_Edit"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:240
 msgid "_View"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:241
 msgid "_Page"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:242
 msgid "_Add"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:243
 msgid "Hie_rarchy"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:244
 msgid "A_ttributes"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:245
 msgid "_Options"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:246
 msgid "_Netlist"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:247
 msgid "_Help"
 msgstr ""
 
-#: schematic/scheme/gschem/action.scm:43
 #, scheme-format
 msgid "~S is not a valid gschem action."
 msgstr ""
 
-#: schematic/scheme/gschem/action.scm:158
 msgid "Repeat Last Action"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:47
 msgid "Cancel"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:53
 #, fuzzy
 msgid "New File"
 msgstr "New Page"
 
-#: schematic/scheme/gschem/builtins.scm:56
 msgid "Open File"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:62
 #, fuzzy
 msgid "Save As"
 msgstr "Save All"
 
-#: schematic/scheme/gschem/builtins.scm:68
 #, fuzzy
 msgid "Print"
 msgstr "Print..."
 
-#: schematic/scheme/gschem/builtins.scm:71
 msgid "Export Image"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:74
 msgid "Run Script"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:80
 #, fuzzy
 msgid "Close Window"
 msgstr "New Window"
 
-#: schematic/scheme/gschem/builtins.scm:83
 msgid "Quit"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:87
 msgid "Terminal REPL"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:132
 msgid "Choose Slot"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:135
 msgid "Edit Object Properties"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:138
 msgid "Translate Symbol"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:147
 msgid "Invoke Macro"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:159
 #, fuzzy
 msgid "Show/Hide Invisible Text"
 msgstr "Show/Hide Inv Text"
 
-#: schematic/scheme/gschem/builtins.scm:165
 #, fuzzy
 msgid "Cut"
 msgstr "Cut into 1"
 
-#: schematic/scheme/gschem/builtins.scm:171
 #, fuzzy
 msgid "Paste"
 msgstr "Paste from 1"
 
-#: schematic/scheme/gschem/builtins.scm:177
 msgid "Sidebar"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:183
 #, fuzzy
 msgid "Find Text State"
 msgstr "Edit Text..."
 
-#: schematic/scheme/gschem/builtins.scm:186
 msgid "Redraw"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:192
 msgid "Pan Left"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:195
 msgid "Pan Right"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:198
 msgid "Pan Up"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:201
 msgid "Pan Down"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:216
 msgid "Zoom Full"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:219
 msgid "Dark Color Scheme"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:222
 msgid "Light Color Scheme"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:225
 msgid "Monochrome Color Scheme"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:228
 msgid "Show Color Scheme Editor"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:234
 msgid "Revert Changes"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:240
 #, fuzzy
 msgid "Previous Page"
 msgstr "Close Page"
 
-#: schematic/scheme/gschem/builtins.scm:243
 #, fuzzy
 msgid "Next Page"
 msgstr "New Page"
 
-#: schematic/scheme/gschem/builtins.scm:255
 #, fuzzy
 msgid "Print Page"
 msgstr "Close Page"
 
-#: schematic/scheme/gschem/builtins.scm:276
 #, fuzzy
 msgid "Add Line"
 msgstr "Line"
 
-#: schematic/scheme/gschem/builtins.scm:279
 msgid "Add Path"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:282
 msgid "Add Box"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:285
 #, fuzzy
 msgid "Add Circle"
 msgstr "Circle"
 
-#: schematic/scheme/gschem/builtins.scm:288
 msgid "Add Arc"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:291
 msgid "Add Pin"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:294
 msgid "Add Picture"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:306
 msgid "Up Hierarchy"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:312
 #, fuzzy
 msgid "Attach Attributes"
 msgstr "Attributes"
 
-#: schematic/scheme/gschem/builtins.scm:315
 #, fuzzy
 msgid "Detach Attributes"
 msgstr "Attributes"
 
-#: schematic/scheme/gschem/builtins.scm:318
 #, fuzzy
 msgid "Show Attribute Value"
 msgstr "Attributes"
 
-#: schematic/scheme/gschem/builtins.scm:321
 #, fuzzy
 msgid "Show Attribute Name"
 msgstr "Attributes"
 
-#: schematic/scheme/gschem/builtins.scm:327
 msgid "Toggle Text Visibility"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:330
 msgid "Find Specific Text"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:333
 msgid "Hide Specific Text"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:336
 msgid "Show Specific Text"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:339
 msgid "Autonumber Text"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:345
 #, fuzzy
 msgid "Show Hotkeys"
 msgstr "Hotkeys"
 
-#: schematic/scheme/gschem/builtins.scm:348
 msgid "Switch Grid Style"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:351
 msgid "Switch Snap Mode"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:354
 msgid "Set Grid Spacing"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:357
 msgid "Increase Grid Spacing"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:360
 msgid "Decrease Grid Spacing"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:363
 msgid "Toggle Outline Drawing"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:366
 msgid "Toggle Net Rubber Band"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:369
 msgid "Toggle Magnetic Nets"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:372
 #, fuzzy
 msgid "Show Log Window"
 msgstr "New Window"
 
-#: schematic/scheme/gschem/builtins.scm:375
 msgid "Show Coordinate Window"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:385
 msgid "Component Documentation"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:387
 msgid "View documentation for selected component"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:403
 msgid ""
 "Could not show documentation for selected component:\n"
 "\n"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:408
 msgid "gEDA Manuals"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:409
 msgid "View the front page of the gEDA documentation in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:414
 msgid "gschem User Guide"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:415
 msgid "View the gschem User Guide in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:420
 msgid "gschem FAQ"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:421
 msgid "Frequently Asked Questions about using gschem."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:426
 msgid "gEDA wiki"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:427
 msgid "View the front page of the gEDA wiki in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:431
 msgid "About gschem"
 msgstr "About gschem"
 
-#: schematic/scheme/gschem/deprecated.scm:102
 #, scheme-format
 msgid "Invalid text alignment ~A."
 msgstr ""
 
-#: schematic/scheme/gschem/gschemdoc.scm:241
 msgid "No documentation found"
 msgstr ""
 
-#: schematic/scheme/gschem/keymap.scm:40
 #, scheme-format
 msgid "~S is not a valid key combination."
 msgstr ""
 
-#: schematic/scheme/gschem/keymap.scm:157
 #, scheme-format
 msgid "~S is not a prefix key sequence."
 msgstr ""

--- a/schematic/po/fi.po
+++ b/schematic/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-15 15:13+0300\n"
+"POT-Creation-Date: 2019-02-22 14:08+0300\n"
 "PO-Revision-Date: 2012-01-27 14:18+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: Finnish <fi@li.org>\n"
@@ -18,22 +18,18 @@ msgstr ""
 "X-Launchpad-Export-Date: 2012-11-14 16:52+0000\n"
 "X-Generator: Launchpad (build 16265)\n"
 
-#: schematic/src/a_zoom.c:155
 msgid "Zoom too small!  Cannot zoom further."
 msgstr ""
 
-#: schematic/src/color_edit_widget.c:399
 #, c-format
 msgid ""
 "Could not save file [%s]:\n"
 "%s"
 msgstr ""
 
-#: schematic/src/color_edit_widget.c:434
 msgid "Save Color Scheme As..."
 msgstr ""
 
-#: schematic/src/color_edit_widget.c:482 schematic/src/x_fileselect.c:292
 #, c-format
 msgid ""
 "The selected file `%1$s' already exists.\n"
@@ -41,178 +37,140 @@ msgid ""
 "Would you like to overwrite it?"
 msgstr ""
 
-#: schematic/src/color_edit_widget.c:486 schematic/src/x_fileselect.c:295
 msgid "Overwrite file?"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:211
 msgid "_Apply"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:215
 msgid "Sa_ve..."
 msgstr ""
 
-#: schematic/src/font_select_widget.c:278
 #, c-format
 msgid "<b>Current:</b> %s"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:453
 msgid "Save configuration"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:461
 msgid "Save settings to:"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:465
 msgid "Local configuration file (in current directory)"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:467
 msgid "User configuration file (geda-user.conf)"
 msgstr ""
 
-#: schematic/src/g_attrib.c:90
 msgid "Object ~A is not included in the current gschem page."
 msgstr ""
 
-#: schematic/src/g_attrib.c:110
 msgid "Invalid text name/value visibility ~A."
 msgstr ""
 
-#: schematic/src/g_rc.c:107
 #, c-format
 msgid "You are running gEDA/gaf version [%1$s%2$s.%3$s],\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:111
 #, c-format
 msgid ""
 "but you have a version [%1$s] gschemrc file:\n"
 "[%2$s]\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:114
 #, c-format
 msgid "Please be sure that you have the latest rc file.\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:240
 #, fuzzy, c-format
 msgid "Invalid size [%1$d] passed to text-size\n"
 msgstr "Virheellinen koko [%d] annettu tekstin kooksi.\n"
 
-#: schematic/src/g_rc.c:283
 #, fuzzy, c-format
 msgid "Invalid size [%1$d] passed to snap-size\n"
 msgstr "virheellinen koko [%d] annettu apuruudukonkooksi.\n"
 
-#: schematic/src/g_rc.c:620
 #, fuzzy, c-format
 msgid "Invalid num levels [%1$d] passed to undo-levels\n"
 msgstr "Virheellinen määrä [%d] kumoamistasoja.\n"
 
-#: schematic/src/g_rc.c:831
 #, fuzzy, c-format
 msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
 msgstr "virheellinen koko [%d] annettu apuruudukonkooksi.\n"
 
-#: schematic/src/g_rc.c:931
 #, fuzzy, c-format
 msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
 msgstr "Virheellinen koko [%d] annettu tekstin kooksi.\n"
 
-#: schematic/src/g_rc.c:972
 #, fuzzy, c-format
 msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
 msgstr "Virheellinen määrä [%d] kumoamistasoja.\n"
 
-#: schematic/src/g_rc.c:998
 #, c-format
 msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1023
 #, fuzzy, c-format
 msgid "Invalid offset [%1$d] passed to add-attribute-offset\n"
 msgstr "Virheellinen koko [%d] annettu tekstin kooksi.\n"
 
-#: schematic/src/g_rc.c:1047
 #, fuzzy, c-format
 msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
 msgstr "Virheellinen määrä [%d] kumoamistasoja.\n"
 
-#: schematic/src/g_rc.c:1071
 #, fuzzy, c-format
 msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
 msgstr "virheellinen koko [%d] annettu apuruudukonkooksi.\n"
 
-#: schematic/src/g_rc.c:1094
 #, fuzzy, c-format
 msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
 msgstr "virheellinen koko [%d] annettu apuruudukonkooksi.\n"
 
-#: schematic/src/g_rc.c:1118
 #, fuzzy, c-format
 msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
 msgstr "Virheellinen määrä [%d] kumoamistasoja.\n"
 
-#: schematic/src/g_rc.c:1144
 #, fuzzy, c-format
 msgid "Invalid gain [%1$d] passed to zoom-gain\n"
 msgstr "Virheellinen koko [%d] annettu tekstin kooksi.\n"
 
-#: schematic/src/g_rc.c:1169
 #, c-format
 msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
 msgstr ""
 
-#: schematic/src/g_select.c:78 schematic/src/g_select.c:115
-#: schematic/src/g_select.c:151
 msgid "Object ~A is not directly included in a page."
 msgstr ""
 
-#: schematic/src/g_util.c:54
 msgid "Could not launch URI ~S: ~A"
 msgstr ""
 
-#: schematic/src/g_window.c:139
 msgid "Found invalid gschem window smob ~S"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:156
 #, c-format
 msgid "Lepton EDA/lepton-schematic version %1$s%2$s.%3$s git: %4$.7s"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:163
 #, c-format
 msgid "This is the MINGW32 port.\n"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:167
 #, c-format
 msgid "Current locale settings: %1$s\n"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:201
 #, c-format
 msgid "Couldn't find init scm file [%1$s]"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:206
 #, c-format
 msgid "Read init scm file [%1$s]"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:210
 #, c-format
 msgid "Failed to read init scm file [%1$s]"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:290
 #, c-format
 msgid ""
 "ERROR: Failed to load or evaluate startup script.\n"
@@ -220,690 +178,505 @@ msgid ""
 "The lepton-schematic log may contain more information.\n"
 msgstr ""
 
-#: schematic/src/gschem_about_dialog.c:51
 #, c-format
 msgid "%s (git: %.7s)"
 msgstr ""
 
-#: schematic/src/gschem_about_dialog.c:75
 msgid "Lepton Electronic Design Automation"
 msgstr ""
 
-#: schematic/src/gschem_about_dialog.c:83
 msgid ""
 "Copyright © 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright © 2017-2018 Lepton Developers.\n"
-"See AUTHORS and ChangeLog files for details."
+"Copyright © 2017-2019 Lepton Developers.\n"
+"See AUTHORS, ChangeLog files and consult 'git log' history for details."
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:69
 msgid "Upper Left"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:71
 msgid "Upper Middle"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:73
 msgid "Upper Right"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:78
 msgid "Middle Left"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:80
 msgid "Middle Middle"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:82
 msgid "Middle Right"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:87
 msgid "Lower Left"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:89
 msgid "Lower Middle"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:91
 msgid "Lower Right"
 msgstr ""
 
-#: schematic/src/gschem_arc_dialog.c:104
 msgid "Arc Params"
 msgstr ""
 
-#: schematic/src/gschem_arc_dialog.c:140
 msgid "Arc _Radius:"
 msgstr ""
 
-#: schematic/src/gschem_arc_dialog.c:141
 msgid "Start _Angle:"
 msgstr ""
 
-#: schematic/src/gschem_arc_dialog.c:142
 msgid "_Degrees of Sweep:"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:504
 msgid "Left mouse button"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:508
 msgid "Middle mouse button"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:512
 msgid "Right mouse button"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:595
 msgid "(Snap size, Grid size)"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:603
 msgid "Net rubber band mode"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:614
 msgid "Magnetic net mode"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:622
 msgid "Current action mode"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:935
-#: schematic/src/gschem_bottom_widget.c:951
 msgid "OFF"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:954
 msgid "NONE"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:960
 #, c-format
 msgid "Grid(%1$s, %2$s)"
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:350
-#: schematic/src/x_compselect.c:1236 schematic/src/x_multiattrib.c:2068
 msgid "Name"
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:372
 msgid "S_elect the schematics you want to save:"
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:467
 #, c-format
 msgid "Save the changes to schematic \"%1$s\" before closing?"
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:473
 #, c-format
 msgid ""
 "There are %1$d schematics with unsaved changes. Save changes before closing?"
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:502
 msgid "If you don't save, all your changes will be permanently lost."
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:522
 msgid "Close _without saving"
 msgstr ""
 
-#: schematic/src/gschem_coord_dialog.c:86
 msgid "Coords"
 msgstr ""
 
-#: schematic/src/gschem_coord_dialog.c:106
 msgid "Screen"
 msgstr ""
 
-#: schematic/src/gschem_coord_dialog.c:115
 msgid "World"
 msgstr ""
 
-#: schematic/src/gschem_find_text_state.c:809 schematic/src/x_pagesel.c:432
 msgid "Filename"
 msgstr ""
 
-#: schematic/src/gschem_find_text_state.c:821 schematic/src/i_callbacks.c:1970
-#: schematic/src/x_colorcb.c:154 schematic/src/x_widgets.c:179
-#: schematic/src/x_window.c:1226 schematic/src/x_window.c:1440
 msgid "Text"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:427
 msgid "descend into hierarchy"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:435
 msgid "Find"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:557
 #, fuzzy
 msgid "Find Text:"
 msgstr "Muokkaa tekstiä..."
 
-#: schematic/src/gschem_find_text_widget.c:564
 msgid "Find Pattern:"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:571
 msgid "Find Regex:"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:578
 msgid "Check symbol:"
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:200
 msgid "Hotkeys"
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:229
 msgid ""
 "Start typing action name or keystroke to filter the list.\n"
 "Type hotkeys as they are displayed in \"Keystroke(s)\" column."
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:233 schematic/src/x_compselect.c:1124
 #, fuzzy
 msgid "_Filter:"
 msgstr "_Tiedosto"
 
-#: schematic/src/gschem_hotkey_dialog.c:259 schematic/src/i_basic.c:280
 msgid "Action"
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:277
 msgid "Keystroke(s)"
 msgstr ""
 
-#: schematic/src/gschem_log_widget.c:177
 msgid "** Invalid UTF-8 in log message. See stderr or gschem.log.\n"
 msgstr ""
 
-#: schematic/src/gschem_log_widget.c:434
 #, fuzzy
 msgid "Clear log window?"
 msgstr "Uusi ikkuna"
 
-#: schematic/src/gschem_log_widget.c:477
 #, fuzzy
 msgid "Clear Log _Window"
 msgstr "Näytä _Loki-ikkuna..."
 
-#: schematic/src/gschem_macro_widget.c:231
 msgid "Macro:"
 msgstr ""
 
-#: schematic/src/gschem_macro_widget.c:387
 msgid "Evaluate"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:172
 #, fuzzy
 msgid "_Fill Type:"
 msgstr "Täyttö"
 
-#: schematic/src/gschem_object_properties_widget.c:173
 #, fuzzy
 msgid "Lin_e Width:"
 msgstr "viivan leveys ja tyyppi"
 
-#: schematic/src/gschem_object_properties_widget.c:174
 msgid "Angle _1:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:175
 msgid "P_itch 1:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:176
 msgid "Angle _2:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:177
 msgid "Pitc_h 2:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:237
 msgid "<b>Fill Properties</b>"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:255
-#: schematic/src/gschem_text_properties_widget.c:258
-#: schematic/src/x_newtext.c:271
 #, fuzzy
 msgid "Colo_r:"
 msgstr "Väri..."
 
-#: schematic/src/gschem_object_properties_widget.c:266
 msgid "<b>General Properties</b>"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:284
 #, fuzzy
 msgid "_Type:"
 msgstr "Täyttö"
 
-#: schematic/src/gschem_object_properties_widget.c:285
 #, fuzzy
 msgid "_Width:"
 msgstr "viivan leveys ja tyyppi"
 
-#: schematic/src/gschem_object_properties_widget.c:286
 msgid "Dash _Length:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:287
 msgid "Dash _Space:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:288
 msgid "C_ap style:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:333
 msgid "<b>Line Properties</b>"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:351
 #, fuzzy
 msgid "_Pin Type:"
 msgstr "Täyttö"
 
-#: schematic/src/gschem_object_properties_widget.c:362
 msgid "<b>Pin Properties</b>"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:217
 msgid "_Off"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:220
 msgid "_Dots"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:223
 msgid "M_esh"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:245
 msgid "Net R_ubber Band Mode:"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:246
 msgid "_Magnetic Net Mode:"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:250
-#: schematic/src/gschem_options_widget.c:251
 msgid "Enabled"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:265
 msgid "<b>Net Options</b>"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:282
 msgid "Grid Mode:"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:283
 #, fuzzy
 msgid "Snap Mode:"
 msgstr "Kopiointi"
 
-#: schematic/src/gschem_options_widget.c:284
 #, fuzzy
 msgid "_Snap Size:"
 msgstr "Kopiointi"
 
-#: schematic/src/gschem_options_widget.c:301
 msgid "<b>Snap Options</b>"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:340
 msgid "O_ff"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:343
 #, fuzzy
 msgid "_Grid"
 msgstr "Nosta Ruudukon Tiheyttä"
 
-#: schematic/src/gschem_options_widget.c:346
 msgid "_Resnap"
 msgstr ""
 
-#: schematic/src/gschem_pin_type_combo.c:73
 msgid "Net pin"
 msgstr ""
 
-#: schematic/src/gschem_pin_type_combo.c:80
 msgid "Bus pin (graphical)"
 msgstr ""
 
-#: schematic/src/gschem_preview.c:195
 msgid "Preview Buffer"
 msgstr ""
 
-#: schematic/src/gschem_show_hide_text_widget.c:148
-#: schematic/src/x_window.c:1268
 msgid "Hide"
 msgstr ""
 
-#: schematic/src/gschem_show_hide_text_widget.c:157
-#: schematic/src/x_window.c:1269
 msgid "Hide text starting with:"
 msgstr ""
 
-#: schematic/src/gschem_slot_edit_dialog.c:91
 msgid "Edit slot number"
 msgstr ""
 
-#: schematic/src/gschem_slot_edit_dialog.c:121
 msgid "Number of Slots:"
 msgstr ""
 
-#: schematic/src/gschem_slot_edit_dialog.c:122
 msgid "Slot Number:"
 msgstr ""
 
-#: schematic/src/gschem_text_properties_widget.c:240
-#: schematic/src/x_newtext.c:265
 msgid "<b>Text Content</b>"
 msgstr ""
 
-#: schematic/src/gschem_text_properties_widget.c:259
-#: schematic/src/x_newtext.c:291
 msgid "_Size:"
 msgstr ""
 
-#: schematic/src/gschem_text_properties_widget.c:260
-#: schematic/src/x_newtext.c:310
 msgid "Ali_gnment:"
 msgstr ""
 
-#: schematic/src/gschem_text_properties_widget.c:261
-#: schematic/src/x_newtext.c:330
 #, fuzzy
 msgid "Ro_tation:"
 msgstr "D_okumentaatio..."
 
-#: schematic/src/gschem_text_properties_widget.c:294
-#: schematic/src/x_newtext.c:253
 msgid "<b>Text Properties</b>"
 msgstr ""
 
-#: schematic/src/gschem_translate_widget.c:238
 #, fuzzy
 msgid "Coordinate:"
 msgstr "Näytä _Koordinaatti-ikkuna..."
 
-#: schematic/src/gschem_translate_widget.c:405 schematic/src/i_callbacks.c:800
 msgid "Translate"
 msgstr ""
 
-#: schematic/src/i_basic.c:64 schematic/src/x_window.c:1369
-#: schematic/scheme/conf/schematic/menu.scm:59
-#: schematic/scheme/gschem/builtins.scm:99
 msgid "Select Mode"
 msgstr "Valintatila"
 
-#: schematic/src/i_basic.c:65
 #, fuzzy
 msgid "Select Box Mode"
 msgstr "Valintatila"
 
-#: schematic/src/i_basic.c:66
 msgid "Text Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:67
 msgid "Pan Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:70
 #, c-format
 msgid "Paste %d Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:74
 msgid "Magnetic Net Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:76
 msgid "Net Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:77
 msgid "Arc Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:78
 msgid "Box Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:79
 msgid "Bus Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:80
 msgid "Circle Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:81
 msgid "Component Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:82 schematic/scheme/conf/schematic/menu.scm:62
-#: schematic/scheme/gschem/builtins.scm:114
 msgid "Copy Mode"
 msgstr "Kopiointi"
 
-#: schematic/src/i_basic.c:83 schematic/scheme/conf/schematic/menu.scm:63
-#: schematic/scheme/gschem/builtins.scm:117
 msgid "Multiple Copy Mode"
 msgstr "Kopioi useita"
 
-#: schematic/src/i_basic.c:84
 msgid "Line Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:85 schematic/scheme/conf/schematic/menu.scm:66
-#: schematic/scheme/gschem/builtins.scm:123
 msgid "Mirror Mode"
 msgstr "Peilaa"
 
-#: schematic/src/i_basic.c:86 schematic/scheme/conf/schematic/menu.scm:64
-#: schematic/scheme/gschem/builtins.scm:111
 msgid "Move Mode"
 msgstr "Siirrä"
 
-#: schematic/src/i_basic.c:87
 #, fuzzy
 msgid "Path Mode"
 msgstr "Käännä 90 astetta"
 
-#: schematic/src/i_basic.c:88
 msgid "Picture Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:89
 msgid "Pin Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:90 schematic/scheme/gschem/builtins.scm:120
 msgid "Rotate Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:91
 #, fuzzy
 msgid "Modify Mode"
 msgstr "Kopiointi"
 
-#: schematic/src/i_basic.c:92 schematic/src/x_menus.c:49
-#: schematic/scheme/gschem/builtins.scm:204
 msgid "Zoom Box"
 msgstr ""
 
-#: schematic/src/i_basic.c:121
 msgid "Show Hidden"
 msgstr ""
 
-#: schematic/src/i_basic.c:124
 msgid "Snap Off"
 msgstr ""
 
-#: schematic/src/i_basic.c:126
 msgid "Resnap Active"
 msgstr ""
 
-#: schematic/src/i_basic.c:288 schematic/src/x_colorcb.c:159
 msgid "Stroke"
 msgstr ""
 
-#: schematic/src/i_basic.c:296 schematic/src/i_basic.c:330
-#: schematic/src/x_window.c:1361
 msgid "none"
 msgstr ""
 
-#: schematic/src/i_basic.c:304
 msgid "Repeat/"
 msgstr ""
 
-#: schematic/src/i_basic.c:315
 msgid "Repeat/none"
 msgstr ""
 
-#: schematic/src/i_basic.c:323 schematic/src/i_callbacks.c:1239
-#: schematic/scheme/gschem/builtins.scm:189
 msgid "Pan"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:74
 #, c-format
 msgid "New page created [%1$s]"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:108
 #, c-format
 msgid "New Window created [%1$s]"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:245
 msgid "Failed to Save All"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:247
 msgid "Saved All"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:308
 #, fuzzy
 msgid "Closing Window"
 msgstr "Uusi ikkuna"
 
-#: schematic/src/i_callbacks.c:505 schematic/src/x_menus.c:55
-#: schematic/scheme/gschem/builtins.scm:168
 msgid "Copy"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:514 schematic/src/i_callbacks.c:539
-#: schematic/src/i_callbacks.c:564
 msgid "Select objs first"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:530
 msgid "Multiple Copy"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:555 schematic/src/x_menus.c:56
 msgid "Move"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:579 schematic/src/x_menus.c:57
-#: schematic/src/x_multiattrib.c:1656 schematic/scheme/gschem/builtins.scm:108
 msgid "Delete"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:603
 msgid "Edit"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:618 schematic/scheme/gschem/builtins.scm:129
 msgid "Edit Text"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:637
 msgid "Slot"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:688 schematic/src/i_callbacks.c:698
 msgid "Rotate"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:736 schematic/src/i_callbacks.c:746
 msgid "Mirror"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:763 schematic/src/x_colorcb.c:160
-#: schematic/scheme/conf/schematic/menu.scm:73
-#: schematic/scheme/gschem/builtins.scm:141
 msgid "Lock"
 msgstr "Lukitse"
 
-#: schematic/src/i_callbacks.c:781 schematic/scheme/conf/schematic/menu.scm:74
-#: schematic/scheme/gschem/builtins.scm:144
 msgid "Unlock"
 msgstr "Vapauta"
 
-#: schematic/src/i_callbacks.c:805
 msgid "WARNING: Do not translate with snap off!"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:806
 msgid "WARNING: Turning snap on and continuing with translate."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:813
 msgid "WARNING: Snap grid size is not equal to 100!"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:815
 msgid ""
 "WARNING: If you are translating a symbol to the origin, the snap grid size "
 "should be set to 100"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:847
 msgid "Embed"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:886
 msgid "Unembed"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:928
 msgid "Update"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:970
 msgid "ShowHidden"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1537
 #, c-format
 msgid ""
 "<b>Revert page:</b>\n"
@@ -914,99 +687,77 @@ msgid ""
 "discarded and page file will be reloaded from disk."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1555
 #, fuzzy
 msgid "Revert"
 msgstr "_Hylkää muutokset"
 
-#: schematic/src/i_callbacks.c:1647
 msgid "Copy to clipboard"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1664
 msgid "Cut to clipboard"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1686
 msgid "Paste from clipboard"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1694
 msgid "Empty clipboard"
 msgstr ""
 
 #. TRANSLATORS: The number is the number of the buffer that the
 #. * selection is being copied to.
-#: schematic/src/i_callbacks.c:1719
 #, fuzzy, c-format
 msgid "Copy %i"
 msgstr "Kopioi puskuriin 1"
 
 #. TRANSLATORS: The number is the number of the buffer that the
 #. * selection is being cut to.
-#: schematic/src/i_callbacks.c:1746
 #, fuzzy, c-format
 msgid "Cut %i"
 msgstr "Leikkaa puskuriin 1"
 
 #. TRANSLATORS: The number is the number of the buffer that is being
 #. * pasted to the schematic.
-#: schematic/src/i_callbacks.c:1776
 #, fuzzy, c-format
 msgid "Paste %i"
 msgstr "L_iitä"
 
-#: schematic/src/i_callbacks.c:1785
 msgid "Empty buffer"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1833 schematic/src/x_window.c:1203
 msgid "Component"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1865 schematic/src/x_colorcb.c:150
 msgid "Attribute"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1885 schematic/src/x_colorcb.c:149
 msgid "Net"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1928 schematic/src/x_colorcb.c:155
-#: schematic/src/x_window.c:1222
 msgid "Bus"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2004
 msgid "Line"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2021
 msgid "Path"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2043
 msgid "Box"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2085
 msgid "Circle"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2108
 msgid "Arc"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2131 schematic/src/x_colorcb.c:146
 msgid "Pin"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2191
 #, c-format
 msgid "Searching for source [%1$s]"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2223
 #, c-format
 msgid ""
 "Failed to descend hierarchy into '%1$s': %2$s\n"
@@ -1014,106 +765,81 @@ msgid ""
 "The lepton-schematic log may contain more information."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2227
 #, c-format
 msgid "Failed to descend into '%1$s': %2$s"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2234
 msgid "Failed to descend hierarchy."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2312
 #, c-format
 msgid "Searching for symbol [%1$s]"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2320
 msgid "Symbol is not a real file. Symbol cannot be loaded."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2367 schematic/src/x_tabs.c:1060
 msgid "Cannot find any schematics above the current one!"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2400
 msgid "Attach"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2456
 msgid "Detach"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2500
 msgid "ShowN"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2537
 msgid "ShowV"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2574
 msgid "ShowB"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2612
 msgid "VisToggle"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2643
 #, c-format
 msgid "Sorry but this is a non-functioning menu option\n"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2703
 msgid "Action feedback mode set to OUTLINE"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2706
 msgid "Action feedback mode set to BOUNDINGBOX"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2730
 msgid "Grid OFF"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2731
 msgid "Dot grid selected"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2732
 msgid "Mesh grid selected"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2733
 msgid "Invalid grid mode"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2755
 msgid "Snap OFF (CAUTION!)"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2758
 msgid "Snap ON"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2761
 msgid "Snap back to the grid (CAUTION!)"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2790
 msgid "Rubber band ON"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2792
 msgid "Rubber band OFF"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2811
 msgid "magnetic net mode: ON"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2814
 msgid "magnetic net mode: OFF"
 msgstr ""
 
@@ -1122,134 +848,105 @@ msgstr ""
 #. the form "untitled_N.sch", where N is a number.  Please make
 #. sure that the translation contains characters suitable for use
 #. in a filename.
-#: schematic/src/i_vars.c:209
 msgid "untitled"
 msgstr ""
 
-#: schematic/src/o_complex.c:192 schematic/src/o_complex.c:195
 #, c-format
 msgid "Translating schematic [%1$d %2$d]"
 msgstr ""
 
-#: schematic/src/o_delete.c:82
 #, c-format
 msgid "Delete locked object?"
 msgid_plural "Delete %1$u locked objects?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/o_misc.c:55
 #, c-format
 msgid "Got an unexpected NULL in o_edit\n"
 msgstr ""
 
-#: schematic/src/o_misc.c:315
 msgid "Hidden text is now visible"
 msgstr ""
 
-#: schematic/src/o_misc.c:317
 msgid "Hidden text is now invisible"
 msgstr ""
 
-#: schematic/src/o_misc.c:425
 #, c-format
 msgid "Could not find symbol [%1$s] in library. Update failed."
 msgstr ""
 
-#: schematic/src/o_misc.c:541
 #, c-format
 msgid "o_autosave_backups: Can't get the real filename of %1$s."
 msgstr ""
 
-#: schematic/src/o_misc.c:585
 #, c-format
 msgid "Could NOT set previous backup file [%1$s] read-write"
 msgstr ""
 
-#: schematic/src/o_misc.c:605
 #, c-format
 msgid "Could NOT set backup file [%1$s] readonly"
 msgstr ""
 
-#: schematic/src/o_misc.c:610
 #, c-format
 msgid "Could NOT save backup file [%1$s]"
 msgstr ""
 
-#: schematic/src/o_move.c:192
 #, c-format
 msgid "ERROR: NULL object in o_move_end!\n"
 msgstr ""
 
-#: schematic/src/o_move.c:519
 #, c-format
 msgid "DOH! tried to find the whichone, but didn't find it!\n"
 msgstr ""
 
-#: schematic/src/o_move.c:546
 #, c-format
 msgid "Got a non line object in o_move_check_endpoint\n"
 msgstr ""
 
-#: schematic/src/o_net.c:444
 msgid "Warning: Starting net at off grid coordinate"
 msgstr ""
 
-#: schematic/src/o_net.c:508
 msgid "Warning: Ending net at off grid coordinate"
 msgstr ""
 
-#: schematic/src/o_net.c:856 schematic/src/o_net.c:893
-#: schematic/src/o_net.c:964 schematic/src/o_net.c:1000
 #, c-format
 msgid "Tried to add more than two bus rippers. Internal gschem error.\n"
 msgstr ""
 
-#: schematic/src/o_net.c:1068
 #, c-format
 msgid "Bus ripper symbol [%1$s] was not found in any component library"
 msgstr ""
 
-#: schematic/src/o_picture.c:133 schematic/src/o_picture.c:343
 msgid "Select a picture file..."
 msgstr ""
 
-#: schematic/src/o_picture.c:166
 #, c-format
 msgid "Failed to load picture: %1$s"
 msgstr ""
 
-#: schematic/src/o_picture.c:182
 msgid "Picture"
 msgstr ""
 
-#: schematic/src/o_picture.c:378
 #, c-format
 msgid "Failed to replace pictures: %s"
 msgstr ""
 
-#: schematic/src/o_slot.c:80
 #, fuzzy
 msgid "Slot attribute malformed"
 msgstr "Näytä _Nimi"
 
-#: schematic/src/o_slot.c:88
 msgid "numslots attribute missing"
 msgstr ""
 
-#: schematic/src/o_slot.c:89
 msgid "Slotting not allowed for this component"
 msgstr ""
 
-#: schematic/src/o_slot.c:104
 msgid "New slot number out of range"
 msgstr ""
 
-#: schematic/src/o_undo.c:397
 msgid "Undo/Redo disabled in rc file"
 msgstr ""
 
-#: schematic/src/parsecmd.c:77
 #, c-format
 msgid ""
 "Usage: %1$s [OPTION ...] [--] [FILE ...]\n"
@@ -1274,188 +971,144 @@ msgid ""
 "gEDA/gaf homepage: <http://www.geda-project.org/>\n"
 msgstr ""
 
-#: schematic/src/parsecmd.c:110
 #, c-format
 msgid ""
 "Lepton EDA %1$s (git: %2$.7s)\n"
 "Copyright (C) 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright (C) 2017-2018 Lepton Developers.\n"
+"Copyright (C) 2017-2019 Lepton Developers.\n"
 "This is free software, and you are welcome to redistribute it under\n"
 "certain conditions. For details, see the file `COPYING', which is\n"
 "included in the Lepton EDA distribution.\n"
 "There is NO WARRANTY, to the extent permitted by law.\n"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:125
 #, c-format
 msgid "Got invalid show option; defaulting to show both\n"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:139
 #, c-format
 msgid "ERROR: NULL object!\n"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:328
 msgid "Single Attribute Editor"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:358
 msgid "<b>Edit Attribute</b>"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:360
 msgid "<b>Add Attribute</b>"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:376
 msgid "N_ame:"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:396 schematic/src/x_multiattrib.c:2222
 #, fuzzy
 msgid "_Value:"
 msgstr "Näytä _Arvo"
 
-#: schematic/src/x_attribedit.c:415 schematic/src/x_multiattrib.c:2281
 msgid "Vi_sible"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:434
 msgid "Show Value Only"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:436
 msgid "Show Name Only"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:438 schematic/src/x_multiattrib.c:1620
-#: schematic/scheme/gschem/builtins.scm:324
 msgid "Show Name & Value"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:445
 msgid "<b>Attach Options</b>"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:460
 msgid "All"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:476 schematic/src/x_compselect.c:986
-#: schematic/src/x_compselect.c:1100
 msgid "Components"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:492 schematic/src/x_window.c:1214
 msgid "Nets"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:508
 msgid "Replace existing attributes"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:412
 msgid ""
 "slotted object without slot attribute may cause problems when autonumbering "
 "slots"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:427
 #, c-format
 msgid ""
 "duplicate slot may cause problems: [symbolname=%1$s, number=%2$d, slot=%3$d]"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:675
 msgid "No searchstring given in autonumber text."
 msgstr ""
 
-#: schematic/src/x_autonumber.c:728
 msgid "No '*' or '?' given at the end of the autonumber text."
 msgstr ""
 
-#: schematic/src/x_autonumber.c:873
 msgid "Diagonal"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:874
 msgid "Top to bottom"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:875
 msgid "Bottom to top"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:876
 msgid "Left to right"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:877
 msgid "Right to left"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:878
 msgid "File order"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1214
 msgid "Autonumber text"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1237
 msgid "<b>Scope</b>"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1259
 msgid "Search for:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1273
 msgid "Autonumber text in:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1280
 msgid "Skip numbers found in:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1292 schematic/src/x_autonumber.c:1301
 msgid "Selected objects"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1293 schematic/src/x_autonumber.c:1302
 msgid "Current page"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1294 schematic/src/x_autonumber.c:1303
 msgid "Whole hierarchy"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1305
 msgid "Overwrite existing numbers"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1310
 msgid "<b>Options</b>"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1332
 msgid "Starting number:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1339
 msgid "Sort order:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1371
 msgid "Remove numbers"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1375
 msgid "Automatic slotting"
 msgstr ""
 
-#: schematic/src/x_clipboard.c:245
 #, c-format
 msgid ""
 "<b>Invalid schematic on clipboard.</b>\n"
@@ -1463,174 +1116,134 @@ msgid ""
 "An error occurred while inserting clipboard data: %s."
 msgstr ""
 
-#: schematic/src/x_clipboard.c:247
 msgid "Clipboard insertion failed"
 msgstr ""
 
-#: schematic/src/x_color.c:89 schematic/src/x_color.c:98
 #, c-format
 msgid "Could not allocate the color %1$s!\n"
 msgstr ""
 
-#: schematic/src/x_color.c:89
 msgid "black"
 msgstr ""
 
-#: schematic/src/x_color.c:98
 msgid "white"
 msgstr ""
 
-#: schematic/src/x_color.c:120
 #, c-format
 msgid "Could not allocate display color %1$i!\n"
 msgstr ""
 
-#: schematic/src/x_color.c:142
 #, c-format
 msgid "Could not allocate outline color %1$i!\n"
 msgstr ""
 
-#: schematic/src/x_color.c:159
 #, c-format
 msgid "Tried to get an invalid color: %1$d\n"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:145
 msgid "Background"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:147
 msgid "Net endpoint"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:148
 msgid "Graphic"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:151
 msgid "Logic bubble"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:152
 #, fuzzy
 msgid "Grid point"
 msgstr "Nosta Ruudukon Tiheyttä"
 
-#: schematic/src/x_colorcb.c:153
 #, fuzzy
 msgid "Detached attribute"
 msgstr "Määri_tteet..."
 
-#: schematic/src/x_colorcb.c:156
 #, fuzzy
 msgid "Selection"
 msgstr "Valintatila"
 
-#: schematic/src/x_colorcb.c:157
 msgid "Bounding box"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:158
 #, fuzzy
 msgid "Zoom box"
 msgstr "_Lähennä"
 
-#: schematic/src/x_colorcb.c:161
 msgid "Output background"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:162
 msgid "Freestyle 1"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:163
 msgid "Freestyle 2"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:164
 msgid "Freestyle 3"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:165
 msgid "Freestyle 4"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:166
 msgid "Net junction"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:167
 msgid "Mesh grid major"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:168
 msgid "Mesh grid minor"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:172
 msgid "Unknown"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1169
 msgid "Reset filter"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1192
 msgid "Reload all libraries"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1245 schematic/src/x_multiattrib.c:2092
 msgid "Value"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1284
 msgid "Default behavior - reference component"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1287
 msgid "Embed component in schematic"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1290
 msgid "Include component as individual objects"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1448
 msgid "Select Component..."
 msgstr ""
 
-#: schematic/src/x_compselect.c:1471
 msgid "In Us_e"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1475
 msgid "Lib_raries"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1484 schematic/src/x_fileselect.c:119
 msgid "Preview"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1510
 msgid "Attributes"
 msgstr ""
 
-#: schematic/src/x_dialog.c:325
 msgid "Major symbol changes detected."
 msgstr ""
 
-#: schematic/src/x_dialog.c:349
 msgid ""
 "Changes have occurred to the symbols shown below.\n"
 "\n"
 "Be sure to verify each of these symbols."
 msgstr ""
 
-#: schematic/src/x_dialog.c:369
 msgid "Symbol"
 msgstr ""
 
-#: schematic/src/x_dialog.c:406
 #, c-format
 msgid ""
 "<span weight=\"bold\" size=\"larger\">The input attribute \"%s\" is invalid\n"
@@ -1641,39 +1254,30 @@ msgid ""
 "The value cannot start with a space."
 msgstr ""
 
-#: schematic/src/x_dialog.c:408
 msgid "Invalid Attribute"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:37
 msgid "Schematics"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:42
 msgid "Symbols"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:47
 msgid "Schematics and symbols"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:53
 msgid "All files"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:169
 msgid "Open..."
 msgstr ""
 
-#: schematic/src/x_fileselect.c:233
 msgid "Save as..."
 msgstr ""
 
-#: schematic/src/x_fileselect.c:297
 msgid "Save cancelled on user request"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:334
 msgid ""
 "\n"
 "If you load the original file, the backup file will be overwritten in the "
@@ -1682,28 +1286,22 @@ msgid ""
 "Do you want to load the backup file?\n"
 msgstr ""
 
-#: schematic/src/x_fstylecb.c:73
 msgid "Hollow"
 msgstr ""
 
-#: schematic/src/x_fstylecb.c:80
 msgid "Filled"
 msgstr ""
 
-#: schematic/src/x_fstylecb.c:87
 msgid "Mesh"
 msgstr ""
 
-#: schematic/src/x_fstylecb.c:94
 msgid "Hatch"
 msgstr ""
 
-#: schematic/src/x_image.c:279
 #, c-format
 msgid "x_image_lowlevel: Unable to write %1$s file %2$s."
 msgstr ""
 
-#: schematic/src/x_image.c:289
 #, c-format
 msgid ""
 "There was the following error when saving image with type %1$s to filename:\n"
@@ -1712,303 +1310,236 @@ msgid ""
 "%3$s.\n"
 msgstr ""
 
-#: schematic/src/x_image.c:309
 #, c-format
 msgid "Wrote color image to [%1$s] [%2$d x %3$d]"
 msgstr ""
 
-#: schematic/src/x_image.c:311
 #, c-format
 msgid "Wrote black and white image to [%1$s] [%2$d x %3$d]"
 msgstr ""
 
-#: schematic/src/x_image.c:319
 msgid "x_image_lowlevel: Unable to get pixbuf from gschem's window."
 msgstr ""
 
-#: schematic/src/x_image.c:358
 msgid "Width x Height"
 msgstr ""
 
-#: schematic/src/x_image.c:374
 msgid "Image type"
 msgstr ""
 
-#: schematic/src/x_image.c:395
 msgid "Write image..."
 msgstr ""
 
-#: schematic/src/x_linecapcb.c:74
 msgid "Butt"
 msgstr ""
 
-#: schematic/src/x_linecapcb.c:81
 msgid "Square"
 msgstr ""
 
-#: schematic/src/x_linecapcb.c:88
 msgid "Round"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:74
 msgid "Solid"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:81
 msgid "Dotted"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:88
 msgid "Dashed"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:95
 msgid "Center"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:102
 msgid "Phantom"
 msgstr ""
 
-#: schematic/src/x_menus.c:41 schematic/scheme/gschem/builtins.scm:267
 msgid "Add Net"
 msgstr ""
 
-#: schematic/src/x_menus.c:42 schematic/src/x_multiattrib.c:2187
-#: schematic/scheme/gschem/builtins.scm:264
 msgid "Add Attribute"
 msgstr ""
 
-#: schematic/src/x_menus.c:43 schematic/scheme/gschem/builtins.scm:261
 #, fuzzy
 msgid "Add Component"
 msgstr "Päivitä komponentti"
 
-#: schematic/src/x_menus.c:44 schematic/scheme/gschem/builtins.scm:270
 msgid "Add Bus"
 msgstr ""
 
-#: schematic/src/x_menus.c:45 schematic/scheme/gschem/builtins.scm:273
 #, fuzzy
 msgid "Add Text"
 msgstr "Muokkaa tekstiä..."
 
-#: schematic/src/x_menus.c:47 schematic/scheme/gschem/builtins.scm:210
 #, fuzzy
 msgid "Zoom In"
 msgstr "_Lähennä"
 
-#: schematic/src/x_menus.c:48 schematic/scheme/gschem/builtins.scm:213
 #, fuzzy
 msgid "Zoom Out"
 msgstr "L_oitonna"
 
-#: schematic/src/x_menus.c:50 schematic/scheme/gschem/builtins.scm:207
 #, fuzzy
 msgid "Zoom Extents"
 msgstr "_Lähennä"
 
-#: schematic/src/x_menus.c:52 schematic/src/x_window.c:1233
 msgid "Select"
 msgstr ""
 
-#: schematic/src/x_menus.c:53 schematic/scheme/conf/schematic/menu.scm:69
-#: schematic/scheme/gschem/builtins.scm:126
 msgid "Edit..."
 msgstr "Muokkaa..."
 
-#: schematic/src/x_menus.c:54 schematic/scheme/conf/schematic/menu.scm:68
 msgid "Object Properties..."
 msgstr ""
 
-#: schematic/src/x_menus.c:59 schematic/scheme/gschem/builtins.scm:300
 msgid "Down Schematic"
 msgstr ""
 
-#: schematic/src/x_menus.c:60 schematic/scheme/gschem/builtins.scm:303
 msgid "Down Symbol"
 msgstr ""
 
-#: schematic/src/x_menus.c:61
 #, fuzzy
 msgid "Up"
 msgstr "_Ylös"
 
-#: schematic/src/x_menus.c:336
 #, c-format
 msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
 msgstr ""
 
-#: schematic/src/x_menus.c:360
 #, c-format
 msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
 msgstr ""
 
-#: schematic/src/x_misc.c:70
 msgid "The operating system is out of memory or resources."
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:798 schematic/src/x_multiattrib.c:2704
 msgid "<various>"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:930
 msgid "Attributes with empty name are not allowed. Please set a name."
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1622
 msgid "Show Value only"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1624
 msgid "Show Name only"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1651
 msgid "Promote"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1655
 msgid "Duplicate"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1657
 #, fuzzy
 msgid "Copy to all"
 msgstr "Kopioi puskuriin 1"
 
-#: schematic/src/x_multiattrib.c:1986 schematic/src/x_multiattrib.c:2602
 msgid "Edit Attributes"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2112
 msgid "Vis?"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2130
 msgid "N"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2148
 msgid "V"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2170
 #, fuzzy
 msgid "Sho_w inherited attributes"
 msgstr "Määri_tteet..."
 
-#: schematic/src/x_multiattrib.c:2197
 #, fuzzy
 msgid "_Name:"
 msgstr "Näytä _Nimi"
 
-#: schematic/src/x_multiattrib.c:2241
 msgid "Ctrl+Enter inserts new line; Ctrl+Tab inserts Tab"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2618
 #, c-format
 msgid "%2$i symbol (%1$s)"
 msgid_plural "%2$i symbols (%1$s)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2624
 #, c-format
 msgid "%1$i pin"
 msgid_plural "%1$i pins"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2630
 #, c-format
 msgid "%1$i net"
 msgid_plural "%1$i nets"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2636
 #, c-format
 msgid "%1$i bus"
 msgid_plural "%1$i buses"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2642
 #, fuzzy, c-format
 msgid "%1$i attribute"
 msgid_plural "%1$i attributes"
 msgstr[0] "Määri_tteet..."
 msgstr[1] "Määri_tteet..."
 
-#: schematic/src/x_newtext.c:433
 #, fuzzy
 msgid "Text Entry..."
 msgstr "_Teksti..."
 
-#: schematic/src/x_pagesel.c:253
 msgid "New Page"
 msgstr ""
 
-#: schematic/src/x_pagesel.c:254
 msgid "Open Page..."
 msgstr ""
 
-#: schematic/src/x_pagesel.c:256
 msgid "Save Page"
 msgstr ""
 
-#: schematic/src/x_pagesel.c:257 schematic/scheme/gschem/builtins.scm:246
 msgid "Close Page"
 msgstr ""
 
-#: schematic/src/x_pagesel.c:376 schematic/scheme/gschem/builtins.scm:237
 msgid "Page Manager"
 msgstr ""
 
-#: schematic/src/x_pagesel.c:448
 msgid "Changed"
 msgstr ""
 
-#: schematic/src/x_pagesel.c:468
 msgid "Right click on the filename for more options..."
 msgstr ""
 
-#: schematic/src/x_print.c:306
 #, c-format
 msgid "Failed to write PDF to '%s': %s\n"
 msgstr ""
 
-#: schematic/src/x_print.c:364
 #, c-format
 msgid "Failed to write PDF to '%1$s': %2$s\n"
 msgstr ""
 
-#: schematic/src/x_print.c:449
 #, c-format
 msgid ""
 "Error printing file:\n"
 "%1$s"
 msgstr ""
 
-#: schematic/src/x_rc.c:39
 msgid "ERROR: An unknown error occurred while parsing configuration files."
 msgstr ""
 
-#: schematic/src/x_rc.c:44
 msgid ""
 "An unknown error occurred while parsing configuration files.\n"
 "\n"
 "The lepton-schematic log may contain more information."
 msgstr ""
 
-#: schematic/src/x_rc.c:56
 #, c-format
 msgid "ERROR: %1$s"
 msgstr ""
 
-#: schematic/src/x_rc.c:59
 #, c-format
 msgid ""
 "%1$s\n"
@@ -2016,136 +1547,105 @@ msgid ""
 "The lepton-schematic log may contain more information."
 msgstr ""
 
-#: schematic/src/x_rc.c:67
 msgid "Cannot load lepton-schematic configuration."
 msgstr ""
 
-#: schematic/src/x_script.c:42 schematic/scheme/conf/schematic/menu.scm:40
 msgid "Execute Script..."
 msgstr "Aja skripti"
 
-#: schematic/src/x_script.c:61
 #, c-format
 msgid "Executing guile script [%1$s]"
 msgstr ""
 
-#: schematic/src/x_tabs.c:860
 #, c-format
 msgid "Hierarchy up: %s"
 msgstr ""
 
-#: schematic/src/x_tabs.c:863
 msgid "Hierarchy up"
 msgstr ""
 
-#: schematic/src/x_widgets.c:158 schematic/src/x_window.c:1444
 msgid "Options"
 msgstr ""
 
-#: schematic/src/x_widgets.c:203 schematic/src/x_window.c:1436
 msgid "Object"
 msgstr ""
 
-#: schematic/src/x_widgets.c:224
 msgid "Log"
 msgstr ""
 
-#: schematic/src/x_widgets.c:245 schematic/src/x_window.c:1466
 msgid "Find Text"
 msgstr ""
 
-#: schematic/src/x_widgets.c:259
 msgid "Color Scheme Editor"
 msgstr ""
 
-#: schematic/src/x_widgets.c:272 schematic/scheme/gschem/builtins.scm:378
 #, fuzzy
 msgid "Select Schematic Font"
 msgstr "Valintatila"
 
-#: schematic/src/x_window.c:763
 #, c-format
 msgid "Loading schematic [%1$s]"
 msgstr ""
 
-#: schematic/src/x_window.c:864
 #, c-format
 msgid "Could NOT save page [%1$s]\n"
 msgstr ""
 
-#: schematic/src/x_window.c:865
 msgid "Error while trying to save"
 msgstr ""
 
-#: schematic/src/x_window.c:875
 msgid "Failed to save file"
 msgstr ""
 
-#: schematic/src/x_window.c:885
 #, fuzzy, c-format
 msgid "Saved as [%1$s]"
 msgstr "Tallenna _kaikki"
 
-#: schematic/src/x_window.c:887
 #, fuzzy, c-format
 msgid "Saved [%1$s]"
 msgstr "Tallenna _kaikki"
 
-#: schematic/src/x_window.c:889
 msgid "Saved"
 msgstr ""
 
-#: schematic/src/x_window.c:966
 #, c-format
 msgid "Discarding page [%1$s]"
 msgstr ""
 
-#: schematic/src/x_window.c:966
 #, c-format
 msgid "Closing [%1$s]"
 msgstr ""
 
-#: schematic/src/x_window.c:1175
 msgid "New"
 msgstr ""
 
-#: schematic/src/x_window.c:1175
 msgid "New file"
 msgstr ""
 
-#: schematic/src/x_window.c:1179
 msgid "Open"
 msgstr ""
 
-#: schematic/src/x_window.c:1179
 msgid "Open file"
 msgstr ""
 
-#: schematic/src/x_window.c:1183 schematic/scheme/gschem/builtins.scm:59
 msgid "Save"
 msgstr ""
 
-#: schematic/src/x_window.c:1183
 msgid "Save file"
 msgstr ""
 
-#: schematic/src/x_window.c:1189 schematic/scheme/gschem/builtins.scm:93
 msgid "Undo"
 msgstr ""
 
-#: schematic/src/x_window.c:1189
 msgid "Undo last operation"
 msgstr ""
 
-#: schematic/src/x_window.c:1193 schematic/scheme/gschem/builtins.scm:96
 msgid "Redo"
 msgstr ""
 
-#: schematic/src/x_window.c:1193
 msgid "Redo last undo"
 msgstr ""
 
-#: schematic/src/x_window.c:1198
 msgid ""
 "Add component...\n"
 "Select library and component from list, move the mouse into main window, "
@@ -2153,56 +1653,44 @@ msgid ""
 "Right mouse button to cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1209
 msgid ""
 "Add nets mode\n"
 "Right mouse button to cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1217
 msgid ""
 "Add buses mode\n"
 "Right mouse button to cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1226
 msgid "Add Text..."
 msgstr ""
 
-#: schematic/src/x_window.c:1233
 msgid "Select mode"
 msgstr ""
 
-#: schematic/src/x_window.c:1288
 msgid "Show"
 msgstr ""
 
-#: schematic/src/x_window.c:1289
 msgid "Show text starting with:"
 msgstr ""
 
-#: schematic/src/x_window.c:1345
 msgid "Menu/Cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1349
 msgid "Pan/Cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1359
 msgid "Pick"
 msgstr ""
 
-#: schematic/src/x_window.c:1470 schematic/scheme/gschem/builtins.scm:180
 msgid "Status"
 msgstr ""
 
-#: schematic/src/x_window.c:1568
 #, fuzzy, c-format
 msgid "New file [%s]"
 msgstr "_Tiedosto"
 
-#: schematic/src/x_window.c:1598
 #, c-format
 msgid ""
 "<b>An error occurred while loading the requested file.</b>\n"
@@ -2216,873 +1704,663 @@ msgid ""
 "monitor program's output in terminal window."
 msgstr ""
 
-#: schematic/src/x_window.c:1617
 msgid "Failed to load file"
 msgstr ""
 
-#: schematic/data/lepton-schematic.desktop.in:3
 msgid "Lepton EDA Schematic Editor"
 msgstr ""
 
-#: schematic/data/lepton-schematic.desktop.in:4
 msgid "Create and edit electrical schematics and symbols with lepton-schematic"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:27
 msgid "_New"
 msgstr "_Uusi"
 
-#: schematic/scheme/conf/schematic/menu.scm:28
 msgid "_Open..."
 msgstr "_Avaa…"
 
-#: schematic/scheme/conf/schematic/menu.scm:30
 msgid "Open Recen_t"
 msgstr "_Viimeisimmät tiedostot"
 
-#: schematic/scheme/conf/schematic/menu.scm:32
 msgid "_Save"
 msgstr "_Tallenna"
 
-#: schematic/scheme/conf/schematic/menu.scm:33
 msgid "Save _As..."
 msgstr "Tallenna _nimellä..."
 
-#: schematic/scheme/conf/schematic/menu.scm:34
-#: schematic/scheme/gschem/builtins.scm:65
 msgid "Save All"
 msgstr "Tallenna _kaikki"
 
-#: schematic/scheme/conf/schematic/menu.scm:36
 msgid "_Print..."
 msgstr "T_ulosta…"
 
-#: schematic/scheme/conf/schematic/menu.scm:37
 #, fuzzy
 msgid "Write _Image..."
 msgstr "_Vie kuvaksi..."
 
-#: schematic/scheme/conf/schematic/menu.scm:39
 #, fuzzy
 msgid "Invoke Macro..."
 msgstr "Suorita makro"
 
-#: schematic/scheme/conf/schematic/menu.scm:41
 msgid "REPL..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:43
-#: schematic/scheme/gschem/builtins.scm:77
 msgid "New Window"
 msgstr "Uusi ikkuna"
 
-#: schematic/scheme/conf/schematic/menu.scm:44
 msgid "_Close Window"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:45
 msgid "_Quit"
 msgstr "L_opeta"
 
-#: schematic/scheme/conf/schematic/menu.scm:51
 msgid "_Undo"
 msgstr "K_umoa"
 
-#: schematic/scheme/conf/schematic/menu.scm:52
 msgid "_Redo"
 msgstr "_Tee uudelleen"
 
-#: schematic/scheme/conf/schematic/menu.scm:54
 msgid "Cu_t"
 msgstr "_Leikkaa"
 
-#: schematic/scheme/conf/schematic/menu.scm:55
 msgid "_Copy"
 msgstr "_Kopioi"
 
-#: schematic/scheme/conf/schematic/menu.scm:56
 msgid "_Paste"
 msgstr "L_iitä"
 
-#: schematic/scheme/conf/schematic/menu.scm:57
 msgid "_Delete"
 msgstr "_Poista"
 
-#: schematic/scheme/conf/schematic/menu.scm:60
-#: schematic/scheme/gschem/builtins.scm:102
 msgid "Select All"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:61
-#: schematic/scheme/gschem/builtins.scm:105
 msgid "Deselect"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:65
 msgid "Rotate 90 Mode"
 msgstr "Käännä 90 astetta"
 
-#: schematic/scheme/conf/schematic/menu.scm:70
 msgid "Edit Text..."
 msgstr "Muokkaa tekstiä..."
 
-#: schematic/scheme/conf/schematic/menu.scm:71
 msgid "Slot..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:76
-#: schematic/scheme/gschem/builtins.scm:150
 msgid "Embed Component/Picture"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:77
-#: schematic/scheme/gschem/builtins.scm:153
 msgid "Unembed Component/Picture"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:78
-#: schematic/scheme/gschem/builtins.scm:156
 msgid "Update Component"
 msgstr "Päivitä komponentti"
 
-#: schematic/scheme/conf/schematic/menu.scm:79
 msgid "Symbol Translate..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:85
 msgid "Copy into 1"
 msgstr "Kopioi puskuriin 1"
 
-#: schematic/scheme/conf/schematic/menu.scm:86
 msgid "Copy into 2"
 msgstr "Kopioi puskuriin 2"
 
-#: schematic/scheme/conf/schematic/menu.scm:87
 msgid "Copy into 3"
 msgstr "Kopioi puskuriin 3"
 
-#: schematic/scheme/conf/schematic/menu.scm:88
 msgid "Copy into 4"
 msgstr "Kopioi puskuriin 4"
 
-#: schematic/scheme/conf/schematic/menu.scm:89
 msgid "Copy into 5"
 msgstr "Kopioi puskuriin 5"
 
-#: schematic/scheme/conf/schematic/menu.scm:90
 msgid "Cut into 1"
 msgstr "Leikkaa puskuriin 1"
 
-#: schematic/scheme/conf/schematic/menu.scm:91
 msgid "Cut into 2"
 msgstr "Leikkaa puskuriin 2"
 
-#: schematic/scheme/conf/schematic/menu.scm:92
 msgid "Cut into 3"
 msgstr "Leikkaa puskuriin 3"
 
-#: schematic/scheme/conf/schematic/menu.scm:93
 msgid "Cut into 4"
 msgstr "Leikkaa puskuriin 4"
 
-#: schematic/scheme/conf/schematic/menu.scm:94
 msgid "Cut into 5"
 msgstr "Leikkaa puskuriin 5"
 
-#: schematic/scheme/conf/schematic/menu.scm:95
 msgid "Paste from 1"
 msgstr "Liitä puskurista 1"
 
-#: schematic/scheme/conf/schematic/menu.scm:96
 msgid "Paste from 2"
 msgstr "Liitä puskurista 2"
 
-#: schematic/scheme/conf/schematic/menu.scm:97
 msgid "Paste from 3"
 msgstr "Liitä puskurista 3"
 
-#: schematic/scheme/conf/schematic/menu.scm:98
 msgid "Paste from 4"
 msgstr "Liitä puskurista 4"
 
-#: schematic/scheme/conf/schematic/menu.scm:99
 msgid "Paste from 5"
 msgstr "Liitä puskurista 5"
 
-#: schematic/scheme/conf/schematic/menu.scm:105
 msgid "Side Dock"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:106
 msgid "Bottom Dock"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:108
 #, fuzzy
 msgid "Find Text Results"
 msgstr "Muokkaa tekstiä..."
 
-#: schematic/scheme/conf/schematic/menu.scm:110
 msgid "_Redraw"
 msgstr "_Päivitä näkymä"
 
-#: schematic/scheme/conf/schematic/menu.scm:111
 msgid "_Pan"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:112
 msgid "Zoom _Box"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:113
 msgid "Zoom _Extents"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:114
 msgid "Zoom _In"
 msgstr "_Lähennä"
 
-#: schematic/scheme/conf/schematic/menu.scm:115
 msgid "Zoom _Out"
 msgstr "L_oitonna"
 
-#: schematic/scheme/conf/schematic/menu.scm:116
 msgid "Zoom _Full"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:118
 msgid "_Dark Color Scheme"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:119
 msgid "_Light Color Scheme"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:120
 msgid "B_W Color Scheme"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:122
 msgid "Color Scheme Editor..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:129
 msgid "_Manager..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:131
 msgid "_Previous"
 msgstr "_Edellinen"
 
-#: schematic/scheme/conf/schematic/menu.scm:132
 msgid "_Next"
 msgstr "_Seuraava"
 
-#: schematic/scheme/conf/schematic/menu.scm:133
 msgid "_Close"
 msgstr "Sul_je"
 
-#: schematic/scheme/conf/schematic/menu.scm:135
 #, fuzzy
 msgid "_Revert..."
 msgstr "_Hylkää muutokset"
 
-#: schematic/scheme/conf/schematic/menu.scm:137
-#: schematic/scheme/gschem/builtins.scm:249
 #, fuzzy
 msgid "Next Tab"
 msgstr "_Seuraava"
 
-#: schematic/scheme/conf/schematic/menu.scm:138
-#: schematic/scheme/gschem/builtins.scm:252
 #, fuzzy
 msgid "Previous Tab"
 msgstr "_Edellinen"
 
-#: schematic/scheme/conf/schematic/menu.scm:146
 msgid "_Component..."
 msgstr "_komponentti..."
 
-#: schematic/scheme/conf/schematic/menu.scm:148
 msgid "_Net"
 msgstr "Johdi_n"
 
-#: schematic/scheme/conf/schematic/menu.scm:149
 msgid "B_us"
 msgstr "Väy_lä"
 
-#: schematic/scheme/conf/schematic/menu.scm:151
 msgid "_Attribute..."
 msgstr "_Määrite..."
 
-#: schematic/scheme/conf/schematic/menu.scm:152
 msgid "_Text..."
 msgstr "_Teksti..."
 
-#: schematic/scheme/conf/schematic/menu.scm:154
 msgid "_Line"
 msgstr "_Viiva"
 
-#: schematic/scheme/conf/schematic/menu.scm:155
 msgid "Pat_h"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:156
 msgid "_Box"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:157
 msgid "C_ircle"
 msgstr "Ympyrä"
 
-#: schematic/scheme/conf/schematic/menu.scm:158
 msgid "A_rc"
 msgstr "Kaa_ri"
 
-#: schematic/scheme/conf/schematic/menu.scm:159
 msgid "_Pin"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:161
 msgid "Pictu_re..."
 msgstr "Kuva..."
 
-#: schematic/scheme/conf/schematic/menu.scm:167
 msgid "_Up"
 msgstr "_Ylös"
 
-#: schematic/scheme/conf/schematic/menu.scm:169
 msgid "_Down Schematic"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:170
 msgid "Down _Symbol"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:176
 msgid "_Attach"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:177
 msgid "_Detach"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:179
 msgid "Show _Value"
 msgstr "Näytä _Arvo"
 
-#: schematic/scheme/conf/schematic/menu.scm:180
 msgid "Show _Name"
 msgstr "Näytä _Nimi"
 
-#: schematic/scheme/conf/schematic/menu.scm:181
 msgid "Show _Both"
 msgstr "Näytä _Molemmat"
 
-#: schematic/scheme/conf/schematic/menu.scm:182
 msgid "_Toggle Visibility"
 msgstr "Vaihda Näk_yvyys"
 
-#: schematic/scheme/conf/schematic/menu.scm:184
 msgid "_Hide Specific Text..."
 msgstr "_Piilota"
 
-#: schematic/scheme/conf/schematic/menu.scm:185
 msgid "_Show Specific Text..."
 msgstr "_Näytä Maarite tekstillä..."
 
-#: schematic/scheme/conf/schematic/menu.scm:186
 msgid "Show/Hide Hidden Text"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:188
 msgid "_Find Text/Check Symbol..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:189
 msgid "A_utonumber Text..."
 msgstr "A_utonumeroi määritteet tekstillä..."
 
-#: schematic/scheme/conf/schematic/menu.scm:195
 msgid "_Options..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:196
 #, fuzzy
 msgid "_Font..."
 msgstr "T_ulosta…"
 
-#: schematic/scheme/conf/schematic/menu.scm:198
 #, fuzzy
 msgid "Grid +"
 msgstr "Nosta Ruudukon Tiheyttä"
 
-#: schematic/scheme/conf/schematic/menu.scm:199
 #, fuzzy
 msgid "Grid -"
 msgstr "Nosta Ruudukon Tiheyttä"
 
-#: schematic/scheme/conf/schematic/menu.scm:201
 msgid "Grid Style: Cycle Dots/Mesh/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:202
 msgid "Grid Snap: Cycle Grid/Resnap/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:204
 #, fuzzy
 msgid "Feedback Mode: Outline/Box"
 msgstr "Näytä _Liikutettaessa Komponentti/Neliö"
 
-#: schematic/scheme/conf/schematic/menu.scm:205
 msgid "Net: Rubberband On/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:206
 msgid "Net: Magnetic On/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:208
 #, fuzzy
 msgid "_Coord Window"
 msgstr "Näytä _Koordinaatti-ikkuna..."
 
-#: schematic/scheme/conf/schematic/menu.scm:209
 #, fuzzy
 msgid "_Log Window"
 msgstr "Näytä _Loki-ikkuna..."
 
-#: schematic/scheme/conf/schematic/menu.scm:215
 msgid "_1 allegro"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:223
 #, fuzzy
 msgid "User _Guide"
 msgstr "gschem _UKK..."
 
-#: schematic/scheme/conf/schematic/menu.scm:224
 msgid "_FAQ"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:225
 #, fuzzy
 msgid "Docu_mentation"
 msgstr "D_okumentaatio..."
 
-#: schematic/scheme/conf/schematic/menu.scm:226
 msgid "_Wiki"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:228
 #, fuzzy
 msgid "Find Component D_ocumentation"
 msgstr "Komponentin D_okumentaatio..."
 
-#: schematic/scheme/conf/schematic/menu.scm:230
 msgid "_Hotkeys..."
 msgstr "_Pikanäppäimet"
 
-#: schematic/scheme/conf/schematic/menu.scm:231
 #, fuzzy
 msgid "_About"
 msgstr "_Tietoja..."
 
-#: schematic/scheme/conf/schematic/menu.scm:237
 msgid "_File"
 msgstr "_Tiedosto"
 
-#: schematic/scheme/conf/schematic/menu.scm:238
 msgid "_Edit"
 msgstr "_Muokkaa"
 
-#: schematic/scheme/conf/schematic/menu.scm:240
 msgid "_View"
 msgstr "_Näytä"
 
-#: schematic/scheme/conf/schematic/menu.scm:241
 msgid "_Page"
 msgstr "_Sivu"
 
-#: schematic/scheme/conf/schematic/menu.scm:242
 msgid "_Add"
 msgstr "_Lisää"
 
-#: schematic/scheme/conf/schematic/menu.scm:243
 msgid "Hie_rarchy"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:244
 msgid "A_ttributes"
 msgstr "Määri_tteet..."
 
-#: schematic/scheme/conf/schematic/menu.scm:245
 msgid "_Options"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:246
 #, fuzzy
 msgid "_Netlist"
 msgstr "Johdi_n"
 
-#: schematic/scheme/conf/schematic/menu.scm:247
 msgid "_Help"
 msgstr "O_hje"
 
-#: schematic/scheme/gschem/action.scm:43
 #, scheme-format
 msgid "~S is not a valid gschem action."
 msgstr ""
 
-#: schematic/scheme/gschem/action.scm:158
 msgid "Repeat Last Action"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:47
 msgid "Cancel"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:53
 #, fuzzy
 msgid "New File"
 msgstr "_Tiedosto"
 
-#: schematic/scheme/gschem/builtins.scm:56
 msgid "Open File"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:62
 #, fuzzy
 msgid "Save As"
 msgstr "Tallenna _kaikki"
 
-#: schematic/scheme/gschem/builtins.scm:68
 #, fuzzy
 msgid "Print"
 msgstr "T_ulosta…"
 
-#: schematic/scheme/gschem/builtins.scm:71
 msgid "Export Image"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:74
 msgid "Run Script"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:80
 #, fuzzy
 msgid "Close Window"
 msgstr "Uusi ikkuna"
 
-#: schematic/scheme/gschem/builtins.scm:83
 #, fuzzy
 msgid "Quit"
 msgstr "L_opeta"
 
-#: schematic/scheme/gschem/builtins.scm:87
 msgid "Terminal REPL"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:132
 msgid "Choose Slot"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:135
 msgid "Edit Object Properties"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:138
 msgid "Translate Symbol"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:147
 msgid "Invoke Macro"
 msgstr "Suorita makro"
 
-#: schematic/scheme/gschem/builtins.scm:159
 msgid "Show/Hide Invisible Text"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:165
 #, fuzzy
 msgid "Cut"
 msgstr "_Leikkaa"
 
-#: schematic/scheme/gschem/builtins.scm:171
 #, fuzzy
 msgid "Paste"
 msgstr "L_iitä"
 
-#: schematic/scheme/gschem/builtins.scm:177
 msgid "Sidebar"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:183
 #, fuzzy
 msgid "Find Text State"
 msgstr "Muokkaa tekstiä..."
 
-#: schematic/scheme/gschem/builtins.scm:186
 #, fuzzy
 msgid "Redraw"
 msgstr "_Päivitä näkymä"
 
-#: schematic/scheme/gschem/builtins.scm:192
 msgid "Pan Left"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:195
 msgid "Pan Right"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:198
 msgid "Pan Up"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:201
 msgid "Pan Down"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:216
 #, fuzzy
 msgid "Zoom Full"
 msgstr "L_oitonna"
 
-#: schematic/scheme/gschem/builtins.scm:219
 msgid "Dark Color Scheme"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:222
 msgid "Light Color Scheme"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:225
 msgid "Monochrome Color Scheme"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:228
 msgid "Show Color Scheme Editor"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:234
 msgid "Revert Changes"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:240
 #, fuzzy
 msgid "Previous Page"
 msgstr "_Edellinen"
 
-#: schematic/scheme/gschem/builtins.scm:243
 msgid "Next Page"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:255
 #, fuzzy
 msgid "Print Page"
 msgstr "_Edellinen"
 
-#: schematic/scheme/gschem/builtins.scm:276
 #, fuzzy
 msgid "Add Line"
 msgstr "_Viiva"
 
-#: schematic/scheme/gschem/builtins.scm:279
 msgid "Add Path"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:282
 msgid "Add Box"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:285
 #, fuzzy
 msgid "Add Circle"
 msgstr "Ympyrä"
 
-#: schematic/scheme/gschem/builtins.scm:288
 msgid "Add Arc"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:291
 msgid "Add Pin"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:294
 #, fuzzy
 msgid "Add Picture"
 msgstr "Kuva..."
 
-#: schematic/scheme/gschem/builtins.scm:306
 msgid "Up Hierarchy"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:312
 #, fuzzy
 msgid "Attach Attributes"
 msgstr "Määri_tteet..."
 
-#: schematic/scheme/gschem/builtins.scm:315
 #, fuzzy
 msgid "Detach Attributes"
 msgstr "Määri_tteet..."
 
-#: schematic/scheme/gschem/builtins.scm:318
 #, fuzzy
 msgid "Show Attribute Value"
 msgstr "Näytä _Arvo"
 
-#: schematic/scheme/gschem/builtins.scm:321
 #, fuzzy
 msgid "Show Attribute Name"
 msgstr "Näytä _Nimi"
 
-#: schematic/scheme/gschem/builtins.scm:327
 #, fuzzy
 msgid "Toggle Text Visibility"
 msgstr "Vaihda Näk_yvyys"
 
-#: schematic/scheme/gschem/builtins.scm:330
 #, fuzzy
 msgid "Find Specific Text"
 msgstr "_Piilota"
 
-#: schematic/scheme/gschem/builtins.scm:333
 #, fuzzy
 msgid "Hide Specific Text"
 msgstr "_Piilota"
 
-#: schematic/scheme/gschem/builtins.scm:336
 #, fuzzy
 msgid "Show Specific Text"
 msgstr "_Näytä Maarite tekstillä..."
 
-#: schematic/scheme/gschem/builtins.scm:339
 #, fuzzy
 msgid "Autonumber Text"
 msgstr "A_utonumeroi määritteet tekstillä..."
 
-#: schematic/scheme/gschem/builtins.scm:345
 #, fuzzy
 msgid "Show Hotkeys"
 msgstr "Näytä _Molemmat"
 
-#: schematic/scheme/gschem/builtins.scm:348
 msgid "Switch Grid Style"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:351
 msgid "Switch Snap Mode"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:354
 #, fuzzy
 msgid "Set Grid Spacing"
 msgstr "Nosta Ruudukon Tiheyttä"
 
-#: schematic/scheme/gschem/builtins.scm:357
 #, fuzzy
 msgid "Increase Grid Spacing"
 msgstr "Nosta Ruudukon Tiheyttä"
 
-#: schematic/scheme/gschem/builtins.scm:360
 #, fuzzy
 msgid "Decrease Grid Spacing"
 msgstr "Nosta Ruudukon Tiheyttä"
 
-#: schematic/scheme/gschem/builtins.scm:363
 #, fuzzy
 msgid "Toggle Outline Drawing"
 msgstr "Näytä _Liikutettaessa Komponentti/Neliö"
 
-#: schematic/scheme/gschem/builtins.scm:366
 msgid "Toggle Net Rubber Band"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:369
 msgid "Toggle Magnetic Nets"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:372
 #, fuzzy
 msgid "Show Log Window"
 msgstr "Näytä _Loki-ikkuna..."
 
-#: schematic/scheme/gschem/builtins.scm:375
 #, fuzzy
 msgid "Show Coordinate Window"
 msgstr "Näytä _Koordinaatti-ikkuna..."
 
-#: schematic/scheme/gschem/builtins.scm:385
 #, fuzzy
 msgid "Component Documentation"
 msgstr "Komponentin D_okumentaatio..."
 
-#: schematic/scheme/gschem/builtins.scm:387
 msgid "View documentation for selected component"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:403
 msgid ""
 "Could not show documentation for selected component:\n"
 "\n"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:408
 msgid "gEDA Manuals"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:409
 msgid "View the front page of the gEDA documentation in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:414
 #, fuzzy
 msgid "gschem User Guide"
 msgstr "gschem _UKK..."
 
-#: schematic/scheme/gschem/builtins.scm:415
 msgid "View the gschem User Guide in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:420
 #, fuzzy
 msgid "gschem FAQ"
 msgstr "gschem _UKK..."
 
-#: schematic/scheme/gschem/builtins.scm:421
 msgid "Frequently Asked Questions about using gschem."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:426
 #, fuzzy
 msgid "gEDA wiki"
 msgstr "gEDA _Wiki..."
 
-#: schematic/scheme/gschem/builtins.scm:427
 msgid "View the front page of the gEDA wiki in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:431
 msgid "About gschem"
 msgstr ""
 
-#: schematic/scheme/gschem/deprecated.scm:102
 #, scheme-format
 msgid "Invalid text alignment ~A."
 msgstr ""
 
-#: schematic/scheme/gschem/gschemdoc.scm:241
 msgid "No documentation found"
 msgstr ""
 
-#: schematic/scheme/gschem/keymap.scm:40
 #, scheme-format
 msgid "~S is not a valid key combination."
 msgstr ""
 
-#: schematic/scheme/gschem/keymap.scm:157
 #, scheme-format
 msgid "~S is not a prefix key sequence."
 msgstr ""

--- a/schematic/po/fr.po
+++ b/schematic/po/fr.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fr_FR\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-15 15:13+0300\n"
+"POT-Creation-Date: 2019-02-22 14:08+0300\n"
 "PO-Revision-Date: 2012-10-28 15:46+0000\n"
 "Last-Translator: Penegal <Unknown>\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -21,24 +21,20 @@ msgstr ""
 "X-Launchpad-Export-Date: 2012-11-14 16:52+0000\n"
 "X-Generator: Launchpad (build 16265)\n"
 
-#: schematic/src/a_zoom.c:155
 #, fuzzy
 msgid "Zoom too small!  Cannot zoom further."
 msgstr "Agrandissement maximum ! Impossible d'agrandir plus.\n"
 
-#: schematic/src/color_edit_widget.c:399
 #, fuzzy, c-format
 msgid ""
 "Could not save file [%s]:\n"
 "%s"
 msgstr "Échec sauvegarde de la page [%s]\n"
 
-#: schematic/src/color_edit_widget.c:434
 #, fuzzy
 msgid "Save Color Scheme As..."
 msgstr "Couleurs _clairs"
 
-#: schematic/src/color_edit_widget.c:482 schematic/src/x_fileselect.c:292
 #, fuzzy, c-format
 msgid ""
 "The selected file `%1$s' already exists.\n"
@@ -49,180 +45,142 @@ msgstr ""
 "\n"
 "Voulez-vous l'écraser?"
 
-#: schematic/src/color_edit_widget.c:486 schematic/src/x_fileselect.c:295
 msgid "Overwrite file?"
 msgstr "Écraser le fichier ?"
 
-#: schematic/src/font_select_widget.c:211
 msgid "_Apply"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:215
 msgid "Sa_ve..."
 msgstr ""
 
-#: schematic/src/font_select_widget.c:278
 #, c-format
 msgid "<b>Current:</b> %s"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:453
 msgid "Save configuration"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:461
 #, fuzzy
 msgid "Save settings to:"
 msgstr "Configuration"
 
-#: schematic/src/font_select_widget.c:465
 msgid "Local configuration file (in current directory)"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:467
 msgid "User configuration file (geda-user.conf)"
 msgstr ""
 
-#: schematic/src/g_attrib.c:90
 msgid "Object ~A is not included in the current gschem page."
 msgstr "L'objet ~A n'est pas inclus dans la page gschem courante."
 
-#: schematic/src/g_attrib.c:110
 msgid "Invalid text name/value visibility ~A."
 msgstr ""
 
-#: schematic/src/g_rc.c:107
 #, fuzzy, c-format
 msgid "You are running gEDA/gaf version [%1$s%2$s.%3$s],\n"
 msgstr "gEDA/gschem version %s%s.%s\n"
 
-#: schematic/src/g_rc.c:111
 #, c-format
 msgid ""
 "but you have a version [%1$s] gschemrc file:\n"
 "[%2$s]\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:114
 #, c-format
 msgid "Please be sure that you have the latest rc file.\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:240
 #, fuzzy, c-format
 msgid "Invalid size [%1$d] passed to text-size\n"
 msgstr "Taille [%d] passée à text-size invalide\n"
 
-#: schematic/src/g_rc.c:283
 #, fuzzy, c-format
 msgid "Invalid size [%1$d] passed to snap-size\n"
 msgstr "Taille [%d] passée à snap-size invalide\n"
 
-#: schematic/src/g_rc.c:620
 #, fuzzy, c-format
 msgid "Invalid num levels [%1$d] passed to undo-levels\n"
 msgstr "Nombre de niveaux [%d] passé à undo-levels invalide\n"
 
-#: schematic/src/g_rc.c:831
 #, fuzzy, c-format
 msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
 msgstr "Taille [%d] passée à bus-ripper-size invalide\n"
 
-#: schematic/src/g_rc.c:931
 #, fuzzy, c-format
 msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
 msgstr "Taille de point [%d] invalide passé à dots-grid-dot-size\n"
 
-#: schematic/src/g_rc.c:972
 #, fuzzy, c-format
 msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
 msgstr "Espace de pixel [%d] invalide passé à dots-grid-fixed-threshold\n"
 
-#: schematic/src/g_rc.c:998
 #, fuzzy, c-format
 msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
 msgstr ""
 "Espacement [%d] de pixel invalide passé à mesh-grid-display-threshold\n"
 
-#: schematic/src/g_rc.c:1023
 #, fuzzy, c-format
 msgid "Invalid offset [%1$d] passed to add-attribute-offset\n"
 msgstr "Offset [%d] passé à add-attribute-offset invalide\n"
 
-#: schematic/src/g_rc.c:1047
 #, fuzzy, c-format
 msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
 msgstr "Nombre de secondes [%d] passé  auto-save-interval invalide\n"
 
-#: schematic/src/g_rc.c:1071
 #, fuzzy, c-format
 msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
 msgstr "Gain [%d] passé à mousepan-gain invalide\n"
 
-#: schematic/src/g_rc.c:1094
 #, fuzzy, c-format
 msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
 msgstr "Gain [%d] passé à keyboardpan-gain invalide\n"
 
-#: schematic/src/g_rc.c:1118
 #, fuzzy, c-format
 msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
 msgstr "Nombre [%d] de pixels invalides passés à select-slack-pixels\n"
 
-#: schematic/src/g_rc.c:1144
 #, fuzzy, c-format
 msgid "Invalid gain [%1$d] passed to zoom-gain\n"
 msgstr "Gain [%d] invalide passé à zoom-gain\n"
 
-#: schematic/src/g_rc.c:1169
 #, fuzzy, c-format
 msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
 msgstr "Nombre d'étapes [%d] scrollpan-steps invalide\n"
 
-#: schematic/src/g_select.c:78 schematic/src/g_select.c:115
-#: schematic/src/g_select.c:151
 msgid "Object ~A is not directly included in a page."
 msgstr "L'objet ~A n'est inclus directement par aucune page."
 
-#: schematic/src/g_util.c:54
 msgid "Could not launch URI ~S: ~A"
 msgstr "Impossible de lancer l'URI ~S: ~A"
 
-#: schematic/src/g_window.c:139
 msgid "Found invalid gschem window smob ~S"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:156
 #, fuzzy, c-format
 msgid "Lepton EDA/lepton-schematic version %1$s%2$s.%3$s git: %4$.7s"
 msgstr "gEDA/gschem version %s%s.%s\n"
 
-#: schematic/src/lepton-schematic.c:163
 #, c-format
 msgid "This is the MINGW32 port.\n"
 msgstr "Ceci est le portage sous MINGW32\n"
 
-#: schematic/src/lepton-schematic.c:167
 #, fuzzy, c-format
 msgid "Current locale settings: %1$s\n"
 msgstr "Locale en cours : %s\n"
 
-#: schematic/src/lepton-schematic.c:201
 #, fuzzy, c-format
 msgid "Couldn't find init scm file [%1$s]"
 msgstr "Impossible de trouver le fichier scm d'init [%s]\n"
 
-#: schematic/src/lepton-schematic.c:206
 #, fuzzy, c-format
 msgid "Read init scm file [%1$s]"
 msgstr "Lecture du fichier scm de démarrage [%s]\n"
 
-#: schematic/src/lepton-schematic.c:210
 #, fuzzy, c-format
 msgid "Failed to read init scm file [%1$s]"
 msgstr "Échec de la lecture du fichier scm de démarrage [%s]\n"
 
-#: schematic/src/lepton-schematic.c:290
 #, fuzzy, c-format
 msgid ""
 "ERROR: Failed to load or evaluate startup script.\n"
@@ -233,148 +191,116 @@ msgstr ""
 "\n"
 "Le journal gschem pourrait contenir plus d'informations."
 
-#: schematic/src/gschem_about_dialog.c:51
 #, fuzzy, c-format
 msgid "%s (git: %.7s)"
 msgstr "%s (g%.7s)"
 
-#: schematic/src/gschem_about_dialog.c:75
 msgid "Lepton Electronic Design Automation"
 msgstr ""
 
-#: schematic/src/gschem_about_dialog.c:83
 #, fuzzy
 msgid ""
 "Copyright © 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright © 2017-2018 Lepton Developers.\n"
-"See AUTHORS and ChangeLog files for details."
+"Copyright © 2017-2019 Lepton Developers.\n"
+"See AUTHORS, ChangeLog files and consult 'git log' history for details."
 msgstr ""
 "Copyright © 1998-2012 Ales Hvezda <ahvezda@geda.seul.org>\n"
 "Copyright © 1998-2012 gEDA Contributors (reportez-vous au fichier CHANGELOG "
 "pour plus de détails)"
 
-#: schematic/src/gschem_alignment_combo.c:69
 msgid "Upper Left"
 msgstr "En haut à gauche"
 
-#: schematic/src/gschem_alignment_combo.c:71
 msgid "Upper Middle"
 msgstr "En haut au milieu"
 
-#: schematic/src/gschem_alignment_combo.c:73
 #, fuzzy
 msgid "Upper Right"
 msgstr "En bas à droite"
 
-#: schematic/src/gschem_alignment_combo.c:78
 msgid "Middle Left"
 msgstr "Au milieu à gauche"
 
-#: schematic/src/gschem_alignment_combo.c:80
 msgid "Middle Middle"
 msgstr "Au centre"
 
-#: schematic/src/gschem_alignment_combo.c:82
 msgid "Middle Right"
 msgstr "Au milieu à droite"
 
-#: schematic/src/gschem_alignment_combo.c:87
 msgid "Lower Left"
 msgstr "En bas à gauche"
 
-#: schematic/src/gschem_alignment_combo.c:89
 msgid "Lower Middle"
 msgstr "En bas au milieu"
 
-#: schematic/src/gschem_alignment_combo.c:91
 msgid "Lower Right"
 msgstr "En bas à droite"
 
-#: schematic/src/gschem_arc_dialog.c:104
 msgid "Arc Params"
 msgstr "Paramètres d'arc"
 
-#: schematic/src/gschem_arc_dialog.c:140
 #, fuzzy
 msgid "Arc _Radius:"
 msgstr "Rayon de l'Arc:"
 
-#: schematic/src/gschem_arc_dialog.c:141
 #, fuzzy
 msgid "Start _Angle:"
 msgstr "Angle de départ :"
 
-#: schematic/src/gschem_arc_dialog.c:142
 #, fuzzy
 msgid "_Degrees of Sweep:"
 msgstr "Balayage :"
 
-#: schematic/src/gschem_bottom_widget.c:504
 msgid "Left mouse button"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:508
 #, fuzzy
 msgid "Middle mouse button"
 msgstr "Au milieu à gauche"
 
-#: schematic/src/gschem_bottom_widget.c:512
 #, fuzzy
 msgid "Right mouse button"
 msgstr ""
 "Mode ajout de piste\n"
 "Clic droit pour annuler"
 
-#: schematic/src/gschem_bottom_widget.c:595
 msgid "(Snap size, Grid size)"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:603
 #, fuzzy
 msgid "Net rubber band mode"
 msgstr "Piste é_lastique On/Off"
 
-#: schematic/src/gschem_bottom_widget.c:614
 #, fuzzy
 msgid "Magnetic net mode"
 msgstr "Mode Piste Magnétique"
 
-#: schematic/src/gschem_bottom_widget.c:622
 #, fuzzy
 msgid "Current action mode"
 msgstr "Vue en cours"
 
-#: schematic/src/gschem_bottom_widget.c:935
-#: schematic/src/gschem_bottom_widget.c:951
 msgid "OFF"
 msgstr "OFF"
 
-#: schematic/src/gschem_bottom_widget.c:954
 msgid "NONE"
 msgstr "AUCUN"
 
-#: schematic/src/gschem_bottom_widget.c:960
 #, fuzzy, c-format
 msgid "Grid(%1$s, %2$s)"
 msgstr "Grille(%s,%s)"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:350
-#: schematic/src/x_compselect.c:1236 schematic/src/x_multiattrib.c:2068
 msgid "Name"
 msgstr "Nom"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:372
 msgid "S_elect the schematics you want to save:"
 msgstr "_Sélectionnez les schémas que vous souhaitez enregistrer :"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:467
 #, fuzzy, c-format
 msgid "Save the changes to schematic \"%1$s\" before closing?"
 msgstr ""
 "Voulez-vous enregistrer les modifications dans le schéma \"%s\" avant de le "
 "fermer ?"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:473
 #, fuzzy, c-format
 msgid ""
 "There are %1$d schematics with unsaved changes. Save changes before closing?"
@@ -382,568 +308,420 @@ msgstr ""
 "Il y a %d schémas avec des modifications non sauvegardées. Les sauvegarder "
 "avant de fermer?"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:502
 msgid "If you don't save, all your changes will be permanently lost."
 msgstr ""
 "Si vous n'enregistrez pas, les modifications effectuées seront "
 "définitivement perdues."
 
-#: schematic/src/gschem_close_confirmation_dialog.c:522
 #, fuzzy
 msgid "Close _without saving"
 msgstr "Fermer sans sa_uvegarder"
 
-#: schematic/src/gschem_coord_dialog.c:86
 msgid "Coords"
 msgstr "Coordonnées"
 
-#: schematic/src/gschem_coord_dialog.c:106
 msgid "Screen"
 msgstr "Écran"
 
-#: schematic/src/gschem_coord_dialog.c:115
 msgid "World"
 msgstr "Monde"
 
-#: schematic/src/gschem_find_text_state.c:809 schematic/src/x_pagesel.c:432
 msgid "Filename"
 msgstr "Nom de fichier"
 
-#: schematic/src/gschem_find_text_state.c:821 schematic/src/i_callbacks.c:1970
-#: schematic/src/x_colorcb.c:154 schematic/src/x_widgets.c:179
-#: schematic/src/x_window.c:1226 schematic/src/x_window.c:1440
 msgid "Text"
 msgstr "Texte"
 
-#: schematic/src/gschem_find_text_widget.c:427
 msgid "descend into hierarchy"
 msgstr "descendre dans la hiérarchie"
 
-#: schematic/src/gschem_find_text_widget.c:435
 #, fuzzy
 msgid "Find"
 msgstr "Recherche de texte"
 
-#: schematic/src/gschem_find_text_widget.c:557
 #, fuzzy
 msgid "Find Text:"
 msgstr "Recherche de texte"
 
-#: schematic/src/gschem_find_text_widget.c:564
 msgid "Find Pattern:"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:571
 #, fuzzy
 msgid "Find Regex:"
 msgstr "Recherche de texte"
 
-#: schematic/src/gschem_find_text_widget.c:578
 msgid "Check symbol:"
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:200
 msgid "Hotkeys"
 msgstr "Raccourcis"
 
-#: schematic/src/gschem_hotkey_dialog.c:229
 msgid ""
 "Start typing action name or keystroke to filter the list.\n"
 "Type hotkeys as they are displayed in \"Keystroke(s)\" column."
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:233 schematic/src/x_compselect.c:1124
 #, fuzzy
 msgid "_Filter:"
 msgstr "Filtre:"
 
-#: schematic/src/gschem_hotkey_dialog.c:259 schematic/src/i_basic.c:280
 msgid "Action"
 msgstr "Action"
 
-#: schematic/src/gschem_hotkey_dialog.c:277
 msgid "Keystroke(s)"
 msgstr "Touche(s)"
 
-#: schematic/src/gschem_log_widget.c:177
 msgid "** Invalid UTF-8 in log message. See stderr or gschem.log.\n"
 msgstr ""
 "** UTF-8 invalide dans le message de log. Regardez stderr ou gschem.log.\n"
 
-#: schematic/src/gschem_log_widget.c:434
 #, fuzzy
 msgid "Clear log window?"
 msgstr "Fermeture de la fenêtre\n"
 
-#: schematic/src/gschem_log_widget.c:477
 #, fuzzy
 msgid "Clear Log _Window"
 msgstr "Afficher le _journal des messages"
 
-#: schematic/src/gschem_macro_widget.c:231
 msgid "Macro:"
 msgstr ""
 
-#: schematic/src/gschem_macro_widget.c:387
 #, fuzzy
 msgid "Evaluate"
 msgstr "Évaluer :"
 
-#: schematic/src/gschem_object_properties_widget.c:172
 #, fuzzy
 msgid "_Fill Type:"
 msgstr "Type de remplissage :"
 
-#: schematic/src/gschem_object_properties_widget.c:173
 #, fuzzy
 msgid "Lin_e Width:"
 msgstr "Épaisseur :"
 
-#: schematic/src/gschem_object_properties_widget.c:174
 #, fuzzy
 msgid "Angle _1:"
 msgstr "Angle1 :"
 
-#: schematic/src/gschem_object_properties_widget.c:175
 #, fuzzy
 msgid "P_itch 1:"
 msgstr "Écart1 :"
 
-#: schematic/src/gschem_object_properties_widget.c:176
 #, fuzzy
 msgid "Angle _2:"
 msgstr "Angle2 :"
 
-#: schematic/src/gschem_object_properties_widget.c:177
 #, fuzzy
 msgid "Pitc_h 2:"
 msgstr "Écart2 :"
 
-#: schematic/src/gschem_object_properties_widget.c:237
 #, fuzzy
 msgid "<b>Fill Properties</b>"
 msgstr "<b>Propriétés du texte</b>"
 
-#: schematic/src/gschem_object_properties_widget.c:255
-#: schematic/src/gschem_text_properties_widget.c:258
-#: schematic/src/x_newtext.c:271
 #, fuzzy
 msgid "Colo_r:"
 msgstr "Couleur :"
 
-#: schematic/src/gschem_object_properties_widget.c:266
 #, fuzzy
 msgid "<b>General Properties</b>"
 msgstr "<b>Propriétés du texte</b>"
 
-#: schematic/src/gschem_object_properties_widget.c:284
 #, fuzzy
 msgid "_Type:"
 msgstr "Type :"
 
-#: schematic/src/gschem_object_properties_widget.c:285
 #, fuzzy
 msgid "_Width:"
 msgstr "Largeur :"
 
-#: schematic/src/gschem_object_properties_widget.c:286
 #, fuzzy
 msgid "Dash _Length:"
 msgstr "Longueur du tiret :"
 
-#: schematic/src/gschem_object_properties_widget.c:287
 #, fuzzy
 msgid "Dash _Space:"
 msgstr "Espace entre tirets :"
 
-#: schematic/src/gschem_object_properties_widget.c:288
 msgid "C_ap style:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:333
 #, fuzzy
 msgid "<b>Line Properties</b>"
 msgstr "<b>Propriétés du texte</b>"
 
-#: schematic/src/gschem_object_properties_widget.c:351
 #, fuzzy
 msgid "_Pin Type:"
 msgstr "Type de broche"
 
-#: schematic/src/gschem_object_properties_widget.c:362
 #, fuzzy
 msgid "<b>Pin Properties</b>"
 msgstr "<b>Propriétés du texte</b>"
 
-#: schematic/src/gschem_options_widget.c:217
 msgid "_Off"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:220
 msgid "_Dots"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:223
 msgid "M_esh"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:245
 #, fuzzy
 msgid "Net R_ubber Band Mode:"
 msgstr "Piste é_lastique On/Off"
 
-#: schematic/src/gschem_options_widget.c:246
 #, fuzzy
 msgid "_Magnetic Net Mode:"
 msgstr "Mode Piste Magnétique"
 
-#: schematic/src/gschem_options_widget.c:250
-#: schematic/src/gschem_options_widget.c:251
 msgid "Enabled"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:265
 #, fuzzy
 msgid "<b>Net Options</b>"
 msgstr "<b>Options</b>"
 
-#: schematic/src/gschem_options_widget.c:282
 #, fuzzy
 msgid "Grid Mode:"
 msgstr "Mode Arc de cercle"
 
-#: schematic/src/gschem_options_widget.c:283
 #, fuzzy
 msgid "Snap Mode:"
 msgstr "Mode Panoramique"
 
-#: schematic/src/gschem_options_widget.c:284
 #, fuzzy
 msgid "_Snap Size:"
 msgstr "Grille de snap"
 
-#: schematic/src/gschem_options_widget.c:301
 #, fuzzy
 msgid "<b>Snap Options</b>"
 msgstr "<b>Options</b>"
 
-#: schematic/src/gschem_options_widget.c:340
 msgid "O_ff"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:343
 #, fuzzy
 msgid "_Grid"
 msgstr "Grille OFF\n"
 
-#: schematic/src/gschem_options_widget.c:346
 #, fuzzy
 msgid "_Resnap"
 msgstr "Resnap Actif"
 
-#: schematic/src/gschem_pin_type_combo.c:73
 msgid "Net pin"
 msgstr "Broche de liaison"
 
-#: schematic/src/gschem_pin_type_combo.c:80
 msgid "Bus pin (graphical)"
 msgstr "Broche de bus (graphique)"
 
-#: schematic/src/gschem_preview.c:195
 msgid "Preview Buffer"
 msgstr "Prévisualisation du tampon"
 
-#: schematic/src/gschem_show_hide_text_widget.c:148
-#: schematic/src/x_window.c:1268
 #, fuzzy
 msgid "Hide"
 msgstr "Cacher le texte"
 
-#: schematic/src/gschem_show_hide_text_widget.c:157
-#: schematic/src/x_window.c:1269
 msgid "Hide text starting with:"
 msgstr "Cacher le texte commençant par :"
 
-#: schematic/src/gschem_slot_edit_dialog.c:91
 msgid "Edit slot number"
 msgstr "Numéro de slot"
 
-#: schematic/src/gschem_slot_edit_dialog.c:121
 msgid "Number of Slots:"
 msgstr ""
 
-#: schematic/src/gschem_slot_edit_dialog.c:122
 #, fuzzy
 msgid "Slot Number:"
 msgstr "Numéro de slot :"
 
-#: schematic/src/gschem_text_properties_widget.c:240
-#: schematic/src/x_newtext.c:265
 msgid "<b>Text Content</b>"
 msgstr "<b>Texte</b>"
 
-#: schematic/src/gschem_text_properties_widget.c:259
-#: schematic/src/x_newtext.c:291
 #, fuzzy
 msgid "_Size:"
 msgstr "Taille :"
 
-#: schematic/src/gschem_text_properties_widget.c:260
-#: schematic/src/x_newtext.c:310
 #, fuzzy
 msgid "Ali_gnment:"
 msgstr "Alignement du texte :"
 
-#: schematic/src/gschem_text_properties_widget.c:261
-#: schematic/src/x_newtext.c:330
 #, fuzzy
 msgid "Ro_tation:"
 msgstr "Orientation :"
 
-#: schematic/src/gschem_text_properties_widget.c:294
-#: schematic/src/x_newtext.c:253
 msgid "<b>Text Properties</b>"
 msgstr "<b>Propriétés du texte</b>"
 
-#: schematic/src/gschem_translate_widget.c:238
 #, fuzzy
 msgid "Coordinate:"
 msgstr "Afficher les _coordonnées"
 
-#: schematic/src/gschem_translate_widget.c:405 schematic/src/i_callbacks.c:800
 msgid "Translate"
 msgstr "Translater"
 
-#: schematic/src/i_basic.c:64 schematic/src/x_window.c:1369
-#: schematic/scheme/conf/schematic/menu.scm:59
-#: schematic/scheme/gschem/builtins.scm:99
 msgid "Select Mode"
 msgstr "Mode Sélection"
 
-#: schematic/src/i_basic.c:65
 #, fuzzy
 msgid "Select Box Mode"
 msgstr "Mode Sélection"
 
-#: schematic/src/i_basic.c:66
 msgid "Text Mode"
 msgstr "Mode Texte"
 
-#: schematic/src/i_basic.c:67
 msgid "Pan Mode"
 msgstr "Mode Panoramique"
 
-#: schematic/src/i_basic.c:70
 #, c-format
 msgid "Paste %d Mode"
 msgstr "Mode Coller %d"
 
-#: schematic/src/i_basic.c:74
 msgid "Magnetic Net Mode"
 msgstr "Mode Piste Magnétique"
 
-#: schematic/src/i_basic.c:76
 msgid "Net Mode"
 msgstr "Mode Piste"
 
-#: schematic/src/i_basic.c:77
 msgid "Arc Mode"
 msgstr "Mode Arc de cercle"
 
-#: schematic/src/i_basic.c:78
 msgid "Box Mode"
 msgstr "Mode Cadre"
 
-#: schematic/src/i_basic.c:79
 msgid "Bus Mode"
 msgstr "Mode Bus"
 
-#: schematic/src/i_basic.c:80
 msgid "Circle Mode"
 msgstr "Mode Cercle"
 
-#: schematic/src/i_basic.c:81
 msgid "Component Mode"
 msgstr "Mode Composant"
 
-#: schematic/src/i_basic.c:82 schematic/scheme/conf/schematic/menu.scm:62
-#: schematic/scheme/gschem/builtins.scm:114
 msgid "Copy Mode"
 msgstr "Mode Copie"
 
-#: schematic/src/i_basic.c:83 schematic/scheme/conf/schematic/menu.scm:63
-#: schematic/scheme/gschem/builtins.scm:117
 msgid "Multiple Copy Mode"
 msgstr "Mode Copie Multiple"
 
-#: schematic/src/i_basic.c:84
 msgid "Line Mode"
 msgstr "Mode Ligne"
 
-#: schematic/src/i_basic.c:85 schematic/scheme/conf/schematic/menu.scm:66
-#: schematic/scheme/gschem/builtins.scm:123
 msgid "Mirror Mode"
 msgstr "Mode Miroir"
 
-#: schematic/src/i_basic.c:86 schematic/scheme/conf/schematic/menu.scm:64
-#: schematic/scheme/gschem/builtins.scm:111
 msgid "Move Mode"
 msgstr "Mode Déplacement"
 
-#: schematic/src/i_basic.c:87
 #, fuzzy
 msgid "Path Mode"
 msgstr "Mode Panoramique"
 
-#: schematic/src/i_basic.c:88
 msgid "Picture Mode"
 msgstr "Mode Image"
 
-#: schematic/src/i_basic.c:89
 msgid "Pin Mode"
 msgstr "Mode Broche"
 
-#: schematic/src/i_basic.c:90 schematic/scheme/gschem/builtins.scm:120
 msgid "Rotate Mode"
 msgstr "Mode Rotation"
 
-#: schematic/src/i_basic.c:91
 #, fuzzy
 msgid "Modify Mode"
 msgstr "Mode Copie"
 
-#: schematic/src/i_basic.c:92 schematic/src/x_menus.c:49
-#: schematic/scheme/gschem/builtins.scm:204
 msgid "Zoom Box"
 msgstr "Zoom boîte"
 
-#: schematic/src/i_basic.c:121
 msgid "Show Hidden"
 msgstr "Montrer caché"
 
-#: schematic/src/i_basic.c:124
 msgid "Snap Off"
 msgstr "Snap Off"
 
-#: schematic/src/i_basic.c:126
 msgid "Resnap Active"
 msgstr "Resnap Actif"
 
-#: schematic/src/i_basic.c:288 schematic/src/x_colorcb.c:159
 msgid "Stroke"
 msgstr "Trait"
 
-#: schematic/src/i_basic.c:296 schematic/src/i_basic.c:330
-#: schematic/src/x_window.c:1361
 msgid "none"
 msgstr "aucun"
 
-#: schematic/src/i_basic.c:304
 msgid "Repeat/"
 msgstr "Répéter"
 
-#: schematic/src/i_basic.c:315
 msgid "Repeat/none"
 msgstr "Répéter/aucun"
 
-#: schematic/src/i_basic.c:323 schematic/src/i_callbacks.c:1239
-#: schematic/scheme/gschem/builtins.scm:189
 msgid "Pan"
 msgstr "Panoramique"
 
-#: schematic/src/i_callbacks.c:74
 #, fuzzy, c-format
 msgid "New page created [%1$s]"
 msgstr "Nouvelle page [%s] créée\n"
 
-#: schematic/src/i_callbacks.c:108
 #, fuzzy, c-format
 msgid "New Window created [%1$s]"
 msgstr "Nouvelle création de fenêtre [%s]\n"
 
-#: schematic/src/i_callbacks.c:245
 msgid "Failed to Save All"
 msgstr "Échec de la sauvegarde de toutes les pages"
 
-#: schematic/src/i_callbacks.c:247
 msgid "Saved All"
 msgstr "Toutes les pages enregistrées"
 
-#: schematic/src/i_callbacks.c:308
 #, fuzzy
 msgid "Closing Window"
 msgstr "Fermeture de la fenêtre\n"
 
-#: schematic/src/i_callbacks.c:505 schematic/src/x_menus.c:55
-#: schematic/scheme/gschem/builtins.scm:168
 msgid "Copy"
 msgstr "Copier"
 
-#: schematic/src/i_callbacks.c:514 schematic/src/i_callbacks.c:539
-#: schematic/src/i_callbacks.c:564
 msgid "Select objs first"
 msgstr "Sélectionnez d'abord des objets"
 
-#: schematic/src/i_callbacks.c:530
 msgid "Multiple Copy"
 msgstr "Copie Multiple"
 
-#: schematic/src/i_callbacks.c:555 schematic/src/x_menus.c:56
 msgid "Move"
 msgstr "Déplacer"
 
-#: schematic/src/i_callbacks.c:579 schematic/src/x_menus.c:57
-#: schematic/src/x_multiattrib.c:1656 schematic/scheme/gschem/builtins.scm:108
 msgid "Delete"
 msgstr "Supprimer"
 
-#: schematic/src/i_callbacks.c:603
 msgid "Edit"
 msgstr "Édition"
 
-#: schematic/src/i_callbacks.c:618 schematic/scheme/gschem/builtins.scm:129
 msgid "Edit Text"
 msgstr "Éditer le texte"
 
-#: schematic/src/i_callbacks.c:637
 msgid "Slot"
 msgstr "Slot"
 
-#: schematic/src/i_callbacks.c:688 schematic/src/i_callbacks.c:698
 msgid "Rotate"
 msgstr "Pivoter"
 
-#: schematic/src/i_callbacks.c:736 schematic/src/i_callbacks.c:746
 msgid "Mirror"
 msgstr "Miroir"
 
-#: schematic/src/i_callbacks.c:763 schematic/src/x_colorcb.c:160
-#: schematic/scheme/conf/schematic/menu.scm:73
-#: schematic/scheme/gschem/builtins.scm:141
 msgid "Lock"
 msgstr "Verrouiller"
 
-#: schematic/src/i_callbacks.c:781 schematic/scheme/conf/schematic/menu.scm:74
-#: schematic/scheme/gschem/builtins.scm:144
 msgid "Unlock"
 msgstr "Déverrouiller"
 
-#: schematic/src/i_callbacks.c:805
 #, fuzzy
 msgid "WARNING: Do not translate with snap off!"
 msgstr "ATTENTION : ne translatez pas quand le snap est désactivé !\n"
 
-#: schematic/src/i_callbacks.c:806
 #, fuzzy
 msgid "WARNING: Turning snap on and continuing with translate."
 msgstr "ATTENTION : activation du snap et poursuite de la translation.\n"
 
-#: schematic/src/i_callbacks.c:813
 #, fuzzy
 msgid "WARNING: Snap grid size is not equal to 100!"
 msgstr "ATTENTION : la taille du snap sur la grille n'est pas égale à 100 !\n"
 
-#: schematic/src/i_callbacks.c:815
 #, fuzzy
 msgid ""
 "WARNING: If you are translating a symbol to the origin, the snap grid size "
@@ -952,23 +730,18 @@ msgstr ""
 "ATTENTION : si vous déplacez un symbole à l'origine, la taille de snap de la "
 "grille devrait être de 100 !\n"
 
-#: schematic/src/i_callbacks.c:847
 msgid "Embed"
 msgstr "Embarquer"
 
-#: schematic/src/i_callbacks.c:886
 msgid "Unembed"
 msgstr "Débarquer"
 
-#: schematic/src/i_callbacks.c:928
 msgid "Update"
 msgstr "Mettre à jour"
 
-#: schematic/src/i_callbacks.c:970
 msgid "ShowHidden"
 msgstr "AfficheCaché"
 
-#: schematic/src/i_callbacks.c:1537
 #, c-format
 msgid ""
 "<b>Revert page:</b>\n"
@@ -979,100 +752,78 @@ msgid ""
 "discarded and page file will be reloaded from disk."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1555
 #, fuzzy
 msgid "Revert"
 msgstr "_Rétablir"
 
-#: schematic/src/i_callbacks.c:1647
 msgid "Copy to clipboard"
 msgstr "Copier vers le presse-papier"
 
-#: schematic/src/i_callbacks.c:1664
 msgid "Cut to clipboard"
 msgstr "Coupe la sélection dans le presse-papier"
 
-#: schematic/src/i_callbacks.c:1686
 msgid "Paste from clipboard"
 msgstr "Coller depuis le presse-papiers"
 
-#: schematic/src/i_callbacks.c:1694
 #, fuzzy
 msgid "Empty clipboard"
 msgstr "Copier vers le presse-papier"
 
 #. TRANSLATORS: The number is the number of the buffer that the
 #. * selection is being copied to.
-#: schematic/src/i_callbacks.c:1719
 #, fuzzy, c-format
 msgid "Copy %i"
 msgstr "Copier 1"
 
 #. TRANSLATORS: The number is the number of the buffer that the
 #. * selection is being cut to.
-#: schematic/src/i_callbacks.c:1746
 #, fuzzy, c-format
 msgid "Cut %i"
 msgstr "Couper 1"
 
 #. TRANSLATORS: The number is the number of the buffer that is being
 #. * pasted to the schematic.
-#: schematic/src/i_callbacks.c:1776
 #, fuzzy, c-format
 msgid "Paste %i"
 msgstr "Coller 1"
 
-#: schematic/src/i_callbacks.c:1785
 msgid "Empty buffer"
 msgstr "Tampon vide"
 
-#: schematic/src/i_callbacks.c:1833 schematic/src/x_window.c:1203
 msgid "Component"
 msgstr "Composant"
 
-#: schematic/src/i_callbacks.c:1865 schematic/src/x_colorcb.c:150
 msgid "Attribute"
 msgstr "Attribut"
 
-#: schematic/src/i_callbacks.c:1885 schematic/src/x_colorcb.c:149
 msgid "Net"
 msgstr "Piste"
 
-#: schematic/src/i_callbacks.c:1928 schematic/src/x_colorcb.c:155
-#: schematic/src/x_window.c:1222
 msgid "Bus"
 msgstr "Bus"
 
-#: schematic/src/i_callbacks.c:2004
 msgid "Line"
 msgstr "Ligne"
 
-#: schematic/src/i_callbacks.c:2021
 msgid "Path"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2043
 msgid "Box"
 msgstr "Cadre"
 
-#: schematic/src/i_callbacks.c:2085
 msgid "Circle"
 msgstr "Cercle"
 
-#: schematic/src/i_callbacks.c:2108
 msgid "Arc"
 msgstr "Arc"
 
-#: schematic/src/i_callbacks.c:2131 schematic/src/x_colorcb.c:146
 msgid "Pin"
 msgstr "Broche"
 
-#: schematic/src/i_callbacks.c:2191
 #, fuzzy, c-format
 msgid "Searching for source [%1$s]"
 msgstr "Recherche de source [%s]\n"
 
-#: schematic/src/i_callbacks.c:2223
 #, fuzzy, c-format
 msgid ""
 "Failed to descend hierarchy into '%1$s': %2$s\n"
@@ -1083,121 +834,96 @@ msgstr ""
 "\n"
 "Le journal gschem pourrait contenir plus d'informations."
 
-#: schematic/src/i_callbacks.c:2227
 #, fuzzy, c-format
 msgid "Failed to descend into '%1$s': %2$s"
 msgstr "Impossible de remplacer les images: %s"
 
-#: schematic/src/i_callbacks.c:2234
 #, fuzzy
 msgid "Failed to descend hierarchy."
 msgstr "descendre dans la hiérarchie"
 
-#: schematic/src/i_callbacks.c:2312
 #, fuzzy, c-format
 msgid "Searching for symbol [%1$s]"
 msgstr "Recherche du symbole [%s]\n"
 
-#: schematic/src/i_callbacks.c:2320
 #, fuzzy
 msgid "Symbol is not a real file. Symbol cannot be loaded."
 msgstr "Le symbole n'est pas un fichier réel. Il ne peut pas être chargé.\n"
 
-#: schematic/src/i_callbacks.c:2367 schematic/src/x_tabs.c:1060
 #, fuzzy
 msgid "Cannot find any schematics above the current one!"
 msgstr "Impossible de trouver des schémas au-dessus de celui-ci!\n"
 
-#: schematic/src/i_callbacks.c:2400
 msgid "Attach"
 msgstr "Attacher"
 
-#: schematic/src/i_callbacks.c:2456
 msgid "Detach"
 msgstr "Détacher"
 
-#: schematic/src/i_callbacks.c:2500
 msgid "ShowN"
 msgstr "MontrerN"
 
-#: schematic/src/i_callbacks.c:2537
 msgid "ShowV"
 msgstr "MontrerV"
 
-#: schematic/src/i_callbacks.c:2574
 msgid "ShowB"
 msgstr "MontrerNV"
 
-#: schematic/src/i_callbacks.c:2612
 msgid "VisToggle"
 msgstr "VisToggle"
 
-#: schematic/src/i_callbacks.c:2643
 #, c-format
 msgid "Sorry but this is a non-functioning menu option\n"
 msgstr "Désolé mais c'est une option de menu non fonctionnelle\n"
 
-#: schematic/src/i_callbacks.c:2703
 #, fuzzy
 msgid "Action feedback mode set to OUTLINE"
 msgstr "Mode de retour utilisateur positionné à OUTLINE\n"
 
-#: schematic/src/i_callbacks.c:2706
 #, fuzzy
 msgid "Action feedback mode set to BOUNDINGBOX"
 msgstr "Mode de retour utilisateur positionné à BOUNDINGBOX\n"
 
-#: schematic/src/i_callbacks.c:2730
 #, fuzzy
 msgid "Grid OFF"
 msgstr "Grille OFF\n"
 
-#: schematic/src/i_callbacks.c:2731
 #, fuzzy
 msgid "Dot grid selected"
 msgstr "Grille à points sélectionnée\n"
 
-#: schematic/src/i_callbacks.c:2732
 #, fuzzy
 msgid "Mesh grid selected"
 msgstr "Grille à mailles sélectionnée\n"
 
-#: schematic/src/i_callbacks.c:2733
 #, fuzzy
 msgid "Invalid grid mode"
 msgstr "Attribut invalide"
 
-#: schematic/src/i_callbacks.c:2755
 #, fuzzy
 msgid "Snap OFF (CAUTION!)"
 msgstr "Snap OFF (ATTENTION)\n"
 
-#: schematic/src/i_callbacks.c:2758
 #, fuzzy
 msgid "Snap ON"
 msgstr "Snap ON\n"
 
-#: schematic/src/i_callbacks.c:2761
 #, fuzzy
 msgid "Snap back to the grid (CAUTION!)"
 msgstr "Retour brusque à la grille (ATTENTION!)\n"
 
-#: schematic/src/i_callbacks.c:2790
 #, fuzzy
 msgid "Rubber band ON"
 msgstr "Mode piste élastique : ON\n"
 
-#: schematic/src/i_callbacks.c:2792
 #, fuzzy
 msgid "Rubber band OFF"
 msgstr "Mode piste élastique : OFF \n"
 
-#: schematic/src/i_callbacks.c:2811
 #, fuzzy
 msgid "magnetic net mode: ON"
 msgstr "Mode Piste Magnétique : ON\n"
 
-#: schematic/src/i_callbacks.c:2814
 #, fuzzy
 msgid "magnetic net mode: OFF"
 msgstr "Mode Piste Magnétique : OFF\n"
@@ -1207,153 +933,124 @@ msgstr "Mode Piste Magnétique : OFF\n"
 #. the form "untitled_N.sch", where N is a number.  Please make
 #. sure that the translation contains characters suitable for use
 #. in a filename.
-#: schematic/src/i_vars.c:209
 msgid "untitled"
 msgstr ""
 
-#: schematic/src/o_complex.c:192 schematic/src/o_complex.c:195
 #, fuzzy, c-format
 msgid "Translating schematic [%1$d %2$d]"
 msgstr "Translation du schéma [%d %d]\n"
 
-#: schematic/src/o_delete.c:82
 #, fuzzy, c-format
 msgid "Delete locked object?"
 msgid_plural "Delete %1$u locked objects?"
 msgstr[0] "les objets sélectionnés"
 msgstr[1] "les objets sélectionnés"
 
-#: schematic/src/o_misc.c:55
 #, c-format
 msgid "Got an unexpected NULL in o_edit\n"
 msgstr "o_current==NULL dans o_edit()\n"
 
-#: schematic/src/o_misc.c:315
 #, fuzzy
 msgid "Hidden text is now visible"
 msgstr "Le texte normalement caché est maintenant visible\n"
 
-#: schematic/src/o_misc.c:317
 #, fuzzy
 msgid "Hidden text is now invisible"
 msgstr "Le texte normalement caché est maintenant invisible\n"
 
-#: schematic/src/o_misc.c:425
 #, fuzzy, c-format
 msgid "Could not find symbol [%1$s] in library. Update failed."
 msgstr ""
 "Impossible de trouver le symbole [%s] dans la bibliothèque. Échec de la mise "
 "à jour.\n"
 
-#: schematic/src/o_misc.c:541
 #, fuzzy, c-format
 msgid "o_autosave_backups: Can't get the real filename of %1$s."
 msgstr ""
 "o_autosave_backups() : Impossible de récupérer le véritable nom du fichier %s"
 
-#: schematic/src/o_misc.c:585
 #, fuzzy, c-format
 msgid "Could NOT set previous backup file [%1$s] read-write"
 msgstr ""
 "Impossible de passer le fichier copie de sauvegarde [%s] en lecture/"
 "écriture\n"
 
-#: schematic/src/o_misc.c:605
 #, fuzzy, c-format
 msgid "Could NOT set backup file [%1$s] readonly"
 msgstr ""
 "Impossible de passer le fichier copie de sauvegarde [%s] en lecture seule\n"
 
-#: schematic/src/o_misc.c:610
 #, fuzzy, c-format
 msgid "Could NOT save backup file [%1$s]"
 msgstr "Échec lors de la création de la copie de sauvegarde [%s]\n"
 
-#: schematic/src/o_move.c:192
 #, c-format
 msgid "ERROR: NULL object in o_move_end!\n"
 msgstr "ERREUR : object==NULL dans o_move_end !\n"
 
-#: schematic/src/o_move.c:519
 #, c-format
 msgid "DOH! tried to find the whichone, but didn't find it!\n"
 msgstr "Incapable de déterminer le whichone de l'object !\n"
 
-#: schematic/src/o_move.c:546
 #, c-format
 msgid "Got a non line object in o_move_check_endpoint\n"
 msgstr "L'objet passé n'est pas une ligne dans o_move_check_endpoint\n"
 
-#: schematic/src/o_net.c:444
 #, fuzzy
 msgid "Warning: Starting net at off grid coordinate"
 msgstr ""
 "Attention; Démarrage d'une liaison en-dehors des coordonnées de la grille\n"
 
-#: schematic/src/o_net.c:508
 #, fuzzy
 msgid "Warning: Ending net at off grid coordinate"
 msgstr ""
 "Attention; Arrêt d'une liaison en-dehors des coordonnées de la grille\n"
 
-#: schematic/src/o_net.c:856 schematic/src/o_net.c:893
-#: schematic/src/o_net.c:964 schematic/src/o_net.c:1000
 #, c-format
 msgid "Tried to add more than two bus rippers. Internal gschem error.\n"
 msgstr ""
 "Tentative d'ajout de plus de deux jonctions de bus. Erreur interne gschem.\n"
 
-#: schematic/src/o_net.c:1068
 #, fuzzy, c-format
 msgid "Bus ripper symbol [%1$s] was not found in any component library"
 msgstr ""
 "Bus ripper symbol [%s] n'a été trouvé dans aucune librairie de composants\n"
 
-#: schematic/src/o_picture.c:133 schematic/src/o_picture.c:343
 #, fuzzy
 msgid "Select a picture file..."
 msgstr "Enregistrer en PostScript sous..."
 
-#: schematic/src/o_picture.c:166
 #, fuzzy, c-format
 msgid "Failed to load picture: %1$s"
 msgstr "Échec lors du chargement de l'image : %s"
 
-#: schematic/src/o_picture.c:182
 msgid "Picture"
 msgstr "Image"
 
-#: schematic/src/o_picture.c:378
 #, c-format
 msgid "Failed to replace pictures: %s"
 msgstr "Impossible de remplacer les images: %s"
 
-#: schematic/src/o_slot.c:80
 #, fuzzy
 msgid "Slot attribute malformed"
 msgstr "Attribut slot mal formé\n"
 
-#: schematic/src/o_slot.c:88
 #, fuzzy
 msgid "numslots attribute missing"
 msgstr "attribut numslots manquant\n"
 
-#: schematic/src/o_slot.c:89
 #, fuzzy
 msgid "Slotting not allowed for this component"
 msgstr "Le slotting n'est pas supporté par ce composant\n"
 
-#: schematic/src/o_slot.c:104
 #, fuzzy
 msgid "New slot number out of range"
 msgstr "Nouvelle valeur de slot hors plage\n"
 
-#: schematic/src/o_undo.c:397
 #, fuzzy
 msgid "Undo/Redo disabled in rc file"
 msgstr "Opérations Défaire/Refaire désactivées dans fichier rc\n"
 
-#: schematic/src/parsecmd.c:77
 #, fuzzy, c-format
 msgid ""
 "Usage: %1$s [OPTION ...] [--] [FILE ...]\n"
@@ -1401,12 +1098,11 @@ msgstr ""
 "En cas de bug, prévenir <https://bugs.launchpad.net/geda>\n"
 "Page d'accueil gEDA/gaf: <http://www.geda-project.org/>\n"
 
-#: schematic/src/parsecmd.c:110
 #, fuzzy, c-format
 msgid ""
 "Lepton EDA %1$s (git: %2$.7s)\n"
 "Copyright (C) 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright (C) 2017-2018 Lepton Developers.\n"
+"Copyright (C) 2017-2019 Lepton Developers.\n"
 "This is free software, and you are welcome to redistribute it under\n"
 "certain conditions. For details, see the file `COPYING', which is\n"
 "included in the Lepton EDA distribution.\n"
@@ -1420,80 +1116,61 @@ msgstr ""
 "inclus dans la distribution gEDA.\n"
 "Il n'y a AUCUNE GARANTIE autre que celles prévues par la loi.\n"
 
-#: schematic/src/x_attribedit.c:125
 #, c-format
 msgid "Got invalid show option; defaulting to show both\n"
 msgstr ""
 "Option d'affichage invalide ; changement pour affichage du nom et de la "
 "valeur\n"
 
-#: schematic/src/x_attribedit.c:139
 #, c-format
 msgid "ERROR: NULL object!\n"
 msgstr "ERREUR : object==NULL !\n"
 
-#: schematic/src/x_attribedit.c:328
 msgid "Single Attribute Editor"
 msgstr "Éditeur d'attribut"
 
-#: schematic/src/x_attribedit.c:358
 msgid "<b>Edit Attribute</b>"
 msgstr "<b>Éditer un attribut</b>"
 
-#: schematic/src/x_attribedit.c:360
 msgid "<b>Add Attribute</b>"
 msgstr "<b>Ajouter un attribut</b>"
 
-#: schematic/src/x_attribedit.c:376
 #, fuzzy
 msgid "N_ame:"
 msgstr "Nom :"
 
-#: schematic/src/x_attribedit.c:396 schematic/src/x_multiattrib.c:2222
 #, fuzzy
 msgid "_Value:"
 msgstr "Valeur :"
 
-#: schematic/src/x_attribedit.c:415 schematic/src/x_multiattrib.c:2281
 #, fuzzy
 msgid "Vi_sible"
 msgstr "Visible"
 
-#: schematic/src/x_attribedit.c:434
 msgid "Show Value Only"
 msgstr "Montrer seulement la valeur"
 
-#: schematic/src/x_attribedit.c:436
 msgid "Show Name Only"
 msgstr "Montrer seulement le nom"
 
-#: schematic/src/x_attribedit.c:438 schematic/src/x_multiattrib.c:1620
-#: schematic/scheme/gschem/builtins.scm:324
 msgid "Show Name & Value"
 msgstr "Montrer le nom et la valeur"
 
-#: schematic/src/x_attribedit.c:445
 msgid "<b>Attach Options</b>"
 msgstr "<b>Options d'attache</b>"
 
-#: schematic/src/x_attribedit.c:460
 msgid "All"
 msgstr "Tous"
 
-#: schematic/src/x_attribedit.c:476 schematic/src/x_compselect.c:986
-#: schematic/src/x_compselect.c:1100
 msgid "Components"
 msgstr "Composants"
 
-#: schematic/src/x_attribedit.c:492 schematic/src/x_window.c:1214
 msgid "Nets"
 msgstr "Pistes"
 
-#: schematic/src/x_attribedit.c:508
 msgid "Replace existing attributes"
 msgstr "Remplacer les attributs existants"
 
-#: schematic/src/x_autonumber.c:412
 #, fuzzy
 msgid ""
 "slotted object without slot attribute may cause problems when autonumbering "
@@ -1502,7 +1179,6 @@ msgstr ""
 "Les objets à slots sans attribut de slot sont susceptibles de créer des "
 "problèmes durant l'annotation automatique\n"
 
-#: schematic/src/x_autonumber.c:427
 #, fuzzy, c-format
 msgid ""
 "duplicate slot may cause problems: [symbolname=%1$s, number=%2$d, slot=%3$d]"
@@ -1510,99 +1186,76 @@ msgstr ""
 "Les slots dupliqués sont susceptibles de créer des problèmes : [symbolname="
 "%s, number=%d, slot=%d]\n"
 
-#: schematic/src/x_autonumber.c:675
 #, fuzzy
 msgid "No searchstring given in autonumber text."
 msgstr "Pas de motif de recherche fourni pour l'annotation automatique.\n"
 
-#: schematic/src/x_autonumber.c:728
 #, fuzzy
 msgid "No '*' or '?' given at the end of the autonumber text."
 msgstr ""
 "Pas de caractère '*' ou '?' à la fin du motif de recherche pour annotation "
 "automatique.\n"
 
-#: schematic/src/x_autonumber.c:873
 msgid "Diagonal"
 msgstr "en diagonal"
 
-#: schematic/src/x_autonumber.c:874
 msgid "Top to bottom"
 msgstr "de haut en bas"
 
-#: schematic/src/x_autonumber.c:875
 msgid "Bottom to top"
 msgstr "de bas en haut"
 
-#: schematic/src/x_autonumber.c:876
 msgid "Left to right"
 msgstr "de gauche à droite"
 
-#: schematic/src/x_autonumber.c:877
 msgid "Right to left"
 msgstr "de droite à gauche"
 
-#: schematic/src/x_autonumber.c:878
 msgid "File order"
 msgstr "dans l'ordre des éléments du fichier"
 
-#: schematic/src/x_autonumber.c:1214
 msgid "Autonumber text"
 msgstr "Annotation automatique"
 
-#: schematic/src/x_autonumber.c:1237
 msgid "<b>Scope</b>"
 msgstr "<b>Portée</b>"
 
-#: schematic/src/x_autonumber.c:1259
 msgid "Search for:"
 msgstr "Motif de recherche :"
 
-#: schematic/src/x_autonumber.c:1273
 msgid "Autonumber text in:"
 msgstr "Annoter automatiquement :"
 
-#: schematic/src/x_autonumber.c:1280
 msgid "Skip numbers found in:"
 msgstr "Passer les nombres trouvés dans :"
 
-#: schematic/src/x_autonumber.c:1292 schematic/src/x_autonumber.c:1301
 msgid "Selected objects"
 msgstr "les objets sélectionnés"
 
-#: schematic/src/x_autonumber.c:1293 schematic/src/x_autonumber.c:1302
 msgid "Current page"
 msgstr "la page en cours"
 
-#: schematic/src/x_autonumber.c:1294 schematic/src/x_autonumber.c:1303
 msgid "Whole hierarchy"
 msgstr "la hiérarchie complète"
 
-#: schematic/src/x_autonumber.c:1305
 msgid "Overwrite existing numbers"
 msgstr "Remplacer les annotations existantes"
 
-#: schematic/src/x_autonumber.c:1310
 msgid "<b>Options</b>"
 msgstr "<b>Options</b>"
 
-#: schematic/src/x_autonumber.c:1332
 msgid "Starting number:"
 msgstr "Indice de départ :"
 
-#: schematic/src/x_autonumber.c:1339
 msgid "Sort order:"
 msgstr "Ordre :"
 
-#: schematic/src/x_autonumber.c:1371
 msgid "Remove numbers"
 msgstr "Supprimer les annotations"
 
-#: schematic/src/x_autonumber.c:1375
 msgid "Automatic slotting"
 msgstr "Slotting automatique"
 
-#: schematic/src/x_clipboard.c:245
 #, c-format
 msgid ""
 "<b>Invalid schematic on clipboard.</b>\n"
@@ -1613,175 +1266,135 @@ msgstr ""
 "\n"
 "Une erreur est survenue lors de l'insertion du contenu du presse-papier: %s."
 
-#: schematic/src/x_clipboard.c:247
 msgid "Clipboard insertion failed"
 msgstr "Échec de l'insertion du contenu copié"
 
-#: schematic/src/x_color.c:89 schematic/src/x_color.c:98
 #, fuzzy, c-format
 msgid "Could not allocate the color %1$s!\n"
 msgstr "Impossible d'allouer la couleur %s !\n"
 
-#: schematic/src/x_color.c:89
 msgid "black"
 msgstr "noir"
 
-#: schematic/src/x_color.c:98
 msgid "white"
 msgstr "blanc"
 
-#: schematic/src/x_color.c:120
 #, fuzzy, c-format
 msgid "Could not allocate display color %1$i!\n"
 msgstr "Impossible d'allouer la couleur affichée %i!\n"
 
-#: schematic/src/x_color.c:142
 #, fuzzy, c-format
 msgid "Could not allocate outline color %1$i!\n"
 msgstr "Impossible d'allouer la couleur de contour %i!\n"
 
-#: schematic/src/x_color.c:159
 #, fuzzy, c-format
 msgid "Tried to get an invalid color: %1$d\n"
 msgstr "Tentative d'obtention d'une couleur invalide : %d\n"
 
-#: schematic/src/x_colorcb.c:145
 msgid "Background"
 msgstr "Arrière-plan"
 
-#: schematic/src/x_colorcb.c:147
 msgid "Net endpoint"
 msgstr "Point d'arrêt de la liaison"
 
-#: schematic/src/x_colorcb.c:148
 msgid "Graphic"
 msgstr "Graphique"
 
-#: schematic/src/x_colorcb.c:151
 msgid "Logic bubble"
 msgstr "Bulle logique"
 
-#: schematic/src/x_colorcb.c:152
 msgid "Grid point"
 msgstr "Point de grille"
 
-#: schematic/src/x_colorcb.c:153
 #, fuzzy
 msgid "Detached attribute"
 msgstr "Attribut détaché"
 
-#: schematic/src/x_colorcb.c:156
 msgid "Selection"
 msgstr "Sélection"
 
-#: schematic/src/x_colorcb.c:157
 msgid "Bounding box"
 msgstr "Boîte englobante"
 
-#: schematic/src/x_colorcb.c:158
 msgid "Zoom box"
 msgstr "Boîte d'agrandissement"
 
-#: schematic/src/x_colorcb.c:161
 msgid "Output background"
 msgstr "Arrière-plan de sortie"
 
-#: schematic/src/x_colorcb.c:162
 msgid "Freestyle 1"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:163
 msgid "Freestyle 2"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:164
 msgid "Freestyle 3"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:165
 msgid "Freestyle 4"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:166
 msgid "Net junction"
 msgstr "Jonction de liaison"
 
-#: schematic/src/x_colorcb.c:167
 msgid "Mesh grid major"
 msgstr "Maille de la grille principale"
 
-#: schematic/src/x_colorcb.c:168
 msgid "Mesh grid minor"
 msgstr "Maille de la grille secondaire"
 
-#: schematic/src/x_colorcb.c:172
 msgid "Unknown"
 msgstr "Inconnu"
 
-#: schematic/src/x_compselect.c:1169
 #, fuzzy
 msgid "Reset filter"
 msgstr "Nouveau fichier"
 
-#: schematic/src/x_compselect.c:1192
 msgid "Reload all libraries"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1245 schematic/src/x_multiattrib.c:2092
 msgid "Value"
 msgstr "Valeur"
 
-#: schematic/src/x_compselect.c:1284
 msgid "Default behavior - reference component"
 msgstr "Comportement par défaut - référencer le composant"
 
-#: schematic/src/x_compselect.c:1287
 msgid "Embed component in schematic"
 msgstr "Embarquer le composant dans le schéma"
 
-#: schematic/src/x_compselect.c:1290
 msgid "Include component as individual objects"
 msgstr "Éclater le composant en objets individuels"
 
-#: schematic/src/x_compselect.c:1448
 msgid "Select Component..."
 msgstr "Sélecteur de composant..."
 
-#: schematic/src/x_compselect.c:1471
 #, fuzzy
 msgid "In Us_e"
 msgstr "En cours d'utilisation"
 
-#: schematic/src/x_compselect.c:1475
 #, fuzzy
 msgid "Lib_raries"
 msgstr "Bibliothèques"
 
-#: schematic/src/x_compselect.c:1484 schematic/src/x_fileselect.c:119
 msgid "Preview"
 msgstr "Prévisualisation"
 
-#: schematic/src/x_compselect.c:1510
 msgid "Attributes"
 msgstr "Attributs"
 
-#: schematic/src/x_dialog.c:325
 msgid "Major symbol changes detected."
 msgstr ""
 
-#: schematic/src/x_dialog.c:349
 msgid ""
 "Changes have occurred to the symbols shown below.\n"
 "\n"
 "Be sure to verify each of these symbols."
 msgstr ""
 
-#: schematic/src/x_dialog.c:369
 #, fuzzy
 msgid "Symbol"
 msgstr "sym - Symboles"
 
-#: schematic/src/x_dialog.c:406
 #, c-format
 msgid ""
 "<span weight=\"bold\" size=\"larger\">The input attribute \"%s\" is invalid\n"
@@ -1799,40 +1412,31 @@ msgstr ""
 "Le nom ne peut se terminer par un espace.\n"
 "La valeur ne peut débuter avec un espace."
 
-#: schematic/src/x_dialog.c:408
 msgid "Invalid Attribute"
 msgstr "Attribut invalide"
 
-#: schematic/src/x_fileselect.c:37
 msgid "Schematics"
 msgstr "sch - Schémas"
 
-#: schematic/src/x_fileselect.c:42
 msgid "Symbols"
 msgstr "sym - Symboles"
 
-#: schematic/src/x_fileselect.c:47
 msgid "Schematics and symbols"
 msgstr "sym/sch - Schémas et symboles"
 
-#: schematic/src/x_fileselect.c:53
 msgid "All files"
 msgstr "* - Tous fichiers"
 
-#: schematic/src/x_fileselect.c:169
 msgid "Open..."
 msgstr "Ouvrir..."
 
-#: schematic/src/x_fileselect.c:233
 msgid "Save as..."
 msgstr "Enregistrer sous..."
 
-#: schematic/src/x_fileselect.c:297
 #, fuzzy
 msgid "Save cancelled on user request"
 msgstr "Sauvegarde annulée sur demande de l'utilisateur\n"
 
-#: schematic/src/x_fileselect.c:334
 msgid ""
 "\n"
 "If you load the original file, the backup file will be overwritten in the "
@@ -1841,28 +1445,22 @@ msgid ""
 "Do you want to load the backup file?\n"
 msgstr ""
 
-#: schematic/src/x_fstylecb.c:73
 msgid "Hollow"
 msgstr "Vide"
 
-#: schematic/src/x_fstylecb.c:80
 msgid "Filled"
 msgstr "Plein"
 
-#: schematic/src/x_fstylecb.c:87
 msgid "Mesh"
 msgstr "Quadrillage"
 
-#: schematic/src/x_fstylecb.c:94
 msgid "Hatch"
 msgstr "Rayures"
 
-#: schematic/src/x_image.c:279
 #, fuzzy, c-format
 msgid "x_image_lowlevel: Unable to write %1$s file %2$s."
 msgstr "x_image_lowlevel: Impossible d'écrire le %s fichier %s.\n"
 
-#: schematic/src/x_image.c:289
 #, fuzzy, c-format
 msgid ""
 "There was the following error when saving image with type %1$s to filename:\n"
@@ -1876,303 +1474,238 @@ msgstr ""
 "\n"
 "%s.\n"
 
-#: schematic/src/x_image.c:309
 #, fuzzy, c-format
 msgid "Wrote color image to [%1$s] [%2$d x %3$d]"
 msgstr "Image couleur exportée dans fichier [%s] [%d x %d]\n"
 
-#: schematic/src/x_image.c:311
 #, fuzzy, c-format
 msgid "Wrote black and white image to [%1$s] [%2$d x %3$d]"
 msgstr "Image noire et blanche exportée dans fichier [%s] [%d x %d]\n"
 
-#: schematic/src/x_image.c:319
 #, fuzzy
 msgid "x_image_lowlevel: Unable to get pixbuf from gschem's window."
 msgstr ""
 "x_image_lowlevel(): Impossible de récupérer le pixbuf depuis la fenêtre de "
 "gschem.\n"
 
-#: schematic/src/x_image.c:358
 msgid "Width x Height"
 msgstr "Largeur x Hauteur"
 
-#: schematic/src/x_image.c:374
 msgid "Image type"
 msgstr "Type d'image"
 
-#: schematic/src/x_image.c:395
 msgid "Write image..."
 msgstr "Tracer l'image"
 
-#: schematic/src/x_linecapcb.c:74
 msgid "Butt"
 msgstr ""
 
-#: schematic/src/x_linecapcb.c:81
 msgid "Square"
 msgstr ""
 
-#: schematic/src/x_linecapcb.c:88
 msgid "Round"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:74
 msgid "Solid"
 msgstr "Continu"
 
-#: schematic/src/x_linetypecb.c:81
 msgid "Dotted"
 msgstr "Pointillés"
 
-#: schematic/src/x_linetypecb.c:88
 msgid "Dashed"
 msgstr "Tirets"
 
-#: schematic/src/x_linetypecb.c:95
 msgid "Center"
 msgstr "Centré"
 
-#: schematic/src/x_linetypecb.c:102
 msgid "Phantom"
 msgstr "Fantôme"
 
-#: schematic/src/x_menus.c:41 schematic/scheme/gschem/builtins.scm:267
 #, fuzzy
 msgid "Add Net"
 msgstr "/Ajouter une piste"
 
-#: schematic/src/x_menus.c:42 schematic/src/x_multiattrib.c:2187
-#: schematic/scheme/gschem/builtins.scm:264
 msgid "Add Attribute"
 msgstr "Ajouter un attribut"
 
-#: schematic/src/x_menus.c:43 schematic/scheme/gschem/builtins.scm:261
 #, fuzzy
 msgid "Add Component"
 msgstr "/Ajouter un composant..."
 
-#: schematic/src/x_menus.c:44 schematic/scheme/gschem/builtins.scm:270
 #, fuzzy
 msgid "Add Bus"
 msgstr "/Ajouter un bus"
 
-#: schematic/src/x_menus.c:45 schematic/scheme/gschem/builtins.scm:273
 #, fuzzy
 msgid "Add Text"
 msgstr "/Ajouter du texte"
 
-#: schematic/src/x_menus.c:47 schematic/scheme/gschem/builtins.scm:210
 #, fuzzy
 msgid "Zoom In"
 msgstr "/Zoom avant"
 
-#: schematic/src/x_menus.c:48 schematic/scheme/gschem/builtins.scm:213
 #, fuzzy
 msgid "Zoom Out"
 msgstr "/Zoom arrière"
 
-#: schematic/src/x_menus.c:50 schematic/scheme/gschem/builtins.scm:207
 #, fuzzy
 msgid "Zoom Extents"
 msgstr "/Agrandissement auto"
 
-#: schematic/src/x_menus.c:52 schematic/src/x_window.c:1233
 msgid "Select"
 msgstr "Sélectionner"
 
-#: schematic/src/x_menus.c:53 schematic/scheme/conf/schematic/menu.scm:69
-#: schematic/scheme/gschem/builtins.scm:126
 msgid "Edit..."
 msgstr "Éditer"
 
-#: schematic/src/x_menus.c:54 schematic/scheme/conf/schematic/menu.scm:68
 #, fuzzy
 msgid "Object Properties..."
 msgstr "<b>Propriétés du texte</b>"
 
-#: schematic/src/x_menus.c:59 schematic/scheme/gschem/builtins.scm:300
 #, fuzzy
 msgid "Down Schematic"
 msgstr "/Descendre dans le schéma"
 
-#: schematic/src/x_menus.c:60 schematic/scheme/gschem/builtins.scm:303
 #, fuzzy
 msgid "Down Symbol"
 msgstr "/Descendre dans le symbole"
 
-#: schematic/src/x_menus.c:61
 #, fuzzy
 msgid "Up"
 msgstr "/Remonter"
 
-#: schematic/src/x_menus.c:336
 #, fuzzy, c-format
 msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
 msgstr ""
 "Tentative de valider la sensibilité ou un menu inexistant d'un objet '%s'\n"
 
-#: schematic/src/x_menus.c:360
 #, c-format
 msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
 msgstr ""
 "Tentative de valider la sensibilité ou un menu inexistant d'un objet '%s'\n"
 
-#: schematic/src/x_misc.c:70
 msgid "The operating system is out of memory or resources."
 msgstr "Le système d'exploitation n'a plus assez de mémoire ou de ressources."
 
-#: schematic/src/x_multiattrib.c:798 schematic/src/x_multiattrib.c:2704
 msgid "<various>"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:930
 msgid "Attributes with empty name are not allowed. Please set a name."
 msgstr "Les attributs sans nom sont interdits. Donnez un nom."
 
-#: schematic/src/x_multiattrib.c:1622
 msgid "Show Value only"
 msgstr "Montrer seulement la valeur"
 
-#: schematic/src/x_multiattrib.c:1624
 msgid "Show Name only"
 msgstr "Montrer seulement le nom"
 
-#: schematic/src/x_multiattrib.c:1651
 msgid "Promote"
 msgstr "Promouvoir"
 
-#: schematic/src/x_multiattrib.c:1655
 msgid "Duplicate"
 msgstr "Cloner"
 
-#: schematic/src/x_multiattrib.c:1657
 #, fuzzy
 msgid "Copy to all"
 msgstr "Copier dans 1"
 
-#: schematic/src/x_multiattrib.c:1986 schematic/src/x_multiattrib.c:2602
 msgid "Edit Attributes"
 msgstr "Éditeur d'attributs"
 
-#: schematic/src/x_multiattrib.c:2112
 msgid "Vis?"
 msgstr "Vis?"
 
-#: schematic/src/x_multiattrib.c:2130
 msgid "N"
 msgstr "N"
 
-#: schematic/src/x_multiattrib.c:2148
 msgid "V"
 msgstr "V"
 
-#: schematic/src/x_multiattrib.c:2170
 #, fuzzy
 msgid "Sho_w inherited attributes"
 msgstr "Montrer les attributs hérités"
 
-#: schematic/src/x_multiattrib.c:2197
 #, fuzzy
 msgid "_Name:"
 msgstr "Nom :"
 
-#: schematic/src/x_multiattrib.c:2241
 msgid "Ctrl+Enter inserts new line; Ctrl+Tab inserts Tab"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2618
 #, c-format
 msgid "%2$i symbol (%1$s)"
 msgid_plural "%2$i symbols (%1$s)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2624
 #, fuzzy, c-format
 msgid "%1$i pin"
 msgid_plural "%1$i pins"
 msgstr[0] "Broche de liaison"
 msgstr[1] "Broche de liaison"
 
-#: schematic/src/x_multiattrib.c:2630
 #, c-format
 msgid "%1$i net"
 msgid_plural "%1$i nets"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2636
 #, c-format
 msgid "%1$i bus"
 msgid_plural "%1$i buses"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2642
 #, fuzzy, c-format
 msgid "%1$i attribute"
 msgid_plural "%1$i attributes"
 msgstr[0] "Attribut"
 msgstr[1] "Attribut"
 
-#: schematic/src/x_newtext.c:433
 msgid "Text Entry..."
 msgstr "Ajout de texte..."
 
-#: schematic/src/x_pagesel.c:253
 msgid "New Page"
 msgstr "Nouvelle page"
 
-#: schematic/src/x_pagesel.c:254
 msgid "Open Page..."
 msgstr "Ouvrir une page..."
 
-#: schematic/src/x_pagesel.c:256
 msgid "Save Page"
 msgstr "Enregistrer la page"
 
-#: schematic/src/x_pagesel.c:257 schematic/scheme/gschem/builtins.scm:246
 msgid "Close Page"
 msgstr "Fermer la page"
 
-#: schematic/src/x_pagesel.c:376 schematic/scheme/gschem/builtins.scm:237
 msgid "Page Manager"
 msgstr "Gestionnaire de pages"
 
-#: schematic/src/x_pagesel.c:448
 msgid "Changed"
 msgstr "Modifié"
 
-#: schematic/src/x_pagesel.c:468
 msgid "Right click on the filename for more options..."
 msgstr "Utilisez le clic droit sur le nom de fichier pour plus d'options..."
 
-#: schematic/src/x_print.c:306
 #, fuzzy, c-format
 msgid "Failed to write PDF to '%s': %s\n"
 msgstr "Impossible de remplacer les images: %s"
 
-#: schematic/src/x_print.c:364
 #, fuzzy, c-format
 msgid "Failed to write PDF to '%1$s': %2$s\n"
 msgstr "Impossible de remplacer les images: %s"
 
-#: schematic/src/x_print.c:449
 #, c-format
 msgid ""
 "Error printing file:\n"
 "%1$s"
 msgstr ""
 
-#: schematic/src/x_rc.c:39
 #, fuzzy
 msgid "ERROR: An unknown error occurred while parsing configuration files."
 msgstr ""
 "ERREUR: Une erreur inconnue a eu lieu lors du chargement des fichiers de "
 "configuration.\n"
 
-#: schematic/src/x_rc.c:44
 #, fuzzy
 msgid ""
 "An unknown error occurred while parsing configuration files.\n"
@@ -2184,12 +1717,10 @@ msgstr ""
 "\n"
 "Le journal de gschem pourrait contenir plus d'informations."
 
-#: schematic/src/x_rc.c:56
 #, fuzzy, c-format
 msgid "ERROR: %1$s"
 msgstr "ERREUR : %s\n"
 
-#: schematic/src/x_rc.c:59
 #, fuzzy, c-format
 msgid ""
 "%1$s\n"
@@ -2200,142 +1731,111 @@ msgstr ""
 "\n"
 "Le journal gschem pourrait contenir plus d'informations."
 
-#: schematic/src/x_rc.c:67
 #, fuzzy
 msgid "Cannot load lepton-schematic configuration."
 msgstr "Impossible de charger la configuration de gschem."
 
-#: schematic/src/x_script.c:42 schematic/scheme/conf/schematic/menu.scm:40
 msgid "Execute Script..."
 msgstr "Exécuter le script..."
 
-#: schematic/src/x_script.c:61
 #, fuzzy, c-format
 msgid "Executing guile script [%1$s]"
 msgstr "Exécution du script guile [%s]\n"
 
-#: schematic/src/x_tabs.c:860
 #, fuzzy, c-format
 msgid "Hierarchy up: %s"
 msgstr "Hié_rarchie"
 
-#: schematic/src/x_tabs.c:863
 #, fuzzy
 msgid "Hierarchy up"
 msgstr "Hié_rarchie"
 
-#: schematic/src/x_widgets.c:158 schematic/src/x_window.c:1444
 #, fuzzy
 msgid "Options"
 msgstr "_Options"
 
-#: schematic/src/x_widgets.c:203 schematic/src/x_window.c:1436
 #, fuzzy
 msgid "Object"
 msgstr "Couleur de l'objet :"
 
-#: schematic/src/x_widgets.c:224
 msgid "Log"
 msgstr ""
 
-#: schematic/src/x_widgets.c:245 schematic/src/x_window.c:1466
 msgid "Find Text"
 msgstr "Recherche de texte"
 
-#: schematic/src/x_widgets.c:259
 #, fuzzy
 msgid "Color Scheme Editor"
 msgstr "Couleurs _clairs"
 
-#: schematic/src/x_widgets.c:272 schematic/scheme/gschem/builtins.scm:378
 #, fuzzy
 msgid "Select Schematic Font"
 msgstr "_Sélectionnez les schémas que vous souhaitez enregistrer :"
 
-#: schematic/src/x_window.c:763
 #, fuzzy, c-format
 msgid "Loading schematic [%1$s]"
 msgstr "Chargement du schéma [%s]\n"
 
-#: schematic/src/x_window.c:864
 #, fuzzy, c-format
 msgid "Could NOT save page [%1$s]\n"
 msgstr "Échec sauvegarde de la page [%s]\n"
 
-#: schematic/src/x_window.c:865
 msgid "Error while trying to save"
 msgstr "Erreur lors de la tentative de sauvegarde"
 
-#: schematic/src/x_window.c:875
 msgid "Failed to save file"
 msgstr "Impossible d'enregistrer le fichier"
 
-#: schematic/src/x_window.c:885
 #, fuzzy, c-format
 msgid "Saved as [%1$s]"
 msgstr "Enregistré sous [%s]\n"
 
-#: schematic/src/x_window.c:887
 #, fuzzy, c-format
 msgid "Saved [%1$s]"
 msgstr "Enregistrer [%s]\n"
 
-#: schematic/src/x_window.c:889
 msgid "Saved"
 msgstr "Enregistrer"
 
-#: schematic/src/x_window.c:966
 #, fuzzy, c-format
 msgid "Discarding page [%1$s]"
 msgstr "Abandonne page [%s]\n"
 
-#: schematic/src/x_window.c:966
 #, fuzzy, c-format
 msgid "Closing [%1$s]"
 msgstr "Ferme [%s]\n"
 
-#: schematic/src/x_window.c:1175
 msgid "New"
 msgstr "Nouvelle"
 
-#: schematic/src/x_window.c:1175
 msgid "New file"
 msgstr "Nouveau fichier"
 
-#: schematic/src/x_window.c:1179
 msgid "Open"
 msgstr "Ouvrir"
 
-#: schematic/src/x_window.c:1179
 #, fuzzy
 msgid "Open file"
 msgstr "Ouvrir fichier..."
 
-#: schematic/src/x_window.c:1183 schematic/scheme/gschem/builtins.scm:59
 msgid "Save"
 msgstr "Enregistrer"
 
-#: schematic/src/x_window.c:1183
 msgid "Save file"
 msgstr "Enregistrer le fichier"
 
-#: schematic/src/x_window.c:1189 schematic/scheme/gschem/builtins.scm:93
 msgid "Undo"
 msgstr "Défaire"
 
-#: schematic/src/x_window.c:1189
 msgid "Undo last operation"
 msgstr "Défaire la dernière opération"
 
-#: schematic/src/x_window.c:1193 schematic/scheme/gschem/builtins.scm:96
 msgid "Redo"
 msgstr "Refaire"
 
-#: schematic/src/x_window.c:1193
 msgid "Redo last undo"
 msgstr "Refaire le dernier défait"
 
-#: schematic/src/x_window.c:1198
 msgid ""
 "Add component...\n"
 "Select library and component from list, move the mouse into main window, "
@@ -2347,7 +1847,6 @@ msgstr ""
 "pointeur dans la fenêtre principale.\n"
 "Clic gauche pour placer, clic droit pour annuler."
 
-#: schematic/src/x_window.c:1209
 msgid ""
 "Add nets mode\n"
 "Right mouse button to cancel"
@@ -2355,7 +1854,6 @@ msgstr ""
 "Mode ajout de piste\n"
 "Clic droit pour annuler"
 
-#: schematic/src/x_window.c:1217
 msgid ""
 "Add buses mode\n"
 "Right mouse button to cancel"
@@ -2363,45 +1861,35 @@ msgstr ""
 "Mode ajout de bus\n"
 "Clic droit pour annuler"
 
-#: schematic/src/x_window.c:1226
 msgid "Add Text..."
 msgstr "Ajouter du texte..."
 
-#: schematic/src/x_window.c:1233
 msgid "Select mode"
 msgstr "Mode sélection"
 
-#: schematic/src/x_window.c:1288
 #, fuzzy
 msgid "Show"
 msgstr "MontrerN"
 
-#: schematic/src/x_window.c:1289
 msgid "Show text starting with:"
 msgstr "Montrer le texte commençant par :"
 
-#: schematic/src/x_window.c:1345
 msgid "Menu/Cancel"
 msgstr "Menu/Annuler"
 
-#: schematic/src/x_window.c:1349
 msgid "Pan/Cancel"
 msgstr "Panoramique/Annuler"
 
-#: schematic/src/x_window.c:1359
 msgid "Pick"
 msgstr "Prendre"
 
-#: schematic/src/x_window.c:1470 schematic/scheme/gschem/builtins.scm:180
 msgid "Status"
 msgstr "Messages"
 
-#: schematic/src/x_window.c:1568
 #, fuzzy, c-format
 msgid "New file [%s]"
 msgstr "Nouveau fichier [%s]\n"
 
-#: schematic/src/x_window.c:1598
 #, fuzzy, c-format
 msgid ""
 "<b>An error occurred while loading the requested file.</b>\n"
@@ -2419,902 +1907,692 @@ msgstr ""
 "Le chargement de '%s' a échoué: %s. Le journal gschem pourrait contenir plus "
 "d'informations."
 
-#: schematic/src/x_window.c:1617
 msgid "Failed to load file"
 msgstr "Échec lors du chargement du fichier"
 
-#: schematic/data/lepton-schematic.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Schematic Editor"
 msgstr "Éditeur de schémas gEDA"
 
-#: schematic/data/lepton-schematic.desktop.in:4
 #, fuzzy
 msgid "Create and edit electrical schematics and symbols with lepton-schematic"
 msgstr "Créer et éditer des schémas électriques et des symboles avec gschem"
 
-#: schematic/scheme/conf/schematic/menu.scm:27
 msgid "_New"
 msgstr "_Nouveau"
 
-#: schematic/scheme/conf/schematic/menu.scm:28
 msgid "_Open..."
 msgstr "_Ouvrir..."
 
-#: schematic/scheme/conf/schematic/menu.scm:30
 msgid "Open Recen_t"
 msgstr "_Récemment ouverts"
 
-#: schematic/scheme/conf/schematic/menu.scm:32
 msgid "_Save"
 msgstr "_Enregistrer"
 
-#: schematic/scheme/conf/schematic/menu.scm:33
 msgid "Save _As..."
 msgstr "Enregistrer _sous..."
 
-#: schematic/scheme/conf/schematic/menu.scm:34
-#: schematic/scheme/gschem/builtins.scm:65
 msgid "Save All"
 msgstr "Enregistrer toutes les pages"
 
-#: schematic/scheme/conf/schematic/menu.scm:36
 msgid "_Print..."
 msgstr "_Imprimer..."
 
-#: schematic/scheme/conf/schematic/menu.scm:37
 #, fuzzy
 msgid "Write _Image..."
 msgstr "Tracer l'image"
 
-#: schematic/scheme/conf/schematic/menu.scm:39
 #, fuzzy
 msgid "Invoke Macro..."
 msgstr "Lancer une Macro"
 
-#: schematic/scheme/conf/schematic/menu.scm:41
 msgid "REPL..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:43
-#: schematic/scheme/gschem/builtins.scm:77
 msgid "New Window"
 msgstr "Nouvelle fenêtre"
 
-#: schematic/scheme/conf/schematic/menu.scm:44
 msgid "_Close Window"
 msgstr "_Fermer la fenêtre"
 
-#: schematic/scheme/conf/schematic/menu.scm:45
 msgid "_Quit"
 msgstr "_Quitter"
 
-#: schematic/scheme/conf/schematic/menu.scm:51
 msgid "_Undo"
 msgstr "A_nnuler"
 
-#: schematic/scheme/conf/schematic/menu.scm:52
 msgid "_Redo"
 msgstr "_Rétablir"
 
-#: schematic/scheme/conf/schematic/menu.scm:54
 msgid "Cu_t"
 msgstr "Co_uper"
 
-#: schematic/scheme/conf/schematic/menu.scm:55
 msgid "_Copy"
 msgstr "_Copier"
 
-#: schematic/scheme/conf/schematic/menu.scm:56
 msgid "_Paste"
 msgstr "C_oller"
 
-#: schematic/scheme/conf/schematic/menu.scm:57
 msgid "_Delete"
 msgstr "_Supprimer"
 
-#: schematic/scheme/conf/schematic/menu.scm:60
-#: schematic/scheme/gschem/builtins.scm:102
 msgid "Select All"
 msgstr "Sélectionner tout"
 
-#: schematic/scheme/conf/schematic/menu.scm:61
-#: schematic/scheme/gschem/builtins.scm:105
 msgid "Deselect"
 msgstr "Dé-sélectionner"
 
-#: schematic/scheme/conf/schematic/menu.scm:65
 msgid "Rotate 90 Mode"
 msgstr "Mode Rotation 90"
 
-#: schematic/scheme/conf/schematic/menu.scm:70
 msgid "Edit Text..."
 msgstr "Éditer le texte..."
 
-#: schematic/scheme/conf/schematic/menu.scm:71
 msgid "Slot..."
 msgstr "Slot..."
 
-#: schematic/scheme/conf/schematic/menu.scm:76
-#: schematic/scheme/gschem/builtins.scm:150
 msgid "Embed Component/Picture"
 msgstr "Embarquer le composant/l'image"
 
-#: schematic/scheme/conf/schematic/menu.scm:77
-#: schematic/scheme/gschem/builtins.scm:153
 msgid "Unembed Component/Picture"
 msgstr "Débarquer le composant/l'image"
 
-#: schematic/scheme/conf/schematic/menu.scm:78
-#: schematic/scheme/gschem/builtins.scm:156
 msgid "Update Component"
 msgstr "Mise à jour du composant"
 
-#: schematic/scheme/conf/schematic/menu.scm:79
 msgid "Symbol Translate..."
 msgstr "Translater le symbole..."
 
-#: schematic/scheme/conf/schematic/menu.scm:85
 msgid "Copy into 1"
 msgstr "Copier dans 1"
 
-#: schematic/scheme/conf/schematic/menu.scm:86
 msgid "Copy into 2"
 msgstr "Copier dans 2"
 
-#: schematic/scheme/conf/schematic/menu.scm:87
 msgid "Copy into 3"
 msgstr "Copier dans 3"
 
-#: schematic/scheme/conf/schematic/menu.scm:88
 msgid "Copy into 4"
 msgstr "Copier dans 4"
 
-#: schematic/scheme/conf/schematic/menu.scm:89
 msgid "Copy into 5"
 msgstr "Copier dans 5"
 
-#: schematic/scheme/conf/schematic/menu.scm:90
 msgid "Cut into 1"
 msgstr "Couper dans 1"
 
-#: schematic/scheme/conf/schematic/menu.scm:91
 msgid "Cut into 2"
 msgstr "Couper dans 2"
 
-#: schematic/scheme/conf/schematic/menu.scm:92
 msgid "Cut into 3"
 msgstr "Couper dans 3"
 
-#: schematic/scheme/conf/schematic/menu.scm:93
 msgid "Cut into 4"
 msgstr "Couper dans 4"
 
-#: schematic/scheme/conf/schematic/menu.scm:94
 msgid "Cut into 5"
 msgstr "Couper dans 5"
 
-#: schematic/scheme/conf/schematic/menu.scm:95
 msgid "Paste from 1"
 msgstr "Coller depuis 1"
 
-#: schematic/scheme/conf/schematic/menu.scm:96
 msgid "Paste from 2"
 msgstr "Coller depuis 2"
 
-#: schematic/scheme/conf/schematic/menu.scm:97
 msgid "Paste from 3"
 msgstr "Coller depuis 3"
 
-#: schematic/scheme/conf/schematic/menu.scm:98
 msgid "Paste from 4"
 msgstr "Coller depuis 4"
 
-#: schematic/scheme/conf/schematic/menu.scm:99
 msgid "Paste from 5"
 msgstr "Coller depuis 5"
 
-#: schematic/scheme/conf/schematic/menu.scm:105
 msgid "Side Dock"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:106
 #, fuzzy
 msgid "Bottom Dock"
 msgstr "de bas en haut"
 
-#: schematic/scheme/conf/schematic/menu.scm:108
 #, fuzzy
 msgid "Find Text Results"
 msgstr "Recherche de texte"
 
-#: schematic/scheme/conf/schematic/menu.scm:110
 msgid "_Redraw"
 msgstr "_Redessiner"
 
-#: schematic/scheme/conf/schematic/menu.scm:111
 msgid "_Pan"
 msgstr "_Déplacer"
 
-#: schematic/scheme/conf/schematic/menu.scm:112
 msgid "Zoom _Box"
 msgstr "_Zone de Zoom"
 
-#: schematic/scheme/conf/schematic/menu.scm:113
 msgid "Zoom _Extents"
 msgstr "A_juster au mieux"
 
-#: schematic/scheme/conf/schematic/menu.scm:114
 msgid "Zoom _In"
 msgstr "Zoom a_vant"
 
-#: schematic/scheme/conf/schematic/menu.scm:115
 msgid "Zoom _Out"
 msgstr "Zoom a_rrière"
 
-#: schematic/scheme/conf/schematic/menu.scm:116
 msgid "Zoom _Full"
 msgstr "Zoom _Complet"
 
-#: schematic/scheme/conf/schematic/menu.scm:118
 #, fuzzy
 msgid "_Dark Color Scheme"
 msgstr "Couleurs _foncé"
 
-#: schematic/scheme/conf/schematic/menu.scm:119
 #, fuzzy
 msgid "_Light Color Scheme"
 msgstr "Couleurs _clairs"
 
-#: schematic/scheme/conf/schematic/menu.scm:120
 #, fuzzy
 msgid "B_W Color Scheme"
 msgstr "Mode N/_B"
 
-#: schematic/scheme/conf/schematic/menu.scm:122
 #, fuzzy
 msgid "Color Scheme Editor..."
 msgstr "Couleurs _clairs"
 
-#: schematic/scheme/conf/schematic/menu.scm:129
 msgid "_Manager..."
 msgstr "_Gestionnaire..."
 
-#: schematic/scheme/conf/schematic/menu.scm:131
 msgid "_Previous"
 msgstr "_Précédent"
 
-#: schematic/scheme/conf/schematic/menu.scm:132
 msgid "_Next"
 msgstr "_Suivant"
 
-#: schematic/scheme/conf/schematic/menu.scm:133
 msgid "_Close"
 msgstr "_Fermer"
 
-#: schematic/scheme/conf/schematic/menu.scm:135
 #, fuzzy
 msgid "_Revert..."
 msgstr "_Rétablir"
 
-#: schematic/scheme/conf/schematic/menu.scm:137
-#: schematic/scheme/gschem/builtins.scm:249
 #, fuzzy
 msgid "Next Tab"
 msgstr "Nouvelle page"
 
-#: schematic/scheme/conf/schematic/menu.scm:138
-#: schematic/scheme/gschem/builtins.scm:252
 #, fuzzy
 msgid "Previous Tab"
 msgstr "_Précédent"
 
-#: schematic/scheme/conf/schematic/menu.scm:146
 msgid "_Component..."
 msgstr "_Composant..."
 
-#: schematic/scheme/conf/schematic/menu.scm:148
 msgid "_Net"
 msgstr "_Piste"
 
-#: schematic/scheme/conf/schematic/menu.scm:149
 msgid "B_us"
 msgstr "B_us"
 
-#: schematic/scheme/conf/schematic/menu.scm:151
 msgid "_Attribute..."
 msgstr "_Attribut..."
 
-#: schematic/scheme/conf/schematic/menu.scm:152
 msgid "_Text..."
 msgstr "_Texte..."
 
-#: schematic/scheme/conf/schematic/menu.scm:154
 msgid "_Line"
 msgstr "_Ligne"
 
-#: schematic/scheme/conf/schematic/menu.scm:155
 msgid "Pat_h"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:156
 msgid "_Box"
 msgstr "_Cadre"
 
-#: schematic/scheme/conf/schematic/menu.scm:157
 msgid "C_ircle"
 msgstr "C_ercle"
 
-#: schematic/scheme/conf/schematic/menu.scm:158
 msgid "A_rc"
 msgstr "A_rc de cercle"
 
-#: schematic/scheme/conf/schematic/menu.scm:159
 msgid "_Pin"
 msgstr "_Broche"
 
-#: schematic/scheme/conf/schematic/menu.scm:161
 msgid "Pictu_re..."
 msgstr "_Image"
 
-#: schematic/scheme/conf/schematic/menu.scm:167
 msgid "_Up"
 msgstr "_Monter"
 
-#: schematic/scheme/conf/schematic/menu.scm:169
 msgid "_Down Schematic"
 msgstr "_Par Schématique"
 
-#: schematic/scheme/conf/schematic/menu.scm:170
 msgid "Down _Symbol"
 msgstr "Par _Symbol"
 
-#: schematic/scheme/conf/schematic/menu.scm:176
 msgid "_Attach"
 msgstr "_Attacher"
 
-#: schematic/scheme/conf/schematic/menu.scm:177
 msgid "_Detach"
 msgstr "_Détacher"
 
-#: schematic/scheme/conf/schematic/menu.scm:179
 msgid "Show _Value"
 msgstr "Afficher la _valeur"
 
-#: schematic/scheme/conf/schematic/menu.scm:180
 msgid "Show _Name"
 msgstr "Afficher le _nom"
 
-#: schematic/scheme/conf/schematic/menu.scm:181
 msgid "Show _Both"
 msgstr "Afficher les _deux"
 
-#: schematic/scheme/conf/schematic/menu.scm:182
 msgid "_Toggle Visibility"
 msgstr "_Inverser la visibilité"
 
-#: schematic/scheme/conf/schematic/menu.scm:184
 msgid "_Hide Specific Text..."
 msgstr "_Cacher le texte..."
 
-#: schematic/scheme/conf/schematic/menu.scm:185
 msgid "_Show Specific Text..."
 msgstr "_Afficher le texte..."
 
-#: schematic/scheme/conf/schematic/menu.scm:186
 #, fuzzy
 msgid "Show/Hide Hidden Text"
 msgstr "Afficher/Cacher le texte invisible"
 
-#: schematic/scheme/conf/schematic/menu.scm:188
 msgid "_Find Text/Check Symbol..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:189
 msgid "A_utonumber Text..."
 msgstr "A_nnotation automatique"
 
-#: schematic/scheme/conf/schematic/menu.scm:195
 #, fuzzy
 msgid "_Options..."
 msgstr "_Options"
 
-#: schematic/scheme/conf/schematic/menu.scm:196
 #, fuzzy
 msgid "_Font..."
 msgstr "_Imprimer..."
 
-#: schematic/scheme/conf/schematic/menu.scm:198
 #, fuzzy
 msgid "Grid +"
 msgstr "Grille OFF\n"
 
-#: schematic/scheme/conf/schematic/menu.scm:199
 #, fuzzy
 msgid "Grid -"
 msgstr "Grille OFF\n"
 
-#: schematic/scheme/conf/schematic/menu.scm:201
 msgid "Grid Style: Cycle Dots/Mesh/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:202
 msgid "Grid Snap: Cycle Grid/Resnap/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:204
 #, fuzzy
 msgid "Feedback Mode: Outline/Box"
 msgstr "Basculer vers _Aperçu/Zone"
 
-#: schematic/scheme/conf/schematic/menu.scm:205
 #, fuzzy
 msgid "Net: Rubberband On/Off"
 msgstr "Mode piste élastique : ON\n"
 
-#: schematic/scheme/conf/schematic/menu.scm:206
 msgid "Net: Magnetic On/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:208
 #, fuzzy
 msgid "_Coord Window"
 msgstr "_Fermer la fenêtre"
 
-#: schematic/scheme/conf/schematic/menu.scm:209
 #, fuzzy
 msgid "_Log Window"
 msgstr "Afficher le _journal des messages"
 
-#: schematic/scheme/conf/schematic/menu.scm:215
 msgid "_1 allegro"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:223
 #, fuzzy
 msgid "User _Guide"
 msgstr "gschem _FAQ..."
 
-#: schematic/scheme/conf/schematic/menu.scm:224
 msgid "_FAQ"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:225
 #, fuzzy
 msgid "Docu_mentation"
 msgstr "D_ocumentation..."
 
-#: schematic/scheme/conf/schematic/menu.scm:226
 msgid "_Wiki"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:228
 #, fuzzy
 msgid "Find Component D_ocumentation"
 msgstr "Documentation du composant"
 
-#: schematic/scheme/conf/schematic/menu.scm:230
 msgid "_Hotkeys..."
 msgstr "_Raccourcis"
 
-#: schematic/scheme/conf/schematic/menu.scm:231
 #, fuzzy
 msgid "_About"
 msgstr "À _propos..."
 
-#: schematic/scheme/conf/schematic/menu.scm:237
 msgid "_File"
 msgstr "_Fichier"
 
-#: schematic/scheme/conf/schematic/menu.scm:238
 msgid "_Edit"
 msgstr "É_dition"
 
-#: schematic/scheme/conf/schematic/menu.scm:240
 msgid "_View"
 msgstr "_Affichage"
 
-#: schematic/scheme/conf/schematic/menu.scm:241
 msgid "_Page"
 msgstr "_Page"
 
-#: schematic/scheme/conf/schematic/menu.scm:242
 msgid "_Add"
 msgstr "_Ajouter"
 
-#: schematic/scheme/conf/schematic/menu.scm:243
 msgid "Hie_rarchy"
 msgstr "Hié_rarchie"
 
-#: schematic/scheme/conf/schematic/menu.scm:244
 msgid "A_ttributes"
 msgstr "A_ttributs"
 
-#: schematic/scheme/conf/schematic/menu.scm:245
 msgid "_Options"
 msgstr "_Options"
 
-#: schematic/scheme/conf/schematic/menu.scm:246
 #, fuzzy
 msgid "_Netlist"
 msgstr "_Piste"
 
-#: schematic/scheme/conf/schematic/menu.scm:247
 msgid "_Help"
 msgstr "Aid_e"
 
-#: schematic/scheme/gschem/action.scm:43
 #, fuzzy, scheme-format
 msgid "~S is not a valid gschem action."
 msgstr "~S n'est pas une combinaison de touches valide."
 
-#: schematic/scheme/gschem/action.scm:158
 msgid "Repeat Last Action"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:47
 #, fuzzy
 msgid "Cancel"
 msgstr "Panoramique/Annuler"
 
-#: schematic/scheme/gschem/builtins.scm:53
 #, fuzzy
 msgid "New File"
 msgstr "Nouveau fichier"
 
-#: schematic/scheme/gschem/builtins.scm:56
 #, fuzzy
 msgid "Open File"
 msgstr "Ouvrir fichier..."
 
-#: schematic/scheme/gschem/builtins.scm:62
 #, fuzzy
 msgid "Save As"
 msgstr "Enregistrer toutes les pages"
 
-#: schematic/scheme/gschem/builtins.scm:68
 #, fuzzy
 msgid "Print"
 msgstr "Imprimer..."
 
-#: schematic/scheme/gschem/builtins.scm:71
 msgid "Export Image"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:74
 msgid "Run Script"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:80
 #, fuzzy
 msgid "Close Window"
 msgstr "_Fermer la fenêtre"
 
-#: schematic/scheme/gschem/builtins.scm:83
 #, fuzzy
 msgid "Quit"
 msgstr "_Quitter"
 
-#: schematic/scheme/gschem/builtins.scm:87
 msgid "Terminal REPL"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:132
 msgid "Choose Slot"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:135
 #, fuzzy
 msgid "Edit Object Properties"
 msgstr "Editer les propriétés du texte"
 
-#: schematic/scheme/gschem/builtins.scm:138
 #, fuzzy
 msgid "Translate Symbol"
 msgstr "Translater"
 
-#: schematic/scheme/gschem/builtins.scm:147
 msgid "Invoke Macro"
 msgstr "Lancer une Macro"
 
-#: schematic/scheme/gschem/builtins.scm:159
 #, fuzzy
 msgid "Show/Hide Invisible Text"
 msgstr "Afficher/Cacher le texte invisible"
 
-#: schematic/scheme/gschem/builtins.scm:165
 #, fuzzy
 msgid "Cut"
 msgstr "Co_uper"
 
-#: schematic/scheme/gschem/builtins.scm:171
 #, fuzzy
 msgid "Paste"
 msgstr "C_oller"
 
-#: schematic/scheme/gschem/builtins.scm:177
 msgid "Sidebar"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:183
 #, fuzzy
 msgid "Find Text State"
 msgstr "Recherche de texte"
 
-#: schematic/scheme/gschem/builtins.scm:186
 #, fuzzy
 msgid "Redraw"
 msgstr "_Redessiner"
 
-#: schematic/scheme/gschem/builtins.scm:192
 #, fuzzy
 msgid "Pan Left"
 msgstr "Mode Panoramique"
 
-#: schematic/scheme/gschem/builtins.scm:195
 #, fuzzy
 msgid "Pan Right"
 msgstr "En haut à droite"
 
-#: schematic/scheme/gschem/builtins.scm:198
 msgid "Pan Up"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:201
 #, fuzzy
 msgid "Pan Down"
 msgstr "Mode Panoramique"
 
-#: schematic/scheme/gschem/builtins.scm:216
 #, fuzzy
 msgid "Zoom Full"
 msgstr "Zoom _Complet"
 
-#: schematic/scheme/gschem/builtins.scm:219
 #, fuzzy
 msgid "Dark Color Scheme"
 msgstr "Couleurs _foncé"
 
-#: schematic/scheme/gschem/builtins.scm:222
 #, fuzzy
 msgid "Light Color Scheme"
 msgstr "Couleurs _clairs"
 
-#: schematic/scheme/gschem/builtins.scm:225
 msgid "Monochrome Color Scheme"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:228
 #, fuzzy
 msgid "Show Color Scheme Editor"
 msgstr "Couleurs _clairs"
 
-#: schematic/scheme/gschem/builtins.scm:234
 #, fuzzy
 msgid "Revert Changes"
 msgstr "Abandonner les modifications ?"
 
-#: schematic/scheme/gschem/builtins.scm:240
 #, fuzzy
 msgid "Previous Page"
 msgstr "_Précédent"
 
-#: schematic/scheme/gschem/builtins.scm:243
 #, fuzzy
 msgid "Next Page"
 msgstr "Nouvelle page"
 
-#: schematic/scheme/gschem/builtins.scm:255
 #, fuzzy
 msgid "Print Page"
 msgstr "_Précédent"
 
-#: schematic/scheme/gschem/builtins.scm:276
 #, fuzzy
 msgid "Add Line"
 msgstr "Ligne"
 
-#: schematic/scheme/gschem/builtins.scm:279
 #, fuzzy
 msgid "Add Path"
 msgstr "/Ajouter une piste"
 
-#: schematic/scheme/gschem/builtins.scm:282
 #, fuzzy
 msgid "Add Box"
 msgstr "/Ajouter un bus"
 
-#: schematic/scheme/gschem/builtins.scm:285
 #, fuzzy
 msgid "Add Circle"
 msgstr "Cercle"
 
-#: schematic/scheme/gschem/builtins.scm:288
 #, fuzzy
 msgid "Add Arc"
 msgstr "Ajouter un attribut"
 
-#: schematic/scheme/gschem/builtins.scm:291
 msgid "Add Pin"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:294
 #, fuzzy
 msgid "Add Picture"
 msgstr "Image"
 
-#: schematic/scheme/gschem/builtins.scm:306
 #, fuzzy
 msgid "Up Hierarchy"
 msgstr "Hié_rarchie"
 
-#: schematic/scheme/gschem/builtins.scm:312
 #, fuzzy
 msgid "Attach Attributes"
 msgstr "Éditeur d'attributs"
 
-#: schematic/scheme/gschem/builtins.scm:315
 #, fuzzy
 msgid "Detach Attributes"
 msgstr "Attribut détaché"
 
-#: schematic/scheme/gschem/builtins.scm:318
 #, fuzzy
 msgid "Show Attribute Value"
 msgstr "Attribut slot mal formé\n"
 
-#: schematic/scheme/gschem/builtins.scm:321
 #, fuzzy
 msgid "Show Attribute Name"
 msgstr "Attribut slot mal formé\n"
 
-#: schematic/scheme/gschem/builtins.scm:327
 #, fuzzy
 msgid "Toggle Text Visibility"
 msgstr "_Inverser la visibilité"
 
-#: schematic/scheme/gschem/builtins.scm:330
 #, fuzzy
 msgid "Find Specific Text"
 msgstr "_Rechercher le texte..."
 
-#: schematic/scheme/gschem/builtins.scm:333
 #, fuzzy
 msgid "Hide Specific Text"
 msgstr "_Cacher le texte..."
 
-#: schematic/scheme/gschem/builtins.scm:336
 #, fuzzy
 msgid "Show Specific Text"
 msgstr "_Afficher le texte..."
 
-#: schematic/scheme/gschem/builtins.scm:339
 #, fuzzy
 msgid "Autonumber Text"
 msgstr "Annotation automatique"
 
-#: schematic/scheme/gschem/builtins.scm:345
 #, fuzzy
 msgid "Show Hotkeys"
 msgstr "Raccourcis"
 
-#: schematic/scheme/gschem/builtins.scm:348
 msgid "Switch Grid Style"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:351
 msgid "Switch Snap Mode"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:354
 #, fuzzy
 msgid "Set Grid Spacing"
 msgstr "_Augmenter l'espacement de la grille"
 
-#: schematic/scheme/gschem/builtins.scm:357
 #, fuzzy
 msgid "Increase Grid Spacing"
 msgstr "_Augmenter l'espacement de la grille"
 
-#: schematic/scheme/gschem/builtins.scm:360
 #, fuzzy
 msgid "Decrease Grid Spacing"
 msgstr "_Augmenter l'espacement de la grille"
 
-#: schematic/scheme/gschem/builtins.scm:363
 #, fuzzy
 msgid "Toggle Outline Drawing"
 msgstr "Basculer vers _Aperçu/Zone"
 
-#: schematic/scheme/gschem/builtins.scm:366
 #, fuzzy
 msgid "Toggle Net Rubber Band"
 msgstr "Piste é_lastique On/Off"
 
-#: schematic/scheme/gschem/builtins.scm:369
 #, fuzzy
 msgid "Toggle Magnetic Nets"
 msgstr "Piste _magnétique On/Off"
 
-#: schematic/scheme/gschem/builtins.scm:372
 #, fuzzy
 msgid "Show Log Window"
 msgstr "Afficher le _journal des messages"
 
-#: schematic/scheme/gschem/builtins.scm:375
 #, fuzzy
 msgid "Show Coordinate Window"
 msgstr "Afficher les _coordonnées"
 
-#: schematic/scheme/gschem/builtins.scm:385
 #, fuzzy
 msgid "Component Documentation"
 msgstr "Documentation du composant"
 
-#: schematic/scheme/gschem/builtins.scm:387
 msgid "View documentation for selected component"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:403
 msgid ""
 "Could not show documentation for selected component:\n"
 "\n"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:408
 msgid "gEDA Manuals"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:409
 msgid "View the front page of the gEDA documentation in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:414
 #, fuzzy
 msgid "gschem User Guide"
 msgstr "gschem _FAQ..."
 
-#: schematic/scheme/gschem/builtins.scm:415
 msgid "View the gschem User Guide in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:420
 #, fuzzy
 msgid "gschem FAQ"
 msgstr "gschem _FAQ..."
 
-#: schematic/scheme/gschem/builtins.scm:421
 msgid "Frequently Asked Questions about using gschem."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:426
 #, fuzzy
 msgid "gEDA wiki"
 msgstr "gEDA _Wiki..."
 
-#: schematic/scheme/gschem/builtins.scm:427
 msgid "View the front page of the gEDA wiki in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:431
 msgid "About gschem"
 msgstr "À propos de gschem"
 
-#: schematic/scheme/gschem/deprecated.scm:102
 #, scheme-format
 msgid "Invalid text alignment ~A."
 msgstr "Alignement du paragraphe invalide ~A."
 
-#: schematic/scheme/gschem/gschemdoc.scm:241
 msgid "No documentation found"
 msgstr "Aucune documentation trouvée"
 
-#: schematic/scheme/gschem/keymap.scm:40
 #, scheme-format
 msgid "~S is not a valid key combination."
 msgstr "~S n'est pas une combinaison de touches valide."
 
-#: schematic/scheme/gschem/keymap.scm:157
 #, scheme-format
 msgid "~S is not a prefix key sequence."
 msgstr "~S n'est pas un préfixe valide."

--- a/schematic/po/he.po
+++ b/schematic/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-15 15:13+0300\n"
+"POT-Creation-Date: 2019-02-22 14:08+0300\n"
 "PO-Revision-Date: 2012-01-27 14:23+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -18,22 +18,18 @@ msgstr ""
 "X-Launchpad-Export-Date: 2012-11-14 16:52+0000\n"
 "X-Generator: Launchpad (build 16265)\n"
 
-#: schematic/src/a_zoom.c:155
 msgid "Zoom too small!  Cannot zoom further."
 msgstr ""
 
-#: schematic/src/color_edit_widget.c:399
 #, c-format
 msgid ""
 "Could not save file [%s]:\n"
 "%s"
 msgstr ""
 
-#: schematic/src/color_edit_widget.c:434
 msgid "Save Color Scheme As..."
 msgstr ""
 
-#: schematic/src/color_edit_widget.c:482 schematic/src/x_fileselect.c:292
 #, c-format
 msgid ""
 "The selected file `%1$s' already exists.\n"
@@ -41,178 +37,140 @@ msgid ""
 "Would you like to overwrite it?"
 msgstr ""
 
-#: schematic/src/color_edit_widget.c:486 schematic/src/x_fileselect.c:295
 msgid "Overwrite file?"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:211
 msgid "_Apply"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:215
 msgid "Sa_ve..."
 msgstr ""
 
-#: schematic/src/font_select_widget.c:278
 #, c-format
 msgid "<b>Current:</b> %s"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:453
 msgid "Save configuration"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:461
 msgid "Save settings to:"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:465
 msgid "Local configuration file (in current directory)"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:467
 msgid "User configuration file (geda-user.conf)"
 msgstr ""
 
-#: schematic/src/g_attrib.c:90
 msgid "Object ~A is not included in the current gschem page."
 msgstr ""
 
-#: schematic/src/g_attrib.c:110
 msgid "Invalid text name/value visibility ~A."
 msgstr ""
 
-#: schematic/src/g_rc.c:107
 #, c-format
 msgid "You are running gEDA/gaf version [%1$s%2$s.%3$s],\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:111
 #, c-format
 msgid ""
 "but you have a version [%1$s] gschemrc file:\n"
 "[%2$s]\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:114
 #, c-format
 msgid "Please be sure that you have the latest rc file.\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:240
 #, c-format
 msgid "Invalid size [%1$d] passed to text-size\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:283
 #, c-format
 msgid "Invalid size [%1$d] passed to snap-size\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:620
 #, c-format
 msgid "Invalid num levels [%1$d] passed to undo-levels\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:831
 #, c-format
 msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:931
 #, c-format
 msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:972
 #, c-format
 msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:998
 #, c-format
 msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1023
 #, c-format
 msgid "Invalid offset [%1$d] passed to add-attribute-offset\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1047
 #, c-format
 msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1071
 #, c-format
 msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1094
 #, c-format
 msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1118
 #, c-format
 msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1144
 #, c-format
 msgid "Invalid gain [%1$d] passed to zoom-gain\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1169
 #, c-format
 msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
 msgstr ""
 
-#: schematic/src/g_select.c:78 schematic/src/g_select.c:115
-#: schematic/src/g_select.c:151
 msgid "Object ~A is not directly included in a page."
 msgstr ""
 
-#: schematic/src/g_util.c:54
 msgid "Could not launch URI ~S: ~A"
 msgstr ""
 
-#: schematic/src/g_window.c:139
 msgid "Found invalid gschem window smob ~S"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:156
 #, c-format
 msgid "Lepton EDA/lepton-schematic version %1$s%2$s.%3$s git: %4$.7s"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:163
 #, c-format
 msgid "This is the MINGW32 port.\n"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:167
 #, c-format
 msgid "Current locale settings: %1$s\n"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:201
 #, c-format
 msgid "Couldn't find init scm file [%1$s]"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:206
 #, c-format
 msgid "Read init scm file [%1$s]"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:210
 #, c-format
 msgid "Failed to read init scm file [%1$s]"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:290
 #, c-format
 msgid ""
 "ERROR: Failed to load or evaluate startup script.\n"
@@ -220,687 +178,502 @@ msgid ""
 "The lepton-schematic log may contain more information.\n"
 msgstr ""
 
-#: schematic/src/gschem_about_dialog.c:51
 #, c-format
 msgid "%s (git: %.7s)"
 msgstr ""
 
-#: schematic/src/gschem_about_dialog.c:75
 msgid "Lepton Electronic Design Automation"
 msgstr ""
 
-#: schematic/src/gschem_about_dialog.c:83
 msgid ""
 "Copyright © 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright © 2017-2018 Lepton Developers.\n"
-"See AUTHORS and ChangeLog files for details."
+"Copyright © 2017-2019 Lepton Developers.\n"
+"See AUTHORS, ChangeLog files and consult 'git log' history for details."
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:69
 msgid "Upper Left"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:71
 msgid "Upper Middle"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:73
 msgid "Upper Right"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:78
 msgid "Middle Left"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:80
 msgid "Middle Middle"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:82
 msgid "Middle Right"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:87
 msgid "Lower Left"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:89
 msgid "Lower Middle"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:91
 msgid "Lower Right"
 msgstr ""
 
-#: schematic/src/gschem_arc_dialog.c:104
 msgid "Arc Params"
 msgstr ""
 
-#: schematic/src/gschem_arc_dialog.c:140
 msgid "Arc _Radius:"
 msgstr ""
 
-#: schematic/src/gschem_arc_dialog.c:141
 msgid "Start _Angle:"
 msgstr ""
 
-#: schematic/src/gschem_arc_dialog.c:142
 msgid "_Degrees of Sweep:"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:504
 msgid "Left mouse button"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:508
 msgid "Middle mouse button"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:512
 msgid "Right mouse button"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:595
 msgid "(Snap size, Grid size)"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:603
 msgid "Net rubber band mode"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:614
 msgid "Magnetic net mode"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:622
 msgid "Current action mode"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:935
-#: schematic/src/gschem_bottom_widget.c:951
 msgid "OFF"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:954
 msgid "NONE"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:960
 #, c-format
 msgid "Grid(%1$s, %2$s)"
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:350
-#: schematic/src/x_compselect.c:1236 schematic/src/x_multiattrib.c:2068
 msgid "Name"
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:372
 msgid "S_elect the schematics you want to save:"
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:467
 #, c-format
 msgid "Save the changes to schematic \"%1$s\" before closing?"
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:473
 #, c-format
 msgid ""
 "There are %1$d schematics with unsaved changes. Save changes before closing?"
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:502
 msgid "If you don't save, all your changes will be permanently lost."
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:522
 msgid "Close _without saving"
 msgstr ""
 
-#: schematic/src/gschem_coord_dialog.c:86
 msgid "Coords"
 msgstr ""
 
-#: schematic/src/gschem_coord_dialog.c:106
 msgid "Screen"
 msgstr ""
 
-#: schematic/src/gschem_coord_dialog.c:115
 msgid "World"
 msgstr ""
 
-#: schematic/src/gschem_find_text_state.c:809 schematic/src/x_pagesel.c:432
 msgid "Filename"
 msgstr ""
 
-#: schematic/src/gschem_find_text_state.c:821 schematic/src/i_callbacks.c:1970
-#: schematic/src/x_colorcb.c:154 schematic/src/x_widgets.c:179
-#: schematic/src/x_window.c:1226 schematic/src/x_window.c:1440
 msgid "Text"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:427
 msgid "descend into hierarchy"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:435
 msgid "Find"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:557
 #, fuzzy
 msgid "Find Text:"
 msgstr "ערוך טקסט"
 
-#: schematic/src/gschem_find_text_widget.c:564
 msgid "Find Pattern:"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:571
 msgid "Find Regex:"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:578
 msgid "Check symbol:"
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:200
 msgid "Hotkeys"
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:229
 msgid ""
 "Start typing action name or keystroke to filter the list.\n"
 "Type hotkeys as they are displayed in \"Keystroke(s)\" column."
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:233 schematic/src/x_compselect.c:1124
 #, fuzzy
 msgid "_Filter:"
 msgstr "קובץ"
 
-#: schematic/src/gschem_hotkey_dialog.c:259 schematic/src/i_basic.c:280
 msgid "Action"
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:277
 msgid "Keystroke(s)"
 msgstr ""
 
-#: schematic/src/gschem_log_widget.c:177
 msgid "** Invalid UTF-8 in log message. See stderr or gschem.log.\n"
 msgstr ""
 
-#: schematic/src/gschem_log_widget.c:434
 #, fuzzy
 msgid "Clear log window?"
 msgstr "חלון חדש"
 
-#: schematic/src/gschem_log_widget.c:477
 #, fuzzy
 msgid "Clear Log _Window"
 msgstr "חלון חדש"
 
-#: schematic/src/gschem_macro_widget.c:231
 msgid "Macro:"
 msgstr ""
 
-#: schematic/src/gschem_macro_widget.c:387
 msgid "Evaluate"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:172
 #, fuzzy
 msgid "_Fill Type:"
 msgstr "צורת מילוי..."
 
-#: schematic/src/gschem_object_properties_widget.c:173
 #, fuzzy
 msgid "Lin_e Width:"
 msgstr "סוג ורוחב קו..."
 
-#: schematic/src/gschem_object_properties_widget.c:174
 msgid "Angle _1:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:175
 msgid "P_itch 1:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:176
 msgid "Angle _2:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:177
 msgid "Pitc_h 2:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:237
 msgid "<b>Fill Properties</b>"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:255
-#: schematic/src/gschem_text_properties_widget.c:258
-#: schematic/src/x_newtext.c:271
 #, fuzzy
 msgid "Colo_r:"
 msgstr "צבע..."
 
-#: schematic/src/gschem_object_properties_widget.c:266
 msgid "<b>General Properties</b>"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:284
 #, fuzzy
 msgid "_Type:"
 msgstr "צורת מילוי..."
 
-#: schematic/src/gschem_object_properties_widget.c:285
 #, fuzzy
 msgid "_Width:"
 msgstr "סוג ורוחב קו..."
 
-#: schematic/src/gschem_object_properties_widget.c:286
 msgid "Dash _Length:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:287
 msgid "Dash _Space:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:288
 msgid "C_ap style:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:333
 msgid "<b>Line Properties</b>"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:351
 #, fuzzy
 msgid "_Pin Type:"
 msgstr "צורת מילוי..."
 
-#: schematic/src/gschem_object_properties_widget.c:362
 msgid "<b>Pin Properties</b>"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:217
 msgid "_Off"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:220
 msgid "_Dots"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:223
 msgid "M_esh"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:245
 msgid "Net R_ubber Band Mode:"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:246
 msgid "_Magnetic Net Mode:"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:250
-#: schematic/src/gschem_options_widget.c:251
 msgid "Enabled"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:265
 msgid "<b>Net Options</b>"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:282
 msgid "Grid Mode:"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:283
 #, fuzzy
 msgid "Snap Mode:"
 msgstr "מצב העתקה"
 
-#: schematic/src/gschem_options_widget.c:284
 #, fuzzy
 msgid "_Snap Size:"
 msgstr "מצב העתקה"
 
-#: schematic/src/gschem_options_widget.c:301
 msgid "<b>Snap Options</b>"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:340
 msgid "O_ff"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:343
 msgid "_Grid"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:346
 msgid "_Resnap"
 msgstr ""
 
-#: schematic/src/gschem_pin_type_combo.c:73
 msgid "Net pin"
 msgstr ""
 
-#: schematic/src/gschem_pin_type_combo.c:80
 msgid "Bus pin (graphical)"
 msgstr ""
 
-#: schematic/src/gschem_preview.c:195
 msgid "Preview Buffer"
 msgstr ""
 
-#: schematic/src/gschem_show_hide_text_widget.c:148
-#: schematic/src/x_window.c:1268
 msgid "Hide"
 msgstr ""
 
-#: schematic/src/gschem_show_hide_text_widget.c:157
-#: schematic/src/x_window.c:1269
 msgid "Hide text starting with:"
 msgstr ""
 
-#: schematic/src/gschem_slot_edit_dialog.c:91
 msgid "Edit slot number"
 msgstr ""
 
-#: schematic/src/gschem_slot_edit_dialog.c:121
 msgid "Number of Slots:"
 msgstr ""
 
-#: schematic/src/gschem_slot_edit_dialog.c:122
 msgid "Slot Number:"
 msgstr ""
 
-#: schematic/src/gschem_text_properties_widget.c:240
-#: schematic/src/x_newtext.c:265
 msgid "<b>Text Content</b>"
 msgstr ""
 
-#: schematic/src/gschem_text_properties_widget.c:259
-#: schematic/src/x_newtext.c:291
 msgid "_Size:"
 msgstr ""
 
-#: schematic/src/gschem_text_properties_widget.c:260
-#: schematic/src/x_newtext.c:310
 msgid "Ali_gnment:"
 msgstr ""
 
-#: schematic/src/gschem_text_properties_widget.c:261
-#: schematic/src/x_newtext.c:330
 msgid "Ro_tation:"
 msgstr ""
 
-#: schematic/src/gschem_text_properties_widget.c:294
-#: schematic/src/x_newtext.c:253
 msgid "<b>Text Properties</b>"
 msgstr ""
 
-#: schematic/src/gschem_translate_widget.c:238
 msgid "Coordinate:"
 msgstr ""
 
-#: schematic/src/gschem_translate_widget.c:405 schematic/src/i_callbacks.c:800
 msgid "Translate"
 msgstr ""
 
-#: schematic/src/i_basic.c:64 schematic/src/x_window.c:1369
-#: schematic/scheme/conf/schematic/menu.scm:59
-#: schematic/scheme/gschem/builtins.scm:99
 msgid "Select Mode"
 msgstr "מצב בחירה"
 
-#: schematic/src/i_basic.c:65
 #, fuzzy
 msgid "Select Box Mode"
 msgstr "מצב בחירה"
 
-#: schematic/src/i_basic.c:66
 msgid "Text Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:67
 msgid "Pan Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:70
 #, c-format
 msgid "Paste %d Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:74
 msgid "Magnetic Net Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:76
 msgid "Net Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:77
 msgid "Arc Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:78
 msgid "Box Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:79
 msgid "Bus Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:80
 msgid "Circle Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:81
 msgid "Component Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:82 schematic/scheme/conf/schematic/menu.scm:62
-#: schematic/scheme/gschem/builtins.scm:114
 msgid "Copy Mode"
 msgstr "מצב העתקה"
 
-#: schematic/src/i_basic.c:83 schematic/scheme/conf/schematic/menu.scm:63
-#: schematic/scheme/gschem/builtins.scm:117
 msgid "Multiple Copy Mode"
 msgstr "מצב העתקה מרובה"
 
-#: schematic/src/i_basic.c:84
 msgid "Line Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:85 schematic/scheme/conf/schematic/menu.scm:66
-#: schematic/scheme/gschem/builtins.scm:123
 msgid "Mirror Mode"
 msgstr "מצב ראי"
 
-#: schematic/src/i_basic.c:86 schematic/scheme/conf/schematic/menu.scm:64
-#: schematic/scheme/gschem/builtins.scm:111
 msgid "Move Mode"
 msgstr "מצב הזזה"
 
-#: schematic/src/i_basic.c:87
 #, fuzzy
 msgid "Path Mode"
 msgstr "מצב סיבוב 90"
 
-#: schematic/src/i_basic.c:88
 msgid "Picture Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:89
 msgid "Pin Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:90 schematic/scheme/gschem/builtins.scm:120
 msgid "Rotate Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:91
 #, fuzzy
 msgid "Modify Mode"
 msgstr "מצב העתקה"
 
-#: schematic/src/i_basic.c:92 schematic/src/x_menus.c:49
-#: schematic/scheme/gschem/builtins.scm:204
 msgid "Zoom Box"
 msgstr "תיבת תקריב"
 
-#: schematic/src/i_basic.c:121
 msgid "Show Hidden"
 msgstr ""
 
-#: schematic/src/i_basic.c:124
 msgid "Snap Off"
 msgstr ""
 
-#: schematic/src/i_basic.c:126
 msgid "Resnap Active"
 msgstr ""
 
-#: schematic/src/i_basic.c:288 schematic/src/x_colorcb.c:159
 msgid "Stroke"
 msgstr ""
 
-#: schematic/src/i_basic.c:296 schematic/src/i_basic.c:330
-#: schematic/src/x_window.c:1361
 msgid "none"
 msgstr ""
 
-#: schematic/src/i_basic.c:304
 msgid "Repeat/"
 msgstr ""
 
-#: schematic/src/i_basic.c:315
 msgid "Repeat/none"
 msgstr ""
 
-#: schematic/src/i_basic.c:323 schematic/src/i_callbacks.c:1239
-#: schematic/scheme/gschem/builtins.scm:189
 msgid "Pan"
 msgstr "עבור"
 
-#: schematic/src/i_callbacks.c:74
 #, c-format
 msgid "New page created [%1$s]"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:108
 #, c-format
 msgid "New Window created [%1$s]"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:245
 msgid "Failed to Save All"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:247
 msgid "Saved All"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:308
 #, fuzzy
 msgid "Closing Window"
 msgstr "חלון חדש"
 
-#: schematic/src/i_callbacks.c:505 schematic/src/x_menus.c:55
-#: schematic/scheme/gschem/builtins.scm:168
 msgid "Copy"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:514 schematic/src/i_callbacks.c:539
-#: schematic/src/i_callbacks.c:564
 msgid "Select objs first"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:530
 msgid "Multiple Copy"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:555 schematic/src/x_menus.c:56
 msgid "Move"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:579 schematic/src/x_menus.c:57
-#: schematic/src/x_multiattrib.c:1656 schematic/scheme/gschem/builtins.scm:108
 msgid "Delete"
 msgstr "מחק"
 
-#: schematic/src/i_callbacks.c:603
 msgid "Edit"
 msgstr "עריכה"
 
-#: schematic/src/i_callbacks.c:618 schematic/scheme/gschem/builtins.scm:129
 msgid "Edit Text"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:637
 msgid "Slot"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:688 schematic/src/i_callbacks.c:698
 msgid "Rotate"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:736 schematic/src/i_callbacks.c:746
 msgid "Mirror"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:763 schematic/src/x_colorcb.c:160
-#: schematic/scheme/conf/schematic/menu.scm:73
-#: schematic/scheme/gschem/builtins.scm:141
 msgid "Lock"
 msgstr "נעילה"
 
-#: schematic/src/i_callbacks.c:781 schematic/scheme/conf/schematic/menu.scm:74
-#: schematic/scheme/gschem/builtins.scm:144
 msgid "Unlock"
 msgstr "שחרר נעילה"
 
-#: schematic/src/i_callbacks.c:805
 msgid "WARNING: Do not translate with snap off!"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:806
 msgid "WARNING: Turning snap on and continuing with translate."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:813
 msgid "WARNING: Snap grid size is not equal to 100!"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:815
 msgid ""
 "WARNING: If you are translating a symbol to the origin, the snap grid size "
 "should be set to 100"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:847
 msgid "Embed"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:886
 msgid "Unembed"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:928
 msgid "Update"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:970
 msgid "ShowHidden"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1537
 #, c-format
 msgid ""
 "<b>Revert page:</b>\n"
@@ -911,98 +684,76 @@ msgid ""
 "discarded and page file will be reloaded from disk."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1555
 msgid "Revert"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1647
 msgid "Copy to clipboard"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1664
 msgid "Cut to clipboard"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1686
 msgid "Paste from clipboard"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1694
 msgid "Empty clipboard"
 msgstr ""
 
 #. TRANSLATORS: The number is the number of the buffer that the
 #. * selection is being copied to.
-#: schematic/src/i_callbacks.c:1719
 #, fuzzy, c-format
 msgid "Copy %i"
 msgstr "העתק אל 1"
 
 #. TRANSLATORS: The number is the number of the buffer that the
 #. * selection is being cut to.
-#: schematic/src/i_callbacks.c:1746
 #, fuzzy, c-format
 msgid "Cut %i"
 msgstr "גזור אל 1"
 
 #. TRANSLATORS: The number is the number of the buffer that is being
 #. * pasted to the schematic.
-#: schematic/src/i_callbacks.c:1776
 #, fuzzy, c-format
 msgid "Paste %i"
 msgstr "הדבק מ-1"
 
-#: schematic/src/i_callbacks.c:1785
 msgid "Empty buffer"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1833 schematic/src/x_window.c:1203
 msgid "Component"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1865 schematic/src/x_colorcb.c:150
 msgid "Attribute"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1885 schematic/src/x_colorcb.c:149
 msgid "Net"
 msgstr "חיבור"
 
-#: schematic/src/i_callbacks.c:1928 schematic/src/x_colorcb.c:155
-#: schematic/src/x_window.c:1222
 msgid "Bus"
 msgstr "אפיק"
 
-#: schematic/src/i_callbacks.c:2004
 msgid "Line"
 msgstr "קו"
 
-#: schematic/src/i_callbacks.c:2021
 msgid "Path"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2043
 msgid "Box"
 msgstr "מרובע"
 
-#: schematic/src/i_callbacks.c:2085
 msgid "Circle"
 msgstr "מעגל"
 
-#: schematic/src/i_callbacks.c:2108
 msgid "Arc"
 msgstr "קשת"
 
-#: schematic/src/i_callbacks.c:2131 schematic/src/x_colorcb.c:146
 msgid "Pin"
 msgstr "פין"
 
-#: schematic/src/i_callbacks.c:2191
 #, c-format
 msgid "Searching for source [%1$s]"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2223
 #, c-format
 msgid ""
 "Failed to descend hierarchy into '%1$s': %2$s\n"
@@ -1010,106 +761,81 @@ msgid ""
 "The lepton-schematic log may contain more information."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2227
 #, c-format
 msgid "Failed to descend into '%1$s': %2$s"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2234
 msgid "Failed to descend hierarchy."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2312
 #, c-format
 msgid "Searching for symbol [%1$s]"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2320
 msgid "Symbol is not a real file. Symbol cannot be loaded."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2367 schematic/src/x_tabs.c:1060
 msgid "Cannot find any schematics above the current one!"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2400
 msgid "Attach"
 msgstr "צרף"
 
-#: schematic/src/i_callbacks.c:2456
 msgid "Detach"
 msgstr "נתק"
 
-#: schematic/src/i_callbacks.c:2500
 msgid "ShowN"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2537
 msgid "ShowV"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2574
 msgid "ShowB"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2612
 msgid "VisToggle"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2643
 #, c-format
 msgid "Sorry but this is a non-functioning menu option\n"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2703
 msgid "Action feedback mode set to OUTLINE"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2706
 msgid "Action feedback mode set to BOUNDINGBOX"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2730
 msgid "Grid OFF"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2731
 msgid "Dot grid selected"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2732
 msgid "Mesh grid selected"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2733
 msgid "Invalid grid mode"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2755
 msgid "Snap OFF (CAUTION!)"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2758
 msgid "Snap ON"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2761
 msgid "Snap back to the grid (CAUTION!)"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2790
 msgid "Rubber band ON"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2792
 msgid "Rubber band OFF"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2811
 msgid "magnetic net mode: ON"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2814
 msgid "magnetic net mode: OFF"
 msgstr ""
 
@@ -1118,134 +844,105 @@ msgstr ""
 #. the form "untitled_N.sch", where N is a number.  Please make
 #. sure that the translation contains characters suitable for use
 #. in a filename.
-#: schematic/src/i_vars.c:209
 msgid "untitled"
 msgstr ""
 
-#: schematic/src/o_complex.c:192 schematic/src/o_complex.c:195
 #, c-format
 msgid "Translating schematic [%1$d %2$d]"
 msgstr ""
 
-#: schematic/src/o_delete.c:82
 #, c-format
 msgid "Delete locked object?"
 msgid_plural "Delete %1$u locked objects?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/o_misc.c:55
 #, c-format
 msgid "Got an unexpected NULL in o_edit\n"
 msgstr ""
 
-#: schematic/src/o_misc.c:315
 msgid "Hidden text is now visible"
 msgstr ""
 
-#: schematic/src/o_misc.c:317
 msgid "Hidden text is now invisible"
 msgstr ""
 
-#: schematic/src/o_misc.c:425
 #, c-format
 msgid "Could not find symbol [%1$s] in library. Update failed."
 msgstr ""
 
-#: schematic/src/o_misc.c:541
 #, c-format
 msgid "o_autosave_backups: Can't get the real filename of %1$s."
 msgstr ""
 
-#: schematic/src/o_misc.c:585
 #, c-format
 msgid "Could NOT set previous backup file [%1$s] read-write"
 msgstr ""
 
-#: schematic/src/o_misc.c:605
 #, c-format
 msgid "Could NOT set backup file [%1$s] readonly"
 msgstr ""
 
-#: schematic/src/o_misc.c:610
 #, c-format
 msgid "Could NOT save backup file [%1$s]"
 msgstr ""
 
-#: schematic/src/o_move.c:192
 #, c-format
 msgid "ERROR: NULL object in o_move_end!\n"
 msgstr ""
 
-#: schematic/src/o_move.c:519
 #, c-format
 msgid "DOH! tried to find the whichone, but didn't find it!\n"
 msgstr ""
 
-#: schematic/src/o_move.c:546
 #, c-format
 msgid "Got a non line object in o_move_check_endpoint\n"
 msgstr ""
 
-#: schematic/src/o_net.c:444
 msgid "Warning: Starting net at off grid coordinate"
 msgstr ""
 
-#: schematic/src/o_net.c:508
 msgid "Warning: Ending net at off grid coordinate"
 msgstr ""
 
-#: schematic/src/o_net.c:856 schematic/src/o_net.c:893
-#: schematic/src/o_net.c:964 schematic/src/o_net.c:1000
 #, c-format
 msgid "Tried to add more than two bus rippers. Internal gschem error.\n"
 msgstr ""
 
-#: schematic/src/o_net.c:1068
 #, c-format
 msgid "Bus ripper symbol [%1$s] was not found in any component library"
 msgstr ""
 
-#: schematic/src/o_picture.c:133 schematic/src/o_picture.c:343
 msgid "Select a picture file..."
 msgstr ""
 
-#: schematic/src/o_picture.c:166
 #, c-format
 msgid "Failed to load picture: %1$s"
 msgstr ""
 
-#: schematic/src/o_picture.c:182
 msgid "Picture"
 msgstr ""
 
-#: schematic/src/o_picture.c:378
 #, c-format
 msgid "Failed to replace pictures: %s"
 msgstr ""
 
-#: schematic/src/o_slot.c:80
 #, fuzzy
 msgid "Slot attribute malformed"
 msgstr "מאפיינים"
 
-#: schematic/src/o_slot.c:88
 msgid "numslots attribute missing"
 msgstr ""
 
-#: schematic/src/o_slot.c:89
 msgid "Slotting not allowed for this component"
 msgstr ""
 
-#: schematic/src/o_slot.c:104
 msgid "New slot number out of range"
 msgstr ""
 
-#: schematic/src/o_undo.c:397
 msgid "Undo/Redo disabled in rc file"
 msgstr ""
 
-#: schematic/src/parsecmd.c:77
 #, c-format
 msgid ""
 "Usage: %1$s [OPTION ...] [--] [FILE ...]\n"
@@ -1270,187 +967,143 @@ msgid ""
 "gEDA/gaf homepage: <http://www.geda-project.org/>\n"
 msgstr ""
 
-#: schematic/src/parsecmd.c:110
 #, c-format
 msgid ""
 "Lepton EDA %1$s (git: %2$.7s)\n"
 "Copyright (C) 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright (C) 2017-2018 Lepton Developers.\n"
+"Copyright (C) 2017-2019 Lepton Developers.\n"
 "This is free software, and you are welcome to redistribute it under\n"
 "certain conditions. For details, see the file `COPYING', which is\n"
 "included in the Lepton EDA distribution.\n"
 "There is NO WARRANTY, to the extent permitted by law.\n"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:125
 #, c-format
 msgid "Got invalid show option; defaulting to show both\n"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:139
 #, c-format
 msgid "ERROR: NULL object!\n"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:328
 msgid "Single Attribute Editor"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:358
 msgid "<b>Edit Attribute</b>"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:360
 msgid "<b>Add Attribute</b>"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:376
 msgid "N_ame:"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:396 schematic/src/x_multiattrib.c:2222
 msgid "_Value:"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:415 schematic/src/x_multiattrib.c:2281
 msgid "Vi_sible"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:434
 msgid "Show Value Only"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:436
 msgid "Show Name Only"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:438 schematic/src/x_multiattrib.c:1620
-#: schematic/scheme/gschem/builtins.scm:324
 msgid "Show Name & Value"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:445
 msgid "<b>Attach Options</b>"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:460
 msgid "All"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:476 schematic/src/x_compselect.c:986
-#: schematic/src/x_compselect.c:1100
 msgid "Components"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:492 schematic/src/x_window.c:1214
 msgid "Nets"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:508
 msgid "Replace existing attributes"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:412
 msgid ""
 "slotted object without slot attribute may cause problems when autonumbering "
 "slots"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:427
 #, c-format
 msgid ""
 "duplicate slot may cause problems: [symbolname=%1$s, number=%2$d, slot=%3$d]"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:675
 msgid "No searchstring given in autonumber text."
 msgstr ""
 
-#: schematic/src/x_autonumber.c:728
 msgid "No '*' or '?' given at the end of the autonumber text."
 msgstr ""
 
-#: schematic/src/x_autonumber.c:873
 msgid "Diagonal"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:874
 msgid "Top to bottom"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:875
 msgid "Bottom to top"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:876
 msgid "Left to right"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:877
 msgid "Right to left"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:878
 msgid "File order"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1214
 msgid "Autonumber text"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1237
 msgid "<b>Scope</b>"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1259
 msgid "Search for:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1273
 msgid "Autonumber text in:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1280
 msgid "Skip numbers found in:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1292 schematic/src/x_autonumber.c:1301
 msgid "Selected objects"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1293 schematic/src/x_autonumber.c:1302
 msgid "Current page"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1294 schematic/src/x_autonumber.c:1303
 msgid "Whole hierarchy"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1305
 msgid "Overwrite existing numbers"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1310
 msgid "<b>Options</b>"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1332
 msgid "Starting number:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1339
 msgid "Sort order:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1371
 msgid "Remove numbers"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1375
 msgid "Automatic slotting"
 msgstr ""
 
-#: schematic/src/x_clipboard.c:245
 #, c-format
 msgid ""
 "<b>Invalid schematic on clipboard.</b>\n"
@@ -1458,173 +1111,133 @@ msgid ""
 "An error occurred while inserting clipboard data: %s."
 msgstr ""
 
-#: schematic/src/x_clipboard.c:247
 msgid "Clipboard insertion failed"
 msgstr ""
 
-#: schematic/src/x_color.c:89 schematic/src/x_color.c:98
 #, c-format
 msgid "Could not allocate the color %1$s!\n"
 msgstr ""
 
-#: schematic/src/x_color.c:89
 msgid "black"
 msgstr ""
 
-#: schematic/src/x_color.c:98
 msgid "white"
 msgstr ""
 
-#: schematic/src/x_color.c:120
 #, c-format
 msgid "Could not allocate display color %1$i!\n"
 msgstr ""
 
-#: schematic/src/x_color.c:142
 #, c-format
 msgid "Could not allocate outline color %1$i!\n"
 msgstr ""
 
-#: schematic/src/x_color.c:159
 #, c-format
 msgid "Tried to get an invalid color: %1$d\n"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:145
 msgid "Background"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:147
 msgid "Net endpoint"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:148
 msgid "Graphic"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:151
 msgid "Logic bubble"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:152
 msgid "Grid point"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:153
 #, fuzzy
 msgid "Detached attribute"
 msgstr "מאפיינים"
 
-#: schematic/src/x_colorcb.c:156
 #, fuzzy
 msgid "Selection"
 msgstr "מצב בחירה"
 
-#: schematic/src/x_colorcb.c:157
 msgid "Bounding box"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:158
 #, fuzzy
 msgid "Zoom box"
 msgstr "תיבת תקריב"
 
-#: schematic/src/x_colorcb.c:161
 msgid "Output background"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:162
 msgid "Freestyle 1"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:163
 msgid "Freestyle 2"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:164
 msgid "Freestyle 3"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:165
 msgid "Freestyle 4"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:166
 msgid "Net junction"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:167
 msgid "Mesh grid major"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:168
 msgid "Mesh grid minor"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:172
 msgid "Unknown"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1169
 msgid "Reset filter"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1192
 msgid "Reload all libraries"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1245 schematic/src/x_multiattrib.c:2092
 msgid "Value"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1284
 msgid "Default behavior - reference component"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1287
 msgid "Embed component in schematic"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1290
 msgid "Include component as individual objects"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1448
 msgid "Select Component..."
 msgstr ""
 
-#: schematic/src/x_compselect.c:1471
 msgid "In Us_e"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1475
 msgid "Lib_raries"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1484 schematic/src/x_fileselect.c:119
 msgid "Preview"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1510
 msgid "Attributes"
 msgstr "מאפיינים"
 
-#: schematic/src/x_dialog.c:325
 msgid "Major symbol changes detected."
 msgstr ""
 
-#: schematic/src/x_dialog.c:349
 msgid ""
 "Changes have occurred to the symbols shown below.\n"
 "\n"
 "Be sure to verify each of these symbols."
 msgstr ""
 
-#: schematic/src/x_dialog.c:369
 msgid "Symbol"
 msgstr ""
 
-#: schematic/src/x_dialog.c:406
 #, c-format
 msgid ""
 "<span weight=\"bold\" size=\"larger\">The input attribute \"%s\" is invalid\n"
@@ -1635,39 +1248,30 @@ msgid ""
 "The value cannot start with a space."
 msgstr ""
 
-#: schematic/src/x_dialog.c:408
 msgid "Invalid Attribute"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:37
 msgid "Schematics"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:42
 msgid "Symbols"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:47
 msgid "Schematics and symbols"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:53
 msgid "All files"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:169
 msgid "Open..."
 msgstr ""
 
-#: schematic/src/x_fileselect.c:233
 msgid "Save as..."
 msgstr ""
 
-#: schematic/src/x_fileselect.c:297
 msgid "Save cancelled on user request"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:334
 msgid ""
 "\n"
 "If you load the original file, the backup file will be overwritten in the "
@@ -1676,28 +1280,22 @@ msgid ""
 "Do you want to load the backup file?\n"
 msgstr ""
 
-#: schematic/src/x_fstylecb.c:73
 msgid "Hollow"
 msgstr ""
 
-#: schematic/src/x_fstylecb.c:80
 msgid "Filled"
 msgstr ""
 
-#: schematic/src/x_fstylecb.c:87
 msgid "Mesh"
 msgstr ""
 
-#: schematic/src/x_fstylecb.c:94
 msgid "Hatch"
 msgstr ""
 
-#: schematic/src/x_image.c:279
 #, c-format
 msgid "x_image_lowlevel: Unable to write %1$s file %2$s."
 msgstr ""
 
-#: schematic/src/x_image.c:289
 #, c-format
 msgid ""
 "There was the following error when saving image with type %1$s to filename:\n"
@@ -1706,300 +1304,233 @@ msgid ""
 "%3$s.\n"
 msgstr ""
 
-#: schematic/src/x_image.c:309
 #, c-format
 msgid "Wrote color image to [%1$s] [%2$d x %3$d]"
 msgstr ""
 
-#: schematic/src/x_image.c:311
 #, c-format
 msgid "Wrote black and white image to [%1$s] [%2$d x %3$d]"
 msgstr ""
 
-#: schematic/src/x_image.c:319
 msgid "x_image_lowlevel: Unable to get pixbuf from gschem's window."
 msgstr ""
 
-#: schematic/src/x_image.c:358
 msgid "Width x Height"
 msgstr ""
 
-#: schematic/src/x_image.c:374
 msgid "Image type"
 msgstr ""
 
-#: schematic/src/x_image.c:395
 msgid "Write image..."
 msgstr "כתוב תמונה..."
 
-#: schematic/src/x_linecapcb.c:74
 msgid "Butt"
 msgstr ""
 
-#: schematic/src/x_linecapcb.c:81
 msgid "Square"
 msgstr ""
 
-#: schematic/src/x_linecapcb.c:88
 msgid "Round"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:74
 msgid "Solid"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:81
 msgid "Dotted"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:88
 msgid "Dashed"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:95
 msgid "Center"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:102
 msgid "Phantom"
 msgstr ""
 
-#: schematic/src/x_menus.c:41 schematic/scheme/gschem/builtins.scm:267
 msgid "Add Net"
 msgstr ""
 
-#: schematic/src/x_menus.c:42 schematic/src/x_multiattrib.c:2187
-#: schematic/scheme/gschem/builtins.scm:264
 msgid "Add Attribute"
 msgstr ""
 
-#: schematic/src/x_menus.c:43 schematic/scheme/gschem/builtins.scm:261
 #, fuzzy
 msgid "Add Component"
 msgstr "עדכן רכיב"
 
-#: schematic/src/x_menus.c:44 schematic/scheme/gschem/builtins.scm:270
 msgid "Add Bus"
 msgstr ""
 
-#: schematic/src/x_menus.c:45 schematic/scheme/gschem/builtins.scm:273
 #, fuzzy
 msgid "Add Text"
 msgstr "ערוך טקסט"
 
-#: schematic/src/x_menus.c:47 schematic/scheme/gschem/builtins.scm:210
 #, fuzzy
 msgid "Zoom In"
 msgstr "תיבת תקריב"
 
-#: schematic/src/x_menus.c:48 schematic/scheme/gschem/builtins.scm:213
 #, fuzzy
 msgid "Zoom Out"
 msgstr "תיבת תקריב"
 
-#: schematic/src/x_menus.c:50 schematic/scheme/gschem/builtins.scm:207
 #, fuzzy
 msgid "Zoom Extents"
 msgstr "תיבת תקריב"
 
-#: schematic/src/x_menus.c:52 schematic/src/x_window.c:1233
 msgid "Select"
 msgstr ""
 
-#: schematic/src/x_menus.c:53 schematic/scheme/conf/schematic/menu.scm:69
-#: schematic/scheme/gschem/builtins.scm:126
 msgid "Edit..."
 msgstr "ערוך..."
 
-#: schematic/src/x_menus.c:54 schematic/scheme/conf/schematic/menu.scm:68
 msgid "Object Properties..."
 msgstr ""
 
-#: schematic/src/x_menus.c:59 schematic/scheme/gschem/builtins.scm:300
 msgid "Down Schematic"
 msgstr ""
 
-#: schematic/src/x_menus.c:60 schematic/scheme/gschem/builtins.scm:303
 msgid "Down Symbol"
 msgstr ""
 
-#: schematic/src/x_menus.c:61
 msgid "Up"
 msgstr ""
 
-#: schematic/src/x_menus.c:336
 #, c-format
 msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
 msgstr ""
 
-#: schematic/src/x_menus.c:360
 #, c-format
 msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
 msgstr ""
 
-#: schematic/src/x_misc.c:70
 msgid "The operating system is out of memory or resources."
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:798 schematic/src/x_multiattrib.c:2704
 msgid "<various>"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:930
 msgid "Attributes with empty name are not allowed. Please set a name."
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1622
 msgid "Show Value only"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1624
 msgid "Show Name only"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1651
 msgid "Promote"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1655
 msgid "Duplicate"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1657
 #, fuzzy
 msgid "Copy to all"
 msgstr "העתק אל 1"
 
-#: schematic/src/x_multiattrib.c:1986 schematic/src/x_multiattrib.c:2602
 msgid "Edit Attributes"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2112
 msgid "Vis?"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2130
 msgid "N"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2148
 msgid "V"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2170
 #, fuzzy
 msgid "Sho_w inherited attributes"
 msgstr "מאפיינים"
 
-#: schematic/src/x_multiattrib.c:2197
 msgid "_Name:"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2241
 msgid "Ctrl+Enter inserts new line; Ctrl+Tab inserts Tab"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2618
 #, c-format
 msgid "%2$i symbol (%1$s)"
 msgid_plural "%2$i symbols (%1$s)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2624
 #, c-format
 msgid "%1$i pin"
 msgid_plural "%1$i pins"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2630
 #, c-format
 msgid "%1$i net"
 msgid_plural "%1$i nets"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2636
 #, c-format
 msgid "%1$i bus"
 msgid_plural "%1$i buses"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2642
 #, fuzzy, c-format
 msgid "%1$i attribute"
 msgid_plural "%1$i attributes"
 msgstr[0] "מאפיינים"
 msgstr[1] "מאפיינים"
 
-#: schematic/src/x_newtext.c:433
 msgid "Text Entry..."
 msgstr ""
 
-#: schematic/src/x_pagesel.c:253
 msgid "New Page"
 msgstr "דף חדש"
 
-#: schematic/src/x_pagesel.c:254
 msgid "Open Page..."
 msgstr "פתח דף..."
 
-#: schematic/src/x_pagesel.c:256
 msgid "Save Page"
 msgstr "שמור דף"
 
-#: schematic/src/x_pagesel.c:257 schematic/scheme/gschem/builtins.scm:246
 msgid "Close Page"
 msgstr "סגור דף"
 
-#: schematic/src/x_pagesel.c:376 schematic/scheme/gschem/builtins.scm:237
 msgid "Page Manager"
 msgstr ""
 
-#: schematic/src/x_pagesel.c:448
 msgid "Changed"
 msgstr ""
 
-#: schematic/src/x_pagesel.c:468
 msgid "Right click on the filename for more options..."
 msgstr ""
 
-#: schematic/src/x_print.c:306
 #, c-format
 msgid "Failed to write PDF to '%s': %s\n"
 msgstr ""
 
-#: schematic/src/x_print.c:364
 #, c-format
 msgid "Failed to write PDF to '%1$s': %2$s\n"
 msgstr ""
 
-#: schematic/src/x_print.c:449
 #, c-format
 msgid ""
 "Error printing file:\n"
 "%1$s"
 msgstr ""
 
-#: schematic/src/x_rc.c:39
 msgid "ERROR: An unknown error occurred while parsing configuration files."
 msgstr ""
 
-#: schematic/src/x_rc.c:44
 msgid ""
 "An unknown error occurred while parsing configuration files.\n"
 "\n"
 "The lepton-schematic log may contain more information."
 msgstr ""
 
-#: schematic/src/x_rc.c:56
 #, c-format
 msgid "ERROR: %1$s"
 msgstr ""
 
-#: schematic/src/x_rc.c:59
 #, c-format
 msgid ""
 "%1$s\n"
@@ -2007,138 +1538,107 @@ msgid ""
 "The lepton-schematic log may contain more information."
 msgstr ""
 
-#: schematic/src/x_rc.c:67
 msgid "Cannot load lepton-schematic configuration."
 msgstr ""
 
-#: schematic/src/x_script.c:42 schematic/scheme/conf/schematic/menu.scm:40
 msgid "Execute Script..."
 msgstr "בצע תסריט..."
 
-#: schematic/src/x_script.c:61
 #, c-format
 msgid "Executing guile script [%1$s]"
 msgstr ""
 
-#: schematic/src/x_tabs.c:860
 #, fuzzy, c-format
 msgid "Hierarchy up: %s"
 msgstr "היררכיה"
 
-#: schematic/src/x_tabs.c:863
 #, fuzzy
 msgid "Hierarchy up"
 msgstr "היררכיה"
 
-#: schematic/src/x_widgets.c:158 schematic/src/x_window.c:1444
 #, fuzzy
 msgid "Options"
 msgstr "הגדרות"
 
-#: schematic/src/x_widgets.c:203 schematic/src/x_window.c:1436
 msgid "Object"
 msgstr ""
 
-#: schematic/src/x_widgets.c:224
 msgid "Log"
 msgstr ""
 
-#: schematic/src/x_widgets.c:245 schematic/src/x_window.c:1466
 msgid "Find Text"
 msgstr ""
 
-#: schematic/src/x_widgets.c:259
 msgid "Color Scheme Editor"
 msgstr ""
 
-#: schematic/src/x_widgets.c:272 schematic/scheme/gschem/builtins.scm:378
 #, fuzzy
 msgid "Select Schematic Font"
 msgstr "מצב בחירה"
 
-#: schematic/src/x_window.c:763
 #, c-format
 msgid "Loading schematic [%1$s]"
 msgstr ""
 
-#: schematic/src/x_window.c:864
 #, c-format
 msgid "Could NOT save page [%1$s]\n"
 msgstr ""
 
-#: schematic/src/x_window.c:865
 msgid "Error while trying to save"
 msgstr ""
 
-#: schematic/src/x_window.c:875
 msgid "Failed to save file"
 msgstr ""
 
-#: schematic/src/x_window.c:885
 #, fuzzy, c-format
 msgid "Saved as [%1$s]"
 msgstr "שמור הכל"
 
-#: schematic/src/x_window.c:887
 #, fuzzy, c-format
 msgid "Saved [%1$s]"
 msgstr "שמור הכל"
 
-#: schematic/src/x_window.c:889
 msgid "Saved"
 msgstr ""
 
-#: schematic/src/x_window.c:966
 #, c-format
 msgid "Discarding page [%1$s]"
 msgstr ""
 
-#: schematic/src/x_window.c:966
 #, c-format
 msgid "Closing [%1$s]"
 msgstr ""
 
-#: schematic/src/x_window.c:1175
 msgid "New"
 msgstr "חדש"
 
-#: schematic/src/x_window.c:1175
 msgid "New file"
 msgstr ""
 
-#: schematic/src/x_window.c:1179
 msgid "Open"
 msgstr ""
 
-#: schematic/src/x_window.c:1179
 msgid "Open file"
 msgstr ""
 
-#: schematic/src/x_window.c:1183 schematic/scheme/gschem/builtins.scm:59
 msgid "Save"
 msgstr ""
 
-#: schematic/src/x_window.c:1183
 msgid "Save file"
 msgstr ""
 
-#: schematic/src/x_window.c:1189 schematic/scheme/gschem/builtins.scm:93
 msgid "Undo"
 msgstr "בטל את הפעולה האחרונה"
 
-#: schematic/src/x_window.c:1189
 msgid "Undo last operation"
 msgstr ""
 
-#: schematic/src/x_window.c:1193 schematic/scheme/gschem/builtins.scm:96
 msgid "Redo"
 msgstr "בצע שוב"
 
-#: schematic/src/x_window.c:1193
 msgid "Redo last undo"
 msgstr ""
 
-#: schematic/src/x_window.c:1198
 msgid ""
 "Add component...\n"
 "Select library and component from list, move the mouse into main window, "
@@ -2146,56 +1646,44 @@ msgid ""
 "Right mouse button to cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1209
 msgid ""
 "Add nets mode\n"
 "Right mouse button to cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1217
 msgid ""
 "Add buses mode\n"
 "Right mouse button to cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1226
 msgid "Add Text..."
 msgstr ""
 
-#: schematic/src/x_window.c:1233
 msgid "Select mode"
 msgstr ""
 
-#: schematic/src/x_window.c:1288
 msgid "Show"
 msgstr ""
 
-#: schematic/src/x_window.c:1289
 msgid "Show text starting with:"
 msgstr ""
 
-#: schematic/src/x_window.c:1345
 msgid "Menu/Cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1349
 msgid "Pan/Cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1359
 msgid "Pick"
 msgstr ""
 
-#: schematic/src/x_window.c:1470 schematic/scheme/gschem/builtins.scm:180
 msgid "Status"
 msgstr ""
 
-#: schematic/src/x_window.c:1568
 #, fuzzy, c-format
 msgid "New file [%s]"
 msgstr "דף חדש"
 
-#: schematic/src/x_window.c:1598
 #, c-format
 msgid ""
 "<b>An error occurred while loading the requested file.</b>\n"
@@ -2209,849 +1697,639 @@ msgid ""
 "monitor program's output in terminal window."
 msgstr ""
 
-#: schematic/src/x_window.c:1617
 msgid "Failed to load file"
 msgstr ""
 
-#: schematic/data/lepton-schematic.desktop.in:3
 msgid "Lepton EDA Schematic Editor"
 msgstr ""
 
-#: schematic/data/lepton-schematic.desktop.in:4
 msgid "Create and edit electrical schematics and symbols with lepton-schematic"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:27
 msgid "_New"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:28
 msgid "_Open..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:30
 msgid "Open Recen_t"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:32
 msgid "_Save"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:33
 msgid "Save _As..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:34
-#: schematic/scheme/gschem/builtins.scm:65
 msgid "Save All"
 msgstr "שמור הכל"
 
-#: schematic/scheme/conf/schematic/menu.scm:36
 msgid "_Print..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:37
 #, fuzzy
 msgid "Write _Image..."
 msgstr "כתוב תמונה..."
 
-#: schematic/scheme/conf/schematic/menu.scm:39
 msgid "Invoke Macro..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:41
 msgid "REPL..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:43
-#: schematic/scheme/gschem/builtins.scm:77
 msgid "New Window"
 msgstr "חלון חדש"
 
-#: schematic/scheme/conf/schematic/menu.scm:44
 msgid "_Close Window"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:45
 msgid "_Quit"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:51
 msgid "_Undo"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:52
 msgid "_Redo"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:54
 msgid "Cu_t"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:55
 msgid "_Copy"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:56
 msgid "_Paste"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:57
 msgid "_Delete"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:60
-#: schematic/scheme/gschem/builtins.scm:102
 msgid "Select All"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:61
-#: schematic/scheme/gschem/builtins.scm:105
 msgid "Deselect"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:65
 msgid "Rotate 90 Mode"
 msgstr "מצב סיבוב 90"
 
-#: schematic/scheme/conf/schematic/menu.scm:70
 msgid "Edit Text..."
 msgstr "ערוך טקסט"
 
-#: schematic/scheme/conf/schematic/menu.scm:71
 msgid "Slot..."
 msgstr "חריץ..."
 
-#: schematic/scheme/conf/schematic/menu.scm:76
-#: schematic/scheme/gschem/builtins.scm:150
 msgid "Embed Component/Picture"
 msgstr "שבץ רכיב/תמונה"
 
-#: schematic/scheme/conf/schematic/menu.scm:77
-#: schematic/scheme/gschem/builtins.scm:153
 msgid "Unembed Component/Picture"
 msgstr "שחרר משיבוץ רכיב/תמונה"
 
-#: schematic/scheme/conf/schematic/menu.scm:78
-#: schematic/scheme/gschem/builtins.scm:156
 msgid "Update Component"
 msgstr "עדכן רכיב"
 
-#: schematic/scheme/conf/schematic/menu.scm:79
 msgid "Symbol Translate..."
 msgstr "תרגם סמל..."
 
-#: schematic/scheme/conf/schematic/menu.scm:85
 msgid "Copy into 1"
 msgstr "העתק אל 1"
 
-#: schematic/scheme/conf/schematic/menu.scm:86
 msgid "Copy into 2"
 msgstr "העתק אל 2"
 
-#: schematic/scheme/conf/schematic/menu.scm:87
 msgid "Copy into 3"
 msgstr "העתק אל 3"
 
-#: schematic/scheme/conf/schematic/menu.scm:88
 msgid "Copy into 4"
 msgstr "העתק אל 4"
 
-#: schematic/scheme/conf/schematic/menu.scm:89
 msgid "Copy into 5"
 msgstr "העתק אל 5"
 
-#: schematic/scheme/conf/schematic/menu.scm:90
 msgid "Cut into 1"
 msgstr "גזור אל 1"
 
-#: schematic/scheme/conf/schematic/menu.scm:91
 msgid "Cut into 2"
 msgstr "גזור אל 2"
 
-#: schematic/scheme/conf/schematic/menu.scm:92
 msgid "Cut into 3"
 msgstr "גזור אל 3"
 
-#: schematic/scheme/conf/schematic/menu.scm:93
 msgid "Cut into 4"
 msgstr "גזור אל 4"
 
-#: schematic/scheme/conf/schematic/menu.scm:94
 msgid "Cut into 5"
 msgstr "גזור אל 5"
 
-#: schematic/scheme/conf/schematic/menu.scm:95
 msgid "Paste from 1"
 msgstr "הדבק מ-1"
 
-#: schematic/scheme/conf/schematic/menu.scm:96
 msgid "Paste from 2"
 msgstr "הדבק מ-2"
 
-#: schematic/scheme/conf/schematic/menu.scm:97
 msgid "Paste from 3"
 msgstr "הדבק מ-3"
 
-#: schematic/scheme/conf/schematic/menu.scm:98
 msgid "Paste from 4"
 msgstr "הדבק מ-4"
 
-#: schematic/scheme/conf/schematic/menu.scm:99
 msgid "Paste from 5"
 msgstr "הדבק מ-5"
 
-#: schematic/scheme/conf/schematic/menu.scm:105
 msgid "Side Dock"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:106
 msgid "Bottom Dock"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:108
 #, fuzzy
 msgid "Find Text Results"
 msgstr "ערוך טקסט"
 
-#: schematic/scheme/conf/schematic/menu.scm:110
 msgid "_Redraw"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:111
 msgid "_Pan"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:112
 msgid "Zoom _Box"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:113
 msgid "Zoom _Extents"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:114
 msgid "Zoom _In"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:115
 msgid "Zoom _Out"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:116
 msgid "Zoom _Full"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:118
 msgid "_Dark Color Scheme"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:119
 msgid "_Light Color Scheme"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:120
 msgid "B_W Color Scheme"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:122
 msgid "Color Scheme Editor..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:129
 msgid "_Manager..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:131
 msgid "_Previous"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:132
 msgid "_Next"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:133
 msgid "_Close"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:135
 msgid "_Revert..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:137
-#: schematic/scheme/gschem/builtins.scm:249
 #, fuzzy
 msgid "Next Tab"
 msgstr "דף חדש"
 
-#: schematic/scheme/conf/schematic/menu.scm:138
-#: schematic/scheme/gschem/builtins.scm:252
 #, fuzzy
 msgid "Previous Tab"
 msgstr "סגור דף"
 
-#: schematic/scheme/conf/schematic/menu.scm:146
 msgid "_Component..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:148
 msgid "_Net"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:149
 msgid "B_us"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:151
 msgid "_Attribute..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:152
 msgid "_Text..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:154
 msgid "_Line"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:155
 msgid "Pat_h"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:156
 msgid "_Box"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:157
 msgid "C_ircle"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:158
 msgid "A_rc"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:159
 msgid "_Pin"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:161
 msgid "Pictu_re..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:167
 msgid "_Up"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:169
 msgid "_Down Schematic"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:170
 msgid "Down _Symbol"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:176
 msgid "_Attach"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:177
 msgid "_Detach"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:179
 msgid "Show _Value"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:180
 msgid "Show _Name"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:181
 msgid "Show _Both"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:182
 msgid "_Toggle Visibility"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:184
 msgid "_Hide Specific Text..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:185
 msgid "_Show Specific Text..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:186
 #, fuzzy
 msgid "Show/Hide Hidden Text"
 msgstr "הראה/הסתר טקסט חבוי"
 
-#: schematic/scheme/conf/schematic/menu.scm:188
 msgid "_Find Text/Check Symbol..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:189
 msgid "A_utonumber Text..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:195
 #, fuzzy
 msgid "_Options..."
 msgstr "הגדרות"
 
-#: schematic/scheme/conf/schematic/menu.scm:196
 #, fuzzy
 msgid "_Font..."
 msgstr "חריץ..."
 
-#: schematic/scheme/conf/schematic/menu.scm:198
 msgid "Grid +"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:199
 msgid "Grid -"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:201
 msgid "Grid Style: Cycle Dots/Mesh/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:202
 msgid "Grid Snap: Cycle Grid/Resnap/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:204
 msgid "Feedback Mode: Outline/Box"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:205
 msgid "Net: Rubberband On/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:206
 msgid "Net: Magnetic On/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:208
 #, fuzzy
 msgid "_Coord Window"
 msgstr "חלון חדש"
 
-#: schematic/scheme/conf/schematic/menu.scm:209
 #, fuzzy
 msgid "_Log Window"
 msgstr "חלון חדש"
 
-#: schematic/scheme/conf/schematic/menu.scm:215
 msgid "_1 allegro"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:223
 msgid "User _Guide"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:224
 msgid "_FAQ"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:225
 msgid "Docu_mentation"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:226
 msgid "_Wiki"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:228
 msgid "Find Component D_ocumentation"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:230
 msgid "_Hotkeys..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:231
 msgid "_About"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:237
 msgid "_File"
 msgstr "קובץ"
 
-#: schematic/scheme/conf/schematic/menu.scm:238
 msgid "_Edit"
 msgstr "עריכה"
 
-#: schematic/scheme/conf/schematic/menu.scm:240
 msgid "_View"
 msgstr "הצג"
 
-#: schematic/scheme/conf/schematic/menu.scm:241
 msgid "_Page"
 msgstr "דף"
 
-#: schematic/scheme/conf/schematic/menu.scm:242
 msgid "_Add"
 msgstr "הוסף"
 
-#: schematic/scheme/conf/schematic/menu.scm:243
 msgid "Hie_rarchy"
 msgstr "היררכיה"
 
-#: schematic/scheme/conf/schematic/menu.scm:244
 msgid "A_ttributes"
 msgstr "מאפיינים"
 
-#: schematic/scheme/conf/schematic/menu.scm:245
 msgid "_Options"
 msgstr "הגדרות"
 
-#: schematic/scheme/conf/schematic/menu.scm:246
 msgid "_Netlist"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:247
 msgid "_Help"
 msgstr ""
 
-#: schematic/scheme/gschem/action.scm:43
 #, scheme-format
 msgid "~S is not a valid gschem action."
 msgstr ""
 
-#: schematic/scheme/gschem/action.scm:158
 msgid "Repeat Last Action"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:47
 msgid "Cancel"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:53
 #, fuzzy
 msgid "New File"
 msgstr "דף חדש"
 
-#: schematic/scheme/gschem/builtins.scm:56
 msgid "Open File"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:62
 #, fuzzy
 msgid "Save As"
 msgstr "שמור הכל"
 
-#: schematic/scheme/gschem/builtins.scm:68
 #, fuzzy
 msgid "Print"
 msgstr "הדפס..."
 
-#: schematic/scheme/gschem/builtins.scm:71
 msgid "Export Image"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:74
 msgid "Run Script"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:80
 #, fuzzy
 msgid "Close Window"
 msgstr "חלון חדש"
 
-#: schematic/scheme/gschem/builtins.scm:83
 msgid "Quit"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:87
 msgid "Terminal REPL"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:132
 msgid "Choose Slot"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:135
 msgid "Edit Object Properties"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:138
 msgid "Translate Symbol"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:147
 msgid "Invoke Macro"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:159
 #, fuzzy
 msgid "Show/Hide Invisible Text"
 msgstr "הראה/הסתר טקסט חבוי"
 
-#: schematic/scheme/gschem/builtins.scm:165
 #, fuzzy
 msgid "Cut"
 msgstr "גזור אל 1"
 
-#: schematic/scheme/gschem/builtins.scm:171
 #, fuzzy
 msgid "Paste"
 msgstr "הדבק מ-1"
 
-#: schematic/scheme/gschem/builtins.scm:177
 msgid "Sidebar"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:183
 #, fuzzy
 msgid "Find Text State"
 msgstr "ערוך טקסט"
 
-#: schematic/scheme/gschem/builtins.scm:186
 msgid "Redraw"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:192
 msgid "Pan Left"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:195
 msgid "Pan Right"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:198
 msgid "Pan Up"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:201
 msgid "Pan Down"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:216
 msgid "Zoom Full"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:219
 msgid "Dark Color Scheme"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:222
 msgid "Light Color Scheme"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:225
 msgid "Monochrome Color Scheme"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:228
 msgid "Show Color Scheme Editor"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:234
 msgid "Revert Changes"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:240
 #, fuzzy
 msgid "Previous Page"
 msgstr "סגור דף"
 
-#: schematic/scheme/gschem/builtins.scm:243
 #, fuzzy
 msgid "Next Page"
 msgstr "דף חדש"
 
-#: schematic/scheme/gschem/builtins.scm:255
 #, fuzzy
 msgid "Print Page"
 msgstr "סגור דף"
 
-#: schematic/scheme/gschem/builtins.scm:276
 #, fuzzy
 msgid "Add Line"
 msgstr "קו"
 
-#: schematic/scheme/gschem/builtins.scm:279
 msgid "Add Path"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:282
 msgid "Add Box"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:285
 #, fuzzy
 msgid "Add Circle"
 msgstr "מעגל"
 
-#: schematic/scheme/gschem/builtins.scm:288
 msgid "Add Arc"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:291
 msgid "Add Pin"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:294
 msgid "Add Picture"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:306
 #, fuzzy
 msgid "Up Hierarchy"
 msgstr "היררכיה"
 
-#: schematic/scheme/gschem/builtins.scm:312
 #, fuzzy
 msgid "Attach Attributes"
 msgstr "מאפיינים"
 
-#: schematic/scheme/gschem/builtins.scm:315
 #, fuzzy
 msgid "Detach Attributes"
 msgstr "מאפיינים"
 
-#: schematic/scheme/gschem/builtins.scm:318
 #, fuzzy
 msgid "Show Attribute Value"
 msgstr "מאפיינים"
 
-#: schematic/scheme/gschem/builtins.scm:321
 #, fuzzy
 msgid "Show Attribute Name"
 msgstr "מאפיינים"
 
-#: schematic/scheme/gschem/builtins.scm:327
 msgid "Toggle Text Visibility"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:330
 msgid "Find Specific Text"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:333
 msgid "Hide Specific Text"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:336
 msgid "Show Specific Text"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:339
 msgid "Autonumber Text"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:345
 msgid "Show Hotkeys"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:348
 msgid "Switch Grid Style"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:351
 msgid "Switch Snap Mode"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:354
 msgid "Set Grid Spacing"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:357
 msgid "Increase Grid Spacing"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:360
 msgid "Decrease Grid Spacing"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:363
 msgid "Toggle Outline Drawing"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:366
 msgid "Toggle Net Rubber Band"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:369
 msgid "Toggle Magnetic Nets"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:372
 #, fuzzy
 msgid "Show Log Window"
 msgstr "חלון חדש"
 
-#: schematic/scheme/gschem/builtins.scm:375
 msgid "Show Coordinate Window"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:385
 msgid "Component Documentation"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:387
 msgid "View documentation for selected component"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:403
 msgid ""
 "Could not show documentation for selected component:\n"
 "\n"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:408
 msgid "gEDA Manuals"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:409
 msgid "View the front page of the gEDA documentation in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:414
 msgid "gschem User Guide"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:415
 msgid "View the gschem User Guide in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:420
 msgid "gschem FAQ"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:421
 msgid "Frequently Asked Questions about using gschem."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:426
 msgid "gEDA wiki"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:427
 msgid "View the front page of the gEDA wiki in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:431
 msgid "About gschem"
 msgstr ""
 
-#: schematic/scheme/gschem/deprecated.scm:102
 #, scheme-format
 msgid "Invalid text alignment ~A."
 msgstr ""
 
-#: schematic/scheme/gschem/gschemdoc.scm:241
 msgid "No documentation found"
 msgstr ""
 
-#: schematic/scheme/gschem/keymap.scm:40
 #, scheme-format
 msgid "~S is not a valid key combination."
 msgstr ""
 
-#: schematic/scheme/gschem/keymap.scm:157
 #, scheme-format
 msgid "~S is not a prefix key sequence."
 msgstr ""

--- a/schematic/po/hu.po
+++ b/schematic/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-15 15:13+0300\n"
+"POT-Creation-Date: 2019-02-22 14:08+0300\n"
 "PO-Revision-Date: 2012-01-27 14:23+0000\n"
 "Last-Translator: kop <Unknown>\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -18,24 +18,20 @@ msgstr ""
 "X-Launchpad-Export-Date: 2012-11-14 16:52+0000\n"
 "X-Generator: Launchpad (build 16265)\n"
 
-#: schematic/src/a_zoom.c:155
 #, fuzzy
 msgid "Zoom too small!  Cannot zoom further."
 msgstr "Túl nagy nagyítás! Nem tudok tovább nagyítani.\n"
 
-#: schematic/src/color_edit_widget.c:399
 #, fuzzy, c-format
 msgid ""
 "Could not save file [%s]:\n"
 "%s"
 msgstr "A [%s] rajz mentése nem sikerült.\n"
 
-#: schematic/src/color_edit_widget.c:434
 #, fuzzy
 msgid "Save Color Scheme As..."
 msgstr "Világos színséma"
 
-#: schematic/src/color_edit_widget.c:482 schematic/src/x_fileselect.c:292
 #, fuzzy, c-format
 msgid ""
 "The selected file `%1$s' already exists.\n"
@@ -45,179 +41,141 @@ msgstr ""
 "A kiválasztott fájl - '%s' - már létezik.\n"
 "Felül szeretnéd írni?"
 
-#: schematic/src/color_edit_widget.c:486 schematic/src/x_fileselect.c:295
 msgid "Overwrite file?"
 msgstr "Felülírod a fájlt?"
 
-#: schematic/src/font_select_widget.c:211
 msgid "_Apply"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:215
 msgid "Sa_ve..."
 msgstr ""
 
-#: schematic/src/font_select_widget.c:278
 #, c-format
 msgid "<b>Current:</b> %s"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:453
 msgid "Save configuration"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:461
 #, fuzzy
 msgid "Save settings to:"
 msgstr "Beállitások"
 
-#: schematic/src/font_select_widget.c:465
 msgid "Local configuration file (in current directory)"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:467
 msgid "User configuration file (geda-user.conf)"
 msgstr ""
 
-#: schematic/src/g_attrib.c:90
 msgid "Object ~A is not included in the current gschem page."
 msgstr "A ~A objektum nem tálható a jelen gschem lapon."
 
-#: schematic/src/g_attrib.c:110
 msgid "Invalid text name/value visibility ~A."
 msgstr "Érvénytelen szöveg név/érték megjelenés ~A."
 
-#: schematic/src/g_rc.c:107
 #, fuzzy, c-format
 msgid "You are running gEDA/gaf version [%1$s%2$s.%3$s],\n"
 msgstr "gEDA/gschem verzió %s%s.%s\n"
 
-#: schematic/src/g_rc.c:111
 #, c-format
 msgid ""
 "but you have a version [%1$s] gschemrc file:\n"
 "[%2$s]\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:114
 #, c-format
 msgid "Please be sure that you have the latest rc file.\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:240
 #, fuzzy, c-format
 msgid "Invalid size [%1$d] passed to text-size\n"
 msgstr "Érvénytelen méret [%d] szöveg méretként\n"
 
-#: schematic/src/g_rc.c:283
 #, fuzzy, c-format
 msgid "Invalid size [%1$d] passed to snap-size\n"
 msgstr "Érvénytelen méret [%d] snap méretként\n"
 
-#: schematic/src/g_rc.c:620
 #, fuzzy, c-format
 msgid "Invalid num levels [%1$d] passed to undo-levels\n"
 msgstr "Érvénytelen méret [%d] snap méretként\n"
 
-#: schematic/src/g_rc.c:831
 #, fuzzy, c-format
 msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
 msgstr "Érvénytelen méret [%d] snap méretként\n"
 
-#: schematic/src/g_rc.c:931
 #, fuzzy, c-format
 msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
 msgstr "Érvénytelen méret [%d] szöveg méretként\n"
 
-#: schematic/src/g_rc.c:972
 #, fuzzy, c-format
 msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
 msgstr "Érvénytelen méret [%d] szöveg méretként\n"
 
-#: schematic/src/g_rc.c:998
 #, c-format
 msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1023
 #, fuzzy, c-format
 msgid "Invalid offset [%1$d] passed to add-attribute-offset\n"
 msgstr "Érvénytelen méret [%d] szöveg méretként\n"
 
-#: schematic/src/g_rc.c:1047
 #, fuzzy, c-format
 msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
 msgstr "Érvénytelen méret [%d] szöveg méretként\n"
 
-#: schematic/src/g_rc.c:1071
 #, fuzzy, c-format
 msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
 msgstr "Érvénytelen méret [%d] snap méretként\n"
 
-#: schematic/src/g_rc.c:1094
 #, fuzzy, c-format
 msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
 msgstr "Érvénytelen méret [%d] snap méretként\n"
 
-#: schematic/src/g_rc.c:1118
 #, fuzzy, c-format
 msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
 msgstr "Érvénytelen méret [%d] szöveg méretként\n"
 
-#: schematic/src/g_rc.c:1144
 #, fuzzy, c-format
 msgid "Invalid gain [%1$d] passed to zoom-gain\n"
 msgstr "Érvénytelen méret [%d] szöveg méretként\n"
 
-#: schematic/src/g_rc.c:1169
 #, c-format
 msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
 msgstr ""
 
-#: schematic/src/g_select.c:78 schematic/src/g_select.c:115
-#: schematic/src/g_select.c:151
 msgid "Object ~A is not directly included in a page."
 msgstr ""
 
-#: schematic/src/g_util.c:54
 msgid "Could not launch URI ~S: ~A"
 msgstr ""
 
-#: schematic/src/g_window.c:139
 msgid "Found invalid gschem window smob ~S"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:156
 #, fuzzy, c-format
 msgid "Lepton EDA/lepton-schematic version %1$s%2$s.%3$s git: %4$.7s"
 msgstr "gEDA/gschem verzió %s%s.%s\n"
 
-#: schematic/src/lepton-schematic.c:163
 #, c-format
 msgid "This is the MINGW32 port.\n"
 msgstr "Ez a MinGW32 port.\n"
 
-#: schematic/src/lepton-schematic.c:167
 #, fuzzy, c-format
 msgid "Current locale settings: %1$s\n"
 msgstr "Jelenlegi területi beállítás: %s\n"
 
-#: schematic/src/lepton-schematic.c:201
 #, fuzzy, c-format
 msgid "Couldn't find init scm file [%1$s]"
 msgstr "[%s] init scm fájl olvasása sikertelen.\n"
 
-#: schematic/src/lepton-schematic.c:206
 #, fuzzy, c-format
 msgid "Read init scm file [%1$s]"
 msgstr "[%s] init scm fájl olvasása.\n"
 
-#: schematic/src/lepton-schematic.c:210
 #, fuzzy, c-format
 msgid "Failed to read init scm file [%1$s]"
 msgstr "[%s] init scm fájl olvasása sikertelen.\n"
 
-#: schematic/src/lepton-schematic.c:290
 #, c-format
 msgid ""
 "ERROR: Failed to load or evaluate startup script.\n"
@@ -225,698 +183,518 @@ msgid ""
 "The lepton-schematic log may contain more information.\n"
 msgstr ""
 
-#: schematic/src/gschem_about_dialog.c:51
 #, c-format
 msgid "%s (git: %.7s)"
 msgstr ""
 
-#: schematic/src/gschem_about_dialog.c:75
 msgid "Lepton Electronic Design Automation"
 msgstr ""
 
-#: schematic/src/gschem_about_dialog.c:83
 msgid ""
 "Copyright © 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright © 2017-2018 Lepton Developers.\n"
-"See AUTHORS and ChangeLog files for details."
+"Copyright © 2017-2019 Lepton Developers.\n"
+"See AUTHORS, ChangeLog files and consult 'git log' history for details."
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:69
 msgid "Upper Left"
 msgstr "Bal felső"
 
-#: schematic/src/gschem_alignment_combo.c:71
 msgid "Upper Middle"
 msgstr "Közép felső"
 
-#: schematic/src/gschem_alignment_combo.c:73
 #, fuzzy
 msgid "Upper Right"
 msgstr "Jobb alsó"
 
-#: schematic/src/gschem_alignment_combo.c:78
 msgid "Middle Left"
 msgstr "Bal közép"
 
-#: schematic/src/gschem_alignment_combo.c:80
 msgid "Middle Middle"
 msgstr "Közép közép"
 
-#: schematic/src/gschem_alignment_combo.c:82
 msgid "Middle Right"
 msgstr "Jobb közép"
 
-#: schematic/src/gschem_alignment_combo.c:87
 msgid "Lower Left"
 msgstr "Bal alsó"
 
-#: schematic/src/gschem_alignment_combo.c:89
 msgid "Lower Middle"
 msgstr "Közép alsó"
 
-#: schematic/src/gschem_alignment_combo.c:91
 msgid "Lower Right"
 msgstr "Jobb alsó"
 
-#: schematic/src/gschem_arc_dialog.c:104
 msgid "Arc Params"
 msgstr "Ívparaméterek"
 
-#: schematic/src/gschem_arc_dialog.c:140
 msgid "Arc _Radius:"
 msgstr ""
 
-#: schematic/src/gschem_arc_dialog.c:141
 #, fuzzy
 msgid "Start _Angle:"
 msgstr "Kezdőszög:"
 
-#: schematic/src/gschem_arc_dialog.c:142
 #, fuzzy
 msgid "_Degrees of Sweep:"
 msgstr "Ív szöge:"
 
-#: schematic/src/gschem_bottom_widget.c:504
 msgid "Left mouse button"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:508
 #, fuzzy
 msgid "Middle mouse button"
 msgstr "Bal közép"
 
-#: schematic/src/gschem_bottom_widget.c:512
 #, fuzzy
 msgid "Right mouse button"
 msgstr "Összeköttetések hozzáadása mód"
 
-#: schematic/src/gschem_bottom_widget.c:595
 msgid "(Snap size, Grid size)"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:603
 msgid "Net rubber band mode"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:614
 #, fuzzy
 msgid "Magnetic net mode"
 msgstr "Összeköttetés üzemmód"
 
-#: schematic/src/gschem_bottom_widget.c:622
 #, fuzzy
 msgid "Current action mode"
 msgstr "Jelenlegi oldal"
 
-#: schematic/src/gschem_bottom_widget.c:935
-#: schematic/src/gschem_bottom_widget.c:951
 msgid "OFF"
 msgstr "Ki"
 
-#: schematic/src/gschem_bottom_widget.c:954
 msgid "NONE"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:960
 #, fuzzy, c-format
 msgid "Grid(%1$s, %2$s)"
 msgstr "Háló (%s, %s)"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:350
-#: schematic/src/x_compselect.c:1236 schematic/src/x_multiattrib.c:2068
 msgid "Name"
 msgstr "Név"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:372
 msgid "S_elect the schematics you want to save:"
 msgstr "Válaszd ki a menteni kívánt rajzot:"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:467
 #, fuzzy, c-format
 msgid "Save the changes to schematic \"%1$s\" before closing?"
 msgstr "Elmentsem a(z) \"%s\" rajz változásait bezárás előtt?"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:473
 #, fuzzy, c-format
 msgid ""
 "There are %1$d schematics with unsaved changes. Save changes before closing?"
 msgstr ""
 "%d megváltoztatott rajz van még megnyitva. Elmentsem őket kilépés előtt?"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:502
 msgid "If you don't save, all your changes will be permanently lost."
 msgstr "Ha nem menti, akkor az összes változás véglegesen elveszik."
 
-#: schematic/src/gschem_close_confirmation_dialog.c:522
 #, fuzzy
 msgid "Close _without saving"
 msgstr "_Bezárás mentés nélkül"
 
-#: schematic/src/gschem_coord_dialog.c:86
 msgid "Coords"
 msgstr "Koordináták"
 
-#: schematic/src/gschem_coord_dialog.c:106
 msgid "Screen"
 msgstr "Képernyő"
 
-#: schematic/src/gschem_coord_dialog.c:115
 msgid "World"
 msgstr "Világ"
 
-#: schematic/src/gschem_find_text_state.c:809 schematic/src/x_pagesel.c:432
 msgid "Filename"
 msgstr "Fájlnév"
 
-#: schematic/src/gschem_find_text_state.c:821 schematic/src/i_callbacks.c:1970
-#: schematic/src/x_colorcb.c:154 schematic/src/x_widgets.c:179
-#: schematic/src/x_window.c:1226 schematic/src/x_window.c:1440
 msgid "Text"
 msgstr "Szöveg"
 
-#: schematic/src/gschem_find_text_widget.c:427
 msgid "descend into hierarchy"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:435
 #, fuzzy
 msgid "Find"
 msgstr "Szöveg keresése"
 
-#: schematic/src/gschem_find_text_widget.c:557
 #, fuzzy
 msgid "Find Text:"
 msgstr "Szöveg keresése"
 
-#: schematic/src/gschem_find_text_widget.c:564
 msgid "Find Pattern:"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:571
 #, fuzzy
 msgid "Find Regex:"
 msgstr "Szöveg keresése"
 
-#: schematic/src/gschem_find_text_widget.c:578
 msgid "Check symbol:"
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:200
 msgid "Hotkeys"
 msgstr "Gyorsbillentyűk"
 
-#: schematic/src/gschem_hotkey_dialog.c:229
 msgid ""
 "Start typing action name or keystroke to filter the list.\n"
 "Type hotkeys as they are displayed in \"Keystroke(s)\" column."
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:233 schematic/src/x_compselect.c:1124
 #, fuzzy
 msgid "_Filter:"
 msgstr "Szűrő:"
 
-#: schematic/src/gschem_hotkey_dialog.c:259 schematic/src/i_basic.c:280
 msgid "Action"
 msgstr "Művelet"
 
-#: schematic/src/gschem_hotkey_dialog.c:277
 msgid "Keystroke(s)"
 msgstr ""
 
-#: schematic/src/gschem_log_widget.c:177
 msgid "** Invalid UTF-8 in log message. See stderr or gschem.log.\n"
 msgstr ""
 "** hibás UTF-8 a log üzenetben. Nézd meg az stderr-t vagy a gschem.log-ot.\n"
 
-#: schematic/src/gschem_log_widget.c:434
 #, fuzzy
 msgid "Clear log window?"
 msgstr "Ablak bezárása\n"
 
-#: schematic/src/gschem_log_widget.c:477
 #, fuzzy
 msgid "Clear Log _Window"
 msgstr "Új ablak"
 
-#: schematic/src/gschem_macro_widget.c:231
 msgid "Macro:"
 msgstr ""
 
-#: schematic/src/gschem_macro_widget.c:387
 msgid "Evaluate"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:172
 #, fuzzy
 msgid "_Fill Type:"
 msgstr "Kitöltés típusa:"
 
-#: schematic/src/gschem_object_properties_widget.c:173
 #, fuzzy
 msgid "Lin_e Width:"
 msgstr "Vonalvastagság:"
 
-#: schematic/src/gschem_object_properties_widget.c:174
 #, fuzzy
 msgid "Angle _1:"
 msgstr "Kezdőszög:"
 
-#: schematic/src/gschem_object_properties_widget.c:175
 msgid "P_itch 1:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:176
 #, fuzzy
 msgid "Angle _2:"
 msgstr "Kezdőszög:"
 
-#: schematic/src/gschem_object_properties_widget.c:177
 msgid "Pitc_h 2:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:237
 #, fuzzy
 msgid "<b>Fill Properties</b>"
 msgstr "<b>Szöveg tulajdonságai</b>"
 
-#: schematic/src/gschem_object_properties_widget.c:255
-#: schematic/src/gschem_text_properties_widget.c:258
-#: schematic/src/x_newtext.c:271
 #, fuzzy
 msgid "Colo_r:"
 msgstr "Szín:"
 
-#: schematic/src/gschem_object_properties_widget.c:266
 #, fuzzy
 msgid "<b>General Properties</b>"
 msgstr "<b>Szöveg tulajdonságai</b>"
 
-#: schematic/src/gschem_object_properties_widget.c:284
 #, fuzzy
 msgid "_Type:"
 msgstr "Típus:"
 
-#: schematic/src/gschem_object_properties_widget.c:285
 #, fuzzy
 msgid "_Width:"
 msgstr "Vastagság:"
 
-#: schematic/src/gschem_object_properties_widget.c:286
 #, fuzzy
 msgid "Dash _Length:"
 msgstr "Vonalszakasz hossza:"
 
-#: schematic/src/gschem_object_properties_widget.c:287
 #, fuzzy
 msgid "Dash _Space:"
 msgstr "Kihagyás hossza:"
 
-#: schematic/src/gschem_object_properties_widget.c:288
 msgid "C_ap style:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:333
 #, fuzzy
 msgid "<b>Line Properties</b>"
 msgstr "<b>Szöveg tulajdonságai</b>"
 
-#: schematic/src/gschem_object_properties_widget.c:351
 #, fuzzy
 msgid "_Pin Type:"
 msgstr "Kitöltés típusa"
 
-#: schematic/src/gschem_object_properties_widget.c:362
 #, fuzzy
 msgid "<b>Pin Properties</b>"
 msgstr "<b>Szöveg tulajdonságai</b>"
 
-#: schematic/src/gschem_options_widget.c:217
 msgid "_Off"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:220
 msgid "_Dots"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:223
 msgid "M_esh"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:245
 msgid "Net R_ubber Band Mode:"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:246
 #, fuzzy
 msgid "_Magnetic Net Mode:"
 msgstr "Összeköttetés üzemmód"
 
-#: schematic/src/gschem_options_widget.c:250
-#: schematic/src/gschem_options_widget.c:251
 msgid "Enabled"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:265
 #, fuzzy
 msgid "<b>Net Options</b>"
 msgstr "<b>Opciók</b>"
 
-#: schematic/src/gschem_options_widget.c:282
 #, fuzzy
 msgid "Grid Mode:"
 msgstr "Ív üzemmód"
 
-#: schematic/src/gschem_options_widget.c:283
 #, fuzzy
 msgid "Snap Mode:"
 msgstr "\"Középre\" üzemmód"
 
-#: schematic/src/gschem_options_widget.c:284
 #, fuzzy
 msgid "_Snap Size:"
 msgstr "Méret:"
 
-#: schematic/src/gschem_options_widget.c:301
 #, fuzzy
 msgid "<b>Snap Options</b>"
 msgstr "<b>Opciók</b>"
 
-#: schematic/src/gschem_options_widget.c:340
 msgid "O_ff"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:343
 #, fuzzy
 msgid "_Grid"
 msgstr "Háló ki\n"
 
-#: schematic/src/gschem_options_widget.c:346
 msgid "_Resnap"
 msgstr ""
 
-#: schematic/src/gschem_pin_type_combo.c:73
 msgid "Net pin"
 msgstr ""
 
-#: schematic/src/gschem_pin_type_combo.c:80
 msgid "Bus pin (graphical)"
 msgstr ""
 
-#: schematic/src/gschem_preview.c:195
 msgid "Preview Buffer"
 msgstr ""
 
-#: schematic/src/gschem_show_hide_text_widget.c:148
-#: schematic/src/x_window.c:1268
 #, fuzzy
 msgid "Hide"
 msgstr "Szöveg elrejtése"
 
-#: schematic/src/gschem_show_hide_text_widget.c:157
-#: schematic/src/x_window.c:1269
 msgid "Hide text starting with:"
 msgstr "A következővel kezdődő szöveg elrejtése:"
 
-#: schematic/src/gschem_slot_edit_dialog.c:91
 msgid "Edit slot number"
 msgstr ""
 
-#: schematic/src/gschem_slot_edit_dialog.c:121
 msgid "Number of Slots:"
 msgstr ""
 
-#: schematic/src/gschem_slot_edit_dialog.c:122
 #, fuzzy
 msgid "Slot Number:"
 msgstr "Kezdőszám:"
 
-#: schematic/src/gschem_text_properties_widget.c:240
-#: schematic/src/x_newtext.c:265
 #, fuzzy
 msgid "<b>Text Content</b>"
 msgstr "<b>Szöveg tulajdonságai</b>"
 
-#: schematic/src/gschem_text_properties_widget.c:259
-#: schematic/src/x_newtext.c:291
 #, fuzzy
 msgid "_Size:"
 msgstr "Méret:"
 
-#: schematic/src/gschem_text_properties_widget.c:260
-#: schematic/src/x_newtext.c:310
 #, fuzzy
 msgid "Ali_gnment:"
 msgstr "Igazítás:"
 
-#: schematic/src/gschem_text_properties_widget.c:261
-#: schematic/src/x_newtext.c:330
 #, fuzzy
 msgid "Ro_tation:"
 msgstr "Tájolás:"
 
-#: schematic/src/gschem_text_properties_widget.c:294
-#: schematic/src/x_newtext.c:253
 msgid "<b>Text Properties</b>"
 msgstr "<b>Szöveg tulajdonságai</b>"
 
-#: schematic/src/gschem_translate_widget.c:238
 #, fuzzy
 msgid "Coordinate:"
 msgstr "Jelenlegi nézet"
 
-#: schematic/src/gschem_translate_widget.c:405 schematic/src/i_callbacks.c:800
 msgid "Translate"
 msgstr "Eltolás"
 
-#: schematic/src/i_basic.c:64 schematic/src/x_window.c:1369
-#: schematic/scheme/conf/schematic/menu.scm:59
-#: schematic/scheme/gschem/builtins.scm:99
 msgid "Select Mode"
 msgstr "Kiválasztás mód"
 
-#: schematic/src/i_basic.c:65
 #, fuzzy
 msgid "Select Box Mode"
 msgstr "Kiválasztás mód"
 
-#: schematic/src/i_basic.c:66
 msgid "Text Mode"
 msgstr "Szövegbeviteli üzemmód"
 
-#: schematic/src/i_basic.c:67
 msgid "Pan Mode"
 msgstr "\"Középre\" üzemmód"
 
-#: schematic/src/i_basic.c:70
 #, c-format
 msgid "Paste %d Mode"
 msgstr "Beillesztés %d üzemmód"
 
-#: schematic/src/i_basic.c:74
 msgid "Magnetic Net Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:76
 msgid "Net Mode"
 msgstr "Összeköttetés üzemmód"
 
-#: schematic/src/i_basic.c:77
 msgid "Arc Mode"
 msgstr "Ív üzemmód"
 
-#: schematic/src/i_basic.c:78
 msgid "Box Mode"
 msgstr "Téglalap üzemmód"
 
-#: schematic/src/i_basic.c:79
 msgid "Bus Mode"
 msgstr "Busz üzemmód"
 
-#: schematic/src/i_basic.c:80
 msgid "Circle Mode"
 msgstr "Kör üzemmód"
 
-#: schematic/src/i_basic.c:81
 msgid "Component Mode"
 msgstr "Alkatrész mód"
 
-#: schematic/src/i_basic.c:82 schematic/scheme/conf/schematic/menu.scm:62
-#: schematic/scheme/gschem/builtins.scm:114
 msgid "Copy Mode"
 msgstr "Másolási mód"
 
-#: schematic/src/i_basic.c:83 schematic/scheme/conf/schematic/menu.scm:63
-#: schematic/scheme/gschem/builtins.scm:117
 msgid "Multiple Copy Mode"
 msgstr "Többszörös másolás mód"
 
-#: schematic/src/i_basic.c:84
 msgid "Line Mode"
 msgstr "Vonal üzemmód"
 
-#: schematic/src/i_basic.c:85 schematic/scheme/conf/schematic/menu.scm:66
-#: schematic/scheme/gschem/builtins.scm:123
 msgid "Mirror Mode"
 msgstr "Tükrözés"
 
-#: schematic/src/i_basic.c:86 schematic/scheme/conf/schematic/menu.scm:64
-#: schematic/scheme/gschem/builtins.scm:111
 msgid "Move Mode"
 msgstr "Mozgatási mód"
 
-#: schematic/src/i_basic.c:87
 #, fuzzy
 msgid "Path Mode"
 msgstr "\"Középre\" üzemmód"
 
-#: schematic/src/i_basic.c:88
 msgid "Picture Mode"
 msgstr "Kép üzemmód"
 
-#: schematic/src/i_basic.c:89
 msgid "Pin Mode"
 msgstr "Alkatrészláb üzemmód"
 
-#: schematic/src/i_basic.c:90 schematic/scheme/gschem/builtins.scm:120
 msgid "Rotate Mode"
 msgstr "Forgatás üzemmód"
 
-#: schematic/src/i_basic.c:91
 #, fuzzy
 msgid "Modify Mode"
 msgstr "Másolási mód"
 
-#: schematic/src/i_basic.c:92 schematic/src/x_menus.c:49
-#: schematic/scheme/gschem/builtins.scm:204
 msgid "Zoom Box"
 msgstr "Doboz nagyítás"
 
-#: schematic/src/i_basic.c:121
 msgid "Show Hidden"
 msgstr "Rejtett megjelenítése"
 
-#: schematic/src/i_basic.c:124
 msgid "Snap Off"
 msgstr ""
 
-#: schematic/src/i_basic.c:126
 msgid "Resnap Active"
 msgstr ""
 
-#: schematic/src/i_basic.c:288 schematic/src/x_colorcb.c:159
 msgid "Stroke"
 msgstr ""
 
-#: schematic/src/i_basic.c:296 schematic/src/i_basic.c:330
-#: schematic/src/x_window.c:1361
 msgid "none"
 msgstr "semmi"
 
-#: schematic/src/i_basic.c:304
 msgid "Repeat/"
 msgstr "Imétlés/"
 
-#: schematic/src/i_basic.c:315
 msgid "Repeat/none"
 msgstr "Ismétlés/semmi"
 
-#: schematic/src/i_basic.c:323 schematic/src/i_callbacks.c:1239
-#: schematic/scheme/gschem/builtins.scm:189
 msgid "Pan"
 msgstr "Középre"
 
-#: schematic/src/i_callbacks.c:74
 #, fuzzy, c-format
 msgid "New page created [%1$s]"
 msgstr "[%s] oldal létrehozva.\n"
 
-#: schematic/src/i_callbacks.c:108
 #, fuzzy, c-format
 msgid "New Window created [%1$s]"
 msgstr "[%s] ablak létrehozva.\n"
 
-#: schematic/src/i_callbacks.c:245
 msgid "Failed to Save All"
 msgstr "Nem sikerült mindent menteni."
 
-#: schematic/src/i_callbacks.c:247
 msgid "Saved All"
 msgstr "Minden oldal elmentve."
 
-#: schematic/src/i_callbacks.c:308
 #, fuzzy
 msgid "Closing Window"
 msgstr "Ablak bezárása\n"
 
-#: schematic/src/i_callbacks.c:505 schematic/src/x_menus.c:55
-#: schematic/scheme/gschem/builtins.scm:168
 msgid "Copy"
 msgstr "Másolás"
 
-#: schematic/src/i_callbacks.c:514 schematic/src/i_callbacks.c:539
-#: schematic/src/i_callbacks.c:564
 msgid "Select objs first"
 msgstr "Először válassz objektumokat"
 
-#: schematic/src/i_callbacks.c:530
 msgid "Multiple Copy"
 msgstr "Többszörös másolás"
 
-#: schematic/src/i_callbacks.c:555 schematic/src/x_menus.c:56
 msgid "Move"
 msgstr "Mozgatás"
 
-#: schematic/src/i_callbacks.c:579 schematic/src/x_menus.c:57
-#: schematic/src/x_multiattrib.c:1656 schematic/scheme/gschem/builtins.scm:108
 msgid "Delete"
 msgstr "Törlés"
 
-#: schematic/src/i_callbacks.c:603
 msgid "Edit"
 msgstr "Szerkesztés"
 
-#: schematic/src/i_callbacks.c:618 schematic/scheme/gschem/builtins.scm:129
 msgid "Edit Text"
 msgstr "Szöveg szerkesztése"
 
-#: schematic/src/i_callbacks.c:637
 msgid "Slot"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:688 schematic/src/i_callbacks.c:698
 msgid "Rotate"
 msgstr "Forgatás"
 
-#: schematic/src/i_callbacks.c:736 schematic/src/i_callbacks.c:746
 msgid "Mirror"
 msgstr "Tükrözés"
 
-#: schematic/src/i_callbacks.c:763 schematic/src/x_colorcb.c:160
-#: schematic/scheme/conf/schematic/menu.scm:73
-#: schematic/scheme/gschem/builtins.scm:141
 msgid "Lock"
 msgstr "Zárolás"
 
-#: schematic/src/i_callbacks.c:781 schematic/scheme/conf/schematic/menu.scm:74
-#: schematic/scheme/gschem/builtins.scm:144
 msgid "Unlock"
 msgstr "Zárolás feloldása"
 
-#: schematic/src/i_callbacks.c:805
 msgid "WARNING: Do not translate with snap off!"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:806
 msgid "WARNING: Turning snap on and continuing with translate."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:813
 #, fuzzy
 msgid "WARNING: Snap grid size is not equal to 100!"
 msgstr "Vigyázat, a hálószemméret nem 100!\n"
 
-#: schematic/src/i_callbacks.c:815
 #, fuzzy
 msgid ""
 "WARNING: If you are translating a symbol to the origin, the snap grid size "
@@ -925,23 +703,18 @@ msgstr ""
 "Vigyázat, az alkatrész kezdőponthoz való tolásához a hálószemméretnek 100-"
 "nak kell lennie!\n"
 
-#: schematic/src/i_callbacks.c:847
 msgid "Embed"
 msgstr "Beágyazás"
 
-#: schematic/src/i_callbacks.c:886
 msgid "Unembed"
 msgstr "Beágyazás megszüntetése"
 
-#: schematic/src/i_callbacks.c:928
 msgid "Update"
 msgstr "Frissítés"
 
-#: schematic/src/i_callbacks.c:970
 msgid "ShowHidden"
 msgstr "Rejtettek megjelenítése"
 
-#: schematic/src/i_callbacks.c:1537
 #, c-format
 msgid ""
 "<b>Revert page:</b>\n"
@@ -952,100 +725,78 @@ msgid ""
 "discarded and page file will be reloaded from disk."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1555
 #, fuzzy
 msgid "Revert"
 msgstr "_Visszaállítás"
 
-#: schematic/src/i_callbacks.c:1647
 msgid "Copy to clipboard"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1664
 msgid "Cut to clipboard"
 msgstr "Kivágás a vágólapra"
 
-#: schematic/src/i_callbacks.c:1686
 msgid "Paste from clipboard"
 msgstr "Beillesztés a vágólapról"
 
-#: schematic/src/i_callbacks.c:1694
 #, fuzzy
 msgid "Empty clipboard"
 msgstr "Kivágás a vágólapra"
 
 #. TRANSLATORS: The number is the number of the buffer that the
 #. * selection is being copied to.
-#: schematic/src/i_callbacks.c:1719
 #, fuzzy, c-format
 msgid "Copy %i"
 msgstr "Másolás az 1-be"
 
 #. TRANSLATORS: The number is the number of the buffer that the
 #. * selection is being cut to.
-#: schematic/src/i_callbacks.c:1746
 #, fuzzy, c-format
 msgid "Cut %i"
 msgstr "Kivágás az 1-be"
 
 #. TRANSLATORS: The number is the number of the buffer that is being
 #. * pasted to the schematic.
-#: schematic/src/i_callbacks.c:1776
 #, fuzzy, c-format
 msgid "Paste %i"
 msgstr "Beillesztés az 1-ből"
 
-#: schematic/src/i_callbacks.c:1785
 msgid "Empty buffer"
 msgstr "Üres buffer"
 
-#: schematic/src/i_callbacks.c:1833 schematic/src/x_window.c:1203
 msgid "Component"
 msgstr "Alkatrész"
 
-#: schematic/src/i_callbacks.c:1865 schematic/src/x_colorcb.c:150
 msgid "Attribute"
 msgstr "Attribútum"
 
-#: schematic/src/i_callbacks.c:1885 schematic/src/x_colorcb.c:149
 msgid "Net"
 msgstr "Net"
 
-#: schematic/src/i_callbacks.c:1928 schematic/src/x_colorcb.c:155
-#: schematic/src/x_window.c:1222
 msgid "Bus"
 msgstr "Busz"
 
-#: schematic/src/i_callbacks.c:2004
 msgid "Line"
 msgstr "Vonal"
 
-#: schematic/src/i_callbacks.c:2021
 msgid "Path"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2043
 msgid "Box"
 msgstr "Téglalap"
 
-#: schematic/src/i_callbacks.c:2085
 msgid "Circle"
 msgstr "Kör"
 
-#: schematic/src/i_callbacks.c:2108
 msgid "Arc"
 msgstr "Ív"
 
-#: schematic/src/i_callbacks.c:2131 schematic/src/x_colorcb.c:146
 msgid "Pin"
 msgstr "Alkatrészláb"
 
-#: schematic/src/i_callbacks.c:2191
 #, fuzzy, c-format
 msgid "Searching for source [%1$s]"
 msgstr "[%s] forrás keresése\n"
 
-#: schematic/src/i_callbacks.c:2223
 #, c-format
 msgid ""
 "Failed to descend hierarchy into '%1$s': %2$s\n"
@@ -1053,109 +804,84 @@ msgid ""
 "The lepton-schematic log may contain more information."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2227
 #, fuzzy, c-format
 msgid "Failed to descend into '%1$s': %2$s"
 msgstr "[%s] init scm fájl olvasása sikertelen.\n"
 
-#: schematic/src/i_callbacks.c:2234
 msgid "Failed to descend hierarchy."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2312
 #, fuzzy, c-format
 msgid "Searching for symbol [%1$s]"
 msgstr "[%s] szimbólum keresése\n"
 
-#: schematic/src/i_callbacks.c:2320
 msgid "Symbol is not a real file. Symbol cannot be loaded."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2367 schematic/src/x_tabs.c:1060
 msgid "Cannot find any schematics above the current one!"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2400
 msgid "Attach"
 msgstr "Csatolás"
 
-#: schematic/src/i_callbacks.c:2456
 msgid "Detach"
 msgstr "Leválasztás"
 
-#: schematic/src/i_callbacks.c:2500
 msgid "ShowN"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2537
 msgid "ShowV"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2574
 msgid "ShowB"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2612
 msgid "VisToggle"
 msgstr "Láthatóság be/ki"
 
-#: schematic/src/i_callbacks.c:2643
 #, c-format
 msgid "Sorry but this is a non-functioning menu option\n"
 msgstr "Elnézést, ez egy nem működő menüpont.\n"
 
-#: schematic/src/i_callbacks.c:2703
 msgid "Action feedback mode set to OUTLINE"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2706
 msgid "Action feedback mode set to BOUNDINGBOX"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2730
 #, fuzzy
 msgid "Grid OFF"
 msgstr "Háló ki\n"
 
-#: schematic/src/i_callbacks.c:2731
 msgid "Dot grid selected"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2732
 msgid "Mesh grid selected"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2733
 #, fuzzy
 msgid "Invalid grid mode"
 msgstr "Hibás attribútum"
 
-#: schematic/src/i_callbacks.c:2755
 msgid "Snap OFF (CAUTION!)"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2758
 msgid "Snap ON"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2761
 msgid "Snap back to the grid (CAUTION!)"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2790
 msgid "Rubber band ON"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2792
 msgid "Rubber band OFF"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2811
 #, fuzzy
 msgid "magnetic net mode: ON"
 msgstr "Összeköttetés üzemmód"
 
-#: schematic/src/i_callbacks.c:2814
 #, fuzzy
 msgid "magnetic net mode: OFF"
 msgstr "Összeköttetés üzemmód"
@@ -1165,137 +891,108 @@ msgstr "Összeköttetés üzemmód"
 #. the form "untitled_N.sch", where N is a number.  Please make
 #. sure that the translation contains characters suitable for use
 #. in a filename.
-#: schematic/src/i_vars.c:209
 msgid "untitled"
 msgstr ""
 
-#: schematic/src/o_complex.c:192 schematic/src/o_complex.c:195
 #, fuzzy, c-format
 msgid "Translating schematic [%1$d %2$d]"
 msgstr "[%s] rajz betöltése\n"
 
-#: schematic/src/o_delete.c:82
 #, fuzzy, c-format
 msgid "Delete locked object?"
 msgid_plural "Delete %1$u locked objects?"
 msgstr[0] "Kiválasztott objektumok"
 msgstr[1] "Kiválasztott objektumok"
 
-#: schematic/src/o_misc.c:55
 #, c-format
 msgid "Got an unexpected NULL in o_edit\n"
 msgstr ""
 
-#: schematic/src/o_misc.c:315
 msgid "Hidden text is now visible"
 msgstr ""
 
-#: schematic/src/o_misc.c:317
 msgid "Hidden text is now invisible"
 msgstr ""
 
-#: schematic/src/o_misc.c:425
 #, fuzzy, c-format
 msgid "Could not find symbol [%1$s] in library. Update failed."
 msgstr "Nem találom a(z) [%s] szimbólumot. A frissítés nem sikerült.\n"
 
-#: schematic/src/o_misc.c:541
 #, c-format
 msgid "o_autosave_backups: Can't get the real filename of %1$s."
 msgstr ""
 
-#: schematic/src/o_misc.c:585
 #, c-format
 msgid "Could NOT set previous backup file [%1$s] read-write"
 msgstr ""
 
-#: schematic/src/o_misc.c:605
 #, fuzzy, c-format
 msgid "Could NOT set backup file [%1$s] readonly"
 msgstr "A [%s] rajz mentése nem sikerült.\n"
 
-#: schematic/src/o_misc.c:610
 #, fuzzy, c-format
 msgid "Could NOT save backup file [%1$s]"
 msgstr "A [%s] rajz mentése nem sikerült.\n"
 
-#: schematic/src/o_move.c:192
 #, c-format
 msgid "ERROR: NULL object in o_move_end!\n"
 msgstr ""
 
-#: schematic/src/o_move.c:519
 #, c-format
 msgid "DOH! tried to find the whichone, but didn't find it!\n"
 msgstr ""
 
-#: schematic/src/o_move.c:546
 #, c-format
 msgid "Got a non line object in o_move_check_endpoint\n"
 msgstr ""
 
-#: schematic/src/o_net.c:444
 msgid "Warning: Starting net at off grid coordinate"
 msgstr ""
 
-#: schematic/src/o_net.c:508
 msgid "Warning: Ending net at off grid coordinate"
 msgstr ""
 
-#: schematic/src/o_net.c:856 schematic/src/o_net.c:893
-#: schematic/src/o_net.c:964 schematic/src/o_net.c:1000
 #, c-format
 msgid "Tried to add more than two bus rippers. Internal gschem error.\n"
 msgstr ""
 
-#: schematic/src/o_net.c:1068
 #, c-format
 msgid "Bus ripper symbol [%1$s] was not found in any component library"
 msgstr ""
 
-#: schematic/src/o_picture.c:133 schematic/src/o_picture.c:343
 #, fuzzy
 msgid "Select a picture file..."
 msgstr "PostScript fájlnév kiválasztása..."
 
-#: schematic/src/o_picture.c:166
 #, fuzzy, c-format
 msgid "Failed to load picture: %1$s"
 msgstr "Sikertelen a(z) %s kép betöltése"
 
-#: schematic/src/o_picture.c:182
 msgid "Picture"
 msgstr "Kép"
 
-#: schematic/src/o_picture.c:378
 #, c-format
 msgid "Failed to replace pictures: %s"
 msgstr ""
 
-#: schematic/src/o_slot.c:80
 #, fuzzy
 msgid "Slot attribute malformed"
 msgstr "Attribútum"
 
-#: schematic/src/o_slot.c:88
 #, fuzzy
 msgid "numslots attribute missing"
 msgstr "numslots attribútum hiányzik.\n"
 
-#: schematic/src/o_slot.c:89
 msgid "Slotting not allowed for this component"
 msgstr ""
 
-#: schematic/src/o_slot.c:104
 msgid "New slot number out of range"
 msgstr ""
 
-#: schematic/src/o_undo.c:397
 #, fuzzy
 msgid "Undo/Redo disabled in rc file"
 msgstr "A visszavonás/újra művelet nem használható rc fájlban.\n"
 
-#: schematic/src/parsecmd.c:77
 #, c-format
 msgid ""
 "Usage: %1$s [OPTION ...] [--] [FILE ...]\n"
@@ -1320,192 +1017,148 @@ msgid ""
 "gEDA/gaf homepage: <http://www.geda-project.org/>\n"
 msgstr ""
 
-#: schematic/src/parsecmd.c:110
 #, c-format
 msgid ""
 "Lepton EDA %1$s (git: %2$.7s)\n"
 "Copyright (C) 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright (C) 2017-2018 Lepton Developers.\n"
+"Copyright (C) 2017-2019 Lepton Developers.\n"
 "This is free software, and you are welcome to redistribute it under\n"
 "certain conditions. For details, see the file `COPYING', which is\n"
 "included in the Lepton EDA distribution.\n"
 "There is NO WARRANTY, to the extent permitted by law.\n"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:125
 #, c-format
 msgid "Got invalid show option; defaulting to show both\n"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:139
 #, c-format
 msgid "ERROR: NULL object!\n"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:328
 msgid "Single Attribute Editor"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:358
 msgid "<b>Edit Attribute</b>"
 msgstr "<b>Attribútum szerkesztése</b>"
 
-#: schematic/src/x_attribedit.c:360
 msgid "<b>Add Attribute</b>"
 msgstr "<b>Attribútum hozzáadása</b>"
 
-#: schematic/src/x_attribedit.c:376
 #, fuzzy
 msgid "N_ame:"
 msgstr "Név:"
 
-#: schematic/src/x_attribedit.c:396 schematic/src/x_multiattrib.c:2222
 #, fuzzy
 msgid "_Value:"
 msgstr "Érték:"
 
-#: schematic/src/x_attribedit.c:415 schematic/src/x_multiattrib.c:2281
 #, fuzzy
 msgid "Vi_sible"
 msgstr "Látható"
 
-#: schematic/src/x_attribedit.c:434
 msgid "Show Value Only"
 msgstr "Csak az érték mutatása"
 
-#: schematic/src/x_attribedit.c:436
 msgid "Show Name Only"
 msgstr "Csak a név mutatása"
 
-#: schematic/src/x_attribedit.c:438 schematic/src/x_multiattrib.c:1620
-#: schematic/scheme/gschem/builtins.scm:324
 msgid "Show Name & Value"
 msgstr "Név és érték mutatása"
 
-#: schematic/src/x_attribedit.c:445
 msgid "<b>Attach Options</b>"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:460
 msgid "All"
 msgstr "Mind"
 
-#: schematic/src/x_attribedit.c:476 schematic/src/x_compselect.c:986
-#: schematic/src/x_compselect.c:1100
 msgid "Components"
 msgstr "Alkatrészek"
 
-#: schematic/src/x_attribedit.c:492 schematic/src/x_window.c:1214
 msgid "Nets"
 msgstr "Összeköttetések"
 
-#: schematic/src/x_attribedit.c:508
 msgid "Replace existing attributes"
 msgstr "Meglevő attribútumok cseréje"
 
-#: schematic/src/x_autonumber.c:412
 msgid ""
 "slotted object without slot attribute may cause problems when autonumbering "
 "slots"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:427
 #, c-format
 msgid ""
 "duplicate slot may cause problems: [symbolname=%1$s, number=%2$d, slot=%3$d]"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:675
 #, fuzzy
 msgid "No searchstring given in autonumber text."
 msgstr "Nincs keresőszöveg megadva az újraszámozáshoz.\n"
 
-#: schematic/src/x_autonumber.c:728
 #, fuzzy
 msgid "No '*' or '?' given at the end of the autonumber text."
 msgstr "Hiányzik a  '*' vagy '?' a szöveg végéről.\n"
 
-#: schematic/src/x_autonumber.c:873
 msgid "Diagonal"
 msgstr "Átlós"
 
-#: schematic/src/x_autonumber.c:874
 msgid "Top to bottom"
 msgstr "Fentről lefelé"
 
-#: schematic/src/x_autonumber.c:875
 msgid "Bottom to top"
 msgstr "Lentről felfelé"
 
-#: schematic/src/x_autonumber.c:876
 msgid "Left to right"
 msgstr "Balról jobbra"
 
-#: schematic/src/x_autonumber.c:877
 msgid "Right to left"
 msgstr "Jobbról balra"
 
-#: schematic/src/x_autonumber.c:878
 msgid "File order"
 msgstr "Fáljsorrend"
 
-#: schematic/src/x_autonumber.c:1214
 msgid "Autonumber text"
 msgstr "Automatikus számozás"
 
-#: schematic/src/x_autonumber.c:1237
 msgid "<b>Scope</b>"
 msgstr "<b>Hatáskör</b>"
 
-#: schematic/src/x_autonumber.c:1259
 msgid "Search for:"
 msgstr "Keresés:"
 
-#: schematic/src/x_autonumber.c:1273
 msgid "Autonumber text in:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1280
 msgid "Skip numbers found in:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1292 schematic/src/x_autonumber.c:1301
 msgid "Selected objects"
 msgstr "Kiválasztott objektumok"
 
-#: schematic/src/x_autonumber.c:1293 schematic/src/x_autonumber.c:1302
 msgid "Current page"
 msgstr "Jelenlegi oldal"
 
-#: schematic/src/x_autonumber.c:1294 schematic/src/x_autonumber.c:1303
 msgid "Whole hierarchy"
 msgstr "Teljes hierarchia"
 
-#: schematic/src/x_autonumber.c:1305
 msgid "Overwrite existing numbers"
 msgstr "Meglevő számok felülírása"
 
-#: schematic/src/x_autonumber.c:1310
 msgid "<b>Options</b>"
 msgstr "<b>Opciók</b>"
 
-#: schematic/src/x_autonumber.c:1332
 msgid "Starting number:"
 msgstr "Kezdőszám:"
 
-#: schematic/src/x_autonumber.c:1339
 msgid "Sort order:"
 msgstr "Rendezési sorrend:"
 
-#: schematic/src/x_autonumber.c:1371
 msgid "Remove numbers"
 msgstr "Számok törlése"
 
-#: schematic/src/x_autonumber.c:1375
 msgid "Automatic slotting"
 msgstr "Automatikus slot-kiválasztás"
 
-#: schematic/src/x_clipboard.c:245
 #, c-format
 msgid ""
 "<b>Invalid schematic on clipboard.</b>\n"
@@ -1513,178 +1166,138 @@ msgid ""
 "An error occurred while inserting clipboard data: %s."
 msgstr ""
 
-#: schematic/src/x_clipboard.c:247
 msgid "Clipboard insertion failed"
 msgstr ""
 
-#: schematic/src/x_color.c:89 schematic/src/x_color.c:98
 #, fuzzy, c-format
 msgid "Could not allocate the color %1$s!\n"
 msgstr "Nem találom a(z) %s színt!\n"
 
-#: schematic/src/x_color.c:89
 msgid "black"
 msgstr "fekete"
 
-#: schematic/src/x_color.c:98
 msgid "white"
 msgstr "fehér"
 
-#: schematic/src/x_color.c:120
 #, fuzzy, c-format
 msgid "Could not allocate display color %1$i!\n"
 msgstr "Nem találom a(z) %s színt!\n"
 
-#: schematic/src/x_color.c:142
 #, fuzzy, c-format
 msgid "Could not allocate outline color %1$i!\n"
 msgstr "Nem találom a(z) %s színt!\n"
 
-#: schematic/src/x_color.c:159
 #, c-format
 msgid "Tried to get an invalid color: %1$d\n"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:145
 msgid "Background"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:147
 msgid "Net endpoint"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:148
 msgid "Graphic"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:151
 msgid "Logic bubble"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:152
 msgid "Grid point"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:153
 #, fuzzy
 msgid "Detached attribute"
 msgstr "Attribútumok szerkesztése"
 
-#: schematic/src/x_colorcb.c:156
 #, fuzzy
 msgid "Selection"
 msgstr "Kiválasztás"
 
-#: schematic/src/x_colorcb.c:157
 msgid "Bounding box"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:158
 #, fuzzy
 msgid "Zoom box"
 msgstr "Doboz nagyítás"
 
-#: schematic/src/x_colorcb.c:161
 msgid "Output background"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:162
 msgid "Freestyle 1"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:163
 msgid "Freestyle 2"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:164
 msgid "Freestyle 3"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:165
 msgid "Freestyle 4"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:166
 #, fuzzy
 msgid "Net junction"
 msgstr "Funkció"
 
-#: schematic/src/x_colorcb.c:167
 msgid "Mesh grid major"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:168
 msgid "Mesh grid minor"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:172
 msgid "Unknown"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1169
 #, fuzzy
 msgid "Reset filter"
 msgstr "Új fájl"
 
-#: schematic/src/x_compselect.c:1192
 msgid "Reload all libraries"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1245 schematic/src/x_multiattrib.c:2092
 msgid "Value"
 msgstr "Érték"
 
-#: schematic/src/x_compselect.c:1284
 msgid "Default behavior - reference component"
 msgstr "Alapviselkedés - mutató az alkatrészre"
 
-#: schematic/src/x_compselect.c:1287
 msgid "Embed component in schematic"
 msgstr "Alkatrész beágyazása a rajzba"
 
-#: schematic/src/x_compselect.c:1290
 msgid "Include component as individual objects"
 msgstr "Alkatrész hozzáadása mint független objektum"
 
-#: schematic/src/x_compselect.c:1448
 msgid "Select Component..."
 msgstr "Alkatrész kiválasztása..."
 
-#: schematic/src/x_compselect.c:1471
 #, fuzzy
 msgid "In Us_e"
 msgstr "Használatban"
 
-#: schematic/src/x_compselect.c:1475
 #, fuzzy
 msgid "Lib_raries"
 msgstr "Könyvtárak"
 
-#: schematic/src/x_compselect.c:1484 schematic/src/x_fileselect.c:119
 msgid "Preview"
 msgstr "Előnézet"
 
-#: schematic/src/x_compselect.c:1510
 msgid "Attributes"
 msgstr "Attribútumok"
 
-#: schematic/src/x_dialog.c:325
 msgid "Major symbol changes detected."
 msgstr ""
 
-#: schematic/src/x_dialog.c:349
 msgid ""
 "Changes have occurred to the symbols shown below.\n"
 "\n"
 "Be sure to verify each of these symbols."
 msgstr ""
 
-#: schematic/src/x_dialog.c:369
 #, fuzzy
 msgid "Symbol"
 msgstr "szimbólumok"
 
-#: schematic/src/x_dialog.c:406
 #, c-format
 msgid ""
 "<span weight=\"bold\" size=\"larger\">The input attribute \"%s\" is invalid\n"
@@ -1695,40 +1308,31 @@ msgid ""
 "The value cannot start with a space."
 msgstr ""
 
-#: schematic/src/x_dialog.c:408
 msgid "Invalid Attribute"
 msgstr "Hibás attribútum"
 
-#: schematic/src/x_fileselect.c:37
 msgid "Schematics"
 msgstr "rajzok"
 
-#: schematic/src/x_fileselect.c:42
 msgid "Symbols"
 msgstr "szimbólumok"
 
-#: schematic/src/x_fileselect.c:47
 msgid "Schematics and symbols"
 msgstr "rajzok és szimbólumok"
 
-#: schematic/src/x_fileselect.c:53
 msgid "All files"
 msgstr "Összes fájl"
 
-#: schematic/src/x_fileselect.c:169
 msgid "Open..."
 msgstr "Megnyitás…"
 
-#: schematic/src/x_fileselect.c:233
 msgid "Save as..."
 msgstr "Mentés másként..."
 
-#: schematic/src/x_fileselect.c:297
 #, fuzzy
 msgid "Save cancelled on user request"
 msgstr "A mentés a felhasználó kérésének megfelelően megszakítva.\n"
 
-#: schematic/src/x_fileselect.c:334
 msgid ""
 "\n"
 "If you load the original file, the backup file will be overwritten in the "
@@ -1737,28 +1341,22 @@ msgid ""
 "Do you want to load the backup file?\n"
 msgstr ""
 
-#: schematic/src/x_fstylecb.c:73
 msgid "Hollow"
 msgstr "Üres"
 
-#: schematic/src/x_fstylecb.c:80
 msgid "Filled"
 msgstr "Kitöltött"
 
-#: schematic/src/x_fstylecb.c:87
 msgid "Mesh"
 msgstr "Háló"
 
-#: schematic/src/x_fstylecb.c:94
 msgid "Hatch"
 msgstr "Sraffozott"
 
-#: schematic/src/x_image.c:279
 #, c-format
 msgid "x_image_lowlevel: Unable to write %1$s file %2$s."
 msgstr ""
 
-#: schematic/src/x_image.c:289
 #, fuzzy, c-format
 msgid ""
 "There was the following error when saving image with type %1$s to filename:\n"
@@ -1772,310 +1370,243 @@ msgstr ""
 "\n"
 "%s\n"
 
-#: schematic/src/x_image.c:309
 #, fuzzy, c-format
 msgid "Wrote color image to [%1$s] [%2$d x %3$d]"
 msgstr "Színes kép kiírva: [%s] [%d x %d]\n"
 
-#: schematic/src/x_image.c:311
 #, fuzzy, c-format
 msgid "Wrote black and white image to [%1$s] [%2$d x %3$d]"
 msgstr "Fekete-fehér kép kiírva: [%s] [%d x %d]\n"
 
-#: schematic/src/x_image.c:319
 msgid "x_image_lowlevel: Unable to get pixbuf from gschem's window."
 msgstr ""
 
-#: schematic/src/x_image.c:358
 msgid "Width x Height"
 msgstr "szélesség x magasság"
 
-#: schematic/src/x_image.c:374
 msgid "Image type"
 msgstr "Képtípus"
 
-#: schematic/src/x_image.c:395
 msgid "Write image..."
 msgstr "Képfájl írása..."
 
-#: schematic/src/x_linecapcb.c:74
 msgid "Butt"
 msgstr ""
 
-#: schematic/src/x_linecapcb.c:81
 msgid "Square"
 msgstr ""
 
-#: schematic/src/x_linecapcb.c:88
 msgid "Round"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:74
 msgid "Solid"
 msgstr "Folytonos"
 
-#: schematic/src/x_linetypecb.c:81
 msgid "Dotted"
 msgstr "Pontvonal"
 
-#: schematic/src/x_linetypecb.c:88
 msgid "Dashed"
 msgstr "Szaggatott"
 
-#: schematic/src/x_linetypecb.c:95
 msgid "Center"
 msgstr "Középre"
 
-#: schematic/src/x_linetypecb.c:102
 msgid "Phantom"
 msgstr ""
 
-#: schematic/src/x_menus.c:41 schematic/scheme/gschem/builtins.scm:267
 #, fuzzy
 msgid "Add Net"
 msgstr "/Összeköttetés hozzáadása"
 
-#: schematic/src/x_menus.c:42 schematic/src/x_multiattrib.c:2187
-#: schematic/scheme/gschem/builtins.scm:264
 msgid "Add Attribute"
 msgstr "Attribútum hozzáadása"
 
-#: schematic/src/x_menus.c:43 schematic/scheme/gschem/builtins.scm:261
 #, fuzzy
 msgid "Add Component"
 msgstr "/Alkatrész hozzáadása"
 
-#: schematic/src/x_menus.c:44 schematic/scheme/gschem/builtins.scm:270
 #, fuzzy
 msgid "Add Bus"
 msgstr "/Busz hozzáadása"
 
-#: schematic/src/x_menus.c:45 schematic/scheme/gschem/builtins.scm:273
 #, fuzzy
 msgid "Add Text"
 msgstr "/Szöveg hozzáadása"
 
-#: schematic/src/x_menus.c:47 schematic/scheme/gschem/builtins.scm:210
 #, fuzzy
 msgid "Zoom In"
 msgstr "/Nagyítás"
 
-#: schematic/src/x_menus.c:48 schematic/scheme/gschem/builtins.scm:213
 #, fuzzy
 msgid "Zoom Out"
 msgstr "/Kicsinyítés"
 
-#: schematic/src/x_menus.c:50 schematic/scheme/gschem/builtins.scm:207
 #, fuzzy
 msgid "Zoom Extents"
 msgstr "/Teljes rajz"
 
-#: schematic/src/x_menus.c:52 schematic/src/x_window.c:1233
 msgid "Select"
 msgstr "Kiválasztás"
 
-#: schematic/src/x_menus.c:53 schematic/scheme/conf/schematic/menu.scm:69
-#: schematic/scheme/gschem/builtins.scm:126
 msgid "Edit..."
 msgstr "Szerkesztés..."
 
-#: schematic/src/x_menus.c:54 schematic/scheme/conf/schematic/menu.scm:68
 #, fuzzy
 msgid "Object Properties..."
 msgstr "<b>Szöveg tulajdonságai</b>"
 
-#: schematic/src/x_menus.c:59 schematic/scheme/gschem/builtins.scm:300
 #, fuzzy
 msgid "Down Schematic"
 msgstr "Rajz szerkesztése"
 
-#: schematic/src/x_menus.c:60 schematic/scheme/gschem/builtins.scm:303
 #, fuzzy
 msgid "Down Symbol"
 msgstr "/Szimbólum szerkesztése"
 
-#: schematic/src/x_menus.c:61
 #, fuzzy
 msgid "Up"
 msgstr "/Fel"
 
-#: schematic/src/x_menus.c:336
 #, c-format
 msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
 msgstr ""
 
-#: schematic/src/x_menus.c:360
 #, c-format
 msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
 msgstr ""
 
-#: schematic/src/x_misc.c:70
 msgid "The operating system is out of memory or resources."
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:798 schematic/src/x_multiattrib.c:2704
 msgid "<various>"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:930
 msgid "Attributes with empty name are not allowed. Please set a name."
 msgstr ""
 "Név nélküli attribútumok nem használhatóak. Kérlek adj nevet az "
 "attribútumnak!"
 
-#: schematic/src/x_multiattrib.c:1622
 msgid "Show Value only"
 msgstr "Csak az érték mutatása"
 
-#: schematic/src/x_multiattrib.c:1624
 msgid "Show Name only"
 msgstr "Csak a név mutatása"
 
-#: schematic/src/x_multiattrib.c:1651
 msgid "Promote"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1655
 msgid "Duplicate"
 msgstr "Megkettőzés"
 
-#: schematic/src/x_multiattrib.c:1657
 #, fuzzy
 msgid "Copy to all"
 msgstr "Másolás 1-be"
 
-#: schematic/src/x_multiattrib.c:1986 schematic/src/x_multiattrib.c:2602
 msgid "Edit Attributes"
 msgstr "Attribútumok szerkesztése"
 
-#: schematic/src/x_multiattrib.c:2112
 msgid "Vis?"
 msgstr "Látható?"
 
-#: schematic/src/x_multiattrib.c:2130
 msgid "N"
 msgstr "N"
 
-#: schematic/src/x_multiattrib.c:2148
 msgid "V"
 msgstr "É"
 
-#: schematic/src/x_multiattrib.c:2170
 #, fuzzy
 msgid "Sho_w inherited attributes"
 msgstr "Attribútumok szerkesztése"
 
-#: schematic/src/x_multiattrib.c:2197
 #, fuzzy
 msgid "_Name:"
 msgstr "Név:"
 
-#: schematic/src/x_multiattrib.c:2241
 msgid "Ctrl+Enter inserts new line; Ctrl+Tab inserts Tab"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2618
 #, c-format
 msgid "%2$i symbol (%1$s)"
 msgid_plural "%2$i symbols (%1$s)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2624
 #, c-format
 msgid "%1$i pin"
 msgid_plural "%1$i pins"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2630
 #, c-format
 msgid "%1$i net"
 msgid_plural "%1$i nets"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2636
 #, c-format
 msgid "%1$i bus"
 msgid_plural "%1$i buses"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2642
 #, fuzzy, c-format
 msgid "%1$i attribute"
 msgid_plural "%1$i attributes"
 msgstr[0] "Attribútum"
 msgstr[1] "Attribútum"
 
-#: schematic/src/x_newtext.c:433
 #, fuzzy
 msgid "Text Entry..."
 msgstr "Szöveg"
 
-#: schematic/src/x_pagesel.c:253
 msgid "New Page"
 msgstr "Új lap"
 
-#: schematic/src/x_pagesel.c:254
 msgid "Open Page..."
 msgstr "Lap megnyitása"
 
-#: schematic/src/x_pagesel.c:256
 msgid "Save Page"
 msgstr "Mentés"
 
-#: schematic/src/x_pagesel.c:257 schematic/scheme/gschem/builtins.scm:246
 msgid "Close Page"
 msgstr "Lap bezárása"
 
-#: schematic/src/x_pagesel.c:376 schematic/scheme/gschem/builtins.scm:237
 msgid "Page Manager"
 msgstr "Oldalkiválasztó"
 
-#: schematic/src/x_pagesel.c:448
 msgid "Changed"
 msgstr "Módosítva"
 
-#: schematic/src/x_pagesel.c:468
 msgid "Right click on the filename for more options..."
 msgstr "Kattints a jobb egérgombbal a fájlnével a további opciókért..."
 
-#: schematic/src/x_print.c:306
 #, fuzzy, c-format
 msgid "Failed to write PDF to '%s': %s\n"
 msgstr "[%s] init scm fájl olvasása sikertelen.\n"
 
-#: schematic/src/x_print.c:364
 #, fuzzy, c-format
 msgid "Failed to write PDF to '%1$s': %2$s\n"
 msgstr "[%s] init scm fájl olvasása sikertelen.\n"
 
-#: schematic/src/x_print.c:449
 #, c-format
 msgid ""
 "Error printing file:\n"
 "%1$s"
 msgstr ""
 
-#: schematic/src/x_rc.c:39
 msgid "ERROR: An unknown error occurred while parsing configuration files."
 msgstr ""
 
-#: schematic/src/x_rc.c:44
 msgid ""
 "An unknown error occurred while parsing configuration files.\n"
 "\n"
 "The lepton-schematic log may contain more information."
 msgstr ""
 
-#: schematic/src/x_rc.c:56
 #, c-format
 msgid "ERROR: %1$s"
 msgstr ""
 
-#: schematic/src/x_rc.c:59
 #, c-format
 msgid ""
 "%1$s\n"
@@ -2083,141 +1614,110 @@ msgid ""
 "The lepton-schematic log may contain more information."
 msgstr ""
 
-#: schematic/src/x_rc.c:67
 msgid "Cannot load lepton-schematic configuration."
 msgstr ""
 
-#: schematic/src/x_script.c:42 schematic/scheme/conf/schematic/menu.scm:40
 msgid "Execute Script..."
 msgstr "Szkript végrehajtása"
 
-#: schematic/src/x_script.c:61
 #, fuzzy, c-format
 msgid "Executing guile script [%1$s]"
 msgstr "[%s] guile szkript végrehajtása.\n"
 
-#: schematic/src/x_tabs.c:860
 #, fuzzy, c-format
 msgid "Hierarchy up: %s"
 msgstr "Hie_rarchia"
 
-#: schematic/src/x_tabs.c:863
 #, fuzzy
 msgid "Hierarchy up"
 msgstr "Hie_rarchia"
 
-#: schematic/src/x_widgets.c:158 schematic/src/x_window.c:1444
 #, fuzzy
 msgid "Options"
 msgstr "Beállítás_ok"
 
-#: schematic/src/x_widgets.c:203 schematic/src/x_window.c:1436
 #, fuzzy
 msgid "Object"
 msgstr "Objektum színe:"
 
-#: schematic/src/x_widgets.c:224
 msgid "Log"
 msgstr ""
 
-#: schematic/src/x_widgets.c:245 schematic/src/x_window.c:1466
 msgid "Find Text"
 msgstr "Szöveg keresése"
 
-#: schematic/src/x_widgets.c:259
 #, fuzzy
 msgid "Color Scheme Editor"
 msgstr "Világos színséma"
 
-#: schematic/src/x_widgets.c:272 schematic/scheme/gschem/builtins.scm:378
 #, fuzzy
 msgid "Select Schematic Font"
 msgstr "Válaszd ki a menteni kívánt rajzot:"
 
-#: schematic/src/x_window.c:763
 #, fuzzy, c-format
 msgid "Loading schematic [%1$s]"
 msgstr "[%s] rajz betöltése\n"
 
-#: schematic/src/x_window.c:864
 #, fuzzy, c-format
 msgid "Could NOT save page [%1$s]\n"
 msgstr "A [%s] rajz mentése nem sikerült.\n"
 
-#: schematic/src/x_window.c:865
 msgid "Error while trying to save"
 msgstr "Hiba mentés közben"
 
-#: schematic/src/x_window.c:875
 msgid "Failed to save file"
 msgstr ""
 
-#: schematic/src/x_window.c:885
 #, fuzzy, c-format
 msgid "Saved as [%1$s]"
 msgstr "[%s]-ként elmentve.\n"
 
-#: schematic/src/x_window.c:887
 #, fuzzy, c-format
 msgid "Saved [%1$s]"
 msgstr "[%s] elmentve.\n"
 
-#: schematic/src/x_window.c:889
 msgid "Saved"
 msgstr "Elmentve"
 
-#: schematic/src/x_window.c:966
 #, fuzzy, c-format
 msgid "Discarding page [%1$s]"
 msgstr "A(z) [%s] rajz eldobása\n"
 
-#: schematic/src/x_window.c:966
 #, fuzzy, c-format
 msgid "Closing [%1$s]"
 msgstr "[%s] bezárása\n"
 
-#: schematic/src/x_window.c:1175
 msgid "New"
 msgstr "Új"
 
-#: schematic/src/x_window.c:1175
 msgid "New file"
 msgstr "Új fájl"
 
-#: schematic/src/x_window.c:1179
 msgid "Open"
 msgstr "Megnyitás"
 
-#: schematic/src/x_window.c:1179
 #, fuzzy
 msgid "Open file"
 msgstr "Fájl megnyitása…"
 
-#: schematic/src/x_window.c:1183 schematic/scheme/gschem/builtins.scm:59
 msgid "Save"
 msgstr "Mentés"
 
-#: schematic/src/x_window.c:1183
 msgid "Save file"
 msgstr "Fájl mentése"
 
-#: schematic/src/x_window.c:1189 schematic/scheme/gschem/builtins.scm:93
 msgid "Undo"
 msgstr "Visszavonás"
 
-#: schematic/src/x_window.c:1189
 msgid "Undo last operation"
 msgstr "Utolsó művelet visszavonása"
 
-#: schematic/src/x_window.c:1193 schematic/scheme/gschem/builtins.scm:96
 msgid "Redo"
 msgstr "Újra"
 
-#: schematic/src/x_window.c:1193
 msgid "Redo last undo"
 msgstr "Utolsó visszavont művelet újra"
 
-#: schematic/src/x_window.c:1198
 msgid ""
 "Add component...\n"
 "Select library and component from list, move the mouse into main window, "
@@ -2228,57 +1728,45 @@ msgstr ""
 "Válaszd ki a könyvtárt és abból az alkatrészt, mozgasd az egérmutatót a rajz "
 "fölé, lerakás bal klikk."
 
-#: schematic/src/x_window.c:1209
 msgid ""
 "Add nets mode\n"
 "Right mouse button to cancel"
 msgstr "Összeköttetések hozzáadása mód"
 
-#: schematic/src/x_window.c:1217
 msgid ""
 "Add buses mode\n"
 "Right mouse button to cancel"
 msgstr "Busz hozzáadása mód"
 
-#: schematic/src/x_window.c:1226
 msgid "Add Text..."
 msgstr "Szöveg hozzáadása"
 
-#: schematic/src/x_window.c:1233
 msgid "Select mode"
 msgstr "Kiválasztás mód"
 
-#: schematic/src/x_window.c:1288
 #, fuzzy
 msgid "Show"
 msgstr "Szöveg mutatása"
 
-#: schematic/src/x_window.c:1289
 msgid "Show text starting with:"
 msgstr "A következővel kezdődő szöveg mutatása:"
 
-#: schematic/src/x_window.c:1345
 msgid "Menu/Cancel"
 msgstr "Menü/mégsem"
 
-#: schematic/src/x_window.c:1349
 msgid "Pan/Cancel"
 msgstr "Középre/mégsem"
 
-#: schematic/src/x_window.c:1359
 msgid "Pick"
 msgstr "Kijelöl"
 
-#: schematic/src/x_window.c:1470 schematic/scheme/gschem/builtins.scm:180
 msgid "Status"
 msgstr "Állapot."
 
-#: schematic/src/x_window.c:1568
 #, fuzzy, c-format
 msgid "New file [%s]"
 msgstr "Új fájl: [%s]\n"
 
-#: schematic/src/x_window.c:1598
 #, c-format
 msgid ""
 "<b>An error occurred while loading the requested file.</b>\n"
@@ -2292,897 +1780,687 @@ msgid ""
 "monitor program's output in terminal window."
 msgstr ""
 
-#: schematic/src/x_window.c:1617
 msgid "Failed to load file"
 msgstr "A fájl betöltése nem sikerült."
 
-#: schematic/data/lepton-schematic.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Schematic Editor"
 msgstr "gEDA kapcsolásirajz-szerkesztő"
 
-#: schematic/data/lepton-schematic.desktop.in:4
 #, fuzzy
 msgid "Create and edit electrical schematics and symbols with lepton-schematic"
 msgstr ""
 "Elektromos kapcsolási rajzok és szimbólumok készítése és szerkesztése a "
 "gschemmel"
 
-#: schematic/scheme/conf/schematic/menu.scm:27
 msgid "_New"
 msgstr "_Új"
 
-#: schematic/scheme/conf/schematic/menu.scm:28
 msgid "_Open..."
 msgstr "_Megnyitás..."
 
-#: schematic/scheme/conf/schematic/menu.scm:30
 msgid "Open Recen_t"
 msgstr "Legutóbbi megnyitása"
 
-#: schematic/scheme/conf/schematic/menu.scm:32
 msgid "_Save"
 msgstr "Menté_s"
 
-#: schematic/scheme/conf/schematic/menu.scm:33
 msgid "Save _As..."
 msgstr "Mentés másként"
 
-#: schematic/scheme/conf/schematic/menu.scm:34
-#: schematic/scheme/gschem/builtins.scm:65
 msgid "Save All"
 msgstr "Mind mentése"
 
-#: schematic/scheme/conf/schematic/menu.scm:36
 msgid "_Print..."
 msgstr "_Nyomtatás…"
 
-#: schematic/scheme/conf/schematic/menu.scm:37
 #, fuzzy
 msgid "Write _Image..."
 msgstr "Képfájl írása..."
 
-#: schematic/scheme/conf/schematic/menu.scm:39
 #, fuzzy
 msgid "Invoke Macro..."
 msgstr "Makró végrehajtása"
 
-#: schematic/scheme/conf/schematic/menu.scm:41
 msgid "REPL..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:43
-#: schematic/scheme/gschem/builtins.scm:77
 msgid "New Window"
 msgstr "Új ablak"
 
-#: schematic/scheme/conf/schematic/menu.scm:44
 msgid "_Close Window"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:45
 msgid "_Quit"
 msgstr "Kilépés"
 
-#: schematic/scheme/conf/schematic/menu.scm:51
 msgid "_Undo"
 msgstr "_Visszavonás"
 
-#: schematic/scheme/conf/schematic/menu.scm:52
 msgid "_Redo"
 msgstr "Új_ra"
 
-#: schematic/scheme/conf/schematic/menu.scm:54
 msgid "Cu_t"
 msgstr "Kivágás"
 
-#: schematic/scheme/conf/schematic/menu.scm:55
 msgid "_Copy"
 msgstr "Másolás (_C)"
 
-#: schematic/scheme/conf/schematic/menu.scm:56
 msgid "_Paste"
 msgstr "Beillesztés (_P)"
 
-#: schematic/scheme/conf/schematic/menu.scm:57
 msgid "_Delete"
 msgstr "Törlés (_D)"
 
-#: schematic/scheme/conf/schematic/menu.scm:60
-#: schematic/scheme/gschem/builtins.scm:102
 msgid "Select All"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:61
-#: schematic/scheme/gschem/builtins.scm:105
 msgid "Deselect"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:65
 msgid "Rotate 90 Mode"
 msgstr "Elforgatás 90 fokkal"
 
-#: schematic/scheme/conf/schematic/menu.scm:70
 msgid "Edit Text..."
 msgstr "Szöveg szerkesztése..."
 
-#: schematic/scheme/conf/schematic/menu.scm:71
 msgid "Slot..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:76
-#: schematic/scheme/gschem/builtins.scm:150
 msgid "Embed Component/Picture"
 msgstr "Alkatrész/kép beágyazása"
 
-#: schematic/scheme/conf/schematic/menu.scm:77
-#: schematic/scheme/gschem/builtins.scm:153
 msgid "Unembed Component/Picture"
 msgstr "Alkatrész/kép beágyazásának megszüntetése"
 
-#: schematic/scheme/conf/schematic/menu.scm:78
-#: schematic/scheme/gschem/builtins.scm:156
 msgid "Update Component"
 msgstr "Alkatrész frissítése"
 
-#: schematic/scheme/conf/schematic/menu.scm:79
 msgid "Symbol Translate..."
 msgstr "Szimbólum áthelyezése"
 
-#: schematic/scheme/conf/schematic/menu.scm:85
 msgid "Copy into 1"
 msgstr "Másolás 1-be"
 
-#: schematic/scheme/conf/schematic/menu.scm:86
 msgid "Copy into 2"
 msgstr "Másolás 2-be"
 
-#: schematic/scheme/conf/schematic/menu.scm:87
 msgid "Copy into 3"
 msgstr "Másolás 3-ba"
 
-#: schematic/scheme/conf/schematic/menu.scm:88
 msgid "Copy into 4"
 msgstr "Másolás 4-be"
 
-#: schematic/scheme/conf/schematic/menu.scm:89
 msgid "Copy into 5"
 msgstr "Másolás 5-be"
 
-#: schematic/scheme/conf/schematic/menu.scm:90
 msgid "Cut into 1"
 msgstr "Kivágás 1-be"
 
-#: schematic/scheme/conf/schematic/menu.scm:91
 msgid "Cut into 2"
 msgstr "Kivágás 2-be"
 
-#: schematic/scheme/conf/schematic/menu.scm:92
 msgid "Cut into 3"
 msgstr "Kivágás 3-ba"
 
-#: schematic/scheme/conf/schematic/menu.scm:93
 msgid "Cut into 4"
 msgstr "Kivágás 4-be"
 
-#: schematic/scheme/conf/schematic/menu.scm:94
 msgid "Cut into 5"
 msgstr "Kivágás 5-be"
 
-#: schematic/scheme/conf/schematic/menu.scm:95
 msgid "Paste from 1"
 msgstr "Beillesztés 1-ből"
 
-#: schematic/scheme/conf/schematic/menu.scm:96
 msgid "Paste from 2"
 msgstr "Beillesztés 2-ből"
 
-#: schematic/scheme/conf/schematic/menu.scm:97
 msgid "Paste from 3"
 msgstr "Beillesztés 3-ból"
 
-#: schematic/scheme/conf/schematic/menu.scm:98
 msgid "Paste from 4"
 msgstr "Beillesztés 4-ből"
 
-#: schematic/scheme/conf/schematic/menu.scm:99
 msgid "Paste from 5"
 msgstr "Beillesztés 5-ből"
 
-#: schematic/scheme/conf/schematic/menu.scm:105
 msgid "Side Dock"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:106
 #, fuzzy
 msgid "Bottom Dock"
 msgstr "Lentről felfelé"
 
-#: schematic/scheme/conf/schematic/menu.scm:108
 #, fuzzy
 msgid "Find Text Results"
 msgstr "Szöveg keresése"
 
-#: schematic/scheme/conf/schematic/menu.scm:110
 msgid "_Redraw"
 msgstr "Újrarajzolás"
 
-#: schematic/scheme/conf/schematic/menu.scm:111
 msgid "_Pan"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:112
 msgid "Zoom _Box"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:113
 msgid "Zoom _Extents"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:114
 msgid "Zoom _In"
 msgstr "Nagyítás"
 
-#: schematic/scheme/conf/schematic/menu.scm:115
 msgid "Zoom _Out"
 msgstr "Kicsinyítés"
 
-#: schematic/scheme/conf/schematic/menu.scm:116
 msgid "Zoom _Full"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:118
 #, fuzzy
 msgid "_Dark Color Scheme"
 msgstr "Sötét színséma"
 
-#: schematic/scheme/conf/schematic/menu.scm:119
 #, fuzzy
 msgid "_Light Color Scheme"
 msgstr "Világos színséma"
 
-#: schematic/scheme/conf/schematic/menu.scm:120
 #, fuzzy
 msgid "B_W Color Scheme"
 msgstr "Sötét színséma"
 
-#: schematic/scheme/conf/schematic/menu.scm:122
 #, fuzzy
 msgid "Color Scheme Editor..."
 msgstr "Világos színséma"
 
-#: schematic/scheme/conf/schematic/menu.scm:129
 msgid "_Manager..."
 msgstr "_Kezelő..."
 
-#: schematic/scheme/conf/schematic/menu.scm:131
 msgid "_Previous"
 msgstr "Előző"
 
-#: schematic/scheme/conf/schematic/menu.scm:132
 msgid "_Next"
 msgstr "Következő"
 
-#: schematic/scheme/conf/schematic/menu.scm:133
 msgid "_Close"
 msgstr "_Bezárás"
 
-#: schematic/scheme/conf/schematic/menu.scm:135
 #, fuzzy
 msgid "_Revert..."
 msgstr "_Visszaállítás"
 
-#: schematic/scheme/conf/schematic/menu.scm:137
-#: schematic/scheme/gschem/builtins.scm:249
 #, fuzzy
 msgid "Next Tab"
 msgstr "Új lap"
 
-#: schematic/scheme/conf/schematic/menu.scm:138
-#: schematic/scheme/gschem/builtins.scm:252
 #, fuzzy
 msgid "Previous Tab"
 msgstr "Előző"
 
-#: schematic/scheme/conf/schematic/menu.scm:146
 msgid "_Component..."
 msgstr "Alkatrész"
 
-#: schematic/scheme/conf/schematic/menu.scm:148
 msgid "_Net"
 msgstr "_Net"
 
-#: schematic/scheme/conf/schematic/menu.scm:149
 msgid "B_us"
 msgstr "B_usz"
 
-#: schematic/scheme/conf/schematic/menu.scm:151
 msgid "_Attribute..."
 msgstr "_Attribútum"
 
-#: schematic/scheme/conf/schematic/menu.scm:152
 msgid "_Text..."
 msgstr "Szöveg"
 
-#: schematic/scheme/conf/schematic/menu.scm:154
 msgid "_Line"
 msgstr "Vona_l"
 
-#: schematic/scheme/conf/schematic/menu.scm:155
 msgid "Pat_h"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:156
 msgid "_Box"
 msgstr "Do_boz"
 
-#: schematic/scheme/conf/schematic/menu.scm:157
 msgid "C_ircle"
 msgstr "Kör"
 
-#: schematic/scheme/conf/schematic/menu.scm:158
 msgid "A_rc"
 msgstr "Kö_rív"
 
-#: schematic/scheme/conf/schematic/menu.scm:159
 msgid "_Pin"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:161
 msgid "Pictu_re..."
 msgstr "Kép"
 
-#: schematic/scheme/conf/schematic/menu.scm:167
 msgid "_Up"
 msgstr "Vissza a rajzhoz"
 
-#: schematic/scheme/conf/schematic/menu.scm:169
 msgid "_Down Schematic"
 msgstr "Kapcsolási rajz szerkesztése"
 
-#: schematic/scheme/conf/schematic/menu.scm:170
 msgid "Down _Symbol"
 msgstr "Szimbólum szerkesztése"
 
-#: schematic/scheme/conf/schematic/menu.scm:176
 msgid "_Attach"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:177
 msgid "_Detach"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:179
 msgid "Show _Value"
 msgstr "Érték mutatása"
 
-#: schematic/scheme/conf/schematic/menu.scm:180
 msgid "Show _Name"
 msgstr "Név mutatása"
 
-#: schematic/scheme/conf/schematic/menu.scm:181
 msgid "Show _Both"
 msgstr "Mindkettő mutatása"
 
-#: schematic/scheme/conf/schematic/menu.scm:182
 msgid "_Toggle Visibility"
 msgstr "Lá_thatóság váltása"
 
-#: schematic/scheme/conf/schematic/menu.scm:184
 msgid "_Hide Specific Text..."
 msgstr "Szöveg elrejtése"
 
-#: schematic/scheme/conf/schematic/menu.scm:185
 msgid "_Show Specific Text..."
 msgstr "Szöveg mutatása"
 
-#: schematic/scheme/conf/schematic/menu.scm:186
 #, fuzzy
 msgid "Show/Hide Hidden Text"
 msgstr "Láthatatlan szöveg mutatása/elrejtése"
 
-#: schematic/scheme/conf/schematic/menu.scm:188
 msgid "_Find Text/Check Symbol..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:189
 msgid "A_utonumber Text..."
 msgstr "Szöveg automatikus számozása"
 
-#: schematic/scheme/conf/schematic/menu.scm:195
 #, fuzzy
 msgid "_Options..."
 msgstr "Beállítás_ok"
 
-#: schematic/scheme/conf/schematic/menu.scm:196
 #, fuzzy
 msgid "_Font..."
 msgstr "_Nyomtatás…"
 
-#: schematic/scheme/conf/schematic/menu.scm:198
 #, fuzzy
 msgid "Grid +"
 msgstr "Háló ki\n"
 
-#: schematic/scheme/conf/schematic/menu.scm:199
 #, fuzzy
 msgid "Grid -"
 msgstr "Háló ki\n"
 
-#: schematic/scheme/conf/schematic/menu.scm:201
 msgid "Grid Style: Cycle Dots/Mesh/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:202
 msgid "Grid Snap: Cycle Grid/Resnap/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:204
 msgid "Feedback Mode: Outline/Box"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:205
 msgid "Net: Rubberband On/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:206
 msgid "Net: Magnetic On/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:208
 #, fuzzy
 msgid "_Coord Window"
 msgstr "Ablak bezárása\n"
 
-#: schematic/scheme/conf/schematic/menu.scm:209
 #, fuzzy
 msgid "_Log Window"
 msgstr "Új ablak"
 
-#: schematic/scheme/conf/schematic/menu.scm:215
 msgid "_1 allegro"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:223
 #, fuzzy
 msgid "User _Guide"
 msgstr "gschem _GYIK..."
 
-#: schematic/scheme/conf/schematic/menu.scm:224
 msgid "_FAQ"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:225
 #, fuzzy
 msgid "Docu_mentation"
 msgstr "D_okumentáció"
 
-#: schematic/scheme/conf/schematic/menu.scm:226
 msgid "_Wiki"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:228
 #, fuzzy
 msgid "Find Component D_ocumentation"
 msgstr "Alkatrész dokumentáció"
 
-#: schematic/scheme/conf/schematic/menu.scm:230
 msgid "_Hotkeys..."
 msgstr "_Gyorsbillentyűk..."
 
-#: schematic/scheme/conf/schematic/menu.scm:231
 #, fuzzy
 msgid "_About"
 msgstr "Névjegy"
 
-#: schematic/scheme/conf/schematic/menu.scm:237
 msgid "_File"
 msgstr "_Fájl"
 
-#: schematic/scheme/conf/schematic/menu.scm:238
 msgid "_Edit"
 msgstr "Szerkesztés"
 
-#: schematic/scheme/conf/schematic/menu.scm:240
 msgid "_View"
 msgstr "Nézet"
 
-#: schematic/scheme/conf/schematic/menu.scm:241
 msgid "_Page"
 msgstr "Oldal"
 
-#: schematic/scheme/conf/schematic/menu.scm:242
 msgid "_Add"
 msgstr "Hozzá_adás"
 
-#: schematic/scheme/conf/schematic/menu.scm:243
 msgid "Hie_rarchy"
 msgstr "Hie_rarchia"
 
-#: schematic/scheme/conf/schematic/menu.scm:244
 msgid "A_ttributes"
 msgstr "A_ttribútumok"
 
-#: schematic/scheme/conf/schematic/menu.scm:245
 msgid "_Options"
 msgstr "Beállítás_ok"
 
-#: schematic/scheme/conf/schematic/menu.scm:246
 #, fuzzy
 msgid "_Netlist"
 msgstr "_Net"
 
-#: schematic/scheme/conf/schematic/menu.scm:247
 msgid "_Help"
 msgstr "Segítség"
 
-#: schematic/scheme/gschem/action.scm:43
 #, scheme-format
 msgid "~S is not a valid gschem action."
 msgstr ""
 
-#: schematic/scheme/gschem/action.scm:158
 msgid "Repeat Last Action"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:47
 #, fuzzy
 msgid "Cancel"
 msgstr "Középre/mégsem"
 
-#: schematic/scheme/gschem/builtins.scm:53
 #, fuzzy
 msgid "New File"
 msgstr "Új fájl"
 
-#: schematic/scheme/gschem/builtins.scm:56
 #, fuzzy
 msgid "Open File"
 msgstr "Fájl megnyitása…"
 
-#: schematic/scheme/gschem/builtins.scm:62
 #, fuzzy
 msgid "Save As"
 msgstr "Mind mentése"
 
-#: schematic/scheme/gschem/builtins.scm:68
 #, fuzzy
 msgid "Print"
 msgstr "Nyomtatás..."
 
-#: schematic/scheme/gschem/builtins.scm:71
 msgid "Export Image"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:74
 msgid "Run Script"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:80
 #, fuzzy
 msgid "Close Window"
 msgstr "Ablak bezárása\n"
 
-#: schematic/scheme/gschem/builtins.scm:83
 #, fuzzy
 msgid "Quit"
 msgstr "Kilépés"
 
-#: schematic/scheme/gschem/builtins.scm:87
 msgid "Terminal REPL"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:132
 msgid "Choose Slot"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:135
 #, fuzzy
 msgid "Edit Object Properties"
 msgstr "Szövegtulajdonságok szerkesztése"
 
-#: schematic/scheme/gschem/builtins.scm:138
 #, fuzzy
 msgid "Translate Symbol"
 msgstr "Eltolás"
 
-#: schematic/scheme/gschem/builtins.scm:147
 msgid "Invoke Macro"
 msgstr "Makró végrehajtása"
 
-#: schematic/scheme/gschem/builtins.scm:159
 #, fuzzy
 msgid "Show/Hide Invisible Text"
 msgstr "Láthatatlan szöveg mutatása/elrejtése"
 
-#: schematic/scheme/gschem/builtins.scm:165
 #, fuzzy
 msgid "Cut"
 msgstr "Kivágás"
 
-#: schematic/scheme/gschem/builtins.scm:171
 #, fuzzy
 msgid "Paste"
 msgstr "Beillesztés (_P)"
 
-#: schematic/scheme/gschem/builtins.scm:177
 msgid "Sidebar"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:183
 #, fuzzy
 msgid "Find Text State"
 msgstr "Szöveg keresése"
 
-#: schematic/scheme/gschem/builtins.scm:186
 #, fuzzy
 msgid "Redraw"
 msgstr "Újrarajzolás"
 
-#: schematic/scheme/gschem/builtins.scm:192
 #, fuzzy
 msgid "Pan Left"
 msgstr "\"Középre\" üzemmód"
 
-#: schematic/scheme/gschem/builtins.scm:195
 #, fuzzy
 msgid "Pan Right"
 msgstr "Jobb felső"
 
-#: schematic/scheme/gschem/builtins.scm:198
 msgid "Pan Up"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:201
 #, fuzzy
 msgid "Pan Down"
 msgstr "\"Középre\" üzemmód"
 
-#: schematic/scheme/gschem/builtins.scm:216
 #, fuzzy
 msgid "Zoom Full"
 msgstr "/Kicsinyítés"
 
-#: schematic/scheme/gschem/builtins.scm:219
 #, fuzzy
 msgid "Dark Color Scheme"
 msgstr "Sötét színséma"
 
-#: schematic/scheme/gschem/builtins.scm:222
 #, fuzzy
 msgid "Light Color Scheme"
 msgstr "Világos színséma"
 
-#: schematic/scheme/gschem/builtins.scm:225
 msgid "Monochrome Color Scheme"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:228
 #, fuzzy
 msgid "Show Color Scheme Editor"
 msgstr "Világos színséma"
 
-#: schematic/scheme/gschem/builtins.scm:234
 #, fuzzy
 msgid "Revert Changes"
 msgstr "Biztosan újratöltsem az oldalt?"
 
-#: schematic/scheme/gschem/builtins.scm:240
 #, fuzzy
 msgid "Previous Page"
 msgstr "Előző"
 
-#: schematic/scheme/gschem/builtins.scm:243
 #, fuzzy
 msgid "Next Page"
 msgstr "Új lap"
 
-#: schematic/scheme/gschem/builtins.scm:255
 #, fuzzy
 msgid "Print Page"
 msgstr "Előző"
 
-#: schematic/scheme/gschem/builtins.scm:276
 #, fuzzy
 msgid "Add Line"
 msgstr "Vonal"
 
-#: schematic/scheme/gschem/builtins.scm:279
 #, fuzzy
 msgid "Add Path"
 msgstr "/Összeköttetés hozzáadása"
 
-#: schematic/scheme/gschem/builtins.scm:282
 #, fuzzy
 msgid "Add Box"
 msgstr "/Busz hozzáadása"
 
-#: schematic/scheme/gschem/builtins.scm:285
 #, fuzzy
 msgid "Add Circle"
 msgstr "Kör"
 
-#: schematic/scheme/gschem/builtins.scm:288
 #, fuzzy
 msgid "Add Arc"
 msgstr "Attribútum hozzáadása"
 
-#: schematic/scheme/gschem/builtins.scm:291
 msgid "Add Pin"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:294
 #, fuzzy
 msgid "Add Picture"
 msgstr "Kép"
 
-#: schematic/scheme/gschem/builtins.scm:306
 #, fuzzy
 msgid "Up Hierarchy"
 msgstr "Hie_rarchia"
 
-#: schematic/scheme/gschem/builtins.scm:312
 #, fuzzy
 msgid "Attach Attributes"
 msgstr "Attribútumok szerkesztése"
 
-#: schematic/scheme/gschem/builtins.scm:315
 #, fuzzy
 msgid "Detach Attributes"
 msgstr "Attribútumok szerkesztése"
 
-#: schematic/scheme/gschem/builtins.scm:318
 #, fuzzy
 msgid "Show Attribute Value"
 msgstr "Név és érték mutatása"
 
-#: schematic/scheme/gschem/builtins.scm:321
 #, fuzzy
 msgid "Show Attribute Name"
 msgstr "Attribútum"
 
-#: schematic/scheme/gschem/builtins.scm:327
 #, fuzzy
 msgid "Toggle Text Visibility"
 msgstr "Lá_thatóság váltása"
 
-#: schematic/scheme/gschem/builtins.scm:330
 #, fuzzy
 msgid "Find Specific Text"
 msgstr "Szöveg keresése"
 
-#: schematic/scheme/gschem/builtins.scm:333
 #, fuzzy
 msgid "Hide Specific Text"
 msgstr "Szöveg elrejtése"
 
-#: schematic/scheme/gschem/builtins.scm:336
 #, fuzzy
 msgid "Show Specific Text"
 msgstr "Szöveg mutatása"
 
-#: schematic/scheme/gschem/builtins.scm:339
 #, fuzzy
 msgid "Autonumber Text"
 msgstr "Automatikus számozás"
 
-#: schematic/scheme/gschem/builtins.scm:345
 #, fuzzy
 msgid "Show Hotkeys"
 msgstr "Gyorsbillentyűk"
 
-#: schematic/scheme/gschem/builtins.scm:348
 msgid "Switch Grid Style"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:351
 msgid "Switch Snap Mode"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:354
 msgid "Set Grid Spacing"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:357
 #, fuzzy
 msgid "Increase Grid Spacing"
 msgstr "Új hálóméret:"
 
-#: schematic/scheme/gschem/builtins.scm:360
 #, fuzzy
 msgid "Decrease Grid Spacing"
 msgstr "Új hálóméret:"
 
-#: schematic/scheme/gschem/builtins.scm:363
 msgid "Toggle Outline Drawing"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:366
 msgid "Toggle Net Rubber Band"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:369
 msgid "Toggle Magnetic Nets"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:372
 #, fuzzy
 msgid "Show Log Window"
 msgstr "Új ablak"
 
-#: schematic/scheme/gschem/builtins.scm:375
 #, fuzzy
 msgid "Show Coordinate Window"
 msgstr "Jelenlegi nézet"
 
-#: schematic/scheme/gschem/builtins.scm:385
 #, fuzzy
 msgid "Component Documentation"
 msgstr "Alkatrész dokumentáció"
 
-#: schematic/scheme/gschem/builtins.scm:387
 msgid "View documentation for selected component"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:403
 msgid ""
 "Could not show documentation for selected component:\n"
 "\n"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:408
 msgid "gEDA Manuals"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:409
 msgid "View the front page of the gEDA documentation in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:414
 #, fuzzy
 msgid "gschem User Guide"
 msgstr "gschem _GYIK..."
 
-#: schematic/scheme/gschem/builtins.scm:415
 msgid "View the gschem User Guide in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:420
 #, fuzzy
 msgid "gschem FAQ"
 msgstr "gschem _GYIK..."
 
-#: schematic/scheme/gschem/builtins.scm:421
 msgid "Frequently Asked Questions about using gschem."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:426
 msgid "gEDA wiki"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:427
 msgid "View the front page of the gEDA wiki in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:431
 msgid "About gschem"
 msgstr "Névjegy"
 
-#: schematic/scheme/gschem/deprecated.scm:102
 #, scheme-format
 msgid "Invalid text alignment ~A."
 msgstr ""
 
-#: schematic/scheme/gschem/gschemdoc.scm:241
 msgid "No documentation found"
 msgstr "Nem találtam dokumentumot"
 
-#: schematic/scheme/gschem/keymap.scm:40
 #, scheme-format
 msgid "~S is not a valid key combination."
 msgstr ""
 
-#: schematic/scheme/gschem/keymap.scm:157
 #, scheme-format
 msgid "~S is not a prefix key sequence."
 msgstr ""

--- a/schematic/po/it.po
+++ b/schematic/po/it.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-15 15:13+0300\n"
+"POT-Creation-Date: 2019-02-22 14:08+0300\n"
 "PO-Revision-Date: 2014-12-29 20:06+0300\n"
 "Last-Translator: Marco Ciampa <ciampix@libero.it>\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -21,25 +21,21 @@ msgstr ""
 "X-Launchpad-Export-Date: 2012-11-14 16:52+0000\n"
 "X-Generator: Launchpad (build 16265)\n"
 
-#: schematic/src/a_zoom.c:155
 #, fuzzy
 msgid "Zoom too small!  Cannot zoom further."
 msgstr ""
 "Eccessiva riduzione dell'immagine!  Non è possibile ridurla ulteriormente.\n"
 
-#: schematic/src/color_edit_widget.c:399
 #, fuzzy, c-format
 msgid ""
 "Could not save file [%s]:\n"
 "%s"
 msgstr "Non è possibile salvare la pagina [%s]\n"
 
-#: schematic/src/color_edit_widget.c:434
 #, fuzzy
 msgid "Save Color Scheme As..."
 msgstr "Schema colori chiari"
 
-#: schematic/src/color_edit_widget.c:482 schematic/src/x_fileselect.c:292
 #, fuzzy, c-format
 msgid ""
 "The selected file `%1$s' already exists.\n"
@@ -49,53 +45,41 @@ msgstr ""
 "Il file '%s' selezionato esiste già.\n"
 "Sostituire il file esistente ?"
 
-#: schematic/src/color_edit_widget.c:486 schematic/src/x_fileselect.c:295
 msgid "Overwrite file?"
 msgstr "Sovrascrivere il file?"
 
-#: schematic/src/font_select_widget.c:211
 msgid "_Apply"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:215
 msgid "Sa_ve..."
 msgstr ""
 
-#: schematic/src/font_select_widget.c:278
 #, c-format
 msgid "<b>Current:</b> %s"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:453
 msgid "Save configuration"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:461
 msgid "Save settings to:"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:465
 msgid "Local configuration file (in current directory)"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:467
 msgid "User configuration file (geda-user.conf)"
 msgstr ""
 
-#: schematic/src/g_attrib.c:90
 msgid "Object ~A is not included in the current gschem page."
 msgstr "L'oggetto ~A non è incluso nella pagina di gschem corrente."
 
-#: schematic/src/g_attrib.c:110
 msgid "Invalid text name/value visibility ~A."
 msgstr "Visibilità nome/valore testo non valida ~A."
 
-#: schematic/src/g_rc.c:107
 #, fuzzy, c-format
 msgid "You are running gEDA/gaf version [%1$s%2$s.%3$s],\n"
 msgstr "Stai usando gEDA/gaf versione [%s%s.%s],\n"
 
-#: schematic/src/g_rc.c:111
 #, fuzzy, c-format
 msgid ""
 "but you have a version [%1$s] gschemrc file:\n"
@@ -104,129 +88,103 @@ msgstr ""
 "ma hai una versione [%s] di file gschemrc:\n"
 "[%s]\n"
 
-#: schematic/src/g_rc.c:114
 #, c-format
 msgid "Please be sure that you have the latest rc file.\n"
 msgstr "Assicurarsi di avere l'ultimo file rc.\n"
 
-#: schematic/src/g_rc.c:240
 #, fuzzy, c-format
 msgid "Invalid size [%1$d] passed to text-size\n"
 msgstr "Grandezza [%d] passata alla dimensione del testo, non valida\n"
 
-#: schematic/src/g_rc.c:283
 #, fuzzy, c-format
 msgid "Invalid size [%1$d] passed to snap-size\n"
 msgstr "Ampiezza non valida [%d], passata alla dimensione magnetismo\n"
 
-#: schematic/src/g_rc.c:620
 #, fuzzy, c-format
 msgid "Invalid num levels [%1$d] passed to undo-levels\n"
 msgstr ""
 "Il numero di livelli non valido [%d] passato ai livelli di annullamento\n"
 
-#: schematic/src/g_rc.c:831
 #, fuzzy, c-format
 msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
 msgstr "Dimensione non valida [%d] passata a bus-ripper-size\n"
 
-#: schematic/src/g_rc.c:931
 #, fuzzy, c-format
 msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
 msgstr "Dimensione punto non valida [%d] passata a dots-grid-dot-size\n"
 
-#: schematic/src/g_rc.c:972
 #, fuzzy, c-format
 msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
 msgstr "Spaziatura pixel non valida [%d] passata a dots-grid-fixed-threshold\n"
 
-#: schematic/src/g_rc.c:998
 #, fuzzy, c-format
 msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
 msgstr ""
 "Spaziatura pixel non valida [%d] passata a mesh-grid-display-threshold\n"
 
-#: schematic/src/g_rc.c:1023
 #, fuzzy, c-format
 msgid "Invalid offset [%1$d] passed to add-attribute-offset\n"
 msgstr "Offset non valido [%d] passato a  add-attribute-offset\n"
 
-#: schematic/src/g_rc.c:1047
 #, fuzzy, c-format
 msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
 msgstr ""
 "Il numero di secondi indicati [%d] non è valido ai fini dell'intervallo di "
 "auto salvataggio\n"
 
-#: schematic/src/g_rc.c:1071
 #, fuzzy, c-format
 msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
 msgstr "Guadagno non valido [%d] passato a mousepan-gain\n"
 
-#: schematic/src/g_rc.c:1094
 #, fuzzy, c-format
 msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
 msgstr "Guadagno non valido [%d] passato a keyboardpan-gain\n"
 
-#: schematic/src/g_rc.c:1118
 #, fuzzy, c-format
 msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
 msgstr "Il numero [%d] di pixel indicati non è valido\n"
 
-#: schematic/src/g_rc.c:1144
 #, fuzzy, c-format
 msgid "Invalid gain [%1$d] passed to zoom-gain\n"
 msgstr "Guadagno non valido [%d] passato a zoom-gain\n"
 
-#: schematic/src/g_rc.c:1169
 #, fuzzy, c-format
 msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
 msgstr "Numero passi non valido [%d] scrollpan-steps\n"
 
-#: schematic/src/g_select.c:78 schematic/src/g_select.c:115
-#: schematic/src/g_select.c:151
 msgid "Object ~A is not directly included in a page."
 msgstr "L'oggetto ~A non è direttamente incluso in una pagina."
 
-#: schematic/src/g_util.c:54
 msgid "Could not launch URI ~S: ~A"
 msgstr "Impossibile avviare l'URI ~S: ~A"
 
-#: schematic/src/g_window.c:139
 msgid "Found invalid gschem window smob ~S"
 msgstr "Trovato smob finestra gschem non valido ~S"
 
-#: schematic/src/lepton-schematic.c:156
 #, fuzzy, c-format
 msgid "Lepton EDA/lepton-schematic version %1$s%2$s.%3$s git: %4$.7s"
 msgstr "gEDA/gschem versione %s%s.%s\n"
 
-#: schematic/src/lepton-schematic.c:163
 #, c-format
 msgid "This is the MINGW32 port.\n"
 msgstr "Port per MINGW32.\n"
 
-#: schematic/src/lepton-schematic.c:167
 #, fuzzy, c-format
 msgid "Current locale settings: %1$s\n"
 msgstr "Impostazioni locali correnti: %s\n"
 
-#: schematic/src/lepton-schematic.c:201
 #, fuzzy, c-format
 msgid "Couldn't find init scm file [%1$s]"
 msgstr "Impossibile trovare il file di inizializzazione scm [%s]\n"
 
-#: schematic/src/lepton-schematic.c:206
 #, fuzzy, c-format
 msgid "Read init scm file [%1$s]"
 msgstr "Lettura del file init scm [%s]\n"
 
-#: schematic/src/lepton-schematic.c:210
 #, fuzzy, c-format
 msgid "Failed to read init scm file [%1$s]"
 msgstr "Fallita la lettura del file init scm [%s]\n"
 
-#: schematic/src/lepton-schematic.c:290
 #, fuzzy, c-format
 msgid ""
 "ERROR: Failed to load or evaluate startup script.\n"
@@ -237,93 +195,74 @@ msgstr ""
 "\n"
 "Il file di log di gschem potrebbe contenere ulteriori informazioni.\n"
 
-#: schematic/src/gschem_about_dialog.c:51
 #, fuzzy, c-format
 msgid "%s (git: %.7s)"
 msgstr "%s (g%.7s)"
 
-#: schematic/src/gschem_about_dialog.c:75
 #, fuzzy
 msgid "Lepton Electronic Design Automation"
 msgstr "gEDA: GPL Electronic Design Automation"
 
-#: schematic/src/gschem_about_dialog.c:83
 #, fuzzy
 msgid ""
 "Copyright © 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright © 2017-2018 Lepton Developers.\n"
-"See AUTHORS and ChangeLog files for details."
+"Copyright © 2017-2019 Lepton Developers.\n"
+"See AUTHORS, ChangeLog files and consult 'git log' history for details."
 msgstr ""
 "Copyright © 1998-2012 Ales Hvezda <ahvezda@geda.seul.org>\n"
 "Copyright © 1998-2012 collaboratori di gEDA (vedere il ChangeLog per i "
 "dettagli)"
 
-#: schematic/src/gschem_alignment_combo.c:69
 msgid "Upper Left"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:71
 msgid "Upper Middle"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:73
 #, fuzzy
 msgid "Upper Right"
 msgstr "Trascina a destra"
 
-#: schematic/src/gschem_alignment_combo.c:78
 msgid "Middle Left"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:80
 msgid "Middle Middle"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:82
 msgid "Middle Right"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:87
 msgid "Lower Left"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:89
 msgid "Lower Middle"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:91
 #, fuzzy
 msgid "Lower Right"
 msgstr "Trascina a destra"
 
-#: schematic/src/gschem_arc_dialog.c:104
 msgid "Arc Params"
 msgstr "Parametri Arco"
 
-#: schematic/src/gschem_arc_dialog.c:140
 #, fuzzy
 msgid "Arc _Radius:"
 msgstr "Raggio Arco:"
 
-#: schematic/src/gschem_arc_dialog.c:141
 #, fuzzy
 msgid "Start _Angle:"
 msgstr "Angolo di Attacco:"
 
-#: schematic/src/gschem_arc_dialog.c:142
 #, fuzzy
 msgid "_Degrees of Sweep:"
 msgstr "Gradi di sviluppo dell'arco:"
 
-#: schematic/src/gschem_bottom_widget.c:504
 msgid "Left mouse button"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:508
 msgid "Middle mouse button"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:512
 #, fuzzy
 msgid "Right mouse button"
 msgstr ""
@@ -331,54 +270,41 @@ msgstr ""
 "Tasto destro del mouse per\n"
 "cancellare il collegamento"
 
-#: schematic/src/gschem_bottom_widget.c:595
 msgid "(Snap size, Grid size)"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:603
 #, fuzzy
 msgid "Net rubber band mode"
 msgstr "Commuta net elastiche"
 
-#: schematic/src/gschem_bottom_widget.c:614
 #, fuzzy
 msgid "Magnetic net mode"
 msgstr "Modo Net Magnetiche"
 
-#: schematic/src/gschem_bottom_widget.c:622
 #, fuzzy
 msgid "Current action mode"
 msgstr "Pagina corrente"
 
-#: schematic/src/gschem_bottom_widget.c:935
-#: schematic/src/gschem_bottom_widget.c:951
 msgid "OFF"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:954
 msgid "NONE"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:960
 #, c-format
 msgid "Grid(%1$s, %2$s)"
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:350
-#: schematic/src/x_compselect.c:1236 schematic/src/x_multiattrib.c:2068
 msgid "Name"
 msgstr "Nome"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:372
 msgid "S_elect the schematics you want to save:"
 msgstr "S_eleziona lo schema che vuoi salvare:"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:467
 #, fuzzy, c-format
 msgid "Save the changes to schematic \"%1$s\" before closing?"
 msgstr "Salvare i cambi allo schema \"%s\" prima di chiudere?"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:473
 #, fuzzy, c-format
 msgid ""
 "There are %1$d schematics with unsaved changes. Save changes before closing?"
@@ -386,562 +312,414 @@ msgstr ""
 "Ci sono %d schemi che presentano cambi non salvati. Salvare i cambi prima di "
 "chiudere?"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:502
 msgid "If you don't save, all your changes will be permanently lost."
 msgstr "Se non salvi, tutte le modifiche saranno perse definitivamente."
 
-#: schematic/src/gschem_close_confirmation_dialog.c:522
 msgid "Close _without saving"
 msgstr "Chiudi senza sal_vare"
 
-#: schematic/src/gschem_coord_dialog.c:86
 msgid "Coords"
 msgstr "Coordinate"
 
-#: schematic/src/gschem_coord_dialog.c:106
 msgid "Screen"
 msgstr "Schermo"
 
-#: schematic/src/gschem_coord_dialog.c:115
 msgid "World"
 msgstr "Mondo"
 
-#: schematic/src/gschem_find_text_state.c:809 schematic/src/x_pagesel.c:432
 msgid "Filename"
 msgstr "Nome file"
 
-#: schematic/src/gschem_find_text_state.c:821 schematic/src/i_callbacks.c:1970
-#: schematic/src/x_colorcb.c:154 schematic/src/x_widgets.c:179
-#: schematic/src/x_window.c:1226 schematic/src/x_window.c:1440
 msgid "Text"
 msgstr "Testo"
 
-#: schematic/src/gschem_find_text_widget.c:427
 msgid "descend into hierarchy"
 msgstr "discende nella gerarchia"
 
-#: schematic/src/gschem_find_text_widget.c:435
 #, fuzzy
 msgid "Find"
 msgstr "Trova testo"
 
-#: schematic/src/gschem_find_text_widget.c:557
 #, fuzzy
 msgid "Find Text:"
 msgstr "Trova testo"
 
-#: schematic/src/gschem_find_text_widget.c:564
 msgid "Find Pattern:"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:571
 #, fuzzy
 msgid "Find Regex:"
 msgstr "Trova testo"
 
-#: schematic/src/gschem_find_text_widget.c:578
 msgid "Check symbol:"
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:200
 msgid "Hotkeys"
 msgstr "Tasti scelta rapida"
 
-#: schematic/src/gschem_hotkey_dialog.c:229
 msgid ""
 "Start typing action name or keystroke to filter the list.\n"
 "Type hotkeys as they are displayed in \"Keystroke(s)\" column."
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:233 schematic/src/x_compselect.c:1124
 #, fuzzy
 msgid "_Filter:"
 msgstr "Filtro:"
 
-#: schematic/src/gschem_hotkey_dialog.c:259 schematic/src/i_basic.c:280
 msgid "Action"
 msgstr "Azione"
 
-#: schematic/src/gschem_hotkey_dialog.c:277
 msgid "Keystroke(s)"
 msgstr "Tasto(i)"
 
-#: schematic/src/gschem_log_widget.c:177
 msgid "** Invalid UTF-8 in log message. See stderr or gschem.log.\n"
 msgstr ""
 "**  UTF-8 non valido in messaggio del log. Verificare in stderr o gschem."
 "log.\n"
 
-#: schematic/src/gschem_log_widget.c:434
 #, fuzzy
 msgid "Clear log window?"
 msgstr "Chiusura Finestra\n"
 
-#: schematic/src/gschem_log_widget.c:477
 #, fuzzy
 msgid "Clear Log _Window"
 msgstr "Mostra la finestra di log"
 
-#: schematic/src/gschem_macro_widget.c:231
 msgid "Macro:"
 msgstr ""
 
-#: schematic/src/gschem_macro_widget.c:387
 msgid "Evaluate"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:172
 #, fuzzy
 msgid "_Fill Type:"
 msgstr "Tipo riempimento..."
 
-#: schematic/src/gschem_object_properties_widget.c:173
 #, fuzzy
 msgid "Lin_e Width:"
 msgstr "Tipo & Larghezza linea..."
 
-#: schematic/src/gschem_object_properties_widget.c:174
 #, fuzzy
 msgid "Angle _1:"
 msgstr "Angolo di Attacco:"
 
-#: schematic/src/gschem_object_properties_widget.c:175
 msgid "P_itch 1:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:176
 #, fuzzy
 msgid "Angle _2:"
 msgstr "Angolo di Attacco:"
 
-#: schematic/src/gschem_object_properties_widget.c:177
 msgid "Pitc_h 2:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:237
 #, fuzzy
 msgid "<b>Fill Properties</b>"
 msgstr "<b>Opzioni</b>"
 
-#: schematic/src/gschem_object_properties_widget.c:255
-#: schematic/src/gschem_text_properties_widget.c:258
-#: schematic/src/x_newtext.c:271
 #, fuzzy
 msgid "Colo_r:"
 msgstr "Colore"
 
-#: schematic/src/gschem_object_properties_widget.c:266
 msgid "<b>General Properties</b>"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:284
 #, fuzzy
 msgid "_Type:"
 msgstr "Tipo di pin"
 
-#: schematic/src/gschem_object_properties_widget.c:285
 #, fuzzy
 msgid "_Width:"
 msgstr "Tipo & Larghezza linea..."
 
-#: schematic/src/gschem_object_properties_widget.c:286
 msgid "Dash _Length:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:287
 msgid "Dash _Space:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:288
 msgid "C_ap style:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:333
 #, fuzzy
 msgid "<b>Line Properties</b>"
 msgstr "<b>Opzioni</b>"
 
-#: schematic/src/gschem_object_properties_widget.c:351
 #, fuzzy
 msgid "_Pin Type:"
 msgstr "Tipo di pin"
 
-#: schematic/src/gschem_object_properties_widget.c:362
 #, fuzzy
 msgid "<b>Pin Properties</b>"
 msgstr "<b>Opzioni</b>"
 
-#: schematic/src/gschem_options_widget.c:217
 msgid "_Off"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:220
 msgid "_Dots"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:223
 msgid "M_esh"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:245
 #, fuzzy
 msgid "Net R_ubber Band Mode:"
 msgstr "Commuta net elastiche"
 
-#: schematic/src/gschem_options_widget.c:246
 #, fuzzy
 msgid "_Magnetic Net Mode:"
 msgstr "Modo Net Magnetiche"
 
-#: schematic/src/gschem_options_widget.c:250
-#: schematic/src/gschem_options_widget.c:251
 msgid "Enabled"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:265
 #, fuzzy
 msgid "<b>Net Options</b>"
 msgstr "<b>Opzioni</b>"
 
-#: schematic/src/gschem_options_widget.c:282
 #, fuzzy
 msgid "Grid Mode:"
 msgstr "Modalità Arco"
 
-#: schematic/src/gschem_options_widget.c:283
 #, fuzzy
 msgid "Snap Mode:"
 msgstr "Commuta la modalità magnetica"
 
-#: schematic/src/gschem_options_widget.c:284
 #, fuzzy
 msgid "_Snap Size:"
 msgstr "Dimensione Snap"
 
-#: schematic/src/gschem_options_widget.c:301
 #, fuzzy
 msgid "<b>Snap Options</b>"
 msgstr "<b>Opzioni</b>"
 
-#: schematic/src/gschem_options_widget.c:340
 msgid "O_ff"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:343
 #, fuzzy
 msgid "_Grid"
 msgstr "Griglia NON ATTIVA\n"
 
-#: schematic/src/gschem_options_widget.c:346
 #, fuzzy
 msgid "_Resnap"
 msgstr "Resnap Attivo"
 
-#: schematic/src/gschem_pin_type_combo.c:73
 msgid "Net pin"
 msgstr "Net pin"
 
-#: schematic/src/gschem_pin_type_combo.c:80
 msgid "Bus pin (graphical)"
 msgstr "Bus pin (grafico)"
 
-#: schematic/src/gschem_preview.c:195
 msgid "Preview Buffer"
 msgstr "Buffer di anteprima"
 
-#: schematic/src/gschem_show_hide_text_widget.c:148
-#: schematic/src/x_window.c:1268
 #, fuzzy
 msgid "Hide"
 msgstr "Nascondi testo"
 
-#: schematic/src/gschem_show_hide_text_widget.c:157
-#: schematic/src/x_window.c:1269
 msgid "Hide text starting with:"
 msgstr "Nascondi il testo iniziando con:"
 
-#: schematic/src/gschem_slot_edit_dialog.c:91
 msgid "Edit slot number"
 msgstr "Modifica numero slot"
 
-#: schematic/src/gschem_slot_edit_dialog.c:121
 msgid "Number of Slots:"
 msgstr ""
 
-#: schematic/src/gschem_slot_edit_dialog.c:122
 #, fuzzy
 msgid "Slot Number:"
 msgstr "Modifica numero slot:"
 
-#: schematic/src/gschem_text_properties_widget.c:240
-#: schematic/src/x_newtext.c:265
 #, fuzzy
 msgid "<b>Text Content</b>"
 msgstr "<b>Opzioni</b>"
 
-#: schematic/src/gschem_text_properties_widget.c:259
-#: schematic/src/x_newtext.c:291
 #, fuzzy
 msgid "_Size:"
 msgstr "Dimensione Snap"
 
-#: schematic/src/gschem_text_properties_widget.c:260
-#: schematic/src/x_newtext.c:310
 msgid "Ali_gnment:"
 msgstr ""
 
-#: schematic/src/gschem_text_properties_widget.c:261
-#: schematic/src/x_newtext.c:330
 #, fuzzy
 msgid "Ro_tation:"
 msgstr "Ruota"
 
-#: schematic/src/gschem_text_properties_widget.c:294
-#: schematic/src/x_newtext.c:253
 #, fuzzy
 msgid "<b>Text Properties</b>"
 msgstr "<b>Opzioni</b>"
 
-#: schematic/src/gschem_translate_widget.c:238
 #, fuzzy
 msgid "Coordinate:"
 msgstr "Mostra la finestra coordinate"
 
-#: schematic/src/gschem_translate_widget.c:405 schematic/src/i_callbacks.c:800
 msgid "Translate"
 msgstr "Converti"
 
-#: schematic/src/i_basic.c:64 schematic/src/x_window.c:1369
-#: schematic/scheme/conf/schematic/menu.scm:59
-#: schematic/scheme/gschem/builtins.scm:99
 msgid "Select Mode"
 msgstr "Modalità selezione"
 
-#: schematic/src/i_basic.c:65
 #, fuzzy
 msgid "Select Box Mode"
 msgstr "Modalità selezione"
 
-#: schematic/src/i_basic.c:66
 msgid "Text Mode"
 msgstr "Modalità Testo"
 
-#: schematic/src/i_basic.c:67
 msgid "Pan Mode"
 msgstr "Trascina ingrandimento"
 
-#: schematic/src/i_basic.c:70
 #, c-format
 msgid "Paste %d Mode"
 msgstr "Modalità %d Incolla"
 
-#: schematic/src/i_basic.c:74
 msgid "Magnetic Net Mode"
 msgstr "Modo Net Magnetiche"
 
-#: schematic/src/i_basic.c:76
 msgid "Net Mode"
 msgstr "Modalità Collegamento"
 
-#: schematic/src/i_basic.c:77
 msgid "Arc Mode"
 msgstr "Modalità Arco"
 
-#: schematic/src/i_basic.c:78
 msgid "Box Mode"
 msgstr "Modalità Riquadro"
 
-#: schematic/src/i_basic.c:79
 msgid "Bus Mode"
 msgstr "Modalità Bus"
 
-#: schematic/src/i_basic.c:80
 msgid "Circle Mode"
 msgstr "Modalità Cerchio"
 
-#: schematic/src/i_basic.c:81
 msgid "Component Mode"
 msgstr "Scelta Componente"
 
-#: schematic/src/i_basic.c:82 schematic/scheme/conf/schematic/menu.scm:62
-#: schematic/scheme/gschem/builtins.scm:114
 msgid "Copy Mode"
 msgstr "Modalità copia"
 
-#: schematic/src/i_basic.c:83 schematic/scheme/conf/schematic/menu.scm:63
-#: schematic/scheme/gschem/builtins.scm:117
 msgid "Multiple Copy Mode"
 msgstr "Modalità di copiatura multipla"
 
-#: schematic/src/i_basic.c:84
 msgid "Line Mode"
 msgstr "Modalità Linea"
 
-#: schematic/src/i_basic.c:85 schematic/scheme/conf/schematic/menu.scm:66
-#: schematic/scheme/gschem/builtins.scm:123
 msgid "Mirror Mode"
 msgstr "Modalità specchio"
 
-#: schematic/src/i_basic.c:86 schematic/scheme/conf/schematic/menu.scm:64
-#: schematic/scheme/gschem/builtins.scm:111
 msgid "Move Mode"
 msgstr "Modalità spostamento"
 
-#: schematic/src/i_basic.c:87
 msgid "Path Mode"
 msgstr "Modalità percorso"
 
-#: schematic/src/i_basic.c:88
 msgid "Picture Mode"
 msgstr "Modalità Immagine"
 
-#: schematic/src/i_basic.c:89
 msgid "Pin Mode"
 msgstr "Modalità Pin"
 
-#: schematic/src/i_basic.c:90 schematic/scheme/gschem/builtins.scm:120
 msgid "Rotate Mode"
 msgstr "Modalità Rotazione"
 
-#: schematic/src/i_basic.c:91
 #, fuzzy
 msgid "Modify Mode"
 msgstr "Modalità copia"
 
-#: schematic/src/i_basic.c:92 schematic/src/x_menus.c:49
-#: schematic/scheme/gschem/builtins.scm:204
 msgid "Zoom Box"
 msgstr "Ingrandisci Riquadro"
 
-#: schematic/src/i_basic.c:121
 msgid "Show Hidden"
 msgstr "Mostra Nascosto"
 
-#: schematic/src/i_basic.c:124
 msgid "Snap Off"
 msgstr "Snap Off"
 
-#: schematic/src/i_basic.c:126
 msgid "Resnap Active"
 msgstr "Resnap Attivo"
 
-#: schematic/src/i_basic.c:288 schematic/src/x_colorcb.c:159
 msgid "Stroke"
 msgstr "Tratto"
 
-#: schematic/src/i_basic.c:296 schematic/src/i_basic.c:330
-#: schematic/src/x_window.c:1361
 msgid "none"
 msgstr "nessuno"
 
-#: schematic/src/i_basic.c:304
 msgid "Repeat/"
 msgstr "Ripeti/"
 
-#: schematic/src/i_basic.c:315
 msgid "Repeat/none"
 msgstr "Ripeti/Niente"
 
-#: schematic/src/i_basic.c:323 schematic/src/i_callbacks.c:1239
-#: schematic/scheme/gschem/builtins.scm:189
 msgid "Pan"
 msgstr "Pan"
 
-#: schematic/src/i_callbacks.c:74
 #, fuzzy, c-format
 msgid "New page created [%1$s]"
 msgstr "Nuova Pagina Creata [%s]\n"
 
-#: schematic/src/i_callbacks.c:108
 #, fuzzy, c-format
 msgid "New Window created [%1$s]"
 msgstr "Creata Nuova Finestra [%s]\n"
 
-#: schematic/src/i_callbacks.c:245
 msgid "Failed to Save All"
 msgstr "Salvataggio Fallito"
 
-#: schematic/src/i_callbacks.c:247
 msgid "Saved All"
 msgstr "Salvato Tutto"
 
-#: schematic/src/i_callbacks.c:308
 #, fuzzy
 msgid "Closing Window"
 msgstr "Chiusura Finestra\n"
 
-#: schematic/src/i_callbacks.c:505 schematic/src/x_menus.c:55
-#: schematic/scheme/gschem/builtins.scm:168
 msgid "Copy"
 msgstr "Copia"
 
-#: schematic/src/i_callbacks.c:514 schematic/src/i_callbacks.c:539
-#: schematic/src/i_callbacks.c:564
 msgid "Select objs first"
 msgstr "Seleziona prima un oggetto"
 
-#: schematic/src/i_callbacks.c:530
 msgid "Multiple Copy"
 msgstr "Copia Multipla"
 
-#: schematic/src/i_callbacks.c:555 schematic/src/x_menus.c:56
 msgid "Move"
 msgstr "Sposta"
 
-#: schematic/src/i_callbacks.c:579 schematic/src/x_menus.c:57
-#: schematic/src/x_multiattrib.c:1656 schematic/scheme/gschem/builtins.scm:108
 msgid "Delete"
 msgstr "Cancella"
 
-#: schematic/src/i_callbacks.c:603
 msgid "Edit"
 msgstr "Modifica"
 
-#: schematic/src/i_callbacks.c:618 schematic/scheme/gschem/builtins.scm:129
 msgid "Edit Text"
 msgstr "Modifica Testo"
 
-#: schematic/src/i_callbacks.c:637
 msgid "Slot"
 msgstr "Slot"
 
-#: schematic/src/i_callbacks.c:688 schematic/src/i_callbacks.c:698
 msgid "Rotate"
 msgstr "Ruota"
 
-#: schematic/src/i_callbacks.c:736 schematic/src/i_callbacks.c:746
 msgid "Mirror"
 msgstr "Specchio"
 
-#: schematic/src/i_callbacks.c:763 schematic/src/x_colorcb.c:160
-#: schematic/scheme/conf/schematic/menu.scm:73
-#: schematic/scheme/gschem/builtins.scm:141
 msgid "Lock"
 msgstr "Blocca"
 
-#: schematic/src/i_callbacks.c:781 schematic/scheme/conf/schematic/menu.scm:74
-#: schematic/scheme/gschem/builtins.scm:144
 msgid "Unlock"
 msgstr "Sblocca"
 
-#: schematic/src/i_callbacks.c:805
 #, fuzzy
 msgid "WARNING: Do not translate with snap off!"
 msgstr "ATTENZIONE: Non effettuare la conversione in modalità snap off!\n"
 
-#: schematic/src/i_callbacks.c:806
 #, fuzzy
 msgid "WARNING: Turning snap on and continuing with translate."
 msgstr ""
 "ATTENZIONE: Sei in modalità snap off; passa prima in modalità snap on e poi "
 "continua con la conversione.\n"
 
-#: schematic/src/i_callbacks.c:813
 #, fuzzy
 msgid "WARNING: Snap grid size is not equal to 100!"
 msgstr "ATTENZIONE: L'ampiezza snap gride non è uguale a 100!\n"
 
-#: schematic/src/i_callbacks.c:815
 #, fuzzy
 msgid ""
 "WARNING: If you are translating a symbol to the origin, the snap grid size "
@@ -950,23 +728,18 @@ msgstr ""
 "ATTENZIONE: se stai convertendo un simbolo dalla sua origine, è opportuno "
 "che l'ampiezza snap gride venga impostata a 100\n"
 
-#: schematic/src/i_callbacks.c:847
 msgid "Embed"
 msgstr "Incorpora"
 
-#: schematic/src/i_callbacks.c:886
 msgid "Unembed"
 msgstr "Scorpora"
 
-#: schematic/src/i_callbacks.c:928
 msgid "Update"
 msgstr "Aggiorna"
 
-#: schematic/src/i_callbacks.c:970
 msgid "ShowHidden"
 msgstr "Mostra Nascosto"
 
-#: schematic/src/i_callbacks.c:1537
 #, c-format
 msgid ""
 "<b>Revert page:</b>\n"
@@ -977,99 +750,77 @@ msgid ""
 "discarded and page file will be reloaded from disk."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1555
 #, fuzzy
 msgid "Revert"
 msgstr "_Ripristina"
 
-#: schematic/src/i_callbacks.c:1647
 msgid "Copy to clipboard"
 msgstr "Copia negli appunti"
 
-#: schematic/src/i_callbacks.c:1664
 msgid "Cut to clipboard"
 msgstr "Taglia negli appunti"
 
-#: schematic/src/i_callbacks.c:1686
 msgid "Paste from clipboard"
 msgstr "Incolla dagli appunti"
 
-#: schematic/src/i_callbacks.c:1694
 msgid "Empty clipboard"
 msgstr "Appunti vuoti"
 
 #. TRANSLATORS: The number is the number of the buffer that the
 #. * selection is being copied to.
-#: schematic/src/i_callbacks.c:1719
 #, c-format
 msgid "Copy %i"
 msgstr "Copia %i"
 
 #. TRANSLATORS: The number is the number of the buffer that the
 #. * selection is being cut to.
-#: schematic/src/i_callbacks.c:1746
 #, c-format
 msgid "Cut %i"
 msgstr "Taglia %i"
 
 #. TRANSLATORS: The number is the number of the buffer that is being
 #. * pasted to the schematic.
-#: schematic/src/i_callbacks.c:1776
 #, c-format
 msgid "Paste %i"
 msgstr "Incolla %i"
 
-#: schematic/src/i_callbacks.c:1785
 msgid "Empty buffer"
 msgstr "Buffer vuoto"
 
-#: schematic/src/i_callbacks.c:1833 schematic/src/x_window.c:1203
 msgid "Component"
 msgstr "Componente"
 
-#: schematic/src/i_callbacks.c:1865 schematic/src/x_colorcb.c:150
 msgid "Attribute"
 msgstr "Attributo"
 
-#: schematic/src/i_callbacks.c:1885 schematic/src/x_colorcb.c:149
 msgid "Net"
 msgstr "Collegamento"
 
-#: schematic/src/i_callbacks.c:1928 schematic/src/x_colorcb.c:155
-#: schematic/src/x_window.c:1222
 msgid "Bus"
 msgstr "Bus"
 
-#: schematic/src/i_callbacks.c:2004
 msgid "Line"
 msgstr "Linea"
 
-#: schematic/src/i_callbacks.c:2021
 msgid "Path"
 msgstr "Percorso"
 
-#: schematic/src/i_callbacks.c:2043
 msgid "Box"
 msgstr "Rettangolo"
 
-#: schematic/src/i_callbacks.c:2085
 msgid "Circle"
 msgstr "Cerchio"
 
-#: schematic/src/i_callbacks.c:2108
 msgid "Arc"
 msgstr "Arco"
 
-#: schematic/src/i_callbacks.c:2131 schematic/src/x_colorcb.c:146
 msgid "Pin"
 msgstr "Pin"
 
-#: schematic/src/i_callbacks.c:2191
 #, fuzzy, c-format
 msgid "Searching for source [%1$s]"
 msgstr "Ricerca del sorgente [%s]\n"
 
-#: schematic/src/i_callbacks.c:2223
 #, fuzzy, c-format
 msgid ""
 "Failed to descend hierarchy into '%1$s': %2$s\n"
@@ -1080,120 +831,95 @@ msgstr ""
 "\n"
 "Il file di log di gschem potrebbe contenere ulteriori informazioni."
 
-#: schematic/src/i_callbacks.c:2227
 #, fuzzy, c-format
 msgid "Failed to descend into '%1$s': %2$s"
 msgstr "Fallita la discesa in \"%s\": %s\n"
 
-#: schematic/src/i_callbacks.c:2234
 msgid "Failed to descend hierarchy."
 msgstr "Fallita la discesa nella gerarchia."
 
-#: schematic/src/i_callbacks.c:2312
 #, fuzzy, c-format
 msgid "Searching for symbol [%1$s]"
 msgstr "Ricerca del simbolo [%s]\n"
 
-#: schematic/src/i_callbacks.c:2320
 #, fuzzy
 msgid "Symbol is not a real file. Symbol cannot be loaded."
 msgstr "Il simolo non è un file reale, impossibile caricarlo.\n"
 
-#: schematic/src/i_callbacks.c:2367 schematic/src/x_tabs.c:1060
 #, fuzzy
 msgid "Cannot find any schematics above the current one!"
 msgstr "Impossibile trovare uno schema a livello più alto di questo!\n"
 
-#: schematic/src/i_callbacks.c:2400
 msgid "Attach"
 msgstr "Collega"
 
-#: schematic/src/i_callbacks.c:2456
 msgid "Detach"
 msgstr "Scollega"
 
-#: schematic/src/i_callbacks.c:2500
 msgid "ShowN"
 msgstr "MostraN"
 
-#: schematic/src/i_callbacks.c:2537
 msgid "ShowV"
 msgstr "MostraV"
 
-#: schematic/src/i_callbacks.c:2574
 msgid "ShowB"
 msgstr "MostraB"
 
-#: schematic/src/i_callbacks.c:2612
 msgid "VisToggle"
 msgstr "Visibilità Strumenti"
 
-#: schematic/src/i_callbacks.c:2643
 #, c-format
 msgid "Sorry but this is a non-functioning menu option\n"
 msgstr "Spiacente, ma questa non è una funzione del menù opzioni\n"
 
-#: schematic/src/i_callbacks.c:2703
 #, fuzzy
 msgid "Action feedback mode set to OUTLINE"
 msgstr "Controllo azioni in modalità CONTORNO\n"
 
-#: schematic/src/i_callbacks.c:2706
 #, fuzzy
 msgid "Action feedback mode set to BOUNDINGBOX"
 msgstr "Controllo azioni in modalità PERIMETRO\n"
 
-#: schematic/src/i_callbacks.c:2730
 #, fuzzy
 msgid "Grid OFF"
 msgstr "Griglia NON ATTIVA\n"
 
-#: schematic/src/i_callbacks.c:2731
 #, fuzzy
 msgid "Dot grid selected"
 msgstr "Selezionata griglia a punti\n"
 
-#: schematic/src/i_callbacks.c:2732
 #, fuzzy
 msgid "Mesh grid selected"
 msgstr "Selezionata griglia a maglie\n"
 
-#: schematic/src/i_callbacks.c:2733
 #, fuzzy
 msgid "Invalid grid mode"
 msgstr "Attributo non valido"
 
-#: schematic/src/i_callbacks.c:2755
 #, fuzzy
 msgid "Snap OFF (CAUTION!)"
 msgstr "Snap OFF (ATTENZIONE!)\n"
 
-#: schematic/src/i_callbacks.c:2758
 #, fuzzy
 msgid "Snap ON"
 msgstr "Snap ON\n"
 
-#: schematic/src/i_callbacks.c:2761
 #, fuzzy
 msgid "Snap back to the grid (CAUTION!)"
 msgstr "Snap alla griglia (ATTENZIONE)!\n"
 
-#: schematic/src/i_callbacks.c:2790
 #, fuzzy
 msgid "Rubber band ON"
 msgstr "Rubber band ON\n"
 
-#: schematic/src/i_callbacks.c:2792
 #, fuzzy
 msgid "Rubber band OFF"
 msgstr "Rubber band OFF \n"
 
-#: schematic/src/i_callbacks.c:2811
 #, fuzzy
 msgid "magnetic net mode: ON"
 msgstr "modalià net magnetiche: ON\n"
 
-#: schematic/src/i_callbacks.c:2814
 #, fuzzy
 msgid "magnetic net mode: OFF"
 msgstr "modalià net magnetiche: OFF\n"
@@ -1203,149 +929,120 @@ msgstr "modalià net magnetiche: OFF\n"
 #. the form "untitled_N.sch", where N is a number.  Please make
 #. sure that the translation contains characters suitable for use
 #. in a filename.
-#: schematic/src/i_vars.c:209
 msgid "untitled"
 msgstr "senzanome"
 
-#: schematic/src/o_complex.c:192 schematic/src/o_complex.c:195
 #, fuzzy, c-format
 msgid "Translating schematic [%1$d %2$d]"
 msgstr "Spostamento schema [%d %d]\n"
 
-#: schematic/src/o_delete.c:82
 #, fuzzy, c-format
 msgid "Delete locked object?"
 msgid_plural "Delete %1$u locked objects?"
 msgstr[0] "Cancellare l'oggetto bloccato?"
 msgstr[1] "Cancellare i %u oggetti bloccati?"
 
-#: schematic/src/o_misc.c:55
 #, c-format
 msgid "Got an unexpected NULL in o_edit\n"
 msgstr "Ottenuto un NULL inaspettato in o_edit\n"
 
-#: schematic/src/o_misc.c:315
 #, fuzzy
 msgid "Hidden text is now visible"
 msgstr "Il testo nascosto è ora visibile\n"
 
-#: schematic/src/o_misc.c:317
 #, fuzzy
 msgid "Hidden text is now invisible"
 msgstr "Il testo ora è non visibile\n"
 
-#: schematic/src/o_misc.c:425
 #, fuzzy, c-format
 msgid "Could not find symbol [%1$s] in library. Update failed."
 msgstr ""
 "Non è possibile trovare il simbolo [%s] nella libreria. Aggiornamento "
 "fallito.\n"
 
-#: schematic/src/o_misc.c:541
 #, fuzzy, c-format
 msgid "o_autosave_backups: Can't get the real filename of %1$s."
 msgstr "o_autosave_backups: Non è possibile ottenere il vero nome del file %s."
 
-#: schematic/src/o_misc.c:585
 #, fuzzy, c-format
 msgid "Could NOT set previous backup file [%1$s] read-write"
 msgstr ""
 "NOn è possibile impostare il precedente file di ripristino [%s] in lettura-"
 "scrittura\n"
 
-#: schematic/src/o_misc.c:605
 #, fuzzy, c-format
 msgid "Could NOT set backup file [%1$s] readonly"
 msgstr ""
 "Non è possibile impostare il precedente file di ripristino [%s] in sola "
 "lettura\n"
 
-#: schematic/src/o_misc.c:610
 #, fuzzy, c-format
 msgid "Could NOT save backup file [%1$s]"
 msgstr "Non è possibile salvare il file di ripristino [%s]\n"
 
-#: schematic/src/o_move.c:192
 #, c-format
 msgid "ERROR: NULL object in o_move_end!\n"
 msgstr "ERRORE: oggetto NULLO in o_move_end!\n"
 
-#: schematic/src/o_move.c:519
 #, c-format
 msgid "DOH! tried to find the whichone, but didn't find it!\n"
 msgstr "ACC! Ho cercato whichone ma non l'ho trovato!\n"
 
-#: schematic/src/o_move.c:546
 #, c-format
 msgid "Got a non line object in o_move_check_endpoint\n"
 msgstr "Ottenuto un oggetto non in linea in o_move_check_endpoint\n"
 
-#: schematic/src/o_net.c:444
 #, fuzzy
 msgid "Warning: Starting net at off grid coordinate"
 msgstr "Attenzione: una net inizia in un punto fuori griglia\n"
 
-#: schematic/src/o_net.c:508
 #, fuzzy
 msgid "Warning: Ending net at off grid coordinate"
 msgstr "Attenzione: una net finisce in un punto fuori griglia\n"
 
-#: schematic/src/o_net.c:856 schematic/src/o_net.c:893
-#: schematic/src/o_net.c:964 schematic/src/o_net.c:1000
 #, c-format
 msgid "Tried to add more than two bus rippers. Internal gschem error.\n"
 msgstr ""
 "Tentato di aggiungere più di due bus ripper. Errore interno di gschem.\n"
 
-#: schematic/src/o_net.c:1068
 #, fuzzy, c-format
 msgid "Bus ripper symbol [%1$s] was not found in any component library"
 msgstr "Simbolo bus ripper [%s] non trovato in alcuna libreria\n"
 
-#: schematic/src/o_picture.c:133 schematic/src/o_picture.c:343
 msgid "Select a picture file..."
 msgstr "Seleziona un file disegno..."
 
-#: schematic/src/o_picture.c:166
 #, fuzzy, c-format
 msgid "Failed to load picture: %1$s"
 msgstr "Fallito il caricamento del disegno: %s"
 
-#: schematic/src/o_picture.c:182
 msgid "Picture"
 msgstr "Disegno"
 
-#: schematic/src/o_picture.c:378
 #, c-format
 msgid "Failed to replace pictures: %s"
 msgstr "Fallito il rimpiazzo dei disegni: %s"
 
-#: schematic/src/o_slot.c:80
 #, fuzzy
 msgid "Slot attribute malformed"
 msgstr "Attributo dello slot malposto\n"
 
-#: schematic/src/o_slot.c:88
 #, fuzzy
 msgid "numslots attribute missing"
 msgstr "attributo del numero dello slot mancante\n"
 
-#: schematic/src/o_slot.c:89
 #, fuzzy
 msgid "Slotting not allowed for this component"
 msgstr "Slot non ammesso per questo componente\n"
 
-#: schematic/src/o_slot.c:104
 #, fuzzy
 msgid "New slot number out of range"
 msgstr "Numero del nuovo slot fuori dal limite\n"
 
-#: schematic/src/o_undo.c:397
 #, fuzzy
 msgid "Undo/Redo disabled in rc file"
 msgstr "Cancella/Ripristina disabilitato nel file rc\n"
 
-#: schematic/src/parsecmd.c:77
 #, fuzzy, c-format
 msgid ""
 "Usage: %1$s [OPTION ...] [--] [FILE ...]\n"
@@ -1392,12 +1089,11 @@ msgstr ""
 "Riportare eventuali difetti su <https://bugs.launchpad.net/geda>\n"
 "Homepage di gEDA/gaf: <http://www.geda-project.org/>\n"
 
-#: schematic/src/parsecmd.c:110
 #, fuzzy, c-format
 msgid ""
 "Lepton EDA %1$s (git: %2$.7s)\n"
 "Copyright (C) 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright (C) 2017-2018 Lepton Developers.\n"
+"Copyright (C) 2017-2019 Lepton Developers.\n"
 "This is free software, and you are welcome to redistribute it under\n"
 "certain conditions. For details, see the file `COPYING', which is\n"
 "included in the Lepton EDA distribution.\n"
@@ -1410,78 +1106,59 @@ msgstr ""
 "nella distribuzione di gEDA.\n"
 "Non c'è ALCUNA GARANZIA, nei limiti di legge.\n"
 
-#: schematic/src/x_attribedit.c:125
 #, c-format
 msgid "Got invalid show option; defaulting to show both\n"
 msgstr "Ottenuta opzione mostra non valida; ritorno a mostra entrambi\n"
 
-#: schematic/src/x_attribedit.c:139
 #, c-format
 msgid "ERROR: NULL object!\n"
 msgstr "ERRORE: oggetto NULLO!\n"
 
-#: schematic/src/x_attribedit.c:328
 msgid "Single Attribute Editor"
 msgstr "Editor Singola Caratteristica"
 
-#: schematic/src/x_attribedit.c:358
 msgid "<b>Edit Attribute</b>"
 msgstr "<b>Modifica Caratteristiche</b>"
 
-#: schematic/src/x_attribedit.c:360
 msgid "<b>Add Attribute</b>"
 msgstr "<b>Aggiungi Caratteristiche</b>"
 
-#: schematic/src/x_attribedit.c:376
 #, fuzzy
 msgid "N_ame:"
 msgstr "Nome:"
 
-#: schematic/src/x_attribedit.c:396 schematic/src/x_multiattrib.c:2222
 #, fuzzy
 msgid "_Value:"
 msgstr "Valore:"
 
-#: schematic/src/x_attribedit.c:415 schematic/src/x_multiattrib.c:2281
 #, fuzzy
 msgid "Vi_sible"
 msgstr "Visibile"
 
-#: schematic/src/x_attribedit.c:434
 msgid "Show Value Only"
 msgstr "Mostra Solo il Valore"
 
-#: schematic/src/x_attribedit.c:436
 msgid "Show Name Only"
 msgstr "Mostra Solo il Nome"
 
-#: schematic/src/x_attribedit.c:438 schematic/src/x_multiattrib.c:1620
-#: schematic/scheme/gschem/builtins.scm:324
 msgid "Show Name & Value"
 msgstr "Mostra Nome & Valore"
 
-#: schematic/src/x_attribedit.c:445
 msgid "<b>Attach Options</b>"
 msgstr "<b>Aggiungi Opzioni</b>"
 
-#: schematic/src/x_attribedit.c:460
 msgid "All"
 msgstr "Tutto"
 
-#: schematic/src/x_attribedit.c:476 schematic/src/x_compselect.c:986
-#: schematic/src/x_compselect.c:1100
 msgid "Components"
 msgstr "Componenti"
 
-#: schematic/src/x_attribedit.c:492 schematic/src/x_window.c:1214
 msgid "Nets"
 msgstr "Collegamenti"
 
-#: schematic/src/x_attribedit.c:508
 msgid "Replace existing attributes"
 msgstr "Ridefinisci le caratteristiche esistenti"
 
-#: schematic/src/x_autonumber.c:412
 #, fuzzy
 msgid ""
 "slotted object without slot attribute may cause problems when autonumbering "
@@ -1490,7 +1167,6 @@ msgstr ""
 "un oggetto con slot ma senza attributo di slot potrebbe causare problemi con "
 "l'autonumerazione\n"
 
-#: schematic/src/x_autonumber.c:427
 #, fuzzy, c-format
 msgid ""
 "duplicate slot may cause problems: [symbolname=%1$s, number=%2$d, slot=%3$d]"
@@ -1498,97 +1174,74 @@ msgstr ""
 "uno slot duplicato potrebbe causare problemi: [nome simbolo=%s, numero=%d, "
 "slot=%d]\n"
 
-#: schematic/src/x_autonumber.c:675
 #, fuzzy
 msgid "No searchstring given in autonumber text."
 msgstr "Nessuna stringa di ricerca nel testo di autonumerazione.\n"
 
-#: schematic/src/x_autonumber.c:728
 #, fuzzy
 msgid "No '*' or '?' given at the end of the autonumber text."
 msgstr "Nessun '*' o '?' alla fine del testo di autonumerazione.\n"
 
-#: schematic/src/x_autonumber.c:873
 msgid "Diagonal"
 msgstr "Diagonale"
 
-#: schematic/src/x_autonumber.c:874
 msgid "Top to bottom"
 msgstr "Dall'alto verso il basso"
 
-#: schematic/src/x_autonumber.c:875
 msgid "Bottom to top"
 msgstr "Dal basso verso l'alto"
 
-#: schematic/src/x_autonumber.c:876
 msgid "Left to right"
 msgstr "Da sinistra a destra"
 
-#: schematic/src/x_autonumber.c:877
 msgid "Right to left"
 msgstr "Da destra a sinistra"
 
-#: schematic/src/x_autonumber.c:878
 msgid "File order"
 msgstr "Sequenza dei file"
 
-#: schematic/src/x_autonumber.c:1214
 msgid "Autonumber text"
 msgstr "Testo di autonumerazione"
 
-#: schematic/src/x_autonumber.c:1237
 msgid "<b>Scope</b>"
 msgstr "<b>Visibilità</b>"
 
-#: schematic/src/x_autonumber.c:1259
 msgid "Search for:"
 msgstr "Ricerca di:"
 
-#: schematic/src/x_autonumber.c:1273
 msgid "Autonumber text in:"
 msgstr "Testo di autonumerazione in:"
 
-#: schematic/src/x_autonumber.c:1280
 msgid "Skip numbers found in:"
 msgstr "Trovati numeri mancanti in:"
 
-#: schematic/src/x_autonumber.c:1292 schematic/src/x_autonumber.c:1301
 msgid "Selected objects"
 msgstr "Oggetti selezionati"
 
-#: schematic/src/x_autonumber.c:1293 schematic/src/x_autonumber.c:1302
 msgid "Current page"
 msgstr "Pagina corrente"
 
-#: schematic/src/x_autonumber.c:1294 schematic/src/x_autonumber.c:1303
 msgid "Whole hierarchy"
 msgstr "Intera gerarchia"
 
-#: schematic/src/x_autonumber.c:1305
 msgid "Overwrite existing numbers"
 msgstr "Sovrascrivi i numeri esistenti"
 
-#: schematic/src/x_autonumber.c:1310
 msgid "<b>Options</b>"
 msgstr "<b>Opzioni</b>"
 
-#: schematic/src/x_autonumber.c:1332
 msgid "Starting number:"
 msgstr "Numero iniziale:"
 
-#: schematic/src/x_autonumber.c:1339
 msgid "Sort order:"
 msgstr "Ordinamento:"
 
-#: schematic/src/x_autonumber.c:1371
 msgid "Remove numbers"
 msgstr "Rimuovi numeri"
 
-#: schematic/src/x_autonumber.c:1375
 msgid "Automatic slotting"
 msgstr "Slot automatico"
 
-#: schematic/src/x_clipboard.c:245
 #, c-format
 msgid ""
 "<b>Invalid schematic on clipboard.</b>\n"
@@ -1599,168 +1252,130 @@ msgstr ""
 "\n"
 "Si è verificato un errore durante l'inserimento dei dati negli appunti: %s."
 
-#: schematic/src/x_clipboard.c:247
 msgid "Clipboard insertion failed"
 msgstr "Inserimento appunti fallito"
 
-#: schematic/src/x_color.c:89 schematic/src/x_color.c:98
 #, fuzzy, c-format
 msgid "Could not allocate the color %1$s!\n"
 msgstr "Non è possibile inserire il colore %s!\n"
 
-#: schematic/src/x_color.c:89
 msgid "black"
 msgstr "nero"
 
-#: schematic/src/x_color.c:98
 msgid "white"
 msgstr "bianco"
 
-#: schematic/src/x_color.c:120
 #, fuzzy, c-format
 msgid "Could not allocate display color %1$i!\n"
 msgstr "Impossibile allocare il colore display %i!\n"
 
-#: schematic/src/x_color.c:142
 #, fuzzy, c-format
 msgid "Could not allocate outline color %1$i!\n"
 msgstr "Impossibile allocare il colore outline %i!\n"
 
-#: schematic/src/x_color.c:159
 #, fuzzy, c-format
 msgid "Tried to get an invalid color: %1$d\n"
 msgstr "Provato a ottenere un colore non valido: %d\n"
 
-#: schematic/src/x_colorcb.c:145
 msgid "Background"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:147
 #, fuzzy
 msgid "Net endpoint"
 msgstr "Net pin"
 
-#: schematic/src/x_colorcb.c:148
 msgid "Graphic"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:151
 msgid "Logic bubble"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:152
 #, fuzzy
 msgid "Grid point"
 msgstr "Imposta la spaziatura griglia"
 
-#: schematic/src/x_colorcb.c:153
 #, fuzzy
 msgid "Detached attribute"
 msgstr "Scollega attributi"
 
-#: schematic/src/x_colorcb.c:156
 #, fuzzy
 msgid "Selection"
 msgstr "Seleziona"
 
-#: schematic/src/x_colorcb.c:157
 msgid "Bounding box"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:158
 #, fuzzy
 msgid "Zoom box"
 msgstr "Ingrandisci Riquadro"
 
-#: schematic/src/x_colorcb.c:161
 msgid "Output background"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:162
 msgid "Freestyle 1"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:163
 msgid "Freestyle 2"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:164
 msgid "Freestyle 3"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:165
 msgid "Freestyle 4"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:166
 #, fuzzy
 msgid "Net junction"
 msgstr "Net pin"
 
-#: schematic/src/x_colorcb.c:167
 msgid "Mesh grid major"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:168
 msgid "Mesh grid minor"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:172
 msgid "Unknown"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1169
 #, fuzzy
 msgid "Reset filter"
 msgstr "Nuovo file"
 
-#: schematic/src/x_compselect.c:1192
 msgid "Reload all libraries"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1245 schematic/src/x_multiattrib.c:2092
 msgid "Value"
 msgstr "Valore"
 
-#: schematic/src/x_compselect.c:1284
 msgid "Default behavior - reference component"
 msgstr "Comportamento predefinito - Consultazione componente"
 
-#: schematic/src/x_compselect.c:1287
 msgid "Embed component in schematic"
 msgstr "Incorpora il componente nello schema"
 
-#: schematic/src/x_compselect.c:1290
 msgid "Include component as individual objects"
 msgstr "Includi componente come oggetto individuale"
 
-#: schematic/src/x_compselect.c:1448
 msgid "Select Component..."
 msgstr "Seleziona Componente..."
 
-#: schematic/src/x_compselect.c:1471
 #, fuzzy
 msgid "In Us_e"
 msgstr "In uso"
 
-#: schematic/src/x_compselect.c:1475
 #, fuzzy
 msgid "Lib_raries"
 msgstr "Librerie"
 
-#: schematic/src/x_compselect.c:1484 schematic/src/x_fileselect.c:119
 msgid "Preview"
 msgstr "Anteprima"
 
-#: schematic/src/x_compselect.c:1510
 msgid "Attributes"
 msgstr "Attributi"
 
-#: schematic/src/x_dialog.c:325
 msgid "Major symbol changes detected."
 msgstr "Rilevati importanti cambiamenti sul simbolo."
 
-#: schematic/src/x_dialog.c:349
 msgid ""
 "Changes have occurred to the symbols shown below.\n"
 "\n"
@@ -1770,11 +1385,9 @@ msgstr ""
 "\n"
 "Assicurarsi di verificare ogni simbolo."
 
-#: schematic/src/x_dialog.c:369
 msgid "Symbol"
 msgstr "Simbolo"
 
-#: schematic/src/x_dialog.c:406
 #, c-format
 msgid ""
 "<span weight=\"bold\" size=\"larger\">The input attribute \"%s\" is invalid\n"
@@ -1792,40 +1405,31 @@ msgstr ""
 "Il nome non deve terminare con uno spazio.\n"
 "Il valore non deve iniziare con uno spazio."
 
-#: schematic/src/x_dialog.c:408
 msgid "Invalid Attribute"
 msgstr "Attributo non valido"
 
-#: schematic/src/x_fileselect.c:37
 msgid "Schematics"
 msgstr "Schemi"
 
-#: schematic/src/x_fileselect.c:42
 msgid "Symbols"
 msgstr "Simboli"
 
-#: schematic/src/x_fileselect.c:47
 msgid "Schematics and symbols"
 msgstr "Schemi e simboli"
 
-#: schematic/src/x_fileselect.c:53
 msgid "All files"
 msgstr "Tutti i File"
 
-#: schematic/src/x_fileselect.c:169
 msgid "Open..."
 msgstr "Apri..."
 
-#: schematic/src/x_fileselect.c:233
 msgid "Save as..."
 msgstr "Salva con nome..."
 
-#: schematic/src/x_fileselect.c:297
 #, fuzzy
 msgid "Save cancelled on user request"
 msgstr "Salvataggio annullato su richiesta utente.\n"
 
-#: schematic/src/x_fileselect.c:334
 msgid ""
 "\n"
 "If you load the original file, the backup file will be overwritten in the "
@@ -1839,28 +1443,22 @@ msgstr ""
 "\n"
 "Caricare il file di backup?\n"
 
-#: schematic/src/x_fstylecb.c:73
 msgid "Hollow"
 msgstr ""
 
-#: schematic/src/x_fstylecb.c:80
 msgid "Filled"
 msgstr ""
 
-#: schematic/src/x_fstylecb.c:87
 msgid "Mesh"
 msgstr ""
 
-#: schematic/src/x_fstylecb.c:94
 msgid "Hatch"
 msgstr ""
 
-#: schematic/src/x_image.c:279
 #, fuzzy, c-format
 msgid "x_image_lowlevel: Unable to write %1$s file %2$s."
 msgstr "x_image_lowlevel: impossibile scrivere %s file %s.\n"
 
-#: schematic/src/x_image.c:289
 #, fuzzy, c-format
 msgid ""
 "There was the following error when saving image with type %1$s to filename:\n"
@@ -1874,283 +1472,220 @@ msgstr ""
 "\n"
 "%s.\n"
 
-#: schematic/src/x_image.c:309
 #, fuzzy, c-format
 msgid "Wrote color image to [%1$s] [%2$d x %3$d]"
 msgstr "Scritta immagine a colori per [%s] [%d x %d]\n"
 
-#: schematic/src/x_image.c:311
 #, fuzzy, c-format
 msgid "Wrote black and white image to [%1$s] [%2$d x %3$d]"
 msgstr "Scritta immagine in bianco e nero per [%s] [%d x %d]\n"
 
-#: schematic/src/x_image.c:319
 #, fuzzy
 msgid "x_image_lowlevel: Unable to get pixbuf from gschem's window."
 msgstr ""
 "x_image_lowlevel: incapace ad ottenere immagine pixbuf dalla finestra di "
 "gschem.\n"
 
-#: schematic/src/x_image.c:358
 msgid "Width x Height"
 msgstr "Larghezza x Altezza"
 
-#: schematic/src/x_image.c:374
 msgid "Image type"
 msgstr "Tipo di immagine"
 
-#: schematic/src/x_image.c:395
 msgid "Write image..."
 msgstr "Scrivi immagine..."
 
-#: schematic/src/x_linecapcb.c:74
 msgid "Butt"
 msgstr ""
 
-#: schematic/src/x_linecapcb.c:81
 msgid "Square"
 msgstr ""
 
-#: schematic/src/x_linecapcb.c:88
 msgid "Round"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:74
 msgid "Solid"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:81
 msgid "Dotted"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:88
 msgid "Dashed"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:95
 msgid "Center"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:102
 msgid "Phantom"
 msgstr ""
 
-#: schematic/src/x_menus.c:41 schematic/scheme/gschem/builtins.scm:267
 msgid "Add Net"
 msgstr "Aggiungi net"
 
-#: schematic/src/x_menus.c:42 schematic/src/x_multiattrib.c:2187
-#: schematic/scheme/gschem/builtins.scm:264
 msgid "Add Attribute"
 msgstr "Aggiungi attributo"
 
-#: schematic/src/x_menus.c:43 schematic/scheme/gschem/builtins.scm:261
 msgid "Add Component"
 msgstr "Aggiungi componente"
 
-#: schematic/src/x_menus.c:44 schematic/scheme/gschem/builtins.scm:270
 msgid "Add Bus"
 msgstr "Aggiungi bus"
 
-#: schematic/src/x_menus.c:45 schematic/scheme/gschem/builtins.scm:273
 msgid "Add Text"
 msgstr "Aggiungi testo"
 
-#: schematic/src/x_menus.c:47 schematic/scheme/gschem/builtins.scm:210
 msgid "Zoom In"
 msgstr "Zoom In"
 
-#: schematic/src/x_menus.c:48 schematic/scheme/gschem/builtins.scm:213
 msgid "Zoom Out"
 msgstr "Zoom Out"
 
-#: schematic/src/x_menus.c:50 schematic/scheme/gschem/builtins.scm:207
 msgid "Zoom Extents"
 msgstr "Zoom alla pagina"
 
-#: schematic/src/x_menus.c:52 schematic/src/x_window.c:1233
 msgid "Select"
 msgstr "Seleziona"
 
-#: schematic/src/x_menus.c:53 schematic/scheme/conf/schematic/menu.scm:69
-#: schematic/scheme/gschem/builtins.scm:126
 msgid "Edit..."
 msgstr "Modifica..."
 
-#: schematic/src/x_menus.c:54 schematic/scheme/conf/schematic/menu.scm:68
 #, fuzzy
 msgid "Object Properties..."
 msgstr "<b>Opzioni</b>"
 
-#: schematic/src/x_menus.c:59 schematic/scheme/gschem/builtins.scm:300
 msgid "Down Schematic"
 msgstr "Giu nello schema"
 
-#: schematic/src/x_menus.c:60 schematic/scheme/gschem/builtins.scm:303
 msgid "Down Symbol"
 msgstr "Giu nel simbolo"
 
-#: schematic/src/x_menus.c:61
 msgid "Up"
 msgstr "Su"
 
-#: schematic/src/x_menus.c:336
 #, fuzzy, c-format
 msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
 msgstr ""
 "Si è tentato di regolare la sensitività su un oggetto di menu inesistente "
 "%s\n"
 
-#: schematic/src/x_menus.c:360
 #, c-format
 msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
 msgstr ""
 "Si è tentato di regolare la sensitività su un oggetto di menu inesistente "
 "%s\n"
 
-#: schematic/src/x_misc.c:70
 msgid "The operating system is out of memory or resources."
 msgstr "Il sistema operativo ha terminato le risorse di memoria."
 
-#: schematic/src/x_multiattrib.c:798 schematic/src/x_multiattrib.c:2704
 msgid "<various>"
 msgstr "<vari>"
 
-#: schematic/src/x_multiattrib.c:930
 msgid "Attributes with empty name are not allowed. Please set a name."
 msgstr "Attributi con il nome vuoto non sono permessi. Inserire un nome."
 
-#: schematic/src/x_multiattrib.c:1622
 msgid "Show Value only"
 msgstr "Mostra solo il valore"
 
-#: schematic/src/x_multiattrib.c:1624
 msgid "Show Name only"
 msgstr "Mostra solo il nome"
 
-#: schematic/src/x_multiattrib.c:1651
 msgid "Promote"
 msgstr "Promuovi"
 
-#: schematic/src/x_multiattrib.c:1655
 msgid "Duplicate"
 msgstr "Duplica"
 
-#: schematic/src/x_multiattrib.c:1657
 msgid "Copy to all"
 msgstr "Copia in tutti"
 
-#: schematic/src/x_multiattrib.c:1986 schematic/src/x_multiattrib.c:2602
 msgid "Edit Attributes"
 msgstr "Modifica attributi"
 
-#: schematic/src/x_multiattrib.c:2112
 msgid "Vis?"
 msgstr "Vis?"
 
-#: schematic/src/x_multiattrib.c:2130
 msgid "N"
 msgstr "N"
 
-#: schematic/src/x_multiattrib.c:2148
 msgid "V"
 msgstr "V"
 
-#: schematic/src/x_multiattrib.c:2170
 #, fuzzy
 msgid "Sho_w inherited attributes"
 msgstr "Mostra gli attributi ereditati"
 
-#: schematic/src/x_multiattrib.c:2197
 #, fuzzy
 msgid "_Name:"
 msgstr "Nome:"
 
-#: schematic/src/x_multiattrib.c:2241
 msgid "Ctrl+Enter inserts new line; Ctrl+Tab inserts Tab"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2618
 #, fuzzy, c-format
 msgid "%2$i symbol (%1$s)"
 msgid_plural "%2$i symbols (%1$s)"
 msgstr[0] "%i simbolo (%s)"
 msgstr[1] "%i simboli (%s)"
 
-#: schematic/src/x_multiattrib.c:2624
 #, fuzzy, c-format
 msgid "%1$i pin"
 msgid_plural "%1$i pins"
 msgstr[0] "%i pin"
 msgstr[1] "%i pin"
 
-#: schematic/src/x_multiattrib.c:2630
 #, fuzzy, c-format
 msgid "%1$i net"
 msgid_plural "%1$i nets"
 msgstr[0] "%i net"
 msgstr[1] "%i net"
 
-#: schematic/src/x_multiattrib.c:2636
 #, fuzzy, c-format
 msgid "%1$i bus"
 msgid_plural "%1$i buses"
 msgstr[0] "%i bus"
 msgstr[1] "%i bus"
 
-#: schematic/src/x_multiattrib.c:2642
 #, fuzzy, c-format
 msgid "%1$i attribute"
 msgid_plural "%1$i attributes"
 msgstr[0] "%i attributo"
 msgstr[1] "%i attributi"
 
-#: schematic/src/x_newtext.c:433
 #, fuzzy
 msgid "Text Entry..."
 msgstr "_Testo..."
 
-#: schematic/src/x_pagesel.c:253
 msgid "New Page"
 msgstr "Nuova pagina"
 
-#: schematic/src/x_pagesel.c:254
 msgid "Open Page..."
 msgstr "Apri pagina..."
 
-#: schematic/src/x_pagesel.c:256
 msgid "Save Page"
 msgstr "Salva la pagina"
 
-#: schematic/src/x_pagesel.c:257 schematic/scheme/gschem/builtins.scm:246
 msgid "Close Page"
 msgstr "Chiudi pagina"
 
-#: schematic/src/x_pagesel.c:376 schematic/scheme/gschem/builtins.scm:237
 msgid "Page Manager"
 msgstr "Gestore Pagina"
 
-#: schematic/src/x_pagesel.c:448
 msgid "Changed"
 msgstr "Cambiato"
 
-#: schematic/src/x_pagesel.c:468
 msgid "Right click on the filename for more options..."
 msgstr ""
 "Clicca con il tasto destro del mouse sul nome del file per ulteriori "
 "opzioni..."
 
-#: schematic/src/x_print.c:306
 #, c-format
 msgid "Failed to write PDF to '%s': %s\n"
 msgstr "Fallita la scrittura PDF su \"%s\": %s\n"
 
-#: schematic/src/x_print.c:364
 #, fuzzy, c-format
 msgid "Failed to write PDF to '%1$s': %2$s\n"
 msgstr "Fallita la scrittura PDF su \"%s\": %s\n"
 
-#: schematic/src/x_print.c:449
 #, fuzzy, c-format
 msgid ""
 "Error printing file:\n"
@@ -2159,14 +1694,12 @@ msgstr ""
 "Errore durante la stampa del file:\n"
 "%s"
 
-#: schematic/src/x_rc.c:39
 #, fuzzy
 msgid "ERROR: An unknown error occurred while parsing configuration files."
 msgstr ""
 "ERRORE: un errore sconosciuto si è verificato durante l'analisi dei file di "
 "configurazione.\n"
 
-#: schematic/src/x_rc.c:44
 #, fuzzy
 msgid ""
 "An unknown error occurred while parsing configuration files.\n"
@@ -2178,12 +1711,10 @@ msgstr ""
 "\n"
 "Il file di log di gschem potrebbe contenere ulteriori informazioni."
 
-#: schematic/src/x_rc.c:56
 #, fuzzy, c-format
 msgid "ERROR: %1$s"
 msgstr "ERRORE: %s\n"
 
-#: schematic/src/x_rc.c:59
 #, fuzzy, c-format
 msgid ""
 "%1$s\n"
@@ -2194,141 +1725,110 @@ msgstr ""
 "\n"
 "Il log di gschem potrebbe contenere ulteriori informazioni."
 
-#: schematic/src/x_rc.c:67
 #, fuzzy
 msgid "Cannot load lepton-schematic configuration."
 msgstr "Impossibile caricare la configurazione di gschem."
 
-#: schematic/src/x_script.c:42 schematic/scheme/conf/schematic/menu.scm:40
 msgid "Execute Script..."
 msgstr "Esegui script..."
 
-#: schematic/src/x_script.c:61
 #, fuzzy, c-format
 msgid "Executing guile script [%1$s]"
 msgstr "Esecuzione dello script guile [%s]\n"
 
-#: schematic/src/x_tabs.c:860
 #, fuzzy, c-format
 msgid "Hierarchy up: %s"
 msgstr "Ge_rarchia"
 
-#: schematic/src/x_tabs.c:863
 #, fuzzy
 msgid "Hierarchy up"
 msgstr "Ge_rarchia"
 
-#: schematic/src/x_widgets.c:158 schematic/src/x_window.c:1444
 #, fuzzy
 msgid "Options"
 msgstr "_Opzioni"
 
-#: schematic/src/x_widgets.c:203 schematic/src/x_window.c:1436
 msgid "Object"
 msgstr ""
 
-#: schematic/src/x_widgets.c:224
 msgid "Log"
 msgstr ""
 
-#: schematic/src/x_widgets.c:245 schematic/src/x_window.c:1466
 msgid "Find Text"
 msgstr "Trova testo"
 
-#: schematic/src/x_widgets.c:259
 #, fuzzy
 msgid "Color Scheme Editor"
 msgstr "Schema colori chiari"
 
-#: schematic/src/x_widgets.c:272 schematic/scheme/gschem/builtins.scm:378
 #, fuzzy
 msgid "Select Schematic Font"
 msgstr "S_eleziona lo schema che vuoi salvare:"
 
-#: schematic/src/x_window.c:763
 #, fuzzy, c-format
 msgid "Loading schematic [%1$s]"
 msgstr "Caricamento schema [%s]\n"
 
-#: schematic/src/x_window.c:864
 #, fuzzy, c-format
 msgid "Could NOT save page [%1$s]\n"
 msgstr "Non è possibile salvare la pagina [%s]\n"
 
-#: schematic/src/x_window.c:865
 msgid "Error while trying to save"
 msgstr "Errore durante il salvataggio"
 
-#: schematic/src/x_window.c:875
 msgid "Failed to save file"
 msgstr "Fallito il salvataggio file"
 
-#: schematic/src/x_window.c:885
 #, fuzzy, c-format
 msgid "Saved as [%1$s]"
 msgstr "Salvato con il nome [%s]\n"
 
-#: schematic/src/x_window.c:887
 #, fuzzy, c-format
 msgid "Saved [%1$s]"
 msgstr "Salvato [%s]\n"
 
-#: schematic/src/x_window.c:889
 msgid "Saved"
 msgstr "Salvato"
 
-#: schematic/src/x_window.c:966
 #, fuzzy, c-format
 msgid "Discarding page [%1$s]"
 msgstr "Annulla pagina [%s]\n"
 
-#: schematic/src/x_window.c:966
 #, fuzzy, c-format
 msgid "Closing [%1$s]"
 msgstr "Chiusura [%s]\n"
 
-#: schematic/src/x_window.c:1175
 msgid "New"
 msgstr "Nuovo"
 
-#: schematic/src/x_window.c:1175
 msgid "New file"
 msgstr "Nuovo file"
 
-#: schematic/src/x_window.c:1179
 msgid "Open"
 msgstr "Apri"
 
-#: schematic/src/x_window.c:1179
 #, fuzzy
 msgid "Open file"
 msgstr "Apri file"
 
-#: schematic/src/x_window.c:1183 schematic/scheme/gschem/builtins.scm:59
 msgid "Save"
 msgstr "Salva"
 
-#: schematic/src/x_window.c:1183
 msgid "Save file"
 msgstr "Salva file"
 
-#: schematic/src/x_window.c:1189 schematic/scheme/gschem/builtins.scm:93
 msgid "Undo"
 msgstr "Annulla"
 
-#: schematic/src/x_window.c:1189
 msgid "Undo last operation"
 msgstr "Annulla l'ultima operazione"
 
-#: schematic/src/x_window.c:1193 schematic/scheme/gschem/builtins.scm:96
 msgid "Redo"
 msgstr "Ripristina"
 
-#: schematic/src/x_window.c:1193
 msgid "Redo last undo"
 msgstr "Ripristina ultima operazione annullata"
 
-#: schematic/src/x_window.c:1198
 msgid ""
 "Add component...\n"
 "Select library and component from list, move the mouse into main window, "
@@ -2342,7 +1842,6 @@ msgstr ""
 "Il tasto destro del mouse serve ad abbandonare il componente al fine di "
 "sceglierne un altro."
 
-#: schematic/src/x_window.c:1209
 msgid ""
 "Add nets mode\n"
 "Right mouse button to cancel"
@@ -2351,7 +1850,6 @@ msgstr ""
 "Tasto destro del mouse per\n"
 "cancellare il collegamento"
 
-#: schematic/src/x_window.c:1217
 msgid ""
 "Add buses mode\n"
 "Right mouse button to cancel"
@@ -2360,45 +1858,35 @@ msgstr ""
 "Tasto destro del mouse per\n"
 "cancellare il collegamento"
 
-#: schematic/src/x_window.c:1226
 msgid "Add Text..."
 msgstr "Aggiungi Testo..."
 
-#: schematic/src/x_window.c:1233
 msgid "Select mode"
 msgstr "Modalità Selezione"
 
-#: schematic/src/x_window.c:1288
 #, fuzzy
 msgid "Show"
 msgstr "MostraN"
 
-#: schematic/src/x_window.c:1289
 msgid "Show text starting with:"
 msgstr "Mostra il testo iniziando con:"
 
-#: schematic/src/x_window.c:1345
 msgid "Menu/Cancel"
 msgstr "Menu/Cancella"
 
-#: schematic/src/x_window.c:1349
 msgid "Pan/Cancel"
 msgstr "Pan/Cancella"
 
-#: schematic/src/x_window.c:1359
 msgid "Pick"
 msgstr "Prendi"
 
-#: schematic/src/x_window.c:1470 schematic/scheme/gschem/builtins.scm:180
 msgid "Status"
 msgstr "Stato"
 
-#: schematic/src/x_window.c:1568
 #, fuzzy, c-format
 msgid "New file [%s]"
 msgstr "Nuovo file [%s]\n"
 
-#: schematic/src/x_window.c:1598
 #, fuzzy, c-format
 msgid ""
 "<b>An error occurred while loading the requested file.</b>\n"
@@ -2416,795 +1904,598 @@ msgstr ""
 "Caricamento da \"%s\" fallito: %s. Il log di gschem potrebbe contenere "
 "ulteriori informazioni."
 
-#: schematic/src/x_window.c:1617
 msgid "Failed to load file"
 msgstr "Impossibile caricare il file"
 
-#: schematic/data/lepton-schematic.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Schematic Editor"
 msgstr "Editor di schemi gEDA"
 
-#: schematic/data/lepton-schematic.desktop.in:4
 #, fuzzy
 msgid "Create and edit electrical schematics and symbols with lepton-schematic"
 msgstr "Crea e modifica schemi elettrici e simboli con gschem"
 
-#: schematic/scheme/conf/schematic/menu.scm:27
 msgid "_New"
 msgstr "_Nuovo"
 
-#: schematic/scheme/conf/schematic/menu.scm:28
 msgid "_Open..."
 msgstr "_Apri..."
 
-#: schematic/scheme/conf/schematic/menu.scm:30
 msgid "Open Recen_t"
 msgstr "Apri recen_ti"
 
-#: schematic/scheme/conf/schematic/menu.scm:32
 msgid "_Save"
 msgstr "_Salva"
 
-#: schematic/scheme/conf/schematic/menu.scm:33
 msgid "Save _As..."
 msgstr "Salva _come..."
 
-#: schematic/scheme/conf/schematic/menu.scm:34
-#: schematic/scheme/gschem/builtins.scm:65
 msgid "Save All"
 msgstr "Salva tutto"
 
-#: schematic/scheme/conf/schematic/menu.scm:36
 msgid "_Print..."
 msgstr "_Stampa..."
 
-#: schematic/scheme/conf/schematic/menu.scm:37
 #, fuzzy
 msgid "Write _Image..."
 msgstr "Scrivi _immagine..."
 
-#: schematic/scheme/conf/schematic/menu.scm:39
 #, fuzzy
 msgid "Invoke Macro..."
 msgstr "Esegui macro"
 
-#: schematic/scheme/conf/schematic/menu.scm:41
 msgid "REPL..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:43
-#: schematic/scheme/gschem/builtins.scm:77
 msgid "New Window"
 msgstr "Nuova finestra"
 
-#: schematic/scheme/conf/schematic/menu.scm:44
 msgid "_Close Window"
 msgstr "_Chiudi finestra"
 
-#: schematic/scheme/conf/schematic/menu.scm:45
 msgid "_Quit"
 msgstr "_Esci"
 
-#: schematic/scheme/conf/schematic/menu.scm:51
 msgid "_Undo"
 msgstr "Ann_ulla"
 
-#: schematic/scheme/conf/schematic/menu.scm:52
 msgid "_Redo"
 msgstr "_Ripeti"
 
-#: schematic/scheme/conf/schematic/menu.scm:54
 msgid "Cu_t"
 msgstr "_Taglia"
 
-#: schematic/scheme/conf/schematic/menu.scm:55
 msgid "_Copy"
 msgstr "_Copia"
 
-#: schematic/scheme/conf/schematic/menu.scm:56
 msgid "_Paste"
 msgstr "_Incolla"
 
-#: schematic/scheme/conf/schematic/menu.scm:57
 msgid "_Delete"
 msgstr "_Elimina"
 
-#: schematic/scheme/conf/schematic/menu.scm:60
-#: schematic/scheme/gschem/builtins.scm:102
 msgid "Select All"
 msgstr "Seleziona tutto"
 
-#: schematic/scheme/conf/schematic/menu.scm:61
-#: schematic/scheme/gschem/builtins.scm:105
 msgid "Deselect"
 msgstr "Deseleziona"
 
-#: schematic/scheme/conf/schematic/menu.scm:65
 msgid "Rotate 90 Mode"
 msgstr "Ruota di 90 gradi"
 
-#: schematic/scheme/conf/schematic/menu.scm:70
 msgid "Edit Text..."
 msgstr "Modifica il testo..."
 
-#: schematic/scheme/conf/schematic/menu.scm:71
 msgid "Slot..."
 msgstr "Slot..."
 
-#: schematic/scheme/conf/schematic/menu.scm:76
-#: schematic/scheme/gschem/builtins.scm:150
 msgid "Embed Component/Picture"
 msgstr "Componente/Immagine fissato/a"
 
-#: schematic/scheme/conf/schematic/menu.scm:77
-#: schematic/scheme/gschem/builtins.scm:153
 msgid "Unembed Component/Picture"
 msgstr "Componente/immagine non fissato/a"
 
-#: schematic/scheme/conf/schematic/menu.scm:78
-#: schematic/scheme/gschem/builtins.scm:156
 msgid "Update Component"
 msgstr "Aggiorna componente"
 
-#: schematic/scheme/conf/schematic/menu.scm:79
 msgid "Symbol Translate..."
 msgstr "Conversione simbolo..."
 
-#: schematic/scheme/conf/schematic/menu.scm:85
 msgid "Copy into 1"
 msgstr "Copia in 1"
 
-#: schematic/scheme/conf/schematic/menu.scm:86
 msgid "Copy into 2"
 msgstr "Copia in 2"
 
-#: schematic/scheme/conf/schematic/menu.scm:87
 msgid "Copy into 3"
 msgstr "Copia in 3"
 
-#: schematic/scheme/conf/schematic/menu.scm:88
 msgid "Copy into 4"
 msgstr "Copia in 4"
 
-#: schematic/scheme/conf/schematic/menu.scm:89
 msgid "Copy into 5"
 msgstr "Copia in 5"
 
-#: schematic/scheme/conf/schematic/menu.scm:90
 msgid "Cut into 1"
 msgstr "Taglia in 1"
 
-#: schematic/scheme/conf/schematic/menu.scm:91
 msgid "Cut into 2"
 msgstr "Taglia in 2"
 
-#: schematic/scheme/conf/schematic/menu.scm:92
 msgid "Cut into 3"
 msgstr "Taglia in 3"
 
-#: schematic/scheme/conf/schematic/menu.scm:93
 msgid "Cut into 4"
 msgstr "Taglia in 4"
 
-#: schematic/scheme/conf/schematic/menu.scm:94
 msgid "Cut into 5"
 msgstr "Taglia in 5"
 
-#: schematic/scheme/conf/schematic/menu.scm:95
 msgid "Paste from 1"
 msgstr "Incolla da 1"
 
-#: schematic/scheme/conf/schematic/menu.scm:96
 msgid "Paste from 2"
 msgstr "Incolla da 2"
 
-#: schematic/scheme/conf/schematic/menu.scm:97
 msgid "Paste from 3"
 msgstr "Incolla da 3"
 
-#: schematic/scheme/conf/schematic/menu.scm:98
 msgid "Paste from 4"
 msgstr "Incolla da 4"
 
-#: schematic/scheme/conf/schematic/menu.scm:99
 msgid "Paste from 5"
 msgstr "Incolla da 5"
 
-#: schematic/scheme/conf/schematic/menu.scm:105
 msgid "Side Dock"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:106
 #, fuzzy
 msgid "Bottom Dock"
 msgstr "Dal basso verso l'alto"
 
-#: schematic/scheme/conf/schematic/menu.scm:108
 #, fuzzy
 msgid "Find Text Results"
 msgstr "Trova testo"
 
-#: schematic/scheme/conf/schematic/menu.scm:110
 msgid "_Redraw"
 msgstr "_Ridisegna"
 
-#: schematic/scheme/conf/schematic/menu.scm:111
 msgid "_Pan"
 msgstr "_Scorri"
 
-#: schematic/scheme/conf/schematic/menu.scm:112
 msgid "Zoom _Box"
 msgstr "Ingrandisci _Riquadro"
 
-#: schematic/scheme/conf/schematic/menu.scm:113
 msgid "Zoom _Extents"
 msgstr "Adatta al _contenuto"
 
-#: schematic/scheme/conf/schematic/menu.scm:114
 msgid "Zoom _In"
 msgstr "Aum_enta ingrandimento"
 
-#: schematic/scheme/conf/schematic/menu.scm:115
 msgid "Zoom _Out"
 msgstr "Rid_uci ingrandimento"
 
-#: schematic/scheme/conf/schematic/menu.scm:116
 msgid "Zoom _Full"
 msgstr "Visualizza _tutto"
 
-#: schematic/scheme/conf/schematic/menu.scm:118
 #, fuzzy
 msgid "_Dark Color Scheme"
 msgstr "Schema colori scuri"
 
-#: schematic/scheme/conf/schematic/menu.scm:119
 #, fuzzy
 msgid "_Light Color Scheme"
 msgstr "Schema colori chiari"
 
-#: schematic/scheme/conf/schematic/menu.scm:120
 #, fuzzy
 msgid "B_W Color Scheme"
 msgstr "Schema colore B e N"
 
-#: schematic/scheme/conf/schematic/menu.scm:122
 #, fuzzy
 msgid "Color Scheme Editor..."
 msgstr "Schema colori chiari"
 
-#: schematic/scheme/conf/schematic/menu.scm:129
 msgid "_Manager..."
 msgstr "_Manager..."
 
-#: schematic/scheme/conf/schematic/menu.scm:131
 msgid "_Previous"
 msgstr "_Precedente"
 
-#: schematic/scheme/conf/schematic/menu.scm:132
 msgid "_Next"
 msgstr "_Successivo"
 
-#: schematic/scheme/conf/schematic/menu.scm:133
 msgid "_Close"
 msgstr "_Chiudi"
 
-#: schematic/scheme/conf/schematic/menu.scm:135
 #, fuzzy
 msgid "_Revert..."
 msgstr "_Ripristina"
 
-#: schematic/scheme/conf/schematic/menu.scm:137
-#: schematic/scheme/gschem/builtins.scm:249
 #, fuzzy
 msgid "Next Tab"
 msgstr "Pagina successiva"
 
-#: schematic/scheme/conf/schematic/menu.scm:138
-#: schematic/scheme/gschem/builtins.scm:252
 #, fuzzy
 msgid "Previous Tab"
 msgstr "Pagina precedente"
 
-#: schematic/scheme/conf/schematic/menu.scm:146
 msgid "_Component..."
 msgstr "_Componente..."
 
-#: schematic/scheme/conf/schematic/menu.scm:148
 msgid "_Net"
 msgstr "_Net"
 
-#: schematic/scheme/conf/schematic/menu.scm:149
 msgid "B_us"
 msgstr "B_us"
 
-#: schematic/scheme/conf/schematic/menu.scm:151
 msgid "_Attribute..."
 msgstr "_Attributo..."
 
-#: schematic/scheme/conf/schematic/menu.scm:152
 msgid "_Text..."
 msgstr "_Testo..."
 
-#: schematic/scheme/conf/schematic/menu.scm:154
 msgid "_Line"
 msgstr "_Linea"
 
-#: schematic/scheme/conf/schematic/menu.scm:155
 msgid "Pat_h"
 msgstr "Pe_rcorso"
 
-#: schematic/scheme/conf/schematic/menu.scm:156
 msgid "_Box"
 msgstr "_Rettangolo"
 
-#: schematic/scheme/conf/schematic/menu.scm:157
 msgid "C_ircle"
 msgstr "Cerch_io"
 
-#: schematic/scheme/conf/schematic/menu.scm:158
 msgid "A_rc"
 msgstr "A_rco"
 
-#: schematic/scheme/conf/schematic/menu.scm:159
 msgid "_Pin"
 msgstr "_Pin"
 
-#: schematic/scheme/conf/schematic/menu.scm:161
 msgid "Pictu_re..."
 msgstr "Dise_gno..."
 
-#: schematic/scheme/conf/schematic/menu.scm:167
 msgid "_Up"
 msgstr "_Torna su"
 
-#: schematic/scheme/conf/schematic/menu.scm:169
 msgid "_Down Schematic"
 msgstr "_Apri Schema"
 
-#: schematic/scheme/conf/schematic/menu.scm:170
 msgid "Down _Symbol"
 msgstr "Apri _Simbolo"
 
-#: schematic/scheme/conf/schematic/menu.scm:176
 msgid "_Attach"
 msgstr "_Collega"
 
-#: schematic/scheme/conf/schematic/menu.scm:177
 msgid "_Detach"
 msgstr "_Scollega"
 
-#: schematic/scheme/conf/schematic/menu.scm:179
 msgid "Show _Value"
 msgstr "Mostra _Valore"
 
-#: schematic/scheme/conf/schematic/menu.scm:180
 msgid "Show _Name"
 msgstr "Mostra _Nome"
 
-#: schematic/scheme/conf/schematic/menu.scm:181
 msgid "Show _Both"
 msgstr "Mostra _entrambi"
 
-#: schematic/scheme/conf/schematic/menu.scm:182
 msgid "_Toggle Visibility"
 msgstr "Commu_ta Visibilità"
 
-#: schematic/scheme/conf/schematic/menu.scm:184
 msgid "_Hide Specific Text..."
 msgstr "_Nascondi testo specifico..."
 
-#: schematic/scheme/conf/schematic/menu.scm:185
 msgid "_Show Specific Text..."
 msgstr "_Mostra testo specifico..."
 
-#: schematic/scheme/conf/schematic/menu.scm:186
 #, fuzzy
 msgid "Show/Hide Hidden Text"
 msgstr "Mostra/Nascondi testo invisibile"
 
-#: schematic/scheme/conf/schematic/menu.scm:188
 msgid "_Find Text/Check Symbol..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:189
 msgid "A_utonumber Text..."
 msgstr "Testo di a_utonumerazione..."
 
-#: schematic/scheme/conf/schematic/menu.scm:195
 #, fuzzy
 msgid "_Options..."
 msgstr "_Opzioni"
 
-#: schematic/scheme/conf/schematic/menu.scm:196
 #, fuzzy
 msgid "_Font..."
 msgstr "_Stampa..."
 
-#: schematic/scheme/conf/schematic/menu.scm:198
 #, fuzzy
 msgid "Grid +"
 msgstr "Griglia NON ATTIVA\n"
 
-#: schematic/scheme/conf/schematic/menu.scm:199
 #, fuzzy
 msgid "Grid -"
 msgstr "Griglia NON ATTIVA\n"
 
-#: schematic/scheme/conf/schematic/menu.scm:201
 msgid "Grid Style: Cycle Dots/Mesh/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:202
 msgid "Grid Snap: Cycle Grid/Resnap/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:204
 #, fuzzy
 msgid "Feedback Mode: Outline/Box"
 msgstr "C_ommuta disegno elementi/perimetro"
 
-#: schematic/scheme/conf/schematic/menu.scm:205
 #, fuzzy
 msgid "Net: Rubberband On/Off"
 msgstr "Rubber band ON\n"
 
-#: schematic/scheme/conf/schematic/menu.scm:206
 msgid "Net: Magnetic On/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:208
 #, fuzzy
 msgid "_Coord Window"
 msgstr "_Chiudi finestra"
 
-#: schematic/scheme/conf/schematic/menu.scm:209
 #, fuzzy
 msgid "_Log Window"
 msgstr "Mostra la finestra di log"
 
-#: schematic/scheme/conf/schematic/menu.scm:215
 msgid "_1 allegro"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:223
 #, fuzzy
 msgid "User _Guide"
 msgstr "Guida utente di gschem"
 
-#: schematic/scheme/conf/schematic/menu.scm:224
 msgid "_FAQ"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:225
 #, fuzzy
 msgid "Docu_mentation"
 msgstr "D_ocumentazione..."
 
-#: schematic/scheme/conf/schematic/menu.scm:226
 msgid "_Wiki"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:228
 #, fuzzy
 msgid "Find Component D_ocumentation"
 msgstr "Documentazione componente"
 
-#: schematic/scheme/conf/schematic/menu.scm:230
 msgid "_Hotkeys..."
 msgstr "Combina_zioni tasti..."
 
-#: schematic/scheme/conf/schematic/menu.scm:231
 #, fuzzy
 msgid "_About"
 msgstr "_Info su..."
 
-#: schematic/scheme/conf/schematic/menu.scm:237
 msgid "_File"
 msgstr "_File"
 
-#: schematic/scheme/conf/schematic/menu.scm:238
 msgid "_Edit"
 msgstr "_Modifica"
 
-#: schematic/scheme/conf/schematic/menu.scm:240
 msgid "_View"
 msgstr "_Vista"
 
-#: schematic/scheme/conf/schematic/menu.scm:241
 msgid "_Page"
 msgstr "_Pagina"
 
-#: schematic/scheme/conf/schematic/menu.scm:242
 msgid "_Add"
 msgstr "_Aggiungi"
 
-#: schematic/scheme/conf/schematic/menu.scm:243
 msgid "Hie_rarchy"
 msgstr "Ge_rarchia"
 
-#: schematic/scheme/conf/schematic/menu.scm:244
 msgid "A_ttributes"
 msgstr "A_ttributi"
 
-#: schematic/scheme/conf/schematic/menu.scm:245
 msgid "_Options"
 msgstr "_Opzioni"
 
-#: schematic/scheme/conf/schematic/menu.scm:246
 #, fuzzy
 msgid "_Netlist"
 msgstr "_Net"
 
-#: schematic/scheme/conf/schematic/menu.scm:247
 msgid "_Help"
 msgstr "Aiuto"
 
-#: schematic/scheme/gschem/action.scm:43
 #, scheme-format
 msgid "~S is not a valid gschem action."
 msgstr "~S non è un'azione valida gschem."
 
-#: schematic/scheme/gschem/action.scm:158
 msgid "Repeat Last Action"
 msgstr "Ripeti l'ultima azione"
 
-#: schematic/scheme/gschem/builtins.scm:47
 msgid "Cancel"
 msgstr "Annulla"
 
-#: schematic/scheme/gschem/builtins.scm:53
 msgid "New File"
 msgstr "Nuovo file"
 
-#: schematic/scheme/gschem/builtins.scm:56
 msgid "Open File"
 msgstr "Apri file"
 
-#: schematic/scheme/gschem/builtins.scm:62
 msgid "Save As"
 msgstr "Salva come"
 
-#: schematic/scheme/gschem/builtins.scm:68
 msgid "Print"
 msgstr "Stampa"
 
-#: schematic/scheme/gschem/builtins.scm:71
 msgid "Export Image"
 msgstr "Esporta immagine"
 
-#: schematic/scheme/gschem/builtins.scm:74
 msgid "Run Script"
 msgstr "Esegui script"
 
-#: schematic/scheme/gschem/builtins.scm:80
 msgid "Close Window"
 msgstr "Chiudi finestra"
 
-#: schematic/scheme/gschem/builtins.scm:83
 msgid "Quit"
 msgstr "Esci"
 
-#: schematic/scheme/gschem/builtins.scm:87
 msgid "Terminal REPL"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:132
 msgid "Choose Slot"
 msgstr "Scegli slot"
 
-#: schematic/scheme/gschem/builtins.scm:135
 #, fuzzy
 msgid "Edit Object Properties"
 msgstr "<b>Opzioni</b>"
 
-#: schematic/scheme/gschem/builtins.scm:138
 msgid "Translate Symbol"
 msgstr "Converti simbolo"
 
-#: schematic/scheme/gschem/builtins.scm:147
 msgid "Invoke Macro"
 msgstr "Esegui macro"
 
-#: schematic/scheme/gschem/builtins.scm:159
 msgid "Show/Hide Invisible Text"
 msgstr "Mostra/Nascondi testo invisibile"
 
-#: schematic/scheme/gschem/builtins.scm:165
 msgid "Cut"
 msgstr "Taglia"
 
-#: schematic/scheme/gschem/builtins.scm:171
 msgid "Paste"
 msgstr "Incolla"
 
-#: schematic/scheme/gschem/builtins.scm:177
 msgid "Sidebar"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:183
 #, fuzzy
 msgid "Find Text State"
 msgstr "Trova testo"
 
-#: schematic/scheme/gschem/builtins.scm:186
 msgid "Redraw"
 msgstr "Ridisegna"
 
-#: schematic/scheme/gschem/builtins.scm:192
 msgid "Pan Left"
 msgstr "Trascina a sinistra"
 
-#: schematic/scheme/gschem/builtins.scm:195
 msgid "Pan Right"
 msgstr "Trascina a destra"
 
-#: schematic/scheme/gschem/builtins.scm:198
 msgid "Pan Up"
 msgstr "Trascina in su"
 
-#: schematic/scheme/gschem/builtins.scm:201
 msgid "Pan Down"
 msgstr "Trascina in giù"
 
-#: schematic/scheme/gschem/builtins.scm:216
 msgid "Zoom Full"
 msgstr "Zoom tutto"
 
-#: schematic/scheme/gschem/builtins.scm:219
 msgid "Dark Color Scheme"
 msgstr "Schema colori scuri"
 
-#: schematic/scheme/gschem/builtins.scm:222
 msgid "Light Color Scheme"
 msgstr "Schema colori chiari"
 
-#: schematic/scheme/gschem/builtins.scm:225
 msgid "Monochrome Color Scheme"
 msgstr "Schema colori monocromatico"
 
-#: schematic/scheme/gschem/builtins.scm:228
 #, fuzzy
 msgid "Show Color Scheme Editor"
 msgstr "Schema colori chiari"
 
-#: schematic/scheme/gschem/builtins.scm:234
 msgid "Revert Changes"
 msgstr "Annulla i cambiamenti"
 
-#: schematic/scheme/gschem/builtins.scm:240
 msgid "Previous Page"
 msgstr "Pagina precedente"
 
-#: schematic/scheme/gschem/builtins.scm:243
 msgid "Next Page"
 msgstr "Pagina successiva"
 
-#: schematic/scheme/gschem/builtins.scm:255
 msgid "Print Page"
 msgstr "Stampa pagina"
 
-#: schematic/scheme/gschem/builtins.scm:276
 msgid "Add Line"
 msgstr "Aggiungi linea"
 
-#: schematic/scheme/gschem/builtins.scm:279
 msgid "Add Path"
 msgstr "Aggiungi percorso"
 
-#: schematic/scheme/gschem/builtins.scm:282
 msgid "Add Box"
 msgstr "Aggiungi riquadro"
 
-#: schematic/scheme/gschem/builtins.scm:285
 msgid "Add Circle"
 msgstr "Aggiungi cerchio"
 
-#: schematic/scheme/gschem/builtins.scm:288
 msgid "Add Arc"
 msgstr "Aggiungi arco"
 
-#: schematic/scheme/gschem/builtins.scm:291
 msgid "Add Pin"
 msgstr "Aggiungi pin"
 
-#: schematic/scheme/gschem/builtins.scm:294
 msgid "Add Picture"
 msgstr "Aggiungi immagine"
 
-#: schematic/scheme/gschem/builtins.scm:306
 msgid "Up Hierarchy"
 msgstr "Su nella gerarchia"
 
-#: schematic/scheme/gschem/builtins.scm:312
 msgid "Attach Attributes"
 msgstr "Collega attributi"
 
-#: schematic/scheme/gschem/builtins.scm:315
 msgid "Detach Attributes"
 msgstr "Scollega attributi"
 
-#: schematic/scheme/gschem/builtins.scm:318
 msgid "Show Attribute Value"
 msgstr "Mostra il valore dell'attributo"
 
-#: schematic/scheme/gschem/builtins.scm:321
 msgid "Show Attribute Name"
 msgstr "Mostra il nome dell'attributo"
 
-#: schematic/scheme/gschem/builtins.scm:327
 msgid "Toggle Text Visibility"
 msgstr "Commuta la visibilità del testo"
 
-#: schematic/scheme/gschem/builtins.scm:330
 msgid "Find Specific Text"
 msgstr "Trova testo specifico"
 
-#: schematic/scheme/gschem/builtins.scm:333
 msgid "Hide Specific Text"
 msgstr "Nascondi testo specifico"
 
-#: schematic/scheme/gschem/builtins.scm:336
 msgid "Show Specific Text"
 msgstr "Mostra testo specifico"
 
-#: schematic/scheme/gschem/builtins.scm:339
 msgid "Autonumber Text"
 msgstr "Testo di autonumerazione"
 
-#: schematic/scheme/gschem/builtins.scm:345
 msgid "Show Hotkeys"
 msgstr "Mostra i tasti scelta rapida"
 
-#: schematic/scheme/gschem/builtins.scm:348
 msgid "Switch Grid Style"
 msgstr "Commuta lo stile griglia"
 
-#: schematic/scheme/gschem/builtins.scm:351
 msgid "Switch Snap Mode"
 msgstr "Commuta la modalità magnetica"
 
-#: schematic/scheme/gschem/builtins.scm:354
 msgid "Set Grid Spacing"
 msgstr "Imposta la spaziatura griglia"
 
-#: schematic/scheme/gschem/builtins.scm:357
 msgid "Increase Grid Spacing"
 msgstr "Aumenta la spaziatura griglia"
 
-#: schematic/scheme/gschem/builtins.scm:360
 msgid "Decrease Grid Spacing"
 msgstr "Diminuisci la spaziatura griglia"
 
-#: schematic/scheme/gschem/builtins.scm:363
 msgid "Toggle Outline Drawing"
 msgstr "Commuta disegno perimetro"
 
-#: schematic/scheme/gschem/builtins.scm:366
 msgid "Toggle Net Rubber Band"
 msgstr "Commuta net elastiche"
 
-#: schematic/scheme/gschem/builtins.scm:369
 msgid "Toggle Magnetic Nets"
 msgstr "Commuta net magnetiche"
 
-#: schematic/scheme/gschem/builtins.scm:372
 msgid "Show Log Window"
 msgstr "Mostra la finestra di log"
 
-#: schematic/scheme/gschem/builtins.scm:375
 msgid "Show Coordinate Window"
 msgstr "Mostra la finestra coordinate"
 
-#: schematic/scheme/gschem/builtins.scm:385
 msgid "Component Documentation"
 msgstr "Documentazione componente"
 
-#: schematic/scheme/gschem/builtins.scm:387
 msgid "View documentation for selected component"
 msgstr "Mostra la documentazione per il componente selezionato"
 
-#: schematic/scheme/gschem/builtins.scm:403
 msgid ""
 "Could not show documentation for selected component:\n"
 "\n"
@@ -3212,59 +2503,46 @@ msgstr ""
 "Impossibile mostrare la documentazione per i componenti selezionati:\n"
 "\n"
 
-#: schematic/scheme/gschem/builtins.scm:408
 msgid "gEDA Manuals"
 msgstr "Manuali gEDA"
 
-#: schematic/scheme/gschem/builtins.scm:409
 #, fuzzy
 msgid "View the front page of the gEDA documentation in a browser."
 msgstr ""
 "Visualizza la pagina principale della documentazione gEDA in un browser."
 
-#: schematic/scheme/gschem/builtins.scm:414
 msgid "gschem User Guide"
 msgstr "Guida utente di gschem"
 
-#: schematic/scheme/gschem/builtins.scm:415
 msgid "View the gschem User Guide in a browser."
 msgstr "Mostra la guida utente di gschem in un browser."
 
-#: schematic/scheme/gschem/builtins.scm:420
 msgid "gschem FAQ"
 msgstr "FAQ di gschem"
 
-#: schematic/scheme/gschem/builtins.scm:421
 msgid "Frequently Asked Questions about using gschem."
 msgstr "Le domande ricorrenti su gschem."
 
-#: schematic/scheme/gschem/builtins.scm:426
 msgid "gEDA wiki"
 msgstr "Wiki di gEDA"
 
-#: schematic/scheme/gschem/builtins.scm:427
 msgid "View the front page of the gEDA wiki in a browser."
 msgstr "Visualizza la pagina principale del wiki di gEDA in un browser."
 
-#: schematic/scheme/gschem/builtins.scm:431
 msgid "About gschem"
 msgstr "Informazioni su gschem"
 
-#: schematic/scheme/gschem/deprecated.scm:102
 #, scheme-format
 msgid "Invalid text alignment ~A."
 msgstr "Allineamento testo non valido ~A."
 
-#: schematic/scheme/gschem/gschemdoc.scm:241
 msgid "No documentation found"
 msgstr "Nessun documento trovato"
 
-#: schematic/scheme/gschem/keymap.scm:40
 #, scheme-format
 msgid "~S is not a valid key combination."
 msgstr "~S non è una combinazione di tasti valida."
 
-#: schematic/scheme/gschem/keymap.scm:157
 #, scheme-format
 msgid "~S is not a prefix key sequence."
 msgstr "~S non è un prefisso di sequenza di tasti."

--- a/schematic/po/ja.po
+++ b/schematic/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-15 15:13+0300\n"
+"POT-Creation-Date: 2019-02-22 14:08+0300\n"
 "PO-Revision-Date: 2012-01-31 12:07+0000\n"
 "Last-Translator: Peter TB Brett <Unknown>\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -18,24 +18,20 @@ msgstr ""
 "X-Launchpad-Export-Date: 2012-11-14 16:52+0000\n"
 "X-Generator: Launchpad (build 16265)\n"
 
-#: schematic/src/a_zoom.c:155
 #, fuzzy
 msgid "Zoom too small!  Cannot zoom further."
 msgstr "これ以上ズームできません。\n"
 
-#: schematic/src/color_edit_widget.c:399
 #, fuzzy, c-format
 msgid ""
 "Could not save file [%s]:\n"
 "%s"
 msgstr "初期化scmファイルの読み込みに失敗。[%s]\n"
 
-#: schematic/src/color_edit_widget.c:434
 #, fuzzy
 msgid "Save Color Scheme As..."
 msgstr "明るい配色(_L)"
 
-#: schematic/src/color_edit_widget.c:482 schematic/src/x_fileselect.c:292
 #, c-format
 msgid ""
 "The selected file `%1$s' already exists.\n"
@@ -43,178 +39,140 @@ msgid ""
 "Would you like to overwrite it?"
 msgstr ""
 
-#: schematic/src/color_edit_widget.c:486 schematic/src/x_fileselect.c:295
 msgid "Overwrite file?"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:211
 msgid "_Apply"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:215
 msgid "Sa_ve..."
 msgstr ""
 
-#: schematic/src/font_select_widget.c:278
 #, c-format
 msgid "<b>Current:</b> %s"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:453
 msgid "Save configuration"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:461
 msgid "Save settings to:"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:465
 msgid "Local configuration file (in current directory)"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:467
 msgid "User configuration file (geda-user.conf)"
 msgstr ""
 
-#: schematic/src/g_attrib.c:90
 msgid "Object ~A is not included in the current gschem page."
 msgstr ""
 
-#: schematic/src/g_attrib.c:110
 msgid "Invalid text name/value visibility ~A."
 msgstr ""
 
-#: schematic/src/g_rc.c:107
 #, c-format
 msgid "You are running gEDA/gaf version [%1$s%2$s.%3$s],\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:111
 #, c-format
 msgid ""
 "but you have a version [%1$s] gschemrc file:\n"
 "[%2$s]\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:114
 #, c-format
 msgid "Please be sure that you have the latest rc file.\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:240
 #, fuzzy, c-format
 msgid "Invalid size [%1$d] passed to text-size\n"
 msgstr "無効なサイズ[%d]がtext-sizeに指定されました。\n"
 
-#: schematic/src/g_rc.c:283
 #, fuzzy, c-format
 msgid "Invalid size [%1$d] passed to snap-size\n"
 msgstr "無効なサイズ[%d]がsnap-sizeに指定されました。\n"
 
-#: schematic/src/g_rc.c:620
 #, fuzzy, c-format
 msgid "Invalid num levels [%1$d] passed to undo-levels\n"
 msgstr "無効なアンドゥレベル[%d]がundo-levelsに指定されました。\n"
 
-#: schematic/src/g_rc.c:831
 #, fuzzy, c-format
 msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
 msgstr "無効なサイズ[%d]がbus-ripperに指定されました。\n"
 
-#: schematic/src/g_rc.c:931
 #, fuzzy, c-format
 msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
 msgstr "無効なサイズ[%d]がtext-sizeに指定されました。\n"
 
-#: schematic/src/g_rc.c:972
 #, fuzzy, c-format
 msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
 msgstr "無効なサイズ[%d]がbus-ripperに指定されました。\n"
 
-#: schematic/src/g_rc.c:998
 #, fuzzy, c-format
 msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
 msgstr "無効なサイズ[%d]がbus-ripperに指定されました。\n"
 
-#: schematic/src/g_rc.c:1023
 #, fuzzy, c-format
 msgid "Invalid offset [%1$d] passed to add-attribute-offset\n"
 msgstr "無効なサイズ[%d]がtext-sizeに指定されました。\n"
 
-#: schematic/src/g_rc.c:1047
 #, fuzzy, c-format
 msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
 msgstr "無効なアンドゥレベル[%d]がundo-levelsに指定されました。\n"
 
-#: schematic/src/g_rc.c:1071
 #, fuzzy, c-format
 msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
 msgstr "無効なサイズ[%d]がsnap-sizeに指定されました。\n"
 
-#: schematic/src/g_rc.c:1094
 #, fuzzy, c-format
 msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
 msgstr "無効なサイズ[%d]がsnap-sizeに指定されました。\n"
 
-#: schematic/src/g_rc.c:1118
 #, fuzzy, c-format
 msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
 msgstr "無効なアンドゥレベル[%d]がundo-levelsに指定されました。\n"
 
-#: schematic/src/g_rc.c:1144
 #, fuzzy, c-format
 msgid "Invalid gain [%1$d] passed to zoom-gain\n"
 msgstr "無効なサイズ[%d]がtext-sizeに指定されました。\n"
 
-#: schematic/src/g_rc.c:1169
 #, c-format
 msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
 msgstr ""
 
-#: schematic/src/g_select.c:78 schematic/src/g_select.c:115
-#: schematic/src/g_select.c:151
 msgid "Object ~A is not directly included in a page."
 msgstr ""
 
-#: schematic/src/g_util.c:54
 msgid "Could not launch URI ~S: ~A"
 msgstr ""
 
-#: schematic/src/g_window.c:139
 msgid "Found invalid gschem window smob ~S"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:156
 #, c-format
 msgid "Lepton EDA/lepton-schematic version %1$s%2$s.%3$s git: %4$.7s"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:163
 #, c-format
 msgid "This is the MINGW32 port.\n"
 msgstr "MIGW32版です。\n"
 
-#: schematic/src/lepton-schematic.c:167
 #, c-format
 msgid "Current locale settings: %1$s\n"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:201
 #, fuzzy, c-format
 msgid "Couldn't find init scm file [%1$s]"
 msgstr "初期化scmファイルの読み込みに失敗。[%s]\n"
 
-#: schematic/src/lepton-schematic.c:206
 #, fuzzy, c-format
 msgid "Read init scm file [%1$s]"
 msgstr "初期化scmファイルを読み込んでいます。[%s]\n"
 
-#: schematic/src/lepton-schematic.c:210
 #, fuzzy, c-format
 msgid "Failed to read init scm file [%1$s]"
 msgstr "初期化scmファイルの読み込みに失敗。[%s]\n"
 
-#: schematic/src/lepton-schematic.c:290
 #, c-format
 msgid ""
 "ERROR: Failed to load or evaluate startup script.\n"
@@ -222,682 +180,502 @@ msgid ""
 "The lepton-schematic log may contain more information.\n"
 msgstr ""
 
-#: schematic/src/gschem_about_dialog.c:51
 #, c-format
 msgid "%s (git: %.7s)"
 msgstr ""
 
-#: schematic/src/gschem_about_dialog.c:75
 msgid "Lepton Electronic Design Automation"
 msgstr ""
 
-#: schematic/src/gschem_about_dialog.c:83
 msgid ""
 "Copyright © 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright © 2017-2018 Lepton Developers.\n"
-"See AUTHORS and ChangeLog files for details."
+"Copyright © 2017-2019 Lepton Developers.\n"
+"See AUTHORS, ChangeLog files and consult 'git log' history for details."
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:69
 msgid "Upper Left"
 msgstr "上 左"
 
-#: schematic/src/gschem_alignment_combo.c:71
 msgid "Upper Middle"
 msgstr "上 中央"
 
-#: schematic/src/gschem_alignment_combo.c:73
 #, fuzzy
 msgid "Upper Right"
 msgstr "下 右"
 
-#: schematic/src/gschem_alignment_combo.c:78
 msgid "Middle Left"
 msgstr "中央 左"
 
-#: schematic/src/gschem_alignment_combo.c:80
 msgid "Middle Middle"
 msgstr "中央 中央"
 
-#: schematic/src/gschem_alignment_combo.c:82
 msgid "Middle Right"
 msgstr "中央 右"
 
-#: schematic/src/gschem_alignment_combo.c:87
 msgid "Lower Left"
 msgstr "下 左"
 
-#: schematic/src/gschem_alignment_combo.c:89
 msgid "Lower Middle"
 msgstr "下 中央"
 
-#: schematic/src/gschem_alignment_combo.c:91
 msgid "Lower Right"
 msgstr "下 右"
 
-#: schematic/src/gschem_arc_dialog.c:104
 msgid "Arc Params"
 msgstr "円弧パラメータ"
 
-#: schematic/src/gschem_arc_dialog.c:140
 msgid "Arc _Radius:"
 msgstr ""
 
-#: schematic/src/gschem_arc_dialog.c:141
 msgid "Start _Angle:"
 msgstr ""
 
-#: schematic/src/gschem_arc_dialog.c:142
 msgid "_Degrees of Sweep:"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:504
 msgid "Left mouse button"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:508
 #, fuzzy
 msgid "Middle mouse button"
 msgstr "中央 左"
 
-#: schematic/src/gschem_bottom_widget.c:512
 #, fuzzy
 msgid "Right mouse button"
 msgstr ""
 "ネット追加モード\n"
 "右ボタンでキャンセル"
 
-#: schematic/src/gschem_bottom_widget.c:595
 msgid "(Snap size, Grid size)"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:603
 #, fuzzy
 msgid "Net rubber band mode"
 msgstr "ラバーバンド・オン\n"
 
-#: schematic/src/gschem_bottom_widget.c:614
 #, fuzzy
 msgid "Magnetic net mode"
 msgstr "ネットモード"
 
-#: schematic/src/gschem_bottom_widget.c:622
 msgid "Current action mode"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:935
-#: schematic/src/gschem_bottom_widget.c:951
 msgid "OFF"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:954
 msgid "NONE"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:960
 #, c-format
 msgid "Grid(%1$s, %2$s)"
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:350
-#: schematic/src/x_compselect.c:1236 schematic/src/x_multiattrib.c:2068
 msgid "Name"
 msgstr "名前"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:372
 msgid "S_elect the schematics you want to save:"
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:467
 #, c-format
 msgid "Save the changes to schematic \"%1$s\" before closing?"
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:473
 #, c-format
 msgid ""
 "There are %1$d schematics with unsaved changes. Save changes before closing?"
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:502
 msgid "If you don't save, all your changes will be permanently lost."
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:522
 msgid "Close _without saving"
 msgstr ""
 
-#: schematic/src/gschem_coord_dialog.c:86
 msgid "Coords"
 msgstr "座標"
 
-#: schematic/src/gschem_coord_dialog.c:106
 msgid "Screen"
 msgstr "スクリーン"
 
-#: schematic/src/gschem_coord_dialog.c:115
 msgid "World"
 msgstr "ワールド"
 
-#: schematic/src/gschem_find_text_state.c:809 schematic/src/x_pagesel.c:432
 msgid "Filename"
 msgstr "ファイル名"
 
-#: schematic/src/gschem_find_text_state.c:821 schematic/src/i_callbacks.c:1970
-#: schematic/src/x_colorcb.c:154 schematic/src/x_widgets.c:179
-#: schematic/src/x_window.c:1226 schematic/src/x_window.c:1440
 msgid "Text"
 msgstr "テキスト"
 
-#: schematic/src/gschem_find_text_widget.c:427
 msgid "descend into hierarchy"
 msgstr "下の階層も検索"
 
-#: schematic/src/gschem_find_text_widget.c:435
 msgid "Find"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:557
 #, fuzzy
 msgid "Find Text:"
 msgstr "テキスト追加..."
 
-#: schematic/src/gschem_find_text_widget.c:564
 msgid "Find Pattern:"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:571
 msgid "Find Regex:"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:578
 msgid "Check symbol:"
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:200
 msgid "Hotkeys"
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:229
 msgid ""
 "Start typing action name or keystroke to filter the list.\n"
 "Type hotkeys as they are displayed in \"Keystroke(s)\" column."
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:233 schematic/src/x_compselect.c:1124
 #, fuzzy
 msgid "_Filter:"
 msgstr "ファイル(_F)"
 
-#: schematic/src/gschem_hotkey_dialog.c:259 schematic/src/i_basic.c:280
 msgid "Action"
 msgstr "アクション"
 
-#: schematic/src/gschem_hotkey_dialog.c:277
 msgid "Keystroke(s)"
 msgstr ""
 
-#: schematic/src/gschem_log_widget.c:177
 msgid "** Invalid UTF-8 in log message. See stderr or gschem.log.\n"
 msgstr ""
 
-#: schematic/src/gschem_log_widget.c:434
 #, fuzzy
 msgid "Clear log window?"
 msgstr "ウィンドウを閉じています。\n"
 
-#: schematic/src/gschem_log_widget.c:477
 #, fuzzy
 msgid "Clear Log _Window"
 msgstr "新規ウィンドウ"
 
-#: schematic/src/gschem_macro_widget.c:231
 msgid "Macro:"
 msgstr ""
 
-#: schematic/src/gschem_macro_widget.c:387
 msgid "Evaluate"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:172
 #, fuzzy
 msgid "_Fill Type:"
 msgstr "塗りつぶし種類..."
 
-#: schematic/src/gschem_object_properties_widget.c:173
 #, fuzzy
 msgid "Lin_e Width:"
 msgstr "線種と幅..."
 
-#: schematic/src/gschem_object_properties_widget.c:174
 msgid "Angle _1:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:175
 msgid "P_itch 1:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:176
 msgid "Angle _2:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:177
 msgid "Pitc_h 2:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:237
 msgid "<b>Fill Properties</b>"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:255
-#: schematic/src/gschem_text_properties_widget.c:258
-#: schematic/src/x_newtext.c:271
 #, fuzzy
 msgid "Colo_r:"
 msgstr "色"
 
-#: schematic/src/gschem_object_properties_widget.c:266
 msgid "<b>General Properties</b>"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:284
 #, fuzzy
 msgid "_Type:"
 msgstr "塗りつぶし種類..."
 
-#: schematic/src/gschem_object_properties_widget.c:285
 #, fuzzy
 msgid "_Width:"
 msgstr "線種と幅..."
 
-#: schematic/src/gschem_object_properties_widget.c:286
 msgid "Dash _Length:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:287
 msgid "Dash _Space:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:288
 msgid "C_ap style:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:333
 msgid "<b>Line Properties</b>"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:351
 #, fuzzy
 msgid "_Pin Type:"
 msgstr "塗りつぶし種類..."
 
-#: schematic/src/gschem_object_properties_widget.c:362
 msgid "<b>Pin Properties</b>"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:217
 msgid "_Off"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:220
 msgid "_Dots"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:223
 msgid "M_esh"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:245
 #, fuzzy
 msgid "Net R_ubber Band Mode:"
 msgstr "ラバーバンド・オン\n"
 
-#: schematic/src/gschem_options_widget.c:246
 #, fuzzy
 msgid "_Magnetic Net Mode:"
 msgstr "ネットモード"
 
-#: schematic/src/gschem_options_widget.c:250
-#: schematic/src/gschem_options_widget.c:251
 msgid "Enabled"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:265
 msgid "<b>Net Options</b>"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:282
 #, fuzzy
 msgid "Grid Mode:"
 msgstr "円弧モード"
 
-#: schematic/src/gschem_options_widget.c:283
 #, fuzzy
 msgid "Snap Mode:"
 msgstr "パンモード"
 
-#: schematic/src/gschem_options_widget.c:284
 #, fuzzy
 msgid "_Snap Size:"
 msgstr "パンモード"
 
-#: schematic/src/gschem_options_widget.c:301
 msgid "<b>Snap Options</b>"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:340
 msgid "O_ff"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:343
 #, fuzzy
 msgid "_Grid"
 msgstr "グリッド・オフ\n"
 
-#: schematic/src/gschem_options_widget.c:346
 msgid "_Resnap"
 msgstr ""
 
-#: schematic/src/gschem_pin_type_combo.c:73
 msgid "Net pin"
 msgstr ""
 
-#: schematic/src/gschem_pin_type_combo.c:80
 msgid "Bus pin (graphical)"
 msgstr ""
 
-#: schematic/src/gschem_preview.c:195
 msgid "Preview Buffer"
 msgstr ""
 
-#: schematic/src/gschem_show_hide_text_widget.c:148
-#: schematic/src/x_window.c:1268
 msgid "Hide"
 msgstr ""
 
-#: schematic/src/gschem_show_hide_text_widget.c:157
-#: schematic/src/x_window.c:1269
 msgid "Hide text starting with:"
 msgstr "隠しテキスト"
 
-#: schematic/src/gschem_slot_edit_dialog.c:91
 msgid "Edit slot number"
 msgstr "スロット番号編集"
 
-#: schematic/src/gschem_slot_edit_dialog.c:121
 msgid "Number of Slots:"
 msgstr ""
 
-#: schematic/src/gschem_slot_edit_dialog.c:122
 #, fuzzy
 msgid "Slot Number:"
 msgstr "スロット番号編集"
 
-#: schematic/src/gschem_text_properties_widget.c:240
-#: schematic/src/x_newtext.c:265
 msgid "<b>Text Content</b>"
 msgstr ""
 
-#: schematic/src/gschem_text_properties_widget.c:259
-#: schematic/src/x_newtext.c:291
 msgid "_Size:"
 msgstr ""
 
-#: schematic/src/gschem_text_properties_widget.c:260
-#: schematic/src/x_newtext.c:310
 msgid "Ali_gnment:"
 msgstr ""
 
-#: schematic/src/gschem_text_properties_widget.c:261
-#: schematic/src/x_newtext.c:330
 #, fuzzy
 msgid "Ro_tation:"
 msgstr "回転"
 
-#: schematic/src/gschem_text_properties_widget.c:294
-#: schematic/src/x_newtext.c:253
 msgid "<b>Text Properties</b>"
 msgstr ""
 
-#: schematic/src/gschem_translate_widget.c:238
 #, fuzzy
 msgid "Coordinate:"
 msgstr "現在のウィンドウ"
 
-#: schematic/src/gschem_translate_widget.c:405 schematic/src/i_callbacks.c:800
 msgid "Translate"
 msgstr "転送"
 
-#: schematic/src/i_basic.c:64 schematic/src/x_window.c:1369
-#: schematic/scheme/conf/schematic/menu.scm:59
-#: schematic/scheme/gschem/builtins.scm:99
 msgid "Select Mode"
 msgstr "選択モード"
 
-#: schematic/src/i_basic.c:65
 #, fuzzy
 msgid "Select Box Mode"
 msgstr "選択モード"
 
-#: schematic/src/i_basic.c:66
 msgid "Text Mode"
 msgstr "ネットモード"
 
-#: schematic/src/i_basic.c:67
 msgid "Pan Mode"
 msgstr "パンモード"
 
-#: schematic/src/i_basic.c:70
 #, c-format
 msgid "Paste %d Mode"
 msgstr "ペースト%dモード"
 
-#: schematic/src/i_basic.c:74
 msgid "Magnetic Net Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:76
 msgid "Net Mode"
 msgstr "ネットモード"
 
-#: schematic/src/i_basic.c:77
 msgid "Arc Mode"
 msgstr "円弧モード"
 
-#: schematic/src/i_basic.c:78
 msgid "Box Mode"
 msgstr "ボックスモード"
 
-#: schematic/src/i_basic.c:79
 msgid "Bus Mode"
 msgstr "バスモード"
 
-#: schematic/src/i_basic.c:80
 msgid "Circle Mode"
 msgstr "円モード"
 
-#: schematic/src/i_basic.c:81
 msgid "Component Mode"
 msgstr "部品モード"
 
-#: schematic/src/i_basic.c:82 schematic/scheme/conf/schematic/menu.scm:62
-#: schematic/scheme/gschem/builtins.scm:114
 msgid "Copy Mode"
 msgstr "コピーモード"
 
-#: schematic/src/i_basic.c:83 schematic/scheme/conf/schematic/menu.scm:63
-#: schematic/scheme/gschem/builtins.scm:117
 msgid "Multiple Copy Mode"
 msgstr "複数コピーモード"
 
-#: schematic/src/i_basic.c:84
 msgid "Line Mode"
 msgstr "線モード"
 
-#: schematic/src/i_basic.c:85 schematic/scheme/conf/schematic/menu.scm:66
-#: schematic/scheme/gschem/builtins.scm:123
 msgid "Mirror Mode"
 msgstr "反転モード"
 
-#: schematic/src/i_basic.c:86 schematic/scheme/conf/schematic/menu.scm:64
-#: schematic/scheme/gschem/builtins.scm:111
 msgid "Move Mode"
 msgstr "移動モード"
 
-#: schematic/src/i_basic.c:87
 #, fuzzy
 msgid "Path Mode"
 msgstr "パンモード"
 
-#: schematic/src/i_basic.c:88
 msgid "Picture Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:89
 msgid "Pin Mode"
 msgstr "ピンモード"
 
-#: schematic/src/i_basic.c:90 schematic/scheme/gschem/builtins.scm:120
 msgid "Rotate Mode"
 msgstr "回転モード"
 
-#: schematic/src/i_basic.c:91
 #, fuzzy
 msgid "Modify Mode"
 msgstr "コピーモード"
 
-#: schematic/src/i_basic.c:92 schematic/src/x_menus.c:49
-#: schematic/scheme/gschem/builtins.scm:204
 msgid "Zoom Box"
 msgstr "拡大"
 
-#: schematic/src/i_basic.c:121
 msgid "Show Hidden"
 msgstr "隠しテキスト表示"
 
-#: schematic/src/i_basic.c:124
 msgid "Snap Off"
 msgstr "スナップ・オフ"
 
-#: schematic/src/i_basic.c:126
 msgid "Resnap Active"
 msgstr ""
 
-#: schematic/src/i_basic.c:288 schematic/src/x_colorcb.c:159
 msgid "Stroke"
 msgstr "ストローク"
 
-#: schematic/src/i_basic.c:296 schematic/src/i_basic.c:330
-#: schematic/src/x_window.c:1361
 msgid "none"
 msgstr "なし"
 
-#: schematic/src/i_basic.c:304
 msgid "Repeat/"
 msgstr "繰り返し/"
 
-#: schematic/src/i_basic.c:315
 msgid "Repeat/none"
 msgstr "繰り返し/なし"
 
-#: schematic/src/i_basic.c:323 schematic/src/i_callbacks.c:1239
-#: schematic/scheme/gschem/builtins.scm:189
 msgid "Pan"
 msgstr "パン"
 
-#: schematic/src/i_callbacks.c:74
 #, c-format
 msgid "New page created [%1$s]"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:108
 #, c-format
 msgid "New Window created [%1$s]"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:245
 msgid "Failed to Save All"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:247
 msgid "Saved All"
 msgstr "すべて保存"
 
-#: schematic/src/i_callbacks.c:308
 #, fuzzy
 msgid "Closing Window"
 msgstr "ウィンドウを閉じています。\n"
 
-#: schematic/src/i_callbacks.c:505 schematic/src/x_menus.c:55
-#: schematic/scheme/gschem/builtins.scm:168
 msgid "Copy"
 msgstr "コピー"
 
-#: schematic/src/i_callbacks.c:514 schematic/src/i_callbacks.c:539
-#: schematic/src/i_callbacks.c:564
 msgid "Select objs first"
 msgstr "まずオブジェクトを選択してください。"
 
-#: schematic/src/i_callbacks.c:530
 msgid "Multiple Copy"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:555 schematic/src/x_menus.c:56
 msgid "Move"
 msgstr "移動"
 
-#: schematic/src/i_callbacks.c:579 schematic/src/x_menus.c:57
-#: schematic/src/x_multiattrib.c:1656 schematic/scheme/gschem/builtins.scm:108
 msgid "Delete"
 msgstr "削除"
 
-#: schematic/src/i_callbacks.c:603
 msgid "Edit"
 msgstr "編集"
 
-#: schematic/src/i_callbacks.c:618 schematic/scheme/gschem/builtins.scm:129
 msgid "Edit Text"
 msgstr "テキスト編集"
 
-#: schematic/src/i_callbacks.c:637
 msgid "Slot"
 msgstr "スロット"
 
-#: schematic/src/i_callbacks.c:688 schematic/src/i_callbacks.c:698
 msgid "Rotate"
 msgstr "回転"
 
-#: schematic/src/i_callbacks.c:736 schematic/src/i_callbacks.c:746
 msgid "Mirror"
 msgstr "反転"
 
-#: schematic/src/i_callbacks.c:763 schematic/src/x_colorcb.c:160
-#: schematic/scheme/conf/schematic/menu.scm:73
-#: schematic/scheme/gschem/builtins.scm:141
 msgid "Lock"
 msgstr "ロック"
 
-#: schematic/src/i_callbacks.c:781 schematic/scheme/conf/schematic/menu.scm:74
-#: schematic/scheme/gschem/builtins.scm:144
 msgid "Unlock"
 msgstr "ロック解除"
 
-#: schematic/src/i_callbacks.c:805
 #, fuzzy
 msgid "WARNING: Do not translate with snap off!"
 msgstr "警告:スナップ・オフで転送しないでください!\n"
 
-#: schematic/src/i_callbacks.c:806
 #, fuzzy
 msgid "WARNING: Turning snap on and continuing with translate."
 msgstr "警告:スナップをオンしてから転送してください。\n"
 
-#: schematic/src/i_callbacks.c:813
 #, fuzzy
 msgid "WARNING: Snap grid size is not equal to 100!"
 msgstr "警告:グリッドサイズが100ではありません!\n"
 
-#: schematic/src/i_callbacks.c:815
 #, fuzzy
 msgid ""
 "WARNING: If you are translating a symbol to the origin, the snap grid size "
@@ -906,23 +684,18 @@ msgstr ""
 "警告:原点へ転送するときはスナップのグリッドサイズを\n"
 "100に設定してください。\n"
 
-#: schematic/src/i_callbacks.c:847
 msgid "Embed"
 msgstr "組み込み"
 
-#: schematic/src/i_callbacks.c:886
 msgid "Unembed"
 msgstr "組み込み解除"
 
-#: schematic/src/i_callbacks.c:928
 msgid "Update"
 msgstr "更新"
 
-#: schematic/src/i_callbacks.c:970
 msgid "ShowHidden"
 msgstr "隠しテキスト表示"
 
-#: schematic/src/i_callbacks.c:1537
 #, c-format
 msgid ""
 "<b>Revert page:</b>\n"
@@ -933,99 +706,77 @@ msgid ""
 "discarded and page file will be reloaded from disk."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1555
 #, fuzzy
 msgid "Revert"
 msgstr "再読み込み(_R)"
 
-#: schematic/src/i_callbacks.c:1647
 msgid "Copy to clipboard"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1664
 msgid "Cut to clipboard"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1686
 msgid "Paste from clipboard"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1694
 msgid "Empty clipboard"
 msgstr ""
 
 #. TRANSLATORS: The number is the number of the buffer that the
 #. * selection is being copied to.
-#: schematic/src/i_callbacks.c:1719
 #, fuzzy, c-format
 msgid "Copy %i"
 msgstr "コピー1"
 
 #. TRANSLATORS: The number is the number of the buffer that the
 #. * selection is being cut to.
-#: schematic/src/i_callbacks.c:1746
 #, fuzzy, c-format
 msgid "Cut %i"
 msgstr "カット1"
 
 #. TRANSLATORS: The number is the number of the buffer that is being
 #. * pasted to the schematic.
-#: schematic/src/i_callbacks.c:1776
 #, fuzzy, c-format
 msgid "Paste %i"
 msgstr "ペースト1"
 
-#: schematic/src/i_callbacks.c:1785
 msgid "Empty buffer"
 msgstr "バッファが空です。"
 
-#: schematic/src/i_callbacks.c:1833 schematic/src/x_window.c:1203
 msgid "Component"
 msgstr "部品"
 
-#: schematic/src/i_callbacks.c:1865 schematic/src/x_colorcb.c:150
 msgid "Attribute"
 msgstr "アトリビュート"
 
-#: schematic/src/i_callbacks.c:1885 schematic/src/x_colorcb.c:149
 msgid "Net"
 msgstr "ネット"
 
-#: schematic/src/i_callbacks.c:1928 schematic/src/x_colorcb.c:155
-#: schematic/src/x_window.c:1222
 msgid "Bus"
 msgstr "バス"
 
-#: schematic/src/i_callbacks.c:2004
 msgid "Line"
 msgstr "線"
 
-#: schematic/src/i_callbacks.c:2021
 msgid "Path"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2043
 msgid "Box"
 msgstr "ボックス"
 
-#: schematic/src/i_callbacks.c:2085
 msgid "Circle"
 msgstr "円"
 
-#: schematic/src/i_callbacks.c:2108
 msgid "Arc"
 msgstr "円弧"
 
-#: schematic/src/i_callbacks.c:2131 schematic/src/x_colorcb.c:146
 msgid "Pin"
 msgstr "ピン"
 
-#: schematic/src/i_callbacks.c:2191
 #, fuzzy, c-format
 msgid "Searching for source [%1$s]"
 msgstr "ソース検索中[%s]\n"
 
-#: schematic/src/i_callbacks.c:2223
 #, c-format
 msgid ""
 "Failed to descend hierarchy into '%1$s': %2$s\n"
@@ -1033,114 +784,89 @@ msgid ""
 "The lepton-schematic log may contain more information."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2227
 #, fuzzy, c-format
 msgid "Failed to descend into '%1$s': %2$s"
 msgstr "初期化scmファイルの読み込みに失敗。[%s]\n"
 
-#: schematic/src/i_callbacks.c:2234
 #, fuzzy
 msgid "Failed to descend hierarchy."
 msgstr "下の階層も検索"
 
-#: schematic/src/i_callbacks.c:2312
 #, fuzzy, c-format
 msgid "Searching for symbol [%1$s]"
 msgstr "シンボル検索中[%s]\n"
 
-#: schematic/src/i_callbacks.c:2320
 msgid "Symbol is not a real file. Symbol cannot be loaded."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2367 schematic/src/x_tabs.c:1060
 msgid "Cannot find any schematics above the current one!"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2400
 msgid "Attach"
 msgstr "アタッチ"
 
-#: schematic/src/i_callbacks.c:2456
 msgid "Detach"
 msgstr "アタッチ解除"
 
-#: schematic/src/i_callbacks.c:2500
 msgid "ShowN"
 msgstr "N表示"
 
-#: schematic/src/i_callbacks.c:2537
 msgid "ShowV"
 msgstr "表示V"
 
-#: schematic/src/i_callbacks.c:2574
 msgid "ShowB"
 msgstr "表示B"
 
-#: schematic/src/i_callbacks.c:2612
 msgid "VisToggle"
 msgstr "表示切替え"
 
-#: schematic/src/i_callbacks.c:2643
 #, c-format
 msgid "Sorry but this is a non-functioning menu option\n"
 msgstr "機能しないメニューオプションです。\n"
 
-#: schematic/src/i_callbacks.c:2703
 msgid "Action feedback mode set to OUTLINE"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2706
 msgid "Action feedback mode set to BOUNDINGBOX"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2730
 #, fuzzy
 msgid "Grid OFF"
 msgstr "グリッド・オフ\n"
 
-#: schematic/src/i_callbacks.c:2731
 msgid "Dot grid selected"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2732
 msgid "Mesh grid selected"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2733
 msgid "Invalid grid mode"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2755
 #, fuzzy
 msgid "Snap OFF (CAUTION!)"
 msgstr "スナップ・オフ(注意!)\n"
 
-#: schematic/src/i_callbacks.c:2758
 #, fuzzy
 msgid "Snap ON"
 msgstr "スナップ・オン\n"
 
-#: schematic/src/i_callbacks.c:2761
 #, fuzzy
 msgid "Snap back to the grid (CAUTION!)"
 msgstr "スナップ・オフ(注意!)\n"
 
-#: schematic/src/i_callbacks.c:2790
 #, fuzzy
 msgid "Rubber band ON"
 msgstr "ラバーバンド・オン\n"
 
-#: schematic/src/i_callbacks.c:2792
 #, fuzzy
 msgid "Rubber band OFF"
 msgstr "ラバーバンド・オフ \n"
 
-#: schematic/src/i_callbacks.c:2811
 #, fuzzy
 msgid "magnetic net mode: ON"
 msgstr "ネットモード"
 
-#: schematic/src/i_callbacks.c:2814
 #, fuzzy
 msgid "magnetic net mode: OFF"
 msgstr "ネットモード"
@@ -1150,140 +876,111 @@ msgstr "ネットモード"
 #. the form "untitled_N.sch", where N is a number.  Please make
 #. sure that the translation contains characters suitable for use
 #. in a filename.
-#: schematic/src/i_vars.c:209
 msgid "untitled"
 msgstr ""
 
-#: schematic/src/o_complex.c:192 schematic/src/o_complex.c:195
 #, fuzzy, c-format
 msgid "Translating schematic [%1$d %2$d]"
 msgstr "スケマチックを転送しています。[%d %d]\n"
 
-#: schematic/src/o_delete.c:82
 #, c-format
 msgid "Delete locked object?"
 msgid_plural "Delete %1$u locked objects?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/o_misc.c:55
 #, c-format
 msgid "Got an unexpected NULL in o_edit\n"
 msgstr ""
 
-#: schematic/src/o_misc.c:315
 #, fuzzy
 msgid "Hidden text is now visible"
 msgstr "隠しテキストが表示されました。\n"
 
-#: schematic/src/o_misc.c:317
 #, fuzzy
 msgid "Hidden text is now invisible"
 msgstr "隠しテキストが非表示になりました。\n"
 
-#: schematic/src/o_misc.c:425
 #, c-format
 msgid "Could not find symbol [%1$s] in library. Update failed."
 msgstr ""
 
-#: schematic/src/o_misc.c:541
 #, c-format
 msgid "o_autosave_backups: Can't get the real filename of %1$s."
 msgstr ""
 
-#: schematic/src/o_misc.c:585
 #, c-format
 msgid "Could NOT set previous backup file [%1$s] read-write"
 msgstr ""
 
-#: schematic/src/o_misc.c:605
 #, c-format
 msgid "Could NOT set backup file [%1$s] readonly"
 msgstr ""
 
-#: schematic/src/o_misc.c:610
 #, c-format
 msgid "Could NOT save backup file [%1$s]"
 msgstr ""
 
-#: schematic/src/o_move.c:192
 #, c-format
 msgid "ERROR: NULL object in o_move_end!\n"
 msgstr ""
 
-#: schematic/src/o_move.c:519
 #, c-format
 msgid "DOH! tried to find the whichone, but didn't find it!\n"
 msgstr ""
 
-#: schematic/src/o_move.c:546
 #, c-format
 msgid "Got a non line object in o_move_check_endpoint\n"
 msgstr ""
 
-#: schematic/src/o_net.c:444
 msgid "Warning: Starting net at off grid coordinate"
 msgstr ""
 
-#: schematic/src/o_net.c:508
 msgid "Warning: Ending net at off grid coordinate"
 msgstr ""
 
-#: schematic/src/o_net.c:856 schematic/src/o_net.c:893
-#: schematic/src/o_net.c:964 schematic/src/o_net.c:1000
 #, c-format
 msgid "Tried to add more than two bus rippers. Internal gschem error.\n"
 msgstr ""
 
-#: schematic/src/o_net.c:1068
 #, c-format
 msgid "Bus ripper symbol [%1$s] was not found in any component library"
 msgstr ""
 
-#: schematic/src/o_picture.c:133 schematic/src/o_picture.c:343
 msgid "Select a picture file..."
 msgstr ""
 
-#: schematic/src/o_picture.c:166
 #, fuzzy, c-format
 msgid "Failed to load picture: %1$s"
 msgstr "初期化scmファイルの読み込みに失敗。[%s]\n"
 
-#: schematic/src/o_picture.c:182
 msgid "Picture"
 msgstr ""
 
-#: schematic/src/o_picture.c:378
 #, c-format
 msgid "Failed to replace pictures: %s"
 msgstr ""
 
-#: schematic/src/o_slot.c:80
 #, fuzzy
 msgid "Slot attribute malformed"
 msgstr "スロットアトリビュートが変です。\n"
 
-#: schematic/src/o_slot.c:88
 #, fuzzy
 msgid "numslots attribute missing"
 msgstr "スロット番号がありません。\n"
 
-#: schematic/src/o_slot.c:89
 #, fuzzy
 msgid "Slotting not allowed for this component"
 msgstr "この部品にスロットは許可されていません。\n"
 
-#: schematic/src/o_slot.c:104
 #, fuzzy
 msgid "New slot number out of range"
 msgstr "スロット番号が範囲を越えています。\n"
 
-#: schematic/src/o_undo.c:397
 #, fuzzy
 msgid "Undo/Redo disabled in rc file"
 msgstr "アンドゥ/リドゥはrcファイルで無効に設定されています。\n"
 
-#: schematic/src/parsecmd.c:77
 #, c-format
 msgid ""
 "Usage: %1$s [OPTION ...] [--] [FILE ...]\n"
@@ -1308,190 +1005,146 @@ msgid ""
 "gEDA/gaf homepage: <http://www.geda-project.org/>\n"
 msgstr ""
 
-#: schematic/src/parsecmd.c:110
 #, c-format
 msgid ""
 "Lepton EDA %1$s (git: %2$.7s)\n"
 "Copyright (C) 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright (C) 2017-2018 Lepton Developers.\n"
+"Copyright (C) 2017-2019 Lepton Developers.\n"
 "This is free software, and you are welcome to redistribute it under\n"
 "certain conditions. For details, see the file `COPYING', which is\n"
 "included in the Lepton EDA distribution.\n"
 "There is NO WARRANTY, to the extent permitted by law.\n"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:125
 #, c-format
 msgid "Got invalid show option; defaulting to show both\n"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:139
 #, c-format
 msgid "ERROR: NULL object!\n"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:328
 msgid "Single Attribute Editor"
 msgstr "シングルアトルビュートエディタ"
 
-#: schematic/src/x_attribedit.c:358
 msgid "<b>Edit Attribute</b>"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:360
 msgid "<b>Add Attribute</b>"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:376
 #, fuzzy
 msgid "N_ame:"
 msgstr "名前:"
 
-#: schematic/src/x_attribedit.c:396 schematic/src/x_multiattrib.c:2222
 #, fuzzy
 msgid "_Value:"
 msgstr "値:"
 
-#: schematic/src/x_attribedit.c:415 schematic/src/x_multiattrib.c:2281
 #, fuzzy
 msgid "Vi_sible"
 msgstr "表示"
 
-#: schematic/src/x_attribedit.c:434
 msgid "Show Value Only"
 msgstr "値のみ表示"
 
-#: schematic/src/x_attribedit.c:436
 msgid "Show Name Only"
 msgstr "名前のみ表示"
 
-#: schematic/src/x_attribedit.c:438 schematic/src/x_multiattrib.c:1620
-#: schematic/scheme/gschem/builtins.scm:324
 msgid "Show Name & Value"
 msgstr "名前と値を表示"
 
-#: schematic/src/x_attribedit.c:445
 msgid "<b>Attach Options</b>"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:460
 msgid "All"
 msgstr "すべて"
 
-#: schematic/src/x_attribedit.c:476 schematic/src/x_compselect.c:986
-#: schematic/src/x_compselect.c:1100
 msgid "Components"
 msgstr "部品"
 
-#: schematic/src/x_attribedit.c:492 schematic/src/x_window.c:1214
 msgid "Nets"
 msgstr "ネット"
 
-#: schematic/src/x_attribedit.c:508
 msgid "Replace existing attributes"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:412
 msgid ""
 "slotted object without slot attribute may cause problems when autonumbering "
 "slots"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:427
 #, c-format
 msgid ""
 "duplicate slot may cause problems: [symbolname=%1$s, number=%2$d, slot=%3$d]"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:675
 msgid "No searchstring given in autonumber text."
 msgstr ""
 
-#: schematic/src/x_autonumber.c:728
 msgid "No '*' or '?' given at the end of the autonumber text."
 msgstr ""
 
-#: schematic/src/x_autonumber.c:873
 msgid "Diagonal"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:874
 msgid "Top to bottom"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:875
 msgid "Bottom to top"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:876
 msgid "Left to right"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:877
 msgid "Right to left"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:878
 msgid "File order"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1214
 msgid "Autonumber text"
 msgstr "オートナンバーテキスト"
 
-#: schematic/src/x_autonumber.c:1237
 msgid "<b>Scope</b>"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1259
 msgid "Search for:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1273
 msgid "Autonumber text in:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1280
 msgid "Skip numbers found in:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1292 schematic/src/x_autonumber.c:1301
 msgid "Selected objects"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1293 schematic/src/x_autonumber.c:1302
 msgid "Current page"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1294 schematic/src/x_autonumber.c:1303
 msgid "Whole hierarchy"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1305
 msgid "Overwrite existing numbers"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1310
 msgid "<b>Options</b>"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1332
 msgid "Starting number:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1339
 msgid "Sort order:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1371
 msgid "Remove numbers"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1375
 msgid "Automatic slotting"
 msgstr ""
 
-#: schematic/src/x_clipboard.c:245
 #, c-format
 msgid ""
 "<b>Invalid schematic on clipboard.</b>\n"
@@ -1499,175 +1152,135 @@ msgid ""
 "An error occurred while inserting clipboard data: %s."
 msgstr ""
 
-#: schematic/src/x_clipboard.c:247
 msgid "Clipboard insertion failed"
 msgstr ""
 
-#: schematic/src/x_color.c:89 schematic/src/x_color.c:98
 #, fuzzy, c-format
 msgid "Could not allocate the color %1$s!\n"
 msgstr "指定できない色[%s]です!\n"
 
-#: schematic/src/x_color.c:89
 msgid "black"
 msgstr "黒"
 
-#: schematic/src/x_color.c:98
 msgid "white"
 msgstr "白"
 
-#: schematic/src/x_color.c:120
 #, fuzzy, c-format
 msgid "Could not allocate display color %1$i!\n"
 msgstr "指定できない色[%s]です!\n"
 
-#: schematic/src/x_color.c:142
 #, fuzzy, c-format
 msgid "Could not allocate outline color %1$i!\n"
 msgstr "指定できない色[%s]です!\n"
 
-#: schematic/src/x_color.c:159
 #, fuzzy, c-format
 msgid "Tried to get an invalid color: %1$d\n"
 msgstr "無効な色の指定です。 : %d\n"
 
-#: schematic/src/x_colorcb.c:145
 msgid "Background"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:147
 msgid "Net endpoint"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:148
 msgid "Graphic"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:151
 msgid "Logic bubble"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:152
 msgid "Grid point"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:153
 #, fuzzy
 msgid "Detached attribute"
 msgstr "アトリビュート編集"
 
-#: schematic/src/x_colorcb.c:156
 #, fuzzy
 msgid "Selection"
 msgstr "選択"
 
-#: schematic/src/x_colorcb.c:157
 msgid "Bounding box"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:158
 #, fuzzy
 msgid "Zoom box"
 msgstr "拡大"
 
-#: schematic/src/x_colorcb.c:161
 msgid "Output background"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:162
 msgid "Freestyle 1"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:163
 msgid "Freestyle 2"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:164
 msgid "Freestyle 3"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:165
 msgid "Freestyle 4"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:166
 msgid "Net junction"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:167
 msgid "Mesh grid major"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:168
 msgid "Mesh grid minor"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:172
 msgid "Unknown"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1169
 #, fuzzy
 msgid "Reset filter"
 msgstr "新規ファイル"
 
-#: schematic/src/x_compselect.c:1192
 msgid "Reload all libraries"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1245 schematic/src/x_multiattrib.c:2092
 msgid "Value"
 msgstr "値"
 
-#: schematic/src/x_compselect.c:1284
 msgid "Default behavior - reference component"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1287
 msgid "Embed component in schematic"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1290
 msgid "Include component as individual objects"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1448
 msgid "Select Component..."
 msgstr "部品選択..."
 
-#: schematic/src/x_compselect.c:1471
 msgid "In Us_e"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1475
 #, fuzzy
 msgid "Lib_raries"
 msgstr "ライブラリ"
 
-#: schematic/src/x_compselect.c:1484 schematic/src/x_fileselect.c:119
 msgid "Preview"
 msgstr "プレビュー"
 
-#: schematic/src/x_compselect.c:1510
 msgid "Attributes"
 msgstr "アトリビュート"
 
-#: schematic/src/x_dialog.c:325
 msgid "Major symbol changes detected."
 msgstr ""
 
-#: schematic/src/x_dialog.c:349
 msgid ""
 "Changes have occurred to the symbols shown below.\n"
 "\n"
 "Be sure to verify each of these symbols."
 msgstr ""
 
-#: schematic/src/x_dialog.c:369
 msgid "Symbol"
 msgstr ""
 
-#: schematic/src/x_dialog.c:406
 #, c-format
 msgid ""
 "<span weight=\"bold\" size=\"larger\">The input attribute \"%s\" is invalid\n"
@@ -1678,39 +1291,30 @@ msgid ""
 "The value cannot start with a space."
 msgstr ""
 
-#: schematic/src/x_dialog.c:408
 msgid "Invalid Attribute"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:37
 msgid "Schematics"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:42
 msgid "Symbols"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:47
 msgid "Schematics and symbols"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:53
 msgid "All files"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:169
 msgid "Open..."
 msgstr "開く..."
 
-#: schematic/src/x_fileselect.c:233
 msgid "Save as..."
 msgstr ""
 
-#: schematic/src/x_fileselect.c:297
 msgid "Save cancelled on user request"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:334
 msgid ""
 "\n"
 "If you load the original file, the backup file will be overwritten in the "
@@ -1719,28 +1323,22 @@ msgid ""
 "Do you want to load the backup file?\n"
 msgstr ""
 
-#: schematic/src/x_fstylecb.c:73
 msgid "Hollow"
 msgstr "空洞"
 
-#: schematic/src/x_fstylecb.c:80
 msgid "Filled"
 msgstr "塗りつぶし"
 
-#: schematic/src/x_fstylecb.c:87
 msgid "Mesh"
 msgstr "メッシュ"
 
-#: schematic/src/x_fstylecb.c:94
 msgid "Hatch"
 msgstr "ハッチ"
 
-#: schematic/src/x_image.c:279
 #, c-format
 msgid "x_image_lowlevel: Unable to write %1$s file %2$s."
 msgstr ""
 
-#: schematic/src/x_image.c:289
 #, c-format
 msgid ""
 "There was the following error when saving image with type %1$s to filename:\n"
@@ -1749,302 +1347,235 @@ msgid ""
 "%3$s.\n"
 msgstr ""
 
-#: schematic/src/x_image.c:309
 #, fuzzy, c-format
 msgid "Wrote color image to [%1$s] [%2$d x %3$d]"
 msgstr "カラーイメージを出力しました。[%s] [%d x %d]\n"
 
-#: schematic/src/x_image.c:311
 #, fuzzy, c-format
 msgid "Wrote black and white image to [%1$s] [%2$d x %3$d]"
 msgstr "白黒イメージを出力しました。[%s] [%d x %d]\n"
 
-#: schematic/src/x_image.c:319
 msgid "x_image_lowlevel: Unable to get pixbuf from gschem's window."
 msgstr ""
 
-#: schematic/src/x_image.c:358
 msgid "Width x Height"
 msgstr ""
 
-#: schematic/src/x_image.c:374
 msgid "Image type"
 msgstr ""
 
-#: schematic/src/x_image.c:395
 msgid "Write image..."
 msgstr ""
 
-#: schematic/src/x_linecapcb.c:74
 msgid "Butt"
 msgstr ""
 
-#: schematic/src/x_linecapcb.c:81
 msgid "Square"
 msgstr ""
 
-#: schematic/src/x_linecapcb.c:88
 msgid "Round"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:74
 msgid "Solid"
 msgstr "実線"
 
-#: schematic/src/x_linetypecb.c:81
 msgid "Dotted"
 msgstr "点線"
 
-#: schematic/src/x_linetypecb.c:88
 msgid "Dashed"
 msgstr "破線"
 
-#: schematic/src/x_linetypecb.c:95
 msgid "Center"
 msgstr "中央"
 
-#: schematic/src/x_linetypecb.c:102
 msgid "Phantom"
 msgstr "ファントム"
 
-#: schematic/src/x_menus.c:41 schematic/scheme/gschem/builtins.scm:267
 #, fuzzy
 msgid "Add Net"
 msgstr "テキスト追加..."
 
-#: schematic/src/x_menus.c:42 schematic/src/x_multiattrib.c:2187
-#: schematic/scheme/gschem/builtins.scm:264
 msgid "Add Attribute"
 msgstr ""
 
-#: schematic/src/x_menus.c:43 schematic/scheme/gschem/builtins.scm:261
 #, fuzzy
 msgid "Add Component"
 msgstr "部品"
 
-#: schematic/src/x_menus.c:44 schematic/scheme/gschem/builtins.scm:270
 msgid "Add Bus"
 msgstr ""
 
-#: schematic/src/x_menus.c:45 schematic/scheme/gschem/builtins.scm:273
 #, fuzzy
 msgid "Add Text"
 msgstr "テキスト追加..."
 
-#: schematic/src/x_menus.c:47 schematic/scheme/gschem/builtins.scm:210
 #, fuzzy
 msgid "Zoom In"
 msgstr "拡大(_I)"
 
-#: schematic/src/x_menus.c:48 schematic/scheme/gschem/builtins.scm:213
 #, fuzzy
 msgid "Zoom Out"
 msgstr "縮小(_O)"
 
-#: schematic/src/x_menus.c:50 schematic/scheme/gschem/builtins.scm:207
 #, fuzzy
 msgid "Zoom Extents"
 msgstr "回路全体の表示(_E)"
 
-#: schematic/src/x_menus.c:52 schematic/src/x_window.c:1233
 msgid "Select"
 msgstr "選択"
 
-#: schematic/src/x_menus.c:53 schematic/scheme/conf/schematic/menu.scm:69
-#: schematic/scheme/gschem/builtins.scm:126
 msgid "Edit..."
 msgstr "編集..."
 
-#: schematic/src/x_menus.c:54 schematic/scheme/conf/schematic/menu.scm:68
 msgid "Object Properties..."
 msgstr ""
 
-#: schematic/src/x_menus.c:59 schematic/scheme/gschem/builtins.scm:300
 msgid "Down Schematic"
 msgstr ""
 
-#: schematic/src/x_menus.c:60 schematic/scheme/gschem/builtins.scm:303
 msgid "Down Symbol"
 msgstr ""
 
-#: schematic/src/x_menus.c:61
 msgid "Up"
 msgstr ""
 
-#: schematic/src/x_menus.c:336
 #, c-format
 msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
 msgstr ""
 
-#: schematic/src/x_menus.c:360
 #, c-format
 msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
 msgstr ""
 
-#: schematic/src/x_misc.c:70
 msgid "The operating system is out of memory or resources."
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:798 schematic/src/x_multiattrib.c:2704
 msgid "<various>"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:930
 msgid "Attributes with empty name are not allowed. Please set a name."
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1622
 msgid "Show Value only"
 msgstr "値のみ表示"
 
-#: schematic/src/x_multiattrib.c:1624
 msgid "Show Name only"
 msgstr "名前のみ表示"
 
-#: schematic/src/x_multiattrib.c:1651
 msgid "Promote"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1655
 msgid "Duplicate"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1657
 #, fuzzy
 msgid "Copy to all"
 msgstr "コピー1"
 
-#: schematic/src/x_multiattrib.c:1986 schematic/src/x_multiattrib.c:2602
 msgid "Edit Attributes"
 msgstr "アトリビュート編集"
 
-#: schematic/src/x_multiattrib.c:2112
 msgid "Vis?"
 msgstr "表示"
 
-#: schematic/src/x_multiattrib.c:2130
 msgid "N"
 msgstr "名前"
 
-#: schematic/src/x_multiattrib.c:2148
 msgid "V"
 msgstr "値"
 
-#: schematic/src/x_multiattrib.c:2170
 #, fuzzy
 msgid "Sho_w inherited attributes"
 msgstr "アトリビュート編集"
 
-#: schematic/src/x_multiattrib.c:2197
 #, fuzzy
 msgid "_Name:"
 msgstr "名前:"
 
-#: schematic/src/x_multiattrib.c:2241
 msgid "Ctrl+Enter inserts new line; Ctrl+Tab inserts Tab"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2618
 #, c-format
 msgid "%2$i symbol (%1$s)"
 msgid_plural "%2$i symbols (%1$s)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2624
 #, c-format
 msgid "%1$i pin"
 msgid_plural "%1$i pins"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2630
 #, c-format
 msgid "%1$i net"
 msgid_plural "%1$i nets"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2636
 #, c-format
 msgid "%1$i bus"
 msgid_plural "%1$i buses"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2642
 #, fuzzy, c-format
 msgid "%1$i attribute"
 msgid_plural "%1$i attributes"
 msgstr[0] "アトリビュート"
 msgstr[1] "アトリビュート"
 
-#: schematic/src/x_newtext.c:433
 msgid "Text Entry..."
 msgstr "テキスト..."
 
-#: schematic/src/x_pagesel.c:253
 msgid "New Page"
 msgstr "新規ページ"
 
-#: schematic/src/x_pagesel.c:254
 msgid "Open Page..."
 msgstr "開く..."
 
-#: schematic/src/x_pagesel.c:256
 msgid "Save Page"
 msgstr "保存"
 
-#: schematic/src/x_pagesel.c:257 schematic/scheme/gschem/builtins.scm:246
 msgid "Close Page"
 msgstr "閉じる"
 
-#: schematic/src/x_pagesel.c:376 schematic/scheme/gschem/builtins.scm:237
 msgid "Page Manager"
 msgstr "ページマネージャ"
 
-#: schematic/src/x_pagesel.c:448
 msgid "Changed"
 msgstr ""
 
-#: schematic/src/x_pagesel.c:468
 msgid "Right click on the filename for more options..."
 msgstr ""
 
-#: schematic/src/x_print.c:306
 #, fuzzy, c-format
 msgid "Failed to write PDF to '%s': %s\n"
 msgstr "初期化scmファイルの読み込みに失敗。[%s]\n"
 
-#: schematic/src/x_print.c:364
 #, fuzzy, c-format
 msgid "Failed to write PDF to '%1$s': %2$s\n"
 msgstr "初期化scmファイルの読み込みに失敗。[%s]\n"
 
-#: schematic/src/x_print.c:449
 #, c-format
 msgid ""
 "Error printing file:\n"
 "%1$s"
 msgstr ""
 
-#: schematic/src/x_rc.c:39
 msgid "ERROR: An unknown error occurred while parsing configuration files."
 msgstr ""
 
-#: schematic/src/x_rc.c:44
 msgid ""
 "An unknown error occurred while parsing configuration files.\n"
 "\n"
 "The lepton-schematic log may contain more information."
 msgstr ""
 
-#: schematic/src/x_rc.c:56
 #, c-format
 msgid "ERROR: %1$s"
 msgstr ""
 
-#: schematic/src/x_rc.c:59
 #, c-format
 msgid ""
 "%1$s\n"
@@ -2052,140 +1583,109 @@ msgid ""
 "The lepton-schematic log may contain more information."
 msgstr ""
 
-#: schematic/src/x_rc.c:67
 msgid "Cannot load lepton-schematic configuration."
 msgstr ""
 
-#: schematic/src/x_script.c:42 schematic/scheme/conf/schematic/menu.scm:40
 msgid "Execute Script..."
 msgstr "スクリプト実行..."
 
-#: schematic/src/x_script.c:61
 #, fuzzy, c-format
 msgid "Executing guile script [%1$s]"
 msgstr "guileスクリプトを実行しています。[%s]\n"
 
-#: schematic/src/x_tabs.c:860
 #, fuzzy, c-format
 msgid "Hierarchy up: %s"
 msgstr "階層"
 
-#: schematic/src/x_tabs.c:863
 #, fuzzy
 msgid "Hierarchy up"
 msgstr "階層"
 
-#: schematic/src/x_widgets.c:158 schematic/src/x_window.c:1444
 #, fuzzy
 msgid "Options"
 msgstr "オプション"
 
-#: schematic/src/x_widgets.c:203 schematic/src/x_window.c:1436
 msgid "Object"
 msgstr ""
 
-#: schematic/src/x_widgets.c:224
 msgid "Log"
 msgstr ""
 
-#: schematic/src/x_widgets.c:245 schematic/src/x_window.c:1466
 msgid "Find Text"
 msgstr ""
 
-#: schematic/src/x_widgets.c:259
 #, fuzzy
 msgid "Color Scheme Editor"
 msgstr "明るい配色(_L)"
 
-#: schematic/src/x_widgets.c:272 schematic/scheme/gschem/builtins.scm:378
 #, fuzzy
 msgid "Select Schematic Font"
 msgstr "選択"
 
-#: schematic/src/x_window.c:763
 #, fuzzy, c-format
 msgid "Loading schematic [%1$s]"
 msgstr "スケマチックを読み込んでいます。[%s]\n"
 
-#: schematic/src/x_window.c:864
 #, c-format
 msgid "Could NOT save page [%1$s]\n"
 msgstr ""
 
-#: schematic/src/x_window.c:865
 msgid "Error while trying to save"
 msgstr "保存中にエラー発生"
 
-#: schematic/src/x_window.c:875
 msgid "Failed to save file"
 msgstr ""
 
-#: schematic/src/x_window.c:885
 #, fuzzy, c-format
 msgid "Saved as [%1$s]"
 msgstr "保存しました。[%s]\n"
 
-#: schematic/src/x_window.c:887
 #, fuzzy, c-format
 msgid "Saved [%1$s]"
 msgstr "保存しました。[%s]\n"
 
-#: schematic/src/x_window.c:889
 msgid "Saved"
 msgstr "保存しました。"
 
-#: schematic/src/x_window.c:966
 #, fuzzy, c-format
 msgid "Discarding page [%1$s]"
 msgstr "ページを破棄しています。[%s]\n"
 
-#: schematic/src/x_window.c:966
 #, fuzzy, c-format
 msgid "Closing [%1$s]"
 msgstr "閉じています。[%s]\n"
 
-#: schematic/src/x_window.c:1175
 msgid "New"
 msgstr "新規"
 
-#: schematic/src/x_window.c:1175
 msgid "New file"
 msgstr "新規ファイル"
 
-#: schematic/src/x_window.c:1179
 msgid "Open"
 msgstr "開く"
 
-#: schematic/src/x_window.c:1179
 #, fuzzy
 msgid "Open file"
 msgstr "ファイルを開く..."
 
-#: schematic/src/x_window.c:1183 schematic/scheme/gschem/builtins.scm:59
 msgid "Save"
 msgstr "保存"
 
-#: schematic/src/x_window.c:1183
 msgid "Save file"
 msgstr "ファイルを保存"
 
-#: schematic/src/x_window.c:1189 schematic/scheme/gschem/builtins.scm:93
 msgid "Undo"
 msgstr "アンドゥ"
 
-#: schematic/src/x_window.c:1189
 msgid "Undo last operation"
 msgstr "アンドゥ"
 
-#: schematic/src/x_window.c:1193 schematic/scheme/gschem/builtins.scm:96
 msgid "Redo"
 msgstr "リドゥ"
 
-#: schematic/src/x_window.c:1193
 msgid "Redo last undo"
 msgstr "リドゥ"
 
-#: schematic/src/x_window.c:1198
 msgid ""
 "Add component...\n"
 "Select library and component from list, move the mouse into main window, "
@@ -2197,7 +1697,6 @@ msgstr ""
 "クリックすると、配置します。\n"
 "右ボタンでキャンセルします。"
 
-#: schematic/src/x_window.c:1209
 msgid ""
 "Add nets mode\n"
 "Right mouse button to cancel"
@@ -2205,7 +1704,6 @@ msgstr ""
 "ネット追加モード\n"
 "右ボタンでキャンセル"
 
-#: schematic/src/x_window.c:1217
 msgid ""
 "Add buses mode\n"
 "Right mouse button to cancel"
@@ -2213,45 +1711,35 @@ msgstr ""
 "バス追加モード\n"
 "右ボタンでキャンセル"
 
-#: schematic/src/x_window.c:1226
 msgid "Add Text..."
 msgstr "テキスト追加..."
 
-#: schematic/src/x_window.c:1233
 msgid "Select mode"
 msgstr "選択モード"
 
-#: schematic/src/x_window.c:1288
 #, fuzzy
 msgid "Show"
 msgstr "N表示"
 
-#: schematic/src/x_window.c:1289
 msgid "Show text starting with:"
 msgstr "テキスト"
 
-#: schematic/src/x_window.c:1345
 msgid "Menu/Cancel"
 msgstr "メニュー/キャンセル"
 
-#: schematic/src/x_window.c:1349
 msgid "Pan/Cancel"
 msgstr "パン/キャンセル"
 
-#: schematic/src/x_window.c:1359
 msgid "Pick"
 msgstr "ピック"
 
-#: schematic/src/x_window.c:1470 schematic/scheme/gschem/builtins.scm:180
 msgid "Status"
 msgstr "ステータス"
 
-#: schematic/src/x_window.c:1568
 #, fuzzy, c-format
 msgid "New file [%s]"
 msgstr "新規ファイル"
 
-#: schematic/src/x_window.c:1598
 #, c-format
 msgid ""
 "<b>An error occurred while loading the requested file.</b>\n"
@@ -2265,878 +1753,668 @@ msgid ""
 "monitor program's output in terminal window."
 msgstr ""
 
-#: schematic/src/x_window.c:1617
 msgid "Failed to load file"
 msgstr ""
 
-#: schematic/data/lepton-schematic.desktop.in:3
 msgid "Lepton EDA Schematic Editor"
 msgstr ""
 
-#: schematic/data/lepton-schematic.desktop.in:4
 msgid "Create and edit electrical schematics and symbols with lepton-schematic"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:27
 msgid "_New"
 msgstr "新規(_N)"
 
-#: schematic/scheme/conf/schematic/menu.scm:28
 msgid "_Open..."
 msgstr "開く(_O)..."
 
-#: schematic/scheme/conf/schematic/menu.scm:30
 msgid "Open Recen_t"
 msgstr "最近使用したファイル(_T)"
 
-#: schematic/scheme/conf/schematic/menu.scm:32
 msgid "_Save"
 msgstr "保存(_S)"
 
-#: schematic/scheme/conf/schematic/menu.scm:33
 msgid "Save _As..."
 msgstr "別名で保存(_A)..."
 
-#: schematic/scheme/conf/schematic/menu.scm:34
-#: schematic/scheme/gschem/builtins.scm:65
 msgid "Save All"
 msgstr "すべて保存"
 
-#: schematic/scheme/conf/schematic/menu.scm:36
 msgid "_Print..."
 msgstr "印刷(_P)..."
 
-#: schematic/scheme/conf/schematic/menu.scm:37
 #, fuzzy
 msgid "Write _Image..."
 msgstr "画像として保存(_I)..."
 
-#: schematic/scheme/conf/schematic/menu.scm:39
 #, fuzzy
 msgid "Invoke Macro..."
 msgstr "マクロの実行"
 
-#: schematic/scheme/conf/schematic/menu.scm:41
 msgid "REPL..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:43
-#: schematic/scheme/gschem/builtins.scm:77
 msgid "New Window"
 msgstr "新規ウィンドウ"
 
-#: schematic/scheme/conf/schematic/menu.scm:44
 msgid "_Close Window"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:45
 msgid "_Quit"
 msgstr "終了(_Q)"
 
-#: schematic/scheme/conf/schematic/menu.scm:51
 msgid "_Undo"
 msgstr "元に戻す(_U)"
 
-#: schematic/scheme/conf/schematic/menu.scm:52
 msgid "_Redo"
 msgstr "やり直す(_R)"
 
-#: schematic/scheme/conf/schematic/menu.scm:54
 msgid "Cu_t"
 msgstr "切り取り(_T)"
 
-#: schematic/scheme/conf/schematic/menu.scm:55
 msgid "_Copy"
 msgstr "コピー(_C)"
 
-#: schematic/scheme/conf/schematic/menu.scm:56
 msgid "_Paste"
 msgstr "貼り付け(_P)"
 
-#: schematic/scheme/conf/schematic/menu.scm:57
 msgid "_Delete"
 msgstr "削除(_D)"
 
-#: schematic/scheme/conf/schematic/menu.scm:60
-#: schematic/scheme/gschem/builtins.scm:102
 msgid "Select All"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:61
-#: schematic/scheme/gschem/builtins.scm:105
 msgid "Deselect"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:65
 msgid "Rotate 90 Mode"
 msgstr "90度回転モード"
 
-#: schematic/scheme/conf/schematic/menu.scm:70
 msgid "Edit Text..."
 msgstr "テキスト編集..."
 
-#: schematic/scheme/conf/schematic/menu.scm:71
 msgid "Slot..."
 msgstr "スロット..."
 
-#: schematic/scheme/conf/schematic/menu.scm:76
-#: schematic/scheme/gschem/builtins.scm:150
 msgid "Embed Component/Picture"
 msgstr "画像・コンポーネントの埋め込み"
 
-#: schematic/scheme/conf/schematic/menu.scm:77
-#: schematic/scheme/gschem/builtins.scm:153
 msgid "Unembed Component/Picture"
 msgstr "画像・コンポーネントの埋め込み解除"
 
-#: schematic/scheme/conf/schematic/menu.scm:78
-#: schematic/scheme/gschem/builtins.scm:156
 msgid "Update Component"
 msgstr "部品更新"
 
-#: schematic/scheme/conf/schematic/menu.scm:79
 msgid "Symbol Translate..."
 msgstr "シンボル転送..."
 
-#: schematic/scheme/conf/schematic/menu.scm:85
 msgid "Copy into 1"
 msgstr "コピー1"
 
-#: schematic/scheme/conf/schematic/menu.scm:86
 msgid "Copy into 2"
 msgstr "コピー2"
 
-#: schematic/scheme/conf/schematic/menu.scm:87
 msgid "Copy into 3"
 msgstr "コピー3"
 
-#: schematic/scheme/conf/schematic/menu.scm:88
 msgid "Copy into 4"
 msgstr "コピー4"
 
-#: schematic/scheme/conf/schematic/menu.scm:89
 msgid "Copy into 5"
 msgstr "コピー5"
 
-#: schematic/scheme/conf/schematic/menu.scm:90
 msgid "Cut into 1"
 msgstr "カット1"
 
-#: schematic/scheme/conf/schematic/menu.scm:91
 msgid "Cut into 2"
 msgstr "カット2"
 
-#: schematic/scheme/conf/schematic/menu.scm:92
 msgid "Cut into 3"
 msgstr "カット3"
 
-#: schematic/scheme/conf/schematic/menu.scm:93
 msgid "Cut into 4"
 msgstr "カット4"
 
-#: schematic/scheme/conf/schematic/menu.scm:94
 msgid "Cut into 5"
 msgstr "カット5"
 
-#: schematic/scheme/conf/schematic/menu.scm:95
 msgid "Paste from 1"
 msgstr "ペースト1"
 
-#: schematic/scheme/conf/schematic/menu.scm:96
 msgid "Paste from 2"
 msgstr "ペースト2"
 
-#: schematic/scheme/conf/schematic/menu.scm:97
 msgid "Paste from 3"
 msgstr "ペースト3"
 
-#: schematic/scheme/conf/schematic/menu.scm:98
 msgid "Paste from 4"
 msgstr "ペースト4"
 
-#: schematic/scheme/conf/schematic/menu.scm:99
 msgid "Paste from 5"
 msgstr "ペースト5"
 
-#: schematic/scheme/conf/schematic/menu.scm:105
 msgid "Side Dock"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:106
 msgid "Bottom Dock"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:108
 #, fuzzy
 msgid "Find Text Results"
 msgstr "テキスト追加..."
 
-#: schematic/scheme/conf/schematic/menu.scm:110
 msgid "_Redraw"
 msgstr "再描画"
 
-#: schematic/scheme/conf/schematic/menu.scm:111
 msgid "_Pan"
 msgstr "パン"
 
-#: schematic/scheme/conf/schematic/menu.scm:112
 msgid "Zoom _Box"
 msgstr "ズームボックス"
 
-#: schematic/scheme/conf/schematic/menu.scm:113
 msgid "Zoom _Extents"
 msgstr "回路全体の表示(_E)"
 
-#: schematic/scheme/conf/schematic/menu.scm:114
 msgid "Zoom _In"
 msgstr "拡大(_I)"
 
-#: schematic/scheme/conf/schematic/menu.scm:115
 msgid "Zoom _Out"
 msgstr "縮小(_O)"
 
-#: schematic/scheme/conf/schematic/menu.scm:116
 msgid "Zoom _Full"
 msgstr "最縮小して表示(_F)"
 
-#: schematic/scheme/conf/schematic/menu.scm:118
 #, fuzzy
 msgid "_Dark Color Scheme"
 msgstr "暗い配色(_D)"
 
-#: schematic/scheme/conf/schematic/menu.scm:119
 #, fuzzy
 msgid "_Light Color Scheme"
 msgstr "明るい配色(_L)"
 
-#: schematic/scheme/conf/schematic/menu.scm:120
 #, fuzzy
 msgid "B_W Color Scheme"
 msgstr "暗い配色(_D)"
 
-#: schematic/scheme/conf/schematic/menu.scm:122
 #, fuzzy
 msgid "Color Scheme Editor..."
 msgstr "明るい配色(_L)"
 
-#: schematic/scheme/conf/schematic/menu.scm:129
 msgid "_Manager..."
 msgstr "管理(_M)"
 
-#: schematic/scheme/conf/schematic/menu.scm:131
 msgid "_Previous"
 msgstr "前のページ(_P)"
 
-#: schematic/scheme/conf/schematic/menu.scm:132
 msgid "_Next"
 msgstr "次のページ(_N)"
 
-#: schematic/scheme/conf/schematic/menu.scm:133
 msgid "_Close"
 msgstr "閉じる(_C)"
 
-#: schematic/scheme/conf/schematic/menu.scm:135
 #, fuzzy
 msgid "_Revert..."
 msgstr "再読み込み(_R)"
 
-#: schematic/scheme/conf/schematic/menu.scm:137
-#: schematic/scheme/gschem/builtins.scm:249
 #, fuzzy
 msgid "Next Tab"
 msgstr "新規ページ"
 
-#: schematic/scheme/conf/schematic/menu.scm:138
-#: schematic/scheme/gschem/builtins.scm:252
 #, fuzzy
 msgid "Previous Tab"
 msgstr "前のページ(_P)"
 
-#: schematic/scheme/conf/schematic/menu.scm:146
 msgid "_Component..."
 msgstr "部品(_C)"
 
-#: schematic/scheme/conf/schematic/menu.scm:148
 msgid "_Net"
 msgstr "ネット(_N)"
 
-#: schematic/scheme/conf/schematic/menu.scm:149
 msgid "B_us"
 msgstr "バス(_U)"
 
-#: schematic/scheme/conf/schematic/menu.scm:151
 msgid "_Attribute..."
 msgstr "アトリビュート(_A)"
 
-#: schematic/scheme/conf/schematic/menu.scm:152
 msgid "_Text..."
 msgstr "テキスト(_T)..."
 
-#: schematic/scheme/conf/schematic/menu.scm:154
 msgid "_Line"
 msgstr "直線(_L)"
 
-#: schematic/scheme/conf/schematic/menu.scm:155
 msgid "Pat_h"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:156
 msgid "_Box"
 msgstr "ボックス(_B)"
 
-#: schematic/scheme/conf/schematic/menu.scm:157
 msgid "C_ircle"
 msgstr "円(_I)"
 
-#: schematic/scheme/conf/schematic/menu.scm:158
 msgid "A_rc"
 msgstr "円弧(_R)"
 
-#: schematic/scheme/conf/schematic/menu.scm:159
 msgid "_Pin"
 msgstr "ピン(_P)"
 
-#: schematic/scheme/conf/schematic/menu.scm:161
 msgid "Pictu_re..."
 msgstr "画像(_R)"
 
-#: schematic/scheme/conf/schematic/menu.scm:167
 msgid "_Up"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:169
 msgid "_Down Schematic"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:170
 msgid "Down _Symbol"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:176
 msgid "_Attach"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:177
 msgid "_Detach"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:179
 msgid "Show _Value"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:180
 msgid "Show _Name"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:181
 msgid "Show _Both"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:182
 msgid "_Toggle Visibility"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:184
 msgid "_Hide Specific Text..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:185
 msgid "_Show Specific Text..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:186
 #, fuzzy
 msgid "Show/Hide Hidden Text"
 msgstr "テキスト表示/非表示"
 
-#: schematic/scheme/conf/schematic/menu.scm:188
 msgid "_Find Text/Check Symbol..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:189
 msgid "A_utonumber Text..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:195
 #, fuzzy
 msgid "_Options..."
 msgstr "オプション"
 
-#: schematic/scheme/conf/schematic/menu.scm:196
 #, fuzzy
 msgid "_Font..."
 msgstr "印刷(_P)..."
 
-#: schematic/scheme/conf/schematic/menu.scm:198
 #, fuzzy
 msgid "Grid +"
 msgstr "グリッド・オフ\n"
 
-#: schematic/scheme/conf/schematic/menu.scm:199
 #, fuzzy
 msgid "Grid -"
 msgstr "グリッド・オフ\n"
 
-#: schematic/scheme/conf/schematic/menu.scm:201
 msgid "Grid Style: Cycle Dots/Mesh/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:202
 msgid "Grid Snap: Cycle Grid/Resnap/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:204
 msgid "Feedback Mode: Outline/Box"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:205
 #, fuzzy
 msgid "Net: Rubberband On/Off"
 msgstr "ラバーバンド・オン\n"
 
-#: schematic/scheme/conf/schematic/menu.scm:206
 msgid "Net: Magnetic On/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:208
 #, fuzzy
 msgid "_Coord Window"
 msgstr "ウィンドウを閉じています。\n"
 
-#: schematic/scheme/conf/schematic/menu.scm:209
 #, fuzzy
 msgid "_Log Window"
 msgstr "新規ウィンドウ"
 
-#: schematic/scheme/conf/schematic/menu.scm:215
 msgid "_1 allegro"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:223
 msgid "User _Guide"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:224
 msgid "_FAQ"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:225
 #, fuzzy
 msgid "Docu_mentation"
 msgstr "部品モード"
 
-#: schematic/scheme/conf/schematic/menu.scm:226
 msgid "_Wiki"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:228
 #, fuzzy
 msgid "Find Component D_ocumentation"
 msgstr "部品モード"
 
-#: schematic/scheme/conf/schematic/menu.scm:230
 msgid "_Hotkeys..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:231
 msgid "_About"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:237
 msgid "_File"
 msgstr "ファイル(_F)"
 
-#: schematic/scheme/conf/schematic/menu.scm:238
 msgid "_Edit"
 msgstr "編集(_E)"
 
-#: schematic/scheme/conf/schematic/menu.scm:240
 msgid "_View"
 msgstr "表示(_V)"
 
-#: schematic/scheme/conf/schematic/menu.scm:241
 msgid "_Page"
 msgstr "ページ(_P)"
 
-#: schematic/scheme/conf/schematic/menu.scm:242
 msgid "_Add"
 msgstr "追加"
 
-#: schematic/scheme/conf/schematic/menu.scm:243
 msgid "Hie_rarchy"
 msgstr "階層"
 
-#: schematic/scheme/conf/schematic/menu.scm:244
 msgid "A_ttributes"
 msgstr "アトリビュート"
 
-#: schematic/scheme/conf/schematic/menu.scm:245
 msgid "_Options"
 msgstr "オプション"
 
-#: schematic/scheme/conf/schematic/menu.scm:246
 #, fuzzy
 msgid "_Netlist"
 msgstr "ネット(_N)"
 
-#: schematic/scheme/conf/schematic/menu.scm:247
 msgid "_Help"
 msgstr "ヘルプ"
 
-#: schematic/scheme/gschem/action.scm:43
 #, scheme-format
 msgid "~S is not a valid gschem action."
 msgstr ""
 
-#: schematic/scheme/gschem/action.scm:158
 msgid "Repeat Last Action"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:47
 #, fuzzy
 msgid "Cancel"
 msgstr "パン/キャンセル"
 
-#: schematic/scheme/gschem/builtins.scm:53
 #, fuzzy
 msgid "New File"
 msgstr "新規ファイル"
 
-#: schematic/scheme/gschem/builtins.scm:56
 #, fuzzy
 msgid "Open File"
 msgstr "ファイルを開く..."
 
-#: schematic/scheme/gschem/builtins.scm:62
 #, fuzzy
 msgid "Save As"
 msgstr "すべて保存"
 
-#: schematic/scheme/gschem/builtins.scm:68
 #, fuzzy
 msgid "Print"
 msgstr "印刷..."
 
-#: schematic/scheme/gschem/builtins.scm:71
 msgid "Export Image"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:74
 msgid "Run Script"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:80
 #, fuzzy
 msgid "Close Window"
 msgstr "ウィンドウを閉じています。\n"
 
-#: schematic/scheme/gschem/builtins.scm:83
 #, fuzzy
 msgid "Quit"
 msgstr "終了(_Q)"
 
-#: schematic/scheme/gschem/builtins.scm:87
 msgid "Terminal REPL"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:132
 msgid "Choose Slot"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:135
 msgid "Edit Object Properties"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:138
 #, fuzzy
 msgid "Translate Symbol"
 msgstr "転送"
 
-#: schematic/scheme/gschem/builtins.scm:147
 msgid "Invoke Macro"
 msgstr "マクロの実行"
 
-#: schematic/scheme/gschem/builtins.scm:159
 #, fuzzy
 msgid "Show/Hide Invisible Text"
 msgstr "テキスト表示/非表示"
 
-#: schematic/scheme/gschem/builtins.scm:165
 #, fuzzy
 msgid "Cut"
 msgstr "切り取り(_T)"
 
-#: schematic/scheme/gschem/builtins.scm:171
 #, fuzzy
 msgid "Paste"
 msgstr "貼り付け(_P)"
 
-#: schematic/scheme/gschem/builtins.scm:177
 msgid "Sidebar"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:183
 #, fuzzy
 msgid "Find Text State"
 msgstr "テキスト追加..."
 
-#: schematic/scheme/gschem/builtins.scm:186
 #, fuzzy
 msgid "Redraw"
 msgstr "再描画"
 
-#: schematic/scheme/gschem/builtins.scm:192
 #, fuzzy
 msgid "Pan Left"
 msgstr "パンモード"
 
-#: schematic/scheme/gschem/builtins.scm:195
 #, fuzzy
 msgid "Pan Right"
 msgstr "上 右"
 
-#: schematic/scheme/gschem/builtins.scm:198
 msgid "Pan Up"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:201
 #, fuzzy
 msgid "Pan Down"
 msgstr "パンモード"
 
-#: schematic/scheme/gschem/builtins.scm:216
 #, fuzzy
 msgid "Zoom Full"
 msgstr "最縮小して表示(_F)"
 
-#: schematic/scheme/gschem/builtins.scm:219
 #, fuzzy
 msgid "Dark Color Scheme"
 msgstr "暗い配色(_D)"
 
-#: schematic/scheme/gschem/builtins.scm:222
 #, fuzzy
 msgid "Light Color Scheme"
 msgstr "明るい配色(_L)"
 
-#: schematic/scheme/gschem/builtins.scm:225
 msgid "Monochrome Color Scheme"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:228
 #, fuzzy
 msgid "Show Color Scheme Editor"
 msgstr "明るい配色(_L)"
 
-#: schematic/scheme/gschem/builtins.scm:234
 msgid "Revert Changes"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:240
 #, fuzzy
 msgid "Previous Page"
 msgstr "前のページ(_P)"
 
-#: schematic/scheme/gschem/builtins.scm:243
 #, fuzzy
 msgid "Next Page"
 msgstr "新規ページ"
 
-#: schematic/scheme/gschem/builtins.scm:255
 #, fuzzy
 msgid "Print Page"
 msgstr "前のページ(_P)"
 
-#: schematic/scheme/gschem/builtins.scm:276
 #, fuzzy
 msgid "Add Line"
 msgstr "線"
 
-#: schematic/scheme/gschem/builtins.scm:279
 msgid "Add Path"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:282
 msgid "Add Box"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:285
 #, fuzzy
 msgid "Add Circle"
 msgstr "円"
 
-#: schematic/scheme/gschem/builtins.scm:288
 msgid "Add Arc"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:291
 msgid "Add Pin"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:294
 #, fuzzy
 msgid "Add Picture"
 msgstr "画像(_R)"
 
-#: schematic/scheme/gschem/builtins.scm:306
 #, fuzzy
 msgid "Up Hierarchy"
 msgstr "階層"
 
-#: schematic/scheme/gschem/builtins.scm:312
 #, fuzzy
 msgid "Attach Attributes"
 msgstr "アトリビュート編集"
 
-#: schematic/scheme/gschem/builtins.scm:315
 #, fuzzy
 msgid "Detach Attributes"
 msgstr "アトリビュート編集"
 
-#: schematic/scheme/gschem/builtins.scm:318
 #, fuzzy
 msgid "Show Attribute Value"
 msgstr "スロットアトリビュートが変です。\n"
 
-#: schematic/scheme/gschem/builtins.scm:321
 #, fuzzy
 msgid "Show Attribute Name"
 msgstr "スロットアトリビュートが変です。\n"
 
-#: schematic/scheme/gschem/builtins.scm:327
 msgid "Toggle Text Visibility"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:330
 msgid "Find Specific Text"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:333
 msgid "Hide Specific Text"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:336
 msgid "Show Specific Text"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:339
 #, fuzzy
 msgid "Autonumber Text"
 msgstr "オートナンバーテキスト"
 
-#: schematic/scheme/gschem/builtins.scm:345
 #, fuzzy
 msgid "Show Hotkeys"
 msgstr "隠しテキスト表示"
 
-#: schematic/scheme/gschem/builtins.scm:348
 msgid "Switch Grid Style"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:351
 msgid "Switch Snap Mode"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:354
 msgid "Set Grid Spacing"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:357
 msgid "Increase Grid Spacing"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:360
 msgid "Decrease Grid Spacing"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:363
 msgid "Toggle Outline Drawing"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:366
 msgid "Toggle Net Rubber Band"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:369
 msgid "Toggle Magnetic Nets"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:372
 #, fuzzy
 msgid "Show Log Window"
 msgstr "新規ウィンドウ"
 
-#: schematic/scheme/gschem/builtins.scm:375
 #, fuzzy
 msgid "Show Coordinate Window"
 msgstr "現在のウィンドウ"
 
-#: schematic/scheme/gschem/builtins.scm:385
 #, fuzzy
 msgid "Component Documentation"
 msgstr "部品モード"
 
-#: schematic/scheme/gschem/builtins.scm:387
 msgid "View documentation for selected component"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:403
 msgid ""
 "Could not show documentation for selected component:\n"
 "\n"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:408
 msgid "gEDA Manuals"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:409
 msgid "View the front page of the gEDA documentation in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:414
 msgid "gschem User Guide"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:415
 msgid "View the gschem User Guide in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:420
 msgid "gschem FAQ"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:421
 msgid "Frequently Asked Questions about using gschem."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:426
 msgid "gEDA wiki"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:427
 msgid "View the front page of the gEDA wiki in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:431
 msgid "About gschem"
 msgstr ""
 
-#: schematic/scheme/gschem/deprecated.scm:102
 #, scheme-format
 msgid "Invalid text alignment ~A."
 msgstr ""
 
-#: schematic/scheme/gschem/gschemdoc.scm:241
 msgid "No documentation found"
 msgstr ""
 
-#: schematic/scheme/gschem/keymap.scm:40
 #, scheme-format
 msgid "~S is not a valid key combination."
 msgstr ""
 
-#: schematic/scheme/gschem/keymap.scm:157
 #, scheme-format
 msgid "~S is not a prefix key sequence."
 msgstr ""

--- a/schematic/po/lepton-schematic.pot
+++ b/schematic/po/lepton-schematic.pot
@@ -1,0 +1,2999 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR gEDA Developers
+# This file is distributed under the same license as the lepton-eda package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: lepton-eda 1.9.7\n"
+"Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
+"POT-Creation-Date: 2019-02-22 14:08+0300\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+#: schematic/src/a_zoom.c:155
+msgid "Zoom too small!  Cannot zoom further."
+msgstr ""
+
+#: schematic/src/color_edit_widget.c:399
+#, c-format
+msgid ""
+"Could not save file [%s]:\n"
+"%s"
+msgstr ""
+
+#: schematic/src/color_edit_widget.c:434
+msgid "Save Color Scheme As..."
+msgstr ""
+
+#: schematic/src/color_edit_widget.c:482 schematic/src/x_fileselect.c:378
+#, c-format
+msgid ""
+"The selected file `%1$s' already exists.\n"
+"\n"
+"Would you like to overwrite it?"
+msgstr ""
+
+#: schematic/src/color_edit_widget.c:486 schematic/src/x_fileselect.c:381
+msgid "Overwrite file?"
+msgstr ""
+
+#: schematic/src/font_select_widget.c:211
+msgid "_Apply"
+msgstr ""
+
+#: schematic/src/font_select_widget.c:215
+msgid "Sa_ve..."
+msgstr ""
+
+#: schematic/src/font_select_widget.c:278
+#, c-format
+msgid "<b>Current:</b> %s"
+msgstr ""
+
+#: schematic/src/font_select_widget.c:453
+msgid "Save configuration"
+msgstr ""
+
+#: schematic/src/font_select_widget.c:461
+msgid "Save settings to:"
+msgstr ""
+
+#: schematic/src/font_select_widget.c:465
+msgid "Local configuration file (in current directory)"
+msgstr ""
+
+#: schematic/src/font_select_widget.c:467
+msgid "User configuration file (geda-user.conf)"
+msgstr ""
+
+#: schematic/src/g_attrib.c:90
+msgid "Object ~A is not included in the current gschem page."
+msgstr ""
+
+#: schematic/src/g_attrib.c:110
+msgid "Invalid text name/value visibility ~A."
+msgstr ""
+
+#: schematic/src/g_rc.c:107
+#, c-format
+msgid "You are running gEDA/gaf version [%1$s%2$s.%3$s],\n"
+msgstr ""
+
+#: schematic/src/g_rc.c:111
+#, c-format
+msgid ""
+"but you have a version [%1$s] gschemrc file:\n"
+"[%2$s]\n"
+msgstr ""
+
+#: schematic/src/g_rc.c:114
+#, c-format
+msgid "Please be sure that you have the latest rc file.\n"
+msgstr ""
+
+#: schematic/src/g_rc.c:240
+#, c-format
+msgid "Invalid size [%1$d] passed to text-size\n"
+msgstr ""
+
+#: schematic/src/g_rc.c:283
+#, c-format
+msgid "Invalid size [%1$d] passed to snap-size\n"
+msgstr ""
+
+#: schematic/src/g_rc.c:620
+#, c-format
+msgid "Invalid num levels [%1$d] passed to undo-levels\n"
+msgstr ""
+
+#: schematic/src/g_rc.c:831
+#, c-format
+msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
+msgstr ""
+
+#: schematic/src/g_rc.c:931
+#, c-format
+msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
+msgstr ""
+
+#: schematic/src/g_rc.c:972
+#, c-format
+msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
+msgstr ""
+
+#: schematic/src/g_rc.c:998
+#, c-format
+msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
+msgstr ""
+
+#: schematic/src/g_rc.c:1023
+#, c-format
+msgid "Invalid offset [%1$d] passed to add-attribute-offset\n"
+msgstr ""
+
+#: schematic/src/g_rc.c:1047
+#, c-format
+msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
+msgstr ""
+
+#: schematic/src/g_rc.c:1071
+#, c-format
+msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
+msgstr ""
+
+#: schematic/src/g_rc.c:1094
+#, c-format
+msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
+msgstr ""
+
+#: schematic/src/g_rc.c:1118
+#, c-format
+msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
+msgstr ""
+
+#: schematic/src/g_rc.c:1144
+#, c-format
+msgid "Invalid gain [%1$d] passed to zoom-gain\n"
+msgstr ""
+
+#: schematic/src/g_rc.c:1169
+#, c-format
+msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
+msgstr ""
+
+#: schematic/src/g_select.c:78 schematic/src/g_select.c:115
+#: schematic/src/g_select.c:151
+msgid "Object ~A is not directly included in a page."
+msgstr ""
+
+#: schematic/src/g_util.c:54
+msgid "Could not launch URI ~S: ~A"
+msgstr ""
+
+#: schematic/src/g_window.c:139
+msgid "Found invalid gschem window smob ~S"
+msgstr ""
+
+#: schematic/src/lepton-schematic.c:155
+#, c-format
+msgid "Lepton EDA/lepton-schematic version %1$s%2$s.%3$s git: %4$.7s"
+msgstr ""
+
+#: schematic/src/lepton-schematic.c:162
+#, c-format
+msgid "This is the MINGW32 port.\n"
+msgstr ""
+
+#: schematic/src/lepton-schematic.c:166
+#, c-format
+msgid "Current locale settings: %1$s\n"
+msgstr ""
+
+#: schematic/src/lepton-schematic.c:200
+#, c-format
+msgid "Couldn't find init scm file [%1$s]"
+msgstr ""
+
+#: schematic/src/lepton-schematic.c:205
+#, c-format
+msgid "Read init scm file [%1$s]"
+msgstr ""
+
+#: schematic/src/lepton-schematic.c:209
+#, c-format
+msgid "Failed to read init scm file [%1$s]"
+msgstr ""
+
+#: schematic/src/lepton-schematic.c:289
+#, c-format
+msgid ""
+"ERROR: Failed to load or evaluate startup script.\n"
+"\n"
+"The lepton-schematic log may contain more information.\n"
+msgstr ""
+
+#: schematic/src/gschem_about_dialog.c:48
+#, c-format
+msgid "%s (git: %.7s)"
+msgstr ""
+
+#: schematic/src/gschem_about_dialog.c:72
+msgid "Lepton Electronic Design Automation"
+msgstr ""
+
+#: schematic/src/gschem_about_dialog.c:80
+msgid ""
+"Copyright © 1998-2017 by Ales Hvezda and the respective original authors.\n"
+"Copyright © 2017-2019 Lepton Developers.\n"
+"See AUTHORS, ChangeLog files and consult 'git log' history for details."
+msgstr ""
+
+#: schematic/src/gschem_alignment_combo.c:69
+msgid "Upper Left"
+msgstr ""
+
+#: schematic/src/gschem_alignment_combo.c:71
+msgid "Upper Middle"
+msgstr ""
+
+#: schematic/src/gschem_alignment_combo.c:73
+msgid "Upper Right"
+msgstr ""
+
+#: schematic/src/gschem_alignment_combo.c:78
+msgid "Middle Left"
+msgstr ""
+
+#: schematic/src/gschem_alignment_combo.c:80
+msgid "Middle Middle"
+msgstr ""
+
+#: schematic/src/gschem_alignment_combo.c:82
+msgid "Middle Right"
+msgstr ""
+
+#: schematic/src/gschem_alignment_combo.c:87
+msgid "Lower Left"
+msgstr ""
+
+#: schematic/src/gschem_alignment_combo.c:89
+msgid "Lower Middle"
+msgstr ""
+
+#: schematic/src/gschem_alignment_combo.c:91
+msgid "Lower Right"
+msgstr ""
+
+#: schematic/src/gschem_arc_dialog.c:104
+msgid "Arc Params"
+msgstr ""
+
+#: schematic/src/gschem_arc_dialog.c:140
+msgid "Arc _Radius:"
+msgstr ""
+
+#: schematic/src/gschem_arc_dialog.c:141
+msgid "Start _Angle:"
+msgstr ""
+
+#: schematic/src/gschem_arc_dialog.c:142
+msgid "_Degrees of Sweep:"
+msgstr ""
+
+#: schematic/src/gschem_bottom_widget.c:504
+msgid "Left mouse button"
+msgstr ""
+
+#: schematic/src/gschem_bottom_widget.c:508
+msgid "Middle mouse button"
+msgstr ""
+
+#: schematic/src/gschem_bottom_widget.c:512
+msgid "Right mouse button"
+msgstr ""
+
+#: schematic/src/gschem_bottom_widget.c:595
+msgid "(Snap size, Grid size)"
+msgstr ""
+
+#: schematic/src/gschem_bottom_widget.c:603
+msgid "Net rubber band mode"
+msgstr ""
+
+#: schematic/src/gschem_bottom_widget.c:614
+msgid "Magnetic net mode"
+msgstr ""
+
+#: schematic/src/gschem_bottom_widget.c:622
+msgid "Current action mode"
+msgstr ""
+
+#: schematic/src/gschem_bottom_widget.c:935
+#: schematic/src/gschem_bottom_widget.c:951
+msgid "OFF"
+msgstr ""
+
+#: schematic/src/gschem_bottom_widget.c:954
+msgid "NONE"
+msgstr ""
+
+#: schematic/src/gschem_bottom_widget.c:960
+#, c-format
+msgid "Grid(%1$s, %2$s)"
+msgstr ""
+
+#: schematic/src/gschem_close_confirmation_dialog.c:350
+#: schematic/src/x_compselect.c:1236 schematic/src/x_multiattrib.c:2068
+msgid "Name"
+msgstr ""
+
+#: schematic/src/gschem_close_confirmation_dialog.c:372
+msgid "S_elect the schematics you want to save:"
+msgstr ""
+
+#: schematic/src/gschem_close_confirmation_dialog.c:467
+#, c-format
+msgid "Save the changes to schematic \"%1$s\" before closing?"
+msgstr ""
+
+#: schematic/src/gschem_close_confirmation_dialog.c:473
+#, c-format
+msgid ""
+"There are %1$d schematics with unsaved changes. Save changes before closing?"
+msgstr ""
+
+#: schematic/src/gschem_close_confirmation_dialog.c:502
+msgid "If you don't save, all your changes will be permanently lost."
+msgstr ""
+
+#: schematic/src/gschem_close_confirmation_dialog.c:522
+msgid "Close _without saving"
+msgstr ""
+
+#: schematic/src/gschem_coord_dialog.c:86
+msgid "Coords"
+msgstr ""
+
+#: schematic/src/gschem_coord_dialog.c:106
+msgid "Screen"
+msgstr ""
+
+#: schematic/src/gschem_coord_dialog.c:115
+msgid "World"
+msgstr ""
+
+#: schematic/src/gschem_find_text_state.c:809 schematic/src/x_pagesel.c:432
+msgid "Filename"
+msgstr ""
+
+#: schematic/src/gschem_find_text_state.c:821 schematic/src/i_callbacks.c:1970
+#: schematic/src/x_colorcb.c:154 schematic/src/x_widgets.c:179
+#: schematic/src/x_window.c:1226 schematic/src/x_window.c:1440
+msgid "Text"
+msgstr ""
+
+#: schematic/src/gschem_find_text_widget.c:427
+msgid "descend into hierarchy"
+msgstr ""
+
+#: schematic/src/gschem_find_text_widget.c:435
+msgid "Find"
+msgstr ""
+
+#: schematic/src/gschem_find_text_widget.c:557
+msgid "Find Text:"
+msgstr ""
+
+#: schematic/src/gschem_find_text_widget.c:564
+msgid "Find Pattern:"
+msgstr ""
+
+#: schematic/src/gschem_find_text_widget.c:571
+msgid "Find Regex:"
+msgstr ""
+
+#: schematic/src/gschem_find_text_widget.c:578
+msgid "Check symbol:"
+msgstr ""
+
+#: schematic/src/gschem_hotkey_dialog.c:200
+msgid "Hotkeys"
+msgstr ""
+
+#: schematic/src/gschem_hotkey_dialog.c:229
+msgid ""
+"Start typing action name or keystroke to filter the list.\n"
+"Type hotkeys as they are displayed in \"Keystroke(s)\" column."
+msgstr ""
+
+#: schematic/src/gschem_hotkey_dialog.c:233 schematic/src/x_compselect.c:1124
+msgid "_Filter:"
+msgstr ""
+
+#: schematic/src/gschem_hotkey_dialog.c:259 schematic/src/i_basic.c:280
+msgid "Action"
+msgstr ""
+
+#: schematic/src/gschem_hotkey_dialog.c:277
+msgid "Keystroke(s)"
+msgstr ""
+
+#: schematic/src/gschem_log_widget.c:177
+msgid "** Invalid UTF-8 in log message. See stderr or gschem.log.\n"
+msgstr ""
+
+#: schematic/src/gschem_log_widget.c:434
+msgid "Clear log window?"
+msgstr ""
+
+#: schematic/src/gschem_log_widget.c:477
+msgid "Clear Log _Window"
+msgstr ""
+
+#: schematic/src/gschem_macro_widget.c:231
+msgid "Macro:"
+msgstr ""
+
+#: schematic/src/gschem_macro_widget.c:387
+msgid "Evaluate"
+msgstr ""
+
+#: schematic/src/gschem_object_properties_widget.c:172
+msgid "_Fill Type:"
+msgstr ""
+
+#: schematic/src/gschem_object_properties_widget.c:173
+msgid "Lin_e Width:"
+msgstr ""
+
+#: schematic/src/gschem_object_properties_widget.c:174
+msgid "Angle _1:"
+msgstr ""
+
+#: schematic/src/gschem_object_properties_widget.c:175
+msgid "P_itch 1:"
+msgstr ""
+
+#: schematic/src/gschem_object_properties_widget.c:176
+msgid "Angle _2:"
+msgstr ""
+
+#: schematic/src/gschem_object_properties_widget.c:177
+msgid "Pitc_h 2:"
+msgstr ""
+
+#: schematic/src/gschem_object_properties_widget.c:237
+msgid "<b>Fill Properties</b>"
+msgstr ""
+
+#: schematic/src/gschem_object_properties_widget.c:255
+#: schematic/src/gschem_text_properties_widget.c:258
+#: schematic/src/x_newtext.c:271
+msgid "Colo_r:"
+msgstr ""
+
+#: schematic/src/gschem_object_properties_widget.c:266
+msgid "<b>General Properties</b>"
+msgstr ""
+
+#: schematic/src/gschem_object_properties_widget.c:284
+msgid "_Type:"
+msgstr ""
+
+#: schematic/src/gschem_object_properties_widget.c:285
+msgid "_Width:"
+msgstr ""
+
+#: schematic/src/gschem_object_properties_widget.c:286
+msgid "Dash _Length:"
+msgstr ""
+
+#: schematic/src/gschem_object_properties_widget.c:287
+msgid "Dash _Space:"
+msgstr ""
+
+#: schematic/src/gschem_object_properties_widget.c:288
+msgid "C_ap style:"
+msgstr ""
+
+#: schematic/src/gschem_object_properties_widget.c:333
+msgid "<b>Line Properties</b>"
+msgstr ""
+
+#: schematic/src/gschem_object_properties_widget.c:351
+msgid "_Pin Type:"
+msgstr ""
+
+#: schematic/src/gschem_object_properties_widget.c:362
+msgid "<b>Pin Properties</b>"
+msgstr ""
+
+#: schematic/src/gschem_options_widget.c:217
+msgid "_Off"
+msgstr ""
+
+#: schematic/src/gschem_options_widget.c:220
+msgid "_Dots"
+msgstr ""
+
+#: schematic/src/gschem_options_widget.c:223
+msgid "M_esh"
+msgstr ""
+
+#: schematic/src/gschem_options_widget.c:245
+msgid "Net R_ubber Band Mode:"
+msgstr ""
+
+#: schematic/src/gschem_options_widget.c:246
+msgid "_Magnetic Net Mode:"
+msgstr ""
+
+#: schematic/src/gschem_options_widget.c:250
+#: schematic/src/gschem_options_widget.c:251
+msgid "Enabled"
+msgstr ""
+
+#: schematic/src/gschem_options_widget.c:265
+msgid "<b>Net Options</b>"
+msgstr ""
+
+#: schematic/src/gschem_options_widget.c:282
+msgid "Grid Mode:"
+msgstr ""
+
+#: schematic/src/gschem_options_widget.c:283
+msgid "Snap Mode:"
+msgstr ""
+
+#: schematic/src/gschem_options_widget.c:284
+msgid "_Snap Size:"
+msgstr ""
+
+#: schematic/src/gschem_options_widget.c:301
+msgid "<b>Snap Options</b>"
+msgstr ""
+
+#: schematic/src/gschem_options_widget.c:340
+msgid "O_ff"
+msgstr ""
+
+#: schematic/src/gschem_options_widget.c:343
+msgid "_Grid"
+msgstr ""
+
+#: schematic/src/gschem_options_widget.c:346
+msgid "_Resnap"
+msgstr ""
+
+#: schematic/src/gschem_pin_type_combo.c:73
+msgid "Net pin"
+msgstr ""
+
+#: schematic/src/gschem_pin_type_combo.c:80
+msgid "Bus pin (graphical)"
+msgstr ""
+
+#: schematic/src/gschem_preview.c:195
+msgid "Preview Buffer"
+msgstr ""
+
+#: schematic/src/gschem_show_hide_text_widget.c:148
+#: schematic/src/x_window.c:1268
+msgid "Hide"
+msgstr ""
+
+#: schematic/src/gschem_show_hide_text_widget.c:157
+#: schematic/src/x_window.c:1269
+msgid "Hide text starting with:"
+msgstr ""
+
+#: schematic/src/gschem_slot_edit_dialog.c:91
+msgid "Edit slot number"
+msgstr ""
+
+#: schematic/src/gschem_slot_edit_dialog.c:121
+msgid "Number of Slots:"
+msgstr ""
+
+#: schematic/src/gschem_slot_edit_dialog.c:122
+msgid "Slot Number:"
+msgstr ""
+
+#: schematic/src/gschem_text_properties_widget.c:240
+#: schematic/src/x_newtext.c:265
+msgid "<b>Text Content</b>"
+msgstr ""
+
+#: schematic/src/gschem_text_properties_widget.c:259
+#: schematic/src/x_newtext.c:291
+msgid "_Size:"
+msgstr ""
+
+#: schematic/src/gschem_text_properties_widget.c:260
+#: schematic/src/x_newtext.c:310
+msgid "Ali_gnment:"
+msgstr ""
+
+#: schematic/src/gschem_text_properties_widget.c:261
+#: schematic/src/x_newtext.c:330
+msgid "Ro_tation:"
+msgstr ""
+
+#: schematic/src/gschem_text_properties_widget.c:294
+#: schematic/src/x_newtext.c:253
+msgid "<b>Text Properties</b>"
+msgstr ""
+
+#: schematic/src/gschem_translate_widget.c:238
+msgid "Coordinate:"
+msgstr ""
+
+#: schematic/src/gschem_translate_widget.c:405 schematic/src/i_callbacks.c:800
+msgid "Translate"
+msgstr ""
+
+#: schematic/src/i_basic.c:64 schematic/src/x_window.c:1369
+#: schematic/scheme/conf/schematic/menu.scm:59
+#: schematic/scheme/gschem/builtins.scm:99
+msgid "Select Mode"
+msgstr ""
+
+#: schematic/src/i_basic.c:65
+msgid "Select Box Mode"
+msgstr ""
+
+#: schematic/src/i_basic.c:66
+msgid "Text Mode"
+msgstr ""
+
+#: schematic/src/i_basic.c:67
+msgid "Pan Mode"
+msgstr ""
+
+#: schematic/src/i_basic.c:70
+#, c-format
+msgid "Paste %d Mode"
+msgstr ""
+
+#: schematic/src/i_basic.c:74
+msgid "Magnetic Net Mode"
+msgstr ""
+
+#: schematic/src/i_basic.c:76
+msgid "Net Mode"
+msgstr ""
+
+#: schematic/src/i_basic.c:77
+msgid "Arc Mode"
+msgstr ""
+
+#: schematic/src/i_basic.c:78
+msgid "Box Mode"
+msgstr ""
+
+#: schematic/src/i_basic.c:79
+msgid "Bus Mode"
+msgstr ""
+
+#: schematic/src/i_basic.c:80
+msgid "Circle Mode"
+msgstr ""
+
+#: schematic/src/i_basic.c:81
+msgid "Component Mode"
+msgstr ""
+
+#: schematic/src/i_basic.c:82 schematic/scheme/conf/schematic/menu.scm:62
+#: schematic/scheme/gschem/builtins.scm:114
+msgid "Copy Mode"
+msgstr ""
+
+#: schematic/src/i_basic.c:83 schematic/scheme/conf/schematic/menu.scm:63
+#: schematic/scheme/gschem/builtins.scm:117
+msgid "Multiple Copy Mode"
+msgstr ""
+
+#: schematic/src/i_basic.c:84
+msgid "Line Mode"
+msgstr ""
+
+#: schematic/src/i_basic.c:85 schematic/scheme/conf/schematic/menu.scm:66
+#: schematic/scheme/gschem/builtins.scm:123
+msgid "Mirror Mode"
+msgstr ""
+
+#: schematic/src/i_basic.c:86 schematic/scheme/conf/schematic/menu.scm:64
+#: schematic/scheme/gschem/builtins.scm:111
+msgid "Move Mode"
+msgstr ""
+
+#: schematic/src/i_basic.c:87
+msgid "Path Mode"
+msgstr ""
+
+#: schematic/src/i_basic.c:88
+msgid "Picture Mode"
+msgstr ""
+
+#: schematic/src/i_basic.c:89
+msgid "Pin Mode"
+msgstr ""
+
+#: schematic/src/i_basic.c:90 schematic/scheme/gschem/builtins.scm:120
+msgid "Rotate Mode"
+msgstr ""
+
+#: schematic/src/i_basic.c:91
+msgid "Modify Mode"
+msgstr ""
+
+#: schematic/src/i_basic.c:92 schematic/src/x_menus.c:49
+#: schematic/scheme/gschem/builtins.scm:204
+msgid "Zoom Box"
+msgstr ""
+
+#: schematic/src/i_basic.c:121
+msgid "Show Hidden"
+msgstr ""
+
+#: schematic/src/i_basic.c:124
+msgid "Snap Off"
+msgstr ""
+
+#: schematic/src/i_basic.c:126
+msgid "Resnap Active"
+msgstr ""
+
+#: schematic/src/i_basic.c:288 schematic/src/x_colorcb.c:159
+msgid "Stroke"
+msgstr ""
+
+#: schematic/src/i_basic.c:296 schematic/src/i_basic.c:330
+#: schematic/src/x_window.c:1361
+msgid "none"
+msgstr ""
+
+#: schematic/src/i_basic.c:304
+msgid "Repeat/"
+msgstr ""
+
+#: schematic/src/i_basic.c:315
+msgid "Repeat/none"
+msgstr ""
+
+#: schematic/src/i_basic.c:323 schematic/src/i_callbacks.c:1239
+#: schematic/scheme/gschem/builtins.scm:189
+msgid "Pan"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:74
+#, c-format
+msgid "New page created [%1$s]"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:108
+#, c-format
+msgid "New Window created [%1$s]"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:245
+msgid "Failed to Save All"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:247
+msgid "Saved All"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:308
+msgid "Closing Window"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:505 schematic/src/x_menus.c:55
+#: schematic/scheme/gschem/builtins.scm:168
+msgid "Copy"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:514 schematic/src/i_callbacks.c:539
+#: schematic/src/i_callbacks.c:564
+msgid "Select objs first"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:530
+msgid "Multiple Copy"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:555 schematic/src/x_menus.c:56
+msgid "Move"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:579 schematic/src/x_menus.c:57
+#: schematic/src/x_multiattrib.c:1656 schematic/scheme/gschem/builtins.scm:108
+msgid "Delete"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:603
+msgid "Edit"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:618 schematic/scheme/gschem/builtins.scm:129
+msgid "Edit Text"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:637
+msgid "Slot"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:688 schematic/src/i_callbacks.c:698
+msgid "Rotate"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:736 schematic/src/i_callbacks.c:746
+msgid "Mirror"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:763 schematic/src/x_colorcb.c:160
+#: schematic/scheme/conf/schematic/menu.scm:73
+#: schematic/scheme/gschem/builtins.scm:141
+msgid "Lock"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:781 schematic/scheme/conf/schematic/menu.scm:74
+#: schematic/scheme/gschem/builtins.scm:144
+msgid "Unlock"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:805
+msgid "WARNING: Do not translate with snap off!"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:806
+msgid "WARNING: Turning snap on and continuing with translate."
+msgstr ""
+
+#: schematic/src/i_callbacks.c:813
+msgid "WARNING: Snap grid size is not equal to 100!"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:815
+msgid ""
+"WARNING: If you are translating a symbol to the origin, the snap grid size "
+"should be set to 100"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:847
+msgid "Embed"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:886
+msgid "Unembed"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:928
+msgid "Update"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:970
+msgid "ShowHidden"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:1537
+#, c-format
+msgid ""
+"<b>Revert page:</b>\n"
+"%s\n"
+"\n"
+"Are you sure you want to revert this page?\n"
+"All unsaved changes in current schematic will be\n"
+"discarded and page file will be reloaded from disk."
+msgstr ""
+
+#: schematic/src/i_callbacks.c:1555
+msgid "Revert"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:1647
+msgid "Copy to clipboard"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:1664
+msgid "Cut to clipboard"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:1686
+msgid "Paste from clipboard"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:1694
+msgid "Empty clipboard"
+msgstr ""
+
+#. TRANSLATORS: The number is the number of the buffer that the
+#. * selection is being copied to.
+#: schematic/src/i_callbacks.c:1719
+#, c-format
+msgid "Copy %i"
+msgstr ""
+
+#. TRANSLATORS: The number is the number of the buffer that the
+#. * selection is being cut to.
+#: schematic/src/i_callbacks.c:1746
+#, c-format
+msgid "Cut %i"
+msgstr ""
+
+#. TRANSLATORS: The number is the number of the buffer that is being
+#. * pasted to the schematic.
+#: schematic/src/i_callbacks.c:1776
+#, c-format
+msgid "Paste %i"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:1785
+msgid "Empty buffer"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:1833 schematic/src/x_window.c:1203
+msgid "Component"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:1865 schematic/src/x_colorcb.c:150
+msgid "Attribute"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:1885 schematic/src/x_colorcb.c:149
+msgid "Net"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:1928 schematic/src/x_colorcb.c:155
+#: schematic/src/x_window.c:1222
+msgid "Bus"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:2004
+msgid "Line"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:2021
+msgid "Path"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:2043
+msgid "Box"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:2085
+msgid "Circle"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:2108
+msgid "Arc"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:2131 schematic/src/x_colorcb.c:146
+msgid "Pin"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:2191
+#, c-format
+msgid "Searching for source [%1$s]"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:2223
+#, c-format
+msgid ""
+"Failed to descend hierarchy into '%1$s': %2$s\n"
+"\n"
+"The lepton-schematic log may contain more information."
+msgstr ""
+
+#: schematic/src/i_callbacks.c:2227
+#, c-format
+msgid "Failed to descend into '%1$s': %2$s"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:2234
+msgid "Failed to descend hierarchy."
+msgstr ""
+
+#: schematic/src/i_callbacks.c:2312
+#, c-format
+msgid "Searching for symbol [%1$s]"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:2320
+msgid "Symbol is not a real file. Symbol cannot be loaded."
+msgstr ""
+
+#: schematic/src/i_callbacks.c:2367 schematic/src/x_tabs.c:1060
+msgid "Cannot find any schematics above the current one!"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:2400
+msgid "Attach"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:2456
+msgid "Detach"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:2500
+msgid "ShowN"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:2537
+msgid "ShowV"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:2574
+msgid "ShowB"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:2612
+msgid "VisToggle"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:2643
+#, c-format
+msgid "Sorry but this is a non-functioning menu option\n"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:2703
+msgid "Action feedback mode set to OUTLINE"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:2706
+msgid "Action feedback mode set to BOUNDINGBOX"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:2730
+msgid "Grid OFF"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:2731
+msgid "Dot grid selected"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:2732
+msgid "Mesh grid selected"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:2733
+msgid "Invalid grid mode"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:2755
+msgid "Snap OFF (CAUTION!)"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:2758
+msgid "Snap ON"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:2761
+msgid "Snap back to the grid (CAUTION!)"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:2790
+msgid "Rubber band ON"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:2792
+msgid "Rubber band OFF"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:2811
+msgid "magnetic net mode: ON"
+msgstr ""
+
+#: schematic/src/i_callbacks.c:2814
+msgid "magnetic net mode: OFF"
+msgstr ""
+
+#. TRANSLATORS: this string is used to generate a filename for
+#. newly-created files.  It will be used to create a filename of
+#. the form "untitled_N.sch", where N is a number.  Please make
+#. sure that the translation contains characters suitable for use
+#. in a filename.
+#: schematic/src/i_vars.c:202
+msgid "untitled"
+msgstr ""
+
+#: schematic/src/o_complex.c:192 schematic/src/o_complex.c:195
+#, c-format
+msgid "Translating schematic [%1$d %2$d]"
+msgstr ""
+
+#: schematic/src/o_delete.c:82
+#, c-format
+msgid "Delete locked object?"
+msgid_plural "Delete %1$u locked objects?"
+msgstr[0] ""
+msgstr[1] ""
+
+#: schematic/src/o_misc.c:55
+#, c-format
+msgid "Got an unexpected NULL in o_edit\n"
+msgstr ""
+
+#: schematic/src/o_misc.c:361
+msgid "Hidden text is now visible"
+msgstr ""
+
+#: schematic/src/o_misc.c:363
+msgid "Hidden text is now invisible"
+msgstr ""
+
+#: schematic/src/o_misc.c:471
+#, c-format
+msgid "Could not find symbol [%1$s] in library. Update failed."
+msgstr ""
+
+#: schematic/src/o_misc.c:587
+#, c-format
+msgid "o_autosave_backups: Can't get the real filename of %1$s."
+msgstr ""
+
+#: schematic/src/o_misc.c:631
+#, c-format
+msgid "Could NOT set previous backup file [%1$s] read-write"
+msgstr ""
+
+#: schematic/src/o_misc.c:651
+#, c-format
+msgid "Could NOT set backup file [%1$s] readonly"
+msgstr ""
+
+#: schematic/src/o_misc.c:656
+#, c-format
+msgid "Could NOT save backup file [%1$s]"
+msgstr ""
+
+#: schematic/src/o_move.c:192
+#, c-format
+msgid "ERROR: NULL object in o_move_end!\n"
+msgstr ""
+
+#: schematic/src/o_move.c:519
+#, c-format
+msgid "DOH! tried to find the whichone, but didn't find it!\n"
+msgstr ""
+
+#: schematic/src/o_move.c:546
+#, c-format
+msgid "Got a non line object in o_move_check_endpoint\n"
+msgstr ""
+
+#: schematic/src/o_net.c:444
+msgid "Warning: Starting net at off grid coordinate"
+msgstr ""
+
+#: schematic/src/o_net.c:508
+msgid "Warning: Ending net at off grid coordinate"
+msgstr ""
+
+#: schematic/src/o_net.c:856 schematic/src/o_net.c:893
+#: schematic/src/o_net.c:964 schematic/src/o_net.c:1000
+#, c-format
+msgid "Tried to add more than two bus rippers. Internal gschem error.\n"
+msgstr ""
+
+#: schematic/src/o_net.c:1068
+#, c-format
+msgid "Bus ripper symbol [%1$s] was not found in any component library"
+msgstr ""
+
+#: schematic/src/o_picture.c:133 schematic/src/o_picture.c:343
+msgid "Select a picture file..."
+msgstr ""
+
+#: schematic/src/o_picture.c:166
+#, c-format
+msgid "Failed to load picture: %1$s"
+msgstr ""
+
+#: schematic/src/o_picture.c:182
+msgid "Picture"
+msgstr ""
+
+#: schematic/src/o_picture.c:378
+#, c-format
+msgid "Failed to replace pictures: %s"
+msgstr ""
+
+#: schematic/src/o_slot.c:80
+msgid "Slot attribute malformed"
+msgstr ""
+
+#: schematic/src/o_slot.c:88
+msgid "numslots attribute missing"
+msgstr ""
+
+#: schematic/src/o_slot.c:89
+msgid "Slotting not allowed for this component"
+msgstr ""
+
+#: schematic/src/o_slot.c:104
+msgid "New slot number out of range"
+msgstr ""
+
+#: schematic/src/o_undo.c:397
+msgid "Undo/Redo disabled in rc file"
+msgstr ""
+
+#: schematic/src/parsecmd.c:77
+#, c-format
+msgid ""
+"Usage: %1$s [OPTION ...] [--] [FILE ...]\n"
+"\n"
+"Interactively edit gEDA schematics or symbols.  If one or more FILEs\n"
+"are specified, open them for editing; otherwise, create a new, empty\n"
+"schematic.\n"
+"\n"
+"Options:\n"
+"  -q, --quiet              Quiet mode.\n"
+"  -v, --verbose            Verbose mode.\n"
+"  -L DIR                   Add DIR to Scheme search path.\n"
+"  -c EXPR                  Scheme expression to run at startup.\n"
+"  -s FILE                  Scheme script to run at startup.\n"
+"  -o, --output=FILE        Output filename (for printing).\n"
+"  -p                       Automatically place the window.\n"
+"  -V, --version            Show version information.\n"
+"  -h, --help               Help; this message.\n"
+"  --                       Treat all remaining arguments as filenames.\n"
+"\n"
+"Report bugs at <https://github.com/lepton-eda/lepton-eda/issues>\n"
+"gEDA/gaf homepage: <http://www.geda-project.org/>\n"
+msgstr ""
+
+#: schematic/src/parsecmd.c:110
+#, c-format
+msgid ""
+"Lepton EDA %1$s (git: %2$.7s)\n"
+"Copyright (C) 1998-2017 by Ales Hvezda and the respective original authors.\n"
+"Copyright (C) 2017-2019 Lepton Developers.\n"
+"This is free software, and you are welcome to redistribute it under\n"
+"certain conditions. For details, see the file `COPYING', which is\n"
+"included in the Lepton EDA distribution.\n"
+"There is NO WARRANTY, to the extent permitted by law.\n"
+msgstr ""
+
+#: schematic/src/x_attribedit.c:125
+#, c-format
+msgid "Got invalid show option; defaulting to show both\n"
+msgstr ""
+
+#: schematic/src/x_attribedit.c:139
+#, c-format
+msgid "ERROR: NULL object!\n"
+msgstr ""
+
+#: schematic/src/x_attribedit.c:328
+msgid "Single Attribute Editor"
+msgstr ""
+
+#: schematic/src/x_attribedit.c:358
+msgid "<b>Edit Attribute</b>"
+msgstr ""
+
+#: schematic/src/x_attribedit.c:360
+msgid "<b>Add Attribute</b>"
+msgstr ""
+
+#: schematic/src/x_attribedit.c:376
+msgid "N_ame:"
+msgstr ""
+
+#: schematic/src/x_attribedit.c:396 schematic/src/x_multiattrib.c:2222
+msgid "_Value:"
+msgstr ""
+
+#: schematic/src/x_attribedit.c:415 schematic/src/x_multiattrib.c:2281
+msgid "Vi_sible"
+msgstr ""
+
+#: schematic/src/x_attribedit.c:434
+msgid "Show Value Only"
+msgstr ""
+
+#: schematic/src/x_attribedit.c:436
+msgid "Show Name Only"
+msgstr ""
+
+#: schematic/src/x_attribedit.c:438 schematic/src/x_multiattrib.c:1620
+#: schematic/scheme/gschem/builtins.scm:324
+msgid "Show Name & Value"
+msgstr ""
+
+#: schematic/src/x_attribedit.c:445
+msgid "<b>Attach Options</b>"
+msgstr ""
+
+#: schematic/src/x_attribedit.c:460
+msgid "All"
+msgstr ""
+
+#: schematic/src/x_attribedit.c:476 schematic/src/x_compselect.c:986
+#: schematic/src/x_compselect.c:1100
+msgid "Components"
+msgstr ""
+
+#: schematic/src/x_attribedit.c:492 schematic/src/x_window.c:1214
+msgid "Nets"
+msgstr ""
+
+#: schematic/src/x_attribedit.c:508
+msgid "Replace existing attributes"
+msgstr ""
+
+#: schematic/src/x_autonumber.c:412
+msgid ""
+"slotted object without slot attribute may cause problems when autonumbering "
+"slots"
+msgstr ""
+
+#: schematic/src/x_autonumber.c:427
+#, c-format
+msgid ""
+"duplicate slot may cause problems: [symbolname=%1$s, number=%2$d, slot=%3$d]"
+msgstr ""
+
+#: schematic/src/x_autonumber.c:675
+msgid "No searchstring given in autonumber text."
+msgstr ""
+
+#: schematic/src/x_autonumber.c:728
+msgid "No '*' or '?' given at the end of the autonumber text."
+msgstr ""
+
+#: schematic/src/x_autonumber.c:873
+msgid "Diagonal"
+msgstr ""
+
+#: schematic/src/x_autonumber.c:874
+msgid "Top to bottom"
+msgstr ""
+
+#: schematic/src/x_autonumber.c:875
+msgid "Bottom to top"
+msgstr ""
+
+#: schematic/src/x_autonumber.c:876
+msgid "Left to right"
+msgstr ""
+
+#: schematic/src/x_autonumber.c:877
+msgid "Right to left"
+msgstr ""
+
+#: schematic/src/x_autonumber.c:878
+msgid "File order"
+msgstr ""
+
+#: schematic/src/x_autonumber.c:1214
+msgid "Autonumber text"
+msgstr ""
+
+#: schematic/src/x_autonumber.c:1237
+msgid "<b>Scope</b>"
+msgstr ""
+
+#: schematic/src/x_autonumber.c:1259
+msgid "Search for:"
+msgstr ""
+
+#: schematic/src/x_autonumber.c:1273
+msgid "Autonumber text in:"
+msgstr ""
+
+#: schematic/src/x_autonumber.c:1280
+msgid "Skip numbers found in:"
+msgstr ""
+
+#: schematic/src/x_autonumber.c:1292 schematic/src/x_autonumber.c:1301
+msgid "Selected objects"
+msgstr ""
+
+#: schematic/src/x_autonumber.c:1293 schematic/src/x_autonumber.c:1302
+msgid "Current page"
+msgstr ""
+
+#: schematic/src/x_autonumber.c:1294 schematic/src/x_autonumber.c:1303
+msgid "Whole hierarchy"
+msgstr ""
+
+#: schematic/src/x_autonumber.c:1305
+msgid "Overwrite existing numbers"
+msgstr ""
+
+#: schematic/src/x_autonumber.c:1310
+msgid "<b>Options</b>"
+msgstr ""
+
+#: schematic/src/x_autonumber.c:1332
+msgid "Starting number:"
+msgstr ""
+
+#: schematic/src/x_autonumber.c:1339
+msgid "Sort order:"
+msgstr ""
+
+#: schematic/src/x_autonumber.c:1371
+msgid "Remove numbers"
+msgstr ""
+
+#: schematic/src/x_autonumber.c:1375
+msgid "Automatic slotting"
+msgstr ""
+
+#: schematic/src/x_clipboard.c:245
+#, c-format
+msgid ""
+"<b>Invalid schematic on clipboard.</b>\n"
+"\n"
+"An error occurred while inserting clipboard data: %s."
+msgstr ""
+
+#: schematic/src/x_clipboard.c:247
+msgid "Clipboard insertion failed"
+msgstr ""
+
+#: schematic/src/x_color.c:89 schematic/src/x_color.c:98
+#, c-format
+msgid "Could not allocate the color %1$s!\n"
+msgstr ""
+
+#: schematic/src/x_color.c:89
+msgid "black"
+msgstr ""
+
+#: schematic/src/x_color.c:98
+msgid "white"
+msgstr ""
+
+#: schematic/src/x_color.c:120
+#, c-format
+msgid "Could not allocate display color %1$i!\n"
+msgstr ""
+
+#: schematic/src/x_color.c:142
+#, c-format
+msgid "Could not allocate outline color %1$i!\n"
+msgstr ""
+
+#: schematic/src/x_color.c:159
+#, c-format
+msgid "Tried to get an invalid color: %1$d\n"
+msgstr ""
+
+#: schematic/src/x_colorcb.c:145
+msgid "Background"
+msgstr ""
+
+#: schematic/src/x_colorcb.c:147
+msgid "Net endpoint"
+msgstr ""
+
+#: schematic/src/x_colorcb.c:148
+msgid "Graphic"
+msgstr ""
+
+#: schematic/src/x_colorcb.c:151
+msgid "Logic bubble"
+msgstr ""
+
+#: schematic/src/x_colorcb.c:152
+msgid "Grid point"
+msgstr ""
+
+#: schematic/src/x_colorcb.c:153
+msgid "Detached attribute"
+msgstr ""
+
+#: schematic/src/x_colorcb.c:156
+msgid "Selection"
+msgstr ""
+
+#: schematic/src/x_colorcb.c:157
+msgid "Bounding box"
+msgstr ""
+
+#: schematic/src/x_colorcb.c:158
+msgid "Zoom box"
+msgstr ""
+
+#: schematic/src/x_colorcb.c:161
+msgid "Output background"
+msgstr ""
+
+#: schematic/src/x_colorcb.c:162
+msgid "Freestyle 1"
+msgstr ""
+
+#: schematic/src/x_colorcb.c:163
+msgid "Freestyle 2"
+msgstr ""
+
+#: schematic/src/x_colorcb.c:164
+msgid "Freestyle 3"
+msgstr ""
+
+#: schematic/src/x_colorcb.c:165
+msgid "Freestyle 4"
+msgstr ""
+
+#: schematic/src/x_colorcb.c:166
+msgid "Net junction"
+msgstr ""
+
+#: schematic/src/x_colorcb.c:167
+msgid "Mesh grid major"
+msgstr ""
+
+#: schematic/src/x_colorcb.c:168
+msgid "Mesh grid minor"
+msgstr ""
+
+#: schematic/src/x_colorcb.c:172
+msgid "Unknown"
+msgstr ""
+
+#: schematic/src/x_compselect.c:1169
+msgid "Reset filter"
+msgstr ""
+
+#: schematic/src/x_compselect.c:1192
+msgid "Reload all libraries"
+msgstr ""
+
+#: schematic/src/x_compselect.c:1245 schematic/src/x_multiattrib.c:2092
+msgid "Value"
+msgstr ""
+
+#: schematic/src/x_compselect.c:1284
+msgid "Default behavior - reference component"
+msgstr ""
+
+#: schematic/src/x_compselect.c:1287
+msgid "Embed component in schematic"
+msgstr ""
+
+#: schematic/src/x_compselect.c:1290
+msgid "Include component as individual objects"
+msgstr ""
+
+#: schematic/src/x_compselect.c:1448
+msgid "Select Component..."
+msgstr ""
+
+#: schematic/src/x_compselect.c:1471
+msgid "In Us_e"
+msgstr ""
+
+#: schematic/src/x_compselect.c:1475
+msgid "Lib_raries"
+msgstr ""
+
+#: schematic/src/x_compselect.c:1484 schematic/src/x_fileselect.c:197
+msgid "Preview"
+msgstr ""
+
+#: schematic/src/x_compselect.c:1510
+msgid "Attributes"
+msgstr ""
+
+#: schematic/src/x_dialog.c:325
+msgid "Major symbol changes detected."
+msgstr ""
+
+#: schematic/src/x_dialog.c:349
+msgid ""
+"Changes have occurred to the symbols shown below.\n"
+"\n"
+"Be sure to verify each of these symbols."
+msgstr ""
+
+#: schematic/src/x_dialog.c:369
+msgid "Symbol"
+msgstr ""
+
+#: schematic/src/x_dialog.c:406
+#, c-format
+msgid ""
+"<span weight=\"bold\" size=\"larger\">The input attribute \"%s\" is invalid\n"
+"Please correct in order to continue</span>\n"
+"\n"
+"The name and value must be non-empty.\n"
+"The name cannot end with a space.\n"
+"The value cannot start with a space."
+msgstr ""
+
+#: schematic/src/x_dialog.c:408
+msgid "Invalid Attribute"
+msgstr ""
+
+#: schematic/src/x_fileselect.c:57
+msgid "Schematics"
+msgstr ""
+
+#: schematic/src/x_fileselect.c:69
+msgid "Symbols"
+msgstr ""
+
+#: schematic/src/x_fileselect.c:79
+msgid "Schematics and symbols"
+msgstr ""
+
+#: schematic/src/x_fileselect.c:90
+msgid "All files"
+msgstr ""
+
+#: schematic/src/x_fileselect.c:247
+msgid "Open..."
+msgstr ""
+
+#: schematic/src/x_fileselect.c:315
+msgid "Save as..."
+msgstr ""
+
+#: schematic/src/x_fileselect.c:383
+msgid "Save cancelled on user request"
+msgstr ""
+
+#: schematic/src/x_fileselect.c:420
+msgid ""
+"\n"
+"If you load the original file, the backup file will be overwritten in the "
+"next autosave timeout and it will be lost.\n"
+"\n"
+"Do you want to load the backup file?\n"
+msgstr ""
+
+#: schematic/src/x_fstylecb.c:73
+msgid "Hollow"
+msgstr ""
+
+#: schematic/src/x_fstylecb.c:80
+msgid "Filled"
+msgstr ""
+
+#: schematic/src/x_fstylecb.c:87
+msgid "Mesh"
+msgstr ""
+
+#: schematic/src/x_fstylecb.c:94
+msgid "Hatch"
+msgstr ""
+
+#: schematic/src/x_image.c:279
+#, c-format
+msgid "x_image_lowlevel: Unable to write %1$s file %2$s."
+msgstr ""
+
+#: schematic/src/x_image.c:289
+#, c-format
+msgid ""
+"There was the following error when saving image with type %1$s to filename:\n"
+"%2$s\n"
+"\n"
+"%3$s.\n"
+msgstr ""
+
+#: schematic/src/x_image.c:309
+#, c-format
+msgid "Wrote color image to [%1$s] [%2$d x %3$d]"
+msgstr ""
+
+#: schematic/src/x_image.c:311
+#, c-format
+msgid "Wrote black and white image to [%1$s] [%2$d x %3$d]"
+msgstr ""
+
+#: schematic/src/x_image.c:319
+msgid "x_image_lowlevel: Unable to get pixbuf from gschem's window."
+msgstr ""
+
+#: schematic/src/x_image.c:358
+msgid "Width x Height"
+msgstr ""
+
+#: schematic/src/x_image.c:374
+msgid "Image type"
+msgstr ""
+
+#: schematic/src/x_image.c:395
+msgid "Write image..."
+msgstr ""
+
+#: schematic/src/x_linecapcb.c:74
+msgid "Butt"
+msgstr ""
+
+#: schematic/src/x_linecapcb.c:81
+msgid "Square"
+msgstr ""
+
+#: schematic/src/x_linecapcb.c:88
+msgid "Round"
+msgstr ""
+
+#: schematic/src/x_linetypecb.c:74
+msgid "Solid"
+msgstr ""
+
+#: schematic/src/x_linetypecb.c:81
+msgid "Dotted"
+msgstr ""
+
+#: schematic/src/x_linetypecb.c:88
+msgid "Dashed"
+msgstr ""
+
+#: schematic/src/x_linetypecb.c:95
+msgid "Center"
+msgstr ""
+
+#: schematic/src/x_linetypecb.c:102
+msgid "Phantom"
+msgstr ""
+
+#: schematic/src/x_menus.c:41 schematic/scheme/gschem/builtins.scm:267
+msgid "Add Net"
+msgstr ""
+
+#: schematic/src/x_menus.c:42 schematic/src/x_multiattrib.c:2187
+#: schematic/scheme/gschem/builtins.scm:264
+msgid "Add Attribute"
+msgstr ""
+
+#: schematic/src/x_menus.c:43 schematic/scheme/gschem/builtins.scm:261
+msgid "Add Component"
+msgstr ""
+
+#: schematic/src/x_menus.c:44 schematic/scheme/gschem/builtins.scm:270
+msgid "Add Bus"
+msgstr ""
+
+#: schematic/src/x_menus.c:45 schematic/scheme/gschem/builtins.scm:273
+msgid "Add Text"
+msgstr ""
+
+#: schematic/src/x_menus.c:47 schematic/scheme/gschem/builtins.scm:210
+msgid "Zoom In"
+msgstr ""
+
+#: schematic/src/x_menus.c:48 schematic/scheme/gschem/builtins.scm:213
+msgid "Zoom Out"
+msgstr ""
+
+#: schematic/src/x_menus.c:50 schematic/scheme/gschem/builtins.scm:207
+msgid "Zoom Extents"
+msgstr ""
+
+#: schematic/src/x_menus.c:52 schematic/src/x_window.c:1233
+msgid "Select"
+msgstr ""
+
+#: schematic/src/x_menus.c:53 schematic/scheme/conf/schematic/menu.scm:69
+#: schematic/scheme/gschem/builtins.scm:126
+msgid "Edit..."
+msgstr ""
+
+#: schematic/src/x_menus.c:54 schematic/scheme/conf/schematic/menu.scm:68
+msgid "Object Properties..."
+msgstr ""
+
+#: schematic/src/x_menus.c:59 schematic/scheme/gschem/builtins.scm:300
+msgid "Down Schematic"
+msgstr ""
+
+#: schematic/src/x_menus.c:60 schematic/scheme/gschem/builtins.scm:303
+msgid "Down Symbol"
+msgstr ""
+
+#: schematic/src/x_menus.c:61
+msgid "Up"
+msgstr ""
+
+#: schematic/src/x_menus.c:336
+#, c-format
+msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
+msgstr ""
+
+#: schematic/src/x_menus.c:360
+#, c-format
+msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
+msgstr ""
+
+#: schematic/src/x_misc.c:70
+msgid "The operating system is out of memory or resources."
+msgstr ""
+
+#: schematic/src/x_multiattrib.c:798 schematic/src/x_multiattrib.c:2704
+msgid "<various>"
+msgstr ""
+
+#: schematic/src/x_multiattrib.c:930
+msgid "Attributes with empty name are not allowed. Please set a name."
+msgstr ""
+
+#: schematic/src/x_multiattrib.c:1622
+msgid "Show Value only"
+msgstr ""
+
+#: schematic/src/x_multiattrib.c:1624
+msgid "Show Name only"
+msgstr ""
+
+#: schematic/src/x_multiattrib.c:1651
+msgid "Promote"
+msgstr ""
+
+#: schematic/src/x_multiattrib.c:1655
+msgid "Duplicate"
+msgstr ""
+
+#: schematic/src/x_multiattrib.c:1657
+msgid "Copy to all"
+msgstr ""
+
+#: schematic/src/x_multiattrib.c:1986 schematic/src/x_multiattrib.c:2602
+msgid "Edit Attributes"
+msgstr ""
+
+#: schematic/src/x_multiattrib.c:2112
+msgid "Vis?"
+msgstr ""
+
+#: schematic/src/x_multiattrib.c:2130
+msgid "N"
+msgstr ""
+
+#: schematic/src/x_multiattrib.c:2148
+msgid "V"
+msgstr ""
+
+#: schematic/src/x_multiattrib.c:2170
+msgid "Sho_w inherited attributes"
+msgstr ""
+
+#: schematic/src/x_multiattrib.c:2197
+msgid "_Name:"
+msgstr ""
+
+#: schematic/src/x_multiattrib.c:2241
+msgid "Ctrl+Enter inserts new line; Ctrl+Tab inserts Tab"
+msgstr ""
+
+#: schematic/src/x_multiattrib.c:2618
+#, c-format
+msgid "%2$i symbol (%1$s)"
+msgid_plural "%2$i symbols (%1$s)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: schematic/src/x_multiattrib.c:2624
+#, c-format
+msgid "%1$i pin"
+msgid_plural "%1$i pins"
+msgstr[0] ""
+msgstr[1] ""
+
+#: schematic/src/x_multiattrib.c:2630
+#, c-format
+msgid "%1$i net"
+msgid_plural "%1$i nets"
+msgstr[0] ""
+msgstr[1] ""
+
+#: schematic/src/x_multiattrib.c:2636
+#, c-format
+msgid "%1$i bus"
+msgid_plural "%1$i buses"
+msgstr[0] ""
+msgstr[1] ""
+
+#: schematic/src/x_multiattrib.c:2642
+#, c-format
+msgid "%1$i attribute"
+msgid_plural "%1$i attributes"
+msgstr[0] ""
+msgstr[1] ""
+
+#: schematic/src/x_newtext.c:433
+msgid "Text Entry..."
+msgstr ""
+
+#: schematic/src/x_pagesel.c:253
+msgid "New Page"
+msgstr ""
+
+#: schematic/src/x_pagesel.c:254
+msgid "Open Page..."
+msgstr ""
+
+#: schematic/src/x_pagesel.c:256
+msgid "Save Page"
+msgstr ""
+
+#: schematic/src/x_pagesel.c:257 schematic/scheme/gschem/builtins.scm:246
+msgid "Close Page"
+msgstr ""
+
+#: schematic/src/x_pagesel.c:376 schematic/scheme/gschem/builtins.scm:237
+msgid "Page Manager"
+msgstr ""
+
+#: schematic/src/x_pagesel.c:448
+msgid "Changed"
+msgstr ""
+
+#: schematic/src/x_pagesel.c:468
+msgid "Right click on the filename for more options..."
+msgstr ""
+
+#: schematic/src/x_print.c:306
+#, c-format
+msgid "Failed to write PDF to '%s': %s\n"
+msgstr ""
+
+#: schematic/src/x_print.c:364
+#, c-format
+msgid "Failed to write PDF to '%1$s': %2$s\n"
+msgstr ""
+
+#: schematic/src/x_print.c:449
+#, c-format
+msgid ""
+"Error printing file:\n"
+"%1$s"
+msgstr ""
+
+#: schematic/src/x_rc.c:39
+msgid "ERROR: An unknown error occurred while parsing configuration files."
+msgstr ""
+
+#: schematic/src/x_rc.c:44
+msgid ""
+"An unknown error occurred while parsing configuration files.\n"
+"\n"
+"The lepton-schematic log may contain more information."
+msgstr ""
+
+#: schematic/src/x_rc.c:56
+#, c-format
+msgid "ERROR: %1$s"
+msgstr ""
+
+#: schematic/src/x_rc.c:59
+#, c-format
+msgid ""
+"%1$s\n"
+"\n"
+"The lepton-schematic log may contain more information."
+msgstr ""
+
+#: schematic/src/x_rc.c:67
+msgid "Cannot load lepton-schematic configuration."
+msgstr ""
+
+#: schematic/src/x_script.c:42 schematic/scheme/conf/schematic/menu.scm:40
+msgid "Execute Script..."
+msgstr ""
+
+#: schematic/src/x_script.c:61
+#, c-format
+msgid "Executing guile script [%1$s]"
+msgstr ""
+
+#: schematic/src/x_tabs.c:860
+#, c-format
+msgid "Hierarchy up: %s"
+msgstr ""
+
+#: schematic/src/x_tabs.c:863
+msgid "Hierarchy up"
+msgstr ""
+
+#: schematic/src/x_widgets.c:158 schematic/src/x_window.c:1444
+msgid "Options"
+msgstr ""
+
+#: schematic/src/x_widgets.c:203 schematic/src/x_window.c:1436
+msgid "Object"
+msgstr ""
+
+#: schematic/src/x_widgets.c:224
+msgid "Log"
+msgstr ""
+
+#: schematic/src/x_widgets.c:245 schematic/src/x_window.c:1466
+msgid "Find Text"
+msgstr ""
+
+#: schematic/src/x_widgets.c:259
+msgid "Color Scheme Editor"
+msgstr ""
+
+#: schematic/src/x_widgets.c:272 schematic/scheme/gschem/builtins.scm:378
+msgid "Select Schematic Font"
+msgstr ""
+
+#: schematic/src/x_window.c:763
+#, c-format
+msgid "Loading schematic [%1$s]"
+msgstr ""
+
+#: schematic/src/x_window.c:864
+#, c-format
+msgid "Could NOT save page [%1$s]\n"
+msgstr ""
+
+#: schematic/src/x_window.c:865
+msgid "Error while trying to save"
+msgstr ""
+
+#: schematic/src/x_window.c:875
+msgid "Failed to save file"
+msgstr ""
+
+#: schematic/src/x_window.c:885
+#, c-format
+msgid "Saved as [%1$s]"
+msgstr ""
+
+#: schematic/src/x_window.c:887
+#, c-format
+msgid "Saved [%1$s]"
+msgstr ""
+
+#: schematic/src/x_window.c:889
+msgid "Saved"
+msgstr ""
+
+#: schematic/src/x_window.c:966
+#, c-format
+msgid "Discarding page [%1$s]"
+msgstr ""
+
+#: schematic/src/x_window.c:966
+#, c-format
+msgid "Closing [%1$s]"
+msgstr ""
+
+#: schematic/src/x_window.c:1175
+msgid "New"
+msgstr ""
+
+#: schematic/src/x_window.c:1175
+msgid "New file"
+msgstr ""
+
+#: schematic/src/x_window.c:1179
+msgid "Open"
+msgstr ""
+
+#: schematic/src/x_window.c:1179
+msgid "Open file"
+msgstr ""
+
+#: schematic/src/x_window.c:1183 schematic/scheme/gschem/builtins.scm:59
+msgid "Save"
+msgstr ""
+
+#: schematic/src/x_window.c:1183
+msgid "Save file"
+msgstr ""
+
+#: schematic/src/x_window.c:1189 schematic/scheme/gschem/builtins.scm:93
+msgid "Undo"
+msgstr ""
+
+#: schematic/src/x_window.c:1189
+msgid "Undo last operation"
+msgstr ""
+
+#: schematic/src/x_window.c:1193 schematic/scheme/gschem/builtins.scm:96
+msgid "Redo"
+msgstr ""
+
+#: schematic/src/x_window.c:1193
+msgid "Redo last undo"
+msgstr ""
+
+#: schematic/src/x_window.c:1198
+msgid ""
+"Add component...\n"
+"Select library and component from list, move the mouse into main window, "
+"click to place\n"
+"Right mouse button to cancel"
+msgstr ""
+
+#: schematic/src/x_window.c:1209
+msgid ""
+"Add nets mode\n"
+"Right mouse button to cancel"
+msgstr ""
+
+#: schematic/src/x_window.c:1217
+msgid ""
+"Add buses mode\n"
+"Right mouse button to cancel"
+msgstr ""
+
+#: schematic/src/x_window.c:1226
+msgid "Add Text..."
+msgstr ""
+
+#: schematic/src/x_window.c:1233
+msgid "Select mode"
+msgstr ""
+
+#: schematic/src/x_window.c:1288
+msgid "Show"
+msgstr ""
+
+#: schematic/src/x_window.c:1289
+msgid "Show text starting with:"
+msgstr ""
+
+#: schematic/src/x_window.c:1345
+msgid "Menu/Cancel"
+msgstr ""
+
+#: schematic/src/x_window.c:1349
+msgid "Pan/Cancel"
+msgstr ""
+
+#: schematic/src/x_window.c:1359
+msgid "Pick"
+msgstr ""
+
+#: schematic/src/x_window.c:1470 schematic/scheme/gschem/builtins.scm:180
+msgid "Status"
+msgstr ""
+
+#: schematic/src/x_window.c:1568
+#, c-format
+msgid "New file [%s]"
+msgstr ""
+
+#: schematic/src/x_window.c:1598
+#, c-format
+msgid ""
+"<b>An error occurred while loading the requested file.</b>\n"
+"\n"
+"Loading from '%1$s' failed. Error message:\n"
+"\n"
+"%2$s.\n"
+"\n"
+"The lepton-schematic log may contain more information.\n"
+"You may also launch lepton-schematic with --verbose command line switch and "
+"monitor program's output in terminal window."
+msgstr ""
+
+#: schematic/src/x_window.c:1617
+msgid "Failed to load file"
+msgstr ""
+
+#: schematic/data/lepton-schematic.desktop.in:3
+msgid "Lepton EDA Schematic Editor"
+msgstr ""
+
+#: schematic/data/lepton-schematic.desktop.in:4
+msgid "Create and edit electrical schematics and symbols with lepton-schematic"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:27
+msgid "_New"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:28
+msgid "_Open..."
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:30
+msgid "Open Recen_t"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:32
+msgid "_Save"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:33
+msgid "Save _As..."
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:34
+#: schematic/scheme/gschem/builtins.scm:65
+msgid "Save All"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:36
+msgid "_Print..."
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:37
+msgid "Write _Image..."
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:39
+msgid "Invoke Macro..."
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:41
+msgid "REPL..."
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:43
+#: schematic/scheme/gschem/builtins.scm:77
+msgid "New Window"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:44
+msgid "_Close Window"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:45
+msgid "_Quit"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:51
+msgid "_Undo"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:52
+msgid "_Redo"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:54
+msgid "Cu_t"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:55
+msgid "_Copy"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:56
+msgid "_Paste"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:57
+msgid "_Delete"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:60
+#: schematic/scheme/gschem/builtins.scm:102
+msgid "Select All"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:61
+#: schematic/scheme/gschem/builtins.scm:105
+msgid "Deselect"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:65
+msgid "Rotate 90 Mode"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:70
+msgid "Edit Text..."
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:71
+msgid "Slot..."
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:76
+#: schematic/scheme/gschem/builtins.scm:150
+msgid "Embed Component/Picture"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:77
+#: schematic/scheme/gschem/builtins.scm:153
+msgid "Unembed Component/Picture"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:78
+#: schematic/scheme/gschem/builtins.scm:156
+msgid "Update Component"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:79
+msgid "Symbol Translate..."
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:85
+msgid "Copy into 1"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:86
+msgid "Copy into 2"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:87
+msgid "Copy into 3"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:88
+msgid "Copy into 4"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:89
+msgid "Copy into 5"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:90
+msgid "Cut into 1"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:91
+msgid "Cut into 2"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:92
+msgid "Cut into 3"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:93
+msgid "Cut into 4"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:94
+msgid "Cut into 5"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:95
+msgid "Paste from 1"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:96
+msgid "Paste from 2"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:97
+msgid "Paste from 3"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:98
+msgid "Paste from 4"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:99
+msgid "Paste from 5"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:105
+msgid "Side Dock"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:106
+msgid "Bottom Dock"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:108
+msgid "Find Text Results"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:110
+msgid "_Redraw"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:111
+msgid "_Pan"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:112
+msgid "Zoom _Box"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:113
+msgid "Zoom _Extents"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:114
+msgid "Zoom _In"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:115
+msgid "Zoom _Out"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:116
+msgid "Zoom _Full"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:118
+msgid "_Dark Color Scheme"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:119
+msgid "_Light Color Scheme"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:120
+msgid "B_W Color Scheme"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:122
+msgid "Color Scheme Editor..."
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:129
+msgid "_Manager..."
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:131
+msgid "_Previous"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:132
+msgid "_Next"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:133
+msgid "_Close"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:135
+msgid "_Revert..."
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:137
+#: schematic/scheme/gschem/builtins.scm:249
+msgid "Next Tab"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:138
+#: schematic/scheme/gschem/builtins.scm:252
+msgid "Previous Tab"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:146
+msgid "_Component..."
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:148
+msgid "_Net"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:149
+msgid "B_us"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:151
+msgid "_Attribute..."
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:152
+msgid "_Text..."
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:154
+msgid "_Line"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:155
+msgid "Pat_h"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:156
+msgid "_Box"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:157
+msgid "C_ircle"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:158
+msgid "A_rc"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:159
+msgid "_Pin"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:161
+msgid "Pictu_re..."
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:167
+msgid "_Up"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:169
+msgid "_Down Schematic"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:170
+msgid "Down _Symbol"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:176
+msgid "_Attach"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:177
+msgid "_Detach"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:179
+msgid "Show _Value"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:180
+msgid "Show _Name"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:181
+msgid "Show _Both"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:182
+msgid "_Toggle Visibility"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:184
+msgid "_Hide Specific Text..."
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:185
+msgid "_Show Specific Text..."
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:186
+msgid "Show/Hide Hidden Text"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:188
+msgid "_Find Text/Check Symbol..."
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:189
+msgid "A_utonumber Text..."
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:195
+msgid "_Options..."
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:196
+msgid "_Font..."
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:198
+msgid "Grid +"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:199
+msgid "Grid -"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:201
+msgid "Grid Style: Cycle Dots/Mesh/Off"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:202
+msgid "Grid Snap: Cycle Grid/Resnap/Off"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:204
+msgid "Feedback Mode: Outline/Box"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:205
+msgid "Net: Rubberband On/Off"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:206
+msgid "Net: Magnetic On/Off"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:208
+msgid "_Coord Window"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:209
+msgid "_Log Window"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:215
+msgid "_1 allegro"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:223
+msgid "User _Guide"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:224
+msgid "_FAQ"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:225
+msgid "Docu_mentation"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:226
+msgid "_Wiki"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:228
+msgid "Find Component D_ocumentation"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:230
+msgid "_Hotkeys..."
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:231
+msgid "_About"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:237
+msgid "_File"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:238
+msgid "_Edit"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:240
+msgid "_View"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:241
+msgid "_Page"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:242
+msgid "_Add"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:243
+msgid "Hie_rarchy"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:244
+msgid "A_ttributes"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:245
+msgid "_Options"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:246
+msgid "_Netlist"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:247
+msgid "_Help"
+msgstr ""
+
+#: schematic/scheme/gschem/action.scm:43
+#, scheme-format
+msgid "~S is not a valid gschem action."
+msgstr ""
+
+#: schematic/scheme/gschem/action.scm:162
+msgid "Repeat Last Action"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:47
+msgid "Cancel"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:53
+msgid "New File"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:56
+msgid "Open File"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:62
+msgid "Save As"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:68
+msgid "Print"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:71
+msgid "Export Image"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:74
+msgid "Run Script"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:80
+msgid "Close Window"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:83
+msgid "Quit"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:87
+msgid "Terminal REPL"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:132
+msgid "Choose Slot"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:135
+msgid "Edit Object Properties"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:138
+msgid "Translate Symbol"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:147
+msgid "Invoke Macro"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:159
+msgid "Show/Hide Invisible Text"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:165
+msgid "Cut"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:171
+msgid "Paste"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:177
+msgid "Sidebar"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:183
+msgid "Find Text State"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:186
+msgid "Redraw"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:192
+msgid "Pan Left"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:195
+msgid "Pan Right"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:198
+msgid "Pan Up"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:201
+msgid "Pan Down"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:216
+msgid "Zoom Full"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:219
+msgid "Dark Color Scheme"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:222
+msgid "Light Color Scheme"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:225
+msgid "Monochrome Color Scheme"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:228
+msgid "Show Color Scheme Editor"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:234
+msgid "Revert Changes"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:240
+msgid "Previous Page"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:243
+msgid "Next Page"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:255
+msgid "Print Page"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:276
+msgid "Add Line"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:279
+msgid "Add Path"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:282
+msgid "Add Box"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:285
+msgid "Add Circle"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:288
+msgid "Add Arc"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:291
+msgid "Add Pin"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:294
+msgid "Add Picture"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:306
+msgid "Up Hierarchy"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:312
+msgid "Attach Attributes"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:315
+msgid "Detach Attributes"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:318
+msgid "Show Attribute Value"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:321
+msgid "Show Attribute Name"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:327
+msgid "Toggle Text Visibility"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:330
+msgid "Find Specific Text"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:333
+msgid "Hide Specific Text"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:336
+msgid "Show Specific Text"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:339
+msgid "Autonumber Text"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:345
+msgid "Show Hotkeys"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:348
+msgid "Switch Grid Style"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:351
+msgid "Switch Snap Mode"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:354
+msgid "Set Grid Spacing"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:357
+msgid "Increase Grid Spacing"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:360
+msgid "Decrease Grid Spacing"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:363
+msgid "Toggle Outline Drawing"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:366
+msgid "Toggle Net Rubber Band"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:369
+msgid "Toggle Magnetic Nets"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:372
+msgid "Show Log Window"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:375
+msgid "Show Coordinate Window"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:385
+msgid "Component Documentation"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:387
+msgid "View documentation for selected component"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:403
+msgid ""
+"Could not show documentation for selected component:\n"
+"\n"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:408
+msgid "gEDA Manuals"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:409
+msgid "View the front page of the gEDA documentation in a browser."
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:414
+msgid "gschem User Guide"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:415
+msgid "View the gschem User Guide in a browser."
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:420
+msgid "gschem FAQ"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:421
+msgid "Frequently Asked Questions about using gschem."
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:426
+msgid "gEDA wiki"
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:427
+msgid "View the front page of the gEDA wiki in a browser."
+msgstr ""
+
+#: schematic/scheme/gschem/builtins.scm:431
+msgid "About gschem"
+msgstr ""
+
+#: schematic/scheme/gschem/deprecated.scm:102
+#, scheme-format
+msgid "Invalid text alignment ~A."
+msgstr ""
+
+#: schematic/scheme/gschem/gschemdoc.scm.in:218
+msgid "No documentation found"
+msgstr ""
+
+#: schematic/scheme/gschem/keymap.scm:40
+#, scheme-format
+msgid "~S is not a valid key combination."
+msgstr ""
+
+#: schematic/scheme/gschem/keymap.scm:157
+#, scheme-format
+msgid "~S is not a prefix key sequence."
+msgstr ""

--- a/schematic/po/ml.po
+++ b/schematic/po/ml.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-15 15:13+0300\n"
+"POT-Creation-Date: 2019-02-22 14:08+0300\n"
 "PO-Revision-Date: 2012-01-27 14:23+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -18,22 +18,18 @@ msgstr ""
 "X-Launchpad-Export-Date: 2012-11-14 16:52+0000\n"
 "X-Generator: Launchpad (build 16265)\n"
 
-#: schematic/src/a_zoom.c:155
 msgid "Zoom too small!  Cannot zoom further."
 msgstr ""
 
-#: schematic/src/color_edit_widget.c:399
 #, c-format
 msgid ""
 "Could not save file [%s]:\n"
 "%s"
 msgstr ""
 
-#: schematic/src/color_edit_widget.c:434
 msgid "Save Color Scheme As..."
 msgstr ""
 
-#: schematic/src/color_edit_widget.c:482 schematic/src/x_fileselect.c:292
 #, c-format
 msgid ""
 "The selected file `%1$s' already exists.\n"
@@ -41,178 +37,140 @@ msgid ""
 "Would you like to overwrite it?"
 msgstr ""
 
-#: schematic/src/color_edit_widget.c:486 schematic/src/x_fileselect.c:295
 msgid "Overwrite file?"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:211
 msgid "_Apply"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:215
 msgid "Sa_ve..."
 msgstr ""
 
-#: schematic/src/font_select_widget.c:278
 #, c-format
 msgid "<b>Current:</b> %s"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:453
 msgid "Save configuration"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:461
 msgid "Save settings to:"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:465
 msgid "Local configuration file (in current directory)"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:467
 msgid "User configuration file (geda-user.conf)"
 msgstr ""
 
-#: schematic/src/g_attrib.c:90
 msgid "Object ~A is not included in the current gschem page."
 msgstr ""
 
-#: schematic/src/g_attrib.c:110
 msgid "Invalid text name/value visibility ~A."
 msgstr ""
 
-#: schematic/src/g_rc.c:107
 #, c-format
 msgid "You are running gEDA/gaf version [%1$s%2$s.%3$s],\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:111
 #, c-format
 msgid ""
 "but you have a version [%1$s] gschemrc file:\n"
 "[%2$s]\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:114
 #, c-format
 msgid "Please be sure that you have the latest rc file.\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:240
 #, c-format
 msgid "Invalid size [%1$d] passed to text-size\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:283
 #, c-format
 msgid "Invalid size [%1$d] passed to snap-size\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:620
 #, c-format
 msgid "Invalid num levels [%1$d] passed to undo-levels\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:831
 #, c-format
 msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:931
 #, c-format
 msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:972
 #, c-format
 msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:998
 #, c-format
 msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1023
 #, c-format
 msgid "Invalid offset [%1$d] passed to add-attribute-offset\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1047
 #, c-format
 msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1071
 #, c-format
 msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1094
 #, c-format
 msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1118
 #, c-format
 msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1144
 #, c-format
 msgid "Invalid gain [%1$d] passed to zoom-gain\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1169
 #, c-format
 msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
 msgstr ""
 
-#: schematic/src/g_select.c:78 schematic/src/g_select.c:115
-#: schematic/src/g_select.c:151
 msgid "Object ~A is not directly included in a page."
 msgstr ""
 
-#: schematic/src/g_util.c:54
 msgid "Could not launch URI ~S: ~A"
 msgstr ""
 
-#: schematic/src/g_window.c:139
 msgid "Found invalid gschem window smob ~S"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:156
 #, c-format
 msgid "Lepton EDA/lepton-schematic version %1$s%2$s.%3$s git: %4$.7s"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:163
 #, c-format
 msgid "This is the MINGW32 port.\n"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:167
 #, c-format
 msgid "Current locale settings: %1$s\n"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:201
 #, c-format
 msgid "Couldn't find init scm file [%1$s]"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:206
 #, c-format
 msgid "Read init scm file [%1$s]"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:210
 #, c-format
 msgid "Failed to read init scm file [%1$s]"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:290
 #, c-format
 msgid ""
 "ERROR: Failed to load or evaluate startup script.\n"
@@ -220,685 +178,500 @@ msgid ""
 "The lepton-schematic log may contain more information.\n"
 msgstr ""
 
-#: schematic/src/gschem_about_dialog.c:51
 #, c-format
 msgid "%s (git: %.7s)"
 msgstr ""
 
-#: schematic/src/gschem_about_dialog.c:75
 msgid "Lepton Electronic Design Automation"
 msgstr ""
 
-#: schematic/src/gschem_about_dialog.c:83
 msgid ""
 "Copyright © 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright © 2017-2018 Lepton Developers.\n"
-"See AUTHORS and ChangeLog files for details."
+"Copyright © 2017-2019 Lepton Developers.\n"
+"See AUTHORS, ChangeLog files and consult 'git log' history for details."
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:69
 msgid "Upper Left"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:71
 msgid "Upper Middle"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:73
 msgid "Upper Right"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:78
 msgid "Middle Left"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:80
 msgid "Middle Middle"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:82
 msgid "Middle Right"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:87
 msgid "Lower Left"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:89
 msgid "Lower Middle"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:91
 msgid "Lower Right"
 msgstr ""
 
-#: schematic/src/gschem_arc_dialog.c:104
 msgid "Arc Params"
 msgstr ""
 
-#: schematic/src/gschem_arc_dialog.c:140
 msgid "Arc _Radius:"
 msgstr ""
 
-#: schematic/src/gschem_arc_dialog.c:141
 msgid "Start _Angle:"
 msgstr ""
 
-#: schematic/src/gschem_arc_dialog.c:142
 msgid "_Degrees of Sweep:"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:504
 msgid "Left mouse button"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:508
 msgid "Middle mouse button"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:512
 msgid "Right mouse button"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:595
 msgid "(Snap size, Grid size)"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:603
 msgid "Net rubber band mode"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:614
 msgid "Magnetic net mode"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:622
 msgid "Current action mode"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:935
-#: schematic/src/gschem_bottom_widget.c:951
 msgid "OFF"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:954
 msgid "NONE"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:960
 #, c-format
 msgid "Grid(%1$s, %2$s)"
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:350
-#: schematic/src/x_compselect.c:1236 schematic/src/x_multiattrib.c:2068
 msgid "Name"
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:372
 msgid "S_elect the schematics you want to save:"
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:467
 #, c-format
 msgid "Save the changes to schematic \"%1$s\" before closing?"
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:473
 #, c-format
 msgid ""
 "There are %1$d schematics with unsaved changes. Save changes before closing?"
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:502
 msgid "If you don't save, all your changes will be permanently lost."
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:522
 msgid "Close _without saving"
 msgstr ""
 
-#: schematic/src/gschem_coord_dialog.c:86
 msgid "Coords"
 msgstr ""
 
-#: schematic/src/gschem_coord_dialog.c:106
 msgid "Screen"
 msgstr ""
 
-#: schematic/src/gschem_coord_dialog.c:115
 msgid "World"
 msgstr ""
 
-#: schematic/src/gschem_find_text_state.c:809 schematic/src/x_pagesel.c:432
 msgid "Filename"
 msgstr ""
 
-#: schematic/src/gschem_find_text_state.c:821 schematic/src/i_callbacks.c:1970
-#: schematic/src/x_colorcb.c:154 schematic/src/x_widgets.c:179
-#: schematic/src/x_window.c:1226 schematic/src/x_window.c:1440
 msgid "Text"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:427
 msgid "descend into hierarchy"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:435
 msgid "Find"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:557
 msgid "Find Text:"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:564
 msgid "Find Pattern:"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:571
 msgid "Find Regex:"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:578
 msgid "Check symbol:"
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:200
 msgid "Hotkeys"
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:229
 msgid ""
 "Start typing action name or keystroke to filter the list.\n"
 "Type hotkeys as they are displayed in \"Keystroke(s)\" column."
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:233 schematic/src/x_compselect.c:1124
 #, fuzzy
 msgid "_Filter:"
 msgstr "ഫയല്‍"
 
-#: schematic/src/gschem_hotkey_dialog.c:259 schematic/src/i_basic.c:280
 msgid "Action"
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:277
 msgid "Keystroke(s)"
 msgstr ""
 
-#: schematic/src/gschem_log_widget.c:177
 msgid "** Invalid UTF-8 in log message. See stderr or gschem.log.\n"
 msgstr ""
 
-#: schematic/src/gschem_log_widget.c:434
 #, fuzzy
 msgid "Clear log window?"
 msgstr "പുതിയ ജാലകം"
 
-#: schematic/src/gschem_log_widget.c:477
 #, fuzzy
 msgid "Clear Log _Window"
 msgstr "പുതിയ ജാലകം"
 
-#: schematic/src/gschem_macro_widget.c:231
 msgid "Macro:"
 msgstr ""
 
-#: schematic/src/gschem_macro_widget.c:387
 msgid "Evaluate"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:172
 #, fuzzy
 msgid "_Fill Type:"
 msgstr "ലൈന്‍ വീതിയും , തരവും"
 
-#: schematic/src/gschem_object_properties_widget.c:173
 #, fuzzy
 msgid "Lin_e Width:"
 msgstr "ലൈന്‍ വീതിയും , തരവും"
 
-#: schematic/src/gschem_object_properties_widget.c:174
 msgid "Angle _1:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:175
 msgid "P_itch 1:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:176
 msgid "Angle _2:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:177
 msgid "Pitc_h 2:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:237
 msgid "<b>Fill Properties</b>"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:255
-#: schematic/src/gschem_text_properties_widget.c:258
-#: schematic/src/x_newtext.c:271
 #, fuzzy
 msgid "Colo_r:"
 msgstr "കളര്‍"
 
-#: schematic/src/gschem_object_properties_widget.c:266
 msgid "<b>General Properties</b>"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:284
 #, fuzzy
 msgid "_Type:"
 msgstr "ലൈന്‍ വീതിയും , തരവും"
 
-#: schematic/src/gschem_object_properties_widget.c:285
 #, fuzzy
 msgid "_Width:"
 msgstr "ലൈന്‍ വീതിയും , തരവും"
 
-#: schematic/src/gschem_object_properties_widget.c:286
 msgid "Dash _Length:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:287
 msgid "Dash _Space:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:288
 msgid "C_ap style:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:333
 msgid "<b>Line Properties</b>"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:351
 #, fuzzy
 msgid "_Pin Type:"
 msgstr "ലൈന്‍ വീതിയും , തരവും"
 
-#: schematic/src/gschem_object_properties_widget.c:362
 msgid "<b>Pin Properties</b>"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:217
 msgid "_Off"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:220
 msgid "_Dots"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:223
 msgid "M_esh"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:245
 msgid "Net R_ubber Band Mode:"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:246
 msgid "_Magnetic Net Mode:"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:250
-#: schematic/src/gschem_options_widget.c:251
 msgid "Enabled"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:265
 msgid "<b>Net Options</b>"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:282
 msgid "Grid Mode:"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:283
 #, fuzzy
 msgid "Snap Mode:"
 msgstr "പ്രവര്‍ത്തന രീതി നിര്‍ണയിക്കുക"
 
-#: schematic/src/gschem_options_widget.c:284
 #, fuzzy
 msgid "_Snap Size:"
 msgstr "പ്രവര്‍ത്തന രീതി നിര്‍ണയിക്കുക"
 
-#: schematic/src/gschem_options_widget.c:301
 msgid "<b>Snap Options</b>"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:340
 msgid "O_ff"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:343
 msgid "_Grid"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:346
 msgid "_Resnap"
 msgstr ""
 
-#: schematic/src/gschem_pin_type_combo.c:73
 msgid "Net pin"
 msgstr ""
 
-#: schematic/src/gschem_pin_type_combo.c:80
 msgid "Bus pin (graphical)"
 msgstr ""
 
-#: schematic/src/gschem_preview.c:195
 msgid "Preview Buffer"
 msgstr ""
 
-#: schematic/src/gschem_show_hide_text_widget.c:148
-#: schematic/src/x_window.c:1268
 msgid "Hide"
 msgstr ""
 
-#: schematic/src/gschem_show_hide_text_widget.c:157
-#: schematic/src/x_window.c:1269
 msgid "Hide text starting with:"
 msgstr ""
 
-#: schematic/src/gschem_slot_edit_dialog.c:91
 msgid "Edit slot number"
 msgstr ""
 
-#: schematic/src/gschem_slot_edit_dialog.c:121
 msgid "Number of Slots:"
 msgstr ""
 
-#: schematic/src/gschem_slot_edit_dialog.c:122
 msgid "Slot Number:"
 msgstr ""
 
-#: schematic/src/gschem_text_properties_widget.c:240
-#: schematic/src/x_newtext.c:265
 msgid "<b>Text Content</b>"
 msgstr ""
 
-#: schematic/src/gschem_text_properties_widget.c:259
-#: schematic/src/x_newtext.c:291
 msgid "_Size:"
 msgstr ""
 
-#: schematic/src/gschem_text_properties_widget.c:260
-#: schematic/src/x_newtext.c:310
 msgid "Ali_gnment:"
 msgstr ""
 
-#: schematic/src/gschem_text_properties_widget.c:261
-#: schematic/src/x_newtext.c:330
 msgid "Ro_tation:"
 msgstr ""
 
-#: schematic/src/gschem_text_properties_widget.c:294
-#: schematic/src/x_newtext.c:253
 msgid "<b>Text Properties</b>"
 msgstr ""
 
-#: schematic/src/gschem_translate_widget.c:238
 msgid "Coordinate:"
 msgstr ""
 
-#: schematic/src/gschem_translate_widget.c:405 schematic/src/i_callbacks.c:800
 msgid "Translate"
 msgstr ""
 
-#: schematic/src/i_basic.c:64 schematic/src/x_window.c:1369
-#: schematic/scheme/conf/schematic/menu.scm:59
-#: schematic/scheme/gschem/builtins.scm:99
 msgid "Select Mode"
 msgstr "പ്രവര്‍ത്തന രീതി നിര്‍ണയിക്കുക"
 
-#: schematic/src/i_basic.c:65
 #, fuzzy
 msgid "Select Box Mode"
 msgstr "പ്രവര്‍ത്തന രീതി നിര്‍ണയിക്കുക"
 
-#: schematic/src/i_basic.c:66
 msgid "Text Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:67
 msgid "Pan Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:70
 #, c-format
 msgid "Paste %d Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:74
 msgid "Magnetic Net Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:76
 msgid "Net Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:77
 msgid "Arc Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:78
 msgid "Box Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:79
 msgid "Bus Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:80
 msgid "Circle Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:81
 msgid "Component Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:82 schematic/scheme/conf/schematic/menu.scm:62
-#: schematic/scheme/gschem/builtins.scm:114
 msgid "Copy Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:83 schematic/scheme/conf/schematic/menu.scm:63
-#: schematic/scheme/gschem/builtins.scm:117
 msgid "Multiple Copy Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:84
 msgid "Line Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:85 schematic/scheme/conf/schematic/menu.scm:66
-#: schematic/scheme/gschem/builtins.scm:123
 msgid "Mirror Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:86 schematic/scheme/conf/schematic/menu.scm:64
-#: schematic/scheme/gschem/builtins.scm:111
 msgid "Move Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:87
 #, fuzzy
 msgid "Path Mode"
 msgstr "പ്രവര്‍ത്തന രീതി നിര്‍ണയിക്കുക"
 
-#: schematic/src/i_basic.c:88
 msgid "Picture Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:89
 msgid "Pin Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:90 schematic/scheme/gschem/builtins.scm:120
 msgid "Rotate Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:91
 msgid "Modify Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:92 schematic/src/x_menus.c:49
-#: schematic/scheme/gschem/builtins.scm:204
 msgid "Zoom Box"
 msgstr "വലുതാക്കി കാണിക്കുന്ന പെട്ടി"
 
-#: schematic/src/i_basic.c:121
 msgid "Show Hidden"
 msgstr ""
 
-#: schematic/src/i_basic.c:124
 msgid "Snap Off"
 msgstr ""
 
-#: schematic/src/i_basic.c:126
 msgid "Resnap Active"
 msgstr ""
 
-#: schematic/src/i_basic.c:288 schematic/src/x_colorcb.c:159
 msgid "Stroke"
 msgstr ""
 
-#: schematic/src/i_basic.c:296 schematic/src/i_basic.c:330
-#: schematic/src/x_window.c:1361
 msgid "none"
 msgstr ""
 
-#: schematic/src/i_basic.c:304
 msgid "Repeat/"
 msgstr ""
 
-#: schematic/src/i_basic.c:315
 msgid "Repeat/none"
 msgstr ""
 
-#: schematic/src/i_basic.c:323 schematic/src/i_callbacks.c:1239
-#: schematic/scheme/gschem/builtins.scm:189
 msgid "Pan"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:74
 #, c-format
 msgid "New page created [%1$s]"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:108
 #, c-format
 msgid "New Window created [%1$s]"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:245
 msgid "Failed to Save All"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:247
 msgid "Saved All"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:308
 #, fuzzy
 msgid "Closing Window"
 msgstr "പുതിയ ജാലകം"
 
-#: schematic/src/i_callbacks.c:505 schematic/src/x_menus.c:55
-#: schematic/scheme/gschem/builtins.scm:168
 msgid "Copy"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:514 schematic/src/i_callbacks.c:539
-#: schematic/src/i_callbacks.c:564
 msgid "Select objs first"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:530
 msgid "Multiple Copy"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:555 schematic/src/x_menus.c:56
 msgid "Move"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:579 schematic/src/x_menus.c:57
-#: schematic/src/x_multiattrib.c:1656 schematic/scheme/gschem/builtins.scm:108
 msgid "Delete"
 msgstr "മായ്ക്കുക"
 
-#: schematic/src/i_callbacks.c:603
 msgid "Edit"
 msgstr "തിരുത്തിയെഴുതുക (Edit)"
 
-#: schematic/src/i_callbacks.c:618 schematic/scheme/gschem/builtins.scm:129
 msgid "Edit Text"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:637
 msgid "Slot"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:688 schematic/src/i_callbacks.c:698
 msgid "Rotate"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:736 schematic/src/i_callbacks.c:746
 msgid "Mirror"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:763 schematic/src/x_colorcb.c:160
-#: schematic/scheme/conf/schematic/menu.scm:73
-#: schematic/scheme/gschem/builtins.scm:141
 msgid "Lock"
 msgstr "പൂട്ടുക"
 
-#: schematic/src/i_callbacks.c:781 schematic/scheme/conf/schematic/menu.scm:74
-#: schematic/scheme/gschem/builtins.scm:144
 msgid "Unlock"
 msgstr "പൂട്ടു തുറക്കുക"
 
-#: schematic/src/i_callbacks.c:805
 msgid "WARNING: Do not translate with snap off!"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:806
 msgid "WARNING: Turning snap on and continuing with translate."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:813
 msgid "WARNING: Snap grid size is not equal to 100!"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:815
 msgid ""
 "WARNING: If you are translating a symbol to the origin, the snap grid size "
 "should be set to 100"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:847
 msgid "Embed"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:886
 msgid "Unembed"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:928
 msgid "Update"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:970
 msgid "ShowHidden"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1537
 #, c-format
 msgid ""
 "<b>Revert page:</b>\n"
@@ -909,98 +682,76 @@ msgid ""
 "discarded and page file will be reloaded from disk."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1555
 msgid "Revert"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1647
 msgid "Copy to clipboard"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1664
 msgid "Cut to clipboard"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1686
 msgid "Paste from clipboard"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1694
 msgid "Empty clipboard"
 msgstr ""
 
 #. TRANSLATORS: The number is the number of the buffer that the
 #. * selection is being copied to.
-#: schematic/src/i_callbacks.c:1719
 #, fuzzy, c-format
 msgid "Copy %i"
 msgstr "പകര്‍ത്തുക 1ലേക്ക്"
 
 #. TRANSLATORS: The number is the number of the buffer that the
 #. * selection is being cut to.
-#: schematic/src/i_callbacks.c:1746
 #, fuzzy, c-format
 msgid "Cut %i"
 msgstr "കട്ട് ചെയുക  1 ലേക്ക്"
 
 #. TRANSLATORS: The number is the number of the buffer that is being
 #. * pasted to the schematic.
-#: schematic/src/i_callbacks.c:1776
 #, fuzzy, c-format
 msgid "Paste %i"
 msgstr "പകര്‍ത്തി എടുക്കുക 1 ല്‍ നിന്നും"
 
-#: schematic/src/i_callbacks.c:1785
 msgid "Empty buffer"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1833 schematic/src/x_window.c:1203
 msgid "Component"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1865 schematic/src/x_colorcb.c:150
 msgid "Attribute"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1885 schematic/src/x_colorcb.c:149
 msgid "Net"
 msgstr "നെറ്റ്"
 
-#: schematic/src/i_callbacks.c:1928 schematic/src/x_colorcb.c:155
-#: schematic/src/x_window.c:1222
 msgid "Bus"
 msgstr "ബസ്"
 
-#: schematic/src/i_callbacks.c:2004
 msgid "Line"
 msgstr "രേഖ"
 
-#: schematic/src/i_callbacks.c:2021
 msgid "Path"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2043
 msgid "Box"
 msgstr "ബോക്സ്"
 
-#: schematic/src/i_callbacks.c:2085
 msgid "Circle"
 msgstr "വൃത്തം"
 
-#: schematic/src/i_callbacks.c:2108
 msgid "Arc"
 msgstr "അര്ദ്ധവൃത്തം"
 
-#: schematic/src/i_callbacks.c:2131 schematic/src/x_colorcb.c:146
 msgid "Pin"
 msgstr "പിന്‍"
 
-#: schematic/src/i_callbacks.c:2191
 #, c-format
 msgid "Searching for source [%1$s]"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2223
 #, c-format
 msgid ""
 "Failed to descend hierarchy into '%1$s': %2$s\n"
@@ -1008,106 +759,81 @@ msgid ""
 "The lepton-schematic log may contain more information."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2227
 #, c-format
 msgid "Failed to descend into '%1$s': %2$s"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2234
 msgid "Failed to descend hierarchy."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2312
 #, c-format
 msgid "Searching for symbol [%1$s]"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2320
 msgid "Symbol is not a real file. Symbol cannot be loaded."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2367 schematic/src/x_tabs.c:1060
 msgid "Cannot find any schematics above the current one!"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2400
 msgid "Attach"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2456
 msgid "Detach"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2500
 msgid "ShowN"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2537
 msgid "ShowV"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2574
 msgid "ShowB"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2612
 msgid "VisToggle"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2643
 #, c-format
 msgid "Sorry but this is a non-functioning menu option\n"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2703
 msgid "Action feedback mode set to OUTLINE"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2706
 msgid "Action feedback mode set to BOUNDINGBOX"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2730
 msgid "Grid OFF"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2731
 msgid "Dot grid selected"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2732
 msgid "Mesh grid selected"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2733
 msgid "Invalid grid mode"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2755
 msgid "Snap OFF (CAUTION!)"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2758
 msgid "Snap ON"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2761
 msgid "Snap back to the grid (CAUTION!)"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2790
 msgid "Rubber band ON"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2792
 msgid "Rubber band OFF"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2811
 msgid "magnetic net mode: ON"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2814
 msgid "magnetic net mode: OFF"
 msgstr ""
 
@@ -1116,133 +842,104 @@ msgstr ""
 #. the form "untitled_N.sch", where N is a number.  Please make
 #. sure that the translation contains characters suitable for use
 #. in a filename.
-#: schematic/src/i_vars.c:209
 msgid "untitled"
 msgstr ""
 
-#: schematic/src/o_complex.c:192 schematic/src/o_complex.c:195
 #, c-format
 msgid "Translating schematic [%1$d %2$d]"
 msgstr ""
 
-#: schematic/src/o_delete.c:82
 #, c-format
 msgid "Delete locked object?"
 msgid_plural "Delete %1$u locked objects?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/o_misc.c:55
 #, c-format
 msgid "Got an unexpected NULL in o_edit\n"
 msgstr ""
 
-#: schematic/src/o_misc.c:315
 msgid "Hidden text is now visible"
 msgstr ""
 
-#: schematic/src/o_misc.c:317
 msgid "Hidden text is now invisible"
 msgstr ""
 
-#: schematic/src/o_misc.c:425
 #, c-format
 msgid "Could not find symbol [%1$s] in library. Update failed."
 msgstr ""
 
-#: schematic/src/o_misc.c:541
 #, c-format
 msgid "o_autosave_backups: Can't get the real filename of %1$s."
 msgstr ""
 
-#: schematic/src/o_misc.c:585
 #, c-format
 msgid "Could NOT set previous backup file [%1$s] read-write"
 msgstr ""
 
-#: schematic/src/o_misc.c:605
 #, c-format
 msgid "Could NOT set backup file [%1$s] readonly"
 msgstr ""
 
-#: schematic/src/o_misc.c:610
 #, c-format
 msgid "Could NOT save backup file [%1$s]"
 msgstr ""
 
-#: schematic/src/o_move.c:192
 #, c-format
 msgid "ERROR: NULL object in o_move_end!\n"
 msgstr ""
 
-#: schematic/src/o_move.c:519
 #, c-format
 msgid "DOH! tried to find the whichone, but didn't find it!\n"
 msgstr ""
 
-#: schematic/src/o_move.c:546
 #, c-format
 msgid "Got a non line object in o_move_check_endpoint\n"
 msgstr ""
 
-#: schematic/src/o_net.c:444
 msgid "Warning: Starting net at off grid coordinate"
 msgstr ""
 
-#: schematic/src/o_net.c:508
 msgid "Warning: Ending net at off grid coordinate"
 msgstr ""
 
-#: schematic/src/o_net.c:856 schematic/src/o_net.c:893
-#: schematic/src/o_net.c:964 schematic/src/o_net.c:1000
 #, c-format
 msgid "Tried to add more than two bus rippers. Internal gschem error.\n"
 msgstr ""
 
-#: schematic/src/o_net.c:1068
 #, c-format
 msgid "Bus ripper symbol [%1$s] was not found in any component library"
 msgstr ""
 
-#: schematic/src/o_picture.c:133 schematic/src/o_picture.c:343
 msgid "Select a picture file..."
 msgstr ""
 
-#: schematic/src/o_picture.c:166
 #, c-format
 msgid "Failed to load picture: %1$s"
 msgstr ""
 
-#: schematic/src/o_picture.c:182
 msgid "Picture"
 msgstr ""
 
-#: schematic/src/o_picture.c:378
 #, c-format
 msgid "Failed to replace pictures: %s"
 msgstr ""
 
-#: schematic/src/o_slot.c:80
 msgid "Slot attribute malformed"
 msgstr ""
 
-#: schematic/src/o_slot.c:88
 msgid "numslots attribute missing"
 msgstr ""
 
-#: schematic/src/o_slot.c:89
 msgid "Slotting not allowed for this component"
 msgstr ""
 
-#: schematic/src/o_slot.c:104
 msgid "New slot number out of range"
 msgstr ""
 
-#: schematic/src/o_undo.c:397
 msgid "Undo/Redo disabled in rc file"
 msgstr ""
 
-#: schematic/src/parsecmd.c:77
 #, c-format
 msgid ""
 "Usage: %1$s [OPTION ...] [--] [FILE ...]\n"
@@ -1267,187 +964,143 @@ msgid ""
 "gEDA/gaf homepage: <http://www.geda-project.org/>\n"
 msgstr ""
 
-#: schematic/src/parsecmd.c:110
 #, c-format
 msgid ""
 "Lepton EDA %1$s (git: %2$.7s)\n"
 "Copyright (C) 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright (C) 2017-2018 Lepton Developers.\n"
+"Copyright (C) 2017-2019 Lepton Developers.\n"
 "This is free software, and you are welcome to redistribute it under\n"
 "certain conditions. For details, see the file `COPYING', which is\n"
 "included in the Lepton EDA distribution.\n"
 "There is NO WARRANTY, to the extent permitted by law.\n"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:125
 #, c-format
 msgid "Got invalid show option; defaulting to show both\n"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:139
 #, c-format
 msgid "ERROR: NULL object!\n"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:328
 msgid "Single Attribute Editor"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:358
 msgid "<b>Edit Attribute</b>"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:360
 msgid "<b>Add Attribute</b>"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:376
 msgid "N_ame:"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:396 schematic/src/x_multiattrib.c:2222
 msgid "_Value:"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:415 schematic/src/x_multiattrib.c:2281
 msgid "Vi_sible"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:434
 msgid "Show Value Only"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:436
 msgid "Show Name Only"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:438 schematic/src/x_multiattrib.c:1620
-#: schematic/scheme/gschem/builtins.scm:324
 msgid "Show Name & Value"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:445
 msgid "<b>Attach Options</b>"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:460
 msgid "All"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:476 schematic/src/x_compselect.c:986
-#: schematic/src/x_compselect.c:1100
 msgid "Components"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:492 schematic/src/x_window.c:1214
 msgid "Nets"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:508
 msgid "Replace existing attributes"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:412
 msgid ""
 "slotted object without slot attribute may cause problems when autonumbering "
 "slots"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:427
 #, c-format
 msgid ""
 "duplicate slot may cause problems: [symbolname=%1$s, number=%2$d, slot=%3$d]"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:675
 msgid "No searchstring given in autonumber text."
 msgstr ""
 
-#: schematic/src/x_autonumber.c:728
 msgid "No '*' or '?' given at the end of the autonumber text."
 msgstr ""
 
-#: schematic/src/x_autonumber.c:873
 msgid "Diagonal"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:874
 msgid "Top to bottom"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:875
 msgid "Bottom to top"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:876
 msgid "Left to right"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:877
 msgid "Right to left"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:878
 msgid "File order"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1214
 msgid "Autonumber text"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1237
 msgid "<b>Scope</b>"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1259
 msgid "Search for:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1273
 msgid "Autonumber text in:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1280
 msgid "Skip numbers found in:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1292 schematic/src/x_autonumber.c:1301
 msgid "Selected objects"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1293 schematic/src/x_autonumber.c:1302
 msgid "Current page"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1294 schematic/src/x_autonumber.c:1303
 msgid "Whole hierarchy"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1305
 msgid "Overwrite existing numbers"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1310
 msgid "<b>Options</b>"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1332
 msgid "Starting number:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1339
 msgid "Sort order:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1371
 msgid "Remove numbers"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1375
 msgid "Automatic slotting"
 msgstr ""
 
-#: schematic/src/x_clipboard.c:245
 #, c-format
 msgid ""
 "<b>Invalid schematic on clipboard.</b>\n"
@@ -1455,172 +1108,132 @@ msgid ""
 "An error occurred while inserting clipboard data: %s."
 msgstr ""
 
-#: schematic/src/x_clipboard.c:247
 msgid "Clipboard insertion failed"
 msgstr ""
 
-#: schematic/src/x_color.c:89 schematic/src/x_color.c:98
 #, c-format
 msgid "Could not allocate the color %1$s!\n"
 msgstr ""
 
-#: schematic/src/x_color.c:89
 msgid "black"
 msgstr ""
 
-#: schematic/src/x_color.c:98
 msgid "white"
 msgstr ""
 
-#: schematic/src/x_color.c:120
 #, c-format
 msgid "Could not allocate display color %1$i!\n"
 msgstr ""
 
-#: schematic/src/x_color.c:142
 #, c-format
 msgid "Could not allocate outline color %1$i!\n"
 msgstr ""
 
-#: schematic/src/x_color.c:159
 #, c-format
 msgid "Tried to get an invalid color: %1$d\n"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:145
 msgid "Background"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:147
 msgid "Net endpoint"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:148
 msgid "Graphic"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:151
 msgid "Logic bubble"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:152
 msgid "Grid point"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:153
 msgid "Detached attribute"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:156
 #, fuzzy
 msgid "Selection"
 msgstr "പ്രവര്‍ത്തന രീതി നിര്‍ണയിക്കുക"
 
-#: schematic/src/x_colorcb.c:157
 msgid "Bounding box"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:158
 #, fuzzy
 msgid "Zoom box"
 msgstr "വലുതാക്കി കാണിക്കുന്ന പെട്ടി"
 
-#: schematic/src/x_colorcb.c:161
 msgid "Output background"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:162
 msgid "Freestyle 1"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:163
 msgid "Freestyle 2"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:164
 msgid "Freestyle 3"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:165
 msgid "Freestyle 4"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:166
 msgid "Net junction"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:167
 msgid "Mesh grid major"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:168
 msgid "Mesh grid minor"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:172
 msgid "Unknown"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1169
 msgid "Reset filter"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1192
 msgid "Reload all libraries"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1245 schematic/src/x_multiattrib.c:2092
 msgid "Value"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1284
 msgid "Default behavior - reference component"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1287
 msgid "Embed component in schematic"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1290
 msgid "Include component as individual objects"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1448
 msgid "Select Component..."
 msgstr ""
 
-#: schematic/src/x_compselect.c:1471
 msgid "In Us_e"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1475
 msgid "Lib_raries"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1484 schematic/src/x_fileselect.c:119
 msgid "Preview"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1510
 msgid "Attributes"
 msgstr ""
 
-#: schematic/src/x_dialog.c:325
 msgid "Major symbol changes detected."
 msgstr ""
 
-#: schematic/src/x_dialog.c:349
 msgid ""
 "Changes have occurred to the symbols shown below.\n"
 "\n"
 "Be sure to verify each of these symbols."
 msgstr ""
 
-#: schematic/src/x_dialog.c:369
 msgid "Symbol"
 msgstr ""
 
-#: schematic/src/x_dialog.c:406
 #, c-format
 msgid ""
 "<span weight=\"bold\" size=\"larger\">The input attribute \"%s\" is invalid\n"
@@ -1631,39 +1244,30 @@ msgid ""
 "The value cannot start with a space."
 msgstr ""
 
-#: schematic/src/x_dialog.c:408
 msgid "Invalid Attribute"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:37
 msgid "Schematics"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:42
 msgid "Symbols"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:47
 msgid "Schematics and symbols"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:53
 msgid "All files"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:169
 msgid "Open..."
 msgstr ""
 
-#: schematic/src/x_fileselect.c:233
 msgid "Save as..."
 msgstr ""
 
-#: schematic/src/x_fileselect.c:297
 msgid "Save cancelled on user request"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:334
 msgid ""
 "\n"
 "If you load the original file, the backup file will be overwritten in the "
@@ -1672,28 +1276,22 @@ msgid ""
 "Do you want to load the backup file?\n"
 msgstr ""
 
-#: schematic/src/x_fstylecb.c:73
 msgid "Hollow"
 msgstr ""
 
-#: schematic/src/x_fstylecb.c:80
 msgid "Filled"
 msgstr ""
 
-#: schematic/src/x_fstylecb.c:87
 msgid "Mesh"
 msgstr ""
 
-#: schematic/src/x_fstylecb.c:94
 msgid "Hatch"
 msgstr ""
 
-#: schematic/src/x_image.c:279
 #, c-format
 msgid "x_image_lowlevel: Unable to write %1$s file %2$s."
 msgstr ""
 
-#: schematic/src/x_image.c:289
 #, c-format
 msgid ""
 "There was the following error when saving image with type %1$s to filename:\n"
@@ -1702,298 +1300,231 @@ msgid ""
 "%3$s.\n"
 msgstr ""
 
-#: schematic/src/x_image.c:309
 #, c-format
 msgid "Wrote color image to [%1$s] [%2$d x %3$d]"
 msgstr ""
 
-#: schematic/src/x_image.c:311
 #, c-format
 msgid "Wrote black and white image to [%1$s] [%2$d x %3$d]"
 msgstr ""
 
-#: schematic/src/x_image.c:319
 msgid "x_image_lowlevel: Unable to get pixbuf from gschem's window."
 msgstr ""
 
-#: schematic/src/x_image.c:358
 msgid "Width x Height"
 msgstr ""
 
-#: schematic/src/x_image.c:374
 msgid "Image type"
 msgstr ""
 
-#: schematic/src/x_image.c:395
 msgid "Write image..."
 msgstr ""
 
-#: schematic/src/x_linecapcb.c:74
 msgid "Butt"
 msgstr ""
 
-#: schematic/src/x_linecapcb.c:81
 msgid "Square"
 msgstr ""
 
-#: schematic/src/x_linecapcb.c:88
 msgid "Round"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:74
 msgid "Solid"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:81
 msgid "Dotted"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:88
 msgid "Dashed"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:95
 msgid "Center"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:102
 msgid "Phantom"
 msgstr ""
 
-#: schematic/src/x_menus.c:41 schematic/scheme/gschem/builtins.scm:267
 msgid "Add Net"
 msgstr ""
 
-#: schematic/src/x_menus.c:42 schematic/src/x_multiattrib.c:2187
-#: schematic/scheme/gschem/builtins.scm:264
 msgid "Add Attribute"
 msgstr ""
 
-#: schematic/src/x_menus.c:43 schematic/scheme/gschem/builtins.scm:261
 #, fuzzy
 msgid "Add Component"
 msgstr "സാധനത്തിലെ മാറ്റങ്ങള്‍ നടപ്പില്‍ വരുത്തുക"
 
-#: schematic/src/x_menus.c:44 schematic/scheme/gschem/builtins.scm:270
 msgid "Add Bus"
 msgstr ""
 
-#: schematic/src/x_menus.c:45 schematic/scheme/gschem/builtins.scm:273
 msgid "Add Text"
 msgstr ""
 
-#: schematic/src/x_menus.c:47 schematic/scheme/gschem/builtins.scm:210
 #, fuzzy
 msgid "Zoom In"
 msgstr "വലുതാക്കി കാണിക്കുന്ന പെട്ടി"
 
-#: schematic/src/x_menus.c:48 schematic/scheme/gschem/builtins.scm:213
 #, fuzzy
 msgid "Zoom Out"
 msgstr "വലുതാക്കി കാണിക്കുന്ന പെട്ടി"
 
-#: schematic/src/x_menus.c:50 schematic/scheme/gschem/builtins.scm:207
 #, fuzzy
 msgid "Zoom Extents"
 msgstr "വലുതാക്കി കാണിക്കുന്ന പെട്ടി"
 
-#: schematic/src/x_menus.c:52 schematic/src/x_window.c:1233
 msgid "Select"
 msgstr ""
 
-#: schematic/src/x_menus.c:53 schematic/scheme/conf/schematic/menu.scm:69
-#: schematic/scheme/gschem/builtins.scm:126
 msgid "Edit..."
 msgstr "മാറ്റം വരുത്തുക..."
 
-#: schematic/src/x_menus.c:54 schematic/scheme/conf/schematic/menu.scm:68
 msgid "Object Properties..."
 msgstr ""
 
-#: schematic/src/x_menus.c:59 schematic/scheme/gschem/builtins.scm:300
 msgid "Down Schematic"
 msgstr ""
 
-#: schematic/src/x_menus.c:60 schematic/scheme/gschem/builtins.scm:303
 msgid "Down Symbol"
 msgstr ""
 
-#: schematic/src/x_menus.c:61
 msgid "Up"
 msgstr ""
 
-#: schematic/src/x_menus.c:336
 #, c-format
 msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
 msgstr ""
 
-#: schematic/src/x_menus.c:360
 #, c-format
 msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
 msgstr ""
 
-#: schematic/src/x_misc.c:70
 msgid "The operating system is out of memory or resources."
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:798 schematic/src/x_multiattrib.c:2704
 msgid "<various>"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:930
 msgid "Attributes with empty name are not allowed. Please set a name."
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1622
 msgid "Show Value only"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1624
 msgid "Show Name only"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1651
 msgid "Promote"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1655
 msgid "Duplicate"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1657
 #, fuzzy
 msgid "Copy to all"
 msgstr "പകര്‍ത്തുക 1ലേക്ക്"
 
-#: schematic/src/x_multiattrib.c:1986 schematic/src/x_multiattrib.c:2602
 msgid "Edit Attributes"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2112
 msgid "Vis?"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2130
 msgid "N"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2148
 msgid "V"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2170
 msgid "Sho_w inherited attributes"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2197
 msgid "_Name:"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2241
 msgid "Ctrl+Enter inserts new line; Ctrl+Tab inserts Tab"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2618
 #, c-format
 msgid "%2$i symbol (%1$s)"
 msgid_plural "%2$i symbols (%1$s)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2624
 #, c-format
 msgid "%1$i pin"
 msgid_plural "%1$i pins"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2630
 #, c-format
 msgid "%1$i net"
 msgid_plural "%1$i nets"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2636
 #, c-format
 msgid "%1$i bus"
 msgid_plural "%1$i buses"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2642
 #, c-format
 msgid "%1$i attribute"
 msgid_plural "%1$i attributes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_newtext.c:433
 msgid "Text Entry..."
 msgstr ""
 
-#: schematic/src/x_pagesel.c:253
 msgid "New Page"
 msgstr "പുതിയ പേജ്"
 
-#: schematic/src/x_pagesel.c:254
 msgid "Open Page..."
 msgstr "പേജ് തുറക്കുക"
 
-#: schematic/src/x_pagesel.c:256
 msgid "Save Page"
 msgstr "പേജ് സേവ് ചെയുക"
 
-#: schematic/src/x_pagesel.c:257 schematic/scheme/gschem/builtins.scm:246
 msgid "Close Page"
 msgstr "പേജ് അടയ്ക്കുക"
 
-#: schematic/src/x_pagesel.c:376 schematic/scheme/gschem/builtins.scm:237
 msgid "Page Manager"
 msgstr ""
 
-#: schematic/src/x_pagesel.c:448
 msgid "Changed"
 msgstr ""
 
-#: schematic/src/x_pagesel.c:468
 msgid "Right click on the filename for more options..."
 msgstr ""
 
-#: schematic/src/x_print.c:306
 #, c-format
 msgid "Failed to write PDF to '%s': %s\n"
 msgstr ""
 
-#: schematic/src/x_print.c:364
 #, c-format
 msgid "Failed to write PDF to '%1$s': %2$s\n"
 msgstr ""
 
-#: schematic/src/x_print.c:449
 #, c-format
 msgid ""
 "Error printing file:\n"
 "%1$s"
 msgstr ""
 
-#: schematic/src/x_rc.c:39
 msgid "ERROR: An unknown error occurred while parsing configuration files."
 msgstr ""
 
-#: schematic/src/x_rc.c:44
 msgid ""
 "An unknown error occurred while parsing configuration files.\n"
 "\n"
 "The lepton-schematic log may contain more information."
 msgstr ""
 
-#: schematic/src/x_rc.c:56
 #, c-format
 msgid "ERROR: %1$s"
 msgstr ""
 
-#: schematic/src/x_rc.c:59
 #, c-format
 msgid ""
 "%1$s\n"
@@ -2001,136 +1532,105 @@ msgid ""
 "The lepton-schematic log may contain more information."
 msgstr ""
 
-#: schematic/src/x_rc.c:67
 msgid "Cannot load lepton-schematic configuration."
 msgstr ""
 
-#: schematic/src/x_script.c:42 schematic/scheme/conf/schematic/menu.scm:40
 msgid "Execute Script..."
 msgstr "സ്ക്രിപ്റ്റ് പ്രവര്‍ത്തിപ്പിക്കുക"
 
-#: schematic/src/x_script.c:61
 #, c-format
 msgid "Executing guile script [%1$s]"
 msgstr ""
 
-#: schematic/src/x_tabs.c:860
 #, c-format
 msgid "Hierarchy up: %s"
 msgstr ""
 
-#: schematic/src/x_tabs.c:863
 msgid "Hierarchy up"
 msgstr ""
 
-#: schematic/src/x_widgets.c:158 schematic/src/x_window.c:1444
 msgid "Options"
 msgstr ""
 
-#: schematic/src/x_widgets.c:203 schematic/src/x_window.c:1436
 msgid "Object"
 msgstr ""
 
-#: schematic/src/x_widgets.c:224
 msgid "Log"
 msgstr ""
 
-#: schematic/src/x_widgets.c:245 schematic/src/x_window.c:1466
 msgid "Find Text"
 msgstr ""
 
-#: schematic/src/x_widgets.c:259
 msgid "Color Scheme Editor"
 msgstr ""
 
-#: schematic/src/x_widgets.c:272 schematic/scheme/gschem/builtins.scm:378
 #, fuzzy
 msgid "Select Schematic Font"
 msgstr "പ്രവര്‍ത്തന രീതി നിര്‍ണയിക്കുക"
 
-#: schematic/src/x_window.c:763
 #, c-format
 msgid "Loading schematic [%1$s]"
 msgstr ""
 
-#: schematic/src/x_window.c:864
 #, c-format
 msgid "Could NOT save page [%1$s]\n"
 msgstr ""
 
-#: schematic/src/x_window.c:865
 msgid "Error while trying to save"
 msgstr ""
 
-#: schematic/src/x_window.c:875
 msgid "Failed to save file"
 msgstr ""
 
-#: schematic/src/x_window.c:885
 #, fuzzy, c-format
 msgid "Saved as [%1$s]"
 msgstr "എല്ലാം സേവ് ചെയുക"
 
-#: schematic/src/x_window.c:887
 #, fuzzy, c-format
 msgid "Saved [%1$s]"
 msgstr "എല്ലാം സേവ് ചെയുക"
 
-#: schematic/src/x_window.c:889
 msgid "Saved"
 msgstr ""
 
-#: schematic/src/x_window.c:966
 #, c-format
 msgid "Discarding page [%1$s]"
 msgstr ""
 
-#: schematic/src/x_window.c:966
 #, c-format
 msgid "Closing [%1$s]"
 msgstr ""
 
-#: schematic/src/x_window.c:1175
 msgid "New"
 msgstr "പുതിയ"
 
-#: schematic/src/x_window.c:1175
 msgid "New file"
 msgstr ""
 
-#: schematic/src/x_window.c:1179
 msgid "Open"
 msgstr ""
 
-#: schematic/src/x_window.c:1179
 msgid "Open file"
 msgstr ""
 
-#: schematic/src/x_window.c:1183 schematic/scheme/gschem/builtins.scm:59
 msgid "Save"
 msgstr ""
 
-#: schematic/src/x_window.c:1183
 msgid "Save file"
 msgstr ""
 
-#: schematic/src/x_window.c:1189 schematic/scheme/gschem/builtins.scm:93
 msgid "Undo"
 msgstr "തിരിച്ച് ചെയ്യുക"
 
-#: schematic/src/x_window.c:1189
 msgid "Undo last operation"
 msgstr ""
 
-#: schematic/src/x_window.c:1193 schematic/scheme/gschem/builtins.scm:96
 msgid "Redo"
 msgstr "ആവര്‍ത്തിക്കുക"
 
-#: schematic/src/x_window.c:1193
 msgid "Redo last undo"
 msgstr ""
 
-#: schematic/src/x_window.c:1198
 msgid ""
 "Add component...\n"
 "Select library and component from list, move the mouse into main window, "
@@ -2138,56 +1638,44 @@ msgid ""
 "Right mouse button to cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1209
 msgid ""
 "Add nets mode\n"
 "Right mouse button to cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1217
 msgid ""
 "Add buses mode\n"
 "Right mouse button to cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1226
 msgid "Add Text..."
 msgstr ""
 
-#: schematic/src/x_window.c:1233
 msgid "Select mode"
 msgstr ""
 
-#: schematic/src/x_window.c:1288
 msgid "Show"
 msgstr ""
 
-#: schematic/src/x_window.c:1289
 msgid "Show text starting with:"
 msgstr ""
 
-#: schematic/src/x_window.c:1345
 msgid "Menu/Cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1349
 msgid "Pan/Cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1359
 msgid "Pick"
 msgstr ""
 
-#: schematic/src/x_window.c:1470 schematic/scheme/gschem/builtins.scm:180
 msgid "Status"
 msgstr ""
 
-#: schematic/src/x_window.c:1568
 #, fuzzy, c-format
 msgid "New file [%s]"
 msgstr "പുതിയ പേജ്"
 
-#: schematic/src/x_window.c:1598
 #, c-format
 msgid ""
 "<b>An error occurred while loading the requested file.</b>\n"
@@ -2201,837 +1689,627 @@ msgid ""
 "monitor program's output in terminal window."
 msgstr ""
 
-#: schematic/src/x_window.c:1617
 msgid "Failed to load file"
 msgstr ""
 
-#: schematic/data/lepton-schematic.desktop.in:3
 msgid "Lepton EDA Schematic Editor"
 msgstr ""
 
-#: schematic/data/lepton-schematic.desktop.in:4
 msgid "Create and edit electrical schematics and symbols with lepton-schematic"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:27
 msgid "_New"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:28
 msgid "_Open..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:30
 msgid "Open Recen_t"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:32
 msgid "_Save"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:33
 msgid "Save _As..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:34
-#: schematic/scheme/gschem/builtins.scm:65
 msgid "Save All"
 msgstr "എല്ലാം സേവ് ചെയുക"
 
-#: schematic/scheme/conf/schematic/menu.scm:36
 msgid "_Print..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:37
 msgid "Write _Image..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:39
 msgid "Invoke Macro..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:41
 msgid "REPL..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:43
-#: schematic/scheme/gschem/builtins.scm:77
 msgid "New Window"
 msgstr "പുതിയ ജാലകം"
 
-#: schematic/scheme/conf/schematic/menu.scm:44
 msgid "_Close Window"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:45
 msgid "_Quit"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:51
 msgid "_Undo"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:52
 msgid "_Redo"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:54
 msgid "Cu_t"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:55
 msgid "_Copy"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:56
 msgid "_Paste"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:57
 msgid "_Delete"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:60
-#: schematic/scheme/gschem/builtins.scm:102
 msgid "Select All"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:61
-#: schematic/scheme/gschem/builtins.scm:105
 msgid "Deselect"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:65
 msgid "Rotate 90 Mode"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:70
 msgid "Edit Text..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:71
 msgid "Slot..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:76
-#: schematic/scheme/gschem/builtins.scm:150
 msgid "Embed Component/Picture"
 msgstr "പടം/സാധനം ഉള്ളടക്കം ചെയുക"
 
-#: schematic/scheme/conf/schematic/menu.scm:77
-#: schematic/scheme/gschem/builtins.scm:153
 msgid "Unembed Component/Picture"
 msgstr "പടം/സാധനം ഉള്ളടക്കം വേണ്ടയെന്നു വെയ്ക്കുക"
 
-#: schematic/scheme/conf/schematic/menu.scm:78
-#: schematic/scheme/gschem/builtins.scm:156
 msgid "Update Component"
 msgstr "സാധനത്തിലെ മാറ്റങ്ങള്‍ നടപ്പില്‍ വരുത്തുക"
 
-#: schematic/scheme/conf/schematic/menu.scm:79
 msgid "Symbol Translate..."
 msgstr "സിംബല്‍ വിവര്‍ത്തനം"
 
-#: schematic/scheme/conf/schematic/menu.scm:85
 msgid "Copy into 1"
 msgstr "പകര്‍ത്തുക 1ലേക്ക്"
 
-#: schematic/scheme/conf/schematic/menu.scm:86
 msgid "Copy into 2"
 msgstr "പകര്‍ത്തുക 2ലേക്ക്"
 
-#: schematic/scheme/conf/schematic/menu.scm:87
 msgid "Copy into 3"
 msgstr "പകര്‍ത്തുക 3ലേക്ക്"
 
-#: schematic/scheme/conf/schematic/menu.scm:88
 msgid "Copy into 4"
 msgstr "പകര്‍ത്തുക 4ലേക്ക്"
 
-#: schematic/scheme/conf/schematic/menu.scm:89
 msgid "Copy into 5"
 msgstr "പകര്‍ത്തുക 5ലേക്ക്"
 
-#: schematic/scheme/conf/schematic/menu.scm:90
 msgid "Cut into 1"
 msgstr "കട്ട് ചെയുക  1 ലേക്ക്"
 
-#: schematic/scheme/conf/schematic/menu.scm:91
 msgid "Cut into 2"
 msgstr "കട്ട് ചെയുക 2 ലേക്ക്"
 
-#: schematic/scheme/conf/schematic/menu.scm:92
 msgid "Cut into 3"
 msgstr "കട്ട് ചെയുക  3 ലേക്ക്"
 
-#: schematic/scheme/conf/schematic/menu.scm:93
 msgid "Cut into 4"
 msgstr "കട്ട് ചെയുക  4 ലേക്ക്"
 
-#: schematic/scheme/conf/schematic/menu.scm:94
 msgid "Cut into 5"
 msgstr "കട്ട് ചെയുക  5 ലേക്ക്"
 
-#: schematic/scheme/conf/schematic/menu.scm:95
 msgid "Paste from 1"
 msgstr "പകര്‍ത്തി എടുക്കുക 1 ല്‍ നിന്നും"
 
-#: schematic/scheme/conf/schematic/menu.scm:96
 msgid "Paste from 2"
 msgstr "പകര്‍ത്തി എടുക്കുക 2 ല്‍ നിന്നും"
 
-#: schematic/scheme/conf/schematic/menu.scm:97
 msgid "Paste from 3"
 msgstr "പകര്‍ത്തി എടുക്കുക 3ല്‍ നിന്നും"
 
-#: schematic/scheme/conf/schematic/menu.scm:98
 msgid "Paste from 4"
 msgstr "പകര്‍ത്തി എടുക്കുക 4ല്‍ നിന്നും"
 
-#: schematic/scheme/conf/schematic/menu.scm:99
 msgid "Paste from 5"
 msgstr "പകര്‍ത്തി എടുക്കുക 5 ല്‍ നിന്നും"
 
-#: schematic/scheme/conf/schematic/menu.scm:105
 msgid "Side Dock"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:106
 msgid "Bottom Dock"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:108
 msgid "Find Text Results"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:110
 msgid "_Redraw"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:111
 msgid "_Pan"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:112
 msgid "Zoom _Box"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:113
 msgid "Zoom _Extents"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:114
 msgid "Zoom _In"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:115
 msgid "Zoom _Out"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:116
 msgid "Zoom _Full"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:118
 msgid "_Dark Color Scheme"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:119
 msgid "_Light Color Scheme"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:120
 msgid "B_W Color Scheme"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:122
 msgid "Color Scheme Editor..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:129
 msgid "_Manager..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:131
 msgid "_Previous"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:132
 msgid "_Next"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:133
 msgid "_Close"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:135
 msgid "_Revert..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:137
-#: schematic/scheme/gschem/builtins.scm:249
 #, fuzzy
 msgid "Next Tab"
 msgstr "പുതിയ പേജ്"
 
-#: schematic/scheme/conf/schematic/menu.scm:138
-#: schematic/scheme/gschem/builtins.scm:252
 #, fuzzy
 msgid "Previous Tab"
 msgstr "പേജ് അടയ്ക്കുക"
 
-#: schematic/scheme/conf/schematic/menu.scm:146
 msgid "_Component..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:148
 msgid "_Net"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:149
 msgid "B_us"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:151
 msgid "_Attribute..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:152
 msgid "_Text..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:154
 msgid "_Line"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:155
 msgid "Pat_h"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:156
 msgid "_Box"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:157
 msgid "C_ircle"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:158
 msgid "A_rc"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:159
 msgid "_Pin"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:161
 msgid "Pictu_re..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:167
 msgid "_Up"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:169
 msgid "_Down Schematic"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:170
 msgid "Down _Symbol"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:176
 msgid "_Attach"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:177
 msgid "_Detach"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:179
 msgid "Show _Value"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:180
 msgid "Show _Name"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:181
 msgid "Show _Both"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:182
 msgid "_Toggle Visibility"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:184
 msgid "_Hide Specific Text..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:185
 msgid "_Show Specific Text..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:186
 msgid "Show/Hide Hidden Text"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:188
 msgid "_Find Text/Check Symbol..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:189
 msgid "A_utonumber Text..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:195
 msgid "_Options..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:196
 msgid "_Font..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:198
 msgid "Grid +"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:199
 msgid "Grid -"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:201
 msgid "Grid Style: Cycle Dots/Mesh/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:202
 msgid "Grid Snap: Cycle Grid/Resnap/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:204
 msgid "Feedback Mode: Outline/Box"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:205
 msgid "Net: Rubberband On/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:206
 msgid "Net: Magnetic On/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:208
 #, fuzzy
 msgid "_Coord Window"
 msgstr "പുതിയ ജാലകം"
 
-#: schematic/scheme/conf/schematic/menu.scm:209
 #, fuzzy
 msgid "_Log Window"
 msgstr "പുതിയ ജാലകം"
 
-#: schematic/scheme/conf/schematic/menu.scm:215
 msgid "_1 allegro"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:223
 msgid "User _Guide"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:224
 msgid "_FAQ"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:225
 msgid "Docu_mentation"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:226
 msgid "_Wiki"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:228
 msgid "Find Component D_ocumentation"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:230
 msgid "_Hotkeys..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:231
 msgid "_About"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:237
 msgid "_File"
 msgstr "ഫയല്‍"
 
-#: schematic/scheme/conf/schematic/menu.scm:238
 msgid "_Edit"
 msgstr "തിരുത്തിയെഴുതുക (_Edit)"
 
-#: schematic/scheme/conf/schematic/menu.scm:240
 msgid "_View"
 msgstr "വീക്ഷണം"
 
-#: schematic/scheme/conf/schematic/menu.scm:241
 msgid "_Page"
 msgstr "താള്"
 
-#: schematic/scheme/conf/schematic/menu.scm:242
 msgid "_Add"
 msgstr "കൂട്ടിച്ചേര്‍ക്കുക"
 
-#: schematic/scheme/conf/schematic/menu.scm:243
 msgid "Hie_rarchy"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:244
 msgid "A_ttributes"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:245
 msgid "_Options"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:246
 msgid "_Netlist"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:247
 msgid "_Help"
 msgstr ""
 
-#: schematic/scheme/gschem/action.scm:43
 #, scheme-format
 msgid "~S is not a valid gschem action."
 msgstr ""
 
-#: schematic/scheme/gschem/action.scm:158
 msgid "Repeat Last Action"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:47
 msgid "Cancel"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:53
 #, fuzzy
 msgid "New File"
 msgstr "പുതിയ പേജ്"
 
-#: schematic/scheme/gschem/builtins.scm:56
 msgid "Open File"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:62
 #, fuzzy
 msgid "Save As"
 msgstr "എല്ലാം സേവ് ചെയുക"
 
-#: schematic/scheme/gschem/builtins.scm:68
 #, fuzzy
 msgid "Print"
 msgstr "പ്രിന്‍റ് ചെയ്യുക..."
 
-#: schematic/scheme/gschem/builtins.scm:71
 msgid "Export Image"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:74
 msgid "Run Script"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:80
 #, fuzzy
 msgid "Close Window"
 msgstr "പുതിയ ജാലകം"
 
-#: schematic/scheme/gschem/builtins.scm:83
 msgid "Quit"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:87
 msgid "Terminal REPL"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:132
 msgid "Choose Slot"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:135
 msgid "Edit Object Properties"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:138
 msgid "Translate Symbol"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:147
 msgid "Invoke Macro"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:159
 msgid "Show/Hide Invisible Text"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:165
 #, fuzzy
 msgid "Cut"
 msgstr "കട്ട് ചെയുക  1 ലേക്ക്"
 
-#: schematic/scheme/gschem/builtins.scm:171
 #, fuzzy
 msgid "Paste"
 msgstr "പകര്‍ത്തി എടുക്കുക 1 ല്‍ നിന്നും"
 
-#: schematic/scheme/gschem/builtins.scm:177
 msgid "Sidebar"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:183
 msgid "Find Text State"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:186
 msgid "Redraw"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:192
 msgid "Pan Left"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:195
 msgid "Pan Right"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:198
 msgid "Pan Up"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:201
 msgid "Pan Down"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:216
 msgid "Zoom Full"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:219
 msgid "Dark Color Scheme"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:222
 msgid "Light Color Scheme"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:225
 msgid "Monochrome Color Scheme"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:228
 msgid "Show Color Scheme Editor"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:234
 msgid "Revert Changes"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:240
 #, fuzzy
 msgid "Previous Page"
 msgstr "പേജ് അടയ്ക്കുക"
 
-#: schematic/scheme/gschem/builtins.scm:243
 #, fuzzy
 msgid "Next Page"
 msgstr "പുതിയ പേജ്"
 
-#: schematic/scheme/gschem/builtins.scm:255
 #, fuzzy
 msgid "Print Page"
 msgstr "പേജ് അടയ്ക്കുക"
 
-#: schematic/scheme/gschem/builtins.scm:276
 #, fuzzy
 msgid "Add Line"
 msgstr "രേഖ"
 
-#: schematic/scheme/gschem/builtins.scm:279
 msgid "Add Path"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:282
 msgid "Add Box"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:285
 #, fuzzy
 msgid "Add Circle"
 msgstr "വൃത്തം"
 
-#: schematic/scheme/gschem/builtins.scm:288
 msgid "Add Arc"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:291
 msgid "Add Pin"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:294
 msgid "Add Picture"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:306
 msgid "Up Hierarchy"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:312
 msgid "Attach Attributes"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:315
 msgid "Detach Attributes"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:318
 msgid "Show Attribute Value"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:321
 msgid "Show Attribute Name"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:327
 msgid "Toggle Text Visibility"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:330
 msgid "Find Specific Text"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:333
 msgid "Hide Specific Text"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:336
 msgid "Show Specific Text"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:339
 msgid "Autonumber Text"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:345
 msgid "Show Hotkeys"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:348
 msgid "Switch Grid Style"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:351
 msgid "Switch Snap Mode"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:354
 msgid "Set Grid Spacing"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:357
 msgid "Increase Grid Spacing"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:360
 msgid "Decrease Grid Spacing"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:363
 msgid "Toggle Outline Drawing"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:366
 msgid "Toggle Net Rubber Band"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:369
 msgid "Toggle Magnetic Nets"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:372
 #, fuzzy
 msgid "Show Log Window"
 msgstr "പുതിയ ജാലകം"
 
-#: schematic/scheme/gschem/builtins.scm:375
 msgid "Show Coordinate Window"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:385
 msgid "Component Documentation"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:387
 msgid "View documentation for selected component"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:403
 msgid ""
 "Could not show documentation for selected component:\n"
 "\n"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:408
 msgid "gEDA Manuals"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:409
 msgid "View the front page of the gEDA documentation in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:414
 msgid "gschem User Guide"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:415
 msgid "View the gschem User Guide in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:420
 msgid "gschem FAQ"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:421
 msgid "Frequently Asked Questions about using gschem."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:426
 msgid "gEDA wiki"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:427
 msgid "View the front page of the gEDA wiki in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:431
 msgid "About gschem"
 msgstr ""
 
-#: schematic/scheme/gschem/deprecated.scm:102
 #, scheme-format
 msgid "Invalid text alignment ~A."
 msgstr ""
 
-#: schematic/scheme/gschem/gschemdoc.scm:241
 msgid "No documentation found"
 msgstr ""
 
-#: schematic/scheme/gschem/keymap.scm:40
 #, scheme-format
 msgid "~S is not a valid key combination."
 msgstr ""
 
-#: schematic/scheme/gschem/keymap.scm:157
 #, scheme-format
 msgid "~S is not a prefix key sequence."
 msgstr ""

--- a/schematic/po/nl.po
+++ b/schematic/po/nl.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda-gschem\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-15 15:13+0300\n"
+"POT-Creation-Date: 2019-02-22 14:08+0300\n"
 "PO-Revision-Date: 2014-08-31 22:35+0100\n"
 "Last-Translator: Bert Timmerman <bert.timmerman@xs4all.nl>\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -18,24 +18,20 @@ msgstr ""
 "X-Generator: Launchpad (build 16265)\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: schematic/src/a_zoom.c:155
 #, fuzzy
 msgid "Zoom too small!  Cannot zoom further."
 msgstr "Vergroting te klein! Kan niet verder vergroten.\n"
 
-#: schematic/src/color_edit_widget.c:399
 #, fuzzy, c-format
 msgid ""
 "Could not save file [%s]:\n"
 "%s"
 msgstr "Pagina [%s] kan NIET opgeslagen worden\n"
 
-#: schematic/src/color_edit_widget.c:434
 #, fuzzy
 msgid "Save Color Scheme As..."
 msgstr "Licht Kleuren Schema"
 
-#: schematic/src/color_edit_widget.c:482 schematic/src/x_fileselect.c:292
 #, fuzzy, c-format
 msgid ""
 "The selected file `%1$s' already exists.\n"
@@ -46,54 +42,42 @@ msgstr ""
 "\n"
 "Wil je het overschrijven ?"
 
-#: schematic/src/color_edit_widget.c:486 schematic/src/x_fileselect.c:295
 msgid "Overwrite file?"
 msgstr "Overschrijf bestand ?"
 
-#: schematic/src/font_select_widget.c:211
 msgid "_Apply"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:215
 msgid "Sa_ve..."
 msgstr ""
 
-#: schematic/src/font_select_widget.c:278
 #, c-format
 msgid "<b>Current:</b> %s"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:453
 msgid "Save configuration"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:461
 #, fuzzy
 msgid "Save settings to:"
 msgstr "Instellingen"
 
-#: schematic/src/font_select_widget.c:465
 msgid "Local configuration file (in current directory)"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:467
 msgid "User configuration file (geda-user.conf)"
 msgstr ""
 
-#: schematic/src/g_attrib.c:90
 msgid "Object ~A is not included in the current gschem page."
 msgstr "Objekt ~A is niet bijgevoegd in de huidige gschem pagina."
 
-#: schematic/src/g_attrib.c:110
 msgid "Invalid text name/value visibility ~A."
 msgstr "Ongeldige tekst naam/waarde zichtbaarheid ~A."
 
-#: schematic/src/g_rc.c:107
 #, fuzzy, c-format
 msgid "You are running gEDA/gaf version [%1$s%2$s.%3$s],\n"
 msgstr "U gebruikt gEDA/gaf versie [%s%s.%s],\n"
 
-#: schematic/src/g_rc.c:111
 #, fuzzy, c-format
 msgid ""
 "but you have a version [%1$s] gschemrc file:\n"
@@ -102,129 +86,103 @@ msgstr ""
 "maar U heeft een versie [%s] gschemrc bestand:\n"
 "[%s]\n"
 
-#: schematic/src/g_rc.c:114
 #, c-format
 msgid "Please be sure that you have the latest rc file.\n"
 msgstr "Wees alstublieft zeker dat U het laatste rc bestand heeft.\n"
 
-#: schematic/src/g_rc.c:240
 #, fuzzy, c-format
 msgid "Invalid size [%1$d] passed to text-size\n"
 msgstr "Ongeldige waarde [%d] overgedragen aan text-size\n"
 
-#: schematic/src/g_rc.c:283
 #, fuzzy, c-format
 msgid "Invalid size [%1$d] passed to snap-size\n"
 msgstr "Ongeldige waarde [%d] overgedragen aan snap-size\n"
 
-#: schematic/src/g_rc.c:620
 #, fuzzy, c-format
 msgid "Invalid num levels [%1$d] passed to undo-levels\n"
 msgstr "Ongeldige num niveaus [%d] overgedragen naar undo-levels\n"
 
-#: schematic/src/g_rc.c:831
 #, fuzzy, c-format
 msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
 msgstr "Ongeldige afmeting [%d] overgedragen aan bus-ripper-size\n"
 
-#: schematic/src/g_rc.c:931
 #, fuzzy, c-format
 msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
 msgstr "Ongeldige punt afmeting [%d] overgedragen aan dots-grid-dot-size\n"
 
-#: schematic/src/g_rc.c:972
 #, fuzzy, c-format
 msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
 msgstr ""
 "Ongeldige beeldpunt ruimte [%d] overgedragen aan dots-grid-fixed-threshold\n"
 
-#: schematic/src/g_rc.c:998
 #, fuzzy, c-format
 msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
 msgstr ""
 "Ongeldige beeldpunt ruimte [%d] overgedragen aan mesh-grid-display-"
 "threshold\n"
 
-#: schematic/src/g_rc.c:1023
 #, fuzzy, c-format
 msgid "Invalid offset [%1$d] passed to add-attribute-offset\n"
 msgstr "Ongeldige offset waarde [%d] overgedragen aan add-attribute-offset\n"
 
-#: schematic/src/g_rc.c:1047
 #, fuzzy, c-format
 msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
 msgstr "Ongeldig aantal seconden [%d] overgedragen naar auto-save-interval\n"
 
-#: schematic/src/g_rc.c:1071
 #, fuzzy, c-format
 msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
 msgstr "Ongeldige versterking [%d] overgedragen aan mousepan-gain\n"
 
-#: schematic/src/g_rc.c:1094
 #, fuzzy, c-format
 msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
 msgstr "Ongeldige versterking [%d] overgedragen aan keyboardpan-gain\n"
 
-#: schematic/src/g_rc.c:1118
 #, fuzzy, c-format
 msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
 msgstr ""
 "Ongeldig aantal beeldpunten [%d] overgedragen aan select-slack-pixels\n"
 
-#: schematic/src/g_rc.c:1144
 #, fuzzy, c-format
 msgid "Invalid gain [%1$d] passed to zoom-gain\n"
 msgstr "Ongeldige versterking [%d] overgedragen aan zoom-gain\n"
 
-#: schematic/src/g_rc.c:1169
 #, fuzzy, c-format
 msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
 msgstr "Ongeldig aantal stappen [%d] scrollpan-steps\n"
 
-#: schematic/src/g_select.c:78 schematic/src/g_select.c:115
-#: schematic/src/g_select.c:151
 msgid "Object ~A is not directly included in a page."
 msgstr "Object ~A is niet direct bijgevoegd in een pagina."
 
-#: schematic/src/g_util.c:54
 msgid "Could not launch URI ~S: ~A"
 msgstr "Kan URI ~S: ~A niet starten"
 
-#: schematic/src/g_window.c:139
 msgid "Found invalid gschem window smob ~S"
 msgstr "Ongeldige gschem venster smob ~S gevonden"
 
-#: schematic/src/lepton-schematic.c:156
 #, fuzzy, c-format
 msgid "Lepton EDA/lepton-schematic version %1$s%2$s.%3$s git: %4$.7s"
 msgstr "gEDA/gschem versie %s%s.%s\n"
 
-#: schematic/src/lepton-schematic.c:163
 #, c-format
 msgid "This is the MINGW32 port.\n"
 msgstr "Dit is de MINGW32 versie.\n"
 
-#: schematic/src/lepton-schematic.c:167
 #, fuzzy, c-format
 msgid "Current locale settings: %1$s\n"
 msgstr "Huidige locale instellingen: %s\n"
 
-#: schematic/src/lepton-schematic.c:201
 #, fuzzy, c-format
 msgid "Couldn't find init scm file [%1$s]"
 msgstr "Kan init scm bestand [%s]niet vinden\n"
 
-#: schematic/src/lepton-schematic.c:206
 #, fuzzy, c-format
 msgid "Read init scm file [%1$s]"
 msgstr "Lees init scm bestand [%s]\n"
 
-#: schematic/src/lepton-schematic.c:210
 #, fuzzy, c-format
 msgid "Failed to read init scm file [%1$s]"
 msgstr "Fout bij het lezen van het init scm bestand [%s]\n"
 
-#: schematic/src/lepton-schematic.c:290
 #, fuzzy, c-format
 msgid ""
 "ERROR: Failed to load or evaluate startup script.\n"
@@ -235,710 +193,530 @@ msgstr ""
 "\n"
 "Het gschem log kan meer informatie bevatten.\n"
 
-#: schematic/src/gschem_about_dialog.c:51
 #, fuzzy, c-format
 msgid "%s (git: %.7s)"
 msgstr "%s (g%.7s)"
 
-#: schematic/src/gschem_about_dialog.c:75
 #, fuzzy
 msgid "Lepton Electronic Design Automation"
 msgstr "gEDA: GPL Elektronische Ontwerp Automatisering"
 
-#: schematic/src/gschem_about_dialog.c:83
 #, fuzzy
 msgid ""
 "Copyright © 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright © 2017-2018 Lepton Developers.\n"
-"See AUTHORS and ChangeLog files for details."
+"Copyright © 2017-2019 Lepton Developers.\n"
+"See AUTHORS, ChangeLog files and consult 'git log' history for details."
 msgstr ""
 "Copyright © 1998-2012 Ales Hvezda <ahvezda@geda.seul.org>\n"
 "Copyright © 1998-2012 gEDA Contributors (zie het ChangeLog voor details)"
 
-#: schematic/src/gschem_alignment_combo.c:69
 msgid "Upper Left"
 msgstr "Boven Links"
 
-#: schematic/src/gschem_alignment_combo.c:71
 msgid "Upper Middle"
 msgstr "Boven Midden"
 
-#: schematic/src/gschem_alignment_combo.c:73
 #, fuzzy
 msgid "Upper Right"
 msgstr "Onder Rechts"
 
-#: schematic/src/gschem_alignment_combo.c:78
 msgid "Middle Left"
 msgstr "Midden Links"
 
-#: schematic/src/gschem_alignment_combo.c:80
 msgid "Middle Middle"
 msgstr "Midden Midden"
 
-#: schematic/src/gschem_alignment_combo.c:82
 msgid "Middle Right"
 msgstr "Midden Rechts"
 
-#: schematic/src/gschem_alignment_combo.c:87
 msgid "Lower Left"
 msgstr "Onder Links"
 
-#: schematic/src/gschem_alignment_combo.c:89
 msgid "Lower Middle"
 msgstr "Onder Midden"
 
-#: schematic/src/gschem_alignment_combo.c:91
 msgid "Lower Right"
 msgstr "Onder Rechts"
 
-#: schematic/src/gschem_arc_dialog.c:104
 msgid "Arc Params"
 msgstr "Boog parameters"
 
-#: schematic/src/gschem_arc_dialog.c:140
 #, fuzzy
 msgid "Arc _Radius:"
 msgstr "Boog Straal:"
 
-#: schematic/src/gschem_arc_dialog.c:141
 #, fuzzy
 msgid "Start _Angle:"
 msgstr "Start Hoek:"
 
-#: schematic/src/gschem_arc_dialog.c:142
 #, fuzzy
 msgid "_Degrees of Sweep:"
 msgstr "Doorlopen Hoek:"
 
-#: schematic/src/gschem_bottom_widget.c:504
 msgid "Left mouse button"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:508
 #, fuzzy
 msgid "Middle mouse button"
 msgstr "Midden Links"
 
-#: schematic/src/gschem_bottom_widget.c:512
 #, fuzzy
 msgid "Right mouse button"
 msgstr ""
 "Plaats draden modus\n"
 "Rechter muisknop om af te breken"
 
-#: schematic/src/gschem_bottom_widget.c:595
 msgid "(Snap size, Grid size)"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:603
 #, fuzzy
 msgid "Net rubber band mode"
 msgstr "Schakel Draad Elastiekband"
 
-#: schematic/src/gschem_bottom_widget.c:614
 #, fuzzy
 msgid "Magnetic net mode"
 msgstr "Magnetische Draad Mode"
 
-#: schematic/src/gschem_bottom_widget.c:622
 #, fuzzy
 msgid "Current action mode"
 msgstr "Huidige Venster"
 
-#: schematic/src/gschem_bottom_widget.c:935
-#: schematic/src/gschem_bottom_widget.c:951
 msgid "OFF"
 msgstr "UIT"
 
-#: schematic/src/gschem_bottom_widget.c:954
 msgid "NONE"
 msgstr "GEEN"
 
-#: schematic/src/gschem_bottom_widget.c:960
 #, fuzzy, c-format
 msgid "Grid(%1$s, %2$s)"
 msgstr "Raster(%s, %s)"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:350
-#: schematic/src/x_compselect.c:1236 schematic/src/x_multiattrib.c:2068
 msgid "Name"
 msgstr "Naam"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:372
 msgid "S_elect the schematics you want to save:"
 msgstr "S_electeer de schema's die je op wil slaan:"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:467
 #, fuzzy, c-format
 msgid "Save the changes to schematic \"%1$s\" before closing?"
 msgstr "Wijzigingen in schema \"%s\" opslaan voor het afsluiten?"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:473
 #, fuzzy, c-format
 msgid ""
 "There are %1$d schematics with unsaved changes. Save changes before closing?"
 msgstr ""
 "Er zijn %d schema's met wijzigingen. Wijzigingen opslaan voor het afsluiten?"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:502
 msgid "If you don't save, all your changes will be permanently lost."
 msgstr "Als je niet opslaat, verlies je alle wijzigingen definitief."
 
-#: schematic/src/gschem_close_confirmation_dialog.c:522
 msgid "Close _without saving"
 msgstr "Afsluiten zonder opslaan"
 
-#: schematic/src/gschem_coord_dialog.c:86
 msgid "Coords"
 msgstr "Coord."
 
-#: schematic/src/gschem_coord_dialog.c:106
 msgid "Screen"
 msgstr "Scherm"
 
-#: schematic/src/gschem_coord_dialog.c:115
 msgid "World"
 msgstr "Wereld"
 
-#: schematic/src/gschem_find_text_state.c:809 schematic/src/x_pagesel.c:432
 msgid "Filename"
 msgstr "Bestandsnaam"
 
-#: schematic/src/gschem_find_text_state.c:821 schematic/src/i_callbacks.c:1970
-#: schematic/src/x_colorcb.c:154 schematic/src/x_widgets.c:179
-#: schematic/src/x_window.c:1226 schematic/src/x_window.c:1440
 msgid "Text"
 msgstr "Tekst"
 
-#: schematic/src/gschem_find_text_widget.c:427
 msgid "descend into hierarchy"
 msgstr "afdalen in hierarchie"
 
-#: schematic/src/gschem_find_text_widget.c:435
 #, fuzzy
 msgid "Find"
 msgstr "Vind tekst"
 
-#: schematic/src/gschem_find_text_widget.c:557
 #, fuzzy
 msgid "Find Text:"
 msgstr "Vind tekst"
 
-#: schematic/src/gschem_find_text_widget.c:564
 msgid "Find Pattern:"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:571
 #, fuzzy
 msgid "Find Regex:"
 msgstr "Vind tekst"
 
-#: schematic/src/gschem_find_text_widget.c:578
 msgid "Check symbol:"
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:200
 msgid "Hotkeys"
 msgstr "Sneltoets"
 
-#: schematic/src/gschem_hotkey_dialog.c:229
 msgid ""
 "Start typing action name or keystroke to filter the list.\n"
 "Type hotkeys as they are displayed in \"Keystroke(s)\" column."
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:233 schematic/src/x_compselect.c:1124
 #, fuzzy
 msgid "_Filter:"
 msgstr "Filter:"
 
-#: schematic/src/gschem_hotkey_dialog.c:259 schematic/src/i_basic.c:280
 msgid "Action"
 msgstr "Aktie"
 
-#: schematic/src/gschem_hotkey_dialog.c:277
 msgid "Keystroke(s)"
 msgstr "Toetsaanslag(en)"
 
-#: schematic/src/gschem_log_widget.c:177
 msgid "** Invalid UTF-8 in log message. See stderr or gschem.log.\n"
 msgstr "** Ongeldige UTF-8 in logboek bericht. Zie stderr of gschem.log.\n"
 
-#: schematic/src/gschem_log_widget.c:434
 #, fuzzy
 msgid "Clear log window?"
 msgstr "Sluit Venster\n"
 
-#: schematic/src/gschem_log_widget.c:477
 #, fuzzy
 msgid "Clear Log _Window"
 msgstr "Toon Logboek Venster"
 
-#: schematic/src/gschem_macro_widget.c:231
 msgid "Macro:"
 msgstr ""
 
-#: schematic/src/gschem_macro_widget.c:387
 #, fuzzy
 msgid "Evaluate"
 msgstr "Evalueer:"
 
-#: schematic/src/gschem_object_properties_widget.c:172
 #, fuzzy
 msgid "_Fill Type:"
 msgstr "Arcering Type:"
 
-#: schematic/src/gschem_object_properties_widget.c:173
 #, fuzzy
 msgid "Lin_e Width:"
 msgstr "Lijn Dikte:"
 
-#: schematic/src/gschem_object_properties_widget.c:174
 #, fuzzy
 msgid "Angle _1:"
 msgstr "Hoek 1:"
 
-#: schematic/src/gschem_object_properties_widget.c:175
 #, fuzzy
 msgid "P_itch 1:"
 msgstr "Steek 1:"
 
-#: schematic/src/gschem_object_properties_widget.c:176
 #, fuzzy
 msgid "Angle _2:"
 msgstr "Hoek 2:"
 
-#: schematic/src/gschem_object_properties_widget.c:177
 #, fuzzy
 msgid "Pitc_h 2:"
 msgstr "Steek 2:"
 
-#: schematic/src/gschem_object_properties_widget.c:237
 #, fuzzy
 msgid "<b>Fill Properties</b>"
 msgstr "<b>Tekst Eigenschappen</b>"
 
-#: schematic/src/gschem_object_properties_widget.c:255
-#: schematic/src/gschem_text_properties_widget.c:258
-#: schematic/src/x_newtext.c:271
 #, fuzzy
 msgid "Colo_r:"
 msgstr "Kleur:"
 
-#: schematic/src/gschem_object_properties_widget.c:266
 #, fuzzy
 msgid "<b>General Properties</b>"
 msgstr "<b>Tekst Eigenschappen</b>"
 
-#: schematic/src/gschem_object_properties_widget.c:284
 #, fuzzy
 msgid "_Type:"
 msgstr "Type:"
 
-#: schematic/src/gschem_object_properties_widget.c:285
 #, fuzzy
 msgid "_Width:"
 msgstr "Breedte:"
 
-#: schematic/src/gschem_object_properties_widget.c:286
 #, fuzzy
 msgid "Dash _Length:"
 msgstr "Lijn Streeplengte:"
 
-#: schematic/src/gschem_object_properties_widget.c:287
 #, fuzzy
 msgid "Dash _Space:"
 msgstr "Lijn Tussenruimte:"
 
-#: schematic/src/gschem_object_properties_widget.c:288
 #, fuzzy
 msgid "C_ap style:"
 msgstr "Lijneinde stijl:"
 
-#: schematic/src/gschem_object_properties_widget.c:333
 #, fuzzy
 msgid "<b>Line Properties</b>"
 msgstr "<b>Tekst Eigenschappen</b>"
 
-#: schematic/src/gschem_object_properties_widget.c:351
 #, fuzzy
 msgid "_Pin Type:"
 msgstr "Pen type"
 
-#: schematic/src/gschem_object_properties_widget.c:362
 #, fuzzy
 msgid "<b>Pin Properties</b>"
 msgstr "<b>Tekst Eigenschappen</b>"
 
-#: schematic/src/gschem_options_widget.c:217
 msgid "_Off"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:220
 msgid "_Dots"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:223
 msgid "M_esh"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:245
 #, fuzzy
 msgid "Net R_ubber Band Mode:"
 msgstr "Schakel Draad Elastiekband"
 
-#: schematic/src/gschem_options_widget.c:246
 #, fuzzy
 msgid "_Magnetic Net Mode:"
 msgstr "Magnetische Draad Mode"
 
-#: schematic/src/gschem_options_widget.c:250
-#: schematic/src/gschem_options_widget.c:251
 msgid "Enabled"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:265
 #, fuzzy
 msgid "<b>Net Options</b>"
 msgstr "<b>Opties</b>"
 
-#: schematic/src/gschem_options_widget.c:282
 #, fuzzy
 msgid "Grid Mode:"
 msgstr "Boog Mode"
 
-#: schematic/src/gschem_options_widget.c:283
 #, fuzzy
 msgid "Snap Mode:"
 msgstr "Schakel Snap Modus"
 
-#: schematic/src/gschem_options_widget.c:284
 #, fuzzy
 msgid "_Snap Size:"
 msgstr "Snap Grootte"
 
-#: schematic/src/gschem_options_widget.c:301
 #, fuzzy
 msgid "<b>Snap Options</b>"
 msgstr "<b>Opties</b>"
 
-#: schematic/src/gschem_options_widget.c:340
 msgid "O_ff"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:343
 #, fuzzy
 msgid "_Grid"
 msgstr "Raster UIT\n"
 
-#: schematic/src/gschem_options_widget.c:346
 #, fuzzy
 msgid "_Resnap"
 msgstr "Hersnappen Aktief"
 
-#: schematic/src/gschem_pin_type_combo.c:73
 msgid "Net pin"
 msgstr "Draad pen"
 
-#: schematic/src/gschem_pin_type_combo.c:80
 msgid "Bus pin (graphical)"
 msgstr "Bus pen (grafisch)"
 
-#: schematic/src/gschem_preview.c:195
 msgid "Preview Buffer"
 msgstr "Vooraf zien Buffer"
 
-#: schematic/src/gschem_show_hide_text_widget.c:148
-#: schematic/src/x_window.c:1268
 #, fuzzy
 msgid "Hide"
 msgstr "Verberg tekst"
 
-#: schematic/src/gschem_show_hide_text_widget.c:157
-#: schematic/src/x_window.c:1269
 msgid "Hide text starting with:"
 msgstr "Verberg tekst beginnend met:"
 
-#: schematic/src/gschem_slot_edit_dialog.c:91
 msgid "Edit slot number"
 msgstr "Bewerk slot nummer"
 
-#: schematic/src/gschem_slot_edit_dialog.c:121
 msgid "Number of Slots:"
 msgstr ""
 
-#: schematic/src/gschem_slot_edit_dialog.c:122
 #, fuzzy
 msgid "Slot Number:"
 msgstr "Bewerk slot nummer:"
 
-#: schematic/src/gschem_text_properties_widget.c:240
-#: schematic/src/x_newtext.c:265
 msgid "<b>Text Content</b>"
 msgstr "<b>Tekst Inhoud</b>"
 
-#: schematic/src/gschem_text_properties_widget.c:259
-#: schematic/src/x_newtext.c:291
 #, fuzzy
 msgid "_Size:"
 msgstr "Grootte:"
 
-#: schematic/src/gschem_text_properties_widget.c:260
-#: schematic/src/x_newtext.c:310
 #, fuzzy
 msgid "Ali_gnment:"
 msgstr "Uitlijning:"
 
-#: schematic/src/gschem_text_properties_widget.c:261
-#: schematic/src/x_newtext.c:330
 #, fuzzy
 msgid "Ro_tation:"
 msgstr "Orientatie:"
 
-#: schematic/src/gschem_text_properties_widget.c:294
-#: schematic/src/x_newtext.c:253
 msgid "<b>Text Properties</b>"
 msgstr "<b>Tekst Eigenschappen</b>"
 
-#: schematic/src/gschem_translate_widget.c:238
 #, fuzzy
 msgid "Coordinate:"
 msgstr "Toon Coordinaten Venster"
 
-#: schematic/src/gschem_translate_widget.c:405 schematic/src/i_callbacks.c:800
 msgid "Translate"
 msgstr "Verplaats"
 
-#: schematic/src/i_basic.c:64 schematic/src/x_window.c:1369
-#: schematic/scheme/conf/schematic/menu.scm:59
-#: schematic/scheme/gschem/builtins.scm:99
 msgid "Select Mode"
 msgstr "Selectie Mode"
 
-#: schematic/src/i_basic.c:65
 #, fuzzy
 msgid "Select Box Mode"
 msgstr "Selectie Mode"
 
-#: schematic/src/i_basic.c:66
 msgid "Text Mode"
 msgstr "Tekst Mode"
 
-#: schematic/src/i_basic.c:67
 msgid "Pan Mode"
 msgstr "Schuif Mode"
 
-#: schematic/src/i_basic.c:70
 #, c-format
 msgid "Paste %d Mode"
 msgstr "Plak %d Mode"
 
-#: schematic/src/i_basic.c:74
 msgid "Magnetic Net Mode"
 msgstr "Magnetische Draad Mode"
 
-#: schematic/src/i_basic.c:76
 msgid "Net Mode"
 msgstr "Draad Mode"
 
-#: schematic/src/i_basic.c:77
 msgid "Arc Mode"
 msgstr "Boog Mode"
 
-#: schematic/src/i_basic.c:78
 msgid "Box Mode"
 msgstr "Rechthoek Mode"
 
-#: schematic/src/i_basic.c:79
 msgid "Bus Mode"
 msgstr "Bus Mode"
 
-#: schematic/src/i_basic.c:80
 msgid "Circle Mode"
 msgstr "Cirkel Mode"
 
-#: schematic/src/i_basic.c:81
 msgid "Component Mode"
 msgstr "Component Mode"
 
-#: schematic/src/i_basic.c:82 schematic/scheme/conf/schematic/menu.scm:62
-#: schematic/scheme/gschem/builtins.scm:114
 msgid "Copy Mode"
 msgstr "Kopieer Mode"
 
-#: schematic/src/i_basic.c:83 schematic/scheme/conf/schematic/menu.scm:63
-#: schematic/scheme/gschem/builtins.scm:117
 msgid "Multiple Copy Mode"
 msgstr "Meervoudige Kopieer Mode"
 
-#: schematic/src/i_basic.c:84
 msgid "Line Mode"
 msgstr "Lijn Mode"
 
-#: schematic/src/i_basic.c:85 schematic/scheme/conf/schematic/menu.scm:66
-#: schematic/scheme/gschem/builtins.scm:123
 msgid "Mirror Mode"
 msgstr "Spiegel Mode"
 
-#: schematic/src/i_basic.c:86 schematic/scheme/conf/schematic/menu.scm:64
-#: schematic/scheme/gschem/builtins.scm:111
 msgid "Move Mode"
 msgstr "Verplaats Mode"
 
-#: schematic/src/i_basic.c:87
 msgid "Path Mode"
 msgstr "Pad Mode"
 
-#: schematic/src/i_basic.c:88
 msgid "Picture Mode"
 msgstr "Afbeelding Mode"
 
-#: schematic/src/i_basic.c:89
 msgid "Pin Mode"
 msgstr "Pen Mode"
 
-#: schematic/src/i_basic.c:90 schematic/scheme/gschem/builtins.scm:120
 msgid "Rotate Mode"
 msgstr "Rotatie Mode"
 
-#: schematic/src/i_basic.c:91
 #, fuzzy
 msgid "Modify Mode"
 msgstr "Kopieer Mode"
 
-#: schematic/src/i_basic.c:92 schematic/src/x_menus.c:49
-#: schematic/scheme/gschem/builtins.scm:204
 msgid "Zoom Box"
 msgstr "Vergroot Venster"
 
-#: schematic/src/i_basic.c:121
 msgid "Show Hidden"
 msgstr "Zichtbaar Verborgen"
 
-#: schematic/src/i_basic.c:124
 msgid "Snap Off"
 msgstr "Snap Aan"
 
-#: schematic/src/i_basic.c:126
 msgid "Resnap Active"
 msgstr "Hersnappen Aktief"
 
-#: schematic/src/i_basic.c:288 schematic/src/x_colorcb.c:159
 msgid "Stroke"
 msgstr "Slag"
 
-#: schematic/src/i_basic.c:296 schematic/src/i_basic.c:330
-#: schematic/src/x_window.c:1361
 msgid "none"
 msgstr "geen"
 
-#: schematic/src/i_basic.c:304
 msgid "Repeat/"
 msgstr "Herhaal/"
 
-#: schematic/src/i_basic.c:315
 msgid "Repeat/none"
 msgstr "Herhaal/geen"
 
-#: schematic/src/i_basic.c:323 schematic/src/i_callbacks.c:1239
-#: schematic/scheme/gschem/builtins.scm:189
 msgid "Pan"
 msgstr "Schuif"
 
-#: schematic/src/i_callbacks.c:74
 #, fuzzy, c-format
 msgid "New page created [%1$s]"
 msgstr "Nieuwe pagina gemaakt [%s]\n"
 
-#: schematic/src/i_callbacks.c:108
 #, fuzzy, c-format
 msgid "New Window created [%1$s]"
 msgstr "Nieuw venster gemaakt [%s]\n"
 
-#: schematic/src/i_callbacks.c:245
 msgid "Failed to Save All"
 msgstr "Fout tijdens Alles Opslaan"
 
-#: schematic/src/i_callbacks.c:247
 msgid "Saved All"
 msgstr "Alles Opgeslagen"
 
-#: schematic/src/i_callbacks.c:308
 #, fuzzy
 msgid "Closing Window"
 msgstr "Sluit Venster\n"
 
-#: schematic/src/i_callbacks.c:505 schematic/src/x_menus.c:55
-#: schematic/scheme/gschem/builtins.scm:168
 msgid "Copy"
 msgstr "Kopieer"
 
-#: schematic/src/i_callbacks.c:514 schematic/src/i_callbacks.c:539
-#: schematic/src/i_callbacks.c:564
 msgid "Select objs first"
 msgstr "Selecteer voorwerpen eerst"
 
-#: schematic/src/i_callbacks.c:530
 msgid "Multiple Copy"
 msgstr "Meervoudig Kopieren"
 
-#: schematic/src/i_callbacks.c:555 schematic/src/x_menus.c:56
 msgid "Move"
 msgstr "Verplaats"
 
-#: schematic/src/i_callbacks.c:579 schematic/src/x_menus.c:57
-#: schematic/src/x_multiattrib.c:1656 schematic/scheme/gschem/builtins.scm:108
 msgid "Delete"
 msgstr "Verwijder"
 
-#: schematic/src/i_callbacks.c:603
 msgid "Edit"
 msgstr "Bewerk"
 
-#: schematic/src/i_callbacks.c:618 schematic/scheme/gschem/builtins.scm:129
 msgid "Edit Text"
 msgstr "Bewerk Tekst"
 
-#: schematic/src/i_callbacks.c:637
 msgid "Slot"
 msgstr "Slot"
 
-#: schematic/src/i_callbacks.c:688 schematic/src/i_callbacks.c:698
 msgid "Rotate"
 msgstr "Roteer"
 
-#: schematic/src/i_callbacks.c:736 schematic/src/i_callbacks.c:746
 msgid "Mirror"
 msgstr "Spiegel"
 
-#: schematic/src/i_callbacks.c:763 schematic/src/x_colorcb.c:160
-#: schematic/scheme/conf/schematic/menu.scm:73
-#: schematic/scheme/gschem/builtins.scm:141
 msgid "Lock"
 msgstr "Vergrendel"
 
-#: schematic/src/i_callbacks.c:781 schematic/scheme/conf/schematic/menu.scm:74
-#: schematic/scheme/gschem/builtins.scm:144
 msgid "Unlock"
 msgstr "Ontgrendel"
 
-#: schematic/src/i_callbacks.c:805
 #, fuzzy
 msgid "WARNING: Do not translate with snap off!"
 msgstr "WAARSCHUWING: Niet verplaatsen met snap uit!\n"
 
-#: schematic/src/i_callbacks.c:806
 #, fuzzy
 msgid "WARNING: Turning snap on and continuing with translate."
 msgstr "WAARSCHUWING: Zet snap aan en vervolg de verplaatsing.\n"
 
-#: schematic/src/i_callbacks.c:813
 #, fuzzy
 msgid "WARNING: Snap grid size is not equal to 100!"
 msgstr "WAARSCHUWING: Snap grid waarde is niet gelijk aan 100!\n"
 
-#: schematic/src/i_callbacks.c:815
 #, fuzzy
 msgid ""
 "WARNING: If you are translating a symbol to the origin, the snap grid size "
@@ -947,23 +725,18 @@ msgstr ""
 "WAARSCHUWING: Als je een symbool naar de oorsprong verschuift, dan moet de "
 "snap grip waarde op 100 gezet worden\n"
 
-#: schematic/src/i_callbacks.c:847
 msgid "Embed"
 msgstr "Insluiten"
 
-#: schematic/src/i_callbacks.c:886
 msgid "Unembed"
 msgstr "Uitsluiten"
 
-#: schematic/src/i_callbacks.c:928
 msgid "Update"
 msgstr "Vernieuw"
 
-#: schematic/src/i_callbacks.c:970
 msgid "ShowHidden"
 msgstr "ZichtbaarVerborgen"
 
-#: schematic/src/i_callbacks.c:1537
 #, c-format
 msgid ""
 "<b>Revert page:</b>\n"
@@ -974,99 +747,77 @@ msgid ""
 "discarded and page file will be reloaded from disk."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1555
 #, fuzzy
 msgid "Revert"
 msgstr "Te_rughalen"
 
-#: schematic/src/i_callbacks.c:1647
 msgid "Copy to clipboard"
 msgstr "Kopieer naar klembord"
 
-#: schematic/src/i_callbacks.c:1664
 msgid "Cut to clipboard"
 msgstr "Knip naar klembord"
 
-#: schematic/src/i_callbacks.c:1686
 msgid "Paste from clipboard"
 msgstr "Plak van klembord"
 
-#: schematic/src/i_callbacks.c:1694
 msgid "Empty clipboard"
 msgstr "Leeg het klembord"
 
 #. TRANSLATORS: The number is the number of the buffer that the
 #. * selection is being copied to.
-#: schematic/src/i_callbacks.c:1719
 #, c-format
 msgid "Copy %i"
 msgstr "Kopieer %i"
 
 #. TRANSLATORS: The number is the number of the buffer that the
 #. * selection is being cut to.
-#: schematic/src/i_callbacks.c:1746
 #, c-format
 msgid "Cut %i"
 msgstr "Knip %i"
 
 #. TRANSLATORS: The number is the number of the buffer that is being
 #. * pasted to the schematic.
-#: schematic/src/i_callbacks.c:1776
 #, c-format
 msgid "Paste %i"
 msgstr "Plak %i"
 
-#: schematic/src/i_callbacks.c:1785
 msgid "Empty buffer"
 msgstr "Maak buffer leeg"
 
-#: schematic/src/i_callbacks.c:1833 schematic/src/x_window.c:1203
 msgid "Component"
 msgstr "Component"
 
-#: schematic/src/i_callbacks.c:1865 schematic/src/x_colorcb.c:150
 msgid "Attribute"
 msgstr "Attribuut"
 
-#: schematic/src/i_callbacks.c:1885 schematic/src/x_colorcb.c:149
 msgid "Net"
 msgstr "Draad"
 
-#: schematic/src/i_callbacks.c:1928 schematic/src/x_colorcb.c:155
-#: schematic/src/x_window.c:1222
 msgid "Bus"
 msgstr "Bus"
 
-#: schematic/src/i_callbacks.c:2004
 msgid "Line"
 msgstr "Lijn"
 
-#: schematic/src/i_callbacks.c:2021
 msgid "Path"
 msgstr "Pad"
 
-#: schematic/src/i_callbacks.c:2043
 msgid "Box"
 msgstr "Rechthoek"
 
-#: schematic/src/i_callbacks.c:2085
 msgid "Circle"
 msgstr "Cirkel"
 
-#: schematic/src/i_callbacks.c:2108
 msgid "Arc"
 msgstr "Boog"
 
-#: schematic/src/i_callbacks.c:2131 schematic/src/x_colorcb.c:146
 msgid "Pin"
 msgstr "Pen"
 
-#: schematic/src/i_callbacks.c:2191
 #, fuzzy, c-format
 msgid "Searching for source [%1$s]"
 msgstr "Zoek naar bron [%s]\n"
 
-#: schematic/src/i_callbacks.c:2223
 #, fuzzy, c-format
 msgid ""
 "Failed to descend hierarchy into '%1$s': %2$s\n"
@@ -1077,120 +828,95 @@ msgstr ""
 "\n"
 "Het gschem log kan meer informatie bevatten."
 
-#: schematic/src/i_callbacks.c:2227
 #, fuzzy, c-format
 msgid "Failed to descend into '%1$s': %2$s"
 msgstr "Faalde bij het afdalen in '%s': %s\n"
 
-#: schematic/src/i_callbacks.c:2234
 msgid "Failed to descend hierarchy."
 msgstr "Faalde om af te dalen in hierarchie"
 
-#: schematic/src/i_callbacks.c:2312
 #, fuzzy, c-format
 msgid "Searching for symbol [%1$s]"
 msgstr "Zoek naar symbool [%s]\n"
 
-#: schematic/src/i_callbacks.c:2320
 #, fuzzy
 msgid "Symbol is not a real file. Symbol cannot be loaded."
 msgstr "Symbool is geen werkelijk bestand. Symbool kan niet geladen worden.\n"
 
-#: schematic/src/i_callbacks.c:2367 schematic/src/x_tabs.c:1060
 #, fuzzy
 msgid "Cannot find any schematics above the current one!"
 msgstr "Kan geen schema's vinden boven het huidige schema!\n"
 
-#: schematic/src/i_callbacks.c:2400
 msgid "Attach"
 msgstr "Vastmaken"
 
-#: schematic/src/i_callbacks.c:2456
 msgid "Detach"
 msgstr "Losmaken"
 
-#: schematic/src/i_callbacks.c:2500
 msgid "ShowN"
 msgstr "ToonN"
 
-#: schematic/src/i_callbacks.c:2537
 msgid "ShowV"
 msgstr "ToonW"
 
-#: schematic/src/i_callbacks.c:2574
 msgid "ShowB"
 msgstr "ToonB"
 
-#: schematic/src/i_callbacks.c:2612
 msgid "VisToggle"
 msgstr "SchakelZichtbaarheid"
 
-#: schematic/src/i_callbacks.c:2643
 #, c-format
 msgid "Sorry but this is a non-functioning menu option\n"
 msgstr "Sorry, maar dit is een niet werkende menu optie\n"
 
-#: schematic/src/i_callbacks.c:2703
 #, fuzzy
 msgid "Action feedback mode set to OUTLINE"
 msgstr "Aktie terugkoppel mode is ingesteld op OUTLINE\n"
 
-#: schematic/src/i_callbacks.c:2706
 #, fuzzy
 msgid "Action feedback mode set to BOUNDINGBOX"
 msgstr "Aktie terugkoppel mode is ingesteld op BOUNDINGBOX.\n"
 
-#: schematic/src/i_callbacks.c:2730
 #, fuzzy
 msgid "Grid OFF"
 msgstr "Raster UIT\n"
 
-#: schematic/src/i_callbacks.c:2731
 #, fuzzy
 msgid "Dot grid selected"
 msgstr "Punt raster geselecteerd\n"
 
-#: schematic/src/i_callbacks.c:2732
 #, fuzzy
 msgid "Mesh grid selected"
 msgstr "Maas raster geselecteerd\n"
 
-#: schematic/src/i_callbacks.c:2733
 #, fuzzy
 msgid "Invalid grid mode"
 msgstr "Ongeldige raster modus\n"
 
-#: schematic/src/i_callbacks.c:2755
 #, fuzzy
 msgid "Snap OFF (CAUTION!)"
 msgstr "Snap UIT (PAS OP!)\n"
 
-#: schematic/src/i_callbacks.c:2758
 #, fuzzy
 msgid "Snap ON"
 msgstr "Snap AAN\n"
 
-#: schematic/src/i_callbacks.c:2761
 #, fuzzy
 msgid "Snap back to the grid (CAUTION!)"
 msgstr "Snap terug op raster (PAS OP!)\n"
 
-#: schematic/src/i_callbacks.c:2790
 #, fuzzy
 msgid "Rubber band ON"
 msgstr "Elastiek band AAN\n"
 
-#: schematic/src/i_callbacks.c:2792
 #, fuzzy
 msgid "Rubber band OFF"
 msgstr "Elastiek band UIT \n"
 
-#: schematic/src/i_callbacks.c:2811
 #, fuzzy
 msgid "magnetic net mode: ON"
 msgstr "magnetische draad mode: AAN\n"
 
-#: schematic/src/i_callbacks.c:2814
 #, fuzzy
 msgid "magnetic net mode: OFF"
 msgstr "magnetische draad mode: UIT\n"
@@ -1200,146 +926,117 @@ msgstr "magnetische draad mode: UIT\n"
 #. the form "untitled_N.sch", where N is a number.  Please make
 #. sure that the translation contains characters suitable for use
 #. in a filename.
-#: schematic/src/i_vars.c:209
 msgid "untitled"
 msgstr "onbetiteld"
 
-#: schematic/src/o_complex.c:192 schematic/src/o_complex.c:195
 #, fuzzy, c-format
 msgid "Translating schematic [%1$d %2$d]"
 msgstr "Vertaal schema [%d %d]\n"
 
-#: schematic/src/o_delete.c:82
 #, fuzzy, c-format
 msgid "Delete locked object?"
 msgid_plural "Delete %1$u locked objects?"
 msgstr[0] "Verwijder vergrendeld object?"
 msgstr[1] "Verwijder %u vergrendelde objecten?"
 
-#: schematic/src/o_misc.c:55
 #, c-format
 msgid "Got an unexpected NULL in o_edit\n"
 msgstr "Ontving een onverwachte NULL in o_edit\n"
 
-#: schematic/src/o_misc.c:315
 #, fuzzy
 msgid "Hidden text is now visible"
 msgstr "Verborgen tekst is nu zichtbaar\n"
 
-#: schematic/src/o_misc.c:317
 #, fuzzy
 msgid "Hidden text is now invisible"
 msgstr "Verborgen tekst is nu onzichtbaar\n"
 
-#: schematic/src/o_misc.c:425
 #, fuzzy, c-format
 msgid "Could not find symbol [%1$s] in library. Update failed."
 msgstr "Kan symbool [%s] niet in bibliotheek vinden. Vernieuwen faalde.\n"
 
-#: schematic/src/o_misc.c:541
 #, fuzzy, c-format
 msgid "o_autosave_backups: Can't get the real filename of %1$s."
 msgstr "o_autosave_backups: Kan de echte bestandsnaam van %s niet krijgen."
 
-#: schematic/src/o_misc.c:585
 #, fuzzy, c-format
 msgid "Could NOT set previous backup file [%1$s] read-write"
 msgstr ""
 "Voorgaande reserve bestand [%s] kan NIET op lezen-schrijven ingesteld "
 "worden\n"
 
-#: schematic/src/o_misc.c:605
 #, fuzzy, c-format
 msgid "Could NOT set backup file [%1$s] readonly"
 msgstr "Reserve bestand [%s] kan NIET op alleen-lezen ingesteld worden\n"
 
-#: schematic/src/o_misc.c:610
 #, fuzzy, c-format
 msgid "Could NOT save backup file [%1$s]"
 msgstr "Reserve bestand [%s] kan NIET opgeslagen worden\n"
 
-#: schematic/src/o_move.c:192
 #, c-format
 msgid "ERROR: NULL object in o_move_end!\n"
 msgstr "FOUT: NULL object in o_move_end!\n"
 
-#: schematic/src/o_move.c:519
 #, c-format
 msgid "DOH! tried to find the whichone, but didn't find it!\n"
 msgstr "OH! probeerde er een te vinden, maar heb 'em niet gevonden!\n"
 
-#: schematic/src/o_move.c:546
 #, c-format
 msgid "Got a non line object in o_move_check_endpoint\n"
 msgstr "Ontving een niet lijn object in o_move_check_endpoint\n"
 
-#: schematic/src/o_net.c:444
 #, fuzzy
 msgid "Warning: Starting net at off grid coordinate"
 msgstr "Waarschuwing: begin van draad niet op raster coordinaat\n"
 
-#: schematic/src/o_net.c:508
 #, fuzzy
 msgid "Warning: Ending net at off grid coordinate"
 msgstr "Waarschuwing: einde van draad niet op raster coordinaat\n"
 
-#: schematic/src/o_net.c:856 schematic/src/o_net.c:893
-#: schematic/src/o_net.c:964 schematic/src/o_net.c:1000
 #, c-format
 msgid "Tried to add more than two bus rippers. Internal gschem error.\n"
 msgstr ""
 "Probeerde meer dan twee busrippers toe te voegen. Interne gschem fout.\n"
 
-#: schematic/src/o_net.c:1068
 #, fuzzy, c-format
 msgid "Bus ripper symbol [%1$s] was not found in any component library"
 msgstr ""
 "Bus ripper symbool [%s] niet gevonden in een van de component bibliotheken\n"
 
-#: schematic/src/o_picture.c:133 schematic/src/o_picture.c:343
 msgid "Select a picture file..."
 msgstr "Selecteer een afbeelding bestands..."
 
-#: schematic/src/o_picture.c:166
 #, fuzzy, c-format
 msgid "Failed to load picture: %1$s"
 msgstr "Fout bij het lezen van afbeelding: %s"
 
-#: schematic/src/o_picture.c:182
 msgid "Picture"
 msgstr "Afbeelding"
 
-#: schematic/src/o_picture.c:378
 #, c-format
 msgid "Failed to replace pictures: %s"
 msgstr "Fout bij het vervangen van afbeeldingen: %s"
 
-#: schematic/src/o_slot.c:80
 #, fuzzy
 msgid "Slot attribute malformed"
 msgstr "Slot attribuut misvormd\n"
 
-#: schematic/src/o_slot.c:88
 #, fuzzy
 msgid "numslots attribute missing"
 msgstr "numslots attribuut ontbreekt\n"
 
-#: schematic/src/o_slot.c:89
 #, fuzzy
 msgid "Slotting not allowed for this component"
 msgstr "Slots niet toegestaan voor deze component\n"
 
-#: schematic/src/o_slot.c:104
 #, fuzzy
 msgid "New slot number out of range"
 msgstr "Nieuw slotnummer buiten het bereik\n"
 
-#: schematic/src/o_undo.c:397
 #, fuzzy
 msgid "Undo/Redo disabled in rc file"
 msgstr "Ongedaan/Opnieuw doen uitgeschakeld in rc bestand\n"
 
-#: schematic/src/parsecmd.c:77
 #, fuzzy, c-format
 msgid ""
 "Usage: %1$s [OPTION ...] [--] [FILE ...]\n"
@@ -1387,12 +1084,11 @@ msgstr ""
 "Rapporteer fouten aan <https://bugs.launchpad.net/geda>\n"
 "gEDA/gaf startpagina: <http://www.geda-project.org/>\n"
 
-#: schematic/src/parsecmd.c:110
 #, fuzzy, c-format
 msgid ""
 "Lepton EDA %1$s (git: %2$.7s)\n"
 "Copyright (C) 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright (C) 2017-2018 Lepton Developers.\n"
+"Copyright (C) 2017-2019 Lepton Developers.\n"
 "This is free software, and you are welcome to redistribute it under\n"
 "certain conditions. For details, see the file `COPYING', which is\n"
 "included in the Lepton EDA distribution.\n"
@@ -1405,78 +1101,59 @@ msgstr ""
 "bijgevoegd in de gEDA distributie.\n"
 "Er is GEEN GARANTIE, voor zover de wet dit toelaat.\n"
 
-#: schematic/src/x_attribedit.c:125
 #, c-format
 msgid "Got invalid show option; defaulting to show both\n"
 msgstr "Kreeg ongeldige toon optie; standaardwaarde is toon beide\n"
 
-#: schematic/src/x_attribedit.c:139
 #, c-format
 msgid "ERROR: NULL object!\n"
 msgstr "FOUT: NULL object!\n"
 
-#: schematic/src/x_attribedit.c:328
 msgid "Single Attribute Editor"
 msgstr "Enkelvoudige Attribuut Bewerking"
 
-#: schematic/src/x_attribedit.c:358
 msgid "<b>Edit Attribute</b>"
 msgstr "<b>Bewerk Attribuut</b>"
 
-#: schematic/src/x_attribedit.c:360
 msgid "<b>Add Attribute</b>"
 msgstr "<b>Plaats Attribuut</b>"
 
-#: schematic/src/x_attribedit.c:376
 #, fuzzy
 msgid "N_ame:"
 msgstr "Naam:"
 
-#: schematic/src/x_attribedit.c:396 schematic/src/x_multiattrib.c:2222
 #, fuzzy
 msgid "_Value:"
 msgstr "Waarde:"
 
-#: schematic/src/x_attribedit.c:415 schematic/src/x_multiattrib.c:2281
 #, fuzzy
 msgid "Vi_sible"
 msgstr "Zichtbaar"
 
-#: schematic/src/x_attribedit.c:434
 msgid "Show Value Only"
 msgstr "Toon Alleen Waarde"
 
-#: schematic/src/x_attribedit.c:436
 msgid "Show Name Only"
 msgstr "Toon Alleen Naam"
 
-#: schematic/src/x_attribedit.c:438 schematic/src/x_multiattrib.c:1620
-#: schematic/scheme/gschem/builtins.scm:324
 msgid "Show Name & Value"
 msgstr "Toon Naam & Waarde"
 
-#: schematic/src/x_attribedit.c:445
 msgid "<b>Attach Options</b>"
 msgstr "<b>Opties Vastmaken</b>"
 
-#: schematic/src/x_attribedit.c:460
 msgid "All"
 msgstr "Alle"
 
-#: schematic/src/x_attribedit.c:476 schematic/src/x_compselect.c:986
-#: schematic/src/x_compselect.c:1100
 msgid "Components"
 msgstr "Componenten"
 
-#: schematic/src/x_attribedit.c:492 schematic/src/x_window.c:1214
 msgid "Nets"
 msgstr "Draden"
 
-#: schematic/src/x_attribedit.c:508
 msgid "Replace existing attributes"
 msgstr "Vervang bestaande attributen"
 
-#: schematic/src/x_autonumber.c:412
 #, fuzzy
 msgid ""
 "slotted object without slot attribute may cause problems when autonumbering "
@@ -1485,105 +1162,81 @@ msgstr ""
 "geslotte objecten zonder slot attribuut kunnen een probleem geven bij het "
 "automatisch nummeren van slots\n"
 
-#: schematic/src/x_autonumber.c:427
 #, fuzzy, c-format
 msgid ""
 "duplicate slot may cause problems: [symbolname=%1$s, number=%2$d, slot=%3$d]"
 msgstr ""
 "een dubbel slot kan een probleem geven: [symbolname=%s, number=%d, slot=%d]\n"
 
-#: schematic/src/x_autonumber.c:675
 #, fuzzy
 msgid "No searchstring given in autonumber text."
 msgstr "Geen zoektekst gegeven in automatisch nummeren tekst.\n"
 
-#: schematic/src/x_autonumber.c:728
 #, fuzzy
 msgid "No '*' or '?' given at the end of the autonumber text."
 msgstr ""
 "Geen '*' of '?' gegeven aan het einden van de automatisch nummeren tekst.\n"
 
-#: schematic/src/x_autonumber.c:873
 msgid "Diagonal"
 msgstr "Diagonaal"
 
-#: schematic/src/x_autonumber.c:874
 msgid "Top to bottom"
 msgstr "Van boven naar beneden"
 
-#: schematic/src/x_autonumber.c:875
 msgid "Bottom to top"
 msgstr "Van beneden naar boven"
 
-#: schematic/src/x_autonumber.c:876
 msgid "Left to right"
 msgstr "Van links naar rechts"
 
-#: schematic/src/x_autonumber.c:877
 msgid "Right to left"
 msgstr "Van rechts naar links"
 
-#: schematic/src/x_autonumber.c:878
 msgid "File order"
 msgstr "Bestand volgorde"
 
-#: schematic/src/x_autonumber.c:1214
 msgid "Autonumber text"
 msgstr "Automatisch tekst nummeren"
 
-#: schematic/src/x_autonumber.c:1237
 msgid "<b>Scope</b>"
 msgstr "<b>Omvang</b>"
 
-#: schematic/src/x_autonumber.c:1259
 msgid "Search for:"
 msgstr "Zoek naar:"
 
-#: schematic/src/x_autonumber.c:1273
 msgid "Autonumber text in:"
 msgstr "Automatisch tekst nummeren in:"
 
-#: schematic/src/x_autonumber.c:1280
 msgid "Skip numbers found in:"
 msgstr "Sla nummers over gevonden in:"
 
-#: schematic/src/x_autonumber.c:1292 schematic/src/x_autonumber.c:1301
 msgid "Selected objects"
 msgstr "Geselecteerde objecten"
 
-#: schematic/src/x_autonumber.c:1293 schematic/src/x_autonumber.c:1302
 msgid "Current page"
 msgstr "Huidig blad"
 
-#: schematic/src/x_autonumber.c:1294 schematic/src/x_autonumber.c:1303
 msgid "Whole hierarchy"
 msgstr "Hele hierarchie"
 
-#: schematic/src/x_autonumber.c:1305
 msgid "Overwrite existing numbers"
 msgstr "Overschrijven van bestaande nummers"
 
-#: schematic/src/x_autonumber.c:1310
 msgid "<b>Options</b>"
 msgstr "<b>Opties</b>"
 
-#: schematic/src/x_autonumber.c:1332
 msgid "Starting number:"
 msgstr "Start nummer:"
 
-#: schematic/src/x_autonumber.c:1339
 msgid "Sort order:"
 msgstr "Sorteer volgorde:"
 
-#: schematic/src/x_autonumber.c:1371
 msgid "Remove numbers"
 msgstr "Verwijder nummers"
 
-#: schematic/src/x_autonumber.c:1375
 msgid "Automatic slotting"
 msgstr "Automatisch slotten"
 
-#: schematic/src/x_clipboard.c:245
 #, c-format
 msgid ""
 "<b>Invalid schematic on clipboard.</b>\n"
@@ -1594,163 +1247,125 @@ msgstr ""
 "\n"
 "Er trad een fout op tijdens het invoegen van klembord data: %s."
 
-#: schematic/src/x_clipboard.c:247
 msgid "Clipboard insertion failed"
 msgstr "Klembord invoegen faalde"
 
-#: schematic/src/x_color.c:89 schematic/src/x_color.c:98
 #, fuzzy, c-format
 msgid "Could not allocate the color %1$s!\n"
 msgstr "Kan de kleur %s niet toewijzen!\n"
 
-#: schematic/src/x_color.c:89
 msgid "black"
 msgstr "zwart"
 
-#: schematic/src/x_color.c:98
 msgid "white"
 msgstr "wit"
 
-#: schematic/src/x_color.c:120
 #, fuzzy, c-format
 msgid "Could not allocate display color %1$i!\n"
 msgstr "Kan scherm kleur %i niet toewijzen!\n"
 
-#: schematic/src/x_color.c:142
 #, fuzzy, c-format
 msgid "Could not allocate outline color %1$i!\n"
 msgstr "Kan de omlijning kleur %i niet toewijzen!\n"
 
-#: schematic/src/x_color.c:159
 #, fuzzy, c-format
 msgid "Tried to get an invalid color: %1$d\n"
 msgstr "Probeerde een ongeldige kleur te verkrijgen: %d\n"
 
-#: schematic/src/x_colorcb.c:145
 msgid "Background"
 msgstr "Achtergrond"
 
-#: schematic/src/x_colorcb.c:147
 msgid "Net endpoint"
 msgstr "Draad eindpunt"
 
-#: schematic/src/x_colorcb.c:148
 msgid "Graphic"
 msgstr "Grafisch"
 
-#: schematic/src/x_colorcb.c:151
 msgid "Logic bubble"
 msgstr "Logische inverter"
 
-#: schematic/src/x_colorcb.c:152
 msgid "Grid point"
 msgstr "Rasterpunt"
 
-#: schematic/src/x_colorcb.c:153
 #, fuzzy
 msgid "Detached attribute"
 msgstr "Maak Attributen Los"
 
-#: schematic/src/x_colorcb.c:156
 msgid "Selection"
 msgstr "Selectie"
 
-#: schematic/src/x_colorcb.c:157
 msgid "Bounding box"
 msgstr "Omhullende rechthoek"
 
-#: schematic/src/x_colorcb.c:158
 msgid "Zoom box"
 msgstr "Vergroot venster"
 
-#: schematic/src/x_colorcb.c:161
 msgid "Output background"
 msgstr "Uitvoer achtergrond"
 
-#: schematic/src/x_colorcb.c:162
 msgid "Freestyle 1"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:163
 msgid "Freestyle 2"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:164
 msgid "Freestyle 3"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:165
 msgid "Freestyle 4"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:166
 msgid "Net junction"
 msgstr "Draad aftakking"
 
-#: schematic/src/x_colorcb.c:167
 msgid "Mesh grid major"
 msgstr "Maas raster groot"
 
-#: schematic/src/x_colorcb.c:168
 msgid "Mesh grid minor"
 msgstr "Maas raster klein"
 
-#: schematic/src/x_colorcb.c:172
 msgid "Unknown"
 msgstr "Onbekend"
 
-#: schematic/src/x_compselect.c:1169
 #, fuzzy
 msgid "Reset filter"
 msgstr "Nieuw bestand"
 
-#: schematic/src/x_compselect.c:1192
 msgid "Reload all libraries"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1245 schematic/src/x_multiattrib.c:2092
 msgid "Value"
 msgstr "Waarde"
 
-#: schematic/src/x_compselect.c:1284
 msgid "Default behavior - reference component"
 msgstr "Normaal gedrag - referentie component"
 
-#: schematic/src/x_compselect.c:1287
 msgid "Embed component in schematic"
 msgstr "Component insluiten in schema"
 
-#: schematic/src/x_compselect.c:1290
 msgid "Include component as individual objects"
 msgstr "Invoegen component als individuele objecten"
 
-#: schematic/src/x_compselect.c:1448
 msgid "Select Component..."
 msgstr "Selecteer Component..."
 
-#: schematic/src/x_compselect.c:1471
 #, fuzzy
 msgid "In Us_e"
 msgstr "In gebruik"
 
-#: schematic/src/x_compselect.c:1475
 #, fuzzy
 msgid "Lib_raries"
 msgstr "Bibliotheken"
 
-#: schematic/src/x_compselect.c:1484 schematic/src/x_fileselect.c:119
 msgid "Preview"
 msgstr "Vooraf zien"
 
-#: schematic/src/x_compselect.c:1510
 msgid "Attributes"
 msgstr "Attributen"
 
-#: schematic/src/x_dialog.c:325
 msgid "Major symbol changes detected."
 msgstr "Grote symbool veranderingen gedetecteerd."
 
-#: schematic/src/x_dialog.c:349
 msgid ""
 "Changes have occurred to the symbols shown below.\n"
 "\n"
@@ -1759,11 +1374,9 @@ msgstr ""
 "Er zijn in onderstaande symbolen veranderingen opgetreden.\n"
 "'nWees er zeker van elk van deze symbolen te verifiëren."
 
-#: schematic/src/x_dialog.c:369
 msgid "Symbol"
 msgstr "Symbool"
 
-#: schematic/src/x_dialog.c:406
 #, c-format
 msgid ""
 "<span weight=\"bold\" size=\"larger\">The input attribute \"%s\" is invalid\n"
@@ -1781,40 +1394,31 @@ msgstr ""
 "De naam mag niet eindigen met een spatie.\n"
 "De waarde mag niet met een spatie beginnen."
 
-#: schematic/src/x_dialog.c:408
 msgid "Invalid Attribute"
 msgstr "Ongeldig Attribuut"
 
-#: schematic/src/x_fileselect.c:37
 msgid "Schematics"
 msgstr "Schema's"
 
-#: schematic/src/x_fileselect.c:42
 msgid "Symbols"
 msgstr "Symbolen"
 
-#: schematic/src/x_fileselect.c:47
 msgid "Schematics and symbols"
 msgstr "Schema's en symbolen"
 
-#: schematic/src/x_fileselect.c:53
 msgid "All files"
 msgstr "Alle bestanden"
 
-#: schematic/src/x_fileselect.c:169
 msgid "Open..."
 msgstr "Open..."
 
-#: schematic/src/x_fileselect.c:233
 msgid "Save as..."
 msgstr "Opslaan Als..."
 
-#: schematic/src/x_fileselect.c:297
 #, fuzzy
 msgid "Save cancelled on user request"
 msgstr "Opslaan afgebroken op verzoek van de gebruiker\n"
 
-#: schematic/src/x_fileselect.c:334
 msgid ""
 "\n"
 "If you load the original file, the backup file will be overwritten in the "
@@ -1828,28 +1432,22 @@ msgstr ""
 "\n"
 "Wil je het reserve bestand laden ?\n"
 
-#: schematic/src/x_fstylecb.c:73
 msgid "Hollow"
 msgstr "Hol"
 
-#: schematic/src/x_fstylecb.c:80
 msgid "Filled"
 msgstr "Gevuld"
 
-#: schematic/src/x_fstylecb.c:87
 msgid "Mesh"
 msgstr "Maas"
 
-#: schematic/src/x_fstylecb.c:94
 msgid "Hatch"
 msgstr "Arcering"
 
-#: schematic/src/x_image.c:279
 #, fuzzy, c-format
 msgid "x_image_lowlevel: Unable to write %1$s file %2$s."
 msgstr "x_image_lowlevel: Kan %s bestand %s niet schrijven.\n"
 
-#: schematic/src/x_image.c:289
 #, fuzzy, c-format
 msgid ""
 "There was the following error when saving image with type %1$s to filename:\n"
@@ -1863,277 +1461,214 @@ msgstr ""
 "\n"
 "%s.\n"
 
-#: schematic/src/x_image.c:309
 #, fuzzy, c-format
 msgid "Wrote color image to [%1$s] [%2$d x %3$d]"
 msgstr "Schreef kleuren afbeelding naar [%s] [%d x %d]\n"
 
-#: schematic/src/x_image.c:311
 #, fuzzy, c-format
 msgid "Wrote black and white image to [%1$s] [%2$d x %3$d]"
 msgstr "Schreef zwart/wit afbeelding naar [%s] [%d x %d]\n"
 
-#: schematic/src/x_image.c:319
 #, fuzzy
 msgid "x_image_lowlevel: Unable to get pixbuf from gschem's window."
 msgstr "x_image_lowlevel: Kan geen pixbuf krijgen van gschem's venster.\n"
 
-#: schematic/src/x_image.c:358
 msgid "Width x Height"
 msgstr "Breedte x Hoogte"
 
-#: schematic/src/x_image.c:374
 msgid "Image type"
 msgstr "Afbeelding type"
 
-#: schematic/src/x_image.c:395
 msgid "Write image..."
 msgstr "Schrijf afbeelding..."
 
-#: schematic/src/x_linecapcb.c:74
 msgid "Butt"
 msgstr "Afgekort"
 
-#: schematic/src/x_linecapcb.c:81
 msgid "Square"
 msgstr "Vierkant"
 
-#: schematic/src/x_linecapcb.c:88
 msgid "Round"
 msgstr "Rond"
 
-#: schematic/src/x_linetypecb.c:74
 msgid "Solid"
 msgstr "Getrokken lijn"
 
-#: schematic/src/x_linetypecb.c:81
 msgid "Dotted"
 msgstr "Gestippeld"
 
-#: schematic/src/x_linetypecb.c:88
 msgid "Dashed"
 msgstr "Gestreept"
 
-#: schematic/src/x_linetypecb.c:95
 msgid "Center"
 msgstr "Hart"
 
-#: schematic/src/x_linetypecb.c:102
 msgid "Phantom"
 msgstr "Begrenzing"
 
-#: schematic/src/x_menus.c:41 schematic/scheme/gschem/builtins.scm:267
 msgid "Add Net"
 msgstr "Voeg Draad Toe"
 
-#: schematic/src/x_menus.c:42 schematic/src/x_multiattrib.c:2187
-#: schematic/scheme/gschem/builtins.scm:264
 msgid "Add Attribute"
 msgstr "Plaats Attribuut"
 
-#: schematic/src/x_menus.c:43 schematic/scheme/gschem/builtins.scm:261
 msgid "Add Component"
 msgstr "Voeg Component Toe"
 
-#: schematic/src/x_menus.c:44 schematic/scheme/gschem/builtins.scm:270
 msgid "Add Bus"
 msgstr "Voeg Bus Toe"
 
-#: schematic/src/x_menus.c:45 schematic/scheme/gschem/builtins.scm:273
 msgid "Add Text"
 msgstr "Voeg Tekst Toe"
 
-#: schematic/src/x_menus.c:47 schematic/scheme/gschem/builtins.scm:210
 msgid "Zoom In"
 msgstr "Vergroot"
 
-#: schematic/src/x_menus.c:48 schematic/scheme/gschem/builtins.scm:213
 msgid "Zoom Out"
 msgstr "Verklein"
 
-#: schematic/src/x_menus.c:50 schematic/scheme/gschem/builtins.scm:207
 msgid "Zoom Extents"
 msgstr "Toon Alles"
 
-#: schematic/src/x_menus.c:52 schematic/src/x_window.c:1233
 msgid "Select"
 msgstr "Selecteer"
 
-#: schematic/src/x_menus.c:53 schematic/scheme/conf/schematic/menu.scm:69
-#: schematic/scheme/gschem/builtins.scm:126
 msgid "Edit..."
 msgstr "Bewerk..."
 
-#: schematic/src/x_menus.c:54 schematic/scheme/conf/schematic/menu.scm:68
 #, fuzzy
 msgid "Object Properties..."
 msgstr "<b>Tekst Eigenschappen</b>"
 
-#: schematic/src/x_menus.c:59 schematic/scheme/gschem/builtins.scm:300
 msgid "Down Schematic"
 msgstr "Naar Schema"
 
-#: schematic/src/x_menus.c:60 schematic/scheme/gschem/builtins.scm:303
 msgid "Down Symbol"
 msgstr "Naar Symbool"
 
-#: schematic/src/x_menus.c:61
 msgid "Up"
 msgstr "Omhoog"
 
-#: schematic/src/x_menus.c:336
 #, fuzzy, c-format
 msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
 msgstr ""
 "Probeerde de gevoeligheid in te stellen op een niet bestaand menu_item '%s'\n"
 
-#: schematic/src/x_menus.c:360
 #, c-format
 msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
 msgstr ""
 "Probeerde de gevoeligheid in te stellen op een niet bestaand menu_item '%s'\n"
 
-#: schematic/src/x_misc.c:70
 msgid "The operating system is out of memory or resources."
 msgstr "Het besturingssysteem heeft niet meer geheugen of bronnen."
 
-#: schematic/src/x_multiattrib.c:798 schematic/src/x_multiattrib.c:2704
 msgid "<various>"
 msgstr "<gevarieerde>"
 
-#: schematic/src/x_multiattrib.c:930
 msgid "Attributes with empty name are not allowed. Please set a name."
 msgstr "Attributen met een lege naam zijn niet toegestaan. Geef een naam."
 
-#: schematic/src/x_multiattrib.c:1622
 msgid "Show Value only"
 msgstr "Toon alleen Waarde"
 
-#: schematic/src/x_multiattrib.c:1624
 msgid "Show Name only"
 msgstr "Toon alleen Naam"
 
-#: schematic/src/x_multiattrib.c:1651
 msgid "Promote"
 msgstr "Promoot"
 
-#: schematic/src/x_multiattrib.c:1655
 msgid "Duplicate"
 msgstr "Dupliceer"
 
-#: schematic/src/x_multiattrib.c:1657
 msgid "Copy to all"
 msgstr "Kopieer naar alles"
 
-#: schematic/src/x_multiattrib.c:1986 schematic/src/x_multiattrib.c:2602
 msgid "Edit Attributes"
 msgstr "Bewerk Attribuut"
 
-#: schematic/src/x_multiattrib.c:2112
 msgid "Vis?"
 msgstr "Zichtbaar?"
 
-#: schematic/src/x_multiattrib.c:2130
 msgid "N"
 msgstr "N"
 
 # GtkTreeViewColumn
-#: schematic/src/x_multiattrib.c:2148
 msgid "V"
 msgstr "W"
 
-#: schematic/src/x_multiattrib.c:2170
 #, fuzzy
 msgid "Sho_w inherited attributes"
 msgstr "Toon geërfde attributen"
 
-#: schematic/src/x_multiattrib.c:2197
 #, fuzzy
 msgid "_Name:"
 msgstr "Naam:"
 
-#: schematic/src/x_multiattrib.c:2241
 msgid "Ctrl+Enter inserts new line; Ctrl+Tab inserts Tab"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2618
 #, c-format
 msgid "%2$i symbol (%1$s)"
 msgid_plural "%2$i symbols (%1$s)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2624
 #, fuzzy, c-format
 msgid "%1$i pin"
 msgid_plural "%1$i pins"
 msgstr[0] "%i pen"
 msgstr[1] "%i pennen"
 
-#: schematic/src/x_multiattrib.c:2630
 #, c-format
 msgid "%1$i net"
 msgid_plural "%1$i nets"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2636
 #, c-format
 msgid "%1$i bus"
 msgid_plural "%1$i buses"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2642
 #, fuzzy, c-format
 msgid "%1$i attribute"
 msgid_plural "%1$i attributes"
 msgstr[0] "%i attribuut"
 msgstr[1] "%i attributen"
 
-#: schematic/src/x_newtext.c:433
 msgid "Text Entry..."
 msgstr "Tekst Ingeven..."
 
-#: schematic/src/x_pagesel.c:253
 msgid "New Page"
 msgstr "Nieuwe Pagina"
 
-#: schematic/src/x_pagesel.c:254
 msgid "Open Page..."
 msgstr "Open Pagina..."
 
-#: schematic/src/x_pagesel.c:256
 msgid "Save Page"
 msgstr "Opslaan Pagina"
 
-#: schematic/src/x_pagesel.c:257 schematic/scheme/gschem/builtins.scm:246
 msgid "Close Page"
 msgstr "Sluit Pagina"
 
-#: schematic/src/x_pagesel.c:376 schematic/scheme/gschem/builtins.scm:237
 msgid "Page Manager"
 msgstr "Pagina Manager"
 
-#: schematic/src/x_pagesel.c:448
 msgid "Changed"
 msgstr "Veranderd"
 
-#: schematic/src/x_pagesel.c:468
 msgid "Right click on the filename for more options..."
 msgstr "Klik met rechts op de bestandnaam voor meer opties..."
 
-#: schematic/src/x_print.c:306
 #, c-format
 msgid "Failed to write PDF to '%s': %s\n"
 msgstr "Faalde bij het schrijven van PDF naar '%s': %s\n"
 
-#: schematic/src/x_print.c:364
 #, fuzzy, c-format
 msgid "Failed to write PDF to '%1$s': %2$s\n"
 msgstr "Faalde bij het schrijven van PDF naar '%s': %s\n"
 
-#: schematic/src/x_print.c:449
 #, fuzzy, c-format
 msgid ""
 "Error printing file:\n"
@@ -2142,14 +1677,12 @@ msgstr ""
 "Fout bij het afdrukken van bestand:\n"
 "%s"
 
-#: schematic/src/x_rc.c:39
 #, fuzzy
 msgid "ERROR: An unknown error occurred while parsing configuration files."
 msgstr ""
 "FOUT: Een onbekende fout trad op tijdens het ontleden van "
 "configuratiebestanden.\n"
 
-#: schematic/src/x_rc.c:44
 #, fuzzy
 msgid ""
 "An unknown error occurred while parsing configuration files.\n"
@@ -2160,12 +1693,10 @@ msgstr ""
 "\n"
 "Het gschem log kan meer informatie bevatten."
 
-#: schematic/src/x_rc.c:56
 #, fuzzy, c-format
 msgid "ERROR: %1$s"
 msgstr "FOUT: %s\n"
 
-#: schematic/src/x_rc.c:59
 #, fuzzy, c-format
 msgid ""
 "%1$s\n"
@@ -2176,142 +1707,111 @@ msgstr ""
 "\n"
 "Het gschem log kan meer informatie bevatten."
 
-#: schematic/src/x_rc.c:67
 #, fuzzy
 msgid "Cannot load lepton-schematic configuration."
 msgstr "Kan geen gschem configuratie laden."
 
-#: schematic/src/x_script.c:42 schematic/scheme/conf/schematic/menu.scm:40
 msgid "Execute Script..."
 msgstr "Script Uitvoeren..."
 
-#: schematic/src/x_script.c:61
 #, fuzzy, c-format
 msgid "Executing guile script [%1$s]"
 msgstr "Bezig met uitvoeren van guile script [%s]\n"
 
-#: schematic/src/x_tabs.c:860
 #, fuzzy, c-format
 msgid "Hierarchy up: %s"
 msgstr "Hie_rarchie"
 
-#: schematic/src/x_tabs.c:863
 #, fuzzy
 msgid "Hierarchy up"
 msgstr "Hie_rarchie"
 
-#: schematic/src/x_widgets.c:158 schematic/src/x_window.c:1444
 #, fuzzy
 msgid "Options"
 msgstr "_Opties"
 
-#: schematic/src/x_widgets.c:203 schematic/src/x_window.c:1436
 #, fuzzy
 msgid "Object"
 msgstr "Object kleur:"
 
-#: schematic/src/x_widgets.c:224
 msgid "Log"
 msgstr ""
 
-#: schematic/src/x_widgets.c:245 schematic/src/x_window.c:1466
 msgid "Find Text"
 msgstr "Vind tekst"
 
-#: schematic/src/x_widgets.c:259
 #, fuzzy
 msgid "Color Scheme Editor"
 msgstr "Licht Kleuren Schema"
 
-#: schematic/src/x_widgets.c:272 schematic/scheme/gschem/builtins.scm:378
 #, fuzzy
 msgid "Select Schematic Font"
 msgstr "S_electeer de schema's die je op wil slaan:"
 
-#: schematic/src/x_window.c:763
 #, fuzzy, c-format
 msgid "Loading schematic [%1$s]"
 msgstr "Bezig met laden van schema [%s]\n"
 
-#: schematic/src/x_window.c:864
 #, fuzzy, c-format
 msgid "Could NOT save page [%1$s]\n"
 msgstr "Pagina [%s] kan NIET opgeslagen worden\n"
 
-#: schematic/src/x_window.c:865
 msgid "Error while trying to save"
 msgstr "Fout tijdens het opslaan"
 
-#: schematic/src/x_window.c:875
 msgid "Failed to save file"
 msgstr "Fout bij het opslaan van bestand"
 
-#: schematic/src/x_window.c:885
 #, fuzzy, c-format
 msgid "Saved as [%1$s]"
 msgstr "Opgeslagen Als [%s]\n"
 
-#: schematic/src/x_window.c:887
 #, fuzzy, c-format
 msgid "Saved [%1$s]"
 msgstr "Opgeslagen [%s]\n"
 
-#: schematic/src/x_window.c:889
 msgid "Saved"
 msgstr "Opgeslagen"
 
-#: schematic/src/x_window.c:966
 #, fuzzy, c-format
 msgid "Discarding page [%1$s]"
 msgstr "Pagina [%s] wegdoen\n"
 
-#: schematic/src/x_window.c:966
 #, fuzzy, c-format
 msgid "Closing [%1$s]"
 msgstr "Sluiten [%s]\n"
 
-#: schematic/src/x_window.c:1175
 msgid "New"
 msgstr "Nieuw"
 
-#: schematic/src/x_window.c:1175
 msgid "New file"
 msgstr "Nieuw bestand"
 
-#: schematic/src/x_window.c:1179
 msgid "Open"
 msgstr "Open"
 
-#: schematic/src/x_window.c:1179
 #, fuzzy
 msgid "Open file"
 msgstr "Open Bestand"
 
-#: schematic/src/x_window.c:1183 schematic/scheme/gschem/builtins.scm:59
 msgid "Save"
 msgstr "Opslaan"
 
-#: schematic/src/x_window.c:1183
 msgid "Save file"
 msgstr "Opslaan bestand"
 
-#: schematic/src/x_window.c:1189 schematic/scheme/gschem/builtins.scm:93
 msgid "Undo"
 msgstr "Ongedaan maken"
 
-#: schematic/src/x_window.c:1189
 msgid "Undo last operation"
 msgstr "Maak laatste bewerking ongedaan"
 
-#: schematic/src/x_window.c:1193 schematic/scheme/gschem/builtins.scm:96
 msgid "Redo"
 msgstr "Herstel"
 
-#: schematic/src/x_window.c:1193
 msgid "Redo last undo"
 msgstr "Herstel de laatste ongedaanmaking"
 
-#: schematic/src/x_window.c:1198
 msgid ""
 "Add component...\n"
 "Select library and component from list, move the mouse into main window, "
@@ -2323,7 +1823,6 @@ msgstr ""
 "muisindicator in het hoofdvensterklik om component te plaatsen\n"
 "Rechter muisknop om af te breken"
 
-#: schematic/src/x_window.c:1209
 msgid ""
 "Add nets mode\n"
 "Right mouse button to cancel"
@@ -2331,7 +1830,6 @@ msgstr ""
 "Plaats draden modus\n"
 "Rechter muisknop om af te breken"
 
-#: schematic/src/x_window.c:1217
 msgid ""
 "Add buses mode\n"
 "Right mouse button to cancel"
@@ -2339,45 +1837,35 @@ msgstr ""
 "Plaats bussen modus\n"
 "Rechter muisknop om af te breken"
 
-#: schematic/src/x_window.c:1226
 msgid "Add Text..."
 msgstr "Plaats een tekst..."
 
-#: schematic/src/x_window.c:1233
 msgid "Select mode"
 msgstr "Selectie mode"
 
-#: schematic/src/x_window.c:1288
 #, fuzzy
 msgid "Show"
 msgstr "ToonN"
 
-#: schematic/src/x_window.c:1289
 msgid "Show text starting with:"
 msgstr "Toon tekst beginnend met:"
 
-#: schematic/src/x_window.c:1345
 msgid "Menu/Cancel"
 msgstr "Menu/Afbreken"
 
-#: schematic/src/x_window.c:1349
 msgid "Pan/Cancel"
 msgstr "Schuif/Afbreken"
 
-#: schematic/src/x_window.c:1359
 msgid "Pick"
 msgstr "Pak"
 
-#: schematic/src/x_window.c:1470 schematic/scheme/gschem/builtins.scm:180
 msgid "Status"
 msgstr "Status"
 
-#: schematic/src/x_window.c:1568
 #, fuzzy, c-format
 msgid "New file [%s]"
 msgstr "Nieuw bestand [%s]\n"
 
-#: schematic/src/x_window.c:1598
 #, fuzzy, c-format
 msgid ""
 "<b>An error occurred while loading the requested file.</b>\n"
@@ -2394,795 +1882,598 @@ msgstr ""
 "\n"
 "Laden van '%s' faalde: %s. Het gschem log kan meer informatie bevatten."
 
-#: schematic/src/x_window.c:1617
 msgid "Failed to load file"
 msgstr "Fout bij het lezen van bestand"
 
-#: schematic/data/lepton-schematic.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Schematic Editor"
 msgstr "gEDA schema bewerking"
 
-#: schematic/data/lepton-schematic.desktop.in:4
 #, fuzzy
 msgid "Create and edit electrical schematics and symbols with lepton-schematic"
 msgstr "Creer en bewerk elektrische schema's en symbolen met gschem"
 
-#: schematic/scheme/conf/schematic/menu.scm:27
 msgid "_New"
 msgstr "_Nieuw"
 
-#: schematic/scheme/conf/schematic/menu.scm:28
 msgid "_Open..."
 msgstr "_Open..."
 
-#: schematic/scheme/conf/schematic/menu.scm:30
 msgid "Open Recen_t"
 msgstr "Open Recen_t"
 
-#: schematic/scheme/conf/schematic/menu.scm:32
 msgid "_Save"
 msgstr "Op_slaan"
 
-#: schematic/scheme/conf/schematic/menu.scm:33
 msgid "Save _As..."
 msgstr "Opslaan _Als..."
 
-#: schematic/scheme/conf/schematic/menu.scm:34
-#: schematic/scheme/gschem/builtins.scm:65
 msgid "Save All"
 msgstr "Alles Opslaan"
 
-#: schematic/scheme/conf/schematic/menu.scm:36
 msgid "_Print..."
 msgstr "Af_drukken..."
 
-#: schematic/scheme/conf/schematic/menu.scm:37
 #, fuzzy
 msgid "Write _Image..."
 msgstr "Schrijf afbeeld_ing..."
 
-#: schematic/scheme/conf/schematic/menu.scm:39
 #, fuzzy
 msgid "Invoke Macro..."
 msgstr "Macro Aanroepen"
 
-#: schematic/scheme/conf/schematic/menu.scm:41
 msgid "REPL..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:43
-#: schematic/scheme/gschem/builtins.scm:77
 msgid "New Window"
 msgstr "Nieuw Venster"
 
-#: schematic/scheme/conf/schematic/menu.scm:44
 msgid "_Close Window"
 msgstr "Sluit Venster"
 
-#: schematic/scheme/conf/schematic/menu.scm:45
 msgid "_Quit"
 msgstr "A_fsluiten"
 
-#: schematic/scheme/conf/schematic/menu.scm:51
 msgid "_Undo"
 msgstr "_Ongedaan maken"
 
-#: schematic/scheme/conf/schematic/menu.scm:52
 msgid "_Redo"
 msgstr "He_rstel"
 
-#: schematic/scheme/conf/schematic/menu.scm:54
 msgid "Cu_t"
 msgstr "K_nip"
 
-#: schematic/scheme/conf/schematic/menu.scm:55
 msgid "_Copy"
 msgstr "_Kopieer"
 
-#: schematic/scheme/conf/schematic/menu.scm:56
 msgid "_Paste"
 msgstr "_Plak"
 
-#: schematic/scheme/conf/schematic/menu.scm:57
 msgid "_Delete"
 msgstr "Verwij_der"
 
-#: schematic/scheme/conf/schematic/menu.scm:60
-#: schematic/scheme/gschem/builtins.scm:102
 msgid "Select All"
 msgstr "Selecteer Alles"
 
-#: schematic/scheme/conf/schematic/menu.scm:61
-#: schematic/scheme/gschem/builtins.scm:105
 msgid "Deselect"
 msgstr "Deselecteer"
 
-#: schematic/scheme/conf/schematic/menu.scm:65
 msgid "Rotate 90 Mode"
 msgstr "Rotatie 90 Mode"
 
-#: schematic/scheme/conf/schematic/menu.scm:70
 msgid "Edit Text..."
 msgstr "Bewerk Tekst..."
 
-#: schematic/scheme/conf/schematic/menu.scm:71
 msgid "Slot..."
 msgstr "Slot..."
 
-#: schematic/scheme/conf/schematic/menu.scm:76
-#: schematic/scheme/gschem/builtins.scm:150
 msgid "Embed Component/Picture"
 msgstr "Component/Afbeelding Insluiten"
 
-#: schematic/scheme/conf/schematic/menu.scm:77
-#: schematic/scheme/gschem/builtins.scm:153
 msgid "Unembed Component/Picture"
 msgstr "Component/Afbeelding Uitsluiten"
 
-#: schematic/scheme/conf/schematic/menu.scm:78
-#: schematic/scheme/gschem/builtins.scm:156
 msgid "Update Component"
 msgstr "Hernieuw Component"
 
-#: schematic/scheme/conf/schematic/menu.scm:79
 msgid "Symbol Translate..."
 msgstr "Verplaats Symbool..."
 
-#: schematic/scheme/conf/schematic/menu.scm:85
 msgid "Copy into 1"
 msgstr "Kopieer naar 1"
 
-#: schematic/scheme/conf/schematic/menu.scm:86
 msgid "Copy into 2"
 msgstr "Kopieer naar 2"
 
-#: schematic/scheme/conf/schematic/menu.scm:87
 msgid "Copy into 3"
 msgstr "Kopieer naar 3"
 
-#: schematic/scheme/conf/schematic/menu.scm:88
 msgid "Copy into 4"
 msgstr "Kopieer naar 4"
 
-#: schematic/scheme/conf/schematic/menu.scm:89
 msgid "Copy into 5"
 msgstr "Kopieer naar 5"
 
-#: schematic/scheme/conf/schematic/menu.scm:90
 msgid "Cut into 1"
 msgstr "Knip naar 1"
 
-#: schematic/scheme/conf/schematic/menu.scm:91
 msgid "Cut into 2"
 msgstr "Knip naar 2"
 
-#: schematic/scheme/conf/schematic/menu.scm:92
 msgid "Cut into 3"
 msgstr "Knip naar 3"
 
-#: schematic/scheme/conf/schematic/menu.scm:93
 msgid "Cut into 4"
 msgstr "Knip naar 4"
 
-#: schematic/scheme/conf/schematic/menu.scm:94
 msgid "Cut into 5"
 msgstr "Knip naar 5"
 
-#: schematic/scheme/conf/schematic/menu.scm:95
 msgid "Paste from 1"
 msgstr "Plak vanuit 1"
 
-#: schematic/scheme/conf/schematic/menu.scm:96
 msgid "Paste from 2"
 msgstr "Plak vanuit 2"
 
-#: schematic/scheme/conf/schematic/menu.scm:97
 msgid "Paste from 3"
 msgstr "Plak vanuit 3"
 
-#: schematic/scheme/conf/schematic/menu.scm:98
 msgid "Paste from 4"
 msgstr "Plak vanuit 4"
 
-#: schematic/scheme/conf/schematic/menu.scm:99
 msgid "Paste from 5"
 msgstr "Plak vanuit 5"
 
-#: schematic/scheme/conf/schematic/menu.scm:105
 msgid "Side Dock"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:106
 #, fuzzy
 msgid "Bottom Dock"
 msgstr "Van beneden naar boven"
 
-#: schematic/scheme/conf/schematic/menu.scm:108
 #, fuzzy
 msgid "Find Text Results"
 msgstr "Vind tekst"
 
-#: schematic/scheme/conf/schematic/menu.scm:110
 msgid "_Redraw"
 msgstr "He_rtekenen"
 
-#: schematic/scheme/conf/schematic/menu.scm:111
 msgid "_Pan"
 msgstr "_Schuif"
 
-#: schematic/scheme/conf/schematic/menu.scm:112
 msgid "Zoom _Box"
 msgstr "_Vergroot Venster"
 
-#: schematic/scheme/conf/schematic/menu.scm:113
 msgid "Zoom _Extents"
 msgstr "Toon All_es"
 
-#: schematic/scheme/conf/schematic/menu.scm:114
 msgid "Zoom _In"
 msgstr "Ver_groot"
 
-#: schematic/scheme/conf/schematic/menu.scm:115
 msgid "Zoom _Out"
 msgstr "Ver_klein"
 
-#: schematic/scheme/conf/schematic/menu.scm:116
 msgid "Zoom _Full"
 msgstr "Toon _Maximaal"
 
-#: schematic/scheme/conf/schematic/menu.scm:118
 #, fuzzy
 msgid "_Dark Color Scheme"
 msgstr "Donker Kleuren Schema"
 
-#: schematic/scheme/conf/schematic/menu.scm:119
 #, fuzzy
 msgid "_Light Color Scheme"
 msgstr "Licht Kleuren Schema"
 
-#: schematic/scheme/conf/schematic/menu.scm:120
 #, fuzzy
 msgid "B_W Color Scheme"
 msgstr "Z_W kleuren schema"
 
-#: schematic/scheme/conf/schematic/menu.scm:122
 #, fuzzy
 msgid "Color Scheme Editor..."
 msgstr "Licht Kleuren Schema"
 
-#: schematic/scheme/conf/schematic/menu.scm:129
 msgid "_Manager..."
 msgstr "_Manager..."
 
-#: schematic/scheme/conf/schematic/menu.scm:131
 msgid "_Previous"
 msgstr "_Vorige"
 
-#: schematic/scheme/conf/schematic/menu.scm:132
 msgid "_Next"
 msgstr "Volge_nde"
 
-#: schematic/scheme/conf/schematic/menu.scm:133
 msgid "_Close"
 msgstr "S_luit"
 
-#: schematic/scheme/conf/schematic/menu.scm:135
 #, fuzzy
 msgid "_Revert..."
 msgstr "Te_rughalen"
 
-#: schematic/scheme/conf/schematic/menu.scm:137
-#: schematic/scheme/gschem/builtins.scm:249
 #, fuzzy
 msgid "Next Tab"
 msgstr "Volgende Pagina"
 
-#: schematic/scheme/conf/schematic/menu.scm:138
-#: schematic/scheme/gschem/builtins.scm:252
 #, fuzzy
 msgid "Previous Tab"
 msgstr "Vorige Pagina"
 
-#: schematic/scheme/conf/schematic/menu.scm:146
 msgid "_Component..."
 msgstr "_Component..."
 
-#: schematic/scheme/conf/schematic/menu.scm:148
 msgid "_Net"
 msgstr "_Draad"
 
-#: schematic/scheme/conf/schematic/menu.scm:149
 msgid "B_us"
 msgstr "B_us"
 
-#: schematic/scheme/conf/schematic/menu.scm:151
 msgid "_Attribute..."
 msgstr "_Attribuut..."
 
-#: schematic/scheme/conf/schematic/menu.scm:152
 msgid "_Text..."
 msgstr "_Tekst..."
 
-#: schematic/scheme/conf/schematic/menu.scm:154
 msgid "_Line"
 msgstr "_Lijn"
 
-#: schematic/scheme/conf/schematic/menu.scm:155
 msgid "Pat_h"
 msgstr "Pat_h"
 
-#: schematic/scheme/conf/schematic/menu.scm:156
 msgid "_Box"
 msgstr "_Rechthoek"
 
-#: schematic/scheme/conf/schematic/menu.scm:157
 msgid "C_ircle"
 msgstr "C_irkel"
 
-#: schematic/scheme/conf/schematic/menu.scm:158
 msgid "A_rc"
 msgstr "_Boog"
 
-#: schematic/scheme/conf/schematic/menu.scm:159
 msgid "_Pin"
 msgstr "_Pen"
 
-#: schematic/scheme/conf/schematic/menu.scm:161
 msgid "Pictu_re..."
 msgstr "A_fbeelding..."
 
-#: schematic/scheme/conf/schematic/menu.scm:167
 msgid "_Up"
 msgstr "O_mhoog"
 
-#: schematic/scheme/conf/schematic/menu.scm:169
 msgid "_Down Schematic"
 msgstr "_Naar Schema"
 
-#: schematic/scheme/conf/schematic/menu.scm:170
 msgid "Down _Symbol"
 msgstr "Naar _Symbool"
 
-#: schematic/scheme/conf/schematic/menu.scm:176
 msgid "_Attach"
 msgstr "V_astmaken"
 
-#: schematic/scheme/conf/schematic/menu.scm:177
 msgid "_Detach"
 msgstr "_Losmaken"
 
-#: schematic/scheme/conf/schematic/menu.scm:179
 msgid "Show _Value"
 msgstr "Toon _Waarde"
 
-#: schematic/scheme/conf/schematic/menu.scm:180
 msgid "Show _Name"
 msgstr "Toon _Naam"
 
-#: schematic/scheme/conf/schematic/menu.scm:181
 msgid "Show _Both"
 msgstr "Toon _Beide"
 
-#: schematic/scheme/conf/schematic/menu.scm:182
 msgid "_Toggle Visibility"
 msgstr "Schakel Zich_tbaarheid"
 
-#: schematic/scheme/conf/schematic/menu.scm:184
 msgid "_Hide Specific Text..."
 msgstr "Verberg Specifieke Tekst..."
 
-#: schematic/scheme/conf/schematic/menu.scm:185
 msgid "_Show Specific Text..."
 msgstr "Toon _Specifieke Tekst..."
 
-#: schematic/scheme/conf/schematic/menu.scm:186
 #, fuzzy
 msgid "Show/Hide Hidden Text"
 msgstr "Zichtbaar/Verborgen Onzichtbare Tekst"
 
-#: schematic/scheme/conf/schematic/menu.scm:188
 msgid "_Find Text/Check Symbol..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:189
 msgid "A_utonumber Text..."
 msgstr "A_utomatisch Tekst Nummeren..."
 
-#: schematic/scheme/conf/schematic/menu.scm:195
 #, fuzzy
 msgid "_Options..."
 msgstr "_Opties"
 
-#: schematic/scheme/conf/schematic/menu.scm:196
 #, fuzzy
 msgid "_Font..."
 msgstr "Af_drukken..."
 
-#: schematic/scheme/conf/schematic/menu.scm:198
 #, fuzzy
 msgid "Grid +"
 msgstr "Raster UIT\n"
 
-#: schematic/scheme/conf/schematic/menu.scm:199
 #, fuzzy
 msgid "Grid -"
 msgstr "Raster UIT\n"
 
-#: schematic/scheme/conf/schematic/menu.scm:201
 msgid "Grid Style: Cycle Dots/Mesh/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:202
 msgid "Grid Snap: Cycle Grid/Resnap/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:204
 #, fuzzy
 msgid "Feedback Mode: Outline/Box"
 msgstr "Schakel C_ontour/Rechthoek"
 
-#: schematic/scheme/conf/schematic/menu.scm:205
 #, fuzzy
 msgid "Net: Rubberband On/Off"
 msgstr "Elastiek band AAN\n"
 
-#: schematic/scheme/conf/schematic/menu.scm:206
 msgid "Net: Magnetic On/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:208
 #, fuzzy
 msgid "_Coord Window"
 msgstr "Sluit Venster"
 
-#: schematic/scheme/conf/schematic/menu.scm:209
 #, fuzzy
 msgid "_Log Window"
 msgstr "Toon Logboek Venster"
 
-#: schematic/scheme/conf/schematic/menu.scm:215
 msgid "_1 allegro"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:223
 #, fuzzy
 msgid "User _Guide"
 msgstr "gschem Gebruikers Gids"
 
-#: schematic/scheme/conf/schematic/menu.scm:224
 msgid "_FAQ"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:225
 #, fuzzy
 msgid "Docu_mentation"
 msgstr "D_ocumentatie..."
 
-#: schematic/scheme/conf/schematic/menu.scm:226
 msgid "_Wiki"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:228
 #, fuzzy
 msgid "Find Component D_ocumentation"
 msgstr "Component Documentatie"
 
-#: schematic/scheme/conf/schematic/menu.scm:230
 msgid "_Hotkeys..."
 msgstr "_Sneltoets..."
 
-#: schematic/scheme/conf/schematic/menu.scm:231
 #, fuzzy
 msgid "_About"
 msgstr "Om_trent..."
 
-#: schematic/scheme/conf/schematic/menu.scm:237
 msgid "_File"
 msgstr "_Bestand"
 
-#: schematic/scheme/conf/schematic/menu.scm:238
 msgid "_Edit"
 msgstr "B_ewerk"
 
-#: schematic/scheme/conf/schematic/menu.scm:240
 msgid "_View"
 msgstr "_Toon"
 
-#: schematic/scheme/conf/schematic/menu.scm:241
 msgid "_Page"
 msgstr "_Pagina"
 
-#: schematic/scheme/conf/schematic/menu.scm:242
 msgid "_Add"
 msgstr "Toe_voegen"
 
-#: schematic/scheme/conf/schematic/menu.scm:243
 msgid "Hie_rarchy"
 msgstr "Hie_rarchie"
 
-#: schematic/scheme/conf/schematic/menu.scm:244
 msgid "A_ttributes"
 msgstr "_Attributen"
 
-#: schematic/scheme/conf/schematic/menu.scm:245
 msgid "_Options"
 msgstr "_Opties"
 
-#: schematic/scheme/conf/schematic/menu.scm:246
 #, fuzzy
 msgid "_Netlist"
 msgstr "_Draad"
 
-#: schematic/scheme/conf/schematic/menu.scm:247
 msgid "_Help"
 msgstr "_Help"
 
-#: schematic/scheme/gschem/action.scm:43
 #, scheme-format
 msgid "~S is not a valid gschem action."
 msgstr "~S is geen geldige gschem actie."
 
-#: schematic/scheme/gschem/action.scm:158
 msgid "Repeat Last Action"
 msgstr "Herhaal Laatste Actie"
 
-#: schematic/scheme/gschem/builtins.scm:47
 msgid "Cancel"
 msgstr "Afbreken"
 
-#: schematic/scheme/gschem/builtins.scm:53
 msgid "New File"
 msgstr "Nieuw Bestand"
 
-#: schematic/scheme/gschem/builtins.scm:56
 msgid "Open File"
 msgstr "Open Bestand"
 
-#: schematic/scheme/gschem/builtins.scm:62
 msgid "Save As"
 msgstr "Opslaan Als"
 
-#: schematic/scheme/gschem/builtins.scm:68
 msgid "Print"
 msgstr "Afdrukken"
 
-#: schematic/scheme/gschem/builtins.scm:71
 msgid "Export Image"
 msgstr "Exporteer Afbeelding"
 
-#: schematic/scheme/gschem/builtins.scm:74
 msgid "Run Script"
 msgstr "Voer Script Uit"
 
-#: schematic/scheme/gschem/builtins.scm:80
 msgid "Close Window"
 msgstr "Sluit Venster"
 
-#: schematic/scheme/gschem/builtins.scm:83
 msgid "Quit"
 msgstr "Stoppen"
 
-#: schematic/scheme/gschem/builtins.scm:87
 msgid "Terminal REPL"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:132
 msgid "Choose Slot"
 msgstr "Kies Slot"
 
-#: schematic/scheme/gschem/builtins.scm:135
 #, fuzzy
 msgid "Edit Object Properties"
 msgstr "Bewerk Tekst Eigenschappen"
 
-#: schematic/scheme/gschem/builtins.scm:138
 msgid "Translate Symbol"
 msgstr "Verschuif Symbool"
 
-#: schematic/scheme/gschem/builtins.scm:147
 msgid "Invoke Macro"
 msgstr "Macro Aanroepen"
 
-#: schematic/scheme/gschem/builtins.scm:159
 msgid "Show/Hide Invisible Text"
 msgstr "Zichtbaar/Verborgen Onzichtbare Tekst"
 
-#: schematic/scheme/gschem/builtins.scm:165
 msgid "Cut"
 msgstr "Knip"
 
-#: schematic/scheme/gschem/builtins.scm:171
 msgid "Paste"
 msgstr "Plak"
 
-#: schematic/scheme/gschem/builtins.scm:177
 msgid "Sidebar"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:183
 #, fuzzy
 msgid "Find Text State"
 msgstr "Vind tekst"
 
-#: schematic/scheme/gschem/builtins.scm:186
 msgid "Redraw"
 msgstr "Hertekenen"
 
-#: schematic/scheme/gschem/builtins.scm:192
 msgid "Pan Left"
 msgstr "Verschuif Links"
 
-#: schematic/scheme/gschem/builtins.scm:195
 msgid "Pan Right"
 msgstr "Verschuif Rechts"
 
-#: schematic/scheme/gschem/builtins.scm:198
 msgid "Pan Up"
 msgstr "Verschuif Omhoog"
 
-#: schematic/scheme/gschem/builtins.scm:201
 msgid "Pan Down"
 msgstr "Verschuif Omlaag"
 
-#: schematic/scheme/gschem/builtins.scm:216
 msgid "Zoom Full"
 msgstr "Toon Volledig"
 
-#: schematic/scheme/gschem/builtins.scm:219
 msgid "Dark Color Scheme"
 msgstr "Donker Kleuren Schema"
 
-#: schematic/scheme/gschem/builtins.scm:222
 msgid "Light Color Scheme"
 msgstr "Licht Kleuren Schema"
 
-#: schematic/scheme/gschem/builtins.scm:225
 msgid "Monochrome Color Scheme"
 msgstr "Monochroom Kleuren Schema"
 
-#: schematic/scheme/gschem/builtins.scm:228
 #, fuzzy
 msgid "Show Color Scheme Editor"
 msgstr "Licht Kleuren Schema"
 
-#: schematic/scheme/gschem/builtins.scm:234
 msgid "Revert Changes"
 msgstr "Terughalen Wijzigingen"
 
-#: schematic/scheme/gschem/builtins.scm:240
 msgid "Previous Page"
 msgstr "Vorige Pagina"
 
-#: schematic/scheme/gschem/builtins.scm:243
 msgid "Next Page"
 msgstr "Volgende Pagina"
 
-#: schematic/scheme/gschem/builtins.scm:255
 msgid "Print Page"
 msgstr "Druk Pagina Af"
 
-#: schematic/scheme/gschem/builtins.scm:276
 msgid "Add Line"
 msgstr "Voeg Lijn Toe"
 
-#: schematic/scheme/gschem/builtins.scm:279
 msgid "Add Path"
 msgstr "Voeg Pad Toe"
 
-#: schematic/scheme/gschem/builtins.scm:282
 msgid "Add Box"
 msgstr "Voeg Rechthoek Toe"
 
-#: schematic/scheme/gschem/builtins.scm:285
 msgid "Add Circle"
 msgstr "Voeg Cirkel Toe"
 
-#: schematic/scheme/gschem/builtins.scm:288
 msgid "Add Arc"
 msgstr "Voeg Boog Toe"
 
-#: schematic/scheme/gschem/builtins.scm:291
 msgid "Add Pin"
 msgstr "Voeg Pen Toe"
 
-#: schematic/scheme/gschem/builtins.scm:294
 msgid "Add Picture"
 msgstr "Voeg Afbeelding Toe"
 
-#: schematic/scheme/gschem/builtins.scm:306
 msgid "Up Hierarchy"
 msgstr "Hierarchie Omhoog"
 
-#: schematic/scheme/gschem/builtins.scm:312
 msgid "Attach Attributes"
 msgstr "Bevestig Attributen"
 
-#: schematic/scheme/gschem/builtins.scm:315
 msgid "Detach Attributes"
 msgstr "Maak Attributen Los"
 
-#: schematic/scheme/gschem/builtins.scm:318
 msgid "Show Attribute Value"
 msgstr "Toon Attribuut Waarde"
 
-#: schematic/scheme/gschem/builtins.scm:321
 msgid "Show Attribute Name"
 msgstr "Toon Attribuut Naam"
 
-#: schematic/scheme/gschem/builtins.scm:327
 msgid "Toggle Text Visibility"
 msgstr "Schakel Tekst Zichtbaarheid"
 
-#: schematic/scheme/gschem/builtins.scm:330
 msgid "Find Specific Text"
 msgstr "Vind Specifieke Tekst"
 
-#: schematic/scheme/gschem/builtins.scm:333
 msgid "Hide Specific Text"
 msgstr "Verberg Specifieke Tekst"
 
-#: schematic/scheme/gschem/builtins.scm:336
 msgid "Show Specific Text"
 msgstr "Toon Specifieke Tekst"
 
-#: schematic/scheme/gschem/builtins.scm:339
 msgid "Autonumber Text"
 msgstr "Automatisch Tekst Nummeren"
 
-#: schematic/scheme/gschem/builtins.scm:345
 msgid "Show Hotkeys"
 msgstr "Toon Sneltoets"
 
-#: schematic/scheme/gschem/builtins.scm:348
 msgid "Switch Grid Style"
 msgstr "Schakel Raster Stijl"
 
-#: schematic/scheme/gschem/builtins.scm:351
 msgid "Switch Snap Mode"
 msgstr "Schakel Snap Modus"
 
-#: schematic/scheme/gschem/builtins.scm:354
 msgid "Set Grid Spacing"
 msgstr "Ste Raster Afstand In"
 
-#: schematic/scheme/gschem/builtins.scm:357
 msgid "Increase Grid Spacing"
 msgstr "Verhoog Raster Afstand"
 
-#: schematic/scheme/gschem/builtins.scm:360
 msgid "Decrease Grid Spacing"
 msgstr "Verlaag schalen Raster Afstand"
 
-#: schematic/scheme/gschem/builtins.scm:363
 msgid "Toggle Outline Drawing"
 msgstr "Schakel Omtrek Tekening"
 
-#: schematic/scheme/gschem/builtins.scm:366
 msgid "Toggle Net Rubber Band"
 msgstr "Schakel Draad Elastiekband"
 
-#: schematic/scheme/gschem/builtins.scm:369
 msgid "Toggle Magnetic Nets"
 msgstr "Schakel Magnetische Draden"
 
-#: schematic/scheme/gschem/builtins.scm:372
 msgid "Show Log Window"
 msgstr "Toon Logboek Venster"
 
-#: schematic/scheme/gschem/builtins.scm:375
 msgid "Show Coordinate Window"
 msgstr "Toon Coordinaten Venster"
 
-#: schematic/scheme/gschem/builtins.scm:385
 msgid "Component Documentation"
 msgstr "Component Documentatie"
 
-#: schematic/scheme/gschem/builtins.scm:387
 msgid "View documentation for selected component"
 msgstr "Toon documentatie voor geselecteerde component"
 
-#: schematic/scheme/gschem/builtins.scm:403
 msgid ""
 "Could not show documentation for selected component:\n"
 "\n"
@@ -3190,58 +2481,45 @@ msgstr ""
 "Kan geen documentatie tonen voor de geselecteerde component:\n"
 "\n"
 
-#: schematic/scheme/gschem/builtins.scm:408
 msgid "gEDA Manuals"
 msgstr "gEDA Handleidingen"
 
-#: schematic/scheme/gschem/builtins.scm:409
 #, fuzzy
 msgid "View the front page of the gEDA documentation in a browser."
 msgstr "Toon de voorpagina van de gEDA documentatie in een browser."
 
-#: schematic/scheme/gschem/builtins.scm:414
 msgid "gschem User Guide"
 msgstr "gschem Gebruikers Gids"
 
-#: schematic/scheme/gschem/builtins.scm:415
 msgid "View the gschem User Guide in a browser."
 msgstr "Toon de gschem Gebruikers Gids in een browser."
 
-#: schematic/scheme/gschem/builtins.scm:420
 msgid "gschem FAQ"
 msgstr "gschem FAQ"
 
-#: schematic/scheme/gschem/builtins.scm:421
 msgid "Frequently Asked Questions about using gschem."
 msgstr "Veel Gestelde Vragen over het gebruik van gschem."
 
-#: schematic/scheme/gschem/builtins.scm:426
 msgid "gEDA wiki"
 msgstr "gEDA wiki"
 
-#: schematic/scheme/gschem/builtins.scm:427
 msgid "View the front page of the gEDA wiki in a browser."
 msgstr "Toon de voorpagina van de gEDA wiki in een browser."
 
-#: schematic/scheme/gschem/builtins.scm:431
 msgid "About gschem"
 msgstr "Over gschem"
 
-#: schematic/scheme/gschem/deprecated.scm:102
 #, scheme-format
 msgid "Invalid text alignment ~A."
 msgstr "Ongeldige tekst uitlijning ~A."
 
-#: schematic/scheme/gschem/gschemdoc.scm:241
 msgid "No documentation found"
 msgstr "Geen documentatie gevonden"
 
-#: schematic/scheme/gschem/keymap.scm:40
 #, scheme-format
 msgid "~S is not a valid key combination."
 msgstr "~S is geen geldige toetsencombinatie."
 
-#: schematic/scheme/gschem/keymap.scm:157
 #, scheme-format
 msgid "~S is not a prefix key sequence."
 msgstr "~S is geen voorafgaande toetsen combinatie."

--- a/schematic/po/pl.po
+++ b/schematic/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-15 15:13+0300\n"
+"POT-Creation-Date: 2019-02-22 14:08+0300\n"
 "PO-Revision-Date: 2012-02-04 00:18+0000\n"
 "Last-Translator: Krzysztof Kościuszkiewicz <Unknown>\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -18,24 +18,20 @@ msgstr ""
 "X-Launchpad-Export-Date: 2012-11-14 16:52+0000\n"
 "X-Generator: Launchpad (build 16265)\n"
 
-#: schematic/src/a_zoom.c:155
 #, fuzzy
 msgid "Zoom too small!  Cannot zoom further."
 msgstr "Zbyt mały obszar! Osiągnięto maksymalny stopień powiększenia.\n"
 
-#: schematic/src/color_edit_widget.c:399
 #, fuzzy, c-format
 msgid ""
 "Could not save file [%s]:\n"
 "%s"
 msgstr "Zapisanie arkusza [%s] nie powiodło się\n"
 
-#: schematic/src/color_edit_widget.c:434
 #, fuzzy
 msgid "Save Color Scheme As..."
 msgstr "_Jasny zestaw kolorów"
 
-#: schematic/src/color_edit_widget.c:482 schematic/src/x_fileselect.c:292
 #, fuzzy, c-format
 msgid ""
 "The selected file `%1$s' already exists.\n"
@@ -46,186 +42,148 @@ msgstr ""
 "\n"
 "Czy chcesz go zastąpić bieżącym schematem?"
 
-#: schematic/src/color_edit_widget.c:486 schematic/src/x_fileselect.c:295
 msgid "Overwrite file?"
 msgstr "Zastąpić plik?"
 
-#: schematic/src/font_select_widget.c:211
 msgid "_Apply"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:215
 msgid "Sa_ve..."
 msgstr ""
 
-#: schematic/src/font_select_widget.c:278
 #, c-format
 msgid "<b>Current:</b> %s"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:453
 msgid "Save configuration"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:461
 #, fuzzy
 msgid "Save settings to:"
 msgstr "Ustawienia"
 
-#: schematic/src/font_select_widget.c:465
 msgid "Local configuration file (in current directory)"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:467
 msgid "User configuration file (geda-user.conf)"
 msgstr ""
 
-#: schematic/src/g_attrib.c:90
 msgid "Object ~A is not included in the current gschem page."
 msgstr "Obiekt ~A nie występuje w bieżącym arkuszu."
 
-#: schematic/src/g_attrib.c:110
 msgid "Invalid text name/value visibility ~A."
 msgstr "Nieprawidłowe ustawienie widoczności tekstu: ~A."
 
-#: schematic/src/g_rc.c:107
 #, fuzzy, c-format
 msgid "You are running gEDA/gaf version [%1$s%2$s.%3$s],\n"
 msgstr "gEDA/gschem, wersja %s%s.%s\n"
 
-#: schematic/src/g_rc.c:111
 #, c-format
 msgid ""
 "but you have a version [%1$s] gschemrc file:\n"
 "[%2$s]\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:114
 #, c-format
 msgid "Please be sure that you have the latest rc file.\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:240
 #, fuzzy, c-format
 msgid "Invalid size [%1$d] passed to text-size\n"
 msgstr "Nieprawidłowy rozmiar [%d] przekazany do funkcji text-size\n"
 
-#: schematic/src/g_rc.c:283
 #, fuzzy, c-format
 msgid "Invalid size [%1$d] passed to snap-size\n"
 msgstr "Nieprawidłowy rozmiar [%d] przekazany do funkcji snap-size\n"
 
-#: schematic/src/g_rc.c:620
 #, fuzzy, c-format
 msgid "Invalid num levels [%1$d] passed to undo-levels\n"
 msgstr "Nieprawidłowa liczba poziomów [%d] przekazana do funkcji undo-levels\n"
 
-#: schematic/src/g_rc.c:831
 #, fuzzy, c-format
 msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
 msgstr "Nieprawidłowy rozmiar [%d] przekazany do funkcji bus-ripper-size\n"
 
-#: schematic/src/g_rc.c:931
 #, fuzzy, c-format
 msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
 msgstr ""
 "Nieprawidłowy rozmiar punktu [%d] przekazany do funkcji dots-grid-dot-size\n"
 
-#: schematic/src/g_rc.c:972
 #, fuzzy, c-format
 msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
 msgstr ""
 "Nieprawidłowy odstęp pikseli [%d] przekazany do funkcji dots-grid-fixed-"
 "threshold\n"
 
-#: schematic/src/g_rc.c:998
 #, fuzzy, c-format
 msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
 msgstr ""
 "Nieprawidłowy odstęp pikseli [%d] przekazany do funkcji mesh-grid-display-"
 "threshold\n"
 
-#: schematic/src/g_rc.c:1023
 #, fuzzy, c-format
 msgid "Invalid offset [%1$d] passed to add-attribute-offset\n"
 msgstr "Nieprawidłowy offset [%d] przekazany do funkcji add-attribute-offset\n"
 
-#: schematic/src/g_rc.c:1047
 #, fuzzy, c-format
 msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
 msgstr ""
 "Nieprawidłowa liczba sekund [%d] przekazana do funkcji auto-save-interval\n"
 
-#: schematic/src/g_rc.c:1071
 #, fuzzy, c-format
 msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
 msgstr "Nieprawidłowa wartość [%d] przekazana do funkcji mousepan-gain\n"
 
-#: schematic/src/g_rc.c:1094
 #, fuzzy, c-format
 msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
 msgstr "Nieprawidłowa wartość [%d] przekazana do funkcji keyboardpan-gain\n"
 
-#: schematic/src/g_rc.c:1118
 #, fuzzy, c-format
 msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
 msgstr ""
 "Nieprawidłowa ilość pikseli [%d] przekazana do funkcji select-slack-pixels\n"
 
-#: schematic/src/g_rc.c:1144
 #, fuzzy, c-format
 msgid "Invalid gain [%1$d] passed to zoom-gain\n"
 msgstr "Nieprawidłowa wartość [%d] przekazana do funkcji zoom-gain\n"
 
-#: schematic/src/g_rc.c:1169
 #, fuzzy, c-format
 msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
 msgstr "Niepoprawna liczba kroków [%d] w funkcji scrollpan-steps\n"
 
-#: schematic/src/g_select.c:78 schematic/src/g_select.c:115
-#: schematic/src/g_select.c:151
 msgid "Object ~A is not directly included in a page."
 msgstr "Obiekt ~A nie jest przypisany do arkusza"
 
-#: schematic/src/g_util.c:54
 msgid "Could not launch URI ~S: ~A"
 msgstr "Nie można otworzyć adresu URI ~S: ~A"
 
-#: schematic/src/g_window.c:139
 msgid "Found invalid gschem window smob ~S"
 msgstr "Nieprawidłowy obiekt reprezentujący okno gschem: ~S"
 
-#: schematic/src/lepton-schematic.c:156
 #, fuzzy, c-format
 msgid "Lepton EDA/lepton-schematic version %1$s%2$s.%3$s git: %4$.7s"
 msgstr "gEDA/gschem, wersja %s%s.%s\n"
 
-#: schematic/src/lepton-schematic.c:163
 #, c-format
 msgid "This is the MINGW32 port.\n"
 msgstr "Ta wersja programu została skompilowana na MINGW32.\n"
 
-#: schematic/src/lepton-schematic.c:167
 #, fuzzy, c-format
 msgid "Current locale settings: %1$s\n"
 msgstr "Bieżące ustawienia lokalizacji: %s\n"
 
-#: schematic/src/lepton-schematic.c:201
 #, fuzzy, c-format
 msgid "Couldn't find init scm file [%1$s]"
 msgstr "Nie znaleziono pliku inicjalizacyjnego scm [%s]\n"
 
-#: schematic/src/lepton-schematic.c:206
 #, fuzzy, c-format
 msgid "Read init scm file [%1$s]"
 msgstr "Wczytano plik inicjalizacji scm [%s]\n"
 
-#: schematic/src/lepton-schematic.c:210
 #, fuzzy, c-format
 msgid "Failed to read init scm file [%1$s]"
 msgstr "Błąd podczas wczytywania pliku inicjalizacji scm [%s]\n"
 
-#: schematic/src/lepton-schematic.c:290
 #, fuzzy, c-format
 msgid ""
 "ERROR: Failed to load or evaluate startup script.\n"
@@ -236,730 +194,545 @@ msgstr ""
 "\n"
 "Logi programu mogą zawierać dodatkowe informacje."
 
-#: schematic/src/gschem_about_dialog.c:51
 #, fuzzy, c-format
 msgid "%s (git: %.7s)"
 msgstr "%s (g%.7s)"
 
-#: schematic/src/gschem_about_dialog.c:75
 #, fuzzy
 msgid "Lepton Electronic Design Automation"
 msgstr "gEDA: GPL Electronic Design Automation"
 
-#: schematic/src/gschem_about_dialog.c:83
 #, fuzzy
 msgid ""
 "Copyright © 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright © 2017-2018 Lepton Developers.\n"
-"See AUTHORS and ChangeLog files for details."
+"Copyright © 2017-2019 Lepton Developers.\n"
+"See AUTHORS, ChangeLog files and consult 'git log' history for details."
 msgstr ""
 "Copyright © 1998-2012 Ales Hvezda <ahvezda@geda.seul.org>\n"
 "Copyright © 1998-2012 Kontrybutorzy gEDA (szczegóły w pliku ChangeLog)"
 
-#: schematic/src/gschem_alignment_combo.c:69
 msgid "Upper Left"
 msgstr "Na górze po lewej"
 
-#: schematic/src/gschem_alignment_combo.c:71
 msgid "Upper Middle"
 msgstr "Na środku powyżej"
 
-#: schematic/src/gschem_alignment_combo.c:73
 #, fuzzy
 msgid "Upper Right"
 msgstr "Na dole po prawej"
 
-#: schematic/src/gschem_alignment_combo.c:78
 msgid "Middle Left"
 msgstr "Na środku po lewej"
 
-#: schematic/src/gschem_alignment_combo.c:80
 msgid "Middle Middle"
 msgstr "Pośrodku"
 
-#: schematic/src/gschem_alignment_combo.c:82
 msgid "Middle Right"
 msgstr "Na środku po prawej"
 
-#: schematic/src/gschem_alignment_combo.c:87
 msgid "Lower Left"
 msgstr "Na dole po lewej"
 
-#: schematic/src/gschem_alignment_combo.c:89
 msgid "Lower Middle"
 msgstr "Na środku poniżej"
 
-#: schematic/src/gschem_alignment_combo.c:91
 msgid "Lower Right"
 msgstr "Na dole po prawej"
 
-#: schematic/src/gschem_arc_dialog.c:104
 msgid "Arc Params"
 msgstr "Parametry łuku"
 
-#: schematic/src/gschem_arc_dialog.c:140
 #, fuzzy
 msgid "Arc _Radius:"
 msgstr "Promień łuku:"
 
-#: schematic/src/gschem_arc_dialog.c:141
 #, fuzzy
 msgid "Start _Angle:"
 msgstr "Kąt początkowy:"
 
-#: schematic/src/gschem_arc_dialog.c:142
 #, fuzzy
 msgid "_Degrees of Sweep:"
 msgstr "Kąt rozwarcia"
 
-#: schematic/src/gschem_bottom_widget.c:504
 msgid "Left mouse button"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:508
 #, fuzzy
 msgid "Middle mouse button"
 msgstr "Na środku po lewej"
 
-#: schematic/src/gschem_bottom_widget.c:512
 #, fuzzy
 msgid "Right mouse button"
 msgstr ""
 "Tryb dodawania połączeń\n"
 "Anuluj prawym przyciskiem myszy"
 
-#: schematic/src/gschem_bottom_widget.c:595
 msgid "(Snap size, Grid size)"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:603
 #, fuzzy
 msgid "Net rubber band mode"
 msgstr "Przełącz _rozciąganie połączeń"
 
-#: schematic/src/gschem_bottom_widget.c:614
 #, fuzzy
 msgid "Magnetic net mode"
 msgstr "Tryb \"magnetycznych\" połączeń"
 
-#: schematic/src/gschem_bottom_widget.c:622
 #, fuzzy
 msgid "Current action mode"
 msgstr "Bieżący widok"
 
-#: schematic/src/gschem_bottom_widget.c:935
-#: schematic/src/gschem_bottom_widget.c:951
 msgid "OFF"
 msgstr "WYŁĄCZONE"
 
-#: schematic/src/gschem_bottom_widget.c:954
 msgid "NONE"
 msgstr "BRAK"
 
-#: schematic/src/gschem_bottom_widget.c:960
 #, fuzzy, c-format
 msgid "Grid(%1$s, %2$s)"
 msgstr "Siatka(%s, %s)"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:350
-#: schematic/src/x_compselect.c:1236 schematic/src/x_multiattrib.c:2068
 msgid "Name"
 msgstr "Nazwa"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:372
 msgid "S_elect the schematics you want to save:"
 msgstr "Wybi_erz schematy, które chcesz zapisać:"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:467
 #, fuzzy, c-format
 msgid "Save the changes to schematic \"%1$s\" before closing?"
 msgstr "Zapisać zmiany w schemacie \"%s\" przed wyjściem?"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:473
 #, fuzzy, c-format
 msgid ""
 "There are %1$d schematics with unsaved changes. Save changes before closing?"
 msgstr "Niezapisane zmiany w %d schematach. Zapisać zmiany przed wyjściem?"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:502
 msgid "If you don't save, all your changes will be permanently lost."
 msgstr "Jeżeli nie zapiszesz, wszystkie zmiany zostaną bezpowrotnie utracone."
 
-#: schematic/src/gschem_close_confirmation_dialog.c:522
 #, fuzzy
 msgid "Close _without saving"
 msgstr "_Zamknij bez zapisywania"
 
-#: schematic/src/gschem_coord_dialog.c:86
 msgid "Coords"
 msgstr "Współrzędne"
 
-#: schematic/src/gschem_coord_dialog.c:106
 msgid "Screen"
 msgstr "Ekran"
 
-#: schematic/src/gschem_coord_dialog.c:115
 msgid "World"
 msgstr "Świat"
 
-#: schematic/src/gschem_find_text_state.c:809 schematic/src/x_pagesel.c:432
 msgid "Filename"
 msgstr "Nazwa pliku"
 
-#: schematic/src/gschem_find_text_state.c:821 schematic/src/i_callbacks.c:1970
-#: schematic/src/x_colorcb.c:154 schematic/src/x_widgets.c:179
-#: schematic/src/x_window.c:1226 schematic/src/x_window.c:1440
 msgid "Text"
 msgstr "Tekst"
 
-#: schematic/src/gschem_find_text_widget.c:427
 msgid "descend into hierarchy"
 msgstr "Szukaj również wewnątrz elementów"
 
-#: schematic/src/gschem_find_text_widget.c:435
 #, fuzzy
 msgid "Find"
 msgstr "Znajdź tekst"
 
-#: schematic/src/gschem_find_text_widget.c:557
 #, fuzzy
 msgid "Find Text:"
 msgstr "Znajdź tekst"
 
-#: schematic/src/gschem_find_text_widget.c:564
 msgid "Find Pattern:"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:571
 #, fuzzy
 msgid "Find Regex:"
 msgstr "Znajdź tekst"
 
-#: schematic/src/gschem_find_text_widget.c:578
 msgid "Check symbol:"
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:200
 msgid "Hotkeys"
 msgstr "Klawisze skrótów"
 
-#: schematic/src/gschem_hotkey_dialog.c:229
 msgid ""
 "Start typing action name or keystroke to filter the list.\n"
 "Type hotkeys as they are displayed in \"Keystroke(s)\" column."
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:233 schematic/src/x_compselect.c:1124
 #, fuzzy
 msgid "_Filter:"
 msgstr "Filtr:"
 
-#: schematic/src/gschem_hotkey_dialog.c:259 schematic/src/i_basic.c:280
 msgid "Action"
 msgstr "Czynność"
 
-#: schematic/src/gschem_hotkey_dialog.c:277
 msgid "Keystroke(s)"
 msgstr "Klawisz(e)"
 
-#: schematic/src/gschem_log_widget.c:177
 msgid "** Invalid UTF-8 in log message. See stderr or gschem.log.\n"
 msgstr ""
 "** Nieprawidłowy znak UTF-8 w komunikacie. Zobacz standardowe wyjście błędów "
 "lub plik gschem.log.\n"
 
-#: schematic/src/gschem_log_widget.c:434
 #, fuzzy
 msgid "Clear log window?"
 msgstr "Zamykanie okna\n"
 
-#: schematic/src/gschem_log_widget.c:477
 #, fuzzy
 msgid "Clear Log _Window"
 msgstr "Pokaż okno komunikatów..."
 
-#: schematic/src/gschem_macro_widget.c:231
 msgid "Macro:"
 msgstr ""
 
-#: schematic/src/gschem_macro_widget.c:387
 msgid "Evaluate"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:172
 #, fuzzy
 msgid "_Fill Type:"
 msgstr "Typ wypełnienia:"
 
-#: schematic/src/gschem_object_properties_widget.c:173
 #, fuzzy
 msgid "Lin_e Width:"
 msgstr "Szerokość linii:"
 
-#: schematic/src/gschem_object_properties_widget.c:174
 #, fuzzy
 msgid "Angle _1:"
 msgstr "Kąt linii 1:"
 
-#: schematic/src/gschem_object_properties_widget.c:175
 #, fuzzy
 msgid "P_itch 1:"
 msgstr "Odstęp między liniami 1:"
 
-#: schematic/src/gschem_object_properties_widget.c:176
 #, fuzzy
 msgid "Angle _2:"
 msgstr "Kąt linii 2:"
 
-#: schematic/src/gschem_object_properties_widget.c:177
 #, fuzzy
 msgid "Pitc_h 2:"
 msgstr "Odstęp między liniami 2:"
 
-#: schematic/src/gschem_object_properties_widget.c:237
 #, fuzzy
 msgid "<b>Fill Properties</b>"
 msgstr "<b>Właściwości tekstu</b>"
 
-#: schematic/src/gschem_object_properties_widget.c:255
-#: schematic/src/gschem_text_properties_widget.c:258
-#: schematic/src/x_newtext.c:271
 #, fuzzy
 msgid "Colo_r:"
 msgstr "Kolor:"
 
-#: schematic/src/gschem_object_properties_widget.c:266
 #, fuzzy
 msgid "<b>General Properties</b>"
 msgstr "<b>Właściwości tekstu</b>"
 
-#: schematic/src/gschem_object_properties_widget.c:284
 #, fuzzy
 msgid "_Type:"
 msgstr "Rodzaj:"
 
-#: schematic/src/gschem_object_properties_widget.c:285
 #, fuzzy
 msgid "_Width:"
 msgstr "Szerokość:"
 
-#: schematic/src/gschem_object_properties_widget.c:286
 #, fuzzy
 msgid "Dash _Length:"
 msgstr "Długość kreski"
 
-#: schematic/src/gschem_object_properties_widget.c:287
 #, fuzzy
 msgid "Dash _Space:"
 msgstr "Długość przerwy"
 
-#: schematic/src/gschem_object_properties_widget.c:288
 msgid "C_ap style:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:333
 #, fuzzy
 msgid "<b>Line Properties</b>"
 msgstr "<b>Właściwości tekstu</b>"
 
-#: schematic/src/gschem_object_properties_widget.c:351
 #, fuzzy
 msgid "_Pin Type:"
 msgstr "Styl wypełnienia..."
 
-#: schematic/src/gschem_object_properties_widget.c:362
 #, fuzzy
 msgid "<b>Pin Properties</b>"
 msgstr "<b>Właściwości tekstu</b>"
 
-#: schematic/src/gschem_options_widget.c:217
 msgid "_Off"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:220
 msgid "_Dots"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:223
 msgid "M_esh"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:245
 #, fuzzy
 msgid "Net R_ubber Band Mode:"
 msgstr "Przełącz _rozciąganie połączeń"
 
-#: schematic/src/gschem_options_widget.c:246
 #, fuzzy
 msgid "_Magnetic Net Mode:"
 msgstr "Tryb \"magnetycznych\" połączeń"
 
-#: schematic/src/gschem_options_widget.c:250
-#: schematic/src/gschem_options_widget.c:251
 msgid "Enabled"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:265
 #, fuzzy
 msgid "<b>Net Options</b>"
 msgstr "<b>Opcje</b>"
 
-#: schematic/src/gschem_options_widget.c:282
 #, fuzzy
 msgid "Grid Mode:"
 msgstr "Tryb łuków"
 
-#: schematic/src/gschem_options_widget.c:283
 #, fuzzy
 msgid "Snap Mode:"
 msgstr "Tryb przesuwania widoku"
 
-#: schematic/src/gschem_options_widget.c:284
 #, fuzzy
 msgid "_Snap Size:"
 msgstr "Odległość przyciągania"
 
-#: schematic/src/gschem_options_widget.c:301
 #, fuzzy
 msgid "<b>Snap Options</b>"
 msgstr "<b>Opcje</b>"
 
-#: schematic/src/gschem_options_widget.c:340
 msgid "O_ff"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:343
 #, fuzzy
 msgid "_Grid"
 msgstr "Siatka: włączona\n"
 
-#: schematic/src/gschem_options_widget.c:346
 msgid "_Resnap"
 msgstr ""
 
-#: schematic/src/gschem_pin_type_combo.c:73
 msgid "Net pin"
 msgstr ""
 
-#: schematic/src/gschem_pin_type_combo.c:80
 msgid "Bus pin (graphical)"
 msgstr ""
 
-#: schematic/src/gschem_preview.c:195
 msgid "Preview Buffer"
 msgstr ""
 
-#: schematic/src/gschem_show_hide_text_widget.c:148
-#: schematic/src/x_window.c:1268
 #, fuzzy
 msgid "Hide"
 msgstr "Ukryj tekst"
 
-#: schematic/src/gschem_show_hide_text_widget.c:157
-#: schematic/src/x_window.c:1269
 msgid "Hide text starting with:"
 msgstr "Ukryj tekst zaczynający się od:"
 
-#: schematic/src/gschem_slot_edit_dialog.c:91
 msgid "Edit slot number"
 msgstr ""
 
-#: schematic/src/gschem_slot_edit_dialog.c:121
 msgid "Number of Slots:"
 msgstr ""
 
-#: schematic/src/gschem_slot_edit_dialog.c:122
 #, fuzzy
 msgid "Slot Number:"
 msgstr "Numer początkowy"
 
-#: schematic/src/gschem_text_properties_widget.c:240
-#: schematic/src/x_newtext.c:265
 msgid "<b>Text Content</b>"
 msgstr "<b>Treść tekstu</b>"
 
-#: schematic/src/gschem_text_properties_widget.c:259
-#: schematic/src/x_newtext.c:291
 #, fuzzy
 msgid "_Size:"
 msgstr "Rozmiar:"
 
-#: schematic/src/gschem_text_properties_widget.c:260
-#: schematic/src/x_newtext.c:310
 #, fuzzy
 msgid "Ali_gnment:"
 msgstr "Punkt odniesienia:"
 
-#: schematic/src/gschem_text_properties_widget.c:261
-#: schematic/src/x_newtext.c:330
 #, fuzzy
 msgid "Ro_tation:"
 msgstr "Ułożenie papieru:"
 
-#: schematic/src/gschem_text_properties_widget.c:294
-#: schematic/src/x_newtext.c:253
 msgid "<b>Text Properties</b>"
 msgstr "<b>Właściwości tekstu</b>"
 
-#: schematic/src/gschem_translate_widget.c:238
 #, fuzzy
 msgid "Coordinate:"
 msgstr "Pokaż okno współrzędnych..."
 
-#: schematic/src/gschem_translate_widget.c:405 schematic/src/i_callbacks.c:800
 msgid "Translate"
 msgstr "Tłumacz"
 
-#: schematic/src/i_basic.c:64 schematic/src/x_window.c:1369
-#: schematic/scheme/conf/schematic/menu.scm:59
-#: schematic/scheme/gschem/builtins.scm:99
 msgid "Select Mode"
 msgstr "Tryb zaznaczania"
 
-#: schematic/src/i_basic.c:65
 #, fuzzy
 msgid "Select Box Mode"
 msgstr "Tryb zaznaczania"
 
-#: schematic/src/i_basic.c:66
 msgid "Text Mode"
 msgstr "Tryb tekstu"
 
-#: schematic/src/i_basic.c:67
 msgid "Pan Mode"
 msgstr "Tryb przesuwania widoku"
 
-#: schematic/src/i_basic.c:70
 #, c-format
 msgid "Paste %d Mode"
 msgstr "Tryb wklejania z bufora %d"
 
-#: schematic/src/i_basic.c:74
 msgid "Magnetic Net Mode"
 msgstr "Tryb \"magnetycznych\" połączeń"
 
-#: schematic/src/i_basic.c:76
 msgid "Net Mode"
 msgstr "Tryb połączeń"
 
-#: schematic/src/i_basic.c:77
 msgid "Arc Mode"
 msgstr "Tryb łuków"
 
-#: schematic/src/i_basic.c:78
 msgid "Box Mode"
 msgstr "Tryb prostokątów"
 
-#: schematic/src/i_basic.c:79
 msgid "Bus Mode"
 msgstr "Tryb magistrali"
 
-#: schematic/src/i_basic.c:80
 msgid "Circle Mode"
 msgstr "Tryb okręgów"
 
-#: schematic/src/i_basic.c:81
 msgid "Component Mode"
 msgstr "Tryb elementów"
 
-#: schematic/src/i_basic.c:82 schematic/scheme/conf/schematic/menu.scm:62
-#: schematic/scheme/gschem/builtins.scm:114
 msgid "Copy Mode"
 msgstr "Tryb kopiowania"
 
-#: schematic/src/i_basic.c:83 schematic/scheme/conf/schematic/menu.scm:63
-#: schematic/scheme/gschem/builtins.scm:117
 msgid "Multiple Copy Mode"
 msgstr "Duplikuj wielokrotnie"
 
-#: schematic/src/i_basic.c:84
 msgid "Line Mode"
 msgstr "Tryb linii"
 
-#: schematic/src/i_basic.c:85 schematic/scheme/conf/schematic/menu.scm:66
-#: schematic/scheme/gschem/builtins.scm:123
 msgid "Mirror Mode"
 msgstr "Tryb odbijania"
 
-#: schematic/src/i_basic.c:86 schematic/scheme/conf/schematic/menu.scm:64
-#: schematic/scheme/gschem/builtins.scm:111
 msgid "Move Mode"
 msgstr "Tryb przesuwania"
 
-#: schematic/src/i_basic.c:87
 #, fuzzy
 msgid "Path Mode"
 msgstr "Tryb przesuwania widoku"
 
-#: schematic/src/i_basic.c:88
 msgid "Picture Mode"
 msgstr "Tryb obrazów"
 
-#: schematic/src/i_basic.c:89
 msgid "Pin Mode"
 msgstr "Tryb pinów"
 
-#: schematic/src/i_basic.c:90 schematic/scheme/gschem/builtins.scm:120
 msgid "Rotate Mode"
 msgstr "Tryb obrotu"
 
-#: schematic/src/i_basic.c:91
 #, fuzzy
 msgid "Modify Mode"
 msgstr "Tryb kopiowania"
 
-#: schematic/src/i_basic.c:92 schematic/src/x_menus.c:49
-#: schematic/scheme/gschem/builtins.scm:204
 msgid "Zoom Box"
 msgstr "Dopasuj do fragmentu"
 
-#: schematic/src/i_basic.c:121
 msgid "Show Hidden"
 msgstr "Pokaż ukryte"
 
-#: schematic/src/i_basic.c:124
 msgid "Snap Off"
 msgstr "Wyłącz przyciąganie"
 
-#: schematic/src/i_basic.c:126
 msgid "Resnap Active"
 msgstr ""
 
-#: schematic/src/i_basic.c:288 schematic/src/x_colorcb.c:159
 msgid "Stroke"
 msgstr "Gest"
 
-#: schematic/src/i_basic.c:296 schematic/src/i_basic.c:330
-#: schematic/src/x_window.c:1361
 msgid "none"
 msgstr "brak"
 
-#: schematic/src/i_basic.c:304
 msgid "Repeat/"
 msgstr "Powtórz/"
 
-#: schematic/src/i_basic.c:315
 msgid "Repeat/none"
 msgstr "Powtórz/brak"
 
-#: schematic/src/i_basic.c:323 schematic/src/i_callbacks.c:1239
-#: schematic/scheme/gschem/builtins.scm:189
 msgid "Pan"
 msgstr "Przesuń widok"
 
-#: schematic/src/i_callbacks.c:74
 #, fuzzy, c-format
 msgid "New page created [%1$s]"
 msgstr "Utworzono nowy arkusz [%s]\n"
 
-#: schematic/src/i_callbacks.c:108
 #, fuzzy, c-format
 msgid "New Window created [%1$s]"
 msgstr "Utworzono nowe okno [%s]\n"
 
-#: schematic/src/i_callbacks.c:245
 msgid "Failed to Save All"
 msgstr "Zapisanie wszystkich dokumentów nie powiodło się"
 
-#: schematic/src/i_callbacks.c:247
 msgid "Saved All"
 msgstr "Zapisano wszystkie dokumenty"
 
-#: schematic/src/i_callbacks.c:308
 #, fuzzy
 msgid "Closing Window"
 msgstr "Zamykanie okna\n"
 
-#: schematic/src/i_callbacks.c:505 schematic/src/x_menus.c:55
-#: schematic/scheme/gschem/builtins.scm:168
 msgid "Copy"
 msgstr "Kopiuj"
 
-#: schematic/src/i_callbacks.c:514 schematic/src/i_callbacks.c:539
-#: schematic/src/i_callbacks.c:564
 msgid "Select objs first"
 msgstr "Wpierw wybierz obiekty"
 
-#: schematic/src/i_callbacks.c:530
 msgid "Multiple Copy"
 msgstr "Kopiuj wielokrotnie"
 
-#: schematic/src/i_callbacks.c:555 schematic/src/x_menus.c:56
 msgid "Move"
 msgstr "Przesuń"
 
-#: schematic/src/i_callbacks.c:579 schematic/src/x_menus.c:57
-#: schematic/src/x_multiattrib.c:1656 schematic/scheme/gschem/builtins.scm:108
 msgid "Delete"
 msgstr "Usuń"
 
-#: schematic/src/i_callbacks.c:603
 msgid "Edit"
 msgstr "Edycja"
 
-#: schematic/src/i_callbacks.c:618 schematic/scheme/gschem/builtins.scm:129
 msgid "Edit Text"
 msgstr "Edytuj tekst"
 
-#: schematic/src/i_callbacks.c:637
 msgid "Slot"
 msgstr "Slot"
 
-#: schematic/src/i_callbacks.c:688 schematic/src/i_callbacks.c:698
 msgid "Rotate"
 msgstr "Obróć"
 
-#: schematic/src/i_callbacks.c:736 schematic/src/i_callbacks.c:746
 msgid "Mirror"
 msgstr "Lustrzane odbicie"
 
-#: schematic/src/i_callbacks.c:763 schematic/src/x_colorcb.c:160
-#: schematic/scheme/conf/schematic/menu.scm:73
-#: schematic/scheme/gschem/builtins.scm:141
 msgid "Lock"
 msgstr "Zablokuj"
 
-#: schematic/src/i_callbacks.c:781 schematic/scheme/conf/schematic/menu.scm:74
-#: schematic/scheme/gschem/builtins.scm:144
 msgid "Unlock"
 msgstr "Odblokuj"
 
-#: schematic/src/i_callbacks.c:805
 msgid "WARNING: Do not translate with snap off!"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:806
 msgid "WARNING: Turning snap on and continuing with translate."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:813
 #, fuzzy
 msgid "WARNING: Snap grid size is not equal to 100!"
 msgstr "UWAGA: Rozmiar siatki przyciągania jest inny niż 100!\n"
 
-#: schematic/src/i_callbacks.c:815
 msgid ""
 "WARNING: If you are translating a symbol to the origin, the snap grid size "
 "should be set to 100"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:847
 msgid "Embed"
 msgstr "Osadź"
 
-#: schematic/src/i_callbacks.c:886
 msgid "Unembed"
 msgstr "Cofnij osadzanie"
 
-#: schematic/src/i_callbacks.c:928
 msgid "Update"
 msgstr "Aktualizuj"
 
-#: schematic/src/i_callbacks.c:970
 msgid "ShowHidden"
 msgstr "Wyśw. ukryte"
 
-#: schematic/src/i_callbacks.c:1537
 #, c-format
 msgid ""
 "<b>Revert page:</b>\n"
@@ -970,100 +743,78 @@ msgid ""
 "discarded and page file will be reloaded from disk."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1555
 #, fuzzy
 msgid "Revert"
 msgstr "P_rzywróć"
 
-#: schematic/src/i_callbacks.c:1647
 msgid "Copy to clipboard"
 msgstr "Kopiuj do schowka"
 
-#: schematic/src/i_callbacks.c:1664
 msgid "Cut to clipboard"
 msgstr "Wytnij do schowka"
 
-#: schematic/src/i_callbacks.c:1686
 msgid "Paste from clipboard"
 msgstr "Wklej ze schowka"
 
-#: schematic/src/i_callbacks.c:1694
 #, fuzzy
 msgid "Empty clipboard"
 msgstr "Kopiuj do schowka"
 
 #. TRANSLATORS: The number is the number of the buffer that the
 #. * selection is being copied to.
-#: schematic/src/i_callbacks.c:1719
 #, fuzzy, c-format
 msgid "Copy %i"
 msgstr "Kopiuj do 1"
 
 #. TRANSLATORS: The number is the number of the buffer that the
 #. * selection is being cut to.
-#: schematic/src/i_callbacks.c:1746
 #, fuzzy, c-format
 msgid "Cut %i"
 msgstr "Wytnij do 1"
 
 #. TRANSLATORS: The number is the number of the buffer that is being
 #. * pasted to the schematic.
-#: schematic/src/i_callbacks.c:1776
 #, fuzzy, c-format
 msgid "Paste %i"
 msgstr "Wklej z 1"
 
-#: schematic/src/i_callbacks.c:1785
 msgid "Empty buffer"
 msgstr "Schowek jest pusty"
 
-#: schematic/src/i_callbacks.c:1833 schematic/src/x_window.c:1203
 msgid "Component"
 msgstr "Element"
 
-#: schematic/src/i_callbacks.c:1865 schematic/src/x_colorcb.c:150
 msgid "Attribute"
 msgstr "Atrybut"
 
-#: schematic/src/i_callbacks.c:1885 schematic/src/x_colorcb.c:149
 msgid "Net"
 msgstr "Połączenie"
 
-#: schematic/src/i_callbacks.c:1928 schematic/src/x_colorcb.c:155
-#: schematic/src/x_window.c:1222
 msgid "Bus"
 msgstr "Magistralę"
 
-#: schematic/src/i_callbacks.c:2004
 msgid "Line"
 msgstr "Linię"
 
-#: schematic/src/i_callbacks.c:2021
 msgid "Path"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2043
 msgid "Box"
 msgstr "Prostokąt"
 
-#: schematic/src/i_callbacks.c:2085
 msgid "Circle"
 msgstr "Okrąg"
 
-#: schematic/src/i_callbacks.c:2108
 msgid "Arc"
 msgstr "Łuk"
 
-#: schematic/src/i_callbacks.c:2131 schematic/src/x_colorcb.c:146
 msgid "Pin"
 msgstr "Pin"
 
-#: schematic/src/i_callbacks.c:2191
 #, fuzzy, c-format
 msgid "Searching for source [%1$s]"
 msgstr "Szukam źródła [%s]\n"
 
-#: schematic/src/i_callbacks.c:2223
 #, fuzzy, c-format
 msgid ""
 "Failed to descend hierarchy into '%1$s': %2$s\n"
@@ -1074,121 +825,96 @@ msgstr ""
 "\n"
 "Logi programu mogą zawierać dodatkowe informacje."
 
-#: schematic/src/i_callbacks.c:2227
 #, fuzzy, c-format
 msgid "Failed to descend into '%1$s': %2$s"
 msgstr "Błąd podczas wczytywania pliku inicjalizacji scm [%s]\n"
 
-#: schematic/src/i_callbacks.c:2234
 #, fuzzy
 msgid "Failed to descend hierarchy."
 msgstr "Szukaj również wewnątrz elementów"
 
-#: schematic/src/i_callbacks.c:2312
 #, fuzzy, c-format
 msgid "Searching for symbol [%1$s]"
 msgstr "Szukam symbolu [%s]\n"
 
-#: schematic/src/i_callbacks.c:2320
 #, fuzzy
 msgid "Symbol is not a real file. Symbol cannot be loaded."
 msgstr "Symbol nie jest plikiem. Nie można wczytać symbolu.\n"
 
-#: schematic/src/i_callbacks.c:2367 schematic/src/x_tabs.c:1060
 #, fuzzy
 msgid "Cannot find any schematics above the current one!"
 msgstr "Nie znaleziono żadnego schematu wyżej w hierarchii!\n"
 
-#: schematic/src/i_callbacks.c:2400
 msgid "Attach"
 msgstr "Dołącz"
 
-#: schematic/src/i_callbacks.c:2456
 msgid "Detach"
 msgstr "Odłącz"
 
-#: schematic/src/i_callbacks.c:2500
 msgid "ShowN"
 msgstr "Wyśw. nazwę"
 
-#: schematic/src/i_callbacks.c:2537
 msgid "ShowV"
 msgstr "Wyśw. wartość"
 
-#: schematic/src/i_callbacks.c:2574
 msgid "ShowB"
 msgstr "Wyśw. oba"
 
-#: schematic/src/i_callbacks.c:2612
 msgid "VisToggle"
 msgstr "Przeł. widoczność"
 
-#: schematic/src/i_callbacks.c:2643
 #, c-format
 msgid "Sorry but this is a non-functioning menu option\n"
 msgstr "Niestety to polecenie jeszcze nie działa\n"
 
-#: schematic/src/i_callbacks.c:2703
 #, fuzzy
 msgid "Action feedback mode set to OUTLINE"
 msgstr "Tryb wyświetlania przemieszczanych elementów\n"
 
-#: schematic/src/i_callbacks.c:2706
 #, fuzzy
 msgid "Action feedback mode set to BOUNDINGBOX"
 msgstr "Tryb wyświetlania obwiedni przemieszczanych elementów\n"
 
-#: schematic/src/i_callbacks.c:2730
 #, fuzzy
 msgid "Grid OFF"
 msgstr "Siatka: włączona\n"
 
-#: schematic/src/i_callbacks.c:2731
 #, fuzzy
 msgid "Dot grid selected"
 msgstr "Siatka kropkowana\n"
 
-#: schematic/src/i_callbacks.c:2732
 #, fuzzy
 msgid "Mesh grid selected"
 msgstr "Siatka z linii\n"
 
-#: schematic/src/i_callbacks.c:2733
 #, fuzzy
 msgid "Invalid grid mode"
 msgstr "Nieprawidłowy atrybut"
 
-#: schematic/src/i_callbacks.c:2755
 #, fuzzy
 msgid "Snap OFF (CAUTION!)"
 msgstr "Przyciąganie do siatki: wyłączone (OSTROŻNIE!)\n"
 
-#: schematic/src/i_callbacks.c:2758
 #, fuzzy
 msgid "Snap ON"
 msgstr "Przyciąganie do siatki: włączone\n"
 
-#: schematic/src/i_callbacks.c:2761
 #, fuzzy
 msgid "Snap back to the grid (CAUTION!)"
 msgstr "Przyciąganie do siatki: wyłączone (OSTROŻNIE!)\n"
 
-#: schematic/src/i_callbacks.c:2790
 #, fuzzy
 msgid "Rubber band ON"
 msgstr "Uzupełnianie połączeń przy przesuwaniu: wyłączone\n"
 
-#: schematic/src/i_callbacks.c:2792
 #, fuzzy
 msgid "Rubber band OFF"
 msgstr "Uzupełnianie połączeń przy przesuwaniu: włączone \n"
 
-#: schematic/src/i_callbacks.c:2811
 #, fuzzy
 msgid "magnetic net mode: ON"
 msgstr "tryb \"magnesu\": włączony\n"
 
-#: schematic/src/i_callbacks.c:2814
 #, fuzzy
 msgid "magnetic net mode: OFF"
 msgstr "tryb \"magnesu\": wyłączony\n"
@@ -1198,146 +924,117 @@ msgstr "tryb \"magnesu\": wyłączony\n"
 #. the form "untitled_N.sch", where N is a number.  Please make
 #. sure that the translation contains characters suitable for use
 #. in a filename.
-#: schematic/src/i_vars.c:209
 msgid "untitled"
 msgstr ""
 
-#: schematic/src/o_complex.c:192 schematic/src/o_complex.c:195
 #, fuzzy, c-format
 msgid "Translating schematic [%1$d %2$d]"
 msgstr "Wczytywanie schematu [%s]\n"
 
-#: schematic/src/o_delete.c:82
 #, fuzzy, c-format
 msgid "Delete locked object?"
 msgid_plural "Delete %1$u locked objects?"
 msgstr[0] "Zaznaczonych elementach"
 msgstr[1] "Zaznaczonych elementach"
 
-#: schematic/src/o_misc.c:55
 #, c-format
 msgid "Got an unexpected NULL in o_edit\n"
 msgstr "Niespodziewany wskaźnik NULL w funkcji o_edit\n"
 
-#: schematic/src/o_misc.c:315
 #, fuzzy
 msgid "Hidden text is now visible"
 msgstr "Ukryty tekst jest teraz widoczny\n"
 
-#: schematic/src/o_misc.c:317
 #, fuzzy
 msgid "Hidden text is now invisible"
 msgstr "Ukryty tekst jest teraz niewidoczny\n"
 
-#: schematic/src/o_misc.c:425
 #, fuzzy, c-format
 msgid "Could not find symbol [%1$s] in library. Update failed."
 msgstr ""
 "Nie odnaleziono symbolu [%s] w bibliotece. Aktualizacja nie powiodła się.\n"
 
-#: schematic/src/o_misc.c:541
 #, fuzzy, c-format
 msgid "o_autosave_backups: Can't get the real filename of %1$s."
 msgstr ""
 "o_autosave_backups: Nie można określić rzeczywistej nazwy pliku dla %s."
 
-#: schematic/src/o_misc.c:585
 #, fuzzy, c-format
 msgid "Could NOT set previous backup file [%1$s] read-write"
 msgstr "Nie można ustawić pliku kopii zapasowej w tryb zapisu i odczytu [%s]\n"
 
-#: schematic/src/o_misc.c:605
 #, fuzzy, c-format
 msgid "Could NOT set backup file [%1$s] readonly"
 msgstr ""
 "Nie można ustawić pliku kopii zapasowej w tryb tylko do odczytu [%s].\n"
 
-#: schematic/src/o_misc.c:610
 #, fuzzy, c-format
 msgid "Could NOT save backup file [%1$s]"
 msgstr "Zapisywanie kopii zapasowej [%s] nie powiodło się\n"
 
-#: schematic/src/o_move.c:192
 #, c-format
 msgid "ERROR: NULL object in o_move_end!\n"
 msgstr "BŁĄD: objekt NULL w funkcji o_move_end!\n"
 
-#: schematic/src/o_move.c:519
 #, c-format
 msgid "DOH! tried to find the whichone, but didn't find it!\n"
 msgstr ""
 
-#: schematic/src/o_move.c:546
 #, c-format
 msgid "Got a non line object in o_move_check_endpoint\n"
 msgstr ""
 "Obiekt który nie jest linią przekazany do funkcji o_move_check_endpoint\n"
 
-#: schematic/src/o_net.c:444
 #, fuzzy
 msgid "Warning: Starting net at off grid coordinate"
 msgstr "Uwaga: Początek połączenia jest poza siatką\n"
 
-#: schematic/src/o_net.c:508
 #, fuzzy
 msgid "Warning: Ending net at off grid coordinate"
 msgstr "Uwaga: Koniec połączenia jest poza siatką\n"
 
-#: schematic/src/o_net.c:856 schematic/src/o_net.c:893
-#: schematic/src/o_net.c:964 schematic/src/o_net.c:1000
 #, c-format
 msgid "Tried to add more than two bus rippers. Internal gschem error.\n"
 msgstr ""
 
-#: schematic/src/o_net.c:1068
 #, c-format
 msgid "Bus ripper symbol [%1$s] was not found in any component library"
 msgstr ""
 
-#: schematic/src/o_picture.c:133 schematic/src/o_picture.c:343
 #, fuzzy
 msgid "Select a picture file..."
 msgstr "Wybierz nazwę pliku PostScript..."
 
-#: schematic/src/o_picture.c:166
 #, fuzzy, c-format
 msgid "Failed to load picture: %1$s"
 msgstr "Wczytanie obrazu %s nie powiodło się"
 
-#: schematic/src/o_picture.c:182
 msgid "Picture"
 msgstr "Obraz"
 
-#: schematic/src/o_picture.c:378
 #, c-format
 msgid "Failed to replace pictures: %s"
 msgstr ""
 
-#: schematic/src/o_slot.c:80
 #, fuzzy
 msgid "Slot attribute malformed"
 msgstr "Nieprawidłowa wartość atrybutu \"slot\"\n"
 
-#: schematic/src/o_slot.c:88
 #, fuzzy
 msgid "numslots attribute missing"
 msgstr "Brak atrybutu \"numslots\"\n"
 
-#: schematic/src/o_slot.c:89
 msgid "Slotting not allowed for this component"
 msgstr ""
 
-#: schematic/src/o_slot.c:104
 msgid "New slot number out of range"
 msgstr ""
 
-#: schematic/src/o_undo.c:397
 #, fuzzy
 msgid "Undo/Redo disabled in rc file"
 msgstr ""
 "Funkcjonalność Cofnij/Powtórz zostały wyłączone w pliku konfiguracyjnym\n"
 
-#: schematic/src/parsecmd.c:77
 #, c-format
 msgid ""
 "Usage: %1$s [OPTION ...] [--] [FILE ...]\n"
@@ -1362,194 +1059,150 @@ msgid ""
 "gEDA/gaf homepage: <http://www.geda-project.org/>\n"
 msgstr ""
 
-#: schematic/src/parsecmd.c:110
 #, c-format
 msgid ""
 "Lepton EDA %1$s (git: %2$.7s)\n"
 "Copyright (C) 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright (C) 2017-2018 Lepton Developers.\n"
+"Copyright (C) 2017-2019 Lepton Developers.\n"
 "This is free software, and you are welcome to redistribute it under\n"
 "certain conditions. For details, see the file `COPYING', which is\n"
 "included in the Lepton EDA distribution.\n"
 "There is NO WARRANTY, to the extent permitted by law.\n"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:125
 #, c-format
 msgid "Got invalid show option; defaulting to show both\n"
 msgstr ""
 "Nieprawidłowa opcja; przyjmuję domyślną wartość \"wyświetlaj nazwę i wartość"
 "\"\n"
 
-#: schematic/src/x_attribedit.c:139
 #, c-format
 msgid "ERROR: NULL object!\n"
 msgstr "BŁĄD: obiekt NULL!\n"
 
-#: schematic/src/x_attribedit.c:328
 msgid "Single Attribute Editor"
 msgstr "Edycja pojedyńczego atrybutu"
 
-#: schematic/src/x_attribedit.c:358
 msgid "<b>Edit Attribute</b>"
 msgstr "<b>Edytuj atrybut</b>"
 
-#: schematic/src/x_attribedit.c:360
 msgid "<b>Add Attribute</b>"
 msgstr "<b>Dodaj atrybut</b>"
 
-#: schematic/src/x_attribedit.c:376
 #, fuzzy
 msgid "N_ame:"
 msgstr "Nazwa:"
 
-#: schematic/src/x_attribedit.c:396 schematic/src/x_multiattrib.c:2222
 #, fuzzy
 msgid "_Value:"
 msgstr "Wartość:"
 
-#: schematic/src/x_attribedit.c:415 schematic/src/x_multiattrib.c:2281
 #, fuzzy
 msgid "Vi_sible"
 msgstr "Widoczny"
 
-#: schematic/src/x_attribedit.c:434
 msgid "Show Value Only"
 msgstr "Wyświetlaj wartość"
 
-#: schematic/src/x_attribedit.c:436
 msgid "Show Name Only"
 msgstr "Wyświetlaj nazwę"
 
-#: schematic/src/x_attribedit.c:438 schematic/src/x_multiattrib.c:1620
-#: schematic/scheme/gschem/builtins.scm:324
 msgid "Show Name & Value"
 msgstr "Wyświetlaj nazwę i wartość"
 
-#: schematic/src/x_attribedit.c:445
 msgid "<b>Attach Options</b>"
 msgstr "<b>Opcje dołączenia</b>"
 
-#: schematic/src/x_attribedit.c:460
 msgid "All"
 msgstr "Wszystko"
 
-#: schematic/src/x_attribedit.c:476 schematic/src/x_compselect.c:986
-#: schematic/src/x_compselect.c:1100
 msgid "Components"
 msgstr "Elementy"
 
-#: schematic/src/x_attribedit.c:492 schematic/src/x_window.c:1214
 msgid "Nets"
 msgstr "Połączenia"
 
-#: schematic/src/x_attribedit.c:508
 msgid "Replace existing attributes"
 msgstr "Zastąp istniejące atrybuty"
 
-#: schematic/src/x_autonumber.c:412
 msgid ""
 "slotted object without slot attribute may cause problems when autonumbering "
 "slots"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:427
 #, c-format
 msgid ""
 "duplicate slot may cause problems: [symbolname=%1$s, number=%2$d, slot=%3$d]"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:675
 #, fuzzy
 msgid "No searchstring given in autonumber text."
 msgstr "Nie podano tekstu wyszukiwania.\n"
 
-#: schematic/src/x_autonumber.c:728
 #, fuzzy
 msgid "No '*' or '?' given at the end of the autonumber text."
 msgstr "Brak '*' lub '?' na końcu tekstu do automatycznej numeracji.\n"
 
-#: schematic/src/x_autonumber.c:873
 msgid "Diagonal"
 msgstr "Po przekątnej"
 
-#: schematic/src/x_autonumber.c:874
 msgid "Top to bottom"
 msgstr "Od góry do dołu"
 
-#: schematic/src/x_autonumber.c:875
 msgid "Bottom to top"
 msgstr "Od dołu do góry"
 
-#: schematic/src/x_autonumber.c:876
 msgid "Left to right"
 msgstr "Od lewej do prawej"
 
-#: schematic/src/x_autonumber.c:877
 msgid "Right to left"
 msgstr "Od prawej do lewej"
 
-#: schematic/src/x_autonumber.c:878
 msgid "File order"
 msgstr "Kolejność plików"
 
-#: schematic/src/x_autonumber.c:1214
 msgid "Autonumber text"
 msgstr "Automatyczna numeracja"
 
-#: schematic/src/x_autonumber.c:1237
 msgid "<b>Scope</b>"
 msgstr "<b>Zakres</b>"
 
-#: schematic/src/x_autonumber.c:1259
 msgid "Search for:"
 msgstr "Wyszukiwany tekst:"
 
-#: schematic/src/x_autonumber.c:1273
 msgid "Autonumber text in:"
 msgstr "Automatycznie numeruj w:"
 
-#: schematic/src/x_autonumber.c:1280
 msgid "Skip numbers found in:"
 msgstr "Pomiń numery znalezione w:"
 
-#: schematic/src/x_autonumber.c:1292 schematic/src/x_autonumber.c:1301
 msgid "Selected objects"
 msgstr "Zaznaczonych elementach"
 
-#: schematic/src/x_autonumber.c:1293 schematic/src/x_autonumber.c:1302
 msgid "Current page"
 msgstr "Bieżącej stronie"
 
-#: schematic/src/x_autonumber.c:1294 schematic/src/x_autonumber.c:1303
 msgid "Whole hierarchy"
 msgstr "Całej hierarchii"
 
-#: schematic/src/x_autonumber.c:1305
 msgid "Overwrite existing numbers"
 msgstr "Zastępuj istniejącą numerację"
 
-#: schematic/src/x_autonumber.c:1310
 msgid "<b>Options</b>"
 msgstr "<b>Opcje</b>"
 
-#: schematic/src/x_autonumber.c:1332
 msgid "Starting number:"
 msgstr "Numer początkowy"
 
-#: schematic/src/x_autonumber.c:1339
 msgid "Sort order:"
 msgstr "Kolejność:"
 
-#: schematic/src/x_autonumber.c:1371
 msgid "Remove numbers"
 msgstr "Usuń numery"
 
-#: schematic/src/x_autonumber.c:1375
 msgid "Automatic slotting"
 msgstr ""
 
-#: schematic/src/x_clipboard.c:245
 #, c-format
 msgid ""
 "<b>Invalid schematic on clipboard.</b>\n"
@@ -1560,175 +1213,135 @@ msgstr ""
 "\n"
 "Wystąpił błąd podczas wklejania danych ze schowka: %s."
 
-#: schematic/src/x_clipboard.c:247
 msgid "Clipboard insertion failed"
 msgstr "Błąd podczas wklejania"
 
-#: schematic/src/x_color.c:89 schematic/src/x_color.c:98
 #, fuzzy, c-format
 msgid "Could not allocate the color %1$s!\n"
 msgstr "Nieudana alokacja koloru %s!\n"
 
-#: schematic/src/x_color.c:89
 msgid "black"
 msgstr "czarny"
 
-#: schematic/src/x_color.c:98
 msgid "white"
 msgstr "biały"
 
-#: schematic/src/x_color.c:120
 #, fuzzy, c-format
 msgid "Could not allocate display color %1$i!\n"
 msgstr "Nie udało się przydzielić koloru %i!\n"
 
-#: schematic/src/x_color.c:142
 #, fuzzy, c-format
 msgid "Could not allocate outline color %1$i!\n"
 msgstr "Nie udało się przydzielić koloru obwiedni %i!\n"
 
-#: schematic/src/x_color.c:159
 #, fuzzy, c-format
 msgid "Tried to get an invalid color: %1$d\n"
 msgstr "Próba użycia nieprawidłowego koloru: %d\n"
 
-#: schematic/src/x_colorcb.c:145
 msgid "Background"
 msgstr "Tło"
 
-#: schematic/src/x_colorcb.c:147
 msgid "Net endpoint"
 msgstr "Koniec połączeni"
 
-#: schematic/src/x_colorcb.c:148
 msgid "Graphic"
 msgstr "Graficzne"
 
-#: schematic/src/x_colorcb.c:151
 msgid "Logic bubble"
 msgstr "Negacja logiczna"
 
-#: schematic/src/x_colorcb.c:152
 msgid "Grid point"
 msgstr "Punkt siatki"
 
-#: schematic/src/x_colorcb.c:153
 #, fuzzy
 msgid "Detached attribute"
 msgstr "Odłączony atrybut"
 
-#: schematic/src/x_colorcb.c:156
 msgid "Selection"
 msgstr "Zaznaczenie"
 
-#: schematic/src/x_colorcb.c:157
 msgid "Bounding box"
 msgstr "Obwiednia"
 
-#: schematic/src/x_colorcb.c:158
 msgid "Zoom box"
 msgstr "Obszar powiększenia"
 
-#: schematic/src/x_colorcb.c:161
 msgid "Output background"
 msgstr "Tło wydruku"
 
-#: schematic/src/x_colorcb.c:162
 msgid "Freestyle 1"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:163
 msgid "Freestyle 2"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:164
 msgid "Freestyle 3"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:165
 msgid "Freestyle 4"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:166
 msgid "Net junction"
 msgstr "Połączenie przewodów"
 
-#: schematic/src/x_colorcb.c:167
 msgid "Mesh grid major"
 msgstr "Siatka zgrubna"
 
-#: schematic/src/x_colorcb.c:168
 msgid "Mesh grid minor"
 msgstr "Siatka dokładna"
 
-#: schematic/src/x_colorcb.c:172
 msgid "Unknown"
 msgstr "Nieznane"
 
-#: schematic/src/x_compselect.c:1169
 #, fuzzy
 msgid "Reset filter"
 msgstr "Nowy plik"
 
-#: schematic/src/x_compselect.c:1192
 msgid "Reload all libraries"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1245 schematic/src/x_multiattrib.c:2092
 msgid "Value"
 msgstr "Wartość"
 
-#: schematic/src/x_compselect.c:1284
 msgid "Default behavior - reference component"
 msgstr "Domyślnie - użyj odniesiena do pliku elementu"
 
-#: schematic/src/x_compselect.c:1287
 msgid "Embed component in schematic"
 msgstr "Osadź element w pliku schematu"
 
-#: schematic/src/x_compselect.c:1290
 msgid "Include component as individual objects"
 msgstr "Wstaw element jako indywidualne obiekty składowe"
 
-#: schematic/src/x_compselect.c:1448
 msgid "Select Component..."
 msgstr "Wybierz element..."
 
-#: schematic/src/x_compselect.c:1471
 #, fuzzy
 msgid "In Us_e"
 msgstr "W użyciu"
 
-#: schematic/src/x_compselect.c:1475
 #, fuzzy
 msgid "Lib_raries"
 msgstr "Biblioteki"
 
-#: schematic/src/x_compselect.c:1484 schematic/src/x_fileselect.c:119
 msgid "Preview"
 msgstr "Podgląd"
 
-#: schematic/src/x_compselect.c:1510
 msgid "Attributes"
 msgstr "Atrybuty"
 
-#: schematic/src/x_dialog.c:325
 msgid "Major symbol changes detected."
 msgstr ""
 
-#: schematic/src/x_dialog.c:349
 msgid ""
 "Changes have occurred to the symbols shown below.\n"
 "\n"
 "Be sure to verify each of these symbols."
 msgstr ""
 
-#: schematic/src/x_dialog.c:369
 #, fuzzy
 msgid "Symbol"
 msgstr "Symbole"
 
-#: schematic/src/x_dialog.c:406
 #, c-format
 msgid ""
 "<span weight=\"bold\" size=\"larger\">The input attribute \"%s\" is invalid\n"
@@ -1745,40 +1358,31 @@ msgstr ""
 "Nazwa nie może zaczynać się od spacji.\n"
 "Wartość nie może zaczynać się od spacji."
 
-#: schematic/src/x_dialog.c:408
 msgid "Invalid Attribute"
 msgstr "Nieprawidłowy atrybut"
 
-#: schematic/src/x_fileselect.c:37
 msgid "Schematics"
 msgstr "Schematy"
 
-#: schematic/src/x_fileselect.c:42
 msgid "Symbols"
 msgstr "Symbole"
 
-#: schematic/src/x_fileselect.c:47
 msgid "Schematics and symbols"
 msgstr "Schematy i symbole"
 
-#: schematic/src/x_fileselect.c:53
 msgid "All files"
 msgstr "Wszystkie pliki"
 
-#: schematic/src/x_fileselect.c:169
 msgid "Open..."
 msgstr "Otwórz..."
 
-#: schematic/src/x_fileselect.c:233
 msgid "Save as..."
 msgstr "Zapisz jako..."
 
-#: schematic/src/x_fileselect.c:297
 #, fuzzy
 msgid "Save cancelled on user request"
 msgstr "Zapis anulowany na życzenie użytkownika\n"
 
-#: schematic/src/x_fileselect.c:334
 msgid ""
 "\n"
 "If you load the original file, the backup file will be overwritten in the "
@@ -1787,28 +1391,22 @@ msgid ""
 "Do you want to load the backup file?\n"
 msgstr ""
 
-#: schematic/src/x_fstylecb.c:73
 msgid "Hollow"
 msgstr "Brak"
 
-#: schematic/src/x_fstylecb.c:80
 msgid "Filled"
 msgstr "Pełne"
 
-#: schematic/src/x_fstylecb.c:87
 msgid "Mesh"
 msgstr "Siatka"
 
-#: schematic/src/x_fstylecb.c:94
 msgid "Hatch"
 msgstr "Kreskowanie"
 
-#: schematic/src/x_image.c:279
 #, fuzzy, c-format
 msgid "x_image_lowlevel: Unable to write %1$s file %2$s."
 msgstr "x_image_lowlevel: Nieudany zapis pliku %s o nazwie %s.\n"
 
-#: schematic/src/x_image.c:289
 #, fuzzy, c-format
 msgid ""
 "There was the following error when saving image with type %1$s to filename:\n"
@@ -1821,298 +1419,233 @@ msgstr ""
 "\n"
 "%s.\n"
 
-#: schematic/src/x_image.c:309
 #, fuzzy, c-format
 msgid "Wrote color image to [%1$s] [%2$d x %3$d]"
 msgstr "Zapisano kolorowy obraz do [%s] [%d x %d]\n"
 
-#: schematic/src/x_image.c:311
 #, fuzzy, c-format
 msgid "Wrote black and white image to [%1$s] [%2$d x %3$d]"
 msgstr "Zapisano czarno-biały obraz do [%s] [%d x %d]\n"
 
-#: schematic/src/x_image.c:319
 #, fuzzy
 msgid "x_image_lowlevel: Unable to get pixbuf from gschem's window."
 msgstr "x_image_lowlevel: Nieudane pobranie obrazu z okna gschem.\n"
 
-#: schematic/src/x_image.c:358
 msgid "Width x Height"
 msgstr "Szerokość x Wysokość"
 
-#: schematic/src/x_image.c:374
 msgid "Image type"
 msgstr "Typ obrazu"
 
-#: schematic/src/x_image.c:395
 msgid "Write image..."
 msgstr "Zapisz jako obraz..."
 
-#: schematic/src/x_linecapcb.c:74
 msgid "Butt"
 msgstr ""
 
-#: schematic/src/x_linecapcb.c:81
 msgid "Square"
 msgstr ""
 
-#: schematic/src/x_linecapcb.c:88
 msgid "Round"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:74
 msgid "Solid"
 msgstr "Jednolita"
 
-#: schematic/src/x_linetypecb.c:81
 msgid "Dotted"
 msgstr "Kropki"
 
-#: schematic/src/x_linetypecb.c:88
 msgid "Dashed"
 msgstr "Kreski"
 
-#: schematic/src/x_linetypecb.c:95
 msgid "Center"
 msgstr "Kropka-kreska"
 
-#: schematic/src/x_linetypecb.c:102
 msgid "Phantom"
 msgstr "Kropka-kropka-kreska"
 
-#: schematic/src/x_menus.c:41 schematic/scheme/gschem/builtins.scm:267
 #, fuzzy
 msgid "Add Net"
 msgstr "/Dodaj połączenie"
 
-#: schematic/src/x_menus.c:42 schematic/src/x_multiattrib.c:2187
-#: schematic/scheme/gschem/builtins.scm:264
 msgid "Add Attribute"
 msgstr "Dodaj atrybut"
 
-#: schematic/src/x_menus.c:43 schematic/scheme/gschem/builtins.scm:261
 #, fuzzy
 msgid "Add Component"
 msgstr "/Dodaj element..."
 
-#: schematic/src/x_menus.c:44 schematic/scheme/gschem/builtins.scm:270
 #, fuzzy
 msgid "Add Bus"
 msgstr "/Dodaj magistralę"
 
-#: schematic/src/x_menus.c:45 schematic/scheme/gschem/builtins.scm:273
 #, fuzzy
 msgid "Add Text"
 msgstr "/Dodaj tekst"
 
-#: schematic/src/x_menus.c:47 schematic/scheme/gschem/builtins.scm:210
 #, fuzzy
 msgid "Zoom In"
 msgstr "/Powiększ"
 
-#: schematic/src/x_menus.c:48 schematic/scheme/gschem/builtins.scm:213
 #, fuzzy
 msgid "Zoom Out"
 msgstr "/Pomniejsz"
 
-#: schematic/src/x_menus.c:50 schematic/scheme/gschem/builtins.scm:207
 #, fuzzy
 msgid "Zoom Extents"
 msgstr "/Dopasuj do ekranu"
 
-#: schematic/src/x_menus.c:52 schematic/src/x_window.c:1233
 msgid "Select"
 msgstr "Zaznaczanie"
 
-#: schematic/src/x_menus.c:53 schematic/scheme/conf/schematic/menu.scm:69
-#: schematic/scheme/gschem/builtins.scm:126
 msgid "Edit..."
 msgstr "Edytuj..."
 
-#: schematic/src/x_menus.c:54 schematic/scheme/conf/schematic/menu.scm:68
 #, fuzzy
 msgid "Object Properties..."
 msgstr "<b>Właściwości tekstu</b>"
 
-#: schematic/src/x_menus.c:59 schematic/scheme/gschem/builtins.scm:300
 #, fuzzy
 msgid "Down Schematic"
 msgstr "/Wgłąb schematu"
 
-#: schematic/src/x_menus.c:60 schematic/scheme/gschem/builtins.scm:303
 #, fuzzy
 msgid "Down Symbol"
 msgstr "/Wgłąb symbolu"
 
-#: schematic/src/x_menus.c:61
 #, fuzzy
 msgid "Up"
 msgstr "/Do góry"
 
-#: schematic/src/x_menus.c:336
 #, fuzzy, c-format
 msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
 msgstr "Próba aktywacji nieistniejącego elementu menu '%s'\n"
 
-#: schematic/src/x_menus.c:360
 #, c-format
 msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
 msgstr "Próba aktywacji nieistniejącego elementu menu '%s'\n"
 
-#: schematic/src/x_misc.c:70
 msgid "The operating system is out of memory or resources."
 msgstr "Brak pamięci lub innych zasobów systemu operacyjnego."
 
-#: schematic/src/x_multiattrib.c:798 schematic/src/x_multiattrib.c:2704
 msgid "<various>"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:930
 msgid "Attributes with empty name are not allowed. Please set a name."
 msgstr "Atrybuty bez nazwy nie są dozwolone. Podaj prawidłową nazwę."
 
-#: schematic/src/x_multiattrib.c:1622
 msgid "Show Value only"
 msgstr "Wyświetlaj wartość"
 
-#: schematic/src/x_multiattrib.c:1624
 msgid "Show Name only"
 msgstr "Wyświetlaj nazwę"
 
-#: schematic/src/x_multiattrib.c:1651
 msgid "Promote"
 msgstr "Promuj"
 
-#: schematic/src/x_multiattrib.c:1655
 msgid "Duplicate"
 msgstr "Duplikuj"
 
-#: schematic/src/x_multiattrib.c:1657
 #, fuzzy
 msgid "Copy to all"
 msgstr "Kopiuj do 1"
 
-#: schematic/src/x_multiattrib.c:1986 schematic/src/x_multiattrib.c:2602
 msgid "Edit Attributes"
 msgstr "Zmodyfikuj atrybuty"
 
-#: schematic/src/x_multiattrib.c:2112
 msgid "Vis?"
 msgstr "Widoczny?"
 
-#: schematic/src/x_multiattrib.c:2130
 msgid "N"
 msgstr "N"
 
-#: schematic/src/x_multiattrib.c:2148
 msgid "V"
 msgstr "W"
 
-#: schematic/src/x_multiattrib.c:2170
 #, fuzzy
 msgid "Sho_w inherited attributes"
 msgstr "Pokaż odziedziczone atrybuty"
 
-#: schematic/src/x_multiattrib.c:2197
 #, fuzzy
 msgid "_Name:"
 msgstr "Nazwa:"
 
-#: schematic/src/x_multiattrib.c:2241
 msgid "Ctrl+Enter inserts new line; Ctrl+Tab inserts Tab"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2618
 #, c-format
 msgid "%2$i symbol (%1$s)"
 msgid_plural "%2$i symbols (%1$s)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2624
 #, c-format
 msgid "%1$i pin"
 msgid_plural "%1$i pins"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2630
 #, c-format
 msgid "%1$i net"
 msgid_plural "%1$i nets"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2636
 #, c-format
 msgid "%1$i bus"
 msgid_plural "%1$i buses"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2642
 #, fuzzy, c-format
 msgid "%1$i attribute"
 msgid_plural "%1$i attributes"
 msgstr[0] "Atrybut"
 msgstr[1] "Atrybut"
 
-#: schematic/src/x_newtext.c:433
 msgid "Text Entry..."
 msgstr "Wprowadzanie tekstu..."
 
-#: schematic/src/x_pagesel.c:253
 msgid "New Page"
 msgstr "Nowy arkusz"
 
-#: schematic/src/x_pagesel.c:254
 msgid "Open Page..."
 msgstr "Otwórz arkusz"
 
-#: schematic/src/x_pagesel.c:256
 msgid "Save Page"
 msgstr "Zapisz arkusz"
 
-#: schematic/src/x_pagesel.c:257 schematic/scheme/gschem/builtins.scm:246
 msgid "Close Page"
 msgstr "Zamknij arkusz"
 
-#: schematic/src/x_pagesel.c:376 schematic/scheme/gschem/builtins.scm:237
 msgid "Page Manager"
 msgstr "Zarządzanie arkuszami"
 
-#: schematic/src/x_pagesel.c:448
 msgid "Changed"
 msgstr "Zmieniono"
 
-#: schematic/src/x_pagesel.c:468
 msgid "Right click on the filename for more options..."
 msgstr "Kliknij prawym przyciskiem myszy na nazwie pliku aby zobaczyć opcje..."
 
-#: schematic/src/x_print.c:306
 #, fuzzy, c-format
 msgid "Failed to write PDF to '%s': %s\n"
 msgstr "Błąd podczas wczytywania pliku inicjalizacji scm [%s]\n"
 
-#: schematic/src/x_print.c:364
 #, fuzzy, c-format
 msgid "Failed to write PDF to '%1$s': %2$s\n"
 msgstr "Błąd podczas wczytywania pliku inicjalizacji scm [%s]\n"
 
-#: schematic/src/x_print.c:449
 #, c-format
 msgid ""
 "Error printing file:\n"
 "%1$s"
 msgstr ""
 
-#: schematic/src/x_rc.c:39
 #, fuzzy
 msgid "ERROR: An unknown error occurred while parsing configuration files."
 msgstr ""
 "BŁĄD: Wystąpił nieznany błąd podczas przetwarzania plików konfiguracyjnych.\n"
 
-#: schematic/src/x_rc.c:44
 #, fuzzy
 msgid ""
 "An unknown error occurred while parsing configuration files.\n"
@@ -2120,12 +1653,10 @@ msgid ""
 "The lepton-schematic log may contain more information."
 msgstr "Wystąpił nieznany błąd podczas przetwarzania plików konfiguracyjnych."
 
-#: schematic/src/x_rc.c:56
 #, fuzzy, c-format
 msgid "ERROR: %1$s"
 msgstr "BŁĄD: %s\n"
 
-#: schematic/src/x_rc.c:59
 #, fuzzy, c-format
 msgid ""
 "%1$s\n"
@@ -2136,142 +1667,111 @@ msgstr ""
 "\n"
 "Logi programu mogą zawierać dodatkowe informacje."
 
-#: schematic/src/x_rc.c:67
 #, fuzzy
 msgid "Cannot load lepton-schematic configuration."
 msgstr "Nie można wczytać konfiguracji gschem."
 
-#: schematic/src/x_script.c:42 schematic/scheme/conf/schematic/menu.scm:40
 msgid "Execute Script..."
 msgstr "Wykonaj skrypt..."
 
-#: schematic/src/x_script.c:61
 #, fuzzy, c-format
 msgid "Executing guile script [%1$s]"
 msgstr "Wykonywanie skryptu guile [%s]\n"
 
-#: schematic/src/x_tabs.c:860
 #, fuzzy, c-format
 msgid "Hierarchy up: %s"
 msgstr "Hie_rarchia"
 
-#: schematic/src/x_tabs.c:863
 #, fuzzy
 msgid "Hierarchy up"
 msgstr "Hie_rarchia"
 
-#: schematic/src/x_widgets.c:158 schematic/src/x_window.c:1444
 #, fuzzy
 msgid "Options"
 msgstr "_Ustawienia"
 
-#: schematic/src/x_widgets.c:203 schematic/src/x_window.c:1436
 #, fuzzy
 msgid "Object"
 msgstr "Kolor obiektu:"
 
-#: schematic/src/x_widgets.c:224
 msgid "Log"
 msgstr ""
 
-#: schematic/src/x_widgets.c:245 schematic/src/x_window.c:1466
 msgid "Find Text"
 msgstr "Znajdź tekst"
 
-#: schematic/src/x_widgets.c:259
 #, fuzzy
 msgid "Color Scheme Editor"
 msgstr "_Jasny zestaw kolorów"
 
-#: schematic/src/x_widgets.c:272 schematic/scheme/gschem/builtins.scm:378
 #, fuzzy
 msgid "Select Schematic Font"
 msgstr "Wybi_erz schematy, które chcesz zapisać:"
 
-#: schematic/src/x_window.c:763
 #, fuzzy, c-format
 msgid "Loading schematic [%1$s]"
 msgstr "Wczytywanie schematu [%s]\n"
 
-#: schematic/src/x_window.c:864
 #, fuzzy, c-format
 msgid "Could NOT save page [%1$s]\n"
 msgstr "Zapisanie arkusza [%s] nie powiodło się\n"
 
-#: schematic/src/x_window.c:865
 msgid "Error while trying to save"
 msgstr "Błąd podczas próby zapisania"
 
-#: schematic/src/x_window.c:875
 msgid "Failed to save file"
 msgstr "Zapisanie pliku nie powiodło się"
 
-#: schematic/src/x_window.c:885
 #, fuzzy, c-format
 msgid "Saved as [%1$s]"
 msgstr "Zapisano jako [%s]\n"
 
-#: schematic/src/x_window.c:887
 #, fuzzy, c-format
 msgid "Saved [%1$s]"
 msgstr "Zapisano [%s]\n"
 
-#: schematic/src/x_window.c:889
 msgid "Saved"
 msgstr "Zapisano"
 
-#: schematic/src/x_window.c:966
 #, fuzzy, c-format
 msgid "Discarding page [%1$s]"
 msgstr "Porzucanie arkusza [%s]\n"
 
-#: schematic/src/x_window.c:966
 #, fuzzy, c-format
 msgid "Closing [%1$s]"
 msgstr "Zamykanie [%s]\n"
 
-#: schematic/src/x_window.c:1175
 msgid "New"
 msgstr "Nowy"
 
-#: schematic/src/x_window.c:1175
 msgid "New file"
 msgstr "Nowy plik"
 
-#: schematic/src/x_window.c:1179
 msgid "Open"
 msgstr "Otwórz"
 
-#: schematic/src/x_window.c:1179
 #, fuzzy
 msgid "Open file"
 msgstr "Otwórz plik..."
 
-#: schematic/src/x_window.c:1183 schematic/scheme/gschem/builtins.scm:59
 msgid "Save"
 msgstr "Zapisz"
 
-#: schematic/src/x_window.c:1183
 msgid "Save file"
 msgstr "Zapisz plik"
 
-#: schematic/src/x_window.c:1189 schematic/scheme/gschem/builtins.scm:93
 msgid "Undo"
 msgstr "Cofnij"
 
-#: schematic/src/x_window.c:1189
 msgid "Undo last operation"
 msgstr "Cofnij ostatnią operację"
 
-#: schematic/src/x_window.c:1193 schematic/scheme/gschem/builtins.scm:96
 msgid "Redo"
 msgstr "Przywróć"
 
-#: schematic/src/x_window.c:1193
 msgid "Redo last undo"
 msgstr "Przywróć ostatnią operację"
 
-#: schematic/src/x_window.c:1198
 msgid ""
 "Add component...\n"
 "Select library and component from list, move the mouse into main window, "
@@ -2283,7 +1783,6 @@ msgstr ""
 "kliknij aby umieścić element\n"
 "Anuluj prawym przyciskiem myszy"
 
-#: schematic/src/x_window.c:1209
 msgid ""
 "Add nets mode\n"
 "Right mouse button to cancel"
@@ -2291,7 +1790,6 @@ msgstr ""
 "Tryb dodawania połączeń\n"
 "Anuluj prawym przyciskiem myszy"
 
-#: schematic/src/x_window.c:1217
 msgid ""
 "Add buses mode\n"
 "Right mouse button to cancel"
@@ -2299,45 +1797,35 @@ msgstr ""
 "Tryb dodawania magistral\n"
 "Anuluj prawym przyciskiem myszy"
 
-#: schematic/src/x_window.c:1226
 msgid "Add Text..."
 msgstr "Dodaj tekst..."
 
-#: schematic/src/x_window.c:1233
 msgid "Select mode"
 msgstr "Tryb zaznaczania"
 
-#: schematic/src/x_window.c:1288
 #, fuzzy
 msgid "Show"
 msgstr "Wyśw. nazwę"
 
-#: schematic/src/x_window.c:1289
 msgid "Show text starting with:"
 msgstr "Wyświetl tekst zaczynający się od:"
 
-#: schematic/src/x_window.c:1345
 msgid "Menu/Cancel"
 msgstr "Menu/Anuluj"
 
-#: schematic/src/x_window.c:1349
 msgid "Pan/Cancel"
 msgstr "Przesuń widok/Anuluj"
 
-#: schematic/src/x_window.c:1359
 msgid "Pick"
 msgstr "Wybierz"
 
-#: schematic/src/x_window.c:1470 schematic/scheme/gschem/builtins.scm:180
 msgid "Status"
 msgstr "Stan"
 
-#: schematic/src/x_window.c:1568
 #, fuzzy, c-format
 msgid "New file [%s]"
 msgstr "Nowy plik [%s]\n"
 
-#: schematic/src/x_window.c:1598
 #, fuzzy, c-format
 msgid ""
 "<b>An error occurred while loading the requested file.</b>\n"
@@ -2355,902 +1843,692 @@ msgstr ""
 "Wczytywanie z pliku '%s' nie powiodło się: %s. Log programu może zawierać "
 "dodatkowe informacje."
 
-#: schematic/src/x_window.c:1617
 msgid "Failed to load file"
 msgstr "Otwarcie pliku nie powiodło się"
 
-#: schematic/data/lepton-schematic.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Schematic Editor"
 msgstr "gEDA Edytor Schematów"
 
-#: schematic/data/lepton-schematic.desktop.in:4
 #, fuzzy
 msgid "Create and edit electrical schematics and symbols with lepton-schematic"
 msgstr "Projektuj i edytuj schematy i symbole elektroniczne za pomocą gschem"
 
-#: schematic/scheme/conf/schematic/menu.scm:27
 msgid "_New"
 msgstr "_Nowy"
 
-#: schematic/scheme/conf/schematic/menu.scm:28
 msgid "_Open..."
 msgstr "_Otwórz..."
 
-#: schematic/scheme/conf/schematic/menu.scm:30
 msgid "Open Recen_t"
 msgstr "Otwórz os_tatnio używane"
 
-#: schematic/scheme/conf/schematic/menu.scm:32
 msgid "_Save"
 msgstr "Zapi_sz"
 
-#: schematic/scheme/conf/schematic/menu.scm:33
 msgid "Save _As..."
 msgstr "Zapisz j_ako..."
 
-#: schematic/scheme/conf/schematic/menu.scm:34
-#: schematic/scheme/gschem/builtins.scm:65
 msgid "Save All"
 msgstr "Zapisz _wszystkie"
 
-#: schematic/scheme/conf/schematic/menu.scm:36
 msgid "_Print..."
 msgstr "_Drukuj..."
 
-#: schematic/scheme/conf/schematic/menu.scm:37
 #, fuzzy
 msgid "Write _Image..."
 msgstr "Zap_isz obraz..."
 
-#: schematic/scheme/conf/schematic/menu.scm:39
 #, fuzzy
 msgid "Invoke Macro..."
 msgstr "Wykonaj makro"
 
-#: schematic/scheme/conf/schematic/menu.scm:41
 msgid "REPL..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:43
-#: schematic/scheme/gschem/builtins.scm:77
 msgid "New Window"
 msgstr "Nowe o_kno"
 
-#: schematic/scheme/conf/schematic/menu.scm:44
 msgid "_Close Window"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:45
 msgid "_Quit"
 msgstr "Za_kończ"
 
-#: schematic/scheme/conf/schematic/menu.scm:51
 msgid "_Undo"
 msgstr "_Cofnij"
 
-#: schematic/scheme/conf/schematic/menu.scm:52
 msgid "_Redo"
 msgstr "_Ponów"
 
-#: schematic/scheme/conf/schematic/menu.scm:54
 msgid "Cu_t"
 msgstr "Wy_tnij"
 
-#: schematic/scheme/conf/schematic/menu.scm:55
 msgid "_Copy"
 msgstr "_Kopiuj"
 
-#: schematic/scheme/conf/schematic/menu.scm:56
 msgid "_Paste"
 msgstr "_Wklej"
 
-#: schematic/scheme/conf/schematic/menu.scm:57
 msgid "_Delete"
 msgstr "_Usuń"
 
-#: schematic/scheme/conf/schematic/menu.scm:60
-#: schematic/scheme/gschem/builtins.scm:102
 msgid "Select All"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:61
-#: schematic/scheme/gschem/builtins.scm:105
 msgid "Deselect"
 msgstr "Odznacz"
 
-#: schematic/scheme/conf/schematic/menu.scm:65
 msgid "Rotate 90 Mode"
 msgstr "Obróć o 90 stopni"
 
-#: schematic/scheme/conf/schematic/menu.scm:70
 msgid "Edit Text..."
 msgstr "Edytuj tekst..."
 
-#: schematic/scheme/conf/schematic/menu.scm:71
 msgid "Slot..."
 msgstr "Slot..."
 
-#: schematic/scheme/conf/schematic/menu.scm:76
-#: schematic/scheme/gschem/builtins.scm:150
 msgid "Embed Component/Picture"
 msgstr "Osadź element/obraz"
 
-#: schematic/scheme/conf/schematic/menu.scm:77
-#: schematic/scheme/gschem/builtins.scm:153
 msgid "Unembed Component/Picture"
 msgstr "Cofnij osadzanie elem./obr."
 
-#: schematic/scheme/conf/schematic/menu.scm:78
-#: schematic/scheme/gschem/builtins.scm:156
 msgid "Update Component"
 msgstr "Aktualizuj element"
 
-#: schematic/scheme/conf/schematic/menu.scm:79
 msgid "Symbol Translate..."
 msgstr "Tłumaczenie symbolu..."
 
-#: schematic/scheme/conf/schematic/menu.scm:85
 msgid "Copy into 1"
 msgstr "Kopiuj do 1"
 
-#: schematic/scheme/conf/schematic/menu.scm:86
 msgid "Copy into 2"
 msgstr "Kopiuj do 2"
 
-#: schematic/scheme/conf/schematic/menu.scm:87
 msgid "Copy into 3"
 msgstr "Kopiuj do 3"
 
-#: schematic/scheme/conf/schematic/menu.scm:88
 msgid "Copy into 4"
 msgstr "Kopiuj do 4"
 
-#: schematic/scheme/conf/schematic/menu.scm:89
 msgid "Copy into 5"
 msgstr "Kopiuj do 5"
 
-#: schematic/scheme/conf/schematic/menu.scm:90
 msgid "Cut into 1"
 msgstr "Wytnij do 1"
 
-#: schematic/scheme/conf/schematic/menu.scm:91
 msgid "Cut into 2"
 msgstr "Wytnij do 2"
 
-#: schematic/scheme/conf/schematic/menu.scm:92
 msgid "Cut into 3"
 msgstr "Wytnij do 3"
 
-#: schematic/scheme/conf/schematic/menu.scm:93
 msgid "Cut into 4"
 msgstr "Wytnij do 4"
 
-#: schematic/scheme/conf/schematic/menu.scm:94
 msgid "Cut into 5"
 msgstr "Wytnij do 5"
 
-#: schematic/scheme/conf/schematic/menu.scm:95
 msgid "Paste from 1"
 msgstr "Wklej z 1"
 
-#: schematic/scheme/conf/schematic/menu.scm:96
 msgid "Paste from 2"
 msgstr "Wklej z 2"
 
-#: schematic/scheme/conf/schematic/menu.scm:97
 msgid "Paste from 3"
 msgstr "Wklej z 3"
 
-#: schematic/scheme/conf/schematic/menu.scm:98
 msgid "Paste from 4"
 msgstr "Wklej z 4"
 
-#: schematic/scheme/conf/schematic/menu.scm:99
 msgid "Paste from 5"
 msgstr "Wklej z 5"
 
-#: schematic/scheme/conf/schematic/menu.scm:105
 msgid "Side Dock"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:106
 #, fuzzy
 msgid "Bottom Dock"
 msgstr "Od dołu do góry"
 
-#: schematic/scheme/conf/schematic/menu.scm:108
 #, fuzzy
 msgid "Find Text Results"
 msgstr "Znajdź tekst"
 
-#: schematic/scheme/conf/schematic/menu.scm:110
 msgid "_Redraw"
 msgstr "_Aktualizuj"
 
-#: schematic/scheme/conf/schematic/menu.scm:111
 msgid "_Pan"
 msgstr "_Przesuń"
 
-#: schematic/scheme/conf/schematic/menu.scm:112
 msgid "Zoom _Box"
 msgstr "Powiększ _obszar"
 
-#: schematic/scheme/conf/schematic/menu.scm:113
 msgid "Zoom _Extents"
 msgstr "_Dopasuj widok"
 
-#: schematic/scheme/conf/schematic/menu.scm:114
 msgid "Zoom _In"
 msgstr "Pow_iększ"
 
-#: schematic/scheme/conf/schematic/menu.scm:115
 msgid "Zoom _Out"
 msgstr "P_omniejsz"
 
-#: schematic/scheme/conf/schematic/menu.scm:116
 msgid "Zoom _Full"
 msgstr "Maksymalne pomniejszenie"
 
-#: schematic/scheme/conf/schematic/menu.scm:118
 #, fuzzy
 msgid "_Dark Color Scheme"
 msgstr "_Ciemny zestaw kolorów"
 
-#: schematic/scheme/conf/schematic/menu.scm:119
 #, fuzzy
 msgid "_Light Color Scheme"
 msgstr "_Jasny zestaw kolorów"
 
-#: schematic/scheme/conf/schematic/menu.scm:120
 #, fuzzy
 msgid "B_W Color Scheme"
 msgstr "_Ciemny zestaw kolorów"
 
-#: schematic/scheme/conf/schematic/menu.scm:122
 #, fuzzy
 msgid "Color Scheme Editor..."
 msgstr "_Jasny zestaw kolorów"
 
-#: schematic/scheme/conf/schematic/menu.scm:129
 msgid "_Manager..."
 msgstr "_Zarządzaj..."
 
-#: schematic/scheme/conf/schematic/menu.scm:131
 msgid "_Previous"
 msgstr "_Poprzedni"
 
-#: schematic/scheme/conf/schematic/menu.scm:132
 msgid "_Next"
 msgstr "_Następny"
 
-#: schematic/scheme/conf/schematic/menu.scm:133
 msgid "_Close"
 msgstr "_Zamknij"
 
-#: schematic/scheme/conf/schematic/menu.scm:135
 #, fuzzy
 msgid "_Revert..."
 msgstr "P_rzywróć"
 
-#: schematic/scheme/conf/schematic/menu.scm:137
-#: schematic/scheme/gschem/builtins.scm:249
 #, fuzzy
 msgid "Next Tab"
 msgstr "Nowy arkusz"
 
-#: schematic/scheme/conf/schematic/menu.scm:138
-#: schematic/scheme/gschem/builtins.scm:252
 #, fuzzy
 msgid "Previous Tab"
 msgstr "_Poprzedni"
 
-#: schematic/scheme/conf/schematic/menu.scm:146
 msgid "_Component..."
 msgstr "_Element..."
 
-#: schematic/scheme/conf/schematic/menu.scm:148
 msgid "_Net"
 msgstr "_Sieć"
 
-#: schematic/scheme/conf/schematic/menu.scm:149
 msgid "B_us"
 msgstr "_Magistrala"
 
-#: schematic/scheme/conf/schematic/menu.scm:151
 msgid "_Attribute..."
 msgstr "_Atrybut..."
 
-#: schematic/scheme/conf/schematic/menu.scm:152
 msgid "_Text..."
 msgstr "_Tekst..."
 
-#: schematic/scheme/conf/schematic/menu.scm:154
 msgid "_Line"
 msgstr "_Linia"
 
-#: schematic/scheme/conf/schematic/menu.scm:155
 msgid "Pat_h"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:156
 msgid "_Box"
 msgstr "Pros_tokąt"
 
-#: schematic/scheme/conf/schematic/menu.scm:157
 msgid "C_ircle"
 msgstr "_Okrąg"
 
-#: schematic/scheme/conf/schematic/menu.scm:158
 msgid "A_rc"
 msgstr "Ł_uk"
 
-#: schematic/scheme/conf/schematic/menu.scm:159
 msgid "_Pin"
 msgstr "_Pin"
 
-#: schematic/scheme/conf/schematic/menu.scm:161
 msgid "Pictu_re..."
 msgstr "Ob_raz..."
 
-#: schematic/scheme/conf/schematic/menu.scm:167
 msgid "_Up"
 msgstr "W _górę"
 
-#: schematic/scheme/conf/schematic/menu.scm:169
 msgid "_Down Schematic"
 msgstr "W głąb _schematu"
 
-#: schematic/scheme/conf/schematic/menu.scm:170
 msgid "Down _Symbol"
 msgstr "W głąb _elementu"
 
-#: schematic/scheme/conf/schematic/menu.scm:176
 msgid "_Attach"
 msgstr "_Dołącz"
 
-#: schematic/scheme/conf/schematic/menu.scm:177
 msgid "_Detach"
 msgstr "_Odłącz"
 
-#: schematic/scheme/conf/schematic/menu.scm:179
 msgid "Show _Value"
 msgstr "Pokazuj _wartość"
 
-#: schematic/scheme/conf/schematic/menu.scm:180
 msgid "Show _Name"
 msgstr "Pokazuj _nazwę"
 
-#: schematic/scheme/conf/schematic/menu.scm:181
 msgid "Show _Both"
 msgstr "Pokazuj o_bie"
 
-#: schematic/scheme/conf/schematic/menu.scm:182
 msgid "_Toggle Visibility"
 msgstr "Przełącz _widoczność"
 
-#: schematic/scheme/conf/schematic/menu.scm:184
 msgid "_Hide Specific Text..."
 msgstr "_Ukryj wybrany tekst..."
 
-#: schematic/scheme/conf/schematic/menu.scm:185
 msgid "_Show Specific Text..."
 msgstr "_Pokazuj wybrany tekst..."
 
-#: schematic/scheme/conf/schematic/menu.scm:186
 #, fuzzy
 msgid "Show/Hide Hidden Text"
 msgstr "Wyświetlaj/ukryj niewidoczny tekst"
 
-#: schematic/scheme/conf/schematic/menu.scm:188
 msgid "_Find Text/Check Symbol..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:189
 msgid "A_utonumber Text..."
 msgstr "A_utomatycznie numeruj..."
 
-#: schematic/scheme/conf/schematic/menu.scm:195
 #, fuzzy
 msgid "_Options..."
 msgstr "_Ustawienia"
 
-#: schematic/scheme/conf/schematic/menu.scm:196
 #, fuzzy
 msgid "_Font..."
 msgstr "_Drukuj..."
 
-#: schematic/scheme/conf/schematic/menu.scm:198
 #, fuzzy
 msgid "Grid +"
 msgstr "Siatka: włączona\n"
 
-#: schematic/scheme/conf/schematic/menu.scm:199
 #, fuzzy
 msgid "Grid -"
 msgstr "Siatka: włączona\n"
 
-#: schematic/scheme/conf/schematic/menu.scm:201
 msgid "Grid Style: Cycle Dots/Mesh/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:202
 msgid "Grid Snap: Cycle Grid/Resnap/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:204
 #, fuzzy
 msgid "Feedback Mode: Outline/Box"
 msgstr "Przełącz wyświetlanie _konturów"
 
-#: schematic/scheme/conf/schematic/menu.scm:205
 #, fuzzy
 msgid "Net: Rubberband On/Off"
 msgstr "Uzupełnianie połączeń przy przesuwaniu: wyłączone\n"
 
-#: schematic/scheme/conf/schematic/menu.scm:206
 msgid "Net: Magnetic On/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:208
 #, fuzzy
 msgid "_Coord Window"
 msgstr "Pokaż okno współrzędnych..."
 
-#: schematic/scheme/conf/schematic/menu.scm:209
 #, fuzzy
 msgid "_Log Window"
 msgstr "Pokaż okno komunikatów..."
 
-#: schematic/scheme/conf/schematic/menu.scm:215
 msgid "_1 allegro"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:223
 #, fuzzy
 msgid "User _Guide"
 msgstr "_FAQ gschem..."
 
-#: schematic/scheme/conf/schematic/menu.scm:224
 msgid "_FAQ"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:225
 #, fuzzy
 msgid "Docu_mentation"
 msgstr "Do_kumentacja..."
 
-#: schematic/scheme/conf/schematic/menu.scm:226
 msgid "_Wiki"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:228
 #, fuzzy
 msgid "Find Component D_ocumentation"
 msgstr "Dokumentacja _elementu..."
 
-#: schematic/scheme/conf/schematic/menu.scm:230
 msgid "_Hotkeys..."
 msgstr "Skróty _klawiszowe..."
 
-#: schematic/scheme/conf/schematic/menu.scm:231
 #, fuzzy
 msgid "_About"
 msgstr "_O programie..."
 
-#: schematic/scheme/conf/schematic/menu.scm:237
 msgid "_File"
 msgstr "_Plik"
 
-#: schematic/scheme/conf/schematic/menu.scm:238
 msgid "_Edit"
 msgstr "_Edycja"
 
-#: schematic/scheme/conf/schematic/menu.scm:240
 msgid "_View"
 msgstr "_Widok"
 
-#: schematic/scheme/conf/schematic/menu.scm:241
 msgid "_Page"
 msgstr "_Arkusz"
 
-#: schematic/scheme/conf/schematic/menu.scm:242
 msgid "_Add"
 msgstr "_Dodaj"
 
-#: schematic/scheme/conf/schematic/menu.scm:243
 msgid "Hie_rarchy"
 msgstr "Hie_rarchia"
 
-#: schematic/scheme/conf/schematic/menu.scm:244
 msgid "A_ttributes"
 msgstr "A_trybuty"
 
-#: schematic/scheme/conf/schematic/menu.scm:245
 msgid "_Options"
 msgstr "_Ustawienia"
 
-#: schematic/scheme/conf/schematic/menu.scm:246
 #, fuzzy
 msgid "_Netlist"
 msgstr "_Sieć"
 
-#: schematic/scheme/conf/schematic/menu.scm:247
 msgid "_Help"
 msgstr "_Pomoc"
 
-#: schematic/scheme/gschem/action.scm:43
 #, fuzzy, scheme-format
 msgid "~S is not a valid gschem action."
 msgstr "Nie można wczytać konfiguracji gschem."
 
-#: schematic/scheme/gschem/action.scm:158
 msgid "Repeat Last Action"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:47
 #, fuzzy
 msgid "Cancel"
 msgstr "Przesuń widok/Anuluj"
 
-#: schematic/scheme/gschem/builtins.scm:53
 #, fuzzy
 msgid "New File"
 msgstr "Nowy plik"
 
-#: schematic/scheme/gschem/builtins.scm:56
 #, fuzzy
 msgid "Open File"
 msgstr "Otwórz plik..."
 
-#: schematic/scheme/gschem/builtins.scm:62
 #, fuzzy
 msgid "Save As"
 msgstr "Zapisz _wszystkie"
 
-#: schematic/scheme/gschem/builtins.scm:68
 #, fuzzy
 msgid "Print"
 msgstr "Drukuj..."
 
-#: schematic/scheme/gschem/builtins.scm:71
 msgid "Export Image"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:74
 msgid "Run Script"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:80
 #, fuzzy
 msgid "Close Window"
 msgstr "Zamykanie okna\n"
 
-#: schematic/scheme/gschem/builtins.scm:83
 #, fuzzy
 msgid "Quit"
 msgstr "Za_kończ"
 
-#: schematic/scheme/gschem/builtins.scm:87
 msgid "Terminal REPL"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:132
 msgid "Choose Slot"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:135
 #, fuzzy
 msgid "Edit Object Properties"
 msgstr "Edycja właściwości tekstu"
 
-#: schematic/scheme/gschem/builtins.scm:138
 #, fuzzy
 msgid "Translate Symbol"
 msgstr "Tłumacz"
 
-#: schematic/scheme/gschem/builtins.scm:147
 msgid "Invoke Macro"
 msgstr "Wykonaj makro"
 
-#: schematic/scheme/gschem/builtins.scm:159
 #, fuzzy
 msgid "Show/Hide Invisible Text"
 msgstr "Wyświetlaj/ukryj niewidoczny tekst"
 
-#: schematic/scheme/gschem/builtins.scm:165
 #, fuzzy
 msgid "Cut"
 msgstr "Wy_tnij"
 
-#: schematic/scheme/gschem/builtins.scm:171
 #, fuzzy
 msgid "Paste"
 msgstr "_Wklej"
 
-#: schematic/scheme/gschem/builtins.scm:177
 msgid "Sidebar"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:183
 #, fuzzy
 msgid "Find Text State"
 msgstr "Znajdź tekst"
 
-#: schematic/scheme/gschem/builtins.scm:186
 #, fuzzy
 msgid "Redraw"
 msgstr "_Aktualizuj"
 
-#: schematic/scheme/gschem/builtins.scm:192
 #, fuzzy
 msgid "Pan Left"
 msgstr "Tryb przesuwania widoku"
 
-#: schematic/scheme/gschem/builtins.scm:195
 #, fuzzy
 msgid "Pan Right"
 msgstr "Na górze po prawej"
 
-#: schematic/scheme/gschem/builtins.scm:198
 msgid "Pan Up"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:201
 #, fuzzy
 msgid "Pan Down"
 msgstr "Tryb przesuwania widoku"
 
-#: schematic/scheme/gschem/builtins.scm:216
 #, fuzzy
 msgid "Zoom Full"
 msgstr "Maksymalne pomniejszenie"
 
-#: schematic/scheme/gschem/builtins.scm:219
 #, fuzzy
 msgid "Dark Color Scheme"
 msgstr "_Ciemny zestaw kolorów"
 
-#: schematic/scheme/gschem/builtins.scm:222
 #, fuzzy
 msgid "Light Color Scheme"
 msgstr "_Jasny zestaw kolorów"
 
-#: schematic/scheme/gschem/builtins.scm:225
 msgid "Monochrome Color Scheme"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:228
 #, fuzzy
 msgid "Show Color Scheme Editor"
 msgstr "_Jasny zestaw kolorów"
 
-#: schematic/scheme/gschem/builtins.scm:234
 #, fuzzy
 msgid "Revert Changes"
 msgstr "Czy na pewno przywrócić arkusz?"
 
-#: schematic/scheme/gschem/builtins.scm:240
 #, fuzzy
 msgid "Previous Page"
 msgstr "_Poprzedni"
 
-#: schematic/scheme/gschem/builtins.scm:243
 #, fuzzy
 msgid "Next Page"
 msgstr "Nowy arkusz"
 
-#: schematic/scheme/gschem/builtins.scm:255
 #, fuzzy
 msgid "Print Page"
 msgstr "_Poprzedni"
 
-#: schematic/scheme/gschem/builtins.scm:276
 #, fuzzy
 msgid "Add Line"
 msgstr "Linię"
 
-#: schematic/scheme/gschem/builtins.scm:279
 #, fuzzy
 msgid "Add Path"
 msgstr "/Dodaj połączenie"
 
-#: schematic/scheme/gschem/builtins.scm:282
 #, fuzzy
 msgid "Add Box"
 msgstr "/Dodaj magistralę"
 
-#: schematic/scheme/gschem/builtins.scm:285
 #, fuzzy
 msgid "Add Circle"
 msgstr "Okrąg"
 
-#: schematic/scheme/gschem/builtins.scm:288
 #, fuzzy
 msgid "Add Arc"
 msgstr "Dodaj atrybut"
 
-#: schematic/scheme/gschem/builtins.scm:291
 msgid "Add Pin"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:294
 #, fuzzy
 msgid "Add Picture"
 msgstr "Obraz"
 
-#: schematic/scheme/gschem/builtins.scm:306
 #, fuzzy
 msgid "Up Hierarchy"
 msgstr "Hie_rarchia"
 
-#: schematic/scheme/gschem/builtins.scm:312
 #, fuzzy
 msgid "Attach Attributes"
 msgstr "Zmodyfikuj atrybuty"
 
-#: schematic/scheme/gschem/builtins.scm:315
 #, fuzzy
 msgid "Detach Attributes"
 msgstr "Odłączony atrybut"
 
-#: schematic/scheme/gschem/builtins.scm:318
 #, fuzzy
 msgid "Show Attribute Value"
 msgstr "Nieprawidłowa wartość atrybutu \"slot\"\n"
 
-#: schematic/scheme/gschem/builtins.scm:321
 #, fuzzy
 msgid "Show Attribute Name"
 msgstr "Nieprawidłowa wartość atrybutu \"slot\"\n"
 
-#: schematic/scheme/gschem/builtins.scm:327
 #, fuzzy
 msgid "Toggle Text Visibility"
 msgstr "Przełącz _widoczność"
 
-#: schematic/scheme/gschem/builtins.scm:330
 #, fuzzy
 msgid "Find Specific Text"
 msgstr "_Szukaj tekstu..."
 
-#: schematic/scheme/gschem/builtins.scm:333
 #, fuzzy
 msgid "Hide Specific Text"
 msgstr "_Ukryj wybrany tekst..."
 
-#: schematic/scheme/gschem/builtins.scm:336
 #, fuzzy
 msgid "Show Specific Text"
 msgstr "_Pokazuj wybrany tekst..."
 
-#: schematic/scheme/gschem/builtins.scm:339
 #, fuzzy
 msgid "Autonumber Text"
 msgstr "Automatyczna numeracja"
 
-#: schematic/scheme/gschem/builtins.scm:345
 #, fuzzy
 msgid "Show Hotkeys"
 msgstr "Klawisze skrótów"
 
-#: schematic/scheme/gschem/builtins.scm:348
 msgid "Switch Grid Style"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:351
 msgid "Switch Snap Mode"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:354
 #, fuzzy
 msgid "Set Grid Spacing"
 msgstr "Z_mniejsz siatkę przyciągania"
 
-#: schematic/scheme/gschem/builtins.scm:357
 #, fuzzy
 msgid "Increase Grid Spacing"
 msgstr "Z_mniejsz siatkę przyciągania"
 
-#: schematic/scheme/gschem/builtins.scm:360
 #, fuzzy
 msgid "Decrease Grid Spacing"
 msgstr "Z_mniejsz siatkę przyciągania"
 
-#: schematic/scheme/gschem/builtins.scm:363
 #, fuzzy
 msgid "Toggle Outline Drawing"
 msgstr "Przełącz wyświetlanie _konturów"
 
-#: schematic/scheme/gschem/builtins.scm:366
 #, fuzzy
 msgid "Toggle Net Rubber Band"
 msgstr "Przełącz _rozciąganie połączeń"
 
-#: schematic/scheme/gschem/builtins.scm:369
 #, fuzzy
 msgid "Toggle Magnetic Nets"
 msgstr "Przełącz \"_magnes\" połączeń"
 
-#: schematic/scheme/gschem/builtins.scm:372
 #, fuzzy
 msgid "Show Log Window"
 msgstr "Pokaż okno komunikatów..."
 
-#: schematic/scheme/gschem/builtins.scm:375
 #, fuzzy
 msgid "Show Coordinate Window"
 msgstr "Pokaż okno współrzędnych..."
 
-#: schematic/scheme/gschem/builtins.scm:385
 #, fuzzy
 msgid "Component Documentation"
 msgstr "Dokumentacja _elementu..."
 
-#: schematic/scheme/gschem/builtins.scm:387
 msgid "View documentation for selected component"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:403
 msgid ""
 "Could not show documentation for selected component:\n"
 "\n"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:408
 msgid "gEDA Manuals"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:409
 msgid "View the front page of the gEDA documentation in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:414
 #, fuzzy
 msgid "gschem User Guide"
 msgstr "_FAQ gschem..."
 
-#: schematic/scheme/gschem/builtins.scm:415
 msgid "View the gschem User Guide in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:420
 #, fuzzy
 msgid "gschem FAQ"
 msgstr "_FAQ gschem..."
 
-#: schematic/scheme/gschem/builtins.scm:421
 msgid "Frequently Asked Questions about using gschem."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:426
 #, fuzzy
 msgid "gEDA wiki"
 msgstr "_Wiki gEDA..."
 
-#: schematic/scheme/gschem/builtins.scm:427
 msgid "View the front page of the gEDA wiki in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:431
 msgid "About gschem"
 msgstr "O programie"
 
-#: schematic/scheme/gschem/deprecated.scm:102
 #, scheme-format
 msgid "Invalid text alignment ~A."
 msgstr ""
 
-#: schematic/scheme/gschem/gschemdoc.scm:241
 msgid "No documentation found"
 msgstr ""
 
-#: schematic/scheme/gschem/keymap.scm:40
 #, scheme-format
 msgid "~S is not a valid key combination."
 msgstr ""
 
-#: schematic/scheme/gschem/keymap.scm:157
 #, scheme-format
 msgid "~S is not a prefix key sequence."
 msgstr ""

--- a/schematic/po/pt.po
+++ b/schematic/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-15 15:13+0300\n"
+"POT-Creation-Date: 2019-02-22 14:08+0300\n"
 "PO-Revision-Date: 2012-01-27 14:23+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -18,24 +18,20 @@ msgstr ""
 "X-Launchpad-Export-Date: 2012-11-14 16:52+0000\n"
 "X-Generator: Launchpad (build 16265)\n"
 
-#: schematic/src/a_zoom.c:155
 #, fuzzy
 msgid "Zoom too small!  Cannot zoom further."
 msgstr "Ampliação ampliação pequena! Não é possível ampliar mais.\n"
 
-#: schematic/src/color_edit_widget.c:399
 #, fuzzy, c-format
 msgid ""
 "Could not save file [%s]:\n"
 "%s"
 msgstr "NÃO foi possível gravar pagina [%s]\n"
 
-#: schematic/src/color_edit_widget.c:434
 #, fuzzy
 msgid "Save Color Scheme As..."
 msgstr "Esquema C_laro de Cor"
 
-#: schematic/src/color_edit_widget.c:482 schematic/src/x_fileselect.c:292
 #, fuzzy, c-format
 msgid ""
 "The selected file `%1$s' already exists.\n"
@@ -46,183 +42,145 @@ msgstr ""
 "\n"
 "Pretende sobrepor a gravação?"
 
-#: schematic/src/color_edit_widget.c:486 schematic/src/x_fileselect.c:295
 msgid "Overwrite file?"
 msgstr "Sobrepor a gravação?"
 
-#: schematic/src/font_select_widget.c:211
 msgid "_Apply"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:215
 msgid "Sa_ve..."
 msgstr ""
 
-#: schematic/src/font_select_widget.c:278
 #, c-format
 msgid "<b>Current:</b> %s"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:453
 msgid "Save configuration"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:461
 #, fuzzy
 msgid "Save settings to:"
 msgstr "Preferências"
 
-#: schematic/src/font_select_widget.c:465
 msgid "Local configuration file (in current directory)"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:467
 msgid "User configuration file (geda-user.conf)"
 msgstr ""
 
-#: schematic/src/g_attrib.c:90
 msgid "Object ~A is not included in the current gschem page."
 msgstr ""
 
-#: schematic/src/g_attrib.c:110
 msgid "Invalid text name/value visibility ~A."
 msgstr ""
 
-#: schematic/src/g_rc.c:107
 #, fuzzy, c-format
 msgid "You are running gEDA/gaf version [%1$s%2$s.%3$s],\n"
 msgstr "gEDA/gschem versão %s%s.%s\n"
 
-#: schematic/src/g_rc.c:111
 #, c-format
 msgid ""
 "but you have a version [%1$s] gschemrc file:\n"
 "[%2$s]\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:114
 #, c-format
 msgid "Please be sure that you have the latest rc file.\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:240
 #, fuzzy, c-format
 msgid "Invalid size [%1$d] passed to text-size\n"
 msgstr "Tamanho inválido [%d] passado a tamanho de texto\n"
 
-#: schematic/src/g_rc.c:283
 #, fuzzy, c-format
 msgid "Invalid size [%1$d] passed to snap-size\n"
 msgstr "Tamanho inválido [%d] passado a função snap-size\n"
 
-#: schematic/src/g_rc.c:620
 #, fuzzy, c-format
 msgid "Invalid num levels [%1$d] passed to undo-levels\n"
 msgstr "Numero de níveis inválidos [%d] passados a função undo-levels\n"
 
-#: schematic/src/g_rc.c:831
 #, fuzzy, c-format
 msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
 msgstr "Tamanho inválido [%d] passado a função bus-ripper-size\n"
 
-#: schematic/src/g_rc.c:931
 #, fuzzy, c-format
 msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
 msgstr "Tamanho de ponto inválido [%d] passado a função dots-grid-dot-size\n"
 
-#: schematic/src/g_rc.c:972
 #, fuzzy, c-format
 msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
 msgstr ""
 "Espaçamento de pixel inválido [%d] passado a função dots-grid-fixed-"
 "threshold\n"
 
-#: schematic/src/g_rc.c:998
 #, fuzzy, c-format
 msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
 msgstr ""
 "Espaçamento de pixel inválido [%d] passado a função mesh-grid-display-"
 "threshold\n"
 
-#: schematic/src/g_rc.c:1023
 #, fuzzy, c-format
 msgid "Invalid offset [%1$d] passed to add-attribute-offset\n"
 msgstr "Deslocamento inválido [%d] passado a função add-attribute-offset\n"
 
-#: schematic/src/g_rc.c:1047
 #, fuzzy, c-format
 msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
 msgstr "Numero de segundos inválido [%d] passado a função auto-save-interval\n"
 
-#: schematic/src/g_rc.c:1071
 #, fuzzy, c-format
 msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
 msgstr "Ganho inválido [%d] passado a função mousepan-gain\n"
 
-#: schematic/src/g_rc.c:1094
 #, fuzzy, c-format
 msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
 msgstr "Ganho inválido [%d] passado a função keyboardpan-gain\n"
 
-#: schematic/src/g_rc.c:1118
 #, fuzzy, c-format
 msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
 msgstr "Número de pixeis inválido [%d] passado a função select-slack-pixels\n"
 
-#: schematic/src/g_rc.c:1144
 #, fuzzy, c-format
 msgid "Invalid gain [%1$d] passed to zoom-gain\n"
 msgstr "Ganho inválido [%d] passado a função zoom-gain\n"
 
-#: schematic/src/g_rc.c:1169
 #, fuzzy, c-format
 msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
 msgstr "Numero de passos inválido [%d] passado a função scrollpan-steps\n"
 
-#: schematic/src/g_select.c:78 schematic/src/g_select.c:115
-#: schematic/src/g_select.c:151
 msgid "Object ~A is not directly included in a page."
 msgstr ""
 
-#: schematic/src/g_util.c:54
 msgid "Could not launch URI ~S: ~A"
 msgstr ""
 
-#: schematic/src/g_window.c:139
 msgid "Found invalid gschem window smob ~S"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:156
 #, fuzzy, c-format
 msgid "Lepton EDA/lepton-schematic version %1$s%2$s.%3$s git: %4$.7s"
 msgstr "gEDA/gschem versão %s%s.%s\n"
 
-#: schematic/src/lepton-schematic.c:163
 #, c-format
 msgid "This is the MINGW32 port.\n"
 msgstr "Este é uma adaptação para MINGW32.\n"
 
-#: schematic/src/lepton-schematic.c:167
 #, fuzzy, c-format
 msgid "Current locale settings: %1$s\n"
 msgstr "Definições actuais de localização: %s\n"
 
-#: schematic/src/lepton-schematic.c:201
 #, fuzzy, c-format
 msgid "Couldn't find init scm file [%1$s]"
 msgstr "Não foi possível encontrar  ficheiro scm de inicialização [%s]\n"
 
-#: schematic/src/lepton-schematic.c:206
 #, fuzzy, c-format
 msgid "Read init scm file [%1$s]"
 msgstr "Lido ficheiro de inicialização scm [%s]\n"
 
-#: schematic/src/lepton-schematic.c:210
 #, fuzzy, c-format
 msgid "Failed to read init scm file [%1$s]"
 msgstr "Falha ao ler ficheiro de inicialização scm [%s]\n"
 
-#: schematic/src/lepton-schematic.c:290
 #, c-format
 msgid ""
 "ERROR: Failed to load or evaluate startup script.\n"
@@ -230,142 +188,110 @@ msgid ""
 "The lepton-schematic log may contain more information.\n"
 msgstr ""
 
-#: schematic/src/gschem_about_dialog.c:51
 #, c-format
 msgid "%s (git: %.7s)"
 msgstr ""
 
-#: schematic/src/gschem_about_dialog.c:75
 msgid "Lepton Electronic Design Automation"
 msgstr ""
 
-#: schematic/src/gschem_about_dialog.c:83
 msgid ""
 "Copyright © 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright © 2017-2018 Lepton Developers.\n"
-"See AUTHORS and ChangeLog files for details."
+"Copyright © 2017-2019 Lepton Developers.\n"
+"See AUTHORS, ChangeLog files and consult 'git log' history for details."
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:69
 msgid "Upper Left"
 msgstr "Superior Esquerdo"
 
-#: schematic/src/gschem_alignment_combo.c:71
 msgid "Upper Middle"
 msgstr "Superior, ao Meio"
 
-#: schematic/src/gschem_alignment_combo.c:73
 #, fuzzy
 msgid "Upper Right"
 msgstr "Inferior Direito"
 
-#: schematic/src/gschem_alignment_combo.c:78
 msgid "Middle Left"
 msgstr "Centro Esquerda"
 
-#: schematic/src/gschem_alignment_combo.c:80
 msgid "Middle Middle"
 msgstr "Ao meio, no centro"
 
-#: schematic/src/gschem_alignment_combo.c:82
 msgid "Middle Right"
 msgstr "Centro Direito"
 
-#: schematic/src/gschem_alignment_combo.c:87
 msgid "Lower Left"
 msgstr "Inferior Esquerdo"
 
-#: schematic/src/gschem_alignment_combo.c:89
 msgid "Lower Middle"
 msgstr "Inferior ao Meio"
 
-#: schematic/src/gschem_alignment_combo.c:91
 msgid "Lower Right"
 msgstr "Inferior Direito"
 
-#: schematic/src/gschem_arc_dialog.c:104
 msgid "Arc Params"
 msgstr "Parâmetros do Arco"
 
-#: schematic/src/gschem_arc_dialog.c:140
 #, fuzzy
 msgid "Arc _Radius:"
 msgstr "Raio do Arco:"
 
-#: schematic/src/gschem_arc_dialog.c:141
 #, fuzzy
 msgid "Start _Angle:"
 msgstr "Ângulo Inicial:"
 
-#: schematic/src/gschem_arc_dialog.c:142
 #, fuzzy
 msgid "_Degrees of Sweep:"
 msgstr "Graus de Varrimento:"
 
-#: schematic/src/gschem_bottom_widget.c:504
 msgid "Left mouse button"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:508
 #, fuzzy
 msgid "Middle mouse button"
 msgstr "Centro Esquerda"
 
-#: schematic/src/gschem_bottom_widget.c:512
 #, fuzzy
 msgid "Right mouse button"
 msgstr ""
 "Modo de adição de ligações\n"
 "Use botão direito do rato para cancelar"
 
-#: schematic/src/gschem_bottom_widget.c:595
 msgid "(Snap size, Grid size)"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:603
 #, fuzzy
 msgid "Net rubber band mode"
 msgstr "Alternar Conservar _Ligações"
 
-#: schematic/src/gschem_bottom_widget.c:614
 #, fuzzy
 msgid "Magnetic net mode"
 msgstr "Modo Ligação Magnética"
 
-#: schematic/src/gschem_bottom_widget.c:622
 #, fuzzy
 msgid "Current action mode"
 msgstr "Janela Actual"
 
-#: schematic/src/gschem_bottom_widget.c:935
-#: schematic/src/gschem_bottom_widget.c:951
 msgid "OFF"
 msgstr "DESLIGADO"
 
-#: schematic/src/gschem_bottom_widget.c:954
 msgid "NONE"
 msgstr "NENHUM"
 
-#: schematic/src/gschem_bottom_widget.c:960
 #, fuzzy, c-format
 msgid "Grid(%1$s, %2$s)"
 msgstr "Grelha(%s, %s)"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:350
-#: schematic/src/x_compselect.c:1236 schematic/src/x_multiattrib.c:2068
 msgid "Name"
 msgstr "Nome"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:372
 msgid "S_elect the schematics you want to save:"
 msgstr "S_eleccione os esquemas que quer gravar:"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:467
 #, fuzzy, c-format
 msgid "Save the changes to schematic \"%1$s\" before closing?"
 msgstr "Gravar as alterações no esquema \"%s\" antes de fechar?"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:473
 #, fuzzy, c-format
 msgid ""
 "There are %1$d schematics with unsaved changes. Save changes before closing?"
@@ -373,564 +299,416 @@ msgstr ""
 "Existem %d esquemas com alterações não gravadas. Gravar alterações antes de "
 "fechar?"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:502
 msgid "If you don't save, all your changes will be permanently lost."
 msgstr "Se não gravar, todas as alterações serão permanentemente perdidas."
 
-#: schematic/src/gschem_close_confirmation_dialog.c:522
 #, fuzzy
 msgid "Close _without saving"
 msgstr "_Fechar sem gravar"
 
-#: schematic/src/gschem_coord_dialog.c:86
 msgid "Coords"
 msgstr "Coordenadas"
 
-#: schematic/src/gschem_coord_dialog.c:106
 msgid "Screen"
 msgstr "Ecrã"
 
-#: schematic/src/gschem_coord_dialog.c:115
 msgid "World"
 msgstr "Mundo"
 
-#: schematic/src/gschem_find_text_state.c:809 schematic/src/x_pagesel.c:432
 msgid "Filename"
 msgstr "Nome de ficheiro"
 
-#: schematic/src/gschem_find_text_state.c:821 schematic/src/i_callbacks.c:1970
-#: schematic/src/x_colorcb.c:154 schematic/src/x_widgets.c:179
-#: schematic/src/x_window.c:1226 schematic/src/x_window.c:1440
 msgid "Text"
 msgstr "Texto"
 
-#: schematic/src/gschem_find_text_widget.c:427
 msgid "descend into hierarchy"
 msgstr "descender na hierarquia"
 
-#: schematic/src/gschem_find_text_widget.c:435
 #, fuzzy
 msgid "Find"
 msgstr "Procurar Texto"
 
-#: schematic/src/gschem_find_text_widget.c:557
 #, fuzzy
 msgid "Find Text:"
 msgstr "Procurar Texto"
 
-#: schematic/src/gschem_find_text_widget.c:564
 msgid "Find Pattern:"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:571
 #, fuzzy
 msgid "Find Regex:"
 msgstr "Procurar Texto"
 
-#: schematic/src/gschem_find_text_widget.c:578
 msgid "Check symbol:"
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:200
 msgid "Hotkeys"
 msgstr "Teclas de Atalho"
 
-#: schematic/src/gschem_hotkey_dialog.c:229
 msgid ""
 "Start typing action name or keystroke to filter the list.\n"
 "Type hotkeys as they are displayed in \"Keystroke(s)\" column."
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:233 schematic/src/x_compselect.c:1124
 #, fuzzy
 msgid "_Filter:"
 msgstr "Filtro:"
 
-#: schematic/src/gschem_hotkey_dialog.c:259 schematic/src/i_basic.c:280
 msgid "Action"
 msgstr "Acção"
 
-#: schematic/src/gschem_hotkey_dialog.c:277
 msgid "Keystroke(s)"
 msgstr "Premir de tecla(s)"
 
-#: schematic/src/gschem_log_widget.c:177
 msgid "** Invalid UTF-8 in log message. See stderr or gschem.log.\n"
 msgstr "** UTF-8 inválido na mensagem de registo. Veja stderr ou gschem.log.\n"
 
-#: schematic/src/gschem_log_widget.c:434
 #, fuzzy
 msgid "Clear log window?"
 msgstr "A Fechar janela\n"
 
-#: schematic/src/gschem_log_widget.c:477
 #, fuzzy
 msgid "Clear Log _Window"
 msgstr "Mostrar Janela de _Registo"
 
-#: schematic/src/gschem_macro_widget.c:231
 msgid "Macro:"
 msgstr ""
 
-#: schematic/src/gschem_macro_widget.c:387
 msgid "Evaluate"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:172
 #, fuzzy
 msgid "_Fill Type:"
 msgstr "Tipo de Enchimento:"
 
-#: schematic/src/gschem_object_properties_widget.c:173
 #, fuzzy
 msgid "Lin_e Width:"
 msgstr "Espessura de Linha"
 
-#: schematic/src/gschem_object_properties_widget.c:174
 #, fuzzy
 msgid "Angle _1:"
 msgstr "Ângulo 1:"
 
-#: schematic/src/gschem_object_properties_widget.c:175
 #, fuzzy
 msgid "P_itch 1:"
 msgstr "Espaçamento 1:"
 
-#: schematic/src/gschem_object_properties_widget.c:176
 #, fuzzy
 msgid "Angle _2:"
 msgstr "Ângulo 2:"
 
-#: schematic/src/gschem_object_properties_widget.c:177
 #, fuzzy
 msgid "Pitc_h 2:"
 msgstr "Espaçamento 2:"
 
-#: schematic/src/gschem_object_properties_widget.c:237
 #, fuzzy
 msgid "<b>Fill Properties</b>"
 msgstr "<b>Propriedades do Texto</b>"
 
-#: schematic/src/gschem_object_properties_widget.c:255
-#: schematic/src/gschem_text_properties_widget.c:258
-#: schematic/src/x_newtext.c:271
 #, fuzzy
 msgid "Colo_r:"
 msgstr "Cor:"
 
-#: schematic/src/gschem_object_properties_widget.c:266
 #, fuzzy
 msgid "<b>General Properties</b>"
 msgstr "<b>Propriedades do Texto</b>"
 
-#: schematic/src/gschem_object_properties_widget.c:284
 #, fuzzy
 msgid "_Type:"
 msgstr "Tipo:"
 
-#: schematic/src/gschem_object_properties_widget.c:285
 #, fuzzy
 msgid "_Width:"
 msgstr "Largura:"
 
-#: schematic/src/gschem_object_properties_widget.c:286
 #, fuzzy
 msgid "Dash _Length:"
 msgstr "Comprimento do Traço:"
 
-#: schematic/src/gschem_object_properties_widget.c:287
 #, fuzzy
 msgid "Dash _Space:"
 msgstr "Espaçamento do Traço:"
 
-#: schematic/src/gschem_object_properties_widget.c:288
 msgid "C_ap style:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:333
 #, fuzzy
 msgid "<b>Line Properties</b>"
 msgstr "<b>Propriedades do Texto</b>"
 
-#: schematic/src/gschem_object_properties_widget.c:351
 #, fuzzy
 msgid "_Pin Type:"
 msgstr "Tipo de pino"
 
-#: schematic/src/gschem_object_properties_widget.c:362
 #, fuzzy
 msgid "<b>Pin Properties</b>"
 msgstr "<b>Propriedades do Texto</b>"
 
-#: schematic/src/gschem_options_widget.c:217
 msgid "_Off"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:220
 msgid "_Dots"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:223
 msgid "M_esh"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:245
 #, fuzzy
 msgid "Net R_ubber Band Mode:"
 msgstr "Alternar Conservar _Ligações"
 
-#: schematic/src/gschem_options_widget.c:246
 #, fuzzy
 msgid "_Magnetic Net Mode:"
 msgstr "Modo Ligação Magnética"
 
-#: schematic/src/gschem_options_widget.c:250
-#: schematic/src/gschem_options_widget.c:251
 msgid "Enabled"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:265
 #, fuzzy
 msgid "<b>Net Options</b>"
 msgstr "<b>Opções</b>"
 
-#: schematic/src/gschem_options_widget.c:282
 #, fuzzy
 msgid "Grid Mode:"
 msgstr "Modo de Arco"
 
-#: schematic/src/gschem_options_widget.c:283
 #, fuzzy
 msgid "Snap Mode:"
 msgstr "Modo Centrar"
 
-#: schematic/src/gschem_options_widget.c:284
 #, fuzzy
 msgid "_Snap Size:"
 msgstr "Tamanho da Grelha"
 
-#: schematic/src/gschem_options_widget.c:301
 #, fuzzy
 msgid "<b>Snap Options</b>"
 msgstr "<b>Opções</b>"
 
-#: schematic/src/gschem_options_widget.c:340
 msgid "O_ff"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:343
 #, fuzzy
 msgid "_Grid"
 msgstr "Grelha Desligada\n"
 
-#: schematic/src/gschem_options_widget.c:346
 #, fuzzy
 msgid "_Resnap"
 msgstr "Reajuste a Grelha Activo"
 
-#: schematic/src/gschem_pin_type_combo.c:73
 msgid "Net pin"
 msgstr "Pino de Ligação"
 
-#: schematic/src/gschem_pin_type_combo.c:80
 msgid "Bus pin (graphical)"
 msgstr "Pino do Barramento (gráfico)"
 
-#: schematic/src/gschem_preview.c:195
 msgid "Preview Buffer"
 msgstr "Previsualizar Buffer"
 
-#: schematic/src/gschem_show_hide_text_widget.c:148
-#: schematic/src/x_window.c:1268
 #, fuzzy
 msgid "Hide"
 msgstr "Esconder Texto"
 
-#: schematic/src/gschem_show_hide_text_widget.c:157
-#: schematic/src/x_window.c:1269
 msgid "Hide text starting with:"
 msgstr "Esconder texto que comece por:"
 
-#: schematic/src/gschem_slot_edit_dialog.c:91
 msgid "Edit slot number"
 msgstr "Editar numero de elemento"
 
-#: schematic/src/gschem_slot_edit_dialog.c:121
 msgid "Number of Slots:"
 msgstr ""
 
-#: schematic/src/gschem_slot_edit_dialog.c:122
 #, fuzzy
 msgid "Slot Number:"
 msgstr "Editar numero de elemento:"
 
-#: schematic/src/gschem_text_properties_widget.c:240
-#: schematic/src/x_newtext.c:265
 msgid "<b>Text Content</b>"
 msgstr "<b>Conteúdo do texto</b>"
 
-#: schematic/src/gschem_text_properties_widget.c:259
-#: schematic/src/x_newtext.c:291
 #, fuzzy
 msgid "_Size:"
 msgstr "Tamanho:"
 
-#: schematic/src/gschem_text_properties_widget.c:260
-#: schematic/src/x_newtext.c:310
 #, fuzzy
 msgid "Ali_gnment:"
 msgstr "Alinhamento:"
 
-#: schematic/src/gschem_text_properties_widget.c:261
-#: schematic/src/x_newtext.c:330
 #, fuzzy
 msgid "Ro_tation:"
 msgstr "Orientação:"
 
-#: schematic/src/gschem_text_properties_widget.c:294
-#: schematic/src/x_newtext.c:253
 msgid "<b>Text Properties</b>"
 msgstr "<b>Propriedades do Texto</b>"
 
-#: schematic/src/gschem_translate_widget.c:238
 #, fuzzy
 msgid "Coordinate:"
 msgstr "Mostrar Janela de _Coordenadas..."
 
-#: schematic/src/gschem_translate_widget.c:405 schematic/src/i_callbacks.c:800
 msgid "Translate"
 msgstr "Mover"
 
-#: schematic/src/i_basic.c:64 schematic/src/x_window.c:1369
-#: schematic/scheme/conf/schematic/menu.scm:59
-#: schematic/scheme/gschem/builtins.scm:99
 msgid "Select Mode"
 msgstr "Modo de Selecção"
 
-#: schematic/src/i_basic.c:65
 #, fuzzy
 msgid "Select Box Mode"
 msgstr "Modo de Selecção"
 
-#: schematic/src/i_basic.c:66
 msgid "Text Mode"
 msgstr "Modo de texto"
 
-#: schematic/src/i_basic.c:67
 msgid "Pan Mode"
 msgstr "Modo Centrar"
 
-#: schematic/src/i_basic.c:70
 #, c-format
 msgid "Paste %d Mode"
 msgstr "Modo pegar %d"
 
-#: schematic/src/i_basic.c:74
 msgid "Magnetic Net Mode"
 msgstr "Modo Ligação Magnética"
 
-#: schematic/src/i_basic.c:76
 msgid "Net Mode"
 msgstr "Modo Ligação"
 
-#: schematic/src/i_basic.c:77
 msgid "Arc Mode"
 msgstr "Modo de Arco"
 
-#: schematic/src/i_basic.c:78
 msgid "Box Mode"
 msgstr "Modo Rectângulo"
 
-#: schematic/src/i_basic.c:79
 msgid "Bus Mode"
 msgstr "Modo de Barramento"
 
-#: schematic/src/i_basic.c:80
 msgid "Circle Mode"
 msgstr "Modo de Círculo"
 
-#: schematic/src/i_basic.c:81
 msgid "Component Mode"
 msgstr "Modo Componente"
 
-#: schematic/src/i_basic.c:82 schematic/scheme/conf/schematic/menu.scm:62
-#: schematic/scheme/gschem/builtins.scm:114
 msgid "Copy Mode"
 msgstr "Modo de Cópia"
 
-#: schematic/src/i_basic.c:83 schematic/scheme/conf/schematic/menu.scm:63
-#: schematic/scheme/gschem/builtins.scm:117
 msgid "Multiple Copy Mode"
 msgstr "Modo de Cópia Múltiplo"
 
-#: schematic/src/i_basic.c:84
 msgid "Line Mode"
 msgstr "Modo de Linha"
 
-#: schematic/src/i_basic.c:85 schematic/scheme/conf/schematic/menu.scm:66
-#: schematic/scheme/gschem/builtins.scm:123
 msgid "Mirror Mode"
 msgstr "Modo simetria"
 
-#: schematic/src/i_basic.c:86 schematic/scheme/conf/schematic/menu.scm:64
-#: schematic/scheme/gschem/builtins.scm:111
 msgid "Move Mode"
 msgstr "Modo de Movimentação"
 
-#: schematic/src/i_basic.c:87
 #, fuzzy
 msgid "Path Mode"
 msgstr "Modo Centrar"
 
-#: schematic/src/i_basic.c:88
 msgid "Picture Mode"
 msgstr "Modo de Imagem"
 
-#: schematic/src/i_basic.c:89
 msgid "Pin Mode"
 msgstr "Modo de Pino"
 
-#: schematic/src/i_basic.c:90 schematic/scheme/gschem/builtins.scm:120
 msgid "Rotate Mode"
 msgstr "Modo de Rotação"
 
-#: schematic/src/i_basic.c:91
 #, fuzzy
 msgid "Modify Mode"
 msgstr "Modo de Cópia"
 
-#: schematic/src/i_basic.c:92 schematic/src/x_menus.c:49
-#: schematic/scheme/gschem/builtins.scm:204
 msgid "Zoom Box"
 msgstr "Zona de Ampliação"
 
-#: schematic/src/i_basic.c:121
 msgid "Show Hidden"
 msgstr "Mostrar Escondidos"
 
-#: schematic/src/i_basic.c:124
 msgid "Snap Off"
 msgstr "Desactivado o Ajuste à Grelha"
 
-#: schematic/src/i_basic.c:126
 msgid "Resnap Active"
 msgstr "Reajuste a Grelha Activo"
 
-#: schematic/src/i_basic.c:288 schematic/src/x_colorcb.c:159
 msgid "Stroke"
 msgstr "Gesto"
 
-#: schematic/src/i_basic.c:296 schematic/src/i_basic.c:330
-#: schematic/src/x_window.c:1361
 msgid "none"
 msgstr "nenhum"
 
-#: schematic/src/i_basic.c:304
 msgid "Repeat/"
 msgstr "Repetir/"
 
-#: schematic/src/i_basic.c:315
 msgid "Repeat/none"
 msgstr "Repetir/nenhum"
 
-#: schematic/src/i_basic.c:323 schematic/src/i_callbacks.c:1239
-#: schematic/scheme/gschem/builtins.scm:189
 msgid "Pan"
 msgstr "Centrar em respeito com o cursor"
 
-#: schematic/src/i_callbacks.c:74
 #, fuzzy, c-format
 msgid "New page created [%1$s]"
 msgstr "Nova pagina criada [%s]\n"
 
-#: schematic/src/i_callbacks.c:108
 #, fuzzy, c-format
 msgid "New Window created [%1$s]"
 msgstr "Nova Janela criada [%s]\n"
 
-#: schematic/src/i_callbacks.c:245
 msgid "Failed to Save All"
 msgstr "Falhou a Gravar Tudo"
 
-#: schematic/src/i_callbacks.c:247
 msgid "Saved All"
 msgstr "Tudo Gravado"
 
-#: schematic/src/i_callbacks.c:308
 #, fuzzy
 msgid "Closing Window"
 msgstr "A Fechar janela\n"
 
-#: schematic/src/i_callbacks.c:505 schematic/src/x_menus.c:55
-#: schematic/scheme/gschem/builtins.scm:168
 msgid "Copy"
 msgstr "Copiar"
 
-#: schematic/src/i_callbacks.c:514 schematic/src/i_callbacks.c:539
-#: schematic/src/i_callbacks.c:564
 msgid "Select objs first"
 msgstr "Seleccione objectos primeiro"
 
-#: schematic/src/i_callbacks.c:530
 msgid "Multiple Copy"
 msgstr "Cópia Múltipla"
 
-#: schematic/src/i_callbacks.c:555 schematic/src/x_menus.c:56
 msgid "Move"
 msgstr "Mover"
 
-#: schematic/src/i_callbacks.c:579 schematic/src/x_menus.c:57
-#: schematic/src/x_multiattrib.c:1656 schematic/scheme/gschem/builtins.scm:108
 msgid "Delete"
 msgstr "Eliminar"
 
-#: schematic/src/i_callbacks.c:603
 msgid "Edit"
 msgstr "Editar"
 
-#: schematic/src/i_callbacks.c:618 schematic/scheme/gschem/builtins.scm:129
 msgid "Edit Text"
 msgstr "Editar Texto"
 
-#: schematic/src/i_callbacks.c:637
 msgid "Slot"
 msgstr "Elemento"
 
-#: schematic/src/i_callbacks.c:688 schematic/src/i_callbacks.c:698
 msgid "Rotate"
 msgstr "Rodar"
 
-#: schematic/src/i_callbacks.c:736 schematic/src/i_callbacks.c:746
 msgid "Mirror"
 msgstr "Simetria"
 
-#: schematic/src/i_callbacks.c:763 schematic/src/x_colorcb.c:160
-#: schematic/scheme/conf/schematic/menu.scm:73
-#: schematic/scheme/gschem/builtins.scm:141
 msgid "Lock"
 msgstr "Trancar"
 
-#: schematic/src/i_callbacks.c:781 schematic/scheme/conf/schematic/menu.scm:74
-#: schematic/scheme/gschem/builtins.scm:144
 msgid "Unlock"
 msgstr "Destrancar"
 
-#: schematic/src/i_callbacks.c:805
 #, fuzzy
 msgid "WARNING: Do not translate with snap off!"
 msgstr "AVISO: Não mova com ajuste à grelha desligado!\n"
 
-#: schematic/src/i_callbacks.c:806
 #, fuzzy
 msgid "WARNING: Turning snap on and continuing with translate."
 msgstr "AVISO: Active ajuste à grelha e continue com a movimentação.\n"
 
-#: schematic/src/i_callbacks.c:813
 #, fuzzy
 msgid "WARNING: Snap grid size is not equal to 100!"
 msgstr "AVISO: O tamanha do ajuste a grelha não é igual a 100!\n"
 
-#: schematic/src/i_callbacks.c:815
 #, fuzzy
 msgid ""
 "WARNING: If you are translating a symbol to the origin, the snap grid size "
@@ -939,23 +717,18 @@ msgstr ""
 "AVISO: Se está a mover um símbolo para a origem, o tamanho do ajuste a "
 "grelha deve ser definido para 100\n"
 
-#: schematic/src/i_callbacks.c:847
 msgid "Embed"
 msgstr "Embutir"
 
-#: schematic/src/i_callbacks.c:886
 msgid "Unembed"
 msgstr "Retirar"
 
-#: schematic/src/i_callbacks.c:928
 msgid "Update"
 msgstr "Actualizar"
 
-#: schematic/src/i_callbacks.c:970
 msgid "ShowHidden"
 msgstr "Mostrar Objectos Escondidos"
 
-#: schematic/src/i_callbacks.c:1537
 #, c-format
 msgid ""
 "<b>Revert page:</b>\n"
@@ -966,100 +739,78 @@ msgid ""
 "discarded and page file will be reloaded from disk."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1555
 #, fuzzy
 msgid "Revert"
 msgstr "_Reverter"
 
-#: schematic/src/i_callbacks.c:1647
 msgid "Copy to clipboard"
 msgstr "Copiar para a área de transferência"
 
-#: schematic/src/i_callbacks.c:1664
 msgid "Cut to clipboard"
 msgstr "Cortar para a área de transferência"
 
-#: schematic/src/i_callbacks.c:1686
 msgid "Paste from clipboard"
 msgstr "Colar da área de transferência"
 
-#: schematic/src/i_callbacks.c:1694
 #, fuzzy
 msgid "Empty clipboard"
 msgstr "Copiar para a área de transferência"
 
 #. TRANSLATORS: The number is the number of the buffer that the
 #. * selection is being copied to.
-#: schematic/src/i_callbacks.c:1719
 #, fuzzy, c-format
 msgid "Copy %i"
 msgstr "Cópia 1"
 
 #. TRANSLATORS: The number is the number of the buffer that the
 #. * selection is being cut to.
-#: schematic/src/i_callbacks.c:1746
 #, fuzzy, c-format
 msgid "Cut %i"
 msgstr "Cortar 1"
 
 #. TRANSLATORS: The number is the number of the buffer that is being
 #. * pasted to the schematic.
-#: schematic/src/i_callbacks.c:1776
 #, fuzzy, c-format
 msgid "Paste %i"
 msgstr "Colar 1"
 
-#: schematic/src/i_callbacks.c:1785
 msgid "Empty buffer"
 msgstr "Buffer vazio"
 
-#: schematic/src/i_callbacks.c:1833 schematic/src/x_window.c:1203
 msgid "Component"
 msgstr "Componente"
 
-#: schematic/src/i_callbacks.c:1865 schematic/src/x_colorcb.c:150
 msgid "Attribute"
 msgstr "Atributo"
 
-#: schematic/src/i_callbacks.c:1885 schematic/src/x_colorcb.c:149
 msgid "Net"
 msgstr "Ligação"
 
-#: schematic/src/i_callbacks.c:1928 schematic/src/x_colorcb.c:155
-#: schematic/src/x_window.c:1222
 msgid "Bus"
 msgstr "Barramento"
 
-#: schematic/src/i_callbacks.c:2004
 msgid "Line"
 msgstr "Linha"
 
-#: schematic/src/i_callbacks.c:2021
 msgid "Path"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2043
 msgid "Box"
 msgstr "Rectângulo"
 
-#: schematic/src/i_callbacks.c:2085
 msgid "Circle"
 msgstr "Círculo"
 
-#: schematic/src/i_callbacks.c:2108
 msgid "Arc"
 msgstr "Arco"
 
-#: schematic/src/i_callbacks.c:2131 schematic/src/x_colorcb.c:146
 msgid "Pin"
 msgstr "Pino"
 
-#: schematic/src/i_callbacks.c:2191
 #, fuzzy, c-format
 msgid "Searching for source [%1$s]"
 msgstr "A procura da fonte [%s]\n"
 
-#: schematic/src/i_callbacks.c:2223
 #, c-format
 msgid ""
 "Failed to descend hierarchy into '%1$s': %2$s\n"
@@ -1067,122 +818,97 @@ msgid ""
 "The lepton-schematic log may contain more information."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2227
 #, fuzzy, c-format
 msgid "Failed to descend into '%1$s': %2$s"
 msgstr "Falha ao ler ficheiro de inicialização scm [%s]\n"
 
-#: schematic/src/i_callbacks.c:2234
 #, fuzzy
 msgid "Failed to descend hierarchy."
 msgstr "descender na hierarquia"
 
-#: schematic/src/i_callbacks.c:2312
 #, fuzzy, c-format
 msgid "Searching for symbol [%1$s]"
 msgstr "A procurar por símbolo [%s]\n"
 
-#: schematic/src/i_callbacks.c:2320
 #, fuzzy
 msgid "Symbol is not a real file. Symbol cannot be loaded."
 msgstr ""
 "O símbolo não existe como ficheiro. O não é possível carregar o símbolo.\n"
 
-#: schematic/src/i_callbacks.c:2367 schematic/src/x_tabs.c:1060
 #, fuzzy
 msgid "Cannot find any schematics above the current one!"
 msgstr "Não é possível encontrar mais esquemas acima do esquema corrente!\n"
 
-#: schematic/src/i_callbacks.c:2400
 msgid "Attach"
 msgstr "Anexar"
 
-#: schematic/src/i_callbacks.c:2456
 msgid "Detach"
 msgstr "Retirar"
 
-#: schematic/src/i_callbacks.c:2500
 msgid "ShowN"
 msgstr "Mostrar Nome"
 
-#: schematic/src/i_callbacks.c:2537
 msgid "ShowV"
 msgstr "Mostrar valor"
 
-#: schematic/src/i_callbacks.c:2574
 msgid "ShowB"
 msgstr "Mostrar Ambos"
 
-#: schematic/src/i_callbacks.c:2612
 msgid "VisToggle"
 msgstr "Alterar Visibilidade"
 
-#: schematic/src/i_callbacks.c:2643
 #, c-format
 msgid "Sorry but this is a non-functioning menu option\n"
 msgstr "Desculpe mas esta é uma função do menu não funcional\n"
 
-#: schematic/src/i_callbacks.c:2703
 #, fuzzy
 msgid "Action feedback mode set to OUTLINE"
 msgstr "Acção modo de retorno definida para OUTLINE\n"
 
-#: schematic/src/i_callbacks.c:2706
 #, fuzzy
 msgid "Action feedback mode set to BOUNDINGBOX"
 msgstr "Acção modo de retorno definida para BOUNDINGBOX\n"
 
-#: schematic/src/i_callbacks.c:2730
 #, fuzzy
 msgid "Grid OFF"
 msgstr "Grelha Desligada\n"
 
-#: schematic/src/i_callbacks.c:2731
 #, fuzzy
 msgid "Dot grid selected"
 msgstr "Seleccionada grelha de pontos\n"
 
-#: schematic/src/i_callbacks.c:2732
 #, fuzzy
 msgid "Mesh grid selected"
 msgstr "Seleccionada grelha de traços\n"
 
-#: schematic/src/i_callbacks.c:2733
 #, fuzzy
 msgid "Invalid grid mode"
 msgstr "Atributo Inválido"
 
-#: schematic/src/i_callbacks.c:2755
 #, fuzzy
 msgid "Snap OFF (CAUTION!)"
 msgstr "PRECAUÇÃO  Ajuste a grelha DESLIGADO!\n"
 
-#: schematic/src/i_callbacks.c:2758
 #, fuzzy
 msgid "Snap ON"
 msgstr "Ajuste a grelha LIGADO\n"
 
-#: schematic/src/i_callbacks.c:2761
 #, fuzzy
 msgid "Snap back to the grid (CAUTION!)"
 msgstr "Reajuste a grelha (ATENÇÃO!)\n"
 
-#: schematic/src/i_callbacks.c:2790
 #, fuzzy
 msgid "Rubber band ON"
 msgstr "Banda de borracha Ligada\n"
 
-#: schematic/src/i_callbacks.c:2792
 #, fuzzy
 msgid "Rubber band OFF"
 msgstr "Banda de borracha Desligada \n"
 
-#: schematic/src/i_callbacks.c:2811
 #, fuzzy
 msgid "magnetic net mode: ON"
 msgstr "Modo de ligação magnética: Activa\n"
 
-#: schematic/src/i_callbacks.c:2814
 #, fuzzy
 msgid "magnetic net mode: OFF"
 msgstr "Modo de ligação magnética: Desactiva\n"
@@ -1192,152 +918,123 @@ msgstr "Modo de ligação magnética: Desactiva\n"
 #. the form "untitled_N.sch", where N is a number.  Please make
 #. sure that the translation contains characters suitable for use
 #. in a filename.
-#: schematic/src/i_vars.c:209
 msgid "untitled"
 msgstr ""
 
-#: schematic/src/o_complex.c:192 schematic/src/o_complex.c:195
 #, fuzzy, c-format
 msgid "Translating schematic [%1$d %2$d]"
 msgstr "A converter esquema [%d %d]\n"
 
-#: schematic/src/o_delete.c:82
 #, fuzzy, c-format
 msgid "Delete locked object?"
 msgid_plural "Delete %1$u locked objects?"
 msgstr[0] "Objectos seleccionados"
 msgstr[1] "Objectos seleccionados"
 
-#: schematic/src/o_misc.c:55
 #, c-format
 msgid "Got an unexpected NULL in o_edit\n"
 msgstr "Foi obtido um NULL inesperado em o_edit\n"
 
-#: schematic/src/o_misc.c:315
 #, fuzzy
 msgid "Hidden text is now visible"
 msgstr "Texto escondido é agora visível\n"
 
-#: schematic/src/o_misc.c:317
 #, fuzzy
 msgid "Hidden text is now invisible"
 msgstr "Texto escondido é agora invisível\n"
 
-#: schematic/src/o_misc.c:425
 #, fuzzy, c-format
 msgid "Could not find symbol [%1$s] in library. Update failed."
 msgstr ""
 "Não foi possível encontrar símbolo [%s] na biblioteca. Actualização falhou.\n"
 
-#: schematic/src/o_misc.c:541
 #, fuzzy, c-format
 msgid "o_autosave_backups: Can't get the real filename of %1$s."
 msgstr "o_autosave_backups: Não foi possível obter o verdadeiro nome de %s."
 
-#: schematic/src/o_misc.c:585
 #, fuzzy, c-format
 msgid "Could NOT set previous backup file [%1$s] read-write"
 msgstr ""
 "NÃO foi possível definir o ficheiro de salvaguarda anterior [%s] como "
 "leitura e escrita\n"
 
-#: schematic/src/o_misc.c:605
 #, fuzzy, c-format
 msgid "Could NOT set backup file [%1$s] readonly"
 msgstr ""
 "Não foi possível definir o ficheiro de salvaguarda [%s] apenas como leitura\n"
 
-#: schematic/src/o_misc.c:610
 #, fuzzy, c-format
 msgid "Could NOT save backup file [%1$s]"
 msgstr "Não foi possível guardar ficheiro de salvaguarda [%s]\n"
 
-#: schematic/src/o_move.c:192
 #, c-format
 msgid "ERROR: NULL object in o_move_end!\n"
 msgstr "ERRO: Objecto NULL em o_move_end!\n"
 
-#: schematic/src/o_move.c:519
 #, c-format
 msgid "DOH! tried to find the whichone, but didn't find it!\n"
 msgstr ""
 "EH! Tentou-se encontrar o parâmetro  whichone, mas tal não foi possível!\n"
 
-#: schematic/src/o_move.c:546
 #, c-format
 msgid "Got a non line object in o_move_check_endpoint\n"
 msgstr "Foi obtido um objecto que não é linha em  o_move_check_endpoint\n"
 
-#: schematic/src/o_net.c:444
 #, fuzzy
 msgid "Warning: Starting net at off grid coordinate"
 msgstr "Aviso: A iniciar ligação numa coordenada fora da grelha\n"
 
-#: schematic/src/o_net.c:508
 #, fuzzy
 msgid "Warning: Ending net at off grid coordinate"
 msgstr "Aviso: A terminar ligação numa coordenada fora da grelha\n"
 
-#: schematic/src/o_net.c:856 schematic/src/o_net.c:893
-#: schematic/src/o_net.c:964 schematic/src/o_net.c:1000
 #, c-format
 msgid "Tried to add more than two bus rippers. Internal gschem error.\n"
 msgstr ""
 "Tentativa de adicionar mais de duas ligações ao barramento. Erro interno do "
 "gschem.\n"
 
-#: schematic/src/o_net.c:1068
 #, fuzzy, c-format
 msgid "Bus ripper symbol [%1$s] was not found in any component library"
 msgstr ""
 "Símbolo de ligação ao barramento [%s] não foi encontrado em nenhuma "
 "biblioteca de componentes\n"
 
-#: schematic/src/o_picture.c:133 schematic/src/o_picture.c:343
 #, fuzzy
 msgid "Select a picture file..."
 msgstr "Seleccione nome do ficheiro PostScript..."
 
-#: schematic/src/o_picture.c:166
 #, fuzzy, c-format
 msgid "Failed to load picture: %1$s"
 msgstr "Falha ao carregar imagem: %s"
 
-#: schematic/src/o_picture.c:182
 msgid "Picture"
 msgstr "Imagem"
 
-#: schematic/src/o_picture.c:378
 #, c-format
 msgid "Failed to replace pictures: %s"
 msgstr ""
 
-#: schematic/src/o_slot.c:80
 #, fuzzy
 msgid "Slot attribute malformed"
 msgstr "Atribuição de elemento mal especificado\n"
 
-#: schematic/src/o_slot.c:88
 #, fuzzy
 msgid "numslots attribute missing"
 msgstr "numslots atributo em falta\n"
 
-#: schematic/src/o_slot.c:89
 #, fuzzy
 msgid "Slotting not allowed for this component"
 msgstr "Não são permitidos múltiplos elementos para este componente\n"
 
-#: schematic/src/o_slot.c:104
 #, fuzzy
 msgid "New slot number out of range"
 msgstr "Novo numero de elemento fora de alcance\n"
 
-#: schematic/src/o_undo.c:397
 #, fuzzy
 msgid "Undo/Redo disabled in rc file"
 msgstr "Desfazer/Refazer não activo no ficheiro rc\n"
 
-#: schematic/src/parsecmd.c:77
 #, c-format
 msgid ""
 "Usage: %1$s [OPTION ...] [--] [FILE ...]\n"
@@ -1362,91 +1059,71 @@ msgid ""
 "gEDA/gaf homepage: <http://www.geda-project.org/>\n"
 msgstr ""
 
-#: schematic/src/parsecmd.c:110
 #, c-format
 msgid ""
 "Lepton EDA %1$s (git: %2$.7s)\n"
 "Copyright (C) 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright (C) 2017-2018 Lepton Developers.\n"
+"Copyright (C) 2017-2019 Lepton Developers.\n"
 "This is free software, and you are welcome to redistribute it under\n"
 "certain conditions. For details, see the file `COPYING', which is\n"
 "included in the Lepton EDA distribution.\n"
 "There is NO WARRANTY, to the extent permitted by law.\n"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:125
 #, c-format
 msgid "Got invalid show option; defaulting to show both\n"
 msgstr ""
 "Obtida opção de visualização inválida; A alterar para visualizar ambos\n"
 
-#: schematic/src/x_attribedit.c:139
 #, c-format
 msgid "ERROR: NULL object!\n"
 msgstr "ERROR: Objecto NULL!\n"
 
-#: schematic/src/x_attribedit.c:328
 msgid "Single Attribute Editor"
 msgstr "Editor de único atributo"
 
-#: schematic/src/x_attribedit.c:358
 msgid "<b>Edit Attribute</b>"
 msgstr "<b>Editar Atributo</b>"
 
-#: schematic/src/x_attribedit.c:360
 msgid "<b>Add Attribute</b>"
 msgstr "<b>Adicionar Atributo</b>"
 
-#: schematic/src/x_attribedit.c:376
 #, fuzzy
 msgid "N_ame:"
 msgstr "Nome:"
 
-#: schematic/src/x_attribedit.c:396 schematic/src/x_multiattrib.c:2222
 #, fuzzy
 msgid "_Value:"
 msgstr "Valor:"
 
-#: schematic/src/x_attribedit.c:415 schematic/src/x_multiattrib.c:2281
 #, fuzzy
 msgid "Vi_sible"
 msgstr "Visível"
 
-#: schematic/src/x_attribedit.c:434
 msgid "Show Value Only"
 msgstr "Mostrar Valor Apenas"
 
-#: schematic/src/x_attribedit.c:436
 msgid "Show Name Only"
 msgstr "Mostrar Nome Apenas"
 
-#: schematic/src/x_attribedit.c:438 schematic/src/x_multiattrib.c:1620
-#: schematic/scheme/gschem/builtins.scm:324
 msgid "Show Name & Value"
 msgstr "Mostrar Nome & Valor"
 
-#: schematic/src/x_attribedit.c:445
 msgid "<b>Attach Options</b>"
 msgstr "<b>Opções de Anexação </b>"
 
-#: schematic/src/x_attribedit.c:460
 msgid "All"
 msgstr "Tudo"
 
-#: schematic/src/x_attribedit.c:476 schematic/src/x_compselect.c:986
-#: schematic/src/x_compselect.c:1100
 msgid "Components"
 msgstr "Componentes"
 
-#: schematic/src/x_attribedit.c:492 schematic/src/x_window.c:1214
 msgid "Nets"
 msgstr "Ligações"
 
-#: schematic/src/x_attribedit.c:508
 msgid "Replace existing attributes"
 msgstr "Substituir atributos existentes"
 
-#: schematic/src/x_autonumber.c:412
 #, fuzzy
 msgid ""
 "slotted object without slot attribute may cause problems when autonumbering "
@@ -1455,7 +1132,6 @@ msgstr ""
 "Objecto elementar atribuição de elemento pode causar problemas durante auto-"
 "numeração de elementos\n"
 
-#: schematic/src/x_autonumber.c:427
 #, fuzzy, c-format
 msgid ""
 "duplicate slot may cause problems: [symbolname=%1$s, number=%2$d, slot=%3$d]"
@@ -1463,97 +1139,74 @@ msgstr ""
 "Duplicação de elementos pode causar problemas: [symbolname=%s, number=%d, "
 "slot=%d]\n"
 
-#: schematic/src/x_autonumber.c:675
 #, fuzzy
 msgid "No searchstring given in autonumber text."
 msgstr "Nenhuma frase de procura dada no texto de auto-numeração.\n"
 
-#: schematic/src/x_autonumber.c:728
 #, fuzzy
 msgid "No '*' or '?' given at the end of the autonumber text."
 msgstr "Sem '*' ou '?' dado no fim do texto de auto-numeração.\n"
 
-#: schematic/src/x_autonumber.c:873
 msgid "Diagonal"
 msgstr "Diagonal"
 
-#: schematic/src/x_autonumber.c:874
 msgid "Top to bottom"
 msgstr "De cima para baixo"
 
-#: schematic/src/x_autonumber.c:875
 msgid "Bottom to top"
 msgstr "De baixo para cima"
 
-#: schematic/src/x_autonumber.c:876
 msgid "Left to right"
 msgstr "Da esquerda para a direita"
 
-#: schematic/src/x_autonumber.c:877
 msgid "Right to left"
 msgstr "Da direita para a esquerda"
 
-#: schematic/src/x_autonumber.c:878
 msgid "File order"
 msgstr "Ordem de ficheiro"
 
-#: schematic/src/x_autonumber.c:1214
 msgid "Autonumber text"
 msgstr "Texto de auto-numeração"
 
-#: schematic/src/x_autonumber.c:1237
 msgid "<b>Scope</b>"
 msgstr "<b>Âmbito</b>"
 
-#: schematic/src/x_autonumber.c:1259
 msgid "Search for:"
 msgstr "Procurar por:"
 
-#: schematic/src/x_autonumber.c:1273
 msgid "Autonumber text in:"
 msgstr "Texto de auto-numeração em:"
 
-#: schematic/src/x_autonumber.c:1280
 msgid "Skip numbers found in:"
 msgstr "Ignorar números encontrados em:"
 
-#: schematic/src/x_autonumber.c:1292 schematic/src/x_autonumber.c:1301
 msgid "Selected objects"
 msgstr "Objectos seleccionados"
 
-#: schematic/src/x_autonumber.c:1293 schematic/src/x_autonumber.c:1302
 msgid "Current page"
 msgstr "Página actual"
 
-#: schematic/src/x_autonumber.c:1294 schematic/src/x_autonumber.c:1303
 msgid "Whole hierarchy"
 msgstr "Hierarquia inteira"
 
-#: schematic/src/x_autonumber.c:1305
 msgid "Overwrite existing numbers"
 msgstr "Reescrever números existentes"
 
-#: schematic/src/x_autonumber.c:1310
 msgid "<b>Options</b>"
 msgstr "<b>Opções</b>"
 
-#: schematic/src/x_autonumber.c:1332
 msgid "Starting number:"
 msgstr "Numero inicial:"
 
-#: schematic/src/x_autonumber.c:1339
 msgid "Sort order:"
 msgstr "Ordenação:"
 
-#: schematic/src/x_autonumber.c:1371
 msgid "Remove numbers"
 msgstr "Retirar números"
 
-#: schematic/src/x_autonumber.c:1375
 msgid "Automatic slotting"
 msgstr "Atribuição automática"
 
-#: schematic/src/x_clipboard.c:245
 #, c-format
 msgid ""
 "<b>Invalid schematic on clipboard.</b>\n"
@@ -1561,175 +1214,135 @@ msgid ""
 "An error occurred while inserting clipboard data: %s."
 msgstr ""
 
-#: schematic/src/x_clipboard.c:247
 msgid "Clipboard insertion failed"
 msgstr ""
 
-#: schematic/src/x_color.c:89 schematic/src/x_color.c:98
 #, fuzzy, c-format
 msgid "Could not allocate the color %1$s!\n"
 msgstr "Não foi possível atribuir a cor %s!\n"
 
-#: schematic/src/x_color.c:89
 msgid "black"
 msgstr "preto"
 
-#: schematic/src/x_color.c:98
 msgid "white"
 msgstr "branco"
 
-#: schematic/src/x_color.c:120
 #, fuzzy, c-format
 msgid "Could not allocate display color %1$i!\n"
 msgstr "Não foi possível atribuir cor do ecran %i!\n"
 
-#: schematic/src/x_color.c:142
 #, fuzzy, c-format
 msgid "Could not allocate outline color %1$i!\n"
 msgstr "Não foi possível atribuir cor do contorno %i!\n"
 
-#: schematic/src/x_color.c:159
 #, fuzzy, c-format
 msgid "Tried to get an invalid color: %1$d\n"
 msgstr "Tentou obter uma cor inválida: %d\n"
 
-#: schematic/src/x_colorcb.c:145
 msgid "Background"
 msgstr "Plano de fundo"
 
-#: schematic/src/x_colorcb.c:147
 msgid "Net endpoint"
 msgstr "Destino da ligação"
 
-#: schematic/src/x_colorcb.c:148
 msgid "Graphic"
 msgstr "Gráficos"
 
-#: schematic/src/x_colorcb.c:151
 msgid "Logic bubble"
 msgstr "Negação lógica"
 
-#: schematic/src/x_colorcb.c:152
 msgid "Grid point"
 msgstr "Ponto da grelha"
 
-#: schematic/src/x_colorcb.c:153
 #, fuzzy
 msgid "Detached attribute"
 msgstr "Atributo Removido"
 
-#: schematic/src/x_colorcb.c:156
 msgid "Selection"
 msgstr "Selecção"
 
-#: schematic/src/x_colorcb.c:157
 msgid "Bounding box"
 msgstr "Caixa de contorno"
 
-#: schematic/src/x_colorcb.c:158
 msgid "Zoom box"
 msgstr "Zona de ampliação"
 
-#: schematic/src/x_colorcb.c:161
 msgid "Output background"
 msgstr "Imagem de fundo de saída"
 
-#: schematic/src/x_colorcb.c:162
 msgid "Freestyle 1"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:163
 msgid "Freestyle 2"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:164
 msgid "Freestyle 3"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:165
 msgid "Freestyle 4"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:166
 msgid "Net junction"
 msgstr "Junção da ligação"
 
-#: schematic/src/x_colorcb.c:167
 msgid "Mesh grid major"
 msgstr "Grelha de malha maior"
 
-#: schematic/src/x_colorcb.c:168
 msgid "Mesh grid minor"
 msgstr "Grelha de malha menor"
 
-#: schematic/src/x_colorcb.c:172
 msgid "Unknown"
 msgstr "Desconhecido"
 
-#: schematic/src/x_compselect.c:1169
 #, fuzzy
 msgid "Reset filter"
 msgstr "Novo ficheiro"
 
-#: schematic/src/x_compselect.c:1192
 msgid "Reload all libraries"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1245 schematic/src/x_multiattrib.c:2092
 msgid "Value"
 msgstr "Valor"
 
-#: schematic/src/x_compselect.c:1284
 msgid "Default behavior - reference component"
 msgstr "Comportamento padrão - componente de referência"
 
-#: schematic/src/x_compselect.c:1287
 msgid "Embed component in schematic"
 msgstr "Embutir componente no esquema"
 
-#: schematic/src/x_compselect.c:1290
 msgid "Include component as individual objects"
 msgstr "Inclua componentes como objectos individuais"
 
-#: schematic/src/x_compselect.c:1448
 msgid "Select Component..."
 msgstr "Seleccione Componente..."
 
-#: schematic/src/x_compselect.c:1471
 #, fuzzy
 msgid "In Us_e"
 msgstr "Em Uso"
 
-#: schematic/src/x_compselect.c:1475
 #, fuzzy
 msgid "Lib_raries"
 msgstr "Bibliotecas"
 
-#: schematic/src/x_compselect.c:1484 schematic/src/x_fileselect.c:119
 msgid "Preview"
 msgstr "Pré-visualizar"
 
-#: schematic/src/x_compselect.c:1510
 msgid "Attributes"
 msgstr "Atributos"
 
-#: schematic/src/x_dialog.c:325
 msgid "Major symbol changes detected."
 msgstr ""
 
-#: schematic/src/x_dialog.c:349
 msgid ""
 "Changes have occurred to the symbols shown below.\n"
 "\n"
 "Be sure to verify each of these symbols."
 msgstr ""
 
-#: schematic/src/x_dialog.c:369
 #, fuzzy
 msgid "Symbol"
 msgstr "Símbolos"
 
-#: schematic/src/x_dialog.c:406
 #, c-format
 msgid ""
 "<span weight=\"bold\" size=\"larger\">The input attribute \"%s\" is invalid\n"
@@ -1747,40 +1360,31 @@ msgstr ""
 "O nome não pode terminar com um espaço.\n"
 "O valor não pode começar com um espaço."
 
-#: schematic/src/x_dialog.c:408
 msgid "Invalid Attribute"
 msgstr "Atributo Inválido"
 
-#: schematic/src/x_fileselect.c:37
 msgid "Schematics"
 msgstr "Esquemas"
 
-#: schematic/src/x_fileselect.c:42
 msgid "Symbols"
 msgstr "Símbolos"
 
-#: schematic/src/x_fileselect.c:47
 msgid "Schematics and symbols"
 msgstr "Esquemas e símbolos"
 
-#: schematic/src/x_fileselect.c:53
 msgid "All files"
 msgstr "Todos os ficheiros"
 
-#: schematic/src/x_fileselect.c:169
 msgid "Open..."
 msgstr "Abrir..."
 
-#: schematic/src/x_fileselect.c:233
 msgid "Save as..."
 msgstr "Gravar como..."
 
-#: schematic/src/x_fileselect.c:297
 #, fuzzy
 msgid "Save cancelled on user request"
 msgstr "Gravação cancelada a pedido do utilizador\n"
 
-#: schematic/src/x_fileselect.c:334
 msgid ""
 "\n"
 "If you load the original file, the backup file will be overwritten in the "
@@ -1789,28 +1393,22 @@ msgid ""
 "Do you want to load the backup file?\n"
 msgstr ""
 
-#: schematic/src/x_fstylecb.c:73
 msgid "Hollow"
 msgstr "Oco"
 
-#: schematic/src/x_fstylecb.c:80
 msgid "Filled"
 msgstr "Preenchido"
 
-#: schematic/src/x_fstylecb.c:87
 msgid "Mesh"
 msgstr "Malha"
 
-#: schematic/src/x_fstylecb.c:94
 msgid "Hatch"
 msgstr "Escotilha"
 
-#: schematic/src/x_image.c:279
 #, fuzzy, c-format
 msgid "x_image_lowlevel: Unable to write %1$s file %2$s."
 msgstr "x_image_lowlevel: Não foi possível escrever %s no ficheiro %s.\n"
 
-#: schematic/src/x_image.c:289
 #, fuzzy, c-format
 msgid ""
 "There was the following error when saving image with type %1$s to filename:\n"
@@ -1824,311 +1422,244 @@ msgstr ""
 "\n"
 "%s.\n"
 
-#: schematic/src/x_image.c:309
 #, fuzzy, c-format
 msgid "Wrote color image to [%1$s] [%2$d x %3$d]"
 msgstr "Escreveu-se imagem a cores em [%s] [%d x %d]\n"
 
-#: schematic/src/x_image.c:311
 #, fuzzy, c-format
 msgid "Wrote black and white image to [%1$s] [%2$d x %3$d]"
 msgstr "Escreveu-se imagem a preto e branco em [%s] [%d x %d]\n"
 
-#: schematic/src/x_image.c:319
 #, fuzzy
 msgid "x_image_lowlevel: Unable to get pixbuf from gschem's window."
 msgstr ""
 "x_image_lowlevel: Não foi possível obter mapa de bits a partir janela do "
 "gschem.\n"
 
-#: schematic/src/x_image.c:358
 msgid "Width x Height"
 msgstr "Largura x Altura"
 
-#: schematic/src/x_image.c:374
 msgid "Image type"
 msgstr "Tipo de imagem"
 
-#: schematic/src/x_image.c:395
 msgid "Write image..."
 msgstr "Escrever Imagem..."
 
-#: schematic/src/x_linecapcb.c:74
 msgid "Butt"
 msgstr ""
 
-#: schematic/src/x_linecapcb.c:81
 msgid "Square"
 msgstr ""
 
-#: schematic/src/x_linecapcb.c:88
 msgid "Round"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:74
 msgid "Solid"
 msgstr "Solido"
 
-#: schematic/src/x_linetypecb.c:81
 msgid "Dotted"
 msgstr "Tracejado"
 
-#: schematic/src/x_linetypecb.c:88
 msgid "Dashed"
 msgstr "Tracejado"
 
-#: schematic/src/x_linetypecb.c:95
 msgid "Center"
 msgstr "Centrado"
 
-#: schematic/src/x_linetypecb.c:102
 msgid "Phantom"
 msgstr "Fantasma"
 
-#: schematic/src/x_menus.c:41 schematic/scheme/gschem/builtins.scm:267
 #, fuzzy
 msgid "Add Net"
 msgstr "/Adicionar Ligação"
 
-#: schematic/src/x_menus.c:42 schematic/src/x_multiattrib.c:2187
-#: schematic/scheme/gschem/builtins.scm:264
 msgid "Add Attribute"
 msgstr "Adicionar Atributo"
 
-#: schematic/src/x_menus.c:43 schematic/scheme/gschem/builtins.scm:261
 #, fuzzy
 msgid "Add Component"
 msgstr "/Adicionar Componente..."
 
-#: schematic/src/x_menus.c:44 schematic/scheme/gschem/builtins.scm:270
 #, fuzzy
 msgid "Add Bus"
 msgstr "/Adicionar Barramento"
 
-#: schematic/src/x_menus.c:45 schematic/scheme/gschem/builtins.scm:273
 #, fuzzy
 msgid "Add Text"
 msgstr "/Adicionar Texto"
 
-#: schematic/src/x_menus.c:47 schematic/scheme/gschem/builtins.scm:210
 #, fuzzy
 msgid "Zoom In"
 msgstr "/Ampliar"
 
-#: schematic/src/x_menus.c:48 schematic/scheme/gschem/builtins.scm:213
 #, fuzzy
 msgid "Zoom Out"
 msgstr "/Diminuir"
 
-#: schematic/src/x_menus.c:50 schematic/scheme/gschem/builtins.scm:207
 #, fuzzy
 msgid "Zoom Extents"
 msgstr "/Mostrar Tudo"
 
-#: schematic/src/x_menus.c:52 schematic/src/x_window.c:1233
 msgid "Select"
 msgstr "Seleccionar"
 
-#: schematic/src/x_menus.c:53 schematic/scheme/conf/schematic/menu.scm:69
-#: schematic/scheme/gschem/builtins.scm:126
 msgid "Edit..."
 msgstr "Editar..."
 
-#: schematic/src/x_menus.c:54 schematic/scheme/conf/schematic/menu.scm:68
 #, fuzzy
 msgid "Object Properties..."
 msgstr "<b>Propriedades do Texto</b>"
 
-#: schematic/src/x_menus.c:59 schematic/scheme/gschem/builtins.scm:300
 #, fuzzy
 msgid "Down Schematic"
 msgstr "/Baixar Esquema"
 
-#: schematic/src/x_menus.c:60 schematic/scheme/gschem/builtins.scm:303
 #, fuzzy
 msgid "Down Symbol"
 msgstr "/Baixar Símbolo"
 
-#: schematic/src/x_menus.c:61
 #, fuzzy
 msgid "Up"
 msgstr "/Acima"
 
-#: schematic/src/x_menus.c:336
 #, fuzzy, c-format
 msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
 msgstr "Tentou-se definir a sensibilidade num menu_item não existente '%s'\n"
 
-#: schematic/src/x_menus.c:360
 #, c-format
 msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
 msgstr "Tentou-se definir a sensibilidade num menu_item não existente '%s'\n"
 
-#: schematic/src/x_misc.c:70
 msgid "The operating system is out of memory or resources."
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:798 schematic/src/x_multiattrib.c:2704
 msgid "<various>"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:930
 msgid "Attributes with empty name are not allowed. Please set a name."
 msgstr ""
 "Atributos com nome sem conteúdo não são permitidos. Por favor defina um nome."
 
-#: schematic/src/x_multiattrib.c:1622
 msgid "Show Value only"
 msgstr "Mostrar Valor apenas"
 
-#: schematic/src/x_multiattrib.c:1624
 msgid "Show Name only"
 msgstr "Mostrar Nome Apenas"
 
-#: schematic/src/x_multiattrib.c:1651
 msgid "Promote"
 msgstr "Promover"
 
-#: schematic/src/x_multiattrib.c:1655
 msgid "Duplicate"
 msgstr "Duplicar"
 
-#: schematic/src/x_multiattrib.c:1657
 #, fuzzy
 msgid "Copy to all"
 msgstr "Copiar para 1"
 
-#: schematic/src/x_multiattrib.c:1986 schematic/src/x_multiattrib.c:2602
 msgid "Edit Attributes"
 msgstr "Editar Atributos"
 
-#: schematic/src/x_multiattrib.c:2112
 msgid "Vis?"
 msgstr "Visivel?"
 
-#: schematic/src/x_multiattrib.c:2130
 msgid "N"
 msgstr "N"
 
-#: schematic/src/x_multiattrib.c:2148
 msgid "V"
 msgstr "V"
 
-#: schematic/src/x_multiattrib.c:2170
 #, fuzzy
 msgid "Sho_w inherited attributes"
 msgstr "Mostrar atributos inerentes"
 
-#: schematic/src/x_multiattrib.c:2197
 #, fuzzy
 msgid "_Name:"
 msgstr "Nome:"
 
-#: schematic/src/x_multiattrib.c:2241
 msgid "Ctrl+Enter inserts new line; Ctrl+Tab inserts Tab"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2618
 #, c-format
 msgid "%2$i symbol (%1$s)"
 msgid_plural "%2$i symbols (%1$s)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2624
 #, fuzzy, c-format
 msgid "%1$i pin"
 msgid_plural "%1$i pins"
 msgstr[0] "Pino de Ligação"
 msgstr[1] "Pino de Ligação"
 
-#: schematic/src/x_multiattrib.c:2630
 #, c-format
 msgid "%1$i net"
 msgid_plural "%1$i nets"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2636
 #, c-format
 msgid "%1$i bus"
 msgid_plural "%1$i buses"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2642
 #, fuzzy, c-format
 msgid "%1$i attribute"
 msgid_plural "%1$i attributes"
 msgstr[0] "Atributo"
 msgstr[1] "Atributo"
 
-#: schematic/src/x_newtext.c:433
 msgid "Text Entry..."
 msgstr "Entrada de Texto..."
 
-#: schematic/src/x_pagesel.c:253
 msgid "New Page"
 msgstr "Nova Página"
 
-#: schematic/src/x_pagesel.c:254
 msgid "Open Page..."
 msgstr "Abrir Página..."
 
-#: schematic/src/x_pagesel.c:256
 msgid "Save Page"
 msgstr "Guardar Página"
 
-#: schematic/src/x_pagesel.c:257 schematic/scheme/gschem/builtins.scm:246
 msgid "Close Page"
 msgstr "Fechar Página"
 
-#: schematic/src/x_pagesel.c:376 schematic/scheme/gschem/builtins.scm:237
 msgid "Page Manager"
 msgstr "Gestor de Pagina"
 
-#: schematic/src/x_pagesel.c:448
 msgid "Changed"
 msgstr "Alterado"
 
-#: schematic/src/x_pagesel.c:468
 msgid "Right click on the filename for more options..."
 msgstr "Use o botão direito sobre o nome do ficheiro para mais opções..."
 
-#: schematic/src/x_print.c:306
 #, fuzzy, c-format
 msgid "Failed to write PDF to '%s': %s\n"
 msgstr "Falha ao ler ficheiro de inicialização scm [%s]\n"
 
-#: schematic/src/x_print.c:364
 #, fuzzy, c-format
 msgid "Failed to write PDF to '%1$s': %2$s\n"
 msgstr "Falha ao ler ficheiro de inicialização scm [%s]\n"
 
-#: schematic/src/x_print.c:449
 #, c-format
 msgid ""
 "Error printing file:\n"
 "%1$s"
 msgstr ""
 
-#: schematic/src/x_rc.c:39
 msgid "ERROR: An unknown error occurred while parsing configuration files."
 msgstr ""
 
-#: schematic/src/x_rc.c:44
 msgid ""
 "An unknown error occurred while parsing configuration files.\n"
 "\n"
 "The lepton-schematic log may contain more information."
 msgstr ""
 
-#: schematic/src/x_rc.c:56
 #, c-format
 msgid "ERROR: %1$s"
 msgstr ""
 
-#: schematic/src/x_rc.c:59
 #, c-format
 msgid ""
 "%1$s\n"
@@ -2136,141 +1667,110 @@ msgid ""
 "The lepton-schematic log may contain more information."
 msgstr ""
 
-#: schematic/src/x_rc.c:67
 msgid "Cannot load lepton-schematic configuration."
 msgstr ""
 
-#: schematic/src/x_script.c:42 schematic/scheme/conf/schematic/menu.scm:40
 msgid "Execute Script..."
 msgstr "Executar Script..."
 
-#: schematic/src/x_script.c:61
 #, fuzzy, c-format
 msgid "Executing guile script [%1$s]"
 msgstr "A executar script guile [%s]\n"
 
-#: schematic/src/x_tabs.c:860
 #, fuzzy, c-format
 msgid "Hierarchy up: %s"
 msgstr "Hie_rarquia"
 
-#: schematic/src/x_tabs.c:863
 #, fuzzy
 msgid "Hierarchy up"
 msgstr "Hie_rarquia"
 
-#: schematic/src/x_widgets.c:158 schematic/src/x_window.c:1444
 #, fuzzy
 msgid "Options"
 msgstr "_Opções"
 
-#: schematic/src/x_widgets.c:203 schematic/src/x_window.c:1436
 #, fuzzy
 msgid "Object"
 msgstr "Cor do Objecto:"
 
-#: schematic/src/x_widgets.c:224
 msgid "Log"
 msgstr ""
 
-#: schematic/src/x_widgets.c:245 schematic/src/x_window.c:1466
 msgid "Find Text"
 msgstr "Procurar Texto"
 
-#: schematic/src/x_widgets.c:259
 #, fuzzy
 msgid "Color Scheme Editor"
 msgstr "Esquema C_laro de Cor"
 
-#: schematic/src/x_widgets.c:272 schematic/scheme/gschem/builtins.scm:378
 #, fuzzy
 msgid "Select Schematic Font"
 msgstr "S_eleccione os esquemas que quer gravar:"
 
-#: schematic/src/x_window.c:763
 #, fuzzy, c-format
 msgid "Loading schematic [%1$s]"
 msgstr "A carregar esquema [%s]\n"
 
-#: schematic/src/x_window.c:864
 #, fuzzy, c-format
 msgid "Could NOT save page [%1$s]\n"
 msgstr "NÃO foi possível gravar pagina [%s]\n"
 
-#: schematic/src/x_window.c:865
 msgid "Error while trying to save"
 msgstr "Erro ao tentar gravar"
 
-#: schematic/src/x_window.c:875
 msgid "Failed to save file"
 msgstr ""
 
-#: schematic/src/x_window.c:885
 #, fuzzy, c-format
 msgid "Saved as [%1$s]"
 msgstr "Gravado como [%s]\n"
 
-#: schematic/src/x_window.c:887
 #, fuzzy, c-format
 msgid "Saved [%1$s]"
 msgstr "Guardado [%s]\n"
 
-#: schematic/src/x_window.c:889
 msgid "Saved"
 msgstr "Guardado"
 
-#: schematic/src/x_window.c:966
 #, fuzzy, c-format
 msgid "Discarding page [%1$s]"
 msgstr "A anular página [%s]\n"
 
-#: schematic/src/x_window.c:966
 #, fuzzy, c-format
 msgid "Closing [%1$s]"
 msgstr "A Fechar [%s]\n"
 
-#: schematic/src/x_window.c:1175
 msgid "New"
 msgstr "Novo"
 
-#: schematic/src/x_window.c:1175
 msgid "New file"
 msgstr "Novo ficheiro"
 
-#: schematic/src/x_window.c:1179
 msgid "Open"
 msgstr "Abrir"
 
-#: schematic/src/x_window.c:1179
 #, fuzzy
 msgid "Open file"
 msgstr "Abrir ficheiro..."
 
-#: schematic/src/x_window.c:1183 schematic/scheme/gschem/builtins.scm:59
 msgid "Save"
 msgstr "Gravar"
 
-#: schematic/src/x_window.c:1183
 msgid "Save file"
 msgstr "Gravar ficheiro"
 
-#: schematic/src/x_window.c:1189 schematic/scheme/gschem/builtins.scm:93
 msgid "Undo"
 msgstr "Anular"
 
-#: schematic/src/x_window.c:1189
 msgid "Undo last operation"
 msgstr "Desfazer a ultima operação"
 
-#: schematic/src/x_window.c:1193 schematic/scheme/gschem/builtins.scm:96
 msgid "Redo"
 msgstr "Repetir"
 
-#: schematic/src/x_window.c:1193
 msgid "Redo last undo"
 msgstr "Refazer a ultima anulação"
 
-#: schematic/src/x_window.c:1198
 msgid ""
 "Add component...\n"
 "Select library and component from list, move the mouse into main window, "
@@ -2282,7 +1782,6 @@ msgstr ""
 "principal, pressione para colocar\n"
 "Use botão direito do rato para cancelar"
 
-#: schematic/src/x_window.c:1209
 msgid ""
 "Add nets mode\n"
 "Right mouse button to cancel"
@@ -2290,7 +1789,6 @@ msgstr ""
 "Modo de adição de ligações\n"
 "Use botão direito do rato para cancelar"
 
-#: schematic/src/x_window.c:1217
 msgid ""
 "Add buses mode\n"
 "Right mouse button to cancel"
@@ -2298,45 +1796,35 @@ msgstr ""
 "Modo de adição de barramentos\n"
 "Use botão direito do rato para cancelar"
 
-#: schematic/src/x_window.c:1226
 msgid "Add Text..."
 msgstr "Adicionar Texto..."
 
-#: schematic/src/x_window.c:1233
 msgid "Select mode"
 msgstr "Seleccionar modo"
 
-#: schematic/src/x_window.c:1288
 #, fuzzy
 msgid "Show"
 msgstr "Mostrar Nome"
 
-#: schematic/src/x_window.c:1289
 msgid "Show text starting with:"
 msgstr "Mostrar texto que comece por:"
 
-#: schematic/src/x_window.c:1345
 msgid "Menu/Cancel"
 msgstr "Menu/Cancelar"
 
-#: schematic/src/x_window.c:1349
 msgid "Pan/Cancel"
 msgstr "Panorâmica/Cancelar"
 
-#: schematic/src/x_window.c:1359
 msgid "Pick"
 msgstr "Escolher"
 
-#: schematic/src/x_window.c:1470 schematic/scheme/gschem/builtins.scm:180
 msgid "Status"
 msgstr "Estado"
 
-#: schematic/src/x_window.c:1568
 #, fuzzy, c-format
 msgid "New file [%s]"
 msgstr "Novo ficheiro [%s]\n"
 
-#: schematic/src/x_window.c:1598
 #, c-format
 msgid ""
 "<b>An error occurred while loading the requested file.</b>\n"
@@ -2350,902 +1838,692 @@ msgid ""
 "monitor program's output in terminal window."
 msgstr ""
 
-#: schematic/src/x_window.c:1617
 msgid "Failed to load file"
 msgstr "Falha ao carregar ficheiro"
 
-#: schematic/data/lepton-schematic.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Schematic Editor"
 msgstr "gEDA - Editor Esquemático"
 
-#: schematic/data/lepton-schematic.desktop.in:4
 #, fuzzy
 msgid "Create and edit electrical schematics and symbols with lepton-schematic"
 msgstr "Crie e edite esquemas e símbolos eléctricos e electrónicos com gschem"
 
-#: schematic/scheme/conf/schematic/menu.scm:27
 msgid "_New"
 msgstr "_Novo"
 
-#: schematic/scheme/conf/schematic/menu.scm:28
 msgid "_Open..."
 msgstr "_Abrir..."
 
-#: schematic/scheme/conf/schematic/menu.scm:30
 msgid "Open Recen_t"
 msgstr "Abrir Recen_te"
 
-#: schematic/scheme/conf/schematic/menu.scm:32
 msgid "_Save"
 msgstr "_Guardar"
 
-#: schematic/scheme/conf/schematic/menu.scm:33
 msgid "Save _As..."
 msgstr "Gu_ardar como..."
 
-#: schematic/scheme/conf/schematic/menu.scm:34
-#: schematic/scheme/gschem/builtins.scm:65
 msgid "Save All"
 msgstr "Guardar Tudo"
 
-#: schematic/scheme/conf/schematic/menu.scm:36
 msgid "_Print..."
 msgstr "Im_primir..."
 
-#: schematic/scheme/conf/schematic/menu.scm:37
 #, fuzzy
 msgid "Write _Image..."
 msgstr "Escrever _imagem..."
 
-#: schematic/scheme/conf/schematic/menu.scm:39
 #, fuzzy
 msgid "Invoke Macro..."
 msgstr "Chamar Macro"
 
-#: schematic/scheme/conf/schematic/menu.scm:41
 msgid "REPL..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:43
-#: schematic/scheme/gschem/builtins.scm:77
 msgid "New Window"
 msgstr "Nova Janela"
 
-#: schematic/scheme/conf/schematic/menu.scm:44
 msgid "_Close Window"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:45
 msgid "_Quit"
 msgstr "_Sair"
 
-#: schematic/scheme/conf/schematic/menu.scm:51
 msgid "_Undo"
 msgstr "_Desfazer"
 
-#: schematic/scheme/conf/schematic/menu.scm:52
 msgid "_Redo"
 msgstr "_Refazer"
 
-#: schematic/scheme/conf/schematic/menu.scm:54
 msgid "Cu_t"
 msgstr "Cor_tar"
 
-#: schematic/scheme/conf/schematic/menu.scm:55
 msgid "_Copy"
 msgstr "_Copiar"
 
-#: schematic/scheme/conf/schematic/menu.scm:56
 msgid "_Paste"
 msgstr "C_olar"
 
-#: schematic/scheme/conf/schematic/menu.scm:57
 msgid "_Delete"
 msgstr "_Eliminar"
 
-#: schematic/scheme/conf/schematic/menu.scm:60
-#: schematic/scheme/gschem/builtins.scm:102
 msgid "Select All"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:61
-#: schematic/scheme/gschem/builtins.scm:105
 msgid "Deselect"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:65
 msgid "Rotate 90 Mode"
 msgstr "Modo rotação 90"
 
-#: schematic/scheme/conf/schematic/menu.scm:70
 msgid "Edit Text..."
 msgstr "Editar Texto..."
 
-#: schematic/scheme/conf/schematic/menu.scm:71
 msgid "Slot..."
 msgstr "Elemento..."
 
-#: schematic/scheme/conf/schematic/menu.scm:76
-#: schematic/scheme/gschem/builtins.scm:150
 msgid "Embed Component/Picture"
 msgstr "Componente/Imagem Embutida"
 
-#: schematic/scheme/conf/schematic/menu.scm:77
-#: schematic/scheme/gschem/builtins.scm:153
 msgid "Unembed Component/Picture"
 msgstr "Remover Componente/Imagem"
 
-#: schematic/scheme/conf/schematic/menu.scm:78
-#: schematic/scheme/gschem/builtins.scm:156
 msgid "Update Component"
 msgstr "Actualizar Componente"
 
-#: schematic/scheme/conf/schematic/menu.scm:79
 msgid "Symbol Translate..."
 msgstr "Traduzir Símbolo..."
 
-#: schematic/scheme/conf/schematic/menu.scm:85
 msgid "Copy into 1"
 msgstr "Copiar para 1"
 
-#: schematic/scheme/conf/schematic/menu.scm:86
 msgid "Copy into 2"
 msgstr "Copiar para 2"
 
-#: schematic/scheme/conf/schematic/menu.scm:87
 msgid "Copy into 3"
 msgstr "Copiar para 3"
 
-#: schematic/scheme/conf/schematic/menu.scm:88
 msgid "Copy into 4"
 msgstr "Copiar para 4"
 
-#: schematic/scheme/conf/schematic/menu.scm:89
 msgid "Copy into 5"
 msgstr "Copiar para 5"
 
-#: schematic/scheme/conf/schematic/menu.scm:90
 msgid "Cut into 1"
 msgstr "Cortar para 1"
 
-#: schematic/scheme/conf/schematic/menu.scm:91
 msgid "Cut into 2"
 msgstr "Cortar para 2"
 
-#: schematic/scheme/conf/schematic/menu.scm:92
 msgid "Cut into 3"
 msgstr "Cortar para 3"
 
-#: schematic/scheme/conf/schematic/menu.scm:93
 msgid "Cut into 4"
 msgstr "Cortar para 4"
 
-#: schematic/scheme/conf/schematic/menu.scm:94
 msgid "Cut into 5"
 msgstr "Cortar para 5"
 
-#: schematic/scheme/conf/schematic/menu.scm:95
 msgid "Paste from 1"
 msgstr "Colar de 1"
 
-#: schematic/scheme/conf/schematic/menu.scm:96
 msgid "Paste from 2"
 msgstr "Colar de 2"
 
-#: schematic/scheme/conf/schematic/menu.scm:97
 msgid "Paste from 3"
 msgstr "Colar de 3"
 
-#: schematic/scheme/conf/schematic/menu.scm:98
 msgid "Paste from 4"
 msgstr "Colar de 4"
 
-#: schematic/scheme/conf/schematic/menu.scm:99
 msgid "Paste from 5"
 msgstr "Colar de 5"
 
-#: schematic/scheme/conf/schematic/menu.scm:105
 msgid "Side Dock"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:106
 #, fuzzy
 msgid "Bottom Dock"
 msgstr "De baixo para cima"
 
-#: schematic/scheme/conf/schematic/menu.scm:108
 #, fuzzy
 msgid "Find Text Results"
 msgstr "Procurar Texto"
 
-#: schematic/scheme/conf/schematic/menu.scm:110
 msgid "_Redraw"
 msgstr "Re_desenhar"
 
-#: schematic/scheme/conf/schematic/menu.scm:111
 msgid "_Pan"
 msgstr "Centrar no _Cursor"
 
-#: schematic/scheme/conf/schematic/menu.scm:112
 msgid "Zoom _Box"
 msgstr "Ampliar _Zona"
 
-#: schematic/scheme/conf/schematic/menu.scm:113
 msgid "Zoom _Extents"
 msgstr "Mostrar _Tudo"
 
-#: schematic/scheme/conf/schematic/menu.scm:114
 msgid "Zoom _In"
 msgstr "_Ampliar"
 
-#: schematic/scheme/conf/schematic/menu.scm:115
 msgid "Zoom _Out"
 msgstr "_Reduzir"
 
-#: schematic/scheme/conf/schematic/menu.scm:116
 msgid "Zoom _Full"
 msgstr "_Ver tudo"
 
-#: schematic/scheme/conf/schematic/menu.scm:118
 #, fuzzy
 msgid "_Dark Color Scheme"
 msgstr "Esquema _Escuro de Cor"
 
-#: schematic/scheme/conf/schematic/menu.scm:119
 #, fuzzy
 msgid "_Light Color Scheme"
 msgstr "Esquema C_laro de Cor"
 
-#: schematic/scheme/conf/schematic/menu.scm:120
 #, fuzzy
 msgid "B_W Color Scheme"
 msgstr "Esquema _Escuro de Cor"
 
-#: schematic/scheme/conf/schematic/menu.scm:122
 #, fuzzy
 msgid "Color Scheme Editor..."
 msgstr "Esquema C_laro de Cor"
 
-#: schematic/scheme/conf/schematic/menu.scm:129
 msgid "_Manager..."
 msgstr "_Gerente..."
 
-#: schematic/scheme/conf/schematic/menu.scm:131
 msgid "_Previous"
 msgstr "_Anterior"
 
-#: schematic/scheme/conf/schematic/menu.scm:132
 msgid "_Next"
 msgstr "_Seguinte"
 
-#: schematic/scheme/conf/schematic/menu.scm:133
 msgid "_Close"
 msgstr "Fe_char"
 
-#: schematic/scheme/conf/schematic/menu.scm:135
 #, fuzzy
 msgid "_Revert..."
 msgstr "_Reverter"
 
-#: schematic/scheme/conf/schematic/menu.scm:137
-#: schematic/scheme/gschem/builtins.scm:249
 #, fuzzy
 msgid "Next Tab"
 msgstr "Nova Página"
 
-#: schematic/scheme/conf/schematic/menu.scm:138
-#: schematic/scheme/gschem/builtins.scm:252
 #, fuzzy
 msgid "Previous Tab"
 msgstr "_Anterior"
 
-#: schematic/scheme/conf/schematic/menu.scm:146
 msgid "_Component..."
 msgstr "_Componente"
 
-#: schematic/scheme/conf/schematic/menu.scm:148
 msgid "_Net"
 msgstr "_Ligação"
 
-#: schematic/scheme/conf/schematic/menu.scm:149
 msgid "B_us"
 msgstr "_Barramento"
 
-#: schematic/scheme/conf/schematic/menu.scm:151
 msgid "_Attribute..."
 msgstr "_Atributo"
 
-#: schematic/scheme/conf/schematic/menu.scm:152
 msgid "_Text..."
 msgstr "_Texto..."
 
-#: schematic/scheme/conf/schematic/menu.scm:154
 msgid "_Line"
 msgstr "Li_nha"
 
-#: schematic/scheme/conf/schematic/menu.scm:155
 msgid "Pat_h"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:156
 msgid "_Box"
 msgstr "Rectân_gulo"
 
-#: schematic/scheme/conf/schematic/menu.scm:157
 msgid "C_ircle"
 msgstr "Círc_ulo"
 
-#: schematic/scheme/conf/schematic/menu.scm:158
 msgid "A_rc"
 msgstr "A_rco"
 
-#: schematic/scheme/conf/schematic/menu.scm:159
 msgid "_Pin"
 msgstr "_Pino"
 
-#: schematic/scheme/conf/schematic/menu.scm:161
 msgid "Pictu_re..."
 msgstr "_Imagem"
 
-#: schematic/scheme/conf/schematic/menu.scm:167
 msgid "_Up"
 msgstr "_Acima"
 
-#: schematic/scheme/conf/schematic/menu.scm:169
 msgid "_Down Schematic"
 msgstr "_Descender no Esquema"
 
-#: schematic/scheme/conf/schematic/menu.scm:170
 msgid "Down _Symbol"
 msgstr "Descender no _Símbolo"
 
-#: schematic/scheme/conf/schematic/menu.scm:176
 msgid "_Attach"
 msgstr "_Anexar"
 
-#: schematic/scheme/conf/schematic/menu.scm:177
 msgid "_Detach"
 msgstr "_Retirar"
 
-#: schematic/scheme/conf/schematic/menu.scm:179
 msgid "Show _Value"
 msgstr "Mostrar _Valor"
 
-#: schematic/scheme/conf/schematic/menu.scm:180
 msgid "Show _Name"
 msgstr "Mostrar _Nome"
 
-#: schematic/scheme/conf/schematic/menu.scm:181
 msgid "Show _Both"
 msgstr "_Mostrar Ambos"
 
-#: schematic/scheme/conf/schematic/menu.scm:182
 msgid "_Toggle Visibility"
 msgstr "Al_ternar Visibilidade"
 
-#: schematic/scheme/conf/schematic/menu.scm:184
 msgid "_Hide Specific Text..."
 msgstr "_Esconder Texto Específico..."
 
-#: schematic/scheme/conf/schematic/menu.scm:185
 msgid "_Show Specific Text..."
 msgstr "_Mostrar Texto Específico"
 
-#: schematic/scheme/conf/schematic/menu.scm:186
 #, fuzzy
 msgid "Show/Hide Hidden Text"
 msgstr "Mostrar/Esconder Texto Escondido"
 
-#: schematic/scheme/conf/schematic/menu.scm:188
 msgid "_Find Text/Check Symbol..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:189
 msgid "A_utonumber Text..."
 msgstr "Auton_umerar texto"
 
-#: schematic/scheme/conf/schematic/menu.scm:195
 #, fuzzy
 msgid "_Options..."
 msgstr "_Opções"
 
-#: schematic/scheme/conf/schematic/menu.scm:196
 #, fuzzy
 msgid "_Font..."
 msgstr "Im_primir..."
 
-#: schematic/scheme/conf/schematic/menu.scm:198
 #, fuzzy
 msgid "Grid +"
 msgstr "Grelha Desligada\n"
 
-#: schematic/scheme/conf/schematic/menu.scm:199
 #, fuzzy
 msgid "Grid -"
 msgstr "Grelha Desligada\n"
 
-#: schematic/scheme/conf/schematic/menu.scm:201
 msgid "Grid Style: Cycle Dots/Mesh/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:202
 msgid "Grid Snap: Cycle Grid/Resnap/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:204
 #, fuzzy
 msgid "Feedback Mode: Outline/Box"
 msgstr "Alternar _Contorno/Rectângulo"
 
-#: schematic/scheme/conf/schematic/menu.scm:205
 #, fuzzy
 msgid "Net: Rubberband On/Off"
 msgstr "Banda de borracha Ligada\n"
 
-#: schematic/scheme/conf/schematic/menu.scm:206
 msgid "Net: Magnetic On/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:208
 #, fuzzy
 msgid "_Coord Window"
 msgstr "Mostrar Janela de _Coordenadas..."
 
-#: schematic/scheme/conf/schematic/menu.scm:209
 #, fuzzy
 msgid "_Log Window"
 msgstr "Mostrar Janela de _Registo"
 
-#: schematic/scheme/conf/schematic/menu.scm:215
 msgid "_1 allegro"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:223
 #, fuzzy
 msgid "User _Guide"
 msgstr "gschem _Perguntas Frequentes..."
 
-#: schematic/scheme/conf/schematic/menu.scm:224
 msgid "_FAQ"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:225
 #, fuzzy
 msgid "Docu_mentation"
 msgstr "D_ocumentação..."
 
-#: schematic/scheme/conf/schematic/menu.scm:226
 msgid "_Wiki"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:228
 #, fuzzy
 msgid "Find Component D_ocumentation"
 msgstr "Documentação de _Componente..."
 
-#: schematic/scheme/conf/schematic/menu.scm:230
 msgid "_Hotkeys..."
 msgstr "_Teclas Rápidas..."
 
-#: schematic/scheme/conf/schematic/menu.scm:231
 #, fuzzy
 msgid "_About"
 msgstr "_Acerca de..."
 
-#: schematic/scheme/conf/schematic/menu.scm:237
 msgid "_File"
 msgstr "_Ficheiro"
 
-#: schematic/scheme/conf/schematic/menu.scm:238
 msgid "_Edit"
 msgstr "_Editar"
 
-#: schematic/scheme/conf/schematic/menu.scm:240
 msgid "_View"
 msgstr "_Ver"
 
-#: schematic/scheme/conf/schematic/menu.scm:241
 msgid "_Page"
 msgstr "_Página"
 
-#: schematic/scheme/conf/schematic/menu.scm:242
 msgid "_Add"
 msgstr "_Adicionar"
 
-#: schematic/scheme/conf/schematic/menu.scm:243
 msgid "Hie_rarchy"
 msgstr "Hie_rarquia"
 
-#: schematic/scheme/conf/schematic/menu.scm:244
 msgid "A_ttributes"
 msgstr "A_tributos"
 
-#: schematic/scheme/conf/schematic/menu.scm:245
 msgid "_Options"
 msgstr "_Opções"
 
-#: schematic/scheme/conf/schematic/menu.scm:246
 #, fuzzy
 msgid "_Netlist"
 msgstr "_Ligação"
 
-#: schematic/scheme/conf/schematic/menu.scm:247
 msgid "_Help"
 msgstr "_Ajuda"
 
-#: schematic/scheme/gschem/action.scm:43
 #, scheme-format
 msgid "~S is not a valid gschem action."
 msgstr ""
 
-#: schematic/scheme/gschem/action.scm:158
 msgid "Repeat Last Action"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:47
 #, fuzzy
 msgid "Cancel"
 msgstr "Panorâmica/Cancelar"
 
-#: schematic/scheme/gschem/builtins.scm:53
 #, fuzzy
 msgid "New File"
 msgstr "Novo ficheiro"
 
-#: schematic/scheme/gschem/builtins.scm:56
 #, fuzzy
 msgid "Open File"
 msgstr "Abrir ficheiro..."
 
-#: schematic/scheme/gschem/builtins.scm:62
 #, fuzzy
 msgid "Save As"
 msgstr "Guardar Tudo"
 
-#: schematic/scheme/gschem/builtins.scm:68
 #, fuzzy
 msgid "Print"
 msgstr "Imprimir..."
 
-#: schematic/scheme/gschem/builtins.scm:71
 msgid "Export Image"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:74
 msgid "Run Script"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:80
 #, fuzzy
 msgid "Close Window"
 msgstr "A Fechar janela\n"
 
-#: schematic/scheme/gschem/builtins.scm:83
 #, fuzzy
 msgid "Quit"
 msgstr "_Sair"
 
-#: schematic/scheme/gschem/builtins.scm:87
 msgid "Terminal REPL"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:132
 msgid "Choose Slot"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:135
 #, fuzzy
 msgid "Edit Object Properties"
 msgstr "Editar Propriedades do Texto"
 
-#: schematic/scheme/gschem/builtins.scm:138
 #, fuzzy
 msgid "Translate Symbol"
 msgstr "Mover"
 
-#: schematic/scheme/gschem/builtins.scm:147
 msgid "Invoke Macro"
 msgstr "Chamar Macro"
 
-#: schematic/scheme/gschem/builtins.scm:159
 #, fuzzy
 msgid "Show/Hide Invisible Text"
 msgstr "Mostrar/Esconder Texto Escondido"
 
-#: schematic/scheme/gschem/builtins.scm:165
 #, fuzzy
 msgid "Cut"
 msgstr "Cor_tar"
 
-#: schematic/scheme/gschem/builtins.scm:171
 #, fuzzy
 msgid "Paste"
 msgstr "C_olar"
 
-#: schematic/scheme/gschem/builtins.scm:177
 msgid "Sidebar"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:183
 #, fuzzy
 msgid "Find Text State"
 msgstr "Procurar Texto"
 
-#: schematic/scheme/gschem/builtins.scm:186
 #, fuzzy
 msgid "Redraw"
 msgstr "Re_desenhar"
 
-#: schematic/scheme/gschem/builtins.scm:192
 #, fuzzy
 msgid "Pan Left"
 msgstr "Modo Centrar"
 
-#: schematic/scheme/gschem/builtins.scm:195
 #, fuzzy
 msgid "Pan Right"
 msgstr "Superior Direito"
 
-#: schematic/scheme/gschem/builtins.scm:198
 msgid "Pan Up"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:201
 #, fuzzy
 msgid "Pan Down"
 msgstr "Modo Centrar"
 
-#: schematic/scheme/gschem/builtins.scm:216
 #, fuzzy
 msgid "Zoom Full"
 msgstr "_Ver tudo"
 
-#: schematic/scheme/gschem/builtins.scm:219
 #, fuzzy
 msgid "Dark Color Scheme"
 msgstr "Esquema _Escuro de Cor"
 
-#: schematic/scheme/gschem/builtins.scm:222
 #, fuzzy
 msgid "Light Color Scheme"
 msgstr "Esquema C_laro de Cor"
 
-#: schematic/scheme/gschem/builtins.scm:225
 msgid "Monochrome Color Scheme"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:228
 #, fuzzy
 msgid "Show Color Scheme Editor"
 msgstr "Esquema C_laro de Cor"
 
-#: schematic/scheme/gschem/builtins.scm:234
 #, fuzzy
 msgid "Revert Changes"
 msgstr "Reverter pagina realmente?"
 
-#: schematic/scheme/gschem/builtins.scm:240
 #, fuzzy
 msgid "Previous Page"
 msgstr "_Anterior"
 
-#: schematic/scheme/gschem/builtins.scm:243
 #, fuzzy
 msgid "Next Page"
 msgstr "Nova Página"
 
-#: schematic/scheme/gschem/builtins.scm:255
 #, fuzzy
 msgid "Print Page"
 msgstr "_Anterior"
 
-#: schematic/scheme/gschem/builtins.scm:276
 #, fuzzy
 msgid "Add Line"
 msgstr "Linha"
 
-#: schematic/scheme/gschem/builtins.scm:279
 #, fuzzy
 msgid "Add Path"
 msgstr "/Adicionar Ligação"
 
-#: schematic/scheme/gschem/builtins.scm:282
 #, fuzzy
 msgid "Add Box"
 msgstr "/Adicionar Barramento"
 
-#: schematic/scheme/gschem/builtins.scm:285
 #, fuzzy
 msgid "Add Circle"
 msgstr "Círculo"
 
-#: schematic/scheme/gschem/builtins.scm:288
 #, fuzzy
 msgid "Add Arc"
 msgstr "Adicionar Atributo"
 
-#: schematic/scheme/gschem/builtins.scm:291
 msgid "Add Pin"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:294
 #, fuzzy
 msgid "Add Picture"
 msgstr "Imagem"
 
-#: schematic/scheme/gschem/builtins.scm:306
 #, fuzzy
 msgid "Up Hierarchy"
 msgstr "Hie_rarquia"
 
-#: schematic/scheme/gschem/builtins.scm:312
 #, fuzzy
 msgid "Attach Attributes"
 msgstr "Editar Atributos"
 
-#: schematic/scheme/gschem/builtins.scm:315
 #, fuzzy
 msgid "Detach Attributes"
 msgstr "Atributo Removido"
 
-#: schematic/scheme/gschem/builtins.scm:318
 #, fuzzy
 msgid "Show Attribute Value"
 msgstr "Atribuição de elemento mal especificado\n"
 
-#: schematic/scheme/gschem/builtins.scm:321
 #, fuzzy
 msgid "Show Attribute Name"
 msgstr "Atribuição de elemento mal especificado\n"
 
-#: schematic/scheme/gschem/builtins.scm:327
 #, fuzzy
 msgid "Toggle Text Visibility"
 msgstr "Al_ternar Visibilidade"
 
-#: schematic/scheme/gschem/builtins.scm:330
 #, fuzzy
 msgid "Find Specific Text"
 msgstr "_Procurar Texto Específico..."
 
-#: schematic/scheme/gschem/builtins.scm:333
 #, fuzzy
 msgid "Hide Specific Text"
 msgstr "_Esconder Texto Específico..."
 
-#: schematic/scheme/gschem/builtins.scm:336
 #, fuzzy
 msgid "Show Specific Text"
 msgstr "_Mostrar Texto Específico"
 
-#: schematic/scheme/gschem/builtins.scm:339
 #, fuzzy
 msgid "Autonumber Text"
 msgstr "Texto de auto-numeração"
 
-#: schematic/scheme/gschem/builtins.scm:345
 #, fuzzy
 msgid "Show Hotkeys"
 msgstr "Teclas de Atalho"
 
-#: schematic/scheme/gschem/builtins.scm:348
 msgid "Switch Grid Style"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:351
 msgid "Switch Snap Mode"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:354
 #, fuzzy
 msgid "Set Grid Spacing"
 msgstr "_Aumentar Espaçamento da Grelha"
 
-#: schematic/scheme/gschem/builtins.scm:357
 #, fuzzy
 msgid "Increase Grid Spacing"
 msgstr "_Aumentar Espaçamento da Grelha"
 
-#: schematic/scheme/gschem/builtins.scm:360
 #, fuzzy
 msgid "Decrease Grid Spacing"
 msgstr "_Aumentar Espaçamento da Grelha"
 
-#: schematic/scheme/gschem/builtins.scm:363
 #, fuzzy
 msgid "Toggle Outline Drawing"
 msgstr "Alternar _Contorno/Rectângulo"
 
-#: schematic/scheme/gschem/builtins.scm:366
 #, fuzzy
 msgid "Toggle Net Rubber Band"
 msgstr "Alternar Conservar _Ligações"
 
-#: schematic/scheme/gschem/builtins.scm:369
 #, fuzzy
 msgid "Toggle Magnetic Nets"
 msgstr "Alternar Ligação _Magnética"
 
-#: schematic/scheme/gschem/builtins.scm:372
 #, fuzzy
 msgid "Show Log Window"
 msgstr "Mostrar Janela de _Registo"
 
-#: schematic/scheme/gschem/builtins.scm:375
 #, fuzzy
 msgid "Show Coordinate Window"
 msgstr "Mostrar Janela de _Coordenadas..."
 
-#: schematic/scheme/gschem/builtins.scm:385
 #, fuzzy
 msgid "Component Documentation"
 msgstr "Documentação de _Componente..."
 
-#: schematic/scheme/gschem/builtins.scm:387
 msgid "View documentation for selected component"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:403
 msgid ""
 "Could not show documentation for selected component:\n"
 "\n"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:408
 msgid "gEDA Manuals"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:409
 msgid "View the front page of the gEDA documentation in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:414
 #, fuzzy
 msgid "gschem User Guide"
 msgstr "gschem _Perguntas Frequentes..."
 
-#: schematic/scheme/gschem/builtins.scm:415
 msgid "View the gschem User Guide in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:420
 #, fuzzy
 msgid "gschem FAQ"
 msgstr "gschem _Perguntas Frequentes..."
 
-#: schematic/scheme/gschem/builtins.scm:421
 msgid "Frequently Asked Questions about using gschem."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:426
 #, fuzzy
 msgid "gEDA wiki"
 msgstr "gEDA _Wiki..."
 
-#: schematic/scheme/gschem/builtins.scm:427
 msgid "View the front page of the gEDA wiki in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:431
 msgid "About gschem"
 msgstr "Sobre gschem"
 
-#: schematic/scheme/gschem/deprecated.scm:102
 #, scheme-format
 msgid "Invalid text alignment ~A."
 msgstr ""
 
-#: schematic/scheme/gschem/gschemdoc.scm:241
 msgid "No documentation found"
 msgstr ""
 
-#: schematic/scheme/gschem/keymap.scm:40
 #, scheme-format
 msgid "~S is not a valid key combination."
 msgstr ""
 
-#: schematic/scheme/gschem/keymap.scm:157
 #, scheme-format
 msgid "~S is not a prefix key sequence."
 msgstr ""

--- a/schematic/po/pt_BR.po
+++ b/schematic/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-15 15:13+0300\n"
+"POT-Creation-Date: 2019-02-22 14:08+0300\n"
 "PO-Revision-Date: 2012-01-31 12:08+0000\n"
 "Last-Translator: Antonio Augusto Todo Bom Neto <atodobom@gmail.com>\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -19,24 +19,20 @@ msgstr ""
 "X-Launchpad-Export-Date: 2012-11-14 16:52+0000\n"
 "X-Generator: Launchpad (build 16265)\n"
 
-#: schematic/src/a_zoom.c:155
 #, fuzzy
 msgid "Zoom too small!  Cannot zoom further."
 msgstr "Zoom muito pequeno! Não posso diminuir.\n"
 
-#: schematic/src/color_edit_widget.c:399
 #, fuzzy, c-format
 msgid ""
 "Could not save file [%s]:\n"
 "%s"
 msgstr "Impossível salvar página [%s]\n"
 
-#: schematic/src/color_edit_widget.c:434
 #, fuzzy
 msgid "Save Color Scheme As..."
 msgstr "Esquema de cores Claro"
 
-#: schematic/src/color_edit_widget.c:482 schematic/src/x_fileselect.c:292
 #, fuzzy, c-format
 msgid ""
 "The selected file `%1$s' already exists.\n"
@@ -47,179 +43,141 @@ msgstr ""
 "\n"
 "Deseja sobrescrevê-los?"
 
-#: schematic/src/color_edit_widget.c:486 schematic/src/x_fileselect.c:295
 msgid "Overwrite file?"
 msgstr "Sobrescrever arquivo?"
 
-#: schematic/src/font_select_widget.c:211
 msgid "_Apply"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:215
 msgid "Sa_ve..."
 msgstr ""
 
-#: schematic/src/font_select_widget.c:278
 #, c-format
 msgid "<b>Current:</b> %s"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:453
 msgid "Save configuration"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:461
 msgid "Save settings to:"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:465
 msgid "Local configuration file (in current directory)"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:467
 msgid "User configuration file (geda-user.conf)"
 msgstr ""
 
-#: schematic/src/g_attrib.c:90
 msgid "Object ~A is not included in the current gschem page."
 msgstr ""
 
-#: schematic/src/g_attrib.c:110
 msgid "Invalid text name/value visibility ~A."
 msgstr ""
 
-#: schematic/src/g_rc.c:107
 #, fuzzy, c-format
 msgid "You are running gEDA/gaf version [%1$s%2$s.%3$s],\n"
 msgstr "gEDA/gschem versão %s%s.%s\n"
 
-#: schematic/src/g_rc.c:111
 #, c-format
 msgid ""
 "but you have a version [%1$s] gschemrc file:\n"
 "[%2$s]\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:114
 #, c-format
 msgid "Please be sure that you have the latest rc file.\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:240
 #, fuzzy, c-format
 msgid "Invalid size [%1$d] passed to text-size\n"
 msgstr "Tamanho [%d] inválido (text-size)\n"
 
-#: schematic/src/g_rc.c:283
 #, fuzzy, c-format
 msgid "Invalid size [%1$d] passed to snap-size\n"
 msgstr "Tamanho [%d] inválido passado tamanho de grade\n"
 
-#: schematic/src/g_rc.c:620
 #, fuzzy, c-format
 msgid "Invalid num levels [%1$d] passed to undo-levels\n"
 msgstr ""
 "Número de níveis [%d] inválido para função desfaz passado para undo-level\n"
 
-#: schematic/src/g_rc.c:831
 #, fuzzy, c-format
 msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
 msgstr "Tamanho inválido [%d] passado para bus-ripper-size\n"
 
-#: schematic/src/g_rc.c:931
 #, fuzzy, c-format
 msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
 msgstr "Tamanho [%d] inválido (text-size)\n"
 
-#: schematic/src/g_rc.c:972
 #, fuzzy, c-format
 msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
 msgstr "Tamanho inválido [%d] passado para bus-ripper-size\n"
 
-#: schematic/src/g_rc.c:998
 #, fuzzy, c-format
 msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
 msgstr "Número de pixels inválido [%d] passado para select-slack-pixels\n"
 
-#: schematic/src/g_rc.c:1023
 #, fuzzy, c-format
 msgid "Invalid offset [%1$d] passed to add-attribute-offset\n"
 msgstr "Offset [%d] inválido passado para add-attribute-offset\n"
 
-#: schematic/src/g_rc.c:1047
 #, fuzzy, c-format
 msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
 msgstr "Número de segundos inválido [%d] passado para auto-save-interval\n"
 
-#: schematic/src/g_rc.c:1071
 #, fuzzy, c-format
 msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
 msgstr "Ganho inválido [%d] passado para mousepan-gain\n"
 
-#: schematic/src/g_rc.c:1094
 #, fuzzy, c-format
 msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
 msgstr "Ganho inválido [%d] passado para keyboardpan-gain\n"
 
-#: schematic/src/g_rc.c:1118
 #, fuzzy, c-format
 msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
 msgstr "Número de pixels inválido [%d] passado para select-slack-pixels\n"
 
-#: schematic/src/g_rc.c:1144
 #, fuzzy, c-format
 msgid "Invalid gain [%1$d] passed to zoom-gain\n"
 msgstr "Ganho inválido [%d] passado para mousepan-gain\n"
 
-#: schematic/src/g_rc.c:1169
 #, fuzzy, c-format
 msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
 msgstr "Número de segundos inválido [%d] passado para auto-save-interval\n"
 
-#: schematic/src/g_select.c:78 schematic/src/g_select.c:115
-#: schematic/src/g_select.c:151
 msgid "Object ~A is not directly included in a page."
 msgstr ""
 
-#: schematic/src/g_util.c:54
 msgid "Could not launch URI ~S: ~A"
 msgstr "Impossível lançar URI ~S: ~A"
 
-#: schematic/src/g_window.c:139
 msgid "Found invalid gschem window smob ~S"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:156
 #, fuzzy, c-format
 msgid "Lepton EDA/lepton-schematic version %1$s%2$s.%3$s git: %4$.7s"
 msgstr "gEDA/gschem versão %s%s.%s\n"
 
-#: schematic/src/lepton-schematic.c:163
 #, c-format
 msgid "This is the MINGW32 port.\n"
 msgstr "Esta é a versão portada para MINGW32.\n"
 
-#: schematic/src/lepton-schematic.c:167
 #, fuzzy, c-format
 msgid "Current locale settings: %1$s\n"
 msgstr "Configuração para Localização: %s\n"
 
-#: schematic/src/lepton-schematic.c:201
 #, fuzzy, c-format
 msgid "Couldn't find init scm file [%1$s]"
 msgstr "Arquivo de inicialização scm [%s] não encontrado\n"
 
-#: schematic/src/lepton-schematic.c:206
 #, fuzzy, c-format
 msgid "Read init scm file [%1$s]"
 msgstr "Lendo o arquivo scm [%s]\n"
 
-#: schematic/src/lepton-schematic.c:210
 #, fuzzy, c-format
 msgid "Failed to read init scm file [%1$s]"
 msgstr "Falha ao ler o arquivo scm [%s]\n"
 
-#: schematic/src/lepton-schematic.c:290
 #, fuzzy, c-format
 msgid ""
 "ERROR: Failed to load or evaluate startup script.\n"
@@ -230,712 +188,532 @@ msgstr ""
 "\n"
 "O log do gschem log deve conter mais informações.\n"
 
-#: schematic/src/gschem_about_dialog.c:51
 #, c-format
 msgid "%s (git: %.7s)"
 msgstr ""
 
-#: schematic/src/gschem_about_dialog.c:75
 #, fuzzy
 msgid "Lepton Electronic Design Automation"
 msgstr "gEDA: GPL Electronic Design Automation"
 
-#: schematic/src/gschem_about_dialog.c:83
 #, fuzzy
 msgid ""
 "Copyright © 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright © 2017-2018 Lepton Developers.\n"
-"See AUTHORS and ChangeLog files for details."
+"Copyright © 2017-2019 Lepton Developers.\n"
+"See AUTHORS, ChangeLog files and consult 'git log' history for details."
 msgstr ""
 "Copyright © 1998-2011 Ales Hvezda <ahvezda@geda.seul.org>\n"
 "Copyright © 1998-2011 Contribuidores gEDA  (veja ChangeLog para detalhes)"
 
-#: schematic/src/gschem_alignment_combo.c:69
 msgid "Upper Left"
 msgstr "Esq Alto"
 
-#: schematic/src/gschem_alignment_combo.c:71
 msgid "Upper Middle"
 msgstr "Centro Alto"
 
-#: schematic/src/gschem_alignment_combo.c:73
 #, fuzzy
 msgid "Upper Right"
 msgstr "Dir Baixo"
 
-#: schematic/src/gschem_alignment_combo.c:78
 msgid "Middle Left"
 msgstr "Esq Centro"
 
-#: schematic/src/gschem_alignment_combo.c:80
 msgid "Middle Middle"
 msgstr "Centro Centro"
 
-#: schematic/src/gschem_alignment_combo.c:82
 msgid "Middle Right"
 msgstr "Dir Centro"
 
-#: schematic/src/gschem_alignment_combo.c:87
 msgid "Lower Left"
 msgstr "Esq Baixo"
 
-#: schematic/src/gschem_alignment_combo.c:89
 msgid "Lower Middle"
 msgstr "Centro Baixo"
 
-#: schematic/src/gschem_alignment_combo.c:91
 msgid "Lower Right"
 msgstr "Dir Baixo"
 
-#: schematic/src/gschem_arc_dialog.c:104
 msgid "Arc Params"
 msgstr "Parametros do Arco"
 
-#: schematic/src/gschem_arc_dialog.c:140
 #, fuzzy
 msgid "Arc _Radius:"
 msgstr "Raio do arco:"
 
-#: schematic/src/gschem_arc_dialog.c:141
 #, fuzzy
 msgid "Start _Angle:"
 msgstr "Ângulo Inicial:"
 
-#: schematic/src/gschem_arc_dialog.c:142
 #, fuzzy
 msgid "_Degrees of Sweep:"
 msgstr "Graud da varredura:"
 
-#: schematic/src/gschem_bottom_widget.c:504
 msgid "Left mouse button"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:508
 #, fuzzy
 msgid "Middle mouse button"
 msgstr "Esq Centro"
 
-#: schematic/src/gschem_bottom_widget.c:512
 #, fuzzy
 msgid "Right mouse button"
 msgstr ""
 "Modo de conexões\n"
 "Botão Direito para cancelar"
 
-#: schematic/src/gschem_bottom_widget.c:595
 msgid "(Snap size, Grid size)"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:603
 #, fuzzy
 msgid "Net rubber band mode"
 msgstr "Alterna_r conexão elástica"
 
-#: schematic/src/gschem_bottom_widget.c:614
 #, fuzzy
 msgid "Magnetic net mode"
 msgstr "Modo de Conexão magnético"
 
-#: schematic/src/gschem_bottom_widget.c:622
 #, fuzzy
 msgid "Current action mode"
 msgstr "Página Atual"
 
-#: schematic/src/gschem_bottom_widget.c:935
-#: schematic/src/gschem_bottom_widget.c:951
 msgid "OFF"
 msgstr "DESLIGADO"
 
-#: schematic/src/gschem_bottom_widget.c:954
 msgid "NONE"
 msgstr "NENHUM"
 
-#: schematic/src/gschem_bottom_widget.c:960
 #, fuzzy, c-format
 msgid "Grid(%1$s, %2$s)"
 msgstr "Grade(%s, %s)"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:350
-#: schematic/src/x_compselect.c:1236 schematic/src/x_multiattrib.c:2068
 msgid "Name"
 msgstr "Nome"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:372
 msgid "S_elect the schematics you want to save:"
 msgstr "S_elecione os diagramas que a salvar:"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:467
 #, fuzzy, c-format
 msgid "Save the changes to schematic \"%1$s\" before closing?"
 msgstr "Salvar mudanças do diagrama \"%s\" antes de fechar?"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:473
 #, fuzzy, c-format
 msgid ""
 "There are %1$d schematics with unsaved changes. Save changes before closing?"
 msgstr "Existem %d diagramas alterados. Salvar mudanças antes de fechar?"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:502
 msgid "If you don't save, all your changes will be permanently lost."
 msgstr ""
 "Se você não salvar, todas as suas modificações serão permanentemente "
 "perdidas."
 
-#: schematic/src/gschem_close_confirmation_dialog.c:522
 msgid "Close _without saving"
 msgstr "_Fechar sem salvar"
 
-#: schematic/src/gschem_coord_dialog.c:86
 msgid "Coords"
 msgstr "Coordenadas"
 
-#: schematic/src/gschem_coord_dialog.c:106
 msgid "Screen"
 msgstr "Janela"
 
-#: schematic/src/gschem_coord_dialog.c:115
 msgid "World"
 msgstr "Canvas"
 
-#: schematic/src/gschem_find_text_state.c:809 schematic/src/x_pagesel.c:432
 msgid "Filename"
 msgstr "Nome do arquivo"
 
-#: schematic/src/gschem_find_text_state.c:821 schematic/src/i_callbacks.c:1970
-#: schematic/src/x_colorcb.c:154 schematic/src/x_widgets.c:179
-#: schematic/src/x_window.c:1226 schematic/src/x_window.c:1440
 msgid "Text"
 msgstr "Texto"
 
-#: schematic/src/gschem_find_text_widget.c:427
 msgid "descend into hierarchy"
 msgstr "Desce à hierarquia"
 
-#: schematic/src/gschem_find_text_widget.c:435
 #, fuzzy
 msgid "Find"
 msgstr "Localizar Texto"
 
-#: schematic/src/gschem_find_text_widget.c:557
 #, fuzzy
 msgid "Find Text:"
 msgstr "Localizar Texto"
 
-#: schematic/src/gschem_find_text_widget.c:564
 msgid "Find Pattern:"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:571
 #, fuzzy
 msgid "Find Regex:"
 msgstr "Localizar Texto"
 
-#: schematic/src/gschem_find_text_widget.c:578
 msgid "Check symbol:"
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:200
 msgid "Hotkeys"
 msgstr "Atalhos"
 
-#: schematic/src/gschem_hotkey_dialog.c:229
 msgid ""
 "Start typing action name or keystroke to filter the list.\n"
 "Type hotkeys as they are displayed in \"Keystroke(s)\" column."
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:233 schematic/src/x_compselect.c:1124
 #, fuzzy
 msgid "_Filter:"
 msgstr "Filtro:"
 
-#: schematic/src/gschem_hotkey_dialog.c:259 schematic/src/i_basic.c:280
 msgid "Action"
 msgstr "Ação"
 
-#: schematic/src/gschem_hotkey_dialog.c:277
 msgid "Keystroke(s)"
 msgstr "Arranjos de tecla"
 
-#: schematic/src/gschem_log_widget.c:177
 msgid "** Invalid UTF-8 in log message. See stderr or gschem.log.\n"
 msgstr "** Mensagem UTF-8 inválida no log. Veja stderr ou gschem.log.\n"
 
-#: schematic/src/gschem_log_widget.c:434
 #, fuzzy
 msgid "Clear log window?"
 msgstr "Fechando Janela\n"
 
-#: schematic/src/gschem_log_widget.c:477
 #, fuzzy
 msgid "Clear Log _Window"
 msgstr "Mostra janela de log..."
 
-#: schematic/src/gschem_macro_widget.c:231
 msgid "Macro:"
 msgstr ""
 
-#: schematic/src/gschem_macro_widget.c:387
 #, fuzzy
 msgid "Evaluate"
 msgstr "Analisar:"
 
-#: schematic/src/gschem_object_properties_widget.c:172
 #, fuzzy
 msgid "_Fill Type:"
 msgstr "Preenchimento"
 
-#: schematic/src/gschem_object_properties_widget.c:173
 #, fuzzy
 msgid "Lin_e Width:"
 msgstr "Largura da Linha:"
 
-#: schematic/src/gschem_object_properties_widget.c:174
 #, fuzzy
 msgid "Angle _1:"
 msgstr "Ângulo 1"
 
-#: schematic/src/gschem_object_properties_widget.c:175
 #, fuzzy
 msgid "P_itch 1:"
 msgstr "Passo 1"
 
-#: schematic/src/gschem_object_properties_widget.c:176
 #, fuzzy
 msgid "Angle _2:"
 msgstr "Ângulo 2:"
 
-#: schematic/src/gschem_object_properties_widget.c:177
 #, fuzzy
 msgid "Pitc_h 2:"
 msgstr "Passo 2"
 
-#: schematic/src/gschem_object_properties_widget.c:237
 #, fuzzy
 msgid "<b>Fill Properties</b>"
 msgstr "<b>Propriedades do Texto</b>"
 
-#: schematic/src/gschem_object_properties_widget.c:255
-#: schematic/src/gschem_text_properties_widget.c:258
-#: schematic/src/x_newtext.c:271
 #, fuzzy
 msgid "Colo_r:"
 msgstr "Cor:"
 
-#: schematic/src/gschem_object_properties_widget.c:266
 #, fuzzy
 msgid "<b>General Properties</b>"
 msgstr "<b>Propriedades do Texto</b>"
 
-#: schematic/src/gschem_object_properties_widget.c:284
 #, fuzzy
 msgid "_Type:"
 msgstr "Tipo:"
 
-#: schematic/src/gschem_object_properties_widget.c:285
 #, fuzzy
 msgid "_Width:"
 msgstr "Largura:"
 
-#: schematic/src/gschem_object_properties_widget.c:286
 #, fuzzy
 msgid "Dash _Length:"
 msgstr "Tamanho do traço"
 
-#: schematic/src/gschem_object_properties_widget.c:287
 #, fuzzy
 msgid "Dash _Space:"
 msgstr "Tamanho do espaço:"
 
-#: schematic/src/gschem_object_properties_widget.c:288
 #, fuzzy
 msgid "C_ap style:"
 msgstr "Estilo do Cap"
 
-#: schematic/src/gschem_object_properties_widget.c:333
 #, fuzzy
 msgid "<b>Line Properties</b>"
 msgstr "<b>Propriedades do Texto</b>"
 
-#: schematic/src/gschem_object_properties_widget.c:351
 #, fuzzy
 msgid "_Pin Type:"
 msgstr "Tipo de pino"
 
-#: schematic/src/gschem_object_properties_widget.c:362
 #, fuzzy
 msgid "<b>Pin Properties</b>"
 msgstr "<b>Propriedades do Texto</b>"
 
-#: schematic/src/gschem_options_widget.c:217
 msgid "_Off"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:220
 msgid "_Dots"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:223
 msgid "M_esh"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:245
 #, fuzzy
 msgid "Net R_ubber Band Mode:"
 msgstr "Alterna_r conexão elástica"
 
-#: schematic/src/gschem_options_widget.c:246
 #, fuzzy
 msgid "_Magnetic Net Mode:"
 msgstr "Modo de Conexão magnético"
 
-#: schematic/src/gschem_options_widget.c:250
-#: schematic/src/gschem_options_widget.c:251
 msgid "Enabled"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:265
 #, fuzzy
 msgid "<b>Net Options</b>"
 msgstr "<b>Opções</b>"
 
-#: schematic/src/gschem_options_widget.c:282
 #, fuzzy
 msgid "Grid Mode:"
 msgstr "Modo de Arco"
 
-#: schematic/src/gschem_options_widget.c:283
 #, fuzzy
 msgid "Snap Mode:"
 msgstr "Modo Centrar"
 
-#: schematic/src/gschem_options_widget.c:284
 #, fuzzy
 msgid "_Snap Size:"
 msgstr "Tamanho do Ajuste"
 
-#: schematic/src/gschem_options_widget.c:301
 #, fuzzy
 msgid "<b>Snap Options</b>"
 msgstr "<b>Opções</b>"
 
-#: schematic/src/gschem_options_widget.c:340
 msgid "O_ff"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:343
 #, fuzzy
 msgid "_Grid"
 msgstr "Grade DESLIGADA\n"
 
-#: schematic/src/gschem_options_widget.c:346
 #, fuzzy
 msgid "_Resnap"
 msgstr "Reajuste Ativo"
 
-#: schematic/src/gschem_pin_type_combo.c:73
 msgid "Net pin"
 msgstr "Tipo de NET"
 
-#: schematic/src/gschem_pin_type_combo.c:80
 msgid "Bus pin (graphical)"
 msgstr "Pino de Barramento (gráfico)"
 
-#: schematic/src/gschem_preview.c:195
 msgid "Preview Buffer"
 msgstr ""
 
-#: schematic/src/gschem_show_hide_text_widget.c:148
-#: schematic/src/x_window.c:1268
 #, fuzzy
 msgid "Hide"
 msgstr "Esconder Texto"
 
-#: schematic/src/gschem_show_hide_text_widget.c:157
-#: schematic/src/x_window.c:1269
 msgid "Hide text starting with:"
 msgstr "Ocultar texto iniciado com:"
 
-#: schematic/src/gschem_slot_edit_dialog.c:91
 msgid "Edit slot number"
 msgstr "Editar número de SLOT"
 
-#: schematic/src/gschem_slot_edit_dialog.c:121
 msgid "Number of Slots:"
 msgstr ""
 
-#: schematic/src/gschem_slot_edit_dialog.c:122
 #, fuzzy
 msgid "Slot Number:"
 msgstr "Editar número de SLOT:"
 
-#: schematic/src/gschem_text_properties_widget.c:240
-#: schematic/src/x_newtext.c:265
 msgid "<b>Text Content</b>"
 msgstr "<b>Conteúdo do Texto</b>"
 
-#: schematic/src/gschem_text_properties_widget.c:259
-#: schematic/src/x_newtext.c:291
 #, fuzzy
 msgid "_Size:"
 msgstr "Tamanho:"
 
-#: schematic/src/gschem_text_properties_widget.c:260
-#: schematic/src/x_newtext.c:310
 #, fuzzy
 msgid "Ali_gnment:"
 msgstr "Alinhamento:"
 
-#: schematic/src/gschem_text_properties_widget.c:261
-#: schematic/src/x_newtext.c:330
 #, fuzzy
 msgid "Ro_tation:"
 msgstr "Rotacionar"
 
-#: schematic/src/gschem_text_properties_widget.c:294
-#: schematic/src/x_newtext.c:253
 msgid "<b>Text Properties</b>"
 msgstr "<b>Propriedades do Texto</b>"
 
-#: schematic/src/gschem_translate_widget.c:238
 #, fuzzy
 msgid "Coordinate:"
 msgstr "Mostra _Coordenadas"
 
-#: schematic/src/gschem_translate_widget.c:405 schematic/src/i_callbacks.c:800
 msgid "Translate"
 msgstr "Transladar"
 
-#: schematic/src/i_basic.c:64 schematic/src/x_window.c:1369
-#: schematic/scheme/conf/schematic/menu.scm:59
-#: schematic/scheme/gschem/builtins.scm:99
 msgid "Select Mode"
 msgstr "Modo de Seleção"
 
-#: schematic/src/i_basic.c:65
 #, fuzzy
 msgid "Select Box Mode"
 msgstr "Modo de Seleção"
 
-#: schematic/src/i_basic.c:66
 msgid "Text Mode"
 msgstr "Modo Texto"
 
-#: schematic/src/i_basic.c:67
 msgid "Pan Mode"
 msgstr "Modo Centrar"
 
-#: schematic/src/i_basic.c:70
 #, c-format
 msgid "Paste %d Mode"
 msgstr "Modo Colar de %d"
 
-#: schematic/src/i_basic.c:74
 msgid "Magnetic Net Mode"
 msgstr "Modo de Conexão magnético"
 
-#: schematic/src/i_basic.c:76
 msgid "Net Mode"
 msgstr "Modo de Conexão (NET)"
 
-#: schematic/src/i_basic.c:77
 msgid "Arc Mode"
 msgstr "Modo de Arco"
 
-#: schematic/src/i_basic.c:78
 msgid "Box Mode"
 msgstr "Modo de Caixa"
 
-#: schematic/src/i_basic.c:79
 msgid "Bus Mode"
 msgstr "Modo Barramento (BUS)"
 
-#: schematic/src/i_basic.c:80
 msgid "Circle Mode"
 msgstr "Modo de Círculo"
 
-#: schematic/src/i_basic.c:81
 msgid "Component Mode"
 msgstr "Modo de Componente"
 
-#: schematic/src/i_basic.c:82 schematic/scheme/conf/schematic/menu.scm:62
-#: schematic/scheme/gschem/builtins.scm:114
 msgid "Copy Mode"
 msgstr "Modo de Cópia"
 
-#: schematic/src/i_basic.c:83 schematic/scheme/conf/schematic/menu.scm:63
-#: schematic/scheme/gschem/builtins.scm:117
 msgid "Multiple Copy Mode"
 msgstr "Modo de Múltipla Cópia"
 
-#: schematic/src/i_basic.c:84
 msgid "Line Mode"
 msgstr "Modo de Linha"
 
-#: schematic/src/i_basic.c:85 schematic/scheme/conf/schematic/menu.scm:66
-#: schematic/scheme/gschem/builtins.scm:123
 msgid "Mirror Mode"
 msgstr "Modo de espelho"
 
-#: schematic/src/i_basic.c:86 schematic/scheme/conf/schematic/menu.scm:64
-#: schematic/scheme/gschem/builtins.scm:111
 msgid "Move Mode"
 msgstr "Modo de Movimentação"
 
-#: schematic/src/i_basic.c:87
 #, fuzzy
 msgid "Path Mode"
 msgstr "Modo Centrar"
 
-#: schematic/src/i_basic.c:88
 msgid "Picture Mode"
 msgstr "Modo Imagem"
 
-#: schematic/src/i_basic.c:89
 msgid "Pin Mode"
 msgstr "Modo de Pino"
 
-#: schematic/src/i_basic.c:90 schematic/scheme/gschem/builtins.scm:120
 msgid "Rotate Mode"
 msgstr "Modo de Rotação"
 
-#: schematic/src/i_basic.c:91
 #, fuzzy
 msgid "Modify Mode"
 msgstr "Modo de Cópia"
 
-#: schematic/src/i_basic.c:92 schematic/src/x_menus.c:49
-#: schematic/scheme/gschem/builtins.scm:204
 msgid "Zoom Box"
 msgstr "Caixa de Zoom"
 
-#: schematic/src/i_basic.c:121
 msgid "Show Hidden"
 msgstr "Mostrar Oculto"
 
-#: schematic/src/i_basic.c:124
 msgid "Snap Off"
 msgstr "Ajuste desligado"
 
-#: schematic/src/i_basic.c:126
 msgid "Resnap Active"
 msgstr "Reajuste Ativo"
 
-#: schematic/src/i_basic.c:288 schematic/src/x_colorcb.c:159
 msgid "Stroke"
 msgstr "Gesto"
 
-#: schematic/src/i_basic.c:296 schematic/src/i_basic.c:330
-#: schematic/src/x_window.c:1361
 msgid "none"
 msgstr "nenhum"
 
-#: schematic/src/i_basic.c:304
 msgid "Repeat/"
 msgstr "Repetir/"
 
-#: schematic/src/i_basic.c:315
 msgid "Repeat/none"
 msgstr "Repetir/nenhum"
 
-#: schematic/src/i_basic.c:323 schematic/src/i_callbacks.c:1239
-#: schematic/scheme/gschem/builtins.scm:189
 msgid "Pan"
 msgstr "Pan"
 
-#: schematic/src/i_callbacks.c:74
 #, fuzzy, c-format
 msgid "New page created [%1$s]"
 msgstr "Criada Nova Página [%s]\n"
 
-#: schematic/src/i_callbacks.c:108
 #, fuzzy, c-format
 msgid "New Window created [%1$s]"
 msgstr "Criada nova Janela [%s]\n"
 
-#: schematic/src/i_callbacks.c:245
 msgid "Failed to Save All"
 msgstr "Falha ao salvar tudo"
 
-#: schematic/src/i_callbacks.c:247
 msgid "Saved All"
 msgstr "Tudo foi salvo"
 
-#: schematic/src/i_callbacks.c:308
 #, fuzzy
 msgid "Closing Window"
 msgstr "Fechando Janela\n"
 
-#: schematic/src/i_callbacks.c:505 schematic/src/x_menus.c:55
-#: schematic/scheme/gschem/builtins.scm:168
 msgid "Copy"
 msgstr "Copiar"
 
-#: schematic/src/i_callbacks.c:514 schematic/src/i_callbacks.c:539
-#: schematic/src/i_callbacks.c:564
 msgid "Select objs first"
 msgstr "Selecione objetos antes"
 
-#: schematic/src/i_callbacks.c:530
 msgid "Multiple Copy"
 msgstr "Multipla Cópia"
 
-#: schematic/src/i_callbacks.c:555 schematic/src/x_menus.c:56
 msgid "Move"
 msgstr "Mover"
 
-#: schematic/src/i_callbacks.c:579 schematic/src/x_menus.c:57
-#: schematic/src/x_multiattrib.c:1656 schematic/scheme/gschem/builtins.scm:108
 msgid "Delete"
 msgstr "Apagar"
 
-#: schematic/src/i_callbacks.c:603
 msgid "Edit"
 msgstr "Editar"
 
-#: schematic/src/i_callbacks.c:618 schematic/scheme/gschem/builtins.scm:129
 msgid "Edit Text"
 msgstr "Editar Texto"
 
-#: schematic/src/i_callbacks.c:637
 msgid "Slot"
 msgstr "Slot"
 
-#: schematic/src/i_callbacks.c:688 schematic/src/i_callbacks.c:698
 msgid "Rotate"
 msgstr "Rotacionar"
 
-#: schematic/src/i_callbacks.c:736 schematic/src/i_callbacks.c:746
 msgid "Mirror"
 msgstr "Espelhar"
 
-#: schematic/src/i_callbacks.c:763 schematic/src/x_colorcb.c:160
-#: schematic/scheme/conf/schematic/menu.scm:73
-#: schematic/scheme/gschem/builtins.scm:141
 msgid "Lock"
 msgstr "Bloquear"
 
-#: schematic/src/i_callbacks.c:781 schematic/scheme/conf/schematic/menu.scm:74
-#: schematic/scheme/gschem/builtins.scm:144
 msgid "Unlock"
 msgstr "Desbloquear"
 
-#: schematic/src/i_callbacks.c:805
 #, fuzzy
 msgid "WARNING: Do not translate with snap off!"
 msgstr "ATENÇÃO: Não translade com o Ajuste (snap) desligado!\n"
 
-#: schematic/src/i_callbacks.c:806
 #, fuzzy
 msgid "WARNING: Turning snap on and continuing with translate."
 msgstr "ATENÇÃO: Ligando o Ajuste e continuando o translado.\n"
 
-#: schematic/src/i_callbacks.c:813
 #, fuzzy
 msgid "WARNING: Snap grid size is not equal to 100!"
 msgstr "ATENÇÃO: A grade de Ajuste não está em 100!\n"
 
-#: schematic/src/i_callbacks.c:815
 #, fuzzy
 msgid ""
 "WARNING: If you are translating a symbol to the origin, the snap grid size "
@@ -943,23 +721,18 @@ msgid ""
 msgstr ""
 "ATENÇÃO: Se transladar um símbolo para origem, a grade deve estar em 100\n"
 
-#: schematic/src/i_callbacks.c:847
 msgid "Embed"
 msgstr "Embutir"
 
-#: schematic/src/i_callbacks.c:886
 msgid "Unembed"
 msgstr "Desembutir"
 
-#: schematic/src/i_callbacks.c:928
 msgid "Update"
 msgstr "Atualizar"
 
-#: schematic/src/i_callbacks.c:970
 msgid "ShowHidden"
 msgstr "Mostrar Oculto"
 
-#: schematic/src/i_callbacks.c:1537
 #, c-format
 msgid ""
 "<b>Revert page:</b>\n"
@@ -970,100 +743,78 @@ msgid ""
 "discarded and page file will be reloaded from disk."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1555
 #, fuzzy
 msgid "Revert"
 msgstr "_Recarregar"
 
-#: schematic/src/i_callbacks.c:1647
 msgid "Copy to clipboard"
 msgstr "Copiar à área de transferência"
 
-#: schematic/src/i_callbacks.c:1664
 msgid "Cut to clipboard"
 msgstr "Cortar à área de transferência"
 
-#: schematic/src/i_callbacks.c:1686
 msgid "Paste from clipboard"
 msgstr "Colar da área de transferência"
 
-#: schematic/src/i_callbacks.c:1694
 #, fuzzy
 msgid "Empty clipboard"
 msgstr "Copiar à área de transferência"
 
 #. TRANSLATORS: The number is the number of the buffer that the
 #. * selection is being copied to.
-#: schematic/src/i_callbacks.c:1719
 #, fuzzy, c-format
 msgid "Copy %i"
 msgstr "Copiar à 1"
 
 #. TRANSLATORS: The number is the number of the buffer that the
 #. * selection is being cut to.
-#: schematic/src/i_callbacks.c:1746
 #, fuzzy, c-format
 msgid "Cut %i"
 msgstr "Cortar à 1"
 
 #. TRANSLATORS: The number is the number of the buffer that is being
 #. * pasted to the schematic.
-#: schematic/src/i_callbacks.c:1776
 #, fuzzy, c-format
 msgid "Paste %i"
 msgstr "Colar da 1"
 
-#: schematic/src/i_callbacks.c:1785
 msgid "Empty buffer"
 msgstr "Buffer vazio"
 
-#: schematic/src/i_callbacks.c:1833 schematic/src/x_window.c:1203
 msgid "Component"
 msgstr "Componente"
 
-#: schematic/src/i_callbacks.c:1865 schematic/src/x_colorcb.c:150
 msgid "Attribute"
 msgstr "Atributo"
 
-#: schematic/src/i_callbacks.c:1885 schematic/src/x_colorcb.c:149
 msgid "Net"
 msgstr "Conexão"
 
-#: schematic/src/i_callbacks.c:1928 schematic/src/x_colorcb.c:155
-#: schematic/src/x_window.c:1222
 msgid "Bus"
 msgstr "Barramento"
 
-#: schematic/src/i_callbacks.c:2004
 msgid "Line"
 msgstr "Linha"
 
-#: schematic/src/i_callbacks.c:2021
 msgid "Path"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2043
 msgid "Box"
 msgstr "Caixa"
 
-#: schematic/src/i_callbacks.c:2085
 msgid "Circle"
 msgstr "Círculo"
 
-#: schematic/src/i_callbacks.c:2108
 msgid "Arc"
 msgstr "Arco"
 
-#: schematic/src/i_callbacks.c:2131 schematic/src/x_colorcb.c:146
 msgid "Pin"
 msgstr "Pino"
 
-#: schematic/src/i_callbacks.c:2191
 #, fuzzy, c-format
 msgid "Searching for source [%1$s]"
 msgstr "Procurando por origem [%s]\n"
 
-#: schematic/src/i_callbacks.c:2223
 #, fuzzy, c-format
 msgid ""
 "Failed to descend hierarchy into '%1$s': %2$s\n"
@@ -1074,120 +825,95 @@ msgstr ""
 "\n"
 "O log do gschem deve conter mais informações."
 
-#: schematic/src/i_callbacks.c:2227
 #, fuzzy, c-format
 msgid "Failed to descend into '%1$s': %2$s"
 msgstr "Falhou descendo em '%s': %s\n"
 
-#: schematic/src/i_callbacks.c:2234
 msgid "Failed to descend hierarchy."
 msgstr "Falhou descendo à hierarquia"
 
-#: schematic/src/i_callbacks.c:2312
 #, fuzzy, c-format
 msgid "Searching for symbol [%1$s]"
 msgstr "Procurando por símbolo [%s]\n"
 
-#: schematic/src/i_callbacks.c:2320
 #, fuzzy
 msgid "Symbol is not a real file. Symbol cannot be loaded."
 msgstr "Símbolo não é um arquivo real. Não pode ser lido.\n"
 
-#: schematic/src/i_callbacks.c:2367 schematic/src/x_tabs.c:1060
 #, fuzzy
 msgid "Cannot find any schematics above the current one!"
 msgstr "Impossível encontrar um esquema sobre o corrente!\n"
 
-#: schematic/src/i_callbacks.c:2400
 msgid "Attach"
 msgstr "Anexar"
 
-#: schematic/src/i_callbacks.c:2456
 msgid "Detach"
 msgstr "Desanexar"
 
-#: schematic/src/i_callbacks.c:2500
 msgid "ShowN"
 msgstr "Mostrar Nome"
 
-#: schematic/src/i_callbacks.c:2537
 msgid "ShowV"
 msgstr "Mostrar Valor"
 
-#: schematic/src/i_callbacks.c:2574
 msgid "ShowB"
 msgstr "Mostrar Ambos"
 
-#: schematic/src/i_callbacks.c:2612
 msgid "VisToggle"
 msgstr "Alterna Visibilidade"
 
-#: schematic/src/i_callbacks.c:2643
 #, c-format
 msgid "Sorry but this is a non-functioning menu option\n"
 msgstr "Desculpe, mas esta é uma opção de menu sem função\n"
 
-#: schematic/src/i_callbacks.c:2703
 #, fuzzy
 msgid "Action feedback mode set to OUTLINE"
 msgstr "Retorno de ação ajustado para silhueta\n"
 
-#: schematic/src/i_callbacks.c:2706
 #, fuzzy
 msgid "Action feedback mode set to BOUNDINGBOX"
 msgstr "Retorno de ação ajustado para caixa completa\n"
 
-#: schematic/src/i_callbacks.c:2730
 #, fuzzy
 msgid "Grid OFF"
 msgstr "Grade DESLIGADA\n"
 
-#: schematic/src/i_callbacks.c:2731
 #, fuzzy
 msgid "Dot grid selected"
 msgstr "Usar grade de pontos\n"
 
-#: schematic/src/i_callbacks.c:2732
 #, fuzzy
 msgid "Mesh grid selected"
 msgstr "Usar grade em malha\n"
 
-#: schematic/src/i_callbacks.c:2733
 #, fuzzy
 msgid "Invalid grid mode"
 msgstr "Atributo Inválido"
 
-#: schematic/src/i_callbacks.c:2755
 #, fuzzy
 msgid "Snap OFF (CAUTION!)"
 msgstr "Ajuste desligado (CUIDADO!)\n"
 
-#: schematic/src/i_callbacks.c:2758
 #, fuzzy
 msgid "Snap ON"
 msgstr "Ajuste ligado\n"
 
-#: schematic/src/i_callbacks.c:2761
 #, fuzzy
 msgid "Snap back to the grid (CAUTION!)"
 msgstr "Reajuste à grade (CUIDADO!)\n"
 
-#: schematic/src/i_callbacks.c:2790
 #, fuzzy
 msgid "Rubber band ON"
 msgstr "Elástico ligado\n"
 
-#: schematic/src/i_callbacks.c:2792
 #, fuzzy
 msgid "Rubber band OFF"
 msgstr "Elástico desligado \n"
 
-#: schematic/src/i_callbacks.c:2811
 #, fuzzy
 msgid "magnetic net mode: ON"
 msgstr "Modo conexão magnética: LIGADA\n"
 
-#: schematic/src/i_callbacks.c:2814
 #, fuzzy
 msgid "magnetic net mode: OFF"
 msgstr "Modo conexão magnética: DESLIGADA\n"
@@ -1197,143 +923,114 @@ msgstr "Modo conexão magnética: DESLIGADA\n"
 #. the form "untitled_N.sch", where N is a number.  Please make
 #. sure that the translation contains characters suitable for use
 #. in a filename.
-#: schematic/src/i_vars.c:209
 msgid "untitled"
 msgstr "semnome"
 
-#: schematic/src/o_complex.c:192 schematic/src/o_complex.c:195
 #, fuzzy, c-format
 msgid "Translating schematic [%1$d %2$d]"
 msgstr "Transladando diagrama [%d %d]\n"
 
-#: schematic/src/o_delete.c:82
 #, fuzzy, c-format
 msgid "Delete locked object?"
 msgid_plural "Delete %1$u locked objects?"
 msgstr[0] "Apagar objeto bloqueado?"
 msgstr[1] "Apagar %u objetos bloqueados?"
 
-#: schematic/src/o_misc.c:55
 #, c-format
 msgid "Got an unexpected NULL in o_edit\n"
 msgstr "Encontrado um NULL inesperado em o_edit\n"
 
-#: schematic/src/o_misc.c:315
 #, fuzzy
 msgid "Hidden text is now visible"
 msgstr "Texto oculto agora está visível\n"
 
-#: schematic/src/o_misc.c:317
 #, fuzzy
 msgid "Hidden text is now invisible"
 msgstr "Texto oculto agora está invisível\n"
 
-#: schematic/src/o_misc.c:425
 #, fuzzy, c-format
 msgid "Could not find symbol [%1$s] in library. Update failed."
 msgstr "Impossível encontrar simbolo [%s] na biblioteca. Atualização falhou.\n"
 
-#: schematic/src/o_misc.c:541
 #, fuzzy, c-format
 msgid "o_autosave_backups: Can't get the real filename of %1$s."
 msgstr "o_autosave_backups: Impossível pegar o nome real do arquivo de %s"
 
-#: schematic/src/o_misc.c:585
 #, fuzzy, c-format
 msgid "Could NOT set previous backup file [%1$s] read-write"
 msgstr "NÃO foi possível deixar arquivo backup [%s] como leitura e gravação\n"
 
-#: schematic/src/o_misc.c:605
 #, fuzzy, c-format
 msgid "Could NOT set backup file [%1$s] readonly"
 msgstr "NÃO foi possível deixar arquivo backup [%s] apenas leitura\n"
 
-#: schematic/src/o_misc.c:610
 #, fuzzy, c-format
 msgid "Could NOT save backup file [%1$s]"
 msgstr "NÃO foi possível salvar  arquivo backup [%s] !\n"
 
-#: schematic/src/o_move.c:192
 #, c-format
 msgid "ERROR: NULL object in o_move_end!\n"
 msgstr "ERRO: Objeto NULL em o_move_end!\n"
 
-#: schematic/src/o_move.c:519
 #, c-format
 msgid "DOH! tried to find the whichone, but didn't find it!\n"
 msgstr "Ops! Tentando encontrar algum, mas não foi possível!\n"
 
-#: schematic/src/o_move.c:546
 #, c-format
 msgid "Got a non line object in o_move_check_endpoint\n"
 msgstr "Encontrei um objeto que não é linha em o_move_check_endpoint\n"
 
-#: schematic/src/o_net.c:444
 #, fuzzy
 msgid "Warning: Starting net at off grid coordinate"
 msgstr "Aviso: Iniciando uma NET fora de grade\n"
 
-#: schematic/src/o_net.c:508
 #, fuzzy
 msgid "Warning: Ending net at off grid coordinate"
 msgstr "Aviso: Fim de NET fora de grade\n"
 
-#: schematic/src/o_net.c:856 schematic/src/o_net.c:893
-#: schematic/src/o_net.c:964 schematic/src/o_net.c:1000
 #, c-format
 msgid "Tried to add more than two bus rippers. Internal gschem error.\n"
 msgstr ""
 "Tentou-se adicionar mais de duas entradas em barramento. Erro interno.\n"
 
-#: schematic/src/o_net.c:1068
 #, fuzzy, c-format
 msgid "Bus ripper symbol [%1$s] was not found in any component library"
 msgstr "Símbolo de entrada de barramento [%s] não encontrado nas bibliotecas\n"
 
-#: schematic/src/o_picture.c:133 schematic/src/o_picture.c:343
 msgid "Select a picture file..."
 msgstr "Selecione um arquivo de imagem..."
 
-#: schematic/src/o_picture.c:166
 #, fuzzy, c-format
 msgid "Failed to load picture: %1$s"
 msgstr "Falhou ao ler imagem: %s"
 
-#: schematic/src/o_picture.c:182
 msgid "Picture"
 msgstr "Imagem"
 
-#: schematic/src/o_picture.c:378
 #, c-format
 msgid "Failed to replace pictures: %s"
 msgstr "Falha ao substituir imagem: %s"
 
-#: schematic/src/o_slot.c:80
 #, fuzzy
 msgid "Slot attribute malformed"
 msgstr "Atributo Slot mau feito\n"
 
-#: schematic/src/o_slot.c:88
 #, fuzzy
 msgid "numslots attribute missing"
 msgstr "Sem atributo NUMSLOTS\n"
 
-#: schematic/src/o_slot.c:89
 #, fuzzy
 msgid "Slotting not allowed for this component"
 msgstr "Slots não disponível para este componente\n"
 
-#: schematic/src/o_slot.c:104
 #, fuzzy
 msgid "New slot number out of range"
 msgstr "Número de slot fora dos limites\n"
 
-#: schematic/src/o_undo.c:397
 #, fuzzy
 msgid "Undo/Redo disabled in rc file"
 msgstr "Desfaz e Refaz desabilitado no arquivo rc\n"
 
-#: schematic/src/parsecmd.c:77
 #, fuzzy, c-format
 msgid ""
 "Usage: %1$s [OPTION ...] [--] [FILE ...]\n"
@@ -1380,12 +1077,11 @@ msgstr ""
 "Reportagens de bugs para <https://bugs.launchpad.net/geda>\n"
 "Homepage gEDA/gaf: <http://www.geda-project.org/>\n"
 
-#: schematic/src/parsecmd.c:110
 #, fuzzy, c-format
 msgid ""
 "Lepton EDA %1$s (git: %2$.7s)\n"
 "Copyright (C) 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright (C) 2017-2018 Lepton Developers.\n"
+"Copyright (C) 2017-2019 Lepton Developers.\n"
 "This is free software, and you are welcome to redistribute it under\n"
 "certain conditions. For details, see the file `COPYING', which is\n"
 "included in the Lepton EDA distribution.\n"
@@ -1398,78 +1094,59 @@ msgstr ""
 "é incluído na distribuição gEDA.\n"
 "Ele é SEM GARANTIA, dentro do permitido pela lei.\n"
 
-#: schematic/src/x_attribedit.c:125
 #, c-format
 msgid "Got invalid show option; defaulting to show both\n"
 msgstr "Opção Visualização inválida; redefinindo para Ambos\n"
 
-#: schematic/src/x_attribedit.c:139
 #, c-format
 msgid "ERROR: NULL object!\n"
 msgstr "ERRO: NENHUM objeto!\n"
 
-#: schematic/src/x_attribedit.c:328
 msgid "Single Attribute Editor"
 msgstr "Editor de atributo único"
 
-#: schematic/src/x_attribedit.c:358
 msgid "<b>Edit Attribute</b>"
 msgstr "<b>Editar Atributo</b>"
 
-#: schematic/src/x_attribedit.c:360
 msgid "<b>Add Attribute</b>"
 msgstr "<b>Adicionar Atributo</b>"
 
-#: schematic/src/x_attribedit.c:376
 #, fuzzy
 msgid "N_ame:"
 msgstr "Nome:"
 
-#: schematic/src/x_attribedit.c:396 schematic/src/x_multiattrib.c:2222
 #, fuzzy
 msgid "_Value:"
 msgstr "Valor:"
 
-#: schematic/src/x_attribedit.c:415 schematic/src/x_multiattrib.c:2281
 #, fuzzy
 msgid "Vi_sible"
 msgstr "Visível"
 
-#: schematic/src/x_attribedit.c:434
 msgid "Show Value Only"
 msgstr "Mostra só o valor"
 
-#: schematic/src/x_attribedit.c:436
 msgid "Show Name Only"
 msgstr "Mostra só o nome"
 
-#: schematic/src/x_attribedit.c:438 schematic/src/x_multiattrib.c:1620
-#: schematic/scheme/gschem/builtins.scm:324
 msgid "Show Name & Value"
 msgstr "Mostra ambos"
 
-#: schematic/src/x_attribedit.c:445
 msgid "<b>Attach Options</b>"
 msgstr "<b>Opções de anexar</b>"
 
-#: schematic/src/x_attribedit.c:460
 msgid "All"
 msgstr "Todos"
 
-#: schematic/src/x_attribedit.c:476 schematic/src/x_compselect.c:986
-#: schematic/src/x_compselect.c:1100
 msgid "Components"
 msgstr "Componentes"
 
-#: schematic/src/x_attribedit.c:492 schematic/src/x_window.c:1214
 msgid "Nets"
 msgstr "Conexões"
 
-#: schematic/src/x_attribedit.c:508
 msgid "Replace existing attributes"
 msgstr "Substituir atributos existentes"
 
-#: schematic/src/x_autonumber.c:412
 #, fuzzy
 msgid ""
 "slotted object without slot attribute may cause problems when autonumbering "
@@ -1478,104 +1155,80 @@ msgstr ""
 "Objetos com slots, sem atributo slot, podem causar problemas na "
 "autonumeraçãode slots\n"
 
-#: schematic/src/x_autonumber.c:427
 #, fuzzy, c-format
 msgid ""
 "duplicate slot may cause problems: [symbolname=%1$s, number=%2$d, slot=%3$d]"
 msgstr ""
 "Slots duplicados podem causar problemas: [símbolo=%s, número=%d, slot=%d]\n"
 
-#: schematic/src/x_autonumber.c:675
 #, fuzzy
 msgid "No searchstring given in autonumber text."
 msgstr "Sem chave de pesquisa na autonumeração.\n"
 
-#: schematic/src/x_autonumber.c:728
 #, fuzzy
 msgid "No '*' or '?' given at the end of the autonumber text."
 msgstr "Sem '*' or '?' no final do texto de autonumeração.\n"
 
-#: schematic/src/x_autonumber.c:873
 msgid "Diagonal"
 msgstr "Diagonal"
 
-#: schematic/src/x_autonumber.c:874
 msgid "Top to bottom"
 msgstr "De cima para baixo"
 
-#: schematic/src/x_autonumber.c:875
 msgid "Bottom to top"
 msgstr "De baixo para cima"
 
-#: schematic/src/x_autonumber.c:876
 msgid "Left to right"
 msgstr "Da esquerda para direita"
 
-#: schematic/src/x_autonumber.c:877
 msgid "Right to left"
 msgstr "Da direita para a esquerda"
 
-#: schematic/src/x_autonumber.c:878
 msgid "File order"
 msgstr "Ordem dos arquivos"
 
-#: schematic/src/x_autonumber.c:1214
 msgid "Autonumber text"
 msgstr "Autonumerar texto"
 
-#: schematic/src/x_autonumber.c:1237
 msgid "<b>Scope</b>"
 msgstr "<b>Escopo</b>"
 
-#: schematic/src/x_autonumber.c:1259
 msgid "Search for:"
 msgstr "Pesquisar por:"
 
-#: schematic/src/x_autonumber.c:1273
 msgid "Autonumber text in:"
 msgstr "Auto numerar texto em:"
 
-#: schematic/src/x_autonumber.c:1280
 msgid "Skip numbers found in:"
 msgstr "Ignorar numeros encontrados in:"
 
-#: schematic/src/x_autonumber.c:1292 schematic/src/x_autonumber.c:1301
 msgid "Selected objects"
 msgstr "Selecionar Objetos"
 
-#: schematic/src/x_autonumber.c:1293 schematic/src/x_autonumber.c:1302
 msgid "Current page"
 msgstr "Página Atual"
 
-#: schematic/src/x_autonumber.c:1294 schematic/src/x_autonumber.c:1303
 msgid "Whole hierarchy"
 msgstr "Toda hierarquia"
 
-#: schematic/src/x_autonumber.c:1305
 msgid "Overwrite existing numbers"
 msgstr "Sobrescrever números existentes"
 
-#: schematic/src/x_autonumber.c:1310
 msgid "<b>Options</b>"
 msgstr "<b>Opções</b>"
 
-#: schematic/src/x_autonumber.c:1332
 msgid "Starting number:"
 msgstr "Número inicial"
 
-#: schematic/src/x_autonumber.c:1339
 msgid "Sort order:"
 msgstr "Ordem de numeração:"
 
-#: schematic/src/x_autonumber.c:1371
 msgid "Remove numbers"
 msgstr "Remover números"
 
-#: schematic/src/x_autonumber.c:1375
 msgid "Automatic slotting"
 msgstr "Autonumerar slots"
 
-#: schematic/src/x_clipboard.c:245
 #, c-format
 msgid ""
 "<b>Invalid schematic on clipboard.</b>\n"
@@ -1586,163 +1239,125 @@ msgstr ""
 "\n"
 "Um erro ocorreu inserindo dados da área de transferência: %s."
 
-#: schematic/src/x_clipboard.c:247
 msgid "Clipboard insertion failed"
 msgstr "Inserção da área de tranferência falhou"
 
-#: schematic/src/x_color.c:89 schematic/src/x_color.c:98
 #, fuzzy, c-format
 msgid "Could not allocate the color %1$s!\n"
 msgstr "Impossível alocar a cor %s!\n"
 
-#: schematic/src/x_color.c:89
 msgid "black"
 msgstr "preto"
 
-#: schematic/src/x_color.c:98
 msgid "white"
 msgstr "branco"
 
-#: schematic/src/x_color.c:120
 #, fuzzy, c-format
 msgid "Could not allocate display color %1$i!\n"
 msgstr "Impossível alocar a cor à tela %i!\n"
 
-#: schematic/src/x_color.c:142
 #, fuzzy, c-format
 msgid "Could not allocate outline color %1$i!\n"
 msgstr "Impossível alocar a cor de outline %i!\n"
 
-#: schematic/src/x_color.c:159
 #, fuzzy, c-format
 msgid "Tried to get an invalid color: %1$d\n"
 msgstr "Tentou obter cor inválida: %d\n"
 
-#: schematic/src/x_colorcb.c:145
 msgid "Background"
 msgstr "Fundo"
 
-#: schematic/src/x_colorcb.c:147
 msgid "Net endpoint"
 msgstr "Fim da conexão"
 
-#: schematic/src/x_colorcb.c:148
 msgid "Graphic"
 msgstr "Gráfico"
 
-#: schematic/src/x_colorcb.c:151
 msgid "Logic bubble"
 msgstr "Negação lógica"
 
-#: schematic/src/x_colorcb.c:152
 msgid "Grid point"
 msgstr "Ponto de grade"
 
-#: schematic/src/x_colorcb.c:153
 #, fuzzy
 msgid "Detached attribute"
 msgstr "Atributo livre"
 
-#: schematic/src/x_colorcb.c:156
 msgid "Selection"
 msgstr "Seleção"
 
-#: schematic/src/x_colorcb.c:157
 msgid "Bounding box"
 msgstr "Caixa de contorno"
 
-#: schematic/src/x_colorcb.c:158
 msgid "Zoom box"
 msgstr "Janela de Zoom"
 
-#: schematic/src/x_colorcb.c:161
 msgid "Output background"
 msgstr "Plano de fundo de saída"
 
-#: schematic/src/x_colorcb.c:162
 msgid "Freestyle 1"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:163
 msgid "Freestyle 2"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:164
 msgid "Freestyle 3"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:165
 msgid "Freestyle 4"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:166
 msgid "Net junction"
 msgstr "Junção de conexão"
 
-#: schematic/src/x_colorcb.c:167
 msgid "Mesh grid major"
 msgstr "Grade de malha maior"
 
-#: schematic/src/x_colorcb.c:168
 msgid "Mesh grid minor"
 msgstr "Grade de malha menor"
 
-#: schematic/src/x_colorcb.c:172
 msgid "Unknown"
 msgstr "Desconhecido"
 
-#: schematic/src/x_compselect.c:1169
 #, fuzzy
 msgid "Reset filter"
 msgstr "Novo arquivo"
 
-#: schematic/src/x_compselect.c:1192
 msgid "Reload all libraries"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1245 schematic/src/x_multiattrib.c:2092
 msgid "Value"
 msgstr "Valor"
 
-#: schematic/src/x_compselect.c:1284
 msgid "Default behavior - reference component"
 msgstr "Apenas referenciar (uso padrão)"
 
-#: schematic/src/x_compselect.c:1287
 msgid "Embed component in schematic"
 msgstr "Embutir componente no diagrama"
 
-#: schematic/src/x_compselect.c:1290
 msgid "Include component as individual objects"
 msgstr "Incluir como objetos individuais"
 
-#: schematic/src/x_compselect.c:1448
 msgid "Select Component..."
 msgstr "Selecionar Componente"
 
-#: schematic/src/x_compselect.c:1471
 #, fuzzy
 msgid "In Us_e"
 msgstr "Em Uso"
 
-#: schematic/src/x_compselect.c:1475
 #, fuzzy
 msgid "Lib_raries"
 msgstr "Bibliotecas"
 
-#: schematic/src/x_compselect.c:1484 schematic/src/x_fileselect.c:119
 msgid "Preview"
 msgstr "Visualização"
 
-#: schematic/src/x_compselect.c:1510
 msgid "Attributes"
 msgstr "Atributos"
 
-#: schematic/src/x_dialog.c:325
 msgid "Major symbol changes detected."
 msgstr "Alterações de símbolo detectada."
 
-#: schematic/src/x_dialog.c:349
 msgid ""
 "Changes have occurred to the symbols shown below.\n"
 "\n"
@@ -1752,11 +1367,9 @@ msgstr ""
 "\n"
 "Verifique cada um dos símbolos."
 
-#: schematic/src/x_dialog.c:369
 msgid "Symbol"
 msgstr "Símbolo"
 
-#: schematic/src/x_dialog.c:406
 #, c-format
 msgid ""
 "<span weight=\"bold\" size=\"larger\">The input attribute \"%s\" is invalid\n"
@@ -1774,40 +1387,31 @@ msgstr ""
 "O nome não pode acabar com espaço.\n"
 "O valor não pode começar com espaço."
 
-#: schematic/src/x_dialog.c:408
 msgid "Invalid Attribute"
 msgstr "Atributo Inválido"
 
-#: schematic/src/x_fileselect.c:37
 msgid "Schematics"
 msgstr "Diagramas"
 
-#: schematic/src/x_fileselect.c:42
 msgid "Symbols"
 msgstr "Símbolos"
 
-#: schematic/src/x_fileselect.c:47
 msgid "Schematics and symbols"
 msgstr "Diagramas e Símbolos"
 
-#: schematic/src/x_fileselect.c:53
 msgid "All files"
 msgstr "Todos os arquivos"
 
-#: schematic/src/x_fileselect.c:169
 msgid "Open..."
 msgstr "Abrir..."
 
-#: schematic/src/x_fileselect.c:233
 msgid "Save as..."
 msgstr "Salvar como..."
 
-#: schematic/src/x_fileselect.c:297
 #, fuzzy
 msgid "Save cancelled on user request"
 msgstr "Salvar cancelado a pedido do usuário\n"
 
-#: schematic/src/x_fileselect.c:334
 msgid ""
 "\n"
 "If you load the original file, the backup file will be overwritten in the "
@@ -1821,28 +1425,22 @@ msgstr ""
 "\n"
 "Você quer ler o arquivo de backup?\n"
 
-#: schematic/src/x_fstylecb.c:73
 msgid "Hollow"
 msgstr "Vazio"
 
-#: schematic/src/x_fstylecb.c:80
 msgid "Filled"
 msgstr "Preenchida"
 
-#: schematic/src/x_fstylecb.c:87
 msgid "Mesh"
 msgstr "Malha"
 
-#: schematic/src/x_fstylecb.c:94
 msgid "Hatch"
 msgstr "Linhas"
 
-#: schematic/src/x_image.c:279
 #, fuzzy, c-format
 msgid "x_image_lowlevel: Unable to write %1$s file %2$s."
 msgstr "x_image_lowlevel: Impossível captura do pixbuf da janela gschem.\n"
 
-#: schematic/src/x_image.c:289
 #, fuzzy, c-format
 msgid ""
 "There was the following error when saving image with type %1$s to filename:\n"
@@ -1855,285 +1453,222 @@ msgstr ""
 "\n"
 "%s.\n"
 
-#: schematic/src/x_image.c:309
 #, fuzzy, c-format
 msgid "Wrote color image to [%1$s] [%2$d x %3$d]"
 msgstr "Salva imagem colorida [%s] [%d x %d]\n"
 
-#: schematic/src/x_image.c:311
 #, fuzzy, c-format
 msgid "Wrote black and white image to [%1$s] [%2$d x %3$d]"
 msgstr "Imagem em preto e branco salva [%s] [%d x %d]\n"
 
-#: schematic/src/x_image.c:319
 #, fuzzy
 msgid "x_image_lowlevel: Unable to get pixbuf from gschem's window."
 msgstr "x_image_lowlevel: Impossível captura do pixbuf da janela gschem.\n"
 
-#: schematic/src/x_image.c:358
 msgid "Width x Height"
 msgstr "Largura x Altura"
 
-#: schematic/src/x_image.c:374
 msgid "Image type"
 msgstr "Tipo de imagem"
 
-#: schematic/src/x_image.c:395
 msgid "Write image..."
 msgstr "Gravar imagem..."
 
-#: schematic/src/x_linecapcb.c:74
 msgid "Butt"
 msgstr "Ponta"
 
-#: schematic/src/x_linecapcb.c:81
 msgid "Square"
 msgstr "Quadrado"
 
-#: schematic/src/x_linecapcb.c:88
 msgid "Round"
 msgstr "Redondo"
 
-#: schematic/src/x_linetypecb.c:74
 msgid "Solid"
 msgstr "Solido"
 
-#: schematic/src/x_linetypecb.c:81
 msgid "Dotted"
 msgstr "Pontilhado"
 
-#: schematic/src/x_linetypecb.c:88
 msgid "Dashed"
 msgstr "Tracejado"
 
-#: schematic/src/x_linetypecb.c:95
 msgid "Center"
 msgstr "Centro"
 
-#: schematic/src/x_linetypecb.c:102
 msgid "Phantom"
 msgstr "Fantasma"
 
-#: schematic/src/x_menus.c:41 schematic/scheme/gschem/builtins.scm:267
 #, fuzzy
 msgid "Add Net"
 msgstr "/Inserir Conexão"
 
-#: schematic/src/x_menus.c:42 schematic/src/x_multiattrib.c:2187
-#: schematic/scheme/gschem/builtins.scm:264
 msgid "Add Attribute"
 msgstr "Inserir atributo"
 
-#: schematic/src/x_menus.c:43 schematic/scheme/gschem/builtins.scm:261
 #, fuzzy
 msgid "Add Component"
 msgstr "/Inserir Componente..."
 
-#: schematic/src/x_menus.c:44 schematic/scheme/gschem/builtins.scm:270
 #, fuzzy
 msgid "Add Bus"
 msgstr "/Inserir Barramento"
 
-#: schematic/src/x_menus.c:45 schematic/scheme/gschem/builtins.scm:273
 #, fuzzy
 msgid "Add Text"
 msgstr "/Inserir Texto"
 
-#: schematic/src/x_menus.c:47 schematic/scheme/gschem/builtins.scm:210
 #, fuzzy
 msgid "Zoom In"
 msgstr "/Zoom maior"
 
-#: schematic/src/x_menus.c:48 schematic/scheme/gschem/builtins.scm:213
 #, fuzzy
 msgid "Zoom Out"
 msgstr "/Zoom menor"
 
-#: schematic/src/x_menus.c:50 schematic/scheme/gschem/builtins.scm:207
 #, fuzzy
 msgid "Zoom Extents"
 msgstr "/Zoom desenho"
 
-#: schematic/src/x_menus.c:52 schematic/src/x_window.c:1233
 msgid "Select"
 msgstr "Selecionar"
 
-#: schematic/src/x_menus.c:53 schematic/scheme/conf/schematic/menu.scm:69
-#: schematic/scheme/gschem/builtins.scm:126
 msgid "Edit..."
 msgstr "Editar..."
 
-#: schematic/src/x_menus.c:54 schematic/scheme/conf/schematic/menu.scm:68
 #, fuzzy
 msgid "Object Properties..."
 msgstr "<b>Propriedades do Texto</b>"
 
-#: schematic/src/x_menus.c:59 schematic/scheme/gschem/builtins.scm:300
 #, fuzzy
 msgid "Down Schematic"
 msgstr "/Descer ao Esquemático"
 
-#: schematic/src/x_menus.c:60 schematic/scheme/gschem/builtins.scm:303
 #, fuzzy
 msgid "Down Symbol"
 msgstr "/Descer ao Símbolo"
 
-#: schematic/src/x_menus.c:61
 #, fuzzy
 msgid "Up"
 msgstr "/Subir"
 
-#: schematic/src/x_menus.c:336
 #, fuzzy, c-format
 msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
 msgstr "Tentou-se dar sensibilidade a item não existente '%s'\n"
 
-#: schematic/src/x_menus.c:360
 #, c-format
 msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
 msgstr "Tentou-se dar sensibilidade a item não existente '%s'\n"
 
-#: schematic/src/x_misc.c:70
 msgid "The operating system is out of memory or resources."
 msgstr "Sistema sem memória ou recursos suficientes."
 
-#: schematic/src/x_multiattrib.c:798 schematic/src/x_multiattrib.c:2704
 msgid "<various>"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:930
 msgid "Attributes with empty name are not allowed. Please set a name."
 msgstr "Atributos com nome vazio não são permitidos. Defina um nome."
 
-#: schematic/src/x_multiattrib.c:1622
 msgid "Show Value only"
 msgstr "Mostra apenas Valor"
 
-#: schematic/src/x_multiattrib.c:1624
 msgid "Show Name only"
 msgstr "Mostra apenas Nome"
 
-#: schematic/src/x_multiattrib.c:1651
 msgid "Promote"
 msgstr "Promover"
 
-#: schematic/src/x_multiattrib.c:1655
 msgid "Duplicate"
 msgstr "Duplicar"
 
-#: schematic/src/x_multiattrib.c:1657
 #, fuzzy
 msgid "Copy to all"
 msgstr "Copiar para 1"
 
-#: schematic/src/x_multiattrib.c:1986 schematic/src/x_multiattrib.c:2602
 msgid "Edit Attributes"
 msgstr "Editar Atributos"
 
-#: schematic/src/x_multiattrib.c:2112
 msgid "Vis?"
 msgstr "Vis?"
 
-#: schematic/src/x_multiattrib.c:2130
 msgid "N"
 msgstr "N"
 
-#: schematic/src/x_multiattrib.c:2148
 msgid "V"
 msgstr "V"
 
-#: schematic/src/x_multiattrib.c:2170
 #, fuzzy
 msgid "Sho_w inherited attributes"
 msgstr "Mostra atributos relativos"
 
-#: schematic/src/x_multiattrib.c:2197
 #, fuzzy
 msgid "_Name:"
 msgstr "Nome:"
 
-#: schematic/src/x_multiattrib.c:2241
 msgid "Ctrl+Enter inserts new line; Ctrl+Tab inserts Tab"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2618
 #, c-format
 msgid "%2$i symbol (%1$s)"
 msgid_plural "%2$i symbols (%1$s)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2624
 #, fuzzy, c-format
 msgid "%1$i pin"
 msgid_plural "%1$i pins"
 msgstr[0] "Tipo de NET"
 msgstr[1] "Tipo de NET"
 
-#: schematic/src/x_multiattrib.c:2630
 #, c-format
 msgid "%1$i net"
 msgid_plural "%1$i nets"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2636
 #, c-format
 msgid "%1$i bus"
 msgid_plural "%1$i buses"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2642
 #, fuzzy, c-format
 msgid "%1$i attribute"
 msgid_plural "%1$i attributes"
 msgstr[0] "Atributo"
 msgstr[1] "Atributo"
 
-#: schematic/src/x_newtext.c:433
 msgid "Text Entry..."
 msgstr "Inserir texto..."
 
-#: schematic/src/x_pagesel.c:253
 msgid "New Page"
 msgstr "Nova página"
 
-#: schematic/src/x_pagesel.c:254
 msgid "Open Page..."
 msgstr "Abrir página..."
 
-#: schematic/src/x_pagesel.c:256
 msgid "Save Page"
 msgstr "Salvar página"
 
-#: schematic/src/x_pagesel.c:257 schematic/scheme/gschem/builtins.scm:246
 msgid "Close Page"
 msgstr "Fechar página"
 
-#: schematic/src/x_pagesel.c:376 schematic/scheme/gschem/builtins.scm:237
 msgid "Page Manager"
 msgstr "Gerenciador de Páginas"
 
-#: schematic/src/x_pagesel.c:448
 msgid "Changed"
 msgstr "Alterado"
 
-#: schematic/src/x_pagesel.c:468
 msgid "Right click on the filename for more options..."
 msgstr "Clique direito no arquivo para opções..."
 
-#: schematic/src/x_print.c:306
 #, c-format
 msgid "Failed to write PDF to '%s': %s\n"
 msgstr "Falhou ao salvar PDF em '%s': %s\n"
 
-#: schematic/src/x_print.c:364
 #, fuzzy, c-format
 msgid "Failed to write PDF to '%1$s': %2$s\n"
 msgstr "Falhou ao salvar PDF em '%s': %s\n"
 
-#: schematic/src/x_print.c:449
 #, fuzzy, c-format
 msgid ""
 "Error printing file:\n"
@@ -2142,12 +1677,10 @@ msgstr ""
 "Erro imprimindo arquivo:\n"
 "%s"
 
-#: schematic/src/x_rc.c:39
 #, fuzzy
 msgid "ERROR: An unknown error occurred while parsing configuration files."
 msgstr "ERRO: Erro desconhecido ao analisar arquivos de configuração.\n"
 
-#: schematic/src/x_rc.c:44
 #, fuzzy
 msgid ""
 "An unknown error occurred while parsing configuration files.\n"
@@ -2158,12 +1691,10 @@ msgstr ""
 "\n"
 "O arquivo de log pode conter mais informações."
 
-#: schematic/src/x_rc.c:56
 #, fuzzy, c-format
 msgid "ERROR: %1$s"
 msgstr "ERRO: %s\n"
 
-#: schematic/src/x_rc.c:59
 #, fuzzy, c-format
 msgid ""
 "%1$s\n"
@@ -2174,142 +1705,111 @@ msgstr ""
 "\n"
 "O arquivo de log pode conter mais informações."
 
-#: schematic/src/x_rc.c:67
 #, fuzzy
 msgid "Cannot load lepton-schematic configuration."
 msgstr "Impossível ler configuração do gschem."
 
-#: schematic/src/x_script.c:42 schematic/scheme/conf/schematic/menu.scm:40
 msgid "Execute Script..."
 msgstr "Executar Script..."
 
-#: schematic/src/x_script.c:61
 #, fuzzy, c-format
 msgid "Executing guile script [%1$s]"
 msgstr "Executando script guile [%s]\n"
 
-#: schematic/src/x_tabs.c:860
 #, fuzzy, c-format
 msgid "Hierarchy up: %s"
 msgstr "Hie_rarquia"
 
-#: schematic/src/x_tabs.c:863
 #, fuzzy
 msgid "Hierarchy up"
 msgstr "Hie_rarquia"
 
-#: schematic/src/x_widgets.c:158 schematic/src/x_window.c:1444
 #, fuzzy
 msgid "Options"
 msgstr "_Opções"
 
-#: schematic/src/x_widgets.c:203 schematic/src/x_window.c:1436
 #, fuzzy
 msgid "Object"
 msgstr "Cor do objeto:"
 
-#: schematic/src/x_widgets.c:224
 msgid "Log"
 msgstr ""
 
-#: schematic/src/x_widgets.c:245 schematic/src/x_window.c:1466
 msgid "Find Text"
 msgstr "Localizar Texto"
 
-#: schematic/src/x_widgets.c:259
 #, fuzzy
 msgid "Color Scheme Editor"
 msgstr "Esquema de cores Claro"
 
-#: schematic/src/x_widgets.c:272 schematic/scheme/gschem/builtins.scm:378
 #, fuzzy
 msgid "Select Schematic Font"
 msgstr "S_elecione os diagramas que a salvar:"
 
-#: schematic/src/x_window.c:763
 #, fuzzy, c-format
 msgid "Loading schematic [%1$s]"
 msgstr "Carregando o diagrama [%s]\n"
 
-#: schematic/src/x_window.c:864
 #, fuzzy, c-format
 msgid "Could NOT save page [%1$s]\n"
 msgstr "Impossível salvar página [%s]\n"
 
-#: schematic/src/x_window.c:865
 msgid "Error while trying to save"
 msgstr "Erro tentando salvar"
 
-#: schematic/src/x_window.c:875
 msgid "Failed to save file"
 msgstr "Falha ao salvar arquivo"
 
-#: schematic/src/x_window.c:885
 #, fuzzy, c-format
 msgid "Saved as [%1$s]"
 msgstr "Salvar como [%s]\n"
 
-#: schematic/src/x_window.c:887
 #, fuzzy, c-format
 msgid "Saved [%1$s]"
 msgstr "Salvo [%s]\n"
 
-#: schematic/src/x_window.c:889
 msgid "Saved"
 msgstr "Salvo"
 
-#: schematic/src/x_window.c:966
 #, fuzzy, c-format
 msgid "Discarding page [%1$s]"
 msgstr "Descartando página [%s]\n"
 
-#: schematic/src/x_window.c:966
 #, fuzzy, c-format
 msgid "Closing [%1$s]"
 msgstr "Fechando [%s]\n"
 
-#: schematic/src/x_window.c:1175
 msgid "New"
 msgstr "Novo"
 
-#: schematic/src/x_window.c:1175
 msgid "New file"
 msgstr "Novo arquivo"
 
-#: schematic/src/x_window.c:1179
 msgid "Open"
 msgstr "Abrir"
 
-#: schematic/src/x_window.c:1179
 #, fuzzy
 msgid "Open file"
 msgstr "Abrir arquivo..."
 
-#: schematic/src/x_window.c:1183 schematic/scheme/gschem/builtins.scm:59
 msgid "Save"
 msgstr "Salvar"
 
-#: schematic/src/x_window.c:1183
 msgid "Save file"
 msgstr "Salvar arquivo"
 
-#: schematic/src/x_window.c:1189 schematic/scheme/gschem/builtins.scm:93
 msgid "Undo"
 msgstr "Desfazer"
 
-#: schematic/src/x_window.c:1189
 msgid "Undo last operation"
 msgstr "Desfazer última operação"
 
-#: schematic/src/x_window.c:1193 schematic/scheme/gschem/builtins.scm:96
 msgid "Redo"
 msgstr "Refazer"
 
-#: schematic/src/x_window.c:1193
 msgid "Redo last undo"
 msgstr "Refaz o último Desfaz"
 
-#: schematic/src/x_window.c:1198
 msgid ""
 "Add component...\n"
 "Select library and component from list, move the mouse into main window, "
@@ -2321,7 +1821,6 @@ msgstr ""
 "para colocar o componente\n"
 "Botão Direito para cancelar"
 
-#: schematic/src/x_window.c:1209
 msgid ""
 "Add nets mode\n"
 "Right mouse button to cancel"
@@ -2329,7 +1828,6 @@ msgstr ""
 "Modo de conexões\n"
 "Botão Direito para cancelar"
 
-#: schematic/src/x_window.c:1217
 msgid ""
 "Add buses mode\n"
 "Right mouse button to cancel"
@@ -2337,45 +1835,35 @@ msgstr ""
 "Modo de Barramentos\n"
 "Botão Direito do mouse para cancelar"
 
-#: schematic/src/x_window.c:1226
 msgid "Add Text..."
 msgstr "Adicionar Texto..."
 
-#: schematic/src/x_window.c:1233
 msgid "Select mode"
 msgstr "Modo de Seleção"
 
-#: schematic/src/x_window.c:1288
 #, fuzzy
 msgid "Show"
 msgstr "Mostrar Nome"
 
-#: schematic/src/x_window.c:1289
 msgid "Show text starting with:"
 msgstr "Mostrar texto iniciado com:"
 
-#: schematic/src/x_window.c:1345
 msgid "Menu/Cancel"
 msgstr "Menu/Cancelar"
 
-#: schematic/src/x_window.c:1349
 msgid "Pan/Cancel"
 msgstr "Pan/Cancelar"
 
-#: schematic/src/x_window.c:1359
 msgid "Pick"
 msgstr "Pegar"
 
-#: schematic/src/x_window.c:1470 schematic/scheme/gschem/builtins.scm:180
 msgid "Status"
 msgstr "Status"
 
-#: schematic/src/x_window.c:1568
 #, fuzzy, c-format
 msgid "New file [%s]"
 msgstr "Novo arquivo [%s]\n"
 
-#: schematic/src/x_window.c:1598
 #, fuzzy, c-format
 msgid ""
 "<b>An error occurred while loading the requested file.</b>\n"
@@ -2392,902 +1880,692 @@ msgstr ""
 "\n"
 "Leitura de '%s' falhou: %s. A log do gSchem deve conter mais detalhes."
 
-#: schematic/src/x_window.c:1617
 msgid "Failed to load file"
 msgstr "Falha ao ler arquivo"
 
-#: schematic/data/lepton-schematic.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Schematic Editor"
 msgstr "Editor de Esquemas gEDA"
 
-#: schematic/data/lepton-schematic.desktop.in:4
 #, fuzzy
 msgid "Create and edit electrical schematics and symbols with lepton-schematic"
 msgstr "Crie e edite esquemas elétricos e símbolos com o gschem"
 
-#: schematic/scheme/conf/schematic/menu.scm:27
 msgid "_New"
 msgstr "_Novo"
 
-#: schematic/scheme/conf/schematic/menu.scm:28
 msgid "_Open..."
 msgstr "_Abrir..."
 
-#: schematic/scheme/conf/schematic/menu.scm:30
 msgid "Open Recen_t"
 msgstr "Abrir Recent_e"
 
-#: schematic/scheme/conf/schematic/menu.scm:32
 msgid "_Save"
 msgstr "_Salvar"
 
-#: schematic/scheme/conf/schematic/menu.scm:33
 msgid "Save _As..."
 msgstr "Salvar _Como..."
 
-#: schematic/scheme/conf/schematic/menu.scm:34
-#: schematic/scheme/gschem/builtins.scm:65
 msgid "Save All"
 msgstr "Salvar _Tudo"
 
-#: schematic/scheme/conf/schematic/menu.scm:36
 msgid "_Print..."
 msgstr "Im_primir..."
 
-#: schematic/scheme/conf/schematic/menu.scm:37
 #, fuzzy
 msgid "Write _Image..."
 msgstr "Salvar _imagem..."
 
-#: schematic/scheme/conf/schematic/menu.scm:39
 #, fuzzy
 msgid "Invoke Macro..."
 msgstr "Chamar Macro"
 
-#: schematic/scheme/conf/schematic/menu.scm:41
 msgid "REPL..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:43
-#: schematic/scheme/gschem/builtins.scm:77
 msgid "New Window"
 msgstr "Nova _Janela"
 
-#: schematic/scheme/conf/schematic/menu.scm:44
 msgid "_Close Window"
 msgstr "_Fechar janela"
 
-#: schematic/scheme/conf/schematic/menu.scm:45
 msgid "_Quit"
 msgstr "_Sair"
 
-#: schematic/scheme/conf/schematic/menu.scm:51
 msgid "_Undo"
 msgstr "_Desfazer"
 
-#: schematic/scheme/conf/schematic/menu.scm:52
 msgid "_Redo"
 msgstr "_Refazer"
 
-#: schematic/scheme/conf/schematic/menu.scm:54
 msgid "Cu_t"
 msgstr "Cor_tar"
 
-#: schematic/scheme/conf/schematic/menu.scm:55
 msgid "_Copy"
 msgstr "_Copiar"
 
-#: schematic/scheme/conf/schematic/menu.scm:56
 msgid "_Paste"
 msgstr "Co_lar"
 
-#: schematic/scheme/conf/schematic/menu.scm:57
 msgid "_Delete"
 msgstr "_Apagar"
 
-#: schematic/scheme/conf/schematic/menu.scm:60
-#: schematic/scheme/gschem/builtins.scm:102
 msgid "Select All"
 msgstr "_Selecionar Tudo"
 
-#: schematic/scheme/conf/schematic/menu.scm:61
-#: schematic/scheme/gschem/builtins.scm:105
 msgid "Deselect"
 msgstr "D_esselecionar"
 
-#: schematic/scheme/conf/schematic/menu.scm:65
 msgid "Rotate 90 Mode"
 msgstr "Modo de Rotação"
 
-#: schematic/scheme/conf/schematic/menu.scm:70
 msgid "Edit Text..."
 msgstr "Editar Texto..."
 
-#: schematic/scheme/conf/schematic/menu.scm:71
 msgid "Slot..."
 msgstr "Slot..."
 
-#: schematic/scheme/conf/schematic/menu.scm:76
-#: schematic/scheme/gschem/builtins.scm:150
 msgid "Embed Component/Picture"
 msgstr "Embutir Componente/Imagem"
 
-#: schematic/scheme/conf/schematic/menu.scm:77
-#: schematic/scheme/gschem/builtins.scm:153
 msgid "Unembed Component/Picture"
 msgstr "Desembutir Componente/Imagem"
 
-#: schematic/scheme/conf/schematic/menu.scm:78
-#: schematic/scheme/gschem/builtins.scm:156
 msgid "Update Component"
 msgstr "Atualizar Componente"
 
-#: schematic/scheme/conf/schematic/menu.scm:79
 msgid "Symbol Translate..."
 msgstr "Transladar..."
 
-#: schematic/scheme/conf/schematic/menu.scm:85
 msgid "Copy into 1"
 msgstr "Copiar para 1"
 
-#: schematic/scheme/conf/schematic/menu.scm:86
 msgid "Copy into 2"
 msgstr "Copiar para 2"
 
-#: schematic/scheme/conf/schematic/menu.scm:87
 msgid "Copy into 3"
 msgstr "Copiar para 3"
 
-#: schematic/scheme/conf/schematic/menu.scm:88
 msgid "Copy into 4"
 msgstr "Copiar para 4"
 
-#: schematic/scheme/conf/schematic/menu.scm:89
 msgid "Copy into 5"
 msgstr "Copiar para 5"
 
-#: schematic/scheme/conf/schematic/menu.scm:90
 msgid "Cut into 1"
 msgstr "Cortar para 1"
 
-#: schematic/scheme/conf/schematic/menu.scm:91
 msgid "Cut into 2"
 msgstr "Cortar para 2"
 
-#: schematic/scheme/conf/schematic/menu.scm:92
 msgid "Cut into 3"
 msgstr "Cortar para 3"
 
-#: schematic/scheme/conf/schematic/menu.scm:93
 msgid "Cut into 4"
 msgstr "Cortar para 4"
 
-#: schematic/scheme/conf/schematic/menu.scm:94
 msgid "Cut into 5"
 msgstr "Cortar para 5"
 
-#: schematic/scheme/conf/schematic/menu.scm:95
 msgid "Paste from 1"
 msgstr "Colar de 1"
 
-#: schematic/scheme/conf/schematic/menu.scm:96
 msgid "Paste from 2"
 msgstr "Colar de 2"
 
-#: schematic/scheme/conf/schematic/menu.scm:97
 msgid "Paste from 3"
 msgstr "Colar de 3"
 
-#: schematic/scheme/conf/schematic/menu.scm:98
 msgid "Paste from 4"
 msgstr "Colar de 4"
 
-#: schematic/scheme/conf/schematic/menu.scm:99
 msgid "Paste from 5"
 msgstr "Colar de 5"
 
-#: schematic/scheme/conf/schematic/menu.scm:105
 msgid "Side Dock"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:106
 #, fuzzy
 msgid "Bottom Dock"
 msgstr "De baixo para cima"
 
-#: schematic/scheme/conf/schematic/menu.scm:108
 #, fuzzy
 msgid "Find Text Results"
 msgstr "Localizar Texto"
 
-#: schematic/scheme/conf/schematic/menu.scm:110
 msgid "_Redraw"
 msgstr "_Redesenhar"
 
-#: schematic/scheme/conf/schematic/menu.scm:111
 msgid "_Pan"
 msgstr "_Pan"
 
-#: schematic/scheme/conf/schematic/menu.scm:112
 msgid "Zoom _Box"
 msgstr "Zoom - _Caixa"
 
-#: schematic/scheme/conf/schematic/menu.scm:113
 msgid "Zoom _Extents"
 msgstr "Zoom - _Extensão"
 
-#: schematic/scheme/conf/schematic/menu.scm:114
 msgid "Zoom _In"
 msgstr "Ampliar"
 
-#: schematic/scheme/conf/schematic/menu.scm:115
 msgid "Zoom _Out"
 msgstr "Reduzir"
 
-#: schematic/scheme/conf/schematic/menu.scm:116
 msgid "Zoom _Full"
 msgstr "Ver todo o canvas"
 
-#: schematic/scheme/conf/schematic/menu.scm:118
 #, fuzzy
 msgid "_Dark Color Scheme"
 msgstr "Esquema de cores Escuro"
 
-#: schematic/scheme/conf/schematic/menu.scm:119
 #, fuzzy
 msgid "_Light Color Scheme"
 msgstr "Esquema de cores Claro"
 
-#: schematic/scheme/conf/schematic/menu.scm:120
 #, fuzzy
 msgid "B_W Color Scheme"
 msgstr "Esquema Preto e Branco"
 
-#: schematic/scheme/conf/schematic/menu.scm:122
 #, fuzzy
 msgid "Color Scheme Editor..."
 msgstr "Esquema de cores Claro"
 
-#: schematic/scheme/conf/schematic/menu.scm:129
 msgid "_Manager..."
 msgstr "_Gerenciador..."
 
-#: schematic/scheme/conf/schematic/menu.scm:131
 msgid "_Previous"
 msgstr "_Anterior"
 
-#: schematic/scheme/conf/schematic/menu.scm:132
 msgid "_Next"
 msgstr "_Próximo"
 
-#: schematic/scheme/conf/schematic/menu.scm:133
 msgid "_Close"
 msgstr "_Fechar"
 
-#: schematic/scheme/conf/schematic/menu.scm:135
 #, fuzzy
 msgid "_Revert..."
 msgstr "_Recarregar"
 
-#: schematic/scheme/conf/schematic/menu.scm:137
-#: schematic/scheme/gschem/builtins.scm:249
 #, fuzzy
 msgid "Next Tab"
 msgstr "Nova página"
 
-#: schematic/scheme/conf/schematic/menu.scm:138
-#: schematic/scheme/gschem/builtins.scm:252
 #, fuzzy
 msgid "Previous Tab"
 msgstr "_Anterior"
 
-#: schematic/scheme/conf/schematic/menu.scm:146
 msgid "_Component..."
 msgstr "_Componente..."
 
-#: schematic/scheme/conf/schematic/menu.scm:148
 msgid "_Net"
 msgstr "Co_nexão"
 
-#: schematic/scheme/conf/schematic/menu.scm:149
 msgid "B_us"
 msgstr "_Barramento"
 
-#: schematic/scheme/conf/schematic/menu.scm:151
 msgid "_Attribute..."
 msgstr "_Atributo..."
 
-#: schematic/scheme/conf/schematic/menu.scm:152
 msgid "_Text..."
 msgstr "_Texto..."
 
-#: schematic/scheme/conf/schematic/menu.scm:154
 msgid "_Line"
 msgstr "_Linha"
 
-#: schematic/scheme/conf/schematic/menu.scm:155
 msgid "Pat_h"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:156
 msgid "_Box"
 msgstr "_Caixa"
 
-#: schematic/scheme/conf/schematic/menu.scm:157
 msgid "C_ircle"
 msgstr "C_irculo"
 
-#: schematic/scheme/conf/schematic/menu.scm:158
 msgid "A_rc"
 msgstr "A_rco"
 
-#: schematic/scheme/conf/schematic/menu.scm:159
 msgid "_Pin"
 msgstr "_Pino"
 
-#: schematic/scheme/conf/schematic/menu.scm:161
 msgid "Pictu_re..."
 msgstr "Ima_gem..."
 
-#: schematic/scheme/conf/schematic/menu.scm:167
 msgid "_Up"
 msgstr "S_ubir"
 
-#: schematic/scheme/conf/schematic/menu.scm:169
 msgid "_Down Schematic"
 msgstr "_Descer ao Diagrama"
 
-#: schematic/scheme/conf/schematic/menu.scm:170
 msgid "Down _Symbol"
 msgstr "Descer ao _Símbolo"
 
-#: schematic/scheme/conf/schematic/menu.scm:176
 msgid "_Attach"
 msgstr "_Anexar"
 
-#: schematic/scheme/conf/schematic/menu.scm:177
 msgid "_Detach"
 msgstr "_Desanexar"
 
-#: schematic/scheme/conf/schematic/menu.scm:179
 msgid "Show _Value"
 msgstr "Mostrar _Valor"
 
-#: schematic/scheme/conf/schematic/menu.scm:180
 msgid "Show _Name"
 msgstr "Mostrar _Nome"
 
-#: schematic/scheme/conf/schematic/menu.scm:181
 msgid "Show _Both"
 msgstr "Mostrar Am_bos"
 
-#: schematic/scheme/conf/schematic/menu.scm:182
 msgid "_Toggle Visibility"
 msgstr "Al_ternar visibilidade"
 
-#: schematic/scheme/conf/schematic/menu.scm:184
 msgid "_Hide Specific Text..."
 msgstr "Ocultar um texto..."
 
-#: schematic/scheme/conf/schematic/menu.scm:185
 msgid "_Show Specific Text..."
 msgstr "Mostrar um texto..."
 
-#: schematic/scheme/conf/schematic/menu.scm:186
 #, fuzzy
 msgid "Show/Hide Hidden Text"
 msgstr "Exibir/Ocultar textos ocultos"
 
-#: schematic/scheme/conf/schematic/menu.scm:188
 msgid "_Find Text/Check Symbol..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:189
 msgid "A_utonumber Text..."
 msgstr "A_utonumerar textos..."
 
-#: schematic/scheme/conf/schematic/menu.scm:195
 #, fuzzy
 msgid "_Options..."
 msgstr "_Opções"
 
-#: schematic/scheme/conf/schematic/menu.scm:196
 #, fuzzy
 msgid "_Font..."
 msgstr "Im_primir..."
 
-#: schematic/scheme/conf/schematic/menu.scm:198
 #, fuzzy
 msgid "Grid +"
 msgstr "Grade DESLIGADA\n"
 
-#: schematic/scheme/conf/schematic/menu.scm:199
 #, fuzzy
 msgid "Grid -"
 msgstr "Grade DESLIGADA\n"
 
-#: schematic/scheme/conf/schematic/menu.scm:201
 msgid "Grid Style: Cycle Dots/Mesh/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:202
 msgid "Grid Snap: Cycle Grid/Resnap/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:204
 #, fuzzy
 msgid "Feedback Mode: Outline/Box"
 msgstr "Alternar _Caixa limite"
 
-#: schematic/scheme/conf/schematic/menu.scm:205
 #, fuzzy
 msgid "Net: Rubberband On/Off"
 msgstr "Elástico ligado\n"
 
-#: schematic/scheme/conf/schematic/menu.scm:206
 msgid "Net: Magnetic On/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:208
 #, fuzzy
 msgid "_Coord Window"
 msgstr "_Fechar janela"
 
-#: schematic/scheme/conf/schematic/menu.scm:209
 #, fuzzy
 msgid "_Log Window"
 msgstr "Mostra janela de log..."
 
-#: schematic/scheme/conf/schematic/menu.scm:215
 msgid "_1 allegro"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:223
 #, fuzzy
 msgid "User _Guide"
 msgstr "_Guia de usuário..."
 
-#: schematic/scheme/conf/schematic/menu.scm:224
 msgid "_FAQ"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:225
 #, fuzzy
 msgid "Docu_mentation"
 msgstr "D_ocumentação..."
 
-#: schematic/scheme/conf/schematic/menu.scm:226
 msgid "_Wiki"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:228
 #, fuzzy
 msgid "Find Component D_ocumentation"
 msgstr "_Documentação de componente"
 
-#: schematic/scheme/conf/schematic/menu.scm:230
 msgid "_Hotkeys..."
 msgstr "Atalhos..."
 
-#: schematic/scheme/conf/schematic/menu.scm:231
 #, fuzzy
 msgid "_About"
 msgstr "Sobre..."
 
-#: schematic/scheme/conf/schematic/menu.scm:237
 msgid "_File"
 msgstr "Arquivo"
 
-#: schematic/scheme/conf/schematic/menu.scm:238
 msgid "_Edit"
 msgstr "_Editar"
 
-#: schematic/scheme/conf/schematic/menu.scm:240
 msgid "_View"
 msgstr "Exibir"
 
-#: schematic/scheme/conf/schematic/menu.scm:241
 msgid "_Page"
 msgstr "_Página"
 
-#: schematic/scheme/conf/schematic/menu.scm:242
 msgid "_Add"
 msgstr "_Adicionar"
 
-#: schematic/scheme/conf/schematic/menu.scm:243
 msgid "Hie_rarchy"
 msgstr "Hie_rarquia"
 
-#: schematic/scheme/conf/schematic/menu.scm:244
 msgid "A_ttributes"
 msgstr "A_tributos"
 
-#: schematic/scheme/conf/schematic/menu.scm:245
 msgid "_Options"
 msgstr "_Opções"
 
-#: schematic/scheme/conf/schematic/menu.scm:246
 #, fuzzy
 msgid "_Netlist"
 msgstr "Co_nexão"
 
-#: schematic/scheme/conf/schematic/menu.scm:247
 msgid "_Help"
 msgstr "Ajuda"
 
-#: schematic/scheme/gschem/action.scm:43
 #, fuzzy, scheme-format
 msgid "~S is not a valid gschem action."
 msgstr "~S não é uma combinação válida."
 
-#: schematic/scheme/gschem/action.scm:158
 msgid "Repeat Last Action"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:47
 #, fuzzy
 msgid "Cancel"
 msgstr "Pan/Cancelar"
 
-#: schematic/scheme/gschem/builtins.scm:53
 #, fuzzy
 msgid "New File"
 msgstr "Novo arquivo"
 
-#: schematic/scheme/gschem/builtins.scm:56
 #, fuzzy
 msgid "Open File"
 msgstr "Abrir arquivo..."
 
-#: schematic/scheme/gschem/builtins.scm:62
 #, fuzzy
 msgid "Save As"
 msgstr "Salvar _Tudo"
 
-#: schematic/scheme/gschem/builtins.scm:68
 #, fuzzy
 msgid "Print"
 msgstr "Im_primir..."
 
-#: schematic/scheme/gschem/builtins.scm:71
 msgid "Export Image"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:74
 msgid "Run Script"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:80
 #, fuzzy
 msgid "Close Window"
 msgstr "_Fechar janela"
 
-#: schematic/scheme/gschem/builtins.scm:83
 #, fuzzy
 msgid "Quit"
 msgstr "_Sair"
 
-#: schematic/scheme/gschem/builtins.scm:87
 msgid "Terminal REPL"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:132
 msgid "Choose Slot"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:135
 #, fuzzy
 msgid "Edit Object Properties"
 msgstr "Editar Propriedades do Texto"
 
-#: schematic/scheme/gschem/builtins.scm:138
 #, fuzzy
 msgid "Translate Symbol"
 msgstr "Transladar"
 
-#: schematic/scheme/gschem/builtins.scm:147
 msgid "Invoke Macro"
 msgstr "Chamar Macro"
 
-#: schematic/scheme/gschem/builtins.scm:159
 #, fuzzy
 msgid "Show/Hide Invisible Text"
 msgstr "Exibir/Ocultar textos ocultos"
 
-#: schematic/scheme/gschem/builtins.scm:165
 #, fuzzy
 msgid "Cut"
 msgstr "Cor_tar"
 
-#: schematic/scheme/gschem/builtins.scm:171
 #, fuzzy
 msgid "Paste"
 msgstr "Co_lar"
 
-#: schematic/scheme/gschem/builtins.scm:177
 msgid "Sidebar"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:183
 #, fuzzy
 msgid "Find Text State"
 msgstr "Localizar Texto"
 
-#: schematic/scheme/gschem/builtins.scm:186
 #, fuzzy
 msgid "Redraw"
 msgstr "_Redesenhar"
 
-#: schematic/scheme/gschem/builtins.scm:192
 #, fuzzy
 msgid "Pan Left"
 msgstr "Modo Centrar"
 
-#: schematic/scheme/gschem/builtins.scm:195
 #, fuzzy
 msgid "Pan Right"
 msgstr "Dir Alto"
 
-#: schematic/scheme/gschem/builtins.scm:198
 msgid "Pan Up"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:201
 #, fuzzy
 msgid "Pan Down"
 msgstr "Modo Centrar"
 
-#: schematic/scheme/gschem/builtins.scm:216
 #, fuzzy
 msgid "Zoom Full"
 msgstr "Ver todo o canvas"
 
-#: schematic/scheme/gschem/builtins.scm:219
 #, fuzzy
 msgid "Dark Color Scheme"
 msgstr "Esquema de cores Escuro"
 
-#: schematic/scheme/gschem/builtins.scm:222
 #, fuzzy
 msgid "Light Color Scheme"
 msgstr "Esquema de cores Claro"
 
-#: schematic/scheme/gschem/builtins.scm:225
 msgid "Monochrome Color Scheme"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:228
 #, fuzzy
 msgid "Show Color Scheme Editor"
 msgstr "Esquema de cores Claro"
 
-#: schematic/scheme/gschem/builtins.scm:234
 #, fuzzy
 msgid "Revert Changes"
 msgstr "Reverter Página?"
 
-#: schematic/scheme/gschem/builtins.scm:240
 #, fuzzy
 msgid "Previous Page"
 msgstr "_Anterior"
 
-#: schematic/scheme/gschem/builtins.scm:243
 #, fuzzy
 msgid "Next Page"
 msgstr "Nova página"
 
-#: schematic/scheme/gschem/builtins.scm:255
 #, fuzzy
 msgid "Print Page"
 msgstr "_Anterior"
 
-#: schematic/scheme/gschem/builtins.scm:276
 #, fuzzy
 msgid "Add Line"
 msgstr "Linha"
 
-#: schematic/scheme/gschem/builtins.scm:279
 #, fuzzy
 msgid "Add Path"
 msgstr "/Inserir Conexão"
 
-#: schematic/scheme/gschem/builtins.scm:282
 #, fuzzy
 msgid "Add Box"
 msgstr "/Inserir Barramento"
 
-#: schematic/scheme/gschem/builtins.scm:285
 #, fuzzy
 msgid "Add Circle"
 msgstr "Círculo"
 
-#: schematic/scheme/gschem/builtins.scm:288
 #, fuzzy
 msgid "Add Arc"
 msgstr "Inserir atributo"
 
-#: schematic/scheme/gschem/builtins.scm:291
 msgid "Add Pin"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:294
 #, fuzzy
 msgid "Add Picture"
 msgstr "Imagem"
 
-#: schematic/scheme/gschem/builtins.scm:306
 #, fuzzy
 msgid "Up Hierarchy"
 msgstr "Hie_rarquia"
 
-#: schematic/scheme/gschem/builtins.scm:312
 #, fuzzy
 msgid "Attach Attributes"
 msgstr "Editar Atributos"
 
-#: schematic/scheme/gschem/builtins.scm:315
 #, fuzzy
 msgid "Detach Attributes"
 msgstr "Atributo livre"
 
-#: schematic/scheme/gschem/builtins.scm:318
 #, fuzzy
 msgid "Show Attribute Value"
 msgstr "Atributo Slot mau feito\n"
 
-#: schematic/scheme/gschem/builtins.scm:321
 #, fuzzy
 msgid "Show Attribute Name"
 msgstr "Atributo Slot mau feito\n"
 
-#: schematic/scheme/gschem/builtins.scm:327
 #, fuzzy
 msgid "Toggle Text Visibility"
 msgstr "Al_ternar visibilidade"
 
-#: schematic/scheme/gschem/builtins.scm:330
 #, fuzzy
 msgid "Find Specific Text"
 msgstr "Procurar um texto..."
 
-#: schematic/scheme/gschem/builtins.scm:333
 #, fuzzy
 msgid "Hide Specific Text"
 msgstr "Ocultar um texto..."
 
-#: schematic/scheme/gschem/builtins.scm:336
 #, fuzzy
 msgid "Show Specific Text"
 msgstr "Mostrar um texto..."
 
-#: schematic/scheme/gschem/builtins.scm:339
 #, fuzzy
 msgid "Autonumber Text"
 msgstr "Autonumerar texto"
 
-#: schematic/scheme/gschem/builtins.scm:345
 #, fuzzy
 msgid "Show Hotkeys"
 msgstr "Atalhos"
 
-#: schematic/scheme/gschem/builtins.scm:348
 msgid "Switch Grid Style"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:351
 msgid "Switch Snap Mode"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:354
 #, fuzzy
 msgid "Set Grid Spacing"
 msgstr "A_umentar espaço de grade"
 
-#: schematic/scheme/gschem/builtins.scm:357
 #, fuzzy
 msgid "Increase Grid Spacing"
 msgstr "A_umentar espaço de grade"
 
-#: schematic/scheme/gschem/builtins.scm:360
 #, fuzzy
 msgid "Decrease Grid Spacing"
 msgstr "A_umentar espaço de grade"
 
-#: schematic/scheme/gschem/builtins.scm:363
 #, fuzzy
 msgid "Toggle Outline Drawing"
 msgstr "Alternar _Caixa limite"
 
-#: schematic/scheme/gschem/builtins.scm:366
 #, fuzzy
 msgid "Toggle Net Rubber Band"
 msgstr "Alterna_r conexão elástica"
 
-#: schematic/scheme/gschem/builtins.scm:369
 #, fuzzy
 msgid "Toggle Magnetic Nets"
 msgstr "Alternar conexão _Magnética"
 
-#: schematic/scheme/gschem/builtins.scm:372
 #, fuzzy
 msgid "Show Log Window"
 msgstr "Mostra janela de log..."
 
-#: schematic/scheme/gschem/builtins.scm:375
 #, fuzzy
 msgid "Show Coordinate Window"
 msgstr "Mostra _Coordenadas"
 
-#: schematic/scheme/gschem/builtins.scm:385
 #, fuzzy
 msgid "Component Documentation"
 msgstr "_Documentação de componente"
 
-#: schematic/scheme/gschem/builtins.scm:387
 msgid "View documentation for selected component"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:403
 msgid ""
 "Could not show documentation for selected component:\n"
 "\n"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:408
 msgid "gEDA Manuals"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:409
 msgid "View the front page of the gEDA documentation in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:414
 #, fuzzy
 msgid "gschem User Guide"
 msgstr "_Guia de usuário..."
 
-#: schematic/scheme/gschem/builtins.scm:415
 msgid "View the gschem User Guide in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:420
 #, fuzzy
 msgid "gschem FAQ"
 msgstr "Perguntas e Respostas"
 
-#: schematic/scheme/gschem/builtins.scm:421
 msgid "Frequently Asked Questions about using gschem."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:426
 #, fuzzy
 msgid "gEDA wiki"
 msgstr "_Wiki gEDA..."
 
-#: schematic/scheme/gschem/builtins.scm:427
 msgid "View the front page of the gEDA wiki in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:431
 msgid "About gschem"
 msgstr "Sobre gschem"
 
-#: schematic/scheme/gschem/deprecated.scm:102
 #, scheme-format
 msgid "Invalid text alignment ~A."
 msgstr "Alinhamento de texto ~A inválido."
 
-#: schematic/scheme/gschem/gschemdoc.scm:241
 msgid "No documentation found"
 msgstr "Documento não encontrado"
 
-#: schematic/scheme/gschem/keymap.scm:40
 #, scheme-format
 msgid "~S is not a valid key combination."
 msgstr "~S não é uma combinação válida."
 
-#: schematic/scheme/gschem/keymap.scm:157
 #, scheme-format
 msgid "~S is not a prefix key sequence."
 msgstr "~S não é uma sequência de prefixo."

--- a/schematic/po/ru.po
+++ b/schematic/po/ru.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda gschem ru\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-15 15:13+0300\n"
+"POT-Creation-Date: 2019-02-22 14:08+0300\n"
 "PO-Revision-Date: 2015-09-13 16:05+0300\n"
 "Last-Translator: Sergey Alyoshin <alyoshin.s@gmail.com>\n"
 "Language-Team: geda-user@delorie.com\n"
@@ -22,24 +22,20 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: schematic/src/a_zoom.c:155
 #, fuzzy
 msgid "Zoom too small!  Cannot zoom further."
 msgstr "Масштаб слишком мал! Дальнейшее изменение невозможно.\n"
 
-#: schematic/src/color_edit_widget.c:399
 #, fuzzy, c-format
 msgid ""
 "Could not save file [%s]:\n"
 "%s"
 msgstr "Не удалось сохранить страницу «%s»\n"
 
-#: schematic/src/color_edit_widget.c:434
 #, fuzzy
 msgid "Save Color Scheme As..."
 msgstr "Светлая цветовая схема"
 
-#: schematic/src/color_edit_widget.c:482 schematic/src/x_fileselect.c:292
 #, fuzzy, c-format
 msgid ""
 "The selected file `%1$s' already exists.\n"
@@ -51,53 +47,41 @@ msgstr ""
 "Перезаписать?"
 
 # Заголовок окна
-#: schematic/src/color_edit_widget.c:486 schematic/src/x_fileselect.c:295
 msgid "Overwrite file?"
 msgstr "Перезаписать файл?"
 
-#: schematic/src/font_select_widget.c:211
 msgid "_Apply"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:215
 msgid "Sa_ve..."
 msgstr ""
 
-#: schematic/src/font_select_widget.c:278
 #, c-format
 msgid "<b>Current:</b> %s"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:453
 msgid "Save configuration"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:461
 msgid "Save settings to:"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:465
 msgid "Local configuration file (in current directory)"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:467
 msgid "User configuration file (geda-user.conf)"
 msgstr ""
 
-#: schematic/src/g_attrib.c:90
 msgid "Object ~A is not included in the current gschem page."
 msgstr "Объект ~A не принадлежит текущей странице."
 
-#: schematic/src/g_attrib.c:110
 msgid "Invalid text name/value visibility ~A."
 msgstr "Недопустимое сочетание видимости имени/значения ~A."
 
-#: schematic/src/g_rc.c:107
 #, fuzzy, c-format
 msgid "You are running gEDA/gaf version [%1$s%2$s.%3$s],\n"
 msgstr "Вы работаете с gEDA/gschem версии %s%s.%s,\n"
 
-#: schematic/src/g_rc.c:111
 #, fuzzy, c-format
 msgid ""
 "but you have a version [%1$s] gschemrc file:\n"
@@ -106,92 +90,77 @@ msgstr ""
 "но версия файла gschemrc «%s»:\n"
 "%s\n"
 
-#: schematic/src/g_rc.c:114
 #, c-format
 msgid "Please be sure that you have the latest rc file.\n"
 msgstr "Удостоверьтесь, что у вас последняя версия файла настроек.\n"
 
-#: schematic/src/g_rc.c:240
 #, fuzzy, c-format
 msgid "Invalid size [%1$d] passed to text-size\n"
 msgstr "text-size (размер текста по умолчанию): недопустимое значение «%d»\n"
 
-#: schematic/src/g_rc.c:283
 #, fuzzy, c-format
 msgid "Invalid size [%1$d] passed to snap-size\n"
 msgstr "snap-size (размер сетки привязки): недопустимое значение «%d»\n"
 
-#: schematic/src/g_rc.c:620
 #, fuzzy, c-format
 msgid "Invalid num levels [%1$d] passed to undo-levels\n"
 msgstr "undo-levels (количество шагов отмены): недопустимое значение «%d» \n"
 
-#: schematic/src/g_rc.c:831
 #, fuzzy, c-format
 msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
 msgstr ""
 "bus-ripper-size (размер ответвления от шины): недопустимое значение «%d»\n"
 
-#: schematic/src/g_rc.c:931
 #, fuzzy, c-format
 msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
 msgstr "dots-grid-dot-size (размер точки сетки): недопустимое значение «%d»\n"
 
-#: schematic/src/g_rc.c:972
 #, fuzzy, c-format
 msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
 msgstr ""
 "dots-grid-fixed-threshold (мин. интервал между точками сетки в пикселах): "
 "недопустимое значение «%d»\n"
 
-#: schematic/src/g_rc.c:998
 #, fuzzy, c-format
 msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
 msgstr ""
 "mesh-grid-display-threshold (мин. интервал между линиями сетки в пикселах): "
 "недопустимое значение «%d»\n"
 
-#: schematic/src/g_rc.c:1023
 #, fuzzy, c-format
 msgid "Invalid offset [%1$d] passed to add-attribute-offset\n"
 msgstr ""
 "add-attribute-offset (отступ атрибута от объекта при его добавлении): "
 "недопустимое значение «%d»\n"
 
-#: schematic/src/g_rc.c:1047
 #, fuzzy, c-format
 msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
 msgstr ""
 "auto-save-interval (интервал автосохранения в секундах): недопустимое "
 "значение «%d»\n"
 
-#: schematic/src/g_rc.c:1071
 #, fuzzy, c-format
 msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
 msgstr ""
 "mousepan-gain (смещение при панорамировании мышью): недопустимое значение "
 "«%d»\n"
 
-#: schematic/src/g_rc.c:1094
 #, fuzzy, c-format
 msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
 msgstr ""
 "keyboardpan-gain (смещение при панорамировании клавишами): недопустимое "
 "значение «%d»\n"
 
-#: schematic/src/g_rc.c:1118
 #, fuzzy, c-format
 msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
 msgstr ""
 "select-slack-pixels (число соседних пикселов для выделения): недопустимое "
 "значение «%d»\n"
 
-#: schematic/src/g_rc.c:1144
 #, fuzzy, c-format
 msgid "Invalid gain [%1$d] passed to zoom-gain\n"
 msgstr "zoom-gain (процент увеличения масштаба): недопустимое значение «%d»\n"
 
-#: schematic/src/g_rc.c:1169
 #, fuzzy, c-format
 msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
 msgstr ""
@@ -201,51 +170,40 @@ msgstr ""
 # Данная ошибка возникает, например, в случае попытки отдельного выделения
 # объекта, не являющегося самостоятельной частью страницы, а входящего в
 # состав какого-то символа, то есть включенного в страницу косвенно.
-#: schematic/src/g_select.c:78 schematic/src/g_select.c:115
-#: schematic/src/g_select.c:151
 msgid "Object ~A is not directly included in a page."
 msgstr "Объект ~A непосредственно в данных страницы не содержится. "
 
-#: schematic/src/g_util.c:54
 msgid "Could not launch URI ~S: ~A"
 msgstr "Не удалось открыть URI ~S: ~A"
 
 # smob -- представление данных объекта для Scheme
-#: schematic/src/g_window.c:139
 msgid "Found invalid gschem window smob ~S"
 msgstr "Обнаружена недопустимая структура данных smob окна gschem ~S"
 
-#: schematic/src/lepton-schematic.c:156
 #, fuzzy, c-format
 msgid "Lepton EDA/lepton-schematic version %1$s%2$s.%3$s git: %4$.7s"
 msgstr "gEDA/gschem версии %s%s.%s\n"
 
-#: schematic/src/lepton-schematic.c:163
 #, c-format
 msgid "This is the MINGW32 port.\n"
 msgstr "Это версия для MINGW32.\n"
 
-#: schematic/src/lepton-schematic.c:167
 #, fuzzy, c-format
 msgid "Current locale settings: %1$s\n"
 msgstr "Текущие настройки локализации: %s\n"
 
-#: schematic/src/lepton-schematic.c:201
 #, fuzzy, c-format
 msgid "Couldn't find init scm file [%1$s]"
 msgstr "Не удалось найти scm-файл инициализации «%s»\n"
 
-#: schematic/src/lepton-schematic.c:206
 #, fuzzy, c-format
 msgid "Read init scm file [%1$s]"
 msgstr "Чтение scm-файла инициализации «%s»\n"
 
-#: schematic/src/lepton-schematic.c:210
 #, fuzzy, c-format
 msgid "Failed to read init scm file [%1$s]"
 msgstr "Не удалось прочесть scm-файл инициализации «%s»\n"
 
-#: schematic/src/lepton-schematic.c:290
 #, fuzzy, c-format
 msgid ""
 "ERROR: Failed to load or evaluate startup script.\n"
@@ -256,710 +214,530 @@ msgstr ""
 "\n"
 "В журнале gschem может быть больше информации.\n"
 
-#: schematic/src/gschem_about_dialog.c:51
 #, fuzzy, c-format
 msgid "%s (git: %.7s)"
 msgstr "%s (g%.7s)"
 
-#: schematic/src/gschem_about_dialog.c:75
 #, fuzzy
 msgid "Lepton Electronic Design Automation"
 msgstr "gEDA: САПР электроники под лицензией GPL"
 
-#: schematic/src/gschem_about_dialog.c:83
 #, fuzzy
 msgid ""
 "Copyright © 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright © 2017-2018 Lepton Developers.\n"
-"See AUTHORS and ChangeLog files for details."
+"Copyright © 2017-2019 Lepton Developers.\n"
+"See AUTHORS, ChangeLog files and consult 'git log' history for details."
 msgstr ""
 "Copyright © 1998-2012 Ales Hvezda <ahvezda@geda.seul.org>\n"
 "Copyright © 1998-2012 gEDA Contributors (подробности см. в файле ChangeLog)"
 
-#: schematic/src/gschem_alignment_combo.c:69
 msgid "Upper Left"
 msgstr "слева сверху"
 
-#: schematic/src/gschem_alignment_combo.c:71
 msgid "Upper Middle"
 msgstr "по центру сверху"
 
-#: schematic/src/gschem_alignment_combo.c:73
 msgid "Upper Right"
 msgstr "справа сверху"
 
-#: schematic/src/gschem_alignment_combo.c:78
 msgid "Middle Left"
 msgstr "слева по центру"
 
-#: schematic/src/gschem_alignment_combo.c:80
 msgid "Middle Middle"
 msgstr "по центру"
 
-#: schematic/src/gschem_alignment_combo.c:82
 msgid "Middle Right"
 msgstr "справа по центру"
 
-#: schematic/src/gschem_alignment_combo.c:87
 msgid "Lower Left"
 msgstr "слева снизу"
 
-#: schematic/src/gschem_alignment_combo.c:89
 msgid "Lower Middle"
 msgstr "по центру снизу"
 
-#: schematic/src/gschem_alignment_combo.c:91
 msgid "Lower Right"
 msgstr "справа снизу"
 
-#: schematic/src/gschem_arc_dialog.c:104
 msgid "Arc Params"
 msgstr "Параметры дуги"
 
-#: schematic/src/gschem_arc_dialog.c:140
 #, fuzzy
 msgid "Arc _Radius:"
 msgstr "Радиус:"
 
-#: schematic/src/gschem_arc_dialog.c:141
 #, fuzzy
 msgid "Start _Angle:"
 msgstr "Начальный угол:"
 
-#: schematic/src/gschem_arc_dialog.c:142
 #, fuzzy
 msgid "_Degrees of Sweep:"
 msgstr "Угол разворота:"
 
-#: schematic/src/gschem_bottom_widget.c:504
 msgid "Left mouse button"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:508
 #, fuzzy
 msgid "Middle mouse button"
 msgstr "слева по центру"
 
-#: schematic/src/gschem_bottom_widget.c:512
 #, fuzzy
 msgid "Right mouse button"
 msgstr ""
 "Ввод соединений\n"
 "Щелчок правой кнопкой отменяет операцию"
 
-#: schematic/src/gschem_bottom_widget.c:595
 msgid "(Snap size, Grid size)"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:603
 #, fuzzy
 msgid "Net rubber band mode"
 msgstr "Резиновые соединения:"
 
-#: schematic/src/gschem_bottom_widget.c:614
 #, fuzzy
 msgid "Magnetic net mode"
 msgstr "Магнитные соединения"
 
-#: schematic/src/gschem_bottom_widget.c:622
 #, fuzzy
 msgid "Current action mode"
 msgstr "Текущая страница"
 
-#: schematic/src/gschem_bottom_widget.c:935
-#: schematic/src/gschem_bottom_widget.c:951
 msgid "OFF"
 msgstr "ОТКЛ"
 
-#: schematic/src/gschem_bottom_widget.c:954
 msgid "NONE"
 msgstr "НЕТ"
 
-#: schematic/src/gschem_bottom_widget.c:960
 #, fuzzy, c-format
 msgid "Grid(%1$s, %2$s)"
 msgstr "Сетка(%s, %s)"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:350
-#: schematic/src/x_compselect.c:1236 schematic/src/x_multiattrib.c:2068
 msgid "Name"
 msgstr "Имя"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:372
 msgid "S_elect the schematics you want to save:"
 msgstr "_Выберите сохраняемые схемы:"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:467
 #, fuzzy, c-format
 msgid "Save the changes to schematic \"%1$s\" before closing?"
 msgstr "Сохранить изменения в схеме «%s» перед закрытием?"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:473
 #, fuzzy, c-format
 msgid ""
 "There are %1$d schematics with unsaved changes. Save changes before closing?"
 msgstr ""
 "В %d схемах есть несохранённые изменения. Сохранить их перед закрытием?"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:502
 msgid "If you don't save, all your changes will be permanently lost."
 msgstr "Если их не сохранить, все изменения будут безвозвратно утрачены."
 
-#: schematic/src/gschem_close_confirmation_dialog.c:522
 msgid "Close _without saving"
 msgstr "_Закрыть без сохранения"
 
-#: schematic/src/gschem_coord_dialog.c:86
 msgid "Coords"
 msgstr "Координаты"
 
-#: schematic/src/gschem_coord_dialog.c:106
 msgid "Screen"
 msgstr "Отображаемая область"
 
-#: schematic/src/gschem_coord_dialog.c:115
 msgid "World"
 msgstr "Вся рабочая область"
 
-#: schematic/src/gschem_find_text_state.c:809 schematic/src/x_pagesel.c:432
 msgid "Filename"
 msgstr "Имя файла"
 
-#: schematic/src/gschem_find_text_state.c:821 schematic/src/i_callbacks.c:1970
-#: schematic/src/x_colorcb.c:154 schematic/src/x_widgets.c:179
-#: schematic/src/x_window.c:1226 schematic/src/x_window.c:1440
 msgid "Text"
 msgstr "Текст"
 
 # Почти дословно "Спускаться по иерархии", подразумевается, что поиск ведётся
 # во всей иерархической структуре, корнем которой является данная страница
-#: schematic/src/gschem_find_text_widget.c:427
 msgid "descend into hierarchy"
 msgstr "Искать в подсхемах"
 
-#: schematic/src/gschem_find_text_widget.c:435
 msgid "Find"
 msgstr "Найти"
 
-#: schematic/src/gschem_find_text_widget.c:557
 msgid "Find Text:"
 msgstr "Текст:"
 
-#: schematic/src/gschem_find_text_widget.c:564
 msgid "Find Pattern:"
 msgstr "Шаблон:"
 
-#: schematic/src/gschem_find_text_widget.c:571
 msgid "Find Regex:"
 msgstr "Рег. выраж.:"
 
-#: schematic/src/gschem_find_text_widget.c:578
 msgid "Check symbol:"
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:200
 msgid "Hotkeys"
 msgstr "Горячие клавиши"
 
-#: schematic/src/gschem_hotkey_dialog.c:229
 msgid ""
 "Start typing action name or keystroke to filter the list.\n"
 "Type hotkeys as they are displayed in \"Keystroke(s)\" column."
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:233 schematic/src/x_compselect.c:1124
 #, fuzzy
 msgid "_Filter:"
 msgstr "Фильтр:"
 
-#: schematic/src/gschem_hotkey_dialog.c:259 schematic/src/i_basic.c:280
 msgid "Action"
 msgstr "Действие"
 
-#: schematic/src/gschem_hotkey_dialog.c:277
 msgid "Keystroke(s)"
 msgstr "Сочетание клавиш"
 
-#: schematic/src/gschem_log_widget.c:177
 msgid "** Invalid UTF-8 in log message. See stderr or gschem.log.\n"
 msgstr ""
 "** Недопустимый символ в кодировке UTF-8 в окне журнала. См. stderr или "
 "gschem.log.\n"
 
-#: schematic/src/gschem_log_widget.c:434
 #, fuzzy
 msgid "Clear log window?"
 msgstr "Закрытие окна\n"
 
-#: schematic/src/gschem_log_widget.c:477
 #, fuzzy
 msgid "Clear Log _Window"
 msgstr "Показать окно журнала"
 
-#: schematic/src/gschem_macro_widget.c:231
 msgid "Macro:"
 msgstr "Макрос:"
 
-#: schematic/src/gschem_macro_widget.c:387
 msgid "Evaluate"
 msgstr "Выполнить"
 
-#: schematic/src/gschem_object_properties_widget.c:172
 #, fuzzy
 msgid "_Fill Type:"
 msgstr "Тип:"
 
-#: schematic/src/gschem_object_properties_widget.c:173
 #, fuzzy
 msgid "Lin_e Width:"
 msgstr "Толщина:"
 
-#: schematic/src/gschem_object_properties_widget.c:174
 #, fuzzy
 msgid "Angle _1:"
 msgstr "Угол 1:"
 
-#: schematic/src/gschem_object_properties_widget.c:175
 #, fuzzy
 msgid "P_itch 1:"
 msgstr "Шаг 1:"
 
-#: schematic/src/gschem_object_properties_widget.c:176
 #, fuzzy
 msgid "Angle _2:"
 msgstr "Угол 2:"
 
-#: schematic/src/gschem_object_properties_widget.c:177
 #, fuzzy
 msgid "Pitc_h 2:"
 msgstr "Шаг 2:"
 
-#: schematic/src/gschem_object_properties_widget.c:237
 msgid "<b>Fill Properties</b>"
 msgstr "<b>Заполнение</b>"
 
-#: schematic/src/gschem_object_properties_widget.c:255
-#: schematic/src/gschem_text_properties_widget.c:258
-#: schematic/src/x_newtext.c:271
 #, fuzzy
 msgid "Colo_r:"
 msgstr "Цвет:"
 
-#: schematic/src/gschem_object_properties_widget.c:266
 msgid "<b>General Properties</b>"
 msgstr "<b>Общие свойства</b>"
 
-#: schematic/src/gschem_object_properties_widget.c:284
 #, fuzzy
 msgid "_Type:"
 msgstr "Тип:"
 
-#: schematic/src/gschem_object_properties_widget.c:285
 #, fuzzy
 msgid "_Width:"
 msgstr "Толщина:"
 
-#: schematic/src/gschem_object_properties_widget.c:286
 #, fuzzy
 msgid "Dash _Length:"
 msgstr "Штрих:"
 
-#: schematic/src/gschem_object_properties_widget.c:287
 #, fuzzy
 msgid "Dash _Space:"
 msgstr "Промежуток:"
 
-#: schematic/src/gschem_object_properties_widget.c:288
 #, fuzzy
 msgid "C_ap style:"
 msgstr "Концы:"
 
-#: schematic/src/gschem_object_properties_widget.c:333
 msgid "<b>Line Properties</b>"
 msgstr "<b>Линия</b>"
 
-#: schematic/src/gschem_object_properties_widget.c:351
 #, fuzzy
 msgid "_Pin Type:"
 msgstr "Тип вывода:"
 
-#: schematic/src/gschem_object_properties_widget.c:362
 msgid "<b>Pin Properties</b>"
 msgstr "<b>Вывод</b>"
 
-#: schematic/src/gschem_options_widget.c:217
 msgid "_Off"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:220
 #, fuzzy
 msgid "_Dots"
 msgstr "Точки"
 
-#: schematic/src/gschem_options_widget.c:223
 msgid "M_esh"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:245
 #, fuzzy
 msgid "Net R_ubber Band Mode:"
 msgstr "Резиновые соединения:"
 
-#: schematic/src/gschem_options_widget.c:246
 #, fuzzy
 msgid "_Magnetic Net Mode:"
 msgstr "Магнитные соединения:"
 
-#: schematic/src/gschem_options_widget.c:250
-#: schematic/src/gschem_options_widget.c:251
 msgid "Enabled"
 msgstr "Включено"
 
-#: schematic/src/gschem_options_widget.c:265
 msgid "<b>Net Options</b>"
 msgstr "<b>Соединение</b>"
 
-#: schematic/src/gschem_options_widget.c:282
 msgid "Grid Mode:"
 msgstr "Сетка:"
 
-#: schematic/src/gschem_options_widget.c:283
 msgid "Snap Mode:"
 msgstr "Привязка:"
 
-#: schematic/src/gschem_options_widget.c:284
 #, fuzzy
 msgid "_Snap Size:"
 msgstr "Шаг:"
 
-#: schematic/src/gschem_options_widget.c:301
 msgid "<b>Snap Options</b>"
 msgstr "<b>Привязка</b>"
 
-#: schematic/src/gschem_options_widget.c:340
 msgid "O_ff"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:343
 #, fuzzy
 msgid "_Grid"
 msgstr "Сетка"
 
-#: schematic/src/gschem_options_widget.c:346
 #, fuzzy
 msgid "_Resnap"
 msgstr "Перепривязка"
 
-#: schematic/src/gschem_pin_type_combo.c:73
 msgid "Net pin"
 msgstr "Вывод соединения"
 
-#: schematic/src/gschem_pin_type_combo.c:80
 msgid "Bus pin (graphical)"
 msgstr "Вывод шины (графический)"
 
-#: schematic/src/gschem_preview.c:195
 msgid "Preview Buffer"
 msgstr "Буфер предпросмотра"
 
-#: schematic/src/gschem_show_hide_text_widget.c:148
-#: schematic/src/x_window.c:1268
 msgid "Hide"
 msgstr "Скрыть"
 
-#: schematic/src/gschem_show_hide_text_widget.c:157
-#: schematic/src/x_window.c:1269
 msgid "Hide text starting with:"
 msgstr "Скрыть текст, начинающийся с:"
 
-#: schematic/src/gschem_slot_edit_dialog.c:91
 msgid "Edit slot number"
 msgstr "Правка номера секции"
 
-#: schematic/src/gschem_slot_edit_dialog.c:121
 msgid "Number of Slots:"
 msgstr "Количество секций:"
 
-#: schematic/src/gschem_slot_edit_dialog.c:122
 msgid "Slot Number:"
 msgstr "Номер секции:"
 
-#: schematic/src/gschem_text_properties_widget.c:240
-#: schematic/src/x_newtext.c:265
 msgid "<b>Text Content</b>"
 msgstr "<b>Содержание текста</b>"
 
-#: schematic/src/gschem_text_properties_widget.c:259
-#: schematic/src/x_newtext.c:291
 #, fuzzy
 msgid "_Size:"
 msgstr "Размер:"
 
-#: schematic/src/gschem_text_properties_widget.c:260
-#: schematic/src/x_newtext.c:310
 #, fuzzy
 msgid "Ali_gnment:"
 msgstr "Выравнивание:"
 
-#: schematic/src/gschem_text_properties_widget.c:261
-#: schematic/src/x_newtext.c:330
 #, fuzzy
 msgid "Ro_tation:"
 msgstr "Поворот:"
 
-#: schematic/src/gschem_text_properties_widget.c:294
-#: schematic/src/x_newtext.c:253
 msgid "<b>Text Properties</b>"
 msgstr "<b>Текст</b>"
 
-#: schematic/src/gschem_translate_widget.c:238
 msgid "Coordinate:"
 msgstr "Координаты:"
 
-#: schematic/src/gschem_translate_widget.c:405 schematic/src/i_callbacks.c:800
 msgid "Translate"
 msgstr "Сместить"
 
-#: schematic/src/i_basic.c:64 schematic/src/x_window.c:1369
-#: schematic/scheme/conf/schematic/menu.scm:59
-#: schematic/scheme/gschem/builtins.scm:99
 msgid "Select Mode"
 msgstr "Выделение"
 
-#: schematic/src/i_basic.c:65
 msgid "Select Box Mode"
 msgstr "Выделение рамкой"
 
-#: schematic/src/i_basic.c:66
 msgid "Text Mode"
 msgstr "Ввод текста"
 
 # Перевод в соответствии с пунктом меню
-#: schematic/src/i_basic.c:67
 msgid "Pan Mode"
 msgstr "Центрирование"
 
-#: schematic/src/i_basic.c:70
 #, c-format
 msgid "Paste %d Mode"
 msgstr "Вставка из %d"
 
-#: schematic/src/i_basic.c:74
 msgid "Magnetic Net Mode"
 msgstr "Магнитные соединения"
 
-#: schematic/src/i_basic.c:76
 msgid "Net Mode"
 msgstr "Ввод соединений"
 
-#: schematic/src/i_basic.c:77
 msgid "Arc Mode"
 msgstr "Ввод дуг"
 
-#: schematic/src/i_basic.c:78
 msgid "Box Mode"
 msgstr "Ввод прямоугольников"
 
-#: schematic/src/i_basic.c:79
 msgid "Bus Mode"
 msgstr "Ввод шин"
 
-#: schematic/src/i_basic.c:80
 msgid "Circle Mode"
 msgstr "Ввод окружностей"
 
-#: schematic/src/i_basic.c:81
 msgid "Component Mode"
 msgstr "Вставка компонентов"
 
-#: schematic/src/i_basic.c:82 schematic/scheme/conf/schematic/menu.scm:62
-#: schematic/scheme/gschem/builtins.scm:114
 msgid "Copy Mode"
 msgstr "Копирование"
 
-#: schematic/src/i_basic.c:83 schematic/scheme/conf/schematic/menu.scm:63
-#: schematic/scheme/gschem/builtins.scm:117
 msgid "Multiple Copy Mode"
 msgstr "Многократное копирование"
 
-#: schematic/src/i_basic.c:84
 msgid "Line Mode"
 msgstr "Ввод линий"
 
-#: schematic/src/i_basic.c:85 schematic/scheme/conf/schematic/menu.scm:66
-#: schematic/scheme/gschem/builtins.scm:123
 msgid "Mirror Mode"
 msgstr "Зеркальное отражение"
 
-#: schematic/src/i_basic.c:86 schematic/scheme/conf/schematic/menu.scm:64
-#: schematic/scheme/gschem/builtins.scm:111
 msgid "Move Mode"
 msgstr "Перемещение"
 
-#: schematic/src/i_basic.c:87
 msgid "Path Mode"
 msgstr "Ввод контуров"
 
-#: schematic/src/i_basic.c:88
 msgid "Picture Mode"
 msgstr "Вставка изображений"
 
-#: schematic/src/i_basic.c:89
 msgid "Pin Mode"
 msgstr "Добавление выводов"
 
-#: schematic/src/i_basic.c:90 schematic/scheme/gschem/builtins.scm:120
 msgid "Rotate Mode"
 msgstr "Поворот"
 
-#: schematic/src/i_basic.c:91
 msgid "Modify Mode"
 msgstr "Захват"
 
-#: schematic/src/i_basic.c:92 schematic/src/x_menus.c:49
-#: schematic/scheme/gschem/builtins.scm:204
 msgid "Zoom Box"
 msgstr "Масштаб на область"
 
 # См. примечание для "Copy"
-#: schematic/src/i_basic.c:121
 msgid "Show Hidden"
 msgstr "Отображение скрытого текста"
 
-#: schematic/src/i_basic.c:124
 msgid "Snap Off"
 msgstr "Привязка отключена"
 
-#: schematic/src/i_basic.c:126
 msgid "Resnap Active"
 msgstr "Режим перепривязки"
 
-#: schematic/src/i_basic.c:288 schematic/src/x_colorcb.c:159
 msgid "Stroke"
 msgstr "Жест"
 
 # Эта строка выводится в режиме ввода жестов, когда библиотека жестов не
 # подключена.
-#: schematic/src/i_basic.c:296 schematic/src/i_basic.c:330
-#: schematic/src/x_window.c:1361
 msgid "none"
 msgstr "---"
 
 # Функция средней кнопки мыши.
 # За этой строкой следует название действия
-#: schematic/src/i_basic.c:304
 msgid "Repeat/"
 msgstr "Повтор: "
 
 # Функция средней кнопки мыши.
 # Должно соответствовать переводам строк "Repeat/" и "none", указанным выше
-#: schematic/src/i_basic.c:315
 msgid "Repeat/none"
 msgstr "Повтор: ---"
 
-#: schematic/src/i_basic.c:323 schematic/src/i_callbacks.c:1239
-#: schematic/scheme/gschem/builtins.scm:189
 msgid "Pan"
 msgstr "Центрирование"
 
-#: schematic/src/i_callbacks.c:74
 #, fuzzy, c-format
 msgid "New page created [%1$s]"
 msgstr "Создана новая страница «%s»\n"
 
-#: schematic/src/i_callbacks.c:108
 #, fuzzy, c-format
 msgid "New Window created [%1$s]"
 msgstr "Создано новое окно «%s»\n"
 
-#: schematic/src/i_callbacks.c:245
 msgid "Failed to Save All"
 msgstr "Не удалось сохранить все файлы"
 
-#: schematic/src/i_callbacks.c:247
 msgid "Saved All"
 msgstr "Все файлы сохранены"
 
-#: schematic/src/i_callbacks.c:308
 #, fuzzy
 msgid "Closing Window"
 msgstr "Закрытие окна\n"
 
 # Это используется только в функциях обновления строки состояния, поэтому
 # переводится как существительное, а не глагол, так как означает режим работы.
-#: schematic/src/i_callbacks.c:505 schematic/src/x_menus.c:55
-#: schematic/scheme/gschem/builtins.scm:168
 msgid "Copy"
 msgstr "Копирование"
 
-#: schematic/src/i_callbacks.c:514 schematic/src/i_callbacks.c:539
-#: schematic/src/i_callbacks.c:564
 msgid "Select objs first"
 msgstr "Сначала что-нибудь выделите"
 
 # См. примечание выше для "Copy"
-#: schematic/src/i_callbacks.c:530
 msgid "Multiple Copy"
 msgstr "Многократное копирование"
 
 # См. примечание выше для "Copy"
-#: schematic/src/i_callbacks.c:555 schematic/src/x_menus.c:56
 msgid "Move"
 msgstr "Перемещение"
 
-#: schematic/src/i_callbacks.c:579 schematic/src/x_menus.c:57
-#: schematic/src/x_multiattrib.c:1656 schematic/scheme/gschem/builtins.scm:108
 msgid "Delete"
 msgstr "Удалить"
 
-#: schematic/src/i_callbacks.c:603
 msgid "Edit"
 msgstr "Правка"
 
-#: schematic/src/i_callbacks.c:618 schematic/scheme/gschem/builtins.scm:129
 msgid "Edit Text"
 msgstr "Правка текста"
 
 # Отображение последнего действия для повтора
-#: schematic/src/i_callbacks.c:637
 msgid "Slot"
 msgstr "Правка секции"
 
-#: schematic/src/i_callbacks.c:688 schematic/src/i_callbacks.c:698
 msgid "Rotate"
 msgstr "Поворот"
 
-#: schematic/src/i_callbacks.c:736 schematic/src/i_callbacks.c:746
 msgid "Mirror"
 msgstr "Отражение"
 
-#: schematic/src/i_callbacks.c:763 schematic/src/x_colorcb.c:160
-#: schematic/scheme/conf/schematic/menu.scm:73
-#: schematic/scheme/gschem/builtins.scm:141
 msgid "Lock"
 msgstr "Блокировка"
 
-#: schematic/src/i_callbacks.c:781 schematic/scheme/conf/schematic/menu.scm:74
-#: schematic/scheme/gschem/builtins.scm:144
 msgid "Unlock"
 msgstr "Разблокировка"
 
-#: schematic/src/i_callbacks.c:805
 #, fuzzy
 msgid "WARNING: Do not translate with snap off!"
 msgstr "ВНИМАНИЕ: Не производите смещение с отключенной привязкой!\n"
 
-#: schematic/src/i_callbacks.c:806
 #, fuzzy
 msgid "WARNING: Turning snap on and continuing with translate."
 msgstr "ВНИМАНИЕ: Включите привязку и повторите смещение.\n"
 
-#: schematic/src/i_callbacks.c:813
 #, fuzzy
 msgid "WARNING: Snap grid size is not equal to 100!"
 msgstr "ВНИМАНИЕ: Размер сетки привязки не равен 100!\n"
 
-#: schematic/src/i_callbacks.c:815
 #, fuzzy
 msgid ""
 "WARNING: If you are translating a symbol to the origin, the snap grid size "
@@ -968,26 +746,21 @@ msgstr ""
 "ВНИМАНИЕ: Если символ смещается в начало координат, размер сетки привязки "
 "должен быть установлен в 100\n"
 
-#: schematic/src/i_callbacks.c:847
 msgid "Embed"
 msgstr "Внедрение"
 
-#: schematic/src/i_callbacks.c:886
 msgid "Unembed"
 msgstr "Исключение"
 
-#: schematic/src/i_callbacks.c:928
 msgid "Update"
 msgstr "Обновление"
 
 # Как и прочие строки в gschem/src/i_callbacks.c данная строка используется
 # для показа последнего действия, которое будет использоваться при повторе. В
 # данном случае текст при повторе будет то скрываться, то отображаться
-#: schematic/src/i_callbacks.c:970
 msgid "ShowHidden"
 msgstr "Отображение/скрытие текста"
 
-#: schematic/src/i_callbacks.c:1537
 #, c-format
 msgid ""
 "<b>Revert page:</b>\n"
@@ -998,102 +771,80 @@ msgid ""
 "discarded and page file will be reloaded from disk."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1555
 #, fuzzy
 msgid "Revert"
 msgstr "_Возвратить"
 
-#: schematic/src/i_callbacks.c:1647
 msgid "Copy to clipboard"
 msgstr "Копирование в буфер"
 
-#: schematic/src/i_callbacks.c:1664
 msgid "Cut to clipboard"
 msgstr "Вырезание в буфер"
 
-#: schematic/src/i_callbacks.c:1686
 msgid "Paste from clipboard"
 msgstr "Вставка из буфера"
 
-#: schematic/src/i_callbacks.c:1694
 msgid "Empty clipboard"
 msgstr "Буфер пуст"
 
 #. TRANSLATORS: The number is the number of the buffer that the
 #. * selection is being copied to.
-#: schematic/src/i_callbacks.c:1719
 #, c-format
 msgid "Copy %i"
 msgstr "Копирование в %i"
 
 #. TRANSLATORS: The number is the number of the buffer that the
 #. * selection is being cut to.
-#: schematic/src/i_callbacks.c:1746
 #, c-format
 msgid "Cut %i"
 msgstr "Вырезание в %i"
 
 #. TRANSLATORS: The number is the number of the buffer that is being
 #. * pasted to the schematic.
-#: schematic/src/i_callbacks.c:1776
 #, c-format
 msgid "Paste %i"
 msgstr "Вставка из %i"
 
 # Здесь на самом деле не действие, а состояние. Поэтому не "Очистить буфер", а
 # "Буфер пуст".
-#: schematic/src/i_callbacks.c:1785
 msgid "Empty buffer"
 msgstr "Буфер пуст"
 
 # В обеих функциях речь идёт о добавлении компонента
-#: schematic/src/i_callbacks.c:1833 schematic/src/x_window.c:1203
 msgid "Component"
 msgstr "Добавление компонента"
 
-#: schematic/src/i_callbacks.c:1865 schematic/src/x_colorcb.c:150
 msgid "Attribute"
 msgstr "Атрибут"
 
-#: schematic/src/i_callbacks.c:1885 schematic/src/x_colorcb.c:149
 msgid "Net"
 msgstr "Соединение"
 
-#: schematic/src/i_callbacks.c:1928 schematic/src/x_colorcb.c:155
-#: schematic/src/x_window.c:1222
 msgid "Bus"
 msgstr "Шина"
 
-#: schematic/src/i_callbacks.c:2004
 msgid "Line"
 msgstr "Линия"
 
-#: schematic/src/i_callbacks.c:2021
 msgid "Path"
 msgstr "Контур"
 
-#: schematic/src/i_callbacks.c:2043
 msgid "Box"
 msgstr "Прямоугольник"
 
-#: schematic/src/i_callbacks.c:2085
 msgid "Circle"
 msgstr "Окружность"
 
-#: schematic/src/i_callbacks.c:2108
 msgid "Arc"
 msgstr "Дуга"
 
-#: schematic/src/i_callbacks.c:2131 schematic/src/x_colorcb.c:146
 msgid "Pin"
 msgstr "Вывод"
 
-#: schematic/src/i_callbacks.c:2191
 #, fuzzy, c-format
 msgid "Searching for source [%1$s]"
 msgstr "Поиск источника данных «%s»\n"
 
-#: schematic/src/i_callbacks.c:2223
 #, fuzzy, c-format
 msgid ""
 "Failed to descend hierarchy into '%1$s': %2$s\n"
@@ -1104,122 +855,97 @@ msgstr ""
 "\n"
 "В журнале gschem может быть больше информации."
 
-#: schematic/src/i_callbacks.c:2227
 #, fuzzy, c-format
 msgid "Failed to descend into '%1$s': %2$s"
 msgstr "Не удалось перейти к подсхеме «%s»: %s\n"
 
 # Почти дословно "Спускаться по иерархии", подразумевается, что поиск ведётся
 # во всей иерархической структуре, корнем которой является данная страница
-#: schematic/src/i_callbacks.c:2234
 msgid "Failed to descend hierarchy."
 msgstr "Не удалось перейти к подсхеме."
 
-#: schematic/src/i_callbacks.c:2312
 #, fuzzy, c-format
 msgid "Searching for symbol [%1$s]"
 msgstr "Поиск символа «%s»\n"
 
-#: schematic/src/i_callbacks.c:2320
 #, fuzzy
 msgid "Symbol is not a real file. Symbol cannot be loaded."
 msgstr "Нет реального файла для символа. Символ не может быть загружен.\n"
 
-#: schematic/src/i_callbacks.c:2367 schematic/src/x_tabs.c:1060
 #, fuzzy
 msgid "Cannot find any schematics above the current one!"
 msgstr "Для текущей схемы не удалось найти схему, вышестоящую по иерархии!\n"
 
-#: schematic/src/i_callbacks.c:2400
 msgid "Attach"
 msgstr "Прикрепление"
 
-#: schematic/src/i_callbacks.c:2456
 msgid "Detach"
 msgstr "Отделение"
 
-#: schematic/src/i_callbacks.c:2500
 msgid "ShowN"
 msgstr "Отображение имени"
 
-#: schematic/src/i_callbacks.c:2537
 msgid "ShowV"
 msgstr "Отображение значения"
 
-#: schematic/src/i_callbacks.c:2574
 msgid "ShowB"
 msgstr "Отображение имя=значение"
 
-#: schematic/src/i_callbacks.c:2612
 msgid "VisToggle"
 msgstr "Переключение видимости"
 
-#: schematic/src/i_callbacks.c:2643
 #, c-format
 msgid "Sorry but this is a non-functioning menu option\n"
 msgstr "Извините, но это этот пункт меню не работает\n"
 
-#: schematic/src/i_callbacks.c:2703
 #, fuzzy
 msgid "Action feedback mode set to OUTLINE"
 msgstr "При выполнении действий объекты будут отрисовываться полностью\n"
 
-#: schematic/src/i_callbacks.c:2706
 #, fuzzy
 msgid "Action feedback mode set to BOUNDINGBOX"
 msgstr "При выполнении действий вместо объектов будет отрисовываться рамка\n"
 
-#: schematic/src/i_callbacks.c:2730
 #, fuzzy
 msgid "Grid OFF"
 msgstr "Сетка отключена\n"
 
-#: schematic/src/i_callbacks.c:2731
 #, fuzzy
 msgid "Dot grid selected"
 msgstr "Выбрана сетка из точек\n"
 
-#: schematic/src/i_callbacks.c:2732
 #, fuzzy
 msgid "Mesh grid selected"
 msgstr "Выбрана сетка из линий\n"
 
-#: schematic/src/i_callbacks.c:2733
 #, fuzzy
 msgid "Invalid grid mode"
 msgstr "Недопустимый режим сетки\n"
 
-#: schematic/src/i_callbacks.c:2755
 #, fuzzy
 msgid "Snap OFF (CAUTION!)"
 msgstr "ВНИМАНИЕ! Привязка отключена!\n"
 
-#: schematic/src/i_callbacks.c:2758
 #, fuzzy
 msgid "Snap ON"
 msgstr "Привязка включена\n"
 
-#: schematic/src/i_callbacks.c:2761
 #, fuzzy
 msgid "Snap back to the grid (CAUTION!)"
 msgstr "ВНИМАНИЕ! Включите привязку к сетке!\n"
 
-#: schematic/src/i_callbacks.c:2790
 #, fuzzy
 msgid "Rubber band ON"
 msgstr "Режим «резиновых» соединений включён\n"
 
-#: schematic/src/i_callbacks.c:2792
 #, fuzzy
 msgid "Rubber band OFF"
 msgstr "Режим «резиновых» соединений отключён\n"
 
-#: schematic/src/i_callbacks.c:2811
 #, fuzzy
 msgid "magnetic net mode: ON"
 msgstr "Режим «магнитных» соединений включён\n"
 
-#: schematic/src/i_callbacks.c:2814
 #, fuzzy
 msgid "magnetic net mode: OFF"
 msgstr "Режим «магнитных» соединений отключён\n"
@@ -1229,16 +955,13 @@ msgstr "Режим «магнитных» соединений отключён\
 #. the form "untitled_N.sch", where N is a number.  Please make
 #. sure that the translation contains characters suitable for use
 #. in a filename.
-#: schematic/src/i_vars.c:209
 msgid "untitled"
 msgstr "безымянный"
 
-#: schematic/src/o_complex.c:192 schematic/src/o_complex.c:195
 #, fuzzy, c-format
 msgid "Translating schematic [%1$d %2$d]"
 msgstr "Смещение схемы [%d %d]\n"
 
-#: schematic/src/o_delete.c:82
 #, fuzzy, c-format
 msgid "Delete locked object?"
 msgid_plural "Delete %1$u locked objects?"
@@ -1246,143 +969,117 @@ msgstr[0] "Удалить %u заблокированный объект?"
 msgstr[1] "Удалить %u заблокированных объекта?"
 msgstr[2] "Удалить %u заблокированных объектов?"
 
-#: schematic/src/o_misc.c:55
 #, c-format
 msgid "Got an unexpected NULL in o_edit\n"
 msgstr "o_edit: неожиданный NULL вместо объекта\n"
 
-#: schematic/src/o_misc.c:315
 #, fuzzy
 msgid "Hidden text is now visible"
 msgstr "Скрытый текст теперь видим\n"
 
-#: schematic/src/o_misc.c:317
 #, fuzzy
 msgid "Hidden text is now invisible"
 msgstr "Скрытый текст теперь невидим\n"
 
-#: schematic/src/o_misc.c:425
 #, fuzzy, c-format
 msgid "Could not find symbol [%1$s] in library. Update failed."
 msgstr "Символ «%s» в библиотеке не найден. Обновление не выполнено.\n"
 
 # Квадратные скобки добавлены для единообразия
-#: schematic/src/o_misc.c:541
 #, fuzzy, c-format
 msgid "o_autosave_backups: Can't get the real filename of %1$s."
 msgstr ""
 "o_autosave_backups: не удалось определить имя реального файла для «%s»."
 
-#: schematic/src/o_misc.c:585
 #, fuzzy, c-format
 msgid "Could NOT set previous backup file [%1$s] read-write"
 msgstr ""
 "Не удалось установить режим доступа на чтение-запись для предыдущей "
 "резервной копии файла «%s»\n"
 
-#: schematic/src/o_misc.c:605
 #, fuzzy, c-format
 msgid "Could NOT set backup file [%1$s] readonly"
 msgstr ""
 "Не удалось установить режим доступа только на чтение для файла резервной "
 "копии «%s»\n"
 
-#: schematic/src/o_misc.c:610
 #, fuzzy, c-format
 msgid "Could NOT save backup file [%1$s]"
 msgstr "Не удалось сохранить файл резервной копии «%s»\n"
 
-#: schematic/src/o_move.c:192
 #, c-format
 msgid "ERROR: NULL object in o_move_end!\n"
 msgstr "o_move_end: ОШИБКА! NULL вместо объекта\n"
 
 # whichone -- флаг, определяющий подключаемый конец для соединения
-#: schematic/src/o_move.c:519
 #, c-format
 msgid "DOH! tried to find the whichone, but didn't find it!\n"
 msgstr ""
 "Ох! Попытка найти точку подключения для соединения оказалась безуспешной!\n"
 
 # Имеется в виду, что объект не является соединением, выводом или шиной
-#: schematic/src/o_move.c:546
 #, c-format
 msgid "Got a non line object in o_move_check_endpoint\n"
 msgstr "o_move_check_endpoint: задан объект, не являющийся линейным\n"
 
-#: schematic/src/o_net.c:444
 #, fuzzy
 msgid "Warning: Starting net at off grid coordinate"
 msgstr "Внимание: начальная точка соединения не совпадает с узлом сетки\n"
 
-#: schematic/src/o_net.c:508
 #, fuzzy
 msgid "Warning: Ending net at off grid coordinate"
 msgstr "Внимание: конечная точка соединения не совпадает с узлом сетки\n"
 
-#: schematic/src/o_net.c:856 schematic/src/o_net.c:893
-#: schematic/src/o_net.c:964 schematic/src/o_net.c:1000
 #, c-format
 msgid "Tried to add more than two bus rippers. Internal gschem error.\n"
 msgstr ""
 "Попытка добавить более двух ответвлений шины. Внутренняя ошибка gschem.\n"
 
-#: schematic/src/o_net.c:1068
 #, fuzzy, c-format
 msgid "Bus ripper symbol [%1$s] was not found in any component library"
 msgstr ""
 "Символ ответвления шины «%s» не найден ни в одной из библиотек компонентов\n"
 
 # Заголовок окна выбора файла изображения
-#: schematic/src/o_picture.c:133 schematic/src/o_picture.c:343
 msgid "Select a picture file..."
 msgstr "Выберите файл изображения"
 
 # Квадратные скобки добавлены для единообразия
-#: schematic/src/o_picture.c:166
 #, fuzzy, c-format
 msgid "Failed to load picture: %1$s"
 msgstr "Не удалось загрузить изображение: «%s»"
 
 # Используется для вывода действия повтора в строке состояния
-#: schematic/src/o_picture.c:182
 msgid "Picture"
 msgstr "Вставка изображения"
 
 # Квадратные скобки добавлены для единообразия
-#: schematic/src/o_picture.c:378
 #, c-format
 msgid "Failed to replace pictures: %s"
 msgstr "Не удалось заменить изображение: «%s»"
 
-#: schematic/src/o_slot.c:80
 #, fuzzy
 msgid "Slot attribute malformed"
 msgstr "Недопустимый формат атрибута «slot»\n"
 
 # Используется в паре со следующей строкой
-#: schematic/src/o_slot.c:88
 #, fuzzy
 msgid "numslots attribute missing"
 msgstr "Атрибут «numslots» отсутствует\n"
 
 # Используется в паре с предыдущей строкой
-#: schematic/src/o_slot.c:89
 #, fuzzy
 msgid "Slotting not allowed for this component"
 msgstr "Нумерация секций для этого компонента невозможна\n"
 
-#: schematic/src/o_slot.c:104
 #, fuzzy
 msgid "New slot number out of range"
 msgstr "Новый номер секции вне допустимого диапазона\n"
 
-#: schematic/src/o_undo.c:397
 #, fuzzy
 msgid "Undo/Redo disabled in rc file"
 msgstr "Отмена/повтор отключены в файле настроек\n"
 
-#: schematic/src/parsecmd.c:77
 #, fuzzy, c-format
 msgid ""
 "Usage: %1$s [OPTION ...] [--] [FILE ...]\n"
@@ -1429,12 +1126,11 @@ msgstr ""
 "Отчёты об ошибках отправляйте по адресу <https://bugs.launchpad.net/geda>\n"
 "Домашняя страница gEDA/gaf: <http://www.geda-project.org/>\n"
 
-#: schematic/src/parsecmd.c:110
 #, fuzzy, c-format
 msgid ""
 "Lepton EDA %1$s (git: %2$.7s)\n"
 "Copyright (C) 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright (C) 2017-2018 Lepton Developers.\n"
+"Copyright (C) 2017-2019 Lepton Developers.\n"
 "This is free software, and you are welcome to redistribute it under\n"
 "certain conditions. For details, see the file `COPYING', which is\n"
 "included in the Lepton EDA distribution.\n"
@@ -1448,19 +1144,16 @@ msgstr ""
 "Нет НИКАКИХ ГАРАНТИЙ в рамках, допустимых имеющимся\n"
 "законодательством.\n"
 
-#: schematic/src/x_attribedit.c:125
 #, c-format
 msgid "Got invalid show option; defaulting to show both\n"
 msgstr ""
 "Выбран недопустимый способ отображения, установка отображения имени и "
 "значения\n"
 
-#: schematic/src/x_attribedit.c:139
 #, c-format
 msgid "ERROR: NULL object!\n"
 msgstr "ОШИБКА! NULL вместо объекта\n"
 
-#: schematic/src/x_attribedit.c:328
 msgid "Single Attribute Editor"
 msgstr "Редактор атрибута"
 
@@ -1468,69 +1161,53 @@ msgstr "Редактор атрибута"
 # там далее идут поля "Имя" и "Значение". Т. е. "изменить ... имя"
 # представляется красивше, чем "изменить атрибут ... имя", т. к. и так известно
 # (из заголовка окна), что меняется атрибут.
-#: schematic/src/x_attribedit.c:358
 msgid "<b>Edit Attribute</b>"
 msgstr "<b>Изменить</b>"
 
 # См. выше. Но тут слово "атрибут" необходимо. Иначе получается "добавить ... имя" или
 # "значение", а не "атрибут".
-#: schematic/src/x_attribedit.c:360
 msgid "<b>Add Attribute</b>"
 msgstr "<b>Добавить атрибут</b>"
 
-#: schematic/src/x_attribedit.c:376
 #, fuzzy
 msgid "N_ame:"
 msgstr "Имя:"
 
-#: schematic/src/x_attribedit.c:396 schematic/src/x_multiattrib.c:2222
 #, fuzzy
 msgid "_Value:"
 msgstr "Значение:"
 
-#: schematic/src/x_attribedit.c:415 schematic/src/x_multiattrib.c:2281
 #, fuzzy
 msgid "Vi_sible"
 msgstr "Отображать"
 
-#: schematic/src/x_attribedit.c:434
 msgid "Show Value Only"
 msgstr "Значение"
 
-#: schematic/src/x_attribedit.c:436
 msgid "Show Name Only"
 msgstr "Имя"
 
-#: schematic/src/x_attribedit.c:438 schematic/src/x_multiattrib.c:1620
-#: schematic/scheme/gschem/builtins.scm:324
 msgid "Show Name & Value"
 msgstr "Имя и значение"
 
-#: schematic/src/x_attribedit.c:445
 msgid "<b>Attach Options</b>"
 msgstr ""
 "<b>Объекты, к которым следует\n"
 " прикрепить атрибут:</b>"
 
-#: schematic/src/x_attribedit.c:460
 msgid "All"
 msgstr "Все"
 
-#: schematic/src/x_attribedit.c:476 schematic/src/x_compselect.c:986
-#: schematic/src/x_compselect.c:1100
 msgid "Components"
 msgstr "Компоненты"
 
-#: schematic/src/x_attribedit.c:492 schematic/src/x_window.c:1214
 msgid "Nets"
 msgstr "Соединения"
 
 # Здесь под "существующими" понимаются, конечно же, одноимённые
-#: schematic/src/x_attribedit.c:508
 msgid "Replace existing attributes"
 msgstr "Заместить одноимённые атрибуты"
 
-#: schematic/src/x_autonumber.c:412
 #, fuzzy
 msgid ""
 "slotted object without slot attribute may cause problems when autonumbering "
@@ -1539,7 +1216,6 @@ msgstr ""
 "Многосекционный объект без атрибута «slot» может вызвать проблемы при "
 "автонумерации секций\n"
 
-#: schematic/src/x_autonumber.c:427
 #, fuzzy, c-format
 msgid ""
 "duplicate slot may cause problems: [symbolname=%1$s, number=%2$d, slot=%3$d]"
@@ -1547,102 +1223,79 @@ msgstr ""
 "Дублирование секций может вызвать проблемы: symbolname=%s, number=%d, slot="
 "%d\n"
 
-#: schematic/src/x_autonumber.c:675
 #, fuzzy
 msgid "No searchstring given in autonumber text."
 msgstr "Не задано выражение для автонумерации.\n"
 
-#: schematic/src/x_autonumber.c:728
 #, fuzzy
 msgid "No '*' or '?' given at the end of the autonumber text."
 msgstr "В конце выражения для автонумерации не задан символ «*» или «?».\n"
 
-#: schematic/src/x_autonumber.c:873
 msgid "Diagonal"
 msgstr "По диагонали"
 
-#: schematic/src/x_autonumber.c:874
 msgid "Top to bottom"
 msgstr "Сверху вниз"
 
-#: schematic/src/x_autonumber.c:875
 msgid "Bottom to top"
 msgstr "Снизу вверх"
 
-#: schematic/src/x_autonumber.c:876
 msgid "Left to right"
 msgstr "Слева направо"
 
-#: schematic/src/x_autonumber.c:877
 msgid "Right to left"
 msgstr "Справа налево"
 
 # По порядку нахождения элементов в тексте файла, то есть по порядку их
 # добавления
-#: schematic/src/x_autonumber.c:878
 msgid "File order"
 msgstr "По порядку в файле"
 
-#: schematic/src/x_autonumber.c:1214
 msgid "Autonumber text"
 msgstr "Автонумерация"
 
-#: schematic/src/x_autonumber.c:1237
 msgid "<b>Scope</b>"
 msgstr "<b>Ограничения</b>"
 
-#: schematic/src/x_autonumber.c:1259
 msgid "Search for:"
 msgstr "Выражение:"
 
-#: schematic/src/x_autonumber.c:1273
 msgid "Autonumber text in:"
 msgstr "Область автонумерации:"
 
 # Здесь определяется область, уже имеющиеся номера в которой для новой
 # автонумерации использоваться не должны
-#: schematic/src/x_autonumber.c:1280
 msgid "Skip numbers found in:"
 msgstr "Пропуск номеров, уже имеющихся в области:"
 
-#: schematic/src/x_autonumber.c:1292 schematic/src/x_autonumber.c:1301
 msgid "Selected objects"
 msgstr "Выделенные объекты"
 
-#: schematic/src/x_autonumber.c:1293 schematic/src/x_autonumber.c:1302
 msgid "Current page"
 msgstr "Текущая страница"
 
-#: schematic/src/x_autonumber.c:1294 schematic/src/x_autonumber.c:1303
 msgid "Whole hierarchy"
 msgstr "Вся иерархия"
 
-#: schematic/src/x_autonumber.c:1305
 msgid "Overwrite existing numbers"
 msgstr "Перезаписывать уже имеющиеся номера"
 
-#: schematic/src/x_autonumber.c:1310
 msgid "<b>Options</b>"
 msgstr "<b>Настройки</b>"
 
-#: schematic/src/x_autonumber.c:1332
 msgid "Starting number:"
 msgstr "Начальный номер:"
 
 # "Порядок сортировки:" не очень подходит в данном случае
-#: schematic/src/x_autonumber.c:1339
 msgid "Sort order:"
 msgstr "Порядок нумерации:"
 
-#: schematic/src/x_autonumber.c:1371
 msgid "Remove numbers"
 msgstr "Удалить все номера"
 
-#: schematic/src/x_autonumber.c:1375
 msgid "Automatic slotting"
 msgstr "Автоматически нумеровать секции"
 
-#: schematic/src/x_clipboard.c:245
 #, c-format
 msgid ""
 "<b>Invalid schematic on clipboard.</b>\n"
@@ -1654,7 +1307,6 @@ msgstr ""
 "Ошибка при вставке данных из буфера: %s."
 
 # Заголовок окна ошибки
-#: schematic/src/x_clipboard.c:247
 msgid "Clipboard insertion failed"
 msgstr "Ошибка вставки данных из буфера обмена"
 
@@ -1662,23 +1314,19 @@ msgstr "Ошибка вставки данных из буфера обмена"
 # как речь идёт о резервировании поля в colormap.
 # %s разместил по-другому, потому что будет выдаваться, например, "чёрный
 # цвет".
-#: schematic/src/x_color.c:89 schematic/src/x_color.c:98
 #, fuzzy, c-format
 msgid "Could not allocate the color %1$s!\n"
 msgstr "Не удалось выделить %s цвет!\n"
 
-#: schematic/src/x_color.c:89
 msgid "black"
 msgstr "чёрный"
 
-#: schematic/src/x_color.c:98
 msgid "white"
 msgstr "белый"
 
 # См. перевод выше.
 # В этом случае речь идёт о выделении поля для цвета с указанным индексом.
 # Про "display color" и "outline color" см. примечания ниже
-#: schematic/src/x_color.c:120
 #, fuzzy, c-format
 msgid "Could not allocate display color %1$i!\n"
 msgstr "Не удалось выделить цвет для индекса %i!\n"
@@ -1686,7 +1334,6 @@ msgstr "Не удалось выделить цвет для индекса %i!\
 # "outline" ни к каким контурам отношения не имеет. Более того, ввиду ошибок
 # реализации вообще малоинформативное сообщение. См. примечания к
 # нижеследующим переводам.
-#: schematic/src/x_color.c:142
 #, fuzzy, c-format
 msgid "Could not allocate outline color %1$i!\n"
 msgstr "Невозможно выделить цвет контура %i!\n"
@@ -1698,141 +1345,109 @@ msgstr "Невозможно выделить цвет контура %i!\n"
 # инициализации display_colors[], вторая для display_outline_colors[]. Так что
 # бессмысленно здесь делать какие-то различения.
 # См. также примечание к следующему переводу.
-#: schematic/src/x_color.c:159
 #, fuzzy, c-format
 msgid "Tried to get an invalid color: %1$d\n"
 msgstr "Запрос недопустимого цвета: %d\n"
 
-#: schematic/src/x_colorcb.c:145
 msgid "Background"
 msgstr "Фон"
 
-#: schematic/src/x_colorcb.c:147
 msgid "Net endpoint"
 msgstr "Метка конца соединения"
 
-#: schematic/src/x_colorcb.c:148
 msgid "Graphic"
 msgstr "Графический объект"
 
-#: schematic/src/x_colorcb.c:151
 msgid "Logic bubble"
 msgstr "Логическая инверсия"
 
-#: schematic/src/x_colorcb.c:152
 msgid "Grid point"
 msgstr "Точка сетки"
 
-#: schematic/src/x_colorcb.c:153
 msgid "Detached attribute"
 msgstr "Неприкреплённый атрибут"
 
-#: schematic/src/x_colorcb.c:156
 msgid "Selection"
 msgstr "Выделение"
 
 # Цвет рамки, которая отображается при переключении "Внешние контуры/Рамка"
 # вместо объекта
-#: schematic/src/x_colorcb.c:157
 msgid "Bounding box"
 msgstr "Ограничительная рамка"
 
-#: schematic/src/x_colorcb.c:158
 msgid "Zoom box"
 msgstr "Рамка масштабирования"
 
 # Можно было бы "Фон распечатки", но можно вывести и в файл...
-#: schematic/src/x_colorcb.c:161
 msgid "Output background"
 msgstr "Фон экспорта"
 
-#: schematic/src/x_colorcb.c:162
 msgid "Freestyle 1"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:163
 msgid "Freestyle 2"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:164
 msgid "Freestyle 3"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:165
 msgid "Freestyle 4"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:166
 msgid "Net junction"
 msgstr "Соединительная точка"
 
-#: schematic/src/x_colorcb.c:167
 msgid "Mesh grid major"
 msgstr "Линии сетки основные"
 
-#: schematic/src/x_colorcb.c:168
 msgid "Mesh grid minor"
 msgstr "Линии сетки вспомогательные"
 
 # Имеется в виду цвет
-#: schematic/src/x_colorcb.c:172
 msgid "Unknown"
 msgstr "Неизвестный"
 
-#: schematic/src/x_compselect.c:1169
 #, fuzzy
 msgid "Reset filter"
 msgstr "Новый файл"
 
-#: schematic/src/x_compselect.c:1192
 msgid "Reload all libraries"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1245 schematic/src/x_multiattrib.c:2092
 msgid "Value"
 msgstr "Значение"
 
-#: schematic/src/x_compselect.c:1284
 msgid "Default behavior - reference component"
 msgstr "Вставить как ссылку (по умолчанию)"
 
-#: schematic/src/x_compselect.c:1287
 msgid "Embed component in schematic"
 msgstr "Внедрить в схему"
 
-#: schematic/src/x_compselect.c:1290
 msgid "Include component as individual objects"
 msgstr "Вставить как отдельные объекты"
 
-#: schematic/src/x_compselect.c:1448
 msgid "Select Component..."
 msgstr "Выбор компонента"
 
-#: schematic/src/x_compselect.c:1471
 #, fuzzy
 msgid "In Us_e"
 msgstr "Используемые"
 
 # Можно просто "Библиотеки", но вместе с "Используемые", думаю будет лучше так
-#: schematic/src/x_compselect.c:1475
 #, fuzzy
 msgid "Lib_raries"
 msgstr "Библиотечные"
 
 # Можно "Предварительный просмотр", но занимает много места на экране
-#: schematic/src/x_compselect.c:1484 schematic/src/x_fileselect.c:119
 msgid "Preview"
 msgstr "Предпросмотр"
 
-#: schematic/src/x_compselect.c:1510
 msgid "Attributes"
 msgstr "Атрибуты"
 
-#: schematic/src/x_dialog.c:325
 msgid "Major symbol changes detected."
 msgstr "Обнаружено значительное изменение символа."
 
-#: schematic/src/x_dialog.c:349
 msgid ""
 "Changes have occurred to the symbols shown below.\n"
 "\n"
@@ -1842,11 +1457,9 @@ msgstr ""
 "\n"
 "Удостоверьтесь, что проверили каждый из них."
 
-#: schematic/src/x_dialog.c:369
 msgid "Symbol"
 msgstr "Символ"
 
-#: schematic/src/x_dialog.c:406
 #, c-format
 msgid ""
 "<span weight=\"bold\" size=\"larger\">The input attribute \"%s\" is invalid\n"
@@ -1864,42 +1477,33 @@ msgstr ""
 "Имя не должно заканчиваться пробелом.\n"
 "Значение не должно начинаться с пробела."
 
-#: schematic/src/x_dialog.c:408
 msgid "Invalid Attribute"
 msgstr "Недопустимый атрибут"
 
-#: schematic/src/x_fileselect.c:37
 msgid "Schematics"
 msgstr "Схемы"
 
-#: schematic/src/x_fileselect.c:42
 msgid "Symbols"
 msgstr "Символы"
 
-#: schematic/src/x_fileselect.c:47
 msgid "Schematics and symbols"
 msgstr "Схемы и символы"
 
-#: schematic/src/x_fileselect.c:53
 msgid "All files"
 msgstr "Все файлы"
 
 # Заголовок окна выбора файла при открывании существующего файла
-#: schematic/src/x_fileselect.c:169
 msgid "Open..."
 msgstr "Выберите файл"
 
 # Заголовок окна выбора файла при сохранении
-#: schematic/src/x_fileselect.c:233
 msgid "Save as..."
 msgstr "Введите имя файла для сохранения"
 
-#: schematic/src/x_fileselect.c:297
 #, fuzzy
 msgid "Save cancelled on user request"
 msgstr "Сохранение отменено по команде пользователя\n"
 
-#: schematic/src/x_fileselect.c:334
 msgid ""
 "\n"
 "If you load the original file, the backup file will be overwritten in the "
@@ -1913,28 +1517,22 @@ msgstr ""
 "\n"
 "Загрузить файл резервной копии?\n"
 
-#: schematic/src/x_fstylecb.c:73
 msgid "Hollow"
 msgstr "Пусто"
 
-#: schematic/src/x_fstylecb.c:80
 msgid "Filled"
 msgstr "Заливка"
 
-#: schematic/src/x_fstylecb.c:87
 msgid "Mesh"
 msgstr "Сетка"
 
-#: schematic/src/x_fstylecb.c:94
 msgid "Hatch"
 msgstr "Штриховка"
 
-#: schematic/src/x_image.c:279
 #, fuzzy, c-format
 msgid "x_image_lowlevel: Unable to write %1$s file %2$s."
 msgstr "x_image_lowlevel: не удалось записать %s-файл %s.\n"
 
-#: schematic/src/x_image.c:289
 #, fuzzy, c-format
 msgid ""
 "There was the following error when saving image with type %1$s to filename:\n"
@@ -1947,200 +1545,152 @@ msgstr ""
 "\n"
 "%s.\n"
 
-#: schematic/src/x_image.c:309
 #, fuzzy, c-format
 msgid "Wrote color image to [%1$s] [%2$d x %3$d]"
 msgstr "Записано цветное изображение в «%s» [%d×%d]\n"
 
-#: schematic/src/x_image.c:311
 #, fuzzy, c-format
 msgid "Wrote black and white image to [%1$s] [%2$d x %3$d]"
 msgstr "Записано чёрно-белое изображение в «%s» [%d×%d]\n"
 
-#: schematic/src/x_image.c:319
 #, fuzzy
 msgid "x_image_lowlevel: Unable to get pixbuf from gschem's window."
 msgstr "x_image_lowlevel: не удалось получить растровую копию окна gschem.\n"
 
-#: schematic/src/x_image.c:358
 msgid "Width x Height"
 msgstr "Ширина × высота"
 
-#: schematic/src/x_image.c:374
 msgid "Image type"
 msgstr "Формат"
 
-#: schematic/src/x_image.c:395
 msgid "Write image..."
 msgstr "Введите имя файла для изображения"
 
-#: schematic/src/x_linecapcb.c:74
 msgid "Butt"
 msgstr "Усечённые"
 
-#: schematic/src/x_linecapcb.c:81
 msgid "Square"
 msgstr "Прямые"
 
-#: schematic/src/x_linecapcb.c:88
 msgid "Round"
 msgstr "Закруглённые"
 
-#: schematic/src/x_linetypecb.c:74
 msgid "Solid"
 msgstr "Сплошная"
 
-#: schematic/src/x_linetypecb.c:81
 msgid "Dotted"
 msgstr "Пунктир"
 
-#: schematic/src/x_linetypecb.c:88
 msgid "Dashed"
 msgstr "Штрих"
 
-#: schematic/src/x_linetypecb.c:95
 msgid "Center"
 msgstr "Штрих-пунктир"
 
-#: schematic/src/x_linetypecb.c:102
 msgid "Phantom"
 msgstr "Двойной штрих-пунктир"
 
 # Контекстное меню, вызываемое по правой кнопке в основном окне.
-#: schematic/src/x_menus.c:41 schematic/scheme/gschem/builtins.scm:267
 msgid "Add Net"
 msgstr "Добавить соединение"
 
-#: schematic/src/x_menus.c:42 schematic/src/x_multiattrib.c:2187
-#: schematic/scheme/gschem/builtins.scm:264
 msgid "Add Attribute"
 msgstr "Добавить атрибут"
 
-#: schematic/src/x_menus.c:43 schematic/scheme/gschem/builtins.scm:261
 msgid "Add Component"
 msgstr "Добавить компонент"
 
-#: schematic/src/x_menus.c:44 schematic/scheme/gschem/builtins.scm:270
 msgid "Add Bus"
 msgstr "Добавить шину"
 
-#: schematic/src/x_menus.c:45 schematic/scheme/gschem/builtins.scm:273
 msgid "Add Text"
 msgstr "Добавить текст"
 
-#: schematic/src/x_menus.c:47 schematic/scheme/gschem/builtins.scm:210
 msgid "Zoom In"
 msgstr "Увеличить"
 
-#: schematic/src/x_menus.c:48 schematic/scheme/gschem/builtins.scm:213
 msgid "Zoom Out"
 msgstr "Уменьшить"
 
-#: schematic/src/x_menus.c:50 schematic/scheme/gschem/builtins.scm:207
 msgid "Zoom Extents"
 msgstr "Уместить в окне"
 
-#: schematic/src/x_menus.c:52 schematic/src/x_window.c:1233
 msgid "Select"
 msgstr "Выделение"
 
-#: schematic/src/x_menus.c:53 schematic/scheme/conf/schematic/menu.scm:69
-#: schematic/scheme/gschem/builtins.scm:126
 msgid "Edit..."
 msgstr "Правка..."
 
-#: schematic/src/x_menus.c:54 schematic/scheme/conf/schematic/menu.scm:68
 #, fuzzy
 msgid "Object Properties..."
 msgstr "<b>Текст</b>"
 
-#: schematic/src/x_menus.c:59 schematic/scheme/gschem/builtins.scm:300
 msgid "Down Schematic"
 msgstr "Войти в подсхему"
 
-#: schematic/src/x_menus.c:60 schematic/scheme/gschem/builtins.scm:303
 msgid "Down Symbol"
 msgstr "Войти в символ"
 
-#: schematic/src/x_menus.c:61
 msgid "Up"
 msgstr "Вверх"
 
-#: schematic/src/x_menus.c:336
 #, fuzzy, c-format
 msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
 msgstr ""
 "Попытка установки чувствительности несуществующего элемента меню «%s»\n"
 
-#: schematic/src/x_menus.c:360
 #, c-format
 msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
 msgstr ""
 "Попытка установки чувствительности несуществующего элемента меню «%s»\n"
 
-#: schematic/src/x_misc.c:70
 msgid "The operating system is out of memory or resources."
 msgstr "Операционной системе не хватает памяти или ресурсов."
 
-#: schematic/src/x_multiattrib.c:798 schematic/src/x_multiattrib.c:2704
 msgid "<various>"
 msgstr "<различные>"
 
-#: schematic/src/x_multiattrib.c:930
 msgid "Attributes with empty name are not allowed. Please set a name."
 msgstr "Не допускается отсутствие имени у атрибута. Введите имя."
 
-#: schematic/src/x_multiattrib.c:1622
 msgid "Show Value only"
 msgstr "Значение"
 
-#: schematic/src/x_multiattrib.c:1624
 msgid "Show Name only"
 msgstr "Имя"
 
-#: schematic/src/x_multiattrib.c:1651
 msgid "Promote"
 msgstr "Вынести"
 
-#: schematic/src/x_multiattrib.c:1655
 msgid "Duplicate"
 msgstr "Дублировать"
 
-#: schematic/src/x_multiattrib.c:1657
 msgid "Copy to all"
 msgstr "Скопировать во все"
 
-#: schematic/src/x_multiattrib.c:1986 schematic/src/x_multiattrib.c:2602
 msgid "Edit Attributes"
 msgstr "Правка атрибутов"
 
-#: schematic/src/x_multiattrib.c:2112
 msgid "Vis?"
 msgstr "Видимый"
 
-#: schematic/src/x_multiattrib.c:2130
 msgid "N"
 msgstr "И"
 
-#: schematic/src/x_multiattrib.c:2148
 msgid "V"
 msgstr "З"
 
-#: schematic/src/x_multiattrib.c:2170
 #, fuzzy
 msgid "Sho_w inherited attributes"
 msgstr "Показать унаследованные атрибуты"
 
-#: schematic/src/x_multiattrib.c:2197
 #, fuzzy
 msgid "_Name:"
 msgstr "Имя:"
 
-#: schematic/src/x_multiattrib.c:2241
 msgid "Ctrl+Enter inserts new line; Ctrl+Tab inserts Tab"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2618
 #, fuzzy, c-format
 msgid "%2$i symbol (%1$s)"
 msgid_plural "%2$i symbols (%1$s)"
@@ -2148,7 +1698,6 @@ msgstr[0] "%i символ (%s)"
 msgstr[1] "%i символа (%s)"
 msgstr[2] "%i символов (%s)"
 
-#: schematic/src/x_multiattrib.c:2624
 #, fuzzy, c-format
 msgid "%1$i pin"
 msgid_plural "%1$i pins"
@@ -2156,7 +1705,6 @@ msgstr[0] "%i вывод"
 msgstr[1] "%i вывода"
 msgstr[2] "%i выводов"
 
-#: schematic/src/x_multiattrib.c:2630
 #, fuzzy, c-format
 msgid "%1$i net"
 msgid_plural "%1$i nets"
@@ -2164,7 +1712,6 @@ msgstr[0] "%i соединение"
 msgstr[1] "%i соединения"
 msgstr[2] "%i соединений"
 
-#: schematic/src/x_multiattrib.c:2636
 #, fuzzy, c-format
 msgid "%1$i bus"
 msgid_plural "%1$i buses"
@@ -2172,7 +1719,6 @@ msgstr[0] "%i шина"
 msgstr[1] "%i шины"
 msgstr[2] "%i шин"
 
-#: schematic/src/x_multiattrib.c:2642
 #, fuzzy, c-format
 msgid "%1$i attribute"
 msgid_plural "%1$i attributes"
@@ -2180,52 +1726,41 @@ msgstr[0] "%i атрибут"
 msgstr[1] "%i атрибута"
 msgstr[2] "%i атрибутов"
 
-#: schematic/src/x_newtext.c:433
 msgid "Text Entry..."
 msgstr "Ввод текста..."
 
-#: schematic/src/x_pagesel.c:253
 msgid "New Page"
 msgstr "Новая страница"
 
-#: schematic/src/x_pagesel.c:254
 msgid "Open Page..."
 msgstr "Открыть страницу..."
 
-#: schematic/src/x_pagesel.c:256
 msgid "Save Page"
 msgstr "Сохранить страницу"
 
-#: schematic/src/x_pagesel.c:257 schematic/scheme/gschem/builtins.scm:246
 msgid "Close Page"
 msgstr "Закрыть страницу"
 
-#: schematic/src/x_pagesel.c:376 schematic/scheme/gschem/builtins.scm:237
 msgid "Page Manager"
 msgstr "Менеджер страниц"
 
-#: schematic/src/x_pagesel.c:448
 msgid "Changed"
 msgstr "Изменён"
 
-#: schematic/src/x_pagesel.c:468
 msgid "Right click on the filename for more options..."
 msgstr ""
 "Щёлкните по имени файла правой кнопкой для выбора дополнительных действий."
 
 # Квадратные скобки добавлены для единообразия
-#: schematic/src/x_print.c:306
 #, c-format
 msgid "Failed to write PDF to '%s': %s\n"
 msgstr "Не удалось записать PDF в «%s»: %s\n"
 
 # Квадратные скобки добавлены для единообразия
-#: schematic/src/x_print.c:364
 #, fuzzy, c-format
 msgid "Failed to write PDF to '%1$s': %2$s\n"
 msgstr "Не удалось записать PDF в «%s»: %s\n"
 
-#: schematic/src/x_print.c:449
 #, fuzzy, c-format
 msgid ""
 "Error printing file:\n"
@@ -2234,12 +1769,10 @@ msgstr ""
 "Ошибка печати файла:\n"
 "%s"
 
-#: schematic/src/x_rc.c:39
 #, fuzzy
 msgid "ERROR: An unknown error occurred while parsing configuration files."
 msgstr "ОШИБКА: неизвестная ошибка при анализе файлов настроек.\n"
 
-#: schematic/src/x_rc.c:44
 #, fuzzy
 msgid ""
 "An unknown error occurred while parsing configuration files.\n"
@@ -2250,12 +1783,10 @@ msgstr ""
 "\n"
 "В журнале gschem может быть больше информации."
 
-#: schematic/src/x_rc.c:56
 #, fuzzy, c-format
 msgid "ERROR: %1$s"
 msgstr "ОШИБКА: %s\n"
 
-#: schematic/src/x_rc.c:59
 #, fuzzy, c-format
 msgid ""
 "%1$s\n"
@@ -2266,140 +1797,109 @@ msgstr ""
 "\n"
 "В журнале gschem может быть больше информации."
 
-#: schematic/src/x_rc.c:67
 #, fuzzy
 msgid "Cannot load lepton-schematic configuration."
 msgstr "Не удалось загрузить файлы настроек gschem"
 
-#: schematic/src/x_script.c:42 schematic/scheme/conf/schematic/menu.scm:40
 msgid "Execute Script..."
 msgstr "Выполнить скрипт..."
 
-#: schematic/src/x_script.c:61
 #, fuzzy, c-format
 msgid "Executing guile script [%1$s]"
 msgstr "Выполнение скрипта Guile «%s»\n"
 
-#: schematic/src/x_tabs.c:860
 #, fuzzy, c-format
 msgid "Hierarchy up: %s"
 msgstr "_Иерархия"
 
-#: schematic/src/x_tabs.c:863
 #, fuzzy
 msgid "Hierarchy up"
 msgstr "_Иерархия"
 
-#: schematic/src/x_widgets.c:158 schematic/src/x_window.c:1444
 msgid "Options"
 msgstr "Настройки"
 
-#: schematic/src/x_widgets.c:203 schematic/src/x_window.c:1436
 msgid "Object"
 msgstr "Объект"
 
-#: schematic/src/x_widgets.c:224
 msgid "Log"
 msgstr ""
 
-#: schematic/src/x_widgets.c:245 schematic/src/x_window.c:1466
 msgid "Find Text"
 msgstr "Поиск"
 
-#: schematic/src/x_widgets.c:259
 #, fuzzy
 msgid "Color Scheme Editor"
 msgstr "Светлая цветовая схема"
 
-#: schematic/src/x_widgets.c:272 schematic/scheme/gschem/builtins.scm:378
 #, fuzzy
 msgid "Select Schematic Font"
 msgstr "_Выберите сохраняемые схемы:"
 
-#: schematic/src/x_window.c:763
 #, fuzzy, c-format
 msgid "Loading schematic [%1$s]"
 msgstr "Загрузка схемы «%s»\n"
 
-#: schematic/src/x_window.c:864
 #, fuzzy, c-format
 msgid "Could NOT save page [%1$s]\n"
 msgstr "Не удалось сохранить страницу «%s»\n"
 
-#: schematic/src/x_window.c:865
 msgid "Error while trying to save"
 msgstr "Ошибка при попытке сохранения"
 
-#: schematic/src/x_window.c:875
 msgid "Failed to save file"
 msgstr "Не удалось сохранить файл"
 
-#: schematic/src/x_window.c:885
 #, fuzzy, c-format
 msgid "Saved as [%1$s]"
 msgstr "Файл сохранён под именем «%s»\n"
 
-#: schematic/src/x_window.c:887
 #, fuzzy, c-format
 msgid "Saved [%1$s]"
 msgstr "Файл «%s» сохранён\n"
 
-#: schematic/src/x_window.c:889
 msgid "Saved"
 msgstr "Файл сохранён"
 
-#: schematic/src/x_window.c:966
 #, fuzzy, c-format
 msgid "Discarding page [%1$s]"
 msgstr "Закрытие «%s» без сохранения изменений\n"
 
-#: schematic/src/x_window.c:966
 #, fuzzy, c-format
 msgid "Closing [%1$s]"
 msgstr "Закрытие «%s»\n"
 
 # Подписи к кнопкам панели инструментов
-#: schematic/src/x_window.c:1175
 msgid "New"
 msgstr "Новый"
 
-#: schematic/src/x_window.c:1175
 msgid "New file"
 msgstr "Новый файл"
 
-#: schematic/src/x_window.c:1179
 msgid "Open"
 msgstr "Открыть"
 
-#: schematic/src/x_window.c:1179
 msgid "Open file"
 msgstr "Открыть файл"
 
-#: schematic/src/x_window.c:1183 schematic/scheme/gschem/builtins.scm:59
 msgid "Save"
 msgstr "Сохранить"
 
-#: schematic/src/x_window.c:1183
 msgid "Save file"
 msgstr "Сохранить файл"
 
-#: schematic/src/x_window.c:1189 schematic/scheme/gschem/builtins.scm:93
 msgid "Undo"
 msgstr "Отменить"
 
-#: schematic/src/x_window.c:1189
 msgid "Undo last operation"
 msgstr "Отменить последнее действие"
 
-#: schematic/src/x_window.c:1193 schematic/scheme/gschem/builtins.scm:96
 msgid "Redo"
 msgstr "Повторить"
 
-#: schematic/src/x_window.c:1193
 msgid "Redo last undo"
 msgstr "Повторить отменённое действие"
 
-#: schematic/src/x_window.c:1198
 msgid ""
 "Add component...\n"
 "Select library and component from list, move the mouse into main window, "
@@ -2411,7 +1911,6 @@ msgstr ""
 "для добавления щёлкните левой кнопкой в нужном месте.\n"
 "Щелчок правой кнопкой отменяет операцию"
 
-#: schematic/src/x_window.c:1209
 msgid ""
 "Add nets mode\n"
 "Right mouse button to cancel"
@@ -2419,7 +1918,6 @@ msgstr ""
 "Ввод соединений\n"
 "Щелчок правой кнопкой отменяет операцию"
 
-#: schematic/src/x_window.c:1217
 msgid ""
 "Add buses mode\n"
 "Right mouse button to cancel"
@@ -2427,47 +1925,37 @@ msgstr ""
 "Ввод шин\n"
 "Щелчок правой кнопкой отменяет операцию"
 
-#: schematic/src/x_window.c:1226
 msgid "Add Text..."
 msgstr "Ввод текста..."
 
-#: schematic/src/x_window.c:1233
 msgid "Select mode"
 msgstr "Режим выделения"
 
-#: schematic/src/x_window.c:1288
 msgid "Show"
 msgstr "Показать"
 
-#: schematic/src/x_window.c:1289
 msgid "Show text starting with:"
 msgstr "Показать текст, начинающийся с:"
 
-#: schematic/src/x_window.c:1345
 msgid "Menu/Cancel"
 msgstr "Меню/Отмена действия"
 
-#: schematic/src/x_window.c:1349
 msgid "Pan/Cancel"
 msgstr "Прокрутка/Отмена действия"
 
 # Функция левой кнопки мыши.
 # Имеется в виду выбор чего угодно -- объектов, пунктов меню и т. д.
-#: schematic/src/x_window.c:1359
 msgid "Pick"
 msgstr "Выбор"
 
-#: schematic/src/x_window.c:1470 schematic/scheme/gschem/builtins.scm:180
 msgid "Status"
 msgstr "Журнал"
 
-#: schematic/src/x_window.c:1568
 #, fuzzy, c-format
 msgid "New file [%s]"
 msgstr "Новый файл «%s»\n"
 
 # Если оставить '. В журнале', то получим '. ' в начале строки.
-#: schematic/src/x_window.c:1598
 #, fuzzy, c-format
 msgid ""
 "<b>An error occurred while loading the requested file.</b>\n"
@@ -2485,798 +1973,601 @@ msgstr ""
 "Не удалось загрузить файл «%s»: %s\n"
 "В журнале gschem может быть больше информации."
 
-#: schematic/src/x_window.c:1617
 msgid "Failed to load file"
 msgstr "Не удалось загрузить файл"
 
-#: schematic/data/lepton-schematic.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Schematic Editor"
 msgstr "Схемотехнический редактор gEDA"
 
-#: schematic/data/lepton-schematic.desktop.in:4
 #, fuzzy
 msgid "Create and edit electrical schematics and symbols with lepton-schematic"
 msgstr "Создание и редактирование электрических схем и символов в gschem"
 
-#: schematic/scheme/conf/schematic/menu.scm:27
 msgid "_New"
 msgstr "_Новый"
 
-#: schematic/scheme/conf/schematic/menu.scm:28
 msgid "_Open..."
 msgstr "_Открыть..."
 
-#: schematic/scheme/conf/schematic/menu.scm:30
 msgid "Open Recen_t"
 msgstr "Открыть не_давние"
 
-#: schematic/scheme/conf/schematic/menu.scm:32
 msgid "_Save"
 msgstr "_Сохранить"
 
-#: schematic/scheme/conf/schematic/menu.scm:33
 msgid "Save _As..."
 msgstr "Сохранить _как..."
 
-#: schematic/scheme/conf/schematic/menu.scm:34
-#: schematic/scheme/gschem/builtins.scm:65
 msgid "Save All"
 msgstr "Сохранить все"
 
-#: schematic/scheme/conf/schematic/menu.scm:36
 msgid "_Print..."
 msgstr "_Печать..."
 
-#: schematic/scheme/conf/schematic/menu.scm:37
 #, fuzzy
 msgid "Write _Image..."
 msgstr "Сохранить _изображение..."
 
-#: schematic/scheme/conf/schematic/menu.scm:39
 #, fuzzy
 msgid "Invoke Macro..."
 msgstr "Выполнить макрос"
 
-#: schematic/scheme/conf/schematic/menu.scm:41
 msgid "REPL..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:43
-#: schematic/scheme/gschem/builtins.scm:77
 msgid "New Window"
 msgstr "Новое окно"
 
-#: schematic/scheme/conf/schematic/menu.scm:44
 msgid "_Close Window"
 msgstr "_Закрыть окно"
 
-#: schematic/scheme/conf/schematic/menu.scm:45
 msgid "_Quit"
 msgstr "В_ыход"
 
-#: schematic/scheme/conf/schematic/menu.scm:51
 msgid "_Undo"
 msgstr "_Отменить"
 
-#: schematic/scheme/conf/schematic/menu.scm:52
 msgid "_Redo"
 msgstr "_Повторить"
 
-#: schematic/scheme/conf/schematic/menu.scm:54
 msgid "Cu_t"
 msgstr "_Вырезать"
 
-#: schematic/scheme/conf/schematic/menu.scm:55
 msgid "_Copy"
 msgstr "С_копировать"
 
-#: schematic/scheme/conf/schematic/menu.scm:56
 msgid "_Paste"
 msgstr "В_ставить"
 
-#: schematic/scheme/conf/schematic/menu.scm:57
 msgid "_Delete"
 msgstr "_Удалить"
 
-#: schematic/scheme/conf/schematic/menu.scm:60
-#: schematic/scheme/gschem/builtins.scm:102
 msgid "Select All"
 msgstr "Выделить всё"
 
-#: schematic/scheme/conf/schematic/menu.scm:61
-#: schematic/scheme/gschem/builtins.scm:105
 msgid "Deselect"
 msgstr "Снять выделение"
 
 # Можно было бы перевести как "Повернуть на 90°", но большинство соседних
 # пунктов меню переведены как существительные, так как они используются и для
 # отображения в строке состояния.
-#: schematic/scheme/conf/schematic/menu.scm:65
 msgid "Rotate 90 Mode"
 msgstr "Поворот на 90°"
 
-#: schematic/scheme/conf/schematic/menu.scm:70
 msgid "Edit Text..."
 msgstr "Правка текста..."
 
-#: schematic/scheme/conf/schematic/menu.scm:71
 msgid "Slot..."
 msgstr "Секция..."
 
-#: schematic/scheme/conf/schematic/menu.scm:76
-#: schematic/scheme/gschem/builtins.scm:150
 msgid "Embed Component/Picture"
 msgstr "Внедрить компонент/изображение"
 
-#: schematic/scheme/conf/schematic/menu.scm:77
-#: schematic/scheme/gschem/builtins.scm:153
 msgid "Unembed Component/Picture"
 msgstr "Исключить компонент/изображение"
 
-#: schematic/scheme/conf/schematic/menu.scm:78
-#: schematic/scheme/gschem/builtins.scm:156
 msgid "Update Component"
 msgstr "Обновить компонент"
 
-#: schematic/scheme/conf/schematic/menu.scm:79
 msgid "Symbol Translate..."
 msgstr "Смещение символа..."
 
-#: schematic/scheme/conf/schematic/menu.scm:85
 msgid "Copy into 1"
 msgstr "Скопировать в 1"
 
-#: schematic/scheme/conf/schematic/menu.scm:86
 msgid "Copy into 2"
 msgstr "Скопировать в 2"
 
-#: schematic/scheme/conf/schematic/menu.scm:87
 msgid "Copy into 3"
 msgstr "Скопировать в 3"
 
-#: schematic/scheme/conf/schematic/menu.scm:88
 msgid "Copy into 4"
 msgstr "Скопировать в 4"
 
-#: schematic/scheme/conf/schematic/menu.scm:89
 msgid "Copy into 5"
 msgstr "Скопировать в 5"
 
-#: schematic/scheme/conf/schematic/menu.scm:90
 msgid "Cut into 1"
 msgstr "Вырезать в 1"
 
-#: schematic/scheme/conf/schematic/menu.scm:91
 msgid "Cut into 2"
 msgstr "Вырезать в 2"
 
-#: schematic/scheme/conf/schematic/menu.scm:92
 msgid "Cut into 3"
 msgstr "Вырезать в 3"
 
-#: schematic/scheme/conf/schematic/menu.scm:93
 msgid "Cut into 4"
 msgstr "Вырезать в 4"
 
-#: schematic/scheme/conf/schematic/menu.scm:94
 msgid "Cut into 5"
 msgstr "Вырезать в 5"
 
-#: schematic/scheme/conf/schematic/menu.scm:95
 msgid "Paste from 1"
 msgstr "Вставить из 1"
 
-#: schematic/scheme/conf/schematic/menu.scm:96
 msgid "Paste from 2"
 msgstr "Вставить из 2"
 
-#: schematic/scheme/conf/schematic/menu.scm:97
 msgid "Paste from 3"
 msgstr "Вставить из 3"
 
-#: schematic/scheme/conf/schematic/menu.scm:98
 msgid "Paste from 4"
 msgstr "Вставить из 4"
 
-#: schematic/scheme/conf/schematic/menu.scm:99
 msgid "Paste from 5"
 msgstr "Вставить из 5"
 
-#: schematic/scheme/conf/schematic/menu.scm:105
 msgid "Side Dock"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:106
 #, fuzzy
 msgid "Bottom Dock"
 msgstr "Снизу вверх"
 
-#: schematic/scheme/conf/schematic/menu.scm:108
 #, fuzzy
 msgid "Find Text Results"
 msgstr "Поиск"
 
-#: schematic/scheme/conf/schematic/menu.scm:110
 msgid "_Redraw"
 msgstr "Пе_рерисовать"
 
-#: schematic/scheme/conf/schematic/menu.scm:111
 msgid "_Pan"
 msgstr "_Центрировать"
 
-#: schematic/scheme/conf/schematic/menu.scm:112
 msgid "Zoom _Box"
 msgstr "Об_ласть масштабирования"
 
-#: schematic/scheme/conf/schematic/menu.scm:113
 msgid "Zoom _Extents"
 msgstr "_Уместить в окне"
 
-#: schematic/scheme/conf/schematic/menu.scm:114
 msgid "Zoom _In"
 msgstr "У_величить"
 
-#: schematic/scheme/conf/schematic/menu.scm:115
 msgid "Zoom _Out"
 msgstr "Уме_ньшить"
 
-#: schematic/scheme/conf/schematic/menu.scm:116
 msgid "Zoom _Full"
 msgstr "_Показать всё"
 
-#: schematic/scheme/conf/schematic/menu.scm:118
 #, fuzzy
 msgid "_Dark Color Scheme"
 msgstr "Тёмная цветовая схема"
 
-#: schematic/scheme/conf/schematic/menu.scm:119
 #, fuzzy
 msgid "_Light Color Scheme"
 msgstr "Светлая цветовая схема"
 
-#: schematic/scheme/conf/schematic/menu.scm:120
 #, fuzzy
 msgid "B_W Color Scheme"
 msgstr "_Чёрно-белая цветовая схема"
 
-#: schematic/scheme/conf/schematic/menu.scm:122
 #, fuzzy
 msgid "Color Scheme Editor..."
 msgstr "Светлая цветовая схема"
 
-#: schematic/scheme/conf/schematic/menu.scm:129
 msgid "_Manager..."
 msgstr "_Менеджер..."
 
-#: schematic/scheme/conf/schematic/menu.scm:131
 msgid "_Previous"
 msgstr "_Предыдущая"
 
-#: schematic/scheme/conf/schematic/menu.scm:132
 msgid "_Next"
 msgstr "_Следующая"
 
-#: schematic/scheme/conf/schematic/menu.scm:133
 msgid "_Close"
 msgstr "_Закрыть"
 
-#: schematic/scheme/conf/schematic/menu.scm:135
 #, fuzzy
 msgid "_Revert..."
 msgstr "_Возвратить"
 
-#: schematic/scheme/conf/schematic/menu.scm:137
-#: schematic/scheme/gschem/builtins.scm:249
 #, fuzzy
 msgid "Next Tab"
 msgstr "Следующая страница"
 
-#: schematic/scheme/conf/schematic/menu.scm:138
-#: schematic/scheme/gschem/builtins.scm:252
 #, fuzzy
 msgid "Previous Tab"
 msgstr "Предыдущая страница"
 
-#: schematic/scheme/conf/schematic/menu.scm:146
 msgid "_Component..."
 msgstr "_Компонент..."
 
-#: schematic/scheme/conf/schematic/menu.scm:148
 msgid "_Net"
 msgstr "_Соединение"
 
-#: schematic/scheme/conf/schematic/menu.scm:149
 msgid "B_us"
 msgstr "_Шину"
 
-#: schematic/scheme/conf/schematic/menu.scm:151
 msgid "_Attribute..."
 msgstr "_Атрибут..."
 
-#: schematic/scheme/conf/schematic/menu.scm:152
 msgid "_Text..."
 msgstr "_Текст..."
 
-#: schematic/scheme/conf/schematic/menu.scm:154
 msgid "_Line"
 msgstr "_Линию"
 
-#: schematic/scheme/conf/schematic/menu.scm:155
 msgid "Pat_h"
 msgstr "Ко_нтур"
 
-#: schematic/scheme/conf/schematic/menu.scm:156
 msgid "_Box"
 msgstr "_Прямоугольник"
 
-#: schematic/scheme/conf/schematic/menu.scm:157
 msgid "C_ircle"
 msgstr "_Окружность"
 
-#: schematic/scheme/conf/schematic/menu.scm:158
 msgid "A_rc"
 msgstr "_Дугу"
 
-#: schematic/scheme/conf/schematic/menu.scm:159
 msgid "_Pin"
 msgstr "_Вывод"
 
-#: schematic/scheme/conf/schematic/menu.scm:161
 msgid "Pictu_re..."
 msgstr "_Изображение..."
 
-#: schematic/scheme/conf/schematic/menu.scm:167
 msgid "_Up"
 msgstr "_Вверх"
 
-#: schematic/scheme/conf/schematic/menu.scm:169
 msgid "_Down Schematic"
 msgstr "Войти в _подсхему"
 
-#: schematic/scheme/conf/schematic/menu.scm:170
 msgid "Down _Symbol"
 msgstr "Войти в _символ"
 
-#: schematic/scheme/conf/schematic/menu.scm:176
 msgid "_Attach"
 msgstr "_Прикрепить"
 
-#: schematic/scheme/conf/schematic/menu.scm:177
 msgid "_Detach"
 msgstr "_Отделить"
 
-#: schematic/scheme/conf/schematic/menu.scm:179
 msgid "Show _Value"
 msgstr "Показать _значение"
 
-#: schematic/scheme/conf/schematic/menu.scm:180
 msgid "Show _Name"
 msgstr "Показать _имя"
 
-#: schematic/scheme/conf/schematic/menu.scm:181
 msgid "Show _Both"
 msgstr "По_казать имя и значение"
 
-#: schematic/scheme/conf/schematic/menu.scm:182
 msgid "_Toggle Visibility"
 msgstr "Переключить _видимость"
 
-#: schematic/scheme/conf/schematic/menu.scm:184
 msgid "_Hide Specific Text..."
 msgstr "_Скрыть текст..."
 
-#: schematic/scheme/conf/schematic/menu.scm:185
 msgid "_Show Specific Text..."
 msgstr "Показать _текст..."
 
-#: schematic/scheme/conf/schematic/menu.scm:186
 #, fuzzy
 msgid "Show/Hide Hidden Text"
 msgstr "Показать/скрыть невидимый текст"
 
-#: schematic/scheme/conf/schematic/menu.scm:188
 msgid "_Find Text/Check Symbol..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:189
 msgid "A_utonumber Text..."
 msgstr "_Автонумерация..."
 
-#: schematic/scheme/conf/schematic/menu.scm:195
 #, fuzzy
 msgid "_Options..."
 msgstr "_Настройки"
 
-#: schematic/scheme/conf/schematic/menu.scm:196
 #, fuzzy
 msgid "_Font..."
 msgstr "_Печать..."
 
-#: schematic/scheme/conf/schematic/menu.scm:198
 #, fuzzy
 msgid "Grid +"
 msgstr "Сетка"
 
-#: schematic/scheme/conf/schematic/menu.scm:199
 #, fuzzy
 msgid "Grid -"
 msgstr "Сетка"
 
-#: schematic/scheme/conf/schematic/menu.scm:201
 msgid "Grid Style: Cycle Dots/Mesh/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:202
 msgid "Grid Snap: Cycle Grid/Resnap/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:204
 #, fuzzy
 msgid "Feedback Mode: Outline/Box"
 msgstr "_Внешние контуры/рамка"
 
-#: schematic/scheme/conf/schematic/menu.scm:205
 #, fuzzy
 msgid "Net: Rubberband On/Off"
 msgstr "Режим «резиновых» соединений включён\n"
 
-#: schematic/scheme/conf/schematic/menu.scm:206
 msgid "Net: Magnetic On/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:208
 #, fuzzy
 msgid "_Coord Window"
 msgstr "_Закрыть окно"
 
-#: schematic/scheme/conf/schematic/menu.scm:209
 #, fuzzy
 msgid "_Log Window"
 msgstr "Показать окно журнала"
 
-#: schematic/scheme/conf/schematic/menu.scm:215
 msgid "_1 allegro"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:223
 #, fuzzy
 msgid "User _Guide"
 msgstr "Руководство пользователя gschem"
 
-#: schematic/scheme/conf/schematic/menu.scm:224
 msgid "_FAQ"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:225
 #, fuzzy
 msgid "Docu_mentation"
 msgstr "_Документация"
 
-#: schematic/scheme/conf/schematic/menu.scm:226
 msgid "_Wiki"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:228
 #, fuzzy
 msgid "Find Component D_ocumentation"
 msgstr "Документация на компонент"
 
-#: schematic/scheme/conf/schematic/menu.scm:230
 msgid "_Hotkeys..."
 msgstr "_Горячие клавиши"
 
-#: schematic/scheme/conf/schematic/menu.scm:231
 #, fuzzy
 msgid "_About"
 msgstr "_О программе..."
 
-#: schematic/scheme/conf/schematic/menu.scm:237
 msgid "_File"
 msgstr "_Файл"
 
-#: schematic/scheme/conf/schematic/menu.scm:238
 msgid "_Edit"
 msgstr "_Правка"
 
-#: schematic/scheme/conf/schematic/menu.scm:240
 msgid "_View"
 msgstr "_Вид"
 
-#: schematic/scheme/conf/schematic/menu.scm:241
 msgid "_Page"
 msgstr "Ст_раница"
 
-#: schematic/scheme/conf/schematic/menu.scm:242
 msgid "_Add"
 msgstr "_Добавить"
 
-#: schematic/scheme/conf/schematic/menu.scm:243
 msgid "Hie_rarchy"
 msgstr "_Иерархия"
 
-#: schematic/scheme/conf/schematic/menu.scm:244
 msgid "A_ttributes"
 msgstr "_Атрибуты"
 
-#: schematic/scheme/conf/schematic/menu.scm:245
 msgid "_Options"
 msgstr "_Настройки"
 
-#: schematic/scheme/conf/schematic/menu.scm:246
 #, fuzzy
 msgid "_Netlist"
 msgstr "_Соединение"
 
-#: schematic/scheme/conf/schematic/menu.scm:247
 msgid "_Help"
 msgstr "_Справка"
 
-#: schematic/scheme/gschem/action.scm:43
 #, scheme-format
 msgid "~S is not a valid gschem action."
 msgstr "Недопустимое для gschem действие ~S."
 
-#: schematic/scheme/gschem/action.scm:158
 msgid "Repeat Last Action"
 msgstr "Повторить последнее действие"
 
-#: schematic/scheme/gschem/builtins.scm:47
 msgid "Cancel"
 msgstr "Отмена"
 
-#: schematic/scheme/gschem/builtins.scm:53
 msgid "New File"
 msgstr "Новый файл"
 
-#: schematic/scheme/gschem/builtins.scm:56
 msgid "Open File"
 msgstr "Открыть файл"
 
-#: schematic/scheme/gschem/builtins.scm:62
 msgid "Save As"
 msgstr "Сохранить как"
 
-#: schematic/scheme/gschem/builtins.scm:68
 msgid "Print"
 msgstr "Печать"
 
-#: schematic/scheme/gschem/builtins.scm:71
 msgid "Export Image"
 msgstr "Экспорт изображения"
 
-#: schematic/scheme/gschem/builtins.scm:74
 msgid "Run Script"
 msgstr "Выполнить скрипт"
 
-#: schematic/scheme/gschem/builtins.scm:80
 msgid "Close Window"
 msgstr "Закрыть окно"
 
-#: schematic/scheme/gschem/builtins.scm:83
 msgid "Quit"
 msgstr "Выход"
 
-#: schematic/scheme/gschem/builtins.scm:87
 msgid "Terminal REPL"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:132
 msgid "Choose Slot"
 msgstr "Выбрать секцию"
 
-#: schematic/scheme/gschem/builtins.scm:135
 #, fuzzy
 msgid "Edit Object Properties"
 msgstr "<b>Текст</b>"
 
-#: schematic/scheme/gschem/builtins.scm:138
 msgid "Translate Symbol"
 msgstr "Сместить символ"
 
-#: schematic/scheme/gschem/builtins.scm:147
 msgid "Invoke Macro"
 msgstr "Выполнить макрос"
 
-#: schematic/scheme/gschem/builtins.scm:159
 msgid "Show/Hide Invisible Text"
 msgstr "Показать/скрыть невидимый текст"
 
-#: schematic/scheme/gschem/builtins.scm:165
 msgid "Cut"
 msgstr "Вырезать"
 
-#: schematic/scheme/gschem/builtins.scm:171
 msgid "Paste"
 msgstr "Вставить"
 
-#: schematic/scheme/gschem/builtins.scm:177
 msgid "Sidebar"
 msgstr "Боковая панель"
 
-#: schematic/scheme/gschem/builtins.scm:183
 #, fuzzy
 msgid "Find Text State"
 msgstr "Поиск"
 
-#: schematic/scheme/gschem/builtins.scm:186
 msgid "Redraw"
 msgstr "Перерисовать"
 
-#: schematic/scheme/gschem/builtins.scm:192
 msgid "Pan Left"
 msgstr "Прокрутка влево"
 
-#: schematic/scheme/gschem/builtins.scm:195
 msgid "Pan Right"
 msgstr "Прокрутка вправо"
 
-#: schematic/scheme/gschem/builtins.scm:198
 msgid "Pan Up"
 msgstr "Прокрутка вверх"
 
-#: schematic/scheme/gschem/builtins.scm:201
 msgid "Pan Down"
 msgstr "Прокрутка вниз"
 
-#: schematic/scheme/gschem/builtins.scm:216
 msgid "Zoom Full"
 msgstr "Показать всё"
 
-#: schematic/scheme/gschem/builtins.scm:219
 msgid "Dark Color Scheme"
 msgstr "Тёмная цветовая схема"
 
-#: schematic/scheme/gschem/builtins.scm:222
 msgid "Light Color Scheme"
 msgstr "Светлая цветовая схема"
 
-#: schematic/scheme/gschem/builtins.scm:225
 msgid "Monochrome Color Scheme"
 msgstr "Чёрно-белая цветовая схема"
 
-#: schematic/scheme/gschem/builtins.scm:228
 #, fuzzy
 msgid "Show Color Scheme Editor"
 msgstr "Светлая цветовая схема"
 
-#: schematic/scheme/gschem/builtins.scm:234
 msgid "Revert Changes"
 msgstr "Отменить все изменения"
 
-#: schematic/scheme/gschem/builtins.scm:240
 msgid "Previous Page"
 msgstr "Предыдущая страница"
 
-#: schematic/scheme/gschem/builtins.scm:243
 msgid "Next Page"
 msgstr "Следующая страница"
 
-#: schematic/scheme/gschem/builtins.scm:255
 msgid "Print Page"
 msgstr "Печать страницы"
 
-#: schematic/scheme/gschem/builtins.scm:276
 msgid "Add Line"
 msgstr "Добавить линию"
 
-#: schematic/scheme/gschem/builtins.scm:279
 msgid "Add Path"
 msgstr "Добавить контур"
 
-#: schematic/scheme/gschem/builtins.scm:282
 msgid "Add Box"
 msgstr "Добавить прямоугольник"
 
-#: schematic/scheme/gschem/builtins.scm:285
 msgid "Add Circle"
 msgstr "Добавить окружность"
 
-#: schematic/scheme/gschem/builtins.scm:288
 msgid "Add Arc"
 msgstr "Добавить дугу"
 
-#: schematic/scheme/gschem/builtins.scm:291
 msgid "Add Pin"
 msgstr "Добавить вывод"
 
-#: schematic/scheme/gschem/builtins.scm:294
 msgid "Add Picture"
 msgstr "Добавить изображение"
 
-#: schematic/scheme/gschem/builtins.scm:306
 msgid "Up Hierarchy"
 msgstr "Вверх по иерархии"
 
-#: schematic/scheme/gschem/builtins.scm:312
 msgid "Attach Attributes"
 msgstr "Прикрепить атрибуты"
 
-#: schematic/scheme/gschem/builtins.scm:315
 msgid "Detach Attributes"
 msgstr "Отделить атрибуты"
 
-#: schematic/scheme/gschem/builtins.scm:318
 msgid "Show Attribute Value"
 msgstr "Показать значение атрибута"
 
-#: schematic/scheme/gschem/builtins.scm:321
 msgid "Show Attribute Name"
 msgstr "Показать имя атрибута"
 
-#: schematic/scheme/gschem/builtins.scm:327
 msgid "Toggle Text Visibility"
 msgstr "Переключить видимость текста"
 
-#: schematic/scheme/gschem/builtins.scm:330
 msgid "Find Specific Text"
 msgstr "Найти текст"
 
-#: schematic/scheme/gschem/builtins.scm:333
 msgid "Hide Specific Text"
 msgstr "Скрыть текст"
 
-#: schematic/scheme/gschem/builtins.scm:336
 msgid "Show Specific Text"
 msgstr "Показать текст"
 
-#: schematic/scheme/gschem/builtins.scm:339
 msgid "Autonumber Text"
 msgstr "Автонумерация"
 
-#: schematic/scheme/gschem/builtins.scm:345
 msgid "Show Hotkeys"
 msgstr "Показать горячие клавиши"
 
-#: schematic/scheme/gschem/builtins.scm:348
 msgid "Switch Grid Style"
 msgstr "Переключить стиль сетки"
 
-#: schematic/scheme/gschem/builtins.scm:351
 msgid "Switch Snap Mode"
 msgstr "Переключить привязку"
 
-#: schematic/scheme/gschem/builtins.scm:354
 msgid "Set Grid Spacing"
 msgstr "Задать шаг сетки"
 
-#: schematic/scheme/gschem/builtins.scm:357
 msgid "Increase Grid Spacing"
 msgstr "Увеличить шаг сетки"
 
-#: schematic/scheme/gschem/builtins.scm:360
 msgid "Decrease Grid Spacing"
 msgstr "Уменьшить шаг сетки"
 
-#: schematic/scheme/gschem/builtins.scm:363
 msgid "Toggle Outline Drawing"
 msgstr "Отображать контуры объектов/рамку при перемещении"
 
-#: schematic/scheme/gschem/builtins.scm:366
 msgid "Toggle Net Rubber Band"
 msgstr "Вкл/откл резиновые соединения"
 
-#: schematic/scheme/gschem/builtins.scm:369
 msgid "Toggle Magnetic Nets"
 msgstr "Вкл/откл магнитные соединения"
 
-#: schematic/scheme/gschem/builtins.scm:372
 msgid "Show Log Window"
 msgstr "Показать окно журнала"
 
-#: schematic/scheme/gschem/builtins.scm:375
 msgid "Show Coordinate Window"
 msgstr "Показать окно координат"
 
-#: schematic/scheme/gschem/builtins.scm:385
 msgid "Component Documentation"
 msgstr "Документация на компонент"
 
-#: schematic/scheme/gschem/builtins.scm:387
 msgid "View documentation for selected component"
 msgstr "Просмотр документации для выбранного компонента"
 
-#: schematic/scheme/gschem/builtins.scm:403
 msgid ""
 "Could not show documentation for selected component:\n"
 "\n"
@@ -3284,57 +2575,44 @@ msgstr ""
 "Не удалось показать документацию для выбранного компонента:\n"
 "\n"
 
-#: schematic/scheme/gschem/builtins.scm:408
 msgid "gEDA Manuals"
 msgstr "Документация gEDA"
 
-#: schematic/scheme/gschem/builtins.scm:409
 msgid "View the front page of the gEDA documentation in a browser."
 msgstr "Открыть основную страницу документации gEDA в браузере."
 
-#: schematic/scheme/gschem/builtins.scm:414
 msgid "gschem User Guide"
 msgstr "Руководство пользователя gschem"
 
-#: schematic/scheme/gschem/builtins.scm:415
 msgid "View the gschem User Guide in a browser."
 msgstr "Открыть «Руководство пользователя gschem» в браузере."
 
-#: schematic/scheme/gschem/builtins.scm:420
 msgid "gschem FAQ"
 msgstr "gschem FAQ"
 
-#: schematic/scheme/gschem/builtins.scm:421
 msgid "Frequently Asked Questions about using gschem."
 msgstr "Часто задаваемые вопросы по использованию gschem."
 
-#: schematic/scheme/gschem/builtins.scm:426
 msgid "gEDA wiki"
 msgstr "gEDA wiki"
 
-#: schematic/scheme/gschem/builtins.scm:427
 msgid "View the front page of the gEDA wiki in a browser."
 msgstr "Открыть основную страницу gEDA wiki в браузере."
 
-#: schematic/scheme/gschem/builtins.scm:431
 msgid "About gschem"
 msgstr "О программе..."
 
-#: schematic/scheme/gschem/deprecated.scm:102
 #, scheme-format
 msgid "Invalid text alignment ~A."
 msgstr "Недопустимое выравнивание текста ~A."
 
-#: schematic/scheme/gschem/gschemdoc.scm:241
 msgid "No documentation found"
 msgstr "Документация не найдена"
 
-#: schematic/scheme/gschem/keymap.scm:40
 #, scheme-format
 msgid "~S is not a valid key combination."
 msgstr "Недопустимая комбинация клавиш ~S."
 
-#: schematic/scheme/gschem/keymap.scm:157
 #, scheme-format
 msgid "~S is not a prefix key sequence."
 msgstr "~S не является префиксом клавишной последовательности."

--- a/schematic/po/sl.po
+++ b/schematic/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-15 15:13+0300\n"
+"POT-Creation-Date: 2019-02-22 14:08+0300\n"
 "PO-Revision-Date: 2012-01-27 14:18+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: Slovenian <sl@li.org>\n"
@@ -18,22 +18,18 @@ msgstr ""
 "X-Launchpad-Export-Date: 2012-11-14 16:52+0000\n"
 "X-Generator: Launchpad (build 16265)\n"
 
-#: schematic/src/a_zoom.c:155
 msgid "Zoom too small!  Cannot zoom further."
 msgstr ""
 
-#: schematic/src/color_edit_widget.c:399
 #, c-format
 msgid ""
 "Could not save file [%s]:\n"
 "%s"
 msgstr ""
 
-#: schematic/src/color_edit_widget.c:434
 msgid "Save Color Scheme As..."
 msgstr ""
 
-#: schematic/src/color_edit_widget.c:482 schematic/src/x_fileselect.c:292
 #, c-format
 msgid ""
 "The selected file `%1$s' already exists.\n"
@@ -41,178 +37,140 @@ msgid ""
 "Would you like to overwrite it?"
 msgstr ""
 
-#: schematic/src/color_edit_widget.c:486 schematic/src/x_fileselect.c:295
 msgid "Overwrite file?"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:211
 msgid "_Apply"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:215
 msgid "Sa_ve..."
 msgstr ""
 
-#: schematic/src/font_select_widget.c:278
 #, c-format
 msgid "<b>Current:</b> %s"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:453
 msgid "Save configuration"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:461
 msgid "Save settings to:"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:465
 msgid "Local configuration file (in current directory)"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:467
 msgid "User configuration file (geda-user.conf)"
 msgstr ""
 
-#: schematic/src/g_attrib.c:90
 msgid "Object ~A is not included in the current gschem page."
 msgstr ""
 
-#: schematic/src/g_attrib.c:110
 msgid "Invalid text name/value visibility ~A."
 msgstr ""
 
-#: schematic/src/g_rc.c:107
 #, c-format
 msgid "You are running gEDA/gaf version [%1$s%2$s.%3$s],\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:111
 #, c-format
 msgid ""
 "but you have a version [%1$s] gschemrc file:\n"
 "[%2$s]\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:114
 #, c-format
 msgid "Please be sure that you have the latest rc file.\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:240
 #, c-format
 msgid "Invalid size [%1$d] passed to text-size\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:283
 #, c-format
 msgid "Invalid size [%1$d] passed to snap-size\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:620
 #, c-format
 msgid "Invalid num levels [%1$d] passed to undo-levels\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:831
 #, c-format
 msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:931
 #, c-format
 msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:972
 #, c-format
 msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:998
 #, c-format
 msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1023
 #, c-format
 msgid "Invalid offset [%1$d] passed to add-attribute-offset\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1047
 #, c-format
 msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1071
 #, c-format
 msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1094
 #, c-format
 msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1118
 #, c-format
 msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1144
 #, c-format
 msgid "Invalid gain [%1$d] passed to zoom-gain\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1169
 #, c-format
 msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
 msgstr ""
 
-#: schematic/src/g_select.c:78 schematic/src/g_select.c:115
-#: schematic/src/g_select.c:151
 msgid "Object ~A is not directly included in a page."
 msgstr ""
 
-#: schematic/src/g_util.c:54
 msgid "Could not launch URI ~S: ~A"
 msgstr ""
 
-#: schematic/src/g_window.c:139
 msgid "Found invalid gschem window smob ~S"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:156
 #, c-format
 msgid "Lepton EDA/lepton-schematic version %1$s%2$s.%3$s git: %4$.7s"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:163
 #, c-format
 msgid "This is the MINGW32 port.\n"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:167
 #, c-format
 msgid "Current locale settings: %1$s\n"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:201
 #, c-format
 msgid "Couldn't find init scm file [%1$s]"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:206
 #, c-format
 msgid "Read init scm file [%1$s]"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:210
 #, c-format
 msgid "Failed to read init scm file [%1$s]"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:290
 #, c-format
 msgid ""
 "ERROR: Failed to load or evaluate startup script.\n"
@@ -220,676 +178,491 @@ msgid ""
 "The lepton-schematic log may contain more information.\n"
 msgstr ""
 
-#: schematic/src/gschem_about_dialog.c:51
 #, c-format
 msgid "%s (git: %.7s)"
 msgstr ""
 
-#: schematic/src/gschem_about_dialog.c:75
 msgid "Lepton Electronic Design Automation"
 msgstr ""
 
-#: schematic/src/gschem_about_dialog.c:83
 msgid ""
 "Copyright © 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright © 2017-2018 Lepton Developers.\n"
-"See AUTHORS and ChangeLog files for details."
+"Copyright © 2017-2019 Lepton Developers.\n"
+"See AUTHORS, ChangeLog files and consult 'git log' history for details."
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:69
 msgid "Upper Left"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:71
 msgid "Upper Middle"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:73
 msgid "Upper Right"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:78
 msgid "Middle Left"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:80
 msgid "Middle Middle"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:82
 msgid "Middle Right"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:87
 msgid "Lower Left"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:89
 msgid "Lower Middle"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:91
 msgid "Lower Right"
 msgstr ""
 
-#: schematic/src/gschem_arc_dialog.c:104
 msgid "Arc Params"
 msgstr ""
 
-#: schematic/src/gschem_arc_dialog.c:140
 msgid "Arc _Radius:"
 msgstr ""
 
-#: schematic/src/gschem_arc_dialog.c:141
 msgid "Start _Angle:"
 msgstr ""
 
-#: schematic/src/gschem_arc_dialog.c:142
 msgid "_Degrees of Sweep:"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:504
 msgid "Left mouse button"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:508
 msgid "Middle mouse button"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:512
 msgid "Right mouse button"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:595
 msgid "(Snap size, Grid size)"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:603
 msgid "Net rubber band mode"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:614
 msgid "Magnetic net mode"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:622
 msgid "Current action mode"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:935
-#: schematic/src/gschem_bottom_widget.c:951
 msgid "OFF"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:954
 msgid "NONE"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:960
 #, c-format
 msgid "Grid(%1$s, %2$s)"
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:350
-#: schematic/src/x_compselect.c:1236 schematic/src/x_multiattrib.c:2068
 msgid "Name"
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:372
 msgid "S_elect the schematics you want to save:"
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:467
 #, c-format
 msgid "Save the changes to schematic \"%1$s\" before closing?"
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:473
 #, c-format
 msgid ""
 "There are %1$d schematics with unsaved changes. Save changes before closing?"
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:502
 msgid "If you don't save, all your changes will be permanently lost."
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:522
 msgid "Close _without saving"
 msgstr ""
 
-#: schematic/src/gschem_coord_dialog.c:86
 msgid "Coords"
 msgstr ""
 
-#: schematic/src/gschem_coord_dialog.c:106
 msgid "Screen"
 msgstr ""
 
-#: schematic/src/gschem_coord_dialog.c:115
 msgid "World"
 msgstr ""
 
-#: schematic/src/gschem_find_text_state.c:809 schematic/src/x_pagesel.c:432
 msgid "Filename"
 msgstr ""
 
-#: schematic/src/gschem_find_text_state.c:821 schematic/src/i_callbacks.c:1970
-#: schematic/src/x_colorcb.c:154 schematic/src/x_widgets.c:179
-#: schematic/src/x_window.c:1226 schematic/src/x_window.c:1440
 msgid "Text"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:427
 msgid "descend into hierarchy"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:435
 msgid "Find"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:557
 msgid "Find Text:"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:564
 msgid "Find Pattern:"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:571
 msgid "Find Regex:"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:578
 msgid "Check symbol:"
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:200
 msgid "Hotkeys"
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:229
 msgid ""
 "Start typing action name or keystroke to filter the list.\n"
 "Type hotkeys as they are displayed in \"Keystroke(s)\" column."
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:233 schematic/src/x_compselect.c:1124
 #, fuzzy
 msgid "_Filter:"
 msgstr "_Datoteka"
 
-#: schematic/src/gschem_hotkey_dialog.c:259 schematic/src/i_basic.c:280
 msgid "Action"
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:277
 msgid "Keystroke(s)"
 msgstr ""
 
-#: schematic/src/gschem_log_widget.c:177
 msgid "** Invalid UTF-8 in log message. See stderr or gschem.log.\n"
 msgstr ""
 
-#: schematic/src/gschem_log_widget.c:434
 #, fuzzy
 msgid "Clear log window?"
 msgstr "Novo okno"
 
-#: schematic/src/gschem_log_widget.c:477
 #, fuzzy
 msgid "Clear Log _Window"
 msgstr "Novo okno"
 
-#: schematic/src/gschem_macro_widget.c:231
 msgid "Macro:"
 msgstr ""
 
-#: schematic/src/gschem_macro_widget.c:387
 msgid "Evaluate"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:172
 #, fuzzy
 msgid "_Fill Type:"
 msgstr "_Datoteka"
 
-#: schematic/src/gschem_object_properties_widget.c:173
 msgid "Lin_e Width:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:174
 msgid "Angle _1:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:175
 msgid "P_itch 1:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:176
 msgid "Angle _2:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:177
 msgid "Pitc_h 2:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:237
 msgid "<b>Fill Properties</b>"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:255
-#: schematic/src/gschem_text_properties_widget.c:258
-#: schematic/src/x_newtext.c:271
 msgid "Colo_r:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:266
 msgid "<b>General Properties</b>"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:284
 msgid "_Type:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:285
 msgid "_Width:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:286
 msgid "Dash _Length:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:287
 msgid "Dash _Space:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:288
 msgid "C_ap style:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:333
 msgid "<b>Line Properties</b>"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:351
 msgid "_Pin Type:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:362
 msgid "<b>Pin Properties</b>"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:217
 msgid "_Off"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:220
 msgid "_Dots"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:223
 msgid "M_esh"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:245
 msgid "Net R_ubber Band Mode:"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:246
 msgid "_Magnetic Net Mode:"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:250
-#: schematic/src/gschem_options_widget.c:251
 msgid "Enabled"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:265
 msgid "<b>Net Options</b>"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:282
 msgid "Grid Mode:"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:283
 msgid "Snap Mode:"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:284
 msgid "_Snap Size:"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:301
 msgid "<b>Snap Options</b>"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:340
 msgid "O_ff"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:343
 msgid "_Grid"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:346
 msgid "_Resnap"
 msgstr ""
 
-#: schematic/src/gschem_pin_type_combo.c:73
 msgid "Net pin"
 msgstr ""
 
-#: schematic/src/gschem_pin_type_combo.c:80
 msgid "Bus pin (graphical)"
 msgstr ""
 
-#: schematic/src/gschem_preview.c:195
 msgid "Preview Buffer"
 msgstr ""
 
-#: schematic/src/gschem_show_hide_text_widget.c:148
-#: schematic/src/x_window.c:1268
 msgid "Hide"
 msgstr ""
 
-#: schematic/src/gschem_show_hide_text_widget.c:157
-#: schematic/src/x_window.c:1269
 msgid "Hide text starting with:"
 msgstr ""
 
-#: schematic/src/gschem_slot_edit_dialog.c:91
 msgid "Edit slot number"
 msgstr ""
 
-#: schematic/src/gschem_slot_edit_dialog.c:121
 msgid "Number of Slots:"
 msgstr ""
 
-#: schematic/src/gschem_slot_edit_dialog.c:122
 msgid "Slot Number:"
 msgstr ""
 
-#: schematic/src/gschem_text_properties_widget.c:240
-#: schematic/src/x_newtext.c:265
 msgid "<b>Text Content</b>"
 msgstr ""
 
-#: schematic/src/gschem_text_properties_widget.c:259
-#: schematic/src/x_newtext.c:291
 msgid "_Size:"
 msgstr ""
 
-#: schematic/src/gschem_text_properties_widget.c:260
-#: schematic/src/x_newtext.c:310
 msgid "Ali_gnment:"
 msgstr ""
 
-#: schematic/src/gschem_text_properties_widget.c:261
-#: schematic/src/x_newtext.c:330
 msgid "Ro_tation:"
 msgstr ""
 
-#: schematic/src/gschem_text_properties_widget.c:294
-#: schematic/src/x_newtext.c:253
 msgid "<b>Text Properties</b>"
 msgstr ""
 
-#: schematic/src/gschem_translate_widget.c:238
 msgid "Coordinate:"
 msgstr ""
 
-#: schematic/src/gschem_translate_widget.c:405 schematic/src/i_callbacks.c:800
 msgid "Translate"
 msgstr ""
 
-#: schematic/src/i_basic.c:64 schematic/src/x_window.c:1369
-#: schematic/scheme/conf/schematic/menu.scm:59
-#: schematic/scheme/gschem/builtins.scm:99
 msgid "Select Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:65
 msgid "Select Box Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:66
 msgid "Text Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:67
 msgid "Pan Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:70
 #, c-format
 msgid "Paste %d Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:74
 msgid "Magnetic Net Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:76
 msgid "Net Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:77
 msgid "Arc Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:78
 msgid "Box Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:79
 msgid "Bus Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:80
 msgid "Circle Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:81
 msgid "Component Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:82 schematic/scheme/conf/schematic/menu.scm:62
-#: schematic/scheme/gschem/builtins.scm:114
 msgid "Copy Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:83 schematic/scheme/conf/schematic/menu.scm:63
-#: schematic/scheme/gschem/builtins.scm:117
 msgid "Multiple Copy Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:84
 msgid "Line Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:85 schematic/scheme/conf/schematic/menu.scm:66
-#: schematic/scheme/gschem/builtins.scm:123
 msgid "Mirror Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:86 schematic/scheme/conf/schematic/menu.scm:64
-#: schematic/scheme/gschem/builtins.scm:111
 msgid "Move Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:87
 msgid "Path Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:88
 msgid "Picture Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:89
 msgid "Pin Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:90 schematic/scheme/gschem/builtins.scm:120
 msgid "Rotate Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:91
 msgid "Modify Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:92 schematic/src/x_menus.c:49
-#: schematic/scheme/gschem/builtins.scm:204
 msgid "Zoom Box"
 msgstr ""
 
-#: schematic/src/i_basic.c:121
 msgid "Show Hidden"
 msgstr ""
 
-#: schematic/src/i_basic.c:124
 msgid "Snap Off"
 msgstr ""
 
-#: schematic/src/i_basic.c:126
 msgid "Resnap Active"
 msgstr ""
 
-#: schematic/src/i_basic.c:288 schematic/src/x_colorcb.c:159
 msgid "Stroke"
 msgstr ""
 
-#: schematic/src/i_basic.c:296 schematic/src/i_basic.c:330
-#: schematic/src/x_window.c:1361
 msgid "none"
 msgstr ""
 
-#: schematic/src/i_basic.c:304
 msgid "Repeat/"
 msgstr ""
 
-#: schematic/src/i_basic.c:315
 msgid "Repeat/none"
 msgstr ""
 
-#: schematic/src/i_basic.c:323 schematic/src/i_callbacks.c:1239
-#: schematic/scheme/gschem/builtins.scm:189
 msgid "Pan"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:74
 #, c-format
 msgid "New page created [%1$s]"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:108
 #, c-format
 msgid "New Window created [%1$s]"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:245
 msgid "Failed to Save All"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:247
 msgid "Saved All"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:308
 #, fuzzy
 msgid "Closing Window"
 msgstr "Novo okno"
 
-#: schematic/src/i_callbacks.c:505 schematic/src/x_menus.c:55
-#: schematic/scheme/gschem/builtins.scm:168
 msgid "Copy"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:514 schematic/src/i_callbacks.c:539
-#: schematic/src/i_callbacks.c:564
 msgid "Select objs first"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:530
 msgid "Multiple Copy"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:555 schematic/src/x_menus.c:56
 msgid "Move"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:579 schematic/src/x_menus.c:57
-#: schematic/src/x_multiattrib.c:1656 schematic/scheme/gschem/builtins.scm:108
 msgid "Delete"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:603
 msgid "Edit"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:618 schematic/scheme/gschem/builtins.scm:129
 msgid "Edit Text"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:637
 msgid "Slot"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:688 schematic/src/i_callbacks.c:698
 msgid "Rotate"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:736 schematic/src/i_callbacks.c:746
 msgid "Mirror"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:763 schematic/src/x_colorcb.c:160
-#: schematic/scheme/conf/schematic/menu.scm:73
-#: schematic/scheme/gschem/builtins.scm:141
 msgid "Lock"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:781 schematic/scheme/conf/schematic/menu.scm:74
-#: schematic/scheme/gschem/builtins.scm:144
 msgid "Unlock"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:805
 msgid "WARNING: Do not translate with snap off!"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:806
 msgid "WARNING: Turning snap on and continuing with translate."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:813
 msgid "WARNING: Snap grid size is not equal to 100!"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:815
 msgid ""
 "WARNING: If you are translating a symbol to the origin, the snap grid size "
 "should be set to 100"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:847
 msgid "Embed"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:886
 msgid "Unembed"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:928
 msgid "Update"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:970
 msgid "ShowHidden"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1537
 #, c-format
 msgid ""
 "<b>Revert page:</b>\n"
@@ -900,99 +673,77 @@ msgid ""
 "discarded and page file will be reloaded from disk."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1555
 #, fuzzy
 msgid "Revert"
 msgstr "_Povrni"
 
-#: schematic/src/i_callbacks.c:1647
 msgid "Copy to clipboard"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1664
 msgid "Cut to clipboard"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1686
 msgid "Paste from clipboard"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1694
 msgid "Empty clipboard"
 msgstr ""
 
 #. TRANSLATORS: The number is the number of the buffer that the
 #. * selection is being copied to.
-#: schematic/src/i_callbacks.c:1719
 #, c-format
 msgid "Copy %i"
 msgstr ""
 
 #. TRANSLATORS: The number is the number of the buffer that the
 #. * selection is being cut to.
-#: schematic/src/i_callbacks.c:1746
 #, c-format
 msgid "Cut %i"
 msgstr ""
 
 #. TRANSLATORS: The number is the number of the buffer that is being
 #. * pasted to the schematic.
-#: schematic/src/i_callbacks.c:1776
 #, c-format
 msgid "Paste %i"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1785
 msgid "Empty buffer"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1833 schematic/src/x_window.c:1203
 msgid "Component"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1865 schematic/src/x_colorcb.c:150
 msgid "Attribute"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1885 schematic/src/x_colorcb.c:149
 msgid "Net"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1928 schematic/src/x_colorcb.c:155
-#: schematic/src/x_window.c:1222
 msgid "Bus"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2004
 msgid "Line"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2021
 msgid "Path"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2043
 msgid "Box"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2085
 msgid "Circle"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2108
 msgid "Arc"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2131 schematic/src/x_colorcb.c:146
 msgid "Pin"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2191
 #, c-format
 msgid "Searching for source [%1$s]"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2223
 #, c-format
 msgid ""
 "Failed to descend hierarchy into '%1$s': %2$s\n"
@@ -1000,106 +751,81 @@ msgid ""
 "The lepton-schematic log may contain more information."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2227
 #, c-format
 msgid "Failed to descend into '%1$s': %2$s"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2234
 msgid "Failed to descend hierarchy."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2312
 #, c-format
 msgid "Searching for symbol [%1$s]"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2320
 msgid "Symbol is not a real file. Symbol cannot be loaded."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2367 schematic/src/x_tabs.c:1060
 msgid "Cannot find any schematics above the current one!"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2400
 msgid "Attach"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2456
 msgid "Detach"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2500
 msgid "ShowN"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2537
 msgid "ShowV"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2574
 msgid "ShowB"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2612
 msgid "VisToggle"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2643
 #, c-format
 msgid "Sorry but this is a non-functioning menu option\n"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2703
 msgid "Action feedback mode set to OUTLINE"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2706
 msgid "Action feedback mode set to BOUNDINGBOX"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2730
 msgid "Grid OFF"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2731
 msgid "Dot grid selected"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2732
 msgid "Mesh grid selected"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2733
 msgid "Invalid grid mode"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2755
 msgid "Snap OFF (CAUTION!)"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2758
 msgid "Snap ON"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2761
 msgid "Snap back to the grid (CAUTION!)"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2790
 msgid "Rubber band ON"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2792
 msgid "Rubber band OFF"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2811
 msgid "magnetic net mode: ON"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2814
 msgid "magnetic net mode: OFF"
 msgstr ""
 
@@ -1108,133 +834,104 @@ msgstr ""
 #. the form "untitled_N.sch", where N is a number.  Please make
 #. sure that the translation contains characters suitable for use
 #. in a filename.
-#: schematic/src/i_vars.c:209
 msgid "untitled"
 msgstr ""
 
-#: schematic/src/o_complex.c:192 schematic/src/o_complex.c:195
 #, c-format
 msgid "Translating schematic [%1$d %2$d]"
 msgstr ""
 
-#: schematic/src/o_delete.c:82
 #, c-format
 msgid "Delete locked object?"
 msgid_plural "Delete %1$u locked objects?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/o_misc.c:55
 #, c-format
 msgid "Got an unexpected NULL in o_edit\n"
 msgstr ""
 
-#: schematic/src/o_misc.c:315
 msgid "Hidden text is now visible"
 msgstr ""
 
-#: schematic/src/o_misc.c:317
 msgid "Hidden text is now invisible"
 msgstr ""
 
-#: schematic/src/o_misc.c:425
 #, c-format
 msgid "Could not find symbol [%1$s] in library. Update failed."
 msgstr ""
 
-#: schematic/src/o_misc.c:541
 #, c-format
 msgid "o_autosave_backups: Can't get the real filename of %1$s."
 msgstr ""
 
-#: schematic/src/o_misc.c:585
 #, c-format
 msgid "Could NOT set previous backup file [%1$s] read-write"
 msgstr ""
 
-#: schematic/src/o_misc.c:605
 #, c-format
 msgid "Could NOT set backup file [%1$s] readonly"
 msgstr ""
 
-#: schematic/src/o_misc.c:610
 #, c-format
 msgid "Could NOT save backup file [%1$s]"
 msgstr ""
 
-#: schematic/src/o_move.c:192
 #, c-format
 msgid "ERROR: NULL object in o_move_end!\n"
 msgstr ""
 
-#: schematic/src/o_move.c:519
 #, c-format
 msgid "DOH! tried to find the whichone, but didn't find it!\n"
 msgstr ""
 
-#: schematic/src/o_move.c:546
 #, c-format
 msgid "Got a non line object in o_move_check_endpoint\n"
 msgstr ""
 
-#: schematic/src/o_net.c:444
 msgid "Warning: Starting net at off grid coordinate"
 msgstr ""
 
-#: schematic/src/o_net.c:508
 msgid "Warning: Ending net at off grid coordinate"
 msgstr ""
 
-#: schematic/src/o_net.c:856 schematic/src/o_net.c:893
-#: schematic/src/o_net.c:964 schematic/src/o_net.c:1000
 #, c-format
 msgid "Tried to add more than two bus rippers. Internal gschem error.\n"
 msgstr ""
 
-#: schematic/src/o_net.c:1068
 #, c-format
 msgid "Bus ripper symbol [%1$s] was not found in any component library"
 msgstr ""
 
-#: schematic/src/o_picture.c:133 schematic/src/o_picture.c:343
 msgid "Select a picture file..."
 msgstr ""
 
-#: schematic/src/o_picture.c:166
 #, c-format
 msgid "Failed to load picture: %1$s"
 msgstr ""
 
-#: schematic/src/o_picture.c:182
 msgid "Picture"
 msgstr ""
 
-#: schematic/src/o_picture.c:378
 #, c-format
 msgid "Failed to replace pictures: %s"
 msgstr ""
 
-#: schematic/src/o_slot.c:80
 msgid "Slot attribute malformed"
 msgstr ""
 
-#: schematic/src/o_slot.c:88
 msgid "numslots attribute missing"
 msgstr ""
 
-#: schematic/src/o_slot.c:89
 msgid "Slotting not allowed for this component"
 msgstr ""
 
-#: schematic/src/o_slot.c:104
 msgid "New slot number out of range"
 msgstr ""
 
-#: schematic/src/o_undo.c:397
 msgid "Undo/Redo disabled in rc file"
 msgstr ""
 
-#: schematic/src/parsecmd.c:77
 #, c-format
 msgid ""
 "Usage: %1$s [OPTION ...] [--] [FILE ...]\n"
@@ -1259,187 +956,143 @@ msgid ""
 "gEDA/gaf homepage: <http://www.geda-project.org/>\n"
 msgstr ""
 
-#: schematic/src/parsecmd.c:110
 #, c-format
 msgid ""
 "Lepton EDA %1$s (git: %2$.7s)\n"
 "Copyright (C) 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright (C) 2017-2018 Lepton Developers.\n"
+"Copyright (C) 2017-2019 Lepton Developers.\n"
 "This is free software, and you are welcome to redistribute it under\n"
 "certain conditions. For details, see the file `COPYING', which is\n"
 "included in the Lepton EDA distribution.\n"
 "There is NO WARRANTY, to the extent permitted by law.\n"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:125
 #, c-format
 msgid "Got invalid show option; defaulting to show both\n"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:139
 #, c-format
 msgid "ERROR: NULL object!\n"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:328
 msgid "Single Attribute Editor"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:358
 msgid "<b>Edit Attribute</b>"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:360
 msgid "<b>Add Attribute</b>"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:376
 msgid "N_ame:"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:396 schematic/src/x_multiattrib.c:2222
 msgid "_Value:"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:415 schematic/src/x_multiattrib.c:2281
 msgid "Vi_sible"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:434
 msgid "Show Value Only"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:436
 msgid "Show Name Only"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:438 schematic/src/x_multiattrib.c:1620
-#: schematic/scheme/gschem/builtins.scm:324
 msgid "Show Name & Value"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:445
 msgid "<b>Attach Options</b>"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:460
 msgid "All"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:476 schematic/src/x_compselect.c:986
-#: schematic/src/x_compselect.c:1100
 msgid "Components"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:492 schematic/src/x_window.c:1214
 msgid "Nets"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:508
 msgid "Replace existing attributes"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:412
 msgid ""
 "slotted object without slot attribute may cause problems when autonumbering "
 "slots"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:427
 #, c-format
 msgid ""
 "duplicate slot may cause problems: [symbolname=%1$s, number=%2$d, slot=%3$d]"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:675
 msgid "No searchstring given in autonumber text."
 msgstr ""
 
-#: schematic/src/x_autonumber.c:728
 msgid "No '*' or '?' given at the end of the autonumber text."
 msgstr ""
 
-#: schematic/src/x_autonumber.c:873
 msgid "Diagonal"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:874
 msgid "Top to bottom"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:875
 msgid "Bottom to top"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:876
 msgid "Left to right"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:877
 msgid "Right to left"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:878
 msgid "File order"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1214
 msgid "Autonumber text"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1237
 msgid "<b>Scope</b>"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1259
 msgid "Search for:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1273
 msgid "Autonumber text in:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1280
 msgid "Skip numbers found in:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1292 schematic/src/x_autonumber.c:1301
 msgid "Selected objects"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1293 schematic/src/x_autonumber.c:1302
 msgid "Current page"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1294 schematic/src/x_autonumber.c:1303
 msgid "Whole hierarchy"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1305
 msgid "Overwrite existing numbers"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1310
 msgid "<b>Options</b>"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1332
 msgid "Starting number:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1339
 msgid "Sort order:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1371
 msgid "Remove numbers"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1375
 msgid "Automatic slotting"
 msgstr ""
 
-#: schematic/src/x_clipboard.c:245
 #, c-format
 msgid ""
 "<b>Invalid schematic on clipboard.</b>\n"
@@ -1447,170 +1100,130 @@ msgid ""
 "An error occurred while inserting clipboard data: %s."
 msgstr ""
 
-#: schematic/src/x_clipboard.c:247
 msgid "Clipboard insertion failed"
 msgstr ""
 
-#: schematic/src/x_color.c:89 schematic/src/x_color.c:98
 #, c-format
 msgid "Could not allocate the color %1$s!\n"
 msgstr ""
 
-#: schematic/src/x_color.c:89
 msgid "black"
 msgstr ""
 
-#: schematic/src/x_color.c:98
 msgid "white"
 msgstr ""
 
-#: schematic/src/x_color.c:120
 #, c-format
 msgid "Could not allocate display color %1$i!\n"
 msgstr ""
 
-#: schematic/src/x_color.c:142
 #, c-format
 msgid "Could not allocate outline color %1$i!\n"
 msgstr ""
 
-#: schematic/src/x_color.c:159
 #, c-format
 msgid "Tried to get an invalid color: %1$d\n"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:145
 msgid "Background"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:147
 msgid "Net endpoint"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:148
 msgid "Graphic"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:151
 msgid "Logic bubble"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:152
 msgid "Grid point"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:153
 msgid "Detached attribute"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:156
 msgid "Selection"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:157
 msgid "Bounding box"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:158
 msgid "Zoom box"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:161
 msgid "Output background"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:162
 msgid "Freestyle 1"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:163
 msgid "Freestyle 2"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:164
 msgid "Freestyle 3"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:165
 msgid "Freestyle 4"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:166
 msgid "Net junction"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:167
 msgid "Mesh grid major"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:168
 msgid "Mesh grid minor"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:172
 msgid "Unknown"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1169
 msgid "Reset filter"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1192
 msgid "Reload all libraries"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1245 schematic/src/x_multiattrib.c:2092
 msgid "Value"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1284
 msgid "Default behavior - reference component"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1287
 msgid "Embed component in schematic"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1290
 msgid "Include component as individual objects"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1448
 msgid "Select Component..."
 msgstr ""
 
-#: schematic/src/x_compselect.c:1471
 msgid "In Us_e"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1475
 msgid "Lib_raries"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1484 schematic/src/x_fileselect.c:119
 msgid "Preview"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1510
 msgid "Attributes"
 msgstr ""
 
-#: schematic/src/x_dialog.c:325
 msgid "Major symbol changes detected."
 msgstr ""
 
-#: schematic/src/x_dialog.c:349
 msgid ""
 "Changes have occurred to the symbols shown below.\n"
 "\n"
 "Be sure to verify each of these symbols."
 msgstr ""
 
-#: schematic/src/x_dialog.c:369
 msgid "Symbol"
 msgstr ""
 
-#: schematic/src/x_dialog.c:406
 #, c-format
 msgid ""
 "<span weight=\"bold\" size=\"larger\">The input attribute \"%s\" is invalid\n"
@@ -1621,39 +1234,30 @@ msgid ""
 "The value cannot start with a space."
 msgstr ""
 
-#: schematic/src/x_dialog.c:408
 msgid "Invalid Attribute"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:37
 msgid "Schematics"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:42
 msgid "Symbols"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:47
 msgid "Schematics and symbols"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:53
 msgid "All files"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:169
 msgid "Open..."
 msgstr ""
 
-#: schematic/src/x_fileselect.c:233
 msgid "Save as..."
 msgstr ""
 
-#: schematic/src/x_fileselect.c:297
 msgid "Save cancelled on user request"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:334
 msgid ""
 "\n"
 "If you load the original file, the backup file will be overwritten in the "
@@ -1662,28 +1266,22 @@ msgid ""
 "Do you want to load the backup file?\n"
 msgstr ""
 
-#: schematic/src/x_fstylecb.c:73
 msgid "Hollow"
 msgstr ""
 
-#: schematic/src/x_fstylecb.c:80
 msgid "Filled"
 msgstr ""
 
-#: schematic/src/x_fstylecb.c:87
 msgid "Mesh"
 msgstr ""
 
-#: schematic/src/x_fstylecb.c:94
 msgid "Hatch"
 msgstr ""
 
-#: schematic/src/x_image.c:279
 #, c-format
 msgid "x_image_lowlevel: Unable to write %1$s file %2$s."
 msgstr ""
 
-#: schematic/src/x_image.c:289
 #, c-format
 msgid ""
 "There was the following error when saving image with type %1$s to filename:\n"
@@ -1692,293 +1290,226 @@ msgid ""
 "%3$s.\n"
 msgstr ""
 
-#: schematic/src/x_image.c:309
 #, c-format
 msgid "Wrote color image to [%1$s] [%2$d x %3$d]"
 msgstr ""
 
-#: schematic/src/x_image.c:311
 #, c-format
 msgid "Wrote black and white image to [%1$s] [%2$d x %3$d]"
 msgstr ""
 
-#: schematic/src/x_image.c:319
 msgid "x_image_lowlevel: Unable to get pixbuf from gschem's window."
 msgstr ""
 
-#: schematic/src/x_image.c:358
 msgid "Width x Height"
 msgstr ""
 
-#: schematic/src/x_image.c:374
 msgid "Image type"
 msgstr ""
 
-#: schematic/src/x_image.c:395
 msgid "Write image..."
 msgstr ""
 
-#: schematic/src/x_linecapcb.c:74
 msgid "Butt"
 msgstr ""
 
-#: schematic/src/x_linecapcb.c:81
 msgid "Square"
 msgstr ""
 
-#: schematic/src/x_linecapcb.c:88
 msgid "Round"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:74
 msgid "Solid"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:81
 msgid "Dotted"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:88
 msgid "Dashed"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:95
 msgid "Center"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:102
 msgid "Phantom"
 msgstr ""
 
-#: schematic/src/x_menus.c:41 schematic/scheme/gschem/builtins.scm:267
 msgid "Add Net"
 msgstr ""
 
-#: schematic/src/x_menus.c:42 schematic/src/x_multiattrib.c:2187
-#: schematic/scheme/gschem/builtins.scm:264
 msgid "Add Attribute"
 msgstr ""
 
-#: schematic/src/x_menus.c:43 schematic/scheme/gschem/builtins.scm:261
 msgid "Add Component"
 msgstr ""
 
-#: schematic/src/x_menus.c:44 schematic/scheme/gschem/builtins.scm:270
 msgid "Add Bus"
 msgstr ""
 
-#: schematic/src/x_menus.c:45 schematic/scheme/gschem/builtins.scm:273
 msgid "Add Text"
 msgstr ""
 
-#: schematic/src/x_menus.c:47 schematic/scheme/gschem/builtins.scm:210
 msgid "Zoom In"
 msgstr ""
 
-#: schematic/src/x_menus.c:48 schematic/scheme/gschem/builtins.scm:213
 msgid "Zoom Out"
 msgstr ""
 
-#: schematic/src/x_menus.c:50 schematic/scheme/gschem/builtins.scm:207
 msgid "Zoom Extents"
 msgstr ""
 
-#: schematic/src/x_menus.c:52 schematic/src/x_window.c:1233
 msgid "Select"
 msgstr ""
 
-#: schematic/src/x_menus.c:53 schematic/scheme/conf/schematic/menu.scm:69
-#: schematic/scheme/gschem/builtins.scm:126
 msgid "Edit..."
 msgstr ""
 
-#: schematic/src/x_menus.c:54 schematic/scheme/conf/schematic/menu.scm:68
 msgid "Object Properties..."
 msgstr ""
 
-#: schematic/src/x_menus.c:59 schematic/scheme/gschem/builtins.scm:300
 msgid "Down Schematic"
 msgstr ""
 
-#: schematic/src/x_menus.c:60 schematic/scheme/gschem/builtins.scm:303
 msgid "Down Symbol"
 msgstr ""
 
-#: schematic/src/x_menus.c:61
 msgid "Up"
 msgstr ""
 
-#: schematic/src/x_menus.c:336
 #, c-format
 msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
 msgstr ""
 
-#: schematic/src/x_menus.c:360
 #, c-format
 msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
 msgstr ""
 
-#: schematic/src/x_misc.c:70
 msgid "The operating system is out of memory or resources."
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:798 schematic/src/x_multiattrib.c:2704
 msgid "<various>"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:930
 msgid "Attributes with empty name are not allowed. Please set a name."
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1622
 msgid "Show Value only"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1624
 msgid "Show Name only"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1651
 msgid "Promote"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1655
 msgid "Duplicate"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1657
 msgid "Copy to all"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1986 schematic/src/x_multiattrib.c:2602
 msgid "Edit Attributes"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2112
 msgid "Vis?"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2130
 msgid "N"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2148
 msgid "V"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2170
 msgid "Sho_w inherited attributes"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2197
 msgid "_Name:"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2241
 msgid "Ctrl+Enter inserts new line; Ctrl+Tab inserts Tab"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2618
 #, c-format
 msgid "%2$i symbol (%1$s)"
 msgid_plural "%2$i symbols (%1$s)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2624
 #, c-format
 msgid "%1$i pin"
 msgid_plural "%1$i pins"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2630
 #, c-format
 msgid "%1$i net"
 msgid_plural "%1$i nets"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2636
 #, c-format
 msgid "%1$i bus"
 msgid_plural "%1$i buses"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2642
 #, c-format
 msgid "%1$i attribute"
 msgid_plural "%1$i attributes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_newtext.c:433
 msgid "Text Entry..."
 msgstr ""
 
-#: schematic/src/x_pagesel.c:253
 msgid "New Page"
 msgstr ""
 
-#: schematic/src/x_pagesel.c:254
 msgid "Open Page..."
 msgstr ""
 
-#: schematic/src/x_pagesel.c:256
 msgid "Save Page"
 msgstr ""
 
-#: schematic/src/x_pagesel.c:257 schematic/scheme/gschem/builtins.scm:246
 msgid "Close Page"
 msgstr ""
 
-#: schematic/src/x_pagesel.c:376 schematic/scheme/gschem/builtins.scm:237
 msgid "Page Manager"
 msgstr ""
 
-#: schematic/src/x_pagesel.c:448
 msgid "Changed"
 msgstr ""
 
-#: schematic/src/x_pagesel.c:468
 msgid "Right click on the filename for more options..."
 msgstr ""
 
-#: schematic/src/x_print.c:306
 #, c-format
 msgid "Failed to write PDF to '%s': %s\n"
 msgstr ""
 
-#: schematic/src/x_print.c:364
 #, c-format
 msgid "Failed to write PDF to '%1$s': %2$s\n"
 msgstr ""
 
-#: schematic/src/x_print.c:449
 #, c-format
 msgid ""
 "Error printing file:\n"
 "%1$s"
 msgstr ""
 
-#: schematic/src/x_rc.c:39
 msgid "ERROR: An unknown error occurred while parsing configuration files."
 msgstr ""
 
-#: schematic/src/x_rc.c:44
 msgid ""
 "An unknown error occurred while parsing configuration files.\n"
 "\n"
 "The lepton-schematic log may contain more information."
 msgstr ""
 
-#: schematic/src/x_rc.c:56
 #, c-format
 msgid "ERROR: %1$s"
 msgstr ""
 
-#: schematic/src/x_rc.c:59
 #, c-format
 msgid ""
 "%1$s\n"
@@ -1986,135 +1517,104 @@ msgid ""
 "The lepton-schematic log may contain more information."
 msgstr ""
 
-#: schematic/src/x_rc.c:67
 msgid "Cannot load lepton-schematic configuration."
 msgstr ""
 
-#: schematic/src/x_script.c:42 schematic/scheme/conf/schematic/menu.scm:40
 msgid "Execute Script..."
 msgstr ""
 
-#: schematic/src/x_script.c:61
 #, c-format
 msgid "Executing guile script [%1$s]"
 msgstr ""
 
-#: schematic/src/x_tabs.c:860
 #, c-format
 msgid "Hierarchy up: %s"
 msgstr ""
 
-#: schematic/src/x_tabs.c:863
 msgid "Hierarchy up"
 msgstr ""
 
-#: schematic/src/x_widgets.c:158 schematic/src/x_window.c:1444
 msgid "Options"
 msgstr ""
 
-#: schematic/src/x_widgets.c:203 schematic/src/x_window.c:1436
 msgid "Object"
 msgstr ""
 
-#: schematic/src/x_widgets.c:224
 msgid "Log"
 msgstr ""
 
-#: schematic/src/x_widgets.c:245 schematic/src/x_window.c:1466
 msgid "Find Text"
 msgstr ""
 
-#: schematic/src/x_widgets.c:259
 msgid "Color Scheme Editor"
 msgstr ""
 
-#: schematic/src/x_widgets.c:272 schematic/scheme/gschem/builtins.scm:378
 msgid "Select Schematic Font"
 msgstr ""
 
-#: schematic/src/x_window.c:763
 #, c-format
 msgid "Loading schematic [%1$s]"
 msgstr ""
 
-#: schematic/src/x_window.c:864
 #, c-format
 msgid "Could NOT save page [%1$s]\n"
 msgstr ""
 
-#: schematic/src/x_window.c:865
 msgid "Error while trying to save"
 msgstr ""
 
-#: schematic/src/x_window.c:875
 msgid "Failed to save file"
 msgstr ""
 
-#: schematic/src/x_window.c:885
 #, fuzzy, c-format
 msgid "Saved as [%1$s]"
 msgstr "Shrani vse"
 
-#: schematic/src/x_window.c:887
 #, fuzzy, c-format
 msgid "Saved [%1$s]"
 msgstr "Shrani vse"
 
-#: schematic/src/x_window.c:889
 msgid "Saved"
 msgstr ""
 
-#: schematic/src/x_window.c:966
 #, c-format
 msgid "Discarding page [%1$s]"
 msgstr ""
 
-#: schematic/src/x_window.c:966
 #, c-format
 msgid "Closing [%1$s]"
 msgstr ""
 
-#: schematic/src/x_window.c:1175
 msgid "New"
 msgstr ""
 
-#: schematic/src/x_window.c:1175
 msgid "New file"
 msgstr ""
 
-#: schematic/src/x_window.c:1179
 msgid "Open"
 msgstr ""
 
-#: schematic/src/x_window.c:1179
 msgid "Open file"
 msgstr ""
 
-#: schematic/src/x_window.c:1183 schematic/scheme/gschem/builtins.scm:59
 msgid "Save"
 msgstr ""
 
-#: schematic/src/x_window.c:1183
 msgid "Save file"
 msgstr ""
 
-#: schematic/src/x_window.c:1189 schematic/scheme/gschem/builtins.scm:93
 msgid "Undo"
 msgstr ""
 
-#: schematic/src/x_window.c:1189
 msgid "Undo last operation"
 msgstr ""
 
-#: schematic/src/x_window.c:1193 schematic/scheme/gschem/builtins.scm:96
 msgid "Redo"
 msgstr ""
 
-#: schematic/src/x_window.c:1193
 msgid "Redo last undo"
 msgstr ""
 
-#: schematic/src/x_window.c:1198
 msgid ""
 "Add component...\n"
 "Select library and component from list, move the mouse into main window, "
@@ -2122,56 +1622,44 @@ msgid ""
 "Right mouse button to cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1209
 msgid ""
 "Add nets mode\n"
 "Right mouse button to cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1217
 msgid ""
 "Add buses mode\n"
 "Right mouse button to cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1226
 msgid "Add Text..."
 msgstr ""
 
-#: schematic/src/x_window.c:1233
 msgid "Select mode"
 msgstr ""
 
-#: schematic/src/x_window.c:1288
 msgid "Show"
 msgstr ""
 
-#: schematic/src/x_window.c:1289
 msgid "Show text starting with:"
 msgstr ""
 
-#: schematic/src/x_window.c:1345
 msgid "Menu/Cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1349
 msgid "Pan/Cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1359
 msgid "Pick"
 msgstr ""
 
-#: schematic/src/x_window.c:1470 schematic/scheme/gschem/builtins.scm:180
 msgid "Status"
 msgstr ""
 
-#: schematic/src/x_window.c:1568
 #, fuzzy, c-format
 msgid "New file [%s]"
 msgstr "Nova datoteka [%s]\n"
 
-#: schematic/src/x_window.c:1598
 #, c-format
 msgid ""
 "<b>An error occurred while loading the requested file.</b>\n"
@@ -2185,832 +1673,622 @@ msgid ""
 "monitor program's output in terminal window."
 msgstr ""
 
-#: schematic/src/x_window.c:1617
 msgid "Failed to load file"
 msgstr ""
 
-#: schematic/data/lepton-schematic.desktop.in:3
 msgid "Lepton EDA Schematic Editor"
 msgstr ""
 
-#: schematic/data/lepton-schematic.desktop.in:4
 msgid "Create and edit electrical schematics and symbols with lepton-schematic"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:27
 msgid "_New"
 msgstr "_Nova"
 
-#: schematic/scheme/conf/schematic/menu.scm:28
 msgid "_Open..."
 msgstr "_Odpri ..."
 
-#: schematic/scheme/conf/schematic/menu.scm:30
 msgid "Open Recen_t"
 msgstr "Odpri nedav_no"
 
-#: schematic/scheme/conf/schematic/menu.scm:32
 msgid "_Save"
 msgstr "_Shrani"
 
-#: schematic/scheme/conf/schematic/menu.scm:33
 msgid "Save _As..."
 msgstr "Shrani _kot ..."
 
-#: schematic/scheme/conf/schematic/menu.scm:34
-#: schematic/scheme/gschem/builtins.scm:65
 msgid "Save All"
 msgstr "Shrani vse"
 
-#: schematic/scheme/conf/schematic/menu.scm:36
 msgid "_Print..."
 msgstr "Na_tisni ..."
 
-#: schematic/scheme/conf/schematic/menu.scm:37
 msgid "Write _Image..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:39
 msgid "Invoke Macro..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:41
 msgid "REPL..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:43
-#: schematic/scheme/gschem/builtins.scm:77
 msgid "New Window"
 msgstr "Novo okno"
 
-#: schematic/scheme/conf/schematic/menu.scm:44
 msgid "_Close Window"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:45
 msgid "_Quit"
 msgstr "_Končaj"
 
-#: schematic/scheme/conf/schematic/menu.scm:51
 msgid "_Undo"
 msgstr "_Razveljavi"
 
-#: schematic/scheme/conf/schematic/menu.scm:52
 msgid "_Redo"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:54
 msgid "Cu_t"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:55
 msgid "_Copy"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:56
 msgid "_Paste"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:57
 msgid "_Delete"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:60
-#: schematic/scheme/gschem/builtins.scm:102
 msgid "Select All"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:61
-#: schematic/scheme/gschem/builtins.scm:105
 msgid "Deselect"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:65
 msgid "Rotate 90 Mode"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:70
 msgid "Edit Text..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:71
 msgid "Slot..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:76
-#: schematic/scheme/gschem/builtins.scm:150
 msgid "Embed Component/Picture"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:77
-#: schematic/scheme/gschem/builtins.scm:153
 msgid "Unembed Component/Picture"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:78
-#: schematic/scheme/gschem/builtins.scm:156
 msgid "Update Component"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:79
 msgid "Symbol Translate..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:85
 msgid "Copy into 1"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:86
 msgid "Copy into 2"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:87
 msgid "Copy into 3"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:88
 msgid "Copy into 4"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:89
 msgid "Copy into 5"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:90
 msgid "Cut into 1"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:91
 msgid "Cut into 2"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:92
 msgid "Cut into 3"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:93
 msgid "Cut into 4"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:94
 msgid "Cut into 5"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:95
 msgid "Paste from 1"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:96
 msgid "Paste from 2"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:97
 msgid "Paste from 3"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:98
 msgid "Paste from 4"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:99
 msgid "Paste from 5"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:105
 msgid "Side Dock"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:106
 msgid "Bottom Dock"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:108
 msgid "Find Text Results"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:110
 msgid "_Redraw"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:111
 msgid "_Pan"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:112
 msgid "Zoom _Box"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:113
 msgid "Zoom _Extents"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:114
 msgid "Zoom _In"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:115
 msgid "Zoom _Out"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:116
 msgid "Zoom _Full"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:118
 msgid "_Dark Color Scheme"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:119
 msgid "_Light Color Scheme"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:120
 msgid "B_W Color Scheme"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:122
 msgid "Color Scheme Editor..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:129
 msgid "_Manager..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:131
 msgid "_Previous"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:132
 msgid "_Next"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:133
 msgid "_Close"
 msgstr "_Zapri"
 
-#: schematic/scheme/conf/schematic/menu.scm:135
 #, fuzzy
 msgid "_Revert..."
 msgstr "_Povrni"
 
-#: schematic/scheme/conf/schematic/menu.scm:137
-#: schematic/scheme/gschem/builtins.scm:249
 msgid "Next Tab"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:138
-#: schematic/scheme/gschem/builtins.scm:252
 msgid "Previous Tab"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:146
 msgid "_Component..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:148
 msgid "_Net"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:149
 msgid "B_us"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:151
 msgid "_Attribute..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:152
 msgid "_Text..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:154
 msgid "_Line"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:155
 msgid "Pat_h"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:156
 msgid "_Box"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:157
 msgid "C_ircle"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:158
 msgid "A_rc"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:159
 msgid "_Pin"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:161
 msgid "Pictu_re..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:167
 msgid "_Up"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:169
 msgid "_Down Schematic"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:170
 msgid "Down _Symbol"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:176
 msgid "_Attach"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:177
 msgid "_Detach"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:179
 msgid "Show _Value"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:180
 msgid "Show _Name"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:181
 msgid "Show _Both"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:182
 msgid "_Toggle Visibility"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:184
 msgid "_Hide Specific Text..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:185
 msgid "_Show Specific Text..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:186
 msgid "Show/Hide Hidden Text"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:188
 msgid "_Find Text/Check Symbol..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:189
 msgid "A_utonumber Text..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:195
 msgid "_Options..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:196
 #, fuzzy
 msgid "_Font..."
 msgstr "Na_tisni ..."
 
-#: schematic/scheme/conf/schematic/menu.scm:198
 msgid "Grid +"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:199
 msgid "Grid -"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:201
 msgid "Grid Style: Cycle Dots/Mesh/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:202
 msgid "Grid Snap: Cycle Grid/Resnap/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:204
 msgid "Feedback Mode: Outline/Box"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:205
 msgid "Net: Rubberband On/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:206
 msgid "Net: Magnetic On/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:208
 #, fuzzy
 msgid "_Coord Window"
 msgstr "Novo okno"
 
-#: schematic/scheme/conf/schematic/menu.scm:209
 #, fuzzy
 msgid "_Log Window"
 msgstr "Novo okno"
 
-#: schematic/scheme/conf/schematic/menu.scm:215
 msgid "_1 allegro"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:223
 msgid "User _Guide"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:224
 msgid "_FAQ"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:225
 msgid "Docu_mentation"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:226
 msgid "_Wiki"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:228
 msgid "Find Component D_ocumentation"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:230
 msgid "_Hotkeys..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:231
 msgid "_About"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:237
 msgid "_File"
 msgstr "_Datoteka"
 
-#: schematic/scheme/conf/schematic/menu.scm:238
 msgid "_Edit"
 msgstr "_Uredi"
 
-#: schematic/scheme/conf/schematic/menu.scm:240
 msgid "_View"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:241
 msgid "_Page"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:242
 msgid "_Add"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:243
 msgid "Hie_rarchy"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:244
 msgid "A_ttributes"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:245
 msgid "_Options"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:246
 msgid "_Netlist"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:247
 msgid "_Help"
 msgstr ""
 
-#: schematic/scheme/gschem/action.scm:43
 #, scheme-format
 msgid "~S is not a valid gschem action."
 msgstr ""
 
-#: schematic/scheme/gschem/action.scm:158
 msgid "Repeat Last Action"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:47
 msgid "Cancel"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:53
 #, fuzzy
 msgid "New File"
 msgstr "Nova datoteka [%s]\n"
 
-#: schematic/scheme/gschem/builtins.scm:56
 msgid "Open File"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:62
 #, fuzzy
 msgid "Save As"
 msgstr "Shrani vse"
 
-#: schematic/scheme/gschem/builtins.scm:68
 #, fuzzy
 msgid "Print"
 msgstr "Na_tisni ..."
 
-#: schematic/scheme/gschem/builtins.scm:71
 msgid "Export Image"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:74
 msgid "Run Script"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:80
 #, fuzzy
 msgid "Close Window"
 msgstr "Novo okno"
 
-#: schematic/scheme/gschem/builtins.scm:83
 #, fuzzy
 msgid "Quit"
 msgstr "_Končaj"
 
-#: schematic/scheme/gschem/builtins.scm:87
 msgid "Terminal REPL"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:132
 msgid "Choose Slot"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:135
 msgid "Edit Object Properties"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:138
 msgid "Translate Symbol"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:147
 msgid "Invoke Macro"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:159
 msgid "Show/Hide Invisible Text"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:165
 msgid "Cut"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:171
 msgid "Paste"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:177
 msgid "Sidebar"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:183
 msgid "Find Text State"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:186
 msgid "Redraw"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:192
 msgid "Pan Left"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:195
 msgid "Pan Right"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:198
 msgid "Pan Up"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:201
 msgid "Pan Down"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:216
 msgid "Zoom Full"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:219
 msgid "Dark Color Scheme"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:222
 msgid "Light Color Scheme"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:225
 msgid "Monochrome Color Scheme"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:228
 msgid "Show Color Scheme Editor"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:234
 msgid "Revert Changes"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:240
 msgid "Previous Page"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:243
 msgid "Next Page"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:255
 #, fuzzy
 msgid "Print Page"
 msgstr "Na_tisni ..."
 
-#: schematic/scheme/gschem/builtins.scm:276
 msgid "Add Line"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:279
 msgid "Add Path"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:282
 msgid "Add Box"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:285
 msgid "Add Circle"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:288
 msgid "Add Arc"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:291
 msgid "Add Pin"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:294
 msgid "Add Picture"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:306
 msgid "Up Hierarchy"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:312
 msgid "Attach Attributes"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:315
 msgid "Detach Attributes"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:318
 msgid "Show Attribute Value"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:321
 msgid "Show Attribute Name"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:327
 msgid "Toggle Text Visibility"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:330
 msgid "Find Specific Text"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:333
 msgid "Hide Specific Text"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:336
 msgid "Show Specific Text"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:339
 msgid "Autonumber Text"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:345
 msgid "Show Hotkeys"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:348
 msgid "Switch Grid Style"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:351
 msgid "Switch Snap Mode"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:354
 msgid "Set Grid Spacing"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:357
 msgid "Increase Grid Spacing"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:360
 msgid "Decrease Grid Spacing"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:363
 msgid "Toggle Outline Drawing"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:366
 msgid "Toggle Net Rubber Band"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:369
 msgid "Toggle Magnetic Nets"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:372
 #, fuzzy
 msgid "Show Log Window"
 msgstr "Novo okno"
 
-#: schematic/scheme/gschem/builtins.scm:375
 msgid "Show Coordinate Window"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:385
 msgid "Component Documentation"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:387
 msgid "View documentation for selected component"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:403
 msgid ""
 "Could not show documentation for selected component:\n"
 "\n"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:408
 msgid "gEDA Manuals"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:409
 msgid "View the front page of the gEDA documentation in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:414
 msgid "gschem User Guide"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:415
 msgid "View the gschem User Guide in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:420
 msgid "gschem FAQ"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:421
 msgid "Frequently Asked Questions about using gschem."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:426
 msgid "gEDA wiki"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:427
 msgid "View the front page of the gEDA wiki in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:431
 msgid "About gschem"
 msgstr ""
 
-#: schematic/scheme/gschem/deprecated.scm:102
 #, scheme-format
 msgid "Invalid text alignment ~A."
 msgstr ""
 
-#: schematic/scheme/gschem/gschemdoc.scm:241
 msgid "No documentation found"
 msgstr ""
 
-#: schematic/scheme/gschem/keymap.scm:40
 #, scheme-format
 msgid "~S is not a valid key combination."
 msgstr ""
 
-#: schematic/scheme/gschem/keymap.scm:157
 #, scheme-format
 msgid "~S is not a prefix key sequence."
 msgstr ""

--- a/schematic/po/sr.po
+++ b/schematic/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-15 15:13+0300\n"
+"POT-Creation-Date: 2019-02-22 14:08+0300\n"
 "PO-Revision-Date: 2012-01-27 14:18+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: Serbian <sr@li.org>\n"
@@ -18,22 +18,18 @@ msgstr ""
 "X-Launchpad-Export-Date: 2012-11-14 16:52+0000\n"
 "X-Generator: Launchpad (build 16265)\n"
 
-#: schematic/src/a_zoom.c:155
 msgid "Zoom too small!  Cannot zoom further."
 msgstr ""
 
-#: schematic/src/color_edit_widget.c:399
 #, c-format
 msgid ""
 "Could not save file [%s]:\n"
 "%s"
 msgstr ""
 
-#: schematic/src/color_edit_widget.c:434
 msgid "Save Color Scheme As..."
 msgstr ""
 
-#: schematic/src/color_edit_widget.c:482 schematic/src/x_fileselect.c:292
 #, c-format
 msgid ""
 "The selected file `%1$s' already exists.\n"
@@ -41,178 +37,140 @@ msgid ""
 "Would you like to overwrite it?"
 msgstr ""
 
-#: schematic/src/color_edit_widget.c:486 schematic/src/x_fileselect.c:295
 msgid "Overwrite file?"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:211
 msgid "_Apply"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:215
 msgid "Sa_ve..."
 msgstr ""
 
-#: schematic/src/font_select_widget.c:278
 #, c-format
 msgid "<b>Current:</b> %s"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:453
 msgid "Save configuration"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:461
 msgid "Save settings to:"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:465
 msgid "Local configuration file (in current directory)"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:467
 msgid "User configuration file (geda-user.conf)"
 msgstr ""
 
-#: schematic/src/g_attrib.c:90
 msgid "Object ~A is not included in the current gschem page."
 msgstr ""
 
-#: schematic/src/g_attrib.c:110
 msgid "Invalid text name/value visibility ~A."
 msgstr ""
 
-#: schematic/src/g_rc.c:107
 #, c-format
 msgid "You are running gEDA/gaf version [%1$s%2$s.%3$s],\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:111
 #, c-format
 msgid ""
 "but you have a version [%1$s] gschemrc file:\n"
 "[%2$s]\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:114
 #, c-format
 msgid "Please be sure that you have the latest rc file.\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:240
 #, c-format
 msgid "Invalid size [%1$d] passed to text-size\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:283
 #, c-format
 msgid "Invalid size [%1$d] passed to snap-size\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:620
 #, c-format
 msgid "Invalid num levels [%1$d] passed to undo-levels\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:831
 #, c-format
 msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:931
 #, c-format
 msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:972
 #, c-format
 msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:998
 #, c-format
 msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1023
 #, c-format
 msgid "Invalid offset [%1$d] passed to add-attribute-offset\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1047
 #, c-format
 msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1071
 #, c-format
 msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1094
 #, c-format
 msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1118
 #, c-format
 msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1144
 #, c-format
 msgid "Invalid gain [%1$d] passed to zoom-gain\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1169
 #, c-format
 msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
 msgstr ""
 
-#: schematic/src/g_select.c:78 schematic/src/g_select.c:115
-#: schematic/src/g_select.c:151
 msgid "Object ~A is not directly included in a page."
 msgstr ""
 
-#: schematic/src/g_util.c:54
 msgid "Could not launch URI ~S: ~A"
 msgstr ""
 
-#: schematic/src/g_window.c:139
 msgid "Found invalid gschem window smob ~S"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:156
 #, c-format
 msgid "Lepton EDA/lepton-schematic version %1$s%2$s.%3$s git: %4$.7s"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:163
 #, c-format
 msgid "This is the MINGW32 port.\n"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:167
 #, c-format
 msgid "Current locale settings: %1$s\n"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:201
 #, c-format
 msgid "Couldn't find init scm file [%1$s]"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:206
 #, c-format
 msgid "Read init scm file [%1$s]"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:210
 #, c-format
 msgid "Failed to read init scm file [%1$s]"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:290
 #, c-format
 msgid ""
 "ERROR: Failed to load or evaluate startup script.\n"
@@ -220,676 +178,491 @@ msgid ""
 "The lepton-schematic log may contain more information.\n"
 msgstr ""
 
-#: schematic/src/gschem_about_dialog.c:51
 #, c-format
 msgid "%s (git: %.7s)"
 msgstr ""
 
-#: schematic/src/gschem_about_dialog.c:75
 msgid "Lepton Electronic Design Automation"
 msgstr ""
 
-#: schematic/src/gschem_about_dialog.c:83
 msgid ""
 "Copyright © 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright © 2017-2018 Lepton Developers.\n"
-"See AUTHORS and ChangeLog files for details."
+"Copyright © 2017-2019 Lepton Developers.\n"
+"See AUTHORS, ChangeLog files and consult 'git log' history for details."
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:69
 msgid "Upper Left"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:71
 msgid "Upper Middle"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:73
 msgid "Upper Right"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:78
 msgid "Middle Left"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:80
 msgid "Middle Middle"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:82
 msgid "Middle Right"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:87
 msgid "Lower Left"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:89
 msgid "Lower Middle"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:91
 msgid "Lower Right"
 msgstr ""
 
-#: schematic/src/gschem_arc_dialog.c:104
 msgid "Arc Params"
 msgstr ""
 
-#: schematic/src/gschem_arc_dialog.c:140
 msgid "Arc _Radius:"
 msgstr ""
 
-#: schematic/src/gschem_arc_dialog.c:141
 msgid "Start _Angle:"
 msgstr ""
 
-#: schematic/src/gschem_arc_dialog.c:142
 msgid "_Degrees of Sweep:"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:504
 msgid "Left mouse button"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:508
 msgid "Middle mouse button"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:512
 msgid "Right mouse button"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:595
 msgid "(Snap size, Grid size)"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:603
 msgid "Net rubber band mode"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:614
 msgid "Magnetic net mode"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:622
 msgid "Current action mode"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:935
-#: schematic/src/gschem_bottom_widget.c:951
 msgid "OFF"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:954
 msgid "NONE"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:960
 #, c-format
 msgid "Grid(%1$s, %2$s)"
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:350
-#: schematic/src/x_compselect.c:1236 schematic/src/x_multiattrib.c:2068
 msgid "Name"
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:372
 msgid "S_elect the schematics you want to save:"
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:467
 #, c-format
 msgid "Save the changes to schematic \"%1$s\" before closing?"
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:473
 #, c-format
 msgid ""
 "There are %1$d schematics with unsaved changes. Save changes before closing?"
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:502
 msgid "If you don't save, all your changes will be permanently lost."
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:522
 msgid "Close _without saving"
 msgstr ""
 
-#: schematic/src/gschem_coord_dialog.c:86
 msgid "Coords"
 msgstr ""
 
-#: schematic/src/gschem_coord_dialog.c:106
 msgid "Screen"
 msgstr ""
 
-#: schematic/src/gschem_coord_dialog.c:115
 msgid "World"
 msgstr ""
 
-#: schematic/src/gschem_find_text_state.c:809 schematic/src/x_pagesel.c:432
 msgid "Filename"
 msgstr ""
 
-#: schematic/src/gschem_find_text_state.c:821 schematic/src/i_callbacks.c:1970
-#: schematic/src/x_colorcb.c:154 schematic/src/x_widgets.c:179
-#: schematic/src/x_window.c:1226 schematic/src/x_window.c:1440
 msgid "Text"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:427
 msgid "descend into hierarchy"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:435
 msgid "Find"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:557
 msgid "Find Text:"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:564
 msgid "Find Pattern:"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:571
 msgid "Find Regex:"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:578
 msgid "Check symbol:"
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:200
 msgid "Hotkeys"
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:229
 msgid ""
 "Start typing action name or keystroke to filter the list.\n"
 "Type hotkeys as they are displayed in \"Keystroke(s)\" column."
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:233 schematic/src/x_compselect.c:1124
 #, fuzzy
 msgid "_Filter:"
 msgstr "Да_тотека"
 
-#: schematic/src/gschem_hotkey_dialog.c:259 schematic/src/i_basic.c:280
 msgid "Action"
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:277
 msgid "Keystroke(s)"
 msgstr ""
 
-#: schematic/src/gschem_log_widget.c:177
 msgid "** Invalid UTF-8 in log message. See stderr or gschem.log.\n"
 msgstr ""
 
-#: schematic/src/gschem_log_widget.c:434
 #, fuzzy
 msgid "Clear log window?"
 msgstr "Нови прозор"
 
-#: schematic/src/gschem_log_widget.c:477
 #, fuzzy
 msgid "Clear Log _Window"
 msgstr "Нови прозор"
 
-#: schematic/src/gschem_macro_widget.c:231
 msgid "Macro:"
 msgstr ""
 
-#: schematic/src/gschem_macro_widget.c:387
 msgid "Evaluate"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:172
 #, fuzzy
 msgid "_Fill Type:"
 msgstr "Да_тотека"
 
-#: schematic/src/gschem_object_properties_widget.c:173
 msgid "Lin_e Width:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:174
 msgid "Angle _1:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:175
 msgid "P_itch 1:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:176
 msgid "Angle _2:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:177
 msgid "Pitc_h 2:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:237
 msgid "<b>Fill Properties</b>"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:255
-#: schematic/src/gschem_text_properties_widget.c:258
-#: schematic/src/x_newtext.c:271
 msgid "Colo_r:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:266
 msgid "<b>General Properties</b>"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:284
 msgid "_Type:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:285
 msgid "_Width:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:286
 msgid "Dash _Length:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:287
 msgid "Dash _Space:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:288
 msgid "C_ap style:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:333
 msgid "<b>Line Properties</b>"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:351
 msgid "_Pin Type:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:362
 msgid "<b>Pin Properties</b>"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:217
 msgid "_Off"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:220
 msgid "_Dots"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:223
 msgid "M_esh"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:245
 msgid "Net R_ubber Band Mode:"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:246
 msgid "_Magnetic Net Mode:"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:250
-#: schematic/src/gschem_options_widget.c:251
 msgid "Enabled"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:265
 msgid "<b>Net Options</b>"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:282
 msgid "Grid Mode:"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:283
 msgid "Snap Mode:"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:284
 msgid "_Snap Size:"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:301
 msgid "<b>Snap Options</b>"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:340
 msgid "O_ff"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:343
 msgid "_Grid"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:346
 msgid "_Resnap"
 msgstr ""
 
-#: schematic/src/gschem_pin_type_combo.c:73
 msgid "Net pin"
 msgstr ""
 
-#: schematic/src/gschem_pin_type_combo.c:80
 msgid "Bus pin (graphical)"
 msgstr ""
 
-#: schematic/src/gschem_preview.c:195
 msgid "Preview Buffer"
 msgstr ""
 
-#: schematic/src/gschem_show_hide_text_widget.c:148
-#: schematic/src/x_window.c:1268
 msgid "Hide"
 msgstr ""
 
-#: schematic/src/gschem_show_hide_text_widget.c:157
-#: schematic/src/x_window.c:1269
 msgid "Hide text starting with:"
 msgstr ""
 
-#: schematic/src/gschem_slot_edit_dialog.c:91
 msgid "Edit slot number"
 msgstr ""
 
-#: schematic/src/gschem_slot_edit_dialog.c:121
 msgid "Number of Slots:"
 msgstr ""
 
-#: schematic/src/gschem_slot_edit_dialog.c:122
 msgid "Slot Number:"
 msgstr ""
 
-#: schematic/src/gschem_text_properties_widget.c:240
-#: schematic/src/x_newtext.c:265
 msgid "<b>Text Content</b>"
 msgstr ""
 
-#: schematic/src/gschem_text_properties_widget.c:259
-#: schematic/src/x_newtext.c:291
 msgid "_Size:"
 msgstr ""
 
-#: schematic/src/gschem_text_properties_widget.c:260
-#: schematic/src/x_newtext.c:310
 msgid "Ali_gnment:"
 msgstr ""
 
-#: schematic/src/gschem_text_properties_widget.c:261
-#: schematic/src/x_newtext.c:330
 msgid "Ro_tation:"
 msgstr ""
 
-#: schematic/src/gschem_text_properties_widget.c:294
-#: schematic/src/x_newtext.c:253
 msgid "<b>Text Properties</b>"
 msgstr ""
 
-#: schematic/src/gschem_translate_widget.c:238
 msgid "Coordinate:"
 msgstr ""
 
-#: schematic/src/gschem_translate_widget.c:405 schematic/src/i_callbacks.c:800
 msgid "Translate"
 msgstr ""
 
-#: schematic/src/i_basic.c:64 schematic/src/x_window.c:1369
-#: schematic/scheme/conf/schematic/menu.scm:59
-#: schematic/scheme/gschem/builtins.scm:99
 msgid "Select Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:65
 msgid "Select Box Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:66
 msgid "Text Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:67
 msgid "Pan Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:70
 #, c-format
 msgid "Paste %d Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:74
 msgid "Magnetic Net Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:76
 msgid "Net Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:77
 msgid "Arc Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:78
 msgid "Box Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:79
 msgid "Bus Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:80
 msgid "Circle Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:81
 msgid "Component Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:82 schematic/scheme/conf/schematic/menu.scm:62
-#: schematic/scheme/gschem/builtins.scm:114
 msgid "Copy Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:83 schematic/scheme/conf/schematic/menu.scm:63
-#: schematic/scheme/gschem/builtins.scm:117
 msgid "Multiple Copy Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:84
 msgid "Line Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:85 schematic/scheme/conf/schematic/menu.scm:66
-#: schematic/scheme/gschem/builtins.scm:123
 msgid "Mirror Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:86 schematic/scheme/conf/schematic/menu.scm:64
-#: schematic/scheme/gschem/builtins.scm:111
 msgid "Move Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:87
 msgid "Path Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:88
 msgid "Picture Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:89
 msgid "Pin Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:90 schematic/scheme/gschem/builtins.scm:120
 msgid "Rotate Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:91
 msgid "Modify Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:92 schematic/src/x_menus.c:49
-#: schematic/scheme/gschem/builtins.scm:204
 msgid "Zoom Box"
 msgstr ""
 
-#: schematic/src/i_basic.c:121
 msgid "Show Hidden"
 msgstr ""
 
-#: schematic/src/i_basic.c:124
 msgid "Snap Off"
 msgstr ""
 
-#: schematic/src/i_basic.c:126
 msgid "Resnap Active"
 msgstr ""
 
-#: schematic/src/i_basic.c:288 schematic/src/x_colorcb.c:159
 msgid "Stroke"
 msgstr ""
 
-#: schematic/src/i_basic.c:296 schematic/src/i_basic.c:330
-#: schematic/src/x_window.c:1361
 msgid "none"
 msgstr ""
 
-#: schematic/src/i_basic.c:304
 msgid "Repeat/"
 msgstr ""
 
-#: schematic/src/i_basic.c:315
 msgid "Repeat/none"
 msgstr ""
 
-#: schematic/src/i_basic.c:323 schematic/src/i_callbacks.c:1239
-#: schematic/scheme/gschem/builtins.scm:189
 msgid "Pan"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:74
 #, c-format
 msgid "New page created [%1$s]"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:108
 #, c-format
 msgid "New Window created [%1$s]"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:245
 msgid "Failed to Save All"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:247
 msgid "Saved All"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:308
 #, fuzzy
 msgid "Closing Window"
 msgstr "Нови прозор"
 
-#: schematic/src/i_callbacks.c:505 schematic/src/x_menus.c:55
-#: schematic/scheme/gschem/builtins.scm:168
 msgid "Copy"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:514 schematic/src/i_callbacks.c:539
-#: schematic/src/i_callbacks.c:564
 msgid "Select objs first"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:530
 msgid "Multiple Copy"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:555 schematic/src/x_menus.c:56
 msgid "Move"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:579 schematic/src/x_menus.c:57
-#: schematic/src/x_multiattrib.c:1656 schematic/scheme/gschem/builtins.scm:108
 msgid "Delete"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:603
 msgid "Edit"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:618 schematic/scheme/gschem/builtins.scm:129
 msgid "Edit Text"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:637
 msgid "Slot"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:688 schematic/src/i_callbacks.c:698
 msgid "Rotate"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:736 schematic/src/i_callbacks.c:746
 msgid "Mirror"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:763 schematic/src/x_colorcb.c:160
-#: schematic/scheme/conf/schematic/menu.scm:73
-#: schematic/scheme/gschem/builtins.scm:141
 msgid "Lock"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:781 schematic/scheme/conf/schematic/menu.scm:74
-#: schematic/scheme/gschem/builtins.scm:144
 msgid "Unlock"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:805
 msgid "WARNING: Do not translate with snap off!"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:806
 msgid "WARNING: Turning snap on and continuing with translate."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:813
 msgid "WARNING: Snap grid size is not equal to 100!"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:815
 msgid ""
 "WARNING: If you are translating a symbol to the origin, the snap grid size "
 "should be set to 100"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:847
 msgid "Embed"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:886
 msgid "Unembed"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:928
 msgid "Update"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:970
 msgid "ShowHidden"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1537
 #, c-format
 msgid ""
 "<b>Revert page:</b>\n"
@@ -900,99 +673,77 @@ msgid ""
 "discarded and page file will be reloaded from disk."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1555
 #, fuzzy
 msgid "Revert"
 msgstr "_Врати"
 
-#: schematic/src/i_callbacks.c:1647
 msgid "Copy to clipboard"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1664
 msgid "Cut to clipboard"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1686
 msgid "Paste from clipboard"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1694
 msgid "Empty clipboard"
 msgstr ""
 
 #. TRANSLATORS: The number is the number of the buffer that the
 #. * selection is being copied to.
-#: schematic/src/i_callbacks.c:1719
 #, c-format
 msgid "Copy %i"
 msgstr ""
 
 #. TRANSLATORS: The number is the number of the buffer that the
 #. * selection is being cut to.
-#: schematic/src/i_callbacks.c:1746
 #, c-format
 msgid "Cut %i"
 msgstr ""
 
 #. TRANSLATORS: The number is the number of the buffer that is being
 #. * pasted to the schematic.
-#: schematic/src/i_callbacks.c:1776
 #, c-format
 msgid "Paste %i"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1785
 msgid "Empty buffer"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1833 schematic/src/x_window.c:1203
 msgid "Component"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1865 schematic/src/x_colorcb.c:150
 msgid "Attribute"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1885 schematic/src/x_colorcb.c:149
 msgid "Net"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1928 schematic/src/x_colorcb.c:155
-#: schematic/src/x_window.c:1222
 msgid "Bus"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2004
 msgid "Line"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2021
 msgid "Path"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2043
 msgid "Box"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2085
 msgid "Circle"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2108
 msgid "Arc"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2131 schematic/src/x_colorcb.c:146
 msgid "Pin"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2191
 #, c-format
 msgid "Searching for source [%1$s]"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2223
 #, c-format
 msgid ""
 "Failed to descend hierarchy into '%1$s': %2$s\n"
@@ -1000,106 +751,81 @@ msgid ""
 "The lepton-schematic log may contain more information."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2227
 #, c-format
 msgid "Failed to descend into '%1$s': %2$s"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2234
 msgid "Failed to descend hierarchy."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2312
 #, c-format
 msgid "Searching for symbol [%1$s]"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2320
 msgid "Symbol is not a real file. Symbol cannot be loaded."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2367 schematic/src/x_tabs.c:1060
 msgid "Cannot find any schematics above the current one!"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2400
 msgid "Attach"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2456
 msgid "Detach"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2500
 msgid "ShowN"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2537
 msgid "ShowV"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2574
 msgid "ShowB"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2612
 msgid "VisToggle"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2643
 #, c-format
 msgid "Sorry but this is a non-functioning menu option\n"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2703
 msgid "Action feedback mode set to OUTLINE"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2706
 msgid "Action feedback mode set to BOUNDINGBOX"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2730
 msgid "Grid OFF"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2731
 msgid "Dot grid selected"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2732
 msgid "Mesh grid selected"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2733
 msgid "Invalid grid mode"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2755
 msgid "Snap OFF (CAUTION!)"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2758
 msgid "Snap ON"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2761
 msgid "Snap back to the grid (CAUTION!)"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2790
 msgid "Rubber band ON"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2792
 msgid "Rubber band OFF"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2811
 msgid "magnetic net mode: ON"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2814
 msgid "magnetic net mode: OFF"
 msgstr ""
 
@@ -1108,133 +834,104 @@ msgstr ""
 #. the form "untitled_N.sch", where N is a number.  Please make
 #. sure that the translation contains characters suitable for use
 #. in a filename.
-#: schematic/src/i_vars.c:209
 msgid "untitled"
 msgstr ""
 
-#: schematic/src/o_complex.c:192 schematic/src/o_complex.c:195
 #, c-format
 msgid "Translating schematic [%1$d %2$d]"
 msgstr ""
 
-#: schematic/src/o_delete.c:82
 #, c-format
 msgid "Delete locked object?"
 msgid_plural "Delete %1$u locked objects?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/o_misc.c:55
 #, c-format
 msgid "Got an unexpected NULL in o_edit\n"
 msgstr ""
 
-#: schematic/src/o_misc.c:315
 msgid "Hidden text is now visible"
 msgstr ""
 
-#: schematic/src/o_misc.c:317
 msgid "Hidden text is now invisible"
 msgstr ""
 
-#: schematic/src/o_misc.c:425
 #, c-format
 msgid "Could not find symbol [%1$s] in library. Update failed."
 msgstr ""
 
-#: schematic/src/o_misc.c:541
 #, c-format
 msgid "o_autosave_backups: Can't get the real filename of %1$s."
 msgstr ""
 
-#: schematic/src/o_misc.c:585
 #, c-format
 msgid "Could NOT set previous backup file [%1$s] read-write"
 msgstr ""
 
-#: schematic/src/o_misc.c:605
 #, c-format
 msgid "Could NOT set backup file [%1$s] readonly"
 msgstr ""
 
-#: schematic/src/o_misc.c:610
 #, c-format
 msgid "Could NOT save backup file [%1$s]"
 msgstr ""
 
-#: schematic/src/o_move.c:192
 #, c-format
 msgid "ERROR: NULL object in o_move_end!\n"
 msgstr ""
 
-#: schematic/src/o_move.c:519
 #, c-format
 msgid "DOH! tried to find the whichone, but didn't find it!\n"
 msgstr ""
 
-#: schematic/src/o_move.c:546
 #, c-format
 msgid "Got a non line object in o_move_check_endpoint\n"
 msgstr ""
 
-#: schematic/src/o_net.c:444
 msgid "Warning: Starting net at off grid coordinate"
 msgstr ""
 
-#: schematic/src/o_net.c:508
 msgid "Warning: Ending net at off grid coordinate"
 msgstr ""
 
-#: schematic/src/o_net.c:856 schematic/src/o_net.c:893
-#: schematic/src/o_net.c:964 schematic/src/o_net.c:1000
 #, c-format
 msgid "Tried to add more than two bus rippers. Internal gschem error.\n"
 msgstr ""
 
-#: schematic/src/o_net.c:1068
 #, c-format
 msgid "Bus ripper symbol [%1$s] was not found in any component library"
 msgstr ""
 
-#: schematic/src/o_picture.c:133 schematic/src/o_picture.c:343
 msgid "Select a picture file..."
 msgstr ""
 
-#: schematic/src/o_picture.c:166
 #, c-format
 msgid "Failed to load picture: %1$s"
 msgstr ""
 
-#: schematic/src/o_picture.c:182
 msgid "Picture"
 msgstr ""
 
-#: schematic/src/o_picture.c:378
 #, c-format
 msgid "Failed to replace pictures: %s"
 msgstr ""
 
-#: schematic/src/o_slot.c:80
 msgid "Slot attribute malformed"
 msgstr ""
 
-#: schematic/src/o_slot.c:88
 msgid "numslots attribute missing"
 msgstr ""
 
-#: schematic/src/o_slot.c:89
 msgid "Slotting not allowed for this component"
 msgstr ""
 
-#: schematic/src/o_slot.c:104
 msgid "New slot number out of range"
 msgstr ""
 
-#: schematic/src/o_undo.c:397
 msgid "Undo/Redo disabled in rc file"
 msgstr ""
 
-#: schematic/src/parsecmd.c:77
 #, c-format
 msgid ""
 "Usage: %1$s [OPTION ...] [--] [FILE ...]\n"
@@ -1259,187 +956,143 @@ msgid ""
 "gEDA/gaf homepage: <http://www.geda-project.org/>\n"
 msgstr ""
 
-#: schematic/src/parsecmd.c:110
 #, c-format
 msgid ""
 "Lepton EDA %1$s (git: %2$.7s)\n"
 "Copyright (C) 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright (C) 2017-2018 Lepton Developers.\n"
+"Copyright (C) 2017-2019 Lepton Developers.\n"
 "This is free software, and you are welcome to redistribute it under\n"
 "certain conditions. For details, see the file `COPYING', which is\n"
 "included in the Lepton EDA distribution.\n"
 "There is NO WARRANTY, to the extent permitted by law.\n"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:125
 #, c-format
 msgid "Got invalid show option; defaulting to show both\n"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:139
 #, c-format
 msgid "ERROR: NULL object!\n"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:328
 msgid "Single Attribute Editor"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:358
 msgid "<b>Edit Attribute</b>"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:360
 msgid "<b>Add Attribute</b>"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:376
 msgid "N_ame:"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:396 schematic/src/x_multiattrib.c:2222
 msgid "_Value:"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:415 schematic/src/x_multiattrib.c:2281
 msgid "Vi_sible"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:434
 msgid "Show Value Only"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:436
 msgid "Show Name Only"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:438 schematic/src/x_multiattrib.c:1620
-#: schematic/scheme/gschem/builtins.scm:324
 msgid "Show Name & Value"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:445
 msgid "<b>Attach Options</b>"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:460
 msgid "All"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:476 schematic/src/x_compselect.c:986
-#: schematic/src/x_compselect.c:1100
 msgid "Components"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:492 schematic/src/x_window.c:1214
 msgid "Nets"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:508
 msgid "Replace existing attributes"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:412
 msgid ""
 "slotted object without slot attribute may cause problems when autonumbering "
 "slots"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:427
 #, c-format
 msgid ""
 "duplicate slot may cause problems: [symbolname=%1$s, number=%2$d, slot=%3$d]"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:675
 msgid "No searchstring given in autonumber text."
 msgstr ""
 
-#: schematic/src/x_autonumber.c:728
 msgid "No '*' or '?' given at the end of the autonumber text."
 msgstr ""
 
-#: schematic/src/x_autonumber.c:873
 msgid "Diagonal"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:874
 msgid "Top to bottom"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:875
 msgid "Bottom to top"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:876
 msgid "Left to right"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:877
 msgid "Right to left"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:878
 msgid "File order"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1214
 msgid "Autonumber text"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1237
 msgid "<b>Scope</b>"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1259
 msgid "Search for:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1273
 msgid "Autonumber text in:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1280
 msgid "Skip numbers found in:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1292 schematic/src/x_autonumber.c:1301
 msgid "Selected objects"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1293 schematic/src/x_autonumber.c:1302
 msgid "Current page"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1294 schematic/src/x_autonumber.c:1303
 msgid "Whole hierarchy"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1305
 msgid "Overwrite existing numbers"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1310
 msgid "<b>Options</b>"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1332
 msgid "Starting number:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1339
 msgid "Sort order:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1371
 msgid "Remove numbers"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1375
 msgid "Automatic slotting"
 msgstr ""
 
-#: schematic/src/x_clipboard.c:245
 #, c-format
 msgid ""
 "<b>Invalid schematic on clipboard.</b>\n"
@@ -1447,170 +1100,130 @@ msgid ""
 "An error occurred while inserting clipboard data: %s."
 msgstr ""
 
-#: schematic/src/x_clipboard.c:247
 msgid "Clipboard insertion failed"
 msgstr ""
 
-#: schematic/src/x_color.c:89 schematic/src/x_color.c:98
 #, c-format
 msgid "Could not allocate the color %1$s!\n"
 msgstr ""
 
-#: schematic/src/x_color.c:89
 msgid "black"
 msgstr ""
 
-#: schematic/src/x_color.c:98
 msgid "white"
 msgstr ""
 
-#: schematic/src/x_color.c:120
 #, c-format
 msgid "Could not allocate display color %1$i!\n"
 msgstr ""
 
-#: schematic/src/x_color.c:142
 #, c-format
 msgid "Could not allocate outline color %1$i!\n"
 msgstr ""
 
-#: schematic/src/x_color.c:159
 #, c-format
 msgid "Tried to get an invalid color: %1$d\n"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:145
 msgid "Background"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:147
 msgid "Net endpoint"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:148
 msgid "Graphic"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:151
 msgid "Logic bubble"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:152
 msgid "Grid point"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:153
 msgid "Detached attribute"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:156
 msgid "Selection"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:157
 msgid "Bounding box"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:158
 msgid "Zoom box"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:161
 msgid "Output background"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:162
 msgid "Freestyle 1"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:163
 msgid "Freestyle 2"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:164
 msgid "Freestyle 3"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:165
 msgid "Freestyle 4"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:166
 msgid "Net junction"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:167
 msgid "Mesh grid major"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:168
 msgid "Mesh grid minor"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:172
 msgid "Unknown"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1169
 msgid "Reset filter"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1192
 msgid "Reload all libraries"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1245 schematic/src/x_multiattrib.c:2092
 msgid "Value"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1284
 msgid "Default behavior - reference component"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1287
 msgid "Embed component in schematic"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1290
 msgid "Include component as individual objects"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1448
 msgid "Select Component..."
 msgstr ""
 
-#: schematic/src/x_compselect.c:1471
 msgid "In Us_e"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1475
 msgid "Lib_raries"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1484 schematic/src/x_fileselect.c:119
 msgid "Preview"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1510
 msgid "Attributes"
 msgstr ""
 
-#: schematic/src/x_dialog.c:325
 msgid "Major symbol changes detected."
 msgstr ""
 
-#: schematic/src/x_dialog.c:349
 msgid ""
 "Changes have occurred to the symbols shown below.\n"
 "\n"
 "Be sure to verify each of these symbols."
 msgstr ""
 
-#: schematic/src/x_dialog.c:369
 msgid "Symbol"
 msgstr ""
 
-#: schematic/src/x_dialog.c:406
 #, c-format
 msgid ""
 "<span weight=\"bold\" size=\"larger\">The input attribute \"%s\" is invalid\n"
@@ -1621,39 +1234,30 @@ msgid ""
 "The value cannot start with a space."
 msgstr ""
 
-#: schematic/src/x_dialog.c:408
 msgid "Invalid Attribute"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:37
 msgid "Schematics"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:42
 msgid "Symbols"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:47
 msgid "Schematics and symbols"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:53
 msgid "All files"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:169
 msgid "Open..."
 msgstr ""
 
-#: schematic/src/x_fileselect.c:233
 msgid "Save as..."
 msgstr ""
 
-#: schematic/src/x_fileselect.c:297
 msgid "Save cancelled on user request"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:334
 msgid ""
 "\n"
 "If you load the original file, the backup file will be overwritten in the "
@@ -1662,28 +1266,22 @@ msgid ""
 "Do you want to load the backup file?\n"
 msgstr ""
 
-#: schematic/src/x_fstylecb.c:73
 msgid "Hollow"
 msgstr ""
 
-#: schematic/src/x_fstylecb.c:80
 msgid "Filled"
 msgstr ""
 
-#: schematic/src/x_fstylecb.c:87
 msgid "Mesh"
 msgstr ""
 
-#: schematic/src/x_fstylecb.c:94
 msgid "Hatch"
 msgstr ""
 
-#: schematic/src/x_image.c:279
 #, c-format
 msgid "x_image_lowlevel: Unable to write %1$s file %2$s."
 msgstr ""
 
-#: schematic/src/x_image.c:289
 #, c-format
 msgid ""
 "There was the following error when saving image with type %1$s to filename:\n"
@@ -1692,293 +1290,226 @@ msgid ""
 "%3$s.\n"
 msgstr ""
 
-#: schematic/src/x_image.c:309
 #, c-format
 msgid "Wrote color image to [%1$s] [%2$d x %3$d]"
 msgstr ""
 
-#: schematic/src/x_image.c:311
 #, c-format
 msgid "Wrote black and white image to [%1$s] [%2$d x %3$d]"
 msgstr ""
 
-#: schematic/src/x_image.c:319
 msgid "x_image_lowlevel: Unable to get pixbuf from gschem's window."
 msgstr ""
 
-#: schematic/src/x_image.c:358
 msgid "Width x Height"
 msgstr ""
 
-#: schematic/src/x_image.c:374
 msgid "Image type"
 msgstr ""
 
-#: schematic/src/x_image.c:395
 msgid "Write image..."
 msgstr ""
 
-#: schematic/src/x_linecapcb.c:74
 msgid "Butt"
 msgstr ""
 
-#: schematic/src/x_linecapcb.c:81
 msgid "Square"
 msgstr ""
 
-#: schematic/src/x_linecapcb.c:88
 msgid "Round"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:74
 msgid "Solid"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:81
 msgid "Dotted"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:88
 msgid "Dashed"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:95
 msgid "Center"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:102
 msgid "Phantom"
 msgstr ""
 
-#: schematic/src/x_menus.c:41 schematic/scheme/gschem/builtins.scm:267
 msgid "Add Net"
 msgstr ""
 
-#: schematic/src/x_menus.c:42 schematic/src/x_multiattrib.c:2187
-#: schematic/scheme/gschem/builtins.scm:264
 msgid "Add Attribute"
 msgstr ""
 
-#: schematic/src/x_menus.c:43 schematic/scheme/gschem/builtins.scm:261
 msgid "Add Component"
 msgstr ""
 
-#: schematic/src/x_menus.c:44 schematic/scheme/gschem/builtins.scm:270
 msgid "Add Bus"
 msgstr ""
 
-#: schematic/src/x_menus.c:45 schematic/scheme/gschem/builtins.scm:273
 msgid "Add Text"
 msgstr ""
 
-#: schematic/src/x_menus.c:47 schematic/scheme/gschem/builtins.scm:210
 msgid "Zoom In"
 msgstr ""
 
-#: schematic/src/x_menus.c:48 schematic/scheme/gschem/builtins.scm:213
 msgid "Zoom Out"
 msgstr ""
 
-#: schematic/src/x_menus.c:50 schematic/scheme/gschem/builtins.scm:207
 msgid "Zoom Extents"
 msgstr ""
 
-#: schematic/src/x_menus.c:52 schematic/src/x_window.c:1233
 msgid "Select"
 msgstr ""
 
-#: schematic/src/x_menus.c:53 schematic/scheme/conf/schematic/menu.scm:69
-#: schematic/scheme/gschem/builtins.scm:126
 msgid "Edit..."
 msgstr ""
 
-#: schematic/src/x_menus.c:54 schematic/scheme/conf/schematic/menu.scm:68
 msgid "Object Properties..."
 msgstr ""
 
-#: schematic/src/x_menus.c:59 schematic/scheme/gschem/builtins.scm:300
 msgid "Down Schematic"
 msgstr ""
 
-#: schematic/src/x_menus.c:60 schematic/scheme/gschem/builtins.scm:303
 msgid "Down Symbol"
 msgstr ""
 
-#: schematic/src/x_menus.c:61
 msgid "Up"
 msgstr ""
 
-#: schematic/src/x_menus.c:336
 #, c-format
 msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
 msgstr ""
 
-#: schematic/src/x_menus.c:360
 #, c-format
 msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
 msgstr ""
 
-#: schematic/src/x_misc.c:70
 msgid "The operating system is out of memory or resources."
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:798 schematic/src/x_multiattrib.c:2704
 msgid "<various>"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:930
 msgid "Attributes with empty name are not allowed. Please set a name."
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1622
 msgid "Show Value only"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1624
 msgid "Show Name only"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1651
 msgid "Promote"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1655
 msgid "Duplicate"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1657
 msgid "Copy to all"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1986 schematic/src/x_multiattrib.c:2602
 msgid "Edit Attributes"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2112
 msgid "Vis?"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2130
 msgid "N"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2148
 msgid "V"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2170
 msgid "Sho_w inherited attributes"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2197
 msgid "_Name:"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2241
 msgid "Ctrl+Enter inserts new line; Ctrl+Tab inserts Tab"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2618
 #, c-format
 msgid "%2$i symbol (%1$s)"
 msgid_plural "%2$i symbols (%1$s)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2624
 #, c-format
 msgid "%1$i pin"
 msgid_plural "%1$i pins"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2630
 #, c-format
 msgid "%1$i net"
 msgid_plural "%1$i nets"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2636
 #, c-format
 msgid "%1$i bus"
 msgid_plural "%1$i buses"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2642
 #, c-format
 msgid "%1$i attribute"
 msgid_plural "%1$i attributes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_newtext.c:433
 msgid "Text Entry..."
 msgstr ""
 
-#: schematic/src/x_pagesel.c:253
 msgid "New Page"
 msgstr ""
 
-#: schematic/src/x_pagesel.c:254
 msgid "Open Page..."
 msgstr ""
 
-#: schematic/src/x_pagesel.c:256
 msgid "Save Page"
 msgstr ""
 
-#: schematic/src/x_pagesel.c:257 schematic/scheme/gschem/builtins.scm:246
 msgid "Close Page"
 msgstr ""
 
-#: schematic/src/x_pagesel.c:376 schematic/scheme/gschem/builtins.scm:237
 msgid "Page Manager"
 msgstr ""
 
-#: schematic/src/x_pagesel.c:448
 msgid "Changed"
 msgstr ""
 
-#: schematic/src/x_pagesel.c:468
 msgid "Right click on the filename for more options..."
 msgstr ""
 
-#: schematic/src/x_print.c:306
 #, c-format
 msgid "Failed to write PDF to '%s': %s\n"
 msgstr ""
 
-#: schematic/src/x_print.c:364
 #, c-format
 msgid "Failed to write PDF to '%1$s': %2$s\n"
 msgstr ""
 
-#: schematic/src/x_print.c:449
 #, c-format
 msgid ""
 "Error printing file:\n"
 "%1$s"
 msgstr ""
 
-#: schematic/src/x_rc.c:39
 msgid "ERROR: An unknown error occurred while parsing configuration files."
 msgstr ""
 
-#: schematic/src/x_rc.c:44
 msgid ""
 "An unknown error occurred while parsing configuration files.\n"
 "\n"
 "The lepton-schematic log may contain more information."
 msgstr ""
 
-#: schematic/src/x_rc.c:56
 #, c-format
 msgid "ERROR: %1$s"
 msgstr ""
 
-#: schematic/src/x_rc.c:59
 #, c-format
 msgid ""
 "%1$s\n"
@@ -1986,135 +1517,104 @@ msgid ""
 "The lepton-schematic log may contain more information."
 msgstr ""
 
-#: schematic/src/x_rc.c:67
 msgid "Cannot load lepton-schematic configuration."
 msgstr ""
 
-#: schematic/src/x_script.c:42 schematic/scheme/conf/schematic/menu.scm:40
 msgid "Execute Script..."
 msgstr ""
 
-#: schematic/src/x_script.c:61
 #, c-format
 msgid "Executing guile script [%1$s]"
 msgstr ""
 
-#: schematic/src/x_tabs.c:860
 #, c-format
 msgid "Hierarchy up: %s"
 msgstr ""
 
-#: schematic/src/x_tabs.c:863
 msgid "Hierarchy up"
 msgstr ""
 
-#: schematic/src/x_widgets.c:158 schematic/src/x_window.c:1444
 msgid "Options"
 msgstr ""
 
-#: schematic/src/x_widgets.c:203 schematic/src/x_window.c:1436
 msgid "Object"
 msgstr ""
 
-#: schematic/src/x_widgets.c:224
 msgid "Log"
 msgstr ""
 
-#: schematic/src/x_widgets.c:245 schematic/src/x_window.c:1466
 msgid "Find Text"
 msgstr ""
 
-#: schematic/src/x_widgets.c:259
 msgid "Color Scheme Editor"
 msgstr ""
 
-#: schematic/src/x_widgets.c:272 schematic/scheme/gschem/builtins.scm:378
 msgid "Select Schematic Font"
 msgstr ""
 
-#: schematic/src/x_window.c:763
 #, c-format
 msgid "Loading schematic [%1$s]"
 msgstr ""
 
-#: schematic/src/x_window.c:864
 #, c-format
 msgid "Could NOT save page [%1$s]\n"
 msgstr ""
 
-#: schematic/src/x_window.c:865
 msgid "Error while trying to save"
 msgstr ""
 
-#: schematic/src/x_window.c:875
 msgid "Failed to save file"
 msgstr ""
 
-#: schematic/src/x_window.c:885
 #, fuzzy, c-format
 msgid "Saved as [%1$s]"
 msgstr "Сачувај све"
 
-#: schematic/src/x_window.c:887
 #, fuzzy, c-format
 msgid "Saved [%1$s]"
 msgstr "Сачувај све"
 
-#: schematic/src/x_window.c:889
 msgid "Saved"
 msgstr ""
 
-#: schematic/src/x_window.c:966
 #, c-format
 msgid "Discarding page [%1$s]"
 msgstr ""
 
-#: schematic/src/x_window.c:966
 #, c-format
 msgid "Closing [%1$s]"
 msgstr ""
 
-#: schematic/src/x_window.c:1175
 msgid "New"
 msgstr ""
 
-#: schematic/src/x_window.c:1175
 msgid "New file"
 msgstr ""
 
-#: schematic/src/x_window.c:1179
 msgid "Open"
 msgstr ""
 
-#: schematic/src/x_window.c:1179
 msgid "Open file"
 msgstr ""
 
-#: schematic/src/x_window.c:1183 schematic/scheme/gschem/builtins.scm:59
 msgid "Save"
 msgstr ""
 
-#: schematic/src/x_window.c:1183
 msgid "Save file"
 msgstr ""
 
-#: schematic/src/x_window.c:1189 schematic/scheme/gschem/builtins.scm:93
 msgid "Undo"
 msgstr ""
 
-#: schematic/src/x_window.c:1189
 msgid "Undo last operation"
 msgstr ""
 
-#: schematic/src/x_window.c:1193 schematic/scheme/gschem/builtins.scm:96
 msgid "Redo"
 msgstr ""
 
-#: schematic/src/x_window.c:1193
 msgid "Redo last undo"
 msgstr ""
 
-#: schematic/src/x_window.c:1198
 msgid ""
 "Add component...\n"
 "Select library and component from list, move the mouse into main window, "
@@ -2122,56 +1622,44 @@ msgid ""
 "Right mouse button to cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1209
 msgid ""
 "Add nets mode\n"
 "Right mouse button to cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1217
 msgid ""
 "Add buses mode\n"
 "Right mouse button to cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1226
 msgid "Add Text..."
 msgstr ""
 
-#: schematic/src/x_window.c:1233
 msgid "Select mode"
 msgstr ""
 
-#: schematic/src/x_window.c:1288
 msgid "Show"
 msgstr ""
 
-#: schematic/src/x_window.c:1289
 msgid "Show text starting with:"
 msgstr ""
 
-#: schematic/src/x_window.c:1345
 msgid "Menu/Cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1349
 msgid "Pan/Cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1359
 msgid "Pick"
 msgstr ""
 
-#: schematic/src/x_window.c:1470 schematic/scheme/gschem/builtins.scm:180
 msgid "Status"
 msgstr ""
 
-#: schematic/src/x_window.c:1568
 #, fuzzy, c-format
 msgid "New file [%s]"
 msgstr "Да_тотека"
 
-#: schematic/src/x_window.c:1598
 #, c-format
 msgid ""
 "<b>An error occurred while loading the requested file.</b>\n"
@@ -2185,831 +1673,621 @@ msgid ""
 "monitor program's output in terminal window."
 msgstr ""
 
-#: schematic/src/x_window.c:1617
 msgid "Failed to load file"
 msgstr ""
 
-#: schematic/data/lepton-schematic.desktop.in:3
 msgid "Lepton EDA Schematic Editor"
 msgstr ""
 
-#: schematic/data/lepton-schematic.desktop.in:4
 msgid "Create and edit electrical schematics and symbols with lepton-schematic"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:27
 msgid "_New"
 msgstr "Но_во"
 
-#: schematic/scheme/conf/schematic/menu.scm:28
 msgid "_Open..."
 msgstr "Отв_ори..."
 
-#: schematic/scheme/conf/schematic/menu.scm:30
 msgid "Open Recen_t"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:32
 msgid "_Save"
 msgstr "Сачу_вај"
 
-#: schematic/scheme/conf/schematic/menu.scm:33
 msgid "Save _As..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:34
-#: schematic/scheme/gschem/builtins.scm:65
 msgid "Save All"
 msgstr "Сачувај све"
 
-#: schematic/scheme/conf/schematic/menu.scm:36
 msgid "_Print..."
 msgstr "_Штампај..."
 
-#: schematic/scheme/conf/schematic/menu.scm:37
 msgid "Write _Image..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:39
 msgid "Invoke Macro..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:41
 msgid "REPL..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:43
-#: schematic/scheme/gschem/builtins.scm:77
 msgid "New Window"
 msgstr "Нови прозор"
 
-#: schematic/scheme/conf/schematic/menu.scm:44
 msgid "_Close Window"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:45
 msgid "_Quit"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:51
 msgid "_Undo"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:52
 msgid "_Redo"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:54
 msgid "Cu_t"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:55
 msgid "_Copy"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:56
 msgid "_Paste"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:57
 msgid "_Delete"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:60
-#: schematic/scheme/gschem/builtins.scm:102
 msgid "Select All"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:61
-#: schematic/scheme/gschem/builtins.scm:105
 msgid "Deselect"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:65
 msgid "Rotate 90 Mode"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:70
 msgid "Edit Text..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:71
 msgid "Slot..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:76
-#: schematic/scheme/gschem/builtins.scm:150
 msgid "Embed Component/Picture"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:77
-#: schematic/scheme/gschem/builtins.scm:153
 msgid "Unembed Component/Picture"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:78
-#: schematic/scheme/gschem/builtins.scm:156
 msgid "Update Component"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:79
 msgid "Symbol Translate..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:85
 msgid "Copy into 1"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:86
 msgid "Copy into 2"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:87
 msgid "Copy into 3"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:88
 msgid "Copy into 4"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:89
 msgid "Copy into 5"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:90
 msgid "Cut into 1"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:91
 msgid "Cut into 2"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:92
 msgid "Cut into 3"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:93
 msgid "Cut into 4"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:94
 msgid "Cut into 5"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:95
 msgid "Paste from 1"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:96
 msgid "Paste from 2"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:97
 msgid "Paste from 3"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:98
 msgid "Paste from 4"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:99
 msgid "Paste from 5"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:105
 msgid "Side Dock"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:106
 msgid "Bottom Dock"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:108
 msgid "Find Text Results"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:110
 msgid "_Redraw"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:111
 msgid "_Pan"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:112
 msgid "Zoom _Box"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:113
 msgid "Zoom _Extents"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:114
 msgid "Zoom _In"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:115
 msgid "Zoom _Out"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:116
 msgid "Zoom _Full"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:118
 msgid "_Dark Color Scheme"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:119
 msgid "_Light Color Scheme"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:120
 msgid "B_W Color Scheme"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:122
 msgid "Color Scheme Editor..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:129
 msgid "_Manager..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:131
 msgid "_Previous"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:132
 msgid "_Next"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:133
 msgid "_Close"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:135
 #, fuzzy
 msgid "_Revert..."
 msgstr "_Врати"
 
-#: schematic/scheme/conf/schematic/menu.scm:137
-#: schematic/scheme/gschem/builtins.scm:249
 msgid "Next Tab"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:138
-#: schematic/scheme/gschem/builtins.scm:252
 msgid "Previous Tab"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:146
 msgid "_Component..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:148
 msgid "_Net"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:149
 msgid "B_us"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:151
 msgid "_Attribute..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:152
 msgid "_Text..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:154
 msgid "_Line"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:155
 msgid "Pat_h"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:156
 msgid "_Box"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:157
 msgid "C_ircle"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:158
 msgid "A_rc"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:159
 msgid "_Pin"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:161
 msgid "Pictu_re..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:167
 msgid "_Up"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:169
 msgid "_Down Schematic"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:170
 msgid "Down _Symbol"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:176
 msgid "_Attach"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:177
 msgid "_Detach"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:179
 msgid "Show _Value"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:180
 msgid "Show _Name"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:181
 msgid "Show _Both"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:182
 msgid "_Toggle Visibility"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:184
 msgid "_Hide Specific Text..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:185
 msgid "_Show Specific Text..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:186
 msgid "Show/Hide Hidden Text"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:188
 msgid "_Find Text/Check Symbol..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:189
 msgid "A_utonumber Text..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:195
 msgid "_Options..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:196
 #, fuzzy
 msgid "_Font..."
 msgstr "_Штампај..."
 
-#: schematic/scheme/conf/schematic/menu.scm:198
 msgid "Grid +"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:199
 msgid "Grid -"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:201
 msgid "Grid Style: Cycle Dots/Mesh/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:202
 msgid "Grid Snap: Cycle Grid/Resnap/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:204
 msgid "Feedback Mode: Outline/Box"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:205
 msgid "Net: Rubberband On/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:206
 msgid "Net: Magnetic On/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:208
 #, fuzzy
 msgid "_Coord Window"
 msgstr "Нови прозор"
 
-#: schematic/scheme/conf/schematic/menu.scm:209
 #, fuzzy
 msgid "_Log Window"
 msgstr "Нови прозор"
 
-#: schematic/scheme/conf/schematic/menu.scm:215
 msgid "_1 allegro"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:223
 msgid "User _Guide"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:224
 msgid "_FAQ"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:225
 msgid "Docu_mentation"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:226
 msgid "_Wiki"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:228
 msgid "Find Component D_ocumentation"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:230
 msgid "_Hotkeys..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:231
 msgid "_About"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:237
 msgid "_File"
 msgstr "Да_тотека"
 
-#: schematic/scheme/conf/schematic/menu.scm:238
 msgid "_Edit"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:240
 msgid "_View"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:241
 msgid "_Page"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:242
 msgid "_Add"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:243
 msgid "Hie_rarchy"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:244
 msgid "A_ttributes"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:245
 msgid "_Options"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:246
 msgid "_Netlist"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:247
 msgid "_Help"
 msgstr ""
 
-#: schematic/scheme/gschem/action.scm:43
 #, scheme-format
 msgid "~S is not a valid gschem action."
 msgstr ""
 
-#: schematic/scheme/gschem/action.scm:158
 msgid "Repeat Last Action"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:47
 msgid "Cancel"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:53
 #, fuzzy
 msgid "New File"
 msgstr "Да_тотека"
 
-#: schematic/scheme/gschem/builtins.scm:56
 msgid "Open File"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:62
 #, fuzzy
 msgid "Save As"
 msgstr "Сачувај све"
 
-#: schematic/scheme/gschem/builtins.scm:68
 #, fuzzy
 msgid "Print"
 msgstr "_Штампај..."
 
-#: schematic/scheme/gschem/builtins.scm:71
 msgid "Export Image"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:74
 msgid "Run Script"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:80
 #, fuzzy
 msgid "Close Window"
 msgstr "Нови прозор"
 
-#: schematic/scheme/gschem/builtins.scm:83
 msgid "Quit"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:87
 msgid "Terminal REPL"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:132
 msgid "Choose Slot"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:135
 msgid "Edit Object Properties"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:138
 msgid "Translate Symbol"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:147
 msgid "Invoke Macro"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:159
 msgid "Show/Hide Invisible Text"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:165
 msgid "Cut"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:171
 msgid "Paste"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:177
 msgid "Sidebar"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:183
 msgid "Find Text State"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:186
 msgid "Redraw"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:192
 msgid "Pan Left"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:195
 msgid "Pan Right"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:198
 msgid "Pan Up"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:201
 msgid "Pan Down"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:216
 msgid "Zoom Full"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:219
 msgid "Dark Color Scheme"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:222
 msgid "Light Color Scheme"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:225
 msgid "Monochrome Color Scheme"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:228
 msgid "Show Color Scheme Editor"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:234
 msgid "Revert Changes"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:240
 msgid "Previous Page"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:243
 msgid "Next Page"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:255
 #, fuzzy
 msgid "Print Page"
 msgstr "_Штампај..."
 
-#: schematic/scheme/gschem/builtins.scm:276
 msgid "Add Line"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:279
 msgid "Add Path"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:282
 msgid "Add Box"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:285
 msgid "Add Circle"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:288
 msgid "Add Arc"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:291
 msgid "Add Pin"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:294
 msgid "Add Picture"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:306
 msgid "Up Hierarchy"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:312
 msgid "Attach Attributes"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:315
 msgid "Detach Attributes"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:318
 msgid "Show Attribute Value"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:321
 msgid "Show Attribute Name"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:327
 msgid "Toggle Text Visibility"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:330
 msgid "Find Specific Text"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:333
 msgid "Hide Specific Text"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:336
 msgid "Show Specific Text"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:339
 msgid "Autonumber Text"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:345
 msgid "Show Hotkeys"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:348
 msgid "Switch Grid Style"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:351
 msgid "Switch Snap Mode"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:354
 msgid "Set Grid Spacing"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:357
 msgid "Increase Grid Spacing"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:360
 msgid "Decrease Grid Spacing"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:363
 msgid "Toggle Outline Drawing"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:366
 msgid "Toggle Net Rubber Band"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:369
 msgid "Toggle Magnetic Nets"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:372
 #, fuzzy
 msgid "Show Log Window"
 msgstr "Нови прозор"
 
-#: schematic/scheme/gschem/builtins.scm:375
 msgid "Show Coordinate Window"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:385
 msgid "Component Documentation"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:387
 msgid "View documentation for selected component"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:403
 msgid ""
 "Could not show documentation for selected component:\n"
 "\n"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:408
 msgid "gEDA Manuals"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:409
 msgid "View the front page of the gEDA documentation in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:414
 msgid "gschem User Guide"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:415
 msgid "View the gschem User Guide in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:420
 msgid "gschem FAQ"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:421
 msgid "Frequently Asked Questions about using gschem."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:426
 msgid "gEDA wiki"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:427
 msgid "View the front page of the gEDA wiki in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:431
 msgid "About gschem"
 msgstr ""
 
-#: schematic/scheme/gschem/deprecated.scm:102
 #, scheme-format
 msgid "Invalid text alignment ~A."
 msgstr ""
 
-#: schematic/scheme/gschem/gschemdoc.scm:241
 msgid "No documentation found"
 msgstr ""
 
-#: schematic/scheme/gschem/keymap.scm:40
 #, scheme-format
 msgid "~S is not a valid key combination."
 msgstr ""
 
-#: schematic/scheme/gschem/keymap.scm:157
 #, scheme-format
 msgid "~S is not a prefix key sequence."
 msgstr ""

--- a/schematic/po/tr.po
+++ b/schematic/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-15 15:13+0300\n"
+"POT-Creation-Date: 2019-02-22 14:08+0300\n"
 "PO-Revision-Date: 2012-01-27 14:22+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -18,22 +18,18 @@ msgstr ""
 "X-Launchpad-Export-Date: 2012-11-14 16:52+0000\n"
 "X-Generator: Launchpad (build 16265)\n"
 
-#: schematic/src/a_zoom.c:155
 msgid "Zoom too small!  Cannot zoom further."
 msgstr ""
 
-#: schematic/src/color_edit_widget.c:399
 #, c-format
 msgid ""
 "Could not save file [%s]:\n"
 "%s"
 msgstr ""
 
-#: schematic/src/color_edit_widget.c:434
 msgid "Save Color Scheme As..."
 msgstr ""
 
-#: schematic/src/color_edit_widget.c:482 schematic/src/x_fileselect.c:292
 #, c-format
 msgid ""
 "The selected file `%1$s' already exists.\n"
@@ -41,178 +37,140 @@ msgid ""
 "Would you like to overwrite it?"
 msgstr ""
 
-#: schematic/src/color_edit_widget.c:486 schematic/src/x_fileselect.c:295
 msgid "Overwrite file?"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:211
 msgid "_Apply"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:215
 msgid "Sa_ve..."
 msgstr ""
 
-#: schematic/src/font_select_widget.c:278
 #, c-format
 msgid "<b>Current:</b> %s"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:453
 msgid "Save configuration"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:461
 msgid "Save settings to:"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:465
 msgid "Local configuration file (in current directory)"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:467
 msgid "User configuration file (geda-user.conf)"
 msgstr ""
 
-#: schematic/src/g_attrib.c:90
 msgid "Object ~A is not included in the current gschem page."
 msgstr ""
 
-#: schematic/src/g_attrib.c:110
 msgid "Invalid text name/value visibility ~A."
 msgstr ""
 
-#: schematic/src/g_rc.c:107
 #, c-format
 msgid "You are running gEDA/gaf version [%1$s%2$s.%3$s],\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:111
 #, c-format
 msgid ""
 "but you have a version [%1$s] gschemrc file:\n"
 "[%2$s]\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:114
 #, c-format
 msgid "Please be sure that you have the latest rc file.\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:240
 #, c-format
 msgid "Invalid size [%1$d] passed to text-size\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:283
 #, c-format
 msgid "Invalid size [%1$d] passed to snap-size\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:620
 #, c-format
 msgid "Invalid num levels [%1$d] passed to undo-levels\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:831
 #, c-format
 msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:931
 #, c-format
 msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:972
 #, c-format
 msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:998
 #, c-format
 msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1023
 #, c-format
 msgid "Invalid offset [%1$d] passed to add-attribute-offset\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1047
 #, c-format
 msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1071
 #, c-format
 msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1094
 #, c-format
 msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1118
 #, c-format
 msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1144
 #, c-format
 msgid "Invalid gain [%1$d] passed to zoom-gain\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1169
 #, c-format
 msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
 msgstr ""
 
-#: schematic/src/g_select.c:78 schematic/src/g_select.c:115
-#: schematic/src/g_select.c:151
 msgid "Object ~A is not directly included in a page."
 msgstr ""
 
-#: schematic/src/g_util.c:54
 msgid "Could not launch URI ~S: ~A"
 msgstr ""
 
-#: schematic/src/g_window.c:139
 msgid "Found invalid gschem window smob ~S"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:156
 #, c-format
 msgid "Lepton EDA/lepton-schematic version %1$s%2$s.%3$s git: %4$.7s"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:163
 #, c-format
 msgid "This is the MINGW32 port.\n"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:167
 #, fuzzy, c-format
 msgid "Current locale settings: %1$s\n"
 msgstr "Şu andaki yerel ayarlar: %s\n"
 
-#: schematic/src/lepton-schematic.c:201
 #, c-format
 msgid "Couldn't find init scm file [%1$s]"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:206
 #, c-format
 msgid "Read init scm file [%1$s]"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:210
 #, c-format
 msgid "Failed to read init scm file [%1$s]"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:290
 #, c-format
 msgid ""
 "ERROR: Failed to load or evaluate startup script.\n"
@@ -220,688 +178,503 @@ msgid ""
 "The lepton-schematic log may contain more information.\n"
 msgstr ""
 
-#: schematic/src/gschem_about_dialog.c:51
 #, c-format
 msgid "%s (git: %.7s)"
 msgstr ""
 
-#: schematic/src/gschem_about_dialog.c:75
 msgid "Lepton Electronic Design Automation"
 msgstr ""
 
-#: schematic/src/gschem_about_dialog.c:83
 msgid ""
 "Copyright © 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright © 2017-2018 Lepton Developers.\n"
-"See AUTHORS and ChangeLog files for details."
+"Copyright © 2017-2019 Lepton Developers.\n"
+"See AUTHORS, ChangeLog files and consult 'git log' history for details."
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:69
 msgid "Upper Left"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:71
 msgid "Upper Middle"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:73
 msgid "Upper Right"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:78
 msgid "Middle Left"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:80
 msgid "Middle Middle"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:82
 msgid "Middle Right"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:87
 msgid "Lower Left"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:89
 msgid "Lower Middle"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:91
 msgid "Lower Right"
 msgstr ""
 
-#: schematic/src/gschem_arc_dialog.c:104
 msgid "Arc Params"
 msgstr ""
 
-#: schematic/src/gschem_arc_dialog.c:140
 msgid "Arc _Radius:"
 msgstr ""
 
-#: schematic/src/gschem_arc_dialog.c:141
 msgid "Start _Angle:"
 msgstr ""
 
-#: schematic/src/gschem_arc_dialog.c:142
 msgid "_Degrees of Sweep:"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:504
 msgid "Left mouse button"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:508
 msgid "Middle mouse button"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:512
 msgid "Right mouse button"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:595
 msgid "(Snap size, Grid size)"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:603
 msgid "Net rubber band mode"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:614
 msgid "Magnetic net mode"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:622
 msgid "Current action mode"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:935
-#: schematic/src/gschem_bottom_widget.c:951
 msgid "OFF"
 msgstr "KAPALI"
 
-#: schematic/src/gschem_bottom_widget.c:954
 msgid "NONE"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:960
 #, c-format
 msgid "Grid(%1$s, %2$s)"
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:350
-#: schematic/src/x_compselect.c:1236 schematic/src/x_multiattrib.c:2068
 msgid "Name"
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:372
 msgid "S_elect the schematics you want to save:"
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:467
 #, c-format
 msgid "Save the changes to schematic \"%1$s\" before closing?"
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:473
 #, c-format
 msgid ""
 "There are %1$d schematics with unsaved changes. Save changes before closing?"
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:502
 msgid "If you don't save, all your changes will be permanently lost."
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:522
 msgid "Close _without saving"
 msgstr ""
 
-#: schematic/src/gschem_coord_dialog.c:86
 msgid "Coords"
 msgstr ""
 
-#: schematic/src/gschem_coord_dialog.c:106
 msgid "Screen"
 msgstr ""
 
-#: schematic/src/gschem_coord_dialog.c:115
 msgid "World"
 msgstr ""
 
-#: schematic/src/gschem_find_text_state.c:809 schematic/src/x_pagesel.c:432
 msgid "Filename"
 msgstr ""
 
-#: schematic/src/gschem_find_text_state.c:821 schematic/src/i_callbacks.c:1970
-#: schematic/src/x_colorcb.c:154 schematic/src/x_widgets.c:179
-#: schematic/src/x_window.c:1226 schematic/src/x_window.c:1440
 msgid "Text"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:427
 msgid "descend into hierarchy"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:435
 msgid "Find"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:557
 #, fuzzy
 msgid "Find Text:"
 msgstr "Metni Düzenle"
 
-#: schematic/src/gschem_find_text_widget.c:564
 msgid "Find Pattern:"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:571
 msgid "Find Regex:"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:578
 msgid "Check symbol:"
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:200
 msgid "Hotkeys"
 msgstr "Kısayollar"
 
-#: schematic/src/gschem_hotkey_dialog.c:229
 msgid ""
 "Start typing action name or keystroke to filter the list.\n"
 "Type hotkeys as they are displayed in \"Keystroke(s)\" column."
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:233 schematic/src/x_compselect.c:1124
 #, fuzzy
 msgid "_Filter:"
 msgstr "Dosya"
 
-#: schematic/src/gschem_hotkey_dialog.c:259 schematic/src/i_basic.c:280
 msgid "Action"
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:277
 msgid "Keystroke(s)"
 msgstr ""
 
-#: schematic/src/gschem_log_widget.c:177
 msgid "** Invalid UTF-8 in log message. See stderr or gschem.log.\n"
 msgstr ""
 
-#: schematic/src/gschem_log_widget.c:434
 #, fuzzy
 msgid "Clear log window?"
 msgstr "Pencere kapatılıyor\n"
 
-#: schematic/src/gschem_log_widget.c:477
 #, fuzzy
 msgid "Clear Log _Window"
 msgstr "Yeni pencere"
 
-#: schematic/src/gschem_macro_widget.c:231
 msgid "Macro:"
 msgstr ""
 
-#: schematic/src/gschem_macro_widget.c:387
 msgid "Evaluate"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:172
 #, fuzzy
 msgid "_Fill Type:"
 msgstr "doldurma tipi.."
 
-#: schematic/src/gschem_object_properties_widget.c:173
 #, fuzzy
 msgid "Lin_e Width:"
 msgstr "Çizgi Kalınlığı & Tipi"
 
-#: schematic/src/gschem_object_properties_widget.c:174
 msgid "Angle _1:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:175
 msgid "P_itch 1:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:176
 msgid "Angle _2:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:177
 msgid "Pitc_h 2:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:237
 msgid "<b>Fill Properties</b>"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:255
-#: schematic/src/gschem_text_properties_widget.c:258
-#: schematic/src/x_newtext.c:271
 #, fuzzy
 msgid "Colo_r:"
 msgstr "Renk"
 
-#: schematic/src/gschem_object_properties_widget.c:266
 msgid "<b>General Properties</b>"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:284
 #, fuzzy
 msgid "_Type:"
 msgstr "doldurma tipi.."
 
-#: schematic/src/gschem_object_properties_widget.c:285
 #, fuzzy
 msgid "_Width:"
 msgstr "Çizgi Kalınlığı & Tipi"
 
-#: schematic/src/gschem_object_properties_widget.c:286
 msgid "Dash _Length:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:287
 msgid "Dash _Space:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:288
 msgid "C_ap style:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:333
 msgid "<b>Line Properties</b>"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:351
 #, fuzzy
 msgid "_Pin Type:"
 msgstr "doldurma tipi.."
 
-#: schematic/src/gschem_object_properties_widget.c:362
 msgid "<b>Pin Properties</b>"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:217
 msgid "_Off"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:220
 msgid "_Dots"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:223
 msgid "M_esh"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:245
 msgid "Net R_ubber Band Mode:"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:246
 msgid "_Magnetic Net Mode:"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:250
-#: schematic/src/gschem_options_widget.c:251
 msgid "Enabled"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:265
 msgid "<b>Net Options</b>"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:282
 msgid "Grid Mode:"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:283
 #, fuzzy
 msgid "Snap Mode:"
 msgstr "Kopyalama Kipi"
 
-#: schematic/src/gschem_options_widget.c:284
 #, fuzzy
 msgid "_Snap Size:"
 msgstr "Kopyalama Kipi"
 
-#: schematic/src/gschem_options_widget.c:301
 msgid "<b>Snap Options</b>"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:340
 msgid "O_ff"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:343
 msgid "_Grid"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:346
 msgid "_Resnap"
 msgstr ""
 
-#: schematic/src/gschem_pin_type_combo.c:73
 msgid "Net pin"
 msgstr ""
 
-#: schematic/src/gschem_pin_type_combo.c:80
 msgid "Bus pin (graphical)"
 msgstr ""
 
-#: schematic/src/gschem_preview.c:195
 msgid "Preview Buffer"
 msgstr ""
 
-#: schematic/src/gschem_show_hide_text_widget.c:148
-#: schematic/src/x_window.c:1268
 msgid "Hide"
 msgstr ""
 
-#: schematic/src/gschem_show_hide_text_widget.c:157
-#: schematic/src/x_window.c:1269
 msgid "Hide text starting with:"
 msgstr ""
 
-#: schematic/src/gschem_slot_edit_dialog.c:91
 msgid "Edit slot number"
 msgstr ""
 
-#: schematic/src/gschem_slot_edit_dialog.c:121
 msgid "Number of Slots:"
 msgstr ""
 
-#: schematic/src/gschem_slot_edit_dialog.c:122
 msgid "Slot Number:"
 msgstr ""
 
-#: schematic/src/gschem_text_properties_widget.c:240
-#: schematic/src/x_newtext.c:265
 msgid "<b>Text Content</b>"
 msgstr ""
 
-#: schematic/src/gschem_text_properties_widget.c:259
-#: schematic/src/x_newtext.c:291
 msgid "_Size:"
 msgstr ""
 
-#: schematic/src/gschem_text_properties_widget.c:260
-#: schematic/src/x_newtext.c:310
 msgid "Ali_gnment:"
 msgstr ""
 
-#: schematic/src/gschem_text_properties_widget.c:261
-#: schematic/src/x_newtext.c:330
 #, fuzzy
 msgid "Ro_tation:"
 msgstr "Döndür"
 
-#: schematic/src/gschem_text_properties_widget.c:294
-#: schematic/src/x_newtext.c:253
 msgid "<b>Text Properties</b>"
 msgstr ""
 
-#: schematic/src/gschem_translate_widget.c:238
 msgid "Coordinate:"
 msgstr ""
 
-#: schematic/src/gschem_translate_widget.c:405 schematic/src/i_callbacks.c:800
 msgid "Translate"
 msgstr "Çevir"
 
-#: schematic/src/i_basic.c:64 schematic/src/x_window.c:1369
-#: schematic/scheme/conf/schematic/menu.scm:59
-#: schematic/scheme/gschem/builtins.scm:99
 msgid "Select Mode"
 msgstr "Seçim Kipi"
 
-#: schematic/src/i_basic.c:65
 #, fuzzy
 msgid "Select Box Mode"
 msgstr "Seçim Kipi"
 
-#: schematic/src/i_basic.c:66
 msgid "Text Mode"
 msgstr "Metin kipi"
 
-#: schematic/src/i_basic.c:67
 msgid "Pan Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:70
 #, c-format
 msgid "Paste %d Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:74
 msgid "Magnetic Net Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:76
 msgid "Net Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:77
 msgid "Arc Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:78
 msgid "Box Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:79
 msgid "Bus Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:80
 msgid "Circle Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:81
 msgid "Component Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:82 schematic/scheme/conf/schematic/menu.scm:62
-#: schematic/scheme/gschem/builtins.scm:114
 msgid "Copy Mode"
 msgstr "Kopyalama Kipi"
 
-#: schematic/src/i_basic.c:83 schematic/scheme/conf/schematic/menu.scm:63
-#: schematic/scheme/gschem/builtins.scm:117
 msgid "Multiple Copy Mode"
 msgstr "Çoklu Kopyalama Kipi"
 
-#: schematic/src/i_basic.c:84
 msgid "Line Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:85 schematic/scheme/conf/schematic/menu.scm:66
-#: schematic/scheme/gschem/builtins.scm:123
 msgid "Mirror Mode"
 msgstr "Ayna modu"
 
-#: schematic/src/i_basic.c:86 schematic/scheme/conf/schematic/menu.scm:64
-#: schematic/scheme/gschem/builtins.scm:111
 msgid "Move Mode"
 msgstr "Taşıma Kipi"
 
-#: schematic/src/i_basic.c:87
 #, fuzzy
 msgid "Path Mode"
 msgstr "Döndürme kipi"
 
-#: schematic/src/i_basic.c:88
 msgid "Picture Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:89
 msgid "Pin Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:90 schematic/scheme/gschem/builtins.scm:120
 msgid "Rotate Mode"
 msgstr "Döndürme kipi"
 
-#: schematic/src/i_basic.c:91
 #, fuzzy
 msgid "Modify Mode"
 msgstr "Kopyalama Kipi"
 
-#: schematic/src/i_basic.c:92 schematic/src/x_menus.c:49
-#: schematic/scheme/gschem/builtins.scm:204
 msgid "Zoom Box"
 msgstr ""
 
-#: schematic/src/i_basic.c:121
 msgid "Show Hidden"
 msgstr "Gizlileri Göster"
 
-#: schematic/src/i_basic.c:124
 msgid "Snap Off"
 msgstr ""
 
-#: schematic/src/i_basic.c:126
 msgid "Resnap Active"
 msgstr ""
 
-#: schematic/src/i_basic.c:288 schematic/src/x_colorcb.c:159
 msgid "Stroke"
 msgstr ""
 
-#: schematic/src/i_basic.c:296 schematic/src/i_basic.c:330
-#: schematic/src/x_window.c:1361
 msgid "none"
 msgstr ""
 
-#: schematic/src/i_basic.c:304
 msgid "Repeat/"
 msgstr ""
 
-#: schematic/src/i_basic.c:315
 msgid "Repeat/none"
 msgstr ""
 
-#: schematic/src/i_basic.c:323 schematic/src/i_callbacks.c:1239
-#: schematic/scheme/gschem/builtins.scm:189
 msgid "Pan"
 msgstr "Kaydırma"
 
-#: schematic/src/i_callbacks.c:74
 #, fuzzy, c-format
 msgid "New page created [%1$s]"
 msgstr "Yeni sayfa oluşturuldu [%s]\n"
 
-#: schematic/src/i_callbacks.c:108
 #, fuzzy, c-format
 msgid "New Window created [%1$s]"
 msgstr "Yeni pencere oluşturuldu [%s]\n"
 
-#: schematic/src/i_callbacks.c:245
 msgid "Failed to Save All"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:247
 msgid "Saved All"
 msgstr "Hepsi kaydedildi"
 
-#: schematic/src/i_callbacks.c:308
 #, fuzzy
 msgid "Closing Window"
 msgstr "Pencere kapatılıyor\n"
 
-#: schematic/src/i_callbacks.c:505 schematic/src/x_menus.c:55
-#: schematic/scheme/gschem/builtins.scm:168
 msgid "Copy"
 msgstr "Kopyala"
 
-#: schematic/src/i_callbacks.c:514 schematic/src/i_callbacks.c:539
-#: schematic/src/i_callbacks.c:564
 msgid "Select objs first"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:530
 msgid "Multiple Copy"
 msgstr "Çoklu kopyala"
 
-#: schematic/src/i_callbacks.c:555 schematic/src/x_menus.c:56
 msgid "Move"
 msgstr "Taşı"
 
-#: schematic/src/i_callbacks.c:579 schematic/src/x_menus.c:57
-#: schematic/src/x_multiattrib.c:1656 schematic/scheme/gschem/builtins.scm:108
 msgid "Delete"
 msgstr "Sil"
 
-#: schematic/src/i_callbacks.c:603
 msgid "Edit"
 msgstr "Düzenle"
 
-#: schematic/src/i_callbacks.c:618 schematic/scheme/gschem/builtins.scm:129
 msgid "Edit Text"
 msgstr "Metni Düzenle"
 
-#: schematic/src/i_callbacks.c:637
 msgid "Slot"
 msgstr "Slot"
 
-#: schematic/src/i_callbacks.c:688 schematic/src/i_callbacks.c:698
 msgid "Rotate"
 msgstr "Döndür"
 
-#: schematic/src/i_callbacks.c:736 schematic/src/i_callbacks.c:746
 msgid "Mirror"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:763 schematic/src/x_colorcb.c:160
-#: schematic/scheme/conf/schematic/menu.scm:73
-#: schematic/scheme/gschem/builtins.scm:141
 msgid "Lock"
 msgstr "Kilitle"
 
-#: schematic/src/i_callbacks.c:781 schematic/scheme/conf/schematic/menu.scm:74
-#: schematic/scheme/gschem/builtins.scm:144
 msgid "Unlock"
 msgstr "Kilidi Aç"
 
-#: schematic/src/i_callbacks.c:805
 msgid "WARNING: Do not translate with snap off!"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:806
 msgid "WARNING: Turning snap on and continuing with translate."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:813
 msgid "WARNING: Snap grid size is not equal to 100!"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:815
 msgid ""
 "WARNING: If you are translating a symbol to the origin, the snap grid size "
 "should be set to 100"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:847
 msgid "Embed"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:886
 msgid "Unembed"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:928
 msgid "Update"
 msgstr "Güncelle"
 
-#: schematic/src/i_callbacks.c:970
 msgid "ShowHidden"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1537
 #, c-format
 msgid ""
 "<b>Revert page:</b>\n"
@@ -912,98 +685,76 @@ msgid ""
 "discarded and page file will be reloaded from disk."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1555
 msgid "Revert"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1647
 msgid "Copy to clipboard"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1664
 msgid "Cut to clipboard"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1686
 msgid "Paste from clipboard"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1694
 msgid "Empty clipboard"
 msgstr ""
 
 #. TRANSLATORS: The number is the number of the buffer that the
 #. * selection is being copied to.
-#: schematic/src/i_callbacks.c:1719
 #, fuzzy, c-format
 msgid "Copy %i"
 msgstr "Kopyala"
 
 #. TRANSLATORS: The number is the number of the buffer that the
 #. * selection is being cut to.
-#: schematic/src/i_callbacks.c:1746
 #, fuzzy, c-format
 msgid "Cut %i"
 msgstr "1'e Kes"
 
 #. TRANSLATORS: The number is the number of the buffer that is being
 #. * pasted to the schematic.
-#: schematic/src/i_callbacks.c:1776
 #, fuzzy, c-format
 msgid "Paste %i"
 msgstr "1'den yapıştır"
 
-#: schematic/src/i_callbacks.c:1785
 msgid "Empty buffer"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1833 schematic/src/x_window.c:1203
 msgid "Component"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1865 schematic/src/x_colorcb.c:150
 msgid "Attribute"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1885 schematic/src/x_colorcb.c:149
 msgid "Net"
 msgstr "Ağ"
 
-#: schematic/src/i_callbacks.c:1928 schematic/src/x_colorcb.c:155
-#: schematic/src/x_window.c:1222
 msgid "Bus"
 msgstr "Veriyolu"
 
-#: schematic/src/i_callbacks.c:2004
 msgid "Line"
 msgstr "Satır"
 
-#: schematic/src/i_callbacks.c:2021
 msgid "Path"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2043
 msgid "Box"
 msgstr "Kutu"
 
-#: schematic/src/i_callbacks.c:2085
 msgid "Circle"
 msgstr "Daire"
 
-#: schematic/src/i_callbacks.c:2108
 msgid "Arc"
 msgstr "Eğri"
 
-#: schematic/src/i_callbacks.c:2131 schematic/src/x_colorcb.c:146
 msgid "Pin"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2191
 #, c-format
 msgid "Searching for source [%1$s]"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2223
 #, c-format
 msgid ""
 "Failed to descend hierarchy into '%1$s': %2$s\n"
@@ -1011,106 +762,81 @@ msgid ""
 "The lepton-schematic log may contain more information."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2227
 #, c-format
 msgid "Failed to descend into '%1$s': %2$s"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2234
 msgid "Failed to descend hierarchy."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2312
 #, c-format
 msgid "Searching for symbol [%1$s]"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2320
 msgid "Symbol is not a real file. Symbol cannot be loaded."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2367 schematic/src/x_tabs.c:1060
 msgid "Cannot find any schematics above the current one!"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2400
 msgid "Attach"
 msgstr "Ekle"
 
-#: schematic/src/i_callbacks.c:2456
 msgid "Detach"
 msgstr "Ayır"
 
-#: schematic/src/i_callbacks.c:2500
 msgid "ShowN"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2537
 msgid "ShowV"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2574
 msgid "ShowB"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2612
 msgid "VisToggle"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2643
 #, c-format
 msgid "Sorry but this is a non-functioning menu option\n"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2703
 msgid "Action feedback mode set to OUTLINE"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2706
 msgid "Action feedback mode set to BOUNDINGBOX"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2730
 msgid "Grid OFF"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2731
 msgid "Dot grid selected"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2732
 msgid "Mesh grid selected"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2733
 msgid "Invalid grid mode"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2755
 msgid "Snap OFF (CAUTION!)"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2758
 msgid "Snap ON"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2761
 msgid "Snap back to the grid (CAUTION!)"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2790
 msgid "Rubber band ON"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2792
 msgid "Rubber band OFF"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2811
 msgid "magnetic net mode: ON"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2814
 msgid "magnetic net mode: OFF"
 msgstr ""
 
@@ -1119,134 +845,105 @@ msgstr ""
 #. the form "untitled_N.sch", where N is a number.  Please make
 #. sure that the translation contains characters suitable for use
 #. in a filename.
-#: schematic/src/i_vars.c:209
 msgid "untitled"
 msgstr ""
 
-#: schematic/src/o_complex.c:192 schematic/src/o_complex.c:195
 #, c-format
 msgid "Translating schematic [%1$d %2$d]"
 msgstr ""
 
-#: schematic/src/o_delete.c:82
 #, c-format
 msgid "Delete locked object?"
 msgid_plural "Delete %1$u locked objects?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/o_misc.c:55
 #, c-format
 msgid "Got an unexpected NULL in o_edit\n"
 msgstr ""
 
-#: schematic/src/o_misc.c:315
 msgid "Hidden text is now visible"
 msgstr ""
 
-#: schematic/src/o_misc.c:317
 msgid "Hidden text is now invisible"
 msgstr ""
 
-#: schematic/src/o_misc.c:425
 #, c-format
 msgid "Could not find symbol [%1$s] in library. Update failed."
 msgstr ""
 
-#: schematic/src/o_misc.c:541
 #, c-format
 msgid "o_autosave_backups: Can't get the real filename of %1$s."
 msgstr ""
 
-#: schematic/src/o_misc.c:585
 #, c-format
 msgid "Could NOT set previous backup file [%1$s] read-write"
 msgstr ""
 
-#: schematic/src/o_misc.c:605
 #, c-format
 msgid "Could NOT set backup file [%1$s] readonly"
 msgstr ""
 
-#: schematic/src/o_misc.c:610
 #, c-format
 msgid "Could NOT save backup file [%1$s]"
 msgstr ""
 
-#: schematic/src/o_move.c:192
 #, c-format
 msgid "ERROR: NULL object in o_move_end!\n"
 msgstr ""
 
-#: schematic/src/o_move.c:519
 #, c-format
 msgid "DOH! tried to find the whichone, but didn't find it!\n"
 msgstr ""
 
-#: schematic/src/o_move.c:546
 #, c-format
 msgid "Got a non line object in o_move_check_endpoint\n"
 msgstr ""
 
-#: schematic/src/o_net.c:444
 msgid "Warning: Starting net at off grid coordinate"
 msgstr ""
 
-#: schematic/src/o_net.c:508
 msgid "Warning: Ending net at off grid coordinate"
 msgstr ""
 
-#: schematic/src/o_net.c:856 schematic/src/o_net.c:893
-#: schematic/src/o_net.c:964 schematic/src/o_net.c:1000
 #, c-format
 msgid "Tried to add more than two bus rippers. Internal gschem error.\n"
 msgstr ""
 
-#: schematic/src/o_net.c:1068
 #, c-format
 msgid "Bus ripper symbol [%1$s] was not found in any component library"
 msgstr ""
 
-#: schematic/src/o_picture.c:133 schematic/src/o_picture.c:343
 msgid "Select a picture file..."
 msgstr ""
 
-#: schematic/src/o_picture.c:166
 #, c-format
 msgid "Failed to load picture: %1$s"
 msgstr ""
 
-#: schematic/src/o_picture.c:182
 msgid "Picture"
 msgstr ""
 
-#: schematic/src/o_picture.c:378
 #, c-format
 msgid "Failed to replace pictures: %s"
 msgstr ""
 
-#: schematic/src/o_slot.c:80
 #, fuzzy
 msgid "Slot attribute malformed"
 msgstr "Öznitelikler"
 
-#: schematic/src/o_slot.c:88
 msgid "numslots attribute missing"
 msgstr ""
 
-#: schematic/src/o_slot.c:89
 msgid "Slotting not allowed for this component"
 msgstr ""
 
-#: schematic/src/o_slot.c:104
 msgid "New slot number out of range"
 msgstr ""
 
-#: schematic/src/o_undo.c:397
 msgid "Undo/Redo disabled in rc file"
 msgstr ""
 
-#: schematic/src/parsecmd.c:77
 #, c-format
 msgid ""
 "Usage: %1$s [OPTION ...] [--] [FILE ...]\n"
@@ -1271,187 +968,143 @@ msgid ""
 "gEDA/gaf homepage: <http://www.geda-project.org/>\n"
 msgstr ""
 
-#: schematic/src/parsecmd.c:110
 #, c-format
 msgid ""
 "Lepton EDA %1$s (git: %2$.7s)\n"
 "Copyright (C) 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright (C) 2017-2018 Lepton Developers.\n"
+"Copyright (C) 2017-2019 Lepton Developers.\n"
 "This is free software, and you are welcome to redistribute it under\n"
 "certain conditions. For details, see the file `COPYING', which is\n"
 "included in the Lepton EDA distribution.\n"
 "There is NO WARRANTY, to the extent permitted by law.\n"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:125
 #, c-format
 msgid "Got invalid show option; defaulting to show both\n"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:139
 #, c-format
 msgid "ERROR: NULL object!\n"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:328
 msgid "Single Attribute Editor"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:358
 msgid "<b>Edit Attribute</b>"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:360
 msgid "<b>Add Attribute</b>"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:376
 msgid "N_ame:"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:396 schematic/src/x_multiattrib.c:2222
 msgid "_Value:"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:415 schematic/src/x_multiattrib.c:2281
 msgid "Vi_sible"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:434
 msgid "Show Value Only"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:436
 msgid "Show Name Only"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:438 schematic/src/x_multiattrib.c:1620
-#: schematic/scheme/gschem/builtins.scm:324
 msgid "Show Name & Value"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:445
 msgid "<b>Attach Options</b>"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:460
 msgid "All"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:476 schematic/src/x_compselect.c:986
-#: schematic/src/x_compselect.c:1100
 msgid "Components"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:492 schematic/src/x_window.c:1214
 msgid "Nets"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:508
 msgid "Replace existing attributes"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:412
 msgid ""
 "slotted object without slot attribute may cause problems when autonumbering "
 "slots"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:427
 #, c-format
 msgid ""
 "duplicate slot may cause problems: [symbolname=%1$s, number=%2$d, slot=%3$d]"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:675
 msgid "No searchstring given in autonumber text."
 msgstr ""
 
-#: schematic/src/x_autonumber.c:728
 msgid "No '*' or '?' given at the end of the autonumber text."
 msgstr ""
 
-#: schematic/src/x_autonumber.c:873
 msgid "Diagonal"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:874
 msgid "Top to bottom"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:875
 msgid "Bottom to top"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:876
 msgid "Left to right"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:877
 msgid "Right to left"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:878
 msgid "File order"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1214
 msgid "Autonumber text"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1237
 msgid "<b>Scope</b>"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1259
 msgid "Search for:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1273
 msgid "Autonumber text in:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1280
 msgid "Skip numbers found in:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1292 schematic/src/x_autonumber.c:1301
 msgid "Selected objects"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1293 schematic/src/x_autonumber.c:1302
 msgid "Current page"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1294 schematic/src/x_autonumber.c:1303
 msgid "Whole hierarchy"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1305
 msgid "Overwrite existing numbers"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1310
 msgid "<b>Options</b>"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1332
 msgid "Starting number:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1339
 msgid "Sort order:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1371
 msgid "Remove numbers"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1375
 msgid "Automatic slotting"
 msgstr ""
 
-#: schematic/src/x_clipboard.c:245
 #, c-format
 msgid ""
 "<b>Invalid schematic on clipboard.</b>\n"
@@ -1459,172 +1112,132 @@ msgid ""
 "An error occurred while inserting clipboard data: %s."
 msgstr ""
 
-#: schematic/src/x_clipboard.c:247
 msgid "Clipboard insertion failed"
 msgstr ""
 
-#: schematic/src/x_color.c:89 schematic/src/x_color.c:98
 #, c-format
 msgid "Could not allocate the color %1$s!\n"
 msgstr ""
 
-#: schematic/src/x_color.c:89
 msgid "black"
 msgstr ""
 
-#: schematic/src/x_color.c:98
 msgid "white"
 msgstr ""
 
-#: schematic/src/x_color.c:120
 #, c-format
 msgid "Could not allocate display color %1$i!\n"
 msgstr ""
 
-#: schematic/src/x_color.c:142
 #, c-format
 msgid "Could not allocate outline color %1$i!\n"
 msgstr ""
 
-#: schematic/src/x_color.c:159
 #, c-format
 msgid "Tried to get an invalid color: %1$d\n"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:145
 msgid "Background"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:147
 msgid "Net endpoint"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:148
 msgid "Graphic"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:151
 msgid "Logic bubble"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:152
 msgid "Grid point"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:153
 #, fuzzy
 msgid "Detached attribute"
 msgstr "Öznitelikler"
 
-#: schematic/src/x_colorcb.c:156
 #, fuzzy
 msgid "Selection"
 msgstr "Seçim Kipi"
 
-#: schematic/src/x_colorcb.c:157
 msgid "Bounding box"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:158
 msgid "Zoom box"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:161
 msgid "Output background"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:162
 msgid "Freestyle 1"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:163
 msgid "Freestyle 2"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:164
 msgid "Freestyle 3"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:165
 msgid "Freestyle 4"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:166
 msgid "Net junction"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:167
 msgid "Mesh grid major"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:168
 msgid "Mesh grid minor"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:172
 msgid "Unknown"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1169
 msgid "Reset filter"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1192
 msgid "Reload all libraries"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1245 schematic/src/x_multiattrib.c:2092
 msgid "Value"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1284
 msgid "Default behavior - reference component"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1287
 msgid "Embed component in schematic"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1290
 msgid "Include component as individual objects"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1448
 msgid "Select Component..."
 msgstr ""
 
-#: schematic/src/x_compselect.c:1471
 msgid "In Us_e"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1475
 msgid "Lib_raries"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1484 schematic/src/x_fileselect.c:119
 msgid "Preview"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1510
 msgid "Attributes"
 msgstr "Öznitelikler"
 
-#: schematic/src/x_dialog.c:325
 msgid "Major symbol changes detected."
 msgstr ""
 
-#: schematic/src/x_dialog.c:349
 msgid ""
 "Changes have occurred to the symbols shown below.\n"
 "\n"
 "Be sure to verify each of these symbols."
 msgstr ""
 
-#: schematic/src/x_dialog.c:369
 msgid "Symbol"
 msgstr ""
 
-#: schematic/src/x_dialog.c:406
 #, c-format
 msgid ""
 "<span weight=\"bold\" size=\"larger\">The input attribute \"%s\" is invalid\n"
@@ -1635,39 +1248,30 @@ msgid ""
 "The value cannot start with a space."
 msgstr ""
 
-#: schematic/src/x_dialog.c:408
 msgid "Invalid Attribute"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:37
 msgid "Schematics"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:42
 msgid "Symbols"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:47
 msgid "Schematics and symbols"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:53
 msgid "All files"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:169
 msgid "Open..."
 msgstr ""
 
-#: schematic/src/x_fileselect.c:233
 msgid "Save as..."
 msgstr ""
 
-#: schematic/src/x_fileselect.c:297
 msgid "Save cancelled on user request"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:334
 msgid ""
 "\n"
 "If you load the original file, the backup file will be overwritten in the "
@@ -1676,28 +1280,22 @@ msgid ""
 "Do you want to load the backup file?\n"
 msgstr ""
 
-#: schematic/src/x_fstylecb.c:73
 msgid "Hollow"
 msgstr ""
 
-#: schematic/src/x_fstylecb.c:80
 msgid "Filled"
 msgstr ""
 
-#: schematic/src/x_fstylecb.c:87
 msgid "Mesh"
 msgstr ""
 
-#: schematic/src/x_fstylecb.c:94
 msgid "Hatch"
 msgstr ""
 
-#: schematic/src/x_image.c:279
 #, c-format
 msgid "x_image_lowlevel: Unable to write %1$s file %2$s."
 msgstr ""
 
-#: schematic/src/x_image.c:289
 #, c-format
 msgid ""
 "There was the following error when saving image with type %1$s to filename:\n"
@@ -1706,298 +1304,231 @@ msgid ""
 "%3$s.\n"
 msgstr ""
 
-#: schematic/src/x_image.c:309
 #, c-format
 msgid "Wrote color image to [%1$s] [%2$d x %3$d]"
 msgstr ""
 
-#: schematic/src/x_image.c:311
 #, c-format
 msgid "Wrote black and white image to [%1$s] [%2$d x %3$d]"
 msgstr ""
 
-#: schematic/src/x_image.c:319
 msgid "x_image_lowlevel: Unable to get pixbuf from gschem's window."
 msgstr ""
 
-#: schematic/src/x_image.c:358
 msgid "Width x Height"
 msgstr ""
 
-#: schematic/src/x_image.c:374
 msgid "Image type"
 msgstr ""
 
-#: schematic/src/x_image.c:395
 msgid "Write image..."
 msgstr "imaj olarak yaz"
 
-#: schematic/src/x_linecapcb.c:74
 msgid "Butt"
 msgstr ""
 
-#: schematic/src/x_linecapcb.c:81
 msgid "Square"
 msgstr ""
 
-#: schematic/src/x_linecapcb.c:88
 msgid "Round"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:74
 msgid "Solid"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:81
 msgid "Dotted"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:88
 msgid "Dashed"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:95
 msgid "Center"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:102
 msgid "Phantom"
 msgstr ""
 
-#: schematic/src/x_menus.c:41 schematic/scheme/gschem/builtins.scm:267
 msgid "Add Net"
 msgstr ""
 
-#: schematic/src/x_menus.c:42 schematic/src/x_multiattrib.c:2187
-#: schematic/scheme/gschem/builtins.scm:264
 msgid "Add Attribute"
 msgstr ""
 
-#: schematic/src/x_menus.c:43 schematic/scheme/gschem/builtins.scm:261
 #, fuzzy
 msgid "Add Component"
 msgstr "Bileşen Güncelle"
 
-#: schematic/src/x_menus.c:44 schematic/scheme/gschem/builtins.scm:270
 msgid "Add Bus"
 msgstr ""
 
-#: schematic/src/x_menus.c:45 schematic/scheme/gschem/builtins.scm:273
 #, fuzzy
 msgid "Add Text"
 msgstr "Metni Düzenle"
 
-#: schematic/src/x_menus.c:47 schematic/scheme/gschem/builtins.scm:210
 msgid "Zoom In"
 msgstr ""
 
-#: schematic/src/x_menus.c:48 schematic/scheme/gschem/builtins.scm:213
 msgid "Zoom Out"
 msgstr ""
 
-#: schematic/src/x_menus.c:50 schematic/scheme/gschem/builtins.scm:207
 msgid "Zoom Extents"
 msgstr ""
 
-#: schematic/src/x_menus.c:52 schematic/src/x_window.c:1233
 msgid "Select"
 msgstr ""
 
-#: schematic/src/x_menus.c:53 schematic/scheme/conf/schematic/menu.scm:69
-#: schematic/scheme/gschem/builtins.scm:126
 msgid "Edit..."
 msgstr "Düzenle..."
 
-#: schematic/src/x_menus.c:54 schematic/scheme/conf/schematic/menu.scm:68
 msgid "Object Properties..."
 msgstr ""
 
-#: schematic/src/x_menus.c:59 schematic/scheme/gschem/builtins.scm:300
 #, fuzzy
 msgid "Down Schematic"
 msgstr "gEDA Şematik Editörü"
 
-#: schematic/src/x_menus.c:60 schematic/scheme/gschem/builtins.scm:303
 msgid "Down Symbol"
 msgstr ""
 
-#: schematic/src/x_menus.c:61
 msgid "Up"
 msgstr ""
 
-#: schematic/src/x_menus.c:336
 #, c-format
 msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
 msgstr ""
 
-#: schematic/src/x_menus.c:360
 #, c-format
 msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
 msgstr ""
 
-#: schematic/src/x_misc.c:70
 msgid "The operating system is out of memory or resources."
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:798 schematic/src/x_multiattrib.c:2704
 msgid "<various>"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:930
 msgid "Attributes with empty name are not allowed. Please set a name."
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1622
 msgid "Show Value only"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1624
 msgid "Show Name only"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1651
 msgid "Promote"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1655
 msgid "Duplicate"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1657
 #, fuzzy
 msgid "Copy to all"
 msgstr "1'e kopyala"
 
-#: schematic/src/x_multiattrib.c:1986 schematic/src/x_multiattrib.c:2602
 msgid "Edit Attributes"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2112
 msgid "Vis?"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2130
 msgid "N"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2148
 msgid "V"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2170
 #, fuzzy
 msgid "Sho_w inherited attributes"
 msgstr "Öznitelikler"
 
-#: schematic/src/x_multiattrib.c:2197
 msgid "_Name:"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2241
 msgid "Ctrl+Enter inserts new line; Ctrl+Tab inserts Tab"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2618
 #, c-format
 msgid "%2$i symbol (%1$s)"
 msgid_plural "%2$i symbols (%1$s)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2624
 #, c-format
 msgid "%1$i pin"
 msgid_plural "%1$i pins"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2630
 #, c-format
 msgid "%1$i net"
 msgid_plural "%1$i nets"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2636
 #, c-format
 msgid "%1$i bus"
 msgid_plural "%1$i buses"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2642
 #, fuzzy, c-format
 msgid "%1$i attribute"
 msgid_plural "%1$i attributes"
 msgstr[0] "Öznitelikler"
 msgstr[1] "Öznitelikler"
 
-#: schematic/src/x_newtext.c:433
 msgid "Text Entry..."
 msgstr ""
 
-#: schematic/src/x_pagesel.c:253
 msgid "New Page"
 msgstr "Yeni Sayfa"
 
-#: schematic/src/x_pagesel.c:254
 msgid "Open Page..."
 msgstr "Sayfa Aç..."
 
-#: schematic/src/x_pagesel.c:256
 msgid "Save Page"
 msgstr "Sayfayı Kaydet"
 
-#: schematic/src/x_pagesel.c:257 schematic/scheme/gschem/builtins.scm:246
 msgid "Close Page"
 msgstr "Sayfayı Kapat"
 
-#: schematic/src/x_pagesel.c:376 schematic/scheme/gschem/builtins.scm:237
 msgid "Page Manager"
 msgstr ""
 
-#: schematic/src/x_pagesel.c:448
 msgid "Changed"
 msgstr ""
 
-#: schematic/src/x_pagesel.c:468
 msgid "Right click on the filename for more options..."
 msgstr ""
 
-#: schematic/src/x_print.c:306
 #, c-format
 msgid "Failed to write PDF to '%s': %s\n"
 msgstr ""
 
-#: schematic/src/x_print.c:364
 #, c-format
 msgid "Failed to write PDF to '%1$s': %2$s\n"
 msgstr ""
 
-#: schematic/src/x_print.c:449
 #, c-format
 msgid ""
 "Error printing file:\n"
 "%1$s"
 msgstr ""
 
-#: schematic/src/x_rc.c:39
 msgid "ERROR: An unknown error occurred while parsing configuration files."
 msgstr ""
 
-#: schematic/src/x_rc.c:44
 msgid ""
 "An unknown error occurred while parsing configuration files.\n"
 "\n"
 "The lepton-schematic log may contain more information."
 msgstr ""
 
-#: schematic/src/x_rc.c:56
 #, c-format
 msgid "ERROR: %1$s"
 msgstr ""
 
-#: schematic/src/x_rc.c:59
 #, c-format
 msgid ""
 "%1$s\n"
@@ -2005,139 +1536,108 @@ msgid ""
 "The lepton-schematic log may contain more information."
 msgstr ""
 
-#: schematic/src/x_rc.c:67
 msgid "Cannot load lepton-schematic configuration."
 msgstr ""
 
-#: schematic/src/x_script.c:42 schematic/scheme/conf/schematic/menu.scm:40
 msgid "Execute Script..."
 msgstr "Betik Çalıştır..."
 
-#: schematic/src/x_script.c:61
 #, c-format
 msgid "Executing guile script [%1$s]"
 msgstr ""
 
-#: schematic/src/x_tabs.c:860
 #, fuzzy, c-format
 msgid "Hierarchy up: %s"
 msgstr "Hiyerarşi"
 
-#: schematic/src/x_tabs.c:863
 #, fuzzy
 msgid "Hierarchy up"
 msgstr "Hiyerarşi"
 
-#: schematic/src/x_widgets.c:158 schematic/src/x_window.c:1444
 #, fuzzy
 msgid "Options"
 msgstr "Seçenekler"
 
-#: schematic/src/x_widgets.c:203 schematic/src/x_window.c:1436
 msgid "Object"
 msgstr ""
 
-#: schematic/src/x_widgets.c:224
 msgid "Log"
 msgstr ""
 
-#: schematic/src/x_widgets.c:245 schematic/src/x_window.c:1466
 msgid "Find Text"
 msgstr ""
 
-#: schematic/src/x_widgets.c:259
 #, fuzzy
 msgid "Color Scheme Editor"
 msgstr "gEDA Şematik Editörü"
 
-#: schematic/src/x_widgets.c:272 schematic/scheme/gschem/builtins.scm:378
 #, fuzzy
 msgid "Select Schematic Font"
 msgstr "Seçim Kipi"
 
-#: schematic/src/x_window.c:763
 #, c-format
 msgid "Loading schematic [%1$s]"
 msgstr ""
 
-#: schematic/src/x_window.c:864
 #, c-format
 msgid "Could NOT save page [%1$s]\n"
 msgstr ""
 
-#: schematic/src/x_window.c:865
 msgid "Error while trying to save"
 msgstr ""
 
-#: schematic/src/x_window.c:875
 msgid "Failed to save file"
 msgstr ""
 
-#: schematic/src/x_window.c:885
 #, fuzzy, c-format
 msgid "Saved as [%1$s]"
 msgstr "Tümünü kaydet"
 
-#: schematic/src/x_window.c:887
 #, fuzzy, c-format
 msgid "Saved [%1$s]"
 msgstr "Tümünü kaydet"
 
-#: schematic/src/x_window.c:889
 msgid "Saved"
 msgstr ""
 
-#: schematic/src/x_window.c:966
 #, c-format
 msgid "Discarding page [%1$s]"
 msgstr ""
 
-#: schematic/src/x_window.c:966
 #, c-format
 msgid "Closing [%1$s]"
 msgstr ""
 
-#: schematic/src/x_window.c:1175
 msgid "New"
 msgstr "Yeni"
 
-#: schematic/src/x_window.c:1175
 msgid "New file"
 msgstr ""
 
-#: schematic/src/x_window.c:1179
 msgid "Open"
 msgstr ""
 
-#: schematic/src/x_window.c:1179
 msgid "Open file"
 msgstr ""
 
-#: schematic/src/x_window.c:1183 schematic/scheme/gschem/builtins.scm:59
 msgid "Save"
 msgstr ""
 
-#: schematic/src/x_window.c:1183
 msgid "Save file"
 msgstr ""
 
-#: schematic/src/x_window.c:1189 schematic/scheme/gschem/builtins.scm:93
 msgid "Undo"
 msgstr "Geri Al"
 
-#: schematic/src/x_window.c:1189
 msgid "Undo last operation"
 msgstr ""
 
-#: schematic/src/x_window.c:1193 schematic/scheme/gschem/builtins.scm:96
 msgid "Redo"
 msgstr "Yinele"
 
-#: schematic/src/x_window.c:1193
 msgid "Redo last undo"
 msgstr ""
 
-#: schematic/src/x_window.c:1198
 msgid ""
 "Add component...\n"
 "Select library and component from list, move the mouse into main window, "
@@ -2145,56 +1645,44 @@ msgid ""
 "Right mouse button to cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1209
 msgid ""
 "Add nets mode\n"
 "Right mouse button to cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1217
 msgid ""
 "Add buses mode\n"
 "Right mouse button to cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1226
 msgid "Add Text..."
 msgstr ""
 
-#: schematic/src/x_window.c:1233
 msgid "Select mode"
 msgstr ""
 
-#: schematic/src/x_window.c:1288
 msgid "Show"
 msgstr ""
 
-#: schematic/src/x_window.c:1289
 msgid "Show text starting with:"
 msgstr ""
 
-#: schematic/src/x_window.c:1345
 msgid "Menu/Cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1349
 msgid "Pan/Cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1359
 msgid "Pick"
 msgstr ""
 
-#: schematic/src/x_window.c:1470 schematic/scheme/gschem/builtins.scm:180
 msgid "Status"
 msgstr ""
 
-#: schematic/src/x_window.c:1568
 #, fuzzy, c-format
 msgid "New file [%s]"
 msgstr "Yeni Sayfa"
 
-#: schematic/src/x_window.c:1598
 #, c-format
 msgid ""
 "<b>An error occurred while loading the requested file.</b>\n"
@@ -2208,853 +1696,643 @@ msgid ""
 "monitor program's output in terminal window."
 msgstr ""
 
-#: schematic/src/x_window.c:1617
 msgid "Failed to load file"
 msgstr ""
 
-#: schematic/data/lepton-schematic.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Schematic Editor"
 msgstr "gEDA Şematik Editörü"
 
-#: schematic/data/lepton-schematic.desktop.in:4
 msgid "Create and edit electrical schematics and symbols with lepton-schematic"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:27
 msgid "_New"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:28
 msgid "_Open..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:30
 msgid "Open Recen_t"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:32
 msgid "_Save"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:33
 msgid "Save _As..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:34
-#: schematic/scheme/gschem/builtins.scm:65
 msgid "Save All"
 msgstr "Tümünü kaydet"
 
-#: schematic/scheme/conf/schematic/menu.scm:36
 msgid "_Print..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:37
 #, fuzzy
 msgid "Write _Image..."
 msgstr "imaj olarak yaz"
 
-#: schematic/scheme/conf/schematic/menu.scm:39
 msgid "Invoke Macro..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:41
 msgid "REPL..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:43
-#: schematic/scheme/gschem/builtins.scm:77
 msgid "New Window"
 msgstr "Yeni pencere"
 
-#: schematic/scheme/conf/schematic/menu.scm:44
 msgid "_Close Window"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:45
 msgid "_Quit"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:51
 msgid "_Undo"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:52
 msgid "_Redo"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:54
 msgid "Cu_t"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:55
 msgid "_Copy"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:56
 msgid "_Paste"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:57
 msgid "_Delete"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:60
-#: schematic/scheme/gschem/builtins.scm:102
 msgid "Select All"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:61
-#: schematic/scheme/gschem/builtins.scm:105
 msgid "Deselect"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:65
 msgid "Rotate 90 Mode"
 msgstr "90 derece döndür kipi"
 
-#: schematic/scheme/conf/schematic/menu.scm:70
 msgid "Edit Text..."
 msgstr "Metin Düzenle..."
 
-#: schematic/scheme/conf/schematic/menu.scm:71
 msgid "Slot..."
 msgstr "Yuva..."
 
-#: schematic/scheme/conf/schematic/menu.scm:76
-#: schematic/scheme/gschem/builtins.scm:150
 msgid "Embed Component/Picture"
 msgstr "Bileşen/Resim göm"
 
-#: schematic/scheme/conf/schematic/menu.scm:77
-#: schematic/scheme/gschem/builtins.scm:153
 msgid "Unembed Component/Picture"
 msgstr "Bileşen/resim gömme"
 
-#: schematic/scheme/conf/schematic/menu.scm:78
-#: schematic/scheme/gschem/builtins.scm:156
 msgid "Update Component"
 msgstr "Bileşen Güncelle"
 
-#: schematic/scheme/conf/schematic/menu.scm:79
 msgid "Symbol Translate..."
 msgstr "Sembölü çevir.."
 
-#: schematic/scheme/conf/schematic/menu.scm:85
 msgid "Copy into 1"
 msgstr "1'e kopyala"
 
-#: schematic/scheme/conf/schematic/menu.scm:86
 msgid "Copy into 2"
 msgstr "2'ye kopyala"
 
-#: schematic/scheme/conf/schematic/menu.scm:87
 msgid "Copy into 3"
 msgstr "3'e kopyala"
 
-#: schematic/scheme/conf/schematic/menu.scm:88
 msgid "Copy into 4"
 msgstr "4'e kopyala"
 
-#: schematic/scheme/conf/schematic/menu.scm:89
 msgid "Copy into 5"
 msgstr "5'e kopyala"
 
-#: schematic/scheme/conf/schematic/menu.scm:90
 msgid "Cut into 1"
 msgstr "1'e Kes"
 
-#: schematic/scheme/conf/schematic/menu.scm:91
 msgid "Cut into 2"
 msgstr "2'ye Kes"
 
-#: schematic/scheme/conf/schematic/menu.scm:92
 msgid "Cut into 3"
 msgstr "3'e Kes"
 
-#: schematic/scheme/conf/schematic/menu.scm:93
 msgid "Cut into 4"
 msgstr "4'e Kes"
 
-#: schematic/scheme/conf/schematic/menu.scm:94
 msgid "Cut into 5"
 msgstr "5'e Kes"
 
-#: schematic/scheme/conf/schematic/menu.scm:95
 msgid "Paste from 1"
 msgstr "1'den yapıştır"
 
-#: schematic/scheme/conf/schematic/menu.scm:96
 msgid "Paste from 2"
 msgstr "2'den yapıştır"
 
-#: schematic/scheme/conf/schematic/menu.scm:97
 msgid "Paste from 3"
 msgstr "3'ten yapıştır"
 
-#: schematic/scheme/conf/schematic/menu.scm:98
 msgid "Paste from 4"
 msgstr "4'ten yapıştır"
 
-#: schematic/scheme/conf/schematic/menu.scm:99
 msgid "Paste from 5"
 msgstr "5'ten yapıştır"
 
-#: schematic/scheme/conf/schematic/menu.scm:105
 msgid "Side Dock"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:106
 msgid "Bottom Dock"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:108
 #, fuzzy
 msgid "Find Text Results"
 msgstr "Metni Düzenle"
 
-#: schematic/scheme/conf/schematic/menu.scm:110
 msgid "_Redraw"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:111
 msgid "_Pan"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:112
 msgid "Zoom _Box"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:113
 msgid "Zoom _Extents"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:114
 msgid "Zoom _In"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:115
 msgid "Zoom _Out"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:116
 msgid "Zoom _Full"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:118
 msgid "_Dark Color Scheme"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:119
 msgid "_Light Color Scheme"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:120
 msgid "B_W Color Scheme"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:122
 msgid "Color Scheme Editor..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:129
 msgid "_Manager..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:131
 msgid "_Previous"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:132
 msgid "_Next"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:133
 msgid "_Close"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:135
 msgid "_Revert..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:137
-#: schematic/scheme/gschem/builtins.scm:249
 #, fuzzy
 msgid "Next Tab"
 msgstr "Yeni Sayfa"
 
-#: schematic/scheme/conf/schematic/menu.scm:138
-#: schematic/scheme/gschem/builtins.scm:252
 #, fuzzy
 msgid "Previous Tab"
 msgstr "Sayfayı Kapat"
 
-#: schematic/scheme/conf/schematic/menu.scm:146
 msgid "_Component..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:148
 msgid "_Net"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:149
 msgid "B_us"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:151
 msgid "_Attribute..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:152
 msgid "_Text..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:154
 msgid "_Line"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:155
 msgid "Pat_h"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:156
 msgid "_Box"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:157
 msgid "C_ircle"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:158
 msgid "A_rc"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:159
 msgid "_Pin"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:161
 msgid "Pictu_re..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:167
 msgid "_Up"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:169
 msgid "_Down Schematic"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:170
 msgid "Down _Symbol"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:176
 msgid "_Attach"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:177
 msgid "_Detach"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:179
 msgid "Show _Value"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:180
 msgid "Show _Name"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:181
 msgid "Show _Both"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:182
 msgid "_Toggle Visibility"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:184
 msgid "_Hide Specific Text..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:185
 msgid "_Show Specific Text..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:186
 #, fuzzy
 msgid "Show/Hide Hidden Text"
 msgstr "Metni Göster/Gizle"
 
-#: schematic/scheme/conf/schematic/menu.scm:188
 msgid "_Find Text/Check Symbol..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:189
 msgid "A_utonumber Text..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:195
 #, fuzzy
 msgid "_Options..."
 msgstr "Seçenekler"
 
-#: schematic/scheme/conf/schematic/menu.scm:196
 #, fuzzy
 msgid "_Font..."
 msgstr "Yuva..."
 
-#: schematic/scheme/conf/schematic/menu.scm:198
 msgid "Grid +"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:199
 msgid "Grid -"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:201
 msgid "Grid Style: Cycle Dots/Mesh/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:202
 msgid "Grid Snap: Cycle Grid/Resnap/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:204
 msgid "Feedback Mode: Outline/Box"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:205
 msgid "Net: Rubberband On/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:206
 msgid "Net: Magnetic On/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:208
 #, fuzzy
 msgid "_Coord Window"
 msgstr "Pencere kapatılıyor\n"
 
-#: schematic/scheme/conf/schematic/menu.scm:209
 #, fuzzy
 msgid "_Log Window"
 msgstr "Yeni pencere"
 
-#: schematic/scheme/conf/schematic/menu.scm:215
 msgid "_1 allegro"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:223
 msgid "User _Guide"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:224
 msgid "_FAQ"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:225
 #, fuzzy
 msgid "Docu_mentation"
 msgstr "Döndür"
 
-#: schematic/scheme/conf/schematic/menu.scm:226
 msgid "_Wiki"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:228
 msgid "Find Component D_ocumentation"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:230
 msgid "_Hotkeys..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:231
 msgid "_About"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:237
 msgid "_File"
 msgstr "Dosya"
 
-#: schematic/scheme/conf/schematic/menu.scm:238
 msgid "_Edit"
 msgstr "Düzenle"
 
-#: schematic/scheme/conf/schematic/menu.scm:240
 msgid "_View"
 msgstr "Görüntüle"
 
-#: schematic/scheme/conf/schematic/menu.scm:241
 msgid "_Page"
 msgstr "Sayfa"
 
-#: schematic/scheme/conf/schematic/menu.scm:242
 msgid "_Add"
 msgstr "Ekle"
 
-#: schematic/scheme/conf/schematic/menu.scm:243
 msgid "Hie_rarchy"
 msgstr "Hiyerarşi"
 
-#: schematic/scheme/conf/schematic/menu.scm:244
 msgid "A_ttributes"
 msgstr "Öznitelikler"
 
-#: schematic/scheme/conf/schematic/menu.scm:245
 msgid "_Options"
 msgstr "Seçenekler"
 
-#: schematic/scheme/conf/schematic/menu.scm:246
 msgid "_Netlist"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:247
 msgid "_Help"
 msgstr "Yardım"
 
-#: schematic/scheme/gschem/action.scm:43
 #, scheme-format
 msgid "~S is not a valid gschem action."
 msgstr ""
 
-#: schematic/scheme/gschem/action.scm:158
 msgid "Repeat Last Action"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:47
 msgid "Cancel"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:53
 #, fuzzy
 msgid "New File"
 msgstr "Yeni Sayfa"
 
-#: schematic/scheme/gschem/builtins.scm:56
 msgid "Open File"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:62
 #, fuzzy
 msgid "Save As"
 msgstr "Tümünü kaydet"
 
-#: schematic/scheme/gschem/builtins.scm:68
 #, fuzzy
 msgid "Print"
 msgstr "Yazdır..."
 
-#: schematic/scheme/gschem/builtins.scm:71
 msgid "Export Image"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:74
 msgid "Run Script"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:80
 #, fuzzy
 msgid "Close Window"
 msgstr "Pencere kapatılıyor\n"
 
-#: schematic/scheme/gschem/builtins.scm:83
 msgid "Quit"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:87
 msgid "Terminal REPL"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:132
 msgid "Choose Slot"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:135
 msgid "Edit Object Properties"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:138
 #, fuzzy
 msgid "Translate Symbol"
 msgstr "Çevir"
 
-#: schematic/scheme/gschem/builtins.scm:147
 msgid "Invoke Macro"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:159
 #, fuzzy
 msgid "Show/Hide Invisible Text"
 msgstr "Metni Göster/Gizle"
 
-#: schematic/scheme/gschem/builtins.scm:165
 #, fuzzy
 msgid "Cut"
 msgstr "1'e Kes"
 
-#: schematic/scheme/gschem/builtins.scm:171
 #, fuzzy
 msgid "Paste"
 msgstr "1'den yapıştır"
 
-#: schematic/scheme/gschem/builtins.scm:177
 msgid "Sidebar"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:183
 #, fuzzy
 msgid "Find Text State"
 msgstr "Metni Düzenle"
 
-#: schematic/scheme/gschem/builtins.scm:186
 msgid "Redraw"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:192
 msgid "Pan Left"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:195
 msgid "Pan Right"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:198
 msgid "Pan Up"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:201
 msgid "Pan Down"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:216
 msgid "Zoom Full"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:219
 msgid "Dark Color Scheme"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:222
 msgid "Light Color Scheme"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:225
 msgid "Monochrome Color Scheme"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:228
 msgid "Show Color Scheme Editor"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:234
 msgid "Revert Changes"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:240
 #, fuzzy
 msgid "Previous Page"
 msgstr "Sayfayı Kapat"
 
-#: schematic/scheme/gschem/builtins.scm:243
 #, fuzzy
 msgid "Next Page"
 msgstr "Yeni Sayfa"
 
-#: schematic/scheme/gschem/builtins.scm:255
 #, fuzzy
 msgid "Print Page"
 msgstr "Sayfayı Kapat"
 
-#: schematic/scheme/gschem/builtins.scm:276
 #, fuzzy
 msgid "Add Line"
 msgstr "Satır"
 
-#: schematic/scheme/gschem/builtins.scm:279
 msgid "Add Path"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:282
 msgid "Add Box"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:285
 #, fuzzy
 msgid "Add Circle"
 msgstr "Daire"
 
-#: schematic/scheme/gschem/builtins.scm:288
 msgid "Add Arc"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:291
 msgid "Add Pin"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:294
 msgid "Add Picture"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:306
 #, fuzzy
 msgid "Up Hierarchy"
 msgstr "Hiyerarşi"
 
-#: schematic/scheme/gschem/builtins.scm:312
 #, fuzzy
 msgid "Attach Attributes"
 msgstr "Öznitelikler"
 
-#: schematic/scheme/gschem/builtins.scm:315
 #, fuzzy
 msgid "Detach Attributes"
 msgstr "Öznitelikler"
 
-#: schematic/scheme/gschem/builtins.scm:318
 #, fuzzy
 msgid "Show Attribute Value"
 msgstr "Öznitelikler"
 
-#: schematic/scheme/gschem/builtins.scm:321
 #, fuzzy
 msgid "Show Attribute Name"
 msgstr "Öznitelikler"
 
-#: schematic/scheme/gschem/builtins.scm:327
 msgid "Toggle Text Visibility"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:330
 msgid "Find Specific Text"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:333
 msgid "Hide Specific Text"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:336
 msgid "Show Specific Text"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:339
 msgid "Autonumber Text"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:345
 #, fuzzy
 msgid "Show Hotkeys"
 msgstr "Kısayollar"
 
-#: schematic/scheme/gschem/builtins.scm:348
 msgid "Switch Grid Style"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:351
 msgid "Switch Snap Mode"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:354
 msgid "Set Grid Spacing"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:357
 msgid "Increase Grid Spacing"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:360
 msgid "Decrease Grid Spacing"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:363
 msgid "Toggle Outline Drawing"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:366
 msgid "Toggle Net Rubber Band"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:369
 msgid "Toggle Magnetic Nets"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:372
 #, fuzzy
 msgid "Show Log Window"
 msgstr "Yeni pencere"
 
-#: schematic/scheme/gschem/builtins.scm:375
 msgid "Show Coordinate Window"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:385
 msgid "Component Documentation"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:387
 msgid "View documentation for selected component"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:403
 msgid ""
 "Could not show documentation for selected component:\n"
 "\n"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:408
 msgid "gEDA Manuals"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:409
 msgid "View the front page of the gEDA documentation in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:414
 msgid "gschem User Guide"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:415
 msgid "View the gschem User Guide in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:420
 msgid "gschem FAQ"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:421
 msgid "Frequently Asked Questions about using gschem."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:426
 msgid "gEDA wiki"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:427
 msgid "View the front page of the gEDA wiki in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:431
 msgid "About gschem"
 msgstr "gschem Hakkında"
 
-#: schematic/scheme/gschem/deprecated.scm:102
 #, scheme-format
 msgid "Invalid text alignment ~A."
 msgstr ""
 
-#: schematic/scheme/gschem/gschemdoc.scm:241
 msgid "No documentation found"
 msgstr ""
 
-#: schematic/scheme/gschem/keymap.scm:40
 #, scheme-format
 msgid "~S is not a valid key combination."
 msgstr ""
 
-#: schematic/scheme/gschem/keymap.scm:157
 #, scheme-format
 msgid "~S is not a prefix key sequence."
 msgstr ""

--- a/schematic/po/zh_CN.po
+++ b/schematic/po/zh_CN.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-15 15:13+0300\n"
+"POT-Creation-Date: 2019-02-22 14:08+0300\n"
 "PO-Revision-Date: 2010-02-11 03:18+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -18,22 +18,18 @@ msgstr ""
 "X-Launchpad-Export-Date: 2010-02-14 12:56+0000\n"
 "X-Generator: Launchpad (build Unknown)\n"
 
-#: schematic/src/a_zoom.c:155
 msgid "Zoom too small!  Cannot zoom further."
 msgstr ""
 
-#: schematic/src/color_edit_widget.c:399
 #, c-format
 msgid ""
 "Could not save file [%s]:\n"
 "%s"
 msgstr ""
 
-#: schematic/src/color_edit_widget.c:434
 msgid "Save Color Scheme As..."
 msgstr ""
 
-#: schematic/src/color_edit_widget.c:482 schematic/src/x_fileselect.c:292
 #, c-format
 msgid ""
 "The selected file `%1$s' already exists.\n"
@@ -41,178 +37,140 @@ msgid ""
 "Would you like to overwrite it?"
 msgstr ""
 
-#: schematic/src/color_edit_widget.c:486 schematic/src/x_fileselect.c:295
 msgid "Overwrite file?"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:211
 msgid "_Apply"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:215
 msgid "Sa_ve..."
 msgstr ""
 
-#: schematic/src/font_select_widget.c:278
 #, c-format
 msgid "<b>Current:</b> %s"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:453
 msgid "Save configuration"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:461
 msgid "Save settings to:"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:465
 msgid "Local configuration file (in current directory)"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:467
 msgid "User configuration file (geda-user.conf)"
 msgstr ""
 
-#: schematic/src/g_attrib.c:90
 msgid "Object ~A is not included in the current gschem page."
 msgstr ""
 
-#: schematic/src/g_attrib.c:110
 msgid "Invalid text name/value visibility ~A."
 msgstr ""
 
-#: schematic/src/g_rc.c:107
 #, c-format
 msgid "You are running gEDA/gaf version [%1$s%2$s.%3$s],\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:111
 #, c-format
 msgid ""
 "but you have a version [%1$s] gschemrc file:\n"
 "[%2$s]\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:114
 #, c-format
 msgid "Please be sure that you have the latest rc file.\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:240
 #, c-format
 msgid "Invalid size [%1$d] passed to text-size\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:283
 #, c-format
 msgid "Invalid size [%1$d] passed to snap-size\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:620
 #, c-format
 msgid "Invalid num levels [%1$d] passed to undo-levels\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:831
 #, c-format
 msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:931
 #, c-format
 msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:972
 #, c-format
 msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:998
 #, c-format
 msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1023
 #, c-format
 msgid "Invalid offset [%1$d] passed to add-attribute-offset\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1047
 #, c-format
 msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1071
 #, c-format
 msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1094
 #, c-format
 msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1118
 #, c-format
 msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1144
 #, c-format
 msgid "Invalid gain [%1$d] passed to zoom-gain\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1169
 #, c-format
 msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
 msgstr ""
 
-#: schematic/src/g_select.c:78 schematic/src/g_select.c:115
-#: schematic/src/g_select.c:151
 msgid "Object ~A is not directly included in a page."
 msgstr ""
 
-#: schematic/src/g_util.c:54
 msgid "Could not launch URI ~S: ~A"
 msgstr ""
 
-#: schematic/src/g_window.c:139
 msgid "Found invalid gschem window smob ~S"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:156
 #, c-format
 msgid "Lepton EDA/lepton-schematic version %1$s%2$s.%3$s git: %4$.7s"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:163
 #, c-format
 msgid "This is the MINGW32 port.\n"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:167
 #, c-format
 msgid "Current locale settings: %1$s\n"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:201
 #, c-format
 msgid "Couldn't find init scm file [%1$s]"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:206
 #, c-format
 msgid "Read init scm file [%1$s]"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:210
 #, c-format
 msgid "Failed to read init scm file [%1$s]"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:290
 #, c-format
 msgid ""
 "ERROR: Failed to load or evaluate startup script.\n"
@@ -220,688 +178,503 @@ msgid ""
 "The lepton-schematic log may contain more information.\n"
 msgstr ""
 
-#: schematic/src/gschem_about_dialog.c:51
 #, c-format
 msgid "%s (git: %.7s)"
 msgstr ""
 
-#: schematic/src/gschem_about_dialog.c:75
 msgid "Lepton Electronic Design Automation"
 msgstr ""
 
-#: schematic/src/gschem_about_dialog.c:83
 msgid ""
 "Copyright © 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright © 2017-2018 Lepton Developers.\n"
-"See AUTHORS and ChangeLog files for details."
+"Copyright © 2017-2019 Lepton Developers.\n"
+"See AUTHORS, ChangeLog files and consult 'git log' history for details."
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:69
 msgid "Upper Left"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:71
 msgid "Upper Middle"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:73
 msgid "Upper Right"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:78
 msgid "Middle Left"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:80
 msgid "Middle Middle"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:82
 msgid "Middle Right"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:87
 msgid "Lower Left"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:89
 msgid "Lower Middle"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:91
 msgid "Lower Right"
 msgstr ""
 
-#: schematic/src/gschem_arc_dialog.c:104
 msgid "Arc Params"
 msgstr ""
 
-#: schematic/src/gschem_arc_dialog.c:140
 msgid "Arc _Radius:"
 msgstr ""
 
-#: schematic/src/gschem_arc_dialog.c:141
 msgid "Start _Angle:"
 msgstr ""
 
-#: schematic/src/gschem_arc_dialog.c:142
 msgid "_Degrees of Sweep:"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:504
 msgid "Left mouse button"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:508
 msgid "Middle mouse button"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:512
 msgid "Right mouse button"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:595
 msgid "(Snap size, Grid size)"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:603
 msgid "Net rubber band mode"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:614
 msgid "Magnetic net mode"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:622
 msgid "Current action mode"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:935
-#: schematic/src/gschem_bottom_widget.c:951
 msgid "OFF"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:954
 msgid "NONE"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:960
 #, c-format
 msgid "Grid(%1$s, %2$s)"
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:350
-#: schematic/src/x_compselect.c:1236 schematic/src/x_multiattrib.c:2068
 msgid "Name"
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:372
 msgid "S_elect the schematics you want to save:"
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:467
 #, c-format
 msgid "Save the changes to schematic \"%1$s\" before closing?"
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:473
 #, c-format
 msgid ""
 "There are %1$d schematics with unsaved changes. Save changes before closing?"
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:502
 msgid "If you don't save, all your changes will be permanently lost."
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:522
 msgid "Close _without saving"
 msgstr ""
 
-#: schematic/src/gschem_coord_dialog.c:86
 msgid "Coords"
 msgstr ""
 
-#: schematic/src/gschem_coord_dialog.c:106
 msgid "Screen"
 msgstr ""
 
-#: schematic/src/gschem_coord_dialog.c:115
 msgid "World"
 msgstr ""
 
-#: schematic/src/gschem_find_text_state.c:809 schematic/src/x_pagesel.c:432
 msgid "Filename"
 msgstr ""
 
-#: schematic/src/gschem_find_text_state.c:821 schematic/src/i_callbacks.c:1970
-#: schematic/src/x_colorcb.c:154 schematic/src/x_widgets.c:179
-#: schematic/src/x_window.c:1226 schematic/src/x_window.c:1440
 msgid "Text"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:427
 msgid "descend into hierarchy"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:435
 msgid "Find"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:557
 #, fuzzy
 msgid "Find Text:"
 msgstr "编辑文本..."
 
-#: schematic/src/gschem_find_text_widget.c:564
 msgid "Find Pattern:"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:571
 msgid "Find Regex:"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:578
 msgid "Check symbol:"
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:200
 msgid "Hotkeys"
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:229
 msgid ""
 "Start typing action name or keystroke to filter the list.\n"
 "Type hotkeys as they are displayed in \"Keystroke(s)\" column."
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:233 schematic/src/x_compselect.c:1124
 #, fuzzy
 msgid "_Filter:"
 msgstr "文件"
 
-#: schematic/src/gschem_hotkey_dialog.c:259 schematic/src/i_basic.c:280
 msgid "Action"
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:277
 msgid "Keystroke(s)"
 msgstr ""
 
-#: schematic/src/gschem_log_widget.c:177
 msgid "** Invalid UTF-8 in log message. See stderr or gschem.log.\n"
 msgstr ""
 
-#: schematic/src/gschem_log_widget.c:434
 #, fuzzy
 msgid "Clear log window?"
 msgstr "关闭窗口"
 
-#: schematic/src/gschem_log_widget.c:477
 #, fuzzy
 msgid "Clear Log _Window"
 msgstr "新建窗口"
 
-#: schematic/src/gschem_macro_widget.c:231
 msgid "Macro:"
 msgstr ""
 
-#: schematic/src/gschem_macro_widget.c:387
 msgid "Evaluate"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:172
 #, fuzzy
 msgid "_Fill Type:"
 msgstr "填充类型..."
 
-#: schematic/src/gschem_object_properties_widget.c:173
 #, fuzzy
 msgid "Lin_e Width:"
 msgstr "线宽和线型..."
 
-#: schematic/src/gschem_object_properties_widget.c:174
 msgid "Angle _1:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:175
 msgid "P_itch 1:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:176
 msgid "Angle _2:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:177
 msgid "Pitc_h 2:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:237
 msgid "<b>Fill Properties</b>"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:255
-#: schematic/src/gschem_text_properties_widget.c:258
-#: schematic/src/x_newtext.c:271
 #, fuzzy
 msgid "Colo_r:"
 msgstr "颜色..."
 
-#: schematic/src/gschem_object_properties_widget.c:266
 msgid "<b>General Properties</b>"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:284
 #, fuzzy
 msgid "_Type:"
 msgstr "填充类型..."
 
-#: schematic/src/gschem_object_properties_widget.c:285
 #, fuzzy
 msgid "_Width:"
 msgstr "线宽和线型..."
 
-#: schematic/src/gschem_object_properties_widget.c:286
 msgid "Dash _Length:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:287
 msgid "Dash _Space:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:288
 msgid "C_ap style:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:333
 msgid "<b>Line Properties</b>"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:351
 #, fuzzy
 msgid "_Pin Type:"
 msgstr "填充类型..."
 
-#: schematic/src/gschem_object_properties_widget.c:362
 msgid "<b>Pin Properties</b>"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:217
 msgid "_Off"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:220
 msgid "_Dots"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:223
 msgid "M_esh"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:245
 msgid "Net R_ubber Band Mode:"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:246
 msgid "_Magnetic Net Mode:"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:250
-#: schematic/src/gschem_options_widget.c:251
 msgid "Enabled"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:265
 msgid "<b>Net Options</b>"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:282
 msgid "Grid Mode:"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:283
 #, fuzzy
 msgid "Snap Mode:"
 msgstr "复制模式"
 
-#: schematic/src/gschem_options_widget.c:284
 #, fuzzy
 msgid "_Snap Size:"
 msgstr "复制模式"
 
-#: schematic/src/gschem_options_widget.c:301
 msgid "<b>Snap Options</b>"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:340
 msgid "O_ff"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:343
 msgid "_Grid"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:346
 msgid "_Resnap"
 msgstr ""
 
-#: schematic/src/gschem_pin_type_combo.c:73
 msgid "Net pin"
 msgstr ""
 
-#: schematic/src/gschem_pin_type_combo.c:80
 msgid "Bus pin (graphical)"
 msgstr ""
 
-#: schematic/src/gschem_preview.c:195
 msgid "Preview Buffer"
 msgstr ""
 
-#: schematic/src/gschem_show_hide_text_widget.c:148
-#: schematic/src/x_window.c:1268
 msgid "Hide"
 msgstr ""
 
-#: schematic/src/gschem_show_hide_text_widget.c:157
-#: schematic/src/x_window.c:1269
 msgid "Hide text starting with:"
 msgstr ""
 
-#: schematic/src/gschem_slot_edit_dialog.c:91
 msgid "Edit slot number"
 msgstr ""
 
-#: schematic/src/gschem_slot_edit_dialog.c:121
 msgid "Number of Slots:"
 msgstr ""
 
-#: schematic/src/gschem_slot_edit_dialog.c:122
 msgid "Slot Number:"
 msgstr ""
 
-#: schematic/src/gschem_text_properties_widget.c:240
-#: schematic/src/x_newtext.c:265
 msgid "<b>Text Content</b>"
 msgstr ""
 
-#: schematic/src/gschem_text_properties_widget.c:259
-#: schematic/src/x_newtext.c:291
 msgid "_Size:"
 msgstr ""
 
-#: schematic/src/gschem_text_properties_widget.c:260
-#: schematic/src/x_newtext.c:310
 msgid "Ali_gnment:"
 msgstr ""
 
-#: schematic/src/gschem_text_properties_widget.c:261
-#: schematic/src/x_newtext.c:330
 #, fuzzy
 msgid "Ro_tation:"
 msgstr "文档"
 
-#: schematic/src/gschem_text_properties_widget.c:294
-#: schematic/src/x_newtext.c:253
 msgid "<b>Text Properties</b>"
 msgstr ""
 
-#: schematic/src/gschem_translate_widget.c:238
 msgid "Coordinate:"
 msgstr ""
 
-#: schematic/src/gschem_translate_widget.c:405 schematic/src/i_callbacks.c:800
 msgid "Translate"
 msgstr ""
 
-#: schematic/src/i_basic.c:64 schematic/src/x_window.c:1369
-#: schematic/scheme/conf/schematic/menu.scm:59
-#: schematic/scheme/gschem/builtins.scm:99
 msgid "Select Mode"
 msgstr "选择模式"
 
-#: schematic/src/i_basic.c:65
 #, fuzzy
 msgid "Select Box Mode"
 msgstr "选择模式"
 
-#: schematic/src/i_basic.c:66
 msgid "Text Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:67
 msgid "Pan Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:70
 #, c-format
 msgid "Paste %d Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:74
 msgid "Magnetic Net Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:76
 msgid "Net Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:77
 msgid "Arc Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:78
 msgid "Box Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:79
 msgid "Bus Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:80
 msgid "Circle Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:81
 msgid "Component Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:82 schematic/scheme/conf/schematic/menu.scm:62
-#: schematic/scheme/gschem/builtins.scm:114
 msgid "Copy Mode"
 msgstr "复制模式"
 
-#: schematic/src/i_basic.c:83 schematic/scheme/conf/schematic/menu.scm:63
-#: schematic/scheme/gschem/builtins.scm:117
 msgid "Multiple Copy Mode"
 msgstr "多重复制模式"
 
-#: schematic/src/i_basic.c:84
 msgid "Line Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:85 schematic/scheme/conf/schematic/menu.scm:66
-#: schematic/scheme/gschem/builtins.scm:123
 msgid "Mirror Mode"
 msgstr "镜像模式"
 
-#: schematic/src/i_basic.c:86 schematic/scheme/conf/schematic/menu.scm:64
-#: schematic/scheme/gschem/builtins.scm:111
 msgid "Move Mode"
 msgstr "移动模式"
 
-#: schematic/src/i_basic.c:87
 #, fuzzy
 msgid "Path Mode"
 msgstr "旋转 90 度"
 
-#: schematic/src/i_basic.c:88
 msgid "Picture Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:89
 msgid "Pin Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:90 schematic/scheme/gschem/builtins.scm:120
 msgid "Rotate Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:91
 #, fuzzy
 msgid "Modify Mode"
 msgstr "复制模式"
 
-#: schematic/src/i_basic.c:92 schematic/src/x_menus.c:49
-#: schematic/scheme/gschem/builtins.scm:204
 msgid "Zoom Box"
 msgstr ""
 
-#: schematic/src/i_basic.c:121
 msgid "Show Hidden"
 msgstr ""
 
-#: schematic/src/i_basic.c:124
 msgid "Snap Off"
 msgstr ""
 
-#: schematic/src/i_basic.c:126
 msgid "Resnap Active"
 msgstr ""
 
-#: schematic/src/i_basic.c:288 schematic/src/x_colorcb.c:159
 msgid "Stroke"
 msgstr ""
 
-#: schematic/src/i_basic.c:296 schematic/src/i_basic.c:330
-#: schematic/src/x_window.c:1361
 msgid "none"
 msgstr ""
 
-#: schematic/src/i_basic.c:304
 msgid "Repeat/"
 msgstr ""
 
-#: schematic/src/i_basic.c:315
 msgid "Repeat/none"
 msgstr ""
 
-#: schematic/src/i_basic.c:323 schematic/src/i_callbacks.c:1239
-#: schematic/scheme/gschem/builtins.scm:189
 msgid "Pan"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:74
 #, c-format
 msgid "New page created [%1$s]"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:108
 #, c-format
 msgid "New Window created [%1$s]"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:245
 msgid "Failed to Save All"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:247
 msgid "Saved All"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:308
 #, fuzzy
 msgid "Closing Window"
 msgstr "关闭窗口"
 
-#: schematic/src/i_callbacks.c:505 schematic/src/x_menus.c:55
-#: schematic/scheme/gschem/builtins.scm:168
 msgid "Copy"
 msgstr "复制"
 
-#: schematic/src/i_callbacks.c:514 schematic/src/i_callbacks.c:539
-#: schematic/src/i_callbacks.c:564
 msgid "Select objs first"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:530
 msgid "Multiple Copy"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:555 schematic/src/x_menus.c:56
 msgid "Move"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:579 schematic/src/x_menus.c:57
-#: schematic/src/x_multiattrib.c:1656 schematic/scheme/gschem/builtins.scm:108
 msgid "Delete"
 msgstr "删除"
 
-#: schematic/src/i_callbacks.c:603
 msgid "Edit"
 msgstr "编辑"
 
-#: schematic/src/i_callbacks.c:618 schematic/scheme/gschem/builtins.scm:129
 msgid "Edit Text"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:637
 msgid "Slot"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:688 schematic/src/i_callbacks.c:698
 msgid "Rotate"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:736 schematic/src/i_callbacks.c:746
 msgid "Mirror"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:763 schematic/src/x_colorcb.c:160
-#: schematic/scheme/conf/schematic/menu.scm:73
-#: schematic/scheme/gschem/builtins.scm:141
 msgid "Lock"
 msgstr "锁定"
 
-#: schematic/src/i_callbacks.c:781 schematic/scheme/conf/schematic/menu.scm:74
-#: schematic/scheme/gschem/builtins.scm:144
 msgid "Unlock"
 msgstr "解锁"
 
-#: schematic/src/i_callbacks.c:805
 msgid "WARNING: Do not translate with snap off!"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:806
 msgid "WARNING: Turning snap on and continuing with translate."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:813
 msgid "WARNING: Snap grid size is not equal to 100!"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:815
 msgid ""
 "WARNING: If you are translating a symbol to the origin, the snap grid size "
 "should be set to 100"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:847
 msgid "Embed"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:886
 msgid "Unembed"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:928
 msgid "Update"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:970
 msgid "ShowHidden"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1537
 #, c-format
 msgid ""
 "<b>Revert page:</b>\n"
@@ -912,99 +685,77 @@ msgid ""
 "discarded and page file will be reloaded from disk."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1555
 #, fuzzy
 msgid "Revert"
 msgstr "翻转页面"
 
-#: schematic/src/i_callbacks.c:1647
 msgid "Copy to clipboard"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1664
 msgid "Cut to clipboard"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1686
 msgid "Paste from clipboard"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1694
 msgid "Empty clipboard"
 msgstr ""
 
 #. TRANSLATORS: The number is the number of the buffer that the
 #. * selection is being copied to.
-#: schematic/src/i_callbacks.c:1719
 #, fuzzy, c-format
 msgid "Copy %i"
 msgstr "复制"
 
 #. TRANSLATORS: The number is the number of the buffer that the
 #. * selection is being cut to.
-#: schematic/src/i_callbacks.c:1746
 #, fuzzy, c-format
 msgid "Cut %i"
 msgstr "剪切到 1"
 
 #. TRANSLATORS: The number is the number of the buffer that is being
 #. * pasted to the schematic.
-#: schematic/src/i_callbacks.c:1776
 #, fuzzy, c-format
 msgid "Paste %i"
 msgstr "粘贴"
 
-#: schematic/src/i_callbacks.c:1785
 msgid "Empty buffer"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1833 schematic/src/x_window.c:1203
 msgid "Component"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1865 schematic/src/x_colorcb.c:150
 msgid "Attribute"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1885 schematic/src/x_colorcb.c:149
 msgid "Net"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1928 schematic/src/x_colorcb.c:155
-#: schematic/src/x_window.c:1222
 msgid "Bus"
 msgstr "总线"
 
-#: schematic/src/i_callbacks.c:2004
 msgid "Line"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2021
 msgid "Path"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2043
 msgid "Box"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2085
 msgid "Circle"
 msgstr "圆"
 
-#: schematic/src/i_callbacks.c:2108
 msgid "Arc"
 msgstr "弧线"
 
-#: schematic/src/i_callbacks.c:2131 schematic/src/x_colorcb.c:146
 msgid "Pin"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2191
 #, c-format
 msgid "Searching for source [%1$s]"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2223
 #, c-format
 msgid ""
 "Failed to descend hierarchy into '%1$s': %2$s\n"
@@ -1012,106 +763,81 @@ msgid ""
 "The lepton-schematic log may contain more information."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2227
 #, c-format
 msgid "Failed to descend into '%1$s': %2$s"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2234
 msgid "Failed to descend hierarchy."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2312
 #, c-format
 msgid "Searching for symbol [%1$s]"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2320
 msgid "Symbol is not a real file. Symbol cannot be loaded."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2367 schematic/src/x_tabs.c:1060
 msgid "Cannot find any schematics above the current one!"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2400
 msgid "Attach"
 msgstr "连接"
 
-#: schematic/src/i_callbacks.c:2456
 msgid "Detach"
 msgstr "脱离"
 
-#: schematic/src/i_callbacks.c:2500
 msgid "ShowN"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2537
 msgid "ShowV"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2574
 msgid "ShowB"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2612
 msgid "VisToggle"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2643
 #, c-format
 msgid "Sorry but this is a non-functioning menu option\n"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2703
 msgid "Action feedback mode set to OUTLINE"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2706
 msgid "Action feedback mode set to BOUNDINGBOX"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2730
 msgid "Grid OFF"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2731
 msgid "Dot grid selected"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2732
 msgid "Mesh grid selected"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2733
 msgid "Invalid grid mode"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2755
 msgid "Snap OFF (CAUTION!)"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2758
 msgid "Snap ON"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2761
 msgid "Snap back to the grid (CAUTION!)"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2790
 msgid "Rubber band ON"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2792
 msgid "Rubber band OFF"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2811
 msgid "magnetic net mode: ON"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2814
 msgid "magnetic net mode: OFF"
 msgstr ""
 
@@ -1120,134 +846,105 @@ msgstr ""
 #. the form "untitled_N.sch", where N is a number.  Please make
 #. sure that the translation contains characters suitable for use
 #. in a filename.
-#: schematic/src/i_vars.c:209
 msgid "untitled"
 msgstr ""
 
-#: schematic/src/o_complex.c:192 schematic/src/o_complex.c:195
 #, c-format
 msgid "Translating schematic [%1$d %2$d]"
 msgstr ""
 
-#: schematic/src/o_delete.c:82
 #, c-format
 msgid "Delete locked object?"
 msgid_plural "Delete %1$u locked objects?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/o_misc.c:55
 #, c-format
 msgid "Got an unexpected NULL in o_edit\n"
 msgstr ""
 
-#: schematic/src/o_misc.c:315
 msgid "Hidden text is now visible"
 msgstr ""
 
-#: schematic/src/o_misc.c:317
 msgid "Hidden text is now invisible"
 msgstr ""
 
-#: schematic/src/o_misc.c:425
 #, c-format
 msgid "Could not find symbol [%1$s] in library. Update failed."
 msgstr ""
 
-#: schematic/src/o_misc.c:541
 #, c-format
 msgid "o_autosave_backups: Can't get the real filename of %1$s."
 msgstr ""
 
-#: schematic/src/o_misc.c:585
 #, c-format
 msgid "Could NOT set previous backup file [%1$s] read-write"
 msgstr ""
 
-#: schematic/src/o_misc.c:605
 #, c-format
 msgid "Could NOT set backup file [%1$s] readonly"
 msgstr ""
 
-#: schematic/src/o_misc.c:610
 #, c-format
 msgid "Could NOT save backup file [%1$s]"
 msgstr ""
 
-#: schematic/src/o_move.c:192
 #, c-format
 msgid "ERROR: NULL object in o_move_end!\n"
 msgstr ""
 
-#: schematic/src/o_move.c:519
 #, c-format
 msgid "DOH! tried to find the whichone, but didn't find it!\n"
 msgstr ""
 
-#: schematic/src/o_move.c:546
 #, c-format
 msgid "Got a non line object in o_move_check_endpoint\n"
 msgstr ""
 
-#: schematic/src/o_net.c:444
 msgid "Warning: Starting net at off grid coordinate"
 msgstr ""
 
-#: schematic/src/o_net.c:508
 msgid "Warning: Ending net at off grid coordinate"
 msgstr ""
 
-#: schematic/src/o_net.c:856 schematic/src/o_net.c:893
-#: schematic/src/o_net.c:964 schematic/src/o_net.c:1000
 #, c-format
 msgid "Tried to add more than two bus rippers. Internal gschem error.\n"
 msgstr ""
 
-#: schematic/src/o_net.c:1068
 #, c-format
 msgid "Bus ripper symbol [%1$s] was not found in any component library"
 msgstr ""
 
-#: schematic/src/o_picture.c:133 schematic/src/o_picture.c:343
 msgid "Select a picture file..."
 msgstr ""
 
-#: schematic/src/o_picture.c:166
 #, c-format
 msgid "Failed to load picture: %1$s"
 msgstr ""
 
-#: schematic/src/o_picture.c:182
 msgid "Picture"
 msgstr ""
 
-#: schematic/src/o_picture.c:378
 #, c-format
 msgid "Failed to replace pictures: %s"
 msgstr ""
 
-#: schematic/src/o_slot.c:80
 #, fuzzy
 msgid "Slot attribute malformed"
 msgstr "属性"
 
-#: schematic/src/o_slot.c:88
 msgid "numslots attribute missing"
 msgstr ""
 
-#: schematic/src/o_slot.c:89
 msgid "Slotting not allowed for this component"
 msgstr ""
 
-#: schematic/src/o_slot.c:104
 msgid "New slot number out of range"
 msgstr ""
 
-#: schematic/src/o_undo.c:397
 msgid "Undo/Redo disabled in rc file"
 msgstr ""
 
-#: schematic/src/parsecmd.c:77
 #, c-format
 msgid ""
 "Usage: %1$s [OPTION ...] [--] [FILE ...]\n"
@@ -1272,188 +969,144 @@ msgid ""
 "gEDA/gaf homepage: <http://www.geda-project.org/>\n"
 msgstr ""
 
-#: schematic/src/parsecmd.c:110
 #, c-format
 msgid ""
 "Lepton EDA %1$s (git: %2$.7s)\n"
 "Copyright (C) 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright (C) 2017-2018 Lepton Developers.\n"
+"Copyright (C) 2017-2019 Lepton Developers.\n"
 "This is free software, and you are welcome to redistribute it under\n"
 "certain conditions. For details, see the file `COPYING', which is\n"
 "included in the Lepton EDA distribution.\n"
 "There is NO WARRANTY, to the extent permitted by law.\n"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:125
 #, c-format
 msgid "Got invalid show option; defaulting to show both\n"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:139
 #, c-format
 msgid "ERROR: NULL object!\n"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:328
 msgid "Single Attribute Editor"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:358
 msgid "<b>Edit Attribute</b>"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:360
 msgid "<b>Add Attribute</b>"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:376
 msgid "N_ame:"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:396 schematic/src/x_multiattrib.c:2222
 #, fuzzy
 msgid "_Value:"
 msgstr "显示数值"
 
-#: schematic/src/x_attribedit.c:415 schematic/src/x_multiattrib.c:2281
 msgid "Vi_sible"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:434
 msgid "Show Value Only"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:436
 msgid "Show Name Only"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:438 schematic/src/x_multiattrib.c:1620
-#: schematic/scheme/gschem/builtins.scm:324
 msgid "Show Name & Value"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:445
 msgid "<b>Attach Options</b>"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:460
 msgid "All"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:476 schematic/src/x_compselect.c:986
-#: schematic/src/x_compselect.c:1100
 msgid "Components"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:492 schematic/src/x_window.c:1214
 msgid "Nets"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:508
 msgid "Replace existing attributes"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:412
 msgid ""
 "slotted object without slot attribute may cause problems when autonumbering "
 "slots"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:427
 #, c-format
 msgid ""
 "duplicate slot may cause problems: [symbolname=%1$s, number=%2$d, slot=%3$d]"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:675
 msgid "No searchstring given in autonumber text."
 msgstr ""
 
-#: schematic/src/x_autonumber.c:728
 msgid "No '*' or '?' given at the end of the autonumber text."
 msgstr ""
 
-#: schematic/src/x_autonumber.c:873
 msgid "Diagonal"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:874
 msgid "Top to bottom"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:875
 msgid "Bottom to top"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:876
 msgid "Left to right"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:877
 msgid "Right to left"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:878
 msgid "File order"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1214
 msgid "Autonumber text"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1237
 msgid "<b>Scope</b>"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1259
 msgid "Search for:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1273
 msgid "Autonumber text in:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1280
 msgid "Skip numbers found in:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1292 schematic/src/x_autonumber.c:1301
 msgid "Selected objects"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1293 schematic/src/x_autonumber.c:1302
 msgid "Current page"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1294 schematic/src/x_autonumber.c:1303
 msgid "Whole hierarchy"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1305
 msgid "Overwrite existing numbers"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1310
 msgid "<b>Options</b>"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1332
 msgid "Starting number:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1339
 msgid "Sort order:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1371
 msgid "Remove numbers"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1375
 msgid "Automatic slotting"
 msgstr ""
 
-#: schematic/src/x_clipboard.c:245
 #, c-format
 msgid ""
 "<b>Invalid schematic on clipboard.</b>\n"
@@ -1461,174 +1114,134 @@ msgid ""
 "An error occurred while inserting clipboard data: %s."
 msgstr ""
 
-#: schematic/src/x_clipboard.c:247
 msgid "Clipboard insertion failed"
 msgstr ""
 
-#: schematic/src/x_color.c:89 schematic/src/x_color.c:98
 #, c-format
 msgid "Could not allocate the color %1$s!\n"
 msgstr ""
 
-#: schematic/src/x_color.c:89
 msgid "black"
 msgstr ""
 
-#: schematic/src/x_color.c:98
 msgid "white"
 msgstr ""
 
-#: schematic/src/x_color.c:120
 #, c-format
 msgid "Could not allocate display color %1$i!\n"
 msgstr ""
 
-#: schematic/src/x_color.c:142
 #, c-format
 msgid "Could not allocate outline color %1$i!\n"
 msgstr ""
 
-#: schematic/src/x_color.c:159
 #, c-format
 msgid "Tried to get an invalid color: %1$d\n"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:145
 msgid "Background"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:147
 msgid "Net endpoint"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:148
 msgid "Graphic"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:151
 msgid "Logic bubble"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:152
 msgid "Grid point"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:153
 #, fuzzy
 msgid "Detached attribute"
 msgstr "属性"
 
-#: schematic/src/x_colorcb.c:156
 #, fuzzy
 msgid "Selection"
 msgstr "选择模式"
 
-#: schematic/src/x_colorcb.c:157
 msgid "Bounding box"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:158
 #, fuzzy
 msgid "Zoom box"
 msgstr "放大"
 
-#: schematic/src/x_colorcb.c:161
 msgid "Output background"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:162
 msgid "Freestyle 1"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:163
 msgid "Freestyle 2"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:164
 msgid "Freestyle 3"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:165
 msgid "Freestyle 4"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:166
 msgid "Net junction"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:167
 msgid "Mesh grid major"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:168
 msgid "Mesh grid minor"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:172
 msgid "Unknown"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1169
 #, fuzzy
 msgid "Reset filter"
 msgstr "最近打开的文件"
 
-#: schematic/src/x_compselect.c:1192
 msgid "Reload all libraries"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1245 schematic/src/x_multiattrib.c:2092
 msgid "Value"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1284
 msgid "Default behavior - reference component"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1287
 msgid "Embed component in schematic"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1290
 msgid "Include component as individual objects"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1448
 msgid "Select Component..."
 msgstr ""
 
-#: schematic/src/x_compselect.c:1471
 msgid "In Us_e"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1475
 msgid "Lib_raries"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1484 schematic/src/x_fileselect.c:119
 msgid "Preview"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1510
 msgid "Attributes"
 msgstr "属性"
 
-#: schematic/src/x_dialog.c:325
 msgid "Major symbol changes detected."
 msgstr ""
 
-#: schematic/src/x_dialog.c:349
 msgid ""
 "Changes have occurred to the symbols shown below.\n"
 "\n"
 "Be sure to verify each of these symbols."
 msgstr ""
 
-#: schematic/src/x_dialog.c:369
 msgid "Symbol"
 msgstr ""
 
-#: schematic/src/x_dialog.c:406
 #, c-format
 msgid ""
 "<span weight=\"bold\" size=\"larger\">The input attribute \"%s\" is invalid\n"
@@ -1639,39 +1252,30 @@ msgid ""
 "The value cannot start with a space."
 msgstr ""
 
-#: schematic/src/x_dialog.c:408
 msgid "Invalid Attribute"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:37
 msgid "Schematics"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:42
 msgid "Symbols"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:47
 msgid "Schematics and symbols"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:53
 msgid "All files"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:169
 msgid "Open..."
 msgstr ""
 
-#: schematic/src/x_fileselect.c:233
 msgid "Save as..."
 msgstr ""
 
-#: schematic/src/x_fileselect.c:297
 msgid "Save cancelled on user request"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:334
 msgid ""
 "\n"
 "If you load the original file, the backup file will be overwritten in the "
@@ -1680,28 +1284,22 @@ msgid ""
 "Do you want to load the backup file?\n"
 msgstr ""
 
-#: schematic/src/x_fstylecb.c:73
 msgid "Hollow"
 msgstr ""
 
-#: schematic/src/x_fstylecb.c:80
 msgid "Filled"
 msgstr ""
 
-#: schematic/src/x_fstylecb.c:87
 msgid "Mesh"
 msgstr ""
 
-#: schematic/src/x_fstylecb.c:94
 msgid "Hatch"
 msgstr ""
 
-#: schematic/src/x_image.c:279
 #, c-format
 msgid "x_image_lowlevel: Unable to write %1$s file %2$s."
 msgstr ""
 
-#: schematic/src/x_image.c:289
 #, c-format
 msgid ""
 "There was the following error when saving image with type %1$s to filename:\n"
@@ -1710,302 +1308,235 @@ msgid ""
 "%3$s.\n"
 msgstr ""
 
-#: schematic/src/x_image.c:309
 #, c-format
 msgid "Wrote color image to [%1$s] [%2$d x %3$d]"
 msgstr ""
 
-#: schematic/src/x_image.c:311
 #, c-format
 msgid "Wrote black and white image to [%1$s] [%2$d x %3$d]"
 msgstr ""
 
-#: schematic/src/x_image.c:319
 msgid "x_image_lowlevel: Unable to get pixbuf from gschem's window."
 msgstr ""
 
-#: schematic/src/x_image.c:358
 msgid "Width x Height"
 msgstr ""
 
-#: schematic/src/x_image.c:374
 msgid "Image type"
 msgstr ""
 
-#: schematic/src/x_image.c:395
 msgid "Write image..."
 msgstr "写入图片..."
 
-#: schematic/src/x_linecapcb.c:74
 msgid "Butt"
 msgstr ""
 
-#: schematic/src/x_linecapcb.c:81
 msgid "Square"
 msgstr ""
 
-#: schematic/src/x_linecapcb.c:88
 msgid "Round"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:74
 msgid "Solid"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:81
 msgid "Dotted"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:88
 msgid "Dashed"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:95
 msgid "Center"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:102
 msgid "Phantom"
 msgstr ""
 
-#: schematic/src/x_menus.c:41 schematic/scheme/gschem/builtins.scm:267
 msgid "Add Net"
 msgstr ""
 
-#: schematic/src/x_menus.c:42 schematic/src/x_multiattrib.c:2187
-#: schematic/scheme/gschem/builtins.scm:264
 msgid "Add Attribute"
 msgstr ""
 
-#: schematic/src/x_menus.c:43 schematic/scheme/gschem/builtins.scm:261
 #, fuzzy
 msgid "Add Component"
 msgstr "更新组件"
 
-#: schematic/src/x_menus.c:44 schematic/scheme/gschem/builtins.scm:270
 msgid "Add Bus"
 msgstr ""
 
-#: schematic/src/x_menus.c:45 schematic/scheme/gschem/builtins.scm:273
 #, fuzzy
 msgid "Add Text"
 msgstr "编辑文本..."
 
-#: schematic/src/x_menus.c:47 schematic/scheme/gschem/builtins.scm:210
 #, fuzzy
 msgid "Zoom In"
 msgstr "放大"
 
-#: schematic/src/x_menus.c:48 schematic/scheme/gschem/builtins.scm:213
 #, fuzzy
 msgid "Zoom Out"
 msgstr "缩小"
 
-#: schematic/src/x_menus.c:50 schematic/scheme/gschem/builtins.scm:207
 #, fuzzy
 msgid "Zoom Extents"
 msgstr "放大"
 
-#: schematic/src/x_menus.c:52 schematic/src/x_window.c:1233
 msgid "Select"
 msgstr ""
 
-#: schematic/src/x_menus.c:53 schematic/scheme/conf/schematic/menu.scm:69
-#: schematic/scheme/gschem/builtins.scm:126
 msgid "Edit..."
 msgstr "编辑..."
 
-#: schematic/src/x_menus.c:54 schematic/scheme/conf/schematic/menu.scm:68
 msgid "Object Properties..."
 msgstr ""
 
-#: schematic/src/x_menus.c:59 schematic/scheme/gschem/builtins.scm:300
 msgid "Down Schematic"
 msgstr ""
 
-#: schematic/src/x_menus.c:60 schematic/scheme/gschem/builtins.scm:303
 msgid "Down Symbol"
 msgstr ""
 
-#: schematic/src/x_menus.c:61
 msgid "Up"
 msgstr ""
 
-#: schematic/src/x_menus.c:336
 #, c-format
 msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
 msgstr ""
 
-#: schematic/src/x_menus.c:360
 #, c-format
 msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
 msgstr ""
 
-#: schematic/src/x_misc.c:70
 msgid "The operating system is out of memory or resources."
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:798 schematic/src/x_multiattrib.c:2704
 msgid "<various>"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:930
 msgid "Attributes with empty name are not allowed. Please set a name."
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1622
 msgid "Show Value only"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1624
 msgid "Show Name only"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1651
 msgid "Promote"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1655
 msgid "Duplicate"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1657
 #, fuzzy
 msgid "Copy to all"
 msgstr "复制到 1"
 
-#: schematic/src/x_multiattrib.c:1986 schematic/src/x_multiattrib.c:2602
 msgid "Edit Attributes"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2112
 msgid "Vis?"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2130
 msgid "N"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2148
 msgid "V"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2170
 #, fuzzy
 msgid "Sho_w inherited attributes"
 msgstr "属性"
 
-#: schematic/src/x_multiattrib.c:2197
 #, fuzzy
 msgid "_Name:"
 msgstr "显示名称"
 
-#: schematic/src/x_multiattrib.c:2241
 msgid "Ctrl+Enter inserts new line; Ctrl+Tab inserts Tab"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2618
 #, c-format
 msgid "%2$i symbol (%1$s)"
 msgid_plural "%2$i symbols (%1$s)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2624
 #, c-format
 msgid "%1$i pin"
 msgid_plural "%1$i pins"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2630
 #, c-format
 msgid "%1$i net"
 msgid_plural "%1$i nets"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2636
 #, c-format
 msgid "%1$i bus"
 msgid_plural "%1$i buses"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2642
 #, fuzzy, c-format
 msgid "%1$i attribute"
 msgid_plural "%1$i attributes"
 msgstr[0] "属性"
 msgstr[1] "属性"
 
-#: schematic/src/x_newtext.c:433
 #, fuzzy
 msgid "Text Entry..."
 msgstr "文本..."
 
-#: schematic/src/x_pagesel.c:253
 msgid "New Page"
 msgstr "新建页面"
 
-#: schematic/src/x_pagesel.c:254
 msgid "Open Page..."
 msgstr "打开页面..."
 
-#: schematic/src/x_pagesel.c:256
 msgid "Save Page"
 msgstr "保存页面"
 
-#: schematic/src/x_pagesel.c:257 schematic/scheme/gschem/builtins.scm:246
 msgid "Close Page"
 msgstr "关闭页面"
 
-#: schematic/src/x_pagesel.c:376 schematic/scheme/gschem/builtins.scm:237
 msgid "Page Manager"
 msgstr ""
 
-#: schematic/src/x_pagesel.c:448
 msgid "Changed"
 msgstr ""
 
-#: schematic/src/x_pagesel.c:468
 msgid "Right click on the filename for more options..."
 msgstr ""
 
-#: schematic/src/x_print.c:306
 #, c-format
 msgid "Failed to write PDF to '%s': %s\n"
 msgstr ""
 
-#: schematic/src/x_print.c:364
 #, c-format
 msgid "Failed to write PDF to '%1$s': %2$s\n"
 msgstr ""
 
-#: schematic/src/x_print.c:449
 #, c-format
 msgid ""
 "Error printing file:\n"
 "%1$s"
 msgstr ""
 
-#: schematic/src/x_rc.c:39
 msgid "ERROR: An unknown error occurred while parsing configuration files."
 msgstr ""
 
-#: schematic/src/x_rc.c:44
 msgid ""
 "An unknown error occurred while parsing configuration files.\n"
 "\n"
 "The lepton-schematic log may contain more information."
 msgstr ""
 
-#: schematic/src/x_rc.c:56
 #, c-format
 msgid "ERROR: %1$s"
 msgstr ""
 
-#: schematic/src/x_rc.c:59
 #, c-format
 msgid ""
 "%1$s\n"
@@ -2013,138 +1544,107 @@ msgid ""
 "The lepton-schematic log may contain more information."
 msgstr ""
 
-#: schematic/src/x_rc.c:67
 msgid "Cannot load lepton-schematic configuration."
 msgstr ""
 
-#: schematic/src/x_script.c:42 schematic/scheme/conf/schematic/menu.scm:40
 msgid "Execute Script..."
 msgstr "执行脚本..."
 
-#: schematic/src/x_script.c:61
 #, c-format
 msgid "Executing guile script [%1$s]"
 msgstr ""
 
-#: schematic/src/x_tabs.c:860
 #, fuzzy, c-format
 msgid "Hierarchy up: %s"
 msgstr "层次"
 
-#: schematic/src/x_tabs.c:863
 #, fuzzy
 msgid "Hierarchy up"
 msgstr "层次"
 
-#: schematic/src/x_widgets.c:158 schematic/src/x_window.c:1444
 msgid "Options"
 msgstr ""
 
-#: schematic/src/x_widgets.c:203 schematic/src/x_window.c:1436
 msgid "Object"
 msgstr ""
 
-#: schematic/src/x_widgets.c:224
 msgid "Log"
 msgstr ""
 
-#: schematic/src/x_widgets.c:245 schematic/src/x_window.c:1466
 msgid "Find Text"
 msgstr ""
 
-#: schematic/src/x_widgets.c:259
 msgid "Color Scheme Editor"
 msgstr ""
 
-#: schematic/src/x_widgets.c:272 schematic/scheme/gschem/builtins.scm:378
 #, fuzzy
 msgid "Select Schematic Font"
 msgstr "选择模式"
 
-#: schematic/src/x_window.c:763
 #, c-format
 msgid "Loading schematic [%1$s]"
 msgstr ""
 
-#: schematic/src/x_window.c:864
 #, c-format
 msgid "Could NOT save page [%1$s]\n"
 msgstr ""
 
-#: schematic/src/x_window.c:865
 msgid "Error while trying to save"
 msgstr ""
 
-#: schematic/src/x_window.c:875
 msgid "Failed to save file"
 msgstr ""
 
-#: schematic/src/x_window.c:885
 #, fuzzy, c-format
 msgid "Saved as [%1$s]"
 msgstr "全部保存"
 
-#: schematic/src/x_window.c:887
 #, fuzzy, c-format
 msgid "Saved [%1$s]"
 msgstr "全部保存"
 
-#: schematic/src/x_window.c:889
 msgid "Saved"
 msgstr ""
 
-#: schematic/src/x_window.c:966
 #, c-format
 msgid "Discarding page [%1$s]"
 msgstr ""
 
-#: schematic/src/x_window.c:966
 #, c-format
 msgid "Closing [%1$s]"
 msgstr ""
 
-#: schematic/src/x_window.c:1175
 msgid "New"
 msgstr "新建"
 
-#: schematic/src/x_window.c:1175
 msgid "New file"
 msgstr ""
 
-#: schematic/src/x_window.c:1179
 msgid "Open"
 msgstr ""
 
-#: schematic/src/x_window.c:1179
 #, fuzzy
 msgid "Open file"
 msgstr "文件"
 
-#: schematic/src/x_window.c:1183 schematic/scheme/gschem/builtins.scm:59
 msgid "Save"
 msgstr ""
 
-#: schematic/src/x_window.c:1183
 msgid "Save file"
 msgstr ""
 
-#: schematic/src/x_window.c:1189 schematic/scheme/gschem/builtins.scm:93
 msgid "Undo"
 msgstr "撤销"
 
-#: schematic/src/x_window.c:1189
 msgid "Undo last operation"
 msgstr ""
 
-#: schematic/src/x_window.c:1193 schematic/scheme/gschem/builtins.scm:96
 msgid "Redo"
 msgstr "重做"
 
-#: schematic/src/x_window.c:1193
 msgid "Redo last undo"
 msgstr ""
 
-#: schematic/src/x_window.c:1198
 msgid ""
 "Add component...\n"
 "Select library and component from list, move the mouse into main window, "
@@ -2152,56 +1652,44 @@ msgid ""
 "Right mouse button to cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1209
 msgid ""
 "Add nets mode\n"
 "Right mouse button to cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1217
 msgid ""
 "Add buses mode\n"
 "Right mouse button to cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1226
 msgid "Add Text..."
 msgstr ""
 
-#: schematic/src/x_window.c:1233
 msgid "Select mode"
 msgstr ""
 
-#: schematic/src/x_window.c:1288
 msgid "Show"
 msgstr ""
 
-#: schematic/src/x_window.c:1289
 msgid "Show text starting with:"
 msgstr ""
 
-#: schematic/src/x_window.c:1345
 msgid "Menu/Cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1349
 msgid "Pan/Cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1359
 msgid "Pick"
 msgstr ""
 
-#: schematic/src/x_window.c:1470 schematic/scheme/gschem/builtins.scm:180
 msgid "Status"
 msgstr ""
 
-#: schematic/src/x_window.c:1568
 #, fuzzy, c-format
 msgid "New file [%s]"
 msgstr "文件"
 
-#: schematic/src/x_window.c:1598
 #, c-format
 msgid ""
 "<b>An error occurred while loading the requested file.</b>\n"
@@ -2215,904 +1703,694 @@ msgid ""
 "monitor program's output in terminal window."
 msgstr ""
 
-#: schematic/src/x_window.c:1617
 msgid "Failed to load file"
 msgstr ""
 
-#: schematic/data/lepton-schematic.desktop.in:3
 msgid "Lepton EDA Schematic Editor"
 msgstr ""
 
-#: schematic/data/lepton-schematic.desktop.in:4
 msgid "Create and edit electrical schematics and symbols with lepton-schematic"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:27
 #, fuzzy
 msgid "_New"
 msgstr "新建"
 
-#: schematic/scheme/conf/schematic/menu.scm:28
 #, fuzzy
 msgid "_Open..."
 msgstr "打开页面..."
 
-#: schematic/scheme/conf/schematic/menu.scm:30
 msgid "Open Recen_t"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:32
 #, fuzzy
 msgid "_Save"
 msgstr "全部保存"
 
-#: schematic/scheme/conf/schematic/menu.scm:33
 #, fuzzy
 msgid "Save _As..."
 msgstr "页面保存为..."
 
-#: schematic/scheme/conf/schematic/menu.scm:34
-#: schematic/scheme/gschem/builtins.scm:65
 msgid "Save All"
 msgstr "全部保存"
 
-#: schematic/scheme/conf/schematic/menu.scm:36
 #, fuzzy
 msgid "_Print..."
 msgstr "打印..."
 
-#: schematic/scheme/conf/schematic/menu.scm:37
 #, fuzzy
 msgid "Write _Image..."
 msgstr "写入图片..."
 
-#: schematic/scheme/conf/schematic/menu.scm:39
 msgid "Invoke Macro..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:41
 msgid "REPL..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:43
-#: schematic/scheme/gschem/builtins.scm:77
 msgid "New Window"
 msgstr "新建窗口"
 
-#: schematic/scheme/conf/schematic/menu.scm:44
 #, fuzzy
 msgid "_Close Window"
 msgstr "关闭窗口"
 
-#: schematic/scheme/conf/schematic/menu.scm:45
 #, fuzzy
 msgid "_Quit"
 msgstr "退出"
 
-#: schematic/scheme/conf/schematic/menu.scm:51
 #, fuzzy
 msgid "_Undo"
 msgstr "撤销"
 
-#: schematic/scheme/conf/schematic/menu.scm:52
 #, fuzzy
 msgid "_Redo"
 msgstr "重做"
 
-#: schematic/scheme/conf/schematic/menu.scm:54
 #, fuzzy
 msgid "Cu_t"
 msgstr "剪切"
 
-#: schematic/scheme/conf/schematic/menu.scm:55
 #, fuzzy
 msgid "_Copy"
 msgstr "复制"
 
-#: schematic/scheme/conf/schematic/menu.scm:56
 #, fuzzy
 msgid "_Paste"
 msgstr "粘贴"
 
-#: schematic/scheme/conf/schematic/menu.scm:57
 #, fuzzy
 msgid "_Delete"
 msgstr "删除"
 
-#: schematic/scheme/conf/schematic/menu.scm:60
-#: schematic/scheme/gschem/builtins.scm:102
 #, fuzzy
 msgid "Select All"
 msgstr "选择模式"
 
-#: schematic/scheme/conf/schematic/menu.scm:61
-#: schematic/scheme/gschem/builtins.scm:105
 msgid "Deselect"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:65
 msgid "Rotate 90 Mode"
 msgstr "旋转 90 度"
 
-#: schematic/scheme/conf/schematic/menu.scm:70
 msgid "Edit Text..."
 msgstr "编辑文本..."
 
-#: schematic/scheme/conf/schematic/menu.scm:71
 msgid "Slot..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:76
-#: schematic/scheme/gschem/builtins.scm:150
 msgid "Embed Component/Picture"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:77
-#: schematic/scheme/gschem/builtins.scm:153
 msgid "Unembed Component/Picture"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:78
-#: schematic/scheme/gschem/builtins.scm:156
 msgid "Update Component"
 msgstr "更新组件"
 
-#: schematic/scheme/conf/schematic/menu.scm:79
 msgid "Symbol Translate..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:85
 msgid "Copy into 1"
 msgstr "复制到 1"
 
-#: schematic/scheme/conf/schematic/menu.scm:86
 msgid "Copy into 2"
 msgstr "复制到 2"
 
-#: schematic/scheme/conf/schematic/menu.scm:87
 msgid "Copy into 3"
 msgstr "复制到 3"
 
-#: schematic/scheme/conf/schematic/menu.scm:88
 msgid "Copy into 4"
 msgstr "复制到 4"
 
-#: schematic/scheme/conf/schematic/menu.scm:89
 msgid "Copy into 5"
 msgstr "复制到 5"
 
-#: schematic/scheme/conf/schematic/menu.scm:90
 msgid "Cut into 1"
 msgstr "剪切到 1"
 
-#: schematic/scheme/conf/schematic/menu.scm:91
 msgid "Cut into 2"
 msgstr "剪切到 2"
 
-#: schematic/scheme/conf/schematic/menu.scm:92
 msgid "Cut into 3"
 msgstr "剪切到 3"
 
-#: schematic/scheme/conf/schematic/menu.scm:93
 msgid "Cut into 4"
 msgstr "剪切到 4"
 
-#: schematic/scheme/conf/schematic/menu.scm:94
 msgid "Cut into 5"
 msgstr "剪切到 5"
 
-#: schematic/scheme/conf/schematic/menu.scm:95
 msgid "Paste from 1"
 msgstr "粘贴自 1"
 
-#: schematic/scheme/conf/schematic/menu.scm:96
 msgid "Paste from 2"
 msgstr "粘贴自 2"
 
-#: schematic/scheme/conf/schematic/menu.scm:97
 msgid "Paste from 3"
 msgstr "粘贴自 3"
 
-#: schematic/scheme/conf/schematic/menu.scm:98
 msgid "Paste from 4"
 msgstr "粘贴自 4"
 
-#: schematic/scheme/conf/schematic/menu.scm:99
 msgid "Paste from 5"
 msgstr "粘贴自 5"
 
-#: schematic/scheme/conf/schematic/menu.scm:105
 msgid "Side Dock"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:106
 msgid "Bottom Dock"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:108
 #, fuzzy
 msgid "Find Text Results"
 msgstr "编辑文本..."
 
-#: schematic/scheme/conf/schematic/menu.scm:110
 #, fuzzy
 msgid "_Redraw"
 msgstr "重画"
 
-#: schematic/scheme/conf/schematic/menu.scm:111
 msgid "_Pan"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:112
 #, fuzzy
 msgid "Zoom _Box"
 msgstr "放大"
 
-#: schematic/scheme/conf/schematic/menu.scm:113
 #, fuzzy
 msgid "Zoom _Extents"
 msgstr "放大"
 
-#: schematic/scheme/conf/schematic/menu.scm:114
 #, fuzzy
 msgid "Zoom _In"
 msgstr "放大"
 
-#: schematic/scheme/conf/schematic/menu.scm:115
 #, fuzzy
 msgid "Zoom _Out"
 msgstr "缩小"
 
-#: schematic/scheme/conf/schematic/menu.scm:116
 #, fuzzy
 msgid "Zoom _Full"
 msgstr "缩小"
 
-#: schematic/scheme/conf/schematic/menu.scm:118
 msgid "_Dark Color Scheme"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:119
 msgid "_Light Color Scheme"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:120
 msgid "B_W Color Scheme"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:122
 msgid "Color Scheme Editor..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:129
 #, fuzzy
 msgid "_Manager..."
 msgstr "打开页面..."
 
-#: schematic/scheme/conf/schematic/menu.scm:131
 #, fuzzy
 msgid "_Previous"
 msgstr "上一个"
 
-#: schematic/scheme/conf/schematic/menu.scm:132
 #, fuzzy
 msgid "_Next"
 msgstr "下一个"
 
-#: schematic/scheme/conf/schematic/menu.scm:133
 #, fuzzy
 msgid "_Close"
 msgstr "关闭"
 
-#: schematic/scheme/conf/schematic/menu.scm:135
 #, fuzzy
 msgid "_Revert..."
 msgstr "翻转页面"
 
-#: schematic/scheme/conf/schematic/menu.scm:137
-#: schematic/scheme/gschem/builtins.scm:249
 #, fuzzy
 msgid "Next Tab"
 msgstr "新建页面"
 
-#: schematic/scheme/conf/schematic/menu.scm:138
-#: schematic/scheme/gschem/builtins.scm:252
 #, fuzzy
 msgid "Previous Tab"
 msgstr "上一个"
 
-#: schematic/scheme/conf/schematic/menu.scm:146
 #, fuzzy
 msgid "_Component..."
 msgstr "组件..."
 
-#: schematic/scheme/conf/schematic/menu.scm:148
 #, fuzzy
 msgid "_Net"
 msgstr "下一个"
 
-#: schematic/scheme/conf/schematic/menu.scm:149
 #, fuzzy
 msgid "B_us"
 msgstr "总线"
 
-#: schematic/scheme/conf/schematic/menu.scm:151
 #, fuzzy
 msgid "_Attribute..."
 msgstr "属性..."
 
-#: schematic/scheme/conf/schematic/menu.scm:152
 #, fuzzy
 msgid "_Text..."
 msgstr "文本..."
 
-#: schematic/scheme/conf/schematic/menu.scm:154
 msgid "_Line"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:155
 msgid "Pat_h"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:156
 msgid "_Box"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:157
 #, fuzzy
 msgid "C_ircle"
 msgstr "圆"
 
-#: schematic/scheme/conf/schematic/menu.scm:158
 #, fuzzy
 msgid "A_rc"
 msgstr "弧线"
 
-#: schematic/scheme/conf/schematic/menu.scm:159
 msgid "_Pin"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:161
 #, fuzzy
 msgid "Pictu_re..."
 msgstr "图片..."
 
-#: schematic/scheme/conf/schematic/menu.scm:167
 msgid "_Up"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:169
 msgid "_Down Schematic"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:170
 msgid "Down _Symbol"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:176
 #, fuzzy
 msgid "_Attach"
 msgstr "连接"
 
-#: schematic/scheme/conf/schematic/menu.scm:177
 #, fuzzy
 msgid "_Detach"
 msgstr "脱离"
 
-#: schematic/scheme/conf/schematic/menu.scm:179
 #, fuzzy
 msgid "Show _Value"
 msgstr "显示数值"
 
-#: schematic/scheme/conf/schematic/menu.scm:180
 #, fuzzy
 msgid "Show _Name"
 msgstr "显示名称"
 
-#: schematic/scheme/conf/schematic/menu.scm:181
 #, fuzzy
 msgid "Show _Both"
 msgstr "都显示"
 
-#: schematic/scheme/conf/schematic/menu.scm:182
 #, fuzzy
 msgid "_Toggle Visibility"
 msgstr "变换可见性"
 
-#: schematic/scheme/conf/schematic/menu.scm:184
 msgid "_Hide Specific Text..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:185
 msgid "_Show Specific Text..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:186
 msgid "Show/Hide Hidden Text"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:188
 msgid "_Find Text/Check Symbol..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:189
 msgid "A_utonumber Text..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:195
 msgid "_Options..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:196
 #, fuzzy
 msgid "_Font..."
 msgstr "打印..."
 
-#: schematic/scheme/conf/schematic/menu.scm:198
 msgid "Grid +"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:199
 msgid "Grid -"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:201
 msgid "Grid Style: Cycle Dots/Mesh/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:202
 msgid "Grid Snap: Cycle Grid/Resnap/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:204
 msgid "Feedback Mode: Outline/Box"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:205
 msgid "Net: Rubberband On/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:206
 msgid "Net: Magnetic On/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:208
 #, fuzzy
 msgid "_Coord Window"
 msgstr "关闭窗口"
 
-#: schematic/scheme/conf/schematic/menu.scm:209
 #, fuzzy
 msgid "_Log Window"
 msgstr "新建窗口"
 
-#: schematic/scheme/conf/schematic/menu.scm:215
 msgid "_1 allegro"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:223
 msgid "User _Guide"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:224
 msgid "_FAQ"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:225
 #, fuzzy
 msgid "Docu_mentation"
 msgstr "文档"
 
-#: schematic/scheme/conf/schematic/menu.scm:226
 msgid "_Wiki"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:228
 #, fuzzy
 msgid "Find Component D_ocumentation"
 msgstr "文档"
 
-#: schematic/scheme/conf/schematic/menu.scm:230
 msgid "_Hotkeys..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:231
 #, fuzzy
 msgid "_About"
 msgstr "属性..."
 
-#: schematic/scheme/conf/schematic/menu.scm:237
 #, fuzzy
 msgid "_File"
 msgstr "文件"
 
-#: schematic/scheme/conf/schematic/menu.scm:238
 #, fuzzy
 msgid "_Edit"
 msgstr "编辑"
 
-#: schematic/scheme/conf/schematic/menu.scm:240
 #, fuzzy
 msgid "_View"
 msgstr "查看"
 
-#: schematic/scheme/conf/schematic/menu.scm:241
 #, fuzzy
 msgid "_Page"
 msgstr "页面"
 
-#: schematic/scheme/conf/schematic/menu.scm:242
 #, fuzzy
 msgid "_Add"
 msgstr "添加"
 
-#: schematic/scheme/conf/schematic/menu.scm:243
 #, fuzzy
 msgid "Hie_rarchy"
 msgstr "层次"
 
-#: schematic/scheme/conf/schematic/menu.scm:244
 #, fuzzy
 msgid "A_ttributes"
 msgstr "属性"
 
-#: schematic/scheme/conf/schematic/menu.scm:245
 msgid "_Options"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:246
 #, fuzzy
 msgid "_Netlist"
 msgstr "下一个"
 
-#: schematic/scheme/conf/schematic/menu.scm:247
 msgid "_Help"
 msgstr ""
 
-#: schematic/scheme/gschem/action.scm:43
 #, scheme-format
 msgid "~S is not a valid gschem action."
 msgstr ""
 
-#: schematic/scheme/gschem/action.scm:158
 msgid "Repeat Last Action"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:47
 msgid "Cancel"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:53
 #, fuzzy
 msgid "New File"
 msgstr "文件"
 
-#: schematic/scheme/gschem/builtins.scm:56
 #, fuzzy
 msgid "Open File"
 msgstr "文件"
 
-#: schematic/scheme/gschem/builtins.scm:62
 #, fuzzy
 msgid "Save As"
 msgstr "全部保存"
 
-#: schematic/scheme/gschem/builtins.scm:68
 #, fuzzy
 msgid "Print"
 msgstr "打印..."
 
-#: schematic/scheme/gschem/builtins.scm:71
 msgid "Export Image"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:74
 msgid "Run Script"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:80
 #, fuzzy
 msgid "Close Window"
 msgstr "关闭窗口"
 
-#: schematic/scheme/gschem/builtins.scm:83
 #, fuzzy
 msgid "Quit"
 msgstr "退出"
 
-#: schematic/scheme/gschem/builtins.scm:87
 msgid "Terminal REPL"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:132
 msgid "Choose Slot"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:135
 msgid "Edit Object Properties"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:138
 msgid "Translate Symbol"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:147
 msgid "Invoke Macro"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:159
 msgid "Show/Hide Invisible Text"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:165
 #, fuzzy
 msgid "Cut"
 msgstr "剪切"
 
-#: schematic/scheme/gschem/builtins.scm:171
 #, fuzzy
 msgid "Paste"
 msgstr "粘贴"
 
-#: schematic/scheme/gschem/builtins.scm:177
 msgid "Sidebar"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:183
 #, fuzzy
 msgid "Find Text State"
 msgstr "编辑文本..."
 
-#: schematic/scheme/gschem/builtins.scm:186
 #, fuzzy
 msgid "Redraw"
 msgstr "重画"
 
-#: schematic/scheme/gschem/builtins.scm:192
 msgid "Pan Left"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:195
 msgid "Pan Right"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:198
 msgid "Pan Up"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:201
 msgid "Pan Down"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:216
 #, fuzzy
 msgid "Zoom Full"
 msgstr "缩小"
 
-#: schematic/scheme/gschem/builtins.scm:219
 msgid "Dark Color Scheme"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:222
 msgid "Light Color Scheme"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:225
 msgid "Monochrome Color Scheme"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:228
 msgid "Show Color Scheme Editor"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:234
 msgid "Revert Changes"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:240
 #, fuzzy
 msgid "Previous Page"
 msgstr "上一个"
 
-#: schematic/scheme/gschem/builtins.scm:243
 #, fuzzy
 msgid "Next Page"
 msgstr "新建页面"
 
-#: schematic/scheme/gschem/builtins.scm:255
 #, fuzzy
 msgid "Print Page"
 msgstr "上一个"
 
-#: schematic/scheme/gschem/builtins.scm:276
 msgid "Add Line"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:279
 msgid "Add Path"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:282
 msgid "Add Box"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:285
 #, fuzzy
 msgid "Add Circle"
 msgstr "圆"
 
-#: schematic/scheme/gschem/builtins.scm:288
 msgid "Add Arc"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:291
 msgid "Add Pin"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:294
 #, fuzzy
 msgid "Add Picture"
 msgstr "图片..."
 
-#: schematic/scheme/gschem/builtins.scm:306
 #, fuzzy
 msgid "Up Hierarchy"
 msgstr "层次"
 
-#: schematic/scheme/gschem/builtins.scm:312
 #, fuzzy
 msgid "Attach Attributes"
 msgstr "属性"
 
-#: schematic/scheme/gschem/builtins.scm:315
 #, fuzzy
 msgid "Detach Attributes"
 msgstr "属性"
 
-#: schematic/scheme/gschem/builtins.scm:318
 #, fuzzy
 msgid "Show Attribute Value"
 msgstr "显示数值"
 
-#: schematic/scheme/gschem/builtins.scm:321
 #, fuzzy
 msgid "Show Attribute Name"
 msgstr "属性"
 
-#: schematic/scheme/gschem/builtins.scm:327
 #, fuzzy
 msgid "Toggle Text Visibility"
 msgstr "变换可见性"
 
-#: schematic/scheme/gschem/builtins.scm:330
 msgid "Find Specific Text"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:333
 msgid "Hide Specific Text"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:336
 msgid "Show Specific Text"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:339
 msgid "Autonumber Text"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:345
 #, fuzzy
 msgid "Show Hotkeys"
 msgstr "都显示"
 
-#: schematic/scheme/gschem/builtins.scm:348
 msgid "Switch Grid Style"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:351
 msgid "Switch Snap Mode"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:354
 msgid "Set Grid Spacing"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:357
 msgid "Increase Grid Spacing"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:360
 msgid "Decrease Grid Spacing"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:363
 msgid "Toggle Outline Drawing"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:366
 msgid "Toggle Net Rubber Band"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:369
 msgid "Toggle Magnetic Nets"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:372
 #, fuzzy
 msgid "Show Log Window"
 msgstr "新建窗口"
 
-#: schematic/scheme/gschem/builtins.scm:375
 msgid "Show Coordinate Window"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:385
 #, fuzzy
 msgid "Component Documentation"
 msgstr "文档"
 
-#: schematic/scheme/gschem/builtins.scm:387
 msgid "View documentation for selected component"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:403
 msgid ""
 "Could not show documentation for selected component:\n"
 "\n"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:408
 msgid "gEDA Manuals"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:409
 msgid "View the front page of the gEDA documentation in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:414
 msgid "gschem User Guide"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:415
 msgid "View the gschem User Guide in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:420
 msgid "gschem FAQ"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:421
 msgid "Frequently Asked Questions about using gschem."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:426
 msgid "gEDA wiki"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:427
 msgid "View the front page of the gEDA wiki in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:431
 msgid "About gschem"
 msgstr ""
 
-#: schematic/scheme/gschem/deprecated.scm:102
 #, scheme-format
 msgid "Invalid text alignment ~A."
 msgstr ""
 
-#: schematic/scheme/gschem/gschemdoc.scm:241
 #, fuzzy
 msgid "No documentation found"
 msgstr "文档"
 
-#: schematic/scheme/gschem/keymap.scm:40
 #, scheme-format
 msgid "~S is not a valid key combination."
 msgstr ""
 
-#: schematic/scheme/gschem/keymap.scm:157
 #, scheme-format
 msgid "~S is not a prefix key sequence."
 msgstr ""

--- a/schematic/po/zh_TW.po
+++ b/schematic/po/zh_TW.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-15 15:13+0300\n"
+"POT-Creation-Date: 2019-02-22 14:08+0300\n"
 "PO-Revision-Date: 2012-01-27 14:22+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -18,24 +18,20 @@ msgstr ""
 "X-Launchpad-Export-Date: 2012-11-14 16:52+0000\n"
 "X-Generator: Launchpad (build 16265)\n"
 
-#: schematic/src/a_zoom.c:155
 #, fuzzy
 msgid "Zoom too small!  Cannot zoom further."
 msgstr "已經縮到最小了，無法再縮小囉！\n"
 
-#: schematic/src/color_edit_widget.c:399
 #, fuzzy, c-format
 msgid ""
 "Could not save file [%s]:\n"
 "%s"
 msgstr "無法儲存備份檔 [%s]\n"
 
-#: schematic/src/color_edit_widget.c:434
 #, fuzzy
 msgid "Save Color Scheme As..."
 msgstr "白色背景"
 
-#: schematic/src/color_edit_widget.c:482 schematic/src/x_fileselect.c:292
 #, c-format
 msgid ""
 "The selected file `%1$s' already exists.\n"
@@ -43,178 +39,140 @@ msgid ""
 "Would you like to overwrite it?"
 msgstr ""
 
-#: schematic/src/color_edit_widget.c:486 schematic/src/x_fileselect.c:295
 msgid "Overwrite file?"
 msgstr "覆蓋檔案？"
 
-#: schematic/src/font_select_widget.c:211
 msgid "_Apply"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:215
 msgid "Sa_ve..."
 msgstr ""
 
-#: schematic/src/font_select_widget.c:278
 #, c-format
 msgid "<b>Current:</b> %s"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:453
 msgid "Save configuration"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:461
 msgid "Save settings to:"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:465
 msgid "Local configuration file (in current directory)"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:467
 msgid "User configuration file (geda-user.conf)"
 msgstr ""
 
-#: schematic/src/g_attrib.c:90
 msgid "Object ~A is not included in the current gschem page."
 msgstr ""
 
-#: schematic/src/g_attrib.c:110
 msgid "Invalid text name/value visibility ~A."
 msgstr ""
 
-#: schematic/src/g_rc.c:107
 #, fuzzy, c-format
 msgid "You are running gEDA/gaf version [%1$s%2$s.%3$s],\n"
 msgstr "gEDA/gschem 版本 %s%s.%s\n"
 
-#: schematic/src/g_rc.c:111
 #, c-format
 msgid ""
 "but you have a version [%1$s] gschemrc file:\n"
 "[%2$s]\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:114
 #, c-format
 msgid "Please be sure that you have the latest rc file.\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:240
 #, c-format
 msgid "Invalid size [%1$d] passed to text-size\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:283
 #, c-format
 msgid "Invalid size [%1$d] passed to snap-size\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:620
 #, c-format
 msgid "Invalid num levels [%1$d] passed to undo-levels\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:831
 #, c-format
 msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:931
 #, c-format
 msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:972
 #, c-format
 msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:998
 #, c-format
 msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1023
 #, c-format
 msgid "Invalid offset [%1$d] passed to add-attribute-offset\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1047
 #, c-format
 msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1071
 #, c-format
 msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1094
 #, c-format
 msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1118
 #, c-format
 msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1144
 #, c-format
 msgid "Invalid gain [%1$d] passed to zoom-gain\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:1169
 #, c-format
 msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
 msgstr ""
 
-#: schematic/src/g_select.c:78 schematic/src/g_select.c:115
-#: schematic/src/g_select.c:151
 msgid "Object ~A is not directly included in a page."
 msgstr ""
 
-#: schematic/src/g_util.c:54
 msgid "Could not launch URI ~S: ~A"
 msgstr ""
 
-#: schematic/src/g_window.c:139
 msgid "Found invalid gschem window smob ~S"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:156
 #, fuzzy, c-format
 msgid "Lepton EDA/lepton-schematic version %1$s%2$s.%3$s git: %4$.7s"
 msgstr "gEDA/gschem 版本 %s%s.%s\n"
 
-#: schematic/src/lepton-schematic.c:163
 #, c-format
 msgid "This is the MINGW32 port.\n"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:167
 #, fuzzy, c-format
 msgid "Current locale settings: %1$s\n"
 msgstr "目前的語系設定: %s\n"
 
-#: schematic/src/lepton-schematic.c:201
 #, c-format
 msgid "Couldn't find init scm file [%1$s]"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:206
 #, c-format
 msgid "Read init scm file [%1$s]"
 msgstr ""
 
-#: schematic/src/lepton-schematic.c:210
 #, fuzzy, c-format
 msgid "Failed to read init scm file [%1$s]"
 msgstr "讀取檔案失敗"
 
-#: schematic/src/lepton-schematic.c:290
 #, c-format
 msgid ""
 "ERROR: Failed to load or evaluate startup script.\n"
@@ -222,697 +180,512 @@ msgid ""
 "The lepton-schematic log may contain more information.\n"
 msgstr ""
 
-#: schematic/src/gschem_about_dialog.c:51
 #, c-format
 msgid "%s (git: %.7s)"
 msgstr ""
 
-#: schematic/src/gschem_about_dialog.c:75
 msgid "Lepton Electronic Design Automation"
 msgstr ""
 
-#: schematic/src/gschem_about_dialog.c:83
 msgid ""
 "Copyright © 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright © 2017-2018 Lepton Developers.\n"
-"See AUTHORS and ChangeLog files for details."
+"Copyright © 2017-2019 Lepton Developers.\n"
+"See AUTHORS, ChangeLog files and consult 'git log' history for details."
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:69
 msgid "Upper Left"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:71
 msgid "Upper Middle"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:73
 msgid "Upper Right"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:78
 msgid "Middle Left"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:80
 msgid "Middle Middle"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:82
 msgid "Middle Right"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:87
 msgid "Lower Left"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:89
 msgid "Lower Middle"
 msgstr ""
 
-#: schematic/src/gschem_alignment_combo.c:91
 msgid "Lower Right"
 msgstr ""
 
-#: schematic/src/gschem_arc_dialog.c:104
 msgid "Arc Params"
 msgstr ""
 
-#: schematic/src/gschem_arc_dialog.c:140
 msgid "Arc _Radius:"
 msgstr ""
 
-#: schematic/src/gschem_arc_dialog.c:141
 msgid "Start _Angle:"
 msgstr ""
 
-#: schematic/src/gschem_arc_dialog.c:142
 msgid "_Degrees of Sweep:"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:504
 msgid "Left mouse button"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:508
 msgid "Middle mouse button"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:512
 msgid "Right mouse button"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:595
 msgid "(Snap size, Grid size)"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:603
 msgid "Net rubber band mode"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:614
 msgid "Magnetic net mode"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:622
 msgid "Current action mode"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:935
-#: schematic/src/gschem_bottom_widget.c:951
 msgid "OFF"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:954
 msgid "NONE"
 msgstr ""
 
-#: schematic/src/gschem_bottom_widget.c:960
 #, fuzzy, c-format
 msgid "Grid(%1$s, %2$s)"
 msgstr "網格(%s, %s)"
 
-#: schematic/src/gschem_close_confirmation_dialog.c:350
-#: schematic/src/x_compselect.c:1236 schematic/src/x_multiattrib.c:2068
 msgid "Name"
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:372
 msgid "S_elect the schematics you want to save:"
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:467
 #, c-format
 msgid "Save the changes to schematic \"%1$s\" before closing?"
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:473
 #, c-format
 msgid ""
 "There are %1$d schematics with unsaved changes. Save changes before closing?"
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:502
 msgid "If you don't save, all your changes will be permanently lost."
 msgstr ""
 
-#: schematic/src/gschem_close_confirmation_dialog.c:522
 msgid "Close _without saving"
 msgstr ""
 
-#: schematic/src/gschem_coord_dialog.c:86
 msgid "Coords"
 msgstr ""
 
-#: schematic/src/gschem_coord_dialog.c:106
 msgid "Screen"
 msgstr ""
 
-#: schematic/src/gschem_coord_dialog.c:115
 msgid "World"
 msgstr ""
 
-#: schematic/src/gschem_find_text_state.c:809 schematic/src/x_pagesel.c:432
 msgid "Filename"
 msgstr ""
 
-#: schematic/src/gschem_find_text_state.c:821 schematic/src/i_callbacks.c:1970
-#: schematic/src/x_colorcb.c:154 schematic/src/x_widgets.c:179
-#: schematic/src/x_window.c:1226 schematic/src/x_window.c:1440
 msgid "Text"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:427
 msgid "descend into hierarchy"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:435
 msgid "Find"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:557
 #, fuzzy
 msgid "Find Text:"
 msgstr "新增文字"
 
-#: schematic/src/gschem_find_text_widget.c:564
 msgid "Find Pattern:"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:571
 msgid "Find Regex:"
 msgstr ""
 
-#: schematic/src/gschem_find_text_widget.c:578
 msgid "Check symbol:"
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:200
 msgid "Hotkeys"
 msgstr "熱鍵"
 
-#: schematic/src/gschem_hotkey_dialog.c:229
 msgid ""
 "Start typing action name or keystroke to filter the list.\n"
 "Type hotkeys as they are displayed in \"Keystroke(s)\" column."
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:233 schematic/src/x_compselect.c:1124
 #, fuzzy
 msgid "_Filter:"
 msgstr "檔案"
 
-#: schematic/src/gschem_hotkey_dialog.c:259 schematic/src/i_basic.c:280
 msgid "Action"
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:277
 msgid "Keystroke(s)"
 msgstr ""
 
-#: schematic/src/gschem_log_widget.c:177
 msgid "** Invalid UTF-8 in log message. See stderr or gschem.log.\n"
 msgstr ""
 
-#: schematic/src/gschem_log_widget.c:434
 #, fuzzy
 msgid "Clear log window?"
 msgstr "開新視窗"
 
-#: schematic/src/gschem_log_widget.c:477
 #, fuzzy
 msgid "Clear Log _Window"
 msgstr "開新視窗"
 
-#: schematic/src/gschem_macro_widget.c:231
 msgid "Macro:"
 msgstr ""
 
-#: schematic/src/gschem_macro_widget.c:387
 msgid "Evaluate"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:172
 #, fuzzy
 msgid "_Fill Type:"
 msgstr "編輯文字"
 
-#: schematic/src/gschem_object_properties_widget.c:173
 #, fuzzy
 msgid "Lin_e Width:"
 msgstr "直線模式"
 
-#: schematic/src/gschem_object_properties_widget.c:174
 msgid "Angle _1:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:175
 msgid "P_itch 1:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:176
 msgid "Angle _2:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:177
 msgid "Pitc_h 2:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:237
 #, fuzzy
 msgid "<b>Fill Properties</b>"
 msgstr "<b>選項</b>"
 
-#: schematic/src/gschem_object_properties_widget.c:255
-#: schematic/src/gschem_text_properties_widget.c:258
-#: schematic/src/x_newtext.c:271
 #, fuzzy
 msgid "Colo_r:"
 msgstr "變更顏色"
 
-#: schematic/src/gschem_object_properties_widget.c:266
 msgid "<b>General Properties</b>"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:284
 #, fuzzy
 msgid "_Type:"
 msgstr "編輯文字"
 
-#: schematic/src/gschem_object_properties_widget.c:285
 #, fuzzy
 msgid "_Width:"
 msgstr "直線模式"
 
-#: schematic/src/gschem_object_properties_widget.c:286
 msgid "Dash _Length:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:287
 msgid "Dash _Space:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:288
 msgid "C_ap style:"
 msgstr ""
 
-#: schematic/src/gschem_object_properties_widget.c:333
 #, fuzzy
 msgid "<b>Line Properties</b>"
 msgstr "<b>選項</b>"
 
-#: schematic/src/gschem_object_properties_widget.c:351
 #, fuzzy
 msgid "_Pin Type:"
 msgstr "編輯文字"
 
-#: schematic/src/gschem_object_properties_widget.c:362
 #, fuzzy
 msgid "<b>Pin Properties</b>"
 msgstr "<b>選項</b>"
 
-#: schematic/src/gschem_options_widget.c:217
 msgid "_Off"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:220
 msgid "_Dots"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:223
 msgid "M_esh"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:245
 msgid "Net R_ubber Band Mode:"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:246
 msgid "_Magnetic Net Mode:"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:250
-#: schematic/src/gschem_options_widget.c:251
 msgid "Enabled"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:265
 #, fuzzy
 msgid "<b>Net Options</b>"
 msgstr "<b>選項</b>"
 
-#: schematic/src/gschem_options_widget.c:282
 #, fuzzy
 msgid "Grid Mode:"
 msgstr "弧線模式"
 
-#: schematic/src/gschem_options_widget.c:283
 #, fuzzy
 msgid "Snap Mode:"
 msgstr "複製模式"
 
-#: schematic/src/gschem_options_widget.c:284
 #, fuzzy
 msgid "_Snap Size:"
 msgstr "複製模式"
 
-#: schematic/src/gschem_options_widget.c:301
 #, fuzzy
 msgid "<b>Snap Options</b>"
 msgstr "<b>選項</b>"
 
-#: schematic/src/gschem_options_widget.c:340
 msgid "O_ff"
 msgstr ""
 
-#: schematic/src/gschem_options_widget.c:343
 #, fuzzy
 msgid "_Grid"
 msgstr "關閉網格\n"
 
-#: schematic/src/gschem_options_widget.c:346
 msgid "_Resnap"
 msgstr ""
 
-#: schematic/src/gschem_pin_type_combo.c:73
 msgid "Net pin"
 msgstr ""
 
-#: schematic/src/gschem_pin_type_combo.c:80
 msgid "Bus pin (graphical)"
 msgstr ""
 
-#: schematic/src/gschem_preview.c:195
 msgid "Preview Buffer"
 msgstr ""
 
-#: schematic/src/gschem_show_hide_text_widget.c:148
-#: schematic/src/x_window.c:1268
 msgid "Hide"
 msgstr ""
 
-#: schematic/src/gschem_show_hide_text_widget.c:157
-#: schematic/src/x_window.c:1269
 msgid "Hide text starting with:"
 msgstr ""
 
-#: schematic/src/gschem_slot_edit_dialog.c:91
 msgid "Edit slot number"
 msgstr ""
 
-#: schematic/src/gschem_slot_edit_dialog.c:121
 msgid "Number of Slots:"
 msgstr ""
 
-#: schematic/src/gschem_slot_edit_dialog.c:122
 msgid "Slot Number:"
 msgstr ""
 
-#: schematic/src/gschem_text_properties_widget.c:240
-#: schematic/src/x_newtext.c:265
 #, fuzzy
 msgid "<b>Text Content</b>"
 msgstr "<b>選項</b>"
 
-#: schematic/src/gschem_text_properties_widget.c:259
-#: schematic/src/x_newtext.c:291
 msgid "_Size:"
 msgstr ""
 
-#: schematic/src/gschem_text_properties_widget.c:260
-#: schematic/src/x_newtext.c:310
 msgid "Ali_gnment:"
 msgstr ""
 
-#: schematic/src/gschem_text_properties_widget.c:261
-#: schematic/src/x_newtext.c:330
 #, fuzzy
 msgid "Ro_tation:"
 msgstr "旋轉"
 
-#: schematic/src/gschem_text_properties_widget.c:294
-#: schematic/src/x_newtext.c:253
 #, fuzzy
 msgid "<b>Text Properties</b>"
 msgstr "<b>選項</b>"
 
-#: schematic/src/gschem_translate_widget.c:238
 msgid "Coordinate:"
 msgstr ""
 
-#: schematic/src/gschem_translate_widget.c:405 schematic/src/i_callbacks.c:800
 msgid "Translate"
 msgstr ""
 
-#: schematic/src/i_basic.c:64 schematic/src/x_window.c:1369
-#: schematic/scheme/conf/schematic/menu.scm:59
-#: schematic/scheme/gschem/builtins.scm:99
 msgid "Select Mode"
 msgstr "選擇模式"
 
-#: schematic/src/i_basic.c:65
 #, fuzzy
 msgid "Select Box Mode"
 msgstr "選擇模式"
 
-#: schematic/src/i_basic.c:66
 msgid "Text Mode"
 msgstr "文字模式"
 
-#: schematic/src/i_basic.c:67
 msgid "Pan Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:70
 #, c-format
 msgid "Paste %d Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:74
 msgid "Magnetic Net Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:76
 msgid "Net Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:77
 msgid "Arc Mode"
 msgstr "弧線模式"
 
-#: schematic/src/i_basic.c:78
 msgid "Box Mode"
 msgstr "矩形模式"
 
-#: schematic/src/i_basic.c:79
 msgid "Bus Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:80
 msgid "Circle Mode"
 msgstr "圓形模式"
 
-#: schematic/src/i_basic.c:81
 msgid "Component Mode"
 msgstr "元件模式"
 
-#: schematic/src/i_basic.c:82 schematic/scheme/conf/schematic/menu.scm:62
-#: schematic/scheme/gschem/builtins.scm:114
 msgid "Copy Mode"
 msgstr "複製模式"
 
-#: schematic/src/i_basic.c:83 schematic/scheme/conf/schematic/menu.scm:63
-#: schematic/scheme/gschem/builtins.scm:117
 msgid "Multiple Copy Mode"
 msgstr "多重複製模式"
 
-#: schematic/src/i_basic.c:84
 msgid "Line Mode"
 msgstr "直線模式"
 
-#: schematic/src/i_basic.c:85 schematic/scheme/conf/schematic/menu.scm:66
-#: schematic/scheme/gschem/builtins.scm:123
 msgid "Mirror Mode"
 msgstr "水平鏡射"
 
-#: schematic/src/i_basic.c:86 schematic/scheme/conf/schematic/menu.scm:64
-#: schematic/scheme/gschem/builtins.scm:111
 msgid "Move Mode"
 msgstr "移動元件"
 
-#: schematic/src/i_basic.c:87
 #, fuzzy
 msgid "Path Mode"
 msgstr "旋轉模式"
 
-#: schematic/src/i_basic.c:88
 msgid "Picture Mode"
 msgstr "圖片模式"
 
-#: schematic/src/i_basic.c:89
 msgid "Pin Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:90 schematic/scheme/gschem/builtins.scm:120
 msgid "Rotate Mode"
 msgstr "旋轉模式"
 
-#: schematic/src/i_basic.c:91
 #, fuzzy
 msgid "Modify Mode"
 msgstr "複製模式"
 
-#: schematic/src/i_basic.c:92 schematic/src/x_menus.c:49
-#: schematic/scheme/gschem/builtins.scm:204
 msgid "Zoom Box"
 msgstr ""
 
-#: schematic/src/i_basic.c:121
 msgid "Show Hidden"
 msgstr ""
 
-#: schematic/src/i_basic.c:124
 msgid "Snap Off"
 msgstr ""
 
-#: schematic/src/i_basic.c:126
 msgid "Resnap Active"
 msgstr ""
 
-#: schematic/src/i_basic.c:288 schematic/src/x_colorcb.c:159
 msgid "Stroke"
 msgstr ""
 
-#: schematic/src/i_basic.c:296 schematic/src/i_basic.c:330
-#: schematic/src/x_window.c:1361
 msgid "none"
 msgstr ""
 
-#: schematic/src/i_basic.c:304
 msgid "Repeat/"
 msgstr ""
 
-#: schematic/src/i_basic.c:315
 msgid "Repeat/none"
 msgstr ""
 
-#: schematic/src/i_basic.c:323 schematic/src/i_callbacks.c:1239
-#: schematic/scheme/gschem/builtins.scm:189
 msgid "Pan"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:74
 #, c-format
 msgid "New page created [%1$s]"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:108
 #, c-format
 msgid "New Window created [%1$s]"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:245
 msgid "Failed to Save All"
 msgstr "儲存全部失敗"
 
-#: schematic/src/i_callbacks.c:247
 msgid "Saved All"
 msgstr "儲存全部"
 
-#: schematic/src/i_callbacks.c:308
 #, fuzzy
 msgid "Closing Window"
 msgstr "開新視窗"
 
-#: schematic/src/i_callbacks.c:505 schematic/src/x_menus.c:55
-#: schematic/scheme/gschem/builtins.scm:168
 msgid "Copy"
 msgstr "複製"
 
-#: schematic/src/i_callbacks.c:514 schematic/src/i_callbacks.c:539
-#: schematic/src/i_callbacks.c:564
 msgid "Select objs first"
 msgstr "請先選擇物件"
 
-#: schematic/src/i_callbacks.c:530
 msgid "Multiple Copy"
 msgstr "多重複製"
 
-#: schematic/src/i_callbacks.c:555 schematic/src/x_menus.c:56
 msgid "Move"
 msgstr "搬移"
 
-#: schematic/src/i_callbacks.c:579 schematic/src/x_menus.c:57
-#: schematic/src/x_multiattrib.c:1656 schematic/scheme/gschem/builtins.scm:108
 msgid "Delete"
 msgstr "刪除"
 
-#: schematic/src/i_callbacks.c:603
 msgid "Edit"
 msgstr "編輯"
 
-#: schematic/src/i_callbacks.c:618 schematic/scheme/gschem/builtins.scm:129
 msgid "Edit Text"
 msgstr "編輯文字"
 
-#: schematic/src/i_callbacks.c:637
 msgid "Slot"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:688 schematic/src/i_callbacks.c:698
 msgid "Rotate"
 msgstr "旋轉"
 
-#: schematic/src/i_callbacks.c:736 schematic/src/i_callbacks.c:746
 msgid "Mirror"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:763 schematic/src/x_colorcb.c:160
-#: schematic/scheme/conf/schematic/menu.scm:73
-#: schematic/scheme/gschem/builtins.scm:141
 msgid "Lock"
 msgstr "鎖定"
 
-#: schematic/src/i_callbacks.c:781 schematic/scheme/conf/schematic/menu.scm:74
-#: schematic/scheme/gschem/builtins.scm:144
 msgid "Unlock"
 msgstr "解除鎖定"
 
-#: schematic/src/i_callbacks.c:805
 msgid "WARNING: Do not translate with snap off!"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:806
 msgid "WARNING: Turning snap on and continuing with translate."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:813
 msgid "WARNING: Snap grid size is not equal to 100!"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:815
 msgid ""
 "WARNING: If you are translating a symbol to the origin, the snap grid size "
 "should be set to 100"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:847
 msgid "Embed"
 msgstr "嵌入"
 
-#: schematic/src/i_callbacks.c:886
 msgid "Unembed"
 msgstr "解除嵌入"
 
-#: schematic/src/i_callbacks.c:928
 msgid "Update"
 msgstr "更新"
 
-#: schematic/src/i_callbacks.c:970
 msgid "ShowHidden"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1537
 #, c-format
 msgid ""
 "<b>Revert page:</b>\n"
@@ -923,100 +696,78 @@ msgid ""
 "discarded and page file will be reloaded from disk."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1555
 #, fuzzy
 msgid "Revert"
 msgstr "還原"
 
-#: schematic/src/i_callbacks.c:1647
 msgid "Copy to clipboard"
 msgstr "複製到剪貼簿"
 
-#: schematic/src/i_callbacks.c:1664
 msgid "Cut to clipboard"
 msgstr "剪下至剪貼簿"
 
-#: schematic/src/i_callbacks.c:1686
 msgid "Paste from clipboard"
 msgstr "從剪貼簿貼上"
 
-#: schematic/src/i_callbacks.c:1694
 #, fuzzy
 msgid "Empty clipboard"
 msgstr "複製到剪貼簿"
 
 #. TRANSLATORS: The number is the number of the buffer that the
 #. * selection is being copied to.
-#: schematic/src/i_callbacks.c:1719
 #, fuzzy, c-format
 msgid "Copy %i"
 msgstr "複製"
 
 #. TRANSLATORS: The number is the number of the buffer that the
 #. * selection is being cut to.
-#: schematic/src/i_callbacks.c:1746
 #, fuzzy, c-format
 msgid "Cut %i"
 msgstr "剪下至 緩衝區1"
 
 #. TRANSLATORS: The number is the number of the buffer that is being
 #. * pasted to the schematic.
-#: schematic/src/i_callbacks.c:1776
 #, fuzzy, c-format
 msgid "Paste %i"
 msgstr "貼上"
 
-#: schematic/src/i_callbacks.c:1785
 msgid "Empty buffer"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1833 schematic/src/x_window.c:1203
 msgid "Component"
 msgstr "元件"
 
-#: schematic/src/i_callbacks.c:1865 schematic/src/x_colorcb.c:150
 msgid "Attribute"
 msgstr "屬性"
 
-#: schematic/src/i_callbacks.c:1885 schematic/src/x_colorcb.c:149
 msgid "Net"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1928 schematic/src/x_colorcb.c:155
-#: schematic/src/x_window.c:1222
 msgid "Bus"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2004
 msgid "Line"
 msgstr "直線"
 
-#: schematic/src/i_callbacks.c:2021
 msgid "Path"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2043
 msgid "Box"
 msgstr "矩形"
 
-#: schematic/src/i_callbacks.c:2085
 msgid "Circle"
 msgstr "圓形"
 
-#: schematic/src/i_callbacks.c:2108
 msgid "Arc"
 msgstr "弧線"
 
-#: schematic/src/i_callbacks.c:2131 schematic/src/x_colorcb.c:146
 msgid "Pin"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2191
 #, c-format
 msgid "Searching for source [%1$s]"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2223
 #, c-format
 msgid ""
 "Failed to descend hierarchy into '%1$s': %2$s\n"
@@ -1024,107 +775,82 @@ msgid ""
 "The lepton-schematic log may contain more information."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2227
 #, fuzzy, c-format
 msgid "Failed to descend into '%1$s': %2$s"
 msgstr "無法讀取圖片: %s"
 
-#: schematic/src/i_callbacks.c:2234
 msgid "Failed to descend hierarchy."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2312
 #, c-format
 msgid "Searching for symbol [%1$s]"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2320
 msgid "Symbol is not a real file. Symbol cannot be loaded."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2367 schematic/src/x_tabs.c:1060
 msgid "Cannot find any schematics above the current one!"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2400
 msgid "Attach"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2456
 msgid "Detach"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2500
 msgid "ShowN"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2537
 msgid "ShowV"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2574
 msgid "ShowB"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2612
 msgid "VisToggle"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2643
 #, c-format
 msgid "Sorry but this is a non-functioning menu option\n"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2703
 msgid "Action feedback mode set to OUTLINE"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2706
 msgid "Action feedback mode set to BOUNDINGBOX"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2730
 #, fuzzy
 msgid "Grid OFF"
 msgstr "關閉網格\n"
 
-#: schematic/src/i_callbacks.c:2731
 msgid "Dot grid selected"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2732
 msgid "Mesh grid selected"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2733
 msgid "Invalid grid mode"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2755
 msgid "Snap OFF (CAUTION!)"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2758
 msgid "Snap ON"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2761
 msgid "Snap back to the grid (CAUTION!)"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2790
 msgid "Rubber band ON"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2792
 msgid "Rubber band OFF"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2811
 msgid "magnetic net mode: ON"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2814
 msgid "magnetic net mode: OFF"
 msgstr ""
 
@@ -1133,136 +859,107 @@ msgstr ""
 #. the form "untitled_N.sch", where N is a number.  Please make
 #. sure that the translation contains characters suitable for use
 #. in a filename.
-#: schematic/src/i_vars.c:209
 msgid "untitled"
 msgstr ""
 
-#: schematic/src/o_complex.c:192 schematic/src/o_complex.c:195
 #, c-format
 msgid "Translating schematic [%1$d %2$d]"
 msgstr ""
 
-#: schematic/src/o_delete.c:82
 #, fuzzy, c-format
 msgid "Delete locked object?"
 msgid_plural "Delete %1$u locked objects?"
 msgstr[0] "選擇物件"
 msgstr[1] "選擇物件"
 
-#: schematic/src/o_misc.c:55
 #, c-format
 msgid "Got an unexpected NULL in o_edit\n"
 msgstr ""
 
-#: schematic/src/o_misc.c:315
 #, fuzzy
 msgid "Hidden text is now visible"
 msgstr "隱藏的文字現在已經可以看見\n"
 
-#: schematic/src/o_misc.c:317
 #, fuzzy
 msgid "Hidden text is now invisible"
 msgstr "隱藏的文字現在無法看見\n"
 
-#: schematic/src/o_misc.c:425
 #, c-format
 msgid "Could not find symbol [%1$s] in library. Update failed."
 msgstr ""
 
-#: schematic/src/o_misc.c:541
 #, c-format
 msgid "o_autosave_backups: Can't get the real filename of %1$s."
 msgstr ""
 
-#: schematic/src/o_misc.c:585
 #, fuzzy, c-format
 msgid "Could NOT set previous backup file [%1$s] read-write"
 msgstr "無法設定備份檔[%s]為唯讀\n"
 
-#: schematic/src/o_misc.c:605
 #, fuzzy, c-format
 msgid "Could NOT set backup file [%1$s] readonly"
 msgstr "無法設定備份檔[%s]為唯讀\n"
 
-#: schematic/src/o_misc.c:610
 #, fuzzy, c-format
 msgid "Could NOT save backup file [%1$s]"
 msgstr "無法儲存備份檔 [%s]\n"
 
-#: schematic/src/o_move.c:192
 #, c-format
 msgid "ERROR: NULL object in o_move_end!\n"
 msgstr ""
 
-#: schematic/src/o_move.c:519
 #, c-format
 msgid "DOH! tried to find the whichone, but didn't find it!\n"
 msgstr ""
 
-#: schematic/src/o_move.c:546
 #, c-format
 msgid "Got a non line object in o_move_check_endpoint\n"
 msgstr ""
 
-#: schematic/src/o_net.c:444
 msgid "Warning: Starting net at off grid coordinate"
 msgstr ""
 
-#: schematic/src/o_net.c:508
 msgid "Warning: Ending net at off grid coordinate"
 msgstr ""
 
-#: schematic/src/o_net.c:856 schematic/src/o_net.c:893
-#: schematic/src/o_net.c:964 schematic/src/o_net.c:1000
 #, c-format
 msgid "Tried to add more than two bus rippers. Internal gschem error.\n"
 msgstr ""
 
-#: schematic/src/o_net.c:1068
 #, c-format
 msgid "Bus ripper symbol [%1$s] was not found in any component library"
 msgstr ""
 
-#: schematic/src/o_picture.c:133 schematic/src/o_picture.c:343
 msgid "Select a picture file..."
 msgstr ""
 
-#: schematic/src/o_picture.c:166
 #, fuzzy, c-format
 msgid "Failed to load picture: %1$s"
 msgstr "無法讀取圖片: %s"
 
-#: schematic/src/o_picture.c:182
 msgid "Picture"
 msgstr "圖片"
 
-#: schematic/src/o_picture.c:378
 #, c-format
 msgid "Failed to replace pictures: %s"
 msgstr ""
 
-#: schematic/src/o_slot.c:80
 #, fuzzy
 msgid "Slot attribute malformed"
 msgstr "屬性"
 
-#: schematic/src/o_slot.c:88
 msgid "numslots attribute missing"
 msgstr ""
 
-#: schematic/src/o_slot.c:89
 msgid "Slotting not allowed for this component"
 msgstr ""
 
-#: schematic/src/o_slot.c:104
 msgid "New slot number out of range"
 msgstr ""
 
-#: schematic/src/o_undo.c:397
 msgid "Undo/Redo disabled in rc file"
 msgstr ""
 
-#: schematic/src/parsecmd.c:77
 #, c-format
 msgid ""
 "Usage: %1$s [OPTION ...] [--] [FILE ...]\n"
@@ -1287,189 +984,145 @@ msgid ""
 "gEDA/gaf homepage: <http://www.geda-project.org/>\n"
 msgstr ""
 
-#: schematic/src/parsecmd.c:110
 #, c-format
 msgid ""
 "Lepton EDA %1$s (git: %2$.7s)\n"
 "Copyright (C) 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright (C) 2017-2018 Lepton Developers.\n"
+"Copyright (C) 2017-2019 Lepton Developers.\n"
 "This is free software, and you are welcome to redistribute it under\n"
 "certain conditions. For details, see the file `COPYING', which is\n"
 "included in the Lepton EDA distribution.\n"
 "There is NO WARRANTY, to the extent permitted by law.\n"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:125
 #, c-format
 msgid "Got invalid show option; defaulting to show both\n"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:139
 #, c-format
 msgid "ERROR: NULL object!\n"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:328
 msgid "Single Attribute Editor"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:358
 msgid "<b>Edit Attribute</b>"
 msgstr "<b>編輯屬性</b>"
 
-#: schematic/src/x_attribedit.c:360
 msgid "<b>Add Attribute</b>"
 msgstr "<b>增加屬性</b>"
 
-#: schematic/src/x_attribedit.c:376
 #, fuzzy
 msgid "N_ame:"
 msgstr "名稱："
 
-#: schematic/src/x_attribedit.c:396 schematic/src/x_multiattrib.c:2222
 #, fuzzy
 msgid "_Value:"
 msgstr "數值："
 
-#: schematic/src/x_attribedit.c:415 schematic/src/x_multiattrib.c:2281
 msgid "Vi_sible"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:434
 msgid "Show Value Only"
 msgstr "僅顯示數值"
 
-#: schematic/src/x_attribedit.c:436
 msgid "Show Name Only"
 msgstr "僅顯示名稱"
 
-#: schematic/src/x_attribedit.c:438 schematic/src/x_multiattrib.c:1620
-#: schematic/scheme/gschem/builtins.scm:324
 msgid "Show Name & Value"
 msgstr "顯示名稱與數值"
 
-#: schematic/src/x_attribedit.c:445
 msgid "<b>Attach Options</b>"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:460
 msgid "All"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:476 schematic/src/x_compselect.c:986
-#: schematic/src/x_compselect.c:1100
 msgid "Components"
 msgstr "元件"
 
-#: schematic/src/x_attribedit.c:492 schematic/src/x_window.c:1214
 msgid "Nets"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:508
 msgid "Replace existing attributes"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:412
 msgid ""
 "slotted object without slot attribute may cause problems when autonumbering "
 "slots"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:427
 #, c-format
 msgid ""
 "duplicate slot may cause problems: [symbolname=%1$s, number=%2$d, slot=%3$d]"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:675
 msgid "No searchstring given in autonumber text."
 msgstr ""
 
-#: schematic/src/x_autonumber.c:728
 msgid "No '*' or '?' given at the end of the autonumber text."
 msgstr ""
 
-#: schematic/src/x_autonumber.c:873
 msgid "Diagonal"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:874
 msgid "Top to bottom"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:875
 msgid "Bottom to top"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:876
 msgid "Left to right"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:877
 msgid "Right to left"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:878
 msgid "File order"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1214
 msgid "Autonumber text"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1237
 msgid "<b>Scope</b>"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1259
 msgid "Search for:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1273
 msgid "Autonumber text in:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1280
 msgid "Skip numbers found in:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1292 schematic/src/x_autonumber.c:1301
 msgid "Selected objects"
 msgstr "選擇物件"
 
-#: schematic/src/x_autonumber.c:1293 schematic/src/x_autonumber.c:1302
 msgid "Current page"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1294 schematic/src/x_autonumber.c:1303
 msgid "Whole hierarchy"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1305
 msgid "Overwrite existing numbers"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1310
 msgid "<b>Options</b>"
 msgstr "<b>選項</b>"
 
-#: schematic/src/x_autonumber.c:1332
 msgid "Starting number:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1339
 msgid "Sort order:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1371
 msgid "Remove numbers"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1375
 msgid "Automatic slotting"
 msgstr ""
 
-#: schematic/src/x_clipboard.c:245
 #, c-format
 msgid ""
 "<b>Invalid schematic on clipboard.</b>\n"
@@ -1477,173 +1130,133 @@ msgid ""
 "An error occurred while inserting clipboard data: %s."
 msgstr ""
 
-#: schematic/src/x_clipboard.c:247
 msgid "Clipboard insertion failed"
 msgstr ""
 
-#: schematic/src/x_color.c:89 schematic/src/x_color.c:98
 #, c-format
 msgid "Could not allocate the color %1$s!\n"
 msgstr ""
 
-#: schematic/src/x_color.c:89
 msgid "black"
 msgstr ""
 
-#: schematic/src/x_color.c:98
 msgid "white"
 msgstr ""
 
-#: schematic/src/x_color.c:120
 #, c-format
 msgid "Could not allocate display color %1$i!\n"
 msgstr ""
 
-#: schematic/src/x_color.c:142
 #, c-format
 msgid "Could not allocate outline color %1$i!\n"
 msgstr ""
 
-#: schematic/src/x_color.c:159
 #, c-format
 msgid "Tried to get an invalid color: %1$d\n"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:145
 msgid "Background"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:147
 msgid "Net endpoint"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:148
 msgid "Graphic"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:151
 msgid "Logic bubble"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:152
 msgid "Grid point"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:153
 #, fuzzy
 msgid "Detached attribute"
 msgstr "屬性"
 
-#: schematic/src/x_colorcb.c:156
 #, fuzzy
 msgid "Selection"
 msgstr "選擇"
 
-#: schematic/src/x_colorcb.c:157
 msgid "Bounding box"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:158
 #, fuzzy
 msgid "Zoom box"
 msgstr "放大檢視"
 
-#: schematic/src/x_colorcb.c:161
 msgid "Output background"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:162
 msgid "Freestyle 1"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:163
 msgid "Freestyle 2"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:164
 msgid "Freestyle 3"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:165
 msgid "Freestyle 4"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:166
 msgid "Net junction"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:167
 msgid "Mesh grid major"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:168
 msgid "Mesh grid minor"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:172
 msgid "Unknown"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1169
 msgid "Reset filter"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1192
 msgid "Reload all libraries"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1245 schematic/src/x_multiattrib.c:2092
 msgid "Value"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1284
 msgid "Default behavior - reference component"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1287
 msgid "Embed component in schematic"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1290
 msgid "Include component as individual objects"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1448
 msgid "Select Component..."
 msgstr ""
 
-#: schematic/src/x_compselect.c:1471
 msgid "In Us_e"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1475
 msgid "Lib_raries"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1484 schematic/src/x_fileselect.c:119
 msgid "Preview"
 msgstr "預覽"
 
-#: schematic/src/x_compselect.c:1510
 msgid "Attributes"
 msgstr "屬性"
 
-#: schematic/src/x_dialog.c:325
 msgid "Major symbol changes detected."
 msgstr ""
 
-#: schematic/src/x_dialog.c:349
 msgid ""
 "Changes have occurred to the symbols shown below.\n"
 "\n"
 "Be sure to verify each of these symbols."
 msgstr ""
 
-#: schematic/src/x_dialog.c:369
 msgid "Symbol"
 msgstr ""
 
-#: schematic/src/x_dialog.c:406
 #, c-format
 msgid ""
 "<span weight=\"bold\" size=\"larger\">The input attribute \"%s\" is invalid\n"
@@ -1654,39 +1267,30 @@ msgid ""
 "The value cannot start with a space."
 msgstr ""
 
-#: schematic/src/x_dialog.c:408
 msgid "Invalid Attribute"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:37
 msgid "Schematics"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:42
 msgid "Symbols"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:47
 msgid "Schematics and symbols"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:53
 msgid "All files"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:169
 msgid "Open..."
 msgstr ""
 
-#: schematic/src/x_fileselect.c:233
 msgid "Save as..."
 msgstr "另存為..."
 
-#: schematic/src/x_fileselect.c:297
 msgid "Save cancelled on user request"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:334
 msgid ""
 "\n"
 "If you load the original file, the backup file will be overwritten in the "
@@ -1695,28 +1299,22 @@ msgid ""
 "Do you want to load the backup file?\n"
 msgstr ""
 
-#: schematic/src/x_fstylecb.c:73
 msgid "Hollow"
 msgstr ""
 
-#: schematic/src/x_fstylecb.c:80
 msgid "Filled"
 msgstr ""
 
-#: schematic/src/x_fstylecb.c:87
 msgid "Mesh"
 msgstr ""
 
-#: schematic/src/x_fstylecb.c:94
 msgid "Hatch"
 msgstr ""
 
-#: schematic/src/x_image.c:279
 #, c-format
 msgid "x_image_lowlevel: Unable to write %1$s file %2$s."
 msgstr ""
 
-#: schematic/src/x_image.c:289
 #, c-format
 msgid ""
 "There was the following error when saving image with type %1$s to filename:\n"
@@ -1725,305 +1323,238 @@ msgid ""
 "%3$s.\n"
 msgstr ""
 
-#: schematic/src/x_image.c:309
 #, c-format
 msgid "Wrote color image to [%1$s] [%2$d x %3$d]"
 msgstr ""
 
-#: schematic/src/x_image.c:311
 #, c-format
 msgid "Wrote black and white image to [%1$s] [%2$d x %3$d]"
 msgstr ""
 
-#: schematic/src/x_image.c:319
 msgid "x_image_lowlevel: Unable to get pixbuf from gschem's window."
 msgstr ""
 
-#: schematic/src/x_image.c:358
 msgid "Width x Height"
 msgstr "寬度 x 高度"
 
-#: schematic/src/x_image.c:374
 msgid "Image type"
 msgstr "圖片格式"
 
-#: schematic/src/x_image.c:395
 msgid "Write image..."
 msgstr "匯出成圖片"
 
-#: schematic/src/x_linecapcb.c:74
 msgid "Butt"
 msgstr ""
 
-#: schematic/src/x_linecapcb.c:81
 msgid "Square"
 msgstr ""
 
-#: schematic/src/x_linecapcb.c:88
 msgid "Round"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:74
 msgid "Solid"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:81
 msgid "Dotted"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:88
 msgid "Dashed"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:95
 msgid "Center"
 msgstr ""
 
-#: schematic/src/x_linetypecb.c:102
 msgid "Phantom"
 msgstr ""
 
-#: schematic/src/x_menus.c:41 schematic/scheme/gschem/builtins.scm:267
 #, fuzzy
 msgid "Add Net"
 msgstr "新增文字"
 
-#: schematic/src/x_menus.c:42 schematic/src/x_multiattrib.c:2187
-#: schematic/scheme/gschem/builtins.scm:264
 msgid "Add Attribute"
 msgstr ""
 
-#: schematic/src/x_menus.c:43 schematic/scheme/gschem/builtins.scm:261
 #, fuzzy
 msgid "Add Component"
 msgstr "元件"
 
-#: schematic/src/x_menus.c:44 schematic/scheme/gschem/builtins.scm:270
 msgid "Add Bus"
 msgstr ""
 
-#: schematic/src/x_menus.c:45 schematic/scheme/gschem/builtins.scm:273
 #, fuzzy
 msgid "Add Text"
 msgstr "新增文字"
 
-#: schematic/src/x_menus.c:47 schematic/scheme/gschem/builtins.scm:210
 #, fuzzy
 msgid "Zoom In"
 msgstr "放大檢視"
 
-#: schematic/src/x_menus.c:48 schematic/scheme/gschem/builtins.scm:213
 #, fuzzy
 msgid "Zoom Out"
 msgstr "縮小檢視"
 
-#: schematic/src/x_menus.c:50 schematic/scheme/gschem/builtins.scm:207
 #, fuzzy
 msgid "Zoom Extents"
 msgstr "放大檢視"
 
-#: schematic/src/x_menus.c:52 schematic/src/x_window.c:1233
 msgid "Select"
 msgstr "選擇"
 
-#: schematic/src/x_menus.c:53 schematic/scheme/conf/schematic/menu.scm:69
-#: schematic/scheme/gschem/builtins.scm:126
 msgid "Edit..."
 msgstr "編輯"
 
-#: schematic/src/x_menus.c:54 schematic/scheme/conf/schematic/menu.scm:68
 #, fuzzy
 msgid "Object Properties..."
 msgstr "<b>選項</b>"
 
-#: schematic/src/x_menus.c:59 schematic/scheme/gschem/builtins.scm:300
 #, fuzzy
 msgid "Down Schematic"
 msgstr "gEDA 電路圖編輯器"
 
-#: schematic/src/x_menus.c:60 schematic/scheme/gschem/builtins.scm:303
 msgid "Down Symbol"
 msgstr ""
 
-#: schematic/src/x_menus.c:61
 msgid "Up"
 msgstr ""
 
-#: schematic/src/x_menus.c:336
 #, c-format
 msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
 msgstr ""
 
-#: schematic/src/x_menus.c:360
 #, c-format
 msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
 msgstr ""
 
-#: schematic/src/x_misc.c:70
 msgid "The operating system is out of memory or resources."
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:798 schematic/src/x_multiattrib.c:2704
 msgid "<various>"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:930
 msgid "Attributes with empty name are not allowed. Please set a name."
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1622
 msgid "Show Value only"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1624
 msgid "Show Name only"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1651
 msgid "Promote"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1655
 msgid "Duplicate"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:1657
 #, fuzzy
 msgid "Copy to all"
 msgstr "複製到 緩衝區1"
 
-#: schematic/src/x_multiattrib.c:1986 schematic/src/x_multiattrib.c:2602
 msgid "Edit Attributes"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2112
 msgid "Vis?"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2130
 msgid "N"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2148
 msgid "V"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2170
 #, fuzzy
 msgid "Sho_w inherited attributes"
 msgstr "屬性"
 
-#: schematic/src/x_multiattrib.c:2197
 #, fuzzy
 msgid "_Name:"
 msgstr "名稱："
 
-#: schematic/src/x_multiattrib.c:2241
 msgid "Ctrl+Enter inserts new line; Ctrl+Tab inserts Tab"
 msgstr ""
 
-#: schematic/src/x_multiattrib.c:2618
 #, c-format
 msgid "%2$i symbol (%1$s)"
 msgid_plural "%2$i symbols (%1$s)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2624
 #, c-format
 msgid "%1$i pin"
 msgid_plural "%1$i pins"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2630
 #, c-format
 msgid "%1$i net"
 msgid_plural "%1$i nets"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2636
 #, c-format
 msgid "%1$i bus"
 msgid_plural "%1$i buses"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/x_multiattrib.c:2642
 #, fuzzy, c-format
 msgid "%1$i attribute"
 msgid_plural "%1$i attributes"
 msgstr[0] "屬性"
 msgstr[1] "屬性"
 
-#: schematic/src/x_newtext.c:433
 #, fuzzy
 msgid "Text Entry..."
 msgstr "文字"
 
-#: schematic/src/x_pagesel.c:253
 msgid "New Page"
 msgstr "新增分頁"
 
-#: schematic/src/x_pagesel.c:254
 msgid "Open Page..."
 msgstr "開啟舊檔"
 
-#: schematic/src/x_pagesel.c:256
 msgid "Save Page"
 msgstr "儲存檔案"
 
-#: schematic/src/x_pagesel.c:257 schematic/scheme/gschem/builtins.scm:246
 msgid "Close Page"
 msgstr "關閉檔案"
 
-#: schematic/src/x_pagesel.c:376 schematic/scheme/gschem/builtins.scm:237
 msgid "Page Manager"
 msgstr ""
 
-#: schematic/src/x_pagesel.c:448
 msgid "Changed"
 msgstr ""
 
-#: schematic/src/x_pagesel.c:468
 msgid "Right click on the filename for more options..."
 msgstr ""
 
-#: schematic/src/x_print.c:306
 #, c-format
 msgid "Failed to write PDF to '%s': %s\n"
 msgstr ""
 
-#: schematic/src/x_print.c:364
 #, fuzzy, c-format
 msgid "Failed to write PDF to '%1$s': %2$s\n"
 msgstr "無法讀取圖片: %s"
 
-#: schematic/src/x_print.c:449
 #, c-format
 msgid ""
 "Error printing file:\n"
 "%1$s"
 msgstr ""
 
-#: schematic/src/x_rc.c:39
 msgid "ERROR: An unknown error occurred while parsing configuration files."
 msgstr ""
 
-#: schematic/src/x_rc.c:44
 msgid ""
 "An unknown error occurred while parsing configuration files.\n"
 "\n"
 "The lepton-schematic log may contain more information."
 msgstr ""
 
-#: schematic/src/x_rc.c:56
 #, c-format
 msgid "ERROR: %1$s"
 msgstr ""
 
-#: schematic/src/x_rc.c:59
 #, c-format
 msgid ""
 "%1$s\n"
@@ -2031,139 +1562,108 @@ msgid ""
 "The lepton-schematic log may contain more information."
 msgstr ""
 
-#: schematic/src/x_rc.c:67
 msgid "Cannot load lepton-schematic configuration."
 msgstr ""
 
-#: schematic/src/x_script.c:42 schematic/scheme/conf/schematic/menu.scm:40
 msgid "Execute Script..."
 msgstr "執行命令稿"
 
-#: schematic/src/x_script.c:61
 #, fuzzy, c-format
 msgid "Executing guile script [%1$s]"
 msgstr "正在執行guile腳本 [%s]\n"
 
-#: schematic/src/x_tabs.c:860
 #, c-format
 msgid "Hierarchy up: %s"
 msgstr ""
 
-#: schematic/src/x_tabs.c:863
 msgid "Hierarchy up"
 msgstr ""
 
-#: schematic/src/x_widgets.c:158 schematic/src/x_window.c:1444
 #, fuzzy
 msgid "Options"
 msgstr "選項"
 
-#: schematic/src/x_widgets.c:203 schematic/src/x_window.c:1436
 msgid "Object"
 msgstr ""
 
-#: schematic/src/x_widgets.c:224
 msgid "Log"
 msgstr ""
 
-#: schematic/src/x_widgets.c:245 schematic/src/x_window.c:1466
 msgid "Find Text"
 msgstr ""
 
-#: schematic/src/x_widgets.c:259
 #, fuzzy
 msgid "Color Scheme Editor"
 msgstr "白色背景"
 
-#: schematic/src/x_widgets.c:272 schematic/scheme/gschem/builtins.scm:378
 #, fuzzy
 msgid "Select Schematic Font"
 msgstr "選擇"
 
-#: schematic/src/x_window.c:763
 #, c-format
 msgid "Loading schematic [%1$s]"
 msgstr ""
 
-#: schematic/src/x_window.c:864
 #, fuzzy, c-format
 msgid "Could NOT save page [%1$s]\n"
 msgstr "無法儲存備份檔 [%s]\n"
 
-#: schematic/src/x_window.c:865
 msgid "Error while trying to save"
 msgstr "儲存檔案時發生錯誤"
 
-#: schematic/src/x_window.c:875
 msgid "Failed to save file"
 msgstr ""
 
-#: schematic/src/x_window.c:885
 #, fuzzy, c-format
 msgid "Saved as [%1$s]"
 msgstr "另存為 [%s]\n"
 
-#: schematic/src/x_window.c:887
 #, fuzzy, c-format
 msgid "Saved [%1$s]"
 msgstr "儲存 [%s]\n"
 
-#: schematic/src/x_window.c:889
 msgid "Saved"
 msgstr "儲存"
 
-#: schematic/src/x_window.c:966
 #, c-format
 msgid "Discarding page [%1$s]"
 msgstr ""
 
-#: schematic/src/x_window.c:966
 #, fuzzy, c-format
 msgid "Closing [%1$s]"
 msgstr "關閉 [%s]\n"
 
-#: schematic/src/x_window.c:1175
 msgid "New"
 msgstr "新增分頁"
 
-#: schematic/src/x_window.c:1175
 msgid "New file"
 msgstr ""
 
-#: schematic/src/x_window.c:1179
 msgid "Open"
 msgstr ""
 
-#: schematic/src/x_window.c:1179
 #, fuzzy
 msgid "Open file"
 msgstr "開啟檔案"
 
-#: schematic/src/x_window.c:1183 schematic/scheme/gschem/builtins.scm:59
 msgid "Save"
 msgstr "儲存"
 
-#: schematic/src/x_window.c:1183
 msgid "Save file"
 msgstr "儲存檔案"
 
-#: schematic/src/x_window.c:1189 schematic/scheme/gschem/builtins.scm:93
 msgid "Undo"
 msgstr "復原"
 
-#: schematic/src/x_window.c:1189
 msgid "Undo last operation"
 msgstr "復原上一次操作"
 
-#: schematic/src/x_window.c:1193 schematic/scheme/gschem/builtins.scm:96
 msgid "Redo"
 msgstr "取消上次復原"
 
-#: schematic/src/x_window.c:1193
 msgid "Redo last undo"
 msgstr "取消上一次復原"
 
-#: schematic/src/x_window.c:1198
 msgid ""
 "Add component...\n"
 "Select library and component from list, move the mouse into main window, "
@@ -2171,56 +1671,44 @@ msgid ""
 "Right mouse button to cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1209
 msgid ""
 "Add nets mode\n"
 "Right mouse button to cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1217
 msgid ""
 "Add buses mode\n"
 "Right mouse button to cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1226
 msgid "Add Text..."
 msgstr "新增文字"
 
-#: schematic/src/x_window.c:1233
 msgid "Select mode"
 msgstr "選擇模式"
 
-#: schematic/src/x_window.c:1288
 msgid "Show"
 msgstr ""
 
-#: schematic/src/x_window.c:1289
 msgid "Show text starting with:"
 msgstr ""
 
-#: schematic/src/x_window.c:1345
 msgid "Menu/Cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1349
 msgid "Pan/Cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1359
 msgid "Pick"
 msgstr ""
 
-#: schematic/src/x_window.c:1470 schematic/scheme/gschem/builtins.scm:180
 msgid "Status"
 msgstr ""
 
-#: schematic/src/x_window.c:1568
 #, fuzzy, c-format
 msgid "New file [%s]"
 msgstr "新增分頁"
 
-#: schematic/src/x_window.c:1598
 #, c-format
 msgid ""
 "<b>An error occurred while loading the requested file.</b>\n"
@@ -2234,868 +1722,658 @@ msgid ""
 "monitor program's output in terminal window."
 msgstr ""
 
-#: schematic/src/x_window.c:1617
 msgid "Failed to load file"
 msgstr "讀取檔案失敗"
 
-#: schematic/data/lepton-schematic.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Schematic Editor"
 msgstr "gEDA 電路圖編輯器"
 
-#: schematic/data/lepton-schematic.desktop.in:4
 #, fuzzy
 msgid "Create and edit electrical schematics and symbols with lepton-schematic"
 msgstr "用 gschem 建立並編輯電子電路圖表及符號"
 
-#: schematic/scheme/conf/schematic/menu.scm:27
 msgid "_New"
 msgstr "新增檔案"
 
-#: schematic/scheme/conf/schematic/menu.scm:28
 msgid "_Open..."
 msgstr "開啟舊檔"
 
-#: schematic/scheme/conf/schematic/menu.scm:30
 msgid "Open Recen_t"
 msgstr "最近的檔案"
 
-#: schematic/scheme/conf/schematic/menu.scm:32
 msgid "_Save"
 msgstr "儲存檔案"
 
-#: schematic/scheme/conf/schematic/menu.scm:33
 msgid "Save _As..."
 msgstr "另存新檔"
 
-#: schematic/scheme/conf/schematic/menu.scm:34
-#: schematic/scheme/gschem/builtins.scm:65
 msgid "Save All"
 msgstr "儲存全部"
 
-#: schematic/scheme/conf/schematic/menu.scm:36
 msgid "_Print..."
 msgstr "列印檔案"
 
-#: schematic/scheme/conf/schematic/menu.scm:37
 #, fuzzy
 msgid "Write _Image..."
 msgstr "轉換成圖片"
 
-#: schematic/scheme/conf/schematic/menu.scm:39
 msgid "Invoke Macro..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:41
 msgid "REPL..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:43
-#: schematic/scheme/gschem/builtins.scm:77
 msgid "New Window"
 msgstr "開新視窗"
 
-#: schematic/scheme/conf/schematic/menu.scm:44
 msgid "_Close Window"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:45
 msgid "_Quit"
 msgstr "結束程式"
 
-#: schematic/scheme/conf/schematic/menu.scm:51
 msgid "_Undo"
 msgstr "還原"
 
-#: schematic/scheme/conf/schematic/menu.scm:52
 msgid "_Redo"
 msgstr "取消還原"
 
-#: schematic/scheme/conf/schematic/menu.scm:54
 msgid "Cu_t"
 msgstr "剪下"
 
-#: schematic/scheme/conf/schematic/menu.scm:55
 msgid "_Copy"
 msgstr "複製"
 
-#: schematic/scheme/conf/schematic/menu.scm:56
 msgid "_Paste"
 msgstr "貼上"
 
-#: schematic/scheme/conf/schematic/menu.scm:57
 msgid "_Delete"
 msgstr "刪除"
 
-#: schematic/scheme/conf/schematic/menu.scm:60
-#: schematic/scheme/gschem/builtins.scm:102
 msgid "Select All"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:61
-#: schematic/scheme/gschem/builtins.scm:105
 msgid "Deselect"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:65
 msgid "Rotate 90 Mode"
 msgstr "逆時針旋轉90度"
 
-#: schematic/scheme/conf/schematic/menu.scm:70
 msgid "Edit Text..."
 msgstr "編輯文字"
 
-#: schematic/scheme/conf/schematic/menu.scm:71
 msgid "Slot..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:76
-#: schematic/scheme/gschem/builtins.scm:150
 msgid "Embed Component/Picture"
 msgstr "嵌入元件/圖片"
 
-#: schematic/scheme/conf/schematic/menu.scm:77
-#: schematic/scheme/gschem/builtins.scm:153
 msgid "Unembed Component/Picture"
 msgstr "解除嵌入元件/圖片"
 
-#: schematic/scheme/conf/schematic/menu.scm:78
-#: schematic/scheme/gschem/builtins.scm:156
 msgid "Update Component"
 msgstr "更新元件資訊"
 
-#: schematic/scheme/conf/schematic/menu.scm:79
 msgid "Symbol Translate..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:85
 msgid "Copy into 1"
 msgstr "複製到 緩衝區1"
 
-#: schematic/scheme/conf/schematic/menu.scm:86
 msgid "Copy into 2"
 msgstr "複製到 緩衝區2"
 
-#: schematic/scheme/conf/schematic/menu.scm:87
 msgid "Copy into 3"
 msgstr "複製到 緩衝區3"
 
-#: schematic/scheme/conf/schematic/menu.scm:88
 msgid "Copy into 4"
 msgstr "複製到 緩衝區4"
 
-#: schematic/scheme/conf/schematic/menu.scm:89
 msgid "Copy into 5"
 msgstr "複製到 緩衝區5"
 
-#: schematic/scheme/conf/schematic/menu.scm:90
 msgid "Cut into 1"
 msgstr "剪下至 緩衝區1"
 
-#: schematic/scheme/conf/schematic/menu.scm:91
 msgid "Cut into 2"
 msgstr "剪下至 緩衝區2"
 
-#: schematic/scheme/conf/schematic/menu.scm:92
 msgid "Cut into 3"
 msgstr "剪下至 緩衝區3"
 
-#: schematic/scheme/conf/schematic/menu.scm:93
 msgid "Cut into 4"
 msgstr "剪下至 緩衝區4"
 
-#: schematic/scheme/conf/schematic/menu.scm:94
 msgid "Cut into 5"
 msgstr "剪下至 緩衝區5"
 
-#: schematic/scheme/conf/schematic/menu.scm:95
 msgid "Paste from 1"
 msgstr "自 緩衝區1 貼上"
 
-#: schematic/scheme/conf/schematic/menu.scm:96
 msgid "Paste from 2"
 msgstr "自 緩衝區2 貼上"
 
-#: schematic/scheme/conf/schematic/menu.scm:97
 msgid "Paste from 3"
 msgstr "自 緩衝區3 貼上"
 
-#: schematic/scheme/conf/schematic/menu.scm:98
 msgid "Paste from 4"
 msgstr "自 緩衝區4 貼上"
 
-#: schematic/scheme/conf/schematic/menu.scm:99
 msgid "Paste from 5"
 msgstr "自 緩衝區5 貼上"
 
-#: schematic/scheme/conf/schematic/menu.scm:105
 msgid "Side Dock"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:106
 msgid "Bottom Dock"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:108
 #, fuzzy
 msgid "Find Text Results"
 msgstr "新增文字"
 
-#: schematic/scheme/conf/schematic/menu.scm:110
 msgid "_Redraw"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:111
 msgid "_Pan"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:112
 msgid "Zoom _Box"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:113
 msgid "Zoom _Extents"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:114
 msgid "Zoom _In"
 msgstr "放大檢視"
 
-#: schematic/scheme/conf/schematic/menu.scm:115
 msgid "Zoom _Out"
 msgstr "縮小檢視"
 
-#: schematic/scheme/conf/schematic/menu.scm:116
 msgid "Zoom _Full"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:118
 #, fuzzy
 msgid "_Dark Color Scheme"
 msgstr "黑色背景"
 
-#: schematic/scheme/conf/schematic/menu.scm:119
 #, fuzzy
 msgid "_Light Color Scheme"
 msgstr "白色背景"
 
-#: schematic/scheme/conf/schematic/menu.scm:120
 #, fuzzy
 msgid "B_W Color Scheme"
 msgstr "黑色背景"
 
-#: schematic/scheme/conf/schematic/menu.scm:122
 #, fuzzy
 msgid "Color Scheme Editor..."
 msgstr "白色背景"
 
-#: schematic/scheme/conf/schematic/menu.scm:129
 msgid "_Manager..."
 msgstr "管理分頁"
 
-#: schematic/scheme/conf/schematic/menu.scm:131
 msgid "_Previous"
 msgstr "上一個分頁"
 
-#: schematic/scheme/conf/schematic/menu.scm:132
 msgid "_Next"
 msgstr "下一個分頁"
 
-#: schematic/scheme/conf/schematic/menu.scm:133
 msgid "_Close"
 msgstr "關閉視窗"
 
-#: schematic/scheme/conf/schematic/menu.scm:135
 #, fuzzy
 msgid "_Revert..."
 msgstr "還原"
 
-#: schematic/scheme/conf/schematic/menu.scm:137
-#: schematic/scheme/gschem/builtins.scm:249
 #, fuzzy
 msgid "Next Tab"
 msgstr "新增分頁"
 
-#: schematic/scheme/conf/schematic/menu.scm:138
-#: schematic/scheme/gschem/builtins.scm:252
 #, fuzzy
 msgid "Previous Tab"
 msgstr "上一個分頁"
 
-#: schematic/scheme/conf/schematic/menu.scm:146
 msgid "_Component..."
 msgstr "元件"
 
-#: schematic/scheme/conf/schematic/menu.scm:148
 msgid "_Net"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:149
 msgid "B_us"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:151
 msgid "_Attribute..."
 msgstr "屬性"
 
-#: schematic/scheme/conf/schematic/menu.scm:152
 msgid "_Text..."
 msgstr "文字"
 
-#: schematic/scheme/conf/schematic/menu.scm:154
 msgid "_Line"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:155
 msgid "Pat_h"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:156
 msgid "_Box"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:157
 msgid "C_ircle"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:158
 msgid "A_rc"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:159
 msgid "_Pin"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:161
 msgid "Pictu_re..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:167
 msgid "_Up"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:169
 msgid "_Down Schematic"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:170
 msgid "Down _Symbol"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:176
 msgid "_Attach"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:177
 msgid "_Detach"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:179
 msgid "Show _Value"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:180
 msgid "Show _Name"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:181
 msgid "Show _Both"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:182
 msgid "_Toggle Visibility"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:184
 msgid "_Hide Specific Text..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:185
 msgid "_Show Specific Text..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:186
 msgid "Show/Hide Hidden Text"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:188
 msgid "_Find Text/Check Symbol..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:189
 msgid "A_utonumber Text..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:195
 #, fuzzy
 msgid "_Options..."
 msgstr "選項"
 
-#: schematic/scheme/conf/schematic/menu.scm:196
 #, fuzzy
 msgid "_Font..."
 msgstr "列印檔案"
 
-#: schematic/scheme/conf/schematic/menu.scm:198
 #, fuzzy
 msgid "Grid +"
 msgstr "關閉網格\n"
 
-#: schematic/scheme/conf/schematic/menu.scm:199
 #, fuzzy
 msgid "Grid -"
 msgstr "關閉網格\n"
 
-#: schematic/scheme/conf/schematic/menu.scm:201
 msgid "Grid Style: Cycle Dots/Mesh/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:202
 msgid "Grid Snap: Cycle Grid/Resnap/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:204
 msgid "Feedback Mode: Outline/Box"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:205
 msgid "Net: Rubberband On/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:206
 msgid "Net: Magnetic On/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:208
 #, fuzzy
 msgid "_Coord Window"
 msgstr "開新視窗"
 
-#: schematic/scheme/conf/schematic/menu.scm:209
 #, fuzzy
 msgid "_Log Window"
 msgstr "開新視窗"
 
-#: schematic/scheme/conf/schematic/menu.scm:215
 msgid "_1 allegro"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:223
 msgid "User _Guide"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:224
 msgid "_FAQ"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:225
 #, fuzzy
 msgid "Docu_mentation"
 msgstr "元件模式"
 
-#: schematic/scheme/conf/schematic/menu.scm:226
 msgid "_Wiki"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:228
 #, fuzzy
 msgid "Find Component D_ocumentation"
 msgstr "元件模式"
 
-#: schematic/scheme/conf/schematic/menu.scm:230
 msgid "_Hotkeys..."
 msgstr "熱鍵"
 
-#: schematic/scheme/conf/schematic/menu.scm:231
 #, fuzzy
 msgid "_About"
 msgstr "關於"
 
-#: schematic/scheme/conf/schematic/menu.scm:237
 msgid "_File"
 msgstr "檔案"
 
-#: schematic/scheme/conf/schematic/menu.scm:238
 msgid "_Edit"
 msgstr "編輯"
 
-#: schematic/scheme/conf/schematic/menu.scm:240
 msgid "_View"
 msgstr "顯示"
 
-#: schematic/scheme/conf/schematic/menu.scm:241
 msgid "_Page"
 msgstr "分頁"
 
-#: schematic/scheme/conf/schematic/menu.scm:242
 msgid "_Add"
 msgstr "新增"
 
-#: schematic/scheme/conf/schematic/menu.scm:243
 msgid "Hie_rarchy"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:244
 msgid "A_ttributes"
 msgstr "屬性"
 
-#: schematic/scheme/conf/schematic/menu.scm:245
 msgid "_Options"
 msgstr "選項"
 
-#: schematic/scheme/conf/schematic/menu.scm:246
 msgid "_Netlist"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:247
 msgid "_Help"
 msgstr "幫助"
 
-#: schematic/scheme/gschem/action.scm:43
 #, scheme-format
 msgid "~S is not a valid gschem action."
 msgstr ""
 
-#: schematic/scheme/gschem/action.scm:158
 msgid "Repeat Last Action"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:47
 msgid "Cancel"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:53
 #, fuzzy
 msgid "New File"
 msgstr "新增分頁"
 
-#: schematic/scheme/gschem/builtins.scm:56
 #, fuzzy
 msgid "Open File"
 msgstr "開啟檔案"
 
-#: schematic/scheme/gschem/builtins.scm:62
 #, fuzzy
 msgid "Save As"
 msgstr "儲存全部"
 
-#: schematic/scheme/gschem/builtins.scm:68
 #, fuzzy
 msgid "Print"
 msgstr "列印"
 
-#: schematic/scheme/gschem/builtins.scm:71
 msgid "Export Image"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:74
 msgid "Run Script"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:80
 #, fuzzy
 msgid "Close Window"
 msgstr "開新視窗"
 
-#: schematic/scheme/gschem/builtins.scm:83
 #, fuzzy
 msgid "Quit"
 msgstr "結束程式"
 
-#: schematic/scheme/gschem/builtins.scm:87
 msgid "Terminal REPL"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:132
 msgid "Choose Slot"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:135
 #, fuzzy
 msgid "Edit Object Properties"
 msgstr "<b>選項</b>"
 
-#: schematic/scheme/gschem/builtins.scm:138
 msgid "Translate Symbol"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:147
 msgid "Invoke Macro"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:159
 msgid "Show/Hide Invisible Text"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:165
 #, fuzzy
 msgid "Cut"
 msgstr "剪下"
 
-#: schematic/scheme/gschem/builtins.scm:171
 #, fuzzy
 msgid "Paste"
 msgstr "貼上"
 
-#: schematic/scheme/gschem/builtins.scm:177
 msgid "Sidebar"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:183
 #, fuzzy
 msgid "Find Text State"
 msgstr "新增文字"
 
-#: schematic/scheme/gschem/builtins.scm:186
 msgid "Redraw"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:192
 msgid "Pan Left"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:195
 msgid "Pan Right"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:198
 msgid "Pan Up"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:201
 msgid "Pan Down"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:216
 #, fuzzy
 msgid "Zoom Full"
 msgstr "縮小檢視"
 
-#: schematic/scheme/gschem/builtins.scm:219
 #, fuzzy
 msgid "Dark Color Scheme"
 msgstr "黑色背景"
 
-#: schematic/scheme/gschem/builtins.scm:222
 #, fuzzy
 msgid "Light Color Scheme"
 msgstr "白色背景"
 
-#: schematic/scheme/gschem/builtins.scm:225
 msgid "Monochrome Color Scheme"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:228
 #, fuzzy
 msgid "Show Color Scheme Editor"
 msgstr "白色背景"
 
-#: schematic/scheme/gschem/builtins.scm:234
 msgid "Revert Changes"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:240
 #, fuzzy
 msgid "Previous Page"
 msgstr "上一個分頁"
 
-#: schematic/scheme/gschem/builtins.scm:243
 #, fuzzy
 msgid "Next Page"
 msgstr "新增分頁"
 
-#: schematic/scheme/gschem/builtins.scm:255
 #, fuzzy
 msgid "Print Page"
 msgstr "上一個分頁"
 
-#: schematic/scheme/gschem/builtins.scm:276
 #, fuzzy
 msgid "Add Line"
 msgstr "直線"
 
-#: schematic/scheme/gschem/builtins.scm:279
 msgid "Add Path"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:282
 msgid "Add Box"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:285
 #, fuzzy
 msgid "Add Circle"
 msgstr "圓形"
 
-#: schematic/scheme/gschem/builtins.scm:288
 msgid "Add Arc"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:291
 msgid "Add Pin"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:294
 #, fuzzy
 msgid "Add Picture"
 msgstr "圖片"
 
-#: schematic/scheme/gschem/builtins.scm:306
 msgid "Up Hierarchy"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:312
 #, fuzzy
 msgid "Attach Attributes"
 msgstr "屬性"
 
-#: schematic/scheme/gschem/builtins.scm:315
 #, fuzzy
 msgid "Detach Attributes"
 msgstr "屬性"
 
-#: schematic/scheme/gschem/builtins.scm:318
 #, fuzzy
 msgid "Show Attribute Value"
 msgstr "顯示名稱與數值"
 
-#: schematic/scheme/gschem/builtins.scm:321
 #, fuzzy
 msgid "Show Attribute Name"
 msgstr "屬性"
 
-#: schematic/scheme/gschem/builtins.scm:327
 msgid "Toggle Text Visibility"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:330
 msgid "Find Specific Text"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:333
 msgid "Hide Specific Text"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:336
 msgid "Show Specific Text"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:339
 msgid "Autonumber Text"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:345
 #, fuzzy
 msgid "Show Hotkeys"
 msgstr "熱鍵"
 
-#: schematic/scheme/gschem/builtins.scm:348
 msgid "Switch Grid Style"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:351
 msgid "Switch Snap Mode"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:354
 msgid "Set Grid Spacing"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:357
 msgid "Increase Grid Spacing"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:360
 msgid "Decrease Grid Spacing"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:363
 msgid "Toggle Outline Drawing"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:366
 msgid "Toggle Net Rubber Band"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:369
 msgid "Toggle Magnetic Nets"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:372
 #, fuzzy
 msgid "Show Log Window"
 msgstr "開新視窗"
 
-#: schematic/scheme/gschem/builtins.scm:375
 msgid "Show Coordinate Window"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:385
 #, fuzzy
 msgid "Component Documentation"
 msgstr "元件模式"
 
-#: schematic/scheme/gschem/builtins.scm:387
 msgid "View documentation for selected component"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:403
 msgid ""
 "Could not show documentation for selected component:\n"
 "\n"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:408
 msgid "gEDA Manuals"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:409
 msgid "View the front page of the gEDA documentation in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:414
 msgid "gschem User Guide"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:415
 msgid "View the gschem User Guide in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:420
 msgid "gschem FAQ"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:421
 msgid "Frequently Asked Questions about using gschem."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:426
 msgid "gEDA wiki"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:427
 msgid "View the front page of the gEDA wiki in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:431
 msgid "About gschem"
 msgstr "關於 gschem"
 
-#: schematic/scheme/gschem/deprecated.scm:102
 #, scheme-format
 msgid "Invalid text alignment ~A."
 msgstr ""
 
-#: schematic/scheme/gschem/gschemdoc.scm:241
 msgid "No documentation found"
 msgstr ""
 
-#: schematic/scheme/gschem/keymap.scm:40
 #, scheme-format
 msgid "~S is not a valid key combination."
 msgstr ""
 
-#: schematic/scheme/gschem/keymap.scm:157
 #, scheme-format
 msgid "~S is not a prefix key sequence."
 msgstr ""


### PR DESCRIPTION
It appears that at last we can get rid of those annoying unintentional changes to `PO` files, that happens during the build process. `PO` files, then, must be manually checked out. When doing hundreds and hundreds of builds, it can drive one really nuts.

1) add POT file to source control, do not ignore it
2) modify `Makevars`:
  - `MSGMERGE_OPTIONS = --no-location` (eliminates comments with line numbers)
  - `PO_DEPENDS_ON_POT = no` (do not modify `PO` files if it's not necessary)
3) `make update-po`

@vzh Please check, if it works for you. If everything fine, I can push here updates for the other tools (`liblepton`, `netlist`, `symcheck`, `cli`, `attrib`).