### PR TITLE
Refactor menu sensitivity code in lepton-schematic

### DIFF
--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -646,7 +646,7 @@ gboolean x_show_uri (GschemToplevel *w_current, const gchar *buf, GError **err);
 GtkWidget *get_main_menu(GschemToplevel *w_current);
 GtkWidget *get_main_popup(GschemToplevel *w_current);
 gint do_popup(GschemToplevel *w_current, GdkEventButton *event);
-void x_menus_sensitivity(GschemToplevel *w_current, const char *buf, int flag);
+void x_menus_sensitivity (GschemToplevel* w_current, const gchar* action_name, gboolean sensitive);
 void x_menus_popup_sensitivity(GschemToplevel *w_current, const char *buf, int flag);
 /* x_multiattrib.c */
 void x_multiattrib_open (GschemToplevel *w_current);

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -646,7 +646,7 @@ gboolean x_show_uri (GschemToplevel *w_current, const gchar *buf, GError **err);
 GtkWidget *get_main_menu(GschemToplevel *w_current);
 GtkWidget *get_main_popup(GschemToplevel *w_current);
 gint do_popup(GschemToplevel *w_current, GdkEventButton *event);
-void x_menus_sensitivity (GschemToplevel* w_current, const gchar* action_name, gboolean sensitive);
+void x_menus_sensitivity (GtkWidget* menu, const gchar* action_name, gboolean sensitive);
 void x_menus_popup_sensitivity(GschemToplevel *w_current, const char *buf, int flag);
 /* x_multiattrib.c */
 void x_multiattrib_open (GschemToplevel *w_current);

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -648,7 +648,6 @@ GtkWidget *get_main_popup(GschemToplevel *w_current);
 gint do_popup(GschemToplevel *w_current, GdkEventButton *event);
 void x_menus_sensitivity(GschemToplevel *w_current, const char *buf, int flag);
 void x_menus_popup_sensitivity(GschemToplevel *w_current, const char *buf, int flag);
-void x_menu_attach_recent_files_submenu(GschemToplevel *w_current);
 /* x_multiattrib.c */
 void x_multiattrib_open (GschemToplevel *w_current);
 void x_multiattrib_close (GschemToplevel *w_current);

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -647,7 +647,6 @@ GtkWidget *get_main_menu(GschemToplevel *w_current);
 GtkWidget *get_main_popup(GschemToplevel *w_current);
 gint do_popup(GschemToplevel *w_current, GdkEventButton *event);
 void x_menus_sensitivity (GtkWidget* menu, const gchar* action_name, gboolean sensitive);
-void x_menus_popup_sensitivity(GschemToplevel *w_current, const char *buf, int flag);
 /* x_multiattrib.c */
 void x_multiattrib_open (GschemToplevel *w_current);
 void x_multiattrib_close (GschemToplevel *w_current);

--- a/schematic/src/i_basic.c
+++ b/schematic/src/i_basic.c
@@ -410,11 +410,14 @@ void i_update_menus(GschemToplevel *w_current)
 
   x_menus_sensitivity (mmenu, "&hierarchy-documentation", comp_selected);
 
-  x_menus_popup_sensitivity (w_current, "Edit...", selected);
-  x_menus_popup_sensitivity (w_current, "Object Properties...", selected);
-  x_menus_popup_sensitivity (w_current, "Delete", selected);
-  x_menus_popup_sensitivity (w_current, "Down Schematic", comp_selected);
-  x_menus_popup_sensitivity (w_current, "Down Symbol", comp_selected);
+
+  GtkWidget* pmenu = w_current->popup_menu;
+
+  x_menus_sensitivity (pmenu, "edit-edit", selected);
+  x_menus_sensitivity (pmenu, "edit-object-properties", selected);
+  x_menus_sensitivity (pmenu, "edit-delete", selected);
+  x_menus_sensitivity (pmenu, "hierarchy-down-schematic", comp_selected);
+  x_menus_sensitivity (pmenu, "hierarchy-down-symbol", comp_selected);
 
 } /* i_update_menus() */
 

--- a/schematic/src/i_basic.c
+++ b/schematic/src/i_basic.c
@@ -311,6 +311,7 @@ void i_update_toolbar(GschemToplevel *w_current)
 }
 
 
