### PR TITLE
Adjust default values in lepton-schematic code

### DIFF
--- a/liblepton/src/i_vars.c
+++ b/liblepton/src/i_vars.c
@@ -1,7 +1,8 @@
-/* gEDA - GPL Electronic Design Automation
- * libgeda - gEDA's library
+/* Lepton EDA
+ * liblepton - Lepton's library
  * Copyright (C) 1998-2010 Ales Hvezda
- * Copyright (C) 1998-2017 gEDA Contributors (see ChangeLog for details)
+ * Copyright (C) 1998-2017 gEDA Contributors
+ * Copyright (C) 2017-2019 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -22,19 +23,16 @@
 
 #include "libgeda_priv.h"
 
-/*! \def INIT_STR(w, name, str) */
-#define INIT_STR(w, name, str) {                                        \
-        g_free((w)->name);                                              \
-        (w)->name = g_strdup(((default_ ## name) != NULL) ?             \
-                             (default_ ## name) : (str));               \
-}
 
-/* \note 
+
+/* \note
  * Kazu Hirata <kazu@seul.org> on July 16, 1999 - Added these absolute
  * defaults used when default_... is NULL.
  */
 #define DEFAULT_BITMAP_DIRECTORY "../lib/bitmaps"
 #define DEFAULT_BUS_RIPPER_SYMNAME "busripper-1.sym"
+
+
 
 char *default_bitmap_directory = NULL;
 char *default_bus_ripper_symname = NULL;
@@ -46,11 +44,13 @@ int   default_keep_invisible = TRUE;
 
 int   default_make_backup_files = TRUE;
 
+
+
 /*! \brief Initialize variables in TOPLEVEL object
  *  \par Function Description
  *  This function will initialize variables to default values.
  *
- *  \param [out] toplevel  The TOPLEVEL object to be updated.
+ *  \param [in] toplevel  The TOPLEVEL object to be updated.
  *
  */
 void i_vars_libgeda_set(TOPLEVEL *toplevel)
@@ -74,9 +74,17 @@ void i_vars_libgeda_set(TOPLEVEL *toplevel)
 
   /* you cannot free the default* strings here since new windows */
   /* need them */
-  INIT_STR(toplevel, bitmap_directory, DEFAULT_BITMAP_DIRECTORY);
-  INIT_STR(toplevel, bus_ripper_symname, DEFAULT_BUS_RIPPER_SYMNAME);
+  g_free (toplevel->bitmap_directory);
+  toplevel->bitmap_directory = g_strdup (default_bitmap_directory ?
+                                         default_bitmap_directory :
+                                         DEFAULT_BITMAP_DIRECTORY);
+
+  g_free (toplevel->bus_ripper_symname);
+  toplevel->bus_ripper_symname = g_strdup (default_bus_ripper_symname ?
+                                           default_bus_ripper_symname :
+                                           DEFAULT_BUS_RIPPER_SYMNAME);
 }
+
 
 
 /*! \brief Free default names

--- a/schematic/include/gschem_options.h
+++ b/schematic/include/gschem_options.h
@@ -39,7 +39,7 @@
  *
  *  Loading a configuration will overwrite this value
  */
-#define DEFAULT_NET_RUBBER_BAND_MODE (FALSE)
+#define DEFAULT_NET_RUBBER_BAND_MODE (TRUE)
 
 
 /*! \brief The initial grid mode

--- a/schematic/src/i_vars.c
+++ b/schematic/src/i_vars.c
@@ -25,7 +25,7 @@
 /* Absolute default used when default_... strings are NULL */
 
 int   default_text_size = DEFAULT_TEXT_SIZE;
-int   default_text_caps = LOWER;
+int   default_text_caps = BOTH;
 int   default_net_direction_mode = TRUE;
 int   default_net_selection_mode = 0;
 int   default_actionfeedback_mode = OUTLINE;
@@ -36,22 +36,18 @@ int   default_include_complex = FALSE;
 int   default_snap_size = DEFAULT_SNAP_SIZE;
 
 int   default_scrollbars_flag = TRUE;
-int   default_image_color = FALSE;
+int   default_image_color = TRUE;
 int   default_image_width = 800;
 int   default_image_height = 600;
 int   default_log_window = MAP_ON_STARTUP;
 int   default_third_button = POPUP_ENABLED;
 int   default_third_button_cancel = TRUE;
-#ifdef HAVE_LIBSTROKE
-int   default_middle_button = STROKE;
-#else
-int   default_middle_button = REPEAT;
-#endif
+int   default_middle_button = MOUSEPAN_ENABLED;
 int   default_scroll_wheel = SCROLL_WHEEL_CLASSIC;
 int   default_net_consolidate = TRUE;
-int   default_file_preview = FALSE;
+int   default_file_preview = TRUE;
 int   default_enforce_hierarchy = TRUE;
-int   default_fast_mousepan = TRUE;
+int   default_fast_mousepan = FALSE;
 int   default_continue_component_place = TRUE;
 int   default_undo_levels = 20;
 int   default_undo_control = TRUE;
@@ -60,7 +56,7 @@ int   default_undo_panzoom = FALSE;
 int   default_draw_grips = TRUE;
 int   default_netconn_rubberband = DEFAULT_NET_RUBBER_BAND_MODE;
 int   default_magnetic_net_mode = DEFAULT_MAGNETIC_NET_MODE;
-int   default_warp_cursor = TRUE;
+int   default_warp_cursor = FALSE;
 int   default_toolbars = TRUE;
 int   default_handleboxes = TRUE;
 int   default_setpagedevice_orientation = FALSE;
@@ -80,9 +76,9 @@ int   default_auto_save_interval = 120;
 int   default_width = 800;  /* these variables are used in x_window.c */
 int   default_height = 600;
 
-int default_mousepan_gain = 5;
+int default_mousepan_gain = 1;
 int default_keyboardpan_gain = 20;
-int default_select_slack_pixels = 4;
+int default_select_slack_pixels = 10;
 int default_zoom_gain = 20;
 int default_scrollpan_steps = 8;
 


### PR DESCRIPTION
Set default values for global variables and preprocessor defines
to be the same as options set in `conf/schematic/options.scm`.