### PR TITLE
Change default settings

### DIFF
--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -77,7 +77,7 @@ net-attribute-separator=/
 [export]
 align=auto
 dpi=96
-font=Arial
+font=Sans
 layout=auto
 margins=18;18;18;18
 monochrome=false

--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -4,7 +4,7 @@
 
 [schematic.gui]
 use-docks=true
-use-tabs=false
+use-tabs=true
 max-recent-files=10
 text-sizes=
 font=

--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -21,7 +21,7 @@ status-bold-font=false
 status-active-color=green
 
 [schematic.log-window]
-font=
+font=Monospace 11
 
 [schematic.macro-widget]
 history-length=10

--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -15,8 +15,8 @@ show-up-button=true
 
 [schematic.status-bar]
 show-mouse-buttons=true
-show-rubber-band=false
-show-magnetic-net=false
+show-rubber-band=true
+show-magnetic-net=true
 status-bold-font=false
 status-active-color=green
 

--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -25,7 +25,7 @@ font=Monospace 11
 
 [schematic.macro-widget]
 history-length=10
-font=
+font=Monospace 11
 
 [schematic.undo]
 modify-viewport=false

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -77,7 +77,7 @@ net-attribute-separator=/
 [export]
 align=auto
 dpi=96
-font=Arial
+font=Sans
 layout=auto
 margins=18;18;18;18
 monochrome=false

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -4,7 +4,7 @@
 
 [schematic.gui]
 use-docks=true
-use-tabs=false
+use-tabs=true
 max-recent-files=10
 text-sizes=
 font=

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -21,7 +21,7 @@ status-bold-font=false
 status-active-color=green
 
 [schematic.log-window]
-font=
+font=Monospace 11
 
 [schematic.macro-widget]
 history-length=10

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -15,8 +15,8 @@ show-up-button=true
 
 [schematic.status-bar]
 show-mouse-buttons=true
-show-rubber-band=false
-show-magnetic-net=false
+show-rubber-band=true
+show-magnetic-net=true
 status-bold-font=false
 status-active-color=green
 

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -25,7 +25,7 @@ font=Monospace 11
 
 [schematic.macro-widget]
 history-length=10
-font=
+font=Monospace 11
 
 [schematic.undo]
 modify-viewport=false

--- a/liblepton/scheme/lepton/legacy-config/keylist.scm
+++ b/liblepton/scheme/lepton/legacy-config/keylist.scm
@@ -136,7 +136,7 @@
          "export" "dpi"
          "export" "dpi"
   )
-  ( list pfn-get-str "Arial"
+  ( list pfn-get-str "Sans"
          "export" "font"
          "export" "font"
   )

--- a/libleptonrenderer/edarenderer.c
+++ b/libleptonrenderer/edarenderer.c
@@ -110,7 +110,7 @@ EDA_RENDERER_STROKE_WIDTH0 (EdaRenderer *r, double width) {
   return (width == 0) ? 0 : EDA_RENDERER_STROKE_WIDTH (r, width);
 }
 
-#define DEFAULT_FONT_NAME "Arial"
+#define DEFAULT_FONT_NAME "Sans"
 #define GRIP_STROKE_COLOR SELECT_COLOR
 #define GRIP_FILL_COLOR BACKGROUND_COLOR
 #define TEXT_MARKER_SIZE 10

--- a/utils/scripts/lepton-schdiff
+++ b/utils/scripts/lepton-schdiff
@@ -1,7 +1,7 @@
 #! /bin/sh
 
 VIEWER="display"
-DEFAULT_FONT="Arial"
+DEFAULT_FONT="Sans"
 
 usage ()
 {


### PR DESCRIPTION
- Show `rubber band` mode and `magnetic net` mode status bar indicators
- Enable tabbed GUI
- Use monospace font in the log window
- Use monospace font in the macro widget entry
- Change default font name from `Arial` to `Sans` in `libleptonrenderer`
- Use `Sans` font for `lepton-cli export` and in the `lepton-schdiff` utility

Affects #369 