### PR TITLE
symcheck: Fix localization.

### DIFF
--- a/symcheck/scheme/Makefile.am
+++ b/symcheck/scheme/Makefile.am
@@ -5,6 +5,7 @@ EXTRA_DIST = lepton-symcheck.in
 
 do_subst = sed -e 's,[@]libdir[@],$(libdir),g' \
 	-e 's,[@]GUILE[@],$(GUILE),g' \
+	-e 's,[@]localedir[@],$(localedir),g'
 	-e 's,[@]ccachedir[@],@LEPTON_SCM_PRECOMPILE_DIR@,g'
 
 lepton-symcheck: lepton-symcheck.in Makefile

--- a/symcheck/scheme/lepton-symcheck.in
+++ b/symcheck/scheme/lepton-symcheck.in
@@ -23,6 +23,12 @@ exec @GUILE@ -s "$0" "$@"
 (load-extension (or (getenv "LIBLEPTON") "@libdir@/liblepton")
                 "liblepton_init")
 
+;;; Localization.
+(define %textdomain "lepton-symcheck")
+(textdomain %textdomain)
+(bindtextdomain %textdomain "@localedir@")
+(bind-textdomain-codeset %textdomain "UTF-8")
+
 ;;; At compile time of this program guile won't be aware of these
 ;;; modules, since it compiles the code before loading the above
 ;;; extension. Let's make it quiet here.


### PR DESCRIPTION
The localization was not working at least since rewritting the
tool in Scheme.