### PR TITLE
Rename variables and files related to dealing with guile load paths

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -161,7 +161,7 @@ equivalent: `-b`.
     modules.
 
   - The new script eliminates direct setting of
-    `GEDADATA`/`GEDADATADIR` to the directory where `system-gafrc`
+    `GEDADATA`/`LEPTONDATADIR` to the directory where `system-gafrc`
     should be placed, and parsing of the lines containing
     `component-library` and `component-library-search` in system
     rc files, as it is no longer required.

--- a/docs/specifications/paths.txt
+++ b/docs/specifications/paths.txt
@@ -52,7 +52,7 @@ There are some key considerations for backwards compatibility:
 
 1) Lepton historically observes the `$GEDADATA` environment variable by
    using the directory it specifies as the *sole* source of system
-   data.  Similarly, `$GEDARCDIR` specifies the directory for system
+   data.  Similarly, `$LEPTONRCDIR` specifies the directory for system
    configuration.
 
 2) Lepton also historically *ensures* that `$GEDADATA` points to the
@@ -132,7 +132,7 @@ follows:
    list.
 
 2. If neither relocatable builds are enabled nor the target platform
-   is Windows, the value of the `GEDARCDIR` preprocessor macro
+   is Windows, the value of the `LEPTONRCDIR` preprocessor macro
    (usually `${prefix}/share/lepton-eda`) is appended to the list.
 
 3. Finally, if relocatable builds *are* enabled, guess the

--- a/docs/specifications/paths.txt
+++ b/docs/specifications/paths.txt
@@ -98,7 +98,7 @@ searched in order.  The list is constructed as follows:
    `g_get_system_data_dirs()` is added to the list.
 
 2. If neither relocatable builds are enabled nor the target platform
-   is Windows, the value of the `GEDADATADIR` preprocessor macro
+   is Windows, the value of the `LEPTONDATADIR` preprocessor macro
    (usually `${prefix}/share/lepton-eda`) is appended to the list.
 
 3. Finally, if relocatable builds *are* enabled, guess the

--- a/docs/specifications/paths.txt
+++ b/docs/specifications/paths.txt
@@ -1,6 +1,6 @@
-==============================
- gEDA Relocatable Directories
-==============================
+===================================
+ Lepton EDA Relocatable Directories
+===================================
 
 :Author: Peter Brett
 :Status: Implemented
@@ -30,15 +30,15 @@ Introduction
 ============
 
 This document describes a new API and approach for liblepton for
-locating gEDA's resource files, configuration files, and other
+locating Lepton's resource files, configuration files, and other
 run-time resources.  In particular, the new API is designed to:
 
-* facilitate relocatable builds (where a gEDA installation tree can be
+* facilitate relocatable builds (where a Lepton installation tree can be
   moved around the system without needing any further configuration)
 
 * improve the experience for Windows users by reducing the number of
   environment variables that need to be correctly configured in order
-  for gEDA to run
+  for Lepton to run
 
 * better respect the *XDG Base Directory Specification* [XDGDIRS]_ on
   UNIX platforms.
@@ -50,13 +50,13 @@ Backwards compatibility
 
 There are some key considerations for backwards compatibility:
 
-1) gEDA historically observes the `$GEDADATA` environment variable by
+1) Lepton historically observes the `$GEDADATA` environment variable by
    using the directory it specifies as the *sole* source of system
    data.  Similarly, `$GEDARCDIR` specifies the directory for system
    configuration.
 
-2) gEDA also historically *ensures* that `$GEDADATA` points to the
-   directory into which gEDA was installed, and there are a lot users
+2) Lepton also historically *ensures* that `$GEDADATA` points to the
+   directory into which Lepton was installed, and there are a lot users
    who depend on that being the case.
 
 3) In the past the installation path (specified with the `--prefix`
@@ -68,7 +68,7 @@ There are some key considerations for backwards compatibility:
 4) The legacy location for user data and configuration is
    `$HOME/.gEDA` (or `$HOMEDRIVE$HOMEPATH/.gEDA` on Windows.
 
-5) Finally, gEDA expects the default configuration files (such as
+5) Finally, Lepton expects the default configuration files (such as
    `system-gafrc`) to be loaded from the installation *data*
    directory.
 
@@ -94,16 +94,16 @@ searched in order.  The list is constructed as follows:
 
 1. If the `$GEDADATA` environment variable is set and deprecated
    features are enabled, it is added to the list.  Otherwise, the
