### PR TITLE
Fix the procedure component-library-search().

### DIFF
--- a/liblepton/scheme/lepton/library/component.scm
+++ b/liblepton/scheme/lepton/library/component.scm
@@ -152,9 +152,15 @@
 (define* (component-library-search rootdir  #:optional (prefix ""))
   "Add all symbol libraries found below ROOTDIR to be searched for
 components, naming them with an optional PREFIX."
+  ;; Recursively removes file name separator suffices in DIR-NAME.
+  (define (remove-/-suffices dir-name)
+    (if (string-suffix? file-name-separator-string dir-name)
+        (remove-/-suffices (string-drop-right dir-name
+                                              (string-length file-name-separator-string)))
+        dir-name))
 
   (let ((dht (make-hash-table 31))
-        (rootdir (expand-env-variables rootdir)))
+        (rootdir (remove-/-suffices (expand-env-variables rootdir))))
 
     ;; Build symbol directory list.
     (ftw rootdir
@@ -168,6 +174,9 @@ components, naming them with an optional PREFIX."
             (else
              (and (eq? 'regular flags)
                   (string-suffix-ci? ".sym" filename)
+                  ;; Filter out symbol files in root dir.  Dunno,
+                  ;; where to add them.
+                  (not (string= (dirname filename) rootdir))
                   (hashq-set! dht
                               (string->symbol (dirname filename))
                               #t))))

--- a/netlist/scheme/Makefile.am
+++ b/netlist/scheme/Makefile.am
@@ -109,6 +109,7 @@ DIST_SCM = \
 	netlist/verbose.scm
 
 TESTS = unit-tests/test-netlist-load-path.scm \
+	unit-tests/test-component-library-search.scm \
 	unit-tests/test-netlist-attrib.scm \
 	unit-tests/test-netlist-partlist.scm
 

--- a/netlist/scheme/unit-tests/test-component-library-search.scm
+++ b/netlist/scheme/unit-tests/test-component-library-search.scm
@@ -28,11 +28,13 @@
     (mkdir (make-filename *toplevel-dir* "a"))
     (mkdir (make-filename *toplevel-dir* "b"))
     (mkdir (make-filename *toplevel-dir* "b" "b"))
+    (mkdir (make-filename *toplevel-dir* "b" "b" "c"))
     ;; Make symbol files.
     (touch (make-filename *toplevel-dir* "toplevel.sym"))
     (touch (make-filename *toplevel-dir* "a" "a.sym"))
     (touch (make-filename *toplevel-dir* "b" "b.sym"))
-    (touch (make-filename *toplevel-dir* "b" "b" "bb.sym")))
+    (touch (make-filename *toplevel-dir* "b" "b" "bb.sym"))
+    (touch (make-filename *toplevel-dir* "b" "b" "c" "bbc.sym")))
 
   ;; Test body.
   (lambda ()
@@ -43,18 +45,52 @@
     ;; Just check that all symbols but the toplevel one exist in
     ;; the component library created.
     (test-assert
-        (and (absolute-component-name "a.sym")
+        (and (absolute-component-name "toplevel.sym")
+             (absolute-component-name "a.sym")
              (absolute-component-name "b.sym")
-             (absolute-component-name "bb.sym")))
-
-    (test-assert (not (absolute-component-name "toplevel.sym")))
+             (absolute-component-name "bb.sym")
+             (absolute-component-name "bbc.sym")))
 
     ;; The same as above but the directory ends with "/".
     (reset-component-library)
     (component-library-search (string-append *toplevel-dir*
                                              file-name-separator-string))
 
-    (test-assert (not (absolute-component-name "toplevel.sym"))))
+    (test-assert (absolute-component-name "toplevel.sym"))
+
+
+    ;; Test of libraries with same directory basenames.
+    (reset-component-library)
+    (component-library-search (string-append (make-filename *toplevel-dir* "b" "b")
+                                             file-name-separator-string)
+                              "myprefix")
+    (test-assert (absolute-component-name "bbc.sym"))
+
+    ;; Test of toplevel library with symbols without prefix.
+    (reset-component-library)
+
+    (component-library-search *toplevel-dir*)
+
+    (let ((libs (filter
+                 (lambda (lib) (string= (symbol-library-path lib) *toplevel-dir*))
+                 (component-libraries))))
+      (test-equal (map symbol-library-name libs)
+        (list (basename *toplevel-dir*))))
+
+    ;; Test of toplevel library with symbols with prefix.
+    (reset-component-library)
+
+    (component-library-search *toplevel-dir* "xxx")
+
+    (let ((libs (component-libraries))
+          ;; On *nix the following should result in
+          ;; '("xxx" "xxxa" "xxxb" "xxxb/b" "xxxb/b/c")
+          (result (map (lambda (x) (string-append "xxx" x))
+                       (map (lambda (ls) (string-join ls file-name-separator-string))
+                            '(("") ("a") ("b") ("b" "b") ("b" "b" "c"))))))
+      (test-eq (length libs) 5)
+      (test-equal (sort (map symbol-library-name libs) string<)
+        result)))
 
   ;; Get rid of the test directory.
   (lambda ()

--- a/netlist/scheme/unit-tests/test-component-library-search.scm
+++ b/netlist/scheme/unit-tests/test-component-library-search.scm
@@ -1,0 +1,62 @@
+(use-modules (srfi srfi-64)
+             (lepton library component))
+
+;;; Helper procedures.
+
+;;; Make filenames by joining strings and using filename separator
+;;; as a delimiter between them.
+(define (make-filename . args)
+  (string-join args file-name-separator-string 'infix))
+
+
+;;; Create symbol files.
+(define (touch file)
+  (with-output-to-file file (lambda () (display ""))))
+
+
+;;; Main testing directory.
+(define *toplevel-dir*
+  (make-filename (getcwd) "component-library-search-test"))
+
+(test-begin "component-library-search" 1)
+(dynamic-wind
+  ;; Make test directory with all necessary subdirectories and files.  We
+  ;; use a toplevel directory with two level folded subdirectories
+  ;; and symbol files in them.
+  (lambda ()
+    (mkdir *toplevel-dir*)
+    (mkdir (make-filename *toplevel-dir* "a"))
+    (mkdir (make-filename *toplevel-dir* "b"))
+    (mkdir (make-filename *toplevel-dir* "b" "b"))
+    ;; Make symbol files.
+    (touch (make-filename *toplevel-dir* "toplevel.sym"))
+    (touch (make-filename *toplevel-dir* "a" "a.sym"))
+    (touch (make-filename *toplevel-dir* "b" "b.sym"))
+    (touch (make-filename *toplevel-dir* "b" "b" "bb.sym")))
+
+  ;; Test body.
+  (lambda ()
+    ;; First, reset the component library to be sure it is empty.
+    (reset-component-library)
+    (component-library-search *toplevel-dir*)
+
+    ;; Just check that all symbols but the toplevel one exist in
+    ;; the component library created.
+    (test-assert
+        (and (absolute-component-name "a.sym")
+             (absolute-component-name "b.sym")
+             (absolute-component-name "bb.sym")))
+
+    (test-assert (not (absolute-component-name "toplevel.sym")))
+
+    ;; The same as above but the directory ends with "/".
+    (reset-component-library)
+    (component-library-search (string-append *toplevel-dir*
+                                             file-name-separator-string))
+
+    (test-assert (not (absolute-component-name "toplevel.sym"))))
+
+  ;; Get rid of the test directory.
+  (lambda ()
+    (system* "rm" "-rf" *toplevel-dir*)))
+(test-end "component-library-search")


### PR DESCRIPTION
In some cases, when the root directory processed by the procedure
contained symbol files, the procedure failed with the error as
follows:

ERROR: In procedure substring:
Value out of range 0 to 30: 31

This has been fixed by filtering out the symbols whose directory
is the same as the root directory.