+
 /*! \brief Update sensitivity of the Edit/Paste menu item
  *
  *  \par Function Description
@@ -320,7 +321,7 @@ void i_update_toolbar(GschemToplevel *w_current)
 static void clipboard_usable_cb (int usable, void *userdata)
 {
   GschemToplevel *w_current = GSCHEM_TOPLEVEL (userdata);
-  x_menus_sensitivity (w_current, "_Edit/_Paste", usable);
+  x_menus_sensitivity (w_current, "&clipboard-paste", usable);
 }
 
 
@@ -377,36 +378,35 @@ void i_update_menus(GschemToplevel *w_current)
   gboolean pic_selected  = selected && obj_selected (toplevel, OBJ_PICTURE);
   gboolean embeddable    = comp_selected || pic_selected;
 
-  /* These strings should NOT be internationalized */
-  x_menus_sensitivity (w_current, "_Edit/Cu_t", selected);
-  x_menus_sensitivity (w_current, "_Edit/_Copy", selected);
-  x_menus_sensitivity (w_current, "_Edit/_Delete", selected);
-  x_menus_sensitivity (w_current, "_Edit/Copy Mode", selected);
-  x_menus_sensitivity (w_current, "_Edit/Multiple Copy Mode", selected);
-  x_menus_sensitivity (w_current, "_Edit/Move Mode", selected);
-  x_menus_sensitivity (w_current, "_Edit/Rotate 90 Mode", selected);
-  x_menus_sensitivity (w_current, "_Edit/Mirror Mode", selected);
-  x_menus_sensitivity (w_current, "_Edit/Edit...", selected);
-  x_menus_sensitivity (w_current, "_Edit/Edit Text...", text_selected);
-  x_menus_sensitivity (w_current, "_Edit/Object Properties...", selected);
-  x_menus_sensitivity (w_current, "_Edit/Slot...", comp_selected);
-  x_menus_sensitivity (w_current, "_Edit/Lock", selected);
-  x_menus_sensitivity (w_current, "_Edit/Unlock", selected);
-  x_menus_sensitivity (w_current, "_Edit/Embed Component/Picture", embeddable);
-  x_menus_sensitivity (w_current, "_Edit/Unembed Component/Picture", embeddable);
-  x_menus_sensitivity (w_current, "_Edit/Update Component", comp_selected);
+  x_menus_sensitivity (w_current, "&clipboard-cut", selected);
+  x_menus_sensitivity (w_current, "&clipboard-copy", selected);
+  x_menus_sensitivity (w_current, "&edit-delete", selected);
+  x_menus_sensitivity (w_current, "&edit-copy", selected);
+  x_menus_sensitivity (w_current, "&edit-mcopy", selected);
+  x_menus_sensitivity (w_current, "&edit-move", selected);
+  x_menus_sensitivity (w_current, "&edit-rotate-90", selected);
+  x_menus_sensitivity (w_current, "&edit-mirror", selected);
+  x_menus_sensitivity (w_current, "&edit-edit", selected);
+  x_menus_sensitivity (w_current, "&edit-text", text_selected);
+  x_menus_sensitivity (w_current, "&edit-object-properties", selected);
+  x_menus_sensitivity (w_current, "&edit-slot", comp_selected);
+  x_menus_sensitivity (w_current, "&edit-lock", selected);
+  x_menus_sensitivity (w_current, "&edit-unlock", selected);
+  x_menus_sensitivity (w_current, "&edit-embed", embeddable);
+  x_menus_sensitivity (w_current, "&edit-unembed", embeddable);
+  x_menus_sensitivity (w_current, "&edit-update", comp_selected);
 
-  x_menus_sensitivity (w_current, "Hie_rarchy/_Down Schematic", comp_selected);
-  x_menus_sensitivity (w_current, "Hie_rarchy/Down _Symbol", comp_selected);
+  x_menus_sensitivity (w_current, "&hierarchy-down-schematic", comp_selected);
+  x_menus_sensitivity (w_current, "&hierarchy-down-symbol", comp_selected);
 
-  x_menus_sensitivity (w_current, "A_ttributes/_Attach", selected);
-  x_menus_sensitivity (w_current, "A_ttributes/_Detach", selected);
-  x_menus_sensitivity (w_current, "A_ttributes/Show _Value", text_selected);
-  x_menus_sensitivity (w_current, "A_ttributes/Show _Name", text_selected);
-  x_menus_sensitivity (w_current, "A_ttributes/Show _Both", text_selected);
-  x_menus_sensitivity (w_current, "A_ttributes/_Toggle Visibility", text_selected);
+  x_menus_sensitivity (w_current, "&attributes-attach", selected);
+  x_menus_sensitivity (w_current, "&attributes-detach", selected);
+  x_menus_sensitivity (w_current, "&attributes-show-value", text_selected);
+  x_menus_sensitivity (w_current, "&attributes-show-name", text_selected);
+  x_menus_sensitivity (w_current, "&attributes-show-both", text_selected);
+  x_menus_sensitivity (w_current, "&attributes-visibility-toggle", text_selected);
 