-   "gEDA" subdirectory of each entry in `g_get_system_data_dirs()` is
-   added to the list.
+   "lepton-eda" subdirectory of each entry in
+   `g_get_system_data_dirs()` is added to the list.
 
 2. If neither relocatable builds are enabled nor the target platform
    is Windows, the value of the `GEDADATADIR` preprocessor macro
-   (usually `${prefix}/share/gEDA`) is appended to the list.
+   (usually `${prefix}/share/lepton-eda`) is appended to the list.
 
 3. Finally, if relocatable builds *are* enabled, guess the
-   installation prefix, add the corresponding "share/gEDA" directory
-   to it to, and append it to the list
+   installation prefix, add the corresponding "share/lepton-eda"
+   directory to it to, and append it to the list
 
 For backwards compatibility, if the `$GEDADATA` environment variable
 is not set, then it is set to the first directory in the search path
@@ -126,19 +126,20 @@ follows:
 
 1. If the `$GEDADATARC` environment variable is set and deprecated
    features are enabled, it is added to the list.  Otherwise, if
-   `$GEDADATA` is set and deprecated features are enabled, *that* is
-   added to the list.  Otherwise, the "gEDA" subdirectory of each
-   entry in `g_get_system_config_dirs()` is added to the list.
+   `$GEDADATA` is set and deprecated features are enabled, *that*
+   is added to the list.  Otherwise, the "lepton-eda" subdirectory
+   of each entry in `g_get_system_config_dirs()` is added to the
+   list.
 
 2. If neither relocatable builds are enabled nor the target platform
    is Windows, the value of the `GEDARCDIR` preprocessor macro
-   (usually `${prefix}/share/gEDA`) is appended to the list.
+   (usually `${prefix}/share/lepton-eda`) is appended to the list.
 
 3. Finally, if relocatable builds *are* enabled, guess the
-   installation prefix, add the corresponding "share/gEDA" directory
-   to it to, and append it to the list.  This ensures that the default
-   configuration files in the installation tree are in the
-   configuration search path.
+   installation prefix, add the corresponding "share/lepton-eda"
+   directory to it to, and append it to the list.  This ensures
+   that the default configuration files in the installation tree
+   are in the configuration search path.
 
 Per-user data path
 ------------------
@@ -156,8 +157,8 @@ Per-user data is read from a single directory.
 1. If `$HOME/.gEDA` exists (or `$HOMEDRIVE/$HOMEPATH/.gEDA` on
    Windows), this directory is returned.
 
-2. Otherwise, the `gEDA` subdirectory of `g_get_user_data_dir()` is
-   returned.
+2. Otherwise, the `lepton-eda` subdirectory of
+   `g_get_user_data_dir()` is returned.
 
 Per-user configuration path
 ---------------------------
@@ -175,8 +176,8 @@ Per-user data is stored in a single directory.
 1. If `$HOME/.gEDA` exists (or `$HOMEDRIVE/$HOMEPATH/.gEDA` on
    Windows), this directory is returned.
 
-2. Otherwise, the `gEDA` subdirectory of `g_get_user_config_dir()` is
-   returned.
+2. Otherwise, the `lepton-eda` subdirectory of
+   `g_get_user_config_dir()` is returned.
 
 Related changes
 ===============

--- a/liblepton/lib/Makefile.am
+++ b/liblepton/lib/Makefile.am
@@ -1,5 +1,5 @@
 
-rcdatadir = $(GEDARCDIR)
+rcdatadir = $(LEPTONRCDIR)
 dist_rcdata_DATA = lepton-system.conf geda-system.conf system-gafrc print-colormap-lightbg print-colormap-darkbg
 
 MOSTLYCLEANFILES = *.log *~

--- a/liblepton/liblepton.pc.in
+++ b/liblepton/liblepton.pc.in
@@ -2,8 +2,6 @@ prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@
-gedarcdir=@GEDARCDIR@
-gedadatadir=@GEDADATADIR@
 
 Name: liblepton
 Description: lepton EDA's core library

--- a/liblepton/liblepton.pc.in
+++ b/liblepton/liblepton.pc.in
@@ -4,7 +4,7 @@ libdir=@libdir@
 includedir=@includedir@
 
 Name: liblepton
-Description: lepton EDA's core library
+Description: Lepton EDA core library
 Requires: glib-2.0 gdk-pixbuf-2.0 gio-2.0 @GUILE_PKG_NAME@
 Requires.private:
 Version: @DATE_VERSION@

--- a/liblepton/scheme/Makefile.am
+++ b/liblepton/scheme/Makefile.am
@@ -1,5 +1,5 @@
 
