### PR TITLE
Fix 'make check --disable-deprecated'

### DIFF
--- a/cli/export.c
+++ b/cli/export.c
@@ -171,7 +171,7 @@ cmd_export_impl (void *data, int argc, char **argv)
   edascm_dynwind_toplevel (toplevel);
 
   /* Now load rc files, if necessary */
-  if (getenv ("GAF_INHIBIT_RCFILES") == NULL) {
+  if (getenv ("LEPTON_INHIBIT_RC_FILES") == NULL) {
     g_rc_parse (toplevel, "lepton-cli export", NULL, NULL);
   }
   i_vars_libgeda_set (toplevel); /* Ugh */

--- a/cli/lepton-cli.c
+++ b/cli/lepton-cli.c
@@ -126,7 +126,7 @@ main (int argc, char **argv)
       break;
 
     case 2: /* --no-rcfiles */
-      g_setenv ("GAF_INHIBIT_RCFILES", "1", 1);
+      g_setenv ("LEPTON_INHIBIT_RC_FILES", "1", 1);
       break;
 
     case 'V':

--- a/cli/shell.c
+++ b/cli/shell.c
@@ -131,7 +131,7 @@ cmd_shell_impl (void *data, int argc, char **argv)
   }
 
   /* Now load rc files, if necessary */
-  if (getenv ("GAF_INHIBIT_RCFILES") == NULL) {
+  if (getenv ("LEPTON_INHIBIT_RC_FILES") == NULL) {
     g_rc_parse (toplevel, "lepton-cli shell", NULL, NULL);
   }
   i_vars_libgeda_set (toplevel); /* Ugh */

--- a/symcheck/tests/Makefile.am
+++ b/symcheck/tests/Makefile.am
@@ -76,6 +76,7 @@ tests:
 	abs_builddir='$(abs_builddir)'; export abs_builddir; \
 	abs_top_builddir='$(abs_top_builddir)'; export abs_top_builddir; \
 	LIBLEPTON='$(abs_top_builddir)/liblepton/src/liblepton'; export LIBLEPTON; \
+	export LEPTON_INHIBIT_RC_FILES="inhibit"; \
 	abs_srcdir='$(abs_srcdir)'; export abs_srcdir; \
 	abs_top_srcdir='$(abs_top_srcdir)'; export abs_top_srcdir; \
 	fail=0 ; \


### PR DESCRIPTION
On my system the command fails in some cases, e.g. if a previous version of lepton is installed.  There are two patches here:
- The first one fixes this by using especially crafted variable for this goal `LEPTON_INHIBIT_RC_FILES`.
- The second one renames alike variable in `lepton-cli` for uniformity.