-  x_menus_sensitivity (w_current, "_Help/Find Component D_ocumentation", comp_selected);
+  x_menus_sensitivity (w_current, "&hierarchy-documentation", comp_selected);
 
   x_menus_popup_sensitivity (w_current, "Edit...", selected);
   x_menus_popup_sensitivity (w_current, "Object Properties...", selected);

--- a/schematic/src/i_basic.c
+++ b/schematic/src/i_basic.c
@@ -326,7 +326,7 @@ static void clipboard_usable_cb (int usable, void *userdata)
 
 
 
-/*! \brief Return TRUE if at least one object of type \a type is selected
+/*! \brief Return TRUE if at least one object of type \a type is selected.
  *
  *  \param toplevel  pointer to TOPLEVEL structure
  *  \param type      object type constant (OBJ_TEXT, OBJ_COMPLEX, etc.) (o_types.h)
@@ -356,11 +356,11 @@ obj_selected (TOPLEVEL* toplevel, int type)
 
 
 
-/*! \brief Update sensitivity of relevant menu items
+/*! \brief Update menu items sensitivity for the main and popup menus.
  *
  *  \param [in] w_current GschemToplevel structure
  */
-void i_update_menus(GschemToplevel *w_current)
+void i_update_menus (GschemToplevel* w_current)
 {
   g_return_if_fail (w_current != NULL);
 

--- a/schematic/src/i_basic.c
+++ b/schematic/src/i_basic.c
@@ -413,11 +413,11 @@ void i_update_menus(GschemToplevel *w_current)
 
   GtkWidget* pmenu = w_current->popup_menu;
 
-  x_menus_sensitivity (pmenu, "edit-edit", selected);
-  x_menus_sensitivity (pmenu, "edit-object-properties", selected);
-  x_menus_sensitivity (pmenu, "edit-delete", selected);
-  x_menus_sensitivity (pmenu, "hierarchy-down-schematic", comp_selected);
-  x_menus_sensitivity (pmenu, "hierarchy-down-symbol", comp_selected);
+  x_menus_sensitivity (pmenu, "&edit-edit", selected);
+  x_menus_sensitivity (pmenu, "&edit-object-properties", selected);
+  x_menus_sensitivity (pmenu, "&edit-delete", selected);
+  x_menus_sensitivity (pmenu, "&hierarchy-down-schematic", comp_selected);
+  x_menus_sensitivity (pmenu, "&hierarchy-down-symbol", comp_selected);
 
 } /* i_update_menus() */
 

--- a/schematic/src/i_basic.c
+++ b/schematic/src/i_basic.c
@@ -366,7 +366,9 @@ void i_update_menus(GschemToplevel *w_current)
 
   TOPLEVEL* toplevel = gschem_toplevel_get_toplevel (w_current);
   g_return_if_fail (toplevel != NULL);
-  g_return_if_fail (toplevel->page_current != NULL);
+
+  PAGE* page = toplevel->page_current;
+  g_return_if_fail (page != NULL);
 
   /* update Edit->Paste sensitivity in clipboard_usable_cb():
   */
@@ -377,6 +379,7 @@ void i_update_menus(GschemToplevel *w_current)
   gboolean comp_selected = selected && obj_selected (toplevel, OBJ_COMPLEX);
   gboolean pic_selected  = selected && obj_selected (toplevel, OBJ_PICTURE);
   gboolean embeddable    = comp_selected || pic_selected;
+  gboolean has_parent = s_hierarchy_find_up_page (toplevel->pages, page) != NULL;
 
   GtkWidget* mmenu = w_current->menubar;
 
@@ -400,6 +403,7 @@ void i_update_menus(GschemToplevel *w_current)
 
   x_menus_sensitivity (mmenu, "&hierarchy-down-schematic", comp_selected);
   x_menus_sensitivity (mmenu, "&hierarchy-down-symbol", comp_selected);
+  x_menus_sensitivity (mmenu, "&hierarchy-up", has_parent);
 
   x_menus_sensitivity (mmenu, "&attributes-attach", selected);
   x_menus_sensitivity (mmenu, "&attributes-detach", selected);
@@ -418,6 +422,7 @@ void i_update_menus(GschemToplevel *w_current)
   x_menus_sensitivity (pmenu, "&edit-delete", selected);
   x_menus_sensitivity (pmenu, "&hierarchy-down-schematic", comp_selected);
   x_menus_sensitivity (pmenu, "&hierarchy-down-symbol", comp_selected);
+  x_menus_sensitivity (pmenu, "&hierarchy-up", has_parent);
 
 } /* i_update_menus() */
 

