### PR TITLE
Fix crashes of the spice-sdb backend on IO components.

### DIFF
--- a/netlist/scheme/backend/gnet-spice-sdb.scm
+++ b/netlist/scheme/backend/gnet-spice-sdb.scm
@@ -209,7 +209,7 @@
     (and (string-ci=? (gnetlist:get-package-attribute package "device")
                       "spice-io")
          package))
-  (filter-map spice-io? ls))
+  (filter-map spice-io? package-list))
 
 
 ;;; Given a list of spice-IO packages (refdeses), this function


### PR DESCRIPTION
The crashes were happening due to wrong variable names in the
"spice-sdb:get-spice-io-pins" procedure.

Affects #470.