### PR TITLE
Deprecate 4 gschemrc options

### DIFF
--- a/liblepton/include/liblepton/defines.h
+++ b/liblepton/include/liblepton/defines.h
@@ -108,11 +108,6 @@
 #define UNDO_ALL		0
 #define UNDO_VIEWPORT_ONLY	1
 
-/* These are for where status information goes */
-#define LOG_WINDOW		0
-#define STDOUT_TTY		1
-#define BOTH_LOGWIN_STDOUT	2
-
 /* list copying flags */
 #define NORMAL_FLAG		0
 #define SELECTION_FLAG		1

--- a/liblepton/include/liblepton/globals.h
+++ b/liblepton/include/liblepton/globals.h
@@ -31,7 +31,6 @@ extern gboolean config_legacy_mode;
 extern int verbose_loading;
 
 extern int do_logging;
-extern int logging_dest;
 
 /* Size of a tab in characters */
 extern int tab_in_chars;

--- a/liblepton/scheme/geda-deprecated-config.scm
+++ b/liblepton/scheme/geda-deprecated-config.scm
@@ -1,6 +1,7 @@
-;; Lepton EDA
-;; lepton-schematic - Lepton EDA Schematic Capture - Scheme API
+;; Lepton EDA library - Scheme API
 ;; Copyright (C) 2012 Peter Brett <peter@peter-b.co.uk>
+;; Copyright (C) 2016 gEDA Contributors
+;; Copyright (C) 2017-2019 Lepton EDA Contributors
 ;;
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -112,14 +113,14 @@ option's value:
   (string=? "enabled" str))
 
 ;; ===================================================================
-;; Deprecated libgeda configuration functions
+;; Deprecated liblepton configuration functions
 ;; ===================================================================
 
 (define-rc-dead-config postscript-prolog)
 (define-rc-dead-config world-size)
 
 ;; ===================================================================
-;; Deprecated gschem configuration functions
+;; Deprecated lepton-schematic configuration functions
 ;; ===================================================================
 
 (define-rc-dead-config output-capstyle)
@@ -169,8 +170,10 @@ option's value:
  component-dialog-attributes "gschem.library" "component-attributes"
  (lambda (x) x))
 
+(define-rc-dead-config add-attribute-offset)
+
 ;; ===================================================================
-;; Deprecated gnetlist configuration functions
+;; Deprecated lepton-netlist configuration functions
 ;; ===================================================================
 (define-rc-dead-config gnetlist-version)
 

--- a/liblepton/scheme/geda-deprecated-config.scm
+++ b/liblepton/scheme/geda-deprecated-config.scm
@@ -171,6 +171,7 @@ option's value:
  (lambda (x) x))
 
 (define-rc-dead-config add-attribute-offset)
+(define-rc-dead-config logging-destination)
 
 ;; ===================================================================
 ;; Deprecated lepton-netlist configuration functions

--- a/liblepton/scheme/geda-deprecated-config.scm
+++ b/liblepton/scheme/geda-deprecated-config.scm
@@ -172,6 +172,7 @@ option's value:
 
 (define-rc-dead-config add-attribute-offset)
 (define-rc-dead-config logging-destination)
+(define-rc-dead-config log-window-type)
 
 ;; ===================================================================
 ;; Deprecated lepton-netlist configuration functions

--- a/liblepton/scheme/geda-deprecated-config.scm
+++ b/liblepton/scheme/geda-deprecated-config.scm
@@ -173,6 +173,7 @@ option's value:
 (define-rc-dead-config add-attribute-offset)
 (define-rc-dead-config logging-destination)
 (define-rc-dead-config log-window-type)
+(define-rc-dead-config raise-dialog-boxes-on-expose)
 
 ;; ===================================================================
 ;; Deprecated lepton-netlist configuration functions

--- a/schematic/include/globals.h
+++ b/schematic/include/globals.h
@@ -33,7 +33,6 @@ extern GdkColor black;
 extern SCM output_filename_s;
 
 extern int do_logging;
-extern int logging_dest;
 
 
 /* command line options */

--- a/schematic/include/gschem_defines.h
+++ b/schematic/include/gschem_defines.h
@@ -91,10 +91,6 @@ typedef enum
 #define MAP_LATER		0
 #define MAP_ON_STARTUP		1
 
