### PR TITLE
Some fixes for the <package-pin> records

### DIFF
--- a/netlist/scheme/netlist/package-pin.scm
+++ b/netlist/scheme/netlist/package-pin.scm
@@ -38,14 +38,24 @@
 (define-record-type <package-pin>
   (make-package-pin id object type number name label attribs nets connection)
   package-pin?
+  ;; This field is used just for the record representation in
+  ;; set-record-type-printer! below.
   (id package-pin-id set-package-pin-id!)
+  ;; The underlying primitive pin object.
   (object package-pin-object set-package-pin-object!)
+  ;; Corresponds to pin's "pintype" attribute.
   (type package-pin-type set-package-pin-type!)
+  ;; Corresponds to pin's "pinnumber" attribute.
   (number package-pin-number set-package-pin-number!)
+  ;; Corresponds to net name of the net the pin is connected to.
   (name package-pin-name set-package-pin-name!)
+  ;; Corresponds to pin's "pinlabel" attribute.
   (label package-pin-label set-package-pin-label!)
+  ;; The alist representing attributes of the underlying object.
   (attribs package-pin-attribs set-package-pin-attribs!)
+  ;; The list of <pin-net>'s connected to the pin.
   (nets package-pin-nets set-package-pin-nets!)
+  ;; <schematic-connection> the pin is connected to.
   (connection package-pin-connection set-package-pin-connection!))
 
 ;;; Sets default printer for <package-pin>

--- a/netlist/scheme/netlist/package-pin.scm
+++ b/netlist/scheme/netlist/package-pin.scm
@@ -21,17 +21,19 @@
   #:use-module (ice-9 match)
   #:use-module (srfi srfi-9)
   #:use-module (srfi srfi-9 gnu)
-  #:export (make-package-pin package-pin?
-            package-pin-id set-package-pin-id!
-            package-pin-object set-package-pin-object!
-            package-pin-type set-package-pin-type!
-            package-pin-number set-package-pin-number!
-            package-pin-name set-package-pin-name!
-            package-pin-label set-package-pin-label!
-            package-pin-attribs set-package-pin-attribs!
-            package-pin-nets set-package-pin-nets!
-            package-pin-connection set-package-pin-connection!
-            set-package-pin-printer!))
+
+  #:export-syntax (make-package-pin package-pin?
+                   package-pin-id set-package-pin-id!
+                   package-pin-object set-package-pin-object!
+                   package-pin-type set-package-pin-type!
+                   package-pin-number set-package-pin-number!
+                   package-pin-name set-package-pin-name!
+                   package-pin-label set-package-pin-label!
+                   package-pin-attribs set-package-pin-attribs!
+                   package-pin-nets set-package-pin-nets!
+                   package-pin-connection set-package-pin-connection!)
+
+  #:export (set-package-pin-printer!))
 
 (define-record-type <package-pin>
   (make-package-pin id object type number name label attribs nets connection)

--- a/netlist/scheme/netlist/package-pin.scm
+++ b/netlist/scheme/netlist/package-pin.scm
@@ -25,7 +25,6 @@
   #:export-syntax (make-package-pin package-pin?
                    package-pin-id set-package-pin-id!
                    package-pin-object set-package-pin-object!
-                   package-pin-type set-package-pin-type!
                    package-pin-number set-package-pin-number!
                    package-pin-name set-package-pin-name!
                    package-pin-label set-package-pin-label!
@@ -36,15 +35,13 @@
   #:export (set-package-pin-printer!))
 
 (define-record-type <package-pin>
-  (make-package-pin id object type number name label attribs nets connection)
+  (make-package-pin id object number name label attribs nets connection)
   package-pin?
   ;; This field is used just for the record representation in
   ;; set-record-type-printer! below.
   (id package-pin-id set-package-pin-id!)
   ;; The underlying primitive pin object.
   (object package-pin-object set-package-pin-object!)
-  ;; Corresponds to pin's "pintype" attribute.
-  (type package-pin-type set-package-pin-type!)
   ;; Corresponds to pin's "pinnumber" attribute.
   (number package-pin-number set-package-pin-number!)
   ;; Corresponds to net name of the net the pin is connected to.
@@ -69,7 +66,6 @@ FORMAT-STRING must be in the form required by the procedure
 `format'. The following ARGS may be used:
   'id
   'object
-  'type
   'number
   'name
   'label
@@ -89,7 +85,6 @@ Example usage:
                (match arg
                  ('id (package-pin-id record))
                  ('object (package-pin-object record))
-                 ('type (package-pin-type record))
                  ('number (package-pin-number record))
                  ('name (package-pin-name record))
                  ('label (package-pin-label record))

--- a/netlist/scheme/netlist/traverse.scm
+++ b/netlist/scheme/netlist/traverse.scm
@@ -216,7 +216,6 @@
                  nets))
            (make-package-pin (object-id object)
                              object
-                             'net-pin
                              (assq-ref attribs 'pinnumber)
                              netname
                              (assq-ref attribs 'pinlabel)
@@ -293,7 +292,7 @@
            (object #f)
            (attribs '())
            (nets (list (make-pin-net id net-priority netname refdes pinnumber))))
-      (make-package-pin id object 'net pinnumber netname label attribs nets #f)))
+      (make-package-pin id object pinnumber netname label attribs nets #f)))
 
   (define (add-net-power-pin-override pin net-map tag)
     (define (power-pin? pin)


### PR DESCRIPTION
- Get rid of an unused field.
- Use `export-syntax` instead of `export`.
- Add some comments.

No need to update NEWS in this case.