### PR TITLE
Fix crash in hotkeys dialog

### DIFF
--- a/schematic/include/gschemhotkeystore.h
+++ b/schematic/include/gschemhotkeystore.h
@@ -1,5 +1,6 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 2013 Peter Brett <peter@peter-b.co.uk>
+ * Copyright (C) 2017-2019 Lepton EDA Contributors
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -17,20 +18,16 @@
  * MA 02111-1301 USA.
  */
 
-#ifndef __GSCHEM_HOTKEY_STORE_H__
-#define __GSCHEM_HOTKEY_STORE_H__
-
-G_BEGIN_DECLS
+#ifndef GSCHEM_HOTKEY_STORE_H__
+#define GSCHEM_HOTKEY_STORE_H__
 
 /* ---------------------------------------------------------------- */
 
 /*! \class GschemHotkeyStore gschemhotkeystore.h "gschemhotkeystore.h"
  * \brief GtkTreeModel that contains keybinding data.
  *
- * A GtkListStore that contains a list of user editing actions with
- * their icons and their current keybindings.  The store automatically
- * updates when any of the actions' labels, icons or keybindings are
- * changed.
+ * A GtkListStore that contains a list of actions with
+ * their icons and their current keybindings.
  */
 
 #define GSCHEM_TYPE_HOTKEY_STORE (gschem_hotkey_store_get_type ())
@@ -40,12 +37,14 @@ G_BEGIN_DECLS
 #define GSCHEM_IS_HOTKEY_STORE_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE ((klass), GSCHEM_TYPE_HOTKEY_STORE))
 #define GSCHEM_HOTKEY_STORE_GET_CLASS(obj) (G_TYPE_INSTANCE_GET_CLASS ((obj), GSCHEM_TYPE_HOTKEY_STORE, GschemHotkeyStoreClass))
 
+
 enum {
   GSCHEM_HOTKEY_STORE_COLUMN_ICON  = 0,
   GSCHEM_HOTKEY_STORE_COLUMN_LABEL,
   GSCHEM_HOTKEY_STORE_COLUMN_KEYS,
-  GSCHEM_HOTKEY_STORE_NUM_COLUMNS,
+  GSCHEM_HOTKEY_STORE_NUM_COLUMNS
 };
+
 
 typedef struct _GschemHotkeyStoreClass GschemHotkeyStoreClass;
 typedef struct _GschemHotkeyStore GschemHotkeyStore;
@@ -58,17 +57,12 @@ struct _GschemHotkeyStoreClass
 struct _GschemHotkeyStore
 {
   GtkListStore parent_instance;
-
-  /* Protected members */
-  EdascmHookProxy *action_hook_proxy;
-  EdascmHookProxy *keymap_hook_proxy;
-  guint rebuild_source_id;
 };
 
-GType gschem_hotkey_store_get_type (void) G_GNUC_CONST;
 
-GschemHotkeyStore *gschem_hotkey_store_new (void) G_GNUC_WARN_UNUSED_RESULT;
+GType gschem_hotkey_store_get_type();
+GschemHotkeyStore* gschem_hotkey_store_new();
 
-G_END_DECLS
 
-#endif /* ! __GSCHEM_HOTKEY_STORE_H__ */
+#endif /* GSCHEM_HOTKEY_STORE_H__ */
+

--- a/schematic/src/gschem_hotkey_dialog.c
+++ b/schematic/src/gschem_hotkey_dialog.c
@@ -18,16 +18,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 /*! \todo STILL NEED to clean up line lengths in aa and tr */
-#include <config.h>
-#include <version.h>
-
-#include <stdio.h>
-#ifdef HAVE_STDLIB_H
-#include <stdlib.h>
-#endif
-#ifdef HAVE_STRING_H
-#include <string.h>
-#endif
 
 #include "gschem.h"
 
@@ -161,6 +151,21 @@ filter_setup (GtkTreeView* tree, GtkTreeModel* model, GtkEntry* entry)
 
 
 
+/*! \brief "response" signal handler for hotkeys dialog
+ */
+static void
+response (GtkWidget* widget, gint response, gpointer data)
+{
+  GschemToplevel* w_current = (GschemToplevel*) data;
+  g_return_if_fail (w_current != NULL);
+  g_return_if_fail (w_current->hkwindow != NULL);
+
+  gtk_widget_destroy (w_current->hkwindow);
+  w_current->hkwindow = NULL;
+}
+
+
+
 /*! \brief Creates the hotkeys dialog
  *  \par Function Description
  *  This function creates the hotkey dialog and puts the list of hotkeys
@@ -187,26 +192,12 @@ void x_dialog_hotkeys (GschemToplevel *w_current)
     GTK_WINDOW (w_current->main_window),
     (GtkDialogFlags) 0, /* not modal */
     "hotkeys", w_current,
-    GTK_STOCK_CLOSE, GTK_RESPONSE_NONE,
+    GTK_STOCK_CLOSE, GTK_RESPONSE_REJECT,
     NULL);
 
