### PR TITLE
Prevent unwanted updates of PO files in lepton-attrib

### DIFF
--- a/attrib/po/.gitignore
+++ b/attrib/po/.gitignore
@@ -9,7 +9,6 @@ POTFILES
 *.sin
 Rules-quot
 Makevars.template
-lepton-attrib.pot
 stamp-po
 stamp-it
 stamp-i18n

--- a/attrib/po/Makevars
+++ b/attrib/po/Makevars
@@ -10,6 +10,10 @@ top_builddir = ../..
 # These options get passed to xgettext.
 XGETTEXT_OPTIONS = --keyword=_ --keyword=N_ --from-code=UTF-8
 
+MSGMERGE_OPTIONS = --no-location
+
+PO_DEPENDS_ON_POT = no
+
 # This is the copyright holder that gets inserted into the header of the
 # $(DOMAIN).pot file.  Set this to the copyright holder of the surrounding
 # package.  (Note that the msgstr strings, extracted from the package's

--- a/attrib/po/af.po
+++ b/attrib/po/af.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-12 00:10+0300\n"
+"POT-Creation-Date: 2019-05-10 08:15+0300\n"
 "PO-Revision-Date: 2012-01-27 14:17+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: Afrikaans <af@li.org>\n"
@@ -18,38 +18,30 @@ msgstr ""
 "X-Launchpad-Export-Date: 2012-11-14 16:52+0000\n"
 "X-Generator: Launchpad (build 16265)\n"
 
-#: attrib/data/lepton-attrib.desktop.in:3
 msgid "Lepton EDA Attribute Editor"
 msgstr ""
 
-#: attrib/data/lepton-attrib.desktop.in:4
 msgid "Manipulate component attributes with lepton-attrib"
 msgstr ""
 
-#: attrib/src/f_export.c:82
 #, c-format
 msgid "o_save: Could not open [%1$s]"
 msgstr ""
 
-#: attrib/src/lepton-attrib.c:160
 #, c-format
 msgid "Lepton EDA/lepton-attrib version %1$s%2$s.%3$s git: %4$.7s"
 msgstr ""
 
-#: attrib/src/lepton-attrib.c:196
 #, c-format
 msgid "Couldn't find file [%1$s]\n"
 msgstr ""
 
-#: attrib/src/gtksheet_2_2.c:6302
 msgid "Entry type must be GtkEntry subclass, using default"
 msgstr ""
 
-#: attrib/src/gtksheet_2_2.c:8499
 msgid "Widget must be a GtkSheet child"
 msgstr ""
 
-#: attrib/src/parsecmd.c:73
 #, c-format
 msgid ""
 "\n"
@@ -81,174 +73,143 @@ msgid ""
 "Please report bugs to %2$s.\n"
 msgstr ""
 
-#: attrib/src/s_attrib.c:101
 #, c-format
 msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 
-#: attrib/src/s_misc.c:81
 #, c-format
 msgid ""
 "\n"
 "DONE\n"
 msgstr ""
 
-#: attrib/src/s_misc.c:83
 #, c-format
 msgid " DONE\n"
 msgstr ""
 
-#: attrib/src/s_object.c:217
 #, c-format
 msgid ""
 "In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
 "on the component.  Exiting . . .\n"
 msgstr ""
 
-#: attrib/src/s_object.c:276
 #, c-format
 msgid ""
 "In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
 "on the component.  Exiting . . .\n"
 msgstr ""
 
-#: attrib/src/s_object.c:329
 #, c-format
 msgid ""
 "In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
 "or non-net!\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:116
 #, c-format
 msgid "- Starting master comp list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:184
 #, c-format
 msgid "- Starting master comp attrib list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:297
 #, c-format
 msgid "- Starting master pin list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:331
 #, c-format
 msgid ""
 "In s_sheet_data_add_master_pin_list_items, found component pin with no "
 "pinnumber.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:389
 #, c-format
 msgid "- Starting master pin attrib list creation.\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:123
 #, c-format
 msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:188
 #, c-format
 msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:252
 #, c-format
 msgid "In s_string_list_delete_item, couldn't delete item %s\n"
 msgstr ""
 
-#: attrib/src/s_table.c:242
 #, c-format
 msgid ""
 "In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
 msgstr ""
 
-#: attrib/src/s_table.c:285
 #, c-format
 msgid "- Starting internal component TABLE creation\n"
 msgstr ""
 
-#: attrib/src/s_table.c:344
 #, c-format
 msgid ""
 "In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
 "or col in the lists!\n"
 msgstr ""
 
-#: attrib/src/s_table.c:493
 #, c-format
 msgid "- Starting internal pin TABLE creation\n"
 msgstr ""
 
-#: attrib/src/s_table.c:553
 #, c-format
 msgid ""
 "In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
 "col in the lists!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:185
 msgid "_cancel"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:318
 #, c-format
 msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:554
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
 "the master list!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:582
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:891
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
 "missing!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:900
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
 "master list!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:928
 #, c-format
 msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:74
 msgid "Add new attribute"
 msgstr ""
 
-#: attrib/src/x_dialog.c:83
 msgid "Enter new attribute name"
 msgstr ""
 
-#: attrib/src/x_dialog.c:147
 msgid "Are you sure you want to delete this attribute?"
 msgstr ""
 
-#: attrib/src/x_dialog.c:149
 msgid "Delete attribute"
 msgstr ""
 
-#: attrib/src/x_dialog.c:174
 msgid ""
 "One or more components have been found with missing symbol files!\n"
 "\n"
@@ -259,31 +220,24 @@ msgid ""
 "\"Forward\" to continue working with lepton-attrib.\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:187
 msgid "Missing symbol file found for component!"
 msgstr ""
 
-#: attrib/src/x_dialog.c:214
 msgid "Save the changes before closing?"
 msgstr ""
 
-#: attrib/src/x_dialog.c:215
 msgid "<big><b>"
 msgstr ""
 
-#: attrib/src/x_dialog.c:215
 msgid "</b></big>"
 msgstr ""
 
-#: attrib/src/x_dialog.c:217
 msgid "If you don't save, all your changes will be permanently lost."
 msgstr ""
 
-#: attrib/src/x_dialog.c:227
 msgid "Close without saving"
 msgstr ""
 
-#: attrib/src/x_dialog.c:274
 msgid ""
 "Sorry -- you have chosen a feature which has not been\n"
 "implemented yet.\n"
@@ -297,15 +251,12 @@ msgid ""
 "Otherwise, just hang tight -- I'll implement this feature soon!\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:282
 msgid "Unimplemented feature!"
 msgstr ""
 
-#: attrib/src/x_dialog.c:309
 msgid "Fatal error"
 msgstr ""
 
-#: attrib/src/x_dialog.c:324
 #, c-format
 msgid ""
 "Lepton Electronic Design Automation\n"
@@ -319,109 +270,84 @@ msgid ""
 "and gtkextra, as well as support from the gEDA community."
 msgstr ""
 
-#: attrib/src/x_dialog.c:335
 msgid "About..."
 msgstr ""
 
-#: attrib/src/x_dialog.c:351
 msgid "Export CSV"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:87
 msgid "Schematics"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:92
 msgid "Symbols"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:97
 msgid "Schematics and symbols"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:103
 msgid "All files"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:134
 #, c-format
 msgid "Loading file [%1$s]"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:140
 #, c-format
 msgid "Couldn't load schematic [%1$s]\n"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:230
 msgid "Open..."
 msgstr ""
 
-#: attrib/src/x_fileselect.c:275
 msgid "Save as..."
 msgstr ""
 
-#: attrib/src/x_fileselect.c:304
 #, c-format
 msgid "Saved As [%1$s]"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:314
 #, c-format
 msgid "Could NOT save [%1$s]"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:70 attrib/src/x_gtksheet.c:79
 msgid "Components"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:71 attrib/src/x_gtksheet.c:88
-#: attrib/src/x_gtksheet.c:91
 msgid "Nets"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:72 attrib/src/x_gtksheet.c:104
-#: attrib/src/x_gtksheet.c:107
 msgid "Pins"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:81
 msgid ""
 "No components found in design.  Please check your schematic and try again!\n"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:92 attrib/src/x_gtksheet.c:94
 msgid "TBD"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:355
 msgid "couldn't allocate color"
 msgstr ""
 
-#: attrib/src/x_window.c:94
 msgid "lepton-attrib - Lepton EDA attribute editor"
 msgstr ""
 
-#: attrib/src/x_window.c:299
 #, c-format
 msgid ""
 "Error loading %1$s:\n"
 "%2$s\n"
 msgstr ""
 
-#: attrib/src/x_window.c:337
 msgid ""
 "No components found in entire design!\n"
 "Do you have refdeses on your components?"
 msgstr ""
 
-#: attrib/src/x_window.c:342
 msgid ""
 "No configurable component attributes found in entire design!\n"
 "Please attach at least some attributes before running lepton-attrib."
 msgstr ""
 
-#: attrib/src/x_window.c:347
 msgid ""
 "No pins found on any components!\n"
 "Please check your design."

--- a/attrib/po/ar.po
+++ b/attrib/po/ar.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-12 00:10+0300\n"
+"POT-Creation-Date: 2019-05-10 08:15+0300\n"
 "PO-Revision-Date: 2010-02-08 18:58+0000\n"
 "Last-Translator: عبدالله شلي (Abdellah Chelli) <Unknown>\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -17,40 +17,32 @@ msgstr ""
 "X-Launchpad-Export-Date: 2010-02-14 12:56+0000\n"
 "X-Generator: Launchpad (build Unknown)\n"
 
-#: attrib/data/lepton-attrib.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Attribute Editor"
 msgstr "محرّر السّمة ل‍ gEDA"
 
-#: attrib/data/lepton-attrib.desktop.in:4
 #, fuzzy
 msgid "Manipulate component attributes with lepton-attrib"
 msgstr "عالج سمات المكوّن ب‍ gattrib"
 
-#: attrib/src/f_export.c:82
 #, c-format
 msgid "o_save: Could not open [%1$s]"
 msgstr ""
 
-#: attrib/src/lepton-attrib.c:160
 #, c-format
 msgid "Lepton EDA/lepton-attrib version %1$s%2$s.%3$s git: %4$.7s"
 msgstr ""
 
-#: attrib/src/lepton-attrib.c:196
 #, c-format
 msgid "Couldn't find file [%1$s]\n"
 msgstr ""
 
-#: attrib/src/gtksheet_2_2.c:6302
 msgid "Entry type must be GtkEntry subclass, using default"
 msgstr ""
 
-#: attrib/src/gtksheet_2_2.c:8499
 msgid "Widget must be a GtkSheet child"
 msgstr ""
 
-#: attrib/src/parsecmd.c:73
 #, c-format
 msgid ""
 "\n"
@@ -82,174 +74,143 @@ msgid ""
 "Please report bugs to %2$s.\n"
 msgstr ""
 
-#: attrib/src/s_attrib.c:101
 #, c-format
 msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 
-#: attrib/src/s_misc.c:81
 #, c-format
 msgid ""
 "\n"
 "DONE\n"
 msgstr ""
 
-#: attrib/src/s_misc.c:83
 #, c-format
 msgid " DONE\n"
 msgstr ""
 
-#: attrib/src/s_object.c:217
 #, c-format
 msgid ""
 "In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
 "on the component.  Exiting . . .\n"
 msgstr ""
 
-#: attrib/src/s_object.c:276
 #, c-format
 msgid ""
 "In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
 "on the component.  Exiting . . .\n"
 msgstr ""
 
-#: attrib/src/s_object.c:329
 #, c-format
 msgid ""
 "In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
 "or non-net!\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:116
 #, c-format
 msgid "- Starting master comp list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:184
 #, c-format
 msgid "- Starting master comp attrib list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:297
 #, c-format
 msgid "- Starting master pin list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:331
 #, c-format
 msgid ""
 "In s_sheet_data_add_master_pin_list_items, found component pin with no "
 "pinnumber.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:389
 #, c-format
 msgid "- Starting master pin attrib list creation.\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:123
 #, c-format
 msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:188
 #, c-format
 msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:252
 #, c-format
 msgid "In s_string_list_delete_item, couldn't delete item %s\n"
 msgstr ""
 
-#: attrib/src/s_table.c:242
 #, c-format
 msgid ""
 "In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
 msgstr ""
 
-#: attrib/src/s_table.c:285
 #, c-format
 msgid "- Starting internal component TABLE creation\n"
 msgstr ""
 
-#: attrib/src/s_table.c:344
 #, c-format
 msgid ""
 "In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
 "or col in the lists!\n"
 msgstr ""
 
-#: attrib/src/s_table.c:493
 #, c-format
 msgid "- Starting internal pin TABLE creation\n"
 msgstr ""
 
-#: attrib/src/s_table.c:553
 #, c-format
 msgid ""
 "In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
 "col in the lists!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:185
 msgid "_cancel"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:318
 #, c-format
 msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:554
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
 "the master list!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:582
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:891
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
 "missing!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:900
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
 "master list!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:928
 #, c-format
 msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:74
 msgid "Add new attribute"
 msgstr ""
 
-#: attrib/src/x_dialog.c:83
 msgid "Enter new attribute name"
 msgstr ""
 
-#: attrib/src/x_dialog.c:147
 msgid "Are you sure you want to delete this attribute?"
 msgstr ""
 
-#: attrib/src/x_dialog.c:149
 msgid "Delete attribute"
 msgstr ""
 
-#: attrib/src/x_dialog.c:174
 msgid ""
 "One or more components have been found with missing symbol files!\n"
 "\n"
@@ -260,31 +221,24 @@ msgid ""
 "\"Forward\" to continue working with lepton-attrib.\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:187
 msgid "Missing symbol file found for component!"
 msgstr ""
 
-#: attrib/src/x_dialog.c:214
 msgid "Save the changes before closing?"
 msgstr ""
 
-#: attrib/src/x_dialog.c:215
 msgid "<big><b>"
 msgstr ""
 
-#: attrib/src/x_dialog.c:215
 msgid "</b></big>"
 msgstr ""
 
-#: attrib/src/x_dialog.c:217
 msgid "If you don't save, all your changes will be permanently lost."
 msgstr ""
 
-#: attrib/src/x_dialog.c:227
 msgid "Close without saving"
 msgstr ""
 
-#: attrib/src/x_dialog.c:274
 msgid ""
 "Sorry -- you have chosen a feature which has not been\n"
 "implemented yet.\n"
@@ -298,15 +252,12 @@ msgid ""
 "Otherwise, just hang tight -- I'll implement this feature soon!\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:282
 msgid "Unimplemented feature!"
 msgstr ""
 
-#: attrib/src/x_dialog.c:309
 msgid "Fatal error"
 msgstr ""
 
-#: attrib/src/x_dialog.c:324
 #, c-format
 msgid ""
 "Lepton Electronic Design Automation\n"
@@ -320,110 +271,85 @@ msgid ""
 "and gtkextra, as well as support from the gEDA community."
 msgstr ""
 
-#: attrib/src/x_dialog.c:335
 msgid "About..."
 msgstr ""
 
-#: attrib/src/x_dialog.c:351
 msgid "Export CSV"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:87
 msgid "Schematics"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:92
 msgid "Symbols"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:97
 msgid "Schematics and symbols"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:103
 msgid "All files"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:134
 #, c-format
 msgid "Loading file [%1$s]"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:140
 #, c-format
 msgid "Couldn't load schematic [%1$s]\n"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:230
 msgid "Open..."
 msgstr ""
 
-#: attrib/src/x_fileselect.c:275
 msgid "Save as..."
 msgstr ""
 
-#: attrib/src/x_fileselect.c:304
 #, c-format
 msgid "Saved As [%1$s]"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:314
 #, c-format
 msgid "Could NOT save [%1$s]"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:70 attrib/src/x_gtksheet.c:79
 msgid "Components"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:71 attrib/src/x_gtksheet.c:88
-#: attrib/src/x_gtksheet.c:91
 msgid "Nets"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:72 attrib/src/x_gtksheet.c:104
-#: attrib/src/x_gtksheet.c:107
 msgid "Pins"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:81
 msgid ""
 "No components found in design.  Please check your schematic and try again!\n"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:92 attrib/src/x_gtksheet.c:94
 msgid "TBD"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:355
 msgid "couldn't allocate color"
 msgstr ""
 
-#: attrib/src/x_window.c:94
 #, fuzzy
 msgid "lepton-attrib - Lepton EDA attribute editor"
 msgstr "محرّر السّمة ل‍ gEDA"
 
-#: attrib/src/x_window.c:299
 #, c-format
 msgid ""
 "Error loading %1$s:\n"
 "%2$s\n"
 msgstr ""
 
-#: attrib/src/x_window.c:337
 msgid ""
 "No components found in entire design!\n"
 "Do you have refdeses on your components?"
 msgstr ""
 
-#: attrib/src/x_window.c:342
 msgid ""
 "No configurable component attributes found in entire design!\n"
 "Please attach at least some attributes before running lepton-attrib."
 msgstr ""
 
-#: attrib/src/x_window.c:347
 msgid ""
 "No pins found on any components!\n"
 "Please check your design."

--- a/attrib/po/bg.po
+++ b/attrib/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-12 00:10+0300\n"
+"POT-Creation-Date: 2019-05-10 08:15+0300\n"
 "PO-Revision-Date: 2010-02-06 22:09+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -18,40 +18,32 @@ msgstr ""
 "X-Launchpad-Export-Date: 2010-02-14 12:56+0000\n"
 "X-Generator: Launchpad (build Unknown)\n"
 
-#: attrib/data/lepton-attrib.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Attribute Editor"
 msgstr "gEDA Едитор на атрибути"
 
-#: attrib/data/lepton-attrib.desktop.in:4
 #, fuzzy
 msgid "Manipulate component attributes with lepton-attrib"
 msgstr "Манипулирай атрибутите на компонента с gattrib"
 
-#: attrib/src/f_export.c:82
 #, c-format
 msgid "o_save: Could not open [%1$s]"
 msgstr ""
 
-#: attrib/src/lepton-attrib.c:160
 #, c-format
 msgid "Lepton EDA/lepton-attrib version %1$s%2$s.%3$s git: %4$.7s"
 msgstr ""
 
-#: attrib/src/lepton-attrib.c:196
 #, c-format
 msgid "Couldn't find file [%1$s]\n"
 msgstr ""
 
-#: attrib/src/gtksheet_2_2.c:6302
 msgid "Entry type must be GtkEntry subclass, using default"
 msgstr ""
 
-#: attrib/src/gtksheet_2_2.c:8499
 msgid "Widget must be a GtkSheet child"
 msgstr ""
 
-#: attrib/src/parsecmd.c:73
 #, c-format
 msgid ""
 "\n"
@@ -83,174 +75,143 @@ msgid ""
 "Please report bugs to %2$s.\n"
 msgstr ""
 
-#: attrib/src/s_attrib.c:101
 #, c-format
 msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 
-#: attrib/src/s_misc.c:81
 #, c-format
 msgid ""
 "\n"
 "DONE\n"
 msgstr ""
 
-#: attrib/src/s_misc.c:83
 #, c-format
 msgid " DONE\n"
 msgstr ""
 
-#: attrib/src/s_object.c:217
 #, c-format
 msgid ""
 "In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
 "on the component.  Exiting . . .\n"
 msgstr ""
 
-#: attrib/src/s_object.c:276
 #, c-format
 msgid ""
 "In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
 "on the component.  Exiting . . .\n"
 msgstr ""
 
-#: attrib/src/s_object.c:329
 #, c-format
 msgid ""
 "In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
 "or non-net!\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:116
 #, c-format
 msgid "- Starting master comp list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:184
 #, c-format
 msgid "- Starting master comp attrib list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:297
 #, c-format
 msgid "- Starting master pin list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:331
 #, c-format
 msgid ""
 "In s_sheet_data_add_master_pin_list_items, found component pin with no "
 "pinnumber.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:389
 #, c-format
 msgid "- Starting master pin attrib list creation.\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:123
 #, c-format
 msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:188
 #, c-format
 msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:252
 #, c-format
 msgid "In s_string_list_delete_item, couldn't delete item %s\n"
 msgstr ""
 
-#: attrib/src/s_table.c:242
 #, c-format
 msgid ""
 "In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
 msgstr ""
 
-#: attrib/src/s_table.c:285
 #, c-format
 msgid "- Starting internal component TABLE creation\n"
 msgstr ""
 
-#: attrib/src/s_table.c:344
 #, c-format
 msgid ""
 "In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
 "or col in the lists!\n"
 msgstr ""
 
-#: attrib/src/s_table.c:493
 #, c-format
 msgid "- Starting internal pin TABLE creation\n"
 msgstr ""
 
-#: attrib/src/s_table.c:553
 #, c-format
 msgid ""
 "In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
 "col in the lists!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:185
 msgid "_cancel"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:318
 #, c-format
 msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:554
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
 "the master list!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:582
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:891
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
 "missing!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:900
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
 "master list!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:928
 #, c-format
 msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:74
 msgid "Add new attribute"
 msgstr ""
 
-#: attrib/src/x_dialog.c:83
 msgid "Enter new attribute name"
 msgstr ""
 
-#: attrib/src/x_dialog.c:147
 msgid "Are you sure you want to delete this attribute?"
 msgstr ""
 
-#: attrib/src/x_dialog.c:149
 msgid "Delete attribute"
 msgstr ""
 
-#: attrib/src/x_dialog.c:174
 msgid ""
 "One or more components have been found with missing symbol files!\n"
 "\n"
@@ -261,31 +222,24 @@ msgid ""
 "\"Forward\" to continue working with lepton-attrib.\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:187
 msgid "Missing symbol file found for component!"
 msgstr ""
 
-#: attrib/src/x_dialog.c:214
 msgid "Save the changes before closing?"
 msgstr ""
 
-#: attrib/src/x_dialog.c:215
 msgid "<big><b>"
 msgstr ""
 
-#: attrib/src/x_dialog.c:215
 msgid "</b></big>"
 msgstr ""
 
-#: attrib/src/x_dialog.c:217
 msgid "If you don't save, all your changes will be permanently lost."
 msgstr ""
 
-#: attrib/src/x_dialog.c:227
 msgid "Close without saving"
 msgstr ""
 
-#: attrib/src/x_dialog.c:274
 msgid ""
 "Sorry -- you have chosen a feature which has not been\n"
 "implemented yet.\n"
@@ -299,15 +253,12 @@ msgid ""
 "Otherwise, just hang tight -- I'll implement this feature soon!\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:282
 msgid "Unimplemented feature!"
 msgstr ""
 
-#: attrib/src/x_dialog.c:309
 msgid "Fatal error"
 msgstr ""
 
-#: attrib/src/x_dialog.c:324
 #, c-format
 msgid ""
 "Lepton Electronic Design Automation\n"
@@ -321,110 +272,85 @@ msgid ""
 "and gtkextra, as well as support from the gEDA community."
 msgstr ""
 
-#: attrib/src/x_dialog.c:335
 msgid "About..."
 msgstr ""
 
-#: attrib/src/x_dialog.c:351
 msgid "Export CSV"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:87
 msgid "Schematics"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:92
 msgid "Symbols"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:97
 msgid "Schematics and symbols"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:103
 msgid "All files"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:134
 #, c-format
 msgid "Loading file [%1$s]"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:140
 #, c-format
 msgid "Couldn't load schematic [%1$s]\n"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:230
 msgid "Open..."
 msgstr ""
 
-#: attrib/src/x_fileselect.c:275
 msgid "Save as..."
 msgstr ""
 
-#: attrib/src/x_fileselect.c:304
 #, c-format
 msgid "Saved As [%1$s]"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:314
 #, c-format
 msgid "Could NOT save [%1$s]"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:70 attrib/src/x_gtksheet.c:79
 msgid "Components"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:71 attrib/src/x_gtksheet.c:88
-#: attrib/src/x_gtksheet.c:91
 msgid "Nets"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:72 attrib/src/x_gtksheet.c:104
-#: attrib/src/x_gtksheet.c:107
 msgid "Pins"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:81
 msgid ""
 "No components found in design.  Please check your schematic and try again!\n"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:92 attrib/src/x_gtksheet.c:94
 msgid "TBD"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:355
 msgid "couldn't allocate color"
 msgstr ""
 
-#: attrib/src/x_window.c:94
 #, fuzzy
 msgid "lepton-attrib - Lepton EDA attribute editor"
 msgstr "gEDA Едитор на атрибути"
 
-#: attrib/src/x_window.c:299
 #, c-format
 msgid ""
 "Error loading %1$s:\n"
 "%2$s\n"
 msgstr ""
 
-#: attrib/src/x_window.c:337
 msgid ""
 "No components found in entire design!\n"
 "Do you have refdeses on your components?"
 msgstr ""
 
-#: attrib/src/x_window.c:342
 msgid ""
 "No configurable component attributes found in entire design!\n"
 "Please attach at least some attributes before running lepton-attrib."
 msgstr ""
 
-#: attrib/src/x_window.c:347
 msgid ""
 "No pins found on any components!\n"
 "Please check your design."

--- a/attrib/po/bs.po
+++ b/attrib/po/bs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-12 00:10+0300\n"
+"POT-Creation-Date: 2019-05-10 08:15+0300\n"
 "PO-Revision-Date: 2012-01-27 14:17+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: Bosnian <bs@li.org>\n"
@@ -18,40 +18,32 @@ msgstr ""
 "X-Launchpad-Export-Date: 2012-11-14 16:52+0000\n"
 "X-Generator: Launchpad (build 16265)\n"
 
-#: attrib/data/lepton-attrib.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Attribute Editor"
 msgstr "gEDA uređivač atributa"
 
-#: attrib/data/lepton-attrib.desktop.in:4
 #, fuzzy
 msgid "Manipulate component attributes with lepton-attrib"
 msgstr "Upravljajte atributima komponenti pomoću gattrib"
 
-#: attrib/src/f_export.c:82
 #, c-format
 msgid "o_save: Could not open [%1$s]"
 msgstr ""
 
-#: attrib/src/lepton-attrib.c:160
 #, c-format
 msgid "Lepton EDA/lepton-attrib version %1$s%2$s.%3$s git: %4$.7s"
 msgstr ""
 
-#: attrib/src/lepton-attrib.c:196
 #, c-format
 msgid "Couldn't find file [%1$s]\n"
 msgstr ""
 
-#: attrib/src/gtksheet_2_2.c:6302
 msgid "Entry type must be GtkEntry subclass, using default"
 msgstr ""
 
-#: attrib/src/gtksheet_2_2.c:8499
 msgid "Widget must be a GtkSheet child"
 msgstr ""
 
-#: attrib/src/parsecmd.c:73
 #, c-format
 msgid ""
 "\n"
@@ -83,174 +75,143 @@ msgid ""
 "Please report bugs to %2$s.\n"
 msgstr ""
 
-#: attrib/src/s_attrib.c:101
 #, c-format
 msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 
-#: attrib/src/s_misc.c:81
 #, c-format
 msgid ""
 "\n"
 "DONE\n"
 msgstr ""
 
-#: attrib/src/s_misc.c:83
 #, c-format
 msgid " DONE\n"
 msgstr ""
 
-#: attrib/src/s_object.c:217
 #, c-format
 msgid ""
 "In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
 "on the component.  Exiting . . .\n"
 msgstr ""
 
-#: attrib/src/s_object.c:276
 #, c-format
 msgid ""
 "In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
 "on the component.  Exiting . . .\n"
 msgstr ""
 
-#: attrib/src/s_object.c:329
 #, c-format
 msgid ""
 "In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
 "or non-net!\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:116
 #, c-format
 msgid "- Starting master comp list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:184
 #, c-format
 msgid "- Starting master comp attrib list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:297
 #, c-format
 msgid "- Starting master pin list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:331
 #, c-format
 msgid ""
 "In s_sheet_data_add_master_pin_list_items, found component pin with no "
 "pinnumber.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:389
 #, c-format
 msgid "- Starting master pin attrib list creation.\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:123
 #, c-format
 msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:188
 #, c-format
 msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:252
 #, c-format
 msgid "In s_string_list_delete_item, couldn't delete item %s\n"
 msgstr ""
 
-#: attrib/src/s_table.c:242
 #, c-format
 msgid ""
 "In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
 msgstr ""
 
-#: attrib/src/s_table.c:285
 #, c-format
 msgid "- Starting internal component TABLE creation\n"
 msgstr ""
 
-#: attrib/src/s_table.c:344
 #, c-format
 msgid ""
 "In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
 "or col in the lists!\n"
 msgstr ""
 
-#: attrib/src/s_table.c:493
 #, c-format
 msgid "- Starting internal pin TABLE creation\n"
 msgstr ""
 
-#: attrib/src/s_table.c:553
 #, c-format
 msgid ""
 "In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
 "col in the lists!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:185
 msgid "_cancel"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:318
 #, c-format
 msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:554
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
 "the master list!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:582
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:891
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
 "missing!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:900
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
 "master list!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:928
 #, c-format
 msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:74
 msgid "Add new attribute"
 msgstr ""
 
-#: attrib/src/x_dialog.c:83
 msgid "Enter new attribute name"
 msgstr ""
 
-#: attrib/src/x_dialog.c:147
 msgid "Are you sure you want to delete this attribute?"
 msgstr ""
 
-#: attrib/src/x_dialog.c:149
 msgid "Delete attribute"
 msgstr ""
 
-#: attrib/src/x_dialog.c:174
 msgid ""
 "One or more components have been found with missing symbol files!\n"
 "\n"
@@ -261,31 +222,24 @@ msgid ""
 "\"Forward\" to continue working with lepton-attrib.\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:187
 msgid "Missing symbol file found for component!"
 msgstr ""
 
-#: attrib/src/x_dialog.c:214
 msgid "Save the changes before closing?"
 msgstr ""
 
-#: attrib/src/x_dialog.c:215
 msgid "<big><b>"
 msgstr ""
 
-#: attrib/src/x_dialog.c:215
 msgid "</b></big>"
 msgstr ""
 
-#: attrib/src/x_dialog.c:217
 msgid "If you don't save, all your changes will be permanently lost."
 msgstr ""
 
-#: attrib/src/x_dialog.c:227
 msgid "Close without saving"
 msgstr ""
 
-#: attrib/src/x_dialog.c:274
 msgid ""
 "Sorry -- you have chosen a feature which has not been\n"
 "implemented yet.\n"
@@ -299,15 +253,12 @@ msgid ""
 "Otherwise, just hang tight -- I'll implement this feature soon!\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:282
 msgid "Unimplemented feature!"
 msgstr ""
 
-#: attrib/src/x_dialog.c:309
 msgid "Fatal error"
 msgstr ""
 
-#: attrib/src/x_dialog.c:324
 #, c-format
 msgid ""
 "Lepton Electronic Design Automation\n"
@@ -321,110 +272,85 @@ msgid ""
 "and gtkextra, as well as support from the gEDA community."
 msgstr ""
 
-#: attrib/src/x_dialog.c:335
 msgid "About..."
 msgstr ""
 
-#: attrib/src/x_dialog.c:351
 msgid "Export CSV"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:87
 msgid "Schematics"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:92
 msgid "Symbols"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:97
 msgid "Schematics and symbols"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:103
 msgid "All files"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:134
 #, c-format
 msgid "Loading file [%1$s]"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:140
 #, c-format
 msgid "Couldn't load schematic [%1$s]\n"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:230
 msgid "Open..."
 msgstr ""
 
-#: attrib/src/x_fileselect.c:275
 msgid "Save as..."
 msgstr ""
 
-#: attrib/src/x_fileselect.c:304
 #, c-format
 msgid "Saved As [%1$s]"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:314
 #, c-format
 msgid "Could NOT save [%1$s]"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:70 attrib/src/x_gtksheet.c:79
 msgid "Components"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:71 attrib/src/x_gtksheet.c:88
-#: attrib/src/x_gtksheet.c:91
 msgid "Nets"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:72 attrib/src/x_gtksheet.c:104
-#: attrib/src/x_gtksheet.c:107
 msgid "Pins"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:81
 msgid ""
 "No components found in design.  Please check your schematic and try again!\n"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:92 attrib/src/x_gtksheet.c:94
 msgid "TBD"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:355
 msgid "couldn't allocate color"
 msgstr ""
 
-#: attrib/src/x_window.c:94
 #, fuzzy
 msgid "lepton-attrib - Lepton EDA attribute editor"
 msgstr "gEDA uređivač atributa"
 
-#: attrib/src/x_window.c:299
 #, c-format
 msgid ""
 "Error loading %1$s:\n"
 "%2$s\n"
 msgstr ""
 
-#: attrib/src/x_window.c:337
 msgid ""
 "No components found in entire design!\n"
 "Do you have refdeses on your components?"
 msgstr ""
 
-#: attrib/src/x_window.c:342
 msgid ""
 "No configurable component attributes found in entire design!\n"
 "Please attach at least some attributes before running lepton-attrib."
 msgstr ""
 
-#: attrib/src/x_window.c:347
 msgid ""
 "No pins found on any components!\n"
 "Please check your design."

--- a/attrib/po/da.po
+++ b/attrib/po/da.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-12 00:10+0300\n"
+"POT-Creation-Date: 2019-05-10 08:15+0300\n"
 "PO-Revision-Date: 2012-01-27 14:17+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: Danish <da@li.org>\n"
