### PR TITLE
Deprecate other gafrc options

### DIFF
--- a/liblepton/include/i_vars_priv.h
+++ b/liblepton/include/i_vars_priv.h
@@ -1,5 +1,3 @@
-extern GPtrArray *default_always_promote_attributes;
-
 extern int default_attribute_promotion;
 extern int default_promote_invisible;
 extern int default_keep_invisible;

--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -96,6 +96,7 @@ log-window=later
 
 [schematic.attrib]
 promote=true
+promote-invisible=false
 
 
 

--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -94,6 +94,9 @@ logging=true
 auto-save-interval=120
 log-window=later
 
+[schematic.backup]
+create-files=true
+
 [schematic.attrib]
 promote=true
 promote-invisible=false

--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -101,6 +101,7 @@ create-files=true
 promote=true
 promote-invisible=false
 keep-invisible=true
+always-promote=footprint;device;value;model-name
 
 
 

--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -94,6 +94,9 @@ logging=true
 auto-save-interval=120
 log-window=later
 
+[schematic.attrib]
+promote=true
+
 
 
 #

--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -97,6 +97,7 @@ log-window=later
 [schematic.attrib]
 promote=true
 promote-invisible=false
+keep-invisible=true
 
 
 

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -96,6 +96,7 @@ log-window=later
 
 [schematic.attrib]
 promote=true
+promote-invisible=false
 
 
 

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -94,6 +94,9 @@ logging=true
 auto-save-interval=120
 log-window=later
 
+[schematic.backup]
+create-files=true
+
 [schematic.attrib]
 promote=true
 promote-invisible=false

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -101,6 +101,7 @@ create-files=true
 promote=true
 promote-invisible=false
 keep-invisible=true
+always-promote=footprint;device;value;model-name
 
 
 

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -94,6 +94,9 @@ logging=true
 auto-save-interval=120
 log-window=later
 
+[schematic.attrib]
+promote=true
+
 
 
 #

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -97,6 +97,7 @@ log-window=later
 [schematic.attrib]
 promote=true
 promote-invisible=false
+keep-invisible=true
 
 
 

--- a/liblepton/lib/system-gafrc
+++ b/liblepton/lib/system-gafrc
@@ -37,17 +37,6 @@
 ; Start of attribute promotion keywords
 ;
 
-; attribute-promotion string
-;
-; This keyword controls if attribute promotion occurs when you instanciate a
-; component.  Attribute promotion basically means that any floating attribute
-; (unattached) which is inside a symbol gets "promoted" or attached to the
-; newly inserted component.  This only occurs when the component is
-; instanciated.
-;
-(attribute-promotion "enabled")
-;(attribute-promotion "disabled")
-
 ; promote-invisible string
 ;
 ; If attribute-promotion is enabled, then this controls if invisible floating

--- a/liblepton/lib/system-gafrc
+++ b/liblepton/lib/system-gafrc
@@ -37,19 +37,6 @@
 ; Start of attribute promotion keywords
 ;
 
-; keep-invisible string
-;
-; If both attribute-promotion and promote-invisible are enabled, then this
-; controls if invisible floating attributes are kept around in memory and
-; NOT deleted.  Having this enabled will keeps component slotting working.
-; If attribute-promotion and promote-invisible are enabled and this
-; keyword is disabled, then component slotting will NOT work (and maybe
-; other functions which depend on hidden attributes, since those attributes
-; are deleted from memory).
-;
-;(keep-invisible "disabled")
-(keep-invisible "enabled")
-
 ; always-promote-attributes
 ;
 ; Set the list of attributes that are always promoted regardless of

--- a/liblepton/lib/system-gafrc
+++ b/liblepton/lib/system-gafrc
@@ -50,13 +50,6 @@
 ; End of attribute promotion keywords
 ;
 
-; make-backup-files
-;
-; Enable the creation of backup files (name.sch~) when saving a schematic.
-; It may be useful to disable this if your schematic is under version control
-; as you can always recover any mistakes from the revision history.
-;(make-backup-files "disabled")
-(make-backup-files "enabled")
 
 ;;;; Color maps
 

