### PR TITLE
Prevent unwanted updates of PO files in lepton-symcheck

### DIFF
--- a/symcheck/po/.gitignore
+++ b/symcheck/po/.gitignore
@@ -7,7 +7,6 @@ POTFILES
 *.sed
 *.header
 *.sin
-lepton-symcheck.pot
 Rules-quot
 Makevars.template
 stamp-po

--- a/symcheck/po/Makevars
+++ b/symcheck/po/Makevars
@@ -10,6 +10,10 @@ top_builddir = ../..
 # These options get passed to xgettext.
 XGETTEXT_OPTIONS = --keyword=_ --keyword=N_
 
+MSGMERGE_OPTIONS = --no-location
+
+PO_DEPENDS_ON_POT = no
+
 # This is the copyright holder that gets inserted into the header of the
 # $(DOMAIN).pot file.  Set this to the copyright holder of the surrounding
 # package.  (Note that the msgstr strings, extracted from the package's

--- a/symcheck/po/it.po
+++ b/symcheck/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda-gsymcheck\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2018-08-12 12:34+0300\n"
+"POT-Creation-Date: 2019-09-21 00:09+0300\n"
 "PO-Revision-Date: 2015-01-12 10:15+0300\n"
 "Last-Translator: Marco Ciampa <ciampix@libero.it>\n"
 "Language-Team: Italian <it@li.org>\n"
@@ -19,254 +19,205 @@ msgstr ""
 "X-Generator: Poedit 1.5.4\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: symcheck/scheme/symbol/check/arc.scm:34
 #, scheme-format
 msgid "Zero radius arc at ~A"
 msgstr ""
 
-#: symcheck/scheme/symbol/check/arc.scm:46
 #, scheme-format
 msgid "Zero angle arc at ~A"
 msgstr ""
 
-#: symcheck/scheme/symbol/check/attrib.scm:51
 #, scheme-format
 msgid ""
 "Set 'graphical=1' if you want the symbol to be graphical, current value: ~A"
 msgstr ""
 
-#: symcheck/scheme/symbol/check/attrib.scm:68
 #, fuzzy
 msgid "Graphical symbols should have device=none"
 msgstr "Trovato simbolo grafico, device=none\n"
 
-#: symcheck/scheme/symbol/check/attrib.scm:80
 #, fuzzy, scheme-format
 msgid "Forbidden attribute: ~A"
 msgstr "Trovato attributo %s= proibito: [%s=%s]\n"
 
-#: symcheck/scheme/symbol/check/attrib.scm:85
 #, scheme-format
 msgid "Obsolete attribute: ~A"
 msgstr ""
 
-#: symcheck/scheme/symbol/check/attrib.scm:93
 #, fuzzy, scheme-format
 msgid "Misplaced pin attribute: ~A"
 msgstr "Trovato attributo pin posizionato erroneamente: [%s=%s]\n"
 
-#: symcheck/scheme/symbol/check/attrib.scm:105
 #, fuzzy, scheme-format
 msgid "Wrongly attached attribute: ~A"
 msgstr "Trovato attributo allegato erroneamente: [%s=%s]\n"
 
-#: symcheck/scheme/symbol/check/attrib.scm:110
 #, scheme-format
 msgid "Unknown attribute: ~A"
 msgstr ""
 
-#: symcheck/scheme/symbol/check/attrib.scm:118
 #, fuzzy, scheme-format
 msgid "Duplicate floating attribute: ~A"
 msgstr "Trovati multipli attributi footprint=\n"
 
-#: symcheck/scheme/symbol/check/attrib.scm:155
 #, fuzzy, scheme-format
 msgid "Missing required attribute: ~A"
 msgstr "Attributo refdes= mancante\n"
 
-#: symcheck/scheme/symbol/check/box.scm:34
 #, scheme-format
 msgid "Zero sized box at ~A"
 msgstr ""
 
-#: symcheck/scheme/symbol/check/circle.scm:33
 #, scheme-format
 msgid "Zero radius circle at ~A"
 msgstr ""
 
-#: symcheck/scheme/symbol/check/connection.scm:32
 #, scheme-format
 msgid "Object with forbidden connections: ~A"
 msgstr ""
 
-#: symcheck/scheme/symbol/check/forbidden.scm:38
 #, scheme-format
 msgid "Object forbidden inside symbols: ~A"
 msgstr ""
 
-#: symcheck/scheme/symbol/check/line.scm:35
 #, scheme-format
 msgid "Zero length ~A at ~A"
 msgstr ""
 
-#: symcheck/scheme/symbol/check/log.scm:35
 msgid "Wrong check log destination!"
 msgstr ""
 
-#: symcheck/scheme/symbol/check/net-attrib.scm:55
 #, fuzzy, scheme-format
 msgid "Missing pin number after \":\" or \",\": ~A"
 msgstr "Attributo pinnumber= mancante\n"
 
