### PR TITLE
Rewrite attributes attachment code in lepton-schematic

### DIFF
--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -346,7 +346,6 @@ void i_callback_add_pin(gpointer data, guint callback_action, GtkWidget *widget)
 void i_callback_hierarchy_down_schematic(gpointer data, guint callback_action, GtkWidget *widget);
 void i_callback_hierarchy_down_symbol(gpointer data, guint callback_action, GtkWidget *widget);
 void i_callback_hierarchy_up(gpointer data, guint callback_action, GtkWidget *widget);
-void i_callback_attributes_attach(gpointer data, guint callback_action, GtkWidget *widget);
 void i_callback_attributes_show_name(gpointer data, guint callback_action, GtkWidget *widget);
 void i_callback_attributes_show_value(gpointer data, guint callback_action, GtkWidget *widget);
 void i_callback_attributes_show_both(gpointer data, guint callback_action, GtkWidget *widget);

--- a/schematic/scheme/gschem/builtins.scm
+++ b/schematic/scheme/gschem/builtins.scm
@@ -312,8 +312,74 @@
 ;; -------------------------------------------------------------------
 ;;;; Attribute actions
 
-(define-action-public (&attributes-attach #:label (_ "Attach Attributes") #:icon "attribute-attach")
-  (%attributes-attach))
+( define-action-public
+  ( &attributes-attach
+    #:label (_ "Attach Attributes")
+    #:icon  "attribute-attach"
+  )
+
+  ( let*
+    (
+    ( page ( active-page ) )
+    ( sel  ( if page (page-selection page) '() ) )
+    )
+
+    ( define ( can-attach-to? obj )
+      ; return:
+      ( and
+        ( object? obj )
+        ( not (text? obj) )
+      )
+    )
+
+    ( define ( attachable-attr? obj )
+      ; return:
+      ( and
+        ( attribute?    obj )           ; if it's attribute
+        ( text-visible? obj )           ; if it's visible
+        ( not (attrib-attachment obj) ) ; and does not already attached
+      )
+    )
+
+    ( define ( attach-attr obj attr )
+      ( attach-attribs! obj attr )
+      ( log! 'message (_ "Attribute attached: [~a]") (text-string attr) )
+      ( deselect-object! attr )
+    )
+
+
+    ( let*
+      (
+      ( obj   (find   can-attach-to?   sel) )
+      ( attrs (filter attachable-attr? sel) )
+      ( attrs-not-empty ( not (null? attrs) ) )
+      )
+
+      ( when ( and obj attrs-not-empty )
+
+        ( for-each
+        ( lambda( attr )
+          ( attach-attr obj attr )
+        )
+        attrs
+        )
+
+        ( deselect-object! obj )
+
+        ( set-page-dirty! page )
+        ( run-hook attach-attribs-hook attrs )
+        ( undo-save-state )
+
+      ) ; when
+
+      ; return:
+      attrs
+
+    ) ; let
+
+  ) ; let
+
+) ; &attributes-attach action
 
 
 

--- a/schematic/src/g_builtins.c
+++ b/schematic/src/g_builtins.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 2013 Peter Brett <peter@peter-b.co.uk>
  * Copyright (C) 2013-2015 gEDA Contributors
- * Copyright (C) 2017-2018 Lepton EDA Contributors
+ * Copyright (C) 2017-2019 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -133,7 +133,6 @@ static struct BuiltinInfo builtins[] = {
   { "%hierarchy-down-schematic",     0, 0, 0, (SCM (*) ()) g_keys_hierarchy_down_schematic },
   { "%hierarchy-down-symbol",        0, 0, 0, (SCM (*) ()) g_keys_hierarchy_down_symbol },
   { "%hierarchy-up",                 0, 0, 0, (SCM (*) ()) g_keys_hierarchy_up },
-  { "%attributes-attach",            0, 0, 0, (SCM (*) ()) g_keys_attributes_attach },
   { "%attributes-show-name",         0, 0, 0, (SCM (*) ()) g_keys_attributes_show_name },
   { "%attributes-show-value",        0, 0, 0, (SCM (*) ()) g_keys_attributes_show_value },
   { "%attributes-show-both",         0, 0, 0, (SCM (*) ()) g_keys_attributes_show_both },

--- a/schematic/src/g_keys.c
+++ b/schematic/src/g_keys.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2015 gEDA Contributors
- * Copyright (C) 2017-2018 Lepton EDA Contributors
+ * Copyright (C) 2017-2019 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,21 +17,8 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
+
 #include <config.h>
-
-#include <stdio.h>
-#include <sys/stat.h>
-#include <ctype.h>
-#ifdef HAVE_STRING_H
-#include <string.h>
-#endif
-#ifdef HAVE_STDLIB_H
-#include <stdlib.h>
-#endif
-#ifdef HAVE_UNISTD_H
-#include <unistd.h>
-#endif
-
 #include "gschem.h"
 
 #include <gdk/gdkkeysyms.h>
@@ -172,7 +159,6 @@ DEFINE_G_KEYS(add_pin)
 DEFINE_G_KEYS(hierarchy_down_schematic)
 DEFINE_G_KEYS(hierarchy_down_symbol)
 DEFINE_G_KEYS(hierarchy_up)
-DEFINE_G_KEYS(attributes_attach)
 DEFINE_G_KEYS(attributes_show_name)
 DEFINE_G_KEYS(attributes_show_value)
 DEFINE_G_KEYS(attributes_show_both)

--- a/schematic/src/g_register.c
+++ b/schematic/src/g_register.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2015 gEDA Contributors
- * Copyright (C) 2017-2018 Lepton EDA Contributors
+ * Copyright (C) 2017-2019 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,20 +17,8 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
+
 #include <config.h>
-
-#include <stdio.h>
-#include <sys/stat.h>
-#ifdef HAVE_STDLIB_H
-#include <stdlib.h>
-#endif
-#ifdef HAVE_ASSERT_H
-#include <assert.h>
-#endif
-#ifdef HAVE_UNISTD_H
-#include <unistd.h>
-#endif
-
 #include "gschem.h"
 
 /*! \brief */
@@ -213,7 +201,6 @@ static struct gsubr_t gschem_funcs[] = {
   { "hierarchy-down-schematic",     0, 0, 0, (SCM (*) ()) g_keys_hierarchy_down_schematic },
   { "hierarchy-down-symbol",        0, 0, 0, (SCM (*) ()) g_keys_hierarchy_down_symbol },
   { "hierarchy-up",                 0, 0, 0, (SCM (*) ()) g_keys_hierarchy_up },
-  { "attributes-attach",            0, 0, 0, (SCM (*) ()) g_keys_attributes_attach },
   { "attributes-show-name",         0, 0, 0, (SCM (*) ()) g_keys_attributes_show_name },
   { "attributes-show-value",        0, 0, 0, (SCM (*) ()) g_keys_attributes_show_value },
   { "attributes-show-both",         0, 0, 0, (SCM (*) ()) g_keys_attributes_show_both },

--- a/schematic/src/i_callbacks.c
+++ b/schematic/src/i_callbacks.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2016 gEDA Contributors
- * Copyright (C) 2017-2018 Lepton EDA Contributors
+ * Copyright (C) 2017-2019 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,20 +17,10 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
+
 #include <config.h>
-
-#include <stdio.h>
-#ifdef HAVE_STRING_H
-#include <string.h>
-#endif
-#ifdef HAVE_UNISTD_H
-#include <unistd.h>
-#endif
-
 #include "gschem.h"
 
-/*! \brief */
-#define DELIMITERS ", "
 
 /*! \todo Finish function documentation!!!
  *  \brief
@@ -2325,61 +2315,6 @@ DEFINE_I_CALLBACK(hierarchy_up)
     x_window_set_current_page(w_current, up_page);
   }
 }
-
-/*! \section attributes-menu Attributes Menu Callback Functions */
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
-DEFINE_I_CALLBACK(attributes_attach)
-{
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-  OBJECT *first_object;
-  GList *s_current;
-  GList *attached_objects = NULL;
-
-  g_return_if_fail (w_current != NULL);
-
-  /* This is a new addition 3/15 to prevent this from executing
-   * inside an action */
-  if (w_current->inside_action) {
-    return;
-  }
-
-  /* skip over head */
-  s_current = geda_list_get_glist( gschem_toplevel_get_toplevel (w_current)->page_current->selection_list );
-  if (!s_current) {
-    return;
-  }
-
-  first_object = (OBJECT *) s_current->data;
-  if (!first_object) {
-    return;
-  }
-
-  /* skip over first object */
-  s_current = g_list_next(s_current);
-  while (s_current != NULL) {
-    OBJECT *object = (OBJECT*) s_current->data;
-    if (object != NULL) {
-      o_attrib_attach (gschem_toplevel_get_toplevel (w_current), object, first_object, TRUE);
-      attached_objects = g_list_prepend (attached_objects, object);
-      gschem_toplevel_get_toplevel (w_current)->page_current->CHANGED=1;
-    }
-    s_current = g_list_next(s_current);
-  }
-
-  if (attached_objects != NULL) {
-    g_run_hook_object_list (w_current, "%attach-attribs-hook",
-                            attached_objects);
-    g_list_free (attached_objects);
-  }
-
-  o_undo_savestate_old(w_current, UNDO_ALL);
-}
-
-
 
 /*! \todo Finish function documentation!!!
  *  \brief


### PR DESCRIPTION
Rewrite attributes attachment code in Scheme,
improve existing behavior:
- attributes can be attached to any non-text object
- act on visible attributes only
- do nothing if attributes are already attached or
no attributes were selected
- print successfully attached attributes to the log
- deselect successfully attached attributes and
the object they are attached to

Changes are similar to #377 
