### PR TITLE
Fix guile-2.2 deprecation warning in gsch2pcb backend.

### DIFF
--- a/netlist/scheme/Makefile.am
+++ b/netlist/scheme/Makefile.am
@@ -93,10 +93,13 @@ SCM_SRCS=	gnet-gsch2pcb.scm.in
 
 BUILT_SCM=	gnet-gsch2pcb.scm
 
+SETVBUF_MODE = `$(GUILE) -c '(display (if (string= (minor-version) "0") "_IONBF" (quote (quote none))))'`
+
 gnet-gsch2pcb.scm: $(srcdir)/gnet-gsch2pcb.scm.in
 	sed \
 		-e 's;@m4@;${M4};g' \
 		-e 's;@pcbm4dir@;${PCBM4DIR};g' \
+		-e "s;@mode@;${SETVBUF_MODE};g" \
 		$(srcdir)/gnet-gsch2pcb.scm.in > $@
 
 all-local:

--- a/netlist/scheme/gnet-gsch2pcb.scm.in
+++ b/netlist/scheme/gnet-gsch2pcb.scm.in
@@ -141,6 +141,9 @@
 (define-undefined gsch2pcb:pcb-m4-dir "@pcbm4dir@")
 (define-undefined gsch2pcb:m4-files "")
 
+;;; Use different port mode names for guile-2.0 and guile-2.2.
+(define setvbuf-mode @mode@)
+
 ;; Let the user override the m4 search path
 (define-undefined gsch2pcb:pcb-m4-path '("$HOME/.pcb" "."))
 
@@ -188,8 +191,8 @@
     ; Guile 2.0: [mode] is an integer (either _IONBF, _IOLBF or _IOFBF)
     ; Guile 2.2: [mode] is a  symbol  (either 'none,  'line  or 'block)
     ;
-    (setvbuf (cdr c2p) (if (string=? (minor-version) "0") _IONBF 'none))
-    (setvbuf (cdr p2c) (if (string=? (minor-version) "0") _IONBF 'none))
+    (setvbuf (cdr c2p) setvbuf-mode)
+    (setvbuf (cdr p2c) setvbuf-mode)
 
     (let ((pid (primitive-fork)))
       (if (= pid 0)


### PR DESCRIPTION
Port mode variable used by setvbuf() is now defined at the
compilation stage to prevent the deprecation warning due to using
deprecated guile-2.0 port buffering mode name.

Affects #332