### PR TITLE
Fix building of the Scheme API HTML manual with parallel make jobs on FreeBSD

### DIFF
--- a/docs/scheme-api/Makefile.am
+++ b/docs/scheme-api/Makefile.am
@@ -4,10 +4,8 @@ AM_MAKEINFOHTMLFLAGS = --css-ref=lepton-scheme.css
 
 EXTRA_DIST = lepton-scheme.css
 
-html-local:
+all: all-am html
 	$(MKDIR_P) $(builddir)/lepton-scheme.html/
 	cp -fv $(srcdir)/lepton-scheme.css $(builddir)/lepton-scheme.html/
-
-all-local: html
 
 install-data-local: install-html


### PR DESCRIPTION
Building of the Scheme API HTML documentation
on FreeBSD with parallel make jobs (`make -jN`) fails:
`make -jN` in `docs/scheme-api/` does not generate HTML files.
Fix this by reducing the number of `-local` make
targets that may be processed in parallel.
[Commit](https://github.com/graahnul-grom/freebsd-lepton-eda/commit/1779d617bc71a03ce8cbed74fdaa94f6970e1741) in the [FreeBSD port repo](https://github.com/graahnul-grom/freebsd-lepton-eda) describing the issue.