### PR TITLE
Show/hide grips at run-time in lepton-schematic

### DIFF
--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -147,6 +147,7 @@ SCM g_keys_options_magneticnet(SCM rest);
 SCM g_keys_options_show_log_window(SCM rest);
 SCM g_keys_options_show_coord_window(SCM rest);
 SCM g_keys_options_select_font(SCM rest);
+SCM g_keys_options_draw_grips(SCM rest);
 SCM g_keys_help_about(SCM rest);
 SCM g_keys_help_hotkeys(SCM rest);
 SCM g_keys_cancel(SCM rest);
@@ -364,6 +365,7 @@ void i_callback_help_about(gpointer data, guint callback_action, GtkWidget *widg
 void i_callback_help_hotkeys(gpointer data, guint callback_action, GtkWidget *widget);
 void i_callback_options_show_coord_window(gpointer data, guint callback_action, GtkWidget *widget);
 void i_callback_options_select_font(gpointer data, guint callback_action, GtkWidget *widget);
+void i_callback_options_draw_grips(gpointer data, guint callback_action, GtkWidget *widget);
 gboolean i_callback_close_wm(GtkWidget *widget, GdkEvent *event, gpointer data);
 /* i_vars.c */
 void i_vars_set(GschemToplevel *w_current);

--- a/schematic/scheme/conf/schematic/keys.scm
+++ b/schematic/scheme/conf/schematic/keys.scm
@@ -116,6 +116,7 @@
 (global-set-key "O L" '&options-show-log-window)
 (global-set-key "O C" '&options-show-coord-window)
 (global-set-key "O F" '&options-select-font)
+(global-set-key "O I" '&options-draw-grips)
 
 (global-set-key "P M" '&page-manager)
 (global-set-key "P N" '&page-next)

--- a/schematic/scheme/conf/schematic/menu.scm
+++ b/schematic/scheme/conf/schematic/menu.scm
@@ -243,6 +243,7 @@
   ( list (N_ "Grid Style: Cycle Dots/Mesh/Off")  '&options-grid #f )
   ( list (N_ "Grid Snap: Cycle Grid/Resnap/Off") '&options-snap #f )
   ( list "SEPARATOR" #f #f )
+  ( list (N_ "Grips: On/Off")              '&options-draw-grips #f )
   ( list (N_ "Feedback Mode: Outline/Box") '&options-action-feedback #f )
   ( list (N_ "Net: Rubberband On/Off")     '&options-rubberband #f )
   ( list (N_ "Net: Magnetic On/Off")       '&options-magneticnet #f )

--- a/schematic/scheme/gschem/builtins.scm
+++ b/schematic/scheme/gschem/builtins.scm
@@ -497,6 +497,9 @@
 (define-action-public (&options-select-font #:label (_ "Select Schematic Font"))
   (%options-select-font))
 
+(define-action-public (&options-draw-grips #:label (_ "Toggle Grips"))
+  (%options-draw-grips))
+
 ;; -------------------------------------------------------------------
 ;;;; Documentation-related actions
 

--- a/schematic/src/g_builtins.c
+++ b/schematic/src/g_builtins.c
@@ -148,6 +148,7 @@ static struct BuiltinInfo builtins[] = {
   { "%options-show-log-window",      0, 0, 0, (SCM (*) ()) g_keys_options_show_log_window },
   { "%options-show-coord-window",    0, 0, 0, (SCM (*) ()) g_keys_options_show_coord_window },
   { "%options-select-font",          0, 0, 0, (SCM (*) ()) g_keys_options_select_font },
+  { "%options-draw-grips",           0, 0, 0, (SCM (*) ()) g_keys_options_draw_grips },
   { "%help-about",                   0, 0, 0, (SCM (*) ()) g_keys_help_about },
   { "%help-hotkeys",                 0, 0, 0, (SCM (*) ()) g_keys_help_hotkeys },
   { "%cancel",                       0, 0, 0, (SCM (*) ()) g_keys_cancel },

--- a/schematic/src/g_keys.c
+++ b/schematic/src/g_keys.c
@@ -180,6 +180,7 @@ DEFINE_G_KEYS(options_magneticnet)
 DEFINE_G_KEYS(options_show_log_window)
 DEFINE_G_KEYS(options_show_coord_window)
 DEFINE_G_KEYS(options_select_font)
+DEFINE_G_KEYS(options_draw_grips)
 
 DEFINE_G_KEYS(help_about)
 DEFINE_G_KEYS(help_hotkeys)

--- a/schematic/src/g_register.c
+++ b/schematic/src/g_register.c
@@ -215,6 +215,7 @@ static struct gsubr_t gschem_funcs[] = {
   { "options-show-log-window",      0, 0, 0, (SCM (*) ()) g_keys_options_show_log_window },
   { "options-show-coord-window",    0, 0, 0, (SCM (*) ()) g_keys_options_show_coord_window },
   { "options-select-font",          0, 0, 0, (SCM (*) ()) g_keys_options_select_font },
+  { "options-draw-grips",           0, 0, 0, (SCM (*) ()) g_keys_options_draw_grips },
   { "help-about",                   0, 0, 0, (SCM (*) ()) g_keys_help_about },
   { "help-hotkeys",                 0, 0, 0, (SCM (*) ()) g_keys_help_hotkeys },
   { "cancel",                       0, 0, 0, (SCM (*) ()) g_keys_cancel },

--- a/schematic/src/i_callbacks.c
+++ b/schematic/src/i_callbacks.c
@@ -2775,6 +2775,17 @@ DEFINE_I_CALLBACK(options_select_font)
   x_widgets_show_font_select (w_current);
 }
 
+DEFINE_I_CALLBACK(options_draw_grips)
+{
+  GschemToplevel* w_current = GSCHEM_TOPLEVEL (data);
+  g_return_if_fail (w_current != NULL);
+
+  w_current->draw_grips = !w_current->draw_grips;
+
+  GschemPageView* view = gschem_toplevel_get_current_page_view (w_current);
+  gschem_page_view_invalidate_all (view);
+}
+
 /* these is a special wrapper function which cannot use the above */
 /* DEFINE_I_CALLBACK macro */
 


### PR DESCRIPTION
Allow toggling of grips at run-time
(i.e. change the behaviour set by the`draw-grips` `gschemrc` option).
Add `options-draw-grips` action, corresponding menu
item (`Options->Grips: On/Off`) and key binding (`O I`).

Unless constructing a new symbol from scratch
or realigning a lot of text, it's not necessary to show
grips all the time. IMHO, they create visual "noise",
so to say, unpleasant to look at and quite distracting.
It would be nice if one can quickly turn them on and off.