### PR TITLE
Extend liblepton module deprecation warning

### DIFF
--- a/liblepton/scheme/geda/deprecated.scm
+++ b/liblepton/scheme/geda/deprecated.scm
@@ -53,10 +53,15 @@
            promote-invisible
            scheme-directory))
 
-(define (deprecated-module-log-warning!)
+(define* (deprecated-module-log-warning! #:optional (new-modname #f))
   (log! 'warning
-        (_ "The module ~S is deprecated.\nPlease don't use it any more.")
-        (module-name (current-module))))
+        (_ "The module ~S is deprecated. Please don't use it any more.~A")
+        (module-name (current-module))
+        (if new-modname
+          (format #f
+                  (_ "\n  It has been replaced by the ~A module.")
+                  new-modname)
+          "")))
 
 (define-public get-line-width %get-line-width)
 

--- a/liblepton/scheme/geda/library.scm
+++ b/liblepton/scheme/geda/library.scm
@@ -12,4 +12,4 @@
                set-source-library-contents!
                get-source-library-file))
 
-(deprecated-module-log-warning!)
+(deprecated-module-log-warning! "(lepton library)")

--- a/liblepton/scheme/geda/page.scm
+++ b/liblepton/scheme/geda/page.scm
@@ -19,4 +19,4 @@
                page-remove!
                set-page-dirty!))
 
-(deprecated-module-log-warning!)
+(deprecated-module-log-warning! "(lepton page)")


### PR DESCRIPTION
Optionally show which module should be used
instead of the deprecated one in the log message.
The new module's name can be passed to the
`deprecated-module-log-warning!` function.
```
The module (geda page) is deprecated. Please don't use it any more.
  It has been replaced by the (lepton page) module.
```