@@ -18,39 +18,31 @@ msgstr ""
 "X-Launchpad-Export-Date: 2012-11-14 16:52+0000\n"
 "X-Generator: Launchpad (build 16265)\n"
 
-#: attrib/data/lepton-attrib.desktop.in:3
 msgid "Lepton EDA Attribute Editor"
 msgstr ""
 
-#: attrib/data/lepton-attrib.desktop.in:4
 #, fuzzy
 msgid "Manipulate component attributes with lepton-attrib"
 msgstr "Ændre komponent attributter med gattrib"
 
-#: attrib/src/f_export.c:82
 #, c-format
 msgid "o_save: Could not open [%1$s]"
 msgstr ""
 
-#: attrib/src/lepton-attrib.c:160
 #, c-format
 msgid "Lepton EDA/lepton-attrib version %1$s%2$s.%3$s git: %4$.7s"
 msgstr ""
 
-#: attrib/src/lepton-attrib.c:196
 #, c-format
 msgid "Couldn't find file [%1$s]\n"
 msgstr ""
 
-#: attrib/src/gtksheet_2_2.c:6302
 msgid "Entry type must be GtkEntry subclass, using default"
 msgstr ""
 
-#: attrib/src/gtksheet_2_2.c:8499
 msgid "Widget must be a GtkSheet child"
 msgstr ""
 
-#: attrib/src/parsecmd.c:73
 #, c-format
 msgid ""
 "\n"
@@ -82,174 +74,143 @@ msgid ""
 "Please report bugs to %2$s.\n"
 msgstr ""
 
-#: attrib/src/s_attrib.c:101
 #, c-format
 msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 
-#: attrib/src/s_misc.c:81
 #, c-format
 msgid ""
 "\n"
 "DONE\n"
 msgstr ""
 
-#: attrib/src/s_misc.c:83
 #, c-format
 msgid " DONE\n"
 msgstr ""
 
-#: attrib/src/s_object.c:217
 #, c-format
 msgid ""
 "In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
 "on the component.  Exiting . . .\n"
 msgstr ""
 
-#: attrib/src/s_object.c:276
 #, c-format
 msgid ""
 "In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
 "on the component.  Exiting . . .\n"
 msgstr ""
 
-#: attrib/src/s_object.c:329
 #, c-format
 msgid ""
 "In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
 "or non-net!\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:116
 #, c-format
 msgid "- Starting master comp list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:184
 #, c-format
 msgid "- Starting master comp attrib list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:297
 #, c-format
 msgid "- Starting master pin list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:331
 #, c-format
 msgid ""
 "In s_sheet_data_add_master_pin_list_items, found component pin with no "
 "pinnumber.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:389
 #, c-format
 msgid "- Starting master pin attrib list creation.\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:123
 #, c-format
 msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:188
 #, c-format
 msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:252
 #, c-format
 msgid "In s_string_list_delete_item, couldn't delete item %s\n"
 msgstr ""
 
-#: attrib/src/s_table.c:242
 #, c-format
 msgid ""
 "In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
 msgstr ""
 
-#: attrib/src/s_table.c:285
 #, c-format
 msgid "- Starting internal component TABLE creation\n"
 msgstr ""
 
-#: attrib/src/s_table.c:344
 #, c-format
 msgid ""
 "In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
 "or col in the lists!\n"
 msgstr ""
 
-#: attrib/src/s_table.c:493
 #, c-format
 msgid "- Starting internal pin TABLE creation\n"
 msgstr ""
 
-#: attrib/src/s_table.c:553
 #, c-format
 msgid ""
 "In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
 "col in the lists!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:185
 msgid "_cancel"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:318
 #, c-format
 msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:554
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
 "the master list!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:582
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:891
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
 "missing!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:900
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
 "master list!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:928
 #, c-format
 msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:74
 msgid "Add new attribute"
 msgstr ""
 
-#: attrib/src/x_dialog.c:83
 msgid "Enter new attribute name"
 msgstr ""
 
-#: attrib/src/x_dialog.c:147
 msgid "Are you sure you want to delete this attribute?"
 msgstr ""
 
-#: attrib/src/x_dialog.c:149
 msgid "Delete attribute"
 msgstr ""
 
-#: attrib/src/x_dialog.c:174
 msgid ""
 "One or more components have been found with missing symbol files!\n"
 "\n"
@@ -260,31 +221,24 @@ msgid ""
 "\"Forward\" to continue working with lepton-attrib.\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:187
 msgid "Missing symbol file found for component!"
 msgstr ""
 
-#: attrib/src/x_dialog.c:214
 msgid "Save the changes before closing?"
 msgstr ""
 
-#: attrib/src/x_dialog.c:215
 msgid "<big><b>"
 msgstr ""
 
-#: attrib/src/x_dialog.c:215
 msgid "</b></big>"
 msgstr ""
 
-#: attrib/src/x_dialog.c:217
 msgid "If you don't save, all your changes will be permanently lost."
 msgstr ""
 
-#: attrib/src/x_dialog.c:227
 msgid "Close without saving"
 msgstr ""
 
-#: attrib/src/x_dialog.c:274
 msgid ""
 "Sorry -- you have chosen a feature which has not been\n"
 "implemented yet.\n"
@@ -298,15 +252,12 @@ msgid ""
 "Otherwise, just hang tight -- I'll implement this feature soon!\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:282
 msgid "Unimplemented feature!"
 msgstr ""
 
-#: attrib/src/x_dialog.c:309
 msgid "Fatal error"
 msgstr ""
 
-#: attrib/src/x_dialog.c:324
 #, c-format
 msgid ""
 "Lepton Electronic Design Automation\n"
@@ -320,109 +271,84 @@ msgid ""
 "and gtkextra, as well as support from the gEDA community."
 msgstr ""
 
-#: attrib/src/x_dialog.c:335
 msgid "About..."
 msgstr ""
 
-#: attrib/src/x_dialog.c:351
 msgid "Export CSV"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:87
 msgid "Schematics"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:92
 msgid "Symbols"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:97
 msgid "Schematics and symbols"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:103
 msgid "All files"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:134
 #, c-format
 msgid "Loading file [%1$s]"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:140
 #, c-format
 msgid "Couldn't load schematic [%1$s]\n"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:230
 msgid "Open..."
 msgstr ""
 
-#: attrib/src/x_fileselect.c:275
 msgid "Save as..."
 msgstr ""
 
-#: attrib/src/x_fileselect.c:304
 #, c-format
 msgid "Saved As [%1$s]"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:314
 #, c-format
 msgid "Could NOT save [%1$s]"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:70 attrib/src/x_gtksheet.c:79
 msgid "Components"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:71 attrib/src/x_gtksheet.c:88
-#: attrib/src/x_gtksheet.c:91
 msgid "Nets"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:72 attrib/src/x_gtksheet.c:104
-#: attrib/src/x_gtksheet.c:107
 msgid "Pins"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:81
 msgid ""
 "No components found in design.  Please check your schematic and try again!\n"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:92 attrib/src/x_gtksheet.c:94
 msgid "TBD"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:355
 msgid "couldn't allocate color"
 msgstr ""
 
-#: attrib/src/x_window.c:94
 msgid "lepton-attrib - Lepton EDA attribute editor"
 msgstr ""
 
-#: attrib/src/x_window.c:299
 #, c-format
 msgid ""
 "Error loading %1$s:\n"
 "%2$s\n"
 msgstr ""
 
-#: attrib/src/x_window.c:337
 msgid ""
 "No components found in entire design!\n"
 "Do you have refdeses on your components?"
 msgstr ""
 
-#: attrib/src/x_window.c:342
 msgid ""
 "No configurable component attributes found in entire design!\n"
 "Please attach at least some attributes before running lepton-attrib."
 msgstr ""
 
-#: attrib/src/x_window.c:347
 msgid ""
 "No pins found on any components!\n"
 "Please check your design."

--- a/attrib/po/de.po
+++ b/attrib/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-12 00:10+0300\n"
+"POT-Creation-Date: 2019-05-10 08:15+0300\n"
 "PO-Revision-Date: 2010-01-29 16:46+0000\n"
 "Last-Translator: Werner Hoch <werner.ho@gmx.de>\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -18,40 +18,32 @@ msgstr ""
 "X-Launchpad-Export-Date: 2010-02-14 12:56+0000\n"
 "X-Generator: Launchpad (build Unknown)\n"
 
-#: attrib/data/lepton-attrib.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Attribute Editor"
 msgstr "gEDA Attributeditor"
 
-#: attrib/data/lepton-attrib.desktop.in:4
 #, fuzzy
 msgid "Manipulate component attributes with lepton-attrib"
 msgstr "Editieren von Bauteilattributen mit gattrib"
 
-#: attrib/src/f_export.c:82
 #, c-format
 msgid "o_save: Could not open [%1$s]"
 msgstr ""
 
-#: attrib/src/lepton-attrib.c:160
 #, c-format
 msgid "Lepton EDA/lepton-attrib version %1$s%2$s.%3$s git: %4$.7s"
 msgstr ""
 
-#: attrib/src/lepton-attrib.c:196
 #, c-format
 msgid "Couldn't find file [%1$s]\n"
 msgstr ""
 
-#: attrib/src/gtksheet_2_2.c:6302
 msgid "Entry type must be GtkEntry subclass, using default"
 msgstr ""
 
-#: attrib/src/gtksheet_2_2.c:8499
 msgid "Widget must be a GtkSheet child"
 msgstr ""
 
-#: attrib/src/parsecmd.c:73
 #, c-format
 msgid ""
 "\n"
@@ -83,174 +75,143 @@ msgid ""
 "Please report bugs to %2$s.\n"
 msgstr ""
 
-#: attrib/src/s_attrib.c:101
 #, c-format
 msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 
-#: attrib/src/s_misc.c:81
 #, c-format
 msgid ""
 "\n"
 "DONE\n"
 msgstr ""
 
-#: attrib/src/s_misc.c:83
 #, c-format
 msgid " DONE\n"
 msgstr ""
 
-#: attrib/src/s_object.c:217
 #, c-format
 msgid ""
 "In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
 "on the component.  Exiting . . .\n"
 msgstr ""
 
-#: attrib/src/s_object.c:276
 #, c-format
 msgid ""
 "In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
 "on the component.  Exiting . . .\n"
 msgstr ""
 
-#: attrib/src/s_object.c:329
 #, c-format
 msgid ""
 "In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
 "or non-net!\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:116
 #, c-format
 msgid "- Starting master comp list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:184
 #, c-format
 msgid "- Starting master comp attrib list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:297
 #, c-format
 msgid "- Starting master pin list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:331
 #, c-format
 msgid ""
 "In s_sheet_data_add_master_pin_list_items, found component pin with no "
 "pinnumber.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:389
 #, c-format
 msgid "- Starting master pin attrib list creation.\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:123
 #, c-format
 msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:188
 #, c-format
 msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:252
 #, c-format
 msgid "In s_string_list_delete_item, couldn't delete item %s\n"
 msgstr ""
 
-#: attrib/src/s_table.c:242
 #, c-format
 msgid ""
 "In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
 msgstr ""
 
-#: attrib/src/s_table.c:285
 #, c-format
 msgid "- Starting internal component TABLE creation\n"
 msgstr ""
 
-#: attrib/src/s_table.c:344
 #, c-format
 msgid ""
 "In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
 "or col in the lists!\n"
 msgstr ""
 
-#: attrib/src/s_table.c:493
 #, c-format
 msgid "- Starting internal pin TABLE creation\n"
 msgstr ""
 
-#: attrib/src/s_table.c:553
 #, c-format
 msgid ""
 "In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
 "col in the lists!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:185
 msgid "_cancel"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:318
 #, c-format
 msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:554
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
 "the master list!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:582
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:891
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
 "missing!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:900
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
 "master list!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:928
 #, c-format
 msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:74
 msgid "Add new attribute"
 msgstr ""
 
-#: attrib/src/x_dialog.c:83
 msgid "Enter new attribute name"
 msgstr ""
 
-#: attrib/src/x_dialog.c:147
 msgid "Are you sure you want to delete this attribute?"
 msgstr ""
 
-#: attrib/src/x_dialog.c:149
 msgid "Delete attribute"
 msgstr ""
 
-#: attrib/src/x_dialog.c:174
 msgid ""
 "One or more components have been found with missing symbol files!\n"
 "\n"
@@ -261,31 +222,24 @@ msgid ""
 "\"Forward\" to continue working with lepton-attrib.\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:187
 msgid "Missing symbol file found for component!"
 msgstr ""
 
-#: attrib/src/x_dialog.c:214
 msgid "Save the changes before closing?"
 msgstr ""
 
-#: attrib/src/x_dialog.c:215
 msgid "<big><b>"
 msgstr ""
 
-#: attrib/src/x_dialog.c:215
 msgid "</b></big>"
 msgstr ""
 
-#: attrib/src/x_dialog.c:217
 msgid "If you don't save, all your changes will be permanently lost."
 msgstr ""
 
-#: attrib/src/x_dialog.c:227
 msgid "Close without saving"
 msgstr ""
 
-#: attrib/src/x_dialog.c:274
 msgid ""
 "Sorry -- you have chosen a feature which has not been\n"
 "implemented yet.\n"
@@ -299,15 +253,12 @@ msgid ""
 "Otherwise, just hang tight -- I'll implement this feature soon!\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:282
 msgid "Unimplemented feature!"
 msgstr ""
 
-#: attrib/src/x_dialog.c:309
 msgid "Fatal error"
 msgstr ""
 
-#: attrib/src/x_dialog.c:324
 #, c-format
 msgid ""
 "Lepton Electronic Design Automation\n"
@@ -321,110 +272,85 @@ msgid ""
 "and gtkextra, as well as support from the gEDA community."
 msgstr ""
 
-#: attrib/src/x_dialog.c:335
 msgid "About..."
 msgstr ""
 
-#: attrib/src/x_dialog.c:351
 msgid "Export CSV"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:87
 msgid "Schematics"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:92
 msgid "Symbols"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:97
 msgid "Schematics and symbols"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:103
 msgid "All files"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:134
 #, c-format
 msgid "Loading file [%1$s]"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:140
 #, c-format
 msgid "Couldn't load schematic [%1$s]\n"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:230
 msgid "Open..."
 msgstr ""
 
-#: attrib/src/x_fileselect.c:275
 msgid "Save as..."
 msgstr ""
 
-#: attrib/src/x_fileselect.c:304
 #, c-format
 msgid "Saved As [%1$s]"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:314
 #, c-format
 msgid "Could NOT save [%1$s]"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:70 attrib/src/x_gtksheet.c:79
 msgid "Components"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:71 attrib/src/x_gtksheet.c:88
-#: attrib/src/x_gtksheet.c:91
 msgid "Nets"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:72 attrib/src/x_gtksheet.c:104
-#: attrib/src/x_gtksheet.c:107
 msgid "Pins"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:81
 msgid ""
 "No components found in design.  Please check your schematic and try again!\n"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:92 attrib/src/x_gtksheet.c:94
 msgid "TBD"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:355
 msgid "couldn't allocate color"
 msgstr ""
 
-#: attrib/src/x_window.c:94
 #, fuzzy
 msgid "lepton-attrib - Lepton EDA attribute editor"
 msgstr "gEDA Attributeditor"
 
-#: attrib/src/x_window.c:299
 #, c-format
 msgid ""
 "Error loading %1$s:\n"
 "%2$s\n"
 msgstr ""
 
-#: attrib/src/x_window.c:337
 msgid ""
 "No components found in entire design!\n"
 "Do you have refdeses on your components?"
 msgstr ""
 
-#: attrib/src/x_window.c:342
 msgid ""
 "No configurable component attributes found in entire design!\n"
 "Please attach at least some attributes before running lepton-attrib."
 msgstr ""
 
-#: attrib/src/x_window.c:347
 msgid ""
 "No pins found on any components!\n"
 "Please check your design."

--- a/attrib/po/el.po
+++ b/attrib/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-12 00:10+0300\n"
+"POT-Creation-Date: 2019-05-10 08:15+0300\n"
 "PO-Revision-Date: 2012-09-01 18:26+0000\n"
 "Last-Translator: Panos Bouklis <panos@echidna-band.com>\n"
 "Language-Team: Greek <el@li.org>\n"
@@ -18,40 +18,32 @@ msgstr ""
 "X-Launchpad-Export-Date: 2012-11-14 16:52+0000\n"
 "X-Generator: Launchpad (build 16265)\n"
 
-#: attrib/data/lepton-attrib.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Attribute Editor"
 msgstr "Επεξεργαστής γνωρισμάτων gEDA"
 
-#: attrib/data/lepton-attrib.desktop.in:4
 #, fuzzy
 msgid "Manipulate component attributes with lepton-attrib"
 msgstr "Έλεγχος των γνωρισμάτων των στοιχείων με το gattrib"
 
-#: attrib/src/f_export.c:82
 #, c-format
 msgid "o_save: Could not open [%1$s]"
 msgstr ""
 
-#: attrib/src/lepton-attrib.c:160
 #, c-format
 msgid "Lepton EDA/lepton-attrib version %1$s%2$s.%3$s git: %4$.7s"
 msgstr ""
 
-#: attrib/src/lepton-attrib.c:196
 #, c-format
 msgid "Couldn't find file [%1$s]\n"
 msgstr ""
 
-#: attrib/src/gtksheet_2_2.c:6302
 msgid "Entry type must be GtkEntry subclass, using default"
 msgstr ""
 
-#: attrib/src/gtksheet_2_2.c:8499
 msgid "Widget must be a GtkSheet child"
 msgstr ""
 
-#: attrib/src/parsecmd.c:73
 #, c-format
 msgid ""
 "\n"
@@ -83,174 +75,143 @@ msgid ""
 "Please report bugs to %2$s.\n"
 msgstr ""
 
-#: attrib/src/s_attrib.c:101
 #, c-format
 msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 
-#: attrib/src/s_misc.c:81
 #, c-format
 msgid ""
 "\n"
 "DONE\n"
 msgstr ""
 
-#: attrib/src/s_misc.c:83
 #, c-format
 msgid " DONE\n"
 msgstr ""
 
-#: attrib/src/s_object.c:217
 #, c-format
 msgid ""
 "In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
 "on the component.  Exiting . . .\n"
 msgstr ""
 
-#: attrib/src/s_object.c:276
 #, c-format
 msgid ""
 "In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
 "on the component.  Exiting . . .\n"
 msgstr ""
 
-#: attrib/src/s_object.c:329
 #, c-format
 msgid ""
 "In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
 "or non-net!\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:116
 #, c-format
 msgid "- Starting master comp list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:184
 #, c-format
 msgid "- Starting master comp attrib list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:297
 #, c-format
 msgid "- Starting master pin list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:331
 #, c-format
 msgid ""
 "In s_sheet_data_add_master_pin_list_items, found component pin with no "
 "pinnumber.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:389
 #, c-format
 msgid "- Starting master pin attrib list creation.\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:123
 #, c-format
 msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:188
 #, c-format
 msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:252
 #, c-format
 msgid "In s_string_list_delete_item, couldn't delete item %s\n"
 msgstr ""
 
-#: attrib/src/s_table.c:242
 #, c-format
 msgid ""
 "In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
 msgstr ""
 
-#: attrib/src/s_table.c:285
 #, c-format
 msgid "- Starting internal component TABLE creation\n"
 msgstr ""
 
-#: attrib/src/s_table.c:344
 #, c-format
 msgid ""
 "In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
 "or col in the lists!\n"
 msgstr ""
 
-#: attrib/src/s_table.c:493
 #, c-format
 msgid "- Starting internal pin TABLE creation\n"
 msgstr ""
 
-#: attrib/src/s_table.c:553
 #, c-format
 msgid ""
 "In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
 "col in the lists!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:185
 msgid "_cancel"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:318
 #, c-format
 msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:554
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
 "the master list!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:582
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:891
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
 "missing!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:900
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
 "master list!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:928
 #, c-format
 msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:74
 msgid "Add new attribute"
 msgstr ""
 
-#: attrib/src/x_dialog.c:83
 msgid "Enter new attribute name"
 msgstr ""
 
-#: attrib/src/x_dialog.c:147
 msgid "Are you sure you want to delete this attribute?"
 msgstr ""
 
-#: attrib/src/x_dialog.c:149
 msgid "Delete attribute"
 msgstr ""
 
-#: attrib/src/x_dialog.c:174
 msgid ""
 "One or more components have been found with missing symbol files!\n"
 "\n"
@@ -261,31 +222,24 @@ msgid ""
 "\"Forward\" to continue working with lepton-attrib.\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:187
 msgid "Missing symbol file found for component!"
 msgstr ""
 
-#: attrib/src/x_dialog.c:214
 msgid "Save the changes before closing?"
 msgstr ""
 
-#: attrib/src/x_dialog.c:215
 msgid "<big><b>"
 msgstr ""
 
-#: attrib/src/x_dialog.c:215
 msgid "</b></big>"
 msgstr ""
 
-#: attrib/src/x_dialog.c:217
 msgid "If you don't save, all your changes will be permanently lost."
 msgstr ""
 
-#: attrib/src/x_dialog.c:227
 msgid "Close without saving"
 msgstr ""
 
-#: attrib/src/x_dialog.c:274
 msgid ""
 "Sorry -- you have chosen a feature which has not been\n"
 "implemented yet.\n"
@@ -299,15 +253,12 @@ msgid ""
 "Otherwise, just hang tight -- I'll implement this feature soon!\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:282
 msgid "Unimplemented feature!"
 msgstr ""
 
-#: attrib/src/x_dialog.c:309
 msgid "Fatal error"
 msgstr ""
 
-#: attrib/src/x_dialog.c:324
 #, c-format
 msgid ""
 "Lepton Electronic Design Automation\n"
@@ -321,110 +272,85 @@ msgid ""
 "and gtkextra, as well as support from the gEDA community."
 msgstr ""
 
-#: attrib/src/x_dialog.c:335
 msgid "About..."
 msgstr ""
 
-#: attrib/src/x_dialog.c:351
 msgid "Export CSV"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:87
 msgid "Schematics"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:92
 msgid "Symbols"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:97
 msgid "Schematics and symbols"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:103
 msgid "All files"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:134
 #, c-format
 msgid "Loading file [%1$s]"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:140
 #, c-format
 msgid "Couldn't load schematic [%1$s]\n"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:230
 msgid "Open..."
 msgstr ""
 
-#: attrib/src/x_fileselect.c:275
 msgid "Save as..."
 msgstr ""
 
-#: attrib/src/x_fileselect.c:304
 #, c-format
 msgid "Saved As [%1$s]"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:314
 #, c-format
 msgid "Could NOT save [%1$s]"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:70 attrib/src/x_gtksheet.c:79
 msgid "Components"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:71 attrib/src/x_gtksheet.c:88
-#: attrib/src/x_gtksheet.c:91
 msgid "Nets"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:72 attrib/src/x_gtksheet.c:104
-#: attrib/src/x_gtksheet.c:107
 msgid "Pins"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:81
 msgid ""
 "No components found in design.  Please check your schematic and try again!\n"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:92 attrib/src/x_gtksheet.c:94
 msgid "TBD"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:355
 msgid "couldn't allocate color"
 msgstr ""
 
-#: attrib/src/x_window.c:94
 #, fuzzy
 msgid "lepton-attrib - Lepton EDA attribute editor"
 msgstr "Επεξεργαστής γνωρισμάτων gEDA"
 
-#: attrib/src/x_window.c:299
 #, c-format
 msgid ""
 "Error loading %1$s:\n"
 "%2$s\n"
 msgstr ""
 
-#: attrib/src/x_window.c:337
 msgid ""
 "No components found in entire design!\n"
 "Do you have refdeses on your components?"
 msgstr ""
 
-#: attrib/src/x_window.c:342
 msgid ""
 "No configurable component attributes found in entire design!\n"
 "Please attach at least some attributes before running lepton-attrib."
 msgstr ""
 
-#: attrib/src/x_window.c:347
 msgid ""
 "No pins found on any components!\n"
 "Please check your design."

--- a/attrib/po/en_GB.po
+++ b/attrib/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-12 00:10+0300\n"
+"POT-Creation-Date: 2019-05-10 08:15+0300\n"
 "PO-Revision-Date: 2012-01-27 14:17+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: English (United Kingdom) <en_GB@li.org>\n"
@@ -18,40 +18,32 @@ msgstr ""
 "X-Launchpad-Export-Date: 2012-11-14 16:52+0000\n"
 "X-Generator: Launchpad (build 16265)\n"
 
-#: attrib/data/lepton-attrib.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Attribute Editor"
 msgstr "gEDA Attribute Editor"
 
-#: attrib/data/lepton-attrib.desktop.in:4
 #, fuzzy
 msgid "Manipulate component attributes with lepton-attrib"
 msgstr "Manipulate component attributes with gattrib"
 
-#: attrib/src/f_export.c:82
 #, c-format
 msgid "o_save: Could not open [%1$s]"
 msgstr ""
 
-#: attrib/src/lepton-attrib.c:160
 #, c-format
 msgid "Lepton EDA/lepton-attrib version %1$s%2$s.%3$s git: %4$.7s"
 msgstr ""
 
-#: attrib/src/lepton-attrib.c:196
 #, c-format
 msgid "Couldn't find file [%1$s]\n"
 msgstr ""
 
-#: attrib/src/gtksheet_2_2.c:6302
 msgid "Entry type must be GtkEntry subclass, using default"
 msgstr ""
 
-#: attrib/src/gtksheet_2_2.c:8499
 msgid "Widget must be a GtkSheet child"
 msgstr ""
 
-#: attrib/src/parsecmd.c:73
 #, c-format
 msgid ""
 "\n"
@@ -83,174 +75,143 @@ msgid ""
 "Please report bugs to %2$s.\n"
 msgstr ""
 
-#: attrib/src/s_attrib.c:101
 #, c-format
 msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 
-#: attrib/src/s_misc.c:81
 #, c-format
 msgid ""
 "\n"
 "DONE\n"
 msgstr ""
 
-#: attrib/src/s_misc.c:83
 #, c-format
 msgid " DONE\n"
 msgstr ""
 
-#: attrib/src/s_object.c:217
 #, c-format
 msgid ""
 "In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
 "on the component.  Exiting . . .\n"
 msgstr ""
 
-#: attrib/src/s_object.c:276
 #, c-format
 msgid ""
 "In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
 "on the component.  Exiting . . .\n"
 msgstr ""
 
-#: attrib/src/s_object.c:329
 #, c-format
 msgid ""
 "In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
 "or non-net!\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:116
 #, c-format
 msgid "- Starting master comp list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:184
 #, c-format
 msgid "- Starting master comp attrib list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:297
 #, c-format
 msgid "- Starting master pin list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:331
 #, c-format
 msgid ""
 "In s_sheet_data_add_master_pin_list_items, found component pin with no "
 "pinnumber.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:389
 #, c-format
 msgid "- Starting master pin attrib list creation.\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:123
 #, c-format
 msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:188
 #, c-format
 msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:252
 #, c-format
 msgid "In s_string_list_delete_item, couldn't delete item %s\n"
 msgstr ""
 
-#: attrib/src/s_table.c:242
 #, c-format
 msgid ""
 "In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
 msgstr ""
 
-#: attrib/src/s_table.c:285
 #, c-format
 msgid "- Starting internal component TABLE creation\n"
 msgstr ""
 
-#: attrib/src/s_table.c:344
 #, c-format
 msgid ""
 "In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
 "or col in the lists!\n"
 msgstr ""
 
-#: attrib/src/s_table.c:493
 #, c-format
 msgid "- Starting internal pin TABLE creation\n"
 msgstr ""
 
-#: attrib/src/s_table.c:553
 #, c-format
 msgid ""
 "In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
 "col in the lists!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:185
 msgid "_cancel"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:318
 #, c-format
 msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:554
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
 "the master list!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:582
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:891
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
 "missing!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:900
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
 "master list!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:928
 #, c-format
 msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:74
 msgid "Add new attribute"
 msgstr ""
 
-#: attrib/src/x_dialog.c:83
 msgid "Enter new attribute name"
 msgstr ""
 
-#: attrib/src/x_dialog.c:147
 msgid "Are you sure you want to delete this attribute?"
 msgstr ""
 
-#: attrib/src/x_dialog.c:149
 msgid "Delete attribute"
 msgstr ""
 
-#: attrib/src/x_dialog.c:174
 msgid ""
 "One or more components have been found with missing symbol files!\n"
 "\n"
@@ -261,31 +222,24 @@ msgid ""
 "\"Forward\" to continue working with lepton-attrib.\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:187
 msgid "Missing symbol file found for component!"
 msgstr ""
 
-#: attrib/src/x_dialog.c:214
 msgid "Save the changes before closing?"
 msgstr ""
 
-#: attrib/src/x_dialog.c:215
 msgid "<big><b>"
 msgstr ""
 
-#: attrib/src/x_dialog.c:215
 msgid "</b></big>"
 msgstr ""
 
-#: attrib/src/x_dialog.c:217
 msgid "If you don't save, all your changes will be permanently lost."
 msgstr ""
 
-#: attrib/src/x_dialog.c:227
 msgid "Close without saving"
 msgstr ""
 
-#: attrib/src/x_dialog.c:274
 msgid ""
 "Sorry -- you have chosen a feature which has not been\n"
 "implemented yet.\n"
@@ -299,15 +253,12 @@ msgid ""
 "Otherwise, just hang tight -- I'll implement this feature soon!\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:282
 msgid "Unimplemented feature!"
 msgstr ""
 
-#: attrib/src/x_dialog.c:309
 msgid "Fatal error"
 msgstr ""
 
-#: attrib/src/x_dialog.c:324
 #, c-format
 msgid ""
 "Lepton Electronic Design Automation\n"
@@ -321,110 +272,85 @@ msgid ""
 "and gtkextra, as well as support from the gEDA community."
 msgstr ""
 
-#: attrib/src/x_dialog.c:335
 msgid "About..."
 msgstr ""
 
-#: attrib/src/x_dialog.c:351
 msgid "Export CSV"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:87
 msgid "Schematics"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:92
 msgid "Symbols"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:97
 msgid "Schematics and symbols"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:103
 msgid "All files"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:134
 #, c-format
 msgid "Loading file [%1$s]"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:140
 #, c-format
 msgid "Couldn't load schematic [%1$s]\n"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:230
 msgid "Open..."
 msgstr ""
 
-#: attrib/src/x_fileselect.c:275
 msgid "Save as..."
 msgstr ""
 
-#: attrib/src/x_fileselect.c:304
 #, c-format
 msgid "Saved As [%1$s]"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:314
 #, c-format
 msgid "Could NOT save [%1$s]"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:70 attrib/src/x_gtksheet.c:79
 msgid "Components"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:71 attrib/src/x_gtksheet.c:88
-#: attrib/src/x_gtksheet.c:91
 msgid "Nets"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:72 attrib/src/x_gtksheet.c:104
-#: attrib/src/x_gtksheet.c:107
 msgid "Pins"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:81
 msgid ""
 "No components found in design.  Please check your schematic and try again!\n"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:92 attrib/src/x_gtksheet.c:94
 msgid "TBD"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:355
 msgid "couldn't allocate color"
 msgstr ""
 
-#: attrib/src/x_window.c:94
 #, fuzzy
 msgid "lepton-attrib - Lepton EDA attribute editor"
 msgstr "gEDA Attribute Editor"
 
-#: attrib/src/x_window.c:299
 #, c-format
 msgid ""
 "Error loading %1$s:\n"
 "%2$s\n"
 msgstr ""
 
-#: attrib/src/x_window.c:337
 msgid ""
 "No components found in entire design!\n"
 "Do you have refdeses on your components?"
 msgstr ""
 
-#: attrib/src/x_window.c:342
 msgid ""
 "No configurable component attributes found in entire design!\n"
 "Please attach at least some attributes before running lepton-attrib."
 msgstr ""
 
-#: attrib/src/x_window.c:347
 msgid ""
 "No pins found on any components!\n"
 "Please check your design."

--- a/attrib/po/es.po
+++ b/attrib/po/es.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-12 00:10+0300\n"
+"POT-Creation-Date: 2019-05-10 08:15+0300\n"
 "PO-Revision-Date: 2010-01-29 16:49+0000\n"
 "Last-Translator: Carlos Nieves Ónega <Unknown>\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -20,40 +20,32 @@ msgstr ""
 "X-Launchpad-Export-Date: 2010-02-14 12:56+0000\n"
 "X-Generator: Launchpad (build Unknown)\n"
 
-#: attrib/data/lepton-attrib.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Attribute Editor"
 msgstr "Editor de Propiedades de gEDA"
 
-#: attrib/data/lepton-attrib.desktop.in:4
 #, fuzzy
 msgid "Manipulate component attributes with lepton-attrib"
 msgstr "Manejar propiedades de componentes con gattrib"
 
-#: attrib/src/f_export.c:82
 #, c-format
 msgid "o_save: Could not open [%1$s]"
 msgstr ""
 
-#: attrib/src/lepton-attrib.c:160
 #, c-format
 msgid "Lepton EDA/lepton-attrib version %1$s%2$s.%3$s git: %4$.7s"
 msgstr ""
 
