### PR TITLE
Convert page manager dialog to widget

### DIFF
--- a/schematic/include/Makefile.am
+++ b/schematic/include/Makefile.am
@@ -3,10 +3,14 @@
 ## Process this file with automake to produce Makefile.in
 
 noinst_HEADERS = \
-	globals.h i_vars.h prototype.h x_dialog.h x_states.h \
+	globals.h \
+	i_vars.h \
+	prototype.h \
+	x_dialog.h \
+	x_states.h \
 	gettext.h \
 	x_compselect.h \
-	x_multiattrib.h x_pagesel.h \
+	x_multiattrib.h \
 	gschem.h \
 	gschemhotkeystore.h \
 	gschem_accel_label.h \
@@ -39,8 +43,9 @@ noinst_HEADERS = \
 	gschem_text_properties_widget.h \
 	gschem_translate_widget.h \
 	gschem_toplevel.h \
-    color_edit_widget.h \
-    font_select_widget.h
+	color_edit_widget.h \
+	font_select_widget.h \
+	page_select_widget.h
 
 MOSTLYCLEANFILES = *.log core FILE *~
 CLEANFILES = *.log core FILE *~

--- a/schematic/include/gschem.h
+++ b/schematic/include/gschem.h
@@ -40,7 +40,6 @@ typedef void (*i_callback_func) (gpointer, guint, GtkWidget*);
 #include "gschem_preview.h"
 #include "x_compselect.h"
 #include "x_dialog.h"
-#include "x_pagesel.h"
 #include "x_states.h"
 #include "gschem_swatch_column_renderer.h"
 #include "gschem_fill_swatch_cell_renderer.h"
@@ -57,6 +56,7 @@ typedef void (*i_callback_func) (gpointer, guint, GtkWidget*);
 
 #include "color_edit_widget.h"
 #include "font_select_widget.h"
+#include "page_select_widget.h"
 
 /* Gettext translation */
 #include "gettext.h"