-#: symcheck/scheme/symbol/check/net-attrib.scm:73
 #, fuzzy, scheme-format
 msgid "Duplicate pin number in one net= attribute ~A: ~A"
 msgstr "Trovato pinnumber 0 in attributo net=\n"
 
-#: symcheck/scheme/symbol/check/net-attrib.scm:103
 #, fuzzy, scheme-format
 msgid "Invalid net attribute: net=~A"
 msgstr "Attributo net= sbagliato [net=%s]\n"
 
-#: symcheck/scheme/symbol/check/net-attrib.scm:115
 #, fuzzy, scheme-format
 msgid "Duplicate pin number in net= attribute ~A: ~A"
 msgstr "Trovato pinnumber 0 in attributo net=\n"
 
-#: symcheck/scheme/symbol/check/net-attrib.scm:153
 #, scheme-format
 msgid "Duplicate pin number ~A: ~A"
 msgstr ""
 
-#: symcheck/scheme/symbol/check/path.scm:59
 #, scheme-format
 msgid "Zero length path element: ~A"
 msgstr ""
 
-#: symcheck/scheme/symbol/check/picture.scm:35
 #, scheme-format
 msgid "Zero sized picture at ~A"
 msgstr ""
 
-#: symcheck/scheme/symbol/check/picture.scm:51
 #, scheme-format
 msgid "Picture file ~S does not exist or is not readable."
 msgstr ""
 
-#: symcheck/scheme/symbol/check/pin.scm:107
 #, fuzzy, scheme-format
 msgid "Duplicate pin attribute on one pin: ~A"
 msgstr "Trovati attributi multipli pinseq=%s su un pin\n"
 
-#: symcheck/scheme/symbol/check/pin.scm:125
 #, scheme-format
 msgid "Prohibited zero value pin attribute: ~A=0"
 msgstr ""
 
-#: symcheck/scheme/symbol/check/pin.scm:132
 #, fuzzy, scheme-format
 msgid "Invalid pin attribute value: pintype=~A"
 msgstr "Attributo pintype=%s non valido\n"
 
-#: symcheck/scheme/symbol/check/pin.scm:146
 #, fuzzy, scheme-format
 msgid "Missing pin attribute: ~A"
 msgstr "Attributo mancante pinseq=\n"
 
-#: symcheck/scheme/symbol/check/pin-attrib.scm:61
 #, fuzzy, scheme-format
 msgid "Duplicate pin attribute in the symbol: ~A=~A"
 msgstr "Trovato attributo pinseq=%s duplicato nel simbolo\n"
 
-#: symcheck/scheme/symbol/check/primitive.scm:59
 #, scheme-format
 msgid "Object: ~A"
 msgstr ""
 
-#: symcheck/scheme/symbol/check/slot.scm:89
 #, fuzzy, scheme-format
 msgid "Found ~A=~A attribute"
 msgstr "Trovato attributo %s\n"
 
-#: symcheck/scheme/symbol/check/slot.scm:95
 #, fuzzy, scheme-format
 msgid "Invalid slotdef=~A attribute (the format is #:#,#,#,...)"
 msgstr "Malformato slotdef= (il formato è #:#,#,#,...)\n"
 
-#: symcheck/scheme/symbol/check/slot.scm:110
 #, scheme-format
 msgid "Negative attribute: numslots=~A"
 msgstr ""
 
-#: symcheck/scheme/symbol/check/slot.scm:113
 #, fuzzy
 msgid "numslots set to 0, symbol does not have slots"
 msgstr "numslots impostato a zero, il simbolo non ha slots\n"
 
-#: symcheck/scheme/symbol/check/slot.scm:122
 #, fuzzy, scheme-format
 msgid "Zero pin number in slotdef=~A"
 msgstr "Numero slot duplicato in slotdef=%s\n"
 
-#: symcheck/scheme/symbol/check/slot.scm:139
 #, fuzzy, scheme-format
 msgid "Found a zero slot in slotdef=~A"
 msgstr "Trovato uno zero slot in slotdef=%s\n"
 
-#: symcheck/scheme/symbol/check/slot.scm:143
 #, scheme-format
 msgid ""
 "Slot number ~A (slotdef=~A) is greater than the maximum slot number (~A)"
 msgstr ""
 
-#: symcheck/scheme/symbol/check/slot.scm:192
 #, fuzzy, scheme-format
 msgid "Superfluous slotdef=~A:... (there should be ~A slotdef= attributes)"
 msgstr "Mancante slotdef= (dovrebbero esserci %s attributi slotdef=)\n"
 
-#: symcheck/scheme/symbol/check/slot.scm:203
 #, fuzzy, scheme-format
 msgid "Missing slotdef=~A:... (there should be ~A slotdef= attributes)"
 msgstr "Mancante slotdef= (dovrebbero esserci %s attributi slotdef=)\n"
 
-#: symcheck/scheme/symbol/check/slot.scm:218
 #, fuzzy, scheme-format
 msgid "Not enough pins in slotdef=~A (must be ~A)"
 msgstr "Non abbastanza pin in slotdef=%s\n"
 
