### PR TITLE
lepton-attrib fix messages and update its PO file

### DIFF
--- a/attrib/po/af.po
+++ b/attrib/po/af.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-10-03 23:30+0300\n"
+"POT-Creation-Date: 2020-03-07 14:33+0300\n"
 "PO-Revision-Date: 2012-01-27 14:17+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: Afrikaans <af@li.org>\n"
@@ -25,7 +25,7 @@ msgid "Manipulate component attributes with lepton-attrib"
 msgstr ""
 
 #, c-format
-msgid "o_save: Could not open [%1$s]"
+msgid "Could not open [%1$s]"
 msgstr ""
 
 #, c-format
@@ -44,13 +44,15 @@ msgstr ""
 
 #, c-format
 msgid ""
+"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
 "\n"
 "lepton-attrib: Lepton EDA attribute editor.\n"
 "Presents schematic attributes in easy-to-edit spreadsheet format.\n"
 "\n"
-"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
+"Options:\n"
 "  -q, --quiet            Quiet mode\n"
 "  -v, --verbose          Verbose mode on\n"
+"  -V, --version          Show version information\n"
 "  -h, --help             This help menu\n"
 "\n"
 "  FAQ:\n"
@@ -72,11 +74,22 @@ msgid ""
 "Copyright (C) 2007-2016 gEDA Contributors.\n"
 "Copyright (C) 2017-2019 Lepton EDA Contributors.\n"
 "\n"
-"Please report bugs to %2$s.\n"
+"Report bugs at <%2$s>\n"
+"Lepton EDA homepage: <%3$s>\n"
 msgstr ""
 
 #, c-format
-msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
+msgid ""
+"\n"
+"Run `lepton-attrib --help' for more information.\n"
+msgstr ""
+
+#, c-format
+msgid "WARNING: "
+msgstr ""
+
+#, c-format
+msgid "Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 
 #, c-format
@@ -90,114 +103,78 @@ msgid " DONE\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Failed to find the attrib %1$s on the component.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Trying to add attrib to non-component or non-net!\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
-"or non-net!\n"
+msgid "Start master component list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master comp list creation.\n"
+msgid "Start master component attrib list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master comp attrib list creation.\n"
+msgid "Start master pin list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master pin list creation.\n"
+msgid "Found component pin with no pinnumber: refdes = %1$s\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_sheet_data_add_master_pin_list_items, found component pin with no "
-"pinnumber.\n"
+msgid "Start master pin attrib list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master pin attrib list creation.\n"
+msgid "Tried to add to a NULL list.\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
+msgid "Tried to remove item from empty list.\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
+msgid "Couldn't delete item %1$s\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_delete_item, couldn't delete item %s\n"
+msgid "We didn't find the row name in the row list!\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
+msgid "Start internal component TABLE creation\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting internal component TABLE creation\n"
+msgid "We didn't find either row or col in the lists!\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
-"or col in the lists!\n"
-msgstr ""
-
-#, c-format
-msgid "- Starting internal pin TABLE creation\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
-"col in the lists!\n"
+msgid "Start internal pin TABLE creation\n"
 msgstr ""
 
 msgid "_cancel"
 msgstr ""
 
 #, c-format
-msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
+msgid "Can't get attrib name\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
-"the master list!\n"
+msgid "We didn't find the refdes in the master list.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
+msgid "Either refdes or pinnumber of object missing.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
-"missing!\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
-"master list!\n"
-msgstr ""
-
-#, c-format
-msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
+msgid "We didn't find the refdes:pin in the master list.\n"
 msgstr ""
 
 msgid "Add new attribute"
@@ -216,7 +193,7 @@ msgid ""
 "One or more components have been found with missing symbol files!\n"
 "\n"
 "This probably happened because lepton-attrib couldn't find your component "
-"libraries, perhaps because your gafrc or gattribrc files are misconfigured.\n"
+"libraries, perhaps because your gafrc files are misconfigured.\n"
 "\n"
 "Choose \"Quit\" to leave lepton-attrib and fix the problem, or\n"
 "\"Forward\" to continue working with lepton-attrib.\n"

--- a/attrib/po/ar.po
+++ b/attrib/po/ar.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-10-03 23:30+0300\n"
+"POT-Creation-Date: 2020-03-07 14:33+0300\n"
 "PO-Revision-Date: 2010-02-08 18:58+0000\n"
 "Last-Translator: عبدالله شلي (Abdellah Chelli) <Unknown>\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -26,7 +26,7 @@ msgid "Manipulate component attributes with lepton-attrib"
 msgstr "عالج سمات المكوّن ب‍ gattrib"
 
 #, c-format
-msgid "o_save: Could not open [%1$s]"
+msgid "Could not open [%1$s]"
 msgstr ""
 
 #, c-format
@@ -45,13 +45,15 @@ msgstr ""
 
 #, c-format
 msgid ""
+"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
 "\n"
 "lepton-attrib: Lepton EDA attribute editor.\n"
 "Presents schematic attributes in easy-to-edit spreadsheet format.\n"
 "\n"
-"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
+"Options:\n"
 "  -q, --quiet            Quiet mode\n"
 "  -v, --verbose          Verbose mode on\n"
+"  -V, --version          Show version information\n"
 "  -h, --help             This help menu\n"
 "\n"
 "  FAQ:\n"
@@ -73,11 +75,22 @@ msgid ""
 "Copyright (C) 2007-2016 gEDA Contributors.\n"
 "Copyright (C) 2017-2019 Lepton EDA Contributors.\n"
 "\n"
-"Please report bugs to %2$s.\n"
+"Report bugs at <%2$s>\n"
+"Lepton EDA homepage: <%3$s>\n"
 msgstr ""
 
 #, c-format
-msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
+msgid ""
+"\n"
+"Run `lepton-attrib --help' for more information.\n"
+msgstr ""
+
+#, c-format
+msgid "WARNING: "
+msgstr ""
+
+#, c-format
+msgid "Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 
 #, c-format
@@ -91,114 +104,78 @@ msgid " DONE\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Failed to find the attrib %1$s on the component.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Trying to add attrib to non-component or non-net!\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
-"or non-net!\n"
+msgid "Start master component list creation.\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Start master component attrib list creation.\n"
+msgstr "عالج سمات المكوّن ب‍ gattrib"
+
+#, c-format
+msgid "Start master pin list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master comp list creation.\n"
+msgid "Found component pin with no pinnumber: refdes = %1$s\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master comp attrib list creation.\n"
+msgid "Start master pin attrib list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master pin list creation.\n"
+msgid "Tried to add to a NULL list.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_sheet_data_add_master_pin_list_items, found component pin with no "
-"pinnumber.\n"
+msgid "Tried to remove item from empty list.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master pin attrib list creation.\n"
+msgid "Couldn't delete item %1$s\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
+msgid "We didn't find the row name in the row list!\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
+msgid "Start internal component TABLE creation\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_delete_item, couldn't delete item %s\n"
+msgid "We didn't find either row or col in the lists!\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
-msgstr ""
-
-#, c-format
-msgid "- Starting internal component TABLE creation\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
-"or col in the lists!\n"
-msgstr ""
-
-#, c-format
-msgid "- Starting internal pin TABLE creation\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
-"col in the lists!\n"
+msgid "Start internal pin TABLE creation\n"
 msgstr ""
 
 msgid "_cancel"
 msgstr ""
 
 #, c-format
-msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
+msgid "Can't get attrib name\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
-"the master list!\n"
+msgid "We didn't find the refdes in the master list.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
+msgid "Either refdes or pinnumber of object missing.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
-"missing!\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
-"master list!\n"
-msgstr ""
-
-#, c-format
-msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
+msgid "We didn't find the refdes:pin in the master list.\n"
 msgstr ""
 
 msgid "Add new attribute"
@@ -217,7 +194,7 @@ msgid ""
 "One or more components have been found with missing symbol files!\n"
 "\n"
 "This probably happened because lepton-attrib couldn't find your component "
-"libraries, perhaps because your gafrc or gattribrc files are misconfigured.\n"
+"libraries, perhaps because your gafrc files are misconfigured.\n"
 "\n"
 "Choose \"Quit\" to leave lepton-attrib and fix the problem, or\n"
 "\"Forward\" to continue working with lepton-attrib.\n"

--- a/attrib/po/bg.po
+++ b/attrib/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-10-03 23:30+0300\n"
+"POT-Creation-Date: 2020-03-07 14:33+0300\n"
 "PO-Revision-Date: 2010-02-06 22:09+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -27,7 +27,7 @@ msgid "Manipulate component attributes with lepton-attrib"
 msgstr "Манипулирай атрибутите на компонента с gattrib"
 
 #, c-format
-msgid "o_save: Could not open [%1$s]"
+msgid "Could not open [%1$s]"
 msgstr ""
 
 #, c-format
@@ -46,13 +46,15 @@ msgstr ""
 
 #, c-format
 msgid ""
+"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
 "\n"
 "lepton-attrib: Lepton EDA attribute editor.\n"
 "Presents schematic attributes in easy-to-edit spreadsheet format.\n"
 "\n"
-"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
+"Options:\n"
 "  -q, --quiet            Quiet mode\n"
 "  -v, --verbose          Verbose mode on\n"
+"  -V, --version          Show version information\n"
 "  -h, --help             This help menu\n"
 "\n"
 "  FAQ:\n"
@@ -74,11 +76,22 @@ msgid ""
 "Copyright (C) 2007-2016 gEDA Contributors.\n"
 "Copyright (C) 2017-2019 Lepton EDA Contributors.\n"
 "\n"
-"Please report bugs to %2$s.\n"
+"Report bugs at <%2$s>\n"
+"Lepton EDA homepage: <%3$s>\n"
 msgstr ""
 
 #, c-format
-msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
+msgid ""
+"\n"
+"Run `lepton-attrib --help' for more information.\n"
+msgstr ""
+
+#, c-format
+msgid "WARNING: "
+msgstr ""
+
+#, c-format
+msgid "Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 
 #, c-format
@@ -92,114 +105,78 @@ msgid " DONE\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Failed to find the attrib %1$s on the component.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Trying to add attrib to non-component or non-net!\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
-"or non-net!\n"
+msgid "Start master component list creation.\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Start master component attrib list creation.\n"
+msgstr "Манипулирай атрибутите на компонента с gattrib"
+
+#, c-format
+msgid "Start master pin list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master comp list creation.\n"
+msgid "Found component pin with no pinnumber: refdes = %1$s\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master comp attrib list creation.\n"
+msgid "Start master pin attrib list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master pin list creation.\n"
+msgid "Tried to add to a NULL list.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_sheet_data_add_master_pin_list_items, found component pin with no "
-"pinnumber.\n"
+msgid "Tried to remove item from empty list.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master pin attrib list creation.\n"
+msgid "Couldn't delete item %1$s\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
+msgid "We didn't find the row name in the row list!\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
+msgid "Start internal component TABLE creation\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_delete_item, couldn't delete item %s\n"
+msgid "We didn't find either row or col in the lists!\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
-msgstr ""
-
-#, c-format
-msgid "- Starting internal component TABLE creation\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
-"or col in the lists!\n"
-msgstr ""
-
-#, c-format
-msgid "- Starting internal pin TABLE creation\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
-"col in the lists!\n"
+msgid "Start internal pin TABLE creation\n"
 msgstr ""
 
 msgid "_cancel"
 msgstr ""
 
 #, c-format
-msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
+msgid "Can't get attrib name\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
-"the master list!\n"
+msgid "We didn't find the refdes in the master list.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
+msgid "Either refdes or pinnumber of object missing.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
-"missing!\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
-"master list!\n"
-msgstr ""
-
-#, c-format
-msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
+msgid "We didn't find the refdes:pin in the master list.\n"
 msgstr ""
 
 msgid "Add new attribute"
@@ -218,7 +195,7 @@ msgid ""
 "One or more components have been found with missing symbol files!\n"
 "\n"
 "This probably happened because lepton-attrib couldn't find your component "
-"libraries, perhaps because your gafrc or gattribrc files are misconfigured.\n"
+"libraries, perhaps because your gafrc files are misconfigured.\n"
 "\n"
 "Choose \"Quit\" to leave lepton-attrib and fix the problem, or\n"
 "\"Forward\" to continue working with lepton-attrib.\n"

--- a/attrib/po/bs.po
+++ b/attrib/po/bs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-10-03 23:30+0300\n"
+"POT-Creation-Date: 2020-03-07 14:33+0300\n"
 "PO-Revision-Date: 2012-01-27 14:17+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: Bosnian <bs@li.org>\n"
@@ -27,7 +27,7 @@ msgid "Manipulate component attributes with lepton-attrib"
 msgstr "Upravljajte atributima komponenti pomoću gattrib"
 
 #, c-format
-msgid "o_save: Could not open [%1$s]"
+msgid "Could not open [%1$s]"
 msgstr ""
 
 #, c-format
@@ -46,13 +46,15 @@ msgstr ""
 
 #, c-format
 msgid ""
+"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
 "\n"
 "lepton-attrib: Lepton EDA attribute editor.\n"
 "Presents schematic attributes in easy-to-edit spreadsheet format.\n"
 "\n"
-"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
+"Options:\n"
 "  -q, --quiet            Quiet mode\n"
 "  -v, --verbose          Verbose mode on\n"
+"  -V, --version          Show version information\n"
 "  -h, --help             This help menu\n"
 "\n"
 "  FAQ:\n"
@@ -74,11 +76,22 @@ msgid ""
 "Copyright (C) 2007-2016 gEDA Contributors.\n"
 "Copyright (C) 2017-2019 Lepton EDA Contributors.\n"
 "\n"
-"Please report bugs to %2$s.\n"
+"Report bugs at <%2$s>\n"
+"Lepton EDA homepage: <%3$s>\n"
 msgstr ""
 
 #, c-format
-msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
+msgid ""
+"\n"
+"Run `lepton-attrib --help' for more information.\n"
+msgstr ""
+
+#, c-format
+msgid "WARNING: "
+msgstr ""
+
+#, c-format
+msgid "Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 
 #, c-format
@@ -92,114 +105,78 @@ msgid " DONE\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Failed to find the attrib %1$s on the component.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Trying to add attrib to non-component or non-net!\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
-"or non-net!\n"
+msgid "Start master component list creation.\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Start master component attrib list creation.\n"
+msgstr "Upravljajte atributima komponenti pomoću gattrib"
+
+#, c-format
+msgid "Start master pin list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master comp list creation.\n"
+msgid "Found component pin with no pinnumber: refdes = %1$s\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master comp attrib list creation.\n"
+msgid "Start master pin attrib list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master pin list creation.\n"
+msgid "Tried to add to a NULL list.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_sheet_data_add_master_pin_list_items, found component pin with no "
-"pinnumber.\n"
+msgid "Tried to remove item from empty list.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master pin attrib list creation.\n"
+msgid "Couldn't delete item %1$s\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
+msgid "We didn't find the row name in the row list!\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
+msgid "Start internal component TABLE creation\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_delete_item, couldn't delete item %s\n"
+msgid "We didn't find either row or col in the lists!\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
-msgstr ""
-
-#, c-format
-msgid "- Starting internal component TABLE creation\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
-"or col in the lists!\n"
-msgstr ""
-
-#, c-format
-msgid "- Starting internal pin TABLE creation\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
-"col in the lists!\n"
+msgid "Start internal pin TABLE creation\n"
 msgstr ""
 
 msgid "_cancel"
 msgstr ""
 
 #, c-format
-msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
+msgid "Can't get attrib name\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
-"the master list!\n"
+msgid "We didn't find the refdes in the master list.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
+msgid "Either refdes or pinnumber of object missing.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
-"missing!\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
-"master list!\n"
-msgstr ""
-
-#, c-format
-msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
+msgid "We didn't find the refdes:pin in the master list.\n"
 msgstr ""
 
 msgid "Add new attribute"
@@ -218,7 +195,7 @@ msgid ""
 "One or more components have been found with missing symbol files!\n"
 "\n"
 "This probably happened because lepton-attrib couldn't find your component "
-"libraries, perhaps because your gafrc or gattribrc files are misconfigured.\n"
+"libraries, perhaps because your gafrc files are misconfigured.\n"
 "\n"
 "Choose \"Quit\" to leave lepton-attrib and fix the problem, or\n"
 "\"Forward\" to continue working with lepton-attrib.\n"

--- a/attrib/po/ca.po
+++ b/attrib/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-10-03 23:30+0300\n"
+"POT-Creation-Date: 2020-03-07 14:33+0300\n"
 "PO-Revision-Date: 2012-01-27 14:17+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: Catalan <ca@li.org>\n"
@@ -27,7 +27,7 @@ msgid "Manipulate component attributes with lepton-attrib"
 msgstr "Manipuleu atributs de components amb el gattrib"
 
 #, c-format
-msgid "o_save: Could not open [%1$s]"
+msgid "Could not open [%1$s]"
 msgstr ""
 
 #, c-format
@@ -46,13 +46,15 @@ msgstr ""
 
 #, c-format
 msgid ""
+"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
 "\n"
 "lepton-attrib: Lepton EDA attribute editor.\n"
 "Presents schematic attributes in easy-to-edit spreadsheet format.\n"
 "\n"
-"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
+"Options:\n"
 "  -q, --quiet            Quiet mode\n"
 "  -v, --verbose          Verbose mode on\n"
+"  -V, --version          Show version information\n"
 "  -h, --help             This help menu\n"
 "\n"
 "  FAQ:\n"
@@ -74,11 +76,22 @@ msgid ""
 "Copyright (C) 2007-2016 gEDA Contributors.\n"
 "Copyright (C) 2017-2019 Lepton EDA Contributors.\n"
 "\n"
-"Please report bugs to %2$s.\n"
+"Report bugs at <%2$s>\n"
+"Lepton EDA homepage: <%3$s>\n"
 msgstr ""
 
 #, c-format
-msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
+msgid ""
+"\n"
+"Run `lepton-attrib --help' for more information.\n"
+msgstr ""
+
+#, c-format
+msgid "WARNING: "
+msgstr ""
+
+#, c-format
+msgid "Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 
 #, c-format
@@ -92,114 +105,78 @@ msgid " DONE\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Failed to find the attrib %1$s on the component.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Trying to add attrib to non-component or non-net!\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
-"or non-net!\n"
+msgid "Start master component list creation.\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Start master component attrib list creation.\n"
+msgstr "Manipuleu atributs de components amb el gattrib"
+
+#, c-format
+msgid "Start master pin list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master comp list creation.\n"
+msgid "Found component pin with no pinnumber: refdes = %1$s\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master comp attrib list creation.\n"
+msgid "Start master pin attrib list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master pin list creation.\n"
+msgid "Tried to add to a NULL list.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_sheet_data_add_master_pin_list_items, found component pin with no "
-"pinnumber.\n"
+msgid "Tried to remove item from empty list.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master pin attrib list creation.\n"
+msgid "Couldn't delete item %1$s\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
+msgid "We didn't find the row name in the row list!\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
+msgid "Start internal component TABLE creation\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_delete_item, couldn't delete item %s\n"
+msgid "We didn't find either row or col in the lists!\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
-msgstr ""
-
-#, c-format
-msgid "- Starting internal component TABLE creation\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
-"or col in the lists!\n"
-msgstr ""
-
-#, c-format
-msgid "- Starting internal pin TABLE creation\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
-"col in the lists!\n"
+msgid "Start internal pin TABLE creation\n"
 msgstr ""
 
 msgid "_cancel"
 msgstr ""
 
 #, c-format
-msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
+msgid "Can't get attrib name\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
-"the master list!\n"
+msgid "We didn't find the refdes in the master list.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
+msgid "Either refdes or pinnumber of object missing.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
-"missing!\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
-"master list!\n"
-msgstr ""
-
-#, c-format
-msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
+msgid "We didn't find the refdes:pin in the master list.\n"
 msgstr ""
 
 msgid "Add new attribute"
@@ -218,7 +195,7 @@ msgid ""
 "One or more components have been found with missing symbol files!\n"
 "\n"
 "This probably happened because lepton-attrib couldn't find your component "
-"libraries, perhaps because your gafrc or gattribrc files are misconfigured.\n"
+"libraries, perhaps because your gafrc files are misconfigured.\n"
 "\n"
 "Choose \"Quit\" to leave lepton-attrib and fix the problem, or\n"
 "\"Forward\" to continue working with lepton-attrib.\n"

--- a/attrib/po/da.po
+++ b/attrib/po/da.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-10-03 23:30+0300\n"
+"POT-Creation-Date: 2020-03-07 14:33+0300\n"
 "PO-Revision-Date: 2012-01-27 14:17+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: Danish <da@li.org>\n"
@@ -26,7 +26,7 @@ msgid "Manipulate component attributes with lepton-attrib"
 msgstr "Ændre komponent attributter med gattrib"
 
 #, c-format
-msgid "o_save: Could not open [%1$s]"
+msgid "Could not open [%1$s]"
 msgstr ""
 
 #, c-format
@@ -45,13 +45,15 @@ msgstr ""
 
 #, c-format
 msgid ""
+"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
 "\n"
 "lepton-attrib: Lepton EDA attribute editor.\n"
 "Presents schematic attributes in easy-to-edit spreadsheet format.\n"
 "\n"
-"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
+"Options:\n"
 "  -q, --quiet            Quiet mode\n"
 "  -v, --verbose          Verbose mode on\n"
+"  -V, --version          Show version information\n"
 "  -h, --help             This help menu\n"
 "\n"
 "  FAQ:\n"
@@ -73,11 +75,22 @@ msgid ""
 "Copyright (C) 2007-2016 gEDA Contributors.\n"
 "Copyright (C) 2017-2019 Lepton EDA Contributors.\n"
 "\n"
-"Please report bugs to %2$s.\n"
+"Report bugs at <%2$s>\n"
+"Lepton EDA homepage: <%3$s>\n"
 msgstr ""
 
 #, c-format
-msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
+msgid ""
+"\n"
+"Run `lepton-attrib --help' for more information.\n"
+msgstr ""
+
+#, c-format
+msgid "WARNING: "
+msgstr ""
+
+#, c-format
+msgid "Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 
 #, c-format
@@ -91,114 +104,78 @@ msgid " DONE\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Failed to find the attrib %1$s on the component.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Trying to add attrib to non-component or non-net!\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
-"or non-net!\n"
+msgid "Start master component list creation.\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Start master component attrib list creation.\n"
+msgstr "Ændre komponent attributter med gattrib"
+
+#, c-format
+msgid "Start master pin list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master comp list creation.\n"
+msgid "Found component pin with no pinnumber: refdes = %1$s\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master comp attrib list creation.\n"
+msgid "Start master pin attrib list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master pin list creation.\n"
+msgid "Tried to add to a NULL list.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_sheet_data_add_master_pin_list_items, found component pin with no "
-"pinnumber.\n"
+msgid "Tried to remove item from empty list.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master pin attrib list creation.\n"
+msgid "Couldn't delete item %1$s\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
+msgid "We didn't find the row name in the row list!\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
+msgid "Start internal component TABLE creation\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_delete_item, couldn't delete item %s\n"
+msgid "We didn't find either row or col in the lists!\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
-msgstr ""
-
-#, c-format
-msgid "- Starting internal component TABLE creation\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
-"or col in the lists!\n"
-msgstr ""
-
-#, c-format
-msgid "- Starting internal pin TABLE creation\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
-"col in the lists!\n"
+msgid "Start internal pin TABLE creation\n"
 msgstr ""
 
 msgid "_cancel"
 msgstr ""
 
 #, c-format
-msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
+msgid "Can't get attrib name\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
-"the master list!\n"
+msgid "We didn't find the refdes in the master list.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
+msgid "Either refdes or pinnumber of object missing.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
-"missing!\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
-"master list!\n"
-msgstr ""
-
-#, c-format
-msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
+msgid "We didn't find the refdes:pin in the master list.\n"
 msgstr ""
 
 msgid "Add new attribute"
@@ -217,7 +194,7 @@ msgid ""
 "One or more components have been found with missing symbol files!\n"
 "\n"
 "This probably happened because lepton-attrib couldn't find your component "
-"libraries, perhaps because your gafrc or gattribrc files are misconfigured.\n"
+"libraries, perhaps because your gafrc files are misconfigured.\n"
 "\n"
 "Choose \"Quit\" to leave lepton-attrib and fix the problem, or\n"
 "\"Forward\" to continue working with lepton-attrib.\n"

--- a/attrib/po/de.po
+++ b/attrib/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-10-03 23:30+0300\n"
+"POT-Creation-Date: 2020-03-07 14:33+0300\n"
 "PO-Revision-Date: 2010-01-29 16:46+0000\n"
 "Last-Translator: Werner Hoch <werner.ho@gmx.de>\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -27,7 +27,7 @@ msgid "Manipulate component attributes with lepton-attrib"
 msgstr "Editieren von Bauteilattributen mit gattrib"
 
 #, c-format
-msgid "o_save: Could not open [%1$s]"
+msgid "Could not open [%1$s]"
 msgstr ""
 
 #, c-format
@@ -46,13 +46,15 @@ msgstr ""
 
 #, c-format
 msgid ""
+"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
 "\n"
 "lepton-attrib: Lepton EDA attribute editor.\n"
 "Presents schematic attributes in easy-to-edit spreadsheet format.\n"
 "\n"
-"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
+"Options:\n"
 "  -q, --quiet            Quiet mode\n"
 "  -v, --verbose          Verbose mode on\n"
+"  -V, --version          Show version information\n"
 "  -h, --help             This help menu\n"
 "\n"
 "  FAQ:\n"
@@ -74,11 +76,22 @@ msgid ""
 "Copyright (C) 2007-2016 gEDA Contributors.\n"
 "Copyright (C) 2017-2019 Lepton EDA Contributors.\n"
 "\n"
-"Please report bugs to %2$s.\n"
+"Report bugs at <%2$s>\n"
+"Lepton EDA homepage: <%3$s>\n"
 msgstr ""
 
 #, c-format
-msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
+msgid ""
+"\n"
+"Run `lepton-attrib --help' for more information.\n"
+msgstr ""
+
+#, c-format
+msgid "WARNING: "
+msgstr ""
+
+#, c-format
+msgid "Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 
 #, c-format
@@ -92,114 +105,78 @@ msgid " DONE\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Failed to find the attrib %1$s on the component.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Trying to add attrib to non-component or non-net!\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
-"or non-net!\n"
+msgid "Start master component list creation.\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Start master component attrib list creation.\n"
+msgstr "Editieren von Bauteilattributen mit gattrib"
+
+#, c-format
+msgid "Start master pin list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master comp list creation.\n"
+msgid "Found component pin with no pinnumber: refdes = %1$s\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master comp attrib list creation.\n"
+msgid "Start master pin attrib list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master pin list creation.\n"
+msgid "Tried to add to a NULL list.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_sheet_data_add_master_pin_list_items, found component pin with no "
-"pinnumber.\n"
+msgid "Tried to remove item from empty list.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master pin attrib list creation.\n"
+msgid "Couldn't delete item %1$s\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
+msgid "We didn't find the row name in the row list!\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
+msgid "Start internal component TABLE creation\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_delete_item, couldn't delete item %s\n"
+msgid "We didn't find either row or col in the lists!\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
-msgstr ""
-
-#, c-format
-msgid "- Starting internal component TABLE creation\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
-"or col in the lists!\n"
-msgstr ""
-
-#, c-format
-msgid "- Starting internal pin TABLE creation\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
-"col in the lists!\n"
+msgid "Start internal pin TABLE creation\n"
 msgstr ""
 
 msgid "_cancel"
 msgstr ""
 
 #, c-format
-msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
+msgid "Can't get attrib name\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
-"the master list!\n"
+msgid "We didn't find the refdes in the master list.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
+msgid "Either refdes or pinnumber of object missing.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
-"missing!\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
-"master list!\n"
-msgstr ""
-
-#, c-format
-msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
+msgid "We didn't find the refdes:pin in the master list.\n"
 msgstr ""
 
 msgid "Add new attribute"
@@ -218,7 +195,7 @@ msgid ""
 "One or more components have been found with missing symbol files!\n"
 "\n"
 "This probably happened because lepton-attrib couldn't find your component "
-"libraries, perhaps because your gafrc or gattribrc files are misconfigured.\n"
+"libraries, perhaps because your gafrc files are misconfigured.\n"
 "\n"
 "Choose \"Quit\" to leave lepton-attrib and fix the problem, or\n"
 "\"Forward\" to continue working with lepton-attrib.\n"

--- a/attrib/po/el.po
+++ b/attrib/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-10-03 23:30+0300\n"
+"POT-Creation-Date: 2020-03-07 14:33+0300\n"
 "PO-Revision-Date: 2012-09-01 18:26+0000\n"
 "Last-Translator: Panos Bouklis <panos@echidna-band.com>\n"
 "Language-Team: Greek <el@li.org>\n"
@@ -27,7 +27,7 @@ msgid "Manipulate component attributes with lepton-attrib"
 msgstr "Έλεγχος των γνωρισμάτων των στοιχείων με το gattrib"
 
 #, c-format
-msgid "o_save: Could not open [%1$s]"
+msgid "Could not open [%1$s]"
 msgstr ""
 
 #, c-format
@@ -46,13 +46,15 @@ msgstr ""
 
 #, c-format
 msgid ""
+"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
 "\n"
 "lepton-attrib: Lepton EDA attribute editor.\n"
 "Presents schematic attributes in easy-to-edit spreadsheet format.\n"
 "\n"
-"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
+"Options:\n"
 "  -q, --quiet            Quiet mode\n"
 "  -v, --verbose          Verbose mode on\n"
+"  -V, --version          Show version information\n"
 "  -h, --help             This help menu\n"
 "\n"
 "  FAQ:\n"
@@ -74,11 +76,22 @@ msgid ""
 "Copyright (C) 2007-2016 gEDA Contributors.\n"
 "Copyright (C) 2017-2019 Lepton EDA Contributors.\n"
 "\n"
-"Please report bugs to %2$s.\n"
+"Report bugs at <%2$s>\n"
+"Lepton EDA homepage: <%3$s>\n"
 msgstr ""
 
 #, c-format
-msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
+msgid ""
+"\n"
+"Run `lepton-attrib --help' for more information.\n"
+msgstr ""
+
+#, c-format
+msgid "WARNING: "
+msgstr ""
+
+#, c-format
+msgid "Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 
 #, c-format
@@ -92,114 +105,78 @@ msgid " DONE\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Failed to find the attrib %1$s on the component.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Trying to add attrib to non-component or non-net!\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
-"or non-net!\n"
+msgid "Start master component list creation.\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Start master component attrib list creation.\n"
+msgstr "Έλεγχος των γνωρισμάτων των στοιχείων με το gattrib"
+
+#, c-format
+msgid "Start master pin list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master comp list creation.\n"
+msgid "Found component pin with no pinnumber: refdes = %1$s\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master comp attrib list creation.\n"
+msgid "Start master pin attrib list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master pin list creation.\n"
+msgid "Tried to add to a NULL list.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_sheet_data_add_master_pin_list_items, found component pin with no "
-"pinnumber.\n"
+msgid "Tried to remove item from empty list.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master pin attrib list creation.\n"
+msgid "Couldn't delete item %1$s\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
+msgid "We didn't find the row name in the row list!\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
+msgid "Start internal component TABLE creation\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_delete_item, couldn't delete item %s\n"
+msgid "We didn't find either row or col in the lists!\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
-msgstr ""
-
-#, c-format
-msgid "- Starting internal component TABLE creation\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
-"or col in the lists!\n"
-msgstr ""
-
-#, c-format
-msgid "- Starting internal pin TABLE creation\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
-"col in the lists!\n"
+msgid "Start internal pin TABLE creation\n"
 msgstr ""
 
 msgid "_cancel"
 msgstr ""
 
 #, c-format
-msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
+msgid "Can't get attrib name\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
-"the master list!\n"
+msgid "We didn't find the refdes in the master list.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
+msgid "Either refdes or pinnumber of object missing.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
-"missing!\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
-"master list!\n"
-msgstr ""
-
-#, c-format
-msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
+msgid "We didn't find the refdes:pin in the master list.\n"
 msgstr ""
 
 msgid "Add new attribute"
@@ -218,7 +195,7 @@ msgid ""
 "One or more components have been found with missing symbol files!\n"
 "\n"
 "This probably happened because lepton-attrib couldn't find your component "
-"libraries, perhaps because your gafrc or gattribrc files are misconfigured.\n"
+"libraries, perhaps because your gafrc files are misconfigured.\n"
 "\n"
 "Choose \"Quit\" to leave lepton-attrib and fix the problem, or\n"
 "\"Forward\" to continue working with lepton-attrib.\n"

--- a/attrib/po/en_GB.po
+++ b/attrib/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-10-03 23:30+0300\n"
+"POT-Creation-Date: 2020-03-07 14:33+0300\n"
 "PO-Revision-Date: 2012-01-27 14:17+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: English (United Kingdom) <en_GB@li.org>\n"
@@ -27,7 +27,7 @@ msgid "Manipulate component attributes with lepton-attrib"
 msgstr "Manipulate component attributes with gattrib"
 
 #, c-format
-msgid "o_save: Could not open [%1$s]"
+msgid "Could not open [%1$s]"
 msgstr ""
 
 #, c-format
@@ -46,13 +46,15 @@ msgstr ""
 
 #, c-format
 msgid ""
+"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
 "\n"
 "lepton-attrib: Lepton EDA attribute editor.\n"
 "Presents schematic attributes in easy-to-edit spreadsheet format.\n"
 "\n"
-"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
+"Options:\n"
 "  -q, --quiet            Quiet mode\n"
 "  -v, --verbose          Verbose mode on\n"
+"  -V, --version          Show version information\n"
 "  -h, --help             This help menu\n"
 "\n"
 "  FAQ:\n"
@@ -74,11 +76,22 @@ msgid ""
 "Copyright (C) 2007-2016 gEDA Contributors.\n"
 "Copyright (C) 2017-2019 Lepton EDA Contributors.\n"
 "\n"
-"Please report bugs to %2$s.\n"
+"Report bugs at <%2$s>\n"
+"Lepton EDA homepage: <%3$s>\n"
 msgstr ""
 
 #, c-format
-msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
+msgid ""
+"\n"
+"Run `lepton-attrib --help' for more information.\n"
+msgstr ""
+
+#, c-format
+msgid "WARNING: "
+msgstr ""
+
+#, c-format
+msgid "Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 
 #, c-format
@@ -92,114 +105,78 @@ msgid " DONE\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Failed to find the attrib %1$s on the component.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Trying to add attrib to non-component or non-net!\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
-"or non-net!\n"
+msgid "Start master component list creation.\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Start master component attrib list creation.\n"
+msgstr "Manipulate component attributes with gattrib"
+
+#, c-format
+msgid "Start master pin list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master comp list creation.\n"
+msgid "Found component pin with no pinnumber: refdes = %1$s\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master comp attrib list creation.\n"
+msgid "Start master pin attrib list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master pin list creation.\n"
+msgid "Tried to add to a NULL list.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_sheet_data_add_master_pin_list_items, found component pin with no "
-"pinnumber.\n"
+msgid "Tried to remove item from empty list.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master pin attrib list creation.\n"
+msgid "Couldn't delete item %1$s\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
+msgid "We didn't find the row name in the row list!\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
+msgid "Start internal component TABLE creation\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_delete_item, couldn't delete item %s\n"
+msgid "We didn't find either row or col in the lists!\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
-msgstr ""
-
-#, c-format
-msgid "- Starting internal component TABLE creation\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
-"or col in the lists!\n"
-msgstr ""
-
-#, c-format
-msgid "- Starting internal pin TABLE creation\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
-"col in the lists!\n"
+msgid "Start internal pin TABLE creation\n"
 msgstr ""
 
 msgid "_cancel"
 msgstr ""
 
 #, c-format
-msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
+msgid "Can't get attrib name\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
-"the master list!\n"
+msgid "We didn't find the refdes in the master list.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
+msgid "Either refdes or pinnumber of object missing.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
-"missing!\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
-"master list!\n"
-msgstr ""
-
-#, c-format
-msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
+msgid "We didn't find the refdes:pin in the master list.\n"
 msgstr ""
 
 msgid "Add new attribute"
@@ -218,7 +195,7 @@ msgid ""
 "One or more components have been found with missing symbol files!\n"
 "\n"
 "This probably happened because lepton-attrib couldn't find your component "
-"libraries, perhaps because your gafrc or gattribrc files are misconfigured.\n"
+"libraries, perhaps because your gafrc files are misconfigured.\n"
 "\n"
 "Choose \"Quit\" to leave lepton-attrib and fix the problem, or\n"
 "\"Forward\" to continue working with lepton-attrib.\n"

--- a/attrib/po/es.po
+++ b/attrib/po/es.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-10-03 23:30+0300\n"
+"POT-Creation-Date: 2020-03-07 14:33+0300\n"
 "PO-Revision-Date: 2010-01-29 16:49+0000\n"
 "Last-Translator: Carlos Nieves Ónega <Unknown>\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -29,7 +29,7 @@ msgid "Manipulate component attributes with lepton-attrib"
 msgstr "Manejar propiedades de componentes con gattrib"
 
 #, c-format
-msgid "o_save: Could not open [%1$s]"
+msgid "Could not open [%1$s]"
 msgstr ""
 
 #, c-format
@@ -48,13 +48,15 @@ msgstr ""
 
 #, c-format
 msgid ""
+"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
 "\n"
 "lepton-attrib: Lepton EDA attribute editor.\n"
 "Presents schematic attributes in easy-to-edit spreadsheet format.\n"
 "\n"
-"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
+"Options:\n"
 "  -q, --quiet            Quiet mode\n"
 "  -v, --verbose          Verbose mode on\n"
+"  -V, --version          Show version information\n"
 "  -h, --help             This help menu\n"
 "\n"
 "  FAQ:\n"
@@ -76,11 +78,22 @@ msgid ""
 "Copyright (C) 2007-2016 gEDA Contributors.\n"
 "Copyright (C) 2017-2019 Lepton EDA Contributors.\n"
 "\n"
-"Please report bugs to %2$s.\n"
+"Report bugs at <%2$s>\n"
+"Lepton EDA homepage: <%3$s>\n"
 msgstr ""
 
 #, c-format
-msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
+msgid ""
+"\n"
+"Run `lepton-attrib --help' for more information.\n"
+msgstr ""
+
+#, c-format
+msgid "WARNING: "
+msgstr ""
+
+#, c-format
+msgid "Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 
 #, c-format
@@ -94,114 +107,78 @@ msgid " DONE\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Failed to find the attrib %1$s on the component.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Trying to add attrib to non-component or non-net!\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
-"or non-net!\n"
+msgid "Start master component list creation.\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Start master component attrib list creation.\n"
+msgstr "Manejar propiedades de componentes con gattrib"
+
+#, c-format
+msgid "Start master pin list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master comp list creation.\n"
+msgid "Found component pin with no pinnumber: refdes = %1$s\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master comp attrib list creation.\n"
+msgid "Start master pin attrib list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master pin list creation.\n"
+msgid "Tried to add to a NULL list.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_sheet_data_add_master_pin_list_items, found component pin with no "
-"pinnumber.\n"
+msgid "Tried to remove item from empty list.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master pin attrib list creation.\n"
+msgid "Couldn't delete item %1$s\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
+msgid "We didn't find the row name in the row list!\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
+msgid "Start internal component TABLE creation\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_delete_item, couldn't delete item %s\n"
+msgid "We didn't find either row or col in the lists!\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
-msgstr ""
-
-#, c-format
-msgid "- Starting internal component TABLE creation\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
-"or col in the lists!\n"
-msgstr ""
-
-#, c-format
-msgid "- Starting internal pin TABLE creation\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
-"col in the lists!\n"
+msgid "Start internal pin TABLE creation\n"
 msgstr ""
 
 msgid "_cancel"
 msgstr ""
 
 #, c-format
-msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
+msgid "Can't get attrib name\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
-"the master list!\n"
+msgid "We didn't find the refdes in the master list.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
+msgid "Either refdes or pinnumber of object missing.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
-"missing!\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
-"master list!\n"
-msgstr ""
-
-#, c-format
-msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
+msgid "We didn't find the refdes:pin in the master list.\n"
 msgstr ""
 
 msgid "Add new attribute"
@@ -220,7 +197,7 @@ msgid ""
 "One or more components have been found with missing symbol files!\n"
 "\n"
 "This probably happened because lepton-attrib couldn't find your component "
-"libraries, perhaps because your gafrc or gattribrc files are misconfigured.\n"
+"libraries, perhaps because your gafrc files are misconfigured.\n"
 "\n"
 "Choose \"Quit\" to leave lepton-attrib and fix the problem, or\n"
 "\"Forward\" to continue working with lepton-attrib.\n"

--- a/attrib/po/fa.po
+++ b/attrib/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-10-03 23:30+0300\n"
+"POT-Creation-Date: 2020-03-07 14:33+0300\n"
 "PO-Revision-Date: 2012-01-27 14:17+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: Persian <fa@li.org>\n"
@@ -27,7 +27,7 @@ msgid "Manipulate component attributes with lepton-attrib"
 msgstr "Manipulate component attributes with gattrib"
 
 #, c-format
-msgid "o_save: Could not open [%1$s]"
+msgid "Could not open [%1$s]"
 msgstr ""
 
 #, c-format
@@ -46,13 +46,15 @@ msgstr ""
 
 #, c-format
 msgid ""
+"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
 "\n"
 "lepton-attrib: Lepton EDA attribute editor.\n"
 "Presents schematic attributes in easy-to-edit spreadsheet format.\n"
 "\n"
-"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
+"Options:\n"
 "  -q, --quiet            Quiet mode\n"
 "  -v, --verbose          Verbose mode on\n"
+"  -V, --version          Show version information\n"
 "  -h, --help             This help menu\n"
 "\n"
 "  FAQ:\n"
@@ -74,11 +76,22 @@ msgid ""
 "Copyright (C) 2007-2016 gEDA Contributors.\n"
 "Copyright (C) 2017-2019 Lepton EDA Contributors.\n"
 "\n"
-"Please report bugs to %2$s.\n"
+"Report bugs at <%2$s>\n"
+"Lepton EDA homepage: <%3$s>\n"
 msgstr ""
 
 #, c-format
-msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
+msgid ""
+"\n"
+"Run `lepton-attrib --help' for more information.\n"
+msgstr ""
+
+#, c-format
+msgid "WARNING: "
+msgstr ""
+
+#, c-format
+msgid "Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 
 #, c-format
@@ -92,114 +105,78 @@ msgid " DONE\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Failed to find the attrib %1$s on the component.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Trying to add attrib to non-component or non-net!\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
-"or non-net!\n"
+msgid "Start master component list creation.\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Start master component attrib list creation.\n"
+msgstr "Manipulate component attributes with gattrib"
+
+#, c-format
+msgid "Start master pin list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master comp list creation.\n"
+msgid "Found component pin with no pinnumber: refdes = %1$s\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master comp attrib list creation.\n"
+msgid "Start master pin attrib list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master pin list creation.\n"
+msgid "Tried to add to a NULL list.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_sheet_data_add_master_pin_list_items, found component pin with no "
-"pinnumber.\n"
+msgid "Tried to remove item from empty list.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master pin attrib list creation.\n"
+msgid "Couldn't delete item %1$s\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
+msgid "We didn't find the row name in the row list!\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
+msgid "Start internal component TABLE creation\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_delete_item, couldn't delete item %s\n"
+msgid "We didn't find either row or col in the lists!\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
-msgstr ""
-
-#, c-format
-msgid "- Starting internal component TABLE creation\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
-"or col in the lists!\n"
-msgstr ""
-
-#, c-format
-msgid "- Starting internal pin TABLE creation\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
-"col in the lists!\n"
+msgid "Start internal pin TABLE creation\n"
 msgstr ""
 
 msgid "_cancel"
 msgstr ""
 
 #, c-format
-msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
+msgid "Can't get attrib name\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
-"the master list!\n"
+msgid "We didn't find the refdes in the master list.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
+msgid "Either refdes or pinnumber of object missing.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
-"missing!\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
-"master list!\n"
-msgstr ""
-
-#, c-format
-msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
+msgid "We didn't find the refdes:pin in the master list.\n"
 msgstr ""
 
 msgid "Add new attribute"
@@ -218,7 +195,7 @@ msgid ""
 "One or more components have been found with missing symbol files!\n"
 "\n"
 "This probably happened because lepton-attrib couldn't find your component "
-"libraries, perhaps because your gafrc or gattribrc files are misconfigured.\n"
+"libraries, perhaps because your gafrc files are misconfigured.\n"
 "\n"
 "Choose \"Quit\" to leave lepton-attrib and fix the problem, or\n"
 "\"Forward\" to continue working with lepton-attrib.\n"

--- a/attrib/po/fr.po
+++ b/attrib/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-10-03 23:30+0300\n"
+"POT-Creation-Date: 2020-03-07 14:33+0300\n"
 "PO-Revision-Date: 2010-02-06 22:09+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -27,7 +27,7 @@ msgid "Manipulate component attributes with lepton-attrib"
 msgstr "Manipuler les attributs des composants avec gattrib"
 
 #, c-format
-msgid "o_save: Could not open [%1$s]"
+msgid "Could not open [%1$s]"
 msgstr ""
 
 #, c-format
@@ -46,13 +46,15 @@ msgstr ""
 
 #, c-format
 msgid ""
+"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
 "\n"
 "lepton-attrib: Lepton EDA attribute editor.\n"
 "Presents schematic attributes in easy-to-edit spreadsheet format.\n"
 "\n"
-"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
+"Options:\n"
 "  -q, --quiet            Quiet mode\n"
 "  -v, --verbose          Verbose mode on\n"
+"  -V, --version          Show version information\n"
 "  -h, --help             This help menu\n"
 "\n"
 "  FAQ:\n"
@@ -74,11 +76,22 @@ msgid ""
 "Copyright (C) 2007-2016 gEDA Contributors.\n"
 "Copyright (C) 2017-2019 Lepton EDA Contributors.\n"
 "\n"
-"Please report bugs to %2$s.\n"
+"Report bugs at <%2$s>\n"
+"Lepton EDA homepage: <%3$s>\n"
 msgstr ""
 
 #, c-format
-msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
+msgid ""
+"\n"
+"Run `lepton-attrib --help' for more information.\n"
+msgstr ""
+
+#, c-format
+msgid "WARNING: "
+msgstr ""
+
+#, c-format
+msgid "Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 
 #, c-format
@@ -92,114 +105,78 @@ msgid " DONE\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Failed to find the attrib %1$s on the component.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Trying to add attrib to non-component or non-net!\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
-"or non-net!\n"
+msgid "Start master component list creation.\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Start master component attrib list creation.\n"
+msgstr "Manipuler les attributs des composants avec gattrib"
+
+#, c-format
+msgid "Start master pin list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master comp list creation.\n"
+msgid "Found component pin with no pinnumber: refdes = %1$s\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master comp attrib list creation.\n"
+msgid "Start master pin attrib list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master pin list creation.\n"
+msgid "Tried to add to a NULL list.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_sheet_data_add_master_pin_list_items, found component pin with no "
-"pinnumber.\n"
+msgid "Tried to remove item from empty list.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master pin attrib list creation.\n"
+msgid "Couldn't delete item %1$s\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
+msgid "We didn't find the row name in the row list!\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
+msgid "Start internal component TABLE creation\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_delete_item, couldn't delete item %s\n"
+msgid "We didn't find either row or col in the lists!\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
-msgstr ""
-
-#, c-format
-msgid "- Starting internal component TABLE creation\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
-"or col in the lists!\n"
-msgstr ""
-
-#, c-format
-msgid "- Starting internal pin TABLE creation\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
-"col in the lists!\n"
+msgid "Start internal pin TABLE creation\n"
 msgstr ""
 
 msgid "_cancel"
 msgstr ""
 
 #, c-format
-msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
+msgid "Can't get attrib name\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
-"the master list!\n"
+msgid "We didn't find the refdes in the master list.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
+msgid "Either refdes or pinnumber of object missing.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
-"missing!\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
-"master list!\n"
-msgstr ""
-
-#, c-format
-msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
+msgid "We didn't find the refdes:pin in the master list.\n"
 msgstr ""
 
 msgid "Add new attribute"
@@ -218,7 +195,7 @@ msgid ""
 "One or more components have been found with missing symbol files!\n"
 "\n"
 "This probably happened because lepton-attrib couldn't find your component "
-"libraries, perhaps because your gafrc or gattribrc files are misconfigured.\n"
+"libraries, perhaps because your gafrc files are misconfigured.\n"
 "\n"
 "Choose \"Quit\" to leave lepton-attrib and fix the problem, or\n"
 "\"Forward\" to continue working with lepton-attrib.\n"

--- a/attrib/po/gl.po
+++ b/attrib/po/gl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-10-03 23:30+0300\n"
+"POT-Creation-Date: 2020-03-07 14:33+0300\n"
 "PO-Revision-Date: 2012-03-21 00:09+0000\n"
 "Last-Translator: ghas <Unknown>\n"
 "Language-Team: Galician <gl@li.org>\n"
@@ -27,7 +27,7 @@ msgid "Manipulate component attributes with lepton-attrib"
 msgstr "Manipular atributos de compoñentes con gattrib"
 
 #, c-format
-msgid "o_save: Could not open [%1$s]"
+msgid "Could not open [%1$s]"
 msgstr ""
 
 #, c-format
@@ -46,13 +46,15 @@ msgstr ""
 
 #, c-format
 msgid ""
+"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
 "\n"
 "lepton-attrib: Lepton EDA attribute editor.\n"
 "Presents schematic attributes in easy-to-edit spreadsheet format.\n"
 "\n"
-"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
+"Options:\n"
 "  -q, --quiet            Quiet mode\n"
 "  -v, --verbose          Verbose mode on\n"
+"  -V, --version          Show version information\n"
 "  -h, --help             This help menu\n"
 "\n"
 "  FAQ:\n"
@@ -74,11 +76,22 @@ msgid ""
 "Copyright (C) 2007-2016 gEDA Contributors.\n"
 "Copyright (C) 2017-2019 Lepton EDA Contributors.\n"
 "\n"
-"Please report bugs to %2$s.\n"
+"Report bugs at <%2$s>\n"
+"Lepton EDA homepage: <%3$s>\n"
 msgstr ""
 
 #, c-format
-msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
+msgid ""
+"\n"
+"Run `lepton-attrib --help' for more information.\n"
+msgstr ""
+
+#, c-format
+msgid "WARNING: "
+msgstr ""
+
+#, c-format
+msgid "Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 
 #, c-format
@@ -92,114 +105,78 @@ msgid " DONE\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Failed to find the attrib %1$s on the component.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Trying to add attrib to non-component or non-net!\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
-"or non-net!\n"
+msgid "Start master component list creation.\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Start master component attrib list creation.\n"
+msgstr "Manipular atributos de compoñentes con gattrib"
+
+#, c-format
+msgid "Start master pin list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master comp list creation.\n"
+msgid "Found component pin with no pinnumber: refdes = %1$s\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master comp attrib list creation.\n"
+msgid "Start master pin attrib list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master pin list creation.\n"
+msgid "Tried to add to a NULL list.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_sheet_data_add_master_pin_list_items, found component pin with no "
-"pinnumber.\n"
+msgid "Tried to remove item from empty list.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master pin attrib list creation.\n"
+msgid "Couldn't delete item %1$s\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
+msgid "We didn't find the row name in the row list!\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
+msgid "Start internal component TABLE creation\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_delete_item, couldn't delete item %s\n"
+msgid "We didn't find either row or col in the lists!\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
-msgstr ""
-
-#, c-format
-msgid "- Starting internal component TABLE creation\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
-"or col in the lists!\n"
-msgstr ""
-
-#, c-format
-msgid "- Starting internal pin TABLE creation\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
-"col in the lists!\n"
+msgid "Start internal pin TABLE creation\n"
 msgstr ""
 
 msgid "_cancel"
 msgstr ""
 
 #, c-format
-msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
+msgid "Can't get attrib name\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
-"the master list!\n"
+msgid "We didn't find the refdes in the master list.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
+msgid "Either refdes or pinnumber of object missing.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
-"missing!\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
-"master list!\n"
-msgstr ""
-
-#, c-format
-msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
+msgid "We didn't find the refdes:pin in the master list.\n"
 msgstr ""
 
 msgid "Add new attribute"
@@ -218,7 +195,7 @@ msgid ""
 "One or more components have been found with missing symbol files!\n"
 "\n"
 "This probably happened because lepton-attrib couldn't find your component "
-"libraries, perhaps because your gafrc or gattribrc files are misconfigured.\n"
+"libraries, perhaps because your gafrc files are misconfigured.\n"
 "\n"
 "Choose \"Quit\" to leave lepton-attrib and fix the problem, or\n"
 "\"Forward\" to continue working with lepton-attrib.\n"

--- a/attrib/po/hu.po
+++ b/attrib/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-10-03 23:30+0300\n"
+"POT-Creation-Date: 2020-03-07 14:33+0300\n"
 "PO-Revision-Date: 2010-02-06 22:10+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -27,7 +27,7 @@ msgid "Manipulate component attributes with lepton-attrib"
 msgstr "Alkatrészattribútumok szerkesztése gattrib segítségével"
 
 #, c-format
-msgid "o_save: Could not open [%1$s]"
+msgid "Could not open [%1$s]"
 msgstr ""
 
 #, c-format
@@ -46,13 +46,15 @@ msgstr ""
 
 #, c-format
 msgid ""
+"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
 "\n"
 "lepton-attrib: Lepton EDA attribute editor.\n"
 "Presents schematic attributes in easy-to-edit spreadsheet format.\n"
 "\n"
-"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
+"Options:\n"
 "  -q, --quiet            Quiet mode\n"
 "  -v, --verbose          Verbose mode on\n"
+"  -V, --version          Show version information\n"
 "  -h, --help             This help menu\n"
 "\n"
 "  FAQ:\n"
@@ -74,11 +76,22 @@ msgid ""
 "Copyright (C) 2007-2016 gEDA Contributors.\n"
 "Copyright (C) 2017-2019 Lepton EDA Contributors.\n"
 "\n"
-"Please report bugs to %2$s.\n"
+"Report bugs at <%2$s>\n"
+"Lepton EDA homepage: <%3$s>\n"
 msgstr ""
 
 #, c-format
-msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
+msgid ""
+"\n"
+"Run `lepton-attrib --help' for more information.\n"
+msgstr ""
+
+#, c-format
+msgid "WARNING: "
+msgstr ""
+
+#, c-format
+msgid "Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 
 #, c-format