--- a/liblepton/lib/system-gafrc
+++ b/liblepton/lib/system-gafrc
@@ -37,16 +37,6 @@
 ; Start of attribute promotion keywords
 ;
 
-; promote-invisible string
-;
-; If attribute-promotion is enabled, then this controls if invisible floating
-; attributes are promoted (attached to the outside of the component) if the
-; text string is invisible.  There are cases where it is undesirable, so the
-; default is disabled.
-;
-;(promote-invisible "enabled")
-(promote-invisible "disabled")
-
 ; keep-invisible string
 ;
 ; If both attribute-promotion and promote-invisible are enabled, then this

--- a/liblepton/lib/system-gafrc
+++ b/liblepton/lib/system-gafrc
@@ -33,23 +33,6 @@
 ; Guile Scheme libraries.
 ;(scheme-directory "${HOME}/.gEDA/scheme")
 
-;
-; Start of attribute promotion keywords
-;
-
-; always-promote-attributes
-;
-; Set the list of attributes that are always promoted regardless of
-; their visibility. The list should be a scm list of strings. The
-; space separated attribute names are deprecated.
-;
-;(always-promote-attributes "footprint device value model-name")
-(always-promote-attributes '("footprint" "device" "value" "model-name"))
-
-;
-; End of attribute promotion keywords
-;
-
 
 ;;;; Color maps
 

--- a/liblepton/scheme/geda-deprecated-config.scm
+++ b/liblepton/scheme/geda-deprecated-config.scm
@@ -111,6 +111,9 @@
 (define-rc-deprecated-config
  promote-invisible "schematic.attrib" "promote-invisible"
  rc-deprecated-string-boolean-transformer)
+(define-rc-deprecated-config
+ keep-invisible "schematic.attrib" "keep-invisible"
+ rc-deprecated-string-boolean-transformer)
 
 ;; ===================================================================
 ;; Deprecated lepton-schematic configuration functions

--- a/liblepton/scheme/geda-deprecated-config.scm
+++ b/liblepton/scheme/geda-deprecated-config.scm
@@ -114,6 +114,9 @@
 (define-rc-deprecated-config
  keep-invisible "schematic.attrib" "keep-invisible"
  rc-deprecated-string-boolean-transformer)
+(define-rc-deprecated-config
+ make-backup-files "schematic.backup" "create-files"
+ rc-deprecated-string-boolean-transformer)
 
 ;; ===================================================================
 ;; Deprecated lepton-schematic configuration functions

--- a/liblepton/scheme/geda-deprecated-config.scm
+++ b/liblepton/scheme/geda-deprecated-config.scm
@@ -94,6 +94,21 @@
 
 (define (rc-deprecated-int-transformer num) num)
 
+; ( list "attr1" "attr2" "attr3" ) => "attr1;attr2;attr3":
+;
+( define ( rc-deprecated-strlist-transformer strlist )
+  ; return:
+  ( apply
+    string-append
+    ( map
+      ( lambda( str )
+        ( format #f "~a;" str )
+      )
+      strlist
+    )
+  )
+)
+
 ;; Transformer for "enabled"/"disabled" to boolean
 (define (rc-deprecated-string-boolean-transformer str)
   (string=? "enabled" str))
@@ -117,6 +132,9 @@
 (define-rc-deprecated-config
  make-backup-files "schematic.backup" "create-files"
  rc-deprecated-string-boolean-transformer)
+(define-rc-deprecated-config
+ always-promote-attributes "schematic.attrib" "always-promote"
+ rc-deprecated-strlist-transformer)
 
 ;; ===================================================================
 ;; Deprecated lepton-schematic configuration functions

--- a/liblepton/scheme/geda-deprecated-config.scm
+++ b/liblepton/scheme/geda-deprecated-config.scm
@@ -108,6 +108,9 @@
 (define-rc-deprecated-config
  attribute-promotion "schematic.attrib" "promote"
  rc-deprecated-string-boolean-transformer)
+(define-rc-deprecated-config
+ promote-invisible "schematic.attrib" "promote-invisible"
+ rc-deprecated-string-boolean-transformer)
 
 ;; ===================================================================
 ;; Deprecated lepton-schematic configuration functions

--- a/liblepton/scheme/geda-deprecated-config.scm
+++ b/liblepton/scheme/geda-deprecated-config.scm
@@ -105,6 +105,9 @@
 (define-rc-dead-config postscript-prolog)
 (define-rc-dead-config world-size)
 (define-rc-dead-config bitmap-directory)
+(define-rc-deprecated-config
+ attribute-promotion "schematic.attrib" "promote"
+ rc-deprecated-string-boolean-transformer)
 
 ;; ===================================================================
 ;; Deprecated lepton-schematic configuration functions

--- a/liblepton/scheme/geda/deprecated.scm
+++ b/liblepton/scheme/geda/deprecated.scm
@@ -43,7 +43,6 @@
               load-rc-from-sys-config-dirs)
 
  #:export (deprecated-module-log-warning!
-           always-promote-attributes
            print-color-map
            scheme-directory))
 