--- a/schematic/src/i_basic.c
+++ b/schematic/src/i_basic.c
@@ -321,7 +321,7 @@ void i_update_toolbar(GschemToplevel *w_current)
 static void clipboard_usable_cb (int usable, void *userdata)
 {
   GschemToplevel *w_current = GSCHEM_TOPLEVEL (userdata);
-  x_menus_sensitivity (w_current, "&clipboard-paste", usable);
+  x_menus_sensitivity (w_current->menubar, "&clipboard-paste", usable);
 }
 
 
@@ -378,35 +378,37 @@ void i_update_menus(GschemToplevel *w_current)
   gboolean pic_selected  = selected && obj_selected (toplevel, OBJ_PICTURE);
   gboolean embeddable    = comp_selected || pic_selected;
 
-  x_menus_sensitivity (w_current, "&clipboard-cut", selected);
-  x_menus_sensitivity (w_current, "&clipboard-copy", selected);
-  x_menus_sensitivity (w_current, "&edit-delete", selected);
-  x_menus_sensitivity (w_current, "&edit-copy", selected);
-  x_menus_sensitivity (w_current, "&edit-mcopy", selected);
-  x_menus_sensitivity (w_current, "&edit-move", selected);
-  x_menus_sensitivity (w_current, "&edit-rotate-90", selected);
-  x_menus_sensitivity (w_current, "&edit-mirror", selected);
-  x_menus_sensitivity (w_current, "&edit-edit", selected);
-  x_menus_sensitivity (w_current, "&edit-text", text_selected);
-  x_menus_sensitivity (w_current, "&edit-object-properties", selected);
-  x_menus_sensitivity (w_current, "&edit-slot", comp_selected);
-  x_menus_sensitivity (w_current, "&edit-lock", selected);
-  x_menus_sensitivity (w_current, "&edit-unlock", selected);
-  x_menus_sensitivity (w_current, "&edit-embed", embeddable);
-  x_menus_sensitivity (w_current, "&edit-unembed", embeddable);
-  x_menus_sensitivity (w_current, "&edit-update", comp_selected);
+  GtkWidget* mmenu = w_current->menubar;
 
-  x_menus_sensitivity (w_current, "&hierarchy-down-schematic", comp_selected);
-  x_menus_sensitivity (w_current, "&hierarchy-down-symbol", comp_selected);
+  x_menus_sensitivity (mmenu, "&clipboard-cut", selected);
+  x_menus_sensitivity (mmenu, "&clipboard-copy", selected);
+  x_menus_sensitivity (mmenu, "&edit-delete", selected);
+  x_menus_sensitivity (mmenu, "&edit-copy", selected);
+  x_menus_sensitivity (mmenu, "&edit-mcopy", selected);
+  x_menus_sensitivity (mmenu, "&edit-move", selected);
+  x_menus_sensitivity (mmenu, "&edit-rotate-90", selected);
+  x_menus_sensitivity (mmenu, "&edit-mirror", selected);
+  x_menus_sensitivity (mmenu, "&edit-edit", selected);
+  x_menus_sensitivity (mmenu, "&edit-text", text_selected);
+  x_menus_sensitivity (mmenu, "&edit-object-properties", selected);
+  x_menus_sensitivity (mmenu, "&edit-slot", comp_selected);
+  x_menus_sensitivity (mmenu, "&edit-lock", selected);
+  x_menus_sensitivity (mmenu, "&edit-unlock", selected);
+  x_menus_sensitivity (mmenu, "&edit-embed", embeddable);
+  x_menus_sensitivity (mmenu, "&edit-unembed", embeddable);
+  x_menus_sensitivity (mmenu, "&edit-update", comp_selected);
 
-  x_menus_sensitivity (w_current, "&attributes-attach", selected);
-  x_menus_sensitivity (w_current, "&attributes-detach", selected);
-  x_menus_sensitivity (w_current, "&attributes-show-value", text_selected);
-  x_menus_sensitivity (w_current, "&attributes-show-name", text_selected);
-  x_menus_sensitivity (w_current, "&attributes-show-both", text_selected);
-  x_menus_sensitivity (w_current, "&attributes-visibility-toggle", text_selected);
+  x_menus_sensitivity (mmenu, "&hierarchy-down-schematic", comp_selected);
+  x_menus_sensitivity (mmenu, "&hierarchy-down-symbol", comp_selected);
 
-  x_menus_sensitivity (w_current, "&hierarchy-documentation", comp_selected);
+  x_menus_sensitivity (mmenu, "&attributes-attach", selected);
+  x_menus_sensitivity (mmenu, "&attributes-detach", selected);
+  x_menus_sensitivity (mmenu, "&attributes-show-value", text_selected);
+  x_menus_sensitivity (mmenu, "&attributes-show-name", text_selected);
+  x_menus_sensitivity (mmenu, "&attributes-show-both", text_selected);
+  x_menus_sensitivity (mmenu, "&attributes-visibility-toggle", text_selected);
+
+  x_menus_sensitivity (mmenu, "&hierarchy-documentation", comp_selected);
 
   x_menus_popup_sensitivity (w_current, "Edit...", selected);
   x_menus_popup_sensitivity (w_current, "Object Properties...", selected);

