### PR TITLE
Do not warn about missing geda*.conf configuration files

### DIFF
--- a/liblepton/src/scheme_config.c
+++ b/liblepton/src/scheme_config.c
@@ -1,7 +1,7 @@
 /* Lepton EDA
  * liblepton - Lepton's library - Scheme API
  * Copyright (C) 2011-2012 Peter Brett <peter@peter-b.co.uk>
- * Copyright (C) 2017-2018 Lepton EDA Contributors
+ * Copyright (C) 2017-2019 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -259,9 +259,17 @@ SCM_DEFINE (config_load_x, "%config-load!", 1, 0, 0,
 
   EdaConfig *cfg = edascm_to_config (cfg_s);
   GError *error = NULL;
-  if (!eda_config_load (cfg, &error)) {
-    error_from_gerror (s_config_load_x, &error);
+
+  if (!eda_config_load (cfg, &error))
+  {
+    /* Missing configuration file is not an error:
+    */
+    if (!g_error_matches (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))
+    {
+      error_from_gerror (s_config_load_x, &error);
+    }
   }
+
   return cfg_s;
 }
 

--- a/netlist/docs/lepton-netlist.1.in
+++ b/netlist/docs/lepton-netlist.1.in
@@ -68,9 +68,6 @@ After the schematic files have been loaded and compiled, and after all
 Scheme files have been loaded, but before running the backend, enter a
 Scheme read-eval-print loop.
 .TP 8
-\fB-w\fR
-Do not display warnings about missing configuration files.
-.TP 8
 \fB-h\fR, \fB--help\fR
 Print a help message.
 .TP 8

--- a/netlist/scheme/lepton-netlist.in
+++ b/netlist/scheme/lepton-netlist.in
@@ -42,7 +42,6 @@ exec @GUILE@ -s "$0" "$@"
     (eval-code (single-char #\c) (value #t))
     (interactive (single-char #\i))
     (help (single-char #\h))
-    (no-warn-cfg (single-char #\w))
     (version (single-char #\V))))
 
 ;;; Options.

--- a/netlist/scheme/netlist.scm
+++ b/netlist/scheme/netlist.scm
@@ -815,7 +815,6 @@ General options:
   -c EXPR         Evaluate Scheme expression at startup.
   -i              Enter interactive Scheme REPL after loading.
   --list-backends Print a list of available netlist backends.
-  -w              Do not display warning about missing configuration files.
   -h, --help      Help; this message.
   -V, --version   Show version information.
   --              Treat all remaining arguments as filenames.

--- a/netlist/scheme/netlist/config.scm
+++ b/netlist/scheme/netlist/config.scm
@@ -103,18 +103,12 @@
 ;; FIXME[2017-02-01] This should error if the load fails due to
 ;; anything other than "file not found"
 (define (try-load-config cfg)
-(let*
-    (
-    (nowarn (netlist-option-ref 'no-warn-cfg))
-    (level (if nowarn 'info 'warning))
-    )
-
     (catch 'system-error
            (lambda () (config-load! cfg))
            (lambda (key subr message args rest)
-             (log! level "Failed to load config from ~S: ~?"
+             (log! 'warning "Failed to load config from ~S: ~?"
                    (config-filename cfg) message args)))
-))
+)
 
 (define (reload-config config . args)
   (define (process info)

--- a/netlist/scheme/netlist/option.scm
+++ b/netlist/scheme/netlist/option.scm
@@ -41,7 +41,6 @@
     (post-load . ())
     (eval-code . ())
     (interactive . #f)
-    (no-warn-cfg . #f)
     (help . #f)
     (version . #f)))
 


### PR DESCRIPTION
- Fix `config-load!`: do not consider missing configuration files as errors
- `netlist`: remove `-w` command line option (*Do not display warning about missing configuration files*): it's obsolete now

Closes #382 