### PR TITLE
Export several lepton library funcs in Scheme modules

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -43,6 +43,28 @@ Notable changes in Lepton EDA 1.9.8
   Lepton. Two additional categories have been rearranged in order
   "Electronics" to have priority over "Engineering".
 
+- The following rc procedures are now exported in the module
+`(lepton library)`:
+
+  - `component-library-command`
+  - `component-library-funcs`
+  - `component-library-search`
+  - `component-library`
+  - `reset-component-library`
+
+- The following rc procedures are now exported in the module
+`(geda deprecated)`:
+
+  - `always-promote-attributes`
+  - `attribute-promotion`
+  - `bitmap-directory`
+  - `bus-ripper-symname`
+  - `keep-invisible`
+  - `make-backup-files`
+  - `print-color-map`
+  - `promote-invisible`
+  - `scheme-directory`
+
 ### Changes when building from source:
 
 - Building of the tools with Guile 2.2 is now supported.

--- a/liblepton/include/libgedaguile_priv.h
+++ b/liblepton/include/libgedaguile_priv.h
@@ -97,6 +97,7 @@ void edascm_init_closure (void);
 void edascm_init_log (void);
 void edascm_init_version ();
 void edascm_init_deprecated ();
+void edascm_init_rc ();
 
 /* ---------------------------------------- */
 

--- a/liblepton/include/libgedaguile_priv.h
+++ b/liblepton/include/libgedaguile_priv.h
@@ -1,6 +1,7 @@
-/* gEDA - GPL Electronic Design Automation
- * libgeda - gEDA's library - Scheme API
+/* Lepton EDA library
  * Copyright (C) 2010-2013 Peter Brett <peter@peter-b.co.uk>
+ * Copyright (C) 2010-2016 gEDA Contributors
+ * Copyright (C) 2017-2019 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/liblepton/include/prototype_priv.h
+++ b/liblepton/include/prototype_priv.h
@@ -1,7 +1,6 @@
 /* g_rc.c */
 int vstbl_lookup_str(const vstbl_entry *table, int size, const char *str);
 int vstbl_get_val(const vstbl_entry *table, int index);
-SCM g_rc_component_library_funcs (SCM listfunc, SCM getfunc, SCM name);
 SCM g_rc_reset_component_library(void);
 SCM scheme_directory(SCM s_path);
 

--- a/liblepton/include/prototype_priv.h
+++ b/liblepton/include/prototype_priv.h
@@ -6,7 +6,6 @@ SCM g_rc_component_library_command (SCM listcmd, SCM getcmd, SCM name);
 SCM g_rc_component_library_funcs (SCM listfunc, SCM getfunc, SCM name);
 SCM g_rc_reset_component_library(void);
 SCM scheme_directory(SCM s_path);
-SCM g_rc_promote_invisible(SCM mode);
 SCM g_rc_keep_invisible(SCM mode);
 SCM g_rc_always_promote_attributes(SCM scmsymname);
 SCM g_rc_make_backup_files(SCM mode);

--- a/liblepton/include/prototype_priv.h
+++ b/liblepton/include/prototype_priv.h
@@ -1,7 +1,6 @@
 /* g_rc.c */
 int vstbl_lookup_str(const vstbl_entry *table, int size, const char *str);
 int vstbl_get_val(const vstbl_entry *table, int index);
-SCM g_rc_component_library_command (SCM listcmd, SCM getcmd, SCM name);
 SCM g_rc_component_library_funcs (SCM listfunc, SCM getfunc, SCM name);
 SCM g_rc_reset_component_library(void);
 SCM scheme_directory(SCM s_path);

--- a/liblepton/include/prototype_priv.h
+++ b/liblepton/include/prototype_priv.h
@@ -6,7 +6,7 @@ SCM g_rc_component_library_command (SCM listcmd, SCM getcmd, SCM name);
 SCM g_rc_component_library_funcs (SCM listfunc, SCM getfunc, SCM name);
 SCM g_rc_reset_component_library(void);
 SCM g_rc_bitmap_directory(SCM path);
-SCM g_rc_scheme_directory(SCM path);
+SCM scheme_directory(SCM s_path);
 SCM g_rc_bus_ripper_symname(SCM scmsymname);
 SCM g_rc_attribute_promotion(SCM mode);
 SCM g_rc_promote_invisible(SCM mode);

--- a/liblepton/include/prototype_priv.h
+++ b/liblepton/include/prototype_priv.h
@@ -6,7 +6,6 @@ SCM g_rc_component_library_command (SCM listcmd, SCM getcmd, SCM name);
 SCM g_rc_component_library_funcs (SCM listfunc, SCM getfunc, SCM name);
 SCM g_rc_reset_component_library(void);
 SCM scheme_directory(SCM s_path);
-SCM g_rc_always_promote_attributes(SCM scmsymname);
 SCM g_rc_make_backup_files(SCM mode);
 
 /* g_register.c */

--- a/liblepton/include/prototype_priv.h
+++ b/liblepton/include/prototype_priv.h
@@ -1,7 +1,6 @@
 /* g_rc.c */
 int vstbl_lookup_str(const vstbl_entry *table, int size, const char *str);
 int vstbl_get_val(const vstbl_entry *table, int index);
-SCM g_rc_reset_component_library(void);
 SCM scheme_directory(SCM s_path);
 
 /* g_register.c */

--- a/liblepton/include/prototype_priv.h
+++ b/liblepton/include/prototype_priv.h
@@ -6,7 +6,6 @@ SCM g_rc_component_library_command (SCM listcmd, SCM getcmd, SCM name);
 SCM g_rc_component_library_funcs (SCM listfunc, SCM getfunc, SCM name);
 SCM g_rc_reset_component_library(void);
 SCM scheme_directory(SCM s_path);
-SCM g_rc_make_backup_files(SCM mode);
 
 /* g_register.c */
 void g_register_libgeda_funcs(void);

--- a/liblepton/include/prototype_priv.h
+++ b/liblepton/include/prototype_priv.h
@@ -8,7 +8,6 @@ SCM g_rc_reset_component_library(void);
 SCM g_rc_bitmap_directory(SCM path);
 SCM g_rc_scheme_directory(SCM path);
 SCM g_rc_bus_ripper_symname(SCM scmsymname);
-SCM g_rc_map_font_character_to_file(SCM character_param, SCM file_param);
 SCM g_rc_attribute_promotion(SCM mode);
 SCM g_rc_promote_invisible(SCM mode);
 SCM g_rc_keep_invisible(SCM mode);

--- a/liblepton/include/prototype_priv.h
+++ b/liblepton/include/prototype_priv.h
@@ -5,7 +5,6 @@ SCM g_rc_component_library(SCM path, SCM name);
 SCM g_rc_component_library_command (SCM listcmd, SCM getcmd, SCM name);
 SCM g_rc_component_library_funcs (SCM listfunc, SCM getfunc, SCM name);
 SCM g_rc_reset_component_library(void);
-SCM g_rc_bitmap_directory(SCM path);
 SCM scheme_directory(SCM s_path);
 SCM g_rc_bus_ripper_symname(SCM scmsymname);
 SCM g_rc_attribute_promotion(SCM mode);

--- a/liblepton/include/prototype_priv.h
+++ b/liblepton/include/prototype_priv.h
@@ -6,7 +6,6 @@ SCM g_rc_component_library_command (SCM listcmd, SCM getcmd, SCM name);
 SCM g_rc_component_library_funcs (SCM listfunc, SCM getfunc, SCM name);
 SCM g_rc_reset_component_library(void);
 SCM scheme_directory(SCM s_path);
-SCM g_rc_attribute_promotion(SCM mode);
 SCM g_rc_promote_invisible(SCM mode);
 SCM g_rc_keep_invisible(SCM mode);
 SCM g_rc_always_promote_attributes(SCM scmsymname);

--- a/liblepton/include/prototype_priv.h
+++ b/liblepton/include/prototype_priv.h
@@ -1,7 +1,6 @@
 /* g_rc.c */
 int vstbl_lookup_str(const vstbl_entry *table, int size, const char *str);
 int vstbl_get_val(const vstbl_entry *table, int index);
