### PR TITLE
Improve lepton-embed

### DIFF
--- a/utils/docs/lepton-embed.1.in
+++ b/utils/docs/lepton-embed.1.in
@@ -34,6 +34,10 @@ Process pictures only.
 .BR \-c ", " \-\-components
 Process components only.
 .TP
+.BR \-x ", " \-\-suffix " " \fBSUFFIX\fR
+Do not change input files. Modified files will be saved as
+\fIFILE\fR\fB.SUFFIX\fR.
+.TP
 .BR \-V ", " \-\-version
 Show version information.
 .TP

--- a/utils/docs/lepton-embed.1.in
+++ b/utils/docs/lepton-embed.1.in
@@ -5,8 +5,7 @@ lepton-embed \- Embed/unembed schematic components and pictures
 
 .SH SYNOPSIS
 .B lepton-embed
-.RB OPTIONS
-.I FILE ...
+\fB-e\fR | \fB-u\fR [\fIOPTIONS\fR] \fIFILE\fR ...
 
 .SH DESCRIPTION
 .B lepton-embed
@@ -24,10 +23,16 @@ the current Lepton EDA project's library path, a broken schematic results.
 .SH OPTIONS
 .TP
 .BR \-e ", " \-\-embed
-Embed all components and pictures.
+Embed. Without \fB-p\fR or \fB-c\fR, embed all components and pictures.
 .TP
 .BR \-u ", " \-\-unembed
-Unembed all components and pictures.
+Unembed. Without \fB-p\fR or \fB-c\fR, unembed all components and pictures.
+.TP
+.BR \-p ", " \-\-pictures
+Process pictures only.
+.TP
+.BR \-c ", " \-\-components
+Process components only.
 .TP
 .BR \-V ", " \-\-version
 Show version information.

