### PR TITLE
Amend the (geda log-rotate) module in liblepton

### DIFF
--- a/liblepton/scheme/geda.scm
+++ b/liblepton/scheme/geda.scm
@@ -1,6 +1,7 @@
 ; -*-Scheme-*-
 (use-modules (lepton library))
 
-;; Clean up logfiles
-;; FIXME this should be a plugin
+; Clean up logfiles:
+;
 (use-modules (geda log-rotate))
+(cleanup-old-logs!)

--- a/liblepton/scheme/unit-tests/t0001-geda-conf-lib.scm
+++ b/liblepton/scheme/unit-tests/t0001-geda-conf-lib.scm
@@ -1,11 +1,6 @@
-;; Test Scheme procedures defined in geda.scm.  Makes blatant
-;; assumptions about the current directory.  Oh well.
-
 (use-modules (unit-test)
              (lepton file-system)
              (lepton rc))
-
-(load-from-path "geda.scm")
 
 (begin-test 'build-path
  (assert-equal
@@ -15,6 +10,8 @@
   "/path/to/a/directory"
   (build-path "/path" "to" "a" "directory")))
 
+; Makes blatant assumptions about the current directory. Oh well:
+;
 (begin-test 'regular-file?
  (assert-true (regular-file? "Makefile"))
  (assert-true (not (regular-file? "."))))


### PR DESCRIPTION
- do not use top-level code, which is executed
whenever this module is loaded
- export `cleanup-old-logs!()` function
- call it in `geda.scm`