### PR TITLE
Reduce number of arguments for some functions

### DIFF
--- a/liblepton/include/libgedaguile_priv.h
+++ b/liblepton/include/libgedaguile_priv.h
@@ -208,7 +208,7 @@ int edascm_is_object_type (SCM smob, int type);
 
 
 /*! \brief Flag an object's page as having been changed. */
-extern void o_page_changed (TOPLEVEL *t, OBJECT *o);
+extern void o_page_changed (OBJECT *o);
 
 /* ---------------------------------------- */
 

--- a/liblepton/include/liblepton/geda_object.h
+++ b/liblepton/include/liblepton/geda_object.h
@@ -176,7 +176,7 @@ o_get_line_options (OBJECT *object,
                     int *space);
 
 PAGE*
-o_get_page (TOPLEVEL *toplevel, OBJECT *object);
+o_get_page (OBJECT *object);
 
 OBJECT*
 o_get_parent (TOPLEVEL *toplevel, OBJECT *object);

--- a/liblepton/include/liblepton/prototype.h
+++ b/liblepton/include/liblepton/prototype.h
@@ -74,8 +74,8 @@ int o_attrib_is_inherited(const OBJECT *attrib);
 gboolean o_attrib_is_attrib (const OBJECT *attrib);
 
 /* o_embed.c */
-void o_embed(TOPLEVEL *toplevel, OBJECT *o_current);
-void o_unembed(TOPLEVEL *toplevel, OBJECT *o_current);
+void o_embed (OBJECT *o_current);
+void o_unembed (OBJECT *o_current);
 
 /* o_selection.c */
 SELECTION *o_selection_new( void );

--- a/liblepton/include/prototype_priv.h
+++ b/liblepton/include/prototype_priv.h
@@ -22,7 +22,7 @@ GList *o_read_attribs(TOPLEVEL *toplevel,
                       unsigned int fileformat_ver, GError **err);
 OBJECT *o_attrib_find_attrib_by_name (const GList *list, const char *name, int count);
 
-/* o_basic.c */
+/* geda_object.c */
 void o_bounds_invalidate(TOPLEVEL *toplevel, OBJECT *object);
 void o_emit_pre_change_notify(TOPLEVEL *toplevel, OBJECT *object);
 void o_emit_change_notify(TOPLEVEL *toplevel, OBJECT *object);

--- a/liblepton/src/geda_net_object.c
+++ b/liblepton/src/geda_net_object.c
@@ -628,7 +628,7 @@ static int o_net_consolidate_segments (TOPLEVEL *toplevel, OBJECT *object)
   g_return_val_if_fail ((object->type == OBJ_NET), 0);
 
   /* It's meaningless to do anything here if the object isn't in a page. */
-  page = o_get_page (toplevel, object);
+  page = o_get_page (object);
   g_return_val_if_fail ((page != NULL), 0);
 
   object_orient = geda_net_object_orientation (object);

--- a/liblepton/src/geda_object.c
+++ b/liblepton/src/geda_object.c
@@ -873,17 +873,16 @@ void o_set_color (TOPLEVEL *toplevel, OBJECT *object, int color)
  * not currently associated with a PAGE, returns NULL. If \a object is
  * part of a compound object, recurses upward.
  *
- * \param [in] toplevel  The TOPLEVEL structure.
  * \param [in] object    The OBJECT for which to retrieve the parent PAGE.
  * \return The PAGE which owns \a object or NULL.
  *
  * \sa s_page_append_object() s_page_append() s_page_remove()
  */
 PAGE *
-o_get_page (TOPLEVEL *toplevel, OBJECT *object)
+o_get_page (OBJECT *object)
 {
   if (object->parent != NULL) {
-    return o_get_page (toplevel, object->parent);
+    return o_get_page (object->parent);
   }
   return object->page;
 }
