### PR TITLE
Page manager: toggle show full paths + refactoring

### DIFF
--- a/schematic/include/x_pagesel.h
+++ b/schematic/include/x_pagesel.h
@@ -22,7 +22,6 @@
 
 
 typedef enum {
-  PAGESEL_RESPONSE_CLOSE  = 1,
   PAGESEL_RESPONSE_UPDATE = 2
 } PageselResponseType;
 

--- a/schematic/include/x_pagesel.h
+++ b/schematic/include/x_pagesel.h
@@ -21,11 +21,6 @@
 #define LEPTON_PAGESEL_H_
 
 
-typedef enum {
-  PAGESEL_RESPONSE_UPDATE = 2
-} PageselResponseType;
-
-
 #define TYPE_PAGESEL         (pagesel_get_type())
 #define PAGESEL(obj)         (G_TYPE_CHECK_INSTANCE_CAST ((obj), TYPE_PAGESEL, Pagesel))
 #define PAGESEL_CLASS(klass) (G_TYPE_CHECK_CLASS_CAST ((klass), TYPE_PAGESEL, PageselClass))

--- a/schematic/include/x_pagesel.h
+++ b/schematic/include/x_pagesel.h
@@ -39,6 +39,8 @@ struct _Pagesel {
   GschemDialog parent_instance;
 
   GtkTreeView *treeview;
+
+  gboolean show_full_paths;
 };
 
 

--- a/schematic/include/x_pagesel.h
+++ b/schematic/include/x_pagesel.h
@@ -17,6 +17,8 @@
  * MA 02111-1301 USA.
  */
 