-SCM g_rc_component_library(SCM path, SCM name);
 SCM g_rc_component_library_command (SCM listcmd, SCM getcmd, SCM name);
 SCM g_rc_component_library_funcs (SCM listfunc, SCM getfunc, SCM name);
 SCM g_rc_reset_component_library(void);

--- a/liblepton/include/prototype_priv.h
+++ b/liblepton/include/prototype_priv.h
@@ -6,7 +6,6 @@ SCM g_rc_component_library_command (SCM listcmd, SCM getcmd, SCM name);
 SCM g_rc_component_library_funcs (SCM listfunc, SCM getfunc, SCM name);
 SCM g_rc_reset_component_library(void);
 SCM scheme_directory(SCM s_path);
-SCM g_rc_bus_ripper_symname(SCM scmsymname);
 SCM g_rc_attribute_promotion(SCM mode);
 SCM g_rc_promote_invisible(SCM mode);
 SCM g_rc_keep_invisible(SCM mode);

--- a/liblepton/include/prototype_priv.h
+++ b/liblepton/include/prototype_priv.h
@@ -6,7 +6,6 @@ SCM g_rc_component_library_command (SCM listcmd, SCM getcmd, SCM name);
 SCM g_rc_component_library_funcs (SCM listfunc, SCM getfunc, SCM name);
 SCM g_rc_reset_component_library(void);
 SCM scheme_directory(SCM s_path);
-SCM g_rc_keep_invisible(SCM mode);
 SCM g_rc_always_promote_attributes(SCM scmsymname);
 SCM g_rc_make_backup_files(SCM mode);
 

--- a/liblepton/include/prototype_priv.h
+++ b/liblepton/include/prototype_priv.h
@@ -13,7 +13,6 @@ SCM g_rc_promote_invisible(SCM mode);
 SCM g_rc_keep_invisible(SCM mode);
 SCM g_rc_always_promote_attributes(SCM scmsymname);
 SCM g_rc_make_backup_files(SCM mode);
-SCM g_rc_print_color_map (SCM scm_map);
 
 /* g_register.c */
 void g_register_libgeda_funcs(void);

--- a/liblepton/scheme/Makefile.am
+++ b/liblepton/scheme/Makefile.am
@@ -16,6 +16,7 @@ nobase_dist_scmdata_DATA = \
 	geda/repl.scm \
 	lepton/file-system.scm \
 	lepton/library.scm \
+	lepton/library/component.scm \
 	lepton/rc.scm \
 	lepton/version.scm \
 	lepton/legacy-config/keylist.scm \

--- a/liblepton/scheme/geda.scm
+++ b/liblepton/scheme/geda.scm
@@ -1,41 +1,6 @@
 ; -*-Scheme-*-
-(use-modules (ice-9 ftw)
-             (geda os)
-             (lepton library))
+(use-modules (lepton library))
 
 ;; Clean up logfiles
 ;; FIXME this should be a plugin
 (use-modules (geda log-rotate))
-
-
-;; Add all symbol libraries found below DIR to be searched for
-;; components, naming them with an optional PREFIX.
-(define* (component-library-search rootdir  #:optional (prefix ""))
-  (let ((dht (make-hash-table 31))
-        (rootdir (expand-env-variables rootdir)))
-    ;; Build symbol directory list
-    (ftw rootdir
-         (lambda (filename statinfo flags)
-           (cond
-            ((eq? 'invalid-stat flags)
-             (error "Invalid path ~S." filename))
-            ((or (eq? 'directory-not-readable flags)
-                 (eq? 'symlink flags))
-             (format #t "Warning: Cannot access ~S.\n" filename))
-            (else
-             (and (eq? 'regular flags)
-                  (string-suffix-ci? ".sym" filename)
-                  (hashq-set! dht
-                              (string->symbol (dirname filename))
-                              #t))))
-           #t))
-
-    ; Fill component library tree
-    (for-each
-     (lambda (dir)
-       (let ((name (substring dir (string-length rootdir))))
-         (component-library dir (string-append prefix name))))
-     (sort-list! (hash-map->list (lambda (key val)
-                                   (symbol->string key))
-                                 dht)
-                 string>?))))

--- a/liblepton/scheme/geda/deprecated.scm
+++ b/liblepton/scheme/geda/deprecated.scm
@@ -42,7 +42,8 @@
               load-rc-from-sys-config-dirs)
 
  #:export (deprecated-module-log-warning!
-           print-color-map))
+           print-color-map
+           scheme-directory))
 
 (define (deprecated-module-log-warning!)
   (log! 'warning
@@ -134,3 +135,5 @@
       bounds)))
 
 (define print-color-map %print-color-map)
+
+(define scheme-directory %scheme-directory)

--- a/liblepton/scheme/geda/deprecated.scm
+++ b/liblepton/scheme/geda/deprecated.scm
@@ -46,6 +46,7 @@
            bitmap-directory
            bus-ripper-symname
            print-color-map
+           promote-invisible
            scheme-directory))
 
 (define (deprecated-module-log-warning!)
@@ -146,3 +147,5 @@
 (define bus-ripper-symname %bus-ripper-symname)
 
 (define attribute-promotion %attribute-promotion)
+
+(define promote-invisible %promote-invisible)

--- a/liblepton/scheme/geda/deprecated.scm
+++ b/liblepton/scheme/geda/deprecated.scm
@@ -42,6 +42,7 @@
               load-rc-from-sys-config-dirs)
 
  #:export (deprecated-module-log-warning!
+           attribute-promotion
            bitmap-directory
            bus-ripper-symname
            print-color-map
@@ -143,3 +144,5 @@
 (define bitmap-directory %bitmap-directory)
 
 (define bus-ripper-symname %bus-ripper-symname)
+
+(define attribute-promotion %attribute-promotion)

--- a/liblepton/scheme/geda/deprecated.scm
+++ b/liblepton/scheme/geda/deprecated.scm
@@ -45,6 +45,7 @@
            attribute-promotion
            bitmap-directory
            bus-ripper-symname
+           keep-invisible
            print-color-map
            promote-invisible
            scheme-directory))
@@ -149,3 +150,5 @@
 (define attribute-promotion %attribute-promotion)
 
 (define promote-invisible %promote-invisible)
+
+(define keep-invisible %keep-invisible)

--- a/liblepton/scheme/geda/deprecated.scm
+++ b/liblepton/scheme/geda/deprecated.scm
@@ -1,6 +1,7 @@
-;; gEDA - GPL Electronic Design Automation
-;; libgeda - gEDA's library - Scheme API
-;; Copyright (C) 2010 Peter Brett
+;;; Lepton EDA library - Scheme API
+;;; Copyright (C) 2010 Peter Brett
+;;; Copyright (C) 2010-2014 gEDA Contributors
+;;; Copyright (C) 2017-2019 Lepton EDA Contributors
 ;;
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/liblepton/scheme/geda/deprecated.scm
+++ b/liblepton/scheme/geda/deprecated.scm
@@ -42,6 +42,7 @@
               load-rc-from-sys-config-dirs)
 
  #:export (deprecated-module-log-warning!
+           bitmap-directory
            print-color-map
            scheme-directory))
 
@@ -137,3 +138,5 @@
 (define print-color-map %print-color-map)
 
 (define scheme-directory %scheme-directory)
+
+(define bitmap-directory %bitmap-directory)

--- a/liblepton/scheme/geda/deprecated.scm
+++ b/liblepton/scheme/geda/deprecated.scm
@@ -43,6 +43,7 @@
 
  #:export (deprecated-module-log-warning!
            bitmap-directory
+           bus-ripper-symname
            print-color-map
            scheme-directory))
 
@@ -140,3 +141,5 @@
 (define scheme-directory %scheme-directory)
 
 (define bitmap-directory %bitmap-directory)
+
+(define bus-ripper-symname %bus-ripper-symname)

