### PR TITLE
Update, unify --help and --version messages

### DIFF
--- a/attrib/docs/lepton-attrib.1.in
+++ b/attrib/docs/lepton-attrib.1.in
@@ -22,6 +22,9 @@ Verbose mode.  Output all diagnostic information.
 .TP 8
 \fB-h\fR, \fB--help\fR
 Print a help message.
+.TP 8
+\fB-V\fR, \fB--version\fR
+Print version information.
 
 .SH ENVIRONMENT
 .TP 8

--- a/attrib/src/parsecmd.c
+++ b/attrib/src/parsecmd.c
@@ -26,6 +26,7 @@
  */
 
 #include <config.h>
+#include <version.h>
 
 #include <stdio.h>
 #ifdef HAVE_STRING_H
@@ -46,7 +47,7 @@
  *  Command line option string for getopt. Defines "q" for quiet,
  *  "v" for verbose and "h" for help.
  */
-#define OPTIONS "qvh"
+#define OPTIONS "qvhV"
 extern char *optarg;
 extern int optind;
 #endif   /* Checking for getopt_long  */
@@ -68,13 +69,15 @@ extern int optind;
  */
 void usage(char *cmd)
 {
-    printf(_("\n"
+    printf(_("Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
+             "\n"
              "lepton-attrib: Lepton EDA attribute editor.\n"
              "Presents schematic attributes in easy-to-edit spreadsheet format.\n"
              "\n"
-             "Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
+             "Options:\n"
              "  -q, --quiet            Quiet mode\n"
              "  -v, --verbose          Verbose mode on\n"
+             "  -V, --version          Show version information\n"
              "  -h, --help             This help menu\n"
              "\n"
              "  FAQ:\n"
@@ -103,17 +106,24 @@ void usage(char *cmd)
     exit(0);
 }
 
+/*! \brief Print version info and exit.
+ */
+static void
+version()
+{
+  char* msg = version_message();
+  printf ("%s\n", msg);
+  free (msg);
+
+  exit (0);
+}
+
 /*!
  * \brief Parse command line switches.
  *
- * Parse command line switches at startup. There are only 3 command
- * line switches:
- * - verbose
- * - quiet
- * - help
  * \param argc Number of command line arguments
  * \param argv Command line arguments (array of strings)
- * \returns I don't know what - looks uninitialised in some circumstances.
+ * \returns I don't know what - looks uninitialised in some circumstances // :-)
  *
  */
 int parse_commandline(int argc, char *argv[])
@@ -127,41 +137,50 @@ int parse_commandline(int argc, char *argv[])
       {"help", 0, 0, 'h'},
       {"quiet", 0, 0, 'q'},
       {"verbose", 0, 0, 'v'},
+      {"version", 0, 0, 'V'},
       {0, 0, 0, 0}
     };
 
     while (1) {
-      ch = getopt_long(argc, argv, "hqv", long_options, &option_index);
+      ch = getopt_long(argc, argv, "hqvV", long_options, &option_index);
       if (ch == -1)
-	break;
+        break;
 #else
     /* Otherwise just use regular getopt */
     while ((ch = getopt(argc, argv, OPTIONS)) != -1) {
 #endif
 
-      switch (ch) {
+      switch (ch)
+      {
+        case 'v':
+          verbose_mode = TRUE;
+          break;
 	
-      case 'v':
-	verbose_mode = TRUE;
-	break;
+        case 'q':
+          quiet_mode = TRUE;
+          break;
 	
-      case 'q':
-	quiet_mode = TRUE;
-	break;
+        case 'h':
+          usage(argv[0]);
+          break;
+
+        case 'V':
+          version();
+          break;
 	
-      case 'h':
-	usage(argv[0]);
-	break;
-	
-      case '?':
-      default:
-	usage(argv[0]);
-	break;
+        case '?':
+          fprintf (stderr, _("\nRun `lepton-attrib --help' for more information.\n"));
+          exit (1);
+
+        default:
+          usage(argv[0]);
+          break;
       }
     }
     
-    if (quiet_mode) {
-	verbose_mode = FALSE;
+    if (quiet_mode)
+    {
+      verbose_mode = FALSE;
     }
 
     return (optind);

--- a/attrib/src/parsecmd.c
+++ b/attrib/src/parsecmd.c
@@ -62,13 +62,10 @@ extern int optind;
 #include "../include/gettext.h"
 
 /*!
- * \brief Print usage message
+ * \brief Print usage message and exit.
  *
- * Prints gattrib usage information to stdout.
- * \param cmd Unused parameter.
- *
+ * \param cmd  First element of argv (name of program as run).
  */
-
 void usage(char *cmd)
 {
     printf(_("\n"
@@ -97,9 +94,12 @@ void usage(char *cmd)
              "Copyright (C) 2007-2016 gEDA Contributors.\n"
              "Copyright (C) 2017-2019 Lepton EDA Contributors.\n"
              "\n"
-             "Please report bugs to %2$s.\n"),
+             "Report bugs at <%2$s>\n"
+             "Lepton EDA homepage: <%3$s>\n"),
              cmd,
-             PACKAGE_BUGREPORT);
+             PACKAGE_BUGREPORT,
+             PACKAGE_URL);
+
     exit(0);
 }
 

--- a/cli/config.c
+++ b/cli/config.c
@@ -39,7 +39,8 @@ static struct option config_long_options[] =
     {"project", 2, NULL, 'p'},
     {"system", 0, NULL, 's'},
     {"user", 0, NULL, 'u'},
-    {"cache", 0, NULL, 'c'}
+    {"cache", 0, NULL, 'c'},
+    {0, 0, 0, 0}
   };
 
 static void

--- a/cli/config.c
+++ b/cli/config.c
@@ -18,9 +18,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif
+#include <config.h>
 #include <version.h>
 
 #include <unistd.h>
@@ -64,8 +62,11 @@ config_usage (void)
 "store for the current directory). If no GROUP and KEY were provided,\n"
 "outputs the filename of the selected configuration store.\n"
 "\n"
-"Please report bugs to %1$s.\n"),
-          PACKAGE_BUGREPORT);
+"Report bugs at <%1$s>\n"
+"Lepton EDA homepage: <%2$s>\n"),
+    PACKAGE_BUGREPORT,
+    PACKAGE_URL);
+
   exit (0);
 }
 