@@ -144,8 +143,6 @@
 (define print-color-map %print-color-map)
 
 (define scheme-directory %scheme-directory)
-
-(define always-promote-attributes %always-promote-attributes)
 
 (define (enabled? x)
   (string= "enabled" x))

--- a/liblepton/scheme/geda/deprecated.scm
+++ b/liblepton/scheme/geda/deprecated.scm
@@ -47,7 +47,6 @@
            keep-invisible
            make-backup-files
            print-color-map
-           promote-invisible
            scheme-directory))
 
 (define* (deprecated-module-log-warning! #:optional (new-modname #f))
@@ -152,9 +151,6 @@
 
 (define (enabled? x)
   (string= "enabled" x))
-
-(define (promote-invisible mode)
-  (%promote-invisible (enabled? mode)))
 
 (define (keep-invisible mode)
   (%keep-invisible (enabled? mode)))

--- a/liblepton/scheme/geda/deprecated.scm
+++ b/liblepton/scheme/geda/deprecated.scm
@@ -44,7 +44,6 @@
 
  #:export (deprecated-module-log-warning!
            always-promote-attributes
-           make-backup-files
            print-color-map
            scheme-directory))
 
@@ -150,6 +149,3 @@
 
 (define (enabled? x)
   (string= "enabled" x))
-
-(define (make-backup-files mode)
-  (%make-backup-files (enabled? mode)))

--- a/liblepton/scheme/geda/deprecated.scm
+++ b/liblepton/scheme/geda/deprecated.scm
@@ -44,7 +44,6 @@
 
  #:export (deprecated-module-log-warning!
            always-promote-attributes
-           keep-invisible
            make-backup-files
            print-color-map
            scheme-directory))
@@ -151,9 +150,6 @@
 
 (define (enabled? x)
   (string= "enabled" x))
-
-(define (keep-invisible mode)
-  (%keep-invisible (enabled? mode)))
 
 (define (make-backup-files mode)
   (%make-backup-files (enabled? mode)))

--- a/liblepton/scheme/geda/deprecated.scm
+++ b/liblepton/scheme/geda/deprecated.scm
@@ -44,7 +44,6 @@
 
  #:export (deprecated-module-log-warning!
            always-promote-attributes
-           attribute-promotion
            keep-invisible
            make-backup-files
            print-color-map
@@ -153,9 +152,6 @@
 
 (define (enabled? x)
   (string= "enabled" x))
-
-(define (attribute-promotion mode)
-  (%attribute-promotion (enabled? mode)))
 
 (define (promote-invisible mode)
   (%promote-invisible (enabled? mode)))

--- a/liblepton/scheme/lepton/config.scm
+++ b/liblepton/scheme/lepton/config.scm
@@ -21,7 +21,10 @@
 
   ; Import C procedures
   #:use-module (geda core smob)
-  #:use-module (geda core config))
+  #:use-module (geda core config)
+
+  #:use-module (ice-9 optargs) ; for define*-public
+)
 
 (define-public config? %config?)
 (define-public default-config-context %default-config-context)
@@ -30,7 +33,11 @@
 (define-public path-config-context %path-config-context)
 (define-public cache-config-context %cache-config-context)
 (define-public config-filename %config-filename)
