### PR TITLE
Remove obsolete stuff - part 2

### DIFF
--- a/liblepton/lib/system-gafrc
+++ b/liblepton/lib/system-gafrc
@@ -24,14 +24,11 @@
 (use-modules (geda deprecated))
 
 
-; scheme-directory dir
+; Function: scheme-directory( dir )
 ;
-; This keyword allows additional directories to be added to the list
-; of directories which are used by gEDA to load Scheme code.
-; Environment variables in 'dir' are expanded.  By default,
-; '${GEDADATA}/scheme' is in the load path, as are all of the standard
-; Guile Scheme libraries.
-;(scheme-directory "${HOME}/.gEDA/scheme")
+; Allows additional directories to be added to the list
+; of directories which are used by Lepton EDA to load Scheme code.
+; Environment variables in 'dir' are expanded.
 
 
 ;;;; Color maps

--- a/liblepton/scheme/lepton/rc.scm
+++ b/liblepton/scheme/lepton/rc.scm
@@ -37,10 +37,8 @@
 ;; usually return #f if gEDA was compiled with --disable-deprecated.
 ;; Use the sys-data-dirs and sys-config-dirs functions from the (geda
 ;; os) module instead.
-(define geda-data-path (or (getenv "GEDADATA")
-                           (last (sys-data-dirs))))
-(define geda-rc-path (or (getenv "GEDADATARC") (getenv "GEDADATA")
-                         (last (sys-config-dirs))))
+(define geda-data-path (last (sys-data-dirs)))
+(define geda-rc-path (last (sys-config-dirs)))
 
 (define (build-path first . rest)
   "Build path from one or more path components, separating them by

--- a/liblepton/src/edapaths.c
+++ b/liblepton/src/edapaths.c
@@ -318,55 +318,54 @@ eda_get_system_data_dirs()
 
 
 
-/*!
- * \brief Get an ordered list of Lepton EDA configuration directories
- * \par Function Description
- * Return an ordered list of directories to be searched for
- * system-wide Lepton configuration.  This list is computed as
- * follows:
+/*! \brief Get an ordered list of system-wide configuration directories.
  *
- * 1. If the $GEDADATARC environment variable is set, add it to the
- *    list.  Otherwise, if $GEDADATA is set, add that to the list.
- *
- * 2. If neither environment variable is set, add the "lepton-eda"
- *    subdirectory of each of the platform-specific system-wide
- *    application directories, as provided by
- *    g_get_system_config_dirs().
- *
- * 3. For non-relocatable builds the configuration installation
- *    directory configured at build time is appended to the list.
- *
- * \return An ordered list of directories to be searched for system
- * configuration.
+ *  \return Immutable NULL-terminated string array.
  */
-const gchar * const *
-eda_get_system_config_dirs(void)
+const gchar* const*
+eda_get_system_config_dirs()
 {
-	static const gchar **system_config_dirs;
+  static const gchar** system_config_dirs;
 
-	if (g_once_init_enter(&system_config_dirs)) {
-		const gchar * const env_names[] = { CONFIG_ENV, DATA_ENV, NULL };
-		const gchar * const * xdg_dirs = g_get_system_config_dirs();
-		const gchar * const cfg_dirs[] = { LEPTONRCDIR, NULL };
+  if (g_once_init_enter (&system_config_dirs))
+  {
+    const gchar* const* dirs = g_get_system_config_dirs();
 
-		const gchar **dirs =
-			build_search_list(env_names, xdg_dirs, cfg_dirs);
+    /* determine [dirs] array size:
+     */
+    int count = 0;
+    for ( ; dirs[count] != NULL; ++count )
+    {
+    }
+
+    ++ count; /* for LEPTONDATADIR */
+    ++ count; /* for terminating NULL element */
+
+
+    const gchar** result = g_new0 (const gchar*, count);
+
+    int ndx = 0;
+    for ( ; dirs[ ndx ] != NULL; ++ndx )
+    {
+      result[ ndx ] = g_build_filename (dirs[ ndx ], PACKAGE, NULL);
+    }
+
+    result[ ndx ]   = LEPTONDATADIR; /* defined in config.h */
+    result[ ++ndx ] = NULL;
 
 #ifdef DEBUG
     fprintf (stderr, "\n");
-    dbg_out_dirs (env_names, "eda_get_system_config_dirs()::env_names");
-    dbg_out_dirs (xdg_dirs,  "eda_get_system_config_dirs()::xdg_dirs");
-    dbg_out_dirs (cfg_dirs,  "eda_get_system_config_dirs()::cfg_dirs");
-    fprintf (stderr, "\n");
-    dbg_out_dirs (dirs, "eda_get_system_config_dirs()::dirs (combined)");
-    fprintf (stderr, "\n");
+    dbg_out_dirs (result, "eda_get_system_config_dirs()");
 #endif
 
-		g_once_init_leave(&system_config_dirs, dirs);
-	}
+    g_once_init_leave (&system_config_dirs, result);
+  }
 
-	return system_config_dirs;
-}
+  return system_config_dirs;
+
+} /* eda_get_system_config_dirs() */
+
+
 
 const gchar *
 eda_get_user_data_dir(void)

