### PR TITLE
Deprecate the default-titleblock RC option in lepton-schematic

### DIFF
--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -44,6 +44,7 @@ scroll-wheel=classic
 grid-mode=mesh
 dots-grid-mode=variable
 net-selection-mode=enabled_net
+default-titleblock=title-B.sym
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -44,6 +44,7 @@ scroll-wheel=classic
 grid-mode=mesh
 dots-grid-mode=variable
 net-selection-mode=enabled_net
+default-titleblock=title-B.sym
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/scheme/geda-deprecated-config.scm
+++ b/liblepton/scheme/geda-deprecated-config.scm
@@ -30,22 +30,20 @@
 ;; Utility functions and macros
 ;; ===================================================================
 
+
+( use-modules ( lepton legacy-config ) )
+
+
 ;; Returns an RC function closure to replace the legacy configuration
 ;; function OLD-ID.  The returned closure takes an arbitrary number of
 ;; arguments, and does nothing other than print a deprecation message
 ;; the first time it is called.
 (define (rc-dead-config old-id)
-  ;; FIXME more helpful error message with link to documentation.
-  (define (deprecation-warning)
-    (format (current-error-port)
-"
-WARNING: The RC file function '~A' is deprecated
-and does nothing.
-RC configuration functions will be removed in an upcoming Lepton EDA
-release. Please use .conf configuration files instead:
-https://github.com/lepton-eda/lepton-eda/wiki/Configuration-Settings
 
-" old-id))
+  (define (deprecation-warning)
+    (format (current-error-port) (warning-option-obsolete old-id))
+  )
+
   (let ((warned? #f))
     (lambda args
       (or warned? (begin (deprecation-warning) (set! warned? #t))))))
@@ -67,24 +65,11 @@ https://github.com/lepton-eda/lepton-eda/wiki/Configuration-Settings
 ;; VALUE-TRANSFORMER.  The first time the closure is called, it prints
 ;; a deprecation message.
 (define (rc-deprecated-config old-id group key value-transformer)
-  ;; FIXME more helpful error message with link to documentation.
+
   (define (deprecation-warning)
-    (format (current-error-port)
-"
-WARNING: The RC file function '~A' is deprecated.
-RC configuration functions will be removed in an upcoming Lepton EDA
-release. Please use .conf configuration files instead:
-https://github.com/lepton-eda/lepton-eda/wiki/Configuration-Settings
+    (format (current-error-port) (warning-option-deprecated old-id group key))
+  )
 
-Put the following lines into the ~A file (in current directory)
-or ~A (in user's configuration directory, typically
-$HOME/.config/lepton-eda/), replacing MYVALUE with the desired
-option's value:
-
-[~A]
-~A=MYVALUE
-
-" old-id "geda.conf" "geda-user.conf" group key))
   (let ((warned? #f))
     (lambda args
       (or warned?

--- a/liblepton/scheme/lepton/legacy-config.scm
+++ b/liblepton/scheme/lepton/legacy-config.scm
@@ -239,8 +239,8 @@ option's value:
 
 "
     old-name
-    "geda.conf"
-    "geda-user.conf"
+    ( basename ( config-filename (path-config-context (getcwd)) ) )
+    ( basename ( config-filename (user-config-context) ) )
     new-group
     new-key
   )

--- a/liblepton/scheme/lepton/legacy-config.scm
+++ b/liblepton/scheme/lepton/legacy-config.scm
@@ -12,6 +12,8 @@
   #:use-module  ( lepton legacy-config keylist )
 
   #:export      ( config-upgrade )
+  #:export      ( warning-option-deprecated )
+  #:export      ( warning-option-obsolete )
 )
 
 
@@ -216,5 +218,52 @@
 
 
 
-; vim: ft=scheme tabstop=2 softtabstop=2 shiftwidth=2 expandtab
+; public:
+;
+( define ( warning-option-deprecated old-name new-group new-key )
+  ; return:
+  ( format #f
+"
+WARNING: The RC file function '~A' is deprecated.
+RC configuration functions will be removed in an upcoming Lepton EDA
+release. Please use .conf configuration files instead:
+https://github.com/lepton-eda/lepton-eda/wiki/Configuration-Settings
+
+Put the following lines into the ~A file (in current directory)
+or ~A (in user's configuration directory, typically
+$HOME/.config/lepton-eda/), replacing MYVALUE with the desired
+option's value:
+
+[~A]
+~A=MYVALUE
+
+"
+    old-name
+    "geda.conf"
+    "geda-user.conf"
+    new-group
+    new-key
+  )
+
+) ; warning-option-deprecated()
+
+
+
+; public:
+;
+( define ( warning-option-obsolete old-name )
+  ; return:
+  ( format #f
+"
+WARNING: The RC file function '~A' is deprecated
+and does nothing.
+RC configuration functions will be removed in an upcoming Lepton EDA
+release. Please use .conf configuration files instead:
+https://github.com/lepton-eda/lepton-eda/wiki/Configuration-Settings
+
+"
+    old-name
+  )
+
+) ; warning-option-obsolete()
 


### PR DESCRIPTION
Replace it with the `schematic.gui::titleblock-symname` configuration
key (string, "title-B.sym" by default).

@vzh A few questions:
- I've renamed the option by analogy with the `bus-ripper-symname`,
but we can follow the general pattern and retain the old name. WDYT?
- Where does the `B` paper size used? Maybe we should change the
default value (`A3` or `A4`, for example. BTW, `iso_a4` is the default
value for the `paper` keys)?
- In the old code the titleblock symbol is placed at position `(40000 40000)`.
Why exactly these coordinates are used? Could it be placed, say, at `(0 0)`?