### PR TITLE
Uninstall empty directories

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -87,5 +87,12 @@ uninstall-local:
 	rm -fr $(datadir)/lepton-eda/ccache
 
 
+uninstall-hook:
+	rm -fr $(includedir)/liblepton
+	rm -fr $(includedir)/libleptonrenderer
+	rm -fr $(docdir)
+	rm -fr $(pkgdatadir)
+
+
 DISTCLEANFILES = stamp-git
 MAINTAINERCLEANFILES=Makefile.in aclocal.m4 config.h.in configure


### PR DESCRIPTION
Remove empty application-specific directories
after uninstalling all files by `make uninstall`:

- `$(includedir)/liblepton`
- `$(includedir)/libleptonrenderer`
- `$(docdir)`
- `$(pkgdatadir)`

`$(includedir)` expands to `$PREFIX/include`
`$(docdir)` expands to `$PREFIX/share/doc/lepton-eda`
`$(pkgdatadir)` expands to `$PREFIX/share/lepton-eda`