### PR TITLE
Migrate gschemrc settings - part 1

### DIFF
--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -34,6 +34,7 @@ text-size=10
 snap-size=100
 scrollpan-steps=8
 dots-grid-dot-size=1
+dots-grid-fixed-threshold=10
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -18,6 +18,7 @@ zoom-with-pan=true
 fast-mousepan=false
 continue-component-place=true
 file-preview=true
+enforce-hierarchy=true
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -23,6 +23,7 @@ third-button-cancel=true
 warp-cursor=false
 force-boundingbox=false
 net-direction-mode=true
+embed-components=false
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -33,6 +33,7 @@ select-slack-pixels=10
 text-size=10
 snap-size=100
 scrollpan-steps=8
+dots-grid-dot-size=1
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -12,6 +12,7 @@ text-sizes=
 font=
 draw-grips=true
 toolbars=true
+scrollbars=true
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -22,6 +22,7 @@ enforce-hierarchy=true
 third-button-cancel=true
 warp-cursor=false
 force-boundingbox=false
+net-direction-mode=true
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -19,6 +19,7 @@ fast-mousepan=false
 continue-component-place=true
 file-preview=true
 enforce-hierarchy=true
+third-button-cancel=true
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -24,6 +24,7 @@ warp-cursor=false
 force-boundingbox=false
 net-direction-mode=true
 embed-components=false
+netconn-rubberband=true
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -20,6 +20,7 @@ continue-component-place=true
 file-preview=true
 enforce-hierarchy=true
 third-button-cancel=true
+warp-cursor=false
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -13,6 +13,7 @@ font=
 draw-grips=true
 toolbars=true
 scrollbars=true
+handleboxes=true
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -29,6 +29,7 @@ magnetic-net-mode=true
 zoom-gain=20
 mousepan-gain=1
 keyboardpan-gain=20
+select-slack-pixels=10
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -14,6 +14,7 @@ draw-grips=true
 toolbars=true
 scrollbars=true
 handleboxes=true
+zoom-with-pan=true
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -11,6 +11,7 @@ restore-window-geometry=true
 text-sizes=
 font=
 draw-grips=true
+toolbars=true
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -32,6 +32,7 @@ keyboardpan-gain=20
 select-slack-pixels=10
 text-size=10
 snap-size=100
+scrollpan-steps=8
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -10,6 +10,7 @@ title-show-path=false
 restore-window-geometry=true
 text-sizes=
 font=
+draw-grips=true
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -15,6 +15,7 @@ toolbars=true
 scrollbars=true
 handleboxes=true
 zoom-with-pan=true
+fast-mousepan=false
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -31,6 +31,7 @@ mousepan-gain=1
 keyboardpan-gain=20
 select-slack-pixels=10
 text-size=10
+snap-size=100
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -26,6 +26,7 @@ net-direction-mode=true
 embed-components=false
 netconn-rubberband=true
 magnetic-net-mode=true
+zoom-gain=20
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -30,6 +30,7 @@ zoom-gain=20
 mousepan-gain=1
 keyboardpan-gain=20
 select-slack-pixels=10
+text-size=10
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -35,6 +35,7 @@ snap-size=100
 scrollpan-steps=8
 dots-grid-dot-size=1
 dots-grid-fixed-threshold=10
+mesh-grid-display-threshold=3
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -16,6 +16,7 @@ scrollbars=true
 handleboxes=true
 zoom-with-pan=true
 fast-mousepan=false
+continue-component-place=true
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -27,6 +27,7 @@ embed-components=false
 netconn-rubberband=true
 magnetic-net-mode=true
 zoom-gain=20
+mousepan-gain=1
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -25,6 +25,7 @@ force-boundingbox=false
 net-direction-mode=true
 embed-components=false
 netconn-rubberband=true
+magnetic-net-mode=true
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -21,6 +21,7 @@ file-preview=true
 enforce-hierarchy=true
 third-button-cancel=true
 warp-cursor=false
+force-boundingbox=false
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -17,6 +17,7 @@ handleboxes=true
 zoom-with-pan=true
 fast-mousepan=false
 continue-component-place=true
+file-preview=true
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -28,6 +28,7 @@ netconn-rubberband=true
 magnetic-net-mode=true
 zoom-gain=20
 mousepan-gain=1
+keyboardpan-gain=20
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -34,6 +34,7 @@ text-size=10
 snap-size=100
 scrollpan-steps=8
 dots-grid-dot-size=1
+dots-grid-fixed-threshold=10
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -18,6 +18,7 @@ zoom-with-pan=true
 fast-mousepan=false
 continue-component-place=true
 file-preview=true
+enforce-hierarchy=true
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -23,6 +23,7 @@ third-button-cancel=true
 warp-cursor=false
 force-boundingbox=false
 net-direction-mode=true
+embed-components=false
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -33,6 +33,7 @@ select-slack-pixels=10
 text-size=10
 snap-size=100
 scrollpan-steps=8
+dots-grid-dot-size=1
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -12,6 +12,7 @@ text-sizes=
 font=
 draw-grips=true
 toolbars=true
+scrollbars=true
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -22,6 +22,7 @@ enforce-hierarchy=true
 third-button-cancel=true
 warp-cursor=false
 force-boundingbox=false
+net-direction-mode=true
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -19,6 +19,7 @@ fast-mousepan=false
 continue-component-place=true
 file-preview=true
 enforce-hierarchy=true
+third-button-cancel=true
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -24,6 +24,7 @@ warp-cursor=false
 force-boundingbox=false
 net-direction-mode=true
 embed-components=false
+netconn-rubberband=true
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -20,6 +20,7 @@ continue-component-place=true
 file-preview=true
 enforce-hierarchy=true
 third-button-cancel=true
+warp-cursor=false
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -13,6 +13,7 @@ font=
 draw-grips=true
 toolbars=true
 scrollbars=true
+handleboxes=true
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -29,6 +29,7 @@ magnetic-net-mode=true
 zoom-gain=20
 mousepan-gain=1
 keyboardpan-gain=20
+select-slack-pixels=10
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -14,6 +14,7 @@ draw-grips=true
 toolbars=true
 scrollbars=true
 handleboxes=true
+zoom-with-pan=true
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -11,6 +11,7 @@ restore-window-geometry=true
 text-sizes=
 font=
 draw-grips=true
+toolbars=true
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -32,6 +32,7 @@ keyboardpan-gain=20
 select-slack-pixels=10
 text-size=10
 snap-size=100
+scrollpan-steps=8
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -10,6 +10,7 @@ title-show-path=false
 restore-window-geometry=true
 text-sizes=
 font=
+draw-grips=true
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -15,6 +15,7 @@ toolbars=true
 scrollbars=true
 handleboxes=true
 zoom-with-pan=true
+fast-mousepan=false
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -31,6 +31,7 @@ mousepan-gain=1
 keyboardpan-gain=20
 select-slack-pixels=10
 text-size=10
+snap-size=100
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -26,6 +26,7 @@ net-direction-mode=true
 embed-components=false
 netconn-rubberband=true
 magnetic-net-mode=true
+zoom-gain=20
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -30,6 +30,7 @@ zoom-gain=20
 mousepan-gain=1
 keyboardpan-gain=20
 select-slack-pixels=10
+text-size=10
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -35,6 +35,7 @@ snap-size=100
 scrollpan-steps=8
 dots-grid-dot-size=1
 dots-grid-fixed-threshold=10
+mesh-grid-display-threshold=3
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -16,6 +16,7 @@ scrollbars=true
 handleboxes=true
 zoom-with-pan=true
 fast-mousepan=false
+continue-component-place=true
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -27,6 +27,7 @@ embed-components=false
 netconn-rubberband=true
 magnetic-net-mode=true
 zoom-gain=20
+mousepan-gain=1
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -25,6 +25,7 @@ force-boundingbox=false
 net-direction-mode=true
 embed-components=false
 netconn-rubberband=true
+magnetic-net-mode=true
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -21,6 +21,7 @@ file-preview=true
 enforce-hierarchy=true
 third-button-cancel=true
 warp-cursor=false
+force-boundingbox=false
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -17,6 +17,7 @@ handleboxes=true
 zoom-with-pan=true
 fast-mousepan=false
 continue-component-place=true
+file-preview=true
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -28,6 +28,7 @@ netconn-rubberband=true
 magnetic-net-mode=true
 zoom-gain=20
 mousepan-gain=1
+keyboardpan-gain=20
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/scheme/geda-deprecated-config.scm
+++ b/liblepton/scheme/geda-deprecated-config.scm
@@ -253,3 +253,6 @@ option's value:
 (define-rc-deprecated-config
  third-button-cancel "schematic.gui" "third-button-cancel"
  rc-deprecated-string-boolean-transformer)
+(define-rc-deprecated-config
+ warp-cursor "schematic.gui" "warp-cursor"
+ rc-deprecated-string-boolean-transformer)

--- a/liblepton/scheme/geda-deprecated-config.scm
+++ b/liblepton/scheme/geda-deprecated-config.scm
@@ -291,3 +291,6 @@ option's value:
 (define-rc-deprecated-config
  snap-size "schematic.gui" "snap-size"
  rc-deprecated-int-transformer)
+(define-rc-deprecated-config
+ scrollpan-steps "schematic.gui" "scrollpan-steps"
+ rc-deprecated-int-transformer)

--- a/liblepton/scheme/geda-deprecated-config.scm
+++ b/liblepton/scheme/geda-deprecated-config.scm
@@ -279,3 +279,6 @@ option's value:
 (define-rc-deprecated-config
  mousepan-gain "schematic.gui" "mousepan-gain"
  rc-deprecated-int-transformer)
+(define-rc-deprecated-config
+ keyboardpan-gain "schematic.gui" "keyboardpan-gain"
+ rc-deprecated-int-transformer)

--- a/liblepton/scheme/geda-deprecated-config.scm
+++ b/liblepton/scheme/geda-deprecated-config.scm
@@ -282,3 +282,6 @@ option's value:
 (define-rc-deprecated-config
  keyboardpan-gain "schematic.gui" "keyboardpan-gain"
  rc-deprecated-int-transformer)
+(define-rc-deprecated-config
+ select-slack-pixels "schematic.gui" "select-slack-pixels"
+ rc-deprecated-int-transformer)

--- a/liblepton/scheme/geda-deprecated-config.scm
+++ b/liblepton/scheme/geda-deprecated-config.scm
@@ -294,3 +294,6 @@ option's value:
 (define-rc-deprecated-config
  scrollpan-steps "schematic.gui" "scrollpan-steps"
  rc-deprecated-int-transformer)
+(define-rc-deprecated-config
+ dots-grid-dot-size "schematic.gui" "dots-grid-dot-size"
+ rc-deprecated-int-transformer)

--- a/liblepton/scheme/geda-deprecated-config.scm
+++ b/liblepton/scheme/geda-deprecated-config.scm
@@ -247,3 +247,6 @@ option's value:
 (define-rc-deprecated-config
  file-preview "schematic.gui" "file-preview"
  rc-deprecated-string-boolean-transformer)
+(define-rc-deprecated-config
+ enforce-hierarchy "schematic.gui" "enforce-hierarchy"
+ rc-deprecated-string-boolean-transformer)

--- a/liblepton/scheme/geda-deprecated-config.scm
+++ b/liblepton/scheme/geda-deprecated-config.scm
@@ -285,3 +285,6 @@ option's value:
 (define-rc-deprecated-config
  select-slack-pixels "schematic.gui" "select-slack-pixels"
  rc-deprecated-int-transformer)
+(define-rc-deprecated-config
+ text-size "schematic.gui" "text-size"
+ rc-deprecated-int-transformer)

--- a/liblepton/scheme/geda-deprecated-config.scm
+++ b/liblepton/scheme/geda-deprecated-config.scm
@@ -262,3 +262,6 @@ option's value:
 (define-rc-deprecated-config
  net-direction-mode "schematic.gui" "net-direction-mode"
  rc-deprecated-string-boolean-transformer)
+(define-rc-deprecated-config
+ embed-components "schematic.gui" "embed-components"
+ rc-deprecated-string-boolean-transformer)

--- a/liblepton/scheme/geda-deprecated-config.scm
+++ b/liblepton/scheme/geda-deprecated-config.scm
@@ -276,3 +276,6 @@ option's value:
 (define-rc-deprecated-config
  zoom-gain "schematic.gui" "zoom-gain"
  rc-deprecated-int-transformer)
+(define-rc-deprecated-config
+ mousepan-gain "schematic.gui" "mousepan-gain"
+ rc-deprecated-int-transformer)

--- a/liblepton/scheme/geda-deprecated-config.scm
+++ b/liblepton/scheme/geda-deprecated-config.scm
@@ -288,3 +288,6 @@ option's value:
 (define-rc-deprecated-config
  text-size "schematic.gui" "text-size"
  rc-deprecated-int-transformer)
+(define-rc-deprecated-config
+ snap-size "schematic.gui" "snap-size"
+ rc-deprecated-int-transformer)

--- a/liblepton/scheme/geda-deprecated-config.scm
+++ b/liblepton/scheme/geda-deprecated-config.scm
@@ -259,3 +259,6 @@ option's value:
 (define-rc-deprecated-config
  force-boundingbox "schematic.gui" "force-boundingbox"
  rc-deprecated-string-boolean-transformer)
+(define-rc-deprecated-config
+ net-direction-mode "schematic.gui" "net-direction-mode"
+ rc-deprecated-string-boolean-transformer)

--- a/liblepton/scheme/geda-deprecated-config.scm
+++ b/liblepton/scheme/geda-deprecated-config.scm
@@ -235,3 +235,6 @@ option's value:
 (define-rc-deprecated-config
  handleboxes "schematic.gui" "handleboxes"
  rc-deprecated-string-boolean-transformer)
+(define-rc-deprecated-config
+ zoom-with-pan "schematic.gui" "zoom-with-pan"
+ rc-deprecated-string-boolean-transformer)

--- a/liblepton/scheme/geda-deprecated-config.scm
+++ b/liblepton/scheme/geda-deprecated-config.scm
@@ -265,3 +265,6 @@ option's value:
 (define-rc-deprecated-config
  embed-components "schematic.gui" "embed-components"
  rc-deprecated-string-boolean-transformer)
+(define-rc-deprecated-config
+ netconn-rubberband "schematic.gui" "netconn-rubberband"
+ rc-deprecated-string-boolean-transformer)

--- a/liblepton/scheme/geda-deprecated-config.scm
+++ b/liblepton/scheme/geda-deprecated-config.scm
@@ -238,3 +238,6 @@ option's value:
 (define-rc-deprecated-config
  zoom-with-pan "schematic.gui" "zoom-with-pan"
  rc-deprecated-string-boolean-transformer)
