### PR TITLE
Migrate gschemrc settings - part 2

### DIFF
--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -65,6 +65,7 @@ font=Monospace 11
 
 [schematic.undo]
 modify-viewport=false
+undo-control=true
 
 [gschem]
 default-filename=untitled

--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -67,6 +67,7 @@ font=Monospace 11
 modify-viewport=false
 undo-control=true
 undo-type=disk
+undo-levels=20
 
 [gschem]
 default-filename=untitled

--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -88,6 +88,7 @@ bus-ripper-type=component
 bus-ripper-rotation=non-symmetric
 net-consolidate=true
 logging=true
+auto-save-interval=120
 
 
 

--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -41,6 +41,7 @@ text-caps-style=both
 middle-button=mousepan
 third-button=popup
 scroll-wheel=classic
+grid-mode=mesh
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -68,6 +68,7 @@ modify-viewport=false
 undo-control=true
 undo-type=disk
 undo-levels=20
+undo-panzoom=false
 
 [gschem]
 default-filename=untitled

--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -40,6 +40,7 @@ action-feedback-mode=outline
 text-caps-style=both
 middle-button=mousepan
 third-button=popup
+scroll-wheel=classic
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -43,6 +43,7 @@ third-button=popup
 scroll-wheel=classic
 grid-mode=mesh
 dots-grid-mode=variable
+net-selection-mode=enabled_net
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -87,6 +87,7 @@ bus-ripper-size=200
 bus-ripper-type=component
 bus-ripper-rotation=non-symmetric
 net-consolidate=true
+logging=true
 
 
 

--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -39,6 +39,7 @@ mesh-grid-display-threshold=3
 action-feedback-mode=outline
 text-caps-style=both
 middle-button=mousepan
+third-button=popup
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -38,6 +38,7 @@ dots-grid-fixed-threshold=10
 mesh-grid-display-threshold=3
 action-feedback-mode=outline
 text-caps-style=both
+middle-button=mousepan
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -89,6 +89,7 @@ bus-ripper-rotation=non-symmetric
 net-consolidate=true
 logging=true
 auto-save-interval=120
+log-window=later
 
 
 

--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -36,6 +36,7 @@ scrollpan-steps=8
 dots-grid-dot-size=1
 dots-grid-fixed-threshold=10
 mesh-grid-display-threshold=3
+action-feedback-mode=outline
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -37,6 +37,7 @@ dots-grid-dot-size=1
 dots-grid-fixed-threshold=10
 mesh-grid-display-threshold=3
 action-feedback-mode=outline
+text-caps-style=both
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -82,6 +82,9 @@ layout=auto
 monochrome=false
 paper=iso_a4
 
+[schematic]
+bus-ripper-size=200
+
 
 
 #

--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -66,6 +66,7 @@ font=Monospace 11
 [schematic.undo]
 modify-viewport=false
 undo-control=true
+undo-type=disk
 
 [gschem]
 default-filename=untitled

--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -85,6 +85,7 @@ paper=iso_a4
 [schematic]
 bus-ripper-size=200
 bus-ripper-type=component
+bus-ripper-rotation=non-symmetric
 
 
 

--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -86,6 +86,7 @@ paper=iso_a4
 bus-ripper-size=200
 bus-ripper-type=component
 bus-ripper-rotation=non-symmetric
+net-consolidate=true
 
 
 

--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -84,6 +84,7 @@ paper=iso_a4
 
 [schematic]
 bus-ripper-size=200
+bus-ripper-type=component
 
 
 

--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -42,6 +42,7 @@ middle-button=mousepan
 third-button=popup
 scroll-wheel=classic
 grid-mode=mesh
+dots-grid-mode=variable
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -88,6 +88,7 @@ bus-ripper-type=component
 bus-ripper-rotation=non-symmetric
 net-consolidate=true
 logging=true
+auto-save-interval=120
 
 
 

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -41,6 +41,7 @@ text-caps-style=both
 middle-button=mousepan
 third-button=popup
 scroll-wheel=classic
+grid-mode=mesh
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -40,6 +40,7 @@ action-feedback-mode=outline
 text-caps-style=both
 middle-button=mousepan
 third-button=popup
+scroll-wheel=classic
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -68,6 +68,7 @@ modify-viewport=false
 undo-control=true
 undo-type=disk
 undo-levels=20
+undo-panzoom=false
 
 [schematic]
 default-filename=untitled

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -43,6 +43,7 @@ third-button=popup
 scroll-wheel=classic
 grid-mode=mesh
 dots-grid-mode=variable
+net-selection-mode=enabled_net
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -66,6 +66,7 @@ font=Monospace 11
 [schematic.undo]
 modify-viewport=false
 undo-control=true
+undo-type=disk
 
 [schematic]
 default-filename=untitled

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -87,6 +87,7 @@ bus-ripper-size=200
 bus-ripper-type=component
 bus-ripper-rotation=non-symmetric
 net-consolidate=true
+logging=true
 
 
 

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -39,6 +39,7 @@ mesh-grid-display-threshold=3
 action-feedback-mode=outline
 text-caps-style=both
 middle-button=mousepan
+third-button=popup
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -38,6 +38,7 @@ dots-grid-fixed-threshold=10
 mesh-grid-display-threshold=3
 action-feedback-mode=outline
 text-caps-style=both
+middle-button=mousepan
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -89,6 +89,7 @@ bus-ripper-rotation=non-symmetric
 net-consolidate=true
 logging=true
 auto-save-interval=120
+log-window=later
 
 
 

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -36,6 +36,7 @@ scrollpan-steps=8
 dots-grid-dot-size=1
 dots-grid-fixed-threshold=10
 mesh-grid-display-threshold=3
+action-feedback-mode=outline
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -65,6 +65,7 @@ font=Monospace 11
 
 [schematic.undo]
 modify-viewport=false
+undo-control=true
 
 [schematic]
 default-filename=untitled

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -37,6 +37,7 @@ dots-grid-dot-size=1
 dots-grid-fixed-threshold=10
 mesh-grid-display-threshold=3
 action-feedback-mode=outline
+text-caps-style=both
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -82,6 +82,9 @@ layout=auto
 monochrome=false
 paper=iso_a4
 
+[schematic]
+bus-ripper-size=200
+
 
 
 #

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -85,6 +85,7 @@ paper=iso_a4
 [schematic]
 bus-ripper-size=200
 bus-ripper-type=component
+bus-ripper-rotation=non-symmetric
 
 
 

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -86,6 +86,7 @@ paper=iso_a4
 bus-ripper-size=200
 bus-ripper-type=component
 bus-ripper-rotation=non-symmetric
+net-consolidate=true
 
 
 

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -84,6 +84,7 @@ paper=iso_a4
 
 [schematic]
 bus-ripper-size=200
+bus-ripper-type=component
 
 
 

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -67,6 +67,7 @@ font=Monospace 11
 modify-viewport=false
 undo-control=true
 undo-type=disk
+undo-levels=20
 
 [schematic]
 default-filename=untitled

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -42,6 +42,7 @@ middle-button=mousepan
 third-button=popup
 scroll-wheel=classic
 grid-mode=mesh
+dots-grid-mode=variable
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/scheme/geda-deprecated-config.scm
+++ b/liblepton/scheme/geda-deprecated-config.scm
@@ -327,3 +327,6 @@ option's value:
 (define-rc-deprecated-config
  net-selection-mode "schematic.gui" "net-selection-mode"
  rc-deprecated-string-transformer)
+(define-rc-deprecated-config
+ undo-control "schematic.undo" "undo-control"
+ rc-deprecated-string-boolean-transformer)

--- a/liblepton/scheme/geda-deprecated-config.scm
+++ b/liblepton/scheme/geda-deprecated-config.scm
@@ -315,3 +315,6 @@ option's value:
 (define-rc-deprecated-config
  third-button "schematic.gui" "third-button"
  rc-deprecated-string-transformer)
+(define-rc-deprecated-config
+ scroll-wheel "schematic.gui" "scroll-wheel"
+ rc-deprecated-string-transformer)

--- a/liblepton/scheme/geda-deprecated-config.scm
+++ b/liblepton/scheme/geda-deprecated-config.scm
@@ -345,3 +345,6 @@ option's value:
 (define-rc-deprecated-config
  bus-ripper-type "schematic" "bus-ripper-type"
  rc-deprecated-string-transformer)
+(define-rc-deprecated-config
+ bus-ripper-rotation "schematic" "bus-ripper-rotation"
+ rc-deprecated-string-transformer)

--- a/liblepton/scheme/geda-deprecated-config.scm
+++ b/liblepton/scheme/geda-deprecated-config.scm
@@ -309,3 +309,6 @@ option's value:
 (define-rc-deprecated-config
  text-caps-style "schematic.gui" "text-caps-style"
  rc-deprecated-string-transformer)
+(define-rc-deprecated-config
+ middle-button "schematic.gui" "middle-button"
+ rc-deprecated-string-transformer)

--- a/liblepton/scheme/geda-deprecated-config.scm
+++ b/liblepton/scheme/geda-deprecated-config.scm
@@ -351,3 +351,6 @@ option's value:
 (define-rc-deprecated-config
  net-consolidate "schematic" "net-consolidate"
  rc-deprecated-string-boolean-transformer)
+(define-rc-deprecated-config
+ logging "schematic" "logging"
+ rc-deprecated-string-boolean-transformer)

--- a/liblepton/scheme/geda-deprecated-config.scm
+++ b/liblepton/scheme/geda-deprecated-config.scm
@@ -321,3 +321,6 @@ option's value:
 (define-rc-deprecated-config
  grid-mode "schematic.gui" "grid-mode"
  rc-deprecated-string-transformer)
+(define-rc-deprecated-config
+ dots-grid-mode "schematic.gui" "dots-grid-mode"
+ rc-deprecated-string-transformer)