-#: attrib/src/lepton-attrib.c:196
 #, c-format
 msgid "Couldn't find file [%1$s]\n"
 msgstr ""
 
-#: attrib/src/gtksheet_2_2.c:6302
 msgid "Entry type must be GtkEntry subclass, using default"
 msgstr ""
 
-#: attrib/src/gtksheet_2_2.c:8499
 msgid "Widget must be a GtkSheet child"
 msgstr ""
 
-#: attrib/src/parsecmd.c:73
 #, c-format
 msgid ""
 "\n"
@@ -85,174 +77,143 @@ msgid ""
 "Please report bugs to %2$s.\n"
 msgstr ""
 
-#: attrib/src/s_attrib.c:101
 #, c-format
 msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 
-#: attrib/src/s_misc.c:81
 #, c-format
 msgid ""
 "\n"
 "DONE\n"
 msgstr ""
 
-#: attrib/src/s_misc.c:83
 #, c-format
 msgid " DONE\n"
 msgstr ""
 
-#: attrib/src/s_object.c:217
 #, c-format
 msgid ""
 "In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
 "on the component.  Exiting . . .\n"
 msgstr ""
 
-#: attrib/src/s_object.c:276
 #, c-format
 msgid ""
 "In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
 "on the component.  Exiting . . .\n"
 msgstr ""
 
-#: attrib/src/s_object.c:329
 #, c-format
 msgid ""
 "In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
 "or non-net!\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:116
 #, c-format
 msgid "- Starting master comp list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:184
 #, c-format
 msgid "- Starting master comp attrib list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:297
 #, c-format
 msgid "- Starting master pin list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:331
 #, c-format
 msgid ""
 "In s_sheet_data_add_master_pin_list_items, found component pin with no "
 "pinnumber.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:389
 #, c-format
 msgid "- Starting master pin attrib list creation.\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:123
 #, c-format
 msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:188
 #, c-format
 msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:252
 #, c-format
 msgid "In s_string_list_delete_item, couldn't delete item %s\n"
 msgstr ""
 
-#: attrib/src/s_table.c:242
 #, c-format
 msgid ""
 "In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
 msgstr ""
 
-#: attrib/src/s_table.c:285
 #, c-format
 msgid "- Starting internal component TABLE creation\n"
 msgstr ""
 
-#: attrib/src/s_table.c:344
 #, c-format
 msgid ""
 "In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
 "or col in the lists!\n"
 msgstr ""
 
-#: attrib/src/s_table.c:493
 #, c-format
 msgid "- Starting internal pin TABLE creation\n"
 msgstr ""
 
-#: attrib/src/s_table.c:553
 #, c-format
 msgid ""
 "In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
 "col in the lists!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:185
 msgid "_cancel"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:318
 #, c-format
 msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:554
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
 "the master list!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:582
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:891
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
 "missing!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:900
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
 "master list!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:928
 #, c-format
 msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:74
 msgid "Add new attribute"
 msgstr ""
 
-#: attrib/src/x_dialog.c:83
 msgid "Enter new attribute name"
 msgstr ""
 
-#: attrib/src/x_dialog.c:147
 msgid "Are you sure you want to delete this attribute?"
 msgstr ""
 
-#: attrib/src/x_dialog.c:149
 msgid "Delete attribute"
 msgstr ""
 
-#: attrib/src/x_dialog.c:174
 msgid ""
 "One or more components have been found with missing symbol files!\n"
 "\n"
@@ -263,31 +224,24 @@ msgid ""
 "\"Forward\" to continue working with lepton-attrib.\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:187
 msgid "Missing symbol file found for component!"
 msgstr ""
 
-#: attrib/src/x_dialog.c:214
 msgid "Save the changes before closing?"
 msgstr ""
 
-#: attrib/src/x_dialog.c:215
 msgid "<big><b>"
 msgstr ""
 
-#: attrib/src/x_dialog.c:215
 msgid "</b></big>"
 msgstr ""
 
-#: attrib/src/x_dialog.c:217
 msgid "If you don't save, all your changes will be permanently lost."
 msgstr ""
 
-#: attrib/src/x_dialog.c:227
 msgid "Close without saving"
 msgstr ""
 
-#: attrib/src/x_dialog.c:274
 msgid ""
 "Sorry -- you have chosen a feature which has not been\n"
 "implemented yet.\n"
@@ -301,15 +255,12 @@ msgid ""
 "Otherwise, just hang tight -- I'll implement this feature soon!\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:282
 msgid "Unimplemented feature!"
 msgstr ""
 
-#: attrib/src/x_dialog.c:309
 msgid "Fatal error"
 msgstr ""
 
-#: attrib/src/x_dialog.c:324
 #, c-format
 msgid ""
 "Lepton Electronic Design Automation\n"
@@ -323,110 +274,85 @@ msgid ""
 "and gtkextra, as well as support from the gEDA community."
 msgstr ""
 
-#: attrib/src/x_dialog.c:335
 msgid "About..."
 msgstr ""
 
-#: attrib/src/x_dialog.c:351
 msgid "Export CSV"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:87
 msgid "Schematics"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:92
 msgid "Symbols"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:97
 msgid "Schematics and symbols"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:103
 msgid "All files"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:134
 #, c-format
 msgid "Loading file [%1$s]"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:140
 #, c-format
 msgid "Couldn't load schematic [%1$s]\n"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:230
 msgid "Open..."
 msgstr ""
 
-#: attrib/src/x_fileselect.c:275
 msgid "Save as..."
 msgstr ""
 
-#: attrib/src/x_fileselect.c:304
 #, c-format
 msgid "Saved As [%1$s]"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:314
 #, c-format
 msgid "Could NOT save [%1$s]"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:70 attrib/src/x_gtksheet.c:79
 msgid "Components"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:71 attrib/src/x_gtksheet.c:88
-#: attrib/src/x_gtksheet.c:91
 msgid "Nets"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:72 attrib/src/x_gtksheet.c:104
-#: attrib/src/x_gtksheet.c:107
 msgid "Pins"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:81
 msgid ""
 "No components found in design.  Please check your schematic and try again!\n"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:92 attrib/src/x_gtksheet.c:94
 msgid "TBD"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:355
 msgid "couldn't allocate color"
 msgstr ""
 
-#: attrib/src/x_window.c:94
 #, fuzzy
 msgid "lepton-attrib - Lepton EDA attribute editor"
 msgstr "Editor de Propiedades de gEDA"
 
-#: attrib/src/x_window.c:299
 #, c-format
 msgid ""
 "Error loading %1$s:\n"
 "%2$s\n"
 msgstr ""
 
-#: attrib/src/x_window.c:337
 msgid ""
 "No components found in entire design!\n"
 "Do you have refdeses on your components?"
 msgstr ""
 
-#: attrib/src/x_window.c:342
 msgid ""
 "No configurable component attributes found in entire design!\n"
 "Please attach at least some attributes before running lepton-attrib."
 msgstr ""
 
-#: attrib/src/x_window.c:347
 msgid ""
 "No pins found on any components!\n"
 "Please check your design."

--- a/attrib/po/fa.po
+++ b/attrib/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-12 00:10+0300\n"
+"POT-Creation-Date: 2019-05-10 08:15+0300\n"
 "PO-Revision-Date: 2012-01-27 14:17+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: Persian <fa@li.org>\n"
@@ -18,40 +18,32 @@ msgstr ""
 "X-Launchpad-Export-Date: 2012-11-14 16:52+0000\n"
 "X-Generator: Launchpad (build 16265)\n"
 
-#: attrib/data/lepton-attrib.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Attribute Editor"
 msgstr "gEDA Attribute Editor"
 
-#: attrib/data/lepton-attrib.desktop.in:4
 #, fuzzy
 msgid "Manipulate component attributes with lepton-attrib"
 msgstr "Manipulate component attributes with gattrib"
 
-#: attrib/src/f_export.c:82
 #, c-format
 msgid "o_save: Could not open [%1$s]"
 msgstr ""
 
-#: attrib/src/lepton-attrib.c:160
 #, c-format
 msgid "Lepton EDA/lepton-attrib version %1$s%2$s.%3$s git: %4$.7s"
 msgstr ""
 
-#: attrib/src/lepton-attrib.c:196
 #, c-format
 msgid "Couldn't find file [%1$s]\n"
 msgstr ""
 
-#: attrib/src/gtksheet_2_2.c:6302
 msgid "Entry type must be GtkEntry subclass, using default"
 msgstr ""
 
-#: attrib/src/gtksheet_2_2.c:8499
 msgid "Widget must be a GtkSheet child"
 msgstr ""
 
-#: attrib/src/parsecmd.c:73
 #, c-format
 msgid ""
 "\n"
@@ -83,174 +75,143 @@ msgid ""
 "Please report bugs to %2$s.\n"
 msgstr ""
 
-#: attrib/src/s_attrib.c:101
 #, c-format
 msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 
-#: attrib/src/s_misc.c:81
 #, c-format
 msgid ""
 "\n"
 "DONE\n"
 msgstr ""
 
-#: attrib/src/s_misc.c:83
 #, c-format
 msgid " DONE\n"
 msgstr ""
 
-#: attrib/src/s_object.c:217
 #, c-format
 msgid ""
 "In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
 "on the component.  Exiting . . .\n"
 msgstr ""
 
-#: attrib/src/s_object.c:276
 #, c-format
 msgid ""
 "In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
 "on the component.  Exiting . . .\n"
 msgstr ""
 
-#: attrib/src/s_object.c:329
 #, c-format
 msgid ""
 "In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
 "or non-net!\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:116
 #, c-format
 msgid "- Starting master comp list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:184
 #, c-format
 msgid "- Starting master comp attrib list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:297
 #, c-format
 msgid "- Starting master pin list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:331
 #, c-format
 msgid ""
 "In s_sheet_data_add_master_pin_list_items, found component pin with no "
 "pinnumber.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:389
 #, c-format
 msgid "- Starting master pin attrib list creation.\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:123
 #, c-format
 msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:188
 #, c-format
 msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:252
 #, c-format
 msgid "In s_string_list_delete_item, couldn't delete item %s\n"
 msgstr ""
 
-#: attrib/src/s_table.c:242
 #, c-format
 msgid ""
 "In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
 msgstr ""
 
-#: attrib/src/s_table.c:285
 #, c-format
 msgid "- Starting internal component TABLE creation\n"
 msgstr ""
 
-#: attrib/src/s_table.c:344
 #, c-format
 msgid ""
 "In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
 "or col in the lists!\n"
 msgstr ""
 
-#: attrib/src/s_table.c:493
 #, c-format
 msgid "- Starting internal pin TABLE creation\n"
 msgstr ""
 
-#: attrib/src/s_table.c:553
 #, c-format
 msgid ""
 "In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
 "col in the lists!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:185
 msgid "_cancel"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:318
 #, c-format
 msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:554
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
 "the master list!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:582
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:891
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
 "missing!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:900
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
 "master list!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:928
 #, c-format
 msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:74
 msgid "Add new attribute"
 msgstr ""
 
-#: attrib/src/x_dialog.c:83
 msgid "Enter new attribute name"
 msgstr ""
 
-#: attrib/src/x_dialog.c:147
 msgid "Are you sure you want to delete this attribute?"
 msgstr ""
 
-#: attrib/src/x_dialog.c:149
 msgid "Delete attribute"
 msgstr ""
 
-#: attrib/src/x_dialog.c:174
 msgid ""
 "One or more components have been found with missing symbol files!\n"
 "\n"
@@ -261,31 +222,24 @@ msgid ""
 "\"Forward\" to continue working with lepton-attrib.\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:187
 msgid "Missing symbol file found for component!"
 msgstr ""
 
-#: attrib/src/x_dialog.c:214
 msgid "Save the changes before closing?"
 msgstr ""
 
-#: attrib/src/x_dialog.c:215
 msgid "<big><b>"
 msgstr ""
 
-#: attrib/src/x_dialog.c:215
 msgid "</b></big>"
 msgstr ""
 
-#: attrib/src/x_dialog.c:217
 msgid "If you don't save, all your changes will be permanently lost."
 msgstr ""
 
-#: attrib/src/x_dialog.c:227
 msgid "Close without saving"
 msgstr ""
 
-#: attrib/src/x_dialog.c:274
 msgid ""
 "Sorry -- you have chosen a feature which has not been\n"
 "implemented yet.\n"
@@ -299,15 +253,12 @@ msgid ""
 "Otherwise, just hang tight -- I'll implement this feature soon!\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:282
 msgid "Unimplemented feature!"
 msgstr ""
 
-#: attrib/src/x_dialog.c:309
 msgid "Fatal error"
 msgstr ""
 
-#: attrib/src/x_dialog.c:324
 #, c-format
 msgid ""
 "Lepton Electronic Design Automation\n"
@@ -321,110 +272,85 @@ msgid ""
 "and gtkextra, as well as support from the gEDA community."
 msgstr ""
 
-#: attrib/src/x_dialog.c:335
 msgid "About..."
 msgstr ""
 
-#: attrib/src/x_dialog.c:351
 msgid "Export CSV"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:87
 msgid "Schematics"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:92
 msgid "Symbols"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:97
 msgid "Schematics and symbols"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:103
 msgid "All files"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:134
 #, c-format
 msgid "Loading file [%1$s]"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:140
 #, c-format
 msgid "Couldn't load schematic [%1$s]\n"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:230
 msgid "Open..."
 msgstr ""
 
-#: attrib/src/x_fileselect.c:275
 msgid "Save as..."
 msgstr ""
 
-#: attrib/src/x_fileselect.c:304
 #, c-format
 msgid "Saved As [%1$s]"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:314
 #, c-format
 msgid "Could NOT save [%1$s]"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:70 attrib/src/x_gtksheet.c:79
 msgid "Components"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:71 attrib/src/x_gtksheet.c:88
-#: attrib/src/x_gtksheet.c:91
 msgid "Nets"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:72 attrib/src/x_gtksheet.c:104
-#: attrib/src/x_gtksheet.c:107
 msgid "Pins"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:81
 msgid ""
 "No components found in design.  Please check your schematic and try again!\n"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:92 attrib/src/x_gtksheet.c:94
 msgid "TBD"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:355
 msgid "couldn't allocate color"
 msgstr ""
 
-#: attrib/src/x_window.c:94
 #, fuzzy
 msgid "lepton-attrib - Lepton EDA attribute editor"
 msgstr "gEDA Attribute Editor"
 
-#: attrib/src/x_window.c:299
 #, c-format
 msgid ""
 "Error loading %1$s:\n"
 "%2$s\n"
 msgstr ""
 
-#: attrib/src/x_window.c:337
 msgid ""
 "No components found in entire design!\n"
 "Do you have refdeses on your components?"
 msgstr ""
 
-#: attrib/src/x_window.c:342
 msgid ""
 "No configurable component attributes found in entire design!\n"
 "Please attach at least some attributes before running lepton-attrib."
 msgstr ""
 
-#: attrib/src/x_window.c:347
 msgid ""
 "No pins found on any components!\n"
 "Please check your design."

--- a/attrib/po/fr.po
+++ b/attrib/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-12 00:10+0300\n"
+"POT-Creation-Date: 2019-05-10 08:15+0300\n"
 "PO-Revision-Date: 2010-02-06 22:09+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -18,40 +18,32 @@ msgstr ""
 "X-Launchpad-Export-Date: 2010-02-14 12:56+0000\n"
 "X-Generator: Launchpad (build Unknown)\n"
 
-#: attrib/data/lepton-attrib.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Attribute Editor"
 msgstr "Éditeur d'attributs gEDA"
 
-#: attrib/data/lepton-attrib.desktop.in:4
 #, fuzzy
 msgid "Manipulate component attributes with lepton-attrib"
 msgstr "Manipuler les attributs des composants avec gattrib"
 
-#: attrib/src/f_export.c:82
 #, c-format
 msgid "o_save: Could not open [%1$s]"
 msgstr ""
 
-#: attrib/src/lepton-attrib.c:160
 #, c-format
 msgid "Lepton EDA/lepton-attrib version %1$s%2$s.%3$s git: %4$.7s"
 msgstr ""
 
-#: attrib/src/lepton-attrib.c:196
 #, c-format
 msgid "Couldn't find file [%1$s]\n"
 msgstr ""
 
-#: attrib/src/gtksheet_2_2.c:6302
 msgid "Entry type must be GtkEntry subclass, using default"
 msgstr ""
 
-#: attrib/src/gtksheet_2_2.c:8499
 msgid "Widget must be a GtkSheet child"
 msgstr ""
 
-#: attrib/src/parsecmd.c:73
 #, c-format
 msgid ""
 "\n"
@@ -83,174 +75,143 @@ msgid ""
 "Please report bugs to %2$s.\n"
 msgstr ""
 
-#: attrib/src/s_attrib.c:101
 #, c-format
 msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 
-#: attrib/src/s_misc.c:81
 #, c-format
 msgid ""
 "\n"
 "DONE\n"
 msgstr ""
 
-#: attrib/src/s_misc.c:83
 #, c-format
 msgid " DONE\n"
 msgstr ""
 
-#: attrib/src/s_object.c:217
 #, c-format
 msgid ""
 "In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
 "on the component.  Exiting . . .\n"
 msgstr ""
 
-#: attrib/src/s_object.c:276
 #, c-format
 msgid ""
 "In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
 "on the component.  Exiting . . .\n"
 msgstr ""
 
-#: attrib/src/s_object.c:329
 #, c-format
 msgid ""
 "In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
 "or non-net!\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:116
 #, c-format
 msgid "- Starting master comp list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:184
 #, c-format
 msgid "- Starting master comp attrib list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:297
 #, c-format
 msgid "- Starting master pin list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:331
 #, c-format
 msgid ""
 "In s_sheet_data_add_master_pin_list_items, found component pin with no "
 "pinnumber.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:389
 #, c-format
 msgid "- Starting master pin attrib list creation.\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:123
 #, c-format
 msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:188
 #, c-format
 msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:252
 #, c-format
 msgid "In s_string_list_delete_item, couldn't delete item %s\n"
 msgstr ""
 
-#: attrib/src/s_table.c:242
 #, c-format
 msgid ""
 "In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
 msgstr ""
 
-#: attrib/src/s_table.c:285
 #, c-format
 msgid "- Starting internal component TABLE creation\n"
 msgstr ""
 
-#: attrib/src/s_table.c:344
 #, c-format
 msgid ""
 "In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
 "or col in the lists!\n"
 msgstr ""
 
-#: attrib/src/s_table.c:493
 #, c-format
 msgid "- Starting internal pin TABLE creation\n"
 msgstr ""
 
-#: attrib/src/s_table.c:553
 #, c-format
 msgid ""
 "In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
 "col in the lists!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:185
 msgid "_cancel"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:318
 #, c-format
 msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:554
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
 "the master list!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:582
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:891
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
 "missing!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:900
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
 "master list!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:928
 #, c-format
 msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:74
 msgid "Add new attribute"
 msgstr ""
 
-#: attrib/src/x_dialog.c:83
 msgid "Enter new attribute name"
 msgstr ""
 
-#: attrib/src/x_dialog.c:147
 msgid "Are you sure you want to delete this attribute?"
 msgstr ""
 
-#: attrib/src/x_dialog.c:149
 msgid "Delete attribute"
 msgstr ""
 
-#: attrib/src/x_dialog.c:174
 msgid ""
 "One or more components have been found with missing symbol files!\n"
 "\n"
@@ -261,31 +222,24 @@ msgid ""
 "\"Forward\" to continue working with lepton-attrib.\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:187
 msgid "Missing symbol file found for component!"
 msgstr ""
 
-#: attrib/src/x_dialog.c:214
 msgid "Save the changes before closing?"
 msgstr ""
 
-#: attrib/src/x_dialog.c:215
 msgid "<big><b>"
 msgstr ""
 
-#: attrib/src/x_dialog.c:215
 msgid "</b></big>"
 msgstr ""
 
-#: attrib/src/x_dialog.c:217
 msgid "If you don't save, all your changes will be permanently lost."
 msgstr ""
 
-#: attrib/src/x_dialog.c:227
 msgid "Close without saving"
 msgstr ""
 
-#: attrib/src/x_dialog.c:274
 msgid ""
 "Sorry -- you have chosen a feature which has not been\n"
 "implemented yet.\n"
@@ -299,15 +253,12 @@ msgid ""
 "Otherwise, just hang tight -- I'll implement this feature soon!\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:282
 msgid "Unimplemented feature!"
 msgstr ""
 
-#: attrib/src/x_dialog.c:309
 msgid "Fatal error"
 msgstr ""
 
-#: attrib/src/x_dialog.c:324
 #, c-format
 msgid ""
 "Lepton Electronic Design Automation\n"
@@ -321,110 +272,85 @@ msgid ""
 "and gtkextra, as well as support from the gEDA community."
 msgstr ""
 
-#: attrib/src/x_dialog.c:335
 msgid "About..."
 msgstr ""
 
-#: attrib/src/x_dialog.c:351
 msgid "Export CSV"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:87
 msgid "Schematics"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:92
 msgid "Symbols"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:97
 msgid "Schematics and symbols"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:103
 msgid "All files"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:134
 #, c-format
 msgid "Loading file [%1$s]"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:140
 #, c-format
 msgid "Couldn't load schematic [%1$s]\n"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:230
 msgid "Open..."
 msgstr ""
 
-#: attrib/src/x_fileselect.c:275
 msgid "Save as..."
 msgstr ""
 
-#: attrib/src/x_fileselect.c:304
 #, c-format
 msgid "Saved As [%1$s]"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:314
 #, c-format
 msgid "Could NOT save [%1$s]"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:70 attrib/src/x_gtksheet.c:79
 msgid "Components"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:71 attrib/src/x_gtksheet.c:88
-#: attrib/src/x_gtksheet.c:91
 msgid "Nets"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:72 attrib/src/x_gtksheet.c:104
-#: attrib/src/x_gtksheet.c:107
 msgid "Pins"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:81
 msgid ""
 "No components found in design.  Please check your schematic and try again!\n"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:92 attrib/src/x_gtksheet.c:94
 msgid "TBD"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:355
 msgid "couldn't allocate color"
 msgstr ""
 
-#: attrib/src/x_window.c:94
 #, fuzzy
 msgid "lepton-attrib - Lepton EDA attribute editor"
 msgstr "Éditeur d'attributs gEDA"
 
-#: attrib/src/x_window.c:299
 #, c-format
 msgid ""
 "Error loading %1$s:\n"
 "%2$s\n"
 msgstr ""
 
-#: attrib/src/x_window.c:337
 msgid ""
 "No components found in entire design!\n"
 "Do you have refdeses on your components?"
 msgstr ""
 
-#: attrib/src/x_window.c:342
 msgid ""
 "No configurable component attributes found in entire design!\n"
 "Please attach at least some attributes before running lepton-attrib."
 msgstr ""
 
-#: attrib/src/x_window.c:347
 msgid ""
 "No pins found on any components!\n"
 "Please check your design."

--- a/attrib/po/gl.po
+++ b/attrib/po/gl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-12 00:10+0300\n"
+"POT-Creation-Date: 2019-05-10 08:15+0300\n"
 "PO-Revision-Date: 2012-03-21 00:09+0000\n"
 "Last-Translator: ghas <Unknown>\n"
 "Language-Team: Galician <gl@li.org>\n"
@@ -18,40 +18,32 @@ msgstr ""
 "X-Launchpad-Export-Date: 2012-11-14 16:52+0000\n"
 "X-Generator: Launchpad (build 16265)\n"
 
-#: attrib/data/lepton-attrib.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Attribute Editor"
 msgstr "Editor de atributos gEDA"
 
-#: attrib/data/lepton-attrib.desktop.in:4
 #, fuzzy
 msgid "Manipulate component attributes with lepton-attrib"
 msgstr "Manipular atributos de compoñentes con gattrib"
 
-#: attrib/src/f_export.c:82
 #, c-format
 msgid "o_save: Could not open [%1$s]"
 msgstr ""
 
-#: attrib/src/lepton-attrib.c:160
 #, c-format
 msgid "Lepton EDA/lepton-attrib version %1$s%2$s.%3$s git: %4$.7s"
 msgstr ""
 
-#: attrib/src/lepton-attrib.c:196
 #, c-format
 msgid "Couldn't find file [%1$s]\n"
 msgstr ""
 
-#: attrib/src/gtksheet_2_2.c:6302
 msgid "Entry type must be GtkEntry subclass, using default"
 msgstr ""
 
-#: attrib/src/gtksheet_2_2.c:8499
 msgid "Widget must be a GtkSheet child"
 msgstr ""
 
-#: attrib/src/parsecmd.c:73
 #, c-format
 msgid ""
 "\n"
@@ -83,174 +75,143 @@ msgid ""
 "Please report bugs to %2$s.\n"
 msgstr ""
 
-#: attrib/src/s_attrib.c:101
 #, c-format
 msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 
-#: attrib/src/s_misc.c:81
 #, c-format
 msgid ""
 "\n"
 "DONE\n"
 msgstr ""
 
-#: attrib/src/s_misc.c:83
 #, c-format
 msgid " DONE\n"
 msgstr ""
 
-#: attrib/src/s_object.c:217
 #, c-format
 msgid ""
 "In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
 "on the component.  Exiting . . .\n"
 msgstr ""
 
-#: attrib/src/s_object.c:276
 #, c-format
 msgid ""
 "In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
 "on the component.  Exiting . . .\n"
 msgstr ""
 
-#: attrib/src/s_object.c:329
 #, c-format
 msgid ""
 "In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
 "or non-net!\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:116
 #, c-format
 msgid "- Starting master comp list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:184
 #, c-format
 msgid "- Starting master comp attrib list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:297
 #, c-format
 msgid "- Starting master pin list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:331
 #, c-format
 msgid ""
 "In s_sheet_data_add_master_pin_list_items, found component pin with no "
 "pinnumber.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:389
 #, c-format
 msgid "- Starting master pin attrib list creation.\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:123
 #, c-format
 msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:188
 #, c-format
 msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:252
 #, c-format
 msgid "In s_string_list_delete_item, couldn't delete item %s\n"
 msgstr ""
 
-#: attrib/src/s_table.c:242
 #, c-format
 msgid ""
 "In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
 msgstr ""
 
-#: attrib/src/s_table.c:285
 #, c-format
 msgid "- Starting internal component TABLE creation\n"
 msgstr ""
 
-#: attrib/src/s_table.c:344
 #, c-format
 msgid ""
 "In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
 "or col in the lists!\n"
 msgstr ""
 
-#: attrib/src/s_table.c:493
 #, c-format
 msgid "- Starting internal pin TABLE creation\n"
 msgstr ""
 
-#: attrib/src/s_table.c:553
 #, c-format
 msgid ""
 "In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
 "col in the lists!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:185
 msgid "_cancel"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:318
 #, c-format
 msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:554
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
 "the master list!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:582
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:891
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
 "missing!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:900
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
 "master list!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:928
 #, c-format
 msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:74
 msgid "Add new attribute"
 msgstr ""
 
-#: attrib/src/x_dialog.c:83
 msgid "Enter new attribute name"
 msgstr ""
 
-#: attrib/src/x_dialog.c:147
 msgid "Are you sure you want to delete this attribute?"
 msgstr ""
 
-#: attrib/src/x_dialog.c:149
 msgid "Delete attribute"
 msgstr ""
 
-#: attrib/src/x_dialog.c:174
 msgid ""
 "One or more components have been found with missing symbol files!\n"
 "\n"
@@ -261,31 +222,24 @@ msgid ""
 "\"Forward\" to continue working with lepton-attrib.\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:187
 msgid "Missing symbol file found for component!"
 msgstr ""
 
-#: attrib/src/x_dialog.c:214
 msgid "Save the changes before closing?"
 msgstr ""
 
-#: attrib/src/x_dialog.c:215
 msgid "<big><b>"
 msgstr ""
 
-#: attrib/src/x_dialog.c:215
 msgid "</b></big>"
 msgstr ""
 
-#: attrib/src/x_dialog.c:217
 msgid "If you don't save, all your changes will be permanently lost."
 msgstr ""
 
-#: attrib/src/x_dialog.c:227
 msgid "Close without saving"
 msgstr ""
 
-#: attrib/src/x_dialog.c:274
 msgid ""
 "Sorry -- you have chosen a feature which has not been\n"
 "implemented yet.\n"
@@ -299,15 +253,12 @@ msgid ""
 "Otherwise, just hang tight -- I'll implement this feature soon!\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:282
 msgid "Unimplemented feature!"
 msgstr ""
 
-#: attrib/src/x_dialog.c:309
 msgid "Fatal error"
 msgstr ""
 
-#: attrib/src/x_dialog.c:324
 #, c-format
 msgid ""
 "Lepton Electronic Design Automation\n"
@@ -321,110 +272,85 @@ msgid ""
 "and gtkextra, as well as support from the gEDA community."
 msgstr ""
 
-#: attrib/src/x_dialog.c:335
 msgid "About..."
 msgstr ""
 
-#: attrib/src/x_dialog.c:351
 msgid "Export CSV"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:87
 msgid "Schematics"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:92
 msgid "Symbols"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:97
 msgid "Schematics and symbols"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:103
 msgid "All files"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:134
 #, c-format
 msgid "Loading file [%1$s]"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:140
 #, c-format
 msgid "Couldn't load schematic [%1$s]\n"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:230
 msgid "Open..."
 msgstr ""
 
-#: attrib/src/x_fileselect.c:275
 msgid "Save as..."
 msgstr ""
 
-#: attrib/src/x_fileselect.c:304
 #, c-format
 msgid "Saved As [%1$s]"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:314
 #, c-format
 msgid "Could NOT save [%1$s]"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:70 attrib/src/x_gtksheet.c:79
 msgid "Components"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:71 attrib/src/x_gtksheet.c:88
-#: attrib/src/x_gtksheet.c:91
 msgid "Nets"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:72 attrib/src/x_gtksheet.c:104
-#: attrib/src/x_gtksheet.c:107
 msgid "Pins"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:81
 msgid ""
 "No components found in design.  Please check your schematic and try again!\n"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:92 attrib/src/x_gtksheet.c:94
 msgid "TBD"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:355
 msgid "couldn't allocate color"
 msgstr ""
 
-#: attrib/src/x_window.c:94
 #, fuzzy
 msgid "lepton-attrib - Lepton EDA attribute editor"
 msgstr "Editor de atributos gEDA"
 
-#: attrib/src/x_window.c:299
 #, c-format
 msgid ""
 "Error loading %1$s:\n"
 "%2$s\n"
 msgstr ""
 
-#: attrib/src/x_window.c:337
 msgid ""
 "No components found in entire design!\n"
 "Do you have refdeses on your components?"
 msgstr ""
 
-#: attrib/src/x_window.c:342
 msgid ""
 "No configurable component attributes found in entire design!\n"
 "Please attach at least some attributes before running lepton-attrib."
 msgstr ""
 
-#: attrib/src/x_window.c:347
 msgid ""
 "No pins found on any components!\n"
 "Please check your design."

--- a/attrib/po/hu.po
+++ b/attrib/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-12 00:10+0300\n"
+"POT-Creation-Date: 2019-05-10 08:15+0300\n"
 "PO-Revision-Date: 2010-02-06 22:10+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -18,40 +18,32 @@ msgstr ""
 "X-Launchpad-Export-Date: 2010-02-14 12:56+0000\n"
 "X-Generator: Launchpad (build Unknown)\n"
 
-#: attrib/data/lepton-attrib.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Attribute Editor"
 msgstr "gEDA attribútumszerkesztő"
 
-#: attrib/data/lepton-attrib.desktop.in:4
 #, fuzzy
 msgid "Manipulate component attributes with lepton-attrib"
 msgstr "Alkatrészattribútumok szerkesztése gattrib segítségével"
 
-#: attrib/src/f_export.c:82
 #, c-format
 msgid "o_save: Could not open [%1$s]"
 msgstr ""
 
-#: attrib/src/lepton-attrib.c:160
 #, c-format
 msgid "Lepton EDA/lepton-attrib version %1$s%2$s.%3$s git: %4$.7s"
 msgstr ""
 
-#: attrib/src/lepton-attrib.c:196
 #, c-format
 msgid "Couldn't find file [%1$s]\n"
 msgstr ""
 
-#: attrib/src/gtksheet_2_2.c:6302
 msgid "Entry type must be GtkEntry subclass, using default"
 msgstr ""
 
-#: attrib/src/gtksheet_2_2.c:8499
 msgid "Widget must be a GtkSheet child"
 msgstr ""
 
-#: attrib/src/parsecmd.c:73
 #, c-format
 msgid ""
 "\n"
@@ -83,174 +75,143 @@ msgid ""
 "Please report bugs to %2$s.\n"
 msgstr ""
 
-#: attrib/src/s_attrib.c:101
 #, c-format
 msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 
-#: attrib/src/s_misc.c:81
 #, c-format
 msgid ""
 "\n"
 "DONE\n"
 msgstr ""
 
-#: attrib/src/s_misc.c:83
 #, c-format
 msgid " DONE\n"
 msgstr ""
 
-#: attrib/src/s_object.c:217
 #, c-format
 msgid ""
 "In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
 "on the component.  Exiting . . .\n"
 msgstr ""
 
