### PR TITLE
Refactor the macro widget code

### DIFF
--- a/schematic/include/gschem.h
+++ b/schematic/include/gschem.h
@@ -1,3 +1,6 @@
+#ifndef LEPTON_MAIN_HEADER_H_
+#define LEPTON_MAIN_HEADER_H_
+
 /* System headers which gschem headers rely on */
 #include <glib.h>
 #include <gtk/gtk.h>
@@ -57,3 +60,7 @@ typedef void (*i_callback_func) (gpointer, guint, GtkWidget*);
 
 /* Gettext translation */
 #include "gettext.h"
+
+
+#endif /* LEPTON_MAIN_HEADER_H_ */
+

--- a/schematic/include/gschem_macro_widget.h
+++ b/schematic/include/gschem_macro_widget.h
@@ -70,20 +70,8 @@ void
 macro_widget_show (GtkWidget* widget);
 
 
-const char*
-gschem_macro_widget_get_label_text (GschemMacroWidget *widget);
-
-const char*
-gschem_macro_widget_get_macro_string (GschemMacroWidget *widget);
-
 GType
-gschem_macro_widget_get_type ();
-
-void
-gschem_macro_widget_set_label_text (GschemMacroWidget *widget, const char *text);
-
-void
-gschem_macro_widget_set_macro_string (GschemMacroWidget *widget, const char *str);
+gschem_macro_widget_get_type();
 
 
 #endif /* LEPTON_MACRO_WIDGET_H_ */

--- a/schematic/include/gschem_macro_widget.h
+++ b/schematic/include/gschem_macro_widget.h
@@ -58,7 +58,6 @@ struct _GschemMacroWidget
   GtkWidget *combo;
   GtkWidget *entry;
   GtkWidget *evaluate_button;
-  GtkWidget *label;
 };
 
 

--- a/schematic/include/gschem_macro_widget.h
+++ b/schematic/include/gschem_macro_widget.h
@@ -66,6 +66,9 @@ struct _GschemMacroWidget
 GtkWidget*
 macro_widget_new (GschemToplevel* toplevel);
 
+void
+macro_widget_show (GtkWidget* widget);
+
 GtkWidget*
 gschem_macro_widget_get_entry (GschemMacroWidget *widget);
 

--- a/schematic/include/gschem_macro_widget.h
+++ b/schematic/include/gschem_macro_widget.h
@@ -69,8 +69,6 @@ macro_widget_new (GschemToplevel* toplevel);
 void
 macro_widget_show (GtkWidget* widget);
 
-GtkWidget*
-gschem_macro_widget_get_entry (GschemMacroWidget *widget);
 
 const char*
 gschem_macro_widget_get_label_text (GschemMacroWidget *widget);

--- a/schematic/include/gschem_macro_widget.h
+++ b/schematic/include/gschem_macro_widget.h
@@ -1,3 +1,6 @@
+#ifndef LEPTON_MACRO_WIDGET_H_
+#define LEPTON_MACRO_WIDGET_H_
+
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2010 gEDA Contributors (see ChangeLog for details)
@@ -74,3 +77,7 @@ gschem_macro_widget_set_label_text (GschemMacroWidget *widget, const char *text)
 
 void
 gschem_macro_widget_set_macro_string (GschemMacroWidget *widget, const char *str);
+
+
+#endif /* LEPTON_MACRO_WIDGET_H_ */
+

