### PR TITLE
Symcheck improvements

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -187,6 +187,17 @@ Notable changes in Lepton EDA 1.9.8
 - Separate menu description *XML* file has been removed. Now the
   menu structure is defined in the source code only.
 
+### Changes in `lepton-symcheck`:
+
+- The program no longer requires specifying any file name when
+  interactive mode is requested, which may be convenient, for
+  example, for debugging its functions.
+
+- A simple error is output instead of Scheme backtrace when
+  neither interactive mode nor input files are specified on
+  command line.
+
+
 ### Scheme API changes
 - Three legacy rc procedures, `attribute-promotion`,
   `promote-invisible`, and `keep-invisible`, have been adjusted to

--- a/symcheck/scheme/symcheck/check.scm
+++ b/symcheck/scheme/symcheck/check.scm
@@ -68,15 +68,17 @@ FILENAME ... are the symbols to check.
         (interactive (symcheck-option-ref 'interactive)))
     (if help
         (usage)
-        (if (null? files)
-            (error (format #f
-                           (_ "No schematic files specified for processing.
+        (let ((pages (map file->page files)))
+          (if interactive
+              ;; Interactive mode. Just run the REPL to work with
+              ;; schematic pages.
+              (lepton-repl)
+              ;; Non-interactive mode.
+              (if (null? pages)
+                  (error (format #f
+                                 (_ "No schematic files specified for processing.
 Run `~A --help' for more information.
 ")
-                           (car (program-arguments))))
-            (let ((pages (map file->page files)))
-              (if interactive
-                  (lepton-repl)
-
+                                 (car (program-arguments))))
                   ;; now report the info/warnings/errors to the user
                   (primitive-exit (apply + (map report-symbol-statistics pages)))))))))

--- a/symcheck/scheme/symcheck/check.scm
+++ b/symcheck/scheme/symcheck/check.scm
@@ -1,6 +1,6 @@
 ;;; Lepton EDA Symbol Checker
 ;;; Scheme API
-;;; Copyright (C) 2017 Lepton EDA Contributors
+;;; Copyright (C) 2017-2019 Lepton EDA Contributors
 ;;;
 ;;; This program is free software; you can redistribute it and/or modify
 ;;; it under the terms of the GNU General Public License as published by
@@ -60,6 +60,13 @@ FILENAME ... are the symbols to check.
     (check-symbol page)
     (check-report `(,page . ,(page-contents page))))
 
+  (define (error-no-files-specified)
+    (format #t
+            (_ "No schematic files specified for processing.
+Run `~A --help' for more information.\n")
+            (car (program-arguments)))
+    (primitive-exit 1))
+
   ;; Symcheck logs to stdout by default.
   (set-check-log-destination! 'stdout)
 
@@ -75,10 +82,6 @@ FILENAME ... are the symbols to check.
               (lepton-repl)
               ;; Non-interactive mode.
               (if (null? pages)
-                  (error (format #f
-                                 (_ "No schematic files specified for processing.
-Run `~A --help' for more information.
-")
-                                 (car (program-arguments))))
+                  (error-no-files-specified)
                   ;; now report the info/warnings/errors to the user
                   (primitive-exit (apply + (map report-symbol-statistics pages)))))))))


### PR DESCRIPTION
The branch introduces the changes in `lepton-symcheck` as follows:
- Interactive mode can now be used without any file specified.
- Instead of displaying of error stack when neither files nor interactive mode were requested, the program just outputs appropriate text and exits with exit code 1.