### PR TITLE
liblepton: Fix a C++ warning.

### DIFF
--- a/liblepton/src/liblepton.c
+++ b/liblepton/src/liblepton.c
@@ -85,7 +85,7 @@ set_guile_compiled_path()
   }
   else
   {
-    path = LEPTON_SCM_PRECOMPILE_DIR;
+    path = (char*) LEPTON_SCM_PRECOMPILE_DIR;
   }
 
   setenv ("GUILE_LOAD_COMPILED_PATH", path, 1);


### PR DESCRIPTION
Fix the warning:

warning: ISO C++ forbids converting a string constant to ‘char*’
[-Wwrite-strings]