### PR TITLE
Fix Netlist->allegro error in lepton-schematic

### DIFF
--- a/schematic/scheme/schematic/netlist.scm
+++ b/schematic/scheme/schematic/netlist.scm
@@ -31,9 +31,8 @@
 ;;; pages, or get schematic files using `lepton-schematic' options
 ;;; (that is, file names on the command line).
 (define (%schematic)
-  ;; FIXME: Just now only 'geda mode is used.
-  (make-toplevel-schematic (map page-filename (active-pages))
-                           'geda))
+  (make-toplevel-schematic (map page-filename (active-pages)))
+)
 
 ;;; First load allegro backend code in order to use `allegro*'
 ;;; below.


### PR DESCRIPTION
`lepton-schematic` logs an error when the `Netlist->allegro`
menu item is clicked.

`make-toplevel-schematic()` function (which is an
alias for `file-name-list->schematic()`) no longer
accepts 2 arguments (since git rev. 23e8685).