### PR TITLE
Log message on Netlist->allegro in lepton-schematic

### DIFF
--- a/schematic/scheme/schematic/netlist.scm
+++ b/schematic/scheme/schematic/netlist.scm
@@ -20,6 +20,7 @@
 
 (define-module (schematic netlist)
   #:use-module (geda page)
+  #:use-module (geda log)
   #:use-module (netlist)
   #:use-module (netlist schematic)
 
@@ -41,4 +42,5 @@
 ;;; Allegro backend
 (define (&netlist-allegro)
   (with-output-to-file "allegro.out"
-    (lambda () (allegro* (%schematic)))))
+    (lambda () (allegro* (%schematic))))
+  (log! 'message "allegro: the output is written to [allegro.out]"))


### PR DESCRIPTION
Provide feedback in the form of the log message
"allegro: the output is written to [allegro.out]"
when the user selects the `allegro` menu item
from the `Netlist` menu.