--- a/liblepton/scheme/geda/deprecated.scm
+++ b/liblepton/scheme/geda/deprecated.scm
@@ -47,6 +47,7 @@
            bitmap-directory
            bus-ripper-symname
            keep-invisible
+           make-backup-files
            print-color-map
            promote-invisible
            scheme-directory))
@@ -155,3 +156,5 @@
 (define keep-invisible %keep-invisible)
 
 (define always-promote-attributes %always-promote-attributes)
+
+(define make-backup-files %make-backup-files)

--- a/liblepton/scheme/geda/deprecated.scm
+++ b/liblepton/scheme/geda/deprecated.scm
@@ -42,6 +42,7 @@
               load-rc-from-sys-config-dirs)
 
  #:export (deprecated-module-log-warning!
+           always-promote-attributes
            attribute-promotion
            bitmap-directory
            bus-ripper-symname
@@ -152,3 +153,5 @@
 (define promote-invisible %promote-invisible)
 
 (define keep-invisible %keep-invisible)
+
+(define always-promote-attributes %always-promote-attributes)

--- a/liblepton/scheme/geda/deprecated.scm
+++ b/liblepton/scheme/geda/deprecated.scm
@@ -24,6 +24,7 @@
  ;; Import C procedures
  #:use-module (geda core gettext)
  #:use-module (geda core deprecated)
+ #:use-module (lepton core rc)
 
  #:use-module (geda page)
  #:use-module (geda object)
@@ -40,7 +41,8 @@
               load-scheme-dir
               load-rc-from-sys-config-dirs)
 
- #:export (deprecated-module-log-warning!))
+ #:export (deprecated-module-log-warning!
+           print-color-map))
 
 (define (deprecated-module-log-warning!)
   (log! 'warning
@@ -130,3 +132,5 @@
       (set-car! (cdr bounds) bottom)
       (set-cdr! (cdr bounds) top)
       bounds)))
+
+(define print-color-map %print-color-map)

--- a/liblepton/scheme/geda/deprecated.scm
+++ b/liblepton/scheme/geda/deprecated.scm
@@ -145,16 +145,23 @@
 
 (define scheme-directory %scheme-directory)
 
+(define always-promote-attributes %always-promote-attributes)
+
 (define bitmap-directory %bitmap-directory)
 
 (define bus-ripper-symname %bus-ripper-symname)
 
-(define attribute-promotion %attribute-promotion)
+(define (enabled? x)
+  (string= "enabled" x))
 
-(define promote-invisible %promote-invisible)
+(define (attribute-promotion mode)
+  (%attribute-promotion (enabled? mode)))
 
-(define keep-invisible %keep-invisible)
+(define (promote-invisible mode)
+  (%promote-invisible (enabled? mode)))
 
-(define always-promote-attributes %always-promote-attributes)
+(define (keep-invisible mode)
+  (%keep-invisible (enabled? mode)))
 
-(define make-backup-files %make-backup-files)
+(define (make-backup-files mode)
+  (%make-backup-files (enabled? mode)))

--- a/liblepton/scheme/lepton/library.scm
+++ b/liblepton/scheme/lepton/library.scm
@@ -1,6 +1,6 @@
 ;;; Lepton EDA library - Scheme API
 ;;; Copyright (C) 2016 gEDA Contributors
-;;; Copyright (C) 2019 Lepton Contributors
+;;; Copyright (C) 2019 Lepton EDA Contributors
 ;;;
 ;;; This program is free software; you can redistribute it and/or modify
 ;;; it under the terms of the GNU General Public License as published by

--- a/liblepton/scheme/lepton/library.scm
+++ b/liblepton/scheme/lepton/library.scm
@@ -49,7 +49,8 @@
 
   #:re-export (component-library
                component-library-search
-               component-library-command))
+               component-library-command
+               component-library-funcs))
 
 
 (define-record-type <source-library>

--- a/liblepton/scheme/lepton/library.scm
+++ b/liblepton/scheme/lepton/library.scm
@@ -50,7 +50,8 @@
   #:re-export (component-library
                component-library-search
                component-library-command
-               component-library-funcs))
+               component-library-funcs
+               reset-component-library))
 
 
 (define-record-type <source-library>

--- a/liblepton/scheme/lepton/library.scm
+++ b/liblepton/scheme/lepton/library.scm
@@ -47,7 +47,8 @@
             ;; temporary
             get-source-library-file)
 
-  #:re-export (component-library-search))
+  #:re-export (component-library
+               component-library-search))
 
 
 (define-record-type <source-library>

--- a/liblepton/scheme/lepton/library.scm
+++ b/liblepton/scheme/lepton/library.scm
@@ -48,7 +48,8 @@
             get-source-library-file)
 
   #:re-export (component-library
-               component-library-search))
+               component-library-search
+               component-library-command))
 
 
 (define-record-type <source-library>

--- a/liblepton/scheme/lepton/library.scm
+++ b/liblepton/scheme/lepton/library.scm
@@ -34,6 +34,7 @@
   #:use-module (ice-9 ftw)
   #:use-module (ice-9 match)
   #:use-module (lepton file-system)
+  #:use-module (lepton library component)
 
   #:export (%default-source-library
             ;; deprecated
@@ -44,7 +45,9 @@
             source-library-contents
             set-source-library-contents!
             ;; temporary
-            get-source-library-file))
+            get-source-library-file)
+
+  #:re-export (component-library-search))
 
 
 (define-record-type <source-library>

--- a/liblepton/scheme/lepton/library/component.scm
+++ b/liblepton/scheme/lepton/library/component.scm
@@ -30,9 +30,12 @@
 (define-module (lepton library component)
   #:use-module (ice-9 ftw)
   #:use-module (geda os)
+  #:use-module (lepton core rc)
 
-  #:export (component-library-search))
+  #:export (component-library
+            component-library-search))
 
+(define component-library %component-library)
 
 (define* (component-library-search rootdir  #:optional (prefix ""))
   "Add all symbol libraries found below ROOTDIR to be searched for

--- a/liblepton/scheme/lepton/library/component.scm
+++ b/liblepton/scheme/lepton/library/component.scm
@@ -34,10 +34,12 @@
 
   #:export (component-library
             component-library-search
-            component-library-command))
+            component-library-command
+            component-library-funcs))
 
 (define component-library %component-library)
 (define component-library-command %component-library-command)
