### PR TITLE
docs/wiki: Makefile note on out-of-source build

### DIFF
--- a/docs/wiki/Makefile.am
+++ b/docs/wiki/Makefile.am
@@ -1,5 +1,13 @@
 wikidir = $(docdir)/wiki
 
+#
+# NOTE: While constructing the list of files to install,
+# we search for symbolic links (-type l) as well as
+# regular files (-type f). This is done to facilitate
+# out-of-source builds using a tree of symbolic links,
+# created, for example, with lndir(1).
+#
+
 # Copy wiki into distribution
 dist-hook:
 	@for dir in $$(cd $(srcdir) && find . -type d -print | sed -e's:^\./::' ); do \


### PR DESCRIPTION
Describe why we search also for symbolic links, while forming the list of files to install (see #341).