### PR TITLE
Add component-filename() Guile function to liblepton

### DIFF
--- a/liblepton/scheme/geda/object.scm
+++ b/liblepton/scheme/geda/object.scm
@@ -393,6 +393,9 @@
 (define-public (component-basename c)
   (list-ref (component-info c) 0))
 
+(define-public (component-filename c)
+  (%complex-filename c))
+
 (define-public (component-position c)
   (list-ref (component-info c) 1))
 

--- a/liblepton/scheme/unit-tests/t0105-object-complex.scm
+++ b/liblepton/scheme/unit-tests/t0105-object-complex.scm
@@ -218,3 +218,67 @@
 
 ;; Clear component library again
 (reset-component-library)
+
+
+
+( begin-test 'component-filename
+( let*
+  (
+  ( srcdir ( getcwd ) ) ; cwd is liblepton/scheme/
+  ( symdir "unit-tests" )
+  ( dir    ( format #f "~a/~a" srcdir symdir ) )
+  ( bname1 "dummy.sym" )
+  ( fname1 ( format #f "~a/~a" dir bname1 ) )
+  ( comp1  #f )
+  ( comp2  #f )
+  )
+
+  ( define ( mk-comp1 )
+    ( with-output-to-file fname1
+      ( lambda()
+        ( format #t "v 20191003 2~%" )
+        ( format #t "B 0 0 500 500 3 10 1 0 -1 -1 0 -1 -1 -1 -1 -1~%" )
+        ( format #t "T 0 600 21 6 1 0 0 0 1~%" )
+        ( format #t "refdes=R?" )
+      )
+    )
+
+    ( component-library symdir "t0105" )
+
+    ; return:
+    ( make-component/library
+      bname1                 ; basename
+      ( cons 0 0 )           ; position
+      0                      ; angle
+      #f                     ; mirror
+      #f                     ; locked
+    )
+  )
+
+  ( define ( mk-comp2 )
+    ; return:
+    ( make-component
+      "does-not-exist"       ; basename
+      ( cons 0 0 )           ; position
+      0                      ; angle
+      #f                     ; mirror
+      #f                     ; locked
+    )
+  )
+
+
+  ( format #t "srcdir: [~a]~%" srcdir )   ; [debug]
+  ( format #t "dir:    [~a]~%" dir )      ; [debug]
+  ( format #t "cwd:    [~a]~%" (getcwd) ) ; [debug]
+  ( format #t "fname1: [~a]~%" fname1 )   ; [debug]
+
+  ( set! comp1 ( mk-comp1 ) )
+  ( set! comp2 ( mk-comp2 ) )
+
+  ( assert-equal (component-filename comp1) fname1 )
+  ( assert-false (component-filename comp2) )
+
+  ( reset-component-library )
+
+) ; let
+) ; 'component-filename()

--- a/liblepton/scheme/unit-tests/t0105-object-complex.scm
+++ b/liblepton/scheme/unit-tests/t0105-object-complex.scm
@@ -224,13 +224,15 @@
 ( begin-test 'component-filename
 ( let*
   (
-  ( fname1 ( format #f "~a/unit-tests/dummy.sym" (getcwd) ) )
-  ( comp1  #f )
-  ( comp2  #f )
+  ( fname1  ( format #f "~a.sym" (tmpnam) ) )
+  ( symname ( basename fname1 ) )
+  ( symdir  ( dirname  fname1 ) )
+  ( comp1   #f )
+  ( comp2   #f )
   )
 
   ( define ( mk-comp1 )
-    ( with-output-to-file "unit-tests/dummy.sym"
+    ( with-output-to-file fname1
       ( lambda()
         ( format #t "v 20191003 2~%" )
         ( format #t "B 0 0 500 500 3 10 1 0 -1 -1 0 -1 -1 -1 -1 -1~%" )
@@ -239,11 +241,11 @@
       )
     )
 
-    ( component-library "unit-tests" ) ; cwd is liblepton/scheme/
+    ( component-library symdir )
 
     ; return:
     ( make-component/library
-      "dummy.sym"            ; basename
+      symname                ; basename
       ( cons 0 0 )           ; position
       0                      ; angle
       #f                     ; mirror
@@ -263,8 +265,10 @@
   )
 
 
-  ( format #t "cwd:    [~a]~%" (getcwd) ) ; [debug]
-  ( format #t "fname1: [~a]~%" fname1 )   ; [debug]
+  ( format #t "cwd:     [~a]~%" (getcwd) ) ; [debug]
+  ( format #t "symdir:  [~a]~%" symdir )   ; [debug]
+  ( format #t "symname: [~a]~%" symname )  ; [debug]
+  ( format #t "fname1:  [~a]~%" fname1 )   ; [debug]
 
   ( set! comp1 ( mk-comp1 ) )
   ( set! comp2 ( mk-comp2 ) )

--- a/liblepton/scheme/unit-tests/t0105-object-complex.scm
+++ b/liblepton/scheme/unit-tests/t0105-object-complex.scm
@@ -224,17 +224,13 @@
 ( begin-test 'component-filename
 ( let*
   (
-  ( srcdir ( getcwd ) ) ; cwd is liblepton/scheme/
-  ( symdir "unit-tests" )
-  ( dir    ( format #f "~a/~a" srcdir symdir ) )
-  ( bname1 "dummy.sym" )
-  ( fname1 ( format #f "~a/~a" dir bname1 ) )
+  ( fname1 ( format #f "~a/unit-tests/dummy.sym" (getcwd) ) )
   ( comp1  #f )
   ( comp2  #f )
   )
 
   ( define ( mk-comp1 )
-    ( with-output-to-file fname1
+    ( with-output-to-file "unit-tests/dummy.sym"
       ( lambda()
         ( format #t "v 20191003 2~%" )
         ( format #t "B 0 0 500 500 3 10 1 0 -1 -1 0 -1 -1 -1 -1 -1~%" )
@@ -243,11 +239,11 @@
       )
     )
 
-    ( component-library symdir "t0105" )
+    ( component-library "unit-tests" ) ; cwd is liblepton/scheme/
 
     ; return:
     ( make-component/library
-      bname1                 ; basename
+      "dummy.sym"            ; basename
       ( cons 0 0 )           ; position
       0                      ; angle
       #f                     ; mirror
@@ -267,8 +263,6 @@
   )
 
 
-  ( format #t "srcdir: [~a]~%" srcdir )   ; [debug]
-  ( format #t "dir:    [~a]~%" dir )      ; [debug]
   ( format #t "cwd:    [~a]~%" (getcwd) ) ; [debug]
   ( format #t "fname1: [~a]~%" fname1 )   ; [debug]
 

--- a/liblepton/src/scheme_complex.c
+++ b/liblepton/src/scheme_complex.c
@@ -380,6 +380,45 @@ SCM_DEFINE (complex_remove_x, "%complex-remove!", 2, 0, 0,
   return complex_s;
 }
 
+/*! \brief Get component's symbol full file name.
+ *
+ * \par Function Description
+ * If a component has a symbol file associated with it, get that
+ * file's full path.
+ *
+ * \note Scheme API: Implements the %complex-filename procedure in the
+ * (geda core complex) module.
+ *
+ * \param complex_s  a complex object.
+ * \return           symbols's file path or #f.
+ */
+SCM_DEFINE (complex_filename, "%complex-filename", 1, 0, 0,
+            (SCM complex_s),
+            "Get component's symbol full file name")
+{
+  SCM_ASSERT (edascm_is_object_type (complex_s, OBJ_COMPLEX), complex_s,
+              SCM_ARG1, s_complex_filename);
+
+  OBJECT* obj = edascm_to_object (complex_s);
+  const CLibSymbol* sym = s_clib_get_symbol_by_name (obj->complex_basename);
+
+  SCM result = SCM_BOOL_F;
+
+  if (sym != NULL)
+  {
+    gchar* fname = s_clib_symbol_get_filename (sym);
+    if (fname != NULL)
+    {
+      result = scm_from_utf8_string (fname);
+      g_free (fname);
+    }
+  }
+
+  return result;
+}
+
+
+
 /*!
  * \brief Create the (geda core complex) Scheme module.
  * \par Function Description
@@ -393,9 +432,15 @@ init_module_geda_core_complex (void *unused)
   #include "scheme_complex.x"
 
   /* Add them to the module's public definitions. */
-  scm_c_export (s_make_complex, s_make_complex_library, s_set_complex_x,
-                s_complex_info, s_complex_contents, s_complex_append_x,
-                s_complex_remove_x, NULL);
+  scm_c_export (s_make_complex,
+                s_make_complex_library,
+                s_set_complex_x,
+                s_complex_info,
+                s_complex_contents,
+                s_complex_append_x,
+                s_complex_remove_x,
+                s_complex_filename,
+                NULL);
 }
 
 /*!

--- a/schematic/src/i_callbacks.c
+++ b/schematic/src/i_callbacks.c
@@ -2259,11 +2259,15 @@ DEFINE_I_CALLBACK(hierarchy_down_symbol)
   if (sym == NULL)
     return;
 
-  if (s_clib_symbol_get_filename (sym) == NULL)
+  gchar* fname = s_clib_symbol_get_filename (sym);
+  if (fname == NULL)
   {
     s_log_message (_("Symbol is not a real file. Symbol cannot be loaded."));
 	  return;
   }
+
+  g_free (fname);
+
 
   TOPLEVEL* toplevel = gschem_toplevel_get_toplevel (w_current);
 


### PR DESCRIPTION
Add `component-filename` function to the
`(geda object)` module, implemented by
`%complex-filename` in the `(geda core complex)`.
If a component object `obj` has a symbol file
associated with it, `( component-filename obj )`
will return its full file name.

It's particularly useful in scenarios like caching schematic symbols.
For example, in Vladimir's [gschem-goodies](https://github.com/vzh/gschem-goodies) repo one can find [code](https://github.com/vzh/gschem-goodies/blob/master/geda/symbol/cache.scm) that saves all schematic symbols to some folder. Here's the relevant part (adapted for Scheme noobs, like me):

```scheme
; save component object's [comp] symbol file to [outdir]
;
( define ( cache-symbol comp outdir )
( let*
  (
  ( separ   file-name-separator-string )
  ( bname   ( component-basename comp ) )
  ( outfile ( format #f "~a~a~a" outdir separ bname ) )
  ( npage   ( make-page outfile ) )
  ( ncomp   ( make-component/library bname (cons 0 0) 0 #f #f ) )
  ( nobj    #f )
  ( attrs  '() )
  ( color   #f )
  )

  ( for-each ; iterate over component's parts 
  ( lambda( o )

    ( set! nobj (copy-object o) )
    ( unless ( attrib-attachment o ) ; not attached to anything
      ( page-append! npage nobj )
    )

    ; handle comp's parts with attachments (e.g. pins):
    ; plain copy-object() will strip off all attrs
    ;
    ( set! attrs (object-attribs o) )
    ( unless ( null? attrs )
      ( page-append! npage nobj )

      ( set! attrs (map copy-object attrs) )
      ( apply page-append! npage attrs )

      ; we can't simply (apply attach-attribs! nobj attrs) here
      ; attach-attribs!() calls o_attrib_attach() with
      ; set_color == TRUE => sets color to ATTRIBUTE_COLOR (5).
      ; it's done to change detached attrs' color on attach
      ; (Attributes->Attach)
      ;
      ( for-each
      ( lambda( a )
        ( set! color ( object-color a ) ) ; remember color
        ( attach-attribs! nobj a )
        ( set-object-color! a color )     ; restore color
      )
        attrs
      )
    ) ; unless !attrs

  )
  ( component-contents ncomp )
  )

  ( with-output-to-file outfile
    ( lambda()
      ( format #t ( page->string npage ) )
    )
  )

) ; let
) ; cache-symbol()
```

Not that trivial, isn't it?
Now we can simply get the symbol's file path and copy it somewhere:
```scheme
( set! outfile
  ( format #f "~a/~a" outdir (component-basename comp) )
)
( copy-file (component-filename comp) outfile )
```