+(define-rc-deprecated-config
+ fast-mousepan "schematic.gui" "fast-mousepan"
+ rc-deprecated-string-boolean-transformer)

--- a/liblepton/scheme/geda-deprecated-config.scm
+++ b/liblepton/scheme/geda-deprecated-config.scm
@@ -241,3 +241,6 @@ option's value:
 (define-rc-deprecated-config
  fast-mousepan "schematic.gui" "fast-mousepan"
  rc-deprecated-string-boolean-transformer)
+(define-rc-deprecated-config
+ continue-component-place "schematic.gui" "continue-component-place"
+ rc-deprecated-string-boolean-transformer)

--- a/liblepton/scheme/geda-deprecated-config.scm
+++ b/liblepton/scheme/geda-deprecated-config.scm
@@ -300,3 +300,6 @@ option's value:
 (define-rc-deprecated-config
  dots-grid-fixed-threshold "schematic.gui" "dots-grid-fixed-threshold"
  rc-deprecated-int-transformer)
+(define-rc-deprecated-config
+ mesh-grid-display-threshold "schematic.gui" "mesh-grid-display-threshold"
+ rc-deprecated-int-transformer)

--- a/liblepton/scheme/geda-deprecated-config.scm
+++ b/liblepton/scheme/geda-deprecated-config.scm
@@ -297,3 +297,6 @@ option's value:
 (define-rc-deprecated-config
  dots-grid-dot-size "schematic.gui" "dots-grid-dot-size"
  rc-deprecated-int-transformer)
+(define-rc-deprecated-config
+ dots-grid-fixed-threshold "schematic.gui" "dots-grid-fixed-threshold"
+ rc-deprecated-int-transformer)

--- a/liblepton/scheme/geda-deprecated-config.scm
+++ b/liblepton/scheme/geda-deprecated-config.scm
@@ -256,3 +256,6 @@ option's value:
 (define-rc-deprecated-config
  warp-cursor "schematic.gui" "warp-cursor"
  rc-deprecated-string-boolean-transformer)
+(define-rc-deprecated-config
+ force-boundingbox "schematic.gui" "force-boundingbox"
+ rc-deprecated-string-boolean-transformer)

--- a/liblepton/scheme/geda-deprecated-config.scm
+++ b/liblepton/scheme/geda-deprecated-config.scm
@@ -229,3 +229,6 @@ option's value:
 (define-rc-deprecated-config
  toolbars "schematic.gui" "toolbars"
  rc-deprecated-string-boolean-transformer)
+(define-rc-deprecated-config
+ scrollbars "schematic.gui" "scrollbars"
+ rc-deprecated-string-boolean-transformer)

--- a/liblepton/scheme/geda-deprecated-config.scm
+++ b/liblepton/scheme/geda-deprecated-config.scm
@@ -250,3 +250,6 @@ option's value:
 (define-rc-deprecated-config
  enforce-hierarchy "schematic.gui" "enforce-hierarchy"
  rc-deprecated-string-boolean-transformer)
+(define-rc-deprecated-config
+ third-button-cancel "schematic.gui" "third-button-cancel"
+ rc-deprecated-string-boolean-transformer)

--- a/liblepton/scheme/geda-deprecated-config.scm
+++ b/liblepton/scheme/geda-deprecated-config.scm
@@ -232,3 +232,6 @@ option's value:
 (define-rc-deprecated-config
  scrollbars "schematic.gui" "scrollbars"
  rc-deprecated-string-boolean-transformer)
+(define-rc-deprecated-config
+ handleboxes "schematic.gui" "handleboxes"
+ rc-deprecated-string-boolean-transformer)

--- a/liblepton/scheme/geda-deprecated-config.scm
+++ b/liblepton/scheme/geda-deprecated-config.scm
@@ -226,3 +226,6 @@ option's value:
 (define-rc-deprecated-config
  draw-grips "schematic.gui" "draw-grips"
  rc-deprecated-string-boolean-transformer)
+(define-rc-deprecated-config
+ toolbars "schematic.gui" "toolbars"
+ rc-deprecated-string-boolean-transformer)

--- a/liblepton/scheme/geda-deprecated-config.scm
+++ b/liblepton/scheme/geda-deprecated-config.scm
@@ -244,3 +244,6 @@ option's value:
 (define-rc-deprecated-config
  continue-component-place "schematic.gui" "continue-component-place"
  rc-deprecated-string-boolean-transformer)
+(define-rc-deprecated-config
+ file-preview "schematic.gui" "file-preview"
+ rc-deprecated-string-boolean-transformer)

--- a/liblepton/scheme/geda-deprecated-config.scm
+++ b/liblepton/scheme/geda-deprecated-config.scm
@@ -268,3 +268,6 @@ option's value:
 (define-rc-deprecated-config
  netconn-rubberband "schematic.gui" "netconn-rubberband"
  rc-deprecated-string-boolean-transformer)
+(define-rc-deprecated-config
+ magnetic-net-mode "schematic.gui" "magnetic-net-mode"
+ rc-deprecated-string-boolean-transformer)

--- a/liblepton/scheme/geda-deprecated-config.scm
+++ b/liblepton/scheme/geda-deprecated-config.scm
@@ -108,6 +108,8 @@ option's value:
 ;; Identity value transformer for define-rc-deprecated-config
 (define (rc-deprecated-string-transformer str) str)
 
+(define (rc-deprecated-int-transformer num) num)
+
 ;; Transformer for "enabled"/"disabled" to boolean
 (define (rc-deprecated-string-boolean-transformer str)
   (string=? "enabled" str))
@@ -271,3 +273,6 @@ option's value:
 (define-rc-deprecated-config
  magnetic-net-mode "schematic.gui" "magnetic-net-mode"
  rc-deprecated-string-boolean-transformer)
+(define-rc-deprecated-config
+ zoom-gain "schematic.gui" "zoom-gain"
+ rc-deprecated-int-transformer)

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -170,7 +170,6 @@ SCM g_rc_third_button_cancel(SCM mode);
 SCM g_rc_middle_button(SCM mode);
 SCM g_rc_scroll_wheel(SCM mode);
 SCM g_rc_net_consolidate(SCM mode);
-SCM g_rc_enforce_hierarchy(SCM mode);
 SCM g_rc_undo_levels(SCM levels);
 SCM g_rc_undo_control(SCM mode);
 SCM g_rc_undo_type(SCM mode);

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -158,7 +158,6 @@ SCM g_rc_gschem_version(SCM version);
 SCM g_rc_net_selection_mode(SCM mode);
 SCM g_rc_action_feedback_mode(SCM mode);
 SCM g_rc_logging(SCM mode);
-SCM g_rc_embed_components(SCM mode);
 SCM g_rc_text_size(SCM size);
 SCM g_rc_text_caps_style(SCM mode);
 SCM g_rc_snap_size(SCM size);

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -159,7 +159,6 @@ SCM g_rc_net_selection_mode(SCM mode);
 SCM g_rc_action_feedback_mode(SCM mode);
 SCM g_rc_logging(SCM mode);
 SCM g_rc_text_caps_style(SCM mode);
-SCM g_rc_snap_size(SCM size);
 SCM g_rc_attribute_name(SCM path);
 SCM g_rc_log_window(SCM mode);
 SCM g_rc_third_button(SCM mode);

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -179,7 +179,6 @@ SCM g_rc_dots_grid_mode(SCM mode);
 SCM g_rc_dots_grid_fixed_threshold(SCM spacing);
 SCM g_rc_mesh_grid_display_threshold(SCM spacing);
 SCM g_rc_auto_save_interval(SCM seconds);
-SCM g_rc_scrollpan_steps(SCM steps);
 SCM g_rc_display_color_map (SCM scm_map);
 SCM g_rc_display_outline_color_map (SCM scm_map);
 /* g_register.c */

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -171,7 +171,6 @@ SCM g_rc_undo_levels(SCM levels);
 SCM g_rc_undo_control(SCM mode);
 SCM g_rc_undo_type(SCM mode);
 SCM g_rc_undo_panzoom(SCM mode);
-SCM g_rc_magnetic_net_mode(SCM mode);
 SCM g_rc_add_menu(SCM menu_name, SCM menu_items);
 SCM g_rc_bus_ripper_size(SCM size);
 SCM g_rc_bus_ripper_type(SCM mode);

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -181,7 +181,6 @@ SCM g_rc_dots_grid_mode(SCM mode);
 SCM g_rc_dots_grid_fixed_threshold(SCM spacing);
 SCM g_rc_mesh_grid_display_threshold(SCM spacing);
 SCM g_rc_auto_save_interval(SCM seconds);
-SCM g_rc_mousepan_gain(SCM mode);
 SCM g_rc_keyboardpan_gain(SCM mode);
 SCM g_rc_select_slack_pixels(SCM pixels);
 SCM g_rc_scrollpan_steps(SCM steps);

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -176,7 +176,6 @@ SCM g_rc_undo_panzoom(SCM mode);
 SCM g_rc_netconn_rubberband(SCM mode);
 SCM g_rc_magnetic_net_mode(SCM mode);
 SCM g_rc_add_menu(SCM menu_name, SCM menu_items);
-SCM g_rc_warp_cursor(SCM mode);
 SCM g_rc_bus_ripper_size(SCM size);
 SCM g_rc_bus_ripper_type(SCM mode);
 SCM g_rc_bus_ripper_rotation(SCM mode);

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -165,7 +165,6 @@ SCM g_rc_text_size(SCM size);
 SCM g_rc_text_caps_style(SCM mode);
 SCM g_rc_snap_size(SCM size);
 SCM g_rc_attribute_name(SCM path);
-SCM g_rc_scrollbars(SCM mode);
 SCM g_rc_log_window(SCM mode);
 SCM g_rc_third_button(SCM mode);
 SCM g_rc_third_button_cancel(SCM mode);

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -155,7 +155,6 @@ void g_init_keys ();
 /* g_rc.c */
 void g_rc_parse_gtkrc();
 SCM g_rc_gschem_version(SCM version);
-SCM g_rc_net_direction_mode(SCM mode);
 SCM g_rc_net_selection_mode(SCM mode);
 SCM g_rc_action_feedback_mode(SCM mode);
 SCM g_rc_logging(SCM mode);

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -158,7 +158,6 @@ SCM g_rc_gschem_version(SCM version);
 SCM g_rc_net_direction_mode(SCM mode);
 SCM g_rc_net_selection_mode(SCM mode);
 SCM g_rc_action_feedback_mode(SCM mode);
-SCM g_rc_zoom_with_pan(SCM mode);
 SCM g_rc_logging(SCM mode);
 SCM g_rc_embed_components(SCM mode);
 SCM g_rc_text_size(SCM size);

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -172,7 +172,6 @@ SCM g_rc_scroll_wheel(SCM mode);
 SCM g_rc_net_consolidate(SCM mode);
 SCM g_rc_file_preview(SCM mode);
 SCM g_rc_enforce_hierarchy(SCM mode);
-SCM g_rc_continue_component_place(SCM mode);
 SCM g_rc_undo_levels(SCM levels);
 SCM g_rc_undo_control(SCM mode);
 SCM g_rc_undo_type(SCM mode);

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -171,7 +171,6 @@ SCM g_rc_undo_levels(SCM levels);
 SCM g_rc_undo_control(SCM mode);
 SCM g_rc_undo_type(SCM mode);
 SCM g_rc_undo_panzoom(SCM mode);
-SCM g_rc_netconn_rubberband(SCM mode);
 SCM g_rc_magnetic_net_mode(SCM mode);
 SCM g_rc_add_menu(SCM menu_name, SCM menu_items);
 SCM g_rc_bus_ripper_size(SCM size);

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -184,7 +184,6 @@ SCM g_rc_netconn_rubberband(SCM mode);
 SCM g_rc_magnetic_net_mode(SCM mode);
 SCM g_rc_add_menu(SCM menu_name, SCM menu_items);
 SCM g_rc_warp_cursor(SCM mode);
-SCM g_rc_toolbars(SCM mode);
 SCM g_rc_handleboxes(SCM mode);
 SCM g_rc_bus_ripper_size(SCM size);
 SCM g_rc_bus_ripper_type(SCM mode);

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -175,7 +175,6 @@ SCM g_rc_bus_ripper_type(SCM mode);
 SCM g_rc_bus_ripper_rotation(SCM mode);
 SCM g_rc_grid_mode(SCM mode);
 SCM g_rc_dots_grid_mode(SCM mode);
-SCM g_rc_mesh_grid_display_threshold(SCM spacing);
 SCM g_rc_auto_save_interval(SCM seconds);
 SCM g_rc_display_color_map (SCM scm_map);
 SCM g_rc_display_outline_color_map (SCM scm_map);

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -175,7 +175,6 @@ SCM g_rc_bus_ripper_type(SCM mode);
 SCM g_rc_bus_ripper_rotation(SCM mode);
 SCM g_rc_grid_mode(SCM mode);
 SCM g_rc_dots_grid_mode(SCM mode);
-SCM g_rc_dots_grid_fixed_threshold(SCM spacing);
 SCM g_rc_mesh_grid_display_threshold(SCM spacing);
 SCM g_rc_auto_save_interval(SCM seconds);
 SCM g_rc_display_color_map (SCM scm_map);

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -166,7 +166,6 @@ SCM g_rc_snap_size(SCM size);
 SCM g_rc_attribute_name(SCM path);
 SCM g_rc_log_window(SCM mode);
 SCM g_rc_third_button(SCM mode);
-SCM g_rc_third_button_cancel(SCM mode);
 SCM g_rc_middle_button(SCM mode);
 SCM g_rc_scroll_wheel(SCM mode);
 SCM g_rc_net_consolidate(SCM mode);

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -172,7 +172,6 @@ SCM g_rc_scroll_wheel(SCM mode);
 SCM g_rc_net_consolidate(SCM mode);
 SCM g_rc_file_preview(SCM mode);
 SCM g_rc_enforce_hierarchy(SCM mode);
-SCM g_rc_fast_mousepan(SCM mode);
 SCM g_rc_continue_component_place(SCM mode);
 SCM g_rc_undo_levels(SCM levels);
 SCM g_rc_undo_control(SCM mode);

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -181,7 +181,6 @@ SCM g_rc_dots_grid_mode(SCM mode);
 SCM g_rc_dots_grid_fixed_threshold(SCM spacing);
 SCM g_rc_mesh_grid_display_threshold(SCM spacing);
 SCM g_rc_auto_save_interval(SCM seconds);