-  gtk_window_set_position (GTK_WINDOW (w_current->hkwindow), GTK_WIN_POS_NONE);
-
-
-  /* Just hide the dialog.
-   * Do not destroy it every time it's closed:
-  */
   g_signal_connect (G_OBJECT (w_current->hkwindow), "response",
-                    G_CALLBACK (&gtk_widget_hide),
-                    NULL);
-
-  g_signal_connect (G_OBJECT (w_current->hkwindow), "delete-event",
-                    G_CALLBACK (&gtk_widget_hide_on_delete),
-                    NULL);
-
-
-  gtk_dialog_set_default_response(GTK_DIALOG(w_current->hkwindow),
-                                  GTK_RESPONSE_ACCEPT);
+                    G_CALLBACK (&response),
+                    w_current);
 
   gtk_container_set_border_width (GTK_CONTAINER (w_current->hkwindow),
                                   DIALOG_BORDER_SPACING);
@@ -282,4 +273,3 @@ void x_dialog_hotkeys (GschemToplevel *w_current)
   gtk_widget_show_all(w_current->hkwindow);
 
 } /* x_dialog_hotkeys() */
-

--- a/schematic/src/gschemhotkeystore.c
+++ b/schematic/src/gschemhotkeystore.c
@@ -1,5 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 2013 Peter Brett <peter@peter-b.co.uk>
+ * Copyright (C) 2015 gEDA Contributors
+ * Copyright (C) 2017-2019 Lepton EDA Contributors
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -20,36 +22,23 @@
 #include <config.h>
 #include "gschem.h"
 
-enum {
-  COLUMN_ICON = 0,
-  COLUMN_LABEL,
-  COLUMN_KEYS,
-  NUM_COLUMNS,
-};
 
 #define HELPER_FUNC_NAME "%gschem-hotkey-store/dump-global-keymap"
 
-static void gschem_hotkey_store_dispose (GObject *object);
-static void gschem_hotkey_store_schedule_rebuild (GschemHotkeyStore *store);
+
 static gboolean gschem_hotkey_store_rebuild (GschemHotkeyStore *store);
-static void gschem_hotkey_store_action_property_handler (GschemHotkeyStore *store,
-                                                          SCM s_args,
-                                                          EdascmHookProxy *proxy);
-static void gschem_hotkey_store_bind_keys_handler (GschemHotkeyStore *store,
-                                                    SCM s_args,
-                                                    EdascmHookProxy *proxy);
+
 
 G_DEFINE_TYPE (GschemHotkeyStore, gschem_hotkey_store, GTK_TYPE_LIST_STORE);
+
 
 /*! Initialise GschemHotkeyStore class */
 static void
 gschem_hotkey_store_class_init (GschemHotkeyStoreClass *klass)
 {
-  GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
-
-  /* Register functions with base class */
-  gobject_class->dispose = gschem_hotkey_store_dispose;
 }
+
+
 
 /*! Initialise GschemHotkeyStore instance */
 static void
@@ -63,59 +52,10 @@ gschem_hotkey_store_init (GschemHotkeyStore *store)
                                    GSCHEM_HOTKEY_STORE_NUM_COLUMNS,
                                    column_types);
 
-  /* Make sure we can get notified when actions or keybindings
-   * change */
-  store->action_hook_proxy =
-    g_hook_new_proxy_by_name ("%action-property-hook");
-  g_signal_connect_swapped (store->action_hook_proxy, "run",
-                            G_CALLBACK (gschem_hotkey_store_action_property_handler),
-                            store);
-
-  store->keymap_hook_proxy =
-    g_hook_new_proxy_by_name ("%bind-keys-hook");
-  g_signal_connect_swapped (store->keymap_hook_proxy, "run",
-                            G_CALLBACK (gschem_hotkey_store_bind_keys_handler),
-                            store);
-
-  /* Finally, carry out initial rebuild of the treeview's backing
-   * store */
-  gschem_hotkey_store_schedule_rebuild (store);
+  gschem_hotkey_store_rebuild (store);
 }
 
-/*! Dispose of a GschemHotkeyStore instance.  Drop all references to
- * other GObjects, but keep the instance otherwise intact. May be run
- * multiple times (due to reference loops).
- */
-static void
-gschem_hotkey_store_dispose (GObject *object)
-{
-  GschemHotkeyStore *store = GSCHEM_HOTKEY_STORE (object);
 
-  if (store->action_hook_proxy) {
-    g_object_unref (store->action_hook_proxy);
-    store->action_hook_proxy = NULL;
-  }
-
-  if (store->keymap_hook_proxy) {
-    g_object_unref (store->keymap_hook_proxy);
-    store->keymap_hook_proxy = NULL;
-  }
-
-  /* Chain up to the parent class */
-  G_OBJECT_CLASS (gschem_hotkey_store_parent_class)->dispose (object);
-}
-
-/*! Schedule a list view rebuild to occur next time the GLib main loop
- * is idle. */
-static void
-gschem_hotkey_store_schedule_rebuild (GschemHotkeyStore *store)
-{
-  if (store->rebuild_source_id) return;
-
-  store->rebuild_source_id =
-    g_idle_add ((GSourceFunc) gschem_hotkey_store_rebuild,
-                store);
-}
 
 /*! Rebuild the list view. Calls into Scheme to generate a list of
  * current keybindings, and uses it to update the GtkListStore that
@@ -123,15 +63,13 @@ gschem_hotkey_store_schedule_rebuild (GschemHotkeyStore *store)
 static gboolean
 gschem_hotkey_store_rebuild (GschemHotkeyStore *store)
 {
-  static SCM s_expr = SCM_UNDEFINED;
+  SCM s_expr = SCM_UNDEFINED;
   SCM s_lst, s_iter;
 
   g_assert (GSCHEM_IS_HOTKEY_STORE (store));
 
   /* First run the Scheme function to dump the global keymap */
