### PR TITLE
Fix File->Save All

### DIFF
--- a/liblepton/include/liblepton/geda_page.h
+++ b/liblepton/include/liblepton/geda_page.h
@@ -92,6 +92,9 @@ PAGE*
 s_page_search (TOPLEVEL *toplevel, const gchar *filename);
 
 PAGE*
+s_page_search_by_basename (TOPLEVEL *toplevel, const gchar *filename);
+
+PAGE*
 s_page_search_by_page_id (GedaPageList *list, int pid);
 
 void

--- a/liblepton/src/geda_page.c
+++ b/liblepton/src/geda_page.c
@@ -418,6 +418,47 @@ PAGE *s_page_search (TOPLEVEL *toplevel, const gchar *filename)
   return NULL;
 }
 
+/*! \brief Search for page by its filename's basename.
+ *  \par Function Description
+ *  Searches in \a toplevel's list of pages for a page with
+ *  basename( filename ) equal to \a filename.
+ *
+ *  \param toplevel  The TOPLEVEL object
+ *  \param filename  The filename string to search for
+ *
+ *  \return PAGE pointer to a matching page, NULL otherwise.
+ */
+PAGE *s_page_search_by_basename (TOPLEVEL *toplevel, const gchar *filename)
+{
+  const GList* iter   = NULL;
+  PAGE*        page   = NULL;
+  PAGE*        result = NULL;
+
+  for ( iter = geda_list_get_glist( toplevel->pages );
+        iter != NULL;
+        iter = g_list_next( iter ) )
+  {
+    page = (PAGE*) iter->data;
+
+    const gchar* fname = s_page_get_filename (page);
+    gchar* bname = g_path_get_basename (fname);
+
+    /* FIXME this may not be correct on platforms with
+     * case-insensitive filesystems. */
+
+    if ( strcmp( bname, filename ) == 0 )
+    {
+      result = page;
+      g_free (bname);
+      break;
+    }
+
+    g_free (bname);
+  }
+
+  return result;
+}
+
 /*! \brief Search for a page given its page id in a page list.
  *  \par Function Description
  *  This functions returns the page that have the page id \a pid in

--- a/schematic/include/gschem_defines.h
+++ b/schematic/include/gschem_defines.h
@@ -112,4 +112,17 @@ typedef enum
 #define MENU			1
 #define HOTKEY			2
 
+/* The prefix of the default filename used for newly created pages
+ *
+ * TRANSLATORS:
+ *
+ * This string is used to generate a filename for newly-created files.
+ * It will be used to create a filename of the form "untitled_N.sch",
+ * where N is a number.
+ * Please make sure that the translation contains characters
+ * suitable for use in a filename.
+ *
+ * */
+#define UNTITLED_FILENAME_PREFIX _("untitled")
+
 #endif /* !_GSCHEM_DEFINES_H_INCL */

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -758,6 +758,7 @@ void x_window_init_icons (void);
 GschemToplevel* x_window_new (TOPLEVEL *toplevel);
 void x_window_select_object (GschemFindTextState *state, OBJECT *object, GschemToplevel *w_current);
 void x_window_setup_scrolling (GschemToplevel *w_current, GtkWidget *scrolled);
+gboolean x_window_untitled_page (PAGE* page);
 
 /* x_widgets.c */
 gboolean x_widgets_use_docks();

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -668,7 +668,7 @@ void x_compselect_open (GschemToplevel *w_current);
 void x_compselect_deselect (GschemToplevel *w_current);
 /* x_fileselect.c */
 void x_fileselect_open(GschemToplevel *w_current);
-void x_fileselect_save(GschemToplevel *w_current, PAGE* page);
+gboolean x_fileselect_save(GschemToplevel *w_current, PAGE* page, gboolean* result);
 int x_fileselect_load_backup(void *user_data, GString *message);
 /* x_fstylecb.c */
 GtkWidget* x_fstylecb_new ();

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -668,7 +668,7 @@ void x_compselect_open (GschemToplevel *w_current);
 void x_compselect_deselect (GschemToplevel *w_current);
 /* x_fileselect.c */
 void x_fileselect_open(GschemToplevel *w_current);