-scmdatadir = $(GEDADATADIR)/scheme
+scmdatadir = $(LEPTONDATADIR)/scheme
 nobase_dist_scmdata_DATA = \
 	geda.scm \
 	geda-deprecated-config.scm \

--- a/liblepton/src/edapaths.c
+++ b/liblepton/src/edapaths.c
@@ -29,8 +29,8 @@
 #if !defined(LEPTONDATADIR)
 #	define LEPTONDATADIR NULL
 #endif
-#if !defined(GEDARCDIR)
-#	define GEDARCDIR LEPTONDATADIR
+#if !defined(LEPTONRCDIR)
+#	define LEPTONRCDIR LEPTONDATADIR
 #endif
 
 static const gchar* const DATA_ENV        = "GEDADATA";
@@ -353,7 +353,7 @@ eda_get_system_config_dirs(void)
 	if (g_once_init_enter(&system_config_dirs)) {
 		const gchar * const env_names[] = { CONFIG_ENV, DATA_ENV, NULL };
 		const gchar * const * xdg_dirs = g_get_system_config_dirs();
-		const gchar * const cfg_dirs[] = { GEDARCDIR, NULL };
+		const gchar * const cfg_dirs[] = { LEPTONRCDIR, NULL };
 
 		const gchar **dirs =
 			build_search_list(env_names, xdg_dirs, cfg_dirs);

--- a/liblepton/src/edapaths.c
+++ b/liblepton/src/edapaths.c
@@ -26,11 +26,11 @@
 #include "libgeda_priv.h"
 
 /* For convenience in this file only! */
-#if !defined(GEDADATADIR)
-#	define GEDADATADIR NULL
+#if !defined(LEPTONDATADIR)
+#	define LEPTONDATADIR NULL
 #endif
 #if !defined(GEDARCDIR)
-#	define GEDARCDIR GEDADATADIR
+#	define GEDARCDIR LEPTONDATADIR
 #endif
 
 static const gchar* const DATA_ENV        = "GEDADATA";
@@ -303,7 +303,7 @@ eda_get_system_data_dirs(void)
 	if (g_once_init_enter(&system_data_dirs)) {
 		const gchar * const env_names[] = { DATA_ENV, NULL };
 		const gchar * const * xdg_dirs = g_get_system_data_dirs();
-		const gchar * const cfg_dirs[] = { GEDADATADIR, NULL };
+		const gchar * const cfg_dirs[] = { LEPTONDATADIR, NULL };
 
 		const gchar **dirs =
 			build_search_list(env_names, xdg_dirs, cfg_dirs);

--- a/liblepton/src/edapaths.c
+++ b/liblepton/src/edapaths.c
@@ -46,11 +46,11 @@ static const gchar* const USER_DOTDIR     = ".gEDA";
  * Private initialisation functions
  * ================================================================ */
 
-/*! \brief Get the gEDA installation's data directory.
- * Attempt to find the "share/gEDA" directory in the prefix where gEDA
- * was installed.  Returns NULL if not on Windows and not a
- * relocatable build (in that case, the install location should have
- * been compiled in via configure options) */
+/*! \brief Get the Lepton EDA installation's data directory.
+ * Attempt to find the "share/lepton-eda" directory in the prefix
+ * where Lepton was installed.  Returns NULL if not on Windows and
+ * not a relocatable build (in that case, the install location
+ * should have been compiled in via configure options) */
 static const gchar *
 guess_install_data_dir(void)
 {
@@ -118,10 +118,10 @@ copy_search_list(const gchar **output,
 	}
 #endif /* ENABLE_DEPRECATED */
 
-	/* Otherwise, use the "gEDA" subdirectory of the configured standard
-	 * directories. */
+	/* Otherwise, use the "lepton-eda" subdirectory of the
+	 * configured standard directories. */
 	for (gsize i = 0; xdg_dirs && xdg_dirs[i]; ++i) {
-		/* Append "gEDA" to each XDG data path */
+		/* Append "lepton-eda" to each XDG data path */
 		if (output) {
 			output[copied] =
 				g_build_filename(xdg_dirs[i],
@@ -176,10 +176,10 @@ copy_search_list(const gchar **output,
  * \param env_names NULL-terminated list of environment variable
  *                  names.  If any of them is set, it is the only item
  *                  in the returned list.
- * \param xdg_dirs  NULL-terminated list of directory names.  All of
- *                  them have gEDA's XDG subdirectory (i.e. "gEDA")
- *                  appended to them and are added to the list in
- *                  order.
+ * \param xdg_dirs  NULL-terminated list of directory names.  All
+ *                  of them have Lepton's XDG subdirectory
+ *                  (i.e. "lepton-eda") appended to them and are
+ *                  added to the list in order.
  * \param cfg_dirs NULL terminated list of additional directories to
  *                 append to the list.
  * \return a newly-allocated, NULL-terminated array of strings.
@@ -207,7 +207,7 @@ build_search_list(const gchar * const * env_names,
 
 /* \brief Initialise backwards-compatible environment variables.
  * Ensure that the $GEDADATA environment variable is always set to
- * something sensible within gEDA programs.
+ * something sensible within Lepton programs.
  */
 static void
 eda_paths_init_env(void)
@@ -276,17 +276,17 @@ dbg_out_dirs (const gchar* const* dirs, const gchar* name)
 #endif
 
 /*!
- * \brief Get an ordered list of gEDA data directories
+ * \brief Get an ordered list of Lepton EDA data directories
  * \par Function Description
  * Return an ordered list of directories to be searched for
- * system-wide gEDA data.  This list is computed as follows:
+ * system-wide Lepton data.  This list is computed as follows:
  *
  * 1. If the $GEDADATA environment variable is set, add it to the
  *    list.
  *
- * 2. If the $GEDADATA environment variable is not set, add the "gEDA"
- *    subdirectory of each of the platform-specific system-wide
- *    application data directories, as provided by
+ * 2. If the $GEDADATA environment variable is not set, add the
+ *    "lepton-eda" subdirectory of each of the platform-specific
+ *    system-wide application data directories, as provided by
  *    g_get_system_data_dirs().
  *
  * 3. For non-relocatable builds the installation directory configured
@@ -325,21 +325,22 @@ eda_get_system_data_dirs(void)
 }
 
 /*!
- * \brief Get an ordered list of gEDA configuration directories
+ * \brief Get an ordered list of Lepton EDA configuration directories
  * \par Function Description
  * Return an ordered list of directories to be searched for
- * system-wide gEDA configuration.  This list is computed as follows:
+ * system-wide Lepton configuration.  This list is computed as
+ * follows:
  *
  * 1. If the $GEDADATARC environment variable is set, add it to the
  *    list.  Otherwise, if $GEDADATA is set, add that to the list.
  *
- * 2. If neither environment variable is set, add the "gEDA"
+ * 2. If neither environment variable is set, add the "lepton-eda"
  *    subdirectory of each of the platform-specific system-wide
  *    application directories, as provided by
  *    g_get_system_config_dirs().
  *
  * 3. For non-relocatable builds the configuration installation
- * directory configured at build time is appended to the list.
+ *    directory configured at build time is appended to the list.
  *
  * \return An ordered list of directories to be searched for system
  * configuration.
@@ -433,10 +434,10 @@ eda_get_user_cache_dir()
  * ================================================================ */
 
 /*!
- * \brief Initialise data and configuration search paths.
+ * \brief Initialise Lepton EDA data and configuration search paths.
  * \par Function Description
  * Compute and initialise configuration and data search paths used by
- * gEDA, and set any related environment variables.  Should only be
+ * Lepton, and set any related environment variables.  Should only be
  * called (once) by liblepton_init().
  */
 void

--- a/m4/geda-data-dirs.m4
+++ b/m4/geda-data-dirs.m4
@@ -29,15 +29,12 @@ AC_DEFUN([AX_DATA_DIRS],
   # gnetlist backends)
   # FIXME at some point this should become "$datarootdir/geda-gaf" to
   # match the tarball name.
-  AC_MSG_CHECKING([where to install gEDA shared data])
   GEDADATADIR="$datarootdir/lepton-eda"
-  AC_MSG_RESULT([$GEDADATADIR])
 
   # Check where to install rc files.
   # FIXME at some point the rc directory needs to start *defaulting*
   # to "$sysconfdir/geda-gaf" in order to comply with the GNU & Linux
   # FHS guidelines.
-  AC_MSG_CHECKING([where to install gEDA rc files])
   AC_ARG_WITH([rcdir],
     AS_HELP_STRING([--with-rcdir[[[=DIR]]]],
       [install system config in specific DIR]),
@@ -47,12 +44,10 @@ AC_DEFUN([AX_DATA_DIRS],
         else
           GEDARCDIR="$with_rcdir"
         fi
-        AC_MSG_RESULT([$GEDARCDIR])
       else
-        AC_MSG_RESULT([$GEDADATADIR])
+        GEDARCDIR="$GEDADATADIR"
       fi ],
-    [ AC_MSG_RESULT([$GEDADATADIR])
-  ])
+      GEDARCDIR="$GEDADATADIR")
 
   # Now define some preprocessor symbols with the *expanded* values,
   # but only if not doing a relocatable build.
@@ -74,6 +69,15 @@ Only libgeda should use this - apps should use eda_get_system_data_dirs()])
     GEDARCDIR=$GEDADATADIR
   fi
 
+  AC_SUBST([GEDADATADIR])
+  AC_SUBST([GEDARCDIR])
+
+  AC_MSG_CHECKING([where to install Lepton shared data (GEDADATADIR)])
+  AC_MSG_RESULT([$GEDADATADIR])
+
+  AC_MSG_CHECKING([where to install Lepton rc files (GEDARCDIR)])
+  AC_MSG_RESULT([$GEDARCDIR])
+
   # create #define LEPTON_SCM_PRECOMPILE_DIR in config.h:
   #
   AC_DEFINE_UNQUOTED([LEPTON_SCM_PRECOMPILE_DIR],
@@ -87,8 +91,5 @@ Only libgeda should use this - apps should use eda_get_system_data_dirs()])
                      [directory with bitmaps])
 
   AC_SUBST([BITMAP_DIRECTORY], ["$GEDADATADIR_expand/bitmap"])
-
-  AC_SUBST([GEDADATADIR])
-  AC_SUBST([GEDARCDIR])
 
 ])dnl AX_DATA_DIRS

--- a/m4/geda-data-dirs.m4
+++ b/m4/geda-data-dirs.m4
@@ -40,14 +40,14 @@ AC_DEFUN([AX_DATA_DIRS],
       [install system config in specific DIR]),
     [ if test "X$with_rcdir" != "Xno"; then
         if test "X$with_rcdir" = "Xyes"; then
-          GEDARCDIR="$sysconfdir/lepton-eda"
+          LEPTONRCDIR="$sysconfdir/lepton-eda"
         else
-          GEDARCDIR="$with_rcdir"
+          LEPTONRCDIR="$with_rcdir"
         fi
       else
-        GEDARCDIR="$LEPTONDATADIR"
+        LEPTONRCDIR="$LEPTONDATADIR"
       fi ],
-      GEDARCDIR="$LEPTONDATADIR")
+      LEPTONRCDIR="$LEPTONDATADIR")
 
   # Now define some preprocessor symbols with the *expanded* values,
   # but only if not doing a relocatable build.
