### PR TITLE
Optionally show full file path in the lepton-schematic main window's title

### DIFF
--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -243,7 +243,7 @@ void i_set_state_msg(GschemToplevel *w_current, enum x_states newstate, const ch
 void i_update_middle_button (GschemToplevel *w_current, i_callback_func func, const char *string);
 void i_update_toolbar(GschemToplevel *w_current);
 void i_update_menus(GschemToplevel *w_current);
-void i_set_filename(GschemToplevel *w_current, const gchar *string, const gchar *changed);
+void i_set_filename(GschemToplevel *w_current, const gchar *filename, gboolean changed);
 void i_update_grid_info(GschemToplevel *w_current);
 void i_update_grid_info_callback (GschemPageView *view, GschemToplevel *w_current);
 void i_update_net_options_status (GschemToplevel* w_current);

--- a/schematic/src/i_basic.c
+++ b/schematic/src/i_basic.c
@@ -507,35 +507,38 @@ void i_update_menus(GschemToplevel *w_current)
 
 }
 
-/*! \brief Set filename as gschem window title
+/*! \brief Set the main window's title
  *
  *  \par Function Description
- *  Set filename as gschem window title using
- *  the gnome HID format style.
+ *  Set the main window's title using \a filename.
+ *  Prepend an asterisk ("*") to indicate that the page
+ *  is modified if \a changed is TRUE.
  *
  *  \param [in] w_current GschemToplevel structure
- *  \param [in] string The filename
- *  \param [in] string 'Page changed' indication in window's title
+ *  \param [in] filename  The filename
+ *  \param [in] changed   Page changed status
  */
-void i_set_filename(GschemToplevel *w_current, const gchar *string, const gchar *changed)
+void i_set_filename(GschemToplevel *w_current, const gchar *filename, gboolean changed)
 {
   gchar *print_string=NULL;
-  gchar *filename=NULL;
+  gchar *fname=NULL;
 
   if (!w_current->main_window)
     return;
-  if (string == NULL)
+  if (filename == NULL)
     return;
 
-  filename = g_path_get_basename(string);
+  fname = g_path_get_basename(filename);
 
-  print_string = g_strdup_printf("%s%s - lepton-schematic", changed, filename);
+  print_string = g_strdup_printf("%s%s - lepton-schematic",
+                                 changed ? "* " : "",
+                                 fname);
 
   gtk_window_set_title(GTK_WINDOW(w_current->main_window),
 		       print_string);
 
   g_free(print_string);
-  g_free(filename);
+  g_free(fname);
 }
 
 /*! \brief Write the grid settings to the gschem status bar

--- a/schematic/src/i_basic.c
+++ b/schematic/src/i_basic.c
@@ -513,32 +513,57 @@ void i_update_menus(GschemToplevel *w_current)
  *  Set the main window's title using \a filename.
  *  Prepend an asterisk ("*") to indicate that the page
  *  is modified if \a changed is TRUE.
+ *  Depending on [schematic.gui]::title-show-path configuration
+ *  value, either full path or basename of \a filename is shown
+ *  in the title.
  *
  *  \param [in] w_current GschemToplevel structure
  *  \param [in] filename  The filename
  *  \param [in] changed   Page changed status
  */
-void i_set_filename(GschemToplevel *w_current, const gchar *filename, gboolean changed)
+void i_set_filename (GschemToplevel* w_current,
+                     const gchar* filename,
+                     gboolean changed)
 {
-  gchar *print_string=NULL;
-  gchar *fname=NULL;
+  g_return_if_fail (w_current != NULL);
+  g_return_if_fail (w_current->main_window != NULL);
+  g_return_if_fail (filename);
 
-  if (!w_current->main_window)
-    return;
-  if (filename == NULL)
-    return;
+  gchar* cwd = g_get_current_dir();
+  EdaConfig* cfg = eda_config_get_context_for_path (cwd);
+  g_free (cwd);
 
-  fname = g_path_get_basename(filename);
+  gboolean show_fullpath = FALSE;
 
-  print_string = g_strdup_printf("%s%s - lepton-schematic",
-                                 changed ? "* " : "",
-                                 fname);
+  if (cfg != NULL)
+  {
+    GError*  err = NULL;
+    gboolean val = eda_config_get_boolean (cfg,
+                                           "schematic.gui",
+                                           "title-show-path",
+                                           &err);
+    if (err == NULL)
+    {
+      show_fullpath = val;
+    }
 
-  gtk_window_set_title(GTK_WINDOW(w_current->main_window),
-		       print_string);
+    g_clear_error (&err);
+  }
 
-  g_free(print_string);
-  g_free(fname);
+
+  gchar* fname = show_fullpath
+                 ? g_strdup (filename)
+                 : g_path_get_basename (filename);
+
+  gchar* title = g_strdup_printf ("%s%s - lepton-schematic",
+                                  changed ? "* " : "",
+                                  fname);
+
+  gtk_window_set_title (GTK_WINDOW (w_current->main_window),
+                        title);
+
+  g_free (title);
+  g_free (fname);
 }
 
 /*! \brief Write the grid settings to the gschem status bar

--- a/schematic/src/x_pagesel.c
+++ b/schematic/src/x_pagesel.c
@@ -99,7 +99,7 @@ void x_pagesel_update (GschemToplevel *w_current)
   }
 
   i_set_filename (w_current, s_page_get_filename (page),
-                  page->CHANGED ? "* " : "");
+                  page->CHANGED);
 
   if (x_tabs_enabled())
   {


### PR DESCRIPTION
Add  new boolean `title-show-path`configuration key (`schematic.gui` group).
If it's `true`, show full file path in the main window's title, otherwise show file name.
By default, just file name is shown.

