### PR TITLE
Improve lepton-version()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,11 @@ dnl directory.
 # Set up configuration system
 #####################################################################
 
-AC_INIT([lepton EDA], [1.9.9], [https://github.com/lepton-eda/lepton-eda/issues], [lepton-eda])
+AC_INIT([Lepton EDA],
+        [1.9.9],
+        [https://github.com/lepton-eda/lepton-eda/issues],
+        [lepton-eda],
+        [https://github.com/lepton-eda/lepton-eda])
 AC_PREREQ([2.60])
 
 AC_CONFIG_SRCDIR([liblepton/src/liblepton.c])

--- a/liblepton/include/liblepton/prototype.h
+++ b/liblepton/include/liblepton/prototype.h
@@ -42,6 +42,7 @@ void i_vars_libgeda_freenames();
 /* libgeda.c */
 void libgeda_init(void);
 void set_guile_compiled_path();
+char* version_message();
 
 /* m_hatch.c */
 void m_hatch_box(GedaBox *box, gint angle, gint pitch, GArray *lines);

--- a/liblepton/scheme/lepton/version.scm
+++ b/liblepton/scheme/lepton/version.scm
@@ -1,6 +1,6 @@
 ;;; Lepton EDA
 ;;; liblepton - Lepton's library - Scheme API
-;;; Copyright (C) 2017 Lepton EDA Contributors
+;;; Copyright (C) 2017-2019 Lepton EDA Contributors
 ;;;
 ;;; This program is free software; you can redistribute it and/or modify
 ;;; it under the terms of the GNU General Public License as published by
@@ -24,4 +24,71 @@
 
   #:export (lepton-version))
 
-(define lepton-version %lepton-version)
+
+
+; public:
+;
+; [what]: symbol, what information to retrieve:
+;   'prepend => get PREPEND_VERSION_STRING (defined in liblepton/defines.h)
+;   'dotted  => get PACKAGE_DOTTED_VERSION (defined in version.h)
+;   'date    => get PACKAGE_DATE_VERSION   (defined in version.h)
+;   'git     => get PACKAGE_GIT_COMMIT     (defined in version.h)
+;   'git7    => get first 7 symbols of PACKAGE_GIT_COMMIT
+;   'bugs    => get PACKAGE_BUGREPORT (defined in config.h)
+;   'url     => get PACKAGE_URL       (defined in config.h)
+;   'msg     => get message from version_message()
+;
+; If [what] is #f, return a list of strings:
+; - PREPEND_VERSION_STRING
+; - PACKAGE_DOTTED_VERSION
+; - PACKAGE_DATE_VERSION
+; - PACKAGE_GIT_COMMIT
+; - PACKAGE_BUGREPORT
+; - PACKAGE_URL
+; - message from version_message()
+;
+( define* ( lepton-version #:optional (what #f) )
+  ; return:
+  ( if what
+    ( lepton-version-ex what ) ; if
+    ( %lepton-version )        ; else
+  )
+)
+
+
+
+; private:
+;
+( define* ( lepton-version-ex what #:optional ( ver (%lepton-version) ) )
+
+  ( define ( item ndx )
+    ( list-ref ver ndx )
+  )
+
+  ( define ( git7 )
+    ( string-take (item 3) 7 )
+  )
+
+  ( let
+    (
+    ( items
+      ( list
+        ( cons 'prepend ( item 0 ) )
+        ( cons 'dotted  ( item 1 ) )
+        ( cons 'date    ( item 2 ) )
+        ( cons 'git     ( item 3 ) )
+        ( cons 'git7    ( git7 )   )
+        ( cons 'bugs    ( item 4 ) )
+        ( cons 'url     ( item 5 ) )
+        ( cons 'msg     ( item 6 ) )
+      )
+    )
+    )
+
+    ; return:
+    ( assoc-ref items what )
+
+  ) ; let
+
+) ; lepton-version-ex()
+

--- a/liblepton/src/liblepton.c
+++ b/liblepton/src/liblepton.c
@@ -18,28 +18,19 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
-#include <config.h>
 
-#include <stdio.h>
-#ifdef HAVE_STRING_H
-#include <string.h>
-#endif
-#ifdef HAVE_STRARG_H
-#include <stdarg.h>
-#endif
-#ifdef HAVE_STDLIB_H
-#include <stdlib.h>
-#endif
+#include "config.h"
+#include "version.h"
 
 #include "libgeda_priv.h"
 #include "liblepton/libgedaguile.h"
 
-/*! \brief Perform runtime initialization of libgeda library.
+/*! \brief Perform runtime initialization of liblepton library.
+ *
  *  \par Function Description
  *  This function is responsible for making sure that any runtime
- *  initialization is done for all the libgeda routines.  It should
- *  be called before any other libgeda functions are called.
- *
+ *  initialization is done for all the liblepton routines. It should
+ *  be called before any other liblepton functions are called.
  */
 void libgeda_init(void)
 {
@@ -88,5 +79,39 @@ set_guile_compiled_path()
   }
 
   setenv ("GUILE_LOAD_COMPILED_PATH", path, 1);
+}
+
+
+
+/*! \brief Returns a message to be used in the --version output.
+ *  \note  Caller must free() the returned value.
+ */
+char*
+version_message()
+{
+  const char* msg =
+    _("Lepton EDA %s%s.%s (git: %.7s)\n"
+    "Copyright (C) 1998-2016 gEDA developers\n"
+    "Copyright (C) 2017-2019 Lepton EDA developers\n"
+    "This is free software, and you are welcome to redistribute it\n"
+    "under certain conditions. For details, see the file `COPYING',\n"
+    "which is included in the Lepton EDA distribution.\n"
+    "There is NO WARRANTY, to the extent permitted by law.");
+
+  size_t sz = snprintf (NULL, 0, msg,
+                        PREPEND_VERSION_STRING,
+                        PACKAGE_DOTTED_VERSION,
+                        PACKAGE_DATE_VERSION,
+                        PACKAGE_GIT_COMMIT);
+
+  char* res = (char*) malloc (++sz);
+
+  snprintf (res, sz, msg,
+            PREPEND_VERSION_STRING,
+            PACKAGE_DOTTED_VERSION,
+            PACKAGE_DATE_VERSION,
+            PACKAGE_GIT_COMMIT);
+
+  return res;
 }
 

--- a/liblepton/src/scheme_version.c
+++ b/liblepton/src/scheme_version.c
@@ -1,5 +1,5 @@
-/* Lepton EDA
- * Copyright (C) 2017 Lepton Developers
+/* Lepton EDA library - Scheme API
+ * Copyright (C) 2017-2019 Lepton Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -31,17 +31,32 @@
  * \brief Returns Lepton EDA version list.
  * \par Function Description
  * Returns the list consisting of Scheme strings representing
- * PREPEND_VERSION_STRING, PACKAGE_DOTTED_VERSION, and
- * PACKAGE_GIT_COMMIT variables.
+ * the following variables:
+ * - PREPEND_VERSION_STRING
+ * - PACKAGE_DOTTED_VERSION
+ * - PACKAGE_GIT_COMMIT
+ * - PACKAGE_BUGREPORT
+ * - PACKAGE_URL
+ * The last element in the list contains version message that
+ * can be used in the --version output.
  */
 SCM_DEFINE (lepton_version, "%lepton-version", 0, 0, 0,
             (),
             "Return Lepton EDA version string list.")
 {
-  return scm_list_4 (scm_from_utf8_string (PREPEND_VERSION_STRING),
-                     scm_from_utf8_string (PACKAGE_DOTTED_VERSION),
-                     scm_from_utf8_string (PACKAGE_DATE_VERSION),
-                     scm_from_utf8_string (PACKAGE_GIT_COMMIT));
+  char* msg = version_message();
+
+  SCM res = scm_list_n (scm_from_utf8_string (PREPEND_VERSION_STRING),
+                        scm_from_utf8_string (PACKAGE_DOTTED_VERSION),
+                        scm_from_utf8_string (PACKAGE_DATE_VERSION),
+                        scm_from_utf8_string (PACKAGE_GIT_COMMIT),
+                        scm_from_utf8_string (PACKAGE_BUGREPORT),
+                        scm_from_utf8_string (PACKAGE_URL),
+                        scm_from_utf8_string (msg),
+                        SCM_UNDEFINED);
+
+  free (msg);
+  return res;
 }
 
 

--- a/netlist/scheme/netlist.scm
+++ b/netlist/scheme/netlist.scm
@@ -110,7 +110,7 @@ included in the Lepton EDA distribution.
 There is NO WARRANTY, to the extent permitted by law.\n"))
 
   (match (lepton-version)
-    ((prepend dotted date commit)
+    ((prepend dotted date commit bugs url msg)
      (if output-to-log?
          (log! 'message version-msg prepend dotted date (string-take commit 7))
          (begin

--- a/utils/upcfg/lepton-upcfg.in
+++ b/utils/upcfg/lepton-upcfg.in
@@ -52,6 +52,11 @@ exec @GUILE@ "$0" "$@"
     ( list 'single-char #\h )
     ( list 'value        #f )
   )
+  ( list ; --version (-V)
+    'version
+    ( list 'single-char #\V )
+    ( list 'value        #f )
+  )
 )
 ) ; cmd-line-args-spec
 
@@ -59,7 +64,7 @@ exec @GUILE@ "$0" "$@"
 
 ( define ( usage exit-code )
   ( format #t "~
-Usage: lepton-upcfg -l | -u | -s [-x] | -h
+Usage: lepton-upcfg -l | -u | -s [-x] | -h | -V
 
 Lepton EDA configuration upgrade utility.
 Converts geda*.conf configuration files
@@ -74,6 +79,7 @@ Options:
                    (in system configuration directory)
   -x, --overwrite  Overwrite existing files
   -h, --help       Show usage information
+  -V, --version    Show version information
 
 Report bugs at <~a>
 Lepton EDA homepage: <~a>
@@ -83,6 +89,13 @@ Lepton EDA homepage: <~a>
   )
 
   ( primitive-exit exit-code )
+)
+
+
+
+( define ( version )
+  ( format #t "~a~%" ( lepton-version 'msg ) )
+  ( primitive-exit 0 )
 )
 
 
@@ -110,6 +123,9 @@ Lepton EDA homepage: <~a>
 
   ( if (option-ref cmd-line-args 'help #f)
     ( usage 0 )
+  )
+  ( if (option-ref cmd-line-args 'version #f)
+    ( version )
   )
 
   ( if (option-ref cmd-line-args 'local #f)

--- a/utils/upcfg/lepton-upcfg.in
+++ b/utils/upcfg/lepton-upcfg.in
@@ -16,8 +16,10 @@ exec @GUILE@ "$0" "$@"
 ; Avoid Scheme compile-time errors using a clever trick
 ; from netlist/scheme/lepton-netlist.in (see comments there):
 ;
+( primitive-eval '(use-modules (ice-9 format)) )
 ( primitive-eval '(use-modules (lepton legacy-config)) )
 ( primitive-eval '(use-modules (ice-9 getopt-long)) )
+( primitive-eval '(use-modules (lepton version)) )
 
 
 
@@ -45,17 +47,42 @@ exec @GUILE@ "$0" "$@"
     ( list 'single-char #\x )
     ( list 'value        #f )
   )
+  ( list ; --help (-h)
+    'help
+    ( list 'single-char #\h )
+    ( list 'value        #f )
+  )
 )
 ) ; cmd-line-args-spec
 
 
 
 ( define ( usage exit-code )
-    ( format #t
-      "Usage: lepton-upcfg ~
-       -l | -u | -s [-x]~%"
-    )
-    ( primitive-exit exit-code )
+  ( format #t "~
+Usage: lepton-upcfg -l | -u | -s [-x] | -h
+
+Lepton EDA configuration upgrade utility.
+Converts geda*.conf configuration files
+to corresponding lepton*.conf files.
+
+Options:
+  -l, --local      geda.conf => lepton.conf
+                   (in current directory)
+  -u, --user       geda-user.conf => lepton-user.conf
+                   (in user configuration directory)
+  -s, --system     geda-system.conf => lepton-system.conf
+                   (in system configuration directory)
+  -x, --overwrite  Overwrite existing files
+  -h, --help       Show usage information
+
+Report bugs at <~a>
+Lepton EDA homepage: <~a>
+"
+    ( lepton-version 'bugs )
+    ( lepton-version 'url )
+  )
+
+  ( primitive-exit exit-code )
 )
 
 
@@ -79,6 +106,10 @@ exec @GUILE@ "$0" "$@"
   ( set! args-len (length cmd-line-args) )
   ( when ( or (< args-len 2) (> args-len 3) )
     ( usage 1 )
+  )
+
+  ( if (option-ref cmd-line-args 'help #f)
+    ( usage 0 )
   )
 
   ( if (option-ref cmd-line-args 'local #f)
@@ -118,8 +149,4 @@ exec @GUILE@ "$0" "$@"
 ; top-level code:
 ;
 ( main )
-
-
-
-; vim: ft=scheme tabstop=2 softtabstop=2 shiftwidth=2 expandtab
 


### PR DESCRIPTION
Make `lepton-version()` return individual version
info items if an (optional) argument is passed to
it. It can be one of the following symbols:

`'prepend` - get string prepended to version (normally, an empty string)
`'dotted`  - get version (e.g. `1.9.9`)
`'date`    - get date string (e.g. `20191003`)
`'git`     - get git commit `SHA1`
`'git7`    - get git commit `SHA1` (first 7 symbols)
`'bugs`    - get bugs reporting URL
`'url`     - get project's home page URL
`'msg`     - get version message (to show in the `--version` output)

The last item is returned by the new `version_message()` `liblepton` function -
a way to unify the `--version` output across all tools in the Lepton EDA suite.
This function substitutes the necessary parameters and returns a string like this:
```
Lepton EDA 1.9.9.20191003 (git: 6f5efea)
Copyright (C) 1998-2016 gEDA developers
Copyright (C) 2017-2019 Lepton EDA developers
This is free software, and you are welcome to redistribute it
under certain conditions. For details, see the file `COPYING',
which is included in the Lepton EDA distribution.
There is NO WARRANTY, to the extent permitted by law.
```

As an example, the `utils/upcfg` tool was modified to use the new functionality.

These changes are the result of my work on making `--help` and `--version`
messages uniform for all of the tools. I've already made many commits (in the
local branch) and finally realized that something could be simplified.