### PR TITLE
Fix .MODEL line generation in the spice-sdb lepton-netlist backend

### DIFF
--- a/netlist/scheme/backend/gnet-spice-sdb.scm
+++ b/netlist/scheme/backend/gnet-spice-sdb.scm
@@ -351,7 +351,7 @@
 
     ;; Now write out any model which is pointed to by the part.
     (when (not (unknown? model))
-      (format #t ".MODEL ~A ~A (~A)\n" model-name type package-model))))
+      (format #t ".MODEL ~A ~A (~A)\n" model-name type model))))
 
 
 ;;  Writes diode SPICE card for PACKAGE.


### PR DESCRIPTION
For components with the `model-name` and `model`
attributes, incorrect output was generated, for example:
```
model-name = D1N4148
model = IS=0.1P RS=16 CJO=2P TT=12N BV=100 IBV=0.1P
```

Incorrect output:
```
D1 node1 node2 D1N4148
.MODEL D1N4148 D (D1N4148)
```

The correct output should be:
```
D1 node1 node2 D1N4148
.MODEL D1N4148 D (IS=0.1P RS=16 CJO=2P TT=12N BV=100 IBV=0.1P)
```

Closes #557.