-SCM g_rc_keyboardpan_gain(SCM mode);
 SCM g_rc_select_slack_pixels(SCM pixels);
 SCM g_rc_scrollpan_steps(SCM steps);
 SCM g_rc_display_color_map (SCM scm_map);

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -158,7 +158,6 @@ SCM g_rc_gschem_version(SCM version);
 SCM g_rc_net_selection_mode(SCM mode);
 SCM g_rc_action_feedback_mode(SCM mode);
 SCM g_rc_logging(SCM mode);
-SCM g_rc_text_size(SCM size);
 SCM g_rc_text_caps_style(SCM mode);
 SCM g_rc_snap_size(SCM size);
 SCM g_rc_attribute_name(SCM path);

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -183,7 +183,6 @@ SCM g_rc_netconn_rubberband(SCM mode);
 SCM g_rc_magnetic_net_mode(SCM mode);
 SCM g_rc_add_menu(SCM menu_name, SCM menu_items);
 SCM g_rc_warp_cursor(SCM mode);
-SCM g_rc_handleboxes(SCM mode);
 SCM g_rc_bus_ripper_size(SCM size);
 SCM g_rc_bus_ripper_type(SCM mode);
 SCM g_rc_bus_ripper_rotation(SCM mode);

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -181,7 +181,6 @@ SCM g_rc_dots_grid_mode(SCM mode);
 SCM g_rc_dots_grid_fixed_threshold(SCM spacing);
 SCM g_rc_mesh_grid_display_threshold(SCM spacing);
 SCM g_rc_auto_save_interval(SCM seconds);
-SCM g_rc_select_slack_pixels(SCM pixels);
 SCM g_rc_scrollpan_steps(SCM steps);
 SCM g_rc_display_color_map (SCM scm_map);
 SCM g_rc_display_outline_color_map (SCM scm_map);

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -179,7 +179,6 @@ SCM g_rc_add_menu(SCM menu_name, SCM menu_items);
 SCM g_rc_bus_ripper_size(SCM size);
 SCM g_rc_bus_ripper_type(SCM mode);
 SCM g_rc_bus_ripper_rotation(SCM mode);
-SCM g_rc_force_boundingbox(SCM mode);
 SCM g_rc_grid_mode(SCM mode);
 SCM g_rc_dots_grid_dot_size(SCM dotsize);
 SCM g_rc_dots_grid_mode(SCM mode);

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -170,7 +170,6 @@ SCM g_rc_third_button_cancel(SCM mode);
 SCM g_rc_middle_button(SCM mode);
 SCM g_rc_scroll_wheel(SCM mode);
 SCM g_rc_net_consolidate(SCM mode);
-SCM g_rc_file_preview(SCM mode);
 SCM g_rc_enforce_hierarchy(SCM mode);
 SCM g_rc_undo_levels(SCM levels);
 SCM g_rc_undo_control(SCM mode);

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -174,7 +174,6 @@ SCM g_rc_bus_ripper_size(SCM size);
 SCM g_rc_bus_ripper_type(SCM mode);
 SCM g_rc_bus_ripper_rotation(SCM mode);
 SCM g_rc_grid_mode(SCM mode);
-SCM g_rc_dots_grid_dot_size(SCM dotsize);
 SCM g_rc_dots_grid_mode(SCM mode);
 SCM g_rc_dots_grid_fixed_threshold(SCM spacing);
 SCM g_rc_mesh_grid_display_threshold(SCM spacing);

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -184,7 +184,6 @@ SCM g_rc_auto_save_interval(SCM seconds);
 SCM g_rc_mousepan_gain(SCM mode);
 SCM g_rc_keyboardpan_gain(SCM mode);
 SCM g_rc_select_slack_pixels(SCM pixels);
-SCM g_rc_zoom_gain(SCM gain);
 SCM g_rc_scrollpan_steps(SCM steps);
 SCM g_rc_display_color_map (SCM scm_map);
 SCM g_rc_display_outline_color_map (SCM scm_map);

--- a/schematic/scheme/conf/schematic/options.scm
+++ b/schematic/scheme/conf/schematic/options.scm
@@ -48,13 +48,6 @@
 ; Autosaving will not be allowed if setting it to zero.
 (auto-save-interval 120)
 
-;  net-direction-mode string
-;
-;  Controls if the net direction mode is used. This mode tries to guess
-;  the best continuation direction of a L-shape net when adding a net.
-;
-(net-direction-mode "enabled")
-;(net-direction-mode "disabled")
 
 ; net-selection-mode string
 ;

--- a/schematic/scheme/conf/schematic/options.scm
+++ b/schematic/scheme/conf/schematic/options.scm
@@ -238,13 +238,6 @@
 (third-button "popup")
 ;(third-button "mousepan")
 
-; third-button-cancel string
-;
-; Controls if the third mouse in mousepan mode cancels draw actions such as
-; placing of a component or drawing of a primitive
-;
-(third-button-cancel "enabled")
-;(third-button-cancel "disabled")
 
 ; scroll-wheel string
 ;

--- a/schematic/scheme/conf/schematic/options.scm
+++ b/schematic/scheme/conf/schematic/options.scm
@@ -335,15 +335,6 @@
 ;
 (mesh-grid-display-threshold 3)
 
-; force-boundingbox string
-;
-; Controls if the entire bounding box of a symbol is used when figuring out
-; whichend of the pin is considered the active port.  Enable this when
-; gschem is guessing incorrectly.
-;
-(force-boundingbox "disabled")
-;(force-boundingbox "enabled")
-
 
 ; reset-component-library
 ;

--- a/schematic/scheme/conf/schematic/options.scm
+++ b/schematic/scheme/conf/schematic/options.scm
@@ -2,14 +2,6 @@
 ; Start of mode related keywords
 ;
 
-; handleboxes string
-;
-; Controls if the handleboxes (which contain the menu and toolbar) are
-; visible or not.
-;
-(handleboxes "enabled")
-;(handleboxes "disabled")
-
 ; undo-control string
 ;
 ; Controls if the undo is enabled or not

--- a/schematic/scheme/conf/schematic/options.scm
+++ b/schematic/scheme/conf/schematic/options.scm
@@ -207,14 +207,6 @@
 (dots-grid-mode "variable")
 ;(dots-grid-mode "fixed")
 
-; Dots grid fixed threshold
-;
-; The dots-grid-fixed-threshold specifies the minimum number of pixels
-; grid-spacing for the grid to be displayed. Using this parameter you can
-; control thedensity of the displayed grid (smaller numbers will cause the
-; grid to be drawn denser). This mode is only used when grid-mode is fixed.
-;
-(dots-grid-fixed-threshold 10)
 
 ; Mesh grid display threshold
 ;

--- a/schematic/scheme/conf/schematic/options.scm
+++ b/schematic/scheme/conf/schematic/options.scm
@@ -2,13 +2,6 @@
 ; Start of mode related keywords
 ;
 
-; toolbars string
-;
-; Controls if the toolbars are visible or not.
-;
-(toolbars "enabled")
-;(toolbars "disabled")
-
 ; handleboxes string
 ;
 ; Controls if the handleboxes (which contain the menu and toolbar) are

--- a/schematic/scheme/conf/schematic/options.scm
+++ b/schematic/scheme/conf/schematic/options.scm
@@ -208,14 +208,6 @@
 ;(dots-grid-mode "fixed")
 
 
-; Mesh grid display threshold
-;
-; The mesh-grid-display-threshold specifies the minimum line pitch for a the
-; grid to be displayed. Using this parameter you can control maximum density
-; of the displayed before the minor, then major grid-lines are switched off.
-;
-(mesh-grid-display-threshold 3)
-
 
 ; reset-component-library
 ;

--- a/schematic/scheme/conf/schematic/options.scm
+++ b/schematic/scheme/conf/schematic/options.scm
@@ -216,13 +216,6 @@
 ;(text-caps-style "lower")
 ;(text-caps-style "upper")
 
-;  file-preview string
-;
-;  Controls if the preview area in the File Open/Save As and Component
-;  dialog boxes is enabled by default or not
-;
-(file-preview "enabled")
-;(file-preview "disabled")
 
 ;  enforce-hierarchy string
 ;

--- a/schematic/scheme/conf/schematic/options.scm
+++ b/schematic/scheme/conf/schematic/options.scm
@@ -158,17 +158,6 @@
 (action-feedback-mode "outline")
 ;(action-feedback-mode "boundingbox")
 
-; continue-component-place string
-;
-; If this enabled then multiple instances of the same component can be placed
-; immediately without having to click on the name or Apply in the Component
-; Place... dialog box.  If this is disabled then only one component can be
-; placed (the user must then press Apply in the dialog box to place multiple
-; instances of the same component)
-;
-(continue-component-place "enabled")
-;(continue-component-place "disabled")
-
 
 ; embed-components string
 ;

--- a/schematic/scheme/conf/schematic/options.scm
+++ b/schematic/scheme/conf/schematic/options.scm
@@ -217,19 +217,6 @@
 ;(text-caps-style "upper")
 
 
-;  enforce-hierarchy string
-;
-;  Controls if the movement between hierarchy levels (of the same underlying
-;  schematics) is allowed or not.
-;  If this is enabled, then the user cannot (without using the page manager)
-;  move between hierarchy levels otherwise, if enabled, the user sees all
-;  the hierarchy levels as being flat.
-;
-(enforce-hierarchy "enabled")
-;(enforce-hierarchy "disabled")
-
-
-
 ; middle-button string
 ;
 ; Controls if the middle mouse button draws strokes, repeats the last

--- a/schematic/scheme/conf/schematic/options.scm
+++ b/schematic/scheme/conf/schematic/options.scm
@@ -114,12 +114,6 @@
 (log-window "later")
 
 
-; snap-size number
-;
-; Sets the default grid spacing at start-up of gschem.
-;
-(snap-size 100)
-
 ; text-caps-style string
 ;
 ; Sets the default caps style used for the input of text

--- a/schematic/scheme/conf/schematic/options.scm
+++ b/schematic/scheme/conf/schematic/options.scm
@@ -78,13 +78,6 @@
 (net-consolidate "enabled")
 ;(net-consolidate "disabled")
 
-; netconn-rubberband string
-;
-; Controls if net connections are maintained when you move a connecting
-; component or net.
-;
-(netconn-rubberband "enabled")
-;(netconn-rubberband "disabled")
 
 ; magnetic-net-mode string
 ;

--- a/schematic/scheme/conf/schematic/options.scm
+++ b/schematic/scheme/conf/schematic/options.scm
@@ -159,15 +159,6 @@
 ;(scroll-wheel "gtk")
 
 
-; scrollpan-steps integer
-;
-; Controls the number of scroll pan events required to traverse the viewed
-; schematic area. Larger numbers mean more scroll steps are required to
-; pan across the viewed area and giving finer control over positioning.
-(scrollpan-steps 8)
-;(scrollpan-steps 4) ; Hard-coded behaviour up to version 1.5.0.20080706
-
-
 ; Bus ripper controls
 ; The following keywords control the auto bus ripper addition code
 ;

--- a/schematic/scheme/conf/schematic/options.scm
+++ b/schematic/scheme/conf/schematic/options.scm
@@ -192,16 +192,6 @@
 (continue-component-place "enabled")
 ;(continue-component-place "disabled")
 
-; scrollbars string
-;
-; Controls if the scrollbars are displayed (enabled) or not (disabled)
-; If you disable the scrollbars, you will not be able to use the scroll
-; wheel on your mouse.  This is an unfortunate side effect of how the
-; code is implemented.
-;
-(scrollbars "enabled")
-;(scrollbars "disabled")
-
 
 ; embed-components string
 ;

--- a/schematic/scheme/conf/schematic/options.scm
+++ b/schematic/scheme/conf/schematic/options.scm
@@ -196,17 +196,6 @@
 ;(grid-mode "dots")
 (grid-mode "mesh")
 
-; Dots grid dot size
-;
-; The dots-grid-dot-size keyword controls the size of the grid dots in the
-; dots grid display. The units are in pixels. The default (min) value of 1
-; is the best performing as the grid dot size is rendered as a single pixel.
-; Values of 2 and 3 are good values to try if the default grid dot size is
-; too small for your tastes. Anything larger than 3 is probably too large.
-;
-(dots-grid-dot-size 1)
-;(dots-grid-dot-size 2)
-;(dots-grid-dot-size 3)
 
 ; Dots grid mode
 ;

--- a/schematic/scheme/conf/schematic/options.scm
+++ b/schematic/scheme/conf/schematic/options.scm
@@ -79,19 +79,6 @@
 ;(net-consolidate "disabled")
 
 
-; zoom-gain integer
-;
-; Controls the percentage size increase when zooming into the page.
-; Un-zooming uses the inverse factor such that a zoom in / zoom out
-; pair will return the schematic to the same size.
-;  E.g:
-;    20% increment => x 1.2 original size when zooming in
-;                  => x 1 / 1.2 x original size when zooming out
-;
-(zoom-gain 20)
-;(zoom-gain 50) ; Hard-coded behaviour up to version 1.5.0.20080706
-
-
 ; mousepan-gain integer
 ;
 ; Controls how much the display pans when using mousepan.  A larger value

--- a/schematic/scheme/conf/schematic/options.scm
+++ b/schematic/scheme/conf/schematic/options.scm
@@ -101,14 +101,6 @@
 (magnetic-net-mode "enabled")
 ;(magnetic-net-mode "disabled")
 
-; zoom-with-pan string
-;
-; Sets the zoom in and zoom out functions to pan the display and then zoom.
-; Basically zoom in / out where the mouse pointer sits on the display.
-; Comment out if you want the default mode.
-;
-(zoom-with-pan "enabled")
-;(zoom-with-pan "disabled")
 
 ; zoom-gain integer
 ;

--- a/schematic/scheme/conf/schematic/options.scm
+++ b/schematic/scheme/conf/schematic/options.scm
@@ -79,17 +79,6 @@
 ;(net-consolidate "disabled")
 
 
-; keyboardpan-gain integer
-;
-; Controls how much the display pans when using the keyboard cursor keys.
-; A larger value provides greater pan distance when pressing the cursor
-; keys, while a smaller value provides a smoother, but smaller pan
-; distance when moving the cursor keys.
-(keyboardpan-gain 20)
-;(keyboardpan-gain 10)
-;(keyboardpan-gain 1)
-;(keyboardpan-gain 5)
-
 ; select-slack-pixels integer
 ;
 ; Controls how many pixels around an object can still be clicked as part of

--- a/schematic/scheme/conf/schematic/options.scm
+++ b/schematic/scheme/conf/schematic/options.scm
@@ -79,15 +79,6 @@
 ;(net-consolidate "disabled")
 
 