--- a/cli/export.c
+++ b/cli/export.c
@@ -18,9 +18,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif
+#include <config.h>
 #include <version.h>
 
 #include <unistd.h>
@@ -981,8 +979,11 @@ export_usage (void)
 "  -F, --font=NAME                      set font family for printing text\n"
 "  -h, --help                           display usage information and exit\n"
 "\n"
-"Please report bugs to %1$s.\n"),
-          PACKAGE_BUGREPORT);
+"Report bugs at <%1$s>\n"
+"Lepton EDA homepage: <%2$s>\n"),
+    PACKAGE_BUGREPORT,
+    PACKAGE_URL);
+
   exit (0);
 }
 

--- a/cli/lepton-cli.c
+++ b/cli/lepton-cli.c
@@ -19,12 +19,10 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif
-#include <locale.h>
+#include <config.h>
 #include <version.h>
 
+#include <locale.h>
 #include <unistd.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -37,6 +35,9 @@
 #include <glib.h>
 
 #include "builtins.h"
+
+#include <liblepton/liblepton.h>
+
 
 #define short_options "+hV"
 
@@ -79,8 +80,11 @@ usage (void)
 "  config         Edit Lepton EDA configuration\n"
 "  export         Export Lepton EDA files in various image formats.\n"
 "\n"
-"Please report bugs to %1$s.\n"),
-PACKAGE_BUGREPORT);
+"Report bugs at <%1$s>\n"
+"Lepton EDA homepage: <%2$s>\n"),
+    PACKAGE_BUGREPORT,
+    PACKAGE_URL);
+
   exit (0);
 }
 
