### PR TITLE
Transform gschem.scm into 2 modules

### DIFF
--- a/schematic/lib/system-gschemrc.scm
+++ b/schematic/lib/system-gschemrc.scm
@@ -3,8 +3,11 @@
 ; Init file for lepton-schematic
 ;
 
-( use-modules ( gschem deprecated ) )
-( use-modules ( schematic netlist ) )
+(use-modules (gschem deprecated)
+             (schematic gui keymap)
+             (schematic gui stroke)
+             (schematic netlist)
+             (gschem builtins))
 
 
 ; gschem-version string

--- a/schematic/scheme/Makefile.am
+++ b/schematic/scheme/Makefile.am
@@ -4,7 +4,6 @@ scmdatadir = $(GEDADATADIR)/scheme
 nobase_dist_scmdata_DATA = \
 	auto-refdes.scm \
 	auto-uref.scm \
-	gschem.scm \
 	list-keys.scm \
 	print-NB-attribs.scm \
 	auto-place-attribs.scm \
@@ -24,6 +23,8 @@ nobase_dist_scmdata_DATA = \
 	gschem/action.scm \
 	gschem/builtins.scm \
 	gschem/symbol/check.scm \
+	schematic/gui/keymap.scm \
+	schematic/gui/stroke.scm \
 	schematic/netlist.scm \
 	schematic/undo.scm \
 	conf/schematic/attribs.scm \

--- a/schematic/scheme/schematic/gui/keymap.scm
+++ b/schematic/scheme/schematic/gui/keymap.scm
@@ -1,6 +1,7 @@
 ;;; Lepton EDA Schematic Capture
 ;;; Copyright (C) 1998-2010 Ales Hvezda
-;;; Copyright (C) 1998-2013 gEDA Contributors (see ChangeLog for details)
+;;; Copyright (C) 1998-2013 gEDA Contributors
+;;; Copyright (C) 2017-2019 Lepton EDA Contributors
 ;;;
 ;;; This program is free software; you can redistribute it and/or modify
 ;;; it under the terms of the GNU General Public License as published by
@@ -17,18 +18,29 @@
 ;;; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
 ;;; MA 02111-1301 USA.
 
-(use-modules (gschem keymap)
-             (gschem action)
-             (gschem builtins)
-             (gschem window)
-             (srfi srfi-1))
+(define-module (schematic gui keymap)
+  #:use-module (srfi srfi-1)
+  #:use-module (gschem keymap)
+  #:use-module (gschem action)
+  #:use-module (gschem builtins)
+  #:use-module (gschem window)
+
+  #:export (%global-keymap
+            current-keymap
+            global-set-key
+            press-key
+            reset-keys
+            find-key
+            %gschem-hotkey-store/dump-global-keymap))
 
 ;; -------------------------------------------------------------------
 ;;;; Global keymaps and key dispatch logic
 
 (define current-keys '())
 
+;;; Default global keymap.
 (define %global-keymap (make-keymap))
+;;; User defined keymap.
 (define current-keymap %global-keymap)
 
 ;; Set a global keybinding
@@ -68,20 +80,6 @@
            (else (reset-keys)))))
 
       (reset-keys)))
