### PR TITLE
Add main category into desktop files.

### DIFF
--- a/attrib/data/lepton-attrib.desktop.in
+++ b/attrib/data/lepton-attrib.desktop.in
@@ -7,4 +7,4 @@ Type=Application
 Exec=lepton-attrib %F
 Icon=lepton-attrib
 #MimeType=application/x-lepton-schematic;application/x-lepton-symbol;
-Categories=Engineering;Electronics;
+Categories=Development;Electronics;Engineering;

--- a/schematic/data/lepton-schematic.desktop.in
+++ b/schematic/data/lepton-schematic.desktop.in
@@ -7,4 +7,4 @@ Type=Application
 Exec=lepton-schematic %F
 Icon=lepton-schematic
 MimeType=application/x-lepton-schematic;application/x-lepton-symbol;
-Categories=Engineering;Electronics;
+Categories=Development;Electronics;Engineering;


### PR DESCRIPTION
According to
https://specifications.freedesktop.org/menu-spec/latest/apa.html,
previously there was no valid main category in the desktop files.

Issue description in #360:
"The problem is that without a main category, it is not possible to
know for sure if a freedesktop compliant menu will show these 2
applications."

This has been fixed by adding "Development" as main category for
Lepton. Two additional categories have been rearranged in order
"Electronics" to have priority over "Engineering".

Closes #360