### PR TITLE
Fix lepton-archive recursive symbol caching

### DIFF
--- a/utils/README
+++ b/utils/README
@@ -186,17 +186,10 @@ Lepton EDA utilities
 
 
 * lepton-archive
-    Stuart Brorson
 
-    This program is used to create a gEDA design archive.  It operates
-    in two modes: archive mode and extract mode.  In archive mode it
-    creates a project archive from a bunch of project files, and in
-    extract mode it extracts the files from the archive and places them in
-    the local dir.
-
-    lepton-archive requires python to run.
-    Run:  lepton-archive -h  for help information.
-
+Create design archive from a set of schematics and configuration
+files including symbols, SPICE source files, etc.  See
+lepton-archive(1) for more information.
 
 * lepton-schdiff
     Alan Somers

--- a/utils/scripts/lepton-archive.in
+++ b/utils/scripts/lepton-archive.in
@@ -256,6 +256,11 @@ Continue? [y/N] "
   (string= (read-line (current-input-port)) "y"))
 
 
+(define (report-preserve-existing-file file)
+  (format #t "Preserving existing ~S in local directory.\n\n" file)
+  #f)
+
+
 (define* (delete-file* filename #:optional quiet)
   (catch #t
     (lambda () (delete-file filename))
@@ -319,11 +324,6 @@ Continue? [y/N] "
               filename
               key
               args))))
-
-
-(define (report-preserve-existing-file file)
-  (format #t "Preserving existing ~S in local directory.\n\n" file)
-  #f)
 
 
 (define (ls->path ls prefix)

--- a/utils/scripts/lepton-archive.in
+++ b/utils/scripts/lepton-archive.in
@@ -642,11 +642,16 @@ symbol cache directory."
          (subschematic-filenames (subschematic-page-filenames schematic))
          (schematic-sources (filter-map (lambda (c) (schematic-component-attribute c 'file))
                                         (schematic-components* schematic)))
-         (source-filenames (filter-map source-library-filename schematic-sources)))
+         (source-filenames (filter-map source-library-filename schematic-sources))
+         (symbol-filenames (create-symbol-file-list
+                            (append (schematic-page-filenames toplevel-schematics)
+                                    subschematic-filenames))))
+
     (for-each (lambda (sch) (copy-to-dir sch temp-dir))
               (schematic-page-filenames toplevel-schematics))
     (for-each (lambda (sch) (copy-to-dir sch cache-dir)) subschematic-filenames)
-    (for-each (lambda (cir) (copy-to-dir cir cache-dir)) source-filenames)))
+    (for-each (lambda (cir) (copy-to-dir cir cache-dir)) source-filenames)
+    (save-symbols symbol-filenames cache-dir)))
 
 
 ;;; Archiver.
@@ -671,11 +676,7 @@ symbol cache directory."
          (archive-file-list (create-archive-file-list))
          ;; Create list of schematic files to open and search.
          ;; Returned paths give only the base name (i.e. no path)
-         (schematic-file-list (create-schematic-file-list archive-file-list))
-         ;; Now run through schematic-file-list and create list of
-         ;; symbols.  Symbols are returned with only base file
-         ;; name (i.e. no path).
-         (symbol-file-list (create-symbol-file-list schematic-file-list)))
+         (schematic-file-list (create-schematic-file-list archive-file-list)))
 
     ;; Copy all files over to temporary directory.
     (for-each (cut copy-to-dir <> tmpdir) archive-file-list)
@@ -687,7 +688,6 @@ symbol cache directory."
       (debug-format "Cache directory: ~S" tmp/cache-directory)
       (mkdir* tmp/cache-directory)
 
-      (save-symbols symbol-file-list tmp/cache-directory)
       (save-schematics-and-sources schematic-file-list
                                    tmpdir
                                    tmp/cache-directory))

--- a/utils/scripts/lepton-archive.in
+++ b/utils/scripts/lepton-archive.in
@@ -167,7 +167,6 @@ default-archive-name))
   (apply format (current-error-port) s args)
   (primitive-exit 1))
 
-(define option-error format-error)
 
 (define (wrong-option-handler)
   "Primitive wrong option handler for getopt-long."
@@ -194,7 +193,7 @@ default-archive-name))
 (define archive-mode?
   (if (and extract-mode?
            (option-ref %options 'archive #f))
-      (option-error "Mutually exclusive option --archive and --extract.\n")
+      (format-error "Mutually exclusive option --archive and --extract.\n")
       (not extract-mode?)))
 
 (define gafrc "gafrc")
@@ -203,7 +202,7 @@ default-archive-name))
 (define (validate/extract-mode filename)
   (if extract-mode?
       (and filename
-           (option-error "Incompatible command line arguments.\n"))
+           (format-error "Incompatible command line arguments.\n"))
       filename))
 
 
@@ -211,7 +210,7 @@ default-archive-name))
 (define (check-existence filename)
   (if (file-exists? filename)
       filename
-      (option-error "Resource file ~S doesn't exist.  Exiting.\n"
+      (format-error "Resource file ~S doesn't exist.  Exiting.\n"
                     filename)))
 
 (define archiverc

--- a/utils/scripts/lepton-archive.in
+++ b/utils/scripts/lepton-archive.in
@@ -633,10 +633,6 @@ symbol cache directory."
     (filter-map source-library-filename files)))
 
 
-(define (schematic-pages schematic)
-  (map file->page (subschematic-page-filenames schematic)))
-
-
 (define (save-schematics-and-sources toplevel-schematics temp-dir cache-dir)
   (let* ((schematic (file-name-list->schematic toplevel-schematics))
          (subschematic-filenames (subschematic-page-filenames schematic))

--- a/utils/scripts/lepton-archive.in
+++ b/utils/scripts/lepton-archive.in
@@ -251,6 +251,11 @@ Continue? [y/N] "
 (define command-line-file-list (option-ref %options '() '()))
 
 
+(define (overwrite-file? message)
+  (display message)
+  (string= (read-line (current-input-port)) "y"))
+
+
 (define* (delete-file* filename #:optional quiet)
   (catch #t
     (lambda () (delete-file filename))
@@ -314,11 +319,6 @@ Continue? [y/N] "
               filename
               key
               args))))
-
-
-(define (overwrite-file? message)
-  (display message)
-  (string= (read-line (current-input-port)) "y"))
 
 
 (define (report-preserve-existing-file file)


### PR DESCRIPTION
The most significant fix is an ability to cache symbols from all subschematics recursively. Previously, it cached symbols from toplevel schematics, only.

Other changes are insignificant.