-#: attrib/src/s_object.c:276
 #, c-format
 msgid ""
 "In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
 "on the component.  Exiting . . .\n"
 msgstr ""
 
-#: attrib/src/s_object.c:329
 #, c-format
 msgid ""
 "In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
 "or non-net!\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:116
 #, c-format
 msgid "- Starting master comp list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:184
 #, c-format
 msgid "- Starting master comp attrib list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:297
 #, c-format
 msgid "- Starting master pin list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:331
 #, c-format
 msgid ""
 "In s_sheet_data_add_master_pin_list_items, found component pin with no "
 "pinnumber.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:389
 #, c-format
 msgid "- Starting master pin attrib list creation.\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:123
 #, c-format
 msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:188
 #, c-format
 msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:252
 #, c-format
 msgid "In s_string_list_delete_item, couldn't delete item %s\n"
 msgstr ""
 
-#: attrib/src/s_table.c:242
 #, c-format
 msgid ""
 "In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
 msgstr ""
 
-#: attrib/src/s_table.c:285
 #, c-format
 msgid "- Starting internal component TABLE creation\n"
 msgstr ""
 
-#: attrib/src/s_table.c:344
 #, c-format
 msgid ""
 "In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
 "or col in the lists!\n"
 msgstr ""
 
-#: attrib/src/s_table.c:493
 #, c-format
 msgid "- Starting internal pin TABLE creation\n"
 msgstr ""
 
-#: attrib/src/s_table.c:553
 #, c-format
 msgid ""
 "In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
 "col in the lists!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:185
 msgid "_cancel"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:318
 #, c-format
 msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:554
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
 "the master list!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:582
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:891
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
 "missing!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:900
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
 "master list!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:928
 #, c-format
 msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:74
 msgid "Add new attribute"
 msgstr ""
 
-#: attrib/src/x_dialog.c:83
 msgid "Enter new attribute name"
 msgstr ""
 
-#: attrib/src/x_dialog.c:147
 msgid "Are you sure you want to delete this attribute?"
 msgstr ""
 
-#: attrib/src/x_dialog.c:149
 msgid "Delete attribute"
 msgstr ""
 
-#: attrib/src/x_dialog.c:174
 msgid ""
 "One or more components have been found with missing symbol files!\n"
 "\n"
@@ -261,31 +222,24 @@ msgid ""
 "\"Forward\" to continue working with lepton-attrib.\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:187
 msgid "Missing symbol file found for component!"
 msgstr ""
 
-#: attrib/src/x_dialog.c:214
 msgid "Save the changes before closing?"
 msgstr ""
 
-#: attrib/src/x_dialog.c:215
 msgid "<big><b>"
 msgstr ""
 
-#: attrib/src/x_dialog.c:215
 msgid "</b></big>"
 msgstr ""
 
-#: attrib/src/x_dialog.c:217
 msgid "If you don't save, all your changes will be permanently lost."
 msgstr ""
 
-#: attrib/src/x_dialog.c:227
 msgid "Close without saving"
 msgstr ""
 
-#: attrib/src/x_dialog.c:274
 msgid ""
 "Sorry -- you have chosen a feature which has not been\n"
 "implemented yet.\n"
@@ -299,15 +253,12 @@ msgid ""
 "Otherwise, just hang tight -- I'll implement this feature soon!\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:282
 msgid "Unimplemented feature!"
 msgstr ""
 
-#: attrib/src/x_dialog.c:309
 msgid "Fatal error"
 msgstr ""
 
-#: attrib/src/x_dialog.c:324
 #, c-format
 msgid ""
 "Lepton Electronic Design Automation\n"
@@ -321,110 +272,85 @@ msgid ""
 "and gtkextra, as well as support from the gEDA community."
 msgstr ""
 
-#: attrib/src/x_dialog.c:335
 msgid "About..."
 msgstr ""
 
-#: attrib/src/x_dialog.c:351
 msgid "Export CSV"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:87
 msgid "Schematics"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:92
 msgid "Symbols"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:97
 msgid "Schematics and symbols"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:103
 msgid "All files"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:134
 #, c-format
 msgid "Loading file [%1$s]"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:140
 #, c-format
 msgid "Couldn't load schematic [%1$s]\n"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:230
 msgid "Open..."
 msgstr ""
 
-#: attrib/src/x_fileselect.c:275
 msgid "Save as..."
 msgstr ""
 
-#: attrib/src/x_fileselect.c:304
 #, c-format
 msgid "Saved As [%1$s]"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:314
 #, c-format
 msgid "Could NOT save [%1$s]"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:70 attrib/src/x_gtksheet.c:79
 msgid "Components"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:71 attrib/src/x_gtksheet.c:88
-#: attrib/src/x_gtksheet.c:91
 msgid "Nets"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:72 attrib/src/x_gtksheet.c:104
-#: attrib/src/x_gtksheet.c:107
 msgid "Pins"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:81
 msgid ""
 "No components found in design.  Please check your schematic and try again!\n"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:92 attrib/src/x_gtksheet.c:94
 msgid "TBD"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:355
 msgid "couldn't allocate color"
 msgstr ""
 
-#: attrib/src/x_window.c:94
 #, fuzzy
 msgid "lepton-attrib - Lepton EDA attribute editor"
 msgstr "gEDA attribútumszerkesztő"
 
-#: attrib/src/x_window.c:299
 #, c-format
 msgid ""
 "Error loading %1$s:\n"
 "%2$s\n"
 msgstr ""
 
-#: attrib/src/x_window.c:337
 msgid ""
 "No components found in entire design!\n"
 "Do you have refdeses on your components?"
 msgstr ""
 
-#: attrib/src/x_window.c:342
 msgid ""
 "No configurable component attributes found in entire design!\n"
 "Please attach at least some attributes before running lepton-attrib."
 msgstr ""
 
-#: attrib/src/x_window.c:347
 msgid ""
 "No pins found on any components!\n"
 "Please check your design."

--- a/attrib/po/it.po
+++ b/attrib/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-12 00:10+0300\n"
+"POT-Creation-Date: 2019-05-10 08:15+0300\n"
 "PO-Revision-Date: 2010-02-06 22:09+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -18,40 +18,32 @@ msgstr ""
 "X-Launchpad-Export-Date: 2010-02-14 12:56+0000\n"
 "X-Generator: Launchpad (build Unknown)\n"
 
-#: attrib/data/lepton-attrib.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Attribute Editor"
 msgstr "gEDA Editor Attributi"
 
-#: attrib/data/lepton-attrib.desktop.in:4
 #, fuzzy
 msgid "Manipulate component attributes with lepton-attrib"
 msgstr "Manipola gli attributi dei componenti con gattrib"
 
-#: attrib/src/f_export.c:82
 #, c-format
 msgid "o_save: Could not open [%1$s]"
 msgstr ""
 
-#: attrib/src/lepton-attrib.c:160
 #, c-format
 msgid "Lepton EDA/lepton-attrib version %1$s%2$s.%3$s git: %4$.7s"
 msgstr ""
 
-#: attrib/src/lepton-attrib.c:196
 #, c-format
 msgid "Couldn't find file [%1$s]\n"
 msgstr ""
 
-#: attrib/src/gtksheet_2_2.c:6302
 msgid "Entry type must be GtkEntry subclass, using default"
 msgstr ""
 
-#: attrib/src/gtksheet_2_2.c:8499
 msgid "Widget must be a GtkSheet child"
 msgstr ""
 
-#: attrib/src/parsecmd.c:73
 #, c-format
 msgid ""
 "\n"
@@ -83,174 +75,143 @@ msgid ""
 "Please report bugs to %2$s.\n"
 msgstr ""
 
-#: attrib/src/s_attrib.c:101
 #, c-format
 msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 
-#: attrib/src/s_misc.c:81
 #, c-format
 msgid ""
 "\n"
 "DONE\n"
 msgstr ""
 
-#: attrib/src/s_misc.c:83
 #, c-format
 msgid " DONE\n"
 msgstr ""
 
-#: attrib/src/s_object.c:217
 #, c-format
 msgid ""
 "In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
 "on the component.  Exiting . . .\n"
 msgstr ""
 
-#: attrib/src/s_object.c:276
 #, c-format
 msgid ""
 "In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
 "on the component.  Exiting . . .\n"
 msgstr ""
 
-#: attrib/src/s_object.c:329
 #, c-format
 msgid ""
 "In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
 "or non-net!\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:116
 #, c-format
 msgid "- Starting master comp list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:184
 #, c-format
 msgid "- Starting master comp attrib list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:297
 #, c-format
 msgid "- Starting master pin list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:331
 #, c-format
 msgid ""
 "In s_sheet_data_add_master_pin_list_items, found component pin with no "
 "pinnumber.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:389
 #, c-format
 msgid "- Starting master pin attrib list creation.\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:123
 #, c-format
 msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:188
 #, c-format
 msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:252
 #, c-format
 msgid "In s_string_list_delete_item, couldn't delete item %s\n"
 msgstr ""
 
-#: attrib/src/s_table.c:242
 #, c-format
 msgid ""
 "In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
 msgstr ""
 
-#: attrib/src/s_table.c:285
 #, c-format
 msgid "- Starting internal component TABLE creation\n"
 msgstr ""
 
-#: attrib/src/s_table.c:344
 #, c-format
 msgid ""
 "In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
 "or col in the lists!\n"
 msgstr ""
 
-#: attrib/src/s_table.c:493
 #, c-format
 msgid "- Starting internal pin TABLE creation\n"
 msgstr ""
 
-#: attrib/src/s_table.c:553
 #, c-format
 msgid ""
 "In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
 "col in the lists!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:185
 msgid "_cancel"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:318
 #, c-format
 msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:554
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
 "the master list!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:582
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:891
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
 "missing!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:900
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
 "master list!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:928
 #, c-format
 msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:74
 msgid "Add new attribute"
 msgstr ""
 
-#: attrib/src/x_dialog.c:83
 msgid "Enter new attribute name"
 msgstr ""
 
-#: attrib/src/x_dialog.c:147
 msgid "Are you sure you want to delete this attribute?"
 msgstr ""
 
-#: attrib/src/x_dialog.c:149
 msgid "Delete attribute"
 msgstr ""
 
-#: attrib/src/x_dialog.c:174
 msgid ""
 "One or more components have been found with missing symbol files!\n"
 "\n"
@@ -261,31 +222,24 @@ msgid ""
 "\"Forward\" to continue working with lepton-attrib.\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:187
 msgid "Missing symbol file found for component!"
 msgstr ""
 
-#: attrib/src/x_dialog.c:214
 msgid "Save the changes before closing?"
 msgstr ""
 
-#: attrib/src/x_dialog.c:215
 msgid "<big><b>"
 msgstr ""
 
-#: attrib/src/x_dialog.c:215
 msgid "</b></big>"
 msgstr ""
 
-#: attrib/src/x_dialog.c:217
 msgid "If you don't save, all your changes will be permanently lost."
 msgstr ""
 
-#: attrib/src/x_dialog.c:227
 msgid "Close without saving"
 msgstr ""
 
-#: attrib/src/x_dialog.c:274
 msgid ""
 "Sorry -- you have chosen a feature which has not been\n"
 "implemented yet.\n"
@@ -299,15 +253,12 @@ msgid ""
 "Otherwise, just hang tight -- I'll implement this feature soon!\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:282
 msgid "Unimplemented feature!"
 msgstr ""
 
-#: attrib/src/x_dialog.c:309
 msgid "Fatal error"
 msgstr ""
 
-#: attrib/src/x_dialog.c:324
 #, c-format
 msgid ""
 "Lepton Electronic Design Automation\n"
@@ -321,110 +272,85 @@ msgid ""
 "and gtkextra, as well as support from the gEDA community."
 msgstr ""
 
-#: attrib/src/x_dialog.c:335
 msgid "About..."
 msgstr ""
 
-#: attrib/src/x_dialog.c:351
 msgid "Export CSV"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:87
 msgid "Schematics"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:92
 msgid "Symbols"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:97
 msgid "Schematics and symbols"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:103
 msgid "All files"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:134
 #, c-format
 msgid "Loading file [%1$s]"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:140
 #, c-format
 msgid "Couldn't load schematic [%1$s]\n"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:230
 msgid "Open..."
 msgstr ""
 
-#: attrib/src/x_fileselect.c:275
 msgid "Save as..."
 msgstr ""
 
-#: attrib/src/x_fileselect.c:304
 #, c-format
 msgid "Saved As [%1$s]"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:314
 #, c-format
 msgid "Could NOT save [%1$s]"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:70 attrib/src/x_gtksheet.c:79
 msgid "Components"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:71 attrib/src/x_gtksheet.c:88
-#: attrib/src/x_gtksheet.c:91
 msgid "Nets"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:72 attrib/src/x_gtksheet.c:104
-#: attrib/src/x_gtksheet.c:107
 msgid "Pins"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:81
 msgid ""
 "No components found in design.  Please check your schematic and try again!\n"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:92 attrib/src/x_gtksheet.c:94
 msgid "TBD"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:355
 msgid "couldn't allocate color"
 msgstr ""
 
-#: attrib/src/x_window.c:94
 #, fuzzy
 msgid "lepton-attrib - Lepton EDA attribute editor"
 msgstr "gEDA Editor Attributi"
 
-#: attrib/src/x_window.c:299
 #, c-format
 msgid ""
 "Error loading %1$s:\n"
 "%2$s\n"
 msgstr ""
 
-#: attrib/src/x_window.c:337
 msgid ""
 "No components found in entire design!\n"
 "Do you have refdeses on your components?"
 msgstr ""
 
-#: attrib/src/x_window.c:342
 msgid ""
 "No configurable component attributes found in entire design!\n"
 "Please attach at least some attributes before running lepton-attrib."
 msgstr ""
 
-#: attrib/src/x_window.c:347
 msgid ""
 "No pins found on any components!\n"
 "Please check your design."

--- a/attrib/po/ja.po
+++ b/attrib/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-12 00:10+0300\n"
+"POT-Creation-Date: 2019-05-10 08:15+0300\n"
 "PO-Revision-Date: 2012-01-27 14:17+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: Japanese <ja@li.org>\n"
@@ -18,38 +18,30 @@ msgstr ""
 "X-Launchpad-Export-Date: 2012-11-14 16:52+0000\n"
 "X-Generator: Launchpad (build 16265)\n"
 
-#: attrib/data/lepton-attrib.desktop.in:3
 msgid "Lepton EDA Attribute Editor"
 msgstr ""
 
-#: attrib/data/lepton-attrib.desktop.in:4
 msgid "Manipulate component attributes with lepton-attrib"
 msgstr ""
 
-#: attrib/src/f_export.c:82
 #, c-format
 msgid "o_save: Could not open [%1$s]"
 msgstr ""
 
-#: attrib/src/lepton-attrib.c:160
 #, c-format
 msgid "Lepton EDA/lepton-attrib version %1$s%2$s.%3$s git: %4$.7s"
 msgstr ""
 
-#: attrib/src/lepton-attrib.c:196
 #, c-format
 msgid "Couldn't find file [%1$s]\n"
 msgstr ""
 
-#: attrib/src/gtksheet_2_2.c:6302
 msgid "Entry type must be GtkEntry subclass, using default"
 msgstr ""
 
-#: attrib/src/gtksheet_2_2.c:8499
 msgid "Widget must be a GtkSheet child"
 msgstr ""
 
-#: attrib/src/parsecmd.c:73
 #, c-format
 msgid ""
 "\n"
@@ -81,174 +73,143 @@ msgid ""
 "Please report bugs to %2$s.\n"
 msgstr ""
 
-#: attrib/src/s_attrib.c:101
 #, c-format
 msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 
-#: attrib/src/s_misc.c:81
 #, c-format
 msgid ""
 "\n"
 "DONE\n"
 msgstr ""
 
-#: attrib/src/s_misc.c:83
 #, c-format
 msgid " DONE\n"
 msgstr ""
 
-#: attrib/src/s_object.c:217
 #, c-format
 msgid ""
 "In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
 "on the component.  Exiting . . .\n"
 msgstr ""
 
-#: attrib/src/s_object.c:276
 #, c-format
 msgid ""
 "In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
 "on the component.  Exiting . . .\n"
 msgstr ""
 
-#: attrib/src/s_object.c:329
 #, c-format
 msgid ""
 "In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
 "or non-net!\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:116
 #, c-format
 msgid "- Starting master comp list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:184
 #, c-format
 msgid "- Starting master comp attrib list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:297
 #, c-format
 msgid "- Starting master pin list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:331
 #, c-format
 msgid ""
 "In s_sheet_data_add_master_pin_list_items, found component pin with no "
 "pinnumber.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:389
 #, c-format
 msgid "- Starting master pin attrib list creation.\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:123
 #, c-format
 msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:188
 #, c-format
 msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:252
 #, c-format
 msgid "In s_string_list_delete_item, couldn't delete item %s\n"
 msgstr ""
 
-#: attrib/src/s_table.c:242
 #, c-format
 msgid ""
 "In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
 msgstr ""
 
-#: attrib/src/s_table.c:285
 #, c-format
 msgid "- Starting internal component TABLE creation\n"
 msgstr ""
 
-#: attrib/src/s_table.c:344
 #, c-format
 msgid ""
 "In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
 "or col in the lists!\n"
 msgstr ""
 
-#: attrib/src/s_table.c:493
 #, c-format
 msgid "- Starting internal pin TABLE creation\n"
 msgstr ""
 
-#: attrib/src/s_table.c:553
 #, c-format
 msgid ""
 "In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
 "col in the lists!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:185
 msgid "_cancel"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:318
 #, c-format
 msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:554
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
 "the master list!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:582
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:891
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
 "missing!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:900
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
 "master list!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:928
 #, c-format
 msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:74
 msgid "Add new attribute"
 msgstr ""
 
-#: attrib/src/x_dialog.c:83
 msgid "Enter new attribute name"
 msgstr ""
 
-#: attrib/src/x_dialog.c:147
 msgid "Are you sure you want to delete this attribute?"
 msgstr ""
 
-#: attrib/src/x_dialog.c:149
 msgid "Delete attribute"
 msgstr ""
 
-#: attrib/src/x_dialog.c:174
 msgid ""
 "One or more components have been found with missing symbol files!\n"
 "\n"
@@ -259,31 +220,24 @@ msgid ""
 "\"Forward\" to continue working with lepton-attrib.\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:187
 msgid "Missing symbol file found for component!"
 msgstr ""
 
-#: attrib/src/x_dialog.c:214
 msgid "Save the changes before closing?"
 msgstr ""
 
-#: attrib/src/x_dialog.c:215
 msgid "<big><b>"
 msgstr ""
 
-#: attrib/src/x_dialog.c:215
 msgid "</b></big>"
 msgstr ""
 
-#: attrib/src/x_dialog.c:217
 msgid "If you don't save, all your changes will be permanently lost."
 msgstr ""
 
-#: attrib/src/x_dialog.c:227
 msgid "Close without saving"
 msgstr ""
 
-#: attrib/src/x_dialog.c:274
 msgid ""
 "Sorry -- you have chosen a feature which has not been\n"
 "implemented yet.\n"
@@ -297,15 +251,12 @@ msgid ""
 "Otherwise, just hang tight -- I'll implement this feature soon!\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:282
 msgid "Unimplemented feature!"
 msgstr ""
 
-#: attrib/src/x_dialog.c:309
 msgid "Fatal error"
 msgstr ""
 
-#: attrib/src/x_dialog.c:324
 #, c-format
 msgid ""
 "Lepton Electronic Design Automation\n"
@@ -319,109 +270,84 @@ msgid ""
 "and gtkextra, as well as support from the gEDA community."
 msgstr ""
 
-#: attrib/src/x_dialog.c:335
 msgid "About..."
 msgstr ""
 
-#: attrib/src/x_dialog.c:351
 msgid "Export CSV"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:87
 msgid "Schematics"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:92
 msgid "Symbols"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:97
 msgid "Schematics and symbols"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:103
 msgid "All files"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:134
 #, c-format
 msgid "Loading file [%1$s]"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:140
 #, c-format
 msgid "Couldn't load schematic [%1$s]\n"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:230
 msgid "Open..."
 msgstr ""
 
-#: attrib/src/x_fileselect.c:275
 msgid "Save as..."
 msgstr ""
 
-#: attrib/src/x_fileselect.c:304
 #, c-format
 msgid "Saved As [%1$s]"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:314
 #, c-format
 msgid "Could NOT save [%1$s]"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:70 attrib/src/x_gtksheet.c:79
 msgid "Components"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:71 attrib/src/x_gtksheet.c:88
-#: attrib/src/x_gtksheet.c:91
 msgid "Nets"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:72 attrib/src/x_gtksheet.c:104
-#: attrib/src/x_gtksheet.c:107
 msgid "Pins"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:81
 msgid ""
 "No components found in design.  Please check your schematic and try again!\n"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:92 attrib/src/x_gtksheet.c:94
 msgid "TBD"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:355
 msgid "couldn't allocate color"
 msgstr ""
 
-#: attrib/src/x_window.c:94
 msgid "lepton-attrib - Lepton EDA attribute editor"
 msgstr ""
 
-#: attrib/src/x_window.c:299
 #, c-format
 msgid ""
 "Error loading %1$s:\n"
 "%2$s\n"
 msgstr ""
 
-#: attrib/src/x_window.c:337
 msgid ""
 "No components found in entire design!\n"
 "Do you have refdeses on your components?"
 msgstr ""
 
-#: attrib/src/x_window.c:342
 msgid ""
 "No configurable component attributes found in entire design!\n"
 "Please attach at least some attributes before running lepton-attrib."
 msgstr ""
 
-#: attrib/src/x_window.c:347
 msgid ""
 "No pins found on any components!\n"
 "Please check your design."

--- a/attrib/po/lepton-attrib.pot
+++ b/attrib/po/lepton-attrib.pot
@@ -1,49 +1,54 @@
-# Catalan translation for geda
-# Copyright (c) 2012 Rosetta Contributors and Canonical Ltd 2012
-# This file is distributed under the same license as the geda package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2012.
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR gEDA Developers
+# This file is distributed under the same license as the lepton-eda package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
+#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: geda\n"
+"Project-Id-Version: lepton-eda 1.9.7\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
 "POT-Creation-Date: 2019-05-10 08:15+0300\n"
-"PO-Revision-Date: 2012-01-27 14:17+0000\n"
-"Last-Translator: Launchpad Translators\n"
-"Language-Team: Catalan <ca@li.org>\n"
-"Language: ca\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2012-11-14 16:52+0000\n"
-"X-Generator: Launchpad (build 16265)\n"
 
-#, fuzzy
+#: attrib/data/lepton-attrib.desktop.in:3
 msgid "Lepton EDA Attribute Editor"
-msgstr "Editor d'atributs gEDA"
+msgstr ""
 
-#, fuzzy
+#: attrib/data/lepton-attrib.desktop.in:4
 msgid "Manipulate component attributes with lepton-attrib"
-msgstr "Manipuleu atributs de components amb el gattrib"
+msgstr ""
 
+#: attrib/src/f_export.c:82
 #, c-format
 msgid "o_save: Could not open [%1$s]"
 msgstr ""
 
+#: attrib/src/lepton-attrib.c:179
 #, c-format
 msgid "Lepton EDA/lepton-attrib version %1$s%2$s.%3$s git: %4$.7s"
 msgstr ""
 
+#: attrib/src/lepton-attrib.c:212
 #, c-format
 msgid "Couldn't find file [%1$s]\n"
 msgstr ""
 
+#: attrib/src/gtksheet_2_2.c:6302
 msgid "Entry type must be GtkEntry subclass, using default"
 msgstr ""
 
+#: attrib/src/gtksheet_2_2.c:8499
 msgid "Widget must be a GtkSheet child"
 msgstr ""
 
+#: attrib/src/parsecmd.c:73
 #, c-format
 msgid ""
 "\n"
@@ -75,143 +80,174 @@ msgid ""
 "Please report bugs to %2$s.\n"
 msgstr ""
 
+#: attrib/src/s_attrib.c:101
 #, c-format
 msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 
+#: attrib/src/s_misc.c:81
 #, c-format
 msgid ""
 "\n"
 "DONE\n"
 msgstr ""
 
+#: attrib/src/s_misc.c:83
 #, c-format
 msgid " DONE\n"
 msgstr ""
 
+#: attrib/src/s_object.c:217
 #, c-format
 msgid ""
 "In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
 "on the component.  Exiting . . .\n"
 msgstr ""
 
+#: attrib/src/s_object.c:276
 #, c-format
 msgid ""
 "In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
 "on the component.  Exiting . . .\n"
 msgstr ""
 
+#: attrib/src/s_object.c:329
 #, c-format
 msgid ""
 "In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
 "or non-net!\n"
 msgstr ""
 
+#: attrib/src/s_sheet_data.c:116
 #, c-format
 msgid "- Starting master comp list creation.\n"
 msgstr ""
 
+#: attrib/src/s_sheet_data.c:184
 #, c-format
 msgid "- Starting master comp attrib list creation.\n"
 msgstr ""
 
+#: attrib/src/s_sheet_data.c:297
 #, c-format
 msgid "- Starting master pin list creation.\n"
 msgstr ""
 
+#: attrib/src/s_sheet_data.c:331
 #, c-format
 msgid ""
 "In s_sheet_data_add_master_pin_list_items, found component pin with no "
 "pinnumber.\n"
 msgstr ""
 
+#: attrib/src/s_sheet_data.c:389
 #, c-format
 msgid "- Starting master pin attrib list creation.\n"
 msgstr ""
 
+#: attrib/src/s_string_list.c:123
 #, c-format
 msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
 msgstr ""
 
+#: attrib/src/s_string_list.c:188
 #, c-format
 msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
 msgstr ""
 
+#: attrib/src/s_string_list.c:252
 #, c-format
 msgid "In s_string_list_delete_item, couldn't delete item %s\n"
 msgstr ""
 
+#: attrib/src/s_table.c:242
 #, c-format
 msgid ""
 "In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
 msgstr ""
 
+#: attrib/src/s_table.c:285
 #, c-format
 msgid "- Starting internal component TABLE creation\n"
 msgstr ""
 
+#: attrib/src/s_table.c:344
 #, c-format
 msgid ""
 "In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
 "or col in the lists!\n"
 msgstr ""
 
+#: attrib/src/s_table.c:493
 #, c-format
 msgid "- Starting internal pin TABLE creation\n"
 msgstr ""
 
+#: attrib/src/s_table.c:553
 #, c-format
 msgid ""
 "In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
 "col in the lists!\n"
 msgstr ""
 
+#: attrib/src/s_toplevel.c:185
 msgid "_cancel"
 msgstr ""
 
+#: attrib/src/s_toplevel.c:318
 #, c-format
 msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
 msgstr ""
 
+#: attrib/src/s_toplevel.c:554
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
 "the master list!\n"
 msgstr ""
 
+#: attrib/src/s_toplevel.c:582
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr ""
 
+#: attrib/src/s_toplevel.c:891
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
 "missing!\n"
 msgstr ""
 
+#: attrib/src/s_toplevel.c:900
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
 "master list!\n"
 msgstr ""
 
+#: attrib/src/s_toplevel.c:928
 #, c-format
 msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr ""
 
+#: attrib/src/x_dialog.c:74
 msgid "Add new attribute"
 msgstr ""
 
+#: attrib/src/x_dialog.c:83
 msgid "Enter new attribute name"
 msgstr ""
 
+#: attrib/src/x_dialog.c:147
 msgid "Are you sure you want to delete this attribute?"
 msgstr ""
 
+#: attrib/src/x_dialog.c:149
 msgid "Delete attribute"
 msgstr ""
 
+#: attrib/src/x_dialog.c:174
 msgid ""
 "One or more components have been found with missing symbol files!\n"
 "\n"
@@ -222,24 +258,31 @@ msgid ""
 "\"Forward\" to continue working with lepton-attrib.\n"
 msgstr ""
 
+#: attrib/src/x_dialog.c:187
 msgid "Missing symbol file found for component!"
 msgstr ""
 
+#: attrib/src/x_dialog.c:214
 msgid "Save the changes before closing?"
 msgstr ""
 
+#: attrib/src/x_dialog.c:215
 msgid "<big><b>"
 msgstr ""
 
+#: attrib/src/x_dialog.c:215
 msgid "</b></big>"
 msgstr ""
 
+#: attrib/src/x_dialog.c:217
 msgid "If you don't save, all your changes will be permanently lost."
 msgstr ""
 
+#: attrib/src/x_dialog.c:227
 msgid "Close without saving"
 msgstr ""
 
+#: attrib/src/x_dialog.c:274
 msgid ""
 "Sorry -- you have chosen a feature which has not been\n"
 "implemented yet.\n"
@@ -253,12 +296,15 @@ msgid ""
 "Otherwise, just hang tight -- I'll implement this feature soon!\n"
 msgstr ""
 
+#: attrib/src/x_dialog.c:282
 msgid "Unimplemented feature!"
 msgstr ""
 
+#: attrib/src/x_dialog.c:309
 msgid "Fatal error"
 msgstr ""
 
+#: attrib/src/x_dialog.c:324
 #, c-format
 msgid ""
 "Lepton Electronic Design Automation\n"
@@ -272,85 +318,109 @@ msgid ""
 "and gtkextra, as well as support from the gEDA community."
 msgstr ""
 
+#: attrib/src/x_dialog.c:335
 msgid "About..."
 msgstr ""
 
+#: attrib/src/x_dialog.c:351
 msgid "Export CSV"
 msgstr ""
 
+#: attrib/src/x_fileselect.c:87
 msgid "Schematics"
 msgstr ""
 
+#: attrib/src/x_fileselect.c:92
 msgid "Symbols"
 msgstr ""
 
+#: attrib/src/x_fileselect.c:97
 msgid "Schematics and symbols"
 msgstr ""
 
+#: attrib/src/x_fileselect.c:103
 msgid "All files"
 msgstr ""
 
+#: attrib/src/x_fileselect.c:134
 #, c-format
 msgid "Loading file [%1$s]"
 msgstr ""
 
+#: attrib/src/x_fileselect.c:140
 #, c-format
 msgid "Couldn't load schematic [%1$s]\n"
 msgstr ""
 
+#: attrib/src/x_fileselect.c:230
 msgid "Open..."
 msgstr ""
 
+#: attrib/src/x_fileselect.c:275
 msgid "Save as..."
 msgstr ""
 
+#: attrib/src/x_fileselect.c:304
 #, c-format
 msgid "Saved As [%1$s]"
 msgstr ""
 
+#: attrib/src/x_fileselect.c:314
 #, c-format
 msgid "Could NOT save [%1$s]"
 msgstr ""
 
+#: attrib/src/x_gtksheet.c:70 attrib/src/x_gtksheet.c:79
 msgid "Components"
 msgstr ""
 
+#: attrib/src/x_gtksheet.c:71 attrib/src/x_gtksheet.c:88
+#: attrib/src/x_gtksheet.c:91
 msgid "Nets"
 msgstr ""
 
+#: attrib/src/x_gtksheet.c:72 attrib/src/x_gtksheet.c:104
+#: attrib/src/x_gtksheet.c:107
 msgid "Pins"
 msgstr ""
 
+#: attrib/src/x_gtksheet.c:81
 msgid ""
 "No components found in design.  Please check your schematic and try again!\n"
 msgstr ""
 
+#: attrib/src/x_gtksheet.c:92 attrib/src/x_gtksheet.c:94
 msgid "TBD"
 msgstr ""
 
+#: attrib/src/x_gtksheet.c:355
 msgid "couldn't allocate color"
 msgstr ""
 
-#, fuzzy
+#: attrib/src/x_window.c:94
 msgid "lepton-attrib - Lepton EDA attribute editor"
-msgstr "Editor d'atributs gEDA"
+msgstr ""
 
+#: attrib/src/x_window.c:318
 #, c-format
 msgid ""
 "Error loading %1$s:\n"
 "%2$s\n"
 msgstr ""
 
+#: attrib/src/x_window.c:356
 msgid ""
 "No components found in entire design!\n"
 "Do you have refdeses on your components?"
 msgstr ""
 
+#: attrib/src/x_window.c:361
 msgid ""
 "No configurable component attributes found in entire design!\n"
 "Please attach at least some attributes before running lepton-attrib."
 msgstr ""
 
+#: attrib/src/x_window.c:366
 msgid ""
 "No pins found on any components!\n"
 "Please check your design."

--- a/attrib/po/ml.po
+++ b/attrib/po/ml.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-12 00:10+0300\n"
+"POT-Creation-Date: 2019-05-10 08:15+0300\n"
 "PO-Revision-Date: 2010-02-06 22:10+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -18,40 +18,32 @@ msgstr ""
 "X-Launchpad-Export-Date: 2010-02-14 12:56+0000\n"
 "X-Generator: Launchpad (build Unknown)\n"
 
-#: attrib/data/lepton-attrib.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Attribute Editor"
 msgstr "gEDA യുടെ കമ്പോണന്‍ടു  സവിശേഷത എഡിറ്റര്‍"
 
-#: attrib/data/lepton-attrib.desktop.in:4
 #, fuzzy
 msgid "Manipulate component attributes with lepton-attrib"
 msgstr "gattrib ഉപയോഗിച്ച്   കമ്പോണന്ടിന്റെ  സവിശേഷതകള്‍ മാറ്റം വരുത്തുക"
 
