### PR TITLE
Cleanup netlist examples

### DIFF
--- a/netlist/examples/Makefile.am
+++ b/netlist/examples/Makefile.am
@@ -1,13 +1,8 @@
-## Process this file with automake to produce Makefile.in
-
 SUBDIRS = vams switcap verilog analog
 
 EXTRA_DIST = 7447.sch test_verilog.sch stack_1.sch
 
-MOSTLYCLEANFILES =  core *.log FILE *.ps *~
-CLEANFILES = core *.log FILE *.ps *~
-DISTCLEANFILES = *.log core FILE *~
-MAINTAINERCLEANFILES = core *.log FILE *.ps *~ Makefile.in
+MAINTAINERCLEANFILES = Makefile.in
 
 
 

--- a/netlist/examples/analog/Makefile.am
+++ b/netlist/examples/analog/Makefile.am
@@ -1,9 +1,4 @@
-## Process this file with automake to produce Makefile.in
-
 SUBDIRS = varactor_osc bandpass voltage_doubler
 
-MOSTLYCLEANFILES =  core *.log FILE *.ps *~
-CLEANFILES = core *.log FILE *.ps *~
-DISTCLEANFILES = *.log core FILE *~
-MAINTAINERCLEANFILES = core *.log FILE *.ps *~ Makefile.in
+MAINTAINERCLEANFILES = Makefile.in
 

--- a/netlist/examples/analog/bandpass/Makefile.am
+++ b/netlist/examples/analog/bandpass/Makefile.am
@@ -1,21 +1,8 @@
+sch_files = sch/frg_band_pass.sch
 
-## Process this file with automake to produce Makefile.in
+model_files = models/D1N4148.sp
 
-sch_files = \
-	sch/frg_band_pass.sch
+EXTRA_DIST = README gafrc ngspice.cmd $(sch_files) $(model_files)
 
-sym_files = 
-
-model_files =
-	models/D1N4148.sp
-
-SUBDIRS = 
-
-EXTRA_DIST = README gafrc ngspice.cmd \
-	$(sch_files) $(sym_files) $(ref_files) $(model_files)
-
-MOSTLYCLEANFILES =  core *.log FILE *.ps *~
-CLEANFILES = core *.log FILE *.ps *~
-DISTCLEANFILES = *.log core FILE *~
-MAINTAINERCLEANFILES = core *.log FILE *.ps *~ Makefile.in
+MAINTAINERCLEANFILES = Makefile.in
 

--- a/netlist/examples/analog/bandpass/README
+++ b/netlist/examples/analog/bandpass/README
@@ -5,15 +5,16 @@ It should show a bandpass responce.
 
 You will find;
 
