### PR TITLE
Fix compiler warnings in liblepton when building with --disable-deprecated

### DIFF
--- a/liblepton/src/edapaths.c
+++ b/liblepton/src/edapaths.c
@@ -36,8 +36,11 @@
 static const gchar* const DATA_ENV        = "GEDADATA";
 static const gchar* const CONFIG_ENV      = "GEDADATARC";
 static const gchar* const DATA_XDG_SUBDIR = "lepton-eda";
+
+#if defined(ENABLE_DEPRECATED)
 static const gchar* const DATA_GUESS_FILE = "scheme/geda.scm";
 static const gchar* const USER_DOTDIR     = ".gEDA";
+#endif
 
 /* ================================================================
  * Private initialisation functions


### PR DESCRIPTION
Fix compiler warnings when building with `--disable-deprecated`:
`DATA_GUESS_FILE` ("scheme/geda.scm") and
`USER_DOTDIR` (".gEDA") are used only when
`ENABLE_DEPRECATED` is defined, hence
"defined but not used" warnings.
