### PR TITLE
Fix icon-theme-installer

### DIFF
--- a/build-tools/icon-theme-installer
+++ b/build-tools/icon-theme-installer
@@ -103,13 +103,13 @@ if test -z "$INSTALL_BASE_DIR"; then
 	exit 1
 fi
 
-if test ! -x `echo "$MKINSTALLDIRS_EXEC" | cut -f1 -d' '`; then
-	echo "Cannot find '$MKINSTALLDIRS_EXEC'; You probably want to pass -m \$(mkinstalldirs)"
+if test -z "$MKINSTALLDIRS_EXEC"; then
+	echo "\$MKINSTALLDIRS_EXEC is not set. Pass it with the -m command line option"
 	exit 1
 fi
 
-if test ! -x `echo "$INSTALL_DATA_EXEC" | cut -f1 -d' '`; then
-	echo "Cannot find '$INSTALL_DATA_EXEC'; You probably want to pass -x \$(INSTALL_DATA)"
+if test -z "$INSTALL_DATA_EXEC"; then
+	echo "\$INSTALL_DATA_EXEC' is not set. Pass it with the -x command line option"
 	exit 1
 fi
 


### PR DESCRIPTION
Simplify command line arguments check.
Do not require that commands for directory
creation and single file installation must
be specified using full program path.
It's not always the case in various build
environments.
The script fails with the FreeBSD ports build system, for example.