### PR TITLE
Enable text wrapping in the lepton-schematic log window

### DIFF
--- a/schematic/include/gschem_log_widget.h
+++ b/schematic/include/gschem_log_widget.h
@@ -42,6 +42,7 @@ struct _GschemLogWidget {
   GschemBin parent_instance;
 
   GtkTextView *viewer;
+  gboolean wrap;
 };
 
 


### PR DESCRIPTION
Extend the log window text view's context menu
by adding the "Wrap Long Lines" menu item. It
toggles text wrapping on and off.

![tb_167_log_wrap_off](https://user-images.githubusercontent.com/26083750/58368289-909ef500-7ef3-11e9-8f0c-d4a528c4cc20.png)

![tb_167_log_wrap_on](https://user-images.githubusercontent.com/26083750/58368294-a4e2f200-7ef3-11e9-8c9e-ce06b085b4ab.png)