--- a/liblepton/src/edapaths.c
+++ b/liblepton/src/edapaths.c
@@ -39,7 +39,6 @@ static const gchar* const DATA_XDG_SUBDIR = "lepton-eda";
 
 #if defined(ENABLE_DEPRECATED)
 static const gchar* const DATA_GUESS_FILE = "scheme/geda.scm";
-static const gchar* const USER_DOTDIR     = ".gEDA";
 #endif
 
 /* ================================================================
@@ -236,20 +235,6 @@ eda_paths_init_env(void)
 #endif /* ENABLE_DEPRECATED */
 }
 
-static gchar *
-get_user_dotdir(void)
-{
-#if defined(ENABLE_DEPRECATED)
-	gchar *dotdir = g_build_filename(g_get_home_dir(),
-	                                 USER_DOTDIR, NULL);
-	if (g_file_test(dotdir, G_FILE_TEST_IS_DIR)) {
-		return dotdir;
-	}
-	g_free(dotdir);
-#endif /* ENABLE_DEPRECATED */
-	return NULL;
-}
-
 /* ================================================================
  * Public accessors
  * ================================================================ */
@@ -367,45 +352,48 @@ eda_get_system_config_dirs()
 
 
 
-const gchar *
-eda_get_user_data_dir(void)
+/*! \brief Get user's data directory (e.g. ~/.local/share/lepton-eda).
+ */
+const gchar*
+eda_get_user_data_dir()
 {
-	static gchar *user_data_dir;
+  static gchar* user_data_dir;
 
-	if (g_once_init_enter(&user_data_dir)) {
-		gchar *dir = get_user_dotdir();
+  if (g_once_init_enter (&user_data_dir))
+  {
+    gchar* dir = g_build_filename (g_get_user_data_dir(),
+                                   PACKAGE, NULL);
 
-		if (!dir) {
-			dir = g_build_filename(g_get_user_data_dir(),
+    g_once_init_leave (&user_data_dir, dir);
+  }
 
-			                       DATA_XDG_SUBDIR, NULL);
-		}
-
-		g_once_init_leave(&user_data_dir, dir);
-	}
-
-	return user_data_dir;
+  return user_data_dir;
 }
 
-const gchar *
-eda_get_user_config_dir(void)
+
+
+/*! \brief Get user's configuration directory (e.g. ~/.config/lepton-eda).
+ */
+const gchar*
+eda_get_user_config_dir()
 {
-	static gchar *user_config_dir;
+  static gchar* user_config_dir;
 
-	if (g_once_init_enter(&user_config_dir)) {
-		gchar *dir = get_user_dotdir();
+  if (g_once_init_enter (&user_config_dir))
+  {
+    gchar* dir = g_build_filename (g_get_user_config_dir(),
+                                   PACKAGE, NULL);
 
-		if (!dir) {
-			dir = g_build_filename(g_get_user_config_dir(),
-			                       DATA_XDG_SUBDIR, NULL);
-		}
+    g_once_init_leave (&user_config_dir, dir);
+  }
 
-		g_once_init_leave(&user_config_dir, dir);
-	}
-
-	return user_config_dir;
+  return user_config_dir;
 }
 