--- a/schematic/src/x_menus.c
+++ b/schematic/src/x_menus.c
@@ -83,6 +83,8 @@ static void g_menu_execute(GtkAction *action, gpointer user_data)
   g_action_eval_by_name (w_current, action_name);
 }
 
+
+
 /*! \todo Finish function documentation!!!
  *  \brief
  *  \par Function Description
@@ -91,7 +93,6 @@ static void g_menu_execute(GtkAction *action, gpointer user_data)
 GtkWidget *
 get_main_menu(GschemToplevel *w_current)
 {
-  char *buf;
   GschemAction *action;
   GtkWidget *menu_item;
   GtkWidget *root_menu;
@@ -226,6 +227,9 @@ get_main_menu(GschemToplevel *w_current)
           }
 
 
+          g_object_set_data (G_OBJECT (menu_bar), action_name, action);
+
+
           free(action_name);
           free(menu_item_stock);
 
@@ -233,16 +237,14 @@ get_main_menu(GschemToplevel *w_current)
           g_signal_connect (G_OBJECT(action), "activate",
                             G_CALLBACK(g_menu_execute),
                             w_current);
-        }
+
+        } // scm_item_func == TRUE
 
         gtk_menu_shell_append (GTK_MENU_SHELL (menu), menu_item);
-      }
+
+      } // !separator
 
       gtk_widget_show (menu_item);
-
-      /* add a handle to the menu_bar object to get access to widget objects */
-      /* This string should NOT be internationalized */
-      buf = g_strdup_printf("%s/%s", *raw_menu_name, raw_menu_item_name);
 
 
       if (strcmp (raw_menu_item_name, "Open Recen_t") == 0)
@@ -251,11 +253,9 @@ get_main_menu(GschemToplevel *w_current)
       }
 
 
-      g_object_set_data (G_OBJECT (menu_bar), buf, menu_item);
-      g_free(buf);
-
       scm_dynwind_end();
-    }
+
+    } // for j: menu items
     
     menu_name = (char *) gettext(*raw_menu_name);
     root_menu = gtk_menu_item_new_with_mnemonic (menu_name);
@@ -266,12 +266,17 @@ get_main_menu(GschemToplevel *w_current)
     gtk_widget_show (root_menu);
     gtk_menu_item_set_submenu (GTK_MENU_ITEM (root_menu), menu);
     gtk_menu_shell_append (GTK_MENU_SHELL (menu_bar), root_menu);
-  }
+
+  } // fot i: menus (file, edit, ...)
+
   scm_dynwind_end ();
 
   g_free(raw_menu_name);
   return menu_bar;
-}
+
+} /* get_main_menu() */
+
+
 
 GtkWidget *
 get_main_popup (GschemToplevel *w_current)

--- a/schematic/src/x_menus.c
+++ b/schematic/src/x_menus.c
@@ -37,28 +37,29 @@ struct PopupEntry
   const gchar* stock_id;
 };
 
