### PR TITLE
liblepton Scheme API functions to embed/unembed objects

### DIFF
--- a/liblepton/include/libgedaguile_priv.h
+++ b/liblepton/include/libgedaguile_priv.h
@@ -153,7 +153,7 @@ enum geda_smob_flags {
 #else
 #  define EDASCM_ASSERT_SMOB_VALID(x) \
   do { if (!EDASCM_SMOB_VALIDP(x)) {                                    \
-      scm_misc_error (NULL, "Found invalid gEDA smob ~S", scm_list_1 (x)); \
+      scm_misc_error (NULL, "Found invalid object (smob) ~S", scm_list_1 (x)); \
     } } while (0)
 #endif
 

--- a/liblepton/scheme/Makefile.am
+++ b/liblepton/scheme/Makefile.am
@@ -50,6 +50,7 @@ TESTS = unit-tests/t0001-geda-conf-lib.scm \
 	unit-tests/t0111-object-path.scm \
 	unit-tests/t0112-object-picture.scm \
 	unit-tests/t0113-object-selectable.scm \
+	unit-tests/t0114-object-embedded.scm \
 	unit-tests/t0200-page.scm \
 	unit-tests/t0201-page-dirty.scm \
 	unit-tests/t0202-page-string.scm \
@@ -90,6 +91,6 @@ update-cli-tool:
 .PHONY: update-cli-tool
 
 MOSTLYCLEANFILES = *.log *~
-CLEANFILES = *.log *~ geda/core/gettext.scm
+CLEANFILES = *.log *~ geda/core/gettext.scm unit-tests/dummy.sym unit-tests/dummy.xpm
 DISTCLEANFILES = *.log core FILE *~
 MAINTAINERCLEANFILES = *.log *~ Makefile.in

--- a/liblepton/scheme/geda/object.scm
+++ b/liblepton/scheme/geda/object.scm
@@ -473,3 +473,6 @@
 
 ( define-public object-selectable?     %object-selectable? )
 ( define-public set-object-selectable! %set-object-selectable! )
+
+( define-public object-embedded?     %object-embedded? )
+( define-public set-object-embedded! %set-object-embedded! )

--- a/liblepton/scheme/unit-tests/.gitignore
+++ b/liblepton/scheme/unit-tests/.gitignore
@@ -1,2 +1,4 @@
 *.log
 *.trs
+*.sym
+*.xpm

--- a/liblepton/scheme/unit-tests/t0114-object-embedded.scm
+++ b/liblepton/scheme/unit-tests/t0114-object-embedded.scm
@@ -1,0 +1,163 @@
+;; Test procedures for Scheme functions:
+;; - object-embedded?
+;; - set-object-embedded!
+
+( use-modules ( unit-test ) )
+
+( use-modules ( geda object ) )
+( use-modules ( lepton page ) )
+( use-modules ( lepton library component ) )
+
+
+
+( define ( mk-component ) ; create and return a component object
+
+  ( with-output-to-file "unit-tests/dummy.sym"
+    ( lambda()
+      ( format #t "v 20191003 2~%" )
+      ( format #t "B 0 0 500 500 3 10 1 0 -1 -1 0 -1 -1 -1 -1 -1~%" )
+      ( format #t "T 0 600 21 6 1 0 0 0 1~%" )
+      ( format #t "refdes=R?" )
+    )
+  )
+
+  ( component-library "unit-tests" ) ; cwd is liblepton/scheme/
+
+  ; return:
+  ( make-component/library "dummy.sym"     ; basename
+                            (cons 100 100) ; position
+                            0              ; angle
+                            #f             ; mirror
+                            #f             ; locked
+  )
+
+) ; mk-component()
+
+
+
+( define ( mk-picture ) ; create and return a picture object
+
+  ( define dummy-str ; red square 5x5
+    "/* XPM */
+    static char * dummy_xpm[] = {
+    \"5 5 2 1\",
+    \" 	c None\",
+    \".	c #FF0000\",
+    \".....\",
+    \".....\",
+    \".....\",
+    \".....\",
+    \".....\"};"
+  )
+
+  ( define dummy-vector
+    ( map char->integer
+      ( string->list dummy-str )
+    )
+  )
+
+  ( with-output-to-file "unit-tests/dummy.xpm"
+    ( lambda()
+      ( format #t dummy-str )
+    )
+  )
+
+  ; return:
+  ( make-picture/vector
+    dummy-vector           ; vector
+    "unit-tests/dummy.xpm" ; filename
+    (cons 100 200)         ; top-left
+    (cons 200 100)         ; bottom-right
+    0                      ; angle
+    #f                     ; mirror
+  )
+
+) ; mk-picture()
+
+
+
+( define ( test-embedded obj )
+( let
+  (
+  ( page #f )
+  ( tmp  #f )
+  )
+
+  ; create a page and add an object to it:
+  ;
+  ( set! page ( make-page "/test/page/A" ) )
+  ( page-append! page obj )
+
+  ; obj should be unembedded:
+  ;
+  ( assert-false (object-embedded? obj) )
+
+
+  ; clear the page modification flag and embed the object:
+  ;
+  ( set-page-dirty! page #f )
+  ( set! tmp (set-object-embedded! obj #t) )
+
+  ; set-object-embedded!() should return the object:
+  ;
+  ( assert-equal tmp obj )
+
+  ; ensure obj is now embedded:
+  ;
+  ( assert-true (object-embedded? obj) )
+
+  ; ensure the page modification flag is set:
+  ;
+  ( assert-true (page-dirty? page) )
+
+
+  ; clear the page modification flag and try to embed the object again:
+  ;
+  ( set-page-dirty! page #f )
+  ( set-object-embedded! obj #t )
+
+  ; ensure the page modification flag is NOT set (obj is not modified):
+  ;
+  ( assert-false (page-dirty? page) )
+
+  ; clear the page modification flag and unembed the object:
+  ;
+  ( set-page-dirty! page #f )
+  ( set! tmp (set-object-embedded! obj #f) )
+
+  ; set-object-embedded!() should return the object:
+  ;
+  ( assert-equal tmp obj )
+
+  ; ensure obj is now unembedded:
+  ;
+  ( assert-false (object-embedded? obj) )
+
+  ; ensure the page modification flag is set:
+  ;
+  ( assert-true (page-dirty? page) )
+
+
+  ( close-page! page )
+
+) ; let
+) ; test-embedded()
+
+
+
+( begin-test 'object-embedded
+( let
+  (
+  ( obj #f )
+  )
+
+  ( set! obj ( mk-component ) )
+  ( test-embedded obj )
+
+  ( set! obj ( mk-picture ) )
+  ( set-object-embedded! obj #f ) ; make-picture/vector() creates embedded object
+  ( test-embedded obj )
+
+) ; let
+) ; 'object-embedded()
+

--- a/liblepton/src/scheme_toplevel.c
+++ b/liblepton/src/scheme_toplevel.c
@@ -1,6 +1,6 @@
-/* gEDA - GPL Electronic Design Automation
- * libgeda - gEDA's library - Scheme API
+/* Lepton EDA library - Scheme API
  * Copyright (C) 2010-2012 Peter Brett <peter@peter-b.co.uk>
+ * Copyright (C) 2017-2019 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -38,7 +38,17 @@ SCM_DEFINE (edascm_make_toplevel, "%make-toplevel", 0, 0, 0,
             (),
             "Make new TOPLEVEL.")
 {
-  return edascm_from_toplevel (s_toplevel_new ());
+  TOPLEVEL* toplevel = s_toplevel_new();
+
+  /* Almost all calls to s_toplevel_new() are accompanied
+   * by subsequent call to i_vars_libgeda_set() in C code.
+   * It can't be done in Scheme.
+   * To get properly initialized TOPLEVEL object in Scheme
+   * code, call i_vars_libgeda_set() here:
+  */
+  i_vars_libgeda_set (toplevel);
+
+  return edascm_from_toplevel (toplevel);
 }
 
 


### PR DESCRIPTION
- Add new functions to embed/unembed pictures and component objects
and check the "embedded" status of an object:
  - `set-object-embedded!`
  - `object-embedded?`
- Fix `%make-toplevel` function: it turned out that `i_vars_libgeda_set()` has
to be called there. Otherwise, inherited attributes of programmatically
embedded components will be visible.