### PR TITLE
Use CSS in Scheme API HTML reference pages

### DIFF
--- a/docs/scheme-api/Makefile.am
+++ b/docs/scheme-api/Makefile.am
@@ -1,1 +1,10 @@
 info_TEXINFOS = lepton-scheme.texi
+
+AM_MAKEINFOHTMLFLAGS = --css-ref=lepton-scheme.css
+
+EXTRA_DIST = lepton-scheme.css
+
+html-local:
+	$(MKDIR_P) $(builddir)/lepton-scheme.html/
+	cp -fv $(srcdir)/lepton-scheme.css $(builddir)/lepton-scheme.html/
+

--- a/docs/scheme-api/lepton-scheme.css
+++ b/docs/scheme-api/lepton-scheme.css
@@ -1,0 +1,5 @@
+body
+{
+  background-color: #f0f0f0
+}
+


### PR DESCRIPTION
Add Cascading Style Sheets (CSS) file, use it
in generated HTML Scheme API reference pages.
Now it sets only background color (to be slightly
darker - to reduce eye fatigue).