### PR TITLE
Catch exceptions in the (gschem gschemdoc) lepton-schematic module

### DIFF
--- a/schematic/scheme/gschem/builtins.scm
+++ b/schematic/scheme/gschem/builtins.scm
@@ -395,30 +395,30 @@ found, shows a dialog with an error message."
 
 
 (define-action-public
-    (&help-manual #:label (_ "gEDA Manuals") #:icon "help-browser"
-     #:tooltip (_ "View the front page of the gEDA documentation in a browser."))
+    (&help-manual #:label (_ "Lepton EDA Manuals") #:icon "help-browser"
+     #:tooltip (_ "View the front page of the Lepton EDA documentation in a browser."))
   (show-wiki "geda:documentation"))
 
 
 (define-action-public
-    (&help-guide #:label (_ "gschem User Guide") #:icon "gtk-help"
-                 #:tooltip (_ "View the gschem User Guide in a browser."))
+    (&help-guide #:label (_ "lepton-schematic User Guide") #:icon "gtk-help"
+                 #:tooltip (_ "View the lepton-schematic User Guide in a browser."))
   (show-wiki "geda:gschem_ug"))
 
 
 (define-action-public
-    (&help-faq #:label (_ "gschem FAQ") #:icon "help-faq"
-     #:tooltip (_ "Frequently Asked Questions about using gschem."))
+    (&help-faq #:label (_ "lepton-schematic FAQ") #:icon "help-faq"
+     #:tooltip (_ "Frequently Asked Questions about using lepton-schematic."))
   (show-wiki "geda:faq-gschem"))
 
 
 (define-action-public
-    (&help-wiki #:label (_ "gEDA wiki") #:icon "web-browser"
-     #:tooltip (_ "View the front page of the gEDA wiki in a browser."))
+    (&help-wiki #:label (_ "Lepton EDA wiki") #:icon "web-browser"
+     #:tooltip (_ "View the front page of the Lepton EDA wiki in a browser."))
   (show-wiki))
 
 
-(define-action-public (&help-about #:label (_ "About gschem") #:icon "gtk-about")
+(define-action-public (&help-about #:label (_ "About lepton-schematic") #:icon "gtk-about")
   (%help-about))
 
 

--- a/schematic/scheme/gschem/builtins.scm
+++ b/schematic/scheme/gschem/builtins.scm
@@ -2,7 +2,7 @@
 ;; Scheme API
 ;; Copyright (C) 2013 Peter Brett <peter@peter-b.co.uk>
 ;; Copyright (C) 2013-2015 gEDA Contributors
-;; Copyright (C) 2017-2018 Lepton EDA Contributors
+;; Copyright (C) 2017-2019 Lepton EDA Contributors
 ;;
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -388,18 +388,10 @@
 documentation in a browser or PDF viewer. If no documentation can be
 found, shows a dialog with an error message."
 
-  (catch 'misc-error
-
-   (lambda ()
      (let ((component
             (any (lambda (obj) (and (component? obj) obj))
                  (page-selection (active-page)))))
        (and component (show-component-documentation component))))
-
-   (lambda (key subr msg args . rest)
-     ((@@ (guile-user) gschem-msg) (string-append
-                  (_ "Could not show documentation for selected component:\n\n")
-                  (apply format #f msg args))))))
 
 
 (define-action-public

--- a/schematic/scheme/gschem/gschemdoc.scm.in
+++ b/schematic/scheme/gschem/gschemdoc.scm.in
@@ -34,6 +34,35 @@
   #:export (show-component-documentation))
 
 
+
+; private:
+;
+; Call (gschem util)::show-uri( url ), catching exceptions.
+; Display message box on error.
+;
+( define ( doc-show-uri url )
+
+  ( catch
+    #t
+    ( lambda()
+      ( show-uri url )
+    )
+    ( lambda ( key subr msg args . rest )
+      ( let*
+      (
+      ( str   (_ "Could not show documentation:") )
+      ( exmsg ( apply format #f msg args ) )
+      ( ermsg ( format #f "~a~%'~a in ~a():~%~%~a" str key subr exmsg ) )
+      )
+        ( (@@ (guile-user) gschem-msg) ermsg )
+      )
+    )
+  ) ; catch()
+
+) ; doc-show-uri()
+
+
+
 (define (sys-doc-dir)
   "sys-doc-dir
 
@@ -69,7 +98,7 @@ gEDA wiki shipped with gEDA/gaf.  The specified PAGE should be a
 string containing the page name as used on the live version of the
 wiki."
 
-  (show-uri
+  (doc-show-uri
    (string-append "file://"
                   (string-join (list (sys-doc-dir) "wiki")
                                file-name-separator-string 'suffix)
@@ -127,7 +156,7 @@ wiki."
 ;;
 ;; FIXME string should be URL-encoded.
 (define (internet-doc-search string)
-  (show-uri (format #f %pdf-search-template string)) #t)
+  (doc-show-uri (format #f %pdf-search-template string)) #t)
 
 ;; Munges a component basename to look more like a device name
 (define (munge-basename basename)
@@ -170,7 +199,7 @@ displayed in the system associated viewer application."
        ;; c) Does the documentation attribute look like a URL?
        (and (any (lambda (prefix) (string-prefix? prefix documentation))
                  '("http://" "ftp://" "file://"))
-            (show-uri documentation))
+            (doc-show-uri documentation))
 
        ;; d) If a documentation attribute was specified at all, search
        ;;    for it with Google.

--- a/schematic/scheme/gschem/gschemdoc.scm.in
+++ b/schematic/scheme/gschem/gschemdoc.scm.in
@@ -63,6 +63,15 @@
 
 
 
+; private:
+;
+( define ( doc-show-file fpath )
+  ; return:
+  ( doc-show-uri (format #f "file://~a" fpath) )
+)
+
+
+
 (define (sys-doc-dir)
   "sys-doc-dir
 
@@ -149,7 +158,7 @@ wiki."
            (file-exists? filename)
            filename)))
   (let ((filename (false-if-exception (directory-any dirname test-dir-entry))))
-    (and filename (begin (show-file filename) #t))))
+    (and filename (begin (doc-show-file filename) #t))))
 
 ;; Searches for documentation STRING on the Internet, using
 ;; %pdf-search-template.


### PR DESCRIPTION
Catch exceptions that can be thrown by `show-uri()` function
called in the `(gschem gschemdoc)` module.
Show a message box with error information.

![tb_136_showuri_catch](https://user-images.githubusercontent.com/26083750/55787804-c1e87080-5abf-11e9-9af0-0952a3345886.png)