--- a/schematic/include/gschem_toplevel.h
+++ b/schematic/include/gschem_toplevel.h
@@ -1,6 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
- * Copyright (C) 1998-2013 gEDA Contributors (see ChangeLog for details)
+ * Copyright (C) 1998-2016 gEDA Contributors
+ * Copyright (C) 2017-2019 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -75,6 +76,9 @@ struct st_gschem_toplevel {
   /* font selection widget: */
   GtkWidget *font_select_widget;
 
+  /* page selection widget: */
+  GtkWidget *page_select_widget;
+
   /* dialogs for widgets */
   GtkWidget *options_widget_dialog;
   GtkWidget *text_properties_dialog;
@@ -83,6 +87,7 @@ struct st_gschem_toplevel {
   GtkWidget *find_text_state_dialog;
   GtkWidget *color_edit_dialog;
   GtkWidget *font_select_dialog;
+  GtkWidget *page_select_dialog;
 
 
   gchar *keyaccel_string;               /* visual feedback when pressing
@@ -95,7 +100,6 @@ struct st_gschem_toplevel {
   GtkWidget *sowindow;                  /* Script open */
   GtkWidget *pfswindow;                 /* Picture File Selection window */
   GtkWidget *cswindow;                  /* component select */
-  GtkWidget *pswindow;                  /* page select */
   GtkWidget *tiwindow;                  /* text input */
   GtkWidget *sewindow;                  /* slot edit */
   GtkWidget *aawindow;                  /* arc attribs */

--- a/schematic/include/page_select_widget.h
+++ b/schematic/include/page_select_widget.h
@@ -52,9 +52,6 @@ GtkWidget*
 page_select_widget_new (GschemToplevel* w_current);
 
 void
-page_select_widget_close (GschemToplevel* w_current);
-
-void
 page_select_widget_update (GschemToplevel* w_current);
 
 

--- a/schematic/include/page_select_widget.h
+++ b/schematic/include/page_select_widget.h
@@ -19,8 +19,8 @@
  * MA 02111-1301 USA.
  */
 
-#ifndef LEPTON_PAGESEL_H_
-#define LEPTON_PAGESEL_H_
+#ifndef LEPTON_PAGE_SELECT_WIDGET_H_
+#define LEPTON_PAGE_SELECT_WIDGET_H_
 
 
 #define PAGE_SELECT_WIDGET_TYPE (page_select_widget_get_type())
@@ -52,14 +52,14 @@ GtkWidget*
 page_select_widget_new (GschemToplevel* w_current);
 
 void
-page_select_widget_close (GschemToplevel *w_current);
+page_select_widget_close (GschemToplevel* w_current);
 
 void
-page_select_widget_update (GschemToplevel *w_current);
+page_select_widget_update (GschemToplevel* w_current);
 
 
 GType
 page_select_widget_get_type();
 
-#endif /* LEPTON_PAGESEL_H_ */
+#endif /* LEPTON_PAGE_SELECT_WIDGET_H_ */
 

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -696,12 +696,6 @@ void x_menu_attach_recent_files_submenu(GschemToplevel *w_current);
 void x_multiattrib_open (GschemToplevel *w_current);
 void x_multiattrib_close (GschemToplevel *w_current);
 void x_multiattrib_update (GschemToplevel *w_current);
-/* x_multimulti.c */
-/* x_pagesel.c */
-void x_pagesel_open (GschemToplevel *w_current);
-void x_pagesel_close (GschemToplevel *w_current);
-void x_pagesel_update (GschemToplevel *w_current);
-/* x_preview.c */
 /* x_print.c */
 gboolean x_print_export_pdf_page (GschemToplevel *w_current, const gchar *filename);
 gboolean x_print_export_pdf (GschemToplevel *w_current, const gchar *filename, gboolean is_color);
@@ -755,6 +749,7 @@ void x_widgets_show_log (GschemToplevel* w_current);
 void x_widgets_show_find_text_state (GschemToplevel* w_current);
 void x_widgets_show_color_edit (GschemToplevel* w_current);
 void x_widgets_show_font_select (GschemToplevel* w_current);
+void x_widgets_show_page_select (GschemToplevel* w_current);
 
 /* x_tabs.c */
 gboolean x_tabs_enabled();

--- a/schematic/include/x_pagesel.h
+++ b/schematic/include/x_pagesel.h
@@ -1,5 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
+ * Copyright (C) 2012 gEDA Contributors
+ * Copyright (C) 2017-2019 Lepton EDA Contributors
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -21,30 +23,43 @@
 #define LEPTON_PAGESEL_H_
 
 
-#define TYPE_PAGESEL         (pagesel_get_type())
-#define PAGESEL(obj)         (G_TYPE_CHECK_INSTANCE_CAST ((obj), TYPE_PAGESEL, Pagesel))
-#define PAGESEL_CLASS(klass) (G_TYPE_CHECK_CLASS_CAST ((klass), TYPE_PAGESEL, PageselClass))
-#define IS_PAGESEL(obj)      (G_TYPE_CHECK_INSTANCE_TYPE ((obj), TYPE_PAGESEL))
+#define PAGE_SELECT_WIDGET_TYPE (page_select_widget_get_type())
+#define PAGE_SELECT_WIDGET(obj) (G_TYPE_CHECK_INSTANCE_CAST ((obj), PAGE_SELECT_WIDGET_TYPE, PageSelectWidget))
+#define PAGE_SELECT_WIDGET_CLASS(cls) (G_TYPE_CHECK_CLASS_CAST ((cls), PAGE_SELECT_WIDGET_TYPE, PageSelectWidgetClass))
+#define IS_PAGE_SELECT_WIDGET(obj) (G_TYPE_CHECK_INSTANCE_TYPE ((obj), PAGE_SELECT_WIDGET_TYPE))
+#define PAGE_SELECT_WIDGET_GET_CLASS(obj) (G_TYPE_INSTANCE_GET_CLASS ((obj), PAGE_SELECT_WIDGET_TYPE, PageSelectWidgetClass))
 
 
-typedef struct _PageselClass PageselClass;
-typedef struct _Pagesel      Pagesel;
-
-
-struct _PageselClass {
-  GschemDialogClass parent_class;
+struct _PageSelectWidgetClass
+{
+  GschemBinClass parent_class;
 };
 
-struct _Pagesel {
-  GschemDialog parent_instance;
+struct _PageSelectWidget
+{
+  GschemBinClass parent_instance;
 
-  GtkTreeView *treeview;
-
-  gboolean show_full_paths;
+  GschemToplevel* toplevel_;
+  GtkTreeView*    treeview_;
+  gboolean        show_paths_;
 };
 
+typedef struct _PageSelectWidgetClass PageSelectWidgetClass;
+typedef struct _PageSelectWidget      PageSelectWidget;
 
-GType pagesel_get_type (void);
+
+GtkWidget*
+page_select_widget_new (GschemToplevel* w_current);
+
+void
+page_select_widget_close (GschemToplevel *w_current);
+
+void
+page_select_widget_update (GschemToplevel *w_current);
+
+
+GType
+page_select_widget_get_type();
 
 #endif /* LEPTON_PAGESEL_H_ */
 

--- a/schematic/po/POTFILES.in
+++ b/schematic/po/POTFILES.in
@@ -94,7 +94,7 @@ schematic/src/x_menus.c
 schematic/src/x_misc.c
 schematic/src/x_multiattrib.c
 schematic/src/x_newtext.c
-schematic/src/x_pagesel.c
+schematic/src/page_select_widget.c
 schematic/src/x_print.c
 schematic/src/x_rc.c
 schematic/src/x_script.c

--- a/schematic/src/Makefile.am
+++ b/schematic/src/Makefile.am
@@ -112,7 +112,7 @@ lepton_schematic_SOURCES = \
 	x_misc.c \
 	x_multiattrib.c \
 	x_newtext.c \
-	x_pagesel.c \
+	page_select_widget.c \
 	x_print.c \
 	x_rc.c \
 	x_script.c \

--- a/schematic/src/gschem_toplevel.c
+++ b/schematic/src/gschem_toplevel.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2016 gEDA Contributors
- * Copyright (C) 2017-2018 Lepton EDA Contributors
+ * Copyright (C) 2017-2019 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -198,6 +198,9 @@ GschemToplevel *gschem_toplevel_new ()
   /* font selection widget: */
   w_current->font_select_widget = NULL;
 
+  /* page selection widget: */
+  w_current->page_select_widget = NULL;
+
   /* dialogs for widgets */
   w_current->options_widget_dialog    = NULL;
   w_current->text_properties_dialog   = NULL;
@@ -206,6 +209,7 @@ GschemToplevel *gschem_toplevel_new ()
   w_current->find_text_state_dialog   = NULL;
   w_current->color_edit_dialog        = NULL;
   w_current->font_select_dialog       = NULL;
+  w_current->page_select_dialog       = NULL;
 
 
   w_current->keyaccel_string = NULL;
@@ -217,7 +221,6 @@ GschemToplevel *gschem_toplevel_new ()
   w_current->sowindow     = NULL;
   w_current->pfswindow    = NULL;
   w_current->cswindow     = NULL;
-  w_current->pswindow     = NULL;
   w_current->tiwindow     = NULL;
   w_current->sewindow     = NULL;
   w_current->aawindow     = NULL;
@@ -689,7 +692,7 @@ gschem_toplevel_page_content_changed (GschemToplevel *w_current, PAGE *page)
 
   page->CHANGED = 1;
 
-  x_pagesel_update (w_current);
+  page_select_widget_update (w_current);
 }
 
 

--- a/schematic/src/i_callbacks.c
+++ b/schematic/src/i_callbacks.c
@@ -250,7 +250,7 @@ DEFINE_I_CALLBACK(file_save_all)
     }
   }
 
-  x_pagesel_update (w_current);
+  page_select_widget_update (w_current);
   i_update_menus(w_current);
 
 } /* i_callback_file_save_all() */
