### PR TITLE
Fix pinseq attributes generation in lepton-tragesym

### DIFF
--- a/utils/examples/tragesym/.gitignore
+++ b/utils/examples/tragesym/.gitignore
@@ -1,3 +1,4 @@
 Makefile
 Makefile.in
 *~
+*.sym

--- a/utils/examples/tragesym/4099.src
+++ b/utils/examples/tragesym/4099.src
@@ -6,7 +6,7 @@
 wordswap=yes
 rotate_labels=no
 sort_labels=no
-generate_pinseq=yes
+generate_pinseq=no
 sym_width=1400
 pinwidthvertical=400
 pinwidthhorizontal=400
@@ -33,7 +33,7 @@ numslots=0
 
 [pins]
 #-----------------------------------------------------
-#pinnr	seq	type	style	posit.	net	label	
+#pinnr	seq	type	style	posit.	net	label
 #-----------------------------------------------------
 5		in	line	l		A0
 6		in	line	l		A1

--- a/utils/examples/tragesym/AT90S8535_TQFP.src
+++ b/utils/examples/tragesym/AT90S8535_TQFP.src
@@ -6,7 +6,7 @@
 wordswap=yes
 rotate_labels=no
 sort_labels=yes
-generate_pinseq=yes
+generate_pinseq=no
 sym_width=2600
 pinwidthvertical=400
 pinwidthhorizontal=500
@@ -31,7 +31,7 @@ numslots=0
 
 [pins]
 #-----------------------------------------------------
-#pinnr	seq	type	style	posit.	net	label	
+#pinnr	seq	type	style	posit.	net	label
 #-----------------------------------------------------
 1		io	line	l		PB5 (MOSI)
 2		io	line	l		PB6 (MISO)

--- a/utils/examples/tragesym/alltest
+++ b/utils/examples/tragesym/alltest
@@ -1,13 +1,25 @@
 #!/bin/sh
 
 # run tragesym over all test and example files
+
+exe=../../scripts/lepton-tragesym
+
 echo testing 4099.src
-../../scripts/tragesym 4099.src 4099.sym
+$exe 4099.src 4099.sym
+echo
+
 echo testing test1.src
-../../scripts/tragesym test1.src test1.sym
+$exe  test1.src test1.sym
+echo
+
 echo testing test2.src
-../../scripts/tragesym test2.src test2.sym
+$exe  test2.src test2.sym
+echo
+
 echo testing test3.src
-../../scripts/tragesym test3.src test3.sym
+$exe  test3.src test3.sym
+echo
+
 echo testing AT90S8535_TQFP.src
-../../scripts/tragesym AT90S8535_TQFP.src AT90S8535_TQFP.sym
+$exe  AT90S8535_TQFP.src AT90S8535_TQFP.sym
+echo

--- a/utils/examples/tragesym/template.src
+++ b/utils/examples/tragesym/template.src
@@ -51,8 +51,8 @@ numslots=0
 # posit. can be (l,r,t,b) or empty for nets.
 # net specifies the name of the net. Vcc or GND for example.
 # label represents the pinlabel.
-#	negation lines can be added with "\_" example: \_enable\_ 
+#	negation lines can be added with "\_" example: \_enable\_
 #	if you want to write a "\" use "\\" as escape sequence
 #-----------------------------------------------------
-#pinnr	seq	type	style	posit.	net	label	
+#pinnr	seq	type	style	posit.	net	label
 #-----------------------------------------------------

--- a/utils/examples/tragesym/test1.src
+++ b/utils/examples/tragesym/test1.src
@@ -6,7 +6,7 @@
 wordswap=yes
 rotate_labels=no
 sort_labels=yes
-generate_pinseq=no
+generate_pinseq=yes
 sym_width=2600
 pinwidthvertical=400
 pinwidthhorizontal=600
@@ -34,7 +34,7 @@ comment=blablub
 
 [pins]
 #-----------------------------------------------------
-#pinnr	seq	type	style	posit.	net	label	
+#pinnr	seq	type	style	posit.	net	label
 #-----------------------------------------------------
 1	21	i	line	l		hello
 2	20	o	clk	l		\_neg\_

--- a/utils/examples/tragesym/test2.src
+++ b/utils/examples/tragesym/test2.src
@@ -6,7 +6,7 @@
 wordswap	yes
 rotate_labels	no
 sort_labels	no
-generate_pinseq	yes
+generate_pinseq	no
 sym_width	2600
 pinwidthvertical	400
 pinwidthhorizontal	800
@@ -31,7 +31,7 @@ comment	comment3
 
 [pins]
 #-----------------------------------------------------
-#pinnr	seq	type	style	posit.	net	label	
+#pinnr	seq	type	style	posit.	net	label
 #-----------------------------------------------------
 1		io	line	l		hello
 2		out	clk	l		\_neg\_

--- a/utils/examples/tragesym/test3.src
+++ b/utils/examples/tragesym/test3.src
@@ -6,7 +6,7 @@
 wordswap=yes
 rotate_labels=yes
 sort_labels=yes
-generate_pinseq=yes
+generate_pinseq=no
 sym_width=2200
 pinwidthvertical=400
 pinwidthhorizontal=400
@@ -31,7 +31,7 @@ numslots=0
 
 [pins]
 #-----------------------------------------------------
-#pinnr	seq	type	style	posit.	net	label	
+#pinnr	seq	type	style	posit.	net	label
 #-----------------------------------------------------
 1		io	line	l		hello
 2		out	clk	l		\_neg\_

--- a/utils/scripts/lepton-tragesym.in
+++ b/utils/scripts/lepton-tragesym.in
@@ -847,11 +847,10 @@ Based on original \"tragesym\" version
     (and (not (string= (pin-style pin) "none"))
          (not (string= (pin-style pin) "spacer"))))
 
-  (let loop ((filtered-pins (filter pin-with-pinseq? pins))
-             (pinseq 1))
+  (let loop ((filtered-pins (filter pin-with-pinseq? pins)))
     (and (not (null? filtered-pins))
-         (set-pin-seq! (car filtered-pins) pinseq)
-         (loop (cdr filtered-pins) (1+ pinseq))))
+         (set-pin-seq! (car filtered-pins) (pin-seq (car filtered-pins)))
+         (loop (cdr filtered-pins))))
   ;; Return value.
   pins)
 


### PR DESCRIPTION
If `generate_pinseq` is set to `yes` in the template
file, add `pinseq` attributes to generated pins,
using values defined in the `[pins]` section.
Discussed in #492. 