### PR TITLE
Small improvements and fixes in lepton-schematic GUI

### DIFF
--- a/schematic/src/color_edit_widget.c
+++ b/schematic/src/color_edit_widget.c
@@ -1,5 +1,5 @@
 /* Lepton EDA Schematic Capture
- * Copyright (C) 2018 dmn <graahnul.grom@gmail.com>
+ * Copyright (C) 2018-2020 dmn <graahnul.grom@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -220,6 +220,18 @@ color_edit_widget_create (ColorEditWidget* widget)
 
   /* separator: */
   gtk_box_pack_start (GTK_BOX (vbox), gtk_hseparator_new(), FALSE, FALSE, 5);
+
+
+  /* informational label: */
+  const gchar* msg =
+    _("Save your color scheme to a file by clicking on the \"Save As...\"\n"
+      "button. It can be loaded on startup with the following\n"
+      "expression in the gschemrc configuration file:\n"
+      "( primitive-load \"/path/to/saved-color-scheme-file\" )");
+
+  GtkWidget* label = gtk_label_new (msg);
+  gtk_label_set_selectable (GTK_LABEL (label), TRUE);
+  gtk_box_pack_start (GTK_BOX (vbox), label, FALSE, FALSE, 0);
 
 
   g_signal_connect (G_OBJECT (widget->color_cb_),

--- a/schematic/src/color_edit_widget.c
+++ b/schematic/src/color_edit_widget.c
@@ -187,7 +187,7 @@ color_edit_widget_create (ColorEditWidget* widget)
   gtk_container_add (GTK_CONTAINER (widget), vbox);
 
   GtkWidget* hbox = gtk_hbox_new (FALSE, 0);
-  gtk_box_pack_start (GTK_BOX (vbox), hbox, TRUE, TRUE, 0);
+  gtk_box_pack_start (GTK_BOX (vbox), hbox, FALSE, TRUE, 0);
 
   /* color selection combo box: */
   widget->color_cb_ = x_colorcb_new();

--- a/schematic/src/font_select_widget.c
+++ b/schematic/src/font_select_widget.c
@@ -232,6 +232,15 @@ font_select_widget_create (FontSelectWidget* widget)
   /* separator */
   gtk_box_pack_start (GTK_BOX (vbox), gtk_hseparator_new(), FALSE, FALSE, 5);
 
+  /* informational label: */
+  const gchar* msg =
+    _("After you're done choosing the font, it's recommended\n"
+      "to reopen schematics or restart the application.");
+
+  GtkWidget* label = gtk_label_new (msg);
+  gtk_label_set_selectable (GTK_LABEL (label), TRUE);
+  gtk_box_pack_start (GTK_BOX (vbox), label, FALSE, FALSE, 0);
+
   g_signal_connect (G_OBJECT (btn_apply),
                     "clicked",
                     G_CALLBACK (&on_btn_apply),

--- a/schematic/src/font_select_widget.c
+++ b/schematic/src/font_select_widget.c
@@ -1,6 +1,6 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 2018 dmn <graahnul.grom@gmail.com>
- * Copyright (C) 2018-2019 Lepton EDA Contributors
+ * Copyright (C) 2018-2020 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/schematic/src/i_basic.c
+++ b/schematic/src/i_basic.c
@@ -415,6 +415,8 @@ void i_update_menus (GschemToplevel* w_current)
 
   x_menus_sensitivity (mmenu, "&hierarchy-documentation", comp_selected);
 
+  x_menus_sensitivity (mmenu, "&page-revert", !x_window_untitled_page (page));
+
 
   GtkWidget* pmenu = w_current->popup_menu;
 

--- a/schematic/src/i_basic.c
+++ b/schematic/src/i_basic.c
@@ -447,6 +447,7 @@ void i_update_menus (GschemToplevel* w_current)
   x_menus_sensitivity (mmenu, "&edit-embed", embeddable);
   x_menus_sensitivity (mmenu, "&edit-unembed", embeddable);
   x_menus_sensitivity (mmenu, "&edit-update", comp_selected);
+  x_menus_sensitivity (mmenu, "&edit-deselect", selected);
 
   x_menus_sensitivity (mmenu, "&hierarchy-down-schematic", parent);
   x_menus_sensitivity (mmenu, "&hierarchy-down-symbol", comp_selected);

--- a/schematic/src/i_basic.c
+++ b/schematic/src/i_basic.c
@@ -195,6 +195,20 @@ void i_action_update_status (GschemToplevel *w_current, gboolean inside_action)
 }
 
 
+
+/*! \brief Update sensitivity of menu items according to current event state.
+ *
+ *  \param [in] w_current  GschemToplevel structure
+ *  \param [in] newstate   The new state
+ */
+static void
+update_state_menu_items (GschemToplevel* w_current, enum x_states newstate)
+{
+  x_menus_sensitivity (w_current->menubar, "&edit-select", newstate != SELECT);
+}
+
+
+
 /*! \brief Set new state, then show state field
  *
  *  \par Function Description
@@ -234,6 +248,8 @@ void i_set_state(GschemToplevel *w_current, enum x_states newstate)
       case MIRRORMODE: mode="mirror-mode"; break;
       case ROTATEMODE: mode="rotate-mode"; break;
     }
+
+  update_state_menu_items (w_current, newstate);
 
   g_run_hook_action_mode (w_current, "%switch-action-mode-hook", mode);
 }
@@ -401,6 +417,8 @@ void i_update_menus (GschemToplevel* w_current)
   /* update Edit->Paste sensitivity in clipboard_usable_cb():
   */
   x_clipboard_query_usable (w_current, clipboard_usable_cb, w_current);
+
+  update_state_menu_items (w_current, w_current->event_state);
 
   gboolean selected      = o_select_selected (w_current);
   gboolean text_selected = selected && obj_selected (toplevel, OBJ_TEXT);

--- a/schematic/src/i_basic.c
+++ b/schematic/src/i_basic.c
@@ -357,6 +357,33 @@ obj_selected (TOPLEVEL* toplevel, int type)
 
 
 
+/*! \brief Return TRUE if a component with "source" attribute is selected.
+ *
+ *  \param [in] w_current  GschemToplevel structure
+ */
+static gboolean
+parent_comp_selected (TOPLEVEL* toplevel)
+{
+  gboolean result = FALSE;
+  OBJECT* obj = obj_selected (toplevel, OBJ_COMPLEX);
+
+  if (obj != NULL)
+  {
+    char* attr = o_attrib_search_attached_attribs_by_name (obj, "source", 0);
+    if (attr == NULL)
+    {
+      attr = o_attrib_search_inherited_attribs_by_name (obj, "source", 0);
+    }
+
+    result = attr != NULL;
+    g_free (attr);
+  }
+
+  return result;
+}
+
+
+
 /*! \brief Update menu items sensitivity for the main and popup menus.
  *
  *  \param [in] w_current GschemToplevel structure
@@ -380,7 +407,8 @@ void i_update_menus (GschemToplevel* w_current)
   gboolean comp_selected = selected && obj_selected (toplevel, OBJ_COMPLEX);
   gboolean pic_selected  = selected && obj_selected (toplevel, OBJ_PICTURE);
   gboolean embeddable    = comp_selected || pic_selected;
-  gboolean has_parent = s_hierarchy_find_up_page (toplevel->pages, page) != NULL;
+  gboolean has_parent    = s_hierarchy_find_up_page (toplevel->pages, page) != NULL;
+  gboolean parent        = comp_selected && parent_comp_selected (toplevel);
 
   GtkWidget* mmenu = w_current->menubar;
 
@@ -402,7 +430,7 @@ void i_update_menus (GschemToplevel* w_current)
   x_menus_sensitivity (mmenu, "&edit-unembed", embeddable);
   x_menus_sensitivity (mmenu, "&edit-update", comp_selected);
 
-  x_menus_sensitivity (mmenu, "&hierarchy-down-schematic", comp_selected);
+  x_menus_sensitivity (mmenu, "&hierarchy-down-schematic", parent);
   x_menus_sensitivity (mmenu, "&hierarchy-down-symbol", comp_selected);
   x_menus_sensitivity (mmenu, "&hierarchy-up", has_parent);
 
@@ -428,7 +456,7 @@ void i_update_menus (GschemToplevel* w_current)
   x_menus_sensitivity (pmenu, "&edit-text", text_selected);
   x_menus_sensitivity (pmenu, "&edit-object-properties", selected);
 
-  x_menus_sensitivity (pmenu, "&hierarchy-down-schematic", comp_selected);
+  x_menus_sensitivity (pmenu, "&hierarchy-down-schematic", parent);
   x_menus_sensitivity (pmenu, "&hierarchy-down-symbol", comp_selected);
   x_menus_sensitivity (pmenu, "&hierarchy-up", has_parent);
 

--- a/schematic/src/i_basic.c
+++ b/schematic/src/i_basic.c
@@ -327,15 +327,15 @@ static void clipboard_usable_cb (int usable, void *userdata)
 
 
 
-/*! \brief Return TRUE if at least one object of type \a type is selected.
+/*! \brief Return the first object of type \a type if it is selected.
  *
  *  \param toplevel  pointer to TOPLEVEL structure
  *  \param type      object type constant (OBJ_TEXT, OBJ_COMPLEX, etc.) (o_types.h)
  */
-static gboolean
+static OBJECT*
 obj_selected (TOPLEVEL* toplevel, int type)
 {
-  gboolean result = FALSE;
+  OBJECT* result = FALSE;
   SELECTION* selection = toplevel->page_current->selection_list;
 
   GList* gl = geda_list_get_glist (selection);
@@ -347,7 +347,7 @@ obj_selected (TOPLEVEL* toplevel, int type)
 #ifdef DEBUG
       printf (" >> obj_selected(): obj->type: [%c]\n", obj->type);
 #endif
-      result = TRUE;
+      result = obj;
       break;
     }
   }