+#ifndef LEPTON_PAGESEL_H_
+#define LEPTON_PAGESEL_H_
 
 
 typedef enum {
@@ -48,4 +50,5 @@ struct _Pagesel {
 
 GType pagesel_get_type (void);
 
-void pagesel_update (Pagesel *pagesel);
+#endif /* LEPTON_PAGESEL_H_ */
+

--- a/schematic/src/x_pagesel.c
+++ b/schematic/src/x_pagesel.c
@@ -221,18 +221,50 @@ static gboolean pagesel_callback_popup_menu (GtkWidget *widget,
   return TRUE;
 }
 
-#define DEFINE_POPUP_CALLBACK(name, action)                       \
-static void                                                       \
-pagesel_callback_popup_ ## name (GtkMenuItem *menuitem,           \
-                                 gpointer user_data)              \
-{                                                                 \
-  i_callback_ ## action (GSCHEM_DIALOG (user_data)->w_current, 0, NULL); \
+
+
+/*! \brief Context menu item handler for "New Page".
+ */
+static void
+pagesel_callback_popup_new_page (GtkMenuItem* mitem, gpointer data)
+{
+  GschemToplevel* toplevel = GSCHEM_DIALOG(data)->w_current;
+  i_callback_file_new (toplevel, 0, NULL);
 }
 
-DEFINE_POPUP_CALLBACK (new_page,     file_new)
-DEFINE_POPUP_CALLBACK (open_page,    file_open)
-DEFINE_POPUP_CALLBACK (save_page,    file_save)
-DEFINE_POPUP_CALLBACK (close_page,   page_close)
+
+
+/*! \brief Context menu item handler for "Open Page".
+ */
+static void
+pagesel_callback_popup_open_page (GtkMenuItem* mitem, gpointer data)
+{
+  GschemToplevel* toplevel = GSCHEM_DIALOG(data)->w_current;
+  i_callback_file_open (toplevel, 0, NULL);
+}
+
+
+
+/*! \brief Context menu item handler for "Save Page".
+ */
+static void
+pagesel_callback_popup_save_page (GtkMenuItem* mitem, gpointer data)
+{
+  GschemToplevel* toplevel = GSCHEM_DIALOG(data)->w_current;
+  i_callback_file_save (toplevel, 0, NULL);
+}
+
+
+
+/*! \brief Context menu item handler for "Close Page".
+ */
+static void
+pagesel_callback_popup_close_page (GtkMenuItem* mitem, gpointer data)
+{
+  GschemToplevel* toplevel = GSCHEM_DIALOG(data)->w_current;
+  i_callback_page_close (toplevel, 0, NULL);
+}
+
 
 
 /*! \brief Popup context-sensitive menu.

--- a/schematic/src/x_pagesel.c
+++ b/schematic/src/x_pagesel.c
@@ -288,6 +288,20 @@ pagesel_callback_fullpaths_toggled (GtkToggleButton* btn, gpointer data)
   pagesel->show_full_paths = gtk_toggle_button_get_active (btn);
   pagesel_update (pagesel);
 
+  /* Save config: whether to show full paths in the pages list:
+  */
+  EdaConfig* cfg = eda_config_get_cache_context();
+  if (cfg != NULL)
+  {
+    eda_config_set_boolean (cfg,
+                           "schematic.page-manager",
+                           "show-full-paths",
+                           pagesel->show_full_paths);
+    GError* err = NULL;
+    eda_config_save (cfg, &err);
+    g_clear_error (&err);
+  }
+
 } /* pagesel_callback_fullpath_toggled() */
 
 
@@ -500,10 +514,32 @@ static void pagesel_init (Pagesel *pagesel)
   gtk_widget_show (label);
 
 
+  /* By default, show full paths in the pages list:
+  */
+  pagesel->show_full_paths = TRUE;
+
+
+  /* Read config: whether to show full paths in the pages list:
+  */
+  EdaConfig* cfg = eda_config_get_cache_context();
+  if (cfg != NULL)
+  {
+    GError* err = NULL;
+    gboolean val = eda_config_get_boolean (cfg,
+                                           "schematic.page-manager",
+                                           "show-full-paths",
+                                           &err);
+    if (err == NULL)
+    {
+      pagesel->show_full_paths = val;
+    }
+
+    g_clear_error (&err);
+  }
+
+
   /* "Show full paths" checkbox:
   */
-
-  pagesel->show_full_paths = TRUE;
 
   GtkWidget* hbox = gtk_hbox_new (TRUE, 0);
   gtk_box_pack_start (GTK_BOX (GTK_DIALOG (pagesel)->vbox),

--- a/schematic/src/x_pagesel.c
+++ b/schematic/src/x_pagesel.c
@@ -482,12 +482,6 @@ static void pagesel_init (Pagesel *pagesel)
                           GTK_STOCK_CLOSE,   PAGESEL_RESPONSE_CLOSE,
                           NULL);
 
-  /* Set the alternative button order (ok, cancel, help) for other systems */
-  gtk_dialog_set_alternative_button_order(GTK_DIALOG(pagesel),
-					  PAGESEL_RESPONSE_UPDATE,
-					  PAGESEL_RESPONSE_CLOSE,
-					  -1);
-
   g_signal_connect( pagesel, "notify::gschem-toplevel",
                     G_CALLBACK( notify_gschem_toplevel_cb ), NULL );
 }

--- a/schematic/src/x_pagesel.c
+++ b/schematic/src/x_pagesel.c
@@ -30,6 +30,10 @@
 #include "gschem.h"
 
 
+G_DEFINE_TYPE (Pagesel, pagesel, GSCHEM_TYPE_DIALOG);
+
+
+
 static void x_pagesel_callback_response (GtkDialog *dialog,
                                          gint arg1,
                                          gpointer user_data);
@@ -148,9 +152,6 @@ enum {
   NUM_COLUMNS
 };
 
-
-static void pagesel_class_init (PageselClass *klass);
-static void pagesel_init       (Pagesel *pagesel);
 
 static void pagesel_popup_menu (Pagesel *pagesel,
                                 GdkEventButton *event);