-void x_fileselect_save(GschemToplevel *w_current);
+void x_fileselect_save(GschemToplevel *w_current, PAGE* page);
 int x_fileselect_load_backup(void *user_data, GString *message);
 /* x_fstylecb.c */
 GtkWidget* x_fstylecb_new ();

--- a/schematic/src/i_callbacks.c
+++ b/schematic/src/i_callbacks.c
@@ -231,16 +231,18 @@ DEFINE_I_CALLBACK(file_save_all)
     if (x_window_untitled_page (page))
     {
       /* open "save as..." dialog: */
-      x_fileselect_save (w_current, page, &res);
+      if (x_fileselect_save (w_current, page, &res))
+      {
+        result = result && res;
+      }
     }
     else
     {
       /* save page: */
       const gchar* fname = s_page_get_filename (page);
       res = x_window_save_page (w_current, page, fname);
+      result = result && res;
     }
-
-    result = result && res;
 
 
     if (x_tabs_enabled())

--- a/schematic/src/i_callbacks.c
+++ b/schematic/src/i_callbacks.c
@@ -181,7 +181,7 @@ DEFINE_I_CALLBACK(file_save)
   if (x_window_untitled_page (page))
   {
     /* open "save as..." dialog: */
-    x_fileselect_save (w_current);
+    x_fileselect_save (w_current, page);
   }
   else
   {
@@ -252,7 +252,11 @@ DEFINE_I_CALLBACK(file_save_as)
   GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
 
   g_return_if_fail (w_current != NULL);
-  x_fileselect_save (w_current);
+
+  TOPLEVEL* toplevel = gschem_toplevel_get_toplevel (w_current);
+  PAGE* page = toplevel->page_current;
+
+  x_fileselect_save (w_current, page);
 }
 
 /*! \todo Finish function documentation!!!

--- a/schematic/src/i_callbacks.c
+++ b/schematic/src/i_callbacks.c
@@ -181,7 +181,7 @@ DEFINE_I_CALLBACK(file_save)
   if (x_window_untitled_page (page))
   {
     /* open "save as..." dialog: */
-    x_fileselect_save (w_current, page);
+    x_fileselect_save (w_current, page, NULL);
   }
   else
   {
@@ -228,7 +228,7 @@ DEFINE_I_CALLBACK(file_save_all)
     if (x_window_untitled_page (page))
     {
       /* open "save as..." dialog: */
-      x_fileselect_save (w_current, page);
+      x_fileselect_save (w_current, page, NULL);
     }
     else
     {
@@ -264,7 +264,7 @@ DEFINE_I_CALLBACK(file_save_as)
   TOPLEVEL* toplevel = gschem_toplevel_get_toplevel (w_current);
   PAGE* page = toplevel->page_current;
 
-  x_fileselect_save (w_current, page);
+  x_fileselect_save (w_current, page, NULL);
 }
 
 /*! \todo Finish function documentation!!!

--- a/schematic/src/i_callbacks.c
+++ b/schematic/src/i_callbacks.c
@@ -209,6 +209,8 @@ void i_callback_toolbar_file_save(GtkWidget* widget, gpointer data)
   i_callback_file_save (data, 0, widget);
 }
 
+
+
 /*! \brief Save all opened pages
  */
 DEFINE_I_CALLBACK(file_save_all)
@@ -234,11 +236,19 @@ DEFINE_I_CALLBACK(file_save_all)
       const gchar* fname = s_page_get_filename (page);
       x_window_save_page (w_current, page, fname);
     }
+
+    if (x_tabs_enabled())
+    {
+      x_tabs_hdr_update (w_current, page);
+    }
   }
 
   x_pagesel_update (w_current);
   i_update_menus(w_current);