@@ -996,6 +995,11 @@ void
 o_emit_pre_change_notify (TOPLEVEL *toplevel, OBJECT *object)
 {
   GList *iter;
+
+  if (toplevel == NULL) {
+    return;
+  }
+
   for (iter = toplevel->change_notify_funcs;
        iter != NULL; iter = g_list_next (iter)) {
 
@@ -1022,6 +1026,11 @@ void
 o_emit_change_notify (TOPLEVEL *toplevel, OBJECT *object)
 {
   GList *iter;
+
+  if (toplevel == NULL) {
+    return;
+  }
+
   for (iter = toplevel->change_notify_funcs;
        iter != NULL; iter = g_list_next (iter)) {
 

--- a/liblepton/src/geda_picture_object.c
+++ b/liblepton/src/geda_picture_object.c
@@ -1234,7 +1234,6 @@ o_picture_set_from_buffer (TOPLEVEL *toplevel, OBJECT *object,
   GInputStream *stream;
   gchar *tmp;
 
-  g_return_val_if_fail (toplevel != NULL, FALSE);
   g_return_val_if_fail (object != NULL, FALSE);
   g_return_val_if_fail (object->picture != NULL, FALSE);
   g_return_val_if_fail (data != NULL, FALSE);

--- a/liblepton/src/o_embed.c
+++ b/liblepton/src/o_embed.c
@@ -32,16 +32,23 @@
 /*! \brief embed an object into a schematic
  *  \par Function Description
  *  This functions embeds an object \a o_current into a
- *  libgeda. Currently complex objects are just marked to
- *  be embedded later. Picture objects are embedded immediatly.
+ *  liblepton. Currently complex objects are just marked to
+ *  be embedded later. Picture objects are embedded immediately.
  *
- *  \param toplevel  The TOPLEVEL object
  *  \param o_current The OBJECT to embed
  */
-void o_embed(TOPLEVEL *toplevel, OBJECT *o_current)
+void
+o_embed (OBJECT *o_current)
 {
-  PAGE *page = o_get_page (toplevel, o_current);
   int page_modified = 0;
+  PAGE *page = NULL;
+  TOPLEVEL *toplevel = NULL;
+
+  page = o_get_page (o_current);
+
+  if (page != NULL) {
+    toplevel = page->toplevel;
+  }
 
   /* check o_current is a complex and is not already embedded */
   if (o_current->type == OBJ_COMPLEX &&
@@ -73,17 +80,24 @@ void o_embed(TOPLEVEL *toplevel, OBJECT *o_current)
 /*! \brief unembed an object from a schematic
  *  \par Function Description
  *  This functions unembeds an object \a o_current from a
- *  libgeda structure. Complex objects are just marked to
- *  be not embedded. Picture objects are unembeded immediatly.
+ *  liblepton structure. Complex objects are just marked to
+ *  be not embedded. Picture objects are unembedded immediately.
  *
- *  \param toplevel  The TOPLEVEL object
  *  \param o_current The OBJECT to unembed
  */
-void o_unembed(TOPLEVEL *toplevel, OBJECT *o_current)
+void
+o_unembed (OBJECT *o_current)
 {
   const CLibSymbol *sym;
-  PAGE *page = o_get_page (toplevel, o_current);
   int page_modified = 0;
+  PAGE *page = NULL;
+  TOPLEVEL *toplevel = NULL;
+
+  page = o_get_page (o_current);
+
+  if (page != NULL) {
+    toplevel = page->toplevel;
+  }
 
   /* check o_current is an embedded complex */
   if (o_current->type == OBJ_COMPLEX &&

--- a/liblepton/src/scheme_attrib.c
+++ b/liblepton/src/scheme_attrib.c
@@ -198,8 +198,8 @@ SCM_DEFINE (attach_attrib_x, "%attach-attrib!", 2, 0, 0,
 
   /* Check that both are in the same page and/or complex object */
   if ((obj->parent != attrib->parent)
-      || (o_get_page (toplevel, obj) != o_get_page (toplevel, attrib))
-      || ((obj->parent == NULL) && (o_get_page (toplevel, obj) == NULL))) {
+      || (o_get_page (obj) != o_get_page (attrib))
+      || ((obj->parent == NULL) && (o_get_page (obj) == NULL))) {
     scm_error (edascm_object_state_sym, s_attach_attrib_x,
                _("Objects ~A and ~A are not part of the same page and/or complex object"),
                scm_list_2 (obj_s, attrib_s), SCM_EOL);

--- a/liblepton/src/scheme_attrib.c
+++ b/liblepton/src/scheme_attrib.c
@@ -222,7 +222,7 @@ SCM_DEFINE (attach_attrib_x, "%attach-attrib!", 2, 0, 0,
   o_attrib_attach (toplevel, attrib, obj, TRUE);
   o_emit_change_notify (toplevel, attrib);
 
-  o_page_changed (toplevel, obj);
+  o_page_changed (obj);
 
   scm_remember_upto_here_1 (attrib_s);
   return obj_s;
@@ -272,7 +272,7 @@ SCM_DEFINE (detach_attrib_x, "%detach-attrib!", 2, 0, 0,
   o_set_color (toplevel, attrib, DETACHED_ATTRIBUTE_COLOR);
   o_emit_change_notify (toplevel, attrib);
 
-  o_page_changed (toplevel, obj);
+  o_page_changed (obj);
 
   scm_remember_upto_here_1 (attrib_s);
   return obj_s;

--- a/liblepton/src/scheme_complex.c
+++ b/liblepton/src/scheme_complex.c
@@ -165,7 +165,7 @@ SCM_DEFINE (set_complex_x, "%set-complex!", 6, 0, 0,
 
   o_emit_change_notify (toplevel, obj);
 
-  o_page_changed (toplevel, obj);
+  o_page_changed (obj);
 
   return complex_s;
 }
@@ -297,7 +297,7 @@ SCM_DEFINE (complex_append_x, "%complex-append!", 2, 0, 0,
 
   o_emit_change_notify (toplevel, parent);
 
-  o_page_changed (toplevel, parent);
+  o_page_changed (parent);
 
   return complex_s;
 }
@@ -373,7 +373,7 @@ SCM_DEFINE (complex_remove_x, "%complex-remove!", 2, 0, 0,
 
   o_emit_change_notify (toplevel, parent);
 
-  o_page_changed (toplevel, parent);
+  o_page_changed (parent);
 
   /* Object cleanup now managed by Guile. */
   edascm_c_set_gc (obj_s, 1);

--- a/liblepton/src/scheme_complex.c
+++ b/liblepton/src/scheme_complex.c
@@ -263,7 +263,7 @@ SCM_DEFINE (complex_append_x, "%complex-append!", 2, 0, 0,
   OBJECT *parent = edascm_to_object (complex_s);
   OBJECT *child = edascm_to_object (obj_s);
 
-  PAGE* page = o_get_page (toplevel, child);
+  PAGE* page = o_get_page (child);
   /* Check that object is not already attached to a page or a
      different complex. */
   if ((page != NULL)
@@ -289,7 +289,7 @@ SCM_DEFINE (complex_append_x, "%complex-append!", 2, 0, 0,
 
   parent->w_bounds_valid_for = NULL;
 
-  PAGE* parent_page = o_get_page (toplevel, parent);
+  PAGE* parent_page = o_get_page (parent);
   /* We may need to update connections */
   if (parent_page != NULL) {
     s_conn_update_object (parent_page, child);
@@ -327,7 +327,7 @@ SCM_DEFINE (complex_remove_x, "%complex-remove!", 2, 0, 0,
   TOPLEVEL *toplevel = edascm_c_current_toplevel ();
   OBJECT *parent = edascm_to_object (complex_s);
   OBJECT *child = edascm_to_object (obj_s);
-  PAGE *child_page = o_get_page (toplevel, child);
+  PAGE *child_page = o_get_page (child);
 
   /* Check that object is not attached to a different complex. */
   if ((child->parent != NULL) && (child->parent != parent)) {

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -76,7 +76,7 @@ SCM_SYMBOL (closepath_sym , "closepath");
 
 void o_page_changed (TOPLEVEL *t, OBJECT *o)
 {
-  PAGE *p = o_get_page (t, o);
+  PAGE *p = o_get_page (o);
   if (p != NULL) p->CHANGED = TRUE;
 }
 
@@ -863,13 +863,13 @@ SCM_DEFINE (set_object_embedded_x, "%set-object-embedded!", 2, 0, 0,
 
     if (embed && !embedded)
     {
-      o_embed (toplevel, obj);
+      o_embed (obj);
       o_page_changed (toplevel, obj);
     }
     else
     if (!embed && embedded)
     {
-      o_unembed (toplevel, obj);
+      o_unembed (obj);
       o_page_changed (toplevel, obj);
     }
   }
@@ -979,7 +979,7 @@ SCM_DEFINE (set_line_x, "%set-line!", 6, 0, 0,
   o_set_color (toplevel, obj, scm_to_int (color_s));
 
   /* We may need to update connectivity. */
-  PAGE *page = o_get_page (toplevel, obj);
+  PAGE *page = o_get_page (obj);
   if (page != NULL) {
     s_conn_update_object (page, obj);
   }
@@ -1739,9 +1739,8 @@ SCM_DEFINE (object_connections, "%object-connections", 1, 0, 0,
   SCM_ASSERT (edascm_is_object (obj_s), obj_s,
               SCM_ARG1, s_object_connections);
 
-  TOPLEVEL *toplevel = edascm_c_current_toplevel ();
   OBJECT *obj = edascm_to_object (obj_s);
-  if (o_get_page (toplevel, obj) == NULL) {
+  if (o_get_page (obj) == NULL) {
     scm_error (edascm_object_state_sym,
                s_object_connections,
                _("Object ~A is not included in a page."),

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -74,7 +74,7 @@ SCM_SYMBOL (lineto_sym , "lineto");
 SCM_SYMBOL (curveto_sym , "curveto");
 SCM_SYMBOL (closepath_sym , "closepath");
 
-void o_page_changed (TOPLEVEL *t, OBJECT *o)
+void o_page_changed (OBJECT *o)
 {
   PAGE *p = o_get_page (o);
   if (p != NULL) p->CHANGED = TRUE;
@@ -500,7 +500,7 @@ SCM_DEFINE (set_object_stroke_x, "%set-object-stroke!", 4, 2, 0,
                       width,
                       length,
                       space);
-  o_page_changed (toplevel, obj);
+  o_page_changed (obj);
 
   return obj_s;
 }
@@ -663,7 +663,7 @@ SCM_DEFINE (set_object_fill_x, "%set-object-fill!", 2, 5, 0,
                       angle1,
                       space2,
                       angle2);
-  o_page_changed (toplevel, obj);
+  o_page_changed (obj);
 
   return obj_s;
 }
@@ -715,7 +715,7 @@ SCM_DEFINE (set_object_color_x, "%set-object-color!", 2, 0, 0,
   OBJECT *obj = edascm_to_object (obj_s);
   o_set_color (toplevel, obj, scm_to_int (color_s));
 
-  o_page_changed (toplevel, obj);
+  o_page_changed (obj);
 
   return obj_s;
 }
@@ -780,8 +780,7 @@ SCM_DEFINE (set_object_selectable_x, "%set-object-selectable!", 2, 0, 0,
 
     /* mark the page as changed:
     */
-    TOPLEVEL* toplevel = edascm_c_current_toplevel();
-    o_page_changed (toplevel, obj);
+    o_page_changed (obj);
   }
 
   return obj_s;
@@ -857,20 +856,19 @@ SCM_DEFINE (set_object_embedded_x, "%set-object-embedded!", 2, 0, 0,
 
   if (embeddable)
   {
-    TOPLEVEL* toplevel = edascm_c_current_toplevel();
     gboolean  embedded = component ? o_complex_is_embedded (obj)
                                    : o_picture_is_embedded (obj);
 
     if (embed && !embedded)
     {
       o_embed (obj);
-      o_page_changed (toplevel, obj);
+      o_page_changed (obj);
     }
     else
     if (!embed && embedded)
     {
       o_unembed (obj);
-      o_page_changed (toplevel, obj);
+      o_page_changed (obj);
     }
   }
 
@@ -984,7 +982,7 @@ SCM_DEFINE (set_line_x, "%set-line!", 6, 0, 0,
     s_conn_update_object (page, obj);
   }
 
-  o_page_changed (toplevel, obj);
+  o_page_changed (obj);
 
   return line_s;
 }
@@ -1238,7 +1236,7 @@ SCM_DEFINE (set_box_x, "%set-box!", 6, 0, 0,
                               scm_to_int (x2_s), scm_to_int (y2_s));
   o_set_color (toplevel, obj, scm_to_int (color_s));
 
-  o_page_changed (toplevel, obj);
+  o_page_changed (obj);
 
   return box_s;
 }
@@ -1336,7 +1334,7 @@ SCM_DEFINE (set_circle_x, "%set-circle!", 5, 0, 0,
   geda_circle_object_modify (toplevel, obj, scm_to_int(r_s), 0, CIRCLE_RADIUS);
   o_set_color (toplevel, obj, scm_to_int (color_s));
 
-  o_page_changed (toplevel, obj);
+  o_page_changed (obj);
 
   return circle_s;
 }
@@ -1442,7 +1440,7 @@ SCM_DEFINE (set_arc_x, "%set-arc!", 7, 0, 0,
   geda_arc_object_modify (toplevel, obj, scm_to_int(end_angle_s), 0, ARC_SWEEP_ANGLE);
   o_set_color (toplevel, obj, scm_to_int (color_s));
 
-  o_page_changed (toplevel, obj);
+  o_page_changed (obj);
 
   return arc_s;
 }
@@ -1637,7 +1635,7 @@ SCM_DEFINE (set_text_x, "%set-text!", 10, 0, 0,
   /* Color */
   o_set_color (toplevel, obj, scm_to_int (color_s));
 
-  o_page_changed (toplevel, obj);
+  o_page_changed (obj);
 
   return text_s;
 }
@@ -1950,7 +1948,7 @@ SCM_DEFINE (path_remove_x, "%path-remove!", 2, 0, 0,
   }
 
   o_emit_change_notify (toplevel, obj);
-  o_page_changed (toplevel, obj);
+  o_page_changed (obj);
 
   return obj_s;
 }
@@ -2065,7 +2063,7 @@ SCM_DEFINE (path_insert_x, "%path-insert", 3, 6, 0,
   path->sections[idx] = section;
 
   o_emit_change_notify (toplevel, obj);
-  o_page_changed (toplevel, obj);
+  o_page_changed (obj);
 
   return obj_s;
 }
@@ -2262,7 +2260,7 @@ SCM_DEFINE (set_picture_data_vector_x, "%set-picture-data/vector!",
                     scm_list_1 (scm_from_utf8_string (error->message)));
   }
 
-  o_page_changed (toplevel, obj);
+  o_page_changed (obj);
   scm_dynwind_end ();
   return obj_s;
 }
@@ -2301,7 +2299,7 @@ SCM_DEFINE (translate_object_x, "%translate-object!", 3, 0, 0,
   o_emit_pre_change_notify (toplevel, obj);
   geda_object_translate (obj, dx, dy);
   o_emit_change_notify (toplevel, obj);
-  o_page_changed (toplevel, obj);
+  o_page_changed (obj);
 
   return obj_s;
 }
@@ -2352,7 +2350,7 @@ SCM_DEFINE (rotate_object_x, "%rotate-object!", 4, 0, 0,
   o_emit_pre_change_notify (toplevel, obj);
   geda_object_rotate (toplevel, x, y, angle, obj);
   o_emit_change_notify (toplevel, obj);
-  o_page_changed (toplevel, obj);
+  o_page_changed (obj);
 
   return obj_s;
 }
@@ -2385,7 +2383,7 @@ SCM_DEFINE (mirror_object_x, "%mirror-object!", 2, 0, 0,
   o_emit_pre_change_notify (toplevel, obj);
   geda_object_mirror (toplevel, x, 0, obj);
   o_emit_change_notify (toplevel, obj);
-  o_page_changed (toplevel, obj);
+  o_page_changed (obj);
 
   return obj_s;
 }

--- a/liblepton/src/scheme_page.c
+++ b/liblepton/src/scheme_page.c
@@ -251,7 +251,7 @@ SCM_DEFINE (page_append_x, "%page-append!", 2, 0, 0,
   /* Object cleanup now managed by C code. */
   edascm_c_set_gc (obj_s, 0);
   o_emit_pre_change_notify (toplevel, obj);
-  s_page_append (edascm_c_current_toplevel (), page, obj);
+  s_page_append (toplevel, page, obj);
   o_emit_change_notify (toplevel, obj);
   page->CHANGED = 1; /* Ugh. */
 

--- a/liblepton/src/scheme_page.c
+++ b/liblepton/src/scheme_page.c
@@ -204,8 +204,7 @@ SCM_DEFINE (object_page, "%object-page", 1, 0, 0,
   SCM_ASSERT (EDASCM_OBJECTP (obj_s), obj_s,
               SCM_ARG1, s_object_page);
 
-  PAGE *page = o_get_page (edascm_c_current_toplevel (),
-                           edascm_to_object (obj_s));
+  PAGE *page = o_get_page (edascm_to_object (obj_s));
 
   if (page != NULL) {
     return edascm_from_page (page);
@@ -239,7 +238,7 @@ SCM_DEFINE (page_append_x, "%page-append!", 2, 0, 0,
   TOPLEVEL *toplevel = edascm_c_current_toplevel ();
 
   /* Check that the object isn't already attached to something. */
-  PAGE *curr_page = o_get_page (toplevel, obj);
+  PAGE *curr_page = o_get_page (obj);
   if (((curr_page != NULL) && (curr_page != page))
       || (obj->parent != NULL)) {
     scm_error (edascm_object_state_sym, s_page_append_x,
@@ -284,7 +283,7 @@ SCM_DEFINE (page_remove_x, "%page-remove!", 2, 0, 0,
   TOPLEVEL *toplevel = edascm_c_current_toplevel ();
 
   /* Check that the object is not attached to something else. */
-  PAGE *curr_page = o_get_page (toplevel, obj);
+  PAGE *curr_page = o_get_page (obj);
   if ((curr_page != NULL && curr_page != page)
       || (obj->parent != NULL)) {
     scm_error (edascm_object_state_sym, s_page_remove_x,

--- a/schematic/src/g_attrib.c
+++ b/schematic/src/g_attrib.c
@@ -84,7 +84,7 @@ SCM_DEFINE (add_attrib_x, "%add-attrib!", 5, 0, 0,
   OBJECT *obj = NULL;
   if (edascm_is_object (target_s)) {
     obj = edascm_to_object (target_s);
-    if (o_get_page (toplevel, obj) != toplevel->page_current) {
+    if (o_get_page (obj) != toplevel->page_current) {
       scm_error (object_state_sym,
                  s_add_attrib_x,
                  _("Object ~A is not included in the current gschem page."),

--- a/schematic/src/g_select.c
+++ b/schematic/src/g_select.c
@@ -71,7 +71,7 @@ SCM_DEFINE (select_object_x, "%select-object!", 1, 0, 0,
 
   TOPLEVEL *toplevel = edascm_c_current_toplevel ();
   OBJECT *obj = edascm_to_object (obj_s);
-  PAGE *page = o_get_page (toplevel, obj);
+  PAGE *page = o_get_page (obj);
   if ((page == NULL) || (obj->parent != NULL)) {
     scm_error (object_state_sym,
                s_select_object_x,
@@ -108,7 +108,7 @@ SCM_DEFINE (deselect_object_x, "%deselect-object!", 1, 0, 0,
 
   TOPLEVEL *toplevel = edascm_c_current_toplevel ();
   OBJECT *obj = edascm_to_object (obj_s);
-  PAGE *page = o_get_page (toplevel, obj);
+  PAGE *page = o_get_page (obj);
   if ((page == NULL) || (obj->parent != NULL)) {
     scm_error (object_state_sym,
                s_deselect_object_x,
@@ -142,9 +142,8 @@ SCM_DEFINE (object_selected_p, "%object-selected?", 1, 0, 0,
   SCM_ASSERT (edascm_is_object (obj_s), obj_s,
               SCM_ARG1, s_object_selected_p);
 
-  TOPLEVEL *toplevel = edascm_c_current_toplevel ();
   OBJECT *obj = edascm_to_object (obj_s);
-  PAGE *page = o_get_page (toplevel, obj);
+  PAGE *page = o_get_page (obj);
   if ((page == NULL) || (obj->parent != NULL)) {
     scm_error (object_state_sym,
                s_object_selected_p,

--- a/schematic/src/i_callbacks.c
+++ b/schematic/src/i_callbacks.c
@@ -841,7 +841,7 @@ DEFINE_I_CALLBACK(edit_embed)
       g_assert (o_current != NULL);
       if ( (o_current->type == OBJ_COMPLEX) ||
 	   (o_current->type == OBJ_PICTURE) ) {
-        o_embed (toplevel, o_current);
+        o_embed (o_current);
       }
       s_current = g_list_next(s_current);
     }
@@ -883,7 +883,7 @@ DEFINE_I_CALLBACK(edit_unembed)
       g_assert (o_current != NULL);
       if ( (o_current->type == OBJ_COMPLEX) ||
            (o_current->type == OBJ_PICTURE) ) {
-        o_unembed (toplevel, o_current);
+        o_unembed (o_current);
       }
       s_current = g_list_next(s_current);
     }

--- a/schematic/src/o_misc.c
+++ b/schematic/src/o_misc.c
@@ -461,7 +461,7 @@ o_update_component (GschemToplevel *w_current, OBJECT *o_current)
   g_return_val_if_fail (o_current->type == OBJ_COMPLEX, NULL);
   g_return_val_if_fail (o_current->complex_basename != NULL, NULL);
 
-  page = o_get_page (toplevel, o_current);
+  page = o_get_page (o_current);
 
   /* Force symbol data to be reloaded from source */
   clib = s_clib_get_symbol_by_name (o_current->complex_basename);
@@ -485,7 +485,7 @@ o_update_component (GschemToplevel *w_current, OBJECT *o_current)
                          clib, o_current->complex_basename,
                          1);
   if (o_complex_is_embedded (o_current)) {
-    o_embed (toplevel, o_new);
+    o_embed (o_new);
   }
 
   new_attribs = o_complex_promote_attribs (toplevel, o_new);


### PR DESCRIPTION
Get rid of the `TOPLEVEL` argument.