@@ -319,50 +320,16 @@ static void notify_gschem_toplevel_cb (GObject    *gobject,
 }
 
 
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
-GType pagesel_get_type()
-{
-  static GType pagesel_type = 0;
-  
-  if (!pagesel_type) {
-    static const GTypeInfo pagesel_info = {
-      sizeof(PageselClass),
-      NULL, /* base_init */
-      NULL, /* base_finalize */
-      (GClassInitFunc) pagesel_class_init,
-      NULL, /* class_finalize */
-      NULL, /* class_data */
-      sizeof(Pagesel),
-      0,    /* n_preallocs */
-      (GInstanceInitFunc) pagesel_init,
-    };
-		
-    pagesel_type = g_type_register_static (GSCHEM_TYPE_DIALOG,
-                                           "Pagesel",
-                                           &pagesel_info,
-                                           (GTypeFlags) 0);
-  }
-  
-  return pagesel_type;
-}
 
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
+/*! \brief gobject class initialization function
  */
 static void pagesel_class_init (PageselClass *klass)
 {
 }
 
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
+
+
+/*! \brief gobject instance initialization function
  */
 static void pagesel_init (Pagesel *pagesel)
 {

--- a/schematic/src/x_pagesel.c
+++ b/schematic/src/x_pagesel.c
@@ -472,7 +472,7 @@ static void pagesel_init (Pagesel *pagesel)
     g_object_new (GTK_TYPE_TREE_VIEW_COLUMN,
                   /* GtkTreeViewColumn */
                   "title", _("Filename"),
-                  "min-width", 400,
+                  "min-width", 200,
                   "resizable", TRUE,
                   NULL));
   gtk_tree_view_column_pack_start (column, renderer, TRUE);

--- a/schematic/src/x_pagesel.c
+++ b/schematic/src/x_pagesel.c
@@ -134,7 +134,7 @@ static void x_pagesel_callback_response (GtkDialog *dialog,
         pagesel_update (PAGESEL (dialog));
         break;
       case GTK_RESPONSE_DELETE_EVENT:
-      case PAGESEL_RESPONSE_CLOSE:
+      case GTK_RESPONSE_CLOSE:
         g_assert (GTK_WIDGET (dialog) == w_current->pswindow);
         gtk_widget_destroy (GTK_WIDGET (dialog));
         w_current->pswindow = NULL;
@@ -479,7 +479,7 @@ static void pagesel_init (Pagesel *pagesel)
                           /*  - update button */
                           GTK_STOCK_REFRESH, PAGESEL_RESPONSE_UPDATE,
                           /*  - close button */
-                          GTK_STOCK_CLOSE,   PAGESEL_RESPONSE_CLOSE,
+                          GTK_STOCK_CLOSE,   GTK_RESPONSE_CLOSE,
                           NULL);
 
   g_signal_connect( pagesel, "notify::gschem-toplevel",

--- a/schematic/src/x_pagesel.c
+++ b/schematic/src/x_pagesel.c
@@ -514,9 +514,9 @@ static void pagesel_init (Pagesel *pagesel)
   gtk_widget_show (label);
 
 
-  /* By default, show full paths in the pages list:
+  /* By default, show basenames in the pages list:
   */
-  pagesel->show_full_paths = TRUE;
+  pagesel->show_full_paths = FALSE;
 
 
   /* Read config: whether to show full paths in the pages list:

--- a/schematic/src/x_pagesel.c
+++ b/schematic/src/x_pagesel.c
@@ -1,6 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
- * Copyright (C) 1998-2010 gEDA Contributors (see ChangeLog for details)
+ * Copyright (C) 1998-2015 gEDA Contributors
+ * Copyright (C) 2017-2019 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -32,6 +33,9 @@
 static void x_pagesel_callback_response (GtkDialog *dialog,
                                          gint arg1,
                                          gpointer user_data);
+
+static void
+pagesel_update (Pagesel* pagesel);
 
 
 
@@ -573,7 +577,7 @@ static void select_page(GtkTreeView *treeview,
  *  \par Function Description
  *
  */
-void pagesel_update (Pagesel *pagesel)
+static void pagesel_update (Pagesel *pagesel)
 {
   GtkTreeModel *model;
   TOPLEVEL *toplevel;

--- a/schematic/src/x_pagesel.c
+++ b/schematic/src/x_pagesel.c
@@ -26,12 +26,19 @@ G_DEFINE_TYPE (Pagesel, pagesel, GSCHEM_TYPE_DIALOG);
 
 
 
+typedef enum
+{
+  PAGESEL_RESPONSE_UPDATE = 1
+
+} PageselResponseType;
+
+
+
 static void x_pagesel_callback_response (GtkDialog *dialog,
                                          gint arg1,
                                          gpointer user_data);
 
-static void
-pagesel_update (Pagesel* pagesel);
+static void pagesel_update (Pagesel* pagesel);
 
 
 

--- a/schematic/src/x_pagesel.c
+++ b/schematic/src/x_pagesel.c
@@ -438,7 +438,7 @@ static void pagesel_init (Pagesel *pagesel)
                   "border-width",      5,
                   /* GtkScrolledWindow */
                   "hscrollbar-policy", GTK_POLICY_AUTOMATIC,
-                  "vscrollbar-policy", GTK_POLICY_ALWAYS,
+                  "vscrollbar-policy", GTK_POLICY_AUTOMATIC,
                   "shadow-type",       GTK_SHADOW_ETCHED_IN,
                   NULL));
   /* create the treeview */

