### PR TITLE
Enable paper selection in the lepton-schematic's print dialog

### DIFF
--- a/schematic/src/x_print.c
+++ b/schematic/src/x_print.c
@@ -438,6 +438,10 @@ x_print (GschemToplevel *w_current)
   */
   gtk_print_operation_set_print_settings (print, settings);
 
+  /* enable the "paper size" and "orientation" combo boxes:
+  */
+  gtk_print_operation_set_embed_page_setup (print, TRUE);
+
 
   res = gtk_print_operation_run (print, GTK_PRINT_OPERATION_ACTION_PRINT_DIALOG,
                                  GTK_WINDOW (w_current->main_window), &err);


### PR DESCRIPTION
Enable the "Paper size" and "Orientation" combo boxes:

![disabled](https://user-images.githubusercontent.com/26083750/72669659-c1650900-3a45-11ea-8c0c-251a50a993cd.png)

=>

![enabled](https://user-images.githubusercontent.com/26083750/72669709-59fb8900-3a46-11ea-9f3e-49a49b429c59.png)
