### PR TITLE
Save and restore window's geometry; deprecate window-size option

### DIFF
--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -7,6 +7,7 @@ use-docks=true
 use-tabs=true
 max-recent-files=10
 title-show-path=false
+restore-window-geometry=true
 text-sizes=
 font=
 

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -7,6 +7,7 @@ use-docks=true
 use-tabs=true
 max-recent-files=10
 title-show-path=false
+restore-window-geometry=true
 text-sizes=
 font=
 

--- a/liblepton/scheme/geda-deprecated-config.scm
+++ b/liblepton/scheme/geda-deprecated-config.scm
@@ -176,6 +176,7 @@ option's value:
 (define-rc-dead-config raise-dialog-boxes-on-expose)
 (define-rc-dead-config image-size)
 (define-rc-dead-config image-color)
+(define-rc-dead-config window-size)
 
 ;; ===================================================================
 ;; Deprecated lepton-netlist configuration functions

--- a/schematic/docs/lepton-schematic.1.in
+++ b/schematic/docs/lepton-schematic.1.in
@@ -39,10 +39,6 @@ Specify a Scheme script to be executed at startup.
 \fB-c\fR \fIEXPR\fR
 Specify a Scheme expression to be evaluated at startup.
 .TP 8
-\fB-p\fR
-Automatically place the window. This may be useful if running \fBlepton-schematic\fR
-from the command line and generating output.
-.TP 8
 \fB-h\fR, \fB--help\fR
 Print a help message.
 .TP 8

--- a/schematic/include/globals.h
+++ b/schematic/include/globals.h
@@ -1,7 +1,7 @@
-/* -*- geda-c -*-
- * Lepton EDA Schematic Capture
+/* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
- * Copyright (C) 1998-2011 gEDA Contributors (see ChangeLog for details)
+ * Copyright (C) 1998-2014 gEDA Contributors
+ * Copyright (C) 2017-2019 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -35,7 +35,6 @@ extern int do_logging;
 /* command line options */
 extern int quiet_mode;
 extern int verbose_mode;
-extern int auto_place_mode;
 
 /* Global buffers */
 #define MAX_BUFFERS      (5)

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -183,7 +183,6 @@ SCM g_rc_draw_grips(SCM mode);
 SCM g_rc_netconn_rubberband(SCM mode);
 SCM g_rc_magnetic_net_mode(SCM mode);
 SCM g_rc_add_menu(SCM menu_name, SCM menu_items);
-SCM g_rc_window_size(SCM width, SCM height);
 SCM g_rc_warp_cursor(SCM mode);
 SCM g_rc_toolbars(SCM mode);
 SCM g_rc_handleboxes(SCM mode);

--- a/schematic/scheme/conf/schematic/options.scm
+++ b/schematic/scheme/conf/schematic/options.scm
@@ -293,18 +293,6 @@
 (enforce-hierarchy "enabled")
 ;(enforce-hierarchy "disabled")
 
-; window-size width height
-;
-; Specifies the size of the drawing area window.  The width and height
-; are specified in pixels and do not include the three menu bars and
-; scrollbars (so the window will be larger than the specified
-; measurements). Try to keep an aspect ratio of 1.333333 if at all possible.
-; These numbers are NOT the true size of the window, but of the drawing area.
-;
-;(window-size 650 487)  ; Good size for 800x600
-(window-size 900 650)   ; Good size for 1024x768
-;(window-size 950 712)  ; Good size for 1152x864
-;(window-size 1100 825) ; Good size for 1280x1024
 
 
 ; middle-button string

--- a/schematic/src/g_rc.c
+++ b/schematic/src/g_rc.c
@@ -692,22 +692,6 @@ SCM g_rc_add_menu(SCM scm_menu_name, SCM scm_menu_items)
  *  \par Function Description
  *
  */
