### PR TITLE
Change default gschemrc options

### DIFF
--- a/schematic/scheme/conf/schematic/options.scm
+++ b/schematic/scheme/conf/schematic/options.scm
@@ -51,8 +51,8 @@
 ; information is saved for every command, so the display will change to the
 ; viewport before a command is executed.
 ;
-(undo-panzoom "enabled")
-;(undo-panzoom "disabled")
+;(undo-panzoom "enabled")
+(undo-panzoom "disabled")
 
 
 ; autosave interval

--- a/schematic/scheme/conf/schematic/options.scm
+++ b/schematic/scheme/conf/schematic/options.scm
@@ -250,8 +250,8 @@
 ;       later   - NOT opened up when gschem starts
 ;                 (can be opened by Options/Show Log Window)
 ;
-(log-window "startup")
-;(log-window "later")
+;(log-window "startup")
+(log-window "later")
 
 
 ; log-window-type string

--- a/schematic/scheme/conf/schematic/options.scm
+++ b/schematic/scheme/conf/schematic/options.scm
@@ -29,7 +29,7 @@
 ; Determines the number of levels of undo.  Basically this number decides
 ; how many backup schematics are saved on disk.
 ;
-(undo-levels 10)
+(undo-levels 20)
 
 ; undo-type string
 ;

--- a/schematic/scheme/conf/schematic/options.scm
+++ b/schematic/scheme/conf/schematic/options.scm
@@ -142,8 +142,8 @@
 ; Controls if text is drawn properly or if a simplified version (a line which
 ; represents the text string) is drawn during mouse pan.  Drawing a simple
 ; line speeds up mousepan a lot for big schematics
-(fast-mousepan "enabled")
-;(fast-mousepan "disabled")
+;(fast-mousepan "enabled")
+(fast-mousepan "disabled")
 
 ; mousepan-gain integer
 ;

--- a/schematic/scheme/conf/schematic/options.scm
+++ b/schematic/scheme/conf/schematic/options.scm
@@ -400,8 +400,8 @@
 ; Controls if the cursor is warped (or moved) when you zoom in and out.
 ; Some people find this forced cursor movement annoying.
 ;
-(warp-cursor "enabled")
-;(warp-cursor "disabled")
+;(warp-cursor "enabled")
+(warp-cursor "disabled")
 
 
 ; Bus ripper controls


### PR DESCRIPTION
- `warp-cursor` = disabled
- `fast-mousepan` = disabled
- `log-window` = later
- `undo-levels` = 20 (it was 10)
- `undo-panzoom` = disabled

Affects #369 