### PR TITLE
Detailed deprecated configuration warnings

### DIFF
--- a/liblepton/scheme/geda-deprecated-config.scm
+++ b/liblepton/scheme/geda-deprecated-config.scm
@@ -37,7 +37,12 @@
   ;; FIXME more helpful error message with link to documentation.
   (define (deprecation-warning)
     (format (current-error-port)
-"WARNING: The RC file function '~A' is deprecated and does nothing.
+"
+WARNING: The RC file function '~A' is deprecated
+and does nothing.
+RC configuration functions will be removed in an upcoming Lepton EDA
+release. Please use .conf configuration files instead:
+https://github.com/lepton-eda/lepton-eda/wiki/Configuration-Settings
 
 " old-id))
   (let ((warned? #f))
@@ -64,12 +69,21 @@
   ;; FIXME more helpful error message with link to documentation.
   (define (deprecation-warning)
     (format (current-error-port)
-"WARNING: The RC file function '~A' is deprecated.
+"
+WARNING: The RC file function '~A' is deprecated.
+RC configuration functions will be removed in an upcoming Lepton EDA
+release. Please use .conf configuration files instead:
+https://github.com/lepton-eda/lepton-eda/wiki/Configuration-Settings
 
-RC configuration functions will be removed in an upcoming Lepton
-EDA release.  Please use configuration files instead.
+Put the following lines into the ~A file (in current directory)
+or ~A (in user's configuration directory, typically
+$HOME/.config/lepton-eda/), replacing MYVALUE with the desired
+option's value:
 
-" old-id))
+[~A]
+~A=MYVALUE
+
+" old-id "geda.conf" "geda-user.conf" group key))
   (let ((warned? #f))
     (lambda args
       (or warned?


### PR DESCRIPTION
Be more verbose when printing warnings about
deprecated `RC` configuration files functions:
print link to [Configuration Settings](https://github.com/lepton-eda/lepton-eda/wiki/Configuration-Settings) wiki page,
suggest a replacement that user should put into
a new `.conf` configuration file.

An example of current deprecation warnings:

Deprecated config:
```
WARNING: The RC file function 'untitled-name' is deprecated.

RC configuration functions will be removed in an upcoming Lepton
EDA release.  Please use configuration files instead.
```

"Dead" config:
```
WARNING: The RC file function 'output-orientation' is deprecated and does nothing.
```

After such vague messages the only option left is to use google
(if you're not an experienced `geda-gaf` user).
New warnings are more verbose:

```
WARNING: The RC file function 'untitled-name' is deprecated.
RC configuration functions will be removed in an upcoming Lepton EDA
release. Please use .conf configuration files instead:
https://github.com/lepton-eda/lepton-eda/wiki/Configuration-Settings

Put the following lines into the geda.conf file (in current directory)
or geda-user.conf (in user's configuration directory, typically
$HOME/.config/lepton-eda/), replacing MYVALUE with the desired
option's value:

[gschem]
default-filename=MYVALUE
```

```
WARNING: The RC file function 'output-orientation' is deprecated
and does nothing.
RC configuration functions will be removed in an upcoming Lepton EDA
release. Please use .conf configuration files instead:
https://github.com/lepton-eda/lepton-eda/wiki/Configuration-Settings
```