--- a/liblepton/scheme/geda-deprecated-config.scm
+++ b/liblepton/scheme/geda-deprecated-config.scm
@@ -303,3 +303,6 @@ option's value:
 (define-rc-deprecated-config
  mesh-grid-display-threshold "schematic.gui" "mesh-grid-display-threshold"
  rc-deprecated-int-transformer)
+(define-rc-deprecated-config
+ action-feedback-mode "schematic.gui" "action-feedback-mode"
+ rc-deprecated-string-transformer)

--- a/liblepton/scheme/geda-deprecated-config.scm
+++ b/liblepton/scheme/geda-deprecated-config.scm
@@ -318,3 +318,6 @@ option's value:
 (define-rc-deprecated-config
  scroll-wheel "schematic.gui" "scroll-wheel"
  rc-deprecated-string-transformer)
+(define-rc-deprecated-config
+ grid-mode "schematic.gui" "grid-mode"
+ rc-deprecated-string-transformer)

--- a/liblepton/scheme/geda-deprecated-config.scm
+++ b/liblepton/scheme/geda-deprecated-config.scm
@@ -354,3 +354,6 @@ option's value:
 (define-rc-deprecated-config
  logging "schematic" "logging"
  rc-deprecated-string-boolean-transformer)
+(define-rc-deprecated-config
+ auto-save-interval "schematic" "auto-save-interval"
+ rc-deprecated-int-transformer)

--- a/liblepton/scheme/geda-deprecated-config.scm
+++ b/liblepton/scheme/geda-deprecated-config.scm
@@ -339,3 +339,6 @@ option's value:
 (define-rc-deprecated-config
  undo-panzoom "schematic.undo" "undo-panzoom"
  rc-deprecated-string-boolean-transformer)
+(define-rc-deprecated-config
+ bus-ripper-size "schematic" "bus-ripper-size"
+ rc-deprecated-int-transformer)

--- a/liblepton/scheme/geda-deprecated-config.scm
+++ b/liblepton/scheme/geda-deprecated-config.scm
@@ -342,3 +342,6 @@ option's value:
 (define-rc-deprecated-config
  bus-ripper-size "schematic" "bus-ripper-size"
  rc-deprecated-int-transformer)
+(define-rc-deprecated-config
+ bus-ripper-type "schematic" "bus-ripper-type"
+ rc-deprecated-string-transformer)

--- a/liblepton/scheme/geda-deprecated-config.scm
+++ b/liblepton/scheme/geda-deprecated-config.scm
@@ -357,3 +357,6 @@ option's value:
 (define-rc-deprecated-config
  auto-save-interval "schematic" "auto-save-interval"
  rc-deprecated-int-transformer)
+(define-rc-deprecated-config
+ log-window "schematic" "log-window"
+ rc-deprecated-string-transformer)

--- a/liblepton/scheme/geda-deprecated-config.scm
+++ b/liblepton/scheme/geda-deprecated-config.scm
@@ -324,3 +324,6 @@ option's value:
 (define-rc-deprecated-config
  dots-grid-mode "schematic.gui" "dots-grid-mode"
  rc-deprecated-string-transformer)
+(define-rc-deprecated-config
+ net-selection-mode "schematic.gui" "net-selection-mode"
+ rc-deprecated-string-transformer)

--- a/liblepton/scheme/geda-deprecated-config.scm
+++ b/liblepton/scheme/geda-deprecated-config.scm
@@ -333,3 +333,6 @@ option's value:
 (define-rc-deprecated-config
  undo-type "schematic.undo" "undo-type"
  rc-deprecated-string-transformer)
+(define-rc-deprecated-config
+ undo-levels "schematic.undo" "undo-levels"
+ rc-deprecated-int-transformer)

--- a/liblepton/scheme/geda-deprecated-config.scm
+++ b/liblepton/scheme/geda-deprecated-config.scm
@@ -336,3 +336,6 @@ option's value:
 (define-rc-deprecated-config
  undo-levels "schematic.undo" "undo-levels"
  rc-deprecated-int-transformer)
+(define-rc-deprecated-config
+ undo-panzoom "schematic.undo" "undo-panzoom"
+ rc-deprecated-string-boolean-transformer)

--- a/liblepton/scheme/geda-deprecated-config.scm
+++ b/liblepton/scheme/geda-deprecated-config.scm
@@ -306,3 +306,6 @@ option's value:
 (define-rc-deprecated-config
  action-feedback-mode "schematic.gui" "action-feedback-mode"
  rc-deprecated-string-transformer)
+(define-rc-deprecated-config
+ text-caps-style "schematic.gui" "text-caps-style"
+ rc-deprecated-string-transformer)

--- a/liblepton/scheme/geda-deprecated-config.scm
+++ b/liblepton/scheme/geda-deprecated-config.scm
@@ -330,3 +330,6 @@ option's value:
 (define-rc-deprecated-config
  undo-control "schematic.undo" "undo-control"
  rc-deprecated-string-boolean-transformer)
+(define-rc-deprecated-config
+ undo-type "schematic.undo" "undo-type"
+ rc-deprecated-string-transformer)

--- a/liblepton/scheme/geda-deprecated-config.scm
+++ b/liblepton/scheme/geda-deprecated-config.scm
@@ -348,3 +348,6 @@ option's value:
 (define-rc-deprecated-config
  bus-ripper-rotation "schematic" "bus-ripper-rotation"
  rc-deprecated-string-transformer)
+(define-rc-deprecated-config
+ net-consolidate "schematic" "net-consolidate"
+ rc-deprecated-string-boolean-transformer)

--- a/liblepton/scheme/geda-deprecated-config.scm
+++ b/liblepton/scheme/geda-deprecated-config.scm
@@ -312,3 +312,6 @@ option's value:
 (define-rc-deprecated-config
  middle-button "schematic.gui" "middle-button"
  rc-deprecated-string-transformer)
+(define-rc-deprecated-config
+ third-button "schematic.gui" "third-button"
+ rc-deprecated-string-transformer)

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -160,7 +160,6 @@ SCM g_rc_attribute_name(SCM path);
 SCM g_rc_log_window(SCM mode);
 SCM g_rc_net_consolidate(SCM mode);
 SCM g_rc_add_menu(SCM menu_name, SCM menu_items);
-SCM g_rc_bus_ripper_type(SCM mode);
 SCM g_rc_bus_ripper_rotation(SCM mode);
 SCM g_rc_auto_save_interval(SCM seconds);
 SCM g_rc_display_color_map (SCM scm_map);

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -160,7 +160,6 @@ SCM g_rc_attribute_name(SCM path);
 SCM g_rc_log_window(SCM mode);
 SCM g_rc_net_consolidate(SCM mode);
 SCM g_rc_undo_levels(SCM levels);
-SCM g_rc_undo_control(SCM mode);
 SCM g_rc_undo_type(SCM mode);
 SCM g_rc_undo_panzoom(SCM mode);
 SCM g_rc_add_menu(SCM menu_name, SCM menu_items);

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -159,7 +159,6 @@ SCM g_rc_net_selection_mode(SCM mode);
 SCM g_rc_logging(SCM mode);
 SCM g_rc_attribute_name(SCM path);
 SCM g_rc_log_window(SCM mode);
-SCM g_rc_scroll_wheel(SCM mode);
 SCM g_rc_net_consolidate(SCM mode);
 SCM g_rc_undo_levels(SCM levels);
 SCM g_rc_undo_control(SCM mode);

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -156,7 +156,6 @@ void g_init_keys ();
 void g_rc_parse_gtkrc();
 SCM g_rc_gschem_version(SCM version);
 SCM g_rc_attribute_name(SCM path);
-SCM g_rc_log_window(SCM mode);
 SCM g_rc_add_menu(SCM menu_name, SCM menu_items);
 SCM g_rc_display_color_map (SCM scm_map);
 SCM g_rc_display_outline_color_map (SCM scm_map);

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -159,7 +159,6 @@ SCM g_rc_logging(SCM mode);
 SCM g_rc_attribute_name(SCM path);
 SCM g_rc_log_window(SCM mode);
 SCM g_rc_net_consolidate(SCM mode);
-SCM g_rc_undo_levels(SCM levels);
 SCM g_rc_undo_panzoom(SCM mode);
 SCM g_rc_add_menu(SCM menu_name, SCM menu_items);
 SCM g_rc_bus_ripper_size(SCM size);

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -160,7 +160,6 @@ SCM g_rc_attribute_name(SCM path);
 SCM g_rc_log_window(SCM mode);
 SCM g_rc_net_consolidate(SCM mode);
 SCM g_rc_add_menu(SCM menu_name, SCM menu_items);
-SCM g_rc_bus_ripper_size(SCM size);
 SCM g_rc_bus_ripper_type(SCM mode);
 SCM g_rc_bus_ripper_rotation(SCM mode);
 SCM g_rc_auto_save_interval(SCM seconds);

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -158,7 +158,6 @@ SCM g_rc_gschem_version(SCM version);
 SCM g_rc_attribute_name(SCM path);
 SCM g_rc_log_window(SCM mode);
 SCM g_rc_add_menu(SCM menu_name, SCM menu_items);
-SCM g_rc_auto_save_interval(SCM seconds);
 SCM g_rc_display_color_map (SCM scm_map);
 SCM g_rc_display_outline_color_map (SCM scm_map);
 /* g_register.c */

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -159,7 +159,6 @@ SCM g_rc_logging(SCM mode);
 SCM g_rc_attribute_name(SCM path);
 SCM g_rc_log_window(SCM mode);
 SCM g_rc_net_consolidate(SCM mode);
-SCM g_rc_undo_panzoom(SCM mode);
 SCM g_rc_add_menu(SCM menu_name, SCM menu_items);
 SCM g_rc_bus_ripper_size(SCM size);
 SCM g_rc_bus_ripper_type(SCM mode);

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -160,7 +160,6 @@ SCM g_rc_logging(SCM mode);
 SCM g_rc_attribute_name(SCM path);
 SCM g_rc_log_window(SCM mode);
 SCM g_rc_third_button(SCM mode);
