### PR TITLE
Build and install Scheme API reference HTML pages

### DIFF
--- a/docs/scheme-api/Makefile.am
+++ b/docs/scheme-api/Makefile.am
@@ -8,3 +8,6 @@ html-local:
 	$(MKDIR_P) $(builddir)/lepton-scheme.html/
 	cp -fv $(srcdir)/lepton-scheme.css $(builddir)/lepton-scheme.html/
 
+all-local: html
+
+install-data-local: install-html


### PR DESCRIPTION
Now `make` and `make install` will build and install
`Lepton EDA Scheme Reference Manual` in `HTML` format.