@@ -88,14 +92,10 @@ PACKAGE_BUGREPORT);
 static void
 version (void)
 {
-  printf(_("Lepton EDA %1$s (g%2$.7s)\n"
-"Copyright (C) 1998-2016 gEDA developers\n"
-"Copyright (C) 2017-2019 Lepton EDA developers\n"
-"This is free software, and you are welcome to redistribute it under\n"
-"certain conditions. For details, see the file `COPYING', which is\n"
-"included in the Lepton EDA distribution.\n"
-"There is NO WARRANTY, to the extent permitted by law.\n"),
-         PACKAGE_DOTTED_VERSION, PACKAGE_GIT_COMMIT);
+  char* msg = version_message();
+  printf ("%s\n", msg);
+  free (msg);
+
   exit (0);
 }
 

--- a/cli/shell.c
+++ b/cli/shell.c
@@ -18,9 +18,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif
+#include <config.h>
 #include <version.h>
 
 #include <unistd.h>
@@ -60,8 +58,11 @@ shell_usage (void)
 "  -l FILE        load Scheme source code from FILE\n"
 "  -h, --help     display usage information and exit\n"
 "\n"
-"Please report bugs to %1$s.\n"),
-PACKAGE_BUGREPORT);
+"Report bugs at <%1$s>\n"
+"Lepton EDA homepage: <%2$s>\n"),
+    PACKAGE_BUGREPORT,
+    PACKAGE_URL);
+
   exit (0);
 }
 
@@ -117,7 +118,7 @@ cmd_shell_impl (void *data, int argc, char **argv)
   /* Interactive, so enable readline support and print an abbreviated
    * version message. */
   if (interactive) {
-    fprintf (stderr, "gEDA %s (g%.7s)\n", PACKAGE_DOTTED_VERSION, PACKAGE_GIT_COMMIT);
+    fprintf (stderr, "Lepton EDA %s (g%.7s)\n", PACKAGE_DOTTED_VERSION, PACKAGE_GIT_COMMIT);
   /* readline is not supported for MinGW builds yet */
 #ifndef __MINGW32__
     SCM expr = scm_list_3 (sym_begin,

--- a/schematic/src/parsecmd.c
+++ b/schematic/src/parsecmd.c
@@ -60,11 +60,8 @@ SCM s_pre_load_expr = SCM_EOL;
 SCM s_post_load_expr = SCM_EOL;
 
 /*! \brief Print brief help message and exit.
- * \par Function Description
- * Print brief help message describing gschem usage & command-line
- * options, then exit with \a exit_status.
  *
- * \param cmd         First element of argv (name of program as run).
+ * \param cmd  First element of argv (name of program as run).
  */
 static void
 usage(char *cmd)
@@ -86,36 +83,28 @@ usage(char *cmd)
 "  -h, --help               Help; this message.\n"
 "  --                       Treat all remaining arguments as filenames.\n"
 "\n"
-"Report bugs at <https://github.com/lepton-eda/lepton-eda/issues>\n"
-"Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>\n"),
-         cmd);
+"Report bugs at <%2$s>\n"
+"Lepton EDA homepage: <%3$s>\n"),
+    cmd,
+    PACKAGE_BUGREPORT,
+    PACKAGE_URL);
+
   exit(0);
 }
 
 /*! \brief Print version info and exit.
- * \par Function Description
- * Print gEDA version, and copyright/warranty notices, and exit with
- * exit status 0.
  */
 static void
-version ()
+version()
 {
-  printf(_(
-"Lepton EDA %1$s (git: %2$.7s)\n"
-"Copyright (C) 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright (C) 2017-2019 Lepton Developers.\n"
-"This is free software, and you are welcome to redistribute it under\n"
-"certain conditions. For details, see the file `COPYING', which is\n"
-"included in the Lepton EDA distribution.\n"
-"There is NO WARRANTY, to the extent permitted by law.\n"),
-         PACKAGE_DOTTED_VERSION, PACKAGE_GIT_COMMIT);
+  char* msg = version_message();
+  printf ("%s\n", msg);
+  free (msg);
+
   exit (0);
 }
 