-SCM g_rc_middle_button(SCM mode);
 SCM g_rc_scroll_wheel(SCM mode);
 SCM g_rc_net_consolidate(SCM mode);
 SCM g_rc_undo_levels(SCM levels);

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -158,7 +158,6 @@ SCM g_rc_gschem_version(SCM version);
 SCM g_rc_logging(SCM mode);
 SCM g_rc_attribute_name(SCM path);
 SCM g_rc_log_window(SCM mode);
-SCM g_rc_net_consolidate(SCM mode);
 SCM g_rc_add_menu(SCM menu_name, SCM menu_items);
 SCM g_rc_auto_save_interval(SCM seconds);
 SCM g_rc_display_color_map (SCM scm_map);

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -160,7 +160,6 @@ SCM g_rc_attribute_name(SCM path);
 SCM g_rc_log_window(SCM mode);
 SCM g_rc_net_consolidate(SCM mode);
 SCM g_rc_undo_levels(SCM levels);
-SCM g_rc_undo_type(SCM mode);
 SCM g_rc_undo_panzoom(SCM mode);
 SCM g_rc_add_menu(SCM menu_name, SCM menu_items);
 SCM g_rc_bus_ripper_size(SCM size);

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -155,7 +155,6 @@ void g_init_keys ();
 /* g_rc.c */
 void g_rc_parse_gtkrc();
 SCM g_rc_gschem_version(SCM version);
-SCM g_rc_logging(SCM mode);
 SCM g_rc_attribute_name(SCM path);
 SCM g_rc_log_window(SCM mode);
 SCM g_rc_add_menu(SCM menu_name, SCM menu_items);

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -159,7 +159,6 @@ SCM g_rc_net_selection_mode(SCM mode);
 SCM g_rc_logging(SCM mode);
 SCM g_rc_attribute_name(SCM path);
 SCM g_rc_log_window(SCM mode);
-SCM g_rc_third_button(SCM mode);
 SCM g_rc_scroll_wheel(SCM mode);
 SCM g_rc_net_consolidate(SCM mode);
 SCM g_rc_undo_levels(SCM levels);

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -168,7 +168,6 @@ SCM g_rc_add_menu(SCM menu_name, SCM menu_items);
 SCM g_rc_bus_ripper_size(SCM size);
 SCM g_rc_bus_ripper_type(SCM mode);
 SCM g_rc_bus_ripper_rotation(SCM mode);
-SCM g_rc_dots_grid_mode(SCM mode);
 SCM g_rc_auto_save_interval(SCM seconds);
 SCM g_rc_display_color_map (SCM scm_map);
 SCM g_rc_display_outline_color_map (SCM scm_map);

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -157,7 +157,6 @@ void g_rc_parse_gtkrc();
 SCM g_rc_gschem_version(SCM version);
 SCM g_rc_net_selection_mode(SCM mode);
 SCM g_rc_logging(SCM mode);
-SCM g_rc_text_caps_style(SCM mode);
 SCM g_rc_attribute_name(SCM path);
 SCM g_rc_log_window(SCM mode);
 SCM g_rc_third_button(SCM mode);

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -168,7 +168,6 @@ SCM g_rc_add_menu(SCM menu_name, SCM menu_items);
 SCM g_rc_bus_ripper_size(SCM size);
 SCM g_rc_bus_ripper_type(SCM mode);
 SCM g_rc_bus_ripper_rotation(SCM mode);
-SCM g_rc_grid_mode(SCM mode);
 SCM g_rc_dots_grid_mode(SCM mode);
 SCM g_rc_auto_save_interval(SCM seconds);
 SCM g_rc_display_color_map (SCM scm_map);

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -156,7 +156,6 @@ void g_init_keys ();
 void g_rc_parse_gtkrc();
 SCM g_rc_gschem_version(SCM version);
 SCM g_rc_net_selection_mode(SCM mode);
-SCM g_rc_action_feedback_mode(SCM mode);
 SCM g_rc_logging(SCM mode);
 SCM g_rc_text_caps_style(SCM mode);
 SCM g_rc_attribute_name(SCM path);

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -155,7 +155,6 @@ void g_init_keys ();
 /* g_rc.c */
 void g_rc_parse_gtkrc();
 SCM g_rc_gschem_version(SCM version);
-SCM g_rc_net_selection_mode(SCM mode);
 SCM g_rc_logging(SCM mode);
 SCM g_rc_attribute_name(SCM path);
 SCM g_rc_log_window(SCM mode);

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -160,7 +160,6 @@ SCM g_rc_attribute_name(SCM path);
 SCM g_rc_log_window(SCM mode);
 SCM g_rc_net_consolidate(SCM mode);
 SCM g_rc_add_menu(SCM menu_name, SCM menu_items);
-SCM g_rc_bus_ripper_rotation(SCM mode);
 SCM g_rc_auto_save_interval(SCM seconds);
 SCM g_rc_display_color_map (SCM scm_map);
 SCM g_rc_display_outline_color_map (SCM scm_map);

--- a/schematic/scheme/conf/schematic/options.scm
+++ b/schematic/scheme/conf/schematic/options.scm
@@ -2,13 +2,6 @@
 ; Start of mode related keywords
 ;
 
-; undo-levels number
-;
-; Determines the number of levels of undo.  Basically this number decides
-; how many backup schematics are saved on disk.
-;
-(undo-levels 20)
-
 
 ; undo-panzoom string
 ;

--- a/schematic/scheme/conf/schematic/options.scm
+++ b/schematic/scheme/conf/schematic/options.scm
@@ -101,18 +101,6 @@
 (log-window "later")
 
 
-; text-caps-style string
-;
-; Sets the default caps style used for the input of text
-; lower specifies that all inputed text is in lowercase
-; upper specifies that all inputed text is in uppercase
-; both specifies that all inputed text is used as is (no case conversion)
-;
-(text-caps-style "both")
-;(text-caps-style "lower")
-;(text-caps-style "upper")
-
-
 ; middle-button string
 ;
 ; Controls if the middle mouse button draws strokes, repeats the last

--- a/schematic/scheme/conf/schematic/options.scm
+++ b/schematic/scheme/conf/schematic/options.scm
@@ -61,7 +61,6 @@
 
 ; The default bus ripper
 (bus-ripper-symname "busripper-1.sym")
-(bus-ripper-rotation "non-symmetric")
 
 ; A symmetric alternative
 ;(bus-ripper-size 200)

--- a/schematic/scheme/conf/schematic/options.scm
+++ b/schematic/scheme/conf/schematic/options.scm
@@ -60,7 +60,6 @@
 ;
 
 ; The default bus ripper
-(bus-ripper-size 200)
 (bus-ripper-type "component")
 (bus-ripper-symname "busripper-1.sym")
 (bus-ripper-rotation "non-symmetric")

--- a/schematic/scheme/conf/schematic/options.scm
+++ b/schematic/scheme/conf/schematic/options.scm
@@ -12,18 +12,6 @@
 (auto-save-interval 120)
 
 
-;  net-consolidate string
-;
-;  Controls if the net consolidation code is used when schematics are read
-;  in, written to disk, and when nets are being drawn (does not consolidate
-;  when things are being copied or moved yet).  Net consolidation is the
-;  connection of nets which can be combined into one.
-;  Comment out if you want the default mode
-;
-(net-consolidate "enabled")
-;(net-consolidate "disabled")
-
-
 ; logging string
 ;
 ; Determines if the logging mechanism is enabled or disabled

--- a/schematic/scheme/conf/schematic/options.scm
+++ b/schematic/scheme/conf/schematic/options.scm
@@ -60,7 +60,6 @@
 ;
 
 ; The default bus ripper
-(bus-ripper-type "component")
 (bus-ripper-symname "busripper-1.sym")
 (bus-ripper-rotation "non-symmetric")
 

--- a/schematic/scheme/conf/schematic/options.scm
+++ b/schematic/scheme/conf/schematic/options.scm
@@ -101,17 +101,6 @@
 (log-window "later")
 
 
-; scroll-wheel string
-;
-; Controls the binding of the mouse scroll wheel.
-; "classic" style is the gschem default, where scrolling with no modifier
-; key is mapped to zoom, + CTRL -> x-axis pan, + SHIFT -> y-axis pan.
-; "gtk" style changes the behaviour to be more like other GTK applications,
-; no modifier -> y-axis pan, + CTRL -> zoom, + SHIFT -> x-axis pan.
-(scroll-wheel "classic")
-;(scroll-wheel "gtk")
-
-
 ; Bus ripper controls
 ; The following keywords control the auto bus ripper addition code
 ;

--- a/schematic/scheme/conf/schematic/options.scm
+++ b/schematic/scheme/conf/schematic/options.scm
@@ -101,15 +101,6 @@
 (log-window "later")
 
 
-; third-button string
-;
-; Controls if the third mouse button performs the popup ("popup") or
-; if it does the mouse panning ("mousepan")
-;
-(third-button "popup")
-;(third-button "mousepan")
-
-
 ; scroll-wheel string
 ;
 ; Controls the binding of the mouse scroll wheel.

--- a/schematic/scheme/conf/schematic/options.scm
+++ b/schematic/scheme/conf/schematic/options.scm
@@ -3,18 +3,6 @@
 ;
 
 
-; log-window string
-;
-; Controls if the log message window is mapped when gschem is started up
-; Possible options:
-;       startup - opened up when gschem starts
-;       later   - NOT opened up when gschem starts
-;                 (can be opened by Options/Show Log Window)
-;
-;(log-window "startup")
-(log-window "later")
-
-
 ; Bus ripper controls
 ; The following keywords control the auto bus ripper addition code
 ;

--- a/schematic/scheme/conf/schematic/options.scm
+++ b/schematic/scheme/conf/schematic/options.scm
@@ -3,15 +3,6 @@
 ;
 
 
