### PR TITLE
Catch exceptions in the main menu configuration file

### DIFF
--- a/schematic/scheme/conf/schematic/menu.scm
+++ b/schematic/scheme/conf/schematic/menu.scm
@@ -12,6 +12,8 @@
 ; The SEPARATOR keyword is case sensitive and puts a separator into the menu.
 ;
 
+( use-modules ( ice-9 format ) )
+( use-modules ( geda config ) )
 
 ;; Define a no-op macro for flagging strings as translatable.
 (define-syntax N_
@@ -105,17 +107,35 @@
 ( define ( view-menu-items )
 ( let*
   (
+  ( default-use-docks #f )
+  ( use-docks default-use-docks )
   ( grp "schematic.gui" )
   ( key "use-docks" )
-  ( cfg ( path-config-context (getcwd) ) )
-  ( val ( if cfg (config-boolean cfg grp key) #f ) )
+  ( cfg #f )
   )
 
   ( define ( opt-item item )
     ; return:
-    ( if val
+    ( if use-docks
       item ; if
       '()  ; else
+    )
+  )
+
+
+  ( catch #t
+    ( lambda()
+      ( set! cfg ( path-config-context (getcwd) ) )
+      ( set! use-docks ( config-boolean cfg grp key ) )
+    )
+    ( lambda( ex . args )
+      ( format
+        ( current-error-port )
+        "menu.scm: Cannot read configuration key [~a::~a]:~%~
+         '~a: ~a~%~
+         Please check your installation.~%"
+        grp key ex args
+      )
     )
   )
 
@@ -148,17 +168,35 @@
 ( define ( page-menu-items )
 ( let*
   (
+  ( default-use-tabs #t )
+  ( use-tabs default-use-tabs )
   ( grp "schematic.gui" )
   ( key "use-tabs" )
-  ( cfg ( path-config-context (getcwd) ) )
-  ( val ( if cfg (config-boolean cfg grp key) #t ) )
+  ( cfg #f )
   )
 
   ( define ( opt-item item )
     ; return:
-    ( if val
+    ( if use-tabs
       item ; if
       '()  ; else
+    )
+  )
+
+
+  ( catch #t
+    ( lambda()
+      ( set! cfg ( path-config-context (getcwd) ) )
+      ( set! use-tabs ( config-boolean cfg grp key ) )
+    )
+    ( lambda( ex . args )
+      ( format
+        ( current-error-port )
+        "menu.scm: Cannot read configuration key [~a::~a]:~%~
+         '~a: ~a~%~
+         Please check your installation.~%"
+        grp key ex args
+      )
     )
   )
 

--- a/schematic/src/x_widgets.c
+++ b/schematic/src/x_widgets.c
@@ -37,7 +37,7 @@
 
 
 static gboolean
-g_x_widgets_use_docks = TRUE;
+g_x_widgets_use_docks = FALSE;
 
 
 
@@ -74,9 +74,8 @@ gboolean x_widgets_use_docks()
  * key:   use-docks
  * group: schematic.gui
  * type:  boolean
- * default value: true
+ * default value: false
  *
- * \return TRUE if use-docks option is set to true, FALSE otherwise.
  */
 void x_widgets_init()
 {


### PR DESCRIPTION
`conf/schematic/menu.scm`:
Generate the main menu correctly, even if some
system configuration `*.conf` files are missing.
Catch exceptions that may be thrown by functions
in the `(geda config)` module, use default values
for configuration keys.
See issue #476.