### PR TITLE
Add a short equivalent for the --list-backends lepton-netlist option

### DIFF
--- a/netlist/docs/lepton-netlist.1.in
+++ b/netlist/docs/lepton-netlist.1.in
@@ -47,7 +47,7 @@ point function NAME (where NAME is the backend's name).
 \fB-O\fR \fISTRING\fR
 Pass an option string to the backend.
 .TP 8
-\fB--list-backends\fR
+\fB-b\fR, \fB--list-backends\fR
 Print a list of available netlist backends.
 .TP 8
 \fB-o\fR \fIFILE\fR

--- a/netlist/scheme/lepton-netlist.in
+++ b/netlist/scheme/lepton-netlist.in
@@ -37,7 +37,7 @@ exec @GUILE@ -s "$0" "$@"
     (backend (single-char #\g) (value #t))
     (file-backend (single-char #\f) (value #t))
     (backend-option (single-char #\O) (value #t))
-    (list-backends)
+    (list-backends (single-char #\b))
     (output (single-char #\o) (value #t))
     (pre-load (single-char #\l) (value #t))
     (post-load (single-char #\m) (value #t))

--- a/netlist/scheme/netlist.scm
+++ b/netlist/scheme/netlist.scm
@@ -806,21 +806,21 @@ begins with \"gnet-\" and ends with \".scm\"."
 Generate a netlist from one or more Lepton EDA schematic FILEs.
 
 General options:
-  -q              Quiet mode.
-  -v, --verbose   Verbose mode.
-  -o FILE         Filename for netlist data output.
-  -L DIR          Add DIR to Scheme search path.
-  -g BACKEND      Specify netlist backend to use.
-  -f FILE         Specify path to netlist backend file to use.
-  -O STRING       Pass an option string to backend.
-  -l FILE         Load Scheme file before loading backend.
-  -m FILE         Load Scheme file after loading backend.
-  -c EXPR         Evaluate Scheme expression at startup.
-  -i              Enter interactive Scheme REPL after loading.
-  --list-backends Print a list of available netlist backends.
-  -h, --help      Help; this message.
-  -V, --version   Show version information.
-  --              Treat all remaining arguments as filenames.
+  -q                  Quiet mode.
+  -v, --verbose       Verbose mode.
+  -o FILE             Filename for netlist data output.
+  -L DIR              Add DIR to Scheme search path.
+  -g BACKEND          Specify netlist backend to use.
+  -f FILE             Specify path to netlist backend file to use.
+  -O STRING           Pass an option string to backend.
+  -l FILE             Load Scheme file before loading backend.
+  -m FILE             Load Scheme file after loading backend.
+  -c EXPR             Evaluate Scheme expression at startup.
+  -i                  Enter interactive Scheme REPL after loading.
+  -b, --list-backends Print a list of available netlist backends.
+  -h, --help          Help; this message.
+  -V, --version       Show version information.
+  --                  Treat all remaining arguments as filenames.
 
 Report bugs at <https://github.com/lepton-eda/lepton-eda/issues>
 Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>


### PR DESCRIPTION
`--list-backends`: too many buttons to press. :-)
Could we type just, say, `-b`? Or is there a more suitable letter?
