### PR TITLE
Fix caching of library symbols in lepton-archive

### DIFF
--- a/utils/scripts/lepton-archive.in
+++ b/utils/scripts/lepton-archive.in
@@ -621,7 +621,7 @@ symbol cache directory."
   (filter-map
    (lambda (sch) (let ((cwd-filename (string-append (getcwd)
                                                file-name-separator-string
-                                               sch)))
+                                               (basename sch))))
               (and (file-exists? cwd-filename) cwd-filename)))
    toplevel-schematics))
 


### PR DESCRIPTION
Fix `schematic-page-filenames()` procedure,
make it work with absolute paths. Otherwise,
`lepton-archive` fails to cache symbols located
outside the project directory (e.g. stock
library symbols).