### PR TITLE
Fix vams backend output and its example

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -290,11 +290,19 @@ Notable changes in Lepton EDA 1.9.8
   - Wrong netlister name has been fixed.
   - generate_netlist.scm has been moved to the example directory.
 
-- A list of attributes that cannot form generic has been
-  introduced in the `vams` backend code.  Two internal (or
-  abstract) attributes, `slot=` and `net=`, are no longer used in
-  forming VHDL generic maps, since they are intended for internal
-  use by netlister itself.
+- The `vams` backend code has been fixed as follows:
+
+  - The code does no longer emit Scheme return values of
+    procedures, which previously mangled the output.
+
+  - The output of generic and port definitions is now going into
+    appropriate place.
+
+  - A list of attributes that cannot form generics does no longer
+    appear in the output.  Two internal (or abstract) attributes,
+    `slot=` and `net=`, are no longer used in forming VHDL generic
+    maps, since they are intended for internal use by netlister
+    itself.
 
 - The `allegro` backend has been refactored so obsolete procedures
   are no longer used in it.

--- a/netlist/examples/vams/generate_netlist.scm
+++ b/netlist/examples/vams/generate_netlist.scm
@@ -89,10 +89,7 @@
        "-g"
        "vams"
        (get-selected-filename)
-     )
-
-     (newline)
-     )))
+       ))))
 
 
 ;; HELP FUNCTIONS