@@ -847,7 +847,7 @@ DEFINE_I_CALLBACK(edit_embed)
     }
 
     o_undo_savestate_old(w_current, UNDO_ALL);
-    x_pagesel_update (w_current);
+    page_select_widget_update (w_current);
 
   } else {
     /* nothing selected, go back to select state */
@@ -889,7 +889,7 @@ DEFINE_I_CALLBACK(edit_unembed)
     }
 
     o_undo_savestate_old(w_current, UNDO_ALL);
-    x_pagesel_update (w_current);
+    page_select_widget_update (w_current);
 
   } else {
     /* nothing selected, go back to select state */
@@ -1379,7 +1379,8 @@ DEFINE_I_CALLBACK(page_manager)
 
   g_return_if_fail (w_current != NULL);
 
-  x_pagesel_open (w_current);
+  x_widgets_show_page_select (w_current);
+  page_select_widget_update (w_current);
 }
 
 /*! \todo Finish function documentation!!!

--- a/schematic/src/o_undo.c
+++ b/schematic/src/o_undo.c
@@ -1,6 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
- * Copyright (C) 1998-2010 gEDA Contributors (see ChangeLog for details)
+ * Copyright (C) 1998-2015 gEDA Contributors
+ * Copyright (C) 2017-2019 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -511,7 +512,7 @@ o_undo_callback (GschemToplevel *w_current, PAGE *page, int type)
   g_free(save_filename);
 
   /* final redraw */