-#: attrib/src/f_export.c:82
 #, c-format
 msgid "o_save: Could not open [%1$s]"
 msgstr ""
 
-#: attrib/src/lepton-attrib.c:160
 #, c-format
 msgid "Lepton EDA/lepton-attrib version %1$s%2$s.%3$s git: %4$.7s"
 msgstr ""
 
-#: attrib/src/lepton-attrib.c:196
 #, c-format
 msgid "Couldn't find file [%1$s]\n"
 msgstr ""
 
-#: attrib/src/gtksheet_2_2.c:6302
 msgid "Entry type must be GtkEntry subclass, using default"
 msgstr ""
 
-#: attrib/src/gtksheet_2_2.c:8499
 msgid "Widget must be a GtkSheet child"
 msgstr ""
 
-#: attrib/src/parsecmd.c:73
 #, c-format
 msgid ""
 "\n"
@@ -83,174 +75,143 @@ msgid ""
 "Please report bugs to %2$s.\n"
 msgstr ""
 
-#: attrib/src/s_attrib.c:101
 #, c-format
 msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 
-#: attrib/src/s_misc.c:81
 #, c-format
 msgid ""
 "\n"
 "DONE\n"
 msgstr ""
 
-#: attrib/src/s_misc.c:83
 #, c-format
 msgid " DONE\n"
 msgstr ""
 
-#: attrib/src/s_object.c:217
 #, c-format
 msgid ""
 "In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
 "on the component.  Exiting . . .\n"
 msgstr ""
 
-#: attrib/src/s_object.c:276
 #, c-format
 msgid ""
 "In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
 "on the component.  Exiting . . .\n"
 msgstr ""
 
-#: attrib/src/s_object.c:329
 #, c-format
 msgid ""
 "In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
 "or non-net!\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:116
 #, c-format
 msgid "- Starting master comp list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:184
 #, c-format
 msgid "- Starting master comp attrib list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:297
 #, c-format
 msgid "- Starting master pin list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:331
 #, c-format
 msgid ""
 "In s_sheet_data_add_master_pin_list_items, found component pin with no "
 "pinnumber.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:389
 #, c-format
 msgid "- Starting master pin attrib list creation.\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:123
 #, c-format
 msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:188
 #, c-format
 msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:252
 #, c-format
 msgid "In s_string_list_delete_item, couldn't delete item %s\n"
 msgstr ""
 
-#: attrib/src/s_table.c:242
 #, c-format
 msgid ""
 "In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
 msgstr ""
 
-#: attrib/src/s_table.c:285
 #, c-format
 msgid "- Starting internal component TABLE creation\n"
 msgstr ""
 
-#: attrib/src/s_table.c:344
 #, c-format
 msgid ""
 "In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
 "or col in the lists!\n"
 msgstr ""
 
-#: attrib/src/s_table.c:493
 #, c-format
 msgid "- Starting internal pin TABLE creation\n"
 msgstr ""
 
-#: attrib/src/s_table.c:553
 #, c-format
 msgid ""
 "In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
 "col in the lists!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:185
 msgid "_cancel"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:318
 #, c-format
 msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:554
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
 "the master list!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:582
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:891
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
 "missing!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:900
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
 "master list!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:928
 #, c-format
 msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:74
 msgid "Add new attribute"
 msgstr ""
 
-#: attrib/src/x_dialog.c:83
 msgid "Enter new attribute name"
 msgstr ""
 
-#: attrib/src/x_dialog.c:147
 msgid "Are you sure you want to delete this attribute?"
 msgstr ""
 
-#: attrib/src/x_dialog.c:149
 msgid "Delete attribute"
 msgstr ""
 
-#: attrib/src/x_dialog.c:174
 msgid ""
 "One or more components have been found with missing symbol files!\n"
 "\n"
@@ -261,31 +222,24 @@ msgid ""
 "\"Forward\" to continue working with lepton-attrib.\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:187
 msgid "Missing symbol file found for component!"
 msgstr ""
 
-#: attrib/src/x_dialog.c:214
 msgid "Save the changes before closing?"
 msgstr ""
 
-#: attrib/src/x_dialog.c:215
 msgid "<big><b>"
 msgstr ""
 
-#: attrib/src/x_dialog.c:215
 msgid "</b></big>"
 msgstr ""
 
-#: attrib/src/x_dialog.c:217
 msgid "If you don't save, all your changes will be permanently lost."
 msgstr ""
 
-#: attrib/src/x_dialog.c:227
 msgid "Close without saving"
 msgstr ""
 
-#: attrib/src/x_dialog.c:274
 msgid ""
 "Sorry -- you have chosen a feature which has not been\n"
 "implemented yet.\n"
@@ -299,15 +253,12 @@ msgid ""
 "Otherwise, just hang tight -- I'll implement this feature soon!\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:282
 msgid "Unimplemented feature!"
 msgstr ""
 
-#: attrib/src/x_dialog.c:309
 msgid "Fatal error"
 msgstr ""
 
-#: attrib/src/x_dialog.c:324
 #, c-format
 msgid ""
 "Lepton Electronic Design Automation\n"
@@ -321,110 +272,85 @@ msgid ""
 "and gtkextra, as well as support from the gEDA community."
 msgstr ""
 
-#: attrib/src/x_dialog.c:335
 msgid "About..."
 msgstr ""
 
-#: attrib/src/x_dialog.c:351
 msgid "Export CSV"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:87
 msgid "Schematics"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:92
 msgid "Symbols"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:97
 msgid "Schematics and symbols"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:103
 msgid "All files"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:134
 #, c-format
 msgid "Loading file [%1$s]"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:140
 #, c-format
 msgid "Couldn't load schematic [%1$s]\n"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:230
 msgid "Open..."
 msgstr ""
 
-#: attrib/src/x_fileselect.c:275
 msgid "Save as..."
 msgstr ""
 
-#: attrib/src/x_fileselect.c:304
 #, c-format
 msgid "Saved As [%1$s]"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:314
 #, c-format
 msgid "Could NOT save [%1$s]"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:70 attrib/src/x_gtksheet.c:79
 msgid "Components"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:71 attrib/src/x_gtksheet.c:88
-#: attrib/src/x_gtksheet.c:91
 msgid "Nets"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:72 attrib/src/x_gtksheet.c:104
-#: attrib/src/x_gtksheet.c:107
 msgid "Pins"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:81
 msgid ""
 "No components found in design.  Please check your schematic and try again!\n"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:92 attrib/src/x_gtksheet.c:94
 msgid "TBD"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:355
 msgid "couldn't allocate color"
 msgstr ""
 
-#: attrib/src/x_window.c:94
 #, fuzzy
 msgid "lepton-attrib - Lepton EDA attribute editor"
 msgstr "gEDA യുടെ കമ്പോണന്‍ടു  സവിശേഷത എഡിറ്റര്‍"
 
-#: attrib/src/x_window.c:299
 #, c-format
 msgid ""
 "Error loading %1$s:\n"
 "%2$s\n"
 msgstr ""
 
-#: attrib/src/x_window.c:337
 msgid ""
 "No components found in entire design!\n"
 "Do you have refdeses on your components?"
 msgstr ""
 
-#: attrib/src/x_window.c:342
 msgid ""
 "No configurable component attributes found in entire design!\n"
 "Please attach at least some attributes before running lepton-attrib."
 msgstr ""
 
-#: attrib/src/x_window.c:347
 msgid ""
 "No pins found on any components!\n"
 "Please check your design."

--- a/attrib/po/nb.po
+++ b/attrib/po/nb.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-12 00:10+0300\n"
+"POT-Creation-Date: 2019-05-10 08:15+0300\n"
 "PO-Revision-Date: 2012-01-27 14:17+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: Norwegian Bokmal <nb@li.org>\n"
@@ -18,39 +18,31 @@ msgstr ""
 "X-Launchpad-Export-Date: 2012-11-14 16:52+0000\n"
 "X-Generator: Launchpad (build 16265)\n"
 
-#: attrib/data/lepton-attrib.desktop.in:3
 msgid "Lepton EDA Attribute Editor"
 msgstr ""
 
-#: attrib/data/lepton-attrib.desktop.in:4
 #, fuzzy
 msgid "Manipulate component attributes with lepton-attrib"
 msgstr "Manipuler komponent attributter med gattrib"
 
-#: attrib/src/f_export.c:82
 #, c-format
 msgid "o_save: Could not open [%1$s]"
 msgstr ""
 
-#: attrib/src/lepton-attrib.c:160
 #, c-format
 msgid "Lepton EDA/lepton-attrib version %1$s%2$s.%3$s git: %4$.7s"
 msgstr ""
 
-#: attrib/src/lepton-attrib.c:196
 #, c-format
 msgid "Couldn't find file [%1$s]\n"
 msgstr ""
 
-#: attrib/src/gtksheet_2_2.c:6302
 msgid "Entry type must be GtkEntry subclass, using default"
 msgstr ""
 
-#: attrib/src/gtksheet_2_2.c:8499
 msgid "Widget must be a GtkSheet child"
 msgstr ""
 
-#: attrib/src/parsecmd.c:73
 #, c-format
 msgid ""
 "\n"
@@ -82,174 +74,143 @@ msgid ""
 "Please report bugs to %2$s.\n"
 msgstr ""
 
-#: attrib/src/s_attrib.c:101
 #, c-format
 msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 
-#: attrib/src/s_misc.c:81
 #, c-format
 msgid ""
 "\n"
 "DONE\n"
 msgstr ""
 
-#: attrib/src/s_misc.c:83
 #, c-format
 msgid " DONE\n"
 msgstr ""
 
-#: attrib/src/s_object.c:217
 #, c-format
 msgid ""
 "In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
 "on the component.  Exiting . . .\n"
 msgstr ""
 
-#: attrib/src/s_object.c:276
 #, c-format
 msgid ""
 "In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
 "on the component.  Exiting . . .\n"
 msgstr ""
 
-#: attrib/src/s_object.c:329
 #, c-format
 msgid ""
 "In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
 "or non-net!\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:116
 #, c-format
 msgid "- Starting master comp list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:184
 #, c-format
 msgid "- Starting master comp attrib list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:297
 #, c-format
 msgid "- Starting master pin list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:331
 #, c-format
 msgid ""
 "In s_sheet_data_add_master_pin_list_items, found component pin with no "
 "pinnumber.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:389
 #, c-format
 msgid "- Starting master pin attrib list creation.\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:123
 #, c-format
 msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:188
 #, c-format
 msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:252
 #, c-format
 msgid "In s_string_list_delete_item, couldn't delete item %s\n"
 msgstr ""
 
-#: attrib/src/s_table.c:242
 #, c-format
 msgid ""
 "In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
 msgstr ""
 
-#: attrib/src/s_table.c:285
 #, c-format
 msgid "- Starting internal component TABLE creation\n"
 msgstr ""
 
-#: attrib/src/s_table.c:344
 #, c-format
 msgid ""
 "In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
 "or col in the lists!\n"
 msgstr ""
 
-#: attrib/src/s_table.c:493
 #, c-format
 msgid "- Starting internal pin TABLE creation\n"
 msgstr ""
 
-#: attrib/src/s_table.c:553
 #, c-format
 msgid ""
 "In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
 "col in the lists!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:185
 msgid "_cancel"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:318
 #, c-format
 msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:554
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
 "the master list!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:582
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:891
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
 "missing!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:900
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
 "master list!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:928
 #, c-format
 msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:74
 msgid "Add new attribute"
 msgstr ""
 
-#: attrib/src/x_dialog.c:83
 msgid "Enter new attribute name"
 msgstr ""
 
-#: attrib/src/x_dialog.c:147
 msgid "Are you sure you want to delete this attribute?"
 msgstr ""
 
-#: attrib/src/x_dialog.c:149
 msgid "Delete attribute"
 msgstr ""
 
-#: attrib/src/x_dialog.c:174
 msgid ""
 "One or more components have been found with missing symbol files!\n"
 "\n"
@@ -260,31 +221,24 @@ msgid ""
 "\"Forward\" to continue working with lepton-attrib.\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:187
 msgid "Missing symbol file found for component!"
 msgstr ""
 
-#: attrib/src/x_dialog.c:214
 msgid "Save the changes before closing?"
 msgstr ""
 
-#: attrib/src/x_dialog.c:215
 msgid "<big><b>"
 msgstr ""
 
-#: attrib/src/x_dialog.c:215
 msgid "</b></big>"
 msgstr ""
 
-#: attrib/src/x_dialog.c:217
 msgid "If you don't save, all your changes will be permanently lost."
 msgstr ""
 
-#: attrib/src/x_dialog.c:227
 msgid "Close without saving"
 msgstr ""
 
-#: attrib/src/x_dialog.c:274
 msgid ""
 "Sorry -- you have chosen a feature which has not been\n"
 "implemented yet.\n"
@@ -298,15 +252,12 @@ msgid ""
 "Otherwise, just hang tight -- I'll implement this feature soon!\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:282
 msgid "Unimplemented feature!"
 msgstr ""
 
-#: attrib/src/x_dialog.c:309
 msgid "Fatal error"
 msgstr ""
 
-#: attrib/src/x_dialog.c:324
 #, c-format
 msgid ""
 "Lepton Electronic Design Automation\n"
@@ -320,109 +271,84 @@ msgid ""
 "and gtkextra, as well as support from the gEDA community."
 msgstr ""
 
-#: attrib/src/x_dialog.c:335
 msgid "About..."
 msgstr ""
 
-#: attrib/src/x_dialog.c:351
 msgid "Export CSV"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:87
 msgid "Schematics"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:92
 msgid "Symbols"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:97
 msgid "Schematics and symbols"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:103
 msgid "All files"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:134
 #, c-format
 msgid "Loading file [%1$s]"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:140
 #, c-format
 msgid "Couldn't load schematic [%1$s]\n"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:230
 msgid "Open..."
 msgstr ""
 
-#: attrib/src/x_fileselect.c:275
 msgid "Save as..."
 msgstr ""
 
-#: attrib/src/x_fileselect.c:304
 #, c-format
 msgid "Saved As [%1$s]"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:314
 #, c-format
 msgid "Could NOT save [%1$s]"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:70 attrib/src/x_gtksheet.c:79
 msgid "Components"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:71 attrib/src/x_gtksheet.c:88
-#: attrib/src/x_gtksheet.c:91
 msgid "Nets"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:72 attrib/src/x_gtksheet.c:104
-#: attrib/src/x_gtksheet.c:107
 msgid "Pins"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:81
 msgid ""
 "No components found in design.  Please check your schematic and try again!\n"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:92 attrib/src/x_gtksheet.c:94
 msgid "TBD"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:355
 msgid "couldn't allocate color"
 msgstr ""
 
-#: attrib/src/x_window.c:94
 msgid "lepton-attrib - Lepton EDA attribute editor"
 msgstr ""
 
-#: attrib/src/x_window.c:299
 #, c-format
 msgid ""
 "Error loading %1$s:\n"
 "%2$s\n"
 msgstr ""
 
-#: attrib/src/x_window.c:337
 msgid ""
 "No components found in entire design!\n"
 "Do you have refdeses on your components?"
 msgstr ""
 
-#: attrib/src/x_window.c:342
 msgid ""
 "No configurable component attributes found in entire design!\n"
 "Please attach at least some attributes before running lepton-attrib."
 msgstr ""
 
-#: attrib/src/x_window.c:347
 msgid ""
 "No pins found on any components!\n"
 "Please check your design."

--- a/attrib/po/nl.po
+++ b/attrib/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-12 00:10+0300\n"
+"POT-Creation-Date: 2019-05-10 08:15+0300\n"
 "PO-Revision-Date: 2014-08-31 20:31+0100\n"
 "Last-Translator: Bert Timmerman <bert.timmerman@xs4all.nl>\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -20,40 +20,32 @@ msgstr ""
 "X-Poedit-Country: NETHERLANDS\n"
 "X-Poedit-Language: Dutch\n"
 
-#: attrib/data/lepton-attrib.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Attribute Editor"
 msgstr "gEDA Attribuut Editor"
 
-#: attrib/data/lepton-attrib.desktop.in:4
 #, fuzzy
 msgid "Manipulate component attributes with lepton-attrib"
 msgstr "Manipuleer componenten attributen met gattrib"
 
-#: attrib/src/f_export.c:82
 #, fuzzy, c-format
 msgid "o_save: Could not open [%1$s]"
 msgstr "o_save: Kan [%s] niet openen\n"
 
-#: attrib/src/lepton-attrib.c:160
 #, c-format
 msgid "Lepton EDA/lepton-attrib version %1$s%2$s.%3$s git: %4$.7s"
 msgstr ""
 
-#: attrib/src/lepton-attrib.c:196
 #, fuzzy, c-format
 msgid "Couldn't find file [%1$s]\n"
 msgstr "Kan bestand [%s] niet vinden\n"
 
-#: attrib/src/gtksheet_2_2.c:6302
 msgid "Entry type must be GtkEntry subclass, using default"
 msgstr "Invoer type moet een GtkEntry subklasse zijn, gebruik de standaard"
 
-#: attrib/src/gtksheet_2_2.c:8499
 msgid "Widget must be a GtkSheet child"
 msgstr "Widget moet een kind van GtkSheet zijn"
 
-#: attrib/src/parsecmd.c:73
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -113,14 +105,12 @@ msgstr ""
 "net.\n"
 "\n"
 
-#: attrib/src/s_attrib.c:101
 #, fuzzy, c-format
 msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 "WAARSCHUWING: uref=%s gevonden, uref= is vervallen, gebruik alstublieft "
 "refdes=\n"
 
-#: attrib/src/s_misc.c:81
 #, c-format
 msgid ""
 "\n"
@@ -129,12 +119,10 @@ msgstr ""
 "\n"
 "GEDAAN\n"
 
-#: attrib/src/s_misc.c:83
 #, c-format
 msgid " DONE\n"
 msgstr " GEDAAN\n"
 
-#: attrib/src/s_object.c:217
 #, fuzzy, c-format
 msgid ""
 "In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
@@ -143,7 +131,6 @@ msgstr ""
 "In s_object_replace_attrib_in_object, is gefaald om attrib %s te vinden in "
 "de component.  Afsluiten . . .\n"
 
-#: attrib/src/s_object.c:276
 #, fuzzy, c-format
 msgid ""
 "In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
@@ -152,7 +139,6 @@ msgstr ""
 "In s_object_remove_attrib_in_object, is gefaald om attrib %s in de component "
 "te vinden.  Afsluiten . . .\n"
 
-#: attrib/src/s_object.c:329
 #, c-format
 msgid ""
 "In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
@@ -161,22 +147,18 @@ msgstr ""
 "In s_object_attrib_add_attrib_in_object, geprobeerd om attrib toe te voegen "
 "aan een non-complex of niet-net!\n"
 
-#: attrib/src/s_sheet_data.c:116
 #, c-format
 msgid "- Starting master comp list creation.\n"
 msgstr "- Start het aanmaken van de hoofdcomponentenlijst.\n"
 
-#: attrib/src/s_sheet_data.c:184
 #, c-format
 msgid "- Starting master comp attrib list creation.\n"
 msgstr "- Start het aanmaken van de hoofdattributenlijst.\n"
 
-#: attrib/src/s_sheet_data.c:297
 #, c-format
 msgid "- Starting master pin list creation.\n"
 msgstr "- Start het aanmaken van de hoofdpennenlijst.\n"
 
-#: attrib/src/s_sheet_data.c:331
 #, c-format
 msgid ""
 "In s_sheet_data_add_master_pin_list_items, found component pin with no "
@@ -185,30 +167,25 @@ msgstr ""
 "In s_sheet_data_add_master_pin_list_items, is een component pen zonder "
 "pennummer gevonden.\n"
 
-#: attrib/src/s_sheet_data.c:389
 #, c-format
 msgid "- Starting master pin attrib list creation.\n"
 msgstr "- Start het aanmaken van de hoofdpennenattributenlijst.\n"
 
-#: attrib/src/s_string_list.c:123
 #, c-format
 msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
 msgstr ""
 "In s_string_list_add_item, is geprobeerd toe te voegen aan een NULL lijst.\n"
 
-#: attrib/src/s_string_list.c:188
 #, c-format
 msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
 msgstr ""
 "In s_string_list_delete_item, is geprobeerd om een item te verwijderen van "
 "een lege lijst\n"
 
-#: attrib/src/s_string_list.c:252
 #, c-format
 msgid "In s_string_list_delete_item, couldn't delete item %s\n"
 msgstr "In s_string_list_delete_item, kan item %s niet verwijderen\n"
 
-#: attrib/src/s_table.c:242
 #, c-format
 msgid ""
 "In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
@@ -216,12 +193,10 @@ msgstr ""
 "In s_table_create_attrib_pair, is de naam van de regel niet gevonden in de "
 "lijst met regels!\n"
 
-#: attrib/src/s_table.c:285
 #, c-format
 msgid "- Starting internal component TABLE creation\n"
 msgstr "- Start het aanmaken van de interne componenten TABEL.\n"
 
-#: attrib/src/s_table.c:344
 #, c-format
 msgid ""
 "In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
@@ -230,12 +205,10 @@ msgstr ""
 "In s_table_add_toplevel_comp_items_to_comp_table, is geen regel of kolom "
 "gevonden in de lijsten!\n"
 
-#: attrib/src/s_table.c:493
 #, c-format
 msgid "- Starting internal pin TABLE creation\n"
 msgstr "- Start het aanmaken van de interne pennen TABEL.\n"
 
-#: attrib/src/s_table.c:553
 #, c-format
 msgid ""
 "In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
@@ -244,16 +217,13 @@ msgstr ""
 "In s_table_add_toplevel_pin_items_to_pin_table, is noch regel noch kolom "
 "gevonden in de lijsten!\n"
 
-#: attrib/src/s_toplevel.c:185
 msgid "_cancel"
 msgstr "_afbreken"
 
-#: attrib/src/s_toplevel.c:318
 #, c-format
 msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
 msgstr "In s_toplevel_delete_attrib_col, kan geen attrib naam krijgen\n"
 
-#: attrib/src/s_toplevel.c:554
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
@@ -262,7 +232,6 @@ msgstr ""
 "In s_toplevel_get_component_attribs_in_sheet, geen refdes gevonden in de "
 "hoofdlijst!\n"
 
-#: attrib/src/s_toplevel.c:582
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
@@ -270,7 +239,6 @@ msgstr ""
 "In s_toplevel_get_component_attribs_in_sheet, count != i!  "
 "Afsluiten . . . .\n"
 
-#: attrib/src/s_toplevel.c:891
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
@@ -279,7 +247,6 @@ msgstr ""
 "In s_toplevel_get_pin_attribs_in_sheet, ofwel een refdes of een pennummer "
 "van het object ontbreken!\n"
 
-#: attrib/src/s_toplevel.c:900
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
@@ -288,29 +255,23 @@ msgstr ""
 "In s_toplevel_get_pin_attribs_in_sheet, is geen refdes:pin gevonden in de "
 "hoofdlijst!\n"
 
-#: attrib/src/s_toplevel.c:928
 #, c-format
 msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr ""
 "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Afsluiten . . . .\n"
 
-#: attrib/src/x_dialog.c:74
 msgid "Add new attribute"
 msgstr "Voeg nieuwe attribuut toe"
 
-#: attrib/src/x_dialog.c:83
 msgid "Enter new attribute name"
 msgstr "Voer nieuwe attribuutnaam toe"
 
-#: attrib/src/x_dialog.c:147
 msgid "Are you sure you want to delete this attribute?"
 msgstr "Bent U zeker dat U deze attribuut wil verwijderen?"
 
-#: attrib/src/x_dialog.c:149
 msgid "Delete attribute"
 msgstr "Verwijder attribuut"
 
-#: attrib/src/x_dialog.c:174
 #, fuzzy
 msgid ""
 "One or more components have been found with missing symbol files!\n"
@@ -330,31 +291,24 @@ msgstr ""
 "Kies \"Quit\" om gattrib te verlaten en het probleem op te lossen, of\n"
 "\"Forward\" om door te gaan met werken met gattrib.\n"
 
-#: attrib/src/x_dialog.c:187
 msgid "Missing symbol file found for component!"
 msgstr "Ontbrekende symbool voor component gevonden!"
 
-#: attrib/src/x_dialog.c:214
 msgid "Save the changes before closing?"
 msgstr "Sla de wijzigingen op voor het afsluiten?"
 
-#: attrib/src/x_dialog.c:215
 msgid "<big><b>"
 msgstr "<big><b>"
 
-#: attrib/src/x_dialog.c:215
 msgid "</b></big>"
 msgstr "</b></big>"
 
-#: attrib/src/x_dialog.c:217
 msgid "If you don't save, all your changes will be permanently lost."
 msgstr "Als je niet opslaat, zullen alle veranderingen verloren gaan."
 
-#: attrib/src/x_dialog.c:227
 msgid "Close without saving"
 msgstr "Afsluiten zonder opslaan"
 
-#: attrib/src/x_dialog.c:274
 #, fuzzy
 msgid ""
 "Sorry -- you have chosen a feature which has not been\n"
@@ -379,15 +333,12 @@ msgstr ""
 "\n"
 "Of anders, hou je vast -- implementeer ik deze opties snel!\n"
 
-#: attrib/src/x_dialog.c:282
 msgid "Unimplemented feature!"
 msgstr "Niet geïmplementeerde functie"
 
-#: attrib/src/x_dialog.c:309
 msgid "Fatal error"
 msgstr "Fatale fout"
 
-#: attrib/src/x_dialog.c:324
 #, fuzzy, c-format
 msgid ""
 "Lepton Electronic Design Automation\n"
@@ -410,93 +361,71 @@ msgstr ""
 "met genereuze programmacodebijdragen van gschem, gnetlist, \n"
 "en gtkextra, en ook ondersteuning van de gEDA gemeenschap."
 
-#: attrib/src/x_dialog.c:335
 msgid "About..."
 msgstr "Over..."
 
-#: attrib/src/x_dialog.c:351
 msgid "Export CSV"
 msgstr "Exporteer CSV"
 
-#: attrib/src/x_fileselect.c:87
 msgid "Schematics"
 msgstr "Schema's"
 
-#: attrib/src/x_fileselect.c:92
 msgid "Symbols"
 msgstr "Symbolen"
 
-#: attrib/src/x_fileselect.c:97
 msgid "Schematics and symbols"
 msgstr "Schema's en symbolen"
 
-#: attrib/src/x_fileselect.c:103
 msgid "All files"
 msgstr "Alle bestanden"
 
-#: attrib/src/x_fileselect.c:134
 #, fuzzy, c-format
 msgid "Loading file [%1$s]"
 msgstr "Laad bestand [%s]\n"
 
-#: attrib/src/x_fileselect.c:140
 #, fuzzy, c-format
 msgid "Couldn't load schematic [%1$s]\n"
 msgstr "Kon schema [%s] niet laden\n"
 
-#: attrib/src/x_fileselect.c:230
 msgid "Open..."
 msgstr "Open..."
 
-#: attrib/src/x_fileselect.c:275
 msgid "Save as..."
 msgstr "Opslaan als..."
 
-#: attrib/src/x_fileselect.c:304
 #, fuzzy, c-format
 msgid "Saved As [%1$s]"
 msgstr "Opgeslagen Als [%s]\n"
 
-#: attrib/src/x_fileselect.c:314
 #, fuzzy, c-format
 msgid "Could NOT save [%1$s]"
 msgstr "Kan [%s] NIET opslaan\n"
 
-#: attrib/src/x_gtksheet.c:70 attrib/src/x_gtksheet.c:79
 msgid "Components"
 msgstr "Componenten"
 
-#: attrib/src/x_gtksheet.c:71 attrib/src/x_gtksheet.c:88
-#: attrib/src/x_gtksheet.c:91
 msgid "Nets"
 msgstr "Netten"
 
-#: attrib/src/x_gtksheet.c:72 attrib/src/x_gtksheet.c:104
-#: attrib/src/x_gtksheet.c:107
 msgid "Pins"
 msgstr "Pennen"
 
-#: attrib/src/x_gtksheet.c:81
 msgid ""
 "No components found in design.  Please check your schematic and try again!\n"
 msgstr ""
 "Geen componenten gevonden in het ontwerp. Controleer alstublieft uw schema "
 "en probeer opnieuw!\n"
 
-#: attrib/src/x_gtksheet.c:92 attrib/src/x_gtksheet.c:94
 msgid "TBD"
 msgstr "NTD"
 
-#: attrib/src/x_gtksheet.c:355
 msgid "couldn't allocate color"
 msgstr "kan geen kleur toewijzen"
 
-#: attrib/src/x_window.c:94
 #, fuzzy
 msgid "lepton-attrib - Lepton EDA attribute editor"
 msgstr "gattrib -- gEDA attribuut editor"
 
-#: attrib/src/x_window.c:299
 #, fuzzy, c-format
 msgid ""
 "Error loading %1$s:\n"
@@ -505,7 +434,6 @@ msgstr ""
 "Fout tijdens laden %s:\n"
 "%s\n"
 
-#: attrib/src/x_window.c:337
 msgid ""
 "No components found in entire design!\n"
 "Do you have refdeses on your components?"
@@ -513,7 +441,6 @@ msgstr ""
 "Geen componenten gevonden in het gehele ontwerp!\n"
 "Heeft U wel refdeses aan Uw componenten?"
 
-#: attrib/src/x_window.c:342
 #, fuzzy
 msgid ""
 "No configurable component attributes found in entire design!\n"
@@ -522,7 +449,6 @@ msgstr ""
 "Geen configureerbare component attributen gevonden in het gehele ontwerp!\n"
 "Bevestig alstublieft ten minste enige attributen voor gattrib te starten. "
 
-#: attrib/src/x_window.c:347
 msgid ""
 "No pins found on any components!\n"
 "Please check your design."

--- a/attrib/po/oc.po
+++ b/attrib/po/oc.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-12 00:10+0300\n"
+"POT-Creation-Date: 2019-05-10 08:15+0300\n"
 "PO-Revision-Date: 2012-01-27 14:17+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: Occitan (post 1500) <oc@li.org>\n"
@@ -18,40 +18,32 @@ msgstr ""
 "X-Launchpad-Export-Date: 2012-11-14 16:52+0000\n"
 "X-Generator: Launchpad (build 16265)\n"
 
-#: attrib/data/lepton-attrib.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Attribute Editor"
 msgstr "Editor d'atributs gEDA"
 
-#: attrib/data/lepton-attrib.desktop.in:4
 #, fuzzy
 msgid "Manipulate component attributes with lepton-attrib"
 msgstr "Manipular los atributs dels components amb gattrib"
 
-#: attrib/src/f_export.c:82
 #, c-format
 msgid "o_save: Could not open [%1$s]"
 msgstr ""
 
-#: attrib/src/lepton-attrib.c:160
 #, c-format
 msgid "Lepton EDA/lepton-attrib version %1$s%2$s.%3$s git: %4$.7s"
 msgstr ""
 
-#: attrib/src/lepton-attrib.c:196
 #, c-format
 msgid "Couldn't find file [%1$s]\n"
 msgstr ""
 
-#: attrib/src/gtksheet_2_2.c:6302
 msgid "Entry type must be GtkEntry subclass, using default"
 msgstr ""
 
-#: attrib/src/gtksheet_2_2.c:8499
 msgid "Widget must be a GtkSheet child"
 msgstr ""
 
-#: attrib/src/parsecmd.c:73
 #, c-format
 msgid ""
 "\n"
@@ -83,174 +75,143 @@ msgid ""
 "Please report bugs to %2$s.\n"
 msgstr ""
 
-#: attrib/src/s_attrib.c:101
 #, c-format
 msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 
-#: attrib/src/s_misc.c:81
 #, c-format
 msgid ""
 "\n"
 "DONE\n"
 msgstr ""
 
-#: attrib/src/s_misc.c:83
 #, c-format
 msgid " DONE\n"
 msgstr ""
 
-#: attrib/src/s_object.c:217
 #, c-format
 msgid ""
 "In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
 "on the component.  Exiting . . .\n"
 msgstr ""
 
-#: attrib/src/s_object.c:276
 #, c-format
 msgid ""
 "In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
 "on the component.  Exiting . . .\n"
 msgstr ""
 
-#: attrib/src/s_object.c:329
 #, c-format
 msgid ""
 "In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
 "or non-net!\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:116
 #, c-format
 msgid "- Starting master comp list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:184
 #, c-format
 msgid "- Starting master comp attrib list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:297
 #, c-format
 msgid "- Starting master pin list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:331
 #, c-format
 msgid ""
 "In s_sheet_data_add_master_pin_list_items, found component pin with no "
 "pinnumber.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:389
 #, c-format
 msgid "- Starting master pin attrib list creation.\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:123
 #, c-format
 msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:188
 #, c-format
 msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:252
 #, c-format
 msgid "In s_string_list_delete_item, couldn't delete item %s\n"
 msgstr ""
 
-#: attrib/src/s_table.c:242
 #, c-format
 msgid ""
 "In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
 msgstr ""
 
-#: attrib/src/s_table.c:285
 #, c-format
 msgid "- Starting internal component TABLE creation\n"
 msgstr ""
 
