### PR TITLE
Rename core modules

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -231,6 +231,9 @@ Notable changes in Lepton EDA 1.9.10 (upcoming)
 - The module `(gschem core util)` has been renamed to `(schematic
   core util)`.
 
+- The module `(gschem core window)` has been renamed to
+  `(schematic core window)`.
+
 - Grips can now be turned on and off at run-time.
   Use the new 'Options → Grips: On/Off' menu item or
   <kbd>O</kbd>-<kbd>I</kbd> keyboard shortcut.

--- a/NEWS.md
+++ b/NEWS.md
@@ -43,6 +43,24 @@ Notable changes in Lepton EDA 1.9.10 (upcoming)
   All the functions and variables available are still re-exported
   in the former one but its using is discouraged.
 
+- The module `(geda repl)` has been renamed to `(lepton repl)`.
+  All the functions and variables available are still re-exported
+  in the former one but its using is discouraged.
+
+- The following *core* (written in C) Scheme modules have been
+  renamed:
+  - `(geda core attrib)` => `(lepton core attrib)`
+  - `(geda core complex)` => `(lepton core complex)`
+  - `(geda core config)` => `(lepton core config)`
+  - `(geda core deprecated)` => `(lepton core deprecated)`
+  - `(geda core gettext)` => `(lepton core gettext)`
+  - `(geda core log)` => `(lepton core log)`
+  - `(geda core object)` => `(lepton core object)`
+  - `(geda core os)` => `(lepton core os)`
+  - `(geda core page)` => `(lepton core page)`
+  - `(geda core smob)` => `(lepton core smob)`
+  - `(geda core toplevel)` => `(lepton core toplevel)`
+
 - Apart from expanding environment variables, the function
   `expand-env-variables` from the `(lepton os)` module now replaces
   **~/** (user home directory prefix) in file names in order to
@@ -83,6 +101,8 @@ Notable changes in Lepton EDA 1.9.10 (upcoming)
   `(lepton page)` module.  All functions from the former have been
   moved to the latter.  The procedure `filename->page()` has been
   renamed to `file->page()`.
+
+- The unused Scheme module `(netlist repl)` has been removed.
 
 - Netlist backends can now set the desired netlist mode by defining
   a `request-netlist-mode` function, which should return either `'geda` or
@@ -212,6 +232,8 @@ Notable changes in Lepton EDA 1.9.10 (upcoming)
 - The module `(gschem window)` has been renamed to `(schematic
   window)`.  All the functions and variables available are still
   re-exported in the former one but its using is discouraged.
+
+- The module `(gschem repl)` has been renamed to `(schematic repl)`.
 
 - The module `(gschem core attrib)` has been renamed to
   `(schematic core attrib)`.

--- a/NEWS.md
+++ b/NEWS.md
@@ -216,6 +216,9 @@ Notable changes in Lepton EDA 1.9.10 (upcoming)
 - The module `(gschem core attrib)` has been renamed to
   `(schematic core attrib)`.
 
+- The module `(gschem core builtins)` has been renamed to
+  `(schematic core builtins)`.
+
 - Grips can now be turned on and off at run-time.
   Use the new 'Options → Grips: On/Off' menu item or
   <kbd>O</kbd>-<kbd>I</kbd> keyboard shortcut.

--- a/NEWS.md
+++ b/NEWS.md
@@ -228,6 +228,9 @@ Notable changes in Lepton EDA 1.9.10 (upcoming)
 - The module `(gschem core selection)` has been renamed to
   `(schematic core selection)`.
 
+- The module `(gschem core util)` has been renamed to `(schematic
+  core util)`.
+
 - Grips can now be turned on and off at run-time.
   Use the new 'Options → Grips: On/Off' menu item or
   <kbd>O</kbd>-<kbd>I</kbd> keyboard shortcut.

--- a/NEWS.md
+++ b/NEWS.md
@@ -222,6 +222,9 @@ Notable changes in Lepton EDA 1.9.10 (upcoming)
 - The module `(gschem core hook)` has been renamed to `(schematic
   core hook)`.
 
+- The module `(gschem core keymap)` has been renamed to
+  `(schematic core keymap)`.
+
 - Grips can now be turned on and off at run-time.
   Use the new 'Options → Grips: On/Off' menu item or
   <kbd>O</kbd>-<kbd>I</kbd> keyboard shortcut.

--- a/NEWS.md
+++ b/NEWS.md
@@ -213,6 +213,9 @@ Notable changes in Lepton EDA 1.9.10 (upcoming)
   window)`.  All the functions and variables available are still
   re-exported in the former one but its using is discouraged.
 
+- The module `(gschem core attrib)` has been renamed to
+  `(schematic core attrib)`.
+
 - Grips can now be turned on and off at run-time.
   Use the new 'Options → Grips: On/Off' menu item or
   <kbd>O</kbd>-<kbd>I</kbd> keyboard shortcut.

--- a/NEWS.md
+++ b/NEWS.md
@@ -20,32 +20,19 @@ Notable changes in Lepton EDA 1.9.10 (upcoming)
   among various build environments.
 
 ### Scheme API changes:
-- The module `(geda attrib)` has been renamed to `(lepton attrib)`.
-  All the functions and variables available are still re-exported
-  in the former one but its using is discouraged.
-
-- The module `(geda config)` has been renamed to `(lepton config)`.
-  All the functions and variables available are still re-exported
-  in the former one but its using is discouraged.
-
-- The module `(geda log)` has been renamed to `(lepton log)`.
-  All the functions and variables available are still re-exported
-  in the former one but its using is discouraged.
-
 - The module `(geda log-rotate)` has been renamed to `(lepton
   log-rotate)`.
 
-- The module `(geda object)` has been renamed to `(lepton object)`.
-  All the functions and variables available are still re-exported
-  in the former one but its using is discouraged.
-
-- The module `(geda os)` has been renamed to `(lepton os)`.
-  All the functions and variables available are still re-exported
-  in the former one but its using is discouraged.
-
-- The module `(geda repl)` has been renamed to `(lepton repl)`.
-  All the functions and variables available are still re-exported
-  in the former one but its using is discouraged.
+- Several `(geda *)` modules have been renamed to `(lepton *)`
+  ones.  All the functions and variables available are still
+  re-exported in the former ones but their using is discouraged.
+  The following renames have been made:
+  - `(geda attrib)` => `(lepton attrib)`
+  - `(geda config)` => `(lepton config)`
+  - `(geda log)` => `(lepton log)`
+  - `(geda object)` => `(lepton object)`
+  - `(geda os)` => `(lepton os)`
+  - `(geda repl)` => `(lepton repl)`
 
 - The following *core* (written in C) Scheme modules have been
   renamed:
@@ -190,71 +177,35 @@ Notable changes in Lepton EDA 1.9.10 (upcoming)
   command-line option `--cache` (`-c`) has been added.
 
 ### Changes in `lepton-schematic`:
-- The module `(gschem action)` has been renamed to `(schematic
-  action)`.  All the functions and variables available are still
-  re-exported in the former one but its using is discouraged.
+- Several `(gschem *)` modules have been renamed to `(schematic
+  *)` ones.  All the functions and variables available are still
+  re-exported in the former ones but their using is discouraged.
+  The following renames have been made:
+  - `(gschem action)` => `(schematic action)`
+  - `(gschem attrib)` => `(schematic attrib)`
+  - `(gschem builtins)` => `(schematic builtins)`
+  - `(gschem gschemdoc)` => `(schematic gschemdoc)`
+  - `(gschem hook)` => `(schematic hook)`
+  - `(gschem keymap)` => `(schematic keymap)`
+  - `(gschem selection)` => `(schematic selection)`
+  - `(gschem symbol check)` => `(schematic symbol check)`
+  - `(gschem util)` => `(schematic util)`
+  - `(gschem window)` => `(schematic window)`
 
-- The module `(gschem attrib)` has been renamed to `(schematic
-  attrib)`.  All the functions and variables available are still
-  re-exported in the former one but its using is discouraged.
+- The following modules were simply renamed without providing any
+  backwards compatibility:
+  - `(gschem core gettext)` => `(schematic core gettext)`
+  - `(gschem repl)` => `(schematic repl)`
 
-- The module `(gschem builtins)` has been renamed to `(schematic
-  builtins)`.  All the functions and variables available are still
-  re-exported in the former one but its using is discouraged.
-
-- The module `(gschem core gettext)` has been renamed to
-  `(schematic core gettext)`.
-
-- The module `(gschem gschemdoc)` has been renamed to `(schematic
-  gschemdoc)`.  All the functions and variables available are still
-  re-exported in the former one but its using is discouraged.
-
-- The module `(gschem hook)` has been renamed to `(schematic
-  hook)`.  All the functions and variables available are still
-  re-exported in the former one but its using is discouraged.
-
-- The module `(gschem keymap)` has been renamed to `(schematic
-  keymap)`.  All the functions and variables available are still
-  re-exported in the former one but its using is discouraged.
-
-- The module `(gschem selection)` has been renamed to `(schematic
-  selection)`.  All the functions and variables available are still
-  re-exported in the former one but its using is discouraged.
-
-- The module `(gschem symbol check)` has been renamed to `(schematic
-  symbol check)`.  All the functions and variables available are still
-  re-exported in the former one but its using is discouraged.
-
-- The module `(gschem util)` has been renamed to `(schematic
-  util)`.  All the functions and variables available are still
-  re-exported in the former one but its using is discouraged.
-
-- The module `(gschem window)` has been renamed to `(schematic
-  window)`.  All the functions and variables available are still
-  re-exported in the former one but its using is discouraged.
-
-- The module `(gschem repl)` has been renamed to `(schematic repl)`.
-
-- The module `(gschem core attrib)` has been renamed to
-  `(schematic core attrib)`.
-
-- The module `(gschem core builtins)` has been renamed to
-  `(schematic core builtins)`.
-
-- The module `(gschem core hook)` has been renamed to `(schematic
-  core hook)`.
-
-- The module `(gschem core keymap)` has been renamed to
-  `(schematic core keymap)`.
-
-- The module `(gschem core selection)` has been renamed to
-  `(schematic core selection)`.
-
-- The module `(gschem core util)` has been renamed to `(schematic
-  core util)`.
-
-- The module `(gschem core window)` has been renamed to
-  `(schematic core window)`.
+- The following *core* (written in C) Scheme modules have been
+  renamed:
+  - `(gschem core attrib)` => `(schematic core attrib)`
+  - `(gschem core builtins)` => `(schematic core builtins)`
+  - `(gschem core hook)` => `(schematic core hook)`
+  - `(gschem core keymap)` => `(schematic core keymap)`
+  - `(gschem core selection)` => `(schematic core selection)`
+  - `(gschem core util)` => `(schematic core util)`
+  - `(gschem core window)` => `(schematic core window)`
 
 - Grips can now be turned on and off at run-time.
   Use the new 'Options → Grips: On/Off' menu item or

--- a/NEWS.md
+++ b/NEWS.md
@@ -219,6 +219,9 @@ Notable changes in Lepton EDA 1.9.10 (upcoming)
 - The module `(gschem core builtins)` has been renamed to
   `(schematic core builtins)`.
 
+- The module `(gschem core hook)` has been renamed to `(schematic
+  core hook)`.
+
 - Grips can now be turned on and off at run-time.
   Use the new 'Options → Grips: On/Off' menu item or
   <kbd>O</kbd>-<kbd>I</kbd> keyboard shortcut.

--- a/NEWS.md
+++ b/NEWS.md
@@ -225,6 +225,9 @@ Notable changes in Lepton EDA 1.9.10 (upcoming)
 - The module `(gschem core keymap)` has been renamed to
   `(schematic core keymap)`.
 
+- The module `(gschem core selection)` has been renamed to
+  `(schematic core selection)`.
+
 - Grips can now be turned on and off at run-time.
   Use the new 'Options → Grips: On/Off' menu item or
   <kbd>O</kbd>-<kbd>I</kbd> keyboard shortcut.

--- a/liblepton/scheme/Makefile.am
+++ b/liblepton/scheme/Makefile.am
@@ -27,7 +27,7 @@ nobase_dist_scmdata_DATA = \
 	lepton/version.scm \
 	lepton/legacy-config/keylist.scm \
 	lepton/legacy-config.scm
-nobase_scmdata_DATA = geda/core/gettext.scm
+nobase_scmdata_DATA = lepton/core/gettext.scm
 
 check-am: update-cli-tool
 
@@ -76,11 +76,11 @@ TESTS = unit-tests/t0001-geda-conf-lib.scm \
 XFAIL_TESTS = \
 	unit-tests/t0301-promotable-attributes.scm
 
-dist_noinst_DATA = geda/core/gettext.scm.in unit-test.scm $(TESTS)
+dist_noinst_DATA = lepton/core/gettext.scm.in unit-test.scm $(TESTS)
 
-geda/core/gettext.scm: $(srcdir)/geda/core/gettext.scm.in Makefile
+lepton/core/gettext.scm: $(srcdir)/lepton/core/gettext.scm.in Makefile
 	@domain=$(LIBLEPTON_GETTEXT_DOMAIN); \
-	$(MKDIR_P) geda/core; \
+	$(MKDIR_P) lepton/core; \
 	sed -e"s:[@]LIBLEPTON_GETTEXT_DOMAIN@:$$domain:" < $(srcdir)/$@.in > $@.new; \
 	if cmp $@ $@.new > /dev/null 2>&1; then \
 	  rm $@.new; echo "$@ is unchanged"; \
@@ -95,7 +95,5 @@ update-cli-tool:
 
 .PHONY: update-cli-tool
 
-MOSTLYCLEANFILES = *.log *~
-CLEANFILES = *.log *~ geda/core/gettext.scm unit-tests/dummy.sym unit-tests/dummy.xpm
-DISTCLEANFILES = *.log core FILE *~
-MAINTAINERCLEANFILES = *.log *~ Makefile.in
+CLEANFILES = lepton/core/gettext.scm unit-tests/dummy.sym unit-tests/dummy.xpm
+MAINTAINERCLEANFILES = Makefile.in

--- a/liblepton/scheme/geda/deprecated.scm
+++ b/liblepton/scheme/geda/deprecated.scm
@@ -23,8 +23,8 @@
 
 (define-module (geda deprecated)
  ;; Import C procedures
- #:use-module (geda core gettext)
  #:use-module (geda core deprecated)
+ #:use-module (lepton core gettext)
  #:use-module (lepton core rc)
 
  #:use-module (lepton attrib)

--- a/liblepton/scheme/geda/deprecated.scm
+++ b/liblepton/scheme/geda/deprecated.scm
@@ -23,7 +23,7 @@
 
 (define-module (geda deprecated)
  ;; Import C procedures
- #:use-module (geda core deprecated)
+ #:use-module (lepton core deprecated)
  #:use-module (lepton core gettext)
  #:use-module (lepton core rc)
 

--- a/liblepton/scheme/lepton/attrib.scm
+++ b/liblepton/scheme/lepton/attrib.scm
@@ -22,7 +22,7 @@
 (define-module (lepton attrib)
 
   ; Import C procedures
-  #:use-module (geda core attrib)
+  #:use-module (lepton core attrib)
 
   #:use-module (geda core gettext)
 

--- a/liblepton/scheme/lepton/attrib.scm
+++ b/liblepton/scheme/lepton/attrib.scm
@@ -23,8 +23,7 @@
 
   ; Import C procedures
   #:use-module (lepton core attrib)
-
-  #:use-module (geda core gettext)
+  #:use-module (lepton core gettext)
 
   #:use-module (lepton object)
   #:use-module (lepton page))

--- a/liblepton/scheme/lepton/config.scm
+++ b/liblepton/scheme/lepton/config.scm
@@ -18,13 +18,11 @@
 ;;; Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111 USA
 
 (define-module (lepton config)
+  #:use-module (ice-9 optargs) ; for define*-public
 
   ; Import C procedures
   #:use-module (geda core smob)
-  #:use-module (geda core config)
-
-  #:use-module (ice-9 optargs) ; for define*-public
-)
+  #:use-module (lepton core config))
 
 (define-public config? %config?)
 (define-public default-config-context %default-config-context)

--- a/liblepton/scheme/lepton/config.scm
+++ b/liblepton/scheme/lepton/config.scm
@@ -21,8 +21,8 @@
   #:use-module (ice-9 optargs) ; for define*-public
 
   ; Import C procedures
-  #:use-module (geda core smob)
-  #:use-module (lepton core config))
+  #:use-module (lepton core config)
+  #:use-module (lepton core smob))
 
 (define-public config? %config?)
 (define-public default-config-context %default-config-context)

--- a/liblepton/scheme/lepton/core/gettext.scm.in
+++ b/liblepton/scheme/lepton/core/gettext.scm.in
@@ -1,6 +1,6 @@
-;; gEDA - GPL Electronic Design Automation
-;; libgeda - gEDA's library - Scheme API
+;; Lepton EDA library - Scheme API
 ;; Copyright (C) 2010-2011 Peter Brett <peter@peter-b.co.uk>
+;; Copyright (C) 2017-2020 Lepton EDA Contributors
 ;;
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -21,7 +21,7 @@
 ;;
 ;; This module is for internal use only.
 
-(define-module (geda core gettext))
+(define-module (lepton core gettext))
 
 (define %liblepton-gettext-domain "@LIBLEPTON_GETTEXT_DOMAIN@")
 (define-public (_ msg) (gettext msg %liblepton-gettext-domain))

--- a/liblepton/scheme/lepton/legacy-config.scm
+++ b/liblepton/scheme/lepton/legacy-config.scm
@@ -1,6 +1,6 @@
 ;; Lepton EDA
 ;; liblepton - Lepton's library - Scheme API
-;; Copyright (C) 2019 dmn <graahnul.grom@gmail.com>
+;; Copyright (C) 2019-2020 dmn <graahnul.grom@gmail.com>
 ;; License: GPLv2+. See the COPYING file
 ;;
 

--- a/liblepton/scheme/lepton/library.scm
+++ b/liblepton/scheme/lepton/library.scm
@@ -25,12 +25,12 @@
 ;;; a warning is output that some of those files won't be used.
 
 (define-module (lepton library)
-  #:use-module (geda core gettext)
 
   #:use-module (srfi srfi-1)
   #:use-module (srfi srfi-9)
   #:use-module (ice-9 ftw)
   #:use-module (ice-9 match)
+  #:use-module (lepton core gettext)
   #:use-module (lepton file-system)
   #:use-module (lepton library component)
   #:use-module (lepton log)

--- a/liblepton/scheme/lepton/library/component.scm
+++ b/liblepton/scheme/lepton/library/component.scm
@@ -32,7 +32,7 @@
   #:use-module (ice-9 match)
   #:use-module (srfi srfi-1)
   #:use-module (srfi srfi-9)
-  #:use-module (geda core gettext)
+  #:use-module (lepton core gettext)
   #:use-module (lepton core rc)
   #:use-module (lepton log)
   #:use-module (lepton os)

--- a/liblepton/scheme/lepton/log.scm
+++ b/liblepton/scheme/lepton/log.scm
@@ -18,7 +18,7 @@
 
 (define-module (lepton log)
   #:use-module (ice-9 format)
-  #:use-module (geda core log)
+  #:use-module (lepton core log)
 
   #:export (init-log
             log!))

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -19,17 +19,14 @@
 ;;
 
 (define-module (lepton object)
+  ;; Optional arguments
+  #:use-module (ice-9 optargs)
+  #:use-module (srfi srfi-1)
 
-  ; Import C procedures
-  #:use-module (geda core smob)
-
+  ;; Import C procedures
   #:use-module (lepton core complex)
   #:use-module (lepton core object)
-
-  ; Optional arguments
-  #:use-module (ice-9 optargs)
-
-  #:use-module (srfi srfi-1))
+  #:use-module (lepton core smob))
 
 (define-public object-type %object-type)
 (define-public object-id %object-id)

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -23,7 +23,8 @@
   ; Import C procedures
   #:use-module (geda core smob)
   #:use-module (geda core object)
-  #:use-module (geda core complex)
+
+  #:use-module (lepton core complex)
 
   ; Optional arguments
   #:use-module (ice-9 optargs)

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -22,9 +22,9 @@
 
   ; Import C procedures
   #:use-module (geda core smob)
-  #:use-module (geda core object)
 
   #:use-module (lepton core complex)
+  #:use-module (lepton core object)
 
   ; Optional arguments
   #:use-module (ice-9 optargs)

--- a/liblepton/scheme/lepton/os.scm
+++ b/liblepton/scheme/lepton/os.scm
@@ -18,13 +18,10 @@
 
 
 (define-module (lepton os)
-
-  ; Import C procedures and variables
-  #:use-module (geda core os)
-
   #:use-module (srfi srfi-1)
-
-  #:use-module (ice-9 regex))
+  #:use-module (ice-9 regex)
+  ;; Import C procedures and variables
+  #:use-module (lepton core os))
 
 (define-public platform %platform)
 

--- a/liblepton/scheme/lepton/page.scm
+++ b/liblepton/scheme/lepton/page.scm
@@ -19,17 +19,15 @@
 
 
 (define-module (lepton page)
-
-  ;; Import C procedures
-  #:use-module (geda core smob)
-  #:use-module (lepton core page)
-
   #:use-module (ice-9 optargs)
   #:use-module ((ice-9 rdelim)
                 #:select (read-string)
                 #:prefix rdelim:)
 
+  ;; Import C procedures
   #:use-module (lepton core gettext)
+  #:use-module (lepton core page)
+  #:use-module (lepton core smob)
 
   #:use-module (lepton os)
 

--- a/liblepton/scheme/lepton/page.scm
+++ b/liblepton/scheme/lepton/page.scm
@@ -21,7 +21,6 @@
 (define-module (lepton page)
 
   ;; Import C procedures
-  #:use-module (geda core gettext)
   #:use-module (geda core smob)
   #:use-module (geda core page)
 
@@ -29,6 +28,8 @@
   #:use-module ((ice-9 rdelim)
                 #:select (read-string)
                 #:prefix rdelim:)
+
+  #:use-module (lepton core gettext)
 
   #:use-module (lepton os)
 

--- a/liblepton/scheme/lepton/page.scm
+++ b/liblepton/scheme/lepton/page.scm
@@ -22,7 +22,7 @@
 
   ;; Import C procedures
   #:use-module (geda core smob)
-  #:use-module (geda core page)
+  #:use-module (lepton core page)
 
   #:use-module (ice-9 optargs)
   #:use-module ((ice-9 rdelim)

--- a/liblepton/scheme/lepton/repl.scm
+++ b/liblepton/scheme/lepton/repl.scm
@@ -21,7 +21,8 @@
 (define-module (lepton repl)
   #:use-module (system repl repl)
   #:use-module (system repl common)
-  #:use-module (geda core gettext)
+
+  #:use-module (lepton core gettext)
   #:use-module ((lepton os) #:select (user-config-dir))
 
   #:export (lepton-repl

--- a/liblepton/scheme/lepton/repl.scm
+++ b/liblepton/scheme/lepton/repl.scm
@@ -58,7 +58,7 @@
                `(begin
                   (use-modules (ice-9 session) ; help, apropos and such
                                (system repl command) ; guile meta-commands
-                               (geda repl)) ; this module
+                               (lepton repl)) ; this module
                   (lepton-repl-welcome)
                   (resolve-module '(ice-9 readline))
                   ;; After resolving that module the variable

--- a/liblepton/scheme/unit-tests/t0113-object-selectable.scm
+++ b/liblepton/scheme/unit-tests/t0113-object-selectable.scm
@@ -2,12 +2,10 @@
 ;; - object-selectable?
 ;; - set-object-selectable!
 
-( use-modules ( unit-test ) )
-
-( use-modules ( geda object ) )
-( use-modules ( geda page   ) )
-
-
+(use-modules (unit-test)
+             (lepton object)
+             ((geda object) #:renamer (symbol-prefix-proc 'geda:))
+             (lepton page))
 
 ( begin-test 'object-selectable
 ( let
@@ -80,3 +78,76 @@
 ) ; let
 ) ; 'object-selectable()
 
+;;; The same tests for the deprecated (geda object) module
+;;; functions.
+
+( begin-test 'geda:object-selectable
+( let
+  (
+  ( page #f )
+  ( obj  #f )
+  ( tmp  #f )
+  )
+
+  ; create a page and an object:
+  ;
+  ( set! page (make-page "/test/page/A") )
+  ( set! obj  (geda:make-box  '(1 . 4) '(3 . 2)) )
+  ( page-append! page obj )
+
+
+  ; obj should be initially unlocked (i.e. selectable):
+  ;
+  ( assert-true (geda:object-selectable? obj) )
+
+
+  ; clear the page modification flag and lock the object:
+  ;
+  ( set-page-dirty! page #f )
+  ( set! tmp (geda:set-object-selectable! obj #f) )
+
+  ; geda:set-object-selectable!() should return the object:
+  ;
+  ( assert-equal tmp obj )
+
+  ; ensure obj is now locked:
+  ;
+  ( assert-false (geda:object-selectable? obj) )
+
+  ; ensure the page modification flag is set:
+  ;
+  ( assert-true (page-dirty? page) )
+
+
+  ; clear the page modification flag and lock the object again:
+  ;
+  ( set-page-dirty! page #f )
+  ( geda:set-object-selectable! obj #f )
+
+  ; ensure the page modification flag is NOT set (obj is not modified):
+  ;
+  ( assert-false (page-dirty? page) )
+
+
+  ; clear the page modification flag and unlock the object:
+  ;
+  ( set-page-dirty! page #f )
+  ( set! tmp (geda:set-object-selectable! obj #t) )
+
+  ; geda:set-object-selectable!() should return the object:
+  ;
+  ( assert-equal tmp obj )
+
+  ; ensure obj is now unlocked:
+  ;
+  ( assert-true (geda:object-selectable? obj) )
+
+  ; ensure the page modification flag is set:
+  ;
+  ( assert-true (page-dirty? page) )
+
+
+  ( close-page! page )
+
+) ; let
+) ; 'object-selectable()

--- a/liblepton/scheme/unit-tests/t0114-object-embedded.scm
+++ b/liblepton/scheme/unit-tests/t0114-object-embedded.scm
@@ -2,12 +2,11 @@
 ;; - object-embedded?
 ;; - set-object-embedded!
 
-( use-modules ( unit-test ) )
-
-( use-modules ( geda object ) )
-( use-modules ( lepton page ) )
-( use-modules ( lepton library component ) )
-
+(use-modules (unit-test)
+             (lepton object)
+             ((geda object) #:renamer (symbol-prefix-proc 'geda:))
+             (lepton page)
+             (lepton library component))
 
 
 ( define ( mk-component ) ; create and return a component object
@@ -161,3 +160,91 @@
 ) ; let
 ) ; 'object-embedded()
 
+;;; The same tests for the deprecated (geda object) module
+;;; functions.
+
+
+( define ( geda:test-embedded obj )
+( let
+  (
+  ( page #f )
+  ( tmp  #f )
+  )
+
+  ; create a page and add an object to it:
+  ;
+  ( set! page ( make-page "/test/page/A" ) )
+  ( page-append! page obj )
+
+  ; obj should be unembedded:
+  ;
+  ( assert-false (geda:object-embedded? obj) )
+
+
+  ; clear the page modification flag and embed the object:
+  ;
+  ( set-page-dirty! page #f )
+  ( set! tmp (geda:set-object-embedded! obj #t) )
+
+  ; geda:set-object-embedded!() should return the object:
+  ;
+  ( assert-equal tmp obj )
+
+  ; ensure obj is now embedded:
+  ;
+  ( assert-true (geda:object-embedded? obj) )
+
+  ; ensure the page modification flag is set:
+  ;
+  ( assert-true (page-dirty? page) )
+
+
+  ; clear the page modification flag and try to embed the object again:
+  ;
+  ( set-page-dirty! page #f )
+  ( geda:set-object-embedded! obj #t )
+
+  ; ensure the page modification flag is NOT set (obj is not modified):
+  ;
+  ( assert-false (page-dirty? page) )
+
+  ; clear the page modification flag and unembed the object:
+  ;
+  ( set-page-dirty! page #f )
+  ( set! tmp (geda:set-object-embedded! obj #f) )
+
+  ; geda:set-object-embedded!() should return the object:
+  ;
+  ( assert-equal tmp obj )
+
+  ; ensure obj is now unembedded:
+  ;
+  ( assert-false (geda:object-embedded? obj) )
+
+  ; ensure the page modification flag is set:
+  ;
+  ( assert-true (page-dirty? page) )
+
+
+  ( close-page! page )
+
+) ; let
+) ; geda:test-embedded()
+
+
+
+( begin-test 'geda:object-embedded
+( let
+  (
+  ( obj #f )
+  )
+
+  ( set! obj ( mk-component ) )
+  ( geda:test-embedded obj )
+
+  ( set! obj ( mk-picture ) )
+  ( geda:set-object-embedded! obj #f ) ; make-picture/vector() creates embedded object
+  ( geda:test-embedded obj )
+
+) ; let
+) ; 'geda:object-embedded()

--- a/liblepton/src/scheme_attrib.c
+++ b/liblepton/src/scheme_attrib.c
@@ -1,6 +1,7 @@
-/* gEDA - GPL Electronic Design Automation
- * libgeda - gEDA's library - Scheme API
+/* Lepton EDA library - Scheme API
  * Copyright (C) 2010-2011 Peter Brett <peter@peter-b.co.uk>
+ * Copyright (C) 2010-2016 gEDA Contributors
+ * Copyright (C) 2017-2020 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -37,7 +38,7 @@ SCM_SYMBOL (attribute_format_sym, "attribute-format");
  * <tt>attribute-format</tt> error.
  *
  * \note Scheme API: Implements the %attrib-parse procedure of the
- * (geda core attrib) module.
+ * (lepton core attrib) module.
  *
  * \param text_s text object to attempt to split.
  * \return name/value pair, or SCM_BOOL_F.
@@ -81,7 +82,7 @@ SCM_DEFINE (parse_attrib, "%parse-attrib", 1, 0, 0,
  * <tt>attribute-format</tt> error.
  *
  * \note Scheme API: Implements the %attrib-name procedure of the
- * (geda core attrib) module.
+ * (lepton core attrib) module.
  *
  * \param text_s text object to parse
  * \return name, or SCM_BOOL_F.
@@ -112,7 +113,7 @@ SCM_DEFINE (attrib_name, "%attrib-name", 1, 0, 0,
  * #OBJECT smobs.
  *
  * \note Scheme API: Implements the %object-attribs procedure of the
- * (geda core attrib) module.
+ * (lepton core attrib) module.
  *
  * \param obj_s object to get attributes for.
  * \return a list of #OBJECT smobs.
@@ -135,7 +136,7 @@ SCM_DEFINE (object_attribs, "%object-attribs", 1, 0, 0,
  * attrib_s is not attached as an attribute, returns SCM_BOOL_F.
  *
  * \note Scheme API: Implements the %attrib-attachment procedure of
- * the (geda core attrib) module.
+ * the (lepton core attrib) module.
  *
  * \param attrib_s the object to get attribute attachment for.
  * \return the object to which \a attrib_s is attached, or SCM_BOOL_F.
@@ -175,7 +176,7 @@ SCM_DEFINE (attrib_attachment, "%attrib-attachment", 1, 0, 0,
  * successfully.
  *
  * \note Scheme API: Implements the %attach-attrib! procedure of
- * the (geda core attrib) module.
+ * the (lepton core attrib) module.
  *
  * \param obj_s the object to which to attach an attribute.
  * \param attrib_s the attribute to attach.
@@ -236,7 +237,7 @@ SCM_DEFINE (attach_attrib_x, "%attach-attrib!", 2, 0, 0,
  * error.
  *
  * \note Scheme API: Implements the %detach-attrib! procedure of
- * the (geda core attrib) module.
+ * the (lepton core attrib) module.
  *
  * \param obj_s the object from which to detach an attribute.
  * \param attrib_s the attribute to detach.
@@ -303,13 +304,13 @@ SCM_DEFINE (promotable_attribs, "%promotable-attribs", 1, 0, 0,
 
 
 /*!
- * \brief Create the (geda core attrib) Scheme module.
+ * \brief Create the (lepton core attrib) Scheme module.
  * \par Function Description
- * Defines procedures in the (geda core attrib) module. The module can
- * be accessed using (use-modules (geda core attrib)).
+ * Defines procedures in the (lepton core attrib) module. The module can
+ * be accessed using (use-modules (lepton core attrib)).
  */
 static void
