### PR TITLE
Fix log output of a translated string.

### DIFF
--- a/liblepton/src/g_basic.c
+++ b/liblepton/src/g_basic.c
@@ -257,9 +257,9 @@ process_error_stack (SCM s_stack, SCM s_key, SCM s_args, GError **err) {
   /* Capture long error message (including possible backtrace) */
   s_port = scm_open_output_string ();
   if (scm_is_true (scm_stack_p (s_stack))) {
-    scm_puts (_("\nBacktrace:\n"), s_port);
+    scm_display (scm_from_utf8_string (_("\nBacktrace:\n")), s_port);
     scm_display_backtrace (s_stack, s_port, SCM_BOOL_F, SCM_BOOL_F);
-    scm_puts ("\n", s_port);
+    scm_display (scm_from_utf8_string ("\n"), s_port);
   }
 
 #ifdef HAVE_SCM_DISPLAY_ERROR_STACK


### PR DESCRIPTION
scm_puts() breaks translated Unicode strings and outputs them as
sets of bytes. Their further transformation by gtk functions
results in unreadable text in lepton-schematic's log window.