@@ -92,114 +105,78 @@ msgid " DONE\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Failed to find the attrib %1$s on the component.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Trying to add attrib to non-component or non-net!\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
-"or non-net!\n"
+msgid "Start master component list creation.\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Start master component attrib list creation.\n"
+msgstr "Alkatrészattribútumok szerkesztése gattrib segítségével"
+
+#, c-format
+msgid "Start master pin list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master comp list creation.\n"
+msgid "Found component pin with no pinnumber: refdes = %1$s\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master comp attrib list creation.\n"
+msgid "Start master pin attrib list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master pin list creation.\n"
+msgid "Tried to add to a NULL list.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_sheet_data_add_master_pin_list_items, found component pin with no "
-"pinnumber.\n"
+msgid "Tried to remove item from empty list.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master pin attrib list creation.\n"
+msgid "Couldn't delete item %1$s\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
+msgid "We didn't find the row name in the row list!\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
+msgid "Start internal component TABLE creation\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_delete_item, couldn't delete item %s\n"
+msgid "We didn't find either row or col in the lists!\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
-msgstr ""
-
-#, c-format
-msgid "- Starting internal component TABLE creation\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
-"or col in the lists!\n"
-msgstr ""
-
-#, c-format
-msgid "- Starting internal pin TABLE creation\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
-"col in the lists!\n"
+msgid "Start internal pin TABLE creation\n"
 msgstr ""
 
 msgid "_cancel"
 msgstr ""
 
 #, c-format
-msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
+msgid "Can't get attrib name\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
-"the master list!\n"
+msgid "We didn't find the refdes in the master list.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
+msgid "Either refdes or pinnumber of object missing.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
-"missing!\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
-"master list!\n"
-msgstr ""
-
-#, c-format
-msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
+msgid "We didn't find the refdes:pin in the master list.\n"
 msgstr ""
 
 msgid "Add new attribute"
@@ -218,7 +195,7 @@ msgid ""
 "One or more components have been found with missing symbol files!\n"
 "\n"
 "This probably happened because lepton-attrib couldn't find your component "
-"libraries, perhaps because your gafrc or gattribrc files are misconfigured.\n"
+"libraries, perhaps because your gafrc files are misconfigured.\n"
 "\n"
 "Choose \"Quit\" to leave lepton-attrib and fix the problem, or\n"
 "\"Forward\" to continue working with lepton-attrib.\n"

--- a/attrib/po/it.po
+++ b/attrib/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-10-03 23:30+0300\n"
+"POT-Creation-Date: 2020-03-07 14:33+0300\n"
 "PO-Revision-Date: 2010-02-06 22:09+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -27,7 +27,7 @@ msgid "Manipulate component attributes with lepton-attrib"
 msgstr "Manipola gli attributi dei componenti con gattrib"
 
 #, c-format
-msgid "o_save: Could not open [%1$s]"
+msgid "Could not open [%1$s]"
 msgstr ""
 
 #, c-format
@@ -46,13 +46,15 @@ msgstr ""
 
 #, c-format
 msgid ""
+"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
 "\n"
 "lepton-attrib: Lepton EDA attribute editor.\n"
 "Presents schematic attributes in easy-to-edit spreadsheet format.\n"
 "\n"
-"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
+"Options:\n"
 "  -q, --quiet            Quiet mode\n"
 "  -v, --verbose          Verbose mode on\n"
+"  -V, --version          Show version information\n"
 "  -h, --help             This help menu\n"
 "\n"
 "  FAQ:\n"
@@ -74,11 +76,22 @@ msgid ""
 "Copyright (C) 2007-2016 gEDA Contributors.\n"
 "Copyright (C) 2017-2019 Lepton EDA Contributors.\n"
 "\n"
-"Please report bugs to %2$s.\n"
+"Report bugs at <%2$s>\n"
+"Lepton EDA homepage: <%3$s>\n"
 msgstr ""
 
 #, c-format
-msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
+msgid ""
+"\n"
+"Run `lepton-attrib --help' for more information.\n"
+msgstr ""
+
+#, c-format
+msgid "WARNING: "
+msgstr ""
+
+#, c-format
+msgid "Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 
 #, c-format
@@ -92,114 +105,78 @@ msgid " DONE\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Failed to find the attrib %1$s on the component.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Trying to add attrib to non-component or non-net!\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
-"or non-net!\n"
+msgid "Start master component list creation.\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Start master component attrib list creation.\n"
+msgstr "Manipola gli attributi dei componenti con gattrib"
+
+#, c-format
+msgid "Start master pin list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master comp list creation.\n"
+msgid "Found component pin with no pinnumber: refdes = %1$s\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master comp attrib list creation.\n"
+msgid "Start master pin attrib list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master pin list creation.\n"
+msgid "Tried to add to a NULL list.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_sheet_data_add_master_pin_list_items, found component pin with no "
-"pinnumber.\n"
+msgid "Tried to remove item from empty list.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master pin attrib list creation.\n"
+msgid "Couldn't delete item %1$s\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
+msgid "We didn't find the row name in the row list!\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
+msgid "Start internal component TABLE creation\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_delete_item, couldn't delete item %s\n"
+msgid "We didn't find either row or col in the lists!\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
-msgstr ""
-
-#, c-format
-msgid "- Starting internal component TABLE creation\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
-"or col in the lists!\n"
-msgstr ""
-
-#, c-format
-msgid "- Starting internal pin TABLE creation\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
-"col in the lists!\n"
+msgid "Start internal pin TABLE creation\n"
 msgstr ""
 
 msgid "_cancel"
 msgstr ""
 
 #, c-format
-msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
+msgid "Can't get attrib name\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
-"the master list!\n"
+msgid "We didn't find the refdes in the master list.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
+msgid "Either refdes or pinnumber of object missing.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
-"missing!\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
-"master list!\n"
-msgstr ""
-
-#, c-format
-msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
+msgid "We didn't find the refdes:pin in the master list.\n"
 msgstr ""
 
 msgid "Add new attribute"
@@ -218,7 +195,7 @@ msgid ""
 "One or more components have been found with missing symbol files!\n"
 "\n"
 "This probably happened because lepton-attrib couldn't find your component "
-"libraries, perhaps because your gafrc or gattribrc files are misconfigured.\n"
+"libraries, perhaps because your gafrc files are misconfigured.\n"
 "\n"
 "Choose \"Quit\" to leave lepton-attrib and fix the problem, or\n"
 "\"Forward\" to continue working with lepton-attrib.\n"

--- a/attrib/po/ja.po
+++ b/attrib/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-10-03 23:30+0300\n"
+"POT-Creation-Date: 2020-03-07 14:33+0300\n"
 "PO-Revision-Date: 2012-01-27 14:17+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: Japanese <ja@li.org>\n"
@@ -25,7 +25,7 @@ msgid "Manipulate component attributes with lepton-attrib"
 msgstr ""
 
 #, c-format
-msgid "o_save: Could not open [%1$s]"
+msgid "Could not open [%1$s]"
 msgstr ""
 
 #, c-format
@@ -44,13 +44,15 @@ msgstr ""
 
 #, c-format
 msgid ""
+"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
 "\n"
 "lepton-attrib: Lepton EDA attribute editor.\n"
 "Presents schematic attributes in easy-to-edit spreadsheet format.\n"
 "\n"
-"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
+"Options:\n"
 "  -q, --quiet            Quiet mode\n"
 "  -v, --verbose          Verbose mode on\n"
+"  -V, --version          Show version information\n"
 "  -h, --help             This help menu\n"
 "\n"
 "  FAQ:\n"
@@ -72,11 +74,22 @@ msgid ""
 "Copyright (C) 2007-2016 gEDA Contributors.\n"
 "Copyright (C) 2017-2019 Lepton EDA Contributors.\n"
 "\n"
-"Please report bugs to %2$s.\n"
+"Report bugs at <%2$s>\n"
+"Lepton EDA homepage: <%3$s>\n"
 msgstr ""
 
 #, c-format
-msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
+msgid ""
+"\n"
+"Run `lepton-attrib --help' for more information.\n"
+msgstr ""
+
+#, c-format
+msgid "WARNING: "
+msgstr ""
+
+#, c-format
+msgid "Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 
 #, c-format
@@ -90,114 +103,78 @@ msgid " DONE\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Failed to find the attrib %1$s on the component.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Trying to add attrib to non-component or non-net!\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
-"or non-net!\n"
+msgid "Start master component list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master comp list creation.\n"
+msgid "Start master component attrib list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master comp attrib list creation.\n"
+msgid "Start master pin list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master pin list creation.\n"
+msgid "Found component pin with no pinnumber: refdes = %1$s\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_sheet_data_add_master_pin_list_items, found component pin with no "
-"pinnumber.\n"
+msgid "Start master pin attrib list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master pin attrib list creation.\n"
+msgid "Tried to add to a NULL list.\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
+msgid "Tried to remove item from empty list.\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
+msgid "Couldn't delete item %1$s\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_delete_item, couldn't delete item %s\n"
+msgid "We didn't find the row name in the row list!\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
+msgid "Start internal component TABLE creation\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting internal component TABLE creation\n"
+msgid "We didn't find either row or col in the lists!\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
-"or col in the lists!\n"
-msgstr ""
-
-#, c-format
-msgid "- Starting internal pin TABLE creation\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
-"col in the lists!\n"
+msgid "Start internal pin TABLE creation\n"
 msgstr ""
 
 msgid "_cancel"
 msgstr ""
 
 #, c-format
-msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
+msgid "Can't get attrib name\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
-"the master list!\n"
+msgid "We didn't find the refdes in the master list.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
+msgid "Either refdes or pinnumber of object missing.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
-"missing!\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
-"master list!\n"
-msgstr ""
-
-#, c-format
-msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
+msgid "We didn't find the refdes:pin in the master list.\n"
 msgstr ""
 
 msgid "Add new attribute"
@@ -216,7 +193,7 @@ msgid ""
 "One or more components have been found with missing symbol files!\n"
 "\n"
 "This probably happened because lepton-attrib couldn't find your component "
-"libraries, perhaps because your gafrc or gattribrc files are misconfigured.\n"
+"libraries, perhaps because your gafrc files are misconfigured.\n"
 "\n"
 "Choose \"Quit\" to leave lepton-attrib and fix the problem, or\n"
 "\"Forward\" to continue working with lepton-attrib.\n"

--- a/attrib/po/lepton-attrib.pot
+++ b/attrib/po/lepton-attrib.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lepton-eda 1.9.9\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-10-03 23:30+0300\n"
+"POT-Creation-Date: 2020-03-07 14:33+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -25,17 +25,17 @@ msgstr ""
 msgid "Manipulate component attributes with lepton-attrib"
 msgstr ""
 
-#: attrib/src/f_export.c:82
+#: attrib/src/f_export.c:83
 #, c-format
-msgid "o_save: Could not open [%1$s]"
+msgid "Could not open [%1$s]"
 msgstr ""
 
-#: attrib/src/lepton-attrib.c:180
+#: attrib/src/lepton-attrib.c:181
 #, c-format
 msgid "Lepton EDA/lepton-attrib version %1$s%2$s.%3$s git: %4$.7s"
 msgstr ""
 
-#: attrib/src/lepton-attrib.c:213
+#: attrib/src/lepton-attrib.c:214
 #, c-format
 msgid "Couldn't find file [%1$s]\n"
 msgstr ""
@@ -48,16 +48,18 @@ msgstr ""
 msgid "Widget must be a GtkSheet child"
 msgstr ""
 
-#: attrib/src/parsecmd.c:74
+#: attrib/src/parsecmd.c:72
 #, c-format
 msgid ""
+"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
 "\n"
 "lepton-attrib: Lepton EDA attribute editor.\n"
 "Presents schematic attributes in easy-to-edit spreadsheet format.\n"
 "\n"
-"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
+"Options:\n"
 "  -q, --quiet            Quiet mode\n"
 "  -v, --verbose          Verbose mode on\n"
+"  -V, --version          Show version information\n"
 "  -h, --help             This help menu\n"
 "\n"
 "  FAQ:\n"
@@ -79,12 +81,25 @@ msgid ""
 "Copyright (C) 2007-2016 gEDA Contributors.\n"
 "Copyright (C) 2017-2019 Lepton EDA Contributors.\n"
 "\n"
-"Please report bugs to %2$s.\n"
+"Report bugs at <%2$s>\n"
+"Lepton EDA homepage: <%3$s>\n"
 msgstr ""
 
-#: attrib/src/s_attrib.c:101
+#: attrib/src/parsecmd.c:172
 #, c-format
-msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
+msgid ""
+"\n"
+"Run `lepton-attrib --help' for more information.\n"
+msgstr ""
+
+#: attrib/src/s_attrib.c:102
+#, c-format
+msgid "WARNING: "
+msgstr ""
+
+#: attrib/src/s_attrib.c:104
+#, c-format
+msgid "Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 
 #: attrib/src/s_misc.c:81
@@ -99,138 +114,98 @@ msgstr ""
 msgid " DONE\n"
 msgstr ""
 
-#: attrib/src/s_object.c:217
+#: attrib/src/s_object.c:219 attrib/src/s_object.c:280
 #, c-format
-msgid ""
-"In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Failed to find the attrib %1$s on the component.\n"
 msgstr ""
 
-#: attrib/src/s_object.c:276
+#: attrib/src/s_object.c:334
 #, c-format
-msgid ""
-"In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Trying to add attrib to non-component or non-net!\n"
 msgstr ""
 
-#: attrib/src/s_object.c:329
+#: attrib/src/s_sheet_data.c:117
 #, c-format
-msgid ""
-"In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
-"or non-net!\n"
+msgid "Start master component list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:116
+#: attrib/src/s_sheet_data.c:188
 #, c-format
-msgid "- Starting master comp list creation.\n"
+msgid "Start master component attrib list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:184
+#: attrib/src/s_sheet_data.c:304
 #, c-format
-msgid "- Starting master comp attrib list creation.\n"
+msgid "Start master pin list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:297
+#: attrib/src/s_sheet_data.c:342
 #, c-format
-msgid "- Starting master pin list creation.\n"
+msgid "Found component pin with no pinnumber: refdes = %1$s\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:331
+#: attrib/src/s_sheet_data.c:399
 #, c-format
-msgid ""
-"In s_sheet_data_add_master_pin_list_items, found component pin with no "
-"pinnumber.\n"
+msgid "Start master pin attrib list creation.\n"
 msgstr ""
 
-#: attrib/src/s_sheet_data.c:389
+#: attrib/src/s_string_list.c:124
 #, c-format
-msgid "- Starting master pin attrib list creation.\n"
+msgid "Tried to add to a NULL list.\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:123
+#: attrib/src/s_string_list.c:191
 #, c-format
-msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
+msgid "Tried to remove item from empty list.\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:188
+#: attrib/src/s_string_list.c:262
 #, c-format
-msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
+msgid "Couldn't delete item %1$s\n"
 msgstr ""
 
-#: attrib/src/s_string_list.c:252
+#: attrib/src/s_table.c:244
 #, c-format
-msgid "In s_string_list_delete_item, couldn't delete item %s\n"
+msgid "We didn't find the row name in the row list!\n"
 msgstr ""
 
-#: attrib/src/s_table.c:242
+#: attrib/src/s_table.c:287
 #, c-format
-msgid ""
-"In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
+msgid "Start internal component TABLE creation\n"
 msgstr ""
 
-#: attrib/src/s_table.c:285
+#: attrib/src/s_table.c:348 attrib/src/s_table.c:565
 #, c-format
-msgid "- Starting internal component TABLE creation\n"
+msgid "We didn't find either row or col in the lists!\n"
 msgstr ""
 
-#: attrib/src/s_table.c:344
+#: attrib/src/s_table.c:503
 #, c-format
-msgid ""
-"In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
-"or col in the lists!\n"
+msgid "Start internal pin TABLE creation\n"
 msgstr ""
 
-#: attrib/src/s_table.c:493
-#, c-format
-msgid "- Starting internal pin TABLE creation\n"
-msgstr ""
-
-#: attrib/src/s_table.c:553
-#, c-format
-msgid ""
-"In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
-"col in the lists!\n"
-msgstr ""
-
-#: attrib/src/s_toplevel.c:185
+#: attrib/src/s_toplevel.c:188
 msgid "_cancel"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:318
+#: attrib/src/s_toplevel.c:328
 #, c-format
-msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
+msgid "Can't get attrib name\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:554
+#: attrib/src/s_toplevel.c:572
 #, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
-"the master list!\n"
+msgid "We didn't find the refdes in the master list.\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:582
+#: attrib/src/s_toplevel.c:911
 #, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
+msgid "Either refdes or pinnumber of object missing.\n"
 msgstr ""
 
-#: attrib/src/s_toplevel.c:891
+#: attrib/src/s_toplevel.c:920
 #, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
-"missing!\n"
-msgstr ""
-
-#: attrib/src/s_toplevel.c:900
-#, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
-"master list!\n"
-msgstr ""
-
-#: attrib/src/s_toplevel.c:928
-#, c-format
-msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
+msgid "We didn't find the refdes:pin in the master list.\n"
 msgstr ""
 
 #: attrib/src/x_dialog.c:75
@@ -254,7 +229,7 @@ msgid ""
 "One or more components have been found with missing symbol files!\n"
 "\n"
 "This probably happened because lepton-attrib couldn't find your component "
-"libraries, perhaps because your gafrc or gattribrc files are misconfigured.\n"
+"libraries, perhaps because your gafrc files are misconfigured.\n"
 "\n"
 "Choose \"Quit\" to leave lepton-attrib and fix the problem, or\n"
 "\"Forward\" to continue working with lepton-attrib.\n"

--- a/attrib/po/ml.po
+++ b/attrib/po/ml.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-10-03 23:30+0300\n"
+"POT-Creation-Date: 2020-03-07 14:33+0300\n"
 "PO-Revision-Date: 2010-02-06 22:10+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -27,7 +27,7 @@ msgid "Manipulate component attributes with lepton-attrib"
 msgstr "gattrib ഉപയോഗിച്ച്   കമ്പോണന്ടിന്റെ  സവിശേഷതകള്‍ മാറ്റം വരുത്തുക"
 
 #, c-format
-msgid "o_save: Could not open [%1$s]"
+msgid "Could not open [%1$s]"
 msgstr ""
 
 #, c-format
@@ -46,13 +46,15 @@ msgstr ""
 
 #, c-format
 msgid ""
+"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
 "\n"
 "lepton-attrib: Lepton EDA attribute editor.\n"
 "Presents schematic attributes in easy-to-edit spreadsheet format.\n"
 "\n"
-"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
+"Options:\n"
 "  -q, --quiet            Quiet mode\n"
 "  -v, --verbose          Verbose mode on\n"
+"  -V, --version          Show version information\n"
 "  -h, --help             This help menu\n"
 "\n"
 "  FAQ:\n"
@@ -74,11 +76,22 @@ msgid ""
 "Copyright (C) 2007-2016 gEDA Contributors.\n"
 "Copyright (C) 2017-2019 Lepton EDA Contributors.\n"
 "\n"
-"Please report bugs to %2$s.\n"
+"Report bugs at <%2$s>\n"
+"Lepton EDA homepage: <%3$s>\n"
 msgstr ""
 
 #, c-format
-msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
+msgid ""
+"\n"
+"Run `lepton-attrib --help' for more information.\n"
+msgstr ""
+
+#, c-format
+msgid "WARNING: "
+msgstr ""
+
+#, c-format
+msgid "Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 
 #, c-format
@@ -92,114 +105,78 @@ msgid " DONE\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Failed to find the attrib %1$s on the component.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Trying to add attrib to non-component or non-net!\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
-"or non-net!\n"
+msgid "Start master component list creation.\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Start master component attrib list creation.\n"
+msgstr "gattrib ഉപയോഗിച്ച്   കമ്പോണന്ടിന്റെ  സവിശേഷതകള്‍ മാറ്റം വരുത്തുക"
+
+#, c-format
+msgid "Start master pin list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master comp list creation.\n"
+msgid "Found component pin with no pinnumber: refdes = %1$s\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master comp attrib list creation.\n"
+msgid "Start master pin attrib list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master pin list creation.\n"
+msgid "Tried to add to a NULL list.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_sheet_data_add_master_pin_list_items, found component pin with no "
-"pinnumber.\n"
+msgid "Tried to remove item from empty list.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master pin attrib list creation.\n"
+msgid "Couldn't delete item %1$s\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
+msgid "We didn't find the row name in the row list!\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
+msgid "Start internal component TABLE creation\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_delete_item, couldn't delete item %s\n"
+msgid "We didn't find either row or col in the lists!\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
-msgstr ""
-
-#, c-format
-msgid "- Starting internal component TABLE creation\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
-"or col in the lists!\n"
-msgstr ""
-
-#, c-format
-msgid "- Starting internal pin TABLE creation\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
-"col in the lists!\n"
+msgid "Start internal pin TABLE creation\n"
 msgstr ""
 
 msgid "_cancel"
 msgstr ""
 
 #, c-format
-msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
+msgid "Can't get attrib name\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
-"the master list!\n"
+msgid "We didn't find the refdes in the master list.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
+msgid "Either refdes or pinnumber of object missing.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
-"missing!\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
-"master list!\n"
-msgstr ""
-
-#, c-format
-msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
+msgid "We didn't find the refdes:pin in the master list.\n"
 msgstr ""
 
 msgid "Add new attribute"
@@ -218,7 +195,7 @@ msgid ""
 "One or more components have been found with missing symbol files!\n"
 "\n"
 "This probably happened because lepton-attrib couldn't find your component "
-"libraries, perhaps because your gafrc or gattribrc files are misconfigured.\n"
+"libraries, perhaps because your gafrc files are misconfigured.\n"
 "\n"
 "Choose \"Quit\" to leave lepton-attrib and fix the problem, or\n"
 "\"Forward\" to continue working with lepton-attrib.\n"

--- a/attrib/po/nb.po
+++ b/attrib/po/nb.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-10-03 23:30+0300\n"
+"POT-Creation-Date: 2020-03-07 14:33+0300\n"
 "PO-Revision-Date: 2012-01-27 14:17+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: Norwegian Bokmal <nb@li.org>\n"
@@ -26,7 +26,7 @@ msgid "Manipulate component attributes with lepton-attrib"
 msgstr "Manipuler komponent attributter med gattrib"
 
 #, c-format
-msgid "o_save: Could not open [%1$s]"
+msgid "Could not open [%1$s]"
 msgstr ""
 
 #, c-format
@@ -45,13 +45,15 @@ msgstr ""
 
 #, c-format
 msgid ""
+"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
 "\n"
 "lepton-attrib: Lepton EDA attribute editor.\n"
 "Presents schematic attributes in easy-to-edit spreadsheet format.\n"
 "\n"
-"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
+"Options:\n"
 "  -q, --quiet            Quiet mode\n"
 "  -v, --verbose          Verbose mode on\n"
+"  -V, --version          Show version information\n"
 "  -h, --help             This help menu\n"
 "\n"
 "  FAQ:\n"
@@ -73,11 +75,22 @@ msgid ""
 "Copyright (C) 2007-2016 gEDA Contributors.\n"
 "Copyright (C) 2017-2019 Lepton EDA Contributors.\n"
 "\n"
-"Please report bugs to %2$s.\n"
+"Report bugs at <%2$s>\n"
+"Lepton EDA homepage: <%3$s>\n"
 msgstr ""
 
 #, c-format
-msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
+msgid ""
+"\n"
+"Run `lepton-attrib --help' for more information.\n"
+msgstr ""
+
+#, c-format
+msgid "WARNING: "
+msgstr ""
+
+#, c-format
+msgid "Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 
 #, c-format
@@ -91,114 +104,78 @@ msgid " DONE\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Failed to find the attrib %1$s on the component.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Trying to add attrib to non-component or non-net!\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
-"or non-net!\n"
+msgid "Start master component list creation.\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Start master component attrib list creation.\n"
+msgstr "Manipuler komponent attributter med gattrib"
+
+#, c-format
+msgid "Start master pin list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master comp list creation.\n"
+msgid "Found component pin with no pinnumber: refdes = %1$s\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master comp attrib list creation.\n"
+msgid "Start master pin attrib list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master pin list creation.\n"
+msgid "Tried to add to a NULL list.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_sheet_data_add_master_pin_list_items, found component pin with no "
-"pinnumber.\n"
+msgid "Tried to remove item from empty list.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master pin attrib list creation.\n"
+msgid "Couldn't delete item %1$s\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
+msgid "We didn't find the row name in the row list!\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
+msgid "Start internal component TABLE creation\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_delete_item, couldn't delete item %s\n"
+msgid "We didn't find either row or col in the lists!\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
-msgstr ""
-
-#, c-format
-msgid "- Starting internal component TABLE creation\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
-"or col in the lists!\n"
-msgstr ""
-
-#, c-format
-msgid "- Starting internal pin TABLE creation\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
-"col in the lists!\n"
+msgid "Start internal pin TABLE creation\n"
 msgstr ""
 
 msgid "_cancel"
 msgstr ""
 
 #, c-format
-msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
+msgid "Can't get attrib name\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
-"the master list!\n"
+msgid "We didn't find the refdes in the master list.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
+msgid "Either refdes or pinnumber of object missing.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
-"missing!\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
-"master list!\n"
-msgstr ""
-
-#, c-format
-msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
+msgid "We didn't find the refdes:pin in the master list.\n"
 msgstr ""
 
 msgid "Add new attribute"
@@ -217,7 +194,7 @@ msgid ""
 "One or more components have been found with missing symbol files!\n"
 "\n"
 "This probably happened because lepton-attrib couldn't find your component "
-"libraries, perhaps because your gafrc or gattribrc files are misconfigured.\n"
+"libraries, perhaps because your gafrc files are misconfigured.\n"
 "\n"
 "Choose \"Quit\" to leave lepton-attrib and fix the problem, or\n"
 "\"Forward\" to continue working with lepton-attrib.\n"

--- a/attrib/po/nl.po
+++ b/attrib/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-10-03 23:30+0300\n"
+"POT-Creation-Date: 2020-03-07 14:33+0300\n"
 "PO-Revision-Date: 2014-08-31 20:31+0100\n"
 "Last-Translator: Bert Timmerman <bert.timmerman@xs4all.nl>\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -29,7 +29,7 @@ msgid "Manipulate component attributes with lepton-attrib"
 msgstr "Manipuleer componenten attributen met gattrib"
 
 #, fuzzy, c-format
-msgid "o_save: Could not open [%1$s]"
+msgid "Could not open [%1$s]"
 msgstr "o_save: Kan [%s] niet openen\n"
 
 #, c-format
@@ -48,13 +48,15 @@ msgstr "Widget moet een kind van GtkSheet zijn"
 
 #, fuzzy, c-format
 msgid ""
+"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
 "\n"
 "lepton-attrib: Lepton EDA attribute editor.\n"
 "Presents schematic attributes in easy-to-edit spreadsheet format.\n"
 "\n"
-"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
+"Options:\n"
 "  -q, --quiet            Quiet mode\n"
 "  -v, --verbose          Verbose mode on\n"
+"  -V, --version          Show version information\n"
 "  -h, --help             This help menu\n"
 "\n"
 "  FAQ:\n"
@@ -76,7 +78,8 @@ msgid ""
 "Copyright (C) 2007-2016 gEDA Contributors.\n"
 "Copyright (C) 2017-2019 Lepton EDA Contributors.\n"
 "\n"
-"Please report bugs to %2$s.\n"
+"Report bugs at <%2$s>\n"
+"Lepton EDA homepage: <%3$s>\n"
 msgstr ""
 "\n"
 "Gattrib:  De gEDA project attribuut editor.\n"
@@ -107,8 +110,18 @@ msgstr ""
 "net.\n"
 "\n"
 
+#, c-format
+msgid ""
+"\n"
+"Run `lepton-attrib --help' for more information.\n"
+msgstr ""
+
+#, c-format
+msgid "WARNING: "
+msgstr ""
+
 #, fuzzy, c-format
-msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
+msgid "Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 "WAARSCHUWING: uref=%s gevonden, uref= is vervallen, gebruik alstublieft "
 "refdes=\n"
@@ -126,141 +139,96 @@ msgid " DONE\n"
 msgstr " GEDAAN\n"
 
 #, fuzzy, c-format
