### PR TITLE
Improve processing of <package-pin>s

### DIFF
--- a/netlist/scheme/netlist/package-pin.scm
+++ b/netlist/scheme/netlist/package-pin.scm
@@ -124,34 +124,33 @@ Example usage:
 
 (define (object->package-pin pin-object)
   "Transform a primitive PIN-OBJECT into <package-pin>."
-  (define (make-pin-attrib-list object)
-    (define (add-attrib attrib)
-      (cons (string->symbol (attrib-name attrib))
-            (attrib-value attrib)))
+  (define (add-attrib attrib)
+    (cons (string->symbol (attrib-name attrib))
+          (attrib-value attrib)))
 
-    (map add-attrib (object-attribs object)))
+  (define attribs
+    (map add-attrib (object-attribs pin-object)))
 
-  (let ((attribs (make-pin-attrib-list pin-object)))
-    (make-package-pin (object-id pin-object)
-                      ;; Primitive pin object.
-                      pin-object
-                      ;; Number.
-                      (assq-ref attribs 'pinnumber)
-                      ;; Add name later.
-                      #f
-                      ;; Add netname list later.
-                      #f
-                      ;; Label.
-                      (assq-ref attribs 'pinlabel)
-                      ;; Attributes.
-                      attribs
-                      ;; No net-map yet.
-                      #f
-                      ;; No nets yet.
-                      #f
-                      ;; Set parent component later.
-                      #f
-                      ;; No connection yet.
-                      #f
-                      ;; No netname connection yet.
-                      #f)))
+  (make-package-pin (object-id pin-object)
+                    ;; Primitive pin object.
+                    pin-object
+                    ;; Number.
+                    (assq-ref attribs 'pinnumber)
+                    ;; Add name later.
+                    #f
+                    ;; Add netname list later.
+                    #f
+                    ;; Label.
+                    (assq-ref attribs 'pinlabel)
+                    ;; Attributes.
+                    attribs
+                    ;; No net-map yet.
+                    #f
+                    ;; No nets yet.
+                    #f
+                    ;; Set parent component later.
+                    #f
+                    ;; No connection yet.
+                    #f
+                    ;; No netname connection yet.
+                    #f))

--- a/netlist/scheme/netlist/package-pin.scm
+++ b/netlist/scheme/netlist/package-pin.scm
@@ -123,6 +123,7 @@ Example usage:
 
 
 (define (object->package-pin pin-object)
+  "Transform a primitive PIN-OBJECT into <package-pin>."
   (define (make-pin-attrib-list object)
     (define (add-attrib attrib)
       (cons (string->symbol (attrib-name attrib))

--- a/netlist/scheme/netlist/package-pin.scm
+++ b/netlist/scheme/netlist/package-pin.scm
@@ -131,26 +131,27 @@ Example usage:
   (define attribs
     (map add-attrib (object-attribs pin-object)))
 
-  (make-package-pin (object-id pin-object)
-                    ;; Primitive pin object.
-                    pin-object
-                    ;; Number.
-                    (assq-ref attribs 'pinnumber)
-                    ;; Add name later.
-                    #f
-                    ;; Add netname list later.
-                    #f
-                    ;; Label.
-                    (assq-ref attribs 'pinlabel)
-                    ;; Attributes.
-                    attribs
-                    ;; No net-map yet.
-                    #f
-                    ;; No nets yet.
-                    #f
-                    ;; Set parent component later.
-                    #f
-                    ;; No connection yet.
-                    #f
-                    ;; No netname connection yet.
-                    #f))
+  (and (net-pin? pin-object)
+       (make-package-pin (object-id pin-object)
+                         ;; Primitive pin object.
+                         pin-object
+                         ;; Number.
+                         (assq-ref attribs 'pinnumber)
+                         ;; Add name later.
+                         #f
+                         ;; Add netname list later.
+                         #f
+                         ;; Label.
+                         (assq-ref attribs 'pinlabel)
+                         ;; Attributes.
+                         attribs
+                         ;; No net-map yet.
+                         #f
+                         ;; No nets yet.
+                         #f
+                         ;; Set parent component later.
+                         #f
+                         ;; No connection yet.
+                         #f
+                         ;; No netname connection yet.
+                         #f)))

--- a/netlist/scheme/netlist/package-pin.scm
+++ b/netlist/scheme/netlist/package-pin.scm
@@ -21,6 +21,8 @@
   #:use-module (ice-9 match)
   #:use-module (srfi srfi-9)
   #:use-module (srfi srfi-9 gnu)
+  #:use-module (geda attrib)
+  #:use-module (geda object)
 
   #:export-syntax (make-package-pin package-pin?
                    package-pin-id set-package-pin-id!
@@ -36,7 +38,8 @@
                    package-pin-connection set-package-pin-connection!
                    package-pin-named-connection set-package-pin-named-connection!)
 
-  #:export (set-package-pin-printer!
+  #:export (object->package-pin
+            set-package-pin-printer!
             set-package-pin-parent-component!))
 
 (define-record-type <package-pin>
@@ -117,3 +120,37 @@ Example usage:
 
 (define (set-package-pin-parent-component! pin component)
   (delay (set-package-pin-parent! pin component)))
+
+
+(define (object->package-pin pin-object)
+  (define (make-pin-attrib-list object)
+    (define (add-attrib attrib)
+      (cons (string->symbol (attrib-name attrib))
+            (attrib-value attrib)))
+
+    (map add-attrib (object-attribs object)))
+
+  (let ((attribs (make-pin-attrib-list pin-object)))
+    (make-package-pin (object-id pin-object)
+                      ;; Primitive pin object.
+                      pin-object
+                      ;; Number.
+                      (assq-ref attribs 'pinnumber)
+                      ;; Add name later.
+                      #f
+                      ;; Add netname list later.
+                      #f
+                      ;; Label.
+                      (assq-ref attribs 'pinlabel)
+                      ;; Attributes.
+                      attribs
+                      ;; No net-map yet.
+                      #f
+                      ;; No nets yet.
+                      #f
+                      ;; Set parent component later.
+                      #f
+                      ;; No connection yet.
+                      #f
+                      ;; No netname connection yet.
+                      #f)))

--- a/netlist/scheme/netlist/traverse.scm
+++ b/netlist/scheme/netlist/traverse.scm
@@ -143,10 +143,6 @@
               (loop (cdr groups)))))))
 
 
-(define (object-pins->package-pins object)
-  (filter-map object->package-pin (component-contents object)))
-
-
 ;;; Searches for pinnumers in NET-MAPS and, if found, updates
 ;;; corresponding pins in PIN-LIST, otherwise creates new pins and
 ;;; adds them to the list.
@@ -412,7 +408,8 @@
          (sources (get-sources graphical
                                inherited-attribs
                                attached-attribs))
-         (real-pins (object-pins->package-pins object))
+         (real-pins (filter-map object->package-pin
+                                (component-contents object)))
          (net-map-pins (net-maps->package-pins net-maps real-pins))
          (pins (append real-pins net-map-pins)))
     (set-schematic-component-sources! component sources)

--- a/netlist/scheme/netlist/traverse.scm
+++ b/netlist/scheme/netlist/traverse.scm
@@ -144,8 +144,7 @@
 
 
 (define (object-pins->package-pins object)
-  (map object->package-pin
-       (filter net-pin? (component-contents object))))
+  (filter-map object->package-pin (component-contents object)))
 
 
 ;;; Searches for pinnumers in NET-MAPS and, if found, updates

--- a/netlist/scheme/netlist/traverse.scm
+++ b/netlist/scheme/netlist/traverse.scm
@@ -142,40 +142,8 @@
               group
               (loop (cdr groups)))))))
 
+
 (define (object-pins->package-pins object)
-  (define (make-pin-attrib-list object)
-    (define (add-attrib attrib)
-      (cons (string->symbol (attrib-name attrib))
-            (attrib-value attrib)))
-
-    (map add-attrib (object-attribs object)))
-
-  (define (object->package-pin pin-object)
-    (let ((attribs (make-pin-attrib-list pin-object)))
-      (make-package-pin (object-id pin-object)
-                        ;; Primitive pin object.
-                        pin-object
-                        ;; Number.
-                        (assq-ref attribs 'pinnumber)
-                        ;; Add name later.
-                        #f
-                        ;; Add netname list later.
-                        #f
-                        ;; Label.
-                        (assq-ref attribs 'pinlabel)
-                        ;; Attributes.
-                        attribs
-                        ;; No net-map yet.
-                        #f
-                        ;; No nets yet.
-                        #f
-                        ;; Set parent component later.
-                        #f
-                        ;; No connection yet.
-                        #f
-                        ;; No netname connection yet.
-                        #f)))
-
   (map object->package-pin
        (filter net-pin? (component-contents object))))
 


### PR DESCRIPTION
The branch contains various little fixes in processing of the `<package-pin>` records, such as reducing and moving around the code and adding docs.
