### PR TITLE
Several fixes in netlister wrt <pin-net> records

### DIFF
--- a/netlist/scheme/netlist/net.scm
+++ b/netlist/scheme/netlist/net.scm
@@ -30,7 +30,6 @@
 
   #:export (create-netattrib
             create-netname
-            create-net-netname
             netattrib-search-net
             check-net-maps
             attrib-value-by-name))
@@ -81,11 +80,6 @@
   (first* (map attrib-value
                (filter has-appropriate-name? (object-attribs object)))))
 
-(define (create-net-netname object hierarchy-tag)
-  ;; Ignore netname= attributes on any objects apart from nets.
-  (and (net? object)
-       (let ((netname (attrib-value-by-name object "netname")))
-         (and netname (create-netname netname hierarchy-tag)))))
 
 (define (blame-missing-colon net-attrib-value)
   (log! 'critical

--- a/netlist/scheme/netlist/pin-net.scm
+++ b/netlist/scheme/netlist/pin-net.scm
@@ -23,6 +23,7 @@
   #:use-module (srfi srfi-9 gnu)
   #:export (make-pin-net pin-net?
             pin-net-id set-pin-net-id!
+            pin-net-object set-pin-net-object!
             pin-net-priority set-pin-net-priority!
             pin-net-name set-pin-net-name!
             pin-net-connection-package set-pin-net-connection-package!
@@ -30,9 +31,10 @@
             set-pin-net-printer!))
 
 (define-record-type <pin-net>
-  (make-pin-net id priority name connection-package connection-pinnumber)
+  (make-pin-net id object priority name connection-package connection-pinnumber)
   pin-net?
   (id pin-net-id set-pin-net-id!)
+  (object pin-net-object set-pin-net-object!)
   (priority pin-net-priority set-pin-net-priority!)
   (name pin-net-name set-pin-net-name!)
   (connection-package pin-net-connection-package set-pin-net-connection-package!)
@@ -48,6 +50,7 @@
 FORMAT-STRING must be in the form required by the procedure
 `format'. The following ARGS may be used:
   'id
+  'object
   'priority
   'name
   'connection-package
@@ -64,6 +67,7 @@ Example usage:
              (lambda (arg)
                (match arg
                  ('id (pin-net-id record))
+                 ('object (pin-net-object record))
                  ('priority (pin-net-priority record))
                  ('name (pin-net-name record))
                  ('connection-package (pin-net-connection-package record))

--- a/netlist/scheme/netlist/traverse.scm
+++ b/netlist/scheme/netlist/traverse.scm
@@ -61,15 +61,6 @@
 
 
 (define (traverse-net current-nets starting object tag)
-  ;; We don't support other object types apart from net-pins and nets yet.
-  (define (connection-type? object)
-    (or (net-pin? object)
-        (net? object)
-        (and (log! 'critical
-                   (_ "Traverse nets: object type ~A is not supported.")
-                   (object-type object))
-             #f)))
-
   (define (check-refdes-pinnumber-pair refdes pinnumber)
     (match `(,refdes . ,pinnumber)
       ;; Wrong case, neither refdes nor pinnumber found.
@@ -138,21 +129,19 @@
     (clear-visits!))
 
   (visit! object)
