### PR TITLE
Fix build when --disable-deprecated option is used on configure stage.

### DIFF
--- a/liblepton/src/liblepton.c
+++ b/liblepton/src/liblepton.c
@@ -48,7 +48,9 @@ void libgeda_init(void)
   s_color_init();
 
   g_register_libgeda_funcs();
-  g_register_libgeda_dirs();
+  if (getenv ("LEPTON_INHIBIT_RC_FILES") == NULL) {
+    g_register_libgeda_dirs ();
+  }
 
   edascm_init ();
 }

--- a/netlist/scheme/Makefile.am
+++ b/netlist/scheme/Makefile.am
@@ -115,10 +115,10 @@ TEST_EXTENSIONS = .scm
 # AM_SCM_LOG_FLAGS below because guile must know where to find
 # netlist modules before it runs tests
 SCM_LOG_DRIVER = $(GUILE) \
-	-L $(srcdir) \
-	-L $(builddir) \
 	-L $(abs_top_srcdir)/liblepton/scheme \
 	-L $(abs_top_builddir)/liblepton/scheme \
+	-L $(abs_top_srcdir)/netlist/scheme \
+	-L $(abs_top_builddir)/netlist/scheme \
 	-L $(abs_top_srcdir)/symcheck/scheme \
 	-L $(abs_top_builddir)/symcheck/scheme \
 	--no-auto-compile -e main/with-toplevel -s unit-test.scm

--- a/netlist/scheme/Makefile.am
+++ b/netlist/scheme/Makefile.am
@@ -108,8 +108,10 @@ DIST_SCM = \
 	netlist/traverse.scm \
 	netlist/verbose.scm
 
-TESTS = unit-tests/test-netlist-partlist.scm \
-	unit-tests/test-netlist-attrib.scm
+TESTS = unit-tests/test-netlist-load-path.scm \
+	unit-tests/test-netlist-attrib.scm \
+	unit-tests/test-netlist-partlist.scm
+
 TEST_EXTENSIONS = .scm
 # $(srcdir) and $(builddir) are added here and not in
 # AM_SCM_LOG_FLAGS below because guile must know where to find

--- a/netlist/scheme/unit-test.scm
+++ b/netlist/scheme/unit-test.scm
@@ -67,6 +67,12 @@
 
 ;;; Initialize liblepton variables and functions.
 (setenv "LEPTON_INHIBIT_RC_FILES" "yes")
+;;; The load path should not be changed after loading the
+;;; liblepton library.  This is tested in the unit test
+;;; "test-netlist-load-path.scm".
+(setenv "INITIAL_GUILE_LOAD_PATH"
+        (with-output-to-string (lambda () (write %load-path))))
+
 
 (load-extension "../../liblepton/src/liblepton" "libgeda_init")
 (define with-toplevel (@@ (geda core toplevel) %with-toplevel))

--- a/netlist/scheme/unit-test.scm
+++ b/netlist/scheme/unit-test.scm
@@ -54,11 +54,16 @@
 ;;;   Must be present once if several tests are done in one
 ;;;   script. It should output some summary.
 
-
 (use-modules (srfi srfi-64)
              (srfi srfi-26)
              (ice-9 getopt-long)
              (ice-9 pretty-print))
+
+;;; In order to facilitate debugging, you can increase the pile of
+;;; info reported on errors by setting the COLUMNS environment
+;;; variable to a bigger value. Example:
+;; (setenv "COLUMNS" "1000")
+
 
 ;;; Initialize liblepton variables and functions.
 (load-extension "../../liblepton/src/liblepton" "libgeda_init")

--- a/netlist/scheme/unit-test.scm
+++ b/netlist/scheme/unit-test.scm
@@ -66,6 +66,8 @@
 
 
 ;;; Initialize liblepton variables and functions.
+(setenv "LEPTON_INHIBIT_RC_FILES" "yes")
+
 (load-extension "../../liblepton/src/liblepton" "libgeda_init")
 (define with-toplevel (@@ (geda core toplevel) %with-toplevel))
 (define make-toplevel (@@ (geda core toplevel) %make-toplevel))