--- a/schematic/src/x_pagesel.c
+++ b/schematic/src/x_pagesel.c
@@ -277,6 +277,21 @@ pagesel_callback_popup_close_page (GtkMenuItem* mitem, gpointer data)
 
 
 
+/*! \brief "Show full paths" checkbox "toggled" signal handler
+ */
+static void
+pagesel_callback_fullpaths_toggled (GtkToggleButton* btn, gpointer data)
+{
+  Pagesel* pagesel = (Pagesel*) data;
+  g_return_if_fail (pagesel != NULL);
+
+  pagesel->show_full_paths = gtk_toggle_button_get_active (btn);
+  pagesel_update (pagesel);
+
+} /* pagesel_callback_fullpath_toggled() */
+
+
+
 /*! \brief Popup context-sensitive menu.
  *  \par Function Description
  *  Pops up a context-sensitive menu.
@@ -484,6 +499,31 @@ static void pagesel_init (Pagesel *pagesel)
                       FALSE, TRUE, 5);
   gtk_widget_show (label);
 
+
+  /* "Show full paths" checkbox:
+  */
+
+  pagesel->show_full_paths = TRUE;
+
+  GtkWidget* hbox = gtk_hbox_new (TRUE, 0);
+  gtk_box_pack_start (GTK_BOX (GTK_DIALOG (pagesel)->vbox),
+                      hbox, FALSE, TRUE, 0);
+  gtk_widget_show (hbox);
+
+  GtkWidget* chkbox = gtk_check_button_new_with_mnemonic ("_Show full paths");
+  gtk_box_pack_start (GTK_BOX (hbox), chkbox, FALSE, TRUE, 5);
+
+  gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (chkbox),
+                                pagesel->show_full_paths);
+
+  g_signal_connect(G_OBJECT (chkbox),
+                   "toggled",
+                   G_CALLBACK (&pagesel_callback_fullpaths_toggled),
+                   pagesel);
+
+  gtk_widget_show (chkbox);
+
+
   /* now add buttons in the action area */
   gtk_dialog_add_buttons (GTK_DIALOG (pagesel),
                           /*  - update button */
@@ -494,7 +534,9 @@ static void pagesel_init (Pagesel *pagesel)
 
   g_signal_connect( pagesel, "notify::gschem-toplevel",
                     G_CALLBACK( notify_gschem_toplevel_cb ), NULL );
-}
+
+} /* pagesel_init() */
+
 
 
 /*! \brief Update tree model of <B>pagesel</B>'s treeview.

--- a/schematic/src/x_pagesel.c
+++ b/schematic/src/x_pagesel.c
@@ -404,7 +404,7 @@ static void pagesel_class_init (PageselClass *klass)
  */
 static void pagesel_init (Pagesel *pagesel)
 {
-  GtkWidget *scrolled_win, *treeview, *label;
+  GtkWidget *scrolled_win, *treeview;
   GtkTreeModel *store;
   GtkCellRenderer *renderer;
   GtkTreeViewColumn *column;
@@ -503,15 +503,6 @@ static void pagesel_init (Pagesel *pagesel)
   gtk_box_pack_start (GTK_BOX (GTK_DIALOG (pagesel)->vbox), scrolled_win,
                       TRUE, TRUE, 0);
   gtk_widget_show_all (scrolled_win);
-
-  /* add a label below the scrolled window */
-  label = GTK_WIDGET (g_object_new (GTK_TYPE_LABEL,
-                                    /* GtkLabel */
-                                    "label", _("Right click on the filename for more options..."),
-                                    NULL));
-  gtk_box_pack_start (GTK_BOX (GTK_DIALOG (pagesel)->vbox), label,
-                      FALSE, TRUE, 5);
-  gtk_widget_show (label);
 
 
   /* By default, show basenames in the pages list:

--- a/schematic/src/x_pagesel.c
+++ b/schematic/src/x_pagesel.c
@@ -17,16 +17,8 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
+
 #include <config.h>
-
-#include <stdio.h>
-#ifdef HAVE_STDLIB_H
-#include <stdlib.h>
-#endif
-#ifdef HAVE_STRING_H
-#include <string.h>
-#endif
-
 #include "gschem.h"
 
 

--- a/schematic/src/x_pagesel.c
+++ b/schematic/src/x_pagesel.c
@@ -52,7 +52,10 @@ pagesel_update (Pagesel* pagesel);
  */
 void x_pagesel_open (GschemToplevel *w_current)
 {
-  if (w_current->pswindow == NULL) {
+  g_return_if_fail (w_current != NULL);
+
+  if (w_current->pswindow == NULL)
+  {
     w_current->pswindow = GTK_WIDGET (g_object_new (TYPE_PAGESEL,
                                                     /* GschemDialog */
                                                     "settings-name", "pagesel",
@@ -64,8 +67,16 @@ void x_pagesel_open (GschemToplevel *w_current)
                       G_CALLBACK (x_pagesel_callback_response),
                       w_current);
 
+    g_signal_connect (w_current->pswindow,
+                      "delete-event",
+                      G_CALLBACK (&gtk_widget_hide_on_delete),
+                      NULL);
+
     gtk_widget_show (w_current->pswindow);
-  } else {
+  }
+  else
+  {
+    gtk_widget_show (w_current->pswindow);
     gdk_window_raise (w_current->pswindow->window);
   }
 
@@ -129,15 +140,15 @@ static void x_pagesel_callback_response (GtkDialog *dialog,
 {
   GschemToplevel *w_current = GSCHEM_TOPLEVEL (user_data);
 
-  switch (arg1) {
+  switch (arg1)
+  {
       case PAGESEL_RESPONSE_UPDATE:
         pagesel_update (PAGESEL (dialog));
         break;
       case GTK_RESPONSE_DELETE_EVENT:
       case GTK_RESPONSE_CLOSE:
         g_assert (GTK_WIDGET (dialog) == w_current->pswindow);
-        gtk_widget_destroy (GTK_WIDGET (dialog));
-        w_current->pswindow = NULL;
+        gtk_widget_hide (GTK_WIDGET (dialog));
         break;
       default:
         g_assert_not_reached ();


### PR DESCRIPTION
This was suggested in launchpad bug report [#721929 "pagemanager is cluttered with paths"](https://bugs.launchpad.net/geda/+bug/721929), and I fully agree with @KaiMartin: when working with hierarchical schematics, full paths just clutters the view most of the time. Now they can be shown at any time or hidden away by checking the "Show full paths" checkbox. By default, they are hidden.
The state of the "Show full paths" checkbox is saved to/loaded from the CACHE configuration context: `show-full-paths` key (boolean), `schematic.page-manager` group.

Additional changes:
- minimum "Filename" column width is reduced
- scrollbars are shown only when needed
- "Right click on the filename for more options..." label is removed

<br />

![tb132_pmgr_basenames](https://user-images.githubusercontent.com/26083750/55580554-7a5e8f00-5723-11e9-8f8d-307a064a2606.png)

![tb132_pmgr_paths](https://user-images.githubusercontent.com/26083750/55580565-80ed0680-5723-11e9-81f4-31e74d559f81.png)