-msgid ""
-"In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
-msgstr ""
-"In s_object_replace_attrib_in_object, is gefaald om attrib %s te vinden in "
-"de component.  Afsluiten . . .\n"
-
-#, fuzzy, c-format
-msgid ""
-"In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Failed to find the attrib %1$s on the component.\n"
 msgstr ""
 "In s_object_remove_attrib_in_object, is gefaald om attrib %s in de component "
 "te vinden.  Afsluiten . . .\n"
 
-#, c-format
-msgid ""
-"In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
-"or non-net!\n"
+#, fuzzy, c-format
+msgid "Trying to add attrib to non-component or non-net!\n"
 msgstr ""
 "In s_object_attrib_add_attrib_in_object, geprobeerd om attrib toe te voegen "
 "aan een non-complex of niet-net!\n"
 
-#, c-format
-msgid "- Starting master comp list creation.\n"
+#, fuzzy, c-format
+msgid "Start master component list creation.\n"
 msgstr "- Start het aanmaken van de hoofdcomponentenlijst.\n"
 
-#, c-format
-msgid "- Starting master comp attrib list creation.\n"
+#, fuzzy, c-format
+msgid "Start master component attrib list creation.\n"
 msgstr "- Start het aanmaken van de hoofdattributenlijst.\n"
 
-#, c-format
-msgid "- Starting master pin list creation.\n"
+#, fuzzy, c-format
+msgid "Start master pin list creation.\n"
 msgstr "- Start het aanmaken van de hoofdpennenlijst.\n"
 
 #, c-format
-msgid ""
-"In s_sheet_data_add_master_pin_list_items, found component pin with no "
-"pinnumber.\n"
+msgid "Found component pin with no pinnumber: refdes = %1$s\n"
 msgstr ""
-"In s_sheet_data_add_master_pin_list_items, is een component pen zonder "
-"pennummer gevonden.\n"
 
-#, c-format
-msgid "- Starting master pin attrib list creation.\n"
+#, fuzzy, c-format
+msgid "Start master pin attrib list creation.\n"
 msgstr "- Start het aanmaken van de hoofdpennenattributenlijst.\n"
 
-#, c-format
-msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
+#, fuzzy, c-format
+msgid "Tried to add to a NULL list.\n"
 msgstr ""
 "In s_string_list_add_item, is geprobeerd toe te voegen aan een NULL lijst.\n"
 
-#, c-format
-msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
+#, fuzzy, c-format
+msgid "Tried to remove item from empty list.\n"
 msgstr ""
 "In s_string_list_delete_item, is geprobeerd om een item te verwijderen van "
 "een lege lijst\n"
 
-#, c-format
-msgid "In s_string_list_delete_item, couldn't delete item %s\n"
-msgstr "In s_string_list_delete_item, kan item %s niet verwijderen\n"
+#, fuzzy, c-format
+msgid "Couldn't delete item %1$s\n"
+msgstr "Kan bestand [%s] niet vinden\n"
 
-#, c-format
-msgid ""
-"In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
+#, fuzzy, c-format
+msgid "We didn't find the row name in the row list!\n"
 msgstr ""
 "In s_table_create_attrib_pair, is de naam van de regel niet gevonden in de "
 "lijst met regels!\n"
 
-#, c-format
-msgid "- Starting internal component TABLE creation\n"
+#, fuzzy, c-format
+msgid "Start internal component TABLE creation\n"
 msgstr "- Start het aanmaken van de interne componenten TABEL.\n"
 
-#, c-format
-msgid ""
-"In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
-"or col in the lists!\n"
-msgstr ""
-"In s_table_add_toplevel_comp_items_to_comp_table, is geen regel of kolom "
-"gevonden in de lijsten!\n"
-
-#, c-format
-msgid "- Starting internal pin TABLE creation\n"
-msgstr "- Start het aanmaken van de interne pennen TABEL.\n"
-
-#, c-format
-msgid ""
-"In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
-"col in the lists!\n"
+#, fuzzy, c-format
+msgid "We didn't find either row or col in the lists!\n"
 msgstr ""
 "In s_table_add_toplevel_pin_items_to_pin_table, is noch regel noch kolom "
 "gevonden in de lijsten!\n"
 
+#, fuzzy, c-format
+msgid "Start internal pin TABLE creation\n"
+msgstr "- Start het aanmaken van de interne pennen TABEL.\n"
+
 msgid "_cancel"
 msgstr "_afbreken"
 
-#, c-format
-msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
-msgstr "In s_toplevel_delete_attrib_col, kan geen attrib naam krijgen\n"
+#, fuzzy, c-format
+msgid "Can't get attrib name\n"
+msgstr "Voer nieuwe attribuutnaam toe"
 
-#, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
-"the master list!\n"
-msgstr ""
-"In s_toplevel_get_component_attribs_in_sheet, geen refdes gevonden in de "
-"hoofdlijst!\n"
-
-#, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
-msgstr ""
-"In s_toplevel_get_component_attribs_in_sheet, count != i!  "
-"Afsluiten . . . .\n"
-
-#, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
-"missing!\n"
-msgstr ""
-"In s_toplevel_get_pin_attribs_in_sheet, ofwel een refdes of een pennummer "
-"van het object ontbreken!\n"
-
-#, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
-"master list!\n"
+#, fuzzy, c-format
+msgid "We didn't find the refdes in the master list.\n"
 msgstr ""
 "In s_toplevel_get_pin_attribs_in_sheet, is geen refdes:pin gevonden in de "
 "hoofdlijst!\n"
 
-#, c-format
-msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
+#, fuzzy, c-format
+msgid "Either refdes or pinnumber of object missing.\n"
 msgstr ""
-"In s_toplevel_get_pin_attribs_in_sheet, count != i!  Afsluiten . . . .\n"
+"In s_toplevel_get_pin_attribs_in_sheet, ofwel een refdes of een pennummer "
+"van het object ontbreken!\n"
+
+#, fuzzy, c-format
+msgid "We didn't find the refdes:pin in the master list.\n"
+msgstr ""
+"In s_toplevel_get_pin_attribs_in_sheet, is geen refdes:pin gevonden in de "
+"hoofdlijst!\n"
 
 msgid "Add new attribute"
 msgstr "Voeg nieuwe attribuut toe"
@@ -279,7 +247,7 @@ msgid ""
 "One or more components have been found with missing symbol files!\n"
 "\n"
 "This probably happened because lepton-attrib couldn't find your component "
-"libraries, perhaps because your gafrc or gattribrc files are misconfigured.\n"
+"libraries, perhaps because your gafrc files are misconfigured.\n"
 "\n"
 "Choose \"Quit\" to leave lepton-attrib and fix the problem, or\n"
 "\"Forward\" to continue working with lepton-attrib.\n"
@@ -455,6 +423,53 @@ msgid ""
 msgstr ""
 "Geen pennen gevonden op geen van de componenten!\n"
 "Controleer alstublieft uw ontwerp."
+
+#, fuzzy
+#~ msgid ""
+#~ "In s_object_replace_attrib_in_object, we have failed to find the attrib "
+#~ "%1$s on the component.  Exiting . . .\n"
+#~ msgstr ""
+#~ "In s_object_replace_attrib_in_object, is gefaald om attrib %s te vinden "
+#~ "in de component.  Afsluiten . . .\n"
+
+#~ msgid ""
+#~ "In s_sheet_data_add_master_pin_list_items, found component pin with no "
+#~ "pinnumber.\n"
+#~ msgstr ""
+#~ "In s_sheet_data_add_master_pin_list_items, is een component pen zonder "
+#~ "pennummer gevonden.\n"
+
+#~ msgid "In s_string_list_delete_item, couldn't delete item %s\n"
+#~ msgstr "In s_string_list_delete_item, kan item %s niet verwijderen\n"
+
+#~ msgid ""
+#~ "In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either "
+#~ "row or col in the lists!\n"
+#~ msgstr ""
+#~ "In s_table_add_toplevel_comp_items_to_comp_table, is geen regel of kolom "
+#~ "gevonden in de lijsten!\n"
+
+#~ msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
+#~ msgstr "In s_toplevel_delete_attrib_col, kan geen attrib naam krijgen\n"
+
+#~ msgid ""
+#~ "In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes "
+#~ "in the master list!\n"
+#~ msgstr ""
+#~ "In s_toplevel_get_component_attribs_in_sheet, geen refdes gevonden in de "
+#~ "hoofdlijst!\n"
+
+#~ msgid ""
+#~ "In s_toplevel_get_component_attribs_in_sheet, count != i!  "
+#~ "Exiting . . . .\n"
+#~ msgstr ""
+#~ "In s_toplevel_get_component_attribs_in_sheet, count != i!  "
+#~ "Afsluiten . . . .\n"
+
+#~ msgid ""
+#~ "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
+#~ msgstr ""
+#~ "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Afsluiten . . . .\n"
 
 #, fuzzy
 #~ msgid ""

--- a/attrib/po/oc.po
+++ b/attrib/po/oc.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-10-03 23:30+0300\n"
+"POT-Creation-Date: 2020-03-07 14:33+0300\n"
 "PO-Revision-Date: 2012-01-27 14:17+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: Occitan (post 1500) <oc@li.org>\n"
@@ -27,7 +27,7 @@ msgid "Manipulate component attributes with lepton-attrib"
 msgstr "Manipular los atributs dels components amb gattrib"
 
 #, c-format
-msgid "o_save: Could not open [%1$s]"
+msgid "Could not open [%1$s]"
 msgstr ""
 
 #, c-format
@@ -46,13 +46,15 @@ msgstr ""
 
 #, c-format
 msgid ""
+"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
 "\n"
 "lepton-attrib: Lepton EDA attribute editor.\n"
 "Presents schematic attributes in easy-to-edit spreadsheet format.\n"
 "\n"
-"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
+"Options:\n"
 "  -q, --quiet            Quiet mode\n"
 "  -v, --verbose          Verbose mode on\n"
+"  -V, --version          Show version information\n"
 "  -h, --help             This help menu\n"
 "\n"
 "  FAQ:\n"
@@ -74,11 +76,22 @@ msgid ""
 "Copyright (C) 2007-2016 gEDA Contributors.\n"
 "Copyright (C) 2017-2019 Lepton EDA Contributors.\n"
 "\n"
-"Please report bugs to %2$s.\n"
+"Report bugs at <%2$s>\n"
+"Lepton EDA homepage: <%3$s>\n"
 msgstr ""
 
 #, c-format
-msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
+msgid ""
+"\n"
+"Run `lepton-attrib --help' for more information.\n"
+msgstr ""
+
+#, c-format
+msgid "WARNING: "
+msgstr ""
+
+#, c-format
+msgid "Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 
 #, c-format
@@ -92,114 +105,78 @@ msgid " DONE\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Failed to find the attrib %1$s on the component.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Trying to add attrib to non-component or non-net!\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
-"or non-net!\n"
+msgid "Start master component list creation.\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Start master component attrib list creation.\n"
+msgstr "Manipular los atributs dels components amb gattrib"
+
+#, c-format
+msgid "Start master pin list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master comp list creation.\n"
+msgid "Found component pin with no pinnumber: refdes = %1$s\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master comp attrib list creation.\n"
+msgid "Start master pin attrib list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master pin list creation.\n"
+msgid "Tried to add to a NULL list.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_sheet_data_add_master_pin_list_items, found component pin with no "
-"pinnumber.\n"
+msgid "Tried to remove item from empty list.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master pin attrib list creation.\n"
+msgid "Couldn't delete item %1$s\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
+msgid "We didn't find the row name in the row list!\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
+msgid "Start internal component TABLE creation\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_delete_item, couldn't delete item %s\n"
+msgid "We didn't find either row or col in the lists!\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
-msgstr ""
-
-#, c-format
-msgid "- Starting internal component TABLE creation\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
-"or col in the lists!\n"
-msgstr ""
-
-#, c-format
-msgid "- Starting internal pin TABLE creation\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
-"col in the lists!\n"
+msgid "Start internal pin TABLE creation\n"
 msgstr ""
 
 msgid "_cancel"
 msgstr ""
 
 #, c-format
-msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
+msgid "Can't get attrib name\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
-"the master list!\n"
+msgid "We didn't find the refdes in the master list.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
+msgid "Either refdes or pinnumber of object missing.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
-"missing!\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
-"master list!\n"
-msgstr ""
-
-#, c-format
-msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
+msgid "We didn't find the refdes:pin in the master list.\n"
 msgstr ""
 
 msgid "Add new attribute"
@@ -218,7 +195,7 @@ msgid ""
 "One or more components have been found with missing symbol files!\n"
 "\n"
 "This probably happened because lepton-attrib couldn't find your component "
-"libraries, perhaps because your gafrc or gattribrc files are misconfigured.\n"
+"libraries, perhaps because your gafrc files are misconfigured.\n"
 "\n"
 "Choose \"Quit\" to leave lepton-attrib and fix the problem, or\n"
 "\"Forward\" to continue working with lepton-attrib.\n"

--- a/attrib/po/pl.po
+++ b/attrib/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-10-03 23:30+0300\n"
+"POT-Creation-Date: 2020-03-07 14:33+0300\n"
 "PO-Revision-Date: 2010-02-06 22:09+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -27,7 +27,7 @@ msgid "Manipulate component attributes with lepton-attrib"
 msgstr "Edytuj atrybuty elementów za pomocą gattrib"
 
 #, c-format
-msgid "o_save: Could not open [%1$s]"
+msgid "Could not open [%1$s]"
 msgstr ""
 
 #, c-format
@@ -46,13 +46,15 @@ msgstr ""
 
 #, c-format
 msgid ""
+"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
 "\n"
 "lepton-attrib: Lepton EDA attribute editor.\n"
 "Presents schematic attributes in easy-to-edit spreadsheet format.\n"
 "\n"
-"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
+"Options:\n"
 "  -q, --quiet            Quiet mode\n"
 "  -v, --verbose          Verbose mode on\n"
+"  -V, --version          Show version information\n"
 "  -h, --help             This help menu\n"
 "\n"
 "  FAQ:\n"
@@ -74,11 +76,22 @@ msgid ""
 "Copyright (C) 2007-2016 gEDA Contributors.\n"
 "Copyright (C) 2017-2019 Lepton EDA Contributors.\n"
 "\n"
-"Please report bugs to %2$s.\n"
+"Report bugs at <%2$s>\n"
+"Lepton EDA homepage: <%3$s>\n"
 msgstr ""
 
 #, c-format
-msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
+msgid ""
+"\n"
+"Run `lepton-attrib --help' for more information.\n"
+msgstr ""
+
+#, c-format
+msgid "WARNING: "
+msgstr ""
+
+#, c-format
+msgid "Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 
 #, c-format
@@ -92,114 +105,78 @@ msgid " DONE\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Failed to find the attrib %1$s on the component.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Trying to add attrib to non-component or non-net!\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
-"or non-net!\n"
+msgid "Start master component list creation.\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Start master component attrib list creation.\n"
+msgstr "Edytuj atrybuty elementów za pomocą gattrib"
+
+#, c-format
+msgid "Start master pin list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master comp list creation.\n"
+msgid "Found component pin with no pinnumber: refdes = %1$s\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master comp attrib list creation.\n"
+msgid "Start master pin attrib list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master pin list creation.\n"
+msgid "Tried to add to a NULL list.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_sheet_data_add_master_pin_list_items, found component pin with no "
-"pinnumber.\n"
+msgid "Tried to remove item from empty list.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master pin attrib list creation.\n"
+msgid "Couldn't delete item %1$s\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
+msgid "We didn't find the row name in the row list!\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
+msgid "Start internal component TABLE creation\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_delete_item, couldn't delete item %s\n"
+msgid "We didn't find either row or col in the lists!\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
-msgstr ""
-
-#, c-format
-msgid "- Starting internal component TABLE creation\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
-"or col in the lists!\n"
-msgstr ""
-
-#, c-format
-msgid "- Starting internal pin TABLE creation\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
-"col in the lists!\n"
+msgid "Start internal pin TABLE creation\n"
 msgstr ""
 
 msgid "_cancel"
 msgstr ""
 
 #, c-format
-msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
+msgid "Can't get attrib name\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
-"the master list!\n"
+msgid "We didn't find the refdes in the master list.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
+msgid "Either refdes or pinnumber of object missing.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
-"missing!\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
-"master list!\n"
-msgstr ""
-
-#, c-format
-msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
+msgid "We didn't find the refdes:pin in the master list.\n"
 msgstr ""
 
 msgid "Add new attribute"
@@ -218,7 +195,7 @@ msgid ""
 "One or more components have been found with missing symbol files!\n"
 "\n"
 "This probably happened because lepton-attrib couldn't find your component "
-"libraries, perhaps because your gafrc or gattribrc files are misconfigured.\n"
+"libraries, perhaps because your gafrc files are misconfigured.\n"
 "\n"
 "Choose \"Quit\" to leave lepton-attrib and fix the problem, or\n"
 "\"Forward\" to continue working with lepton-attrib.\n"

--- a/attrib/po/pt.po
+++ b/attrib/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-10-03 23:30+0300\n"
+"POT-Creation-Date: 2020-03-07 14:33+0300\n"
 "PO-Revision-Date: 2010-02-06 22:10+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -27,7 +27,7 @@ msgid "Manipulate component attributes with lepton-attrib"
 msgstr "Manipular atributos dos componentes com gattrib"
 
 #, c-format
-msgid "o_save: Could not open [%1$s]"
+msgid "Could not open [%1$s]"
 msgstr ""
 
 #, c-format
@@ -46,13 +46,15 @@ msgstr ""
 
 #, c-format
 msgid ""
+"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
 "\n"
 "lepton-attrib: Lepton EDA attribute editor.\n"
 "Presents schematic attributes in easy-to-edit spreadsheet format.\n"
 "\n"
-"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
+"Options:\n"
 "  -q, --quiet            Quiet mode\n"
 "  -v, --verbose          Verbose mode on\n"
+"  -V, --version          Show version information\n"
 "  -h, --help             This help menu\n"
 "\n"
 "  FAQ:\n"
@@ -74,11 +76,22 @@ msgid ""
 "Copyright (C) 2007-2016 gEDA Contributors.\n"
 "Copyright (C) 2017-2019 Lepton EDA Contributors.\n"
 "\n"
-"Please report bugs to %2$s.\n"
+"Report bugs at <%2$s>\n"
+"Lepton EDA homepage: <%3$s>\n"
 msgstr ""
 
 #, c-format
-msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
+msgid ""
+"\n"
+"Run `lepton-attrib --help' for more information.\n"
+msgstr ""
+
+#, c-format
+msgid "WARNING: "
+msgstr ""
+
+#, c-format
+msgid "Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 
 #, c-format
@@ -92,114 +105,78 @@ msgid " DONE\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Failed to find the attrib %1$s on the component.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Trying to add attrib to non-component or non-net!\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
-"or non-net!\n"
+msgid "Start master component list creation.\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Start master component attrib list creation.\n"
+msgstr "Manipular atributos dos componentes com gattrib"
+
+#, c-format
+msgid "Start master pin list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master comp list creation.\n"
+msgid "Found component pin with no pinnumber: refdes = %1$s\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master comp attrib list creation.\n"
+msgid "Start master pin attrib list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master pin list creation.\n"
+msgid "Tried to add to a NULL list.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_sheet_data_add_master_pin_list_items, found component pin with no "
-"pinnumber.\n"
+msgid "Tried to remove item from empty list.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master pin attrib list creation.\n"
+msgid "Couldn't delete item %1$s\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
+msgid "We didn't find the row name in the row list!\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
+msgid "Start internal component TABLE creation\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_delete_item, couldn't delete item %s\n"
+msgid "We didn't find either row or col in the lists!\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
-msgstr ""
-
-#, c-format
-msgid "- Starting internal component TABLE creation\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
-"or col in the lists!\n"
-msgstr ""
-
-#, c-format
-msgid "- Starting internal pin TABLE creation\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
-"col in the lists!\n"
+msgid "Start internal pin TABLE creation\n"
 msgstr ""
 
 msgid "_cancel"
 msgstr ""
 
 #, c-format
-msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
+msgid "Can't get attrib name\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
-"the master list!\n"
+msgid "We didn't find the refdes in the master list.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
+msgid "Either refdes or pinnumber of object missing.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
-"missing!\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
-"master list!\n"
-msgstr ""
-
-#, c-format
-msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
+msgid "We didn't find the refdes:pin in the master list.\n"
 msgstr ""
 
 msgid "Add new attribute"
@@ -218,7 +195,7 @@ msgid ""
 "One or more components have been found with missing symbol files!\n"
 "\n"
 "This probably happened because lepton-attrib couldn't find your component "
-"libraries, perhaps because your gafrc or gattribrc files are misconfigured.\n"
+"libraries, perhaps because your gafrc files are misconfigured.\n"
 "\n"
 "Choose \"Quit\" to leave lepton-attrib and fix the problem, or\n"
 "\"Forward\" to continue working with lepton-attrib.\n"

--- a/attrib/po/pt_BR.po
+++ b/attrib/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-10-03 23:30+0300\n"
+"POT-Creation-Date: 2020-03-07 14:33+0300\n"
 "PO-Revision-Date: 2010-02-06 22:10+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -27,7 +27,7 @@ msgid "Manipulate component attributes with lepton-attrib"
 msgstr "Manipule os atributos dos componentes com o gattrib"
 
 #, c-format
-msgid "o_save: Could not open [%1$s]"
+msgid "Could not open [%1$s]"
 msgstr ""
 
 #, c-format
@@ -46,13 +46,15 @@ msgstr ""
 
 #, c-format
 msgid ""
+"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
 "\n"
 "lepton-attrib: Lepton EDA attribute editor.\n"
 "Presents schematic attributes in easy-to-edit spreadsheet format.\n"
 "\n"
-"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
+"Options:\n"
 "  -q, --quiet            Quiet mode\n"
 "  -v, --verbose          Verbose mode on\n"
+"  -V, --version          Show version information\n"
 "  -h, --help             This help menu\n"
 "\n"
 "  FAQ:\n"
@@ -74,11 +76,22 @@ msgid ""
 "Copyright (C) 2007-2016 gEDA Contributors.\n"
 "Copyright (C) 2017-2019 Lepton EDA Contributors.\n"
 "\n"
-"Please report bugs to %2$s.\n"
+"Report bugs at <%2$s>\n"
+"Lepton EDA homepage: <%3$s>\n"
 msgstr ""
 
 #, c-format
-msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
+msgid ""
+"\n"
+"Run `lepton-attrib --help' for more information.\n"
+msgstr ""
+
+#, c-format
+msgid "WARNING: "
+msgstr ""
+
+#, c-format
+msgid "Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 
 #, c-format
@@ -92,114 +105,78 @@ msgid " DONE\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Failed to find the attrib %1$s on the component.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Trying to add attrib to non-component or non-net!\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
-"or non-net!\n"
+msgid "Start master component list creation.\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Start master component attrib list creation.\n"
+msgstr "Manipule os atributos dos componentes com o gattrib"
+
+#, c-format
+msgid "Start master pin list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master comp list creation.\n"
+msgid "Found component pin with no pinnumber: refdes = %1$s\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master comp attrib list creation.\n"
+msgid "Start master pin attrib list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master pin list creation.\n"
+msgid "Tried to add to a NULL list.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_sheet_data_add_master_pin_list_items, found component pin with no "
-"pinnumber.\n"
+msgid "Tried to remove item from empty list.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master pin attrib list creation.\n"
+msgid "Couldn't delete item %1$s\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
+msgid "We didn't find the row name in the row list!\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
+msgid "Start internal component TABLE creation\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_delete_item, couldn't delete item %s\n"
+msgid "We didn't find either row or col in the lists!\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
-msgstr ""
-
-#, c-format
-msgid "- Starting internal component TABLE creation\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
-"or col in the lists!\n"
-msgstr ""
-
-#, c-format
-msgid "- Starting internal pin TABLE creation\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
-"col in the lists!\n"
+msgid "Start internal pin TABLE creation\n"
 msgstr ""
 
 msgid "_cancel"
 msgstr ""
 
 #, c-format
-msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
+msgid "Can't get attrib name\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
-"the master list!\n"
+msgid "We didn't find the refdes in the master list.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
+msgid "Either refdes or pinnumber of object missing.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
-"missing!\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
-"master list!\n"
-msgstr ""
-
-#, c-format
-msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
+msgid "We didn't find the refdes:pin in the master list.\n"
 msgstr ""
 
 msgid "Add new attribute"
@@ -218,7 +195,7 @@ msgid ""
 "One or more components have been found with missing symbol files!\n"
 "\n"
 "This probably happened because lepton-attrib couldn't find your component "
-"libraries, perhaps because your gafrc or gattribrc files are misconfigured.\n"
+"libraries, perhaps because your gafrc files are misconfigured.\n"
 "\n"
 "Choose \"Quit\" to leave lepton-attrib and fix the problem, or\n"
 "\"Forward\" to continue working with lepton-attrib.\n"

--- a/attrib/po/ru.po
+++ b/attrib/po/ru.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda gattrib\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-10-03 23:30+0300\n"
+"POT-Creation-Date: 2020-03-07 14:08+0300\n"
 "PO-Revision-Date: 2014-03-08 20:49+0400\n"
 "Last-Translator: Vladimir Zhbanov <vzhbanov@gmail.com>\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -29,7 +29,7 @@ msgid "Manipulate component attributes with lepton-attrib"
 msgstr "Управление атрибутами компонента с помощью gattrib"
 
 #, fuzzy, c-format
-msgid "o_save: Could not open [%1$s]"
+msgid "Could not open [%1$s]"
 msgstr "o_save: Не удалось открыть «%s»\n"
 
 #, c-format
@@ -50,13 +50,15 @@ msgstr "Виджет должен быть дочерним для GtkSheet"
 
 #, fuzzy, c-format
 msgid ""
+"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
 "\n"
 "lepton-attrib: Lepton EDA attribute editor.\n"
 "Presents schematic attributes in easy-to-edit spreadsheet format.\n"
 "\n"
-"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
+"Options:\n"
 "  -q, --quiet            Quiet mode\n"
 "  -v, --verbose          Verbose mode on\n"
+"  -V, --version          Show version information\n"
 "  -h, --help             This help menu\n"
 "\n"
 "  FAQ:\n"
@@ -78,7 +80,8 @@ msgid ""
 "Copyright (C) 2007-2016 gEDA Contributors.\n"
 "Copyright (C) 2017-2019 Lepton EDA Contributors.\n"
 "\n"
-"Please report bugs to %2$s.\n"
+"Report bugs at <%2$s>\n"
+"Lepton EDA homepage: <%3$s>\n"
 msgstr ""
 "\n"
 "Gattrib:  редактор атрибутов проекта gEDA.\n"
@@ -109,8 +112,18 @@ msgstr ""
 "net.\n"
 "\n"
 
+#, c-format
+msgid ""
+"\n"
+"Run `lepton-attrib --help' for more information.\n"
+msgstr ""
+
+#, c-format
+msgid "WARNING: "
+msgstr ""
+
 #, fuzzy, c-format
-msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
+msgid "Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 "ВНИМАНИЕ: Обнаружен не рекомендуемый к использованию атрибут «uref=%s», "
 "используйте вместо него «refdes».\n"
@@ -128,136 +141,94 @@ msgid " DONE\n"
 msgstr " ЗАВЕРШЕНО\n"
 
 #, fuzzy, c-format
-msgid ""
-"In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
-msgstr ""
-"s_object_replace_attrib_in_object: не удалось найти атрибут «%s» для "
-"компонента. Выход . . .\n"
-
-#, fuzzy, c-format
-msgid ""
-"In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Failed to find the attrib %1$s on the component.\n"
 msgstr ""
 "s_object_remove_attrib_in_object: не удалось найти атрибут «%s» для "
 "компонента. Выход . . .\n"
 