-/*! \brief Parse gschem command-line options.
- * \par Function Description
- * Parse command line options, displaying usage message or version
- * information as required.
+/*! \brief Parse command-line options.
  *
  * \param argc Number of command-line arguments.
  * \param argv Array of command-line arguments.

--- a/symcheck/docs/lepton-symcheck.1.in
+++ b/symcheck/docs/lepton-symcheck.1.in
@@ -3,19 +3,16 @@
 lepton-symcheck \- Lepton EDA Symbol Checker
 .SH SYNOPSIS
 .B lepton-symcheck
-.RB [ \-h ]
-.RB [ \-v ]
-.RB [ \-q ]
-.I symbol1
-.RI [... symbolN ]
+[\fIOPTION\fR ...] \fIFILE\fR ...
 .SH DESCRIPTION
 .PP
 .B lepton-symcheck
 is a symbol checker for Lepton EDA.
+It checks one or more symbol \fIFILE\fRs passed on the command line.
+
 Here is a list of checks that
 .B lepton-symcheck
 performs:
-
 .IP \[bu] 2
 Checks for \f[I]graphical\f[] attribute (if present does varied tests)
 .IP \[bu]
@@ -44,37 +41,32 @@ Checks to make sure the number of pins is the correct number
 accepts the following options:
 .TP 8
 .BR \-q ", " \-\-quiet
-Quiet mode on.  This mode turns off all warnings/notes/messages. (optional)
+Quiet mode on.  This mode turns off all warnings/notes/messages.
 .TP 8
 .BR \-v ", " \-\-verbose
-Verbose mode 1.  This mode will show all error messages (optional)
+Verbose mode 1.  This mode will show all error messages.
 .TP 8
 .B -vv
-Verbose mode 2.  This mode will show all error and warning messages (optional)
+Verbose mode 2.  This mode will show all error and warning messages.
 .TP 8
 .B -vvv
-Verbose mode 2.  This mode will show all error, warning, and info
-messages (optional)
+Verbose mode 3.  This mode will show all error, warning, and info
+messages.
+.TP 8
+.BR \-V ", " \-\-version
+Print version information.
 .TP 8
 .BR -h ", " \-\-help
-Usage summary /
-.B lepton-symcheck
-help
-.TP 8
-.IR symbol1 " [..." symbolN ]
-At least one symbol file must be specified.
-If multiple symbols are
-specified then they are sequentially read in and checked.
-It is important that the schematic(s) follow all the options (i.e. last).
+Print a help message.
 
 .SH EXAMPLES
 Here are some examples on how to run
 .BR lepton-symcheck :
 
-To get usage information just run:
+To get usage information run:
 
 .RS
-lepton-symcheck
+lepton-symcheck \-\-help
 .RE
 
 To actually check a symbol with just error counts, run:

--- a/symcheck/scheme/symcheck/check.scm
+++ b/symcheck/scheme/symcheck/check.scm
@@ -28,19 +28,35 @@
   #:use-module (symbol check)
   #:use-module (symbol check log)
   #:use-module (symbol gettext)
+  #:use-module (lepton version)
 
   #:export (check-all-symbols))
 
 (define (usage)
   (format #t
-          (_ "Usage: ~A [OPTIONS] FILENAME ...
+          (_ "Usage: ~A [OPTIONS] FILE ...
+
+Check one or more Lepton EDA symbol FILEs.
+
+General options:
   -h, --help        Print usage
+  -V, --version     Show version information
   -q, --quiet       Quiet mode
-  -v, --verbose     Verbose mode (cumulative: errors, warnings, info)
-                    Use this to get the actual symbol error messages
-FILENAME ... are the symbols to check.
+  -v, --verbose     Verbose mode (cumulative, i.e. -v will show error
+                    messages, -vv will show errors and warnings, and
+                    -vvv displays also informational messages)
+
+Report bugs at <~A>
+Lepton EDA homepage: <~A>
 ")
-          (car (program-arguments)))
+          (car (program-arguments))
+          (lepton-version 'bugs)
+          (lepton-version 'url))
+  (primitive-exit 0))
+
+
+(define (lepton-symcheck-version)
+  (format #t "~a~%" (lepton-version 'msg))
   (primitive-exit 0))
 
 
@@ -72,9 +88,13 @@ Run `~A --help' for more information.\n")
 
   (let ((files (symcheck-option-ref '()))
         (help (symcheck-option-ref 'help))
+        (version (symcheck-option-ref 'version))
         (interactive (symcheck-option-ref 'interactive)))
+    (if version
+        (lepton-symcheck-version))
     (if help
-        (usage)
+        (usage))
+
         (let ((pages (map file->page files)))
           (if interactive
               ;; Interactive mode. Just run the REPL to work with
@@ -84,4 +104,4 @@ Run `~A --help' for more information.\n")
               (if (null? pages)
                   (error-no-files-specified)
                   ;; now report the info/warnings/errors to the user
-                  (primitive-exit (apply + (map report-symbol-statistics pages)))))))))
+                  (primitive-exit (apply + (map report-symbol-statistics pages))))))))

--- a/symcheck/scheme/symcheck/option.scm
+++ b/symcheck/scheme/symcheck/option.scm
@@ -29,6 +29,7 @@
   '((quiet . #f)
     (verbose . ())
     (help . #f)
+    (version . #f)
     (interactive . #f)))
 
 ;;; This list contains key names which values must be lists.
@@ -44,6 +45,7 @@
                '((quiet (single-char #\q))
                  (verbose (single-char #\v))
                  (help (single-char #\h))
+                 (version (single-char #\V))
                  (interactive (single-char #\i)))))
 
 ;;; This function extends option-ref so that for keys which may

--- a/utils/src/Makefile.am
+++ b/utils/src/Makefile.am
@@ -8,7 +8,8 @@ lepton_renum_SOURCES = lepton-renum.c lepton-renum.h
 lepton_sch2pcb_SOURCES = lepton-sch2pcb.c
 lepton_sch2pcb_CPPFLAGS = \
 	-DPCBM4DIR=\"$(PCBM4DIR)\" \
-	-DPCBLIBPATH=\"$(PCBLIBPATH)\"
+	-DPCBLIBPATH=\"$(PCBLIBPATH)\" \
+	-I$(top_srcdir)
 lepton_sch2pcb_CFLAGS = $(GLIB_CFLAGS)
 lepton_sch2pcb_LDFLAGS = $(GLIB_LIBS)
 

--- a/utils/src/lepton-sch2pcb.c
+++ b/utils/src/lepton-sch2pcb.c
@@ -18,9 +18,8 @@
  */
 
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
+#include <config.h>
+#include <version.h>
 
 #include <glib.h>
 
