### PR TITLE
Use static gettext domain name in liblepton

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -195,7 +195,6 @@ AC_CONFIG_FILES([Makefile
 
                  liblepton/Makefile
                  liblepton/liblepton.pc
-                 liblepton/po/domain.mak
                  liblepton/po/Makefile.in
                  liblepton/data/Makefile
                  liblepton/docs/Makefile

--- a/liblepton/Makefile.am
+++ b/liblepton/Makefile.am
@@ -1,7 +1,7 @@
 
 SUBDIRS = po data docs include lib src scheme tests
 
-EXTRA_DIST = HACKING ChangeLog ChangeLog-1.0 po/domain.mak.in
+EXTRA_DIST = HACKING ChangeLog ChangeLog-1.0
 
 pkgconfigdir            = $(libdir)/pkgconfig
 pkgconfig_DATA          = liblepton.pc
@@ -21,5 +21,5 @@ endif HAVE_GIT_REPO
 
 MOSTLYCLEANFILES = *.log core FILE *~
 CLEANFILES = *.log core FILE *~
-DISTCLEANFILES = *.log core FILE *~ liblepton.pc po/domain.mak
+DISTCLEANFILES = *.log core FILE *~ liblepton.pc
 MAINTAINERCLEANFILES = *.log core FILE *~ Makefile.in liblepton.pc ChangeLog

--- a/liblepton/po/.gitignore
+++ b/liblepton/po/.gitignore
@@ -12,5 +12,4 @@ Makevars.template
 stamp-po
 stamp-it
 stamp-i18n
-domain.mak
 *~

--- a/liblepton/po/Makevars
+++ b/liblepton/po/Makevars
@@ -2,13 +2,7 @@
 # Makefile variables for PO directory in any package using GNU gettext.
 
 # Usually the message domain is the same as the package name.
-#DOMAIN = $(PACKAGE)
-# Unfortunately, we need to use message domains that match the current
-# version of liblepton. Even more unfortunately, the way that the
-# gettext m4 code merges Makevars into the Makefile precludes Makevars
-# from containing anything determined at configure time. So we have
-# *yet another* Makefile fragment.
-include domain.mak
+DOMAIN = liblepton
 
 # These two variables depend on the location of this directory.
 subdir = liblepton/po

--- a/liblepton/po/domain.mak.in
+++ b/liblepton/po/domain.mak.in
@@ -1,3 +1,0 @@
-#                                                       -*-GNUmakefile-*-
-# This is a workaround for buggy logic in the gettext m4 files.
-DOMAIN = @LIBLEPTON_GETTEXT_DOMAIN@

--- a/liblepton/po/liblepton.pot
+++ b/liblepton/po/liblepton.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: lepton-eda 1.9.7\n"
+"Project-Id-Version: lepton-eda 1.9.8\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-09-28 09:34+0300\n"
+"POT-Creation-Date: 2019-10-03 14:17+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/m4/geda-liblepton.m4
+++ b/m4/geda-liblepton.m4
@@ -30,8 +30,7 @@ AC_DEFUN([AX_LIBLEPTON],
 
   # Work out the gettext domain to use
   AC_MSG_CHECKING([liblepton gettext domain])
-  so_major=`echo $LIBLEPTON_SHLIB_VERSION | sed -e "s/:.*//"`
-  LIBLEPTON_GETTEXT_DOMAIN="liblepton$so_major"
+  LIBLEPTON_GETTEXT_DOMAIN="liblepton"
   AC_MSG_RESULT([$LIBLEPTON_GETTEXT_DOMAIN])
   AC_SUBST([LIBLEPTON_GETTEXT_DOMAIN])
   AC_DEFINE_UNQUOTED([LIBLEPTON_GETTEXT_DOMAIN], ["$LIBLEPTON_GETTEXT_DOMAIN"],


### PR DESCRIPTION
Do not append library's major version number
to the name of the gettext domain, "liblepton",
on configure stage.
LIBLEPTON_GETTEXT_DOMAIN (m4/geda-liblepton.m4)
configuration variable is retained (it's also
set to "liblepton"), though it should probably
be removed in the future.

This was discussed on [gitter](https://gitter.im/Lepton-EDA/Lobby) - 02 oct 2019