-#: symcheck/scheme/symbol/check/slot.scm:224
 #, fuzzy, scheme-format
 msgid "Too many pins in slotdef=~A (must be ~A)"
 msgstr "Troppi pin in slotdef=%s\n"
 
-#: symcheck/scheme/symbol/check/slot.scm:238
 #, fuzzy, scheme-format
 msgid "Duplicate slot number ~A: ~A"
 msgstr "Numero slot duplicato in slotdef=%s\n"
 
-#: symcheck/scheme/symbol/check/slot.scm:258
 #, fuzzy, scheme-format
 msgid "Found ~A distinct pins in slots"
 msgstr "Trovati %d pin distinti negli slot\n"
 
-#: symcheck/scheme/symbol/check/text.scm:41
 #, fuzzy, scheme-format
 msgid "Simple text object with only SHOW_NAME or SHOW_VALUE set: ~A"
 msgstr ""
 "Trovato un oggetto di testo semplice con impostati solo SHOW_NAME o "
 "SHOW_VALUE [%s]\n"
 
-#: symcheck/scheme/symbol/check/text.scm:80
 #, fuzzy, scheme-format
 msgid "Text with a trailing '\\', consider to escape it with '\\\\': ~A"
 msgstr ""
 "Trovato testo con un '' finale: considerate di farne l'escape con '\\"
 "\\' [%s]\n"
 
-#: symcheck/scheme/symbol/check/text.scm:82
 #, fuzzy, scheme-format
 msgid "Text with unbalanced overbar markers '\\_' in it': ~A"
 msgstr "Trovato testo con marcatori '\\_' non bilanciati' [%s]\n"
 
-#: symcheck/scheme/symbol/check/text.scm:84
 #, fuzzy, scheme-format
 msgid "Text with a '\\' in it, consider to escape it with '\\\\': ~A"
 msgstr ""
 "Trovato testo con un '\\' in esso: considerate di farne l'escape con '\\"
 "\\' [%s]\n"
 
-#: symcheck/scheme/symcheck/check.scm:36
 #, fuzzy, scheme-format
 msgid ""
 "Usage: ~A [OPTIONS] FILENAME ...\n"
@@ -287,64 +238,52 @@ msgstr ""
 "nomefile1 ... nomefileN sono i simboli da controllare\n"
 "\n"
 
-#: symcheck/scheme/symcheck/check.scm:52
 #, scheme-format
 msgid "Loading schematic ~S"
 msgstr ""
 
-#: symcheck/scheme/symcheck/check.scm:59
 #, fuzzy, scheme-format
 msgid "Checking: ~A\n"
 msgstr "Controllo: %s\n"
 
-#: symcheck/scheme/symcheck/check.scm:73
 #, scheme-format
 msgid ""
 "No schematic files specified for processing.\n"
 "Run `~A --help' for more information.\n"
 msgstr ""
 
-#: symcheck/scheme/symcheck/report.scm:41
 #, fuzzy, scheme-format
 msgid "Info: ~A"
 msgstr "Info: %s"
 
-#: symcheck/scheme/symcheck/report.scm:45
 #, fuzzy, scheme-format
 msgid "Warning: ~A"
 msgstr "Avvertenza: %s"
 
-#: symcheck/scheme/symcheck/report.scm:49
 #, fuzzy, scheme-format
 msgid "ERROR: ~A"
 msgstr "ERRORE: %s"
 
-#: symcheck/scheme/symcheck/report.scm:52
 #, scheme-format
 msgid "Unrecognized info: ~A\n"
 msgstr ""
 
-#: symcheck/scheme/symcheck/report.scm:77
 #, fuzzy, scheme-format
 msgid "~A warning found"
 msgstr "%d avvertimenti trovati "
 
-#: symcheck/scheme/symcheck/report.scm:82
 #, fuzzy
 msgid "(use -vv to view details)"
 msgstr "(usare -vv per visualizzare i dettagli)\n"
 
-#: symcheck/scheme/symcheck/report.scm:85
 #, fuzzy
 msgid "No errors found"
 msgstr "Nessun errore trovato\n"
 
-#: symcheck/scheme/symcheck/report.scm:87
 #, fuzzy, scheme-format
 msgid "~A ERROR found"
 msgstr "1 ERRORE trovato "
 
-#: symcheck/scheme/symcheck/report.scm:92
 #, fuzzy
 msgid "(use -v to view details)"
 msgstr "(usare -v per visualizzare i dettagli)\n"

