### PR TITLE
Prevent unwanted updates of PO files: cli, liblepton, netlist

### DIFF
--- a/cli/po/.gitignore
+++ b/cli/po/.gitignore
@@ -7,7 +7,6 @@ POTFILES
 *.sed
 *.header
 *.sin
-lepton-cli.pot
 Rules-quot
 Makevars.template
 stamp-po

--- a/cli/po/Makevars
+++ b/cli/po/Makevars
@@ -10,6 +10,10 @@ top_builddir = ../..
 # These options get passed to xgettext.
 XGETTEXT_OPTIONS = --keyword=_ --keyword=N_
 
+MSGMERGE_OPTIONS = --no-location
+
+PO_DEPENDS_ON_POT = no
+
 # This is the copyright holder that gets inserted into the header of the
 # $(DOMAIN).pot file.  Set this to the copyright holder of the surrounding
 # package.  (Note that the msgstr strings, extracted from the package's

--- a/cli/po/it.po
+++ b/cli/po/it.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda-gaf\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2018-08-12 12:30+0300\n"
+"POT-Creation-Date: 2019-05-13 11:38+0300\n"
 "PO-Revision-Date: 2014-12-28 22:09+0100\n"
 "Last-Translator: Marco Ciampa <ciampix@libero.it>\n"
 "Language-Team: Italian <it@li.org>\n"
@@ -15,7 +15,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: cli/lepton-cli.c:66
 #, fuzzy, c-format
 msgid ""
 "Usage: lepton-cli [OPTION...] COMMAND [ARGS ...]\n"
@@ -50,7 +49,6 @@ msgstr ""
 "\n"
 "Segnalare eventuali difetti a %s.\n"
 
-#: cli/lepton-cli.c:89
 #, fuzzy, c-format
 msgid ""
 "Lepton EDA %1$s (g%2$.7s)\n"
@@ -68,7 +66,6 @@ msgstr ""
 "nella distribuzione di gEDA.\n"
 "NON C'È ALCUNA GARANZIA, nei limiti della legislazione vigente.\n"
 
-#: cli/lepton-cli.c:138
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -77,7 +74,6 @@ msgstr ""
 "\n"
 "Eseguire \"gaf config --help\" per ulteriori informazioni.\n"
 
-#: cli/lepton-cli.c:150
 #, fuzzy, c-format
 msgid ""
 "ERROR: You must specify a command to run.\n"
@@ -88,7 +84,6 @@ msgstr ""
 "\n"
 "Eseguire \"gaf --help\" per ulteriori informazioni.\n"
 
-#: cli/lepton-cli.c:168
 #, fuzzy, c-format
 msgid ""
 "ERROR: Unrecognised command `%1$s'.\n"
@@ -99,7 +94,6 @@ msgstr ""
 "\n"
 "Eseguire \"gaf --help\" per ulteriori informazioni.\n"
 
-#: cli/config.c:47
 #, fuzzy, c-format
 msgid ""
 "Usage: lepton-cli config [OPTION] [GROUP KEY [VALUE]]\n"
@@ -141,7 +135,6 @@ msgstr ""
 "\n"
 "Segnalare eventuali difetti a %s.\n"
 
-#: cli/config.c:68
 #, fuzzy
 msgid ""
 "\n"
@@ -150,35 +143,29 @@ msgstr ""
 "\n"
 "Eseguire \"gaf config --help\" per ulteriori informazioni.\n"
 
-#: cli/config.c:69
 msgid "ERROR: You may only specify a single configuration store.\n"
 msgstr ""
 "ERRORE: si può specificare solo un singolo archivio di configurazione.\n"
 
 #. TRANSLATORS: The first string is the filename, the second is
 #. * the detailed error message
-#: cli/config.c:160
 #, fuzzy, c-format
 msgid "WARNING: Could not load '%1$s': %2$s.\n"
 msgstr "ATTENZIONE: impossibile caricare \"%s\": %s.\n"
 
-#: cli/config.c:172
 #, c-format
 msgid "ERROR: You must specify both configuration group and key.\n"
 msgstr ""
 "ERRORE: si deve specificare sia il gruppo di configurazione che la chiave.\n"
 
-#: cli/config.c:184 cli/config.c:198
 #, fuzzy, c-format
 msgid "ERROR: %1$s.\n"
 msgstr "ERRORE: %s.\n"
 
-#: cli/export.c:152
 #, fuzzy, c-format
 msgid "ERROR: Bad argument '%1$s' to %2$s option.\n"
 msgstr "ERRORE: argomento errato \"%s\" all'opzione %s.\n"
 
-#: cli/export.c:153
 #, fuzzy
 msgid ""
 "\n"
@@ -187,25 +174,21 @@ msgstr ""
 "\n"
 "Eseguire `gaf export --help' per ulteriori informazioni.\n"
 
-#: cli/export.c:193
 #, fuzzy, c-format
 msgid "ERROR: Cannot infer output format from filename '%1$s'.\n"
 msgstr ""
 "ERRORE: impossibile ricavare il formato di uscita dal nome del file \"%s\".\n"
 
-#: cli/export.c:210
 #, fuzzy, c-format
 msgid "ERROR: Cannot find supported format for filename '%1$s'.\n"
 msgstr ""
 "ERRORE: impossibile trovare il formato supportato per il file di nome \"%s"
 "\".\n"
 
-#: cli/export.c:215
 #, fuzzy, c-format
 msgid "ERROR: Unsupported output format '%1$s'.\n"
 msgstr "ERRORE: formato di uscita \"%s\" non supportato.\n"
 
-#: cli/export.c:227
 #, c-format
 msgid "ERROR: Selected output format does not support multipage output\n"
 msgstr ""
@@ -213,22 +196,18 @@ msgstr ""
 
 #. TRANSLATORS: The first string is the filename, the second
 #. * is the detailed error message
-#: cli/export.c:241
 #, fuzzy, c-format
 msgid "ERROR: Failed to load '%1$s': %2$s\n"
 msgstr "ERRORE: fallito il caricamento di \"%s\": %s\n"
 
-#: cli/export.c:247
 #, fuzzy, c-format
 msgid "ERROR: Failed to change directory to '%1$s': %2$s\n"
 msgstr "ERRORE: fallito il cambiamento di cartella a \"%s\": %s\n"
 
-#: cli/export.c:329
 #, c-format
 msgid "ERROR: %s.\n"
 msgstr "ERRORE: %s.\n"
 
-#: cli/export.c:962
 #, fuzzy, c-format
 msgid ""
 "Usage: lepton-cli export [OPTION ...] -o OUTPUT [--] FILE ...\n"
@@ -275,17 +254,14 @@ msgstr ""
 "\n"
 "Segnalare eventuali difetti a %s.\n"
 
-#: cli/export.c:1141
 #, c-format
 msgid "ERROR: You must specify at least one input filename.\n"
 msgstr "ERRORE: bisogna specificare almeno un nome file in ingresso.\n"
 
-#: cli/export.c:1150
 #, c-format
 msgid "ERROR: You must specify an output filename.\n"
 msgstr "ERRORE: bisogna specificare un nome file in uscita.\n"
 
-#: cli/shell.c:46
 #, fuzzy, c-format
 msgid ""
 "Usage: lepton-cli shell [OPTION ...]\n"
@@ -324,7 +300,6 @@ msgstr ""
 "\n"
 "Segnalare eventuali difetti a %s.\n"
 
-#: cli/shell.c:102
 #, fuzzy, c-format
 msgid ""
 "\n"

--- a/cli/po/lepton-cli.pot
+++ b/cli/po/lepton-cli.pot
@@ -1,0 +1,234 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR gEDA Developers
+# This file is distributed under the same license as the lepton-eda package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: lepton-eda 1.9.7\n"
+"Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
+"POT-Creation-Date: 2019-05-13 11:38+0300\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: cli/lepton-cli.c:66
+#, c-format
+msgid ""
+"Usage: lepton-cli [OPTION...] COMMAND [ARGS ...]\n"
+"\n"
+"Lepton EDA command-line utility.\n"
+"\n"
+"General options:\n"
+"  --no-rcfiles   inhibit loading of 'gafrc' files\n"
+"  -h, --help     display usage information and exit\n"
+"  -V, --version  display version information and exit\n"
+"\n"
+"Commonly-used commands (type `lepton-cli <cmd> --help' for usage):\n"
+"  shell          Scheme REPL for interactive gEDA data processing\n"
+"  config         Edit gEDA configuration\n"
+"  export         Export gEDA files in various image formats.\n"
+"\n"
+"Please report bugs to %1$s.\n"
+msgstr ""
+
+#: cli/lepton-cli.c:89
+#, c-format
+msgid ""
+"Lepton EDA %1$s (g%2$.7s)\n"
+"Copyright (C) 1998-2017 gEDA developers\n"
+"Copyright (C) 2017 Lepton EDA developers\n"
+"This is free software, and you are welcome to redistribute it under\n"
+"certain conditions. For details, see the file `COPYING', which is\n"
+"included in the gEDA distribution.\n"
+"There is NO WARRANTY, to the extent permitted by law.\n"
+msgstr ""
+
+#: cli/lepton-cli.c:138
+#, c-format
+msgid ""
+"\n"
+"Run `lepton-cli --help' for more information.\n"
+msgstr ""
+
+#: cli/lepton-cli.c:150
+#, c-format
+msgid ""
+"ERROR: You must specify a command to run.\n"
+"\n"
+"Run `lepton-cli --help' for more information.\n"
+msgstr ""
+
+#: cli/lepton-cli.c:168
+#, c-format
+msgid ""
+"ERROR: Unrecognised command `%1$s'.\n"
+"\n"
+"Run `lepton-cli --help' for more information.\n"
+msgstr ""
+
+#: cli/config.c:49
+#, c-format
+msgid ""
+"Usage: lepton-cli config [OPTION] [GROUP KEY [VALUE]]\n"
+"\n"
+"View and modify gEDA configuration.\n"
+"\n"
+"  -p, --project[=PATH]  select project configuration [PATH=.]\n"
+"  -u, --user     select user configuration\n"
+"  -s, --system   select system configuration\n"
+"  -h, --help     display usage information and exit\n"
+"\n"
+"If GROUP and KEY are specified, retrieves the value of that\n"
+"configuration parameter.  If a VALUE was specified, sets the value of\n"
+"the parameter.  The -p, -u and -s options can be used to select the\n"
+"configuration store affected (by default, the project configuration\n"
+"store for the current directory). If no GROUP and KEY were provided,\n"
+"outputs the filename of the selected configuration store.\n"
+"\n"
+"Please report bugs to %1$s.\n"
+msgstr ""
+
+#: cli/config.c:70
+msgid ""
+"\n"
+"Run `lepton-cli config --help' for more information.\n"
+msgstr ""
+
+#: cli/config.c:71
+msgid "ERROR: You may only specify a single configuration store.\n"
+msgstr ""
+
+#. TRANSLATORS: The first string is the filename, the second is
+#. * the detailed error message
+#: cli/config.c:162
+#, c-format
+msgid "WARNING: Could not load '%1$s': %2$s.\n"
+msgstr ""
+
+#: cli/config.c:174
+#, c-format
+msgid "ERROR: You must specify both configuration group and key.\n"
+msgstr ""
+
+#: cli/config.c:186 cli/config.c:200
+#, c-format
+msgid "ERROR: %1$s.\n"
+msgstr ""
+
+#: cli/export.c:154
+#, c-format
+msgid "ERROR: Bad argument '%1$s' to %2$s option.\n"
+msgstr ""
+
+#: cli/export.c:155
+msgid ""
+"\n"
+"Run `lepton-cli export --help' for more information.\n"
+msgstr ""
+
+#: cli/export.c:195
+#, c-format
+msgid "ERROR: Cannot infer output format from filename '%1$s'.\n"
+msgstr ""
+
+#: cli/export.c:212
+#, c-format
+msgid "ERROR: Cannot find supported format for filename '%1$s'.\n"
+msgstr ""
+
+#: cli/export.c:217
+#, c-format
+msgid "ERROR: Unsupported output format '%1$s'.\n"
+msgstr ""
+
+#: cli/export.c:229
+#, c-format
+msgid "ERROR: Selected output format does not support multipage output\n"
+msgstr ""
+
+#. TRANSLATORS: The first string is the filename, the second
+#. * is the detailed error message
+#: cli/export.c:243
+#, c-format
+msgid "ERROR: Failed to load '%1$s': %2$s\n"
+msgstr ""
+
+#: cli/export.c:249
+#, c-format
+msgid "ERROR: Failed to change directory to '%1$s': %2$s\n"
+msgstr ""
+
+#: cli/export.c:331
+#, c-format
+msgid "ERROR: %s.\n"
+msgstr ""
+
+#: cli/export.c:964
+#, c-format
+msgid ""
+"Usage: lepton-cli export [OPTION ...] -o OUTPUT [--] FILE ...\n"
+"\n"
+"Export gEDA files in various image formats.\n"
+"\n"
+"  -f, --format=TYPE      output format (normally autodetected)\n"
+"  -o, --output=OUTPUT    output filename\n"
+"  -p, --paper=NAME       select paper size by name\n"
+"  -s, --size=WIDTH;HEIGHT  specify exact paper size\n"
+"  -k, --scale=FACTOR     specify output scale factor\n"
+"  -l, --layout=ORIENT    page orientation\n"
+"  -m, --margins=TOP;LEFT;BOTTOM;RIGHT\n"
+"                           set page margins\n"
+"  -a, --align=HALIGN;VALIGN\n"
+"                           set alignment of drawing within page\n"
+"  -d, --dpi=DPI          pixels-per-inch for raster outputs\n"
+"  -c, --color            enable color output\n"
+"  --no-color             disable color output\n"
+"  -F, --font=NAME        set font family for printing text\n"
+"  -h, --help     display usage information and exit\n"
+"\n"
+"Please report bugs to %1$s.\n"
+msgstr ""
+
+#: cli/export.c:1143
+#, c-format
+msgid "ERROR: You must specify at least one input filename.\n"
+msgstr ""
+
+#: cli/export.c:1152
+#, c-format
+msgid "ERROR: You must specify an output filename.\n"
+msgstr ""
+
+#: cli/shell.c:48
+#, c-format
+msgid ""
+"Usage: lepton-cli shell [OPTION ...]\n"
+"\n"
+"Shell for interactive processing of gEDA data using Scheme.\n"
+"\n"
+"  -s FILE        load Scheme source code from FILE, and exit\n"
+"  -c EXPR        evaluate Scheme expression EXPR, and exit\n"
+"  --             stop scanning arguments; run interactively\n"
+"\n"
+"The above switches stop argument processing, and pass all\n"
+"remaining arguments as the value of (command-line).\n"
+"\n"
+"  -L DIRECTORY   add DIRECTORY to the front of the Scheme load path\n"
+"  -l FILE        load Scheme source code from FILE\n"
+"  -h, --help     display usage information and exit\n"
+"\n"
+"Please report bugs to %1$s.\n"
+msgstr ""
+
+#: cli/shell.c:104
+#, c-format
+msgid ""
+"\n"
+"Run `lepton-cli shell --help' for more information.\n"
+msgstr ""

--- a/cli/po/nl.po
+++ b/cli/po/nl.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda-gaf\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2018-08-12 12:30+0300\n"
+"POT-Creation-Date: 2019-05-13 11:38+0300\n"
 "PO-Revision-Date: 2014-08-31 20:24+0100\n"
 "Last-Translator: Bert Timmerman <bert.timmerman@xs4all.nl>\n"
 "Language-Team: gEDA developers\n"
@@ -17,7 +17,6 @@ msgstr ""
 "X-Poedit-Language: Dutch\n"
 "X-Poedit-Country: NETHERLANDS\n"
 
-#: cli/lepton-cli.c:66
 #, fuzzy, c-format
 msgid ""
 "Usage: lepton-cli [OPTION...] COMMAND [ARGS ...]\n"
@@ -50,7 +49,6 @@ msgstr ""
 "\n"
 "Rapporteer onvolkomenheden alstublieft aan %s.\n"
 
-#: cli/lepton-cli.c:89
 #, fuzzy, c-format
 msgid ""
 "Lepton EDA %1$s (g%2$.7s)\n"
@@ -68,7 +66,6 @@ msgstr ""
 "de gEDA distributie is bijgevoegd.\n"
 "Er is GEEN GARANTIE, voor zover toegelaten door de wet.\n"
 
-#: cli/lepton-cli.c:138
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -77,7 +74,6 @@ msgstr ""
 "\n"
 "Voer `gaf config --help' uit voor meer informatie.\n"
 
-#: cli/lepton-cli.c:150
 #, fuzzy, c-format
 msgid ""
 "ERROR: You must specify a command to run.\n"
@@ -88,7 +84,6 @@ msgstr ""
 "\n"
 "Voer `gaf --help' uit voor meer informatie.\n"
 
-#: cli/lepton-cli.c:168
 #, fuzzy, c-format
 msgid ""
 "ERROR: Unrecognised command `%1$s'.\n"
@@ -99,7 +94,6 @@ msgstr ""
 "\n"
 "Voer `gaf --help' uit voor meer informatie.\n"
 
-#: cli/config.c:47
 #, fuzzy, c-format
 msgid ""
 "Usage: lepton-cli config [OPTION] [GROUP KEY [VALUE]]\n"
@@ -141,7 +135,6 @@ msgstr ""
 "\n"
 "Rapporteer onvolkomenheden alstublieft aan %s.\n"
 
-#: cli/config.c:68
 #, fuzzy
 msgid ""
 "\n"
@@ -150,33 +143,27 @@ msgstr ""
 "\n"
 "Voer `gaf config --help' uit voor meer informatie.\n"
 
-#: cli/config.c:69
 msgid "ERROR: You may only specify a single configuration store.\n"
 msgstr "FOUT: U mag alleen een enkele configuratie opslag specificeren.\n"
 
 #. TRANSLATORS: The first string is the filename, the second is
 #. * the detailed error message
-#: cli/config.c:160
 #, fuzzy, c-format
 msgid "WARNING: Could not load '%1$s': %2$s.\n"
 msgstr "WAARSCHUWING: Kan '%s': %s niet laden.\n"
 
-#: cli/config.c:172
 #, c-format
 msgid "ERROR: You must specify both configuration group and key.\n"
 msgstr "FOUT: U moet beide configuratie groep en sleutel specificeren.\n"
 
-#: cli/config.c:184 cli/config.c:198
 #, fuzzy, c-format
 msgid "ERROR: %1$s.\n"
 msgstr "FOUT: %s.\n"
 
-#: cli/export.c:152
 #, fuzzy, c-format
 msgid "ERROR: Bad argument '%1$s' to %2$s option.\n"
 msgstr "FOUT: Slecht argument '%s' voor %s optie.\n"
 
-#: cli/export.c:153
 #, fuzzy
 msgid ""
 "\n"
@@ -185,22 +172,18 @@ msgstr ""
 "\n"
 "Voer `gaf export --help' uit voor meer informatie.\n"
 
-#: cli/export.c:193
 #, fuzzy, c-format
 msgid "ERROR: Cannot infer output format from filename '%1$s'.\n"
 msgstr "FOUT: Kan geen uitvoerformaat afleiden van bestandsnaam '%s'.\n"
 
-#: cli/export.c:210
 #, fuzzy, c-format
 msgid "ERROR: Cannot find supported format for filename '%1$s'.\n"
 msgstr "FOUT: Kan geen ondersteund formaat vinden voor bestandsnaam '%s'.\n"
 
-#: cli/export.c:215
 #, fuzzy, c-format
 msgid "ERROR: Unsupported output format '%1$s'.\n"
 msgstr "FOUT: Niet ondersteund uitvoer formaat '%s'.\n"
 
-#: cli/export.c:227
 #, c-format
 msgid "ERROR: Selected output format does not support multipage output\n"
 msgstr ""
@@ -208,22 +191,18 @@ msgstr ""
 
 #. TRANSLATORS: The first string is the filename, the second
 #. * is the detailed error message
-#: cli/export.c:241
 #, fuzzy, c-format
 msgid "ERROR: Failed to load '%1$s': %2$s\n"
 msgstr "FOUT: Faalde om '%s': %s te laden\n"
 
-#: cli/export.c:247
 #, fuzzy, c-format
 msgid "ERROR: Failed to change directory to '%1$s': %2$s\n"
 msgstr "Faalde om bestandenmap te wijzigen naar '%s': %s\n"
 
-#: cli/export.c:329
 #, c-format
 msgid "ERROR: %s.\n"
 msgstr "FOUT: %s.\n"
 
-#: cli/export.c:962
 #, fuzzy, c-format
 msgid ""
 "Usage: lepton-cli export [OPTION ...] -o OUTPUT [--] FILE ...\n"
@@ -270,17 +249,14 @@ msgstr ""
 "\n"
 "Rapporteer onvolkomenheden alstublieft aan %s.\n"
 
-#: cli/export.c:1141
 #, c-format
 msgid "ERROR: You must specify at least one input filename.\n"
 msgstr "FOUT: U moet tenminste een invoer bestandsnaam specificeren.\n"
 
-#: cli/export.c:1150
 #, c-format
 msgid "ERROR: You must specify an output filename.\n"
 msgstr "FOUT: U moet een uitvoer bestandnaam specificeren.\n"
 
-#: cli/shell.c:46
 #, fuzzy, c-format
 msgid ""
 "Usage: lepton-cli shell [OPTION ...]\n"
@@ -318,7 +294,6 @@ msgstr ""
 "\n"
 "Rapporteer onvolkomenheden alstublieft aan %s.\n"
 
-#: cli/shell.c:102
 #, fuzzy, c-format
 msgid ""
 "\n"

--- a/cli/po/ru.po
+++ b/cli/po/ru.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gaf_ru\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2018-08-12 12:30+0300\n"
+"POT-Creation-Date: 2019-05-13 11:38+0300\n"
 "PO-Revision-Date: 2014-03-08 20:49+0400\n"
 "Last-Translator: Vladimir Zhbanov <vzhbanov@gmail.com>\n"
 "Language-Team: geda-user@delorie.com\n"
@@ -19,7 +19,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: cli/lepton-cli.c:66
 #, fuzzy, c-format
 msgid ""
 "Usage: lepton-cli [OPTION...] COMMAND [ARGS ...]\n"
@@ -55,7 +54,6 @@ msgstr ""
 "\n"
 "Сообщайте об ошибках по адресу: %s\n"
 
-#: cli/lepton-cli.c:89
 #, fuzzy, c-format
 msgid ""
 "Lepton EDA %1$s (g%2$.7s)\n"
@@ -73,7 +71,6 @@ msgstr ""
 "gEDA. Нет НИКАКИХ ГАРАНТИЙ в рамках, допустимых имеющимся "
 "законодательством.\n"
 
-#: cli/lepton-cli.c:138
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -82,7 +79,6 @@ msgstr ""
 "\n"
 "Подробности см. в выводе команды «gaf config --help».\n"
 
-#: cli/lepton-cli.c:150
 #, fuzzy, c-format
 msgid ""
 "ERROR: You must specify a command to run.\n"
@@ -93,7 +89,6 @@ msgstr ""
 "\n"
 "Подробности см. в выводе команды «gaf --help».\n"
 
-#: cli/lepton-cli.c:168
 #, fuzzy, c-format
 msgid ""
 "ERROR: Unrecognised command `%1$s'.\n"
@@ -104,7 +99,6 @@ msgstr ""
 "\n"
 "Подробности см. в выводе команды «gaf --help».\n"
 
-#: cli/config.c:47
 #, fuzzy, c-format
 msgid ""
 "Usage: lepton-cli config [OPTION] [GROUP KEY [VALUE]]\n"
@@ -143,7 +137,6 @@ msgstr ""
 "\n"
 "Сообщайте об ошибках по адресу: %s.\n"
 
-#: cli/config.c:68
 #, fuzzy
 msgid ""
 "\n"
@@ -152,33 +145,27 @@ msgstr ""
 "\n"
 "Подробности см. в выводе команды «gaf config --help».\n"
 
-#: cli/config.c:69
 msgid "ERROR: You may only specify a single configuration store.\n"
 msgstr "ОШИБКА: можно указать только одно хранилище настроек.\n"
 
 #. TRANSLATORS: The first string is the filename, the second is
 #. * the detailed error message
-#: cli/config.c:160
 #, fuzzy, c-format
 msgid "WARNING: Could not load '%1$s': %2$s.\n"
 msgstr "ВНИМАНИЕ: не удалось загрузить «%s»: %s.\n"
 
-#: cli/config.c:172
 #, c-format
 msgid "ERROR: You must specify both configuration group and key.\n"
 msgstr "ОШИБКА: необходимо указать и группу настроек, и ключевое слово.\n"
 
-#: cli/config.c:184 cli/config.c:198
 #, fuzzy, c-format
 msgid "ERROR: %1$s.\n"
 msgstr "ОШИБКА: %s.\n"
 
-#: cli/export.c:152
 #, fuzzy, c-format
 msgid "ERROR: Bad argument '%1$s' to %2$s option.\n"
 msgstr "ОШИБКА: Недопустимый аргумент «%s» для опции «%s».\n"
 
-#: cli/export.c:153
 #, fuzzy
 msgid ""
 "\n"
@@ -187,22 +174,18 @@ msgstr ""
 "\n"
 "Подробности см. в выводе команды «gaf export --help».\n"
 
-#: cli/export.c:193
 #, fuzzy, c-format
 msgid "ERROR: Cannot infer output format from filename '%1$s'.\n"
 msgstr "ОШИБКА: не удалось определить формат выходного файла «%s».\n"
 
-#: cli/export.c:210
 #, fuzzy, c-format
 msgid "ERROR: Cannot find supported format for filename '%1$s'.\n"
 msgstr "ОШИБКА: не удалось найти поддерживаемый формат для файла «%s».\n"
 
-#: cli/export.c:215
 #, fuzzy, c-format
 msgid "ERROR: Unsupported output format '%1$s'.\n"
 msgstr "ОШИБКА: вывод в формате «%s» не поддерживается.\n"
 
-#: cli/export.c:227
 #, c-format
 msgid "ERROR: Selected output format does not support multipage output\n"
 msgstr ""
@@ -211,22 +194,18 @@ msgstr ""
 
 #. TRANSLATORS: The first string is the filename, the second
 #. * is the detailed error message
-#: cli/export.c:241
 #, fuzzy, c-format
 msgid "ERROR: Failed to load '%1$s': %2$s\n"
 msgstr "ОШИБКА: не удалось загрузить «%s»: %s.\n"
 
-#: cli/export.c:247
 #, fuzzy, c-format
 msgid "ERROR: Failed to change directory to '%1$s': %2$s\n"
 msgstr "ОШИБКА: Не удалось изменить каталог на «%s»: %s.\n"
 
-#: cli/export.c:329
 #, c-format
 msgid "ERROR: %s.\n"
 msgstr "ОШИБКА: %s.\n"
 
-#: cli/export.c:962
 #, fuzzy, c-format
 msgid ""
 "Usage: lepton-cli export [OPTION ...] -o OUTPUT [--] FILE ...\n"
@@ -277,17 +256,14 @@ msgstr ""
 "\n"
 "Отчёты об ошибках отправляйте по адресу %s.\n"
 
-#: cli/export.c:1141
 #, c-format
 msgid "ERROR: You must specify at least one input filename.\n"
 msgstr "ОШИБКА: необходимо задать имя хотя бы одного входного файла.\n"
 
-#: cli/export.c:1150
 #, c-format
 msgid "ERROR: You must specify an output filename.\n"
 msgstr "ОШИБКА: необходимо задать имя выходного файла.\n"
 
-#: cli/shell.c:46
 #, fuzzy, c-format
 msgid ""
 "Usage: lepton-cli shell [OPTION ...]\n"
@@ -327,7 +303,6 @@ msgstr ""
 "\n"
 "Отчёты об ошибках отправляйте по адресу %s.\n"
 
-#: cli/shell.c:102
 #, fuzzy, c-format
 msgid ""
 "\n"

--- a/liblepton/po/.gitignore
+++ b/liblepton/po/.gitignore
@@ -7,7 +7,6 @@ POTFILES
 *.sed
 *.header
 *.sin
-liblepton*.pot
 Rules-quot
 Makevars.template
 stamp-po

--- a/liblepton/po/Makevars
+++ b/liblepton/po/Makevars
@@ -17,6 +17,10 @@ top_builddir = ../..
 # These options get passed to xgettext.
 XGETTEXT_OPTIONS = --keyword=_ --keyword=N_ --from-code=UTF-8
 
+MSGMERGE_OPTIONS = --no-location
+
+PO_DEPENDS_ON_POT = no
+
 # This is the copyright holder that gets inserted into the header of the
 # $(DOMAIN).pot file.  Set this to the copyright holder of the surrounding
 # package.  (Note that the msgstr strings, extracted from the package's

--- a/liblepton/po/ar.po
+++ b/liblepton/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-12 00:08+0300\n"
+"POT-Creation-Date: 2019-05-13 11:16+0300\n"
 "PO-Revision-Date: 2012-01-31 12:11+0000\n"
 "Last-Translator: Peter TB Brett <Unknown>\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -18,46 +18,37 @@ msgstr ""
 "X-Launchpad-Export-Date: 2012-11-14 16:52+0000\n"
 "X-Generator: Launchpad (build 16265)\n"
 
-#: liblepton/data/liblepton.xml.in:3
 #, fuzzy
 msgid "Lepton EDA circuit schematic"
 msgstr "‏مخطّط دارة gEDA"
 
-#: liblepton/data/liblepton.xml.in:4
 #, fuzzy
 msgid "Lepton EDA schematic symbol"
 msgstr "رمز مخطّط gEDA"
 
-#: liblepton/data/liblepton.xml.in:5
 #, fuzzy
 msgid "Lepton EDA sch2pcb project"
 msgstr "مشروع gEDA gsch2pcb"
 
-#: liblepton/data/x-lepton-sch2pcb-project.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA sch2pcb Project"
 msgstr "مشروع gEDA Gsch2pcb"
 
-#: liblepton/data/x-lepton-schematic.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Circuit Schematic"
 msgstr "مخطط دارة gEDA"
 
-#: liblepton/data/x-lepton-symbol.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Schematic Symbol"
 msgstr "رمز مخطّط gEDA"
 
-#: liblepton/src/a_basic.c:57 liblepton/src/f_basic.c:377
 #, c-format
 msgid "File %1$s is read-only"
 msgstr ""
 
-#: liblepton/src/a_basic.c:114
 msgid "Schematic data was not valid UTF-8"
 msgstr ""
 
-#: liblepton/src/a_basic.c:246
 #, fuzzy, c-format
 msgid ""
 "Read unexpected attach symbol start marker in [%1$s] :\n"
@@ -68,7 +59,6 @@ msgstr ""
 ">>\n"
 "%s<<\n"
 
-#: liblepton/src/a_basic.c:263
 #, fuzzy, c-format
 msgid ""
 "Read unexpected embedded symbol start marker in [%1$s] :\n"
@@ -79,7 +69,6 @@ msgstr ""
 ">>\n"
 "%s<<\n"
 
-#: liblepton/src/a_basic.c:294
 #, c-format
 msgid ""
 "Read unexpected embedded symbol end marker in [%s] :\n"
@@ -90,7 +79,6 @@ msgstr ""
 ">>\n"
 "%s<<\n"
 
-#: liblepton/src/a_basic.c:329
 #, fuzzy, c-format
 msgid ""
 "Read an old format sym/sch file!\n"
@@ -101,7 +89,6 @@ msgstr ""
 "الرجاء تشغيل g[sym|sch]update في:\n"
 "[%s]\n"
 
-#: liblepton/src/a_basic.c:335
 #, fuzzy, c-format
 msgid ""
 "Read garbage in [%1$s] :\n"
@@ -112,17 +99,14 @@ msgstr ""
 ">>\n"
 "%s<<\n"
 
-#: liblepton/src/f_basic.c:119 liblepton/src/f_basic.c:132
 #, fuzzy, c-format
 msgid "Failed to stat [%1$s]: %2$s"
 msgstr "فشل إلى الحالة  [%s]: %s"
 
-#: liblepton/src/f_basic.c:211
 #, fuzzy, c-format
 msgid "Cannot find file %1$s: %2$s"
 msgstr "يتعذّر العثور على الملف ‪%s‬: %s"
 
-#: liblepton/src/f_basic.c:260
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -136,11 +120,9 @@ msgstr ""
 "  %s.\n"
 "\n"
 
-#: liblepton/src/f_basic.c:262
 msgid "I could not guess if it is newer, so you have to do it manually.\n"
 msgstr "لم أستطع تخمين ما إذا كان أحدث، لذلك عليك أن تفعل ذلك يدويا.\n"
 
-#: liblepton/src/f_basic.c:264
 msgid ""
 "The backup copy is newer than the schematic, so it seems you should load it "
 "instead of the original file.\n"
@@ -148,7 +130,6 @@ msgstr ""
 "النسخة الاحتياطية أحدث من المخطّط، لذلك على ما يبدو يجب عليك تحميله بدلا من "
 "الملف الأصلي.\n"
 
-#: liblepton/src/f_basic.c:266
 #, fuzzy
 msgid ""
 "lepton-schematic usually makes backup copies automatically, and this "
@@ -157,7 +138,6 @@ msgstr ""
 "عادة ما يعمل gschem نسخا احتياطية تلقائيا، وهذا الوضع يحدث عندما يتحطم أو "
 "يجبر على الخروج بشكل مفاجئ.\n"
 
-#: liblepton/src/f_basic.c:269
 #, fuzzy
 msgid ""
 "\n"
@@ -168,230 +148,175 @@ msgstr ""
 "شغل gschem و صحح الوضع.\n"
 "\n"
 
-#: liblepton/src/f_basic.c:367
 #, fuzzy, c-format
 msgid "Can't get the real filename of %1$s: %2$s"
 msgstr "‏s_page_delete : يتعذر الحصول على الاسم الحقيقي للملف %s.‏"
 
-#: liblepton/src/f_basic.c:398
 #, fuzzy, c-format
 msgid "Could NOT set previous backup file [%1$s] read-write."
 msgstr "تعذّر وضع الملف الاحتياطي السابق [‎%s‬] للقراءة والكتابة\n"
 
-#: liblepton/src/f_basic.c:404
 #, fuzzy, c-format
 msgid "Can't save backup file: %1$s."
 msgstr "يتعذّر حفظ الملف الاحتياطي: %s."
 
-#: liblepton/src/f_basic.c:414
 #, fuzzy, c-format
 msgid "Could NOT set backup file [%1$s] readonly."
 msgstr "تعذّر وضع الملف الاحتياطي [‎%s‬] للقراءة فقط\n"
 
-#: liblepton/src/f_basic.c:463
 #, fuzzy, c-format
 msgid "Failed to restore permissions on '%1$s': %2$s\n"
 msgstr "فشل في فتح الدليل [%s]: %s\n"
 
-#: liblepton/src/f_basic.c:468
 #, fuzzy, c-format
 msgid "Failed to restore ownership on '%1$s': %2$s\n"
 msgstr "فشل في فتح الدليل [%s]: %s\n"
 
-#: liblepton/src/f_basic.c:478
 #, fuzzy, c-format
 msgid "Could NOT save file: %1$s"
 msgstr "تعذّر حفظ [‎%s‬]\n"
 
-#: liblepton/src/f_basic.c:604
 #, c-format
 msgid "%s: %s"
 msgstr "%s: %s"
 
-#: liblepton/src/g_basic.c:260
 msgid ""
 "\n"
 "Backtrace:\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:99
 #, fuzzy, c-format
 msgid "Invalid mode [%1$s] passed to %2$s\n"
 msgstr "لم يعثر على المكون [%s] في المكتبة المكونات\n"
 
-#: liblepton/src/g_rc.c:139
 msgid "RC file already loaded"
 msgstr ""
 
-#: liblepton/src/g_rc.c:183
 #, fuzzy, c-format
 msgid "Failed to load config from '%1$s': %2$s\n"
 msgstr "‏تعذر تحميل الصورة من الملف ‬‪[%s]‬:‪ %s‮\n"
 
-#: liblepton/src/g_rc.c:207
 #, fuzzy, c-format
 msgid "Loaded RC file [%1$s]"
 msgstr "فشل أمر المكتبة [%s]\n"
 
-#: liblepton/src/g_rc.c:211
 #, fuzzy, c-format
 msgid "Failed to load RC file [%1$s]: "
 msgstr "‏تعذر تحميل الصورة من الملف ‬‪[%s]‬:‪ %s‮\n"
 
-#: liblepton/src/g_rc.c:341
 msgid "ERROR: An unknown error occurred while parsing configuration files."
 msgstr ""
 
-#: liblepton/src/g_rc.c:353
 #, c-format
 msgid "ERROR: %1$s"
 msgstr ""
 
-#: liblepton/src/g_rc.c:354
 #, c-format
 msgid "ERROR: %1$s\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:360
 #, c-format
 msgid "ERROR: The %1$s log may contain more information.\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:512
 #, fuzzy, c-format
 msgid "Invalid path [%1$s] passed to component-library\n"
 msgstr "لم يعثر على المكون [%s] في المكتبة المكونات\n"
 
-#: liblepton/src/g_rc.c:738
 #, fuzzy, c-format
 msgid "Invalid path [%1$s] passed to bitmap-directory\n"
 msgstr "لم يعثر على المكون [%s] في المكتبة المكونات\n"
 
-#: liblepton/src/geda_page.c:197
 #, fuzzy, c-format
 msgid "s_page_delete: Can't get the real filename of %1$s."
 msgstr "‏s_page_delete : يتعذر الحصول على الاسم الحقيقي للملف %s.‏"
 
-#: liblepton/src/geda_page.c:208
 #, fuzzy, c-format
 msgid "s_page_delete: Unable to delete backup file %1$s."
 msgstr "‏s_page_delete: غير قادرة على حذف الملف الاحتياطي %s."
 
-#: liblepton/src/geda_page.c:490
 #, fuzzy, c-format
 msgid "Saved [%1$s]"
 msgstr "‏حفظ [%s]\n"
 
-#: liblepton/src/geda_page.c:496
 #, fuzzy, c-format
 msgid "Could NOT save [%1$s]"
 msgstr "تعذّر حفظ [‎%s‬]\n"
 
-#: liblepton/src/geda_arc_object.c:408 liblepton/src/geda_arc_object.c:421
 msgid "Failed to parse arc object"
 msgstr ""
 
-#: liblepton/src/geda_arc_object.c:428
 #, fuzzy, c-format
 msgid "Found a zero radius arc [ %1$c %2$d, %3$d, %4$d, %5$d, %6$d, %7$d ]"
 msgstr "عثر على قوس صفر الشعاع [ %c %d, %d, %d, %d, %d, %d ]\n"
 
-#: liblepton/src/geda_arc_object.c:435 liblepton/src/geda_box_object.c:328
-#: liblepton/src/geda_bus_object.c:364 liblepton/src/geda_circle_object.c:387
-#: liblepton/src/geda_line_object.c:427 liblepton/src/geda_net_object.c:308
-#: liblepton/src/geda_path_object.c:214 liblepton/src/geda_pin_object.c:369
-#: liblepton/src/geda_text_object.c:555
 #, fuzzy, c-format
 msgid "Found an invalid color [ %1$s ]"
 msgstr "عثر على لون غير صالح [ %s ]\n"
 
-#: liblepton/src/geda_arc_object.c:436 liblepton/src/geda_box_object.c:329
-#: liblepton/src/geda_bus_object.c:365 liblepton/src/geda_circle_object.c:388
-#: liblepton/src/geda_line_object.c:428 liblepton/src/geda_net_object.c:309
-#: liblepton/src/geda_path_object.c:215 liblepton/src/geda_pin_object.c:370
-#: liblepton/src/geda_text_object.c:557
 #, fuzzy
 msgid "Setting color to default color."
 msgstr "تغيير لون إلى اللون الإفتراضي\n"
 
-#: liblepton/src/o_attrib.c:111
 #, c-format
 msgid "Attribute [%1$s] already attached\n"
 msgstr ""
 
-#: liblepton/src/o_attrib.c:117
 msgid "Attempt to attach non text item as an attribute!\n"
 msgstr "محاولة إرفاق عنصر غير نصي كسمة!\n"
 
-#: liblepton/src/o_attrib.c:122
 #, fuzzy, c-format
 msgid "Attempt to attach attribute [%1$s] to more than one object\n"
 msgstr "محاولة إرفاق السمة [%s] لأكثر من كائن واحد\n"
 
-#: liblepton/src/o_attrib.c:325
 msgid "Tried to attach a non-text item as an attribute"
 msgstr ""
 
-#: liblepton/src/o_attrib.c:332
 msgid "Unexpected end-of-file in attribute list"
 msgstr ""
 
-#: liblepton/src/geda_box_object.c:287 liblepton/src/geda_box_object.c:316
 msgid "Failed to parse box object"
 msgstr ""
 
-#: liblepton/src/geda_box_object.c:322
 #, fuzzy, c-format
 msgid "Found a zero width/height box [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr "عثر على إطار صفر العرض/الارتفاع [ %c %d %d %d %d %d ]\n"
 
-#: liblepton/src/geda_bus_object.c:345 liblepton/src/geda_bus_object.c:352
 msgid "Failed to parse bus object"
 msgstr ""
 
-#: liblepton/src/geda_bus_object.c:358
 #, fuzzy, c-format
 msgid "Found a zero length bus [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr "عثر على ناقل صفر الطول [ %c %d %d %d %d %d ]\n"
 
-#: liblepton/src/geda_bus_object.c:370
 #, fuzzy, c-format
 msgid "Found an invalid bus ripper direction [ %1$s ]"
 msgstr "عثر على اتجاه غير صالح لمموج الناقل [ %s ]\n"
 
-#: liblepton/src/geda_bus_object.c:371
 #, fuzzy
 msgid "Resetting direction to neutral (no direction)."
 msgstr "إعادة تعيين الاتجاه إلى محايد (دون اتجاه)\n"
 
-#: liblepton/src/geda_circle_object.c:343
-#: liblepton/src/geda_circle_object.c:372
 msgid "Failed to parse circle object"
 msgstr ""
 
-#: liblepton/src/geda_circle_object.c:379
 #, fuzzy, c-format
 msgid "Found a zero or negative radius circle [ %1$c %2$d %3$d %4$d %5$d ]"
 msgstr "عثر على قوس صفر الشعاع [ %c %d, %d, %d, %d, %d, %d ]\n"
 
-#: liblepton/src/geda_circle_object.c:382
 #, fuzzy
 msgid "Setting radius to 0."
 msgstr "تعيين 'زاوية' إلى 0\n"
 
-#: liblepton/src/geda_color.c:217
 msgid "Color map entry must be a two-element list"
 msgstr "يجب أن يكون إدخال خارطة اللون قائمة عنصرين"
 
-#: liblepton/src/geda_color.c:225
 msgid "Index in color map entry must be an integer"
 msgstr "يجب أن يكون الفهرس في إدخال خارطة اللون عددا صحيحا (integer)"
 
-#: liblepton/src/geda_color.c:251
 msgid "Value in color map entry must be #f or a string"
 msgstr "يجب أن تكون القيمة في إدخال خارطة اللون f# أو نص"
 
-#: liblepton/src/geda_complex_object.c:373
 #, fuzzy, c-format
 msgid ""
 "Component not found:\n"
@@ -400,36 +325,29 @@ msgstr ""
 "لم يعثر على مكون:\n"
 " %s"
 
-#: liblepton/src/geda_complex_object.c:585
 msgid "Failed to parse complex object"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:598
 #, fuzzy, c-format
 msgid ""
 "Found a component with an invalid rotation [ %1$c %2$d %3$d %4$d %5$d %6$d "
 "%7$s ]"
 msgstr "عثر على مكون باستدارة غير صالحة [ %c %d %d %d %d %d %s ]\n"
 
-#: liblepton/src/geda_complex_object.c:601
-#: liblepton/src/geda_picture_object.c:105
 #, fuzzy
 msgid "Setting angle to 0."
 msgstr "تعيين 'زاوية' إلى 0\n"
 
-#: liblepton/src/geda_complex_object.c:613
 #, fuzzy, c-format
 msgid ""
 "Found a component with an invalid mirror flag [ %1$c %2$d %3$d %4$d %5$d "
 "%6$d %7$s ]"
 msgstr "عثر على مكون بعلامة مرآة غير صالحة [ %c %d %d %d %d %d %s ]\n"
 
-#: liblepton/src/geda_complex_object.c:616
 #, fuzzy
 msgid "Setting mirror to 0."
 msgstr "تعيين 'معكوس' إلى 0\n"
 
-#: liblepton/src/geda_complex_object.c:941
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
@@ -438,7 +356,6 @@ msgstr ""
 "تحذير: خطأ عند تحليل(إعراب) إصدار الرمز في refdes %s:\n"
 "‏\tتعذر تحليل ملف الرمز symversion=%s\n"
 
-#: liblepton/src/geda_complex_object.c:945
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
@@ -447,7 +364,6 @@ msgstr ""
 "تحذير: خطأ عند تحليل(إعراب) إصدار الرمز في refdes %s:\n"
 "‏\tتعذر تحليل ملف الرمز symversion=\n"
 
-#: liblepton/src/geda_complex_object.c:961
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
@@ -456,7 +372,6 @@ msgstr ""
 "تحذير: خطأ عند تحليل(إعراب) إصدار الرمز في refdes %s:\n"
 "‏\tتعذر تحليل المرفق symversion=%s\n"
 
-#: liblepton/src/geda_complex_object.c:986
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version oddity on refdes %1$s:\n"
@@ -466,7 +381,6 @@ msgstr ""
 "‏تحذير:  غرابة إصدار الرمز في refdes %s:\n"
 "‏\t‏symversion=%s مرفق إلى رمز مماثل، و لكن لا symversion= ضمن ملف الرمز\n"
 
-#: liblepton/src/geda_complex_object.c:1000
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version mismatch on refdes %1$s (%2$s):\n"
@@ -475,17 +389,14 @@ msgstr ""
 "تحذير: عدم تطابق رمز الإصدار في refdes %s (%s):\n"
 "‏\tالرمز في المكتبة أحدث من مثيله\n"
 
-#: liblepton/src/geda_complex_object.c:1028
 #, fuzzy, c-format
 msgid "\tMAJOR VERSION CHANGE (file %1$.3f, instantiated %2$.3f, %3$s)!"
 msgstr "\t‏\tتغيير أساسي في الإصدار (الملف %.3f، المثيل %.3f، %s)!\n"
 
-#: liblepton/src/geda_complex_object.c:1046
 #, fuzzy, c-format
 msgid "\tMinor version change (file %1$.3f, instantiated %2$.3f)"
 msgstr "\t‏\tتغيير ثانوي في الإصدار (الملف %.3f، المثيل %.3f)\n"
 
-#: liblepton/src/geda_complex_object.c:1057
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version oddity on refdes %1$s:\n"
@@ -494,12 +405,10 @@ msgstr ""
 "تحذير:  غرابة إصدار الرمز في refdes %s:\n"
 "‏\tالمثيل أحدث من الرمز في المكتبة\n"
 
-#: liblepton/src/o_embed.c:54
 #, fuzzy, c-format
 msgid "Component [%1$s] has been embedded."
 msgstr "تم تضمين المكون [‪%s‬]\n"
 
-#: liblepton/src/o_embed.c:98
 #, fuzzy, c-format
 msgid ""
 "Could not find component [%1$s], while trying to unembed. Component is still "
@@ -507,149 +416,118 @@ msgid ""
 msgstr ""
 "﻿تعذر العثور على المكون [%s]، عند محاولة إلغاء التضمين. لا يزال المكون مضمنا\n"
 
-#: liblepton/src/o_embed.c:106
 #, fuzzy, c-format
 msgid "Component [%1$s] has been successfully unembedded."
 msgstr "ألغي تضمين المكون [%s] بنجاح\n"
 
-#: liblepton/src/geda_line_object.c:391 liblepton/src/geda_line_object.c:409
 msgid "Failed to parse line object"
 msgstr ""
 
-#: liblepton/src/geda_line_object.c:421
 #, fuzzy, c-format
 msgid "Found a zero length line [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr "عثر على خط صفر الطول [ %c %d %d %d %d %d ]\n"
 
-#: liblepton/src/geda_net_object.c:297
 msgid "Failed to parse net object"
 msgstr ""
 
-#: liblepton/src/geda_net_object.c:302
 #, fuzzy, c-format
 msgid "Found a zero length net [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr "عثر على شبكة صفر الطول [ %c %d %d %d %d %d ]\n"
 
-#: liblepton/src/geda_path_object.c:206
 msgid "Failed to parse path object"
 msgstr ""
 
-#: liblepton/src/geda_path_object.c:232
 msgid "Unexpected end-of-file when reading path"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:71
 msgid "Failed to parse picture definition"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:76
 #, fuzzy, c-format
 msgid "Found a zero width/height picture [ %1$c %2$d %3$d %4$d %5$d ]"
 msgstr "﻿عثر على صورة صفر العرض/الارتفاع [ %c %d %d %d %d ]\n"
 
-#: liblepton/src/geda_picture_object.c:82
 #, c-format
 msgid "Found a picture with a wrong 'mirrored' parameter: %1$d."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:84
 #, fuzzy
 msgid "Setting mirrored to 0."
 msgstr "تعيين 'معكوس' إلى 0\n"
 
-#: liblepton/src/geda_picture_object.c:89
 #, c-format
 msgid "Found a picture with a wrong 'embedded' parameter: %1$d."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:91
 #, fuzzy
 msgid "Setting embedded to 0."
 msgstr "تعيين 'مضمّن' إلى 0\n"
 
-#: liblepton/src/geda_picture_object.c:104
 #, fuzzy, c-format
 msgid "Found an unsupported picture angle [ %1$d ]"
 msgstr "عثر على زاوية صورة غير مدعومة [ %d ]\n"
 
-#: liblepton/src/geda_picture_object.c:116
 msgid "Found an image with no filename."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:147
 #, fuzzy, c-format
 msgid "Failed to load image from embedded data [%1$s]: %2$s"
 msgstr "‏تعذر تحميل الصورة من البيانات المضمنّة ‬‪[%s]‬:‪ %s‮\n"
 
-#: liblepton/src/geda_picture_object.c:148
 msgid "Base64 decoding failed."
 msgstr "فشل ترميز Base64."
 
-#: liblepton/src/geda_picture_object.c:149
 #, fuzzy
 msgid "Falling back to file loading. Picture unembedded."
 msgstr "التراجع لتحميل الملف. ألغي تضمين الصورة.\n"
 
-#: liblepton/src/geda_picture_object.c:208
 #, fuzzy
 msgid "ERROR: o_picture_save: unable to encode the picture."
 msgstr "﻿خطأ: o_picture_save: غير قادر على ترميز الصورة.\n"
 
-#: liblepton/src/geda_picture_object.c:308
 #, fuzzy, c-format
 msgid "Failed to load buffer image [%1$s]: %2$s"
 msgstr "‏تعذر تحميل الرمز من الملف [%s]: %s\n"
 
-#: liblepton/src/geda_picture_object.c:321
 #, fuzzy, c-format
 msgid "Failed to load image from [%1$s]: %2$s"
 msgstr "‏تعذر تحميل الصورة من الملف ‬‪[%s]‬:‪ %s‮\n"
 
-#: liblepton/src/geda_picture_object.c:415
 #, c-format
 msgid "Picture %1$p has invalid angle %2$i\n"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:772
 #, fuzzy, c-format
 msgid "Picture [%1$s] has no image data."
 msgstr "تم تضمين الصورة [‪%s‬]\n"
 
-#: liblepton/src/geda_picture_object.c:773
 #, fuzzy
 msgid "Falling back to file loading. Picture is still unembedded."
 msgstr "التراجع لتحميل الملف. ألغي تضمين الصورة.\n"
 
-#: liblepton/src/geda_picture_object.c:781
 #, fuzzy, c-format
 msgid "Picture [%1$s] has been embedded."
 msgstr "تم تضمين الصورة [‪%s‬]\n"
 
-#: liblepton/src/geda_picture_object.c:805
 #, fuzzy, c-format
 msgid "Failed to load image from file [%1$s]: %2$s"
 msgstr "‏تعذر تحميل الصورة من الملف ‬‪[%s]‬:‪ %s‮\n"
 
-#: liblepton/src/geda_picture_object.c:807
 #, fuzzy
 msgid "Picture is still embedded."
 msgstr "تم تضمين الصورة [‪%s‬]\n"
 
-#: liblepton/src/geda_picture_object.c:815
 #, fuzzy, c-format
 msgid "Picture [%1$s] has been unembedded."
 msgstr "تم إلغاء تضمين الصورة [‪%s‬]\n"
 
-#: liblepton/src/geda_picture_object.c:1052
 #, fuzzy, c-format
 msgid "Failed to load fallback image %1$s: %2$s.\n"
 msgstr "‏تعذر تحميل الصورة من الملف ‬‪[%s]‬:‪ %s‮\n"
 
-#: liblepton/src/geda_pin_object.c:346 liblepton/src/geda_pin_object.c:354
 msgid "Failed to parse pin object"
 msgstr ""
 
-#: liblepton/src/geda_pin_object.c:360
 #, fuzzy
 msgid ""
 "Found a pin which did not have the whichend field set.\n"
@@ -658,68 +536,54 @@ msgstr ""
 "عثر على دبوس ليس لديه حقل whichone (أيّ-واحد) معين.\n"
 "تحقق منه وصحيحه يدويا.\n"
 
-#: liblepton/src/geda_pin_object.c:363
 #, fuzzy, c-format
 msgid "Found an invalid whichend on a pin (reseting to zero): %d"
 msgstr ""
 "عثر على whichend (أيّ-نهاية) غير صالح على دبوس (إعادة تعيين إلى الصفر): %d\n"
 
-#: liblepton/src/geda_text_object.c:495 liblepton/src/geda_text_object.c:505
-#: liblepton/src/geda_text_object.c:515
 msgid "Failed to parse text object"
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:522
 #, fuzzy, c-format
 msgid "Found an invalid text size [ %1$s ]"
 msgstr "عثر على لون غير صالح [ %s ]\n"
 
-#: liblepton/src/geda_text_object.c:524
 #, fuzzy, c-format
 msgid "Setting text size to %1$d."
 msgstr "تعيين 'معكوس' إلى 0\n"
 
-#: liblepton/src/geda_text_object.c:528
 #, fuzzy, c-format
 msgid "Found an unsupported text angle [ %1$s ]"
 msgstr "عثر على زاوية صورة غير مدعومة [ %d ]\n"
 
-#: liblepton/src/geda_text_object.c:530
 #, fuzzy, c-format
 msgid "Setting angle to %1$d."
 msgstr "تعيين 'زاوية' إلى 0\n"
 
-#: liblepton/src/geda_text_object.c:547
 #, fuzzy, c-format
 msgid "Found an unsupported text alignment [ %1$s ]"
 msgstr "عثر على زاوية صورة غير مدعومة [ %d ]\n"
 
-#: liblepton/src/geda_text_object.c:550
 #, fuzzy
 msgid "Setting alignment to LOWER_LEFT."
 msgstr "تعيين المحاذاة إلى LOWER_LEFT (اليسار-السفلي)\n"
 
-#: liblepton/src/geda_text_object.c:570
 #, c-format
 msgid "Unexpected end-of-file after %1$d lines"
 msgstr ""
 
-#: liblepton/src/s_clib.c:460
 #, fuzzy, c-format
 msgid "Library command failed [%1$s]: %2$s"
 msgstr "فشل أمر المكتبة [%s]: %s\n"
 
-#: liblepton/src/s_clib.c:465
 #, fuzzy, c-format
 msgid "Library command failed [%1$s]: Uncaught signal %2$i."
 msgstr "فشل أمر المكتبة [%s]: إشارة لم تمسك %i.\n"
 
-#: liblepton/src/s_clib.c:469
 #, fuzzy, c-format
 msgid "Library command failed [%1$s]"
 msgstr "فشل أمر المكتبة [%s]\n"
 
-#: liblepton/src/s_clib.c:470
 #, fuzzy, c-format
 msgid ""
 "Error output was:\n"
@@ -728,32 +592,26 @@ msgstr ""
 "كان خطأ الإخراج:\n"
 "%s\n"
 
-#: liblepton/src/s_clib.c:556
 #, fuzzy, c-format
 msgid "Library name [%1$s] already in use.  Using [%2$s]."
 msgstr "اسم المكتبة [%s] قيد الاستخدام بالفعل.استعمال [%s].\n"
 
-#: liblepton/src/s_clib.c:593
 #, fuzzy, c-format
 msgid "Failed to open directory [%1$s]: %2$s"
 msgstr "فشل في فتح الدليل [%s]: %s\n"
 
-#: liblepton/src/s_clib.c:729
 #, fuzzy, c-format
 msgid "Failed to scan library [%1$s]: Scheme function returned non-list."
 msgstr "فشل في فحص المكتبة [%s]: أرجعت الدالة Scheme كائن آخر ليس قائمة\n"
 
-#: liblepton/src/s_clib.c:737
 #, fuzzy, c-format
 msgid "Non-string symbol name while scanning library [%1$s]"
 msgstr "عثر على اسم رمز غير نصي أثناء تفحص المكتبة [%s]\n"
 
-#: liblepton/src/s_clib.c:893 liblepton/src/s_clib.c:940
 #, fuzzy
 msgid "Cannot add library: name not specified."
 msgstr "يتعذر إضافة المكتبة: لم يحدد الاسم\n"
 
-#: liblepton/src/s_clib.c:900
 #, fuzzy, c-format
 msgid ""
 "Cannot add library [%1$s]: both 'list' and 'get' commands must be specified."
@@ -761,263 +619,201 @@ msgstr ""
 "يتعذر إضافة المكتبة [%s]: يجب تحديد الأوامر 'list' (قائمة) و 'get' (أحصل "
 "على).\n"
 
-#: liblepton/src/s_clib.c:948
 #, fuzzy, c-format
 msgid "Cannot add Scheme-library [%1$s]: callbacks must be closures."
 msgstr "يتعذّر إضافة مكتبة Scheme [%s]: الرد يجب أن يكون الإغلاق.\n"
 
-#: liblepton/src/s_clib.c:1075
 #, fuzzy, c-format
 msgid "Failed to load symbol from file [%1$s]: %2$s"
 msgstr "‏تعذر تحميل الرمز من الملف [%s]: %s\n"
 
-#: liblepton/src/s_clib.c:1135
 #, fuzzy, c-format
 msgid "Failed to load symbol data [%1$s] from source [%2$s]"
 msgstr "تعذر تحميل بيانات الرمز [%s] من المصدر [%s]\n"
 
-#: liblepton/src/s_clib.c:1377
 #, fuzzy, c-format
 msgid "Component [%1$s] was not found in the component library."
 msgstr "لم يعثر على المكون [%s] في المكتبة المكونات\n"
 
-#: liblepton/src/s_clib.c:1383
 #, fuzzy, c-format
 msgid "More than one component found with name [%1$s]."
 msgstr "أكثر من مكون واحد عثر عليه باسم [%s]\n"
 
-#: liblepton/src/s_hierarchy.c:78 liblepton/src/s_hierarchy.c:240
 msgid "Schematic not found in source library."
 msgstr ""
 
-#: liblepton/src/s_hierarchy.c:100
 msgid "Hierarchy contains a circular dependency."
 msgstr ""
 
-#: liblepton/src/s_hierarchy.c:200
 #, fuzzy
 msgid "There are no schematics above the current one!"
 msgstr "لا توجد مخططات فوق المخطط الحالي!\n"
 
-#: liblepton/src/s_hierarchy.c:341
 #, fuzzy, c-format
 msgid "Failed to descend hierarchy into '%1$s': %2$s"
 msgstr "فشل في فتح الدليل [%s]: %s\n"
 
-#: liblepton/src/s_slot.c:158
 msgid "Did not find slotdef=#:#,#,#... attribute."
 msgstr ""
 
-#: liblepton/src/s_slot.c:164
 msgid "Improper slotdef syntax: missing \":\"."
 msgstr ""
 
-#: liblepton/src/s_slot.c:179
 msgid "Did not find proper slotdef=#:#,#,#... attribute."
 msgstr ""
 
-#: liblepton/src/s_slot.c:209
 msgid "component missing pinseq= attribute."
 msgstr ""
 
-#: liblepton/src/edaconfig.c:694 liblepton/src/edaconfig.c:780
 msgid "Undefined configuration filename"
 msgstr ""
 
-#: liblepton/src/edaconfig.c:1105 liblepton/src/edaconfig.c:1169
 #, c-format
 msgid "Configuration does not have group '%s'"
 msgstr ""
 
-#: liblepton/src/edaconfig.c:1183
 #, c-format
 msgid "Configuration does not have key '%s'"
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:66 liblepton/src/scheme_attrib.c:100
 msgid "~A is not a valid attribute: invalid string '~A'."
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:204
 msgid "Objects ~A and ~A are not part of the same page and/or complex object"
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:211 liblepton/src/scheme_attrib.c:216
 msgid "Object ~A is already attached as an attribute"
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:265
 msgid "Object ~A is attribute of wrong object"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:148
 msgid "Invalid complex angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:270 liblepton/src/scheme_page.c:246
 msgid "Object ~A is already attached to something"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:332
 msgid "Object ~A is attached to a different complex"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:339
 msgid "Object ~A is attached to a page"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:346 liblepton/src/scheme_page.c:298
 msgid "Object ~A is attached as an attribute"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:353 liblepton/src/scheme_page.c:305
 msgid "Object ~A has attributes"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:234
 msgid "Object ~A has bad type '~A'"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:378
 msgid "Object ~A has invalid stroke cap style ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:391
 msgid "Object ~A has invalid stroke dash style ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:455
 msgid "Invalid stroke cap style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:466
 msgid "Invalid stroke dash style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:476
 msgid "Missing dash length parameter for dash style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:486
 msgid "Missing dot/dash space parameter for dash style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:554
 msgid "Object ~A has invalid fill style ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:603
 msgid "Invalid fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:611
 msgid "Missing second space parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:620
 msgid "Missing second angle parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:630
 msgid "Missing stroke width parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:639
 msgid "Missing space parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:648
 msgid "Missing angle parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:962
 msgid "Invalid pin type ~A, must be 'net or 'bus"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1011
 msgid "Object ~A has invalid pin type."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1417
 msgid "Invalid text alignment ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1433
 msgid "Invalid text angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1452
 msgid "Invalid text name/value visibility ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1526
 msgid "Text object ~A has invalid text alignment ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1535
 msgid "Text object ~A has invalid visibility ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1545
 msgid "Text object ~A has invalid text attribute visibility ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1586
 msgid "Object ~A is not included in a page."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1739
 msgid "Path object ~A has invalid element type ~A at index ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1853
 msgid "Invalid path element type ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:2025
 msgid "Invalid picture angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr ""
 
-#: liblepton/src/scheme_page.c:291
 msgid "Object ~A is attached to a complex or different page"
 msgstr ""
 
-#: liblepton/src/scheme_page.c:438
 msgid "Parse error: ~s"
 msgstr ""
 
-#: liblepton/src/edascmhookproxy.c:83
 msgid "Scheme hook"
 msgstr ""
 
-#: liblepton/src/edascmhookproxy.c:84
 msgid "The Scheme-level hook to proxy"
 msgstr ""
 
-#: liblepton/scheme/geda/attrib.scm:56
 #, scheme-format
 msgid "Object ~A is not part of a page"
 msgstr ""
 
-#: liblepton/scheme/geda/library.scm:108
 #, scheme-format
 msgid "Invalid path ~S or source not readable.\n"
 msgstr ""
 
-#: liblepton/scheme/geda/library.scm:109
 msgid "Source library path must be a string.\n"
 msgstr ""
 
-#: liblepton/scheme/geda/library.scm:168
 #, scheme-format
 msgid "File ~S is not readable.\n"
 msgstr ""
 
-#: liblepton/scheme/geda/repl.scm:48
 msgid "Welcome to Lepton REPL!\n"
 msgstr ""
 
-#: liblepton/scheme/geda/repl.scm:53
 msgid "WARNING: Readline library is not supported in your configuration.\n"
 msgstr ""
 

--- a/liblepton/po/ca.po
+++ b/liblepton/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-12 00:08+0300\n"
+"POT-Creation-Date: 2019-05-13 11:16+0300\n"
 "PO-Revision-Date: 2012-01-27 14:12+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: Catalan <ca@li.org>\n"
@@ -18,46 +18,37 @@ msgstr ""
 "X-Launchpad-Export-Date: 2012-11-14 16:52+0000\n"
 "X-Generator: Launchpad (build 16265)\n"
 
-#: liblepton/data/liblepton.xml.in:3
 #, fuzzy
 msgid "Lepton EDA circuit schematic"
 msgstr "Esquema de circuit del gEDA"
 
-#: liblepton/data/liblepton.xml.in:4
 #, fuzzy
 msgid "Lepton EDA schematic symbol"
 msgstr "Símbol d'esquema del gEDA"
 
-#: liblepton/data/liblepton.xml.in:5
 #, fuzzy
 msgid "Lepton EDA sch2pcb project"
 msgstr "Projecte Gsch2pcb del gEDA"
 
-#: liblepton/data/x-lepton-sch2pcb-project.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA sch2pcb Project"
 msgstr "Projecte Gsch2pcb del gEDA"
 
-#: liblepton/data/x-lepton-schematic.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Circuit Schematic"
 msgstr "Esquema de circuit del gEDA"
 
-#: liblepton/data/x-lepton-symbol.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Schematic Symbol"
 msgstr "Símbol d'esquema del gEDA"
 
-#: liblepton/src/a_basic.c:57 liblepton/src/f_basic.c:377
 #, c-format
 msgid "File %1$s is read-only"
 msgstr ""
 
-#: liblepton/src/a_basic.c:114
 msgid "Schematic data was not valid UTF-8"
 msgstr ""
 
-#: liblepton/src/a_basic.c:246
 #, c-format
 msgid ""
 "Read unexpected attach symbol start marker in [%1$s] :\n"
@@ -65,7 +56,6 @@ msgid ""
 "%2$s<<\n"
 msgstr ""
 
-#: liblepton/src/a_basic.c:263
 #, c-format
 msgid ""
 "Read unexpected embedded symbol start marker in [%1$s] :\n"
@@ -73,7 +63,6 @@ msgid ""
 "%2$s<<\n"
 msgstr ""
 
-#: liblepton/src/a_basic.c:294
 #, c-format
 msgid ""
 "Read unexpected embedded symbol end marker in [%s] :\n"
@@ -81,7 +70,6 @@ msgid ""
 "%s<<\n"
 msgstr ""
 
-#: liblepton/src/a_basic.c:329
 #, c-format
 msgid ""
 "Read an old format sym/sch file!\n"
@@ -89,7 +77,6 @@ msgid ""
 "[%1$s]"
 msgstr ""
 
-#: liblepton/src/a_basic.c:335
 #, c-format
 msgid ""
 "Read garbage in [%1$s] :\n"
@@ -97,17 +84,14 @@ msgid ""
 "%2$s<<\n"
 msgstr ""
 
-#: liblepton/src/f_basic.c:119 liblepton/src/f_basic.c:132
 #, c-format
 msgid "Failed to stat [%1$s]: %2$s"
 msgstr ""
 
-#: liblepton/src/f_basic.c:211
 #, c-format
 msgid "Cannot find file %1$s: %2$s"
 msgstr ""
 
-#: liblepton/src/f_basic.c:260
 #, c-format
 msgid ""
 "\n"
@@ -116,305 +100,236 @@ msgid ""
 "\n"
 msgstr ""
 
-#: liblepton/src/f_basic.c:262
 msgid "I could not guess if it is newer, so you have to do it manually.\n"
 msgstr ""
 
-#: liblepton/src/f_basic.c:264
 msgid ""
 "The backup copy is newer than the schematic, so it seems you should load it "
 "instead of the original file.\n"
 msgstr ""
 
-#: liblepton/src/f_basic.c:266
 msgid ""
 "lepton-schematic usually makes backup copies automatically, and this "
 "situation happens when it crashed or it was forced to exit abruptly.\n"
 msgstr ""
 
-#: liblepton/src/f_basic.c:269
 msgid ""
 "\n"
 "Run lepton-schematic and correct the situation.\n"
 "\n"
 msgstr ""
 
-#: liblepton/src/f_basic.c:367
 #, c-format
 msgid "Can't get the real filename of %1$s: %2$s"
 msgstr ""
 
-#: liblepton/src/f_basic.c:398
 #, c-format
 msgid "Could NOT set previous backup file [%1$s] read-write."
 msgstr ""
 
-#: liblepton/src/f_basic.c:404
 #, c-format
 msgid "Can't save backup file: %1$s."
 msgstr ""
 
-#: liblepton/src/f_basic.c:414
 #, c-format
 msgid "Could NOT set backup file [%1$s] readonly."
 msgstr ""
 
-#: liblepton/src/f_basic.c:463
 #, c-format
 msgid "Failed to restore permissions on '%1$s': %2$s\n"
 msgstr ""
 
-#: liblepton/src/f_basic.c:468
 #, c-format
 msgid "Failed to restore ownership on '%1$s': %2$s\n"
 msgstr ""
 
-#: liblepton/src/f_basic.c:478
 #, c-format
 msgid "Could NOT save file: %1$s"
 msgstr ""
 
-#: liblepton/src/f_basic.c:604
 #, c-format
 msgid "%s: %s"
 msgstr ""
 
-#: liblepton/src/g_basic.c:260
 msgid ""
 "\n"
 "Backtrace:\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:99
 #, c-format
 msgid "Invalid mode [%1$s] passed to %2$s\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:139
 msgid "RC file already loaded"
 msgstr ""
 
-#: liblepton/src/g_rc.c:183
 #, c-format
 msgid "Failed to load config from '%1$s': %2$s\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:207
 #, c-format
 msgid "Loaded RC file [%1$s]"
 msgstr ""
 
-#: liblepton/src/g_rc.c:211
 #, c-format
 msgid "Failed to load RC file [%1$s]: "
 msgstr ""
 
-#: liblepton/src/g_rc.c:341
 msgid "ERROR: An unknown error occurred while parsing configuration files."
 msgstr ""
 
-#: liblepton/src/g_rc.c:353
 #, c-format
 msgid "ERROR: %1$s"
 msgstr ""
 
-#: liblepton/src/g_rc.c:354
 #, c-format
 msgid "ERROR: %1$s\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:360
 #, c-format
 msgid "ERROR: The %1$s log may contain more information.\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:512
 #, c-format
 msgid "Invalid path [%1$s] passed to component-library\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:738
 #, c-format
 msgid "Invalid path [%1$s] passed to bitmap-directory\n"
 msgstr ""
 
-#: liblepton/src/geda_page.c:197
 #, c-format
 msgid "s_page_delete: Can't get the real filename of %1$s."
 msgstr ""
 
-#: liblepton/src/geda_page.c:208
 #, c-format
 msgid "s_page_delete: Unable to delete backup file %1$s."
 msgstr ""
 
-#: liblepton/src/geda_page.c:490
 #, c-format
 msgid "Saved [%1$s]"
 msgstr ""
 
-#: liblepton/src/geda_page.c:496
 #, c-format
 msgid "Could NOT save [%1$s]"
 msgstr ""
 
-#: liblepton/src/geda_arc_object.c:408 liblepton/src/geda_arc_object.c:421
 msgid "Failed to parse arc object"
 msgstr ""
 
-#: liblepton/src/geda_arc_object.c:428
 #, c-format
 msgid "Found a zero radius arc [ %1$c %2$d, %3$d, %4$d, %5$d, %6$d, %7$d ]"
 msgstr ""
 
-#: liblepton/src/geda_arc_object.c:435 liblepton/src/geda_box_object.c:328
-#: liblepton/src/geda_bus_object.c:364 liblepton/src/geda_circle_object.c:387
-#: liblepton/src/geda_line_object.c:427 liblepton/src/geda_net_object.c:308
-#: liblepton/src/geda_path_object.c:214 liblepton/src/geda_pin_object.c:369
-#: liblepton/src/geda_text_object.c:555
 #, c-format
 msgid "Found an invalid color [ %1$s ]"
 msgstr ""
 
-#: liblepton/src/geda_arc_object.c:436 liblepton/src/geda_box_object.c:329
-#: liblepton/src/geda_bus_object.c:365 liblepton/src/geda_circle_object.c:388
-#: liblepton/src/geda_line_object.c:428 liblepton/src/geda_net_object.c:309
-#: liblepton/src/geda_path_object.c:215 liblepton/src/geda_pin_object.c:370
-#: liblepton/src/geda_text_object.c:557
 msgid "Setting color to default color."
 msgstr ""
 
-#: liblepton/src/o_attrib.c:111
 #, c-format
 msgid "Attribute [%1$s] already attached\n"
 msgstr ""
 
-#: liblepton/src/o_attrib.c:117
 msgid "Attempt to attach non text item as an attribute!\n"
 msgstr ""
 
-#: liblepton/src/o_attrib.c:122
 #, c-format
 msgid "Attempt to attach attribute [%1$s] to more than one object\n"
 msgstr ""
 
-#: liblepton/src/o_attrib.c:325
 msgid "Tried to attach a non-text item as an attribute"
 msgstr ""
 
-#: liblepton/src/o_attrib.c:332
 msgid "Unexpected end-of-file in attribute list"
 msgstr ""
 
-#: liblepton/src/geda_box_object.c:287 liblepton/src/geda_box_object.c:316
 msgid "Failed to parse box object"
 msgstr ""
 
-#: liblepton/src/geda_box_object.c:322
 #, c-format
 msgid "Found a zero width/height box [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr ""
 
-#: liblepton/src/geda_bus_object.c:345 liblepton/src/geda_bus_object.c:352
 msgid "Failed to parse bus object"
 msgstr ""
 
-#: liblepton/src/geda_bus_object.c:358
 #, c-format
 msgid "Found a zero length bus [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr ""
 
-#: liblepton/src/geda_bus_object.c:370
 #, c-format
 msgid "Found an invalid bus ripper direction [ %1$s ]"
 msgstr ""
 
-#: liblepton/src/geda_bus_object.c:371
 msgid "Resetting direction to neutral (no direction)."
 msgstr ""
 
-#: liblepton/src/geda_circle_object.c:343
-#: liblepton/src/geda_circle_object.c:372
 msgid "Failed to parse circle object"
 msgstr ""
 
-#: liblepton/src/geda_circle_object.c:379
 #, c-format
 msgid "Found a zero or negative radius circle [ %1$c %2$d %3$d %4$d %5$d ]"
 msgstr ""
 
-#: liblepton/src/geda_circle_object.c:382
 msgid "Setting radius to 0."
 msgstr ""
 
-#: liblepton/src/geda_color.c:217
 msgid "Color map entry must be a two-element list"
 msgstr ""
 
-#: liblepton/src/geda_color.c:225
 msgid "Index in color map entry must be an integer"
 msgstr ""
 
-#: liblepton/src/geda_color.c:251
 msgid "Value in color map entry must be #f or a string"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:373
 #, c-format
 msgid ""
 "Component not found:\n"
 " %1$s"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:585
 msgid "Failed to parse complex object"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:598
 #, c-format
 msgid ""
 "Found a component with an invalid rotation [ %1$c %2$d %3$d %4$d %5$d %6$d "
 "%7$s ]"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:601
-#: liblepton/src/geda_picture_object.c:105
 msgid "Setting angle to 0."
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:613
 #, c-format
 msgid ""
 "Found a component with an invalid mirror flag [ %1$c %2$d %3$d %4$d %5$d "
 "%6$d %7$s ]"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:616
 msgid "Setting mirror to 0."
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:941
 #, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
 "\tCould not parse symbol file symversion=%2$s"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:945
 #, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
 "\tCould not parse symbol file symversion="
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:961
 #, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
 "\tCould not parse attached symversion=%2$s"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:986
 #, c-format
 msgid ""
 "WARNING: Symbol version oddity on refdes %1$s:\n"
@@ -422,536 +337,417 @@ msgid ""
 "symbol file."
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:1000
 #, c-format
 msgid ""
 "WARNING: Symbol version mismatch on refdes %1$s (%2$s):\n"
 "\tSymbol in library is newer than instantiated symbol."
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:1028
 #, c-format
 msgid "\tMAJOR VERSION CHANGE (file %1$.3f, instantiated %2$.3f, %3$s)!"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:1046
 #, c-format
 msgid "\tMinor version change (file %1$.3f, instantiated %2$.3f)"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:1057
 #, c-format
 msgid ""
 "WARNING: Symbol version oddity on refdes %1$s:\n"
 "\tInstantiated symbol is newer than symbol in library."
 msgstr ""
 
-#: liblepton/src/o_embed.c:54
 #, c-format
 msgid "Component [%1$s] has been embedded."
 msgstr ""
 
-#: liblepton/src/o_embed.c:98
 #, c-format
 msgid ""
 "Could not find component [%1$s], while trying to unembed. Component is still "
 "embedded."
 msgstr ""
 
-#: liblepton/src/o_embed.c:106
 #, c-format
 msgid "Component [%1$s] has been successfully unembedded."
 msgstr ""
 
-#: liblepton/src/geda_line_object.c:391 liblepton/src/geda_line_object.c:409
 msgid "Failed to parse line object"
 msgstr ""
 
-#: liblepton/src/geda_line_object.c:421
 #, c-format
 msgid "Found a zero length line [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr ""
 
-#: liblepton/src/geda_net_object.c:297
 msgid "Failed to parse net object"
 msgstr ""
 
-#: liblepton/src/geda_net_object.c:302
 #, c-format
 msgid "Found a zero length net [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr ""
 
-#: liblepton/src/geda_path_object.c:206
 msgid "Failed to parse path object"
 msgstr ""
 
-#: liblepton/src/geda_path_object.c:232
 msgid "Unexpected end-of-file when reading path"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:71
 msgid "Failed to parse picture definition"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:76
 #, c-format
 msgid "Found a zero width/height picture [ %1$c %2$d %3$d %4$d %5$d ]"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:82
 #, c-format
 msgid "Found a picture with a wrong 'mirrored' parameter: %1$d."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:84
 msgid "Setting mirrored to 0."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:89
 #, c-format
 msgid "Found a picture with a wrong 'embedded' parameter: %1$d."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:91
 msgid "Setting embedded to 0."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:104
 #, c-format
 msgid "Found an unsupported picture angle [ %1$d ]"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:116
 msgid "Found an image with no filename."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:147
 #, c-format
 msgid "Failed to load image from embedded data [%1$s]: %2$s"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:148
 msgid "Base64 decoding failed."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:149
 msgid "Falling back to file loading. Picture unembedded."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:208
 msgid "ERROR: o_picture_save: unable to encode the picture."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:308
 #, c-format
 msgid "Failed to load buffer image [%1$s]: %2$s"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:321
 #, c-format
 msgid "Failed to load image from [%1$s]: %2$s"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:415
 #, c-format
 msgid "Picture %1$p has invalid angle %2$i\n"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:772
 #, c-format
 msgid "Picture [%1$s] has no image data."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:773
 msgid "Falling back to file loading. Picture is still unembedded."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:781
 #, c-format
 msgid "Picture [%1$s] has been embedded."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:805
 #, c-format
 msgid "Failed to load image from file [%1$s]: %2$s"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:807
 msgid "Picture is still embedded."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:815
 #, c-format
 msgid "Picture [%1$s] has been unembedded."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:1052
 #, c-format
 msgid "Failed to load fallback image %1$s: %2$s.\n"
 msgstr ""
 
-#: liblepton/src/geda_pin_object.c:346 liblepton/src/geda_pin_object.c:354
 msgid "Failed to parse pin object"
 msgstr ""
 
-#: liblepton/src/geda_pin_object.c:360
 msgid ""
 "Found a pin which did not have the whichend field set.\n"
 "Verify and correct manually."
 msgstr ""
 
-#: liblepton/src/geda_pin_object.c:363
 #, c-format
 msgid "Found an invalid whichend on a pin (reseting to zero): %d"
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:495 liblepton/src/geda_text_object.c:505
-#: liblepton/src/geda_text_object.c:515
 msgid "Failed to parse text object"
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:522
 #, c-format
 msgid "Found an invalid text size [ %1$s ]"
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:524
 #, c-format
 msgid "Setting text size to %1$d."
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:528
 #, c-format
 msgid "Found an unsupported text angle [ %1$s ]"
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:530
 #, c-format
 msgid "Setting angle to %1$d."
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:547
 #, c-format
 msgid "Found an unsupported text alignment [ %1$s ]"
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:550
 msgid "Setting alignment to LOWER_LEFT."
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:570
 #, c-format
 msgid "Unexpected end-of-file after %1$d lines"
 msgstr ""
 
-#: liblepton/src/s_clib.c:460
 #, c-format
 msgid "Library command failed [%1$s]: %2$s"
 msgstr ""
 
-#: liblepton/src/s_clib.c:465
 #, c-format
 msgid "Library command failed [%1$s]: Uncaught signal %2$i."
 msgstr ""
 
-#: liblepton/src/s_clib.c:469
 #, c-format
 msgid "Library command failed [%1$s]"
 msgstr ""
 
-#: liblepton/src/s_clib.c:470
 #, c-format
 msgid ""
 "Error output was:\n"
 "%1$s"
 msgstr ""
 
-#: liblepton/src/s_clib.c:556
 #, c-format
 msgid "Library name [%1$s] already in use.  Using [%2$s]."
 msgstr ""
 
-#: liblepton/src/s_clib.c:593
 #, c-format
 msgid "Failed to open directory [%1$s]: %2$s"
 msgstr ""
 
-#: liblepton/src/s_clib.c:729
 #, c-format
 msgid "Failed to scan library [%1$s]: Scheme function returned non-list."
 msgstr ""
 
-#: liblepton/src/s_clib.c:737
 #, c-format
 msgid "Non-string symbol name while scanning library [%1$s]"
 msgstr ""
 
-#: liblepton/src/s_clib.c:893 liblepton/src/s_clib.c:940
 msgid "Cannot add library: name not specified."
 msgstr ""
 
-#: liblepton/src/s_clib.c:900
 #, c-format
 msgid ""
 "Cannot add library [%1$s]: both 'list' and 'get' commands must be specified."
 msgstr ""
 
-#: liblepton/src/s_clib.c:948
 #, c-format
 msgid "Cannot add Scheme-library [%1$s]: callbacks must be closures."
 msgstr ""
 
-#: liblepton/src/s_clib.c:1075
 #, c-format
 msgid "Failed to load symbol from file [%1$s]: %2$s"
 msgstr ""
 
-#: liblepton/src/s_clib.c:1135
 #, c-format
 msgid "Failed to load symbol data [%1$s] from source [%2$s]"
 msgstr ""
 
-#: liblepton/src/s_clib.c:1377
 #, c-format
 msgid "Component [%1$s] was not found in the component library."
 msgstr ""
 
-#: liblepton/src/s_clib.c:1383
 #, c-format
 msgid "More than one component found with name [%1$s]."
 msgstr ""
 
-#: liblepton/src/s_hierarchy.c:78 liblepton/src/s_hierarchy.c:240
 msgid "Schematic not found in source library."
 msgstr ""
 
-#: liblepton/src/s_hierarchy.c:100
 msgid "Hierarchy contains a circular dependency."
 msgstr ""
 
-#: liblepton/src/s_hierarchy.c:200
 msgid "There are no schematics above the current one!"
 msgstr ""
 
-#: liblepton/src/s_hierarchy.c:341
 #, c-format
 msgid "Failed to descend hierarchy into '%1$s': %2$s"
 msgstr ""
 
-#: liblepton/src/s_slot.c:158
 msgid "Did not find slotdef=#:#,#,#... attribute."
 msgstr ""
 
-#: liblepton/src/s_slot.c:164
 msgid "Improper slotdef syntax: missing \":\"."
 msgstr ""
 
-#: liblepton/src/s_slot.c:179
 msgid "Did not find proper slotdef=#:#,#,#... attribute."
 msgstr ""
 
-#: liblepton/src/s_slot.c:209
 msgid "component missing pinseq= attribute."
 msgstr ""
 
-#: liblepton/src/edaconfig.c:694 liblepton/src/edaconfig.c:780
 msgid "Undefined configuration filename"
 msgstr ""
 
-#: liblepton/src/edaconfig.c:1105 liblepton/src/edaconfig.c:1169
 #, c-format
 msgid "Configuration does not have group '%s'"
 msgstr ""
 
-#: liblepton/src/edaconfig.c:1183
 #, c-format
 msgid "Configuration does not have key '%s'"
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:66 liblepton/src/scheme_attrib.c:100
 msgid "~A is not a valid attribute: invalid string '~A'."
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:204
 msgid "Objects ~A and ~A are not part of the same page and/or complex object"
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:211 liblepton/src/scheme_attrib.c:216
 msgid "Object ~A is already attached as an attribute"
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:265
 msgid "Object ~A is attribute of wrong object"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:148
 msgid "Invalid complex angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:270 liblepton/src/scheme_page.c:246
 msgid "Object ~A is already attached to something"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:332
 msgid "Object ~A is attached to a different complex"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:339
 msgid "Object ~A is attached to a page"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:346 liblepton/src/scheme_page.c:298
 msgid "Object ~A is attached as an attribute"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:353 liblepton/src/scheme_page.c:305
 msgid "Object ~A has attributes"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:234
 msgid "Object ~A has bad type '~A'"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:378
 msgid "Object ~A has invalid stroke cap style ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:391
 msgid "Object ~A has invalid stroke dash style ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:455
 msgid "Invalid stroke cap style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:466
 msgid "Invalid stroke dash style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:476
 msgid "Missing dash length parameter for dash style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:486
 msgid "Missing dot/dash space parameter for dash style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:554
 msgid "Object ~A has invalid fill style ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:603
 msgid "Invalid fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:611
 msgid "Missing second space parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:620
 msgid "Missing second angle parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:630
 msgid "Missing stroke width parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:639
 msgid "Missing space parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:648
 msgid "Missing angle parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:962
 msgid "Invalid pin type ~A, must be 'net or 'bus"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1011
 msgid "Object ~A has invalid pin type."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1417
 msgid "Invalid text alignment ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1433
 msgid "Invalid text angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1452
 msgid "Invalid text name/value visibility ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1526
 msgid "Text object ~A has invalid text alignment ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1535
 msgid "Text object ~A has invalid visibility ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1545
 msgid "Text object ~A has invalid text attribute visibility ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1586
 msgid "Object ~A is not included in a page."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1739
 msgid "Path object ~A has invalid element type ~A at index ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1853
 msgid "Invalid path element type ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:2025
 msgid "Invalid picture angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr ""
 
-#: liblepton/src/scheme_page.c:291
 msgid "Object ~A is attached to a complex or different page"
 msgstr ""
 
-#: liblepton/src/scheme_page.c:438
 msgid "Parse error: ~s"
 msgstr ""
 
-#: liblepton/src/edascmhookproxy.c:83
 msgid "Scheme hook"
 msgstr ""
 
-#: liblepton/src/edascmhookproxy.c:84
 msgid "The Scheme-level hook to proxy"
 msgstr ""
 
-#: liblepton/scheme/geda/attrib.scm:56
 #, scheme-format
 msgid "Object ~A is not part of a page"
 msgstr ""
 
-#: liblepton/scheme/geda/library.scm:108
 #, scheme-format
 msgid "Invalid path ~S or source not readable.\n"
 msgstr ""
 
-#: liblepton/scheme/geda/library.scm:109
 msgid "Source library path must be a string.\n"
 msgstr ""
 
-#: liblepton/scheme/geda/library.scm:168
 #, scheme-format
 msgid "File ~S is not readable.\n"
 msgstr ""
 
-#: liblepton/scheme/geda/repl.scm:48
 msgid "Welcome to Lepton REPL!\n"
 msgstr ""
 
-#: liblepton/scheme/geda/repl.scm:53
 msgid "WARNING: Readline library is not supported in your configuration.\n"
 msgstr ""
 

--- a/liblepton/po/da.po
+++ b/liblepton/po/da.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-12 00:08+0300\n"
+"POT-Creation-Date: 2019-05-13 11:16+0300\n"
 "PO-Revision-Date: 2012-01-27 14:12+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: Danish <da@li.org>\n"
@@ -18,46 +18,37 @@ msgstr ""
 "X-Launchpad-Export-Date: 2012-11-14 16:52+0000\n"
 "X-Generator: Launchpad (build 16265)\n"
 
-#: liblepton/data/liblepton.xml.in:3
 #, fuzzy
 msgid "Lepton EDA circuit schematic"
 msgstr "gEDA kredsløbs diagram"
 
-#: liblepton/data/liblepton.xml.in:4
 #, fuzzy
 msgid "Lepton EDA schematic symbol"
 msgstr "gEDA diagram symbol"
 
-#: liblepton/data/liblepton.xml.in:5
 #, fuzzy
 msgid "Lepton EDA sch2pcb project"
 msgstr "gEDA gsch2pcb projekt"
 
-#: liblepton/data/x-lepton-sch2pcb-project.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA sch2pcb Project"
 msgstr "gEDA Gsch2pcb Projekt"
 
-#: liblepton/data/x-lepton-schematic.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Circuit Schematic"
 msgstr "gEDA Kredsløbs Diagram"
 
-#: liblepton/data/x-lepton-symbol.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Schematic Symbol"
 msgstr "gEDA Diagram Symbol"
 
-#: liblepton/src/a_basic.c:57 liblepton/src/f_basic.c:377
 #, c-format
 msgid "File %1$s is read-only"
 msgstr ""
 
-#: liblepton/src/a_basic.c:114
 msgid "Schematic data was not valid UTF-8"
 msgstr ""
 
-#: liblepton/src/a_basic.c:246
 #, c-format
 msgid ""
 "Read unexpected attach symbol start marker in [%1$s] :\n"
@@ -65,7 +56,6 @@ msgid ""
 "%2$s<<\n"
 msgstr ""
 
-#: liblepton/src/a_basic.c:263
 #, c-format
 msgid ""
 "Read unexpected embedded symbol start marker in [%1$s] :\n"
@@ -73,7 +63,6 @@ msgid ""
 "%2$s<<\n"
 msgstr ""
 
-#: liblepton/src/a_basic.c:294
 #, c-format
 msgid ""
 "Read unexpected embedded symbol end marker in [%s] :\n"
@@ -81,7 +70,6 @@ msgid ""
 "%s<<\n"
 msgstr ""
 
-#: liblepton/src/a_basic.c:329
 #, c-format
 msgid ""
 "Read an old format sym/sch file!\n"
@@ -89,7 +77,6 @@ msgid ""
 "[%1$s]"
 msgstr ""
 
-#: liblepton/src/a_basic.c:335
 #, c-format
 msgid ""
 "Read garbage in [%1$s] :\n"
@@ -97,17 +84,14 @@ msgid ""
 "%2$s<<\n"
 msgstr ""
 
-#: liblepton/src/f_basic.c:119 liblepton/src/f_basic.c:132
 #, c-format
 msgid "Failed to stat [%1$s]: %2$s"
 msgstr ""
 
-#: liblepton/src/f_basic.c:211
 #, c-format
 msgid "Cannot find file %1$s: %2$s"
 msgstr ""
 
-#: liblepton/src/f_basic.c:260
 #, c-format
 msgid ""
 "\n"
@@ -116,305 +100,236 @@ msgid ""
 "\n"
 msgstr ""
 
-#: liblepton/src/f_basic.c:262
 msgid "I could not guess if it is newer, so you have to do it manually.\n"
 msgstr ""
 
-#: liblepton/src/f_basic.c:264
 msgid ""
 "The backup copy is newer than the schematic, so it seems you should load it "
 "instead of the original file.\n"
 msgstr ""
 
-#: liblepton/src/f_basic.c:266
 msgid ""
 "lepton-schematic usually makes backup copies automatically, and this "
 "situation happens when it crashed or it was forced to exit abruptly.\n"
 msgstr ""
 
-#: liblepton/src/f_basic.c:269
 msgid ""
 "\n"
 "Run lepton-schematic and correct the situation.\n"
 "\n"
 msgstr ""
 
-#: liblepton/src/f_basic.c:367
 #, c-format
 msgid "Can't get the real filename of %1$s: %2$s"
 msgstr ""
 
-#: liblepton/src/f_basic.c:398
 #, c-format
 msgid "Could NOT set previous backup file [%1$s] read-write."
 msgstr ""
 
-#: liblepton/src/f_basic.c:404
 #, c-format
 msgid "Can't save backup file: %1$s."
 msgstr ""
 
-#: liblepton/src/f_basic.c:414
 #, c-format
 msgid "Could NOT set backup file [%1$s] readonly."
 msgstr ""
 
-#: liblepton/src/f_basic.c:463
 #, c-format
 msgid "Failed to restore permissions on '%1$s': %2$s\n"
 msgstr ""
 
-#: liblepton/src/f_basic.c:468
 #, c-format
 msgid "Failed to restore ownership on '%1$s': %2$s\n"
 msgstr ""
 
-#: liblepton/src/f_basic.c:478
 #, c-format
 msgid "Could NOT save file: %1$s"
 msgstr ""
 
-#: liblepton/src/f_basic.c:604
 #, c-format
 msgid "%s: %s"
 msgstr ""
 
-#: liblepton/src/g_basic.c:260
 msgid ""
 "\n"
 "Backtrace:\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:99
 #, c-format
 msgid "Invalid mode [%1$s] passed to %2$s\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:139
 msgid "RC file already loaded"
 msgstr ""
 
-#: liblepton/src/g_rc.c:183
 #, c-format
 msgid "Failed to load config from '%1$s': %2$s\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:207
 #, c-format
 msgid "Loaded RC file [%1$s]"
 msgstr ""
 
-#: liblepton/src/g_rc.c:211
 #, c-format
 msgid "Failed to load RC file [%1$s]: "
 msgstr ""
 
-#: liblepton/src/g_rc.c:341
 msgid "ERROR: An unknown error occurred while parsing configuration files."
 msgstr ""
 
-#: liblepton/src/g_rc.c:353
 #, c-format
 msgid "ERROR: %1$s"
 msgstr ""
 
-#: liblepton/src/g_rc.c:354
 #, c-format
 msgid "ERROR: %1$s\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:360
 #, c-format
 msgid "ERROR: The %1$s log may contain more information.\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:512
 #, c-format
 msgid "Invalid path [%1$s] passed to component-library\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:738
 #, c-format
 msgid "Invalid path [%1$s] passed to bitmap-directory\n"
 msgstr ""
 
-#: liblepton/src/geda_page.c:197
 #, c-format
 msgid "s_page_delete: Can't get the real filename of %1$s."
 msgstr ""
 
-#: liblepton/src/geda_page.c:208
 #, c-format
 msgid "s_page_delete: Unable to delete backup file %1$s."
 msgstr ""
 
-#: liblepton/src/geda_page.c:490
 #, c-format
 msgid "Saved [%1$s]"
 msgstr ""
 
-#: liblepton/src/geda_page.c:496
 #, c-format
 msgid "Could NOT save [%1$s]"
 msgstr ""
 
-#: liblepton/src/geda_arc_object.c:408 liblepton/src/geda_arc_object.c:421
 msgid "Failed to parse arc object"
 msgstr ""
 
-#: liblepton/src/geda_arc_object.c:428
 #, c-format
 msgid "Found a zero radius arc [ %1$c %2$d, %3$d, %4$d, %5$d, %6$d, %7$d ]"
 msgstr ""
 
-#: liblepton/src/geda_arc_object.c:435 liblepton/src/geda_box_object.c:328
-#: liblepton/src/geda_bus_object.c:364 liblepton/src/geda_circle_object.c:387
-#: liblepton/src/geda_line_object.c:427 liblepton/src/geda_net_object.c:308
-#: liblepton/src/geda_path_object.c:214 liblepton/src/geda_pin_object.c:369
-#: liblepton/src/geda_text_object.c:555
 #, c-format
 msgid "Found an invalid color [ %1$s ]"
 msgstr ""
 
-#: liblepton/src/geda_arc_object.c:436 liblepton/src/geda_box_object.c:329
-#: liblepton/src/geda_bus_object.c:365 liblepton/src/geda_circle_object.c:388
-#: liblepton/src/geda_line_object.c:428 liblepton/src/geda_net_object.c:309
-#: liblepton/src/geda_path_object.c:215 liblepton/src/geda_pin_object.c:370
-#: liblepton/src/geda_text_object.c:557
 msgid "Setting color to default color."
 msgstr ""
 
-#: liblepton/src/o_attrib.c:111
 #, c-format
 msgid "Attribute [%1$s] already attached\n"
 msgstr ""
 
-#: liblepton/src/o_attrib.c:117
 msgid "Attempt to attach non text item as an attribute!\n"
 msgstr ""
 
-#: liblepton/src/o_attrib.c:122
 #, c-format
 msgid "Attempt to attach attribute [%1$s] to more than one object\n"
 msgstr ""
 
-#: liblepton/src/o_attrib.c:325
 msgid "Tried to attach a non-text item as an attribute"
 msgstr ""
 
-#: liblepton/src/o_attrib.c:332
 msgid "Unexpected end-of-file in attribute list"
 msgstr ""
 
-#: liblepton/src/geda_box_object.c:287 liblepton/src/geda_box_object.c:316
 msgid "Failed to parse box object"
 msgstr ""
 
-#: liblepton/src/geda_box_object.c:322
 #, c-format
 msgid "Found a zero width/height box [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr ""
 
-#: liblepton/src/geda_bus_object.c:345 liblepton/src/geda_bus_object.c:352
 msgid "Failed to parse bus object"
 msgstr ""
 
-#: liblepton/src/geda_bus_object.c:358
 #, c-format
 msgid "Found a zero length bus [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr ""
 
-#: liblepton/src/geda_bus_object.c:370
 #, c-format
 msgid "Found an invalid bus ripper direction [ %1$s ]"
 msgstr ""
 
-#: liblepton/src/geda_bus_object.c:371
 msgid "Resetting direction to neutral (no direction)."
 msgstr ""
 
-#: liblepton/src/geda_circle_object.c:343
-#: liblepton/src/geda_circle_object.c:372
 msgid "Failed to parse circle object"
 msgstr ""
 
-#: liblepton/src/geda_circle_object.c:379
 #, c-format
 msgid "Found a zero or negative radius circle [ %1$c %2$d %3$d %4$d %5$d ]"
 msgstr ""
 
-#: liblepton/src/geda_circle_object.c:382
 msgid "Setting radius to 0."
 msgstr ""
 
-#: liblepton/src/geda_color.c:217
 msgid "Color map entry must be a two-element list"
 msgstr ""
 
-#: liblepton/src/geda_color.c:225
 msgid "Index in color map entry must be an integer"
 msgstr ""
 
-#: liblepton/src/geda_color.c:251
 msgid "Value in color map entry must be #f or a string"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:373
 #, c-format
 msgid ""
 "Component not found:\n"
 " %1$s"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:585
 msgid "Failed to parse complex object"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:598
 #, c-format
 msgid ""
 "Found a component with an invalid rotation [ %1$c %2$d %3$d %4$d %5$d %6$d "
 "%7$s ]"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:601
-#: liblepton/src/geda_picture_object.c:105
 msgid "Setting angle to 0."
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:613
 #, c-format
 msgid ""
 "Found a component with an invalid mirror flag [ %1$c %2$d %3$d %4$d %5$d "
 "%6$d %7$s ]"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:616
 msgid "Setting mirror to 0."
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:941
 #, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
 "\tCould not parse symbol file symversion=%2$s"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:945
 #, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
 "\tCould not parse symbol file symversion="
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:961
 #, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
 "\tCould not parse attached symversion=%2$s"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:986
 #, c-format
 msgid ""
 "WARNING: Symbol version oddity on refdes %1$s:\n"
@@ -422,535 +337,416 @@ msgid ""
 "symbol file."
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:1000
 #, c-format
 msgid ""
 "WARNING: Symbol version mismatch on refdes %1$s (%2$s):\n"
 "\tSymbol in library is newer than instantiated symbol."
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:1028
 #, c-format
 msgid "\tMAJOR VERSION CHANGE (file %1$.3f, instantiated %2$.3f, %3$s)!"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:1046
 #, c-format
 msgid "\tMinor version change (file %1$.3f, instantiated %2$.3f)"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:1057
 #, c-format
 msgid ""
 "WARNING: Symbol version oddity on refdes %1$s:\n"
 "\tInstantiated symbol is newer than symbol in library."
 msgstr ""
 
-#: liblepton/src/o_embed.c:54
 #, c-format
 msgid "Component [%1$s] has been embedded."
 msgstr ""
 
-#: liblepton/src/o_embed.c:98
 #, c-format
 msgid ""
 "Could not find component [%1$s], while trying to unembed. Component is still "
 "embedded."
 msgstr ""
 
-#: liblepton/src/o_embed.c:106
 #, c-format
 msgid "Component [%1$s] has been successfully unembedded."
 msgstr ""
 
-#: liblepton/src/geda_line_object.c:391 liblepton/src/geda_line_object.c:409
 msgid "Failed to parse line object"
 msgstr ""
 
-#: liblepton/src/geda_line_object.c:421
 #, c-format
 msgid "Found a zero length line [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr ""
 
-#: liblepton/src/geda_net_object.c:297
 msgid "Failed to parse net object"
 msgstr ""
 
-#: liblepton/src/geda_net_object.c:302
 #, c-format
 msgid "Found a zero length net [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr ""
 
-#: liblepton/src/geda_path_object.c:206
 msgid "Failed to parse path object"
 msgstr ""
 
-#: liblepton/src/geda_path_object.c:232
 msgid "Unexpected end-of-file when reading path"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:71
 msgid "Failed to parse picture definition"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:76
 #, c-format
 msgid "Found a zero width/height picture [ %1$c %2$d %3$d %4$d %5$d ]"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:82
 #, c-format
 msgid "Found a picture with a wrong 'mirrored' parameter: %1$d."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:84
 msgid "Setting mirrored to 0."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:89
 #, c-format
 msgid "Found a picture with a wrong 'embedded' parameter: %1$d."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:91
 msgid "Setting embedded to 0."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:104
 #, c-format
 msgid "Found an unsupported picture angle [ %1$d ]"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:116
 msgid "Found an image with no filename."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:147
 #, c-format
 msgid "Failed to load image from embedded data [%1$s]: %2$s"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:148
 msgid "Base64 decoding failed."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:149
 msgid "Falling back to file loading. Picture unembedded."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:208
 msgid "ERROR: o_picture_save: unable to encode the picture."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:308
 #, c-format
 msgid "Failed to load buffer image [%1$s]: %2$s"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:321
 #, c-format
 msgid "Failed to load image from [%1$s]: %2$s"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:415
 #, c-format
 msgid "Picture %1$p has invalid angle %2$i\n"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:772
 #, c-format
 msgid "Picture [%1$s] has no image data."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:773
 msgid "Falling back to file loading. Picture is still unembedded."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:781
 #, c-format
 msgid "Picture [%1$s] has been embedded."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:805
 #, c-format
 msgid "Failed to load image from file [%1$s]: %2$s"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:807
 msgid "Picture is still embedded."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:815
 #, c-format
 msgid "Picture [%1$s] has been unembedded."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:1052
 #, c-format
 msgid "Failed to load fallback image %1$s: %2$s.\n"
 msgstr ""
 
-#: liblepton/src/geda_pin_object.c:346 liblepton/src/geda_pin_object.c:354
 msgid "Failed to parse pin object"
 msgstr ""
 
-#: liblepton/src/geda_pin_object.c:360
 msgid ""
 "Found a pin which did not have the whichend field set.\n"
 "Verify and correct manually."
 msgstr ""
 
-#: liblepton/src/geda_pin_object.c:363
 #, c-format
 msgid "Found an invalid whichend on a pin (reseting to zero): %d"
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:495 liblepton/src/geda_text_object.c:505
-#: liblepton/src/geda_text_object.c:515
 msgid "Failed to parse text object"
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:522
 #, c-format
 msgid "Found an invalid text size [ %1$s ]"
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:524
 #, c-format
 msgid "Setting text size to %1$d."
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:528
 #, c-format
 msgid "Found an unsupported text angle [ %1$s ]"
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:530
 #, c-format
 msgid "Setting angle to %1$d."
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:547
 #, c-format
 msgid "Found an unsupported text alignment [ %1$s ]"
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:550
 msgid "Setting alignment to LOWER_LEFT."
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:570
 #, c-format
 msgid "Unexpected end-of-file after %1$d lines"
 msgstr ""
 
-#: liblepton/src/s_clib.c:460
 #, c-format
 msgid "Library command failed [%1$s]: %2$s"
 msgstr ""
 
-#: liblepton/src/s_clib.c:465
 #, c-format
 msgid "Library command failed [%1$s]: Uncaught signal %2$i."
 msgstr ""
 
-#: liblepton/src/s_clib.c:469
 #, c-format
 msgid "Library command failed [%1$s]"
 msgstr ""
 
-#: liblepton/src/s_clib.c:470
 #, c-format
 msgid ""
 "Error output was:\n"
 "%1$s"
 msgstr ""
 
-#: liblepton/src/s_clib.c:556
 #, c-format
 msgid "Library name [%1$s] already in use.  Using [%2$s]."
 msgstr ""
 
-#: liblepton/src/s_clib.c:593
 #, c-format
 msgid "Failed to open directory [%1$s]: %2$s"
 msgstr ""
 
-#: liblepton/src/s_clib.c:729
 #, c-format
 msgid "Failed to scan library [%1$s]: Scheme function returned non-list."
 msgstr ""
 
-#: liblepton/src/s_clib.c:737
 #, c-format
 msgid "Non-string symbol name while scanning library [%1$s]"
 msgstr ""
 
-#: liblepton/src/s_clib.c:893 liblepton/src/s_clib.c:940
 msgid "Cannot add library: name not specified."
 msgstr ""
 
-#: liblepton/src/s_clib.c:900
 #, c-format
 msgid ""
 "Cannot add library [%1$s]: both 'list' and 'get' commands must be specified."
 msgstr ""
 
-#: liblepton/src/s_clib.c:948
 #, c-format
 msgid "Cannot add Scheme-library [%1$s]: callbacks must be closures."
 msgstr ""
 
-#: liblepton/src/s_clib.c:1075
 #, c-format
 msgid "Failed to load symbol from file [%1$s]: %2$s"
 msgstr ""
 
-#: liblepton/src/s_clib.c:1135
 #, c-format
 msgid "Failed to load symbol data [%1$s] from source [%2$s]"
 msgstr ""
 
-#: liblepton/src/s_clib.c:1377
 #, c-format
 msgid "Component [%1$s] was not found in the component library."
 msgstr ""
 
-#: liblepton/src/s_clib.c:1383
 #, c-format
 msgid "More than one component found with name [%1$s]."
 msgstr ""
 
-#: liblepton/src/s_hierarchy.c:78 liblepton/src/s_hierarchy.c:240
 msgid "Schematic not found in source library."
 msgstr ""
 
-#: liblepton/src/s_hierarchy.c:100
 msgid "Hierarchy contains a circular dependency."
 msgstr ""
 
-#: liblepton/src/s_hierarchy.c:200
 msgid "There are no schematics above the current one!"
 msgstr ""
 
-#: liblepton/src/s_hierarchy.c:341
 #, c-format
 msgid "Failed to descend hierarchy into '%1$s': %2$s"
 msgstr ""
 
-#: liblepton/src/s_slot.c:158
 msgid "Did not find slotdef=#:#,#,#... attribute."
 msgstr ""
 
-#: liblepton/src/s_slot.c:164
 msgid "Improper slotdef syntax: missing \":\"."
 msgstr ""
 
-#: liblepton/src/s_slot.c:179
 msgid "Did not find proper slotdef=#:#,#,#... attribute."
 msgstr ""
 
-#: liblepton/src/s_slot.c:209
 msgid "component missing pinseq= attribute."
 msgstr ""
 
-#: liblepton/src/edaconfig.c:694 liblepton/src/edaconfig.c:780
 msgid "Undefined configuration filename"
 msgstr ""
 
-#: liblepton/src/edaconfig.c:1105 liblepton/src/edaconfig.c:1169
 #, c-format
 msgid "Configuration does not have group '%s'"
 msgstr ""
 
-#: liblepton/src/edaconfig.c:1183
 #, c-format
 msgid "Configuration does not have key '%s'"
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:66 liblepton/src/scheme_attrib.c:100
 msgid "~A is not a valid attribute: invalid string '~A'."
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:204
 msgid "Objects ~A and ~A are not part of the same page and/or complex object"
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:211 liblepton/src/scheme_attrib.c:216
 msgid "Object ~A is already attached as an attribute"
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:265
 msgid "Object ~A is attribute of wrong object"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:148
 msgid "Invalid complex angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:270 liblepton/src/scheme_page.c:246
 msgid "Object ~A is already attached to something"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:332
 msgid "Object ~A is attached to a different complex"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:339
 msgid "Object ~A is attached to a page"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:346 liblepton/src/scheme_page.c:298
 msgid "Object ~A is attached as an attribute"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:353 liblepton/src/scheme_page.c:305
 msgid "Object ~A has attributes"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:234
 msgid "Object ~A has bad type '~A'"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:378
 msgid "Object ~A has invalid stroke cap style ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:391
 msgid "Object ~A has invalid stroke dash style ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:455
 msgid "Invalid stroke cap style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:466
 msgid "Invalid stroke dash style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:476
 msgid "Missing dash length parameter for dash style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:486
 msgid "Missing dot/dash space parameter for dash style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:554
 msgid "Object ~A has invalid fill style ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:603
 msgid "Invalid fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:611
 msgid "Missing second space parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:620
 msgid "Missing second angle parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:630
 msgid "Missing stroke width parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:639
 msgid "Missing space parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:648
 msgid "Missing angle parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:962
 msgid "Invalid pin type ~A, must be 'net or 'bus"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1011
 msgid "Object ~A has invalid pin type."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1417
 msgid "Invalid text alignment ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1433
 msgid "Invalid text angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1452
 msgid "Invalid text name/value visibility ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1526
 msgid "Text object ~A has invalid text alignment ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1535
 msgid "Text object ~A has invalid visibility ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1545
 msgid "Text object ~A has invalid text attribute visibility ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1586
 msgid "Object ~A is not included in a page."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1739
 msgid "Path object ~A has invalid element type ~A at index ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1853
 msgid "Invalid path element type ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:2025
 msgid "Invalid picture angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr ""
 
-#: liblepton/src/scheme_page.c:291
 msgid "Object ~A is attached to a complex or different page"
 msgstr ""
 
-#: liblepton/src/scheme_page.c:438
 msgid "Parse error: ~s"
 msgstr ""
 
-#: liblepton/src/edascmhookproxy.c:83
 msgid "Scheme hook"
 msgstr ""
 
-#: liblepton/src/edascmhookproxy.c:84
 msgid "The Scheme-level hook to proxy"
 msgstr ""
 
-#: liblepton/scheme/geda/attrib.scm:56
 #, scheme-format
 msgid "Object ~A is not part of a page"
 msgstr ""
 
-#: liblepton/scheme/geda/library.scm:108
 #, scheme-format
 msgid "Invalid path ~S or source not readable.\n"
 msgstr ""
 
-#: liblepton/scheme/geda/library.scm:109
 msgid "Source library path must be a string.\n"
 msgstr ""
 
-#: liblepton/scheme/geda/library.scm:168
 #, scheme-format
 msgid "File ~S is not readable.\n"
 msgstr ""
 
-#: liblepton/scheme/geda/repl.scm:48
 msgid "Welcome to Lepton REPL!\n"
 msgstr ""
 
-#: liblepton/scheme/geda/repl.scm:53
 msgid "WARNING: Readline library is not supported in your configuration.\n"
 msgstr ""

--- a/liblepton/po/de.po
+++ b/liblepton/po/de.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-12 00:08+0300\n"
+"POT-Creation-Date: 2019-05-13 11:16+0300\n"
 "PO-Revision-Date: 2010-01-31 13:00+0000\n"
 "Last-Translator: Werner Hoch <werner.ho@gmx.de>\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -19,46 +19,37 @@ msgstr ""
 "X-Launchpad-Export-Date: 2010-02-14 12:56+0000\n"
 "X-Generator: Launchpad (build Unknown)\n"
 
-#: liblepton/data/liblepton.xml.in:3
 #, fuzzy
 msgid "Lepton EDA circuit schematic"
 msgstr "gEDA Schaltplan"
 
-#: liblepton/data/liblepton.xml.in:4
 #, fuzzy
 msgid "Lepton EDA schematic symbol"
 msgstr "gEDA Schaltplansymbol"
 
-#: liblepton/data/liblepton.xml.in:5
 #, fuzzy
 msgid "Lepton EDA sch2pcb project"
 msgstr "gEDA gsch2pcb Projekt"
 
-#: liblepton/data/x-lepton-sch2pcb-project.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA sch2pcb Project"
 msgstr "gEDA Gsch2pcb Projekt"
 
-#: liblepton/data/x-lepton-schematic.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Circuit Schematic"
 msgstr "gEDA Schaltplan"
 
-#: liblepton/data/x-lepton-symbol.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Schematic Symbol"
 msgstr "gEDA Schaltplansymbol"
 
-#: liblepton/src/a_basic.c:57 liblepton/src/f_basic.c:377
 #, c-format
 msgid "File %1$s is read-only"
 msgstr ""
 
-#: liblepton/src/a_basic.c:114
 msgid "Schematic data was not valid UTF-8"
 msgstr ""
 
-#: liblepton/src/a_basic.c:246
 #, fuzzy, c-format
 msgid ""
 "Read unexpected attach symbol start marker in [%1$s] :\n"
@@ -69,7 +60,6 @@ msgstr ""
 ">>\n"
 "%s<<\n"
 
-#: liblepton/src/a_basic.c:263
 #, fuzzy, c-format
 msgid ""
 "Read unexpected embedded symbol start marker in [%1$s] :\n"
@@ -80,7 +70,6 @@ msgstr ""
 ">>\n"
 "%s<<\n"
 
-#: liblepton/src/a_basic.c:294
 #, c-format
 msgid ""
 "Read unexpected embedded symbol end marker in [%s] :\n"
@@ -91,7 +80,6 @@ msgstr ""
 ">>\n"
 "%s<<\n"
 
-#: liblepton/src/a_basic.c:329
 #, fuzzy, c-format
 msgid ""
 "Read an old format sym/sch file!\n"
@@ -102,7 +90,6 @@ msgstr ""
 "Bitte aktualisiere die Datei mit g[sym|sch]update:\n"
 "[%s]\n"
 
-#: liblepton/src/a_basic.c:335
 #, fuzzy, c-format
 msgid ""
 "Read garbage in [%1$s] :\n"
@@ -113,17 +100,14 @@ msgstr ""
 ">>\n"
 "%s<<\n"
 
-#: liblepton/src/f_basic.c:119 liblepton/src/f_basic.c:132
 #, fuzzy, c-format
 msgid "Failed to stat [%1$s]: %2$s"
 msgstr "Konnte Dateiinformation nicht ermitteln [%s]: %s"
 
-#: liblepton/src/f_basic.c:211
 #, fuzzy, c-format
 msgid "Cannot find file %1$s: %2$s"
 msgstr "Konnte Datei nicht finden %s: %s"
 
-#: liblepton/src/f_basic.c:260
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -136,13 +120,11 @@ msgstr ""
 "  %s.\n"
 "\n"
 
-#: liblepton/src/f_basic.c:262
 msgid "I could not guess if it is newer, so you have to do it manually.\n"
 msgstr ""
 "Konnte nicht feststellen ob die Backupdatei neuer ist oder nicht. Dies muss "
 "nun manuell durchgeführt werden.\n"
 
-#: liblepton/src/f_basic.c:264
 msgid ""
 "The backup copy is newer than the schematic, so it seems you should load it "
 "instead of the original file.\n"
@@ -150,7 +132,6 @@ msgstr ""
 "Die Backupdatei ist neuer als die des Schaltplanes. Es sollte eventuell das "
 "Backup anstatt der originalen Datei geladen werden.\n"
 
-#: liblepton/src/f_basic.c:266
 #, fuzzy
 msgid ""
 "lepton-schematic usually makes backup copies automatically, and this "
@@ -159,7 +140,6 @@ msgstr ""
 "Gschem erstellt automatisch Backupdateien. Stürzt gschem ab oder wird es "
 "absichtlich getötet, so ergibt sich diese Situation.\n"
 
-#: liblepton/src/f_basic.c:269
 #, fuzzy
 msgid ""
 "\n"
@@ -170,239 +150,184 @@ msgstr ""
 "Starte gschem und korrigiere diesen Zustand.\n"
 "\n"
 
-#: liblepton/src/f_basic.c:367
 #, fuzzy, c-format
 msgid "Can't get the real filename of %1$s: %2$s"
 msgstr "Konnte den wahren Dateinamen von %s nicht ermitteln."
 
-#: liblepton/src/f_basic.c:398
 #, fuzzy, c-format
 msgid "Could NOT set previous backup file [%1$s] read-write."
 msgstr ""
 "Konnte die Rechte der alten Backupdatei [%s] nicht auf lesen+schreiben "
 "setzen\n"
 
-#: liblepton/src/f_basic.c:404
 #, fuzzy, c-format
 msgid "Can't save backup file: %1$s."
 msgstr "Konnte Backupdatei nicht speichern: %s."
 
-#: liblepton/src/f_basic.c:414
 #, fuzzy, c-format
 msgid "Could NOT set backup file [%1$s] readonly."
 msgstr "Konnte die Rechte der Backupdatei [%s] nicht auf nurlesend setzen\n"
 
-#: liblepton/src/f_basic.c:463
 #, fuzzy, c-format
 msgid "Failed to restore permissions on '%1$s': %2$s\n"
 msgstr "Fehler beim Öffnen eines Verzeichnisses [%s]: %s\n"
 
-#: liblepton/src/f_basic.c:468
 #, fuzzy, c-format
 msgid "Failed to restore ownership on '%1$s': %2$s\n"
 msgstr "Fehler beim Öffnen eines Verzeichnisses [%s]: %s\n"
 
-#: liblepton/src/f_basic.c:478
 #, fuzzy, c-format
 msgid "Could NOT save file: %1$s"
 msgstr "ACHTUNG: Konnte Datei nicht speichern [%s]\n"
 
-#: liblepton/src/f_basic.c:604
 #, c-format
 msgid "%s: %s"
 msgstr "%s: %s"
 
-#: liblepton/src/g_basic.c:260
 msgid ""
 "\n"
 "Backtrace:\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:99
 #, fuzzy, c-format
 msgid "Invalid mode [%1$s] passed to %2$s\n"
 msgstr ""
 "Das Bauteil [%s] konnte nicht in der Bauteilbibliothek gefunden werden\n"
 
-#: liblepton/src/g_rc.c:139
 #, fuzzy
 msgid "RC file already loaded"
 msgstr "Konfigurationsdatei [%s] wurde bereits gelesen.\n"
 
-#: liblepton/src/g_rc.c:183
 #, fuzzy, c-format
 msgid "Failed to load config from '%1$s': %2$s\n"
 msgstr "Das Bild konnte nicht aus der Datei [%s] geladen werden: %s\n"
 
-#: liblepton/src/g_rc.c:207
 #, fuzzy, c-format
 msgid "Loaded RC file [%1$s]"
 msgstr "Lese vorgegebene %s Datei [%%s]\n"
 
-#: liblepton/src/g_rc.c:211
 #, fuzzy, c-format
 msgid "Failed to load RC file [%1$s]: "
 msgstr "Das Bild konnte nicht aus der Datei [%s] geladen werden: %s\n"
 
-#: liblepton/src/g_rc.c:341
 msgid "ERROR: An unknown error occurred while parsing configuration files."
 msgstr ""
 
-#: liblepton/src/g_rc.c:353
 #, c-format
 msgid "ERROR: %1$s"
 msgstr ""
 
-#: liblepton/src/g_rc.c:354
 #, c-format
 msgid "ERROR: %1$s\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:360
 #, c-format
 msgid "ERROR: The %1$s log may contain more information.\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:512
 #, fuzzy, c-format
 msgid "Invalid path [%1$s] passed to component-library\n"
 msgstr ""
 "Das Bauteil [%s] konnte nicht in der Bauteilbibliothek gefunden werden\n"
 
-#: liblepton/src/g_rc.c:738
 #, fuzzy, c-format
 msgid "Invalid path [%1$s] passed to bitmap-directory\n"
 msgstr ""
 "Das Bauteil [%s] konnte nicht in der Bauteilbibliothek gefunden werden\n"
 
-#: liblepton/src/geda_page.c:197
 #, fuzzy, c-format
 msgid "s_page_delete: Can't get the real filename of %1$s."
 msgstr ""
 "s_page_delete: Kann den tatsächlichen Dateinamen von [%s] nicht ermitteln."
 
-#: liblepton/src/geda_page.c:208
 #, fuzzy, c-format
 msgid "s_page_delete: Unable to delete backup file %1$s."
 msgstr "s_page_delete: Kann die Backupdatei [%s] nicht löschen."
 
-#: liblepton/src/geda_page.c:490
 #, fuzzy, c-format
 msgid "Saved [%1$s]"
 msgstr "Gespeichert [%s]\n"
 
-#: liblepton/src/geda_page.c:496
 #, fuzzy, c-format
 msgid "Could NOT save [%1$s]"
 msgstr "ACHTUNG: Konnte Datei nicht speichern [%s]\n"
 
-#: liblepton/src/geda_arc_object.c:408 liblepton/src/geda_arc_object.c:421
 msgid "Failed to parse arc object"
 msgstr ""
 
-#: liblepton/src/geda_arc_object.c:428
 #, fuzzy, c-format
 msgid "Found a zero radius arc [ %1$c %2$d, %3$d, %4$d, %5$d, %6$d, %7$d ]"
 msgstr "Kreisbogen mit Radius 0 entdeckt [%c %d, %d, %d, %d, %d, %d ]\n"
 
-#: liblepton/src/geda_arc_object.c:435 liblepton/src/geda_box_object.c:328
-#: liblepton/src/geda_bus_object.c:364 liblepton/src/geda_circle_object.c:387
-#: liblepton/src/geda_line_object.c:427 liblepton/src/geda_net_object.c:308
-#: liblepton/src/geda_path_object.c:214 liblepton/src/geda_pin_object.c:369
-#: liblepton/src/geda_text_object.c:555
 #, fuzzy, c-format
 msgid "Found an invalid color [ %1$s ]"
 msgstr "Fehlerhafte Farbangabe entdeckt [%s]\n"
 
-#: liblepton/src/geda_arc_object.c:436 liblepton/src/geda_box_object.c:329
-#: liblepton/src/geda_bus_object.c:365 liblepton/src/geda_circle_object.c:388
-#: liblepton/src/geda_line_object.c:428 liblepton/src/geda_net_object.c:309
-#: liblepton/src/geda_path_object.c:215 liblepton/src/geda_pin_object.c:370
-#: liblepton/src/geda_text_object.c:557
 #, fuzzy
 msgid "Setting color to default color."
 msgstr "Verwende die Default Farbe\n"
 
-#: liblepton/src/o_attrib.c:111
 #, c-format
 msgid "Attribute [%1$s] already attached\n"
 msgstr ""
 
-#: liblepton/src/o_attrib.c:117
 msgid "Attempt to attach non text item as an attribute!\n"
 msgstr "Es wurde versucht eine Attribut anzubringen, welches kein Text ist!\n"
 
-#: liblepton/src/o_attrib.c:122
 #, fuzzy, c-format
 msgid "Attempt to attach attribute [%1$s] to more than one object\n"
 msgstr ""
 "Es wurde versucht ein Attribute [%s] an mehr als ein Objekt anzubringen\n"
 
-#: liblepton/src/o_attrib.c:325
 #, fuzzy
 msgid "Tried to attach a non-text item as an attribute"
 msgstr "Es wurde versucht eine Attribut anzubringen, welches kein Text ist!\n"
 
-#: liblepton/src/o_attrib.c:332
 msgid "Unexpected end-of-file in attribute list"
 msgstr ""
 
-#: liblepton/src/geda_box_object.c:287 liblepton/src/geda_box_object.c:316
 msgid "Failed to parse box object"
 msgstr ""
 
-#: liblepton/src/geda_box_object.c:322
 #, fuzzy, c-format
 msgid "Found a zero width/height box [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr "Rechteck mit der Kantenlänge 0 entdeckt [ %c %d %d %d %d %d ]\n"
 
-#: liblepton/src/geda_bus_object.c:345 liblepton/src/geda_bus_object.c:352
 msgid "Failed to parse bus object"
 msgstr ""
 
-#: liblepton/src/geda_bus_object.c:358
 #, fuzzy, c-format
 msgid "Found a zero length bus [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr "Bus mit der Länge 0 entdeckt [ %c %d %d %d %d %d ]\n"
 
-#: liblepton/src/geda_bus_object.c:370
 #, fuzzy, c-format
 msgid "Found an invalid bus ripper direction [ %1$s ]"
 msgstr "Fehlerhafte Richtungsangabe [%s] bei einem Busanschluss entdeckt\n"
 
-#: liblepton/src/geda_bus_object.c:371
 #, fuzzy
 msgid "Resetting direction to neutral (no direction)."
 msgstr "Setze die Richtung auf neutral (keine Richtung)\n"
 
-#: liblepton/src/geda_circle_object.c:343
-#: liblepton/src/geda_circle_object.c:372
 msgid "Failed to parse circle object"
 msgstr ""
 
-#: liblepton/src/geda_circle_object.c:379
 #, fuzzy, c-format
 msgid "Found a zero or negative radius circle [ %1$c %2$d %3$d %4$d %5$d ]"
 msgstr "Kreis mit dem Radius 0 entdeckt [ %c %d %d %d %d ]\n"
 
-#: liblepton/src/geda_circle_object.c:382
 #, fuzzy
 msgid "Setting radius to 0."
 msgstr "Setze die Winkelangabe auf 0\n"
 
-#: liblepton/src/geda_color.c:217
 msgid "Color map entry must be a two-element list"
 msgstr "Der Eintrag in der Farbtabelle muss eine zweielementige Liste sein"
 
-#: liblepton/src/geda_color.c:225
 msgid "Index in color map entry must be an integer"
 msgstr "Der Indexeintrag in der Farbtabelle muss ein Integerwert sein"
 
-#: liblepton/src/geda_color.c:251
 msgid "Value in color map entry must be #f or a string"
 msgstr "Der Wert in der Farbtabelle muss '#f' oder ein String sein."
 
-#: liblepton/src/geda_complex_object.c:373
 #, fuzzy, c-format
 msgid ""
 "Component not found:\n"
@@ -411,11 +336,9 @@ msgstr ""
 "Bauteil wurde nicht gefunden:\n"
 " %s"
 
-#: liblepton/src/geda_complex_object.c:585
 msgid "Failed to parse complex object"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:598
 #, fuzzy, c-format
 msgid ""
 "Found a component with an invalid rotation [ %1$c %2$d %3$d %4$d %5$d %6$d "
@@ -423,13 +346,10 @@ msgid ""
 msgstr ""
 "Bauteil mit fehlerhafter Rotationsangabe entdeckt [ %c %d %d %d %d %d %s ]\n"
 
-#: liblepton/src/geda_complex_object.c:601
-#: liblepton/src/geda_picture_object.c:105
 #, fuzzy
 msgid "Setting angle to 0."
 msgstr "Setze die Winkelangabe auf 0\n"
 
-#: liblepton/src/geda_complex_object.c:613
 #, fuzzy, c-format
 msgid ""
 "Found a component with an invalid mirror flag [ %1$c %2$d %3$d %4$d %5$d "
@@ -438,12 +358,10 @@ msgstr ""
 "Bauteil mit fehlerhafter Spiegelungsangabe entdeckt [ %c %d %d %d %d %d "
 "%s ]\n"
 
-#: liblepton/src/geda_complex_object.c:616
 #, fuzzy
 msgid "Setting mirror to 0."
 msgstr "Setze die Spiegelung auf 0\n"
 
-#: liblepton/src/geda_complex_object.c:941
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
@@ -453,7 +371,6 @@ msgstr ""
 "'%s':\n"
 "\tKonnte das Attribut symversion=%s nicht zerlegen\n"
 
-#: liblepton/src/geda_complex_object.c:945
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
@@ -463,7 +380,6 @@ msgstr ""
 "'%s':\n"
 "\tKonnte das Attribut symversion= nicht zerlegen\n"
 
-#: liblepton/src/geda_complex_object.c:961
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
@@ -473,7 +389,6 @@ msgstr ""
 "'%s':\n"
 "\tKonnte das angehängte Attribut symversion=%s nicht zerlegen\n"
 
-#: liblepton/src/geda_complex_object.c:986
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version oddity on refdes %1$s:\n"
@@ -485,7 +400,6 @@ msgstr ""
 "\tsymversion=%s existiert bei dem Symbol im Schaltplan, fehlt aber innerhalb "
 "der Schaltsymbol-Datei\n"
 
-#: liblepton/src/geda_complex_object.c:1000
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version mismatch on refdes %1$s (%2$s):\n"
@@ -495,20 +409,17 @@ msgstr ""
 "(%s):\n"
 "\tDas Symbol in der Bibliothek ist neuer als das Symbol im Schaltplan\n"
 
-#: liblepton/src/geda_complex_object.c:1028
 #, fuzzy, c-format
 msgid "\tMAJOR VERSION CHANGE (file %1$.3f, instantiated %2$.3f, %3$s)!"
 msgstr ""
 "\tGROSSE VERSIONSÄNDERUNG (Symboldatei %.3f, Symbol im Schaltplan %.3f, "
 "%s)!\n"
 
-#: liblepton/src/geda_complex_object.c:1046
 #, fuzzy, c-format
 msgid "\tMinor version change (file %1$.3f, instantiated %2$.3f)"
 msgstr ""
 "\tKleine Versionsänderung (Symboldatei %.3f, Symbol im Schaltplan %.3f)!\n"
 
-#: liblepton/src/geda_complex_object.c:1057
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version oddity on refdes %1$s:\n"
@@ -517,12 +428,10 @@ msgstr ""
 "ACHTUNG: Seltsame Versionskonstellation bei dem Symbol mit der Referenz %s:\n"
 "\tDie Symbolversion im Schaltplan ist aktueller als in der Symbolbibliothek\n"
 
-#: liblepton/src/o_embed.c:54
 #, fuzzy, c-format
 msgid "Component [%1$s] has been embedded."
 msgstr "Bauteil [%s] wurde eingebettet\n"
 
-#: liblepton/src/o_embed.c:98
 #, fuzzy, c-format
 msgid ""
 "Could not find component [%1$s], while trying to unembed. Component is still "
@@ -531,149 +440,118 @@ msgstr ""
 "Konnte Symbol [%s] nicht finden um es auszubetten. Das Bauteil bleibt "
 "eingebettet\n"
 
-#: liblepton/src/o_embed.c:106
 #, fuzzy, c-format
 msgid "Component [%1$s] has been successfully unembedded."
 msgstr "Das Bauteil [%s] wurde erfolgreich ausgebettet\n"
 
-#: liblepton/src/geda_line_object.c:391 liblepton/src/geda_line_object.c:409
 msgid "Failed to parse line object"
 msgstr ""
 
-#: liblepton/src/geda_line_object.c:421
 #, fuzzy, c-format
 msgid "Found a zero length line [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr "Linie mit der Länge 0 entdeckt [ %c %d %d %d %d %d ]\n"
 
-#: liblepton/src/geda_net_object.c:297
 msgid "Failed to parse net object"
 msgstr ""
 
-#: liblepton/src/geda_net_object.c:302
 #, fuzzy, c-format
 msgid "Found a zero length net [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr "Netz mit der Länge 0 entdeckt [ %c %d %d %d %d %d ]\n"
 
-#: liblepton/src/geda_path_object.c:206
 msgid "Failed to parse path object"
 msgstr ""
 
-#: liblepton/src/geda_path_object.c:232
 msgid "Unexpected end-of-file when reading path"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:71
 msgid "Failed to parse picture definition"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:76
 #, fuzzy, c-format
 msgid "Found a zero width/height picture [ %1$c %2$d %3$d %4$d %5$d ]"
 msgstr "Bild mit der Seitenlänge 0 entdeckt [ %c %d %d %d %d ]\n"
 
-#: liblepton/src/geda_picture_object.c:82
 #, fuzzy, c-format
 msgid "Found a picture with a wrong 'mirrored' parameter: %1$d."
 msgstr "Bild mit fehlerhaften Spiegelungsparametern entdeckt: %c.\n"
 
-#: liblepton/src/geda_picture_object.c:84
 #, fuzzy
 msgid "Setting mirrored to 0."
 msgstr "Setze die Spiegelung auf 0\n"
 
-#: liblepton/src/geda_picture_object.c:89
 #, fuzzy, c-format
 msgid "Found a picture with a wrong 'embedded' parameter: %1$d."
 msgstr "Bild mit fehlerhaften Einbettungsparametern entdeckt. %c.\n"
 
-#: liblepton/src/geda_picture_object.c:91
 #, fuzzy
 msgid "Setting embedded to 0."
 msgstr "Setze die Einbettung auf 0\n"
 
-#: liblepton/src/geda_picture_object.c:104
 #, fuzzy, c-format
 msgid "Found an unsupported picture angle [ %1$d ]"
 msgstr "Bild mit fehlerhafter Winkelangabe entdeckt [%d]\n"
 
-#: liblepton/src/geda_picture_object.c:116
 msgid "Found an image with no filename."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:147
 #, fuzzy, c-format
 msgid "Failed to load image from embedded data [%1$s]: %2$s"
 msgstr "Fehler beim Laden der Daten eines eingebetteten Bildes [%s]: %s\n"
 
-#: liblepton/src/geda_picture_object.c:148
 msgid "Base64 decoding failed."
 msgstr "Base64 Dekodierung fehlgeschlagen."
 
-#: liblepton/src/geda_picture_object.c:149
 #, fuzzy
 msgid "Falling back to file loading. Picture unembedded."
 msgstr "Lade das Bild aus der Datei. Das Bild ist ausgebettet.\n"
 
-#: liblepton/src/geda_picture_object.c:208
 #, fuzzy
 msgid "ERROR: o_picture_save: unable to encode the picture."
 msgstr "FEHLER: o_picture_save: Kann das Bild nicht kodieren.\n"
 
-#: liblepton/src/geda_picture_object.c:308
 #, fuzzy, c-format
 msgid "Failed to load buffer image [%1$s]: %2$s"
 msgstr "Fehler beim Laden eines Symbols aus der Datei [%s]: %s\n"
 
-#: liblepton/src/geda_picture_object.c:321
 #, fuzzy, c-format
 msgid "Failed to load image from [%1$s]: %2$s"
 msgstr "Das Bild konnte nicht aus der Datei [%s] geladen werden: %s\n"
 
-#: liblepton/src/geda_picture_object.c:415
 #, fuzzy, c-format
 msgid "Picture %1$p has invalid angle %2$i\n"
 msgstr "Das Bild [%s] wurde eingebettet\n"
 
-#: liblepton/src/geda_picture_object.c:772
 #, fuzzy, c-format
 msgid "Picture [%1$s] has no image data."
 msgstr "Das Bild [%s] wurde eingebettet\n"
 
-#: liblepton/src/geda_picture_object.c:773
 #, fuzzy
 msgid "Falling back to file loading. Picture is still unembedded."
 msgstr "Lade das Bild aus der Datei. Das Bild ist ausgebettet.\n"
 
-#: liblepton/src/geda_picture_object.c:781
 #, fuzzy, c-format
 msgid "Picture [%1$s] has been embedded."
 msgstr "Das Bild [%s] wurde eingebettet\n"
 
-#: liblepton/src/geda_picture_object.c:805
 #, fuzzy, c-format
 msgid "Failed to load image from file [%1$s]: %2$s"
 msgstr "Das Bild konnte nicht aus der Datei [%s] geladen werden: %s\n"
 
-#: liblepton/src/geda_picture_object.c:807
 #, fuzzy
 msgid "Picture is still embedded."
 msgstr "Das Bild [%s] wurde eingebettet\n"
 
-#: liblepton/src/geda_picture_object.c:815
 #, fuzzy, c-format
 msgid "Picture [%1$s] has been unembedded."
 msgstr "Das Bild [%s] wurde ausgebettet\n"
 
-#: liblepton/src/geda_picture_object.c:1052
 #, fuzzy, c-format
 msgid "Failed to load fallback image %1$s: %2$s.\n"
 msgstr "Das Bild konnte nicht aus der Datei [%s] geladen werden: %s\n"
 
-#: liblepton/src/geda_pin_object.c:346 liblepton/src/geda_pin_object.c:354
 msgid "Failed to parse pin object"
 msgstr ""
 
-#: liblepton/src/geda_pin_object.c:360
 #, fuzzy
 msgid ""
 "Found a pin which did not have the whichend field set.\n"
@@ -682,69 +560,55 @@ msgstr ""
 "Pin ohne Markierung (whichend) der aktiven Seite entdeckt.\n"
 "Kontrolliere die Markierung und korrigiere ggf. manuell.\n"
 
-#: liblepton/src/geda_pin_object.c:363
 #, fuzzy, c-format
 msgid "Found an invalid whichend on a pin (reseting to zero): %d"
 msgstr ""
 "Pin mit fehlerafter Markierung (whichend) der aktiven Seite entdeckt. "
 "Verwende 0: %d\n"
 
-#: liblepton/src/geda_text_object.c:495 liblepton/src/geda_text_object.c:505
-#: liblepton/src/geda_text_object.c:515
 msgid "Failed to parse text object"
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:522
 #, fuzzy, c-format
 msgid "Found an invalid text size [ %1$s ]"
 msgstr "Fehlerhafte Farbangabe entdeckt [%s]\n"
 
-#: liblepton/src/geda_text_object.c:524
 #, fuzzy, c-format
 msgid "Setting text size to %1$d."
 msgstr "Setze die Spiegelung auf 0\n"
 
-#: liblepton/src/geda_text_object.c:528
 #, fuzzy, c-format
 msgid "Found an unsupported text angle [ %1$s ]"
 msgstr "Bild mit fehlerhafter Winkelangabe entdeckt [%d]\n"
 
-#: liblepton/src/geda_text_object.c:530
 #, fuzzy, c-format
 msgid "Setting angle to %1$d."
 msgstr "Setze die Winkelangabe auf 0\n"
 
-#: liblepton/src/geda_text_object.c:547
 #, fuzzy, c-format
 msgid "Found an unsupported text alignment [ %1$s ]"
 msgstr "Bild mit fehlerhafter Winkelangabe entdeckt [%d]\n"
 
-#: liblepton/src/geda_text_object.c:550
 #, fuzzy
 msgid "Setting alignment to LOWER_LEFT."
 msgstr "Verwende die Ausrichtung 'Links Unten'\n"
 
-#: liblepton/src/geda_text_object.c:570
 #, c-format
 msgid "Unexpected end-of-file after %1$d lines"
 msgstr ""
 
-#: liblepton/src/s_clib.c:460
 #, fuzzy, c-format
 msgid "Library command failed [%1$s]: %2$s"
 msgstr "Bibliotheksbefehl fehlgeschlagen [%s]: %s\n"
 
-#: liblepton/src/s_clib.c:465
 #, fuzzy, c-format
 msgid "Library command failed [%1$s]: Uncaught signal %2$i."
 msgstr "Bibliotheksbefehl fehlgeschlagen [%s]: Nicht abgefangenes Signal %i.\n"
 
-#: liblepton/src/s_clib.c:469
 #, fuzzy, c-format
 msgid "Library command failed [%1$s]"
 msgstr "Bibliotheksbefehl fehlgeschlagen [%s]\n"
 
-#: liblepton/src/s_clib.c:470
 #, fuzzy, c-format
 msgid ""
 "Error output was:\n"
@@ -753,36 +617,30 @@ msgstr ""
 "Die Fehlermeldung lautete:\n"
 "%s\n"
 
-#: liblepton/src/s_clib.c:556
 #, fuzzy, c-format
 msgid "Library name [%1$s] already in use.  Using [%2$s]."
 msgstr "Bibliotheksname [%s] wird bereits verwendet. Verwende [%s].\n"
 
-#: liblepton/src/s_clib.c:593
 #, fuzzy, c-format
 msgid "Failed to open directory [%1$s]: %2$s"
 msgstr "Fehler beim Öffnen eines Verzeichnisses [%s]: %s\n"
 
-#: liblepton/src/s_clib.c:729
 #, fuzzy, c-format
 msgid "Failed to scan library [%1$s]: Scheme function returned non-list."
 msgstr ""
 "Fehler beim Einlesen der Bibliothek [%s]: Die Scheme-Funktion hat 'non-list' "
 "zurückgegeben\n"
 
-#: liblepton/src/s_clib.c:737
 #, fuzzy, c-format
 msgid "Non-string symbol name while scanning library [%1$s]"
 msgstr ""
 "Beim Einlesen der Bibliothek [%s] wurde der Symbolname 'non-string' "
 "zurückgegeben\n"
 
-#: liblepton/src/s_clib.c:893 liblepton/src/s_clib.c:940
 #, fuzzy
 msgid "Cannot add library: name not specified."
 msgstr "Kann die Bibliothek nicht hinzufügen. Der Name fehlt\n"
 
-#: liblepton/src/s_clib.c:900
 #, fuzzy, c-format
 msgid ""
 "Cannot add library [%1$s]: both 'list' and 'get' commands must be specified."
@@ -790,271 +648,209 @@ msgstr ""
 "Kann die Bibliothek [%s] nicht hinzufügen: Beide Befehle ('list' und 'get') "
 "müssen angegeben werden.\n"
 
-#: liblepton/src/s_clib.c:948
 #, fuzzy, c-format
 msgid "Cannot add Scheme-library [%1$s]: callbacks must be closures."
 msgstr ""
 "Die Scheme-Bibliothek kann nicht hinzugefügt werden [%s]: Die aufgerufenen "
 "Prozeduren müssen abgeschlossen sein (closures)\n"
 
-#: liblepton/src/s_clib.c:1075
 #, fuzzy, c-format
 msgid "Failed to load symbol from file [%1$s]: %2$s"
 msgstr "Fehler beim Laden eines Symbols aus der Datei [%s]: %s\n"
 
-#: liblepton/src/s_clib.c:1135
 #, fuzzy, c-format
 msgid "Failed to load symbol data [%1$s] from source [%2$s]"
 msgstr "Fehler beim Laden der Symboldaten [%s] aus der Quelle [%s]\n"
 
-#: liblepton/src/s_clib.c:1377
 #, fuzzy, c-format
 msgid "Component [%1$s] was not found in the component library."
 msgstr ""
 "Das Bauteil [%s] konnte nicht in der Bauteilbibliothek gefunden werden\n"
 
-#: liblepton/src/s_clib.c:1383
 #, fuzzy, c-format
 msgid "More than one component found with name [%1$s]."
 msgstr "Mehr als ein Bauteil mit dem Namen [%s] gefunden\n"
 
-#: liblepton/src/s_hierarchy.c:78 liblepton/src/s_hierarchy.c:240
 msgid "Schematic not found in source library."
 msgstr ""
 
-#: liblepton/src/s_hierarchy.c:100
 msgid "Hierarchy contains a circular dependency."
 msgstr ""
 
-#: liblepton/src/s_hierarchy.c:200
 #, fuzzy
 msgid "There are no schematics above the current one!"
 msgstr "Über diesem Schaltplan gibt es keinen weiteren!\n"
 
-#: liblepton/src/s_hierarchy.c:341
 #, fuzzy, c-format
 msgid "Failed to descend hierarchy into '%1$s': %2$s"
 msgstr "Fehler beim Öffnen eines Verzeichnisses [%s]: %s\n"
 
-#: liblepton/src/s_slot.c:158
 #, fuzzy
 msgid "Did not find slotdef=#:#,#,#... attribute."
 msgstr "Es wurde kein slotdef=#:#,#,#... Attribut gefunden\n"
 
-#: liblepton/src/s_slot.c:164
 #, fuzzy
 msgid "Improper slotdef syntax: missing \":\"."
 msgstr "Fehlerhafte slotdef syntax: \":\" fehlt.\n"
 
-#: liblepton/src/s_slot.c:179
 #, fuzzy
 msgid "Did not find proper slotdef=#:#,#,#... attribute."
 msgstr "Kein korrektes Attribut slotdef=#:#,#,#... gefunden\n"
 
-#: liblepton/src/s_slot.c:209
 #, fuzzy
 msgid "component missing pinseq= attribute."
 msgstr "pinseq= Attribut fehlt.\n"
 
-#: liblepton/src/edaconfig.c:694 liblepton/src/edaconfig.c:780
 msgid "Undefined configuration filename"
 msgstr ""
 
-#: liblepton/src/edaconfig.c:1105 liblepton/src/edaconfig.c:1169
 #, c-format
 msgid "Configuration does not have group '%s'"
 msgstr ""
 
-#: liblepton/src/edaconfig.c:1183
 #, c-format
 msgid "Configuration does not have key '%s'"
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:66 liblepton/src/scheme_attrib.c:100
 msgid "~A is not a valid attribute: invalid string '~A'."
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:204
 msgid "Objects ~A and ~A are not part of the same page and/or complex object"
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:211 liblepton/src/scheme_attrib.c:216
 msgid "Object ~A is already attached as an attribute"
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:265
 msgid "Object ~A is attribute of wrong object"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:148
 msgid "Invalid complex angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:270 liblepton/src/scheme_page.c:246
 msgid "Object ~A is already attached to something"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:332
 msgid "Object ~A is attached to a different complex"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:339
 msgid "Object ~A is attached to a page"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:346 liblepton/src/scheme_page.c:298
 #, fuzzy
 msgid "Object ~A is attached as an attribute"
 msgstr "Es wurde versucht eine Attribut anzubringen, welches kein Text ist!\n"
 
-#: liblepton/src/scheme_complex.c:353 liblepton/src/scheme_page.c:305
 msgid "Object ~A has attributes"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:234
 msgid "Object ~A has bad type '~A'"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:378
 msgid "Object ~A has invalid stroke cap style ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:391
 msgid "Object ~A has invalid stroke dash style ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:455
 msgid "Invalid stroke cap style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:466
 msgid "Invalid stroke dash style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:476
 msgid "Missing dash length parameter for dash style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:486
 msgid "Missing dot/dash space parameter for dash style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:554
 msgid "Object ~A has invalid fill style ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:603
 msgid "Invalid fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:611
 msgid "Missing second space parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:620
 msgid "Missing second angle parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:630
 msgid "Missing stroke width parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:639
 msgid "Missing space parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:648
 msgid "Missing angle parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:962
 msgid "Invalid pin type ~A, must be 'net or 'bus"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1011
 msgid "Object ~A has invalid pin type."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1417
 msgid "Invalid text alignment ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1433
 msgid "Invalid text angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1452
 msgid "Invalid text name/value visibility ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1526
 msgid "Text object ~A has invalid text alignment ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1535
 msgid "Text object ~A has invalid visibility ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1545
 msgid "Text object ~A has invalid text attribute visibility ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1586
 msgid "Object ~A is not included in a page."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1739
 msgid "Path object ~A has invalid element type ~A at index ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1853
 msgid "Invalid path element type ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:2025
 msgid "Invalid picture angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr ""
 
-#: liblepton/src/scheme_page.c:291
 msgid "Object ~A is attached to a complex or different page"
 msgstr ""
 
-#: liblepton/src/scheme_page.c:438
 msgid "Parse error: ~s"
 msgstr ""
 
-#: liblepton/src/edascmhookproxy.c:83
 msgid "Scheme hook"
 msgstr ""
 
-#: liblepton/src/edascmhookproxy.c:84
 msgid "The Scheme-level hook to proxy"
 msgstr ""
 
-#: liblepton/scheme/geda/attrib.scm:56
 #, scheme-format
 msgid "Object ~A is not part of a page"
 msgstr ""
 
-#: liblepton/scheme/geda/library.scm:108
 #, scheme-format
 msgid "Invalid path ~S or source not readable.\n"
 msgstr ""
 
-#: liblepton/scheme/geda/library.scm:109
 msgid "Source library path must be a string.\n"
 msgstr ""
 
-#: liblepton/scheme/geda/library.scm:168
 #, scheme-format
 msgid "File ~S is not readable.\n"
 msgstr ""
 
-#: liblepton/scheme/geda/repl.scm:48
 msgid "Welcome to Lepton REPL!\n"
 msgstr ""
 
-#: liblepton/scheme/geda/repl.scm:53
 msgid "WARNING: Readline library is not supported in your configuration.\n"
 msgstr ""
 

--- a/liblepton/po/el.po
+++ b/liblepton/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-12 00:08+0300\n"
+"POT-Creation-Date: 2019-05-13 11:16+0300\n"
 "PO-Revision-Date: 2012-09-01 18:46+0000\n"
 "Last-Translator: Panos Bouklis <panos@echidna-band.com>\n"
 "Language-Team: Greek <el@li.org>\n"
@@ -18,46 +18,37 @@ msgstr ""
 "X-Launchpad-Export-Date: 2012-11-14 16:52+0000\n"
 "X-Generator: Launchpad (build 16265)\n"
 
-#: liblepton/data/liblepton.xml.in:3
 #, fuzzy
 msgid "Lepton EDA circuit schematic"
 msgstr "Σχεδιάγραμμα κυκλώματος gEDA"
 
-#: liblepton/data/liblepton.xml.in:4
 #, fuzzy
 msgid "Lepton EDA schematic symbol"
 msgstr "Σύμβολο σχεδίου gEDA"
 
-#: liblepton/data/liblepton.xml.in:5
 #, fuzzy
 msgid "Lepton EDA sch2pcb project"
 msgstr "Έργο gEDA gsch2pcb"
 
-#: liblepton/data/x-lepton-sch2pcb-project.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA sch2pcb Project"
 msgstr "Έργο gEDA Gsch2pcb"
 
-#: liblepton/data/x-lepton-schematic.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Circuit Schematic"
 msgstr "Σχεδιάγραμμα Κυκλώματος gEDA"
 
-#: liblepton/data/x-lepton-symbol.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Schematic Symbol"
 msgstr "Σύμβολο Σχεδίου gEDA"
 
-#: liblepton/src/a_basic.c:57 liblepton/src/f_basic.c:377
 #, fuzzy, c-format
 msgid "File %1$s is read-only"
 msgstr "Το αρχείο %s είναι μόνο για ανάγνωση"
 
-#: liblepton/src/a_basic.c:114
 msgid "Schematic data was not valid UTF-8"
 msgstr ""
 
-#: liblepton/src/a_basic.c:246
 #, c-format
 msgid ""
 "Read unexpected attach symbol start marker in [%1$s] :\n"
@@ -65,7 +56,6 @@ msgid ""
 "%2$s<<\n"
 msgstr ""
 
-#: liblepton/src/a_basic.c:263
 #, c-format
 msgid ""
 "Read unexpected embedded symbol start marker in [%1$s] :\n"
@@ -73,7 +63,6 @@ msgid ""
 "%2$s<<\n"
 msgstr ""
 
-#: liblepton/src/a_basic.c:294
 #, c-format
 msgid ""
 "Read unexpected embedded symbol end marker in [%s] :\n"
@@ -81,7 +70,6 @@ msgid ""
 "%s<<\n"
 msgstr ""
 
-#: liblepton/src/a_basic.c:329
 #, fuzzy, c-format
 msgid ""
 "Read an old format sym/sch file!\n"
@@ -92,7 +80,6 @@ msgstr ""
 "Παρακαλούμε εκτελέστε το g[sym|sch]update σε:\n"
 "[%s]\n"
 
-#: liblepton/src/a_basic.c:335
 #, fuzzy, c-format
 msgid ""
 "Read garbage in [%1$s] :\n"
@@ -103,17 +90,14 @@ msgstr ""
 ">>\n"
 "%s<<\n"
 
-#: liblepton/src/f_basic.c:119 liblepton/src/f_basic.c:132
 #, fuzzy, c-format
 msgid "Failed to stat [%1$s]: %2$s"
 msgstr "Αδυναμία ανοίγματος καταλόγου [%s]: %s\n"
 
-#: liblepton/src/f_basic.c:211
 #, fuzzy, c-format
 msgid "Cannot find file %1$s: %2$s"
 msgstr "Αδυναμία εύρεσης του αρχείου %s: %s"
 
-#: liblepton/src/f_basic.c:260
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -126,13 +110,11 @@ msgstr ""
 "  %s.\n"
 "\n"
 
-#: liblepton/src/f_basic.c:262
 msgid "I could not guess if it is newer, so you have to do it manually.\n"
 msgstr ""
 "Δεν μπόρεσα να καταλάβω αν είναι νεότερο, οπότε πρέπει να το κάνετε με το "
 "χέρι.\n"
 
-#: liblepton/src/f_basic.c:264
 msgid ""
 "The backup copy is newer than the schematic, so it seems you should load it "
 "instead of the original file.\n"
@@ -140,7 +122,6 @@ msgstr ""
 "Το αντίγραφο ασφαλείας είναι νεότερο από το σχεδιάγραμμα, άρα μάλλον πρέπει "
 "να φορτώσετε αυτό αντί για το αρχικό αρχείο.\n"
 
-#: liblepton/src/f_basic.c:266
 #, fuzzy
 msgid ""
 "lepton-schematic usually makes backup copies automatically, and this "
@@ -149,7 +130,6 @@ msgstr ""
 "Το gschem συνήθως δημιουργεί αντίγραφα ασφαλείας αυτόματα, και αυτή η "
 "περίπτωση συμβαίνει όταν κατέρρευσε ή έγινε βίαιη έξοδος.\n"
 
-#: liblepton/src/f_basic.c:269
 #, fuzzy
 msgid ""
 "\n"
@@ -160,232 +140,177 @@ msgstr ""
 "Εκτελέστε το gschem και διορθώστε την κατάσταση.\n"
 "\n"
 
-#: liblepton/src/f_basic.c:367
 #, fuzzy, c-format
 msgid "Can't get the real filename of %1$s: %2$s"
 msgstr "Αδυναμία λήψης του πραγματικού ονόματος αρχείου του %s: %s"
 
-#: liblepton/src/f_basic.c:398
 #, c-format
 msgid "Could NOT set previous backup file [%1$s] read-write."
 msgstr ""
 
-#: liblepton/src/f_basic.c:404
 #, fuzzy, c-format
 msgid "Can't save backup file: %1$s."
 msgstr "Αδυναμία αποθήκευσης αντιγράφου ασφαλείας: %s."
 
-#: liblepton/src/f_basic.c:414
 #, fuzzy, c-format
 msgid "Could NOT set backup file [%1$s] readonly."
 msgstr "ΔΕΝ ήταν δυνατή η αποθήκευση του αρχείου: %s"
 
-#: liblepton/src/f_basic.c:463
 #, fuzzy, c-format
 msgid "Failed to restore permissions on '%1$s': %2$s\n"
 msgstr "Αδυναμία ανοίγματος καταλόγου [%s]: %s\n"
 
-#: liblepton/src/f_basic.c:468
 #, fuzzy, c-format
 msgid "Failed to restore ownership on '%1$s': %2$s\n"
 msgstr "Αδυναμία ανοίγματος καταλόγου [%s]: %s\n"
 
-#: liblepton/src/f_basic.c:478
 #, fuzzy, c-format
 msgid "Could NOT save file: %1$s"
 msgstr "ΔΕΝ ήταν δυνατή η αποθήκευση του αρχείου: %s"
 
-#: liblepton/src/f_basic.c:604
 #, c-format
 msgid "%s: %s"
 msgstr "%s: %s"
 
-#: liblepton/src/g_basic.c:260
 msgid ""
 "\n"
 "Backtrace:\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:99
 #, fuzzy, c-format
 msgid "Invalid mode [%1$s] passed to %2$s\n"
 msgstr "Το στοιχείο [%s] δε βρέθηκε στη βιβλιοθήκη στοιχείων\n"
 
-#: liblepton/src/g_rc.c:139
 #, fuzzy
 msgid "RC file already loaded"
 msgstr "Το αρχείο ρυθμίσεων έχει ήδη φορτωθεί"
 
-#: liblepton/src/g_rc.c:183
 #, fuzzy, c-format
 msgid "Failed to load config from '%1$s': %2$s\n"
 msgstr "Αδυναμία φορτώματος εικόνας από [%s]: %s\n"
 
-#: liblepton/src/g_rc.c:207
 #, fuzzy, c-format
 msgid "Loaded RC file [%1$s]"
 msgstr "Η εντολή της βιβλιοθήκης απέτυχε [%s]\n"
 
-#: liblepton/src/g_rc.c:211
 #, fuzzy, c-format
 msgid "Failed to load RC file [%1$s]: "
 msgstr "Αποτυχία φορτώματος του συμβόλου από το αρχείο [%s]: %s\n"
 
-#: liblepton/src/g_rc.c:341
 msgid "ERROR: An unknown error occurred while parsing configuration files."
 msgstr ""
 
-#: liblepton/src/g_rc.c:353
 #, fuzzy, c-format
 msgid "ERROR: %1$s"
 msgstr "ΣΦΑΛΜΑ: %s\n"
 
-#: liblepton/src/g_rc.c:354
 #, fuzzy, c-format
 msgid "ERROR: %1$s\n"
 msgstr "ΣΦΑΛΜΑ: %s\n"
 
-#: liblepton/src/g_rc.c:360
 #, fuzzy, c-format
 msgid "ERROR: The %1$s log may contain more information.\n"
 msgstr "ΣΦΑΛΜΑ: Η καταγραφή %s μπορεί να περιέχει περισσότερες πληροφορίες.\n"
 
-#: liblepton/src/g_rc.c:512
 #, fuzzy, c-format
 msgid "Invalid path [%1$s] passed to component-library\n"
 msgstr "Το στοιχείο [%s] δε βρέθηκε στη βιβλιοθήκη στοιχείων\n"
 
-#: liblepton/src/g_rc.c:738
 #, fuzzy, c-format
 msgid "Invalid path [%1$s] passed to bitmap-directory\n"
 msgstr "Το στοιχείο [%s] δε βρέθηκε στη βιβλιοθήκη στοιχείων\n"
 
-#: liblepton/src/geda_page.c:197
 #, fuzzy, c-format
 msgid "s_page_delete: Can't get the real filename of %1$s."
 msgstr "s_page_delete: Αδυναμία λήψης του πραγματικού ονόματος αρχείου του %s."
 
-#: liblepton/src/geda_page.c:208
 #, fuzzy, c-format
 msgid "s_page_delete: Unable to delete backup file %1$s."
 msgstr "s_page_delete: Αδυναμία διαγραφής αντιγράφου ασφαλείας %s."
 
-#: liblepton/src/geda_page.c:490
 #, fuzzy, c-format
 msgid "Saved [%1$s]"
 msgstr "Αποθηκεύτηκε [%s]\n"
 
-#: liblepton/src/geda_page.c:496
 #, fuzzy, c-format
 msgid "Could NOT save [%1$s]"
 msgstr "ΔΕΝ αποθηκεύτηκε [%s]\n"
 
-#: liblepton/src/geda_arc_object.c:408 liblepton/src/geda_arc_object.c:421
 msgid "Failed to parse arc object"
 msgstr ""
 
-#: liblepton/src/geda_arc_object.c:428
 #, fuzzy, c-format
 msgid "Found a zero radius arc [ %1$c %2$d, %3$d, %4$d, %5$d, %6$d, %7$d ]"
 msgstr "Βρέθηκε εικόνα με μηδενικό πλάτος/ύψος [ %c %d %d %d %d ]\n"
 
-#: liblepton/src/geda_arc_object.c:435 liblepton/src/geda_box_object.c:328
-#: liblepton/src/geda_bus_object.c:364 liblepton/src/geda_circle_object.c:387
-#: liblepton/src/geda_line_object.c:427 liblepton/src/geda_net_object.c:308
-#: liblepton/src/geda_path_object.c:214 liblepton/src/geda_pin_object.c:369
-#: liblepton/src/geda_text_object.c:555
 #, fuzzy, c-format
 msgid "Found an invalid color [ %1$s ]"
 msgstr "Βρέθηκε ένα μη έγκυρο χρώμα [ %s ]\n"
 
-#: liblepton/src/geda_arc_object.c:436 liblepton/src/geda_box_object.c:329
-#: liblepton/src/geda_bus_object.c:365 liblepton/src/geda_circle_object.c:388
-#: liblepton/src/geda_line_object.c:428 liblepton/src/geda_net_object.c:309
-#: liblepton/src/geda_path_object.c:215 liblepton/src/geda_pin_object.c:370
-#: liblepton/src/geda_text_object.c:557
 #, fuzzy
 msgid "Setting color to default color."
 msgstr "Ρύθμιση χρώματος στο προκαθορισμένο\n"
 
-#: liblepton/src/o_attrib.c:111
 #, c-format
 msgid "Attribute [%1$s] already attached\n"
 msgstr ""
 
-#: liblepton/src/o_attrib.c:117
 msgid "Attempt to attach non text item as an attribute!\n"
 msgstr ""
 
-#: liblepton/src/o_attrib.c:122
 #, fuzzy, c-format
 msgid "Attempt to attach attribute [%1$s] to more than one object\n"
 msgstr ""
 "Προσπάθεια προσθήκης γνωρίσματος [%s] σε περισσότερα από ένα αντικείμενα\n"
 
-#: liblepton/src/o_attrib.c:325
 msgid "Tried to attach a non-text item as an attribute"
 msgstr ""
 
-#: liblepton/src/o_attrib.c:332
 msgid "Unexpected end-of-file in attribute list"
 msgstr "Απροσδόκητο τέλος αρχείου στη λίστα γνωρισμάτων"
 
-#: liblepton/src/geda_box_object.c:287 liblepton/src/geda_box_object.c:316
 msgid "Failed to parse box object"
 msgstr ""
 
-#: liblepton/src/geda_box_object.c:322
 #, fuzzy, c-format
 msgid "Found a zero width/height box [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr "Βρέθηκε εικόνα με μηδενικό πλάτος/ύψος [ %c %d %d %d %d ]\n"
 
-#: liblepton/src/geda_bus_object.c:345 liblepton/src/geda_bus_object.c:352
 msgid "Failed to parse bus object"
 msgstr ""
 
-#: liblepton/src/geda_bus_object.c:358
 #, fuzzy, c-format
 msgid "Found a zero length bus [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr "Βρέθηκε εικόνα με μηδενικό πλάτος/ύψος [ %c %d %d %d %d ]\n"
 
-#: liblepton/src/geda_bus_object.c:370
 #, fuzzy, c-format
 msgid "Found an invalid bus ripper direction [ %1$s ]"
 msgstr "Βρέθηκε ένα μη έγκυρο χρώμα [ %s ]\n"
 
-#: liblepton/src/geda_bus_object.c:371
 #, fuzzy
 msgid "Resetting direction to neutral (no direction)."
 msgstr "Επαναφορά κατεύθυνσης στη φυσική (χωρίς κατεύθυνση)\n"
 
-#: liblepton/src/geda_circle_object.c:343
-#: liblepton/src/geda_circle_object.c:372
 msgid "Failed to parse circle object"
 msgstr ""
 
-#: liblepton/src/geda_circle_object.c:379
 #, fuzzy, c-format
 msgid "Found a zero or negative radius circle [ %1$c %2$d %3$d %4$d %5$d ]"
 msgstr "Βρέθηκε εικόνα με μηδενικό πλάτος/ύψος [ %c %d %d %d %d ]\n"
 
-#: liblepton/src/geda_circle_object.c:382
 #, fuzzy
 msgid "Setting radius to 0."
 msgstr "Ρύθμιση γωνίας σε 0\n"
 
-#: liblepton/src/geda_color.c:217
 msgid "Color map entry must be a two-element list"
 msgstr ""
 
-#: liblepton/src/geda_color.c:225
 msgid "Index in color map entry must be an integer"
 msgstr ""
 
-#: liblepton/src/geda_color.c:251
 msgid "Value in color map entry must be #f or a string"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:373
 #, fuzzy, c-format
 msgid ""
 "Component not found:\n"
@@ -394,24 +319,19 @@ msgstr ""
 "Το στοιχείο δε βρέθηκε:\n"
 " %s"
 
-#: liblepton/src/geda_complex_object.c:585
 msgid "Failed to parse complex object"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:598
 #, fuzzy, c-format
 msgid ""
 "Found a component with an invalid rotation [ %1$c %2$d %3$d %4$d %5$d %6$d "
 "%7$s ]"
 msgstr "Βρέθηκε στοιχείο με μη έγκυρη περιστροφή [ %c %d %d %d %d %d %s ]\n"
 
-#: liblepton/src/geda_complex_object.c:601
-#: liblepton/src/geda_picture_object.c:105
 #, fuzzy
 msgid "Setting angle to 0."
 msgstr "Ρύθμιση γωνίας σε 0\n"
 
-#: liblepton/src/geda_complex_object.c:613
 #, fuzzy, c-format
 msgid ""
 "Found a component with an invalid mirror flag [ %1$c %2$d %3$d %4$d %5$d "
@@ -419,33 +339,28 @@ msgid ""
 msgstr ""
 "Βρέθηκε στοιχείο με μη έγκυρη σημαία καθρεπτισμού [ %c %d %d %d %d %d %s ]\n"
 
-#: liblepton/src/geda_complex_object.c:616
 #, fuzzy
 msgid "Setting mirror to 0."
 msgstr "Ρύθμιση καθρεπτισμού σε 0\n"
 
-#: liblepton/src/geda_complex_object.c:941
 #, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
 "\tCould not parse symbol file symversion=%2$s"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:945
 #, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
 "\tCould not parse symbol file symversion="
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:961
 #, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
 "\tCould not parse attached symversion=%2$s"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:986
 #, c-format
 msgid ""
 "WARNING: Symbol version oddity on refdes %1$s:\n"
@@ -453,36 +368,30 @@ msgid ""
 "symbol file."
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:1000
 #, c-format
 msgid ""
 "WARNING: Symbol version mismatch on refdes %1$s (%2$s):\n"
 "\tSymbol in library is newer than instantiated symbol."
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:1028
 #, c-format
 msgid "\tMAJOR VERSION CHANGE (file %1$.3f, instantiated %2$.3f, %3$s)!"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:1046
 #, c-format
 msgid "\tMinor version change (file %1$.3f, instantiated %2$.3f)"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:1057
 #, c-format
 msgid ""
 "WARNING: Symbol version oddity on refdes %1$s:\n"
 "\tInstantiated symbol is newer than symbol in library."
 msgstr ""
 
-#: liblepton/src/o_embed.c:54
 #, fuzzy, c-format
 msgid "Component [%1$s] has been embedded."
 msgstr "Το στοιχείο [%s] ενσωματώθηκε\n"
 
-#: liblepton/src/o_embed.c:98
 #, fuzzy, c-format
 msgid ""
 "Could not find component [%1$s], while trying to unembed. Component is still "
@@ -491,214 +400,169 @@ msgstr ""
 "Δεν ήταν δυνατή η εύρεση του στοιχείου [%s], κατά τη διάρκεια "
 "αποενσωμάτωσης. Το στοιχείο είναι ακόμα ενσωματωμένο\n"
 
-#: liblepton/src/o_embed.c:106
 #, fuzzy, c-format
 msgid "Component [%1$s] has been successfully unembedded."
 msgstr "Το στοιχείο [%s] αποενσωματώθηκε επιτυχώς\n"
 
-#: liblepton/src/geda_line_object.c:391 liblepton/src/geda_line_object.c:409
 msgid "Failed to parse line object"
 msgstr ""
 
-#: liblepton/src/geda_line_object.c:421
 #, fuzzy, c-format
 msgid "Found a zero length line [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr "Βρέθηκε εικόνα με μηδενικό πλάτος/ύψος [ %c %d %d %d %d ]\n"
 
-#: liblepton/src/geda_net_object.c:297
 msgid "Failed to parse net object"
 msgstr ""
 
-#: liblepton/src/geda_net_object.c:302
 #, fuzzy, c-format
 msgid "Found a zero length net [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr "Βρέθηκε εικόνα με μηδενικό πλάτος/ύψος [ %c %d %d %d %d ]\n"
 
-#: liblepton/src/geda_path_object.c:206
 msgid "Failed to parse path object"
 msgstr ""
 
-#: liblepton/src/geda_path_object.c:232
 msgid "Unexpected end-of-file when reading path"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:71
 msgid "Failed to parse picture definition"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:76
 #, fuzzy, c-format
 msgid "Found a zero width/height picture [ %1$c %2$d %3$d %4$d %5$d ]"
 msgstr "Βρέθηκε εικόνα με μηδενικό πλάτος/ύψος [ %c %d %d %d %d ]\n"
 
-#: liblepton/src/geda_picture_object.c:82
 #, fuzzy, c-format
 msgid "Found a picture with a wrong 'mirrored' parameter: %1$d."
 msgstr "Βρέθηκε εικόνα με λανθασμένη παράμετρο καθρεπτισμού: %d.\n"
 
-#: liblepton/src/geda_picture_object.c:84
 #, fuzzy
 msgid "Setting mirrored to 0."
 msgstr "Ρύθμιση καθρεπτισμού σε 0\n"
 
-#: liblepton/src/geda_picture_object.c:89
 #, fuzzy, c-format
 msgid "Found a picture with a wrong 'embedded' parameter: %1$d."
 msgstr "Βρέθηκε εικόνα με λανθασμένη παράμετρο ενσωματωμένου: %d.\n"
 
-#: liblepton/src/geda_picture_object.c:91
 #, fuzzy
 msgid "Setting embedded to 0."
 msgstr "Ρύθμιση ενσωματωμένου σε 0\n"
 
-#: liblepton/src/geda_picture_object.c:104
 #, fuzzy, c-format
 msgid "Found an unsupported picture angle [ %1$d ]"
 msgstr "Βρέθηκε μη υποστηριζόμενη γωνία εικόνας [ %d ]\n"
 
-#: liblepton/src/geda_picture_object.c:116
 msgid "Found an image with no filename."
 msgstr "Βρέθηκε εικόνα χωρίς όνομα αρχείου."
 
-#: liblepton/src/geda_picture_object.c:147
 #, fuzzy, c-format
 msgid "Failed to load image from embedded data [%1$s]: %2$s"
 msgstr "Αποτυχία φορτώματος εικόνας από τα ενσωματωμένα δεδομένα [%s]: %s\n"
 
-#: liblepton/src/geda_picture_object.c:148
 msgid "Base64 decoding failed."
 msgstr "Η αποκωδικοποίηση Base64 απέτυχε."
 
-#: liblepton/src/geda_picture_object.c:149
 #, fuzzy
 msgid "Falling back to file loading. Picture unembedded."
 msgstr "Επιστροφή στο φόρτωμα αρχείου. Η εικόνα αποενσωματώθηκε.\n"
 
-#: liblepton/src/geda_picture_object.c:208
 #, fuzzy
 msgid "ERROR: o_picture_save: unable to encode the picture."
 msgstr "ΣΦΑΛΜΑ: o_picture_save: αδυναμία κωδικοποίησης εικόνας.\n"
 
-#: liblepton/src/geda_picture_object.c:308
 #, fuzzy, c-format
 msgid "Failed to load buffer image [%1$s]: %2$s"
 msgstr "Αδυναμία φορτώματος εικόνας από [%s]: %s\n"
 
-#: liblepton/src/geda_picture_object.c:321
 #, fuzzy, c-format
 msgid "Failed to load image from [%1$s]: %2$s"
 msgstr "Αδυναμία φορτώματος εικόνας από [%s]: %s\n"
 
-#: liblepton/src/geda_picture_object.c:415
 #, fuzzy, c-format
 msgid "Picture %1$p has invalid angle %2$i\n"
 msgstr "Η εικόνα %p έχει μη έγκυρη γωνία %i\n"
 
-#: liblepton/src/geda_picture_object.c:772
 #, fuzzy, c-format
 msgid "Picture [%1$s] has no image data."
 msgstr "Η εικόνα %p έχει μη έγκυρη γωνία %i\n"
 
-#: liblepton/src/geda_picture_object.c:773
 #, fuzzy
 msgid "Falling back to file loading. Picture is still unembedded."
 msgstr "Επιστροφή στο φόρτωμα αρχείου. Η εικόνα αποενσωματώθηκε.\n"
 
-#: liblepton/src/geda_picture_object.c:781
 #, fuzzy, c-format
 msgid "Picture [%1$s] has been embedded."
 msgstr "Το στοιχείο [%s] ενσωματώθηκε\n"
 
-#: liblepton/src/geda_picture_object.c:805
 #, fuzzy, c-format
 msgid "Failed to load image from file [%1$s]: %2$s"
 msgstr "Αδυναμία φορτώματος εικόνας από [%s]: %s\n"
 
-#: liblepton/src/geda_picture_object.c:807
 msgid "Picture is still embedded."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:815
 #, fuzzy, c-format
 msgid "Picture [%1$s] has been unembedded."
 msgstr "Το στοιχείο [%s] ενσωματώθηκε\n"
 
-#: liblepton/src/geda_picture_object.c:1052
 #, fuzzy, c-format
 msgid "Failed to load fallback image %1$s: %2$s.\n"
 msgstr "Αδυναμία φορτώματος εικόνας από [%s]: %s\n"
 
-#: liblepton/src/geda_pin_object.c:346 liblepton/src/geda_pin_object.c:354
 msgid "Failed to parse pin object"
 msgstr ""
 
-#: liblepton/src/geda_pin_object.c:360
 msgid ""
 "Found a pin which did not have the whichend field set.\n"
 "Verify and correct manually."
 msgstr ""
 
-#: liblepton/src/geda_pin_object.c:363
 #, c-format
 msgid "Found an invalid whichend on a pin (reseting to zero): %d"
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:495 liblepton/src/geda_text_object.c:505
-#: liblepton/src/geda_text_object.c:515
 msgid "Failed to parse text object"
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:522
 #, fuzzy, c-format
 msgid "Found an invalid text size [ %1$s ]"
 msgstr "Βρέθηκε ένα μη έγκυρο χρώμα [ %s ]\n"
 
-#: liblepton/src/geda_text_object.c:524
 #, fuzzy, c-format
 msgid "Setting text size to %1$d."
 msgstr "Ρύθμιση καθρεπτισμού σε 0\n"
 
-#: liblepton/src/geda_text_object.c:528
 #, fuzzy, c-format
 msgid "Found an unsupported text angle [ %1$s ]"
 msgstr "Βρέθηκε μη υποστηριζόμενη γωνία εικόνας [ %d ]\n"
 
-#: liblepton/src/geda_text_object.c:530
 #, fuzzy, c-format
 msgid "Setting angle to %1$d."
 msgstr "Ρύθμιση γωνίας σε 0\n"
 
-#: liblepton/src/geda_text_object.c:547
 #, fuzzy, c-format
 msgid "Found an unsupported text alignment [ %1$s ]"
 msgstr "Βρέθηκε μη υποστηριζόμενη γωνία εικόνας [ %d ]\n"
 
-#: liblepton/src/geda_text_object.c:550
 #, fuzzy
 msgid "Setting alignment to LOWER_LEFT."
 msgstr "Ρύθμιση στοίχισης σε LOWER_LEFT\n"
 
-#: liblepton/src/geda_text_object.c:570
 #, fuzzy, c-format
 msgid "Unexpected end-of-file after %1$d lines"
 msgstr "Απροσδόκητο τέλος αρχείου στη λίστα γνωρισμάτων"
 
-#: liblepton/src/s_clib.c:460
 #, fuzzy, c-format
 msgid "Library command failed [%1$s]: %2$s"
 msgstr "Η εντολή της βιβλιοθήκης απέτυχε [%s]: %s\n"
 
-#: liblepton/src/s_clib.c:465
 #, fuzzy, c-format
 msgid "Library command failed [%1$s]: Uncaught signal %2$i."
 msgstr "Η εντολή της βιβλιοθήκης απέτυχε [%s]: %s\n"
 
-#: liblepton/src/s_clib.c:469
 #, fuzzy, c-format
 msgid "Library command failed [%1$s]"
 msgstr "Η εντολή της βιβλιοθήκης απέτυχε [%s]\n"
 
-#: liblepton/src/s_clib.c:470
 #, fuzzy, c-format
 msgid ""
 "Error output was:\n"
@@ -707,32 +571,26 @@ msgstr ""
 "Η έξοδος σφάλματος ήταν:\n"
 "%s\n"
 
-#: liblepton/src/s_clib.c:556
 #, fuzzy, c-format
 msgid "Library name [%1$s] already in use.  Using [%2$s]."
 msgstr "Η ονομασία βιβλιοθήκης [%s] χρησιμοποιείται ήδη.  Χρήση [%s].\n"
 
-#: liblepton/src/s_clib.c:593
 #, fuzzy, c-format
 msgid "Failed to open directory [%1$s]: %2$s"
 msgstr "Αδυναμία ανοίγματος καταλόγου [%s]: %s\n"
 
-#: liblepton/src/s_clib.c:729
 #, c-format
 msgid "Failed to scan library [%1$s]: Scheme function returned non-list."
 msgstr ""
 
-#: liblepton/src/s_clib.c:737
 #, c-format
 msgid "Non-string symbol name while scanning library [%1$s]"
 msgstr ""
 
-#: liblepton/src/s_clib.c:893 liblepton/src/s_clib.c:940
 #, fuzzy
 msgid "Cannot add library: name not specified."
 msgstr "Αδυναμία προσθήκης βιβλιοθήκης: το όνομα δεν έχει οριστεί\n"
 
-#: liblepton/src/s_clib.c:900
 #, fuzzy, c-format
 msgid ""
 "Cannot add library [%1$s]: both 'list' and 'get' commands must be specified."
@@ -740,271 +598,209 @@ msgstr ""
 "Δεν είναι δυνατή η προσθήκη της βιβλιοθήκης [%s]: πρέπει να καθοριστούν οι "
 "εντολές 'list' και 'get'.\n"
 
-#: liblepton/src/s_clib.c:948
 #, fuzzy, c-format
 msgid "Cannot add Scheme-library [%1$s]: callbacks must be closures."
 msgstr ""
 "Δεν είναι δυνατή η προσθήκη της βιβλιοθήκης [%s]: πρέπει να καθοριστούν οι "
 "εντολές 'list' και 'get'.\n"
 
-#: liblepton/src/s_clib.c:1075
 #, fuzzy, c-format
 msgid "Failed to load symbol from file [%1$s]: %2$s"
 msgstr "Αποτυχία φορτώματος του συμβόλου από το αρχείο [%s]: %s\n"
 
-#: liblepton/src/s_clib.c:1135
 #, fuzzy, c-format
 msgid "Failed to load symbol data [%1$s] from source [%2$s]"
 msgstr "Αποτυχία φορτώματος των δεδομένων συμβόλου [%s] από την πηγή [%s]\n"
 
-#: liblepton/src/s_clib.c:1377
 #, fuzzy, c-format
 msgid "Component [%1$s] was not found in the component library."
 msgstr "Το στοιχείο [%s] δε βρέθηκε στη βιβλιοθήκη στοιχείων\n"
 
-#: liblepton/src/s_clib.c:1383
 #, fuzzy, c-format
 msgid "More than one component found with name [%1$s]."
 msgstr "Βρέθηκαν περισσότερα από ένα στοιχεία με το όνομα [%s]\n"
 
-#: liblepton/src/s_hierarchy.c:78 liblepton/src/s_hierarchy.c:240
 msgid "Schematic not found in source library."
 msgstr ""
 
-#: liblepton/src/s_hierarchy.c:100
 msgid "Hierarchy contains a circular dependency."
 msgstr ""
 
-#: liblepton/src/s_hierarchy.c:200
 #, fuzzy
 msgid "There are no schematics above the current one!"
 msgstr "Δεν υπάρχουν σχεδιαγράμματα πάνω από το τρέχον!\n"
 
-#: liblepton/src/s_hierarchy.c:341
 #, fuzzy, c-format
 msgid "Failed to descend hierarchy into '%1$s': %2$s"
 msgstr "Αδυναμία ανοίγματος καταλόγου [%s]: %s\n"
 
-#: liblepton/src/s_slot.c:158
 #, fuzzy
 msgid "Did not find slotdef=#:#,#,#... attribute."
 msgstr "Δε βρέθηκε γνώρισμα slotdef=#:#,#,#...\n"
 
-#: liblepton/src/s_slot.c:164
 msgid "Improper slotdef syntax: missing \":\"."
 msgstr ""
 
-#: liblepton/src/s_slot.c:179
 #, fuzzy
 msgid "Did not find proper slotdef=#:#,#,#... attribute."
 msgstr "Δε βρέθηκε κατάλληλο γνώρισμα slotdef=#:#,#,#...\n"
 
-#: liblepton/src/s_slot.c:209
 #, fuzzy
 msgid "component missing pinseq= attribute."
 msgstr "Λείπει το γνώρισμα pinseq= από το στοιχείο\n"
 
-#: liblepton/src/edaconfig.c:694 liblepton/src/edaconfig.c:780
 msgid "Undefined configuration filename"
 msgstr ""
 
-#: liblepton/src/edaconfig.c:1105 liblepton/src/edaconfig.c:1169
 #, c-format
 msgid "Configuration does not have group '%s'"
 msgstr ""
 
-#: liblepton/src/edaconfig.c:1183
 #, c-format
 msgid "Configuration does not have key '%s'"
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:66 liblepton/src/scheme_attrib.c:100
 msgid "~A is not a valid attribute: invalid string '~A'."
 msgstr "Το ~A δεν είναι έγκυρο γνώρισμα: μη έγκυρη συμβολοσειρά '~A'."
 
-#: liblepton/src/scheme_attrib.c:204
 msgid "Objects ~A and ~A are not part of the same page and/or complex object"
 msgstr ""
 "Τα αντικείμενα ~A και ~A δεν είναι μέρη της ίδια σελίδας ή/και πολύπλοκου "
 "αντικειμένου"
 
-#: liblepton/src/scheme_attrib.c:211 liblepton/src/scheme_attrib.c:216
 msgid "Object ~A is already attached as an attribute"
 msgstr "Το αντικείμενο Object ~A είναι ήδη συνδεδεμένο με ένα γνώρισμα"
 
-#: liblepton/src/scheme_attrib.c:265
 msgid "Object ~A is attribute of wrong object"
 msgstr "Το αντικείμενο ~A είναι γνώρισμα του λάθος αντικειμένου"
 
-#: liblepton/src/scheme_complex.c:148
 msgid "Invalid complex angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:270 liblepton/src/scheme_page.c:246
 msgid "Object ~A is already attached to something"
 msgstr "Το αντικείμενο ~A είναι ήδη συνδεδεμένο με κάτι"
 
-#: liblepton/src/scheme_complex.c:332
 msgid "Object ~A is attached to a different complex"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:339
 msgid "Object ~A is attached to a page"
 msgstr "Το αντικείμενο ~A είναι συνδεδεμένο με μια σελίδα"
 
-#: liblepton/src/scheme_complex.c:346 liblepton/src/scheme_page.c:298
 msgid "Object ~A is attached as an attribute"
 msgstr "Το αντικείμενο ~A είναι συνδεδεμένο ως γνώρισμα"
 
-#: liblepton/src/scheme_complex.c:353 liblepton/src/scheme_page.c:305
 msgid "Object ~A has attributes"
 msgstr "Το αντικείμενο ~A έχει γνωρίσματα"
 
-#: liblepton/src/scheme_object.c:234
 msgid "Object ~A has bad type '~A'"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:378
 msgid "Object ~A has invalid stroke cap style ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:391
 msgid "Object ~A has invalid stroke dash style ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:455
 msgid "Invalid stroke cap style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:466
 msgid "Invalid stroke dash style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:476
 msgid "Missing dash length parameter for dash style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:486
 msgid "Missing dot/dash space parameter for dash style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:554
 msgid "Object ~A has invalid fill style ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:603
 msgid "Invalid fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:611
 msgid "Missing second space parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:620
 msgid "Missing second angle parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:630
 msgid "Missing stroke width parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:639
 msgid "Missing space parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:648
 msgid "Missing angle parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:962
 msgid "Invalid pin type ~A, must be 'net or 'bus"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1011
 msgid "Object ~A has invalid pin type."
 msgstr "Το αντικείμενο ~A έχει μη έγκυρο τύπο ακροδεκτών."
 
-#: liblepton/src/scheme_object.c:1417
 msgid "Invalid text alignment ~A."
 msgstr "Μη έγκυρη στοίχιση κειμένου ~A."
 
-#: liblepton/src/scheme_object.c:1433
 msgid "Invalid text angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr "Μη έγκυρη γωνία κειμένου ~A. Πρέπει να είναι 0, 90, 180, ή 270 μοίρες"
 
-#: liblepton/src/scheme_object.c:1452
 msgid "Invalid text name/value visibility ~A."
 msgstr "Μη έγκυρο όνομα/τιμή ορατότητας ~A."
 
-#: liblepton/src/scheme_object.c:1526
 msgid "Text object ~A has invalid text alignment ~A"
 msgstr "Το αντικείμενο κειμένου ~A έχει μη έγκυρη στοίχιση κειμένου ~A"
 
-#: liblepton/src/scheme_object.c:1535
 msgid "Text object ~A has invalid visibility ~A"
 msgstr "Το αντικείμενο κειμένου ~A έχει μη έγκυρη ορατότητα ~A"
 
-#: liblepton/src/scheme_object.c:1545
 msgid "Text object ~A has invalid text attribute visibility ~A"
 msgstr ""
 "Το αντικείμενο κειμένου ~A έχει μη έγκυρο γνώρισμα ορατότητας κειμένου ~A"
 
-#: liblepton/src/scheme_object.c:1586
 msgid "Object ~A is not included in a page."
 msgstr "Το αντικείμενο ~A δεν περιλαμβάνεται σε κάποια σελίδα."
 
-#: liblepton/src/scheme_object.c:1739
 msgid "Path object ~A has invalid element type ~A at index ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1853
 msgid "Invalid path element type ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:2025
 msgid "Invalid picture angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr "Μη έγκυρη γωνία εικόνας ~A. Πρέπει να είναι 0, 90, 180, ή 270 μοίρες"
 
-#: liblepton/src/scheme_page.c:291
 msgid "Object ~A is attached to a complex or different page"
 msgstr ""
 
-#: liblepton/src/scheme_page.c:438
 msgid "Parse error: ~s"
 msgstr ""
 
-#: liblepton/src/edascmhookproxy.c:83
 msgid "Scheme hook"
 msgstr ""
 
-#: liblepton/src/edascmhookproxy.c:84
 msgid "The Scheme-level hook to proxy"
 msgstr ""
 
-#: liblepton/scheme/geda/attrib.scm:56
 #, scheme-format
 msgid "Object ~A is not part of a page"
 msgstr "Το αντικείμενο ~A δεν είναι μέρος καμίας σελίδας"
 
-#: liblepton/scheme/geda/library.scm:108
 #, scheme-format
 msgid "Invalid path ~S or source not readable.\n"
 msgstr ""
 
-#: liblepton/scheme/geda/library.scm:109
 msgid "Source library path must be a string.\n"
 msgstr ""
 
-#: liblepton/scheme/geda/library.scm:168
 #, fuzzy, scheme-format
 msgid "File ~S is not readable.\n"
 msgstr "Το αρχείο %s είναι μόνο για ανάγνωση"
 
-#: liblepton/scheme/geda/repl.scm:48
 msgid "Welcome to Lepton REPL!\n"
 msgstr ""
 
-#: liblepton/scheme/geda/repl.scm:53
 msgid "WARNING: Readline library is not supported in your configuration.\n"
 msgstr ""
 

--- a/liblepton/po/en_GB.po
+++ b/liblepton/po/en_GB.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-12 00:08+0300\n"
+"POT-Creation-Date: 2019-05-13 11:16+0300\n"
 "PO-Revision-Date: 2012-01-31 12:15+0000\n"
 "Last-Translator: Peter TB Brett <Unknown>\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -19,46 +19,37 @@ msgstr ""
 "X-Launchpad-Export-Date: 2012-11-14 16:52+0000\n"
 "X-Generator: Launchpad (build 16265)\n"
 
-#: liblepton/data/liblepton.xml.in:3
 #, fuzzy
 msgid "Lepton EDA circuit schematic"
 msgstr "gEDA circuit schematic"
 
-#: liblepton/data/liblepton.xml.in:4
 #, fuzzy
 msgid "Lepton EDA schematic symbol"
 msgstr "gEDA schematic symbol"
 
-#: liblepton/data/liblepton.xml.in:5
 #, fuzzy
 msgid "Lepton EDA sch2pcb project"
 msgstr "gEDA gsch2pcb project"
 
-#: liblepton/data/x-lepton-sch2pcb-project.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA sch2pcb Project"
 msgstr "gEDA Gsch2pcb Project"
 
-#: liblepton/data/x-lepton-schematic.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Circuit Schematic"
 msgstr "gEDA Circuit Schematic"
 
-#: liblepton/data/x-lepton-symbol.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Schematic Symbol"
 msgstr "gEDA Schematic Symbol"
 
-#: liblepton/src/a_basic.c:57 liblepton/src/f_basic.c:377
 #, fuzzy, c-format
 msgid "File %1$s is read-only"
 msgstr "File %s is read-only"
 
-#: liblepton/src/a_basic.c:114
 msgid "Schematic data was not valid UTF-8"
 msgstr ""
 
-#: liblepton/src/a_basic.c:246
 #, fuzzy, c-format
 msgid ""
 "Read unexpected attach symbol start marker in [%1$s] :\n"
@@ -69,7 +60,6 @@ msgstr ""
 ">>\n"
 "%s<<\n"
 
-#: liblepton/src/a_basic.c:263
 #, fuzzy, c-format
 msgid ""
 "Read unexpected embedded symbol start marker in [%1$s] :\n"
@@ -80,7 +70,6 @@ msgstr ""
 ">>\n"
 "%s<<\n"
 
-#: liblepton/src/a_basic.c:294
 #, c-format
 msgid ""
 "Read unexpected embedded symbol end marker in [%s] :\n"
@@ -91,7 +80,6 @@ msgstr ""
 ">>\n"
 "%s<<\n"
 
-#: liblepton/src/a_basic.c:329
 #, fuzzy, c-format
 msgid ""
 "Read an old format sym/sch file!\n"
@@ -102,7 +90,6 @@ msgstr ""
 "Please run g[sym|sch]update on:\n"
 "[%s]\n"
 
-#: liblepton/src/a_basic.c:335
 #, fuzzy, c-format
 msgid ""
 "Read garbage in [%1$s] :\n"
@@ -113,17 +100,14 @@ msgstr ""
 ">>\n"
 "%s<<\n"
 
-#: liblepton/src/f_basic.c:119 liblepton/src/f_basic.c:132
 #, fuzzy, c-format
 msgid "Failed to stat [%1$s]: %2$s"
 msgstr "Failed to stat [%s]: %s"
 
-#: liblepton/src/f_basic.c:211
 #, fuzzy, c-format
 msgid "Cannot find file %1$s: %2$s"
 msgstr "Cannot find file: %s: %s"
 
-#: liblepton/src/f_basic.c:260
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -136,11 +120,9 @@ msgstr ""
 "  %s.\n"
 "\n"
 
-#: liblepton/src/f_basic.c:262
 msgid "I could not guess if it is newer, so you have to do it manually.\n"
 msgstr "I could not guess if it is newer, so you have to do it manually.\n"
 
-#: liblepton/src/f_basic.c:264
 msgid ""
 "The backup copy is newer than the schematic, so it seems you should load it "
 "instead of the original file.\n"
@@ -148,7 +130,6 @@ msgstr ""
 "The backup copy is newer than the schematic, so it seems you should load it "
 "instead of the original file.\n"
 
-#: liblepton/src/f_basic.c:266
 #, fuzzy
 msgid ""
 "lepton-schematic usually makes backup copies automatically, and this "
@@ -157,7 +138,6 @@ msgstr ""
 "Gschem usually makes backup copies automatically, and this situation happens "
 "when it crashed or it was forced to exit abruptly.\n"
 
-#: liblepton/src/f_basic.c:269
 #, fuzzy
 msgid ""
 "\n"
@@ -168,47 +148,38 @@ msgstr ""
 "Run gschem and correct the situation.\n"
 "\n"
 
-#: liblepton/src/f_basic.c:367
 #, fuzzy, c-format
 msgid "Can't get the real filename of %1$s: %2$s"
 msgstr "Can't get the real filename of %s: %s"
 
-#: liblepton/src/f_basic.c:398
 #, fuzzy, c-format
 msgid "Could NOT set previous backup file [%1$s] read-write."
 msgstr "Could NOT set previous backup file [%s] read-write\n"
 
-#: liblepton/src/f_basic.c:404
 #, fuzzy, c-format
 msgid "Can't save backup file: %1$s."
 msgstr "Can't save backup file: %s."
 
-#: liblepton/src/f_basic.c:414
 #, fuzzy, c-format
 msgid "Could NOT set backup file [%1$s] readonly."
 msgstr "Could NOT set backup file [%s] readonly\n"
 
-#: liblepton/src/f_basic.c:463
 #, fuzzy, c-format
 msgid "Failed to restore permissions on '%1$s': %2$s\n"
 msgstr "Failed to open directory [%s]: %s\n"
 
-#: liblepton/src/f_basic.c:468
 #, fuzzy, c-format
 msgid "Failed to restore ownership on '%1$s': %2$s\n"
 msgstr "Failed to open directory [%s]: %s\n"
 
-#: liblepton/src/f_basic.c:478
 #, fuzzy, c-format
 msgid "Could NOT save file: %1$s"
 msgstr "Could NOT save file: %s"
 
-#: liblepton/src/f_basic.c:604
 #, c-format
 msgid "%s: %s"
 msgstr "%s: %s"
 
-#: liblepton/src/g_basic.c:260
 msgid ""
 "\n"
 "Backtrace:\n"
@@ -216,185 +187,139 @@ msgstr ""
 "\n"
 "Backtrace:\n"
 
-#: liblepton/src/g_rc.c:99
 #, fuzzy, c-format
 msgid "Invalid mode [%1$s] passed to %2$s\n"
 msgstr "Component [%s] was not found in the component library\n"
 
-#: liblepton/src/g_rc.c:139
 #, fuzzy
 msgid "RC file already loaded"
 msgstr "Config file already loaded"
 
-#: liblepton/src/g_rc.c:183
 #, fuzzy, c-format
 msgid "Failed to load config from '%1$s': %2$s\n"
 msgstr "Failed to load image from [%s]: %s\n"
 
-#: liblepton/src/g_rc.c:207
 #, fuzzy, c-format
 msgid "Loaded RC file [%1$s]"
 msgstr "Library command failed [%s]\n"
 
-#: liblepton/src/g_rc.c:211
 #, fuzzy, c-format
 msgid "Failed to load RC file [%1$s]: "
 msgstr "Failed to load image from file [%s]: %s\n"
 
-#: liblepton/src/g_rc.c:341
 msgid "ERROR: An unknown error occurred while parsing configuration files."
 msgstr "ERROR: An unknown error occurred while parsing configuration files."
 
-#: liblepton/src/g_rc.c:353
 #, fuzzy, c-format
 msgid "ERROR: %1$s"
 msgstr "ERROR: %s\n"
 
-#: liblepton/src/g_rc.c:354
 #, fuzzy, c-format
 msgid "ERROR: %1$s\n"
 msgstr "ERROR: %s\n"
 
-#: liblepton/src/g_rc.c:360
 #, fuzzy, c-format
 msgid "ERROR: The %1$s log may contain more information.\n"
 msgstr "ERROR: The %s log may contain more information.\n"
 
-#: liblepton/src/g_rc.c:512
 #, fuzzy, c-format
 msgid "Invalid path [%1$s] passed to component-library\n"
 msgstr "Component [%s] was not found in the component library\n"
 
-#: liblepton/src/g_rc.c:738
 #, fuzzy, c-format
 msgid "Invalid path [%1$s] passed to bitmap-directory\n"
 msgstr "Component [%s] was not found in the component library\n"
 
-#: liblepton/src/geda_page.c:197
 #, fuzzy, c-format
 msgid "s_page_delete: Can't get the real filename of %1$s."
 msgstr "s_page_delete: Can't get the real filename of %s."
 
-#: liblepton/src/geda_page.c:208
 #, fuzzy, c-format
 msgid "s_page_delete: Unable to delete backup file %1$s."
 msgstr "s_page_delete: Unable to delete backup file %s."
 
-#: liblepton/src/geda_page.c:490
 #, fuzzy, c-format
 msgid "Saved [%1$s]"
 msgstr "Saved [%s]\n"
 
-#: liblepton/src/geda_page.c:496
 #, fuzzy, c-format
 msgid "Could NOT save [%1$s]"
 msgstr "Could NOT save [%s]\n"
 
-#: liblepton/src/geda_arc_object.c:408 liblepton/src/geda_arc_object.c:421
 msgid "Failed to parse arc object"
 msgstr "Failed to parse arc object"
 
-#: liblepton/src/geda_arc_object.c:428
 #, fuzzy, c-format
 msgid "Found a zero radius arc [ %1$c %2$d, %3$d, %4$d, %5$d, %6$d, %7$d ]"
 msgstr "Found a zero radius arc [ %c %d, %d, %d, %d, %d, %d ]\n"
 
-#: liblepton/src/geda_arc_object.c:435 liblepton/src/geda_box_object.c:328
-#: liblepton/src/geda_bus_object.c:364 liblepton/src/geda_circle_object.c:387
-#: liblepton/src/geda_line_object.c:427 liblepton/src/geda_net_object.c:308
-#: liblepton/src/geda_path_object.c:214 liblepton/src/geda_pin_object.c:369
-#: liblepton/src/geda_text_object.c:555
 #, fuzzy, c-format
 msgid "Found an invalid color [ %1$s ]"
 msgstr "Found an invalid colour [ %s ]\n"
 
-#: liblepton/src/geda_arc_object.c:436 liblepton/src/geda_box_object.c:329
-#: liblepton/src/geda_bus_object.c:365 liblepton/src/geda_circle_object.c:388
-#: liblepton/src/geda_line_object.c:428 liblepton/src/geda_net_object.c:309
-#: liblepton/src/geda_path_object.c:215 liblepton/src/geda_pin_object.c:370
-#: liblepton/src/geda_text_object.c:557
 #, fuzzy
 msgid "Setting color to default color."
 msgstr "Setting colour to default colour\n"
 
-#: liblepton/src/o_attrib.c:111
 #, c-format
 msgid "Attribute [%1$s] already attached\n"
 msgstr ""
 
-#: liblepton/src/o_attrib.c:117
 msgid "Attempt to attach non text item as an attribute!\n"
 msgstr "Attempt to attach non text item as an attribute!\n"
 
-#: liblepton/src/o_attrib.c:122
 #, fuzzy, c-format
 msgid "Attempt to attach attribute [%1$s] to more than one object\n"
 msgstr "Attempt to attach attribute [%s] to more than one object\n"
 
-#: liblepton/src/o_attrib.c:325
 msgid "Tried to attach a non-text item as an attribute"
 msgstr "Tried to attach a non-text item as an attribute"
 
-#: liblepton/src/o_attrib.c:332
 msgid "Unexpected end-of-file in attribute list"
 msgstr "Unexpected end-of-file in attribute list"
 
-#: liblepton/src/geda_box_object.c:287 liblepton/src/geda_box_object.c:316
 msgid "Failed to parse box object"
 msgstr "Failed to parse box object"
 
-#: liblepton/src/geda_box_object.c:322
 #, fuzzy, c-format
 msgid "Found a zero width/height box [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr "Found a zero width/height box [ %c %d %d %d %d %d ]\n"
 
-#: liblepton/src/geda_bus_object.c:345 liblepton/src/geda_bus_object.c:352
 msgid "Failed to parse bus object"
 msgstr "Failed to parse bus object"
 
-#: liblepton/src/geda_bus_object.c:358
 #, fuzzy, c-format
 msgid "Found a zero length bus [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr "Found a zero length bus [ %c %d %d %d %d %d ]\n"
 
-#: liblepton/src/geda_bus_object.c:370
 #, fuzzy, c-format
 msgid "Found an invalid bus ripper direction [ %1$s ]"
 msgstr "Found an invalid bus ripper direction [ %s ]\n"
 
-#: liblepton/src/geda_bus_object.c:371
 #, fuzzy
 msgid "Resetting direction to neutral (no direction)."
 msgstr "Resetting direction to neutral (no direction)\n"
 
-#: liblepton/src/geda_circle_object.c:343
-#: liblepton/src/geda_circle_object.c:372
 msgid "Failed to parse circle object"
 msgstr "Failed to parse circle object"
 
-#: liblepton/src/geda_circle_object.c:379
 #, fuzzy, c-format
 msgid "Found a zero or negative radius circle [ %1$c %2$d %3$d %4$d %5$d ]"
 msgstr "Found a zero or negative radius circle [ %c %d %d %d %d ]\n"
 
-#: liblepton/src/geda_circle_object.c:382
 #, fuzzy
 msgid "Setting radius to 0."
 msgstr "Setting radius to 0\n"
 
-#: liblepton/src/geda_color.c:217
 msgid "Color map entry must be a two-element list"
 msgstr "Colour map entry must be a two-element list"
 
-#: liblepton/src/geda_color.c:225
 msgid "Index in color map entry must be an integer"
 msgstr "Index in colour map entry must be an integer"
 
-#: liblepton/src/geda_color.c:251
 msgid "Value in color map entry must be #f or a string"
 msgstr "Value in colour map entry must be #f or a string"
 
-#: liblepton/src/geda_complex_object.c:373
 #, fuzzy, c-format
 msgid ""
 "Component not found:\n"
@@ -403,24 +328,19 @@ msgstr ""
 "Component not found:\n"
 " %s"
 
-#: liblepton/src/geda_complex_object.c:585
 msgid "Failed to parse complex object"
 msgstr "Failed to parse complex object"
 
-#: liblepton/src/geda_complex_object.c:598
 #, fuzzy, c-format
 msgid ""
 "Found a component with an invalid rotation [ %1$c %2$d %3$d %4$d %5$d %6$d "
 "%7$s ]"
 msgstr "Found a component with an invalid rotation [ %c %d %d %d %d %d %s ]\n"
 
-#: liblepton/src/geda_complex_object.c:601
-#: liblepton/src/geda_picture_object.c:105
 #, fuzzy
 msgid "Setting angle to 0."
 msgstr "Setting angle to 0\n"
 
-#: liblepton/src/geda_complex_object.c:613
 #, fuzzy, c-format
 msgid ""
 "Found a component with an invalid mirror flag [ %1$c %2$d %3$d %4$d %5$d "
@@ -428,12 +348,10 @@ msgid ""
 msgstr ""
 "Found a component with an invalid mirror flag [ %c %d %d %d %d %d %s ]\n"
 
-#: liblepton/src/geda_complex_object.c:616
 #, fuzzy
 msgid "Setting mirror to 0."
 msgstr "Setting mirror to 0\n"
 
-#: liblepton/src/geda_complex_object.c:941
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
@@ -442,7 +360,6 @@ msgstr ""
 "WARNING: Symbol version parse error on refdes %s:\n"
 "\tCould not parse symbol file symversion=%s\n"
 
-#: liblepton/src/geda_complex_object.c:945
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
@@ -451,7 +368,6 @@ msgstr ""
 "WARNING: Symbol version parse error on refdes %s:\n"
 "\tCould not parse symbol file symversion=\n"
 
-#: liblepton/src/geda_complex_object.c:961
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
@@ -460,7 +376,6 @@ msgstr ""
 "WARNING: Symbol version parse error on refdes %s:\n"
 "\tCould not parse attached symversion=%s\n"
 
-#: liblepton/src/geda_complex_object.c:986
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version oddity on refdes %1$s:\n"
@@ -471,7 +386,6 @@ msgstr ""
 "\tsymversion=%s attached to instantiated symbol, but no symversion= inside "
 "symbol file\n"
 
-#: liblepton/src/geda_complex_object.c:1000
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version mismatch on refdes %1$s (%2$s):\n"
@@ -480,17 +394,14 @@ msgstr ""
 "WARNING: Symbol version mismatch on refdes %s (%s):\n"
 "\tSymbol in library is newer than instantiated symbol\n"
 
-#: liblepton/src/geda_complex_object.c:1028
 #, fuzzy, c-format
 msgid "\tMAJOR VERSION CHANGE (file %1$.3f, instantiated %2$.3f, %3$s)!"
 msgstr "\tMAJOR VERSION CHANGE (file %.3f, instantiated %.3f, %s)!\n"
 
-#: liblepton/src/geda_complex_object.c:1046
 #, fuzzy, c-format
 msgid "\tMinor version change (file %1$.3f, instantiated %2$.3f)"
 msgstr "\tMinor version change (file %.3f, instantiated %.3f)\n"
 
-#: liblepton/src/geda_complex_object.c:1057
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version oddity on refdes %1$s:\n"
@@ -499,12 +410,10 @@ msgstr ""
 "WARNING: Symbol version oddity on refdes %s:\n"
 "\tInstantiated symbol is newer than symbol in library\n"
 
-#: liblepton/src/o_embed.c:54
 #, fuzzy, c-format
 msgid "Component [%1$s] has been embedded."
 msgstr "Component [%s] has been embedded\n"
 
-#: liblepton/src/o_embed.c:98
 #, fuzzy, c-format
 msgid ""
 "Could not find component [%1$s], while trying to unembed. Component is still "
@@ -513,149 +422,118 @@ msgstr ""
 "Could not find component [%s], while trying to unembed. Component is still "
 "embedded\n"
 
-#: liblepton/src/o_embed.c:106
 #, fuzzy, c-format
 msgid "Component [%1$s] has been successfully unembedded."
 msgstr "Component [%s] has been successfully unembedded\n"
 
-#: liblepton/src/geda_line_object.c:391 liblepton/src/geda_line_object.c:409
 msgid "Failed to parse line object"
 msgstr "Failed to parse line object"
 
-#: liblepton/src/geda_line_object.c:421
 #, fuzzy, c-format
 msgid "Found a zero length line [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr "Found a zero length line [ %c %d %d %d %d %d ]\n"
 
-#: liblepton/src/geda_net_object.c:297
 msgid "Failed to parse net object"
 msgstr "Failed to parse net object"
 
-#: liblepton/src/geda_net_object.c:302
 #, fuzzy, c-format
 msgid "Found a zero length net [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr "Found a zero length net [ %c %d %d %d %d %d ]\n"
 
-#: liblepton/src/geda_path_object.c:206
 msgid "Failed to parse path object"
 msgstr "Failed to parse path object"
 
-#: liblepton/src/geda_path_object.c:232
 msgid "Unexpected end-of-file when reading path"
 msgstr "Unexpected end-of-file when reading path"
 
-#: liblepton/src/geda_picture_object.c:71
 msgid "Failed to parse picture definition"
 msgstr "Failed to parse picture definition"
 
-#: liblepton/src/geda_picture_object.c:76
 #, fuzzy, c-format
 msgid "Found a zero width/height picture [ %1$c %2$d %3$d %4$d %5$d ]"
 msgstr "Found a zero width/height picture [ %c %d %d %d %d ]\n"
 
-#: liblepton/src/geda_picture_object.c:82
 #, fuzzy, c-format
 msgid "Found a picture with a wrong 'mirrored' parameter: %1$d."
 msgstr "Found a picture with a wrong 'mirrored' parameter: %d.\n"
 
-#: liblepton/src/geda_picture_object.c:84
 #, fuzzy
 msgid "Setting mirrored to 0."
 msgstr "Setting mirrored to 0\n"
 
-#: liblepton/src/geda_picture_object.c:89
 #, fuzzy, c-format
 msgid "Found a picture with a wrong 'embedded' parameter: %1$d."
 msgstr "Found a picture with a wrong 'embedded' parameter: %d.\n"
 
-#: liblepton/src/geda_picture_object.c:91
 #, fuzzy
 msgid "Setting embedded to 0."
 msgstr "Setting embedded to 0\n"
 
-#: liblepton/src/geda_picture_object.c:104
 #, fuzzy, c-format
 msgid "Found an unsupported picture angle [ %1$d ]"
 msgstr "Found an unsupported picture angle [ %d ]\n"
 
-#: liblepton/src/geda_picture_object.c:116
 msgid "Found an image with no filename."
 msgstr "Found an image with no filename."
 
-#: liblepton/src/geda_picture_object.c:147
 #, fuzzy, c-format
 msgid "Failed to load image from embedded data [%1$s]: %2$s"
 msgstr "Failed to load image from embedded data [%s]: %s\n"
 
-#: liblepton/src/geda_picture_object.c:148
 msgid "Base64 decoding failed."
 msgstr "Base64 decoding failed."
 
-#: liblepton/src/geda_picture_object.c:149
 #, fuzzy
 msgid "Falling back to file loading. Picture unembedded."
 msgstr "Falling back to file loading. Picture unembedded.\n"
 
-#: liblepton/src/geda_picture_object.c:208
 #, fuzzy
 msgid "ERROR: o_picture_save: unable to encode the picture."
 msgstr "ERROR: o_picture_save: unable to encode the picture.\n"
 
-#: liblepton/src/geda_picture_object.c:308
 #, fuzzy, c-format
 msgid "Failed to load buffer image [%1$s]: %2$s"
 msgstr "Failed to load buffer image [%s]: %s\n"
 
-#: liblepton/src/geda_picture_object.c:321
 #, fuzzy, c-format
 msgid "Failed to load image from [%1$s]: %2$s"
 msgstr "Failed to load image from [%s]: %s\n"
 
-#: liblepton/src/geda_picture_object.c:415
 #, fuzzy, c-format
 msgid "Picture %1$p has invalid angle %2$i\n"
 msgstr "Picture %p has invalid angle %i\n"
 
-#: liblepton/src/geda_picture_object.c:772
 #, fuzzy, c-format
 msgid "Picture [%1$s] has no image data."
 msgstr "Picture [%s] has no image data.\n"
 
-#: liblepton/src/geda_picture_object.c:773
 #, fuzzy
 msgid "Falling back to file loading. Picture is still unembedded."
 msgstr "Falling back to file loading. Picture is still unembedded.\n"
 
-#: liblepton/src/geda_picture_object.c:781
 #, fuzzy, c-format
 msgid "Picture [%1$s] has been embedded."
 msgstr "Picture [%s] has been embedded\n"
 
-#: liblepton/src/geda_picture_object.c:805
 #, fuzzy, c-format
 msgid "Failed to load image from file [%1$s]: %2$s"
 msgstr "Failed to load image from file [%s]: %s\n"
 
-#: liblepton/src/geda_picture_object.c:807
 #, fuzzy
 msgid "Picture is still embedded."
 msgstr "Picture is still embedded.\n"
 
-#: liblepton/src/geda_picture_object.c:815
 #, fuzzy, c-format
 msgid "Picture [%1$s] has been unembedded."
 msgstr "Picture [%s] has been unembedded\n"
 
-#: liblepton/src/geda_picture_object.c:1052
 #, fuzzy, c-format
 msgid "Failed to load fallback image %1$s: %2$s.\n"
 msgstr "Failed to load fallback image %s: %s.\n"
 
-#: liblepton/src/geda_pin_object.c:346 liblepton/src/geda_pin_object.c:354
 msgid "Failed to parse pin object"
 msgstr "Failed to parse pin object"
 
-#: liblepton/src/geda_pin_object.c:360
 #, fuzzy
 msgid ""
 "Found a pin which did not have the whichend field set.\n"
@@ -664,67 +542,53 @@ msgstr ""
 "Found a pin which did not have the whichone field set.\n"
 "Verify and correct manually.\n"
 
-#: liblepton/src/geda_pin_object.c:363
 #, fuzzy, c-format
 msgid "Found an invalid whichend on a pin (reseting to zero): %d"
 msgstr "Found an invalid whichend on a pin (reseting to zero): %d\n"
 
-#: liblepton/src/geda_text_object.c:495 liblepton/src/geda_text_object.c:505
-#: liblepton/src/geda_text_object.c:515
 msgid "Failed to parse text object"
 msgstr "Failed to parse text object"
 
-#: liblepton/src/geda_text_object.c:522
 #, fuzzy, c-format
 msgid "Found an invalid text size [ %1$s ]"
 msgstr "Found an invalid colour [ %s ]\n"
 
-#: liblepton/src/geda_text_object.c:524
 #, fuzzy, c-format
 msgid "Setting text size to %1$d."
 msgstr "Setting mirrored to 0\n"
 
-#: liblepton/src/geda_text_object.c:528
 #, fuzzy, c-format
 msgid "Found an unsupported text angle [ %1$s ]"
 msgstr "Found an unsupported picture angle [ %d ]\n"
 
-#: liblepton/src/geda_text_object.c:530
 #, fuzzy, c-format
 msgid "Setting angle to %1$d."
 msgstr "Setting angle to 0\n"
 
-#: liblepton/src/geda_text_object.c:547
 #, fuzzy, c-format
 msgid "Found an unsupported text alignment [ %1$s ]"
 msgstr "Found an unsupported picture angle [ %d ]\n"
 
-#: liblepton/src/geda_text_object.c:550
 #, fuzzy
 msgid "Setting alignment to LOWER_LEFT."
 msgstr "Setting alignment to LOWER_LEFT\n"
 
-#: liblepton/src/geda_text_object.c:570
 #, fuzzy, c-format
 msgid "Unexpected end-of-file after %1$d lines"
 msgstr "Unexpected end-of-file after %d lines"
 
-#: liblepton/src/s_clib.c:460
 #, fuzzy, c-format
 msgid "Library command failed [%1$s]: %2$s"
 msgstr "Library command failed [%s]: %s\n"
 
-#: liblepton/src/s_clib.c:465
 #, fuzzy, c-format
 msgid "Library command failed [%1$s]: Uncaught signal %2$i."
 msgstr "Library command failed [%s]: Uncaught signal %i.\n"
 
-#: liblepton/src/s_clib.c:469
 #, fuzzy, c-format
 msgid "Library command failed [%1$s]"
 msgstr "Library command failed [%s]\n"
 
-#: liblepton/src/s_clib.c:470
 #, fuzzy, c-format
 msgid ""
 "Error output was:\n"
@@ -733,299 +597,231 @@ msgstr ""
 "Error output was:\n"
 "%s\n"
 
-#: liblepton/src/s_clib.c:556
 #, fuzzy, c-format
 msgid "Library name [%1$s] already in use.  Using [%2$s]."
 msgstr "Library name [%s] already in use.  Using [%s].\n"
 
-#: liblepton/src/s_clib.c:593
 #, fuzzy, c-format
 msgid "Failed to open directory [%1$s]: %2$s"
 msgstr "Failed to open directory [%s]: %s\n"
 
-#: liblepton/src/s_clib.c:729
 #, fuzzy, c-format
 msgid "Failed to scan library [%1$s]: Scheme function returned non-list."
 msgstr "Failed to scan library [%s]: Scheme function returned non-list\n"
 
-#: liblepton/src/s_clib.c:737
 #, fuzzy, c-format
 msgid "Non-string symbol name while scanning library [%1$s]"
 msgstr "Non-string symbol name while scanning library [%s]\n"
 
-#: liblepton/src/s_clib.c:893 liblepton/src/s_clib.c:940
 #, fuzzy
 msgid "Cannot add library: name not specified."
 msgstr "Cannot add library: name not specified\n"
 
-#: liblepton/src/s_clib.c:900
 #, fuzzy, c-format
 msgid ""
 "Cannot add library [%1$s]: both 'list' and 'get' commands must be specified."
 msgstr ""
 "Cannot add library [%s]: both 'list' and 'get' commands must be specified.\n"
 
-#: liblepton/src/s_clib.c:948
 #, fuzzy, c-format
 msgid "Cannot add Scheme-library [%1$s]: callbacks must be closures."
 msgstr "Cannot add Scheme-library [%s]: callbacks must be closures\n"
 
-#: liblepton/src/s_clib.c:1075
 #, fuzzy, c-format
 msgid "Failed to load symbol from file [%1$s]: %2$s"
 msgstr "Failed to load symbol from file [%s]: %s\n"
 
-#: liblepton/src/s_clib.c:1135
 #, fuzzy, c-format
 msgid "Failed to load symbol data [%1$s] from source [%2$s]"
 msgstr "Failed to load symbol data [%s] from source [%s]\n"
 
-#: liblepton/src/s_clib.c:1377
 #, fuzzy, c-format
 msgid "Component [%1$s] was not found in the component library."
 msgstr "Component [%s] was not found in the component library\n"
 
-#: liblepton/src/s_clib.c:1383
 #, fuzzy, c-format
 msgid "More than one component found with name [%1$s]."
 msgstr "More than one component found with name [%s]\n"
 
-#: liblepton/src/s_hierarchy.c:78 liblepton/src/s_hierarchy.c:240
 msgid "Schematic not found in source library."
 msgstr ""
 
-#: liblepton/src/s_hierarchy.c:100
 msgid "Hierarchy contains a circular dependency."
 msgstr ""
 
-#: liblepton/src/s_hierarchy.c:200
 #, fuzzy
 msgid "There are no schematics above the current one!"
 msgstr "There are no schematics above the current one!\n"
 
-#: liblepton/src/s_hierarchy.c:341
 #, fuzzy, c-format
 msgid "Failed to descend hierarchy into '%1$s': %2$s"
 msgstr "Failed to open directory [%s]: %s\n"
 
-#: liblepton/src/s_slot.c:158
 #, fuzzy
 msgid "Did not find slotdef=#:#,#,#... attribute."
 msgstr "Did not find slotdef=#:#,#,#... attribute\n"
 
-#: liblepton/src/s_slot.c:164
 #, fuzzy
 msgid "Improper slotdef syntax: missing \":\"."
 msgstr "Improper slotdef syntax: missing \":\".\n"
 
-#: liblepton/src/s_slot.c:179
 #, fuzzy
 msgid "Did not find proper slotdef=#:#,#,#... attribute."
 msgstr "Did not find proper slotdef=#:#,#,#... attribute\n"
 
-#: liblepton/src/s_slot.c:209
 #, fuzzy
 msgid "component missing pinseq= attribute."
 msgstr "component missing pinseq= attribute\n"
 
-#: liblepton/src/edaconfig.c:694 liblepton/src/edaconfig.c:780
 msgid "Undefined configuration filename"
 msgstr ""
 
-#: liblepton/src/edaconfig.c:1105 liblepton/src/edaconfig.c:1169
 #, c-format
 msgid "Configuration does not have group '%s'"
 msgstr ""
 
-#: liblepton/src/edaconfig.c:1183
 #, c-format
 msgid "Configuration does not have key '%s'"
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:66 liblepton/src/scheme_attrib.c:100
 msgid "~A is not a valid attribute: invalid string '~A'."
 msgstr "~A is not a valid attribute: invalid string '~A'."
 
-#: liblepton/src/scheme_attrib.c:204
 msgid "Objects ~A and ~A are not part of the same page and/or complex object"
 msgstr "Objects ~A and ~A are not part of the same page and/or complex object"
 
-#: liblepton/src/scheme_attrib.c:211 liblepton/src/scheme_attrib.c:216
 msgid "Object ~A is already attached as an attribute"
 msgstr "Object ~A is already attached as an attribute"
 
-#: liblepton/src/scheme_attrib.c:265
 msgid "Object ~A is attribute of wrong object"
 msgstr "Object ~A is attribute of wrong object"
 
-#: liblepton/src/scheme_complex.c:148
 msgid "Invalid complex angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr "Invalid complex angle ~A. Must be 0, 90, 180, or 270 degrees"
 
-#: liblepton/src/scheme_complex.c:270 liblepton/src/scheme_page.c:246
 msgid "Object ~A is already attached to something"
 msgstr "Object ~A is already attached to something"
 
-#: liblepton/src/scheme_complex.c:332
 msgid "Object ~A is attached to a different complex"
 msgstr "Object ~A is attached to a different complex"
 
-#: liblepton/src/scheme_complex.c:339
 msgid "Object ~A is attached to a page"
 msgstr "Object ~A is attached to a page"
 
-#: liblepton/src/scheme_complex.c:346 liblepton/src/scheme_page.c:298
 msgid "Object ~A is attached as an attribute"
 msgstr "Object ~A is attached as an attribute"
 
-#: liblepton/src/scheme_complex.c:353 liblepton/src/scheme_page.c:305
 msgid "Object ~A has attributes"
 msgstr "Object ~A has attributes"
 
-#: liblepton/src/scheme_object.c:234
 msgid "Object ~A has bad type '~A'"
 msgstr "Object ~A has bad type '~A'"
 
-#: liblepton/src/scheme_object.c:378
 msgid "Object ~A has invalid stroke cap style ~A"
 msgstr "Object ~A has invalid stroke cap style ~A"
 
-#: liblepton/src/scheme_object.c:391
 msgid "Object ~A has invalid stroke dash style ~A"
 msgstr "Object ~A has invalid stroke dash style ~A"
 
-#: liblepton/src/scheme_object.c:455
 msgid "Invalid stroke cap style ~A."
 msgstr "Invalid stroke cap style ~A."
 
-#: liblepton/src/scheme_object.c:466
 msgid "Invalid stroke dash style ~A."
 msgstr "Invalid stroke dash style ~A."
 
-#: liblepton/src/scheme_object.c:476
 msgid "Missing dash length parameter for dash style ~A."
 msgstr "Missing dash length parameter for dash style ~A."
 
-#: liblepton/src/scheme_object.c:486
 msgid "Missing dot/dash space parameter for dash style ~A."
 msgstr "Missing dot/dash space parameter for dash style ~A."
 
-#: liblepton/src/scheme_object.c:554
 msgid "Object ~A has invalid fill style ~A"
 msgstr "Object ~A has invalid fill style ~A"
 
-#: liblepton/src/scheme_object.c:603
 msgid "Invalid fill style ~A."
 msgstr "Invalid fill style ~A."
 
-#: liblepton/src/scheme_object.c:611
 msgid "Missing second space parameter for fill style ~A."
 msgstr "Missing second space parameter for fill style ~A."
 
-#: liblepton/src/scheme_object.c:620
 msgid "Missing second angle parameter for fill style ~A."
 msgstr "Missing second angle parameter for fill style ~A."
 
-#: liblepton/src/scheme_object.c:630
 msgid "Missing stroke width parameter for fill style ~A."
 msgstr "Missing stroke width parameter for fill style ~A."
 
-#: liblepton/src/scheme_object.c:639
 msgid "Missing space parameter for fill style ~A."
 msgstr "Missing space parameter for fill style ~A."
 
-#: liblepton/src/scheme_object.c:648
 msgid "Missing angle parameter for fill style ~A."
 msgstr "Missing angle parameter for fill style ~A."
 
-#: liblepton/src/scheme_object.c:962
 msgid "Invalid pin type ~A, must be 'net or 'bus"
 msgstr "Invalid pin type ~A, must be 'net or 'bus"
 
-#: liblepton/src/scheme_object.c:1011
 msgid "Object ~A has invalid pin type."
 msgstr "Object ~A has invalid pin type."
 
-#: liblepton/src/scheme_object.c:1417
 msgid "Invalid text alignment ~A."
 msgstr "Invalid text alignment ~A."
 
-#: liblepton/src/scheme_object.c:1433
 msgid "Invalid text angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr "Invalid text angle ~A. Must be 0, 90, 180, or 270 degrees"
 
-#: liblepton/src/scheme_object.c:1452
 msgid "Invalid text name/value visibility ~A."
 msgstr "Invalid text name/value visibility ~A."
 
-#: liblepton/src/scheme_object.c:1526
 msgid "Text object ~A has invalid text alignment ~A"
 msgstr "Text object ~A has invalid text alignment ~A"
 
-#: liblepton/src/scheme_object.c:1535
 msgid "Text object ~A has invalid visibility ~A"
 msgstr "Text object ~A has invalid visibility ~A"
 
-#: liblepton/src/scheme_object.c:1545
 msgid "Text object ~A has invalid text attribute visibility ~A"
 msgstr "Text object ~A has invalid text attribute visibility ~A"
 
-#: liblepton/src/scheme_object.c:1586
 msgid "Object ~A is not included in a page."
 msgstr "Object ~A is not included in a page."
 
-#: liblepton/src/scheme_object.c:1739
 msgid "Path object ~A has invalid element type ~A at index ~A"
 msgstr "Path object ~A has invalid element type ~A at index ~A"
 
-#: liblepton/src/scheme_object.c:1853
 msgid "Invalid path element type ~A."
 msgstr "Invalid path element type ~A."
 
-#: liblepton/src/scheme_object.c:2025
 msgid "Invalid picture angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr "Invalid picture angle ~A. Must be 0, 90, 180, or 270 degrees"
 
-#: liblepton/src/scheme_page.c:291
 msgid "Object ~A is attached to a complex or different page"
 msgstr "Object ~A is attached to a complex or different page"
 
-#: liblepton/src/scheme_page.c:438
 msgid "Parse error: ~s"
 msgstr "Parse error: ~s"
 
-#: liblepton/src/edascmhookproxy.c:83
 msgid "Scheme hook"
 msgstr ""
 
-#: liblepton/src/edascmhookproxy.c:84
 msgid "The Scheme-level hook to proxy"
 msgstr ""
 
-#: liblepton/scheme/geda/attrib.scm:56
 #, scheme-format
 msgid "Object ~A is not part of a page"
 msgstr "Object ~A is not part of a page"
 
-#: liblepton/scheme/geda/library.scm:108
 #, scheme-format
 msgid "Invalid path ~S or source not readable.\n"
 msgstr ""
 
-#: liblepton/scheme/geda/library.scm:109
 msgid "Source library path must be a string.\n"
 msgstr ""
 
-#: liblepton/scheme/geda/library.scm:168
 #, fuzzy, scheme-format
 msgid "File ~S is not readable.\n"
 msgstr "File %s is read-only"
 
-#: liblepton/scheme/geda/repl.scm:48
 msgid "Welcome to Lepton REPL!\n"
 msgstr ""
 
-#: liblepton/scheme/geda/repl.scm:53
 msgid "WARNING: Readline library is not supported in your configuration.\n"
 msgstr ""
 

--- a/liblepton/po/es.po
+++ b/liblepton/po/es.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-12 00:08+0300\n"
+"POT-Creation-Date: 2019-05-13 11:16+0300\n"
 "PO-Revision-Date: 2012-02-20 00:09+0000\n"
 "Last-Translator: Carlos Nieves <Unknown>\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -19,46 +19,37 @@ msgstr ""
 "X-Launchpad-Export-Date: 2012-11-14 16:52+0000\n"
 "X-Generator: Launchpad (build 16265)\n"
 
-#: liblepton/data/liblepton.xml.in:3
 #, fuzzy
 msgid "Lepton EDA circuit schematic"
 msgstr "Esquema de circuito gEDA"
 
-#: liblepton/data/liblepton.xml.in:4
 #, fuzzy
 msgid "Lepton EDA schematic symbol"
 msgstr "Símbolo de esquema gEDA"
 
-#: liblepton/data/liblepton.xml.in:5
 #, fuzzy
 msgid "Lepton EDA sch2pcb project"
 msgstr "Proyecto de gEDA gsch2pcb"
 
-#: liblepton/data/x-lepton-sch2pcb-project.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA sch2pcb Project"
 msgstr "Proyecto gEDA Gsch2pcb"
 
-#: liblepton/data/x-lepton-schematic.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Circuit Schematic"
 msgstr "Esquema de circuito gEDA"
 
-#: liblepton/data/x-lepton-symbol.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Schematic Symbol"
 msgstr "Símbolo de esquema gEDA"
 
-#: liblepton/src/a_basic.c:57 liblepton/src/f_basic.c:377
 #, fuzzy, c-format
 msgid "File %1$s is read-only"
 msgstr "Fichero %s es de solo lectura"
 
-#: liblepton/src/a_basic.c:114
 msgid "Schematic data was not valid UTF-8"
 msgstr ""
 
-#: liblepton/src/a_basic.c:246
 #, fuzzy, c-format
 msgid ""
 "Read unexpected attach symbol start marker in [%1$s] :\n"
@@ -70,7 +61,6 @@ msgstr ""
 ">>\n"
 "%s<<\n"
 
-#: liblepton/src/a_basic.c:263
 #, fuzzy, c-format
 msgid ""
 "Read unexpected embedded symbol start marker in [%1$s] :\n"
@@ -81,7 +71,6 @@ msgstr ""
 ">>\n"
 "%s<<\n"
 
-#: liblepton/src/a_basic.c:294
 #, c-format
 msgid ""
 "Read unexpected embedded symbol end marker in [%s] :\n"
@@ -92,7 +81,6 @@ msgstr ""
 ">>\n"
 "%s<<\n"
 
-#: liblepton/src/a_basic.c:329
 #, fuzzy, c-format
 msgid ""
 "Read an old format sym/sch file!\n"
@@ -103,7 +91,6 @@ msgstr ""
 "Por favor ejecute: g[sym|sch]update en: \n"
 "[%s]\n"
 
-#: liblepton/src/a_basic.c:335
 #, fuzzy, c-format
 msgid ""
 "Read garbage in [%1$s] :\n"
@@ -114,17 +101,14 @@ msgstr ""
 ">>\n"
 "%s<<\n"
 
-#: liblepton/src/f_basic.c:119 liblepton/src/f_basic.c:132
 #, fuzzy, c-format
 msgid "Failed to stat [%1$s]: %2$s"
 msgstr "No se ha podido determinar [%s]: %s"
 
-#: liblepton/src/f_basic.c:211
 #, fuzzy, c-format
 msgid "Cannot find file %1$s: %2$s"
 msgstr "No se puede encontrar el archivo %s: %s"
 
-#: liblepton/src/f_basic.c:260
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -137,13 +121,11 @@ msgstr ""
 "  %s.\n"
 "\n"
 
-#: liblepton/src/f_basic.c:262
 msgid "I could not guess if it is newer, so you have to do it manually.\n"
 msgstr ""
 "No se ha podido averiguar si es más reciente, así que lo tendrá que hacer "
 "usted manualmente.\n"
 
-#: liblepton/src/f_basic.c:264
 msgid ""
 "The backup copy is newer than the schematic, so it seems you should load it "
 "instead of the original file.\n"
@@ -151,7 +133,6 @@ msgstr ""
 "La copia de seguridad es más reciente que el esquema. Parece que debería "
 "cargar la copia de seguridad en vez del archivo original.\n"
 
-#: liblepton/src/f_basic.c:266
 #, fuzzy
 msgid ""
 "lepton-schematic usually makes backup copies automatically, and this "
@@ -160,7 +141,6 @@ msgstr ""
 "Gschem normalmente realiza copias de seguridad automáticamente y esta "
 "situaciónocurre cuando ha fallado o se ha forzado una salida abrupta.\n"
 
-#: liblepton/src/f_basic.c:269
 #, fuzzy
 msgid ""
 "\n"
@@ -171,51 +151,42 @@ msgstr ""
 "Ejecute gschem y corrija la situación.\n"
 "\n"
 
-#: liblepton/src/f_basic.c:367
 #, fuzzy, c-format
 msgid "Can't get the real filename of %1$s: %2$s"
 msgstr "No se puede obtener el nombre de fichero real de %s: %s"
 
-#: liblepton/src/f_basic.c:398
 #, fuzzy, c-format
 msgid "Could NOT set previous backup file [%1$s] read-write."
 msgstr ""
 "No se ha podido poner el archivo de copia de seguridad anterior [%s] en modo "
 "de lectura-escritura\n"
 
-#: liblepton/src/f_basic.c:404
 #, fuzzy, c-format
 msgid "Can't save backup file: %1$s."
 msgstr "No se puede guardar la copia de seguridad: %s"
 
-#: liblepton/src/f_basic.c:414
 #, fuzzy, c-format
 msgid "Could NOT set backup file [%1$s] readonly."
 msgstr ""
 "No se ha podido poner el archivo de copia de seguridad [%s] en modo de sólo "
 "lectura\n"
 
-#: liblepton/src/f_basic.c:463
 #, fuzzy, c-format
 msgid "Failed to restore permissions on '%1$s': %2$s\n"
 msgstr "Error al abrir la carpeta [%s]: %s\n"
 
-#: liblepton/src/f_basic.c:468
 #, fuzzy, c-format
 msgid "Failed to restore ownership on '%1$s': %2$s\n"
 msgstr "Error al abrir la carpeta [%s]: %s\n"
 
-#: liblepton/src/f_basic.c:478
 #, fuzzy, c-format
 msgid "Could NOT save file: %1$s"
 msgstr "No se pudo guardar el fichero: %s"
 
-#: liblepton/src/f_basic.c:604
 #, c-format
 msgid "%s: %s"
 msgstr "%s: %s"
 
-#: liblepton/src/g_basic.c:260
 msgid ""
 "\n"
 "Backtrace:\n"
@@ -223,193 +194,147 @@ msgstr ""
 "\n"
 "Backtrace:\n"
 
-#: liblepton/src/g_rc.c:99
 #, fuzzy, c-format
 msgid "Invalid mode [%1$s] passed to %2$s\n"
 msgstr "No se ha encontrado el componente [%s] en la librería de componentes\n"
 
-#: liblepton/src/g_rc.c:139
 #, fuzzy
 msgid "RC file already loaded"
 msgstr "Fichero de Configuración ya está cargado"
 
-#: liblepton/src/g_rc.c:183
 #, fuzzy, c-format
 msgid "Failed to load config from '%1$s': %2$s\n"
 msgstr "Falló la carga de imagen desde [%s]: %s\n"
 
-#: liblepton/src/g_rc.c:207
 #, fuzzy, c-format
 msgid "Loaded RC file [%1$s]"
 msgstr "Un comando de librería ha fallado [%s]\n"
 
-#: liblepton/src/g_rc.c:211
 #, fuzzy, c-format
 msgid "Failed to load RC file [%1$s]: "
 msgstr "Error al cargar imagen desde el archivo [%s]: %s\n"
 
-#: liblepton/src/g_rc.c:341
 msgid "ERROR: An unknown error occurred while parsing configuration files."
 msgstr ""
 "ERROR: Un error desconocido ocurrió mientras se procesaban los ficheros de "
 "configuración."
 
-#: liblepton/src/g_rc.c:353
 #, fuzzy, c-format
 msgid "ERROR: %1$s"
 msgstr "ERROR: %s\n"
 
-#: liblepton/src/g_rc.c:354
 #, fuzzy, c-format
 msgid "ERROR: %1$s\n"
 msgstr "ERROR: %s\n"
 
-#: liblepton/src/g_rc.c:360
 #, fuzzy, c-format
 msgid "ERROR: The %1$s log may contain more information.\n"
 msgstr "ERROR: El log %s puede contener más información.\n"
 
-#: liblepton/src/g_rc.c:512
 #, fuzzy, c-format
 msgid "Invalid path [%1$s] passed to component-library\n"
 msgstr "No se ha encontrado el componente [%s] en la librería de componentes\n"
 
-#: liblepton/src/g_rc.c:738
 #, fuzzy, c-format
 msgid "Invalid path [%1$s] passed to bitmap-directory\n"
 msgstr "No se ha encontrado el componente [%s] en la librería de componentes\n"
 
-#: liblepton/src/geda_page.c:197
 #, fuzzy, c-format
 msgid "s_page_delete: Can't get the real filename of %1$s."
 msgstr "s_page_delete: No se puede encontrar el nombre real del archivo %s."
 
-#: liblepton/src/geda_page.c:208
 #, fuzzy, c-format
 msgid "s_page_delete: Unable to delete backup file %1$s."
 msgstr ""
 "s_page_delete: No se ha podido borrar el archivo de copia de seguridad %s."
 
-#: liblepton/src/geda_page.c:490
 #, fuzzy, c-format
 msgid "Saved [%1$s]"
 msgstr "Guardado [%s]\n"
 
-#: liblepton/src/geda_page.c:496
 #, fuzzy, c-format
 msgid "Could NOT save [%1$s]"
 msgstr "No se ha podido guardar [%s]\n"
 
-#: liblepton/src/geda_arc_object.c:408 liblepton/src/geda_arc_object.c:421
 msgid "Failed to parse arc object"
 msgstr "Falló el procesamiento de objeto arco"
 
-#: liblepton/src/geda_arc_object.c:428
 #, fuzzy, c-format
 msgid "Found a zero radius arc [ %1$c %2$d, %3$d, %4$d, %5$d, %6$d, %7$d ]"
 msgstr ""
 "Se ha encontrado un arco con radio cero [ %c %d, %d, %d, %d, %d, %d ]\n"
 
-#: liblepton/src/geda_arc_object.c:435 liblepton/src/geda_box_object.c:328
-#: liblepton/src/geda_bus_object.c:364 liblepton/src/geda_circle_object.c:387
-#: liblepton/src/geda_line_object.c:427 liblepton/src/geda_net_object.c:308
-#: liblepton/src/geda_path_object.c:214 liblepton/src/geda_pin_object.c:369
-#: liblepton/src/geda_text_object.c:555
 #, fuzzy, c-format
 msgid "Found an invalid color [ %1$s ]"
 msgstr "Se ha encontrado un color no válido [%s]\n"
 
-#: liblepton/src/geda_arc_object.c:436 liblepton/src/geda_box_object.c:329
-#: liblepton/src/geda_bus_object.c:365 liblepton/src/geda_circle_object.c:388
-#: liblepton/src/geda_line_object.c:428 liblepton/src/geda_net_object.c:309
-#: liblepton/src/geda_path_object.c:215 liblepton/src/geda_pin_object.c:370
-#: liblepton/src/geda_text_object.c:557
 #, fuzzy
 msgid "Setting color to default color."
 msgstr "Asignando el color por defecto al color\n"
 
-#: liblepton/src/o_attrib.c:111
 #, c-format
 msgid "Attribute [%1$s] already attached\n"
 msgstr ""
 
-#: liblepton/src/o_attrib.c:117
 msgid "Attempt to attach non text item as an attribute!\n"
 msgstr "¡Se ha intentado añadir un objeto que no es texto como un attributo!\n"
 
-#: liblepton/src/o_attrib.c:122
 #, fuzzy, c-format
 msgid "Attempt to attach attribute [%1$s] to more than one object\n"
 msgstr "Se ha intentado añadir el attributo [%s] a más de un objeto\n"
 
-#: liblepton/src/o_attrib.c:325
 msgid "Tried to attach a non-text item as an attribute"
 msgstr "Se trató de ajuntar un item de texto inválido como atributo."
 
-#: liblepton/src/o_attrib.c:332
 msgid "Unexpected end-of-file in attribute list"
 msgstr "Fin de Fichero inesperado en lista de atributos."
 
-#: liblepton/src/geda_box_object.c:287 liblepton/src/geda_box_object.c:316
 msgid "Failed to parse box object"
 msgstr "Falló el procesamiento de objeto caja"
 
-#: liblepton/src/geda_box_object.c:322
 #, fuzzy, c-format
 msgid "Found a zero width/height box [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr ""
 "Se ha encontrado un rectángulo con altura o anchura cero [ %c %d %d %d %d "
 "%d ]\n"
 
-#: liblepton/src/geda_bus_object.c:345 liblepton/src/geda_bus_object.c:352
 msgid "Failed to parse bus object"
 msgstr "Falló el procesamiento de objeto bus"
 
-#: liblepton/src/geda_bus_object.c:358
 #, fuzzy, c-format
 msgid "Found a zero length bus [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr "Se ha encontrado un bus de longitud cero [ %c %d %d %d %d %d ]\n"
 
-#: liblepton/src/geda_bus_object.c:370
 #, fuzzy, c-format
 msgid "Found an invalid bus ripper direction [ %1$s ]"
 msgstr ""
 "Se ha encontrado una dirección del símbolo de extracción de bus no válida "
 "[ %s ]\n"
 
-#: liblepton/src/geda_bus_object.c:371
 #, fuzzy
 msgid "Resetting direction to neutral (no direction)."
 msgstr "Cambiando la dirección al valor por defecto neutro (sin dirección)\n"
 
-#: liblepton/src/geda_circle_object.c:343
-#: liblepton/src/geda_circle_object.c:372
 msgid "Failed to parse circle object"
 msgstr "Falló el procesamiento de objeto círculo"
 
-#: liblepton/src/geda_circle_object.c:379
 #, fuzzy, c-format
 msgid "Found a zero or negative radius circle [ %1$c %2$d %3$d %4$d %5$d ]"
 msgstr "Se encontró radio menor o igual a cero en círculo [ %c %d %d %d %d ]\n"
 
-#: liblepton/src/geda_circle_object.c:382
 #, fuzzy
 msgid "Setting radius to 0."
 msgstr "Asignando radio nulo.\n"
 
-#: liblepton/src/geda_color.c:217
 msgid "Color map entry must be a two-element list"
 msgstr "La entrada del mapa de colores debe ser una lista de dos elementos"
 
-#: liblepton/src/geda_color.c:225
 msgid "Index in color map entry must be an integer"
 msgstr "El índice en la entrada del mapa de colores debe ser un número entero"
 
-#: liblepton/src/geda_color.c:251
 msgid "Value in color map entry must be #f or a string"
 msgstr "El valor en la entrada del mapa de colores debe ser #f o una cadena"
 
-#: liblepton/src/geda_complex_object.c:373
 #, fuzzy, c-format
 msgid ""
 "Component not found:\n"
@@ -418,11 +343,9 @@ msgstr ""
 "No se ha encontrado el componente:\n"
 " %s"
 
-#: liblepton/src/geda_complex_object.c:585
 msgid "Failed to parse complex object"
 msgstr "Falló el procesamiento de objeto complejo"
 
-#: liblepton/src/geda_complex_object.c:598
 #, fuzzy, c-format
 msgid ""
 "Found a component with an invalid rotation [ %1$c %2$d %3$d %4$d %5$d %6$d "
@@ -431,13 +354,10 @@ msgstr ""
 "Se ha encontrado un componente con un ángulo de rotación no válido [ %c %d "
 "%d %d %d %d %s ]\n"
 
-#: liblepton/src/geda_complex_object.c:601
-#: liblepton/src/geda_picture_object.c:105
 #, fuzzy
 msgid "Setting angle to 0."
 msgstr "Cambiando el parámetro 'ángulo' a 0\n"
 
-#: liblepton/src/geda_complex_object.c:613
 #, fuzzy, c-format
 msgid ""
 "Found a component with an invalid mirror flag [ %1$c %2$d %3$d %4$d %5$d "
@@ -446,12 +366,10 @@ msgstr ""
 "Se ha encontrado un componente con un atributo de simetría no válido [ %c %d "
 "%d %d %d %d %s ]\n"
 
-#: liblepton/src/geda_complex_object.c:616
 #, fuzzy
 msgid "Setting mirror to 0."
 msgstr "Estableciendo espejo en 0\n"
 
-#: liblepton/src/geda_complex_object.c:941
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
@@ -460,7 +378,6 @@ msgstr ""
 "ADVERTENCIA: Error al obtener la versión de símbolo en la referencia %s:\n"
 "\tNo se ha podido procesar el atributo de versión de archivo symversion=%s\n"
 
-#: liblepton/src/geda_complex_object.c:945
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
@@ -469,7 +386,6 @@ msgstr ""
 "ADVERTENCIA: Error al obtener la versión de símbolo en la referencia %s:\n"
 "\tNo se ha podido procesar el atributo de versión de archivo symversion=\n"
 
-#: liblepton/src/geda_complex_object.c:961
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
@@ -478,7 +394,6 @@ msgstr ""
 "ADVERTENCIA: Error al obtener la versión de símbolo en la referencia %s:\n"
 "\tNo se ha podido procesar el atributo añadido symversion=%s\n"
 
-#: liblepton/src/geda_complex_object.c:986
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version oddity on refdes %1$s:\n"
@@ -490,7 +405,6 @@ msgstr ""
 "\tse ha añadido el atributo symversion=%s a la instancia del símbolo, pero "
 "no hay ningún atributo symversion= dentro del archivo del símbolo\n"
 
-#: liblepton/src/geda_complex_object.c:1000
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version mismatch on refdes %1$s (%2$s):\n"
@@ -501,18 +415,15 @@ msgstr ""
 "\t El símbolo en la librería es más reciente que el instanciado en el "
 "esquema\n"
 
-#: liblepton/src/geda_complex_object.c:1028
 #, fuzzy, c-format
 msgid "\tMAJOR VERSION CHANGE (file %1$.3f, instantiated %2$.3f, %3$s)!"
 msgstr ""
 "\t¡CAMBIO DE VERSIÓN IMPORTANTE (archivo %.3f, instanciado %.3f, %s)!\n"
 
-#: liblepton/src/geda_complex_object.c:1046
 #, fuzzy, c-format
 msgid "\tMinor version change (file %1$.3f, instantiated %2$.3f)"
 msgstr "\tCambio menor en la versión (archivo %.3f, instanciado %.3f)\n"
 
-#: liblepton/src/geda_complex_object.c:1057
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version oddity on refdes %1$s:\n"
@@ -522,12 +433,10 @@ msgstr ""
 "referencia %s:\n"
 "\tEl símbolo instanciado es más reciente que el símbolo en la librería\n"
 
-#: liblepton/src/o_embed.c:54
 #, fuzzy, c-format
 msgid "Component [%1$s] has been embedded."
 msgstr "Se ha incrustado el componente [%s]\n"
 
-#: liblepton/src/o_embed.c:98
 #, fuzzy, c-format
 msgid ""
 "Could not find component [%1$s], while trying to unembed. Component is still "
@@ -536,154 +445,123 @@ msgstr ""
 "No se puede encontrar el componente [%s], al intentar desincrustarlo.El "
 "componente permanece todavía incrustado\n"
 
-#: liblepton/src/o_embed.c:106
 #, fuzzy, c-format
 msgid "Component [%1$s] has been successfully unembedded."
 msgstr "Se ha desincrustado satisfactoriamente el componente [%s]\n"
 
-#: liblepton/src/geda_line_object.c:391 liblepton/src/geda_line_object.c:409
 msgid "Failed to parse line object"
 msgstr "Falló el procesamiento de objeto línea"
 
-#: liblepton/src/geda_line_object.c:421
 #, fuzzy, c-format
 msgid "Found a zero length line [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr "Se ha encontrado una línea con longitud cero [ %c %d %d %d %d %d ]\n"
 
-#: liblepton/src/geda_net_object.c:297
 msgid "Failed to parse net object"
 msgstr "Falló el procesamiento de objeto red"
 
-#: liblepton/src/geda_net_object.c:302
 #, fuzzy, c-format
 msgid "Found a zero length net [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr ""
 "Se ha encontrado una conexión con longitud cero [ %c %d %d %d %d %d ]\n"
 
-#: liblepton/src/geda_path_object.c:206
 msgid "Failed to parse path object"
 msgstr "Falló el procesamiento de objeto ruta"
 
-#: liblepton/src/geda_path_object.c:232
 msgid "Unexpected end-of-file when reading path"
 msgstr "Fin de fichero inesperado mientras se leía la ruta"
 
-#: liblepton/src/geda_picture_object.c:71
 msgid "Failed to parse picture definition"
 msgstr "Falló el procesamiento de la definición de imagen"
 
-#: liblepton/src/geda_picture_object.c:76
 #, fuzzy, c-format
 msgid "Found a zero width/height picture [ %1$c %2$d %3$d %4$d %5$d ]"
 msgstr ""
 "Se ha encontrado una imagen con altura ó anchura cero [ %c %d %d %d %d ]\n"
 
-#: liblepton/src/geda_picture_object.c:82
 #, fuzzy, c-format
 msgid "Found a picture with a wrong 'mirrored' parameter: %1$d."
 msgstr ""
 "Se encontró una imagen con un valor erróneo en el parámetro 'mirrored': %d\n"
 
-#: liblepton/src/geda_picture_object.c:84
 #, fuzzy
 msgid "Setting mirrored to 0."
 msgstr "Cambiando el parámetro 'volteado' a 0\n"
 
-#: liblepton/src/geda_picture_object.c:89
 #, fuzzy, c-format
 msgid "Found a picture with a wrong 'embedded' parameter: %1$d."
 msgstr ""
 "Se encontró una imagen con un valor erróneo en el parámetro 'embedded': %d\n"
 
-#: liblepton/src/geda_picture_object.c:91
 #, fuzzy
 msgid "Setting embedded to 0."
 msgstr "Cambiando el parámetro 'incrustado' a 0\n"
 
-#: liblepton/src/geda_picture_object.c:104
 #, fuzzy, c-format
 msgid "Found an unsupported picture angle [ %1$d ]"
 msgstr ""
 "Se ha encontrado una imagen con un ángulo de rotación no válido [ %d ]\n"
 
-#: liblepton/src/geda_picture_object.c:116
 msgid "Found an image with no filename."
 msgstr "Se encontró una iagen sin nombre de archivo."
 
-#: liblepton/src/geda_picture_object.c:147
 #, fuzzy, c-format
 msgid "Failed to load image from embedded data [%1$s]: %2$s"
 msgstr "Error al cargar imagen desde los datos embebidos [%s]: %s\n"
 
-#: liblepton/src/geda_picture_object.c:148
 msgid "Base64 decoding failed."
 msgstr "Ha fallado la decodificación Base64"
 
-#: liblepton/src/geda_picture_object.c:149
 #, fuzzy
 msgid "Falling back to file loading. Picture unembedded."
 msgstr "Volviendo al modo de carga de archivo. Imagen desincrustada.\n"
 
-#: liblepton/src/geda_picture_object.c:208
 #, fuzzy
 msgid "ERROR: o_picture_save: unable to encode the picture."
 msgstr "ERROR: o_picture_save: imposible codificar la imagen.\n"
 
-#: liblepton/src/geda_picture_object.c:308
 #, fuzzy, c-format
 msgid "Failed to load buffer image [%1$s]: %2$s"
 msgstr "Falló la carga de imagen de buffer [%s]: %s\n"
 
-#: liblepton/src/geda_picture_object.c:321
 #, fuzzy, c-format
 msgid "Failed to load image from [%1$s]: %2$s"
 msgstr "Falló la carga de imagen desde [%s]: %s\n"
 
-#: liblepton/src/geda_picture_object.c:415
 #, fuzzy, c-format
 msgid "Picture %1$p has invalid angle %2$i\n"
 msgstr "Imagen %p tiene ángulo inválido: %i\n"
 
-#: liblepton/src/geda_picture_object.c:772
 #, fuzzy, c-format
 msgid "Picture [%1$s] has no image data."
 msgstr "Imagen [%s] no tiene información de imagen.\n"
 
-#: liblepton/src/geda_picture_object.c:773
 #, fuzzy
 msgid "Falling back to file loading. Picture is still unembedded."
 msgstr "Volviendo a la carga de fichero. Imagen aún no está empotrada.\n"
 
-#: liblepton/src/geda_picture_object.c:781
 #, fuzzy, c-format
 msgid "Picture [%1$s] has been embedded."
 msgstr "Se ha incrustado la imagen [%s]\n"
 
-#: liblepton/src/geda_picture_object.c:805
 #, fuzzy, c-format
 msgid "Failed to load image from file [%1$s]: %2$s"
 msgstr "Error al cargar imagen desde el archivo [%s]: %s\n"
 
-#: liblepton/src/geda_picture_object.c:807
 #, fuzzy
 msgid "Picture is still embedded."
 msgstr "Imagen aún está empotrada.\n"
 
-#: liblepton/src/geda_picture_object.c:815
 #, fuzzy, c-format
 msgid "Picture [%1$s] has been unembedded."
 msgstr "Se ha desincrustado la imagen [%s]\n"
 
-#: liblepton/src/geda_picture_object.c:1052
 #, fuzzy, c-format
 msgid "Failed to load fallback image %1$s: %2$s.\n"
 msgstr "Falló la carga de imagen de respaldo %s: %s.\n"
 
-#: liblepton/src/geda_pin_object.c:346 liblepton/src/geda_pin_object.c:354
 msgid "Failed to parse pin object"
 msgstr "Falló el procesamiento de objeto pin"
 
-#: liblepton/src/geda_pin_object.c:360
 #, fuzzy
 msgid ""
 "Found a pin which did not have the whichend field set.\n"
@@ -692,70 +570,56 @@ msgstr ""
 "Se ha encontrado una pata que no tiene el campo 'whichone'.\n"
 "Por favor, compruébelo y corríjalo manualmente.\n"
 
-#: liblepton/src/geda_pin_object.c:363
 #, fuzzy, c-format
 msgid "Found an invalid whichend on a pin (reseting to zero): %d"
 msgstr ""
 "Se ha encontrado un parámetro 'whichone' en una pata (y se cambia a 0): %d\n"
 
-#: liblepton/src/geda_text_object.c:495 liblepton/src/geda_text_object.c:505
-#: liblepton/src/geda_text_object.c:515
 msgid "Failed to parse text object"
 msgstr "Falló el procesamiento de objeto texto"
 
-#: liblepton/src/geda_text_object.c:522
 #, fuzzy, c-format
 msgid "Found an invalid text size [ %1$s ]"
 msgstr "Se ha encontrado un color no válido [%s]\n"
 
-#: liblepton/src/geda_text_object.c:524
 #, fuzzy, c-format
 msgid "Setting text size to %1$d."
 msgstr "Cambiando el parámetro 'volteado' a 0\n"
 
-#: liblepton/src/geda_text_object.c:528
 #, fuzzy, c-format
 msgid "Found an unsupported text angle [ %1$s ]"
 msgstr ""
 "Se ha encontrado una imagen con un ángulo de rotación no válido [ %d ]\n"
 
-#: liblepton/src/geda_text_object.c:530
 #, fuzzy, c-format
 msgid "Setting angle to %1$d."
 msgstr "Cambiando el parámetro 'ángulo' a 0\n"
 
-#: liblepton/src/geda_text_object.c:547
 #, fuzzy, c-format
 msgid "Found an unsupported text alignment [ %1$s ]"
 msgstr ""
 "Se ha encontrado una imagen con un ángulo de rotación no válido [ %d ]\n"
 
-#: liblepton/src/geda_text_object.c:550
 #, fuzzy
 msgid "Setting alignment to LOWER_LEFT."
 msgstr "Cambiando el alineamiento a 'Abajo a la izquierda'\n"
 
-#: liblepton/src/geda_text_object.c:570
 #, fuzzy, c-format
 msgid "Unexpected end-of-file after %1$d lines"
 msgstr "Fin de fichero inesperado luego de %d líneas"
 
-#: liblepton/src/s_clib.c:460
 #, fuzzy, c-format
 msgid "Library command failed [%1$s]: %2$s"
 msgstr "Un comando de librería ha fallado [%s]: %s\n"
 
-#: liblepton/src/s_clib.c:465
 #, fuzzy, c-format
 msgid "Library command failed [%1$s]: Uncaught signal %2$i."
 msgstr "Un comando de librería ha fallado [%s]: Señal no manejada %i.\n"
 
-#: liblepton/src/s_clib.c:469
 #, fuzzy, c-format
 msgid "Library command failed [%1$s]"
 msgstr "Un comando de librería ha fallado [%s]\n"
 
-#: liblepton/src/s_clib.c:470
 #, fuzzy, c-format
 msgid ""
 "Error output was:\n"
@@ -764,37 +628,31 @@ msgstr ""
 "La salida de error fue:\n"
 "%s\n"
 
-#: liblepton/src/s_clib.c:556
 #, fuzzy, c-format
 msgid "Library name [%1$s] already in use.  Using [%2$s]."
 msgstr ""
 "Ya se está usando el nombre de la librería [%s]. Se usará [%s] en su lugar.\n"
 
-#: liblepton/src/s_clib.c:593
 #, fuzzy, c-format
 msgid "Failed to open directory [%1$s]: %2$s"
 msgstr "Error al abrir la carpeta [%s]: %s\n"
 
-#: liblepton/src/s_clib.c:729
 #, fuzzy, c-format
 msgid "Failed to scan library [%1$s]: Scheme function returned non-list."
 msgstr ""
 "Error al buscar en la librería [%s]: la función de Scheme devolvió algo que "
 "no es una lista\n"
 
-#: liblepton/src/s_clib.c:737
 #, fuzzy, c-format
 msgid "Non-string symbol name while scanning library [%1$s]"
 msgstr ""
 "Se ha encontrado un nombre de símbolo que no es una cadena de texto al "
 "buscar en la librería [%s]\n"
 
-#: liblepton/src/s_clib.c:893 liblepton/src/s_clib.c:940
 #, fuzzy
 msgid "Cannot add library: name not specified."
 msgstr "No se puede añadir la librería: nombre sin especificar\n"
 
-#: liblepton/src/s_clib.c:900
 #, fuzzy, c-format
 msgid ""
 "Cannot add library [%1$s]: both 'list' and 'get' commands must be specified."
@@ -802,285 +660,223 @@ msgstr ""
 "No se puede añadir la librería [%s]: se tienen que especificar los comandos "
 "'list' y 'get'.\n"
 
-#: liblepton/src/s_clib.c:948
 #, fuzzy, c-format
 msgid "Cannot add Scheme-library [%1$s]: callbacks must be closures."
 msgstr ""
 "No se puede añadir la librería de Scheme [%s]: las funciones de llamada "
 "deben ser cierres (closures)\n"
 
-#: liblepton/src/s_clib.c:1075
 #, fuzzy, c-format
 msgid "Failed to load symbol from file [%1$s]: %2$s"
 msgstr "Error al cargar símbolo desde el archivo [%s]: %s\n"
 
-#: liblepton/src/s_clib.c:1135
 #, fuzzy, c-format
 msgid "Failed to load symbol data [%1$s] from source [%2$s]"
 msgstr "Error al cargar los datos del símbolo [%s] desde la fuente [%s]\n"
 
-#: liblepton/src/s_clib.c:1377
 #, fuzzy, c-format
 msgid "Component [%1$s] was not found in the component library."
 msgstr "No se ha encontrado el componente [%s] en la librería de componentes\n"
 
-#: liblepton/src/s_clib.c:1383
 #, fuzzy, c-format
 msgid "More than one component found with name [%1$s]."
 msgstr "Se ha encontrado más de un componente con el nombre [%s]\n"
 
-#: liblepton/src/s_hierarchy.c:78 liblepton/src/s_hierarchy.c:240
 msgid "Schematic not found in source library."
 msgstr ""
 
-#: liblepton/src/s_hierarchy.c:100
 msgid "Hierarchy contains a circular dependency."
 msgstr ""
 
-#: liblepton/src/s_hierarchy.c:200
 #, fuzzy
 msgid "There are no schematics above the current one!"
 msgstr "¡No hay más esquemas en un nivel de jerarquía superior al actual!\n"
 
-#: liblepton/src/s_hierarchy.c:341
 #, fuzzy, c-format
 msgid "Failed to descend hierarchy into '%1$s': %2$s"
 msgstr "Error al abrir la carpeta [%s]: %s\n"
 
-#: liblepton/src/s_slot.c:158
 #, fuzzy
 msgid "Did not find slotdef=#:#,#,#... attribute."
 msgstr "No se ha encontrado un atributo slotdef=#:#,#,#...\n"
 
-#: liblepton/src/s_slot.c:164
 #, fuzzy
 msgid "Improper slotdef syntax: missing \":\"."
 msgstr "Sintaxis de slotdef incorrecta: falta el carácter \":\".\n"
 
-#: liblepton/src/s_slot.c:179
 #, fuzzy
 msgid "Did not find proper slotdef=#:#,#,#... attribute."
 msgstr "No se ha encontrado un atributo válido slotdef=#:#,#,#...\n"
 
-#: liblepton/src/s_slot.c:209
 #, fuzzy
 msgid "component missing pinseq= attribute."
 msgstr "El componente no tiene el atributo pinseq\n"
 
-#: liblepton/src/edaconfig.c:694 liblepton/src/edaconfig.c:780
 msgid "Undefined configuration filename"
 msgstr ""
 
-#: liblepton/src/edaconfig.c:1105 liblepton/src/edaconfig.c:1169
 #, c-format
 msgid "Configuration does not have group '%s'"
 msgstr ""
 
-#: liblepton/src/edaconfig.c:1183
 #, c-format
 msgid "Configuration does not have key '%s'"
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:66 liblepton/src/scheme_attrib.c:100
 msgid "~A is not a valid attribute: invalid string '~A'."
 msgstr "~A no es un atributo válido: cadena de caracteres inválida '~A'."
 
-#: liblepton/src/scheme_attrib.c:204
 msgid "Objects ~A and ~A are not part of the same page and/or complex object"
 msgstr "Objetos ~A y ~A no son parte de la misma página y/o objeto complejo"
 
-#: liblepton/src/scheme_attrib.c:211 liblepton/src/scheme_attrib.c:216
 msgid "Object ~A is already attached as an attribute"
 msgstr "Objeto ~A ya está adjunto como atributo"
 
-#: liblepton/src/scheme_attrib.c:265
 msgid "Object ~A is attribute of wrong object"
 msgstr "Objeto ~A es atributo del objeto equivocado"
 
-#: liblepton/src/scheme_complex.c:148
 msgid "Invalid complex angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr ""
 "Angulo complejo inv'alido ~A. Debe ser 0, 90, 180 ó 270 grados sexagesimales."
 
-#: liblepton/src/scheme_complex.c:270 liblepton/src/scheme_page.c:246
 msgid "Object ~A is already attached to something"
 msgstr "Objeto ~A ya está adjunto a algo"
 
-#: liblepton/src/scheme_complex.c:332
 msgid "Object ~A is attached to a different complex"
 msgstr "Objeto ~A está adjunto a un complejo diferente"
 
-#: liblepton/src/scheme_complex.c:339
 msgid "Object ~A is attached to a page"
 msgstr "Objeto ~A está ajunto a la página"
 
-#: liblepton/src/scheme_complex.c:346 liblepton/src/scheme_page.c:298
 msgid "Object ~A is attached as an attribute"
 msgstr "Objeto ~A est'a adjunto como un atributo"
 
-#: liblepton/src/scheme_complex.c:353 liblepton/src/scheme_page.c:305
 msgid "Object ~A has attributes"
 msgstr "Objeto ~A tiene atributos"
 
-#: liblepton/src/scheme_object.c:234
 msgid "Object ~A has bad type '~A'"
 msgstr "Objeto ~A tiene tipo equivocado '~A'"
 
-#: liblepton/src/scheme_object.c:378
 msgid "Object ~A has invalid stroke cap style ~A"
 msgstr "El objeto ~A tiene un estilo de trazado de extremo no válido ~A."
 
-#: liblepton/src/scheme_object.c:391
 msgid "Object ~A has invalid stroke dash style ~A"
 msgstr "El objeto ~A tiene un estilo de trazado discontinuo no válido ~A."
 
-#: liblepton/src/scheme_object.c:455
 msgid "Invalid stroke cap style ~A."
 msgstr "Estilo de trazado de extremo no válido ~A."
 
-#: liblepton/src/scheme_object.c:466
 msgid "Invalid stroke dash style ~A."
 msgstr "Estilo de trazado discontinuo no válido ~A."
 
-#: liblepton/src/scheme_object.c:476
 msgid "Missing dash length parameter for dash style ~A."
 msgstr ""
 "No se ha especificado la longitud de espaciado para el estilo de "
 "interlineado ~A."
 
-#: liblepton/src/scheme_object.c:486
 msgid "Missing dot/dash space parameter for dash style ~A."
 msgstr ""
 "No se ha especificado el parámetro de espaciado entre punto/línea para el "
 "estilo discontinuo ~A."
 
-#: liblepton/src/scheme_object.c:554
 msgid "Object ~A has invalid fill style ~A"
 msgstr "El objeto ~A tiene un estilo de relleno no válido ~A"
 
-#: liblepton/src/scheme_object.c:603
 msgid "Invalid fill style ~A."
 msgstr "Estilo de relleno no válido ~A."
 
-#: liblepton/src/scheme_object.c:611
 msgid "Missing second space parameter for fill style ~A."
 msgstr ""
 "No se encuentra el parámetro de espaciado secundario para el estilo de "
 "relleno ~A."
 
-#: liblepton/src/scheme_object.c:620
 msgid "Missing second angle parameter for fill style ~A."
 msgstr ""
 "No se encuentra el parámetro de ángulo secundario para el estilo de relleno "
 "~A."
 
-#: liblepton/src/scheme_object.c:630
 msgid "Missing stroke width parameter for fill style ~A."
 msgstr ""
 "No se ha especificado el parámetro de grosor de trazado para el estilo de "
 "relleno ~A."
 
-#: liblepton/src/scheme_object.c:639
 msgid "Missing space parameter for fill style ~A."
 msgstr ""
 "No se encuentra el parámetro de espaciado para el estilo de relleno ~A."
 
-#: liblepton/src/scheme_object.c:648
 msgid "Missing angle parameter for fill style ~A."
 msgstr "No se encuentra el parámetro de ángulo para el estilo de relleno ~A."
 
-#: liblepton/src/scheme_object.c:962
 msgid "Invalid pin type ~A, must be 'net or 'bus"
 msgstr "Tipo de pata ~A no válido, debe ser 'conexión o 'bus"
 
-#: liblepton/src/scheme_object.c:1011
 msgid "Object ~A has invalid pin type."
 msgstr "El objeto ~A tiene un tipo de pata no válido."
 
-#: liblepton/src/scheme_object.c:1417
 msgid "Invalid text alignment ~A."
 msgstr "Alineación de texto inválida ~A"
 
-#: liblepton/src/scheme_object.c:1433
 msgid "Invalid text angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr "Ángulo de texto ~A no válido. Debe ser 0, 90, 180 ó 270 grados"
 
-#: liblepton/src/scheme_object.c:1452
 msgid "Invalid text name/value visibility ~A."
 msgstr "Visibilidad de nombre/valor de texto inválida ~A"
 
-#: liblepton/src/scheme_object.c:1526
 msgid "Text object ~A has invalid text alignment ~A"
 msgstr "El objeto de texto ~A tiene una alineación de texto inválida ~A"
 
-#: liblepton/src/scheme_object.c:1535
 msgid "Text object ~A has invalid visibility ~A"
 msgstr "El objeto de texto ~A tiene una visibilidad ~A no válida"
 
-#: liblepton/src/scheme_object.c:1545
 msgid "Text object ~A has invalid text attribute visibility ~A"
 msgstr ""
 "El objeto de texto ~A tiene una visibilidad de propiedad de texto ~A no "
 "válida"
 
-#: liblepton/src/scheme_object.c:1586
 msgid "Object ~A is not included in a page."
 msgstr "El objeto ~A no está incluido en una página."
 
-#: liblepton/src/scheme_object.c:1739
 msgid "Path object ~A has invalid element type ~A at index ~A"
 msgstr ""
 "El objeto de trazado ~A tiene un tipo de elemento ~A no válido en el índice "
 "~A"
 
-#: liblepton/src/scheme_object.c:1853
 msgid "Invalid path element type ~A."
 msgstr "Tipo de elemento de trazado ~A no válido."
 
-#: liblepton/src/scheme_object.c:2025
 msgid "Invalid picture angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr "Ángulo de imagen ~A no válido. Debe ser 0, 90, 180 o 270 grados"
 
-#: liblepton/src/scheme_page.c:291
 msgid "Object ~A is attached to a complex or different page"
 msgstr "El objeto ~A está asociado a un objeto complejo o página diferente"
 
-#: liblepton/src/scheme_page.c:438
 msgid "Parse error: ~s"
 msgstr "Error de procesado: %s"
 
-#: liblepton/src/edascmhookproxy.c:83
 msgid "Scheme hook"
 msgstr ""
 
-#: liblepton/src/edascmhookproxy.c:84
 msgid "The Scheme-level hook to proxy"
 msgstr ""
 
-#: liblepton/scheme/geda/attrib.scm:56
 #, scheme-format
 msgid "Object ~A is not part of a page"
 msgstr "El objeto ~A no es parte de una página"
 
-#: liblepton/scheme/geda/library.scm:108
 #, scheme-format
 msgid "Invalid path ~S or source not readable.\n"
 msgstr ""
 
-#: liblepton/scheme/geda/library.scm:109
 msgid "Source library path must be a string.\n"
 msgstr ""
 
-#: liblepton/scheme/geda/library.scm:168
 #, fuzzy, scheme-format
 msgid "File ~S is not readable.\n"
 msgstr "Fichero %s es de solo lectura"
 
-#: liblepton/scheme/geda/repl.scm:48
 msgid "Welcome to Lepton REPL!\n"
 msgstr ""
 
-#: liblepton/scheme/geda/repl.scm:53
 msgid "WARNING: Readline library is not supported in your configuration.\n"
 msgstr ""
 

--- a/liblepton/po/fr.po
+++ b/liblepton/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-12 00:08+0300\n"
+"POT-Creation-Date: 2019-05-13 11:16+0300\n"
 "PO-Revision-Date: 2012-10-22 13:10+0000\n"
 "Last-Translator: Patrick Fiquet <Unknown>\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -18,46 +18,37 @@ msgstr ""
 "X-Launchpad-Export-Date: 2012-11-14 16:52+0000\n"
 "X-Generator: Launchpad (build 16265)\n"
 
-#: liblepton/data/liblepton.xml.in:3
 #, fuzzy
 msgid "Lepton EDA circuit schematic"
 msgstr "Schéma de circuit gEDA"
 
-#: liblepton/data/liblepton.xml.in:4
 #, fuzzy
 msgid "Lepton EDA schematic symbol"
 msgstr "Schéma de symbole gEDA"
 
-#: liblepton/data/liblepton.xml.in:5
 #, fuzzy
 msgid "Lepton EDA sch2pcb project"
 msgstr "Projet gsch2pcb gEDA"
 
-#: liblepton/data/x-lepton-sch2pcb-project.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA sch2pcb Project"
 msgstr "Projet Gsch2pcb gEDA"
 
-#: liblepton/data/x-lepton-schematic.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Circuit Schematic"
 msgstr "Schéma de Circuit gEDA"
 
-#: liblepton/data/x-lepton-symbol.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Schematic Symbol"
 msgstr "Schéma de Symbole gEDA"
 
-#: liblepton/src/a_basic.c:57 liblepton/src/f_basic.c:377
 #, fuzzy, c-format
 msgid "File %1$s is read-only"
 msgstr "Le fichier %s est en lecture seule"
 
-#: liblepton/src/a_basic.c:114
 msgid "Schematic data was not valid UTF-8"
 msgstr ""
 
-#: liblepton/src/a_basic.c:246
 #, fuzzy, c-format
 msgid ""
 "Read unexpected attach symbol start marker in [%1$s] :\n"
@@ -68,7 +59,6 @@ msgstr ""
 ">>\n"
 "%s<<\n"
 
-#: liblepton/src/a_basic.c:263
 #, fuzzy, c-format
 msgid ""
 "Read unexpected embedded symbol start marker in [%1$s] :\n"
@@ -79,7 +69,6 @@ msgstr ""
 ">>\n"
 "%s<<\n"
 
-#: liblepton/src/a_basic.c:294
 #, c-format
 msgid ""
 "Read unexpected embedded symbol end marker in [%s] :\n"
@@ -90,7 +79,6 @@ msgstr ""
 ">>\n"
 "%s<<\n"
 
-#: liblepton/src/a_basic.c:329
 #, fuzzy, c-format
 msgid ""
 "Read an old format sym/sch file!\n"
@@ -101,7 +89,6 @@ msgstr ""
 "Veuillez lancer g[sym|sch]update sur:\n"
 "[%s]\n"
 
-#: liblepton/src/a_basic.c:335
 #, fuzzy, c-format
 msgid ""
 "Read garbage in [%1$s] :\n"
@@ -112,17 +99,14 @@ msgstr ""
 ">>\n"
 "%s<<\n"
 
-#: liblepton/src/f_basic.c:119 liblepton/src/f_basic.c:132
 #, fuzzy, c-format
 msgid "Failed to stat [%1$s]: %2$s"
 msgstr "Impossible d'évaluer [%s]: %s"
 
-#: liblepton/src/f_basic.c:211
 #, fuzzy, c-format
 msgid "Cannot find file %1$s: %2$s"
 msgstr "Impossible de trouver le fichier %s: %s"
 
-#: liblepton/src/f_basic.c:260
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -135,13 +119,11 @@ msgstr ""
 "  %s.\n"
 "\n"
 
-#: liblepton/src/f_basic.c:262
 msgid "I could not guess if it is newer, so you have to do it manually.\n"
 msgstr ""
 "Je n'arrive pas à deviner s'il est plus récent, vous devez le faire "
 "manuellement.\n"
 
-#: liblepton/src/f_basic.c:264
 msgid ""
 "The backup copy is newer than the schematic, so it seems you should load it "
 "instead of the original file.\n"
@@ -149,7 +131,6 @@ msgstr ""
 "La copie de sauvegarde est plus récente que le schéma, vous devriez la "
 "charge à la place du fichier originel.\n"
 
-#: liblepton/src/f_basic.c:266
 #, fuzzy
 msgid ""
 "lepton-schematic usually makes backup copies automatically, and this "
@@ -159,7 +140,6 @@ msgstr ""
 "situation se produit lorsqu'il a crashé ou qu'il a été obligé de s'arrêter "
 "brutalement.\n"
 
-#: liblepton/src/f_basic.c:269
 #, fuzzy
 msgid ""
 "\n"
@@ -170,242 +150,187 @@ msgstr ""
 "Lancez gschem et corrigez le problème.\n"
 "\n"
 
-#: liblepton/src/f_basic.c:367
 #, fuzzy, c-format
 msgid "Can't get the real filename of %1$s: %2$s"
 msgstr "Impossible d'obtenir le nom réel de %s : %s"
 
-#: liblepton/src/f_basic.c:398
 #, fuzzy, c-format
 msgid "Could NOT set previous backup file [%1$s] read-write."
 msgstr ""
 "Impossible de passer le fichier copie de sauvegarde [%s] en lecture/"
 "écriture\n"
 
-#: liblepton/src/f_basic.c:404
 #, fuzzy, c-format
 msgid "Can't save backup file: %1$s."
 msgstr "Impossible de sauvegarder le fichier de sauvegarde: %s."
 
-#: liblepton/src/f_basic.c:414
 #, fuzzy, c-format
 msgid "Could NOT set backup file [%1$s] readonly."
 msgstr ""
 "Impossible de passer le fichier copie de sauvegarde [%s] en lecture seule\n"
 
-#: liblepton/src/f_basic.c:463
 #, fuzzy, c-format
 msgid "Failed to restore permissions on '%1$s': %2$s\n"
 msgstr "Échec de l'ouverture du répertoire [%s]: %s\n"
 
-#: liblepton/src/f_basic.c:468
 #, fuzzy, c-format
 msgid "Failed to restore ownership on '%1$s': %2$s\n"
 msgstr "Échec de l'ouverture du répertoire [%s]: %s\n"
 
-#: liblepton/src/f_basic.c:478
 #, fuzzy, c-format
 msgid "Could NOT save file: %1$s"
 msgstr "Impossible de sauvegarder le fichier : %s"
 
-#: liblepton/src/f_basic.c:604
 #, c-format
 msgid "%s: %s"
 msgstr "%s: %s"
 
-#: liblepton/src/g_basic.c:260
 msgid ""
 "\n"
 "Backtrace:\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:99
 #, fuzzy, c-format
 msgid "Invalid mode [%1$s] passed to %2$s\n"
 msgstr ""
 "Le composant [%s] n'a pas été trouvé dans la bibliothèque des composants\n"
 
-#: liblepton/src/g_rc.c:139
 #, fuzzy
 msgid "RC file already loaded"
 msgstr "Fichier de configuration déjà chargé"
 
-#: liblepton/src/g_rc.c:183
 #, fuzzy, c-format
 msgid "Failed to load config from '%1$s': %2$s\n"
 msgstr "Échec du chargement de l'image depuis le fichier [%s]: %s\n"
 
-#: liblepton/src/g_rc.c:207
 #, fuzzy, c-format
 msgid "Loaded RC file [%1$s]"
 msgstr "Échec de la commande de bibliothèque [%s]\n"
 
-#: liblepton/src/g_rc.c:211
 #, fuzzy, c-format
 msgid "Failed to load RC file [%1$s]: "
 msgstr "Échec du chargement de l'image depuis le fichier [%s]: %s\n"
 
-#: liblepton/src/g_rc.c:341
 msgid "ERROR: An unknown error occurred while parsing configuration files."
 msgstr ""
 "ERREUR : Une erreur inconnue s'est produite lors de l'interprétation des "
 "fichiers de configuration."
 
-#: liblepton/src/g_rc.c:353
 #, fuzzy, c-format
 msgid "ERROR: %1$s"
 msgstr "ERREUR : %s\n"
 
-#: liblepton/src/g_rc.c:354
 #, fuzzy, c-format
 msgid "ERROR: %1$s\n"
 msgstr "ERREUR : %s\n"
 
-#: liblepton/src/g_rc.c:360
 #, fuzzy, c-format
 msgid "ERROR: The %1$s log may contain more information.\n"
 msgstr "ERREUR : Le fichier journal %s contient plus d'information.\n"
 
-#: liblepton/src/g_rc.c:512
 #, fuzzy, c-format
 msgid "Invalid path [%1$s] passed to component-library\n"
 msgstr ""
 "Le composant [%s] n'a pas été trouvé dans la bibliothèque des composants\n"
 
-#: liblepton/src/g_rc.c:738
 #, fuzzy, c-format
 msgid "Invalid path [%1$s] passed to bitmap-directory\n"
 msgstr ""
 "Le composant [%s] n'a pas été trouvé dans la bibliothèque des composants\n"
 
-#: liblepton/src/geda_page.c:197
 #, fuzzy, c-format
 msgid "s_page_delete: Can't get the real filename of %1$s."
 msgstr "s_page_delete: Impossible d'avoir le nom de fichier réel de %s."
 
-#: liblepton/src/geda_page.c:208
 #, fuzzy, c-format
 msgid "s_page_delete: Unable to delete backup file %1$s."
 msgstr "s_page_delete: Impossible d'effacer le fichier de sauvegarde %s."
 
-#: liblepton/src/geda_page.c:490
 #, fuzzy, c-format
 msgid "Saved [%1$s]"
 msgstr "Sauvegarder [%s]\n"
 
-#: liblepton/src/geda_page.c:496
 #, fuzzy, c-format
 msgid "Could NOT save [%1$s]"
 msgstr "Impossible de sauvegarder [%s]\n"
 
-#: liblepton/src/geda_arc_object.c:408 liblepton/src/geda_arc_object.c:421
 msgid "Failed to parse arc object"
 msgstr ""
 
-#: liblepton/src/geda_arc_object.c:428
 #, fuzzy, c-format
 msgid "Found a zero radius arc [ %1$c %2$d, %3$d, %4$d, %5$d, %6$d, %7$d ]"
 msgstr "Trouvé un arc avec rayon nul [ %c %d, %d, %d, %d, %d, %d ]\n"
 
-#: liblepton/src/geda_arc_object.c:435 liblepton/src/geda_box_object.c:328
-#: liblepton/src/geda_bus_object.c:364 liblepton/src/geda_circle_object.c:387
-#: liblepton/src/geda_line_object.c:427 liblepton/src/geda_net_object.c:308
-#: liblepton/src/geda_path_object.c:214 liblepton/src/geda_pin_object.c:369
-#: liblepton/src/geda_text_object.c:555
 #, fuzzy, c-format
 msgid "Found an invalid color [ %1$s ]"
 msgstr "Trouvé une couleur invalide [ %s ]\n"
 
-#: liblepton/src/geda_arc_object.c:436 liblepton/src/geda_box_object.c:329
-#: liblepton/src/geda_bus_object.c:365 liblepton/src/geda_circle_object.c:388
-#: liblepton/src/geda_line_object.c:428 liblepton/src/geda_net_object.c:309
-#: liblepton/src/geda_path_object.c:215 liblepton/src/geda_pin_object.c:370
-#: liblepton/src/geda_text_object.c:557
 #, fuzzy
 msgid "Setting color to default color."
 msgstr "Initialiser à la couleur par défaut\n"
 
-#: liblepton/src/o_attrib.c:111
 #, c-format
 msgid "Attribute [%1$s] already attached\n"
 msgstr ""
 
-#: liblepton/src/o_attrib.c:117
 msgid "Attempt to attach non text item as an attribute!\n"
 msgstr "Tentative d'attachement d'un objet non textuel comme attribut!\n"
 
-#: liblepton/src/o_attrib.c:122
 #, fuzzy, c-format
 msgid "Attempt to attach attribute [%1$s] to more than one object\n"
 msgstr "Tentative d'attachement d'un attribut [%s] à plus d'un objet\n"
 
-#: liblepton/src/o_attrib.c:325
 msgid "Tried to attach a non-text item as an attribute"
 msgstr ""
 
-#: liblepton/src/o_attrib.c:332
 msgid "Unexpected end-of-file in attribute list"
 msgstr "Fin de fichier inattendue dans la liste des attributs"
 
-#: liblepton/src/geda_box_object.c:287 liblepton/src/geda_box_object.c:316
 msgid "Failed to parse box object"
 msgstr "Erreur lors de l'interprétation d'un objet boîte"
 
-#: liblepton/src/geda_box_object.c:322
 #, fuzzy, c-format
 msgid "Found a zero width/height box [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr ""
 "Trouvé une boîte avec une largeur/hauteur à zéro [ %c %d %d %d %d %d ]\n"
 
-#: liblepton/src/geda_bus_object.c:345 liblepton/src/geda_bus_object.c:352
 msgid "Failed to parse bus object"
 msgstr "Erreur lors de l'interprétation d'un objet bus"
 
-#: liblepton/src/geda_bus_object.c:358
 #, fuzzy, c-format
 msgid "Found a zero length bus [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr "Trouvé un bus de longueur nulle [ %c %d %d %d %d %d ]\n"
 
-#: liblepton/src/geda_bus_object.c:370
 #, fuzzy, c-format
 msgid "Found an invalid bus ripper direction [ %1$s ]"
 msgstr "Trouvé une couleur invalide [ %s ]\n"
 
-#: liblepton/src/geda_bus_object.c:371
 #, fuzzy
 msgid "Resetting direction to neutral (no direction)."
 msgstr "Initialisation de la direction à neutre (pas de direction)\n"
 
-#: liblepton/src/geda_circle_object.c:343
-#: liblepton/src/geda_circle_object.c:372
 msgid "Failed to parse circle object"
 msgstr "Erreur lors de l'interprétation d'un objet cercle"
 
-#: liblepton/src/geda_circle_object.c:379
 #, fuzzy, c-format
 msgid "Found a zero or negative radius circle [ %1$c %2$d %3$d %4$d %5$d ]"
 msgstr "Trouvé  un cercle de rayon à zéro ou négatif [ %c %d %d %d %d ]\n"
 
-#: liblepton/src/geda_circle_object.c:382
 #, fuzzy
 msgid "Setting radius to 0."
 msgstr "Initialisé l'angle à 0\n"
 
-#: liblepton/src/geda_color.c:217
 msgid "Color map entry must be a two-element list"
 msgstr "L'entrée de la carte de couleurs doit être une liste à deux entrées"
 
-#: liblepton/src/geda_color.c:225
 msgid "Index in color map entry must be an integer"
 msgstr "Le champ dans l'index de la carte couleur doit être un entier"
 
-#: liblepton/src/geda_color.c:251
 msgid "Value in color map entry must be #f or a string"
 msgstr ""
 "La valeur du champ dans la carte couleur doit être #f ou une chaîne de "
 "caractères"
 
-#: liblepton/src/geda_complex_object.c:373
 #, fuzzy, c-format
 msgid ""
 "Component not found:\n"
@@ -414,11 +339,9 @@ msgstr ""
 "Composant non trouvé :\n"
 " %s"
 
-#: liblepton/src/geda_complex_object.c:585
 msgid "Failed to parse complex object"
 msgstr "Erreur lors de l'interprétation d'un objet complexe"
 
-#: liblepton/src/geda_complex_object.c:598
 #, fuzzy, c-format
 msgid ""
 "Found a component with an invalid rotation [ %1$c %2$d %3$d %4$d %5$d %6$d "
@@ -426,13 +349,10 @@ msgid ""
 msgstr ""
 "Trouvé un composant avec une mauvaise rotation [ %c %d %d %d %d %d %s ]\n"
 
-#: liblepton/src/geda_complex_object.c:601
-#: liblepton/src/geda_picture_object.c:105
 #, fuzzy
 msgid "Setting angle to 0."
 msgstr "Initialisé l'angle à 0\n"
 
-#: liblepton/src/geda_complex_object.c:613
 #, fuzzy, c-format
 msgid ""
 "Found a component with an invalid mirror flag [ %1$c %2$d %3$d %4$d %5$d "
@@ -441,12 +361,10 @@ msgstr ""
 "Trouvé un composant avec un marqueur de miroir invalide [ %c %d %d %d %d %d "
 "%s ]\n"
 
-#: liblepton/src/geda_complex_object.c:616
 #, fuzzy
 msgid "Setting mirror to 0."
 msgstr "Initilisation du miroir à 0\n"
 
-#: liblepton/src/geda_complex_object.c:941
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
@@ -455,7 +373,6 @@ msgstr ""
 "ATTENTION: erreur du traitement de la version du Symbole sur refdes %s:\n"
 "\tImpossible de traiter la version du fichier de symbole symversion=%s\n"
 
-#: liblepton/src/geda_complex_object.c:945
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
@@ -464,7 +381,6 @@ msgstr ""
 "ATTENTION: erreur du traitement de la version du Symbole sur refdes %s:\n"
 "\tImpossible de traiter la version du fichier de symbole symversion=%s\n"
 
-#: liblepton/src/geda_complex_object.c:961
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
@@ -473,7 +389,6 @@ msgstr ""
 "ATTENTION: erreur du traitement de la version du Symbole sur refdes %s:\n"
 "\tImpossible de traiter symversion=%s attaché\n"
 
-#: liblepton/src/geda_complex_object.c:986
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version oddity on refdes %1$s:\n"
@@ -483,7 +398,6 @@ msgstr ""
 "ATTENTION: erreur du traitement de la version du Symbole sur refdes %s:\n"
 "\tImpossible de traiter la version du fichier de symbole symversion=%s\n"
 
-#: liblepton/src/geda_complex_object.c:1000
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version mismatch on refdes %1$s (%2$s):\n"
@@ -492,18 +406,15 @@ msgstr ""
 "ATTENTION: erreur du traitement de la version du Symbole sur refdes %s:\n"
 "\tImpossible de traiter symversion=%s attaché\n"
 
-#: liblepton/src/geda_complex_object.c:1028
 #, fuzzy, c-format
 msgid "\tMAJOR VERSION CHANGE (file %1$.3f, instantiated %2$.3f, %3$s)!"
 msgstr ""
 "\tCHANGEMENT MAJEUR DE VERSION (fichier %.3f, instantiation %.3f, %s)!\n"
 
-#: liblepton/src/geda_complex_object.c:1046
 #, fuzzy, c-format
 msgid "\tMinor version change (file %1$.3f, instantiated %2$.3f)"
 msgstr "\tChangement de version mineur (fichier %.3f, instantiation %.3f)\n"
 
-#: liblepton/src/geda_complex_object.c:1057
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version oddity on refdes %1$s:\n"
@@ -512,12 +423,10 @@ msgstr ""
 "ATTENTION: erreur du traitement de la version du Symbole sur refdes %s:\n"
 "\tImpossible de traiter la version du fichier de symbole symversion=%s\n"
 
-#: liblepton/src/o_embed.c:54
 #, fuzzy, c-format
 msgid "Component [%1$s] has been embedded."
 msgstr "Le composant [%s] a été embarqué\n"
 
-#: liblepton/src/o_embed.c:98
 #, fuzzy, c-format
 msgid ""
 "Could not find component [%1$s], while trying to unembed. Component is still "
@@ -526,216 +435,171 @@ msgstr ""
 "Impossible de trouver le composant [%s] lors du détachement. Le composant "
 "est encore embarqué\n"
 
-#: liblepton/src/o_embed.c:106
 #, fuzzy, c-format
 msgid "Component [%1$s] has been successfully unembedded."
 msgstr "Le composant [%s] a été détaché avec succès\n"
 
-#: liblepton/src/geda_line_object.c:391 liblepton/src/geda_line_object.c:409
 msgid "Failed to parse line object"
 msgstr ""
 
-#: liblepton/src/geda_line_object.c:421
 #, fuzzy, c-format
 msgid "Found a zero length line [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr "Trouvé une ligne à longueur nulle [ %c %d %d %d %d %d ]\n"
 
-#: liblepton/src/geda_net_object.c:297
 msgid "Failed to parse net object"
 msgstr ""
 
-#: liblepton/src/geda_net_object.c:302
 #, fuzzy, c-format
 msgid "Found a zero length net [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr "Trouvé un net à longueur nulle [ %c %d %d %d %d %d ]\n"
 
-#: liblepton/src/geda_path_object.c:206
 msgid "Failed to parse path object"
 msgstr ""
 
-#: liblepton/src/geda_path_object.c:232
 msgid "Unexpected end-of-file when reading path"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:71
 msgid "Failed to parse picture definition"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:76
 #, fuzzy, c-format
 msgid "Found a zero width/height picture [ %1$c %2$d %3$d %4$d %5$d ]"
 msgstr "Trouvé une image à largeur/hauteur nulle [ %c %d %d %d %d ]\n"
 
-#: liblepton/src/geda_picture_object.c:82
 #, c-format
 msgid "Found a picture with a wrong 'mirrored' parameter: %1$d."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:84
 #, fuzzy
 msgid "Setting mirrored to 0."
 msgstr "Initilisation du miroir à 0\n"
 
-#: liblepton/src/geda_picture_object.c:89
 #, c-format
 msgid "Found a picture with a wrong 'embedded' parameter: %1$d."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:91
 #, fuzzy
 msgid "Setting embedded to 0."
 msgstr "Positionne l'embarqué à 0\n"
 
-#: liblepton/src/geda_picture_object.c:104
 #, fuzzy, c-format
 msgid "Found an unsupported picture angle [ %1$d ]"
 msgstr "Trouvé un angle d'image non supporté [ %d ]\n"
 
-#: liblepton/src/geda_picture_object.c:116
 msgid "Found an image with no filename."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:147
 #, fuzzy, c-format
 msgid "Failed to load image from embedded data [%1$s]: %2$s"
 msgstr ""
 "Échec du chargement de l'image depuis les données embarquées [%s]: %s\n"
 
-#: liblepton/src/geda_picture_object.c:148
 msgid "Base64 decoding failed."
 msgstr "Échec du décodage Base64."
 
-#: liblepton/src/geda_picture_object.c:149
 #, fuzzy
 msgid "Falling back to file loading. Picture unembedded."
 msgstr "Échec du chargement du fichier. Image enlevée.\n"
 
-#: liblepton/src/geda_picture_object.c:208
 #, fuzzy
 msgid "ERROR: o_picture_save: unable to encode the picture."
 msgstr "ERROR: o_picture_save: impossible d'encoder l'image.\n"
 
-#: liblepton/src/geda_picture_object.c:308
 #, fuzzy, c-format
 msgid "Failed to load buffer image [%1$s]: %2$s"
 msgstr "Échec lors du chargement du symbole depuis le fichier [%s]: %s\n"
 
-#: liblepton/src/geda_picture_object.c:321
 #, fuzzy, c-format
 msgid "Failed to load image from [%1$s]: %2$s"
 msgstr "Échec du chargement de l'image depuis le fichier [%s]: %s\n"
 
-#: liblepton/src/geda_picture_object.c:415
 #, c-format
 msgid "Picture %1$p has invalid angle %2$i\n"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:772
 #, fuzzy, c-format
 msgid "Picture [%1$s] has no image data."
 msgstr "L'image [%s] a été embarquée\n"
 
-#: liblepton/src/geda_picture_object.c:773
 #, fuzzy
 msgid "Falling back to file loading. Picture is still unembedded."
 msgstr "Échec du chargement du fichier. Image enlevée.\n"
 
-#: liblepton/src/geda_picture_object.c:781
 #, fuzzy, c-format
 msgid "Picture [%1$s] has been embedded."
 msgstr "L'image [%s] a été embarquée\n"
 
-#: liblepton/src/geda_picture_object.c:805
 #, fuzzy, c-format
 msgid "Failed to load image from file [%1$s]: %2$s"
 msgstr "Échec du chargement de l'image depuis le fichier [%s]: %s\n"
 
-#: liblepton/src/geda_picture_object.c:807
 #, fuzzy
 msgid "Picture is still embedded."
 msgstr "L'image [%s] a été embarquée\n"
 
-#: liblepton/src/geda_picture_object.c:815
 #, fuzzy, c-format
 msgid "Picture [%1$s] has been unembedded."
 msgstr "L'image [%s] a été débarquée\n"
 
-#: liblepton/src/geda_picture_object.c:1052
 #, fuzzy, c-format
 msgid "Failed to load fallback image %1$s: %2$s.\n"
 msgstr "Échec du chargement de l'image depuis le fichier [%s]: %s\n"
 
-#: liblepton/src/geda_pin_object.c:346 liblepton/src/geda_pin_object.c:354
 msgid "Failed to parse pin object"
 msgstr ""
 
-#: liblepton/src/geda_pin_object.c:360
 msgid ""
 "Found a pin which did not have the whichend field set.\n"
 "Verify and correct manually."
 msgstr ""
 
-#: liblepton/src/geda_pin_object.c:363
 #, c-format
 msgid "Found an invalid whichend on a pin (reseting to zero): %d"
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:495 liblepton/src/geda_text_object.c:505
-#: liblepton/src/geda_text_object.c:515
 msgid "Failed to parse text object"
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:522
 #, fuzzy, c-format
 msgid "Found an invalid text size [ %1$s ]"
 msgstr "Trouvé une couleur invalide [ %s ]\n"
 
-#: liblepton/src/geda_text_object.c:524
 #, fuzzy, c-format
 msgid "Setting text size to %1$d."
 msgstr "Initilisation du miroir à 0\n"
 
-#: liblepton/src/geda_text_object.c:528
 #, fuzzy, c-format
 msgid "Found an unsupported text angle [ %1$s ]"
 msgstr "Trouvé un angle d'image non supporté [ %d ]\n"
 
-#: liblepton/src/geda_text_object.c:530
 #, fuzzy, c-format
 msgid "Setting angle to %1$d."
 msgstr "Initialisé l'angle à 0\n"
 
-#: liblepton/src/geda_text_object.c:547
 #, fuzzy, c-format
 msgid "Found an unsupported text alignment [ %1$s ]"
 msgstr "Trouvé un angle d'image non supporté [ %d ]\n"
 
-#: liblepton/src/geda_text_object.c:550
 #, fuzzy
 msgid "Setting alignment to LOWER_LEFT."
 msgstr "Alignement positionné à LOWER_LEFT\n"
 
-#: liblepton/src/geda_text_object.c:570
 #, fuzzy, c-format
 msgid "Unexpected end-of-file after %1$d lines"
 msgstr "Fin de fichier inattendue dans la liste des attributs"
 
-#: liblepton/src/s_clib.c:460
 #, fuzzy, c-format
 msgid "Library command failed [%1$s]: %2$s"
 msgstr "Échec de la commande de bibliothèque [%s]: %s\n"
 
-#: liblepton/src/s_clib.c:465
 #, fuzzy, c-format
 msgid "Library command failed [%1$s]: Uncaught signal %2$i."
 msgstr "Échec de la commande de bibliothèque [%s]: %s\n"
 
-#: liblepton/src/s_clib.c:469
 #, fuzzy, c-format
 msgid "Library command failed [%1$s]"
 msgstr "Échec de la commande de bibliothèque [%s]\n"
 
-#: liblepton/src/s_clib.c:470
 #, fuzzy, c-format
 msgid ""
 "Error output was:\n"
@@ -744,34 +608,28 @@ msgstr ""
 "L'erreur de sortie était:\n"
 "%s\n"
 
-#: liblepton/src/s_clib.c:556
 #, fuzzy, c-format
 msgid "Library name [%1$s] already in use.  Using [%2$s]."
 msgstr "Le nom de bibliothèque [%s] est déjà utilisé. Utilisation de [%s].\n"
 
-#: liblepton/src/s_clib.c:593
 #, fuzzy, c-format
 msgid "Failed to open directory [%1$s]: %2$s"
 msgstr "Échec de l'ouverture du répertoire [%s]: %s\n"
 
-#: liblepton/src/s_clib.c:729
 #, c-format
 msgid "Failed to scan library [%1$s]: Scheme function returned non-list."
 msgstr ""
 
-#: liblepton/src/s_clib.c:737
 #, fuzzy, c-format
 msgid "Non-string symbol name while scanning library [%1$s]"
 msgstr ""
 "Le nom de symbole n'est pas une chaîne de caractère lors du contrôle de la "
 "bibliothèque [%s]\n"
 
-#: liblepton/src/s_clib.c:893 liblepton/src/s_clib.c:940
 #, fuzzy
 msgid "Cannot add library: name not specified."
 msgstr "Impossible d'ajouter le bibliothèque: pas de nom spécifié\n"
 
-#: liblepton/src/s_clib.c:900
 #, fuzzy, c-format
 msgid ""
 "Cannot add library [%1$s]: both 'list' and 'get' commands must be specified."
@@ -779,271 +637,209 @@ msgstr ""
 "Impossible d'ajouter la bibliothèque [%s]: les commandes 'list' et 'get' "
 "doivent être spécifiées.\n"
 
-#: liblepton/src/s_clib.c:948
 #, fuzzy, c-format
 msgid "Cannot add Scheme-library [%1$s]: callbacks must be closures."
 msgstr ""
 "Impossible d'ajouter la bibliothèque [%s]: les commandes 'list' et 'get' "
 "doivent être spécifiées.\n"
 
-#: liblepton/src/s_clib.c:1075
 #, fuzzy, c-format
 msgid "Failed to load symbol from file [%1$s]: %2$s"
 msgstr "Échec lors du chargement du symbole depuis le fichier [%s]: %s\n"
 
-#: liblepton/src/s_clib.c:1135
 #, fuzzy, c-format
 msgid "Failed to load symbol data [%1$s] from source [%2$s]"
 msgstr ""
 "Impossible de charger les données du symbole [%s] depuis la source [%s]\n"
 
-#: liblepton/src/s_clib.c:1377
 #, fuzzy, c-format
 msgid "Component [%1$s] was not found in the component library."
 msgstr ""
 "Le composant [%s] n'a pas été trouvé dans la bibliothèque des composants\n"
 
-#: liblepton/src/s_clib.c:1383
 #, fuzzy, c-format
 msgid "More than one component found with name [%1$s]."
 msgstr "Trouvé plus d'un composant avec le nom [%s]\n"
 
-#: liblepton/src/s_hierarchy.c:78 liblepton/src/s_hierarchy.c:240
 msgid "Schematic not found in source library."
 msgstr ""
 
-#: liblepton/src/s_hierarchy.c:100
 msgid "Hierarchy contains a circular dependency."
 msgstr ""
 
-#: liblepton/src/s_hierarchy.c:200
 #, fuzzy
 msgid "There are no schematics above the current one!"
 msgstr "Il n'y a pas de schéma au-dessus de celui-ci!\n"
 
-#: liblepton/src/s_hierarchy.c:341
 #, fuzzy, c-format
 msgid "Failed to descend hierarchy into '%1$s': %2$s"
 msgstr "Échec de l'ouverture du répertoire [%s]: %s\n"
 
-#: liblepton/src/s_slot.c:158
 #, fuzzy
 msgid "Did not find slotdef=#:#,#,#... attribute."
 msgstr "Impossible de trouver l'attribut slotdef=#:#,#,#...\n"
 
-#: liblepton/src/s_slot.c:164
 #, fuzzy
 msgid "Improper slotdef syntax: missing \":\"."
 msgstr "Syntaxe slotdef impropre: manque \":\".\n"
 
-#: liblepton/src/s_slot.c:179
 #, fuzzy
 msgid "Did not find proper slotdef=#:#,#,#... attribute."
 msgstr "Impossible de trouver l'attribut slotdef=#:#,#,#... correct\n"
 
-#: liblepton/src/s_slot.c:209
 #, fuzzy
 msgid "component missing pinseq= attribute."
 msgstr "manque l'attribut de composant pinseq=\n"
 
-#: liblepton/src/edaconfig.c:694 liblepton/src/edaconfig.c:780
 msgid "Undefined configuration filename"
 msgstr ""
 
-#: liblepton/src/edaconfig.c:1105 liblepton/src/edaconfig.c:1169
 #, c-format
 msgid "Configuration does not have group '%s'"
 msgstr ""
 
-#: liblepton/src/edaconfig.c:1183
 #, c-format
 msgid "Configuration does not have key '%s'"
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:66 liblepton/src/scheme_attrib.c:100
 msgid "~A is not a valid attribute: invalid string '~A'."
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:204
 msgid "Objects ~A and ~A are not part of the same page and/or complex object"
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:211 liblepton/src/scheme_attrib.c:216
 msgid "Object ~A is already attached as an attribute"
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:265
 msgid "Object ~A is attribute of wrong object"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:148
 msgid "Invalid complex angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:270 liblepton/src/scheme_page.c:246
 msgid "Object ~A is already attached to something"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:332
 msgid "Object ~A is attached to a different complex"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:339
 msgid "Object ~A is attached to a page"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:346 liblepton/src/scheme_page.c:298
 msgid "Object ~A is attached as an attribute"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:353 liblepton/src/scheme_page.c:305
 msgid "Object ~A has attributes"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:234
 msgid "Object ~A has bad type '~A'"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:378
 msgid "Object ~A has invalid stroke cap style ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:391
 msgid "Object ~A has invalid stroke dash style ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:455
 msgid "Invalid stroke cap style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:466
 msgid "Invalid stroke dash style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:476
 msgid "Missing dash length parameter for dash style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:486
 msgid "Missing dot/dash space parameter for dash style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:554
 msgid "Object ~A has invalid fill style ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:603
 msgid "Invalid fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:611
 msgid "Missing second space parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:620
 msgid "Missing second angle parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:630
 msgid "Missing stroke width parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:639
 msgid "Missing space parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:648
 msgid "Missing angle parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:962
 msgid "Invalid pin type ~A, must be 'net or 'bus"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1011
 msgid "Object ~A has invalid pin type."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1417
 msgid "Invalid text alignment ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1433
 msgid "Invalid text angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1452
 msgid "Invalid text name/value visibility ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1526
 msgid "Text object ~A has invalid text alignment ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1535
 msgid "Text object ~A has invalid visibility ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1545
 msgid "Text object ~A has invalid text attribute visibility ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1586
 msgid "Object ~A is not included in a page."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1739
 msgid "Path object ~A has invalid element type ~A at index ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1853
 msgid "Invalid path element type ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:2025
 msgid "Invalid picture angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr ""
 
-#: liblepton/src/scheme_page.c:291
 msgid "Object ~A is attached to a complex or different page"
 msgstr ""
 
-#: liblepton/src/scheme_page.c:438
 msgid "Parse error: ~s"
 msgstr ""
 
-#: liblepton/src/edascmhookproxy.c:83
 msgid "Scheme hook"
 msgstr ""
 
-#: liblepton/src/edascmhookproxy.c:84
 msgid "The Scheme-level hook to proxy"
 msgstr ""
 
-#: liblepton/scheme/geda/attrib.scm:56
 #, scheme-format
 msgid "Object ~A is not part of a page"
 msgstr ""
 
-#: liblepton/scheme/geda/library.scm:108
 #, scheme-format
 msgid "Invalid path ~S or source not readable.\n"
 msgstr ""
 
-#: liblepton/scheme/geda/library.scm:109
 msgid "Source library path must be a string.\n"
 msgstr ""
 
-#: liblepton/scheme/geda/library.scm:168
 #, fuzzy, scheme-format
 msgid "File ~S is not readable.\n"
 msgstr "Le fichier %s est en lecture seule"
 
-#: liblepton/scheme/geda/repl.scm:48
 msgid "Welcome to Lepton REPL!\n"
 msgstr ""
 
-#: liblepton/scheme/geda/repl.scm:53
 msgid "WARNING: Readline library is not supported in your configuration.\n"
 msgstr ""
 

--- a/liblepton/po/hu.po
+++ b/liblepton/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-12 00:08+0300\n"
+"POT-Creation-Date: 2019-05-13 11:16+0300\n"
 "PO-Revision-Date: 2010-02-06 22:11+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -18,46 +18,37 @@ msgstr ""
 "X-Launchpad-Export-Date: 2010-02-14 12:56+0000\n"
 "X-Generator: Launchpad (build Unknown)\n"
 
-#: liblepton/data/liblepton.xml.in:3
 #, fuzzy
 msgid "Lepton EDA circuit schematic"
 msgstr "gEDA kapcsolási rajz"
 
-#: liblepton/data/liblepton.xml.in:4
 #, fuzzy
 msgid "Lepton EDA schematic symbol"
 msgstr "gEDA szimbólum"
 
-#: liblepton/data/liblepton.xml.in:5
 #, fuzzy
 msgid "Lepton EDA sch2pcb project"
 msgstr "gEDA gsch2pcb projekt"
 
-#: liblepton/data/x-lepton-sch2pcb-project.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA sch2pcb Project"
 msgstr "gEDA gsch2pcb projekt"
 
-#: liblepton/data/x-lepton-schematic.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Circuit Schematic"
 msgstr "gEDA kapcsolási rajz"
 
-#: liblepton/data/x-lepton-symbol.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Schematic Symbol"
 msgstr "gEDA szimbólum"
 
-#: liblepton/src/a_basic.c:57 liblepton/src/f_basic.c:377
 #, fuzzy, c-format
 msgid "File %1$s is read-only"
 msgstr "Csak olvasható file %s"
 
-#: liblepton/src/a_basic.c:114
 msgid "Schematic data was not valid UTF-8"
 msgstr ""
 
-#: liblepton/src/a_basic.c:246
 #, fuzzy, c-format
 msgid ""
 "Read unexpected attach symbol start marker in [%1$s] :\n"
@@ -68,7 +59,6 @@ msgstr ""
 "<<\n"
 "%s<<\n"
 
-#: liblepton/src/a_basic.c:263
 #, fuzzy, c-format
 msgid ""
 "Read unexpected embedded symbol start marker in [%1$s] :\n"
@@ -79,7 +69,6 @@ msgstr ""
 "<<\n"
 "%s<<\n"
 
-#: liblepton/src/a_basic.c:294
 #, c-format
 msgid ""
 "Read unexpected embedded symbol end marker in [%s] :\n"
@@ -87,7 +76,6 @@ msgid ""
 "%s<<\n"
 msgstr ""
 
-#: liblepton/src/a_basic.c:329
 #, fuzzy, c-format
 msgid ""
 "Read an old format sym/sch file!\n"
@@ -98,7 +86,6 @@ msgstr ""
 "Kérlek frissítsd a [%s] fájlt a\n"
 "g[sym|sch]update program segítségével!\n"
 
-#: liblepton/src/a_basic.c:335
 #, fuzzy, c-format
 msgid ""
 "Read garbage in [%1$s] :\n"
@@ -109,17 +96,14 @@ msgstr ""
 "<<\n"
 "%s<<\n"
 
-#: liblepton/src/f_basic.c:119 liblepton/src/f_basic.c:132
 #, fuzzy, c-format
 msgid "Failed to stat [%1$s]: %2$s"
 msgstr "Nem látom [%s]: %s"
 
-#: liblepton/src/f_basic.c:211
 #, fuzzy, c-format
 msgid "Cannot find file %1$s: %2$s"
 msgstr "Nem találom a file-t %s: %s"
 
-#: liblepton/src/f_basic.c:260
 #, c-format
 msgid ""
 "\n"
@@ -128,305 +112,236 @@ msgid ""
 "\n"
 msgstr ""
 
-#: liblepton/src/f_basic.c:262
 msgid "I could not guess if it is newer, so you have to do it manually.\n"
 msgstr "Nem tudtam eldönteni, hogy ez újabb, ezért neked kell megcsinálnod \n"
 
-#: liblepton/src/f_basic.c:264
 msgid ""
 "The backup copy is newer than the schematic, so it seems you should load it "
 "instead of the original file.\n"
 msgstr ""
 
-#: liblepton/src/f_basic.c:266
 msgid ""
 "lepton-schematic usually makes backup copies automatically, and this "
 "situation happens when it crashed or it was forced to exit abruptly.\n"
 msgstr ""
 
-#: liblepton/src/f_basic.c:269
 msgid ""
 "\n"
 "Run lepton-schematic and correct the situation.\n"
 "\n"
 msgstr ""
 
-#: liblepton/src/f_basic.c:367
 #, c-format
 msgid "Can't get the real filename of %1$s: %2$s"
 msgstr ""
 
-#: liblepton/src/f_basic.c:398
 #, c-format
 msgid "Could NOT set previous backup file [%1$s] read-write."
 msgstr ""
 
-#: liblepton/src/f_basic.c:404
 #, c-format
 msgid "Can't save backup file: %1$s."
 msgstr ""
 
-#: liblepton/src/f_basic.c:414
 #, fuzzy, c-format
 msgid "Could NOT set backup file [%1$s] readonly."
 msgstr "Nem tudtam elmenteni a file-t: %s"
 
-#: liblepton/src/f_basic.c:463
 #, fuzzy, c-format
 msgid "Failed to restore permissions on '%1$s': %2$s\n"
 msgstr "Nem látom [%s]: %s"
 
-#: liblepton/src/f_basic.c:468
 #, fuzzy, c-format
 msgid "Failed to restore ownership on '%1$s': %2$s\n"
 msgstr "Nem látom [%s]: %s"
 
-#: liblepton/src/f_basic.c:478
 #, fuzzy, c-format
 msgid "Could NOT save file: %1$s"
 msgstr "Nem tudtam elmenteni a file-t: %s"
 
-#: liblepton/src/f_basic.c:604
 #, c-format
 msgid "%s: %s"
 msgstr "%s: %s"
 
-#: liblepton/src/g_basic.c:260
 msgid ""
 "\n"
 "Backtrace:\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:99
 #, c-format
 msgid "Invalid mode [%1$s] passed to %2$s\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:139
 msgid "RC file already loaded"
 msgstr ""
 
-#: liblepton/src/g_rc.c:183
 #, fuzzy, c-format
 msgid "Failed to load config from '%1$s': %2$s\n"
 msgstr "Nem látom [%s]: %s"
 
-#: liblepton/src/g_rc.c:207
 #, fuzzy, c-format
 msgid "Loaded RC file [%1$s]"
 msgstr "Nem látom [%s]: %s"
 
-#: liblepton/src/g_rc.c:211
 #, fuzzy, c-format
 msgid "Failed to load RC file [%1$s]: "
 msgstr "Nem látom [%s]: %s"
 
-#: liblepton/src/g_rc.c:341
 msgid "ERROR: An unknown error occurred while parsing configuration files."
 msgstr ""
 
-#: liblepton/src/g_rc.c:353
 #, fuzzy, c-format
 msgid "ERROR: %1$s"
 msgstr "HIBA: %s\n"
 
-#: liblepton/src/g_rc.c:354
 #, fuzzy, c-format
 msgid "ERROR: %1$s\n"
 msgstr "HIBA: %s\n"
 
-#: liblepton/src/g_rc.c:360
 #, c-format
 msgid "ERROR: The %1$s log may contain more information.\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:512
 #, c-format
 msgid "Invalid path [%1$s] passed to component-library\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:738
 #, c-format
 msgid "Invalid path [%1$s] passed to bitmap-directory\n"
 msgstr ""
 
-#: liblepton/src/geda_page.c:197
 #, c-format
 msgid "s_page_delete: Can't get the real filename of %1$s."
 msgstr ""
 
-#: liblepton/src/geda_page.c:208
 #, c-format
 msgid "s_page_delete: Unable to delete backup file %1$s."
 msgstr ""
 
-#: liblepton/src/geda_page.c:490
 #, c-format
 msgid "Saved [%1$s]"
 msgstr ""
 
-#: liblepton/src/geda_page.c:496
 #, fuzzy, c-format
 msgid "Could NOT save [%1$s]"
 msgstr "Nem tudtam elmenteni a file-t: %s"
 
-#: liblepton/src/geda_arc_object.c:408 liblepton/src/geda_arc_object.c:421
 msgid "Failed to parse arc object"
 msgstr ""
 
-#: liblepton/src/geda_arc_object.c:428
 #, c-format
 msgid "Found a zero radius arc [ %1$c %2$d, %3$d, %4$d, %5$d, %6$d, %7$d ]"
 msgstr ""
 
-#: liblepton/src/geda_arc_object.c:435 liblepton/src/geda_box_object.c:328
-#: liblepton/src/geda_bus_object.c:364 liblepton/src/geda_circle_object.c:387
-#: liblepton/src/geda_line_object.c:427 liblepton/src/geda_net_object.c:308
-#: liblepton/src/geda_path_object.c:214 liblepton/src/geda_pin_object.c:369
-#: liblepton/src/geda_text_object.c:555
 #, c-format
 msgid "Found an invalid color [ %1$s ]"
 msgstr ""
 
-#: liblepton/src/geda_arc_object.c:436 liblepton/src/geda_box_object.c:329
-#: liblepton/src/geda_bus_object.c:365 liblepton/src/geda_circle_object.c:388
-#: liblepton/src/geda_line_object.c:428 liblepton/src/geda_net_object.c:309
-#: liblepton/src/geda_path_object.c:215 liblepton/src/geda_pin_object.c:370
-#: liblepton/src/geda_text_object.c:557
 msgid "Setting color to default color."
 msgstr ""
 
-#: liblepton/src/o_attrib.c:111
 #, c-format
 msgid "Attribute [%1$s] already attached\n"
 msgstr ""
 
-#: liblepton/src/o_attrib.c:117
 msgid "Attempt to attach non text item as an attribute!\n"
 msgstr ""
 
-#: liblepton/src/o_attrib.c:122
 #, c-format
 msgid "Attempt to attach attribute [%1$s] to more than one object\n"
 msgstr ""
 
-#: liblepton/src/o_attrib.c:325
 msgid "Tried to attach a non-text item as an attribute"
 msgstr ""
 
-#: liblepton/src/o_attrib.c:332
 msgid "Unexpected end-of-file in attribute list"
 msgstr ""
 
-#: liblepton/src/geda_box_object.c:287 liblepton/src/geda_box_object.c:316
 msgid "Failed to parse box object"
 msgstr ""
 
-#: liblepton/src/geda_box_object.c:322
 #, c-format
 msgid "Found a zero width/height box [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr ""
 
-#: liblepton/src/geda_bus_object.c:345 liblepton/src/geda_bus_object.c:352
 msgid "Failed to parse bus object"
 msgstr ""
 
-#: liblepton/src/geda_bus_object.c:358
 #, c-format
 msgid "Found a zero length bus [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr ""
 
-#: liblepton/src/geda_bus_object.c:370
 #, c-format
 msgid "Found an invalid bus ripper direction [ %1$s ]"
 msgstr ""
 
-#: liblepton/src/geda_bus_object.c:371
 msgid "Resetting direction to neutral (no direction)."
 msgstr ""
 
-#: liblepton/src/geda_circle_object.c:343
-#: liblepton/src/geda_circle_object.c:372
 msgid "Failed to parse circle object"
 msgstr ""
 
-#: liblepton/src/geda_circle_object.c:379
 #, c-format
 msgid "Found a zero or negative radius circle [ %1$c %2$d %3$d %4$d %5$d ]"
 msgstr ""
 
-#: liblepton/src/geda_circle_object.c:382
 msgid "Setting radius to 0."
 msgstr ""
 
-#: liblepton/src/geda_color.c:217
 msgid "Color map entry must be a two-element list"
 msgstr ""
 
-#: liblepton/src/geda_color.c:225
 msgid "Index in color map entry must be an integer"
 msgstr ""
 
-#: liblepton/src/geda_color.c:251
 msgid "Value in color map entry must be #f or a string"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:373
 #, c-format
 msgid ""
 "Component not found:\n"
 " %1$s"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:585
 msgid "Failed to parse complex object"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:598
 #, c-format
 msgid ""
 "Found a component with an invalid rotation [ %1$c %2$d %3$d %4$d %5$d %6$d "
 "%7$s ]"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:601
-#: liblepton/src/geda_picture_object.c:105
 msgid "Setting angle to 0."
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:613
 #, c-format
 msgid ""
 "Found a component with an invalid mirror flag [ %1$c %2$d %3$d %4$d %5$d "
 "%6$d %7$s ]"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:616
 msgid "Setting mirror to 0."
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:941
 #, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
 "\tCould not parse symbol file symversion=%2$s"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:945
 #, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
 "\tCould not parse symbol file symversion="
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:961
 #, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
 "\tCould not parse attached symversion=%2$s"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:986
 #, c-format
 msgid ""
 "WARNING: Symbol version oddity on refdes %1$s:\n"
@@ -434,536 +349,417 @@ msgid ""
 "symbol file."
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:1000
 #, c-format
 msgid ""
 "WARNING: Symbol version mismatch on refdes %1$s (%2$s):\n"
 "\tSymbol in library is newer than instantiated symbol."
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:1028
 #, c-format
 msgid "\tMAJOR VERSION CHANGE (file %1$.3f, instantiated %2$.3f, %3$s)!"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:1046
 #, c-format
 msgid "\tMinor version change (file %1$.3f, instantiated %2$.3f)"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:1057
 #, c-format
 msgid ""
 "WARNING: Symbol version oddity on refdes %1$s:\n"
 "\tInstantiated symbol is newer than symbol in library."
 msgstr ""
 
-#: liblepton/src/o_embed.c:54
 #, c-format
 msgid "Component [%1$s] has been embedded."
 msgstr ""
 
-#: liblepton/src/o_embed.c:98
 #, c-format
 msgid ""
 "Could not find component [%1$s], while trying to unembed. Component is still "
 "embedded."
 msgstr ""
 
-#: liblepton/src/o_embed.c:106
 #, c-format
 msgid "Component [%1$s] has been successfully unembedded."
 msgstr ""
 
-#: liblepton/src/geda_line_object.c:391 liblepton/src/geda_line_object.c:409
 msgid "Failed to parse line object"
 msgstr ""
 
-#: liblepton/src/geda_line_object.c:421
 #, c-format
 msgid "Found a zero length line [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr ""
 
-#: liblepton/src/geda_net_object.c:297
 msgid "Failed to parse net object"
 msgstr ""
 
-#: liblepton/src/geda_net_object.c:302
 #, c-format
 msgid "Found a zero length net [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr ""
 
-#: liblepton/src/geda_path_object.c:206
 msgid "Failed to parse path object"
 msgstr ""
 
-#: liblepton/src/geda_path_object.c:232
 msgid "Unexpected end-of-file when reading path"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:71
 msgid "Failed to parse picture definition"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:76
 #, c-format
 msgid "Found a zero width/height picture [ %1$c %2$d %3$d %4$d %5$d ]"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:82
 #, c-format
 msgid "Found a picture with a wrong 'mirrored' parameter: %1$d."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:84
 msgid "Setting mirrored to 0."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:89
 #, c-format
 msgid "Found a picture with a wrong 'embedded' parameter: %1$d."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:91
 msgid "Setting embedded to 0."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:104
 #, c-format
 msgid "Found an unsupported picture angle [ %1$d ]"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:116
 msgid "Found an image with no filename."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:147
 #, fuzzy, c-format
 msgid "Failed to load image from embedded data [%1$s]: %2$s"
 msgstr "Nem látom [%s]: %s"
 
-#: liblepton/src/geda_picture_object.c:148
 msgid "Base64 decoding failed."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:149
 msgid "Falling back to file loading. Picture unembedded."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:208
 msgid "ERROR: o_picture_save: unable to encode the picture."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:308
 #, fuzzy, c-format
 msgid "Failed to load buffer image [%1$s]: %2$s"
 msgstr "Nem látom [%s]: %s"
 
-#: liblepton/src/geda_picture_object.c:321
 #, fuzzy, c-format
 msgid "Failed to load image from [%1$s]: %2$s"
 msgstr "Nem látom [%s]: %s"
 
-#: liblepton/src/geda_picture_object.c:415
 #, c-format
 msgid "Picture %1$p has invalid angle %2$i\n"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:772
 #, c-format
 msgid "Picture [%1$s] has no image data."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:773
 msgid "Falling back to file loading. Picture is still unembedded."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:781
 #, c-format
 msgid "Picture [%1$s] has been embedded."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:805
 #, fuzzy, c-format
 msgid "Failed to load image from file [%1$s]: %2$s"
 msgstr "Nem látom [%s]: %s"
 
-#: liblepton/src/geda_picture_object.c:807
 msgid "Picture is still embedded."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:815
 #, c-format
 msgid "Picture [%1$s] has been unembedded."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:1052
 #, fuzzy, c-format
 msgid "Failed to load fallback image %1$s: %2$s.\n"
 msgstr "Nem látom [%s]: %s"
 
-#: liblepton/src/geda_pin_object.c:346 liblepton/src/geda_pin_object.c:354
 msgid "Failed to parse pin object"
 msgstr ""
 
-#: liblepton/src/geda_pin_object.c:360
 msgid ""
 "Found a pin which did not have the whichend field set.\n"
 "Verify and correct manually."
 msgstr ""
 
-#: liblepton/src/geda_pin_object.c:363
 #, c-format
 msgid "Found an invalid whichend on a pin (reseting to zero): %d"
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:495 liblepton/src/geda_text_object.c:505
-#: liblepton/src/geda_text_object.c:515
 msgid "Failed to parse text object"
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:522
 #, c-format
 msgid "Found an invalid text size [ %1$s ]"
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:524
 #, c-format
 msgid "Setting text size to %1$d."
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:528
 #, c-format
 msgid "Found an unsupported text angle [ %1$s ]"
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:530
 #, c-format
 msgid "Setting angle to %1$d."
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:547
 #, c-format
 msgid "Found an unsupported text alignment [ %1$s ]"
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:550
 msgid "Setting alignment to LOWER_LEFT."
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:570
 #, c-format
 msgid "Unexpected end-of-file after %1$d lines"
 msgstr ""
 
-#: liblepton/src/s_clib.c:460
 #, c-format
 msgid "Library command failed [%1$s]: %2$s"
 msgstr ""
 
-#: liblepton/src/s_clib.c:465
 #, c-format
 msgid "Library command failed [%1$s]: Uncaught signal %2$i."
 msgstr ""
 
-#: liblepton/src/s_clib.c:469
 #, c-format
 msgid "Library command failed [%1$s]"
 msgstr ""
 
-#: liblepton/src/s_clib.c:470
 #, c-format
 msgid ""
 "Error output was:\n"
 "%1$s"
 msgstr ""
 
-#: liblepton/src/s_clib.c:556
 #, c-format
 msgid "Library name [%1$s] already in use.  Using [%2$s]."
 msgstr ""
 
-#: liblepton/src/s_clib.c:593
 #, fuzzy, c-format
 msgid "Failed to open directory [%1$s]: %2$s"
 msgstr "Nem látom [%s]: %s"
 
-#: liblepton/src/s_clib.c:729
 #, c-format
 msgid "Failed to scan library [%1$s]: Scheme function returned non-list."
 msgstr ""
 
-#: liblepton/src/s_clib.c:737
 #, c-format
 msgid "Non-string symbol name while scanning library [%1$s]"
 msgstr ""
 
-#: liblepton/src/s_clib.c:893 liblepton/src/s_clib.c:940
 msgid "Cannot add library: name not specified."
 msgstr ""
 
-#: liblepton/src/s_clib.c:900
 #, c-format
 msgid ""
 "Cannot add library [%1$s]: both 'list' and 'get' commands must be specified."
 msgstr ""
 
-#: liblepton/src/s_clib.c:948
 #, c-format
 msgid "Cannot add Scheme-library [%1$s]: callbacks must be closures."
 msgstr ""
 
-#: liblepton/src/s_clib.c:1075
 #, fuzzy, c-format
 msgid "Failed to load symbol from file [%1$s]: %2$s"
 msgstr "Nem látom [%s]: %s"
 
-#: liblepton/src/s_clib.c:1135
 #, c-format
 msgid "Failed to load symbol data [%1$s] from source [%2$s]"
 msgstr ""
 
-#: liblepton/src/s_clib.c:1377
 #, c-format
 msgid "Component [%1$s] was not found in the component library."
 msgstr ""
 
-#: liblepton/src/s_clib.c:1383
 #, c-format
 msgid "More than one component found with name [%1$s]."
 msgstr ""
 
-#: liblepton/src/s_hierarchy.c:78 liblepton/src/s_hierarchy.c:240
 msgid "Schematic not found in source library."
 msgstr ""
 
-#: liblepton/src/s_hierarchy.c:100
 msgid "Hierarchy contains a circular dependency."
 msgstr ""
 
-#: liblepton/src/s_hierarchy.c:200
 msgid "There are no schematics above the current one!"
 msgstr ""
 
-#: liblepton/src/s_hierarchy.c:341
 #, fuzzy, c-format
 msgid "Failed to descend hierarchy into '%1$s': %2$s"
 msgstr "Nem látom [%s]: %s"
 
-#: liblepton/src/s_slot.c:158
 msgid "Did not find slotdef=#:#,#,#... attribute."
 msgstr ""
 
-#: liblepton/src/s_slot.c:164
 msgid "Improper slotdef syntax: missing \":\"."
 msgstr ""
 
-#: liblepton/src/s_slot.c:179
 msgid "Did not find proper slotdef=#:#,#,#... attribute."
 msgstr ""
 
-#: liblepton/src/s_slot.c:209
 msgid "component missing pinseq= attribute."
 msgstr ""
 
-#: liblepton/src/edaconfig.c:694 liblepton/src/edaconfig.c:780
 msgid "Undefined configuration filename"
 msgstr ""
 
-#: liblepton/src/edaconfig.c:1105 liblepton/src/edaconfig.c:1169
 #, c-format
 msgid "Configuration does not have group '%s'"
 msgstr ""
 
-#: liblepton/src/edaconfig.c:1183
 #, c-format
 msgid "Configuration does not have key '%s'"
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:66 liblepton/src/scheme_attrib.c:100
 msgid "~A is not a valid attribute: invalid string '~A'."
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:204
 msgid "Objects ~A and ~A are not part of the same page and/or complex object"
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:211 liblepton/src/scheme_attrib.c:216
 msgid "Object ~A is already attached as an attribute"
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:265
 msgid "Object ~A is attribute of wrong object"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:148
 msgid "Invalid complex angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:270 liblepton/src/scheme_page.c:246
 msgid "Object ~A is already attached to something"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:332
 msgid "Object ~A is attached to a different complex"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:339
 msgid "Object ~A is attached to a page"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:346 liblepton/src/scheme_page.c:298
 msgid "Object ~A is attached as an attribute"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:353 liblepton/src/scheme_page.c:305
 msgid "Object ~A has attributes"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:234
 msgid "Object ~A has bad type '~A'"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:378
 msgid "Object ~A has invalid stroke cap style ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:391
 msgid "Object ~A has invalid stroke dash style ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:455
 msgid "Invalid stroke cap style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:466
 msgid "Invalid stroke dash style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:476
 msgid "Missing dash length parameter for dash style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:486
 msgid "Missing dot/dash space parameter for dash style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:554
 msgid "Object ~A has invalid fill style ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:603
 msgid "Invalid fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:611
 msgid "Missing second space parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:620
 msgid "Missing second angle parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:630
 msgid "Missing stroke width parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:639
 msgid "Missing space parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:648
 msgid "Missing angle parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:962
 msgid "Invalid pin type ~A, must be 'net or 'bus"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1011
 msgid "Object ~A has invalid pin type."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1417
 msgid "Invalid text alignment ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1433
 msgid "Invalid text angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1452
 msgid "Invalid text name/value visibility ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1526
 msgid "Text object ~A has invalid text alignment ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1535
 msgid "Text object ~A has invalid visibility ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1545
 msgid "Text object ~A has invalid text attribute visibility ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1586
 msgid "Object ~A is not included in a page."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1739
 msgid "Path object ~A has invalid element type ~A at index ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1853
 msgid "Invalid path element type ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:2025
 msgid "Invalid picture angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr ""
 
-#: liblepton/src/scheme_page.c:291
 msgid "Object ~A is attached to a complex or different page"
 msgstr ""
 
-#: liblepton/src/scheme_page.c:438
 msgid "Parse error: ~s"
 msgstr ""
 
-#: liblepton/src/edascmhookproxy.c:83
 msgid "Scheme hook"
 msgstr ""
 
-#: liblepton/src/edascmhookproxy.c:84
 msgid "The Scheme-level hook to proxy"
 msgstr ""
 
-#: liblepton/scheme/geda/attrib.scm:56
 #, scheme-format
 msgid "Object ~A is not part of a page"
 msgstr ""
 
-#: liblepton/scheme/geda/library.scm:108
 #, scheme-format
 msgid "Invalid path ~S or source not readable.\n"
 msgstr ""
 
-#: liblepton/scheme/geda/library.scm:109
 msgid "Source library path must be a string.\n"
 msgstr ""
 
-#: liblepton/scheme/geda/library.scm:168
 #, fuzzy, scheme-format
 msgid "File ~S is not readable.\n"
 msgstr "Csak olvasható file %s"
 
-#: liblepton/scheme/geda/repl.scm:48
 msgid "Welcome to Lepton REPL!\n"
 msgstr ""
 
-#: liblepton/scheme/geda/repl.scm:53
 msgid "WARNING: Readline library is not supported in your configuration.\n"
 msgstr ""
 

--- a/liblepton/po/it.po
+++ b/liblepton/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-12 00:08+0300\n"
+"POT-Creation-Date: 2019-05-13 11:16+0300\n"
 "PO-Revision-Date: 2012-03-16 10:58+0000\n"
 "Last-Translator: simone.sandri <lexluxsox@hotmail.it>\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -18,46 +18,37 @@ msgstr ""
 "X-Launchpad-Export-Date: 2012-11-14 16:52+0000\n"
 "X-Generator: Launchpad (build 16265)\n"
 
-#: liblepton/data/liblepton.xml.in:3
 #, fuzzy
 msgid "Lepton EDA circuit schematic"
 msgstr "gEDA schema circuitale"
 
-#: liblepton/data/liblepton.xml.in:4
 #, fuzzy
 msgid "Lepton EDA schematic symbol"
 msgstr "gEDA simbolo di circuito"
 
-#: liblepton/data/liblepton.xml.in:5
 #, fuzzy
 msgid "Lepton EDA sch2pcb project"
 msgstr "gEDA progetto gsch2pcb"
 
-#: liblepton/data/x-lepton-sch2pcb-project.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA sch2pcb Project"
 msgstr "gEDA Progetto Gsch2pcb"
 
-#: liblepton/data/x-lepton-schematic.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Circuit Schematic"
 msgstr "gEDA Schema Circuitale"
 
-#: liblepton/data/x-lepton-symbol.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Schematic Symbol"
 msgstr "gEDA Simbolo di Circuito"
 
-#: liblepton/src/a_basic.c:57 liblepton/src/f_basic.c:377
 #, fuzzy, c-format
 msgid "File %1$s is read-only"
 msgstr "Il file %s è di sola lettura"
 
-#: liblepton/src/a_basic.c:114
 msgid "Schematic data was not valid UTF-8"
 msgstr ""
 
-#: liblepton/src/a_basic.c:246
 #, c-format
 msgid ""
 "Read unexpected attach symbol start marker in [%1$s] :\n"
@@ -65,7 +56,6 @@ msgid ""
 "%2$s<<\n"
 msgstr ""
 
-#: liblepton/src/a_basic.c:263
 #, c-format
 msgid ""
 "Read unexpected embedded symbol start marker in [%1$s] :\n"
@@ -73,7 +63,6 @@ msgid ""
 "%2$s<<\n"
 msgstr ""
 
-#: liblepton/src/a_basic.c:294
 #, c-format
 msgid ""
 "Read unexpected embedded symbol end marker in [%s] :\n"
@@ -81,7 +70,6 @@ msgid ""
 "%s<<\n"
 msgstr ""
 
-#: liblepton/src/a_basic.c:329
 #, fuzzy, c-format
 msgid ""
 "Read an old format sym/sch file!\n"
@@ -92,7 +80,6 @@ msgstr ""
 "Esegui g[sym|sch]update su:\n"
 "[%s]\n"
 
-#: liblepton/src/a_basic.c:335
 #, fuzzy, c-format
 msgid ""
 "Read garbage in [%1$s] :\n"
@@ -103,17 +90,14 @@ msgstr ""
 ">>\n"
 "%s<<\n"
 
-#: liblepton/src/f_basic.c:119 liblepton/src/f_basic.c:132
 #, fuzzy, c-format
 msgid "Failed to stat [%1$s]: %2$s"
 msgstr "Impossibile fare lo stat di [%s]: %s"
 
-#: liblepton/src/f_basic.c:211
 #, fuzzy, c-format
 msgid "Cannot find file %1$s: %2$s"
 msgstr "Impossibile trovare il file %s: %s"
 
-#: liblepton/src/f_basic.c:260
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -126,11 +110,9 @@ msgstr ""
 "  %s.\n"
 "\n"
 
-#: liblepton/src/f_basic.c:262
 msgid "I could not guess if it is newer, so you have to do it manually.\n"
 msgstr "Impossibile stabilire se è nuovo, quindi devi farlo manualmente.\n"
 
-#: liblepton/src/f_basic.c:264
 msgid ""
 "The backup copy is newer than the schematic, so it seems you should load it "
 "instead of the original file.\n"
@@ -138,7 +120,6 @@ msgstr ""
 "La copia di backup è più recente dello schema, quindi dovrebbe essere "
 "utilizzata al posto del file originale.\n"
 
-#: liblepton/src/f_basic.c:266
 #, fuzzy
 msgid ""
 "lepton-schematic usually makes backup copies automatically, and this "
@@ -148,7 +129,6 @@ msgstr ""
 "situazione capita in caso di suoi errori gravi o quando viene interrotto "
 "forzatamente.\n"
 
-#: liblepton/src/f_basic.c:269
 #, fuzzy
 msgid ""
 "\n"
@@ -159,233 +139,178 @@ msgstr ""
 "Esegui gschem e correggi la situazione.\n"
 "\n"
 
-#: liblepton/src/f_basic.c:367
 #, c-format
 msgid "Can't get the real filename of %1$s: %2$s"
 msgstr ""
 
-#: liblepton/src/f_basic.c:398
 #, fuzzy, c-format
 msgid "Could NOT set previous backup file [%1$s] read-write."
 msgstr ""
 "Non è possibile impostare il precedente file di ripristino [%s] in lettura-"
 "scrittura\n"
 
-#: liblepton/src/f_basic.c:404
 #, fuzzy, c-format
 msgid "Can't save backup file: %1$s."
 msgstr "Impossibile salvare il file di backup: %s."
 
-#: liblepton/src/f_basic.c:414
 #, fuzzy, c-format
 msgid "Could NOT set backup file [%1$s] readonly."
 msgstr "Impossibile impostare il file di backup [%s] in sola lettura.\n"
 
-#: liblepton/src/f_basic.c:463
 #, fuzzy, c-format
 msgid "Failed to restore permissions on '%1$s': %2$s\n"
 msgstr "Impossibile aprire la directory [%s]: %s\n"
 
-#: liblepton/src/f_basic.c:468
 #, fuzzy, c-format
 msgid "Failed to restore ownership on '%1$s': %2$s\n"
 msgstr "Impossibile aprire la directory [%s]: %s\n"
 
-#: liblepton/src/f_basic.c:478
 #, fuzzy, c-format
 msgid "Could NOT save file: %1$s"
 msgstr "Impossibile impostare il file di backup [%s] in sola lettura.\n"
 
-#: liblepton/src/f_basic.c:604
 #, c-format
 msgid "%s: %s"
 msgstr "%s: %s"
 
-#: liblepton/src/g_basic.c:260
 msgid ""
 "\n"
 "Backtrace:\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:99
 #, fuzzy, c-format
 msgid "Invalid mode [%1$s] passed to %2$s\n"
 msgstr "Impossibile trovare il componente [%s] nella libreria componenti\n"
 
-#: liblepton/src/g_rc.c:139
 msgid "RC file already loaded"
 msgstr ""
 
-#: liblepton/src/g_rc.c:183
 #, fuzzy, c-format
 msgid "Failed to load config from '%1$s': %2$s\n"
 msgstr "Impossibile caricare l'immagine dal file [%s]: %s\n"
 
-#: liblepton/src/g_rc.c:207
 #, fuzzy, c-format
 msgid "Loaded RC file [%1$s]"
 msgstr "Impossibile caricare l'immagine dal file [%s]: %s\n"
 
-#: liblepton/src/g_rc.c:211
 #, fuzzy, c-format
 msgid "Failed to load RC file [%1$s]: "
 msgstr "Impossibile caricare l'immagine dal file [%s]: %s\n"
 
-#: liblepton/src/g_rc.c:341
 msgid "ERROR: An unknown error occurred while parsing configuration files."
 msgstr ""
 
-#: liblepton/src/g_rc.c:353
 #, c-format
 msgid "ERROR: %1$s"
 msgstr ""
 
-#: liblepton/src/g_rc.c:354
 #, c-format
 msgid "ERROR: %1$s\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:360
 #, c-format
 msgid "ERROR: The %1$s log may contain more information.\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:512
 #, fuzzy, c-format
 msgid "Invalid path [%1$s] passed to component-library\n"
 msgstr "Impossibile trovare il componente [%s] nella libreria componenti\n"
 
-#: liblepton/src/g_rc.c:738
 #, fuzzy, c-format
 msgid "Invalid path [%1$s] passed to bitmap-directory\n"
 msgstr "Impossibile trovare il componente [%s] nella libreria componenti\n"
 
-#: liblepton/src/geda_page.c:197
 #, c-format
 msgid "s_page_delete: Can't get the real filename of %1$s."
 msgstr ""
 
-#: liblepton/src/geda_page.c:208
 #, c-format
 msgid "s_page_delete: Unable to delete backup file %1$s."
 msgstr ""
 
-#: liblepton/src/geda_page.c:490
 #, c-format
 msgid "Saved [%1$s]"
 msgstr ""
 
-#: liblepton/src/geda_page.c:496
 #, c-format
 msgid "Could NOT save [%1$s]"
 msgstr ""
 
-#: liblepton/src/geda_arc_object.c:408 liblepton/src/geda_arc_object.c:421
 msgid "Failed to parse arc object"
 msgstr ""
 
-#: liblepton/src/geda_arc_object.c:428
 #, fuzzy, c-format
 msgid "Found a zero radius arc [ %1$c %2$d, %3$d, %4$d, %5$d, %6$d, %7$d ]"
 msgstr "Ho trovato un arco con raggio zero [ %c %d, %d, %d, %d, %d, %d ]\n"
 
-#: liblepton/src/geda_arc_object.c:435 liblepton/src/geda_box_object.c:328
-#: liblepton/src/geda_bus_object.c:364 liblepton/src/geda_circle_object.c:387
-#: liblepton/src/geda_line_object.c:427 liblepton/src/geda_net_object.c:308
-#: liblepton/src/geda_path_object.c:214 liblepton/src/geda_pin_object.c:369
-#: liblepton/src/geda_text_object.c:555
 #, fuzzy, c-format
 msgid "Found an invalid color [ %1$s ]"
 msgstr "Trovato un colore non valido [%s]\n"
 
-#: liblepton/src/geda_arc_object.c:436 liblepton/src/geda_box_object.c:329
-#: liblepton/src/geda_bus_object.c:365 liblepton/src/geda_circle_object.c:388
-#: liblepton/src/geda_line_object.c:428 liblepton/src/geda_net_object.c:309
-#: liblepton/src/geda_path_object.c:215 liblepton/src/geda_pin_object.c:370
-#: liblepton/src/geda_text_object.c:557
 #, fuzzy
 msgid "Setting color to default color."
 msgstr "Imposto il colore al colore predefinito\n"
 
-#: liblepton/src/o_attrib.c:111
 #, c-format
 msgid "Attribute [%1$s] already attached\n"
 msgstr ""
 
-#: liblepton/src/o_attrib.c:117
 msgid "Attempt to attach non text item as an attribute!\n"
 msgstr "Tentativo di allegare un elemento non testuale come attributo!\n"
 
-#: liblepton/src/o_attrib.c:122
 #, fuzzy, c-format
 msgid "Attempt to attach attribute [%1$s] to more than one object\n"
 msgstr "Tentativo di allegare l'attributo [%s] a più di un oggetto\n"
 
-#: liblepton/src/o_attrib.c:325
 msgid "Tried to attach a non-text item as an attribute"
 msgstr ""
 
-#: liblepton/src/o_attrib.c:332
 msgid "Unexpected end-of-file in attribute list"
 msgstr ""
 
-#: liblepton/src/geda_box_object.c:287 liblepton/src/geda_box_object.c:316
 msgid "Failed to parse box object"
 msgstr ""
 
-#: liblepton/src/geda_box_object.c:322
 #, fuzzy, c-format
 msgid "Found a zero width/height box [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr ""
 "Ho trovato un riquadro con altezza/larghezza zero [ %c %d %d %d %d %d ]\n"
 
-#: liblepton/src/geda_bus_object.c:345 liblepton/src/geda_bus_object.c:352
 msgid "Failed to parse bus object"
 msgstr ""
 
-#: liblepton/src/geda_bus_object.c:358
 #, fuzzy, c-format
 msgid "Found a zero length bus [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr "Ho trovato un bus di lunghezza zero [ %c %d %d %d %d %d ]\n"
 
-#: liblepton/src/geda_bus_object.c:370
 #, fuzzy, c-format
 msgid "Found an invalid bus ripper direction [ %1$s ]"
 msgstr "Trovato un colore non valido [%s]\n"
 
-#: liblepton/src/geda_bus_object.c:371
 #, fuzzy
 msgid "Resetting direction to neutral (no direction)."
 msgstr "Reimposto la direzione come neutra (nessuna direzione)\n"
 
-#: liblepton/src/geda_circle_object.c:343
-#: liblepton/src/geda_circle_object.c:372
 msgid "Failed to parse circle object"
 msgstr ""
 
-#: liblepton/src/geda_circle_object.c:379
 #, fuzzy, c-format
 msgid "Found a zero or negative radius circle [ %1$c %2$d %3$d %4$d %5$d ]"
 msgstr "Ho trovato un arco con raggio zero [ %c %d, %d, %d, %d, %d, %d ]\n"
 
-#: liblepton/src/geda_circle_object.c:382
 #, fuzzy
 msgid "Setting radius to 0."
 msgstr "imposto l'angolo a 0\n"
 
-#: liblepton/src/geda_color.c:217
 msgid "Color map entry must be a two-element list"
 msgstr ""
 
-#: liblepton/src/geda_color.c:225
 msgid "Index in color map entry must be an integer"
 msgstr "L'indice nella voce di mappa colore deve essere un intero"
 
-#: liblepton/src/geda_color.c:251
 msgid "Value in color map entry must be #f or a string"
 msgstr "Il valore nella voce di mappa colore deve essere #f o una stringa"
 
-#: liblepton/src/geda_complex_object.c:373
 #, fuzzy, c-format
 msgid ""
 "Component not found:\n"
@@ -394,11 +319,9 @@ msgstr ""
 "Componente non trovato:\n"
 " %s"
 
-#: liblepton/src/geda_complex_object.c:585
 msgid "Failed to parse complex object"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:598
 #, fuzzy, c-format
 msgid ""
 "Found a component with an invalid rotation [ %1$c %2$d %3$d %4$d %5$d %6$d "
@@ -406,13 +329,10 @@ msgid ""
 msgstr ""
 "Ho trovato un componente con rotazione non valida [ %c %d %d %d %d %d %s ]\n"
 
-#: liblepton/src/geda_complex_object.c:601
-#: liblepton/src/geda_picture_object.c:105
 #, fuzzy
 msgid "Setting angle to 0."
 msgstr "imposto l'angolo a 0\n"
 
-#: liblepton/src/geda_complex_object.c:613
 #, fuzzy, c-format
 msgid ""
 "Found a component with an invalid mirror flag [ %1$c %2$d %3$d %4$d %5$d "
@@ -421,12 +341,10 @@ msgstr ""
 "Ho trovato un componente con un flag mirror non valido [ %c %d %d %d %d %d "
 "%s ]\n"
 
-#: liblepton/src/geda_complex_object.c:616
 #, fuzzy
 msgid "Setting mirror to 0."
 msgstr "Imposto mirrored a 0\n"
 
-#: liblepton/src/geda_complex_object.c:941
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
@@ -435,7 +353,6 @@ msgstr ""
 "ATTENZIONE: Errore nell'analisi della versione del simbolo in refdes %s:\n"
 "\tImpossibile analizzare il file di simbolo symversion=%s\n"
 
-#: liblepton/src/geda_complex_object.c:945
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
@@ -444,7 +361,6 @@ msgstr ""
 "ATTENZIONE: Errore nell'analisi della versione del simbolo in refdes %s:\n"
 "\tImpossibile analizzare il file di simbolo symversion=\n"
 
-#: liblepton/src/geda_complex_object.c:961
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
@@ -453,7 +369,6 @@ msgstr ""
 "ATTENZIONE: Errore nell'analisi della versione del simbolo in refdes %s:\n"
 "\tImpossibile analizzare l'allegato symversion=%s\n"
 
-#: liblepton/src/geda_complex_object.c:986
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version oddity on refdes %1$s:\n"
@@ -463,7 +378,6 @@ msgstr ""
 "ATTENZIONE: Errore nell'analisi della versione del simbolo in refdes %s:\n"
 "\tImpossibile analizzare il file di simbolo symversion=%s\n"
 
-#: liblepton/src/geda_complex_object.c:1000
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version mismatch on refdes %1$s (%2$s):\n"
@@ -472,17 +386,14 @@ msgstr ""
 "ATTENZIONE: Errore nell'analisi della versione del simbolo in refdes %s:\n"
 "\tImpossibile analizzare l'allegato symversion=%s\n"
 
-#: liblepton/src/geda_complex_object.c:1028
 #, c-format
 msgid "\tMAJOR VERSION CHANGE (file %1$.3f, instantiated %2$.3f, %3$s)!"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:1046
 #, c-format
 msgid "\tMinor version change (file %1$.3f, instantiated %2$.3f)"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:1057
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version oddity on refdes %1$s:\n"
@@ -491,12 +402,10 @@ msgstr ""
 "ATTENZIONE: Errore nell'analisi della versione del simbolo in refdes %s:\n"
 "\tImpossibile analizzare il file di simbolo symversion=\n"
 
-#: liblepton/src/o_embed.c:54
 #, fuzzy, c-format
 msgid "Component [%1$s] has been embedded."
 msgstr "Il componente [%s] è stato incorporato\n"
 
-#: liblepton/src/o_embed.c:98
 #, fuzzy, c-format
 msgid ""
 "Could not find component [%1$s], while trying to unembed. Component is still "
@@ -505,509 +414,396 @@ msgstr ""
 "Impossibile trovare il componente [%s], durante la rimozione. Il component è "
 "ancora incorporato\n"
 
-#: liblepton/src/o_embed.c:106
 #, fuzzy, c-format
 msgid "Component [%1$s] has been successfully unembedded."
 msgstr "Il componente [%s] è stato rimosso con successo\n"
 
-#: liblepton/src/geda_line_object.c:391 liblepton/src/geda_line_object.c:409
 msgid "Failed to parse line object"
 msgstr ""
 
-#: liblepton/src/geda_line_object.c:421
 #, fuzzy, c-format
 msgid "Found a zero length line [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr "Ho trovato una linea con lunghezza zero [ %c %d %d %d %d %d ]\n"
 
-#: liblepton/src/geda_net_object.c:297
 msgid "Failed to parse net object"
 msgstr ""
 
-#: liblepton/src/geda_net_object.c:302
 #, fuzzy, c-format
 msgid "Found a zero length net [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr "Ho trovato una rete con lunghezza zero [ %c %d %d %d %d %d ]\n"
 
-#: liblepton/src/geda_path_object.c:206
 msgid "Failed to parse path object"
 msgstr ""
 
-#: liblepton/src/geda_path_object.c:232
 msgid "Unexpected end-of-file when reading path"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:71
 msgid "Failed to parse picture definition"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:76
 #, fuzzy, c-format
 msgid "Found a zero width/height picture [ %1$c %2$d %3$d %4$d %5$d ]"
 msgstr "Ho trovato un'immagine con larghezza/altezza zero [ %c %d %d %d %d ]\n"
 
-#: liblepton/src/geda_picture_object.c:82
 #, c-format
 msgid "Found a picture with a wrong 'mirrored' parameter: %1$d."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:84
 #, fuzzy
 msgid "Setting mirrored to 0."
 msgstr "Imposto mirrored a 0\n"
 
-#: liblepton/src/geda_picture_object.c:89
 #, c-format
 msgid "Found a picture with a wrong 'embedded' parameter: %1$d."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:91
 #, fuzzy
 msgid "Setting embedded to 0."
 msgstr "Imposto mirrored a 0\n"
 
-#: liblepton/src/geda_picture_object.c:104
 #, fuzzy, c-format
 msgid "Found an unsupported picture angle [ %1$d ]"
 msgstr "Ho trovato un angolo di immagine non supportato [ %d ]\n"
 
-#: liblepton/src/geda_picture_object.c:116
 msgid "Found an image with no filename."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:147
 #, fuzzy, c-format
 msgid "Failed to load image from embedded data [%1$s]: %2$s"
 msgstr "Impossibile caricare l'immagine dai dati incorporati [%s]: %s\n"
 
-#: liblepton/src/geda_picture_object.c:148
 msgid "Base64 decoding failed."
 msgstr "Decodifica Base64 fallita."
 
-#: liblepton/src/geda_picture_object.c:149
 #, fuzzy
 msgid "Falling back to file loading. Picture unembedded."
 msgstr "Ritorno al caricamento del file. Immagine non incorporata.\n"
 
-#: liblepton/src/geda_picture_object.c:208
 #, fuzzy
 msgid "ERROR: o_picture_save: unable to encode the picture."
 msgstr "ERRORE: o_picture_save: impossibile codificare l'immagine.\n"
 
-#: liblepton/src/geda_picture_object.c:308
 #, fuzzy, c-format
 msgid "Failed to load buffer image [%1$s]: %2$s"
 msgstr "Impossibile caricare l'immagine dal file [%s]: %s\n"
 
-#: liblepton/src/geda_picture_object.c:321
 #, fuzzy, c-format
 msgid "Failed to load image from [%1$s]: %2$s"
 msgstr "Impossibile caricare l'immagine dal file [%s]: %s\n"
 
-#: liblepton/src/geda_picture_object.c:415
 #, c-format
 msgid "Picture %1$p has invalid angle %2$i\n"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:772
 #, fuzzy, c-format
 msgid "Picture [%1$s] has no image data."
 msgstr "L'immagine [%s] è stata incorporata\n"
 
-#: liblepton/src/geda_picture_object.c:773
 #, fuzzy
 msgid "Falling back to file loading. Picture is still unembedded."
 msgstr "Ritorno al caricamento del file. Immagine non incorporata.\n"
 
-#: liblepton/src/geda_picture_object.c:781
 #, fuzzy, c-format
 msgid "Picture [%1$s] has been embedded."
 msgstr "L'immagine [%s] è stata incorporata\n"
 
-#: liblepton/src/geda_picture_object.c:805
 #, fuzzy, c-format
 msgid "Failed to load image from file [%1$s]: %2$s"
 msgstr "Impossibile caricare l'immagine dal file [%s]: %s\n"
 
-#: liblepton/src/geda_picture_object.c:807
 #, fuzzy
 msgid "Picture is still embedded."
 msgstr "L'immagine [%s] è stata incorporata\n"
 
-#: liblepton/src/geda_picture_object.c:815
 #, fuzzy, c-format
 msgid "Picture [%1$s] has been unembedded."
 msgstr "L'immagine [%s] è stata rimossa\n"
 
-#: liblepton/src/geda_picture_object.c:1052
 #, fuzzy, c-format
 msgid "Failed to load fallback image %1$s: %2$s.\n"
 msgstr "Impossibile caricare l'immagine dal file [%s]: %s\n"
 
-#: liblepton/src/geda_pin_object.c:346 liblepton/src/geda_pin_object.c:354
 msgid "Failed to parse pin object"
 msgstr ""
 
-#: liblepton/src/geda_pin_object.c:360
 msgid ""
 "Found a pin which did not have the whichend field set.\n"
 "Verify and correct manually."
 msgstr ""
 
-#: liblepton/src/geda_pin_object.c:363
 #, c-format
 msgid "Found an invalid whichend on a pin (reseting to zero): %d"
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:495 liblepton/src/geda_text_object.c:505
-#: liblepton/src/geda_text_object.c:515
 msgid "Failed to parse text object"
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:522
 #, fuzzy, c-format
 msgid "Found an invalid text size [ %1$s ]"
 msgstr "Trovato un colore non valido [%s]\n"
 
-#: liblepton/src/geda_text_object.c:524
 #, fuzzy, c-format
 msgid "Setting text size to %1$d."
 msgstr "Imposto mirrored a 0\n"
 
-#: liblepton/src/geda_text_object.c:528
 #, fuzzy, c-format
 msgid "Found an unsupported text angle [ %1$s ]"
 msgstr "Ho trovato un angolo di immagine non supportato [ %d ]\n"
 
-#: liblepton/src/geda_text_object.c:530
 #, fuzzy, c-format
 msgid "Setting angle to %1$d."
 msgstr "imposto l'angolo a 0\n"
 
-#: liblepton/src/geda_text_object.c:547
 #, fuzzy, c-format
 msgid "Found an unsupported text alignment [ %1$s ]"
 msgstr "Ho trovato un angolo di immagine non supportato [ %d ]\n"
 
-#: liblepton/src/geda_text_object.c:550
 #, fuzzy
 msgid "Setting alignment to LOWER_LEFT."
 msgstr "Imposto l'allineamento a LOWER_LEFT\n"
 
-#: liblepton/src/geda_text_object.c:570
 #, c-format
 msgid "Unexpected end-of-file after %1$d lines"
 msgstr ""
 
-#: liblepton/src/s_clib.c:460
 #, c-format
 msgid "Library command failed [%1$s]: %2$s"
 msgstr ""
 
-#: liblepton/src/s_clib.c:465
 #, c-format
 msgid "Library command failed [%1$s]: Uncaught signal %2$i."
 msgstr ""
 
-#: liblepton/src/s_clib.c:469
 #, c-format
 msgid "Library command failed [%1$s]"
 msgstr ""
 
-#: liblepton/src/s_clib.c:470
 #, c-format
 msgid ""
 "Error output was:\n"
 "%1$s"
 msgstr ""
 
-#: liblepton/src/s_clib.c:556
 #, fuzzy, c-format
 msgid "Library name [%1$s] already in use.  Using [%2$s]."
 msgstr "Il nome di libreria [%s] è già in uso.  Utilizzo [%s].\n"
 
-#: liblepton/src/s_clib.c:593
 #, fuzzy, c-format
 msgid "Failed to open directory [%1$s]: %2$s"
 msgstr "Impossibile aprire la directory [%s]: %s\n"
 
-#: liblepton/src/s_clib.c:729
 #, c-format
 msgid "Failed to scan library [%1$s]: Scheme function returned non-list."
 msgstr ""
 
-#: liblepton/src/s_clib.c:737
 #, c-format
 msgid "Non-string symbol name while scanning library [%1$s]"
 msgstr ""
 
-#: liblepton/src/s_clib.c:893 liblepton/src/s_clib.c:940
 #, fuzzy
 msgid "Cannot add library: name not specified."
 msgstr "Impossibile caricare la libreria: nome non specificato\n"
 
-#: liblepton/src/s_clib.c:900
 #, fuzzy, c-format
 msgid ""
 "Cannot add library [%1$s]: both 'list' and 'get' commands must be specified."
 msgstr "Impossibile caricare la libreria: nome non specificato\n"
 
-#: liblepton/src/s_clib.c:948
 #, c-format
 msgid "Cannot add Scheme-library [%1$s]: callbacks must be closures."
 msgstr ""
 
-#: liblepton/src/s_clib.c:1075
 #, fuzzy, c-format
 msgid "Failed to load symbol from file [%1$s]: %2$s"
 msgstr "Impossibile caricare l'immagine dal file [%s]: %s\n"
 
-#: liblepton/src/s_clib.c:1135
 #, fuzzy, c-format
 msgid "Failed to load symbol data [%1$s] from source [%2$s]"
 msgstr "Impossibile caricare l'immagine dal file [%s]: %s\n"
 
-#: liblepton/src/s_clib.c:1377
 #, fuzzy, c-format
 msgid "Component [%1$s] was not found in the component library."
 msgstr "Impossibile trovare il componente [%s] nella libreria componenti\n"
 
-#: liblepton/src/s_clib.c:1383
 #, fuzzy, c-format
 msgid "More than one component found with name [%1$s]."
 msgstr "Ho trovato più di un componente con il nome [%s]\n"
 
-#: liblepton/src/s_hierarchy.c:78 liblepton/src/s_hierarchy.c:240
 msgid "Schematic not found in source library."
 msgstr ""
 
-#: liblepton/src/s_hierarchy.c:100
 msgid "Hierarchy contains a circular dependency."
 msgstr ""
 
-#: liblepton/src/s_hierarchy.c:200
 #, fuzzy
 msgid "There are no schematics above the current one!"
 msgstr "Non ci sono schemi sopra a questo!\n"
 
-#: liblepton/src/s_hierarchy.c:341
 #, fuzzy, c-format
 msgid "Failed to descend hierarchy into '%1$s': %2$s"
 msgstr "Impossibile aprire la directory [%s]: %s\n"
 
-#: liblepton/src/s_slot.c:158
 msgid "Did not find slotdef=#:#,#,#... attribute."
 msgstr ""
 
-#: liblepton/src/s_slot.c:164
 msgid "Improper slotdef syntax: missing \":\"."
 msgstr ""
 
-#: liblepton/src/s_slot.c:179
 msgid "Did not find proper slotdef=#:#,#,#... attribute."
 msgstr ""
 
-#: liblepton/src/s_slot.c:209
 msgid "component missing pinseq= attribute."
 msgstr ""
 
-#: liblepton/src/edaconfig.c:694 liblepton/src/edaconfig.c:780
 msgid "Undefined configuration filename"
 msgstr ""
 
-#: liblepton/src/edaconfig.c:1105 liblepton/src/edaconfig.c:1169
 #, c-format
 msgid "Configuration does not have group '%s'"
 msgstr ""
 
-#: liblepton/src/edaconfig.c:1183
 #, c-format
 msgid "Configuration does not have key '%s'"
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:66 liblepton/src/scheme_attrib.c:100
 msgid "~A is not a valid attribute: invalid string '~A'."
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:204
 msgid "Objects ~A and ~A are not part of the same page and/or complex object"
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:211 liblepton/src/scheme_attrib.c:216
 msgid "Object ~A is already attached as an attribute"
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:265
 msgid "Object ~A is attribute of wrong object"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:148
 msgid "Invalid complex angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:270 liblepton/src/scheme_page.c:246
 msgid "Object ~A is already attached to something"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:332
 msgid "Object ~A is attached to a different complex"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:339
 msgid "Object ~A is attached to a page"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:346 liblepton/src/scheme_page.c:298
 msgid "Object ~A is attached as an attribute"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:353 liblepton/src/scheme_page.c:305
 msgid "Object ~A has attributes"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:234
 msgid "Object ~A has bad type '~A'"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:378
 msgid "Object ~A has invalid stroke cap style ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:391
 msgid "Object ~A has invalid stroke dash style ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:455
 msgid "Invalid stroke cap style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:466
 msgid "Invalid stroke dash style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:476
 msgid "Missing dash length parameter for dash style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:486
 msgid "Missing dot/dash space parameter for dash style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:554
 msgid "Object ~A has invalid fill style ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:603
 msgid "Invalid fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:611
 msgid "Missing second space parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:620
 msgid "Missing second angle parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:630
 msgid "Missing stroke width parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:639
 msgid "Missing space parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:648
 msgid "Missing angle parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:962
 msgid "Invalid pin type ~A, must be 'net or 'bus"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1011
 msgid "Object ~A has invalid pin type."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1417
 msgid "Invalid text alignment ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1433
 msgid "Invalid text angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1452
 msgid "Invalid text name/value visibility ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1526
 msgid "Text object ~A has invalid text alignment ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1535
 msgid "Text object ~A has invalid visibility ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1545
 msgid "Text object ~A has invalid text attribute visibility ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1586
 msgid "Object ~A is not included in a page."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1739
 msgid "Path object ~A has invalid element type ~A at index ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1853
 msgid "Invalid path element type ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:2025
 msgid "Invalid picture angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr ""
 
-#: liblepton/src/scheme_page.c:291
 msgid "Object ~A is attached to a complex or different page"
 msgstr ""
 
-#: liblepton/src/scheme_page.c:438
 msgid "Parse error: ~s"
 msgstr ""
 
-#: liblepton/src/edascmhookproxy.c:83
 msgid "Scheme hook"
 msgstr ""
 
-#: liblepton/src/edascmhookproxy.c:84
 msgid "The Scheme-level hook to proxy"
 msgstr ""
 
-#: liblepton/scheme/geda/attrib.scm:56
 #, scheme-format
 msgid "Object ~A is not part of a page"
 msgstr ""
 
-#: liblepton/scheme/geda/library.scm:108
 #, scheme-format
 msgid "Invalid path ~S or source not readable.\n"
 msgstr ""
 
-#: liblepton/scheme/geda/library.scm:109
 msgid "Source library path must be a string.\n"
 msgstr ""
 
-#: liblepton/scheme/geda/library.scm:168
 #, fuzzy, scheme-format
 msgid "File ~S is not readable.\n"
 msgstr "Il file %s è di sola lettura"
 
-#: liblepton/scheme/geda/repl.scm:48
 msgid "Welcome to Lepton REPL!\n"
 msgstr ""
 
-#: liblepton/scheme/geda/repl.scm:53
 msgid "WARNING: Readline library is not supported in your configuration.\n"
 msgstr ""
 

--- a/liblepton/po/liblepton3.pot
+++ b/liblepton/po/liblepton3.pot
@@ -1,48 +1,56 @@
-# Brazilian Portuguese translation for geda
-# Copyright (c) 2012 Rosetta Contributors and Canonical Ltd 2012
-# This file is distributed under the same license as the geda package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2012.
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR gEDA Developers
+# This file is distributed under the same license as the lepton-eda package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
+#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: geda\n"
+"Project-Id-Version: lepton-eda 1.9.7\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
 "POT-Creation-Date: 2019-05-13 11:16+0300\n"
-"PO-Revision-Date: 2012-01-27 14:15+0000\n"
-"Last-Translator: Launchpad Translators\n"
-"Language-Team: Brazilian Portuguese <pt_BR@li.org>\n"
-"Language: pt_BR\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2012-11-14 16:52+0000\n"
-"X-Generator: Launchpad (build 16265)\n"
 
+#: liblepton/data/liblepton.xml.in:3
 msgid "Lepton EDA circuit schematic"
 msgstr ""
 
+#: liblepton/data/liblepton.xml.in:4
 msgid "Lepton EDA schematic symbol"
 msgstr ""
 
+#: liblepton/data/liblepton.xml.in:5
 msgid "Lepton EDA sch2pcb project"
 msgstr ""
 
+#: liblepton/data/x-lepton-sch2pcb-project.desktop.in:3
 msgid "Lepton EDA sch2pcb Project"
 msgstr ""
 
+#: liblepton/data/x-lepton-schematic.desktop.in:3
 msgid "Lepton EDA Circuit Schematic"
 msgstr ""
 
+#: liblepton/data/x-lepton-symbol.desktop.in:3
 msgid "Lepton EDA Schematic Symbol"
 msgstr ""
 
+#: liblepton/src/a_basic.c:57 liblepton/src/f_basic.c:377
 #, c-format
 msgid "File %1$s is read-only"
 msgstr ""
 
+#: liblepton/src/a_basic.c:114
 msgid "Schematic data was not valid UTF-8"
 msgstr ""
 
+#: liblepton/src/a_basic.c:246
 #, c-format
 msgid ""
 "Read unexpected attach symbol start marker in [%1$s] :\n"
@@ -50,6 +58,7 @@ msgid ""
 "%2$s<<\n"
 msgstr ""
 
+#: liblepton/src/a_basic.c:263
 #, c-format
 msgid ""
 "Read unexpected embedded symbol start marker in [%1$s] :\n"
@@ -57,6 +66,7 @@ msgid ""
 "%2$s<<\n"
 msgstr ""
 
+#: liblepton/src/a_basic.c:294
 #, c-format
 msgid ""
 "Read unexpected embedded symbol end marker in [%s] :\n"
@@ -64,6 +74,7 @@ msgid ""
 "%s<<\n"
 msgstr ""
 
+#: liblepton/src/a_basic.c:329
 #, c-format
 msgid ""
 "Read an old format sym/sch file!\n"
@@ -71,6 +82,7 @@ msgid ""
 "[%1$s]"
 msgstr ""
 
+#: liblepton/src/a_basic.c:335
 #, c-format
 msgid ""
 "Read garbage in [%1$s] :\n"
@@ -78,14 +90,17 @@ msgid ""
 "%2$s<<\n"
 msgstr ""
 
+#: liblepton/src/f_basic.c:119 liblepton/src/f_basic.c:132
 #, c-format
 msgid "Failed to stat [%1$s]: %2$s"
 msgstr ""
 
+#: liblepton/src/f_basic.c:211
 #, c-format
 msgid "Cannot find file %1$s: %2$s"
 msgstr ""
 
+#: liblepton/src/f_basic.c:260
 #, c-format
 msgid ""
 "\n"
@@ -94,236 +109,305 @@ msgid ""
 "\n"
 msgstr ""
 
+#: liblepton/src/f_basic.c:262
 msgid "I could not guess if it is newer, so you have to do it manually.\n"
 msgstr ""
 
+#: liblepton/src/f_basic.c:264
 msgid ""
 "The backup copy is newer than the schematic, so it seems you should load it "
 "instead of the original file.\n"
 msgstr ""
 
+#: liblepton/src/f_basic.c:266
 msgid ""
 "lepton-schematic usually makes backup copies automatically, and this "
 "situation happens when it crashed or it was forced to exit abruptly.\n"
 msgstr ""
 
+#: liblepton/src/f_basic.c:269
 msgid ""
 "\n"
 "Run lepton-schematic and correct the situation.\n"
 "\n"
 msgstr ""
 
+#: liblepton/src/f_basic.c:367
 #, c-format
 msgid "Can't get the real filename of %1$s: %2$s"
 msgstr ""
 
+#: liblepton/src/f_basic.c:398
 #, c-format
 msgid "Could NOT set previous backup file [%1$s] read-write."
 msgstr ""
 
+#: liblepton/src/f_basic.c:404
 #, c-format
 msgid "Can't save backup file: %1$s."
 msgstr ""
 
+#: liblepton/src/f_basic.c:414
 #, c-format
 msgid "Could NOT set backup file [%1$s] readonly."
 msgstr ""
 
+#: liblepton/src/f_basic.c:463
 #, c-format
 msgid "Failed to restore permissions on '%1$s': %2$s\n"
 msgstr ""
 
+#: liblepton/src/f_basic.c:468
 #, c-format
 msgid "Failed to restore ownership on '%1$s': %2$s\n"
 msgstr ""
 
+#: liblepton/src/f_basic.c:478
 #, c-format
 msgid "Could NOT save file: %1$s"
 msgstr ""
 
+#: liblepton/src/f_basic.c:604
 #, c-format
 msgid "%s: %s"
 msgstr ""
 
+#: liblepton/src/g_basic.c:260
 msgid ""
 "\n"
 "Backtrace:\n"
 msgstr ""
 
+#: liblepton/src/g_rc.c:99
 #, c-format
 msgid "Invalid mode [%1$s] passed to %2$s\n"
 msgstr ""
 
+#: liblepton/src/g_rc.c:139
 msgid "RC file already loaded"
 msgstr ""
 
+#: liblepton/src/g_rc.c:183
 #, c-format
 msgid "Failed to load config from '%1$s': %2$s\n"
 msgstr ""
 
+#: liblepton/src/g_rc.c:207
 #, c-format
 msgid "Loaded RC file [%1$s]"
 msgstr ""
 
+#: liblepton/src/g_rc.c:211
 #, c-format
 msgid "Failed to load RC file [%1$s]: "
 msgstr ""
 
+#: liblepton/src/g_rc.c:341
 msgid "ERROR: An unknown error occurred while parsing configuration files."
 msgstr ""
 
+#: liblepton/src/g_rc.c:353
 #, c-format
 msgid "ERROR: %1$s"
 msgstr ""
 
+#: liblepton/src/g_rc.c:354
 #, c-format
 msgid "ERROR: %1$s\n"
 msgstr ""
 
+#: liblepton/src/g_rc.c:360
 #, c-format
 msgid "ERROR: The %1$s log may contain more information.\n"
 msgstr ""
 
+#: liblepton/src/g_rc.c:512
 #, c-format
 msgid "Invalid path [%1$s] passed to component-library\n"
 msgstr ""
 
+#: liblepton/src/g_rc.c:738
 #, c-format
 msgid "Invalid path [%1$s] passed to bitmap-directory\n"
 msgstr ""
 
+#: liblepton/src/geda_page.c:197
 #, c-format
 msgid "s_page_delete: Can't get the real filename of %1$s."
 msgstr ""
 
+#: liblepton/src/geda_page.c:208
 #, c-format
 msgid "s_page_delete: Unable to delete backup file %1$s."
 msgstr ""
 
+#: liblepton/src/geda_page.c:531
 #, c-format
 msgid "Saved [%1$s]"
 msgstr ""
 
+#: liblepton/src/geda_page.c:537
 #, c-format
 msgid "Could NOT save [%1$s]"
 msgstr ""
 
+#: liblepton/src/geda_arc_object.c:408 liblepton/src/geda_arc_object.c:421
 msgid "Failed to parse arc object"
 msgstr ""
 
+#: liblepton/src/geda_arc_object.c:428
 #, c-format
 msgid "Found a zero radius arc [ %1$c %2$d, %3$d, %4$d, %5$d, %6$d, %7$d ]"
 msgstr ""
 
+#: liblepton/src/geda_arc_object.c:435 liblepton/src/geda_box_object.c:328
+#: liblepton/src/geda_bus_object.c:364 liblepton/src/geda_circle_object.c:387
+#: liblepton/src/geda_line_object.c:427 liblepton/src/geda_net_object.c:308
+#: liblepton/src/geda_path_object.c:214 liblepton/src/geda_pin_object.c:369
+#: liblepton/src/geda_text_object.c:555
 #, c-format
 msgid "Found an invalid color [ %1$s ]"
 msgstr ""
 
+#: liblepton/src/geda_arc_object.c:436 liblepton/src/geda_box_object.c:329
+#: liblepton/src/geda_bus_object.c:365 liblepton/src/geda_circle_object.c:388
+#: liblepton/src/geda_line_object.c:428 liblepton/src/geda_net_object.c:309
+#: liblepton/src/geda_path_object.c:215 liblepton/src/geda_pin_object.c:370
+#: liblepton/src/geda_text_object.c:557
 msgid "Setting color to default color."
 msgstr ""
 
+#: liblepton/src/o_attrib.c:111
 #, c-format
 msgid "Attribute [%1$s] already attached\n"
 msgstr ""
 
+#: liblepton/src/o_attrib.c:117
 msgid "Attempt to attach non text item as an attribute!\n"
 msgstr ""
 
+#: liblepton/src/o_attrib.c:122
 #, c-format
 msgid "Attempt to attach attribute [%1$s] to more than one object\n"
 msgstr ""
 
+#: liblepton/src/o_attrib.c:329
 msgid "Tried to attach a non-text item as an attribute"
 msgstr ""
 
+#: liblepton/src/o_attrib.c:336
 msgid "Unexpected end-of-file in attribute list"
 msgstr ""
 
+#: liblepton/src/geda_box_object.c:287 liblepton/src/geda_box_object.c:316
 msgid "Failed to parse box object"
 msgstr ""
 
+#: liblepton/src/geda_box_object.c:322
 #, c-format
 msgid "Found a zero width/height box [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr ""
 
+#: liblepton/src/geda_bus_object.c:345 liblepton/src/geda_bus_object.c:352
 msgid "Failed to parse bus object"
 msgstr ""
 
+#: liblepton/src/geda_bus_object.c:358
 #, c-format
 msgid "Found a zero length bus [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr ""
 
+#: liblepton/src/geda_bus_object.c:370
 #, c-format
 msgid "Found an invalid bus ripper direction [ %1$s ]"
 msgstr ""
 
+#: liblepton/src/geda_bus_object.c:371
 msgid "Resetting direction to neutral (no direction)."
 msgstr ""
 
+#: liblepton/src/geda_circle_object.c:343
+#: liblepton/src/geda_circle_object.c:372
 msgid "Failed to parse circle object"
 msgstr ""
 
+#: liblepton/src/geda_circle_object.c:379
 #, c-format
 msgid "Found a zero or negative radius circle [ %1$c %2$d %3$d %4$d %5$d ]"
 msgstr ""
 
+#: liblepton/src/geda_circle_object.c:382
 msgid "Setting radius to 0."
 msgstr ""
 
+#: liblepton/src/geda_color.c:217
 msgid "Color map entry must be a two-element list"
 msgstr ""
 
+#: liblepton/src/geda_color.c:225
 msgid "Index in color map entry must be an integer"
 msgstr ""
 
+#: liblepton/src/geda_color.c:251
 msgid "Value in color map entry must be #f or a string"
 msgstr ""
 
+#: liblepton/src/geda_complex_object.c:373
 #, c-format
 msgid ""
 "Component not found:\n"
 " %1$s"
 msgstr ""
 
+#: liblepton/src/geda_complex_object.c:585
 msgid "Failed to parse complex object"
 msgstr ""
 
+#: liblepton/src/geda_complex_object.c:598
 #, c-format
 msgid ""
 "Found a component with an invalid rotation [ %1$c %2$d %3$d %4$d %5$d %6$d "
 "%7$s ]"
 msgstr ""
 
+#: liblepton/src/geda_complex_object.c:601
+#: liblepton/src/geda_picture_object.c:105
 msgid "Setting angle to 0."
 msgstr ""
 
+#: liblepton/src/geda_complex_object.c:613
 #, c-format
 msgid ""
 "Found a component with an invalid mirror flag [ %1$c %2$d %3$d %4$d %5$d "
 "%6$d %7$s ]"
 msgstr ""
 
+#: liblepton/src/geda_complex_object.c:616
 msgid "Setting mirror to 0."
 msgstr ""
 
+#: liblepton/src/geda_complex_object.c:941
 #, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
 "\tCould not parse symbol file symversion=%2$s"
 msgstr ""
 
+#: liblepton/src/geda_complex_object.c:945
 #, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
 "\tCould not parse symbol file symversion="
 msgstr ""
 
+#: liblepton/src/geda_complex_object.c:961
 #, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
 "\tCould not parse attached symversion=%2$s"
 msgstr ""
 
+#: liblepton/src/geda_complex_object.c:986
 #, c-format
 msgid ""
 "WARNING: Symbol version oddity on refdes %1$s:\n"
@@ -331,416 +415,535 @@ msgid ""
 "symbol file."
 msgstr ""
 
+#: liblepton/src/geda_complex_object.c:1000
 #, c-format
 msgid ""
 "WARNING: Symbol version mismatch on refdes %1$s (%2$s):\n"
 "\tSymbol in library is newer than instantiated symbol."
 msgstr ""
 
+#: liblepton/src/geda_complex_object.c:1028
 #, c-format
 msgid "\tMAJOR VERSION CHANGE (file %1$.3f, instantiated %2$.3f, %3$s)!"
 msgstr ""
 
+#: liblepton/src/geda_complex_object.c:1046
 #, c-format
 msgid "\tMinor version change (file %1$.3f, instantiated %2$.3f)"
 msgstr ""
 
+#: liblepton/src/geda_complex_object.c:1057
 #, c-format
 msgid ""
 "WARNING: Symbol version oddity on refdes %1$s:\n"
 "\tInstantiated symbol is newer than symbol in library."
 msgstr ""
 
+#: liblepton/src/o_embed.c:54
 #, c-format
 msgid "Component [%1$s] has been embedded."
 msgstr ""
 
+#: liblepton/src/o_embed.c:98
 #, c-format
 msgid ""
 "Could not find component [%1$s], while trying to unembed. Component is still "
 "embedded."
 msgstr ""
 
+#: liblepton/src/o_embed.c:106
 #, c-format
 msgid "Component [%1$s] has been successfully unembedded."
 msgstr ""
 
+#: liblepton/src/geda_line_object.c:391 liblepton/src/geda_line_object.c:409
 msgid "Failed to parse line object"
 msgstr ""
 
+#: liblepton/src/geda_line_object.c:421
 #, c-format
 msgid "Found a zero length line [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr ""
 
+#: liblepton/src/geda_net_object.c:297
 msgid "Failed to parse net object"
 msgstr ""
 
+#: liblepton/src/geda_net_object.c:302
 #, c-format
 msgid "Found a zero length net [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr ""
 
+#: liblepton/src/geda_path_object.c:206
 msgid "Failed to parse path object"
 msgstr ""
 
+#: liblepton/src/geda_path_object.c:232
 msgid "Unexpected end-of-file when reading path"
 msgstr ""
 
+#: liblepton/src/geda_picture_object.c:71
 msgid "Failed to parse picture definition"
 msgstr ""
 
+#: liblepton/src/geda_picture_object.c:76
 #, c-format
 msgid "Found a zero width/height picture [ %1$c %2$d %3$d %4$d %5$d ]"
 msgstr ""
 
+#: liblepton/src/geda_picture_object.c:82
 #, c-format
 msgid "Found a picture with a wrong 'mirrored' parameter: %1$d."
 msgstr ""
 
+#: liblepton/src/geda_picture_object.c:84
 msgid "Setting mirrored to 0."
 msgstr ""
 
+#: liblepton/src/geda_picture_object.c:89
 #, c-format
 msgid "Found a picture with a wrong 'embedded' parameter: %1$d."
 msgstr ""
 
+#: liblepton/src/geda_picture_object.c:91
 msgid "Setting embedded to 0."
 msgstr ""
 
+#: liblepton/src/geda_picture_object.c:104
 #, c-format
 msgid "Found an unsupported picture angle [ %1$d ]"
 msgstr ""
 
+#: liblepton/src/geda_picture_object.c:116
 msgid "Found an image with no filename."
 msgstr ""
 
+#: liblepton/src/geda_picture_object.c:147
 #, c-format
 msgid "Failed to load image from embedded data [%1$s]: %2$s"
 msgstr ""
 
+#: liblepton/src/geda_picture_object.c:148
 msgid "Base64 decoding failed."
 msgstr ""
 
+#: liblepton/src/geda_picture_object.c:149
 msgid "Falling back to file loading. Picture unembedded."
 msgstr ""
 
+#: liblepton/src/geda_picture_object.c:208
 msgid "ERROR: o_picture_save: unable to encode the picture."
 msgstr ""
 
+#: liblepton/src/geda_picture_object.c:308
 #, c-format
 msgid "Failed to load buffer image [%1$s]: %2$s"
 msgstr ""
 
+#: liblepton/src/geda_picture_object.c:321
 #, c-format
 msgid "Failed to load image from [%1$s]: %2$s"
 msgstr ""
 
+#: liblepton/src/geda_picture_object.c:412
 #, c-format
 msgid "Picture %1$p has invalid angle %2$i\n"
 msgstr ""
 
+#: liblepton/src/geda_picture_object.c:769
 #, c-format
 msgid "Picture [%1$s] has no image data."
 msgstr ""
 
+#: liblepton/src/geda_picture_object.c:770
 msgid "Falling back to file loading. Picture is still unembedded."
 msgstr ""
 
+#: liblepton/src/geda_picture_object.c:778
 #, c-format
 msgid "Picture [%1$s] has been embedded."
 msgstr ""
 
+#: liblepton/src/geda_picture_object.c:802
 #, c-format
 msgid "Failed to load image from file [%1$s]: %2$s"
 msgstr ""
 
+#: liblepton/src/geda_picture_object.c:804
 msgid "Picture is still embedded."
 msgstr ""
 
+#: liblepton/src/geda_picture_object.c:812
 #, c-format
 msgid "Picture [%1$s] has been unembedded."
 msgstr ""
 
+#: liblepton/src/geda_picture_object.c:1048
 #, c-format
 msgid "Failed to load fallback image %1$s: %2$s.\n"
 msgstr ""
 
+#: liblepton/src/geda_pin_object.c:346 liblepton/src/geda_pin_object.c:354
 msgid "Failed to parse pin object"
 msgstr ""
 
+#: liblepton/src/geda_pin_object.c:360
 msgid ""
 "Found a pin which did not have the whichend field set.\n"
 "Verify and correct manually."
 msgstr ""
 
+#: liblepton/src/geda_pin_object.c:363
 #, c-format
 msgid "Found an invalid whichend on a pin (reseting to zero): %d"
 msgstr ""
 
+#: liblepton/src/geda_text_object.c:495 liblepton/src/geda_text_object.c:505
+#: liblepton/src/geda_text_object.c:515
 msgid "Failed to parse text object"
 msgstr ""
 
+#: liblepton/src/geda_text_object.c:522
 #, c-format
 msgid "Found an invalid text size [ %1$s ]"
 msgstr ""
 
+#: liblepton/src/geda_text_object.c:524
 #, c-format
 msgid "Setting text size to %1$d."
 msgstr ""
 
+#: liblepton/src/geda_text_object.c:528
 #, c-format
 msgid "Found an unsupported text angle [ %1$s ]"
 msgstr ""
 
+#: liblepton/src/geda_text_object.c:530
 #, c-format
 msgid "Setting angle to %1$d."
 msgstr ""
 
+#: liblepton/src/geda_text_object.c:547
 #, c-format
 msgid "Found an unsupported text alignment [ %1$s ]"
 msgstr ""
 
+#: liblepton/src/geda_text_object.c:550
 msgid "Setting alignment to LOWER_LEFT."
 msgstr ""
 
+#: liblepton/src/geda_text_object.c:570
 #, c-format
 msgid "Unexpected end-of-file after %1$d lines"
 msgstr ""
 
+#: liblepton/src/s_clib.c:460
 #, c-format
 msgid "Library command failed [%1$s]: %2$s"
 msgstr ""
 
+#: liblepton/src/s_clib.c:465
 #, c-format
 msgid "Library command failed [%1$s]: Uncaught signal %2$i."
 msgstr ""
 
+#: liblepton/src/s_clib.c:469
 #, c-format
 msgid "Library command failed [%1$s]"
 msgstr ""
 
+#: liblepton/src/s_clib.c:470
 #, c-format
 msgid ""
 "Error output was:\n"
 "%1$s"
 msgstr ""
 
+#: liblepton/src/s_clib.c:556
 #, c-format
 msgid "Library name [%1$s] already in use.  Using [%2$s]."
 msgstr ""
 
+#: liblepton/src/s_clib.c:593
 #, c-format
 msgid "Failed to open directory [%1$s]: %2$s"
 msgstr ""
 
+#: liblepton/src/s_clib.c:729
 #, c-format
 msgid "Failed to scan library [%1$s]: Scheme function returned non-list."
 msgstr ""
 
+#: liblepton/src/s_clib.c:737
 #, c-format
 msgid "Non-string symbol name while scanning library [%1$s]"
 msgstr ""
 
+#: liblepton/src/s_clib.c:893 liblepton/src/s_clib.c:940
 msgid "Cannot add library: name not specified."
 msgstr ""
 
+#: liblepton/src/s_clib.c:900
 #, c-format
 msgid ""
 "Cannot add library [%1$s]: both 'list' and 'get' commands must be specified."
 msgstr ""
 
+#: liblepton/src/s_clib.c:948
 #, c-format
 msgid "Cannot add Scheme-library [%1$s]: callbacks must be closures."
 msgstr ""
 
+#: liblepton/src/s_clib.c:1075
 #, c-format
 msgid "Failed to load symbol from file [%1$s]: %2$s"
 msgstr ""
 
+#: liblepton/src/s_clib.c:1135
 #, c-format
 msgid "Failed to load symbol data [%1$s] from source [%2$s]"
 msgstr ""
 
+#: liblepton/src/s_clib.c:1377
 #, c-format
 msgid "Component [%1$s] was not found in the component library."
 msgstr ""
 
+#: liblepton/src/s_clib.c:1383
 #, c-format
 msgid "More than one component found with name [%1$s]."
 msgstr ""
 
+#: liblepton/src/s_hierarchy.c:78 liblepton/src/s_hierarchy.c:240
 msgid "Schematic not found in source library."
 msgstr ""
 
+#: liblepton/src/s_hierarchy.c:100
 msgid "Hierarchy contains a circular dependency."
 msgstr ""
 
+#: liblepton/src/s_hierarchy.c:200
 msgid "There are no schematics above the current one!"
 msgstr ""
 
+#: liblepton/src/s_hierarchy.c:341
 #, c-format
 msgid "Failed to descend hierarchy into '%1$s': %2$s"
 msgstr ""
 
+#: liblepton/src/s_slot.c:158
 msgid "Did not find slotdef=#:#,#,#... attribute."
 msgstr ""
 
+#: liblepton/src/s_slot.c:164
 msgid "Improper slotdef syntax: missing \":\"."
 msgstr ""
 
+#: liblepton/src/s_slot.c:179
 msgid "Did not find proper slotdef=#:#,#,#... attribute."
 msgstr ""
 
+#: liblepton/src/s_slot.c:209
 msgid "component missing pinseq= attribute."
 msgstr ""
 
+#: liblepton/src/edaconfig.c:837 liblepton/src/edaconfig.c:923
 msgid "Undefined configuration filename"
 msgstr ""
 
+#: liblepton/src/edaconfig.c:1248 liblepton/src/edaconfig.c:1312
 #, c-format
 msgid "Configuration does not have group '%s'"
 msgstr ""
 
+#: liblepton/src/edaconfig.c:1326
 #, c-format
 msgid "Configuration does not have key '%s'"
 msgstr ""
 
+#: liblepton/src/scheme_attrib.c:66 liblepton/src/scheme_attrib.c:100
 msgid "~A is not a valid attribute: invalid string '~A'."
 msgstr ""
 
+#: liblepton/src/scheme_attrib.c:204
 msgid "Objects ~A and ~A are not part of the same page and/or complex object"
 msgstr ""
 
+#: liblepton/src/scheme_attrib.c:211 liblepton/src/scheme_attrib.c:216
 msgid "Object ~A is already attached as an attribute"
 msgstr ""
 
+#: liblepton/src/scheme_attrib.c:265
 msgid "Object ~A is attribute of wrong object"
 msgstr ""
 
+#: liblepton/src/scheme_complex.c:148
 msgid "Invalid complex angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr ""
 
+#: liblepton/src/scheme_complex.c:270 liblepton/src/scheme_page.c:246
 msgid "Object ~A is already attached to something"
 msgstr ""
 
+#: liblepton/src/scheme_complex.c:332
 msgid "Object ~A is attached to a different complex"
 msgstr ""
 
+#: liblepton/src/scheme_complex.c:339
 msgid "Object ~A is attached to a page"
 msgstr ""
 
+#: liblepton/src/scheme_complex.c:346 liblepton/src/scheme_page.c:298
 msgid "Object ~A is attached as an attribute"
 msgstr ""
 
+#: liblepton/src/scheme_complex.c:353 liblepton/src/scheme_page.c:305
 msgid "Object ~A has attributes"
 msgstr ""
 
+#: liblepton/src/scheme_object.c:236
 msgid "Object ~A has bad type '~A'"
 msgstr ""
 
+#: liblepton/src/scheme_object.c:380
 msgid "Object ~A has invalid stroke cap style ~A"
 msgstr ""
 
+#: liblepton/src/scheme_object.c:393
 msgid "Object ~A has invalid stroke dash style ~A"
 msgstr ""
 
+#: liblepton/src/scheme_object.c:457
 msgid "Invalid stroke cap style ~A."
 msgstr ""
 
+#: liblepton/src/scheme_object.c:468
 msgid "Invalid stroke dash style ~A."
 msgstr ""
 
+#: liblepton/src/scheme_object.c:478
 msgid "Missing dash length parameter for dash style ~A."
 msgstr ""
 
+#: liblepton/src/scheme_object.c:488
 msgid "Missing dot/dash space parameter for dash style ~A."
 msgstr ""
 
+#: liblepton/src/scheme_object.c:556
 msgid "Object ~A has invalid fill style ~A"
 msgstr ""
 
+#: liblepton/src/scheme_object.c:605
 msgid "Invalid fill style ~A."
 msgstr ""
 
+#: liblepton/src/scheme_object.c:613
 msgid "Missing second space parameter for fill style ~A."
 msgstr ""
 
+#: liblepton/src/scheme_object.c:622
 msgid "Missing second angle parameter for fill style ~A."
 msgstr ""
 
+#: liblepton/src/scheme_object.c:632
 msgid "Missing stroke width parameter for fill style ~A."
 msgstr ""
 
+#: liblepton/src/scheme_object.c:641
 msgid "Missing space parameter for fill style ~A."
 msgstr ""
 
+#: liblepton/src/scheme_object.c:650
 msgid "Missing angle parameter for fill style ~A."
 msgstr ""
 
+#: liblepton/src/scheme_object.c:1034
 msgid "Invalid pin type ~A, must be 'net or 'bus"
 msgstr ""
 
+#: liblepton/src/scheme_object.c:1083
 msgid "Object ~A has invalid pin type."
 msgstr ""
 
+#: liblepton/src/scheme_object.c:1489
 msgid "Invalid text alignment ~A."
 msgstr ""
 
+#: liblepton/src/scheme_object.c:1505
 msgid "Invalid text angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr ""
 
+#: liblepton/src/scheme_object.c:1524
 msgid "Invalid text name/value visibility ~A."
 msgstr ""
 
+#: liblepton/src/scheme_object.c:1598
 msgid "Text object ~A has invalid text alignment ~A"
 msgstr ""
 
+#: liblepton/src/scheme_object.c:1607
 msgid "Text object ~A has invalid visibility ~A"
 msgstr ""
 
+#: liblepton/src/scheme_object.c:1617
 msgid "Text object ~A has invalid text attribute visibility ~A"
 msgstr ""
 
+#: liblepton/src/scheme_object.c:1658
 msgid "Object ~A is not included in a page."
 msgstr ""
 
+#: liblepton/src/scheme_object.c:1811
 msgid "Path object ~A has invalid element type ~A at index ~A"
 msgstr ""
 
+#: liblepton/src/scheme_object.c:1925
 msgid "Invalid path element type ~A."
 msgstr ""
 
+#: liblepton/src/scheme_object.c:2097
 msgid "Invalid picture angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr ""
 
+#: liblepton/src/scheme_page.c:291
 msgid "Object ~A is attached to a complex or different page"
 msgstr ""
 
+#: liblepton/src/scheme_page.c:438
 msgid "Parse error: ~s"
 msgstr ""
 
+#: liblepton/src/edascmhookproxy.c:81
 msgid "Scheme hook"
 msgstr ""
 
+#: liblepton/src/edascmhookproxy.c:82
 msgid "The Scheme-level hook to proxy"
 msgstr ""
 
+#: liblepton/scheme/geda/attrib.scm:56
 #, scheme-format
 msgid "Object ~A is not part of a page"
 msgstr ""
 
+#: liblepton/scheme/geda/library.scm:108
 #, scheme-format
 msgid "Invalid path ~S or source not readable.\n"
 msgstr ""
 
+#: liblepton/scheme/geda/library.scm:110
 msgid "Source library path must be a string.\n"
 msgstr ""
 
+#: liblepton/scheme/geda/library.scm:169
 #, scheme-format
 msgid "File ~S is not readable.\n"
 msgstr ""
 
+#: liblepton/scheme/geda/repl.scm:48
 msgid "Welcome to Lepton REPL!\n"
 msgstr ""
 
+#: liblepton/scheme/geda/repl.scm:53
 msgid "WARNING: Readline library is not supported in your configuration.\n"
 msgstr ""

--- a/liblepton/po/nl.po
+++ b/liblepton/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-12 00:08+0300\n"
+"POT-Creation-Date: 2019-05-13 11:16+0300\n"
 "PO-Revision-Date: 2014-08-31 23:03+0100\n"
 "Last-Translator: Bert Timmerman <bert.timmerman@xs4all.nl>\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -20,46 +20,37 @@ msgstr ""
 "X-Poedit-Country: NETHERLANDS\n"
 "X-Poedit-Language: Dutch\n"
 
-#: liblepton/data/liblepton.xml.in:3
 #, fuzzy
 msgid "Lepton EDA circuit schematic"
 msgstr "gEDA schakeling schema"
 
-#: liblepton/data/liblepton.xml.in:4
 #, fuzzy
 msgid "Lepton EDA schematic symbol"
 msgstr "gEDA schema symbool"
 
-#: liblepton/data/liblepton.xml.in:5
 #, fuzzy
 msgid "Lepton EDA sch2pcb project"
 msgstr "gEDA gsch2pcb project"
 
-#: liblepton/data/x-lepton-sch2pcb-project.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA sch2pcb Project"
 msgstr "gEDA Gsch2pcb Project"
 
-#: liblepton/data/x-lepton-schematic.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Circuit Schematic"
 msgstr "gEDA Schakeling Schema"
 
-#: liblepton/data/x-lepton-symbol.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Schematic Symbol"
 msgstr "gEDA Schema Symbool"
 
-#: liblepton/src/a_basic.c:57 liblepton/src/f_basic.c:377
 #, fuzzy, c-format
 msgid "File %1$s is read-only"
 msgstr "Bestand %s is alleen-lezen"
 
-#: liblepton/src/a_basic.c:114
 msgid "Schematic data was not valid UTF-8"
 msgstr "Schema gegevens waren geen geldige UTF-8"
 
-#: liblepton/src/a_basic.c:246
 #, fuzzy, c-format
 msgid ""
 "Read unexpected attach symbol start marker in [%1$s] :\n"
@@ -70,7 +61,6 @@ msgstr ""
 ">>\n"
 "%s<<\n"
 
-#: liblepton/src/a_basic.c:263
 #, fuzzy, c-format
 msgid ""
 "Read unexpected embedded symbol start marker in [%1$s] :\n"
@@ -81,7 +71,6 @@ msgstr ""
 ">>\n"
 "%s<<\n"
 
-#: liblepton/src/a_basic.c:294
 #, c-format
 msgid ""
 "Read unexpected embedded symbol end marker in [%s] :\n"
@@ -92,7 +81,6 @@ msgstr ""
 ">>\n"
 "%s<<\n"
 
-#: liblepton/src/a_basic.c:329
 #, fuzzy, c-format
 msgid ""
 "Read an old format sym/sch file!\n"
@@ -103,7 +91,6 @@ msgstr ""
 "Voer g[sym|sch]update uit op:\n"
 "[%s]\n"
 
-#: liblepton/src/a_basic.c:335
 #, fuzzy, c-format
 msgid ""
 "Read garbage in [%1$s] :\n"
@@ -114,17 +101,14 @@ msgstr ""
 ">>\n"
 "%s<<\n"
 
-#: liblepton/src/f_basic.c:119 liblepton/src/f_basic.c:132
 #, fuzzy, c-format
 msgid "Failed to stat [%1$s]: %2$s"
 msgstr "Status niet gelukt [%s]: %s"
 
-#: liblepton/src/f_basic.c:211
 #, fuzzy, c-format
 msgid "Cannot find file %1$s: %2$s"
 msgstr "Kan bestand %s niet vinden: %s"
 
-#: liblepton/src/f_basic.c:260
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -137,11 +121,9 @@ msgstr ""
 " %s.\n"
 "\n"
 
-#: liblepton/src/f_basic.c:262
 msgid "I could not guess if it is newer, so you have to do it manually.\n"
 msgstr "Ik kan niet raden of het nieuwer is, je moet het dus handmatig doen.\n"
 
-#: liblepton/src/f_basic.c:264
 msgid ""
 "The backup copy is newer than the schematic, so it seems you should load it "
 "instead of the original file.\n"
@@ -149,7 +131,6 @@ msgstr ""
 "De reservekopie is nieuwer dan het schema, het lijkt erop dat je deze zou "
 "moeten laden in plaats van het orginele bestand.\n"
 
-#: liblepton/src/f_basic.c:266
 #, fuzzy
 msgid ""
 "lepton-schematic usually makes backup copies automatically, and this "
@@ -159,7 +140,6 @@ msgstr ""
 "voor wanneer er een crash is of wanneer er een abrupte gedwongen beeindiging "
 "was.\n"
 
-#: liblepton/src/f_basic.c:269
 #, fuzzy
 msgid ""
 "\n"
@@ -170,47 +150,38 @@ msgstr ""
 "Voer gschem uit en corrigeer de situatie.\n"
 "\n"
 
-#: liblepton/src/f_basic.c:367
 #, fuzzy, c-format
 msgid "Can't get the real filename of %1$s: %2$s"
 msgstr "Kan de werkelijke bestandsnaam van %s: %s niet krijgen"
 
-#: liblepton/src/f_basic.c:398
 #, fuzzy, c-format
 msgid "Could NOT set previous backup file [%1$s] read-write."
 msgstr "Kan vorige reservekopie [%s] NIET op lezen-schrijven instellen\n"
 
-#: liblepton/src/f_basic.c:404
 #, fuzzy, c-format
 msgid "Can't save backup file: %1$s."
 msgstr "Kan reservekopie niet opslaan: %s."
 
-#: liblepton/src/f_basic.c:414
 #, fuzzy, c-format
 msgid "Could NOT set backup file [%1$s] readonly."
 msgstr "Kan reservekopie [%s] NIET op alleen-lezen instellen\n"
 
-#: liblepton/src/f_basic.c:463
 #, fuzzy, c-format
 msgid "Failed to restore permissions on '%1$s': %2$s\n"
 msgstr "Faalde om permissies te herstellen op '%s: %s\n"
 
-#: liblepton/src/f_basic.c:468
 #, fuzzy, c-format
 msgid "Failed to restore ownership on '%1$s': %2$s\n"
 msgstr "Faalde om eigenaarschap te herstellen op '%s: %s\n"
 
-#: liblepton/src/f_basic.c:478
 #, fuzzy, c-format
 msgid "Could NOT save file: %1$s"
 msgstr "Kan bestand: %s NIET opslaan"
 
-#: liblepton/src/f_basic.c:604
 #, c-format
 msgid "%s: %s"
 msgstr "%s: %s"
 
-#: liblepton/src/g_basic.c:260
 msgid ""
 "\n"
 "Backtrace:\n"
@@ -218,188 +189,142 @@ msgstr ""
 "\n"
 "Traceren:\n"
 
-#: liblepton/src/g_rc.c:99
 #, fuzzy, c-format
 msgid "Invalid mode [%1$s] passed to %2$s\n"
 msgstr "Ongeldige modus [%s] overgedragen aan %s\n"
 
 # We hebben deze al ingelezen.
-#: liblepton/src/g_rc.c:139
 msgid "RC file already loaded"
 msgstr "RC bestand is reeds geladen"
 
-#: liblepton/src/g_rc.c:183
 #, fuzzy, c-format
 msgid "Failed to load config from '%1$s': %2$s\n"
 msgstr "Laden van config uit [%s] faalde: %s\n"
 
-#: liblepton/src/g_rc.c:207
 #, fuzzy, c-format
 msgid "Loaded RC file [%1$s]"
 msgstr "RC bestand geladen [%s]\n"
 
-#: liblepton/src/g_rc.c:211
 #, fuzzy, c-format
 msgid "Failed to load RC file [%1$s]: "
 msgstr "Laden van RC bestand faalde [%s]: "
 
-#: liblepton/src/g_rc.c:341
 msgid "ERROR: An unknown error occurred while parsing configuration files."
 msgstr ""
 "FOUT: Een onbekende fout trad op tijdens het doorlopen van configuratie "
 "bestanden."
 
-#: liblepton/src/g_rc.c:353
 #, fuzzy, c-format
 msgid "ERROR: %1$s"
 msgstr "FOUT: %s\n"
 
-#: liblepton/src/g_rc.c:354
 #, fuzzy, c-format
 msgid "ERROR: %1$s\n"
 msgstr "FOUT: %s\n"
 
-#: liblepton/src/g_rc.c:360
 #, fuzzy, c-format
 msgid "ERROR: The %1$s log may contain more information.\n"
 msgstr "FOUT: De %s log kan meer informatie bevatten.\n"
 
-#: liblepton/src/g_rc.c:512
 #, fuzzy, c-format
 msgid "Invalid path [%1$s] passed to component-library\n"
 msgstr "Ongeldig pad [%s] overgedragen aan component-library\n"
 
-#: liblepton/src/g_rc.c:738
 #, fuzzy, c-format
 msgid "Invalid path [%1$s] passed to bitmap-directory\n"
 msgstr "Ongeldig pad [%s] overgedragen aan bitmap-directory\n"
 
-#: liblepton/src/geda_page.c:197
 #, fuzzy, c-format
 msgid "s_page_delete: Can't get the real filename of %1$s."
 msgstr "s_page_delete: Kan de echte bestandsnaam van %s niet krijgen."
 
-#: liblepton/src/geda_page.c:208
 #, fuzzy, c-format
 msgid "s_page_delete: Unable to delete backup file %1$s."
 msgstr "s_page_delete: Niet mogelijk om reservekopie %s te verwijderen."
 
-#: liblepton/src/geda_page.c:490
 #, fuzzy, c-format
 msgid "Saved [%1$s]"
 msgstr "[%s] opgeslagen\n"
 
-#: liblepton/src/geda_page.c:496
 #, fuzzy, c-format
 msgid "Could NOT save [%1$s]"
 msgstr "Kan [%s] NIET opslaan\n"
 
-#: liblepton/src/geda_arc_object.c:408 liblepton/src/geda_arc_object.c:421
 msgid "Failed to parse arc object"
 msgstr "Faalde bij het ontleden van een boog object"
 
-#: liblepton/src/geda_arc_object.c:428
 #, fuzzy, c-format
 msgid "Found a zero radius arc [ %1$c %2$d, %3$d, %4$d, %5$d, %6$d, %7$d ]"
 msgstr "Boog met een straal van nul gevonden [ %c %d, %d, %d, %d, %d, %d ]\n"
 
-#: liblepton/src/geda_arc_object.c:435 liblepton/src/geda_box_object.c:328
-#: liblepton/src/geda_bus_object.c:364 liblepton/src/geda_circle_object.c:387
-#: liblepton/src/geda_line_object.c:427 liblepton/src/geda_net_object.c:308
-#: liblepton/src/geda_path_object.c:214 liblepton/src/geda_pin_object.c:369
-#: liblepton/src/geda_text_object.c:555
 #, fuzzy, c-format
 msgid "Found an invalid color [ %1$s ]"
 msgstr "Ongeldige kleur [ %s ] gevonden\n"
 
-#: liblepton/src/geda_arc_object.c:436 liblepton/src/geda_box_object.c:329
-#: liblepton/src/geda_bus_object.c:365 liblepton/src/geda_circle_object.c:388
-#: liblepton/src/geda_line_object.c:428 liblepton/src/geda_net_object.c:309
-#: liblepton/src/geda_path_object.c:215 liblepton/src/geda_pin_object.c:370
-#: liblepton/src/geda_text_object.c:557
 #, fuzzy
 msgid "Setting color to default color."
 msgstr "Stel de kleur in op standaard kleur\n"
 
-#: liblepton/src/o_attrib.c:111
 #, fuzzy, c-format
 msgid "Attribute [%1$s] already attached\n"
 msgstr "Attribuut [%s] is al bevestigd\n"
 
-#: liblepton/src/o_attrib.c:117
 msgid "Attempt to attach non text item as an attribute!\n"
 msgstr "Probeerde een niet text item toe te voegen als een attribuut!\n"
 
-#: liblepton/src/o_attrib.c:122
 #, fuzzy, c-format
 msgid "Attempt to attach attribute [%1$s] to more than one object\n"
 msgstr "Probeerde attribuut [%s] aan meer dan een object toe te voegen\n"
 
-#: liblepton/src/o_attrib.c:325
 msgid "Tried to attach a non-text item as an attribute"
 msgstr "Probeerde een niet tekst item toe te voegen als een attribuut"
 
-#: liblepton/src/o_attrib.c:332
 msgid "Unexpected end-of-file in attribute list"
 msgstr "Onverwacht einde-bestand in attribuutlijst"
 
-#: liblepton/src/geda_box_object.c:287 liblepton/src/geda_box_object.c:316
 msgid "Failed to parse box object"
 msgstr "Faalde bij het ontleden van een rechthoek object"
 
-#: liblepton/src/geda_box_object.c:322
 #, fuzzy, c-format
 msgid "Found a zero width/height box [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr ""
 "Rechthoek met een breedte/hoogte van nul gevonden [ %c %d %d %d %d %d ]\n"
 
-#: liblepton/src/geda_bus_object.c:345 liblepton/src/geda_bus_object.c:352
 msgid "Failed to parse bus object"
 msgstr "Faalde bij het ontleden van een bus object"
 
-#: liblepton/src/geda_bus_object.c:358
 #, fuzzy, c-format
 msgid "Found a zero length bus [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr "Bus met een lengte van nul gevonden [ %c %d %d %d %d %d ]\n"
 
-#: liblepton/src/geda_bus_object.c:370
 #, fuzzy, c-format
 msgid "Found an invalid bus ripper direction [ %1$s ]"
 msgstr "Ongeldige bus ripper richting gevonden [ %s ]\n"
 
-#: liblepton/src/geda_bus_object.c:371
 #, fuzzy
 msgid "Resetting direction to neutral (no direction)."
 msgstr "Neutrale richting ingesteld (geen richting)\n"
 
-#: liblepton/src/geda_circle_object.c:343
-#: liblepton/src/geda_circle_object.c:372
 msgid "Failed to parse circle object"
 msgstr "Faalde bij het ontleden van een cirkel object"
 
-#: liblepton/src/geda_circle_object.c:379
 #, fuzzy, c-format
 msgid "Found a zero or negative radius circle [ %1$c %2$d %3$d %4$d %5$d ]"
 msgstr "Een cirkel met een radius van nul gevonden [ %c %d %d %d %d ]\n"
 
-#: liblepton/src/geda_circle_object.c:382
 #, fuzzy
 msgid "Setting radius to 0."
 msgstr "Radius op 0 ingesteld\n"
 
-#: liblepton/src/geda_color.c:217
 msgid "Color map entry must be a two-element list"
 msgstr "Kleuren map invoer moet een twee-element lijst zijn"
 
-#: liblepton/src/geda_color.c:225
 msgid "Index in color map entry must be an integer"
 msgstr "Index in kleuren map invoer moet een integer zijn"
 
-#: liblepton/src/geda_color.c:251
 msgid "Value in color map entry must be #f or a string"
 msgstr "Waarde in kleuren map invoer moet een #f of een string zijn"
 
-#: liblepton/src/geda_complex_object.c:373
 #, fuzzy, c-format
 msgid ""
 "Component not found:\n"
@@ -408,11 +333,9 @@ msgstr ""
 "Komponent niet gevonden:\n"
 " %s"
 
-#: liblepton/src/geda_complex_object.c:585
 msgid "Failed to parse complex object"
 msgstr "Faalde bij het ontleden van een complex object"
 
-#: liblepton/src/geda_complex_object.c:598
 #, fuzzy, c-format
 msgid ""
 "Found a component with an invalid rotation [ %1$c %2$d %3$d %4$d %5$d %6$d "
@@ -420,13 +343,10 @@ msgid ""
 msgstr ""
 "Een komponent met een ongeldige rotatie gevonden [ %c %d %d %d %d %d %s ]\n"
 
-#: liblepton/src/geda_complex_object.c:601
-#: liblepton/src/geda_picture_object.c:105
 #, fuzzy
 msgid "Setting angle to 0."
 msgstr "Hoek op 0 ingesteld\n"
 
-#: liblepton/src/geda_complex_object.c:613
 #, fuzzy, c-format
 msgid ""
 "Found a component with an invalid mirror flag [ %1$c %2$d %3$d %4$d %5$d "
@@ -435,12 +355,10 @@ msgstr ""
 "Een komponent met een ongeldige spiegel vlag gevonden [ %c %d %d %d %d %d "
 "%s ]\n"
 
-#: liblepton/src/geda_complex_object.c:616
 #, fuzzy
 msgid "Setting mirror to 0."
 msgstr "Spiegelen op 0 ingesteld\n"
 
-#: liblepton/src/geda_complex_object.c:941
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
@@ -449,7 +367,6 @@ msgstr ""
 "WAARSCHUWING: Symbool versie zoek fout bij refdes %s:\n"
 "\tKan symboolbestand niet doorzoeken symversion=%s\n"
 
-#: liblepton/src/geda_complex_object.c:945
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
@@ -458,7 +375,6 @@ msgstr ""
 "WAARSCHUWING: Symbool versie zoek fout bij refdes %s:\n"
 "\tKan symboolbestand niet doorzoeken symversion=\n"
 
-#: liblepton/src/geda_complex_object.c:961
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
@@ -467,7 +383,6 @@ msgstr ""
 "WAARSCHUWING: Symbool versie zoek fout bij refdes %s:\n"
 "\tKan bijgevoegd symboolbestand niet doorzoeken symversion=%s\n"
 
-#: liblepton/src/geda_complex_object.c:986
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version oddity on refdes %1$s:\n"
@@ -478,7 +393,6 @@ msgstr ""
 "\tsymversion=%s bijgevoegd aan bedoelde symbool, maar geen symversion= in "
 "het symbool bestand\n"
 
-#: liblepton/src/geda_complex_object.c:1000
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version mismatch on refdes %1$s (%2$s):\n"
@@ -487,17 +401,14 @@ msgstr ""
 "WAARSCHUWING: Symbool versie fout bij refdes %s (%s):\n"
 "\tSymbool in bibliotheek is nieuwer dan bedoelde symbool\n"
 
-#: liblepton/src/geda_complex_object.c:1028
 #, fuzzy, c-format
 msgid "\tMAJOR VERSION CHANGE (file %1$.3f, instantiated %2$.3f, %3$s)!"
 msgstr "\tGROTE VERSIE VERANDERING (bestand %.3f, bedoeld %.3f, %s)!\n"
 
-#: liblepton/src/geda_complex_object.c:1046
 #, fuzzy, c-format
 msgid "\tMinor version change (file %1$.3f, instantiated %2$.3f)"
 msgstr "\tKleine versie verandering (bestand %.3f, bedoeld %.3f)!\n"
 
-#: liblepton/src/geda_complex_object.c:1057
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version oddity on refdes %1$s:\n"
@@ -506,12 +417,10 @@ msgstr ""
 "WAARSCHUWING: Symbool versie afwijking bij refdes %s:\n"
 "\tbedoeld symbool is nieuwer dan het symbool in de bibliotheek\n"
 
-#: liblepton/src/o_embed.c:54
 #, fuzzy, c-format
 msgid "Component [%1$s] has been embedded."
 msgstr "Komponent [%s] is ingevoegd\n"
 
-#: liblepton/src/o_embed.c:98
 #, fuzzy, c-format
 msgid ""
 "Could not find component [%1$s], while trying to unembed. Component is still "
@@ -520,151 +429,120 @@ msgstr ""
 "Kan komponent [%s] niet vinden, tijdens het uitvoegen. Komponent is nog "
 "steeds ingevoegd\n"
 
-#: liblepton/src/o_embed.c:106
 #, fuzzy, c-format
 msgid "Component [%1$s] has been successfully unembedded."
 msgstr "Komponent [%s] is succesvol uitgevoegd\n"
 
-#: liblepton/src/geda_line_object.c:391 liblepton/src/geda_line_object.c:409
 msgid "Failed to parse line object"
 msgstr "Faalde bij het ontleden van een lijn object"
 
-#: liblepton/src/geda_line_object.c:421
 #, fuzzy, c-format
 msgid "Found a zero length line [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr "Lijn met een lengte van nul gevonden [ %c %d %d %d %d %d ]\n"
 
-#: liblepton/src/geda_net_object.c:297
 msgid "Failed to parse net object"
 msgstr "Faalde bij het ontleden van een net object"
 
-#: liblepton/src/geda_net_object.c:302
 #, fuzzy, c-format
 msgid "Found a zero length net [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr "Net met een lengte van nul gevonden [ %c %d %d %d %d %d ]\n"
 
-#: liblepton/src/geda_path_object.c:206
 msgid "Failed to parse path object"
 msgstr "Faalde bij het ontleden van een pad object"
 
-#: liblepton/src/geda_path_object.c:232
 msgid "Unexpected end-of-file when reading path"
 msgstr "Onverwacht einde-bestand tijdens het lezen van een pad"
 
-#: liblepton/src/geda_picture_object.c:71
 msgid "Failed to parse picture definition"
 msgstr "Faalde bij het ontleden van een afbeelding definitie"
 
-#: liblepton/src/geda_picture_object.c:76
 #, fuzzy, c-format
 msgid "Found a zero width/height picture [ %1$c %2$d %3$d %4$d %5$d ]"
 msgstr ""
 "Afbeelding met een breedte/hoogte van nul gevonden [ %c %d %d %d %d ]\n"
 
-#: liblepton/src/geda_picture_object.c:82
 #, fuzzy, c-format
 msgid "Found a picture with a wrong 'mirrored' parameter: %1$d."
 msgstr "Afbeelding met een verkeerde 'gespiegelde' parameter gevonden: %d.\n"
 
-#: liblepton/src/geda_picture_object.c:84
 #, fuzzy
 msgid "Setting mirrored to 0."
 msgstr "Spiegelen op 0 ingesteld\n"
 
-#: liblepton/src/geda_picture_object.c:89
 #, fuzzy, c-format
 msgid "Found a picture with a wrong 'embedded' parameter: %1$d."
 msgstr "Afbeelding met een verkeerd 'ingevoegde' waarde gevonden: %d.\n"
 
-#: liblepton/src/geda_picture_object.c:91
 #, fuzzy
 msgid "Setting embedded to 0."
 msgstr "Invoegen op 0 ingesteld\n"
 
-#: liblepton/src/geda_picture_object.c:104
 #, fuzzy, c-format
 msgid "Found an unsupported picture angle [ %1$d ]"
 msgstr "Niet ondersteunde afbeelding hoek [ %d ] gevonden\n"
 
-#: liblepton/src/geda_picture_object.c:116
 msgid "Found an image with no filename."
 msgstr "Vond een afbeelding zonder bestandsnaam."
 
-#: liblepton/src/geda_picture_object.c:147
 #, fuzzy, c-format
 msgid "Failed to load image from embedded data [%1$s]: %2$s"
 msgstr "Laden van afbeelding uit ingesloten data faalde [%s]: %s\n"
 
-#: liblepton/src/geda_picture_object.c:148
 msgid "Base64 decoding failed."
 msgstr "Base64 decodering faalde."
 
-#: liblepton/src/geda_picture_object.c:149
 #, fuzzy
 msgid "Falling back to file loading. Picture unembedded."
 msgstr "Val terug op het laden van bestand. Afbeelding uitgevoegd.\n"
 
-#: liblepton/src/geda_picture_object.c:208
 #, fuzzy
 msgid "ERROR: o_picture_save: unable to encode the picture."
 msgstr "FOUT: o_picture_save: kan de afbeelding niet coderen.\n"
 
-#: liblepton/src/geda_picture_object.c:308
 #, fuzzy, c-format
 msgid "Failed to load buffer image [%1$s]: %2$s"
 msgstr "Laden van afbeelding [%s] uit buffer faalde: %s\n"
 
-#: liblepton/src/geda_picture_object.c:321
 #, fuzzy, c-format
 msgid "Failed to load image from [%1$s]: %2$s"
 msgstr "Laden van afbeelding uit [%s] faalde: %s\n"
 
-#: liblepton/src/geda_picture_object.c:415
 #, fuzzy, c-format
 msgid "Picture %1$p has invalid angle %2$i\n"
 msgstr "Afbeelding %p heeft een ongeldige hoek %i\n"
 
-#: liblepton/src/geda_picture_object.c:772
 #, fuzzy, c-format
 msgid "Picture [%1$s] has no image data."
 msgstr "Afbeelding [%s] heeft geen beeldinformatie.\n"
 
-#: liblepton/src/geda_picture_object.c:773
 #, fuzzy
 msgid "Falling back to file loading. Picture is still unembedded."
 msgstr ""
 "Val terug op het laden van bestand. Afbeelding is nog steeds uitgevoegd.\n"
 
-#: liblepton/src/geda_picture_object.c:781
 #, fuzzy, c-format
 msgid "Picture [%1$s] has been embedded."
 msgstr "Afbeelding [%s] is ingevoegd\n"
 
-#: liblepton/src/geda_picture_object.c:805
 #, fuzzy, c-format
 msgid "Failed to load image from file [%1$s]: %2$s"
 msgstr "Laden van afbeelding uit bestand faalde [%s]: %s\n"
 
-#: liblepton/src/geda_picture_object.c:807
 #, fuzzy
 msgid "Picture is still embedded."
 msgstr "Afbeelding is nog steeds ingevoegd.\n"
 
-#: liblepton/src/geda_picture_object.c:815
 #, fuzzy, c-format
 msgid "Picture [%1$s] has been unembedded."
 msgstr "Afbeelding [%s] is uitgevoegd\n"
 
-#: liblepton/src/geda_picture_object.c:1052
 #, fuzzy, c-format
 msgid "Failed to load fallback image %1$s: %2$s.\n"
 msgstr "Laden van afbeelding uit bestand %s faalde: %s.\n"
 
-#: liblepton/src/geda_pin_object.c:346 liblepton/src/geda_pin_object.c:354
 msgid "Failed to parse pin object"
 msgstr "Faalde bij het ontleden van een pin object"
 
-#: liblepton/src/geda_pin_object.c:360
 #, fuzzy
 msgid ""
 "Found a pin which did not have the whichend field set.\n"
@@ -673,67 +551,53 @@ msgstr ""
 "Pen gevonden die geen whichone veld ingesteld heeft.\n"
 "Verifieer en corrigeer handmatig.\n"
 
-#: liblepton/src/geda_pin_object.c:363
 #, fuzzy, c-format
 msgid "Found an invalid whichend on a pin (reseting to zero): %d"
 msgstr "Pen met een ongeldige whichend gevonden (instellen op nul): %d\n"
 
-#: liblepton/src/geda_text_object.c:495 liblepton/src/geda_text_object.c:505
-#: liblepton/src/geda_text_object.c:515
 msgid "Failed to parse text object"
 msgstr "Faalde bij het ontleden van een tekst object"
 
-#: liblepton/src/geda_text_object.c:522
 #, fuzzy, c-format
 msgid "Found an invalid text size [ %1$s ]"
 msgstr "Ongeldige kleur [ %s ] gevonden\n"
 
-#: liblepton/src/geda_text_object.c:524
 #, fuzzy, c-format
 msgid "Setting text size to %1$d."
 msgstr "Spiegelen op 0 ingesteld\n"
 
-#: liblepton/src/geda_text_object.c:528
 #, fuzzy, c-format
 msgid "Found an unsupported text angle [ %1$s ]"
 msgstr "Niet ondersteunde afbeelding hoek [ %d ] gevonden\n"
 
-#: liblepton/src/geda_text_object.c:530
 #, fuzzy, c-format
 msgid "Setting angle to %1$d."
 msgstr "Hoek op 0 ingesteld\n"
 
-#: liblepton/src/geda_text_object.c:547
 #, fuzzy, c-format
 msgid "Found an unsupported text alignment [ %1$s ]"
 msgstr "Niet ondersteunde afbeelding hoek [ %d ] gevonden\n"
 
-#: liblepton/src/geda_text_object.c:550
 #, fuzzy
 msgid "Setting alignment to LOWER_LEFT."
 msgstr "Uitlijning op LINKS_ONDER ingesteld\n"
 
-#: liblepton/src/geda_text_object.c:570
 #, fuzzy, c-format
 msgid "Unexpected end-of-file after %1$d lines"
 msgstr "Onverwacht einde-bestand na %d lijnen"
 
-#: liblepton/src/s_clib.c:460
 #, fuzzy, c-format
 msgid "Library command failed [%1$s]: %2$s"
 msgstr "Bibliotheek opdracht faalde [%s]: %s\n"
 
-#: liblepton/src/s_clib.c:465
 #, fuzzy, c-format
 msgid "Library command failed [%1$s]: Uncaught signal %2$i."
 msgstr "Bibliotheek opdracht faalde [%s]: Niet opgevangen signaal %i.\n"
 
-#: liblepton/src/s_clib.c:469
 #, fuzzy, c-format
 msgid "Library command failed [%1$s]"
 msgstr "Bibliotheek opdracht faalde [%s]\n"
 
-#: liblepton/src/s_clib.c:470
 #, fuzzy, c-format
 msgid ""
 "Error output was:\n"
@@ -742,35 +606,29 @@ msgstr ""
 "Fout uitvoer was:\n"
 "%s\n"
 
-#: liblepton/src/s_clib.c:556
 #, fuzzy, c-format
 msgid "Library name [%1$s] already in use.  Using [%2$s]."
 msgstr "Bibliotheeknaam [%s] is al in gebruik.  Gebruik nu [%s].\n"
 
-#: liblepton/src/s_clib.c:593
 #, fuzzy, c-format
 msgid "Failed to open directory [%1$s]: %2$s"
 msgstr "Openen van directory faalde [%s]: %s\n"
 
-#: liblepton/src/s_clib.c:729
 #, fuzzy, c-format
 msgid "Failed to scan library [%1$s]: Scheme function returned non-list."
 msgstr ""
 "Doorzoeken van bibliotheek [%s] faalde: Scheme functie retourneerde non-"
 "list\n"
 
-#: liblepton/src/s_clib.c:737
 #, fuzzy, c-format
 msgid "Non-string symbol name while scanning library [%1$s]"
 msgstr ""
 "Niet string symboolnaam tijdens het doorzoeken van de bibliotheek [%s]\n"
 
-#: liblepton/src/s_clib.c:893 liblepton/src/s_clib.c:940
 #, fuzzy
 msgid "Cannot add library: name not specified."
 msgstr "Kan bibliotheek niet toevoegen: naam niet gespecificeerd\n"
 
-#: liblepton/src/s_clib.c:900
 #, fuzzy, c-format
 msgid ""
 "Cannot add library [%1$s]: both 'list' and 'get' commands must be specified."
@@ -778,272 +636,210 @@ msgstr ""
 "Kan bibliotheek niet toevoegen [%s]: zowel 'list' en 'get' opdrachten moeten "
 "gespecificeerd zijn.\n"
 
-#: liblepton/src/s_clib.c:948
 #, fuzzy, c-format
 msgid "Cannot add Scheme-library [%1$s]: callbacks must be closures."
 msgstr ""
 "Kan scheme bibliotheek niet toevoegen [%s]: callbacks moeten afsluitingen "
 "zijn\n"
 
-#: liblepton/src/s_clib.c:1075
 #, fuzzy, c-format
 msgid "Failed to load symbol from file [%1$s]: %2$s"
 msgstr "Laden van symbool uit bestand faalde [%s]: %s\n"
 
-#: liblepton/src/s_clib.c:1135
 #, fuzzy, c-format
 msgid "Failed to load symbol data [%1$s] from source [%2$s]"
 msgstr "Laden van symbool gegevens [%s] uit bron [%s] faalde\n"
 
-#: liblepton/src/s_clib.c:1377
 #, fuzzy, c-format
 msgid "Component [%1$s] was not found in the component library."
 msgstr "Komponent [%s] is niet in de komponenten bibliotheek gevonden\n"
 
 # Meer dan een symbool
-#: liblepton/src/s_clib.c:1383
 #, fuzzy, c-format
 msgid "More than one component found with name [%1$s]."
 msgstr "Meer dan een komponent gevonden met de naam [%s]\n"
 
-#: liblepton/src/s_hierarchy.c:78 liblepton/src/s_hierarchy.c:240
 msgid "Schematic not found in source library."
 msgstr "Schema niet gevonden in bron bibliotheek."
 
-#: liblepton/src/s_hierarchy.c:100
 msgid "Hierarchy contains a circular dependency."
 msgstr "Hierarchie bevat een rondgaande afhankelijkheid."
 
-#: liblepton/src/s_hierarchy.c:200
 #, fuzzy
 msgid "There are no schematics above the current one!"
 msgstr "Er zijn geen schema's boven de huidige!\n"
 
-#: liblepton/src/s_hierarchy.c:341
 #, fuzzy, c-format
 msgid "Failed to descend hierarchy into '%1$s': %2$s"
 msgstr "Faalde om af te dalen in hierarchie '%s: %s\n"
 
-#: liblepton/src/s_slot.c:158
 #, fuzzy
 msgid "Did not find slotdef=#:#,#,#... attribute."
 msgstr "Geen slotdef=#:#,#,#... attribuut gevonden\n"
 
-#: liblepton/src/s_slot.c:164
 #, fuzzy
 msgid "Improper slotdef syntax: missing \":\"."
 msgstr "Goed slotdef syntax: ontbreekt \":\".\n"
 
-#: liblepton/src/s_slot.c:179
 #, fuzzy
 msgid "Did not find proper slotdef=#:#,#,#... attribute."
 msgstr "Geen goed slotdef=#:#,#,#... attribuut gevonden\n"
 
-#: liblepton/src/s_slot.c:209
 #, fuzzy
 msgid "component missing pinseq= attribute."
 msgstr "component mist een pinseq- attribuut\n"
 
-#: liblepton/src/edaconfig.c:694 liblepton/src/edaconfig.c:780
 msgid "Undefined configuration filename"
 msgstr "Ongedefinieerde configuratie bestandsnaam"
 
-#: liblepton/src/edaconfig.c:1105 liblepton/src/edaconfig.c:1169
 #, c-format
 msgid "Configuration does not have group '%s'"
 msgstr "Configuratie heeft geen groep '%s'"
 
-#: liblepton/src/edaconfig.c:1183
 #, c-format
 msgid "Configuration does not have key '%s'"
 msgstr "Configuratie heeft geen toets '%s'"
 
-#: liblepton/src/scheme_attrib.c:66 liblepton/src/scheme_attrib.c:100
 msgid "~A is not a valid attribute: invalid string '~A'."
 msgstr "~A is een ongeldige attribuut: ongeldige rij '~A'."
 
-#: liblepton/src/scheme_attrib.c:204
 msgid "Objects ~A and ~A are not part of the same page and/or complex object"
 msgstr ""
 "Objecten ~A en ~A zijn geen onderdeel van dezelfde pagina en/of complex "
 "object"
 
-#: liblepton/src/scheme_attrib.c:211 liblepton/src/scheme_attrib.c:216
 msgid "Object ~A is already attached as an attribute"
 msgstr "Object ~A is reeds bevestigd als een attribuut"
 
-#: liblepton/src/scheme_attrib.c:265
 msgid "Object ~A is attribute of wrong object"
 msgstr "Object ~A is attribuut van een fout object"
 
-#: liblepton/src/scheme_complex.c:148
 msgid "Invalid complex angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr "Ongeldige complex hoek ~A. Moet 0, 90, 180, of 270 graden zijn"
 
-#: liblepton/src/scheme_complex.c:270 liblepton/src/scheme_page.c:246
 msgid "Object ~A is already attached to something"
 msgstr "Object ~A is reeds bevestigd aan iets"
 
-#: liblepton/src/scheme_complex.c:332
 msgid "Object ~A is attached to a different complex"
 msgstr "Object ~A is bevestigd aan een andere complex"
 
-#: liblepton/src/scheme_complex.c:339
 msgid "Object ~A is attached to a page"
 msgstr "Object ~A is bevestigd aan een pagina"
 
-#: liblepton/src/scheme_complex.c:346 liblepton/src/scheme_page.c:298
 msgid "Object ~A is attached as an attribute"
 msgstr "Object ~A is bevestigd als een attribuut"
 
-#: liblepton/src/scheme_complex.c:353 liblepton/src/scheme_page.c:305
 msgid "Object ~A has attributes"
 msgstr "Object ~A heeft attributen"
 
-#: liblepton/src/scheme_object.c:234
 msgid "Object ~A has bad type '~A'"
 msgstr "Object ~A heeft een slecht type '~A'"
 
-#: liblepton/src/scheme_object.c:378
 msgid "Object ~A has invalid stroke cap style ~A"
 msgstr "Object ~A heeft een ongeldige slag cap stijl ~A"
 
-#: liblepton/src/scheme_object.c:391
 msgid "Object ~A has invalid stroke dash style ~A"
 msgstr "Object ~A heeft een ongeldige slag streep stijl ~A"
 
-#: liblepton/src/scheme_object.c:455
 msgid "Invalid stroke cap style ~A."
 msgstr "Ongeldige slag cap stijl ~A."
 
-#: liblepton/src/scheme_object.c:466
 msgid "Invalid stroke dash style ~A."
 msgstr "Ongeldige slag streep stijl ~A."
 
-#: liblepton/src/scheme_object.c:476
 msgid "Missing dash length parameter for dash style ~A."
 msgstr "Ontbrekende streeplengte parameter voor streep sijl ~A."
 
-#: liblepton/src/scheme_object.c:486
 msgid "Missing dot/dash space parameter for dash style ~A."
 msgstr "Ontbrekende punt/streep ruimte parameter voor streep stijl ~A."
 
-#: liblepton/src/scheme_object.c:554
 msgid "Object ~A has invalid fill style ~A"
 msgstr "Object ~A heeft een ongeldige opvul stijl ~A"
 
-#: liblepton/src/scheme_object.c:603
 msgid "Invalid fill style ~A."
 msgstr "Ongeldige opvul stijl ~A."
 
-#: liblepton/src/scheme_object.c:611
 msgid "Missing second space parameter for fill style ~A."
 msgstr "Ontbrekende tweede ruimte parameter voor opvul stijl ~A."
 
-#: liblepton/src/scheme_object.c:620
 msgid "Missing second angle parameter for fill style ~A."
 msgstr "Ontbrekende tweede hoek parameter voor opvul stijl ~A."
 
-#: liblepton/src/scheme_object.c:630
 msgid "Missing stroke width parameter for fill style ~A."
 msgstr "Ontbrekende slag breedte parameter voor opvul stijl ~A."
 
-#: liblepton/src/scheme_object.c:639
 msgid "Missing space parameter for fill style ~A."
 msgstr "Ontbrekende ruimte parameter voor opvul stijl ~A."
 
-#: liblepton/src/scheme_object.c:648
 msgid "Missing angle parameter for fill style ~A."
 msgstr "Ontbrekende hoek parameter voor opvul stijl ~A."
 
-#: liblepton/src/scheme_object.c:962
 msgid "Invalid pin type ~A, must be 'net or 'bus"
 msgstr "Ongeldig pen type ~A, moet een 'net of 'bus zijn"
 
-#: liblepton/src/scheme_object.c:1011
 msgid "Object ~A has invalid pin type."
 msgstr "Object ~A heeft een ongeldig pen type."
 
-#: liblepton/src/scheme_object.c:1417
 msgid "Invalid text alignment ~A."
 msgstr "Ongeldige tekst uitlijning ~A."
 
-#: liblepton/src/scheme_object.c:1433
 msgid "Invalid text angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr "Ongeldige tekst hoek ~A. moet 0, 90, 180, of 270 graden zijn"
 
-#: liblepton/src/scheme_object.c:1452
 msgid "Invalid text name/value visibility ~A."
 msgstr "Ongeldige tekst naam/waarde zichtbaarheid ~A."
 
-#: liblepton/src/scheme_object.c:1526
 msgid "Text object ~A has invalid text alignment ~A"
 msgstr "Tekst object ~A heeft een ongeldige tekst uitlijning ~A"
 
-#: liblepton/src/scheme_object.c:1535
 msgid "Text object ~A has invalid visibility ~A"
 msgstr "Tekst object ~A heeft een ongeldige zichtbaarheid ~A"
 
-#: liblepton/src/scheme_object.c:1545
 msgid "Text object ~A has invalid text attribute visibility ~A"
 msgstr "Tekst object ~A heeft een ongeldige tekst attribuut zichtbaarheid ~A"
 
-#: liblepton/src/scheme_object.c:1586
 msgid "Object ~A is not included in a page."
 msgstr "Object ~A is niet opgenomen in een pagina."
 
-#: liblepton/src/scheme_object.c:1739
 msgid "Path object ~A has invalid element type ~A at index ~A"
 msgstr "Pad object ~A heeft een ongeldige element type ~A bij index ~A"
 
-#: liblepton/src/scheme_object.c:1853
 msgid "Invalid path element type ~A."
 msgstr "Ongeldig pad element type ~A."
 
-#: liblepton/src/scheme_object.c:2025
 msgid "Invalid picture angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr "Ongeldige afbeelding hoek ~A. Moet 0, 90, 180, of 270 graden zijn"
 
-#: liblepton/src/scheme_page.c:291
 msgid "Object ~A is attached to a complex or different page"
 msgstr "Object ~A is bevestigd aan een complex of een andere pagina"
 
-#: liblepton/src/scheme_page.c:438
 msgid "Parse error: ~s"
 msgstr "Ontleedfout: ~s"
 
-#: liblepton/src/edascmhookproxy.c:83
 msgid "Scheme hook"
 msgstr "Scheme haak"
 
-#: liblepton/src/edascmhookproxy.c:84
 msgid "The Scheme-level hook to proxy"
 msgstr "De Scheme-level haak naar proxy"
 
-#: liblepton/scheme/geda/attrib.scm:56
 #, scheme-format
 msgid "Object ~A is not part of a page"
 msgstr "Object ~A is geen deel van een pagina"
 
-#: liblepton/scheme/geda/library.scm:108
 #, fuzzy, scheme-format
 msgid "Invalid path ~S or source not readable.\n"
 msgstr "Ongeldig pad [%s] overgedragen aan source-library\n"
 
-#: liblepton/scheme/geda/library.scm:109
 msgid "Source library path must be a string.\n"
 msgstr ""
 
-#: liblepton/scheme/geda/library.scm:168
 #, fuzzy, scheme-format
 msgid "File ~S is not readable.\n"
 msgstr "Bestand %s is alleen-lezen"
 
-#: liblepton/scheme/geda/repl.scm:48
 msgid "Welcome to Lepton REPL!\n"
 msgstr ""
 
-#: liblepton/scheme/geda/repl.scm:53
 msgid "WARNING: Readline library is not supported in your configuration.\n"
 msgstr ""
 

--- a/liblepton/po/pl.po
+++ b/liblepton/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-12 00:08+0300\n"
+"POT-Creation-Date: 2019-05-13 11:16+0300\n"
 "PO-Revision-Date: 2010-02-06 22:09+0000\n"
 "Last-Translator: Jarosław Ogrodnik <nobodythere@gmail.com>\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -18,46 +18,37 @@ msgstr ""
 "X-Launchpad-Export-Date: 2010-02-14 12:56+0000\n"
 "X-Generator: Launchpad (build Unknown)\n"
 
-#: liblepton/data/liblepton.xml.in:3
 #, fuzzy
 msgid "Lepton EDA circuit schematic"
 msgstr "schemat obwodu gEDA"
 
-#: liblepton/data/liblepton.xml.in:4
 #, fuzzy
 msgid "Lepton EDA schematic symbol"
 msgstr "element schematu gEDA"
 
-#: liblepton/data/liblepton.xml.in:5
 #, fuzzy
 msgid "Lepton EDA sch2pcb project"
 msgstr "projekt gsch2pcb gEDA"
 
-#: liblepton/data/x-lepton-sch2pcb-project.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA sch2pcb Project"
 msgstr "Projekt Gsch2pcb gEDA"
 
-#: liblepton/data/x-lepton-schematic.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Circuit Schematic"
 msgstr "Schemat Obwodu gEDA"
 
-#: liblepton/data/x-lepton-symbol.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Schematic Symbol"
 msgstr "Element Schematu gEDA"
 
-#: liblepton/src/a_basic.c:57 liblepton/src/f_basic.c:377
 #, c-format
 msgid "File %1$s is read-only"
 msgstr ""
 
-#: liblepton/src/a_basic.c:114
 msgid "Schematic data was not valid UTF-8"
 msgstr ""
 
-#: liblepton/src/a_basic.c:246
 #, fuzzy, c-format
 msgid ""
 "Read unexpected attach symbol start marker in [%1$s] :\n"
@@ -68,7 +59,6 @@ msgstr ""
 ">>\n"
 "%s<<\n"
 
-#: liblepton/src/a_basic.c:263
 #, fuzzy, c-format
 msgid ""
 "Read unexpected embedded symbol start marker in [%1$s] :\n"
@@ -79,7 +69,6 @@ msgstr ""
 ">>\n"
 "%s<<\n"
 
-#: liblepton/src/a_basic.c:294
 #, c-format
 msgid ""
 "Read unexpected embedded symbol end marker in [%s] :\n"
@@ -90,7 +79,6 @@ msgstr ""
 ">>\n"
 "%s<<\n"
 
-#: liblepton/src/a_basic.c:329
 #, fuzzy, c-format
 msgid ""
 "Read an old format sym/sch file!\n"
@@ -101,7 +89,6 @@ msgstr ""
 "Uruchom program gsymupdate/gschemupdate na pliku:\n"
 "[%s]\n"
 
-#: liblepton/src/a_basic.c:335
 #, fuzzy, c-format
 msgid ""
 "Read garbage in [%1$s] :\n"
@@ -112,17 +99,14 @@ msgstr ""
 ">>\n"
 "%s<<\n"
 
-#: liblepton/src/f_basic.c:119 liblepton/src/f_basic.c:132
 #, fuzzy, c-format
 msgid "Failed to stat [%1$s]: %2$s"
 msgstr "Błąd odczytu atrybutów [%s]: %s"
 
-#: liblepton/src/f_basic.c:211
 #, fuzzy, c-format
 msgid "Cannot find file %1$s: %2$s"
 msgstr "Nie odnaleziono pliku %s: %s"
 
-#: liblepton/src/f_basic.c:260
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -135,12 +119,10 @@ msgstr ""
 "  %s.\n"
 "\n"
 
-#: liblepton/src/f_basic.c:262
 msgid "I could not guess if it is newer, so you have to do it manually.\n"
 msgstr ""
 "Nie można stwierdzić, czy kopia jest nowsza - musisz sprawdzić to ręcznie.\n"
 
-#: liblepton/src/f_basic.c:264
 msgid ""
 "The backup copy is newer than the schematic, so it seems you should load it "
 "instead of the original file.\n"
@@ -148,7 +130,6 @@ msgstr ""
 "Kopia zapasowa jest nowsza niż plik schematu, a więc powinieneś otworzyć "
 "kopię zamiast oryginalnego pliku.\n"
 
-#: liblepton/src/f_basic.c:266
 #, fuzzy
 msgid ""
 "lepton-schematic usually makes backup copies automatically, and this "
@@ -157,7 +138,6 @@ msgstr ""
 "Gschem tworzy kopie zapasowe automatycznie, a ta sytuacja może być wynikiem "
 "niepoprawnego zamknięcia programu, np. z powodu błędu.\n"
 
-#: liblepton/src/f_basic.c:269
 #, fuzzy
 msgid ""
 "\n"
@@ -168,234 +148,179 @@ msgstr ""
 "Uruchom gschem i napraw plik ręcznie.\n"
 "\n"
 
-#: liblepton/src/f_basic.c:367
 #, fuzzy, c-format
 msgid "Can't get the real filename of %1$s: %2$s"
 msgstr "Nie można odczytać rzeczywistej nazwy %s."
 
-#: liblepton/src/f_basic.c:398
 #, fuzzy, c-format
 msgid "Could NOT set previous backup file [%1$s] read-write."
 msgstr "Nie można ustawić pliku kopii zapasowej w tryb zapisu i odczytu [%s]\n"
 
-#: liblepton/src/f_basic.c:404
 #, fuzzy, c-format
 msgid "Can't save backup file: %1$s."
 msgstr "Nie można zapisać kopii zapasowej: %s."
 
-#: liblepton/src/f_basic.c:414
 #, fuzzy, c-format
 msgid "Could NOT set backup file [%1$s] readonly."
 msgstr ""
 "Nie można ustawić pliku kopii zapasowej w tryb tylko do odczytu [%s].\n"
 
-#: liblepton/src/f_basic.c:463
 #, fuzzy, c-format
 msgid "Failed to restore permissions on '%1$s': %2$s\n"
 msgstr "Błąd otwarcia katalogu [%s]: %s\n"
 
-#: liblepton/src/f_basic.c:468
 #, fuzzy, c-format
 msgid "Failed to restore ownership on '%1$s': %2$s\n"
 msgstr "Błąd otwarcia katalogu [%s]: %s\n"
 
-#: liblepton/src/f_basic.c:478
 #, fuzzy, c-format
 msgid "Could NOT save file: %1$s"
 msgstr "Nie można zapisać [%s]\n"
 
-#: liblepton/src/f_basic.c:604
 #, c-format
 msgid "%s: %s"
 msgstr "%s: %s"
 
-#: liblepton/src/g_basic.c:260
 msgid ""
 "\n"
 "Backtrace:\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:99
 #, fuzzy, c-format
 msgid "Invalid mode [%1$s] passed to %2$s\n"
 msgstr "Nie odnaleziono komponentu [%s] w bibliotece komponentów\n"
 
-#: liblepton/src/g_rc.c:139
 #, fuzzy
 msgid "RC file already loaded"
 msgstr "plik RC [%s] został już wczytany.\n"
 
-#: liblepton/src/g_rc.c:183
 #, fuzzy, c-format
 msgid "Failed to load config from '%1$s': %2$s\n"
 msgstr "Błąd odczytu obrazka z pliku [%s]: %s\n"
 
-#: liblepton/src/g_rc.c:207
 #, fuzzy, c-format
 msgid "Loaded RC file [%1$s]"
 msgstr "Wczytano podany plik %s [%%s]\n"
 
-#: liblepton/src/g_rc.c:211
 #, fuzzy, c-format
 msgid "Failed to load RC file [%1$s]: "
 msgstr "Błąd odczytu obrazka z pliku [%s]: %s\n"
 
-#: liblepton/src/g_rc.c:341
 msgid "ERROR: An unknown error occurred while parsing configuration files."
 msgstr ""
 
-#: liblepton/src/g_rc.c:353
 #, c-format
 msgid "ERROR: %1$s"
 msgstr ""
 
-#: liblepton/src/g_rc.c:354
 #, c-format
 msgid "ERROR: %1$s\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:360
 #, c-format
 msgid "ERROR: The %1$s log may contain more information.\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:512
 #, fuzzy, c-format
 msgid "Invalid path [%1$s] passed to component-library\n"
 msgstr "Nie odnaleziono komponentu [%s] w bibliotece komponentów\n"
 
-#: liblepton/src/g_rc.c:738
 #, fuzzy, c-format
 msgid "Invalid path [%1$s] passed to bitmap-directory\n"
 msgstr "Nie odnaleziono komponentu [%s] w bibliotece komponentów\n"
 
-#: liblepton/src/geda_page.c:197
 #, fuzzy, c-format
 msgid "s_page_delete: Can't get the real filename of %1$s."
 msgstr "s_page_delete: nie można uzyskać rzeczywistej nazwy pliku %s."
 
-#: liblepton/src/geda_page.c:208
 #, fuzzy, c-format
 msgid "s_page_delete: Unable to delete backup file %1$s."
 msgstr "s_page_delete: Nie można skasować kopii zapasowej %s."
 
-#: liblepton/src/geda_page.c:490
 #, fuzzy, c-format
 msgid "Saved [%1$s]"
 msgstr "Zapisano [%s]\n"
 
-#: liblepton/src/geda_page.c:496
 #, fuzzy, c-format
 msgid "Could NOT save [%1$s]"
 msgstr "Nie można zapisać [%s]\n"
 
-#: liblepton/src/geda_arc_object.c:408 liblepton/src/geda_arc_object.c:421
 msgid "Failed to parse arc object"
 msgstr ""
 
-#: liblepton/src/geda_arc_object.c:428
 #, fuzzy, c-format
 msgid "Found a zero radius arc [ %1$c %2$d, %3$d, %4$d, %5$d, %6$d, %7$d ]"
 msgstr "Napotkano łuk o zerowym promieniu [ %c %d, %d, %d, %d, %d, %d ]\n"
 
-#: liblepton/src/geda_arc_object.c:435 liblepton/src/geda_box_object.c:328
-#: liblepton/src/geda_bus_object.c:364 liblepton/src/geda_circle_object.c:387
-#: liblepton/src/geda_line_object.c:427 liblepton/src/geda_net_object.c:308
-#: liblepton/src/geda_path_object.c:214 liblepton/src/geda_pin_object.c:369
-#: liblepton/src/geda_text_object.c:555
 #, fuzzy, c-format
 msgid "Found an invalid color [ %1$s ]"
 msgstr "Napotkano niepoprawny kolor [ %s ]\n"
 
-#: liblepton/src/geda_arc_object.c:436 liblepton/src/geda_box_object.c:329
-#: liblepton/src/geda_bus_object.c:365 liblepton/src/geda_circle_object.c:388
-#: liblepton/src/geda_line_object.c:428 liblepton/src/geda_net_object.c:309
-#: liblepton/src/geda_path_object.c:215 liblepton/src/geda_pin_object.c:370
-#: liblepton/src/geda_text_object.c:557
 #, fuzzy
 msgid "Setting color to default color."
 msgstr "Użyję domyślnego koloru\n"
 
-#: liblepton/src/o_attrib.c:111
 #, c-format
 msgid "Attribute [%1$s] already attached\n"
 msgstr ""
 
-#: liblepton/src/o_attrib.c:117
 msgid "Attempt to attach non text item as an attribute!\n"
 msgstr "Próba użycia innego obiektu niż tekst jako atrybut!\n"
 
-#: liblepton/src/o_attrib.c:122
 #, fuzzy, c-format
 msgid "Attempt to attach attribute [%1$s] to more than one object\n"
 msgstr "Próba powiązania atrybutu [%s] z więcej niż jednym obiektem\n"
 
-#: liblepton/src/o_attrib.c:325
 #, fuzzy
 msgid "Tried to attach a non-text item as an attribute"
 msgstr "Próba użycia innego obiektu niż tekst jako atrybut!\n"
 
-#: liblepton/src/o_attrib.c:332
 msgid "Unexpected end-of-file in attribute list"
 msgstr ""
 
-#: liblepton/src/geda_box_object.c:287 liblepton/src/geda_box_object.c:316
 msgid "Failed to parse box object"
 msgstr ""
 
-#: liblepton/src/geda_box_object.c:322
 #, fuzzy, c-format
 msgid "Found a zero width/height box [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr ""
 "Napotkano prostokąt o zerowej wysokości/szerokości [ %c %d %d %d %d %d ]\n"
 
-#: liblepton/src/geda_bus_object.c:345 liblepton/src/geda_bus_object.c:352
 msgid "Failed to parse bus object"
 msgstr ""
 
-#: liblepton/src/geda_bus_object.c:358
 #, fuzzy, c-format
 msgid "Found a zero length bus [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr "Napotkano magistralę o zerowej długości [ %c %d %d %d %d %d ]\n"
 
-#: liblepton/src/geda_bus_object.c:370
 #, fuzzy, c-format
 msgid "Found an invalid bus ripper direction [ %1$s ]"
 msgstr "Napotkano odczep magistrali z błędnym ustawieniem kierunku [ %s ]\n"
 
-#: liblepton/src/geda_bus_object.c:371
 #, fuzzy
 msgid "Resetting direction to neutral (no direction)."
 msgstr "Ustawię kierunek na neutralny (brak kierunku)\n"
 
-#: liblepton/src/geda_circle_object.c:343
-#: liblepton/src/geda_circle_object.c:372
 msgid "Failed to parse circle object"
 msgstr ""
 
-#: liblepton/src/geda_circle_object.c:379
 #, fuzzy, c-format
 msgid "Found a zero or negative radius circle [ %1$c %2$d %3$d %4$d %5$d ]"
 msgstr "Napotkano koło o zerowym promieniu [ %c %d %d %d %d ]\n"
 
-#: liblepton/src/geda_circle_object.c:382
 #, fuzzy
 msgid "Setting radius to 0."
 msgstr "Użyję nachylenia równego 0\n"
 
-#: liblepton/src/geda_color.c:217
 msgid "Color map entry must be a two-element list"
 msgstr "Wpis w mapie kolorów musi być dwuelementową listą"
 
-#: liblepton/src/geda_color.c:225
 msgid "Index in color map entry must be an integer"
 msgstr "Indeks koloru musi być liczbą całkowitą"
 
-#: liblepton/src/geda_color.c:251
 msgid "Value in color map entry must be #f or a string"
 msgstr "Wpis w mapie kolorów musi być wartością #f lub napisem"
 
-#: liblepton/src/geda_complex_object.c:373
 #, fuzzy, c-format
 msgid ""
 "Component not found:\n"
@@ -404,11 +329,9 @@ msgstr ""
 "Nie odnaleziono komponentu:\n"
 " %s"
 
-#: liblepton/src/geda_complex_object.c:585
 msgid "Failed to parse complex object"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:598
 #, fuzzy, c-format
 msgid ""
 "Found a component with an invalid rotation [ %1$c %2$d %3$d %4$d %5$d %6$d "
@@ -416,13 +339,10 @@ msgid ""
 msgstr ""
 "Napotkano komponent o błędnej specyfikacji rotacji [ %c %d %d %d %d %d %s ]\n"
 
-#: liblepton/src/geda_complex_object.c:601
-#: liblepton/src/geda_picture_object.c:105
 #, fuzzy
 msgid "Setting angle to 0."
 msgstr "Użyję nachylenia równego 0\n"
 
-#: liblepton/src/geda_complex_object.c:613
 #, fuzzy, c-format
 msgid ""
 "Found a component with an invalid mirror flag [ %1$c %2$d %3$d %4$d %5$d "
@@ -431,12 +351,10 @@ msgstr ""
 "Napotkano komponent z nieprawidłową wartością flagi odbicia lustrzanego [ %c "
 "%d %d %d %d %d %s ]\n"
 
-#: liblepton/src/geda_complex_object.c:616
 #, fuzzy
 msgid "Setting mirror to 0."
 msgstr "Przyjmuję 'odbity' równe 0\n"
 
-#: liblepton/src/geda_complex_object.c:941
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
@@ -445,7 +363,6 @@ msgstr ""
 "UWAGA: Błąd parsowania wersji symbolu o identyfikatorze %s:\n"
 "\tNiepowodzenie podczas parsowania pliku symbolu symversion=%s\n"
 
-#: liblepton/src/geda_complex_object.c:945
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
@@ -454,7 +371,6 @@ msgstr ""
 "UWAGA: Błąd parsowania wersji symbolu o identyfikatorze %s:\n"
 "\tNiepowodzenie podczas parsowania pliku symbolu symversion=\n"
 
-#: liblepton/src/geda_complex_object.c:961
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
@@ -463,7 +379,6 @@ msgstr ""
 "UWAGA: Błąd parsowania wersji symbolu o identyfikatorze %s:\n"
 "\tNiepowodzenie podczas parsowania dołączonego atrybutu symversion=%s\n"
 
-#: liblepton/src/geda_complex_object.c:986
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version oddity on refdes %1$s:\n"
@@ -474,7 +389,6 @@ msgstr ""
 "\tAtrybut symversion=%s dołączony do symbolu, ale brak atrybutu symversion= "
 "w pliku symbolu\n"
 
-#: liblepton/src/geda_complex_object.c:1000
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version mismatch on refdes %1$s (%2$s):\n"
@@ -483,17 +397,14 @@ msgstr ""
 "UWAGA: Niezgodność wersji symbolu o identyfikatorze %s (%s):\n"
 "\tWersja symbolu w bibliotece jest nowsza niż wersja tej instancji symbolu\n"
 
-#: liblepton/src/geda_complex_object.c:1028
 #, fuzzy, c-format
 msgid "\tMAJOR VERSION CHANGE (file %1$.3f, instantiated %2$.3f, %3$s)!"
 msgstr "\tZNACZĄCA ZMIANA WERSJI (plik %.3f, użyto %.3f, %s)!\n"
 
-#: liblepton/src/geda_complex_object.c:1046
 #, fuzzy, c-format
 msgid "\tMinor version change (file %1$.3f, instantiated %2$.3f)"
 msgstr "\tPomniejsza zmiana wersji (plik %.3f, użyto %.3f)\n"
 
-#: liblepton/src/geda_complex_object.c:1057
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version oddity on refdes %1$s:\n"
@@ -502,12 +413,10 @@ msgstr ""
 "UWAGA: Dziwna wersja symbolu o identyfikatorze %s:\n"
 "\tWersja symbolu w bibliotece jest nowsza niż wersja tej instancji symbolu\n"
 
-#: liblepton/src/o_embed.c:54
 #, fuzzy, c-format
 msgid "Component [%1$s] has been embedded."
 msgstr "Osadzono komponent [%s]\n"
 
-#: liblepton/src/o_embed.c:98
 #, fuzzy, c-format
 msgid ""
 "Could not find component [%1$s], while trying to unembed. Component is still "
@@ -516,149 +425,118 @@ msgstr ""
 "Nie odnaleziono komponentu [%s] podczas próby usunięcia osadzenia. Komponent "
 "pozostanie osadzony\n"
 
-#: liblepton/src/o_embed.c:106
 #, fuzzy, c-format
 msgid "Component [%1$s] has been successfully unembedded."
 msgstr "Komponent [%s] nie jest już osadzony\n"
 
-#: liblepton/src/geda_line_object.c:391 liblepton/src/geda_line_object.c:409
 msgid "Failed to parse line object"
 msgstr ""
 
-#: liblepton/src/geda_line_object.c:421
 #, fuzzy, c-format
 msgid "Found a zero length line [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr "Napotkano linię o zerowej długości [ %c %d %d %d %d %d ]\n"
 
-#: liblepton/src/geda_net_object.c:297
 msgid "Failed to parse net object"
 msgstr ""
 
-#: liblepton/src/geda_net_object.c:302
 #, fuzzy, c-format
 msgid "Found a zero length net [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr "Napotkano połączenie o zerowej długości [ %c %d %d %d %d %d ]\n"
 
-#: liblepton/src/geda_path_object.c:206
 msgid "Failed to parse path object"
 msgstr ""
 
-#: liblepton/src/geda_path_object.c:232
 msgid "Unexpected end-of-file when reading path"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:71
 msgid "Failed to parse picture definition"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:76
 #, fuzzy, c-format
 msgid "Found a zero width/height picture [ %1$c %2$d %3$d %4$d %5$d ]"
 msgstr "Napotkano obrazek o zerowej wysokości/szerokości [ %c %d %d %d %d ]\n"
 
-#: liblepton/src/geda_picture_object.c:82
 #, fuzzy, c-format
 msgid "Found a picture with a wrong 'mirrored' parameter: %1$d."
 msgstr "Napotkano obrazek o niepoprawnej wartości 'odbity': %c.\n"
 
-#: liblepton/src/geda_picture_object.c:84
 #, fuzzy
 msgid "Setting mirrored to 0."
 msgstr "Przyjmuję 'odbity' równe 0\n"
 
-#: liblepton/src/geda_picture_object.c:89
 #, fuzzy, c-format
 msgid "Found a picture with a wrong 'embedded' parameter: %1$d."
 msgstr "Napotkano obrazek o niepoprawnej wartości 'osadzony': %c.\n"
 
-#: liblepton/src/geda_picture_object.c:91
 #, fuzzy
 msgid "Setting embedded to 0."
 msgstr "Przyjmuję 'osadzony' równe 0\n"
 
-#: liblepton/src/geda_picture_object.c:104
 #, fuzzy, c-format
 msgid "Found an unsupported picture angle [ %1$d ]"
 msgstr "Napotkano obrazek z nieprawidłową wartością nachylenia [ %d ]\n"
 
-#: liblepton/src/geda_picture_object.c:116
 msgid "Found an image with no filename."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:147
 #, fuzzy, c-format
 msgid "Failed to load image from embedded data [%1$s]: %2$s"
 msgstr "Błąd odczytu obrazka z osadzonych danych [%s]: %s\n"
 
-#: liblepton/src/geda_picture_object.c:148
 msgid "Base64 decoding failed."
 msgstr "Błąd dekodowania Base64."
 
-#: liblepton/src/geda_picture_object.c:149
 #, fuzzy
 msgid "Falling back to file loading. Picture unembedded."
 msgstr "Spróbuję odczytać obrazek z pliku. Obrazek nie będzie osadzony.\n"
 
-#: liblepton/src/geda_picture_object.c:208
 #, fuzzy
 msgid "ERROR: o_picture_save: unable to encode the picture."
 msgstr "BŁĄD: o_picture_save: nie można zapisać obrazka.\n"
 
-#: liblepton/src/geda_picture_object.c:308
 #, fuzzy, c-format
 msgid "Failed to load buffer image [%1$s]: %2$s"
 msgstr "Błąd podczas ładowania symbolu z pliku [%s]: %s\n"
 
-#: liblepton/src/geda_picture_object.c:321
 #, fuzzy, c-format
 msgid "Failed to load image from [%1$s]: %2$s"
 msgstr "Błąd odczytu obrazka z pliku [%s]: %s\n"
 
-#: liblepton/src/geda_picture_object.c:415
 #, fuzzy, c-format
 msgid "Picture %1$p has invalid angle %2$i\n"
 msgstr "Obrazek [%s] został osadzony\n"
 
-#: liblepton/src/geda_picture_object.c:772
 #, fuzzy, c-format
 msgid "Picture [%1$s] has no image data."
 msgstr "Obrazek [%s] został osadzony\n"
 
-#: liblepton/src/geda_picture_object.c:773
 #, fuzzy
 msgid "Falling back to file loading. Picture is still unembedded."
 msgstr "Spróbuję odczytać obrazek z pliku. Obrazek nie będzie osadzony.\n"
 
-#: liblepton/src/geda_picture_object.c:781
 #, fuzzy, c-format
 msgid "Picture [%1$s] has been embedded."
 msgstr "Obrazek [%s] został osadzony\n"
 
-#: liblepton/src/geda_picture_object.c:805
 #, fuzzy, c-format
 msgid "Failed to load image from file [%1$s]: %2$s"
 msgstr "Błąd odczytu obrazka z pliku [%s]: %s\n"
 
-#: liblepton/src/geda_picture_object.c:807
 #, fuzzy
 msgid "Picture is still embedded."
 msgstr "Obrazek [%s] został osadzony\n"
 
-#: liblepton/src/geda_picture_object.c:815
 #, fuzzy, c-format
 msgid "Picture [%1$s] has been unembedded."
 msgstr "Obrazek [%s] nie jest już osadzony\n"
 
-#: liblepton/src/geda_picture_object.c:1052
 #, fuzzy, c-format
 msgid "Failed to load fallback image %1$s: %2$s.\n"
 msgstr "Błąd odczytu obrazka z pliku [%s]: %s\n"
 
-#: liblepton/src/geda_pin_object.c:346 liblepton/src/geda_pin_object.c:354
 msgid "Failed to parse pin object"
 msgstr ""
 
-#: liblepton/src/geda_pin_object.c:360
 #, fuzzy
 msgid ""
 "Found a pin which did not have the whichend field set.\n"
@@ -667,69 +545,55 @@ msgstr ""
 "Napotkano pin bez ustawionego pola 'whichone'.\n"
 "Popraw plik manualnie.\n"
 
-#: liblepton/src/geda_pin_object.c:363
 #, fuzzy, c-format
 msgid "Found an invalid whichend on a pin (reseting to zero): %d"
 msgstr ""
 "Napotkano nieprawidłową wartość 'whichend' przypisaną do pinu (użyję "
 "wartości 0): %d\n"
 
-#: liblepton/src/geda_text_object.c:495 liblepton/src/geda_text_object.c:505
-#: liblepton/src/geda_text_object.c:515
 msgid "Failed to parse text object"
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:522
 #, fuzzy, c-format
 msgid "Found an invalid text size [ %1$s ]"
 msgstr "Napotkano niepoprawny kolor [ %s ]\n"
 
-#: liblepton/src/geda_text_object.c:524
 #, fuzzy, c-format
 msgid "Setting text size to %1$d."
 msgstr "Przyjmuję 'odbity' równe 0\n"
 
-#: liblepton/src/geda_text_object.c:528
 #, fuzzy, c-format
 msgid "Found an unsupported text angle [ %1$s ]"
 msgstr "Napotkano obrazek z nieprawidłową wartością nachylenia [ %d ]\n"
 
-#: liblepton/src/geda_text_object.c:530
 #, fuzzy, c-format
 msgid "Setting angle to %1$d."
 msgstr "Użyję nachylenia równego 0\n"
 
-#: liblepton/src/geda_text_object.c:547
 #, fuzzy, c-format
 msgid "Found an unsupported text alignment [ %1$s ]"
 msgstr "Napotkano obrazek z nieprawidłową wartością nachylenia [ %d ]\n"
 
-#: liblepton/src/geda_text_object.c:550
 #, fuzzy
 msgid "Setting alignment to LOWER_LEFT."
 msgstr "Użyję wyrównania do dolnego lewego rogu\n"
 
-#: liblepton/src/geda_text_object.c:570
 #, c-format
 msgid "Unexpected end-of-file after %1$d lines"
 msgstr ""
 
-#: liblepton/src/s_clib.c:460
 #, fuzzy, c-format
 msgid "Library command failed [%1$s]: %2$s"
 msgstr "Błąd operacji w bibliotece [%s]: %s\n"
 
-#: liblepton/src/s_clib.c:465
 #, fuzzy, c-format
 msgid "Library command failed [%1$s]: Uncaught signal %2$i."
 msgstr "Błąd operacji w bibliotece [%s]: Nieobsługiwany sygnał %i.\n"
 
-#: liblepton/src/s_clib.c:469
 #, fuzzy, c-format
 msgid "Library command failed [%1$s]"
 msgstr "Błąd operacji w bibliotece [%s]\n"
 
-#: liblepton/src/s_clib.c:470
 #, fuzzy, c-format
 msgid ""
 "Error output was:\n"
@@ -738,302 +602,234 @@ msgstr ""
 "Komunikat o błędzie:\n"
 "%s\n"
 
-#: liblepton/src/s_clib.c:556
 #, fuzzy, c-format
 msgid "Library name [%1$s] already in use.  Using [%2$s]."
 msgstr "Nazwa biblioteki [%s] jest już zajęta.  Użyję [%s].\n"
 
-#: liblepton/src/s_clib.c:593
 #, fuzzy, c-format
 msgid "Failed to open directory [%1$s]: %2$s"
 msgstr "Błąd otwarcia katalogu [%s]: %s\n"
 
-#: liblepton/src/s_clib.c:729
 #, fuzzy, c-format
 msgid "Failed to scan library [%1$s]: Scheme function returned non-list."
 msgstr ""
 "Błąd przeszukiwania biblioteki [%s]: funkcja Scheme zwróciła nie-listę\n"
 
-#: liblepton/src/s_clib.c:737
 #, fuzzy, c-format
 msgid "Non-string symbol name while scanning library [%1$s]"
 msgstr ""
 "Napotkano niepoprawną nazwę symbolu podczas przeszukiwania biblioteki [%s]\n"
 
-#: liblepton/src/s_clib.c:893 liblepton/src/s_clib.c:940
 #, fuzzy
 msgid "Cannot add library: name not specified."
 msgstr "Nie można dodać biblioteki: nie podano nazwy\n"
 
-#: liblepton/src/s_clib.c:900
 #, fuzzy, c-format
 msgid ""
 "Cannot add library [%1$s]: both 'list' and 'get' commands must be specified."
 msgstr ""
 "Nie można dodać biblioteki [%s]: komendy 'list' i 'get' muszą być podane\n"
 
-#: liblepton/src/s_clib.c:948
 #, fuzzy, c-format
 msgid "Cannot add Scheme-library [%1$s]: callbacks must be closures."
 msgstr "Nie można dodać biblioteki Scheme [%s]: callbacks must be closures\n"
 
-#: liblepton/src/s_clib.c:1075
 #, fuzzy, c-format
 msgid "Failed to load symbol from file [%1$s]: %2$s"
 msgstr "Błąd podczas ładowania symbolu z pliku [%s]: %s\n"
 
-#: liblepton/src/s_clib.c:1135
 #, fuzzy, c-format
 msgid "Failed to load symbol data [%1$s] from source [%2$s]"
 msgstr "Odczyt danych symbolu [%s] z pliku [%s] nie powiódł się\n"
 
-#: liblepton/src/s_clib.c:1377
 #, fuzzy, c-format
 msgid "Component [%1$s] was not found in the component library."
 msgstr "Nie odnaleziono komponentu [%s] w bibliotece komponentów\n"
 
-#: liblepton/src/s_clib.c:1383
 #, fuzzy, c-format
 msgid "More than one component found with name [%1$s]."
 msgstr "Odnaleziono więcej niż jeden komponent o nazwie [%s]\n"
 
-#: liblepton/src/s_hierarchy.c:78 liblepton/src/s_hierarchy.c:240
 msgid "Schematic not found in source library."
 msgstr ""
 
-#: liblepton/src/s_hierarchy.c:100
 msgid "Hierarchy contains a circular dependency."
 msgstr ""
 
-#: liblepton/src/s_hierarchy.c:200
 #, fuzzy
 msgid "There are no schematics above the current one!"
 msgstr "Jesteś już na szczycie hierarchii schematów!\n"
 
-#: liblepton/src/s_hierarchy.c:341
 #, fuzzy, c-format
 msgid "Failed to descend hierarchy into '%1$s': %2$s"
 msgstr "Błąd otwarcia katalogu [%s]: %s\n"
 
-#: liblepton/src/s_slot.c:158
 #, fuzzy
 msgid "Did not find slotdef=#:#,#,#... attribute."
 msgstr "Nie odnaleziono atrybutu slotdef=#:#,#,#...\n"
 
-#: liblepton/src/s_slot.c:164
 #, fuzzy
 msgid "Improper slotdef syntax: missing \":\"."
 msgstr "Błąd składni atrybutu slotdef: brak \":\".\n"
 
-#: liblepton/src/s_slot.c:179
 #, fuzzy
 msgid "Did not find proper slotdef=#:#,#,#... attribute."
 msgstr "Nie odnaleziono atrybutu slotdef=#:#,#,#...\n"
 
-#: liblepton/src/s_slot.c:209
 #, fuzzy
 msgid "component missing pinseq= attribute."
 msgstr "komponent nie ma atrybutu pinseq=\n"
 
-#: liblepton/src/edaconfig.c:694 liblepton/src/edaconfig.c:780
 msgid "Undefined configuration filename"
 msgstr ""
 
-#: liblepton/src/edaconfig.c:1105 liblepton/src/edaconfig.c:1169
 #, c-format
 msgid "Configuration does not have group '%s'"
 msgstr ""
 
-#: liblepton/src/edaconfig.c:1183
 #, c-format
 msgid "Configuration does not have key '%s'"
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:66 liblepton/src/scheme_attrib.c:100
 msgid "~A is not a valid attribute: invalid string '~A'."
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:204
 msgid "Objects ~A and ~A are not part of the same page and/or complex object"
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:211 liblepton/src/scheme_attrib.c:216
 msgid "Object ~A is already attached as an attribute"
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:265
 msgid "Object ~A is attribute of wrong object"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:148
 msgid "Invalid complex angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:270 liblepton/src/scheme_page.c:246
 msgid "Object ~A is already attached to something"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:332
 msgid "Object ~A is attached to a different complex"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:339
 msgid "Object ~A is attached to a page"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:346 liblepton/src/scheme_page.c:298
 #, fuzzy
 msgid "Object ~A is attached as an attribute"
 msgstr "Próba użycia innego obiektu niż tekst jako atrybut!\n"
 
-#: liblepton/src/scheme_complex.c:353 liblepton/src/scheme_page.c:305
 msgid "Object ~A has attributes"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:234
 msgid "Object ~A has bad type '~A'"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:378
 msgid "Object ~A has invalid stroke cap style ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:391
 msgid "Object ~A has invalid stroke dash style ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:455
 msgid "Invalid stroke cap style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:466
 msgid "Invalid stroke dash style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:476
 msgid "Missing dash length parameter for dash style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:486
 msgid "Missing dot/dash space parameter for dash style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:554
 msgid "Object ~A has invalid fill style ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:603
 msgid "Invalid fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:611
 msgid "Missing second space parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:620
 msgid "Missing second angle parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:630
 msgid "Missing stroke width parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:639
 msgid "Missing space parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:648
 msgid "Missing angle parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:962
 msgid "Invalid pin type ~A, must be 'net or 'bus"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1011
 msgid "Object ~A has invalid pin type."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1417
 msgid "Invalid text alignment ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1433
 msgid "Invalid text angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1452
 msgid "Invalid text name/value visibility ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1526
 msgid "Text object ~A has invalid text alignment ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1535
 msgid "Text object ~A has invalid visibility ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1545
 msgid "Text object ~A has invalid text attribute visibility ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1586
 msgid "Object ~A is not included in a page."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1739
 msgid "Path object ~A has invalid element type ~A at index ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1853
 msgid "Invalid path element type ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:2025
 msgid "Invalid picture angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr ""
 
-#: liblepton/src/scheme_page.c:291
 msgid "Object ~A is attached to a complex or different page"
 msgstr ""
 
-#: liblepton/src/scheme_page.c:438
 msgid "Parse error: ~s"
 msgstr ""
 
-#: liblepton/src/edascmhookproxy.c:83
 msgid "Scheme hook"
 msgstr ""
 
-#: liblepton/src/edascmhookproxy.c:84
 msgid "The Scheme-level hook to proxy"
 msgstr ""
 
-#: liblepton/scheme/geda/attrib.scm:56
 #, scheme-format
 msgid "Object ~A is not part of a page"
 msgstr ""
 
-#: liblepton/scheme/geda/library.scm:108
 #, scheme-format
 msgid "Invalid path ~S or source not readable.\n"
 msgstr ""
 
-#: liblepton/scheme/geda/library.scm:109
 msgid "Source library path must be a string.\n"
 msgstr ""
 
-#: liblepton/scheme/geda/library.scm:168
 #, scheme-format
 msgid "File ~S is not readable.\n"
 msgstr ""
 
-#: liblepton/scheme/geda/repl.scm:48
 msgid "Welcome to Lepton REPL!\n"
 msgstr ""
 
-#: liblepton/scheme/geda/repl.scm:53
 msgid "WARNING: Readline library is not supported in your configuration.\n"
 msgstr ""
 

--- a/liblepton/po/pt.po
+++ b/liblepton/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-12 00:08+0300\n"
+"POT-Creation-Date: 2019-05-13 11:16+0300\n"
 "PO-Revision-Date: 2012-01-27 14:12+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: Portuguese <pt@li.org>\n"
@@ -18,46 +18,37 @@ msgstr ""
 "X-Launchpad-Export-Date: 2012-11-14 16:52+0000\n"
 "X-Generator: Launchpad (build 16265)\n"
 
-#: liblepton/data/liblepton.xml.in:3
 #, fuzzy
 msgid "Lepton EDA circuit schematic"
 msgstr "esquema de circuito gEDA"
 
-#: liblepton/data/liblepton.xml.in:4
 #, fuzzy
 msgid "Lepton EDA schematic symbol"
 msgstr "símbolo de esquema gEDA"
 
-#: liblepton/data/liblepton.xml.in:5
 #, fuzzy
 msgid "Lepton EDA sch2pcb project"
 msgstr "projecto gEDA gsch2pcb"
 
-#: liblepton/data/x-lepton-sch2pcb-project.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA sch2pcb Project"
 msgstr "Projecto gEDA Gsch2pcb"
 
-#: liblepton/data/x-lepton-schematic.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Circuit Schematic"
 msgstr "Esquema de circuito gEDA"
 
-#: liblepton/data/x-lepton-symbol.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Schematic Symbol"
 msgstr "Símbolo de Esquema gEDA"
 
-#: liblepton/src/a_basic.c:57 liblepton/src/f_basic.c:377
 #, c-format
 msgid "File %1$s is read-only"
 msgstr ""
 
-#: liblepton/src/a_basic.c:114
 msgid "Schematic data was not valid UTF-8"
 msgstr ""
 
-#: liblepton/src/a_basic.c:246
 #, fuzzy, c-format
 msgid ""
 "Read unexpected attach symbol start marker in [%1$s] :\n"
@@ -68,7 +59,6 @@ msgstr ""
 ">>\n"
 "%s<<\n"
 
-#: liblepton/src/a_basic.c:263
 #, fuzzy, c-format
 msgid ""
 "Read unexpected embedded symbol start marker in [%1$s] :\n"
@@ -79,7 +69,6 @@ msgstr ""
 ">>\n"
 "%s<<\n"
 
-#: liblepton/src/a_basic.c:294
 #, c-format
 msgid ""
 "Read unexpected embedded symbol end marker in [%s] :\n"
@@ -90,7 +79,6 @@ msgstr ""
 ">>\n"
 "%s<<\n"
 
-#: liblepton/src/a_basic.c:329
 #, fuzzy, c-format
 msgid ""
 "Read an old format sym/sch file!\n"
@@ -101,7 +89,6 @@ msgstr ""
 "Por favor execute g[sym|sch]update em:\n"
 "[%s]\n"
 
-#: liblepton/src/a_basic.c:335
 #, fuzzy, c-format
 msgid ""
 "Read garbage in [%1$s] :\n"
@@ -112,17 +99,14 @@ msgstr ""
 ">>\n"
 "%s<<\n"
 
-#: liblepton/src/f_basic.c:119 liblepton/src/f_basic.c:132
 #, fuzzy, c-format
 msgid "Failed to stat [%1$s]: %2$s"
 msgstr "Falhou em stat [%s]: %s"
 
-#: liblepton/src/f_basic.c:211
 #, fuzzy, c-format
 msgid "Cannot find file %1$s: %2$s"
 msgstr "Não é possível encontrar o ficheiro %s: %s"
 
-#: liblepton/src/f_basic.c:260
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -135,12 +119,10 @@ msgstr ""
 "  %s.\n"
 "\n"
 
-#: liblepton/src/f_basic.c:262
 msgid "I could not guess if it is newer, so you have to do it manually.\n"
 msgstr ""
 "Não pude adivinhar se é mais recente, por isso terá de o fazer manualmente.\n"
 
-#: liblepton/src/f_basic.c:264
 msgid ""
 "The backup copy is newer than the schematic, so it seems you should load it "
 "instead of the original file.\n"
@@ -148,7 +130,6 @@ msgstr ""
 "A cópia de salvaguarda é mais recente que o esquema, parece então que deverá "
 "abri-la em vez do ficheiro original.\n"
 
-#: liblepton/src/f_basic.c:266
 #, fuzzy
 msgid ""
 "lepton-schematic usually makes backup copies automatically, and this "
@@ -157,7 +138,6 @@ msgstr ""
 "Gschem normalmente faz cópias de salvaguarda automaticamente, e esta "
 "situação acontece quando encrava ou foi forçado a sair abruptamente.\n"
 
-#: liblepton/src/f_basic.c:269
 #, fuzzy
 msgid ""
 "\n"
@@ -168,238 +148,183 @@ msgstr ""
 "Execute gschem e corrija a situação.\n"
 "\n"
 
-#: liblepton/src/f_basic.c:367
 #, fuzzy, c-format
 msgid "Can't get the real filename of %1$s: %2$s"
 msgstr ""
 "s_page_delete: Não foi possível obter o nome de ficheiro verdadeiro de %s."
 
-#: liblepton/src/f_basic.c:398
 #, fuzzy, c-format
 msgid "Could NOT set previous backup file [%1$s] read-write."
 msgstr ""
 "NÃO foi possível definir o ficheiro de salvaguarda anterior [%s] como "
 "leitura e escrita\n"
 
-#: liblepton/src/f_basic.c:404
 #, fuzzy, c-format
 msgid "Can't save backup file: %1$s."
 msgstr "Não é possível guardar o ficheiro de salvaguarda: %s."
 
-#: liblepton/src/f_basic.c:414
 #, fuzzy, c-format
 msgid "Could NOT set backup file [%1$s] readonly."
 msgstr ""
 "Não foi possível definir o ficheiro de salvaguarda [%s] apenas como leitura\n"
 
-#: liblepton/src/f_basic.c:463
 #, fuzzy, c-format
 msgid "Failed to restore permissions on '%1$s': %2$s\n"
 msgstr "Falha ao abrir directoria [%s]: %s\n"
 
-#: liblepton/src/f_basic.c:468
 #, fuzzy, c-format
 msgid "Failed to restore ownership on '%1$s': %2$s\n"
 msgstr "Falha ao abrir directoria [%s]: %s\n"
 
-#: liblepton/src/f_basic.c:478
 #, fuzzy, c-format
 msgid "Could NOT save file: %1$s"
 msgstr "NÃO foi possível guardar [%s]\n"
 
-#: liblepton/src/f_basic.c:604
 #, c-format
 msgid "%s: %s"
 msgstr "%s: %s"
 
-#: liblepton/src/g_basic.c:260
 msgid ""
 "\n"
 "Backtrace:\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:99
 #, fuzzy, c-format
 msgid "Invalid mode [%1$s] passed to %2$s\n"
 msgstr "Componente [%s] não foi encontrado na biblioteca de componentes\n"
 
-#: liblepton/src/g_rc.c:139
 msgid "RC file already loaded"
 msgstr ""
 
-#: liblepton/src/g_rc.c:183
 #, fuzzy, c-format
 msgid "Failed to load config from '%1$s': %2$s\n"
 msgstr "Falha ao carregar imagem a partir do ficheiro [%s]: %s\n"
 
-#: liblepton/src/g_rc.c:207
 #, fuzzy, c-format
 msgid "Loaded RC file [%1$s]"
 msgstr "Comando de biblioteca falhou [%s]\n"
 
-#: liblepton/src/g_rc.c:211
 #, fuzzy, c-format
 msgid "Failed to load RC file [%1$s]: "
 msgstr "Falha ao carregar imagem a partir do ficheiro [%s]: %s\n"
 
-#: liblepton/src/g_rc.c:341
 msgid "ERROR: An unknown error occurred while parsing configuration files."
 msgstr ""
 
-#: liblepton/src/g_rc.c:353
 #, c-format
 msgid "ERROR: %1$s"
 msgstr ""
 
-#: liblepton/src/g_rc.c:354
 #, c-format
 msgid "ERROR: %1$s\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:360
 #, c-format
 msgid "ERROR: The %1$s log may contain more information.\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:512
 #, fuzzy, c-format
 msgid "Invalid path [%1$s] passed to component-library\n"
 msgstr "Componente [%s] não foi encontrado na biblioteca de componentes\n"
 
-#: liblepton/src/g_rc.c:738
 #, fuzzy, c-format
 msgid "Invalid path [%1$s] passed to bitmap-directory\n"
 msgstr "Componente [%s] não foi encontrado na biblioteca de componentes\n"
 
-#: liblepton/src/geda_page.c:197
 #, fuzzy, c-format
 msgid "s_page_delete: Can't get the real filename of %1$s."
 msgstr ""
 "s_page_delete: Não foi possível obter o nome de ficheiro verdadeiro de %s."
 
-#: liblepton/src/geda_page.c:208
 #, fuzzy, c-format
 msgid "s_page_delete: Unable to delete backup file %1$s."
 msgstr "s_page_delete: Não foi possível apagar ficheiro de salvaguarda %s."
 
-#: liblepton/src/geda_page.c:490
 #, fuzzy, c-format
 msgid "Saved [%1$s]"
 msgstr "Guardado [%s]\n"
 
-#: liblepton/src/geda_page.c:496
 #, fuzzy, c-format
 msgid "Could NOT save [%1$s]"
 msgstr "NÃO foi possível guardar [%s]\n"
 
-#: liblepton/src/geda_arc_object.c:408 liblepton/src/geda_arc_object.c:421
 msgid "Failed to parse arc object"
 msgstr ""
 
-#: liblepton/src/geda_arc_object.c:428
 #, fuzzy, c-format
 msgid "Found a zero radius arc [ %1$c %2$d, %3$d, %4$d, %5$d, %6$d, %7$d ]"
 msgstr "Foi encontrado um arco com raio zero [ %c %d, %d, %d, %d, %d, %d ]\n"
 
-#: liblepton/src/geda_arc_object.c:435 liblepton/src/geda_box_object.c:328
-#: liblepton/src/geda_bus_object.c:364 liblepton/src/geda_circle_object.c:387
-#: liblepton/src/geda_line_object.c:427 liblepton/src/geda_net_object.c:308
-#: liblepton/src/geda_path_object.c:214 liblepton/src/geda_pin_object.c:369
-#: liblepton/src/geda_text_object.c:555
 #, fuzzy, c-format
 msgid "Found an invalid color [ %1$s ]"
 msgstr "Foi encontrada uma cor inválida [ %s ]\n"
 
-#: liblepton/src/geda_arc_object.c:436 liblepton/src/geda_box_object.c:329
-#: liblepton/src/geda_bus_object.c:365 liblepton/src/geda_circle_object.c:388
-#: liblepton/src/geda_line_object.c:428 liblepton/src/geda_net_object.c:309
-#: liblepton/src/geda_path_object.c:215 liblepton/src/geda_pin_object.c:370
-#: liblepton/src/geda_text_object.c:557
 #, fuzzy
 msgid "Setting color to default color."
 msgstr "Definindo a cor para cor padrão\n"
 
-#: liblepton/src/o_attrib.c:111
 #, c-format
 msgid "Attribute [%1$s] already attached\n"
 msgstr ""
 
-#: liblepton/src/o_attrib.c:117
 msgid "Attempt to attach non text item as an attribute!\n"
 msgstr "Tentativa de anexar item não textual como um atributo!\n"
 
-#: liblepton/src/o_attrib.c:122
 #, fuzzy, c-format
 msgid "Attempt to attach attribute [%1$s] to more than one object\n"
 msgstr "Tentativa de anexar atributo [%s] a mais de um objecto\n"
 
-#: liblepton/src/o_attrib.c:325
 msgid "Tried to attach a non-text item as an attribute"
 msgstr ""
 
-#: liblepton/src/o_attrib.c:332
 msgid "Unexpected end-of-file in attribute list"
 msgstr ""
 
-#: liblepton/src/geda_box_object.c:287 liblepton/src/geda_box_object.c:316
 msgid "Failed to parse box object"
 msgstr ""
 
-#: liblepton/src/geda_box_object.c:322
 #, fuzzy, c-format
 msgid "Found a zero width/height box [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr "Encontrada caixa de largura/altura zero [ %c %d %d %d %d %d ]\n"
 
-#: liblepton/src/geda_bus_object.c:345 liblepton/src/geda_bus_object.c:352
 msgid "Failed to parse bus object"
 msgstr ""
 
-#: liblepton/src/geda_bus_object.c:358
 #, fuzzy, c-format
 msgid "Found a zero length bus [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr "Encontrado barramento com comprimento zero [ %c %d %d %d %d %d ]\n"
 
-#: liblepton/src/geda_bus_object.c:370
 #, fuzzy, c-format
 msgid "Found an invalid bus ripper direction [ %1$s ]"
 msgstr ""
 "Encontrado um símbolo de extracção de barramento com direcção invalida "
 "[ %s ]\n"
 
-#: liblepton/src/geda_bus_object.c:371
 #, fuzzy
 msgid "Resetting direction to neutral (no direction)."
 msgstr "Alterando a direcção para neutral (sem direcção)\n"
 
-#: liblepton/src/geda_circle_object.c:343
-#: liblepton/src/geda_circle_object.c:372
 msgid "Failed to parse circle object"
 msgstr ""
 
-#: liblepton/src/geda_circle_object.c:379
 #, fuzzy, c-format
 msgid "Found a zero or negative radius circle [ %1$c %2$d %3$d %4$d %5$d ]"
 msgstr "Foi encontrado um arco com raio zero [ %c %d, %d, %d, %d, %d, %d ]\n"
 
-#: liblepton/src/geda_circle_object.c:382
 #, fuzzy
 msgid "Setting radius to 0."
 msgstr "Definindo ângulo para 0\n"
 
-#: liblepton/src/geda_color.c:217
 msgid "Color map entry must be a two-element list"
 msgstr "Entrada do mapa de cor  tem de ser uma lista de dois elementos"
 
-#: liblepton/src/geda_color.c:225
 msgid "Index in color map entry must be an integer"
 msgstr "Índice no na entrada do mapa de cor tem de ser um inteiro"
 
-#: liblepton/src/geda_color.c:251
 msgid "Value in color map entry must be #f or a string"
 msgstr ""
 "Valor na entrada do mapa de cor tem de ser #f ou uma faixa de caracteres"
 
-#: liblepton/src/geda_complex_object.c:373
 #, fuzzy, c-format
 msgid ""
 "Component not found:\n"
@@ -408,11 +333,9 @@ msgstr ""
 "Componente não encontrado:\n"
 " %s"
 
-#: liblepton/src/geda_complex_object.c:585
 msgid "Failed to parse complex object"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:598
 #, fuzzy, c-format
 msgid ""
 "Found a component with an invalid rotation [ %1$c %2$d %3$d %4$d %5$d %6$d "
@@ -421,13 +344,10 @@ msgstr ""
 "Foi encontrado um componente com uma rotação inválida [ %c %d %d %d %d %d "
 "%s ]\n"
 
-#: liblepton/src/geda_complex_object.c:601
-#: liblepton/src/geda_picture_object.c:105
 #, fuzzy
 msgid "Setting angle to 0."
 msgstr "Definindo ângulo para 0\n"
 
-#: liblepton/src/geda_complex_object.c:613
 #, fuzzy, c-format
 msgid ""
 "Found a component with an invalid mirror flag [ %1$c %2$d %3$d %4$d %5$d "
@@ -436,12 +356,10 @@ msgstr ""
 "Foi encontrado um componente com atributo de simetria inválido [ %c %d %d %d "
 "%d %d %s ]\n"
 
-#: liblepton/src/geda_complex_object.c:616
 #, fuzzy
 msgid "Setting mirror to 0."
 msgstr "Defenindo simetria para 0\n"
 
-#: liblepton/src/geda_complex_object.c:941
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
@@ -450,7 +368,6 @@ msgstr ""
 "AVISO: Erro na procura da versão do símbolo em refdes %s:\n"
 "\tNão foi possível verificar ficheiro de símbolo symversion=%s\n"
 
-#: liblepton/src/geda_complex_object.c:945
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
@@ -459,7 +376,6 @@ msgstr ""
 "AVISO: Erro na procura da versão do símbolo em refdes %s:\n"
 "\tNão foi possível verificar ficheiro de símbolo symversion=\n"
 
-#: liblepton/src/geda_complex_object.c:961
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
@@ -468,7 +384,6 @@ msgstr ""
 "AVISO: Erro na procura da versão do símbolo em refdes %s:\n"
 "\tNão foi possível verificar ficheiro anexado symversion=%s\n"
 
-#: liblepton/src/geda_complex_object.c:986
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version oddity on refdes %1$s:\n"
@@ -479,7 +394,6 @@ msgstr ""
 "\tsymversion=%s anexado ao símbolo instanciado, mas não existe symversion= "
 "dentro do ficheiro de simbolo\n"
 
-#: liblepton/src/geda_complex_object.c:1000
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version mismatch on refdes %1$s (%2$s):\n"
@@ -488,18 +402,15 @@ msgstr ""
 "AVISO: Versão de símbolo não coincidente em refdes %s (%s):\n"
 "\tSimbolo na biblioteca é mais recente que o símbolo instanciado\n"
 
-#: liblepton/src/geda_complex_object.c:1028
 #, fuzzy, c-format
 msgid "\tMAJOR VERSION CHANGE (file %1$.3f, instantiated %2$.3f, %3$s)!"
 msgstr ""
 "\tALTERAÇÃO DE VERSÃO IMPORTANTE (ficheiro %.3f, instanciado %.3f, %s)!\n"
 
-#: liblepton/src/geda_complex_object.c:1046
 #, fuzzy, c-format
 msgid "\tMinor version change (file %1$.3f, instantiated %2$.3f)"
 msgstr "\tAlteração de versão menor (ficheiro %.3f, instanciado %.3f)\n"
 
-#: liblepton/src/geda_complex_object.c:1057
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version oddity on refdes %1$s:\n"
@@ -508,12 +419,10 @@ msgstr ""
 "AVISO: Versão de símbolo estranha em refdes %s:\n"
 "\tSimbolo instanciado é mais recente que o símbolo na biblioteca\n"
 
-#: liblepton/src/o_embed.c:54
 #, fuzzy, c-format
 msgid "Component [%1$s] has been embedded."
 msgstr "Componente [%s] foi embutido\n"
 
-#: liblepton/src/o_embed.c:98
 #, fuzzy, c-format
 msgid ""
 "Could not find component [%1$s], while trying to unembed. Component is still "
@@ -522,150 +431,119 @@ msgstr ""
 "Não foi possível encontrar o componente [%s], ao tentar retirar. Componente "
 "permanece embutido\n"
 
-#: liblepton/src/o_embed.c:106
 #, fuzzy, c-format
 msgid "Component [%1$s] has been successfully unembedded."
 msgstr "Componente [%s] foi retirado com sucesso\n"
 
-#: liblepton/src/geda_line_object.c:391 liblepton/src/geda_line_object.c:409
 msgid "Failed to parse line object"
 msgstr ""
 
-#: liblepton/src/geda_line_object.c:421
 #, fuzzy, c-format
 msgid "Found a zero length line [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr "Foi encontrada uma linha de comprimento zero [ %c %d %d %d %d %d ]\n"
 
-#: liblepton/src/geda_net_object.c:297
 msgid "Failed to parse net object"
 msgstr ""
 
-#: liblepton/src/geda_net_object.c:302
 #, fuzzy, c-format
 msgid "Found a zero length net [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr ""
 "Foi encontrada uma ligação com comprimento zero [ %c %d %d %d %d %d ]\n"
 
-#: liblepton/src/geda_path_object.c:206
 msgid "Failed to parse path object"
 msgstr ""
 
-#: liblepton/src/geda_path_object.c:232
 msgid "Unexpected end-of-file when reading path"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:71
 msgid "Failed to parse picture definition"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:76
 #, fuzzy, c-format
 msgid "Found a zero width/height picture [ %1$c %2$d %3$d %4$d %5$d ]"
 msgstr "Foi encontrada uma imagem com largura/altura zero [ %c %d %d %d %d ]\n"
 
-#: liblepton/src/geda_picture_object.c:82
 #, c-format
 msgid "Found a picture with a wrong 'mirrored' parameter: %1$d."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:84
 #, fuzzy
 msgid "Setting mirrored to 0."
 msgstr "Defenindo simetria para 0\n"
 
-#: liblepton/src/geda_picture_object.c:89
 #, c-format
 msgid "Found a picture with a wrong 'embedded' parameter: %1$d."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:91
 #, fuzzy
 msgid "Setting embedded to 0."
 msgstr "Definindo valor embutido para 0\n"
 
-#: liblepton/src/geda_picture_object.c:104
 #, fuzzy, c-format
 msgid "Found an unsupported picture angle [ %1$d ]"
 msgstr "Foi encontrado um valor não suportado para ângulo de imagem [%d]\n"
 
-#: liblepton/src/geda_picture_object.c:116
 msgid "Found an image with no filename."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:147
 #, fuzzy, c-format
 msgid "Failed to load image from embedded data [%1$s]: %2$s"
 msgstr "Falha ao carregar a imagem a partir dos dados embutidos [%s]:%s\n"
 
-#: liblepton/src/geda_picture_object.c:148
 msgid "Base64 decoding failed."
 msgstr "Descodificação Base64 falhou."
 
-#: liblepton/src/geda_picture_object.c:149
 #, fuzzy
 msgid "Falling back to file loading. Picture unembedded."
 msgstr "A recuar ao modo de carregamento de ficheiro. Imagem removida.\n"
 
-#: liblepton/src/geda_picture_object.c:208
 #, fuzzy
 msgid "ERROR: o_picture_save: unable to encode the picture."
 msgstr "ERRO: o_picture_save: não é possível codificar a imagem.\n"
 
-#: liblepton/src/geda_picture_object.c:308
 #, fuzzy, c-format
 msgid "Failed to load buffer image [%1$s]: %2$s"
 msgstr "Falhou ao carregar símbolo a partir do ficheiro  [%s]: %s\n"
 
-#: liblepton/src/geda_picture_object.c:321
 #, fuzzy, c-format
 msgid "Failed to load image from [%1$s]: %2$s"
 msgstr "Falha ao carregar imagem a partir do ficheiro [%s]: %s\n"
 
-#: liblepton/src/geda_picture_object.c:415
 #, c-format
 msgid "Picture %1$p has invalid angle %2$i\n"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:772
 #, fuzzy, c-format
 msgid "Picture [%1$s] has no image data."
 msgstr "Imagem [%s] foi embutida\n"
 
-#: liblepton/src/geda_picture_object.c:773
 #, fuzzy
 msgid "Falling back to file loading. Picture is still unembedded."
 msgstr "A recuar ao modo de carregamento de ficheiro. Imagem removida.\n"
 
-#: liblepton/src/geda_picture_object.c:781
 #, fuzzy, c-format
 msgid "Picture [%1$s] has been embedded."
 msgstr "Imagem [%s] foi embutida\n"
 
-#: liblepton/src/geda_picture_object.c:805
 #, fuzzy, c-format
 msgid "Failed to load image from file [%1$s]: %2$s"
 msgstr "Falha ao carregar imagem a partir do ficheiro [%s]: %s\n"
 
-#: liblepton/src/geda_picture_object.c:807
 #, fuzzy
 msgid "Picture is still embedded."
 msgstr "Imagem [%s] foi embutida\n"
 
-#: liblepton/src/geda_picture_object.c:815
 #, fuzzy, c-format
 msgid "Picture [%1$s] has been unembedded."
 msgstr "Imagem [%s] foi removida\n"
 
-#: liblepton/src/geda_picture_object.c:1052
 #, fuzzy, c-format
 msgid "Failed to load fallback image %1$s: %2$s.\n"
 msgstr "Falha ao carregar imagem a partir do ficheiro [%s]: %s\n"
 
-#: liblepton/src/geda_pin_object.c:346 liblepton/src/geda_pin_object.c:354
 msgid "Failed to parse pin object"
 msgstr ""
 
-#: liblepton/src/geda_pin_object.c:360
 #, fuzzy
 msgid ""
 "Found a pin which did not have the whichend field set.\n"
@@ -674,68 +552,54 @@ msgstr ""
 "Foi encontrado um pino que não tinha o campo 'whichone' atribuído.\n"
 "Verifique e corrija manualmente.\n"
 
-#: liblepton/src/geda_pin_object.c:363
 #, fuzzy, c-format
 msgid "Found an invalid whichend on a pin (reseting to zero): %d"
 msgstr ""
 "Foi encontrado campo invalido 'whichend' num pino (alterando para zero): %d\n"
 
-#: liblepton/src/geda_text_object.c:495 liblepton/src/geda_text_object.c:505
-#: liblepton/src/geda_text_object.c:515
 msgid "Failed to parse text object"
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:522
 #, fuzzy, c-format
 msgid "Found an invalid text size [ %1$s ]"
 msgstr "Foi encontrada uma cor inválida [ %s ]\n"
 
-#: liblepton/src/geda_text_object.c:524
 #, fuzzy, c-format
 msgid "Setting text size to %1$d."
 msgstr "Defenindo simetria para 0\n"
 
-#: liblepton/src/geda_text_object.c:528
 #, fuzzy, c-format
 msgid "Found an unsupported text angle [ %1$s ]"
 msgstr "Foi encontrado um valor não suportado para ângulo de imagem [%d]\n"
 
-#: liblepton/src/geda_text_object.c:530
 #, fuzzy, c-format
 msgid "Setting angle to %1$d."
 msgstr "Definindo ângulo para 0\n"
 
-#: liblepton/src/geda_text_object.c:547
 #, fuzzy, c-format
 msgid "Found an unsupported text alignment [ %1$s ]"
 msgstr "Foi encontrado um valor não suportado para ângulo de imagem [%d]\n"
 
-#: liblepton/src/geda_text_object.c:550
 #, fuzzy
 msgid "Setting alignment to LOWER_LEFT."
 msgstr "A definir alinhamento para 'em baixo à esquerda'\n"
 
-#: liblepton/src/geda_text_object.c:570
 #, c-format
 msgid "Unexpected end-of-file after %1$d lines"
 msgstr ""
 
-#: liblepton/src/s_clib.c:460
 #, fuzzy, c-format
 msgid "Library command failed [%1$s]: %2$s"
 msgstr "Comando de biblioteca falhou [%s]: %s\n"
 
-#: liblepton/src/s_clib.c:465
 #, fuzzy, c-format
 msgid "Library command failed [%1$s]: Uncaught signal %2$i."
 msgstr "Comando de biblioteca falhou [%s]: Sinal não alcançado %i.\n"
 
-#: liblepton/src/s_clib.c:469
 #, fuzzy, c-format
 msgid "Library command failed [%1$s]"
 msgstr "Comando de biblioteca falhou [%s]\n"
 
-#: liblepton/src/s_clib.c:470
 #, fuzzy, c-format
 msgid ""
 "Error output was:\n"
@@ -744,36 +608,30 @@ msgstr ""
 "Erro de saida foi:\n"
 "%s\n"
 
-#: liblepton/src/s_clib.c:556
 #, fuzzy, c-format
 msgid "Library name [%1$s] already in use.  Using [%2$s]."
 msgstr "Nome de biblioteca [%s] já em uso.  A usar [%s].\n"
 
-#: liblepton/src/s_clib.c:593
 #, fuzzy, c-format
 msgid "Failed to open directory [%1$s]: %2$s"
 msgstr "Falha ao abrir directoria [%s]: %s\n"
 
-#: liblepton/src/s_clib.c:729
 #, fuzzy, c-format
 msgid "Failed to scan library [%1$s]: Scheme function returned non-list."
 msgstr ""
 "Falha ao verificar biblioteca [%s]: Função 'scheme' devolveu algo que não é "
 "lista\n"
 
-#: liblepton/src/s_clib.c:737
 #, fuzzy, c-format
 msgid "Non-string symbol name while scanning library [%1$s]"
 msgstr ""
 "Nome de símbolo que não é faixa de caracteres encontrado enquanto se "
 "verificava a biblioteca [%s]\n"
 
-#: liblepton/src/s_clib.c:893 liblepton/src/s_clib.c:940
 #, fuzzy
 msgid "Cannot add library: name not specified."
 msgstr "Não é possível adicionar biblioteca: nome não foi especificado\n"
 
-#: liblepton/src/s_clib.c:900
 #, fuzzy, c-format
 msgid ""
 "Cannot add library [%1$s]: both 'list' and 'get' commands must be specified."
@@ -781,265 +639,203 @@ msgstr ""
 "Não é possível adicionar biblioteca [%s]: ambos os comandos 'list' e 'get' "
 "têm de ser especificados.\n"
 
-#: liblepton/src/s_clib.c:948
 #, fuzzy, c-format
 msgid "Cannot add Scheme-library [%1$s]: callbacks must be closures."
 msgstr ""
 "Não é possível adicionar biblioteca Scheme [%s]: rotinas de chamada devem "
 "ser de encerramento\n"
 
-#: liblepton/src/s_clib.c:1075
 #, fuzzy, c-format
 msgid "Failed to load symbol from file [%1$s]: %2$s"
 msgstr "Falhou ao carregar símbolo a partir do ficheiro  [%s]: %s\n"
 
-#: liblepton/src/s_clib.c:1135
 #, fuzzy, c-format
 msgid "Failed to load symbol data [%1$s] from source [%2$s]"
 msgstr "Falhou ao carregar dados do símbolo [%s] a partir da fonte [%s]\n"
 
-#: liblepton/src/s_clib.c:1377
 #, fuzzy, c-format
 msgid "Component [%1$s] was not found in the component library."
 msgstr "Componente [%s] não foi encontrado na biblioteca de componentes\n"
 
-#: liblepton/src/s_clib.c:1383
 #, fuzzy, c-format
 msgid "More than one component found with name [%1$s]."
 msgstr "Mais de um componente encontrado com o nome [%s]\n"
 
-#: liblepton/src/s_hierarchy.c:78 liblepton/src/s_hierarchy.c:240
 msgid "Schematic not found in source library."
 msgstr ""
 
-#: liblepton/src/s_hierarchy.c:100
 msgid "Hierarchy contains a circular dependency."
 msgstr ""
 
-#: liblepton/src/s_hierarchy.c:200
 #, fuzzy
 msgid "There are no schematics above the current one!"
 msgstr "Não existem esquemas acima do esquema presente!\n"
 
-#: liblepton/src/s_hierarchy.c:341
 #, fuzzy, c-format
 msgid "Failed to descend hierarchy into '%1$s': %2$s"
 msgstr "Falha ao abrir directoria [%s]: %s\n"
 
-#: liblepton/src/s_slot.c:158
 msgid "Did not find slotdef=#:#,#,#... attribute."
 msgstr ""
 
-#: liblepton/src/s_slot.c:164
 msgid "Improper slotdef syntax: missing \":\"."
 msgstr ""
 
-#: liblepton/src/s_slot.c:179
 msgid "Did not find proper slotdef=#:#,#,#... attribute."
 msgstr ""
 
-#: liblepton/src/s_slot.c:209
 msgid "component missing pinseq= attribute."
 msgstr ""
 
-#: liblepton/src/edaconfig.c:694 liblepton/src/edaconfig.c:780
 msgid "Undefined configuration filename"
 msgstr ""
 
-#: liblepton/src/edaconfig.c:1105 liblepton/src/edaconfig.c:1169
 #, c-format
 msgid "Configuration does not have group '%s'"
 msgstr ""
 
-#: liblepton/src/edaconfig.c:1183
 #, c-format
 msgid "Configuration does not have key '%s'"
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:66 liblepton/src/scheme_attrib.c:100
 msgid "~A is not a valid attribute: invalid string '~A'."
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:204
 msgid "Objects ~A and ~A are not part of the same page and/or complex object"
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:211 liblepton/src/scheme_attrib.c:216
 msgid "Object ~A is already attached as an attribute"
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:265
 msgid "Object ~A is attribute of wrong object"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:148
 msgid "Invalid complex angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:270 liblepton/src/scheme_page.c:246
 msgid "Object ~A is already attached to something"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:332
 msgid "Object ~A is attached to a different complex"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:339
 msgid "Object ~A is attached to a page"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:346 liblepton/src/scheme_page.c:298
 msgid "Object ~A is attached as an attribute"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:353 liblepton/src/scheme_page.c:305
 msgid "Object ~A has attributes"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:234
 msgid "Object ~A has bad type '~A'"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:378
 msgid "Object ~A has invalid stroke cap style ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:391
 msgid "Object ~A has invalid stroke dash style ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:455
 msgid "Invalid stroke cap style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:466
 msgid "Invalid stroke dash style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:476
 msgid "Missing dash length parameter for dash style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:486
 msgid "Missing dot/dash space parameter for dash style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:554
 msgid "Object ~A has invalid fill style ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:603
 msgid "Invalid fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:611
 msgid "Missing second space parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:620
 msgid "Missing second angle parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:630
 msgid "Missing stroke width parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:639
 msgid "Missing space parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:648
 msgid "Missing angle parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:962
 msgid "Invalid pin type ~A, must be 'net or 'bus"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1011
 msgid "Object ~A has invalid pin type."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1417
 msgid "Invalid text alignment ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1433
 msgid "Invalid text angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1452
 msgid "Invalid text name/value visibility ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1526
 msgid "Text object ~A has invalid text alignment ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1535
 msgid "Text object ~A has invalid visibility ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1545
 msgid "Text object ~A has invalid text attribute visibility ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1586
 msgid "Object ~A is not included in a page."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1739
 msgid "Path object ~A has invalid element type ~A at index ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1853
 msgid "Invalid path element type ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:2025
 msgid "Invalid picture angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr ""
 
-#: liblepton/src/scheme_page.c:291
 msgid "Object ~A is attached to a complex or different page"
 msgstr ""
 
-#: liblepton/src/scheme_page.c:438
 msgid "Parse error: ~s"
 msgstr ""
 
-#: liblepton/src/edascmhookproxy.c:83
 msgid "Scheme hook"
 msgstr ""
 
-#: liblepton/src/edascmhookproxy.c:84
 msgid "The Scheme-level hook to proxy"
 msgstr ""
 
-#: liblepton/scheme/geda/attrib.scm:56
 #, scheme-format
 msgid "Object ~A is not part of a page"
 msgstr ""
 
-#: liblepton/scheme/geda/library.scm:108
 #, scheme-format
 msgid "Invalid path ~S or source not readable.\n"
 msgstr ""
 
-#: liblepton/scheme/geda/library.scm:109
 msgid "Source library path must be a string.\n"
 msgstr ""
 
-#: liblepton/scheme/geda/library.scm:168
 #, scheme-format
 msgid "File ~S is not readable.\n"
 msgstr ""
 
-#: liblepton/scheme/geda/repl.scm:48
 msgid "Welcome to Lepton REPL!\n"
 msgstr ""
 
-#: liblepton/scheme/geda/repl.scm:53
 msgid "WARNING: Readline library is not supported in your configuration.\n"
 msgstr ""
 

--- a/liblepton/po/ru.po
+++ b/liblepton/po/ru.po
@@ -26,7 +26,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-12 00:08+0300\n"
+"POT-Creation-Date: 2019-05-13 11:16+0300\n"
 "PO-Revision-Date: 2014-06-06 16:40+0400\n"
 "Last-Translator: Vladimir Zhbanov <vzhbanov@gmail.com>\n"
 "Language-Team: geda-user@delorie.com\n"
@@ -35,46 +35,37 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: liblepton/data/liblepton.xml.in:3
 #, fuzzy
 msgid "Lepton EDA circuit schematic"
 msgstr "Принципиальная схема gEDA"
 
-#: liblepton/data/liblepton.xml.in:4
 #, fuzzy
 msgid "Lepton EDA schematic symbol"
 msgstr "Символ схемы gEDA"
 
-#: liblepton/data/liblepton.xml.in:5
 #, fuzzy
 msgid "Lepton EDA sch2pcb project"
 msgstr "Проект gsch2pcb gEDA"
 
-#: liblepton/data/x-lepton-sch2pcb-project.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA sch2pcb Project"
 msgstr "Проект gsch2pcb gEDA"
 
-#: liblepton/data/x-lepton-schematic.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Circuit Schematic"
 msgstr "Принципиальная схема gEDA"
 
-#: liblepton/data/x-lepton-symbol.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Schematic Symbol"
 msgstr "Символ схемы gEDA"
 
-#: liblepton/src/a_basic.c:57 liblepton/src/f_basic.c:377
 #, fuzzy, c-format
 msgid "File %1$s is read-only"
 msgstr "Файл %s только для чтения"
 
-#: liblepton/src/a_basic.c:114
 msgid "Schematic data was not valid UTF-8"
 msgstr "Данные принципиальной схемы не являются допустимыми для UTF-8"
 
-#: liblepton/src/a_basic.c:246
 #, fuzzy, c-format
 msgid ""
 "Read unexpected attach symbol start marker in [%1$s] :\n"
@@ -85,7 +76,6 @@ msgstr ""
 ">>\n"
 "%s<<\n"
 
-#: liblepton/src/a_basic.c:263
 #, fuzzy, c-format
 msgid ""
 "Read unexpected embedded symbol start marker in [%1$s] :\n"
@@ -96,7 +86,6 @@ msgstr ""
 ">>\n"
 "%s<<\n"
 
-#: liblepton/src/a_basic.c:294
 #, c-format
 msgid ""
 "Read unexpected embedded symbol end marker in [%s] :\n"
@@ -107,7 +96,6 @@ msgstr ""
 ">>\n"
 "%s<<\n"
 
-#: liblepton/src/a_basic.c:329
 #, fuzzy, c-format
 msgid ""
 "Read an old format sym/sch file!\n"
@@ -118,7 +106,6 @@ msgstr ""
 "Выполните g[sym|sch]update для:\n"
 "«%s»\n"
 
-#: liblepton/src/a_basic.c:335
 #, fuzzy, c-format
 msgid ""
 "Read garbage in [%1$s] :\n"
@@ -129,17 +116,14 @@ msgstr ""
 ">>\n"
 "%s<<\n"
 
-#: liblepton/src/f_basic.c:119 liblepton/src/f_basic.c:132
 #, fuzzy, c-format
 msgid "Failed to stat [%1$s]: %2$s"
 msgstr "Ошибка чтения статуса «%s»: %s"
 
-#: liblepton/src/f_basic.c:211
 #, fuzzy, c-format
 msgid "Cannot find file %1$s: %2$s"
 msgstr "Файл «%s» не найден: %s"
 
-#: liblepton/src/f_basic.c:260
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -152,11 +136,9 @@ msgstr ""
 "  %s.\n"
 "\n"
 
-#: liblepton/src/f_basic.c:262
 msgid "I could not guess if it is newer, so you have to do it manually.\n"
 msgstr "Не удалось определить новее ли он, решите это сами.\n"
 
-#: liblepton/src/f_basic.c:264
 msgid ""
 "The backup copy is newer than the schematic, so it seems you should load it "
 "instead of the original file.\n"
@@ -164,7 +146,6 @@ msgstr ""
 "Резервная копия новее схемы, поэтому, видимо, следует загрузить её вместо "
 "оригинального файла.\n"
 
-#: liblepton/src/f_basic.c:266
 #, fuzzy
 msgid ""
 "lepton-schematic usually makes backup copies automatically, and this "
@@ -173,7 +154,6 @@ msgstr ""
 "Обычно gschem автоматически создаёт резервные копии, и такая ситуация может "
 "быть результатом крушения или внезапного завершения программы.\n"
 
-#: liblepton/src/f_basic.c:269
 #, fuzzy
 msgid ""
 "\n"
@@ -186,51 +166,42 @@ msgstr ""
 
 # Эта функция пытается найти для указанного имени реальный файл (не являющийся
 # ссылкой).
-#: liblepton/src/f_basic.c:367
 #, fuzzy, c-format
 msgid "Can't get the real filename of %1$s: %2$s"
 msgstr "Не удалось определить имя реального файла для %s: %s"
 
-#: liblepton/src/f_basic.c:398
 #, fuzzy, c-format
 msgid "Could NOT set previous backup file [%1$s] read-write."
 msgstr ""
 "Не удалось установить режим чтения-записи для файла предыдущей резервной  "
 "копии «%s»\n"
 
-#: liblepton/src/f_basic.c:404
 #, fuzzy, c-format
 msgid "Can't save backup file: %1$s."
 msgstr "Не удалось сохранить файл резервной копии: %s."
 
-#: liblepton/src/f_basic.c:414
 #, fuzzy, c-format
 msgid "Could NOT set backup file [%1$s] readonly."
 msgstr ""
 "Не удалось установить режим доступа только на чтение для резервной копии "
 "файла «%s»\n"
 
-#: liblepton/src/f_basic.c:463
 #, fuzzy, c-format
 msgid "Failed to restore permissions on '%1$s': %2$s\n"
 msgstr "Не удалось восстановить права для «%s»: %s\n"
 
-#: liblepton/src/f_basic.c:468
 #, fuzzy, c-format
 msgid "Failed to restore ownership on '%1$s': %2$s\n"
 msgstr "Не удалось восстановить владельца для «%s»: %s\n"
 
-#: liblepton/src/f_basic.c:478
 #, fuzzy, c-format
 msgid "Could NOT save file: %1$s"
 msgstr "Не удалось сохранить файл: %s"
 
-#: liblepton/src/f_basic.c:604
 #, c-format
 msgid "%s: %s"
 msgstr "%s: %s"
 
-#: liblepton/src/g_basic.c:260
 msgid ""
 "\n"
 "Backtrace:\n"
@@ -238,188 +209,142 @@ msgstr ""
 "\n"
 "Последовательность вызовов подпрограмм:\n"
 
-#: liblepton/src/g_rc.c:99
 #, fuzzy, c-format
 msgid "Invalid mode [%1$s] passed to %2$s\n"
 msgstr "%2$s: недопустимый режим «%1$s»\n"
 
-#: liblepton/src/g_rc.c:139
 msgid "RC file already loaded"
 msgstr "Файл настроек уже загружен"
 
-#: liblepton/src/g_rc.c:183
 #, fuzzy, c-format
 msgid "Failed to load config from '%1$s': %2$s\n"
 msgstr "Не удалось загрузить настройки из файла «%s»: %s\n"
 
-#: liblepton/src/g_rc.c:207
 #, fuzzy, c-format
 msgid "Loaded RC file [%1$s]"
 msgstr "Загружен файл настроек «%s»\n"
 
-#: liblepton/src/g_rc.c:211
 #, fuzzy, c-format
 msgid "Failed to load RC file [%1$s]: "
 msgstr "Не удалось загрузить файл настроек «%s»: "
 
-#: liblepton/src/g_rc.c:341
 msgid "ERROR: An unknown error occurred while parsing configuration files."
 msgstr "ОШИБКА: неизвестная ошибка при анализе файлов настроек"
 
-#: liblepton/src/g_rc.c:353
 #, fuzzy, c-format
 msgid "ERROR: %1$s"
 msgstr "ОШИБКА: %s\n"
 
-#: liblepton/src/g_rc.c:354
 #, fuzzy, c-format
 msgid "ERROR: %1$s\n"
 msgstr "ОШИБКА: %s\n"
 
-#: liblepton/src/g_rc.c:360
 #, fuzzy, c-format
 msgid "ERROR: The %1$s log may contain more information.\n"
 msgstr "ОШИБКА: в файле журнала %s может быть больше информации\n"
 
-#: liblepton/src/g_rc.c:512
 #, fuzzy, c-format
 msgid "Invalid path [%1$s] passed to component-library\n"
 msgstr "component-library: недопустимый путь «%s»\n"
 
-#: liblepton/src/g_rc.c:738
 #, fuzzy, c-format
 msgid "Invalid path [%1$s] passed to bitmap-directory\n"
 msgstr "bitmap-directory: недопустимый путь «%s»\n"
 
 # Эта функция пытается найти для указанного имени реальный файл (не являющийся
 # ссылкой).
-#: liblepton/src/geda_page.c:197
 #, fuzzy, c-format
 msgid "s_page_delete: Can't get the real filename of %1$s."
 msgstr "s_page_delete: не удалось определить имя реального файла для %s."
 
-#: liblepton/src/geda_page.c:208
 #, fuzzy, c-format
 msgid "s_page_delete: Unable to delete backup file %1$s."
 msgstr "s_page_delete: не удалось удалить файл резервной копии %s."
 
-#: liblepton/src/geda_page.c:490
 #, fuzzy, c-format
 msgid "Saved [%1$s]"
 msgstr "Файл «%s» сохранён\n"
 
-#: liblepton/src/geda_page.c:496
 #, fuzzy, c-format
 msgid "Could NOT save [%1$s]"
 msgstr "Не удалось сохранить «%s»\n"
 
-#: liblepton/src/geda_arc_object.c:408 liblepton/src/geda_arc_object.c:421
 msgid "Failed to parse arc object"
 msgstr "Ошибка в определении дуги"
 
-#: liblepton/src/geda_arc_object.c:428
 #, fuzzy, c-format
 msgid "Found a zero radius arc [ %1$c %2$d, %3$d, %4$d, %5$d, %6$d, %7$d ]"
 msgstr "Дуга с нулевым радиусом «%c %d, %d, %d, %d, %d, %d»\n"
 
-#: liblepton/src/geda_arc_object.c:435 liblepton/src/geda_box_object.c:328
-#: liblepton/src/geda_bus_object.c:364 liblepton/src/geda_circle_object.c:387
-#: liblepton/src/geda_line_object.c:427 liblepton/src/geda_net_object.c:308
-#: liblepton/src/geda_path_object.c:214 liblepton/src/geda_pin_object.c:369
-#: liblepton/src/geda_text_object.c:555
 #, fuzzy, c-format
 msgid "Found an invalid color [ %1$s ]"
 msgstr "Недопустимое значение цветового индекса «%s»\n"
 
-#: liblepton/src/geda_arc_object.c:436 liblepton/src/geda_box_object.c:329
-#: liblepton/src/geda_bus_object.c:365 liblepton/src/geda_circle_object.c:388
-#: liblepton/src/geda_line_object.c:428 liblepton/src/geda_net_object.c:309
-#: liblepton/src/geda_path_object.c:215 liblepton/src/geda_pin_object.c:370
-#: liblepton/src/geda_text_object.c:557
 #, fuzzy
 msgid "Setting color to default color."
 msgstr "Установка цвета по умолчанию\n"
 
-#: liblepton/src/o_attrib.c:111
 #, fuzzy, c-format
 msgid "Attribute [%1$s] already attached\n"
 msgstr "Атрибут «%s» уже прикреплён\n"
 
-#: liblepton/src/o_attrib.c:117
 msgid "Attempt to attach non text item as an attribute!\n"
 msgstr "Попытка прикрепить не текстовый элемент как атрибут!\n"
 
-#: liblepton/src/o_attrib.c:122
 #, fuzzy, c-format
 msgid "Attempt to attach attribute [%1$s] to more than one object\n"
 msgstr "Попытка прикрепить атрибут «%s» к более чем одному объекту\n"
 
-#: liblepton/src/o_attrib.c:325
 msgid "Tried to attach a non-text item as an attribute"
 msgstr "Попытка прикрепить не текстовый элемент как атрибут!"
 
-#: liblepton/src/o_attrib.c:332
 msgid "Unexpected end-of-file in attribute list"
 msgstr "Неожиданный конец файла при обработке списка атрибутов"
 
-#: liblepton/src/geda_box_object.c:287 liblepton/src/geda_box_object.c:316
 msgid "Failed to parse box object"
 msgstr "Ошибка в определении прямоугольника"
 
-#: liblepton/src/geda_box_object.c:322
 #, fuzzy, c-format
 msgid "Found a zero width/height box [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr "Прямоугольник нулевой ширины или высоты «%c %d %d %d %d %d»\n"
 
-#: liblepton/src/geda_bus_object.c:345 liblepton/src/geda_bus_object.c:352
 msgid "Failed to parse bus object"
 msgstr "Ошибка в определении шины"
 
-#: liblepton/src/geda_bus_object.c:358
 #, fuzzy, c-format
 msgid "Found a zero length bus [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr "Шина нулевой длины «%c %d %d %d %d %d»\n"
 
-#: liblepton/src/geda_bus_object.c:370
 #, fuzzy, c-format
 msgid "Found an invalid bus ripper direction [ %1$s ]"
 msgstr ""
 "Недопустимое значение поля «ripperdir» (направление ответвления от шины) "
 "«%s»\n"
 
-#: liblepton/src/geda_bus_object.c:371
 #, fuzzy
 msgid "Resetting direction to neutral (no direction)."
 msgstr "Сброс направления в нейтральное значение (направление не задано)\n"
 
-#: liblepton/src/geda_circle_object.c:343
-#: liblepton/src/geda_circle_object.c:372
 msgid "Failed to parse circle object"
 msgstr "Ошибка в определении окружности"
 
-#: liblepton/src/geda_circle_object.c:379
 #, fuzzy, c-format
 msgid "Found a zero or negative radius circle [ %1$c %2$d %3$d %4$d %5$d ]"
 msgstr "Окружность с нулевым или отрицательным радиусом «%c %d %d %d %d»\n"
 
-#: liblepton/src/geda_circle_object.c:382
 #, fuzzy
 msgid "Setting radius to 0."
 msgstr "Установка радиуса в 0\n"
 
-#: liblepton/src/geda_color.c:217
 msgid "Color map entry must be a two-element list"
 msgstr "Запись в таблице цветов должна быть двухэлементным списком"
 
-#: liblepton/src/geda_color.c:225
 msgid "Index in color map entry must be an integer"
 msgstr "Индекс записи в таблице цветов должен быть целым числом"
 
-#: liblepton/src/geda_color.c:251
 msgid "Value in color map entry must be #f or a string"
 msgstr "Значение записи в таблице цветов должно быть «#f» или строкой"
 
-#: liblepton/src/geda_complex_object.c:373
 #, fuzzy, c-format
 msgid ""
 "Component not found:\n"
@@ -428,11 +353,9 @@ msgstr ""
 "Не найден компонент:\n"
 " %s"
 
-#: liblepton/src/geda_complex_object.c:585
 msgid "Failed to parse complex object"
 msgstr "Ошибка в определении составного объекта"
 
-#: liblepton/src/geda_complex_object.c:598
 #, fuzzy, c-format
 msgid ""
 "Found a component with an invalid rotation [ %1$c %2$d %3$d %4$d %5$d %6$d "
@@ -441,13 +364,10 @@ msgstr ""
 "Недопустимое значение угла поворота в определении компонента «%c %d %d %d %d "
 "%d %s»\n"
 
-#: liblepton/src/geda_complex_object.c:601
-#: liblepton/src/geda_picture_object.c:105
 #, fuzzy
 msgid "Setting angle to 0."
 msgstr "Установка угла поворота в 0\n"
 
-#: liblepton/src/geda_complex_object.c:613
 #, fuzzy, c-format
 msgid ""
 "Found a component with an invalid mirror flag [ %1$c %2$d %3$d %4$d %5$d "
@@ -456,12 +376,10 @@ msgstr ""
 "Недопустимое значение поля «mirror» в определении компонента «%c %d %d %d %d "
 "%d %s»\n"
 
-#: liblepton/src/geda_complex_object.c:616
 #, fuzzy
 msgid "Setting mirror to 0."
 msgstr "Установка «mirror» в 0\n"
 
-#: liblepton/src/geda_complex_object.c:941
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
@@ -470,7 +388,6 @@ msgstr ""
 "ВНИМАНИЕ: ошибка при анализе версии символа с поз. обозначением %s:\n"
 "\tНекорректный атрибут «symversion=%s» в файле символа\n"
 
-#: liblepton/src/geda_complex_object.c:945
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
@@ -479,7 +396,6 @@ msgstr ""
 "ВНИМАНИЕ: ошибка при анализе версии символа с поз. обозначением %s:\n"
 "\tНекорректный атрибут «symversion» в файле символа\n"
 
-#: liblepton/src/geda_complex_object.c:961
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
@@ -488,7 +404,6 @@ msgstr ""
 "ВНИМАНИЕ: ошибка при анализе версии символа с поз. обозначением %s:\n"
 "\tПрикреплён некорректный атрибут «symversion=%s»\n"
 
-#: liblepton/src/geda_complex_object.c:986
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version oddity on refdes %1$s:\n"
@@ -499,7 +414,6 @@ msgstr ""
 "\tК экземпляру символа прикреплён атрибут «symversion=%s», но в файле "
 "символа «symversion» отсутствует\n"
 
-#: liblepton/src/geda_complex_object.c:1000
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version mismatch on refdes %1$s (%2$s):\n"
@@ -510,21 +424,18 @@ msgstr ""
 
 # Под file здесь имеется в виду символ. Последняя переменная -- позиционное
 # обозначение. Думаю, не стоит это специально отмечать.
-#: liblepton/src/geda_complex_object.c:1028
 #, fuzzy, c-format
 msgid "\tMAJOR VERSION CHANGE (file %1$.3f, instantiated %2$.3f, %3$s)!"
 msgstr ""
 "\tИЗМЕНЕНИЕ СТАРШЕГО НОМЕРА ВЕРСИИ\t(версия символа %.3f, версия экземпляра "
 "%.3f, %s)!\n"
 
-#: liblepton/src/geda_complex_object.c:1046
 #, fuzzy, c-format
 msgid "\tMinor version change (file %1$.3f, instantiated %2$.3f)"
 msgstr ""
 "\tИзменение младшего номера версии\t(версия символа %.3f, версия экземпляра "
 "%.3f)\n"
 
-#: liblepton/src/geda_complex_object.c:1057
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version oddity on refdes %1$s:\n"
@@ -533,12 +444,10 @@ msgstr ""
 "ВНИМАНИЕ: некорректное задание версии для символа с поз. обозначением %s:\n"
 "\tЭкземпляр в схеме новее символа в библиотеке\n"
 
-#: liblepton/src/o_embed.c:54
 #, fuzzy, c-format
 msgid "Component [%1$s] has been embedded."
 msgstr "Компонент «%s» внедрён\n"
 
-#: liblepton/src/o_embed.c:98
 #, fuzzy, c-format
 msgid ""
 "Could not find component [%1$s], while trying to unembed. Component is still "
@@ -547,151 +456,120 @@ msgstr ""
 "Не удалось найти библиотечный символ для исключаемого компонента «%s». "
 "Компонент останется внедрённым\n"
 
-#: liblepton/src/o_embed.c:106
 #, fuzzy, c-format
 msgid "Component [%1$s] has been successfully unembedded."
 msgstr "Компонент «%s» успешно исключён\n"
 
-#: liblepton/src/geda_line_object.c:391 liblepton/src/geda_line_object.c:409
 msgid "Failed to parse line object"
 msgstr "Ошибка в определении линии"
 
-#: liblepton/src/geda_line_object.c:421
 #, fuzzy, c-format
 msgid "Found a zero length line [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr "Линия нулевой длины «%c %d %d %d %d %d»\n"
 
-#: liblepton/src/geda_net_object.c:297
 msgid "Failed to parse net object"
 msgstr "Ошибка в определении соединения"
 
-#: liblepton/src/geda_net_object.c:302
 #, fuzzy, c-format
 msgid "Found a zero length net [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr "Соединение нулевой длины «%c %d %d %d %d %d»\n"
 
-#: liblepton/src/geda_path_object.c:206
 msgid "Failed to parse path object"
 msgstr "Ошибка в определении контура"
 
-#: liblepton/src/geda_path_object.c:232
 msgid "Unexpected end-of-file when reading path"
 msgstr "Неожиданный конец файла при обработке контура"
 
-#: liblepton/src/geda_picture_object.c:71
 msgid "Failed to parse picture definition"
 msgstr "Ошибка в определении изображения"
 
-#: liblepton/src/geda_picture_object.c:76
 #, fuzzy, c-format
 msgid "Found a zero width/height picture [ %1$c %2$d %3$d %4$d %5$d ]"
 msgstr "Изображение нулевой ширины или высоты «%c %d %d %d %d»\n"
 
-#: liblepton/src/geda_picture_object.c:82
 #, fuzzy, c-format
 msgid "Found a picture with a wrong 'mirrored' parameter: %1$d."
 msgstr "Недопустимое значение поля «mirrored» в определении изображения: %d.\n"
 
-#: liblepton/src/geda_picture_object.c:84
 #, fuzzy
 msgid "Setting mirrored to 0."
 msgstr "Установка «mirrored» в 0\n"
 
-#: liblepton/src/geda_picture_object.c:89
 #, fuzzy, c-format
 msgid "Found a picture with a wrong 'embedded' parameter: %1$d."
 msgstr "Недопустимое значение поля «embedded» в определении изображения: %d.\n"
 
-#: liblepton/src/geda_picture_object.c:91
 #, fuzzy
 msgid "Setting embedded to 0."
 msgstr "Установка «embedded» в 0\n"
 
-#: liblepton/src/geda_picture_object.c:104
 #, fuzzy, c-format
 msgid "Found an unsupported picture angle [ %1$d ]"
 msgstr "Неподдерживаемое значение угла поворота изображения «%d»\n"
 
-#: liblepton/src/geda_picture_object.c:116
 msgid "Found an image with no filename."
 msgstr "Обнаружено изображение без имени файла"
 
-#: liblepton/src/geda_picture_object.c:147
 #, fuzzy, c-format
 msgid "Failed to load image from embedded data [%1$s]: %2$s"
 msgstr "Не удалось загрузить изображение из внедрённых данных «%s»: %s\n"
 
-#: liblepton/src/geda_picture_object.c:148
 msgid "Base64 decoding failed."
 msgstr "Ошибка расшифровки данных в формате base64."
 
-#: liblepton/src/geda_picture_object.c:149
 #, fuzzy
 msgid "Falling back to file loading. Picture unembedded."
 msgstr "Возврат к загрузке из файла. Изображение исключено.\n"
 
-#: liblepton/src/geda_picture_object.c:208
 #, fuzzy
 msgid "ERROR: o_picture_save: unable to encode the picture."
 msgstr "ОШИБКА: o_picture_save: невозможно закодировать изображение.\n"
 
 # Ошибка, если данные изображения уже есть во внутреннем буфере
-#: liblepton/src/geda_picture_object.c:308
 #, fuzzy, c-format
 msgid "Failed to load buffer image [%1$s]: %2$s"
 msgstr "Не удалось загрузить изображение «%s» из буфера: %s\n"
 
-#: liblepton/src/geda_picture_object.c:321
 #, fuzzy, c-format
 msgid "Failed to load image from [%1$s]: %2$s"
 msgstr "Не удалось загрузить изображение из файла «%s»: %s\n"
 
-#: liblepton/src/geda_picture_object.c:415
 #, fuzzy, c-format
 msgid "Picture %1$p has invalid angle %2$i\n"
 msgstr "Недопустимое значение угла поворота изображения «%p»: %i\n"
 
 # Указатель на данные возвращает NULL
-#: liblepton/src/geda_picture_object.c:772
 #, fuzzy, c-format
 msgid "Picture [%1$s] has no image data."
 msgstr "Файл «%s» не содержит данных изображения.\n"
 
-#: liblepton/src/geda_picture_object.c:773
 #, fuzzy
 msgid "Falling back to file loading. Picture is still unembedded."
 msgstr "Возврат к загрузке из файла. Изображение всё ещё исключено.\n"
 
-#: liblepton/src/geda_picture_object.c:781
 #, fuzzy, c-format
 msgid "Picture [%1$s] has been embedded."
 msgstr "Изображение «%s» внедрено\n"
 
-#: liblepton/src/geda_picture_object.c:805
 #, fuzzy, c-format
 msgid "Failed to load image from file [%1$s]: %2$s"
 msgstr "Не удалось загрузить изображение из файла «%s»: %s\n"
 
-#: liblepton/src/geda_picture_object.c:807
 #, fuzzy
 msgid "Picture is still embedded."
 msgstr "Изображение всё ещё внедрено.\n"
 
-#: liblepton/src/geda_picture_object.c:815
 #, fuzzy, c-format
 msgid "Picture [%1$s] has been unembedded."
 msgstr "Изображение «%s» исключено\n"
 
-#: liblepton/src/geda_picture_object.c:1052
 #, fuzzy, c-format
 msgid "Failed to load fallback image %1$s: %2$s.\n"
 msgstr "Не удалось загрузить копию изображения для отката «%s»: %s\n"
 
-#: liblepton/src/geda_pin_object.c:346 liblepton/src/geda_pin_object.c:354
 msgid "Failed to parse pin object"
 msgstr "Ошибка в определении вывода"
 
-#: liblepton/src/geda_pin_object.c:360
 #, fuzzy
 msgid ""
 "Found a pin which did not have the whichend field set.\n"
@@ -700,68 +578,54 @@ msgstr ""
 "Вывод с неустановленным полем «whichend».\n"
 "Проверьте и исправьте вручную.\n"
 
-#: liblepton/src/geda_pin_object.c:363
 #, fuzzy, c-format
 msgid "Found an invalid whichend on a pin (reseting to zero): %d"
 msgstr ""
 "Недопустимое значение поля «whichend» в определении вывода (сброс в 0): %d\n"
 
-#: liblepton/src/geda_text_object.c:495 liblepton/src/geda_text_object.c:505
-#: liblepton/src/geda_text_object.c:515
 msgid "Failed to parse text object"
 msgstr "Ошибка в определении текстового объекта"
 
-#: liblepton/src/geda_text_object.c:522
 #, fuzzy, c-format
 msgid "Found an invalid text size [ %1$s ]"
 msgstr "Недопустимое значение цветового индекса «%s»\n"
 
-#: liblepton/src/geda_text_object.c:524
 #, fuzzy, c-format
 msgid "Setting text size to %1$d."
 msgstr "Установка «mirrored» в 0\n"
 
-#: liblepton/src/geda_text_object.c:528
 #, fuzzy, c-format
 msgid "Found an unsupported text angle [ %1$s ]"
 msgstr "Неподдерживаемое значение угла поворота изображения «%d»\n"
 
-#: liblepton/src/geda_text_object.c:530
 #, fuzzy, c-format
 msgid "Setting angle to %1$d."
 msgstr "Установка угла поворота в 0\n"
 
-#: liblepton/src/geda_text_object.c:547
 #, fuzzy, c-format
 msgid "Found an unsupported text alignment [ %1$s ]"
 msgstr "Неподдерживаемое значение угла поворота изображения «%d»\n"
 
-#: liblepton/src/geda_text_object.c:550
 #, fuzzy
 msgid "Setting alignment to LOWER_LEFT."
 msgstr "Установка выравнивания по левому нижнему углу\n"
 
-#: liblepton/src/geda_text_object.c:570
 #, fuzzy, c-format
 msgid "Unexpected end-of-file after %1$d lines"
 msgstr "Неожиданный конец файла после %d строк"
 
-#: liblepton/src/s_clib.c:460
 #, fuzzy, c-format
 msgid "Library command failed [%1$s]: %2$s"
 msgstr "Ошибка при выполнении команды над библиотекой «%s»: %s\n"
 
-#: liblepton/src/s_clib.c:465
 #, fuzzy, c-format
 msgid "Library command failed [%1$s]: Uncaught signal %2$i."
 msgstr "Сбой команды создания библиотеки «%s»: необработанный сигнал %i.\n"
 
-#: liblepton/src/s_clib.c:469
 #, fuzzy, c-format
 msgid "Library command failed [%1$s]"
 msgstr "Сбой команды создания библиотеки «%s»\n"
 
-#: liblepton/src/s_clib.c:470
 #, fuzzy, c-format
 msgid ""
 "Error output was:\n"
@@ -770,35 +634,29 @@ msgstr ""
 "Вывод ошибки:\n"
 "%s\n"
 
-#: liblepton/src/s_clib.c:556
 #, fuzzy, c-format
 msgid "Library name [%1$s] already in use.  Using [%2$s]."
 msgstr "Библиотека с именем «%s» уже имеется. Используется «%s».\n"
 
-#: liblepton/src/s_clib.c:593
 #, fuzzy, c-format
 msgid "Failed to open directory [%1$s]: %2$s"
 msgstr "Не удалось открыть каталог «%s»: %s\n"
 
-#: liblepton/src/s_clib.c:729
 #, fuzzy, c-format
 msgid "Failed to scan library [%1$s]: Scheme function returned non-list."
 msgstr ""
 "Ошибка сканирования библиотеки «%s»: функция Scheme возвратила не список\n"
 
-#: liblepton/src/s_clib.c:737
 #, fuzzy, c-format
 msgid "Non-string symbol name while scanning library [%1$s]"
 msgstr ""
 "При сканировании библиотеки обнаружено имя символа, не являющееся строкой "
 "«%s»\n"
 
-#: liblepton/src/s_clib.c:893 liblepton/src/s_clib.c:940
 #, fuzzy
 msgid "Cannot add library: name not specified."
 msgstr "Невозможно добавить библиотеку: не указано имя\n"
 
-#: liblepton/src/s_clib.c:900
 #, fuzzy, c-format
 msgid ""
 "Cannot add library [%1$s]: both 'list' and 'get' commands must be specified."
@@ -806,279 +664,217 @@ msgstr ""
 "Невозможно добавить библиотеку «%s»: должны быть указаны обе команды «list» "
 "и «get».\n"
 
-#: liblepton/src/s_clib.c:948
 #, fuzzy, c-format
 msgid "Cannot add Scheme-library [%1$s]: callbacks must be closures."
 msgstr ""
 "Невозможно добавить библиотеку Scheme «%s»: функции обратного вызова должны "
 "быть замкнутыми выражениями\n"
 
-#: liblepton/src/s_clib.c:1075
 #, fuzzy, c-format
 msgid "Failed to load symbol from file [%1$s]: %2$s"
 msgstr "Ошибка загрузки символа из файла «%s»: %s\n"
 
-#: liblepton/src/s_clib.c:1135
 #, fuzzy, c-format
 msgid "Failed to load symbol data [%1$s] from source [%2$s]"
 msgstr "Ошибка загрузки данных символа «%s» из источника «%s»\n"
 
-#: liblepton/src/s_clib.c:1377
 #, fuzzy, c-format
 msgid "Component [%1$s] was not found in the component library."
 msgstr "Компонент «%s» не найден в библиотеке компонентов\n"
 
-#: liblepton/src/s_clib.c:1383
 #, fuzzy, c-format
 msgid "More than one component found with name [%1$s]."
 msgstr "Обнаружено несколько компонентов с именем «%s»\n"
 
-#: liblepton/src/s_hierarchy.c:78 liblepton/src/s_hierarchy.c:240
 msgid "Schematic not found in source library."
 msgstr "Схема не найдена в библиотеке исходных данных."
 
-#: liblepton/src/s_hierarchy.c:100
 msgid "Hierarchy contains a circular dependency."
 msgstr "Циклическая зависимость в иерархической структуре."
 
-#: liblepton/src/s_hierarchy.c:200
 #, fuzzy
 msgid "There are no schematics above the current one!"
 msgstr "Для текущей схемы нет схемы, вышестоящей по иерархии!\n"
 
-#: liblepton/src/s_hierarchy.c:341
 #, fuzzy, c-format
 msgid "Failed to descend hierarchy into '%1$s': %2$s"
 msgstr "Не удалось перейти к подсхеме «%s»: %s\n"
 
-#: liblepton/src/s_slot.c:158
 #, fuzzy
 msgid "Did not find slotdef=#:#,#,#... attribute."
 msgstr "Не удалось найти атрибут «slotdef=#:#,#,#...»\n"
 
-#: liblepton/src/s_slot.c:164
 #, fuzzy
 msgid "Improper slotdef syntax: missing \":\"."
 msgstr "Неверный синтаксис атрибута «slotdef»: отсутствует «:».\n"
 
-#: liblepton/src/s_slot.c:179
 #, fuzzy
 msgid "Did not find proper slotdef=#:#,#,#... attribute."
 msgstr "Не удалось найти атрибут «slotdef=#:#,#,#...» в допустимом формате\n"
 
-#: liblepton/src/s_slot.c:209
 #, fuzzy
 msgid "component missing pinseq= attribute."
 msgstr "Отсутствует атрибут «pinseq» у вывода компонента\n"
 
-#: liblepton/src/edaconfig.c:694 liblepton/src/edaconfig.c:780
 msgid "Undefined configuration filename"
 msgstr "Не определено имя файла настроек"
 
-#: liblepton/src/edaconfig.c:1105 liblepton/src/edaconfig.c:1169
 #, c-format
 msgid "Configuration does not have group '%s'"
 msgstr "В настройках не обнаружено группы «%s»"
 
-#: liblepton/src/edaconfig.c:1183
 #, c-format
 msgid "Configuration does not have key '%s'"
 msgstr "В настройках не обнаружено ключа «%s»"
 
-#: liblepton/src/scheme_attrib.c:66 liblepton/src/scheme_attrib.c:100
 msgid "~A is not a valid attribute: invalid string '~A'."
 msgstr "~A не является допустимым атрибутом: недопустимая строка «~A»."
 
-#: liblepton/src/scheme_attrib.c:204
 msgid "Objects ~A and ~A are not part of the same page and/or complex object"
 msgstr ""
 "Объекты ~A и ~A не являются частями одной схемы и (или) одного составного "
 "объекта"
 
-#: liblepton/src/scheme_attrib.c:211 liblepton/src/scheme_attrib.c:216
 msgid "Object ~A is already attached as an attribute"
 msgstr "Объект ~A уже прикреплён как атрибут"
 
-#: liblepton/src/scheme_attrib.c:265
 msgid "Object ~A is attribute of wrong object"
 msgstr "Объект ~A является атрибутом другого объекта"
 
-#: liblepton/src/scheme_complex.c:148
 msgid "Invalid complex angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr ""
 "Недопустимый угол поворота составного объекта ~A. Должен быть 0, 90, 180 или "
 "270 градусов"
 
-#: liblepton/src/scheme_complex.c:270 liblepton/src/scheme_page.c:246
 msgid "Object ~A is already attached to something"
 msgstr "Объект ~A уже к чему-то прикреплён"
 
-#: liblepton/src/scheme_complex.c:332
 msgid "Object ~A is attached to a different complex"
 msgstr "Объект ~A прикреплён к другому составному объекту"
 
-#: liblepton/src/scheme_complex.c:339
 msgid "Object ~A is attached to a page"
 msgstr "Объект ~A прикреплён к странице"
 
-#: liblepton/src/scheme_complex.c:346 liblepton/src/scheme_page.c:298
 msgid "Object ~A is attached as an attribute"
 msgstr "Объект ~A прикреплён как атрибут"
 
-#: liblepton/src/scheme_complex.c:353 liblepton/src/scheme_page.c:305
 msgid "Object ~A has attributes"
 msgstr "К объекту ~A прикреплены атрибуты"
 
-#: liblepton/src/scheme_object.c:234
 msgid "Object ~A has bad type '~A'"
 msgstr "Недопустимый тип объекта ~A: «~A»"
 
-#: liblepton/src/scheme_object.c:378
 msgid "Object ~A has invalid stroke cap style ~A"
 msgstr "Недопустимый стиль концов линий объекта ~A: ~A"
 
 # 'stroke' в данном случае означает линию, а не жест
-#: liblepton/src/scheme_object.c:391
 msgid "Object ~A has invalid stroke dash style ~A"
 msgstr "Недопустимый тип линий для объекта ~A: ~A"
 
-#: liblepton/src/scheme_object.c:455
 msgid "Invalid stroke cap style ~A."
 msgstr "Недопустимое значение поля «capstyle» (стиль концов линии): ~A."
 
-#: liblepton/src/scheme_object.c:466
 msgid "Invalid stroke dash style ~A."
 msgstr "Недопустимое значение поля «dashstyle» (тип линии): ~A."
 
-#: liblepton/src/scheme_object.c:476
 msgid "Missing dash length parameter for dash style ~A."
 msgstr "Отсутствует поле «dashlength» (длина штриха): ~A."
 
-#: liblepton/src/scheme_object.c:486
 msgid "Missing dot/dash space parameter for dash style ~A."
 msgstr "Отсутствует поле «dashspace» (тип линии): ~A."
 
-#: liblepton/src/scheme_object.c:554
 msgid "Object ~A has invalid fill style ~A"
 msgstr "Недопустимый тип заполнения объекта ~A: ~A"
 
-#: liblepton/src/scheme_object.c:603
 msgid "Invalid fill style ~A."
 msgstr "Недопустимый тип заполнения ~A."
 
-#: liblepton/src/scheme_object.c:611
 msgid "Missing second space parameter for fill style ~A."
 msgstr "Отсутствует параметр типа заполнения «pitch2»: ~A."
 
-#: liblepton/src/scheme_object.c:620
 msgid "Missing second angle parameter for fill style ~A."
 msgstr "Отсутствует параметр типа заполнения «angle2»: ~A."
 
-#: liblepton/src/scheme_object.c:630
 msgid "Missing stroke width parameter for fill style ~A."
 msgstr "Отсутствует параметр типа заполнения «fillwidth»: ~A."
 
-#: liblepton/src/scheme_object.c:639
 msgid "Missing space parameter for fill style ~A."
 msgstr "Отсутствует параметр типа заполнения «pitch1»: ~A."
 
-#: liblepton/src/scheme_object.c:648
 msgid "Missing angle parameter for fill style ~A."
 msgstr "Отсутствует параметр типа заполнения «angle1»: ~A."
 
-#: liblepton/src/scheme_object.c:962
 msgid "Invalid pin type ~A, must be 'net or 'bus"
 msgstr "Недопустимый тип вывода ~A, должен быть «'net» или «'bus»"
 
-#: liblepton/src/scheme_object.c:1011
 msgid "Object ~A has invalid pin type."
 msgstr "Недопустимый тип вывода объекта ~A."
 
-#: liblepton/src/scheme_object.c:1417
 msgid "Invalid text alignment ~A."
 msgstr "Недопустимое значение поля «alignment» текстового объекта: ~A."
 
-#: liblepton/src/scheme_object.c:1433
 msgid "Invalid text angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr ""
 "Недопустимое значение угла поворота текстового объекта ~A. Угол должен быть "
 "равен  0, 90, 180 или 270 градусов"
 
-#: liblepton/src/scheme_object.c:1452
 msgid "Invalid text name/value visibility ~A."
 msgstr "Недопустимое значение поля «show_name_value» текстового объекта: ~A."
 
-#: liblepton/src/scheme_object.c:1526
 msgid "Text object ~A has invalid text alignment ~A"
 msgstr "Недопустимое значение поля «alignment» текстового объекта ~A: ~A"
 
-#: liblepton/src/scheme_object.c:1535
 msgid "Text object ~A has invalid visibility ~A"
 msgstr "Недопустимое значение поля «visibility» текстового объекта ~A: ~A"
 
-#: liblepton/src/scheme_object.c:1545
 msgid "Text object ~A has invalid text attribute visibility ~A"
 msgstr "Недопустимое значение поля «show_name_value» текстового объекта ~A: ~A"
 
-#: liblepton/src/scheme_object.c:1586
 msgid "Object ~A is not included in a page."
 msgstr "Объекта ~A нет на странице."
 
-#: liblepton/src/scheme_object.c:1739
 msgid "Path object ~A has invalid element type ~A at index ~A"
 msgstr "Контур ~A имеет недопустимое значение типа элемента ~A с индексом ~A"
 
-#: liblepton/src/scheme_object.c:1853
 msgid "Invalid path element type ~A."
 msgstr "Недопустимое значение типа элемента контура: ~A."
 
-#: liblepton/src/scheme_object.c:2025
 msgid "Invalid picture angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr ""
 "Недопустимое значение угла поворота изображения ~A. Угол должен быть равен  "
 "0, 90, 180 или 270 градусов"
 
-#: liblepton/src/scheme_page.c:291
 msgid "Object ~A is attached to a complex or different page"
 msgstr ""
 "Объект ~A прикреплён к составному объекту или находится на другой странице"
 
-#: liblepton/src/scheme_page.c:438
 msgid "Parse error: ~s"
 msgstr "Ошибка обработки: ~s"
 
-#: liblepton/src/edascmhookproxy.c:83
 msgid "Scheme hook"
 msgstr "Функция перехвата Scheme"
 
-#: liblepton/src/edascmhookproxy.c:84
 msgid "The Scheme-level hook to proxy"
 msgstr "Перехват функций Scheme для EdascmHookProxy"
 
-#: liblepton/scheme/geda/attrib.scm:56
 #, scheme-format
 msgid "Object ~A is not part of a page"
 msgstr "Объект ~A не является частью схемы"
 
-#: liblepton/scheme/geda/library.scm:108
 #, fuzzy, scheme-format
 msgid "Invalid path ~S or source not readable.\n"
 msgstr "source-library: недопустимый путь «%s»\n"
 
-#: liblepton/scheme/geda/library.scm:109
 msgid "Source library path must be a string.\n"
 msgstr ""
 
-#: liblepton/scheme/geda/library.scm:168
 #, fuzzy, scheme-format
 msgid "File ~S is not readable.\n"
 msgstr "Файл %s только для чтения"
 
-#: liblepton/scheme/geda/repl.scm:48
 msgid "Welcome to Lepton REPL!\n"
 msgstr ""
 
-#: liblepton/scheme/geda/repl.scm:53
 msgid "WARNING: Readline library is not supported in your configuration.\n"
 msgstr ""
 

--- a/liblepton/po/sr.po
+++ b/liblepton/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-12 00:08+0300\n"
+"POT-Creation-Date: 2019-05-13 11:16+0300\n"
 "PO-Revision-Date: 2012-01-27 14:12+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: Serbian <sr@li.org>\n"
@@ -18,46 +18,37 @@ msgstr ""
 "X-Launchpad-Export-Date: 2012-11-14 16:52+0000\n"
 "X-Generator: Launchpad (build 16265)\n"
 
-#: liblepton/data/liblepton.xml.in:3
 #, fuzzy
 msgid "Lepton EDA circuit schematic"
 msgstr "гЕДА — шема електричних кола"
 
-#: liblepton/data/liblepton.xml.in:4
 #, fuzzy
 msgid "Lepton EDA schematic symbol"
 msgstr "гЕДА — симбол шеме"
 
-#: liblepton/data/liblepton.xml.in:5
 #, fuzzy
 msgid "Lepton EDA sch2pcb project"
 msgstr "гЕДА — „gsch2pcb“ пројекат"
 
-#: liblepton/data/x-lepton-sch2pcb-project.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA sch2pcb Project"
 msgstr "гЕДА — „gsch2pcb“ пројекат"
 
-#: liblepton/data/x-lepton-schematic.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Circuit Schematic"
 msgstr "гЕДА — шема електричних кола"
 
-#: liblepton/data/x-lepton-symbol.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Schematic Symbol"
 msgstr "гЕДА — симбол шеме"
 
-#: liblepton/src/a_basic.c:57 liblepton/src/f_basic.c:377
 #, c-format
 msgid "File %1$s is read-only"
 msgstr ""
 
-#: liblepton/src/a_basic.c:114
 msgid "Schematic data was not valid UTF-8"
 msgstr ""
 
-#: liblepton/src/a_basic.c:246
 #, fuzzy, c-format
 msgid ""
 "Read unexpected attach symbol start marker in [%1$s] :\n"
@@ -68,7 +59,6 @@ msgstr ""
 ">>\n"
 "%s<<\n"
 
-#: liblepton/src/a_basic.c:263
 #, fuzzy, c-format
 msgid ""
 "Read unexpected embedded symbol start marker in [%1$s] :\n"
@@ -79,7 +69,6 @@ msgstr ""
 ">>\n"
 "%s<<\n"
 
-#: liblepton/src/a_basic.c:294
 #, c-format
 msgid ""
 "Read unexpected embedded symbol end marker in [%s] :\n"
@@ -90,7 +79,6 @@ msgstr ""
 ">>\n"
 "%s<<\n"
 
-#: liblepton/src/a_basic.c:329
 #, fuzzy, c-format
 msgid ""
 "Read an old format sym/sch file!\n"
@@ -101,7 +89,6 @@ msgstr ""
 "Молим покрените „g[sym|sch]update“ на:\n"
 "(%s)\n"
 
-#: liblepton/src/a_basic.c:335
 #, fuzzy, c-format
 msgid ""
 "Read garbage in [%1$s] :\n"
@@ -112,17 +99,14 @@ msgstr ""
 ">>\n"
 "%s<<\n"
 
-#: liblepton/src/f_basic.c:119 liblepton/src/f_basic.c:132
 #, fuzzy, c-format
 msgid "Failed to stat [%1$s]: %2$s"
 msgstr "Нисам успео да направим статистику (%s): %s"
 
-#: liblepton/src/f_basic.c:211
 #, fuzzy, c-format
 msgid "Cannot find file %1$s: %2$s"
 msgstr "Не могу да пронађем датотеку „%s“: %s"
 
-#: liblepton/src/f_basic.c:260
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -135,12 +119,10 @@ msgstr ""
 "  %s.\n"
 "\n"
 
-#: liblepton/src/f_basic.c:262
 msgid "I could not guess if it is newer, so you have to do it manually.\n"
 msgstr ""
 "Не могу да погодим да ли је новија, зато ви морате то да урадите ручно.\n"
 
-#: liblepton/src/f_basic.c:264
 msgid ""
 "The backup copy is newer than the schematic, so it seems you should load it "
 "instead of the original file.\n"
@@ -148,7 +130,6 @@ msgstr ""
 "Резервни примерак је новији од шеме, зато изгледа да треба да га учитате "
 "уместо оригиналне датотеке.\n"
 
-#: liblepton/src/f_basic.c:266
 #, fuzzy
 msgid ""
 "lepton-schematic usually makes backup copies automatically, and this "
@@ -157,7 +138,6 @@ msgstr ""
 "Гшема обично самостално прави резервне примерке, а до ове ситуације је дошло "
 "када се урушио или је био приморан да нагло изађе.\n"
 
-#: liblepton/src/f_basic.c:269
 #, fuzzy
 msgid ""
 "\n"
@@ -168,230 +148,175 @@ msgstr ""
 "Покрените гшему и исправите ситуацију.\n"
 "\n"
 
-#: liblepton/src/f_basic.c:367
 #, fuzzy, c-format
 msgid "Can't get the real filename of %1$s: %2$s"
 msgstr "s_page_delete: Не могу да добавим прави назив датотеке „%s“."
 
-#: liblepton/src/f_basic.c:398
 #, fuzzy, c-format
 msgid "Could NOT set previous backup file [%1$s] read-write."
 msgstr "НЕ могу да подесим читање-писање претходног резервног примерка (%s)\n"
 
-#: liblepton/src/f_basic.c:404
 #, fuzzy, c-format
 msgid "Can't save backup file: %1$s."
 msgstr "Не могу да сачувам датотеку резервног примерка: %s."
 
-#: liblepton/src/f_basic.c:414
 #, fuzzy, c-format
 msgid "Could NOT set backup file [%1$s] readonly."
 msgstr "НЕ могу да подесим само за читање датотеку резервног примерка (%s)\n"
 
-#: liblepton/src/f_basic.c:463
 #, fuzzy, c-format
 msgid "Failed to restore permissions on '%1$s': %2$s\n"
 msgstr "Нисам успео да отворим директоријум (%s): %s\n"
 
-#: liblepton/src/f_basic.c:468
 #, fuzzy, c-format
 msgid "Failed to restore ownership on '%1$s': %2$s\n"
 msgstr "Нисам успео да отворим директоријум (%s): %s\n"
 
-#: liblepton/src/f_basic.c:478
 #, fuzzy, c-format
 msgid "Could NOT save file: %1$s"
 msgstr "НЕ МОГУ да сачувам (%s)\n"
 
-#: liblepton/src/f_basic.c:604
 #, c-format
 msgid "%s: %s"
 msgstr "„%s“: %s"
 
-#: liblepton/src/g_basic.c:260
 msgid ""
 "\n"
 "Backtrace:\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:99
 #, fuzzy, c-format
 msgid "Invalid mode [%1$s] passed to %2$s\n"
 msgstr "Нисам пронашао компоненту (%s) у библиотеци компоненти\n"
 
-#: liblepton/src/g_rc.c:139
 msgid "RC file already loaded"
 msgstr ""
 
-#: liblepton/src/g_rc.c:183
 #, fuzzy, c-format
 msgid "Failed to load config from '%1$s': %2$s\n"
 msgstr "Нисам успео да учитам слику из датотеке (%s): %s\n"
 
-#: liblepton/src/g_rc.c:207
 #, fuzzy, c-format
 msgid "Loaded RC file [%1$s]"
 msgstr "Није успела наредба библиотеке (%s)\n"
 
-#: liblepton/src/g_rc.c:211
 #, fuzzy, c-format
 msgid "Failed to load RC file [%1$s]: "
 msgstr "Нисам успео да учитам слику из датотеке (%s): %s\n"
 
-#: liblepton/src/g_rc.c:341
 msgid "ERROR: An unknown error occurred while parsing configuration files."
 msgstr ""
 
-#: liblepton/src/g_rc.c:353
 #, c-format
 msgid "ERROR: %1$s"
 msgstr ""
 
-#: liblepton/src/g_rc.c:354
 #, c-format
 msgid "ERROR: %1$s\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:360
 #, c-format
 msgid "ERROR: The %1$s log may contain more information.\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:512
 #, fuzzy, c-format
 msgid "Invalid path [%1$s] passed to component-library\n"
 msgstr "Нисам пронашао компоненту (%s) у библиотеци компоненти\n"
 
-#: liblepton/src/g_rc.c:738
 #, fuzzy, c-format
 msgid "Invalid path [%1$s] passed to bitmap-directory\n"
 msgstr "Нисам пронашао компоненту (%s) у библиотеци компоненти\n"
 
-#: liblepton/src/geda_page.c:197
 #, fuzzy, c-format
 msgid "s_page_delete: Can't get the real filename of %1$s."
 msgstr "s_page_delete: Не могу да добавим прави назив датотеке „%s“."
 
-#: liblepton/src/geda_page.c:208
 #, fuzzy, c-format
 msgid "s_page_delete: Unable to delete backup file %1$s."
 msgstr "s_page_delete: Не могу да избришем датотеку резервног примерка „%s“."
 
-#: liblepton/src/geda_page.c:490
 #, fuzzy, c-format
 msgid "Saved [%1$s]"
 msgstr "Сачувао сам (%s)\n"
 
-#: liblepton/src/geda_page.c:496
 #, fuzzy, c-format
 msgid "Could NOT save [%1$s]"
 msgstr "НЕ МОГУ да сачувам (%s)\n"
 
-#: liblepton/src/geda_arc_object.c:408 liblepton/src/geda_arc_object.c:421
 msgid "Failed to parse arc object"
 msgstr ""
 
-#: liblepton/src/geda_arc_object.c:428
 #, fuzzy, c-format
 msgid "Found a zero radius arc [ %1$c %2$d, %3$d, %4$d, %5$d, %6$d, %7$d ]"
 msgstr "Пронашао сам лук нултог полупречника ( %c %d, %d, %d, %d, %d, %d )\n"
 
-#: liblepton/src/geda_arc_object.c:435 liblepton/src/geda_box_object.c:328
-#: liblepton/src/geda_bus_object.c:364 liblepton/src/geda_circle_object.c:387
-#: liblepton/src/geda_line_object.c:427 liblepton/src/geda_net_object.c:308
-#: liblepton/src/geda_path_object.c:214 liblepton/src/geda_pin_object.c:369
-#: liblepton/src/geda_text_object.c:555
 #, fuzzy, c-format
 msgid "Found an invalid color [ %1$s ]"
 msgstr "Пронашао сам неисправну боју ( %s )\n"
 
-#: liblepton/src/geda_arc_object.c:436 liblepton/src/geda_box_object.c:329
-#: liblepton/src/geda_bus_object.c:365 liblepton/src/geda_circle_object.c:388
-#: liblepton/src/geda_line_object.c:428 liblepton/src/geda_net_object.c:309
-#: liblepton/src/geda_path_object.c:215 liblepton/src/geda_pin_object.c:370
-#: liblepton/src/geda_text_object.c:557
 #, fuzzy
 msgid "Setting color to default color."
 msgstr "Подешавам боју на основну боју\n"
 
-#: liblepton/src/o_attrib.c:111
 #, c-format
 msgid "Attribute [%1$s] already attached\n"
 msgstr ""
 
-#: liblepton/src/o_attrib.c:117
 msgid "Attempt to attach non text item as an attribute!\n"
 msgstr "Покушај да се приложи ставка која није текст као особина!\n"
 
-#: liblepton/src/o_attrib.c:122
 #, fuzzy, c-format
 msgid "Attempt to attach attribute [%1$s] to more than one object\n"
 msgstr "Покушај да се приложи особина (%s) на више од једног објекта\n"
 
-#: liblepton/src/o_attrib.c:325
 msgid "Tried to attach a non-text item as an attribute"
 msgstr ""
 
-#: liblepton/src/o_attrib.c:332
 msgid "Unexpected end-of-file in attribute list"
 msgstr ""
 
-#: liblepton/src/geda_box_object.c:287 liblepton/src/geda_box_object.c:316
 msgid "Failed to parse box object"
 msgstr ""
 
-#: liblepton/src/geda_box_object.c:322
 #, fuzzy, c-format
 msgid "Found a zero width/height box [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr "Пронашао сам поље нулте ширине/висине ( %c %d %d %d %d %d )\n"
 
-#: liblepton/src/geda_bus_object.c:345 liblepton/src/geda_bus_object.c:352
 msgid "Failed to parse bus object"
 msgstr ""
 
-#: liblepton/src/geda_bus_object.c:358
 #, fuzzy, c-format
 msgid "Found a zero length bus [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr "Пронашао сам магистралу нулте дужине ( %c %d %d %d %d %d )\n"
 
-#: liblepton/src/geda_bus_object.c:370
 #, fuzzy, c-format
 msgid "Found an invalid bus ripper direction [ %1$s ]"
 msgstr "Пронашао сам неисправан смер извлачивача магистрале ( %s )\n"
 
-#: liblepton/src/geda_bus_object.c:371
 #, fuzzy
 msgid "Resetting direction to neutral (no direction)."
 msgstr "Враћам правац на неутралан (без правца)\n"
 
-#: liblepton/src/geda_circle_object.c:343
-#: liblepton/src/geda_circle_object.c:372
 msgid "Failed to parse circle object"
 msgstr ""
 
-#: liblepton/src/geda_circle_object.c:379
 #, fuzzy, c-format
 msgid "Found a zero or negative radius circle [ %1$c %2$d %3$d %4$d %5$d ]"
 msgstr "Пронашао сам лук нултог полупречника ( %c %d, %d, %d, %d, %d, %d )\n"
 
-#: liblepton/src/geda_circle_object.c:382
 #, fuzzy
 msgid "Setting radius to 0."
 msgstr "Подешавам угао на 0\n"
 
-#: liblepton/src/geda_color.c:217
 msgid "Color map entry must be a two-element list"
 msgstr "Унос мапе боје мора бити списак два елемента"
 
-#: liblepton/src/geda_color.c:225
 msgid "Index in color map entry must be an integer"
 msgstr "Индекс у уносу мапе боје мора бити цео број"
 
-#: liblepton/src/geda_color.c:251
 msgid "Value in color map entry must be #f or a string"
 msgstr "Вредност у уносу мапе боје мора бити „#f“ или ниска"
 
-#: liblepton/src/geda_complex_object.c:373
 #, fuzzy, c-format
 msgid ""
 "Component not found:\n"
@@ -400,11 +325,9 @@ msgstr ""
 "Нисам пронашао компоненту:\n"
 " %s"
 
-#: liblepton/src/geda_complex_object.c:585
 msgid "Failed to parse complex object"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:598
 #, fuzzy, c-format
 msgid ""
 "Found a component with an invalid rotation [ %1$c %2$d %3$d %4$d %5$d %6$d "
@@ -412,13 +335,10 @@ msgid ""
 msgstr ""
 "Пронашао сам компоненту са неисправном ротацијом ( %c %d %d %d %d %d %s )\n"
 
-#: liblepton/src/geda_complex_object.c:601
-#: liblepton/src/geda_picture_object.c:105
 #, fuzzy
 msgid "Setting angle to 0."
 msgstr "Подешавам угао на 0\n"
 
-#: liblepton/src/geda_complex_object.c:613
 #, fuzzy, c-format
 msgid ""
 "Found a component with an invalid mirror flag [ %1$c %2$d %3$d %4$d %5$d "
@@ -427,12 +347,10 @@ msgstr ""
 "Пронашао сам компоненту са неисправном заставицом огледала ( %c %d %d %d %d "
 "%d %s )\n"
 
-#: liblepton/src/geda_complex_object.c:616
 #, fuzzy
 msgid "Setting mirror to 0."
 msgstr "Подешавам пресликано на 0\n"
 
-#: liblepton/src/geda_complex_object.c:941
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
@@ -441,7 +359,6 @@ msgstr ""
 "УПОЗОРЕЊЕ: Грешка при анализи издања симбола на рефдес-у „%s“:\n"
 "\t  Не могу да анализирам датотеку издање_симбола=„%s“\n"
 
-#: liblepton/src/geda_complex_object.c:945
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
@@ -450,7 +367,6 @@ msgstr ""
 "УПОЗОРЕЊЕ: Грешка при анализи издања симбола на рефдес-у „%s“:\n"
 "\t  Не могу да анализирам датотеку издање_симбола=\n"
 
-#: liblepton/src/geda_complex_object.c:961
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
@@ -459,7 +375,6 @@ msgstr ""
 "УПОЗОРЕЊЕ: Грешка при анализи издања симбола на рефдес-у „%s“:\n"
 "\t  Не могу да анализирам приложено издање_симбола=„%s“\n"
 
-#: liblepton/src/geda_complex_object.c:986
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version oddity on refdes %1$s:\n"
@@ -470,7 +385,6 @@ msgstr ""
 "\t  издање_симбола=%s је приложено инстанцном симболу, али нема "
 "издања_симбола= унутар датотеке симбола\n"
 
-#: liblepton/src/geda_complex_object.c:1000
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version mismatch on refdes %1$s (%2$s):\n"
@@ -479,17 +393,14 @@ msgstr ""
 "УПОЗОРЕЊЕ: Неслагање издања симбола на рефдес-у „%s“ (%s):\n"
 "\t  Симбол у библиотеци је новији од инстанцног симбола\n"
 
-#: liblepton/src/geda_complex_object.c:1028
 #, fuzzy, c-format
 msgid "\tMAJOR VERSION CHANGE (file %1$.3f, instantiated %2$.3f, %3$s)!"
 msgstr "\tИЗМЕНА ГЛАВНОГ ИЗДАЊА (датотека „%.3f“, инстанцирана „%.3f“, %s)!\n"
 
-#: liblepton/src/geda_complex_object.c:1046
 #, fuzzy, c-format
 msgid "\tMinor version change (file %1$.3f, instantiated %2$.3f)"
 msgstr "\tИзмена нижег издања (датотека „%.3f“, инстанцирано „%.3f“)\n"
 
-#: liblepton/src/geda_complex_object.c:1057
 #, fuzzy, c-format
 msgid ""
 "WARNING: Symbol version oddity on refdes %1$s:\n"
@@ -498,12 +409,10 @@ msgstr ""
 "УПОЗОРЕЊЕ: Чудност издања симбола на рефдес-у „%s“:\n"
 "\t  Инстанцирани симбол је новији од симбола у библиотеци\n"
 
-#: liblepton/src/o_embed.c:54
 #, fuzzy, c-format
 msgid "Component [%1$s] has been embedded."
 msgstr "Компонента (%s) је уграђена\n"
 
-#: liblepton/src/o_embed.c:98
 #, fuzzy, c-format
 msgid ""
 "Could not find component [%1$s], while trying to unembed. Component is still "
@@ -512,149 +421,118 @@ msgstr ""
 "Не могу да пронађем компоненту (%s), док покушавам да је избацим. Компонента "
 "је још увек уграђена.\n"
 
-#: liblepton/src/o_embed.c:106
 #, fuzzy, c-format
 msgid "Component [%1$s] has been successfully unembedded."
 msgstr "Компонента (%s) је успешно избачена\n"
 
-#: liblepton/src/geda_line_object.c:391 liblepton/src/geda_line_object.c:409
 msgid "Failed to parse line object"
 msgstr ""
 
-#: liblepton/src/geda_line_object.c:421
 #, fuzzy, c-format
 msgid "Found a zero length line [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr "Пронашао сам линију нулте дужине ( %c %d %d %d %d %d )\n"
 
-#: liblepton/src/geda_net_object.c:297
 msgid "Failed to parse net object"
 msgstr ""
 
-#: liblepton/src/geda_net_object.c:302
 #, fuzzy, c-format
 msgid "Found a zero length net [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr "Пронашао сам мрежу нулте дужине ( %c %d %d %d %d %d )\n"
 
-#: liblepton/src/geda_path_object.c:206
 msgid "Failed to parse path object"
 msgstr ""
 
-#: liblepton/src/geda_path_object.c:232
 msgid "Unexpected end-of-file when reading path"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:71
 msgid "Failed to parse picture definition"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:76
 #, fuzzy, c-format
 msgid "Found a zero width/height picture [ %1$c %2$d %3$d %4$d %5$d ]"
 msgstr "Пронашао сам слику нулте ширине/висине ( %c %d %d %d %d )\n"
 
-#: liblepton/src/geda_picture_object.c:82
 #, c-format
 msgid "Found a picture with a wrong 'mirrored' parameter: %1$d."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:84
 #, fuzzy
 msgid "Setting mirrored to 0."
 msgstr "Подешавам пресликано на 0\n"
 
-#: liblepton/src/geda_picture_object.c:89
 #, c-format
 msgid "Found a picture with a wrong 'embedded' parameter: %1$d."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:91
 #, fuzzy
 msgid "Setting embedded to 0."
 msgstr "Подешавам уграђено на 0\n"
 
-#: liblepton/src/geda_picture_object.c:104
 #, fuzzy, c-format
 msgid "Found an unsupported picture angle [ %1$d ]"
 msgstr "Пронашао сам неподржан угао слике ( %d )\n"
 
-#: liblepton/src/geda_picture_object.c:116
 msgid "Found an image with no filename."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:147
 #, fuzzy, c-format
 msgid "Failed to load image from embedded data [%1$s]: %2$s"
 msgstr "Нисам успео да учитам слику из уграђених података (%s): %s\n"
 
-#: liblepton/src/geda_picture_object.c:148
 msgid "Base64 decoding failed."
 msgstr "Није успело декодирање базе64."
 
-#: liblepton/src/geda_picture_object.c:149
 #, fuzzy
 msgid "Falling back to file loading. Picture unembedded."
 msgstr "Пребацујем се назад на учитавање слике. Слика је избачена.\n"
 
-#: liblepton/src/geda_picture_object.c:208
 #, fuzzy
 msgid "ERROR: o_picture_save: unable to encode the picture."
 msgstr "ГРЕШКА: о_сачувај_слику: не могу да шифрујем слику.\n"
 
-#: liblepton/src/geda_picture_object.c:308
 #, fuzzy, c-format
 msgid "Failed to load buffer image [%1$s]: %2$s"
 msgstr "Нисам успео да учитам симбол из датотеке (%s): %s\n"
 
-#: liblepton/src/geda_picture_object.c:321
 #, fuzzy, c-format
 msgid "Failed to load image from [%1$s]: %2$s"
 msgstr "Нисам успео да учитам слику из датотеке (%s): %s\n"
 
-#: liblepton/src/geda_picture_object.c:415
 #, c-format
 msgid "Picture %1$p has invalid angle %2$i\n"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:772
 #, fuzzy, c-format
 msgid "Picture [%1$s] has no image data."
 msgstr "Слика (%s) је уграђена\n"
 
-#: liblepton/src/geda_picture_object.c:773
 #, fuzzy
 msgid "Falling back to file loading. Picture is still unembedded."
 msgstr "Пребацујем се назад на учитавање слике. Слика је избачена.\n"
 
-#: liblepton/src/geda_picture_object.c:781
 #, fuzzy, c-format
 msgid "Picture [%1$s] has been embedded."
 msgstr "Слика (%s) је уграђена\n"
 
-#: liblepton/src/geda_picture_object.c:805
 #, fuzzy, c-format
 msgid "Failed to load image from file [%1$s]: %2$s"
 msgstr "Нисам успео да учитам слику из датотеке (%s): %s\n"
 
-#: liblepton/src/geda_picture_object.c:807
 #, fuzzy
 msgid "Picture is still embedded."
 msgstr "Слика (%s) је уграђена\n"
 
-#: liblepton/src/geda_picture_object.c:815
 #, fuzzy, c-format
 msgid "Picture [%1$s] has been unembedded."
 msgstr "Слика (%s) је избачена\n"
 
-#: liblepton/src/geda_picture_object.c:1052
 #, fuzzy, c-format
 msgid "Failed to load fallback image %1$s: %2$s.\n"
 msgstr "Нисам успео да учитам слику из датотеке (%s): %s\n"
 
-#: liblepton/src/geda_pin_object.c:346 liblepton/src/geda_pin_object.c:354
 msgid "Failed to parse pin object"
 msgstr ""
 
-#: liblepton/src/geda_pin_object.c:360
 #, fuzzy
 msgid ""
 "Found a pin which did not have the whichend field set.\n"
@@ -663,67 +541,53 @@ msgstr ""
 "Пронашао сам ножицу која нема подешено поље „који“.\n"
 "Проверите и исправите ручно.\n"
 
-#: liblepton/src/geda_pin_object.c:363
 #, fuzzy, c-format
 msgid "Found an invalid whichend on a pin (reseting to zero): %d"
 msgstr "Пронашао сам неисправан „који крај“ на ножици (враћам на нулу): %d\n"
 
-#: liblepton/src/geda_text_object.c:495 liblepton/src/geda_text_object.c:505
-#: liblepton/src/geda_text_object.c:515
 msgid "Failed to parse text object"
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:522
 #, fuzzy, c-format
 msgid "Found an invalid text size [ %1$s ]"
 msgstr "Пронашао сам неисправну боју ( %s )\n"
 
-#: liblepton/src/geda_text_object.c:524
 #, fuzzy, c-format
 msgid "Setting text size to %1$d."
 msgstr "Подешавам пресликано на 0\n"
 
-#: liblepton/src/geda_text_object.c:528
 #, fuzzy, c-format
 msgid "Found an unsupported text angle [ %1$s ]"
 msgstr "Пронашао сам неподржан угао слике ( %d )\n"
 
-#: liblepton/src/geda_text_object.c:530
 #, fuzzy, c-format
 msgid "Setting angle to %1$d."
 msgstr "Подешавам угао на 0\n"
 
-#: liblepton/src/geda_text_object.c:547
 #, fuzzy, c-format
 msgid "Found an unsupported text alignment [ %1$s ]"
 msgstr "Пронашао сам неподржан угао слике ( %d )\n"
 
-#: liblepton/src/geda_text_object.c:550
 #, fuzzy
 msgid "Setting alignment to LOWER_LEFT."
 msgstr "Подешавам поравнање на НИЖЕ_ЛЕВО\n"
 
-#: liblepton/src/geda_text_object.c:570
 #, c-format
 msgid "Unexpected end-of-file after %1$d lines"
 msgstr ""
 
-#: liblepton/src/s_clib.c:460
 #, fuzzy, c-format
 msgid "Library command failed [%1$s]: %2$s"
 msgstr "Није успела наредба библиотеке (%s): %s\n"
 
-#: liblepton/src/s_clib.c:465
 #, fuzzy, c-format
 msgid "Library command failed [%1$s]: Uncaught signal %2$i."
 msgstr "Није успела наредба библиотеке (%s): Неухваћени сигнал „%i“.\n"
 
-#: liblepton/src/s_clib.c:469
 #, fuzzy, c-format
 msgid "Library command failed [%1$s]"
 msgstr "Није успела наредба библиотеке (%s)\n"
 
-#: liblepton/src/s_clib.c:470
 #, fuzzy, c-format
 msgid ""
 "Error output was:\n"
@@ -732,33 +596,27 @@ msgstr ""
 "Излаз грешке беше:\n"
 "%s\n"
 
-#: liblepton/src/s_clib.c:556
 #, fuzzy, c-format
 msgid "Library name [%1$s] already in use.  Using [%2$s]."
 msgstr "Назив библиотеке (%s) је већ у употреби.  Користим (%s).\n"
 
-#: liblepton/src/s_clib.c:593
 #, fuzzy, c-format
 msgid "Failed to open directory [%1$s]: %2$s"
 msgstr "Нисам успео да отворим директоријум (%s): %s\n"
 
-#: liblepton/src/s_clib.c:729
 #, fuzzy, c-format
 msgid "Failed to scan library [%1$s]: Scheme function returned non-list."
 msgstr ""
 "Нисам успео да прегледам библиотеку (%s): Функција шеме није вратила списак\n"
 
-#: liblepton/src/s_clib.c:737
 #, fuzzy, c-format
 msgid "Non-string symbol name while scanning library [%1$s]"
 msgstr "Назив симбола не-ниске за време прегледања библиотеке (%s)\n"
 
-#: liblepton/src/s_clib.c:893 liblepton/src/s_clib.c:940
 #, fuzzy
 msgid "Cannot add library: name not specified."
 msgstr "Не могу да додам библиотеку: назив није наведен\n"
 
-#: liblepton/src/s_clib.c:900
 #, fuzzy, c-format
 msgid ""
 "Cannot add library [%1$s]: both 'list' and 'get' commands must be specified."
@@ -766,265 +624,203 @@ msgstr ""
 "Не могу да додам библиотеку (%s): морају бити наведене наредбе и „списак“ и "
 "„добави“.\n"
 
-#: liblepton/src/s_clib.c:948
 #, fuzzy, c-format
 msgid "Cannot add Scheme-library [%1$s]: callbacks must be closures."
 msgstr ""
 "Не могу да додам библиотеку шеме (%s): повратни позиви морају бити "
 "затварајући\n"
 
-#: liblepton/src/s_clib.c:1075
 #, fuzzy, c-format
 msgid "Failed to load symbol from file [%1$s]: %2$s"
 msgstr "Нисам успео да учитам симбол из датотеке (%s): %s\n"
 
-#: liblepton/src/s_clib.c:1135
 #, fuzzy, c-format
 msgid "Failed to load symbol data [%1$s] from source [%2$s]"
 msgstr "Нисам успео да учитам податак симбола (%s) из извора (%s)\n"
 
-#: liblepton/src/s_clib.c:1377
 #, fuzzy, c-format
 msgid "Component [%1$s] was not found in the component library."
 msgstr "Нисам пронашао компоненту (%s) у библиотеци компоненти\n"
 
-#: liblepton/src/s_clib.c:1383
 #, fuzzy, c-format
 msgid "More than one component found with name [%1$s]."
 msgstr "Пронашао сам више од једне компоненте са називом (%s)\n"
 
-#: liblepton/src/s_hierarchy.c:78 liblepton/src/s_hierarchy.c:240
 msgid "Schematic not found in source library."
 msgstr ""
 
-#: liblepton/src/s_hierarchy.c:100
 msgid "Hierarchy contains a circular dependency."
 msgstr ""
 
-#: liblepton/src/s_hierarchy.c:200
 #, fuzzy
 msgid "There are no schematics above the current one!"
 msgstr "Нема других електричних шема осим ове!\n"
 
-#: liblepton/src/s_hierarchy.c:341
 #, fuzzy, c-format
 msgid "Failed to descend hierarchy into '%1$s': %2$s"
 msgstr "Нисам успео да отворим директоријум (%s): %s\n"
 
-#: liblepton/src/s_slot.c:158
 msgid "Did not find slotdef=#:#,#,#... attribute."
 msgstr ""
 
-#: liblepton/src/s_slot.c:164
 msgid "Improper slotdef syntax: missing \":\"."
 msgstr ""
 
-#: liblepton/src/s_slot.c:179
 msgid "Did not find proper slotdef=#:#,#,#... attribute."
 msgstr ""
 
-#: liblepton/src/s_slot.c:209
 msgid "component missing pinseq= attribute."
 msgstr ""
 
-#: liblepton/src/edaconfig.c:694 liblepton/src/edaconfig.c:780
 msgid "Undefined configuration filename"
 msgstr ""
 
-#: liblepton/src/edaconfig.c:1105 liblepton/src/edaconfig.c:1169
 #, c-format
 msgid "Configuration does not have group '%s'"
 msgstr ""
 
-#: liblepton/src/edaconfig.c:1183
 #, c-format
 msgid "Configuration does not have key '%s'"
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:66 liblepton/src/scheme_attrib.c:100
 msgid "~A is not a valid attribute: invalid string '~A'."
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:204
 msgid "Objects ~A and ~A are not part of the same page and/or complex object"
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:211 liblepton/src/scheme_attrib.c:216
 msgid "Object ~A is already attached as an attribute"
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:265
 msgid "Object ~A is attribute of wrong object"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:148
 msgid "Invalid complex angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:270 liblepton/src/scheme_page.c:246
 msgid "Object ~A is already attached to something"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:332
 msgid "Object ~A is attached to a different complex"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:339
 msgid "Object ~A is attached to a page"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:346 liblepton/src/scheme_page.c:298
 msgid "Object ~A is attached as an attribute"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:353 liblepton/src/scheme_page.c:305
 msgid "Object ~A has attributes"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:234
 msgid "Object ~A has bad type '~A'"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:378
 msgid "Object ~A has invalid stroke cap style ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:391
 msgid "Object ~A has invalid stroke dash style ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:455
 msgid "Invalid stroke cap style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:466
 msgid "Invalid stroke dash style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:476
 msgid "Missing dash length parameter for dash style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:486
 msgid "Missing dot/dash space parameter for dash style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:554
 msgid "Object ~A has invalid fill style ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:603
 msgid "Invalid fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:611
 msgid "Missing second space parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:620
 msgid "Missing second angle parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:630
 msgid "Missing stroke width parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:639
 msgid "Missing space parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:648
 msgid "Missing angle parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:962
 msgid "Invalid pin type ~A, must be 'net or 'bus"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1011
 msgid "Object ~A has invalid pin type."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1417
 msgid "Invalid text alignment ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1433
 msgid "Invalid text angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1452
 msgid "Invalid text name/value visibility ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1526
 msgid "Text object ~A has invalid text alignment ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1535
 msgid "Text object ~A has invalid visibility ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1545
 msgid "Text object ~A has invalid text attribute visibility ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1586
 msgid "Object ~A is not included in a page."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1739
 msgid "Path object ~A has invalid element type ~A at index ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1853
 msgid "Invalid path element type ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:2025
 msgid "Invalid picture angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr ""
 
-#: liblepton/src/scheme_page.c:291
 msgid "Object ~A is attached to a complex or different page"
 msgstr ""
 
-#: liblepton/src/scheme_page.c:438
 msgid "Parse error: ~s"
 msgstr ""
 
-#: liblepton/src/edascmhookproxy.c:83
 msgid "Scheme hook"
 msgstr ""
 
-#: liblepton/src/edascmhookproxy.c:84
 msgid "The Scheme-level hook to proxy"
 msgstr ""
 
-#: liblepton/scheme/geda/attrib.scm:56
 #, scheme-format
 msgid "Object ~A is not part of a page"
 msgstr ""
 
-#: liblepton/scheme/geda/library.scm:108
 #, scheme-format
 msgid "Invalid path ~S or source not readable.\n"
 msgstr ""
 
-#: liblepton/scheme/geda/library.scm:109
 msgid "Source library path must be a string.\n"
 msgstr ""
 
-#: liblepton/scheme/geda/library.scm:168
 #, scheme-format
 msgid "File ~S is not readable.\n"
 msgstr ""
 
-#: liblepton/scheme/geda/repl.scm:48
 msgid "Welcome to Lepton REPL!\n"
 msgstr ""
 
-#: liblepton/scheme/geda/repl.scm:53
 msgid "WARNING: Readline library is not supported in your configuration.\n"
 msgstr ""
 

--- a/liblepton/po/sv.po
+++ b/liblepton/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-12 00:08+0300\n"
+"POT-Creation-Date: 2019-05-13 11:16+0300\n"
 "PO-Revision-Date: 2012-01-27 14:12+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: Swedish <sv@li.org>\n"
@@ -18,40 +18,31 @@ msgstr ""
 "X-Launchpad-Export-Date: 2012-11-14 16:52+0000\n"
 "X-Generator: Launchpad (build 16265)\n"
 
-#: liblepton/data/liblepton.xml.in:3
 msgid "Lepton EDA circuit schematic"
 msgstr ""
 
-#: liblepton/data/liblepton.xml.in:4
 msgid "Lepton EDA schematic symbol"
 msgstr ""
 
-#: liblepton/data/liblepton.xml.in:5
 msgid "Lepton EDA sch2pcb project"
 msgstr ""
 
-#: liblepton/data/x-lepton-sch2pcb-project.desktop.in:3
 msgid "Lepton EDA sch2pcb Project"
 msgstr ""
 
-#: liblepton/data/x-lepton-schematic.desktop.in:3
 msgid "Lepton EDA Circuit Schematic"
 msgstr ""
 
-#: liblepton/data/x-lepton-symbol.desktop.in:3
 msgid "Lepton EDA Schematic Symbol"
 msgstr ""
 
-#: liblepton/src/a_basic.c:57 liblepton/src/f_basic.c:377
 #, c-format
 msgid "File %1$s is read-only"
 msgstr ""
 
-#: liblepton/src/a_basic.c:114
 msgid "Schematic data was not valid UTF-8"
 msgstr ""
 
-#: liblepton/src/a_basic.c:246
 #, c-format
 msgid ""
 "Read unexpected attach symbol start marker in [%1$s] :\n"
@@ -59,7 +50,6 @@ msgid ""
 "%2$s<<\n"
 msgstr ""
 
-#: liblepton/src/a_basic.c:263
 #, c-format
 msgid ""
 "Read unexpected embedded symbol start marker in [%1$s] :\n"
@@ -67,7 +57,6 @@ msgid ""
 "%2$s<<\n"
 msgstr ""
 
-#: liblepton/src/a_basic.c:294
 #, c-format
 msgid ""
 "Read unexpected embedded symbol end marker in [%s] :\n"
@@ -75,7 +64,6 @@ msgid ""
 "%s<<\n"
 msgstr ""
 
-#: liblepton/src/a_basic.c:329
 #, c-format
 msgid ""
 "Read an old format sym/sch file!\n"
@@ -83,7 +71,6 @@ msgid ""
 "[%1$s]"
 msgstr ""
 
-#: liblepton/src/a_basic.c:335
 #, c-format
 msgid ""
 "Read garbage in [%1$s] :\n"
@@ -91,17 +78,14 @@ msgid ""
 "%2$s<<\n"
 msgstr ""
 
-#: liblepton/src/f_basic.c:119 liblepton/src/f_basic.c:132
 #, c-format
 msgid "Failed to stat [%1$s]: %2$s"
 msgstr ""
 
-#: liblepton/src/f_basic.c:211
 #, fuzzy, c-format
 msgid "Cannot find file %1$s: %2$s"
 msgstr "Kan inte hitta filen %s: %s"
 
-#: liblepton/src/f_basic.c:260
 #, c-format
 msgid ""
 "\n"
@@ -110,305 +94,236 @@ msgid ""
 "\n"
 msgstr ""
 
-#: liblepton/src/f_basic.c:262
 msgid "I could not guess if it is newer, so you have to do it manually.\n"
 msgstr ""
 
-#: liblepton/src/f_basic.c:264
 msgid ""
 "The backup copy is newer than the schematic, so it seems you should load it "
 "instead of the original file.\n"
 msgstr ""
 
-#: liblepton/src/f_basic.c:266
 msgid ""
 "lepton-schematic usually makes backup copies automatically, and this "
 "situation happens when it crashed or it was forced to exit abruptly.\n"
 msgstr ""
 
-#: liblepton/src/f_basic.c:269
 msgid ""
 "\n"
 "Run lepton-schematic and correct the situation.\n"
 "\n"
 msgstr ""
 
-#: liblepton/src/f_basic.c:367
 #, c-format
 msgid "Can't get the real filename of %1$s: %2$s"
 msgstr ""
 
-#: liblepton/src/f_basic.c:398
 #, c-format
 msgid "Could NOT set previous backup file [%1$s] read-write."
 msgstr ""
 
-#: liblepton/src/f_basic.c:404
 #, c-format
 msgid "Can't save backup file: %1$s."
 msgstr ""
 
-#: liblepton/src/f_basic.c:414
 #, c-format
 msgid "Could NOT set backup file [%1$s] readonly."
 msgstr ""
 
-#: liblepton/src/f_basic.c:463
 #, c-format
 msgid "Failed to restore permissions on '%1$s': %2$s\n"
 msgstr ""
 
-#: liblepton/src/f_basic.c:468
 #, c-format
 msgid "Failed to restore ownership on '%1$s': %2$s\n"
 msgstr ""
 
-#: liblepton/src/f_basic.c:478
 #, c-format
 msgid "Could NOT save file: %1$s"
 msgstr ""
 
-#: liblepton/src/f_basic.c:604
 #, c-format
 msgid "%s: %s"
 msgstr ""
 
-#: liblepton/src/g_basic.c:260
 msgid ""
 "\n"
 "Backtrace:\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:99
 #, c-format
 msgid "Invalid mode [%1$s] passed to %2$s\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:139
 msgid "RC file already loaded"
 msgstr ""
 
-#: liblepton/src/g_rc.c:183
 #, c-format
 msgid "Failed to load config from '%1$s': %2$s\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:207
 #, c-format
 msgid "Loaded RC file [%1$s]"
 msgstr ""
 
-#: liblepton/src/g_rc.c:211
 #, c-format
 msgid "Failed to load RC file [%1$s]: "
 msgstr ""
 
-#: liblepton/src/g_rc.c:341
 msgid "ERROR: An unknown error occurred while parsing configuration files."
 msgstr ""
 
-#: liblepton/src/g_rc.c:353
 #, c-format
 msgid "ERROR: %1$s"
 msgstr ""
 
-#: liblepton/src/g_rc.c:354
 #, c-format
 msgid "ERROR: %1$s\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:360
 #, c-format
 msgid "ERROR: The %1$s log may contain more information.\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:512
 #, c-format
 msgid "Invalid path [%1$s] passed to component-library\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:738
 #, c-format
 msgid "Invalid path [%1$s] passed to bitmap-directory\n"
 msgstr ""
 
-#: liblepton/src/geda_page.c:197
 #, c-format
 msgid "s_page_delete: Can't get the real filename of %1$s."
 msgstr ""
 
-#: liblepton/src/geda_page.c:208
 #, c-format
 msgid "s_page_delete: Unable to delete backup file %1$s."
 msgstr ""
 
-#: liblepton/src/geda_page.c:490
 #, c-format
 msgid "Saved [%1$s]"
 msgstr ""
 
-#: liblepton/src/geda_page.c:496
 #, c-format
 msgid "Could NOT save [%1$s]"
 msgstr ""
 
-#: liblepton/src/geda_arc_object.c:408 liblepton/src/geda_arc_object.c:421
 msgid "Failed to parse arc object"
 msgstr ""
 
-#: liblepton/src/geda_arc_object.c:428
 #, c-format
 msgid "Found a zero radius arc [ %1$c %2$d, %3$d, %4$d, %5$d, %6$d, %7$d ]"
 msgstr ""
 
-#: liblepton/src/geda_arc_object.c:435 liblepton/src/geda_box_object.c:328
-#: liblepton/src/geda_bus_object.c:364 liblepton/src/geda_circle_object.c:387
-#: liblepton/src/geda_line_object.c:427 liblepton/src/geda_net_object.c:308
-#: liblepton/src/geda_path_object.c:214 liblepton/src/geda_pin_object.c:369
-#: liblepton/src/geda_text_object.c:555
 #, c-format
 msgid "Found an invalid color [ %1$s ]"
 msgstr ""
 
-#: liblepton/src/geda_arc_object.c:436 liblepton/src/geda_box_object.c:329
-#: liblepton/src/geda_bus_object.c:365 liblepton/src/geda_circle_object.c:388
-#: liblepton/src/geda_line_object.c:428 liblepton/src/geda_net_object.c:309
-#: liblepton/src/geda_path_object.c:215 liblepton/src/geda_pin_object.c:370
-#: liblepton/src/geda_text_object.c:557
 msgid "Setting color to default color."
 msgstr ""
 
-#: liblepton/src/o_attrib.c:111
 #, c-format
 msgid "Attribute [%1$s] already attached\n"
 msgstr ""
 
-#: liblepton/src/o_attrib.c:117
 msgid "Attempt to attach non text item as an attribute!\n"
 msgstr ""
 
-#: liblepton/src/o_attrib.c:122
 #, c-format
 msgid "Attempt to attach attribute [%1$s] to more than one object\n"
 msgstr ""
 
-#: liblepton/src/o_attrib.c:325
 msgid "Tried to attach a non-text item as an attribute"
 msgstr ""
 
-#: liblepton/src/o_attrib.c:332
 msgid "Unexpected end-of-file in attribute list"
 msgstr ""
 
-#: liblepton/src/geda_box_object.c:287 liblepton/src/geda_box_object.c:316
 msgid "Failed to parse box object"
 msgstr ""
 
-#: liblepton/src/geda_box_object.c:322
 #, c-format
 msgid "Found a zero width/height box [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr ""
 
-#: liblepton/src/geda_bus_object.c:345 liblepton/src/geda_bus_object.c:352
 msgid "Failed to parse bus object"
 msgstr ""
 
-#: liblepton/src/geda_bus_object.c:358
 #, c-format
 msgid "Found a zero length bus [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr ""
 
-#: liblepton/src/geda_bus_object.c:370
 #, c-format
 msgid "Found an invalid bus ripper direction [ %1$s ]"
 msgstr ""
 
-#: liblepton/src/geda_bus_object.c:371
 msgid "Resetting direction to neutral (no direction)."
 msgstr ""
 
-#: liblepton/src/geda_circle_object.c:343
-#: liblepton/src/geda_circle_object.c:372
 msgid "Failed to parse circle object"
 msgstr ""
 
-#: liblepton/src/geda_circle_object.c:379
 #, c-format
 msgid "Found a zero or negative radius circle [ %1$c %2$d %3$d %4$d %5$d ]"
 msgstr ""
 
-#: liblepton/src/geda_circle_object.c:382
 msgid "Setting radius to 0."
 msgstr ""
 
-#: liblepton/src/geda_color.c:217
 msgid "Color map entry must be a two-element list"
 msgstr ""
 
-#: liblepton/src/geda_color.c:225
 msgid "Index in color map entry must be an integer"
 msgstr ""
 
-#: liblepton/src/geda_color.c:251
 msgid "Value in color map entry must be #f or a string"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:373
 #, c-format
 msgid ""
 "Component not found:\n"
 " %1$s"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:585
 msgid "Failed to parse complex object"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:598
 #, c-format
 msgid ""
 "Found a component with an invalid rotation [ %1$c %2$d %3$d %4$d %5$d %6$d "
 "%7$s ]"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:601
-#: liblepton/src/geda_picture_object.c:105
 msgid "Setting angle to 0."
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:613
 #, c-format
 msgid ""
 "Found a component with an invalid mirror flag [ %1$c %2$d %3$d %4$d %5$d "
 "%6$d %7$s ]"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:616
 msgid "Setting mirror to 0."
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:941
 #, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
 "\tCould not parse symbol file symversion=%2$s"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:945
 #, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
 "\tCould not parse symbol file symversion="
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:961
 #, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
 "\tCould not parse attached symversion=%2$s"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:986
 #, c-format
 msgid ""
 "WARNING: Symbol version oddity on refdes %1$s:\n"
@@ -416,535 +331,416 @@ msgid ""
 "symbol file."
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:1000
 #, c-format
 msgid ""
 "WARNING: Symbol version mismatch on refdes %1$s (%2$s):\n"
 "\tSymbol in library is newer than instantiated symbol."
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:1028
 #, c-format
 msgid "\tMAJOR VERSION CHANGE (file %1$.3f, instantiated %2$.3f, %3$s)!"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:1046
 #, c-format
 msgid "\tMinor version change (file %1$.3f, instantiated %2$.3f)"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:1057
 #, c-format
 msgid ""
 "WARNING: Symbol version oddity on refdes %1$s:\n"
 "\tInstantiated symbol is newer than symbol in library."
 msgstr ""
 
-#: liblepton/src/o_embed.c:54
 #, c-format
 msgid "Component [%1$s] has been embedded."
 msgstr ""
 
-#: liblepton/src/o_embed.c:98
 #, c-format
 msgid ""
 "Could not find component [%1$s], while trying to unembed. Component is still "
 "embedded."
 msgstr ""
 
-#: liblepton/src/o_embed.c:106
 #, c-format
 msgid "Component [%1$s] has been successfully unembedded."
 msgstr ""
 
-#: liblepton/src/geda_line_object.c:391 liblepton/src/geda_line_object.c:409
 msgid "Failed to parse line object"
 msgstr ""
 
-#: liblepton/src/geda_line_object.c:421
 #, c-format
 msgid "Found a zero length line [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr ""
 
-#: liblepton/src/geda_net_object.c:297
 msgid "Failed to parse net object"
 msgstr ""
 
-#: liblepton/src/geda_net_object.c:302
 #, c-format
 msgid "Found a zero length net [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr ""
 
-#: liblepton/src/geda_path_object.c:206
 msgid "Failed to parse path object"
 msgstr ""
 
-#: liblepton/src/geda_path_object.c:232
 msgid "Unexpected end-of-file when reading path"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:71
 msgid "Failed to parse picture definition"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:76
 #, c-format
 msgid "Found a zero width/height picture [ %1$c %2$d %3$d %4$d %5$d ]"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:82
 #, c-format
 msgid "Found a picture with a wrong 'mirrored' parameter: %1$d."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:84
 msgid "Setting mirrored to 0."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:89
 #, c-format
 msgid "Found a picture with a wrong 'embedded' parameter: %1$d."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:91
 msgid "Setting embedded to 0."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:104
 #, c-format
 msgid "Found an unsupported picture angle [ %1$d ]"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:116
 msgid "Found an image with no filename."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:147
 #, c-format
 msgid "Failed to load image from embedded data [%1$s]: %2$s"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:148
 msgid "Base64 decoding failed."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:149
 msgid "Falling back to file loading. Picture unembedded."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:208
 msgid "ERROR: o_picture_save: unable to encode the picture."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:308
 #, c-format
 msgid "Failed to load buffer image [%1$s]: %2$s"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:321
 #, c-format
 msgid "Failed to load image from [%1$s]: %2$s"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:415
 #, c-format
 msgid "Picture %1$p has invalid angle %2$i\n"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:772
 #, c-format
 msgid "Picture [%1$s] has no image data."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:773
 msgid "Falling back to file loading. Picture is still unembedded."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:781
 #, c-format
 msgid "Picture [%1$s] has been embedded."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:805
 #, c-format
 msgid "Failed to load image from file [%1$s]: %2$s"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:807
 msgid "Picture is still embedded."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:815
 #, c-format
 msgid "Picture [%1$s] has been unembedded."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:1052
 #, c-format
 msgid "Failed to load fallback image %1$s: %2$s.\n"
 msgstr ""
 
-#: liblepton/src/geda_pin_object.c:346 liblepton/src/geda_pin_object.c:354
 msgid "Failed to parse pin object"
 msgstr ""
 
-#: liblepton/src/geda_pin_object.c:360
 msgid ""
 "Found a pin which did not have the whichend field set.\n"
 "Verify and correct manually."
 msgstr ""
 
-#: liblepton/src/geda_pin_object.c:363
 #, c-format
 msgid "Found an invalid whichend on a pin (reseting to zero): %d"
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:495 liblepton/src/geda_text_object.c:505
-#: liblepton/src/geda_text_object.c:515
 msgid "Failed to parse text object"
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:522
 #, c-format
 msgid "Found an invalid text size [ %1$s ]"
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:524
 #, c-format
 msgid "Setting text size to %1$d."
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:528
 #, c-format
 msgid "Found an unsupported text angle [ %1$s ]"
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:530
 #, c-format
 msgid "Setting angle to %1$d."
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:547
 #, c-format
 msgid "Found an unsupported text alignment [ %1$s ]"
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:550
 msgid "Setting alignment to LOWER_LEFT."
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:570
 #, c-format
 msgid "Unexpected end-of-file after %1$d lines"
 msgstr ""
 
-#: liblepton/src/s_clib.c:460
 #, c-format
 msgid "Library command failed [%1$s]: %2$s"
 msgstr ""
 
-#: liblepton/src/s_clib.c:465
 #, c-format
 msgid "Library command failed [%1$s]: Uncaught signal %2$i."
 msgstr ""
 
-#: liblepton/src/s_clib.c:469
 #, c-format
 msgid "Library command failed [%1$s]"
 msgstr ""
 
-#: liblepton/src/s_clib.c:470
 #, c-format
 msgid ""
 "Error output was:\n"
 "%1$s"
 msgstr ""
 
-#: liblepton/src/s_clib.c:556
 #, c-format
 msgid "Library name [%1$s] already in use.  Using [%2$s]."
 msgstr ""
 
-#: liblepton/src/s_clib.c:593
 #, c-format
 msgid "Failed to open directory [%1$s]: %2$s"
 msgstr ""
 
-#: liblepton/src/s_clib.c:729
 #, c-format
 msgid "Failed to scan library [%1$s]: Scheme function returned non-list."
 msgstr ""
 
-#: liblepton/src/s_clib.c:737
 #, c-format
 msgid "Non-string symbol name while scanning library [%1$s]"
 msgstr ""
 
-#: liblepton/src/s_clib.c:893 liblepton/src/s_clib.c:940
 msgid "Cannot add library: name not specified."
 msgstr ""
 
-#: liblepton/src/s_clib.c:900
 #, c-format
 msgid ""
 "Cannot add library [%1$s]: both 'list' and 'get' commands must be specified."
 msgstr ""
 
-#: liblepton/src/s_clib.c:948
 #, c-format
 msgid "Cannot add Scheme-library [%1$s]: callbacks must be closures."
 msgstr ""
 
-#: liblepton/src/s_clib.c:1075
 #, c-format
 msgid "Failed to load symbol from file [%1$s]: %2$s"
 msgstr ""
 
-#: liblepton/src/s_clib.c:1135
 #, c-format
 msgid "Failed to load symbol data [%1$s] from source [%2$s]"
 msgstr ""
 
-#: liblepton/src/s_clib.c:1377
 #, c-format
 msgid "Component [%1$s] was not found in the component library."
 msgstr ""
 
-#: liblepton/src/s_clib.c:1383
 #, c-format
 msgid "More than one component found with name [%1$s]."
 msgstr ""
 
-#: liblepton/src/s_hierarchy.c:78 liblepton/src/s_hierarchy.c:240
 msgid "Schematic not found in source library."
 msgstr ""
 
-#: liblepton/src/s_hierarchy.c:100
 msgid "Hierarchy contains a circular dependency."
 msgstr ""
 
-#: liblepton/src/s_hierarchy.c:200
 msgid "There are no schematics above the current one!"
 msgstr ""
 
-#: liblepton/src/s_hierarchy.c:341
 #, c-format
 msgid "Failed to descend hierarchy into '%1$s': %2$s"
 msgstr ""
 
-#: liblepton/src/s_slot.c:158
 msgid "Did not find slotdef=#:#,#,#... attribute."
 msgstr ""
 
-#: liblepton/src/s_slot.c:164
 msgid "Improper slotdef syntax: missing \":\"."
 msgstr ""
 
-#: liblepton/src/s_slot.c:179
 msgid "Did not find proper slotdef=#:#,#,#... attribute."
 msgstr ""
 
-#: liblepton/src/s_slot.c:209
 msgid "component missing pinseq= attribute."
 msgstr ""
 
-#: liblepton/src/edaconfig.c:694 liblepton/src/edaconfig.c:780
 msgid "Undefined configuration filename"
 msgstr ""
 
-#: liblepton/src/edaconfig.c:1105 liblepton/src/edaconfig.c:1169
 #, c-format
 msgid "Configuration does not have group '%s'"
 msgstr ""
 
-#: liblepton/src/edaconfig.c:1183
 #, c-format
 msgid "Configuration does not have key '%s'"
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:66 liblepton/src/scheme_attrib.c:100
 msgid "~A is not a valid attribute: invalid string '~A'."
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:204
 msgid "Objects ~A and ~A are not part of the same page and/or complex object"
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:211 liblepton/src/scheme_attrib.c:216
 msgid "Object ~A is already attached as an attribute"
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:265
 msgid "Object ~A is attribute of wrong object"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:148
 msgid "Invalid complex angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:270 liblepton/src/scheme_page.c:246
 msgid "Object ~A is already attached to something"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:332
 msgid "Object ~A is attached to a different complex"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:339
 msgid "Object ~A is attached to a page"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:346 liblepton/src/scheme_page.c:298
 msgid "Object ~A is attached as an attribute"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:353 liblepton/src/scheme_page.c:305
 msgid "Object ~A has attributes"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:234
 msgid "Object ~A has bad type '~A'"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:378
 msgid "Object ~A has invalid stroke cap style ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:391
 msgid "Object ~A has invalid stroke dash style ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:455
 msgid "Invalid stroke cap style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:466
 msgid "Invalid stroke dash style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:476
 msgid "Missing dash length parameter for dash style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:486
 msgid "Missing dot/dash space parameter for dash style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:554
 msgid "Object ~A has invalid fill style ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:603
 msgid "Invalid fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:611
 msgid "Missing second space parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:620
 msgid "Missing second angle parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:630
 msgid "Missing stroke width parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:639
 msgid "Missing space parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:648
 msgid "Missing angle parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:962
 msgid "Invalid pin type ~A, must be 'net or 'bus"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1011
 msgid "Object ~A has invalid pin type."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1417
 msgid "Invalid text alignment ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1433
 msgid "Invalid text angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1452
 msgid "Invalid text name/value visibility ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1526
 msgid "Text object ~A has invalid text alignment ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1535
 msgid "Text object ~A has invalid visibility ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1545
 msgid "Text object ~A has invalid text attribute visibility ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1586
 msgid "Object ~A is not included in a page."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1739
 msgid "Path object ~A has invalid element type ~A at index ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1853
 msgid "Invalid path element type ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:2025
 msgid "Invalid picture angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr ""
 
-#: liblepton/src/scheme_page.c:291
 msgid "Object ~A is attached to a complex or different page"
 msgstr ""
 
-#: liblepton/src/scheme_page.c:438
 msgid "Parse error: ~s"
 msgstr ""
 
-#: liblepton/src/edascmhookproxy.c:83
 msgid "Scheme hook"
 msgstr ""
 
-#: liblepton/src/edascmhookproxy.c:84
 msgid "The Scheme-level hook to proxy"
 msgstr ""
 
-#: liblepton/scheme/geda/attrib.scm:56
 #, scheme-format
 msgid "Object ~A is not part of a page"
 msgstr ""
 
-#: liblepton/scheme/geda/library.scm:108
 #, scheme-format
 msgid "Invalid path ~S or source not readable.\n"
 msgstr ""
 
-#: liblepton/scheme/geda/library.scm:109
 msgid "Source library path must be a string.\n"
 msgstr ""
 
-#: liblepton/scheme/geda/library.scm:168
 #, scheme-format
 msgid "File ~S is not readable.\n"
 msgstr ""
 
-#: liblepton/scheme/geda/repl.scm:48
 msgid "Welcome to Lepton REPL!\n"
 msgstr ""
 
-#: liblepton/scheme/geda/repl.scm:53
 msgid "WARNING: Readline library is not supported in your configuration.\n"
 msgstr ""

--- a/liblepton/po/tr.po
+++ b/liblepton/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-12 00:08+0300\n"
+"POT-Creation-Date: 2019-05-13 11:16+0300\n"
 "PO-Revision-Date: 2012-01-31 12:11+0000\n"
 "Last-Translator: Peter TB Brett <Unknown>\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -18,44 +18,35 @@ msgstr ""
 "X-Launchpad-Export-Date: 2012-11-14 16:52+0000\n"
 "X-Generator: Launchpad (build 16265)\n"
 
-#: liblepton/data/liblepton.xml.in:3
 msgid "Lepton EDA circuit schematic"
 msgstr ""
 
-#: liblepton/data/liblepton.xml.in:4
 #, fuzzy
 msgid "Lepton EDA schematic symbol"
 msgstr "gEDA şematik sembol"
 
-#: liblepton/data/liblepton.xml.in:5
 #, fuzzy
 msgid "Lepton EDA sch2pcb project"
 msgstr "gEDA gsch2pcb projesi"
 
-#: liblepton/data/x-lepton-sch2pcb-project.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA sch2pcb Project"
 msgstr "gEDA Gsch2pcb Projesi"
 
-#: liblepton/data/x-lepton-schematic.desktop.in:3
 msgid "Lepton EDA Circuit Schematic"
 msgstr ""
 
-#: liblepton/data/x-lepton-symbol.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Schematic Symbol"
 msgstr "gEDA şematik sembol"
 
-#: liblepton/src/a_basic.c:57 liblepton/src/f_basic.c:377
 #, c-format
 msgid "File %1$s is read-only"
 msgstr ""
 
-#: liblepton/src/a_basic.c:114
 msgid "Schematic data was not valid UTF-8"
 msgstr ""
 
-#: liblepton/src/a_basic.c:246
 #, c-format
 msgid ""
 "Read unexpected attach symbol start marker in [%1$s] :\n"
@@ -63,7 +54,6 @@ msgid ""
 "%2$s<<\n"
 msgstr ""
 
-#: liblepton/src/a_basic.c:263
 #, c-format
 msgid ""
 "Read unexpected embedded symbol start marker in [%1$s] :\n"
@@ -71,7 +61,6 @@ msgid ""
 "%2$s<<\n"
 msgstr ""
 
-#: liblepton/src/a_basic.c:294
 #, c-format
 msgid ""
 "Read unexpected embedded symbol end marker in [%s] :\n"
@@ -79,7 +68,6 @@ msgid ""
 "%s<<\n"
 msgstr ""
 
-#: liblepton/src/a_basic.c:329
 #, c-format
 msgid ""
 "Read an old format sym/sch file!\n"
@@ -87,7 +75,6 @@ msgid ""
 "[%1$s]"
 msgstr ""
 
-#: liblepton/src/a_basic.c:335
 #, c-format
 msgid ""
 "Read garbage in [%1$s] :\n"
@@ -95,17 +82,14 @@ msgid ""
 "%2$s<<\n"
 msgstr ""
 
-#: liblepton/src/f_basic.c:119 liblepton/src/f_basic.c:132
 #, c-format
 msgid "Failed to stat [%1$s]: %2$s"
 msgstr ""
 
-#: liblepton/src/f_basic.c:211
 #, c-format
 msgid "Cannot find file %1$s: %2$s"
 msgstr ""
 
-#: liblepton/src/f_basic.c:260
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -118,11 +102,9 @@ msgstr ""
 "  %s.\n"
 "\n"
 
-#: liblepton/src/f_basic.c:262
 msgid "I could not guess if it is newer, so you have to do it manually.\n"
 msgstr "Yeniyse tahmin edemiyorum, bunu elle yapın.\n"
 
-#: liblepton/src/f_basic.c:264
 msgid ""
 "The backup copy is newer than the schematic, so it seems you should load it "
 "instead of the original file.\n"
@@ -130,13 +112,11 @@ msgstr ""
 "Yedek kopyası şematikten yeni bu nedenle asıl dosya yerine onu yükleyeceğiz "
 "gözküyor.\n"
 
-#: liblepton/src/f_basic.c:266
 msgid ""
 "lepton-schematic usually makes backup copies automatically, and this "
 "situation happens when it crashed or it was forced to exit abruptly.\n"
 msgstr ""
 
-#: liblepton/src/f_basic.c:269
 #, fuzzy
 msgid ""
 "\n"
@@ -147,17 +127,14 @@ msgstr ""
 "gschem'i çalıştırın ve bu durumu düzeltin\n"
 "\n"
 
-#: liblepton/src/f_basic.c:367
 #, c-format
 msgid "Can't get the real filename of %1$s: %2$s"
 msgstr ""
 
-#: liblepton/src/f_basic.c:398
 #, fuzzy, c-format
 msgid "Could NOT set previous backup file [%1$s] read-write."
 msgstr "sadece okunabilir [%s] yedekleme dosyası oluşturulamadı\n"
 
-#: liblepton/src/f_basic.c:404
 #, fuzzy, c-format
 msgid "Can't save backup file: %1$s."
 msgstr ""
@@ -166,212 +143,160 @@ msgstr ""
 "  %s.\n"
 "\n"
 
-#: liblepton/src/f_basic.c:414
 #, fuzzy, c-format
 msgid "Could NOT set backup file [%1$s] readonly."
 msgstr "sadece okunabilir [%s] yedekleme dosyası oluşturulamadı\n"
 
-#: liblepton/src/f_basic.c:463
 #, c-format
 msgid "Failed to restore permissions on '%1$s': %2$s\n"
 msgstr ""
 
-#: liblepton/src/f_basic.c:468
 #, c-format
 msgid "Failed to restore ownership on '%1$s': %2$s\n"
 msgstr ""
 
-#: liblepton/src/f_basic.c:478
 #, fuzzy, c-format
 msgid "Could NOT save file: %1$s"
 msgstr "[%s] kaydedilemedi.\n"
 
-#: liblepton/src/f_basic.c:604
 #, c-format
 msgid "%s: %s"
 msgstr ""
 
-#: liblepton/src/g_basic.c:260
 msgid ""
 "\n"
 "Backtrace:\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:99
 #, c-format
 msgid "Invalid mode [%1$s] passed to %2$s\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:139
 msgid "RC file already loaded"
 msgstr ""
 
-#: liblepton/src/g_rc.c:183
 #, c-format
 msgid "Failed to load config from '%1$s': %2$s\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:207
 #, fuzzy, c-format
 msgid "Loaded RC file [%1$s]"
 msgstr "Kütüphane komutu başarısız [%s]<br>\n"
 
-#: liblepton/src/g_rc.c:211
 #, fuzzy, c-format
 msgid "Failed to load RC file [%1$s]: "
 msgstr "Kütüphane komutu başarısız [%s]<br>\n"
 
-#: liblepton/src/g_rc.c:341
 msgid "ERROR: An unknown error occurred while parsing configuration files."
 msgstr ""
 
-#: liblepton/src/g_rc.c:353
 #, c-format
 msgid "ERROR: %1$s"
 msgstr ""
 
-#: liblepton/src/g_rc.c:354
 #, c-format
 msgid "ERROR: %1$s\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:360
 #, c-format
 msgid "ERROR: The %1$s log may contain more information.\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:512
 #, c-format
 msgid "Invalid path [%1$s] passed to component-library\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:738
 #, c-format
 msgid "Invalid path [%1$s] passed to bitmap-directory\n"
 msgstr ""
 
-#: liblepton/src/geda_page.c:197
 #, c-format
 msgid "s_page_delete: Can't get the real filename of %1$s."
 msgstr ""
 
-#: liblepton/src/geda_page.c:208
 #, c-format
 msgid "s_page_delete: Unable to delete backup file %1$s."
 msgstr ""
 
-#: liblepton/src/geda_page.c:490
 #, fuzzy, c-format
 msgid "Saved [%1$s]"
 msgstr "[%s] kaydedildi\n"
 
-#: liblepton/src/geda_page.c:496
 #, fuzzy, c-format
 msgid "Could NOT save [%1$s]"
 msgstr "[%s] kaydedilemedi.\n"
 
-#: liblepton/src/geda_arc_object.c:408 liblepton/src/geda_arc_object.c:421
 msgid "Failed to parse arc object"
 msgstr ""
 
-#: liblepton/src/geda_arc_object.c:428
 #, c-format
 msgid "Found a zero radius arc [ %1$c %2$d, %3$d, %4$d, %5$d, %6$d, %7$d ]"
 msgstr ""
 
-#: liblepton/src/geda_arc_object.c:435 liblepton/src/geda_box_object.c:328
-#: liblepton/src/geda_bus_object.c:364 liblepton/src/geda_circle_object.c:387
-#: liblepton/src/geda_line_object.c:427 liblepton/src/geda_net_object.c:308
-#: liblepton/src/geda_path_object.c:214 liblepton/src/geda_pin_object.c:369
-#: liblepton/src/geda_text_object.c:555
 #, fuzzy, c-format
 msgid "Found an invalid color [ %1$s ]"
 msgstr "Geçersiz bir renk bulundu [ %s ]\n"
 
-#: liblepton/src/geda_arc_object.c:436 liblepton/src/geda_box_object.c:329
-#: liblepton/src/geda_bus_object.c:365 liblepton/src/geda_circle_object.c:388
-#: liblepton/src/geda_line_object.c:428 liblepton/src/geda_net_object.c:309
-#: liblepton/src/geda_path_object.c:215 liblepton/src/geda_pin_object.c:370
-#: liblepton/src/geda_text_object.c:557
 msgid "Setting color to default color."
 msgstr ""
 
-#: liblepton/src/o_attrib.c:111
 #, c-format
 msgid "Attribute [%1$s] already attached\n"
 msgstr ""
 
-#: liblepton/src/o_attrib.c:117
 msgid "Attempt to attach non text item as an attribute!\n"
 msgstr ""
 
-#: liblepton/src/o_attrib.c:122
 #, c-format
 msgid "Attempt to attach attribute [%1$s] to more than one object\n"
 msgstr ""
 
-#: liblepton/src/o_attrib.c:325
 msgid "Tried to attach a non-text item as an attribute"
 msgstr ""
 
-#: liblepton/src/o_attrib.c:332
 msgid "Unexpected end-of-file in attribute list"
 msgstr ""
 
-#: liblepton/src/geda_box_object.c:287 liblepton/src/geda_box_object.c:316
 msgid "Failed to parse box object"
 msgstr ""
 
-#: liblepton/src/geda_box_object.c:322
 #, c-format
 msgid "Found a zero width/height box [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr ""
 
-#: liblepton/src/geda_bus_object.c:345 liblepton/src/geda_bus_object.c:352
 msgid "Failed to parse bus object"
 msgstr ""
 
-#: liblepton/src/geda_bus_object.c:358
 #, c-format
 msgid "Found a zero length bus [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr ""
 
-#: liblepton/src/geda_bus_object.c:370
 #, fuzzy, c-format
 msgid "Found an invalid bus ripper direction [ %1$s ]"
 msgstr "Geçersiz bir renk bulundu [ %s ]\n"
 
-#: liblepton/src/geda_bus_object.c:371
 msgid "Resetting direction to neutral (no direction)."
 msgstr ""
 
-#: liblepton/src/geda_circle_object.c:343
-#: liblepton/src/geda_circle_object.c:372
 msgid "Failed to parse circle object"
 msgstr ""
 
-#: liblepton/src/geda_circle_object.c:379
 #, c-format
 msgid "Found a zero or negative radius circle [ %1$c %2$d %3$d %4$d %5$d ]"
 msgstr ""
 
-#: liblepton/src/geda_circle_object.c:382
 msgid "Setting radius to 0."
 msgstr ""
 
-#: liblepton/src/geda_color.c:217
 msgid "Color map entry must be a two-element list"
 msgstr ""
 
-#: liblepton/src/geda_color.c:225
 msgid "Index in color map entry must be an integer"
 msgstr ""
 
-#: liblepton/src/geda_color.c:251
 msgid "Value in color map entry must be #f or a string"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:373
 #, fuzzy, c-format
 msgid ""
 "Component not found:\n"
@@ -380,55 +305,45 @@ msgstr ""
 "bileşen bulanamadı:\n"
 " %s"
 
-#: liblepton/src/geda_complex_object.c:585
 msgid "Failed to parse complex object"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:598
 #, c-format
 msgid ""
 "Found a component with an invalid rotation [ %1$c %2$d %3$d %4$d %5$d %6$d "
 "%7$s ]"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:601
-#: liblepton/src/geda_picture_object.c:105
 msgid "Setting angle to 0."
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:613
 #, c-format
 msgid ""
 "Found a component with an invalid mirror flag [ %1$c %2$d %3$d %4$d %5$d "
 "%6$d %7$s ]"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:616
 msgid "Setting mirror to 0."
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:941
 #, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
 "\tCould not parse symbol file symversion=%2$s"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:945
 #, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
 "\tCould not parse symbol file symversion="
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:961
 #, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
 "\tCould not parse attached symversion=%2$s"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:986
 #, c-format
 msgid ""
 "WARNING: Symbol version oddity on refdes %1$s:\n"
@@ -436,537 +351,418 @@ msgid ""
 "symbol file."
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:1000
 #, c-format
 msgid ""
 "WARNING: Symbol version mismatch on refdes %1$s (%2$s):\n"
 "\tSymbol in library is newer than instantiated symbol."
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:1028
 #, c-format
 msgid "\tMAJOR VERSION CHANGE (file %1$.3f, instantiated %2$.3f, %3$s)!"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:1046
 #, c-format
 msgid "\tMinor version change (file %1$.3f, instantiated %2$.3f)"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:1057
 #, c-format
 msgid ""
 "WARNING: Symbol version oddity on refdes %1$s:\n"
 "\tInstantiated symbol is newer than symbol in library."
 msgstr ""
 
-#: liblepton/src/o_embed.c:54
 #, c-format
 msgid "Component [%1$s] has been embedded."
 msgstr ""
 
-#: liblepton/src/o_embed.c:98
 #, c-format
 msgid ""
 "Could not find component [%1$s], while trying to unembed. Component is still "
 "embedded."
 msgstr ""
 
-#: liblepton/src/o_embed.c:106
 #, c-format
 msgid "Component [%1$s] has been successfully unembedded."
 msgstr ""
 
-#: liblepton/src/geda_line_object.c:391 liblepton/src/geda_line_object.c:409
 msgid "Failed to parse line object"
 msgstr ""
 
-#: liblepton/src/geda_line_object.c:421
 #, c-format
 msgid "Found a zero length line [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr ""
 
-#: liblepton/src/geda_net_object.c:297
 msgid "Failed to parse net object"
 msgstr ""
 
-#: liblepton/src/geda_net_object.c:302
 #, c-format
 msgid "Found a zero length net [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr ""
 
-#: liblepton/src/geda_path_object.c:206
 msgid "Failed to parse path object"
 msgstr ""
 
-#: liblepton/src/geda_path_object.c:232
 msgid "Unexpected end-of-file when reading path"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:71
 msgid "Failed to parse picture definition"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:76
 #, c-format
 msgid "Found a zero width/height picture [ %1$c %2$d %3$d %4$d %5$d ]"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:82
 #, c-format
 msgid "Found a picture with a wrong 'mirrored' parameter: %1$d."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:84
 msgid "Setting mirrored to 0."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:89
 #, c-format
 msgid "Found a picture with a wrong 'embedded' parameter: %1$d."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:91
 msgid "Setting embedded to 0."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:104
 #, fuzzy, c-format
 msgid "Found an unsupported picture angle [ %1$d ]"
 msgstr "Desteklenmeyen yazı açısı bulundu [ %c %d %d %d %d %d %d %d %d ]\n"
 
-#: liblepton/src/geda_picture_object.c:116
 msgid "Found an image with no filename."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:147
 #, c-format
 msgid "Failed to load image from embedded data [%1$s]: %2$s"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:148
 msgid "Base64 decoding failed."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:149
 msgid "Falling back to file loading. Picture unembedded."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:208
 msgid "ERROR: o_picture_save: unable to encode the picture."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:308
 #, c-format
 msgid "Failed to load buffer image [%1$s]: %2$s"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:321
 #, c-format
 msgid "Failed to load image from [%1$s]: %2$s"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:415
 #, c-format
 msgid "Picture %1$p has invalid angle %2$i\n"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:772
 #, c-format
 msgid "Picture [%1$s] has no image data."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:773
 msgid "Falling back to file loading. Picture is still unembedded."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:781
 #, c-format
 msgid "Picture [%1$s] has been embedded."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:805
 #, c-format
 msgid "Failed to load image from file [%1$s]: %2$s"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:807
 msgid "Picture is still embedded."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:815
 #, c-format
 msgid "Picture [%1$s] has been unembedded."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:1052
 #, c-format
 msgid "Failed to load fallback image %1$s: %2$s.\n"
 msgstr ""
 
-#: liblepton/src/geda_pin_object.c:346 liblepton/src/geda_pin_object.c:354
 msgid "Failed to parse pin object"
 msgstr ""
 
-#: liblepton/src/geda_pin_object.c:360
 msgid ""
 "Found a pin which did not have the whichend field set.\n"
 "Verify and correct manually."
 msgstr ""
 
-#: liblepton/src/geda_pin_object.c:363
 #, c-format
 msgid "Found an invalid whichend on a pin (reseting to zero): %d"
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:495 liblepton/src/geda_text_object.c:505
-#: liblepton/src/geda_text_object.c:515
 msgid "Failed to parse text object"
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:522
 #, fuzzy, c-format
 msgid "Found an invalid text size [ %1$s ]"
 msgstr "Geçersiz bir renk bulundu [ %s ]\n"
 
-#: liblepton/src/geda_text_object.c:524
 #, c-format
 msgid "Setting text size to %1$d."
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:528
 #, fuzzy, c-format
 msgid "Found an unsupported text angle [ %1$s ]"
 msgstr "Desteklenmeyen yazı açısı bulundu [ %c %d %d %d %d %d %d %d %d ]\n"
 
-#: liblepton/src/geda_text_object.c:530
 #, c-format
 msgid "Setting angle to %1$d."
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:547
 #, fuzzy, c-format
 msgid "Found an unsupported text alignment [ %1$s ]"
 msgstr ""
 "Desteklenmeyen yazı hizlanması bulundu [ %c %d %d %d %d %d %d %d %d ]\n"
 
-#: liblepton/src/geda_text_object.c:550
 msgid "Setting alignment to LOWER_LEFT."
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:570
 #, c-format
 msgid "Unexpected end-of-file after %1$d lines"
 msgstr ""
 
-#: liblepton/src/s_clib.c:460
 #, fuzzy, c-format
 msgid "Library command failed [%1$s]: %2$s"
 msgstr "Kütüphane komutu başarısız [%s]<br>\n"
 
-#: liblepton/src/s_clib.c:465
 #, fuzzy, c-format
 msgid "Library command failed [%1$s]: Uncaught signal %2$i."
 msgstr "Kütüphane komutu başarısız [%s]<br>\n"
 
-#: liblepton/src/s_clib.c:469
 #, fuzzy, c-format
 msgid "Library command failed [%1$s]"
 msgstr "Kütüphane komutu başarısız [%s]<br>\n"
 
-#: liblepton/src/s_clib.c:470
 #, c-format
 msgid ""
 "Error output was:\n"
 "%1$s"
 msgstr ""
 
-#: liblepton/src/s_clib.c:556
 #, fuzzy, c-format
 msgid "Library name [%1$s] already in use.  Using [%2$s]."
 msgstr "Kütüphane adı [%s] zaten kullanımda.  [%s].\n"
 
-#: liblepton/src/s_clib.c:593
 #, c-format
 msgid "Failed to open directory [%1$s]: %2$s"
 msgstr ""
 
-#: liblepton/src/s_clib.c:729
 #, c-format
 msgid "Failed to scan library [%1$s]: Scheme function returned non-list."
 msgstr ""
 
-#: liblepton/src/s_clib.c:737
 #, c-format
 msgid "Non-string symbol name while scanning library [%1$s]"
 msgstr ""
 
-#: liblepton/src/s_clib.c:893 liblepton/src/s_clib.c:940
 msgid "Cannot add library: name not specified."
 msgstr ""
 
-#: liblepton/src/s_clib.c:900
 #, c-format
 msgid ""
 "Cannot add library [%1$s]: both 'list' and 'get' commands must be specified."
 msgstr ""
 
-#: liblepton/src/s_clib.c:948
 #, c-format
 msgid "Cannot add Scheme-library [%1$s]: callbacks must be closures."
 msgstr ""
 
-#: liblepton/src/s_clib.c:1075
 #, c-format
 msgid "Failed to load symbol from file [%1$s]: %2$s"
 msgstr ""
 
-#: liblepton/src/s_clib.c:1135
 #, c-format
 msgid "Failed to load symbol data [%1$s] from source [%2$s]"
 msgstr ""
 
-#: liblepton/src/s_clib.c:1377
 #, c-format
 msgid "Component [%1$s] was not found in the component library."
 msgstr ""
 
-#: liblepton/src/s_clib.c:1383
 #, c-format
 msgid "More than one component found with name [%1$s]."
 msgstr ""
 
-#: liblepton/src/s_hierarchy.c:78 liblepton/src/s_hierarchy.c:240
 msgid "Schematic not found in source library."
 msgstr ""
 
-#: liblepton/src/s_hierarchy.c:100
 msgid "Hierarchy contains a circular dependency."
 msgstr ""
 
-#: liblepton/src/s_hierarchy.c:200
 msgid "There are no schematics above the current one!"
 msgstr ""
 
-#: liblepton/src/s_hierarchy.c:341
 #, c-format
 msgid "Failed to descend hierarchy into '%1$s': %2$s"
 msgstr ""
 
-#: liblepton/src/s_slot.c:158
 msgid "Did not find slotdef=#:#,#,#... attribute."
 msgstr ""
 
-#: liblepton/src/s_slot.c:164
 msgid "Improper slotdef syntax: missing \":\"."
 msgstr ""
 
-#: liblepton/src/s_slot.c:179
 msgid "Did not find proper slotdef=#:#,#,#... attribute."
 msgstr ""
 
-#: liblepton/src/s_slot.c:209
 msgid "component missing pinseq= attribute."
 msgstr ""
 
-#: liblepton/src/edaconfig.c:694 liblepton/src/edaconfig.c:780
 msgid "Undefined configuration filename"
 msgstr ""
 
-#: liblepton/src/edaconfig.c:1105 liblepton/src/edaconfig.c:1169
 #, c-format
 msgid "Configuration does not have group '%s'"
 msgstr ""
 
-#: liblepton/src/edaconfig.c:1183
 #, c-format
 msgid "Configuration does not have key '%s'"
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:66 liblepton/src/scheme_attrib.c:100
 msgid "~A is not a valid attribute: invalid string '~A'."
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:204
 msgid "Objects ~A and ~A are not part of the same page and/or complex object"
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:211 liblepton/src/scheme_attrib.c:216
 msgid "Object ~A is already attached as an attribute"
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:265
 msgid "Object ~A is attribute of wrong object"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:148
 msgid "Invalid complex angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:270 liblepton/src/scheme_page.c:246
 msgid "Object ~A is already attached to something"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:332
 msgid "Object ~A is attached to a different complex"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:339
 msgid "Object ~A is attached to a page"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:346 liblepton/src/scheme_page.c:298
 msgid "Object ~A is attached as an attribute"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:353 liblepton/src/scheme_page.c:305
 msgid "Object ~A has attributes"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:234
 msgid "Object ~A has bad type '~A'"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:378
 msgid "Object ~A has invalid stroke cap style ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:391
 msgid "Object ~A has invalid stroke dash style ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:455
 msgid "Invalid stroke cap style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:466
 msgid "Invalid stroke dash style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:476
 msgid "Missing dash length parameter for dash style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:486
 msgid "Missing dot/dash space parameter for dash style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:554
 msgid "Object ~A has invalid fill style ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:603
 msgid "Invalid fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:611
 msgid "Missing second space parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:620
 msgid "Missing second angle parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:630
 msgid "Missing stroke width parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:639
 msgid "Missing space parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:648
 msgid "Missing angle parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:962
 msgid "Invalid pin type ~A, must be 'net or 'bus"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1011
 msgid "Object ~A has invalid pin type."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1417
 msgid "Invalid text alignment ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1433
 msgid "Invalid text angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1452
 msgid "Invalid text name/value visibility ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1526
 msgid "Text object ~A has invalid text alignment ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1535
 msgid "Text object ~A has invalid visibility ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1545
 msgid "Text object ~A has invalid text attribute visibility ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1586
 msgid "Object ~A is not included in a page."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1739
 msgid "Path object ~A has invalid element type ~A at index ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1853
 msgid "Invalid path element type ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:2025
 msgid "Invalid picture angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr ""
 
-#: liblepton/src/scheme_page.c:291
 msgid "Object ~A is attached to a complex or different page"
 msgstr ""
 
-#: liblepton/src/scheme_page.c:438
 msgid "Parse error: ~s"
 msgstr ""
 
-#: liblepton/src/edascmhookproxy.c:83
 msgid "Scheme hook"
 msgstr ""
 
-#: liblepton/src/edascmhookproxy.c:84
 msgid "The Scheme-level hook to proxy"
 msgstr ""
 
-#: liblepton/scheme/geda/attrib.scm:56
 #, scheme-format
 msgid "Object ~A is not part of a page"
 msgstr ""
 
-#: liblepton/scheme/geda/library.scm:108
 #, scheme-format
 msgid "Invalid path ~S or source not readable.\n"
 msgstr ""
 
-#: liblepton/scheme/geda/library.scm:109
 msgid "Source library path must be a string.\n"
 msgstr ""
 
-#: liblepton/scheme/geda/library.scm:168
 #, scheme-format
 msgid "File ~S is not readable.\n"
 msgstr ""
 
-#: liblepton/scheme/geda/repl.scm:48
 msgid "Welcome to Lepton REPL!\n"
 msgstr ""
 
-#: liblepton/scheme/geda/repl.scm:53
 msgid "WARNING: Readline library is not supported in your configuration.\n"
 msgstr ""
 

--- a/liblepton/po/uk.po
+++ b/liblepton/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-12 00:08+0300\n"
+"POT-Creation-Date: 2019-05-13 11:16+0300\n"
 "PO-Revision-Date: 2012-01-27 14:12+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: Ukrainian <uk@li.org>\n"
@@ -18,42 +18,33 @@ msgstr ""
 "X-Launchpad-Export-Date: 2012-11-14 16:52+0000\n"
 "X-Generator: Launchpad (build 16265)\n"
 
-#: liblepton/data/liblepton.xml.in:3
 msgid "Lepton EDA circuit schematic"
 msgstr ""
 
-#: liblepton/data/liblepton.xml.in:4
 msgid "Lepton EDA schematic symbol"
 msgstr ""
 
-#: liblepton/data/liblepton.xml.in:5
 #, fuzzy
 msgid "Lepton EDA sch2pcb project"
 msgstr "gEDA проект Gsch2pcb"
 
-#: liblepton/data/x-lepton-sch2pcb-project.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA sch2pcb Project"
 msgstr "gEDA проект Gsch2pcb"
 
-#: liblepton/data/x-lepton-schematic.desktop.in:3
 msgid "Lepton EDA Circuit Schematic"
 msgstr ""
 
-#: liblepton/data/x-lepton-symbol.desktop.in:3
 msgid "Lepton EDA Schematic Symbol"
 msgstr ""
 
-#: liblepton/src/a_basic.c:57 liblepton/src/f_basic.c:377
 #, c-format
 msgid "File %1$s is read-only"
 msgstr ""
 
-#: liblepton/src/a_basic.c:114
 msgid "Schematic data was not valid UTF-8"
 msgstr ""
 
-#: liblepton/src/a_basic.c:246
 #, c-format
 msgid ""
 "Read unexpected attach symbol start marker in [%1$s] :\n"
@@ -61,7 +52,6 @@ msgid ""
 "%2$s<<\n"
 msgstr ""
 
-#: liblepton/src/a_basic.c:263
 #, c-format
 msgid ""
 "Read unexpected embedded symbol start marker in [%1$s] :\n"
@@ -69,7 +59,6 @@ msgid ""
 "%2$s<<\n"
 msgstr ""
 
-#: liblepton/src/a_basic.c:294
 #, c-format
 msgid ""
 "Read unexpected embedded symbol end marker in [%s] :\n"
@@ -77,7 +66,6 @@ msgid ""
 "%s<<\n"
 msgstr ""
 
-#: liblepton/src/a_basic.c:329
 #, c-format
 msgid ""
 "Read an old format sym/sch file!\n"
@@ -85,7 +73,6 @@ msgid ""
 "[%1$s]"
 msgstr ""
 
-#: liblepton/src/a_basic.c:335
 #, c-format
 msgid ""
 "Read garbage in [%1$s] :\n"
@@ -93,17 +80,14 @@ msgid ""
 "%2$s<<\n"
 msgstr ""
 
-#: liblepton/src/f_basic.c:119 liblepton/src/f_basic.c:132
 #, c-format
 msgid "Failed to stat [%1$s]: %2$s"
 msgstr ""
 
-#: liblepton/src/f_basic.c:211
 #, fuzzy, c-format
 msgid "Cannot find file %1$s: %2$s"
 msgstr "Не можу знайти файл %s: %s"
 
-#: liblepton/src/f_basic.c:260
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -116,12 +100,10 @@ msgstr ""
 "  %s.\n"
 "\n"
 
-#: liblepton/src/f_basic.c:262
 msgid "I could not guess if it is newer, so you have to do it manually.\n"
 msgstr ""
 "Не можу визначити чи він більш новий, тому Вам слід зробити це самостійно.\n"
 
-#: liblepton/src/f_basic.c:264
 msgid ""
 "The backup copy is newer than the schematic, so it seems you should load it "
 "instead of the original file.\n"
@@ -129,7 +111,6 @@ msgstr ""
 "Файл резерної копії новіший за файл схеми, здається Вам слід завантажити "
 "його замість оригіналу.\n"
 
-#: liblepton/src/f_basic.c:266
 #, fuzzy
 msgid ""
 "lepton-schematic usually makes backup copies automatically, and this "
@@ -138,7 +119,6 @@ msgstr ""
 "Gschem зазвичай автоматично створює резервні копії, а така ситуація "
 "трапляється при збої чи вимушеному несподіваному виході.\n"
 
-#: liblepton/src/f_basic.c:269
 #, fuzzy
 msgid ""
 "\n"
@@ -149,232 +129,177 @@ msgstr ""
 "Запустіть gschem та виправте ситуацію.\n"
 "\n"
 
-#: liblepton/src/f_basic.c:367
 #, c-format
 msgid "Can't get the real filename of %1$s: %2$s"
 msgstr ""
 
-#: liblepton/src/f_basic.c:398
 #, fuzzy, c-format
 msgid "Could NOT set previous backup file [%1$s] read-write."
 msgstr ""
 "Не мжу встановити для файлу резерної копії [%s] режим тільки для читання\n"
 
-#: liblepton/src/f_basic.c:404
 #, fuzzy, c-format
 msgid "Can't save backup file: %1$s."
 msgstr "Не можу зберегти файл резервної копії: %s."
 
-#: liblepton/src/f_basic.c:414
 #, fuzzy, c-format
 msgid "Could NOT set backup file [%1$s] readonly."
 msgstr ""
 "Не мжу встановити для файлу резерної копії [%s] режим тільки для читання\n"
 
-#: liblepton/src/f_basic.c:463
 #, c-format
 msgid "Failed to restore permissions on '%1$s': %2$s\n"
 msgstr ""
 
-#: liblepton/src/f_basic.c:468
 #, c-format
 msgid "Failed to restore ownership on '%1$s': %2$s\n"
 msgstr ""
 
-#: liblepton/src/f_basic.c:478
 #, fuzzy, c-format
 msgid "Could NOT save file: %1$s"
 msgstr ""
 "Не мжу встановити для файлу резерної копії [%s] режим тільки для читання\n"
 
-#: liblepton/src/f_basic.c:604
 #, c-format
 msgid "%s: %s"
 msgstr "%s: %s"
 
-#: liblepton/src/g_basic.c:260
 msgid ""
 "\n"
 "Backtrace:\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:99
 #, c-format
 msgid "Invalid mode [%1$s] passed to %2$s\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:139
 msgid "RC file already loaded"
 msgstr ""
 
-#: liblepton/src/g_rc.c:183
 #, c-format
 msgid "Failed to load config from '%1$s': %2$s\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:207
 #, c-format
 msgid "Loaded RC file [%1$s]"
 msgstr ""
 
-#: liblepton/src/g_rc.c:211
 #, c-format
 msgid "Failed to load RC file [%1$s]: "
 msgstr ""
 
-#: liblepton/src/g_rc.c:341
 msgid "ERROR: An unknown error occurred while parsing configuration files."
 msgstr ""
 
-#: liblepton/src/g_rc.c:353
 #, c-format
 msgid "ERROR: %1$s"
 msgstr ""
 
-#: liblepton/src/g_rc.c:354
 #, c-format
 msgid "ERROR: %1$s\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:360
 #, c-format
 msgid "ERROR: The %1$s log may contain more information.\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:512
 #, c-format
 msgid "Invalid path [%1$s] passed to component-library\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:738
 #, c-format
 msgid "Invalid path [%1$s] passed to bitmap-directory\n"
 msgstr ""
 
-#: liblepton/src/geda_page.c:197
 #, c-format
 msgid "s_page_delete: Can't get the real filename of %1$s."
 msgstr ""
 
-#: liblepton/src/geda_page.c:208
 #, c-format
 msgid "s_page_delete: Unable to delete backup file %1$s."
 msgstr ""
 
-#: liblepton/src/geda_page.c:490
 #, c-format
 msgid "Saved [%1$s]"
 msgstr ""
 
-#: liblepton/src/geda_page.c:496
 #, c-format
 msgid "Could NOT save [%1$s]"
 msgstr ""
 
-#: liblepton/src/geda_arc_object.c:408 liblepton/src/geda_arc_object.c:421
 msgid "Failed to parse arc object"
 msgstr ""
 
-#: liblepton/src/geda_arc_object.c:428
 #, fuzzy, c-format
 msgid "Found a zero radius arc [ %1$c %2$d, %3$d, %4$d, %5$d, %6$d, %7$d ]"
 msgstr "Дуга з нульовим радіусом [ %c %d, %d, %d, %d, %d, %d ]\n"
 
-#: liblepton/src/geda_arc_object.c:435 liblepton/src/geda_box_object.c:328
-#: liblepton/src/geda_bus_object.c:364 liblepton/src/geda_circle_object.c:387
-#: liblepton/src/geda_line_object.c:427 liblepton/src/geda_net_object.c:308
-#: liblepton/src/geda_path_object.c:214 liblepton/src/geda_pin_object.c:369
-#: liblepton/src/geda_text_object.c:555
 #, fuzzy, c-format
 msgid "Found an invalid color [ %1$s ]"
 msgstr "Недопустимий колір [ %s ]\n"
 
-#: liblepton/src/geda_arc_object.c:436 liblepton/src/geda_box_object.c:329
-#: liblepton/src/geda_bus_object.c:365 liblepton/src/geda_circle_object.c:388
-#: liblepton/src/geda_line_object.c:428 liblepton/src/geda_net_object.c:309
-#: liblepton/src/geda_path_object.c:215 liblepton/src/geda_pin_object.c:370
-#: liblepton/src/geda_text_object.c:557
 #, fuzzy
 msgid "Setting color to default color."
 msgstr "Колір виставлено за замовчуванням\n"
 
-#: liblepton/src/o_attrib.c:111
 #, c-format
 msgid "Attribute [%1$s] already attached\n"
 msgstr ""
 
-#: liblepton/src/o_attrib.c:117
 msgid "Attempt to attach non text item as an attribute!\n"
 msgstr "Спроба встановити не текстовий елемент як атрибут\n"
 
-#: liblepton/src/o_attrib.c:122
 #, fuzzy, c-format
 msgid "Attempt to attach attribute [%1$s] to more than one object\n"
 msgstr "Спроба додати трибут [%s] більш ніж до одного об'єкту\n"
 
-#: liblepton/src/o_attrib.c:325
 msgid "Tried to attach a non-text item as an attribute"
 msgstr ""
 
-#: liblepton/src/o_attrib.c:332
 msgid "Unexpected end-of-file in attribute list"
 msgstr ""
 
-#: liblepton/src/geda_box_object.c:287 liblepton/src/geda_box_object.c:316
 msgid "Failed to parse box object"
 msgstr ""
 
-#: liblepton/src/geda_box_object.c:322
 #, fuzzy, c-format
 msgid "Found a zero width/height box [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr ""
 "Знайдено прямокутник з нульовою довжиною/шириною [ %c %d %d %d %d %d ]\n"
 
-#: liblepton/src/geda_bus_object.c:345 liblepton/src/geda_bus_object.c:352
 msgid "Failed to parse bus object"
 msgstr ""
 
-#: liblepton/src/geda_bus_object.c:358
 #, fuzzy, c-format
 msgid "Found a zero length bus [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr "Знайдено шину нульової довжини [ %c %d %d %d %d %d ]\n"
 
-#: liblepton/src/geda_bus_object.c:370
 #, fuzzy, c-format
 msgid "Found an invalid bus ripper direction [ %1$s ]"
 msgstr "Недопустимий колір [ %s ]\n"
 
-#: liblepton/src/geda_bus_object.c:371
 msgid "Resetting direction to neutral (no direction)."
 msgstr ""
 
-#: liblepton/src/geda_circle_object.c:343
-#: liblepton/src/geda_circle_object.c:372
 msgid "Failed to parse circle object"
 msgstr ""
 
-#: liblepton/src/geda_circle_object.c:379
 #, fuzzy, c-format
 msgid "Found a zero or negative radius circle [ %1$c %2$d %3$d %4$d %5$d ]"
 msgstr "Дуга з нульовим радіусом [ %c %d, %d, %d, %d, %d, %d ]\n"
 
-#: liblepton/src/geda_circle_object.c:382
 msgid "Setting radius to 0."
 msgstr ""
 
-#: liblepton/src/geda_color.c:217
 msgid "Color map entry must be a two-element list"
 msgstr ""
 
-#: liblepton/src/geda_color.c:225
 msgid "Index in color map entry must be an integer"
 msgstr ""
 
-#: liblepton/src/geda_color.c:251
 msgid "Value in color map entry must be #f or a string"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:373
 #, fuzzy, c-format
 msgid ""
 "Component not found:\n"
@@ -383,11 +308,9 @@ msgstr ""
 "Компонент не знайдено:\n"
 " %s"
 
-#: liblepton/src/geda_complex_object.c:585
 msgid "Failed to parse complex object"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:598
 #, fuzzy, c-format
 msgid ""
 "Found a component with an invalid rotation [ %1$c %2$d %3$d %4$d %5$d %6$d "
@@ -395,12 +318,9 @@ msgid ""
 msgstr ""
 "Знайдено не правильно зорієнтований компонент [ %c %d %d %d %d %d %s ]\n"
 
-#: liblepton/src/geda_complex_object.c:601
-#: liblepton/src/geda_picture_object.c:105
 msgid "Setting angle to 0."
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:613
 #, fuzzy, c-format
 msgid ""
 "Found a component with an invalid mirror flag [ %1$c %2$d %3$d %4$d %5$d "
@@ -408,32 +328,27 @@ msgid ""
 msgstr ""
 "Знайдено компонент з не правильним віддзеркаленням [ %c %d %d %d %d %d %s ]\n"
 
-#: liblepton/src/geda_complex_object.c:616
 msgid "Setting mirror to 0."
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:941
 #, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
 "\tCould not parse symbol file symversion=%2$s"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:945
 #, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
 "\tCould not parse symbol file symversion="
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:961
 #, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
 "\tCould not parse attached symversion=%2$s"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:986
 #, c-format
 msgid ""
 "WARNING: Symbol version oddity on refdes %1$s:\n"
@@ -441,537 +356,418 @@ msgid ""
 "symbol file."
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:1000
 #, c-format
 msgid ""
 "WARNING: Symbol version mismatch on refdes %1$s (%2$s):\n"
 "\tSymbol in library is newer than instantiated symbol."
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:1028
 #, c-format
 msgid "\tMAJOR VERSION CHANGE (file %1$.3f, instantiated %2$.3f, %3$s)!"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:1046
 #, c-format
 msgid "\tMinor version change (file %1$.3f, instantiated %2$.3f)"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:1057
 #, c-format
 msgid ""
 "WARNING: Symbol version oddity on refdes %1$s:\n"
 "\tInstantiated symbol is newer than symbol in library."
 msgstr ""
 
-#: liblepton/src/o_embed.c:54
 #, c-format
 msgid "Component [%1$s] has been embedded."
 msgstr ""
 
-#: liblepton/src/o_embed.c:98
 #, c-format
 msgid ""
 "Could not find component [%1$s], while trying to unembed. Component is still "
 "embedded."
 msgstr ""
 
-#: liblepton/src/o_embed.c:106
 #, c-format
 msgid "Component [%1$s] has been successfully unembedded."
 msgstr ""
 
-#: liblepton/src/geda_line_object.c:391 liblepton/src/geda_line_object.c:409
 msgid "Failed to parse line object"
 msgstr ""
 
-#: liblepton/src/geda_line_object.c:421
 #, fuzzy, c-format
 msgid "Found a zero length line [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr "Знайдено шину нульової довжини [ %c %d %d %d %d %d ]\n"
 
-#: liblepton/src/geda_net_object.c:297
 msgid "Failed to parse net object"
 msgstr ""
 
-#: liblepton/src/geda_net_object.c:302
 #, fuzzy, c-format
 msgid "Found a zero length net [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr "Знайдено шину нульової довжини [ %c %d %d %d %d %d ]\n"
 
-#: liblepton/src/geda_path_object.c:206
 msgid "Failed to parse path object"
 msgstr ""
 
-#: liblepton/src/geda_path_object.c:232
 msgid "Unexpected end-of-file when reading path"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:71
 msgid "Failed to parse picture definition"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:76
 #, fuzzy, c-format
 msgid "Found a zero width/height picture [ %1$c %2$d %3$d %4$d %5$d ]"
 msgstr ""
 "Знайдено прямокутник з нульовою довжиною/шириною [ %c %d %d %d %d %d ]\n"
 
-#: liblepton/src/geda_picture_object.c:82
 #, c-format
 msgid "Found a picture with a wrong 'mirrored' parameter: %1$d."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:84
 msgid "Setting mirrored to 0."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:89
 #, c-format
 msgid "Found a picture with a wrong 'embedded' parameter: %1$d."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:91
 msgid "Setting embedded to 0."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:104
 #, fuzzy, c-format
 msgid "Found an unsupported picture angle [ %1$d ]"
 msgstr "Недопустимий колір [ %s ]\n"
 
-#: liblepton/src/geda_picture_object.c:116
 msgid "Found an image with no filename."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:147
 #, c-format
 msgid "Failed to load image from embedded data [%1$s]: %2$s"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:148
 msgid "Base64 decoding failed."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:149
 msgid "Falling back to file loading. Picture unembedded."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:208
 msgid "ERROR: o_picture_save: unable to encode the picture."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:308
 #, c-format
 msgid "Failed to load buffer image [%1$s]: %2$s"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:321
 #, c-format
 msgid "Failed to load image from [%1$s]: %2$s"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:415
 #, c-format
 msgid "Picture %1$p has invalid angle %2$i\n"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:772
 #, c-format
 msgid "Picture [%1$s] has no image data."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:773
 msgid "Falling back to file loading. Picture is still unembedded."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:781
 #, c-format
 msgid "Picture [%1$s] has been embedded."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:805
 #, c-format
 msgid "Failed to load image from file [%1$s]: %2$s"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:807
 msgid "Picture is still embedded."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:815
 #, c-format
 msgid "Picture [%1$s] has been unembedded."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:1052
 #, c-format
 msgid "Failed to load fallback image %1$s: %2$s.\n"
 msgstr ""
 
-#: liblepton/src/geda_pin_object.c:346 liblepton/src/geda_pin_object.c:354
 msgid "Failed to parse pin object"
 msgstr ""
 
-#: liblepton/src/geda_pin_object.c:360
 msgid ""
 "Found a pin which did not have the whichend field set.\n"
 "Verify and correct manually."
 msgstr ""
 
-#: liblepton/src/geda_pin_object.c:363
 #, c-format
 msgid "Found an invalid whichend on a pin (reseting to zero): %d"
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:495 liblepton/src/geda_text_object.c:505
-#: liblepton/src/geda_text_object.c:515
 msgid "Failed to parse text object"
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:522
 #, fuzzy, c-format
 msgid "Found an invalid text size [ %1$s ]"
 msgstr "Недопустимий колір [ %s ]\n"
 
-#: liblepton/src/geda_text_object.c:524
 #, c-format
 msgid "Setting text size to %1$d."
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:528
 #, fuzzy, c-format
 msgid "Found an unsupported text angle [ %1$s ]"
 msgstr "Недопустимий колір [ %s ]\n"
 
-#: liblepton/src/geda_text_object.c:530
 #, c-format
 msgid "Setting angle to %1$d."
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:547
 #, fuzzy, c-format
 msgid "Found an unsupported text alignment [ %1$s ]"
 msgstr "Недопустимий колір [ %s ]\n"
 
-#: liblepton/src/geda_text_object.c:550
 msgid "Setting alignment to LOWER_LEFT."
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:570
 #, c-format
 msgid "Unexpected end-of-file after %1$d lines"
 msgstr ""
 
-#: liblepton/src/s_clib.c:460
 #, c-format
 msgid "Library command failed [%1$s]: %2$s"
 msgstr ""
 
-#: liblepton/src/s_clib.c:465
 #, c-format
 msgid "Library command failed [%1$s]: Uncaught signal %2$i."
 msgstr ""
 
-#: liblepton/src/s_clib.c:469
 #, c-format
 msgid "Library command failed [%1$s]"
 msgstr ""
 
-#: liblepton/src/s_clib.c:470
 #, c-format
 msgid ""
 "Error output was:\n"
 "%1$s"
 msgstr ""
 
-#: liblepton/src/s_clib.c:556
 #, c-format
 msgid "Library name [%1$s] already in use.  Using [%2$s]."
 msgstr ""
 
-#: liblepton/src/s_clib.c:593
 #, c-format
 msgid "Failed to open directory [%1$s]: %2$s"
 msgstr ""
 
-#: liblepton/src/s_clib.c:729
 #, c-format
 msgid "Failed to scan library [%1$s]: Scheme function returned non-list."
 msgstr ""
 
-#: liblepton/src/s_clib.c:737
 #, c-format
 msgid "Non-string symbol name while scanning library [%1$s]"
 msgstr ""
 
-#: liblepton/src/s_clib.c:893 liblepton/src/s_clib.c:940
 msgid "Cannot add library: name not specified."
 msgstr ""
 
-#: liblepton/src/s_clib.c:900
 #, c-format
 msgid ""
 "Cannot add library [%1$s]: both 'list' and 'get' commands must be specified."
 msgstr ""
 
-#: liblepton/src/s_clib.c:948
 #, c-format
 msgid "Cannot add Scheme-library [%1$s]: callbacks must be closures."
 msgstr ""
 
-#: liblepton/src/s_clib.c:1075
 #, c-format
 msgid "Failed to load symbol from file [%1$s]: %2$s"
 msgstr ""
 
-#: liblepton/src/s_clib.c:1135
 #, c-format
 msgid "Failed to load symbol data [%1$s] from source [%2$s]"
 msgstr ""
 
-#: liblepton/src/s_clib.c:1377
 #, c-format
 msgid "Component [%1$s] was not found in the component library."
 msgstr ""
 
-#: liblepton/src/s_clib.c:1383
 #, c-format
 msgid "More than one component found with name [%1$s]."
 msgstr ""
 
-#: liblepton/src/s_hierarchy.c:78 liblepton/src/s_hierarchy.c:240
 msgid "Schematic not found in source library."
 msgstr ""
 
-#: liblepton/src/s_hierarchy.c:100
 msgid "Hierarchy contains a circular dependency."
 msgstr ""
 
-#: liblepton/src/s_hierarchy.c:200
 msgid "There are no schematics above the current one!"
 msgstr ""
 
-#: liblepton/src/s_hierarchy.c:341
 #, c-format
 msgid "Failed to descend hierarchy into '%1$s': %2$s"
 msgstr ""
 
-#: liblepton/src/s_slot.c:158
 msgid "Did not find slotdef=#:#,#,#... attribute."
 msgstr ""
 
-#: liblepton/src/s_slot.c:164
 msgid "Improper slotdef syntax: missing \":\"."
 msgstr ""
 
-#: liblepton/src/s_slot.c:179
 msgid "Did not find proper slotdef=#:#,#,#... attribute."
 msgstr ""
 
-#: liblepton/src/s_slot.c:209
 msgid "component missing pinseq= attribute."
 msgstr ""
 
-#: liblepton/src/edaconfig.c:694 liblepton/src/edaconfig.c:780
 msgid "Undefined configuration filename"
 msgstr ""
 
-#: liblepton/src/edaconfig.c:1105 liblepton/src/edaconfig.c:1169
 #, c-format
 msgid "Configuration does not have group '%s'"
 msgstr ""
 
-#: liblepton/src/edaconfig.c:1183
 #, c-format
 msgid "Configuration does not have key '%s'"
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:66 liblepton/src/scheme_attrib.c:100
 msgid "~A is not a valid attribute: invalid string '~A'."
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:204
 msgid "Objects ~A and ~A are not part of the same page and/or complex object"
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:211 liblepton/src/scheme_attrib.c:216
 msgid "Object ~A is already attached as an attribute"
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:265
 msgid "Object ~A is attribute of wrong object"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:148
 msgid "Invalid complex angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:270 liblepton/src/scheme_page.c:246
 msgid "Object ~A is already attached to something"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:332
 msgid "Object ~A is attached to a different complex"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:339
 msgid "Object ~A is attached to a page"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:346 liblepton/src/scheme_page.c:298
 msgid "Object ~A is attached as an attribute"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:353 liblepton/src/scheme_page.c:305
 msgid "Object ~A has attributes"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:234
 msgid "Object ~A has bad type '~A'"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:378
 msgid "Object ~A has invalid stroke cap style ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:391
 msgid "Object ~A has invalid stroke dash style ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:455
 msgid "Invalid stroke cap style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:466
 msgid "Invalid stroke dash style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:476
 msgid "Missing dash length parameter for dash style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:486
 msgid "Missing dot/dash space parameter for dash style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:554
 msgid "Object ~A has invalid fill style ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:603
 msgid "Invalid fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:611
 msgid "Missing second space parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:620
 msgid "Missing second angle parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:630
 msgid "Missing stroke width parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:639
 msgid "Missing space parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:648
 msgid "Missing angle parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:962
 msgid "Invalid pin type ~A, must be 'net or 'bus"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1011
 msgid "Object ~A has invalid pin type."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1417
 msgid "Invalid text alignment ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1433
 msgid "Invalid text angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1452
 msgid "Invalid text name/value visibility ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1526
 msgid "Text object ~A has invalid text alignment ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1535
 msgid "Text object ~A has invalid visibility ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1545
 msgid "Text object ~A has invalid text attribute visibility ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1586
 msgid "Object ~A is not included in a page."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1739
 msgid "Path object ~A has invalid element type ~A at index ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1853
 msgid "Invalid path element type ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:2025
 msgid "Invalid picture angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr ""
 
-#: liblepton/src/scheme_page.c:291
 msgid "Object ~A is attached to a complex or different page"
 msgstr ""
 
-#: liblepton/src/scheme_page.c:438
 msgid "Parse error: ~s"
 msgstr ""
 
-#: liblepton/src/edascmhookproxy.c:83
 msgid "Scheme hook"
 msgstr ""
 
-#: liblepton/src/edascmhookproxy.c:84
 msgid "The Scheme-level hook to proxy"
 msgstr ""
 
-#: liblepton/scheme/geda/attrib.scm:56
 #, scheme-format
 msgid "Object ~A is not part of a page"
 msgstr ""
 
-#: liblepton/scheme/geda/library.scm:108
 #, scheme-format
 msgid "Invalid path ~S or source not readable.\n"
 msgstr ""
 
-#: liblepton/scheme/geda/library.scm:109
 msgid "Source library path must be a string.\n"
 msgstr ""
 
-#: liblepton/scheme/geda/library.scm:168
 #, scheme-format
 msgid "File ~S is not readable.\n"
 msgstr ""
 
-#: liblepton/scheme/geda/repl.scm:48
 msgid "Welcome to Lepton REPL!\n"
 msgstr ""
 
-#: liblepton/scheme/geda/repl.scm:53
 msgid "WARNING: Readline library is not supported in your configuration.\n"
 msgstr ""
 

--- a/liblepton/po/zh_CN.po
+++ b/liblepton/po/zh_CN.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-12 00:08+0300\n"
+"POT-Creation-Date: 2019-05-13 11:16+0300\n"
 "PO-Revision-Date: 2010-02-06 22:10+0000\n"
 "Last-Translator: 冯超 <rainofchaos@gmail.com>\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -18,46 +18,37 @@ msgstr ""
 "X-Launchpad-Export-Date: 2010-02-14 12:56+0000\n"
 "X-Generator: Launchpad (build Unknown)\n"
 
-#: liblepton/data/liblepton.xml.in:3
 #, fuzzy
 msgid "Lepton EDA circuit schematic"
 msgstr "gEDA 电路图"
 
-#: liblepton/data/liblepton.xml.in:4
 #, fuzzy
 msgid "Lepton EDA schematic symbol"
 msgstr "gEDA 图表符号"
 
-#: liblepton/data/liblepton.xml.in:5
 #, fuzzy
 msgid "Lepton EDA sch2pcb project"
 msgstr "gEDA gsch2pcb 项目"
 
-#: liblepton/data/x-lepton-sch2pcb-project.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA sch2pcb Project"
 msgstr "gEDA Gsch2pcb 项目"
 
-#: liblepton/data/x-lepton-schematic.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Circuit Schematic"
 msgstr "gEDA 电路图"
 
-#: liblepton/data/x-lepton-symbol.desktop.in:3
 #, fuzzy
 msgid "Lepton EDA Schematic Symbol"
 msgstr "gEDA 图表符号"
 
-#: liblepton/src/a_basic.c:57 liblepton/src/f_basic.c:377
 #, c-format
 msgid "File %1$s is read-only"
 msgstr ""
 
-#: liblepton/src/a_basic.c:114
 msgid "Schematic data was not valid UTF-8"
 msgstr ""
 
-#: liblepton/src/a_basic.c:246
 #, c-format
 msgid ""
 "Read unexpected attach symbol start marker in [%1$s] :\n"
@@ -65,7 +56,6 @@ msgid ""
 "%2$s<<\n"
 msgstr ""
 
-#: liblepton/src/a_basic.c:263
 #, c-format
 msgid ""
 "Read unexpected embedded symbol start marker in [%1$s] :\n"
@@ -73,7 +63,6 @@ msgid ""
 "%2$s<<\n"
 msgstr ""
 
-#: liblepton/src/a_basic.c:294
 #, c-format
 msgid ""
 "Read unexpected embedded symbol end marker in [%s] :\n"
@@ -81,7 +70,6 @@ msgid ""
 "%s<<\n"
 msgstr ""
 
-#: liblepton/src/a_basic.c:329
 #, c-format
 msgid ""
 "Read an old format sym/sch file!\n"
@@ -89,7 +77,6 @@ msgid ""
 "[%1$s]"
 msgstr ""
 
-#: liblepton/src/a_basic.c:335
 #, c-format
 msgid ""
 "Read garbage in [%1$s] :\n"
@@ -97,17 +84,14 @@ msgid ""
 "%2$s<<\n"
 msgstr ""
 
-#: liblepton/src/f_basic.c:119 liblepton/src/f_basic.c:132
 #, c-format
 msgid "Failed to stat [%1$s]: %2$s"
 msgstr ""
 
-#: liblepton/src/f_basic.c:211
 #, c-format
 msgid "Cannot find file %1$s: %2$s"
 msgstr ""
 
-#: liblepton/src/f_basic.c:260
 #, c-format
 msgid ""
 "\n"
@@ -116,305 +100,236 @@ msgid ""
 "\n"
 msgstr ""
 
-#: liblepton/src/f_basic.c:262
 msgid "I could not guess if it is newer, so you have to do it manually.\n"
 msgstr ""
 
-#: liblepton/src/f_basic.c:264
 msgid ""
 "The backup copy is newer than the schematic, so it seems you should load it "
 "instead of the original file.\n"
 msgstr ""
 
-#: liblepton/src/f_basic.c:266
 msgid ""
 "lepton-schematic usually makes backup copies automatically, and this "
 "situation happens when it crashed or it was forced to exit abruptly.\n"
 msgstr ""
 
-#: liblepton/src/f_basic.c:269
 msgid ""
 "\n"
 "Run lepton-schematic and correct the situation.\n"
 "\n"
 msgstr ""
 
-#: liblepton/src/f_basic.c:367
 #, c-format
 msgid "Can't get the real filename of %1$s: %2$s"
 msgstr ""
 
-#: liblepton/src/f_basic.c:398
 #, c-format
 msgid "Could NOT set previous backup file [%1$s] read-write."
 msgstr ""
 
-#: liblepton/src/f_basic.c:404
 #, c-format
 msgid "Can't save backup file: %1$s."
 msgstr ""
 
-#: liblepton/src/f_basic.c:414
 #, c-format
 msgid "Could NOT set backup file [%1$s] readonly."
 msgstr ""
 
-#: liblepton/src/f_basic.c:463
 #, c-format
 msgid "Failed to restore permissions on '%1$s': %2$s\n"
 msgstr ""
 
-#: liblepton/src/f_basic.c:468
 #, c-format
 msgid "Failed to restore ownership on '%1$s': %2$s\n"
 msgstr ""
 
-#: liblepton/src/f_basic.c:478
 #, c-format
 msgid "Could NOT save file: %1$s"
 msgstr ""
 
-#: liblepton/src/f_basic.c:604
 #, c-format
 msgid "%s: %s"
 msgstr ""
 
-#: liblepton/src/g_basic.c:260
 msgid ""
 "\n"
 "Backtrace:\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:99
 #, c-format
 msgid "Invalid mode [%1$s] passed to %2$s\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:139
 msgid "RC file already loaded"
 msgstr ""
 
-#: liblepton/src/g_rc.c:183
 #, c-format
 msgid "Failed to load config from '%1$s': %2$s\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:207
 #, c-format
 msgid "Loaded RC file [%1$s]"
 msgstr ""
 
-#: liblepton/src/g_rc.c:211
 #, c-format
 msgid "Failed to load RC file [%1$s]: "
 msgstr ""
 
-#: liblepton/src/g_rc.c:341
 msgid "ERROR: An unknown error occurred while parsing configuration files."
 msgstr ""
 
-#: liblepton/src/g_rc.c:353
 #, c-format
 msgid "ERROR: %1$s"
 msgstr ""
 
-#: liblepton/src/g_rc.c:354
 #, c-format
 msgid "ERROR: %1$s\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:360
 #, c-format
 msgid "ERROR: The %1$s log may contain more information.\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:512
 #, c-format
 msgid "Invalid path [%1$s] passed to component-library\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:738
 #, c-format
 msgid "Invalid path [%1$s] passed to bitmap-directory\n"
 msgstr ""
 
-#: liblepton/src/geda_page.c:197
 #, c-format
 msgid "s_page_delete: Can't get the real filename of %1$s."
 msgstr ""
 
-#: liblepton/src/geda_page.c:208
 #, c-format
 msgid "s_page_delete: Unable to delete backup file %1$s."
 msgstr ""
 
-#: liblepton/src/geda_page.c:490
 #, c-format
 msgid "Saved [%1$s]"
 msgstr ""
 
-#: liblepton/src/geda_page.c:496
 #, c-format
 msgid "Could NOT save [%1$s]"
 msgstr ""
 
-#: liblepton/src/geda_arc_object.c:408 liblepton/src/geda_arc_object.c:421
 msgid "Failed to parse arc object"
 msgstr ""
 
-#: liblepton/src/geda_arc_object.c:428
 #, c-format
 msgid "Found a zero radius arc [ %1$c %2$d, %3$d, %4$d, %5$d, %6$d, %7$d ]"
 msgstr ""
 
-#: liblepton/src/geda_arc_object.c:435 liblepton/src/geda_box_object.c:328
-#: liblepton/src/geda_bus_object.c:364 liblepton/src/geda_circle_object.c:387
-#: liblepton/src/geda_line_object.c:427 liblepton/src/geda_net_object.c:308
-#: liblepton/src/geda_path_object.c:214 liblepton/src/geda_pin_object.c:369
-#: liblepton/src/geda_text_object.c:555
 #, c-format
 msgid "Found an invalid color [ %1$s ]"
 msgstr ""
 
-#: liblepton/src/geda_arc_object.c:436 liblepton/src/geda_box_object.c:329
-#: liblepton/src/geda_bus_object.c:365 liblepton/src/geda_circle_object.c:388
-#: liblepton/src/geda_line_object.c:428 liblepton/src/geda_net_object.c:309
-#: liblepton/src/geda_path_object.c:215 liblepton/src/geda_pin_object.c:370
-#: liblepton/src/geda_text_object.c:557
 msgid "Setting color to default color."
 msgstr ""
 
-#: liblepton/src/o_attrib.c:111
 #, c-format
 msgid "Attribute [%1$s] already attached\n"
 msgstr ""
 
-#: liblepton/src/o_attrib.c:117
 msgid "Attempt to attach non text item as an attribute!\n"
 msgstr ""
 
-#: liblepton/src/o_attrib.c:122
 #, c-format
 msgid "Attempt to attach attribute [%1$s] to more than one object\n"
 msgstr ""
 
-#: liblepton/src/o_attrib.c:325
 msgid "Tried to attach a non-text item as an attribute"
 msgstr ""
 
-#: liblepton/src/o_attrib.c:332
 msgid "Unexpected end-of-file in attribute list"
 msgstr ""
 
-#: liblepton/src/geda_box_object.c:287 liblepton/src/geda_box_object.c:316
 msgid "Failed to parse box object"
 msgstr ""
 
-#: liblepton/src/geda_box_object.c:322
 #, c-format
 msgid "Found a zero width/height box [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr ""
 
-#: liblepton/src/geda_bus_object.c:345 liblepton/src/geda_bus_object.c:352
 msgid "Failed to parse bus object"
 msgstr ""
 
-#: liblepton/src/geda_bus_object.c:358
 #, c-format
 msgid "Found a zero length bus [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr ""
 
-#: liblepton/src/geda_bus_object.c:370
 #, c-format
 msgid "Found an invalid bus ripper direction [ %1$s ]"
 msgstr ""
 
-#: liblepton/src/geda_bus_object.c:371
 msgid "Resetting direction to neutral (no direction)."
 msgstr ""
 
-#: liblepton/src/geda_circle_object.c:343
-#: liblepton/src/geda_circle_object.c:372
 msgid "Failed to parse circle object"
 msgstr ""
 
-#: liblepton/src/geda_circle_object.c:379
 #, c-format
 msgid "Found a zero or negative radius circle [ %1$c %2$d %3$d %4$d %5$d ]"
 msgstr ""
 
-#: liblepton/src/geda_circle_object.c:382
 msgid "Setting radius to 0."
 msgstr ""
 
-#: liblepton/src/geda_color.c:217
 msgid "Color map entry must be a two-element list"
 msgstr ""
 
-#: liblepton/src/geda_color.c:225
 msgid "Index in color map entry must be an integer"
 msgstr ""
 
-#: liblepton/src/geda_color.c:251
 msgid "Value in color map entry must be #f or a string"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:373
 #, c-format
 msgid ""
 "Component not found:\n"
 " %1$s"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:585
 msgid "Failed to parse complex object"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:598
 #, c-format
 msgid ""
 "Found a component with an invalid rotation [ %1$c %2$d %3$d %4$d %5$d %6$d "
 "%7$s ]"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:601
-#: liblepton/src/geda_picture_object.c:105
 msgid "Setting angle to 0."
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:613
 #, c-format
 msgid ""
 "Found a component with an invalid mirror flag [ %1$c %2$d %3$d %4$d %5$d "
 "%6$d %7$s ]"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:616
 msgid "Setting mirror to 0."
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:941
 #, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
 "\tCould not parse symbol file symversion=%2$s"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:945
 #, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
 "\tCould not parse symbol file symversion="
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:961
 #, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
 "\tCould not parse attached symversion=%2$s"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:986
 #, c-format
 msgid ""
 "WARNING: Symbol version oddity on refdes %1$s:\n"
@@ -422,536 +337,417 @@ msgid ""
 "symbol file."
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:1000
 #, c-format
 msgid ""
 "WARNING: Symbol version mismatch on refdes %1$s (%2$s):\n"
 "\tSymbol in library is newer than instantiated symbol."
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:1028
 #, c-format
 msgid "\tMAJOR VERSION CHANGE (file %1$.3f, instantiated %2$.3f, %3$s)!"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:1046
 #, c-format
 msgid "\tMinor version change (file %1$.3f, instantiated %2$.3f)"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:1057
 #, c-format
 msgid ""
 "WARNING: Symbol version oddity on refdes %1$s:\n"
 "\tInstantiated symbol is newer than symbol in library."
 msgstr ""
 
-#: liblepton/src/o_embed.c:54
 #, c-format
 msgid "Component [%1$s] has been embedded."
 msgstr ""
 
-#: liblepton/src/o_embed.c:98
 #, c-format
 msgid ""
 "Could not find component [%1$s], while trying to unembed. Component is still "
 "embedded."
 msgstr ""
 
-#: liblepton/src/o_embed.c:106
 #, c-format
 msgid "Component [%1$s] has been successfully unembedded."
 msgstr ""
 
-#: liblepton/src/geda_line_object.c:391 liblepton/src/geda_line_object.c:409
 msgid "Failed to parse line object"
 msgstr ""
 
-#: liblepton/src/geda_line_object.c:421
 #, c-format
 msgid "Found a zero length line [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr ""
 
-#: liblepton/src/geda_net_object.c:297
 msgid "Failed to parse net object"
 msgstr ""
 
-#: liblepton/src/geda_net_object.c:302
 #, c-format
 msgid "Found a zero length net [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr ""
 
-#: liblepton/src/geda_path_object.c:206
 msgid "Failed to parse path object"
 msgstr ""
 
-#: liblepton/src/geda_path_object.c:232
 msgid "Unexpected end-of-file when reading path"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:71
 msgid "Failed to parse picture definition"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:76
 #, c-format
 msgid "Found a zero width/height picture [ %1$c %2$d %3$d %4$d %5$d ]"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:82
 #, c-format
 msgid "Found a picture with a wrong 'mirrored' parameter: %1$d."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:84
 msgid "Setting mirrored to 0."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:89
 #, c-format
 msgid "Found a picture with a wrong 'embedded' parameter: %1$d."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:91
 msgid "Setting embedded to 0."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:104
 #, c-format
 msgid "Found an unsupported picture angle [ %1$d ]"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:116
 msgid "Found an image with no filename."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:147
 #, c-format
 msgid "Failed to load image from embedded data [%1$s]: %2$s"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:148
 msgid "Base64 decoding failed."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:149
 msgid "Falling back to file loading. Picture unembedded."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:208
 msgid "ERROR: o_picture_save: unable to encode the picture."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:308
 #, c-format
 msgid "Failed to load buffer image [%1$s]: %2$s"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:321
 #, c-format
 msgid "Failed to load image from [%1$s]: %2$s"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:415
 #, c-format
 msgid "Picture %1$p has invalid angle %2$i\n"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:772
 #, c-format
 msgid "Picture [%1$s] has no image data."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:773
 msgid "Falling back to file loading. Picture is still unembedded."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:781
 #, c-format
 msgid "Picture [%1$s] has been embedded."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:805
 #, c-format
 msgid "Failed to load image from file [%1$s]: %2$s"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:807
 msgid "Picture is still embedded."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:815
 #, c-format
 msgid "Picture [%1$s] has been unembedded."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:1052
 #, c-format
 msgid "Failed to load fallback image %1$s: %2$s.\n"
 msgstr ""
 
-#: liblepton/src/geda_pin_object.c:346 liblepton/src/geda_pin_object.c:354
 msgid "Failed to parse pin object"
 msgstr ""
 
-#: liblepton/src/geda_pin_object.c:360
 msgid ""
 "Found a pin which did not have the whichend field set.\n"
 "Verify and correct manually."
 msgstr ""
 
-#: liblepton/src/geda_pin_object.c:363
 #, c-format
 msgid "Found an invalid whichend on a pin (reseting to zero): %d"
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:495 liblepton/src/geda_text_object.c:505
-#: liblepton/src/geda_text_object.c:515
 msgid "Failed to parse text object"
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:522
 #, c-format
 msgid "Found an invalid text size [ %1$s ]"
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:524
 #, c-format
 msgid "Setting text size to %1$d."
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:528
 #, c-format
 msgid "Found an unsupported text angle [ %1$s ]"
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:530
 #, c-format
 msgid "Setting angle to %1$d."
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:547
 #, c-format
 msgid "Found an unsupported text alignment [ %1$s ]"
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:550
 msgid "Setting alignment to LOWER_LEFT."
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:570
 #, c-format
 msgid "Unexpected end-of-file after %1$d lines"
 msgstr ""
 
-#: liblepton/src/s_clib.c:460
 #, c-format
 msgid "Library command failed [%1$s]: %2$s"
 msgstr ""
 
-#: liblepton/src/s_clib.c:465
 #, c-format
 msgid "Library command failed [%1$s]: Uncaught signal %2$i."
 msgstr ""
 
-#: liblepton/src/s_clib.c:469
 #, c-format
 msgid "Library command failed [%1$s]"
 msgstr ""
 
-#: liblepton/src/s_clib.c:470
 #, c-format
 msgid ""
 "Error output was:\n"
 "%1$s"
 msgstr ""
 
-#: liblepton/src/s_clib.c:556
 #, c-format
 msgid "Library name [%1$s] already in use.  Using [%2$s]."
 msgstr ""
 
-#: liblepton/src/s_clib.c:593
 #, c-format
 msgid "Failed to open directory [%1$s]: %2$s"
 msgstr ""
 
-#: liblepton/src/s_clib.c:729
 #, c-format
 msgid "Failed to scan library [%1$s]: Scheme function returned non-list."
 msgstr ""
 
-#: liblepton/src/s_clib.c:737
 #, c-format
 msgid "Non-string symbol name while scanning library [%1$s]"
 msgstr ""
 
-#: liblepton/src/s_clib.c:893 liblepton/src/s_clib.c:940
 msgid "Cannot add library: name not specified."
 msgstr ""
 
-#: liblepton/src/s_clib.c:900
 #, c-format
 msgid ""
 "Cannot add library [%1$s]: both 'list' and 'get' commands must be specified."
 msgstr ""
 
-#: liblepton/src/s_clib.c:948
 #, c-format
 msgid "Cannot add Scheme-library [%1$s]: callbacks must be closures."
 msgstr ""
 
-#: liblepton/src/s_clib.c:1075
 #, c-format
 msgid "Failed to load symbol from file [%1$s]: %2$s"
 msgstr ""
 
-#: liblepton/src/s_clib.c:1135
 #, c-format
 msgid "Failed to load symbol data [%1$s] from source [%2$s]"
 msgstr ""
 
-#: liblepton/src/s_clib.c:1377
 #, c-format
 msgid "Component [%1$s] was not found in the component library."
 msgstr ""
 
-#: liblepton/src/s_clib.c:1383
 #, c-format
 msgid "More than one component found with name [%1$s]."
 msgstr ""
 
-#: liblepton/src/s_hierarchy.c:78 liblepton/src/s_hierarchy.c:240
 msgid "Schematic not found in source library."
 msgstr ""
 
-#: liblepton/src/s_hierarchy.c:100
 msgid "Hierarchy contains a circular dependency."
 msgstr ""
 
-#: liblepton/src/s_hierarchy.c:200
 msgid "There are no schematics above the current one!"
 msgstr ""
 
-#: liblepton/src/s_hierarchy.c:341
 #, c-format
 msgid "Failed to descend hierarchy into '%1$s': %2$s"
 msgstr ""
 
-#: liblepton/src/s_slot.c:158
 msgid "Did not find slotdef=#:#,#,#... attribute."
 msgstr ""
 
-#: liblepton/src/s_slot.c:164
 msgid "Improper slotdef syntax: missing \":\"."
 msgstr ""
 
-#: liblepton/src/s_slot.c:179
 msgid "Did not find proper slotdef=#:#,#,#... attribute."
 msgstr ""
 
-#: liblepton/src/s_slot.c:209
 msgid "component missing pinseq= attribute."
 msgstr ""
 
-#: liblepton/src/edaconfig.c:694 liblepton/src/edaconfig.c:780
 msgid "Undefined configuration filename"
 msgstr ""
 
-#: liblepton/src/edaconfig.c:1105 liblepton/src/edaconfig.c:1169
 #, c-format
 msgid "Configuration does not have group '%s'"
 msgstr ""
 
-#: liblepton/src/edaconfig.c:1183
 #, c-format
 msgid "Configuration does not have key '%s'"
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:66 liblepton/src/scheme_attrib.c:100
 msgid "~A is not a valid attribute: invalid string '~A'."
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:204
 msgid "Objects ~A and ~A are not part of the same page and/or complex object"
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:211 liblepton/src/scheme_attrib.c:216
 msgid "Object ~A is already attached as an attribute"
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:265
 msgid "Object ~A is attribute of wrong object"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:148
 msgid "Invalid complex angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:270 liblepton/src/scheme_page.c:246
 msgid "Object ~A is already attached to something"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:332
 msgid "Object ~A is attached to a different complex"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:339
 msgid "Object ~A is attached to a page"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:346 liblepton/src/scheme_page.c:298
 msgid "Object ~A is attached as an attribute"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:353 liblepton/src/scheme_page.c:305
 msgid "Object ~A has attributes"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:234
 msgid "Object ~A has bad type '~A'"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:378
 msgid "Object ~A has invalid stroke cap style ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:391
 msgid "Object ~A has invalid stroke dash style ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:455
 msgid "Invalid stroke cap style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:466
 msgid "Invalid stroke dash style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:476
 msgid "Missing dash length parameter for dash style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:486
 msgid "Missing dot/dash space parameter for dash style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:554
 msgid "Object ~A has invalid fill style ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:603
 msgid "Invalid fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:611
 msgid "Missing second space parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:620
 msgid "Missing second angle parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:630
 msgid "Missing stroke width parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:639
 msgid "Missing space parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:648
 msgid "Missing angle parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:962
 msgid "Invalid pin type ~A, must be 'net or 'bus"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1011
 msgid "Object ~A has invalid pin type."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1417
 msgid "Invalid text alignment ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1433
 msgid "Invalid text angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1452
 msgid "Invalid text name/value visibility ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1526
 msgid "Text object ~A has invalid text alignment ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1535
 msgid "Text object ~A has invalid visibility ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1545
 msgid "Text object ~A has invalid text attribute visibility ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1586
 msgid "Object ~A is not included in a page."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1739
 msgid "Path object ~A has invalid element type ~A at index ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1853
 msgid "Invalid path element type ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:2025
 msgid "Invalid picture angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr ""
 
-#: liblepton/src/scheme_page.c:291
 msgid "Object ~A is attached to a complex or different page"
 msgstr ""
 
-#: liblepton/src/scheme_page.c:438
 msgid "Parse error: ~s"
 msgstr ""
 
-#: liblepton/src/edascmhookproxy.c:83
 msgid "Scheme hook"
 msgstr ""
 
-#: liblepton/src/edascmhookproxy.c:84
 msgid "The Scheme-level hook to proxy"
 msgstr ""
 
-#: liblepton/scheme/geda/attrib.scm:56
 #, scheme-format
 msgid "Object ~A is not part of a page"
 msgstr ""
 
-#: liblepton/scheme/geda/library.scm:108
 #, scheme-format
 msgid "Invalid path ~S or source not readable.\n"
 msgstr ""
 
-#: liblepton/scheme/geda/library.scm:109
 msgid "Source library path must be a string.\n"
 msgstr ""
 
-#: liblepton/scheme/geda/library.scm:168
 #, scheme-format
 msgid "File ~S is not readable.\n"
 msgstr ""
 
-#: liblepton/scheme/geda/repl.scm:48
 msgid "Welcome to Lepton REPL!\n"
 msgstr ""
 
-#: liblepton/scheme/geda/repl.scm:53
 msgid "WARNING: Readline library is not supported in your configuration.\n"
 msgstr ""
 

--- a/liblepton/po/zh_TW.po
+++ b/liblepton/po/zh_TW.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-12 00:08+0300\n"
+"POT-Creation-Date: 2019-05-13 11:16+0300\n"
 "PO-Revision-Date: 2012-01-27 14:12+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -18,40 +18,31 @@ msgstr ""
 "X-Launchpad-Export-Date: 2012-11-14 16:52+0000\n"
 "X-Generator: Launchpad (build 16265)\n"
 
-#: liblepton/data/liblepton.xml.in:3
 msgid "Lepton EDA circuit schematic"
 msgstr ""
 
-#: liblepton/data/liblepton.xml.in:4
 msgid "Lepton EDA schematic symbol"
 msgstr ""
 
-#: liblepton/data/liblepton.xml.in:5
 msgid "Lepton EDA sch2pcb project"
 msgstr ""
 
-#: liblepton/data/x-lepton-sch2pcb-project.desktop.in:3
 msgid "Lepton EDA sch2pcb Project"
 msgstr ""
 
-#: liblepton/data/x-lepton-schematic.desktop.in:3
 msgid "Lepton EDA Circuit Schematic"
 msgstr ""
 
-#: liblepton/data/x-lepton-symbol.desktop.in:3
 msgid "Lepton EDA Schematic Symbol"
 msgstr ""
 
-#: liblepton/src/a_basic.c:57 liblepton/src/f_basic.c:377
 #, c-format
 msgid "File %1$s is read-only"
 msgstr ""
 
-#: liblepton/src/a_basic.c:114
 msgid "Schematic data was not valid UTF-8"
 msgstr ""
 
-#: liblepton/src/a_basic.c:246
 #, c-format
 msgid ""
 "Read unexpected attach symbol start marker in [%1$s] :\n"
@@ -59,7 +50,6 @@ msgid ""
 "%2$s<<\n"
 msgstr ""
 
-#: liblepton/src/a_basic.c:263
 #, c-format
 msgid ""
 "Read unexpected embedded symbol start marker in [%1$s] :\n"
@@ -67,7 +57,6 @@ msgid ""
 "%2$s<<\n"
 msgstr ""
 
-#: liblepton/src/a_basic.c:294
 #, c-format
 msgid ""
 "Read unexpected embedded symbol end marker in [%s] :\n"
@@ -75,7 +64,6 @@ msgid ""
 "%s<<\n"
 msgstr ""
 
-#: liblepton/src/a_basic.c:329
 #, c-format
 msgid ""
 "Read an old format sym/sch file!\n"
@@ -83,7 +71,6 @@ msgid ""
 "[%1$s]"
 msgstr ""
 
-#: liblepton/src/a_basic.c:335
 #, c-format
 msgid ""
 "Read garbage in [%1$s] :\n"
@@ -91,17 +78,14 @@ msgid ""
 "%2$s<<\n"
 msgstr ""
 
-#: liblepton/src/f_basic.c:119 liblepton/src/f_basic.c:132
 #, c-format
 msgid "Failed to stat [%1$s]: %2$s"
 msgstr ""
 
-#: liblepton/src/f_basic.c:211
 #, fuzzy, c-format
 msgid "Cannot find file %1$s: %2$s"
 msgstr "無法找到檔案 %s: %s"
 
-#: liblepton/src/f_basic.c:260
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -110,23 +94,19 @@ msgid ""
 "\n"
 msgstr "無法儲存備份檔：%s."
 
-#: liblepton/src/f_basic.c:262
 msgid "I could not guess if it is newer, so you have to do it manually.\n"
 msgstr "我無法確定這個檔案是否比較新，你必須自己決定。\n"
 
-#: liblepton/src/f_basic.c:264
 msgid ""
 "The backup copy is newer than the schematic, so it seems you should load it "
 "instead of the original file.\n"
 msgstr ""
 
-#: liblepton/src/f_basic.c:266
 msgid ""
 "lepton-schematic usually makes backup copies automatically, and this "
 "situation happens when it crashed or it was forced to exit abruptly.\n"
 msgstr ""
 
-#: liblepton/src/f_basic.c:269
 #, fuzzy
 msgid ""
 "\n"
@@ -137,227 +117,172 @@ msgstr ""
 "啟動 gschem 來修正這個問題。\n"
 "\n"
 
-#: liblepton/src/f_basic.c:367
 #, c-format
 msgid "Can't get the real filename of %1$s: %2$s"
 msgstr ""
 
-#: liblepton/src/f_basic.c:398
 #, fuzzy, c-format
 msgid "Could NOT set previous backup file [%1$s] read-write."
 msgstr "無法設定備份檔[%s]為唯讀\n"
 
-#: liblepton/src/f_basic.c:404
 #, fuzzy, c-format
 msgid "Can't save backup file: %1$s."
 msgstr "無法儲存備份檔：%s."
 
-#: liblepton/src/f_basic.c:414
 #, fuzzy, c-format
 msgid "Could NOT set backup file [%1$s] readonly."
 msgstr "無法設定備份檔[%s]為唯讀\n"
 
-#: liblepton/src/f_basic.c:463
 #, c-format
 msgid "Failed to restore permissions on '%1$s': %2$s\n"
 msgstr ""
 
-#: liblepton/src/f_basic.c:468
 #, c-format
 msgid "Failed to restore ownership on '%1$s': %2$s\n"
 msgstr ""
 
-#: liblepton/src/f_basic.c:478
 #, fuzzy, c-format
 msgid "Could NOT save file: %1$s"
 msgstr "無法儲存[%s]\n"
 
-#: liblepton/src/f_basic.c:604
 #, c-format
 msgid "%s: %s"
 msgstr "%s: %s"
 
-#: liblepton/src/g_basic.c:260
 msgid ""
 "\n"
 "Backtrace:\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:99
 #, c-format
 msgid "Invalid mode [%1$s] passed to %2$s\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:139
 msgid "RC file already loaded"
 msgstr ""
 
-#: liblepton/src/g_rc.c:183
 #, c-format
 msgid "Failed to load config from '%1$s': %2$s\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:207
 #, c-format
 msgid "Loaded RC file [%1$s]"
 msgstr ""
 
-#: liblepton/src/g_rc.c:211
 #, c-format
 msgid "Failed to load RC file [%1$s]: "
 msgstr ""
 
-#: liblepton/src/g_rc.c:341
 msgid "ERROR: An unknown error occurred while parsing configuration files."
 msgstr ""
 
-#: liblepton/src/g_rc.c:353
 #, c-format
 msgid "ERROR: %1$s"
 msgstr ""
 
-#: liblepton/src/g_rc.c:354
 #, c-format
 msgid "ERROR: %1$s\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:360
 #, c-format
 msgid "ERROR: The %1$s log may contain more information.\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:512
 #, c-format
 msgid "Invalid path [%1$s] passed to component-library\n"
 msgstr ""
 
-#: liblepton/src/g_rc.c:738
 #, c-format
 msgid "Invalid path [%1$s] passed to bitmap-directory\n"
 msgstr ""
 
-#: liblepton/src/geda_page.c:197
 #, c-format
 msgid "s_page_delete: Can't get the real filename of %1$s."
 msgstr ""
 
-#: liblepton/src/geda_page.c:208
 #, c-format
 msgid "s_page_delete: Unable to delete backup file %1$s."
 msgstr ""
 
-#: liblepton/src/geda_page.c:490
 #, fuzzy, c-format
 msgid "Saved [%1$s]"
 msgstr "儲存 [%s]\n"
 
-#: liblepton/src/geda_page.c:496
 #, fuzzy, c-format
 msgid "Could NOT save [%1$s]"
 msgstr "無法儲存[%s]\n"
 
-#: liblepton/src/geda_arc_object.c:408 liblepton/src/geda_arc_object.c:421
 msgid "Failed to parse arc object"
 msgstr ""
 
-#: liblepton/src/geda_arc_object.c:428
 #, c-format
 msgid "Found a zero radius arc [ %1$c %2$d, %3$d, %4$d, %5$d, %6$d, %7$d ]"
 msgstr ""
 
-#: liblepton/src/geda_arc_object.c:435 liblepton/src/geda_box_object.c:328
-#: liblepton/src/geda_bus_object.c:364 liblepton/src/geda_circle_object.c:387
-#: liblepton/src/geda_line_object.c:427 liblepton/src/geda_net_object.c:308
-#: liblepton/src/geda_path_object.c:214 liblepton/src/geda_pin_object.c:369
-#: liblepton/src/geda_text_object.c:555
 #, fuzzy, c-format
 msgid "Found an invalid color [ %1$s ]"
 msgstr "找尋到無效的顏色 [%s]\n"
 
-#: liblepton/src/geda_arc_object.c:436 liblepton/src/geda_box_object.c:329
-#: liblepton/src/geda_bus_object.c:365 liblepton/src/geda_circle_object.c:388
-#: liblepton/src/geda_line_object.c:428 liblepton/src/geda_net_object.c:309
-#: liblepton/src/geda_path_object.c:215 liblepton/src/geda_pin_object.c:370
-#: liblepton/src/geda_text_object.c:557
 msgid "Setting color to default color."
 msgstr ""
 
-#: liblepton/src/o_attrib.c:111
 #, c-format
 msgid "Attribute [%1$s] already attached\n"
 msgstr ""
 
-#: liblepton/src/o_attrib.c:117
 msgid "Attempt to attach non text item as an attribute!\n"
 msgstr ""
 
-#: liblepton/src/o_attrib.c:122
 #, c-format
 msgid "Attempt to attach attribute [%1$s] to more than one object\n"
 msgstr ""
 
-#: liblepton/src/o_attrib.c:325
 msgid "Tried to attach a non-text item as an attribute"
 msgstr ""
 
-#: liblepton/src/o_attrib.c:332
 msgid "Unexpected end-of-file in attribute list"
 msgstr ""
 
-#: liblepton/src/geda_box_object.c:287 liblepton/src/geda_box_object.c:316
 msgid "Failed to parse box object"
 msgstr ""
 
-#: liblepton/src/geda_box_object.c:322
 #, c-format
 msgid "Found a zero width/height box [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr ""
 
-#: liblepton/src/geda_bus_object.c:345 liblepton/src/geda_bus_object.c:352
 msgid "Failed to parse bus object"
 msgstr ""
 
-#: liblepton/src/geda_bus_object.c:358
 #, c-format
 msgid "Found a zero length bus [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr ""
 
-#: liblepton/src/geda_bus_object.c:370
 #, fuzzy, c-format
 msgid "Found an invalid bus ripper direction [ %1$s ]"
 msgstr "找尋到無效的顏色 [%s]\n"
 
-#: liblepton/src/geda_bus_object.c:371
 msgid "Resetting direction to neutral (no direction)."
 msgstr ""
 
-#: liblepton/src/geda_circle_object.c:343
-#: liblepton/src/geda_circle_object.c:372
 msgid "Failed to parse circle object"
 msgstr ""
 
-#: liblepton/src/geda_circle_object.c:379
 #, c-format
 msgid "Found a zero or negative radius circle [ %1$c %2$d %3$d %4$d %5$d ]"
 msgstr ""
 
-#: liblepton/src/geda_circle_object.c:382
 msgid "Setting radius to 0."
 msgstr ""
 
-#: liblepton/src/geda_color.c:217
 msgid "Color map entry must be a two-element list"
 msgstr ""
 
-#: liblepton/src/geda_color.c:225
 msgid "Index in color map entry must be an integer"
 msgstr ""
 
-#: liblepton/src/geda_color.c:251
 msgid "Value in color map entry must be #f or a string"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:373
 #, fuzzy, c-format
 msgid ""
 "Component not found:\n"
@@ -366,55 +291,45 @@ msgstr ""
 "找不到以下元件：\n"
 "        %s"
 
-#: liblepton/src/geda_complex_object.c:585
 msgid "Failed to parse complex object"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:598
 #, c-format
 msgid ""
 "Found a component with an invalid rotation [ %1$c %2$d %3$d %4$d %5$d %6$d "
 "%7$s ]"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:601
-#: liblepton/src/geda_picture_object.c:105
 msgid "Setting angle to 0."
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:613
 #, c-format
 msgid ""
 "Found a component with an invalid mirror flag [ %1$c %2$d %3$d %4$d %5$d "
 "%6$d %7$s ]"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:616
 msgid "Setting mirror to 0."
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:941
 #, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
 "\tCould not parse symbol file symversion=%2$s"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:945
 #, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
 "\tCould not parse symbol file symversion="
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:961
 #, c-format
 msgid ""
 "WARNING: Symbol version parse error on refdes %1$s:\n"
 "\tCould not parse attached symversion=%2$s"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:986
 #, c-format
 msgid ""
 "WARNING: Symbol version oddity on refdes %1$s:\n"
@@ -422,535 +337,416 @@ msgid ""
 "symbol file."
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:1000
 #, c-format
 msgid ""
 "WARNING: Symbol version mismatch on refdes %1$s (%2$s):\n"
 "\tSymbol in library is newer than instantiated symbol."
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:1028
 #, c-format
 msgid "\tMAJOR VERSION CHANGE (file %1$.3f, instantiated %2$.3f, %3$s)!"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:1046
 #, c-format
 msgid "\tMinor version change (file %1$.3f, instantiated %2$.3f)"
 msgstr ""
 
-#: liblepton/src/geda_complex_object.c:1057
 #, c-format
 msgid ""
 "WARNING: Symbol version oddity on refdes %1$s:\n"
 "\tInstantiated symbol is newer than symbol in library."
 msgstr ""
 
-#: liblepton/src/o_embed.c:54
 #, c-format
 msgid "Component [%1$s] has been embedded."
 msgstr ""
 
-#: liblepton/src/o_embed.c:98
 #, c-format
 msgid ""
 "Could not find component [%1$s], while trying to unembed. Component is still "
 "embedded."
 msgstr ""
 
-#: liblepton/src/o_embed.c:106
 #, c-format
 msgid "Component [%1$s] has been successfully unembedded."
 msgstr ""
 
-#: liblepton/src/geda_line_object.c:391 liblepton/src/geda_line_object.c:409
 msgid "Failed to parse line object"
 msgstr ""
 
-#: liblepton/src/geda_line_object.c:421
 #, c-format
 msgid "Found a zero length line [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr ""
 
-#: liblepton/src/geda_net_object.c:297
 msgid "Failed to parse net object"
 msgstr ""
 
-#: liblepton/src/geda_net_object.c:302
 #, c-format
 msgid "Found a zero length net [ %1$c %2$d %3$d %4$d %5$d %6$d ]"
 msgstr ""
 
-#: liblepton/src/geda_path_object.c:206
 msgid "Failed to parse path object"
 msgstr ""
 
-#: liblepton/src/geda_path_object.c:232
 msgid "Unexpected end-of-file when reading path"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:71
 msgid "Failed to parse picture definition"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:76
 #, c-format
 msgid "Found a zero width/height picture [ %1$c %2$d %3$d %4$d %5$d ]"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:82
 #, c-format
 msgid "Found a picture with a wrong 'mirrored' parameter: %1$d."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:84
 msgid "Setting mirrored to 0."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:89
 #, c-format
 msgid "Found a picture with a wrong 'embedded' parameter: %1$d."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:91
 msgid "Setting embedded to 0."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:104
 #, fuzzy, c-format
 msgid "Found an unsupported picture angle [ %1$d ]"
 msgstr "找尋到無效的顏色 [%s]\n"
 
-#: liblepton/src/geda_picture_object.c:116
 msgid "Found an image with no filename."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:147
 #, c-format
 msgid "Failed to load image from embedded data [%1$s]: %2$s"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:148
 msgid "Base64 decoding failed."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:149
 msgid "Falling back to file loading. Picture unembedded."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:208
 msgid "ERROR: o_picture_save: unable to encode the picture."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:308
 #, c-format
 msgid "Failed to load buffer image [%1$s]: %2$s"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:321
 #, c-format
 msgid "Failed to load image from [%1$s]: %2$s"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:415
 #, c-format
 msgid "Picture %1$p has invalid angle %2$i\n"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:772
 #, c-format
 msgid "Picture [%1$s] has no image data."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:773
 msgid "Falling back to file loading. Picture is still unembedded."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:781
 #, c-format
 msgid "Picture [%1$s] has been embedded."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:805
 #, c-format
 msgid "Failed to load image from file [%1$s]: %2$s"
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:807
 msgid "Picture is still embedded."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:815
 #, c-format
 msgid "Picture [%1$s] has been unembedded."
 msgstr ""
 
-#: liblepton/src/geda_picture_object.c:1052
 #, c-format
 msgid "Failed to load fallback image %1$s: %2$s.\n"
 msgstr ""
 
-#: liblepton/src/geda_pin_object.c:346 liblepton/src/geda_pin_object.c:354
 msgid "Failed to parse pin object"
 msgstr ""
 
-#: liblepton/src/geda_pin_object.c:360
 msgid ""
 "Found a pin which did not have the whichend field set.\n"
 "Verify and correct manually."
 msgstr ""
 
-#: liblepton/src/geda_pin_object.c:363
 #, c-format
 msgid "Found an invalid whichend on a pin (reseting to zero): %d"
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:495 liblepton/src/geda_text_object.c:505
-#: liblepton/src/geda_text_object.c:515
 msgid "Failed to parse text object"
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:522
 #, fuzzy, c-format
 msgid "Found an invalid text size [ %1$s ]"
 msgstr "找尋到無效的顏色 [%s]\n"
 
-#: liblepton/src/geda_text_object.c:524
 #, c-format
 msgid "Setting text size to %1$d."
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:528
 #, fuzzy, c-format
 msgid "Found an unsupported text angle [ %1$s ]"
 msgstr "找尋到無效的顏色 [%s]\n"
 
-#: liblepton/src/geda_text_object.c:530
 #, c-format
 msgid "Setting angle to %1$d."
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:547
 #, fuzzy, c-format
 msgid "Found an unsupported text alignment [ %1$s ]"
 msgstr "找尋到無效的顏色 [%s]\n"
 
-#: liblepton/src/geda_text_object.c:550
 msgid "Setting alignment to LOWER_LEFT."
 msgstr ""
 
-#: liblepton/src/geda_text_object.c:570
 #, c-format
 msgid "Unexpected end-of-file after %1$d lines"
 msgstr ""
 
-#: liblepton/src/s_clib.c:460
 #, c-format
 msgid "Library command failed [%1$s]: %2$s"
 msgstr ""
 
-#: liblepton/src/s_clib.c:465
 #, c-format
 msgid "Library command failed [%1$s]: Uncaught signal %2$i."
 msgstr ""
 
-#: liblepton/src/s_clib.c:469
 #, c-format
 msgid "Library command failed [%1$s]"
 msgstr ""
 
-#: liblepton/src/s_clib.c:470
 #, c-format
 msgid ""
 "Error output was:\n"
 "%1$s"
 msgstr ""
 
-#: liblepton/src/s_clib.c:556
 #, c-format
 msgid "Library name [%1$s] already in use.  Using [%2$s]."
 msgstr ""
 
-#: liblepton/src/s_clib.c:593
 #, c-format
 msgid "Failed to open directory [%1$s]: %2$s"
 msgstr ""
 
-#: liblepton/src/s_clib.c:729
 #, c-format
 msgid "Failed to scan library [%1$s]: Scheme function returned non-list."
 msgstr ""
 
-#: liblepton/src/s_clib.c:737
 #, c-format
 msgid "Non-string symbol name while scanning library [%1$s]"
 msgstr ""
 
-#: liblepton/src/s_clib.c:893 liblepton/src/s_clib.c:940
 msgid "Cannot add library: name not specified."
 msgstr ""
 
-#: liblepton/src/s_clib.c:900
 #, c-format
 msgid ""
 "Cannot add library [%1$s]: both 'list' and 'get' commands must be specified."
 msgstr ""
 
-#: liblepton/src/s_clib.c:948
 #, c-format
 msgid "Cannot add Scheme-library [%1$s]: callbacks must be closures."
 msgstr ""
 
-#: liblepton/src/s_clib.c:1075
 #, c-format
 msgid "Failed to load symbol from file [%1$s]: %2$s"
 msgstr ""
 
-#: liblepton/src/s_clib.c:1135
 #, c-format
 msgid "Failed to load symbol data [%1$s] from source [%2$s]"
 msgstr ""
 
-#: liblepton/src/s_clib.c:1377
 #, c-format
 msgid "Component [%1$s] was not found in the component library."
 msgstr ""
 
-#: liblepton/src/s_clib.c:1383
 #, c-format
 msgid "More than one component found with name [%1$s]."
 msgstr ""
 
-#: liblepton/src/s_hierarchy.c:78 liblepton/src/s_hierarchy.c:240
 msgid "Schematic not found in source library."
 msgstr ""
 
-#: liblepton/src/s_hierarchy.c:100
 msgid "Hierarchy contains a circular dependency."
 msgstr ""
 
-#: liblepton/src/s_hierarchy.c:200
 msgid "There are no schematics above the current one!"
 msgstr ""
 
-#: liblepton/src/s_hierarchy.c:341
 #, c-format
 msgid "Failed to descend hierarchy into '%1$s': %2$s"
 msgstr ""
 
-#: liblepton/src/s_slot.c:158
 msgid "Did not find slotdef=#:#,#,#... attribute."
 msgstr ""
 
-#: liblepton/src/s_slot.c:164
 msgid "Improper slotdef syntax: missing \":\"."
 msgstr ""
 
-#: liblepton/src/s_slot.c:179
 msgid "Did not find proper slotdef=#:#,#,#... attribute."
 msgstr ""
 
-#: liblepton/src/s_slot.c:209
 msgid "component missing pinseq= attribute."
 msgstr ""
 
-#: liblepton/src/edaconfig.c:694 liblepton/src/edaconfig.c:780
 msgid "Undefined configuration filename"
 msgstr ""
 
-#: liblepton/src/edaconfig.c:1105 liblepton/src/edaconfig.c:1169
 #, c-format
 msgid "Configuration does not have group '%s'"
 msgstr ""
 
-#: liblepton/src/edaconfig.c:1183
 #, c-format
 msgid "Configuration does not have key '%s'"
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:66 liblepton/src/scheme_attrib.c:100
 msgid "~A is not a valid attribute: invalid string '~A'."
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:204
 msgid "Objects ~A and ~A are not part of the same page and/or complex object"
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:211 liblepton/src/scheme_attrib.c:216
 msgid "Object ~A is already attached as an attribute"
 msgstr ""
 
-#: liblepton/src/scheme_attrib.c:265
 msgid "Object ~A is attribute of wrong object"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:148
 msgid "Invalid complex angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:270 liblepton/src/scheme_page.c:246
 msgid "Object ~A is already attached to something"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:332
 msgid "Object ~A is attached to a different complex"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:339
 msgid "Object ~A is attached to a page"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:346 liblepton/src/scheme_page.c:298
 msgid "Object ~A is attached as an attribute"
 msgstr ""
 
-#: liblepton/src/scheme_complex.c:353 liblepton/src/scheme_page.c:305
 msgid "Object ~A has attributes"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:234
 msgid "Object ~A has bad type '~A'"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:378
 msgid "Object ~A has invalid stroke cap style ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:391
 msgid "Object ~A has invalid stroke dash style ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:455
 msgid "Invalid stroke cap style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:466
 msgid "Invalid stroke dash style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:476
 msgid "Missing dash length parameter for dash style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:486
 msgid "Missing dot/dash space parameter for dash style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:554
 msgid "Object ~A has invalid fill style ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:603
 msgid "Invalid fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:611
 msgid "Missing second space parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:620
 msgid "Missing second angle parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:630
 msgid "Missing stroke width parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:639
 msgid "Missing space parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:648
 msgid "Missing angle parameter for fill style ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:962
 msgid "Invalid pin type ~A, must be 'net or 'bus"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1011
 msgid "Object ~A has invalid pin type."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1417
 msgid "Invalid text alignment ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1433
 msgid "Invalid text angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1452
 msgid "Invalid text name/value visibility ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1526
 msgid "Text object ~A has invalid text alignment ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1535
 msgid "Text object ~A has invalid visibility ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1545
 msgid "Text object ~A has invalid text attribute visibility ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1586
 msgid "Object ~A is not included in a page."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1739
 msgid "Path object ~A has invalid element type ~A at index ~A"
 msgstr ""
 
-#: liblepton/src/scheme_object.c:1853
 msgid "Invalid path element type ~A."
 msgstr ""
 
-#: liblepton/src/scheme_object.c:2025
 msgid "Invalid picture angle ~A. Must be 0, 90, 180, or 270 degrees"
 msgstr ""
 
-#: liblepton/src/scheme_page.c:291
 msgid "Object ~A is attached to a complex or different page"
 msgstr ""
 
-#: liblepton/src/scheme_page.c:438
 msgid "Parse error: ~s"
 msgstr ""
 
-#: liblepton/src/edascmhookproxy.c:83
 msgid "Scheme hook"
 msgstr ""
 
-#: liblepton/src/edascmhookproxy.c:84
 msgid "The Scheme-level hook to proxy"
 msgstr ""
 
-#: liblepton/scheme/geda/attrib.scm:56
 #, scheme-format
 msgid "Object ~A is not part of a page"
 msgstr ""
 
-#: liblepton/scheme/geda/library.scm:108
 #, scheme-format
 msgid "Invalid path ~S or source not readable.\n"
 msgstr ""
 
-#: liblepton/scheme/geda/library.scm:109
 msgid "Source library path must be a string.\n"
 msgstr ""
 
-#: liblepton/scheme/geda/library.scm:168
 #, scheme-format
 msgid "File ~S is not readable.\n"
 msgstr ""
 
-#: liblepton/scheme/geda/repl.scm:48
 msgid "Welcome to Lepton REPL!\n"
 msgstr ""
 
-#: liblepton/scheme/geda/repl.scm:53
 msgid "WARNING: Readline library is not supported in your configuration.\n"
 msgstr ""

--- a/netlist/po/.gitignore
+++ b/netlist/po/.gitignore
@@ -7,7 +7,6 @@ POTFILES
 *.sed
 *.header
 *.sin
-lepton-netlist.pot
 Rules-quot
 Makevars.template
 stamp-po

--- a/netlist/po/Makevars
+++ b/netlist/po/Makevars
@@ -10,6 +10,10 @@ top_builddir = ../..
 # These options get passed to xgettext.
 XGETTEXT_OPTIONS = --keyword=_ --keyword=N_
 
+MSGMERGE_OPTIONS = --no-location
+
+PO_DEPENDS_ON_POT = no
+
 # This is the copyright holder that gets inserted into the header of the
 # $(DOMAIN).pot file.  Set this to the copyright holder of the surrounding
 # package.  (Note that the msgstr strings, extracted from the package's

--- a/netlist/po/lepton-netlist.pot
+++ b/netlist/po/lepton-netlist.pot
@@ -1,0 +1,181 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR gEDA Developers
+# This file is distributed under the same license as the lepton-eda package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: lepton-eda 1.9.7\n"
+"Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
+"POT-Creation-Date: 2019-05-13 12:09+0300\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: netlist/scheme/netlist.scm:102
+msgid ""
+"Copyright (C) 1998-2016 gEDA developers\n"
+"Copyright (C) 2017-2018 Lepton EDA Contributors\n"
+"This is free software, and you are welcome to redistribute it under\n"
+"certain conditions. For details, see the file `COPYING', which is\n"
+"included in the Lepton EDA distribution.\n"
+"There is NO WARRANTY, to the extent permitted by law.\n"
+msgstr ""
+
+#: netlist/scheme/netlist.scm:179
+#, scheme-format
+msgid ""
+"Possible attribute conflict for refdes: ~A\n"
+"name: ~A\n"
+"values: ~A\n"
+msgstr ""
+
+#: netlist/scheme/netlist.scm:245
+#, scheme-format
+msgid "Uref ~a: Bad slot number: ~a.\n"
+msgstr ""
+
+#: netlist/scheme/netlist.scm:288
+msgid "Couldn't wrap string  at requested position\n"
+msgstr ""
+
+#: netlist/scheme/netlist.scm:561
+#, scheme-format
+msgid ""
+"There is a net name collision!\n"
+"The net called \"~A\" will be remapped\n"
+"to \"~A\" which is already used\n"
+"by the net called \"~A\".\n"
+"This may be caused by netname attributes colliding with other netnames\n"
+"due to truncation of the name, case insensitivity, or\n"
+"other limitations imposed by this netlist format.\n"
+msgstr ""
+
+#: netlist/scheme/netlist.scm:598
+#, scheme-format
+msgid ""
+"There is a refdes name collision!\n"
+"The refdes \"~A\" will be mapped\n"
+"to \"~A\" which is already used\n"
+"by \"~A\".\n"
+"This may be caused by refdes attributes colliding with others\n"
+"due to truncation of the refdes, case insensitivity, or\n"
+"other limitations imposed by this netlist format.\n"
+msgstr ""
+
+#: netlist/scheme/netlist.scm:791
+#, scheme-format
+msgid "Can't open directory ~S.\n"
+msgstr ""
+
+#: netlist/scheme/netlist.scm:802
+#, scheme-format
+msgid ""
+"Usage: ~A [OPTION ...] [-g BACKEND] [--] FILE ...\n"
+"\n"
+"Generate a netlist from one or more Lepton EDA schematic FILEs.\n"
+"\n"
+"General options:\n"
+"  -q              Quiet mode.\n"
+"  -v, --verbose   Verbose mode.\n"
+"  -o FILE         Filename for netlist data output.\n"
+"  -L DIR          Add DIR to Scheme search path.\n"
+"  -g BACKEND      Specify netlist backend to use.\n"
+"  -O STRING       Pass an option string to backend.\n"
+"  -l FILE         Load Scheme file before loading backend.\n"
+"  -m FILE         Load Scheme file after loading backend.\n"
+"  -c EXPR         Evaluate Scheme expression at startup.\n"
+"  -i              Enter interactive Scheme REPL after loading.\n"
+"  --list-backends Print a list of available netlist backends.\n"
+"  -h, --help      Help; this message.\n"
+"  -V, --version   Show version information.\n"
+"  --              Treat all remaining arguments as filenames.\n"
+"\n"
+"Report bugs at <https://github.com/lepton-eda/lepton-eda/issues>\n"
+"Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>\n"
+msgstr ""
+
+#: netlist/scheme/netlist.scm:840
+#, scheme-format
+msgid ""
+"\n"
+"Just got an error '~A':\n"
+"        ~A\n"
+"\n"
+msgstr ""
+
+#: netlist/scheme/netlist.scm:880
+msgid "You gave neither backend to execute nor interactive mode!\n"
+msgstr ""
+
+#: netlist/scheme/netlist.scm:884
+#, scheme-format
+msgid ""
+"No schematic files specified for processing.\n"
+"~\n"
+"                         Run `~A --help' for more information.\n"
+msgstr ""
+
+#: netlist/scheme/netlist.scm:890
+#, scheme-format
+msgid ""
+"Could not find backend `~A' in load path.\n"
+"~\n"
+"                         Run `~A --list-backends' for a full list of "
+"available backends.\n"
+msgstr ""
+
+#: netlist/scheme/netlist.scm:915
+msgid "Failed to evaluate Scheme expression at startup.\n"
+msgstr ""
+
+#: netlist/scheme/netlist.scm:949
+msgid "Failed to load Scheme file before loading backend.\n"
+msgstr ""
+
+#: netlist/scheme/netlist.scm:966
+msgid "Failed to load backend file.\n"
+msgstr ""
+
+#: netlist/scheme/netlist.scm:979
+msgid "Failed to load Scheme file after loading backend.\n"
+msgstr ""
+
+#: netlist/scheme/netlist/hierarchy.scm:102
+#, scheme-format
+msgid "Found duplicate net name, renaming ~A to ~A"
+msgstr ""
+
+#: netlist/scheme/netlist/hierarchy.scm:176
+#, scheme-format
+msgid "Source schematic of the component ~S has no port with \"refdes=~A\"."
+msgstr ""
+
+#: netlist/scheme/netlist/hierarchy.scm:180
+#, scheme-format
+msgid "Pin ~S of the component ~S has no \"pinlabel\" attribute."
+msgstr ""
+
+#: netlist/scheme/netlist/net.scm:92
+#, scheme-format
+msgid "Invalid attribute (missing ':'): net=~A"
+msgstr ""
+
+#: netlist/scheme/netlist/net.scm:148
+#, scheme-format
+msgid "Attached net ~A:~A overrides inherited net ~A:~A"
+msgstr ""
+
+#: netlist/scheme/netlist/rename.scm:98
+#, scheme-format
+msgid ""
+"WARNING: Trying to rename something twice:\n"
+"\t~A and ~A\n"
+"are both a src and dest name\n"
+"This warning is okay if you have multiple levels of hierarchy!\n"
+msgstr ""

--- a/netlist/po/nl.po
+++ b/netlist/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda-gnetlist\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-12 00:10+0300\n"
+"POT-Creation-Date: 2019-05-13 12:09+0300\n"
 "PO-Revision-Date: 2014-08-31 20:38+0100\n"
 "Last-Translator: Bert Timmerman <bert.timmerman@xs4all.nl>\n"
 "Language-Team: gEDA Developers\n"
@@ -18,7 +18,6 @@ msgstr ""
 "X-Poedit-Language: Dutch\n"
 "X-Poedit-Country: NETHERLANDS\n"
 
-#: netlist/scheme/netlist.scm:102
 #, fuzzy
 msgid ""
 "Copyright (C) 1998-2016 gEDA developers\n"
@@ -35,7 +34,6 @@ msgstr ""
 "bijgesloten in de gEDA distributie.\n"
 "Er is GEEN GARANTIE, voor zover toegestaan door de wet.\n"
 
-#: netlist/scheme/netlist.scm:179
 #, scheme-format
 msgid ""
 "Possible attribute conflict for refdes: ~A\n"
@@ -43,16 +41,13 @@ msgid ""
 "values: ~A\n"
 msgstr ""
 
-#: netlist/scheme/netlist.scm:245
 #, scheme-format
 msgid "Uref ~a: Bad slot number: ~a.\n"
 msgstr ""
 
-#: netlist/scheme/netlist.scm:288
 msgid "Couldn't wrap string  at requested position\n"
 msgstr ""
 
-#: netlist/scheme/netlist.scm:555
 #, scheme-format
 msgid ""
 "There is a net name collision!\n"
@@ -64,7 +59,6 @@ msgid ""
 "other limitations imposed by this netlist format.\n"
 msgstr ""
 
-#: netlist/scheme/netlist.scm:592
 #, scheme-format
 msgid ""
 "There is a refdes name collision!\n"
@@ -76,12 +70,10 @@ msgid ""
 "other limitations imposed by this netlist format.\n"
 msgstr ""
 
-#: netlist/scheme/netlist.scm:785
 #, scheme-format
 msgid "Can't open directory ~S.\n"
 msgstr "Kan bestandenmap ~S niet openen\n"
 
-#: netlist/scheme/netlist.scm:796
 #, fuzzy, scheme-format
 msgid ""
 "Usage: ~A [OPTION ...] [-g BACKEND] [--] FILE ...\n"
@@ -100,7 +92,6 @@ msgid ""
 "  -c EXPR         Evaluate Scheme expression at startup.\n"
 "  -i              Enter interactive Scheme REPL after loading.\n"
 "  --list-backends Print a list of available netlist backends.\n"
-"  -w              Do not display warning about missing configuration files.\n"
 "  -h, --help      Help; this message.\n"
 "  -V, --version   Show version information.\n"
 "  --              Treat all remaining arguments as filenames.\n"
@@ -131,7 +122,6 @@ msgstr ""
 "Rapporteer gebreken op <https://bugs.launchpad.net/geda>\n"
 "gEDA/gaf huispagina: <http://www.geda-project.org/>\n"
 
-#: netlist/scheme/netlist.scm:835
 #, fuzzy, scheme-format
 msgid ""
 "\n"
@@ -143,11 +133,9 @@ msgstr ""
 "Kreeg net een fout; tag is\n"
 "        "
 
-#: netlist/scheme/netlist.scm:875
 msgid "You gave neither backend to execute nor interactive mode!\n"
 msgstr "U gaf geen backend om uit voeren noch interactieve modus!\n"
 
-#: netlist/scheme/netlist.scm:879
 #, fuzzy, scheme-format
 msgid ""
 "No schematic files specified for processing.\n"
@@ -158,7 +146,6 @@ msgstr ""
 "\n"
 "Doe `~A --help' voor meer informatie.\n"
 
-#: netlist/scheme/netlist.scm:885
 #, fuzzy, scheme-format
 msgid ""
 "Could not find backend `~A' in load path.\n"
@@ -170,48 +157,38 @@ msgstr ""
 "\n"
 "Doe `~A --list-backends' voor een volledige lijst van beschikbare backends.\n"
 
-#: netlist/scheme/netlist.scm:910
 msgid "Failed to evaluate Scheme expression at startup.\n"
 msgstr ""
 
-#: netlist/scheme/netlist.scm:944
 msgid "Failed to load Scheme file before loading backend.\n"
 msgstr ""
 
-#: netlist/scheme/netlist.scm:961
 msgid "Failed to load backend file.\n"
 msgstr ""
 
-#: netlist/scheme/netlist.scm:974
 msgid "Failed to load Scheme file after loading backend.\n"
 msgstr ""
 
-#: netlist/scheme/netlist/hierarchy.scm:106
 #, fuzzy, scheme-format
 msgid "Found duplicate net name, renaming ~A to ~A"
 msgstr "Vond een duplicaat net naam, hernoem [%s] naar [%s]\n"
 
-#: netlist/scheme/netlist/hierarchy.scm:189
 #, scheme-format
 msgid "Source schematic of the component ~S has no port with \"refdes=~A\"."
 msgstr ""
 
-#: netlist/scheme/netlist/hierarchy.scm:193
 #, scheme-format
 msgid "Pin ~S of the component ~S has no \"pinlabel\" attribute."
 msgstr ""
 
-#: netlist/scheme/netlist/net.scm:77
 #, scheme-format
 msgid "Invalid attribute (missing ':'): net=~A"
 msgstr ""
 
-#: netlist/scheme/netlist/net.scm:133
 #, scheme-format
 msgid "Attached net ~A:~A overrides inherited net ~A:~A"
 msgstr ""
 
-#: netlist/scheme/netlist/rename.scm:98
 #, fuzzy, scheme-format
 msgid ""
 "WARNING: Trying to rename something twice:\n"

--- a/netlist/po/ru.po
+++ b/netlist/po/ru.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda gnetlist\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-01-12 00:10+0300\n"
+"POT-Creation-Date: 2019-05-13 12:09+0300\n"
 "PO-Revision-Date: 2014-05-20 08:55+0400\n"
 "Last-Translator: Vladimir Zhbanov <vzhbanov@gmail.com>\n"
 "Language-Team: gEDA Developers\n"
@@ -18,7 +18,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: netlist/scheme/netlist.scm:102
 #, fuzzy
 msgid ""
 "Copyright (C) 1998-2016 gEDA developers\n"
@@ -35,7 +34,6 @@ msgstr ""
 "Нет НИКАКИХ ГАРАНТИЙ в рамках, допустимых имеющимся\n"
 "законодательством.\n"
 
-#: netlist/scheme/netlist.scm:179
 #, scheme-format
 msgid ""
 "Possible attribute conflict for refdes: ~A\n"
@@ -43,16 +41,13 @@ msgid ""
 "values: ~A\n"
 msgstr ""
 
-#: netlist/scheme/netlist.scm:245
 #, scheme-format
 msgid "Uref ~a: Bad slot number: ~a.\n"
 msgstr ""
 
-#: netlist/scheme/netlist.scm:288
 msgid "Couldn't wrap string  at requested position\n"
 msgstr ""
 
-#: netlist/scheme/netlist.scm:555
 #, scheme-format
 msgid ""
 "There is a net name collision!\n"
@@ -64,7 +59,6 @@ msgid ""
 "other limitations imposed by this netlist format.\n"
 msgstr ""
 
-#: netlist/scheme/netlist.scm:592
 #, scheme-format
 msgid ""
 "There is a refdes name collision!\n"
@@ -76,12 +70,10 @@ msgid ""
 "other limitations imposed by this netlist format.\n"
 msgstr ""
 
-#: netlist/scheme/netlist.scm:785
 #, scheme-format
 msgid "Can't open directory ~S.\n"
 msgstr "Не удалось открыть каталог ~S.\n"
 
-#: netlist/scheme/netlist.scm:796
 #, fuzzy, scheme-format
 msgid ""
 "Usage: ~A [OPTION ...] [-g BACKEND] [--] FILE ...\n"
@@ -100,7 +92,6 @@ msgid ""
 "  -c EXPR         Evaluate Scheme expression at startup.\n"
 "  -i              Enter interactive Scheme REPL after loading.\n"
 "  --list-backends Print a list of available netlist backends.\n"
-"  -w              Do not display warning about missing configuration files.\n"
 "  -h, --help      Help; this message.\n"
 "  -V, --version   Show version information.\n"
 "  --              Treat all remaining arguments as filenames.\n"
@@ -131,7 +122,6 @@ msgstr ""
 "Отчёты об ошибках отправляйте по адресу <https://bugs.launchpad.net/geda>\n"
 "Домашняя страница gEDA/gaf: <http://www.geda-project.org/>\n"
 
-#: netlist/scheme/netlist.scm:835
 #, fuzzy, scheme-format
 msgid ""
 "\n"
@@ -143,11 +133,9 @@ msgstr ""
 "Обнаружена ошибка; имя тега\n"
 "        "
 
-#: netlist/scheme/netlist.scm:875
 msgid "You gave neither backend to execute nor interactive mode!\n"
 msgstr "Не задан ни драйвер для работы, ни интерактивный режим!\n"
 
-#: netlist/scheme/netlist.scm:879
 #, fuzzy, scheme-format
 msgid ""
 "No schematic files specified for processing.\n"
@@ -158,7 +146,6 @@ msgstr ""
 "\n"
 "Подробности см. в выводе команды «~A --help».\n"
 
-#: netlist/scheme/netlist.scm:885
 #, fuzzy, scheme-format
 msgid ""
 "Could not find backend `~A' in load path.\n"
@@ -171,48 +158,38 @@ msgstr ""
 "Список всех доступных драйверов можно узнать по команде «~A --list-"
 "backends».\n"
 
-#: netlist/scheme/netlist.scm:910
 msgid "Failed to evaluate Scheme expression at startup.\n"
 msgstr ""
 
-#: netlist/scheme/netlist.scm:944
 msgid "Failed to load Scheme file before loading backend.\n"
 msgstr ""
 
-#: netlist/scheme/netlist.scm:961
 msgid "Failed to load backend file.\n"
 msgstr ""
 
-#: netlist/scheme/netlist.scm:974
 msgid "Failed to load Scheme file after loading backend.\n"
 msgstr ""
 
-#: netlist/scheme/netlist/hierarchy.scm:106
 #, fuzzy, scheme-format
 msgid "Found duplicate net name, renaming ~A to ~A"
 msgstr "Обнаружено ещё одно имя для соединения «%s», переименование в «%s»\n"
 
-#: netlist/scheme/netlist/hierarchy.scm:189
 #, scheme-format
 msgid "Source schematic of the component ~S has no port with \"refdes=~A\"."
 msgstr ""
 
-#: netlist/scheme/netlist/hierarchy.scm:193
 #, scheme-format
 msgid "Pin ~S of the component ~S has no \"pinlabel\" attribute."
 msgstr ""
 
-#: netlist/scheme/netlist/net.scm:77
 #, scheme-format
 msgid "Invalid attribute (missing ':'): net=~A"
 msgstr ""
 
-#: netlist/scheme/netlist/net.scm:133
 #, scheme-format
 msgid "Attached net ~A:~A overrides inherited net ~A:~A"
 msgstr ""
 
-#: netlist/scheme/netlist/rename.scm:98
 #, fuzzy, scheme-format
 msgid ""
 "WARNING: Trying to rename something twice:\n"


### PR DESCRIPTION
The same changes as in #342, #389:

1) add `pot` file to source control
2) modify `Makevars`:
  - `MSGMERGE_OPTIONS = --no-location`
  (eliminates comments with line numbers in `*.po`)
  - `PO_DEPENDS_ON_POT = no`
  (do not modify `PO` files if it's not necessary)
3) run `make update-po` in `po/` directory