-}
+
+} /* i_callback_file_save_all() */
+
+
 
 /*! \todo Finish function documentation!!!
  *  \brief

--- a/schematic/src/i_callbacks.c
+++ b/schematic/src/i_callbacks.c
@@ -219,23 +219,21 @@ DEFINE_I_CALLBACK(file_save_all)
   TOPLEVEL* toplevel = gschem_toplevel_get_toplevel (w_current);
   GList*    pages    = geda_list_get_glist (toplevel->pages);
 
-  /* save currently selected page:
-  */
-  PAGE* lastpage = toplevel->page_current;
-
   for ( ; pages != NULL; pages = g_list_next (pages) )
   {
     PAGE* page = (PAGE*) pages->data;
 
-    x_window_set_current_page (w_current, page);
-    i_callback_file_save (data, callback_action, widget);
-  }
-
-  /* restore last selected page:
-  */
-  if (lastpage != toplevel->page_current)
-  {
-    x_window_set_current_page (w_current, lastpage);
+    if (x_window_untitled_page (page))
+    {
+      /* open "save as..." dialog: */
+      x_fileselect_save (w_current, page);
+    }
+    else
+    {
+      /* save page: */
+      const gchar* fname = s_page_get_filename (page);
+      x_window_save_page (w_current, page, fname);
+    }
   }
 
   x_pagesel_update (w_current);