--- a/symcheck/po/lepton-symcheck.pot
+++ b/symcheck/po/lepton-symcheck.pot
@@ -1,0 +1,327 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR gEDA Developers
+# This file is distributed under the same license as the lepton-eda package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: lepton-eda 1.9.7\n"
+"Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
+"POT-Creation-Date: 2019-09-21 00:09+0300\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: symcheck/scheme/symbol/check/arc.scm:34
+#, scheme-format
+msgid "Zero radius arc at ~A"
+msgstr ""
+
+#: symcheck/scheme/symbol/check/arc.scm:46
+#, scheme-format
+msgid "Zero angle arc at ~A"
+msgstr ""
+
+#: symcheck/scheme/symbol/check/attrib.scm:51
+#, scheme-format
+msgid ""
+"Set 'graphical=1' if you want the symbol to be graphical, current value: ~A"
+msgstr ""
+
+#: symcheck/scheme/symbol/check/attrib.scm:68
+msgid "Graphical symbols should have device=none"
+msgstr ""
+
+#: symcheck/scheme/symbol/check/attrib.scm:80
+#, scheme-format
+msgid "Forbidden attribute: ~A"
+msgstr ""
+
+#: symcheck/scheme/symbol/check/attrib.scm:85
+#, scheme-format
+msgid "Obsolete attribute: ~A"
+msgstr ""
+
+#: symcheck/scheme/symbol/check/attrib.scm:93
+#, scheme-format
+msgid "Misplaced pin attribute: ~A"
+msgstr ""
+
+#: symcheck/scheme/symbol/check/attrib.scm:105
+#, scheme-format
+msgid "Wrongly attached attribute: ~A"
+msgstr ""
+
+#: symcheck/scheme/symbol/check/attrib.scm:110
+#, scheme-format
+msgid "Unknown attribute: ~A"
+msgstr ""
+
+#: symcheck/scheme/symbol/check/attrib.scm:118
+#, scheme-format
+msgid "Duplicate floating attribute: ~A"
+msgstr ""
+
+#: symcheck/scheme/symbol/check/attrib.scm:155
+#, scheme-format
+msgid "Missing required attribute: ~A"
+msgstr ""
+
+#: symcheck/scheme/symbol/check/box.scm:34
+#, scheme-format
+msgid "Zero sized box at ~A"
+msgstr ""
+
+#: symcheck/scheme/symbol/check/circle.scm:33
+#, scheme-format
+msgid "Zero radius circle at ~A"
+msgstr ""
+
+#: symcheck/scheme/symbol/check/connection.scm:32
+#, scheme-format
+msgid "Object with forbidden connections: ~A"
+msgstr ""
+
+#: symcheck/scheme/symbol/check/forbidden.scm:38
+#, scheme-format
+msgid "Object forbidden inside symbols: ~A"
+msgstr ""
+
+#: symcheck/scheme/symbol/check/line.scm:35
+#, scheme-format
+msgid "Zero length ~A at ~A"
+msgstr ""
+
+#: symcheck/scheme/symbol/check/log.scm:35
+msgid "Wrong check log destination!"
+msgstr ""
+
+#: symcheck/scheme/symbol/check/net-attrib.scm:55
+#, scheme-format
+msgid "Missing pin number after \":\" or \",\": ~A"
+msgstr ""
+
+#: symcheck/scheme/symbol/check/net-attrib.scm:73
+#, scheme-format
+msgid "Duplicate pin number in one net= attribute ~A: ~A"
+msgstr ""
+
+#: symcheck/scheme/symbol/check/net-attrib.scm:103
+#, scheme-format
+msgid "Invalid net attribute: net=~A"
+msgstr ""
+
+#: symcheck/scheme/symbol/check/net-attrib.scm:115
+#, scheme-format
+msgid "Duplicate pin number in net= attribute ~A: ~A"
+msgstr ""
+
+#: symcheck/scheme/symbol/check/net-attrib.scm:153
+#, scheme-format
+msgid "Duplicate pin number ~A: ~A"
+msgstr ""
+
+#: symcheck/scheme/symbol/check/path.scm:59
+#, scheme-format
+msgid "Zero length path element: ~A"
+msgstr ""
+
+#: symcheck/scheme/symbol/check/picture.scm:35
+#, scheme-format
+msgid "Zero sized picture at ~A"
+msgstr ""
+
+#: symcheck/scheme/symbol/check/picture.scm:51
+#, scheme-format
+msgid "Picture file ~S does not exist or is not readable."
+msgstr ""
+
+#: symcheck/scheme/symbol/check/pin.scm:107
+#, scheme-format
+msgid "Duplicate pin attribute on one pin: ~A"
+msgstr ""
+
+#: symcheck/scheme/symbol/check/pin.scm:125
+#, scheme-format
+msgid "Prohibited zero value pin attribute: ~A=0"
+msgstr ""
+
+#: symcheck/scheme/symbol/check/pin.scm:132
+#, scheme-format
+msgid "Invalid pin attribute value: pintype=~A"
+msgstr ""
+
+#: symcheck/scheme/symbol/check/pin.scm:146
+#, scheme-format
+msgid "Missing pin attribute: ~A"
+msgstr ""
+
+#: symcheck/scheme/symbol/check/pin-attrib.scm:61
+#, scheme-format
+msgid "Duplicate pin attribute in the symbol: ~A=~A"
+msgstr ""
+
+#: symcheck/scheme/symbol/check/primitive.scm:59
+#, scheme-format
+msgid "Object: ~A"
+msgstr ""
+
+#: symcheck/scheme/symbol/check/slot.scm:89
+#, scheme-format
+msgid "Found ~A=~A attribute"
+msgstr ""
+
+#: symcheck/scheme/symbol/check/slot.scm:95
+#, scheme-format
+msgid "Invalid slotdef=~A attribute (the format is #:#,#,#,...)"
+msgstr ""
+
+#: symcheck/scheme/symbol/check/slot.scm:110
+#, scheme-format
+msgid "Negative attribute: numslots=~A"
+msgstr ""
+
+#: symcheck/scheme/symbol/check/slot.scm:113
+msgid "numslots set to 0, symbol does not have slots"
+msgstr ""
+
+#: symcheck/scheme/symbol/check/slot.scm:122
+#, scheme-format
+msgid "Zero pin number in slotdef=~A"
+msgstr ""
+
+#: symcheck/scheme/symbol/check/slot.scm:139
+#, scheme-format
+msgid "Found a zero slot in slotdef=~A"
+msgstr ""
+
+#: symcheck/scheme/symbol/check/slot.scm:143
+#, scheme-format
+msgid ""
+"Slot number ~A (slotdef=~A) is greater than the maximum slot number (~A)"
+msgstr ""
+
+#: symcheck/scheme/symbol/check/slot.scm:192
+#, scheme-format
+msgid "Superfluous slotdef=~A:... (there should be ~A slotdef= attributes)"
+msgstr ""
+
+#: symcheck/scheme/symbol/check/slot.scm:203
+#, scheme-format
+msgid "Missing slotdef=~A:... (there should be ~A slotdef= attributes)"
+msgstr ""
+
+#: symcheck/scheme/symbol/check/slot.scm:218
+#, scheme-format
+msgid "Not enough pins in slotdef=~A (must be ~A)"
+msgstr ""
+
+#: symcheck/scheme/symbol/check/slot.scm:224
+#, scheme-format
+msgid "Too many pins in slotdef=~A (must be ~A)"
+msgstr ""
+
+#: symcheck/scheme/symbol/check/slot.scm:238
+#, scheme-format
+msgid "Duplicate slot number ~A: ~A"
+msgstr ""
+
+#: symcheck/scheme/symbol/check/slot.scm:258
+#, scheme-format
+msgid "Found ~A distinct pins in slots"
+msgstr ""
+
+#: symcheck/scheme/symbol/check/text.scm:41
+#, scheme-format
+msgid "Simple text object with only SHOW_NAME or SHOW_VALUE set: ~A"
+msgstr ""
+
+#: symcheck/scheme/symbol/check/text.scm:80
+#, scheme-format
+msgid "Text with a trailing '\\', consider to escape it with '\\\\': ~A"
+msgstr ""
+
+#: symcheck/scheme/symbol/check/text.scm:82
+#, scheme-format
+msgid "Text with unbalanced overbar markers '\\_' in it': ~A"
+msgstr ""
+
+#: symcheck/scheme/symbol/check/text.scm:84
+#, scheme-format
+msgid "Text with a '\\' in it, consider to escape it with '\\\\': ~A"
+msgstr ""
+
+#: symcheck/scheme/symcheck/check.scm:36
+#, scheme-format
+msgid ""
+"Usage: ~A [OPTIONS] FILENAME ...\n"
+"  -h, --help        Print usage\n"
+"  -q, --quiet       Quiet mode\n"
+"  -v, --verbose     Verbose mode (cumulative: errors, warnings, info)\n"
+"                    Use this to get the actual symbol error messages\n"
+"FILENAME ... are the symbols to check.\n"
+msgstr ""
+
+#: symcheck/scheme/symcheck/check.scm:52
+#, scheme-format
+msgid "Loading schematic ~S"
+msgstr ""
+
+#: symcheck/scheme/symcheck/check.scm:59
+#, scheme-format
+msgid "Checking: ~A\n"
+msgstr ""
+
+#: symcheck/scheme/symcheck/check.scm:65
+#, scheme-format
+msgid ""
+"No schematic files specified for processing.\n"
+"Run `~A --help' for more information.\n"
+msgstr ""
+
+#: symcheck/scheme/symcheck/report.scm:41
+#, scheme-format
+msgid "Info: ~A"
+msgstr ""
+
+#: symcheck/scheme/symcheck/report.scm:45
+#, scheme-format
+msgid "Warning: ~A"
+msgstr ""
+
+#: symcheck/scheme/symcheck/report.scm:49
+#, scheme-format
+msgid "ERROR: ~A"
+msgstr ""
+
+#: symcheck/scheme/symcheck/report.scm:52
+#, scheme-format
+msgid "Unrecognized info: ~A\n"
+msgstr ""
+
+#: symcheck/scheme/symcheck/report.scm:77
+#, scheme-format
+msgid "~A warning found"
+msgstr ""
+
+#: symcheck/scheme/symcheck/report.scm:82
+msgid "(use -vv to view details)"
+msgstr ""
+
+#: symcheck/scheme/symcheck/report.scm:85
+msgid "No errors found"
+msgstr ""
+
+#: symcheck/scheme/symcheck/report.scm:87
+#, scheme-format
+msgid "~A ERROR found"
+msgstr ""
+
+#: symcheck/scheme/symcheck/report.scm:92
+msgid "(use -v to view details)"
+msgstr ""

