### PR TITLE
Improve the "Write image..." dialog box

### DIFF
--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -672,9 +672,9 @@ void x_grid_draw_region(GschemToplevel *w_current, cairo_t *cr, int x, int y, in
 int x_grid_query_drawn_spacing(GschemToplevel *w_current);
 /* x_image.c */
 void x_image_lowlevel(GschemToplevel *w_current, const char* filename,
-                      int desired_width, int desired_height, const char *filetype);
+                      int desired_width, int desired_height, const char *filetype, gboolean is_color);
 void x_image_setup(GschemToplevel *w_current);
-GdkPixbuf *x_image_get_pixbuf (GschemToplevel *w_current, int width, int height);
+GdkPixbuf *x_image_get_pixbuf (GschemToplevel *w_current, int width, int height, gboolean is_color);
 /* x_integerls.c */
 GtkListStore* x_integerls_new ();
 GtkListStore* x_integerls_new_with_values (const char *value[], int count);
@@ -713,7 +713,7 @@ void x_pagesel_update (GschemToplevel *w_current);
 /* x_preview.c */
 /* x_print.c */
 gboolean x_print_export_pdf_page (GschemToplevel *w_current, const gchar *filename);
-gboolean x_print_export_pdf (GschemToplevel *w_current, const gchar *filename);
+gboolean x_print_export_pdf (GschemToplevel *w_current, const gchar *filename, gboolean is_color);
 void x_print (GschemToplevel *w_current);
 /* x_rc.c */
 void x_rc_parse_gschem (TOPLEVEL *toplevel, const gchar *rcfile);

--- a/schematic/src/g_funcs.c
+++ b/schematic/src/g_funcs.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2015 gEDA Contributors
- * Copyright (C) 2017-2018 Lepton EDA Contributors
+ * Copyright (C) 2017-2019 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -62,7 +62,8 @@ SCM g_funcs_pdf (SCM filename_s)
   filename = scm_to_locale_string (real_filename_s);
   scm_dynwind_free (filename);
 
-  status = x_print_export_pdf (w_current, filename);
+  status = x_print_export_pdf (w_current, filename,
+                               w_current->toplevel->image_color);
 
   scm_dynwind_end ();
 
@@ -100,7 +101,8 @@ SCM g_funcs_image (SCM filename_s)
                     filename,
                     w_current->image_width,
                     w_current->image_height,
-                    "png");
+                    "png",
+                    w_current->toplevel->image_color);
 
   scm_dynwind_end ();
 

--- a/schematic/src/x_image.c
+++ b/schematic/src/x_image.c
@@ -382,6 +382,24 @@ void x_image_setup (GschemToplevel *w_current)
   gtk_box_pack_start (GTK_BOX (vbox2), type_combo, TRUE, TRUE, 0);
   create_type_menu (GTK_COMBO_BOX(type_combo));
 
+
+  /* Color/grayscale selection:
+  */
+  GtkWidget* vbox3 = gtk_vbox_new (TRUE, 0);
+  GtkWidget* label3 = gtk_label_new (_("Color mode"));
+  gtk_misc_set_alignment (GTK_MISC (label3), 0, 0);
+  gtk_misc_set_padding (GTK_MISC (label3), 0, 0);
+  gtk_box_pack_start (GTK_BOX (vbox3), label3, FALSE, FALSE, 0);
+
+  GtkWidget* color_combo = gtk_combo_box_new_text();
+  gtk_box_pack_start (GTK_BOX (vbox3), color_combo, TRUE, TRUE, 0);
+  gtk_combo_box_append_text (GTK_COMBO_BOX (color_combo), _("Color"));
+  gtk_combo_box_append_text (GTK_COMBO_BOX (color_combo), _("Grayscale"));
+  gtk_combo_box_set_active (GTK_COMBO_BOX (color_combo), 0);
+
+  gtk_widget_show_all (vbox3);
+
+
   /* Connect the changed signal to the callback, so the filename
      gets updated every time the image type is changed */
   g_signal_connect (type_combo, "changed",
@@ -408,6 +426,7 @@ void x_image_setup (GschemToplevel *w_current)
   /* Add the extra widgets to the dialog*/
   gtk_box_pack_start(GTK_BOX(hbox), vbox1, FALSE, FALSE, 10);
   gtk_box_pack_start(GTK_BOX(hbox), vbox2, FALSE, FALSE, 10);
+  gtk_box_pack_start(GTK_BOX(hbox), vbox3, FALSE, FALSE, 10);
 
   gtk_file_chooser_set_extra_widget (GTK_FILE_CHOOSER(dialog), hbox);
 
@@ -441,6 +460,10 @@ void x_image_setup (GschemToplevel *w_current)
     image_type = x_image_get_type_from_description(image_type_descr);
     sscanf(image_size, "%ix%i", &width, &height);
     filename = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(dialog));
+
+    /* the first item in the color_combo is "Color", 2nd = "Grayscale":
+    */
+    gboolean is_color = gtk_combo_box_get_active (GTK_COMBO_BOX (color_combo)) == 0;
 
     x_image_lowlevel(w_current, filename, width, height, image_type);
 

