### PR TITLE
Several simplifications in lepton-netlist code base

### DIFF
--- a/netlist/scheme/netlist.scm
+++ b/netlist/scheme/netlist.scm
@@ -472,7 +472,7 @@ connection pairs in the form (\"pin-number\" . \"net-name\")."
 
   (let ((found (lookup-through-netlist (schematic-components (toplevel-schematic)))))
     (match found
-      (((netname . rest) ...)
+      (((netname . rest) ..1)
        (cons (car netname) (apply append (delq #f rest))))
       (_ '("ERROR_INVALID_PIN")))))
 

--- a/netlist/scheme/netlist/hierarchy.scm
+++ b/netlist/scheme/netlist/hierarchy.scm
@@ -159,22 +159,6 @@
   (define refdes (schematic-component-refdes component))
   (define tag (schematic-component-tag component))
 
-  (define (add-net-power-pin-override pin net-map tag)
-    (define (power-pin? pin)
-      (string=? "pwr" (assq-ref (package-pin-attribs pin) 'pintype)))
-
-    (let ((connection (package-pin-connection pin))
-          (name (create-net-name (net-map-netname net-map)
-                                 tag
-                                 'power-rail)))
-      (when (power-pin? pin)
-        (set-schematic-connection-override-name!
-         connection
-         (match (schematic-connection-override-name connection)
-           ((? list? x) `(,name . ,x))
-           (#f name)
-           (x `(,name ,x)))))))
-
   (define (check-shorted-nets a b priority)
     (log! 'critical
           (_ "Rename shorted nets (~A= has priority): ~A -> ~A")
@@ -201,7 +185,6 @@
             (set-pin-net-name! net netname)))))
 
   (let ((net-map (package-pin-net-map pin)))
-    (add-net-power-pin-override pin net-map tag)
     (and refdes
          (let ((netname (create-net-name (net-map-netname net-map)
                                          tag

--- a/netlist/scheme/netlist/hierarchy.scm
+++ b/netlist/scheme/netlist/hierarchy.scm
@@ -192,19 +192,19 @@
 
   (define (update-pin-netname pin netname id refdes)
     (let ((nets (package-pin-nets pin))
-          (net-priority (net-attrib-pin? (package-pin-object pin)))
           (object #f))
       (set-package-pin-name! pin netname)
       (if (null? nets)
           (set-package-pin-nets! pin
                                  (list (make-pin-net id
                                                      object
-                                                     net-priority
+                                                     #f
                                                      netname)))
           (let ((net (car nets)))
             (set-pin-net-id! net id)
-            (set-pin-net-priority! net net-priority)
-            (set-pin-net-name! net netname)))))
+            (set-pin-net-name! net netname)))
+      (when (net-attrib-pin? (package-pin-object pin))
+        (set-pin-net-priority! pin #t))))
 
   (let ((net-map (package-pin-net-map pin)))
     (add-net-power-pin-override pin net-map tag)

--- a/netlist/scheme/netlist/hierarchy.scm
+++ b/netlist/scheme/netlist/hierarchy.scm
@@ -154,7 +154,11 @@
 
 
 ;;; This function does renaming job for PIN.
-(define (net-map-update-pin pin id refdes tag)
+(define (net-map-update-pin component pin)
+  (define id (schematic-component-id component))
+  (define refdes (schematic-component-refdes component))
+  (define tag (schematic-component-tag component))
+
   (define (add-net-power-pin-override pin net-map tag)
     (define (power-pin? pin)
       (string=? "pwr" (assq-ref (package-pin-attribs pin) 'pintype)))
@@ -216,17 +220,12 @@
 
 
 (define (update-component-net-mapped-pins component)
-  (define pins (schematic-component-pins component))
-  (define id (schematic-component-id component))
-  (define refdes (schematic-component-refdes component))
-  (define tag (schematic-component-tag component))
-
   (define (update-pin pin)
     (and (package-pin-object pin)
          (package-pin-net-map pin)
-         (net-map-update-pin pin id refdes tag)))
+         (net-map-update-pin component pin)))
 
-  (for-each update-pin pins))
+  (for-each update-pin (schematic-component-pins component)))
 
 
 (define (update-component-pins schematic-component)

--- a/netlist/scheme/netlist/hierarchy.scm
+++ b/netlist/scheme/netlist/hierarchy.scm
@@ -186,6 +186,8 @@
 
   (let ((net-map (package-pin-net-map pin)))
     (and refdes
+         net-map
+         (package-pin-object pin)
          (let ((netname (create-net-name (net-map-netname net-map)
                                          tag
                                          'power-rail))
@@ -203,12 +205,8 @@
 
 
 (define (update-component-net-mapped-pins component)
-  (define (update-pin pin)
-    (and (package-pin-object pin)
-         (package-pin-net-map pin)
-         (net-map-update-pin component pin)))
-
-  (for-each update-pin (schematic-component-pins component)))
+  (for-each (cut net-map-update-pin component <>)
+            (schematic-component-pins component)))
 
 
 (define (update-component-pins schematic-component)

--- a/netlist/scheme/netlist/hierarchy.scm
+++ b/netlist/scheme/netlist/hierarchy.scm
@@ -48,17 +48,9 @@
   (define (disabled? refdes)
     (equal? refdes disabled-refdes))
 
-  (define (disable-net-connected-to net)
-    (when (and=> (pin-net-connection-package net) disabled?)
-      (set-pin-net-connection-package! net #f)))
-
-  (define (disable-nets-connected-to pin)
-    (for-each disable-net-connected-to (package-pin-nets pin)))
-
   (define (disable-package-refdes package)
     (when (and=> (schematic-component-refdes package) disabled?)
-      (set-schematic-component-refdes! package #f))
-    (for-each disable-nets-connected-to (schematic-component-pins package)))
+      (set-schematic-component-refdes! package #f)))
 
   (for-each disable-package-refdes netlist)
   ;; Return the modified netlist.
@@ -157,17 +149,9 @@
       ((? list? refdes) (car refdes))
       (refdes refdes)))
 
-  (define (fix-net-connections net)
-    (set-pin-net-connection-package! net
-                                     (base-refdes (pin-net-connection-package net))))
-
-  (define (fix-pin-connections pin)
-    (for-each fix-net-connections (package-pin-nets pin)))
-
   (define (fix-package package)
     (set-schematic-component-refdes! package
-                         (base-refdes (schematic-component-refdes package)))
-    (for-each fix-pin-connections (schematic-component-pins package))
+                                     (base-refdes (schematic-component-refdes package)))
     package)
 
   (for-each fix-package netlist)
@@ -229,15 +213,11 @@
                                  (list (make-pin-net id
                                                      object
                                                      net-priority
-                                                     netname
-                                                     refdes
-                                                     pinnumber)))
+                                                     netname)))
           (let ((net (car nets)))
             (set-pin-net-id! net id)
             (set-pin-net-priority! net net-priority)
-            (set-pin-net-name! net netname)
-            (set-pin-net-connection-package! net refdes)
-            (set-pin-net-connection-pinnumber! net pinnumber)))))
+            (set-pin-net-name! net netname)))))
 
   (let ((net-map (package-pin-net-map pin)))
     (add-net-power-pin-override pin net-map tag)

--- a/netlist/scheme/netlist/hierarchy.scm
+++ b/netlist/scheme/netlist/hierarchy.scm
@@ -110,20 +110,13 @@
     (let ((current-name (pin-net-name net)))
       (if (and prev-name current-name)
           ;; Both names defined.
-          (if (pin-net-priority net)
-              (if (gnetlist-config-ref 'netname-attribute-priority)
-                  ;; netname= has priority over net=.
-                  ;; Rename the current net to the previously
-                  ;; found name (label= name) and return the
-                  ;; latter.
-                  (simple-add-rename current-name prev-name)
-                  ;; net= has priority over netname=.
-                  ;; Since the net has net= priority set, use
-                  ;; its name instead of the name found
-                  ;; previously.
-                  (simple-add-rename prev-name current-name))
-              ;; Do the rename anyways (this might cause problems).
-              ;; Rename net which has the same label=.
+          (if (and (pin-net-priority net)
+                   (gnetlist-config-ref 'netname-attribute-priority))
+              ;; If netname= has priority over net=, but the pin
+              ;; is a power (net= driven) pin, use netname=,
+              ;; anyways.
+              (simple-add-rename current-name prev-name)
+              ;; Otherwise, do the rename anyways (this might cause problems).
               (simple-add-rename prev-name current-name))
           ;; One or both undefined: return either defined or #f.
           (or prev-name current-name))))

--- a/netlist/scheme/netlist/hierarchy.scm
+++ b/netlist/scheme/netlist/hierarchy.scm
@@ -192,7 +192,6 @@
 
   (define (update-pin-netname pin netname id refdes)
     (let ((nets (package-pin-nets pin))
-          (pinnumber (package-pin-number pin))
           (net-priority (net-attrib-pin? (package-pin-object pin)))
           (object #f))
       (set-package-pin-name! pin netname)

--- a/netlist/scheme/netlist/hierarchy.scm
+++ b/netlist/scheme/netlist/hierarchy.scm
@@ -110,7 +110,7 @@
     (let ((current-name (pin-net-name net)))
       (if (and prev-name current-name)
           ;; Both names defined.
-          (if (and (pin-net-priority net)
+          (if (and (net-attrib-pin? (pin-net-object net))
                    (gnetlist-config-ref 'netname-attribute-priority))
               ;; If netname= has priority over net=, but the pin
               ;; is a power (net= driven) pin, use netname=,
@@ -191,7 +191,6 @@
           (set-package-pin-nets! pin
                                  (list (make-pin-net id
                                                      object
-                                                     #f
                                                      netname)))
           (let ((net (car nets)))
             (set-pin-net-id! net id)

--- a/netlist/scheme/netlist/hierarchy.scm
+++ b/netlist/scheme/netlist/hierarchy.scm
@@ -202,9 +202,7 @@
                                                      netname)))
           (let ((net (car nets)))
             (set-pin-net-id! net id)
-            (set-pin-net-name! net netname)))
-      (when (net-attrib-pin? (package-pin-object pin))
-        (set-pin-net-priority! pin #t))))
+            (set-pin-net-name! net netname)))))
 
   (let ((net-map (package-pin-net-map pin)))
     (add-net-power-pin-override pin net-map tag)

--- a/netlist/scheme/netlist/net.scm
+++ b/netlist/scheme/netlist/net.scm
@@ -24,7 +24,6 @@
   #:use-module (geda object)
   #:use-module (netlist config)
   #:use-module (netlist core gettext)
-  #:use-module (netlist hierarchy)
   #:use-module (symbol check net-attrib)
   #:use-module (symbol check duplicate)
 

--- a/netlist/scheme/netlist/pin-net.scm
+++ b/netlist/scheme/netlist/pin-net.scm
@@ -24,16 +24,14 @@
   #:export (make-pin-net pin-net?
             pin-net-id set-pin-net-id!
             pin-net-object set-pin-net-object!
-            pin-net-priority set-pin-net-priority!
             pin-net-name set-pin-net-name!
             set-pin-net-printer!))
 
 (define-record-type <pin-net>
-  (make-pin-net id object priority name)
+  (make-pin-net id object name)
   pin-net?
   (id pin-net-id set-pin-net-id!)
   (object pin-net-object set-pin-net-object!)
-  (priority pin-net-priority set-pin-net-priority!)
   (name pin-net-name set-pin-net-name!))
 
 ;;; Sets default printer for <pin-net>
@@ -47,7 +45,6 @@ FORMAT-STRING must be in the form required by the procedure
 `format'. The following ARGS may be used:
   'id
   'object
-  'priority
   'name
 Any other unrecognized argument will lead to yielding '?' in the
 corresponding place.
@@ -62,7 +59,6 @@ Example usage:
                (match arg
                  ('id (pin-net-id record))
                  ('object (pin-net-object record))
-                 ('priority (pin-net-priority record))
                  ('name (pin-net-name record))
                  (_ #\?)))
              args)))))

--- a/netlist/scheme/netlist/pin-net.scm
+++ b/netlist/scheme/netlist/pin-net.scm
@@ -26,19 +26,15 @@
             pin-net-object set-pin-net-object!
             pin-net-priority set-pin-net-priority!
             pin-net-name set-pin-net-name!
-            pin-net-connection-package set-pin-net-connection-package!
-            pin-net-connection-pinnumber set-pin-net-connection-pinnumber!
             set-pin-net-printer!))
 
 (define-record-type <pin-net>
-  (make-pin-net id object priority name connection-package connection-pinnumber)
+  (make-pin-net id object priority name)
   pin-net?
   (id pin-net-id set-pin-net-id!)
   (object pin-net-object set-pin-net-object!)
   (priority pin-net-priority set-pin-net-priority!)
-  (name pin-net-name set-pin-net-name!)
-  (connection-package pin-net-connection-package set-pin-net-connection-package!)
-  (connection-pinnumber pin-net-connection-pinnumber set-pin-net-connection-pinnumber!))
+  (name pin-net-name set-pin-net-name!))
 
 ;;; Sets default printer for <pin-net>
 (set-record-type-printer!
@@ -53,8 +49,6 @@ FORMAT-STRING must be in the form required by the procedure
   'object
   'priority
   'name
-  'connection-package
-  'connection-pinnumber
 Any other unrecognized argument will lead to yielding '?' in the
 corresponding place.
 Example usage:
@@ -70,7 +64,5 @@ Example usage:
                  ('object (pin-net-object record))
                  ('priority (pin-net-priority record))
                  ('name (pin-net-name record))
-                 ('connection-package (pin-net-connection-package record))
-                 ('connection-pinnumber (pin-net-connection-pinnumber record))
                  (_ #\?)))
              args)))))

--- a/netlist/scheme/netlist/schematic.scm
+++ b/netlist/scheme/netlist/schematic.scm
@@ -335,7 +335,7 @@ of schematic pages."
                       ))))
 
 
-(define* (file-name-list->schematic filenames)
+(define (file-name-list->schematic filenames)
   "Creates a new schematic record from FILENAMES, which must be a
 list of strings representing file names."
   (let ((pages (map file->page filenames)))

--- a/netlist/scheme/netlist/traverse.scm
+++ b/netlist/scheme/netlist/traverse.scm
@@ -294,8 +294,7 @@
   (let* ((object (pin-net-object pin))
          (refdes-pinnumber-pair (pin-refdes-pinnumber-pair object))
          (refdes (car refdes-pinnumber-pair))
-         (pinnumber (cdr refdes-pinnumber-pair))
-         (net-driven? (net-attrib-pin? object)))
+         (pinnumber (cdr refdes-pinnumber-pair)))
     ;; The object is a pin, and it defines net name using
     ;; "net=".  Use hierarchy tag here to make this netname
     ;; unique.
@@ -305,8 +304,8 @@
                                             pinnumber)
                       tag
                       'power-rail))
-    (when net-driven?
-      (set-pin-net-priority! pin net-driven?))))
+    (when (net-attrib-pin? object)
+      (set-pin-net-priority! pin #t))))
 
 
 (define (set-real-package-pin-connection-properties! pin connections)

--- a/netlist/scheme/netlist/traverse.scm
+++ b/netlist/scheme/netlist/traverse.scm
@@ -265,8 +265,6 @@
    (object-id object)
    ;; object
    object
-   ;; priority
-   #f
    ;; name
    #f))
 
@@ -303,8 +301,7 @@
      (create-net-name (netattrib-search-net (object-component object)
                                             pinnumber)
                       tag
-                      'power-rail))
-    (set-pin-net-priority! pin (net-attrib-pin? object))))
+                      'power-rail))))
 
 
 (define (set-real-package-pin-connection-properties! pin connections)
@@ -332,7 +329,6 @@
                                    'power-rail))
          (nets (list (make-pin-net (package-pin-id pin)
                                    (package-pin-object pin)
-                                   #f
                                    netname)))
          (connection (get-connection-by-netname netname
                                                 connections

--- a/netlist/scheme/netlist/traverse.scm
+++ b/netlist/scheme/netlist/traverse.scm
@@ -304,8 +304,7 @@
                                             pinnumber)
                       tag
                       'power-rail))
-    (when (net-attrib-pin? object)
-      (set-pin-net-priority! pin #t))))
+    (set-pin-net-priority! pin (net-attrib-pin? object))))
 
 
 (define (set-real-package-pin-connection-properties! pin connections)

--- a/netlist/scheme/netlist/traverse.scm
+++ b/netlist/scheme/netlist/traverse.scm
@@ -291,7 +291,6 @@
 (define (assign-pin-properties! pin tag)
   (let* ((object (pin-net-object pin))
          (refdes-pinnumber-pair (pin-refdes-pinnumber-pair object))
-         (refdes (car refdes-pinnumber-pair))
          (pinnumber (cdr refdes-pinnumber-pair)))
     ;; The object is a pin, and it defines net name using
     ;; "net=".  Use hierarchy tag here to make this netname

--- a/netlist/scheme/netlist/traverse.scm
+++ b/netlist/scheme/netlist/traverse.scm
@@ -268,10 +268,6 @@
    ;; priority
    #f
    ;; name
-   #f
-   ;; connection-package
-   #f
-   ;; connection-pinnumber
    #f))
 
 
@@ -309,13 +305,8 @@
                                             pinnumber)
                       tag
                       'power-rail))
-    (if net-driven?
-        (set-pin-net-priority! pin net-driven?)
-        (begin
-          (set-pin-net-connection-package! pin
-                                           (hierarchy-create-refdes refdes
-                                                                    tag))
-          (set-pin-net-connection-pinnumber! pin pinnumber)))))
+    (when net-driven?
+      (set-pin-net-priority! pin net-driven?))))
 
 
 (define (set-real-package-pin-connection-properties! pin connections)
@@ -344,9 +335,7 @@
          (nets (list (make-pin-net (package-pin-id pin)
                                    (package-pin-object pin)
                                    #f
-                                   netname
-                                   refdes
-                                   (package-pin-number pin))))
+                                   netname)))
          (connection (get-connection-by-netname netname
                                                 connections
                                                 tag)))

--- a/netlist/scheme/netlist/verbose.scm
+++ b/netlist/scheme/netlist/verbose.scm
@@ -17,6 +17,7 @@
 ;;; MA 02111-1301 USA.
 
 (define-module (netlist verbose)
+  #:use-module (ice-9 format)
   #:use-module (netlist option)
   #:use-module (netlist schematic-component)
   #:use-module (netlist package-pin)

--- a/netlist/scheme/netlist/verbose.scm
+++ b/netlist/scheme/netlist/verbose.scm
@@ -20,31 +20,31 @@
   #:use-module (ice-9 format)
   #:use-module (netlist option)
   #:use-module (netlist schematic-component)
+  #:use-module (netlist schematic-connection)
   #:use-module (netlist package-pin)
-  #:use-module (netlist pin-net)
 
   #:export (verbose-print-netlist))
 
 (define (verbose-print-netlist netlist)
-  (define (print-net net)
-    (let ((package (pin-net-connection-package net))
-          (pinnumber (pin-net-connection-pinnumber net)))
-      (if (and package pinnumber)
+  (define (print-pin-connection-info pin)
+    (let ((refdes (schematic-component-refdes (package-pin-parent pin)))
+          (pinnumber (package-pin-number pin)))
+      (if (and refdes pinnumber)
           (format #f "\t\t~A ~A [~A]\n"
-                  package
+                  refdes
                   pinnumber
-                  (pin-net-id net))
+                  (package-pin-id pin))
           "")))
-
-  (define (print-nets net-list)
-    (string-join (map print-net net-list) ""))
 
   (define (print-pin-info pin)
     (format #f "\tpin~A (~A) ~A\n~A\n"
             (or (package-pin-number pin) "?")
             (or (package-pin-label pin) "")
             (or (package-pin-name pin) "Null net name")
-            (print-nets (package-pin-nets pin))))
+            (string-join
+             (map print-pin-connection-info
+                  (schematic-connection-pins (package-pin-connection pin)))
+             "")))
 
   (define (print-pin-list pin-list)
     (map print-pin-info pin-list))


### PR DESCRIPTION
- Getting rid of several unused variables, module dependencies, and procedures.
- Fix `format` and `match` calls.
- Reduce the `<pin-net>` record by getting rid of its 3 fields: `connection-package`, `connection-pinnumber`, and `priority`.
- Other minor simplifications.