--- a/symcheck/po/nl.po
+++ b/symcheck/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda-gsymcheck\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2018-08-12 12:34+0300\n"
+"POT-Creation-Date: 2019-09-21 00:09+0300\n"
 "PO-Revision-Date: 2014-08-31 22:48+0100\n"
 "Last-Translator: Bert Timmerman <bert.timmerman@xs4all.nl>\n"
 "Language-Team: gEDA Developers\n"
@@ -18,254 +18,205 @@ msgstr ""
 "X-Poedit-Language: Dutch\n"
 "X-Poedit-Country: NETHERLANDS\n"
 
-#: symcheck/scheme/symbol/check/arc.scm:34
 #, scheme-format
 msgid "Zero radius arc at ~A"
 msgstr ""
 
-#: symcheck/scheme/symbol/check/arc.scm:46
 #, scheme-format
 msgid "Zero angle arc at ~A"
 msgstr ""
 
-#: symcheck/scheme/symbol/check/attrib.scm:51
 #, scheme-format
 msgid ""
 "Set 'graphical=1' if you want the symbol to be graphical, current value: ~A"
 msgstr ""
 
-#: symcheck/scheme/symbol/check/attrib.scm:68
 #, fuzzy
 msgid "Graphical symbols should have device=none"
 msgstr "Grafisch symbool gevonden, device=none\n"
 
