### PR TITLE
Allow lepton-netlist backends to set the netlist mode ('spice or 'geda)

### DIFF
--- a/netlist/scheme/backend/gnet-spice-sdb.scm
+++ b/netlist/scheme/backend/gnet-spice-sdb.scm
@@ -907,6 +907,16 @@ the name is changed to canonical."
 "
           subckt-name))
 
+
+; public:
+; Instruct the netlister to use 'spice mode
+;
+( define ( request-netlist-mode )
+  ; return:
+  'spice
+)
+
+
 ;;---------------------------------------------------------------
 ;; Spice netlist generation
 ;;   This is the entry point.

--- a/netlist/scheme/backend/gnet-spice.scm
+++ b/netlist/scheme/backend/gnet-spice.scm
@@ -109,6 +109,16 @@
   (display ".END")
   (newline))
 
+
+; public:
+; Instruct the netlister to use 'spice mode
+;
+( define ( request-netlist-mode )
+  ; return:
+  'spice
+)
+
+
 ;;
 ;; Spice netlist generation
 ;;

--- a/netlist/scheme/netlist/mode.scm
+++ b/netlist/scheme/netlist/mode.scm
@@ -18,12 +18,26 @@
 
 (define-module (netlist mode)
   #:export (netlist-mode
-            set-netlist-mode!))
+            set-netlist-mode!
+            netlist-modes
+            default-netlist-mode
+            netlist-mode?))
 
-(define %netlist-mode 'geda)
+(define %netlist-modes (list 'geda 'spice))
+(define %default-netlist-mode 'geda)
+(define %netlist-mode %default-netlist-mode)
 
 (define (netlist-mode)
   %netlist-mode)
 
 (define (set-netlist-mode! mode)
   (set! %netlist-mode mode))
+
+(define (netlist-modes)
+  %netlist-modes)
+
+(define (default-netlist-mode)
+  %default-netlist-mode)
+
+(define (netlist-mode? mode)
+  (member mode (netlist-modes)))


### PR DESCRIPTION
- Netlister backends can now request the desired mode by defining
`request-netlist-mode()` function, which (if present) should return
either `'geda` or `'spice`. By default, the `'geda` mode is used.
- Remove the old kludge from lepton-netlist code, that decides what
mode should be used based on the backend's file name (it sets the `'spice`
mode if backend filename contains `"spice"`, e.g. `gnet-spice.scm`,
`gnet-spice-sdb.scm`, `gnet-spice-noqsi.scm`).
- Add `request-netlist-mode()` function to the `gnet-spice.scm` and
`gnet-spice-sdb.scm` backends.
- Add new functions to the `(netlist mode)` module:
  - `default-netlist-mode()`
  - `netlist-modes()`
  - `netlist-mode?()`

Closes #477 