--reference material for frg_7700 in the directory.
--spice models for the simulaton in models directory.
--ngspice cmds used to run simulation.
+- reference material for frg_7700 in the directory.
+- spice models for the simulaton in models directory.
+- ngspice cmds used to run simulation.
 
 You must also have gaw wave viewer` installed.
 http://gaw.tuxfamily.org/linux/gaw.php
 
 ac analysis results are complex so
-vectors must be show as mag(vec) or db(vec) which is equivalent to 
-db(mag(vec)). 
+vectors must be show as mag(vec) or db(vec) which is equivalent to
+db(mag(vec)).
 
-After writing file open file with gaw, set Abscissa (X) to Log scale and display.
+After writing file open file with gaw, set Abscissa (X) to Log
+scale and display.

--- a/netlist/examples/analog/varactor_osc/Makefile.am
+++ b/netlist/examples/analog/varactor_osc/Makefile.am
@@ -1,24 +1,14 @@
+sch_files = sch/frg-vco.sch
 
-## Process this file with automake to produce Makefile.in
+sym_files = sym/varactor-1.sym
 
-sch_files = \
-	sch/frg-vco.sch
-
-sym_files = \
-	sym/varactor-1.sym
-
-model_files =
-	models/D1N4148.sp\
-	models/MV104.sp\
+model_files = \
+	models/D1N4148.sp \
+	models/MV104.sp \
 	bc337_25.sp
 
-SUBDIRS =
+EXTRA_DIST = README gafrc ngspice.cmd \
+	$(sch_files) $(sym_files) $(model_files)
 
-EXTRA_DIST = README gafrc ngspice.cmd\
-	$(sch_files) $(sym_files) $(ref_files) $(model_files)
-
-MOSTLYCLEANFILES =  core *.log FILE *.ps *~
-CLEANFILES = core *.log FILE *.ps *~
-DISTCLEANFILES = *.log core FILE *~
-MAINTAINERCLEANFILES = core *.log FILE *.ps *~ Makefile.in
+MAINTAINERCLEANFILES = Makefile.in
 

--- a/netlist/examples/analog/varactor_osc/Makefile.am
+++ b/netlist/examples/analog/varactor_osc/Makefile.am
@@ -5,7 +5,7 @@ sym_files = sym/varactor-1.sym
 model_files = \
 	models/D1N4148.sp \
 	models/MV104.sp \
-	bc337_25.sp
+	models/bc337_25.sp
 
 EXTRA_DIST = README gafrc ngspice.cmd \
 	$(sch_files) $(sym_files) $(model_files)

--- a/netlist/examples/analog/varactor_osc/README
+++ b/netlist/examples/analog/varactor_osc/README
@@ -1,11 +1,13 @@
 Analog  simulation used on frg-7700 repair.
 This simulates one of the PLL's using a varactor.
 
-FFT does a fft analysis on the vecs spicified. This is of course complex and 
-requires mag, just like bandpass example. You can also just look at transient 
-analysis which should be REAL and see the wave form.
-Both can be viewed with gaw, gwave or built in viewer in ngpsice.
+FFT does a fft analysis on the vecs spicified. This is of course
+complex and requires mag, just like bandpass example. You can also
+just look at transient analysis which should be REAL and see the
+wave form.  Both can be viewed with gaw, gwave or built in viewer
+in ngpsice.
 
-You will find the schematics and the custom symbols. The models directory contain the models for the project.
+You will find the schematics and the custom symbols. The models
+directory contain the models for the project.
 
 Dr Forbin.

--- a/netlist/examples/analog/voltage_doubler/Makefile.am
+++ b/netlist/examples/analog/voltage_doubler/Makefile.am
@@ -1,22 +1,12 @@
-## Process this file with automake to produce Makefile.in
-
 sch_files = \
-	sch/doubler_a.sch\
-	sch/doubler_b.sch\
+	sch/doubler_a.sch \
+	sch/doubler_b.sch \
 	sch/doubler_c.sch
 
-sym_files = 
-
-model_files =
-	models/D1N4148.sp
-
-SUBDIRS = 
+model_files = models/D1N4148.sp
 
 EXTRA_DIST = README gafrc ngspice.cmd \
-	$(sch_files) $(sym_files) $(ref_files) $(model_files)
+	$(sch_files) $(model_files)
 
-MOSTLYCLEANFILES =  core *.log FILE *.ps *~
-CLEANFILES = core *.log FILE *.ps *~
-DISTCLEANFILES = *.log core FILE *~
-MAINTAINERCLEANFILES = core *.log FILE *.ps *~ Makefile.in
+MAINTAINERCLEANFILES = Makefile.in
 

--- a/netlist/examples/analog/voltage_doubler/README
+++ b/netlist/examples/analog/voltage_doubler/README
@@ -11,17 +11,21 @@ The first of the three schematics
 
 -doubler_a
 
-is an example of using a single line model. The 'model-name' attribute is defined as the name you wish to name he model
-and the model is (one line) defined in the 'model' attribute. 
+is an example of using a single line model. The 'model-name'
+attribute is defined as the name you wish to name he model and the
+model is (one line) defined in the 'model' attribute.
 
 -doubler_b
 
-uses the attributes 'model-name' and 'file'. In 'model-name' you define again the model-name and than define in 'file' the file which
-contains the SPICE model to be used.
+uses the attributes 'model-name' and 'file'. In 'model-name' you
+define again the model-name and than define in 'file' the file
+which contains the SPICE model to be used.
 
 -doubler_c
 
-The attributes used in this schematic are a SPICE model symbol which defines the 'file' attribute which holds the name of the file which
-contains the SPICE model. The device symbols contain the 'model-name' attribute which connects to two together.
+The attributes used in this schematic are a SPICE model symbol
+which defines the 'file' attribute which holds the name of the
+file which contains the SPICE model. The device symbols contain
+the 'model-name' attribute which connects to two together.
 
 You should pick which method suits you best!

--- a/netlist/examples/analog/voltage_doubler/ngspice.cmd
+++ b/netlist/examples/analog/voltage_doubler/ngspice.cmd
@@ -1,4 +1,4 @@
-.control 
+.control
 tran 0.01m 5m
 write volt.raw v(1) v(2) v(3)
 rusage everything

--- a/netlist/examples/switcap/Makefile.am
+++ b/netlist/examples/switcap/Makefile.am
@@ -1,12 +1,7 @@
-## Process this file with automake to produce Makefile.in
-
 EXTRA_DIST = README analysis.sch ckt.sch clocks.sch example.out example.scn \
 	     test.ana
 
-MOSTLYCLEANFILES =  core *.log FILE *.ps *~
-CLEANFILES = core *.log FILE *.ps *~
-DISTCLEANFILES = *.log core FILE *~
-MAINTAINERCLEANFILES = core *.log FILE *.ps *~ Makefile.in
+MAINTAINERCLEANFILES = Makefile.in
 
 
 

--- a/netlist/examples/vams/Makefile.am
+++ b/netlist/examples/vams/Makefile.am
@@ -1,5 +1,3 @@
-## Process this file with automake to produce Makefile.in
-
 sch_files = \
 	sch/simple_trans.sch \
 	sch/sp_diode.sch \
@@ -22,8 +20,5 @@ SUBDIRS = vhdl
 EXTRA_DIST = README gschemrc geda.conf generate_netlist.scm \
 	$(sch_files) $(sym_files)
 
-MOSTLYCLEANFILES =  core *.log FILE *.ps *~
-CLEANFILES = core *.log FILE *.ps *~
-DISTCLEANFILES = *.log core FILE *~
-MAINTAINERCLEANFILES = core *.log FILE *.ps *~ Makefile.in
+MAINTAINERCLEANFILES = Makefile.in
 

--- a/netlist/examples/vams/vhdl/Makefile.am
+++ b/netlist/examples/vams/vhdl/Makefile.am
@@ -1,11 +1,6 @@
-## Process this file with automake to produce Makefile.in
-
 SUBDIRS = basic-vhdl new-vhdl
 
-MOSTLYCLEANFILES =  core *.log FILE *.ps *~
-CLEANFILES = core *.log FILE *.ps *~
-DISTCLEANFILES = *.log core FILE *~
-MAINTAINERCLEANFILES = core *.log FILE *.ps *~ Makefile.in
+MAINTAINERCLEANFILES = Makefile.in
 
 
 

--- a/netlist/examples/vams/vhdl/basic-vhdl/Makefile.am
+++ b/netlist/examples/vams/vhdl/basic-vhdl/Makefile.am
@@ -1,5 +1,3 @@
-## Process this file with automake to produce Makefile.in
-
 EXTRA_DIST = bjt_transistor_simple.vhdl bjt_transistor_simple_arc.vhdl \
 	     capacitor.vhdl capacitor_arc.vhdl current_source.vhdl \
 	     current_source_arc.vhdl electrical_system.vhdl \
@@ -10,10 +8,7 @@ EXTRA_DIST = bjt_transistor_simple.vhdl bjt_transistor_simple_arc.vhdl \
 	     voltage_dependend_capacitor_arc.vhdl voltage_source.vhdl \
 	     voltage_source_arc.vhdl
 
-MOSTLYCLEANFILES =  core *.log FILE *.ps *~
-CLEANFILES = core *.log FILE *.ps *~
-DISTCLEANFILES = *.log core FILE *~
-MAINTAINERCLEANFILES = core *.log FILE *.ps *~ Makefile.in
+MAINTAINERCLEANFILES = Makefile.in
 
 
 

--- a/netlist/examples/vams/vhdl/new-vhdl/Makefile.am
+++ b/netlist/examples/vams/vhdl/new-vhdl/Makefile.am
@@ -1,12 +1,7 @@
-## Process this file with automake to produce Makefile.in
-
 EXTRA_DIST = bjt_transistor_simple_top.vhdl default_entity.vhdl \
 	     resistor.vhdl top_test_entity.vhdl
 
-MOSTLYCLEANFILES =  core *.log FILE *.ps *~
-CLEANFILES = core *.log FILE *.ps *~
-DISTCLEANFILES = *.log core FILE *~
-MAINTAINERCLEANFILES = core *.log FILE *.ps *~ Makefile.in
+MAINTAINERCLEANFILES = Makefile.in
 
 
 

--- a/netlist/examples/verilog/Makefile.am
+++ b/netlist/examples/verilog/Makefile.am
@@ -1,9 +1,4 @@
-## Process this file with automake to produce Makefile.in
-
 SUBDIRS = T_FF_example
 
-MOSTLYCLEANFILES =  core *.log FILE *.ps *~
-CLEANFILES = core *.log FILE *.ps *~
-DISTCLEANFILES = *.log core FILE *~
-MAINTAINERCLEANFILES = core *.log FILE *.ps *~ Makefile.in
+MAINTAINERCLEANFILES = Makefile.in
 

--- a/netlist/examples/verilog/T_FF_example/Makefile.am
+++ b/netlist/examples/verilog/T_FF_example/Makefile.am
@@ -1,19 +1,12 @@
-sch_files = \
-	sch/verilog_rip_test.sch
-	
+sch_files = sch/verilog_rip_test.sch
 
-sym_files = \
-	sym/T_FF.sym
+sym_files = sym/T_FF.sym
 
-ex_gmk_files = \
-	rip_gmk_example/T_FF.sym.txt
+ex_gmk_files = rip_gmk_example/T_FF.sym.txt
 
 SUBDIRS = verilog_modules
 
-EXTRA_DIST = README gafrc dummy_test.v\
+EXTRA_DIST = README gafrc dummy_test.v \
 	$(sch_files) $(sym_files) $(ex_gmk_files)
 
-MOSTLYCLEANFILES =  core *.log FILE *.ps *~
-CLEANFILES = core *.log FILE *.ps *~
-DISTCLEANFILES = *.log core FILE *~
-MAINTAINERCLEANFILES = core *.log FILE *.ps *~ Makefile.in
+MAINTAINERCLEANFILES = Makefile.in

--- a/netlist/examples/verilog/T_FF_example/verilog_modules/Makefile.am
+++ b/netlist/examples/verilog/T_FF_example/verilog_modules/Makefile.am
@@ -1,9 +1,4 @@
-## Process this file with automake to produce Makefile.in
-
 EXTRA_DIST = T_FF_TESTBENCH.v T_FF.v RIPPLE_COUNT.v D_FF.v
 
-MOSTLYCLEANFILES =  core *.log FILE *.ps *~
-CLEANFILES = core *.log FILE *.ps *~
-DISTCLEANFILES = *.log core FILE *~
-MAINTAINERCLEANFILES = core *.log FILE *.ps *~ Makefile.in
+MAINTAINERCLEANFILES = Makefile.in
 


### PR DESCRIPTION
- Fix texts in READMEs and other files: remove whitespaces and get rid of long lines.
- Fix Makefiles: get rid of superfluous `*CLEAN*` targets, empty variables, fix lines (add `\` where appropriate).
- Fix `make distcheck` by using proper file name.