-#: attrib/src/s_table.c:344
 #, c-format
 msgid ""
 "In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
 "or col in the lists!\n"
 msgstr ""
 
-#: attrib/src/s_table.c:493
 #, c-format
 msgid "- Starting internal pin TABLE creation\n"
 msgstr ""
 
-#: attrib/src/s_table.c:553
 #, c-format
 msgid ""
 "In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
 "col in the lists!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:185
 msgid "_cancel"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:318
 #, c-format
 msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:554
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
 "the master list!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:582
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:891
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
 "missing!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:900
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
 "master list!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:928
 #, c-format
 msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:74
 msgid "Add new attribute"
 msgstr ""
 
-#: attrib/src/x_dialog.c:83
 msgid "Enter new attribute name"
 msgstr ""
 
-#: attrib/src/x_dialog.c:147
 msgid "Are you sure you want to delete this attribute?"
 msgstr ""
 
-#: attrib/src/x_dialog.c:149
 msgid "Delete attribute"
 msgstr ""
 
-#: attrib/src/x_dialog.c:174
 msgid ""
 "One or more components have been found with missing symbol files!\n"
 "\n"
@@ -261,31 +222,24 @@ msgid ""
 "\"Forward\" to continue working with lepton-attrib.\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:187
 msgid "Missing symbol file found for component!"
 msgstr ""
 
-#: attrib/src/x_dialog.c:214
 msgid "Save the changes before closing?"
 msgstr ""
 
-#: attrib/src/x_dialog.c:215
 msgid "<big><b>"
 msgstr ""
 
-#: attrib/src/x_dialog.c:215
 msgid "</b></big>"
 msgstr ""
 
-#: attrib/src/x_dialog.c:217
 msgid "If you don't save, all your changes will be permanently lost."
 msgstr ""
 
-#: attrib/src/x_dialog.c:227
 msgid "Close without saving"
 msgstr ""
 
-#: attrib/src/x_dialog.c:274
 msgid ""
 "Sorry -- you have chosen a feature which has not been\n"
 "implemented yet.\n"
@@ -299,15 +253,12 @@ msgid ""
 "Otherwise, just hang tight -- I'll implement this feature soon!\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:282
 msgid "Unimplemented feature!"
 msgstr ""
 
-#: attrib/src/x_dialog.c:309
 msgid "Fatal error"
 msgstr ""
 
-#: attrib/src/x_dialog.c:324
 #, c-format
 msgid ""
 "Lepton Electronic Design Automation\n"
@@ -321,110 +272,85 @@ msgid ""
 "and gtkextra, as well as support from the gEDA community."
 msgstr ""
 
-#: attrib/src/x_dialog.c:335
 msgid "About..."
 msgstr ""
 
-#: attrib/src/x_dialog.c:351
 msgid "Export CSV"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:87
 msgid "Schematics"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:92
 msgid "Symbols"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:97
 msgid "Schematics and symbols"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:103
 msgid "All files"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:134
 #, c-format
 msgid "Loading file [%1$s]"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:140
 #, c-format
 msgid "Couldn't load schematic [%1$s]\n"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:230
 msgid "Open..."
 msgstr ""
 
-#: attrib/src/x_fileselect.c:275
 msgid "Save as..."
 msgstr ""
 
-#: attrib/src/x_fileselect.c:304
 #, c-format
 msgid "Saved As [%1$s]"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:314
 #, c-format
 msgid "Could NOT save [%1$s]"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:70 attrib/src/x_gtksheet.c:79
 msgid "Components"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:71 attrib/src/x_gtksheet.c:88
-#: attrib/src/x_gtksheet.c:91
 msgid "Nets"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:72 attrib/src/x_gtksheet.c:104
-#: attrib/src/x_gtksheet.c:107
 msgid "Pins"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:81
 msgid ""
 "No components found in design.  Please check your schematic and try again!\n"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:92 attrib/src/x_gtksheet.c:94
 msgid "TBD"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:355
 msgid "couldn't allocate color"
 msgstr ""
 
-#: attrib/src/x_window.c:94
 #, fuzzy
 msgid "lepton-attrib - Lepton EDA attribute editor"
 msgstr "Editor d'atributs gEDA"
 
-#: attrib/src/x_window.c:299
 #, c-format
 msgid ""
 "Error loading %1$s:\n"
 "%2$s\n"
 msgstr ""
 
-#: attrib/src/x_window.c:337
 msgid ""
 "No components found in entire design!\n"
 "Do you have refdeses on your components?"
 msgstr ""
 
-#: attrib/src/x_window.c:342
 msgid ""
 "No configurable component attributes found in entire design!\n"
 "Please attach at least some attributes before running lepton-attrib."
 msgstr ""
 
-#: attrib/src/x_window.c:347
 msgid ""
 "No pins found on any components!\n"
 "Please check your design."

--- a/attrib/po/pl.po
+++ b/attrib/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-12 00:10+0300\n"
+"POT-Creation-Date: 2019-05-10 08:15+0300\n"
 "PO-Revision-Date: 2010-02-06 22:09+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -18,40 +18,32 @@ msgstr ""
 "X-Launchpad-Export-Date: 2010-02-14 12:56+0000\n"
 "X-Generator: Launchpad (build Unknown)\n"
 
-#: attrib/data/lepton-attrib.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Attribute Editor"
 msgstr "gEDA Edytor atrybutów"
 
-#: attrib/data/lepton-attrib.desktop.in:4
 #, fuzzy
 msgid "Manipulate component attributes with lepton-attrib"
 msgstr "Edytuj atrybuty elementów za pomocą gattrib"
 
-#: attrib/src/f_export.c:82
 #, c-format
 msgid "o_save: Could not open [%1$s]"
 msgstr ""
 
-#: attrib/src/lepton-attrib.c:160
 #, c-format
 msgid "Lepton EDA/lepton-attrib version %1$s%2$s.%3$s git: %4$.7s"
 msgstr ""
 
-#: attrib/src/lepton-attrib.c:196
 #, c-format
 msgid "Couldn't find file [%1$s]\n"
 msgstr ""
 
-#: attrib/src/gtksheet_2_2.c:6302
 msgid "Entry type must be GtkEntry subclass, using default"
 msgstr ""
 
-#: attrib/src/gtksheet_2_2.c:8499
 msgid "Widget must be a GtkSheet child"
 msgstr ""
 
-#: attrib/src/parsecmd.c:73
 #, c-format
 msgid ""
 "\n"
@@ -83,174 +75,143 @@ msgid ""
 "Please report bugs to %2$s.\n"
 msgstr ""
 
-#: attrib/src/s_attrib.c:101
 #, c-format
 msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 
-#: attrib/src/s_misc.c:81
 #, c-format
 msgid ""
 "\n"
 "DONE\n"
 msgstr ""
 
-#: attrib/src/s_misc.c:83
 #, c-format
 msgid " DONE\n"
 msgstr ""
 
-#: attrib/src/s_object.c:217
 #, c-format
 msgid ""
 "In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
 "on the component.  Exiting . . .\n"
 msgstr ""
 
-#: attrib/src/s_object.c:276
 #, c-format
 msgid ""
 "In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
 "on the component.  Exiting . . .\n"
 msgstr ""
 
-#: attrib/src/s_object.c:329
 #, c-format
 msgid ""
 "In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
 "or non-net!\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:116
 #, c-format
 msgid "- Starting master comp list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:184
 #, c-format
 msgid "- Starting master comp attrib list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:297
 #, c-format
 msgid "- Starting master pin list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:331
 #, c-format
 msgid ""
 "In s_sheet_data_add_master_pin_list_items, found component pin with no "
 "pinnumber.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:389
 #, c-format
 msgid "- Starting master pin attrib list creation.\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:123
 #, c-format
 msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:188
 #, c-format
 msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:252
 #, c-format
 msgid "In s_string_list_delete_item, couldn't delete item %s\n"
 msgstr ""
 
-#: attrib/src/s_table.c:242
 #, c-format
 msgid ""
 "In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
 msgstr ""
 
-#: attrib/src/s_table.c:285
 #, c-format
 msgid "- Starting internal component TABLE creation\n"
 msgstr ""
 
-#: attrib/src/s_table.c:344
 #, c-format
 msgid ""
 "In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
 "or col in the lists!\n"
 msgstr ""
 
-#: attrib/src/s_table.c:493
 #, c-format
 msgid "- Starting internal pin TABLE creation\n"
 msgstr ""
 
-#: attrib/src/s_table.c:553
 #, c-format
 msgid ""
 "In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
 "col in the lists!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:185
 msgid "_cancel"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:318
 #, c-format
 msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:554
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
 "the master list!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:582
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:891
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
 "missing!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:900
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
 "master list!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:928
 #, c-format
 msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:74
 msgid "Add new attribute"
 msgstr ""
 
-#: attrib/src/x_dialog.c:83
 msgid "Enter new attribute name"
 msgstr ""
 
-#: attrib/src/x_dialog.c:147
 msgid "Are you sure you want to delete this attribute?"
 msgstr ""
 
-#: attrib/src/x_dialog.c:149
 msgid "Delete attribute"
 msgstr ""
 
-#: attrib/src/x_dialog.c:174
 msgid ""
 "One or more components have been found with missing symbol files!\n"
 "\n"
@@ -261,31 +222,24 @@ msgid ""
 "\"Forward\" to continue working with lepton-attrib.\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:187
 msgid "Missing symbol file found for component!"
 msgstr ""
 
-#: attrib/src/x_dialog.c:214
 msgid "Save the changes before closing?"
 msgstr ""
 
-#: attrib/src/x_dialog.c:215
 msgid "<big><b>"
 msgstr ""
 
-#: attrib/src/x_dialog.c:215
 msgid "</b></big>"
 msgstr ""
 
-#: attrib/src/x_dialog.c:217
 msgid "If you don't save, all your changes will be permanently lost."
 msgstr ""
 
-#: attrib/src/x_dialog.c:227
 msgid "Close without saving"
 msgstr ""
 
-#: attrib/src/x_dialog.c:274
 msgid ""
 "Sorry -- you have chosen a feature which has not been\n"
 "implemented yet.\n"
@@ -299,15 +253,12 @@ msgid ""
 "Otherwise, just hang tight -- I'll implement this feature soon!\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:282
 msgid "Unimplemented feature!"
 msgstr ""
 
-#: attrib/src/x_dialog.c:309
 msgid "Fatal error"
 msgstr ""
 
-#: attrib/src/x_dialog.c:324
 #, c-format
 msgid ""
 "Lepton Electronic Design Automation\n"
@@ -321,110 +272,85 @@ msgid ""
 "and gtkextra, as well as support from the gEDA community."
 msgstr ""
 
-#: attrib/src/x_dialog.c:335
 msgid "About..."
 msgstr ""
 
-#: attrib/src/x_dialog.c:351
 msgid "Export CSV"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:87
 msgid "Schematics"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:92
 msgid "Symbols"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:97
 msgid "Schematics and symbols"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:103
 msgid "All files"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:134
 #, c-format
 msgid "Loading file [%1$s]"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:140
 #, c-format
 msgid "Couldn't load schematic [%1$s]\n"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:230
 msgid "Open..."
 msgstr ""
 
-#: attrib/src/x_fileselect.c:275
 msgid "Save as..."
 msgstr ""
 
-#: attrib/src/x_fileselect.c:304
 #, c-format
 msgid "Saved As [%1$s]"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:314
 #, c-format
 msgid "Could NOT save [%1$s]"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:70 attrib/src/x_gtksheet.c:79
 msgid "Components"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:71 attrib/src/x_gtksheet.c:88
-#: attrib/src/x_gtksheet.c:91
 msgid "Nets"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:72 attrib/src/x_gtksheet.c:104
-#: attrib/src/x_gtksheet.c:107
 msgid "Pins"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:81
 msgid ""
 "No components found in design.  Please check your schematic and try again!\n"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:92 attrib/src/x_gtksheet.c:94
 msgid "TBD"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:355
 msgid "couldn't allocate color"
 msgstr ""
 
-#: attrib/src/x_window.c:94
 #, fuzzy
 msgid "lepton-attrib - Lepton EDA attribute editor"
 msgstr "gEDA Edytor atrybutów"
 
-#: attrib/src/x_window.c:299
 #, c-format
 msgid ""
 "Error loading %1$s:\n"
 "%2$s\n"
 msgstr ""
 
-#: attrib/src/x_window.c:337
 msgid ""
 "No components found in entire design!\n"
 "Do you have refdeses on your components?"
 msgstr ""
 
-#: attrib/src/x_window.c:342
 msgid ""
 "No configurable component attributes found in entire design!\n"
 "Please attach at least some attributes before running lepton-attrib."
 msgstr ""
 
-#: attrib/src/x_window.c:347
 msgid ""
 "No pins found on any components!\n"
 "Please check your design."

--- a/attrib/po/pt.po
+++ b/attrib/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-12 00:10+0300\n"
+"POT-Creation-Date: 2019-05-10 08:15+0300\n"
 "PO-Revision-Date: 2010-02-06 22:10+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -18,40 +18,32 @@ msgstr ""
 "X-Launchpad-Export-Date: 2010-02-14 12:56+0000\n"
 "X-Generator: Launchpad (build Unknown)\n"
 
-#: attrib/data/lepton-attrib.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Attribute Editor"
 msgstr "Editor de Atributos gEDA"
 
-#: attrib/data/lepton-attrib.desktop.in:4
 #, fuzzy
 msgid "Manipulate component attributes with lepton-attrib"
 msgstr "Manipular atributos dos componentes com gattrib"
 
-#: attrib/src/f_export.c:82
 #, c-format
 msgid "o_save: Could not open [%1$s]"
 msgstr ""
 
-#: attrib/src/lepton-attrib.c:160
 #, c-format
 msgid "Lepton EDA/lepton-attrib version %1$s%2$s.%3$s git: %4$.7s"
 msgstr ""
 
-#: attrib/src/lepton-attrib.c:196
 #, c-format
 msgid "Couldn't find file [%1$s]\n"
 msgstr ""
 
-#: attrib/src/gtksheet_2_2.c:6302
 msgid "Entry type must be GtkEntry subclass, using default"
 msgstr ""
 
-#: attrib/src/gtksheet_2_2.c:8499
 msgid "Widget must be a GtkSheet child"
 msgstr ""
 
-#: attrib/src/parsecmd.c:73
 #, c-format
 msgid ""
 "\n"
@@ -83,174 +75,143 @@ msgid ""
 "Please report bugs to %2$s.\n"
 msgstr ""
 
-#: attrib/src/s_attrib.c:101
 #, c-format
 msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 
-#: attrib/src/s_misc.c:81
 #, c-format
 msgid ""
 "\n"
 "DONE\n"
 msgstr ""
 
-#: attrib/src/s_misc.c:83
 #, c-format
 msgid " DONE\n"
 msgstr ""
 
-#: attrib/src/s_object.c:217
 #, c-format
 msgid ""
 "In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
 "on the component.  Exiting . . .\n"
 msgstr ""
 
-#: attrib/src/s_object.c:276
 #, c-format
 msgid ""
 "In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
 "on the component.  Exiting . . .\n"
 msgstr ""
 
-#: attrib/src/s_object.c:329
 #, c-format
 msgid ""
 "In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
 "or non-net!\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:116
 #, c-format
 msgid "- Starting master comp list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:184
 #, c-format
 msgid "- Starting master comp attrib list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:297
 #, c-format
 msgid "- Starting master pin list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:331
 #, c-format
 msgid ""
 "In s_sheet_data_add_master_pin_list_items, found component pin with no "
 "pinnumber.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:389
 #, c-format
 msgid "- Starting master pin attrib list creation.\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:123
 #, c-format
 msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:188
 #, c-format
 msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:252
 #, c-format
 msgid "In s_string_list_delete_item, couldn't delete item %s\n"
 msgstr ""
 
-#: attrib/src/s_table.c:242
 #, c-format
 msgid ""
 "In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
 msgstr ""
 
-#: attrib/src/s_table.c:285
 #, c-format
 msgid "- Starting internal component TABLE creation\n"
 msgstr ""
 
-#: attrib/src/s_table.c:344
 #, c-format
 msgid ""
 "In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
 "or col in the lists!\n"
 msgstr ""
 
-#: attrib/src/s_table.c:493
 #, c-format
 msgid "- Starting internal pin TABLE creation\n"
 msgstr ""
 
-#: attrib/src/s_table.c:553
 #, c-format
 msgid ""
 "In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
 "col in the lists!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:185
 msgid "_cancel"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:318
 #, c-format
 msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:554
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
 "the master list!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:582
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:891
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
 "missing!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:900
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
 "master list!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:928
 #, c-format
 msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:74
 msgid "Add new attribute"
 msgstr ""
 
-#: attrib/src/x_dialog.c:83
 msgid "Enter new attribute name"
 msgstr ""
 
-#: attrib/src/x_dialog.c:147
 msgid "Are you sure you want to delete this attribute?"
 msgstr ""
 
-#: attrib/src/x_dialog.c:149
 msgid "Delete attribute"
 msgstr ""
 
-#: attrib/src/x_dialog.c:174
 msgid ""
 "One or more components have been found with missing symbol files!\n"
 "\n"
@@ -261,31 +222,24 @@ msgid ""
 "\"Forward\" to continue working with lepton-attrib.\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:187
 msgid "Missing symbol file found for component!"
 msgstr ""
 
-#: attrib/src/x_dialog.c:214
 msgid "Save the changes before closing?"
 msgstr ""
 
-#: attrib/src/x_dialog.c:215
 msgid "<big><b>"
 msgstr ""
 
-#: attrib/src/x_dialog.c:215
 msgid "</b></big>"
 msgstr ""
 
-#: attrib/src/x_dialog.c:217
 msgid "If you don't save, all your changes will be permanently lost."
 msgstr ""
 
-#: attrib/src/x_dialog.c:227
 msgid "Close without saving"
 msgstr ""
 
-#: attrib/src/x_dialog.c:274
 msgid ""
 "Sorry -- you have chosen a feature which has not been\n"
 "implemented yet.\n"
@@ -299,15 +253,12 @@ msgid ""
 "Otherwise, just hang tight -- I'll implement this feature soon!\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:282
 msgid "Unimplemented feature!"
 msgstr ""
 
-#: attrib/src/x_dialog.c:309
 msgid "Fatal error"
 msgstr ""
 
-#: attrib/src/x_dialog.c:324
 #, c-format
 msgid ""
 "Lepton Electronic Design Automation\n"
@@ -321,110 +272,85 @@ msgid ""
 "and gtkextra, as well as support from the gEDA community."
 msgstr ""
 
-#: attrib/src/x_dialog.c:335
 msgid "About..."
 msgstr ""
 
-#: attrib/src/x_dialog.c:351
 msgid "Export CSV"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:87
 msgid "Schematics"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:92
 msgid "Symbols"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:97
 msgid "Schematics and symbols"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:103
 msgid "All files"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:134
 #, c-format
 msgid "Loading file [%1$s]"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:140
 #, c-format
 msgid "Couldn't load schematic [%1$s]\n"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:230
 msgid "Open..."
 msgstr ""
 
-#: attrib/src/x_fileselect.c:275
 msgid "Save as..."
 msgstr ""
 
-#: attrib/src/x_fileselect.c:304
 #, c-format
 msgid "Saved As [%1$s]"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:314
 #, c-format
 msgid "Could NOT save [%1$s]"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:70 attrib/src/x_gtksheet.c:79
 msgid "Components"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:71 attrib/src/x_gtksheet.c:88
-#: attrib/src/x_gtksheet.c:91
 msgid "Nets"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:72 attrib/src/x_gtksheet.c:104
-#: attrib/src/x_gtksheet.c:107
 msgid "Pins"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:81
 msgid ""
 "No components found in design.  Please check your schematic and try again!\n"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:92 attrib/src/x_gtksheet.c:94
 msgid "TBD"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:355
 msgid "couldn't allocate color"
 msgstr ""
 
-#: attrib/src/x_window.c:94
 #, fuzzy
 msgid "lepton-attrib - Lepton EDA attribute editor"
 msgstr "Editor de Atributos gEDA"
 
-#: attrib/src/x_window.c:299
 #, c-format
 msgid ""
 "Error loading %1$s:\n"
 "%2$s\n"
 msgstr ""
 
-#: attrib/src/x_window.c:337
 msgid ""
 "No components found in entire design!\n"
 "Do you have refdeses on your components?"
 msgstr ""
 
-#: attrib/src/x_window.c:342
 msgid ""
 "No configurable component attributes found in entire design!\n"
 "Please attach at least some attributes before running lepton-attrib."
 msgstr ""
 
-#: attrib/src/x_window.c:347
 msgid ""
 "No pins found on any components!\n"
 "Please check your design."

--- a/attrib/po/pt_BR.po
+++ b/attrib/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-12 00:10+0300\n"
+"POT-Creation-Date: 2019-05-10 08:15+0300\n"
 "PO-Revision-Date: 2010-02-06 22:10+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -18,40 +18,32 @@ msgstr ""
 "X-Launchpad-Export-Date: 2010-02-14 12:56+0000\n"
 "X-Generator: Launchpad (build Unknown)\n"
 
-#: attrib/data/lepton-attrib.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Attribute Editor"
 msgstr "Editor de atributos gEDA"
 
-#: attrib/data/lepton-attrib.desktop.in:4
 #, fuzzy
 msgid "Manipulate component attributes with lepton-attrib"
 msgstr "Manipule os atributos dos componentes com o gattrib"
 
-#: attrib/src/f_export.c:82
 #, c-format
 msgid "o_save: Could not open [%1$s]"
 msgstr ""
 
-#: attrib/src/lepton-attrib.c:160
 #, c-format
 msgid "Lepton EDA/lepton-attrib version %1$s%2$s.%3$s git: %4$.7s"
 msgstr ""
 
-#: attrib/src/lepton-attrib.c:196
 #, c-format
 msgid "Couldn't find file [%1$s]\n"
 msgstr ""
 
-#: attrib/src/gtksheet_2_2.c:6302
 msgid "Entry type must be GtkEntry subclass, using default"
 msgstr ""
 
-#: attrib/src/gtksheet_2_2.c:8499
 msgid "Widget must be a GtkSheet child"
 msgstr ""
 
-#: attrib/src/parsecmd.c:73
 #, c-format
 msgid ""
 "\n"
@@ -83,174 +75,143 @@ msgid ""
 "Please report bugs to %2$s.\n"
 msgstr ""
 
-#: attrib/src/s_attrib.c:101
 #, c-format
 msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 
-#: attrib/src/s_misc.c:81
 #, c-format
 msgid ""
 "\n"
 "DONE\n"
 msgstr ""
 
-#: attrib/src/s_misc.c:83
 #, c-format
 msgid " DONE\n"
 msgstr ""
 
-#: attrib/src/s_object.c:217
 #, c-format
 msgid ""
 "In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
 "on the component.  Exiting . . .\n"
 msgstr ""
 
-#: attrib/src/s_object.c:276
 #, c-format
 msgid ""
 "In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
 "on the component.  Exiting . . .\n"
 msgstr ""
 
-#: attrib/src/s_object.c:329
 #, c-format
 msgid ""
 "In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
 "or non-net!\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:116
 #, c-format
 msgid "- Starting master comp list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:184
 #, c-format
 msgid "- Starting master comp attrib list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:297
 #, c-format
 msgid "- Starting master pin list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:331
 #, c-format
 msgid ""
 "In s_sheet_data_add_master_pin_list_items, found component pin with no "
 "pinnumber.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:389
 #, c-format
 msgid "- Starting master pin attrib list creation.\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:123
 #, c-format
 msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:188
 #, c-format
 msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:252
 #, c-format
 msgid "In s_string_list_delete_item, couldn't delete item %s\n"
 msgstr ""
 
-#: attrib/src/s_table.c:242
 #, c-format
 msgid ""
 "In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
 msgstr ""
 
-#: attrib/src/s_table.c:285
 #, c-format
 msgid "- Starting internal component TABLE creation\n"
 msgstr ""
 
-#: attrib/src/s_table.c:344
 #, c-format
 msgid ""
 "In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
 "or col in the lists!\n"
 msgstr ""
 
-#: attrib/src/s_table.c:493
 #, c-format
 msgid "- Starting internal pin TABLE creation\n"
 msgstr ""
 
-#: attrib/src/s_table.c:553
 #, c-format
 msgid ""
 "In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
 "col in the lists!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:185
 msgid "_cancel"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:318
 #, c-format
 msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:554
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
 "the master list!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:582
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:891
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
 "missing!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:900
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
 "master list!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:928
 #, c-format
 msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:74
 msgid "Add new attribute"
 msgstr ""
 
-#: attrib/src/x_dialog.c:83
 msgid "Enter new attribute name"
 msgstr ""
 
-#: attrib/src/x_dialog.c:147
 msgid "Are you sure you want to delete this attribute?"
 msgstr ""
 
-#: attrib/src/x_dialog.c:149
 msgid "Delete attribute"
 msgstr ""
 
-#: attrib/src/x_dialog.c:174
 msgid ""
 "One or more components have been found with missing symbol files!\n"
 "\n"
@@ -261,31 +222,24 @@ msgid ""
 "\"Forward\" to continue working with lepton-attrib.\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:187
 msgid "Missing symbol file found for component!"
 msgstr ""
 
-#: attrib/src/x_dialog.c:214
 msgid "Save the changes before closing?"
 msgstr ""
 
-#: attrib/src/x_dialog.c:215
 msgid "<big><b>"
 msgstr ""
 
-#: attrib/src/x_dialog.c:215
 msgid "</b></big>"
 msgstr ""
 
-#: attrib/src/x_dialog.c:217
 msgid "If you don't save, all your changes will be permanently lost."
 msgstr ""
 
-#: attrib/src/x_dialog.c:227
 msgid "Close without saving"
 msgstr ""
 
-#: attrib/src/x_dialog.c:274
 msgid ""
 "Sorry -- you have chosen a feature which has not been\n"
 "implemented yet.\n"
@@ -299,15 +253,12 @@ msgid ""
 "Otherwise, just hang tight -- I'll implement this feature soon!\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:282
 msgid "Unimplemented feature!"
 msgstr ""
 
-#: attrib/src/x_dialog.c:309
 msgid "Fatal error"
 msgstr ""
 
-#: attrib/src/x_dialog.c:324
 #, c-format
 msgid ""
 "Lepton Electronic Design Automation\n"
@@ -321,110 +272,85 @@ msgid ""
 "and gtkextra, as well as support from the gEDA community."
 msgstr ""
 
-#: attrib/src/x_dialog.c:335
 msgid "About..."
 msgstr ""
 
-#: attrib/src/x_dialog.c:351
 msgid "Export CSV"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:87
 msgid "Schematics"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:92
 msgid "Symbols"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:97
 msgid "Schematics and symbols"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:103
 msgid "All files"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:134
 #, c-format
 msgid "Loading file [%1$s]"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:140
 #, c-format
 msgid "Couldn't load schematic [%1$s]\n"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:230
 msgid "Open..."
 msgstr ""
 
-#: attrib/src/x_fileselect.c:275
 msgid "Save as..."
 msgstr ""
 
-#: attrib/src/x_fileselect.c:304
 #, c-format
 msgid "Saved As [%1$s]"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:314
 #, c-format
 msgid "Could NOT save [%1$s]"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:70 attrib/src/x_gtksheet.c:79
 msgid "Components"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:71 attrib/src/x_gtksheet.c:88
-#: attrib/src/x_gtksheet.c:91
 msgid "Nets"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:72 attrib/src/x_gtksheet.c:104
-#: attrib/src/x_gtksheet.c:107
 msgid "Pins"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:81
 msgid ""
 "No components found in design.  Please check your schematic and try again!\n"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:92 attrib/src/x_gtksheet.c:94
 msgid "TBD"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:355
 msgid "couldn't allocate color"
 msgstr ""
 
-#: attrib/src/x_window.c:94
 #, fuzzy
 msgid "lepton-attrib - Lepton EDA attribute editor"
 msgstr "Editor de atributos gEDA"
 
-#: attrib/src/x_window.c:299
 #, c-format
 msgid ""
 "Error loading %1$s:\n"
 "%2$s\n"
 msgstr ""
 
-#: attrib/src/x_window.c:337
 msgid ""
 "No components found in entire design!\n"
 "Do you have refdeses on your components?"
 msgstr ""
 
-#: attrib/src/x_window.c:342
 msgid ""
 "No configurable component attributes found in entire design!\n"
 "Please attach at least some attributes before running lepton-attrib."
 msgstr ""
 
-#: attrib/src/x_window.c:347
 msgid ""
 "No pins found on any components!\n"
 "Please check your design."

--- a/attrib/po/ru.po
+++ b/attrib/po/ru.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda gattrib\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-12 00:10+0300\n"
+"POT-Creation-Date: 2019-05-10 08:15+0300\n"
 "PO-Revision-Date: 2014-03-08 20:49+0400\n"
 "Last-Translator: Vladimir Zhbanov <vzhbanov@gmail.com>\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -20,42 +20,34 @@ msgstr ""
 "X-Launchpad-Export-Date: 2010-02-14 12:56+0000\n"
 "X-Generator: Launchpad (build Unknown)\n"
 
-#: attrib/data/lepton-attrib.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Attribute Editor"
 msgstr "Редактор атрибутов gEDA"
 
-#: attrib/data/lepton-attrib.desktop.in:4
 #, fuzzy
 msgid "Manipulate component attributes with lepton-attrib"
 msgstr "Управление атрибутами компонента с помощью gattrib"
 
-#: attrib/src/f_export.c:82
 #, fuzzy, c-format
 msgid "o_save: Could not open [%1$s]"
 msgstr "o_save: Не удалось открыть «%s»\n"
 
-#: attrib/src/lepton-attrib.c:160
 #, c-format
 msgid "Lepton EDA/lepton-attrib version %1$s%2$s.%3$s git: %4$.7s"
 msgstr ""
 
-#: attrib/src/lepton-attrib.c:196
 #, fuzzy, c-format
 msgid "Couldn't find file [%1$s]\n"
 msgstr "Не удалось найти файл «%s»\n"
 
-#: attrib/src/gtksheet_2_2.c:6302
 msgid "Entry type must be GtkEntry subclass, using default"
 msgstr ""
 "Тип записи должен быть подклассом GtkEntry, используется значение по "
 "умолчанию"
 
-#: attrib/src/gtksheet_2_2.c:8499
 msgid "Widget must be a GtkSheet child"
 msgstr "Виджет должен быть дочерним для GtkSheet"
 
-#: attrib/src/parsecmd.c:73
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -115,14 +107,12 @@ msgstr ""
 "net.\n"
 "\n"
 
-#: attrib/src/s_attrib.c:101
 #, fuzzy, c-format
 msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 "ВНИМАНИЕ: Обнаружен не рекомендуемый к использованию атрибут «uref=%s», "
 "используйте вместо него «refdes».\n"
 
-#: attrib/src/s_misc.c:81
 #, c-format
 msgid ""
 "\n"
@@ -131,12 +121,10 @@ msgstr ""
 "\n"
 "ЗАВЕРШЕНО\n"
 
-#: attrib/src/s_misc.c:83
 #, c-format
 msgid " DONE\n"
 msgstr " ЗАВЕРШЕНО\n"
 
-#: attrib/src/s_object.c:217
 #, fuzzy, c-format
 msgid ""
 "In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
@@ -145,7 +133,6 @@ msgstr ""
 "s_object_replace_attrib_in_object: не удалось найти атрибут «%s» для "
 "компонента. Выход . . .\n"
 
-#: attrib/src/s_object.c:276
 #, fuzzy, c-format
 msgid ""
 "In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
@@ -154,7 +141,6 @@ msgstr ""
 "s_object_remove_attrib_in_object: не удалось найти атрибут «%s» для "
 "компонента. Выход . . .\n"
 
-#: attrib/src/s_object.c:329
 #, c-format
 msgid ""
 "In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
@@ -163,22 +149,18 @@ msgstr ""
 "s_object_attrib_add_attrib_in_object: попытка добавить атрибут к объекту, не "
 "являющимся ни составным, ни соединением!\n"
 
-#: attrib/src/s_sheet_data.c:116
 #, c-format
 msgid "- Starting master comp list creation.\n"
 msgstr "- Приступаем к созданию основного списка компонентов.\n"
 
-#: attrib/src/s_sheet_data.c:184
 #, c-format
 msgid "- Starting master comp attrib list creation.\n"
 msgstr "- Приступаем к созданию основного списка атрибутов компонентов.\n"
 
-#: attrib/src/s_sheet_data.c:297
 #, c-format
 msgid "- Starting master pin list creation.\n"
 msgstr "- Приступаем к созданию основного списка выводов.\n"
 
-#: attrib/src/s_sheet_data.c:331
 #, c-format
 msgid ""
 "In s_sheet_data_add_master_pin_list_items, found component pin with no "
@@ -187,41 +169,34 @@ msgstr ""
 "s_sheet_data_add_master_pin_list_items: обнаружен вывод компонента без "
 "атрибута pinnumber.\n"
 
-#: attrib/src/s_sheet_data.c:389
 #, c-format
 msgid "- Starting master pin attrib list creation.\n"
 msgstr "- Приступаем к созданию основного списка атрибутов выводов.\n"
 