--- a/schematic/include/gschem_macro_widget.h
+++ b/schematic/include/gschem_macro_widget.h
@@ -50,7 +50,10 @@ struct _GschemMacroWidget
 {
   GtkInfoBar parent;
 
+  /* command history: */
   GtkListStore* store;
+
+  GschemToplevel* toplevel;
 
   GtkWidget *combo;
   GtkWidget *entry;

--- a/schematic/include/gschem_macro_widget.h
+++ b/schematic/include/gschem_macro_widget.h
@@ -64,6 +64,9 @@ struct _GschemMacroWidget
 
 
 GtkWidget*
+macro_widget_new (GschemToplevel* toplevel);
+
+GtkWidget*
 gschem_macro_widget_get_entry (GschemMacroWidget *widget);
 
 const char*

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -1,4 +1,5 @@
-/* $Id$ */
+#ifndef LEPTON_PROTOTYPE_H_
+#define LEPTON_PROTOTYPE_H_
 
 /* a_zoom.c */
 void a_zoom(GschemToplevel *w_current, GschemPageView *page_view, int dir, int selected_from);
@@ -787,4 +788,7 @@ void x_tabs_dbg_pages_dump (GschemToplevel* w_current);
 
 /* color_edit_widget.c */
 void color_edit_widget_update (GschemToplevel* w_current);
+
+
+#endif /* LEPTON_PROTOTYPE_H_ */
 

--- a/schematic/scheme/conf/schematic/deprecated.scm
+++ b/schematic/scheme/conf/schematic/deprecated.scm
@@ -157,11 +157,6 @@
    ((@ (geda page) set-page-dirty!) (active-page) #f))
 	   #t)
 
-; Evaluate an expression entered in the magic-colon text box.
-; In 20 years this might dispatch to an interpreter for some other language.
-(define (invoke-macro s-expr)
-  (gschem-log (format #f "~s\n" (eval-string-protected s-expr))))
-
 ;
 ; End of hooks
 ;

--- a/schematic/src/gschem_macro_widget.c
+++ b/schematic/src/gschem_macro_widget.c
@@ -24,18 +24,6 @@
  */
 
 #include <config.h>
-
-#include <stdio.h>
-#ifdef HAVE_STDLIB_H
-#include <stdlib.h>
-#endif
-#ifdef HAVE_STRING_H
-#include <string.h>
-#endif
-#ifdef HAVE_MATH_H
-#include <math.h>
-#endif
-
 #include "gschem.h"
 
 

--- a/schematic/src/gschem_macro_widget.c
+++ b/schematic/src/gschem_macro_widget.c
@@ -43,7 +43,8 @@ enum
 {
   PROP_0,
   PROP_LABEL_TEXT,
-  PROP_MACRO_STRING
+  PROP_MACRO_STRING,
+  PROP_TOPLEVEL
 };
 
 
@@ -201,6 +202,10 @@ get_property (GObject *object, guint param_id, GValue *value, GParamSpec *pspec)
       g_value_set_string (value, gschem_macro_widget_get_macro_string (widget));
       break;
 
+    case PROP_TOPLEVEL:
+      g_value_set_pointer (value, widget->toplevel);
+      break;
+
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, param_id, pspec);
   }
@@ -240,6 +245,10 @@ gschem_macro_widget_class_init (GschemMacroWidgetClass *klass)
                                                         "",
                                                         (GParamFlags) (G_PARAM_READWRITE
                                                                        | G_PARAM_CONSTRUCT)));
+
+  GParamFlags flags = (GParamFlags) (G_PARAM_CONSTRUCT_ONLY | G_PARAM_READWRITE);
+  GParamSpec* spec  = g_param_spec_pointer ("toplevel", "", "", flags);
+  g_object_class_install_property (G_OBJECT_CLASS (klass), PROP_TOPLEVEL, spec);
 }
 
 
@@ -480,6 +489,10 @@ set_property (GObject *object, guint param_id, const GValue *value, GParamSpec *
 
     case PROP_MACRO_STRING:
       gschem_macro_widget_set_macro_string (widget, g_value_get_string (value));
+      break;
+
+    case PROP_TOPLEVEL:
+      widget->toplevel = GSCHEM_TOPLEVEL (g_value_get_pointer (value));
       break;
 
     default:

--- a/schematic/src/gschem_macro_widget.c
+++ b/schematic/src/gschem_macro_widget.c
@@ -88,6 +88,9 @@ static void
 macro_widget_exec_macro (GschemMacroWidget* widget, const gchar* macro_text);
 
 static void
+macro_widget_create (GschemMacroWidget* widget);
+
+static void
 history_add (GtkListStore* store, const gchar* line);
 
 static void
@@ -343,12 +346,18 @@ gschem_macro_widget_get_type ()
 
 
 
-/*! \brief Initialize GschemMacroWidget instance
- *
- *  \param [in,out] view the GschemMacroWidget
+/*! \brief Initialize gobject instance
  */
 static void
-gschem_macro_widget_init (GschemMacroWidget *widget)
+gschem_macro_widget_init (GschemMacroWidget* widget)
+{
+  macro_widget_create (widget);
+}
+
+
+
+static void
+macro_widget_create (GschemMacroWidget* widget)
 {
   GtkWidget *action = gtk_info_bar_get_action_area (GTK_INFO_BAR (widget));
   GtkWidget *button_box;
@@ -438,7 +447,8 @@ gschem_macro_widget_init (GschemMacroWidget *widget)
                     "notify::text",
                     G_CALLBACK (notify_entry_text),
                     widget);
-}
+
+} /* macro_widget_create() */
 
 
 

