### PR TITLE
Copyable attributes in the component selection dialog

### DIFF
--- a/schematic/src/x_compselect.c
+++ b/schematic/src/x_compselect.c
@@ -1229,7 +1229,7 @@ create_attributes_treeview (Compselect *compselect)
 
   /* two columns for name and value of the attributes */
   renderer = GTK_CELL_RENDERER (g_object_new (GTK_TYPE_CELL_RENDERER_TEXT,
-                                              "editable", FALSE,
+                                              "editable", TRUE,
                                               NULL));
 
   column = GTK_TREE_VIEW_COLUMN (g_object_new (GTK_TYPE_TREE_VIEW_COLUMN,


### PR DESCRIPTION
Names and values of attributes in the component
selection dialog can now be copied to clipboard.