-#: symcheck/scheme/symbol/check/attrib.scm:80
 #, fuzzy, scheme-format
 msgid "Forbidden attribute: ~A"
 msgstr "Verboden %s= attribuut: [%s=%s] gevonden\n"
 
-#: symcheck/scheme/symbol/check/attrib.scm:85
 #, scheme-format
 msgid "Obsolete attribute: ~A"
 msgstr ""
 
-#: symcheck/scheme/symbol/check/attrib.scm:93
 #, fuzzy, scheme-format
 msgid "Misplaced pin attribute: ~A"
 msgstr "Misplaatst pen attribuut: [%s=%s] gevonden\n"
 
-#: symcheck/scheme/symbol/check/attrib.scm:105
 #, fuzzy, scheme-format
 msgid "Wrongly attached attribute: ~A"
 msgstr "Verkeerd bevestigd attribuut: [%s=%s] gevonden\n"
 
-#: symcheck/scheme/symbol/check/attrib.scm:110
 #, scheme-format
 msgid "Unknown attribute: ~A"
 msgstr ""
 
-#: symcheck/scheme/symbol/check/attrib.scm:118
 #, fuzzy, scheme-format
 msgid "Duplicate floating attribute: ~A"
 msgstr "Meerdere footprint= attributen gevonden\n"
 
-#: symcheck/scheme/symbol/check/attrib.scm:155
 #, fuzzy, scheme-format
 msgid "Missing required attribute: ~A"
 msgstr "Ontbrekend refdes= attribuut\n"
 
-#: symcheck/scheme/symbol/check/box.scm:34
 #, scheme-format
 msgid "Zero sized box at ~A"
 msgstr ""
 
-#: symcheck/scheme/symbol/check/circle.scm:33
 #, scheme-format
 msgid "Zero radius circle at ~A"
 msgstr ""
 
-#: symcheck/scheme/symbol/check/connection.scm:32
 #, scheme-format
 msgid "Object with forbidden connections: ~A"
 msgstr ""
 
-#: symcheck/scheme/symbol/check/forbidden.scm:38
 #, scheme-format
 msgid "Object forbidden inside symbols: ~A"
 msgstr ""
 
-#: symcheck/scheme/symbol/check/line.scm:35
 #, scheme-format
 msgid "Zero length ~A at ~A"
 msgstr ""
 
-#: symcheck/scheme/symbol/check/log.scm:35
 msgid "Wrong check log destination!"
 msgstr ""
 
-#: symcheck/scheme/symbol/check/net-attrib.scm:55
 #, fuzzy, scheme-format
 msgid "Missing pin number after \":\" or \",\": ~A"
 msgstr "Ontbrekend pinnumber= attribuut\n"
 
-#: symcheck/scheme/symbol/check/net-attrib.scm:73
 #, fuzzy, scheme-format
 msgid "Duplicate pin number in one net= attribute ~A: ~A"
 msgstr "Pen met nummer 0 in net= attribuut gevonden\n"
 