+(define component-library-funcs %component-library-funcs)
 
 (define* (component-library-search rootdir  #:optional (prefix ""))
   "Add all symbol libraries found below ROOTDIR to be searched for

--- a/liblepton/scheme/lepton/library/component.scm
+++ b/liblepton/scheme/lepton/library/component.scm
@@ -1,0 +1,69 @@
+;;; Lepton EDA library - Scheme API
+;;; Copyright (C) 2011-2016 gEDA Contributors
+;;; Copyright (C) 2017-2019 Lepton EDA Contributors
+;;;
+;;; This program is free software; you can redistribute it and/or modify
+;;; it under the terms of the GNU General Public License as published by
+;;; the Free Software Foundation; either version 2 of the License, or
+;;; (at your option) any later version.
+;;;
+;;; This program is distributed in the hope that it will be useful,
+;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;; GNU General Public License for more details.
+;;;
+;;; You should have received a copy of the GNU General Public License
+;;; along with this program; if not, write to the Free Software
+;;; Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111 USA
+
+;;; Source library is a list of directories to search for source
+;;; files by their basenames. The directories are searched for
+;;; files recursively. First found file with a given basename is
+;;; returned.
+;;; If any given directory is not readable, error is returned.
+;;; If there are several files with the same given basename,
+;;; a warning is output that some of those files won't be used.
+
+
+;;; Lepton component library procedures.
+
+(define-module (lepton library component)
+  #:use-module (ice-9 ftw)
+  #:use-module (geda os)
+
+  #:export (component-library-search))
+
+
+(define* (component-library-search rootdir  #:optional (prefix ""))
+  "Add all symbol libraries found below ROOTDIR to be searched for
+components, naming them with an optional PREFIX."
+
+  (let ((dht (make-hash-table 31))
+        (rootdir (expand-env-variables rootdir)))
+
+    ;; Build symbol directory list.
+    (ftw rootdir
+         (lambda (filename statinfo flags)
+           (cond
+            ((eq? 'invalid-stat flags)
+             (error "Invalid path ~S." filename))
+            ((or (eq? 'directory-not-readable flags)
+                 (eq? 'symlink flags))
+             (format #t "Warning: Cannot access ~S.\n" filename))
+            (else
+             (and (eq? 'regular flags)
+                  (string-suffix-ci? ".sym" filename)
+                  (hashq-set! dht
+                              (string->symbol (dirname filename))
+                              #t))))
+           #t))
+
+    ;; Fill component library tree.
+    (for-each
+     (lambda (dir)
+       (let ((name (substring dir (string-length rootdir))))
+         (component-library dir (string-append prefix name))))
+     (sort-list! (hash-map->list (lambda (key val)
+                                   (symbol->string key))
+                                 dht)
+                 string>?))))

--- a/liblepton/scheme/lepton/library/component.scm
+++ b/liblepton/scheme/lepton/library/component.scm
@@ -35,11 +35,13 @@
   #:export (component-library
             component-library-search
             component-library-command
-            component-library-funcs))
+            component-library-funcs
+            reset-component-library))
 
 (define component-library %component-library)
 (define component-library-command %component-library-command)
 (define component-library-funcs %component-library-funcs)
+(define reset-component-library %reset-component-library)
 
 (define* (component-library-search rootdir  #:optional (prefix ""))
   "Add all symbol libraries found below ROOTDIR to be searched for

--- a/liblepton/scheme/lepton/library/component.scm
+++ b/liblepton/scheme/lepton/library/component.scm
@@ -33,9 +33,11 @@
   #:use-module (lepton core rc)
 
   #:export (component-library
-            component-library-search))
+            component-library-search
+            component-library-command))
 
 (define component-library %component-library)
+(define component-library-command %component-library-command)
 
 (define* (component-library-search rootdir  #:optional (prefix ""))
   "Add all symbol libraries found below ROOTDIR to be searched for

--- a/liblepton/scheme/unit-tests/t0105-object-complex.scm
+++ b/liblepton/scheme/unit-tests/t0105-object-complex.scm
@@ -4,6 +4,7 @@
 (use-modules (geda object))
 (use-modules (geda page))
 (use-modules (geda attrib))
+(use-modules (lepton library))
 
 (begin-test 'component
   (let ((a (make-component "test component" '(1 . 2) 0 #t #f)))

--- a/liblepton/src/Makefile.am
+++ b/liblepton/src/Makefile.am
@@ -15,7 +15,8 @@ BUILT_SOURCES = \
 	scheme_closure.x \
 	scheme_log.x \
 	scheme_version.x \
-	scheme_deprecated.x
+	scheme_deprecated.x \
+	g_rc.x
 
 scheme_api_sources = \
 	scheme_init.c \
@@ -32,7 +33,8 @@ scheme_api_sources = \
 	scheme_log.c \
 	scheme_version.c \
 	edascmhookproxy.c \
-	edascmvaluetypes.c
+	edascmvaluetypes.c \
+	g_rc.c
 
 liblepton_la_SOURCES = \
 	$(scheme_api_sources) \
@@ -74,7 +76,6 @@ liblepton_la_SOURCES = \
 	geda_toplevel.c \
 	geda_transform.c \
 	geda_undo.c \
-	g_rc.c \
 	g_register.c \
 	i_vars.c \
 	liblepton.c \

--- a/liblepton/src/g_rc.c
+++ b/liblepton/src/g_rc.c
@@ -612,17 +612,26 @@ SCM_DEFINE (component_library_command, "%component-library-command", 3, 0, 0,
  *
  *  \returns SCM_BOOL_T on success, SCM_BOOL_F otherwise.
  */
-SCM g_rc_component_library_funcs (SCM listfunc, SCM getfunc, SCM name)
+
+SCM_DEFINE (component_library_funcs, "%component-library-funcs", 3, 0, 0,
+            (SCM listfunc, SCM getfunc, SCM name),
+            "Creates a component library source called NAME (the third"
+"argument) driven by two user Scheme procedures: LIST-FUNCTION (the"
+"first argument) and GET-FUNCTION (the second argument). The list"
+"function should return a Scheme list of component names in the"
+"source.  The get function should return symbol contents by"
+"specified component name as a Scheme string or #f, if there is no"
+"such name in the list.")
 {
   char *namestr;
   SCM result = SCM_BOOL_F;
 
   SCM_ASSERT (scm_is_true (scm_procedure_p (listfunc)), listfunc, SCM_ARG1,
-	      "component-library-funcs");
+              s_component_library_funcs);
   SCM_ASSERT (scm_is_true (scm_procedure_p (getfunc)), getfunc, SCM_ARG2,
-	      "component-library-funcs");
+              s_component_library_funcs);
   SCM_ASSERT (scm_is_string (name), name, SCM_ARG3, 
-	      "component-library-funcs");
+              s_component_library_funcs);
 
   namestr = scm_to_utf8_string (name);
 
@@ -1033,6 +1042,7 @@ init_module_lepton_core_rc (void *unused)
                 s_bus_ripper_symname,
                 s_component_library,
                 s_component_library_command,
+                s_component_library_funcs,
                 s_keep_invisible,
                 s_make_backup_files,
                 s_print_color_map,

--- a/liblepton/src/g_rc.c
+++ b/liblepton/src/g_rc.c
@@ -885,10 +885,12 @@ SCM_DEFINE (keep_invisible, "%keep-invisible", 0, 1, 0,
  *  \param [in] attrlist
  *  \return SCM_BOOL_T always.
  */
-SCM g_rc_always_promote_attributes(SCM attrlist)
+SCM_DEFINE (always_promote_attributes, "%always-promote-attributes", 1, 0, 0,
+            (SCM attrlist),
+            "Set the list of attributes that are always promoted regardless of their visibility.")
 {
-  SCM_ASSERT(scm_is_true (scm_list_p (attrlist)), attrlist, SCM_ARG1,
-             "always-promote-attributes");
+  SCM_ASSERT (scm_is_true (scm_list_p (attrlist)), attrlist, SCM_ARG1,
+              s_always_promote_attributes);
 
   if (default_always_promote_attributes) {
     g_ptr_array_unref (default_always_promote_attributes);
@@ -1011,7 +1013,8 @@ init_module_lepton_core_rc (void *unused)
   #include "g_rc.x"
 
   /* Add them to the module's public definitions. */
-  scm_c_export (s_attribute_promotion,
+  scm_c_export (s_always_promote_attributes,
+                s_attribute_promotion,
                 s_bitmap_directory,
                 s_bus_ripper_symname,
                 s_keep_invisible,

--- a/liblepton/src/g_rc.c
+++ b/liblepton/src/g_rc.c
@@ -807,7 +807,8 @@ SCM_DEFINE (bus_ripper_symname, "%bus-ripper-symname", 1, 0, 0,
  *
  *  \return SCM_BOOL_T always.
  */
-SCM g_rc_reset_component_library(void)
+SCM_DEFINE (reset_component_library, "%reset-component-library", 0, 0, 0,
+            (void), "Reset component library and initialise it to an empty list.")
 {
   s_clib_init();
   
@@ -1047,6 +1048,7 @@ init_module_lepton_core_rc (void *unused)
                 s_make_backup_files,
                 s_print_color_map,
                 s_promote_invisible,
+                s_reset_component_library,
                 s_scheme_directory,
                 NULL);
 }

--- a/liblepton/src/g_rc.c
+++ b/liblepton/src/g_rc.c
@@ -1,5 +1,4 @@
-/* gEDA - GPL Electronic Design Automation
- * libgeda - gEDA's library
+/* Lepton EDA library
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2016 gEDA Contributors
  * Copyright (C) 2016 Peter Brett <peter@peter-b.co.uk>

--- a/liblepton/src/g_rc.c
+++ b/liblepton/src/g_rc.c
@@ -766,12 +766,14 @@ SCM_DEFINE (bitmap_directory, "%bitmap-directory", 0, 1, 0,
  *  \param [in] scmsymname  
  *  \return SCM_BOOL_T always.
  */
-SCM g_rc_bus_ripper_symname(SCM scmsymname)
+SCM_DEFINE (bus_ripper_symname, "%bus-ripper-symname", 1, 0, 0,
+            (SCM scmsymname),
+            "Choose the name of a symbol which should represent bus-rippers in schematics.")
 {
   char *temp;
 
   SCM_ASSERT (scm_is_string (scmsymname), scmsymname,
-              SCM_ARG1, "bus-ripper-symname");
+              SCM_ARG1, s_bus_ripper_symname);
 
   g_free(default_bus_ripper_symname);
 
@@ -992,6 +994,7 @@ init_module_lepton_core_rc (void *unused)
 
   /* Add them to the module's public definitions. */
   scm_c_export (s_bitmap_directory,
+                s_bus_ripper_symname,
                 s_print_color_map,
                 s_scheme_directory,
                 NULL);

--- a/liblepton/src/g_rc.c
+++ b/liblepton/src/g_rc.c
@@ -935,20 +935,26 @@ SCM_DEFINE (always_promote_attributes, "%always-promote-attributes", 1, 0, 0,
  *  If enabled then a backup file, of the form 'example.sch~', is created when
  *  saving a file.
  *
- *  \param [in] mode  String. 'enabled' or 'disabled'
- *  \return           Bool. False if mode is not a valid value; true if it is.
+ *  \param [in] s_mode  String. 'enabled' or 'disabled'
+ *  \return           Bool. False if s_mode is not a valid value; true if it is.
  *
  */
-SCM g_rc_make_backup_files(SCM mode)
+SCM_DEFINE (make_backup_files, "%make-backup-files", 1, 0, 0,
+            (SCM s_mode), "Enable or disable the creation of backup files.")
 {
+  SCM_ASSERT (scm_is_string (s_mode), s_mode,
+              SCM_ARG1, s_make_backup_files);
+
   static const vstbl_entry mode_table[] = {
     {TRUE , "enabled" },
     {FALSE, "disabled"},
   };
 
-  RETURN_G_RC_MODE("make-backup-files",
-                  default_make_backup_files,
-                  2);
+  return g_rc_mode_general (s_mode,
+                            "make-backup-files",
+                            &default_make_backup_files,
+                            mode_table,
+                            2);
 }
 
 SCM_DEFINE (print_color_map, "%print-color-map", 0, 1, 0,
@@ -1018,6 +1024,7 @@ init_module_lepton_core_rc (void *unused)
                 s_bitmap_directory,
                 s_bus_ripper_symname,
                 s_keep_invisible,
+                s_make_backup_files,
                 s_print_color_map,
                 s_promote_invisible,
                 s_scheme_directory,

--- a/liblepton/src/g_rc.c
+++ b/liblepton/src/g_rc.c
@@ -827,19 +827,8 @@ SCM_DEFINE (attribute_promotion, "%attribute-promotion", 0, 1, 0,
     return scm_from_bool (default_attribute_promotion);
   }
 
-  SCM_ASSERT (scm_is_string (s_mode), s_mode,
-              SCM_ARG1, s_attribute_promotion);
-
-  static const vstbl_entry mode_table[] = {
-    {TRUE , "enabled" },
-    {FALSE, "disabled"},
-  };
-
-  return g_rc_mode_general (s_mode,
-                            "attribute-promotion",
-                            &default_attribute_promotion,
-                            mode_table,
-                            2);
+  default_attribute_promotion = scm_is_true (s_mode);
+  return s_mode;
 }
 
 /*! \todo Finish function documentation!!!
@@ -854,19 +843,8 @@ SCM_DEFINE (promote_invisible, "%promote-invisible", 0, 1, 0,
     return scm_from_bool (default_promote_invisible);
   }
 
-  SCM_ASSERT (scm_is_string (s_mode), s_mode,
-              SCM_ARG1, s_promote_invisible);
-
-  static const vstbl_entry mode_table[] = {
-    {TRUE , "enabled" },
-    {FALSE, "disabled"},
-  };
-
-  return g_rc_mode_general (s_mode,
-                            "promote-invisible",
-                            &default_promote_invisible,
-                            mode_table,
-                            2);
+  default_promote_invisible = scm_is_true (s_mode);
+  return s_mode;
 }
 
 /*! \todo Finish function documentation!!!
@@ -881,19 +859,8 @@ SCM_DEFINE (keep_invisible, "%keep-invisible", 0, 1, 0,
     return scm_from_bool (default_keep_invisible);
   }
 
-  SCM_ASSERT (scm_is_string (s_mode), s_mode,
-              SCM_ARG1, s_keep_invisible);
-
-  static const vstbl_entry mode_table[] = {
-    {TRUE , "enabled" },
-    {FALSE, "disabled"},
-  };
-
-  return g_rc_mode_general (s_mode,
-                            "keep-invisible",
-                            &default_keep_invisible,
-                            mode_table,
-                            2);
+  default_keep_invisible = scm_is_true (s_mode);
+  return s_mode;
 }
 
 /*! \todo Finish function description!!!
@@ -960,19 +927,8 @@ SCM_DEFINE (always_promote_attributes, "%always-promote-attributes", 1, 0, 0,
 SCM_DEFINE (make_backup_files, "%make-backup-files", 1, 0, 0,
             (SCM s_mode), "Enable or disable the creation of backup files.")
 {
-  SCM_ASSERT (scm_is_string (s_mode), s_mode,
-              SCM_ARG1, s_make_backup_files);
-
-  static const vstbl_entry mode_table[] = {
-    {TRUE , "enabled" },
-    {FALSE, "disabled"},
-  };
-
-  return g_rc_mode_general (s_mode,
-                            "make-backup-files",
-                            &default_make_backup_files,
-                            mode_table,
-                            2);
+  default_make_backup_files = scm_is_true (s_mode);
+  return s_mode;
 }
 
 SCM_DEFINE (print_color_map, "%print-color-map", 0, 1, 0,

--- a/liblepton/src/g_rc.c
+++ b/liblepton/src/g_rc.c
@@ -856,20 +856,26 @@ SCM_DEFINE (promote_invisible, "%promote-invisible", 0, 1, 0,
  *  \par Function Description
  *
  */
-SCM g_rc_keep_invisible(SCM mode)
+SCM_DEFINE (keep_invisible, "%keep-invisible", 0, 1, 0,
+            (SCM s_mode), "Controls or sets if invisible promoted attributes are not deleted.")
 {
-  if (scm_is_eq (mode, SCM_UNDEFINED)) {
+  if (scm_is_eq (s_mode, SCM_UNDEFINED)) {
     return scm_from_bool (default_keep_invisible);
   }
+
+  SCM_ASSERT (scm_is_string (s_mode), s_mode,
+              SCM_ARG1, s_keep_invisible);
 
   static const vstbl_entry mode_table[] = {
     {TRUE , "enabled" },
     {FALSE, "disabled"},
   };
 
-  RETURN_G_RC_MODE("keep-invisible",
-		   default_keep_invisible,
-		   2);
+  return g_rc_mode_general (s_mode,
+                            "keep-invisible",
+                            &default_keep_invisible,
+                            mode_table,
+                            2);
 }
 
 /*! \todo Finish function description!!!
@@ -1008,6 +1014,7 @@ init_module_lepton_core_rc (void *unused)
   scm_c_export (s_attribute_promotion,
                 s_bitmap_directory,
                 s_bus_ripper_symname,
+                s_keep_invisible,
                 s_print_color_map,
                 s_promote_invisible,
                 s_scheme_directory,

--- a/liblepton/src/g_rc.c
+++ b/liblepton/src/g_rc.c
@@ -545,20 +545,25 @@ SCM_DEFINE (component_library, "%component-library", 1, 1, 0,
  *  \param [in] name    Optional descriptive name for component source.
  *  \return SCM_BOOL_T on success, SCM_BOOL_F otherwise.
  */
-SCM
-g_rc_component_library_command (SCM listcmd, SCM getcmd,
-                                SCM name)
+SCM_DEFINE (component_library_command, "%component-library-command", 3, 0, 0,
+            (SCM listcmd, SCM getcmd, SCM name),
+            "Creates a component library source called NAME (the third"
+"argument) driven by two user commands: LIST-COMMAND (the first"
+"argument) and GET-COMMAND (the second argument). The list command"
+"should return a list of component names in the source.  The get"
+"command should return symbol contents by specified component name."
+"Both commands should output their results to stdout.")
 {
   const CLibSource *src;
   gchar *lcmdstr, *gcmdstr;
   char *tmp_str, *namestr;
 
   SCM_ASSERT (scm_is_string (listcmd), listcmd, SCM_ARG1, 
-              "component-library-command");
+              s_component_library_command);
   SCM_ASSERT (scm_is_string (getcmd), getcmd, SCM_ARG2, 
-              "component-library-command");
+              s_component_library_command);
   SCM_ASSERT (scm_is_string (name), name, SCM_ARG3, 
-              "component-library-command");
+              s_component_library_command);
 
   scm_dynwind_begin ((scm_t_dynwind_flags) 0);
 
@@ -1027,6 +1032,7 @@ init_module_lepton_core_rc (void *unused)
                 s_bitmap_directory,
                 s_bus_ripper_symname,
                 s_component_library,
+                s_component_library_command,
                 s_keep_invisible,
                 s_make_backup_files,
                 s_print_color_map,

--- a/liblepton/src/g_rc.c
+++ b/liblepton/src/g_rc.c
@@ -829,20 +829,26 @@ SCM_DEFINE (attribute_promotion, "%attribute-promotion", 0, 1, 0,
  *  \par Function Description
  *
  */
-SCM g_rc_promote_invisible(SCM mode)
+SCM_DEFINE (promote_invisible, "%promote-invisible", 0, 1, 0,
+            (SCM s_mode), "Set attribute promotion behaviour for invisible attributes or return its state.")
 {
-  if (scm_is_eq (mode, SCM_UNDEFINED)) {
+  if (scm_is_eq (s_mode, SCM_UNDEFINED)) {
     return scm_from_bool (default_promote_invisible);
   }
+
+  SCM_ASSERT (scm_is_string (s_mode), s_mode,
+              SCM_ARG1, s_promote_invisible);
 
   static const vstbl_entry mode_table[] = {
     {TRUE , "enabled" },
     {FALSE, "disabled"},
   };
 
-  RETURN_G_RC_MODE("promote-invisible",
-		   default_promote_invisible,
-		   2);
+  return g_rc_mode_general (s_mode,
+                            "promote-invisible",
+                            &default_promote_invisible,
+                            mode_table,
+                            2);
 }
 
 /*! \todo Finish function documentation!!!
@@ -1003,6 +1009,7 @@ init_module_lepton_core_rc (void *unused)
                 s_bitmap_directory,
                 s_bus_ripper_symname,
                 s_print_color_map,
+                s_promote_invisible,
                 s_scheme_directory,
                 NULL);
 }

--- a/liblepton/src/g_rc.c
+++ b/liblepton/src/g_rc.c
@@ -721,9 +721,11 @@ SCM_DEFINE (scheme_directory,"%scheme-directory", 1, 0, 0,
  *  \param [in] path  
  *  \return SCM_BOOL_T on success, SCM_BOOL_F otherwise.
  */
-SCM g_rc_bitmap_directory(SCM path)
+
+SCM_DEFINE (bitmap_directory, "%bitmap-directory", 0, 1, 0,
+            (SCM s_path), "Set bitmap directory to retrieve pictures from.")
 {
-  if (scm_is_eq (path, SCM_UNDEFINED)) {
+  if (scm_is_eq (s_path, SCM_UNDEFINED)) {
     if (default_bitmap_directory != NULL) {
       return scm_from_utf8_string (default_bitmap_directory);
     } else {
@@ -734,11 +736,11 @@ SCM g_rc_bitmap_directory(SCM path)
   gchar *string;
   char *temp;
 
-  SCM_ASSERT (scm_is_string (path), path,
-              SCM_ARG1, "bitmap-directory");
+  SCM_ASSERT (scm_is_string (s_path), s_path,
+              SCM_ARG1, s_bitmap_directory);
   
   /* take care of any shell variables */
-  temp = scm_to_utf8_string (path);
+  temp = scm_to_utf8_string (s_path);
   string = s_expand_env_variables (temp);
   free (temp);
 
@@ -989,7 +991,8 @@ init_module_lepton_core_rc (void *unused)
   #include "g_rc.x"
 
   /* Add them to the module's public definitions. */
-  scm_c_export (s_print_color_map,
+  scm_c_export (s_bitmap_directory,
+                s_print_color_map,
                 s_scheme_directory,
                 NULL);
 }

--- a/liblepton/src/g_rc.c
+++ b/liblepton/src/g_rc.c
@@ -802,20 +802,26 @@ SCM g_rc_reset_component_library(void)
  *  \par Function Description
  *
  */
-SCM g_rc_attribute_promotion(SCM mode)
+SCM_DEFINE (attribute_promotion, "%attribute-promotion", 0, 1, 0,
+            (SCM s_mode), "Set attribute promotion behaviour or return its state.")
 {
-  if (scm_is_eq (mode, SCM_UNDEFINED)) {
+  if (scm_is_eq (s_mode, SCM_UNDEFINED)) {
     return scm_from_bool (default_attribute_promotion);
   }
+
+  SCM_ASSERT (scm_is_string (s_mode), s_mode,
+              SCM_ARG1, s_attribute_promotion);
 
   static const vstbl_entry mode_table[] = {
     {TRUE , "enabled" },
     {FALSE, "disabled"},
   };
 
-  RETURN_G_RC_MODE("attribute-promotion",
-		   default_attribute_promotion,
-		   2);
+  return g_rc_mode_general (s_mode,
+                            "attribute-promotion",
+                            &default_attribute_promotion,
+                            mode_table,
+                            2);
 }
 
 /*! \todo Finish function documentation!!!
@@ -993,7 +999,8 @@ init_module_lepton_core_rc (void *unused)
   #include "g_rc.x"
 
   /* Add them to the module's public definitions. */
-  scm_c_export (s_bitmap_directory,
+  scm_c_export (s_attribute_promotion,
+                s_bitmap_directory,
                 s_bus_ripper_symname,
                 s_print_color_map,
                 s_scheme_directory,

--- a/liblepton/src/g_rc.c
+++ b/liblepton/src/g_rc.c
@@ -43,7 +43,7 @@
 #endif
 
 #include "libgeda_priv.h"
-#include "libgedaguile.h"
+#include "libgedaguile_priv.h"
 
 /*! \todo Finish function documentation!!!
  *  \brief
@@ -926,14 +926,15 @@ SCM g_rc_make_backup_files(SCM mode)
                   2);
 }
 
-SCM g_rc_print_color_map (SCM scm_map)
+SCM_DEFINE (print_color_map, "%print-color-map", 0, 1, 0,
+            (SCM scm_map), "Set or view current print color map.")
 {
   if (scm_is_eq (scm_map, SCM_UNDEFINED)) {
     return s_color_map_to_scm (print_colors);
   }
 
   SCM_ASSERT (scm_is_true (scm_list_p (scm_map)),
-              scm_map, SCM_ARG1, "print-color-map");
+              scm_map, SCM_ARG1, s_print_color_map);
 
   s_color_map_from_scm (print_colors, scm_map, "print-color-map");
   return SCM_BOOL_T;
@@ -971,3 +972,38 @@ g_rc_load_cache_config (TOPLEVEL* toplevel, GError** err)
   return status;
 }
 
+
+
+/*!
+ * \brief Create the (lepton core rc) Scheme module.
+ * \par Function Description
+ * Defines procedures in the (lepton core rc) module. The module can
+ * be accessed using (use-modules (lepton core rc)).
+ */
+static void
+init_module_lepton_core_rc (void *unused)
+{
+  /* Register the functions and symbols */
+  /* #include "scheme_rc.x" */
+  #include "g_rc.x"
+
+  /* Add them to the module's public definitions. */
+  scm_c_export (s_print_color_map,
+                NULL);
+}
+
+/*!
+ * \brief Initialise the host platform support procedures.
+ * \par Function Description
+
+ * Registers some Scheme procedures that provide cross-platform
+ * support. Should only be called by edascm_init().
+ */
+void
+edascm_init_rc ()
+{
+  /* Define the (lepton core os) module */
+  scm_c_define_module ("lepton core rc",
+                       (void (*)(void*)) init_module_lepton_core_rc,
+                       NULL);
+}

--- a/liblepton/src/g_rc.c
+++ b/liblepton/src/g_rc.c
@@ -686,7 +686,8 @@ g_rc_rc_config()
  *  \param [in] s_path  Path to be added.
  *  \return SCM_BOOL_T.
  */
-SCM g_rc_scheme_directory(SCM s_path)
+SCM_DEFINE (scheme_directory,"%scheme-directory", 1, 0, 0,
+            (SCM s_path),"Add a directory to the Guile load path.")
 {
   char *temp;
   gchar *expanded;
@@ -694,7 +695,7 @@ SCM g_rc_scheme_directory(SCM s_path)
   SCM s_load_path;
 
   SCM_ASSERT (scm_is_string (s_path), s_path,
-              SCM_ARG1, "scheme-directory");
+              SCM_ARG1, s_scheme_directory);
 
   /* take care of any shell variables */
   temp = scm_to_utf8_string (s_path);
@@ -989,6 +990,7 @@ init_module_lepton_core_rc (void *unused)
 
   /* Add them to the module's public definitions. */
   scm_c_export (s_print_color_map,
+                s_scheme_directory,
                 NULL);
 }
 

--- a/liblepton/src/g_rc.c
+++ b/liblepton/src/g_rc.c
@@ -484,19 +484,22 @@ g_rc_parse_handler (TOPLEVEL *toplevel,
  *  \param [in] name Optional descriptive name for library directory.
  *  \return SCM_BOOL_T on success, SCM_BOOL_F otherwise.
  */
-SCM g_rc_component_library(SCM path, SCM name)
+
+SCM_DEFINE (component_library, "%component-library", 1, 1, 0,
+            (SCM path, SCM name),
+            "Adds the component library with specified PATH and NAME to the list of component libraries.")
 {
   gchar *string;
   char *temp;
   char *namestr = NULL;
 
   SCM_ASSERT (scm_is_string (path), path,
-              SCM_ARG1, "component-library");
+              SCM_ARG1, s_component_library);
 
   scm_dynwind_begin ((scm_t_dynwind_flags) 0);
   if (!scm_is_eq (name, SCM_UNDEFINED)) {
     SCM_ASSERT (scm_is_string (name), name,
-		SCM_ARG2, "component-library");
+		SCM_ARG2, s_component_library);
     namestr = scm_to_utf8_string (name);
     scm_dynwind_free(namestr);
   }
@@ -1023,6 +1026,7 @@ init_module_lepton_core_rc (void *unused)
                 s_attribute_promotion,
                 s_bitmap_directory,
                 s_bus_ripper_symname,
+                s_component_library,
                 s_keep_invisible,
                 s_make_backup_files,
                 s_print_color_map,

--- a/liblepton/src/g_register.c
+++ b/liblepton/src/g_register.c
@@ -1,5 +1,4 @@
-/* gEDA - GPL Electronic Design Automation
- * libgeda - gEDA's library
+/* Lepton EDA library
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2016 gEDA Contributors
  * Copyright (C) 2016 Peter Brett <peter@peter-b.co.uk>

--- a/liblepton/src/g_register.c
+++ b/liblepton/src/g_register.c
@@ -53,7 +53,6 @@ static struct gsubr_t libgeda_funcs[] = {
   
   { "reset-component-library",   0, 0, 0, (SCM (*) ()) g_rc_reset_component_library },
   
-  { "always-promote-attributes", 1, 0, 0, (SCM (*) ()) g_rc_always_promote_attributes },
   { "make-backup-files",         1, 0, 0, (SCM (*) ()) g_rc_make_backup_files },
   { "rc-filename",               0, 0, 0, (SCM (*) ()) g_rc_rc_filename },
   { "rc-config",                 0, 0, 0, (SCM (*) ()) g_rc_rc_config },

--- a/liblepton/src/g_register.c
+++ b/liblepton/src/g_register.c
@@ -47,8 +47,6 @@ static struct gsubr_t libgeda_funcs[] = {
   { "eval-protected",            1, 1, 0, (SCM (*) ()) g_scm_eval_protected },
   { "eval-string-protected",     1, 0, 0, (SCM (*) ()) g_scm_eval_string_protected },
 
-  { "component-library-funcs",   3, 0, 0, (SCM (*) ()) g_rc_component_library_funcs },
-  
   { "reset-component-library",   0, 0, 0, (SCM (*) ()) g_rc_reset_component_library },
   
   { "rc-filename",               0, 0, 0, (SCM (*) ()) g_rc_rc_filename },

--- a/liblepton/src/g_register.c
+++ b/liblepton/src/g_register.c
@@ -53,7 +53,6 @@ static struct gsubr_t libgeda_funcs[] = {
   
   { "reset-component-library",   0, 0, 0, (SCM (*) ()) g_rc_reset_component_library },
   
-  { "scheme-directory",          1, 0, 0, (SCM (*) ()) g_rc_scheme_directory },
   { "bitmap-directory",          0, 1, 0, (SCM (*) ()) g_rc_bitmap_directory },
   { "bus-ripper-symname",        1, 0, 0, (SCM (*) ()) g_rc_bus_ripper_symname },
   { "attribute-promotion",       0, 1, 0, (SCM (*) ()) g_rc_attribute_promotion },
@@ -90,7 +89,7 @@ static void
 g_register_scheme_data_dir (const gchar *data_dir)
 {
   gchar *scheme_dir = g_build_filename (data_dir, "scheme", NULL);
-  g_rc_scheme_directory (scm_from_locale_string (scheme_dir));
+  scheme_directory (scm_from_locale_string (scheme_dir));
   g_free (scheme_dir);
 }
 

--- a/liblepton/src/g_register.c
+++ b/liblepton/src/g_register.c
@@ -47,7 +47,6 @@ static struct gsubr_t libgeda_funcs[] = {
   { "eval-protected",            1, 1, 0, (SCM (*) ()) g_scm_eval_protected },
   { "eval-string-protected",     1, 0, 0, (SCM (*) ()) g_scm_eval_string_protected },
 
-  { "component-library",         1, 1, 0, (SCM (*) ()) g_rc_component_library },
   { "component-library-command", 3, 0, 0, (SCM (*) ()) g_rc_component_library_command },
   { "component-library-funcs",   3, 0, 0, (SCM (*) ()) g_rc_component_library_funcs },
   

--- a/liblepton/src/g_register.c
+++ b/liblepton/src/g_register.c
@@ -53,7 +53,6 @@ static struct gsubr_t libgeda_funcs[] = {
   
   { "reset-component-library",   0, 0, 0, (SCM (*) ()) g_rc_reset_component_library },
   
-  { "attribute-promotion",       0, 1, 0, (SCM (*) ()) g_rc_attribute_promotion },
   { "promote-invisible",         0, 1, 0, (SCM (*) ()) g_rc_promote_invisible },
   { "keep-invisible",            0, 1, 0, (SCM (*) ()) g_rc_keep_invisible },
   { "always-promote-attributes", 1, 0, 0, (SCM (*) ()) g_rc_always_promote_attributes },

--- a/liblepton/src/g_register.c
+++ b/liblepton/src/g_register.c
@@ -47,7 +47,6 @@ static struct gsubr_t libgeda_funcs[] = {
   { "eval-protected",            1, 1, 0, (SCM (*) ()) g_scm_eval_protected },
   { "eval-string-protected",     1, 0, 0, (SCM (*) ()) g_scm_eval_string_protected },
 
-  { "component-library-command", 3, 0, 0, (SCM (*) ()) g_rc_component_library_command },
   { "component-library-funcs",   3, 0, 0, (SCM (*) ()) g_rc_component_library_funcs },
   
   { "reset-component-library",   0, 0, 0, (SCM (*) ()) g_rc_reset_component_library },

--- a/liblepton/src/g_register.c
+++ b/liblepton/src/g_register.c
@@ -61,7 +61,6 @@ static struct gsubr_t libgeda_funcs[] = {
   { "keep-invisible",            0, 1, 0, (SCM (*) ()) g_rc_keep_invisible },
   { "always-promote-attributes", 1, 0, 0, (SCM (*) ()) g_rc_always_promote_attributes },
   { "make-backup-files",         1, 0, 0, (SCM (*) ()) g_rc_make_backup_files },
-  { "print-color-map",           0, 1, 0, (SCM (*) ()) g_rc_print_color_map },
   { "rc-filename",               0, 0, 0, (SCM (*) ()) g_rc_rc_filename },
   { "rc-config",                 0, 0, 0, (SCM (*) ()) g_rc_rc_config },
   { "parse-rc",                  2, 0, 0, (SCM (*) ()) g_rc_parse_rc },

--- a/liblepton/src/g_register.c
+++ b/liblepton/src/g_register.c
@@ -53,7 +53,6 @@ static struct gsubr_t libgeda_funcs[] = {
   
   { "reset-component-library",   0, 0, 0, (SCM (*) ()) g_rc_reset_component_library },
   
-  { "keep-invisible",            0, 1, 0, (SCM (*) ()) g_rc_keep_invisible },
   { "always-promote-attributes", 1, 0, 0, (SCM (*) ()) g_rc_always_promote_attributes },
   { "make-backup-files",         1, 0, 0, (SCM (*) ()) g_rc_make_backup_files },
   { "rc-filename",               0, 0, 0, (SCM (*) ()) g_rc_rc_filename },

--- a/liblepton/src/g_register.c
+++ b/liblepton/src/g_register.c
@@ -47,8 +47,6 @@ static struct gsubr_t libgeda_funcs[] = {
   { "eval-protected",            1, 1, 0, (SCM (*) ()) g_scm_eval_protected },
   { "eval-string-protected",     1, 0, 0, (SCM (*) ()) g_scm_eval_string_protected },
 
-  { "reset-component-library",   0, 0, 0, (SCM (*) ()) g_rc_reset_component_library },
-  
   { "rc-filename",               0, 0, 0, (SCM (*) ()) g_rc_rc_filename },
   { "rc-config",                 0, 0, 0, (SCM (*) ()) g_rc_rc_config },
   { "parse-rc",                  2, 0, 0, (SCM (*) ()) g_rc_parse_rc },

--- a/liblepton/src/g_register.c
+++ b/liblepton/src/g_register.c
@@ -53,7 +53,6 @@ static struct gsubr_t libgeda_funcs[] = {
   
   { "reset-component-library",   0, 0, 0, (SCM (*) ()) g_rc_reset_component_library },
   
-  { "bitmap-directory",          0, 1, 0, (SCM (*) ()) g_rc_bitmap_directory },
   { "bus-ripper-symname",        1, 0, 0, (SCM (*) ()) g_rc_bus_ripper_symname },
   { "attribute-promotion",       0, 1, 0, (SCM (*) ()) g_rc_attribute_promotion },
   { "promote-invisible",         0, 1, 0, (SCM (*) ()) g_rc_promote_invisible },

--- a/liblepton/src/g_register.c
+++ b/liblepton/src/g_register.c
@@ -53,7 +53,6 @@ static struct gsubr_t libgeda_funcs[] = {
   
   { "reset-component-library",   0, 0, 0, (SCM (*) ()) g_rc_reset_component_library },
   
-  { "bus-ripper-symname",        1, 0, 0, (SCM (*) ()) g_rc_bus_ripper_symname },
   { "attribute-promotion",       0, 1, 0, (SCM (*) ()) g_rc_attribute_promotion },
   { "promote-invisible",         0, 1, 0, (SCM (*) ()) g_rc_promote_invisible },
   { "keep-invisible",            0, 1, 0, (SCM (*) ()) g_rc_keep_invisible },

--- a/liblepton/src/g_register.c
+++ b/liblepton/src/g_register.c
@@ -53,7 +53,6 @@ static struct gsubr_t libgeda_funcs[] = {
   
   { "reset-component-library",   0, 0, 0, (SCM (*) ()) g_rc_reset_component_library },
   
-  { "make-backup-files",         1, 0, 0, (SCM (*) ()) g_rc_make_backup_files },
   { "rc-filename",               0, 0, 0, (SCM (*) ()) g_rc_rc_filename },
   { "rc-config",                 0, 0, 0, (SCM (*) ()) g_rc_rc_config },
   { "parse-rc",                  2, 0, 0, (SCM (*) ()) g_rc_parse_rc },

--- a/liblepton/src/g_register.c
+++ b/liblepton/src/g_register.c
@@ -53,7 +53,6 @@ static struct gsubr_t libgeda_funcs[] = {
   
   { "reset-component-library",   0, 0, 0, (SCM (*) ()) g_rc_reset_component_library },
   
-  { "promote-invisible",         0, 1, 0, (SCM (*) ()) g_rc_promote_invisible },
   { "keep-invisible",            0, 1, 0, (SCM (*) ()) g_rc_keep_invisible },
   { "always-promote-attributes", 1, 0, 0, (SCM (*) ()) g_rc_always_promote_attributes },
   { "make-backup-files",         1, 0, 0, (SCM (*) ()) g_rc_make_backup_files },

--- a/liblepton/src/scheme_init.c
+++ b/liblepton/src/scheme_init.c
@@ -53,6 +53,7 @@ edascm_init_impl (void *data)
   edascm_init_log ();
   edascm_init_version ();
   edascm_init_deprecated ();
+  edascm_init_rc ();
   return NULL;
 }
 

--- a/liblepton/src/scheme_init.c
+++ b/liblepton/src/scheme_init.c
@@ -1,6 +1,7 @@
-/* gEDA - GPL Electronic Design Automation
- * libgeda - gEDA's library - Scheme API
+/* Lepton EDA library
  * Copyright (C) 2010-2013 Peter Brett <peter@peter-b.co.uk>
+ * Copyright (C) 2010-2016 gEDA Contributors
+ * Copyright (C) 2017-2019 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/netlist/scheme/lepton-netlist.in
+++ b/netlist/scheme/lepton-netlist.in
@@ -71,6 +71,7 @@ exec @GUILE@ -s "$0" "$@"
 ;;; program is compiled by Guile. The following modules are
 ;;; necessary to actually run the code below.
 (primitive-eval '(use-modules (geda core toplevel)
+                              (geda deprecated)
                               (geda log)
                               (netlist)))
 

--- a/netlist/scheme/lepton-netlist.in
+++ b/netlist/scheme/lepton-netlist.in
@@ -73,6 +73,7 @@ exec @GUILE@ -s "$0" "$@"
 (primitive-eval '(use-modules (geda core toplevel)
                               (geda deprecated)
                               (geda log)
+                              (lepton library)
                               (netlist)))
 
 ;;; Run netlister in new toplevel environment.


### PR DESCRIPTION
- `component-library` functions are now exported by the module `(lepton library)`
- Several other Scheme functions defined in the C code have been simplified and are exported by the module `(geda deprecated)`