+
+
+/*! \brief Get user's cache directory (e.g. ~/.cache/lepton-eda).
+ */
 const gchar*
 eda_get_user_cache_dir()
 {
@@ -414,7 +402,7 @@ eda_get_user_cache_dir()
   if (g_once_init_enter (&user_cache_dir))
   {
     gchar* dir = g_build_filename (g_get_user_cache_dir(),
-                                   DATA_XDG_SUBDIR, NULL);
+                                   PACKAGE, NULL);
 
     g_once_init_leave (&user_cache_dir, dir);
   }

--- a/liblepton/src/edapaths.c
+++ b/liblepton/src/edapaths.c
@@ -267,54 +267,56 @@ dbg_out_dirs (const gchar* const* dirs, const gchar* name)
 }
 #endif
 
-/*!
- * \brief Get an ordered list of Lepton EDA data directories
- * \par Function Description
- * Return an ordered list of directories to be searched for
- * system-wide Lepton data.  This list is computed as follows:
+
+
+/*! \brief Get an ordered list of system-wide data directories.
  *
- * 1. If the $GEDADATA environment variable is set, add it to the
- *    list.
- *
- * 2. If the $GEDADATA environment variable is not set, add the
- *    "lepton-eda" subdirectory of each of the platform-specific
- *    system-wide application data directories, as provided by
- *    g_get_system_data_dirs().
- *
- * 3. For non-relocatable builds the installation directory configured
- *    at build time is appended to the list.
- *
- * \return An ordered list of directories to be searched for system
- * data.
+ *  \return Immutable NULL-terminated string array.
  */
-const gchar * const *
-eda_get_system_data_dirs(void)
+const gchar* const*
+eda_get_system_data_dirs()
 {
-	static const gchar **system_data_dirs;
+  static const gchar** system_data_dirs;
 
-	if (g_once_init_enter(&system_data_dirs)) {
-		const gchar * const env_names[] = { DATA_ENV, NULL };
-		const gchar * const * xdg_dirs = g_get_system_data_dirs();
-		const gchar * const cfg_dirs[] = { LEPTONDATADIR, NULL };
+  if (g_once_init_enter (&system_data_dirs))
+  {
+    const gchar* const* dirs = g_get_system_data_dirs();
 
-		const gchar **dirs =
-			build_search_list(env_names, xdg_dirs, cfg_dirs);
+    /* determine [dirs] array size:
+     */
+    int count = 0;
+    for ( ; dirs[count] != NULL; ++count )
+    {
+    }
+
+    ++ count; /* for LEPTONDATADIR */
+    ++ count; /* for terminating NULL element */
+
+
+    const gchar** result = g_new0 (const gchar*, count);
+
+    int ndx = 0;
+    for ( ; dirs[ ndx ] != NULL; ++ndx )
+    {
+      result[ ndx ] = g_build_filename (dirs[ ndx ], PACKAGE, NULL);
+    }
+
+    result[ ndx ]   = LEPTONDATADIR; /* defined in config.h */
+    result[ ++ndx ] = NULL;
 
 #ifdef DEBUG
     fprintf (stderr, "\n");
-    dbg_out_dirs (env_names, "eda_get_system_data_dirs()::env_names");
-    dbg_out_dirs (xdg_dirs,  "eda_get_system_data_dirs()::xdg_dirs");
-    dbg_out_dirs (cfg_dirs,  "eda_get_system_data_dirs()::cfg_dirs");
-    fprintf (stderr, "\n");
-    dbg_out_dirs (dirs, "eda_get_system_data_dirs()::dirs (combined)");
-    fprintf (stderr, "\n");
+    dbg_out_dirs (result, "eda_get_system_data_dirs()");
 #endif
 
-		g_once_init_leave(&system_data_dirs, dirs);
-	}
+    g_once_init_leave (&system_data_dirs, result);
+  }
 
-	return system_data_dirs;
-}
+  return system_data_dirs;
+
+} /* eda_get_system_data_dirs() */
+
+
 
 /*!
  * \brief Get an ordered list of Lepton EDA configuration directories

--- a/liblepton/src/edapaths.c
+++ b/liblepton/src/edapaths.c
@@ -18,226 +18,9 @@
  */
 
 #include <config.h>