-; mousepan-gain integer
-;
-; Controls how much the display pans when using mousepan.  A larger value
-; provides greater pan distance when moving the mouse, while a smaller value
-; provides a smoother, but smaller pan distance when moving the mouse.
-(mousepan-gain 1)
-;(mousepan-gain 5)
-;(mousepan-gain 10)
-
 ; keyboardpan-gain integer
 ;
 ; Controls how much the display pans when using the keyboard cursor keys.

--- a/schematic/scheme/conf/schematic/options.scm
+++ b/schematic/scheme/conf/schematic/options.scm
@@ -114,13 +114,6 @@
 (zoom-gain 20)
 ;(zoom-gain 50) ; Hard-coded behaviour up to version 1.5.0.20080706
 
-; fast-mousepan string
-;
-; Controls if text is drawn properly or if a simplified version (a line which
-; represents the text string) is drawn during mouse pan.  Drawing a simple
-; line speeds up mousepan a lot for big schematics
-;(fast-mousepan "enabled")
-(fast-mousepan "disabled")
 
 ; mousepan-gain integer
 ;

--- a/schematic/scheme/conf/schematic/options.scm
+++ b/schematic/scheme/conf/schematic/options.scm
@@ -79,17 +79,6 @@
 ;(net-consolidate "disabled")
 
 
-; select-slack-pixels integer
-;
-; Controls how many pixels around an object can still be clicked as part of
-; that object.
-; A larger value gives greater ease in selecting small, or narrow objects.
-(select-slack-pixels 10)
-;(select-slack-pixels 4)
-;(select-slack-pixels 0)
-;(select-slack-pixels 1)
-
-
 ; action-feedback-mode string
 ;
 ; Set the default action feedback mode (for copy/move/component place).

--- a/schematic/scheme/conf/schematic/options.scm
+++ b/schematic/scheme/conf/schematic/options.scm
@@ -79,15 +79,6 @@
 ;(net-consolidate "disabled")
 
 
-; magnetic-net-mode string
-;
-; Controls the initial setting of the magnetic net mode. The magnetic
-; net mode marks a possible connection that is close to the current
-; cursor position
-(magnetic-net-mode "enabled")
-;(magnetic-net-mode "disabled")
-
-
 ; zoom-gain integer
 ;
 ; Controls the percentage size increase when zooming into the page.

--- a/schematic/scheme/conf/schematic/options.scm
+++ b/schematic/scheme/conf/schematic/options.scm
@@ -258,14 +258,6 @@
 (scrollpan-steps 8)
 ;(scrollpan-steps 4) ; Hard-coded behaviour up to version 1.5.0.20080706
 
-; warp-cursor string
-;
-; Controls if the cursor is warped (or moved) when you zoom in and out.
-; Some people find this forced cursor movement annoying.
-;
-;(warp-cursor "enabled")
-(warp-cursor "disabled")
-
 
 ; Bus ripper controls
 ; The following keywords control the auto bus ripper addition code

--- a/schematic/scheme/conf/schematic/options.scm
+++ b/schematic/scheme/conf/schematic/options.scm
@@ -152,18 +152,6 @@
 ;(action-feedback-mode "boundingbox")
 
 
-; embed-components string
-;
-; Determines if the newly placed components are embedded in the schematic
-; or if only the filename is specified and the component is searched for
-; instead.  If it is enabled, then all new components will be embedded
-; otherwise they are not embedded.  This can be controlled on the fly during
-; runtime with the "Embed Component" checkbox on the select component dialog
-; box
-;
-;(embed-components "enabled")
-(embed-components "disabled")
-
 ; logging string
 ;
 ; Determines if the logging mechanism is enabled or disabled

--- a/schematic/scheme/conf/schematic/options.scm
+++ b/schematic/scheme/conf/schematic/options.scm
@@ -114,12 +114,6 @@
 (log-window "later")
 
 
-; text-size number
-;
-; Sets the default text size.
-;
-(text-size 10)
-
 ; snap-size number
 ;
 ; Sets the default grid spacing at start-up of gschem.

--- a/schematic/src/g_rc.c
+++ b/schematic/src/g_rc.c
@@ -746,31 +746,6 @@ SCM g_rc_select_slack_pixels(SCM pixels)
  *  \par Function Description
  *
  */
