### PR TITLE
Fix several issues in lepton-archive

### DIFF
--- a/utils/docs/lepton-archive.1.in
+++ b/utils/docs/lepton-archive.1.in
@@ -31,14 +31,19 @@ Archive mode is the default.
 \-e, \-\-extract          Extract mode. Mandatory if you want to extract from archive.
 \-a, \-\-archive          Archive mode. It is the default mode.
 \-o, \-\-output=FILE      Specify the name of the output archive file
-                       in archive mode. The output file extension should be ".tar.gz".
-                       Default name is "project-archive.tar.gz".
+                       in archive mode. If FILE has no ".tar.gz" suffix it will be
+                       automatically appended.
+                       Default file name is "project-archive.tar.gz".
 
 .SH EXAMPLES
 To create an archive named MyArchive.tar.gz, the files to store
 are listed in "archive-list":
 .IP
 lepton-archive \-f archive-list \-o MyArchive.tar.gz
+.PP
+The same by using just file basename:
+.IP
+lepton-archive \-f archive-list \-o MyArchive
 .PP
 Verbosely create an archive from files listed on command line:
 .IP

--- a/utils/scripts/lepton-archive.in
+++ b/utils/scripts/lepton-archive.in
@@ -138,9 +138,46 @@ Example usage:
           default-archive-name
           default-archive-name))
 