--- a/utils/scripts/lepton-embed.in
+++ b/utils/scripts/lepton-embed.in
@@ -49,6 +49,11 @@ exec @GUILE@ "$0" "$@"
     ( list 'single-char #\c )
     ( list 'value        #f )
   )
+  ( list ; --suffix (-x)
+    'suffix
+    ( list 'single-char #\x )
+    ( list 'value        #t )
+  )
   ( list ; --help (-h)
     'help
     ( list 'single-char #\h )
@@ -68,15 +73,16 @@ exec @GUILE@ "$0" "$@"
   ( format #t "~
 Usage: lepton-embed -e | -u [OPTIONS] FILE ...
 
-Lepton EDA component embedding/unembedding utility.
+Lepton EDA schematic components and pictures embedding/unembedding utility.
 
 Options:
-  -e, --embed      Embed: without -p or -c, all components and pictures
-  -u, --unembed    Unembed: without -p or -c, all components and pictures
-  -p, --pictures   Process pictures only
-  -c, --components Process components only
-  -h, --help       Show usage information
-  -V, --version    Show version information
+  -e, --embed          Embed: without -p or -c, all components and pictures
+  -u, --unembed        Unembed: without -p or -c, all components and pictures
+  -p, --pictures       Process pictures only
+  -c, --components     Process components only
+  -x, --suffix SUFFIX  Keep input files intact, save to FILE.SUFFIX
+  -h, --help           Show usage information
+  -V, --version        Show version information
 
 Report bugs at <~a>
 Lepton EDA homepage: <~a>
@@ -116,15 +122,29 @@ Lepton EDA homepage: <~a>
 
 
 ( define* ( page-save page #:optional (suffix "") )
-( let
+
+  ( define ( mk-out-file-name file )
+    ; return:
+    ( if ( string-null? suffix )
+      file                         ; if
+      ( format #f "~a~a~a.~a"      ; else
+        ( dirname file )
+        file-name-separator-string
+        ( basename file )
+        suffix
+      )
+    )
+  ) ; mk-out-file-name()
+
+( let*
   (
   ( file ( page-filename page ) )
+  ( out  ( mk-out-file-name file ) )
   )
 
   ( catch #t
   ( lambda()
-    ( with-output-to-file
-      ( format #f "~a~a" file suffix )
+    ( with-output-to-file out
       ( lambda()
         ; return:
         ( format #t "~a" (page->string page) )
@@ -134,7 +154,7 @@ Lepton EDA homepage: <~a>
   ( lambda( ex . args )
     ( format (current-error-port)
               "Cannot save file [~a]:~%  '~a: ~a ~%"
-              file ex args )
+              out ex args )
     ; return:
     #f
   )
@@ -164,7 +184,7 @@ Lepton EDA homepage: <~a>
 
 
 
-( define ( process-file file embed chk-embeddable )
+( define ( process-file file embed chk-embeddable suffix )
 ( let
   (
   ( page ( page-open file ) )
@@ -172,7 +192,7 @@ Lepton EDA homepage: <~a>
 
   ( when page
     ( do-embed page embed chk-embeddable )
-    ( if ( and (page-dirty? page) (page-save page) )
+    ( if ( and (page-dirty? page) (page-save page suffix) )
       ( format #t "Saved: [~a]~%" file )
     )
   )
@@ -183,7 +203,7 @@ Lepton EDA homepage: <~a>
 
 
 ( define ( main )
-( let
+( let*
   (
   ( cmd-line-args '() )
   ( files         '() )
@@ -192,6 +212,8 @@ Lepton EDA homepage: <~a>
   ( arg-pics       #f )
   ( arg-comps      #f )
   ( chk-embeddable embeddable? )
+  ( suffix-default     "" )
+  ( suffix suffix-default )
   )
 
   ( set! cmd-line-args
@@ -233,12 +255,14 @@ Lepton EDA homepage: <~a>
     ( set! chk-embeddable embeddable? )
   )
 
+  ( set! suffix ( option-ref cmd-line-args 'suffix suffix-default ) )
+
 
   ( (@@ (guile-user) parse-rc) "lepton-embed" "gafrc" )
 
   ( for-each
   ( lambda( file )
-    ( process-file file arg-embed chk-embeddable )
+    ( process-file file arg-embed chk-embeddable suffix )
   )
     files
   )

--- a/utils/scripts/lepton-embed.in
+++ b/utils/scripts/lepton-embed.in
@@ -146,14 +146,16 @@ Lepton EDA homepage: <~a>
   ( lambda()
     ( with-output-to-file out
       ( lambda()
-        ; return:
         ( format #t "~a" (page->string page) )
+        ( format (current-error-port) "Saved: [~a]~%" out )
+        ; return:
+        #t
       )
     )
   )
   ( lambda( ex . args )
     ( format (current-error-port)
-              "Cannot save file [~a]:~%  '~a: ~a ~%"
+              "Cannot save file [~a]:~%  '~a: ~a~%"
               out ex args )
     ; return:
     #f
@@ -192,8 +194,8 @@ Lepton EDA homepage: <~a>
 
   ( when page
     ( do-embed page embed chk-embeddable )
-    ( if ( and (page-dirty? page) (page-save page suffix) )
-      ( format #t "Saved: [~a]~%" file )
+    ( if ( page-dirty? page )
+      ( page-save page suffix )
     )
   )
 

--- a/utils/scripts/lepton-embed.in
+++ b/utils/scripts/lepton-embed.in
@@ -39,6 +39,16 @@ exec @GUILE@ "$0" "$@"
     ( list 'single-char #\u )
     ( list 'value        #f )
   )
+  ( list ; --pictures (-p)
+    'pictures
+    ( list 'single-char #\p )
+    ( list 'value        #f )
+  )
+  ( list ; --components (-c)
+    'components
+    ( list 'single-char #\c )
+    ( list 'value        #f )
+  )
   ( list ; --help (-h)
     'help
     ( list 'single-char #\h )
@@ -56,13 +66,15 @@ exec @GUILE@ "$0" "$@"
 
 ( define ( usage exit-code )
   ( format #t "~
-Usage: lepton-embed OPTIONS FILE ...
+Usage: lepton-embed -e | -u [OPTIONS] FILE ...
 
 Lepton EDA component embedding/unembedding utility.
 
 Options:
-  -e, --embed      Embed all components and pictures
-  -u, --unembed    Unembed all components and pictures
+  -e, --embed      Embed: without -p or -c, all components and pictures
+  -u, --unembed    Unembed: without -p or -c, all components and pictures
+  -p, --pictures   Process pictures only
+  -c, --components Process components only
   -h, --help       Show usage information
   -V, --version    Show version information
 
@@ -177,6 +189,8 @@ Lepton EDA homepage: <~a>
   ( files         '() )
   ( arg-embed      #f )
   ( arg-unembed    #f )
+  ( arg-pics       #f )
+  ( arg-comps      #f )
   ( chk-embeddable embeddable? )
   )
 
@@ -204,6 +218,19 @@ Lepton EDA homepage: <~a>
   ( set! files ( option-ref cmd-line-args '() '() ) )
   ( if ( null? files )
     ( usage 3 )
+  )
+
+  ( set! arg-pics  ( option-ref cmd-line-args 'pictures   #f ) )
+  ( set! arg-comps ( option-ref cmd-line-args 'components #f ) )
+
+  ( if arg-pics
+    ( set! chk-embeddable picture? )
+  )
+  ( if arg-comps
+    ( set! chk-embeddable component? )
+  )
+  ( if ( and arg-pics arg-comps )
+    ( set! chk-embeddable embeddable? )
   )
 
 

--- a/utils/scripts/lepton-embed.in
+++ b/utils/scripts/lepton-embed.in
@@ -111,7 +111,7 @@ Lepton EDA homepage: <~a>
   )
   ( lambda( ex . args )
     ( format (current-error-port)
-              "Cannot open file [~a]:~%  '~a: ~a ~%"
+              "Cannot open file [~a]:~%  '~a: ~a~%"
               file ex args )
     ; return:
     #f
@@ -121,7 +121,7 @@ Lepton EDA homepage: <~a>
 
 
 
-( define* ( page-save page #:optional (suffix "") )
+( define ( page-save page suffix )
 
   ( define ( mk-out-file-name file )
     ; return:
@@ -168,7 +168,11 @@ Lepton EDA homepage: <~a>
 
 
 ( define ( embeddable? obj )
-  ( or (component? obj) (picture? obj) )
+  ; return:
+  ( or
+    ( component? obj )
+    ( picture?   obj )
+  )
 )
 
 
@@ -207,19 +211,14 @@ Lepton EDA homepage: <~a>
 ( define ( main )
 ( let*
   (
-  ( cmd-line-args '() )
-  ( files         '() )
-  ( arg-embed      #f )
-  ( arg-unembed    #f )
-  ( arg-pics       #f )
-  ( arg-comps      #f )
+  ( cmd-line-args  (getopt-long (program-arguments) cmd-line-args-spec) )
+  ( files          (option-ref cmd-line-args '()        '()) )
+  ( arg-embed      (option-ref cmd-line-args 'embed      #f) )
+  ( arg-unembed    (option-ref cmd-line-args 'unembed    #f) )
+  ( arg-pics       (option-ref cmd-line-args 'pictures   #f) )
+  ( arg-comps      (option-ref cmd-line-args 'components #f) )
+  ( suffix         (option-ref cmd-line-args 'suffix     "") )
   ( chk-embeddable embeddable? )
-  ( suffix-default     "" )
-  ( suffix suffix-default )
-  )
-
-  ( set! cmd-line-args
-    ( getopt-long (program-arguments) cmd-line-args-spec )
   )
 
   ( if ( option-ref cmd-line-args 'help #f )
@@ -229,9 +228,6 @@ Lepton EDA homepage: <~a>
     ( version )
   )
 
-  ( set! arg-embed   ( option-ref cmd-line-args 'embed #f ) )
-  ( set! arg-unembed ( option-ref cmd-line-args 'unembed #f ) )
-
   ( if ( and arg-embed arg-unembed )
     ( usage 1 )
   )
@@ -239,13 +235,9 @@ Lepton EDA homepage: <~a>
     ( usage 2 )
   )
 
-  ( set! files ( option-ref cmd-line-args '() '() ) )
   ( if ( null? files )
     ( usage 3 )
   )
-
-  ( set! arg-pics  ( option-ref cmd-line-args 'pictures   #f ) )
-  ( set! arg-comps ( option-ref cmd-line-args 'components #f ) )
 
   ( if arg-pics
     ( set! chk-embeddable picture? )
@@ -256,8 +248,6 @@ Lepton EDA homepage: <~a>
   ( if ( and arg-pics arg-comps )
     ( set! chk-embeddable embeddable? )
   )
-
-  ( set! suffix ( option-ref cmd-line-args 'suffix suffix-default ) )
 
 
   ( (@@ (guile-user) parse-rc) "lepton-embed" "gafrc" )

--- a/utils/scripts/lepton-embed.in
+++ b/utils/scripts/lepton-embed.in
@@ -139,27 +139,27 @@ Lepton EDA homepage: <~a>
 
 
 
-( define ( do-embed page embed )
+( define ( do-embed page embed chk-embeddable )
 
   ( for-each
   ( lambda( comp )
       ( set-object-embedded! comp embed )
   )
-  ( filter embeddable? (page-contents page) )
+  ( filter chk-embeddable (page-contents page) )
   )
 
 ) ; do-embed()
 
 
 
-( define ( process-file file embed )
+( define ( process-file file embed chk-embeddable )
 ( let
   (
   ( page ( page-open file ) )
   )
 
   ( when page
-    ( do-embed page embed )
+    ( do-embed page embed chk-embeddable )
     ( if ( and (page-dirty? page) (page-save page) )
       ( format #t "Saved: [~a]~%" file )
     )
@@ -177,6 +177,7 @@ Lepton EDA homepage: <~a>
   ( files         '() )
   ( arg-embed      #f )
   ( arg-unembed    #f )
+  ( chk-embeddable embeddable? )
   )
 
   ( set! cmd-line-args
@@ -210,7 +211,7 @@ Lepton EDA homepage: <~a>
 
   ( for-each
   ( lambda( file )
-    ( process-file file arg-embed )
+    ( process-file file arg-embed chk-embeddable )
   )
     files
   )

--- a/utils/scripts/lepton-embed.in
+++ b/utils/scripts/lepton-embed.in
@@ -133,11 +133,13 @@ Lepton EDA homepage: <~a>
 
 
 
-( define ( do-embed page embed )
+( define ( embeddable? obj )
+  ( or (component? obj) (picture? obj) )
+)
 
-  ( define ( embeddable? obj )
-    ( or (component? obj) (picture? obj) )
-  )
+
+
+( define ( do-embed page embed )
 
   ( for-each
   ( lambda( comp )


### PR DESCRIPTION
Add new command-line options:
- `--pictures` (`-p`): embed/unembed pictures only
- `--components` (`-c`): embed/unembed components (i.e. symbols) only
- `--suffix SUFFIX` (`-x`): save modified `FILE`s as `FILE`.`SUFFIX`, leave input files intact