@@ -57,26 +57,26 @@ AC_DEFUN([AX_DATA_DIRS],
       [Define to gEDA/gaf shared data directory.
 Only libgeda should use this - apps should use eda_get_system_data_dirs()])
 
-    if test "x$GEDARCDIR" != "x"; then
-      GEDARCDIR_expand=`eval "echo $GEDARCDIR" | sed -e"s:^NONE:$ac_default_prefix:"`
-      AC_DEFINE_UNQUOTED([GEDARCDIR], ["$GEDARCDIR_expand"],
+    if test "x$LEPTONRCDIR" != "x"; then
+      LEPTONRCDIR_expand=`eval "echo $LEPTONRCDIR" | sed -e"s:^NONE:$ac_default_prefix:"`
+      AC_DEFINE_UNQUOTED([LEPTONRCDIR], ["$LEPTONRCDIR_expand"],
         [Define to gEDA/gaf rc directory if different from LEPTONDATADIR.
 Only libgeda should use this - apps should use eda_get_system_data_dirs()])
     fi
   fi
 
-  if test "x$GEDARCDIR" = "x"; then
-    GEDARCDIR=$LEPTONDATADIR
+  if test "x$LEPTONRCDIR" = "x"; then
+    LEPTONRCDIR=$LEPTONDATADIR
   fi
 
   AC_SUBST([LEPTONDATADIR])
-  AC_SUBST([GEDARCDIR])
+  AC_SUBST([LEPTONRCDIR])
 
   AC_MSG_CHECKING([where to install Lepton shared data (LEPTONDATADIR)])
   AC_MSG_RESULT([$LEPTONDATADIR])
 
-  AC_MSG_CHECKING([where to install Lepton rc files (GEDARCDIR)])
-  AC_MSG_RESULT([$GEDARCDIR])
+  AC_MSG_CHECKING([where to install Lepton rc files (LEPTONRCDIR)])
+  AC_MSG_RESULT([$LEPTONRCDIR])
 
   # create #define LEPTON_SCM_PRECOMPILE_DIR in config.h:
   #

--- a/m4/geda-data-dirs.m4
+++ b/m4/geda-data-dirs.m4
@@ -29,7 +29,7 @@ AC_DEFUN([AX_DATA_DIRS],
   # gnetlist backends)
   # FIXME at some point this should become "$datarootdir/geda-gaf" to
   # match the tarball name.
-  GEDADATADIR="$datarootdir/lepton-eda"
+  LEPTONDATADIR="$datarootdir/lepton-eda"
 
   # Check where to install rc files.
   # FIXME at some point the rc directory needs to start *defaulting*
@@ -45,35 +45,35 @@ AC_DEFUN([AX_DATA_DIRS],
           GEDARCDIR="$with_rcdir"
         fi
       else
-        GEDARCDIR="$GEDADATADIR"
+        GEDARCDIR="$LEPTONDATADIR"
       fi ],
-      GEDARCDIR="$GEDADATADIR")
+      GEDARCDIR="$LEPTONDATADIR")
 
   # Now define some preprocessor symbols with the *expanded* values,
   # but only if not doing a relocatable build.
   if test "x$enable_relocatable" != "xyes"; then
