### PR TITLE
Deprecate draw-grips gschemrc option

### DIFF
--- a/liblepton/scheme/geda-deprecated-config.scm
+++ b/liblepton/scheme/geda-deprecated-config.scm
@@ -176,6 +176,7 @@ option's value:
 (define-rc-dead-config raise-dialog-boxes-on-expose)
 (define-rc-dead-config image-size)
 (define-rc-dead-config image-color)
+(define-rc-dead-config draw-grips)
 
 ;; ===================================================================
 ;; Deprecated lepton-netlist configuration functions

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -179,7 +179,6 @@ SCM g_rc_undo_levels(SCM levels);
 SCM g_rc_undo_control(SCM mode);
 SCM g_rc_undo_type(SCM mode);
 SCM g_rc_undo_panzoom(SCM mode);
-SCM g_rc_draw_grips(SCM mode);
 SCM g_rc_netconn_rubberband(SCM mode);
 SCM g_rc_magnetic_net_mode(SCM mode);
 SCM g_rc_add_menu(SCM menu_name, SCM menu_items);

--- a/schematic/scheme/conf/schematic/options.scm
+++ b/schematic/scheme/conf/schematic/options.scm
@@ -63,12 +63,6 @@
 ; Autosaving will not be allowed if setting it to zero.
 (auto-save-interval 120)
 
-; draw-grips string
-;
-; Controls if the editing grips are drawn when selecting objects
-;
-(draw-grips "enabled")
-;(draw-grips "disabled")
 
 ;  net-direction-mode string
 ;

--- a/schematic/src/g_rc.c
+++ b/schematic/src/g_rc.c
@@ -593,23 +593,6 @@ SCM g_rc_undo_panzoom(SCM mode)
  *  \par Function Description
  *
  */
-SCM g_rc_draw_grips(SCM mode)
-{
-  static const vstbl_entry mode_table[] = {
-    {TRUE , "enabled" },
-    {FALSE, "disabled"},
-  };
-
-  RETURN_G_RC_MODE("draw-grips",
-		   default_draw_grips,
-		   2);
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
 SCM g_rc_netconn_rubberband(SCM mode)
 {
   static const vstbl_entry mode_table[] = {

--- a/schematic/src/g_register.c
+++ b/schematic/src/g_register.c
@@ -79,7 +79,6 @@ static struct gsubr_t gschem_funcs[] = {
   { "undo-type",                    1, 0, 0, (SCM (*) ()) g_rc_undo_type },
   { "undo-panzoom",                 1, 0, 0, (SCM (*) ()) g_rc_undo_panzoom },
 
-  { "draw-grips",                   1, 0, 0, (SCM (*) ()) g_rc_draw_grips },
   { "netconn-rubberband",           1, 0, 0, (SCM (*) ()) g_rc_netconn_rubberband },
   { "magnetic-net-mode",            1, 0, 0, (SCM (*) ()) g_rc_magnetic_net_mode },
   { "add-menu",                     2, 0, 0, (SCM (*) ()) g_rc_add_menu },


### PR DESCRIPTION
The behavior controlled by the `draw-grips` `gschemrc`
option is broken. When disabled, it's supposed to
draw no grips for selected objects. Instead, it
disables all resize operations while still drawing
the grips.
Until the behavior is fixed, remove that option
and define it using `define-rc-dead-config()`.

Affects #423 