-  x_pagesel_update (w_current);
+  page_select_widget_update (w_current);
   x_multiattrib_update (w_current);
   i_update_menus(w_current);
 

--- a/schematic/src/page_select_widget.c
+++ b/schematic/src/page_select_widget.c
@@ -263,6 +263,18 @@ pagesel_callback_popup_menu (GtkWidget* widget,
 
 
 
+/*! \brief Context menu item handler for "Refresh".
+ */
+static void
+pagesel_callback_popup_refresh (GtkMenuItem* mitem, gpointer data)
+{
+  PageSelectWidget* pagesel = (PageSelectWidget*) data;
+
+  pagesel_update (pagesel);
+}
+
+
+
 /*! \brief Context menu item handler for "New Page".
  */
 static void
@@ -362,6 +374,8 @@ pagesel_popup_menu (PageSelectWidget* pagesel, GdkEventButton* event)
     GCallback callback;
   };
   struct menuitem_t menuitems[] = {
+    { N_("Refresh"),      G_CALLBACK (pagesel_callback_popup_refresh)      },
+    { "-",                NULL                                             },
     { N_("New Page"),     G_CALLBACK (pagesel_callback_popup_new_page)     },
     { N_("Open Page..."), G_CALLBACK (pagesel_callback_popup_open_page)    },
     { "-",                NULL                                             },

--- a/schematic/src/page_select_widget.c
+++ b/schematic/src/page_select_widget.c
@@ -142,21 +142,6 @@ page_select_widget_init (PageSelectWidget* widget)
  *
  */
 
-/*! \brief Close the page manager.
- *  \public
- */
-void
-page_select_widget_close (GschemToplevel* w_current)
-{
-  if (w_current->page_select_dialog)
-  {
-    gtk_widget_destroy (w_current->page_select_dialog);
-    w_current->page_select_dialog = NULL;
-  }
-}
-
-
-
 /*! \brief Update the list and status of pages in the page manager.
  *  \public
  */

--- a/schematic/src/page_select_widget.c
+++ b/schematic/src/page_select_widget.c
@@ -628,6 +628,17 @@ select_page(GtkTreeView* treeview, GtkTreeIter* parent, PAGE* page)
       gtk_tree_selection_select_iter (
         gtk_tree_view_get_selection (treeview),
         &iter);
+
+      /* Ensure that currently selected item is visible:
+      */
+      GtkTreePath* path = gtk_tree_model_get_path (treemodel, &iter);
+      if (path != NULL)
+      {
+        gtk_tree_view_scroll_to_cell (treeview, path, NULL, TRUE, 0.5, 0);
+        gtk_tree_view_set_cursor (treeview, path, NULL, FALSE);
+        gtk_tree_path_free (path);
+      }
+
       return;
     }
 

--- a/schematic/src/page_select_widget.c
+++ b/schematic/src/page_select_widget.c
@@ -214,7 +214,7 @@ pagesel_callback_selection_changed (GtkTreeSelection* selection,
                       COLUMN_PAGE, &page,
                       -1);
 