-/* for log-window-type */
-#define DECORATED		0
-#define TRANSIENT		1
-
 /* mouse buttons actions */
 #define STROKE			0
 #define REPEAT			1

--- a/schematic/include/gschem_toplevel.h
+++ b/schematic/include/gschem_toplevel.h
@@ -200,7 +200,6 @@ struct st_gschem_toplevel {
   int include_complex;    /* controls if complex objects are included */
   int scrollbars_flag;    /* controls if scrollbars are displayed */
   int log_window;         /* controls if the log windows mapped on startup */
-  int log_window_type;    /* controls if the log window is decorated or not */
   int third_button;       /* controls what the third mouse button does */
   int third_button_cancel;/* controls if the third mouse button cancels actions */
   int middle_button;      /* controls what the third mouse button does */

--- a/schematic/include/gschem_toplevel.h
+++ b/schematic/include/gschem_toplevel.h
@@ -207,7 +207,6 @@ struct st_gschem_toplevel {
   int file_preview;       /* controls if the preview area is enabled or not */
   int enforce_hierarchy;  /* controls how much freedom user has when traversing the hierarchy */
   int fast_mousepan;      /* controls if text is completely drawn during mouse pan */
-  int raise_dialog_boxes; /*controls if expose events raise dialog boxes*/
 
   /* controls if after doing a place the same component can be placed again */
   int continue_component_place;

--- a/schematic/include/gschem_toplevel.h
+++ b/schematic/include/gschem_toplevel.h
@@ -236,10 +236,6 @@ struct st_gschem_toplevel {
   /* Minimum grid line pitch to display. Applies to major and minor lines. */
   int mesh_grid_display_threshold;
 
-  /* sets the offset (in world coordinates) that are added to netname */
-  /* attributes when they are attached to vertical or horizontal nets */
-  int add_attribute_offset;
-
   int mousepan_gain;      /* Controls the gain of the mouse pan */
   int keyboardpan_gain;   /* Controls the gain of the keyboard pan */
   int select_slack_pixels; /* Number of pixels around an object we can still select it with */

--- a/schematic/include/i_vars.h
+++ b/schematic/include/i_vars.h
@@ -29,7 +29,6 @@ extern int default_net_consolidate;
 extern int default_file_preview;
 extern int default_enforce_hierarchy;
 extern int default_fast_mousepan;
-extern int default_raise_dialog_boxes;
 extern int default_continue_component_place;
 extern int default_undo_levels;
 extern int default_undo_control;

--- a/schematic/include/i_vars.h
+++ b/schematic/include/i_vars.h
@@ -54,7 +54,6 @@ extern int default_dots_grid_dot_size;
 extern int default_dots_grid_mode;
 extern int default_dots_grid_fixed_threshold;
 extern int default_mesh_grid_display_threshold;
-extern int default_add_attribute_offset;
 extern int default_auto_save_interval;
 extern int default_mousepan_gain;
 extern int default_keyboardpan_gain;

--- a/schematic/include/i_vars.h
+++ b/schematic/include/i_vars.h
@@ -21,7 +21,6 @@ extern int default_image_height;
 extern int default_width;
 extern int default_height;
 extern int default_log_window;
-extern int default_log_window_type;
 extern int default_third_button;
 extern int default_third_button_cancel;
 extern int default_middle_button;

--- a/schematic/include/i_vars.h
+++ b/schematic/include/i_vars.h
@@ -7,7 +7,6 @@ extern int default_net_selection_mode;
 extern int default_zoom_with_pan;
 extern int default_actionfeedback_mode;
 extern int default_do_logging;
-extern int default_logging_dest;
 extern int default_embed_complex;
 extern int default_include_complex;
 extern int default_snap_size;

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -166,7 +166,6 @@ SCM g_rc_embed_components(SCM mode);
 SCM g_rc_text_size(SCM size);
 SCM g_rc_text_caps_style(SCM mode);
 SCM g_rc_snap_size(SCM size);
-SCM g_rc_logging_destination(SCM mode);
 SCM g_rc_attribute_name(SCM path);
 SCM g_rc_scrollbars(SCM mode);
 SCM g_rc_image_color(SCM mode);

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -171,7 +171,6 @@ SCM g_rc_scrollbars(SCM mode);
 SCM g_rc_image_color(SCM mode);
 SCM g_rc_image_size(SCM width, SCM height);
 SCM g_rc_log_window(SCM mode);
-SCM g_rc_log_window_type(SCM mode);
 SCM g_rc_third_button(SCM mode);
 SCM g_rc_third_button_cancel(SCM mode);
 SCM g_rc_middle_button(SCM mode);

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -204,7 +204,6 @@ SCM g_rc_dots_grid_dot_size(SCM dotsize);
 SCM g_rc_dots_grid_mode(SCM mode);
 SCM g_rc_dots_grid_fixed_threshold(SCM spacing);
 SCM g_rc_mesh_grid_display_threshold(SCM spacing);
-SCM g_rc_add_attribute_offset(SCM offset);
 SCM g_rc_auto_save_interval(SCM seconds);
 SCM g_rc_mousepan_gain(SCM mode);
 SCM g_rc_keyboardpan_gain(SCM mode);

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -179,7 +179,6 @@ SCM g_rc_net_consolidate(SCM mode);
 SCM g_rc_file_preview(SCM mode);
 SCM g_rc_enforce_hierarchy(SCM mode);
 SCM g_rc_fast_mousepan(SCM mode);
-SCM g_rc_raise_dialog_boxes_on_expose(SCM mode);
 SCM g_rc_continue_component_place(SCM mode);
 SCM g_rc_undo_levels(SCM levels);
 SCM g_rc_undo_control(SCM mode);
@@ -634,7 +633,6 @@ void coord_display_update(GschemToplevel *w_current, int x, int y);
 void coord_dialog(GschemToplevel *w_current, int x, int y);
 char *index2functionstring(int index);
 void x_dialog_hotkeys(GschemToplevel *w_current);
-void x_dialog_raise_all(GschemToplevel *w_current);
 
 void generic_msg_dialog(const char *);
 int generic_confirm_dialog(const char *);
@@ -649,7 +647,6 @@ gboolean x_dialog_close_window (GschemToplevel *w_current);
 int x_dialog_validate_attribute(GtkWindow* parent, char *attribute);
 /* x_event.c */
 gint x_event_expose(GschemPageView *widget, GdkEventExpose *event, GschemToplevel *w_current);
-gint x_event_raise_dialog_boxes (GschemPageView *view, GdkEventExpose *event, GschemToplevel *w_current);
 gint x_event_button_pressed(GschemPageView *page_view, GdkEventButton *event, GschemToplevel *w_current);
 gint x_event_button_released(GschemPageView *page_view, GdkEventButton *event, GschemToplevel *w_current);
 gint x_event_motion(GschemPageView *page_view, GdkEventMotion *event, GschemToplevel *w_current);

--- a/schematic/scheme/conf/schematic/options.scm
+++ b/schematic/scheme/conf/schematic/options.scm
@@ -209,14 +209,6 @@
 (scrollbars "enabled")
 ;(scrollbars "disabled")
 
-; raise-dialog-boxes-on-expose string
-;
-; Controls if dialog boxes are raised whenever an expose event happens
-; Default is disabled since gtk2 supposedly handles the raising of these
-; dialogs correctly now.
-;
-;(raise-dialog-boxes-on-expose "enabled")
-(raise-dialog-boxes-on-expose "disabled")
 
 ; embed-components string
 ;

--- a/schematic/scheme/conf/schematic/options.scm
+++ b/schematic/scheme/conf/schematic/options.scm
@@ -490,26 +490,6 @@
 ;(force-boundingbox "enabled")
 
 
-; add-attribute-offset integer
-;
-; This has not been implemented/debugged yet.
-; This has not been implemented/debugged yet.
-; This has not been implemented/debugged yet.
-;
-; Controls a offset which is added to the location of text items that are
-; added to an object as an attribute.  This offset is added when the following
-; conditions occur:
-;
-;  1) Add/Attribute... has been invoked via the hotkey
-;  2) It is the "netname" attribute being added
-;  3) It is being attached to a horizontal or vertical net segment
-;  4) The initial mouse position is at or near the actual net (with one
-;     grid unit).
-;
-; If these four conditions are not met, then this offset is not added.
-;(add-attribute-offset 50)
-
-
 ; reset-component-library
 ;
 ; When reset-component-library is executed, then all known component library

