### PR TITLE
Do not use function deprecated in recent versions of glib

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -75,12 +75,12 @@ PKG_PROG_PKG_CONFIG
 
 AX_CHECK_GUILE([2.0.0])
 
-PKG_CHECK_MODULES(GLIB, [glib-2.0 >= 2.25.0], ,
-  AC_MSG_ERROR([GLib 2.25.0 or later is required.]))
+PKG_CHECK_MODULES(GLIB, [glib-2.0 >= 2.38.0], ,
+  AC_MSG_ERROR([GLib 2.38.0 or later is required.]))
 AC_DEFINE([G_DISABLE_DEPRECATED], [1], [Disable deprecated GLib features])
 
-PKG_CHECK_MODULES(GIO, [gio-2.0 >= 2.25.0], ,
-  AC_MSG_ERROR([GIO 2.25.0 or later is required.]))
+PKG_CHECK_MODULES(GIO, [gio-2.0 >= 2.38.0], ,
+  AC_MSG_ERROR([GIO 2.38.0 or later is required.]))
 
 PKG_CHECK_MODULES(GTK, [gtk+-2.0 >= 2.24.0], ,
   AC_MSG_ERROR([GTK+ 2.24.0 or later is required.]))

--- a/liblepton/src/edaconfig.c
+++ b/liblepton/src/edaconfig.c
@@ -163,7 +163,7 @@ static void parent_config_changed_handler (EdaConfig *parent, const gchar *group
 static void propagate_key_file_error (GError *src, GError **dest);
 
 /*! Magic helpful GObject macro */
-G_DEFINE_TYPE (EdaConfig, eda_config, G_TYPE_OBJECT)
+G_DEFINE_TYPE_WITH_PRIVATE (EdaConfig, eda_config, G_TYPE_OBJECT);
 
 /*! Initialise EdaConfig class. */
 static void
@@ -171,8 +171,6 @@ eda_config_class_init (EdaConfigClass *klass)
 {
   GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
   GParamSpec *pspec;
-
-  g_type_class_add_private (gobject_class, sizeof (EdaConfigPrivate));
 
   /* Register functions with base class */
   gobject_class->dispose = eda_config_dispose;

--- a/liblepton/src/edascmhookproxy.c
+++ b/liblepton/src/edascmhookproxy.c
@@ -54,7 +54,7 @@ static void cclosure_marshal_VOID__SCM (GClosure *closure,
                                         gpointer invocation_hint,
                                         gpointer marshal_data);
 
-G_DEFINE_TYPE (EdascmHookProxy, edascm_hook_proxy, G_TYPE_OBJECT)
+G_DEFINE_TYPE_WITH_PRIVATE (EdascmHookProxy, edascm_hook_proxy, G_TYPE_OBJECT);
 
 /*! Initialise EdascmHookProxy class. */
 static void
@@ -62,8 +62,6 @@ edascm_hook_proxy_class_init (EdascmHookProxyClass *klass)
 {
   GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
   GParamFlags param_flags;
-
-  g_type_class_add_private (gobject_class, sizeof (EdascmHookProxyPrivate));
 
   /* Register functions with base class */
   gobject_class->finalize = edascm_hook_proxy_finalize;

--- a/libleptonrenderer/edapangorenderer.c
+++ b/libleptonrenderer/edapangorenderer.c
@@ -73,7 +73,7 @@ static void eda_pango_renderer_end (PangoRenderer *renderer);
 static void eda_pango_renderer_prepare_run (PangoRenderer *renderer,
                                             PangoLayoutRun *run);
 
-G_DEFINE_TYPE (EdaPangoRenderer, eda_pango_renderer, PANGO_TYPE_RENDERER)
+G_DEFINE_TYPE_WITH_PRIVATE (EdaPangoRenderer, eda_pango_renderer, PANGO_TYPE_RENDERER);
 
 /* ---------------------------------------- */
 
@@ -88,8 +88,6 @@ eda_pango_renderer_class_init (EdaPangoRendererClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
   PangoRendererClass *parent_class = PANGO_RENDERER_CLASS (klass);
-
-  g_type_class_add_private (object_class, sizeof (EdaPangoRendererPrivate));
 
   /* Register functions with base class */
   object_class->constructor = eda_pango_renderer_constructor;

--- a/libleptonrenderer/edarenderer.c
+++ b/libleptonrenderer/edarenderer.c
@@ -182,7 +182,7 @@ eda_renderer_get_text_user_bounds (EdaRenderer *renderer,
                                    double *right,
                                    double *bottom);
 
-G_DEFINE_TYPE (EdaRenderer, eda_renderer, G_TYPE_OBJECT)
+G_DEFINE_TYPE_WITH_PRIVATE (EdaRenderer, eda_renderer, G_TYPE_OBJECT);
 
 GType
 eda_renderer_flags_get_type ()
@@ -208,8 +208,6 @@ eda_renderer_class_init (EdaRendererClass *klass)
 {
   GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
   GParamFlags param_flags;
-
-  g_type_class_add_private (gobject_class, sizeof (EdaRendererPrivate));
 
   /* Register functions with base class */
   gobject_class->constructor = eda_renderer_constructor;


### PR DESCRIPTION
`g_type_class_add_private()` used in `liblepton` and `libleptonrenderer`
code is deprecated since `glib 2.58`. To fix this, we need some new stuff
introduced in `glib 2.38.0`, so minimum required version is bumped. 
Deprecation warnings are fixed by using new `G_DEFINE_TYPE_WITH_PRIVATE` macro.