### PR TITLE
Get rid of a wrong module dependency in the module (netlist attrib refdes).

### DIFF
--- a/netlist/scheme/netlist/attrib/refdes.scm
+++ b/netlist/scheme/netlist/attrib/refdes.scm
@@ -28,7 +28,6 @@
   #:use-module (lepton page)
   #:use-module (netlist config)
   #:use-module (netlist error)
-  #:use-module (netlist hierarchy)
   #:use-module (netlist mode)
 
   #:export (make-refdes


### PR DESCRIPTION
Fix the issue introduced in #546 during refactoring of `lepton-netlist`.  During compilation, it leads to warnings as follows:
```
;;; netlist/subschematic.scm:179:6: warning: possibly unbound variable `make-refdes'
;;; netlist/subschematic.scm:184:25: warning: possibly unbound variable `make-mock-refdes'
;;; netlist/hierarchy.scm:101:35: warning: possibly unbound variable `hierarchical-refdes->string'
```