### PR TITLE
Resize columns in the page manager

### DIFF
--- a/schematic/src/page_select_widget.c
+++ b/schematic/src/page_select_widget.c
@@ -349,6 +349,11 @@ pagesel_callback_fullpaths_toggled (GtkToggleButton* btn, gpointer data)
   pagesel->show_paths_ = gtk_toggle_button_get_active (btn);
   pagesel_update (pagesel);
 
+  if (!pagesel->show_paths_)
+  {
+    gtk_tree_view_columns_autosize (pagesel->treeview_);
+  }
+
   /* Save config: whether to show full paths in the pages list:
   */
   EdaConfig* cfg = eda_config_get_cache_context();


### PR DESCRIPTION
Resize tree view columns to their optimal width
when the "Show full paths" checkbox is clicked.
This conveniently returns the "Changed" column
to its former position after long paths are shown
and then hidden again, in addition removing the
no longer needed horizontal scrollbar.

Happy New Year!