-#: symcheck/scheme/symbol/check/net-attrib.scm:103
 #, fuzzy, scheme-format
 msgid "Invalid net attribute: net=~A"
 msgstr "Slecht net= attribuut [net=%s]\n"
 
-#: symcheck/scheme/symbol/check/net-attrib.scm:115
 #, fuzzy, scheme-format
 msgid "Duplicate pin number in net= attribute ~A: ~A"
 msgstr "Pen met nummer 0 in net= attribuut gevonden\n"
 
-#: symcheck/scheme/symbol/check/net-attrib.scm:153
 #, scheme-format
 msgid "Duplicate pin number ~A: ~A"
 msgstr ""
 
-#: symcheck/scheme/symbol/check/path.scm:59
 #, scheme-format
 msgid "Zero length path element: ~A"
 msgstr ""
 
-#: symcheck/scheme/symbol/check/picture.scm:35
 #, scheme-format
 msgid "Zero sized picture at ~A"
 msgstr ""
 
-#: symcheck/scheme/symbol/check/picture.scm:51
 #, scheme-format
 msgid "Picture file ~S does not exist or is not readable."
 msgstr ""
 
-#: symcheck/scheme/symbol/check/pin.scm:107
 #, fuzzy, scheme-format
 msgid "Duplicate pin attribute on one pin: ~A"
 msgstr "Meerdere pinseq=%s attributen op een pen gevonden\n"
 
-#: symcheck/scheme/symbol/check/pin.scm:125
 #, scheme-format
 msgid "Prohibited zero value pin attribute: ~A=0"
 msgstr ""
 
-#: symcheck/scheme/symbol/check/pin.scm:132
 #, fuzzy, scheme-format
 msgid "Invalid pin attribute value: pintype=~A"
 msgstr "Ongeldig pintype=%s attribuut\n"
 
-#: symcheck/scheme/symbol/check/pin.scm:146
 #, fuzzy, scheme-format
 msgid "Missing pin attribute: ~A"
 msgstr "Ontbrekend pinseq= attribuut\n"
 
-#: symcheck/scheme/symbol/check/pin-attrib.scm:61
 #, fuzzy, scheme-format
 msgid "Duplicate pin attribute in the symbol: ~A=~A"
 msgstr "Dubbel pinseq=%s attribuut in het symbool gevonden\n"
 
-#: symcheck/scheme/symbol/check/primitive.scm:59
 #, scheme-format
 msgid "Object: ~A"
 msgstr ""
 
-#: symcheck/scheme/symbol/check/slot.scm:89
 #, fuzzy, scheme-format
 msgid "Found ~A=~A attribute"
 msgstr "%s attribuut gevonden\n"
 
-#: symcheck/scheme/symbol/check/slot.scm:95
 #, fuzzy, scheme-format
 msgid "Invalid slotdef=~A attribute (the format is #:#,#,#,...)"
 msgstr "Misvormd slotdef= (het formaat is #:#,#,#,...)\n"
 
-#: symcheck/scheme/symbol/check/slot.scm:110
 #, scheme-format
 msgid "Negative attribute: numslots=~A"
 msgstr ""
 
-#: symcheck/scheme/symbol/check/slot.scm:113
 #, fuzzy
 msgid "numslots set to 0, symbol does not have slots"
 msgstr "numslots op nul ingesteld, symbool heeft geen slots\n"
 
-#: symcheck/scheme/symbol/check/slot.scm:122
 #, fuzzy, scheme-format
 msgid "Zero pin number in slotdef=~A"
 msgstr "Dubbel slot nummer in slotdef=%s\n"
 
-#: symcheck/scheme/symbol/check/slot.scm:139
 #, fuzzy, scheme-format
 msgid "Found a zero slot in slotdef=~A"
 msgstr "Een nul slot gevonden in slotdef=%s\n"
 
-#: symcheck/scheme/symbol/check/slot.scm:143
 #, scheme-format
 msgid ""
 "Slot number ~A (slotdef=~A) is greater than the maximum slot number (~A)"
 msgstr ""
 
-#: symcheck/scheme/symbol/check/slot.scm:192
 #, fuzzy, scheme-format
 msgid "Superfluous slotdef=~A:... (there should be ~A slotdef= attributes)"
 msgstr "Ontbrekend slotdef= (er zouden %s slotdef= attributen moeten zijn)\n"
 
-#: symcheck/scheme/symbol/check/slot.scm:203
 #, fuzzy, scheme-format
 msgid "Missing slotdef=~A:... (there should be ~A slotdef= attributes)"
 msgstr "Ontbrekend slotdef= (er zouden %s slotdef= attributen moeten zijn)\n"
 
-#: symcheck/scheme/symbol/check/slot.scm:218
 #, fuzzy, scheme-format
 msgid "Not enough pins in slotdef=~A (must be ~A)"
 msgstr "Niet genoeg pennen in slotdef=%s\n"
 