-#: attrib/src/s_string_list.c:123
 #, c-format
 msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
 msgstr ""
 "s_string_list_add_item: попытка добавления к списку со значением NULL.\n"
 
-#: attrib/src/s_string_list.c:188
 #, c-format
 msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
 msgstr ""
 "s_string_list_delete_item: попытка удаления элемента из пустого списка\n"
 
-#: attrib/src/s_string_list.c:252
 #, c-format
 msgid "In s_string_list_delete_item, couldn't delete item %s\n"
 msgstr "s_string_list_delete_item: не удалось удалить элемент %s\n"
 
-#: attrib/src/s_table.c:242
 #, c-format
 msgid ""
 "In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
 msgstr ""
 "s_table_create_attrib_pair: не удалось найти имя строки в списке строк!\n"
 
-#: attrib/src/s_table.c:285
 #, c-format
 msgid "- Starting internal component TABLE creation\n"
 msgstr "- Приступаем к созданию внутренней таблицы компонентов\n"
 
-#: attrib/src/s_table.c:344
 #, c-format
 msgid ""
 "In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
@@ -230,12 +205,10 @@ msgstr ""
 "s_table_add_toplevel_comp_items_to_comp_table: не удалось найти либо строку, "
 "либо столбец в соответствующем списке!\n"
 
-#: attrib/src/s_table.c:493
 #, c-format
 msgid "- Starting internal pin TABLE creation\n"
 msgstr "- Приступаем к созданию внутренней таблицы выводов\n"
 
-#: attrib/src/s_table.c:553
 #, c-format
 msgid ""
 "In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
@@ -244,16 +217,13 @@ msgstr ""
 "s_table_add_toplevel_pin_items_to_pin_table: не удалось найти либо строку, "
 "либо столбец в соответствующем списке!\n"
 
-#: attrib/src/s_toplevel.c:185
 msgid "_cancel"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:318
 #, c-format
 msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
 msgstr "s_toplevel_delete_attrib_col: не удалось получить имя атрибута\n"
 
-#: attrib/src/s_toplevel.c:554
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
@@ -262,13 +232,11 @@ msgstr ""
 "s_toplevel_get_component_attribs_in_sheet: не найдено значение «refdes» в "
 "основном списке!\n"
 
-#: attrib/src/s_toplevel.c:582
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr "s_toplevel_get_component_attribs_in_sheet: count != i!  Выход . . .\n"
 
-#: attrib/src/s_toplevel.c:891
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
@@ -277,7 +245,6 @@ msgstr ""
 "s_toplevel_get_pin_attribs_in_sheet: отсутствует атрибут «refdes» или "
 "«pinnumber» у объекта!\n"
 
-#: attrib/src/s_toplevel.c:900
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
@@ -286,28 +253,22 @@ msgstr ""
 "s_toplevel_get_pin_attribs_in_sheet: не удалось найти нужную строку "
 "«refdes»:«pinnumber» в основном списке!\n"
 
-#: attrib/src/s_toplevel.c:928
 #, c-format
 msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr "s_toplevel_get_pin_attribs_in_sheet: count != i!  Выход . . .\n"
 
-#: attrib/src/x_dialog.c:74
 msgid "Add new attribute"
 msgstr "Добавление нового атрибута"
 
-#: attrib/src/x_dialog.c:83
 msgid "Enter new attribute name"
 msgstr "Введите новое имя атрибута"
 
-#: attrib/src/x_dialog.c:147
 msgid "Are you sure you want to delete this attribute?"
 msgstr "Вы уверены, что хотите удалить этот атрибут?"
 
-#: attrib/src/x_dialog.c:149
 msgid "Delete attribute"
 msgstr "Удаление атрибута"
 
-#: attrib/src/x_dialog.c:174
 #, fuzzy
 msgid ""
 "One or more components have been found with missing symbol files!\n"
@@ -327,31 +288,24 @@ msgstr ""
 "Выберите «Выход» для выхода из gattrib и устранения проблемы или \n"
 "«Вперёд» для продолжения работы с gattrib.\n"
 
-#: attrib/src/x_dialog.c:187
 msgid "Missing symbol file found for component!"
 msgstr "Не найден символ компонента!"
 
-#: attrib/src/x_dialog.c:214
 msgid "Save the changes before closing?"
 msgstr "Сохранить изменения перед закрытием?"
 
-#: attrib/src/x_dialog.c:215
 msgid "<big><b>"
 msgstr "<big><b>"
 
-#: attrib/src/x_dialog.c:215
 msgid "</b></big>"
 msgstr "</b></big>"
 
-#: attrib/src/x_dialog.c:217
 msgid "If you don't save, all your changes will be permanently lost."
 msgstr "Если их не сохранить, все изменения будут безвозвратно утрачены."
 
-#: attrib/src/x_dialog.c:227
 msgid "Close without saving"
 msgstr "Закрыть без сохранения"
 
-#: attrib/src/x_dialog.c:274
 #, fuzzy
 msgid ""
 "Sorry -- you have chosen a feature which has not been\n"
@@ -375,15 +329,12 @@ msgstr ""
 "\n"
 "Иначе просто ждите — я скоро напишу эту функцию!\n"
 
-#: attrib/src/x_dialog.c:282
 msgid "Unimplemented feature!"
 msgstr "Отсутствующая функциональность!"
 
-#: attrib/src/x_dialog.c:309
 msgid "Fatal error"
 msgstr "Фатальная ошибка"
 
-#: attrib/src/x_dialog.c:324
 #, fuzzy, c-format
 msgid ""
 "Lepton Electronic Design Automation\n"
@@ -406,93 +357,71 @@ msgstr ""
 "с использованием изрядных кусков кода из gschem, gnetlist, \n"
 "и gtkextra, а также при поддержке сообщества gEDA."
 
-#: attrib/src/x_dialog.c:335
 msgid "About..."
 msgstr "О программе..."
 
-#: attrib/src/x_dialog.c:351
 msgid "Export CSV"
 msgstr "Экспорт CSV"
 
-#: attrib/src/x_fileselect.c:87
 msgid "Schematics"
 msgstr "Схемы"
 
-#: attrib/src/x_fileselect.c:92
 msgid "Symbols"
 msgstr "Символы"
 
-#: attrib/src/x_fileselect.c:97
 msgid "Schematics and symbols"
 msgstr "Схемы и символы"
 
-#: attrib/src/x_fileselect.c:103
 msgid "All files"
 msgstr "Все файлы"
 
-#: attrib/src/x_fileselect.c:134
 #, fuzzy, c-format
 msgid "Loading file [%1$s]"
 msgstr "Загрузка файла «%s»\n"
 
-#: attrib/src/x_fileselect.c:140
 #, fuzzy, c-format
 msgid "Couldn't load schematic [%1$s]\n"
 msgstr "Не удалось загрузить схему «%s»\n"
 
-#: attrib/src/x_fileselect.c:230
 msgid "Open..."
 msgstr "Открыть..."
 
-#: attrib/src/x_fileselect.c:275
 msgid "Save as..."
 msgstr "Сохранить как..."
 
-#: attrib/src/x_fileselect.c:304
 #, fuzzy, c-format
 msgid "Saved As [%1$s]"
 msgstr "Файл сохранён как «%s»\n"
 
-#: attrib/src/x_fileselect.c:314
 #, fuzzy, c-format
 msgid "Could NOT save [%1$s]"
 msgstr "Не удалось сохранить «%s»\n"
 
-#: attrib/src/x_gtksheet.c:70 attrib/src/x_gtksheet.c:79
 msgid "Components"
 msgstr "Компоненты"
 
-#: attrib/src/x_gtksheet.c:71 attrib/src/x_gtksheet.c:88
-#: attrib/src/x_gtksheet.c:91
 msgid "Nets"
 msgstr "Соединения"
 
-#: attrib/src/x_gtksheet.c:72 attrib/src/x_gtksheet.c:104
-#: attrib/src/x_gtksheet.c:107
 msgid "Pins"
 msgstr "Выводы"
 
-#: attrib/src/x_gtksheet.c:81
 msgid ""
 "No components found in design.  Please check your schematic and try again!\n"
 msgstr ""
 "Не обнаружено компонентов в проекте. Проверьте свою схему и попробуйте "
 "снова!\n"
 
-#: attrib/src/x_gtksheet.c:92 attrib/src/x_gtksheet.c:94
 msgid "TBD"
 msgstr "не реализовано"
 
-#: attrib/src/x_gtksheet.c:355
 msgid "couldn't allocate color"
 msgstr "Не удалось выделить цвет"
 
-#: attrib/src/x_window.c:94
 #, fuzzy
 msgid "lepton-attrib - Lepton EDA attribute editor"
 msgstr "gattrib — редактор атрибутов gEDA"
 
-#: attrib/src/x_window.c:299
 #, fuzzy, c-format
 msgid ""
 "Error loading %1$s:\n"
@@ -501,7 +430,6 @@ msgstr ""
 "Ошибка загрузки %s:\n"
 "%s\n"
 
-#: attrib/src/x_window.c:337
 msgid ""
 "No components found in entire design!\n"
 "Do you have refdeses on your components?"
@@ -509,7 +437,6 @@ msgstr ""
 "Во всём проекте не обнаружено ни одного компонента!\n"
 "Вы не забыли добавить для своих компонентов позиционные обозначения?"
 
-#: attrib/src/x_window.c:342
 #, fuzzy
 msgid ""
 "No configurable component attributes found in entire design!\n"
@@ -519,7 +446,6 @@ msgstr ""
 "отредактировать!\n"
 "Прикрепите хотя бы несколько атрибутов, прежде чем запускать gattrib."
 
-#: attrib/src/x_window.c:347
 msgid ""
 "No pins found on any components!\n"
 "Please check your design."

--- a/attrib/po/sl.po
+++ b/attrib/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-12 00:10+0300\n"
+"POT-Creation-Date: 2019-05-10 08:15+0300\n"
 "PO-Revision-Date: 2012-04-09 11:22+0000\n"
 "Last-Translator: Miha Gašperšič <mihec.gaspersic@gmail.com>\n"
 "Language-Team: Slovenian <sl@li.org>\n"
@@ -18,40 +18,32 @@ msgstr ""
 "X-Launchpad-Export-Date: 2012-11-14 16:52+0000\n"
 "X-Generator: Launchpad (build 16265)\n"
 
-#: attrib/data/lepton-attrib.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Attribute Editor"
 msgstr "gEDA urejevalnik atributov"
 
-#: attrib/data/lepton-attrib.desktop.in:4
 #, fuzzy
 msgid "Manipulate component attributes with lepton-attrib"
 msgstr "Upravljajte atribute sestavnih delov z gattrib"
 
-#: attrib/src/f_export.c:82
 #, c-format
 msgid "o_save: Could not open [%1$s]"
 msgstr ""
 
-#: attrib/src/lepton-attrib.c:160
 #, c-format
 msgid "Lepton EDA/lepton-attrib version %1$s%2$s.%3$s git: %4$.7s"
 msgstr ""
 
-#: attrib/src/lepton-attrib.c:196
 #, c-format
 msgid "Couldn't find file [%1$s]\n"
 msgstr ""
 
-#: attrib/src/gtksheet_2_2.c:6302
 msgid "Entry type must be GtkEntry subclass, using default"
 msgstr ""
 
-#: attrib/src/gtksheet_2_2.c:8499
 msgid "Widget must be a GtkSheet child"
 msgstr ""
 
-#: attrib/src/parsecmd.c:73
 #, c-format
 msgid ""
 "\n"
@@ -83,174 +75,143 @@ msgid ""
 "Please report bugs to %2$s.\n"
 msgstr ""
 
-#: attrib/src/s_attrib.c:101
 #, c-format
 msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 
-#: attrib/src/s_misc.c:81
 #, c-format
 msgid ""
 "\n"
 "DONE\n"
 msgstr ""
 
-#: attrib/src/s_misc.c:83
 #, c-format
 msgid " DONE\n"
 msgstr ""
 
-#: attrib/src/s_object.c:217
 #, c-format
 msgid ""
 "In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
 "on the component.  Exiting . . .\n"
 msgstr ""
 
-#: attrib/src/s_object.c:276
 #, c-format
 msgid ""
 "In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
 "on the component.  Exiting . . .\n"
 msgstr ""
 
-#: attrib/src/s_object.c:329
 #, c-format
 msgid ""
 "In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
 "or non-net!\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:116
 #, c-format
 msgid "- Starting master comp list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:184
 #, c-format
 msgid "- Starting master comp attrib list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:297
 #, c-format
 msgid "- Starting master pin list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:331
 #, c-format
 msgid ""
 "In s_sheet_data_add_master_pin_list_items, found component pin with no "
 "pinnumber.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:389
 #, c-format
 msgid "- Starting master pin attrib list creation.\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:123
 #, c-format
 msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:188
 #, c-format
 msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:252
 #, c-format
 msgid "In s_string_list_delete_item, couldn't delete item %s\n"
 msgstr ""
 
-#: attrib/src/s_table.c:242
 #, c-format
 msgid ""
 "In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
 msgstr ""
 
-#: attrib/src/s_table.c:285
 #, c-format
 msgid "- Starting internal component TABLE creation\n"
 msgstr ""
 
-#: attrib/src/s_table.c:344
 #, c-format
 msgid ""
 "In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
 "or col in the lists!\n"
 msgstr ""
 
-#: attrib/src/s_table.c:493
 #, c-format
 msgid "- Starting internal pin TABLE creation\n"
 msgstr ""
 
-#: attrib/src/s_table.c:553
 #, c-format
 msgid ""
 "In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
 "col in the lists!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:185
 msgid "_cancel"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:318
 #, c-format
 msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:554
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
 "the master list!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:582
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:891
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
 "missing!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:900
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
 "master list!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:928
 #, c-format
 msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:74
 msgid "Add new attribute"
 msgstr ""
 
-#: attrib/src/x_dialog.c:83
 msgid "Enter new attribute name"
 msgstr ""
 
-#: attrib/src/x_dialog.c:147
 msgid "Are you sure you want to delete this attribute?"
 msgstr ""
 
-#: attrib/src/x_dialog.c:149
 msgid "Delete attribute"
 msgstr ""
 
-#: attrib/src/x_dialog.c:174
 msgid ""
 "One or more components have been found with missing symbol files!\n"
 "\n"
@@ -261,31 +222,24 @@ msgid ""
 "\"Forward\" to continue working with lepton-attrib.\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:187
 msgid "Missing symbol file found for component!"
 msgstr ""
 
-#: attrib/src/x_dialog.c:214
 msgid "Save the changes before closing?"
 msgstr ""
 
-#: attrib/src/x_dialog.c:215
 msgid "<big><b>"
 msgstr ""
 
-#: attrib/src/x_dialog.c:215
 msgid "</b></big>"
 msgstr ""
 
-#: attrib/src/x_dialog.c:217
 msgid "If you don't save, all your changes will be permanently lost."
 msgstr ""
 
-#: attrib/src/x_dialog.c:227
 msgid "Close without saving"
 msgstr ""
 
-#: attrib/src/x_dialog.c:274
 msgid ""
 "Sorry -- you have chosen a feature which has not been\n"
 "implemented yet.\n"
@@ -299,15 +253,12 @@ msgid ""
 "Otherwise, just hang tight -- I'll implement this feature soon!\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:282
 msgid "Unimplemented feature!"
 msgstr ""
 
-#: attrib/src/x_dialog.c:309
 msgid "Fatal error"
 msgstr ""
 
-#: attrib/src/x_dialog.c:324
 #, c-format
 msgid ""
 "Lepton Electronic Design Automation\n"
@@ -321,110 +272,85 @@ msgid ""
 "and gtkextra, as well as support from the gEDA community."
 msgstr ""
 
-#: attrib/src/x_dialog.c:335
 msgid "About..."
 msgstr ""
 
-#: attrib/src/x_dialog.c:351
 msgid "Export CSV"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:87
 msgid "Schematics"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:92
 msgid "Symbols"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:97
 msgid "Schematics and symbols"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:103
 msgid "All files"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:134
 #, c-format
 msgid "Loading file [%1$s]"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:140
 #, c-format
 msgid "Couldn't load schematic [%1$s]\n"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:230
 msgid "Open..."
 msgstr ""
 
-#: attrib/src/x_fileselect.c:275
 msgid "Save as..."
 msgstr ""
 
-#: attrib/src/x_fileselect.c:304
 #, c-format
 msgid "Saved As [%1$s]"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:314
 #, c-format
 msgid "Could NOT save [%1$s]"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:70 attrib/src/x_gtksheet.c:79
 msgid "Components"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:71 attrib/src/x_gtksheet.c:88
-#: attrib/src/x_gtksheet.c:91
 msgid "Nets"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:72 attrib/src/x_gtksheet.c:104
-#: attrib/src/x_gtksheet.c:107
 msgid "Pins"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:81
 msgid ""
 "No components found in design.  Please check your schematic and try again!\n"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:92 attrib/src/x_gtksheet.c:94
 msgid "TBD"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:355
 msgid "couldn't allocate color"
 msgstr ""
 
-#: attrib/src/x_window.c:94
 #, fuzzy
 msgid "lepton-attrib - Lepton EDA attribute editor"
 msgstr "gEDA urejevalnik atributov"
 
-#: attrib/src/x_window.c:299
 #, c-format
 msgid ""
 "Error loading %1$s:\n"
 "%2$s\n"
 msgstr ""
 
-#: attrib/src/x_window.c:337
 msgid ""
 "No components found in entire design!\n"
 "Do you have refdeses on your components?"
 msgstr ""
 
-#: attrib/src/x_window.c:342
 msgid ""
 "No configurable component attributes found in entire design!\n"
 "Please attach at least some attributes before running lepton-attrib."
 msgstr ""
 
-#: attrib/src/x_window.c:347
 msgid ""
 "No pins found on any components!\n"
 "Please check your design."

--- a/attrib/po/sr.po
+++ b/attrib/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-12 00:10+0300\n"
+"POT-Creation-Date: 2019-05-10 08:15+0300\n"
 "PO-Revision-Date: 2012-01-27 14:17+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: Serbian <sr@li.org>\n"
@@ -18,40 +18,32 @@ msgstr ""
 "X-Launchpad-Export-Date: 2012-11-14 16:52+0000\n"
 "X-Generator: Launchpad (build 16265)\n"
 
-#: attrib/data/lepton-attrib.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Attribute Editor"
 msgstr "гЕДА — уређивач особина"
 
-#: attrib/data/lepton-attrib.desktop.in:4
 #, fuzzy
 msgid "Manipulate component attributes with lepton-attrib"
 msgstr "Управљајте особинама компоненти гособинком"
 
-#: attrib/src/f_export.c:82
 #, c-format
 msgid "o_save: Could not open [%1$s]"
 msgstr ""
 
-#: attrib/src/lepton-attrib.c:160
 #, c-format
 msgid "Lepton EDA/lepton-attrib version %1$s%2$s.%3$s git: %4$.7s"
 msgstr ""
 
-#: attrib/src/lepton-attrib.c:196
 #, c-format
 msgid "Couldn't find file [%1$s]\n"
 msgstr ""
 
-#: attrib/src/gtksheet_2_2.c:6302
 msgid "Entry type must be GtkEntry subclass, using default"
 msgstr ""
 
-#: attrib/src/gtksheet_2_2.c:8499
 msgid "Widget must be a GtkSheet child"
 msgstr ""
 
-#: attrib/src/parsecmd.c:73
 #, c-format
 msgid ""
 "\n"
@@ -83,174 +75,143 @@ msgid ""
 "Please report bugs to %2$s.\n"
 msgstr ""
 
-#: attrib/src/s_attrib.c:101
 #, c-format
 msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 
-#: attrib/src/s_misc.c:81
 #, c-format
 msgid ""
 "\n"
 "DONE\n"
 msgstr ""
 
-#: attrib/src/s_misc.c:83
 #, c-format
 msgid " DONE\n"
 msgstr ""
 
-#: attrib/src/s_object.c:217
 #, c-format
 msgid ""
 "In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
 "on the component.  Exiting . . .\n"
 msgstr ""
 
-#: attrib/src/s_object.c:276
 #, c-format
 msgid ""
 "In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
 "on the component.  Exiting . . .\n"
 msgstr ""
 
-#: attrib/src/s_object.c:329
 #, c-format
 msgid ""
 "In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
 "or non-net!\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:116
 #, c-format
 msgid "- Starting master comp list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:184
 #, c-format
 msgid "- Starting master comp attrib list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:297
 #, c-format
 msgid "- Starting master pin list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:331
 #, c-format
 msgid ""
 "In s_sheet_data_add_master_pin_list_items, found component pin with no "
 "pinnumber.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:389
 #, c-format
 msgid "- Starting master pin attrib list creation.\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:123
 #, c-format
 msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:188
 #, c-format
 msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:252
 #, c-format
 msgid "In s_string_list_delete_item, couldn't delete item %s\n"
 msgstr ""
 
-#: attrib/src/s_table.c:242
 #, c-format
 msgid ""
 "In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
 msgstr ""
 
-#: attrib/src/s_table.c:285
 #, c-format
 msgid "- Starting internal component TABLE creation\n"
 msgstr ""
 
-#: attrib/src/s_table.c:344
 #, c-format
 msgid ""
 "In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
 "or col in the lists!\n"
 msgstr ""
 
-#: attrib/src/s_table.c:493
 #, c-format
 msgid "- Starting internal pin TABLE creation\n"
 msgstr ""
 
-#: attrib/src/s_table.c:553
 #, c-format
 msgid ""
 "In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
 "col in the lists!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:185
 msgid "_cancel"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:318
 #, c-format
 msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:554
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
 "the master list!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:582
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:891
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
 "missing!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:900
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
 "master list!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:928
 #, c-format
 msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:74
 msgid "Add new attribute"
 msgstr ""
 
-#: attrib/src/x_dialog.c:83
 msgid "Enter new attribute name"
 msgstr ""
 
-#: attrib/src/x_dialog.c:147
 msgid "Are you sure you want to delete this attribute?"
 msgstr ""
 
-#: attrib/src/x_dialog.c:149
 msgid "Delete attribute"
 msgstr ""
 
-#: attrib/src/x_dialog.c:174
 msgid ""
 "One or more components have been found with missing symbol files!\n"
 "\n"
@@ -261,31 +222,24 @@ msgid ""
 "\"Forward\" to continue working with lepton-attrib.\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:187
 msgid "Missing symbol file found for component!"
 msgstr ""
 
-#: attrib/src/x_dialog.c:214
 msgid "Save the changes before closing?"
 msgstr ""
 
-#: attrib/src/x_dialog.c:215
 msgid "<big><b>"
 msgstr ""
 
-#: attrib/src/x_dialog.c:215
 msgid "</b></big>"
 msgstr ""
 
-#: attrib/src/x_dialog.c:217
 msgid "If you don't save, all your changes will be permanently lost."
 msgstr ""
 
-#: attrib/src/x_dialog.c:227
 msgid "Close without saving"
 msgstr ""
 
-#: attrib/src/x_dialog.c:274
 msgid ""
 "Sorry -- you have chosen a feature which has not been\n"
 "implemented yet.\n"
@@ -299,15 +253,12 @@ msgid ""
 "Otherwise, just hang tight -- I'll implement this feature soon!\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:282
 msgid "Unimplemented feature!"
 msgstr ""
 
-#: attrib/src/x_dialog.c:309
 msgid "Fatal error"
 msgstr ""
 
-#: attrib/src/x_dialog.c:324
 #, c-format
 msgid ""
 "Lepton Electronic Design Automation\n"
@@ -321,110 +272,85 @@ msgid ""
 "and gtkextra, as well as support from the gEDA community."
 msgstr ""
 
-#: attrib/src/x_dialog.c:335
 msgid "About..."
 msgstr ""
 
-#: attrib/src/x_dialog.c:351
 msgid "Export CSV"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:87
 msgid "Schematics"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:92
 msgid "Symbols"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:97
 msgid "Schematics and symbols"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:103
 msgid "All files"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:134
 #, c-format
 msgid "Loading file [%1$s]"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:140
 #, c-format
 msgid "Couldn't load schematic [%1$s]\n"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:230
 msgid "Open..."
 msgstr ""
 
-#: attrib/src/x_fileselect.c:275
 msgid "Save as..."
 msgstr ""
 
-#: attrib/src/x_fileselect.c:304
 #, c-format
 msgid "Saved As [%1$s]"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:314
 #, c-format
 msgid "Could NOT save [%1$s]"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:70 attrib/src/x_gtksheet.c:79
 msgid "Components"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:71 attrib/src/x_gtksheet.c:88
-#: attrib/src/x_gtksheet.c:91
 msgid "Nets"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:72 attrib/src/x_gtksheet.c:104
-#: attrib/src/x_gtksheet.c:107
 msgid "Pins"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:81
 msgid ""
 "No components found in design.  Please check your schematic and try again!\n"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:92 attrib/src/x_gtksheet.c:94
 msgid "TBD"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:355
 msgid "couldn't allocate color"
 msgstr ""
 
-#: attrib/src/x_window.c:94
 #, fuzzy
 msgid "lepton-attrib - Lepton EDA attribute editor"
 msgstr "гЕДА — уређивач особина"
 
-#: attrib/src/x_window.c:299
 #, c-format
 msgid ""
 "Error loading %1$s:\n"
 "%2$s\n"
 msgstr ""
 
-#: attrib/src/x_window.c:337
 msgid ""
 "No components found in entire design!\n"
 "Do you have refdeses on your components?"
 msgstr ""
 
-#: attrib/src/x_window.c:342
 msgid ""
 "No configurable component attributes found in entire design!\n"
 "Please attach at least some attributes before running lepton-attrib."
 msgstr ""
 
-#: attrib/src/x_window.c:347
 msgid ""
 "No pins found on any components!\n"
 "Please check your design."

--- a/attrib/po/sv.po
+++ b/attrib/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-12 00:10+0300\n"
+"POT-Creation-Date: 2019-05-10 08:15+0300\n"
 "PO-Revision-Date: 2012-01-27 14:17+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: Swedish <sv@li.org>\n"
@@ -18,40 +18,32 @@ msgstr ""
 "X-Launchpad-Export-Date: 2012-11-14 16:52+0000\n"
 "X-Generator: Launchpad (build 16265)\n"
 
-#: attrib/data/lepton-attrib.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Attribute Editor"
 msgstr "gEDA-attributredigerare"
 
-#: attrib/data/lepton-attrib.desktop.in:4
 #, fuzzy
 msgid "Manipulate component attributes with lepton-attrib"
 msgstr "Manipulera komponentattribut med gattrib"
 
-#: attrib/src/f_export.c:82
 #, c-format
 msgid "o_save: Could not open [%1$s]"
 msgstr ""
 
-#: attrib/src/lepton-attrib.c:160
 #, c-format
 msgid "Lepton EDA/lepton-attrib version %1$s%2$s.%3$s git: %4$.7s"
 msgstr ""
 
-#: attrib/src/lepton-attrib.c:196
 #, c-format
 msgid "Couldn't find file [%1$s]\n"
 msgstr ""
 
-#: attrib/src/gtksheet_2_2.c:6302
 msgid "Entry type must be GtkEntry subclass, using default"
 msgstr ""
 
-#: attrib/src/gtksheet_2_2.c:8499
 msgid "Widget must be a GtkSheet child"
 msgstr ""
 
-#: attrib/src/parsecmd.c:73
 #, c-format
 msgid ""
 "\n"
@@ -83,174 +75,143 @@ msgid ""
 "Please report bugs to %2$s.\n"
 msgstr ""
 
-#: attrib/src/s_attrib.c:101
 #, c-format
 msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 
-#: attrib/src/s_misc.c:81
 #, c-format
 msgid ""
 "\n"
 "DONE\n"
 msgstr ""
 
-#: attrib/src/s_misc.c:83
 #, c-format
 msgid " DONE\n"
 msgstr ""
 
-#: attrib/src/s_object.c:217
 #, c-format
 msgid ""
 "In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
 "on the component.  Exiting . . .\n"
 msgstr ""
 
-#: attrib/src/s_object.c:276
 #, c-format
 msgid ""
 "In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
 "on the component.  Exiting . . .\n"
 msgstr ""
 
-#: attrib/src/s_object.c:329
 #, c-format
 msgid ""
 "In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
 "or non-net!\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:116
 #, c-format
 msgid "- Starting master comp list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:184
 #, c-format
 msgid "- Starting master comp attrib list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:297
 #, c-format
 msgid "- Starting master pin list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:331
 #, c-format
 msgid ""
 "In s_sheet_data_add_master_pin_list_items, found component pin with no "
 "pinnumber.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:389
 #, c-format
 msgid "- Starting master pin attrib list creation.\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:123
 #, c-format
 msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:188
 #, c-format
 msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:252
 #, c-format
 msgid "In s_string_list_delete_item, couldn't delete item %s\n"
 msgstr ""
 
-#: attrib/src/s_table.c:242
 #, c-format
 msgid ""
 "In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
 msgstr ""
 
-#: attrib/src/s_table.c:285
 #, c-format
 msgid "- Starting internal component TABLE creation\n"
 msgstr ""
 
-#: attrib/src/s_table.c:344
 #, c-format
 msgid ""
 "In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
 "or col in the lists!\n"
 msgstr ""
 
-#: attrib/src/s_table.c:493
 #, c-format
 msgid "- Starting internal pin TABLE creation\n"
 msgstr ""
 
-#: attrib/src/s_table.c:553
 #, c-format
 msgid ""
 "In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
 "col in the lists!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:185
 msgid "_cancel"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:318
 #, c-format
 msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:554
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
 "the master list!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:582
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:891
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
 "missing!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:900
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
 "master list!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:928
 #, c-format
 msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:74
 msgid "Add new attribute"
 msgstr ""
 
-#: attrib/src/x_dialog.c:83
 msgid "Enter new attribute name"
 msgstr ""
 
-#: attrib/src/x_dialog.c:147
 msgid "Are you sure you want to delete this attribute?"
 msgstr ""
 
-#: attrib/src/x_dialog.c:149
 msgid "Delete attribute"
 msgstr ""
 
-#: attrib/src/x_dialog.c:174
 msgid ""
 "One or more components have been found with missing symbol files!\n"
 "\n"
@@ -261,31 +222,24 @@ msgid ""
 "\"Forward\" to continue working with lepton-attrib.\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:187
 msgid "Missing symbol file found for component!"
 msgstr ""
 
-#: attrib/src/x_dialog.c:214
 msgid "Save the changes before closing?"
 msgstr ""
 
-#: attrib/src/x_dialog.c:215
 msgid "<big><b>"
 msgstr ""
 
-#: attrib/src/x_dialog.c:215
 msgid "</b></big>"
 msgstr ""
 
-#: attrib/src/x_dialog.c:217
 msgid "If you don't save, all your changes will be permanently lost."
 msgstr ""
 
-#: attrib/src/x_dialog.c:227
 msgid "Close without saving"
 msgstr ""
 
-#: attrib/src/x_dialog.c:274
 msgid ""
 "Sorry -- you have chosen a feature which has not been\n"
 "implemented yet.\n"
@@ -299,15 +253,12 @@ msgid ""
 "Otherwise, just hang tight -- I'll implement this feature soon!\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:282
 msgid "Unimplemented feature!"
 msgstr ""
 
-#: attrib/src/x_dialog.c:309
 msgid "Fatal error"
 msgstr ""
 
-#: attrib/src/x_dialog.c:324
 #, c-format
 msgid ""
 "Lepton Electronic Design Automation\n"
@@ -321,110 +272,85 @@ msgid ""
 "and gtkextra, as well as support from the gEDA community."
 msgstr ""
 
-#: attrib/src/x_dialog.c:335
 msgid "About..."
 msgstr ""
 
-#: attrib/src/x_dialog.c:351
 msgid "Export CSV"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:87
 msgid "Schematics"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:92
 msgid "Symbols"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:97
 msgid "Schematics and symbols"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:103
 msgid "All files"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:134
 #, c-format
 msgid "Loading file [%1$s]"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:140
 #, c-format
 msgid "Couldn't load schematic [%1$s]\n"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:230
 msgid "Open..."
 msgstr ""
 
-#: attrib/src/x_fileselect.c:275
 msgid "Save as..."
 msgstr ""
 
-#: attrib/src/x_fileselect.c:304
 #, c-format
 msgid "Saved As [%1$s]"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:314
 #, c-format
 msgid "Could NOT save [%1$s]"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:70 attrib/src/x_gtksheet.c:79
 msgid "Components"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:71 attrib/src/x_gtksheet.c:88
-#: attrib/src/x_gtksheet.c:91
 msgid "Nets"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:72 attrib/src/x_gtksheet.c:104
-#: attrib/src/x_gtksheet.c:107
 msgid "Pins"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:81
 msgid ""
 "No components found in design.  Please check your schematic and try again!\n"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:92 attrib/src/x_gtksheet.c:94
 msgid "TBD"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:355
 msgid "couldn't allocate color"
 msgstr ""
 
-#: attrib/src/x_window.c:94
 #, fuzzy
 msgid "lepton-attrib - Lepton EDA attribute editor"
 msgstr "gEDA-attributredigerare"
 
-#: attrib/src/x_window.c:299
 #, c-format
 msgid ""
 "Error loading %1$s:\n"
 "%2$s\n"
 msgstr ""
 