-#, c-format
-msgid ""
-"In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
-"or non-net!\n"
+#, fuzzy, c-format
+msgid "Trying to add attrib to non-component or non-net!\n"
 msgstr ""
 "s_object_attrib_add_attrib_in_object: попытка добавить атрибут к объекту, не "
 "являющимся ни составным, ни соединением!\n"
 
-#, c-format
-msgid "- Starting master comp list creation.\n"
+#, fuzzy, c-format
+msgid "Start master component list creation.\n"
 msgstr "- Приступаем к созданию основного списка компонентов.\n"
 
-#, c-format
-msgid "- Starting master comp attrib list creation.\n"
+#, fuzzy, c-format
+msgid "Start master component attrib list creation.\n"
 msgstr "- Приступаем к созданию основного списка атрибутов компонентов.\n"
 
-#, c-format
-msgid "- Starting master pin list creation.\n"
+#, fuzzy, c-format
+msgid "Start master pin list creation.\n"
 msgstr "- Приступаем к созданию основного списка выводов.\n"
 
 #, c-format
-msgid ""
-"In s_sheet_data_add_master_pin_list_items, found component pin with no "
-"pinnumber.\n"
+msgid "Found component pin with no pinnumber: refdes = %1$s\n"
 msgstr ""
-"s_sheet_data_add_master_pin_list_items: обнаружен вывод компонента без "
-"атрибута pinnumber.\n"
 
-#, c-format
-msgid "- Starting master pin attrib list creation.\n"
+#, fuzzy, c-format
+msgid "Start master pin attrib list creation.\n"
 msgstr "- Приступаем к созданию основного списка атрибутов выводов.\n"
 
-#, c-format
-msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
+#, fuzzy, c-format
+msgid "Tried to add to a NULL list.\n"
 msgstr ""
 "s_string_list_add_item: попытка добавления к списку со значением NULL.\n"
 
-#, c-format
-msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
+#, fuzzy, c-format
+msgid "Tried to remove item from empty list.\n"
 msgstr ""
 "s_string_list_delete_item: попытка удаления элемента из пустого списка\n"
 
-#, c-format
-msgid "In s_string_list_delete_item, couldn't delete item %s\n"
-msgstr "s_string_list_delete_item: не удалось удалить элемент %s\n"
+#, fuzzy, c-format
+msgid "Couldn't delete item %1$s\n"
+msgstr "Не удалось найти файл «%s»\n"
 
-#, c-format
-msgid ""
-"In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
+#, fuzzy, c-format
+msgid "We didn't find the row name in the row list!\n"
 msgstr ""
 "s_table_create_attrib_pair: не удалось найти имя строки в списке строк!\n"
 
-#, c-format
-msgid "- Starting internal component TABLE creation\n"
+#, fuzzy, c-format
+msgid "Start internal component TABLE creation\n"
 msgstr "- Приступаем к созданию внутренней таблицы компонентов\n"
 
-#, c-format
-msgid ""
-"In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
-"or col in the lists!\n"
-msgstr ""
-"s_table_add_toplevel_comp_items_to_comp_table: не удалось найти либо строку, "
-"либо столбец в соответствующем списке!\n"
-
-#, c-format
-msgid "- Starting internal pin TABLE creation\n"
-msgstr "- Приступаем к созданию внутренней таблицы выводов\n"
-
-#, c-format
-msgid ""
-"In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
-"col in the lists!\n"
+#, fuzzy, c-format
+msgid "We didn't find either row or col in the lists!\n"
 msgstr ""
 "s_table_add_toplevel_pin_items_to_pin_table: не удалось найти либо строку, "
 "либо столбец в соответствующем списке!\n"
 
+#, fuzzy, c-format
+msgid "Start internal pin TABLE creation\n"
+msgstr "- Приступаем к созданию внутренней таблицы выводов\n"
+
 msgid "_cancel"
 msgstr ""
 
-#, c-format
-msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
-msgstr "s_toplevel_delete_attrib_col: не удалось получить имя атрибута\n"
+#, fuzzy, c-format
+msgid "Can't get attrib name\n"
+msgstr "Введите новое имя атрибута"
 
-#, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
-"the master list!\n"
-msgstr ""
-"s_toplevel_get_component_attribs_in_sheet: не найдено значение «refdes» в "
-"основном списке!\n"
-
-#, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
-msgstr "s_toplevel_get_component_attribs_in_sheet: count != i!  Выход . . .\n"
-
-#, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
-"missing!\n"
-msgstr ""
-"s_toplevel_get_pin_attribs_in_sheet: отсутствует атрибут «refdes» или "
-"«pinnumber» у объекта!\n"
-
-#, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
-"master list!\n"
+#, fuzzy, c-format
+msgid "We didn't find the refdes in the master list.\n"
 msgstr ""
 "s_toplevel_get_pin_attribs_in_sheet: не удалось найти нужную строку "
 "«refdes»:«pinnumber» в основном списке!\n"
 
-#, c-format
-msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
-msgstr "s_toplevel_get_pin_attribs_in_sheet: count != i!  Выход . . .\n"
+#, fuzzy, c-format
+msgid "Either refdes or pinnumber of object missing.\n"
+msgstr ""
+"s_toplevel_get_pin_attribs_in_sheet: отсутствует атрибут «refdes» или "
+"«pinnumber» у объекта!\n"
+
+#, fuzzy, c-format
+msgid "We didn't find the refdes:pin in the master list.\n"
+msgstr ""
+"s_toplevel_get_pin_attribs_in_sheet: не удалось найти нужную строку "
+"«refdes»:«pinnumber» в основном списке!\n"
 
 msgid "Add new attribute"
 msgstr "Добавление нового атрибута"
@@ -452,6 +423,51 @@ msgid ""
 msgstr ""
 "Не найдено выводов ни у одного компонента!\n"
 "Проверьте свой проект."
+
+#, fuzzy
+#~ msgid ""
+#~ "In s_object_replace_attrib_in_object, we have failed to find the attrib "
+#~ "%1$s on the component.  Exiting . . .\n"
+#~ msgstr ""
+#~ "s_object_replace_attrib_in_object: не удалось найти атрибут «%s» для "
+#~ "компонента. Выход . . .\n"
+
+#~ msgid ""
+#~ "In s_sheet_data_add_master_pin_list_items, found component pin with no "
+#~ "pinnumber.\n"
+#~ msgstr ""
+#~ "s_sheet_data_add_master_pin_list_items: обнаружен вывод компонента без "
+#~ "атрибута pinnumber.\n"
+
+#~ msgid "In s_string_list_delete_item, couldn't delete item %s\n"
+#~ msgstr "s_string_list_delete_item: не удалось удалить элемент %s\n"
+
+#~ msgid ""
+#~ "In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either "
+#~ "row or col in the lists!\n"
+#~ msgstr ""
+#~ "s_table_add_toplevel_comp_items_to_comp_table: не удалось найти либо "
+#~ "строку, либо столбец в соответствующем списке!\n"
+
+#~ msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
+#~ msgstr "s_toplevel_delete_attrib_col: не удалось получить имя атрибута\n"
+
+#~ msgid ""
+#~ "In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes "
+#~ "in the master list!\n"
+#~ msgstr ""
+#~ "s_toplevel_get_component_attribs_in_sheet: не найдено значение «refdes» в "
+#~ "основном списке!\n"
+
+#~ msgid ""
+#~ "In s_toplevel_get_component_attribs_in_sheet, count != i!  "
+#~ "Exiting . . . .\n"
+#~ msgstr ""
+#~ "s_toplevel_get_component_attribs_in_sheet: count != i!  Выход . . .\n"
+
+#~ msgid ""
+#~ "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
+#~ msgstr "s_toplevel_get_pin_attribs_in_sheet: count != i!  Выход . . .\n"
 
 #, fuzzy
 #~ msgid ""

--- a/attrib/po/sl.po
+++ b/attrib/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-10-03 23:30+0300\n"
+"POT-Creation-Date: 2020-03-07 14:33+0300\n"
 "PO-Revision-Date: 2012-04-09 11:22+0000\n"
 "Last-Translator: Miha Gašperšič <mihec.gaspersic@gmail.com>\n"
 "Language-Team: Slovenian <sl@li.org>\n"
@@ -27,7 +27,7 @@ msgid "Manipulate component attributes with lepton-attrib"
 msgstr "Upravljajte atribute sestavnih delov z gattrib"
 
 #, c-format
-msgid "o_save: Could not open [%1$s]"
+msgid "Could not open [%1$s]"
 msgstr ""
 
 #, c-format
@@ -46,13 +46,15 @@ msgstr ""
 
 #, c-format
 msgid ""
+"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
 "\n"
 "lepton-attrib: Lepton EDA attribute editor.\n"
 "Presents schematic attributes in easy-to-edit spreadsheet format.\n"
 "\n"
-"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
+"Options:\n"
 "  -q, --quiet            Quiet mode\n"
 "  -v, --verbose          Verbose mode on\n"
+"  -V, --version          Show version information\n"
 "  -h, --help             This help menu\n"
 "\n"
 "  FAQ:\n"
@@ -74,11 +76,22 @@ msgid ""
 "Copyright (C) 2007-2016 gEDA Contributors.\n"
 "Copyright (C) 2017-2019 Lepton EDA Contributors.\n"
 "\n"
-"Please report bugs to %2$s.\n"
+"Report bugs at <%2$s>\n"
+"Lepton EDA homepage: <%3$s>\n"
 msgstr ""
 
 #, c-format
-msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
+msgid ""
+"\n"
+"Run `lepton-attrib --help' for more information.\n"
+msgstr ""
+
+#, c-format
+msgid "WARNING: "
+msgstr ""
+
+#, c-format
+msgid "Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 
 #, c-format
@@ -92,114 +105,78 @@ msgid " DONE\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Failed to find the attrib %1$s on the component.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Trying to add attrib to non-component or non-net!\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
-"or non-net!\n"
+msgid "Start master component list creation.\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Start master component attrib list creation.\n"
+msgstr "Upravljajte atribute sestavnih delov z gattrib"
+
+#, c-format
+msgid "Start master pin list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master comp list creation.\n"
+msgid "Found component pin with no pinnumber: refdes = %1$s\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master comp attrib list creation.\n"
+msgid "Start master pin attrib list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master pin list creation.\n"
+msgid "Tried to add to a NULL list.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_sheet_data_add_master_pin_list_items, found component pin with no "
-"pinnumber.\n"
+msgid "Tried to remove item from empty list.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master pin attrib list creation.\n"
+msgid "Couldn't delete item %1$s\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
+msgid "We didn't find the row name in the row list!\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
+msgid "Start internal component TABLE creation\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_delete_item, couldn't delete item %s\n"
+msgid "We didn't find either row or col in the lists!\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
-msgstr ""
-
-#, c-format
-msgid "- Starting internal component TABLE creation\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
-"or col in the lists!\n"
-msgstr ""
-
-#, c-format
-msgid "- Starting internal pin TABLE creation\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
-"col in the lists!\n"
+msgid "Start internal pin TABLE creation\n"
 msgstr ""
 
 msgid "_cancel"
 msgstr ""
 
 #, c-format
-msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
+msgid "Can't get attrib name\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
-"the master list!\n"
+msgid "We didn't find the refdes in the master list.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
+msgid "Either refdes or pinnumber of object missing.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
-"missing!\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
-"master list!\n"
-msgstr ""
-
-#, c-format
-msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
+msgid "We didn't find the refdes:pin in the master list.\n"
 msgstr ""
 
 msgid "Add new attribute"
@@ -218,7 +195,7 @@ msgid ""
 "One or more components have been found with missing symbol files!\n"
 "\n"
 "This probably happened because lepton-attrib couldn't find your component "
-"libraries, perhaps because your gafrc or gattribrc files are misconfigured.\n"
+"libraries, perhaps because your gafrc files are misconfigured.\n"
 "\n"
 "Choose \"Quit\" to leave lepton-attrib and fix the problem, or\n"
 "\"Forward\" to continue working with lepton-attrib.\n"

--- a/attrib/po/sr.po
+++ b/attrib/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-10-03 23:30+0300\n"
+"POT-Creation-Date: 2020-03-07 14:33+0300\n"
 "PO-Revision-Date: 2012-01-27 14:17+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: Serbian <sr@li.org>\n"
@@ -27,7 +27,7 @@ msgid "Manipulate component attributes with lepton-attrib"
 msgstr "Управљајте особинама компоненти гособинком"
 
 #, c-format
-msgid "o_save: Could not open [%1$s]"
+msgid "Could not open [%1$s]"
 msgstr ""
 
 #, c-format
@@ -46,13 +46,15 @@ msgstr ""
 
 #, c-format
 msgid ""
+"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
 "\n"
 "lepton-attrib: Lepton EDA attribute editor.\n"
 "Presents schematic attributes in easy-to-edit spreadsheet format.\n"
 "\n"
-"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
+"Options:\n"
 "  -q, --quiet            Quiet mode\n"
 "  -v, --verbose          Verbose mode on\n"
+"  -V, --version          Show version information\n"
 "  -h, --help             This help menu\n"
 "\n"
 "  FAQ:\n"
@@ -74,11 +76,22 @@ msgid ""
 "Copyright (C) 2007-2016 gEDA Contributors.\n"
 "Copyright (C) 2017-2019 Lepton EDA Contributors.\n"
 "\n"
-"Please report bugs to %2$s.\n"
+"Report bugs at <%2$s>\n"
+"Lepton EDA homepage: <%3$s>\n"
 msgstr ""
 
 #, c-format
-msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
+msgid ""
+"\n"
+"Run `lepton-attrib --help' for more information.\n"
+msgstr ""
+
+#, c-format
+msgid "WARNING: "
+msgstr ""
+
+#, c-format
+msgid "Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 
 #, c-format
@@ -92,114 +105,78 @@ msgid " DONE\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Failed to find the attrib %1$s on the component.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Trying to add attrib to non-component or non-net!\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
-"or non-net!\n"
+msgid "Start master component list creation.\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Start master component attrib list creation.\n"
+msgstr "Управљајте особинама компоненти гособинком"
+
+#, c-format
+msgid "Start master pin list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master comp list creation.\n"
+msgid "Found component pin with no pinnumber: refdes = %1$s\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master comp attrib list creation.\n"
+msgid "Start master pin attrib list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master pin list creation.\n"
+msgid "Tried to add to a NULL list.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_sheet_data_add_master_pin_list_items, found component pin with no "
-"pinnumber.\n"
+msgid "Tried to remove item from empty list.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master pin attrib list creation.\n"
+msgid "Couldn't delete item %1$s\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
+msgid "We didn't find the row name in the row list!\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
+msgid "Start internal component TABLE creation\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_delete_item, couldn't delete item %s\n"
+msgid "We didn't find either row or col in the lists!\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
-msgstr ""
-
-#, c-format
-msgid "- Starting internal component TABLE creation\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
-"or col in the lists!\n"
-msgstr ""
-
-#, c-format
-msgid "- Starting internal pin TABLE creation\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
-"col in the lists!\n"
+msgid "Start internal pin TABLE creation\n"
 msgstr ""
 
 msgid "_cancel"
 msgstr ""
 
 #, c-format
-msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
+msgid "Can't get attrib name\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
-"the master list!\n"
+msgid "We didn't find the refdes in the master list.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
+msgid "Either refdes or pinnumber of object missing.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
-"missing!\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
-"master list!\n"
-msgstr ""
-
-#, c-format
-msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
+msgid "We didn't find the refdes:pin in the master list.\n"
 msgstr ""
 
 msgid "Add new attribute"
@@ -218,7 +195,7 @@ msgid ""
 "One or more components have been found with missing symbol files!\n"
 "\n"
 "This probably happened because lepton-attrib couldn't find your component "
-"libraries, perhaps because your gafrc or gattribrc files are misconfigured.\n"
+"libraries, perhaps because your gafrc files are misconfigured.\n"
 "\n"
 "Choose \"Quit\" to leave lepton-attrib and fix the problem, or\n"
 "\"Forward\" to continue working with lepton-attrib.\n"

--- a/attrib/po/sv.po
+++ b/attrib/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-10-03 23:30+0300\n"
+"POT-Creation-Date: 2020-03-07 14:33+0300\n"
 "PO-Revision-Date: 2012-01-27 14:17+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: Swedish <sv@li.org>\n"
@@ -27,7 +27,7 @@ msgid "Manipulate component attributes with lepton-attrib"
 msgstr "Manipulera komponentattribut med gattrib"
 
 #, c-format
-msgid "o_save: Could not open [%1$s]"
+msgid "Could not open [%1$s]"
 msgstr ""
 
 #, c-format
@@ -46,13 +46,15 @@ msgstr ""
 
 #, c-format
 msgid ""
+"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
 "\n"
 "lepton-attrib: Lepton EDA attribute editor.\n"
 "Presents schematic attributes in easy-to-edit spreadsheet format.\n"
 "\n"
-"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
+"Options:\n"
 "  -q, --quiet            Quiet mode\n"
 "  -v, --verbose          Verbose mode on\n"
+"  -V, --version          Show version information\n"
 "  -h, --help             This help menu\n"
 "\n"
 "  FAQ:\n"
@@ -74,11 +76,22 @@ msgid ""
 "Copyright (C) 2007-2016 gEDA Contributors.\n"
 "Copyright (C) 2017-2019 Lepton EDA Contributors.\n"
 "\n"
-"Please report bugs to %2$s.\n"
+"Report bugs at <%2$s>\n"
+"Lepton EDA homepage: <%3$s>\n"
 msgstr ""
 
 #, c-format
-msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
+msgid ""
+"\n"
+"Run `lepton-attrib --help' for more information.\n"
+msgstr ""
+
+#, c-format
+msgid "WARNING: "
+msgstr ""
+
+#, c-format
+msgid "Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 
 #, c-format
@@ -92,114 +105,78 @@ msgid " DONE\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Failed to find the attrib %1$s on the component.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Trying to add attrib to non-component or non-net!\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
-"or non-net!\n"
+msgid "Start master component list creation.\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Start master component attrib list creation.\n"
+msgstr "Manipulera komponentattribut med gattrib"
+
+#, c-format
+msgid "Start master pin list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master comp list creation.\n"
+msgid "Found component pin with no pinnumber: refdes = %1$s\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master comp attrib list creation.\n"
+msgid "Start master pin attrib list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master pin list creation.\n"
+msgid "Tried to add to a NULL list.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_sheet_data_add_master_pin_list_items, found component pin with no "
-"pinnumber.\n"
+msgid "Tried to remove item from empty list.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master pin attrib list creation.\n"
+msgid "Couldn't delete item %1$s\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
+msgid "We didn't find the row name in the row list!\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
+msgid "Start internal component TABLE creation\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_delete_item, couldn't delete item %s\n"
+msgid "We didn't find either row or col in the lists!\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
-msgstr ""
-
-#, c-format
-msgid "- Starting internal component TABLE creation\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
-"or col in the lists!\n"
-msgstr ""
-
-#, c-format
-msgid "- Starting internal pin TABLE creation\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
-"col in the lists!\n"
+msgid "Start internal pin TABLE creation\n"
 msgstr ""
 
 msgid "_cancel"
 msgstr ""
 
 #, c-format
-msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
+msgid "Can't get attrib name\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
-"the master list!\n"
+msgid "We didn't find the refdes in the master list.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
+msgid "Either refdes or pinnumber of object missing.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
-"missing!\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
-"master list!\n"
-msgstr ""
-
-#, c-format
-msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
+msgid "We didn't find the refdes:pin in the master list.\n"
 msgstr ""
 
 msgid "Add new attribute"
@@ -218,7 +195,7 @@ msgid ""
 "One or more components have been found with missing symbol files!\n"
 "\n"
 "This probably happened because lepton-attrib couldn't find your component "
-"libraries, perhaps because your gafrc or gattribrc files are misconfigured.\n"
+"libraries, perhaps because your gafrc files are misconfigured.\n"
 "\n"
 "Choose \"Quit\" to leave lepton-attrib and fix the problem, or\n"
 "\"Forward\" to continue working with lepton-attrib.\n"

--- a/attrib/po/tr.po
+++ b/attrib/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-10-03 23:30+0300\n"
+"POT-Creation-Date: 2020-03-07 14:33+0300\n"
 "PO-Revision-Date: 2010-02-06 22:09+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -27,7 +27,7 @@ msgid "Manipulate component attributes with lepton-attrib"
 msgstr "Bileşen özelliklerini gattrib ile düzenle"
 
 #, c-format
-msgid "o_save: Could not open [%1$s]"
+msgid "Could not open [%1$s]"
 msgstr ""
 
 #, c-format
@@ -46,13 +46,15 @@ msgstr ""
 
 #, c-format
 msgid ""
+"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
 "\n"
 "lepton-attrib: Lepton EDA attribute editor.\n"
 "Presents schematic attributes in easy-to-edit spreadsheet format.\n"
 "\n"
-"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
+"Options:\n"
 "  -q, --quiet            Quiet mode\n"
 "  -v, --verbose          Verbose mode on\n"
+"  -V, --version          Show version information\n"
 "  -h, --help             This help menu\n"
 "\n"
 "  FAQ:\n"
@@ -74,11 +76,22 @@ msgid ""
 "Copyright (C) 2007-2016 gEDA Contributors.\n"
 "Copyright (C) 2017-2019 Lepton EDA Contributors.\n"
 "\n"
-"Please report bugs to %2$s.\n"
+"Report bugs at <%2$s>\n"
+"Lepton EDA homepage: <%3$s>\n"
 msgstr ""
 
 #, c-format
-msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
+msgid ""
+"\n"
+"Run `lepton-attrib --help' for more information.\n"
+msgstr ""
+
+#, c-format
+msgid "WARNING: "
+msgstr ""
+
+#, c-format
+msgid "Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 
 #, c-format
@@ -92,114 +105,78 @@ msgid " DONE\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Failed to find the attrib %1$s on the component.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Trying to add attrib to non-component or non-net!\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
-"or non-net!\n"
+msgid "Start master component list creation.\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Start master component attrib list creation.\n"
+msgstr "Bileşen özelliklerini gattrib ile düzenle"
+
+#, c-format
+msgid "Start master pin list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master comp list creation.\n"
+msgid "Found component pin with no pinnumber: refdes = %1$s\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master comp attrib list creation.\n"
+msgid "Start master pin attrib list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master pin list creation.\n"
+msgid "Tried to add to a NULL list.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_sheet_data_add_master_pin_list_items, found component pin with no "
-"pinnumber.\n"
+msgid "Tried to remove item from empty list.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master pin attrib list creation.\n"
+msgid "Couldn't delete item %1$s\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
+msgid "We didn't find the row name in the row list!\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
+msgid "Start internal component TABLE creation\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_delete_item, couldn't delete item %s\n"
+msgid "We didn't find either row or col in the lists!\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
-msgstr ""
-
-#, c-format
-msgid "- Starting internal component TABLE creation\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
-"or col in the lists!\n"
-msgstr ""
-
-#, c-format
-msgid "- Starting internal pin TABLE creation\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
-"col in the lists!\n"
+msgid "Start internal pin TABLE creation\n"
 msgstr ""
 
 msgid "_cancel"
 msgstr ""
 
 #, c-format
-msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
+msgid "Can't get attrib name\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
-"the master list!\n"
+msgid "We didn't find the refdes in the master list.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
+msgid "Either refdes or pinnumber of object missing.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
-"missing!\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
-"master list!\n"
-msgstr ""
-
-#, c-format
-msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
+msgid "We didn't find the refdes:pin in the master list.\n"
 msgstr ""
 
 msgid "Add new attribute"
@@ -218,7 +195,7 @@ msgid ""
 "One or more components have been found with missing symbol files!\n"
 "\n"
 "This probably happened because lepton-attrib couldn't find your component "
-"libraries, perhaps because your gafrc or gattribrc files are misconfigured.\n"
+"libraries, perhaps because your gafrc files are misconfigured.\n"
 "\n"
 "Choose \"Quit\" to leave lepton-attrib and fix the problem, or\n"
 "\"Forward\" to continue working with lepton-attrib.\n"

--- a/attrib/po/uk.po
+++ b/attrib/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-10-03 23:30+0300\n"
+"POT-Creation-Date: 2020-03-07 14:33+0300\n"
 "PO-Revision-Date: 2012-01-27 14:17+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: Ukrainian <uk@li.org>\n"
@@ -27,7 +27,7 @@ msgid "Manipulate component attributes with lepton-attrib"
 msgstr "Керувати властивостями компонентів за допомогою gattrib"
 
 #, c-format
-msgid "o_save: Could not open [%1$s]"
+msgid "Could not open [%1$s]"
 msgstr ""
 
 #, c-format
@@ -46,13 +46,15 @@ msgstr ""
 
 #, c-format
 msgid ""
+"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
 "\n"
 "lepton-attrib: Lepton EDA attribute editor.\n"
 "Presents schematic attributes in easy-to-edit spreadsheet format.\n"
 "\n"
-"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
+"Options:\n"
 "  -q, --quiet            Quiet mode\n"
 "  -v, --verbose          Verbose mode on\n"
+"  -V, --version          Show version information\n"
 "  -h, --help             This help menu\n"
 "\n"
 "  FAQ:\n"
@@ -74,11 +76,22 @@ msgid ""
 "Copyright (C) 2007-2016 gEDA Contributors.\n"
 "Copyright (C) 2017-2019 Lepton EDA Contributors.\n"
 "\n"
-"Please report bugs to %2$s.\n"
+"Report bugs at <%2$s>\n"
+"Lepton EDA homepage: <%3$s>\n"
 msgstr ""
 
 #, c-format
-msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
+msgid ""
+"\n"
+"Run `lepton-attrib --help' for more information.\n"
+msgstr ""
+
+#, c-format
+msgid "WARNING: "
+msgstr ""
+
+#, c-format
+msgid "Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 
 #, c-format
@@ -92,114 +105,78 @@ msgid " DONE\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Failed to find the attrib %1$s on the component.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Trying to add attrib to non-component or non-net!\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
-"or non-net!\n"
+msgid "Start master component list creation.\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Start master component attrib list creation.\n"
+msgstr "Керувати властивостями компонентів за допомогою gattrib"
+
+#, c-format
+msgid "Start master pin list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master comp list creation.\n"
+msgid "Found component pin with no pinnumber: refdes = %1$s\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master comp attrib list creation.\n"
+msgid "Start master pin attrib list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master pin list creation.\n"
+msgid "Tried to add to a NULL list.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_sheet_data_add_master_pin_list_items, found component pin with no "
-"pinnumber.\n"
+msgid "Tried to remove item from empty list.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master pin attrib list creation.\n"
+msgid "Couldn't delete item %1$s\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
+msgid "We didn't find the row name in the row list!\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
+msgid "Start internal component TABLE creation\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_delete_item, couldn't delete item %s\n"
+msgid "We didn't find either row or col in the lists!\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
-msgstr ""
-
-#, c-format
-msgid "- Starting internal component TABLE creation\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
-"or col in the lists!\n"
-msgstr ""
-
-#, c-format
-msgid "- Starting internal pin TABLE creation\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
-"col in the lists!\n"
+msgid "Start internal pin TABLE creation\n"
 msgstr ""
 
 msgid "_cancel"
 msgstr ""
 
 #, c-format
-msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
+msgid "Can't get attrib name\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
-"the master list!\n"
+msgid "We didn't find the refdes in the master list.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
+msgid "Either refdes or pinnumber of object missing.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
-"missing!\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
-"master list!\n"
-msgstr ""
-
-#, c-format
-msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
+msgid "We didn't find the refdes:pin in the master list.\n"
 msgstr ""
 
 msgid "Add new attribute"
@@ -218,7 +195,7 @@ msgid ""
 "One or more components have been found with missing symbol files!\n"
 "\n"
 "This probably happened because lepton-attrib couldn't find your component "
