### PR TITLE
Escape status bar message strings in lepton-schematic

### DIFF
--- a/schematic/src/gschem_bottom_widget.c
+++ b/schematic/src/gschem_bottom_widget.c
@@ -813,8 +813,11 @@ gschem_bottom_widget_set_status_text (GschemBottomWidget *widget, const char *te
 {
   g_return_if_fail (widget != NULL);
 
-  gchar* str = g_strdup_printf (widget->status_bold_font ? "<b>%s</b>" : "%s",
-                                text);
+  gchar* str = g_markup_printf_escaped (widget->status_bold_font
+                                        ? "<b>%s</b>"
+                                        : "%s",
+                                        text);
+
   gtk_label_set_markup (GTK_LABEL (widget->status_label), str);
   g_free (str);
 


### PR DESCRIPTION
`gtk_label_set_markup()` is used to display status
messages in the status bar. Message string needs
to be escaped, so that special characters (e.g.
accelerator keys, such as '<' and '>' ) are
displayed correctly.

Otherwise, you get a ` Gtk-WARNING` like this:
```
Failed to set text from markup due to error parsing markup: Error on line 1 char 13: ' ' is not a valid character following a '<' character; it may not begin an element name
```