-
-#if !defined(G_OS_WIN32)
-#	include <libgen.h>
-#endif
-
 #include "libgeda_priv.h"
 
-/* For convenience in this file only! */
-#if !defined(LEPTONDATADIR)
-#	define LEPTONDATADIR NULL
-#endif
-#if !defined(LEPTONRCDIR)
-#	define LEPTONRCDIR LEPTONDATADIR
-#endif
 
-static const gchar* const DATA_ENV        = "GEDADATA";
-static const gchar* const CONFIG_ENV      = "GEDADATARC";
-static const gchar* const DATA_XDG_SUBDIR = "lepton-eda";
-
-#if defined(ENABLE_DEPRECATED)
-static const gchar* const DATA_GUESS_FILE = "scheme/geda.scm";
-#endif
-
-/* ================================================================
- * Private initialisation functions
- * ================================================================ */
-
-/*! \brief Get the Lepton EDA installation's data directory.
- * Attempt to find the "share/lepton-eda" directory in the prefix
- * where Lepton was installed.  Returns NULL if not on Windows and
- * not a relocatable build (in that case, the install location
- * should have been compiled in via configure options) */
-static const gchar *
-guess_install_data_dir(void)
-{
-	static const gchar *install_dir = NULL;
-	static gsize is_init = 0;
-	if (g_once_init_enter(&is_init)) {
-		gchar *tmp_dir = NULL;
-
-#if defined(G_OS_WIN32)
-		/* The installation data directory should be the last element in
-		 *  g_get_system_data_dirs(). */
-		static const gchar * const *sys_dirs;
-		for (gint i = 0; sys_dirs[i]; ++i, tmp_dir = sys_dirs[i]);
-
-#endif
-
-		/* Check that the directory actually exists */
-		if (tmp_dir && !g_file_test(tmp_dir, G_FILE_TEST_IS_DIR)) {
-			g_free(tmp_dir);
-		} else {
-			install_dir = tmp_dir;
-		}
-
-		g_once_init_leave(&is_init, 1);
-	}
-	return install_dir;
-}
-
-/*! \brief Copy search paths into result structure.
- * Helper function that duplicated search paths from the various
- * sources into an output buffer and returns the number of paths.  If
- * the output pointer is NULL, doesn't copy, but still returns the
- * number of paths.  Only exists for the use of
- * build_search_list(). */
-static gsize
-copy_search_list(const gchar **output,
-                 const gchar * const * env_names,
-                 const gchar * const * xdg_dirs,
-                 const gchar * const * cfg_dirs)
-{
-	/* Copy in the entries.  Duplicate everything so the result is fully
-	 * owned by us. */
-	gsize copied = 0;
-
-#if defined(ENABLE_DEPRECATED)
-	/* If one of the environment variables is set, it takes precedence. */
-	for (gsize i = 0; env_names && env_names[i]; ++i) {
-		const gchar *env_value = g_getenv(env_names[i]);
-		if (!env_value) continue;
-
-		if (output) {
-			output[0] = g_strdup(env_value);
-			output[1] = NULL;
-		}
-		/* The first environment variable found overrides all. */
-		return 2;
-	}
-#endif /* ENABLE_DEPRECATED */
-
-	/* Otherwise, use the "lepton-eda" subdirectory of the
-	 * configured standard directories. */
-	for (gsize i = 0; xdg_dirs && xdg_dirs[i]; ++i) {
-		/* Append "lepton-eda" to each XDG data path */
-		if (output) {
-			output[copied] =
-				g_build_filename(xdg_dirs[i],
-				                 DATA_XDG_SUBDIR, NULL);
-		}
-		++copied;
-	}
-
-#if !defined(G_OS_WIN32)
-	/* Append the configured variables to the list */
-	for (gsize i = 0; cfg_dirs && cfg_dirs[i]; ++i) {
-		if (output) {
-			output[copied] = g_strdup(cfg_dirs[i]);
-		}
-		++copied;
-	}
-#endif
-
-	/* Append the guessed install directory to the list, if it's not in
-	 * there already. */
-	const gchar *install_dir = guess_install_data_dir();
-	if (install_dir) {
-		if (output) {
-			/* Only append to search path if not already an element.
-			 * N.b. we could use g_strv_contains() here, but it's only
-			 * available in quite recent versions of GLib.*/
-			gboolean found = FALSE;
-			for (guint i = 0; !found && i < copied; ++i) {
-				found = (0 == strcmp(install_dir, output[i]));
-			}
-
-			if (!found) {
-				output[copied] = g_strdup(install_dir);
-				++copied;
-			}
-		} else {
-			/* Allow space just in case */
-			++copied;
-		}
-	}
-
-	if (output) output[copied] = NULL;
-	++copied;
-
-	return copied;
-}
-
-/*! \brief Build a set of search paths.
- * Build a null-terminated array of constant strings, using the input
- * parameters.
- *
- * \param env_names NULL-terminated list of environment variable
- *                  names.  If any of them is set, it is the only item
- *                  in the returned list.
- * \param xdg_dirs  NULL-terminated list of directory names.  All
- *                  of them have Lepton's XDG subdirectory
- *                  (i.e. "lepton-eda") appended to them and are
- *                  added to the list in order.
- * \param cfg_dirs NULL terminated list of additional directories to
- *                 append to the list.
- * \return a newly-allocated, NULL-terminated array of strings.
- */
-static const gchar **
-build_search_list(const gchar * const * env_names,
-                  const gchar * const * xdg_dirs,
-                  const gchar * const * cfg_dirs)
-{
-	
-	gsize count = 0;
-	const gchar **result = NULL;
-
-	while (TRUE) {
-		/* The first time copy_search_list() is called, it returns the
-		 * length of buffer required. */
-		count = copy_search_list(result, env_names, xdg_dirs, cfg_dirs);
-
-		if (result) break;
-		result = g_new0(const gchar *, count);
-	}
-
-	return result;
-}
-
-/* \brief Initialise backwards-compatible environment variables.
- * Ensure that the $GEDADATA environment variable is always set to
- * something sensible within Lepton programs.
- */
-static void
-eda_paths_init_env(void)
-{
-#if defined(ENABLE_DEPRECATED)
-	static gsize is_init = 0;
-
-	/* If $GEDADATA is not set, find a directory containing
-	 * scheme/geda.scm and set $GEDADATA to it.  Note that this
-	 * *doesn't* use guess_install_data_dir() because the user might
-	 * have deliberately set $XDG_DATA_DIRS to put other directories
-	 * ahead of the installation data directory. */
-	if (g_once_init_enter(&is_init)) {
-
-		gboolean found = FALSE;
-		const gchar * const *dirs = eda_get_system_data_dirs();
-
-		for (int i = 0; dirs[i]; ++i) {
-
-			gchar *guess_file =
-				g_build_filename(dirs[i], DATA_GUESS_FILE, NULL);
-			found = g_file_test(guess_file, G_FILE_TEST_IS_REGULAR);
-			g_free(guess_file);
-
-			if (!found) continue;
-
-			g_setenv(DATA_ENV, dirs[i], FALSE);
-			break;
-		}
-
-		gsize setup = 1;
-		g_once_init_leave(&is_init, setup);
-	}
-#endif /* ENABLE_DEPRECATED */
-}
-
-/* ================================================================
- * Public accessors
- * ================================================================ */
 
 #ifdef DEBUG
 static void
