### PR TITLE
Fix preview in the lepton-schematic font selection widget

### DIFF
--- a/schematic/src/font_select_widget.c
+++ b/schematic/src/font_select_widget.c
@@ -26,6 +26,9 @@
 #include "gschem.h"
 
 
+#define PREVIEW_TEXT_SIZE 18
+
+
 /* convenience macro - gobject type implementation:
 */
 G_DEFINE_TYPE (FontSelectWidget, font_select_widget, GSCHEM_TYPE_BIN);
@@ -356,7 +359,15 @@ fontsel_set_font (FontSelectWidget* widget, const gchar* font)
 {
   g_return_if_fail (widget != NULL);
 
-  gtk_font_selection_set_font_name (widget->font_sel_, font);
+  /* Append font size to the [font] name.
+   * If the [font] name string doesn't contain font size,
+   * GtkFontSelection widget will set its "Size" field to 0,
+   * effectively hiding text in the "Preview" box:
+  */
+  gchar* fname = g_strdup_printf ("%s %d", font, PREVIEW_TEXT_SIZE);
+  gtk_font_selection_set_font_name (widget->font_sel_, fname);
+
+  g_free (fname);
 }
 
 

--- a/schematic/src/font_select_widget.c
+++ b/schematic/src/font_select_widget.c
@@ -27,6 +27,7 @@
 
 
 #define PREVIEW_TEXT_SIZE 18
+#define PREVIEW_TEXT "refdes=R1 Q23 U45 footprint=TQFN20_4_EP.fp"
 
 
 /* convenience macro - gobject type implementation:
@@ -368,6 +369,10 @@ fontsel_set_font (FontSelectWidget* widget, const gchar* font)
   gtk_font_selection_set_font_name (widget->font_sel_, fname);
 
   g_free (fname);
+
+  /* Set preview text:
+  */
+  gtk_font_selection_set_preview_text (widget->font_sel_, PREVIEW_TEXT);
 }
 
 


### PR DESCRIPTION
If a custom font is specified in the configuration (`schematic.gui::font`),
there is no preview text visible in the "Preview" box, because the "Size" field
is set to `0` (font size has a separate setting: `text-size` in `gschemrc`).
Fix this by appending font size to the font name string set for
`GtkFontSelection` widget.