-SCM g_rc_window_size(SCM width, SCM height)
-{
-  SCM_ASSERT (scm_is_integer (width),  width,  SCM_ARG1, "window-size");
-  SCM_ASSERT (scm_is_integer (height), height, SCM_ARG2, "window-size");
-
-  default_width  = scm_to_int (width);
-  default_height = scm_to_int (height);
-
-  return SCM_BOOL_T;
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
 SCM g_rc_warp_cursor(SCM mode)
 {
   static const vstbl_entry mode_table[] = {

--- a/schematic/src/g_register.c
+++ b/schematic/src/g_register.c
@@ -83,7 +83,6 @@ static struct gsubr_t gschem_funcs[] = {
   { "netconn-rubberband",           1, 0, 0, (SCM (*) ()) g_rc_netconn_rubberband },
   { "magnetic-net-mode",            1, 0, 0, (SCM (*) ()) g_rc_magnetic_net_mode },
   { "add-menu",                     2, 0, 0, (SCM (*) ()) g_rc_add_menu },
-  { "window-size",                  2, 0, 0, (SCM (*) ()) g_rc_window_size },
   { "warp-cursor",                  1, 0, 0, (SCM (*) ()) g_rc_warp_cursor },
   { "toolbars",                     1, 0, 0, (SCM (*) ()) g_rc_toolbars },
   { "handleboxes",                  1, 0, 0, (SCM (*) ()) g_rc_handleboxes },

--- a/schematic/src/globals.c
+++ b/schematic/src/globals.c
@@ -1,6 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
- * Copyright (C) 1998-2011 gEDA Contributors (see ChangeLog for details)
+ * Copyright (C) 1998-2014 gEDA Contributors
+ * Copyright (C) 2017-2019 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,9 +17,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
-/*! \todo Add global variable documentation!!!
- *
- */
+
 #include <config.h>
 #include <stdio.h>
 
@@ -34,7 +33,6 @@ GdkColor black;
 /* command line options */
 int quiet_mode = FALSE;
 int verbose_mode = FALSE;
-int auto_place_mode = FALSE;
 
 /* Hooks */
 SCM complex_place_list_changed_hook;

--- a/schematic/src/parsecmd.c
+++ b/schematic/src/parsecmd.c
@@ -28,7 +28,7 @@
 
 #include "gschem.h"
 
-#define GETOPT_OPTIONS "c:hL:pqs:vV"
+#define GETOPT_OPTIONS "c:hL:qs:vV"
 
 extern char *optarg;
 extern int optind;
@@ -82,7 +82,6 @@ usage(char *cmd)
 "  -L DIR                   Add DIR to Scheme search path.\n"
 "  -c EXPR                  Scheme expression to run at startup.\n"
 "  -s FILE                  Scheme script to run at startup.\n"
-"  -p                       Automatically place the window.\n"
 "  -V, --version            Show version information.\n"
 "  -h, --help               Help; this message.\n"
 "  --                       Treat all remaining arguments as filenames.\n"
@@ -166,10 +165,6 @@ parse_commandline(int argc, char *argv[])
           scm_cons (scm_list_2 (sym_eval_string,
                                 scm_from_locale_string (optarg)),
                     s_post_load_expr);
-        break;
-
-      case 'p':
-        auto_place_mode = TRUE;
         break;
 
       case 'L':

--- a/schematic/src/x_tabs.c
+++ b/schematic/src/x_tabs.c
@@ -728,9 +728,6 @@ x_tabs_pview_create (GschemToplevel* w_current,
   gtk_container_add (GTK_CONTAINER (wtab), GTK_WIDGET (pview));
   gtk_widget_show_all (wtab);
 
-  gtk_widget_set_size_request (GTK_WIDGET (pview),
-                               default_width, default_height);
-
   GTK_WIDGET_SET_FLAGS (pview, GTK_CAN_FOCUS);
 
   x_window_setup_draw_events_drawing_area (w_current, pview);

--- a/schematic/src/x_widgets.c
+++ b/schematic/src/x_widgets.c
@@ -127,12 +127,6 @@ void x_widgets_create (GschemToplevel* w_current)
   g_signal_connect (w_current->find_text_state, "select-object",
                     G_CALLBACK (&x_window_select_object), w_current);
 
-  if (x_widgets_use_docks())
-  {
-    gtk_widget_set_size_request (GTK_WIDGET (w_current->find_text_state),
-                                 default_width, default_height / 4);
-  }
-
   w_current->color_edit_widget = color_edit_widget_new (w_current);
 
   w_current->font_select_widget = font_select_widget_new (w_current);

--- a/schematic/src/x_window.c
+++ b/schematic/src/x_window.c
@@ -430,15 +430,6 @@ void x_window_create_main(GschemToplevel *w_current)
    * see below
    */
 
-   /*
-    * normally we let the window manager handle locating and sizing
-    * the window.  However, for some batch processing of schematics
-    * (generating a pdf of all schematics for example) we want to
-    * override this.  Hence "auto_place_mode".
-    */
-   if( auto_place_mode )
-   	gtk_widget_set_uposition (w_current->main_window, 10, 10);
-
   /* this should work fine */
   g_signal_connect (G_OBJECT (w_current->main_window), "delete_event",
                     G_CALLBACK (i_callback_close_wm),


### PR DESCRIPTION
Save `lepton-schematic` main window's size and position to the `CACHE`
configuration context (`schematic.window-geometry`group) and restore
them on startup.
Geometry is restored if the (new) `[schematic.gui]::restore-window-geometry`
configuration key is set to `true` (it's `true` by default).
Deprecate `window-size` `gschemrc` option (`define-rc-dead-config`).

Affects #423 