-; autosave interval
-;
-; Controls if a backup copy is made every "interval" seconds.
-; Note that the backup copy is made when you make some change to the schematic,
-; and there were more than "interval" seconds from the last autosave.
-; Autosaving will not be allowed if setting it to zero.
-(auto-save-interval 120)
-
-
 ; log-window string
 ;
 ; Controls if the log message window is mapped when gschem is started up

--- a/schematic/scheme/conf/schematic/options.scm
+++ b/schematic/scheme/conf/schematic/options.scm
@@ -130,14 +130,6 @@
 ;(bus-ripper-size 200)
 ;(bus-ripper-type "net")
 
-; Grid mode
-;
-; The grid-mode keyword controls which mode of grid is used by default in
-; gschem.
-;(grid-mode "none")
-;(grid-mode "dots")
-(grid-mode "mesh")
-
 
 ; Dots grid mode
 ;

--- a/schematic/scheme/conf/schematic/options.scm
+++ b/schematic/scheme/conf/schematic/options.scm
@@ -3,19 +3,6 @@
 ;
 
 
-; undo-panzoom string
-;
-; Controls if pan or zoom commands are saved in the undo list.  If this
-; is enabled then a pan or zoom command will be considered a command and
-; can be undone.  If this is false, then panning and zooming is not saved
-; in the undo list and cannot be undone.  Note, the current viewport
-; information is saved for every command, so the display will change to the
-; viewport before a command is executed.
-;
-;(undo-panzoom "enabled")
-(undo-panzoom "disabled")
-
-
 ; autosave interval
 ;
 ; Controls if a backup copy is made every "interval" seconds.

--- a/schematic/scheme/conf/schematic/options.scm
+++ b/schematic/scheme/conf/schematic/options.scm
@@ -12,16 +12,6 @@
 (auto-save-interval 120)
 
 
-; logging string
-;
-; Determines if the logging mechanism is enabled or disabled
-;   Possible options: enabled or disabled
-; Default is enabled.
-;
-(logging "enabled")
-;(logging "disabled")
-
-
 ; log-window string
 ;
 ; Controls if the log message window is mapped when gschem is started up

--- a/schematic/scheme/conf/schematic/options.scm
+++ b/schematic/scheme/conf/schematic/options.scm
@@ -9,16 +9,6 @@
 ;
 (undo-levels 20)
 
-; undo-type string
-;
-; Controls which kind of undo is used.  The default is to use the disk as
-; the storing medium (ie after every action the undo information is stored
-; to disk).  The other mechanism uses only memory.  The disk mechanism is
-; nice because you get undo-level number of backups of the schematic written
-; to disk as backups so you should never lose a schematic due to a crash.
-;
-(undo-type "disk")
-;(undo-type "memory")
 
 ; undo-panzoom string
 ;

--- a/schematic/scheme/conf/schematic/options.scm
+++ b/schematic/scheme/conf/schematic/options.scm
@@ -79,19 +79,6 @@
 ;(net-consolidate "disabled")
 
 
-; action-feedback-mode string
-;
-; Set the default action feedback mode (for copy/move/component place).
-; Set to outline to get an outline of the selection.
-; Set to boundingbox to get a bounding box of the selection.
-; For a fast machines with fast video use outline (it looks good).
-; For a slow machine use boundingbox; it is much faster.
-; Comment out if you want the default mode.
-;
-(action-feedback-mode "outline")
-;(action-feedback-mode "boundingbox")
-
-
 ; logging string
 ;
 ; Determines if the logging mechanism is enabled or disabled

--- a/schematic/scheme/conf/schematic/options.scm
+++ b/schematic/scheme/conf/schematic/options.scm
@@ -2,13 +2,6 @@
 ; Start of mode related keywords
 ;
 
-; undo-control string
-;
-; Controls if the undo is enabled or not
-;
-(undo-control "enabled")
-;(undo-control "disabled")
-
 ; undo-levels number
 ;
 ; Determines the number of levels of undo.  Basically this number decides

--- a/schematic/scheme/conf/schematic/options.scm
+++ b/schematic/scheme/conf/schematic/options.scm
@@ -101,19 +101,6 @@
 (log-window "later")
 
 
-; middle-button string
-;
-; Controls if the middle mouse button draws strokes, repeats the last
-; command, does an action (move and copy (holding down the ALT key)
-; are supported) on a single objects, performs the popup,
-; or if it does the mouse panning.
-;
-(middle-button "mousepan")
-;(middle-button "popup")
-;(middle-button "action")
-;(middle-button "stroke")
-;(middle-button "repeat")
-
 ; third-button string
 ;
 ; Controls if the third mouse button performs the popup ("popup") or

--- a/schematic/scheme/conf/schematic/options.scm
+++ b/schematic/scheme/conf/schematic/options.scm
@@ -49,24 +49,6 @@
 (auto-save-interval 120)
 
 
-; net-selection-mode string
-;
-; Controls how many net segments are selected when you click at a net.
-;
-; - enabled_all:
-;   - first click selects the net itself
-;   - second click selects all nets directly connected to the selected one
-;   - third click in addition selects all nets with equal "netname" attributes
-; - enabled_net:
-;   - first click selects the net itself
-;   - second click selects all nets directly connected to the selected one
-; - disabled:
-;   - mouse clicks just selects the clicked net
-
-;(net-selection-mode "disabled")
-(net-selection-mode "enabled_net")
-;(net-selection-mode "enabled_all")
-
 ;  net-consolidate string
 ;
 ;  Controls if the net consolidation code is used when schematics are read

--- a/schematic/scheme/conf/schematic/options.scm
+++ b/schematic/scheme/conf/schematic/options.scm
@@ -131,18 +131,6 @@
 ;(bus-ripper-type "net")
 
 
-; Dots grid mode
-;
-; The dots-grid-mode keyword controls the mode of the dotted grid, either
-; variable or fixed. In the variable mode, the grid spacing changes
-; depending on the zoom factor. In the fixed mode, the grid always
-; represents the same number of units as the snap-spacing. You can
-; control the density of the grid using the dots-grid-fixed-threshold.
-(dots-grid-mode "variable")
-;(dots-grid-mode "fixed")
-
-
-
 ; reset-component-library
 ;
 ; When reset-component-library is executed, then all known component library

--- a/schematic/src/g_rc.c
+++ b/schematic/src/g_rc.c
@@ -152,23 +152,6 @@ SCM g_rc_attribute_name(SCM scm_path)
  *  \par Function Description
  *
  */