+(define %option-spec
+  '((help (single-char #\h) (value #f))
+    (files-from (single-char #\f) (value #t))
+    (verbose (single-char #\v) (value #f))
+    (extract (single-char #\e) (value #f))
+    (archive (single-char #\a) (value #f))
+    (output (single-char #\o) (value #t))))
+
+
+(define (format-error s . args)
+  (apply format (current-error-port) s args)
+  (primitive-exit 1))
+
+
+(define (wrong-option-handler)
+  "Primitive wrong option handler for getopt-long."
+  (format-error "Use \"~A -h\" for help\n" (car (program-arguments))))
+
+
+;;; Options.
+(define %options
+  (catch #t
+    (lambda ()
+      (getopt-long (program-arguments) %option-spec))
+    (lambda (key . args)
+      (wrong-option-handler))))
+
+
+(define archive-mode? (option-ref %options 'archive #f))
+(define extract-mode? (option-ref %options 'extract #f))
+(define output-archive-name (option-ref %options 'output #f))
+(define archiverc-name (option-ref %options 'files-from #f))
+(define help-mode? (option-ref %options 'help #f))
+(define verbose-mode? (option-ref %options 'verbose #f))
+(define command-line-file-list (option-ref %options '() '()))
+
+
 (define (debug-format s . args)
   "Formats and outputs S using ARGS when the verbose mode is set."
-  (when (option-ref %options 'verbose #f)
+  (when verbose-mode?
     (display "---- ")
     (apply format (current-error-port) s args)
     (newline)))
@@ -173,45 +210,17 @@ or no directory path can be converted into absolute."
   (string-suffix-ci? ".tar.gz" filename))
 
 
-(define %option-spec
-  '((help (single-char #\h) (value #f))
-    (files-from (single-char #\f) (value #t))
-    (verbose (single-char #\v) (value #f))
-    (extract (single-char #\e) (value #f))
-    (archive (single-char #\a) (value #f))
-    (output (single-char #\o) (value #t))))
-
-
-(define (format-error s . args)
-  (apply format (current-error-port) s args)
-  (primitive-exit 1))
-
-
-(define (wrong-option-handler)
-  "Primitive wrong option handler for getopt-long."
-  (format-error "Use \"~A -h\" for help\n" (car (program-arguments))))
-
-;;; Options.
-(define %options
-  (catch #t
-    (lambda ()
-      (getopt-long (program-arguments) %option-spec))
-    (lambda (key . args)
-      (wrong-option-handler))))
-
 ;;; Program mode.
-(define help-mode?
-  (and (option-ref %options 'help #f)
+(define check-help-mode?
+  (and help-mode?
        (display usage-info)
        (primitive-exit 0)))
 
-(define extract-mode? (option-ref %options 'extract #f))
 
 ;; Archive mode is default. Don't check any options, just check
 ;; extract mode is not set.
-(define archive-mode?
-  (if (and extract-mode?
-           (option-ref %options 'archive #f))
+(define check-archive-mode?
+  (if (and extract-mode? archive-mode?)
       (format-error "Mutually exclusive option --archive and --extract.\n")
       (not extract-mode?)))
 
@@ -233,7 +242,7 @@ or no directory path can be converted into absolute."
                     filename)))
 
 (define archiverc
-  (let ((files-from (option-ref %options 'files-from #f)))
+  (let ((files-from archiverc-name))
     (and (not extract-mode?)
          (string? files-from)
          files-from
@@ -251,7 +260,7 @@ or no directory path can be converted into absolute."
 ;;; Make up output archive name.
 (define (make-output-file-name)
   (form-output-file-name
-   (or (validate/extract-mode (option-ref %options 'output #f))
+   (or (validate/extract-mode output-archive-name)
        default-archive-name)))
 
 ;;; Directory holding files to archive. It is the current
@@ -260,9 +269,6 @@ or no directory path can be converted into absolute."
 
 ;;; Directory for caching schematic files.
 (define cache-directory "cache")
-
-
-(define command-line-file-list (option-ref %options '() '()))
 
 
 (define (report-preserve-existing-file file)

--- a/utils/scripts/lepton-archive.in
+++ b/utils/scripts/lepton-archive.in
@@ -175,6 +175,14 @@ Example usage:
 (define command-line-file-list (option-ref %options '() '()))
 
 
+(define gafrc "gafrc")
+;;; Directory holding files to archive. It is the current
+;;; directory where the program was invoked.
+(define project-directory (getcwd))
+;;; Directory for caching schematic files.
+(define cache-directory "cache")
+
+
 (define (debug-format s . args)
   "Formats and outputs S using ARGS when the verbose mode is set."
   (when verbose-mode?
@@ -209,8 +217,6 @@ or no directory path can be converted into absolute."
   "Checks if FILENAME is a valid archive filename."
   (string-suffix-ci? ".tar.gz" filename))
 
-
-(define gafrc "gafrc")
 
 ;;; Check for options invalid in extract mode.
 (define (validate/extract-mode filename)
@@ -248,13 +254,6 @@ or no directory path can be converted into absolute."
   (form-output-file-name
    (or (validate/extract-mode output-archive-name)
        default-archive-name)))
-
-;;; Directory holding files to archive. It is the current
-;;; directory where the program was invoked.
-(define project-directory (getcwd))
-
-;;; Directory for caching schematic files.
-(define cache-directory "cache")
 
 
 (define (report-preserve-existing-file file)

--- a/utils/scripts/lepton-archive.in
+++ b/utils/scripts/lepton-archive.in
@@ -141,6 +141,17 @@ default-archive-name))
     (apply format (current-error-port) s args)
     (newline)))
 
+
+(define (prompt-confirmed? prompt default-char)
+  (display prompt)
+  (let ((input-string (read-line (current-input-port))))
+    (display #\newline)
+    (and (not (string-ci=? input-string "n"))
+         (or (string-ci=? input-string "y")
+             (and (not (string-ci=? default-char "n"))
+                  (string-ci=? default-char "y"))))))
+
+
 (define (make-absolute-filename dir-name file-name)
   (if (absolute-file-name? file-name)
       file-name
@@ -220,12 +231,6 @@ default-archive-name))
          files-from
          (check-existence files-from))))
 
-(define (request-confirmation prompt result)
-  (format #t prompt)
-  (if (char=? (read-char (current-input-port)) #\y)
-      result
-      (primitive-exit 1)))
-
 
 ;;; Make up output archive name.
 (define (make-output-file-name)
@@ -234,12 +239,13 @@ default-archive-name))
              default-archive-name)))
     (if (check-archive-filename filename)
         filename
-        (request-confirmation
-         "Warning: output file suffix is not \".tar.gz\" -- the
+        (if (prompt-confirmed?
+             "Warning: output file suffix is not \".tar.gz\" -- the
 extractor won't know how to deal with your archive.
 Continue? [y/N] "
-         filename))))
-
+             "n")
+            filename
+            (primitive-exit 1)))))
 
 ;;; Directory holding files to archive. It is the current
 ;;; directory where the program was invoked.
@@ -250,11 +256,6 @@ Continue? [y/N] "
 
 
 (define command-line-file-list (option-ref %options '() '()))
-
-
-(define (overwrite-file? message)
-  (display message)
-  (string= (read-line (current-input-port)) "y"))
 
 
 (define (report-preserve-existing-file file)
@@ -306,9 +307,11 @@ Continue? [y/N] "
       ;; If file exists, and it is directory, do nothing.
       ;; Otherwise, ask the user, if she wants to overwrite it.
       (unless (directory? path)
-        (if (overwrite-file?
-             (format #f "~S already exists and is not directory. Overwrite? [y/N]"
-                     path))
+        (if (prompt-confirmed?
+             (format #f "~S already exists and is not directory. Overwrite? [y/N] "
+                     path)
+             ;; default
+             "n")
             (begin
               (delete-file* path)
               (apply mkdir path args))
@@ -348,9 +351,11 @@ Continue? [y/N] "
       ;; Otherwise, ask the user, if she wants to overwrite it.
       (if (and (file-exists? directory-name)
                (not (directory? directory-name)))
-          (if (overwrite-file?
-               (format #f "~S already exists and is not directory. Overwrite? [y/N]"
-                       directory-name))
+          (if (prompt-confirmed?
+               (format #f "~S already exists and is not directory. Overwrite? [y/N] "
+                       directory-name)
+               ;; default
+               "n")
               (delete-file* directory-name)
               (report-preserve-existing-file directory-name))
           ;; No file exists, just create the directory.
@@ -362,8 +367,11 @@ Continue? [y/N] "
                                   to-path)))
       (debug-format "Move file ~S to ~S" name new-filename)
       (if (and (file-exists? new-filename)
-               (not (overwrite-file? (format #f "~S already exists.  Overwrite? [y/N]"
-                                             new-filename))))
+               (not (prompt-confirmed?
+                     (format #f "~S already exists.  Overwrite? [y/N] "
+                             new-filename)
+                     ;; default
+                     "n")))
           (begin
             (report-preserve-existing-file new-filename)
             ;; Remove the file anyway. The user can restore it
@@ -418,9 +426,11 @@ Continue? [y/N] "
       ;; Otherwise, ask the user, if she wants to overwrite it.
       (if (and (file-exists? directory-name)
                (not (directory? directory-name)))
-          (if (overwrite-file?
-               (format #f "~S already exists and is not directory. Overwrite? [y/N]"
-                       directory-name))
+          (if (prompt-confirmed?
+               (format #f "~S already exists and is not directory. Overwrite? [y/N] "
+                       directory-name)
+               ;; default
+               "n")
               (delete-file* directory-name)
               (report-preserve-existing-file directory-name))
           ;; No file exists, just create the directory.
@@ -432,8 +442,11 @@ Continue? [y/N] "
                                   to-path)))
       (debug-format "Copy file ~S to ~S" name new-filename)
       (if (and (file-exists? new-filename)
-               (not (overwrite-file? (format #f "~S already exists.  Overwrite? [y/N]"
-                                             new-filename))))
+               (not (prompt-confirmed?
+                     (format #f "~S already exists.  Overwrite? [y/N] "
+                             new-filename)
+                     ;; default
+                     "n")))
           (report-preserve-existing-file new-filename)
           (copy-file* name new-filename))
       result))
@@ -518,12 +531,13 @@ option \"--files-from\" (\"-f\")."
                      filename)
              #f)
             ('rc
-             (format #t "Non-existent file ~S.\nCreate empty version in local dir? [Y/n] "
-                     filename)
-             (let ((input-char (read-char (current-input-port))))
-               (if (char=? input-char #\n)
-                   (format-error "You need ~S to create archive. Aborting.\n" filename)
-                   (make-empty-file filename))))))))
+             (if (prompt-confirmed?
+                  (format #f "Non-existent file ~S.\nCreate empty version in local dir? [Y/n] "
+                          filename)
+                  ;; default
+                  "y")
+                 (make-empty-file filename)
+                 (format-error "You need ~S to create archive. Aborting.\n" filename)))))))
 
   (define (add-rc-file filename)
     (add-file filename 'rc))
@@ -721,19 +735,19 @@ symbol cache directory."
       (debug-format "Rename archive to ~S" output.tar.gz)
       (if (file-exists? output.tar.gz)
           ;; Directory already exists
-          (begin
-            (format #t "~S already exists. Overwrite? [y/N] " output.tar.gz)
-            (let ((input-char (read-char (current-input-port))))
-              (if (char=? input-char #\y)
-                  ;; Remove old archive
-                  (begin
-                    (delete-file* output.tar.gz)
-                    (rename-file* output-file-name output.tar.gz)
-                    (format #t "Project archive ~S created successfully!\n"
-                            output.tar.gz))
-                  ;; Report place of the new archive.
-                  (format #t "Preserving existing archive in local directory.
-Your new archive lives in ~S\n" temp/output.tar.gz))))
+          (if (prompt-confirmed?
+               (format #f "~S already exists. Overwrite? [y/N] " output.tar.gz)
+               ;; default
+               "n")
+              ;; Remove old archive
+              (begin
+                (delete-file* output.tar.gz)
+                (rename-file* output-file-name output.tar.gz)
+                (format #t "Project archive ~S created successfully!\n"
+                        output.tar.gz))
+              ;; Report place of the new archive.
+              (format #t "Preserving existing archive in local directory.
+Your new archive lives in ~S\n" temp/output.tar.gz))
           ;; Archive is not in user directory yet, no need to force it.
           (rename-file* output-file-name output.tar.gz)))
 

--- a/utils/scripts/lepton-archive.in
+++ b/utils/scripts/lepton-archive.in
@@ -714,8 +714,11 @@ symbol cache directory."
          ;; Returned paths give only the base name (i.e. no path)
          (schematic-file-list (create-schematic-file-list archive-file-list)))
 
-    (debug-format "Cache directory: ~S" temp/project/cache)
-    (debug-format "Archive directory: ~S" temp/project)
+    (debug-format "Temp directory: ~S" temp/)
+    (debug-format "Temp project directory: ~S" temp/project)
+    (debug-format "Temp cache directory: ~S" temp/project/cache)
+    (debug-format "Temp archive name: ~S" temp/output.tar.gz)
+    (debug-format "Destination archive name: ~S" project/output.tar.gz)
 
     ;; Copy all files over to temporary directory.
     (for-each (cut copy-to-dir <> temp/project) archive-file-list)

--- a/utils/scripts/lepton-archive.in
+++ b/utils/scripts/lepton-archive.in
@@ -714,8 +714,9 @@ symbol cache directory."
                                    temp/project
                                    temp/project/cache))
 
-    ;; Now create tar file.  We copy remaining files over to /tmp, and then tar them
-    ;; all up using a local, relative file prefix.
+    ;; Now create tar file.  We copy remaining files over to /tmp,
+    ;; and then tar them all up using a local, relative file
+    ;; prefix.
 
     ;; Update copy of gafrc.
     (update-rc temp/project)

--- a/utils/scripts/lepton-archive.in
+++ b/utils/scripts/lepton-archive.in
@@ -226,19 +226,17 @@ or no directory path can be converted into absolute."
       filename))
 
 
-;;; File must exist.
-(define (check-existence filename)
-  (if (file-exists? filename)
-      filename
-      (format-error "Resource file ~S doesn't exist.  Exiting.\n"
-                    filename)))
 
 (define archiverc
   (let ((files-from archiverc-name))
     (and (not extract-mode?)
          (string? files-from)
          files-from
-         (check-existence files-from))))
+         ;; The file must exist.
+         (if (file-exists? files-from)
+             files-from
+             (format-error "Resource file ~S doesn't exist.  Exiting.\n"
+                           files-from)))))
 
 
 (define (form-output-file-name s)

--- a/utils/scripts/lepton-archive.in
+++ b/utils/scripts/lepton-archive.in
@@ -94,6 +94,13 @@ exec @GUILE@ -s "$0" "$@"
 ;;; Default archive name. Use lowercase letters to avoid issues
 ;;; with case sensitive filesystems.
 (define default-archive-name "project-archive")
+(define gafrc "gafrc")
+;;; Directory holding files to archive. It is the current
+;;; directory where the program was invoked.
+(define project-directory (getcwd))
+;;; Directory for caching schematic files.
+(define cache-directory "cache")
+
 
 ;;; Help string.
 (define usage-info
@@ -173,14 +180,6 @@ Example usage:
 (define help-mode? (option-ref %options 'help #f))
 (define verbose-mode? (option-ref %options 'verbose #f))
 (define command-line-file-list (option-ref %options '() '()))
-
-
-(define gafrc "gafrc")
-;;; Directory holding files to archive. It is the current
-;;; directory where the program was invoked.
-(define project-directory (getcwd))
-;;; Directory for caching schematic files.
-(define cache-directory "cache")
 
 
 (define (debug-format s . args)

--- a/utils/scripts/lepton-archive.in
+++ b/utils/scripts/lepton-archive.in
@@ -639,9 +639,13 @@ symbol cache directory."
 
 (define (source-library-filename filename)
   (let ((source-filename (get-source-library-file filename)))
-    (and source-filename
-         (file-exists? source-filename)
-         source-filename)))
+    (if (and source-filename
+             (file-exists? source-filename))
+        source-filename
+        (begin
+          (debug-format "File ~S does not exist. Check your source-library."
+                        filename)
+          #f))))
 
 
 (define (subschematic-page-filenames schematic)

--- a/utils/scripts/lepton-archive.in
+++ b/utils/scripts/lepton-archive.in
@@ -210,20 +210,6 @@ or no directory path can be converted into absolute."
   (string-suffix-ci? ".tar.gz" filename))
 
 
-;;; Program mode.
-(define check-help-mode?
-  (and help-mode?
-       (display usage-info)
-       (primitive-exit 0)))
-
-
-;; Archive mode is default. Don't check any options, just check
-;; extract mode is not set.
-(define check-archive-mode?
-  (if (and extract-mode? archive-mode?)
-      (format-error "Mutually exclusive option --archive and --extract.\n")
-      (not extract-mode?)))
-
 (define gafrc "gafrc")
 
 ;;; Check for options invalid in extract mode.
@@ -866,9 +852,18 @@ the file manually.\n"))
 
 ;;; Main program.
 (define (main)
-  (if extract-mode?
-      (extract)
-      (archive)))
+  (when help-mode?
+    (display usage-info)
+    (primitive-exit 0))
+
+  (if (and extract-mode? archive-mode?)
+      (format-error "Mutually exclusive option --archive and --extract.\n")
+
+      ;; Archive mode is default. Don't check any options, just check
+      ;; extract mode is set or not.
+      (if extract-mode?
+          (extract)
+          (archive))))
 
 
 (%with-toplevel (%make-toplevel)

--- a/utils/scripts/lepton-archive.in
+++ b/utils/scripts/lepton-archive.in
@@ -669,6 +669,10 @@ symbol cache directory."
                             (append (schematic-page-filenames toplevel-schematics)
                                     subschematic-filenames))))
 
+    (debug-format "Subschematic filenames: ~S" subschematic-filenames)
+    (debug-format "Source filenames: ~S" source-filenames)
+    (debug-format "Symbol filenames: ~S" symbol-filenames)
+
     (for-each (lambda (sch) (copy-to-dir sch temp-dir))
               (schematic-page-filenames toplevel-schematics))
     (for-each (lambda (sch) (copy-to-dir sch cache-dir)) subschematic-filenames)

--- a/utils/scripts/lepton-archive.in
+++ b/utils/scripts/lepton-archive.in
@@ -710,14 +710,14 @@ symbol cache directory."
 
     (let* (
            ;; Output archive name.
-           (output-file-name (make-output-file-name))
+           (output.tar.gz (make-output-file-name))
            (temp/output.tar.gz
-            (make-absolute-filename temp/project output-file-name))
+            (make-absolute-filename temp/project output.tar.gz))
            (temp/output.tar
             (make-absolute-filename temp/project
-                                    (basename output-file-name ".gz")))
+                                    (basename output.tar.gz ".gz")))
            (project/output.tar.gz
-            (make-absolute-filename project-directory output-file-name)))
+            (make-absolute-filename project-directory output.tar.gz)))
 
       (debug-format "Archive directory: ~S" temp/project)
 

--- a/utils/scripts/lepton-archive.in
+++ b/utils/scripts/lepton-archive.in
@@ -757,12 +757,11 @@ symbol cache directory."
               (delete-file* project/output.tar.gz))
             (rename-file* temp/output.tar.gz project/output.tar.gz)
             (format #t "Project archive ~S created successfully!\n"
-                    project/output.tar.gz))
+                    project/output.tar.gz)
+            (remove-temp-dir temp/))
           ;; Otherwise, report the place of the new archive.
           (format #t "Preserving existing archive in local directory.
-Your new archive lives in ~S\n" temp/output.tar.gz)))
-
-    (remove-temp-dir temp/)))
+Your new archive lives in ~S\n" temp/output.tar.gz)))))
 
 
 ;;; Extracter.

--- a/utils/scripts/lepton-archive.in
+++ b/utils/scripts/lepton-archive.in
@@ -687,11 +687,12 @@ symbol cache directory."
   (let* (
          ;; Make a temporary directory.
          (temp/ (make-tmp-dir (tmpnam)))
-         ;; Temporary project directory to put files and create archive in.
+         ;; Temporary project directory to put files and create
+         ;; archive in.
          (temp/project
-          (make-tmp-dir (string-append temp/
-                                       file-name-separator-string
-                                       (basename project-directory))))
+          (make-tmp-dir
+           (make-absolute-filename temp/
+                                   (basename project-directory))))
          ;; Add cache directory for symbols.
          (temp/project/cache
           (make-tmp-dir (make-absolute-filename temp/project

--- a/utils/scripts/lepton-archive.in
+++ b/utils/scripts/lepton-archive.in
@@ -668,18 +668,17 @@ symbol cache directory."
 (define (archive)
   "Main archiver."
 
-  (define (make-tmp-dir)
-    (let* ((temp/ (tmpnam))
-           (name (string-append temp/
-                                file-name-separator-string
-                                (basename project-directory))))
-      (mkdir* temp/ #o700)
-      (mkdir* name #o700)
-      name))
+  (define (make-tmp-dir name)
+    (mkdir* name #o700)
+    name)
 
   (let* (
-         ;; Temporary directory to put files and create archive in.
-         (tmpdir (make-tmp-dir))
+         ;; Make a temporary directory.
+         (temp/ (make-tmp-dir (tmpnam)))
+         ;; Temporary project directory to put files and create archive in.
+         (tmpdir (make-tmp-dir (string-append temp/
+                                              file-name-separator-string
+                                              (basename project-directory))))
          ;; Create list of files (and directories) to stick into
          ;; archive.  Returned paths point to the absolute paths of
          ;; the files.

--- a/utils/scripts/lepton-archive.in
+++ b/utils/scripts/lepton-archive.in
@@ -115,7 +115,7 @@ Command line switches:
   -o,--output=FILE      -- Specify the name of the output archive file
                            in archive mode.   If FILE has no \".tar.gz\"
                            suffix it will be automatically appended.
-                           Default file name is ~S.
+                           Default file name is \"~A.tar.gz\".
 
 Example usage:
    Create an archive named \"MyArchive.tar.gz\",

--- a/utils/scripts/lepton-archive.in
+++ b/utils/scripts/lepton-archive.in
@@ -218,19 +218,15 @@ or no directory path can be converted into absolute."
   (string-suffix-ci? ".tar.gz" filename))
 
 
-(define (form-output-file-name s)
-  (let* ((suffix ".tar.gz")
-         (suffix-length (string-length ".tar.gz")))
-    (if (string-suffix-ci? suffix s)
-        (string-drop-right s suffix-length)
-        s)))
-
-
 ;;; Make up output archive name.
-(define (make-output-file-name)
-  (form-output-file-name
-   (or output-archive-name
-       default-archive-name)))
+(define (form-output-file-name)
+  (let* ((name (or output-archive-name
+                   default-archive-name))
+         (suffix ".tar.gz")
+         (suffix-length (string-length ".tar.gz")))
+    (if (string-suffix-ci? suffix name)
+        (string-drop-right name suffix-length)
+        name)))
 
 
 (define (report-preserve-existing-file file)
@@ -687,7 +683,7 @@ symbol cache directory."
           (make-tmp-dir (make-absolute-filename temp/project
                                                 cache-directory)))
 
-         (output (make-output-file-name))
+         (output (form-output-file-name))
          (output.tar (string-append output ".tar"))
          (output.tar.gz (string-append output.tar ".gz"))
          (temp/output.tar

--- a/utils/scripts/lepton-archive.in
+++ b/utils/scripts/lepton-archive.in
@@ -644,15 +644,6 @@ symbol cache directory."
          source-filename)))
 
 
-(define (schematic-page-filenames toplevel-schematics)
-  (filter-map
-   (lambda (sch) (let ((cwd-filename (string-append (getcwd)
-                                               file-name-separator-string
-                                               sch)))
-              (and (file-exists? cwd-filename) cwd-filename)))
-   toplevel-schematics))
-
-
 (define (subschematic-page-filenames schematic)
   (let ((files (delete-duplicates
                 (flatten-tree (schematic-name-tree schematic)))))
@@ -666,15 +657,9 @@ symbol cache directory."
                                         (schematic-components* schematic)))
          (source-filenames (filter-map source-library-filename schematic-sources))
          (symbol-filenames (create-symbol-file-list
-                            (append (schematic-page-filenames toplevel-schematics)
-                                    subschematic-filenames))))
+                            (append toplevel-schematics subschematic-filenames))))
 
-    (debug-format "Subschematic filenames: ~S" subschematic-filenames)
-    (debug-format "Source filenames: ~S" source-filenames)
-    (debug-format "Symbol filenames: ~S" symbol-filenames)
-
-    (for-each (lambda (sch) (copy-to-dir sch temp-dir))
-              (schematic-page-filenames toplevel-schematics))
+    (for-each (lambda (sch) (copy-to-dir sch temp-dir)) toplevel-schematics)
     (for-each (lambda (sch) (copy-to-dir sch cache-dir)) subschematic-filenames)
     (for-each (lambda (cir) (copy-to-dir cir cache-dir)) source-filenames)
     (save-symbols symbol-filenames cache-dir)))

--- a/utils/scripts/lepton-archive.in
+++ b/utils/scripts/lepton-archive.in
@@ -711,11 +711,11 @@ symbol cache directory."
     (let* (
            ;; Output archive name.
            (output-file-name (make-output-file-name))
-           (output.tar (basename output-file-name ".gz"))
            (temp/output.tar.gz
             (make-absolute-filename temp/project output-file-name))
            (temp/output.tar
-            (make-absolute-filename temp/project output.tar))
+            (make-absolute-filename temp/project
+                                    (basename output-file-name ".gz")))
            (output.tar.gz
             (make-absolute-filename project-directory output-file-name)))
 

--- a/utils/scripts/lepton-archive.in
+++ b/utils/scripts/lepton-archive.in
@@ -700,11 +700,11 @@ symbol cache directory."
 
          (output (make-output-file-name))
          (output.tar (string-append output ".tar"))
-         (output.tar.gz (string-append output ".tar.gz"))
+         (output.tar.gz (string-append output.tar ".gz"))
          (temp/output.tar
-          (make-absolute-filename temp/ output.tar))
+          (make-absolute-filename temp/ (basename output.tar)))
          (temp/output.tar.gz
-          (make-absolute-filename temp/ output.tar.gz))
+          (make-absolute-filename temp/ (basename output.tar.gz)))
          (project/output.tar.gz
           (make-absolute-filename project-directory output.tar.gz))
          ;; Create list of files (and directories) to stick into

--- a/utils/scripts/lepton-archive.in
+++ b/utils/scripts/lepton-archive.in
@@ -134,9 +134,9 @@ Example usage:
    Extract an archive:
    lepton-archive -e ~A.tar.gz
 "
-(basename (car (program-arguments)))
-default-archive-name
-default-archive-name))
+          (basename (car (program-arguments)))
+          default-archive-name
+          default-archive-name))
 
 (define (debug-format s . args)
   "Formats and outputs S using ARGS when the verbose mode is set."

--- a/utils/scripts/lepton-archive.in
+++ b/utils/scripts/lepton-archive.in
@@ -359,7 +359,7 @@ Continue? [y/N] "
   (define (leaf name stat result)
     ;; Increment the number of files processed.
     (let ((new-filename (ls->path (cons (basename name) result)
-                                   to-path)))
+                                  to-path)))
       (debug-format "Move file ~S to ~S" name new-filename)
       (if (and (file-exists? new-filename)
                (not (overwrite-file? (format #f "~S already exists.  Overwrite? [y/N]"
@@ -429,7 +429,7 @@ Continue? [y/N] "
   (define (leaf name stat result)
     ;; Increment the number of files processed.
     (let ((new-filename (ls->path (cons (basename name) result)
-                                   to-path)))
+                                  to-path)))
       (debug-format "Copy file ~S to ~S" name new-filename)
       (if (and (file-exists? new-filename)
                (not (overwrite-file? (format #f "~S already exists.  Overwrite? [y/N]"

--- a/utils/scripts/lepton-archive.in
+++ b/utils/scripts/lepton-archive.in
@@ -218,14 +218,6 @@ or no directory path can be converted into absolute."
   (string-suffix-ci? ".tar.gz" filename))
 
 
-;;; Check for options invalid in extract mode.
-(define (validate/extract-mode filename)
-  (if extract-mode?
-      (and filename
-           (format-error "Incompatible command line arguments.\n"))
-      filename))
-
-
 (define (form-output-file-name s)
   (let* ((suffix ".tar.gz")
          (suffix-length (string-length ".tar.gz")))
@@ -237,7 +229,7 @@ or no directory path can be converted into absolute."
 ;;; Make up output archive name.
 (define (make-output-file-name)
   (form-output-file-name
-   (or (validate/extract-mode output-archive-name)
+   (or output-archive-name
        default-archive-name)))
 
 
@@ -856,7 +848,10 @@ the file manually.\n"))
       ;; Archive mode is default. Don't check any options, just check
       ;; extract mode is set or not.
       (if extract-mode?
-          (extract)
+          (if output-archive-name
+              ;; Check for options invalid in extract mode.
+              (format-error "Incompatible command line arguments --extract and --output.\n")
+              (extract))
           (archive))))
 
 

--- a/utils/scripts/lepton-archive.in
+++ b/utils/scripts/lepton-archive.in
@@ -93,7 +93,7 @@ exec @GUILE@ -s "$0" "$@"
 
 ;;; Default archive name. Use lowercase letters to avoid issues
 ;;; with case sensitive filesystems.
-(define default-archive-name "project-archive.tar.gz")
+(define default-archive-name "project-archive")
 
 ;;; Help string.
 (define usage-info
@@ -113,9 +113,9 @@ Command line switches:
                            extract from archive.
   -a,--archive          -- Archive mode. It is the default mode.
   -o,--output=FILE      -- Specify the name of the output archive file
-                           in archive mode.  The output file extension
-                           should be \".tar.gz\".  Default name is
-                           ~S.
+                           in archive mode.   If FILE has no \".tar.gz\"
+                           suffix it will be automatically appended.
+                           Default file name is ~S.
 
 Example usage:
    Create an archive named \"MyArchive.tar.gz\",
@@ -123,12 +123,16 @@ Example usage:
 
    lepton-archive -f archive-list -o MyArchive.tar.gz
 
+   The same by using just file basename:
+
+   lepton-archive -f archive-list -o MyArchive
+
    Verbosely create an archive from files listed on command line:
 
    lepton-archive -v README sch1.sch sch2.sch sch3.sch
 
    Extract an archive:
-   lepton-archive -e ~A
+   lepton-archive -e ~A.tar.gz
 "
 (basename (car (program-arguments)))
 default-archive-name
@@ -159,10 +163,10 @@ default-archive-name))
                      file-name-separator-string
                      file-name)))
 
+
 (define (check-archive-filename filename)
   "Checks if FILENAME is a valid archive filename."
   (string-suffix-ci? ".tar.gz" filename))
-
 
 
 (define %option-spec
@@ -232,20 +236,19 @@ default-archive-name))
          (check-existence files-from))))
 
 
+(define (form-output-file-name s)
+  (let* ((suffix ".tar.gz")
+         (suffix-length (string-length ".tar.gz")))
+    (if (string-suffix-ci? suffix s)
+        (string-drop-right s suffix-length)
+        s)))
+
+
 ;;; Make up output archive name.
 (define (make-output-file-name)
-  (let ((filename
-         (or (validate/extract-mode (option-ref %options 'output #f))
-             default-archive-name)))
-    (if (check-archive-filename filename)
-        filename
-        (if (prompt-confirmed?
-             "Warning: output file suffix is not \".tar.gz\" -- the
-extractor won't know how to deal with your archive.
-Continue? [y/N] "
-             "n")
-            filename
-            (primitive-exit 1)))))
+  (form-output-file-name
+   (or (validate/extract-mode (option-ref %options 'output #f))
+       default-archive-name)))
 
 ;;; Directory holding files to archive. It is the current
 ;;; directory where the program was invoked.
@@ -708,14 +711,13 @@ symbol cache directory."
     ;; Update copy of gafrc.
     (update-rc temp/project)
 
-    (let* (
-           ;; Output archive name.
-           (output.tar.gz (make-output-file-name))
+    (let* ((output (make-output-file-name))
+           (output.tar (string-append output ".tar"))
+           (output.tar.gz (string-append output ".tar.gz"))
+           (temp/output.tar
+            (make-absolute-filename temp/project output.tar))
            (temp/output.tar.gz
             (make-absolute-filename temp/project output.tar.gz))
-           (temp/output.tar
-            (make-absolute-filename temp/project
-                                    (basename output.tar.gz ".gz")))
            (project/output.tar.gz
             (make-absolute-filename project-directory output.tar.gz)))
 

--- a/utils/scripts/lepton-archive.in
+++ b/utils/scripts/lepton-archive.in
@@ -226,19 +226,6 @@ or no directory path can be converted into absolute."
       filename))
 
 
-
-(define archiverc
-  (let ((files-from archiverc-name))
-    (and (not extract-mode?)
-         (string? files-from)
-         files-from
-         ;; The file must exist.
-         (if (file-exists? files-from)
-             files-from
-             (format-error "Resource file ~S doesn't exist.  Exiting.\n"
-                           files-from)))))
-
-
 (define (form-output-file-name s)
   (let* ((suffix ".tar.gz")
          (suffix-length (string-length ".tar.gz")))
@@ -498,6 +485,16 @@ or no directory path can be converted into absolute."
   "Create the list of files to archive, including \"gafrc\",
 files listed in the command line, and in the file specified by
 option \"--files-from\" (\"-f\")."
+  (define archiverc
+    (let ((files-from archiverc-name))
+      (and (string? files-from)
+           files-from
+           ;; The file must exist.
+           (if (file-exists? files-from)
+               files-from
+               (format-error "Resource file ~S doesn't exist.  Exiting.\n"
+                             files-from)))))
+
   (define not-string-null? (negate string-null?))
 
   (define (archiverc-filenames)

--- a/utils/scripts/lepton-archive.in
+++ b/utils/scripts/lepton-archive.in
@@ -692,8 +692,10 @@ symbol cache directory."
           (make-tmp-dir (string-append temp/
                                        file-name-separator-string
                                        (basename project-directory))))
-         (temp/project/cache (make-absolute-filename temp/project
-                                                     cache-directory))
+         ;; Add cache directory for symbols.
+         (temp/project/cache
+          (make-tmp-dir (make-absolute-filename temp/project
+                                                cache-directory)))
 
          (output (make-output-file-name))
          (output.tar (string-append output ".tar"))
@@ -718,10 +720,7 @@ symbol cache directory."
     ;; Copy all files over to temporary directory.
     (for-each (cut copy-to-dir <> temp/project) archive-file-list)
 
-    ;; Add cache directory for symbols.  Stick symbol & SPICE
-    ;; files into it.
-    (mkdir* temp/project/cache)
-
+    ;; Stick symbol & SPICE files into the cache directory.
     (save-schematics-and-sources schematic-file-list
                                  temp/project
                                  temp/project/cache)

--- a/utils/scripts/lepton-archive.in
+++ b/utils/scripts/lepton-archive.in
@@ -693,14 +693,14 @@ symbol cache directory."
 
     ;; Add cache directory for symbols.  Stick symbol & SPICE
     ;; files into it.
-    (let ((tmp/cache-directory (make-absolute-filename temp/project
-                                                       cache-directory)))
-      (debug-format "Cache directory: ~S" tmp/cache-directory)
-      (mkdir* tmp/cache-directory)
+    (let ((temp/project/cache (make-absolute-filename temp/project
+                                                      cache-directory)))
+      (debug-format "Cache directory: ~S" temp/project/cache)
+      (mkdir* temp/project/cache)
 
       (save-schematics-and-sources schematic-file-list
                                    temp/project
-                                   tmp/cache-directory))
+                                   temp/project/cache))
 
     ;; Now create tar file.  We copy remaining files over to /tmp, and then tar them
     ;; all up using a local, relative file prefix.

--- a/utils/scripts/lepton-archive.in
+++ b/utils/scripts/lepton-archive.in
@@ -492,6 +492,15 @@ default-archive-name))
         (copy-file* filename destination))))
 
 
+(define (remove-temp-dir dir)
+  ;; Get rid of temporary directory.
+  (debug-format "Remove temporary directory ~S" dir)
+  ;; Well, I could make a procedure for recursive removing of
+  ;; the directory contents, but it is simpler just to use 'rm'
+  ;; here.
+  (system* "rm" "-r" "-f" dir))
+
+
 (define (create-archive-file-list)
   "Create the list of files to archive, including \"gafrc\",
 files listed in the command line, and in the file specified by
@@ -754,12 +763,7 @@ Your new archive lives in ~S\n" temp/output.tar.gz))
           ;; Archive is not in user directory yet, no need to force it.
           (rename-file* temp/output.tar.gz project/output.tar.gz)))
 
-    ;; Get rid of temporary directory.
-    (debug-format "Remove temporary directory ~S" temp/)
-    ;; Well, I could make a procedure for recursive removing of
-    ;; the directory contents, but it is simpler just to use 'rm'
-    ;; here.
-    (system* "rm" "-r" "-f" temp/)))
+    (remove-temp-dir temp/)))
 
 
 ;;; Extracter.

--- a/utils/scripts/lepton-archive.in
+++ b/utils/scripts/lepton-archive.in
@@ -676,9 +676,10 @@ symbol cache directory."
          ;; Make a temporary directory.
          (temp/ (make-tmp-dir (tmpnam)))
          ;; Temporary project directory to put files and create archive in.
-         (tmpdir (make-tmp-dir (string-append temp/
-                                              file-name-separator-string
-                                              (basename project-directory))))
+         (temp/project
+          (make-tmp-dir (string-append temp/
+                                       file-name-separator-string
+                                       (basename project-directory))))
          ;; Create list of files (and directories) to stick into
          ;; archive.  Returned paths point to the absolute paths of
          ;; the files.
@@ -688,24 +689,24 @@ symbol cache directory."
          (schematic-file-list (create-schematic-file-list archive-file-list)))
 
     ;; Copy all files over to temporary directory.
-    (for-each (cut copy-to-dir <> tmpdir) archive-file-list)
+    (for-each (cut copy-to-dir <> temp/project) archive-file-list)
 
     ;; Add cache directory for symbols.  Stick symbol & SPICE
     ;; files into it.
-    (let ((tmp/cache-directory (make-absolute-filename tmpdir
+    (let ((tmp/cache-directory (make-absolute-filename temp/project
                                                        cache-directory)))
       (debug-format "Cache directory: ~S" tmp/cache-directory)
       (mkdir* tmp/cache-directory)
 
       (save-schematics-and-sources schematic-file-list
-                                   tmpdir
+                                   temp/project
                                    tmp/cache-directory))
 
     ;; Now create tar file.  We copy remaining files over to /tmp, and then tar them
     ;; all up using a local, relative file prefix.
 
     ;; Update copy of gafrc.
-    (update-rc tmpdir)
+    (update-rc temp/project)
 
     (let* (
            ;; Output archive name.
@@ -713,21 +714,21 @@ symbol cache directory."
            (output-basename (basename output-file-name ".tar.gz"))
            (output.tar (basename output-file-name ".gz"))
            (temp/output.tar.gz
-            (make-absolute-filename tmpdir output-file-name))
+            (make-absolute-filename temp/project output-file-name))
            (output.tar.gz
             (make-absolute-filename project-directory output-file-name)))
 
-      (debug-format "Archive directory: ~S" tmpdir)
+      (debug-format "Archive directory: ~S" temp/project)
 
       ;; Now cd into the temporary directory.
-      (chdir (dirname tmpdir))
+      (chdir (dirname temp/project))
 
       ;;  Now use this in tar command.
       (system* "tar"
                "-c"
                "-f"
                output.tar
-               (basename tmpdir))
+               (basename temp/project))
       (system* "gzip" output.tar)
 
       ;; Now try to move completed archive back to user directory.
@@ -753,11 +754,11 @@ Your new archive lives in ~S\n" temp/output.tar.gz))
     ;; Return to the project directory.
     (chdir project-directory)
     ;; Get rid of temporary directory.
-    (debug-format "Remove temporary directory ~S" (dirname tmpdir))
+    (debug-format "Remove temporary directory ~S" (dirname temp/project))
     ;; Well, I could make a procedure for recursive removing of
     ;; the directory contents, but it is simpler just to use 'rm'
     ;; here.
-    (system* "rm" "-r" "-f" (dirname tmpdir))))
+    (system* "rm" "-r" "-f" (dirname temp/project))))
 
 
 ;;; Extracter.

--- a/utils/scripts/lepton-archive.in
+++ b/utils/scripts/lepton-archive.in
@@ -701,9 +701,9 @@ symbol cache directory."
          (output.tar (string-append output ".tar"))
          (output.tar.gz (string-append output ".tar.gz"))
          (temp/output.tar
-          (make-absolute-filename temp/project output.tar))
+          (make-absolute-filename temp/ output.tar))
          (temp/output.tar.gz
-          (make-absolute-filename temp/project output.tar.gz))
+          (make-absolute-filename temp/ output.tar.gz))
          (project/output.tar.gz
           (make-absolute-filename project-directory output.tar.gz))
          ;; Create list of files (and directories) to stick into

--- a/utils/scripts/lepton-archive.in
+++ b/utils/scripts/lepton-archive.in
@@ -638,7 +638,14 @@ symbol cache directory."
 
 
 (define (source-library-filename filename)
-  (let ((source-filename (get-source-library-file filename)))
+  (define (get-source-or-absolute-filename)
+    (or (get-source-library-file filename)
+        ;; If we cannot find the filename in the source library,
+        ;; maybe it was specified prefixed with a directory name.
+        (and (not (string= filename (basename filename)))
+             (make-absolute-filename project-directory filename))))
+
+  (let ((source-filename (get-source-or-absolute-filename)))
     (if (and source-filename
              (file-exists? source-filename))
         source-filename

--- a/utils/scripts/lepton-archive.in
+++ b/utils/scripts/lepton-archive.in
@@ -226,8 +226,9 @@ default-archive-name))
       result
       (primitive-exit 1)))
 
-;;; Output archive name.
-(define output-file-name
+
+;;; Make up output archive name.
+(define (make-output-file-name)
   (let ((filename
          (or (validate/extract-mode (option-ref %options 'output #f))
              default-archive-name)))
@@ -693,7 +694,10 @@ symbol cache directory."
     ;; Update copy of gafrc.
     (update-rc tmpdir)
 
-    (let* ((output-basename (basename output-file-name ".tar.gz"))
+    (let* (
+           ;; Output archive name.
+           (output-file-name (make-output-file-name))
+           (output-basename (basename output-file-name ".tar.gz"))
            (output.tar (string-append output-basename ".tar"))
            (temp/output.tar.gz
             (make-absolute-filename tmpdir output-file-name))

--- a/utils/scripts/lepton-archive.in
+++ b/utils/scripts/lepton-archive.in
@@ -711,25 +711,26 @@ symbol cache directory."
     (let* (
            ;; Output archive name.
            (output-file-name (make-output-file-name))
-           (output-basename (basename output-file-name ".tar.gz"))
            (output.tar (basename output-file-name ".gz"))
            (temp/output.tar.gz
             (make-absolute-filename temp/project output-file-name))
+           (temp/output.tar
+            (make-absolute-filename temp/project output.tar))
            (output.tar.gz
             (make-absolute-filename project-directory output-file-name)))
 
       (debug-format "Archive directory: ~S" temp/project)
 
-      ;; Now cd into the temporary directory.
-      (chdir (dirname temp/project))
-
       ;;  Now use this in tar command.
       (system* "tar"
+               "-C"
+               temp/
                "-c"
                "-f"
-               output.tar
+               temp/output.tar
                (basename temp/project))
-      (system* "gzip" output.tar)
+      (system* "gzip" temp/output.tar)
+      ;; Now we should have temp/output.tar.gz prepared.
 
       ;; Now try to move completed archive back to user directory.
       (debug-format "Rename archive to ~S" output.tar.gz)
@@ -742,17 +743,15 @@ symbol cache directory."
               ;; Remove old archive
               (begin
                 (delete-file* output.tar.gz)
-                (rename-file* output-file-name output.tar.gz)
+                (rename-file* temp/output.tar.gz output.tar.gz)
                 (format #t "Project archive ~S created successfully!\n"
                         output.tar.gz))
               ;; Report place of the new archive.
               (format #t "Preserving existing archive in local directory.
 Your new archive lives in ~S\n" temp/output.tar.gz))
           ;; Archive is not in user directory yet, no need to force it.
-          (rename-file* output-file-name output.tar.gz)))
+          (rename-file* temp/output.tar.gz output.tar.gz)))
 
-    ;; Return to the project directory.
-    (chdir project-directory)
     ;; Get rid of temporary directory.
     (debug-format "Remove temporary directory ~S" (dirname temp/project))
     ;; Well, I could make a procedure for recursive removing of

--- a/utils/scripts/lepton-archive.in
+++ b/utils/scripts/lepton-archive.in
@@ -692,6 +692,18 @@ symbol cache directory."
           (make-tmp-dir (string-append temp/
                                        file-name-separator-string
                                        (basename project-directory))))
+         (temp/project/cache (make-absolute-filename temp/project
+                                                     cache-directory))
+
+         (output (make-output-file-name))
+         (output.tar (string-append output ".tar"))
+         (output.tar.gz (string-append output ".tar.gz"))
+         (temp/output.tar
+          (make-absolute-filename temp/project output.tar))
+         (temp/output.tar.gz
+          (make-absolute-filename temp/project output.tar.gz))
+         (project/output.tar.gz
+          (make-absolute-filename project-directory output.tar.gz))
          ;; Create list of files (and directories) to stick into
          ;; archive.  Returned paths point to the absolute paths of
          ;; the files.
@@ -700,19 +712,19 @@ symbol cache directory."
          ;; Returned paths give only the base name (i.e. no path)
          (schematic-file-list (create-schematic-file-list archive-file-list)))
 
+    (debug-format "Cache directory: ~S" temp/project/cache)
+    (debug-format "Archive directory: ~S" temp/project)
+
     ;; Copy all files over to temporary directory.
     (for-each (cut copy-to-dir <> temp/project) archive-file-list)
 
     ;; Add cache directory for symbols.  Stick symbol & SPICE
     ;; files into it.
-    (let ((temp/project/cache (make-absolute-filename temp/project
-                                                      cache-directory)))
-      (debug-format "Cache directory: ~S" temp/project/cache)
-      (mkdir* temp/project/cache)
+    (mkdir* temp/project/cache)
 
-      (save-schematics-and-sources schematic-file-list
-                                   temp/project
-                                   temp/project/cache))
+    (save-schematics-and-sources schematic-file-list
+                                 temp/project
+                                 temp/project/cache)
 
     ;; Now create tar file.  We copy remaining files over to /tmp,
     ;; and then tar them all up using a local, relative file
@@ -721,48 +733,36 @@ symbol cache directory."
     ;; Update copy of gafrc.
     (update-rc temp/project)
 
-    (let* ((output (make-output-file-name))
-           (output.tar (string-append output ".tar"))
-           (output.tar.gz (string-append output ".tar.gz"))
-           (temp/output.tar
-            (make-absolute-filename temp/project output.tar))
-           (temp/output.tar.gz
-            (make-absolute-filename temp/project output.tar.gz))
-           (project/output.tar.gz
-            (make-absolute-filename project-directory output.tar.gz)))
+    ;;  Now use this in tar command.
+    (system* "tar"
+             "-C"
+             temp/
+             "-c"
+             "-f"
+             temp/output.tar
+             (basename temp/project))
+    (system* "gzip" temp/output.tar)
+    ;; Now we should have temp/output.tar.gz prepared.
 
-      (debug-format "Archive directory: ~S" temp/project)
-
-      ;;  Now use this in tar command.
-      (system* "tar"
-               "-C"
-               temp/
-               "-c"
-               "-f"
-               temp/output.tar
-               (basename temp/project))
-      (system* "gzip" temp/output.tar)
-      ;; Now we should have temp/output.tar.gz prepared.
-
-      ;; Now try to move completed archive back to user directory.
-      (debug-format "Rename archive to ~S" project/output.tar.gz)
-      (if (or (not (file-exists? project/output.tar.gz))
-              (prompt-confirmed?
-               (format #f "~S already exists. Overwrite? [y/N] " project/output.tar.gz)
-               ;; default
-               "n"))
-          ;; Force renaming.
-          (begin
-            (when (file-exists? project/output.tar.gz)
-              ;; Remove old archive if it exists.
-              (delete-file* project/output.tar.gz))
-            (rename-file* temp/output.tar.gz project/output.tar.gz)
-            (format #t "Project archive ~S created successfully!\n"
-                    project/output.tar.gz)
-            (remove-temp-dir temp/))
-          ;; Otherwise, report the place of the new archive.
-          (format #t "Preserving existing archive in local directory.
-Your new archive lives in ~S\n" temp/output.tar.gz)))))
+    ;; Now try to move completed archive back to user directory.
+    (debug-format "Rename archive to ~S" project/output.tar.gz)
+    (if (or (not (file-exists? project/output.tar.gz))
+            (prompt-confirmed?
+             (format #f "~S already exists. Overwrite? [y/N] " project/output.tar.gz)
+             ;; default
+             "n"))
+        ;; Force renaming.
+        (begin
+          (when (file-exists? project/output.tar.gz)
+            ;; Remove old archive if it exists.
+            (delete-file* project/output.tar.gz))
+          (rename-file* temp/output.tar.gz project/output.tar.gz)
+          (format #t "Project archive ~S created successfully!\n"
+                  project/output.tar.gz)
+          (remove-temp-dir temp/))
+        ;; Otherwise, report the place of the new archive.
+        (format #t "Preserving existing archive in local directory.
+Your new archive lives in ~S\n" temp/output.tar.gz))))
 
 
 ;;; Extracter.

--- a/utils/scripts/lepton-archive.in
+++ b/utils/scripts/lepton-archive.in
@@ -555,7 +555,7 @@ option \"--files-from\" (\"-f\")."
 
   (delete-duplicates
    (append
-     ;; Add RC files.
+    ;; Add RC files.
     (list (add-rc-file gafrc))
     ;; Get names of all schematics and other files to archive.
     ;; First get file names from command line.

--- a/utils/scripts/lepton-archive.in
+++ b/utils/scripts/lepton-archive.in
@@ -716,7 +716,7 @@ symbol cache directory."
            (temp/output.tar
             (make-absolute-filename temp/project
                                     (basename output-file-name ".gz")))
-           (output.tar.gz
+           (project/output.tar.gz
             (make-absolute-filename project-directory output-file-name)))
 
       (debug-format "Archive directory: ~S" temp/project)
@@ -733,24 +733,24 @@ symbol cache directory."
       ;; Now we should have temp/output.tar.gz prepared.
 
       ;; Now try to move completed archive back to user directory.
-      (debug-format "Rename archive to ~S" output.tar.gz)
-      (if (file-exists? output.tar.gz)
+      (debug-format "Rename archive to ~S" project/output.tar.gz)
+      (if (file-exists? project/output.tar.gz)
           ;; Directory already exists
           (if (prompt-confirmed?
-               (format #f "~S already exists. Overwrite? [y/N] " output.tar.gz)
+               (format #f "~S already exists. Overwrite? [y/N] " project/output.tar.gz)
                ;; default
                "n")
               ;; Remove old archive
               (begin
-                (delete-file* output.tar.gz)
-                (rename-file* temp/output.tar.gz output.tar.gz)
+                (delete-file* project/output.tar.gz)
+                (rename-file* temp/output.tar.gz project/output.tar.gz)
                 (format #t "Project archive ~S created successfully!\n"
-                        output.tar.gz))
+                        project/output.tar.gz))
               ;; Report place of the new archive.
               (format #t "Preserving existing archive in local directory.
 Your new archive lives in ~S\n" temp/output.tar.gz))
           ;; Archive is not in user directory yet, no need to force it.
-          (rename-file* temp/output.tar.gz output.tar.gz)))
+          (rename-file* temp/output.tar.gz project/output.tar.gz)))
 
     ;; Get rid of temporary directory.
     (debug-format "Remove temporary directory ~S" (dirname temp/project))

--- a/utils/scripts/lepton-archive.in
+++ b/utils/scripts/lepton-archive.in
@@ -648,15 +648,22 @@ symbol cache directory."
           #f))))
 
 
-(define (subschematic-page-filenames schematic)
+(define (subschematic-page-filenames schematic toplevel-schematics)
+  (define (non-toplevel? name)
+    (not (member (make-absolute-filename project-directory
+                                         name)
+                 toplevel-schematics)))
+
   (let ((files (delete-duplicates
                 (flatten-tree (schematic-name-tree schematic)))))
-    (filter-map source-library-filename files)))
+    (filter-map source-library-filename
+                (filter non-toplevel? files))))
 
 
 (define (save-schematics-and-sources toplevel-schematics temp-dir cache-dir)
   (let* ((schematic (file-name-list->schematic toplevel-schematics))
-         (subschematic-filenames (subschematic-page-filenames schematic))
+         (subschematic-filenames (subschematic-page-filenames schematic
+                                                              toplevel-schematics))
          (schematic-sources (filter-map (lambda (c) (schematic-component-attribute c 'file))
                                         (schematic-components* schematic)))
          (source-filenames (filter-map source-library-filename schematic-sources))

--- a/utils/scripts/lepton-archive.in
+++ b/utils/scripts/lepton-archive.in
@@ -620,6 +620,11 @@ symbol cache directory."
         ;; If we cannot find the filename in the source library,
         ;; maybe it was specified prefixed with a directory name.
         (and (not (string= filename (basename filename)))
+             (format #t "File ~S will be copied to the ~S subdirectory of your archive.
+This can lead to wrong processing of your schematics by other tools.
+Please use file basenames in your schematics to fix this.\n\n"
+                     filename
+                     cache-directory)
              (make-absolute-filename project-directory filename))))
 
   (let ((source-filename (get-source-or-absolute-filename)))

--- a/utils/scripts/lepton-archive.in
+++ b/utils/scripts/lepton-archive.in
@@ -669,11 +669,11 @@ symbol cache directory."
   "Main archiver."
 
   (define (make-tmp-dir)
-    (let* ((tmp (tmpnam))
-           (name (string-append tmp
+    (let* ((temp/ (tmpnam))
+           (name (string-append temp/
                                 file-name-separator-string
                                 (basename project-directory))))
-      (mkdir* tmp #o700)
+      (mkdir* temp/ #o700)
       (mkdir* name #o700)
       name))
 

--- a/utils/scripts/lepton-archive.in
+++ b/utils/scripts/lepton-archive.in
@@ -745,23 +745,22 @@ symbol cache directory."
 
       ;; Now try to move completed archive back to user directory.
       (debug-format "Rename archive to ~S" project/output.tar.gz)
-      (if (file-exists? project/output.tar.gz)
-          ;; Directory already exists
-          (if (prompt-confirmed?
+      (if (or (not (file-exists? project/output.tar.gz))
+              (prompt-confirmed?
                (format #f "~S already exists. Overwrite? [y/N] " project/output.tar.gz)
                ;; default
-               "n")
-              ;; Remove old archive
-              (begin
-                (delete-file* project/output.tar.gz)
-                (rename-file* temp/output.tar.gz project/output.tar.gz)
-                (format #t "Project archive ~S created successfully!\n"
-                        project/output.tar.gz))
-              ;; Report place of the new archive.
-              (format #t "Preserving existing archive in local directory.
-Your new archive lives in ~S\n" temp/output.tar.gz))
-          ;; Archive is not in user directory yet, no need to force it.
-          (rename-file* temp/output.tar.gz project/output.tar.gz)))
+               "n"))
+          ;; Force renaming.
+          (begin
+            (when (file-exists? project/output.tar.gz)
+              ;; Remove old archive if it exists.
+              (delete-file* project/output.tar.gz))
+            (rename-file* temp/output.tar.gz project/output.tar.gz)
+            (format #t "Project archive ~S created successfully!\n"
+                    project/output.tar.gz))
+          ;; Otherwise, report the place of the new archive.
+          (format #t "Preserving existing archive in local directory.
+Your new archive lives in ~S\n" temp/output.tar.gz)))
 
     (remove-temp-dir temp/)))
 

--- a/utils/scripts/lepton-archive.in
+++ b/utils/scripts/lepton-archive.in
@@ -755,11 +755,11 @@ Your new archive lives in ~S\n" temp/output.tar.gz))
           (rename-file* temp/output.tar.gz project/output.tar.gz)))
 
     ;; Get rid of temporary directory.
-    (debug-format "Remove temporary directory ~S" (dirname temp/project))
+    (debug-format "Remove temporary directory ~S" temp/)
     ;; Well, I could make a procedure for recursive removing of
     ;; the directory contents, but it is simpler just to use 'rm'
     ;; here.
-    (system* "rm" "-r" "-f" (dirname temp/project))))
+    (system* "rm" "-r" "-f" temp/)))
 
 
 ;;; Extracter.

--- a/utils/scripts/lepton-archive.in
+++ b/utils/scripts/lepton-archive.in
@@ -157,6 +157,10 @@ Example usage:
 
 
 (define (make-absolute-filename dir-name file-name)
+  "Transforms FILE-NAME into an absolute filename using DIR-NAME
+as a prefix if it is a relative filename, otherwise leaves it as
+is.  Thus, filenames containing special paths like \".\" or \"..\"
+or no directory path can be converted into absolute."
   (if (absolute-file-name? file-name)
       file-name
       (string-append dir-name

--- a/utils/scripts/lepton-archive.in
+++ b/utils/scripts/lepton-archive.in
@@ -698,7 +698,7 @@ symbol cache directory."
            ;; Output archive name.
            (output-file-name (make-output-file-name))
            (output-basename (basename output-file-name ".tar.gz"))
-           (output.tar (string-append output-basename ".tar"))
+           (output.tar (basename output-file-name ".gz"))
            (temp/output.tar.gz
             (make-absolute-filename tmpdir output-file-name))
            (output.tar.gz


### PR DESCRIPTION
- Refactoring.
- Added a message about wrong attribute usage.
- Toplevel variables and options are defined/evaluated in one place.
- Get rid of non-procedure defines which improves code readability.
- Added docstrings for several functions.
- Added support for absolute and relative source filenames (such
  as "/tmp/simulation.cmd" or using relative paths like "./" or
  "../").
- Files missing in the source library are reported.
- Fixed caching of symbols not present in the project directory.
- More debugging info.
- Fixed creation of archives with absolute names
  (e.g. /tmp/x.tar.gz).  Previously, they could not be created.
- Fixed issue with removing of temporary directory.  When the user
  decided to not overwrite an already existing archive with a new
  one, the program reports the place where a new created archive
  lives.  Previously, `lepton-archive` deleted the directory
  anyways, which has been fixed.
- Successful archive creation is now reported in two cases (one
  case was previously missing): when the file with name in
  question does not exist or when it exists, but the user forces
  it deletion.
- The output archive file name can now be specified without the
  ".tar.gz" suffix.  The users can just use '-o project-archive'
  to save their project to the 'project-archive.tar.gz' file.
- 'tar -C ...' is now used when creating archives instead of
  'chdir' to the temp directory and then 'chdir' back.
- One procedure is now used to output prompts requiring user
  input. This prevents using of different input in such cases.
- Closes #523.