-static struct PopupEntry popup_items[] = {
-  { N_("Add Net"), "add-net", "insert-net" },
-  { N_("Add Attribute"), "add-attribute", "insert-attribute" },
-  { N_("Add Component"), "add-component", "insert-symbol" },
-  { N_("Add Bus"), "add-bus", "insert-bus" },
-  { N_("Add Text"), "add-text", "insert-text" },
+static struct PopupEntry popup_items[] =
+{
+  { N_("Add Net"),       "&add-net",       "insert-net" },
+  { N_("Add Attribute"), "&add-attribute", "insert-attribute" },
+  { N_("Add Component"), "&add-component", "insert-symbol" },
+  { N_("Add Bus"),       "&add-bus",       "insert-bus" },
+  { N_("Add Text"),      "&add-text",      "insert-text" },
   { "SEPARATOR", NULL, NULL },
-  { N_("Zoom In"), "view-zoom-in", "gtk-zoom-in" },
-  { N_("Zoom Out"), "view-zoom-out", "gtk-zoom-out" },
-  { N_("Zoom Box"), "view-zoom-box", NULL },
-  { N_("Zoom Extents"), "view-zoom-extents", "gtk-zoom-fit" },
+  { N_("Zoom In"),      "&view-zoom-in",      "gtk-zoom-in" },
+  { N_("Zoom Out"),     "&view-zoom-out",     "gtk-zoom-out" },
+  { N_("Zoom Box"),     "&view-zoom-box",     NULL },
+  { N_("Zoom Extents"), "&view-zoom-extents", "gtk-zoom-fit" },
   { "SEPARATOR", NULL, NULL },
-  { N_("Select"), "edit-select", "select" },
-  { N_("Edit..."), "edit-edit", NULL },
-  { N_("Object Properties..."), "edit-object-properties", NULL },
-  { N_("Copy"), "edit-copy", "clone" },
-  { N_("Move"), "edit-move", NULL },
-  { N_("Delete"), "edit-delete", "gtk-delete" },
+  { N_("Select"),               "&edit-select",            "select" },
+  { N_("Edit..."),              "&edit-edit",              NULL },
+  { N_("Object Properties..."), "&edit-object-properties", NULL },
+  { N_("Copy"),                 "&edit-copy",              "clone" },
+  { N_("Move"),                 "&edit-move",              NULL },
+  { N_("Delete"),               "&edit-delete",            "gtk-delete" },
   { "SEPARATOR", NULL, NULL },
-  { N_("Down Schematic"), "hierarchy-down-schematic", "gtk-go-down" },
-  { N_("Down Symbol"), "hierarchy-down-symbol", "gtk-goto-bottom" },
-  { N_("Up"), "hierarchy-up", "gtk-go-up" },
+  { N_("Down Schematic"), "&hierarchy-down-schematic", "gtk-go-down" },
+  { N_("Down Symbol"),    "&hierarchy-down-symbol",    "gtk-goto-bottom" },
+  { N_("Up"),             "&hierarchy-up",             "gtk-go-up" },
 
   { NULL, NULL, NULL }, /* Guard */
 };

--- a/schematic/src/x_menus.c
+++ b/schematic/src/x_menus.c
@@ -29,6 +29,7 @@
 #include <glib/gstdio.h>
 
 #define DEFAULT_MAX_RECENT_FILES 10
+#define RECENT_MENU_ITEM_NAME "Open Recen_t"
 
 struct PopupEntry
 {
@@ -248,7 +249,7 @@ get_main_menu(GschemToplevel *w_current)
       gtk_widget_show (menu_item);
 
 
-      if (strcmp (raw_menu_item_name, "Open Recen_t") == 0)
+      if (strcmp (raw_menu_item_name, RECENT_MENU_ITEM_NAME) == 0)
       {
         x_menu_attach_recent_files_submenu (w_current, menu_item);
       }

--- a/schematic/src/x_menus.c
+++ b/schematic/src/x_menus.c
@@ -321,10 +321,7 @@ get_main_popup (GschemToplevel *w_current)
     menu_item = gtk_action_create_menu_item (GTK_ACTION (action));
     gtk_menu_shell_append (GTK_MENU_SHELL (menu), menu_item);
 
-    /* Add a handle to the menu object to get access to widget
-       objects. Horrible horrible hack, but it's the same approach as
-       taken for the main menu bar. :-( */
-    g_object_set_data (G_OBJECT (menu), e.name, menu_item);
+    g_object_set_data (G_OBJECT (menu), e.action, action);
   }
 
   return menu;
@@ -369,30 +366,6 @@ x_menus_sensitivity (GtkWidget*   menu,
   else
   {
     g_debug(_("x_menus_sensitivity(): cannot find action [%s]"), action_name);
-  }
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *  This function sets the sensitivity of the items in the right button
- *  popup.
- */
-void x_menus_popup_sensitivity (GschemToplevel *w_current, const char *buf, int flag)
-{
-  GtkWidget *item;
-
-  g_assert (w_current);
-  g_assert (buf);
-  g_assert (w_current->popup_menu);
-
-  item = GTK_WIDGET (g_object_get_data (G_OBJECT (w_current->popup_menu), buf));
-
-  if (item) {
-    gtk_widget_set_sensitive (item, flag);
-  } else {
-    g_critical (_("Tried to set the sensitivity on non-existent menu item '%s'\n"),
-                buf);
   }
 }
 

--- a/schematic/src/x_menus.c
+++ b/schematic/src/x_menus.c
@@ -353,27 +353,23 @@ gint do_popup (GschemToplevel *w_current, GdkEventButton *event)
  *  \par Function Description
  *
  */
-void x_menus_sensitivity (GschemToplevel *w_current, const char *buf, int flag)
+void
+x_menus_sensitivity (GschemToplevel* w_current,
+                     const gchar*    action_name,
+                     gboolean        sensitive)
 {
-  GtkWidget* item=NULL;
-  
-  if (!buf) {
-    return;
-  }
+  GObject* obj = G_OBJECT (w_current->menubar);
+  gpointer data = g_object_get_data (obj, action_name);
 
-  if (!w_current->menubar) {
-    return;
+  GschemAction* action = (GschemAction*) data;
+  if (action != NULL)
+  {
+    gtk_action_set_sensitive (GTK_ACTION (action), sensitive);
   }
-  
-  item = (GtkWidget *) g_object_get_data (G_OBJECT (w_current->menubar), buf);
-
-  if (item) {
-    gtk_widget_set_sensitive(GTK_WIDGET(item), flag);
-    /* free(item); */ /* Why doesn't this need to be freed?  */
-  } else {
-    g_debug(_("Tried to set the sensitivity on non-existent menu item '%1$s'"), buf);
+  else
+  {
+    g_debug(_("x_menus_sensitivity(): cannot find action [%s]"), action_name);
   }
- 
 }
 
 /*! \todo Finish function documentation!!!

--- a/schematic/src/x_menus.c
+++ b/schematic/src/x_menus.c
@@ -73,10 +73,7 @@ x_menu_attach_recent_files_submenu (GschemToplevel* w_current,
 
 
 
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
+/*! \brief Callback function for menu items. Execute action \a action.
  */
 static void g_menu_execute(GtkAction *action, gpointer user_data)
 {
@@ -87,13 +84,18 @@ static void g_menu_execute(GtkAction *action, gpointer user_data)
 
 
 
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
+/*! \brief Create and return the main menu widget.
  *
+*  \par Function Description
+ *  The key/value data (see g_object_set_data()/g_object_get_data())
+ *  associated with the menu widget created by this function:
+ *  - key:   action name, string, e.g. "&edit-object-properties"
+ *  - value: pointer to a corresponding GschemAction object
+ *
+ *  \todo Refactor
  */
-GtkWidget *
-get_main_menu(GschemToplevel *w_current)
+GtkWidget*
+get_main_menu (GschemToplevel* w_current)
 {
   GschemAction *action;
   GtkWidget *menu_item;
@@ -240,11 +242,11 @@ get_main_menu(GschemToplevel *w_current)
                             G_CALLBACK(g_menu_execute),
                             w_current);
 
-        } // scm_item_func == TRUE
+        } /* scm_item_func == TRUE */
 
         gtk_menu_shell_append (GTK_MENU_SHELL (menu), menu_item);
 
-      } // !separator
+      } /* !separator */
 
       gtk_widget_show (menu_item);
 
@@ -257,19 +259,17 @@ get_main_menu(GschemToplevel *w_current)
 
       scm_dynwind_end();
 
-    } // for j: menu items
+    } /* for j: menu items */
     
     menu_name = (char *) gettext(*raw_menu_name);
     root_menu = gtk_menu_item_new_with_mnemonic (menu_name);
     /* do not free *raw_menu_name */
 
