### PR TITLE
Start gschemrc settings migration

### DIFF
--- a/liblepton/scheme/geda-deprecated-config.scm
+++ b/liblepton/scheme/geda-deprecated-config.scm
@@ -222,3 +222,7 @@ option's value:
 (define-rc-deprecated-config
   hierarchy-netattrib-separator "gnetlist.hierarchy" "net-attribute-separator"
   rc-deprecated-string-transformer)
+
+(define-rc-deprecated-config
+ draw-grips "schematic.gui" "draw-grips"
+ rc-deprecated-string-boolean-transformer)

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -180,7 +180,6 @@ SCM g_rc_undo_levels(SCM levels);
 SCM g_rc_undo_control(SCM mode);
 SCM g_rc_undo_type(SCM mode);
 SCM g_rc_undo_panzoom(SCM mode);
-SCM g_rc_draw_grips(SCM mode);
 SCM g_rc_netconn_rubberband(SCM mode);
 SCM g_rc_magnetic_net_mode(SCM mode);
 SCM g_rc_add_menu(SCM menu_name, SCM menu_items);

--- a/schematic/scheme/conf/schematic/options.scm
+++ b/schematic/scheme/conf/schematic/options.scm
@@ -63,13 +63,6 @@
 ; Autosaving will not be allowed if setting it to zero.
 (auto-save-interval 120)
 
-; draw-grips string
-;
-; Controls if the editing grips are drawn when selecting objects
-;
-(draw-grips "enabled")
-;(draw-grips "disabled")
-
 ;  net-direction-mode string
 ;
 ;  Controls if the net direction mode is used. This mode tries to guess

--- a/schematic/src/g_rc.c
+++ b/schematic/src/g_rc.c
@@ -619,23 +619,6 @@ SCM g_rc_undo_panzoom(SCM mode)
  *  \par Function Description
  *
  */
-SCM g_rc_draw_grips(SCM mode)
-{
-  static const vstbl_entry mode_table[] = {
-    {TRUE , "enabled" },
-    {FALSE, "disabled"},
-  };
-
-  RETURN_G_RC_MODE("draw-grips",
-		   default_draw_grips,
-		   2);
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
 SCM g_rc_netconn_rubberband(SCM mode)
 {
   static const vstbl_entry mode_table[] = {

--- a/schematic/src/g_register.c
+++ b/schematic/src/g_register.c
@@ -67,7 +67,6 @@ static struct gsubr_t gschem_funcs[] = {
   { "undo-type",                    1, 0, 0, (SCM (*) ()) g_rc_undo_type },
   { "undo-panzoom",                 1, 0, 0, (SCM (*) ()) g_rc_undo_panzoom },
 
-  { "draw-grips",                   1, 0, 0, (SCM (*) ()) g_rc_draw_grips },
   { "netconn-rubberband",           1, 0, 0, (SCM (*) ()) g_rc_netconn_rubberband },
   { "magnetic-net-mode",            1, 0, 0, (SCM (*) ()) g_rc_magnetic_net_mode },
   { "add-menu",                     2, 0, 0, (SCM (*) ()) g_rc_add_menu },

--- a/schematic/src/i_vars.c
+++ b/schematic/src/i_vars.c
@@ -79,6 +79,31 @@ int default_select_slack_pixels = 10;
 int default_zoom_gain = 20;
 int default_scrollpan_steps = 8;
 
+
+
+/* \brief Read [schematic.gui]::draw-grips, set w_current->draw_grips.
+ */
+static void
+cfg_read_draw_grips (GschemToplevel* w_current)
+{
+  gchar* cwd = g_get_current_dir();
+  EdaConfig* cfg = eda_config_get_context_for_path (cwd);
+  g_free (cwd);
+
+  GError* err = NULL;
+  gboolean draw_grips =
+    eda_config_get_boolean (cfg, "schematic.gui", "draw-grips", &err);
+
+  if (err == NULL)
+    w_current->draw_grips = draw_grips;
+  else
+    w_current->draw_grips = default_draw_grips;
+
+  g_clear_error (&err);
+}
+
+
+
 /*! \todo Finish function documentation!!!
  *  \brief
  *  \par Function Description
@@ -123,7 +148,10 @@ void i_vars_set(GschemToplevel *w_current)
   w_current->undo_type = default_undo_type;
   w_current->undo_panzoom = default_undo_panzoom;
 
-  w_current->draw_grips = default_draw_grips;
+
+  cfg_read_draw_grips (w_current);
+
+
   gschem_options_set_net_rubber_band_mode (w_current->options, default_netconn_rubberband);
   gschem_options_set_magnetic_net_mode (w_current->options, default_magnetic_net_mode);
   w_current->warp_cursor = default_warp_cursor;


### PR DESCRIPTION
Let's start working on the issue #423.
Convert a simple `lepton-schematic` boolean option: `draw-grips`:

- deprecate `draw-grips` `gschemrc` option
- use `[schematic.gui]::draw-grips` configuration key