### PR TITLE
Don't use some internal attributes in forming generic maps in the vams backend.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -290,6 +290,12 @@ Notable changes in Lepton EDA 1.9.8
   - Wrong netlister name has been fixed.
   - generate_netlist.scm has been moved to the example directory.
 
+- A list of attributes that cannot form generic has been
+  introduced in the `vams` backend code.  Two internal (or
+  abstract) attributes, `slot=` and `net=`, are no longer used in
+  forming VHDL generic maps, since they are intended for internal
+  use by netlister itself.
+
 - The `allegro` backend has been refactored so obsolete procedures
   are no longer used in it.
 

--- a/netlist/scheme/backend/gnet-vams.scm
+++ b/netlist/scheme/backend/gnet-vams.scm
@@ -608,7 +608,8 @@ ARCHITECTURE ~A OF ~A IS
 (define (vams:write-generic-map uref)
   (define non-generics '(refdes
                          source
-                         architecture))
+                         architecture
+                         net))
 
   (define (permitted-attrib->pair attrib)
     (let ((value (gnetlist:get-package-attribute uref attrib)))

--- a/netlist/scheme/backend/gnet-vams.scm
+++ b/netlist/scheme/backend/gnet-vams.scm
@@ -606,13 +606,14 @@ ARCHITECTURE ~A OF ~A IS
 ;; requires the output-port and a uref
 
 (define (vams:write-generic-map uref)
+  (define non-generics '(refdes
+                         source
+                         architecture))
 
   (define (permitted-attrib->pair attrib)
     (let ((value (gnetlist:get-package-attribute uref attrib)))
-      (and (not (or (string=? attrib "refdes")
-                    (string=? attrib "source")
-                    (string=? attrib "architecture")
-                    (string=? "unknown" value)))
+      (and (not (or (memq (string->symbol attrib) non-generics)
+                    (unknown? value)))
            (cons attrib value))))
 
   (define (write-attribute attrib-value)

--- a/netlist/scheme/backend/gnet-vams.scm
+++ b/netlist/scheme/backend/gnet-vams.scm
@@ -609,7 +609,8 @@ ARCHITECTURE ~A OF ~A IS
   (define non-generics '(refdes
                          source
                          architecture
-                         net))
+                         net
+                         slot))
 
   (define (permitted-attrib->pair attrib)
     (let ((value (gnetlist:get-package-attribute uref attrib)))

--- a/netlist/tests/common/SlottedOpamps-vams.out
+++ b/netlist/tests/common/SlottedOpamps-vams.out
@@ -16,7 +16,6 @@ BEGIN
 
   U1 : ENTITY LM324
 	GENERIC MAP (
-			slot => 1, 
 			device => LM324)
 	PORT MAP (	1 => samenet_output_c,
 			2 => minusin_slot1_pin_b,

--- a/netlist/tests/common/netattrib-vams.out
+++ b/netlist/tests/common/netattrib-vams.out
@@ -27,8 +27,6 @@ BEGIN
 			2 => OPEN);
 
   U100 : ENTITY 7400
-	GENERIC MAP (
-			net => netattrib:5)
 	PORT MAP (	1 => OPEN,
 			2 => OPEN,
 			3 => one,
@@ -37,8 +35,6 @@ BEGIN
 			14 => Vcc);
 
   U200 : ENTITY 7404
-	GENERIC MAP (
-			net => XGND:7)
 	PORT MAP (	1 => one,
 			2 => netattrib,
 			7 => XGND,
@@ -52,8 +48,7 @@ BEGIN
 
   U400 : ENTITY 7400
 	GENERIC MAP (
-			slot => 1, 
-			net => signal3:3)
+			slot => 1)
 	PORT MAP (	1 => signal1,
 			2 => DGND,
 			3 => signal3,
@@ -69,8 +64,7 @@ BEGIN
 
   U500 : ENTITY 7400
 	GENERIC MAP (
-			slot => 1, 
-			net => 3.3V:14)
+			slot => 1)
 	PORT MAP (	1 => signal1,
 			2 => OPEN,
 			3 => unnamed_net4,

--- a/netlist/tests/common/netattrib-vams.out
+++ b/netlist/tests/common/netattrib-vams.out
@@ -47,8 +47,6 @@ BEGIN
 			14 => Vcc);
 
   U400 : ENTITY 7400
-	GENERIC MAP (
-			slot => 1)
 	PORT MAP (	1 => signal1,
 			2 => DGND,
 			3 => signal3,
@@ -63,8 +61,6 @@ BEGIN
 			14 => Vcc);
 
   U500 : ENTITY 7400
-	GENERIC MAP (
-			slot => 1)
 	PORT MAP (	1 => signal1,
 			2 => OPEN,
 			3 => unnamed_net4,

--- a/netlist/tests/common/singlenet-vams.out
+++ b/netlist/tests/common/singlenet-vams.out
@@ -10,8 +10,6 @@ BEGIN
 -- Architecture statement part
 
   U100 : ENTITY 7400
-	GENERIC MAP (
-			slot => 2)
 	PORT MAP (	1 => SING_N_2,
 			2 => OPEN,
 			3 => SING_N_2,

--- a/netlist/tests/hierarchy-vams.out
+++ b/netlist/tests/hierarchy-vams.out
@@ -21,24 +21,18 @@ BEGIN
 			14 => Vcc);
 
   U2 : ENTITY 7404
-	GENERIC MAP (
-			net => U2_1_to_E-net:1)
 	PORT MAP (	1 => U2_1_to_E-net,
 			2 => same_for_all,
 			7 => GND,
 			14 => Vcc);
 
   Utop/Umiddle/Urock/Qrock : ENTITY PNP_TRANSISTOR
-	GENERIC MAP (
-			net => BUGA:D)
 	PORT MAP (	B => U1_2_to_B,
 			C => Utop/Umiddle/Urock/-12V,
 			D => Utop/Umiddle/Urock/BUGA,
 			E => U2_1_to_E-net);
 
   Uunder/Umiddle/Urock/Qrock : ENTITY PNP_TRANSISTOR
-	GENERIC MAP (
-			net => BUGA:D)
 	PORT MAP (	B => U1_2_to_B,
 			C => Uunder/Umiddle/Urock/-12V,
 			D => Uunder/Umiddle/Urock/BUGA,

--- a/netlist/tests/hierarchy3-vams.out
+++ b/netlist/tests/hierarchy3-vams.out
@@ -34,16 +34,12 @@ BEGIN
 			14 => Vcc);
 
   Utop/Umiddle/Urock/Qrock : ENTITY PNP_TRANSISTOR
-	GENERIC MAP (
-			net => BUGA:D)
 	PORT MAP (	B => U1_2_to_B,
 			C => Utop/Umiddle/Urock/-12V,
 			D => Utop/Umiddle/Urock/BUGA,
 			E => U2_1_to_E);
 
   Uunder/Umiddle/Urock/Qrock : ENTITY PNP_TRANSISTOR
-	GENERIC MAP (
-			net => BUGA:D)
 	PORT MAP (	B => U1_2_to_B,
 			C => Uunder/Umiddle/Urock/-12V,
 			D => Uunder/Umiddle/Urock/BUGA,


### PR DESCRIPTION
Some internal attributes, such as `net` or `slot` are intended for internal using by netlister, they should not form VHDL generic maps, so they are now filtered and are not exposed in *vams* output netlists.