-#: attrib/src/x_window.c:337
 msgid ""
 "No components found in entire design!\n"
 "Do you have refdeses on your components?"
 msgstr ""
 
-#: attrib/src/x_window.c:342
 msgid ""
 "No configurable component attributes found in entire design!\n"
 "Please attach at least some attributes before running lepton-attrib."
 msgstr ""
 
-#: attrib/src/x_window.c:347
 msgid ""
 "No pins found on any components!\n"
 "Please check your design."

--- a/attrib/po/tr.po
+++ b/attrib/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-12 00:10+0300\n"
+"POT-Creation-Date: 2019-05-10 08:15+0300\n"
 "PO-Revision-Date: 2010-02-06 22:09+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -18,40 +18,32 @@ msgstr ""
 "X-Launchpad-Export-Date: 2010-02-14 12:56+0000\n"
 "X-Generator: Launchpad (build Unknown)\n"
 
-#: attrib/data/lepton-attrib.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Attribute Editor"
 msgstr "gEDA Özellik Düzenleyicisi"
 
-#: attrib/data/lepton-attrib.desktop.in:4
 #, fuzzy
 msgid "Manipulate component attributes with lepton-attrib"
 msgstr "Bileşen özelliklerini gattrib ile düzenle"
 
-#: attrib/src/f_export.c:82
 #, c-format
 msgid "o_save: Could not open [%1$s]"
 msgstr ""
 
-#: attrib/src/lepton-attrib.c:160
 #, c-format
 msgid "Lepton EDA/lepton-attrib version %1$s%2$s.%3$s git: %4$.7s"
 msgstr ""
 
-#: attrib/src/lepton-attrib.c:196
 #, c-format
 msgid "Couldn't find file [%1$s]\n"
 msgstr ""
 
-#: attrib/src/gtksheet_2_2.c:6302
 msgid "Entry type must be GtkEntry subclass, using default"
 msgstr ""
 
-#: attrib/src/gtksheet_2_2.c:8499
 msgid "Widget must be a GtkSheet child"
 msgstr ""
 
-#: attrib/src/parsecmd.c:73
 #, c-format
 msgid ""
 "\n"
@@ -83,174 +75,143 @@ msgid ""
 "Please report bugs to %2$s.\n"
 msgstr ""
 
-#: attrib/src/s_attrib.c:101
 #, c-format
 msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 
-#: attrib/src/s_misc.c:81
 #, c-format
 msgid ""
 "\n"
 "DONE\n"
 msgstr ""
 
-#: attrib/src/s_misc.c:83
 #, c-format
 msgid " DONE\n"
 msgstr ""
 
-#: attrib/src/s_object.c:217
 #, c-format
 msgid ""
 "In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
 "on the component.  Exiting . . .\n"
 msgstr ""
 
-#: attrib/src/s_object.c:276
 #, c-format
 msgid ""
 "In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
 "on the component.  Exiting . . .\n"
 msgstr ""
 
-#: attrib/src/s_object.c:329
 #, c-format
 msgid ""
 "In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
 "or non-net!\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:116
 #, c-format
 msgid "- Starting master comp list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:184
 #, c-format
 msgid "- Starting master comp attrib list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:297
 #, c-format
 msgid "- Starting master pin list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:331
 #, c-format
 msgid ""
 "In s_sheet_data_add_master_pin_list_items, found component pin with no "
 "pinnumber.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:389
 #, c-format
 msgid "- Starting master pin attrib list creation.\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:123
 #, c-format
 msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:188
 #, c-format
 msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:252
 #, c-format
 msgid "In s_string_list_delete_item, couldn't delete item %s\n"
 msgstr ""
 
-#: attrib/src/s_table.c:242
 #, c-format
 msgid ""
 "In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
 msgstr ""
 
-#: attrib/src/s_table.c:285
 #, c-format
 msgid "- Starting internal component TABLE creation\n"
 msgstr ""
 
-#: attrib/src/s_table.c:344
 #, c-format
 msgid ""
 "In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
 "or col in the lists!\n"
 msgstr ""
 
-#: attrib/src/s_table.c:493
 #, c-format
 msgid "- Starting internal pin TABLE creation\n"
 msgstr ""
 
-#: attrib/src/s_table.c:553
 #, c-format
 msgid ""
 "In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
 "col in the lists!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:185
 msgid "_cancel"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:318
 #, c-format
 msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:554
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
 "the master list!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:582
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:891
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
 "missing!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:900
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
 "master list!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:928
 #, c-format
 msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:74
 msgid "Add new attribute"
 msgstr ""
 
-#: attrib/src/x_dialog.c:83
 msgid "Enter new attribute name"
 msgstr ""
 
-#: attrib/src/x_dialog.c:147
 msgid "Are you sure you want to delete this attribute?"
 msgstr ""
 
-#: attrib/src/x_dialog.c:149
 msgid "Delete attribute"
 msgstr ""
 
-#: attrib/src/x_dialog.c:174
 msgid ""
 "One or more components have been found with missing symbol files!\n"
 "\n"
@@ -261,31 +222,24 @@ msgid ""
 "\"Forward\" to continue working with lepton-attrib.\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:187
 msgid "Missing symbol file found for component!"
 msgstr ""
 
-#: attrib/src/x_dialog.c:214
 msgid "Save the changes before closing?"
 msgstr ""
 
-#: attrib/src/x_dialog.c:215
 msgid "<big><b>"
 msgstr ""
 
-#: attrib/src/x_dialog.c:215
 msgid "</b></big>"
 msgstr ""
 
-#: attrib/src/x_dialog.c:217
 msgid "If you don't save, all your changes will be permanently lost."
 msgstr ""
 
-#: attrib/src/x_dialog.c:227
 msgid "Close without saving"
 msgstr ""
 
-#: attrib/src/x_dialog.c:274
 msgid ""
 "Sorry -- you have chosen a feature which has not been\n"
 "implemented yet.\n"
@@ -299,15 +253,12 @@ msgid ""
 "Otherwise, just hang tight -- I'll implement this feature soon!\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:282
 msgid "Unimplemented feature!"
 msgstr ""
 
-#: attrib/src/x_dialog.c:309
 msgid "Fatal error"
 msgstr ""
 
-#: attrib/src/x_dialog.c:324
 #, c-format
 msgid ""
 "Lepton Electronic Design Automation\n"
@@ -321,110 +272,85 @@ msgid ""
 "and gtkextra, as well as support from the gEDA community."
 msgstr ""
 
-#: attrib/src/x_dialog.c:335
 msgid "About..."
 msgstr ""
 
-#: attrib/src/x_dialog.c:351
 msgid "Export CSV"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:87
 msgid "Schematics"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:92
 msgid "Symbols"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:97
 msgid "Schematics and symbols"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:103
 msgid "All files"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:134
 #, c-format
 msgid "Loading file [%1$s]"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:140
 #, c-format
 msgid "Couldn't load schematic [%1$s]\n"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:230
 msgid "Open..."
 msgstr ""
 
-#: attrib/src/x_fileselect.c:275
 msgid "Save as..."
 msgstr ""
 
-#: attrib/src/x_fileselect.c:304
 #, c-format
 msgid "Saved As [%1$s]"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:314
 #, c-format
 msgid "Could NOT save [%1$s]"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:70 attrib/src/x_gtksheet.c:79
 msgid "Components"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:71 attrib/src/x_gtksheet.c:88
-#: attrib/src/x_gtksheet.c:91
 msgid "Nets"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:72 attrib/src/x_gtksheet.c:104
-#: attrib/src/x_gtksheet.c:107
 msgid "Pins"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:81
 msgid ""
 "No components found in design.  Please check your schematic and try again!\n"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:92 attrib/src/x_gtksheet.c:94
 msgid "TBD"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:355
 msgid "couldn't allocate color"
 msgstr ""
 
-#: attrib/src/x_window.c:94
 #, fuzzy
 msgid "lepton-attrib - Lepton EDA attribute editor"
 msgstr "gEDA Özellik Düzenleyicisi"
 
-#: attrib/src/x_window.c:299
 #, c-format
 msgid ""
 "Error loading %1$s:\n"
 "%2$s\n"
 msgstr ""
 
-#: attrib/src/x_window.c:337
 msgid ""
 "No components found in entire design!\n"
 "Do you have refdeses on your components?"
 msgstr ""
 
-#: attrib/src/x_window.c:342
 msgid ""
 "No configurable component attributes found in entire design!\n"
 "Please attach at least some attributes before running lepton-attrib."
 msgstr ""
 
-#: attrib/src/x_window.c:347
 msgid ""
 "No pins found on any components!\n"
 "Please check your design."

--- a/attrib/po/uk.po
+++ b/attrib/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-12 00:10+0300\n"
+"POT-Creation-Date: 2019-05-10 08:15+0300\n"
 "PO-Revision-Date: 2012-01-27 14:17+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: Ukrainian <uk@li.org>\n"
@@ -18,40 +18,32 @@ msgstr ""
 "X-Launchpad-Export-Date: 2012-11-14 16:52+0000\n"
 "X-Generator: Launchpad (build 16265)\n"
 
-#: attrib/data/lepton-attrib.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Attribute Editor"
 msgstr "gEDA Attribute Editor"
 
-#: attrib/data/lepton-attrib.desktop.in:4
 #, fuzzy
 msgid "Manipulate component attributes with lepton-attrib"
 msgstr "Керувати властивостями компонентів за допомогою gattrib"
 
-#: attrib/src/f_export.c:82
 #, c-format
 msgid "o_save: Could not open [%1$s]"
 msgstr ""
 
-#: attrib/src/lepton-attrib.c:160
 #, c-format
 msgid "Lepton EDA/lepton-attrib version %1$s%2$s.%3$s git: %4$.7s"
 msgstr ""
 
-#: attrib/src/lepton-attrib.c:196
 #, c-format
 msgid "Couldn't find file [%1$s]\n"
 msgstr ""
 
-#: attrib/src/gtksheet_2_2.c:6302
 msgid "Entry type must be GtkEntry subclass, using default"
 msgstr ""
 
-#: attrib/src/gtksheet_2_2.c:8499
 msgid "Widget must be a GtkSheet child"
 msgstr ""
 
-#: attrib/src/parsecmd.c:73
 #, c-format
 msgid ""
 "\n"
@@ -83,174 +75,143 @@ msgid ""
 "Please report bugs to %2$s.\n"
 msgstr ""
 
-#: attrib/src/s_attrib.c:101
 #, c-format
 msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 
-#: attrib/src/s_misc.c:81
 #, c-format
 msgid ""
 "\n"
 "DONE\n"
 msgstr ""
 
-#: attrib/src/s_misc.c:83
 #, c-format
 msgid " DONE\n"
 msgstr ""
 
-#: attrib/src/s_object.c:217
 #, c-format
 msgid ""
 "In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
 "on the component.  Exiting . . .\n"
 msgstr ""
 
-#: attrib/src/s_object.c:276
 #, c-format
 msgid ""
 "In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
 "on the component.  Exiting . . .\n"
 msgstr ""
 
-#: attrib/src/s_object.c:329
 #, c-format
 msgid ""
 "In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
 "or non-net!\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:116
 #, c-format
 msgid "- Starting master comp list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:184
 #, c-format
 msgid "- Starting master comp attrib list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:297
 #, c-format
 msgid "- Starting master pin list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:331
 #, c-format
 msgid ""
 "In s_sheet_data_add_master_pin_list_items, found component pin with no "
 "pinnumber.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:389
 #, c-format
 msgid "- Starting master pin attrib list creation.\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:123
 #, c-format
 msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:188
 #, c-format
 msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:252
 #, c-format
 msgid "In s_string_list_delete_item, couldn't delete item %s\n"
 msgstr ""
 
-#: attrib/src/s_table.c:242
 #, c-format
 msgid ""
 "In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
 msgstr ""
 
-#: attrib/src/s_table.c:285
 #, c-format
 msgid "- Starting internal component TABLE creation\n"
 msgstr ""
 
-#: attrib/src/s_table.c:344
 #, c-format
 msgid ""
 "In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
 "or col in the lists!\n"
 msgstr ""
 
-#: attrib/src/s_table.c:493
 #, c-format
 msgid "- Starting internal pin TABLE creation\n"
 msgstr ""
 
-#: attrib/src/s_table.c:553
 #, c-format
 msgid ""
 "In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
 "col in the lists!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:185
 msgid "_cancel"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:318
 #, c-format
 msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:554
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
 "the master list!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:582
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:891
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
 "missing!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:900
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
 "master list!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:928
 #, c-format
 msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:74
 msgid "Add new attribute"
 msgstr ""
 
-#: attrib/src/x_dialog.c:83
 msgid "Enter new attribute name"
 msgstr ""
 
-#: attrib/src/x_dialog.c:147
 msgid "Are you sure you want to delete this attribute?"
 msgstr ""
 
-#: attrib/src/x_dialog.c:149
 msgid "Delete attribute"
 msgstr ""
 
-#: attrib/src/x_dialog.c:174
 msgid ""
 "One or more components have been found with missing symbol files!\n"
 "\n"
@@ -261,31 +222,24 @@ msgid ""
 "\"Forward\" to continue working with lepton-attrib.\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:187
 msgid "Missing symbol file found for component!"
 msgstr ""
 
-#: attrib/src/x_dialog.c:214
 msgid "Save the changes before closing?"
 msgstr ""
 
-#: attrib/src/x_dialog.c:215
 msgid "<big><b>"
 msgstr ""
 
-#: attrib/src/x_dialog.c:215
 msgid "</b></big>"
 msgstr ""
 
-#: attrib/src/x_dialog.c:217
 msgid "If you don't save, all your changes will be permanently lost."
 msgstr ""
 
-#: attrib/src/x_dialog.c:227
 msgid "Close without saving"
 msgstr ""
 
-#: attrib/src/x_dialog.c:274
 msgid ""
 "Sorry -- you have chosen a feature which has not been\n"
 "implemented yet.\n"
@@ -299,15 +253,12 @@ msgid ""
 "Otherwise, just hang tight -- I'll implement this feature soon!\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:282
 msgid "Unimplemented feature!"
 msgstr ""
 
-#: attrib/src/x_dialog.c:309
 msgid "Fatal error"
 msgstr ""
 
-#: attrib/src/x_dialog.c:324
 #, c-format
 msgid ""
 "Lepton Electronic Design Automation\n"
@@ -321,110 +272,85 @@ msgid ""
 "and gtkextra, as well as support from the gEDA community."
 msgstr ""
 
-#: attrib/src/x_dialog.c:335
 msgid "About..."
 msgstr ""
 
-#: attrib/src/x_dialog.c:351
 msgid "Export CSV"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:87
 msgid "Schematics"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:92
 msgid "Symbols"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:97
 msgid "Schematics and symbols"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:103
 msgid "All files"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:134
 #, c-format
 msgid "Loading file [%1$s]"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:140
 #, c-format
 msgid "Couldn't load schematic [%1$s]\n"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:230
 msgid "Open..."
 msgstr ""
 
-#: attrib/src/x_fileselect.c:275
 msgid "Save as..."
 msgstr ""
 
-#: attrib/src/x_fileselect.c:304
 #, c-format
 msgid "Saved As [%1$s]"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:314
 #, c-format
 msgid "Could NOT save [%1$s]"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:70 attrib/src/x_gtksheet.c:79
 msgid "Components"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:71 attrib/src/x_gtksheet.c:88
-#: attrib/src/x_gtksheet.c:91
 msgid "Nets"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:72 attrib/src/x_gtksheet.c:104
-#: attrib/src/x_gtksheet.c:107
 msgid "Pins"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:81
 msgid ""
 "No components found in design.  Please check your schematic and try again!\n"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:92 attrib/src/x_gtksheet.c:94
 msgid "TBD"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:355
 msgid "couldn't allocate color"
 msgstr ""
 
-#: attrib/src/x_window.c:94
 #, fuzzy
 msgid "lepton-attrib - Lepton EDA attribute editor"
 msgstr "gEDA Attribute Editor"
 
-#: attrib/src/x_window.c:299
 #, c-format
 msgid ""
 "Error loading %1$s:\n"
 "%2$s\n"
 msgstr ""
 
-#: attrib/src/x_window.c:337
 msgid ""
 "No components found in entire design!\n"
 "Do you have refdeses on your components?"
 msgstr ""
 
-#: attrib/src/x_window.c:342
 msgid ""
 "No configurable component attributes found in entire design!\n"
 "Please attach at least some attributes before running lepton-attrib."
 msgstr ""
 
-#: attrib/src/x_window.c:347
 msgid ""
 "No pins found on any components!\n"
 "Please check your design."

--- a/attrib/po/zh_CN.po
+++ b/attrib/po/zh_CN.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-12 00:10+0300\n"
+"POT-Creation-Date: 2019-05-10 08:15+0300\n"
 "PO-Revision-Date: 2010-02-06 22:10+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -18,40 +18,32 @@ msgstr ""
 "X-Launchpad-Export-Date: 2010-02-14 12:56+0000\n"
 "X-Generator: Launchpad (build Unknown)\n"
 
-#: attrib/data/lepton-attrib.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Attribute Editor"
 msgstr "gEDA 属性编辑器"
 
-#: attrib/data/lepton-attrib.desktop.in:4
 #, fuzzy
 msgid "Manipulate component attributes with lepton-attrib"
 msgstr "使用 gattrib 操作组件的属性"
 
-#: attrib/src/f_export.c:82
 #, c-format
 msgid "o_save: Could not open [%1$s]"
 msgstr ""
 
-#: attrib/src/lepton-attrib.c:160
 #, c-format
 msgid "Lepton EDA/lepton-attrib version %1$s%2$s.%3$s git: %4$.7s"
 msgstr ""
 
-#: attrib/src/lepton-attrib.c:196
 #, c-format
 msgid "Couldn't find file [%1$s]\n"
 msgstr ""
 
-#: attrib/src/gtksheet_2_2.c:6302
 msgid "Entry type must be GtkEntry subclass, using default"
 msgstr ""
 
-#: attrib/src/gtksheet_2_2.c:8499
 msgid "Widget must be a GtkSheet child"
 msgstr ""
 
-#: attrib/src/parsecmd.c:73
 #, c-format
 msgid ""
 "\n"
@@ -83,174 +75,143 @@ msgid ""
 "Please report bugs to %2$s.\n"
 msgstr ""
 
-#: attrib/src/s_attrib.c:101
 #, c-format
 msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 
-#: attrib/src/s_misc.c:81
 #, c-format
 msgid ""
 "\n"
 "DONE\n"
 msgstr ""
 
-#: attrib/src/s_misc.c:83
 #, c-format
 msgid " DONE\n"
 msgstr ""
 
-#: attrib/src/s_object.c:217
 #, c-format
 msgid ""
 "In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
 "on the component.  Exiting . . .\n"
 msgstr ""
 
-#: attrib/src/s_object.c:276
 #, c-format
 msgid ""
 "In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
 "on the component.  Exiting . . .\n"
 msgstr ""
 
-#: attrib/src/s_object.c:329
 #, c-format
 msgid ""
 "In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
 "or non-net!\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:116
 #, c-format
 msgid "- Starting master comp list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:184
 #, c-format
 msgid "- Starting master comp attrib list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:297
 #, c-format
 msgid "- Starting master pin list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:331
 #, c-format
 msgid ""
 "In s_sheet_data_add_master_pin_list_items, found component pin with no "
 "pinnumber.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:389
 #, c-format
 msgid "- Starting master pin attrib list creation.\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:123
 #, c-format
 msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:188
 #, c-format
 msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:252
 #, c-format
 msgid "In s_string_list_delete_item, couldn't delete item %s\n"
 msgstr ""
 
-#: attrib/src/s_table.c:242
 #, c-format
 msgid ""
 "In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
 msgstr ""
 
-#: attrib/src/s_table.c:285
 #, c-format
 msgid "- Starting internal component TABLE creation\n"
 msgstr ""
 
-#: attrib/src/s_table.c:344
 #, c-format
 msgid ""
 "In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
 "or col in the lists!\n"
 msgstr ""
 
-#: attrib/src/s_table.c:493
 #, c-format
 msgid "- Starting internal pin TABLE creation\n"
 msgstr ""
 
-#: attrib/src/s_table.c:553
 #, c-format
 msgid ""
 "In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
 "col in the lists!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:185
 msgid "_cancel"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:318
 #, c-format
 msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:554
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
 "the master list!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:582
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:891
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
 "missing!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:900
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
 "master list!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:928
 #, c-format
 msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:74
 msgid "Add new attribute"
 msgstr ""
 
-#: attrib/src/x_dialog.c:83
 msgid "Enter new attribute name"
 msgstr ""
 
-#: attrib/src/x_dialog.c:147
 msgid "Are you sure you want to delete this attribute?"
 msgstr ""
 
-#: attrib/src/x_dialog.c:149
 msgid "Delete attribute"
 msgstr ""
 
-#: attrib/src/x_dialog.c:174
 msgid ""
 "One or more components have been found with missing symbol files!\n"
 "\n"
@@ -261,31 +222,24 @@ msgid ""
 "\"Forward\" to continue working with lepton-attrib.\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:187
 msgid "Missing symbol file found for component!"
 msgstr ""
 
-#: attrib/src/x_dialog.c:214
 msgid "Save the changes before closing?"
 msgstr ""
 
-#: attrib/src/x_dialog.c:215
 msgid "<big><b>"
 msgstr ""
 
-#: attrib/src/x_dialog.c:215
 msgid "</b></big>"
 msgstr ""
 
-#: attrib/src/x_dialog.c:217
 msgid "If you don't save, all your changes will be permanently lost."
 msgstr ""
 
-#: attrib/src/x_dialog.c:227
 msgid "Close without saving"
 msgstr ""
 
-#: attrib/src/x_dialog.c:274
 msgid ""
 "Sorry -- you have chosen a feature which has not been\n"
 "implemented yet.\n"
@@ -299,15 +253,12 @@ msgid ""
 "Otherwise, just hang tight -- I'll implement this feature soon!\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:282
 msgid "Unimplemented feature!"
 msgstr ""
 
-#: attrib/src/x_dialog.c:309
 msgid "Fatal error"
 msgstr ""
 
-#: attrib/src/x_dialog.c:324
 #, c-format
 msgid ""
 "Lepton Electronic Design Automation\n"
@@ -321,110 +272,85 @@ msgid ""
 "and gtkextra, as well as support from the gEDA community."
 msgstr ""
 
-#: attrib/src/x_dialog.c:335
 msgid "About..."
 msgstr ""
 
-#: attrib/src/x_dialog.c:351
 msgid "Export CSV"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:87
 msgid "Schematics"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:92
 msgid "Symbols"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:97
 msgid "Schematics and symbols"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:103
 msgid "All files"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:134
 #, c-format
 msgid "Loading file [%1$s]"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:140
 #, c-format
 msgid "Couldn't load schematic [%1$s]\n"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:230
 msgid "Open..."
 msgstr ""
 
-#: attrib/src/x_fileselect.c:275
 msgid "Save as..."
 msgstr ""
 
-#: attrib/src/x_fileselect.c:304
 #, c-format
 msgid "Saved As [%1$s]"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:314
 #, c-format
 msgid "Could NOT save [%1$s]"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:70 attrib/src/x_gtksheet.c:79
 msgid "Components"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:71 attrib/src/x_gtksheet.c:88
-#: attrib/src/x_gtksheet.c:91
 msgid "Nets"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:72 attrib/src/x_gtksheet.c:104
-#: attrib/src/x_gtksheet.c:107
 msgid "Pins"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:81
 msgid ""
 "No components found in design.  Please check your schematic and try again!\n"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:92 attrib/src/x_gtksheet.c:94
 msgid "TBD"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:355
 msgid "couldn't allocate color"
 msgstr ""
 
-#: attrib/src/x_window.c:94
 #, fuzzy
 msgid "lepton-attrib - Lepton EDA attribute editor"
 msgstr "gEDA 属性编辑器"
 
-#: attrib/src/x_window.c:299
 #, c-format
 msgid ""
 "Error loading %1$s:\n"
 "%2$s\n"
 msgstr ""
 
-#: attrib/src/x_window.c:337
 msgid ""
 "No components found in entire design!\n"
 "Do you have refdeses on your components?"
 msgstr ""
 
-#: attrib/src/x_window.c:342
 msgid ""
 "No configurable component attributes found in entire design!\n"
 "Please attach at least some attributes before running lepton-attrib."
 msgstr ""
 
-#: attrib/src/x_window.c:347
 msgid ""
 "No pins found on any components!\n"
 "Please check your design."

--- a/attrib/po/zh_TW.po
+++ b/attrib/po/zh_TW.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-12 00:10+0300\n"
+"POT-Creation-Date: 2019-05-10 08:15+0300\n"
 "PO-Revision-Date: 2010-02-06 22:10+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -18,40 +18,32 @@ msgstr ""
 "X-Launchpad-Export-Date: 2010-02-14 12:56+0000\n"
 "X-Generator: Launchpad (build Unknown)\n"
 
-#: attrib/data/lepton-attrib.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Attribute Editor"
 msgstr "gEDA 屬性編輯器"
 
-#: attrib/data/lepton-attrib.desktop.in:4
 #, fuzzy
 msgid "Manipulate component attributes with lepton-attrib"
 msgstr "使用gattrib修改元件屬性"
 
-#: attrib/src/f_export.c:82
 #, c-format
 msgid "o_save: Could not open [%1$s]"
 msgstr ""
 
-#: attrib/src/lepton-attrib.c:160
 #, c-format
 msgid "Lepton EDA/lepton-attrib version %1$s%2$s.%3$s git: %4$.7s"
 msgstr ""
 
-#: attrib/src/lepton-attrib.c:196
 #, c-format
 msgid "Couldn't find file [%1$s]\n"
 msgstr ""
 
-#: attrib/src/gtksheet_2_2.c:6302
 msgid "Entry type must be GtkEntry subclass, using default"
 msgstr ""
 
-#: attrib/src/gtksheet_2_2.c:8499
 msgid "Widget must be a GtkSheet child"
 msgstr ""
 
-#: attrib/src/parsecmd.c:73
 #, c-format
 msgid ""
 "\n"
@@ -83,174 +75,143 @@ msgid ""
 "Please report bugs to %2$s.\n"
 msgstr ""
 
-#: attrib/src/s_attrib.c:101
 #, c-format
 msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 
-#: attrib/src/s_misc.c:81
 #, c-format
 msgid ""
 "\n"
 "DONE\n"
 msgstr ""
 
-#: attrib/src/s_misc.c:83
 #, c-format
 msgid " DONE\n"
 msgstr ""
 
-#: attrib/src/s_object.c:217
 #, c-format
 msgid ""
 "In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
 "on the component.  Exiting . . .\n"
 msgstr ""
 
-#: attrib/src/s_object.c:276
 #, c-format
 msgid ""
 "In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
 "on the component.  Exiting . . .\n"
 msgstr ""
 
-#: attrib/src/s_object.c:329
 #, c-format
 msgid ""
 "In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
 "or non-net!\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:116
 #, c-format
 msgid "- Starting master comp list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:184
 #, c-format
 msgid "- Starting master comp attrib list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:297
 #, c-format
 msgid "- Starting master pin list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:331
 #, c-format
 msgid ""
 "In s_sheet_data_add_master_pin_list_items, found component pin with no "
 "pinnumber.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:389
 #, c-format
 msgid "- Starting master pin attrib list creation.\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:123
 #, c-format
 msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:188
 #, c-format
 msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:252
 #, c-format
 msgid "In s_string_list_delete_item, couldn't delete item %s\n"
 msgstr ""
 
-#: attrib/src/s_table.c:242
 #, c-format
 msgid ""
 "In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
 msgstr ""
 
-#: attrib/src/s_table.c:285
 #, c-format
 msgid "- Starting internal component TABLE creation\n"
 msgstr ""
 
-#: attrib/src/s_table.c:344
 #, c-format
 msgid ""
 "In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
 "or col in the lists!\n"
 msgstr ""
 
-#: attrib/src/s_table.c:493
 #, c-format
 msgid "- Starting internal pin TABLE creation\n"
 msgstr ""
 
-#: attrib/src/s_table.c:553
 #, c-format
 msgid ""
 "In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
 "col in the lists!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:185
 msgid "_cancel"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:318
 #, c-format
 msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:554
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
 "the master list!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:582
 #, c-format
 msgid ""
 "In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:891
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
 "missing!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:900
 #, c-format
 msgid ""
 "In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
 "master list!\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:928
 #, c-format
 msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:74
 msgid "Add new attribute"
 msgstr ""
 
-#: attrib/src/x_dialog.c:83
 msgid "Enter new attribute name"
 msgstr ""
 
-#: attrib/src/x_dialog.c:147
 msgid "Are you sure you want to delete this attribute?"
 msgstr ""
 
-#: attrib/src/x_dialog.c:149
 msgid "Delete attribute"
 msgstr ""
 
-#: attrib/src/x_dialog.c:174
 msgid ""
 "One or more components have been found with missing symbol files!\n"
 "\n"
@@ -261,31 +222,24 @@ msgid ""
 "\"Forward\" to continue working with lepton-attrib.\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:187
 msgid "Missing symbol file found for component!"
 msgstr ""
 
-#: attrib/src/x_dialog.c:214
 msgid "Save the changes before closing?"
 msgstr ""
 
-#: attrib/src/x_dialog.c:215
 msgid "<big><b>"
 msgstr ""
 
-#: attrib/src/x_dialog.c:215
 msgid "</b></big>"
 msgstr ""
 
-#: attrib/src/x_dialog.c:217
 msgid "If you don't save, all your changes will be permanently lost."
 msgstr ""
 
-#: attrib/src/x_dialog.c:227
 msgid "Close without saving"
 msgstr ""
 
-#: attrib/src/x_dialog.c:274
 msgid ""
 "Sorry -- you have chosen a feature which has not been\n"
 "implemented yet.\n"
@@ -299,15 +253,12 @@ msgid ""
 "Otherwise, just hang tight -- I'll implement this feature soon!\n"
 msgstr ""
 
-#: attrib/src/x_dialog.c:282
 msgid "Unimplemented feature!"
 msgstr ""
 
-#: attrib/src/x_dialog.c:309
 msgid "Fatal error"
 msgstr ""
 
-#: attrib/src/x_dialog.c:324
 #, c-format
 msgid ""
 "Lepton Electronic Design Automation\n"
@@ -321,110 +272,85 @@ msgid ""
 "and gtkextra, as well as support from the gEDA community."
 msgstr ""
 
-#: attrib/src/x_dialog.c:335
 msgid "About..."
 msgstr ""
 
-#: attrib/src/x_dialog.c:351
 msgid "Export CSV"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:87
 msgid "Schematics"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:92
 msgid "Symbols"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:97
 msgid "Schematics and symbols"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:103
 msgid "All files"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:134
 #, c-format
 msgid "Loading file [%1$s]"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:140
 #, c-format
 msgid "Couldn't load schematic [%1$s]\n"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:230
 msgid "Open..."
 msgstr ""
 
-#: attrib/src/x_fileselect.c:275
 msgid "Save as..."
 msgstr ""
 
-#: attrib/src/x_fileselect.c:304
 #, c-format
 msgid "Saved As [%1$s]"
 msgstr ""
 
-#: attrib/src/x_fileselect.c:314
 #, c-format
 msgid "Could NOT save [%1$s]"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:70 attrib/src/x_gtksheet.c:79
 msgid "Components"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:71 attrib/src/x_gtksheet.c:88
-#: attrib/src/x_gtksheet.c:91
 msgid "Nets"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:72 attrib/src/x_gtksheet.c:104
-#: attrib/src/x_gtksheet.c:107
 msgid "Pins"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:81
 msgid ""
 "No components found in design.  Please check your schematic and try again!\n"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:92 attrib/src/x_gtksheet.c:94
 msgid "TBD"
 msgstr ""
 
-#: attrib/src/x_gtksheet.c:355
 msgid "couldn't allocate color"
 msgstr ""
 
-#: attrib/src/x_window.c:94
 #, fuzzy
 msgid "lepton-attrib - Lepton EDA attribute editor"
 msgstr "gEDA 屬性編輯器"
 
-#: attrib/src/x_window.c:299
 #, c-format
 msgid ""
 "Error loading %1$s:\n"
 "%2$s\n"
 msgstr ""
 
-#: attrib/src/x_window.c:337
 msgid ""
 "No components found in entire design!\n"
 "Do you have refdeses on your components?"
 msgstr ""
 
-#: attrib/src/x_window.c:342
 msgid ""
 "No configurable component attributes found in entire design!\n"
 "Please attach at least some attributes before running lepton-attrib."
 msgstr ""
 
-#: attrib/src/x_window.c:347
 msgid ""
 "No pins found on any components!\n"
 "Please check your design."


### PR DESCRIPTION
1) add `lepton-attrib.pot` to source control
2) modify `Makevars`:
  - `MSGMERGE_OPTIONS = --no-location`
  (eliminates comments with line numbers in `*.po`)
  - `PO_DEPENDS_ON_POT = no`
  (do not modify `PO` files if it's not necessary)
3) `make -C attrib/po/ update-po`

This is similar to #342 (for `lepton-schematic`).