-#: symcheck/scheme/symbol/check/slot.scm:224
 #, fuzzy, scheme-format
 msgid "Too many pins in slotdef=~A (must be ~A)"
 msgstr "Teveel pennen in slotdef=%s\n"
 
-#: symcheck/scheme/symbol/check/slot.scm:238
 #, fuzzy, scheme-format
 msgid "Duplicate slot number ~A: ~A"
 msgstr "Dubbel slot nummer in slotdef=%s\n"
 
-#: symcheck/scheme/symbol/check/slot.scm:258
 #, fuzzy, scheme-format
 msgid "Found ~A distinct pins in slots"
 msgstr "%d aparte pennen in slots gevonden\n"
 
-#: symcheck/scheme/symbol/check/text.scm:41
 #, fuzzy, scheme-format
 msgid "Simple text object with only SHOW_NAME or SHOW_VALUE set: ~A"
 msgstr ""
 "Een eenvoudig tekst object gevonden met alleen SHOW_NAME of SHOW_VALUE "
 "ingesteld [%s]\n"
 
-#: symcheck/scheme/symbol/check/text.scm:80
 #, fuzzy, scheme-format
 msgid "Text with a trailing '\\', consider to escape it with '\\\\': ~A"
 msgstr ""
 "Tekst met een achterblijvende '': overweeg om met een '\\\\' stuurcode te "
 "ontkomen [%s]\n"
 
-#: symcheck/scheme/symbol/check/text.scm:82
 #, fuzzy, scheme-format
 msgid "Text with unbalanced overbar markers '\\_' in it': ~A"
 msgstr "Tekst met ongebalanceerde overstreep merkers '\\_' gevonden' [%s]\n"
 
-#: symcheck/scheme/symbol/check/text.scm:84
 #, fuzzy, scheme-format
 msgid "Text with a '\\' in it, consider to escape it with '\\\\': ~A"
 msgstr ""
 "Tekst met een '\\' gevonden: overweeg om met een '\\\\' stuurcode te "
 "ontkomen [%s]\n"
 
-#: symcheck/scheme/symcheck/check.scm:36
 #, fuzzy, scheme-format
 msgid ""
 "Usage: ~A [OPTIONS] FILENAME ...\n"
@@ -286,64 +237,52 @@ msgstr ""
 "bestandsnaam1 ... bestandsnaamN zijn de te controleren symbolen\n"
 "\n"
 
-#: symcheck/scheme/symcheck/check.scm:52
 #, scheme-format
 msgid "Loading schematic ~S"
 msgstr ""
 
-#: symcheck/scheme/symcheck/check.scm:59
 #, fuzzy, scheme-format
 msgid "Checking: ~A\n"
 msgstr "Controleer: %s\n"
 
-#: symcheck/scheme/symcheck/check.scm:73
 #, scheme-format
 msgid ""
 "No schematic files specified for processing.\n"
 "Run `~A --help' for more information.\n"
 msgstr ""
 
-#: symcheck/scheme/symcheck/report.scm:41
 #, fuzzy, scheme-format
 msgid "Info: ~A"
 msgstr "Info: %s"
 
-#: symcheck/scheme/symcheck/report.scm:45
 #, fuzzy, scheme-format
 msgid "Warning: ~A"
 msgstr "Waarschuwing: %s"
 
-#: symcheck/scheme/symcheck/report.scm:49
 #, fuzzy, scheme-format
 msgid "ERROR: ~A"
 msgstr "FOUT: %s"
 
-#: symcheck/scheme/symcheck/report.scm:52
 #, scheme-format
 msgid "Unrecognized info: ~A\n"
 msgstr ""
 
-#: symcheck/scheme/symcheck/report.scm:77
 #, fuzzy, scheme-format
 msgid "~A warning found"
 msgstr "%d waarschuwingen gevonden "
 
-#: symcheck/scheme/symcheck/report.scm:82
 #, fuzzy
 msgid "(use -vv to view details)"
 msgstr "(gebruik -vv om details te zien)\n"
 
-#: symcheck/scheme/symcheck/report.scm:85
 #, fuzzy
 msgid "No errors found"
 msgstr "Geen fouten gevonden\n"
 
-#: symcheck/scheme/symcheck/report.scm:87
 #, fuzzy, scheme-format
 msgid "~A ERROR found"
 msgstr "1 FOUT gevonden "
 
-#: symcheck/scheme/symcheck/report.scm:92
 #, fuzzy
 msgid "(use -v to view details)"
 msgstr "(gebruik -v om details te zien)\n"


### PR DESCRIPTION
The same changes as in #342, #389, #392:

1) add `lepton-symcheck.pot` to source control
2) modify `Makevars`:
    - `MSGMERGE_OPTIONS = --no-location`
    (eliminates comments with line numbers in `*.po`)
    - `PO_DEPENDS_ON_POT = no`
    (do not modify `PO` files if it's not necessary)
3) `make -C symcheck/po/ update-po`