### PR TITLE
Rename and move the Scheme auto-load directory

### DIFF
--- a/liblepton/lib/system-gafrc
+++ b/liblepton/lib/system-gafrc
@@ -1,5 +1,5 @@
 ;                                                         -*-Scheme-*-
-;;; 
+;;;
 ;;; Common init file for gaf
 ;;;
 
@@ -38,14 +38,14 @@
 
 ;
 ; Start of attribute promotion keywords
-; 
+;
 
 ; attribute-promotion string
 ;
 ; This keyword controls if attribute promotion occurs when you instanciate a
 ; component.  Attribute promotion basically means that any floating attribute
-; (unattached) which is inside a symbol gets "promoted" or attached to the 
-; newly inserted component.  This only occurs when the component is 
+; (unattached) which is inside a symbol gets "promoted" or attached to the
+; newly inserted component.  This only occurs when the component is
 ; instanciated.
 ;
 (attribute-promotion "enabled")
@@ -54,8 +54,8 @@
 ; promote-invisible string
 ;
 ; If attribute-promotion is enabled, then this controls if invisible floating
-; attributes are promoted (attached to the outside of the component) if the 
-; text string is invisible.  There are cases where it is undesirable, so the 
+; attributes are promoted (attached to the outside of the component) if the
+; text string is invisible.  There are cases where it is undesirable, so the
 ; default is disabled.
 ;
 ;(promote-invisible "enabled")
@@ -63,11 +63,11 @@
 
 ; keep-invisible string
 ;
-; If both attribute-promotion and promote-invisible are enabled, then this 
+; If both attribute-promotion and promote-invisible are enabled, then this
 ; controls if invisible floating attributes are kept around in memory and
 ; NOT deleted.  Having this enabled will keeps component slotting working.
 ; If attribute-promotion and promote-invisible are enabled and this
-; keyword is disabled, then component slotting will NOT work (and maybe 
+; keyword is disabled, then component slotting will NOT work (and maybe
 ; other functions which depend on hidden attributes, since those attributes
 ; are deleted from memory).
 ;
@@ -85,7 +85,7 @@
 
 ;
 ; End of attribute promotion keywords
-; 
+;
 
 ; make-backup-files
 ;

--- a/liblepton/lib/system-gafrc
+++ b/liblepton/lib/system-gafrc
@@ -114,7 +114,7 @@
 ;;;; Process configuration script directory
 
 ;; The directory containing any extra scheme files to load
-(define geda-confd-path (build-path geda-data-path "gafrc.d"))
+(define autoload-path (build-path geda-data-path "scheme" "autoload"))
 
-;; Execute any scheme files found in the geda-confd-path directory.
-(load-scheme-dir geda-confd-path)
+;; Execute any scheme files found in the autoload-path directory.
+(load-scheme-dir autoload-path)

--- a/netlist/scheme/Makefile.am
+++ b/netlist/scheme/Makefile.am
@@ -32,7 +32,7 @@ nobase_scmdata_DATA = $(DIST_SCM) $(DIST_SCM_BACKENDS) $(DIST_SCM_BACKENDS_COMMO
 config-netlist.scm: config-netlist.scm.in
 	sed -e 's,[@]backenddir[@],$(scmdatadir)/backend,g' < $(srcdir)/$@.in > $@
 
-gafrcddir = @GEDADATADIR@/gafrc.d
+gafrcddir = @GEDADATADIR@/scheme/autoload
 gafrcd_DATA = config-netlist.scm
 
 

--- a/netlist/scheme/config-netlist.scm.in
+++ b/netlist/scheme/config-netlist.scm.in
@@ -1,5 +1,5 @@
 ;
-; lepton-netlist gafrc.d/ configuration file
+; lepton-netlist configuration file
 ;
 
 ; Add netlist backends directory to %load-path:

--- a/symbols/Makefile.am
+++ b/symbols/Makefile.am
@@ -44,15 +44,22 @@ symbol_dirs = \
 	tube \
 	xilinx
 
-SUBDIRS = documentation gnetman verilog vhdl
+SUBDIRS = \
+	documentation \
+	gnetman \
+	verilog \
+	vhdl
 
 gafrcddir = $(GEDADATADIR)/gafrc.d
-dist_gafrcd_DATA = geda-clib.scm
+dist_gafrcd_DATA = config-symbol-libraries.scm
 
 datasymdir = $(GEDADATADIR)/sym
 
-EXTRA_DIST = ChangeLog ChangeLog-1.0 \
-	radio/README AUTHORS
+EXTRA_DIST = \
+	ChangeLog \
+	ChangeLog-1.0 \
+	radio/README \
+	AUTHORS
 
 if HAVE_GIT_REPO
 ChangeLog: $(top_builddir)/stamp-git

--- a/symbols/Makefile.am
+++ b/symbols/Makefile.am
@@ -50,7 +50,7 @@ SUBDIRS = \
 	verilog \
 	vhdl
 
-gafrcddir = $(GEDADATADIR)/gafrc.d
+gafrcddir = $(GEDADATADIR)/scheme/autoload
 dist_gafrcd_DATA = config-symbol-libraries.scm
 
 datasymdir = $(GEDADATADIR)/sym

--- a/symbols/config-symbol-libraries.scm
+++ b/symbols/config-symbol-libraries.scm
@@ -5,9 +5,6 @@
 
 (define geda-sym-path (build-path geda-data-path "sym"))
 
-; NOTE: Some of the below component libraries below are commented out.
-;       This was done because there are conflicting filenames within these
-;       libraries.  
 (for-each
  (lambda (dir)
    (if (list? dir)


### PR DESCRIPTION
- `share/lepton-eda/gafrc.d/` => `share/lepton-eda/scheme/autoload/`
- rename `geda-clib.scm` to `config-symbol-libraries.scm`

Discussed in the comments in #509.