@@ -30,8 +29,6 @@
 #include <ctype.h>
 #include <unistd.h>
 #include <sys/stat.h>
-
-#define GSC2PCB_VERSION "1.6"
 
 #define DEFAULT_PCB_INC "pcb.inc"
 
@@ -1285,9 +1282,10 @@ static const gchar *usage_string0 =
   "usage: lepton-sch2pcb [options] {project | foo.sch [foo1.sch ...]}\n"
   "\n"
   "Generate a PCB layout file from a set of Lepton EDA schematics.\n"
-  "   lepton-netlist -g PCB is run to generate foo.net from the schematics.\n"
   "\n"
-  "   lepton-netlist -g gsch2pcb is run to get PCB m4 derived elements which\n"
+  "   1) `lepton-netlist -g PCB` is run to generate foo.net from the schematics.\n"
+  "\n"
+  "   2) `lepton-netlist -g gsch2pcb` is run to get PCB m4 derived elements which\n"
   "   match schematic footprints.  For schematic footprints which don't match\n"
   "   any PCB m4 layout elements, search a set of file element directories in\n"
   "   an attempt to find matching PCB file elements.\n"
@@ -1297,7 +1295,7 @@ static const gchar *usage_string0 =
   "   have no matching schematic component, then remove those elements from\n"
   "   foo.pcb and rename foo.pcb to a foo.pcb.bak sequence.\n"
   "\n"
-  "   lepton-netlist -g pcbpins is run to get a PCB actions file which will rename all\n"
+  "   3) `lepton-netlist -g pcbpins` is run to get a PCB actions file which will rename all\n"
   "   of the pins in a .pcb file to match pin names from the schematic.\n"
   "\n"
   "   \"project\" is a file (not ending in .sch) containing a list of\n"
@@ -1306,7 +1304,7 @@ static const gchar *usage_string0 =
   "   Options in a project file are like command line args without the \"-\":\n"
   "       output-name myproject\n"
   "\n"
