### PR TITLE
Use proper exit function in lepton-schematic

### DIFF
--- a/schematic/src/lepton-schematic.c
+++ b/schematic/src/lepton-schematic.c
@@ -146,7 +146,16 @@ void gschem_quit(void)
   i_vars_freenames();
   i_vars_libgeda_freenames();
 
-  gtk_main_quit();
+  /* Check whether the main loop is running:
+  */
+  if (gtk_main_level() == 0)
+  {
+    exit (0);
+  }
+  else
+  {
+    gtk_main_quit();
+  }
 }
 
 /*! \brief Main Scheme(GUILE) program function.


### PR DESCRIPTION
On exit, check if the `GTK` main loop is running
and call `gtk_main_quit()` or `exit()` depending on
that. This way we prevent errors if the program
terminates before the main loop has a chance to
start.
For example, this can happen if we want to
measure the application's startup time with
the following command:

```sh
$ time lepton-schematic -c '(file-quit)'
```