--- a/schematic/src/gschem_macro_widget.c
+++ b/schematic/src/gschem_macro_widget.c
@@ -1,6 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
- * Copyright (C) 1998-2010 gEDA Contributors (see ChangeLog for details)
+ * Copyright (C) 1998-2013 gEDA Contributors
+ * Copyright (C) 2017-2019 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -19,7 +20,7 @@
 /*!
  * \file gschem_macro_widget.c
  *
- * \brief A widget for entering macros
+ * \brief A widget for entering and executing Guile macros
  */
 
 #include <config.h>
@@ -107,18 +108,16 @@ enum
 
 
 
-/* convenience macro - gobject type implementation:
+/*! \brief Convenience macro - gobject type implementation:
 */
 G_DEFINE_TYPE (GschemMacroWidget, gschem_macro_widget, GTK_TYPE_INFO_BAR);
 
 
 
-/*! \brief Initialize GschemMacroWidget class
- *
- *  \param [in] klass The class for the GschemMacroWidget
+/*! \brief Initialize gobject class
  */
 static void
-gschem_macro_widget_class_init (GschemMacroWidgetClass *klass)
+gschem_macro_widget_class_init (GschemMacroWidgetClass* klass)
 {
   G_OBJECT_CLASS (klass)->get_property = get_property;
   G_OBJECT_CLASS (klass)->set_property = set_property;
@@ -192,7 +191,7 @@ set_property (GObject* object,
  *
  */
 
-/* Callback for when the user presses enter in the entry widget
+/*! \brief Callback for when the user presses enter in the entry widget
  */
 static void
 on_entry_activate (GtkEntry* entry, gpointer data)
@@ -212,7 +211,7 @@ on_entry_activate (GtkEntry* entry, gpointer data)
 
 
 
-/* Callback for when the user clicks the evaluate button
+/*! \brief Callback for when the user clicks the evaluate button
  */
 static void
 on_evaluate_clicked (GtkButton* button, gpointer data)
@@ -226,7 +225,7 @@ on_evaluate_clicked (GtkButton* button, gpointer data)
 
 
 
-/* Callback for when the user clicks the cancel button
+/*! \brief Callback for when the user clicks the cancel button
  */
 static void
 on_cancel_clicked (GtkButton* button, gpointer data)
@@ -345,6 +344,8 @@ macro_widget_exec_macro (GschemMacroWidget* widget, const gchar* macro_text)
 
 
 
+/*! \brief Create the macro widget
+*/
 static void
 macro_widget_create (GschemMacroWidget* widget)
 {

--- a/schematic/src/gschem_macro_widget.c
+++ b/schematic/src/gschem_macro_widget.c
@@ -359,9 +359,9 @@ gschem_macro_widget_init (GschemMacroWidget *widget)
 
   gtk_widget_set_no_show_all (GTK_WIDGET (widget), TRUE);
 
-  widget->label = gtk_label_new (NULL);
-  gtk_widget_set_visible (widget->label, TRUE);
-  gtk_box_pack_start (GTK_BOX (content), widget->label, FALSE, FALSE, 0);
+  GtkWidget* label = gtk_label_new (_("Macro:"));
+  gtk_widget_set_visible (label, TRUE);
+  gtk_box_pack_start (GTK_BOX (content), label, FALSE, FALSE, 0);
 
 
   /* command history list store:

--- a/schematic/src/gschem_macro_widget.c
+++ b/schematic/src/gschem_macro_widget.c
@@ -101,6 +101,20 @@ static GObjectClass *gschem_macro_widget_parent_class = NULL;
 
 
 
+GtkWidget*
+macro_widget_new (GschemToplevel* toplevel)
+{
+  g_return_val_if_fail (toplevel != NULL, NULL);
+
+  gpointer obj = g_object_new (GSCHEM_TYPE_MACRO_WIDGET,
+                               "toplevel", toplevel,
+                               NULL);
+
+  return GTK_WIDGET (obj);
+}
+
+
+
 /* Callback for when the user presses enter in the entry widget
  */
 static void

--- a/schematic/src/gschem_macro_widget.c
+++ b/schematic/src/gschem_macro_widget.c
@@ -51,13 +51,13 @@ enum
 
 
 static void
-activate_entry (GtkWidget *entry, GschemMacroWidget *widget);
+activate_entry (GtkEntry* entry, gpointer data);
 
 static void
-click_cancel (GtkWidget *button, GschemMacroWidget *widget);
+click_cancel (GtkButton* button, gpointer data);
 
 static void
-click_evaluate (GtkWidget *entry, GschemMacroWidget *widget);
+click_evaluate (GtkButton* button, gpointer data);
 
 static void
 dispose (GObject *object);
@@ -197,23 +197,19 @@ macro_widget_exec_macro (GschemMacroWidget* widget, const gchar* macro_text)
 /* Callback for when the user presses enter in the entry widget
  */
 static void
-activate_entry (GtkWidget *entry, GschemMacroWidget *widget)
+activate_entry (GtkEntry* entry, gpointer data)
 {
+  GschemMacroWidget* widget = (GschemMacroWidget*) data;
   g_return_if_fail (widget != NULL);
 
-  if (gtk_entry_get_text_length (GTK_ENTRY (widget->entry)) > 0)
+  if (gtk_entry_get_text_length (entry) <= 0)
   {
-    gtk_info_bar_response (GTK_INFO_BAR (widget), GTK_RESPONSE_OK);
+    macro_widget_hide (widget);
+    return;
+  }
 
-    history_add  (widget->store,
-                  gtk_entry_get_text (GTK_ENTRY (widget->entry)));
-    history_truncate (widget->store);
-    history_save (widget->store);
-  }
-  else
-  {
-    gtk_info_bar_response (GTK_INFO_BAR (widget), GTK_RESPONSE_CANCEL);
-  }
+  const gchar* text = gtk_entry_get_text (entry);
+  macro_widget_exec_macro (widget, text);
 }
 
 
@@ -221,9 +217,12 @@ activate_entry (GtkWidget *entry, GschemMacroWidget *widget)
 /* Callback for when the user clicks the cancel button
  */
 static void
-click_cancel (GtkWidget *button, GschemMacroWidget *widget)
+click_cancel (GtkButton* button, gpointer data)
 {
-  gtk_info_bar_response (GTK_INFO_BAR (widget), GTK_RESPONSE_CANCEL);
+  GschemMacroWidget* widget = (GschemMacroWidget*) data;
+  g_return_if_fail (widget != NULL);
+
+  macro_widget_hide (widget);
 }
 
 
@@ -231,19 +230,13 @@ click_cancel (GtkWidget *button, GschemMacroWidget *widget)
 /* Callback for when the user clicks the evaluate button
  */
 static void
-click_evaluate (GtkWidget *entry, GschemMacroWidget *widget)
+click_evaluate (GtkButton* button, gpointer data)
 {
+  GschemMacroWidget* widget = (GschemMacroWidget*) data;
   g_return_if_fail (widget != NULL);
 
-  if (gtk_entry_get_text_length (GTK_ENTRY (widget->entry)) > 0)
-  {
-    gtk_info_bar_response (GTK_INFO_BAR (widget), GTK_RESPONSE_OK);
-
-    history_add  (widget->store,
-                  gtk_entry_get_text (GTK_ENTRY (widget->entry)));
-    history_truncate (widget->store);
-    history_save (widget->store);
-  }
+  const gchar* text = gtk_entry_get_text (GTK_ENTRY (widget->entry));
+  macro_widget_exec_macro (widget, text);
 }
 
 

--- a/schematic/src/gschem_macro_widget.c
+++ b/schematic/src/gschem_macro_widget.c
@@ -58,12 +58,6 @@ static void
 click_evaluate (GtkButton* button, gpointer data);
 
 static void
-dispose (GObject *object);
-
-static void
-finalize (GObject *object);
-
-static void
 get_property (GObject *object, guint param_id, GValue *value, GParamSpec *pspec);
 
 static void
@@ -104,10 +98,6 @@ history_truncate (GtkListStore* store);
 
 static void
 command_entry_set_font (GtkWidget* entry);
-
-
-
-static GObjectClass *gschem_macro_widget_parent_class = NULL;
 
 
 
@@ -242,32 +232,6 @@ click_evaluate (GtkButton* button, gpointer data)
 
 
 
-/*! \brief Dispose of the object
- */
-static void
-dispose (GObject *object)
-{
-  /* lastly, chain up to the parent dispose */
-
-  g_return_if_fail (gschem_macro_widget_parent_class != NULL);
-  gschem_macro_widget_parent_class->dispose (object);
-}
-
-
-
-/*! \brief Finalize object
- */
-static void
-finalize (GObject *object)
-{
-  /* lastly, chain up to the parent finalize */
-
-  g_return_if_fail (gschem_macro_widget_parent_class != NULL);
-  gschem_macro_widget_parent_class->finalize (object);
-}
-
-
-
 /*! \brief Get a property
  *
  *  \param [in]     object
@@ -300,11 +264,6 @@ get_property (GObject *object, guint param_id, GValue *value, GParamSpec *pspec)
 static void
 gschem_macro_widget_class_init (GschemMacroWidgetClass *klass)
 {
-  gschem_macro_widget_parent_class = G_OBJECT_CLASS (g_type_class_peek_parent (klass));
-
-  G_OBJECT_CLASS (klass)->dispose  = dispose;
-  G_OBJECT_CLASS (klass)->finalize = finalize;
-
   G_OBJECT_CLASS (klass)->get_property = get_property;
   G_OBJECT_CLASS (klass)->set_property = set_property;
 

--- a/schematic/src/gschem_macro_widget.c
+++ b/schematic/src/gschem_macro_widget.c
@@ -42,8 +42,6 @@
 enum
 {
   PROP_0,
-  PROP_LABEL_TEXT,
-  PROP_MACRO_STRING,
   PROP_TOPLEVEL
 };
 
@@ -279,15 +277,8 @@ get_property (GObject *object, guint param_id, GValue *value, GParamSpec *pspec)
 {
   GschemMacroWidget *widget = GSCHEM_MACRO_WIDGET (object);
 
-  switch (param_id) {
-    case PROP_LABEL_TEXT:
-      g_value_set_string (value, gschem_macro_widget_get_label_text (widget));
-      break;
-
-    case PROP_MACRO_STRING:
-      g_value_set_string (value, gschem_macro_widget_get_macro_string (widget));
-      break;
-
+  switch (param_id)
+  {
     case PROP_TOPLEVEL:
       g_value_set_pointer (value, widget->toplevel);
       break;
@@ -313,24 +304,6 @@ gschem_macro_widget_class_init (GschemMacroWidgetClass *klass)
 
   G_OBJECT_CLASS (klass)->get_property = get_property;
   G_OBJECT_CLASS (klass)->set_property = set_property;
-
-  g_object_class_install_property (G_OBJECT_CLASS (klass),
-                                   PROP_LABEL_TEXT,
-                                   g_param_spec_string ("label-text",
-                                                        "Label Text",
-                                                        "Label Text",
-                                                        _("Macro:"),
-                                                        (GParamFlags) (G_PARAM_READWRITE
-                                                                       | G_PARAM_CONSTRUCT)));
-
-  g_object_class_install_property (G_OBJECT_CLASS (klass),
-                                   PROP_MACRO_STRING,
-                                   g_param_spec_string ("macro-string",
-                                                        "Macro String",
-                                                        "Macro String",
-                                                        "",
-                                                        (GParamFlags) (G_PARAM_READWRITE
-                                                                       | G_PARAM_CONSTRUCT)));
 
   GParamFlags flags = (GParamFlags) (G_PARAM_CONSTRUCT_ONLY | G_PARAM_READWRITE);
   GParamSpec* spec  = g_param_spec_pointer ("toplevel", "", "", flags);
@@ -553,15 +526,8 @@ set_property (GObject *object, guint param_id, const GValue *value, GParamSpec *
 {
   GschemMacroWidget *widget = GSCHEM_MACRO_WIDGET (object);
 
-  switch (param_id) {
-    case PROP_LABEL_TEXT:
-      gschem_macro_widget_set_label_text (widget, g_value_get_string (value));
-      break;
-
-    case PROP_MACRO_STRING:
-      gschem_macro_widget_set_macro_string (widget, g_value_get_string (value));
-      break;
-
+  switch (param_id)
+  {
     case PROP_TOPLEVEL:
       widget->toplevel = GSCHEM_TOPLEVEL (g_value_get_pointer (value));
       break;

--- a/schematic/src/gschem_macro_widget.c
+++ b/schematic/src/gschem_macro_widget.c
@@ -101,6 +101,12 @@ command_entry_set_font (GtkWidget* entry);
 
 
 
+/* convenience macro - gobject type implementation:
+*/
+G_DEFINE_TYPE (GschemMacroWidget, gschem_macro_widget, GTK_TYPE_INFO_BAR);
+
+
+
 GtkWidget*
 macro_widget_new (GschemToplevel* toplevel)
 {
@@ -270,37 +276,6 @@ gschem_macro_widget_class_init (GschemMacroWidgetClass *klass)
   GParamFlags flags = (GParamFlags) (G_PARAM_CONSTRUCT_ONLY | G_PARAM_READWRITE);
   GParamSpec* spec  = g_param_spec_pointer ("toplevel", "", "", flags);
   g_object_class_install_property (G_OBJECT_CLASS (klass), PROP_TOPLEVEL, spec);
-}
-
-
-
-/*! \brief Get/register GschemMacroWidget type.
- */
-GType
-gschem_macro_widget_get_type ()
-{
-  static GType type = 0;
-
-  if (type == 0) {
-    static const GTypeInfo info = {
-      sizeof(GschemMacroWidgetClass),
-      NULL,                                                    /* base_init */
-      NULL,                                                    /* base_finalize */
-      (GClassInitFunc) gschem_macro_widget_class_init,
-      NULL,                                                    /* class_finalize */
-      NULL,                                                    /* class_data */
-      sizeof(GschemMacroWidget),
-      0,                                                       /* n_preallocs */
-      (GInstanceInitFunc) gschem_macro_widget_init,
-    };
-
-    type = g_type_register_static (GTK_TYPE_INFO_BAR,
-                                   "GschemMacroWidget",
-                                   &info,
-                                   (GTypeFlags)  0);
-  }
-
-  return type;
 }
 
 

--- a/schematic/src/gschem_macro_widget.c
+++ b/schematic/src/gschem_macro_widget.c
@@ -282,21 +282,6 @@ gschem_macro_widget_class_init (GschemMacroWidgetClass *klass)
 
 
 
-/*! \brief Get the entry
- *
- *  \param [in] widget This GschemMacroWidget
- *  \return The entry
- */
-GtkWidget*
-gschem_macro_widget_get_entry (GschemMacroWidget *widget)
-{
-  g_return_val_if_fail (widget != NULL, NULL);
-
-  return widget->entry;
-}
-
-
-
 /*! \brief Get the label text
  *
  *  \param [in] widget This GschemMacroWidget

--- a/schematic/src/gschem_macro_widget.c
+++ b/schematic/src/gschem_macro_widget.c
@@ -130,6 +130,15 @@ macro_widget_show (GtkWidget* widget)
 
 
 
+static void
+macro_widget_hide (GschemMacroWidget* widget)
+{
+  gtk_widget_hide (GTK_WIDGET (widget));
+  gtk_widget_grab_focus (widget->toplevel->drawing_area);
+}
+
+
+
 /* Callback for when the user presses enter in the entry widget
  */
 static void

--- a/schematic/src/gschem_macro_widget.c
+++ b/schematic/src/gschem_macro_widget.c
@@ -312,36 +312,6 @@ gschem_macro_widget_class_init (GschemMacroWidgetClass *klass)
 
 
 
-/*! \brief Get the label text
- *
- *  \param [in] widget This GschemMacroWidget
- *  \return The label text
- */
-const char*
-gschem_macro_widget_get_label_text (GschemMacroWidget *widget)
-{
-  g_return_val_if_fail (widget != NULL, NULL);
-
-  return gtk_label_get_text (GTK_LABEL (widget->label));
-}
-
-
-
-/*! \brief Get the macro string
- *
- *  \param [in] widget This GschemMacroWidget
- *  \return The macro string
- */
-const char*
-gschem_macro_widget_get_macro_string (GschemMacroWidget *widget)
-{
-  g_return_val_if_fail (widget != NULL, NULL);
-
-  return gtk_entry_get_text (GTK_ENTRY (widget->entry));
-}
-
-
-
 /*! \brief Get/register GschemMacroWidget type.
  */
 GType
@@ -468,40 +438,6 @@ gschem_macro_widget_init (GschemMacroWidget *widget)
                     "notify::text",
                     G_CALLBACK (notify_entry_text),
                     widget);
-}
-
-
-
-/*! \brief Set the label text
- *
- *  \param [in,out] view This GschemMacroWidget
- *  \param [in]     text The label text
- */
-void
-gschem_macro_widget_set_label_text (GschemMacroWidget *widget, const char *text)
-{
-  g_return_if_fail (widget != NULL);
-
-  gtk_label_set_text (GTK_LABEL (widget->label), text);
-
-  g_object_notify (G_OBJECT (widget), "label-text");
-}
-
-
-
-/*! \brief Set the macro string
- *
- *  \param [in,out] view This GschemMacroWidget
- *  \param [in]     str  The macro string
- */
-void
-gschem_macro_widget_set_macro_string (GschemMacroWidget *widget, const char *str)
-{
-  g_return_if_fail (widget != NULL);
-
-  gtk_entry_set_text (GTK_ENTRY (widget->entry), str);
-
-  g_object_notify (G_OBJECT (widget), "macro-string");
 }
 
 

