### PR TITLE
Get rid of an unused page field (and get rid of GTimeVal warnings)

### DIFF
--- a/liblepton/include/liblepton/geda_page.h
+++ b/liblepton/include/liblepton/geda_page.h
@@ -55,7 +55,6 @@ struct st_page
   int page_control;
 
   /* backup variables */
-  GTimeVal last_load_or_save_time;
   char saved_since_first_loaded;
   gint ops_since_last_backup;
   gchar do_autosave_backup;

--- a/liblepton/src/f_basic.c
+++ b/liblepton/src/f_basic.c
@@ -452,7 +452,6 @@ int f_save(TOPLEVEL *toplevel, PAGE *page, const char *filename, GError **err)
     page->saved_since_first_loaded = 1;
 
     /* Reset the last saved timer */
-    g_get_current_time (&page->last_load_or_save_time);
     page->ops_since_last_backup = 0;
     page->do_autosave_backup = 0;
 

--- a/liblepton/src/geda_page.c
+++ b/liblepton/src/geda_page.c
@@ -146,7 +146,6 @@ PAGE *s_page_new (TOPLEVEL *toplevel, const gchar *filename)
   page->weak_refs = NULL;
 
   /* Backup variables */
-  g_get_current_time (&page->last_load_or_save_time);
   page->ops_since_last_backup = 0;
   page->saved_since_first_loaded = 0;
   page->do_autosave_backup = 0;


### PR DESCRIPTION
This commit also fixes GTimeVal issue. Quote:

  GTimeVal and g_get_current_time() are not year-2038-safe and have
  been deprecated; use GDateTime and g_get_real_time() instead.

The user can watch the deprecation warnings during compilation since Glib 2.61.2.