### PR TITLE
Rename dialog geometry settings in gui.conf

### DIFF
--- a/schematic/src/gschem_dialog.c
+++ b/schematic/src/gschem_dialog.c
@@ -1,6 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
- * Copyright (C) 1998-2010 gEDA Contributors (see ChangeLog for details)
+ * Copyright (C) 1998-2014 gEDA Contributors
+ * Copyright (C) 2017-2019 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -152,7 +153,7 @@ static void show_handler (GtkWidget *widget)
   GschemDialog *dialog = GSCHEM_DIALOG( widget );
 
   if (dialog->settings_name != NULL) {
-    group_name = g_strdup_printf ("gschem.dialog-geometry.%s",
+    group_name = g_strdup_printf ("schematic.dialog-geometry.%s",
                                   dialog->settings_name);
 
     g_assert (cfg != NULL);
@@ -186,7 +187,7 @@ static void unmap_handler (GtkWidget *widget)
   GschemDialog *dialog = GSCHEM_DIALOG (widget);
 
   if (dialog->settings_name != NULL) {
-    group_name = g_strdup_printf ("gschem.dialog-geometry.%s",
+    group_name = g_strdup_printf ("schematic.dialog-geometry.%s",
                                   dialog->settings_name);
 
     g_assert (cfg != NULL);


### PR DESCRIPTION
Rename configuration groups in `gui.conf`:
`gschem.dialog-geometry.*` =>
`schematic.dialog-geometry.*`.
Not sure if it's worth bothering to read values from old groups, write
them to new ones and delete the former, since it can be done with
one simple `sed` command.