### PR TITLE
Show/hide main menu items relevant to current settings

### DIFF
--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -3,7 +3,7 @@
 #
 
 [schematic.gui]
-use-docks=true
+use-docks=false
 use-tabs=true
 max-recent-files=10
 title-show-path=false

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -3,7 +3,7 @@
 #
 
 [schematic.gui]
-use-docks=true
+use-docks=false
 use-tabs=true
 max-recent-files=10
 title-show-path=false

--- a/schematic/lib/system-gschemrc.scm
+++ b/schematic/lib/system-gschemrc.scm
@@ -8,7 +8,8 @@
              (schematic gui stroke)
              (schematic netlist)
              (gschem builtins)
-             (gschem action))
+             (gschem action)
+             (geda config))
 
 
 ; gschem-version string

--- a/schematic/scheme/conf/schematic/menu.scm
+++ b/schematic/scheme/conf/schematic/menu.scm
@@ -126,20 +126,39 @@
 ) ; view-menu-items
 
 
-( define page-menu-items
-( list
-  ( list (N_ "_Manager...")  '&page-manager  #f )
-  ( list "SEPARATOR" #f #f )
-  ( list (N_ "_Previous")    '&page-prev     "gtk-go-back" )
-  ( list (N_ "_Next")        '&page-next     "gtk-go-forward" )
-  ( list (N_ "_Close")       '&page-close    "gtk-close" )
-  ( list "SEPARATOR" #f #f )
-  ( list (N_ "_Revert...")   '&page-revert   "gtk-revert-to-saved" )
-  ( list "SEPARATOR" #f #f )
-  ( list (N_ "Next Tab")     '&page-next-tab "gtk-go-forward" )
-  ( list (N_ "Previous Tab") '&page-prev-tab "gtk-go-back" )
-)
-) ; page-menu-items
+( define ( page-menu-items )
+( let*
+  (
+  ( grp "schematic.gui" )
+  ( key "use-tabs" )
+  ( cfg ( path-config-context (getcwd) ) )
+  ( val ( if cfg (config-boolean cfg grp key) #t ) )
+  )
+
+  ( define ( opt-item item )
+    ; return:
+    ( if val
+      item ; if
+      '()  ; else
+    )
+  )
+
+  ; return:
+  ( list
+    ( list (N_ "_Manager...")  '&page-manager  #f )
+    ( list "SEPARATOR" #f #f )
+    ( list (N_ "_Previous")    '&page-prev     "gtk-go-back" )
+    ( list (N_ "_Next")        '&page-next     "gtk-go-forward" )
+    ( list (N_ "_Close")       '&page-close    "gtk-close" )
+    ( list "SEPARATOR" #f #f )
+    ( list (N_ "_Revert...")   '&page-revert   "gtk-revert-to-saved" )
+    ( opt-item (list "SEPARATOR" #f #f) )
+    ( opt-item (list (N_ "Next Tab")     '&page-next-tab "gtk-go-forward") )
+    ( opt-item (list (N_ "Previous Tab") '&page-prev-tab "gtk-go-back") )
+  )
+
+) ; let
+) ; page-menu-items()
 
 
 ( define add-menu-items
@@ -246,7 +265,7 @@
 ( add-menu (N_ "_Edit")       edit-menu-items )
 ; ( add-menu (N_ "_Buffer")     buffer-menu-items )
 ( add-menu (N_ "_View")       view-menu-items )
-( add-menu (N_ "_Page")       page-menu-items )
+( add-menu (N_ "_Page")       (page-menu-items) )
 ( add-menu (N_ "_Add")        add-menu-items )
 ( add-menu (N_ "Hie_rarchy")  hierarchy-menu-items )
 ( add-menu (N_ "A_ttributes") attributes-menu-items )

--- a/schematic/scheme/conf/schematic/menu.scm
+++ b/schematic/scheme/conf/schematic/menu.scm
@@ -18,229 +18,239 @@
   (syntax-rules ()
     ((N_ expr) expr)))
 
-(define file-menu-items
-;;
-;;          menu item name      menu action             menu stock icon
-;;
-        `( (,(N_ "_New")              &file-new               "gtk-new")
-           (,(N_ "_Open...")          &file-open              "gtk-open")
-;; The entry below will be removed from the menu if glib < 2.6 is detected
-           (,(N_ "Open Recen_t")      #f                      #f)
-           ("SEPARATOR"               #f                      #f)
-           (,(N_ "_Save")             &file-save              "gtk-save")
-           (,(N_ "Save _As...")       &file-save-as           "gtk-save-as")
-           (,(N_ "Save All")          &file-save-all          "gtk-save")
-           ("SEPARATOR"               #f                      #f)
-           (,(N_ "_Print...")         &file-print             "gtk-print")
-           (,(N_ "Write _Image...")   &file-image             #f)
-           ("SEPARATOR"               #f                      #f)
-           (,(N_ "Invoke Macro...")   &edit-invoke-macro      "gtk-execute")
-           (,(N_ "Execute Script...") &file-script            "gtk-execute")
-           (,(N_ "REPL...")           &file-repl              "gtk-execute")
-           ("SEPARATOR"               #f                      #f)
-           (,(N_ "New Window")        &file-new-window        "window-new")
-           (,(N_ "_Close Window")     &file-close-window      "gtk-close")
-           (,(N_ "_Quit")             &file-quit              "gtk-quit")))
 
-(define edit-menu-items
+( define file-menu-items
+( list
 ;;
-;;          menu item name      menu action             menu stock icon
+;;       menu item name           menu action              menu stock icon
 ;;
-        `( (,(N_ "_Undo")              &edit-undo             "gtk-undo")
-           (,(N_ "_Redo")              &edit-redo             "gtk-redo")
-           ("SEPARATOR"                #f                     #f)
-           (,(N_ "Cu_t")               &clipboard-cut         "gtk-cut")
-           (,(N_ "_Copy")              &clipboard-copy        "gtk-copy")
-           (,(N_ "_Paste")             &clipboard-paste       "gtk-paste")
-           (,(N_ "_Delete")            &edit-delete           "gtk-delete"  )
-           ("SEPARATOR"                #f                     #f)
-           (,(N_ "Select Mode")        &edit-select           "select")
-           (,(N_ "Select All")         &edit-select-all       "gtk-select-all")
-           (,(N_ "Deselect")           &edit-deselect         "deselect")
-           (,(N_ "Copy Mode")          &edit-copy             "clone")
-           (,(N_ "Multiple Copy Mode") &edit-mcopy            "multi-clone")
-           (,(N_ "Move Mode")          &edit-move             #f)
-           (,(N_ "Rotate 90 Mode")     &edit-rotate-90        "object-rotate-left")
-           (,(N_ "Mirror Mode")        &edit-mirror           "object-flip-horizontal")
-           ("SEPARATOR"                #f                     #f)
-           (,(N_ "Object Properties...") &edit-object-properties "gtk-properties")
-           (,(N_ "Edit...")            &edit-edit             #f)
-           (,(N_ "Edit Text...")       &edit-text             "gtk-edit")
-           (,(N_ "Slot...")            &edit-slot             #f)
-           ("SEPARATOR"                #f                     #f)
-           (,(N_ "Lock")               &edit-lock             #f)
-           (,(N_ "Unlock")             &edit-unlock           #f)
-           ("SEPARATOR"                #f                     #f)
-           (,(N_ "Embed Component/Picture")    &edit-embed    #f)
-           (,(N_ "Unembed Component/Picture")  &edit-unembed  #f)
-           (,(N_ "Update Component")   &edit-update           "gtk-refresh")
-           (,(N_ "Symbol Translate...")  &edit-translate      #f)))
-
-(define buffer-menu-items
-;;
-;;          menu item name      menu action             menu stock icon
-;;
-	`( (,(N_ "Copy into 1")	buffer-copy1    "gtk-copy")
-	   (,(N_ "Copy into 2")	buffer-copy2    "gtk-copy")
-	   (,(N_ "Copy into 3")	buffer-copy3    "gtk-copy")
-	   (,(N_ "Copy into 4")	buffer-copy4    "gtk-copy")
-	   (,(N_ "Copy into 5")	buffer-copy5    "gtk-copy")
-	   (,(N_ "Cut into 1")	buffer-cut1       	"gtk-cut")
-	   (,(N_ "Cut into 2")	buffer-cut2       	"gtk-cut")
-	   (,(N_ "Cut into 3")	buffer-cut3       	"gtk-cut")
-	   (,(N_ "Cut into 4")	buffer-cut4       	"gtk-cut")
-	   (,(N_ "Cut into 5")	buffer-cut5       	"gtk-cut")
-	   (,(N_ "Paste from 1")	buffer-paste1   "gtk-paste")
-	   (,(N_ "Paste from 2")	buffer-paste2   "gtk-paste")
-	   (,(N_ "Paste from 3")	buffer-paste3   "gtk-paste")
-	   (,(N_ "Paste from 4")	buffer-paste4   "gtk-paste")
-	   (,(N_ "Paste from 5")	buffer-paste5   "gtk-paste")))
-
-(define view-menu-items
-;;
-;;          menu item name        menu action             menu stock icon
-;;
-        `( (,(N_ "Side Dock")           &view-sidebar           #f)
-           (,(N_ "Bottom Dock")         &view-status            #f)
-           ("SEPARATOR"                 #f                      #f)
-           (,(N_ "Find Text Results")   &view-find-text-state   #f)
-           ("SEPARATOR"                 #f                      #f)
-           (,(N_ "_Redraw")             &view-redraw            "gtk-refresh")
-           (,(N_ "_Pan")                &view-pan               #f)
-           (,(N_ "Zoom _Box")           &view-zoom-box          #f)
-           (,(N_ "Zoom _Extents")       &view-zoom-extents      "gtk-zoom-fit")
-           (,(N_ "Zoom _In")            &view-zoom-in           "gtk-zoom-in")
-           (,(N_ "Zoom _Out")           &view-zoom-out          "gtk-zoom-out")
-           (,(N_ "Zoom _Full")          &view-zoom-full         #f)
-           ("SEPARATOR"                 #f                      #f)
-           (,(N_ "_Dark Color Scheme")  &view-dark-colors       #f)
-           (,(N_ "_Light Color Scheme") &view-light-colors      #f)
-           (,(N_ "B_W Color Scheme")    &view-bw-colors         #f)
-           ("SEPARATOR"                 #f                      #f)
-           (,(N_ "Color Scheme Editor...") &view-color-edit     #f)
-         ))
-
-(define page-menu-items
-;;
-;;          menu item name      menu action             menu stock icon
-;;
-        `( (,(N_ "_Manager...")       &page-manager           #f)
-           ("SEPARATOR"               #f                      #f)
-           (,(N_ "_Previous")         &page-prev              "gtk-go-back")
-           (,(N_ "_Next")             &page-next              "gtk-go-forward")
-           (,(N_ "_Close")            &page-close             "gtk-close")
-           ("SEPARATOR"               #f                      #f)
-           (,(N_ "_Revert...")        &page-revert            "gtk-revert-to-saved")
-           ("SEPARATOR"               #f                      #f)
-           (,(N_ "Next Tab")          &page-next-tab          "gtk-go-forward")
-           (,(N_ "Previous Tab")      &page-prev-tab          "gtk-go-back")
-        )
+  ( list (N_ "_New")              '&file-new               "gtk-new"     )
+  ( list (N_ "_Open...")          '&file-open              "gtk-open"    )
+  ( list (N_ "Open Recen_t")      #f                       #f            )
+  ( list "SEPARATOR"              #f                       #f            )
+  ( list (N_ "_Save")             '&file-save              "gtk-save"    )
+  ( list (N_ "Save _As...")       '&file-save-as           "gtk-save-as" )
+  ( list (N_ "Save All")          '&file-save-all          "gtk-save"    )
+  ( list "SEPARATOR"              #f                       #f            )
+  ( list (N_ "_Print...")         '&file-print             "gtk-print"   )
+  ( list (N_ "Write _Image...")   '&file-image             #f            )
+  ( list "SEPARATOR"              #f                       #f            )
+  ( list (N_ "Invoke Macro...")   '&edit-invoke-macro      "gtk-execute" )
+  ( list (N_ "Execute Script...") '&file-script            "gtk-execute" )
+  ( list (N_ "REPL...")           '&file-repl              "gtk-execute" )
+  ( list "SEPARATOR"              #f                       #f )
+  ( list (N_ "New Window")        '&file-new-window        "window-new"  )
+  ( list (N_ "_Close Window")     '&file-close-window      "gtk-close"   )
+  ( list (N_ "_Quit")             '&file-quit              "gtk-quit"    )
 )
+) ; file-menu-items
 
-(define add-menu-items
-;;
-;;          menu item name      menu action             menu stock icon
-;;
-        `( (,(N_ "_Component...")     &add-component   "insert-symbol")
-           ("SEPARATOR"              #f                #f)
-           (,(N_ "_Net")              &add-net         "insert-net")
-           (,(N_ "B_us")              &add-bus         "insert-bus")
-           ("SEPARATOR"              #f                #f)
-           (,(N_ "_Attribute...")     &add-attribute   "insert-attribute")
-           (,(N_ "_Text...")          &add-text        "insert-text")
-           ("SEPARATOR"              #f                #f)
-           (,(N_ "_Line")             &add-line        "insert-line")
-           (,(N_ "Pat_h")             &add-path        "insert-path")
-           (,(N_ "_Box")              &add-box         "insert-box")
-           (,(N_ "C_ircle")           &add-circle      "insert-circle")
-           (,(N_ "A_rc")              &add-arc         "insert-arc")
-           (,(N_ "_Pin")              &add-pin         "insert-pin")
-           ("SEPARATOR"              #f                #f)
-           (,(N_ "Pictu_re...")       &add-picture     "insert-image")))
+
+( define edit-menu-items
+( list
+  ( list (N_ "_Undo")              '&edit-undo       "gtk-undo" )
+  ( list (N_ "_Redo")              '&edit-redo       "gtk-redo" )
+  ( list "SEPARATOR" #f #f )
+  ( list (N_ "Cu_t")               '&clipboard-cut   "gtk-cut" )
+  ( list (N_ "_Copy")              '&clipboard-copy  "gtk-copy" )
+  ( list (N_ "_Paste")             '&clipboard-paste "gtk-paste" )
+  ( list (N_ "_Delete")            '&edit-delete     "gtk-delete" )
+  ( list "SEPARATOR" #f #f )
+  ( list (N_ "Select Mode")        '&edit-select     "select" )
+  ( list (N_ "Select All")         '&edit-select-all "gtk-select-all" )
+  ( list (N_ "Deselect")           '&edit-deselect   "deselect" )
+  ( list (N_ "Copy Mode")          '&edit-copy       "clone" )
+  ( list (N_ "Multiple Copy Mode") '&edit-mcopy      "multi-clone" )
+  ( list (N_ "Move Mode")          '&edit-move       #f)
+  ( list (N_ "Rotate 90 Mode")     '&edit-rotate-90  "object-rotate-left" )
+  ( list (N_ "Mirror Mode")        '&edit-mirror     "object-flip-horizontal" )
+  ( list "SEPARATOR" #f #f )
+  ( list (N_ "Object Properties...") '&edit-object-properties "gtk-properties" )
+  ( list (N_ "Edit...")              '&edit-edit              #f )
+  ( list (N_ "Edit Text...")         '&edit-text              "gtk-edit" )
+  ( list (N_ "Slot...")              '&edit-slot              #f )
+  ( list "SEPARATOR" #f #f )
+  ( list (N_ "Lock")                 '&edit-lock              #f )
+  ( list (N_ "Unlock")               '&edit-unlock            #f )
+  ( list "SEPARATOR" #f #f )
+  ( list (N_ "Embed Component/Picture")   '&edit-embed        #f )
+  ( list (N_ "Unembed Component/Picture") '&edit-unembed      #f )
+  ( list (N_ "Update Component")          '&edit-update       "gtk-refresh" )
+  ( list (N_ "Symbol Translate...")       '&edit-translate    #f )
+)
+) ; edit-menu-items
+
+
+( define buffer-menu-items
+( list
+  ( list (N_ "Copy into 1")  'buffer-copy1  "gtk-copy" )
+  ( list (N_ "Copy into 2")  'buffer-copy2  "gtk-copy" )
+  ( list (N_ "Copy into 3")  'buffer-copy3  "gtk-copy" )
+  ( list (N_ "Copy into 4")  'buffer-copy4  "gtk-copy" )
+  ( list (N_ "Copy into 5")  'buffer-copy5  "gtk-copy" )
+  ( list (N_ "Cut into 1")   'buffer-cut1   "gtk-cut" )
+  ( list (N_ "Cut into 2")   'buffer-cut2   "gtk-cut" )
+  ( list (N_ "Cut into 3")   'buffer-cut3   "gtk-cut" )
+  ( list (N_ "Cut into 4")   'buffer-cut4   "gtk-cut" )
+  ( list (N_ "Cut into 5")   'buffer-cut5   "gtk-cut" )
+  ( list (N_ "Paste from 1") 'buffer-paste1 "gtk-paste" )
+  ( list (N_ "Paste from 2") 'buffer-paste2 "gtk-paste" )
+  ( list (N_ "Paste from 3") 'buffer-paste3 "gtk-paste" )
+  ( list (N_ "Paste from 4") 'buffer-paste4 "gtk-paste" )
+  ( list (N_ "Paste from 5") 'buffer-paste5 "gtk-paste" )
+)
+) ; buffer-menu-items
+
+
+( define view-menu-items
+( list
+  ( list (N_ "Side Dock")           '&view-sidebar           #f )
+  ( list (N_ "Bottom Dock")         '&view-status            #f )
+  ( list "SEPARATOR" #f #f )
+  ( list (N_ "Find Text Results")   '&view-find-text-state   #f )
+  ( list "SEPARATOR" #f #f )
+  ( list (N_ "_Redraw")             '&view-redraw            "gtk-refresh" )
+  ( list (N_ "_Pan")                '&view-pan               #f )
+  ( list (N_ "Zoom _Box")           '&view-zoom-box          #f )
+  ( list (N_ "Zoom _Extents")       '&view-zoom-extents      "gtk-zoom-fit" )
+  ( list (N_ "Zoom _In")            '&view-zoom-in           "gtk-zoom-in" )
+  ( list (N_ "Zoom _Out")           '&view-zoom-out          "gtk-zoom-out" )
+  ( list (N_ "Zoom _Full")          '&view-zoom-full         #f )
+  ( list "SEPARATOR" #f #f )
+  ( list (N_ "_Dark Color Scheme")  '&view-dark-colors       #f )
+  ( list (N_ "_Light Color Scheme") '&view-light-colors      #f )
+  ( list (N_ "B_W Color Scheme")    '&view-bw-colors         #f )
+  ( list "SEPARATOR" #f #f )
+  ( list (N_ "Color Scheme Editor...") '&view-color-edit     #f )
+)
+) ; view-menu-items
+
+
+( define page-menu-items
+( list
+  ( list (N_ "_Manager...")  '&page-manager  #f )
+  ( list "SEPARATOR" #f #f )
+  ( list (N_ "_Previous")    '&page-prev     "gtk-go-back" )
+  ( list (N_ "_Next")        '&page-next     "gtk-go-forward" )
+  ( list (N_ "_Close")       '&page-close    "gtk-close" )
+  ( list "SEPARATOR" #f #f )
+  ( list (N_ "_Revert...")   '&page-revert   "gtk-revert-to-saved" )
+  ( list "SEPARATOR" #f #f )
+  ( list (N_ "Next Tab")     '&page-next-tab "gtk-go-forward" )
+  ( list (N_ "Previous Tab") '&page-prev-tab "gtk-go-back" )
+)
+) ; page-menu-items
+
+
+( define add-menu-items
+( list
+  ( list (N_ "_Component...") '&add-component "insert-symbol" )
+  ( list "SEPARATOR" #f #f )
+  ( list (N_ "_Net")          '&add-net       "insert-net" )
+  ( list (N_ "B_us")          '&add-bus       "insert-bus" )
+  ( list "SEPARATOR" #f #f )
+  ( list (N_ "_Attribute...") '&add-attribute "insert-attribute" )
+  ( list (N_ "_Text...")      '&add-text      "insert-text" )
+  ( list "SEPARATOR" #f #f )
+  ( list (N_ "_Line")         '&add-line      "insert-line" )
+  ( list (N_ "Pat_h")         '&add-path      "insert-path" )
+  ( list (N_ "_Box")          '&add-box       "insert-box" )
+  ( list (N_ "C_ircle")       '&add-circle    "insert-circle" )
+  ( list (N_ "A_rc")          '&add-arc       "insert-arc" )
+  ( list (N_ "_Pin")          '&add-pin       "insert-pin" )
+  ( list "SEPARATOR" #f #f )
+  ( list (N_ "Pictu_re...")   '&add-picture   "insert-image" )
+)
+) ; add-menu-items
+
 
 (define hierarchy-menu-items
-;;
-;;          menu item name      menu action               menu stock icon
-;;
-        `( (,(N_ "_Up")               &hierarchy-up             "gtk-go-up")
-           ("SEPARATOR"              #f                #f)
-           (,(N_ "_Down Schematic")   &hierarchy-down-schematic "gtk-go-down")
-           (,(N_ "Down _Symbol")      &hierarchy-down-symbol    "gtk-goto-bottom")))
+( list
+  ( list (N_ "_Up")             '&hierarchy-up             "gtk-go-up" )
+  ( list "SEPARATOR" #f #f )
+  ( list (N_ "_Down Schematic") '&hierarchy-down-schematic "gtk-go-down" )
+  ( list (N_ "Down _Symbol")    '&hierarchy-down-symbol    "gtk-goto-bottom" )
+)
+) ; hierarchy-menu-items
 
-(define attributes-menu-items
-;;
-;;          menu item name      menu action             menu stock icon
-;;
-        `( (,(N_ "_Attach")           &attributes-attach      "attribute-attach")
-           (,(N_ "_Detach")           &attributes-detach      "attribute-detach")
-           ("SEPARATOR" #f #f)
-           (,(N_ "Show _Value")       &attributes-show-value  "attribute-show-value")
-           (,(N_ "Show _Name")        &attributes-show-name   "attribute-show-name")
-           (,(N_ "Show _Both")        &attributes-show-both   "attribute-show-both")
-           (,(N_ "_Toggle Visibility")  &attributes-visibility-toggle   #f)
-           ("SEPARATOR" #f #f)
-           (,(N_ "_Hide Specific Text...") &edit-hide-text   #f)
-           (,(N_ "_Show Specific Text...") &edit-show-text   #f)
-           (,(N_ "Show/Hide Hidden Text")  &edit-show-hidden #f)
-           ("SEPARATOR" #f #f)
-           (,(N_ "_Find Text/Check Symbol...") &edit-find-text   "gtk-find")
-           (,(N_ "A_utonumber Text...")        &edit-autonumber  #f)))
 
-(define options-menu-items
-;;
-;;          menu item name      menu action             menu stock icon
-;;
-        `( (,(N_ "_Options...") &options-snap-size)
-           (,(N_ "_Font...")    &options-select-font)
-           ("SEPARATOR" #f #f)
-           (,(N_ "Grid +")      &options-scale-up-snap-size)
-           (,(N_ "Grid -")      &options-scale-down-snap-size)
-           ("SEPARATOR" #f #f)
-           (,(N_ "Grid Style: Cycle Dots/Mesh/Off")  &options-grid)
-           (,(N_ "Grid Snap: Cycle Grid/Resnap/Off") &options-snap)
-           ("SEPARATOR" #f #f)
-           (,(N_ "Feedback Mode: Outline/Box") &options-action-feedback)
-           (,(N_ "Net: Rubberband On/Off")     &options-rubberband)
-           (,(N_ "Net: Magnetic On/Off")       &options-magneticnet)
-           ("SEPARATOR" #f #f)
-           (,(N_ "_Coord Window") &options-show-coord-window)
-           (,(N_ "_Log Window")   &options-show-log-window)))
+( define attributes-menu-items
+( list
+  ( list (N_ "_Attach")      '&attributes-attach     "attribute-attach" )
+  ( list (N_ "_Detach")      '&attributes-detach     "attribute-detach" )
+  ( list "SEPARATOR" #f #f )
+  ( list (N_ "Show _Value")  '&attributes-show-value "attribute-show-value" )
+  ( list (N_ "Show _Name")   '&attributes-show-name  "attribute-show-name" )
+  ( list (N_ "Show _Both")   '&attributes-show-both  "attribute-show-both" )
+  ( list (N_ "_Toggle Visibility") '&attributes-visibility-toggle #f )
+  ( list "SEPARATOR" #f #f )
+  ( list (N_ "_Hide Specific Text...") '&edit-hide-text   #f )
+  ( list (N_ "_Show Specific Text...") '&edit-show-text   #f )
+  ( list (N_ "Show/Hide Hidden Text")  '&edit-show-hidden #f )
+  ( list "SEPARATOR" #f #f )
+  ( list (N_ "_Find Text/Check Symbol...") '&edit-find-text  "gtk-find" )
+  ( list (N_ "A_utonumber Text...")        '&edit-autonumber #f )
+)
+) ; attributes-menu-items
 
-(define netlist-menu-items
-  ;; Format of list items is:
-  ;; name action icon
-  `(
-    (,(N_ "_1 allegro") &netlist-allegro #f))
-  )
 
-(define help-menu-items
-;;
-;;          menu item name                menu action               menu stock icon
-;;
-        `(
-           (,(N_ "User _Guide")  &help-guide                "gtk-help")
-           (,(N_ "_FAQ")         &help-faq                  "help-faq")
-           (,(N_ "Docu_mentation") &help-manual               "help-browser")
-           (,(N_ "_Wiki")          &help-wiki                 "web-browser")
-           ("SEPARATOR"                   #f                          #f)
-           (,(N_ "Find Component D_ocumentation") &hierarchy-documentation "symbol-datasheet")
-           ("SEPARATOR"                   #f                          #f)
-           (,(N_ "_Hotkeys...")            &help-hotkeys              "preferences-desktop-keyboard-shortcuts")
-           (,(N_ "_About")              &help-about                "gtk-about")))
+( define options-menu-items
+( list
+  ( list (N_ "_Options...")  '&options-snap-size #f )
+  ( list (N_ "_Font...")     '&options-select-font #f )
+  ( list "SEPARATOR" #f #f )
+  ( list (N_ "Grid +")       '&options-scale-up-snap-size #f )
+  ( list (N_ "Grid -")       '&options-scale-down-snap-size #f )
+  ( list "SEPARATOR" #f #f )
+  ( list (N_ "Grid Style: Cycle Dots/Mesh/Off")  '&options-grid #f )
+  ( list (N_ "Grid Snap: Cycle Grid/Resnap/Off") '&options-snap #f )
+  ( list "SEPARATOR" #f #f )
+  ( list (N_ "Feedback Mode: Outline/Box") '&options-action-feedback #f )
+  ( list (N_ "Net: Rubberband On/Off")     '&options-rubberband #f )
+  ( list (N_ "Net: Magnetic On/Off")       '&options-magneticnet #f )
+  ( list "SEPARATOR" #f #f )
+  ( list (N_ "_Coord Window") '&options-show-coord-window #f )
+  ( list (N_ "_Log Window")   '&options-show-log-window #f )
+)
+) ; options-menu-items
+
+
+( define netlist-menu-items
+( list
+  ( list (N_ "_1 allegro") '&netlist-allegro #f )
+)
+) ; netlist-menu-items
+
+
+( define help-menu-items
+( list
+  ( list (N_ "User _Guide")    '&help-guide  "gtk-help" )
+  ( list (N_ "_FAQ")           '&help-faq    "help-faq" )
+  ( list (N_ "Docu_mentation") '&help-manual "help-browser" )
+  ( list (N_ "_Wiki")          '&help-wiki   "web-browser" )
+  ( list "SEPARATOR" #f #f )
+  ( list (N_ "Find Component D_ocumentation") '&hierarchy-documentation "symbol-datasheet" )
+  ( list "SEPARATOR" #f #f )
+  ( list (N_ "_Hotkeys...")  '&help-hotkeys "preferences-desktop-keyboard-shortcuts" )
+  ( list (N_ "_About")       '&help-about   "gtk-about" )
+)
+) ; help-menu-items
+
+
 
 ;
 ; Now actually add the menus.  The order here defines the order in which
 ; the menus appear in the top menu bar.
 ;
-(add-menu (N_ "_File") file-menu-items)
-(add-menu (N_ "_Edit") edit-menu-items)
-;(add-menu (N_ "_Buffer") buffer-menu-items)
-(add-menu (N_ "_View") view-menu-items)
-(add-menu (N_ "_Page") page-menu-items)
-(add-menu (N_ "_Add") add-menu-items)
-(add-menu (N_ "Hie_rarchy") hierarchy-menu-items)
-(add-menu (N_ "A_ttributes") attributes-menu-items)
-(add-menu (N_ "_Options") options-menu-items)
-(add-menu (N_ "_Netlist") netlist-menu-items)
-(add-menu (N_ "_Help") help-menu-items)
+( add-menu (N_ "_File")       file-menu-items )
+( add-menu (N_ "_Edit")       edit-menu-items )
+; ( add-menu (N_ "_Buffer")     buffer-menu-items )
+( add-menu (N_ "_View")       view-menu-items )
+( add-menu (N_ "_Page")       page-menu-items )
+( add-menu (N_ "_Add")        add-menu-items )
+( add-menu (N_ "Hie_rarchy")  hierarchy-menu-items )
+( add-menu (N_ "A_ttributes") attributes-menu-items )
+( add-menu (N_ "_Options")    options-menu-items )
+( add-menu (N_ "_Netlist")    netlist-menu-items )
+( add-menu (N_ "_Help")       help-menu-items )
 

--- a/schematic/scheme/conf/schematic/menu.scm
+++ b/schematic/scheme/conf/schematic/menu.scm
@@ -102,28 +102,47 @@
 ) ; buffer-menu-items
 
 
-( define view-menu-items
-( list
-  ( list (N_ "Side Dock")           '&view-sidebar           #f )
-  ( list (N_ "Bottom Dock")         '&view-status            #f )
-  ( list "SEPARATOR" #f #f )
-  ( list (N_ "Find Text Results")   '&view-find-text-state   #f )
-  ( list "SEPARATOR" #f #f )
-  ( list (N_ "_Redraw")             '&view-redraw            "gtk-refresh" )
-  ( list (N_ "_Pan")                '&view-pan               #f )
-  ( list (N_ "Zoom _Box")           '&view-zoom-box          #f )
-  ( list (N_ "Zoom _Extents")       '&view-zoom-extents      "gtk-zoom-fit" )
-  ( list (N_ "Zoom _In")            '&view-zoom-in           "gtk-zoom-in" )
-  ( list (N_ "Zoom _Out")           '&view-zoom-out          "gtk-zoom-out" )
-  ( list (N_ "Zoom _Full")          '&view-zoom-full         #f )
-  ( list "SEPARATOR" #f #f )
-  ( list (N_ "_Dark Color Scheme")  '&view-dark-colors       #f )
-  ( list (N_ "_Light Color Scheme") '&view-light-colors      #f )
-  ( list (N_ "B_W Color Scheme")    '&view-bw-colors         #f )
-  ( list "SEPARATOR" #f #f )
-  ( list (N_ "Color Scheme Editor...") '&view-color-edit     #f )
-)
-) ; view-menu-items
+( define ( view-menu-items )
+( let*
+  (
+  ( grp "schematic.gui" )
+  ( key "use-docks" )
+  ( cfg ( path-config-context (getcwd) ) )
+  ( val ( if cfg (config-boolean cfg grp key) #f ) )
+  )
+
+  ( define ( opt-item item )
+    ; return:
+    ( if val
+      item ; if
+      '()  ; else
+    )
+  )
+
+  ; return:
+  ( list
+    ( opt-item (list (N_ "Side Dock")   '&view-sidebar #f) )
+    ( opt-item (list (N_ "Bottom Dock") '&view-status  #f) )
+    ( opt-item (list "SEPARATOR" #f #f) )
+    ( list (N_ "Find Text Results")   '&view-find-text-state   #f )
+    ( list "SEPARATOR" #f #f )
+    ( list (N_ "_Redraw")             '&view-redraw            "gtk-refresh" )
+    ( list (N_ "_Pan")                '&view-pan               #f )
+    ( list (N_ "Zoom _Box")           '&view-zoom-box          #f )
+    ( list (N_ "Zoom _Extents")       '&view-zoom-extents      "gtk-zoom-fit" )
+    ( list (N_ "Zoom _In")            '&view-zoom-in           "gtk-zoom-in" )
+    ( list (N_ "Zoom _Out")           '&view-zoom-out          "gtk-zoom-out" )
+    ( list (N_ "Zoom _Full")          '&view-zoom-full         #f )
+    ( list "SEPARATOR" #f #f )
+    ( list (N_ "_Dark Color Scheme")  '&view-dark-colors       #f )
+    ( list (N_ "_Light Color Scheme") '&view-light-colors      #f )
+    ( list (N_ "B_W Color Scheme")    '&view-bw-colors         #f )
+    ( list "SEPARATOR" #f #f )
+    ( list (N_ "Color Scheme Editor...") '&view-color-edit     #f )
+  )
+
+) ; let
+) ; view-menu-items()
 
 
 ( define ( page-menu-items )
@@ -264,7 +283,7 @@
 ( add-menu (N_ "_File")       file-menu-items )
 ( add-menu (N_ "_Edit")       edit-menu-items )
 ; ( add-menu (N_ "_Buffer")     buffer-menu-items )
-( add-menu (N_ "_View")       view-menu-items )
+( add-menu (N_ "_View")       (view-menu-items) )
 ( add-menu (N_ "_Page")       (page-menu-items) )
 ( add-menu (N_ "_Add")        add-menu-items )
 ( add-menu (N_ "Hie_rarchy")  hierarchy-menu-items )

--- a/schematic/src/x_menus.c
+++ b/schematic/src/x_menus.c
@@ -130,10 +130,28 @@ get_main_menu(GschemToplevel *w_current)
     gtk_widget_show(menu_item);
 
     scm_items_len = (int) scm_ilength (scm_items);
-    for (j = 0 ; j < scm_items_len; j++) {
 
+
+    /* cycle through menu items:
+    */
+    for (j = 0 ; j < scm_items_len; j++)
+    {
       scm_index = scm_from_int (j);
+
+      /* menu item:
+      */
       scm_item = scm_list_ref (scm_items, scm_index);
+
+      /* check if [scm_item] is valid, it must be a
+       * ( list TEXT ACTION ICON ):
+      */
+      if ( scm_is_false (scm_list_p (scm_item)) )
+        continue;
+
+      if ( scm_to_int (scm_length (scm_item)) != 3 )
+        continue;
+
+
       scm_item_name = SCM_CAR (scm_item);
       scm_item_func = SCM_CADR (scm_item);
       scm_item_stock = scm_is_pair (SCM_CDDR (scm_item)) ?


### PR DESCRIPTION
- Show `Side Dock` and `Bottom Dock` menu items in the
`View` menu only if `[schematic.gui]::use-docks` is set to `true`.

- Show `Next Tab` and `Previous Tab` menu items in the
`Page` menu only if `[schematic.gui]::use-tabs` is set to `true`.

-  Do not use docking widgets by default (`[schematic.gui]::use-docks=false`)
(#369)