-init_module_geda_core_attrib (void *unused)
+init_module_lepton_core_attrib (void *unused)
 {
   /* Register the functions */
   #include "scheme_attrib.x"
@@ -330,8 +331,8 @@ init_module_geda_core_attrib (void *unused)
 void
 edascm_init_attrib ()
 {
-  /* Define the (geda core attrib) module */
-  scm_c_define_module ("geda core attrib",
-                       (void (*)(void*)) init_module_geda_core_attrib,
+  /* Define the (lepton core attrib) module */
+  scm_c_define_module ("lepton core attrib",
+                       (void (*)(void*)) init_module_lepton_core_attrib,
                        NULL);
 }

--- a/liblepton/src/scheme_complex.c
+++ b/liblepton/src/scheme_complex.c
@@ -1,7 +1,7 @@
 /* Lepton EDA library - Scheme API
  * Copyright (C) 2010 Peter Brett <peter@peter-b.co.uk>
  * Copyright (C) 2010-2016 gEDA Contributors
- * Copyright (C) 2017-2019 Lepton EDA Contributors
+ * Copyright (C) 2017-2020 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -35,7 +35,7 @@
  * to be embedded.
  *
  * \note Scheme API: Implements the %make-complex procedure in the
- * (geda core complex) module.
+ * (lepton core complex) module.
  *
  * \return a newly-created complex object.
  */
@@ -69,7 +69,7 @@ SCM_DEFINE (make_complex, "%make-complex", 1, 0, 0,
  * SCM_BOOL_F.
  *
  * \note Scheme API: Implements the %make-complex/library procedure in
- * the (geda core complex) module.
+ * the (lepton core complex) module.
  *
  * \param basename component name to search for in the component
  *                 library.
@@ -110,7 +110,7 @@ SCM_DEFINE (make_complex_library, "%make-complex/library", 1, 0, 0,
  * to new values.
  *
  * \note Scheme API: Implements the %set-complex! procedure in the
- * (geda core complex) module.
+ * (lepton core complex) module.
  *
  * \param complex_s the complex object to modify.
  * \param x_s       the new x-coordinate of the complex object.
@@ -183,7 +183,7 @@ SCM_DEFINE (set_complex_x, "%set-complex!", 6, 0, 0,
  * -# Whether object is locked.
  *
  * \note Scheme API: Implements the %complex-info procedure in the
- * (geda core complex) module.
+ * (lepton core complex) module.
  *
  * \param complex_s the complex object to inspect.
  * \return a list of complex object parameters.
@@ -212,7 +212,7 @@ SCM_DEFINE (complex_info, "%complex-info", 1, 0, 0,
  * Retrieves a list of the primitive objects that make up a complex object.
  *
  * \note Scheme API: Implements the %complex-contents procedure in the
- * (geda core complex) module.
+ * (lepton core complex) module.
  *
  * \param complex_s a complex object.
  * \return a list of primitive objects.
@@ -241,7 +241,7 @@ SCM_DEFINE (complex_contents, "%complex-contents", 1, 0, 0,
  * attached to \a complex_s, does nothing.
  *
  * \note Scheme API: Implements the %complex-append! procedure of the
- * (geda core complex) module.
+ * (lepton core complex) module.
  *
  * \param complex_s complex object to modify.
  * \param obj_s     primitive object to add.
@@ -309,7 +309,7 @@ SCM_DEFINE (complex_append_x, "%complex-append!", 2, 0, 0,
  * Scheme error.  If \a obj_s is unattached, does nothing.
  *
  * \note Scheme API: Implements the %complex-remove! procedure of the
- * (geda core complex) module.
+ * (lepton core complex) module.
  *
  * \param complex_s complex object to modify.
  * \param obj_s     primitive object to remove.
@@ -387,7 +387,7 @@ SCM_DEFINE (complex_remove_x, "%complex-remove!", 2, 0, 0,
  * file's full path.
  *
  * \note Scheme API: Implements the %complex-filename procedure in the
- * (geda core complex) module.
+ * (lepton core complex) module.
  *
  * \param complex_s  a complex object.
  * \return           symbols's file path or #f.
@@ -420,13 +420,13 @@ SCM_DEFINE (complex_filename, "%complex-filename", 1, 0, 0,
 
 
 /*!
- * \brief Create the (geda core complex) Scheme module.
+ * \brief Create the (lepton core complex) Scheme module.
  * \par Function Description
- * Defines procedures in the (geda core complex) module. The module can
- * be accessed using (use-modules (geda core complex)).
+ * Defines procedures in the (lepton core complex) module. The module can
+ * be accessed using (use-modules (lepton core complex)).
  */
 static void
-init_module_geda_core_complex (void *unused)
+init_module_lepton_core_complex (void *unused)
 {
   /* Register the functions and symbols */
   #include "scheme_complex.x"
@@ -444,7 +444,7 @@ init_module_geda_core_complex (void *unused)
 }
 
 /*!
- * \brief Initialise the basic gEDA complex object manipulation procedures.
+ * \brief Initialise the basic Lepton EDA complex object manipulation procedures.
  * \par Function Description
  * Registers some Scheme procedures for working with complex #OBJECT
  * smobs. Should only be called by edascm_init().
@@ -452,8 +452,8 @@ init_module_geda_core_complex (void *unused)
 void
 edascm_init_complex ()
 {
-  /* Define the (geda core object) module */
-  scm_c_define_module ("geda core complex",
-                       (void (*)(void*)) init_module_geda_core_complex,
+  /* Define the (lepton core complex) module */
+  scm_c_define_module ("lepton core complex",
+                       (void (*)(void*)) init_module_lepton_core_complex,
                        NULL);
 }

--- a/liblepton/src/scheme_config.c
+++ b/liblepton/src/scheme_config.c
@@ -1,6 +1,6 @@
 /* Lepton EDA library - Scheme API
  * Copyright (C) 2011-2012 Peter Brett <peter@peter-b.co.uk>
- * Copyright (C) 2017-2019 Lepton EDA Contributors
+ * Copyright (C) 2017-2020 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -126,7 +126,7 @@ error_from_gerror (const gchar *subr, GError **error)
  * \see eda_config_get_default_context().
  *
  * \note Scheme API: Implements the \%default-config-context procedure
- * in the (geda core config) module.
+ * in the (lepton core config) module.
  *
  * \return an #EdaConfig smob for the default context.
  */
@@ -143,7 +143,7 @@ SCM_DEFINE (default_config_context, "%default-config-context", 0, 0, 0,
  * \see eda_config_get_system_context().
  *
  * \note Scheme API: Implements the \%system-config-context procedure
- * in the (geda core config) module.
+ * in the (lepton core config) module.
  *
  * \return an #EdaConfig smob for the system context.
  */
@@ -160,7 +160,7 @@ SCM_DEFINE (system_config_context, "%system-config-context", 0, 0, 0,
  * \see eda_config_get_user_context().
  *
  * \note Scheme API: Implements the \%user-config-context procedure
- * in the (geda core config) module.
+ * in the (lepton core config) module.
  *
  * \return an #EdaConfig smob for the user context.
  */
@@ -178,7 +178,7 @@ SCM_DEFINE (user_config_context, "%user-config-context", 0, 0, 0,
  * \see eda_config_get_context_for_path().
  *
  * \note Scheme API: Implements the \%path-config-context procedure in
- * the (geda core config) module.
+ * the (lepton core config) module.
  *
  * \param [in] path_s Path to get context for, as a string.
  * \return an #EdaConfig smob for \a path.
@@ -211,7 +211,7 @@ SCM_DEFINE (path_config_context, "%path-config-context", 1, 0, 0,
  * \see eda_config_get_cache_context().
  *
  * \note Scheme API: Implements the \%cache-config-context procedure
- * in the (geda core config) module.
+ * in the (lepton core config) module.
  *
  * \return an #EdaConfig smob for the cache context.
  */
@@ -229,7 +229,7 @@ SCM_DEFINE (cache_config_context, "%cache-config-context", 0, 0, 0,
  * \see eda_config_get_file().
  *
  * \note Scheme API: Implements the \%config-filename procedure in the
- * (geda core config) module.
+ * (lepton core config) module.
  *
  * \param cfg_s  #EdaConfig smob for configuration context.
  * \return string containing configuration filename.
@@ -262,7 +262,7 @@ SCM_DEFINE (config_filename, "%config-filename", 1, 0, 0,
  * \see eda_config_load().
  *
  * \note Scheme API: Implements the \%config-load! procedure in the
- * (geda core config) module.
+ * (lepton core config) module.
  *
  * \param cfg_s    #EdaConfig smob for configuration context to load.
  * \param force_s  Force configuration loading even if it has been already loaded.
@@ -304,7 +304,7 @@ SCM_DEFINE (config_load_x, "%config-load!", 2, 0, 0,
  * \see eda_config_is_loaded().
  *
  * \note Scheme API: Implements the \%config-loaded? procedure in the
- * (geda core config) module.
+ * (lepton core config) module.
  *
  * \param cfg_s  #EdaConfig smob of configuration context.
  * \return #t if \a cfg_s has been loaded; #f otherwise.
@@ -327,7 +327,7 @@ SCM_DEFINE (config_loaded_p, "%config-loaded?", 1, 0, 0,
  * \see eda_config_save().
  *
  * \note Scheme API: Implements the \%config-save! procedure in the
- * (geda core config) module.
+ * (lepton core config) module.
  *
  * \param cfg_s #EdaConfig smob of configuration context.
  * \return \a cfg_s.
@@ -355,7 +355,7 @@ SCM_DEFINE (config_save_x, "%config-save!", 1, 0, 0,
  * \see eda_config_is_changed().
  *
  * \note Scheme API: Implements the \%config-changed? procedure in the
- * (geda core config) module.
+ * (lepton core config) module.
  *
  * \param cfg_s #EdaConfig smob of configuration context.
  * \return #t if \a cfg_s has unsaved changes, #f otherwise.
@@ -379,7 +379,7 @@ SCM_DEFINE (config_changed_p, "%config-changed?", 1, 0, 0,
  * \see eda_config_get_parent().
  *
  * \note Scheme API: Implements the \%config-parent procedure in the
- * (geda core config) module.
+ * (lepton core config) module.
  *
  * \param cfg_s #EdaConfig smob of configuration context.
  * \return parent context of \a cfg_s, or #f.
@@ -404,7 +404,7 @@ SCM_DEFINE (config_parent, "%config-parent", 1, 0, 0,
  * \see eda_config_set_parent().
  *
  * \note Scheme API: Implements the \%set-config-parent! procedure in
- * the (geda core config) module.
+ * the (lepton core config) module.
  *
  * \param cfg_s #EdaConfig smob of configuration context.
  * \param parent_s #EdaConfig smob of new parent context, or #f.
@@ -433,7 +433,7 @@ SCM_DEFINE (set_config_parent_x, "%set-config-parent!", 2, 0, 0,
  * \see eda_config_is_trusted().
  *
  * \note Scheme API: Implements the \%config-trusted? procedure in
- * the (geda core config) module.
+ * the (lepton core config) module.
  *
  * \param cfg_s #EdaConfig smob of configuration context.
  * \return #t if \a cfg_s is trusted, #f otherwise.
@@ -455,7 +455,7 @@ SCM_DEFINE (config_trusted_p, "%config-trusted?", 1, 0, 0,
  * \see eda_config_set_trusted().
  *
  * \note Scheme API: Implements the \%set-config-trusted! procedure in
- * the (geda core config) module.
+ * the (lepton core config) module.
  *
  * \param cfg_s #EdaConfig smob of configuration context.
  * \param trusted_s #f if \a cfg_s is not to be trusted.
@@ -481,7 +481,7 @@ SCM_DEFINE (set_config_trusted_x, "%set-config-trusted!", 2, 0, 0,
  * \see eda_config_get_groups().
  *
  * \note Scheme API: Implements the \%config-groups procedure in
- * the (geda core config) module.
+ * the (lepton core config) module.
  *
  * \param cfg_s #EdaConfig smob of configuration context.
  * \return a list of available group names as strings.
@@ -519,7 +519,7 @@ SCM_DEFINE (config_groups, "%config-groups", 1, 0, 0,
  * \see eda_config_has_group().
  *
  * \note Scheme API: Implements the \%config-has-group? procedure in
- * the (geda core config) module.
+ * the (lepton core config) module.
  *
  * \param cfg_s #EdaConfig smob of configuration context.
  * \param group_s Group name as a string.
@@ -551,7 +551,7 @@ SCM_DEFINE (config_has_group_p, "%config-has-group?", 2, 0, 0,
  * \see eda_config_get_keys().
  *
  * \note Scheme API: Implements the \%config-keys procedure in
- * the (geda core config) module.
+ * the (lepton core config) module.
  *
  * \param cfg_s #EdaConfig smob of configuration context.
  * \param group_s Group name as a string.
@@ -599,7 +599,7 @@ SCM_DEFINE (config_keys, "%config-keys", 2, 0, 0,
  * \see eda_config_get_source().
  *
  * \note Scheme API: Implements the \%config-source procedure in the
- * (geda core config module).
+ * (lepton core config module).
  *
  * \param cfg_s #EdaConfig smob of configuration context.
  * \param group_s Group name as a string.
@@ -634,7 +634,7 @@ SCM_DEFINE (config_source, "%config-source", 3, 0, 0,
  * \see eda_config_get_string().
  *
  * \note Scheme API: Implements the \%config-string procedure in the
- * (geda core config) module.
+ * (lepton core config) module.
  *
  * \param cfg_s    #EdaConfig smob of configuration context.
  * \param group_s  Group name as a string.
@@ -672,7 +672,7 @@ SCM_DEFINE (config_string, "%config-string", 3, 0, 0,
  * \see eda_config_get_boolean().
  *
  * \note Scheme API: Implements the \%config-boolean procedure in the
- * (geda core config) module.
+ * (lepton core config) module.
  *
  * \param cfg_s    #EdaConfig smob of configuration context.
  * \param group_s  Group name as a string.
@@ -707,7 +707,7 @@ SCM_DEFINE (config_boolean, "%config-boolean", 3, 0, 0,
  * \see eda_config_get_int().
  *
  * \note Scheme API: Implements the \%config-int procedure in the
- * (geda core config) module.
+ * (lepton core config) module.
  *
  * \param cfg_s    #EdaConfig smob of configuration context.
  * \param group_s  Group name as a string.
@@ -742,7 +742,7 @@ SCM_DEFINE (config_int, "%config-int", 3, 0, 0,
  * \see eda_config_get_double().
  *
  * \note Scheme API: Implements the \%config-real procedure in the
- * (geda core config) module.
+ * (lepton core config) module.
  *
  * \param cfg_s    #EdaConfig smob of configuration context.
  * \param group_s  Group name as a string.
@@ -777,7 +777,7 @@ SCM_DEFINE (config_real, "%config-real", 3, 0, 0,
  * \see eda_config_get_string_list().
  *
  * \note Scheme API: Implements the \%config-string-list procedure in
- * the (geda core config) module.
+ * the (lepton core config) module.
  *
  * \param cfg_s    #EdaConfig smob of configuration context.
  * \param group_s  Group name as a string.
@@ -820,7 +820,7 @@ SCM_DEFINE (config_string_list, "%config-string-list", 3, 0, 0,
  * \see eda_config_get_boolean_list().
  *
  * \note Scheme API: Implements the \%config-boolean-list procedure in
- * the (geda core config) module.
+ * the (lepton core config) module.
  *
  * \param cfg_s    #EdaConfig smob of configuration context.
  * \param group_s  Group name as a string.
@@ -863,7 +863,7 @@ SCM_DEFINE (config_boolean_list, "%config-boolean-list", 3, 0, 0,
  * \see eda_config_get_int_list().
  *
  * \note Scheme API: Implements the \%config-int-list procedure in
- * the (geda core config) module.
+ * the (lepton core config) module.
  *
  * \param cfg_s    #EdaConfig smob of configuration context.
  * \param group_s  Group name as a string.
@@ -906,7 +906,7 @@ SCM_DEFINE (config_int_list, "%config-int-list", 3, 0, 0,
  * \see eda_config_get_double_list().
  *
  * \note Scheme API: Implements the \%config-real-list procedure in
- * the (geda core config) module.
+ * the (lepton core config) module.
  *
  * \param cfg_s    #EdaConfig smob of configuration context.
  * \param group_s  Group name as a string.
@@ -949,7 +949,7 @@ SCM_DEFINE (config_real_list, "%config-real-list", 3, 0, 0,
  * integers, real numbers or booleans.
  *
  * \note Scheme API: Implements the \%set-config! procedure in the
- * (geda core config) module.
+ * (lepton core config) module.
  *
  * \param cfg_s    #EdaConfig smob of configuration context.
  * \param group_s  Group name as a string.
@@ -1079,7 +1079,7 @@ edascm_config_event_dispatcher (EdaConfig *cfg, const char *group,
  * caught and logged.
  *
  * \note Scheme API: Implements the \%add-config-event! procedure in the
- * (geda core config) module.
+ * (lepton core config) module.
  *
  * \param cfg_s    #EdaConfig smob of configuration context.
  * \param proc_s   Procedure to add as configuration change handler.
@@ -1124,7 +1124,7 @@ SCM_DEFINE (add_config_event_x, "%add-config-event!", 2, 0, 0,
  * the context \a cfg.
  *
  * \note Scheme API: Implements the \%remove-config-event! procedure
- * in the (geda core config) module.
+ * in the (lepton core config) module.
  *
  * \param cfg_s    #EdaConfig smob of configuration context.
  * \param proc_s   Procedure to remove as configuration change handler.
@@ -1168,7 +1168,7 @@ SCM_DEFINE (remove_config_event_x, "%remove-config-event!", 2, 0, 0,
  * \see eda_config_remove_key().
  *
  * \note Scheme API: Implements the \%config-remove-key!
- * procedure in the (geda core config) module.
+ * procedure in the (lepton core config) module.
  *
  * \param cfg_s    #EdaConfig smob of configuration context.
  * \param group_s  Group name as a string.
@@ -1215,7 +1215,7 @@ SCM_DEFINE (config_remove_key, "%config-remove-key!", 3, 0, 0,
  * \see eda_config_remove_group().
  *
  * \note Scheme API: Implements the \%config-remove-group!
- * procedure in the (geda core config) module.
+ * procedure in the (lepton core config) module.
  *
  * \param cfg_s    #EdaConfig smob of configuration context.
  * \param group_s  Group name as a string.
@@ -1260,7 +1260,7 @@ SCM_DEFINE (config_remove_group, "%config-remove-group!", 2, 0, 0,
  * \see config_set_legacy_mode().
  *
  * \note Scheme API: Implements the \%config-set-legacy-mode!
- * procedure in the (geda core config) module.
+ * procedure in the (lepton core config) module.
  *
  * \param legacy_s  Boolean: set legacy mode or not.
  *
@@ -1280,13 +1280,13 @@ SCM_DEFINE (config_set_legacy_mode_x, "%config-set-legacy-mode!", 1, 0, 0,
 
 
 /*!
- * \brief Create the (geda core config) Scheme module.
+ * \brief Create the (lepton core config) Scheme module.
  * \par Function Description
- * Defines procedures in the (geda core config) module. The module can
- * be accessed using (use-modules (geda core config)).
+ * Defines procedures in the (lepton core config) module. The module can
+ * be accessed using (use-modules (lepton core config)).
  */
 static void
-init_module_geda_core_config (void *unused)
+init_module_lepton_core_config (void *unused)
 {
   /* Register the functions and symbols */
   #include "scheme_config.x"
@@ -1328,7 +1328,7 @@ init_module_geda_core_config (void *unused)
 }
 
 /*!
- * \brief Initialise the basic gEDA configuration manipulation procedures.
+ * \brief Initialise the basic Lepton EDA configuration manipulation procedures.
  * \par Function Description
  * Registers some Scheme procedures for working with #EdaConfig
  * smobs. Should only be called by edascm_init().
@@ -1336,8 +1336,8 @@ init_module_geda_core_config (void *unused)
 void
 edascm_init_config ()
 {
-  /* Define the (geda core object) module */
-  scm_c_define_module ("geda core config",
-                       (void (*)(void*)) init_module_geda_core_config,
+  /* Define the (lepton core config) module */
+  scm_c_define_module ("lepton core config",
+                       (void (*)(void*)) init_module_lepton_core_config,
                        NULL);
 }

--- a/liblepton/src/scheme_deprecated.c
+++ b/liblepton/src/scheme_deprecated.c
@@ -1,6 +1,6 @@
-/* gEDA - GPL Electronic Design Automation
- * libgeda - gEDA's library
- * Copyright (C) 1998-2010 gEDA Contributors (see ChangeLog for details)
+/* Lepton EDA library - Scheme API
+ * Copyright (C) 1998-2013 gEDA Contributors
+ * Copyright (C) 2017-2020 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -47,13 +47,13 @@ SCM_DEFINE (get_line_width, "%get-line-width", 1, 0, 0,
 }
 
 /*!
- * \brief Create the (geda core deprecated) Scheme module.
+ * \brief Create the (lepton core deprecated) Scheme module.
  * \par Function Description
- * Defines procedures in the (geda core deprecated) module. The module can
- * be accessed using (use-modules (geda core deprecated)).
+ * Defines procedures in the (lepton core deprecated) module. The module can
+ * be accessed using (use-modules (lepton core deprecated)).
  */
 static void
-init_module_geda_core_deprecated (void *unused)
+init_module_lepton_core_deprecated (void *unused)
 {
   /* Register the functions */
   #include "scheme_deprecated.x"
@@ -79,16 +79,15 @@ init_module_geda_core_deprecated (void *unused)
 }
 
 /*!
- * \brief Initialise the basic gEDA page manipulation procedures.
+ * \brief Initialise the deprecated Lepton EDA / gEDA procedures.
  * \par Function Description
- * Registers some Scheme procedures for working with #PAGE
- * smobs. Should only be called by edascm_init().
+ * Should only be called by edascm_init().
  */
 void
 edascm_init_deprecated ()
 {
-  /* Define the (geda core page) module */
-  scm_c_define_module ("geda core deprecated",
-                       (void (*)(void*)) init_module_geda_core_deprecated,
+  /* Define the (lepton core deprecated) module */
+  scm_c_define_module ("lepton core deprecated",
+                       (void (*)(void*)) init_module_lepton_core_deprecated,
                        NULL);
 }

--- a/liblepton/src/scheme_deprecated.c
+++ b/liblepton/src/scheme_deprecated.c
@@ -30,7 +30,7 @@
  * \par Function Description
  * Returns the line width used to draw an object. Deprecated because
  * it doesn't respect type restrictions, unlike the %object-stroke
- * function in (geda core object).
+ * function in (lepton core object).
  *
  * \param obj_s the object to get line width for.
  * \return the line width.

--- a/liblepton/src/scheme_log.c
+++ b/liblepton/src/scheme_log.c
@@ -1,6 +1,6 @@
-/* gEDA - GPL Electronic Design Automation
- * libgeda - gEDA's library - Scheme API
+/* Lepton EDA library - Scheme API
  * Copyright (C) 2016  Peter Brett <peter@peter-b.co.uk>
+ * Copyright (C) 2017-2020 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -66,8 +66,8 @@ decode_level (SCM level_s)
  * should be one of the symbols "error", "critical", "message", "info"
  * or "debug".
  *
- * \note Scheme API: Implements the \%log! procedure in the (geda core
- * log) module.
+ * \note Scheme API: Implements the \%log! procedure in the
+ * (lepton core log) module.
  *
  * \param domain_s  The log domain, as a string, or SCM_BOOL_F.
  * \param level_s   The log level, as a symbol.
@@ -110,7 +110,7 @@ SCM_DEFINE (log_x, "%log!", 3, 0, 0,
  * This is a Scheme wrapper for s_log_init().
  *
  * \note Scheme API: Implements the \%init-log procedure in the
- * (geda core log) module.
+ * (lepton core log) module.
  *
  * \param domain_s  The log domain, as a string.
  *
@@ -133,13 +133,13 @@ SCM_DEFINE (init_log, "%init-log", 1, 0, 0,
  * ================================================================ */
 
 /*!
- * \brief Create the (geda core log) Scheme module.
+ * \brief Create the (lepton core log) Scheme module.
  * \par Function Description
- * Defines procedures in the (geda core log) module.  The module can
- * be accessed using (use-modules (geda core log)).
+ * Defines procedures in the (lepton core log) module.  The module can
+ * be accessed using (use-modules (lepton core log)).
  */
 static void
-init_module_geda_core_log (void *unused)
+init_module_lepton_core_log (void *unused)
 {
   /* Register the functions and symbols */
   #include "scheme_log.x"
@@ -151,7 +151,7 @@ init_module_geda_core_log (void *unused)
 }
 
 /*!
- * \brief Initialise the basic gEDA logging procedures
+ * \brief Initialise the basic Lepton EDA logging procedures
  * \par Function Description
  *
  * Registers some core Scheme procedures for logging support.  Should
@@ -160,8 +160,8 @@ init_module_geda_core_log (void *unused)
 void
 edascm_init_log ()
 {
-  /* Define the (geda core log) module */
-  scm_c_define_module ("geda core log",
-                       (void (*)(void*)) init_module_geda_core_log,
+  /* Define the (lepton core log) module */
+  scm_c_define_module ("lepton core log",
+                       (void (*)(void*)) init_module_lepton_core_log,
                        NULL);
 }

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -1,7 +1,7 @@
 /* Lepton EDA library - Scheme API
  * Copyright (C) 2010-2012 Peter Brett <peter@peter-b.co.uk>
  * Copyright (C) 2011-2016 gEDA Contributors
- * Copyright (C) 2017-2019 Lepton EDA Contributors
+ * Copyright (C) 2017-2020 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -175,7 +175,7 @@ edascm_is_object_type (SCM smob, int type)
  * smob.
  *
  * \note Scheme API: Implements the %copy-object procedure in the
- * (geda core object) module.
+ * (lepton core object) module.
  *
  * \param [in] obj_s an #OBJECT smob.
  * \return a new #OBJECT smob containing a copy of the #OBJECT in \a obj_s.
@@ -204,7 +204,7 @@ SCM_DEFINE (copy_object, "%copy-object", 1, 0, 0,
  * Returns a symbol describing the type of the #OBJECT smob \a obj_s.
  *
  * \note Scheme API: Implements the %object-type procedure in the
- * (geda core object) module.
+ * (lepton core object) module.
  *
  * \param [in] obj_s an #OBJECT smob.
  * \return a Scheme symbol representing the object type.
@@ -245,7 +245,7 @@ SCM_DEFINE (object_type, "%object-type", 1, 0, 0,
  * Returns an internal id number of the #OBJECT smob \a obj_s.
  *
  * \note Scheme API: Implements the %object-id procedure in the
- * (geda core object) module.
+ * (lepton core object) module.
  *
  * \param [in] obj_s an #OBJECT smob.
  * \return a Scheme symbol representing the object type.
@@ -279,7 +279,7 @@ SCM_DEFINE (object_id, "%object-id", 1, 0, 0,
  * objects, not the visible bounds.
  *
  * \note Scheme API: Implements the %object-bounds procedure in the
- * (geda core object) module.  The procedure takes any number of
+ * (lepton core object) module.  The procedure takes any number of
  * #OBJECT smobs as arguments.
  *
  * \param [in] rst_s Variable-length list of #OBJECT arguments.
@@ -344,7 +344,7 @@ SCM_DEFINE (object_bounds, "%object-bounds", 0, 0, 1,
  *    -# For other styles, dot/dash spacing and dash length.
  *
  * \note Scheme API: Implements the %object-stroke procedure in the
- * (geda core object) module.
+ * (lepton core object) module.
  *
  * \param obj_s object to get stroke settings for.
  * \return a list of stroke parameters.
@@ -413,7 +413,7 @@ SCM_DEFINE (object_stroke, "%object-stroke", 1, 0, 0,
  * SCM_UNDEFINED if not required by the dash style \a dash_s.
  *
  * \note Scheme API: Implements the %object-stroke procedure in the
- * (geda core object) module.
+ * (lepton core object) module.
  *
  * \param obj_s object to set stroke settings for.
  * \param width_s new stroke width for \a obj_s.
@@ -519,7 +519,7 @@ SCM_DEFINE (set_object_stroke_x, "%set-object-stroke!", 4, 2, 0,
  *      spacing for mesh fills.
  *
  * \note Scheme API: Implements the %object-fill procedure in the
- * (geda core object) module.
+ * (lepton core object) module.
  *
  * \param obj_s object to get fill settings for.
  * \return a list of fill parameters.
@@ -576,7 +576,7 @@ SCM_DEFINE (object_fill, "%object-fill", 1, 0, 0,
  * space2_s
  *
  * \note Scheme API: Implements the %object-fill procedure in the
- * (geda core object) module.
+ * (lepton core object) module.
  *
  * \param obj_s object to set fill settings for.
  * \return \a obj_s.
@@ -675,7 +675,7 @@ SCM_DEFINE (set_object_fill_x, "%set-object-fill!", 2, 5, 0,
  * object types.
  *
  * \note Scheme API: Implements the %object-color procedure in the
- * (geda core object) module.
+ * (lepton core object) module.
  *
  * \param [in] obj_s #OBJECT smob to inspect.
  * \return The colormap index used by \a obj_s.
@@ -697,7 +697,7 @@ SCM_DEFINE (object_color, "%object-color", 1, 0, 0,
  * for some object types.
  *
  * \note Scheme API: Implements the %set-object-color! procedure in
- * the (geda core object) module.
+ * the (lepton core object) module.
  *
  * \param obj_s   #OBJECT smob to modify.
  * \param color_s new colormap index to use for \a obj_s.
@@ -729,7 +729,7 @@ SCM_DEFINE (set_object_color_x, "%set-object-color!", 2, 0, 0,
  * object is considered to be unlocked, otherwise it is locked.
  *
  * \note Scheme API: Implements the %object-selectable? procedure in the
- * (geda core object) module.
+ * (lepton core object) module.
  *
  * \param obj_s  #OBJECT smob to inspect.
  *
@@ -755,7 +755,7 @@ SCM_DEFINE (object_selectable_p, "%object-selectable?", 1, 0, 0,
  * Set object's selectable flag: locked objects cannot be selected.
  *
  * \note Scheme API: Implements the %set-object-selectable! procedure in
- * the (geda core object) module.
+ * the (lepton core object) module.
  *
  * \param obj_s         #OBJECT smob to modify.
  * \param selectable_s  boolean: object's selectable flag.
@@ -793,7 +793,7 @@ SCM_DEFINE (set_object_selectable_x, "%set-object-selectable!", 2, 0, 0,
 /*! \brief Check whether an object is embedded.
  *
  * \note Scheme API: Implements the %object-embedded? procedure in the
- * (geda core object) module.
+ * (lepton core object) module.
  *
  * \param obj_s  #OBJECT smob to inspect.
  *
@@ -833,7 +833,7 @@ SCM_DEFINE (object_embedded_p, "%object-embedded?", 1, 0, 0,
  * or \a obj_s is not a component or picture, does nothing.
  *
  * \note Scheme API: Implements the %set-object-embedded! procedure in
- * the (geda core object) module.
+ * the (lepton core object) module.
  *
  * \param obj_s    #OBJECT smob to modify.
  * \param embed_s  boolean: whether to embed (#t) or unembed (#f) the object.
@@ -885,8 +885,8 @@ SCM_DEFINE (set_object_embedded_x, "%set-object-embedded!", 2, 0, 0,
  * Creates a new line object, with all its parameters set to default
  * values.
  *
- * \note Scheme API: Implements the %make-line procedure in the (geda
- * core object) module.
+ * \note Scheme API: Implements the %make-line procedure in the
+ * (lepton core object) module.
  *
  * \return a newly-created line object.
  */
@@ -913,8 +913,8 @@ SCM_DEFINE (make_line, "%make-line", 0, 0, 0,
  * \par Function Description
  * Modifies a line object by setting its parameters to new values.
  *
- * \note Scheme API: Implements the %set-line! procedure in the (geda
- * core object) module.
+ * \note Scheme API: Implements the %set-line! procedure in the
+ * (lepton core object) module.
  *
  * This function also works on net, bus and pin objects.  For pins,
  * the start is the connectable point on the pin.
@@ -1037,8 +1037,8 @@ SCM_DEFINE (line_info, "%line-info", 1, 0, 0,
  * Creates a new net object, with all its parameters set to default
  * values.
  *
- * \note Scheme API: Implements the %make-net procedure in the (geda
- * core object) module.
+ * \note Scheme API: Implements the %make-net procedure in the
+ * (lepton core object) module.
  *
  * \return a newly-created net object.
  */
@@ -1066,8 +1066,8 @@ SCM_DEFINE (make_net, "%make-net", 0, 0, 0,
  * Creates a new bus object, with all its parameters set to default
  * values.
  *
- * \note Scheme API: Implements the %make-bus procedure in the (geda
- * core object) module.
+ * \note Scheme API: Implements the %make-bus procedure in the
+ * (lepton core object) module.
  *
  * \todo Do we need a way to get/set bus ripper direction?
  *
@@ -1102,8 +1102,8 @@ SCM_DEFINE (make_bus, "%make-bus", 0, 0, 0,
  * values.  type_s is a Scheme symbol indicating whether the pin
  * should be a "net" pin or a "bus" pin.
  *
- * \note Scheme API: Implements the %make-pin procedure in the (geda
- * core object) module.
+ * \note Scheme API: Implements the %make-pin procedure in the
+ * (lepton core object) module.
  *
  * \return a newly-created pin object.
  */
@@ -1146,8 +1146,8 @@ SCM_DEFINE (make_pin, "%make-pin", 1, 0, 0,
  * Returns a symbol describing the pin type of the pin object \a
  * pin_s.
  *
- * \note Scheme API: Implements the %make-pin procedure in the (geda
- * core object) module.
+ * \note Scheme API: Implements the %make-pin procedure in the
+ * (lepton core object) module.
  *
  * \return the symbol 'pin or 'bus.
  */
@@ -1181,8 +1181,8 @@ SCM_DEFINE (pin_type, "%pin-type", 1, 0, 0,
  * Creates a new box object, with all its parameters set to default
  * values.
  *
- * \note Scheme API: Implements the %make-box procedure in the (geda
- * core object) module.
+ * \note Scheme API: Implements the %make-box procedure in the
+ * (lepton core object) module.
  *
  * \return a newly-created box object.
  */
@@ -1206,8 +1206,8 @@ SCM_DEFINE (make_box, "%make-box", 0, 0, 0,
  * \par Function Description
  * Modifies a box object by setting its parameters to new values.
  *
- * \note Scheme API: Implements the %set-box! procedure in the (geda
- * core object) module.
+ * \note Scheme API: Implements the %set-box! procedure in the
+ * (lepton core object) module.
  *
  * \param box_s  the box object to modify.
  * \param x1_s   the new x-coordinate of the top left of the box.
@@ -1280,7 +1280,7 @@ SCM_DEFINE (box_info, "%box-info", 1, 0, 0,
  * values.
  *
  * \note Scheme API: Implements the %make-circle procedure in the
- * (geda core object) module.
+ * (lepton core object) module.
  *
  * \return a newly-created circle object.
  */
@@ -1307,7 +1307,7 @@ SCM_DEFINE (make_circle, "%make-circle", 0, 0, 0,
  * Modifies a circle object by setting its parameters to new values.
  *
  * \note Scheme API: Implements the %set-circle! procedure in the
- * (geda core object) module.
+ * (lepton core object) module.
  *
  * \param circle_s the circle object to modify.
  * \param x_s    the new x-coordinate of the center of the circle.
@@ -1376,7 +1376,7 @@ SCM_DEFINE (circle_info, "%circle-info", 1, 0, 0,
  * values.
  *
  * \note Scheme API: Implements the %make-arc procedure in the
- * (geda core object) module.
+ * (lepton core object) module.
  *
  * \return a newly-created arc object.
  */
@@ -1405,7 +1405,7 @@ SCM_DEFINE (make_arc, "%make-arc", 0, 0, 0,
  * Modifies a arc object by setting its parameters to new values.
  *
  * \note Scheme API: Implements the %set-arc! procedure in the
- * (geda core object) module.
+ * (lepton core object) module.
  *
  * \param arc_s         the arc object to modify.
  * \param x_s           the new x-coordinate of the center of the arc.
@@ -1460,7 +1460,7 @@ SCM_DEFINE (set_arc_x, "%set-arc!", 7, 0, 0,
  * -# Colormap index of color to be used for drawing the arc
  *
  * \note Scheme API: Implements the %arc-info procedure in the
- * (geda core object) module.
+ * (lepton core object) module.
  *
  * \param arc_s the arc object to inspect.
  * \return a list of arc parameters.
@@ -1488,7 +1488,7 @@ SCM_DEFINE (arc_info, "%arc-info", 1, 0, 0,
  * values.
  *
  * \note Scheme API: Implements the %make-text procedure in the
- * (geda core object) module.
+ * (lepton core object) module.
  *
  * \return a newly-created text object.
  */
@@ -1526,7 +1526,7 @@ SCM_DEFINE (make_text, "%make-text", 0, 0, 0,
  * the symbols "name", "value" or "both".
  *
  * \note Scheme API: Implements the %set-text! procedure in the
- * (geda core object) module.
+ * (lepton core object) module.
  *
  * \param text_s    the text object to modify.
  * \param x_s       the new x-coordinate of the anchor of the text.
@@ -1658,7 +1658,7 @@ SCM_DEFINE (set_text_x, "%set-text!", 10, 0, 0,
  * -# Colormap index of color to be used for drawing the text
  *
  * \note Scheme API: Implements the %text-info procedure in the
- * (geda core object) module.
+ * (lepton core object) module.
  *
  * \param text_s the text object to inspect.
  * \return a list of text parameters.
@@ -1727,7 +1727,7 @@ SCM_DEFINE (text_info, "%text-info", 1, 0, 0,
  * list.
  *
  * \note Scheme API: Implements the %object-connections procedure of
- * the (geda core object) module.
+ * the (lepton core object) module.
  *
  * \param obj_s #OBJECT smob for object to get connections for.
  * \return a list of #OBJECT smobs.
@@ -1760,7 +1760,7 @@ SCM_DEFINE (object_connections, "%object-connections", 1, 0, 0,
  * \a obj_s is not part of a component, returns SCM_BOOL_F.
  *
  * \note Scheme API: Implements the %object-complex procedure of the
- * (geda core object) module.
+ * (lepton core object) module.
  *
  * \param obj_s #OBJECT smob for object to get component of.
  * \return the #OBJECT smob of the containing component, or SCM_BOOL_F.
@@ -1786,8 +1786,8 @@ SCM_DEFINE (object_complex, "%object-complex", 1, 0, 0,
  * Creates a new, empty path object with default color, stroke and
  * fill options.
  *
- * \note Scheme API: Implements the %make-path procedure in the (geda
- * core object) module.
+ * \note Scheme API: Implements the %make-path procedure in the
+ * (lepton core object) module.
  *
  * \return a newly-created path object.
  */
@@ -1811,7 +1811,7 @@ SCM_DEFINE (make_path, "%make-path", 0, 0, 0,
  * Retrieves the number of path elements in the path object \a obj_s.
  *
  * \note Scheme API: Implements the %path-length procedure in the
- * (geda core object) module.
+ * (lepton core object) module.
  *
  * \param obj_s #OBJECT smob for path object to inspect.
  * \return The number of path elements in \a obj_s.
@@ -1848,8 +1848,8 @@ SCM_DEFINE (path_length, "%path-length", 1, 0, 0,
  *
  * All coordinates are absolute.
  *
- * \note Scheme API: Implements the %path-ref procedure in the (geda
- * core object) module.
+ * \note Scheme API: Implements the %path-ref procedure in the
+ * (lepton core object) module.
  *
  * \param obj_s   #OBJECT smob of path object to get element from.
  * \param index_s Index of element to retrieve from \a obj_s
@@ -1910,7 +1910,7 @@ SCM_DEFINE (path_ref, "%path-ref", 2, 0, 0,
  * "out-of-range" error.
  *
  * \note Scheme API: Implements the %path-remove! procedure in the
- * (geda core object) module.
+ * (lepton core object) module.
  *
  * \param obj_s   #OBJECT smob of path object to remove element from.
  * \param index_s Index of element to remove from \a obj_s.
@@ -1976,7 +1976,7 @@ SCM_DEFINE (path_remove_x, "%path-remove!", 2, 0, 0,
  * to the path.
  *
  * \note Scheme API: Implements the %path-insert! procedure of the
- * (geda core object) module.
+ * (lepton core object) module.
  *
  * \param obj_s   #OBJECT smob for the path object to modify.
  * \param index_s Index at which to insert new element.
@@ -2078,7 +2078,7 @@ SCM_DEFINE (path_insert_x, "%path-insert", 3, 6, 0,
  * be embedded.
  *
  * \note Scheme API: Implements the %make-picture procedure in the
- * (geda core object) module.
+ * (lepton core object) module.
  *
  * \return a newly-created picture object.
  */
@@ -2111,7 +2111,7 @@ SCM_DEFINE (make_picture, "%make-picture", 0, 0, 0, (),
  * -# Whether object is mirrored.
  *
  * \note Scheme API: Implements the %picture-info procedure in the
- * (geda core object) module.
+ * (lepton core object) module.
  *
  * \param obj_s the picture object to inspect.
  * \return a list of picture object parameters.
@@ -2145,7 +2145,7 @@ SCM_DEFINE (picture_info, "%picture-info", 1, 0, 0,
  * Sets the parameters of the picture object \a obj_s.
  *
  * \note Scheme API: Implements the %set-picture! procedure in the
- * (geda core object) module.
+ * (lepton core object) module.
  *
  * \param obj_s       the picture object to modify
  * \param x1_s  the new x-coordinate of the top left of the picture.
@@ -2208,7 +2208,7 @@ SCM_DEFINE (set_picture_x, "%set-picture!", 7, 0, 0,
  * format.
  *
  * \note Scheme API: Implements the %set-picture-data/vector!
- * procedure in the (geda core object) module.
+ * procedure in the (lepton core object) module.
  *
  * \param obj_s       The picture object to modify.
  * \param data_s      Vector containing encoded image data.
@@ -2276,7 +2276,7 @@ SCM_DEFINE (set_picture_data_vector_x, "%set-picture-data/vector!",
  * y-axis.
  *
  * \note Scheme API: Implements the %translate-object! procedure of the
- * (geda core object) module.
+ * (lepton core object) module.
  *
  * \param obj_s  #OBJECT smob for object to translate.
  * \param dx_s   Integer distance to translate along x-axis.
@@ -2314,7 +2314,7 @@ SCM_DEFINE (translate_object_x, "%translate-object!", 3, 0, 0,
  * multiple of 90 degrees.
  *
  * \note Scheme API: Implements the %rotate-object! procedure of the
- * (geda core object) module.
+ * (lepton core object) module.
  *
  * \param obj_s    #OBJECT smob for object to translate.
  * \param x_s      x-coordinate of centre of rotation.
@@ -2342,8 +2342,8 @@ SCM_DEFINE (rotate_object_x, "%rotate-object!", 4, 0, 0,
   int y = scm_to_int (y_s);
   int angle = scm_to_int (angle_s);
 
-  /* FIXME Work around horribly broken libgeda behaviour.  Some
-   * libgeda functions treat a rotation of -90 degrees as a rotation
+  /* FIXME Work around horribly broken liblepton behaviour.  Some
+   * liblepton functions treat a rotation of -90 degrees as a rotation
    * of +90 degrees, etc., which is not sane. */
   while (angle < 0) angle += 360;
   while (angle >= 360) angle -= 360;
@@ -2363,7 +2363,7 @@ SCM_DEFINE (rotate_object_x, "%rotate-object!", 4, 0, 0,
  * Mirrors \a obj_s in the line x = \a x_s.
  *
  * \note Scheme API: Implements the %mirror-object! procedure of the
- * (geda core object) module.
+ * (lepton core object) module.
  *
  * \param obj_s    #OBJECT smob for object to translate.
  * \param x_s      x-coordinate of centre of rotation.
@@ -2392,13 +2392,13 @@ SCM_DEFINE (mirror_object_x, "%mirror-object!", 2, 0, 0,
 }
 
 /*!
- * \brief Create the (geda core object) Scheme module.
+ * \brief Create the (lepton core object) Scheme module.
  * \par Function Description
- * Defines procedures in the (geda core object) module. The module can
- * be accessed using (use-modules (geda core object)).
+ * Defines procedures in the (lepton core object) module. The module can
+ * be accessed using (use-modules (lepton core object)).
  */
 static void
-init_module_geda_core_object (void *unused)
+init_module_lepton_core_object (void *unused)
 {
   /* Register the functions and symbols */
   #include "scheme_object.x"
@@ -2455,7 +2455,7 @@ init_module_geda_core_object (void *unused)
 }
 
 /*!
- * \brief Initialise the basic gEDA object manipulation procedures.
+ * \brief Initialise the basic Lepton EDA object manipulation procedures.
  * \par Function Description
  * Registers some Scheme procedures for working with #OBJECT
  * smobs. Should only be called by edascm_init().
@@ -2463,8 +2463,8 @@ init_module_geda_core_object (void *unused)
 void
 edascm_init_object ()
 {
-  /* Define the (geda core object) module */
-  scm_c_define_module ("geda core object",
-                       (void (*) (void*)) init_module_geda_core_object,
+  /* Define the (lepton core object) module */
+  scm_c_define_module ("lepton core object",
+                       (void (*) (void*)) init_module_lepton_core_object,
                        NULL);
 }

--- a/liblepton/src/scheme_os.c
+++ b/liblepton/src/scheme_os.c
@@ -1,7 +1,7 @@
-/* gEDA - GPL Electronic Design Automation
- * libgeda - gEDA's library
- * Copyright (C) 1998-2010 gEDA Contributors (see ChangeLog for details)
+/* Lepton EDA library -- Scheme API
+ * Copyright (C) 1998-2016 gEDA Contributors
  * Copyright (C) 2016 Peter Brett <peter@peter-b.co.uk>
+ * Copyright (C) 2017-2020 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -76,7 +76,7 @@ SCM_DEFINE (platform, "%platform", 0, 0, 0, (),
  * Returns a list of directories to be searched for system data.
  *
  * \note Scheme API: Implements the %sys-data-dirs procedure in the
- * (geda core os) module.
+ * (lepton core os) module.
  *
  * \return a Scheme list of strings.
  */
@@ -100,7 +100,7 @@ SCM_DEFINE (sys_data_dirs, "%sys-data-dirs", 0, 0, 0, (),
  * configuration information.
  *
  * \note Scheme API: Implements the %sys-config-dirs procedure in the
- * (geda core os) module.
+ * (lepton core os) module.
  *
  * \return a Scheme list of strings.
  */
@@ -123,7 +123,7 @@ SCM_DEFINE (sys_config_dirs, "%sys-config-dirs", 0, 0, 0, (),
  * Returns the directory where per-user data should be stored
  *
  * \note Scheme API: Implements the %user-data-dir procedure is the
- * (geda core os) module.
+ * (lepton core os) module.
  *
  * \return a string.
  */
@@ -141,7 +141,7 @@ SCM_DEFINE (user_data_dir, "%user-data-dir", 0, 0, 0, (),
  * should be stored
  *
  * \note Scheme API: Implements the %user-config-dir procedure is the
- * (geda core os) module.
+ * (lepton core os) module.
  *
  * \return a string.
  */
@@ -159,7 +159,7 @@ SCM_DEFINE (user_config_dir, "%user-config-dir", 0, 0, 0, (),
  * stored
  *
  * \note Scheme API: Implements the %user-cache-dir procedure is the
- * (geda core os) module.
+ * (lepton core os) module.
  *
  * \return a string.
  */
@@ -173,13 +173,13 @@ SCM_DEFINE (user_cache_dir, "%user-cache-dir", 0, 0, 0, (),
 
 
 /*!
- * \brief Create the (geda core os) Scheme module.
+ * \brief Create the (lepton core os) Scheme module.
  * \par Function Description
- * Defines procedures in the (geda core os) module. The module can
- * be accessed using (use-modules (geda core os)).
+ * Defines procedures in the (lepton core os) module. The module can
+ * be accessed using (use-modules (lepton core os)).
  */
 static void
-init_module_geda_core_os (void *unused)
+init_module_lepton_core_os (void *unused)
 {
   /* Register the functions and symbols */
   #include "scheme_os.x"
@@ -204,8 +204,8 @@ init_module_geda_core_os (void *unused)
 void
 edascm_init_os ()
 {
-  /* Define the (geda core os) module */
-  scm_c_define_module ("geda core os",
-                       (void (*)(void*)) init_module_geda_core_os,
+  /* Define the (lepton core os) module */
+  scm_c_define_module ("lepton core os",
+                       (void (*)(void*)) init_module_lepton_core_os,
                        NULL);
 }

--- a/liblepton/src/scheme_page.c
+++ b/liblepton/src/scheme_page.c
@@ -1,6 +1,7 @@
-/* gEDA - GPL Electronic Design Automation
- * libgeda - gEDA's library - Scheme API
+/* Lepton EDA library - Scheme API
  * Copyright (C) 2010 Peter Brett <peter@peter-b.co.uk>
+ * Copyright (C) 2010-2016 gEDA Contributors
+ * Copyright (C) 2017-2020 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -34,7 +35,7 @@ SCM_SYMBOL (edascm_string_format_sym , "string-format");
  * Retrieves a Scheme list of currently-opened pages.
  *
  * \note Scheme API: Implements the %active-pages procedure of the
- * (geda core page) module.
+ * (lepton core page) module.
  *
  * \return a Scheme list of #PAGE smobs.
  */
@@ -62,8 +63,8 @@ SCM_DEFINE (active_pages, "%active-pages", 0, 0, 0,
  * filename \a filename_s. Note that this does not check that a file
  * exists with that name, or attempt to load any data from it.
  *
- * \note Scheme API: Implements the %new-page procedure of the (geda
- * core page) module.
+ * \note Scheme API: Implements the %new-page procedure of the
+ * (lepton core page) module.
  *
  * \return a newly-created #PAGE smob.
  */
@@ -92,8 +93,8 @@ SCM_DEFINE (new_page, "%new-page", 1, 0, 0,
  * resources.  Attempting to use \a page_s after calling this function
  * will cause an error.
  *
- * \note Scheme API: Implements the %close-page procedure of the (geda
- * core page) module.
+ * \note Scheme API: Implements the %close-page procedure of the
+ * (lepton core page) module.
  *
  * \param page_s The page to close.
  * \return SCM_UNDEFINED.
@@ -118,7 +119,7 @@ SCM_DEFINE (close_page_x, "%close-page!", 1, 0, 0,
  * Retrieves the filename associated with the #PAGE smob \a page_s.
  *
  * \note Scheme API: Implements the %page-filename procedure of the
- * (geda core page) module.
+ * (lepton core page) module.
  *
  * \return a Scheme string containing the page filename.
  */
@@ -141,7 +142,7 @@ SCM_DEFINE (page_filename, "%page-filename", 1, 0, 0,
  * Sets the filename associated with the #PAGE smob \a page_s.
  *
  * \note Scheme API: Implements the %set-page-filename! procedure of
- * the (geda core page) module.
+ * the (lepton core page) module.
  *
  * \param page_s page to set filename for.
  * \param filename_s new filename for \a page.
@@ -169,7 +170,7 @@ SCM_DEFINE (set_page_filename_x, "%set-page-filename!", 2, 0, 0,
  * list of #OBJECT smobs.
  *
  * \note Scheme API: Implements the %page-contents procedure of the
- * (geda core page) module.
+ * (lepton core page) module.
  *
  * \return a list of #OBJECT smobs.
  */
@@ -193,7 +194,7 @@ SCM_DEFINE (page_contents, "%page-contents", 1, 0, 0,
  * does not belong to a #PAGE, returns SCM_BOOL_F.
  *
  * \note Scheme API: Implements the %object-page procedure in the
- * (geda core page) module.
+ * (lepton core page) module.
  *
  * \param [in] obj_s an #OBJECT smob.
  * \return a #PAGE smob or SCM_BOOL_F.
@@ -221,7 +222,7 @@ SCM_DEFINE (object_page, "%object-page", 1, 0, 0,
  * #PAGE or to a complex #OBJECT, throws a Scheme error.
  *
  * \note Scheme API: Implements the %page-append! procedure of the
- * (geda core page) module.
+ * (lepton core page) module.
  *
  * \return \a page_s.
  */
@@ -266,7 +267,7 @@ SCM_DEFINE (page_append_x, "%page-append!", 2, 0, 0,
  * Scheme error. If \a obj_s is not attached to a page, does nothing.
  *
  * \note Scheme API: Implements the %page-remove! procedure of the
- * (geda core page) module.
+ * (lepton core page) module.
  *
  * \return \a page_s.
  */
@@ -326,7 +327,7 @@ SCM_DEFINE (page_remove_x, "%page-remove!", 2, 0, 0,
  * modified.
  *
  * \note Scheme API: Implements the %page-dirty? procedure of the
- * (geda core page) module.
+ * (lepton core page) module.
  *
  * \param page_s page to inspect.
  * \return SCM_BOOL_T if page is dirtied, otherwise SCM_BOOL_F.
@@ -348,7 +349,7 @@ SCM_DEFINE (page_dirty, "%page-dirty?", 1, 0, 0,
  * Otherwise, clears the change flag.
  *
  * \note Scheme API: Implements the %set-page-dirty! procedure of the
- * (geda core page) module.
+ * (lepton core page) module.
  *
  * \param page_s page to modify.
  * \param flag_s new flag setting.
@@ -372,7 +373,7 @@ SCM_DEFINE (set_page_dirty_x, "%set-page-dirty!", 2, 0, 0,
  * Returns a string representation of the contents of \a page_s.
  *
  * \note Scheme API: Implements the %page->string procedure of the
- * (geda core page) module.
+ * (lepton core page) module.
  *
  * \param page_s page to convert to a string.
  * \return a string representation of \a page_s.
@@ -402,7 +403,7 @@ SCM_DEFINE (page_to_string, "%page->string", 1, 0, 0,
  * format syntax.
  *
  * \note Scheme API: Implements the %string->page procedure of the
- * (geda core page) module.
+ * (lepton core page) module.
  *
  * \param filename_s Filename for new page.
  * \param str_s      String to parse to create page.
@@ -444,13 +445,13 @@ SCM_DEFINE (string_to_page, "%string->page", 2, 0, 0,
 }
 
 /*!
- * \brief Create the (geda core page) Scheme module.
+ * \brief Create the (lepton core page) Scheme module.
  * \par Function Description
- * Defines procedures in the (geda core page) module. The module can
- * be accessed using (use-modules (geda core page)).
+ * Defines procedures in the (lepton core page) module. The module can
+ * be accessed using (use-modules (lepton core page)).
  */
 static void
-init_module_geda_core_page (void *unused)
+init_module_lepton_core_page (void *unused)
 {
   /* Register the functions */
   #include "scheme_page.x"
@@ -464,7 +465,7 @@ init_module_geda_core_page (void *unused)
 }
 
 /*!
- * \brief Initialise the basic gEDA page manipulation procedures.
+ * \brief Initialise the basic Lepton EDA page manipulation procedures.
  * \par Function Description
  * Registers some Scheme procedures for working with #PAGE
  * smobs. Should only be called by edascm_init().
@@ -472,8 +473,8 @@ init_module_geda_core_page (void *unused)
 void
 edascm_init_page ()
 {
-  /* Define the (geda core page) module */
-  scm_c_define_module ("geda core page",
-                       (void (*)(void*)) init_module_geda_core_page,
+  /* Define the (lepton core page) module */
+  scm_c_define_module ("lepton core page",
+                       (void (*)(void*)) init_module_lepton_core_page,
                        NULL);
 }

--- a/liblepton/src/scheme_smob.c
+++ b/liblepton/src/scheme_smob.c
@@ -1,6 +1,7 @@
-/* gEDA - GPL Electronic Design Automation
- * libgeda - gEDA's library - Scheme API
+/* Lepton EDA library - Scheme API
  * Copyright (C) 2010-2013, 2016 Peter Brett <peter@peter-b.co.uk>
+ * Copyright (C) 2010-2016 Lepton EDA Contributors
+ * Copyright (C) 2017-2020 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -19,11 +20,11 @@
 
 /*!
  * \file scheme_smob.c
- * \brief Scheme representations of gEDA C structures
+ * \brief Scheme representations of Lepton EDA C structures
  *
- * In order for Scheme code to be able to manipulate libgeda data
+ * In order for Scheme code to be able to manipulate liblepton data
  * structures, it is convenient for it to be able to get handles to
- * several of the different C structures that libgeda uses, in
+ * several of the different C structures that liblepton uses, in
  * particular #TOPLEVEL, #PAGE and #OBJECT.
  *
  * A particular issue is that, in principle, Guile can stash a
@@ -61,8 +62,8 @@
  *
  * \sa weakref.c
  *
- * This file also provides support for a variety of GObject-based gEDA
- * types, including EdaConfig instances.
+ * This file also provides support for a variety of GObject-based
+ * Lepton EDA types, including EdaConfig instances.
  */
 
 #include <config.h>
@@ -209,9 +210,9 @@ smob_cache_contains (void *target)
   return result;
 }
 
-/*! \brief Weak reference notify function for gEDA smobs.
+/*! \brief Weak reference notify function for Lepton EDA smobs.
  * \par Function Description
- * Clears a gEDA smob's pointer when the target object is destroyed.
+ * Clears a Lepton EDA smob's pointer when the target object is destroyed.
  */
 static void
 smob_weakref_notify (void *target, void *smob) {
@@ -220,10 +221,10 @@ smob_weakref_notify (void *target, void *smob) {
   smob_cache_remove (target);
 }
 
-/*! \brief Weak reference notify function for double-length gEDA smobs.
+/*! \brief Weak reference notify function for double-length Lepton EDA smobs.
  * \par Function Description
- * Clears a gEDA smob's second pointer when the target object is
- * destroyed.
+ * Clears a Lepton EDA smob's second pointer when the target
+ * object is destroyed.
  *
  * \see edascm_from_object().
  */
@@ -235,9 +236,9 @@ smob_weakref2_notify (void *target, void *smob) {
   smob_cache_remove (target);
 }
 
-/*! \brief Free a gEDA smob.
+/*! \brief Free a Lepton EDA smob.
  * \par Function Description
- * Finalizes a gEDA smob for deletion, removing the weak reference.
+ * Finalizes a Lepton EDA smob for deletion, removing the weak reference.
  *
  * Used internally to Guile.
  */
@@ -315,11 +316,11 @@ smob_free (SCM smob)
   return 0;
 }
 
-/*! \brief Print a representation of a gEDA smob.
+/*! \brief Print a representation of a Lepton EDA smob.
  * \par Function Description
- * Outputs a string representing the gEDA \a smob to a Scheme output
+ * Outputs a string representing the Lepton EDA \a smob to a Scheme output
  * \a port. The format used is "#<geda-TYPE b7ef65d0>", where TYPE is
- * a string describing the C structure represented by the gEDA smob.
+ * a string describing the C structure represented by the Lepton EDA smob.
  *
  * Used internally to Guile.
  */
@@ -367,9 +368,9 @@ smob_print (SCM smob, SCM port, scm_print_state *pstate)
   return 1;
 }
 
-/*! \brief Check gEDA smobs for equality.
+/*! \brief Check Lepton EDA smobs for equality.
  * \par Function description
- * Returns SCM_BOOL_T if \a obj1 represents the same gEDA structure as
+ * Returns SCM_BOOL_T if \a obj1 represents the same Lepton EDA structure as
  * \a obj2 does. Otherwise, returns SCM_BOOL_F.
  *
  * Used internally to Guile.
@@ -593,7 +594,7 @@ edascm_from_closure (SCM (*func)(SCM, gpointer), gpointer user_data)
   return smob;
 }
 
-/*! \brief Set whether a gEDA object may be garbage collected.
+/*! \brief Set whether a Lepton EDA object may be garbage collected.
  * \ingroup guile_c_iface
  * \par Function Description
  * If \a gc is non-zero, allow the structure represented by \a smob to
@@ -672,8 +673,8 @@ edascm_is_config (SCM smob)
  * If \a page_smob is a #PAGE instance, returns \b SCM_BOOL_T;
  * otherwise returns \b SCM_BOOL_F.
  *
- * \note Scheme API: Implements the %page? procedure in the (geda
- * core smob) module.
+ * \note Scheme API: Implements the %page? procedure in the
+ * (lepton core smob) module.
  *
  * \param [in] page_smob Guile value to test.
  *
@@ -681,7 +682,7 @@ edascm_is_config (SCM smob)
  */
 SCM_DEFINE (page_p, "%page?", 1, 0, 0,
             (SCM page_smob),
-            "Test whether the value is a gEDA PAGE instance.")
+            "Test whether the value is a Lepton EDA PAGE instance.")
 {
   return (EDASCM_PAGEP (page_smob) ? SCM_BOOL_T : SCM_BOOL_F);
 }
@@ -691,8 +692,8 @@ SCM_DEFINE (page_p, "%page?", 1, 0, 0,
  * If \a object_smob is an #OBJECT instance, returns \b SCM_BOOL_T;
  * otherwise returns \b SCM_BOOL_F.
  *
- * \note Scheme API: Implements the %object? procedure in the (geda
- * core smob) module.
+ * \note Scheme API: Implements the %object? procedure in the
+ * (lepton core smob) module.
  *
  * \param [in] object_smob Guile value to test.
  *
@@ -700,7 +701,7 @@ SCM_DEFINE (page_p, "%page?", 1, 0, 0,
  */
 SCM_DEFINE (object_p, "%object?", 1, 0, 0,
             (SCM object_smob),
-            "Test whether the value is a gEDA OBJECT instance.")
+            "Test whether the value is a Lepton EDA OBJECT instance.")
 {
   return (EDASCM_OBJECTP (object_smob) ? SCM_BOOL_T : SCM_BOOL_F);
 }
@@ -710,8 +711,8 @@ SCM_DEFINE (object_p, "%object?", 1, 0, 0,
  * If \a config_smob is a configuration context, returns \b
  * SCM_BOOL_T; otherwise returns \b SCM_BOOL_F.
  *
- * \note Scheme API: Implements the %config? procedure in the (geda
- * core smob) module.
+ * \note Scheme API: Implements the %config? procedure in the
+ * (lepton core smob) module.
  *
  * \param [in] config_smob Guile value to test.
  *
@@ -719,19 +720,19 @@ SCM_DEFINE (object_p, "%object?", 1, 0, 0,
  */
 SCM_DEFINE (config_p, "%config?", 1, 0, 0,
             (SCM config_smob),
-            "Test whether the value is a gEDA configuration context.")
+            "Test whether the value is a Lepton EDA configuration context.")
 {
   return (EDASCM_CONFIGP (config_smob) ? SCM_BOOL_T : SCM_BOOL_F);
 }
 
 /*!
- * \brief Create the (geda core smob) Scheme module.
+ * \brief Create the (lepton core smob) Scheme module.
  * \par Function Description
- * Defines procedures in the (geda core smob) module. The module can
- * be accessed using (use-modules (geda core smob)).
+ * Defines procedures in the (lepton core smob) module. The module can
+ * be accessed using (use-modules (lepton core smob)).
  */
 static void
-init_module_geda_core_smob (void *unused)
+init_module_lepton_core_smob (void *unused)
 {
   /* Register the functions. */
   #include "scheme_smob.x"
@@ -741,13 +742,13 @@ init_module_geda_core_smob (void *unused)
 }
 
 /*!
- * \brief Initialise the basic gEDA smob types.
+ * \brief Initialise the basic Lepton EDA smob types.
  * \par Function Description
- * Registers the gEDA core smob types and some procedures acting on
- * them.  gEDA only uses a single Guile smob, and uses the flags field
- * to multiplex the several different underlying C structures that may
- * be represented by that smob. Should only be called by
- * edascm_init().
+ * Registers the Lepton EDA core smob types and some procedures
+ * acting on them.  Lepton EDA only uses a single Guile smob, and
+ * uses the flags field to multiplex the several different
+ * underlying C structures that may be represented by that
+ * smob. Should only be called by edascm_init().
  */
 void
 edascm_init_smob ()
@@ -755,14 +756,14 @@ edascm_init_smob ()
   /* Initialize smob cache */
   smob_cache_init ();
 
-  /* Register gEDA smob type */
+  /* Register Lepton EDA smob type */
   geda_smob_tag = scm_make_smob_type ("geda", 0);
   scm_set_smob_free (geda_smob_tag, smob_free);
   scm_set_smob_print (geda_smob_tag, smob_print);
   scm_set_smob_equalp (geda_smob_tag, smob_equalp);
 
-  /* Define the (geda core smob) module */
-  scm_c_define_module ("geda core smob",
-                       (void (*)(void*)) init_module_geda_core_smob,
+  /* Define the (lepton core smob) module */
+  scm_c_define_module ("lepton core smob",
+                       (void (*)(void*)) init_module_lepton_core_smob,
                        NULL);
 }

--- a/liblepton/src/scheme_toplevel.c
+++ b/liblepton/src/scheme_toplevel.c
@@ -1,6 +1,6 @@
 /* Lepton EDA library - Scheme API
  * Copyright (C) 2010-2012 Peter Brett <peter@peter-b.co.uk>
- * Copyright (C) 2017-2019 Lepton EDA Contributors
+ * Copyright (C) 2017-2020 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -130,13 +130,13 @@ edascm_c_with_toplevel (TOPLEVEL *toplevel, SCM (*func)(void *),
 }
 
 /*!
- * \brief Create the (geda core toplevel) Scheme module
+ * \brief Create the (lepton core toplevel) Scheme module
  * \par Function Description
- * Defines procedures in the (geda core toplevel) module. The module
- * can be accessed using (use-modules (geda core toplevel)).
+ * Defines procedures in the (lepton core toplevel) module. The module
+ * can be accessed using (use-modules (lepton core toplevel)).
  */
 static void
-init_module_geda_core_toplevel (void *unused)
+init_module_lepton_core_toplevel (void *unused)
 {
   /* Register the functions */
   #include "scheme_toplevel.x"
@@ -160,8 +160,8 @@ edascm_init_toplevel ()
 {
   scheme_toplevel_fluid = scm_permanent_object (scm_make_fluid ());
 
-  /* Define the (geda core toplevel) module */
-  scm_c_define_module ("geda core toplevel",
-                       (void (*)(void*)) init_module_geda_core_toplevel,
+  /* Define the (lepton core toplevel) module */
+  scm_c_define_module ("lepton core toplevel",
+                       (void (*)(void*)) init_module_lepton_core_toplevel,
                        NULL);
 }

--- a/netlist/scheme/lepton-netlist.in
+++ b/netlist/scheme/lepton-netlist.in
@@ -70,7 +70,7 @@ exec @GUILE@ -s "$0" "$@"
 ;;; Using of primitive-eval() here avoids Scheme errors when this
 ;;; program is compiled by Guile. The following modules are
 ;;; necessary to actually run the code below.
-(primitive-eval '(use-modules (geda core toplevel)
+(primitive-eval '(use-modules (lepton core toplevel)
                               (geda deprecated)
                               (lepton library)
                               (lepton log)

--- a/netlist/scheme/unit-test.scm
+++ b/netlist/scheme/unit-test.scm
@@ -75,8 +75,8 @@
 
 
 (load-extension "../../liblepton/src/liblepton" "liblepton_init")
-(define with-toplevel (@@ (geda core toplevel) %with-toplevel))
-(define make-toplevel (@@ (geda core toplevel) %make-toplevel))
+(define with-toplevel (@@ (lepton core toplevel) %with-toplevel))
+(define make-toplevel (@@ (lepton core toplevel) %make-toplevel))
 
 
 (define (report s port)

--- a/schematic/scheme/schematic/attrib.scm
+++ b/schematic/scheme/schematic/attrib.scm
@@ -20,7 +20,7 @@
 
 (define-module (schematic attrib)
 
-  #:use-module (gschem core attrib))
+  #:use-module (schematic core attrib))
 
 ;; add-attrib! target name value visible attribute-mode
 ;;

--- a/schematic/scheme/schematic/builtins.scm
+++ b/schematic/scheme/schematic/builtins.scm
@@ -26,9 +26,9 @@
   #:use-module (lepton object)
   #:use-module (lepton page)
   #:use-module (lepton repl)
-  #:use-module (gschem core builtins)
 
   #:use-module (schematic action)
+  #:use-module (schematic core builtins)
   #:use-module (schematic core gettext)
   #:use-module (schematic gschemdoc)
   #:use-module (schematic hook)

--- a/schematic/scheme/schematic/gui/keymap.scm
+++ b/schematic/scheme/schematic/gui/keymap.scm
@@ -83,12 +83,12 @@
 
 ;; Search the global keymap for a particular symbol and return the
 ;; keys which execute this hotkey, as a string suitable for display to
-;; the user. This is used by the gschem menu system.
+;; the user. This is used by the lepton-schematic menu system.
 (define (find-key action)
   (let ((keys (lookup-binding %global-keymap action)))
     (and keys (keys->display-string keys))))
 
-;; Printing out current key bindings for gEDA (gschem)
+;; Printing out current key bindings for lepton-schematic.
 (define (%gschem-hotkey-store/dump-global-keymap)
   (dump-keymap %global-keymap))
 

--- a/schematic/scheme/schematic/gui/stroke.scm
+++ b/schematic/scheme/schematic/gui/stroke.scm
@@ -1,7 +1,7 @@
 ;;; Lepton EDA Schematic Capture
 ;;; Copyright (C) 1998-2010 Ales Hvezda
 ;;; Copyright (C) 1998-2013 gEDA Contributors
-;;; Copyright (C) 2017-2019 Lepton EDA Contributors
+;;; Copyright (C) 2017-2020 Lepton EDA Contributors
 ;;;
 ;;; This program is free software; you can redistribute it and/or modify
 ;;; it under the terms of the GNU General Public License as published by

--- a/schematic/scheme/schematic/hook.scm
+++ b/schematic/scheme/schematic/hook.scm
@@ -22,7 +22,7 @@
 (define-module (schematic hook)
 
   ;; Import C definitions
-  #:use-module (gschem core hook))
+  #:use-module (schematic core hook))
 
 (define-public add-objects-hook %add-objects-hook)
 

--- a/schematic/scheme/schematic/keymap.scm
+++ b/schematic/scheme/schematic/keymap.scm
@@ -25,9 +25,8 @@
   #:use-module (srfi srfi-1)
   #:use-module (srfi srfi-9)
 
-  #:use-module (gschem core keymap)
-
   #:use-module (schematic core gettext)
+  #:use-module (schematic core keymap)
   #:use-module (schematic hook))
 
 ;; -------------------- Key combinations --------------------

--- a/schematic/scheme/schematic/selection.scm
+++ b/schematic/scheme/schematic/selection.scm
@@ -21,7 +21,7 @@
 (define-module (schematic selection)
 
   ;; Import C procedures
-  #:use-module (gschem core selection))
+  #:use-module (schematic core selection))
 
 (define-public page-selection %page-selection)
 

--- a/schematic/scheme/schematic/symbol/check.scm
+++ b/schematic/scheme/schematic/symbol/check.scm
@@ -19,9 +19,8 @@
 
 (define-module (schematic symbol check)
   #:use-module (srfi srfi-1)
-  #:use-module (geda core toplevel)
+  #:use-module (lepton core toplevel)
   #:use-module (lepton page)
-
   #:use-module (schematic core gettext)
   #:use-module (schematic window)
   #:use-module (symbol blame)

--- a/schematic/scheme/schematic/util.scm
+++ b/schematic/scheme/schematic/util.scm
@@ -20,7 +20,7 @@
 (define-module (schematic util)
 
   ; Import C procedures
-  #:use-module (gschem core util))
+  #:use-module (schematic core util))
 
 (define-public show-uri %show-uri)
 

--- a/schematic/scheme/schematic/window.scm
+++ b/schematic/scheme/schematic/window.scm
@@ -21,7 +21,7 @@
 (define-module (schematic window)
 
   ; Import C procedures
-  #:use-module (gschem core window)
+  #:use-module (schematic core window)
 
   #:use-module (lepton page)
   #:re-export (close-page!))

--- a/schematic/src/g_action.c
+++ b/schematic/src/g_action.c
@@ -1,5 +1,6 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 2013, 2016 Peter Brett <peter@peter-b.co.uk>
+ * Copyright (C) 2017-2020 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -33,7 +34,7 @@ SCM_SYMBOL (quote_sym, "quote");
  * action fails, prints a message to the log and returns FALSE;
  * otherwise, returns TRUE.
  *
- * \param w_current    Current gschem toplevel structure.
+ * \param w_current    Current lepton-schematic toplevel structure.
  * \param action_name  Name of action to evaluate.
  *
  * \return TRUE on success, FALSE on failure.

--- a/schematic/src/g_attrib.c
+++ b/schematic/src/g_attrib.c
@@ -1,5 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 2011 Peter Brett <peter@peter-b.co.uk>
+ * Copyright (C) 2011-2016 gEDA Contributors
+ * Copyright (C) 2017-2020 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -19,7 +21,7 @@
 /*!
  * \file g_attrib.c
  * \brief Scheme API functions for manipulating attributes in
- * gschem-specific ways.
+ * lepton-schematic-specific ways.
  */
 
 #include <config.h>
@@ -41,15 +43,16 @@ SCM_SYMBOL (object_state_sym, "object-state");
  * attribute-formatted string should be shown, and should be one of
  * the symbols "name", "value" or "both".
  *
- * If \a target_s is specified and is a gEDA object, the new attribute
- * will be attached to it. If \a target_s is not in gschem's active
- * page, an "object-state" error will be raised.
+ * If \a target_s is specified and is a gEDA object, the new
+ * attribute will be attached to it. If \a target_s is not in
+ * lepton-schematic's active page, an "object-state" error will be
+ * raised.
  *
  * If \a target_s is #f, the new attribute will be floating in
- * gschem's current active page.
+ * lepton-schematic's current active page.
  *
  * \note Scheme API: Implements the %add-attrib! procedure in the
- * (gschem core attrib) module.
+ * (schematic core attrib) module.
  *
  * \bug This function does not verify that \a name_s is actually a
  * valid attribute name.
@@ -87,7 +90,7 @@ SCM_DEFINE (add_attrib_x, "%add-attrib!", 5, 0, 0,
     if (o_get_page (toplevel, obj) != toplevel->page_current) {
       scm_error (object_state_sym,
                  s_add_attrib_x,
-                 _("Object ~A is not included in the current gschem page."),
+                 _("Object ~A is not included in the current lepton-schematic page."),
                  scm_list_1 (target_s), SCM_EOL);
     }
   }
@@ -133,13 +136,13 @@ SCM_DEFINE (add_attrib_x, "%add-attrib!", 5, 0, 0,
 }
 
 /*!
- * \brief Create the (gschem core attrib) Scheme module.
+ * \brief Create the (schematic core attrib) Scheme module.
  * \par Function Description
- * Defines procedures in the (gschem core attrib) module. The module can
- * be accessed using (use-modules (gschem core attrib)).
+ * Defines procedures in the (schematic core attrib) module. The module can
+ * be accessed using (use-modules (schematic core attrib)).
  */
 static void
-init_module_gschem_core_attrib (void *unused)
+init_module_schematic_core_attrib (void *unused)
 {
   /* Register the functions and symbols */
   #include "g_attrib.x"
@@ -158,8 +161,8 @@ init_module_gschem_core_attrib (void *unused)
 void
 g_init_attrib ()
 {
-  /* Define the (gschem core attrib) module */
-  scm_c_define_module ("gschem core attrib",
-                       (void (*)(void*)) init_module_gschem_core_attrib,
+  /* Define the (schematic core attrib) module */
+  scm_c_define_module ("schematic core attrib",
+                       (void (*)(void*)) init_module_schematic_core_attrib,
                        NULL);
 }

--- a/schematic/src/g_builtins.c
+++ b/schematic/src/g_builtins.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 2013 Peter Brett <peter@peter-b.co.uk>
  * Copyright (C) 2013-2015 gEDA Contributors
- * Copyright (C) 2017-2019 Lepton EDA Contributors
+ * Copyright (C) 2017-2020 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -19,7 +19,7 @@
  */
 
 /*! \file g_builtins.c
- * \brief gschem built-in actions
+ * \brief lepton-schematic built-in actions
  */
 
 #include <config.h>
@@ -156,13 +156,13 @@ static struct BuiltinInfo builtins[] = {
   { NULL, 0, 0, 0, NULL }, /* Custodian */
 };
 
-/*! \brief Create the (gschem core builtins) Scheme module.
+/*! \brief Create the (schematic core builtins) Scheme module.
  * \par Function Description
- * Defines procedures in the (gschem core builtins) module. The module can
- * be accessed using (use-modules (gschem core builtins)).
+ * Defines procedures in the (schematic core builtins) module. The module can
+ * be accessed using (use-modules (schematic core builtins)).
  */
 static void
-init_module_gschem_core_builtins (void *unused)
+init_module_schematic_core_builtins (void *unused)
 {
   int i;
 
@@ -176,18 +176,17 @@ init_module_gschem_core_builtins (void *unused)
 }
 
 /*!
- * \brief Initialise gschem built-in actions.
+ * \brief Initialise lepton-schematic built-in actions.
  * \par Function Description
-
- * Registers the Scheme procedures used to access gschem's built-in
- * editing actions implemented in C.  Should only be called by
- * main_prog().
+ * Registers the Scheme procedures used to access
+ * lepton-schematic's built-in editing actions implemented in C.
+ * Should only be called by main_prog().
  */
 void
 g_init_builtins ()
 {
-  /* Define the (gschem core builtins) module */
-  scm_c_define_module ("gschem core builtins",
-                       (void (*)(void*)) init_module_gschem_core_builtins,
+  /* Define the (schematic core builtins) module */
+  scm_c_define_module ("schematic core builtins",
+                       (void (*)(void*)) init_module_schematic_core_builtins,
                        NULL);
 }

--- a/schematic/src/g_hook.c
+++ b/schematic/src/g_hook.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2016 gEDA Contributors
- * Copyright (C) 2017-2018 Lepton EDA Contributors
+ * Copyright (C) 2017-2020 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -28,7 +28,7 @@
 #include "gschem.h"
 
 SCM_SYMBOL (at_sym, "@");
-SCM_SYMBOL (gschem_sym, "gschem");
+SCM_SYMBOL (schematic_sym, "schematic");
 SCM_SYMBOL (core_sym, "core");
 SCM_SYMBOL (hook_sym, "hook");
 SCM_SYMBOL (run_hook_sym, "run-hook");
@@ -36,17 +36,17 @@ SCM_SYMBOL (list_sym, "list");
 
 /*! \brief Gets a Scheme hook object by name.
  * \par Function Description
- * Returns the contents of variable with the given name in the (gschem
- * core hook).  Used for looking up hook objects.
+ * Returns the contents of variable with the given name in the
+ * (schematic core hook).  Used for looking up hook objects.
  *
  * \param name name of hook to lookup.
- * \return value found in the (gschem core hook) module.
+ * \return value found in the (schematic core hook) module.
  */
 static SCM
 g_get_hook_by_name (const char *name)
 {
   SCM exp = scm_list_3 (at_sym,
-                        scm_list_3 (gschem_sym, core_sym, hook_sym),
+                        scm_list_3 (schematic_sym, core_sym, hook_sym),
                         scm_from_utf8_symbol (name));
   return g_scm_eval_protected (exp, SCM_UNDEFINED);
 }
@@ -172,15 +172,15 @@ g_hook_new_proxy_by_name (const char *name)
   return edascm_hook_proxy_new_with_hook (hook);
 }
 
-/*! \brief Create the (gschem core hook) Scheme module.
+/*! \brief Create the (schematic core hook) Scheme module.
  * \par Function Description
- * Defines some hooks in the (gschem core hook) module.  These hooks
+ * Defines some hooks in the (schematic core hook) module.  These hooks
  * allow Scheme callbacks to be triggered on certain lepton-schematic actions.
  * For a description of the arguments and behaviour of these hooks,
  * please see ../scheme/schematic/hook.scm.
  */
 static void
-init_module_gschem_core_hook (void *unused)
+init_module_schematic_core_hook (void *unused)
 {
 
 #include "g_hook.x"
@@ -212,15 +212,14 @@ init_module_gschem_core_hook (void *unused)
 /*!
  * \brief Initialise the lepton-schematic hooks.
  * \par Function Description
-
- * Registers gschem's Guile hooks for various events.. Should only be
- * called by main_prog().
+ * Registers lepton-schematic's Guile hooks for various
+ * events.. Should only be called by main_prog().
  */
 void
 g_init_hook ()
 {
-  /* Define the (gschem core hook) module */
-  scm_c_define_module ("gschem core hook",
-                       (void (*)(void*)) init_module_gschem_core_hook,
+  /* Define the (schematic core hook) module */
+  scm_c_define_module ("schematic core hook",
+                       (void (*)(void*)) init_module_schematic_core_hook,
                        NULL);
 }

--- a/schematic/src/g_keys.c
+++ b/schematic/src/g_keys.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2015 gEDA Contributors
- * Copyright (C) 2017-2019 Lepton EDA Contributors
+ * Copyright (C) 2017-2020 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -194,7 +194,7 @@ DEFINE_G_KEYS(cancel)
 static scm_t_bits g_key_smob_tag;
 #define G_SCM_IS_KEY(x) SCM_SMOB_PREDICATE (g_key_smob_tag, (x))
 
-/*! Type for keybindings. Used internally by gschem key smobs. */
+/*! Type for keybindings. Used internally by lepton-schematic key smobs. */
 typedef struct {
   guint keyval;
   GdkModifierType modifiers;
@@ -246,9 +246,9 @@ g_key_is_valid (guint keyval, GdkModifierType modifiers)
 
 /*! \brief Create a new bindable key object.
  * \par Function Description
- * Create and return a new gschem key object from a \a keyval and a
- * set of \a modifiers.  If the key combination is invalid, return
- * SCM_BOOL_F.
+ * Create and return a new lepton-schematic key object from a \a
+ * keyval and a set of \a modifiers.  If the key combination is
+ * invalid, return SCM_BOOL_F.
  *
  * \param keyval     the pressed key.
  * \param modifiers  the active modifiers for the key.
@@ -270,17 +270,17 @@ g_make_key (guint keyval, GdkModifierType modifiers)
 
 /*! \brief Test if a Scheme value is a bindable key object.
  * \par Function Description
- * Returns SCM_BOOL_T if \a key_s is a gschem key object.  Otherwise,
- * returns SCM_BOOL_F.
+ * Returns SCM_BOOL_T if \a key_s is a lepton-schematic key
+ * object.  Otherwise, returns SCM_BOOL_F.
  *
  * \note Scheme API: Implements the %key? procedure in the
- * (gschem core keymap) module.
+ * (schematic core keymap) module.
  *
  * \param key_s          value to test
  * \return SCM_BOOL_T iff value is a key, otherwise SCM_BOOL_F.
  */
 SCM_DEFINE (g_keyp, "%key?", 1, 0, 0, (SCM key_s),
-            "Test if value is a gschem key.")
+            "Test if value is a lepton-schematic key.")
 {
   if (G_SCM_IS_KEY (key_s)) {
     return SCM_BOOL_T;
@@ -291,18 +291,19 @@ SCM_DEFINE (g_keyp, "%key?", 1, 0, 0, (SCM key_s),
 
 /*! \brief Create a bindable key object from a string.
  * \par Function Description
- * Parse the string key description \a str_s to create and return a
- * new gschem key object.  If \a str_s contains syntax errors, or does
- * not represent a valid bindable key combination, returns SCM_BOOL_F.
+ * Parse the string key description \a str_s to create and return
+ * a new lepton-schematic key object.  If \a str_s contains syntax
+ * errors, or does not represent a valid bindable key combination,
+ * returns SCM_BOOL_F.
  *
  * \note Scheme API: Implements the %string-key procedure in the
- * (gschem core keymap) module.
+ * (schematic core keymap) module.
  *
  * \param str_s  string to parse.
- * \return a new gschem key object, or SCM_BOOL_F.
+ * \return a new lepton-schematic key object, or SCM_BOOL_F.
  */
 SCM_DEFINE (g_string_to_key, "%string->key", 1, 0, 0, (SCM str_s),
-            "Create a gschem key by parsing a string.")
+            "Create a lepton-schematic key by parsing a string.")
 {
   SCM_ASSERT (scm_is_string (str_s), str_s, SCM_ARG1, s_g_string_to_key);
 
@@ -316,17 +317,18 @@ SCM_DEFINE (g_string_to_key, "%string->key", 1, 0, 0, (SCM str_s),
 
 /*! \brief Convert a bindable key object to a string.
  * \par Function Description
- * Returns a string representation of the gschem key object \a key_s,
- * in a format suitable for parsing with %string->key.
+ * Returns a string representation of the lepton-schematic key
+ * object \a key_s, in a format suitable for parsing with
+ * %string->key.
  *
  * \note Scheme API: Implements the %key->string procedure in the
- * (gschem core keymap) module.
+ * (schematic core keymap) module.
  *
  * \param key_s  Bindable key object to convert to string.
  * \return a string representation of the key combination.
  */
 SCM_DEFINE (g_key_to_string, "%key->string", 1, 0, 0, (SCM key_s),
-            "Create a string from a gschem key.")
+            "Create a string from a lepton-schematic key.")
 {
   SCM_ASSERT (G_SCM_IS_KEY (key_s), key_s, SCM_ARG1, s_g_key_to_string);
 
@@ -339,18 +341,18 @@ SCM_DEFINE (g_key_to_string, "%key->string", 1, 0, 0, (SCM key_s),
 
 /*! \brief Convert a bindable key object to a displayable string.
  * \par Function Description
- * Returns a string representation of the gschem key object \a key_s,
- * in a format suitable for display to the user (e.g. as accelerator
- * text in a menu).
+ * Returns a string representation of the lepton-schematic key
+ * object \a key_s, in a format suitable for display to the user
+ * (e.g. as accelerator text in a menu).
  *
  * \note Scheme API: Implements the %key->display-string procedure in
- * the (gschem core keymap) module.
+ * the (schematic core keymap) module.
  *
  * \param key_s  Bindable key object to convert to string.
  * \return a string representation of the key combination.
  */
 SCM_DEFINE (g_key_to_display_string, "%key->display-string", 1, 0, 0,
-            (SCM key_s), "Create a display string from a gschem key.")
+            (SCM key_s), "Create a display string from a lepton-schematic key.")
 {
   SCM_ASSERT (G_SCM_IS_KEY (key_s), key_s, SCM_ARG1,
               s_g_key_to_display_string);
@@ -382,8 +384,8 @@ g_key_print (SCM smob, SCM port, scm_print_state *pstate)
 
 /* \brief Test if two key combinations are equivalent.
  * \par Function Description
- * Tests if the two gschem key objects \a a and \a b represent the
- * same key event.
+ * Tests if the two lepton-schematic key objects \a a and \a b
+ * represent the same key event.
  *
  * Used internally to Guile.
  */
@@ -399,7 +401,8 @@ g_key_equalp (SCM a, SCM b)
 
 /* \brief Destroy a bindable key object
  * \par Function Description
- * Destroys the contents of a gschem key object on garbage collection.
+ * Destroys the contents of a lepton-schematic key object on
+ * garbage collection.
  *
  * Used internally to Guile.
  */
@@ -469,8 +472,8 @@ g_keys_reset (GschemToplevel *w_current)
 /*! \brief Evaluate a user keystroke.
  * \par Function Description
  * Evaluates the key combination specified by \a event using the
- * current keymap.  Updates the gschem status bar with the current key
- * sequence.
+ * current keymap.  Updates the lepton-schematic status bar with
+ * the current key sequence.
  *
  * \param w_current  The active #GschemToplevel context.
  * \param event      A GdkEventKey structure.
@@ -575,13 +578,13 @@ g_keys_execute(GschemToplevel *w_current, GdkEventKey *event)
   return !scm_is_false (s_retval);
 }
 
-/*! \brief Create the (gschem core keymap) Scheme module
+/*! \brief Create the (schematic core keymap) Scheme module
  * \par Function Description
- * Defines procedures in the (gschem core keymap) module.  The module
- * can be accessed using (use-modules (gschem core keymap)).
+ * Defines procedures in the (schematic core keymap) module.  The module
+ * can be accessed using (use-modules (schematic core keymap)).
  */
 static void
-init_module_gschem_core_keymap (void *unused)
+init_module_schematic_core_keymap (void *unused)
 {
   /* Register the functions */
   #include "g_keys.x"
@@ -605,8 +608,8 @@ g_init_keys ()
   scm_set_smob_equalp (g_key_smob_tag, g_key_equalp);
   scm_set_smob_free (g_key_smob_tag, g_key_free);
 
-  scm_c_define_module ("gschem core keymap",
-                       (void (*)(void*)) init_module_gschem_core_keymap,
+  scm_c_define_module ("schematic core keymap",
+                       (void (*)(void*)) init_module_schematic_core_keymap,
                        NULL);
 }
 

--- a/schematic/src/g_select.c
+++ b/schematic/src/g_select.c
@@ -1,5 +1,6 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 2010 Peter Brett <peter@peter-b.co.uk>
+ * Copyright (C) 2017-2020 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -26,7 +27,7 @@ SCM_SYMBOL (object_state_sym, "object-state");
  * Retrieve a list of selected objects on \a page_s.
  *
  * \note Scheme API: Implements the %page-selection procedure in the
- * (gschem core selection) module.
+ * (schematic core selection) module.
  *
  * \param page_s #PAGE smob for the page from which to get the selection.
  * \return a list of #OBJECT smobs.
@@ -57,7 +58,7 @@ SCM_DEFINE (page_selection, "%page-selection", 1, 0, 0,
  * selected, does nothing.
  *
  * \note Scheme API: Implements the %select-object! procedure in the
- * (gschem core selection) module.
+ * (schematic core selection) module.
  *
  * \param obj_s #OBJECT smob for object to be selected.
  * \return obj_s.
@@ -94,7 +95,7 @@ SCM_DEFINE (select_object_x, "%select-object!", 1, 0, 0,
  * does nothing.
  *
  * \note Scheme API: Implements the %deselect-object! procedure in the
- * (gschem core selection) module.
+ * (schematic core selection) module.
  *
  * \param obj_s #OBJECT smob for object to be deselected.
  * \return obj_s.
@@ -130,7 +131,7 @@ SCM_DEFINE (deselect_object_x, "%deselect-object!", 1, 0, 0,
  * (i.e. not via inclusion in a component), throws a Scheme error.
  *
  * \note Scheme API: Implements the %object-selected? procedure in the
- * (gschem core selection) module.
+ * (schematic core selection) module.
  *
  * \param obj_s #OBJECT smob to be tested.
  * \return SCM_BOOL_T if \a obj_s is selected, otherwise SCM_BOOL_F.
@@ -154,13 +155,13 @@ SCM_DEFINE (object_selected_p, "%object-selected?", 1, 0, 0,
   return (obj->selected ? SCM_BOOL_T : SCM_BOOL_F);
 }
 
-/*! \brief Create the (gschem core selection) Scheme module
+/*! \brief Create the (schematic core selection) Scheme module
  * \par Function Description
- * Defines procedures in the (gschem core selection) module. The module
- * can be accessed using (use-modules (gschem core selection)).
+ * Defines procedures in the (schematic core selection) module. The module
+ * can be accessed using (use-modules (schematic core selection)).
  */
 static void
-init_module_gschem_core_select (void *unused)
+init_module_schematic_core_select (void *unused)
 {
   /* Register the functions */
   #include "g_select.x"
@@ -178,8 +179,8 @@ init_module_gschem_core_select (void *unused)
 void
 g_init_select ()
 {
-  /* Define the (gschem core selection) module */
-  scm_c_define_module ("gschem core selection",
-                       (void (*)(void*)) init_module_gschem_core_select,
+  /* Define the (schematic core selection) module */
+  scm_c_define_module ("schematic core selection",
+                       (void (*)(void*)) init_module_schematic_core_select,
                        NULL);
 }

--- a/schematic/src/g_util.c
+++ b/schematic/src/g_util.c
@@ -1,5 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 2011 Peter Brett <peter@peter-b.co.uk>
+ * Copyright (C) 2011-2015 gEDA Contributors
+ * Copyright (C) 2017-2020 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -29,8 +31,8 @@
  * Launches the default application associated with \a uri_s on the
  * host platform.  Raises an error on failure.
  *
- * \note Scheme API: Implements the %show-uri procedure in the (gschem
- * core util) module.
+ * \note Scheme API: Implements the %show-uri procedure in the
+ * (schematic core util) module.
  *
  * \sa x_show_uri().
  *
@@ -59,13 +61,13 @@ SCM_DEFINE (show_uri, "%show-uri", 1, 0, 0, (SCM uri_s),
   return SCM_UNDEFINED;
 }
 
-/*! \brief Create the (gschem core util) Scheme module.
+/*! \brief Create the (schematic core util) Scheme module.
  * \par Function Description
- * Defines procedures in the (gschem core util) module. The module can
- * be accessed using (use-modules (gschem core util)).
+ * Defines procedures in the (schematic core util) module. The module can
+ * be accessed using (use-modules (schematic core util)).
  */
 static void
-init_module_gschem_core_util (void *unused)
+init_module_schematic_core_util (void *unused)
 {
   /* Register the functions */
   #include "g_util.x"
@@ -85,8 +87,8 @@ init_module_gschem_core_util (void *unused)
 void
 g_init_util ()
 {
-  /* Define the (gschem core util) module */
-  scm_c_define_module ("gschem core util",
-                       (void (*)(void*)) init_module_gschem_core_util,
+  /* Define the (schematic core util) module */
+  scm_c_define_module ("schematic core util",
+                       (void (*)(void*)) init_module_schematic_core_util,
                        NULL);
 }

--- a/schematic/src/g_window.c
+++ b/schematic/src/g_window.c
@@ -153,7 +153,7 @@ g_current_window ()
  * SCM_BOOL_F.
  *
  * \note Scheme API: Implements the %active-page procedure in the
- * (gschem core window) module.
+ * (schematic core window) module.
  *
  * \return the active page.
  */
@@ -175,7 +175,7 @@ SCM_DEFINE (active_page, "%active-page", 0, 0, 0,
  * window to \a page_s.
  *
  * \note Scheme API: Implements the %set-active-page! procedure in the
- * (gschem core window) module.
+ * (schematic core window) module.
  *
  * \param page_s Page to switch to.
  * \return \a page_s.
@@ -197,7 +197,7 @@ SCM_DEFINE (set_active_page_x, "%set-active-page!", 1, 0, 0,
  * Closes the page \a page_s.
  *
  * \note Scheme API: Implements the %close-page! procedure in the
- * (gschem core window) module.  Overrides the %close-page! procedure
+ * (schematic core window) module.  Overrides the %close-page! procedure
  * in the (geda core page) module.
  *
  * \param page_s Page to close.
@@ -241,7 +241,7 @@ SCM_DEFINE (override_close_page_x, "%close-page!", 1, 0, 0,
  * <code>(x . y)</code>
  *
  * \note Scheme API: Implements the %pointer-position procedure in the
- * (gschem core window) module.
+ * (schematic core window) module.
  *
  * \return The current pointer position, or SCM_BOOL_F.
  */
@@ -268,7 +268,7 @@ SCM_DEFINE (pointer_position, "%pointer-position", 0, 0, 0,
  * current user snap settings.
  *
  * \note Scheme API: Implements the %snap-point procedure in the
- * (gschem core window) module.
+ * (schematic core window) module.
  *
  * \param x_s the x-coordinate of the point to be snapped to grid.
  * \param y_s the y-coordinate of the point to be snapped to grid.
@@ -293,13 +293,13 @@ SCM_DEFINE (snap_point, "%snap-point", 2, 0, 0,
 }
 
 /*!
- * \brief Create the (gschem core window) Scheme module
+ * \brief Create the (schematic core window) Scheme module
  * \par Function Description
- * Defines procedures in the (gschem core window) module. The module
- * can be accessed using (use-modules (gschem core window)).
+ * Defines procedures in the (schematic core window) module. The module
+ * can be accessed using (use-modules (schematic core window)).
  */
 static void
-init_module_gschem_core_window (void *unused)
+init_module_schematic_core_window (void *unused)
 {
   /* Register the functions */
   #include "g_window.x"
@@ -337,8 +337,8 @@ g_init_window ()
   /* Create fluid */
   scheme_window_fluid = scm_permanent_object (scm_make_fluid ());
 
-  /* Define the (gschem core window) module */
-  scm_c_define_module ("gschem core window",
-                       (void (*)(void*)) init_module_gschem_core_window,
+  /* Define the (schematic core window) module */
+  scm_c_define_module ("schematic core window",
+                       (void (*)(void*)) init_module_schematic_core_window,
                        NULL);
 }

--- a/schematic/src/g_window.c
+++ b/schematic/src/g_window.c
@@ -198,7 +198,7 @@ SCM_DEFINE (set_active_page_x, "%set-active-page!", 1, 0, 0,
  *
  * \note Scheme API: Implements the %close-page! procedure in the
  * (schematic core window) module.  Overrides the %close-page! procedure
- * in the (geda core page) module.
+ * in the (lepton core page) module.
  *
  * \param page_s Page to close.
  * \return SCM_UNDEFINED
@@ -309,9 +309,9 @@ init_module_schematic_core_window (void *unused)
                 s_override_close_page_x, s_pointer_position,
                 s_snap_point, NULL);
 
-  /* Override procedures in the (geda core page) module */
+  /* Override procedures in the (lepton core page) module */
   {
-    SCM geda_page_module = scm_c_resolve_module ("geda core page");
+    SCM geda_page_module = scm_c_resolve_module ("lepton core page");
     SCM close_page_proc =
       scm_variable_ref (scm_c_lookup (s_override_close_page_x));
     scm_c_module_define (geda_page_module, "%close-page!", close_page_proc);
@@ -329,7 +329,7 @@ init_module_schematic_core_window (void *unused)
 void
 g_init_window ()
 {
-  /* Register gEDA smob type */
+  /* Register Lepton EDA smob type */
   window_smob_tag = scm_make_smob_type ("gschem-window", 0);
   scm_set_smob_free (window_smob_tag, smob_free);
   scm_set_smob_print (window_smob_tag, smob_print);

--- a/schematic/src/gschem_find_text_state.c
+++ b/schematic/src/gschem_find_text_state.c
@@ -1,6 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
- * Copyright (C) 1998-2013 gEDA Contributors (see ChangeLog for details)
+ * Copyright (C) 1998-2016 gEDA Contributors
+ * Copyright (C) 2017-2020 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/schematic/src/x_event.c
+++ b/schematic/src/x_event.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2015 gEDA Contributors
- * Copyright (C) 2017-2019 Lepton EDA Contributors
+ * Copyright (C) 2017-2020 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/symcheck/scheme/lepton-symcheck.in
+++ b/symcheck/scheme/lepton-symcheck.in
@@ -26,8 +26,8 @@ exec @GUILE@ -s "$0" "$@"
 ;;; At compile time of this program guile won't be aware of these
 ;;; modules, since it compiles the code before loading the above
 ;;; extension. Let's make it quiet here.
-(define with-toplevel (@@ (geda core toplevel) %with-toplevel))
-(define make-toplevel (@@ (geda core toplevel) %make-toplevel))
+(define with-toplevel (@@ (lepton core toplevel) %with-toplevel))
+(define make-toplevel (@@ (lepton core toplevel) %make-toplevel))
 
 (primitive-eval '(use-modules (symcheck check)))
 

--- a/utils/scripts/lepton-archive.in
+++ b/utils/scripts/lepton-archive.in
@@ -77,7 +77,7 @@ exec @GUILE@ -s "$0" "$@"
              (srfi srfi-26))
 
 (primitive-eval
- '(use-modules (geda core toplevel)
+ '(use-modules (lepton core toplevel)
                (lepton log)
                (lepton file-system)
                (lepton library)

--- a/utils/scripts/lepton-embed.in
+++ b/utils/scripts/lepton-embed.in
@@ -19,7 +19,7 @@ exec @GUILE@ "$0" "$@"
 ( use-modules ( ice-9 getopt-long ) )
 ( use-modules ( ice-9 format ) )
 
-( primitive-eval '(use-modules (geda core toplevel)) )
+( primitive-eval '(use-modules (lepton core toplevel)) )
 ( primitive-eval '(use-modules (lepton object)) )
 ( primitive-eval '(use-modules (lepton page)) )
 ( primitive-eval '(use-modules (lepton version)) )

--- a/utils/scripts/lepton-tragesym.in
+++ b/utils/scripts/lepton-tragesym.in
@@ -40,7 +40,7 @@ exec @GUILE@ -s "$0" "$@"
 (load-extension (or (getenv "LIBLEPTON") "@libdir@/liblepton")
                 "liblepton_init")
 
-(primitive-eval '(use-modules (geda core toplevel)
+(primitive-eval '(use-modules (lepton core toplevel)
                               (lepton attrib)
                               (lepton object)
                               (lepton page)


### PR DESCRIPTION
- Renamed `(geda *)` and `(gschem *)` core modules.
- Updated NEWS.
- Added missing `(geda object)` tests.

Affects #39.