### PR TITLE
Improve tabbed GUI

### DIFF
--- a/liblepton/include/liblepton/geda_list.h
+++ b/liblepton/include/liblepton/geda_list.h
@@ -1,7 +1,8 @@
-/* gEDA - GPL Electronic Design Automation
- * libgeda - gEDA's library
+/* Lepton EDA library
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 2007-2010 Peter Clifton
+ * Copyright (C) 2011-2015 gEDA Contributors
+ * Copyright (C) 2017-2019 Lepton EDA Contributors
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -56,6 +57,9 @@ void geda_list_add_glist( GedaList *list, GList *items );
 void geda_list_remove( GedaList *list, gpointer item );
 /*void geda_list_remove_glist( GedaList *list, GList *items ); */ /* Undemanded as yet */
 void geda_list_remove_all( GedaList *list );
+void geda_list_move_item( GedaList* list, gpointer item, gint newpos );
+
+
 
 /*const GList *geda_list_get_glist( GedaList *list ); */
 #define geda_list_get_glist(list) (list->glist)

--- a/liblepton/src/geda_list.c
+++ b/liblepton/src/geda_list.c
@@ -1,7 +1,8 @@
-/* gEDA - GPL Electronic Design Automation
- * libgeda - gEDA's library
+/* Lepton EDA library
  * Copyright (C) 1998-2000 Ales Hvezda
  * Copyright (C) 2007-2010 Peter Clifton
+ * Copyright (C) 2011-2013 gEDA Contributors
+ * Copyright (C) 2017-2019 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -177,5 +178,24 @@ void geda_list_remove_all( GedaList *list )
   g_list_free(list->glist);
   list->glist = NULL;
   g_signal_emit( list, geda_list_signals[ CHANGED ], 0 );
+}
+
+
+/*! \brief Moves the list data \a item to a new position \a newpos.
+ */
+void geda_list_move_item( GedaList* list, gpointer item, gint newpos )
+{
+  GList* gl = list->glist;
+  GList* node = g_list_find (gl, item);
+
+  if (node != NULL)
+  {
+    gl = g_list_remove_link (gl, node);
+    gl = g_list_insert (gl, item, newpos);
+    g_list_free (node);
+    list->glist = gl;
+
+    g_signal_emit( list, geda_list_signals[ CHANGED ], 0 );
+  }
 }
 

--- a/schematic/src/x_tabs.c
+++ b/schematic/src/x_tabs.c
@@ -53,7 +53,7 @@
  * key:         use-tabs
  * group:       schematic.gui
  * type:        boolean
- * default val: false
+ * default val: true
  *
  * 2) Whether to show "close" button on tabs:
  * key:         show-close-button
@@ -75,7 +75,7 @@
 
 
 static gboolean
-g_x_tabs_enabled = FALSE;
+g_x_tabs_enabled = TRUE;
 
 static gboolean
 g_x_tabs_show_close_button = TRUE;


### PR DESCRIPTION
- Pages can now be reordered by dragging tab's header to a new position
- Right mouse button click on the active tab's header shows the context menu
with common actions

![tb_214_reorder_ctxmenu ss](https://user-images.githubusercontent.com/26083750/68333385-78114880-00e9-11ea-98d3-09b027322c8e.png)

@all What items should be included in the context menu? In what sequence
should they be displayed?