--- a/netlist/scheme/unit-tests/test-netlist-load-path.scm
+++ b/netlist/scheme/unit-tests/test-netlist-load-path.scm
@@ -1,0 +1,7 @@
+(use-modules (srfi srfi-64))
+
+(test-begin "load-path")
+(test-equal
+    %load-path
+  (with-input-from-string (getenv "INITIAL_GUILE_LOAD_PATH") read))
+(test-end "load-path")

--- a/netlist/tests/run-test
+++ b/netlist/tests/run-test
@@ -9,9 +9,7 @@ LIBLEPTON="${abs_top_builddir}/liblepton/src/liblepton"
 export LIBLEPTON
 
 GNETLIST="${abs_top_builddir}/netlist/scheme/lepton-netlist"
-GEDADATA="${abs_top_srcdir}/netlist" # HACKHACKHACK
 GEDADATARC="${abs_top_builddir}/liblepton/lib"
-export GEDADATA
 export GEDADATARC
 
 export GUILE_LOAD_PATH="${abs_top_srcdir}/netlist/scheme:${abs_top_builddir}/netlist/scheme:${abs_top_srcdir}/liblepton/scheme:${abs_top_builddir}/liblepton/scheme:${abs_top_srcdir}/symcheck/scheme:${abs_top_builddir}/symcheck/scheme:..."

--- a/netlist/tests/run-test
+++ b/netlist/tests/run-test
@@ -251,14 +251,12 @@ vams-device)
     cmd="(define generate-mode 2) (define top-attribs '(refdes=U1 device=7404 footprint=DIP14))"
     ;;
 postload)
-    (cd "${rundir}" && "${GNETLIST}" -L "${abs_top_srcdir}/liblepton/scheme" \
-                  -L "${abs_top_builddir}/liblepton/scheme" \
-                  -L "${abs_top_srcdir}/symcheck/scheme" \
-                  -L "${abs_top_builddir}/symcheck/scheme" \
-                  -g "geda" \
-                  -o - \
-                  -m "${abs_srcdir}/postload/test-postload.scm" \
-                  ${schematic})
+    (cd "${rundir}" &&
+         "${GNETLIST}" \
+             -g "geda" \
+             -o - \
+             -m "${abs_srcdir}/postload/test-postload.scm" \
+             ${schematic})
     if test $? -ne 100 ; then
         echo "FAILED: Post backend load check failed."
         exit 1

--- a/netlist/tests/run-test
+++ b/netlist/tests/run-test
@@ -16,6 +16,8 @@ export GEDADATARC
 
 export GUILE_LOAD_PATH="${abs_top_srcdir}/netlist/scheme:${abs_top_builddir}/netlist/scheme:${abs_top_srcdir}/liblepton/scheme:${abs_top_builddir}/liblepton/scheme:${abs_top_srcdir}/symcheck/scheme:${abs_top_builddir}/symcheck/scheme:..."
 
+export LEPTON_INHIBIT_RC_FILES=yes
+
 schematic="${abs_srcdir}/${stem}.sch"
 # Multi-page schematic
 if test "X${stem}" = "Xhierarchy3" ; then

--- a/netlist/tests/run-test
+++ b/netlist/tests/run-test
@@ -264,7 +264,7 @@ postload)
     ;;
 esac
 
-export GUILE_LOAD_PATH="${abs_top_srcdir}/liblepton/scheme:${abs_top_builddir}/liblepton/scheme:${abs_top_srcdir}/symcheck/scheme:${abs_top_builddir}/symcheck/scheme:$GUILE_LOAD_PATH"
+export GUILE_LOAD_PATH="${abs_top_srcdir}/netlist/scheme:${abs_top_builddir}/netlist/scheme:${abs_top_srcdir}/liblepton/scheme:${abs_top_builddir}/liblepton/scheme:${abs_top_srcdir}/symcheck/scheme:${abs_top_builddir}/symcheck/scheme:..."
 
 # run gnetlist
 echo "${GNETLIST} -c ${cmd} -g ${backend} ${args} ${schematic}"