@@ -410,26 +193,22 @@ eda_get_user_cache_dir()
   return user_cache_dir;
 }
 
-/* ================================================================
- * Module initialisation
- * ================================================================ */
 
-/*!
- * \brief Initialise Lepton EDA data and configuration search paths.
+
+/*! \brief Initialise Lepton EDA data and configuration search paths.
+ *
  * \par Function Description
- * Compute and initialise configuration and data search paths used by
- * Lepton, and set any related environment variables.  Should only be
- * called (once) by liblepton_init().
+ * Should only be called (once) by liblepton_init().
  */
 void
-eda_paths_init(void)
+eda_paths_init()
 {
-	/* Force initialisation */
-	eda_get_system_data_dirs();
-	eda_get_system_config_dirs();
-	eda_get_user_data_dir();
-	eda_get_user_config_dir();
-	eda_get_user_cache_dir();
-
-	eda_paths_init_env();
+  /* These function stores their data in static local variables.
+   * Calling them here forces data initialization:
+  */
+  eda_get_system_data_dirs();
+  eda_get_system_config_dirs();
+  eda_get_user_data_dir();
+  eda_get_user_config_dir();
+  eda_get_user_cache_dir();
 }

--- a/netlist/tests/run-test
+++ b/netlist/tests/run-test
@@ -9,8 +9,6 @@ LIBLEPTON="${abs_top_builddir}/liblepton/src/liblepton"
 export LIBLEPTON
 
 GNETLIST="${abs_top_builddir}/netlist/scheme/lepton-netlist"