--- a/schematic/src/gschem_macro_widget.c
+++ b/schematic/src/gschem_macro_widget.c
@@ -53,16 +53,16 @@ set_property (GObject* object, guint param_id, const GValue* value, GParamSpec* 
 
 
 static void
-activate_entry (GtkEntry* entry, gpointer data);
+on_entry_activate (GtkEntry* entry, gpointer data);
 
 static void
-click_evaluate (GtkButton* button, gpointer data);
+on_evaluate_clicked (GtkButton* button, gpointer data);
 
 static void
-click_cancel (GtkButton* button, gpointer data);
+on_cancel_clicked (GtkButton* button, gpointer data);
 
 static void
-notify_entry_text (GtkWidget* entry, GParamSpec* pspec, GschemMacroWidget* widget);
+on_entry_notify_text (GtkWidget* entry, GParamSpec* pspec, gpointer data);
 
 
 static void
@@ -195,7 +195,7 @@ set_property (GObject* object,
 /* Callback for when the user presses enter in the entry widget
  */
 static void
-activate_entry (GtkEntry* entry, gpointer data)
+on_entry_activate (GtkEntry* entry, gpointer data)
 {
   GschemMacroWidget* widget = (GschemMacroWidget*) data;
   g_return_if_fail (widget != NULL);
@@ -215,7 +215,7 @@ activate_entry (GtkEntry* entry, gpointer data)
 /* Callback for when the user clicks the evaluate button
  */
 static void
-click_evaluate (GtkButton* button, gpointer data)
+on_evaluate_clicked (GtkButton* button, gpointer data)
 {
   GschemMacroWidget* widget = (GschemMacroWidget*) data;
   g_return_if_fail (widget != NULL);
@@ -229,7 +229,7 @@ click_evaluate (GtkButton* button, gpointer data)
 /* Callback for when the user clicks the cancel button
  */
 static void
-click_cancel (GtkButton* button, gpointer data)
+on_cancel_clicked (GtkButton* button, gpointer data)
 {
   GschemMacroWidget* widget = (GschemMacroWidget*) data;
   g_return_if_fail (widget != NULL);
@@ -239,15 +239,18 @@ click_cancel (GtkButton* button, gpointer data)
 
 
 
-/*! \brief Update the sensitivity of the evaluate button
+/*! \brief GtkEntry's "text" property change notification signal handler
  */
 static void
-notify_entry_text (GtkWidget *entry, GParamSpec *pspec, GschemMacroWidget *widget)
+on_entry_notify_text (GtkWidget* entry, GParamSpec* pspec, gpointer data)
 {
+  GschemMacroWidget* widget = (GschemMacroWidget*) data;
   g_return_if_fail (widget != NULL);
 
-  gtk_widget_set_sensitive (widget->evaluate_button,
-                            (gtk_entry_get_text_length (GTK_ENTRY (widget->entry)) > 0));
+  /* Update the sensitivity of the evaluate button:
+  */
+  guint16 len = gtk_entry_get_text_length (GTK_ENTRY (widget->entry));
+  gtk_widget_set_sensitive (widget->evaluate_button, len > 0);
 }
 
 
@@ -416,22 +419,22 @@ macro_widget_create (GschemMacroWidget* widget)
 
   g_signal_connect (G_OBJECT (widget->entry),
                     "activate",
-                    G_CALLBACK (activate_entry),
+                    G_CALLBACK (&on_entry_activate),
                     widget);
 
   g_signal_connect (G_OBJECT (cancel_button),
                     "clicked",
-                    G_CALLBACK (click_cancel),
+                    G_CALLBACK (&on_cancel_clicked),
                     widget);
 
   g_signal_connect (G_OBJECT (widget->evaluate_button),
                     "clicked",
-                    G_CALLBACK (click_evaluate),
+                    G_CALLBACK (&on_evaluate_clicked),
                     widget);
 
   g_signal_connect (G_OBJECT (widget->entry),
                     "notify::text",
-                    G_CALLBACK (notify_entry_text),
+                    G_CALLBACK (&on_entry_notify_text),
                     widget);
 
 } /* macro_widget_create() */

--- a/schematic/src/gschem_macro_widget.c
+++ b/schematic/src/gschem_macro_widget.c
@@ -115,6 +115,21 @@ macro_widget_new (GschemToplevel* toplevel)
 
 
 
+void
+macro_widget_show (GtkWidget* widget)
+{
+  g_return_if_fail (widget != NULL);
+
+  GschemMacroWidget* macro_widget = GSCHEM_MACRO_WIDGET (widget);
+
+  g_return_if_fail (macro_widget->entry != NULL);
+
+  gtk_widget_show (widget);
+  gtk_widget_grab_focus (macro_widget->entry);
+}
+
+
+
 /* Callback for when the user presses enter in the entry widget
  */
 static void

--- a/schematic/src/i_callbacks.c
+++ b/schematic/src/i_callbacks.c
@@ -827,8 +827,7 @@ DEFINE_I_CALLBACK(edit_invoke_macro)
 
   g_return_if_fail (w_current != NULL);
 
-  gtk_widget_show (w_current->macro_widget);
-  gtk_widget_grab_focus (gschem_macro_widget_get_entry (GSCHEM_MACRO_WIDGET (w_current->macro_widget)));
+  macro_widget_show (w_current->macro_widget);
 }
 
 /*! \todo Finish function documentation!!!

--- a/schematic/src/x_window.c
+++ b/schematic/src/x_window.c
@@ -1304,9 +1304,7 @@ create_show_text_widget (GschemToplevel *w_current, GtkWidget *work_box)
 static void
 create_macro_widget (GschemToplevel *w_current, GtkWidget *work_box)
 {
-  gpointer obj = g_object_new (GSCHEM_TYPE_MACRO_WIDGET, NULL);
-
-  w_current->macro_widget = GTK_WIDGET (obj);
+  w_current->macro_widget = macro_widget_new (w_current);
 
   gtk_box_pack_start (GTK_BOX (work_box),
                       w_current->macro_widget,

--- a/schematic/src/x_window.c
+++ b/schematic/src/x_window.c
@@ -368,25 +368,6 @@ x_window_show_text (GtkWidget *widget, gint response, GschemToplevel *w_current)
 }
 
 
-static void
-x_window_invoke_macro (GschemMacroWidget *widget, int response, GschemToplevel *w_current)
-{
-  if (response == GTK_RESPONSE_OK) {
-    const char *macro = gschem_macro_widget_get_macro_string (widget);
-
-    SCM interpreter = scm_list_2(scm_from_utf8_symbol("invoke-macro"),
-                                 scm_from_utf8_string(macro));
-
-    scm_dynwind_begin ((scm_t_dynwind_flags) 0);
-    g_dynwind_window (w_current);
-    g_scm_eval_protected(interpreter, SCM_UNDEFINED);
-    scm_dynwind_end ();
-  }
-
-  gtk_widget_grab_focus (w_current->drawing_area);
-  gtk_widget_hide (GTK_WIDGET (widget));
-}
-
 void
 x_window_select_object (GschemFindTextState *state, OBJECT *object, GschemToplevel *w_current)
 {
@@ -1309,9 +1290,6 @@ create_macro_widget (GschemToplevel *w_current, GtkWidget *work_box)
   gtk_box_pack_start (GTK_BOX (work_box),
                       w_current->macro_widget,
                       FALSE, FALSE, 0);
-
-  g_signal_connect (w_current->macro_widget, "response",
-                    G_CALLBACK (&x_window_invoke_macro), w_current);
 }
 
 


### PR DESCRIPTION
Beside refactoring, this PR fixes `lepton-schematic` crash after entering `(file-quit)` in the `:` prompt.