### PR TITLE
Catch Netlist->allegro errors in lepton-schematic

### DIFF
--- a/schematic/scheme/schematic/netlist.scm
+++ b/schematic/scheme/schematic/netlist.scm
@@ -37,10 +37,18 @@
 
 ;;; First load allegro backend code in order to use `allegro*'
 ;;; below.
-(primitive-load (%search-load-path "gnet-allegro.scm"))
+(let
+  ((fpath (%search-load-path "gnet-allegro.scm")))
+  (if fpath
+    (primitive-load fpath)
+    (log! 'warning "allegro: cannot load backend file")))
 
 ;;; Allegro backend
 (define (&netlist-allegro)
-  (with-output-to-file "allegro.out"
-    (lambda () (allegro* (%schematic))))
-  (log! 'message "allegro: the output is written to [allegro.out]"))
+  (catch #t
+    (lambda()
+      (with-output-to-file "allegro.out"
+        (lambda () (allegro* (%schematic))))
+      (log! 'message "allegro: the output is written to [allegro.out]"))
+    (lambda(ex . args)
+      (log! 'warning "allegro: error launching backend ('~a):~%  ~a" ex args))))


### PR DESCRIPTION
Check errors in code invoked by `Netlist->allegro` menu item:
the `(schematic netlist)` module.

If `allegro*` function fails, backtrace is printed to the log.
If for some reason `allegro` backend cannot be found, `lepton-schematic`
starts in horrible broken state: no menu, no color map, no actions available;
eventually it crashes. All issued errors are absolutely irrelevant, it's very hard to find what actually is wrong.

So, it's better to do some `DBCS` gymnastics now than spend time on debugging later :-).