--- a/netlist/examples/vams/generate_netlist.scm
+++ b/netlist/examples/vams/generate_netlist.scm
@@ -38,16 +38,20 @@
 
 (define generate-netlist
   (lambda ()
-    (let* ((command "")
-	   (source-file (page-filename (active-page)))
-	   (source-file-length (string-length source-file))
-           (target-file (schematic-name->vhdl-name source-file)))
+    (let* ((source-file (page-filename (active-page)))
+	   (target-file (schematic-name->vhdl-name source-file))
+           (command (string-append "lepton-netlist"
+                                   " -c "
+                                   "'(chdir \"..\")'"
+                                   " -o "
+                                   vhdl-path
+                                   "/"
+                                   target-file
+                                   " -g " "vams "
+                                   source-file)))
 
       ;;generating the complex gnetlist command
       (display (getcwd))
-      (set! command "lepton-netlist -c '(chdir \"..\") (display (getcwd)) (newline)'")
-      (set! command (string-append command " -o " vhdl-path "/" target-file))
-      (set! command (string-append command " -g vams " source-file))
       (display "\ngenerating netlist from current schematic\n")
       (display command)
       (newline)

--- a/netlist/examples/vams/generate_netlist.scm
+++ b/netlist/examples/vams/generate_netlist.scm
@@ -26,19 +26,23 @@
 
 (use-modules (geda page) (geda object) (geda attrib))
 
+;; Generate a sensible output-filename
+;; <old-path>/<old-basefilename>.vhdl.
+(define (schematic-name->vhdl-name name)
+  (string-join
+   (reverse
+    (cons "vhdl"
+          (cdr
+           (reverse
+            (string-split (basename name) #\.)))))
+   "."))
+
 (define generate-netlist
   (lambda ()
     (let* ((command "")
 	   (source-file (page-filename (active-page)))
 	   (source-file-length (string-length source-file))
-
-	   ;;generate a sensible output-filename (<old-path>/<old-basefilename>.vhdl)
-	   (target-file (string-append
-			 (substring source-file
-				    (+ (string-rindex source-file #\/ 0
-						      (string-length source-file)) 1)
-				    (- (string-length source-file) 4))
-			 ".vhdl")))
+           (target-file (schematic-name->vhdl-name source-file)))
 
       ;;generating the complex gnetlist command
       (display (getcwd))

--- a/netlist/examples/vams/generate_netlist.scm
+++ b/netlist/examples/vams/generate_netlist.scm
@@ -42,7 +42,7 @@
 
       ;;generating the complex gnetlist command
       (display (getcwd))
-      (set! command "lepton-netlist -w -c '(chdir \"..\") (display (getcwd)) (newline)'")
+      (set! command "lepton-netlist -c '(chdir \"..\") (display (getcwd)) (newline)'")
       (set! command (string-append command " -o " vhdl-path "/" target-file))
       (set! command (string-append command " -g vams " source-file))
       (display "\ngenerating netlist from current schematic\n")
@@ -77,7 +77,6 @@
 
      (system*
        "lepton-netlist"
-       "-w"
        "-c"
        (format #f "(chdir \"..\")~
                    (define top-attribs '~a)~

--- a/netlist/examples/vams/generate_netlist.scm
+++ b/netlist/examples/vams/generate_netlist.scm
@@ -37,6 +37,17 @@
             (string-split (basename name) #\.)))))
    "."))
 
+(define (schematic-name->entity-vhdl-name name)
+  (string-append
+   (substring name
+              (if (string-rindex name #\/ 0
+                                 (string-length name))
+                  (+ (string-rindex name #\/ 0
+                                    (string-length name)) 1)
+                  0)
+              (- (string-length name) 4))
+   ".vhdl"))
+
 (define generate-netlist
   (lambda ()
     (let* ((command "")
@@ -68,16 +79,7 @@
 	  (source-file (which-source-file top-attribs))
 
 	  ;; generates the target-file, like <source-filebasename>.vhdl
-	  (target-file (string-append
-			(substring source-file
-				   (if (string-rindex source-file #\/ 0
-						     (string-length source-file))
-				       (+ (string-rindex source-file #\/ 0
-						     (string-length source-file)) 1)
-				       0)
-				   (- (string-length source-file) 4))
-			".vhdl")))
-
+	  (target-file (schematic-name->entity-vhdl-name source-file)))
 
      (system*
        "lepton-netlist"

--- a/netlist/examples/vams/generate_netlist.scm
+++ b/netlist/examples/vams/generate_netlist.scm
@@ -92,13 +92,7 @@
      )
 
      (newline)
-
-     ;; not important
-     ;;(set! command (string-append "dtpad " vhdl-path "/" target-file " &"))
-     ;;(if (null? top-attribs)
-     ;;	 (system command))
-
-)))
+     )))
 
 
 ;; HELP FUNCTIONS

--- a/netlist/examples/vams/generate_netlist.scm
+++ b/netlist/examples/vams/generate_netlist.scm
@@ -26,8 +26,7 @@
 
 (use-modules (geda page) (geda object) (geda attrib))
 
-;; Generate a sensible output-filename
-;; <old-path>/<old-basefilename>.vhdl.
+;;; Generate vhdl file name for given schematic NAME.
 (define (schematic-name->vhdl-name name)
   (string-join
    (reverse
@@ -36,17 +35,6 @@
            (reverse
             (string-split (basename name) #\.)))))
    "."))
-
-(define (schematic-name->entity-vhdl-name name)
-  (string-append
-   (substring name
-              (if (string-rindex name #\/ 0
-                                 (string-length name))
-                  (+ (string-rindex name #\/ 0
-                                    (string-length name)) 1)
-                  0)
-              (- (string-length name) 4))
-   ".vhdl"))
 
 (define generate-netlist
   (lambda ()
@@ -79,7 +67,7 @@
 	  (source-file (which-source-file top-attribs))
 
 	  ;; generates the target-file, like <source-filebasename>.vhdl
-	  (target-file (schematic-name->entity-vhdl-name source-file)))
+	  (target-file (schematic-name->vhdl-name source-file)))
 
      (system*
        "lepton-netlist"

--- a/netlist/examples/vams/generate_netlist.scm
+++ b/netlist/examples/vams/generate_netlist.scm
@@ -114,9 +114,8 @@
   (lambda (top-attribs)
     (if (not (null? top-attribs))
 	(if (string-prefix? "source=" (car top-attribs))
-	    (begin
-	      (append (substring (car top-attribs) 7
-				 (string-length (car top-attribs)))))
+	    (append (substring (car top-attribs) 7
+                               (string-length (car top-attribs))))
 	    (which-source-file (cdr top-attribs)))
 	(append (get-selected-filename)))))
 

--- a/netlist/scheme/backend/gnet-vams.scm
+++ b/netlist/scheme/backend/gnet-vams.scm
@@ -150,7 +150,7 @@
 ;;; not really clever, but a first solution
 
 (define (vams:write-context-clause)
-  (format #t "LIBRARY ieee,disciplines;
+  (format #f "LIBRARY ieee,disciplines;
 USE ieee.math_real.all;
 USE ieee.math_real.all;
 USE work.electrical_system.all;

--- a/netlist/scheme/backend/gnet-vams.scm
+++ b/netlist/scheme/backend/gnet-vams.scm
@@ -212,7 +212,7 @@ USE work.all;
 
 ENTITY ~A IS
 ~A~
-~A
+~A~
 END ENTITY ~A;
 
 "
@@ -298,40 +298,29 @@ END ENTITY ~A;
 ;;; this function writes the port-clause in the entity-declarartion
 ;;; It requires a list of ports. ports stand for a list of all
 ;;; pin-attributes.
-
-(define (vams:write-port-clause port-list)
-  (if (not (null? port-list))
-      (begin
-        (display "\t PORT (\t\t")
-        (if (list? (car port-list))
-            (format #t "~A \t~A \t: ~A \t~A"
-		    (cadar port-list)
-		    (caar port-list)
-		    (if (equal? (cadar port-list) 'quantity)
-			(car (cdddar port-list))
-			"")
-		    (caddar port-list)))
-        (vams:write-port-list (cdr port-list))
-        (display " );\n"))))
-
 ;;; This little routine writes a single pin on the port-clause.
 ;;; It requires a list containing (port_name, port_object, port_type, port_mode)
 ;;; such like
 ;;; ((heat quantity thermal in) (base terminal electrical unknown) .. )
 
-(define (vams:write-port-list port-list)
-  (if (not (null? port-list))
-      (begin
-        (display ";\n\t\t\t")
-        (if (equal? (length (car port-list)) 4)
-            (format #t "~A \t~A \t: ~A \t~A"
-		    (cadar port-list)
-		    (caar port-list)
-		    (if (equal? (cadar port-list) 'quantity)
-			(car (cdddar port-list))
-			"")
-		    (caddar port-list)))
-        (vams:write-port-list (cdr port-list)))))
+
+(define (vams:write-port-clause port-list)
+  (define (format-port port)
+    (if (equal? (length port) 4)
+	  (let ((name (first port))
+		(object (second port))
+		(type (third port))
+		(mode (fourth port)))
+	    (format #f "~A \t~A \t: ~A \t~A"
+		    object
+		    name
+		    (if (equal? object 'quantity) mode "")
+		    type))
+	  ""))
+  (if (null? port-list)
+      ""
+      (format #f "\t PORT (\t\t~A );\n"
+              (string-join (map format-port port-list) ";\n\t\t\t"))))
 
 
 

--- a/netlist/scheme/backend/gnet-vams.scm
+++ b/netlist/scheme/backend/gnet-vams.scm
@@ -211,7 +211,7 @@ USE work.all;
 -- Entity declaration --
 
 ENTITY ~A IS
-~A
+~A~
 ~A
 END ENTITY ~A;
 
@@ -282,28 +282,17 @@ END ENTITY ~A;
 ;;; its values, such like ((power 12.2) (velocity 233.34))
 
 (define (vams:write-generic-clause generic-list)
-  (if (not (null? generic-list))
-      (begin
-        (display "\t GENERIC (")
-        (display "\t")
-        (if (= 2 (length (car generic-list)))
-            (begin
-              (display (caar generic-list))
-              (display " : REAL := ")
-              (display (cadar generic-list))))
-        (vams:write-generic-list (cdr generic-list))
-        (display " );\n"))))
+  (define (format-generic generic)
+    (if (= 2 (length generic))
+	(let ((name (first generic))
+	      (value (second generic)))
+	  (format #f "~A : REAL := ~A" name value))
+	""))
+  (if (null? generic-list)
+      ""
+      (format #f "\t GENERIC (\t~A );\n"
+              (string-join (map format-generic generic-list) ";\n\t\t\t"))))
 
-(define (vams:write-generic-list generic-list)
-  (if (not (null? generic-list))
-      (begin
-        (display ";\n\t\t\t")
-        (if (= 2 (length (car generic-list)))
-            (begin
-              (display (caar generic-list))
-              (display " : REAL := ")
-              (display (cadar generic-list))))
-        (vams:write-generic-list (cdr generic-list)))))
 
 
 ;;; this function writes the port-clause in the entity-declarartion

--- a/netlist/tests/common/JD-vams-device.out
+++ b/netlist/tests/common/JD-vams-device.out
@@ -3,13 +3,12 @@ USE ieee.math_real.all;
 USE ieee.math_real.all;
 USE work.electrical_system.all;
 USE work.all;
-	 GENERIC (	device : REAL := 7404;
-			footprint : REAL := DIP14 );
 #t
 -- Entity declaration --
 
 ENTITY unknown IS
-#<unspecified>
+	 GENERIC (	device : REAL := 7404;
+			footprint : REAL := DIP14 );
 #<unspecified>
 END ENTITY unknown;
 

--- a/netlist/tests/common/JD-vams-device.out
+++ b/netlist/tests/common/JD-vams-device.out
@@ -9,6 +9,5 @@ USE work.all;
 ENTITY unknown IS
 	 GENERIC (	device : REAL := 7404;
 			footprint : REAL := DIP14 );
-#<unspecified>
 END ENTITY unknown;
 

--- a/netlist/tests/common/JD-vams-device.out
+++ b/netlist/tests/common/JD-vams-device.out
@@ -3,7 +3,7 @@ USE ieee.math_real.all;
 USE ieee.math_real.all;
 USE work.electrical_system.all;
 USE work.all;
-#t
+
 -- Entity declaration --
 
 ENTITY unknown IS

--- a/netlist/tests/common/JD-vams-entity.out
+++ b/netlist/tests/common/JD-vams-entity.out
@@ -8,6 +8,5 @@ USE work.all;
 
 ENTITY default_entity IS
 #<unspecified>
-#<unspecified>
 END ENTITY default_entity;
 

--- a/netlist/tests/common/JD-vams-entity.out
+++ b/netlist/tests/common/JD-vams-entity.out
@@ -7,6 +7,5 @@ USE work.all;
 -- Entity declaration --
 
 ENTITY default_entity IS
-#<unspecified>
 END ENTITY default_entity;
 

--- a/netlist/tests/common/JD-vams-entity.out
+++ b/netlist/tests/common/JD-vams-entity.out
@@ -3,7 +3,7 @@ USE ieee.math_real.all;
 USE ieee.math_real.all;
 USE work.electrical_system.all;
 USE work.all;
-#t
+
 -- Entity declaration --
 
 ENTITY default_entity IS

--- a/netlist/tests/common/SlottedOpamps-vams-device.out
+++ b/netlist/tests/common/SlottedOpamps-vams-device.out
@@ -3,6 +3,12 @@ USE ieee.math_real.all;
 USE ieee.math_real.all;
 USE work.electrical_system.all;
 USE work.all;
+#t
+-- Entity declaration --
+
+ENTITY LM324 IS
+	 GENERIC (	device : REAL := 7404;
+			footprint : REAL := DIP14 );
 	 PORT (		unknown 	1 	:  	unknown;
 			unknown 	2 	:  	unknown;
 			unknown 	3 	:  	unknown;
@@ -15,12 +21,5 @@ USE work.all;
 			unknown 	12 	:  	unknown;
 			unknown 	13 	:  	unknown;
 			unknown 	14 	:  	unknown );
-#t
--- Entity declaration --
-
-ENTITY LM324 IS
-	 GENERIC (	device : REAL := 7404;
-			footprint : REAL := DIP14 );
-#<unspecified>
 END ENTITY LM324;
 

--- a/netlist/tests/common/SlottedOpamps-vams-device.out
+++ b/netlist/tests/common/SlottedOpamps-vams-device.out
@@ -3,8 +3,6 @@ USE ieee.math_real.all;
 USE ieee.math_real.all;
 USE work.electrical_system.all;
 USE work.all;
-	 GENERIC (	device : REAL := 7404;
-			footprint : REAL := DIP14 );
 	 PORT (		unknown 	1 	:  	unknown;
 			unknown 	2 	:  	unknown;
 			unknown 	3 	:  	unknown;
@@ -21,7 +19,8 @@ USE work.all;
 -- Entity declaration --
 
 ENTITY LM324 IS
-#<unspecified>
+	 GENERIC (	device : REAL := 7404;
+			footprint : REAL := DIP14 );
 #<unspecified>
 END ENTITY LM324;
 

--- a/netlist/tests/common/SlottedOpamps-vams-device.out
+++ b/netlist/tests/common/SlottedOpamps-vams-device.out
@@ -3,7 +3,7 @@ USE ieee.math_real.all;
 USE ieee.math_real.all;
 USE work.electrical_system.all;
 USE work.all;
-#t
+
 -- Entity declaration --
 
 ENTITY LM324 IS

--- a/netlist/tests/common/SlottedOpamps-vams-entity.out
+++ b/netlist/tests/common/SlottedOpamps-vams-entity.out
@@ -8,6 +8,5 @@ USE work.all;
 
 ENTITY default_entity IS
 #<unspecified>
-#<unspecified>
 END ENTITY default_entity;
 

--- a/netlist/tests/common/SlottedOpamps-vams-entity.out
+++ b/netlist/tests/common/SlottedOpamps-vams-entity.out
@@ -7,6 +7,5 @@ USE work.all;
 -- Entity declaration --
 
 ENTITY default_entity IS
-#<unspecified>
 END ENTITY default_entity;
 

--- a/netlist/tests/common/SlottedOpamps-vams-entity.out
+++ b/netlist/tests/common/SlottedOpamps-vams-entity.out
@@ -3,7 +3,7 @@ USE ieee.math_real.all;
 USE ieee.math_real.all;
 USE work.electrical_system.all;
 USE work.all;
-#t
+
 -- Entity declaration --
 
 ENTITY default_entity IS

--- a/netlist/tests/common/TwoStageAmp-vams-device.out
+++ b/netlist/tests/common/TwoStageAmp-vams-device.out
@@ -3,13 +3,12 @@ USE ieee.math_real.all;
 USE ieee.math_real.all;
 USE work.electrical_system.all;
 USE work.all;
-	 GENERIC (	device : REAL := 7404;
-			footprint : REAL := DIP14 );
 #t
 -- Entity declaration --
 
 ENTITY unknown IS
-#<unspecified>
+	 GENERIC (	device : REAL := 7404;
+			footprint : REAL := DIP14 );
 #<unspecified>
 END ENTITY unknown;
 

--- a/netlist/tests/common/TwoStageAmp-vams-device.out
+++ b/netlist/tests/common/TwoStageAmp-vams-device.out
@@ -9,6 +9,5 @@ USE work.all;
 ENTITY unknown IS
 	 GENERIC (	device : REAL := 7404;
 			footprint : REAL := DIP14 );
-#<unspecified>
 END ENTITY unknown;
 

--- a/netlist/tests/common/TwoStageAmp-vams-device.out
+++ b/netlist/tests/common/TwoStageAmp-vams-device.out
@@ -3,7 +3,7 @@ USE ieee.math_real.all;
 USE ieee.math_real.all;
 USE work.electrical_system.all;
 USE work.all;
-#t
+
 -- Entity declaration --
 
 ENTITY unknown IS

--- a/netlist/tests/common/TwoStageAmp-vams-entity.out
+++ b/netlist/tests/common/TwoStageAmp-vams-entity.out
@@ -8,6 +8,5 @@ USE work.all;
 
 ENTITY default_entity IS
 #<unspecified>
-#<unspecified>
 END ENTITY default_entity;
 

--- a/netlist/tests/common/TwoStageAmp-vams-entity.out
+++ b/netlist/tests/common/TwoStageAmp-vams-entity.out
@@ -7,6 +7,5 @@ USE work.all;
 -- Entity declaration --
 
 ENTITY default_entity IS
-#<unspecified>
 END ENTITY default_entity;
 

--- a/netlist/tests/common/TwoStageAmp-vams-entity.out
+++ b/netlist/tests/common/TwoStageAmp-vams-entity.out
@@ -3,7 +3,7 @@ USE ieee.math_real.all;
 USE ieee.math_real.all;
 USE work.electrical_system.all;
 USE work.all;
-#t
+
 -- Entity declaration --
 
 ENTITY default_entity IS

--- a/netlist/tests/common/cascade-vams-device.out
+++ b/netlist/tests/common/cascade-vams-device.out
@@ -3,13 +3,12 @@ USE ieee.math_real.all;
 USE ieee.math_real.all;
 USE work.electrical_system.all;
 USE work.all;
-	 GENERIC (	device : REAL := 7404;
-			footprint : REAL := DIP14 );
 #t
 -- Entity declaration --
 
 ENTITY unknown IS
-#<unspecified>
+	 GENERIC (	device : REAL := 7404;
+			footprint : REAL := DIP14 );
 #<unspecified>
 END ENTITY unknown;
 

--- a/netlist/tests/common/cascade-vams-device.out
+++ b/netlist/tests/common/cascade-vams-device.out
@@ -9,6 +9,5 @@ USE work.all;
 ENTITY unknown IS
 	 GENERIC (	device : REAL := 7404;
 			footprint : REAL := DIP14 );
-#<unspecified>
 END ENTITY unknown;
 

--- a/netlist/tests/common/cascade-vams-device.out
+++ b/netlist/tests/common/cascade-vams-device.out
@@ -3,7 +3,7 @@ USE ieee.math_real.all;
 USE ieee.math_real.all;
 USE work.electrical_system.all;
 USE work.all;
-#t
+
 -- Entity declaration --
 
 ENTITY unknown IS

--- a/netlist/tests/common/cascade-vams-entity.out
+++ b/netlist/tests/common/cascade-vams-entity.out
@@ -8,6 +8,5 @@ USE work.all;
 
 ENTITY default_entity IS
 #<unspecified>
-#<unspecified>
 END ENTITY default_entity;
 

--- a/netlist/tests/common/cascade-vams-entity.out
+++ b/netlist/tests/common/cascade-vams-entity.out
@@ -7,6 +7,5 @@ USE work.all;
 -- Entity declaration --
 
 ENTITY default_entity IS
-#<unspecified>
 END ENTITY default_entity;
 

--- a/netlist/tests/common/cascade-vams-entity.out
+++ b/netlist/tests/common/cascade-vams-entity.out
@@ -3,7 +3,7 @@ USE ieee.math_real.all;
 USE ieee.math_real.all;
 USE work.electrical_system.all;
 USE work.all;
-#t
+
 -- Entity declaration --
 
 ENTITY default_entity IS

--- a/netlist/tests/common/graphical-vams-device.out
+++ b/netlist/tests/common/graphical-vams-device.out
@@ -3,13 +3,12 @@ USE ieee.math_real.all;
 USE ieee.math_real.all;
 USE work.electrical_system.all;
 USE work.all;
-	 GENERIC (	device : REAL := 7404;
-			footprint : REAL := DIP14 );
 #t
 -- Entity declaration --
 
 ENTITY unknown IS
-#<unspecified>
+	 GENERIC (	device : REAL := 7404;
+			footprint : REAL := DIP14 );
 #<unspecified>
 END ENTITY unknown;
 

--- a/netlist/tests/common/graphical-vams-device.out
+++ b/netlist/tests/common/graphical-vams-device.out
@@ -9,6 +9,5 @@ USE work.all;
 ENTITY unknown IS
 	 GENERIC (	device : REAL := 7404;
 			footprint : REAL := DIP14 );
-#<unspecified>
 END ENTITY unknown;
 

--- a/netlist/tests/common/graphical-vams-device.out
+++ b/netlist/tests/common/graphical-vams-device.out
@@ -3,7 +3,7 @@ USE ieee.math_real.all;
 USE ieee.math_real.all;
 USE work.electrical_system.all;
 USE work.all;
-#t
+
 -- Entity declaration --
 
 ENTITY unknown IS

--- a/netlist/tests/common/graphical-vams-entity.out
+++ b/netlist/tests/common/graphical-vams-entity.out
@@ -8,6 +8,5 @@ USE work.all;
 
 ENTITY default_entity IS
 #<unspecified>
-#<unspecified>
 END ENTITY default_entity;
 

--- a/netlist/tests/common/graphical-vams-entity.out
+++ b/netlist/tests/common/graphical-vams-entity.out
@@ -7,6 +7,5 @@ USE work.all;
 -- Entity declaration --
 
 ENTITY default_entity IS
-#<unspecified>
 END ENTITY default_entity;
 

--- a/netlist/tests/common/graphical-vams-entity.out
+++ b/netlist/tests/common/graphical-vams-entity.out
@@ -3,7 +3,7 @@ USE ieee.math_real.all;
 USE ieee.math_real.all;
 USE work.electrical_system.all;
 USE work.all;
-#t
+
 -- Entity declaration --
 
 ENTITY default_entity IS

--- a/netlist/tests/common/multiequal-vams-device.out
+++ b/netlist/tests/common/multiequal-vams-device.out
@@ -3,13 +3,12 @@ USE ieee.math_real.all;
 USE ieee.math_real.all;
 USE work.electrical_system.all;
 USE work.all;
-	 GENERIC (	device : REAL := 7404;
-			footprint : REAL := DIP14 );
 #t
 -- Entity declaration --
 
 ENTITY unknown IS
-#<unspecified>
+	 GENERIC (	device : REAL := 7404;
+			footprint : REAL := DIP14 );
 #<unspecified>
 END ENTITY unknown;
 

--- a/netlist/tests/common/multiequal-vams-device.out
+++ b/netlist/tests/common/multiequal-vams-device.out
@@ -9,6 +9,5 @@ USE work.all;
 ENTITY unknown IS
 	 GENERIC (	device : REAL := 7404;
 			footprint : REAL := DIP14 );
-#<unspecified>
 END ENTITY unknown;
 

--- a/netlist/tests/common/multiequal-vams-device.out
+++ b/netlist/tests/common/multiequal-vams-device.out
@@ -3,7 +3,7 @@ USE ieee.math_real.all;
 USE ieee.math_real.all;
 USE work.electrical_system.all;
 USE work.all;
-#t
+
 -- Entity declaration --
 
 ENTITY unknown IS

--- a/netlist/tests/common/multiequal-vams-entity.out
+++ b/netlist/tests/common/multiequal-vams-entity.out
@@ -8,6 +8,5 @@ USE work.all;
 
 ENTITY default_entity IS
 #<unspecified>
-#<unspecified>
 END ENTITY default_entity;
 

--- a/netlist/tests/common/multiequal-vams-entity.out
+++ b/netlist/tests/common/multiequal-vams-entity.out
@@ -7,6 +7,5 @@ USE work.all;
 -- Entity declaration --
 
 ENTITY default_entity IS
-#<unspecified>
 END ENTITY default_entity;
 

--- a/netlist/tests/common/multiequal-vams-entity.out
+++ b/netlist/tests/common/multiequal-vams-entity.out
@@ -3,7 +3,7 @@ USE ieee.math_real.all;
 USE ieee.math_real.all;
 USE work.electrical_system.all;
 USE work.all;
-#t
+
 -- Entity declaration --
 
 ENTITY default_entity IS

--- a/netlist/tests/common/netattrib-vams-device.out
+++ b/netlist/tests/common/netattrib-vams-device.out
@@ -3,13 +3,12 @@ USE ieee.math_real.all;
 USE ieee.math_real.all;
 USE work.electrical_system.all;
 USE work.all;
-	 GENERIC (	device : REAL := 7404;
-			footprint : REAL := DIP14 );
 #t
 -- Entity declaration --
 
 ENTITY unknown IS
-#<unspecified>
+	 GENERIC (	device : REAL := 7404;
+			footprint : REAL := DIP14 );
 #<unspecified>
 END ENTITY unknown;
 

--- a/netlist/tests/common/netattrib-vams-device.out
+++ b/netlist/tests/common/netattrib-vams-device.out
@@ -9,6 +9,5 @@ USE work.all;
 ENTITY unknown IS
 	 GENERIC (	device : REAL := 7404;
 			footprint : REAL := DIP14 );
-#<unspecified>
 END ENTITY unknown;
 

--- a/netlist/tests/common/netattrib-vams-device.out
+++ b/netlist/tests/common/netattrib-vams-device.out
@@ -3,7 +3,7 @@ USE ieee.math_real.all;
 USE ieee.math_real.all;
 USE work.electrical_system.all;
 USE work.all;
-#t
+
 -- Entity declaration --
 
 ENTITY unknown IS

--- a/netlist/tests/common/netattrib-vams-entity.out
+++ b/netlist/tests/common/netattrib-vams-entity.out
@@ -8,6 +8,5 @@ USE work.all;
 
 ENTITY default_entity IS
 #<unspecified>
-#<unspecified>
 END ENTITY default_entity;
 

--- a/netlist/tests/common/netattrib-vams-entity.out
+++ b/netlist/tests/common/netattrib-vams-entity.out
@@ -7,6 +7,5 @@ USE work.all;
 -- Entity declaration --
 
 ENTITY default_entity IS
-#<unspecified>
 END ENTITY default_entity;
 

--- a/netlist/tests/common/netattrib-vams-entity.out
+++ b/netlist/tests/common/netattrib-vams-entity.out
@@ -3,7 +3,7 @@ USE ieee.math_real.all;
 USE ieee.math_real.all;
 USE work.electrical_system.all;
 USE work.all;
-#t
+
 -- Entity declaration --
 
 ENTITY default_entity IS

--- a/netlist/tests/common/powersupply-vams-device.out
+++ b/netlist/tests/common/powersupply-vams-device.out
@@ -3,8 +3,6 @@ USE ieee.math_real.all;
 USE ieee.math_real.all;
 USE work.electrical_system.all;
 USE work.all;
-	 GENERIC (	device : REAL := 7404;
-			footprint : REAL := DIP14 );
 	 PORT (		unknown 	1 	:  	unknown;
 			unknown 	2 	:  	unknown;
 			unknown 	3 	:  	unknown;
@@ -13,7 +11,8 @@ USE work.all;
 -- Entity declaration --
 
 ENTITY DIODE-BRIDGE IS
-#<unspecified>
+	 GENERIC (	device : REAL := 7404;
+			footprint : REAL := DIP14 );
 #<unspecified>
 END ENTITY DIODE-BRIDGE;
 

--- a/netlist/tests/common/powersupply-vams-device.out
+++ b/netlist/tests/common/powersupply-vams-device.out
@@ -3,7 +3,7 @@ USE ieee.math_real.all;
 USE ieee.math_real.all;
 USE work.electrical_system.all;
 USE work.all;
-#t
+
 -- Entity declaration --
 
 ENTITY DIODE-BRIDGE IS

--- a/netlist/tests/common/powersupply-vams-device.out
+++ b/netlist/tests/common/powersupply-vams-device.out
@@ -3,16 +3,15 @@ USE ieee.math_real.all;
 USE ieee.math_real.all;
 USE work.electrical_system.all;
 USE work.all;
-	 PORT (		unknown 	1 	:  	unknown;
-			unknown 	2 	:  	unknown;
-			unknown 	3 	:  	unknown;
-			unknown 	4 	:  	unknown );
 #t
 -- Entity declaration --
 
 ENTITY DIODE-BRIDGE IS
 	 GENERIC (	device : REAL := 7404;
 			footprint : REAL := DIP14 );
-#<unspecified>
+	 PORT (		unknown 	1 	:  	unknown;
+			unknown 	2 	:  	unknown;
+			unknown 	3 	:  	unknown;
+			unknown 	4 	:  	unknown );
 END ENTITY DIODE-BRIDGE;
 

--- a/netlist/tests/common/powersupply-vams-entity.out
+++ b/netlist/tests/common/powersupply-vams-entity.out
@@ -8,6 +8,5 @@ USE work.all;
 
 ENTITY default_entity IS
 #<unspecified>
-#<unspecified>
 END ENTITY default_entity;
 

--- a/netlist/tests/common/powersupply-vams-entity.out
+++ b/netlist/tests/common/powersupply-vams-entity.out
@@ -7,6 +7,5 @@ USE work.all;
 -- Entity declaration --
 
 ENTITY default_entity IS
-#<unspecified>
 END ENTITY default_entity;
 

--- a/netlist/tests/common/powersupply-vams-entity.out
+++ b/netlist/tests/common/powersupply-vams-entity.out
@@ -3,7 +3,7 @@ USE ieee.math_real.all;
 USE ieee.math_real.all;
 USE work.electrical_system.all;
 USE work.all;
-#t
+
 -- Entity declaration --
 
 ENTITY default_entity IS

--- a/netlist/tests/common/singlenet-vams-device.out
+++ b/netlist/tests/common/singlenet-vams-device.out
@@ -3,13 +3,12 @@ USE ieee.math_real.all;
 USE ieee.math_real.all;
 USE work.electrical_system.all;
 USE work.all;
-	 GENERIC (	device : REAL := 7404;
-			footprint : REAL := DIP14 );
 #t
 -- Entity declaration --
 
 ENTITY unknown IS
-#<unspecified>
+	 GENERIC (	device : REAL := 7404;
+			footprint : REAL := DIP14 );
 #<unspecified>
 END ENTITY unknown;
 

--- a/netlist/tests/common/singlenet-vams-device.out
+++ b/netlist/tests/common/singlenet-vams-device.out
@@ -9,6 +9,5 @@ USE work.all;
 ENTITY unknown IS
 	 GENERIC (	device : REAL := 7404;
 			footprint : REAL := DIP14 );
-#<unspecified>
 END ENTITY unknown;
 

--- a/netlist/tests/common/singlenet-vams-device.out
+++ b/netlist/tests/common/singlenet-vams-device.out
@@ -3,7 +3,7 @@ USE ieee.math_real.all;
 USE ieee.math_real.all;
 USE work.electrical_system.all;
 USE work.all;
-#t
+
 -- Entity declaration --
 
 ENTITY unknown IS

--- a/netlist/tests/common/singlenet-vams-entity.out
+++ b/netlist/tests/common/singlenet-vams-entity.out
@@ -8,6 +8,5 @@ USE work.all;
 
 ENTITY default_entity IS
 #<unspecified>
-#<unspecified>
 END ENTITY default_entity;
 

--- a/netlist/tests/common/singlenet-vams-entity.out
+++ b/netlist/tests/common/singlenet-vams-entity.out
@@ -7,6 +7,5 @@ USE work.all;
 -- Entity declaration --
 
 ENTITY default_entity IS
-#<unspecified>
 END ENTITY default_entity;
 

--- a/netlist/tests/common/singlenet-vams-entity.out
+++ b/netlist/tests/common/singlenet-vams-entity.out
@@ -3,7 +3,7 @@ USE ieee.math_real.all;
 USE ieee.math_real.all;
 USE work.electrical_system.all;
 USE work.all;
-#t
+
 -- Entity declaration --
 
 ENTITY default_entity IS

--- a/netlist/tests/hierarchy-vams-device.out
+++ b/netlist/tests/hierarchy-vams-device.out
@@ -3,8 +3,6 @@ USE ieee.math_real.all;
 USE ieee.math_real.all;
 USE work.electrical_system.all;
 USE work.all;
-	 GENERIC (	device : REAL := 7404;
-			footprint : REAL := DIP14 );
 	 PORT (		unknown 	1 	:  	unknown;
 			unknown 	2 	:  	unknown;
 			unknown 	7 	:  	unknown;
@@ -13,7 +11,8 @@ USE work.all;
 -- Entity declaration --
 
 ENTITY 7404 IS
-#<unspecified>
+	 GENERIC (	device : REAL := 7404;
+			footprint : REAL := DIP14 );
 #<unspecified>
 END ENTITY 7404;
 

--- a/netlist/tests/hierarchy-vams-device.out
+++ b/netlist/tests/hierarchy-vams-device.out
@@ -3,16 +3,15 @@ USE ieee.math_real.all;
 USE ieee.math_real.all;
 USE work.electrical_system.all;
 USE work.all;
-	 PORT (		unknown 	1 	:  	unknown;
-			unknown 	2 	:  	unknown;
-			unknown 	7 	:  	unknown;
-			unknown 	14 	:  	unknown );
 #t
 -- Entity declaration --
 
 ENTITY 7404 IS
 	 GENERIC (	device : REAL := 7404;
 			footprint : REAL := DIP14 );
-#<unspecified>
+	 PORT (		unknown 	1 	:  	unknown;
+			unknown 	2 	:  	unknown;
+			unknown 	7 	:  	unknown;
+			unknown 	14 	:  	unknown );
 END ENTITY 7404;
 

--- a/netlist/tests/hierarchy-vams-device.out
+++ b/netlist/tests/hierarchy-vams-device.out
@@ -3,7 +3,7 @@ USE ieee.math_real.all;
 USE ieee.math_real.all;
 USE work.electrical_system.all;
 USE work.all;
-#t
+
 -- Entity declaration --
 
 ENTITY 7404 IS

--- a/netlist/tests/hierarchy-vams-entity.out
+++ b/netlist/tests/hierarchy-vams-entity.out
@@ -8,6 +8,5 @@ USE work.all;
 
 ENTITY default_entity IS
 #<unspecified>
-#<unspecified>
 END ENTITY default_entity;
 

--- a/netlist/tests/hierarchy-vams-entity.out
+++ b/netlist/tests/hierarchy-vams-entity.out
@@ -7,6 +7,5 @@ USE work.all;
 -- Entity declaration --
 
 ENTITY default_entity IS
-#<unspecified>
 END ENTITY default_entity;
 

--- a/netlist/tests/hierarchy-vams-entity.out
+++ b/netlist/tests/hierarchy-vams-entity.out
@@ -3,7 +3,7 @@ USE ieee.math_real.all;
 USE ieee.math_real.all;
 USE work.electrical_system.all;
 USE work.all;
-#t
+
 -- Entity declaration --
 
 ENTITY default_entity IS

--- a/netlist/tests/hierarchy2-vams-device.out
+++ b/netlist/tests/hierarchy2-vams-device.out
@@ -3,13 +3,12 @@ USE ieee.math_real.all;
 USE ieee.math_real.all;
 USE work.electrical_system.all;
 USE work.all;
-	 GENERIC (	device : REAL := 7404;
-			footprint : REAL := DIP14 );
 #t
 -- Entity declaration --
 
 ENTITY unknown IS
-#<unspecified>
+	 GENERIC (	device : REAL := 7404;
+			footprint : REAL := DIP14 );
 #<unspecified>
 END ENTITY unknown;
 

--- a/netlist/tests/hierarchy2-vams-device.out
+++ b/netlist/tests/hierarchy2-vams-device.out
@@ -9,6 +9,5 @@ USE work.all;
 ENTITY unknown IS
 	 GENERIC (	device : REAL := 7404;
 			footprint : REAL := DIP14 );
-#<unspecified>
 END ENTITY unknown;
 

--- a/netlist/tests/hierarchy2-vams-device.out
+++ b/netlist/tests/hierarchy2-vams-device.out
@@ -3,7 +3,7 @@ USE ieee.math_real.all;
 USE ieee.math_real.all;
 USE work.electrical_system.all;
 USE work.all;
-#t
+
 -- Entity declaration --
 
 ENTITY unknown IS

--- a/netlist/tests/hierarchy2-vams-entity.out
+++ b/netlist/tests/hierarchy2-vams-entity.out
@@ -8,6 +8,5 @@ USE work.all;
 
 ENTITY default_entity IS
 #<unspecified>
-#<unspecified>
 END ENTITY default_entity;
 

--- a/netlist/tests/hierarchy2-vams-entity.out
+++ b/netlist/tests/hierarchy2-vams-entity.out
@@ -7,6 +7,5 @@ USE work.all;
 -- Entity declaration --
 
 ENTITY default_entity IS
-#<unspecified>
 END ENTITY default_entity;
 

--- a/netlist/tests/hierarchy2-vams-entity.out
+++ b/netlist/tests/hierarchy2-vams-entity.out
@@ -3,7 +3,7 @@ USE ieee.math_real.all;
 USE ieee.math_real.all;
 USE work.electrical_system.all;
 USE work.all;
-#t
+
 -- Entity declaration --
 
 ENTITY default_entity IS

--- a/netlist/tests/hierarchy3-vams-device.out
+++ b/netlist/tests/hierarchy3-vams-device.out
@@ -3,8 +3,6 @@ USE ieee.math_real.all;
 USE ieee.math_real.all;
 USE work.electrical_system.all;
 USE work.all;
-	 GENERIC (	device : REAL := 7404;
-			footprint : REAL := DIP14 );
 	 PORT (		unknown 	1 	:  	unknown;
 			unknown 	2 	:  	unknown;
 			unknown 	7 	:  	unknown;
@@ -13,7 +11,8 @@ USE work.all;
 -- Entity declaration --
 
 ENTITY 7404 IS
-#<unspecified>
+	 GENERIC (	device : REAL := 7404;
+			footprint : REAL := DIP14 );
 #<unspecified>
 END ENTITY 7404;
 

--- a/netlist/tests/hierarchy3-vams-device.out
+++ b/netlist/tests/hierarchy3-vams-device.out
@@ -3,16 +3,15 @@ USE ieee.math_real.all;
 USE ieee.math_real.all;
 USE work.electrical_system.all;
 USE work.all;
-	 PORT (		unknown 	1 	:  	unknown;
-			unknown 	2 	:  	unknown;
-			unknown 	7 	:  	unknown;
-			unknown 	14 	:  	unknown );
 #t
 -- Entity declaration --
 
 ENTITY 7404 IS
 	 GENERIC (	device : REAL := 7404;
 			footprint : REAL := DIP14 );
-#<unspecified>
+	 PORT (		unknown 	1 	:  	unknown;
+			unknown 	2 	:  	unknown;
+			unknown 	7 	:  	unknown;
+			unknown 	14 	:  	unknown );
 END ENTITY 7404;
 

--- a/netlist/tests/hierarchy3-vams-device.out
+++ b/netlist/tests/hierarchy3-vams-device.out
@@ -3,7 +3,7 @@ USE ieee.math_real.all;
 USE ieee.math_real.all;
 USE work.electrical_system.all;
 USE work.all;
-#t
+
 -- Entity declaration --
 
 ENTITY 7404 IS

--- a/netlist/tests/hierarchy3-vams-entity.out
+++ b/netlist/tests/hierarchy3-vams-entity.out
@@ -8,6 +8,5 @@ USE work.all;
 
 ENTITY default_entity IS
 #<unspecified>
-#<unspecified>
 END ENTITY default_entity;
 

--- a/netlist/tests/hierarchy3-vams-entity.out
+++ b/netlist/tests/hierarchy3-vams-entity.out
@@ -7,6 +7,5 @@ USE work.all;
 -- Entity declaration --
 
 ENTITY default_entity IS
-#<unspecified>
 END ENTITY default_entity;
 

--- a/netlist/tests/hierarchy3-vams-entity.out
+++ b/netlist/tests/hierarchy3-vams-entity.out
@@ -3,7 +3,7 @@ USE ieee.math_real.all;
 USE ieee.math_real.all;
 USE work.electrical_system.all;
 USE work.all;
-#t
+
 -- Entity declaration --
 
 ENTITY default_entity IS


### PR DESCRIPTION
The vams backend output has been broken for many years.
The patchset fixes several issues in the code and the vams example:
- the code doesn't emit Scheme return values of procedures, such as `#t` or `#<unspecified>` in the output;
- the output of generic and port definitions is going into appropriate place, which can be seen if you compare the original examples in the vams example directory with the vams backend output;
- the no more present option **-w** is no longer used in the example.