--- a/netlist/tests/run-test
+++ b/netlist/tests/run-test
@@ -10,7 +10,7 @@ export LIBLEPTON
 
 GNETLIST="${abs_top_builddir}/netlist/scheme/lepton-netlist"
 GEDADATA="${abs_top_srcdir}/netlist" # HACKHACKHACK
-GEDADATARC="${abs_top_builddir}/netlist/lib"
+GEDADATARC="${abs_top_builddir}/liblepton/lib"
 export GEDADATA
 export GEDADATARC
 

--- a/netlist/tests/run-test
+++ b/netlist/tests/run-test
@@ -14,6 +14,8 @@ GEDADATARC="${abs_top_builddir}/netlist/lib"
 export GEDADATA
 export GEDADATARC
 
+export GUILE_LOAD_PATH="${abs_top_srcdir}/netlist/scheme:${abs_top_builddir}/netlist/scheme:${abs_top_srcdir}/liblepton/scheme:${abs_top_builddir}/liblepton/scheme:${abs_top_srcdir}/symcheck/scheme:${abs_top_builddir}/symcheck/scheme:..."
+
 schematic="${abs_srcdir}/${stem}.sch"
 # Multi-page schematic
 if test "X${stem}" = "Xhierarchy3" ; then
@@ -263,8 +265,6 @@ postload)
     fi
     ;;
 esac
-
-export GUILE_LOAD_PATH="${abs_top_srcdir}/netlist/scheme:${abs_top_builddir}/netlist/scheme:${abs_top_srcdir}/liblepton/scheme:${abs_top_builddir}/liblepton/scheme:${abs_top_srcdir}/symcheck/scheme:${abs_top_builddir}/symcheck/scheme:..."
 
 # run gnetlist
 echo "${GNETLIST} -c ${cmd} -g ${backend} ${args} ${schematic}"

--- a/symcheck/tests/Makefile.am
+++ b/symcheck/tests/Makefile.am
@@ -84,7 +84,7 @@ tests:
 	[ -e $$ERRORLOG ] && rm $$ERRORLOG; \
 	for file in $(abs_srcdir)/*.sym; do \
 	  base=`basename $$file`; \
-	  GEDADATARC=$(builddir)/../lib \
+	  GEDADATARC="${abs_top_builddir}/liblepton/lib" \
 	  $(SHELL) $(srcdir)/runtest.sh $$file; \
           if [ $$? -ne 0 ]; then \
 	     echo "FAIL: $$base"; \

--- a/symcheck/tests/runtest.sh
+++ b/symcheck/tests/runtest.sh
@@ -4,8 +4,6 @@ INPUT=$1
 rundir=${abs_builddir}/run
 SYMCHECK=${abs_top_builddir}/symcheck/scheme/lepton-symcheck
 # Hack to enable `make distcheck'
-GEDADATA="${abs_top_srcdir}/symcheck"
-export GEDADATA
 
 # create temporary run directory and required subdirs
 mkdir -m 0700 -p ${rundir}
@@ -25,7 +23,7 @@ tmpfile=${rundir}/tmp$$
 
 # ERRORLOG is a variable exported in Makefile
 cd ${rundir} &&
-    GUILE_LOAD_PATH="${abs_top_srcdir}/liblepton/scheme:${abs_top_builddir}/liblepton/scheme" \
+    GUILE_LOAD_PATH="${abs_top_srcdir}/symcheck/scheme:${abs_top_srcdir}/liblepton/scheme:${abs_top_builddir}/liblepton/scheme" \
                    ${SYMCHECK} -vv ${in} 1> ${tmpfile} 2>> ${ERRORLOG}
 
 cat ${tmpfile} | \


### PR DESCRIPTION
Several test suites have been fixed to let `make check` work without errors.