### PR TITLE
Fix procedure name conflict in netlister code

### DIFF
--- a/netlist/scheme/backend/gnet-ewnet.scm
+++ b/netlist/scheme/backend/gnet-ewnet.scm
@@ -99,7 +99,7 @@
             ;; net
             (display "\t\t\t(net \"")
             (display
-             (gnetlist:alias-net (package-pin-netname package pin)))
+             (gnetlist:alias-net (pin-netname package pin)))
             (display "\")\n")
 
             ;; pin type.  I have seen "PWR", "GND", "IN", "OUT", "BIDIR"

--- a/netlist/scheme/backend/gnet-futurenet2.scm
+++ b/netlist/scheme/backend/gnet-futurenet2.scm
@@ -118,7 +118,7 @@
             (display "PIN,,")
 
             (display
-             (gnetlist:alias-net (package-pin-netname package pin)))
+             (gnetlist:alias-net (pin-netname package pin)))
 
             ;; XXX I've seen 20, 23, and 100 in the position where the
             ;; "23" is here.  Seems to be a property like signal vs

--- a/netlist/scheme/backend/gnet-spice-sdb.scm
+++ b/netlist/scheme/backend/gnet-spice-sdb.scm
@@ -218,7 +218,7 @@
 ;;; returns the list of nets attached to the IOs.
 (define (spice-sdb:get-io-nets package-list)
   (map
-   (lambda (package) (package-pin-netname package "1"))
+   (lambda (package) (pin-netname package "1"))
    package-list))
 
 

--- a/netlist/scheme/backend/gnet-switcap.scm
+++ b/netlist/scheme/backend/gnet-switcap.scm
@@ -133,7 +133,7 @@
 ;;
 (define switcap:write-pin-net
   (lambda (package pin)
-    (display (gnetlist:alias-net (package-pin-netname package pin)))
+    (display (gnetlist:alias-net (pin-netname package pin)))
     )
   )
 

--- a/netlist/scheme/backend/gnet-systemc.scm
+++ b/netlist/scheme/backend/gnet-systemc.scm
@@ -69,8 +69,7 @@
   (define (get-package-pin-netnames package)
     (and (string=? (gnetlist:get-package-attribute package attribute)
                    value)
-         (package-pin-netname package
-                              (car (get-pins package)))))
+         (pin-netname package (car (get-pins package)))))
 
   (filter-map get-package-pin-netnames package-list))
 

--- a/netlist/scheme/backend/gnet-vams.scm
+++ b/netlist/scheme/backend/gnet-vams.scm
@@ -768,7 +768,7 @@ ARCHITECTURE ~A OF ~A IS
 ;;; REFDES-LIST.
 (define (vams:all-packages-nets refdes-list)
   (define (pin-net-names package)
-    (map (cut package-pin-netname package <>)
+    (map (cut pin-netname package <>)
          (get-pins package)))
 
   (map pin-net-names refdes-list))
@@ -830,7 +830,7 @@ ARCHITECTURE ~A OF ~A IS
     (car (get-pins port)))
 
   (define (first-pin-net port)
-    (package-pin-netname port (first-pin port)))
+    (pin-netname port (first-pin port)))
 
   (if (null? ports)
       '()

--- a/netlist/scheme/backend/gnet-verilog.scm
+++ b/netlist/scheme/backend/gnet-verilog.scm
@@ -71,8 +71,7 @@
   (define (get-package-pin-netnames package)
     (and (string=? (gnetlist:get-package-attribute package attribute)
                    value)
-         (package-pin-netname package
-                              (car (get-pins package)))))
+         (pin-netname package (car (get-pins package)))))
 
   (filter-map get-package-pin-netnames package-list))
 