-GEDADATARC="${abs_top_builddir}/liblepton/lib"
-export GEDADATARC
 
 export GUILE_LOAD_PATH="${abs_top_srcdir}/netlist/scheme:${abs_top_builddir}/netlist/scheme:${abs_top_srcdir}/liblepton/scheme:${abs_top_builddir}/liblepton/scheme:${abs_top_srcdir}/symcheck/scheme:${abs_top_builddir}/symcheck/scheme:..."
 

--- a/symcheck/tests/Makefile.am
+++ b/symcheck/tests/Makefile.am
@@ -84,7 +84,6 @@ tests:
 	[ -e $$ERRORLOG ] && rm $$ERRORLOG; \
 	for file in $(abs_srcdir)/*.sym; do \
 	  base=`basename $$file`; \
-	  GEDADATARC="${abs_top_builddir}/liblepton/lib" \
 	  $(SHELL) $(srcdir)/runtest.sh $$file; \
 	  if [ $$? -ne 0 ]; then \
 	     echo "FAIL: $$base"; \

--- a/utils/src/lepton-sch2pcb.c
+++ b/utils/src/lepton-sch2pcb.c
@@ -1267,11 +1267,18 @@ load_extra_project_files (void)
   if (done)
     return;
 
+  /* TODO: rename project files ("gsch2pcb") */
+
+  /* TODO: consider linking sch2pcb with liblepton and
+   *       using eda_get_system_config_dirs() here:
+  */
   load_project ("/etc/gsch2pcb");
   load_project ("/usr/local/etc/gsch2pcb");
 
-  path = g_build_filename ((gchar *) g_get_home_dir (), ".gEDA",
-                           "gsch2pcb", NULL);
+  path = g_build_filename (g_get_user_config_dir(),
+                           PACKAGE,
+                           "gsch2pcb",
+                           NULL);
   load_project (path);
   g_free (path);
 


### PR DESCRIPTION
- Get rid of obsolete `GEDADATA`, `GEDADATARC`  environment variables
- Do not use `$HOME/.gEDA/` directory

In `q3` parlance, three frags left:
- remove `--disable-deprecated`
- remove `--enable-compat-symlinks`
- fix all man pages (the `ENVIRONMENT` section)

I propose to retain one of the "deprecated" features,  namely,
a custom `gtkrc` file (`gschem-gtkrc`, rename it).
