### PR TITLE
Optional tooltips in lepton-schematic tabbed GUI

### DIFF
--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -48,6 +48,7 @@ net-selection-mode=enabled_net
 [schematic.tabs]
 show-close-button=true
 show-up-button=true
+show-tooltips=true
 
 [schematic.status-bar]
 show-mouse-buttons=false

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -48,6 +48,7 @@ net-selection-mode=enabled_net
 [schematic.tabs]
 show-close-button=true
 show-up-button=true
+show-tooltips=true
 
 [schematic.status-bar]
 show-mouse-buttons=false

--- a/schematic/src/x_tabs.c
+++ b/schematic/src/x_tabs.c
@@ -67,6 +67,12 @@
  * type:        boolean
  * default val: true
  *
+ * 4) Whether to show tabs tooltips:
+ * key:         show-tooltips
+ * group:       schematic.tabs
+ * type:        boolean
+ * default val: true
+ *
  */
 
 #include "gschem.h"
@@ -82,6 +88,9 @@ g_x_tabs_show_close_button = TRUE;
 
 static gboolean
 g_x_tabs_show_up_button = TRUE;
+
+static gboolean
+g_x_tabs_show_tooltips = TRUE;
 
 
 
@@ -108,6 +117,14 @@ static gboolean
 x_tabs_show_up_button()
 {
   return g_x_tabs_show_up_button;
+}
+
+
+
+static gboolean
+x_tabs_show_tooltips()
+{
+  return g_x_tabs_show_tooltips;
 }
 
 
@@ -169,7 +186,22 @@ x_tabs_init()
     }
 
     g_clear_error (&err);
-  }
+
+
+    /* read config: whether to show tabs tooltips:
+    */
+    val = eda_config_get_boolean (cfg,
+                                  "schematic.tabs",
+                                  "show-tooltips",
+                                  &err);
+    if (err == NULL)
+    {
+      g_x_tabs_show_tooltips = val;
+    }
+
+    g_clear_error (&err);
+
+  } /* if: cfg */
 
 } /* x_tabs_init() */
 
@@ -840,8 +872,12 @@ x_tabs_hdr_create (TabInfo* nfo)
 
   /* tab's tooltip:
   */
-  /* display full path of the schematic file: */
-  gtk_widget_set_tooltip_text (box_hdr, fname);
+  if (x_tabs_show_tooltips())
+  {
+    /* the full path of the schematic file:
+    */
+    gtk_widget_set_tooltip_text (box_hdr, fname);
+  }
 
 
   /* make tab btns smaller => smaller tabs:

--- a/schematic/src/x_tabs.c
+++ b/schematic/src/x_tabs.c
@@ -129,7 +129,26 @@ x_tabs_show_tooltips()
 
 
 
-/*! \brief Initialize tabbed GUI.
+static void
+cfg_read_bool (EdaConfig*   cfg,
+               const gchar* group,
+               const gchar* key,
+               gboolean*    result)
+{
+  GError*  err = NULL;
+  gboolean val = eda_config_get_boolean (cfg, group, key, &err);
+
+  if (err == NULL)
+  {
+    *result = val;
+  }
+
+  g_clear_error (&err);
+}
+
+
+
+/*! \brief Initialize tabbed GUI; read configuration
  *  \public
  *
  *  \par Function Description
@@ -144,64 +163,18 @@ x_tabs_init()
 
   if (cfg != NULL)
   {
-    GError* err = NULL;
+    cfg_read_bool (cfg, "schematic.gui", "use-tabs",
+                   &g_x_tabs_enabled);
 
-    /* read config: whether to use tabbed GUI:
-    */
-    gboolean val = eda_config_get_boolean (cfg,
-                                           "schematic.gui",
-                                           "use-tabs",
-                                           &err);
-    if (err == NULL)
-    {
-      g_x_tabs_enabled = val;
-    }
+    cfg_read_bool (cfg, "schematic.tabs", "show-close-button",
+                   &g_x_tabs_show_close_button);
 
-    g_clear_error (&err);
+    cfg_read_bool (cfg, "schematic.tabs", "show-up-button",
+                   &g_x_tabs_show_up_button);
 
-
-    /* read config: whether to show "close" button:
-    */
-    val = eda_config_get_boolean (cfg,
-                                  "schematic.tabs",
-                                  "show-close-button",
-                                  &err);
-    if (err == NULL)
-    {
-      g_x_tabs_show_close_button = val;
-    }
-
-    g_clear_error (&err);
-
-
-    /* read config: whether to show "hierarchy up" button:
-    */
-    val = eda_config_get_boolean (cfg,
-                                  "schematic.tabs",
-                                  "show-up-button",
-                                  &err);
-    if (err == NULL)
-    {
-      g_x_tabs_show_up_button = val;
-    }
-
-    g_clear_error (&err);
-
-
-    /* read config: whether to show tabs tooltips:
-    */
-    val = eda_config_get_boolean (cfg,
-                                  "schematic.tabs",
-                                  "show-tooltips",
-                                  &err);
-    if (err == NULL)
-    {
-      g_x_tabs_show_tooltips = val;
-    }
-
-    g_clear_error (&err);
-
-  } /* if: cfg */
+    cfg_read_bool (cfg, "schematic.tabs", "show-tooltips",
+                   &g_x_tabs_show_tooltips);
+  }
 
 } /* x_tabs_init() */
 

--- a/schematic/src/x_tabs.c
+++ b/schematic/src/x_tabs.c
@@ -811,9 +811,6 @@ x_tabs_hdr_create (TabInfo* nfo)
   GtkWidget* box_lab        = gtk_hbox_new (FALSE, 0);
   GtkWidget* box_btns_right = gtk_hbox_new (FALSE, 0);
 
-  const gboolean show_btn_up    = x_tabs_show_up_button();
-  const gboolean show_btn_close = x_tabs_show_close_button();
-
 
   /* label:
   */
@@ -899,7 +896,7 @@ x_tabs_hdr_create (TabInfo* nfo)
   TOPLEVEL* toplevel = gschem_toplevel_get_toplevel (nfo->tl_);
   PAGE* parent = s_hierarchy_find_up_page (toplevel->pages, nfo->page_);
 
-  if (show_btn_up && parent != NULL)
+  if (x_tabs_show_up_button() && parent != NULL)
   {
     const gchar* parent_fname = s_page_get_filename (parent);
     gchar*       parent_bname = NULL;
@@ -929,7 +926,7 @@ x_tabs_hdr_create (TabInfo* nfo)
 
   /* setup "close" btn:
   */
-  if (show_btn_close)
+  if (x_tabs_show_close_button())
   {
     gtk_box_pack_start (GTK_BOX (box_btns_right), btn_close, FALSE, FALSE, 0);
 


### PR DESCRIPTION
Add a new boolean configuration key `show-tooltips` to the
`schematic.tabs` group, which controls whether to show tabs
tooltips in lepton-schematic tabbed GUI. It's is `true` by default.