--- a/schematic/scheme/conf/schematic/options.scm
+++ b/schematic/scheme/conf/schematic/options.scm
@@ -235,8 +235,6 @@
 ; Determines if the logging mechanism is enabled or disabled
 ;   Possible options: enabled or disabled
 ; Default is enabled.
-; See below for the logging-destination keyword for control over
-; where the messages go.
 ;
 (logging "enabled")
 ;(logging "disabled")
@@ -268,22 +266,6 @@
 (log-window-type "decorated")
 ;(log-window-type "transient")
 
-
-; logging-destination string
-;
-; Specifies where log message go during run time.
-; Possible options are:
-;      log_window      The log window (if it's visible)
-;      tty             The stdout of the terminal where gschem was run from
-;      both            Both of the above locations
-; Message are always written to the log file (unless logging is disabled)
-; by the above keyword
-;
-; Default is log_window
-;
-(logging-destination "log_window")
-;(logging-destination "tty")
-;(logging-destination "both")
 
 ; text-size number
 ;

--- a/schematic/scheme/conf/schematic/options.scm
+++ b/schematic/scheme/conf/schematic/options.scm
@@ -252,21 +252,6 @@
 (log-window "later")
 
 
-; log-window-type string
-;
-; Controls if the log message window is a transient or if it is decorated
-; as a normal window (this is dependant on the window manager doing decoration
-; right)
-;
-; Possible options:
-;       decorated       - log window is a normal decorated window
-;       transient       - log window is a transient dialog box, typically
-;                         not decorated by the window manager
-;
-(log-window-type "decorated")
-;(log-window-type "transient")
-
-
 ; text-size number
 ;
 ; Sets the default text size.

--- a/schematic/src/g_rc.c
+++ b/schematic/src/g_rc.c
@@ -1010,31 +1010,6 @@ SCM g_rc_mesh_grid_display_threshold (SCM spacing)
  *  \par Function Description
  *
  */
-SCM g_rc_add_attribute_offset(SCM offset)
-{
-  int val;
-
-  SCM_ASSERT (scm_is_integer (offset), offset,
-              SCM_ARG1, "add-attribute-offset");
-
-  val = scm_to_int (offset);
-
-  if (val < 0) {
-    fprintf(stderr, _("Invalid offset [%1$d] passed to add-attribute-offset\n"),
-            val);
-    val = 50; /* absolute default */
-  }
-
-  default_add_attribute_offset = val;
-
-  return SCM_BOOL_T;
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
 SCM g_rc_auto_save_interval(SCM seconds)
 {
   int val;

--- a/schematic/src/g_rc.c
+++ b/schematic/src/g_rc.c
@@ -295,24 +295,6 @@ SCM g_rc_snap_size(SCM size)
  *  \par Function Description
  *
  */
-SCM g_rc_logging_destination(SCM mode)
-{
-  static const vstbl_entry mode_table[] = {
-    {LOG_WINDOW         , "log_window" },
-    {STDOUT_TTY         , "tty"        },
-    {BOTH_LOGWIN_STDOUT , "both"       }
-  };
-
-  RETURN_G_RC_MODE("logging-destination",
-		   logging_dest,
-		   3);
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
 SCM g_rc_attribute_name(SCM scm_path)
 {
   char *path;

--- a/schematic/src/g_rc.c
+++ b/schematic/src/g_rc.c
@@ -390,23 +390,6 @@ SCM g_rc_log_window(SCM mode)
  *  \par Function Description
  *
  */
-SCM g_rc_log_window_type(SCM mode)
-{
-  static const vstbl_entry mode_table[] = {
-    {TRANSIENT, "transient" },
-    {DECORATED, "decorated" },
-  };
-
-  RETURN_G_RC_MODE("log-window-type",
-		   default_log_window_type,
-		   2);
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
 SCM g_rc_third_button(SCM mode)
 {
   static const vstbl_entry mode_table[] = {

--- a/schematic/src/g_rc.c
+++ b/schematic/src/g_rc.c
@@ -539,23 +539,6 @@ SCM g_rc_fast_mousepan(SCM mode)
  *  \par Function Description
  *
  */
-SCM g_rc_raise_dialog_boxes_on_expose(SCM mode)
-{
-  static const vstbl_entry mode_table[] = {
-    {TRUE , "enabled" },
-    {FALSE, "disabled"},
-  };
-
-  RETURN_G_RC_MODE("raise-dialog-boxes-on-expose",
-		   default_raise_dialog_boxes,
-		   2);
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
 SCM g_rc_continue_component_place(SCM mode)
 {
   static const vstbl_entry mode_table[] = {

--- a/schematic/src/g_register.c
+++ b/schematic/src/g_register.c
@@ -101,7 +101,6 @@ static struct gsubr_t gschem_funcs[] = {
   { "dots-grid-mode",               1, 0, 0, (SCM (*) ()) g_rc_dots_grid_mode },
   { "dots-grid-fixed-threshold",    1, 0, 0, (SCM (*) ()) g_rc_dots_grid_fixed_threshold },
   { "mesh-grid-display-threshold",  1, 0, 0, (SCM (*) ()) g_rc_mesh_grid_display_threshold },
-  { "add-attribute-offset",         1, 0, 0, (SCM (*) ()) g_rc_add_attribute_offset },
   { "mousepan-gain",                1, 0, 0, (SCM (*) ()) g_rc_mousepan_gain },
   { "keyboardpan-gain",             1, 0, 0, (SCM (*) ()) g_rc_keyboardpan_gain },
   { "select-slack-pixels",          1, 0, 0, (SCM (*) ()) g_rc_select_slack_pixels },

--- a/schematic/src/g_register.c
+++ b/schematic/src/g_register.c
@@ -61,7 +61,6 @@ static struct gsubr_t gschem_funcs[] = {
   { "snap-size",                    1, 0, 0, (SCM (*) ()) g_rc_snap_size },
 
   { "text-caps-style",              1, 0, 0, (SCM (*) ()) g_rc_text_caps_style },
-  { "logging-destination",          1, 0, 0, (SCM (*) ()) g_rc_logging_destination },
 
   { "attribute-name",               1, 0, 0, (SCM (*) ()) g_rc_attribute_name },
 

--- a/schematic/src/g_register.c
+++ b/schematic/src/g_register.c
@@ -67,7 +67,6 @@ static struct gsubr_t gschem_funcs[] = {
   { "image-color",                  1, 0, 0, (SCM (*) ()) g_rc_image_color },
   { "image-size",                   2, 0, 0, (SCM (*) ()) g_rc_image_size },
   { "log-window",                   1, 0, 0, (SCM (*) ()) g_rc_log_window },
-  { "log-window-type",              1, 0, 0, (SCM (*) ()) g_rc_log_window_type },
   { "third-button",                 1, 0, 0, (SCM (*) ()) g_rc_third_button },
   { "third-button-cancel",          1, 0, 0, (SCM (*) ()) g_rc_third_button_cancel },
   { "middle-button",                1, 0, 0, (SCM (*) ()) g_rc_middle_button },

--- a/schematic/src/g_register.c
+++ b/schematic/src/g_register.c
@@ -75,7 +75,6 @@ static struct gsubr_t gschem_funcs[] = {
   { "file-preview",                 1, 0, 0, (SCM (*) ()) g_rc_file_preview },
   { "enforce-hierarchy",            1, 0, 0, (SCM (*) ()) g_rc_enforce_hierarchy },
   { "fast-mousepan",                1, 0, 0, (SCM (*) ()) g_rc_fast_mousepan },
-  { "raise-dialog-boxes-on-expose", 1, 0, 0, (SCM (*) ()) g_rc_raise_dialog_boxes_on_expose },
   { "continue-component-place",     1, 0, 0, (SCM (*) ()) g_rc_continue_component_place },
   { "undo-levels",                  1, 0, 0, (SCM (*) ()) g_rc_undo_levels },
   { "undo-control",                 1, 0, 0, (SCM (*) ()) g_rc_undo_control },

--- a/schematic/src/globals.c
+++ b/schematic/src/globals.c
@@ -31,8 +31,6 @@ GList *global_window_list = NULL;
 GdkColor white;
 GdkColor black;
 
-int logging_dest = LOG_WINDOW;
-
 /* command line options */
 int quiet_mode = FALSE;
 int verbose_mode = FALSE;

--- a/schematic/src/gschem_toplevel.c
+++ b/schematic/src/gschem_toplevel.c
@@ -349,7 +349,6 @@ GschemToplevel *gschem_toplevel_new ()
   w_current->dots_grid_dot_size = 1;
   w_current->dots_grid_mode = DOTS_GRID_VARIABLE_MODE;
   w_current->mesh_grid_display_threshold = 3;
-  w_current->add_attribute_offset = 50;
   w_current->mousepan_gain = 5;
   w_current->keyboardpan_gain = 10;
   w_current->select_slack_pixels = 4;

--- a/schematic/src/gschem_toplevel.c
+++ b/schematic/src/gschem_toplevel.c
@@ -324,7 +324,6 @@ GschemToplevel *gschem_toplevel_new ()
   w_current->include_complex = 0;
   w_current->scrollbars_flag = 0;
   w_current->log_window = 0;
-  w_current->log_window_type = 0;
   w_current->third_button = 0;
   w_current->third_button_cancel = TRUE;
   w_current->middle_button = 0;

--- a/schematic/src/gschem_toplevel.c
+++ b/schematic/src/gschem_toplevel.c
@@ -330,7 +330,6 @@ GschemToplevel *gschem_toplevel_new ()
   w_current->file_preview = 0;
   w_current->enforce_hierarchy = 0;
   w_current->fast_mousepan = 0;
-  w_current->raise_dialog_boxes = 0;
   w_current->continue_component_place = 0;
   w_current->undo_levels = 0;
   w_current->undo_control = 0;

--- a/schematic/src/i_vars.c
+++ b/schematic/src/i_vars.c
@@ -77,7 +77,6 @@ int   default_dots_grid_dot_size = 1;
 int   default_dots_grid_mode = DOTS_GRID_VARIABLE_MODE;
 int   default_dots_grid_fixed_threshold = 10;
 int   default_mesh_grid_display_threshold = 3;
-int   default_add_attribute_offset = 50;
 
 int   default_auto_save_interval = 120;
 
@@ -159,8 +158,6 @@ void i_vars_set(GschemToplevel *w_current)
   w_current->dots_grid_mode              = default_dots_grid_mode;
   w_current->dots_grid_fixed_threshold   = default_dots_grid_fixed_threshold;
   w_current->mesh_grid_display_threshold = default_mesh_grid_display_threshold;
-
-  w_current->add_attribute_offset  = default_add_attribute_offset;
 
   w_current->mousepan_gain = default_mousepan_gain;
   w_current->keyboardpan_gain = default_keyboardpan_gain;

--- a/schematic/src/i_vars.c
+++ b/schematic/src/i_vars.c
@@ -40,7 +40,6 @@ int   default_image_color = FALSE;
 int   default_image_width = 800;
 int   default_image_height = 600;
 int   default_log_window = MAP_ON_STARTUP;
-int   default_log_window_type = DECORATED;
 int   default_third_button = POPUP_ENABLED;
 int   default_third_button_cancel = TRUE;
 #ifdef HAVE_LIBSTROKE
@@ -117,7 +116,6 @@ void i_vars_set(GschemToplevel *w_current)
   w_current->include_complex = default_include_complex;
   gschem_options_set_snap_size (w_current->options, default_snap_size);
   w_current->log_window      = default_log_window;
-  w_current->log_window_type = default_log_window_type;
 
   toplevel->image_color        = default_image_color;
   w_current->image_width        = default_image_width;

--- a/schematic/src/i_vars.c
+++ b/schematic/src/i_vars.c
@@ -52,7 +52,6 @@ int   default_net_consolidate = TRUE;
 int   default_file_preview = FALSE;
 int   default_enforce_hierarchy = TRUE;
 int   default_fast_mousepan = TRUE;
-int   default_raise_dialog_boxes = FALSE;
 int   default_continue_component_place = TRUE;
 int   default_undo_levels = 20;
 int   default_undo_control = TRUE;
@@ -128,7 +127,6 @@ void i_vars_set(GschemToplevel *w_current)
   w_current->file_preview       = default_file_preview;
   w_current->enforce_hierarchy  = default_enforce_hierarchy;
   w_current->fast_mousepan      = default_fast_mousepan;
-  w_current->raise_dialog_boxes = default_raise_dialog_boxes;
   w_current->continue_component_place = default_continue_component_place;
   w_current->undo_levels = default_undo_levels;
   w_current->undo_control = default_undo_control;

--- a/schematic/src/i_vars.c
+++ b/schematic/src/i_vars.c
@@ -31,7 +31,6 @@ int   default_net_selection_mode = 0;
 int   default_actionfeedback_mode = OUTLINE;
 int   default_zoom_with_pan = TRUE;
 int   default_do_logging = TRUE;
-int   default_logging_dest = LOG_WINDOW;
 int   default_embed_complex = FALSE;
 int   default_include_complex = FALSE;
 int   default_snap_size = DEFAULT_SNAP_SIZE;
@@ -103,8 +102,6 @@ void i_vars_set(GschemToplevel *w_current)
   if (do_logging != FALSE) {
     do_logging = default_do_logging;
   }
-
-  logging_dest = default_logging_dest;
 
   w_current->text_size     = default_text_size;
   w_current->text_caps     = default_text_caps;

--- a/schematic/src/x_dialog.c
+++ b/schematic/src/x_dialog.c
@@ -31,46 +31,6 @@
 #include "gschem.h"
 
 
-/*********** Start of misc support functions for dialog boxes *******/
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
-void x_dialog_raise_all(GschemToplevel *w_current)
-{
-  if(w_current->sowindow) {
-    gdk_window_raise(w_current->sowindow->window);
-  }
-  if(w_current->cswindow) {
-    gdk_window_raise(w_current->cswindow->window);
-  }
-  if(w_current->tiwindow) {
-    gdk_window_raise(w_current->tiwindow->window);
-  }
-  if(w_current->sewindow) {
-    gdk_window_raise(w_current->sewindow->window);
-  }
-  if(w_current->aawindow) {
-    gdk_window_raise(w_current->aawindow->window);
-  }
-  if(w_current->mawindow) {
-    gdk_window_raise(w_current->mawindow->window);
-  }
-  if(w_current->aewindow) {
-    gdk_window_raise(w_current->aewindow->window);
-  }
-  if(w_current->hkwindow) {
-    gdk_window_raise(w_current->hkwindow->window);
-  }
-  if(w_current->cowindow) {
-    gdk_window_raise(w_current->cowindow->window);
-  }
-}
-
-/*********** End of misc support functions for dialog boxes *******/
-
 /***************** Start of generic message dialog box *******************/
 
 /*! \todo Finish function documentation!!!

--- a/schematic/src/x_event.c
+++ b/schematic/src/x_event.c
@@ -58,27 +58,6 @@ x_event_expose(GschemPageView *view, GdkEventExpose *event, GschemToplevel *w_cu
  *
  */
 gint
-x_event_raise_dialog_boxes (GschemPageView *view, GdkEventExpose *event, GschemToplevel *w_current)
-{
-  g_return_val_if_fail (w_current != NULL, 0);
-
-  /* raise the dialog boxes if this feature is enabled */
-  if (w_current->raise_dialog_boxes) {
-    x_dialog_raise_all(w_current);
-  }
-
-  return 0;
-}
-
-
-
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
-gint
 x_event_button_pressed(GschemPageView *page_view, GdkEventButton *event, GschemToplevel *w_current)
 {
   PAGE *page = gschem_page_view_get_page (page_view);

--- a/schematic/src/x_window.c
+++ b/schematic/src/x_window.c
@@ -219,7 +219,6 @@ void x_window_setup_draw_events_drawing_area (GschemToplevel* w_current,
   struct event_reg_t drawing_area_events[] =
   {
     { "expose_event",         G_CALLBACK(x_event_expose)                       },
-    { "expose_event",         G_CALLBACK(x_event_raise_dialog_boxes)           },
     { "button_press_event",   G_CALLBACK(x_event_button_pressed)               },
     { "button_release_event", G_CALLBACK(x_event_button_released)              },
     { "motion_notify_event",  G_CALLBACK(x_event_motion)                       },


### PR DESCRIPTION
Define the following `gschemrc` options using `define-rc-dead-config()`
in `liblepton/scheme/geda-deprecated-config.scm` (deprecation warnings
will be printed to `stderr` on attempt to use them), remove associated code from
`lepton-schematic` and `liblepton`:

- `add-attribute-offset`
- `logging-destination`
- `log-window-type`
- `raise-dialog-boxes-on-exp`

Closes #415 