-
-
-(define (eval-stroke stroke)
-  (let ((action (assoc stroke strokes)))
-    (cond ((not action)
-;           (display "No such stroke\n")
-;          (display stroke)
-           #f)
-          (else
-;           (display "Scheme found action ")
-;           (display action)
-;           (display "\n")
-           (eval-action! (cdr action))
-           #t))))
 
 ;; Search the global keymap for a particular symbol and return the
 ;; keys which execute this hotkey, as a string suitable for display to

--- a/schematic/scheme/schematic/gui/stroke.scm
+++ b/schematic/scheme/schematic/gui/stroke.scm
@@ -1,0 +1,33 @@
+;;; Lepton EDA Schematic Capture
+;;; Copyright (C) 1998-2010 Ales Hvezda
+;;; Copyright (C) 1998-2013 gEDA Contributors
+;;; Copyright (C) 2017-2019 Lepton EDA Contributors
+;;;
+;;; This program is free software; you can redistribute it and/or modify
+;;; it under the terms of the GNU General Public License as published by
+;;; the Free Software Foundation; either version 2 of the License, or
+;;; (at your option) any later version.
+;;;
+;;; This program is distributed in the hope that it will be useful,
+;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;; GNU General Public License for more details.
+;;;
+;;; You should have received a copy of the GNU General Public License
+;;; along with this program; if not, write to the Free Software
+;;; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+;;; MA 02111-1301 USA.
+
+(define-module (schematic gui stroke)
+  #:use-module (gschem action)
+  #:use-module (gschem builtins)
+
+  #:export (eval-stroke))
+
+(define (eval-stroke stroke)
+  ;; It's a work-around allowing using "strokes" defined somewhere
+  ;; else.  "(assoc stroke (primitive-eval 'strokes))" can also be
+  ;; used here, though it is a bit slower ;)
+  (let ((action (assoc stroke (@@ (guile-user) strokes))))
+    (and action
+         (eval-action! (cdr action)))))

--- a/schematic/src/lepton-schematic.c
+++ b/schematic/src/lepton-schematic.c
@@ -95,19 +95,9 @@ void gschem_quit(void)
   x_stroke_free ();
 #endif /* HAVE_LIBSTROKE */
   o_undo_cleanup();
-  /* s_stroke_free(); no longer needed */
 
   i_vars_freenames();
   i_vars_libgeda_freenames();
-
-  /* x_window_free_head(); can't do this since it causes a
-   * condition in which window_head->... is still being refered
-   * after this */
-
-  /* enable this to get more memory usage from glib */
-  /* You also have to enable something in glib I think */
-  /* g_mem_profile();*/
-
 
   gtk_main_quit();
 }

--- a/schematic/src/lepton-schematic.c
+++ b/schematic/src/lepton-schematic.c
@@ -124,10 +124,8 @@ void main_prog(void *closure, int argc, char *argv[])
   char *cwd = NULL;
   GschemToplevel *w_current = NULL;
   TOPLEVEL *toplevel = NULL;
-  char *input_str = NULL;
   int argv_index;
   char *filename;
-  SCM scm_tmp;
 
 #ifdef HAVE_GTHREAD
   /* Gschem isn't threaded, but some of GTK's file chooser
@@ -193,24 +191,8 @@ void main_prog(void *closure, int argc, char *argv[])
   /* Run pre-load Scheme expressions */
   g_scm_eval_protected (s_pre_load_expr, scm_current_module ());
 
-  /* By this point, libgeda should have setup the Guile load path, so
-   * we can take advantage of that.  */
-  scm_tmp = scm_sys_search_load_path (scm_from_utf8_string ("gschem.scm"));
-  if (scm_is_false (scm_tmp)) {
-    s_log_message (_("Couldn't find init scm file [%1$s]"), "gschem.scm");
-  }
-  input_str = scm_to_utf8_string (scm_tmp);
+  /* Initialize toplevel */
   toplevel = s_toplevel_new ();
-  if (g_read_file(toplevel, input_str, NULL)) {
-    s_log_message(_("Read init scm file [%1$s]"), input_str);
-  } else {
-    /*! \todo These two messages are the same. Should be
-     * integrated. */
-    s_log_message(_("Failed to read init scm file [%1$s]"),
-                  input_str);
-  }
-  free (input_str); /* M'allocated by scm_to_utf8_string() */
-  scm_remember_upto_here_1 (scm_tmp);
 
   /* Set up default configuration */
   i_vars_init_gschem_defaults ();


### PR DESCRIPTION
This simplifies code a bit and eliminates a superfluous step of loading the file.
OTOH, the procedures defined there are no more global, so the users may have to fix up their extensions by loading necessary modules in them.