-SCM g_rc_log_window(SCM mode)
-{
-  static const vstbl_entry mode_table[] = {
-    {MAP_ON_STARTUP, "startup" },
-    {MAP_LATER     , "later"   },
-  };
-
-  RETURN_G_RC_MODE("log-window",
-		   default_log_window,
-		   2);
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
 SCM g_rc_add_menu(SCM scm_menu_name, SCM scm_menu_items)
 {
   char *menu_name;

--- a/schematic/src/g_rc.c
+++ b/schematic/src/g_rc.c
@@ -186,23 +186,6 @@ SCM g_rc_log_window(SCM mode)
  *  \par Function Description
  *
  */
-SCM g_rc_net_consolidate(SCM mode)
-{
-  static const vstbl_entry mode_table[] = {
-    {TRUE , "enabled" },
-    {FALSE, "disabled"},
-  };
-
-  RETURN_G_RC_MODE("net-consolidate",
-		   default_net_consolidate,
-		   2);
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
 SCM g_rc_add_menu(SCM scm_menu_name, SCM scm_menu_items)
 {
   char *menu_name;

--- a/schematic/src/g_rc.c
+++ b/schematic/src/g_rc.c
@@ -203,30 +203,6 @@ SCM g_rc_net_consolidate(SCM mode)
  *  \par Function Description
  *
  */
-SCM g_rc_undo_levels(SCM levels)
-{
-  int val;
-
-  SCM_ASSERT (scm_is_integer (levels), levels, SCM_ARG1, "undo-levels");
-
-  val = scm_to_int (levels);
-
-  if (val == 0) {
-    fprintf(stderr, _("Invalid num levels [%1$d] passed to undo-levels\n"),
-            val);
-    val = 10; /* absolute default */
-  }
-
-  default_undo_levels = val;
-
-  return SCM_BOOL_T;
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
 SCM g_rc_undo_panzoom(SCM mode)
 {
   static const vstbl_entry mode_table[] = {

--- a/schematic/src/g_rc.c
+++ b/schematic/src/g_rc.c
@@ -125,23 +125,6 @@ SCM g_rc_gschem_version(SCM scm_version)
  *  \par Function Description
  *
  */
-SCM g_rc_logging(SCM mode)
-{
-  static const vstbl_entry mode_table[] = {
-    {TRUE , "enabled" },
-    {FALSE, "disabled"}
-  };
-
-  RETURN_G_RC_MODE("logging",
-		   default_do_logging,
-		   2);
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
 SCM g_rc_attribute_name(SCM scm_path)
 {
   char *path;

--- a/schematic/src/g_rc.c
+++ b/schematic/src/g_rc.c
@@ -159,26 +159,6 @@ SCM g_rc_logging(SCM mode)
  *  \brief
  *  \par Function Description
  *
- *  \todo inconsistant naming with keyword name and variable to hold
- *        variable
- */
-SCM g_rc_text_caps_style(SCM mode)
-{
-  static const vstbl_entry mode_table[] = {
-    {LOWER, "lower" },
-    {UPPER, "upper" },
-    {BOTH , "both"  }
-  };
-
-  RETURN_G_RC_MODE("text-caps-style",
-		   default_text_caps,
-		   3);
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
  */
 SCM g_rc_attribute_name(SCM scm_path)
 {

--- a/schematic/src/g_rc.c
+++ b/schematic/src/g_rc.c
@@ -224,23 +224,6 @@ SCM g_rc_add_menu(SCM scm_menu_name, SCM scm_menu_items)
  *  \par Function Description
  *
  */
-SCM g_rc_bus_ripper_rotation(SCM mode)
-{
-  static const vstbl_entry mode_table[] = {
-    {SYMMETRIC,     "symmetric" },
-    {NON_SYMMETRIC, "non-symmetric"  }
-  };
-
-  RETURN_G_RC_MODE("bus-ripper-rotation",
-		   default_bus_ripper_rotation,
-		   2);
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
 SCM g_rc_auto_save_interval(SCM seconds)
 {
   int val;

--- a/schematic/src/g_rc.c
+++ b/schematic/src/g_rc.c
@@ -125,24 +125,6 @@ SCM g_rc_gschem_version(SCM scm_version)
  *  \par Function Description
  *
  */
-SCM g_rc_net_selection_mode(SCM mode)
-{
-  static const vstbl_entry mode_table[] = {
-    {0, "disabled"},
-    {2, "enabled_net"},
-    {3, "enabled_all"}
-  };
-
-  RETURN_G_RC_MODE("net-selection-mode",
-		   default_net_selection_mode,
-		   3);
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
 SCM g_rc_logging(SCM mode)
 {
   static const vstbl_entry mode_table[] = {

--- a/schematic/src/g_rc.c
+++ b/schematic/src/g_rc.c
@@ -185,30 +185,6 @@ SCM g_rc_add_menu(SCM scm_menu_name, SCM scm_menu_items)
   return SCM_BOOL_T;
 }
 
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
-SCM g_rc_auto_save_interval(SCM seconds)
-{
-  int val;
-
-  SCM_ASSERT (scm_is_integer (seconds), seconds, SCM_ARG1, "auto-save-interval");
-
-  val = scm_to_int (seconds);
-
-  if (val < 0) {
-    fprintf(stderr, _("Invalid number of seconds [%1$d] passed to auto-save-interval\n"),
-            val);
-    val = 120; /* absolute default */
-  }
-
-  default_auto_save_interval = val;
-
-  return SCM_BOOL_T;
-}
-
 
 extern GedaColorMap display_colors;
 extern GedaColorMap display_outline_colors;

--- a/schematic/src/g_rc.c
+++ b/schematic/src/g_rc.c
@@ -204,36 +204,6 @@ SCM g_rc_log_window(SCM mode)
  *  \par Function Description
  *
  */
-SCM g_rc_third_button(SCM mode)
-{
-  static const vstbl_entry mode_table[] = {
-    {MOUSEBTN_DO_POPUP, "popup"   },
-    {MOUSEBTN_DO_PAN,   "mousepan"},
-  };
-
-  const int table_size = sizeof (mode_table) / sizeof (mode_table[0]);
-
-  if (scm_is_eq (mode, SCM_UNDEFINED))
-  {
-    for (int i = 0; i < table_size; ++i)
-    {
-      if (default_third_button == mode_table[i].m_val)
-        return scm_from_utf8_string (mode_table[i].m_str);
-    }
-
-    return scm_from_utf8_string ("none");
-  }
-
-  RETURN_G_RC_MODE("third-button",
-		   default_third_button,
-		   table_size);
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
 SCM g_rc_scroll_wheel(SCM mode)
 {
   static const vstbl_entry mode_table[] = {

--- a/schematic/src/g_rc.c
+++ b/schematic/src/g_rc.c
@@ -224,30 +224,6 @@ SCM g_rc_add_menu(SCM scm_menu_name, SCM scm_menu_items)
  *  \par Function Description
  *
  */
-SCM g_rc_bus_ripper_size(SCM size)
-{
-  int val;
-
-  SCM_ASSERT (scm_is_integer (size), size, SCM_ARG1, "bus-ripper-size");
-
-  val = scm_to_int (size);
-
-  if (val == 0) {
-    fprintf(stderr, _("Invalid size [%1$d] passed to bus-ripper-size\n"),
-            val);
-    val = 200; /* absolute default */
-  }
-
-  default_bus_ripper_size = val;
-
-  return SCM_BOOL_T;
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
 SCM g_rc_bus_ripper_type(SCM mode)
 {
   static const vstbl_entry mode_table[] = {

--- a/schematic/src/g_rc.c
+++ b/schematic/src/g_rc.c
@@ -143,23 +143,6 @@ SCM g_rc_net_selection_mode(SCM mode)
  *  \par Function Description
  *
  */
-SCM g_rc_action_feedback_mode(SCM mode)
-{
-  static const vstbl_entry mode_table[] = {
-    {OUTLINE    , "outline"   },
-    {BOUNDINGBOX, "boundingbox"}
-  };
-
-  RETURN_G_RC_MODE("action-feedback-mode",
-		   default_actionfeedback_mode,
-		   2);
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
 SCM g_rc_logging(SCM mode)
 {
   static const vstbl_entry mode_table[] = {

--- a/schematic/src/g_rc.c
+++ b/schematic/src/g_rc.c
@@ -227,21 +227,6 @@ SCM g_rc_undo_levels(SCM levels)
  *  \par Function Description
  *
  */
-SCM g_rc_undo_control(SCM mode)
-{
-  static const vstbl_entry mode_table[] = {
-    {TRUE , "enabled" },
-    {FALSE, "disabled"},
-  };
-
-  RETURN_G_RC_MODE("undo-control", default_undo_control, 2);
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
 SCM g_rc_undo_type(SCM mode)
 {
   static const vstbl_entry mode_table[] = {

--- a/schematic/src/g_rc.c
+++ b/schematic/src/g_rc.c
@@ -366,31 +366,6 @@ SCM g_rc_bus_ripper_rotation(SCM mode)
 		   2);
 }
 
-/*! \brief Verify the grid mode set in the RC file under evaluation.
- *  \par Function Description
- *
- *  Implements the Scheme function "grid-mode". Tests the grid mode
- *  string in the argument against the grid mode of the application
- *  itself.
- *
- *  \param [in] mode Scheme object containing the grid mode string
- *
- *  \returns #t if the grid mode specified in the RC file matches the
- *           application, else #f.
- */
-SCM g_rc_grid_mode (SCM mode)
-{
-  static const vstbl_entry mode_table[] = {
-    {GRID_MODE_NONE, "none" },
-    {GRID_MODE_DOTS, "dots" },
-    {GRID_MODE_MESH, "mesh" }
-  };
-
-  RETURN_G_RC_MODE ("grid-mode",
-                    default_grid_mode,
-                    3);
-}
-
 /*! \todo Finish function documentation!!!
  *  \brief
  *  \par Function Description

--- a/schematic/src/g_rc.c
+++ b/schematic/src/g_rc.c
@@ -203,21 +203,6 @@ SCM g_rc_net_consolidate(SCM mode)
  *  \par Function Description
  *
  */
-SCM g_rc_undo_panzoom(SCM mode)
-{
-  static const vstbl_entry mode_table[] = {
-    {TRUE , "enabled" },
-    {FALSE, "disabled"},
-  };
-
-  RETURN_G_RC_MODE("undo-panzoom", default_undo_panzoom, 2);
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
 SCM g_rc_add_menu(SCM scm_menu_name, SCM scm_menu_items)
 {
   char *menu_name;

--- a/schematic/src/g_rc.c
+++ b/schematic/src/g_rc.c
@@ -204,23 +204,6 @@ SCM g_rc_log_window(SCM mode)
  *  \par Function Description
  *
  */
-SCM g_rc_scroll_wheel(SCM mode)
-{
-  static const vstbl_entry mode_table[] = {
-    {SCROLL_WHEEL_CLASSIC, "classic"},
-    {SCROLL_WHEEL_GTK,     "gtk"},
-  };
-
-  RETURN_G_RC_MODE("scroll-wheel",
-                   default_scroll_wheel,
-                   2);
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
 SCM g_rc_net_consolidate(SCM mode)
 {
   static const vstbl_entry mode_table[] = {

--- a/schematic/src/g_rc.c
+++ b/schematic/src/g_rc.c
@@ -227,23 +227,6 @@ SCM g_rc_undo_levels(SCM levels)
  *  \par Function Description
  *
  */
-SCM g_rc_undo_type(SCM mode)
-{
-  static const vstbl_entry mode_table[] = {
-    {UNDO_DISK  , "disk"   },
-    {UNDO_MEMORY, "memory" },
-  };
-
-  RETURN_G_RC_MODE("undo-type",
-		   default_undo_type,
-		   2);
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
 SCM g_rc_undo_panzoom(SCM mode)
 {
   static const vstbl_entry mode_table[] = {

--- a/schematic/src/g_rc.c
+++ b/schematic/src/g_rc.c
@@ -224,23 +224,6 @@ SCM g_rc_add_menu(SCM scm_menu_name, SCM scm_menu_items)
  *  \par Function Description
  *
  */
-SCM g_rc_bus_ripper_type(SCM mode)
-{
-  static const vstbl_entry mode_table[] = {
-    {COMP_BUS_RIPPER, "component" },
-    {NET_BUS_RIPPER,  "net" }
-  };
-
-  RETURN_G_RC_MODE("bus-ripper-type",
-		   default_bus_ripper_type,
-		   2);
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
 SCM g_rc_bus_ripper_rotation(SCM mode)
 {
   static const vstbl_entry mode_table[] = {

--- a/schematic/src/g_rc.c
+++ b/schematic/src/g_rc.c
@@ -234,39 +234,6 @@ SCM g_rc_third_button(SCM mode)
  *  \par Function Description
  *
  */
-SCM g_rc_middle_button(SCM mode)
-{
-  static const vstbl_entry mode_table[] = {
-    {MOUSEBTN_DO_STROKE, "stroke"},
-    {MOUSEBTN_DO_REPEAT, "repeat"},
-    {MOUSEBTN_DO_ACTION, "action"},
-    {MOUSEBTN_DO_PAN,    "mousepan"},
-    {MOUSEBTN_DO_POPUP,  "popup"},
-  };
-
-  const int table_size = sizeof (mode_table) / sizeof (mode_table[0]);
-
-  if (scm_is_eq (mode, SCM_UNDEFINED))
-  {
-    for (int i = 0; i < table_size; ++i)
-    {
-      if (default_middle_button == mode_table[i].m_val)
-        return scm_from_utf8_string (mode_table[i].m_str);
-    }
-
-    return scm_from_utf8_string ("none");
-  }
-
-  RETURN_G_RC_MODE("middle-button",
-		   default_middle_button,
-		   table_size);
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
 SCM g_rc_scroll_wheel(SCM mode)
 {
   static const vstbl_entry mode_table[] = {

--- a/schematic/src/g_rc.c
+++ b/schematic/src/g_rc.c
@@ -371,23 +371,6 @@ SCM g_rc_bus_ripper_rotation(SCM mode)
  *  \par Function Description
  *
  */
-SCM g_rc_dots_grid_mode (SCM mode)
-{
-  static const vstbl_entry mode_table[] = {
-    {DOTS_GRID_VARIABLE_MODE, "variable" },
-    {DOTS_GRID_FIXED_MODE,    "fixed"  }
-  };
-
-  RETURN_G_RC_MODE ("dots-grid-mode",
-                    default_dots_grid_mode,
-                    2);
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
 SCM g_rc_auto_save_interval(SCM seconds)
 {
   int val;

--- a/schematic/src/g_register.c
+++ b/schematic/src/g_register.c
@@ -39,7 +39,6 @@ static struct gsubr_t gschem_funcs[] = {
   { "display-outline-color-map",    0, 1, 0, (SCM (*) ()) g_rc_display_outline_color_map },
 
   { "net-selection-mode",           1, 0, 0, (SCM (*) ()) g_rc_net_selection_mode },
-  { "action-feedback-mode",         1, 0, 0, (SCM (*) ()) g_rc_action_feedback_mode },
   { "logging",                      1, 0, 0, (SCM (*) ()) g_rc_logging },
 
   { "text-caps-style",              1, 0, 0, (SCM (*) ()) g_rc_text_caps_style },

--- a/schematic/src/g_register.c
+++ b/schematic/src/g_register.c
@@ -45,7 +45,6 @@ static struct gsubr_t gschem_funcs[] = {
   { "log-window",                   1, 0, 0, (SCM (*) ()) g_rc_log_window },
   { "net-consolidate",              1, 0, 0, (SCM (*) ()) g_rc_net_consolidate },
   { "undo-levels",                  1, 0, 0, (SCM (*) ()) g_rc_undo_levels },
-  { "undo-control",                 1, 0, 0, (SCM (*) ()) g_rc_undo_control },
   { "undo-type",                    1, 0, 0, (SCM (*) ()) g_rc_undo_type },
   { "undo-panzoom",                 1, 0, 0, (SCM (*) ()) g_rc_undo_panzoom },
 

--- a/schematic/src/g_register.c
+++ b/schematic/src/g_register.c
@@ -54,7 +54,6 @@ static struct gsubr_t gschem_funcs[] = {
   { "bus-ripper-size",              1, 0, 0, (SCM (*) ()) g_rc_bus_ripper_size },
   { "bus-ripper-type",              1, 0, 0, (SCM (*) ()) g_rc_bus_ripper_type },
   { "bus-ripper-rotation",          1, 0, 0, (SCM (*) ()) g_rc_bus_ripper_rotation },
-  { "grid-mode",                    1, 0, 0, (SCM (*) ()) g_rc_grid_mode },
   { "dots-grid-mode",               1, 0, 0, (SCM (*) ()) g_rc_dots_grid_mode },
 
   /* backup functions */

--- a/schematic/src/g_register.c
+++ b/schematic/src/g_register.c
@@ -45,7 +45,6 @@ static struct gsubr_t gschem_funcs[] = {
   { "log-window",                   1, 0, 0, (SCM (*) ()) g_rc_log_window },
   { "net-consolidate",              1, 0, 0, (SCM (*) ()) g_rc_net_consolidate },
   { "undo-levels",                  1, 0, 0, (SCM (*) ()) g_rc_undo_levels },
-  { "undo-type",                    1, 0, 0, (SCM (*) ()) g_rc_undo_type },
   { "undo-panzoom",                 1, 0, 0, (SCM (*) ()) g_rc_undo_panzoom },
 
   { "add-menu",                     2, 0, 0, (SCM (*) ()) g_rc_add_menu },

--- a/schematic/src/g_register.c
+++ b/schematic/src/g_register.c
@@ -41,8 +41,6 @@ static struct gsubr_t gschem_funcs[] = {
   { "net-selection-mode",           1, 0, 0, (SCM (*) ()) g_rc_net_selection_mode },
   { "logging",                      1, 0, 0, (SCM (*) ()) g_rc_logging },
 
-  { "text-caps-style",              1, 0, 0, (SCM (*) ()) g_rc_text_caps_style },
-
   { "attribute-name",               1, 0, 0, (SCM (*) ()) g_rc_attribute_name },
 
   { "log-window",                   1, 0, 0, (SCM (*) ()) g_rc_log_window },

--- a/schematic/src/g_register.c
+++ b/schematic/src/g_register.c
@@ -46,7 +46,6 @@ static struct gsubr_t gschem_funcs[] = {
   { "net-consolidate",              1, 0, 0, (SCM (*) ()) g_rc_net_consolidate },
 
   { "add-menu",                     2, 0, 0, (SCM (*) ()) g_rc_add_menu },
-  { "bus-ripper-type",              1, 0, 0, (SCM (*) ()) g_rc_bus_ripper_type },
   { "bus-ripper-rotation",          1, 0, 0, (SCM (*) ()) g_rc_bus_ripper_rotation },
 
   /* backup functions */

--- a/schematic/src/g_register.c
+++ b/schematic/src/g_register.c
@@ -45,7 +45,6 @@ static struct gsubr_t gschem_funcs[] = {
 
   { "log-window",                   1, 0, 0, (SCM (*) ()) g_rc_log_window },
   { "third-button",                 0, 1, 0, (SCM (*) ()) g_rc_third_button },
-  { "middle-button",                0, 1, 0, (SCM (*) ()) g_rc_middle_button },
   { "scroll-wheel",                 1, 0, 0, (SCM (*) ()) g_rc_scroll_wheel },
   { "net-consolidate",              1, 0, 0, (SCM (*) ()) g_rc_net_consolidate },
   { "undo-levels",                  1, 0, 0, (SCM (*) ()) g_rc_undo_levels },

--- a/schematic/src/g_register.c
+++ b/schematic/src/g_register.c
@@ -54,7 +54,6 @@ static struct gsubr_t gschem_funcs[] = {
   { "bus-ripper-size",              1, 0, 0, (SCM (*) ()) g_rc_bus_ripper_size },
   { "bus-ripper-type",              1, 0, 0, (SCM (*) ()) g_rc_bus_ripper_type },
   { "bus-ripper-rotation",          1, 0, 0, (SCM (*) ()) g_rc_bus_ripper_rotation },
-  { "dots-grid-mode",               1, 0, 0, (SCM (*) ()) g_rc_dots_grid_mode },
 
   /* backup functions */
   { "auto-save-interval",           1, 0, 0, (SCM (*) ()) g_rc_auto_save_interval },

--- a/schematic/src/g_register.c
+++ b/schematic/src/g_register.c
@@ -44,7 +44,6 @@ static struct gsubr_t gschem_funcs[] = {
 
   { "log-window",                   1, 0, 0, (SCM (*) ()) g_rc_log_window },
   { "net-consolidate",              1, 0, 0, (SCM (*) ()) g_rc_net_consolidate },
-  { "undo-levels",                  1, 0, 0, (SCM (*) ()) g_rc_undo_levels },
   { "undo-panzoom",                 1, 0, 0, (SCM (*) ()) g_rc_undo_panzoom },
 
   { "add-menu",                     2, 0, 0, (SCM (*) ()) g_rc_add_menu },

--- a/schematic/src/g_register.c
+++ b/schematic/src/g_register.c
@@ -44,7 +44,6 @@ static struct gsubr_t gschem_funcs[] = {
 
   { "log-window",                   1, 0, 0, (SCM (*) ()) g_rc_log_window },
   { "net-consolidate",              1, 0, 0, (SCM (*) ()) g_rc_net_consolidate },
-  { "undo-panzoom",                 1, 0, 0, (SCM (*) ()) g_rc_undo_panzoom },
 
   { "add-menu",                     2, 0, 0, (SCM (*) ()) g_rc_add_menu },
   { "bus-ripper-size",              1, 0, 0, (SCM (*) ()) g_rc_bus_ripper_size },

--- a/schematic/src/g_register.c
+++ b/schematic/src/g_register.c
@@ -46,7 +46,6 @@ static struct gsubr_t gschem_funcs[] = {
   { "net-consolidate",              1, 0, 0, (SCM (*) ()) g_rc_net_consolidate },
 
   { "add-menu",                     2, 0, 0, (SCM (*) ()) g_rc_add_menu },
-  { "bus-ripper-rotation",          1, 0, 0, (SCM (*) ()) g_rc_bus_ripper_rotation },
 
   /* backup functions */
   { "auto-save-interval",           1, 0, 0, (SCM (*) ()) g_rc_auto_save_interval },

--- a/schematic/src/g_register.c
+++ b/schematic/src/g_register.c
@@ -44,9 +44,6 @@ static struct gsubr_t gschem_funcs[] = {
 
   { "add-menu",                     2, 0, 0, (SCM (*) ()) g_rc_add_menu },
 
-  /* backup functions */
-  { "auto-save-interval",           1, 0, 0, (SCM (*) ()) g_rc_auto_save_interval },
-
   /* general guile functions */
   { "gschem-exit",                  0, 0, 0, (SCM (*) ()) g_funcs_exit },
   { "gschem-log",                   1, 0, 0, (SCM (*) ()) g_funcs_log },

--- a/schematic/src/g_register.c
+++ b/schematic/src/g_register.c
@@ -44,7 +44,6 @@ static struct gsubr_t gschem_funcs[] = {
   { "attribute-name",               1, 0, 0, (SCM (*) ()) g_rc_attribute_name },
 
   { "log-window",                   1, 0, 0, (SCM (*) ()) g_rc_log_window },
-  { "third-button",                 0, 1, 0, (SCM (*) ()) g_rc_third_button },
   { "scroll-wheel",                 1, 0, 0, (SCM (*) ()) g_rc_scroll_wheel },
   { "net-consolidate",              1, 0, 0, (SCM (*) ()) g_rc_net_consolidate },
   { "undo-levels",                  1, 0, 0, (SCM (*) ()) g_rc_undo_levels },

--- a/schematic/src/g_register.c
+++ b/schematic/src/g_register.c
@@ -44,7 +44,6 @@ static struct gsubr_t gschem_funcs[] = {
   { "attribute-name",               1, 0, 0, (SCM (*) ()) g_rc_attribute_name },
 
   { "log-window",                   1, 0, 0, (SCM (*) ()) g_rc_log_window },
-  { "scroll-wheel",                 1, 0, 0, (SCM (*) ()) g_rc_scroll_wheel },
   { "net-consolidate",              1, 0, 0, (SCM (*) ()) g_rc_net_consolidate },
   { "undo-levels",                  1, 0, 0, (SCM (*) ()) g_rc_undo_levels },
   { "undo-control",                 1, 0, 0, (SCM (*) ()) g_rc_undo_control },

--- a/schematic/src/g_register.c
+++ b/schematic/src/g_register.c
@@ -46,7 +46,6 @@ static struct gsubr_t gschem_funcs[] = {
   { "net-consolidate",              1, 0, 0, (SCM (*) ()) g_rc_net_consolidate },
 
   { "add-menu",                     2, 0, 0, (SCM (*) ()) g_rc_add_menu },
-  { "bus-ripper-size",              1, 0, 0, (SCM (*) ()) g_rc_bus_ripper_size },
   { "bus-ripper-type",              1, 0, 0, (SCM (*) ()) g_rc_bus_ripper_type },
   { "bus-ripper-rotation",          1, 0, 0, (SCM (*) ()) g_rc_bus_ripper_rotation },
 

--- a/schematic/src/g_register.c
+++ b/schematic/src/g_register.c
@@ -38,8 +38,6 @@ static struct gsubr_t gschem_funcs[] = {
   { "display-color-map",            0, 1, 0, (SCM (*) ()) g_rc_display_color_map },
   { "display-outline-color-map",    0, 1, 0, (SCM (*) ()) g_rc_display_outline_color_map },
 
-  { "logging",                      1, 0, 0, (SCM (*) ()) g_rc_logging },
-
   { "attribute-name",               1, 0, 0, (SCM (*) ()) g_rc_attribute_name },
 
   { "log-window",                   1, 0, 0, (SCM (*) ()) g_rc_log_window },

--- a/schematic/src/g_register.c
+++ b/schematic/src/g_register.c
@@ -38,7 +38,6 @@ static struct gsubr_t gschem_funcs[] = {
   { "display-color-map",            0, 1, 0, (SCM (*) ()) g_rc_display_color_map },
   { "display-outline-color-map",    0, 1, 0, (SCM (*) ()) g_rc_display_outline_color_map },
 
-  { "net-selection-mode",           1, 0, 0, (SCM (*) ()) g_rc_net_selection_mode },
   { "logging",                      1, 0, 0, (SCM (*) ()) g_rc_logging },
 
   { "attribute-name",               1, 0, 0, (SCM (*) ()) g_rc_attribute_name },

--- a/schematic/src/g_register.c
+++ b/schematic/src/g_register.c
@@ -40,8 +40,6 @@ static struct gsubr_t gschem_funcs[] = {
 
   { "attribute-name",               1, 0, 0, (SCM (*) ()) g_rc_attribute_name },
 
-  { "log-window",                   1, 0, 0, (SCM (*) ()) g_rc_log_window },
-
   { "add-menu",                     2, 0, 0, (SCM (*) ()) g_rc_add_menu },
 
   /* general guile functions */

--- a/schematic/src/g_register.c
+++ b/schematic/src/g_register.c
@@ -43,7 +43,6 @@ static struct gsubr_t gschem_funcs[] = {
   { "attribute-name",               1, 0, 0, (SCM (*) ()) g_rc_attribute_name },
 
   { "log-window",                   1, 0, 0, (SCM (*) ()) g_rc_log_window },
-  { "net-consolidate",              1, 0, 0, (SCM (*) ()) g_rc_net_consolidate },
 
   { "add-menu",                     2, 0, 0, (SCM (*) ()) g_rc_add_menu },
 

--- a/schematic/src/i_vars.c
+++ b/schematic/src/i_vars.c
@@ -477,7 +477,12 @@ i_vars_set (GschemToplevel* w_current)
 
 
   w_current->undo_levels = default_undo_levels;
-  w_current->undo_control = default_undo_control;
+
+
+  cfg_read_bool ("schematic.undo", "undo-control",
+                 default_undo_control, &w_current->undo_control);
+
+
   w_current->undo_type = default_undo_type;
   w_current->undo_panzoom = default_undo_panzoom;
 

--- a/schematic/src/i_vars.c
+++ b/schematic/src/i_vars.c
@@ -371,7 +371,21 @@ i_vars_set (GschemToplevel* w_current)
   w_current->include_complex = default_include_complex;
   w_current->log_window      = default_log_window;
 
-  w_current->third_button       = default_third_button;
+
+  /* third-button:
+  */
+  const struct OptionStringInt vals_tb[] =
+  {
+    { "popup",    MOUSEBTN_DO_POPUP },
+    { "mousepan", MOUSEBTN_DO_PAN   }
+  };
+
+  cfg_read_string2int ("schematic.gui",
+                       "third-button",
+                       default_third_button,
+                       vals_tb,
+                       sizeof( vals_tb ) / sizeof( vals_tb[0] ),
+                       &w_current->third_button);
 
 
   cfg_read_bool ("schematic.gui", "file-preview",

--- a/schematic/src/i_vars.c
+++ b/schematic/src/i_vars.c
@@ -411,7 +411,22 @@ i_vars_set (GschemToplevel* w_current)
                        &w_current->middle_button);
 
 
-  w_current->scroll_wheel       = default_scroll_wheel;
+  /* scroll-wheel:
+  */
+  const struct OptionStringInt vals_sw[] =
+  {
+    { "classic", SCROLL_WHEEL_CLASSIC },
+    { "gtk",     SCROLL_WHEEL_GTK     }
+  };
+
+  cfg_read_string2int ("schematic.gui",
+                       "scroll-wheel",
+                       default_scroll_wheel,
+                       vals_sw,
+                       sizeof( vals_sw ) / sizeof( vals_sw[0] ),
+                       &w_current->scroll_wheel);
+
+
   toplevel->net_consolidate    = default_net_consolidate;
 
 

--- a/schematic/src/i_vars.c
+++ b/schematic/src/i_vars.c
@@ -499,8 +499,8 @@ i_vars_set (GschemToplevel* w_current)
                        &w_current->undo_type);
 
 
-  w_current->undo_panzoom = default_undo_panzoom;
-
+  cfg_read_bool ("schematic.undo", "undo-panzoom",
+                 default_undo_panzoom, &w_current->undo_panzoom);
 
   cfg_read_bool ("schematic.gui", "draw-grips",
                  default_draw_grips, &w_current->draw_grips);

--- a/schematic/src/i_vars.c
+++ b/schematic/src/i_vars.c
@@ -460,8 +460,8 @@ i_vars_set (GschemToplevel* w_current)
                        &w_current->scroll_wheel);
 
 
-  toplevel->net_consolidate    = default_net_consolidate;
-
+  cfg_read_bool ("schematic", "net-consolidate",
+                 default_net_consolidate, &toplevel->net_consolidate);
 
   cfg_read_bool ("schematic.gui", "file-preview",
                  default_file_preview, &w_current->file_preview);

--- a/schematic/src/i_vars.c
+++ b/schematic/src/i_vars.c
@@ -284,7 +284,25 @@ i_vars_set_options (GschemOptions* opts)
   gschem_options_set_snap_size (opts, snap_size);
 
 
-  gschem_options_set_grid_mode (opts, (GRID_MODE) default_grid_mode);
+  /* grid-mode:
+  */
+  const struct OptionStringInt vals_gm[] =
+  {
+    { "none", GRID_MODE_NONE },
+    { "dots", GRID_MODE_DOTS },
+    { "mesh", GRID_MODE_MESH }
+  };
+
+  int grid_mode = 0;
+  cfg_read_string2int ("schematic.gui",
+                       "grid-mode",
+                       default_grid_mode,
+                       vals_gm,
+                       sizeof( vals_gm ) / sizeof( vals_gm[0] ),
+                       &grid_mode);
+
+  gschem_options_set_grid_mode (opts, (GRID_MODE) grid_mode);
+
 
   gboolean val = FALSE;
   cfg_read_bool ("schematic.gui", "netconn-rubberband",

--- a/schematic/src/i_vars.c
+++ b/schematic/src/i_vars.c
@@ -378,7 +378,25 @@ i_vars_set (GschemToplevel* w_current)
                  default_third_button_cancel, &w_current->third_button_cancel);
 
 
-  w_current->middle_button      = default_middle_button;
+  /* middle-button:
+  */
+  const struct OptionStringInt vals_mb[] =
+  {
+    { "stroke",   MOUSEBTN_DO_STROKE },
+    { "repeat",   MOUSEBTN_DO_REPEAT },
+    { "action",   MOUSEBTN_DO_ACTION },
+    { "mousepan", MOUSEBTN_DO_PAN    },
+    { "popup",    MOUSEBTN_DO_POPUP  }
+  };
+
+  cfg_read_string2int ("schematic.gui",
+                       "middle-button",
+                       default_middle_button,
+                       vals_mb,
+                       sizeof( vals_mb ) / sizeof( vals_mb[0] ),
+                       &w_current->middle_button);
+
+
   w_current->scroll_wheel       = default_scroll_wheel;
   toplevel->net_consolidate    = default_net_consolidate;
 

--- a/schematic/src/i_vars.c
+++ b/schematic/src/i_vars.c
@@ -317,7 +317,21 @@ i_vars_set (GschemToplevel* w_current)
                            &check_int_text_size);
 
 
-  w_current->text_caps     = default_text_caps;
+  /* text-caps-style:
+  */
+  const struct OptionStringInt vals_tcs[] =
+  {
+    { "both",  BOTH  },
+    { "lower", LOWER },
+    { "upper", UPPER }
+  };
+
+  cfg_read_string2int ("schematic.gui",
+                       "text-caps-style",
+                       default_text_caps,
+                       vals_tcs,
+                       sizeof( vals_tcs ) / sizeof( vals_tcs[0] ),
+                       &w_current->text_caps);
 
 
   cfg_read_bool ("schematic.gui", "net-direction-mode",

--- a/schematic/src/i_vars.c
+++ b/schematic/src/i_vars.c
@@ -324,9 +324,12 @@ i_vars_set (GschemToplevel* w_current)
   TOPLEVEL *toplevel = gschem_toplevel_get_toplevel (w_current);
   i_vars_libgeda_set(toplevel);
 
+
   /* this will be false if logging cannot be enabled */
-  if (do_logging != FALSE) {
-    do_logging = default_do_logging;
+  if (do_logging != FALSE)
+  {
+    cfg_read_bool ("schematic", "logging",
+                   default_do_logging, &do_logging);
   }
 
 

--- a/schematic/src/i_vars.c
+++ b/schematic/src/i_vars.c
@@ -535,7 +535,20 @@ i_vars_set (GschemToplevel* w_current)
                        &w_current->bus_ripper_type);
 
 
-  w_current->bus_ripper_rotation  = default_bus_ripper_rotation;
+  /* bus-ripper-rotation:
+  */
+  const struct OptionStringInt vals_brr[] =
+  {
+    { "non-symmetric", NON_SYMMETRIC },
+    { "symmetric",     SYMMETRIC     }
+  };
+
+  cfg_read_string2int ("schematic",
+                       "bus-ripper-rotation",
+                       default_bus_ripper_rotation,
+                       vals_brr,
+                       sizeof( vals_brr ) / sizeof( vals_brr[0] ),
+                       &w_current->bus_ripper_rotation);
 
 
   cfg_read_bool ("schematic.gui", "force-boundingbox",

--- a/schematic/src/i_vars.c
+++ b/schematic/src/i_vars.c
@@ -492,7 +492,20 @@ i_vars_set (GschemToplevel* w_current)
                            &check_int_greater_0);
 
 
-  w_current->dots_grid_mode              = default_dots_grid_mode;
+  /* dots-grid-mode:
+  */
+  const struct OptionStringInt vals_dgm[] =
+  {
+    { "variable", DOTS_GRID_VARIABLE_MODE },
+    { "fixed",    DOTS_GRID_FIXED_MODE    }
+  };
+
+  cfg_read_string2int ("schematic.gui",
+                       "dots-grid-mode",
+                       default_dots_grid_mode,
+                       vals_dgm,
+                       sizeof( vals_dgm ) / sizeof( vals_dgm[0] ),
+                       &w_current->dots_grid_mode);
 
 
   cfg_read_int_with_check ("schematic.gui", "dots-grid-fixed-threshold",

--- a/schematic/src/i_vars.c
+++ b/schematic/src/i_vars.c
@@ -519,7 +519,22 @@ i_vars_set (GschemToplevel* w_current)
                            &check_int_greater_0);
 
 
-  w_current->bus_ripper_type  = default_bus_ripper_type;
+  /* bus-ripper-type:
+  */
+  const struct OptionStringInt vals_brt[] =
+  {
+    { "component", COMP_BUS_RIPPER },
+    { "net",       NET_BUS_RIPPER  }
+  };
+
+  cfg_read_string2int ("schematic",
+                       "bus-ripper-type",
+                       default_bus_ripper_type,
+                       vals_brt,
+                       sizeof( vals_brt ) / sizeof( vals_brt[0] ),
+                       &w_current->bus_ripper_type);
+
+
   w_current->bus_ripper_rotation  = default_bus_ripper_rotation;
 
 

--- a/schematic/src/i_vars.c
+++ b/schematic/src/i_vars.c
@@ -483,7 +483,22 @@ i_vars_set (GschemToplevel* w_current)
                  default_undo_control, &w_current->undo_control);
 
 
-  w_current->undo_type = default_undo_type;
+  /* undo-type:
+  */
+  const struct OptionStringInt vals_ut[] =
+  {
+    { "disk",   UNDO_DISK   },
+    { "memory", UNDO_MEMORY }
+  };
+
+  cfg_read_string2int ("schematic.undo",
+                       "undo-type",
+                       default_undo_type,
+                       vals_ut,
+                       sizeof( vals_ut ) / sizeof( vals_ut[0] ),
+                       &w_current->undo_type);
+
+
   w_current->undo_panzoom = default_undo_panzoom;
 
 

--- a/schematic/src/i_vars.c
+++ b/schematic/src/i_vars.c
@@ -405,7 +405,22 @@ i_vars_set (GschemToplevel* w_current)
 
 
   w_current->include_complex = default_include_complex;
-  w_current->log_window      = default_log_window;
+
+
+  /* log-window:
+  */
+  const struct OptionStringInt vals_lw[] =
+  {
+    { "startup", MAP_ON_STARTUP },
+    { "later",   MAP_LATER      }
+  };
+
+  cfg_read_string2int ("schematic",
+                       "log-window",
+                       default_log_window,
+                       vals_lw,
+                       sizeof( vals_lw ) / sizeof( vals_lw[0] ),
+                       &w_current->log_window);
 
 
   /* third-button:

--- a/schematic/src/i_vars.c
+++ b/schematic/src/i_vars.c
@@ -475,9 +475,9 @@ i_vars_set (GschemToplevel* w_current)
   cfg_read_bool ("schematic.gui", "continue-component-place",
                  default_continue_component_place, &w_current->continue_component_place);
 
-
-  w_current->undo_levels = default_undo_levels;
-
+  cfg_read_int_with_check ("schematic.undo", "undo-levels",
+                           default_undo_levels, &w_current->undo_levels,
+                           &check_int_greater_0);
 
   cfg_read_bool ("schematic.undo", "undo-control",
                  default_undo_control, &w_current->undo_control);

--- a/schematic/src/i_vars.c
+++ b/schematic/src/i_vars.c
@@ -514,7 +514,11 @@ i_vars_set (GschemToplevel* w_current)
   cfg_read_bool ("schematic.gui", "handleboxes",
                  default_handleboxes, &w_current->handleboxes);
 
-  w_current->bus_ripper_size  = default_bus_ripper_size;
+  cfg_read_int_with_check ("schematic", "bus-ripper-size",
+                           default_bus_ripper_size, &w_current->bus_ripper_size,
+                           &check_int_greater_0);
+
+
   w_current->bus_ripper_type  = default_bus_ripper_type;
   w_current->bus_ripper_rotation  = default_bus_ripper_rotation;
 

--- a/schematic/src/i_vars.c
+++ b/schematic/src/i_vars.c
@@ -356,7 +356,22 @@ i_vars_set (GschemToplevel* w_current)
                  default_net_direction_mode, &w_current->net_direction_mode);
 
 
-  w_current->net_selection_mode = default_net_selection_mode;
+  /* net-selection-mode:
+   * TODO: define and use constants for the net-selection-mode values
+  */
+  const struct OptionStringInt vals_nsm[] =
+  {
+    { "disabled",    0 },
+    { "enabled_net", 2 },
+    { "enabled_all", 3 }
+  };
+
+  cfg_read_string2int ("schematic.gui",
+                       "net-selection-mode",
+                       default_net_selection_mode,
+                       vals_nsm,
+                       sizeof( vals_nsm ) / sizeof( vals_nsm[0] ),
+                       &w_current->net_selection_mode);
 
 
   cfg_read_bool ("schematic.gui", "zoom-with-pan",

--- a/schematic/src/i_vars.c
+++ b/schematic/src/i_vars.c
@@ -155,8 +155,8 @@ check_int_not_0 (gint val) { return val != 0; }
 static gboolean
 check_int_greater_0 (gint val) { return val > 0; }
 
-/* static gboolean
-check_int_greater_eq_0 (gint val) { return val >= 0; } */
+static gboolean
+check_int_greater_eq_0 (gint val) { return val >= 0; }
 
 static gboolean
 check_int_text_size (gint val) { return val >= MINIMUM_TEXT_SIZE; }
@@ -606,12 +606,14 @@ i_vars_set (GschemToplevel* w_current)
                            default_scrollpan_steps, &w_current->scrollpan_steps,
                            &check_int_not_0);
 
-
-  toplevel->auto_save_interval = default_auto_save_interval;
+  cfg_read_int_with_check ("schematic", "auto-save-interval",
+                           default_auto_save_interval, &toplevel->auto_save_interval,
+                           &check_int_greater_eq_0);
 
 
   i_vars_set_options (w_current->options);
-}
+
+} /* i_vars_set() */
 
 
 /*! \brief Free default names

--- a/schematic/src/o_undo.c
+++ b/schematic/src/o_undo.c
@@ -395,7 +395,7 @@ o_undo_callback (GschemToplevel *w_current, PAGE *page, int type)
   g_return_if_fail (page != NULL);
 
   if (w_current->undo_control == FALSE) {
-    s_log_message(_("Undo/Redo disabled in rc file"));
+    s_log_message(_("Undo/Redo is disabled in configuration"));
     return;
   }
 


### PR DESCRIPTION
Deprecate remaining `gschemrc` options listed in issue #423, except
`bus-ripper-symname`, convert them to new configuration system.
See also the previous PR ("part 1", #518).