--- a/schematic/src/x_image.c
+++ b/schematic/src/x_image.c
@@ -39,8 +39,18 @@
 
 #define X_IMAGE_DEFAULT_TYPE "PNG"
 
-static const char *x_image_sizes[] = {"320x240", "640x480", "800x600", "1200x768",
-  "1280x960", "1600x1200", "3200x2400", NULL};
+static const char *x_image_sizes[] =
+{
+  "320x240",
+  "640x480",
+  "800x600",
+  "1024x768",
+  "1200x768",
+  "1280x960",
+  "1600x1200",
+  "3200x2400",
+  NULL
+};
 
 /*! \brief Create the options of the image size combobox
  *  \par This function adds the options of the image size to the given combobox.

--- a/schematic/src/x_image.c
+++ b/schematic/src/x_image.c
@@ -364,6 +364,17 @@ void x_image_setup (GschemToplevel *w_current)
 
   hbox = gtk_hbox_new(FALSE, 0);
 
+
+  GtkWidget* vbox = gtk_vbox_new (FALSE, 0);
+  GtkWidget* hbox2 = gtk_hbox_new (FALSE, 0);
+  GtkWidget* label = gtk_label_new(
+    _("NOTE: print-color-map will be used for PDF export"));
+  gtk_box_pack_start (GTK_BOX (hbox2), label, FALSE, FALSE, 10);
+  gtk_box_pack_start (GTK_BOX (vbox),  hbox2, FALSE, FALSE, 5);
+  gtk_box_pack_start (GTK_BOX (vbox),  hbox,  FALSE, FALSE, 0);
+  gtk_widget_show_all (vbox);
+
+
   /* Image size selection */
   vbox1 = gtk_vbox_new(TRUE, 0);
   label1 = gtk_label_new (_("Width x Height"));
@@ -439,7 +450,7 @@ void x_image_setup (GschemToplevel *w_current)
   gtk_box_pack_start(GTK_BOX(hbox), vbox2, FALSE, FALSE, 10);
   gtk_box_pack_start(GTK_BOX(hbox), vbox3, FALSE, FALSE, 10);
 
-  gtk_file_chooser_set_extra_widget (GTK_FILE_CHOOSER(dialog), hbox);
+  gtk_file_chooser_set_extra_widget (GTK_FILE_CHOOSER(dialog), vbox);
 
   g_object_set (dialog,
       /* GtkFileChooser */

--- a/schematic/src/x_image.c
+++ b/schematic/src/x_image.c
@@ -17,26 +17,13 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
+
 #include <config.h>
-
-#include <stdio.h>
-#include <unistd.h>
-#ifdef HAVE_STDLIB_H
-#include <stdlib.h>
-#endif
-#ifdef HAVE_STRING_H
-#include <string.h>
-#endif
-
-#include <glib.h>
-
 #include "gschem.h"
 
+
+
 #define X_IMAGE_DEFAULT_SIZE "800x600"
-
-#define X_IMAGE_SIZE_MENU_NAME "image_size_menu"
-#define X_IMAGE_TYPE_MENU_NAME "image_type_menu"
-
 #define X_IMAGE_DEFAULT_TYPE "PNG"
 
 static const char *x_image_sizes[] =

--- a/schematic/src/x_print.c
+++ b/schematic/src/x_print.c
@@ -1,6 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
- * Copyright (C) 1998-2010 gEDA Contributors (see ChangeLog for details)
+ * Copyright (C) 1998-2015 gEDA Contributors
+ * Copyright (C) 2017-2019 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -322,12 +323,14 @@ x_print_export_pdf_page (GschemToplevel *w_current,
  *
  * \param w_current A #GschemToplevel structure.
  * \param filename  The filename for generated PDF.
+ * \param is_color  Export using colors (TRUE) or in grayscale (FALSE).
  *
  * \returns TRUE if the operation was successful.
  */
 gboolean
 x_print_export_pdf (GschemToplevel *w_current,
-                    const gchar *filename)
+                    const gchar *filename,
+                    gboolean is_color)
 {
   cairo_surface_t *surface;
   cairo_status_t cr_status;
@@ -354,7 +357,7 @@ x_print_export_pdf (GschemToplevel *w_current,
 
   x_print_draw_page (w_current->toplevel, w_current->toplevel->page_current,
                      cr, NULL, width, height,
-                     w_current->toplevel->image_color, FALSE);
+                     is_color, FALSE);
 
   cairo_destroy (cr);
   cairo_surface_finish (surface);


### PR DESCRIPTION
- combo box to select the color mode for export: color or grayscale
- warn that different color map will be used for `PDF` export (label)
- add 1024x768 to the list of sizes
- remember and restore selected parameters:
  - folder path
  - image size
  - output file type
  - color mode

@vzh I would also use the `display` color map when exporting `PDF` - for consistency. What do you think about that?

@vzh What about removing `scripts/image.scm`, `scripts/print.scm`
(and, hence, `--output`, `gschem-pdf()`, `gschem-image()`, `image-color` option)? Deprecated since 2012.

![tb_160_write_img_color ss](https://user-images.githubusercontent.com/26083750/58193979-f8272b80-7ccc-11e9-9679-998492031e4e.png)
