### PR TITLE
Load netlist backend by file name

### DIFF
--- a/netlist/docs/lepton-netlist.1.in
+++ b/netlist/docs/lepton-netlist.1.in
@@ -3,7 +3,7 @@
 lepton-netlist - Lepton EDA Netlist Extraction and Generation
 .SH SYNOPSIS
 .B lepton-netlist
-[\fIOPTION\fR ...] [\fB-g\fR \fIBACKEND\fR] [\fI--\fR] \fIFILE\fR ...
+[\fIOPTION\fR ...] [\fB-g\fR \fIBACKEND\fR | \fB-f\fR \fIFILE\fR] [\fI--\fR] \fIFILE\fR ...
 
 .SH DESCRIPTION
 .PP
@@ -38,6 +38,11 @@ Scheme files.
 .TP 8
 \fB-g\fR \fIBACKEND\fR
 Specify the netlist backend to be used.
+.TP 8
+\fB-f\fR \fIFILE\fR
+Load and use netlist backend from \fIFILE\fR.
+\fIFILE\fR is expected to have name like "gnet-NAME.scm" and contain entry
+point function NAME (where NAME is the backend's name).
 .TP 8
 \fB-O\fR \fISTRING\fR
 Pass an option string to the backend.

--- a/netlist/docs/lepton-netlist.1.in
+++ b/netlist/docs/lepton-netlist.1.in
@@ -10,7 +10,7 @@ lepton-netlist - Lepton EDA Netlist Extraction and Generation
 
 \fBlepton-netlist\fR is a netlist extraction and generation tool, and is
 part of the Lepton EDA (Electronic Design Automation) toolset.  It takes
-one or electronic schematics as input, and outputs a netlist.  A
+one or more electronic schematics as input, and outputs a netlist.  A
 netlist is a machine-interpretable description of the way that
 components in an electronic circuit are connected together, and is
 commonly used as the input to a PCB layout program such as
@@ -170,6 +170,9 @@ Structural SystemC code generation.
 .TP 8
 \fBtango\fR
 Tango netlist format.
+.TP 8
+\fBtEDAx\fR
+Trivial EDA eXchange (tEDAx) format.
 .TP 8
 \fBvams\fR
 VHDL-AMS code generation.

--- a/netlist/scheme/lepton-netlist.in
+++ b/netlist/scheme/lepton-netlist.in
@@ -35,6 +35,7 @@ exec @GUILE@ -s "$0" "$@"
     (verbose (single-char #\v))
     (load-path (single-char #\L) (value #t))
     (backend (single-char #\g) (value #t))
+    (file-backend (single-char #\f) (value #t))
     (backend-option (single-char #\O) (value #t))
     (list-backends)
     (output (single-char #\o) (value #t))

--- a/netlist/scheme/netlist/option.scm
+++ b/netlist/scheme/netlist/option.scm
@@ -34,6 +34,7 @@
     (verbose . #f)
     (load-path . ())
     (backend . #f)
+    (file-backend . #f)
     (backend-option . ())
     (list-backends . #f)
     (output . "output.net")


### PR DESCRIPTION
Add `-f FILE` command line option. Load backend by
file name (file path), which does not have to be
located in `%load-path`. `FILE` should be named like
`"gnet-NAME.scm"`, where `NAME` is the backend's name.
Useful for testing new and 3rd party backends, as well as
running backends from different installation paths.