-(define-public config-load! %config-load!)
+
+( define*-public ( config-load! cfg #:key (force-load #f) )
+  ( %config-load! cfg force-load )
+)
+
 (define-public config-loaded? %config-loaded?)
 (define-public config-save! %config-save!)
 (define-public config-changed? %config-changed?)

--- a/liblepton/scheme/unit-tests/t0402-config.scm
+++ b/liblepton/scheme/unit-tests/t0402-config.scm
@@ -84,9 +84,9 @@
     (assert-equal a (config-load! a))
     (assert-true (config-loaded? a))
     (chmod *testdirAconf* #o000) ;; Make conf unreadable
-    (assert-thrown 'system-error (config-load! a)))
+    (assert-thrown 'system-error (config-load! a #:force-load #t)))
 
-  (assert-thrown 'system-error (config-load! (default-config-context))))
+  (assert-thrown 'system-error (config-load! (default-config-context) #:force-load #t)))
 
 (begin-config-test 'config-save
   (let ((a (path-config-context *testdirA*)))
@@ -137,7 +137,7 @@
 
 (begin-config-test 'config-changed
   (let ((a (path-config-context *testdirA*)))
-    (config-load! a)
+    (config-load! a #:force-load #t)
     (assert-equal #f (config-changed? a))
     (set-config! a "foo" "bar" #t)
     (assert-true (config-changed? a))
@@ -145,7 +145,7 @@
     (assert-equal #f (config-changed? a))
     (set-config! a "foo" "bar" #f)
     (assert-true (config-changed? a))
-    (config-load! a)
+    (config-load! a #:force-load #t)
     (assert-equal #f (config-changed? a))))
 
 (begin-config-test 'config-groups
@@ -155,8 +155,8 @@
        (lambda () (set-config-parent! b a))
        (lambda ()
 
-         (config-load! a)
-         (config-load! b)
+         (config-load! a #:force-load #t)
+         (config-load! b #:force-load #t)
 
          (assert-equal '() (config-groups a))
          (assert-equal '() (config-groups b))
@@ -202,8 +202,8 @@
        (lambda () (set-config-parent! b a))
        (lambda ()
          (set-config-parent! b a)
-         (config-load! a)
-         (config-load! b)
+         (config-load! a #:force-load #t)
+         (config-load! b #:force-load #t)
 
          (assert-thrown 'config-error '() (config-keys a "foo"))
 
@@ -477,9 +477,9 @@
     (assert-equal a (geda:config-load! a))
     (assert-true (geda:config-loaded? a))
     (chmod *testdir-geda-Aconf* #o000) ;; Make conf unreadable
-    (assert-thrown 'system-error (geda:config-load! a)))
+    (assert-thrown 'system-error (geda:config-load! a #:force-load #t)))
 
-  (assert-thrown 'system-error (geda:config-load! (geda:default-config-context))))
+  (assert-thrown 'system-error (geda:config-load! (geda:default-config-context) #:force-load #t)))
 
 (begin-geda-config-test 'geda:config-save
   (let ((a (geda:path-config-context *testdir-geda-A*)))
@@ -530,7 +530,7 @@
 
 (begin-geda-config-test 'geda:config-changed
   (let ((a (geda:path-config-context *testdir-geda-A*)))
-    (geda:config-load! a)
+    (geda:config-load! a #:force-load #t)
     (assert-equal #f (geda:config-changed? a))
     (geda:set-config! a "foo" "bar" #t)
     (assert-true (geda:config-changed? a))
@@ -538,7 +538,7 @@
     (assert-equal #f (geda:config-changed? a))
     (geda:set-config! a "foo" "bar" #f)
     (assert-true (geda:config-changed? a))
-    (geda:config-load! a)
+    (geda:config-load! a #:force-load #t)
     (assert-equal #f (geda:config-changed? a))))
 
 (begin-geda-config-test 'geda:config-groups
@@ -548,8 +548,8 @@
        (lambda () (geda:set-config-parent! b a))
        (lambda ()
 
-         (geda:config-load! a)
-         (geda:config-load! b)
+         (geda:config-load! a #:force-load #t)
+         (geda:config-load! b #:force-load #t)
 
          (assert-equal '() (geda:config-groups a))
          (assert-equal '() (geda:config-groups b))
@@ -595,8 +595,8 @@
        (lambda () (geda:set-config-parent! b a))
        (lambda ()
          (geda:set-config-parent! b a)
-         (geda:config-load! a)
-         (geda:config-load! b)
+         (geda:config-load! a #:force-load #t)
+         (geda:config-load! b #:force-load #t)
 
          (assert-thrown 'config-error '() (geda:config-keys a "foo"))
 

--- a/liblepton/src/g_rc.c
+++ b/liblepton/src/g_rc.c
@@ -796,22 +796,6 @@ SCM_DEFINE (always_promote_attributes, "%always-promote-attributes", 1, 0, 0,
   return SCM_BOOL_T;
 }
 
-/*! \brief Enable the creation of backup files when saving
- *  \par Function Description
- *  If enabled then a backup file, of the form 'example.sch~', is created when
- *  saving a file.
- *
- *  \param [in] s_mode  String. 'enabled' or 'disabled'
- *  \return           Bool. False if s_mode is not a valid value; true if it is.
- *
- */
-SCM_DEFINE (make_backup_files, "%make-backup-files", 1, 0, 0,
-            (SCM s_mode), "Enable or disable the creation of backup files.")
-{
-  default_make_backup_files = scm_is_true (s_mode);
-  return s_mode;
-}
-
 SCM_DEFINE (print_color_map, "%print-color-map", 0, 1, 0,
             (SCM scm_map), "Set or view current print color map.")
 {
@@ -878,7 +862,6 @@ init_module_lepton_core_rc (void *unused)
                 s_component_library,
                 s_component_library_command,
                 s_component_library_funcs,
-                s_make_backup_files,
                 s_print_color_map,
                 s_reset_component_library,
                 s_scheme_directory,

--- a/liblepton/src/g_rc.c
+++ b/liblepton/src/g_rc.c
@@ -2,7 +2,7 @@
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2016 gEDA Contributors
  * Copyright (C) 2016 Peter Brett <peter@peter-b.co.uk>
- * Copyright (C) 2017-2019 Lepton EDA Contributors
+ * Copyright (C) 2017-2020 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -744,58 +744,6 @@ SCM_DEFINE (reset_component_library, "%reset-component-library", 0, 0, 0,
   return SCM_BOOL_T;
 }
 
-/*! \todo Finish function description!!!
- *  \brief
- *  \par Function Description
- *
- *  \param [in] attrlist
- *  \return SCM_BOOL_T always.
- */
-SCM_DEFINE (always_promote_attributes, "%always-promote-attributes", 1, 0, 0,
-            (SCM attrlist),
-            "Set the list of attributes that are always promoted regardless of their visibility.")
-{
-  SCM_ASSERT (scm_is_true (scm_list_p (attrlist)), attrlist, SCM_ARG1,
-              s_always_promote_attributes);
-
-  if (default_always_promote_attributes) {
-    g_ptr_array_unref (default_always_promote_attributes);
-  }
-
-  GPtrArray *promote = g_ptr_array_new ();
-
-  scm_dynwind_begin ((scm_t_dynwind_flags) 0);
-  scm_dynwind_unwind_handler ((void (*)(void *)) g_ptr_array_unref,
-                              promote,
-                              (scm_t_wind_flags) 0);
-
-  for (SCM iter = attrlist; !scm_is_null(iter); iter = scm_cdr(iter))
-  {
-    SCM car = scm_car (iter);
-
-    if (scm_is_string (car))
-    {
-      char* attr = scm_to_utf8_string (car);
-
-      /* Only accept non-empty strings:
-      */
-      if (strlen (attr) > 0)
-      {
-        g_ptr_array_add (promote, (gpointer) g_intern_string (attr));
-      }
-
-      free (attr);
-    }
-
-  }
-
-  scm_dynwind_end();
-
-  default_always_promote_attributes = promote;
-
-  return SCM_BOOL_T;
-}
-
 SCM_DEFINE (print_color_map, "%print-color-map", 0, 1, 0,
             (SCM scm_map), "Set or view current print color map.")
 {
@@ -858,8 +806,7 @@ init_module_lepton_core_rc (void *unused)
   #include "g_rc.x"
 
   /* Add them to the module's public definitions. */
-  scm_c_export (s_always_promote_attributes,
-                s_component_library,
+  scm_c_export (s_component_library,
                 s_component_library_command,
                 s_component_library_funcs,
                 s_print_color_map,

--- a/liblepton/src/g_rc.c
+++ b/liblepton/src/g_rc.c
@@ -744,22 +744,6 @@ SCM_DEFINE (reset_component_library, "%reset-component-library", 0, 0, 0,
   return SCM_BOOL_T;
 }
 
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
-SCM_DEFINE (keep_invisible, "%keep-invisible", 0, 1, 0,
-            (SCM s_mode), "Controls or sets if invisible promoted attributes are not deleted.")
-{
-  if (scm_is_eq (s_mode, SCM_UNDEFINED)) {
-    return scm_from_bool (default_keep_invisible);
-  }
-
-  default_keep_invisible = scm_is_true (s_mode);
-  return s_mode;
-}
-
 /*! \todo Finish function description!!!
  *  \brief
  *  \par Function Description
@@ -894,7 +878,6 @@ init_module_lepton_core_rc (void *unused)
                 s_component_library,
                 s_component_library_command,
                 s_component_library_funcs,
-                s_keep_invisible,
                 s_make_backup_files,
                 s_print_color_map,
                 s_reset_component_library,

--- a/liblepton/src/g_rc.c
+++ b/liblepton/src/g_rc.c
@@ -749,22 +749,6 @@ SCM_DEFINE (reset_component_library, "%reset-component-library", 0, 0, 0,
  *  \par Function Description
  *
  */
-SCM_DEFINE (attribute_promotion, "%attribute-promotion", 0, 1, 0,
-            (SCM s_mode), "Set attribute promotion behaviour or return its state.")
-{
-  if (scm_is_eq (s_mode, SCM_UNDEFINED)) {
-    return scm_from_bool (default_attribute_promotion);
-  }
-
-  default_attribute_promotion = scm_is_true (s_mode);
-  return s_mode;
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
 SCM_DEFINE (promote_invisible, "%promote-invisible", 0, 1, 0,
             (SCM s_mode), "Set attribute promotion behaviour for invisible attributes or return its state.")
 {
@@ -923,7 +907,6 @@ init_module_lepton_core_rc (void *unused)
 
   /* Add them to the module's public definitions. */
   scm_c_export (s_always_promote_attributes,
-                s_attribute_promotion,
                 s_component_library,
                 s_component_library_command,
                 s_component_library_funcs,

--- a/liblepton/src/g_rc.c
+++ b/liblepton/src/g_rc.c
@@ -749,22 +749,6 @@ SCM_DEFINE (reset_component_library, "%reset-component-library", 0, 0, 0,
  *  \par Function Description
  *
  */
-SCM_DEFINE (promote_invisible, "%promote-invisible", 0, 1, 0,
-            (SCM s_mode), "Set attribute promotion behaviour for invisible attributes or return its state.")
-{
-  if (scm_is_eq (s_mode, SCM_UNDEFINED)) {
-    return scm_from_bool (default_promote_invisible);
-  }
-
-  default_promote_invisible = scm_is_true (s_mode);
-  return s_mode;
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
 SCM_DEFINE (keep_invisible, "%keep-invisible", 0, 1, 0,
             (SCM s_mode), "Controls or sets if invisible promoted attributes are not deleted.")
 {
@@ -913,7 +897,6 @@ init_module_lepton_core_rc (void *unused)
                 s_keep_invisible,
                 s_make_backup_files,
                 s_print_color_map,
-                s_promote_invisible,
                 s_reset_component_library,
                 s_scheme_directory,
                 NULL);

--- a/liblepton/src/i_vars.c
+++ b/liblepton/src/i_vars.c
@@ -93,8 +93,8 @@ void i_vars_libgeda_set(TOPLEVEL *toplevel)
   cfg_read_bool ("schematic.attrib", "promote-invisible",
                  default_promote_invisible, &toplevel->promote_invisible);
 
-
-  toplevel->keep_invisible = default_keep_invisible;
+  cfg_read_bool ("schematic.attrib", "keep-invisible",
+                 default_keep_invisible, &toplevel->keep_invisible);
 
   toplevel->make_backup_files = default_make_backup_files;
 

--- a/liblepton/src/i_vars.c
+++ b/liblepton/src/i_vars.c
@@ -40,6 +40,43 @@ int   default_make_backup_files = TRUE;
 
 
 
+/* \brief Read a boolean configuration key.
+ *
+ * \par Function Description
+ * On success, set \a result to the value of the
+ * configuration key, otherwise set it to \a defval.
+ *
+ * \todo  Refactoring: this function was copied as is from schematic/src/i_vars.c.
+ *
+ * \param [in]       group   Configuration group name
+ * \param [in]       key     Configuration key name
+ * \param [in]       defval  Default value
+ * \param [in, out]  result  Result
+ *
+ * \return  TRUE if a specified config parameter was successfully read
+ */
+static gboolean
+cfg_read_bool (const gchar* group,
+               const gchar* key,
+               gboolean     defval,
+               gboolean*    result)
+{
+  gchar*     cwd = g_get_current_dir();
+  EdaConfig* cfg = eda_config_get_context_for_path (cwd);
+  g_free (cwd);
+
+  GError*  err = NULL;
+  gboolean val = eda_config_get_boolean (cfg, group, key, &err);
+
+  gboolean success = err == NULL;
+  g_clear_error (&err);
+
+  *result = success ? val : defval;
+  return success;
+}
+
+
+
 /*! \brief Initialize variables in TOPLEVEL object
  *  \par Function Description
  *  This function will initialize variables to default values.
@@ -50,7 +87,9 @@ int   default_make_backup_files = TRUE;
 void i_vars_libgeda_set(TOPLEVEL *toplevel)
 {
 
-  toplevel->attribute_promotion = default_attribute_promotion;
+  cfg_read_bool ("schematic.attrib", "promote",
+                 default_attribute_promotion, &toplevel->attribute_promotion);
+
   toplevel->promote_invisible = default_promote_invisible;
   toplevel->keep_invisible = default_keep_invisible;
 

--- a/liblepton/src/i_vars.c
+++ b/liblepton/src/i_vars.c
@@ -90,7 +90,10 @@ void i_vars_libgeda_set(TOPLEVEL *toplevel)
   cfg_read_bool ("schematic.attrib", "promote",
                  default_attribute_promotion, &toplevel->attribute_promotion);
 
-  toplevel->promote_invisible = default_promote_invisible;
+  cfg_read_bool ("schematic.attrib", "promote-invisible",
+                 default_promote_invisible, &toplevel->promote_invisible);
+
+
   toplevel->keep_invisible = default_keep_invisible;
 
   toplevel->make_backup_files = default_make_backup_files;

--- a/liblepton/src/i_vars.c
+++ b/liblepton/src/i_vars.c
@@ -96,7 +96,8 @@ void i_vars_libgeda_set(TOPLEVEL *toplevel)
   cfg_read_bool ("schematic.attrib", "keep-invisible",
                  default_keep_invisible, &toplevel->keep_invisible);
 
-  toplevel->make_backup_files = default_make_backup_files;
+  cfg_read_bool ("schematic.backup", "create-files",
+                 default_make_backup_files, &toplevel->make_backup_files);
 
   /* copy the always_promote_attributes list from the default */
   if (toplevel->always_promote_attributes) {


### PR DESCRIPTION
- `attribute-promotion` => `library::attribute-promotion` (`bool`, `true`)
- `promote-invisible` => `library::promote-invisible` (`bool`, `false`)
- `keep-invisible` => `library::keep-invisible` (`bool`, `true`)
- `make-backup-files` => `schematic::make-backup-files` (`bool`, `true`)
- `always-promote-attributes` => `library::always-promote-attributes` (string list,
`footprint;device;value;model-name`)
- to make it work, `config-load!()` guile function has been modified to
accept a new optional boolean parameter: `force-load` (false by default).
So, a configuraion is not **re**loaded by default. Otherwise, any call
to `config-load!` made after the deprecated options are set will erase them
(a couple of refreshing days with debugger revealed that :)).