-  (if (connection-type? object)
-      (let ((nets (cons (make-new-net object) current-nets)))
-        (if (or (not (pin? object))
-                starting)
-            (let loop ((connections (object-connections object))
-                       (nets nets))
-              (if (null? connections)
-                  nets
-                  (loop (cdr connections)
-                        (let ((conn (car connections)))
-                          (if (visited? conn)
-                              nets
-                              (traverse-net nets #f conn tag))))))
-            nets))
-      current-nets))
+  (let ((nets (cons (make-new-net object) current-nets)))
+    (if (or (not (pin? object))
+            starting)
+        (let loop ((connections (object-connections object))
+                   (nets nets))
+          (if (null? connections)
+              nets
+              (loop (cdr connections)
+                    (let ((conn (car connections)))
+                      (if (visited? conn)
+                          nets
+                          (traverse-net nets #f conn tag))))))
+        nets)))
 
 
 (define %unnamed-net-counter 0)

--- a/netlist/scheme/netlist/traverse.scm
+++ b/netlist/scheme/netlist/traverse.scm
@@ -92,16 +92,16 @@
            ;; component, we consider it to be a special symbol
            ;; (like "gnd-1.sym") and get the net name we need from
            ;; its "net=" attribute.
-           (net-attrib-net? (and pinnumber (not refdes))))
+           (net-attrib-pin? (and pinnumber (not refdes))))
 
       (make-pin-net
        ;; id
        (object-id object)
        ;; priority
-       net-attrib-net?
+       net-attrib-pin?
        ;; name
        (if (pin? object)
-           (and net-attrib-net?
+           (and net-attrib-pin?
                 ;; Use hierarchy tag here to make this net unique.
                 (create-netattrib
                  (netattrib-search-net (object-component object)
@@ -110,14 +110,14 @@
            (create-net-netname object tag))
        ;; connection-package
        (and (pin? object)
-            (not net-attrib-net?)
+            (not net-attrib-pin?)
             (hierarchy-create-refdes
              (check-create-refdes refdes
                                   pinnumber)
              tag))
        ;; connection-pinnumber
        (and (pin? object)
-            (not net-attrib-net?)
+            (not net-attrib-pin?)
             (if refdes
                 pinnumber
                 (or pinnumber "?"))))))

--- a/netlist/scheme/netlist/traverse.scm
+++ b/netlist/scheme/netlist/traverse.scm
@@ -111,14 +111,7 @@
        ;; priority
        net-driven?
        ;; name
-       (and net-driven?
-            ;; The object is a pin, and it defines net name using
-            ;; "net=".  Use hierarchy tag here to make this net
-            ;; unique.
-            (create-netattrib (netattrib-search-net (object-component object)
-                                                    pinnumber)
-                              tag))
-
+       #f
        ;; connection-package
        (and (not net-driven?)
             (hierarchy-create-refdes refdes tag))
@@ -228,12 +221,26 @@
            (for-each
             (lambda (net)
               (let ((object (pin-net-object net)))
-                (when (net? object)
-                  (let ((netname (attrib-value-by-name object "netname")))
-                    ;; The object is a net.  For nets we check the "netname="
-                    ;; attribute.
-                    (set-pin-net-name! net
-                                       (and netname (create-netname netname tag)))))))
+                (if (net? object)
+                    (let ((netname (attrib-value-by-name object "netname")))
+                      ;; The object is a net.  For nets we check the "netname="
+                      ;; attribute.
+                      (set-pin-net-name! net
+                                         (and netname (create-netname netname tag))))
+
+                    (let* ((refdes-pinnumber-pair (pin-refdes-pinnumber-pair object))
+                           (refdes (car refdes-pinnumber-pair))
+                           (pinnumber (cdr refdes-pinnumber-pair))
+                           (net-driven? (net-attrib-pin? object)))
+                      (and net-driven?
+                           ;; The object is a pin, and it defines net name using
+                           ;; "net=".  Use hierarchy tag here to make this net
+                           ;; unique.
+                           (set-pin-net-name! net
+                                              (create-netattrib
+                                               (netattrib-search-net (object-component object)
+                                                                     pinnumber)
+                                               tag)))))))
             nets)
            (let ((netname (or
                            ;; If there is no netname, probably

--- a/netlist/scheme/netlist/traverse.scm
+++ b/netlist/scheme/netlist/traverse.scm
@@ -87,13 +87,12 @@
                            (attrib-value-by-name object "pinnumber")))
            (refdes (and (pin? object)
                         (attrib-value-by-name (object-component object) "refdes")))
-           ;; If refdes= of pin component exists, or there is
-           ;; no refdes but pinnumber= exists (which means the
-           ;; pin exists too), we consider the pin to be
-           ;; normal (in the latter case, the symbol is
-           ;; special, like "gnd-1.sym"). Otherwise we believe
-           ;; the pin was created from net= attribute.
-           (net-attrib-net? (and (pin? object) (not (or refdes (not pinnumber))))))
+           ;; If there is a pin object with the "pinnumber="
+           ;; attribute, but there is no refdes on pin's parent
+           ;; component, we consider it to be a special symbol
+           ;; (like "gnd-1.sym") and get the net name we need from
+           ;; its "net=" attribute.
+           (net-attrib-net? (and pinnumber (not refdes))))
 
       (make-pin-net
        ;; id

--- a/netlist/scheme/netlist/traverse.scm
+++ b/netlist/scheme/netlist/traverse.scm
@@ -95,6 +95,8 @@
       (make-pin-net
        ;; id
        (object-id object)
+       ;; object
+       object
        ;; priority
        net-attrib-pin?
        ;; name
@@ -117,6 +119,8 @@
     (make-pin-net
      ;; id
      (object-id object)
+     ;; object
+     object
      ;; priority
      #f
      ;; name
@@ -272,11 +276,13 @@
   (define (update-pin-netname pin netname id refdes)
     (let ((nets (package-pin-nets pin))
           (pinnumber (package-pin-number pin))
-          (net-priority #t))
+          (net-priority #t)
+          (object #f))
       (set-package-pin-name! pin netname)
       (if (null? nets)
           (set-package-pin-nets! pin
                                  (list (make-pin-net id
+                                                     object
                                                      net-priority
                                                      netname
                                                      refdes
@@ -311,7 +317,7 @@
            (label #f)
            (object #f)
            (attribs '())
-           (nets (list (make-pin-net id net-priority netname refdes pinnumber))))
+           (nets (list (make-pin-net id object net-priority netname refdes pinnumber))))
       (make-package-pin id object pinnumber netname label attribs nets #f)))
 
   (define (add-net-power-pin-override pin net-map tag)

--- a/netlist/scheme/netlist/traverse.scm
+++ b/netlist/scheme/netlist/traverse.scm
@@ -207,6 +207,9 @@
     (and (net-pin? object)
          (let* ((attribs (make-pin-attrib-list object))
                 (nets (if (null? (object-connections object))
+                          ;; If there is no connections, we have
+                          ;; an only pin. There is no point to do
+                          ;; something in this case.
                           '()
                           (reverse (traverse-net '() #t object tag))))
                 (netname (or

--- a/netlist/scheme/netlist/traverse.scm
+++ b/netlist/scheme/netlist/traverse.scm
@@ -62,7 +62,7 @@
 
 (define (traverse-net current-nets starting object tag)
   ;; We don't support other object types apart from net-pins and nets yet.
-  (define (connection-type object)
+  (define (connection-type? object)
     (or (net-pin? object)
         (net? object)
         (and (log! 'critical
@@ -126,7 +126,7 @@
     (clear-visits!))
 
   (visit! object)
-  (if (connection-type object)
+  (if (connection-type? object)
       (let ((nets (cons (make-new-net object) current-nets)))
         (if (or (not (pin? object))
                 starting)

--- a/netlist/scheme/netlist/traverse.scm
+++ b/netlist/scheme/netlist/traverse.scm
@@ -83,40 +83,40 @@
               "U?"))))
 
   (define (make-new-net object)
-    (if (pin? object)
-        (let* ((pinnumber (attrib-value-by-name object "pinnumber"))
-               (refdes (attrib-value-by-name (object-component object) "refdes"))
-               ;; If refdes= of pin component exists, or there is
-               ;; no refdes but pinnumber= exists (which means the
-               ;; pin exists too), we consider the pin to be
-               ;; normal (in the latter case, the symbol is
-               ;; special, like "gnd-1.sym"). Otherwise we believe
-               ;; the pin was created from net= attribute.
-               (net-attrib-net? (not (or refdes (not pinnumber)))))
-          (make-pin-net
-           (object-id object)
-           net-attrib-net?
+    (let* ((pinnumber (and (pin? object)
+                           (attrib-value-by-name object "pinnumber")))
+           (refdes (and (pin? object)
+                        (attrib-value-by-name (object-component object) "refdes")))
+           ;; If refdes= of pin component exists, or there is
+           ;; no refdes but pinnumber= exists (which means the
+           ;; pin exists too), we consider the pin to be
+           ;; normal (in the latter case, the symbol is
+           ;; special, like "gnd-1.sym"). Otherwise we believe
+           ;; the pin was created from net= attribute.
+           (net-attrib-net? (and (pin? object) (not (or refdes (not pinnumber))))))
+
+      (make-pin-net
+       (object-id object)
+       net-attrib-net?
+       (if (pin? object)
            (and net-attrib-net?
                 ;; Use hierarchy tag here to make this net unique.
                 (create-netattrib
                  (netattrib-search-net (object-component object)
                                        pinnumber)
                  tag))
-           (and (not net-attrib-net?)
-                (hierarchy-create-refdes
-                 (check-create-refdes refdes
-                                      pinnumber)
-                 tag))
-           (and (not net-attrib-net?)
-                (if refdes
-                    pinnumber
-                    (or pinnumber "?")))))
-        (make-pin-net
-         (object-id object)
-          #f
-          (create-net-netname object tag)
-          #f
-          #f)))
+           (create-net-netname object tag))
+       (and (pin? object)
+            (not net-attrib-net?)
+            (hierarchy-create-refdes
+             (check-create-refdes refdes
+                                  pinnumber)
+             tag))
+       (and (pin? object)
+            (not net-attrib-net?)
+            (if refdes
+                pinnumber
+                (or pinnumber "?"))))))
 
   (when starting
     (clear-visits!))

--- a/netlist/scheme/netlist/traverse.scm
+++ b/netlist/scheme/netlist/traverse.scm
@@ -101,13 +101,19 @@
        net-attrib-pin?
        ;; name
        (if (pin? object)
+           ;; The object is a pin, and it defines net name using
+           ;; "net=".
            (and net-attrib-pin?
                 ;; Use hierarchy tag here to make this net unique.
                 (create-netattrib
                  (netattrib-search-net (object-component object)
                                        pinnumber)
                  tag))
-           (create-net-netname object tag))
+           ;; The object is a net.  For nets we check the
+           ;; "netname=" attribute.
+           (let ((netname (attrib-value-by-name object "netname")))
+             (and netname (create-netname netname tag))))
+
        ;; connection-package
        (and (pin? object)
             (not net-attrib-pin?)

--- a/netlist/scheme/netlist/traverse.scm
+++ b/netlist/scheme/netlist/traverse.scm
@@ -141,7 +141,7 @@
                            make-new-net/net
                            make-new-net/pin))
          (nets (cons (make-new-net object) current-nets)))
-    (if (or (not (pin? object))
+    (if (or (net? object)
             starting)
         (let loop ((connections (object-connections object))
                    (nets nets))

--- a/netlist/scheme/netlist/traverse.scm
+++ b/netlist/scheme/netlist/traverse.scm
@@ -127,8 +127,7 @@
      ;; name
      ;; The object is a net.  For nets we check the "netname="
      ;; attribute.
-     (let ((netname (attrib-value-by-name object "netname")))
-       (and netname (create-netname netname tag)))
+     #f
      ;; connection-package
      #f
      ;; connection-pinnumber
@@ -141,19 +140,24 @@
   (let* ((make-new-net (if (net? object)
                            make-new-net/net
                            make-new-net/pin))
-         (nets (cons (make-new-net object) current-nets)))
-    (if (or (net? object)
-            starting)
-        (let loop ((connections (object-connections object))
-                   (nets nets))
-          (if (null? connections)
-              nets
-              (loop (cdr connections)
-                    (let ((conn (car connections)))
-                      (if (visited? conn)
-                          nets
-                          (traverse-net nets #f conn tag))))))
-        nets)))
+         (new-net (make-new-net object)))
+    (when (net? object)
+      (let ((netname (attrib-value-by-name object "netname")))
+        (set-pin-net-name! new-net
+                           (and netname (create-netname netname tag)))))
+    (let ((nets (cons new-net current-nets)))
+      (if (or (net? object)
+              starting)
+          (let loop ((connections (object-connections object))
+                     (nets nets))
+            (if (null? connections)
+                nets
+                (loop (cdr connections)
+                      (let ((conn (car connections)))
+                        (if (visited? conn)
+                            nets
+                            (traverse-net nets #f conn tag))))))
+          nets))))
 
 
 (define %unnamed-net-counter 0)

--- a/netlist/scheme/netlist/traverse.scm
+++ b/netlist/scheme/netlist/traverse.scm
@@ -60,29 +60,32 @@
   (set! %visits '()))
 
 
-(define (traverse-net current-nets starting object tag)
-  (define (check-refdes-pinnumber-pair refdes pinnumber)
-    (match `(,refdes . ,pinnumber)
-      ;; Wrong case, neither refdes nor pinnumber found.
-      ((#f . #f)
-       (log! 'critical (_ "Missing attributes refdes= and pinnumber="))
-       '("U?" . "?"))
-      ;; Acceptable case for using with the "net="
-      ;; attribute. Return it as is.
-      ((#f . pinnumber) `(#f . ,pinnumber))
-      ;; Missing pin number while refdes exists.
-      ((refdes . #f)
-       (log! 'critical (_ "Missing pinnumber= for refdes=~A)") refdes)
-       `(,refdes . "?"))
-      ;; Otherwise, anything is OK, return it as is.
-      (x x)))
+(define (check-pin-refdes-pinnumber-pair refdes pinnumber)
+  (match `(,refdes . ,pinnumber)
+    ;; Wrong case, neither refdes nor pinnumber found.
+    ((#f . #f)
+     (log! 'critical (_ "Missing attributes refdes= and pinnumber="))
+     '("U?" . "?"))
+    ;; Acceptable case for using with the "net="
+    ;; attribute. Return it as is.
+    ((#f . pinnumber) `(#f . ,pinnumber))
+    ;; Missing pin number while refdes exists.
 
+    ((refdes . #f)
+     (log! 'critical (_ "Missing pinnumber= for refdes=~A)") refdes)
+     `(,refdes . "?"))
+    ;; Otherwise, anything is OK, return it as is.
+    (x x)))
+
+
+
+(define (traverse-net current-nets starting object tag)
   (define (make-new-net/pin object)
     (let* ((component (object-component object))
            (component-refdes (attrib-value-by-name component "refdes"))
            (component-pinnumber (attrib-value-by-name object "pinnumber"))
-           (refdes-pinnumber-pair (check-refdes-pinnumber-pair component-refdes
-                                                               component-pinnumber))
+           (refdes-pinnumber-pair (check-pin-refdes-pinnumber-pair component-refdes
+                                                                   component-pinnumber))
            (refdes (car refdes-pinnumber-pair))
            (pinnumber (cdr refdes-pinnumber-pair))
            ;; If there is a pin object with the "pinnumber="

--- a/netlist/scheme/netlist/traverse.scm
+++ b/netlist/scheme/netlist/traverse.scm
@@ -66,15 +66,13 @@
     ((#f . #f)
      (log! 'critical (_ "Missing attributes refdes= and pinnumber="))
      '("U?" . "?"))
-    ;; Acceptable case for using with the "net="
-    ;; attribute. Return it as is.
-    ((#f . pinnumber) `(#f . ,pinnumber))
     ;; Missing pin number while refdes exists.
-
     ((refdes . #f)
      (log! 'critical (_ "Missing pinnumber= for refdes=~A)") refdes)
      `(,refdes . "?"))
-    ;; Otherwise, anything is OK, return it as is.
+    ;; Otherwise, anything is OK, return it as is.  Even if
+    ;; refdes=#f and pinnumber is non-#f, it is an acceptable case
+    ;; for using with the "net=" attribute. Return it as is.
     (x x)))
 
 

--- a/netlist/scheme/netlist/traverse.scm
+++ b/netlist/scheme/netlist/traverse.scm
@@ -96,8 +96,11 @@
            (net-attrib-net? (and (pin? object) (not (or refdes (not pinnumber))))))
 
       (make-pin-net
+       ;; id
        (object-id object)
+       ;; priority
        net-attrib-net?
+       ;; name
        (if (pin? object)
            (and net-attrib-net?
                 ;; Use hierarchy tag here to make this net unique.
@@ -106,12 +109,14 @@
                                        pinnumber)
                  tag))
            (create-net-netname object tag))
+       ;; connection-package
        (and (pin? object)
             (not net-attrib-net?)
             (hierarchy-create-refdes
              (check-create-refdes refdes
                                   pinnumber)
              tag))
+       ;; connection-pinnumber
        (and (pin? object)
             (not net-attrib-net?)
             (if refdes

--- a/netlist/scheme/netlist/traverse.scm
+++ b/netlist/scheme/netlist/traverse.scm
@@ -93,24 +93,24 @@
                ;; special, like "gnd-1.sym"). Otherwise we believe
                ;; the pin was created from net= attribute.
                (net-attrib-net? (not (or refdes (not pinnumber)))))
-          (if net-attrib-net?
-              (make-pin-net
-                (object-id object)
-                #t
+          (make-pin-net
+           (object-id object)
+           net-attrib-net?
+           (and net-attrib-net?
                 ;; Use hierarchy tag here to make this net unique.
-                (create-netattrib (netattrib-search-net (object-component object)
-                                                         pinnumber)
-                                   tag)
-                #f
-                #f)
-              (make-pin-net
-               (object-id object)
-                #f
-                #f
-                (hierarchy-create-refdes (check-create-refdes refdes
-                                                               pinnumber)
-                                          tag)
-                (if refdes pinnumber (or pinnumber "?")))))
+                (create-netattrib
+                 (netattrib-search-net (object-component object)
+                                       pinnumber)
+                 tag))
+           (and (not net-attrib-net?)
+                (hierarchy-create-refdes
+                 (check-create-refdes refdes
+                                      pinnumber)
+                 tag))
+           (and (not net-attrib-net?)
+                (if refdes
+                    pinnumber
+                    (or pinnumber "?")))))
         (make-pin-net
          (object-id object)
           #f

--- a/netlist/scheme/netlist/traverse.scm
+++ b/netlist/scheme/netlist/traverse.scm
@@ -250,9 +250,14 @@
 (define (net-maps->pins net-maps id refdes tag pin-list)
   (define (pinnumber->pin pinnumber pin-list)
     (and (not (null? pin-list))
-         (if (string=? (package-pin-number (car pin-list)) pinnumber)
-             (car pin-list)
-             (pinnumber->pin pinnumber (cdr pin-list)))))
+         (let ((package-pinnumber (package-pin-number (car pin-list))))
+           ;; FIXME: a pin may have no "pinnumber=", and we have
+           ;; to deal with such cases. A test and drc check is
+           ;; needed.
+           (if (and package-pinnumber
+                    (string=? package-pinnumber pinnumber))
+               (car pin-list)
+               (pinnumber->pin pinnumber (cdr pin-list))))))
 
   (define (check-shorted-nets a b priority)
     (log! 'critical

--- a/netlist/scheme/netlist/traverse.scm
+++ b/netlist/scheme/netlist/traverse.scm
@@ -70,7 +70,7 @@
                    (object-type object))
              #f)))
 
-  (define (check-create-refdes refdes pinnumber)
+  (define (check-refdes-pinnumber-pair refdes pinnumber)
     (match `(,refdes . ,pinnumber)
       ;; Wrong case, neither refdes nor pinnumber found.
       ((#f . #f)
@@ -95,9 +95,8 @@
                                      (attrib-value-by-name object "pinnumber")))
            (refdes-pinnumber-pair
             (and component
-                 (check-create-refdes
-                  component-refdes
-                  component-pinnumber)))
+                 (check-refdes-pinnumber-pair component-refdes
+                                              component-pinnumber)))
            (refdes (and=> refdes-pinnumber-pair car))
            (pinnumber (and=> refdes-pinnumber-pair cdr))
            ;; If there is a pin object with the "pinnumber="


### PR DESCRIPTION
- The function `create-net-name()` is no longer exported in the
  module `(netlist net)`.
- `<pin-net>` record now contains the `object` field, which should
  contain its underlying lepton object.
- Added comments, simplified logic, refactoring and renaming of
  local functions working with <pin-net> records in `(netlist
  traverse)`.
- Fixed crashes on power symbols having "net=" attributes but no
  pinnumber and refdes.