-"libraries, perhaps because your gafrc or gattribrc files are misconfigured.\n"
+"libraries, perhaps because your gafrc files are misconfigured.\n"
 "\n"
 "Choose \"Quit\" to leave lepton-attrib and fix the problem, or\n"
 "\"Forward\" to continue working with lepton-attrib.\n"

--- a/attrib/po/zh_CN.po
+++ b/attrib/po/zh_CN.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-10-03 23:30+0300\n"
+"POT-Creation-Date: 2020-03-07 14:33+0300\n"
 "PO-Revision-Date: 2010-02-06 22:10+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -27,7 +27,7 @@ msgid "Manipulate component attributes with lepton-attrib"
 msgstr "使用 gattrib 操作组件的属性"
 
 #, c-format
-msgid "o_save: Could not open [%1$s]"
+msgid "Could not open [%1$s]"
 msgstr ""
 
 #, c-format
@@ -46,13 +46,15 @@ msgstr ""
 
 #, c-format
 msgid ""
+"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
 "\n"
 "lepton-attrib: Lepton EDA attribute editor.\n"
 "Presents schematic attributes in easy-to-edit spreadsheet format.\n"
 "\n"
-"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
+"Options:\n"
 "  -q, --quiet            Quiet mode\n"
 "  -v, --verbose          Verbose mode on\n"
+"  -V, --version          Show version information\n"
 "  -h, --help             This help menu\n"
 "\n"
 "  FAQ:\n"
@@ -74,11 +76,22 @@ msgid ""
 "Copyright (C) 2007-2016 gEDA Contributors.\n"
 "Copyright (C) 2017-2019 Lepton EDA Contributors.\n"
 "\n"
-"Please report bugs to %2$s.\n"
+"Report bugs at <%2$s>\n"
+"Lepton EDA homepage: <%3$s>\n"
 msgstr ""
 
 #, c-format
-msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
+msgid ""
+"\n"
+"Run `lepton-attrib --help' for more information.\n"
+msgstr ""
+
+#, c-format
+msgid "WARNING: "
+msgstr ""
+
+#, c-format
+msgid "Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 
 #, c-format
@@ -92,114 +105,78 @@ msgid " DONE\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Failed to find the attrib %1$s on the component.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Trying to add attrib to non-component or non-net!\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
-"or non-net!\n"
+msgid "Start master component list creation.\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Start master component attrib list creation.\n"
+msgstr "使用 gattrib 操作组件的属性"
+
+#, c-format
+msgid "Start master pin list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master comp list creation.\n"
+msgid "Found component pin with no pinnumber: refdes = %1$s\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master comp attrib list creation.\n"
+msgid "Start master pin attrib list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master pin list creation.\n"
+msgid "Tried to add to a NULL list.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_sheet_data_add_master_pin_list_items, found component pin with no "
-"pinnumber.\n"
+msgid "Tried to remove item from empty list.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master pin attrib list creation.\n"
+msgid "Couldn't delete item %1$s\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
+msgid "We didn't find the row name in the row list!\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
+msgid "Start internal component TABLE creation\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_delete_item, couldn't delete item %s\n"
+msgid "We didn't find either row or col in the lists!\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
-msgstr ""
-
-#, c-format
-msgid "- Starting internal component TABLE creation\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
-"or col in the lists!\n"
-msgstr ""
-
-#, c-format
-msgid "- Starting internal pin TABLE creation\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
-"col in the lists!\n"
+msgid "Start internal pin TABLE creation\n"
 msgstr ""
 
 msgid "_cancel"
 msgstr ""
 
 #, c-format
-msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
+msgid "Can't get attrib name\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
-"the master list!\n"
+msgid "We didn't find the refdes in the master list.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
+msgid "Either refdes or pinnumber of object missing.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
-"missing!\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
-"master list!\n"
-msgstr ""
-
-#, c-format
-msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
+msgid "We didn't find the refdes:pin in the master list.\n"
 msgstr ""
 
 msgid "Add new attribute"
@@ -218,7 +195,7 @@ msgid ""
 "One or more components have been found with missing symbol files!\n"
 "\n"
 "This probably happened because lepton-attrib couldn't find your component "
-"libraries, perhaps because your gafrc or gattribrc files are misconfigured.\n"
+"libraries, perhaps because your gafrc files are misconfigured.\n"
 "\n"
 "Choose \"Quit\" to leave lepton-attrib and fix the problem, or\n"
 "\"Forward\" to continue working with lepton-attrib.\n"

--- a/attrib/po/zh_TW.po
+++ b/attrib/po/zh_TW.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-10-03 23:30+0300\n"
+"POT-Creation-Date: 2020-03-07 14:33+0300\n"
 "PO-Revision-Date: 2010-02-06 22:10+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -27,7 +27,7 @@ msgid "Manipulate component attributes with lepton-attrib"
 msgstr "使用gattrib修改元件屬性"
 
 #, c-format
-msgid "o_save: Could not open [%1$s]"
+msgid "Could not open [%1$s]"
 msgstr ""
 
 #, c-format
@@ -46,13 +46,15 @@ msgstr ""
 
 #, c-format
 msgid ""
+"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
 "\n"
 "lepton-attrib: Lepton EDA attribute editor.\n"
 "Presents schematic attributes in easy-to-edit spreadsheet format.\n"
 "\n"
-"Usage: %1$s [OPTIONS] filename1 ... filenameN\n"
+"Options:\n"
 "  -q, --quiet            Quiet mode\n"
 "  -v, --verbose          Verbose mode on\n"
+"  -V, --version          Show version information\n"
 "  -h, --help             This help menu\n"
 "\n"
 "  FAQ:\n"
@@ -74,11 +76,22 @@ msgid ""
 "Copyright (C) 2007-2016 gEDA Contributors.\n"
 "Copyright (C) 2017-2019 Lepton EDA Contributors.\n"
 "\n"
-"Please report bugs to %2$s.\n"
+"Report bugs at <%2$s>\n"
+"Lepton EDA homepage: <%3$s>\n"
 msgstr ""
 
 #, c-format
-msgid "WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"
+msgid ""
+"\n"
+"Run `lepton-attrib --help' for more information.\n"
+msgstr ""
+
+#, c-format
+msgid "WARNING: "
+msgstr ""
+
+#, c-format
+msgid "Found uref=%1$s, uref= is deprecated, please use refdes=\n"
 msgstr ""
 
 #, c-format
@@ -92,114 +105,78 @@ msgid " DONE\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Failed to find the attrib %1$s on the component.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s "
-"on the component.  Exiting . . .\n"
+msgid "Trying to add attrib to non-component or non-net!\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_object_attrib_add_attrib_in_object, trying to add attrib to non-complex "
-"or non-net!\n"
+msgid "Start master component list creation.\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Start master component attrib list creation.\n"
+msgstr "使用gattrib修改元件屬性"
+
+#, c-format
+msgid "Start master pin list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master comp list creation.\n"
+msgid "Found component pin with no pinnumber: refdes = %1$s\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master comp attrib list creation.\n"
+msgid "Start master pin attrib list creation.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master pin list creation.\n"
+msgid "Tried to add to a NULL list.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_sheet_data_add_master_pin_list_items, found component pin with no "
-"pinnumber.\n"
+msgid "Tried to remove item from empty list.\n"
 msgstr ""
 
 #, c-format
-msgid "- Starting master pin attrib list creation.\n"
+msgid "Couldn't delete item %1$s\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_add_item, tried to add to a NULL list.\n"
+msgid "We didn't find the row name in the row list!\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_delete_item, tried to remove item from empty list\n"
+msgid "Start internal component TABLE creation\n"
 msgstr ""
 
 #, c-format
-msgid "In s_string_list_delete_item, couldn't delete item %s\n"
+msgid "We didn't find either row or col in the lists!\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"
-msgstr ""
-
-#, c-format
-msgid "- Starting internal component TABLE creation\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row "
-"or col in the lists!\n"
-msgstr ""
-
-#, c-format
-msgid "- Starting internal pin TABLE creation\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or "
-"col in the lists!\n"
+msgid "Start internal pin TABLE creation\n"
 msgstr ""
 
 msgid "_cancel"
 msgstr ""
 
 #, c-format
-msgid "In s_toplevel_delete_attrib_col, can't get attrib name\n"
+msgid "Can't get attrib name\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in "
-"the master list!\n"
+msgid "We didn't find the refdes in the master list.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"
+msgid "Either refdes or pinnumber of object missing.\n"
 msgstr ""
 
 #, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object "
-"missing!\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the "
-"master list!\n"
-msgstr ""
-
-#, c-format
-msgid "In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"
+msgid "We didn't find the refdes:pin in the master list.\n"
 msgstr ""
 
 msgid "Add new attribute"
@@ -218,7 +195,7 @@ msgid ""
 "One or more components have been found with missing symbol files!\n"
 "\n"
 "This probably happened because lepton-attrib couldn't find your component "
-"libraries, perhaps because your gafrc or gattribrc files are misconfigured.\n"
+"libraries, perhaps because your gafrc files are misconfigured.\n"
 "\n"
 "Choose \"Quit\" to leave lepton-attrib and fix the problem, or\n"
 "\"Forward\" to continue working with lepton-attrib.\n"

--- a/attrib/src/f_export.c
+++ b/attrib/src/f_export.c
@@ -75,7 +75,8 @@ void f_export_components(gchar *filename)
   /* -----  First try to open file for writing ----- */
 
 #ifdef DEBUG
-  printf("In f_export_components, trying to open %s.\n", filename);
+  printf ("f_export_components: ");
+  printf ("Trying to open %s.\n", filename);
 #endif
   fp = fopen(filename, "wb");
   if (fp == NULL) {
@@ -113,8 +114,9 @@ void f_export_components(gchar *filename)
     text = g_strdup( s_string_list_get_data_at_index(
 		       sheet_head->master_comp_list_head, i) );
 #ifdef DEBUG
-  printf("In f_export_components, getting refes, i = %d.\n", i);
-  printf("In f_export_components, output component refdes %s.\n", text);
+    printf ("f_export_components: ");
+    printf ("Getting refdes: row number = %d, output component refdes = %s.\n",
+            i, text);
 #endif
     fprintf(fp, "%s, ",text);
     g_free(text);
@@ -125,7 +127,8 @@ void f_export_components(gchar *filename)
         /* make a copy of the text, escaping any special chars, like " */
         text = (gchar *) g_strescape( (sheet_head->component_table)[i][j].attrib_value, "" );
 #ifdef DEBUG
-  printf("In f_export_components, output attribute %s.\n", text);
+        printf ("f_export_components: ");
+        printf ("Output attribute %s.\n", text);
 #endif
         /* if there's a comma anywhere in the field, wrap the field in " */
         gboolean havecomma = ( g_strstr_len(text, -1, ",") != NULL );
@@ -137,7 +140,8 @@ void f_export_components(gchar *filename)
 	g_free(text);
       } else {                                                  /* no attrib string */
 #ifdef DEBUG
-  printf("In f_export_components, output blank attrib space\n");
+        printf ("f_export_components: ");
+        printf ("Output blank attrib space.\n");
 #endif
 	fprintf(fp, ", ");
       }
@@ -147,7 +151,8 @@ void f_export_components(gchar *filename)
       /* make a copy of the text, escaping any special chars, like " */
       text = (gchar *) g_strescape( (sheet_head->component_table)[i][j].attrib_value, "" );
 #ifdef DEBUG
-  printf("In f_export_components, output final attribute %s.\n", text);
+      printf ("f_export_components: ");
+      printf ("Output final attribute %s.\n", text);
 #endif
       /* if there's a comma anywhere in the field, wrap the field in " */
       gboolean havecomma = ( g_strstr_len(text, -1, ",") != NULL );
@@ -159,12 +164,14 @@ void f_export_components(gchar *filename)
       g_free(text);
     } else {                                                  /* no attrib string */
 #ifdef DEBUG
-  printf("In f_export_components, output blank at end of line.\n");
+      printf ("f_export_components: ");
+      printf ("Output blank at end of line.\n");
 #endif
       fprintf(fp, "\n");
     }
 #ifdef DEBUG
-  printf("In f_export_components, Go to next row.\n");
+    printf ("f_export_components: ");
+    printf ("Go to next row.\n");
 #endif
   }  /* close of for over rows */
 

--- a/attrib/src/f_export.c
+++ b/attrib/src/f_export.c
@@ -1,6 +1,7 @@
-/* gEDA - GPL Electronic Design Automation
- * gattrib -- gEDA component and net attribute manipulation using spreadsheet.
+/* Lepton EDA attribute editor
  * Copyright (C) 2003-2010 Stuart D. Brorson.
+ * Copyright (C) 2003-2013 gEDA Contributors
+ * Copyright (C) 2017-2020 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/attrib/src/f_export.c
+++ b/attrib/src/f_export.c
@@ -79,7 +79,7 @@ void f_export_components(gchar *filename)
 #endif
   fp = fopen(filename, "wb");
   if (fp == NULL) {
-    s_log_message(_("o_save: Could not open [%1$s]"), filename);
+    s_log_message(_("Could not open [%1$s]"), filename);
     /* XXXXX Throw up error message  in window */
     return;
   }

--- a/attrib/src/gtksheet_2_2.c
+++ b/attrib/src/gtksheet_2_2.c
@@ -4874,10 +4874,6 @@ gtk_sheet_expose (GtkWidget * widget,
 
   (* GTK_WIDGET_CLASS (gtk_sheet_parent_class)->expose_event) (widget, event);
 
-#ifdef DEBUG
-  printf ("==== Leave gtk_sheet_expose()\n");
-#endif 
-
   return FALSE;
 }
 

