### PR TITLE
Update the lepton-upcfg utility

### DIFF
--- a/docs/scheme-api/lepton-scheme.texi
+++ b/docs/scheme-api/lepton-scheme.texi
@@ -1775,7 +1775,8 @@ Since 1.10.
 
 @defun config-save! cfg
 Attempt to save configuration parameters for the context @var{cfg} to
-its associated file.
+its associated file. Returns @var{cfg}. If configuration cannot be
+saved, raises an error.
 
 Since 1.10.
 @end defun
@@ -1919,13 +1920,15 @@ Since 1.10.
 
 @defun config-remove-key! cfg group key
 Removes the configuration parameter identified by the given @var{group}
-and @var{key} in the configuration context @var{cfg}.
+and @var{key} in the configuration context @var{cfg}. Returns @samp{#t}
+on success, @samp{#f} otherwise.
 
 @end defun
 
 @defun config-remove-group! cfg group
 Removes the configuration group identified by @var{group}
 and all its parameters in the configuration context @var{cfg}.
+Returns @samp{#t} on success, @samp{#f} otherwise.
 
 @end defun
 
@@ -2024,7 +2027,7 @@ Since 1.10.
 @defun set-config! cfg group key value
 Set the configuration parameter identified by the given @var{group}
 and @var{key} in the configuration context @var{cfg}.  The type of
-value to set is inferred from @var{value}.
+value to set is inferred from @var{value}. Returns @var{cfg}.
 
 Since 1.10.
 @end defun

--- a/liblepton/include/liblepton/edaconfig.h
+++ b/liblepton/include/liblepton/edaconfig.h
@@ -149,6 +149,7 @@ gboolean eda_config_remove_key (EdaConfig *cfg, const char *group, const char *k
 gboolean eda_config_remove_group (EdaConfig *cfg, const char *group, GError **error);
 
 void config_set_legacy_mode(gboolean legacy);
+gboolean config_get_legacy_mode();
 
 G_END_DECLS
 

--- a/liblepton/scheme/lepton/config.scm
+++ b/liblepton/scheme/lepton/config.scm
@@ -79,4 +79,5 @@
 (define-public config-remove-group! %config-remove-group!)
 
 (define-public config-set-legacy-mode! %config-set-legacy-mode!)
+(define-public config-legacy-mode? %config-legacy-mode?)
 

--- a/liblepton/scheme/lepton/legacy-config.scm
+++ b/liblepton/scheme/lepton/legacy-config.scm
@@ -11,11 +11,20 @@
   #:use-module  ( lepton config )
   #:use-module  ( lepton legacy-config keylist )
 
+  #:export      ( upcfg-log )
   #:export      ( config-upgrade )
   #:export      ( warning-option-deprecated )
   #:export      ( warning-option-obsolete )
 )
 
+
+
+; public:
+;
+( define ( upcfg-log fmt . args )
+  ( apply format (current-error-port) fmt args )
+  ; ( apply log! 'message fmt args )
+)
 
 
 ; get configuration context
@@ -64,12 +73,12 @@
       ( catch #t
         ( lambda()
           ( set! val ( pfn cfg grp-old key-old ) ) ; pfn() throws
-          ( format #t "ii: read   [~a]::~a ~65,4t = [~a]~%" grp-old key-old val )
+          ( upcfg-log "ii: read   [~a]::~a ~65,4t = [~a]~%" grp-old key-old val )
           ( add-to-res grp-new key-new val )
         )
         ( lambda( ex . args )
           ( if report-absent-keys
-            ( format #t "ww: !read  [~a]::~a~%" grp-old key-old )
+            ( upcfg-log "ww: !read  [~a]::~a~%" grp-old key-old )
           )
         )
       ) ; catch()
@@ -163,8 +172,8 @@
     ( throw 'infile "Input config file does not exist:" fname )
   )
 
-  ( format #t "ii: INPUT: ~a~%" fname )
-  ( format #t "~%" )
+  ( upcfg-log "ii: INPUT: ~a~%" fname )
+  ( upcfg-log "~%" )
 
   ( catch #t
     ( lambda()
@@ -184,7 +193,7 @@
   ; write new config file (lepton*.conf):
   ;
 
-  ( format #t "~%" )
+  ( upcfg-log "~%" )
 
   ( config-set-legacy-mode! #f ) ; use lepton*.conf files
 
@@ -198,7 +207,7 @@
     ( throw 'outfile "Output config file already exists:" fname )
   )
 
-  ( format #t "ii: OUTPUT: ~a~%" fname )
+  ( upcfg-log "ii: OUTPUT: ~a~%" fname )
 
   ( catch #t
     ( lambda()

--- a/liblepton/scheme/lepton/legacy-config.scm
+++ b/liblepton/scheme/lepton/legacy-config.scm
@@ -471,3 +471,34 @@ https://github.com/lepton-eda/lepton-eda/wiki/Configuration-Settings
 ) ; let
 ) ; upgrade-ctx()
 
+
+
+; - create tmp dir
+; - copy config file [fpath] to tmp file in tmp dir
+; - upgrade config in that tmp file
+;
+( define ( upgrade-file fpath )
+( let
+  (
+  ( ctx #f )
+  )
+
+  ( upcfg-mkdir (upcfg-tmp-dir) )
+  ( upcfg-copy-file fpath (upcfg-tmp-file) )
+
+  ( config-set-legacy-mode! #f )
+  ( set! ctx ( path-config-context (upcfg-tmp-dir) ) )
+
+  ( config-load! ctx #:force-load #t )
+  ( upgrade-ctx ctx )
+
+  ( if ( config-changed? ctx )
+    ( upcfg-log "ii: config has been upgraded~%"  )   ; if
+    ( upcfg-log "ii: config has not been changed~%" ) ; else
+  )
+
+  ( config-save! ctx ) ; NOTE: config-save!() raises exception on failure
+
+) ; let
+) ; upgrade-file()
+

--- a/liblepton/scheme/lepton/legacy-config.scm
+++ b/liblepton/scheme/lepton/legacy-config.scm
@@ -29,15 +29,14 @@
 
 ; get configuration context
 ;
-; [what]: symbol: 'local, 'user or 'system
-; {ret}:  requested configuration context or #f on failure
+; [cfg-id]: symbol: 'geda-local, 'geda-user
+; {ret}:    requested configuration context or #f on failure
 ;
-( define ( get-cfg-ctx what )
+( define ( get-cfg-ctx cfg-id )
   ; return:
   ( cond
-    (  ( eq? what 'local  )  ( path-config-context (getcwd) )  )
-    (  ( eq? what 'user   )  ( user-config-context )           )
-    (  ( eq? what 'system )  ( system-config-context )         )
+    (  ( eq? cfg-id 'geda-local )  ( path-config-context (getcwd) )  )
+    (  ( eq? cfg-id 'geda-user  )  ( user-config-context )           )
     (  else #f  )
   )
 )
@@ -128,13 +127,13 @@
 ; config-upgrade(): upgrade legacy gEDA configuration
 ;
 ; Read legacy gEDA configuration from geda.conf (in current
-; directory), geda-user.conf or geda-system.conf file,
+; directory) or geda-user.conf file,
 ; convert it (using new names) and produce the corresponding
 ; lepton*.conf configuration file.
 ; We get conversion information (list of keys, old and new names) from
 ; the list structure defined in the (lepton legacy-config keylist) module.
 ;
-; [what]:                'local, 'user or 'system - config to convert
+; [cfg-id]:              'geda-local, 'geda-user - config to convert
 ; [report-absent-keys]:  print messages about missing keys in old cfg file
 ; [overwrite]:           if #t, overwrite existing new cfg file
 ; {thr}:                 'ctx 'infile 'load 'outfile 'save
@@ -147,7 +146,7 @@
 ; - 'outfile:  output config file already exists
 ; - 'save:     cannot write output config file
 ;
-( define* ( config-upgrade what #:key (report-absent-keys #f) (overwrite #f) )
+( define* ( config-upgrade cfg-id #:key (report-absent-keys #f) (overwrite #f) )
 ( let
   (
   ( cfg    #f )
@@ -162,7 +161,7 @@
 
   ( config-set-legacy-mode! #t ) ; use geda*.conf files
 
-  ( set! cfg ( get-cfg-ctx what ) )
+  ( set! cfg ( get-cfg-ctx cfg-id ) )
   ( unless cfg
     ( throw 'ctx "Cannot get config context (input)" )
   )
@@ -197,7 +196,7 @@
 
   ( config-set-legacy-mode! #f ) ; use lepton*.conf files
 
-  ( set! cfg ( get-cfg-ctx what ) )
+  ( set! cfg ( get-cfg-ctx cfg-id ) )
   ( unless cfg
     ( throw 'ctx "Cannot get config context (output)" )
   )

--- a/liblepton/scheme/lepton/legacy-config.scm
+++ b/liblepton/scheme/lepton/legacy-config.scm
@@ -19,6 +19,7 @@
   #:export      ( config-upgrade )
   #:export      ( config-upgrade-file )
   #:export      ( config-file-path )
+  #:export      ( find-user-config-files )
   #:export      ( warning-option-deprecated )
   #:export      ( warning-option-obsolete )
 )
@@ -606,4 +607,35 @@ https://github.com/lepton-eda/lepton-eda/wiki/Configuration-Settings
 
 ) ; let
 ) ; config-upgrade-file()
+
+
+
+; public:
+;
+; Find available user configuration files.
+;
+; {ret}: list of config ids, sorted by file modification time
+;        (recently updated first).
+;
+( define ( find-user-config-files )
+
+  ( define ( mtime>? a b )
+    ( >
+      ( stat:mtime ( stat (config-file-path a) ) )
+      ( stat:mtime ( stat (config-file-path b) ) )
+    )
+  )
+
+( let*
+  (
+  ( ids (list 'geda-user1 'geda-user2 'geda-user3) )
+  ( ids-readable (filter config-file-readable? ids) )
+  ( ids-by-mtime (sort ids-readable mtime>?) )
+  )
+
+  ; return:
+  ids-by-mtime
+
+) ; let
+) ; find-user-config-files()
 

--- a/liblepton/scheme/lepton/legacy-config.scm
+++ b/liblepton/scheme/lepton/legacy-config.scm
@@ -12,7 +12,7 @@
   #:use-module  ( lepton legacy-config keylist )
 
   #:export      ( upcfg-log )
-  #:export      ( config-upgrade )
+  #:export      ( config-upgrade-old-keys )
   #:export      ( warning-option-deprecated )
   #:export      ( warning-option-obsolete )
 )
@@ -124,7 +124,12 @@
 
 ; public:
 ;
-; config-upgrade(): upgrade legacy gEDA configuration
+; Upgrade legacy gEDA configuration
+;
+; NOTE: this function writes the keys defined in the
+;       (lepton legacy-config keylist) module.
+;       All other keys defined in the source configuration
+;       file are ignored.
 ;
 ; Read legacy gEDA configuration from geda.conf (in current
 ; directory) or geda-user.conf file,
@@ -146,7 +151,7 @@
 ; - 'outfile:  output config file already exists
 ; - 'save:     cannot write output config file
 ;
-( define* ( config-upgrade cfg-id #:key (report-absent-keys #f) (overwrite #f) )
+( define* ( config-upgrade-old-keys cfg-id #:key (report-absent-keys #f) (overwrite #f) )
 ( let
   (
   ( cfg    #f )
@@ -222,7 +227,7 @@
   fname
 
 ) ; let
-) ; config-upgrade()
+) ; config-upgrade-old-keys()
 
 
 

--- a/liblepton/scheme/lepton/legacy-config.scm
+++ b/liblepton/scheme/lepton/legacy-config.scm
@@ -17,6 +17,7 @@
   #:export      ( upcfg-log )
   #:export      ( config-upgrade-old-keys )
   #:export      ( config-upgrade )
+  #:export      ( config-upgrade-file )
   #:export      ( warning-option-deprecated )
   #:export      ( warning-option-obsolete )
 )
@@ -566,4 +567,42 @@ https://github.com/lepton-eda/lepton-eda/wiki/Configuration-Settings
 
 ) ; let
 ) ; config-upgrade()
+
+
+
+; public:
+;
+; Upgrade legacy gEDA configuration read from file [fpath],
+; print result to standard output.
+;
+; {thr}: does not throw exceptions
+; {ret}: #t on success, #f on failure
+;
+( define ( config-upgrade-file fpath )
+( let
+  (
+  ( res #f )
+  )
+
+  ( catch #t
+  ( lambda()
+    ( unless ( access? fpath R_OK )
+      ( throw 'src-file "cannot read config file" fpath )
+    )
+
+    ( upgrade-file fpath )
+    ( upcfg-print-file (upcfg-tmp-file) )
+
+    ( set! res #t )
+  )
+  ( lambda( ex . args )
+    ( upcfg-log "ee: ['~a]:~%  ~s~%" ex args )
+  )
+  ) ; catch()
+
+  ; return:
+  res
+
+) ; let
+) ; config-upgrade-file()
 

--- a/liblepton/scheme/lepton/legacy-config.scm
+++ b/liblepton/scheme/lepton/legacy-config.scm
@@ -18,6 +18,7 @@
   #:export      ( config-upgrade-old-keys )
   #:export      ( config-upgrade )
   #:export      ( config-upgrade-file )
+  #:export      ( config-file-path )
   #:export      ( warning-option-deprecated )
   #:export      ( warning-option-obsolete )
 )

--- a/liblepton/scheme/lepton/legacy-config.scm
+++ b/liblepton/scheme/lepton/legacy-config.scm
@@ -11,6 +11,7 @@
   #:use-module  ( ice-9 rdelim )  ; read-string()
   #:use-module  ( lepton config )
   #:use-module  ( lepton os )
+  #:use-module  ( lepton log )
   #:use-module  ( lepton legacy-config keylist )
 
   #:export      ( upcfg-log )
@@ -25,9 +26,16 @@
 ; public:
 ;
 ( define ( upcfg-log fmt . args )
-  ( apply format (current-error-port) fmt args )
-  ; ( apply log! 'message fmt args )
-)
+( let
+  (
+  ( msg ( apply format #f fmt args ) )
+  )
+
+  ( format (current-error-port) "~a" msg )
+  ( log! 'message "~a" (string-trim-right msg #\newline) )
+
+) ; let
+) ; upcfg-log()
 
 
 ; get configuration context

--- a/liblepton/scheme/lepton/legacy-config.scm
+++ b/liblepton/scheme/lepton/legacy-config.scm
@@ -538,7 +538,15 @@ https://github.com/lepton-eda/lepton-eda/wiki/Configuration-Settings
 ( let
   (
   ( res #f )
+  ( target-id (target-cfg-id cfg-id) )
   )
+
+  ( define ( mk-user-cfg-dir )
+    ( unless ( file-exists? (user-config-dir) )
+      ( upcfg-mkdir (user-config-dir) )
+    )
+  )
+
 
   ( catch #t
   ( lambda()
@@ -548,10 +556,14 @@ https://github.com/lepton-eda/lepton-eda/wiki/Configuration-Settings
 
     ( upgrade-file (config-file-path cfg-id) )
 
+    ( if ( and copy (eq? target-id 'lepton-user) )
+      ( mk-user-cfg-dir )
+    )
+
     ( if copy
       ( upcfg-copy-file ; if
         ( upcfg-tmp-file )
-        ( config-file-path (target-cfg-id cfg-id) )
+        ( config-file-path target-id )
         #:overwrite overwrite
       )
       ( upcfg-print-file (upcfg-tmp-file) ) ; else

--- a/liblepton/scheme/lepton/legacy-config/keylist.scm
+++ b/liblepton/scheme/lepton/legacy-config/keylist.scm
@@ -17,8 +17,6 @@
 ( define pfn-get-bool     config-boolean     )
 ( define pfn-get-str      config-string      )
 ( define pfn-get-str-list config-string-list )
-( define pfn-get-int      config-int         )
-( define pfn-get-int-list config-int-list    )
 
 
 
@@ -125,127 +123,6 @@
          "schematic" "default-filename"
   )
 
-  ; --------------------------------------------------------
-
-  ; group: export
-  ;
-  ( list pfn-get-str "auto" ; TODO: real-list? "auto" | HALIGN;VALIGN
-         "export" "align"
-         "export" "align"
-  )
-  ( list pfn-get-int 96
-         "export" "dpi"
-         "export" "dpi"
-  )
-  ( list pfn-get-str "Sans"
-         "export" "font"
-         "export" "font"
-  )
-  ( list pfn-get-str "auto"
-         "export" "layout"
-         "export" "layout"
-  )
-  ( list pfn-get-int-list (list 18 18 18 18)
-         "export" "margins"
-         "export" "margins"
-  )
-  ( list pfn-get-bool #f
-         "export" "monochrome"
-         "export" "monochrome"
-  )
-  ( list pfn-get-str ""
-         "export" "paper"
-         "export" "paper"
-  )
-  ( list pfn-get-str ""
-         "export" "size"
-         "export" "size"
-  )
-
-  ; --------------------------------------------------------
-
-  ; group: schematic.gui
-  ;
-  ( list pfn-get-bool #f
-         "schematic.gui" "use-tabs"
-         "schematic.gui" "use-tabs"
-  )
-  ( list pfn-get-bool #t
-         "schematic.gui" "use-docks"
-         "schematic.gui" "use-docks"
-  )
-  ( list pfn-get-str ""
-         "schematic.gui" "font"
-         "schematic.gui" "font"
-  )
-  ( list pfn-get-int 10
-         "schematic.gui" "max-recent-files"
-         "schematic.gui" "max-recent-files"
-  )
-  ( list pfn-get-int-list '()
-         "schematic.gui" "text-sizes"
-         "schematic.gui" "text-sizes"
-  )
-
-  ; group: schematic.status-bar
-  ;
-  ( list pfn-get-bool #t
-         "schematic.status-bar" "show-mouse-buttons"
-         "schematic.status-bar" "show-mouse-buttons"
-  )
-  ( list pfn-get-bool #f
-         "schematic.status-bar" "show-rubber-band"
-         "schematic.status-bar" "show-rubber-band"
-  )
-  ( list pfn-get-bool #f
-         "schematic.status-bar" "show-magnetic-net"
-         "schematic.status-bar" "show-magnetic-net"
-  )
-  ( list pfn-get-bool #f
-         "schematic.status-bar" "status-bold-font"
-         "schematic.status-bar" "status-bold-font"
-  )
-  ( list pfn-get-str "green"
-         "schematic.status-bar" "status-active-color"
-         "schematic.status-bar" "status-active-color"
-  )
-
-  ; group: schematic.macro-widget
-  ;
-  ( list pfn-get-int 10
-         "schematic.macro-widget" "history-length"
-         "schematic.macro-widget" "history-length"
-  )
-  ( list pfn-get-str ""
-         "schematic.macro-widget" "font"
-         "schematic.macro-widget" "font"
-  )
-
-  ; group: schematic.undo
-  ;
-  ( list pfn-get-bool #f
-         "schematic.undo" "modify-viewport"
-         "schematic.undo" "modify-viewport"
-  )
-
-  ; group: schematic.tabs
-  ;
-  ( list pfn-get-bool #t
-         "schematic.tabs" "show-close-button"
-         "schematic.tabs" "show-close-button"
-  )
-  ( list pfn-get-bool #t
-         "schematic.tabs" "show-up-button"
-         "schematic.tabs" "show-up-button"
-  )
-
-  ; group: schematic.log-window
-  ;
-  ( list pfn-get-str ""
-         "schematic.log-window" "font"
-         "schematic.log-window" "font"
-  )
-
 ) ; list()
 ) ; keys-list
 
@@ -259,8 +136,4 @@
   ; return:
   keys-list
 )
-
-
-
-; vim: ft=scheme tabstop=2 softtabstop=2 shiftwidth=2 expandtab
 

--- a/liblepton/src/edaconfig.c
+++ b/liblepton/src/edaconfig.c
@@ -78,6 +78,14 @@ config_set_legacy_mode(gboolean legacy)
 
 
 
+gboolean
+config_get_legacy_mode()
+{
+  return config_legacy_mode;
+}
+
+
+
 /*! Legacy configuration file names:
  */
 #define CONFIG_FILENAME_LEGACY_SYSTEM "geda-system.conf"
@@ -101,7 +109,7 @@ config_set_legacy_mode(gboolean legacy)
 static const gchar*
 cfg_filename_system()
 {
-  if (config_legacy_mode)
+  if (config_get_legacy_mode())
     return CONFIG_FILENAME_LEGACY_SYSTEM;
   else
     return CONFIG_FILENAME_SYSTEM;
@@ -114,7 +122,7 @@ cfg_filename_system()
 static const gchar*
 cfg_filename_user()
 {
-  if (config_legacy_mode)
+  if (config_get_legacy_mode())
     return CONFIG_FILENAME_LEGACY_USER;
   else
     return CONFIG_FILENAME_USER;
@@ -127,7 +135,7 @@ cfg_filename_user()
 static const gchar*
 cfg_filename_local()
 {
-  if (config_legacy_mode)
+  if (config_get_legacy_mode())
     return CONFIG_FILENAME_LEGACY_LOCAL;
   else
     return CONFIG_FILENAME_LOCAL;
@@ -509,7 +517,7 @@ create_config_system()
 EdaConfig *
 eda_config_get_system_context ()
 {
-  if (config_legacy_mode)
+  if (config_get_legacy_mode())
   {
     if (g_once_init_enter (&g_context_system_legacy))
     {
@@ -524,7 +532,7 @@ eda_config_get_system_context ()
     }
   }
 
-  return config_legacy_mode ? g_context_system_legacy : g_context_system;
+  return config_get_legacy_mode() ? g_context_system_legacy : g_context_system;
 }
 
 
@@ -573,7 +581,7 @@ create_config_user()
 EdaConfig *
 eda_config_get_user_context ()
 {
-  if (config_legacy_mode)
+  if (config_get_legacy_mode())
   {
     if (g_once_init_enter (&g_context_user_legacy))
     {
@@ -588,7 +596,7 @@ eda_config_get_user_context ()
     }
   }
 
-  return config_legacy_mode ? g_context_user_legacy : g_context_user;
+  return config_get_legacy_mode() ? g_context_user_legacy : g_context_user;
 }
 
 

--- a/liblepton/src/scheme_config.c
+++ b/liblepton/src/scheme_config.c
@@ -1264,7 +1264,7 @@ SCM_DEFINE (config_remove_group, "%config-remove-group!", 2, 0, 0,
  *
  * \param legacy_s  Boolean: set legacy mode or not.
  *
- * \return         SCM_BOOL_T.
+ * \return  Previously set config mode: SCM_BOOL_T - legacy, SCM_BOOL_F otherwise.
  */
 SCM_DEFINE (config_set_legacy_mode_x, "%config-set-legacy-mode!", 1, 0, 0,
             (SCM  legacy_s),
@@ -1272,9 +1272,11 @@ SCM_DEFINE (config_set_legacy_mode_x, "%config-set-legacy-mode!", 1, 0, 0,
 {
   SCM_ASSERT (scm_is_bool (legacy_s), legacy_s, SCM_ARG1, s_config_set_legacy_mode_x);
 
+  gboolean result = config_get_legacy_mode();
+
   config_set_legacy_mode (scm_to_bool (legacy_s));
 
-  return SCM_BOOL_T;
+  return result ? SCM_BOOL_T : SCM_BOOL_F;
 }
 
 

--- a/liblepton/src/scheme_config.c
+++ b/liblepton/src/scheme_config.c
@@ -1279,6 +1279,30 @@ SCM_DEFINE (config_set_legacy_mode_x, "%config-set-legacy-mode!", 1, 0, 0,
 
 
 
+/*! \brief Test whether legacy configuration mode is currently in use.
+ *
+ * \par Function Description
+ * This function is added to assist in config migration and
+ * not intended for the end user.
+ * It will be removed.
+ *
+ * \see config_get_legacy_mode().
+ *
+ * \note Scheme API: Implements the \%config-legacy-mode?
+ * procedure in the (lepton core config) module.
+ *
+ * \return  SCM_BOOL_T or SCM_BOOL_F.
+ */
+SCM_DEFINE (config_legacy_mode_p, "%config-legacy-mode?", 0, 0, 0,
+            (), "Whether legacy configuration mode is used.")
+{
+  gboolean result = config_get_legacy_mode();
+
+  return result ? SCM_BOOL_T : SCM_BOOL_F;
+}
+
+
+
 /*!
  * \brief Create the (lepton core config) Scheme module.
  * \par Function Description
@@ -1324,6 +1348,7 @@ init_module_lepton_core_config (void *unused)
                 s_config_remove_key,
                 s_config_remove_group,
                 s_config_set_legacy_mode_x,
+                s_config_legacy_mode_p,
                 NULL);
 }
 

--- a/utils/scripts/lepton-upcfg.in
+++ b/utils/scripts/lepton-upcfg.in
@@ -101,9 +101,8 @@ Lepton EDA homepage: <~a>
   (
   ( cmd-line-args '() )
   ( args-len       0  )
-  ( what           #f )
+  ( cfg-id         #f )
   ( overwrite      #f )
-  ( fname          #f )
   )
 
   ( set! cmd-line-args
@@ -123,13 +122,13 @@ Lepton EDA homepage: <~a>
   )
 
   ( if (option-ref cmd-line-args 'local #f)
-    ( set! what 'local )
+    ( set! cfg-id 'geda-local )
   )
   ( if (option-ref cmd-line-args 'user #f)
-    ( set! what 'user )
+    ( set! cfg-id 'geda-user )
   )
 
-  ( unless what
+  ( unless cfg-id
     ( usage 1 )
   )
 
@@ -138,10 +137,8 @@ Lepton EDA homepage: <~a>
 
   ( catch #t
     ( lambda()
-      ( upcfg-log "ii: converting [~a] configuration...~%~%" what )
-      ( set! fname
-        ( config-upgrade what #:report-absent-keys #f #:overwrite overwrite )
-      )
+      ( upcfg-log "ii: converting [~a] configuration...~%~%" cfg-id )
+      ( config-upgrade cfg-id #:report-absent-keys #f #:overwrite overwrite )
     )
     ( lambda( ex . args )
       ( upcfg-log "ee: config-upgrade() failed: ['~a]~%  ~a~%" ex args )

--- a/utils/scripts/lepton-upcfg.in
+++ b/utils/scripts/lepton-upcfg.in
@@ -18,6 +18,7 @@ exec @GUILE@ "$0" "$@"
 ; from netlist/scheme/lepton-netlist.in (see comments there):
 ;
 ( primitive-eval '(use-modules (ice-9 format)) )
+( primitive-eval '(use-modules (ice-9 rdelim)) ) ; read-line()
 ( primitive-eval '(use-modules (lepton legacy-config)) )
 ( primitive-eval '(use-modules (ice-9 getopt-long)) )
 ( primitive-eval '(use-modules (lepton version)) )
@@ -116,6 +117,69 @@ Lepton EDA homepage: <~a>
 
 
 
+( define ( prompt-for-user-cfg ids )
+( let
+  (
+  ( i 0 )
+  ( ndx #f )
+  )
+
+  ( define ( input-error )
+    ( upcfg-log "ee: wrong value entered~%" )
+    ( failure )
+  )
+
+  ( upcfg-log "ii: more than one user configuration files found:~%" )
+  ( while ( < i (length ids) )
+    ( upcfg-log "~d: ~a~%" (1+ i) (config-file-path (list-ref ids i)) )
+    ( set! i (1+ i) )
+  )
+
+  ( upcfg-log "Type config file number to upgrade and press Enter: " )
+  ( set! ndx (false-if-exception (read-line)) )
+  ( set! ndx (false-if-exception (string->number ndx)) )
+
+  ( unless ndx
+    ( input-error )
+  )
+
+  ( upcfg-log "ii: choice: [ ~a ]~%" ndx )
+  ( set! ndx ( 1- ndx ) )
+  ( if ( or (< ndx 0) (>= ndx (length ids)) )
+    ( input-error )
+  )
+
+  ; return:
+  ( list-ref ids ndx )
+
+) ; let
+) ; prompt-for-user-cfg()
+
+
+
+( define ( get-user-cfg-id )
+( let
+  (
+  ( ids (find-user-config-files) )
+  )
+
+  ( when ( null? ids )
+    ( upcfg-log "ii: no user configuration files found.~%" )
+    ( primitive-exit 0 )
+  )
+
+  ; return:
+  ( if ( > (length ids) 1 )
+    ( prompt-for-user-cfg ids ) ; if
+    ( list-ref ids 0 )          ; else
+  )
+
+) ; let
+) ; get-user-cfg-id()
+
+
+
+
 ; program entry point:
 ;
 ( define ( main )
@@ -147,7 +211,7 @@ Lepton EDA homepage: <~a>
     ( set! cfg-id 'geda-local )
   )
   ( if (option-ref cmd-line-args 'user #f)
-    ( set! cfg-id 'geda-user3 )
+    ( set! cfg-id ( get-user-cfg-id ) )
   )
 
   ( if ( and (null? files) (not cfg-id) )

--- a/utils/scripts/lepton-upcfg.in
+++ b/utils/scripts/lepton-upcfg.in
@@ -66,13 +66,19 @@ exec @GUILE@ "$0" "$@"
 
 ( define ( usage exit-code )
   ( format #t "~
-Usage: lepton-upcfg -l | -u | -o [-c] [-x]
+Usage: lepton-upcfg [OPTIONS] | FILE
 
 Lepton EDA configuration upgrade utility.
 Converts geda*.conf configuration files
 to corresponding lepton*.conf files.
 By default, the upgraded configuration
 is printed to standard output.
+One of the options can be passed on the
+command line to upgrade the configuration
+located in predefined locations. Instead of
+the options, one can specify the
+configuration file path to convert and
+redirect the output to some destination file.
 
 Options:
   -l, --local      geda.conf => lepton.conf
@@ -106,21 +112,24 @@ Lepton EDA homepage: <~a>
 ; program entry point:
 ;
 ( define ( main )
-( let
+( let*
   (
-  ( cmd-line-args '() )
-  ( args-len       0  )
-  ( cfg-id         #f )
-  ( copy           #f )
-  ( overwrite      #f )
+  ( cmd-line-args (getopt-long (program-arguments) cmd-line-args-spec) )
+  ( files         (option-ref cmd-line-args '() '()) )
+  ( copy          (option-ref cmd-line-args 'copy #f) )
+  ( overwrite     (option-ref cmd-line-args 'overwrite #f) )
+  ( args-len      0  )
+  ( cfg-id        #f )
   )
 
-  ( set! cmd-line-args
-    ( getopt-long (program-arguments) cmd-line-args-spec )
+  ( define ( failure )
+    ( upcfg-log "lepton-upcfg: configuration upgrade failed.~%" )
+    ( primitive-exit 1 )
   )
+
 
   ( set! args-len (length cmd-line-args) )
-  ( when ( or (< args-len 2) (> args-len 4) )
+  ( when ( and (null? files) (or (< args-len 2) (> args-len 4)) )
     ( usage 1 )
   )
 
@@ -138,21 +147,18 @@ Lepton EDA homepage: <~a>
     ( set! cfg-id 'geda-user3 )
   )
 
-  ( unless cfg-id
+  ( if ( and (null? files) (not cfg-id) )
     ( usage 1 )
   )
-
-  ( set! copy      (option-ref cmd-line-args 'copy      #f) )
-  ( set! overwrite (option-ref cmd-line-args 'overwrite #f) )
 
 
   ( init-log "upcfg" )
 
   ( upcfg-log "ii: converting [~a] configuration...~%" cfg-id )
 
-  ( unless ( config-upgrade cfg-id #:copy copy #:overwrite overwrite )
-    ( upcfg-log "lepton-upcfg: configuration upgrade failed.~%" )
-    ( primitive-exit 1 )
+  ( if ( null? files )
+    ( or (config-upgrade cfg-id #:copy copy #:overwrite overwrite) (failure) ) ; if
+    ( or (config-upgrade-file (list-ref files 0))                  (failure) ) ; else
   )
 
 ) ; let

--- a/utils/scripts/lepton-upcfg.in
+++ b/utils/scripts/lepton-upcfg.in
@@ -38,6 +38,11 @@ exec @GUILE@ "$0" "$@"
     ( list 'single-char #\u )
     ( list 'value        #f )
   )
+  ( list ; --copy (-c)
+    'copy
+    ( list 'single-char #\c )
+    ( list 'value        #f )
+  )
   ( list ; --overwrite (-x)
     'overwrite
     ( list 'single-char #\x )
@@ -60,17 +65,20 @@ exec @GUILE@ "$0" "$@"
 
 ( define ( usage exit-code )
   ( format #t "~
-Usage: lepton-upcfg -l | -u | [-x] | -h | -V
+Usage: lepton-upcfg -l | -u | -o [-c] [-x]
 
 Lepton EDA configuration upgrade utility.
 Converts geda*.conf configuration files
 to corresponding lepton*.conf files.
+By default, the upgraded configuration
+is printed to standard output.
 
 Options:
   -l, --local      geda.conf => lepton.conf
                    (in current directory)
   -u, --user       geda-user.conf => lepton-user.conf
                    (in user configuration directory)
+  -c, --copy       Write to configuration file, not STDOUT
   -x, --overwrite  Overwrite existing files
   -h, --help       Show usage information
   -V, --version    Show version information
@@ -102,6 +110,7 @@ Lepton EDA homepage: <~a>
   ( cmd-line-args '() )
   ( args-len       0  )
   ( cfg-id         #f )
+  ( copy           #f )
   ( overwrite      #f )
   )
 
@@ -110,7 +119,7 @@ Lepton EDA homepage: <~a>
   )
 
   ( set! args-len (length cmd-line-args) )
-  ( when ( or (< args-len 2) (> args-len 3) )
+  ( when ( or (< args-len 2) (> args-len 4) )
     ( usage 1 )
   )
 
@@ -132,12 +141,13 @@ Lepton EDA homepage: <~a>
     ( usage 1 )
   )
 
+  ( set! copy      (option-ref cmd-line-args 'copy      #f) )
   ( set! overwrite (option-ref cmd-line-args 'overwrite #f) )
 
 
   ( upcfg-log "ii: converting [~a] configuration...~%~%" cfg-id )
 
-  ( unless ( config-upgrade cfg-id #:overwrite overwrite )
+  ( unless ( config-upgrade cfg-id #:copy copy #:overwrite overwrite )
     ( upcfg-log "lepton-upcfg: configuration upgrade failed.~%" )
     ( primitive-exit 1 )
   )

--- a/utils/scripts/lepton-upcfg.in
+++ b/utils/scripts/lepton-upcfg.in
@@ -21,6 +21,7 @@ exec @GUILE@ "$0" "$@"
 ( primitive-eval '(use-modules (lepton legacy-config)) )
 ( primitive-eval '(use-modules (ice-9 getopt-long)) )
 ( primitive-eval '(use-modules (lepton version)) )
+( primitive-eval '(use-modules (lepton log)) )
 
 
 
@@ -145,7 +146,9 @@ Lepton EDA homepage: <~a>
   ( set! overwrite (option-ref cmd-line-args 'overwrite #f) )
 
 
-  ( upcfg-log "ii: converting [~a] configuration...~%~%" cfg-id )
+  ( init-log "upcfg" )
+
+  ( upcfg-log "ii: converting [~a] configuration...~%" cfg-id )
 
   ( unless ( config-upgrade cfg-id #:copy copy #:overwrite overwrite )
     ( upcfg-log "lepton-upcfg: configuration upgrade failed.~%" )

--- a/utils/scripts/lepton-upcfg.in
+++ b/utils/scripts/lepton-upcfg.in
@@ -38,11 +38,6 @@ exec @GUILE@ "$0" "$@"
     ( list 'single-char #\u )
     ( list 'value        #f )
   )
-  ( list ; --system (-s)
-    'system
-    ( list 'single-char #\s )
-    ( list 'value        #f )
-  )
   ( list ; --overwrite (-x)
     'overwrite
     ( list 'single-char #\x )
@@ -65,7 +60,7 @@ exec @GUILE@ "$0" "$@"
 
 ( define ( usage exit-code )
   ( format #t "~
-Usage: lepton-upcfg -l | -u | -s [-x] | -h | -V
+Usage: lepton-upcfg -l | -u | [-x] | -h | -V
 
 Lepton EDA configuration upgrade utility.
 Converts geda*.conf configuration files
@@ -76,8 +71,6 @@ Options:
                    (in current directory)
   -u, --user       geda-user.conf => lepton-user.conf
                    (in user configuration directory)
-  -s, --system     geda-system.conf => lepton-system.conf
-                   (in system configuration directory)
   -x, --overwrite  Overwrite existing files
   -h, --help       Show usage information
   -V, --version    Show version information
@@ -134,9 +127,6 @@ Lepton EDA homepage: <~a>
   )
   ( if (option-ref cmd-line-args 'user #f)
     ( set! what 'user )
-  )
-  ( if (option-ref cmd-line-args 'system #f)
-    ( set! what 'system )
   )
 
   ( unless what

--- a/utils/scripts/lepton-upcfg.in
+++ b/utils/scripts/lepton-upcfg.in
@@ -125,7 +125,7 @@ Lepton EDA homepage: <~a>
     ( set! cfg-id 'geda-local )
   )
   ( if (option-ref cmd-line-args 'user #f)
-    ( set! cfg-id 'geda-user )
+    ( set! cfg-id 'geda-user3 )
   )
 
   ( unless cfg-id
@@ -135,14 +135,11 @@ Lepton EDA homepage: <~a>
   ( set! overwrite (option-ref cmd-line-args 'overwrite #f) )
 
 
-  ( catch #t
-    ( lambda()
-      ( upcfg-log "ii: converting [~a] configuration...~%~%" cfg-id )
-      ( config-upgrade cfg-id #:report-absent-keys #f #:overwrite overwrite )
-    )
-    ( lambda( ex . args )
-      ( upcfg-log "ee: config-upgrade() failed: ['~a]~%  ~a~%" ex args )
-    )
+  ( upcfg-log "ii: converting [~a] configuration...~%~%" cfg-id )
+
+  ( unless ( config-upgrade cfg-id #:overwrite overwrite )
+    ( upcfg-log "lepton-upcfg: configuration upgrade failed.~%" )
+    ( primitive-exit 1 )
   )
 
 ) ; let

--- a/utils/scripts/lepton-upcfg.in
+++ b/utils/scripts/lepton-upcfg.in
@@ -138,13 +138,13 @@ Lepton EDA homepage: <~a>
 
   ( catch #t
     ( lambda()
-      ( format #t "ii: converting [~a] configuration...~%~%" what )
+      ( upcfg-log "ii: converting [~a] configuration...~%~%" what )
       ( set! fname
         ( config-upgrade what #:report-absent-keys #f #:overwrite overwrite )
       )
     )
     ( lambda( ex . args )
-      ( format #t "xx: config-upgrade() failed: ['~a]~%  ~a~%" ex args )
+      ( upcfg-log "ee: config-upgrade() failed: ['~a]~%  ~a~%" ex args )
     )
   )
 

--- a/utils/scripts/lepton-upcfg.in
+++ b/utils/scripts/lepton-upcfg.in
@@ -154,7 +154,7 @@ Lepton EDA homepage: <~a>
 
   ( init-log "upcfg" )
 
-  ( upcfg-log "ii: converting [~a] configuration...~%" cfg-id )
+  ( upcfg-log "ii: upgrading config in [~a]...~%" (config-file-path cfg-id) )
 
   ( if ( null? files )
     ( or (config-upgrade cfg-id #:copy copy #:overwrite overwrite) (failure) ) ; if

--- a/utils/scripts/lepton-upcfg.in
+++ b/utils/scripts/lepton-upcfg.in
@@ -109,6 +109,13 @@ Lepton EDA homepage: <~a>
 
 
 
+( define ( failure )
+  ( upcfg-log "lepton-upcfg: configuration upgrade failed.~%" )
+  ( primitive-exit 1 )
+)
+
+
+
 ; program entry point:
 ;
 ( define ( main )
@@ -122,11 +129,7 @@ Lepton EDA homepage: <~a>
   ( cfg-id        #f )
   )
 
-  ( define ( failure )
-    ( upcfg-log "lepton-upcfg: configuration upgrade failed.~%" )
-    ( primitive-exit 1 )
-  )
-
+  ( init-log "upcfg" )
 
   ( set! args-len (length cmd-line-args) )
   ( when ( and (null? files) (or (< args-len 2) (> args-len 4)) )
@@ -151,8 +154,6 @@ Lepton EDA homepage: <~a>
     ( usage 1 )
   )
 
-
-  ( init-log "upcfg" )
 
   ( upcfg-log "ii: upgrading config in [~a]...~%" (config-file-path cfg-id) )
 


### PR DESCRIPTION
- source configuration file is copied before the conversion, so that
custom settings and comments are preserved.
- remove the `--system` command line option: `geda-gaf` has no system
configuration file, lepton-eda already provides one with new settings,
so there is no point in converting system config.
- print upgraded configuration file contents to standard output by
default; to copy resulting configuration file to appropriate location,
use (new) `--copy` (`-c`) command line option.
- to convert `geda-user.conf` in `~/.gEDA/` directory, the `--old`
(`-o`) command line option has been added.