### PR TITLE
Improve the Single Attribute Editor dialog in lepton-schematic

### DIFF
--- a/schematic/src/gschem_about_dialog.c
+++ b/schematic/src/gschem_about_dialog.c
@@ -84,7 +84,7 @@ void about_dialog (GschemToplevel *w_current)
 
   gtk_about_dialog_set_copyright (adlg,
     _("Copyright © 1998-2017 by Ales Hvezda and the respective original authors.\n"
-      "Copyright © 2017-2019 Lepton Developers.\n"
+      "Copyright © 2017-2020 Lepton Developers.\n"
       "See AUTHORS, ChangeLog files and consult 'git log' history for details."));
 
   gtk_about_dialog_set_license (adlg,

--- a/schematic/src/x_attribedit.c
+++ b/schematic/src/x_attribedit.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2016 gEDA Contributors
- * Copyright (C) 2017-2018 Lepton EDA Contributors
+ * Copyright (C) 2017-2020 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -391,6 +391,7 @@ void attrib_edit_dialog (GschemToplevel *w_current, OBJECT *attr_obj, int flag)
   g_object_set_data_full (G_OBJECT (aewindow),
                          "attrib_combo_entry", attrib_combo_entry,
                             (GtkDestroyNotify) g_object_unref);
+  gtk_entry_set_activates_default (GTK_ENTRY (attrib_combo_entry), TRUE);
 
   /* Value entry */
   label = gtk_label_new_with_mnemonic (_("_Value:"));


### PR DESCRIPTION
Now the `Single Attribute Editor` dialog can be
accepted by pressing the `Enter` key while the
input focus is in the `Name` field.
Previously, it can be done only when the `Value`
field is focused.