--- a/schematic/src/i_callbacks.c
+++ b/schematic/src/i_callbacks.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2016 gEDA Contributors
- * Copyright (C) 2017-2019 Lepton EDA Contributors
+ * Copyright (C) 2017-2020 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1516,6 +1516,14 @@ DEFINE_I_CALLBACK(page_revert)
   g_return_if_fail (w_current != NULL);
 
   page_current = gschem_toplevel_get_toplevel (w_current)->page_current;
+
+  /* do not revert untitled pages:
+  */
+  if (x_window_untitled_page (page_current))
+  {
+    return;
+  }
+
   filename = g_strdup (s_page_get_filename (page_current));
 
   const gchar* msg =

--- a/schematic/src/i_callbacks.c
+++ b/schematic/src/i_callbacks.c
@@ -1525,7 +1525,8 @@ DEFINE_I_CALLBACK(page_revert)
       "\n"
       "Are you sure you want to revert this page?\n"
       "All unsaved changes in current schematic will be\n"
-      "discarded and page file will be reloaded from disk.");
+      "discarded and page file will be reloaded from disk.\n"
+      "This action will also reload all component libraries.");
 
   dialog = gtk_message_dialog_new_with_markup
     ((GtkWindow*) w_current->main_window,

--- a/schematic/src/x_tabs.c
+++ b/schematic/src/x_tabs.c
@@ -1592,7 +1592,7 @@ x_tabs_menu_create (TabInfo* nfo)
 
   GtkWidget* menu = gtk_menu_new();
   x_tabs_menu_create_item (tl, menu, "file-new", _("_New"), GTK_STOCK_NEW);
-  x_tabs_menu_create_item (tl, menu, "file-open", _("_Open"), GTK_STOCK_OPEN);
+  x_tabs_menu_create_item (tl, menu, "file-open", _("_Open..."), GTK_STOCK_OPEN);
   x_tabs_menu_create_item_separ (menu);
   x_tabs_menu_create_item (tl, menu, "file-save", _("_Save"), GTK_STOCK_SAVE);
   x_tabs_menu_create_item (tl, menu, "file-save-as", _("Save _As..."), GTK_STOCK_SAVE_AS);


### PR DESCRIPTION
- Add labels with informational messages to the color editor
and font selector dialog boxes
- Extend the revert dialog box message
- Do not revert "untitled" pages
- Correctly resize the color editor widget
- Set sensitivity of the following menu items:
  - `Page->Revert`
  - `Hierarchy->Down Schematic`
  - `Edit->Deselect`
  - `Edit->Select Mode`

![revert](https://user-images.githubusercontent.com/26083750/73482768-61f4ea80-43af-11ea-959f-50b94cb98b16.png)

![cdedit](https://user-images.githubusercontent.com/26083750/73482789-6b7e5280-43af-11ea-93b1-0fbcc910a4b3.png)

![fontsel](https://user-images.githubusercontent.com/26083750/73482802-72a56080-43af-11ea-923e-3c9722bffef6.png)
