### PR TITLE
Fix 'config-keys unit test in liblepton

### DIFF
--- a/liblepton/scheme/unit-tests/t0402-config.scm
+++ b/liblepton/scheme/unit-tests/t0402-config.scm
@@ -215,7 +215,8 @@
 
          (set-config! b "foo" "bam" #t)
          (assert-equal '("bar") (config-keys a "foo"))
-         (assert-equal '("bam" "bar") (config-keys b "foo"))
+         (assert-equal (sort '("bam" "bar") string<?)
+                       (sort (config-keys b "foo") string<?))
          (assert-true (config-has-key? b "foo" "bam"))
          (assert-equal #f (config-has-key? a "foo" "bam")))
 


### PR DESCRIPTION
On Ubuntu 19.04 ("disco") `liblepton/scheme/unit-tests/t0402-config.scm`
fails in `'config-keys` test. There is a wrong assumption in the code that
`config-keys` function returns a sorted list of key names.
Documentation of the underlying `g_key_file_get_keys()` function says
nothing about the order of the list returned.