-  /* Since setting the current page may call x_pagesel_update(), which
+  /* Since setting the current page may call page_select_widget_update(), which
    * might change the current page selection, make sure we do nothing
    * if the newly-selected page is already the current page. */
   if (page == w_current->toplevel->page_current)

--- a/schematic/src/x_widgets.c
+++ b/schematic/src/x_widgets.c
@@ -1,5 +1,5 @@
 /* Lepton EDA Schematic Capture
- * Copyright (C) 2017 dmn <graahnul.grom@gmail.com>
+ * Copyright (C) 2017-2019 dmn <graahnul.grom@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -130,6 +130,8 @@ void x_widgets_create (GschemToplevel* w_current)
   w_current->color_edit_widget = color_edit_widget_new (w_current);
 
   w_current->font_select_widget = font_select_widget_new (w_current);
+
+  w_current->page_select_widget = page_select_widget_new (w_current);
 
 } /* x_widgets_create() */
 
@@ -265,6 +267,19 @@ void x_widgets_show_font_select (GschemToplevel* w_current)
                             &w_current->font_select_dialog,
                             _("Select Schematic Font"),
                             "fontsel");
+}
+
+
+
+void x_widgets_show_page_select (GschemToplevel* w_current)
+{
+  g_return_if_fail (w_current != NULL);
+
+  x_widgets_show_in_dialog (w_current,
+                            GTK_WIDGET (w_current->page_select_widget),
+                            &w_current->page_select_dialog,
+                            _("Page Manager"),
+                            "pagesel");
 }
 
 

--- a/schematic/src/x_window.c
+++ b/schematic/src/x_window.c
@@ -608,8 +608,6 @@ void x_window_close(GschemToplevel *w_current)
   if (w_current->aewindow)
   gtk_widget_destroy(w_current->aewindow);
 
-  page_select_widget_close (w_current);
-
   if (w_current->hkwindow)
   gtk_widget_destroy(w_current->hkwindow);
 

--- a/schematic/src/x_window.c
+++ b/schematic/src/x_window.c
@@ -2,7 +2,7 @@
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2016 gEDA Contributors
  * Copyright (C) 2016 Peter Brett <peter@peter-b.co.uk>
- * Copyright (C) 2017-2018 Lepton EDA Contributors
+ * Copyright (C) 2017-2019 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -18,11 +18,10 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
+
 #include <config.h>
-
-#include <stdio.h>
-
 #include "gschem.h"
+
 
 #define GSCHEM_THEME_ICON_NAME "lepton-schematic"
 
@@ -609,7 +608,7 @@ void x_window_close(GschemToplevel *w_current)
   if (w_current->aewindow)
   gtk_widget_destroy(w_current->aewindow);
 
-  x_pagesel_close (w_current);
+  page_select_widget_close (w_current);
 
   if (w_current->hkwindow)
   gtk_widget_destroy(w_current->hkwindow);
@@ -799,7 +798,7 @@ x_window_set_current_page_impl (GschemToplevel *w_current, PAGE *page)
   i_update_menus (w_current);
   /* i_set_filename (w_current, page->page_filename); */
 
-  x_pagesel_update (w_current);
+  page_select_widget_update (w_current);
   x_multiattrib_update (w_current);
 
 } /* x_window_set_current_page_impl() */
@@ -872,8 +871,7 @@ x_window_save_page (GschemToplevel *w_current, PAGE *page, const gchar *filename
     /* add to recent file list */
     recent_manager_add (w_current, filename);
 
-    /* i_set_filename (w_current, page->page_filename); */
-    x_pagesel_update (w_current);
+    page_select_widget_update (w_current);
   }
 
   /* log status of operation */
@@ -882,7 +880,8 @@ x_window_save_page (GschemToplevel *w_current, PAGE *page, const gchar *filename
   i_set_state_msg  (w_current, SELECT, state_msg);
 
   return ret;
-}
+
+} /* x_window_save_page() */
 
 
 


### PR DESCRIPTION
Derive its `GObject` class from `GschemBinClass` and show it using
mechanism implemented in `x_widgets.c`, like other widgets.
No functional changes, except that the "Update" button is removed
(it's not `GschemDialog` anymore) and similar item is added
to the context menu.
Source files were renamed: x_pagesel => page_select_widget