-    GEDADATADIR_expand=`eval "echo $GEDADATADIR" | sed -e"s:^NONE:$ac_default_prefix:"`
-    AC_DEFINE_UNQUOTED([GEDADATADIR], ["$GEDADATADIR_expand"],
+    LEPTONDATADIR_expand=`eval "echo $LEPTONDATADIR" | sed -e"s:^NONE:$ac_default_prefix:"`
+    AC_DEFINE_UNQUOTED([LEPTONDATADIR], ["LEPTONDATADIR_expand"],
       [Define to gEDA/gaf shared data directory.
 Only libgeda should use this - apps should use eda_get_system_data_dirs()])
 
     if test "x$GEDARCDIR" != "x"; then
       GEDARCDIR_expand=`eval "echo $GEDARCDIR" | sed -e"s:^NONE:$ac_default_prefix:"`
       AC_DEFINE_UNQUOTED([GEDARCDIR], ["$GEDARCDIR_expand"],
-        [Define to gEDA/gaf rc directory if different from GEDADATADIR.
+        [Define to gEDA/gaf rc directory if different from LEPTONDATADIR.
 Only libgeda should use this - apps should use eda_get_system_data_dirs()])
     fi
   fi
 
   if test "x$GEDARCDIR" = "x"; then
-    GEDARCDIR=$GEDADATADIR
+    GEDARCDIR=$LEPTONDATADIR
   fi
 
-  AC_SUBST([GEDADATADIR])
+  AC_SUBST([LEPTONDATADIR])
   AC_SUBST([GEDARCDIR])
 
-  AC_MSG_CHECKING([where to install Lepton shared data (GEDADATADIR)])
-  AC_MSG_RESULT([$GEDADATADIR])
+  AC_MSG_CHECKING([where to install Lepton shared data (LEPTONDATADIR)])
+  AC_MSG_RESULT([$LEPTONDATADIR])
 
   AC_MSG_CHECKING([where to install Lepton rc files (GEDARCDIR)])
   AC_MSG_RESULT([$GEDARCDIR])
@@ -81,15 +81,15 @@ Only libgeda should use this - apps should use eda_get_system_data_dirs()])
   # create #define LEPTON_SCM_PRECOMPILE_DIR in config.h:
   #
   AC_DEFINE_UNQUOTED([LEPTON_SCM_PRECOMPILE_DIR],
-                     ["$GEDADATADIR_expand/ccache"],
+                     ["$LEPTONDATADIR_expand/ccache"],
                      [precompiled scm files dir])
 