--- a/attrib/src/gtksheet_2_2.c
+++ b/attrib/src/gtksheet_2_2.c
@@ -4814,7 +4814,8 @@ gtk_sheet_expose (GtkWidget * widget,
   GtkSheetRange range;
 
 #ifdef DEBUG
-  printf("---> Entered gtk_sheet_expose ... must have received expose_event\n");
+  printf ("==== Enter gtk_sheet_expose()\n");
+  printf ("Must have received expose_event\n");
 #endif 
 
   g_return_val_if_fail (widget != NULL, FALSE);
@@ -4874,7 +4875,7 @@ gtk_sheet_expose (GtkWidget * widget,
   (* GTK_WIDGET_CLASS (gtk_sheet_parent_class)->expose_event) (widget, event);
 
 #ifdef DEBUG
-  printf("<--- Leaving gtk_sheet_expose\n");
+  printf ("==== Leave gtk_sheet_expose()\n");
 #endif 
 
   return FALSE;
@@ -5633,7 +5634,7 @@ gtk_sheet_key_press(GtkWidget *widget,
   sheet = GTK_SHEET(widget);
 
 #ifdef DEBUG
-    printf("\n\nJust entered gtk_sheet_key_press. . . . \n");
+  printf ("==== Enter gtk_sheet_key_press()\n");
 #endif
 
 

--- a/attrib/src/gtksheet_2_2.c
+++ b/attrib/src/gtksheet_2_2.c
@@ -2,7 +2,7 @@
  * GtkSheet widget for Gtk+.
  * Copyright (C) 1999-2001 Adrian E. Feiguin <adrian@ifir.ifir.edu.ar>
  * Copyright (C) 2004-2015 gEDA Contributors
- * Copyright (C) 2017-2018 Lepton EDA Contributors
+ * Copyright (C) 2017-2020 Lepton EDA Contributors
  *
  * Based on GtkClist widget by Jay Painter, but major changes.
  * Memory allocation routines inspired on SC (Spreadsheet Calculator)

--- a/attrib/src/gtksheet_2_2.c
+++ b/attrib/src/gtksheet_2_2.c
@@ -5652,7 +5652,7 @@ gtk_sheet_key_press(GtkWidget *widget,
 || key->keyval==GDK_Shift_R;
 
 #ifdef DEBUG
-    printf(". . . .  extend_selection = %d\n", extend_selection);
+  printf ("extend_selection = %d\n", extend_selection);
 #endif
 
   state=sheet->state;
@@ -5660,7 +5660,7 @@ gtk_sheet_key_press(GtkWidget *widget,
   GTK_SHEET_UNSET_FLAGS(sheet, GTK_SHEET_IN_SELECTION);
 
 #ifdef DEBUG
-    printf("We are about to enter the switch statement. . .\n");
+  printf ("Enter the switch statement.\n");
 #endif
 
   switch(key->keyval){
@@ -5687,7 +5687,8 @@ gtk_sheet_key_press(GtkWidget *widget,
     case GDK_ISO_Left_Tab:
     case GDK_Left:   /* Left arrow  */
 #ifdef DEBUG
-      printf("In gtk_sheet_key_press, received GDK_Left.\n");
+      printf ("gtk_sheet_key_press: ");
+      printf ("Received GDK_Left.\n");
 #endif
       row = sheet->active_cell.row;
       col = sheet->active_cell.col;
@@ -5707,7 +5708,8 @@ gtk_sheet_key_press(GtkWidget *widget,
     case GDK_Tab:
     case GDK_Right: /* Right arrow  */
 #ifdef DEBUG
-      printf("In gtk_sheet_key_press, received GDK_Right.\n");
+      printf ("gtk_sheet_key_press: ");
+      printf ("Received GDK_Right.\n");
 #endif
       row = sheet->active_cell.row;
       col = sheet->active_cell.col;
@@ -5887,8 +5889,9 @@ gtk_sheet_key_press(GtkWidget *widget,
 
     default:
 #ifdef DEBUG
-      printf("In gtk_sheet_key_press, after switch, found default case.\n");
-      printf("  User probably typed letter key or DEL.\n");
+      printf ("gtk_sheet_key_press: ");
+      printf ("After switch, found default case.\n");
+      printf ("  User probably typed letter key or DEL.\n");
 #endif
       if(in_selection) {
 	GTK_SHEET_SET_FLAGS(sheet, GTK_SHEET_IN_SELECTION);

--- a/attrib/src/lepton-attrib.c
+++ b/attrib/src/lepton-attrib.c
@@ -121,7 +121,8 @@ gint gattrib_quit(gint return_code)
 #ifdef DEBUG
   fflush(stderr);
   fflush(stdout);
-  printf("In gattrib_quit, calling gtk_main_quit()\n");
+  printf ("gattrib_quit: ");
+  printf ("Calling gtk_main_quit().\n");
 #endif
   gtk_main_quit();
   exit(return_code);

--- a/attrib/src/s_attrib.c
+++ b/attrib/src/s_attrib.c
@@ -102,15 +102,17 @@ char *s_attrib_get_refdes(OBJECT *object)
       printf(_("WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"), temp_uref);
     } else {        /* didn't find refdes.  Report error to log. */
 #ifdef DEBUG
-      printf("In s_attrib_get_refdes, found non-graphical component with no refdes.\n");
-      printf(". . . . component_basename = %s.\n", object->component_basename);
+      printf ("s_attrib_get_refdes: ");
+      printf ("Found non-graphical component with no refdes: component_basename = %s\n",
+              object->component_basename);
 #endif
       return NULL;
     } 
   }
 
 #ifdef DEBUG
-  printf("In s_attrib_get_refdes, found component with refdes %s.\n", temp_uref);
+  printf ("s_attrib_get_refdes: ");
+  printf ("Found component with refdes %s.\n", temp_uref);
 #endif   
   
   /*------- Now append .slot to refdes if part is slotted -------- */
@@ -121,13 +123,13 @@ char *s_attrib_get_refdes(OBJECT *object)
 				    append slot number to refdes. */
     slot_value = s_slot_search_slot (object, &slot_text_object);
 #if DEBUG
-    printf(". . .  , found slotted component with slot = %s\n", slot_value);
+    printf ("  Found slotted component with slot = %s\n", slot_value);
 #endif
     temp_uref = g_strconcat(temp_uref, ".", slot_value, NULL);
   }
 
 #ifdef DEBUG
-  printf(". . . .   returning refdes %s.\n", temp_uref);
+  printf ("  Return refdes %s.\n", temp_uref);
 #endif   
   
   return temp_uref;

--- a/attrib/src/s_attrib.c
+++ b/attrib/src/s_attrib.c
@@ -99,7 +99,10 @@ char *s_attrib_get_refdes(OBJECT *object)
   if (!temp_uref) {
     temp_uref = o_attrib_search_object_attribs_by_name (object, "uref", 0); // deprecated
     if (temp_uref) {
-      printf(_("WARNING: Found uref=%1$s, uref= is deprecated, please use refdes=\n"), temp_uref);
+      fprintf (stderr, _("WARNING: "));
+      fprintf (stderr,
+               _("Found uref=%1$s, uref= is deprecated, please use refdes=\n"),
+               temp_uref);
     } else {        /* didn't find refdes.  Report error to log. */
 #ifdef DEBUG
       printf ("s_attrib_get_refdes: ");

--- a/attrib/src/s_object.c
+++ b/attrib/src/s_object.c
@@ -214,9 +214,10 @@ void s_object_replace_attrib_in_object(TOPLEVEL *toplevel,
 
   /* if we get here, it's because we have failed to find the attrib on the component.
    * This is an error condition. */
-  fprintf(stderr,
-	 _("In s_object_replace_attrib_in_object, we have failed to find the attrib %1$s on the component.  Exiting . . .\n"),
-	 new_attrib_name);
+  fprintf (stderr, "s_object_replace_attrib_in_object: ");
+  fprintf (stderr,
+          _("Failed to find the attrib %1$s on the component.\n"),
+          new_attrib_name);
   exit(-1);
 }
 
@@ -274,9 +275,10 @@ s_object_remove_attrib_in_object (TOPLEVEL *toplevel,
 
   /* if we get here, it's because we have failed to find the attrib on the component.
    * This is an error condition. */
-  fprintf(stderr,
-	 _("In s_object_remove_attrib_in_object, we have failed to find the attrib %1$s on the component.  Exiting . . .\n"),
-	 new_attrib_name);
+  fprintf (stderr, "s_object_remove_attrib_in_object: ");
+  fprintf (stderr,
+           _("Failed to find the attrib %1$s on the component.\n"),
+           new_attrib_name);
   exit(-1);
 }
 
@@ -328,7 +330,8 @@ s_object_attrib_add_attrib_in_object (TOPLEVEL *toplevel,
       break;
 
     default:
-      fprintf (stderr, _("In s_object_attrib_add_attrib_in_object, trying to add attrib to non-component or non-net!\n"));
+      fprintf (stderr, "s_object_attrib_add_attrib_in_object: ");
+      fprintf (stderr, _("Trying to add attrib to non-component or non-net!\n"));
       exit(-1);
     }
   } else {    /* This must be a floating attrib, but what is that !?!?!?!?!  */

--- a/attrib/src/s_object.c
+++ b/attrib/src/s_object.c
@@ -255,7 +255,8 @@ s_object_remove_attrib_in_object (TOPLEVEL *toplevel,
 	/* We've found the attrib.  Delete it and then return. */
 
 #ifdef DEBUG
-	printf("In s_object_remove_attrib_in_object, removing attrib with name = %1$s\n", old_attrib_name);
+	printf ("s_object_remove_attrib_in_object: ");
+	printf ("Removing attrib with name = %1$s\n", old_attrib_name);
 #endif
 
 	attribute_object = a_current;
@@ -345,11 +346,12 @@ s_object_attrib_add_attrib_in_object (TOPLEVEL *toplevel,
 
   /* first create text item */
 #if DEBUG
-  printf("===  In s_object_attrib_add_attrib_in_object, about to attach new text attrib with properties:\n");
-  printf("     color = %d\n", color);
-  printf("     text_string = %s \n", text_string);
-  printf("     visibility = %d \n", visibility);
-  printf("     show_name_value = %d \n", show_name_value);
+  printf ("s_object_attrib_add_attrib_in_object: ");
+  printf ("About to attach new text attrib with properties:\n");
+  printf ("     color = %d\n", color);
+  printf ("     text_string = %s\n", text_string);
+  printf ("     visibility = %d\n", visibility);
+  printf ("     show_name_value = %d\n", show_name_value);
 #endif
 
   new_obj = geda_text_object_new (toplevel,
@@ -417,12 +419,14 @@ int s_object_has_sym_file(OBJECT *object)
   filename = object->component_basename;
   if (filename != NULL) {
 #ifdef DEBUG
-    printf("In s_object_has_sym_file, object has sym file = %s.\n", filename);
+    printf ("s_object_has_sym_file: ");
+    printf ("Object has sym file = %s.\n", filename);
 #endif
     return 0;
   } else {
 #ifdef DEBUG
-    printf("In s_object_has_sym_file, found object with no attached symbol file.\n");
+    printf ("s_object_has_sym_file: ");
+    printf ("Found object with no attached symbol file.\n");
 #endif
     return 1;
   }

--- a/attrib/src/s_sheet_data.c
+++ b/attrib/src/s_sheet_data.c
@@ -338,8 +338,9 @@ void s_sheet_data_add_master_pin_list_items (const GList *obj_list) {
               s_string_list_add_item (sheet_head->master_pin_list_head, &(sheet_head->pin_count), row_label);
 
             } else {      /* didn't find pinnumber.  Report error to log. */
-              fprintf (stderr, _("In s_sheet_data_add_master_pin_list_items, found component pin with no pinnumber.\n"));
-              fprintf (stderr, ". . . . refdes = %s.\n", temp_uref);
+              fprintf (stderr, "s_sheet_data_add_master_pin_list_items: ");
+              fprintf (stderr, _("Found component pin with no pinnumber: refdes = %s\n"),
+                       temp_uref);
             }
             g_free (temp_pinnumber);
 

--- a/attrib/src/s_sheet_data.c
+++ b/attrib/src/s_sheet_data.c
@@ -110,7 +110,7 @@ void s_sheet_data_add_master_comp_list_items (const GList *obj_list) {
   const GList *iter;
   
 #ifdef DEBUG
-  printf("=========== Just entered  s_sheet_data_add_master_comp_list_items!  ==============\n");
+  printf ("==== Enter s_sheet_data_add_master_comp_list_items()\n");
 #endif
 
   if (verbose_mode) {
@@ -178,7 +178,7 @@ void s_sheet_data_add_master_comp_attrib_list_items (const GList *obj_list) {
 #ifdef DEBUG
   fflush(stderr);
   fflush(stdout);
-  printf("=========== Just entered  s_sheet_data_add_master_comp_attrib_list_items!  ==============\n");
+  printf ("==== Enter s_sheet_data_add_master_comp_attrib_list_items()\n");
 #endif
 
   if (verbose_mode) {
@@ -291,7 +291,7 @@ void s_sheet_data_add_master_pin_list_items (const GList *obj_list) {
 #ifdef DEBUG
   fflush(stderr);
   fflush(stdout);
-  printf("=========== Just entered  s_sheet_data_add_master_pin_list_items!  ==============\n");
+  printf ("==== Enter s_sheet_data_add_master_pin_list_items()\n");
 #endif
 
   if (verbose_mode) {
@@ -383,7 +383,7 @@ void s_sheet_data_add_master_pin_attrib_list_items (const GList *obj_list) {
 #ifdef DEBUG
   fflush(stderr);
   fflush(stdout);
-  printf("=========== Just entered  s_sheet_data_add_master_pin_attrib_list_items!  ==============\n");
+  printf ("==== Enter s_sheet_data_add_master_pin_attrib_list_items()\n");
 #endif
 
   if (verbose_mode) {

--- a/attrib/src/s_sheet_data.c
+++ b/attrib/src/s_sheet_data.c
@@ -339,7 +339,7 @@ void s_sheet_data_add_master_pin_list_items (const GList *obj_list) {
 
             } else {      /* didn't find pinnumber.  Report error to log. */
               fprintf (stderr, "s_sheet_data_add_master_pin_list_items: ");
-              fprintf (stderr, _("Found component pin with no pinnumber: refdes = %s\n"),
+              fprintf (stderr, _("Found component pin with no pinnumber: refdes = %1$s\n"),
                        temp_uref);
             }
             g_free (temp_pinnumber);

--- a/attrib/src/s_sheet_data.c
+++ b/attrib/src/s_sheet_data.c
@@ -114,7 +114,7 @@ void s_sheet_data_add_master_comp_list_items (const GList *obj_list) {
 #endif
 
   if (verbose_mode) {
-    printf(_("- Starting master comp list creation.\n"));
+    printf (_("Start master component list creation.\n"));
   }
 
   /* -----  Iterate through all objects found on page looking for components  ----- */
@@ -185,7 +185,7 @@ void s_sheet_data_add_master_comp_attrib_list_items (const GList *obj_list) {
 #endif
 
   if (verbose_mode) {
-    printf(_("- Starting master comp attrib list creation.\n"));
+    printf (_("Start master component attrib list creation.\n"));
   }
 
   /* -----  Iterate through all objects found on page looking for components (OBJ_COMPONENT) ----- */
@@ -301,7 +301,7 @@ void s_sheet_data_add_master_pin_list_items (const GList *obj_list) {
 #endif
 
   if (verbose_mode) {
-    printf(_("- Starting master pin list creation.\n"));
+    printf (_("Start master pin list creation.\n"));
   }
 
   /* -----  Iterate through all objects found on page looking for components  ----- */
@@ -395,7 +395,7 @@ void s_sheet_data_add_master_pin_attrib_list_items (const GList *obj_list) {
 #endif
 
   if (verbose_mode) {
-    printf(_("- Starting master pin attrib list creation.\n"));
+    printf (_("Start master pin attrib list creation.\n"));
   }
 
   /* -----  Iterate through all objects found on page looking for components  ----- */

--- a/attrib/src/s_sheet_data.c
+++ b/attrib/src/s_sheet_data.c
@@ -124,7 +124,8 @@ void s_sheet_data_add_master_comp_list_items (const GList *obj_list) {
     OBJECT *o_current = (OBJECT*) iter->data;
 
 #ifdef DEBUG
-      printf("In s_sheet_data_add_master_comp_list_items, examining o_current->name = %s\n", o_current->name);
+    printf ("s_sheet_data_add_master_comp_list_items: ");
+    printf ("Examining o_current->name = %s\n", o_current->name);
 #endif
 
       /*-----  only process if this is a component with attributes ----*/
@@ -132,8 +133,9 @@ void s_sheet_data_add_master_comp_list_items (const GList *obj_list) {
           o_current->attribs != NULL) {
 
 #if DEBUG
-	printf("      In s_sheet_data_add_master_comp_list_items; found component on page\n");
-	printf(". . . . component_basename = %s.\n", o_current->component_basename);
+        printf ("s_sheet_data_add_master_comp_list_items: ");
+        printf ("Found component on page: component_basename = %s\n",
+                o_current->component_basename);
 #endif
 	verbose_print(" C");
       
@@ -142,7 +144,8 @@ void s_sheet_data_add_master_comp_list_items (const GList *obj_list) {
 	/* Now that we have refdes, store refdes and attach attrib list to component */
 	if (temp_uref) {
 #if DEBUG
-	  printf("       In s_sheet_add_master_comp_list, about to add to master list refdes = %s\n", temp_uref);
+          printf ("s_sheet_data_add_master_comp_list_items: ");
+          printf ("About to add to master list refdes = %s\n", temp_uref);
 #endif
 	  s_string_list_add_item(sheet_head->master_comp_list_head, 
 				  &(sheet_head->comp_count), temp_uref);
@@ -190,7 +193,8 @@ void s_sheet_data_add_master_comp_attrib_list_items (const GList *obj_list) {
     OBJECT *o_current = (OBJECT*) o_iter->data;
 
 #ifdef DEBUG
-      printf("In s_sheet_data_add_master_comp_attrib_list_items, examining o_current->name = %s\n", o_current->name);
+    printf ("s_sheet_data_add_master_comp_attrib_list_items: ");
+    printf ("Examining o_current->name = %s\n", o_current->name);
 #endif
 
       /*-----  only process if this is a component with attributes ----*/
@@ -214,7 +218,9 @@ void s_sheet_data_add_master_comp_attrib_list_items (const GList *obj_list) {
 		 (strcmp(attrib_name, "net") != 0) &&
 		 (strcmp(attrib_name, "slot") != 0) ) {  
 #if DEBUG
-	      printf(" . . . from this component, about to add to master comp attrib list attrib = %s\n", attrib_name);
+              printf ("... from this component, "
+                      "about to add to master comp attrib list attrib=%s\n",
+                      attrib_name);
 #endif
 	      s_string_list_add_item(sheet_head->master_comp_attrib_list_head, 
 				     &(sheet_head->comp_attrib_count), attrib_name);
@@ -303,7 +309,8 @@ void s_sheet_data_add_master_pin_list_items (const GList *obj_list) {
     OBJECT *o_current = (OBJECT*) o_iter->data;
 
 #ifdef DEBUG
-    printf ("In s_sheet_data_add_master_pin_list_items, examining o_current->name = %s\n", o_current->name);
+    printf ("s_sheet_data_add_master_pin_list_items: ");
+    printf ("Examining o_current->name = %s\n", o_current->name);
 #endif
 
     if (o_current->type == OBJ_COMPONENT) {
@@ -316,7 +323,8 @@ void s_sheet_data_add_master_pin_list_items (const GList *obj_list) {
              o_lower_iter = g_list_next (o_lower_iter)) {
           OBJECT *o_lower_current = (OBJECT*) o_lower_iter->data;
 #if DEBUG
-          printf ("In s_sheet_data_add_master_pin_list_items, examining object name %s\n", o_lower_current->name);
+          printf ("s_sheet_data_add_master_pin_list_items: ");
+          printf ("Examining object name %s\n", o_lower_current->name);
 #endif
           if (o_lower_current->type == OBJ_PIN) {
             temp_pinnumber = o_attrib_search_object_attribs_by_name (o_lower_current, "pinnumber", 0);
@@ -324,15 +332,14 @@ void s_sheet_data_add_master_pin_list_items (const GList *obj_list) {
             if (temp_pinnumber != NULL) {
               row_label = g_strconcat (temp_uref, ":", temp_pinnumber, NULL);
 #if DEBUG
-              printf ("In s_sheet_data_add_master_pin_list_items, about to add to master pin list row_label = %s\n", row_label);
+              printf ("s_sheet_data_add_master_pin_list_items: ");
+              printf ("About to add to master pin list row_label = %s\n", row_label);
 #endif
               s_string_list_add_item (sheet_head->master_pin_list_head, &(sheet_head->pin_count), row_label);
 
             } else {      /* didn't find pinnumber.  Report error to log. */
               fprintf (stderr, _("In s_sheet_data_add_master_pin_list_items, found component pin with no pinnumber.\n"));
-#ifdef DEBUG
               fprintf (stderr, ". . . . refdes = %s.\n", temp_uref);
-#endif
             }
             g_free (temp_pinnumber);
 
@@ -341,8 +348,9 @@ void s_sheet_data_add_master_pin_list_items (const GList *obj_list) {
 
       } else {          /* didn't find refdes.  Report error to log. */
 #ifdef DEBUG
-        fprintf (stderr, "In s_sheet_data_add_master_pin_list_items, found component with no refdes.\n");
-        fprintf (stderr, ". . . . component_basename = %s.\n", o_current->component_basename);
+        printf ("s_sheet_data_add_master_pin_list_items: ");
+        printf ("Found component with no refdes: component_basename = %s\n",
+                o_current->component_basename);
 #endif
       }
       g_free (temp_uref);
@@ -395,7 +403,8 @@ void s_sheet_data_add_master_pin_attrib_list_items (const GList *obj_list) {
     OBJECT *o_current = (OBJECT*) o_iter->data;
 
 #ifdef DEBUG
-      printf("In s_sheet_data_add_master_pin_attrib_list_items, examining o_current->name = %s\n", o_current->name);
+      printf ("s_sheet_data_add_master_pin_attrib_list_items: ");
+      printf ("Examining o_current->name = %s\n", o_current->name);
 #endif
 
       if (o_current->type == OBJ_COMPONENT) {
@@ -408,7 +417,8 @@ void s_sheet_data_add_master_pin_attrib_list_items (const GList *obj_list) {
                o_lower_iter = g_list_next (o_lower_iter)) {
             OBJECT *o_lower_current = (OBJECT*) o_lower_iter->data;
 #if DEBUG
-	    printf("In s_sheet_data_add_master_pin_attrib_list_items, examining component refdes =  %s\n", temp_uref);
+            printf ("s_sheet_data_add_master_pin_attrib_list_items: ");
+            printf ("Examining component refdes = %s\n", temp_uref);
 #endif
 	    if (o_lower_current->type == OBJ_PIN) {
 	      /* -----  Found a pin.  Now get attrib head and loop on attribs.  ----- */
@@ -426,8 +436,9 @@ void s_sheet_data_add_master_pin_attrib_list_items (const GList *obj_list) {
 		     * Also guard against pathalogical symbols which have non-attrib text inside pins. */
 
 #if DEBUG
-	    printf("In s_sheet_data_add_master_pin_attrib_list_items, found pin attrib =  %s\n", attrib_name);
-	    printf(". . . . . adding it to master_pin_attrib_list\n");
+                    printf ("s_sheet_data_add_master_pin_attrib_list_items: ");
+                    printf ("Found pin attrib = %s\n", attrib_name);
+                    printf ("Add it to master_pin_attrib_list.\n");
 #endif
 
 		    s_string_list_add_item(sheet_head->master_pin_attrib_list_head, 

--- a/attrib/src/s_string_list.c
+++ b/attrib/src/s_string_list.c
@@ -259,7 +259,7 @@ void s_string_list_delete_item(STRING_LIST **list, int *count, gchar *item) {
    * Spew error and return.
    */
   fprintf (stderr, "s_string_list_delete_item:");
-  fprintf (stderr, _("Couldn't delete item %s\n"), item);
+  fprintf (stderr, _("Couldn't delete item %1$s\n"), item);
   return;
 
 }

--- a/attrib/src/s_string_list.c
+++ b/attrib/src/s_string_list.c
@@ -128,7 +128,8 @@ void s_string_list_add_item(STRING_LIST *list, int *count, char *item) {
      into empty list separately.  (Is this necessary?) */
   if (list->data == NULL) {
 #ifdef DEBUG
-    printf("In s_string_list_add_item, about to place first item in list.\n");
+    printf ("s_string_list_add_item: ");
+    printf ("About to place first item in list.\n");
 #endif
     list->data = (gchar *) g_strdup(item);
     list->next = NULL;
@@ -190,7 +191,8 @@ void s_string_list_delete_item(STRING_LIST **list, int *count, gchar *item) {
   }
 
 #ifdef DEBUG
-    printf("In s_string_list_delete_item, about to delete item %s from list.\n", item);
+    printf ("s_string_list_delete_item: ");
+    printf ("About to delete item %s from list.\n", item);
 #endif
 
   /* Now loop through list looking for item */
@@ -198,12 +200,14 @@ void s_string_list_delete_item(STRING_LIST **list, int *count, gchar *item) {
   while (list_item != NULL) {
     trial_item = (gchar *) g_strdup(list_item->data);        
 #ifdef DEBUG
-    printf("In s_string_list_delete_item, matching item against trial item = %s from list.\n", trial_item);
+    printf ("s_string_list_delete_item: ");
+    printf ("Matching item against trial item = %s from list.\n", trial_item);
 #endif
     if (strcmp(trial_item, item) == 0) {
       /* found item, now delete it. */
 #ifdef DEBUG
-    printf("In s_string_list_delete_item, found match . . . . . \n");
+    printf ("s_string_list_delete_item: ");
+    printf ("Match found.\n");
 #endif
       prev_item = list_item->prev;
       next_item = list_item->next;
@@ -227,18 +231,21 @@ void s_string_list_delete_item(STRING_LIST **list, int *count, gchar *item) {
       }
       
 #ifdef DEBUG
-    printf("In s_string_list_delete_item, now free list_item\n");
+    printf ("s_string_list_delete_item: ");
+    printf ("Free list_item.\n");
 #endif
       g_free(list_item);  /* free current list item */
       (*count)--;       /* decrement count */
       /* Do we need to re-number the list? */
 
 #ifdef DEBUG
-    printf("In s_string_list_delete_item, now free trial_item\n");
+    printf ("s_string_list_delete_item: ");
+    printf ("Free trial_item.\n");
 #endif
       g_free(trial_item); /* free trial item before returning */
 #ifdef DEBUG
-    printf("In s_string_list_delete_item, returning . . . .\n");
+    printf ("s_string_list_delete_item: ");
+    printf ("Return.\n");
 #endif
       return;
     }

--- a/attrib/src/s_string_list.c
+++ b/attrib/src/s_string_list.c
@@ -1,6 +1,7 @@
-/* gEDA - GPL Electronic Design Automation
- * gattrib -- gEDA component and net attribute manipulation using spreadsheet.
+/* Lepton EDA attribute editor
  * Copyright (C) 2003-2010 Stuart D. Brorson.
+ * Copyright (C) 2003-2013 gEDA Contributors
+ * Copyright (C) 2017-2020 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/attrib/src/s_string_list.c
+++ b/attrib/src/s_string_list.c
@@ -120,7 +120,8 @@ void s_string_list_add_item(STRING_LIST *list, int *count, char *item) {
   STRING_LIST *local_list;
   
   if (list == NULL) {
-    fprintf(stderr, _("In s_string_list_add_item, tried to add to a NULL list.\n"));
+    fprintf (stderr, "s_string_list_add_item: ");
+    fprintf (stderr, _("Tried to add to a NULL list.\n"));
     return;
   }
 
@@ -186,7 +187,8 @@ void s_string_list_delete_item(STRING_LIST **list, int *count, gchar *item) {
 
   /* First check to see if list is empty.  If empty, spew error and return */
   if ( (*list)->data == NULL) {
-    fprintf(stderr, _("In s_string_list_delete_item, tried to remove item from empty list\n"));
+    fprintf (stderr, "s_string_list_delete_item: ");
+    fprintf (stderr, _("Tried to remove item from empty list.\n"));
     return;
   }
 
@@ -256,7 +258,8 @@ void s_string_list_delete_item(STRING_LIST **list, int *count, gchar *item) {
   /* If we are here, it's 'cause we didn't find the item.
    * Spew error and return.
    */
-  fprintf(stderr, _("In s_string_list_delete_item, couldn't delete item %s\n"), item);
+  fprintf (stderr, "s_string_list_delete_item:");
+  fprintf (stderr, _("Couldn't delete item %s\n"), item);
   return;
 
 }

--- a/attrib/src/s_table.c
+++ b/attrib/src/s_table.c
@@ -284,7 +284,7 @@ void s_table_add_toplevel_comp_items_to_comp_table (const GList *obj_list) {
 
 
   if (verbose_mode) {
-    printf(_("- Starting internal component TABLE creation\n"));
+    printf (_("Start internal component TABLE creation\n"));
   }
 
 #ifdef DEBUG
@@ -500,7 +500,7 @@ void s_table_add_toplevel_pin_items_to_pin_table (const GList *obj_list) {
   OBJECT *pin_attrib;
 
   if (verbose_mode) {
-    printf(_("- Starting internal pin TABLE creation\n"));
+    printf (_("Start internal pin TABLE creation\n"));
   }
 
 #ifdef DEBUG

--- a/attrib/src/s_table.c
+++ b/attrib/src/s_table.c
@@ -289,7 +289,7 @@ void s_table_add_toplevel_comp_items_to_comp_table (const GList *obj_list) {
 #ifdef DEBUG
   fflush(stderr);
   fflush(stdout);
-  printf("=========== Just entered  s_table_add_toplevel_comp_items_to_comp_table!  ==============\n");
+  printf ("==== Enter s_table_add_toplevel_comp_items_to_comp_table()\n");
 #endif
 
   /* -----  Iterate through all objects found on page  ----- */
@@ -495,7 +495,7 @@ void s_table_add_toplevel_pin_items_to_pin_table (const GList *obj_list) {
   }
 
 #ifdef DEBUG
-  printf("=========== Just entered  s_table_add_toplevel_pin_items_to_pin_table!  ==============\n");
+  printf ("==== Enter s_table_add_toplevel_pin_items_to_pin_table()\n");
 #endif
 
   /* -----  Iterate through all objects found on page  ----- */
@@ -688,7 +688,7 @@ void s_table_gtksheet_to_table(GtkSheet *local_gtk_sheet, STRING_LIST *master_ro
   gchar *attrib_value;
 
 #ifdef DEBUG
-      printf("**********    Entering s_table_gtksheet_to_table     ******************\n");
+  printf ("==== Enter s_table_gtksheet_to_table()\n");
 #endif
 
 

--- a/attrib/src/s_table.c
+++ b/attrib/src/s_table.c
@@ -191,7 +191,8 @@ int s_table_get_index(STRING_LIST *local_list, char *local_string) {
   STRING_LIST *list_element;
 
 #ifdef DEBUG
-  printf("In s_table_get_index, examining %s to see if it is in the list.\n", local_string);
+  printf ("s_table_get_index: ");
+  printf ("Examining %s to see if it is in the list.\n", local_string);
 #endif
 
 
@@ -297,7 +298,8 @@ void s_table_add_toplevel_comp_items_to_comp_table (const GList *obj_list) {
     OBJECT *o_current = (OBJECT*) o_iter->data;
 
 #ifdef DEBUG
-      printf("   ---> In s_table_add_toplevel_comp_items_to_comp_table, examining o_current->name = %s\n", o_current->name);
+    printf ("s_table_add_toplevel_comp_items_to_comp_table: ");
+    printf ("Examining o_current->name = %s\n", o_current->name);
 #endif
 
     /* -----  Now process objects found on page  ----- */
@@ -309,7 +311,8 @@ void s_table_add_toplevel_comp_items_to_comp_table (const GList *obj_list) {
       if (temp_uref) {
 
 #if DEBUG
-        printf("      In s_table_add_toplevel_comp_items_to_comp_table, found component on page. Refdes = %s\n", temp_uref);
+        printf ("s_table_add_toplevel_comp_items_to_comp_table: ");
+        printf ("Found component on page. Refdes = %s\n", temp_uref);
 #endif
         verbose_print(" C");
 
@@ -346,9 +349,11 @@ void s_table_add_toplevel_comp_items_to_comp_table (const GList *obj_list) {
               } else {
 
 #if DEBUG
-                printf("       In s_table_add_toplevel_comp_items_to_comp_table, about to add row %d, col %d, attrib_value = %s\n",
+                printf ("s_table_add_toplevel_comp_items_to_comp_table: ");
+                printf ("About to add row %d, col %d, attrib_value = %s\n",
                        row, col, attrib_value);
-                printf(" . . . current address of attrib_value cell is [%p]\n", &((sheet_head->component_table)[row][col]).attrib_value);
+                printf ("    Current address of attrib_value cell is [%p]\n",
+                        &((sheet_head->component_table)[row][col]).attrib_value);
 #endif
                 /* Is there a compelling reason for me to put this into a separate fcn? */
                 ((sheet_head->component_table)[row][col]).row = row;
@@ -409,7 +414,8 @@ void s_table_add_toplevel_net_items_to_net_table(OBJECT *start_obj) {
 #if DEBUG
       fflush(stderr);
       fflush(stdout);
-      printf("In s_table_add_toplevel_net_items_to_net_table, Found net on page\n");
+      printf ("s_table_add_toplevel_net_items_to_net_table: ");
+      printf ("Found net on page.\n");
 #endif
       verbose_print(" N");
  
@@ -431,9 +437,11 @@ void s_table_add_toplevel_net_items_to_net_table(OBJECT *start_obj) {
 #if DEBUG
             fflush(stderr);
             fflush(stdout);
-            printf("In s_table_add_toplevel_net_items_to_net_table, about to add row %d, col %d, attrib_value = %s\n",
+            printf ("s_table_add_toplevel_net_items_to_net_table: ");
+            printf ("About to add row %d, col %d, attrib_value = %s\n",
                    row, col, attrib_value);
-            printf(" . . . current address of attrib_value cell is [%p]\n", &((sheet_head->net_table)[row][col]).attrib_value);
+            printf ("    Current address of attrib_value cell is [%p]\n",
+                    &((sheet_head->net_table)[row][col]).attrib_value);
 #endif
             /* Is there a compelling reason for me to put this into a separate fcn? */
             ((sheet_head->net_table)[row][col]).row = row;
@@ -462,7 +470,8 @@ void s_table_add_toplevel_net_items_to_net_table(OBJECT *start_obj) {
 #if DEBUG
   fflush(stderr);
   fflush(stdout);
-  printf("In s_table_add_toplevel_net_items_to_net_table -- we are about to return\n");
+  printf ("s_table_add_toplevel_net_items_to_net_table: ");
+  printf ("Return.\n");
 #endif
  
 }
@@ -503,7 +512,8 @@ void s_table_add_toplevel_pin_items_to_pin_table (const GList *obj_list) {
     OBJECT *o_current = (OBJECT*) o_iter->data;
 
 #ifdef DEBUG
-      printf("   ---> In s_table_add_toplevel_pin_items_to_pin_table, examining o_current->name = %s\n", o_current->name);
+    printf ("s_table_add_toplevel_pin_items_to_pin_table: ");
+    printf ("Examining o_current->name = %s\n", o_current->name);
 #endif
 
     /* -----  Now process objects found on page  ----- */
@@ -526,7 +536,8 @@ void s_table_add_toplevel_pin_items_to_pin_table (const GList *obj_list) {
 	    row_label = g_strconcat(temp_uref, ":", pinnumber, NULL);
 
 #if DEBUG
-        printf("      In s_table_add_toplevel_pin_items_to_pin_table, examining pin %s\n", row_label);
+            printf ("s_table_add_toplevel_pin_items_to_pin_table: ");
+            printf ("Examining pin %s\n", row_label);
 #endif
 
 	    a_iter = o_lower_current->attribs;
@@ -555,9 +566,11 @@ void s_table_add_toplevel_pin_items_to_pin_table (const GList *obj_list) {
                   } else {
 
 #if DEBUG
-                    printf("       In s_table_add_toplevel_pin_items_to_pin_table, about to add row %d, col %d, attrib_value = %s\n",
+                    printf ("s_table_add_toplevel_pin_items_to_pin_table: ");
+                    printf ("About to add row %d, col %d, attrib_value = %s\n",
                            row, col, attrib_value);
-                    printf(" . . . current address of attrib_value cell is [%p]\n", &((sheet_head->component_table)[row][col]).attrib_value);
+                    printf ("    Current address of attrib_value cell is [%p]\n",
+                            &((sheet_head->component_table)[row][col]).attrib_value);
 #endif
                     /* Is there a compelling reason for me to put this into a separate fcn? */
                     ((sheet_head->pin_table)[row][col]).row = row;
@@ -618,7 +631,8 @@ void s_table_gtksheet_to_all_tables() {
 
   /* now fill out new table */
 #ifdef DEBUG
-  printf("In s_table_gtksheet_to_all_tables, now about to fill out new component table.\n");
+  printf ("s_table_gtksheet_to_all_tables: ");
+  printf ("Now about to fill out new component table.\n");
 #endif
   s_table_gtksheet_to_table(local_gtk_sheet, master_row_list, 
 		       master_col_list, local_table,
@@ -712,13 +726,14 @@ void s_table_gtksheet_to_table(GtkSheet *local_gtk_sheet, STRING_LIST *master_ro
 
 
 #ifdef DEBUG
-      printf("In s_table_gtksheet_to_table, found attrib_value = %s in cell row=%d, col=%d\n", 
-	     attrib_value, row, col);
+      printf ("s_table_gtksheet_to_table: ");
+      printf ("Found attrib_value = %s in cell row=%d, col=%d\n",
+              attrib_value, row, col);
 #endif
 
       /* first handle attrib value in cell */
 #ifdef DEBUG
-      printf("     Updating attrib_value %s\n", attrib_value);
+      printf ("    Updating attrib_value %s\n", attrib_value);
 #endif
       g_free( local_table[row][col].attrib_value );
       if (attrib_value != NULL) {
@@ -729,7 +744,7 @@ void s_table_gtksheet_to_table(GtkSheet *local_gtk_sheet, STRING_LIST *master_ro
 
       /* next handle name of row (also held in TABLE cell) */
 #ifdef DEBUG
-      printf("     Updating row_name %s\n", row_title);
+      printf ("    Updating row_name %s\n", row_title);
 #endif
       g_free( local_table[row][col].row_name );
       if (row_title != NULL) {
@@ -740,7 +755,7 @@ void s_table_gtksheet_to_table(GtkSheet *local_gtk_sheet, STRING_LIST *master_ro
 
       /* finally handle name of col */
 #ifdef DEBUG
-      printf("     Updating col_name %s\n", col_title);
+      printf ("    Updating col_name %s\n", col_title);
 #endif
       g_free( local_table[row][col].col_name );
       if (col_title != NULL) {

--- a/attrib/src/s_table.c
+++ b/attrib/src/s_table.c
@@ -240,8 +240,8 @@ STRING_LIST *s_table_create_attrib_pair(gchar *row_name,
   /* Sanity check */
   if (row == -1) {
     /* we didn't find the item in the list */
-    fprintf (stderr,
-             _("In s_table_create_attrib_pair, we didn't find the row name in the row list!\n"));
+    fprintf (stderr, "s_table_create_attrib_pair: ");
+    fprintf (stderr, _("We didn't find the row name in the row list!\n"));
     return attrib_pair_list;
   }
 
@@ -344,8 +344,8 @@ void s_table_add_toplevel_comp_items_to_comp_table (const GList *obj_list) {
               /* Sanity check */
               if (row == -1 || col == -1) {
                 /* we didn't find the item in the table */
-                fprintf (stderr,
-                         _("In s_table_add_toplevel_comp_items_to_comp_table, we didn't find either row or col in the lists!\n"));
+                fprintf (stderr, "s_table_add_toplevel_comp_items_to_comp_table: ");
+                fprintf (stderr, _("We didn't find either row or col in the lists!\n"));
               } else {
 
 #if DEBUG
@@ -561,8 +561,8 @@ void s_table_add_toplevel_pin_items_to_pin_table (const GList *obj_list) {
                   /* Sanity check */
                   if (row == -1 || col == -1) {
                     /* we didn't find the item in the table */
-                    fprintf (stderr,
-                             _("In s_table_add_toplevel_pin_items_to_pin_table, we didn't find either row or col in the lists!\n"));
+                    fprintf (stderr, "s_table_add_toplevel_pin_items_to_pin_table: ");
+                    fprintf (stderr, _("We didn't find either row or col in the lists!\n"));
                   } else {
 
 #if DEBUG

--- a/attrib/src/s_toplevel.c
+++ b/attrib/src/s_toplevel.c
@@ -597,7 +597,7 @@ STRING_LIST *s_toplevel_get_component_attribs_in_sheet(char *refdes)
     if (count != i+1) {
       /* for some reason, we have lost a name_value_pair somewhere . . .  */
       fprintf (stderr, "s_toplevel_get_component_attribs_in_sheet: ");
-      fprintf (stderr, _("Count != i.\n"));
+      fprintf (stderr, "count != i.\n");
       exit(-1);
     }
 
@@ -945,7 +945,7 @@ STRING_LIST *s_toplevel_get_pin_attribs_in_sheet(char *refdes, OBJECT *pin)
     if (count != i+1) {
       /* for some reason, we have lost a name_value_pair somewhere . . .  */
       fprintf (stderr, "s_toplevel_get_pin_attribs_in_sheet: ");
-      fprintf (stderr, _("Count != i.\n"));
+      fprintf (stderr, "count != i.\n");
       exit(-1);
     }
 

--- a/attrib/src/s_toplevel.c
+++ b/attrib/src/s_toplevel.c
@@ -136,7 +136,7 @@ s_toplevel_gtksheet_to_toplevel(TOPLEVEL *toplevel)
   PAGE *p_current;
 
 #if DEBUG
-  printf("---------------------   Entering  s_toplevel_gtksheet_to_toplevel   -------------------\n");
+  printf ("==== Enter s_toplevel_gtksheet_to_toplevel()\n");
 #endif
 
   s_sheet_data_gtksheet_to_sheetdata();  /* read data from gtksheet into SHEET_DATA */
@@ -541,7 +541,7 @@ STRING_LIST *s_toplevel_get_component_attribs_in_sheet(char *refdes)
   char *new_attrib_name;
 
 #if DEBUG
-  printf("-----  Entering s_toplevel_get_component_attribs_in_sheet.\n");
+  printf ("==== Enter s_toplevel_get_component_attribs_in_sheet()\n");
 #endif
 
 
@@ -639,7 +639,7 @@ s_toplevel_update_component_attribs_in_toplevel (
   gint show_name_value = 0;
 
 #if DEBUG
-  printf("-----  Entering s_toplevel_update_component_attribs_in_toplevel.\n");
+  printf ("==== Enter s_toplevel_update_component_attribs_in_toplevel()\n");
 #endif
 
   /* 
@@ -877,7 +877,7 @@ STRING_LIST *s_toplevel_get_pin_attribs_in_sheet(char *refdes, OBJECT *pin)
   char *new_attrib_name;
 
 #if DEBUG
-  printf("-----  Entering s_toplevel_get_pin_attribs_in_sheet.\n");
+  printf ("==== Enter s_toplevel_get_pin_attribs_in_sheet()\n");
 #endif
 
   /* First find pos of this pin in the master pin list */
@@ -971,7 +971,7 @@ s_toplevel_update_pin_attribs_in_toplevel (TOPLEVEL *toplevel,
   char *old_attrib_value;
 
 #if DEBUG
-  printf("-----  Entering s_toplevel_update_pin_attribs_in_toplevel.\n");
+  printf ("==== Enter s_toplevel_update_pin_attribs_in_toplevel()\n");
 #endif
 
   /* loop on name=value pairs held in new_pin_attrib_list */

--- a/attrib/src/s_toplevel.c
+++ b/attrib/src/s_toplevel.c
@@ -324,7 +324,8 @@ void s_toplevel_delete_attrib_col() {
       printf ("Attrib to delete = %s\n", attrib_name);
 #endif
     } else {
-      fprintf(stderr, _("In s_toplevel_delete_attrib_col, can't get attrib name\n"));
+      fprintf (stderr, "s_toplevel_delete_attrib_col: ");
+      fprintf (stderr, _("Can't get attrib name\n"));
       return;
     }
     
@@ -567,8 +568,8 @@ STRING_LIST *s_toplevel_get_component_attribs_in_sheet(char *refdes)
   /* Sanity check */
   if (row == -1) {
     /* we didn't find the item in the list */
-    fprintf(stderr, 
-	    _("In s_toplevel_get_component_attribs_in_sheet, we didn't find the refdes in the master list!\n"));
+    fprintf (stderr, "s_toplevel_get_component_attribs_in_sheet: ");
+    fprintf (stderr, _("We didn't find the refdes in the master list.\n"));
     return NULL;
   }
 
@@ -595,8 +596,8 @@ STRING_LIST *s_toplevel_get_component_attribs_in_sheet(char *refdes)
     /* Sanity check */
     if (count != i+1) {
       /* for some reason, we have lost a name_value_pair somewhere . . .  */
-      fprintf(stderr, 
-	      _("In s_toplevel_get_component_attribs_in_sheet, count != i!  Exiting . . . .\n"));
+      fprintf (stderr, "s_toplevel_get_component_attribs_in_sheet: ");
+      fprintf (stderr, _("Count != i.\n"));
       exit(-1);
     }
 
@@ -906,8 +907,8 @@ STRING_LIST *s_toplevel_get_pin_attribs_in_sheet(char *refdes, OBJECT *pin)
   if ( (refdes != NULL) && (pinnumber != NULL) ) {
     row_label = g_strconcat(refdes, ":", pinnumber, NULL);
   } else {
-    fprintf(stderr, 
-	    _("In s_toplevel_get_pin_attribs_in_sheet, either refdes or pinnumber of object missing!\n"));
+    fprintf (stderr, "s_toplevel_get_pin_attribs_in_sheet: ");
+    fprintf (stderr, _("Either refdes or pinnumber of object missing.\n"));
     return NULL;
   }
   row = s_table_get_index(sheet_head->master_pin_list_head, row_label);
@@ -915,8 +916,8 @@ STRING_LIST *s_toplevel_get_pin_attribs_in_sheet(char *refdes, OBJECT *pin)
   /* Sanity check */
   if (row == -1) {
     /* we didn't find the item in the list */
-    fprintf(stderr, 
-	    _("In s_toplevel_get_pin_attribs_in_sheet, we didn't find the refdes:pin in the master list!\n"));
+    fprintf (stderr, "s_toplevel_get_pin_attribs_in_sheet: ");
+    fprintf (stderr, _("We didn't find the refdes:pin in the master list.\n"));
     return NULL;
   }
 
@@ -943,8 +944,8 @@ STRING_LIST *s_toplevel_get_pin_attribs_in_sheet(char *refdes, OBJECT *pin)
     /* Sanity check */
     if (count != i+1) {
       /* for some reason, we have lost a name_value_pair somewhere . . .  */
-      fprintf(stderr, 
-	      _("In s_toplevel_get_pin_attribs_in_sheet, count != i!  Exiting . . . .\n"));
+      fprintf (stderr, "s_toplevel_get_pin_attribs_in_sheet: ");
+      fprintf (stderr, _("Count != i.\n"));
       exit(-1);
     }
 

--- a/attrib/src/s_toplevel.c
+++ b/attrib/src/s_toplevel.c
@@ -141,7 +141,8 @@ s_toplevel_gtksheet_to_toplevel(TOPLEVEL *toplevel)
 
   s_sheet_data_gtksheet_to_sheetdata();  /* read data from gtksheet into SHEET_DATA */
 #if DEBUG
-  printf("In s_toplevel_gtksheet_to_toplevel -- done writing stuff from gtksheet into SHEET_DATA.\n");
+  printf ("s_toplevel_gtksheet_to_toplevel: ");
+  printf ("Done writing stuff from gtksheet into SHEET_DATA.\n");
 #endif
 
   /* must iterate over all pages in design */
@@ -158,7 +159,8 @@ s_toplevel_gtksheet_to_toplevel(TOPLEVEL *toplevel)
   }
 
 #if DEBUG
-  printf("In s_toplevel_gtksheet_to_toplevel -- done writing SHEEET_DATA text back into pr_currnet.\n");
+  printf ("s_toplevel_gtksheet_to_toplevel: ");
+  printf ("Done writing SHEEET_DATA text back into pr_currnet.\n");
 #endif  
 
   return;
@@ -190,8 +192,8 @@ void s_toplevel_add_new_attrib(gchar *new_attrib_name) {
   /* Next must figure out which sheet the attrib belongs to. */
   cur_page = gtk_notebook_get_current_page(GTK_NOTEBOOK(notebook));
 #ifdef DEBUG
-  printf("In s_toplevel_add_new_attrib, adding new attrib to page %d.\n", 
-	 cur_page);
+  printf ("s_toplevel_add_new_attrib: ");
+  printf ("Adding new attrib to page %d.\n", cur_page);
 #endif
 
   switch (cur_page) {
@@ -207,8 +209,9 @@ void s_toplevel_add_new_attrib(gchar *new_attrib_name) {
     */
     old_comp_attrib_count = sheet_head->comp_attrib_count;
 #ifdef DEBUG 
-    printf("In s_toplevel_add_new_attrib, before adding new comp attrib.\n");
-    printf("                           comp_attrib_count = %d\n", old_comp_attrib_count);
+    printf ("s_toplevel_add_new_attrib: ");
+    printf ("Before adding new comp attrib: comp_attrib_count = %d\n",
+            old_comp_attrib_count);
 #endif
 
     s_string_list_add_item(sheet_head->master_comp_attrib_list_head, 
@@ -223,8 +226,9 @@ void s_toplevel_add_new_attrib(gchar *new_attrib_name) {
                                            (char*)new_attrib_name);
 
 #ifdef DEBUG
-    printf("In s_toplevel_add_new_attrib, just updated comp_attrib string list.\n");
-    printf("                             new comp_attrib_count = %d\n", sheet_head->comp_attrib_count);
+    printf ("s_toplevel_add_new_attrib: ");
+    printf ("Updated comp_attrib string list: new comp_attrib_count = %d\n",
+            sheet_head->comp_attrib_count);
 #endif
 
     /* Now create new table */
@@ -239,7 +243,8 @@ void s_toplevel_add_new_attrib(gchar *new_attrib_name) {
 		     old_comp_attrib_count, sheet_head->comp_attrib_count);
 
 #ifdef DEBUG
-    printf("In s_toplevel_add_new_attrib, just resized component table.\n");
+    printf ("s_toplevel_add_new_attrib: ");
+    printf ("Resized component table.\n");
 #endif
 
     /* Fill out new sheet with new stuff from gtksheet */
@@ -249,7 +254,8 @@ void s_toplevel_add_new_attrib(gchar *new_attrib_name) {
 			      sheet_head->master_comp_attrib_list_head);
 
 #ifdef DEBUG
-    printf("In s_toplevel_add_new_attrib, just updated gtksheet.\n");
+    printf ("s_toplevel_add_new_attrib: ");
+    printf ("Updated gtksheet.\n");
 #endif
 
     break;
@@ -293,7 +299,8 @@ void s_toplevel_delete_attrib_col() {
   }
 
 #ifdef DEBUG
-  printf("In s_toplevel_delete_attrib_col, checks were OK, now do real work\n");
+  printf ("s_toplevel_delete_attrib_col: ");
+  printf ("Checks were OK, now do real work\n");
 #endif
 
   /*  Rebuild the gattrib-specific data structures  */
@@ -313,7 +320,8 @@ void s_toplevel_delete_attrib_col() {
     
     if (attrib_name != NULL) {
 #ifdef DEBUG
-      printf("In s_toplevel_delete_attrib_col, attrib to delete = %s\n", attrib_name);
+      printf ("s_toplevel_delete_attrib_col: ");
+      printf ("Attrib to delete = %s\n", attrib_name);
 #endif
     } else {
       fprintf(stderr, _("In s_toplevel_delete_attrib_col, can't get attrib name\n"));
@@ -321,8 +329,9 @@ void s_toplevel_delete_attrib_col() {
     }
     
 #ifdef DEBUG 
-    printf("In s_toplevel_delete_attrib_col, before deleting comp attrib.\n");
-    printf("                           comp_attrib_count = %d\n", sheet_head->comp_attrib_count);
+    printf ("s_toplevel_delete_attrib_col: ");
+    printf ("Before deleting comp attrib: comp_attrib_count = %d\n",
+            sheet_head->comp_attrib_count);
 #endif
     s_string_list_delete_item(&(sheet_head->master_comp_attrib_list_head), 
 			      &(sheet_head->comp_attrib_count), 
@@ -331,8 +340,9 @@ void s_toplevel_delete_attrib_col() {
     g_free(attrib_name);
     
 #ifdef DEBUG
-    printf("In s_toplevel_delete_attrib_col, just updated comp_attrib string list.\n");
-    printf("                             new comp_attrib_count = %d\n", sheet_head->comp_attrib_count);
+    printf ("s_toplevel_delete_attrib_col: ");
+    printf ("Just updated comp_attrib string list: new comp_attrib_count = %d\n",
+            sheet_head->comp_attrib_count);
 #endif
     
     /* Now create new table with new attrib count*/
@@ -341,7 +351,8 @@ void s_toplevel_delete_attrib_col() {
 
     
 #ifdef DEBUG
-    printf("In s_toplevel_delete_attrib_col, just updated SHEET_DATA info.\n");
+    printf ("s_toplevel_delete_attrib_col: ");
+    printf ("Updated SHEET_DATA info.\n");
 #endif
     break;
 
@@ -357,11 +368,13 @@ void s_toplevel_delete_attrib_col() {
 
   /* Delete col on gtksheet  */
 #ifdef DEBUG
-  printf("In s_toplevel_delete_attrib_col, about to delete col in gtksheet.\n");
+  printf ("s_toplevel_delete_attrib_col: ");
+  printf ("About to delete col in gtksheet.\n");
 #endif
   gtk_sheet_delete_columns (sheet, mincol, 1); 
 #ifdef DEBUG
-  printf("In s_toplevel_delete_attrib_col, done deleting col in gtksheet.\n");
+  printf ("s_toplevel_delete_attrib_col: ");
+  printf ("Done deleting col in gtksheet.\n");
 #endif
   
   sheet_head->CHANGED = TRUE;  /* Set changed flag so user is prompted when exiting */
@@ -399,7 +412,8 @@ s_toplevel_sheetdata_to_toplevel (TOPLEVEL *toplevel, PAGE *page)
 
   /* -----  First deal with all components on the page.  ----- */
 #ifdef DEBUG
-  printf("-----  In s_toplevel_sheetdata_to_toplevel, handling components\n");
+  printf ("s_toplevel_sheetdata_to_toplevel: ");
+  printf ("Handling components\n");
 #endif
 
   /* Work from a copy list, as objects can be deleted
@@ -446,8 +460,9 @@ s_toplevel_sheetdata_to_toplevel (TOPLEVEL *toplevel, PAGE *page)
 	g_free(temp_uref);
       } else {
 #ifdef DEBUG
-	printf ("In s_toplevel_sheetdata_to_toplevel, found component with no refdes. name = %s\n",
-	       o_current->name);
+        printf ("s_toplevel_sheetdata_to_toplevel: ");
+        printf ("Found component with no refdes. name = %s\n",
+                o_current->name);
 #endif
       }
     }  /* if (o_current->type == OBJ_COMPONENT) */
@@ -466,7 +481,8 @@ s_toplevel_sheetdata_to_toplevel (TOPLEVEL *toplevel, PAGE *page)
   /* -----  Finally deal with all pins on the page.  ----- */
   /* -----  Next deal with all nets on the page.  ----- */
 #ifdef DEBUG
-	printf("-----  In s_toplevel_sheetdata_to_toplevel, handling pins\n");
+  printf ("s_toplevel_sheetdata_to_toplevel: ");
+  printf ("Handling pins\n");
 #endif
 
   /* Work from a copy list in case objects are
@@ -710,9 +726,8 @@ s_toplevel_update_component_attribs_in_toplevel (
   while (local_list != NULL) {
 
 #if DEBUG
-  printf("\n\n");
-  printf("        In s_toplevel_update_component_attribs_in_toplevel, handling entry in complete list %s .\n", 
-	 local_list->data);
+  printf ("s_toplevel_update_component_attribs_in_toplevel: ");
+  printf ("Handling entry in complete list %s.\n", local_list->data);
 #endif
 
   /*  Now get the old attrib name & value from complete_comp_attrib_list 
@@ -721,10 +736,10 @@ s_toplevel_update_component_attribs_in_toplevel (
   old_attrib_value = o_attrib_search_attached_attribs_by_name (o_current, old_attrib_name, 0);
 
 #if DEBUG
-  printf("        In s_toplevel_update_component_attribs_in_toplevel, old name = \"%s\" .\n", 
-	 old_attrib_name);
-  printf("        In s_toplevel_update_component_attribs_in_toplevel, old value = \"%s\" .\n", 
-	 old_attrib_value);
+  printf ("s_toplevel_update_component_attribs_in_toplevel: ");
+  printf ("Old name = \"%s\".\n", old_attrib_name);
+  printf ("s_toplevel_update_component_attribs_in_toplevel: ");
+  printf ("Old value = \"%s\".\n", old_attrib_value);
 #endif
 
   /*  Next try to get this attrib from new_comp_attrib_list  */
@@ -735,10 +750,10 @@ s_toplevel_update_component_attribs_in_toplevel (
     new_attrib_value = NULL;
   }
 #if DEBUG
-  printf("        In s_toplevel_update_component_attribs_in_toplevel, new name = \"%s\" .\n", 
-	 new_attrib_name);
-  printf("        In s_toplevel_update_component_attribs_in_toplevel, new value = \"%s\" .\n", 
-	 new_attrib_value);
+  printf ("s_toplevel_update_component_attribs_in_toplevel: ");
+  printf ("New name = \"%s\".\n", new_attrib_name);
+  printf ("s_toplevel_update_component_attribs_in_toplevel: ");
+  printf ("New value = \"%s\".\n", new_attrib_value);
 #endif
 
   /* Now get row and col where this new attrib lives.  Then get 
@@ -761,11 +776,11 @@ s_toplevel_update_component_attribs_in_toplevel (
     if ( (old_attrib_value != NULL) && (new_attrib_value != NULL) && (strlen(new_attrib_value) != 0) ) {
       /* simply write new attrib into place of old one. */
 #if DEBUG
-      printf("     -- In s_toplevel_update_component_attribs_in_toplevel,\n");
-      printf("               about to replace old attrib with name= %s, value= %s\n", 
-	                new_attrib_name, new_attrib_value);
-      printf("               visibility = %d, show_name_value = %d.\n",
-	     visibility, show_name_value);
+      printf ("s_toplevel_update_component_attribs_in_toplevel: ");
+      printf ("About to replace old attrib with name= %s, value= %s\n",
+              new_attrib_name, new_attrib_value);
+      printf ("    visibility = %d, show_name_value = %d.\n",
+              visibility, show_name_value);
 #endif
       s_object_replace_attrib_in_object(toplevel,
 					o_current,
@@ -779,8 +794,9 @@ s_toplevel_update_component_attribs_in_toplevel (
     else if ( (old_attrib_value != NULL) && (new_attrib_value == NULL) ) {
       /* remove attrib from component*/
 #if DEBUG
-      printf("     -- In s_toplevel_update_component_attribs_in_toplevel, about to remove old attrib with name= %s, value= %s\n",
-	     old_attrib_name, old_attrib_value);
+      printf ("s_toplevel_update_component_attribs_in_toplevel: ");
+      printf ("About to remove old attrib with name= %s, value= %s\n",
+              old_attrib_name, old_attrib_value);
 #endif
       s_object_remove_attrib_in_object (toplevel, o_current, old_attrib_name);
     }
@@ -790,8 +806,9 @@ s_toplevel_update_component_attribs_in_toplevel (
       /* add new attrib to component. */
 
 #if DEBUG
-      printf("     -- In s_toplevel_update_component_attribs_in_toplevel, about to add new attrib with name= %s, value= %s\n",
-	     new_attrib_name, new_attrib_value);
+      printf ("s_toplevel_update_component_attribs_in_toplevel: ");
+      printf ("About to add new attrib with name= %s, value= %s\n",
+              new_attrib_name, new_attrib_value);
 #endif 
 
       s_object_add_comp_attrib_to_object (toplevel,
@@ -805,7 +822,8 @@ s_toplevel_update_component_attribs_in_toplevel (
     } else {
       /* Do nothing. */
 #if DEBUG
-      printf("     -- In s_toplevel_update_component_attribs_in_toplevel, nothing needs to be done.\n");
+      printf ("s_toplevel_update_component_attribs_in_toplevel: ");
+      printf ("Nothing needs to be done.\n");
 #endif
     }
 
@@ -979,7 +997,8 @@ s_toplevel_update_pin_attribs_in_toplevel (TOPLEVEL *toplevel,
   while (local_list != NULL) {
     new_name_value_pair = g_strdup(local_list->data);
 #if DEBUG
-  printf("        In s_toplevel_update_pin_attribs_in_toplevel, handling entry in master list %s .\n", new_name_value_pair);
+    printf ("s_toplevel_update_pin_attribs_in_toplevel: ");
+    printf ("Handling entry in master list %s.\n", new_name_value_pair);
 #endif
 
   new_attrib_name = u_basic_breakup_string(new_name_value_pair, '=', 0);
@@ -995,8 +1014,9 @@ s_toplevel_update_pin_attribs_in_toplevel (TOPLEVEL *toplevel,
     if ( (old_attrib_value != NULL) && (new_attrib_value != NULL) && (strlen(new_attrib_value) != 0) ) {
       /* simply write new attrib into place of old one. */
 #if DEBUG
-      printf("In s_toplevel_update_pin_attribs_in_toplevel, about to replace old attrib with new one: name= %s, value= %s\n",
-             new_attrib_name, new_attrib_value);
+      printf ("s_toplevel_update_pin_attribs_in_toplevel: ");
+      printf ("About to replace old attrib with new one: name= %s, value= %s\n",
+              new_attrib_name, new_attrib_value);
 #endif
       s_object_replace_attrib_in_object(toplevel,
 					o_pin,
@@ -1010,8 +1030,9 @@ s_toplevel_update_pin_attribs_in_toplevel (TOPLEVEL *toplevel,
     else if ( (old_attrib_value != NULL) && (new_attrib_value == NULL) ) {
       /* remove attrib from pin */
 #if DEBUG
-      printf("In s_toplevel_update_pin_attribs_in_toplevel, about to remove old attrib with name= %s, value= %s\n",
-             new_attrib_name, old_attrib_value);
+      printf ("s_toplevel_update_pin_attribs_in_toplevel: ");
+      printf ("About to remove old attrib with name= %s, value= %s\n",
+              new_attrib_name, old_attrib_value);
 #endif
       s_object_remove_attrib_in_object (toplevel, o_pin, new_attrib_name);
     }
@@ -1021,8 +1042,9 @@ s_toplevel_update_pin_attribs_in_toplevel (TOPLEVEL *toplevel,
       /* add new attrib to pin. */
                                                                                                        
 #if DEBUG
-      printf("In s_toplevel_update_pin_attribs_in_toplevel, about to add new attrib with name= %s, value= %s\n",
-             new_attrib_name, new_attrib_value);
+      printf ("s_toplevel_update_pin_attribs_in_toplevel: ");
+      printf ("About to add new attrib with name= %s, value= %s\n",
+              new_attrib_name, new_attrib_value);
 #endif
 
       s_object_add_pin_attrib_to_object (toplevel,
@@ -1034,7 +1056,8 @@ s_toplevel_update_pin_attribs_in_toplevel (TOPLEVEL *toplevel,
     } else {
       /* Do nothing. */
 #if DEBUG
-      printf("In s_toplevel_update_pin_attribs_in_toplevel, nothing needs to be done.\n");
+      printf ("s_toplevel_update_pin_attribs_in_toplevel: ");
+      printf ("Nothing needs to be done.\n");
 #endif
     }
                                                                                                        

--- a/attrib/src/s_visibility.c
+++ b/attrib/src/s_visibility.c
@@ -1,6 +1,7 @@
-/* gEDA - GPL Electronic Design Automation
- * gattrib -- gEDA component and net attribute manipulation using spreadsheet.
+/* Lepton EDA attribute editor
  * Copyright (C) 2003-2010 Stuart D. Brorson.
+ * Copyright (C) 2003-2013 gEDA Contributors
+ * Copyright (C) 2017-2020 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/attrib/src/s_visibility.c
+++ b/attrib/src/s_visibility.c
@@ -100,7 +100,8 @@ void s_visibility_set_invisible() {
   case GTK_SHEET_ROW_SELECTED: 
 
 #ifdef DEBUG
-    printf("In s_visibility_set_invisible, range/col/row selected.\n");
+    printf ("s_visibility_set_invisible: ");
+    printf ("Range/col/row selected.\n");
 #endif
 
     row_start = sheet->range.row0;
@@ -126,7 +127,8 @@ void s_visibility_set_invisible() {
 
   case GTK_SHEET_NORMAL:
 #ifdef DEBUG
-    printf("In s_visibility_set_invisible, normal selection.\n");
+    printf ("s_visibility_set_invisible: ");
+    printf ("Normal selection.\n");
 #endif
     s_visibility_set_cell(cur_page, 
 			  sheet->active_cell.row, 
@@ -172,7 +174,8 @@ void s_visibility_set_name_only() {
   case GTK_SHEET_COLUMN_SELECTED:  
   case GTK_SHEET_ROW_SELECTED: 
 #ifdef DEBUG
-    printf("In s_visibility_set_name_only, range/col/row selected.\n");
+    printf ("s_visibility_set_name_only: ");
+    printf ("Range/col/row selected.\n");
 #endif
     row_start = sheet->range.row0;
     row_end = sheet->range.rowi;
@@ -233,7 +236,8 @@ void s_visibility_set_value_only() {
   case GTK_SHEET_COLUMN_SELECTED:  
   case GTK_SHEET_ROW_SELECTED: 
 #ifdef DEBUG
-    printf("In s_visibility_set_value_only, range/col/row selected.\n");
+    printf ("s_visibility_set_value_only: ");
+    printf ("Range/col/row selected.\n");
 #endif
     row_start = sheet->range.row0;
     row_end = sheet->range.rowi;
@@ -255,7 +259,8 @@ void s_visibility_set_value_only() {
 
   case GTK_SHEET_NORMAL:
 #ifdef DEBUG
-    printf("In s_visibility_set_value_only, sheet normal selected.\n");
+    printf ("s_visibility_set_value_only: ");
+    printf ("Sheet normal selected.\n");
 #endif
     s_visibility_set_cell(cur_page, 
 			  sheet->active_cell.row, 
@@ -351,7 +356,8 @@ void s_visibility_set_cell(gint cur_page, gint row, gint col,
   TABLE **local_table = NULL;
 
 #ifdef DEBUG
-    printf("In s_visibility_set_cell, setting row = %d, col = %d.\n", 
+  printf ("s_visibility_set_cell: ");
+  printf ("Setting row = %d, col = %d.\n",
 	   row, col);
 #endif
 

--- a/attrib/src/x_dialog.c
+++ b/attrib/src/x_dialog.c
@@ -172,7 +172,7 @@ void x_dialog_delattrib()
 void x_dialog_missing_sym()
 {
   GtkWidget *dialog;
-  const char *string = _("One or more components have been found with missing symbol files!\n\nThis probably happened because lepton-attrib couldn't find your component libraries, perhaps because your gafrc or gattribrc files are misconfigured.\n\nChoose \"Quit\" to leave lepton-attrib and fix the problem, or\n\"Forward\" to continue working with lepton-attrib.\n");
+  const char *string = _("One or more components have been found with missing symbol files!\n\nThis probably happened because lepton-attrib couldn't find your component libraries, perhaps because your gafrc files are misconfigured.\n\nChoose \"Quit\" to leave lepton-attrib and fix the problem, or\n\"Forward\" to continue working with lepton-attrib.\n");
 
   /* Create the dialog */
   dialog = gtk_message_dialog_new (NULL, GTK_DIALOG_MODAL,

--- a/attrib/src/x_dialog.c
+++ b/attrib/src/x_dialog.c
@@ -1,7 +1,7 @@
 /* Lepton EDA attribute editor
  * Copyright (C) 2003-2010 Stuart D. Brorson.
  * Copyright (C) 2003-2014 gEDA Contributors
- * Copyright (C) 2017-2019 Lepton EDA Contributors
+ * Copyright (C) 2017-2020 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
- PO files have been updated.
- Messages for translation have been improved:
  - One function (`fprintf()`) is used to output them.
  - Messages have been splitted up to separately output function
    names and real information, and translate only the latter to
    prevent putting the former in the PO files; this also shortened
    translation strings and lines in the code.
  - Messages with variables only are no longer translated.
  - Obsolete and unused `gattribrc` is no longer mentioned in the
    messages.
- The like changes have been done for debugging messages.