--- a/netlist/scheme/backend/gnet-vipec.scm
+++ b/netlist/scheme/backend/gnet-vipec.scm
@@ -107,10 +107,10 @@
   (do ((i 1 (1+ i)))
       ((> i number-of-pin))
     (let ((pin-name (number->string i)))
-      (display (get-net-number (package-pin-netname uref
-                                                    (gnetlist:get-attribute-by-pinseq uref
-                                                                                      pin-name
-                                                                                      "pinnumber"))
+      (display (get-net-number (pin-netname uref
+                                            (gnetlist:get-attribute-by-pinseq uref
+                                                                              pin-name
+                                                                              "pinnumber"))
                                netnumbers))
       (write-char #\space))))
 

--- a/netlist/scheme/backend/spice/common.scm
+++ b/netlist/scheme/backend/spice/common.scm
@@ -221,7 +221,7 @@
 ;; gnet-spice replacement of get-nets, a net labeled "GND" becomes 0
 ;;-----------------------------------------------------------
 (define (spice:get-net package pin-name)
-  (let ((net-name (package-pin-netname package pin-name)))
+  (let ((net-name (pin-netname package pin-name)))
     (if (string=? net-name "GND")
         "0"
         net-name)))

--- a/netlist/scheme/netlist.scm
+++ b/netlist/scheme/netlist.scm
@@ -61,7 +61,7 @@
             get-nets
             get-pins-nets
             message
-            package-pin-netname
+            pin-netname
             gnetlist:alias-net
             gnetlist:alias-refdes
             gnetlist:build-net-aliases
@@ -481,7 +481,7 @@ connection pairs in the form (\"pin-number\" . \"net-name\")."
       (_ '("ERROR_INVALID_PIN")))))
 
 
-(define (package-pin-netname package pinnumber)
+(define (pin-netname package pinnumber)
   (or (assoc-ref (get-pins-nets package) pinnumber)
       "ERROR_INVALID_PIN"))
 

--- a/netlist/scheme/netlist/package-pin.scm
+++ b/netlist/scheme/netlist/package-pin.scm
@@ -29,7 +29,6 @@
                    package-pin-object set-package-pin-object!
                    package-pin-number set-package-pin-number!
                    package-pin-name set-package-pin-name!
-                   package-pin-netname set-package-pin-netname!
                    package-pin-label set-package-pin-label!
                    package-pin-attribs set-package-pin-attribs!
                    package-pin-net-map set-package-pin-net-map!
@@ -43,7 +42,7 @@
             set-package-pin-parent-component!))
 
 (define-record-type <package-pin>
-  (make-package-pin id object number name netname label attribs net-map parent connection named-connection port-connection)
+  (make-package-pin id object number name label attribs net-map parent connection named-connection port-connection)
   package-pin?
   ;; This field is used just for the record representation in
   ;; set-record-type-printer! below.
@@ -54,8 +53,6 @@
   (number package-pin-number set-package-pin-number!)
   ;; Corresponds to net name of the net the pin is connected to.
   (name package-pin-name set-package-pin-name!)
-  ;; Corresponds to netname= list of the nets the pin is connected to.
-  (netname package-pin-netname set-package-pin-netname!)
   ;; Corresponds to pin's "pinlabel" attribute.
   (label package-pin-label set-package-pin-label!)
   ;; The alist representing attributes of the underlying object.
@@ -84,7 +81,6 @@ FORMAT-STRING must be in the form required by the procedure
   'object
   'number
   'name
-  'netname
   'label
   'attribs
   'net-map
@@ -106,7 +102,6 @@ Example usage:
                  ('object (package-pin-object record))
                  ('number (package-pin-number record))
                  ('name (package-pin-name record))
-                 ('netname (package-pin-netname record))
                  ('label (package-pin-label record))
                  ('attribs (package-pin-attribs record))
                  ('net-map (package-pin-net-map record))
@@ -137,8 +132,6 @@ Example usage:
                          ;; Number.
                          (assq-ref attribs 'pinnumber)
                          ;; Add name later.
-                         #f
-                         ;; Add netname list later.
                          #f
                          ;; Label.
                          (assq-ref attribs 'pinlabel)

--- a/netlist/scheme/netlist/schematic-component.scm
+++ b/netlist/scheme/netlist/schematic-component.scm
@@ -218,7 +218,6 @@ sets the component to be its parent component."
                             #f
                             (net-map-pinnumber net-map)
                             #f
-                            '()
                             #f
                             '()
                             net-map


### PR DESCRIPTION
The issue was reported by @graahnul-grom on gitter:
> I get names conflict when trying to use functions from the (netlist package-pin) module:
> WARNING: (guile-user): `package-pin-netname' imported from both (netlist) and (netlist package-pin)

The patch set fixes it in two ways:
- the procedure in the `(netlist)` module has been renamed in order users to not confuse it with something from the `(netlist package-pin)` module;
- the field `netname` has been removed from the `package-pin` record since it is no longer used after previous refactoring, so there is no `package-pin-netname` in the code at all any more.