-  AC_SUBST([LEPTON_SCM_PRECOMPILE_DIR], ["$GEDADATADIR_expand/ccache"])
+  AC_SUBST([LEPTON_SCM_PRECOMPILE_DIR], ["$LEPTONDATADIR_expand/ccache"])
 
   AC_DEFINE_UNQUOTED([BITMAP_DIRECTORY],
-                     ["$GEDADATADIR_expand/bitmap"],
+                     ["$LEPTONDATADIR_expand/bitmap"],
                      [directory with bitmaps])
 
-  AC_SUBST([BITMAP_DIRECTORY], ["$GEDADATADIR_expand/bitmap"])
+  AC_SUBST([BITMAP_DIRECTORY], ["$LEPTONDATADIR_expand/bitmap"])
 
 ])dnl AX_DATA_DIRS

--- a/m4/geda-data-dirs.m4
+++ b/m4/geda-data-dirs.m4
@@ -1,7 +1,7 @@
 # geda-data-dirs.m4                                     -*-Autoconf-*-
 # serial 2.0
 
-dnl gEDA data and configuration directories
+dnl Lepton EDA data and configuration directories
 dnl Copyright (C) 2009, 2016  Peter Brett <peter@peter-b.co.uk>
 dnl Copyright (C) 2018-2019 Lepton EDA Contributors
 dnl
