### PR TITLE
Set default paper size in configuration

### DIFF
--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -42,7 +42,7 @@ sort=false
 [gschem.printing]
 layout=auto
 monochrome=false
-paper=
+paper=iso_a4
 
 
 
@@ -83,6 +83,6 @@ font=Sans
 layout=auto
 margins=18;18;18;18
 monochrome=false
-paper=
+paper=iso_a4
 size=
 

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -42,7 +42,7 @@ sort=false
 [schematic.printing]
 layout=auto
 monochrome=false
-paper=
+paper=iso_a4
 
 
 
@@ -83,6 +83,6 @@ font=Sans
 layout=auto
 margins=18;18;18;18
 monochrome=false
-paper=
+paper=iso_a4
 size=
 


### PR DESCRIPTION
Set the default paper size in system configuration
files to iso_a4: the "paper" key in the "export"
and "gschem.printing", "schematic.printing" groups.
Although the choice of this particular value does
not necessarily suit all users, these keys should
not be empty, anyway.
It fixes the "Unknown paper size" GTK warning on
File->Print in lepton-schematic.