-SCM g_rc_zoom_gain(SCM gain)
-{
-  int val;
-
-  SCM_ASSERT (scm_is_integer (gain), gain, SCM_ARG1, "zoom-gain");
-
-  val = scm_to_int (gain);
-
-  /* Allow -ve numbers in case the user wishes to reverse zoom direction,
-   * but don't allow zero gain as this would disable the zoom action */
-  if (val == 0) {
-    fprintf(stderr, _("Invalid gain [%1$d] passed to zoom-gain\n"), val);
-    val = 20; /* absolute default */
-  }
-
-  default_zoom_gain = val;
-
-  return SCM_BOOL_T;
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
 SCM g_rc_scrollpan_steps(SCM steps)
 {
   int val;

--- a/schematic/src/g_rc.c
+++ b/schematic/src/g_rc.c
@@ -675,30 +675,6 @@ SCM g_rc_auto_save_interval(SCM seconds)
  *  \par Function Description
  *
  */
-SCM g_rc_select_slack_pixels(SCM pixels)
-{
-  int val;
-
-  SCM_ASSERT (scm_is_integer (pixels), pixels, SCM_ARG1, "select-slack-pixels");
-
-  val = scm_to_int (pixels);
-
-  if (val <= 0) {
-    fprintf(stderr, _("Invalid number of pixels [%1$d] passed to select-slack-pixels\n"),
-            val);
-    val = 4; /* absolute default */
-  }
-
-  default_select_slack_pixels = val;
-
-  return SCM_BOOL_T;
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
 SCM g_rc_scrollpan_steps(SCM steps)
 {
   int val;

--- a/schematic/src/g_rc.c
+++ b/schematic/src/g_rc.c
@@ -546,23 +546,6 @@ SCM g_rc_add_menu(SCM scm_menu_name, SCM scm_menu_items)
  *  \par Function Description
  *
  */
-SCM g_rc_warp_cursor(SCM mode)
-{
-  static const vstbl_entry mode_table[] = {
-    {TRUE , "enabled" },
-    {FALSE, "disabled"},
-  };
-
-  RETURN_G_RC_MODE("warp-cursor",
-		   default_warp_cursor,
-		   2);
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
 SCM g_rc_bus_ripper_size(SCM size)
 {
   int val;

--- a/schematic/src/g_rc.c
+++ b/schematic/src/g_rc.c
@@ -445,24 +445,6 @@ SCM g_rc_net_consolidate(SCM mode)
  *  \par Function Description
  *
  */
-SCM g_rc_file_preview(SCM mode)
-{
-  static const vstbl_entry mode_table[] = {
-    {TRUE , "enabled" },
-    {FALSE, "disabled"},
-  };
-
-  /* this variable is inconsistantly named with the rest */
-  RETURN_G_RC_MODE("file-preview",
-		   default_file_preview,
-		   2);
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
 SCM g_rc_enforce_hierarchy(SCM mode)
 {
   static const vstbl_entry mode_table[] = {

--- a/schematic/src/g_rc.c
+++ b/schematic/src/g_rc.c
@@ -347,32 +347,6 @@ SCM g_rc_third_button(SCM mode)
 		   table_size);
 }
 
-/*! \brief Verify if the third button cancel mode is set in the RC
- *         file under evaluation.
- *  \par Function Description
- *
- *  Implements the Scheme function "third-button-cancel". Tests
- *  the mode string in the argument against the third button
- *  cancel mode of the application itself.
- *
- *  \param [in] mode Scheme object containing the third button
- *                   cancel mode string
- *
- *  \returns #t if the third button cancel mode specified in the
- *              RC file matches the application, else #f.
- */
-SCM g_rc_third_button_cancel(SCM mode)
-{
-  static const vstbl_entry mode_table[] = {
-    {TRUE , "enabled" },
-    {FALSE, "disabled"},
-  };
-
-  RETURN_G_RC_MODE("third-button-cancel",
-		   default_third_button_cancel,
-		   2);
-}
-
 /*! \todo Finish function documentation!!!
  *  \brief
  *  \par Function Description

--- a/schematic/src/g_rc.c
+++ b/schematic/src/g_rc.c
@@ -623,31 +623,6 @@ SCM g_rc_auto_save_interval(SCM seconds)
   return SCM_BOOL_T;
 }
 
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
-SCM g_rc_scrollpan_steps(SCM steps)
-{
-  int val;
-
-  SCM_ASSERT (scm_is_integer (steps), steps, SCM_ARG1, "scrollpan-steps");
-
-  val = scm_to_int (steps);
-
-  /* Allow -ve numbers in case the user wishes to reverse scroll direction,
-   * but don't allow zero steps as this would cause a division by zero error */
-  if (val == 0) {
-    fprintf(stderr, _("Invalid number of steps [%1$d] scrollpan-steps\n"), val);
-    val = 8; /* absolute default */
-  }
-
-  default_scrollpan_steps = val;
-
-  return SCM_BOOL_T;
-}
-
 
 extern GedaColorMap display_colors;
 extern GedaColorMap display_outline_colors;

--- a/schematic/src/g_rc.c
+++ b/schematic/src/g_rc.c
@@ -445,23 +445,6 @@ SCM g_rc_net_consolidate(SCM mode)
  *  \par Function Description
  *
  */
-SCM g_rc_enforce_hierarchy(SCM mode)
-{
-  static const vstbl_entry mode_table[] = {
-    {TRUE , "enabled" },
-    {FALSE, "disabled"},
-  };
-
-  RETURN_G_RC_MODE("enforce-hierarchy",
-		   default_enforce_hierarchy,
-		   2);
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
 SCM g_rc_undo_levels(SCM levels)
 {
   int val;

--- a/schematic/src/g_rc.c
+++ b/schematic/src/g_rc.c
@@ -176,30 +176,6 @@ SCM g_rc_logging(SCM mode)
  *  \brief
  *  \par Function Description
  *
- */
-SCM g_rc_text_size(SCM size)
-{
-  int val;
-
-  SCM_ASSERT (scm_is_integer (size), size, SCM_ARG1, "text-size");
-
-  val = scm_to_int (size);
-  if (val < MINIMUM_TEXT_SIZE) {
-    fprintf(stderr,
-            _("Invalid size [%1$d] passed to text-size\n"),
-            val);
-    val = DEFAULT_TEXT_SIZE; /* absolute default */
-  }
-
-  default_text_size = val;
-
-  return SCM_BOOL_T;
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
  *  \todo inconsistant naming with keyword name and variable to hold
  *        variable
  */

--- a/schematic/src/g_rc.c
+++ b/schematic/src/g_rc.c
@@ -322,23 +322,6 @@ SCM g_rc_attribute_name(SCM scm_path)
  *  \par Function Description
  *
  */
-SCM g_rc_scrollbars(SCM mode)
-{
-  static const vstbl_entry mode_table[] = {
-    {TRUE , "enabled" },
-    {FALSE, "disabled"},
-  };
-
-  RETURN_G_RC_MODE("scrollbars",
-		   default_scrollbars_flag,
-		   2);
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
 SCM g_rc_log_window(SCM mode)
 {
   static const vstbl_entry mode_table[] = {

--- a/schematic/src/g_rc.c
+++ b/schematic/src/g_rc.c
@@ -197,29 +197,6 @@ SCM g_rc_text_caps_style(SCM mode)
  *  \par Function Description
  *
  */
-SCM g_rc_snap_size(SCM size)
-{
-  int val;
-
-  SCM_ASSERT (scm_is_integer (size), size, SCM_ARG1, "snap-size");
-
-  val = scm_to_int (size);
-  if (val == 0) {
-    fprintf(stderr, _("Invalid size [%1$d] passed to snap-size\n"),
-            val);
-    val = 100; /* absolute default */
-  }
-
-  default_snap_size = val;
-
-  return SCM_BOOL_T;
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
 SCM g_rc_attribute_name(SCM scm_path)
 {
   char *path;

--- a/schematic/src/g_rc.c
+++ b/schematic/src/g_rc.c
@@ -456,24 +456,6 @@ SCM g_rc_undo_panzoom(SCM mode)
  *  \par Function Description
  *
  */
-SCM g_rc_netconn_rubberband(SCM mode)
-{
-  static const vstbl_entry mode_table[] = {
-    {TRUE , "enabled" },
-    {FALSE, "disabled"},
-  };
-
-  RETURN_G_RC_MODE("netconn-rubberband",
-		   default_netconn_rubberband,
-		   2);
-}
-
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
 SCM g_rc_magnetic_net_mode(SCM mode)
 {
   static const vstbl_entry mode_table[] = {

--- a/schematic/src/g_rc.c
+++ b/schematic/src/g_rc.c
@@ -692,23 +692,6 @@ SCM g_rc_warp_cursor(SCM mode)
  *  \par Function Description
  *
  */
-SCM g_rc_toolbars(SCM mode)
-{
-  static const vstbl_entry mode_table[] = {
-    {TRUE , "enabled" },
-    {FALSE, "disabled"},
-  };
-
-  RETURN_G_RC_MODE("toolbars",
-		   default_toolbars,
-		   2);
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
 SCM g_rc_handleboxes(SCM mode)
 {
   static const vstbl_entry mode_table[] = {

--- a/schematic/src/g_rc.c
+++ b/schematic/src/g_rc.c
@@ -530,31 +530,6 @@ SCM g_rc_dots_grid_mode (SCM mode)
  *  \par Function Description
  *
  */
-SCM g_rc_mesh_grid_display_threshold (SCM spacing)
-{
-  int val;
-
-  SCM_ASSERT (scm_is_integer (spacing), spacing, SCM_ARG1,
-              "mesh-grid-display-threshold");
-
-  val = scm_to_int (spacing);
-
-  if (val <= 0) {
-    fprintf (stderr, _("Invalid pixel spacing [%1$d] passed to "
-                       "mesh-grid-display-threshold\n"), val);
-    val = 3; /* absolute default */
-  }
-
-  default_mesh_grid_display_threshold = val;
-
-  return SCM_BOOL_T;
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
 SCM g_rc_auto_save_interval(SCM seconds)
 {
   int val;

--- a/schematic/src/g_rc.c
+++ b/schematic/src/g_rc.c
@@ -675,23 +675,6 @@ SCM g_rc_warp_cursor(SCM mode)
  *  \par Function Description
  *
  */
-SCM g_rc_handleboxes(SCM mode)
-{
-  static const vstbl_entry mode_table[] = {
-    {TRUE , "enabled" },
-    {FALSE, "disabled"},
-  };
-
-  RETURN_G_RC_MODE("handleboxes",
-		   default_handleboxes,
-		   2);
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
 SCM g_rc_bus_ripper_size(SCM size)
 {
   int val;

--- a/schematic/src/g_rc.c
+++ b/schematic/src/g_rc.c
@@ -670,29 +670,6 @@ SCM g_rc_auto_save_interval(SCM seconds)
   return SCM_BOOL_T;
 }
 
-/*! \brief Scheme function for setting the step for keyboard pan.
- *
- * Default setting is 20.
- */
-SCM g_rc_keyboardpan_gain(SCM gain)
-{
-  int val;
-
-  SCM_ASSERT (scm_is_integer (gain), gain, SCM_ARG1, "keyboardpan-gain");
-
-  val = scm_to_int (gain);
-
-  if (val <= 0) {
-    fprintf(stderr, _("Invalid gain [%1$d] passed to keyboardpan-gain\n"),
-            val);
-    val = 20; /* absolute default */
-  }
-
-  default_keyboardpan_gain = val;
-
-  return SCM_BOOL_T;
-}
-
 /*! \todo Finish function documentation!!!
  *  \brief
  *  \par Function Description

--- a/schematic/src/g_rc.c
+++ b/schematic/src/g_rc.c
@@ -599,23 +599,6 @@ SCM g_rc_bus_ripper_rotation(SCM mode)
 		   2);
 }
 
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
-SCM g_rc_force_boundingbox(SCM mode)
-{
-  static const vstbl_entry mode_table[] = {
-    {TRUE,  "enabled" },
-    {FALSE, "disabled"  }
-  };
-
-  RETURN_G_RC_MODE("force-boundingbox",
-		   default_force_boundingbox,
-		   2);
-}
-
 /*! \brief Verify the grid mode set in the RC file under evaluation.
  *  \par Function Description
  *

--- a/schematic/src/g_rc.c
+++ b/schematic/src/g_rc.c
@@ -125,23 +125,6 @@ SCM g_rc_gschem_version(SCM scm_version)
  *  \par Function Description
  *
  */
-SCM g_rc_net_direction_mode(SCM mode)
-{
-  static const vstbl_entry mode_table[] = {
-    {TRUE , "enabled" },
-    {FALSE, "disabled"}
-  };
-
-  RETURN_G_RC_MODE("net-direction-mode",
-		   default_net_direction_mode,
-		   2);
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
 SCM g_rc_net_selection_mode(SCM mode)
 {
   static const vstbl_entry mode_table[] = {

--- a/schematic/src/g_rc.c
+++ b/schematic/src/g_rc.c
@@ -670,30 +670,6 @@ SCM g_rc_auto_save_interval(SCM seconds)
   return SCM_BOOL_T;
 }
 
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
-SCM g_rc_mousepan_gain(SCM gain)
-{
-  int val;
-
-  SCM_ASSERT (scm_is_integer (gain), gain, SCM_ARG1, "mousepan-gain");
-
-  val = scm_to_int (gain);
-
-  if (val <= 0) {
-    fprintf(stderr, _("Invalid gain [%1$d] passed to mousepan-gain\n"),
-            val);
-    val = 5; /* absolute default */
-  }
-
-  default_mousepan_gain = val;
-
-  return SCM_BOOL_T;
-}
-
 /*! \brief Scheme function for setting the step for keyboard pan.
  *
  * Default setting is 20.

--- a/schematic/src/g_rc.c
+++ b/schematic/src/g_rc.c
@@ -456,23 +456,6 @@ SCM g_rc_undo_panzoom(SCM mode)
  *  \par Function Description
  *
  */
-SCM g_rc_magnetic_net_mode(SCM mode)
-{
-  static const vstbl_entry mode_table[] = {
-    {TRUE , "enabled" },
-    {FALSE, "disabled"},
-  };
-
-  RETURN_G_RC_MODE("magnetic-net-mode",
-		   default_magnetic_net_mode,
-		   2);
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
 SCM g_rc_add_menu(SCM scm_menu_name, SCM scm_menu_items)
 {
   char *menu_name;

--- a/schematic/src/g_rc.c
+++ b/schematic/src/g_rc.c
@@ -177,23 +177,6 @@ SCM g_rc_action_feedback_mode(SCM mode)
  *  \par Function Description
  *
  */
-SCM g_rc_zoom_with_pan(SCM mode)
-{
-  static const vstbl_entry mode_table[] = {
-    {TRUE,  "enabled" },
-    {FALSE, "disabled"}
-  };
-
-  RETURN_G_RC_MODE("zoom-with-pan",
-		   default_zoom_with_pan,
-		   2);
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
 SCM g_rc_logging(SCM mode)
 {
   static const vstbl_entry mode_table[] = {

--- a/schematic/src/g_rc.c
+++ b/schematic/src/g_rc.c
@@ -513,30 +513,6 @@ SCM g_rc_grid_mode (SCM mode)
  *  \par Function Description
  *
  */
-SCM g_rc_dots_grid_dot_size (SCM dotsize)
-{
-  int val;
-
-  SCM_ASSERT (scm_is_integer (dotsize), dotsize, SCM_ARG1, "dots-grid-dot-size");
-
-  val = scm_to_int (dotsize);
-
-  if (val <= 0) {
-    fprintf(stderr, _("Invalid dot size [%1$d] passed to dots-grid-dot-size\n"),
-            val);
-    val = 1; /* absolute default */
-  }
-
-  default_dots_grid_dot_size = val;
-
-  return SCM_BOOL_T;
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
 SCM g_rc_dots_grid_mode (SCM mode)
 {
   static const vstbl_entry mode_table[] = {

--- a/schematic/src/g_rc.c
+++ b/schematic/src/g_rc.c
@@ -480,23 +480,6 @@ SCM g_rc_enforce_hierarchy(SCM mode)
  *  \par Function Description
  *
  */
-SCM g_rc_continue_component_place(SCM mode)
-{
-  static const vstbl_entry mode_table[] = {
-    {TRUE , "enabled" },
-    {FALSE, "disabled"},
-  };
-
-  RETURN_G_RC_MODE("continue-component-place",
-		   default_continue_component_place,
-		   2);
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
 SCM g_rc_undo_levels(SCM levels)
 {
   int val;

--- a/schematic/src/g_rc.c
+++ b/schematic/src/g_rc.c
@@ -177,23 +177,6 @@ SCM g_rc_logging(SCM mode)
  *  \par Function Description
  *
  */
-SCM g_rc_embed_components(SCM mode)
-{
-  static const vstbl_entry mode_table[] = {
-    {TRUE , "enabled" },
-    {FALSE, "disabled"}
-  };
-
-  RETURN_G_RC_MODE("embed-components",
-		   default_embed_complex,
-		   2);
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
 SCM g_rc_text_size(SCM size)
 {
   int val;

--- a/schematic/src/g_rc.c
+++ b/schematic/src/g_rc.c
@@ -480,23 +480,6 @@ SCM g_rc_enforce_hierarchy(SCM mode)
  *  \par Function Description
  *
  */
-SCM g_rc_fast_mousepan(SCM mode)
-{
-  static const vstbl_entry mode_table[] = {
-    {TRUE , "enabled" },
-    {FALSE, "disabled"},
-  };
-
-  RETURN_G_RC_MODE("fast-mousepan",
-		   default_fast_mousepan,
-		   2);
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
 SCM g_rc_continue_component_place(SCM mode)
 {
   static const vstbl_entry mode_table[] = {

--- a/schematic/src/g_rc.c
+++ b/schematic/src/g_rc.c
@@ -530,31 +530,6 @@ SCM g_rc_dots_grid_mode (SCM mode)
  *  \par Function Description
  *
  */
-SCM g_rc_dots_grid_fixed_threshold (SCM spacing)
-{
-  int val;
-
-  SCM_ASSERT (scm_is_integer (spacing), spacing, SCM_ARG1, "dots-grid-fixed-threshold");
-
-  val = scm_to_int (spacing);
-
-  if (val <= 0) {
-    fprintf(stderr, _("Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"),
-            val);
-    val = 10; /* absolute default */
-  }
-
-  default_dots_grid_fixed_threshold = val;
-
-  return SCM_BOOL_T;
-}
-
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
 SCM g_rc_mesh_grid_display_threshold (SCM spacing)
 {
   int val;

--- a/schematic/src/g_register.c
+++ b/schematic/src/g_register.c
@@ -67,7 +67,6 @@ static struct gsubr_t gschem_funcs[] = {
   { "dots-grid-mode",               1, 0, 0, (SCM (*) ()) g_rc_dots_grid_mode },
   { "dots-grid-fixed-threshold",    1, 0, 0, (SCM (*) ()) g_rc_dots_grid_fixed_threshold },
   { "mesh-grid-display-threshold",  1, 0, 0, (SCM (*) ()) g_rc_mesh_grid_display_threshold },
-  { "keyboardpan-gain",             1, 0, 0, (SCM (*) ()) g_rc_keyboardpan_gain },
   { "select-slack-pixels",          1, 0, 0, (SCM (*) ()) g_rc_select_slack_pixels },
   { "scrollpan-steps",              1, 0, 0, (SCM (*) ()) g_rc_scrollpan_steps },
 

--- a/schematic/src/g_register.c
+++ b/schematic/src/g_register.c
@@ -56,7 +56,6 @@ static struct gsubr_t gschem_funcs[] = {
   { "middle-button",                0, 1, 0, (SCM (*) ()) g_rc_middle_button },
   { "scroll-wheel",                 1, 0, 0, (SCM (*) ()) g_rc_scroll_wheel },
   { "net-consolidate",              1, 0, 0, (SCM (*) ()) g_rc_net_consolidate },
-  { "enforce-hierarchy",            1, 0, 0, (SCM (*) ()) g_rc_enforce_hierarchy },
   { "undo-levels",                  1, 0, 0, (SCM (*) ()) g_rc_undo_levels },
   { "undo-control",                 1, 0, 0, (SCM (*) ()) g_rc_undo_control },
   { "undo-type",                    1, 0, 0, (SCM (*) ()) g_rc_undo_type },

--- a/schematic/src/g_register.c
+++ b/schematic/src/g_register.c
@@ -70,7 +70,6 @@ static struct gsubr_t gschem_funcs[] = {
   { "magnetic-net-mode",            1, 0, 0, (SCM (*) ()) g_rc_magnetic_net_mode },
   { "add-menu",                     2, 0, 0, (SCM (*) ()) g_rc_add_menu },
   { "warp-cursor",                  1, 0, 0, (SCM (*) ()) g_rc_warp_cursor },
-  { "handleboxes",                  1, 0, 0, (SCM (*) ()) g_rc_handleboxes },
   { "bus-ripper-size",              1, 0, 0, (SCM (*) ()) g_rc_bus_ripper_size },
   { "bus-ripper-type",              1, 0, 0, (SCM (*) ()) g_rc_bus_ripper_type },
   { "bus-ripper-rotation",          1, 0, 0, (SCM (*) ()) g_rc_bus_ripper_rotation },

--- a/schematic/src/g_register.c
+++ b/schematic/src/g_register.c
@@ -58,7 +58,6 @@ static struct gsubr_t gschem_funcs[] = {
   { "undo-type",                    1, 0, 0, (SCM (*) ()) g_rc_undo_type },
   { "undo-panzoom",                 1, 0, 0, (SCM (*) ()) g_rc_undo_panzoom },
 
-  { "netconn-rubberband",           1, 0, 0, (SCM (*) ()) g_rc_netconn_rubberband },
   { "magnetic-net-mode",            1, 0, 0, (SCM (*) ()) g_rc_magnetic_net_mode },
   { "add-menu",                     2, 0, 0, (SCM (*) ()) g_rc_add_menu },
   { "bus-ripper-size",              1, 0, 0, (SCM (*) ()) g_rc_bus_ripper_size },

--- a/schematic/src/g_register.c
+++ b/schematic/src/g_register.c
@@ -41,7 +41,6 @@ static struct gsubr_t gschem_funcs[] = {
   { "net-selection-mode",           1, 0, 0, (SCM (*) ()) g_rc_net_selection_mode },
   { "action-feedback-mode",         1, 0, 0, (SCM (*) ()) g_rc_action_feedback_mode },
   { "logging",                      1, 0, 0, (SCM (*) ()) g_rc_logging },
-  { "text-size",                    1, 0, 0, (SCM (*) ()) g_rc_text_size },
   { "snap-size",                    1, 0, 0, (SCM (*) ()) g_rc_snap_size },
 
   { "text-caps-style",              1, 0, 0, (SCM (*) ()) g_rc_text_caps_style },

--- a/schematic/src/g_register.c
+++ b/schematic/src/g_register.c
@@ -67,7 +67,6 @@ static struct gsubr_t gschem_funcs[] = {
   { "dots-grid-mode",               1, 0, 0, (SCM (*) ()) g_rc_dots_grid_mode },
   { "dots-grid-fixed-threshold",    1, 0, 0, (SCM (*) ()) g_rc_dots_grid_fixed_threshold },
   { "mesh-grid-display-threshold",  1, 0, 0, (SCM (*) ()) g_rc_mesh_grid_display_threshold },
-  { "select-slack-pixels",          1, 0, 0, (SCM (*) ()) g_rc_select_slack_pixels },
   { "scrollpan-steps",              1, 0, 0, (SCM (*) ()) g_rc_scrollpan_steps },
 
   /* backup functions */

--- a/schematic/src/g_register.c
+++ b/schematic/src/g_register.c
@@ -40,7 +40,6 @@ static struct gsubr_t gschem_funcs[] = {
 
   { "net-direction-mode",           1, 0, 0, (SCM (*) ()) g_rc_net_direction_mode },
   { "net-selection-mode",           1, 0, 0, (SCM (*) ()) g_rc_net_selection_mode },
-  { "zoom-with-pan",                1, 0, 0, (SCM (*) ()) g_rc_zoom_with_pan },
   { "action-feedback-mode",         1, 0, 0, (SCM (*) ()) g_rc_action_feedback_mode },
   { "embed-components",             1, 0, 0, (SCM (*) ()) g_rc_embed_components },
   { "logging",                      1, 0, 0, (SCM (*) ()) g_rc_logging },

--- a/schematic/src/g_register.c
+++ b/schematic/src/g_register.c
@@ -58,7 +58,6 @@ static struct gsubr_t gschem_funcs[] = {
   { "net-consolidate",              1, 0, 0, (SCM (*) ()) g_rc_net_consolidate },
   { "file-preview",                 1, 0, 0, (SCM (*) ()) g_rc_file_preview },
   { "enforce-hierarchy",            1, 0, 0, (SCM (*) ()) g_rc_enforce_hierarchy },
-  { "continue-component-place",     1, 0, 0, (SCM (*) ()) g_rc_continue_component_place },
   { "undo-levels",                  1, 0, 0, (SCM (*) ()) g_rc_undo_levels },
   { "undo-control",                 1, 0, 0, (SCM (*) ()) g_rc_undo_control },
   { "undo-type",                    1, 0, 0, (SCM (*) ()) g_rc_undo_type },

--- a/schematic/src/g_register.c
+++ b/schematic/src/g_register.c
@@ -67,7 +67,6 @@ static struct gsubr_t gschem_funcs[] = {
   { "dots-grid-mode",               1, 0, 0, (SCM (*) ()) g_rc_dots_grid_mode },
   { "dots-grid-fixed-threshold",    1, 0, 0, (SCM (*) ()) g_rc_dots_grid_fixed_threshold },
   { "mesh-grid-display-threshold",  1, 0, 0, (SCM (*) ()) g_rc_mesh_grid_display_threshold },
-  { "mousepan-gain",                1, 0, 0, (SCM (*) ()) g_rc_mousepan_gain },
   { "keyboardpan-gain",             1, 0, 0, (SCM (*) ()) g_rc_keyboardpan_gain },
   { "select-slack-pixels",          1, 0, 0, (SCM (*) ()) g_rc_select_slack_pixels },
   { "scrollpan-steps",              1, 0, 0, (SCM (*) ()) g_rc_scrollpan_steps },

--- a/schematic/src/g_register.c
+++ b/schematic/src/g_register.c
@@ -71,7 +71,6 @@ static struct gsubr_t gschem_funcs[] = {
   { "magnetic-net-mode",            1, 0, 0, (SCM (*) ()) g_rc_magnetic_net_mode },
   { "add-menu",                     2, 0, 0, (SCM (*) ()) g_rc_add_menu },
   { "warp-cursor",                  1, 0, 0, (SCM (*) ()) g_rc_warp_cursor },
-  { "toolbars",                     1, 0, 0, (SCM (*) ()) g_rc_toolbars },
   { "handleboxes",                  1, 0, 0, (SCM (*) ()) g_rc_handleboxes },
   { "bus-ripper-size",              1, 0, 0, (SCM (*) ()) g_rc_bus_ripper_size },
   { "bus-ripper-type",              1, 0, 0, (SCM (*) ()) g_rc_bus_ripper_type },

--- a/schematic/src/g_register.c
+++ b/schematic/src/g_register.c
@@ -61,7 +61,6 @@ static struct gsubr_t gschem_funcs[] = {
   { "bus-ripper-type",              1, 0, 0, (SCM (*) ()) g_rc_bus_ripper_type },
   { "bus-ripper-rotation",          1, 0, 0, (SCM (*) ()) g_rc_bus_ripper_rotation },
   { "grid-mode",                    1, 0, 0, (SCM (*) ()) g_rc_grid_mode },
-  { "dots-grid-dot-size",           1, 0, 0, (SCM (*) ()) g_rc_dots_grid_dot_size },
   { "dots-grid-mode",               1, 0, 0, (SCM (*) ()) g_rc_dots_grid_mode },
   { "dots-grid-fixed-threshold",    1, 0, 0, (SCM (*) ()) g_rc_dots_grid_fixed_threshold },
   { "mesh-grid-display-threshold",  1, 0, 0, (SCM (*) ()) g_rc_mesh_grid_display_threshold },

--- a/schematic/src/g_register.c
+++ b/schematic/src/g_register.c
@@ -38,7 +38,6 @@ static struct gsubr_t gschem_funcs[] = {
   { "display-color-map",            0, 1, 0, (SCM (*) ()) g_rc_display_color_map },
   { "display-outline-color-map",    0, 1, 0, (SCM (*) ()) g_rc_display_outline_color_map },
 
-  { "net-direction-mode",           1, 0, 0, (SCM (*) ()) g_rc_net_direction_mode },
   { "net-selection-mode",           1, 0, 0, (SCM (*) ()) g_rc_net_selection_mode },
   { "action-feedback-mode",         1, 0, 0, (SCM (*) ()) g_rc_action_feedback_mode },
   { "embed-components",             1, 0, 0, (SCM (*) ()) g_rc_embed_components },

--- a/schematic/src/g_register.c
+++ b/schematic/src/g_register.c
@@ -40,7 +40,6 @@ static struct gsubr_t gschem_funcs[] = {
 
   { "net-selection-mode",           1, 0, 0, (SCM (*) ()) g_rc_net_selection_mode },
   { "action-feedback-mode",         1, 0, 0, (SCM (*) ()) g_rc_action_feedback_mode },
-  { "embed-components",             1, 0, 0, (SCM (*) ()) g_rc_embed_components },
   { "logging",                      1, 0, 0, (SCM (*) ()) g_rc_logging },
   { "text-size",                    1, 0, 0, (SCM (*) ()) g_rc_text_size },
   { "snap-size",                    1, 0, 0, (SCM (*) ()) g_rc_snap_size },

--- a/schematic/src/g_register.c
+++ b/schematic/src/g_register.c
@@ -42,7 +42,6 @@ static struct gsubr_t gschem_funcs[] = {
   { "net-selection-mode",           1, 0, 0, (SCM (*) ()) g_rc_net_selection_mode },
   { "zoom-with-pan",                1, 0, 0, (SCM (*) ()) g_rc_zoom_with_pan },
   { "action-feedback-mode",         1, 0, 0, (SCM (*) ()) g_rc_action_feedback_mode },
-  { "scrollbars",                   1, 0, 0, (SCM (*) ()) g_rc_scrollbars },
   { "embed-components",             1, 0, 0, (SCM (*) ()) g_rc_embed_components },
   { "logging",                      1, 0, 0, (SCM (*) ()) g_rc_logging },
   { "text-size",                    1, 0, 0, (SCM (*) ()) g_rc_text_size },

--- a/schematic/src/g_register.c
+++ b/schematic/src/g_register.c
@@ -70,7 +70,6 @@ static struct gsubr_t gschem_funcs[] = {
   { "mousepan-gain",                1, 0, 0, (SCM (*) ()) g_rc_mousepan_gain },
   { "keyboardpan-gain",             1, 0, 0, (SCM (*) ()) g_rc_keyboardpan_gain },
   { "select-slack-pixels",          1, 0, 0, (SCM (*) ()) g_rc_select_slack_pixels },
-  { "zoom-gain",                    1, 0, 0, (SCM (*) ()) g_rc_zoom_gain },
   { "scrollpan-steps",              1, 0, 0, (SCM (*) ()) g_rc_scrollpan_steps },
 
   /* backup functions */

--- a/schematic/src/g_register.c
+++ b/schematic/src/g_register.c
@@ -65,7 +65,6 @@ static struct gsubr_t gschem_funcs[] = {
   { "dots-grid-mode",               1, 0, 0, (SCM (*) ()) g_rc_dots_grid_mode },
   { "dots-grid-fixed-threshold",    1, 0, 0, (SCM (*) ()) g_rc_dots_grid_fixed_threshold },
   { "mesh-grid-display-threshold",  1, 0, 0, (SCM (*) ()) g_rc_mesh_grid_display_threshold },
-  { "scrollpan-steps",              1, 0, 0, (SCM (*) ()) g_rc_scrollpan_steps },
 
   /* backup functions */
   { "auto-save-interval",           1, 0, 0, (SCM (*) ()) g_rc_auto_save_interval },

--- a/schematic/src/g_register.c
+++ b/schematic/src/g_register.c
@@ -62,7 +62,6 @@ static struct gsubr_t gschem_funcs[] = {
   { "bus-ripper-rotation",          1, 0, 0, (SCM (*) ()) g_rc_bus_ripper_rotation },
   { "grid-mode",                    1, 0, 0, (SCM (*) ()) g_rc_grid_mode },
   { "dots-grid-mode",               1, 0, 0, (SCM (*) ()) g_rc_dots_grid_mode },
-  { "dots-grid-fixed-threshold",    1, 0, 0, (SCM (*) ()) g_rc_dots_grid_fixed_threshold },
   { "mesh-grid-display-threshold",  1, 0, 0, (SCM (*) ()) g_rc_mesh_grid_display_threshold },
 
   /* backup functions */

--- a/schematic/src/g_register.c
+++ b/schematic/src/g_register.c
@@ -66,7 +66,6 @@ static struct gsubr_t gschem_funcs[] = {
   { "bus-ripper-size",              1, 0, 0, (SCM (*) ()) g_rc_bus_ripper_size },
   { "bus-ripper-type",              1, 0, 0, (SCM (*) ()) g_rc_bus_ripper_type },
   { "bus-ripper-rotation",          1, 0, 0, (SCM (*) ()) g_rc_bus_ripper_rotation },
-  { "force-boundingbox",            1, 0, 0, (SCM (*) ()) g_rc_force_boundingbox },
   { "grid-mode",                    1, 0, 0, (SCM (*) ()) g_rc_grid_mode },
   { "dots-grid-dot-size",           1, 0, 0, (SCM (*) ()) g_rc_dots_grid_dot_size },
   { "dots-grid-mode",               1, 0, 0, (SCM (*) ()) g_rc_dots_grid_mode },

--- a/schematic/src/g_register.c
+++ b/schematic/src/g_register.c
@@ -63,7 +63,6 @@ static struct gsubr_t gschem_funcs[] = {
   { "netconn-rubberband",           1, 0, 0, (SCM (*) ()) g_rc_netconn_rubberband },
   { "magnetic-net-mode",            1, 0, 0, (SCM (*) ()) g_rc_magnetic_net_mode },
   { "add-menu",                     2, 0, 0, (SCM (*) ()) g_rc_add_menu },
-  { "warp-cursor",                  1, 0, 0, (SCM (*) ()) g_rc_warp_cursor },
   { "bus-ripper-size",              1, 0, 0, (SCM (*) ()) g_rc_bus_ripper_size },
   { "bus-ripper-type",              1, 0, 0, (SCM (*) ()) g_rc_bus_ripper_type },
   { "bus-ripper-rotation",          1, 0, 0, (SCM (*) ()) g_rc_bus_ripper_rotation },

--- a/schematic/src/g_register.c
+++ b/schematic/src/g_register.c
@@ -58,7 +58,6 @@ static struct gsubr_t gschem_funcs[] = {
   { "undo-type",                    1, 0, 0, (SCM (*) ()) g_rc_undo_type },
   { "undo-panzoom",                 1, 0, 0, (SCM (*) ()) g_rc_undo_panzoom },
 
-  { "magnetic-net-mode",            1, 0, 0, (SCM (*) ()) g_rc_magnetic_net_mode },
   { "add-menu",                     2, 0, 0, (SCM (*) ()) g_rc_add_menu },
   { "bus-ripper-size",              1, 0, 0, (SCM (*) ()) g_rc_bus_ripper_size },
   { "bus-ripper-type",              1, 0, 0, (SCM (*) ()) g_rc_bus_ripper_type },

--- a/schematic/src/g_register.c
+++ b/schematic/src/g_register.c
@@ -62,7 +62,6 @@ static struct gsubr_t gschem_funcs[] = {
   { "bus-ripper-rotation",          1, 0, 0, (SCM (*) ()) g_rc_bus_ripper_rotation },
   { "grid-mode",                    1, 0, 0, (SCM (*) ()) g_rc_grid_mode },
   { "dots-grid-mode",               1, 0, 0, (SCM (*) ()) g_rc_dots_grid_mode },
-  { "mesh-grid-display-threshold",  1, 0, 0, (SCM (*) ()) g_rc_mesh_grid_display_threshold },
 
   /* backup functions */
   { "auto-save-interval",           1, 0, 0, (SCM (*) ()) g_rc_auto_save_interval },

--- a/schematic/src/g_register.c
+++ b/schematic/src/g_register.c
@@ -58,7 +58,6 @@ static struct gsubr_t gschem_funcs[] = {
   { "net-consolidate",              1, 0, 0, (SCM (*) ()) g_rc_net_consolidate },
   { "file-preview",                 1, 0, 0, (SCM (*) ()) g_rc_file_preview },
   { "enforce-hierarchy",            1, 0, 0, (SCM (*) ()) g_rc_enforce_hierarchy },
-  { "fast-mousepan",                1, 0, 0, (SCM (*) ()) g_rc_fast_mousepan },
   { "continue-component-place",     1, 0, 0, (SCM (*) ()) g_rc_continue_component_place },
   { "undo-levels",                  1, 0, 0, (SCM (*) ()) g_rc_undo_levels },
   { "undo-control",                 1, 0, 0, (SCM (*) ()) g_rc_undo_control },

--- a/schematic/src/g_register.c
+++ b/schematic/src/g_register.c
@@ -52,7 +52,6 @@ static struct gsubr_t gschem_funcs[] = {
 
   { "log-window",                   1, 0, 0, (SCM (*) ()) g_rc_log_window },
   { "third-button",                 0, 1, 0, (SCM (*) ()) g_rc_third_button },
-  { "third-button-cancel",          1, 0, 0, (SCM (*) ()) g_rc_third_button_cancel },
   { "middle-button",                0, 1, 0, (SCM (*) ()) g_rc_middle_button },
   { "scroll-wheel",                 1, 0, 0, (SCM (*) ()) g_rc_scroll_wheel },
   { "net-consolidate",              1, 0, 0, (SCM (*) ()) g_rc_net_consolidate },

--- a/schematic/src/g_register.c
+++ b/schematic/src/g_register.c
@@ -41,7 +41,6 @@ static struct gsubr_t gschem_funcs[] = {
   { "net-selection-mode",           1, 0, 0, (SCM (*) ()) g_rc_net_selection_mode },
   { "action-feedback-mode",         1, 0, 0, (SCM (*) ()) g_rc_action_feedback_mode },
   { "logging",                      1, 0, 0, (SCM (*) ()) g_rc_logging },
-  { "snap-size",                    1, 0, 0, (SCM (*) ()) g_rc_snap_size },
 
   { "text-caps-style",              1, 0, 0, (SCM (*) ()) g_rc_text_caps_style },
 

--- a/schematic/src/g_register.c
+++ b/schematic/src/g_register.c
@@ -56,7 +56,6 @@ static struct gsubr_t gschem_funcs[] = {
   { "middle-button",                0, 1, 0, (SCM (*) ()) g_rc_middle_button },
   { "scroll-wheel",                 1, 0, 0, (SCM (*) ()) g_rc_scroll_wheel },
   { "net-consolidate",              1, 0, 0, (SCM (*) ()) g_rc_net_consolidate },
-  { "file-preview",                 1, 0, 0, (SCM (*) ()) g_rc_file_preview },
   { "enforce-hierarchy",            1, 0, 0, (SCM (*) ()) g_rc_enforce_hierarchy },
   { "undo-levels",                  1, 0, 0, (SCM (*) ()) g_rc_undo_levels },
   { "undo-control",                 1, 0, 0, (SCM (*) ()) g_rc_undo_control },

--- a/schematic/src/i_vars.c
+++ b/schematic/src/i_vars.c
@@ -190,7 +190,10 @@ void i_vars_set(GschemToplevel *w_current)
 
   gschem_options_set_net_rubber_band_mode (w_current->options, default_netconn_rubberband);
   gschem_options_set_magnetic_net_mode (w_current->options, default_magnetic_net_mode);
-  w_current->warp_cursor = default_warp_cursor;
+
+
+  cfg_read_bool ("schematic.gui", "warp-cursor",
+                 default_warp_cursor, &w_current->warp_cursor);
 
 
   cfg_read_bool ("schematic.gui", "toolbars",

--- a/schematic/src/i_vars.c
+++ b/schematic/src/i_vars.c
@@ -339,7 +339,13 @@ i_vars_set (GschemToplevel* w_current)
 
 
   w_current->dots_grid_mode              = default_dots_grid_mode;
-  w_current->dots_grid_fixed_threshold   = default_dots_grid_fixed_threshold;
+
+
+  cfg_read_int_with_check ("schematic.gui", "dots-grid-fixed-threshold",
+                           default_dots_grid_fixed_threshold, &w_current->dots_grid_fixed_threshold,
+                           &check_int_greater_0);
+
+
   w_current->mesh_grid_display_threshold = default_mesh_grid_display_threshold;
 
 

--- a/schematic/src/i_vars.c
+++ b/schematic/src/i_vars.c
@@ -333,8 +333,11 @@ i_vars_set (GschemToplevel* w_current)
   cfg_read_bool ("schematic.gui", "force-boundingbox",
                  default_force_boundingbox, &toplevel->force_boundingbox);
 
+  cfg_read_int_with_check ("schematic.gui", "dots-grid-dot-size",
+                           default_dots_grid_dot_size, &w_current->dots_grid_dot_size,
+                           &check_int_greater_0);
 
-  w_current->dots_grid_dot_size          = default_dots_grid_dot_size;
+
   w_current->dots_grid_mode              = default_dots_grid_mode;
   w_current->dots_grid_fixed_threshold   = default_dots_grid_fixed_threshold;
   w_current->mesh_grid_display_threshold = default_mesh_grid_display_threshold;

--- a/schematic/src/i_vars.c
+++ b/schematic/src/i_vars.c
@@ -160,6 +160,9 @@ check_int_greater_0 (gint val) { return val > 0; }
 static gboolean
 check_int_greater_eq_0 (gint val) { return val >= 0; }
 
+static gboolean
+check_int_text_size (gint val) { return val >= MINIMUM_TEXT_SIZE; }
+
 
 
 /* \brief Read an int configuration key, check read value.
@@ -236,7 +239,12 @@ i_vars_set (GschemToplevel* w_current)
     do_logging = default_do_logging;
   }
 
-  w_current->text_size     = default_text_size;
+
+  cfg_read_int_with_check ("schematic.gui", "text-size",
+                           default_text_size, &w_current->text_size,
+                           &check_int_text_size);
+
+
   w_current->text_caps     = default_text_caps;
 
 

--- a/schematic/src/i_vars.c
+++ b/schematic/src/i_vars.c
@@ -132,7 +132,11 @@ void i_vars_set(GschemToplevel *w_current)
   w_current->text_size     = default_text_size;
   w_current->text_caps     = default_text_caps;
 
-  w_current->net_direction_mode = default_net_direction_mode;
+
+  cfg_read_bool ("schematic.gui", "net-direction-mode",
+                 default_net_direction_mode, &w_current->net_direction_mode);
+
+
   w_current->net_selection_mode = default_net_selection_mode;
 
 

--- a/schematic/src/i_vars.c
+++ b/schematic/src/i_vars.c
@@ -125,7 +125,9 @@ i_vars_set_options (GschemOptions* opts)
                  default_netconn_rubberband, &val);
   gschem_options_set_net_rubber_band_mode (opts, val);
 
-  gschem_options_set_magnetic_net_mode (opts, default_magnetic_net_mode);
+  cfg_read_bool ("schematic.gui", "magnetic-net-mode",
+                 default_magnetic_net_mode, &val);
+  gschem_options_set_magnetic_net_mode (opts, val);
 }
 
 

--- a/schematic/src/i_vars.c
+++ b/schematic/src/i_vars.c
@@ -356,8 +356,10 @@ i_vars_set (GschemToplevel* w_current)
                            default_zoom_gain, &w_current->zoom_gain,
                            &check_int_not_0);
 
+  cfg_read_int_with_check ("schematic.gui", "scrollpan-steps",
+                           default_scrollpan_steps, &w_current->scrollpan_steps,
+                           &check_int_not_0);
 
-  w_current->scrollpan_steps = default_scrollpan_steps;
 
   toplevel->auto_save_interval = default_auto_save_interval;
 

--- a/schematic/src/i_vars.c
+++ b/schematic/src/i_vars.c
@@ -207,7 +207,10 @@ void i_vars_set(GschemToplevel *w_current)
   w_current->bus_ripper_type  = default_bus_ripper_type;
   w_current->bus_ripper_rotation  = default_bus_ripper_rotation;
 
-  toplevel->force_boundingbox  = default_force_boundingbox;
+
+  cfg_read_bool ("schematic.gui", "force-boundingbox",
+                 default_force_boundingbox, &toplevel->force_boundingbox);
+
 
   gschem_options_set_grid_mode (w_current->options, (GRID_MODE) default_grid_mode);
   w_current->dots_grid_dot_size          = default_dots_grid_dot_size;

--- a/schematic/src/i_vars.c
+++ b/schematic/src/i_vars.c
@@ -211,7 +211,14 @@ cfg_read_int_with_check (const gchar* group,
 static void
 i_vars_set_options (GschemOptions* opts)
 {
-  gschem_options_set_snap_size (opts, default_snap_size);
+//  gschem_options_set_snap_size (opts, default_snap_size);
+  gint snap_size;
+  cfg_read_int_with_check ("schematic.gui", "snap-size",
+                           default_snap_size, &snap_size,
+                           &check_int_greater_0);
+  gschem_options_set_snap_size (opts, snap_size);
+
+
   gschem_options_set_grid_mode (opts, (GRID_MODE) default_grid_mode);
 
   gboolean val = FALSE;

--- a/schematic/src/i_vars.c
+++ b/schematic/src/i_vars.c
@@ -159,7 +159,12 @@ void i_vars_set(GschemToplevel *w_current)
   toplevel->net_consolidate    = default_net_consolidate;
   w_current->file_preview       = default_file_preview;
   w_current->enforce_hierarchy  = default_enforce_hierarchy;
-  w_current->fast_mousepan      = default_fast_mousepan;
+
+
+  cfg_read_bool ("schematic.gui", "fast-mousepan",
+                 default_fast_mousepan, &w_current->fast_mousepan);
+
+
   w_current->continue_component_place = default_continue_component_place;
   w_current->undo_levels = default_undo_levels;
   w_current->undo_control = default_undo_control;

--- a/schematic/src/i_vars.c
+++ b/schematic/src/i_vars.c
@@ -325,7 +325,13 @@ i_vars_set (GschemToplevel* w_current)
   w_current->dots_grid_fixed_threshold   = default_dots_grid_fixed_threshold;
   w_current->mesh_grid_display_threshold = default_mesh_grid_display_threshold;
 
-  w_current->mousepan_gain = default_mousepan_gain;
+
+  cfg_read_int_with_check ("schematic.gui", "mousepan-gain",
+                           default_mousepan_gain, &w_current->mousepan_gain,
+                           &check_int_greater_0,
+                           _("Invalid mousepan-gain (%d) is set in configuration\n"));
+
+
   w_current->keyboardpan_gain = default_keyboardpan_gain;
 
   w_current->select_slack_pixels = default_select_slack_pixels;

--- a/schematic/src/i_vars.c
+++ b/schematic/src/i_vars.c
@@ -18,8 +18,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 #include <config.h>
-#include <stdio.h>
-
 #include "gschem.h"
 
 /* Absolute default used when default_... strings are NULL */
@@ -157,8 +155,8 @@ check_int_not_0 (gint val) { return val != 0; }
 static gboolean
 check_int_greater_0 (gint val) { return val > 0; }
 
-static gboolean
-check_int_greater_eq_0 (gint val) { return val >= 0; }
+/* static gboolean
+check_int_greater_eq_0 (gint val) { return val >= 0; } */
 
 static gboolean
 check_int_text_size (gint val) { return val >= MINIMUM_TEXT_SIZE; }
@@ -211,8 +209,7 @@ cfg_read_int_with_check (const gchar* group,
 static void
 i_vars_set_options (GschemOptions* opts)
 {
-//  gschem_options_set_snap_size (opts, default_snap_size);
-  gint snap_size;
+  gint snap_size = 0;
   cfg_read_int_with_check ("schematic.gui", "snap-size",
                            default_snap_size, &snap_size,
                            &check_int_greater_0);
@@ -297,7 +294,6 @@ i_vars_set (GschemToplevel* w_current)
   cfg_read_bool ("schematic.gui", "enforce-hierarchy",
                  default_enforce_hierarchy, &w_current->enforce_hierarchy);
 
-
   cfg_read_bool ("schematic.gui", "fast-mousepan",
                  default_fast_mousepan, &w_current->fast_mousepan);
 
@@ -317,10 +313,8 @@ i_vars_set (GschemToplevel* w_current)
   cfg_read_bool ("schematic.gui", "warp-cursor",
                  default_warp_cursor, &w_current->warp_cursor);
 
-
   cfg_read_bool ("schematic.gui", "toolbars",
                  default_toolbars, &w_current->toolbars);
-
 
   cfg_read_bool ("schematic.gui", "handleboxes",
                  default_handleboxes, &w_current->handleboxes);
@@ -345,9 +339,9 @@ i_vars_set (GschemToplevel* w_current)
                            default_dots_grid_fixed_threshold, &w_current->dots_grid_fixed_threshold,
                            &check_int_greater_0);
 
-
-  w_current->mesh_grid_display_threshold = default_mesh_grid_display_threshold;
-
+  cfg_read_int_with_check ("schematic.gui", "mesh-grid-display-threshold",
+                           default_mesh_grid_display_threshold, &w_current->mesh_grid_display_threshold,
+                           &check_int_greater_0);
 
   cfg_read_int_with_check ("schematic.gui", "mousepan-gain",
                            default_mousepan_gain, &w_current->mousepan_gain,

--- a/schematic/src/i_vars.c
+++ b/schematic/src/i_vars.c
@@ -135,7 +135,11 @@ void i_vars_set(GschemToplevel *w_current)
   w_current->net_direction_mode = default_net_direction_mode;
   w_current->net_selection_mode = default_net_selection_mode;
 
-  w_current->zoom_with_pan           = default_zoom_with_pan;
+
+  cfg_read_bool ("schematic.gui", "zoom-with-pan",
+                 default_zoom_with_pan, &w_current->zoom_with_pan);
+
+
   w_current->actionfeedback_mode     = default_actionfeedback_mode;
 
 

--- a/schematic/src/i_vars.c
+++ b/schematic/src/i_vars.c
@@ -162,8 +162,8 @@ void i_vars_set(GschemToplevel *w_current)
   cfg_read_bool ("schematic.gui", "file-preview",
                  default_file_preview, &w_current->file_preview);
 
-
-  w_current->enforce_hierarchy  = default_enforce_hierarchy;
+  cfg_read_bool ("schematic.gui", "enforce-hierarchy",
+                 default_enforce_hierarchy, &w_current->enforce_hierarchy);
 
 
   cfg_read_bool ("schematic.gui", "fast-mousepan",

--- a/schematic/src/i_vars.c
+++ b/schematic/src/i_vars.c
@@ -114,12 +114,21 @@ cfg_read_bool (const gchar* group,
 
 
 
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
+static void
+i_vars_set_options (GschemOptions* opts)
+{
+  gschem_options_set_snap_size (opts, default_snap_size);
+  gschem_options_set_grid_mode (opts, (GRID_MODE) default_grid_mode);
+  gschem_options_set_net_rubber_band_mode (opts, default_netconn_rubberband);
+  gschem_options_set_magnetic_net_mode (opts, default_magnetic_net_mode);
+}
+
+
+
+/*! \brief Read configuration and set toplevel options appropriately.
  */
-void i_vars_set(GschemToplevel *w_current)
+void
+i_vars_set (GschemToplevel* w_current)
 {
   TOPLEVEL *toplevel = gschem_toplevel_get_toplevel (w_current);
   i_vars_libgeda_set(toplevel);
@@ -155,7 +164,6 @@ void i_vars_set(GschemToplevel *w_current)
 
 
   w_current->include_complex = default_include_complex;
-  gschem_options_set_snap_size (w_current->options, default_snap_size);
   w_current->log_window      = default_log_window;
 
   w_current->third_button       = default_third_button;
@@ -193,11 +201,6 @@ void i_vars_set(GschemToplevel *w_current)
   cfg_read_bool ("schematic.gui", "draw-grips",
                  default_draw_grips, &w_current->draw_grips);
 
-
-  gschem_options_set_net_rubber_band_mode (w_current->options, default_netconn_rubberband);
-  gschem_options_set_magnetic_net_mode (w_current->options, default_magnetic_net_mode);
-
-
   cfg_read_bool ("schematic.gui", "warp-cursor",
                  default_warp_cursor, &w_current->warp_cursor);
 
@@ -218,7 +221,6 @@ void i_vars_set(GschemToplevel *w_current)
                  default_force_boundingbox, &toplevel->force_boundingbox);
 
 
-  gschem_options_set_grid_mode (w_current->options, (GRID_MODE) default_grid_mode);
   w_current->dots_grid_dot_size          = default_dots_grid_dot_size;
   w_current->dots_grid_mode              = default_dots_grid_mode;
   w_current->dots_grid_fixed_threshold   = default_dots_grid_fixed_threshold;
@@ -232,6 +234,9 @@ void i_vars_set(GschemToplevel *w_current)
   w_current->scrollpan_steps = default_scrollpan_steps;
 
   toplevel->auto_save_interval = default_auto_save_interval;
+
+
+  i_vars_set_options (w_current->options);
 }
 
 

--- a/schematic/src/i_vars.c
+++ b/schematic/src/i_vars.c
@@ -119,7 +119,12 @@ i_vars_set_options (GschemOptions* opts)
 {
   gschem_options_set_snap_size (opts, default_snap_size);
   gschem_options_set_grid_mode (opts, (GRID_MODE) default_grid_mode);
-  gschem_options_set_net_rubber_band_mode (opts, default_netconn_rubberband);
+
+  gboolean val = FALSE;
+  cfg_read_bool ("schematic.gui", "netconn-rubberband",
+                 default_netconn_rubberband, &val);
+  gschem_options_set_net_rubber_band_mode (opts, val);
+
   gschem_options_set_magnetic_net_mode (opts, default_magnetic_net_mode);
 }
 

--- a/schematic/src/i_vars.c
+++ b/schematic/src/i_vars.c
@@ -81,48 +81,35 @@ int default_scrollpan_steps = 8;
 
 
 
-/* \brief Read [schematic.gui]::draw-grips, set w_current->draw_grips.
+/* \brief Read a boolean configuration key.
+ *
+ * \par Function Description
+ * On success, set \a result to the value of the
+ * configuration key, otherwise set it to \a defval.
+ *
+ * \param [in]       group   Configuration group name
+ * \param [in]       key     Configuration key name
+ * \param [in]       defval  Default value
+ * \param [in, out]  result  Result
  */
-static void
-cfg_read_draw_grips (GschemToplevel* w_current)
+static gboolean
+cfg_read_bool (const gchar* group,
+               const gchar* key,
+               gboolean     defval,
+               gboolean*    result)
 {
-  gchar* cwd = g_get_current_dir();
+  gchar*     cwd = g_get_current_dir();
   EdaConfig* cfg = eda_config_get_context_for_path (cwd);
   g_free (cwd);
 
-  GError* err = NULL;
-  gboolean val =
-    eda_config_get_boolean (cfg, "schematic.gui", "draw-grips", &err);
+  GError*  err = NULL;
+  gboolean val = eda_config_get_boolean (cfg, group, key, &err);
 
-  if (err == NULL)
-    w_current->draw_grips = val;
-  else
-    w_current->draw_grips = default_draw_grips;
-
+  gboolean success = err == NULL;
   g_clear_error (&err);
-}
 
-
-
-/* \brief Read [schematic.gui]::toolbars, set w_current->toolbars.
- */
-static void
-cfg_read_toolbars (GschemToplevel* w_current)
-{
-  gchar* cwd = g_get_current_dir();
-  EdaConfig* cfg = eda_config_get_context_for_path (cwd);
-  g_free (cwd);
-
-  GError* err = NULL;
-  gboolean val =
-    eda_config_get_boolean (cfg, "schematic.gui", "toolbars", &err);
-
-  if (err == NULL)
-    w_current->toolbars = val;
-  else
-    w_current->toolbars = default_toolbars;
-
-  g_clear_error (&err);
+  *result = success ? val : defval;
+  return success;
 }
 
 
@@ -172,7 +159,8 @@ void i_vars_set(GschemToplevel *w_current)
   w_current->undo_panzoom = default_undo_panzoom;
 
 
-  cfg_read_draw_grips (w_current);
+  cfg_read_bool ("schematic.gui", "draw-grips",
+                 default_draw_grips, &w_current->draw_grips);
 
 
   gschem_options_set_net_rubber_band_mode (w_current->options, default_netconn_rubberband);
@@ -180,7 +168,8 @@ void i_vars_set(GschemToplevel *w_current)
   w_current->warp_cursor = default_warp_cursor;
 
 
-  cfg_read_toolbars (w_current);
+  cfg_read_bool ("schematic.gui", "toolbars",
+                 default_toolbars, &w_current->toolbars);
 
 
   w_current->handleboxes = default_handleboxes;

--- a/schematic/src/i_vars.c
+++ b/schematic/src/i_vars.c
@@ -169,14 +169,13 @@ check_int_greater_eq_0 (gint val) { return val >= 0; }
  * configuration key, otherwise set it to \a defval.
  * Also, check read value with pfn_check() function, and
  * if it returns FALSE, reset \a result to \a defval and
- * print \a errmsg (substituting a value in it) to STDERR.
+ * print an error message to STDERR.
  *
  * \param [in]       group      Configuration group name
  * \param [in]       key        Configuration key name
  * \param [in]       defval     Default value
  * \param [in, out]  result     Result
  * \param [in]       pfn_check  Function to check if value is valid
- * \param [in]       errmsg     Error mesage format string with single %d
  *
  * \return  TRUE if a specified config parameter was successfully read
  */
@@ -185,8 +184,7 @@ cfg_read_int_with_check (const gchar* group,
                          const gchar* key,
                          gint         defval,
                          gint*        result,
-                         gboolean     (*pfn_check)(int),
-                         const gchar* errmsg)
+                         gboolean     (*pfn_check)(int))
 {
   gint val = 0;
   gboolean success = cfg_read_int (group, key, defval, &val);
@@ -198,7 +196,8 @@ cfg_read_int_with_check (const gchar* group,
   else
   {
     *result = defval;
-    fprintf (stderr, errmsg, val);
+    const gchar* errmsg = _("Invalid [%s]::%s (%d) is set in configuration\n");
+    fprintf (stderr, errmsg, group, key, val);
   }
 
   return success;
@@ -328,8 +327,7 @@ i_vars_set (GschemToplevel* w_current)
 
   cfg_read_int_with_check ("schematic.gui", "mousepan-gain",
                            default_mousepan_gain, &w_current->mousepan_gain,
-                           &check_int_greater_0,
-                           _("Invalid mousepan-gain (%d) is set in configuration\n"));
+                           &check_int_greater_0);
 
 
   w_current->keyboardpan_gain = default_keyboardpan_gain;
@@ -339,8 +337,7 @@ i_vars_set (GschemToplevel* w_current)
 
   cfg_read_int_with_check ("schematic.gui", "zoom-gain",
                            default_zoom_gain, &w_current->zoom_gain,
-                           &check_int_not_0,
-                           _("Invalid zoom-gain (%d) is set in configuration\n"));
+                           &check_int_not_0);
 
 
   w_current->scrollpan_steps = default_scrollpan_steps;

--- a/schematic/src/i_vars.c
+++ b/schematic/src/i_vars.c
@@ -150,8 +150,10 @@ void i_vars_set(GschemToplevel *w_current)
   cfg_read_bool ("schematic.gui", "scrollbars",
                  default_scrollbars_flag, &w_current->scrollbars_flag);
 
+  cfg_read_bool ("schematic.gui", "embed-components",
+                 default_embed_complex, &w_current->embed_complex);
 
-  w_current->embed_complex   = default_embed_complex;
+
   w_current->include_complex = default_include_complex;
   gschem_options_set_snap_size (w_current->options, default_snap_size);
   w_current->log_window      = default_log_window;

--- a/schematic/src/i_vars.c
+++ b/schematic/src/i_vars.c
@@ -157,7 +157,12 @@ void i_vars_set(GschemToplevel *w_current)
   w_current->middle_button      = default_middle_button;
   w_current->scroll_wheel       = default_scroll_wheel;
   toplevel->net_consolidate    = default_net_consolidate;
-  w_current->file_preview       = default_file_preview;
+
+
+  cfg_read_bool ("schematic.gui", "file-preview",
+                 default_file_preview, &w_current->file_preview);
+
+
   w_current->enforce_hierarchy  = default_enforce_hierarchy;
 
 

--- a/schematic/src/i_vars.c
+++ b/schematic/src/i_vars.c
@@ -176,7 +176,8 @@ void i_vars_set(GschemToplevel *w_current)
                  default_toolbars, &w_current->toolbars);
 
 
-  w_current->handleboxes = default_handleboxes;
+  cfg_read_bool ("schematic.gui", "handleboxes",
+                 default_handleboxes, &w_current->handleboxes);
 
   w_current->bus_ripper_size  = default_bus_ripper_size;
   w_current->bus_ripper_type  = default_bus_ripper_type;

--- a/schematic/src/i_vars.c
+++ b/schematic/src/i_vars.c
@@ -329,16 +329,13 @@ i_vars_set (GschemToplevel* w_current)
                            default_mousepan_gain, &w_current->mousepan_gain,
                            &check_int_greater_0);
 
-
-
   cfg_read_int_with_check ("schematic.gui", "keyboardpan-gain",
                            default_keyboardpan_gain, &w_current->keyboardpan_gain,
                            &check_int_greater_0);
 
-
-
-  w_current->select_slack_pixels = default_select_slack_pixels;
-
+  cfg_read_int_with_check ("schematic.gui", "select-slack-pixels",
+                           default_select_slack_pixels, &w_current->select_slack_pixels,
+                           &check_int_greater_0);
 
   cfg_read_int_with_check ("schematic.gui", "zoom-gain",
                            default_zoom_gain, &w_current->zoom_gain,

--- a/schematic/src/i_vars.c
+++ b/schematic/src/i_vars.c
@@ -164,8 +164,10 @@ void i_vars_set(GschemToplevel *w_current)
   cfg_read_bool ("schematic.gui", "fast-mousepan",
                  default_fast_mousepan, &w_current->fast_mousepan);
 
+  cfg_read_bool ("schematic.gui", "continue-component-place",
+                 default_continue_component_place, &w_current->continue_component_place);
 
-  w_current->continue_component_place = default_continue_component_place;
+
   w_current->undo_levels = default_undo_levels;
   w_current->undo_control = default_undo_control;
   w_current->undo_type = default_undo_type;

--- a/schematic/src/i_vars.c
+++ b/schematic/src/i_vars.c
@@ -137,7 +137,11 @@ void i_vars_set(GschemToplevel *w_current)
 
   w_current->zoom_with_pan           = default_zoom_with_pan;
   w_current->actionfeedback_mode     = default_actionfeedback_mode;
-  w_current->scrollbars_flag         = default_scrollbars_flag;
+
+
+  cfg_read_bool ("schematic.gui", "scrollbars",
+                 default_scrollbars_flag, &w_current->scrollbars_flag);
+
 
   w_current->embed_complex   = default_embed_complex;
   w_current->include_complex = default_include_complex;

--- a/schematic/src/i_vars.c
+++ b/schematic/src/i_vars.c
@@ -91,13 +91,36 @@ cfg_read_draw_grips (GschemToplevel* w_current)
   g_free (cwd);
 
   GError* err = NULL;
-  gboolean draw_grips =
+  gboolean val =
     eda_config_get_boolean (cfg, "schematic.gui", "draw-grips", &err);
 
   if (err == NULL)
-    w_current->draw_grips = draw_grips;
+    w_current->draw_grips = val;
   else
     w_current->draw_grips = default_draw_grips;
+
+  g_clear_error (&err);
+}
+
+
+
+/* \brief Read [schematic.gui]::toolbars, set w_current->toolbars.
+ */
+static void
+cfg_read_toolbars (GschemToplevel* w_current)
+{
+  gchar* cwd = g_get_current_dir();
+  EdaConfig* cfg = eda_config_get_context_for_path (cwd);
+  g_free (cwd);
+
+  GError* err = NULL;
+  gboolean val =
+    eda_config_get_boolean (cfg, "schematic.gui", "toolbars", &err);
+
+  if (err == NULL)
+    w_current->toolbars = val;
+  else
+    w_current->toolbars = default_toolbars;
 
   g_clear_error (&err);
 }
@@ -155,7 +178,11 @@ void i_vars_set(GschemToplevel *w_current)
   gschem_options_set_net_rubber_band_mode (w_current->options, default_netconn_rubberband);
   gschem_options_set_magnetic_net_mode (w_current->options, default_magnetic_net_mode);
   w_current->warp_cursor = default_warp_cursor;
-  w_current->toolbars = default_toolbars;
+
+
+  cfg_read_toolbars (w_current);
+
+
   w_current->handleboxes = default_handleboxes;
 
   w_current->bus_ripper_size  = default_bus_ripper_size;

--- a/schematic/src/i_vars.c
+++ b/schematic/src/i_vars.c
@@ -330,7 +330,12 @@ i_vars_set (GschemToplevel* w_current)
                            &check_int_greater_0);
 
 
-  w_current->keyboardpan_gain = default_keyboardpan_gain;
+
+  cfg_read_int_with_check ("schematic.gui", "keyboardpan-gain",
+                           default_keyboardpan_gain, &w_current->keyboardpan_gain,
+                           &check_int_greater_0);
+
+
 
   w_current->select_slack_pixels = default_select_slack_pixels;
 

--- a/schematic/src/i_vars.c
+++ b/schematic/src/i_vars.c
@@ -153,7 +153,12 @@ void i_vars_set(GschemToplevel *w_current)
   w_current->log_window      = default_log_window;
 
   w_current->third_button       = default_third_button;
-  w_current->third_button_cancel= default_third_button_cancel;
+
+
+  cfg_read_bool ("schematic.gui", "file-preview",
+                 default_third_button_cancel, &w_current->third_button_cancel);
+
+
   w_current->middle_button      = default_middle_button;
   w_current->scroll_wheel       = default_scroll_wheel;
   toplevel->net_consolidate    = default_net_consolidate;


### PR DESCRIPTION
Convert most of the `bool` and `int` keys
to new configuration system, deprecate `gschemrc`
options with the same names.
The new keys are named after their deprecated
counterparts.
The following 25 new keys are added
to the `schematic::gui` group (for convenience,
the numbers in the list are the same as in #423;
show data types and default values in parenthesis):

1. toolbars: bool (true)
2. scrollbars: bool (true)
3. handleboxes: bool (true)
5. zoom-with-pan: bool (true)
6. zoom-gain: int (20)
7. fast-mousepan: bool (false)
8. mousepan-gain: int (1)
9. keyboardpan-gain: int (20)
10. select-slack-pixels: int (10)
12. continue-component-place: bool (true)
13. text-size: int (10)
14. snap-size: int (100)
16. file-preview: bool (true)
17. enforce-hierarchy: bool (true)
20. third-button-cancel: bool (true)
22. scrollpan-steps: int (8)
23. warp-cursor: bool (false)
26. dots-grid-dot-size: int (1)
27. dots-grid-fixed-threshold: int (10)
28. mesh-grid-display-threshold: int (3)
29. force-boundingbox: bool (false)
30. net-direction-mode: bool (true)
32. netconn-rubberband: bool (true)
33. magnetic-net-mode: bool (true)
34. embed-components: bool (false)