@@ -19,7 +19,7 @@ dnl You should have received a copy of the GNU General Public License
 dnl along with this program; if not, write to the Free Software
 dnl Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-# Check where gEDA data and configuration should be stored.
+# Check where Lepton data and configuration should be stored.
 AC_DEFUN([AX_DATA_DIRS],
 [
   AC_PREREQ([2.60])dnl
@@ -27,14 +27,11 @@ AC_DEFUN([AX_DATA_DIRS],
 
   # Check where to install ordinary data files (e.g. symbols and
   # gnetlist backends)
-  # FIXME at some point this should become "$datarootdir/geda-gaf" to
-  # match the tarball name.
   LEPTONDATADIR="$datarootdir/lepton-eda"
 
-  # Check where to install rc files.
-  # FIXME at some point the rc directory needs to start *defaulting*
-  # to "$sysconfdir/geda-gaf" in order to comply with the GNU & Linux
-  # FHS guidelines.
+  # Check where to install rc files.  The rc directory name
+  # defaults to "$sysconfdir/" in order to comply with the GNU &
+  # Linux FHS guidelines.
   AC_ARG_WITH([rcdir],
     AS_HELP_STRING([--with-rcdir[[[=DIR]]]],
       [install system config in specific DIR]),
@@ -54,14 +51,14 @@ AC_DEFUN([AX_DATA_DIRS],
   if test "x$enable_relocatable" != "xyes"; then
     LEPTONDATADIR_expand=`eval "echo $LEPTONDATADIR" | sed -e"s:^NONE:$ac_default_prefix:"`
     AC_DEFINE_UNQUOTED([LEPTONDATADIR], ["LEPTONDATADIR_expand"],
-      [Define to gEDA/gaf shared data directory.
-Only libgeda should use this - apps should use eda_get_system_data_dirs()])
+      [Define to Lepton EDA shared data directory.
+Only liblepton should use this - apps should use eda_get_system_data_dirs()])
 
     if test "x$LEPTONRCDIR" != "x"; then
       LEPTONRCDIR_expand=`eval "echo $LEPTONRCDIR" | sed -e"s:^NONE:$ac_default_prefix:"`
       AC_DEFINE_UNQUOTED([LEPTONRCDIR], ["$LEPTONRCDIR_expand"],
-        [Define to gEDA/gaf rc directory if different from LEPTONDATADIR.
-Only libgeda should use this - apps should use eda_get_system_data_dirs()])
+        [Define to Lepton EDA rc directory if different from LEPTONDATADIR.
+Only liblepton should use this - apps should use eda_get_system_data_dirs()])
     fi
   fi
 

--- a/m4/lepton-data-dirs.m4
+++ b/m4/lepton-data-dirs.m4
@@ -1,4 +1,4 @@
-# geda-data-dirs.m4                                     -*-Autoconf-*-
+# lepton-data-dirs.m4                                   -*-Autoconf-*-
 # serial 2.0
 
 dnl Lepton EDA data and configuration directories

--- a/netlist/scheme/Makefile.am
+++ b/netlist/scheme/Makefile.am
@@ -25,14 +25,14 @@ M4=		@M4@
 PCBM4DIR=	@PCBM4DIR@
 PCBCONFDIR=	@PCBCONFDIR@
 
-scmdatadir = @GEDADATADIR@/scheme
+scmdatadir = @LEPTONDATADIR@/scheme
 nobase_scmdata_DATA = $(DIST_SCM) $(DIST_SCM_BACKENDS) $(DIST_SCM_BACKENDS_COMMON) $(BUILT_SCM)
 
 
 config-netlist.scm: config-netlist.scm.in
 	sed -e 's,[@]backenddir[@],$(scmdatadir)/backend,g' < $(srcdir)/$@.in > $@
 
-gafrcddir = @GEDADATADIR@/scheme/autoload
+gafrcddir = @LEPTONDATADIR@/scheme/autoload
 gafrcd_DATA = config-netlist.scm
 
 

--- a/schematic/bitmap/Makefile.am
+++ b/schematic/bitmap/Makefile.am
@@ -1,5 +1,5 @@
 
-bitmapdatadir = $(GEDADATADIR)/bitmap
+bitmapdatadir = $(LEPTONDATADIR)/bitmap
 bitmapdata_DATA = \
                   gschem-about-logo.png                                  \
                   gschem-bus.xpm                                         \

--- a/schematic/data/Makefile.am
+++ b/schematic/data/Makefile.am
@@ -3,7 +3,7 @@ theme=hicolor
 # --------------------------------------------------------------------
 # These icons get installed to a gEDA-specific icons
 # directory. They're used within gschem.
-icondir = $(GEDADATADIR)/icons/$(theme)
+icondir = $(LEPTONDATADIR)/icons/$(theme)
 iconsvg = gschem-icons.svg
 
 action_icons = \

--- a/schematic/lib/Makefile.am
+++ b/schematic/lib/Makefile.am
@@ -1,5 +1,5 @@
 
-rcdatadir = $(GEDARCDIR)
+rcdatadir = $(LEPTONRCDIR)
 rcdata_DATA = system-gschemrc gschem-gtkrc gschem-colormap-lightbg gschem-colormap-darkbg gschem-colormap-bw
 
 system-gschemrc: $(top_builddir)/configure system-gschemrc.scm

--- a/schematic/scheme/Makefile.am
+++ b/schematic/scheme/Makefile.am
@@ -1,6 +1,6 @@
 ## -*- Makefile -*-
 
-scmdatadir = $(GEDADATADIR)/scheme
+scmdatadir = $(LEPTONDATADIR)/scheme
 nobase_dist_scmdata_DATA = \
 	auto-refdes.scm \
 	auto-uref.scm \

--- a/symbols/Makefile.am
+++ b/symbols/Makefile.am
@@ -50,10 +50,10 @@ SUBDIRS = \
 	verilog \
 	vhdl
 
-gafrcddir = $(GEDADATADIR)/scheme/autoload
+gafrcddir = $(LEPTONDATADIR)/scheme/autoload
 dist_gafrcd_DATA = config-symbol-libraries.scm
 
-datasymdir = $(GEDADATADIR)/sym
+datasymdir = $(LEPTONDATADIR)/sym
 
 EXTRA_DIST = \
 	ChangeLog \

--- a/symbols/gnetman/Makefile.am
+++ b/symbols/gnetman/Makefile.am
@@ -1,5 +1,5 @@
 instdirname = sym-gnetman
-datasymdir = $(GEDADATADIR)/$(instdirname)
+datasymdir = $(LEPTONDATADIR)/$(instdirname)
 
 dist-hook:
 	$(MKDIR_P) $(distdir)

--- a/symbols/verilog/Makefile.am
+++ b/symbols/verilog/Makefile.am
@@ -1,5 +1,5 @@
 instdirname = sym-verilog
-datasymdir = $(GEDADATADIR)/$(instdirname)
+datasymdir = $(LEPTONDATADIR)/$(instdirname)
 
 dist-hook:
 	$(MKDIR_P) $(distdir)

--- a/symbols/vhdl/Makefile.am
+++ b/symbols/vhdl/Makefile.am
@@ -1,5 +1,5 @@
 instdirname = sym-vhdl
-datasymdir = $(GEDADATADIR)/$(instdirname)
+datasymdir = $(LEPTONDATADIR)/$(instdirname)
 
 dist-hook:
 	$(MKDIR_P) $(distdir)

--- a/symcheck/scheme/Makefile.am
+++ b/symcheck/scheme/Makefile.am
@@ -22,7 +22,7 @@ uninstall-hook:
 	rm -f $(DESTDIR)$(bindir)/$(COMPAT_NAME)
 endif INSTALL_COMPAT_SYMLINKS
 
-scmdatadir = $(GEDADATADIR)/scheme
+scmdatadir = $(LEPTONDATADIR)/scheme
 nobase_dist_scmdata_DATA = \
 	symbol/blame.scm \
 	symbol/check.scm \


### PR DESCRIPTION
This is ongoing work on renaming *geda* to *lepton*.
In this commit set, two internal m4 variables, `GEDADATADIR` and `GEDARCDIR`, have been renamed and are now reported on the `configure` stage. Several docs, comments, and messages, have been fixed to reflect *real* related to guile directory names currently used in lepton.