--- a/schematic/src/i_callbacks.c
+++ b/schematic/src/i_callbacks.c
@@ -169,35 +169,16 @@ DEFINE_I_CALLBACK(file_script)
 DEFINE_I_CALLBACK(file_save)
 {
   GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-  PAGE *page;
-  EdaConfig *cfg;
-  gchar *untitled_name;
-
   g_return_if_fail (w_current != NULL);
 
-  page = gschem_toplevel_get_toplevel (w_current)->page_current;
+  TOPLEVEL* toplevel = gschem_toplevel_get_toplevel (w_current);
+  PAGE* page = toplevel->page_current;
 
   if (page == NULL) {
     return;
   }
 
-  const gchar* fname = s_page_get_filename (page);
-
-  cfg = eda_config_get_context_for_path (fname);
-  g_return_if_fail (cfg != NULL);
-
-  untitled_name = eda_config_get_string (cfg, "gschem", "default-filename", NULL);
-  g_return_if_fail (untitled_name != NULL);
-
-  gboolean file_exists = g_file_test (fname, G_FILE_TEST_EXISTS);
-  gboolean named_like_untitled = strstr (fname, untitled_name) != NULL;
-  g_free (untitled_name);
-
-  /*
-   * consider page as "untitled" if it is named like untitled
-   * and associated file does not exist:
-  */
-  if (named_like_untitled && !file_exists)
+  if (x_window_untitled_page (page))
   {
     /* open "save as..." dialog: */
     x_fileselect_save (w_current);
@@ -205,6 +186,7 @@ DEFINE_I_CALLBACK(file_save)
   else
   {
     /* save page: */
+    const gchar* fname = s_page_get_filename (page);
     x_window_save_page (w_current, page, fname);
   }
 

--- a/schematic/src/i_callbacks.c
+++ b/schematic/src/i_callbacks.c
@@ -227,24 +227,33 @@ void i_callback_toolbar_file_save(GtkWidget* widget, gpointer data)
   i_callback_file_save (data, 0, widget);
 }
 
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- *  \note
- *  don't use the widget parameter on this function, or do some checking...
- *  since there is a call: widget = NULL, data = 0 (will be w_current)
+/*! \brief Save all opened pages
  */
 DEFINE_I_CALLBACK(file_save_all)
 {
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-
+  GschemToplevel* w_current = GSCHEM_TOPLEVEL (data);
   g_return_if_fail (w_current != NULL);
 
-  if (s_page_save_all(gschem_toplevel_get_toplevel (w_current))) {
-     i_set_state_msg(w_current, SELECT, _("Failed to Save All"));
-  } else {
-     i_set_state_msg(w_current, SELECT, _("Saved All"));
+  TOPLEVEL* toplevel = gschem_toplevel_get_toplevel (w_current);
+  GList*    pages    = geda_list_get_glist (toplevel->pages);
+
+  /* save currently selected page:
+  */
+  PAGE* lastpage = toplevel->page_current;
+
+  for ( ; pages != NULL; pages = g_list_next (pages) )
+  {
+    PAGE* page = (PAGE*) pages->data;
+
+    x_window_set_current_page (w_current, page);
+    i_callback_file_save (data, callback_action, widget);
+  }
+
+  /* restore last selected page:
+  */
+  if (lastpage != toplevel->page_current)
+  {
+    x_window_set_current_page (w_current, lastpage);
   }
 
   x_pagesel_update (w_current);

--- a/schematic/src/i_callbacks.c
+++ b/schematic/src/i_callbacks.c
@@ -221,6 +221,9 @@ DEFINE_I_CALLBACK(file_save_all)
   TOPLEVEL* toplevel = gschem_toplevel_get_toplevel (w_current);
   GList*    pages    = geda_list_get_glist (toplevel->pages);
 
+  gboolean result = TRUE;
+  gboolean res    = FALSE;
+
   for ( ; pages != NULL; pages = g_list_next (pages) )
   {
     PAGE* page = (PAGE*) pages->data;
@@ -228,18 +231,30 @@ DEFINE_I_CALLBACK(file_save_all)
     if (x_window_untitled_page (page))
     {
       /* open "save as..." dialog: */
-      x_fileselect_save (w_current, page, NULL);
+      x_fileselect_save (w_current, page, &res);
     }
     else
     {
       /* save page: */
       const gchar* fname = s_page_get_filename (page);
-      x_window_save_page (w_current, page, fname);
+      res = x_window_save_page (w_current, page, fname);
     }
+
+    result = result && res;
+
 
     if (x_tabs_enabled())
     {
       x_tabs_hdr_update (w_current, page);
+    }
+
+    if (result)
+    {
+      i_set_state_msg(w_current, SELECT, _("Saved All"));
+    }
+    else
+    {
+      i_set_state_msg(w_current, SELECT, _("Failed to Save All"));
     }
   }
 

--- a/schematic/src/i_vars.c
+++ b/schematic/src/i_vars.c
@@ -193,13 +193,12 @@ i_vars_init_gschem_defaults()
   EdaConfig *cfg = eda_config_get_default_context ();
 
   /* This is the prefix of the default filename used for newly created
-   * schematics and symbols. */
-  /// TRANSLATORS: this string is used to generate a filename for
-  /// newly-created files.  It will be used to create a filename of
-  /// the form "untitled_N.sch", where N is a number.  Please make
-  /// sure that the translation contains characters suitable for use
-  /// in a filename.
-  eda_config_set_string (cfg, "gschem", "default-filename", _("untitled"));
+   * schematics and symbols.
+  */
+  eda_config_set_string (cfg,
+                         "gschem",
+                         "default-filename",
+                         UNTITLED_FILENAME_PREFIX);
 }
 
 /*! \brief Save user config on exit.

--- a/schematic/src/x_fileselect.c
+++ b/schematic/src/x_fileselect.c
@@ -296,20 +296,24 @@ x_fileselect_open(GschemToplevel *w_current)
 /*! \brief Opens a file chooser for saving the current page.
  *  \par Function Description
  *  This function opens a file chooser dialog and wait for the user to
- *  select a file where the <B>toplevel</B>'s current page will be
- *  saved.
+ *  select a file where the \a page will be saved.
  *
  *  If the user cancels the operation (with the cancel button), the
  *  page is not saved.
  *
- *  The function updates the user interface.
+ *  The function updates the user interface. (Actual UI update
+ *  is performed in x_window_save_page(), which is called by this
+ *  function.
  *
  *  \param [in] w_current The GschemToplevel environment.
+ *  \param [in] page      The page to be saved.
  */
 void
-x_fileselect_save (GschemToplevel *w_current)
+x_fileselect_save (GschemToplevel *w_current, PAGE* page)
 {
-  TOPLEVEL *toplevel = gschem_toplevel_get_toplevel (w_current);
+  g_return_if_fail (w_current != NULL);
+  g_return_if_fail (page != NULL);
+
   GtkWidget *dialog;
 
   dialog = gtk_file_chooser_dialog_new (_("Save as..."),
@@ -339,17 +343,17 @@ x_fileselect_save (GschemToplevel *w_current)
   /* add file filters to dialog */
   x_fileselect_setup_filechooser_filters (GTK_FILE_CHOOSER (dialog));
   /* set the current filename or directory name if new document */
-  if (g_file_test (s_page_get_filename (toplevel->page_current),
+  if (g_file_test (s_page_get_filename (page),
                    G_FILE_TEST_EXISTS)) {
     gtk_file_chooser_set_filename (GTK_FILE_CHOOSER (dialog),
-                                   s_page_get_filename (toplevel->page_current));
+                                   s_page_get_filename (page));
   } else {
     gchar *cwd = g_get_current_dir ();
     /* force save in current working dir */
     gtk_file_chooser_set_current_folder (GTK_FILE_CHOOSER (dialog), cwd);
     g_free (cwd);
     /* set page file's basename as the current filename: */
-    const gchar* fname = s_page_get_filename (toplevel->page_current);
+    const gchar* fname = s_page_get_filename (page);
     gchar* bname = g_path_get_basename (fname);
     gtk_file_chooser_set_current_name (GTK_FILE_CHOOSER (dialog), bname);
     g_free (bname);
@@ -389,7 +393,7 @@ x_fileselect_save (GschemToplevel *w_current)
     /* try saving current page of toplevel to file filename */
     if (filename != NULL) {
       x_window_save_page (w_current,
-                          w_current->toplevel->page_current,
+                          page,
                           filename);
     }
 

--- a/schematic/src/x_fileselect.c
+++ b/schematic/src/x_fileselect.c
@@ -293,6 +293,8 @@ x_fileselect_open(GschemToplevel *w_current)
 
 }
 
+
+
 /*! \brief Opens a file chooser for saving the current page.
  *  \par Function Description
  *  This function opens a file chooser dialog and wait for the user to
@@ -314,25 +316,25 @@ x_fileselect_save (GschemToplevel *w_current, PAGE* page)
   g_return_if_fail (w_current != NULL);
   g_return_if_fail (page != NULL);
 
-  GtkWidget *dialog;
+  GtkWidget* dialog = gtk_file_chooser_dialog_new(
+    _("Save as..."),
+    GTK_WINDOW(w_current->main_window),
+    GTK_FILE_CHOOSER_ACTION_SAVE,
+    GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL,
+    GTK_STOCK_SAVE,   GTK_RESPONSE_ACCEPT,
+    NULL);
 
-  dialog = gtk_file_chooser_dialog_new (_("Save as..."),
-                                        GTK_WINDOW(w_current->main_window),
-                                        GTK_FILE_CHOOSER_ACTION_SAVE,
-                                        GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL,
-                                        GTK_STOCK_SAVE,   GTK_RESPONSE_ACCEPT,
-                                        NULL);
-
-  /* Set the alternative button order (ok, cancel, help) for other systems */
+  /* Set the alternative button order (ok, cancel, help) for other systems:
+  */
   gtk_dialog_set_alternative_button_order(GTK_DIALOG(dialog),
 					  GTK_RESPONSE_ACCEPT,
 					  GTK_RESPONSE_CANCEL,
 					  -1);
 
   /* set default response signal. This is usually triggered by the
-     "Return" key */
-  gtk_dialog_set_default_response(GTK_DIALOG(dialog),
-				  GTK_RESPONSE_ACCEPT);
+   * "Return" key:
+  */
+  gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_ACCEPT);
 
   g_object_set (dialog,
                 /* GtkFileChooser */
@@ -340,39 +342,56 @@ x_fileselect_save (GschemToplevel *w_current, PAGE* page)
                 /* only in GTK 2.8 */
                 /* "do-overwrite-confirmation", TRUE, */
                 NULL);
-  /* add file filters to dialog */
+
+  /* add file filters to dialog:
+  */
   x_fileselect_setup_filechooser_filters (GTK_FILE_CHOOSER (dialog));
-  /* set the current filename or directory name if new document */
-  if (g_file_test (s_page_get_filename (page),
-                   G_FILE_TEST_EXISTS)) {
+
+  /* set the current filename or directory name if new document:
+  */
+  if (g_file_test (s_page_get_filename (page), G_FILE_TEST_EXISTS))
+  {
     gtk_file_chooser_set_filename (GTK_FILE_CHOOSER (dialog),
                                    s_page_get_filename (page));
-  } else {
+  }
+  else
+  {
     gchar *cwd = g_get_current_dir ();
-    /* force save in current working dir */
+
+    /* force save in current working dir:
+    */
     gtk_file_chooser_set_current_folder (GTK_FILE_CHOOSER (dialog), cwd);
     g_free (cwd);
-    /* set page file's basename as the current filename: */
+
+    /* set page file's basename as the current filename:
+    */
     const gchar* fname = s_page_get_filename (page);
     gchar* bname = g_path_get_basename (fname);
     gtk_file_chooser_set_current_name (GTK_FILE_CHOOSER (dialog), bname);
     g_free (bname);
   }
 
-  gtk_dialog_set_default_response(GTK_DIALOG(dialog),
-				  GTK_RESPONSE_ACCEPT);
-  gtk_widget_show (dialog);
-  if (gtk_dialog_run ((GtkDialog*)dialog) == GTK_RESPONSE_ACCEPT) {
+  gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_ACCEPT);
 
-    /* remember current filter: */
+
+  /*
+   * Open "Save As.." dialog:
+  */
+
+  gtk_widget_show (dialog);
+  if (gtk_dialog_run ((GtkDialog*)dialog) == GTK_RESPONSE_ACCEPT)
+  {
+    /* remember current filter:
+    */
     filter_last_savedlg = gtk_file_chooser_get_filter (GTK_FILE_CHOOSER (dialog));
 
-    gchar *filename =
-      gtk_file_chooser_get_filename (GTK_FILE_CHOOSER (dialog));
+    gchar *filename = gtk_file_chooser_get_filename (GTK_FILE_CHOOSER (dialog));
 
     /* If the file already exists, display a dialog box to check if
-       the user really wants to overwrite it. */
-    if ((filename != NULL) && g_file_test (filename, G_FILE_TEST_EXISTS)) {
+       the user really wants to overwrite it:
+    */
+    if ((filename != NULL) && g_file_test (filename, G_FILE_TEST_EXISTS))
+    {
       GtkWidget *checkdialog =
         gtk_message_dialog_new (GTK_WINDOW(dialog),
                                 (GtkDialogFlags) (GTK_DIALOG_MODAL |
@@ -382,26 +401,36 @@ x_fileselect_save (GschemToplevel *w_current, PAGE* page)
                                 _("The selected file `%1$s' already exists.\n\n"
                                   "Would you like to overwrite it?"),
                                 filename);
+
       gtk_window_set_title (GTK_WINDOW (checkdialog), _("Overwrite file?"));
-      if (gtk_dialog_run (GTK_DIALOG (checkdialog)) != GTK_RESPONSE_YES) {
+
+      if (gtk_dialog_run (GTK_DIALOG (checkdialog)) != GTK_RESPONSE_YES)
+      {
         s_log_message (_("Save cancelled on user request"));
         g_free (filename);
         filename = NULL;
       }
+
       gtk_widget_destroy (checkdialog);
     }
-    /* try saving current page of toplevel to file filename */
-    if (filename != NULL) {
-      x_window_save_page (w_current,
-                          page,
-                          filename);
+
+
+    /* try saving the page to file filename:
+    */
+    if (filename != NULL)
+    {
+      x_window_save_page (w_current, page, filename);
     }
 
     g_free (filename);
-  }
+
+  } /* if: accept response */
+
   gtk_widget_destroy (dialog);
 
-}
+} /* x_fileselect_save() */
+
+
 
 /*! \brief Load/Backup selection dialog.
  *  \par Function Description

--- a/schematic/src/x_fileselect.c
+++ b/schematic/src/x_fileselect.c
@@ -301,20 +301,28 @@ x_fileselect_open(GschemToplevel *w_current)
  *  select a file where the \a page will be saved.
  *
  *  If the user cancels the operation (with the cancel button), the
- *  page is not saved.
+ *  page is not saved and FALSE is returned.
  *
  *  The function updates the user interface. (Actual UI update
  *  is performed in x_window_save_page(), which is called by this
- *  function.
+ *  function).
  *
- *  \param [in] w_current The GschemToplevel environment.
- *  \param [in] page      The page to be saved.
+ *  \param  [in]     w_current The GschemToplevel environment.
+ *  \param  [in]     page      The page to be saved.
+ *  \param  [in,out] result    If not NULL, will be filled with save operation result.
+ *  \return                    TRUE if dialog was closed with ACCEPT response.
  */
-void
-x_fileselect_save (GschemToplevel *w_current, PAGE* page)
+gboolean
+x_fileselect_save (GschemToplevel *w_current, PAGE* page, gboolean* result)
 {
-  g_return_if_fail (w_current != NULL);
-  g_return_if_fail (page != NULL);
+  g_return_val_if_fail (w_current != NULL, FALSE);
+  g_return_val_if_fail (page != NULL, FALSE);
+
+  gboolean ret = FALSE;
+  if (result != NULL)
+  {
+    *result = FALSE;
+  }
 
   GtkWidget* dialog = gtk_file_chooser_dialog_new(
     _("Save as..."),
@@ -371,8 +379,6 @@ x_fileselect_save (GschemToplevel *w_current, PAGE* page)
     g_free (bname);
   }
 
-  gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_ACCEPT);
-
 
   /*
    * Open "Save As.." dialog:
@@ -419,7 +425,14 @@ x_fileselect_save (GschemToplevel *w_current, PAGE* page)
     */
     if (filename != NULL)
     {
-      x_window_save_page (w_current, page, filename);
+      ret = TRUE;
+
+      gboolean res = x_window_save_page (w_current, page, filename);
+
+      if (result != NULL)
+      {
+        *result = res;
+      }
     }
 
     g_free (filename);
@@ -427,6 +440,8 @@ x_fileselect_save (GschemToplevel *w_current, PAGE* page)
   } /* if: accept response */
 
   gtk_widget_destroy (dialog);
+
+  return ret;
 
 } /* x_fileselect_save() */
 

--- a/schematic/src/x_window.c
+++ b/schematic/src/x_window.c
@@ -1675,10 +1675,9 @@ untitled_filename (GschemToplevel* w_current, gboolean log_skipped)
   for (;;)
   {
     /* Build file name (default name + number appended):
-     * TODO: define _("untitled") string globally somewhere:
     */
     fname = g_strdup_printf ("%s_%d.sch",
-                             name ? name : _("untitled"),
+                             name ? name : UNTITLED_FILENAME_PREFIX,
                              untitled_next_index (w_current));
 
     /* Build full path for file name:
@@ -1744,9 +1743,7 @@ x_window_untitled_page (PAGE* page)
 
   if (uname == NULL)
   {
-    /* TODO: define _("untitled") string globally somewhere:
-    */
-    uname = g_strdup (_("untitled"));
+    uname = g_strdup (UNTITLED_FILENAME_PREFIX);
   }
 
   gboolean named_like_untitled = strstr (fname, uname) != NULL;

--- a/schematic/src/x_window.c
+++ b/schematic/src/x_window.c
@@ -97,7 +97,7 @@ static int
 untitled_next_index (GschemToplevel* w_current);
 
 static gchar*
-untitled_filename (GschemToplevel* w_current);
+untitled_filename (GschemToplevel* w_current, gboolean log_skipped);
 
 static PAGE*
 x_window_new_page (GschemToplevel* w_current);
@@ -1534,7 +1534,7 @@ x_window_new_page (GschemToplevel* w_current)
   g_return_val_if_fail (toplevel != NULL, NULL);
 
   /* New page file name: */
-  gchar* filename = untitled_filename (w_current);
+  gchar* filename = untitled_filename (w_current, TRUE);
 
   /* Create a new page: */
   PAGE* page = s_page_new (toplevel, filename);
@@ -1643,12 +1643,16 @@ untitled_next_index (GschemToplevel* w_current)
  *
  * Determine "untitled" schematic file name (used for new pages)
  * and build full path from this name and current working directory.
+ * When constructing this name, avoid reusing names of already opened
+ * files and existing files in current directory; if \a log_skipped
+ * is TRUE, report such (avoided) names to the log.
  *
- *  \param w_current The toplevel environment.
- *  \return          Newly-allocated untitled file path.
+ *  \param  w_current   The toplevel environment.
+ *  \param  log_skipped Print skipped file names to the log.
+ *  \return             Newly-allocated untitled file path.
  */
 static gchar*
-untitled_filename (GschemToplevel* w_current)
+untitled_filename (GschemToplevel* w_current, gboolean log_skipped)
 {
   g_return_val_if_fail (w_current != NULL, NULL);
 
@@ -1674,8 +1678,8 @@ untitled_filename (GschemToplevel* w_current)
      * TODO: define _("untitled") string globally somewhere:
     */
     fname = g_strdup_printf ("%s_%d.sch",
-                           name ? name : _("untitled"),
-                           untitled_next_index (w_current));
+                             name ? name : _("untitled"),
+                             untitled_next_index (w_current));
 
     /* Build full path for file name:
     */
@@ -1687,6 +1691,11 @@ untitled_filename (GschemToplevel* w_current)
     if ( s_page_search_by_basename (toplevel, fname) ||
          g_file_test (fpath, G_FILE_TEST_EXISTS) )
     {
+      if (log_skipped)
+      {
+        s_log_message (_("Skipping existing file [%s]"), fname);
+      }
+
       g_free (fname);
       g_free (fpath);
     }

--- a/schematic/src/x_window.c
+++ b/schematic/src/x_window.c
@@ -1671,9 +1671,10 @@ untitled_filename (GschemToplevel* w_current)
   for (;;)
   {
     /* Build file name (default name + number appended):
+     * TODO: define _("untitled") string globally somewhere:
     */
     fname = g_strdup_printf ("%s_%d.sch",
-                           name ? name : "untitled",
+                           name ? name : _("untitled"),
                            untitled_next_index (w_current));
 
     /* Build full path for file name:

--- a/schematic/src/x_window.c
+++ b/schematic/src/x_window.c
@@ -93,6 +93,9 @@ static void
 recent_manager_add (GschemToplevel* w_current,
                     const gchar*    filename);
 
+static int
+untitled_next_index (GschemToplevel* w_current);
+
 static gchar*
 untitled_filename (GschemToplevel* w_current);
 
@@ -1625,6 +1628,16 @@ recent_manager_add (GschemToplevel* w_current,
 
 
 
+/*! \brief Get next number to be part of the untitled file name.
+ */
+static int
+untitled_next_index (GschemToplevel* w_current)
+{
+  return ++w_current->num_untitled;
+}
+
+
+
 /*! \brief Get untitled file name.
  *  \par Function Description
  *
@@ -1651,7 +1664,7 @@ untitled_filename (GschemToplevel* w_current)
   /* Build file name: */
   gchar* tmp = g_strdup_printf ("%s_%d.sch",
                                 name ? name : "untitled",
-                                ++w_current->num_untitled);
+                                untitled_next_index (w_current));
   g_free (name);
 
   /* Build full path for file name: */

--- a/schematic/src/x_window.c
+++ b/schematic/src/x_window.c
@@ -1703,3 +1703,52 @@ untitled_filename (GschemToplevel* w_current)
 
 } /* untitled_filename() */
 
+
+
+/*! \brief Determine if a given \a page is "untitled" one.
+ *  \par Function Description
+ *
+ *"Untitled" pages are newly created pages with the default
+ * file name and not yet saved to disk.
+ * This function check if a \a page meets these conditions.
+ *
+ *  \param  w_current Page to check.
+ *  \return           TRUE if a \a page looks like "untitled" one.
+ */
+gboolean
+x_window_untitled_page (PAGE* page)
+{
+  g_return_val_if_fail (page != NULL, TRUE);
+
+  const gchar* fname = s_page_get_filename (page);
+  gchar* uname = NULL;
+
+  EdaConfig* cfg = eda_config_get_context_for_path (fname);
+  if (cfg != NULL)
+  {
+    uname = eda_config_get_string (cfg,
+                                   "gschem",
+                                   "default-filename",
+                                   NULL);
+  }
+
+  if (uname == NULL)
+  {
+    /* TODO: define _("untitled") string globally somewhere:
+    */
+    uname = g_strdup (_("untitled"));
+  }
+
+  gboolean named_like_untitled = strstr (fname, uname) != NULL;
+  gboolean file_exists = g_file_test (fname, G_FILE_TEST_EXISTS);
+
+  g_free (uname);
+
+  /*
+   * consider page as "untitled" if it is named like untitled
+   * and associated file does not exist:
+  */
+  return named_like_untitled && !file_exists;
+
+} /* untitled_page() */
+


### PR DESCRIPTION
On `File->Save All`, all opened pages are silently saved,
even if there are new "untitled" pages among them.
The user should be prompted to save new pages.