### PR TITLE
Make the CACHE configuration context accessible in Scheme code and lepton-cli

### DIFF
--- a/cli/config.c
+++ b/cli/config.c
@@ -33,7 +33,7 @@
 
 #include <liblepton/liblepton.h>
 
-#define config_short_options "hp::su"
+#define config_short_options "hp::suc"
 
 static struct option config_long_options[] =
   {
@@ -41,6 +41,7 @@ static struct option config_long_options[] =
     {"project", 2, NULL, 'p'},
     {"system", 0, NULL, 's'},
     {"user", 0, NULL, 'u'},
+    {"cache", 0, NULL, 'c'}
   };
 
 static void
@@ -53,6 +54,7 @@ config_usage (void)
 "  -p, --project[=PATH]  select project configuration [PATH=.]\n"
 "  -u, --user     select user configuration\n"
 "  -s, --system   select system configuration\n"
+"  -c, --cache    select cache configuration\n"
 "  -h, --help     display usage information and exit\n"
 "\n"
 "If GROUP and KEY are specified, retrieves the value of that\n"
@@ -116,6 +118,15 @@ cmd_config_impl (void *data, int argc, char **argv)
         exit (1);
       }
       cfg = eda_config_get_user_context ();
+      break;
+
+    case 'c':
+      if (cfg != NULL || project_store_path != NULL) {
+        fprintf (stderr, multi_store_msg);
+        fprintf (stderr, see_help_msg);
+        exit (1);
+      }
+      cfg = eda_config_get_cache_context();
       break;
 
     case 'h':

--- a/cli/lepton-cli.1.in
+++ b/cli/lepton-cli.1.in
@@ -154,6 +154,10 @@ Select the user configuration store.
 \fB-s\fR, \fB--system\fR
 Select the system configuration store.  Depending on user permissions,
 the system configuration store may be read-only.
+.TP 8
+\fB-c\fR, \fB--cache\fR
+Select the program-specific configuration store (CACHE configuration context,
+associated with $XDG_CACHE_HOME/lepton-eda/gui.conf configuration file).
 
 .SH "SCHEME PROCESSING"
 .B lepton-cli shell

--- a/liblepton/scheme/geda/config.scm
+++ b/liblepton/scheme/geda/config.scm
@@ -29,6 +29,7 @@
 (define-public system-config-context %system-config-context)
 (define-public user-config-context %user-config-context)
 (define-public path-config-context %path-config-context)
+(define-public cache-config-context %cache-config-context)
 (define-public config-filename %config-filename)
 (define-public config-load! %config-load!)
 (define-public config-loaded? %config-loaded?)

--- a/liblepton/src/scheme_config.c
+++ b/liblepton/src/scheme_config.c
@@ -204,6 +204,23 @@ SCM_DEFINE (path_config_context, "%path-config-context", 1, 0, 0,
   return result;
 }
 
+/*! \brief Get the cache configuration context.
+ * \par Function Description
+ * Returns the configuration context for program-specific settings.
+ *
+ * \see eda_config_get_cache_context().
+ *
+ * \note Scheme API: Implements the \%cache-config-context procedure
+ * in the (geda core config) module.
+ *
+ * \return an #EdaConfig smob for the cache context.
+ */
+SCM_DEFINE (cache_config_context, "%cache-config-context", 0, 0, 0,
+            (), "Get cache configuration context.")
+{
+  return edascm_from_config (eda_config_get_cache_context());
+}
+
 /*! \brief Get a configuration context's filename.
  * \par Function Description
  * Returns the underlying filename for the configuration context \a
@@ -1272,6 +1289,7 @@ init_module_geda_core_config (void *unused)
                 s_system_config_context,
                 s_user_config_context,
                 s_path_config_context,
+                s_cache_config_context,
                 s_config_filename,
                 s_config_load_x,
                 s_config_loaded_p,


### PR DESCRIPTION
- add `cache-config-context()` function to the `(geda config)` module
- add a new command line option to the `lepton-cli config` command: `--cache` (`-c`)