-  if (scm_is_eq (s_expr, SCM_UNDEFINED)) {
-    s_expr = scm_permanent_object (scm_list_1 (scm_from_utf8_symbol (HELPER_FUNC_NAME)));
-  }
+  s_expr = scm_list_1 (scm_from_utf8_symbol (HELPER_FUNC_NAME));
   s_lst = g_scm_eval_protected (s_expr, SCM_UNDEFINED);
 
   g_return_val_if_fail (scm_is_true (scm_list_p (s_lst)), FALSE);
@@ -169,72 +107,14 @@ gschem_hotkey_store_rebuild (GschemHotkeyStore *store)
     scm_dynwind_end ();
   }
 
-  store->rebuild_source_id = 0;
   return FALSE;
-}
 
-/*! Scheme-level hook handler for %action-property-hook.  Triggers
- * rebuilding of the list of hotkeys, but only if the property that
- * was changed was the label or icon (since those are the properties
- * that are actually used in the hotkey display).
- */
-static void
-gschem_hotkey_store_action_property_handler (GschemHotkeyStore *store,
-                                             SCM s_args,
-                                             EdascmHookProxy *proxy)
-{
-  static SCM label_sym = SCM_UNDEFINED;
-  static SCM icon_sym = SCM_UNDEFINED;
-  SCM s_key;
-  gboolean rebuild = FALSE;
+} /* gschem_hotkey_store_rebuild() */
 
-  g_assert (GSCHEM_IS_HOTKEY_STORE (store));
 
-  /* Unpack Scheme value before making any changes to the store.
-   * args should be a list of the form (action key value).  We only
-   * want to rebuild the store if the change is to a label or to an
-   * icon. */
-  if (scm_is_eq (label_sym, SCM_UNDEFINED)) {
-    label_sym = scm_permanent_object (scm_from_utf8_symbol ("label"));
-    icon_sym = scm_permanent_object (scm_from_utf8_symbol ("icon"));
-  }
-  /* Don't even bother checking that there's a well-formed argument
-   * list; if there isn't, you've got bigger problems! */
-  s_key = scm_cadr (s_args);
-  rebuild = (scm_is_eq (s_key, label_sym) || scm_is_eq (s_key, icon_sym));
 
-  if (rebuild) gschem_hotkey_store_schedule_rebuild (store);
-}
-
-/*! Scheme-level hook handler for %bind-keys-hook.  Triggers
- * rebuilding the list of hotkeys, but only if the %global-keymap was
- * modified.
- */
-static void
-gschem_hotkey_store_bind_keys_handler (GschemHotkeyStore *store,
-                                       SCM s_args,
-                                       EdascmHookProxy *proxy)
-{
-  static SCM global_keymap_sym = SCM_UNDEFINED;
-  gboolean rebuild = FALSE;
-
-  g_assert (GSCHEM_IS_HOTKEY_STORE (store));
-
-  if (scm_is_eq (global_keymap_sym, SCM_UNDEFINED)) {
-    global_keymap_sym =
-      scm_permanent_object (scm_from_utf8_symbol ("%global-keymap"));
-  }
-  /* Rather brute-force approach to checking whether the affected
-   * keymap is the global keymap */
-  rebuild = (scm_is_eq (scm_car (s_args),
-                        g_scm_eval_protected (global_keymap_sym,
-                                              SCM_UNDEFINED)));
-
-  if (rebuild) gschem_hotkey_store_schedule_rebuild (store);
-}
-
-GschemHotkeyStore *
-gschem_hotkey_store_new (void)
+GschemHotkeyStore*
+gschem_hotkey_store_new()
 {
   return GSCHEM_HOTKEY_STORE (g_object_new (GSCHEM_TYPE_HOTKEY_STORE, NULL));
 }


### PR DESCRIPTION
`lepton-schematic` crashes on attempt to open hotkeys dialog
from the new window (opened by `File->New Window`), when the
previous window is closed. `SIGSEGV` on Linux, `SIGBUS` on FreeBSD.
The problem is in `GschemHotkeyStore` code trying to do live
updates to the list of hotkeys. With that code simplified, the crash is gone.