-    /* no longer right justify the help menu since that has gone out of style */
-
     gtk_widget_show (root_menu);
     gtk_menu_item_set_submenu (GTK_MENU_ITEM (root_menu), menu);
     gtk_menu_shell_append (GTK_MENU_SHELL (menu_bar), root_menu);
 
-  } // fot i: menus (file, edit, ...)
+  } /* fot i: menus (File, Edit, ...) */
 
   scm_dynwind_end ();
 
@@ -280,8 +280,16 @@ get_main_menu(GschemToplevel *w_current)
 
 
 
-GtkWidget *
-get_main_popup (GschemToplevel *w_current)
+/*! \brief Create and return the popup menu widget.
+ *
+ *  \par Function Description
+ *  The key/value data (see g_object_set_data()/g_object_get_data())
+ *  associated with the menu widget created by this function:
+ *  - key:   action name, string, e.g. "&edit-object-properties"
+ *  - value: pointer to a corresponding GschemAction object
+ */
+GtkWidget*
+get_main_popup (GschemToplevel* w_current)
 {
   GschemAction *action;
   GtkWidget *menu_item;
@@ -329,9 +337,7 @@ get_main_popup (GschemToplevel *w_current)
   return menu;
 }
 
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
+/*! \brief Show the popup menu.
  *
  *  \note
  *  need to look at this... here and the setup
@@ -347,10 +353,15 @@ gint do_popup (GschemToplevel *w_current, GdkEventButton *event)
   return FALSE;
 }
 
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
+/*! \brief Enable/disable menu item linked to the action \a action_name.
  *
+ *  \par Function Description
+ *  Use the key/value data associated with the \a menu to find
+ *  an action object, and if found, set its sensitivity (\a sensitive).
+ *
+ *  \param menu         Menu widget (menubar, popup_menu in st_gschem_toplevel)
+ *  \param action_name  Action name (e.g. "&edit-object-properties")
+ *  \param sensitive    Boolean, enable or disable the action
  */
 void
 x_menus_sensitivity (GtkWidget*   menu,
@@ -373,7 +384,8 @@ x_menus_sensitivity (GtkWidget*   menu,
 
 /*! \brief Callback for recent-chooser.
  *
- * Will be called if element of recent-file-list is activated
+ *  \par Function Description
+ *  Will be called if element of recent-file-list is activated
  */
 void
 recent_chooser_item_activated (GtkRecentChooser *chooser, GschemToplevel *w_current)

--- a/schematic/src/x_menus.c
+++ b/schematic/src/x_menus.c
@@ -64,6 +64,13 @@ static struct PopupEntry popup_items[] = {
 };
 
 
+
+static void
+x_menu_attach_recent_files_submenu (GschemToplevel* w_current,
+                                    GtkWidget*      menuitem);
+
+
+
 /*! \todo Finish function documentation!!!
  *  \brief
  *  \par Function Description
@@ -236,6 +243,14 @@ get_main_menu(GschemToplevel *w_current)
       /* add a handle to the menu_bar object to get access to widget objects */
       /* This string should NOT be internationalized */
       buf = g_strdup_printf("%s/%s", *raw_menu_name, raw_menu_item_name);
+
+
+      if (strcmp (raw_menu_item_name, "Open Recen_t") == 0)
+      {
+        x_menu_attach_recent_files_submenu (w_current, menu_item);
+      }
+
+
       g_object_set_data (G_OBJECT (menu_bar), buf, menu_item);
       g_free(buf);
 
@@ -403,14 +418,14 @@ recent_chooser_item_activated (GtkRecentChooser *chooser, GschemToplevel *w_curr
   g_free(filename);
 }
 
-/*! \brief Attach a submenu with filenames to the 'Open Recent'
- *         menu item.
- *
- *  Called from x_window_setup().
+
+
+/*! \brief Attach 'Open Recent' submenu to \a menuitem.
  */
-void x_menu_attach_recent_files_submenu(GschemToplevel *w_current)
+static void
+x_menu_attach_recent_files_submenu (GschemToplevel* w_current,
+                                    GtkWidget*      menuitem)
 {
-  GtkWidget* menuitem_to_append_to = NULL;
   GtkRecentFilter *recent_filter;
   GtkWidget *menuitem_file_recent_items;
 
@@ -458,9 +473,8 @@ void x_menu_attach_recent_files_submenu(GschemToplevel *w_current)
   g_signal_connect(GTK_OBJECT(menuitem_file_recent_items), "item-activated",
                    G_CALLBACK(recent_chooser_item_activated), w_current);
 
-  menuitem_to_append_to = (GtkWidget *) g_object_get_data (G_OBJECT (w_current->menubar),
-                                                           "_File/Open Recen_t");
-  if(menuitem_to_append_to == NULL)
+  if (menuitem == NULL)
     return;
-  gtk_menu_item_set_submenu(GTK_MENU_ITEM(menuitem_to_append_to), menuitem_file_recent_items);
+
+  gtk_menu_item_set_submenu(GTK_MENU_ITEM(menuitem), menuitem_file_recent_items);
 }

--- a/schematic/src/x_menus.c
+++ b/schematic/src/x_menus.c
@@ -354,11 +354,11 @@ gint do_popup (GschemToplevel *w_current, GdkEventButton *event)
  *
  */
 void
-x_menus_sensitivity (GschemToplevel* w_current,
-                     const gchar*    action_name,
-                     gboolean        sensitive)
+x_menus_sensitivity (GtkWidget*   menu,
+                     const gchar* action_name,
+                     gboolean     sensitive)
 {
-  GObject* obj = G_OBJECT (w_current->menubar);
+  GObject* obj = G_OBJECT (menu);
   gpointer data = g_object_get_data (obj, action_name);
 
   GschemAction* action = (GschemAction*) data;

--- a/schematic/src/x_window.c
+++ b/schematic/src/x_window.c
@@ -133,8 +133,6 @@ void x_window_setup (GschemToplevel *w_current)
 
   /* X related stuff */
   x_window_create_main (w_current);
-
-  x_menu_attach_recent_files_submenu(w_current);
 }
 
 /*! \todo Finish function documentation!!!


### PR DESCRIPTION
- refactor, simplify menu items sensitivity setting code, add comments
- do not refer to menu items by their display name (e.g. `_Edit/_Copy`),
  it's error-prone and inconvenient
- change the key/value data mapping associated with the menu widgets:
  key is the action name (e.g. `&edit-copy`), value is the `GschemAction` object
- when setting sensitivity, take into account the type of selected objects
- enable/disable `Hierarchy->Up` menu item in the main and popup menus