### PR TITLE
liblepton: Add generated 'gettext.scm' to .gitignore.

### DIFF
--- a/liblepton/scheme/.gitignore
+++ b/liblepton/scheme/.gitignore
@@ -1,4 +1,5 @@
 Makefile
 Makefile.in
 test-suite.log
+lepton/core/gettext.scm
 *~


### PR DESCRIPTION
Affects #556.