### PR TITLE
Remember lepton-attrib main window's size and position

### DIFF
--- a/attrib/src/lepton-attrib.c
+++ b/attrib/src/lepton-attrib.c
@@ -76,6 +76,26 @@ GtkWidget *label;
  */
 gboolean gattrib_really_quit(void)
 {
+  /* Save main window's geometry:
+  */
+  gint x = 0;
+  gint y = 0;
+  gtk_window_get_position (GTK_WINDOW (window), &x, &y);
+
+  gint width  = 0;
+  gint height = 0;
+  gtk_window_get_size (GTK_WINDOW (window), &width, &height);
+
+  EdaConfig* cfg = eda_config_get_cache_context();
+
+  eda_config_set_int (cfg, "attrib.window-geometry", "x", x);
+  eda_config_set_int (cfg, "attrib.window-geometry", "y", y);
+  eda_config_set_int (cfg, "attrib.window-geometry", "width", width);
+  eda_config_set_int (cfg, "attrib.window-geometry", "height", height);
+
+  eda_config_save (cfg, NULL);
+
+
   if (sheet_head->CHANGED == TRUE) {
     x_dialog_unsaved_data();
   } else {

--- a/attrib/src/x_window.c
+++ b/attrib/src/x_window.c
@@ -116,7 +116,26 @@ x_window_init()
    * it.  The memory for the actual sheet cells is allocated later,
    * when gtk_sheet_new is invoked, I think.  */
   sheets = g_new0 (GtkSheet*, NUM_SHEETS);
-}
+
+
+  /* Restore main window's geometry:
+  */
+  EdaConfig* cfg = eda_config_get_cache_context();
+
+  gint x = eda_config_get_int (cfg, "attrib.window-geometry", "x", NULL);
+  gint y = eda_config_get_int (cfg, "attrib.window-geometry", "y", NULL);
+
+  gtk_window_move (GTK_WINDOW (window), x, y);
+
+  gint width  = eda_config_get_int (cfg, "attrib.window-geometry", "width",  NULL);
+  gint height = eda_config_get_int (cfg, "attrib.window-geometry", "height", NULL);
+
+  if (width > 0 && height > 0)
+  {
+    gtk_window_resize (GTK_WINDOW (window), width, height);
+  }
+
+} /* x_window_init() */
 
 
 /*------------------------------------------------------------------


### PR DESCRIPTION
Save window's geometry to the `CACHE` configuration
context, `attrib.window-geometry` group.