### PR TITLE
Get rid of `log! 'error` in the code

### DIFF
--- a/liblepton/scheme/lepton/library.scm
+++ b/liblepton/scheme/lepton/library.scm
@@ -99,9 +99,9 @@ code. Use set-library-contents! instead."
                                                         file-name-separator-string
                                                         expanded-path)))
             (and
-             (log! 'error (_ "Invalid path ~S or source not readable.\n") path)
+             (log! 'critical (_ "Invalid path ~S or source not readable.\n") path)
              #f)))
-      (and (log! 'error (_ "Source library path must be a string.\n")) #f)))
+      (and (log! 'critical (_ "Source library path must be a string.\n")) #f)))
 
 
 (define (reset-source-library)
@@ -160,7 +160,7 @@ been found."
                (if (file-readable? full-name)
                    full-name
                    (begin
-                     (log! 'error (_ "File ~S is not readable.\n")
+                     (log! 'critical (_ "File ~S is not readable.\n")
                            full-name)
                      (loop (cdr paths)))))
              (loop (cdr paths))))))

--- a/netlist/scheme/netlist/traverse.scm
+++ b/netlist/scheme/netlist/traverse.scm
@@ -249,7 +249,7 @@
           (unless quiet-mode
             (log! 'message (_ "Loading subcircuit ~S.") filename))
           (file->page filename 'new-page))
-        (log! 'error (_ "Failed to load subcircuit ~S.") name))))
+        (log! 'critical (_ "Failed to load subcircuit ~S.") name))))
 
 
 (define (create-schematic-component-refdes component)

--- a/symcheck/scheme/symbol/check.scm
+++ b/symcheck/scheme/symbol/check.scm
@@ -20,7 +20,6 @@
   #:use-module (ice-9 receive)
   #:use-module (srfi srfi-1)
   #:use-module (srfi srfi-26)
-  #:use-module (sxml match)
   #:use-module (lepton page)
   #:use-module (symbol blame)
   #:use-module (symbol check attrib)

--- a/symcheck/scheme/symcheck/report.scm
+++ b/symcheck/scheme/symcheck/report.scm
@@ -49,7 +49,7 @@
          (check-log! 'critical (format #f (_ "ERROR: ~A") msg)))
        '(0 0 1 0))
       (_
-       (check-log! 'error (format #f (_ "Unrecognized info: ~A\n") blame))
+       (check-log! 'critical (format #f (_ "Unrecognized info: ~A\n") blame))
        '(0 0 0 1))))
 
   (map report (or (object-blames object) '())))


### PR DESCRIPTION
- Use `(log! 'critical ...)` instead of `(log! 'error)` in the code to prevent unexpected exits of
programs, especially, when the user works in interactive mode.
- Get rid of export of an unused module.