### PR TITLE
contrib/scripts: Fix build from the distribution tarball sources

### DIFF
--- a/contrib/scripts/Makefile.am
+++ b/contrib/scripts/Makefile.am
@@ -21,7 +21,8 @@ EXTRA_DIST = \
 	gnet_hier_verilog.1.in \
 	pads_backannotate.1.in \
 	sarlacc_sym.1.in \
-	sw2asc.1.in
+	sw2asc.1.in \
+	sch2eaglepos.sh
 
 .1.in.1:
 	d=`$(GUILE) -c '(setlocale LC_ALL "C") \

--- a/contrib/scripts/Makefile.am
+++ b/contrib/scripts/Makefile.am
@@ -1,14 +1,27 @@
 ## Process this file with automake to produce Makefile.in
 
-noinst_SCRIPTS = gnet_hier_verilog.sh sarlacc_sym pads_backannotate \
-	 bompp.sh.in bom_xref.sh.in sch2eaglepos.sh sw2asc
+noinst_SCRIPTS = \
+	gnet_hier_verilog.sh \
+	sarlacc_sym \
+	pads_backannotate \
+	bompp.sh.in \
+	bom_xref.sh.in \
+	sch2eaglepos.sh \
+	sw2asc
 
 dist_noinst_MANS = gnet_hier_verilog.1 pads_backannotate.1 \
 	sarlacc_sym.1 sw2asc.1
 
-EXTRA_DIST = gnet_hier_verilog.sh sarlacc_sym pads_backannotate \
-	sw2asc.in mk_char_tab.pl  gnet_hier_verilog.1.in \
-	pads_backannotate.1.in sarlacc_sym.1.in sw2asc.1.in
+EXTRA_DIST = \
+	gnet_hier_verilog.sh \
+	sarlacc_sym \
+	pads_backannotate \
+	sw2asc.in \
+	mk_char_tab.pl \
+	gnet_hier_verilog.1.in \
+	pads_backannotate.1.in \
+	sarlacc_sym.1.in \
+	sw2asc.1.in
 
 .1.in.1:
 	d=`$(GUILE) -c '(setlocale LC_ALL "C") \


### PR DESCRIPTION
Build fails in `contrib/scripts/` when compiling
from the distribution tarball sources (made by
`make dist`) with `--enable-contrib`, because of
missing `sch2eaglepos.sh` in `EXTRA_DIST`.