-  "options (may be included in a project file):\n"
+  "Options (may be included in a project file):\n"
   "   -d, --elements-dir D    Search D for PCB file elements.  These defaults\n"
   "                           are searched if they exist: ./packages,\n"
   "                           /usr/local/share/pcb/newlib, /usr/share/pcb/newlib,\n"
@@ -1349,7 +1347,7 @@ static const gchar *usage_string1 =
   "                           Creates:  myproject.partslist3\n"
   "   --empty-footprint name  See the project.sample file.\n"
   "\n"
-  "options (not recognized in a project file):\n"
+  "Options (not recognized in a project file):\n"
   "   --gnetlist-arg arg      Allows additional arguments to be passed to lepton-netlist.\n"
   "   --fix-elements          If a schematic component footprint is not equal\n"
   "                           to its PCB element Description, update the\n"
@@ -1358,23 +1356,45 @@ static const gchar *usage_string1 =
   "                           PCB files originally created with gschem2pcb.\n"
   "   -v, --verbose           Use -v -v for additional file element debugging.\n"
   "   -V, --version\n\n"
-  "environment variables:\n"
+  "Environment variables:\n"
   "   NETLISTER               If set, this specifies the name of the netlister program\n"
   "                           to execute.\n"
   "\n"
   "Additional Resources:\n"
-  "\n"
-  "  Lepton EDA homepage:     https://github.com/lepton-eda/lepton-eda\n"
   "  gnetlist user guide:     http://wiki.geda-project.org/geda:gnetlist_ug\n"
   "  gEDA homepage:           http://www.geda-project.org\n"
-  "  PCB homepage:            http://pcb.geda-project.org\n"  "\n";
+  "  PCB homepage:            http://pcb.geda-project.org\n"
+  "\n"
+  "Report bugs at <%s>\n"
+  "Lepton EDA homepage: <%s>\n";
 
 static void
 usage ()
 {
   puts (usage_string0);
   printf ("                           %s\n\n", default_m4_pcbdir);
-  puts (usage_string1);
+  printf (usage_string1, PACKAGE_BUGREPORT, PACKAGE_URL);
+  exit (0);
+}
+
+static void
+version()
+{
+  const char* msg =
+    "Lepton EDA %s.%s (git: %.7s)\n"
+    "Copyright (C) 1998-2016 gEDA developers\n"
+    "Copyright (C) 2017-2019 Lepton EDA developers\n"
+    "This is free software, and you are welcome to redistribute it\n"
+    "under certain conditions. For details, see the file `COPYING',\n"
+    "which is included in the Lepton EDA distribution.\n"
+    "There is NO WARRANTY, to the extent permitted by law."
+    "\n";
+
+  printf (msg,
+          PACKAGE_DOTTED_VERSION,
+          PACKAGE_DATE_VERSION,
+          PACKAGE_GIT_COMMIT);
+
   exit (0);
 }
 
@@ -1392,8 +1412,7 @@ get_args (gint argc, gchar ** argv)
       if (*opt == '-')
         ++opt;
       if (!strcmp (opt, "version") || !strcmp (opt, "V")) {
-        printf ("lepton-sch2pcb %s\n", GSC2PCB_VERSION);
-        exit (0);
+        version();
       } else if (!strcmp (opt, "verbose") || !strcmp (opt, "v")) {
         verbose += 1;
         continue;
@@ -1509,7 +1528,7 @@ main (gint argc, gchar ** argv)
 
   if (!run_gnetlist (pins_file_name, net_file_name, pcb_new_file_name,
 		     sch_basename, schematics)) {
-    fprintf(stderr, "Failed to run gnetlist\n");
+    fprintf(stderr, "Failed to run netlister\n");
     exit (1);
   }
 


### PR DESCRIPTION
- Unify `--help` messages: use `PACKAGE_BUGREPORT`, `PACKAGE_URL` macros
- Unify `--version` messages: use `version_message()` function
- A new `--version` command line option for `attrib` and `symcheck`
- Update `symcheck` man page
- Update `symcheck` `usage()` message: explain `-v`, `-vv`, `-vvv`
- Update `sch2pcb --help` output; leptonize one error message