### PR TITLE
Fix "unbound variable" error on lepton-schematic startup

### DIFF
--- a/schematic/scheme/conf/schematic/deprecated.scm
+++ b/schematic/scheme/conf/schematic/deprecated.scm
@@ -154,7 +154,7 @@
        (add-component-at-xy page default-titleblock 40000 40000   0       #f       #f))
 
    ;; After adding titleblock, reset page to mark as unchanged.
-   ((@ (geda page) set-page-dirty!) (active-page) #f))
+   ((@ (geda page) set-page-dirty!) ((@ (gschem window) active-page)) #f))
 	   #t)
 
 ;


### PR DESCRIPTION
On `lepton-schematic` startup the following error appears in the log:

```
Backtrace:
In ice-9/boot-9.scm:
 160: 7 [catch #t #<catch-closure 80b338e80> ...]
In unknown file:
   ?: 6 [apply-smob/1 #<catch-closure 80b338e80>]
In ice-9/boot-9.scm:
 160: 5 [catch #t #<catch-closure 80ce05260> ...]
In unknown file:
   ?: 4 [apply-smob/1 #<catch-closure 80ce05260>]
   ?: 3 [run-hook #<hook 1 80b3ca0f0 ?> #<geda-page 0x80e2162e0>]
In conf/schematic/deprecated.scm:
 157: 2 [#<procedure 80c9fd380 at conf/schematic/deprecated.scm:143:43 (page)> #]
In ice-9/boot-9.scm:
 105: 1 [#<procedure 80ce077c0 at ice-9/boot-9.scm:100:6 (thrown-k . args)> unbound-variable ...]
In unknown file:
   ?: 0 [apply-smob/1 #<catch-closure 80ce05220> unbound-variable ...]

ERROR: In procedure apply-smob/1:
ERROR: In procedure module-lookup: Unbound variable: active-page
```


That's because `@`-syntax should be used to call `active-page` function in  `conf/schematic/deprecated.scm` (there is no `(use-modules (gschem window)) statement)`.
Note: if this error cannot be reproduced, delete guile cache, turn off any custom configuration and try again.