### PR TITLE
lepton-schematic: Fix translation messages and update PO file.

### DIFF
--- a/schematic/po/af.po
+++ b/schematic/po/af.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda-gschem\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-10-03 23:34+0300\n"
+"POT-Creation-Date: 2020-03-18 20:44+0300\n"
 "PO-Revision-Date: 2010-02-14 01:03+0000\n"
 "Last-Translator: Bernd Jendrissek <Unknown>\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -20,6 +20,13 @@ msgstr ""
 #, fuzzy
 msgid "Zoom too small!  Cannot zoom further."
 msgstr "Zoem is te klein!  Kan nie verder zoem nie.\n"
+
+msgid ""
+"Save your color scheme to a file by clicking on the \"Save As...\"\n"
+"button. It can be loaded on startup with the following\n"
+"expression in the gschemrc configuration file:\n"
+"( primitive-load \"/path/to/saved-color-scheme-file\" )"
+msgstr ""
 
 #, fuzzy, c-format
 msgid ""
@@ -47,6 +54,11 @@ msgstr ""
 msgid "Sa_ve..."
 msgstr ""
 
+msgid ""
+"After you're done choosing the font, it's recommended\n"
+"to reopen schematics or restart the application."
+msgstr ""
+
 #, c-format
 msgid "<b>Current:</b> %s"
 msgstr ""
@@ -54,24 +66,20 @@ msgstr ""
 msgid "Save configuration"
 msgstr ""
 
-#, fuzzy
-msgid "Save settings to:"
-msgstr "Instellinge"
-
-msgid "Local configuration file (in current directory)"
+msgid "Local configuration file:"
 msgstr ""
 
-msgid "User configuration file (geda-user.conf)"
+msgid "User configuration file:"
 msgstr ""
 
-msgid "Object ~A is not included in the current gschem page."
+msgid "Object ~A is not included in the current lepton-schematic page."
 msgstr ""
 
 msgid "Invalid text name/value visibility ~A."
 msgstr ""
 
 #, fuzzy, c-format
-msgid "You are running gEDA/gaf version [%1$s%2$s.%3$s],\n"
+msgid "You are running lepton-schematic version [%1$s%2$s.%3$s],\n"
 msgstr "gEDA/gschem uitgawe %s%s.%s\n"
 
 #, c-format
@@ -84,65 +92,13 @@ msgstr ""
 msgid "Please be sure that you have the latest rc file.\n"
 msgstr ""
 
-#, fuzzy, c-format
-msgid "Invalid size [%1$d] passed to text-size\n"
-msgstr "Ongeldige grootte [%d] gegee aan text-size\n"
-
-#, fuzzy, c-format
-msgid "Invalid size [%1$d] passed to snap-size\n"
-msgstr "Ongeldige grootte [%d] aan snap-size gegee\n"
-
-#, fuzzy, c-format
-msgid "Invalid num levels [%1$d] passed to undo-levels\n"
-msgstr "Ongeldige getal vlakke [%d] gegee aan undo-levels\n"
-
-#, fuzzy, c-format
-msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
-msgstr "Ongeldige grootte [%d] gegee aan bus-ripper-size\n"
-
-#, fuzzy, c-format
-msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
-msgstr "Ongeldige puntgrootte [%d] gegee aan dots-grid-dot-size\n"
-
-#, fuzzy, c-format
-msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
-msgstr "Ongeldige puntgrootte [%d] gegee aan dots-grid-dot-size\n"
-
-#, fuzzy, c-format
-msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
-msgstr "Ongeldige puntgrootte [%d] gegee aan dots-grid-dot-size\n"
-
-#, fuzzy, c-format
-msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
-msgstr "Ongeldige hoeveelheid sekondes [%d] gegee aan auto-save-interval\n"
-
-#, fuzzy, c-format
-msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
-msgstr "Ongeldige versterking [%d] gegee aan mousepan-gain\n"
-
-#, fuzzy, c-format
-msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
-msgstr "Ongeldige versterking [%d] gegee aan keyboardpan-gain\n"
-
-#, fuzzy, c-format
-msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
-msgstr "Ongeldige hoeveelheid sekondes [%d] gegee aan auto-save-interval\n"
-
-#, fuzzy, c-format
-msgid "Invalid gain [%1$d] passed to zoom-gain\n"
-msgstr "Ongeldige versterking [%d] gegee aan zoom-gain\n"
-
-#, fuzzy, c-format
-msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
-msgstr "Ongeldige hoeveelheid sekondes [%d] gegee aan auto-save-interval\n"
-
 msgid "Object ~A is not directly included in a page."
 msgstr ""
 
 msgid "Could not launch URI ~S: ~A"
 msgstr ""
 
-msgid "Found invalid gschem window smob ~S"
+msgid "Found invalid lepton-schematic window smob ~S"
 msgstr ""
 
 #, fuzzy, c-format
@@ -174,7 +130,7 @@ msgstr "gEDA: GPL Elektroniese Ontwerp Outomatisering"
 
 msgid ""
 "Copyright © 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright © 2017-2019 Lepton Developers.\n"
+"Copyright © 2017-2020 Lepton Developers.\n"
 "See AUTHORS, ChangeLog files and consult 'git log' history for details."
 msgstr ""
 
@@ -650,7 +606,8 @@ msgid ""
 "\n"
 "Are you sure you want to revert this page?\n"
 "All unsaved changes in current schematic will be\n"
-"discarded and page file will be reloaded from disk."
+"discarded and page file will be reloaded from disk.\n"
+"This action will also reload all component libraries."
 msgstr ""
 
 #, fuzzy
@@ -753,10 +710,6 @@ msgid_plural "Delete %1$u locked objects?"
 msgstr[0] ""
 msgstr[1] ""
 
-#, c-format
-msgid "Got an unexpected NULL in o_edit\n"
-msgstr "Het 'n onverwagte NULL in o_edit gekry\n"
-
 #, fuzzy
 msgid "Hidden text is now visible"
 msgstr "Verskuilde teks is nou sigbaar\n"
@@ -770,7 +723,7 @@ msgid "Could not find symbol [%1$s] in library. Update failed."
 msgstr ""
 
 #, fuzzy, c-format
-msgid "o_autosave_backups: Can't get the real filename of %1$s."
+msgid "Can't get the real filename of %1$s."
 msgstr "o_autosave_backups: Kan nie die egte lêernaam van %s kry nie."
 
 #, fuzzy, c-format
@@ -784,10 +737,6 @@ msgstr "Kon NIE bestandlêer [%s] lees-slegs stel nie\n"
 #, fuzzy, c-format
 msgid "Could NOT save backup file [%1$s]"
 msgstr "Kon NIE bestandlêer [%s] bewaar nie\n"
-
-#, c-format
-msgid "ERROR: NULL object in o_move_end!\n"
-msgstr "FOUT: NULL voorwerp in o_move_end!\n"
 
 # Thanks to Frank Shearar for reminding me of BLIKSEM!
 #, c-format
@@ -842,7 +791,7 @@ msgstr "Gleuwe is nie toegelaat vir hierdie komponent nie\n"
 msgid "New slot number out of range"
 msgstr "Nuwe gleufnommer buite bereik\n"
 
-msgid "Undo/Redo disabled in rc file"
+msgid "Undo/Redo is disabled in configuration"
 msgstr ""
 
 #, c-format
@@ -863,28 +812,13 @@ msgid ""
 "  -h, --help               Help; this message.\n"
 "  --                       Treat all remaining arguments as filenames.\n"
 "\n"
-"Report bugs at <https://github.com/lepton-eda/lepton-eda/issues>\n"
-"Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"Lepton EDA %1$s (git: %2$.7s)\n"
-"Copyright (C) 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright (C) 2017-2019 Lepton Developers.\n"
-"This is free software, and you are welcome to redistribute it under\n"
-"certain conditions. For details, see the file `COPYING', which is\n"
-"included in the Lepton EDA distribution.\n"
-"There is NO WARRANTY, to the extent permitted by law.\n"
+"Report bugs at <%2$s>\n"
+"Lepton EDA homepage: <%3$s>\n"
 msgstr ""
 
 #, c-format
 msgid "Got invalid show option; defaulting to show both\n"
 msgstr ""
-
-#, c-format
-msgid "ERROR: NULL object!\n"
-msgstr "FOUT: NULL voorwerp!\n"
 
 msgid "Single Attribute Editor"
 msgstr "Enkeleienskap-Bewerker"
@@ -943,7 +877,7 @@ msgid ""
 msgstr ""
 "duplikaatgleuf mag probleme veroorsaak: [symbolname=%s, number=%d, slot=%d]\n"
 
-msgid "No searchstring given in autonumber text."
+msgid "No search string given in autonumber text."
 msgstr ""
 
 msgid "No '*' or '?' given at the end of the autonumber text."
@@ -1018,24 +952,6 @@ msgstr ""
 
 msgid "Clipboard insertion failed"
 msgstr ""
-
-#, fuzzy, c-format
-msgid "Could not allocate the color %1$s!\n"
-msgstr "Kon nie aanspraak maak op die kleur %s nie!\n"
-
-msgid "black"
-msgstr "swart"
-
-msgid "white"
-msgstr "wit"
-
-#, fuzzy, c-format
-msgid "Could not allocate display color %1$i!\n"
-msgstr "Kon nie aanspraak maak op die kleur %s nie!\n"
-
-#, fuzzy, c-format
-msgid "Could not allocate outline color %1$i!\n"
-msgstr "Kon nie aanspraak maak op die kleur %s nie!\n"
 
 #, fuzzy, c-format
 msgid "Tried to get an invalid color: %1$d\n"
@@ -1185,13 +1101,16 @@ msgstr ""
 msgid "Invalid Attribute"
 msgstr "Ongeldige Eienskap"
 
-msgid "Schematics"
+#, fuzzy
+msgid "Schematics (*.sch)"
 msgstr "Stroombaandiagramme"
 
-msgid "Symbols"
+#, fuzzy
+msgid "Symbols (*.sym)"
 msgstr "Simbole"
 
-msgid "Schematics and symbols"
+#, fuzzy
+msgid "Schematics and symbols (*.sch *.sym)"
 msgstr "Stroombaandiagramme en simbole"
 
 msgid "All files"
@@ -1227,7 +1146,7 @@ msgid "Hatch"
 msgstr "Arseer"
 
 #, fuzzy, c-format
-msgid "x_image_lowlevel: Unable to write %1$s file %2$s."
+msgid "Unable to write %1$s file %2$s."
 msgstr "x_image_lowlevel: Kon nie %s-lêer %s skryf nie.\n"
 
 #, fuzzy, c-format
@@ -1251,7 +1170,7 @@ msgid "Wrote black and white image to [%1$s] [%2$d x %3$d]"
 msgstr "Het swart-en-witafbeelding na [%s] [%d x %d] geskryf\n"
 
 #, fuzzy
-msgid "x_image_lowlevel: Unable to get pixbuf from gschem's window."
+msgid "Unable to get pixbuf from lepton-schematic's window."
 msgstr "x_image_lowlevel: Kon nie pixbuf van gschem se venster kry nie.\n"
 
 msgid "NOTE: print-color-map will be used for PDF export"
@@ -1301,74 +1220,60 @@ msgid "Phantom"
 msgstr "Spook"
 
 #, fuzzy
-msgid "Add Net"
-msgstr "/Voeg Net By"
-
-msgid "Add Attribute"
-msgstr "Voeg Eienskap By"
-
-#, fuzzy
-msgid "Add Component"
+msgid "Add Co_mponent..."
 msgstr "/Voeg Komponent By"
 
 #, fuzzy
-msgid "Add Bus"
+msgid "Add Te_xt..."
+msgstr "Voeg Teks By..."
+
+#, fuzzy
+msgid "Add _Attribute..."
+msgstr "/Voeg Eienskap By"
+
+#, fuzzy
+msgid "Add _Net"
+msgstr "/Voeg Net By"
+
+#, fuzzy
+msgid "Add _Bus"
 msgstr "/Voeg Bus By"
 
-#, fuzzy
-msgid "Add Text"
-msgstr "/Voeg Teks By"
+msgid "Cu_t"
+msgstr ""
+
+msgid "_Copy"
+msgstr ""
+
+msgid "_Paste"
+msgstr ""
+
+msgid "_Delete"
+msgstr ""
 
 #, fuzzy
-msgid "Zoom In"
-msgstr "/Zoem In"
-
-#, fuzzy
-msgid "Zoom Out"
-msgstr "/Zoem Uit"
-
-#, fuzzy
-msgid "Zoom Extents"
-msgstr "/Zoem Uitmate"
-
-msgid "Select"
-msgstr "Kies"
-
-msgid "Edit..."
+msgid "_Edit..."
 msgstr "Bewerk..."
 
 #, fuzzy
-msgid "Object Properties..."
-msgstr "<b>Tekseienskappe</b>"
-
-msgid "Copy"
-msgstr "Kopieer"
-
-msgid "Move"
-msgstr "Beweeg"
-
-msgid "Delete"
-msgstr "Verwyder"
+msgid "Ed_it Text..."
+msgstr "Bewerk Teks..."
 
 #, fuzzy
-msgid "Down Schematic"
+msgid "_Object Properties..."
+msgstr "<b>Tekseienskappe</b>"
+
+#, fuzzy
+msgid "Hierarchy: Down _Schematic"
 msgstr "/Stroombaandiagram Af"
 
 #, fuzzy
-msgid "Down Symbol"
+msgid "Hierarchy: Down S_ymbol"
 msgstr "/Simbool Af"
 
 #, fuzzy
-msgid "Up"
-msgstr "/Op"
-
-#, fuzzy, c-format
-msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
-msgstr "Het probeer om gevoeligheid op nie-bestaande menu-artikel '%s'\n"
-
-#, c-format
-msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
-msgstr "Het probeer om gevoeligheid op nie-bestaande menu-artikel '%s'\n"
+msgid "Hierarchy: _Up"
+msgstr "Hierargie"
 
 msgid "The operating system is out of memory or resources."
 msgstr ""
@@ -1391,6 +1296,9 @@ msgstr ""
 msgid "Duplicate"
 msgstr "Dupliseer"
 
+msgid "Delete"
+msgstr "Verwyder"
+
 #, fuzzy
 msgid "Copy to all"
 msgstr "Kopieer in 1 in"
@@ -1410,6 +1318,9 @@ msgstr "W"
 #, fuzzy
 msgid "Sho_w inherited attributes"
 msgstr "Bewerk Eienskappe"
+
+msgid "Add Attribute"
+msgstr "Voeg Eienskap By"
 
 #, fuzzy
 msgid "_Name:"
@@ -1520,6 +1431,25 @@ msgstr "Hierargie"
 #, fuzzy
 msgid "Hierarchy up"
 msgstr "Hierargie"
+
+msgid "_New"
+msgstr ""
+
+msgid "_Open..."
+msgstr ""
+
+msgid "_Save"
+msgstr ""
+
+msgid "Save _As..."
+msgstr ""
+
+#, fuzzy
+msgid "Page _Manager..."
+msgstr "Bladsybestuurder"
+
+msgid "_Close"
+msgstr ""
 
 msgid "Options"
 msgstr "Opsies"
@@ -1633,6 +1563,9 @@ msgstr ""
 msgid "Add Text..."
 msgstr "Voeg Teks By..."
 
+msgid "Select"
+msgstr "Kies"
+
 msgid "Select mode"
 msgstr "Kiesmodus"
 
@@ -1698,19 +1631,7 @@ msgstr "gEDA Stroombaandiagram Bewerker"
 msgid "Create and edit electrical schematics and symbols with lepton-schematic"
 msgstr "Skep en bewerk stroombaandiagramme en simbole met gschem"
 
-msgid "_New"
-msgstr ""
-
-msgid "_Open..."
-msgstr ""
-
 msgid "Open Recen_t"
-msgstr ""
-
-msgid "_Save"
-msgstr ""
-
-msgid "Save _As..."
 msgstr ""
 
 msgid "Save All"
@@ -1745,18 +1666,6 @@ msgstr ""
 msgid "_Redo"
 msgstr ""
 
-msgid "Cu_t"
-msgstr ""
-
-msgid "_Copy"
-msgstr ""
-
-msgid "_Paste"
-msgstr ""
-
-msgid "_Delete"
-msgstr ""
-
 #, fuzzy
 msgid "Select All"
 msgstr "Kies"
@@ -1767,6 +1676,13 @@ msgstr "Kies"
 
 msgid "Rotate 90 Mode"
 msgstr "Roteer-90-modus"
+
+#, fuzzy
+msgid "Object Properties..."
+msgstr "<b>Tekseienskappe</b>"
+
+msgid "Edit..."
+msgstr "Bewerk..."
 
 msgid "Edit Text..."
 msgstr "Bewerk Teks..."
@@ -1889,9 +1805,6 @@ msgstr ""
 msgid "_Next"
 msgstr ""
 
-msgid "_Close"
-msgstr ""
-
 msgid "_Revert..."
 msgstr ""
 
@@ -2002,6 +1915,9 @@ msgid "Grid Style: Cycle Dots/Mesh/Off"
 msgstr ""
 
 msgid "Grid Snap: Cycle Grid/Resnap/Off"
+msgstr ""
+
+msgid "Grips: On/Off"
 msgstr ""
 
 msgid "Feedback Mode: Outline/Box"
@@ -2150,6 +2066,9 @@ msgstr "Toon/Verberg Onsigbare Teks"
 msgid "Cut"
 msgstr "Sny 2"
 
+msgid "Copy"
+msgstr "Kopieer"
+
 #, fuzzy
 msgid "Paste"
 msgstr "Plak 2"
@@ -2178,6 +2097,18 @@ msgstr ""
 #, fuzzy
 msgid "Pan Down"
 msgstr "Aansigskuifmodus"
+
+#, fuzzy
+msgid "Zoom Extents"
+msgstr "/Zoem Uitmate"
+
+#, fuzzy
+msgid "Zoom In"
+msgstr "/Zoem In"
+
+#, fuzzy
+msgid "Zoom Out"
+msgstr "/Zoem Uit"
 
 #, fuzzy
 msgid "Zoom Full"
@@ -2212,6 +2143,22 @@ msgid "Print Page"
 msgstr "Sluit Bladsy"
 
 #, fuzzy
+msgid "Add Component"
+msgstr "/Voeg Komponent By"
+
+#, fuzzy
+msgid "Add Net"
+msgstr "/Voeg Net By"
+
+#, fuzzy
+msgid "Add Bus"
+msgstr "/Voeg Bus By"
+
+#, fuzzy
+msgid "Add Text"
+msgstr "/Voeg Teks By"
+
+#, fuzzy
 msgid "Add Line"
 msgstr "Lyn"
 
@@ -2237,6 +2184,14 @@ msgstr ""
 #, fuzzy
 msgid "Add Picture"
 msgstr "Afbeelding"
+
+#, fuzzy
+msgid "Down Schematic"
+msgstr "/Stroombaandiagram Af"
+
+#, fuzzy
+msgid "Down Symbol"
+msgstr "/Simbool Af"
 
 #, fuzzy
 msgid "Up Hierarchy"
@@ -2320,6 +2275,9 @@ msgstr "Nuwe Venster"
 msgid "Show Coordinate Window"
 msgstr "Huidige Venster"
 
+msgid "Toggle Grips"
+msgstr ""
+
 #, fuzzy
 msgid "Component Documentation"
 msgstr "Komponentmodus"
@@ -2358,10 +2316,6 @@ msgstr ""
 msgid "About lepton-schematic"
 msgstr "Oor gschem"
 
-#, scheme-format
-msgid "Invalid text alignment ~A."
-msgstr ""
-
 #, fuzzy
 msgid "Could not show documentation:"
 msgstr "Komponentmodus"
@@ -2376,6 +2330,107 @@ msgstr ""
 #, scheme-format
 msgid "~S is not a prefix key sequence."
 msgstr ""
+
+#, scheme-format
+msgid "Invalid text alignment ~A."
+msgstr ""
+
+#, fuzzy
+#~ msgid "Save settings to:"
+#~ msgstr "Instellinge"
+
+#, fuzzy
+#~ msgid "Invalid size [%1$d] passed to text-size\n"
+#~ msgstr "Ongeldige grootte [%d] gegee aan text-size\n"
+
+#, fuzzy
+#~ msgid "Invalid size [%1$d] passed to snap-size\n"
+#~ msgstr "Ongeldige grootte [%d] aan snap-size gegee\n"
+
+#, fuzzy
+#~ msgid "Invalid num levels [%1$d] passed to undo-levels\n"
+#~ msgstr "Ongeldige getal vlakke [%d] gegee aan undo-levels\n"
+
+#, fuzzy
+#~ msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
+#~ msgstr "Ongeldige grootte [%d] gegee aan bus-ripper-size\n"
+
+#, fuzzy
+#~ msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
+#~ msgstr "Ongeldige puntgrootte [%d] gegee aan dots-grid-dot-size\n"
+
+#, fuzzy
+#~ msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
+#~ msgstr "Ongeldige puntgrootte [%d] gegee aan dots-grid-dot-size\n"
+
+#, fuzzy
+#~ msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
+#~ msgstr "Ongeldige puntgrootte [%d] gegee aan dots-grid-dot-size\n"
+
+#, fuzzy
+#~ msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
+#~ msgstr "Ongeldige hoeveelheid sekondes [%d] gegee aan auto-save-interval\n"
+
+#, fuzzy
+#~ msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
+#~ msgstr "Ongeldige versterking [%d] gegee aan mousepan-gain\n"
+
+#, fuzzy
+#~ msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
+#~ msgstr "Ongeldige versterking [%d] gegee aan keyboardpan-gain\n"
+
+#, fuzzy
+#~ msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
+#~ msgstr "Ongeldige hoeveelheid sekondes [%d] gegee aan auto-save-interval\n"
+
+#, fuzzy
+#~ msgid "Invalid gain [%1$d] passed to zoom-gain\n"
+#~ msgstr "Ongeldige versterking [%d] gegee aan zoom-gain\n"
+
+#, fuzzy
+#~ msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
+#~ msgstr "Ongeldige hoeveelheid sekondes [%d] gegee aan auto-save-interval\n"
+
+#~ msgid "Got an unexpected NULL in o_edit\n"
+#~ msgstr "Het 'n onverwagte NULL in o_edit gekry\n"
+
+#~ msgid "ERROR: NULL object in o_move_end!\n"
+#~ msgstr "FOUT: NULL voorwerp in o_move_end!\n"
+
+#~ msgid "ERROR: NULL object!\n"
+#~ msgstr "FOUT: NULL voorwerp!\n"
+
+#, fuzzy
+#~ msgid "Could not allocate the color %1$s!\n"
+#~ msgstr "Kon nie aanspraak maak op die kleur %s nie!\n"
+
+#~ msgid "black"
+#~ msgstr "swart"
+
+#~ msgid "white"
+#~ msgstr "wit"
+
+#, fuzzy
+#~ msgid "Could not allocate display color %1$i!\n"
+#~ msgstr "Kon nie aanspraak maak op die kleur %s nie!\n"
+
+#, fuzzy
+#~ msgid "Could not allocate outline color %1$i!\n"
+#~ msgstr "Kon nie aanspraak maak op die kleur %s nie!\n"
+
+#~ msgid "Move"
+#~ msgstr "Beweeg"
+
+#, fuzzy
+#~ msgid "Up"
+#~ msgstr "/Op"
+
+#, fuzzy
+#~ msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
+#~ msgstr "Het probeer om gevoeligheid op nie-bestaande menu-artikel '%s'\n"
+
+#~ msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
+#~ msgstr "Het probeer om gevoeligheid op nie-bestaande menu-artikel '%s'\n"
 
 #, fuzzy
 #~ msgid "Invalid offset [%1$d] passed to add-attribute-offset\n"
@@ -2560,9 +2615,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Embed Component/Pictore"
 #~ msgstr "Lê Komponent/Afbeelding In"
-
-#~ msgid "/Add Attribute..."
-#~ msgstr "/Voeg Eienskap By"
 
 #~ msgid "/Zoom Box"
 #~ msgstr "/Zoem Reghoek"

--- a/schematic/po/ar.po
+++ b/schematic/po/ar.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-10-03 23:34+0300\n"
+"POT-Creation-Date: 2020-03-18 20:44+0300\n"
 "PO-Revision-Date: 2010-02-14 06:08+0000\n"
 "Last-Translator: عبدالله شلي (Abdellah Chelli) <Unknown>\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -22,6 +22,13 @@ msgstr ""
 #, fuzzy
 msgid "Zoom too small!  Cannot zoom further."
 msgstr "التبعيد كبير جدا! لا يمكن التبعيد أكثر.\n"
+
+msgid ""
+"Save your color scheme to a file by clicking on the \"Save As...\"\n"
+"button. It can be loaded on startup with the following\n"
+"expression in the gschemrc configuration file:\n"
+"( primitive-load \"/path/to/saved-color-scheme-file\" )"
+msgstr ""
 
 #, fuzzy, c-format
 msgid ""
@@ -52,6 +59,11 @@ msgstr ""
 msgid "Sa_ve..."
 msgstr ""
 
+msgid ""
+"After you're done choosing the font, it's recommended\n"
+"to reopen schematics or restart the application."
+msgstr ""
+
 #, c-format
 msgid "<b>Current:</b> %s"
 msgstr ""
@@ -59,24 +71,20 @@ msgstr ""
 msgid "Save configuration"
 msgstr ""
 
-#, fuzzy
-msgid "Save settings to:"
-msgstr "إعدادات"
-
-msgid "Local configuration file (in current directory)"
+msgid "Local configuration file:"
 msgstr ""
 
-msgid "User configuration file (geda-user.conf)"
+msgid "User configuration file:"
 msgstr ""
 
-msgid "Object ~A is not included in the current gschem page."
+msgid "Object ~A is not included in the current lepton-schematic page."
 msgstr ""
 
 msgid "Invalid text name/value visibility ~A."
 msgstr ""
 
 #, fuzzy, c-format
-msgid "You are running gEDA/gaf version [%1$s%2$s.%3$s],\n"
+msgid "You are running lepton-schematic version [%1$s%2$s.%3$s],\n"
 msgstr "إصدار gEDA/gschem‫ %s%s.%s\n"
 
 #, c-format
@@ -89,65 +97,13 @@ msgstr ""
 msgid "Please be sure that you have the latest rc file.\n"
 msgstr ""
 
-#, fuzzy, c-format
-msgid "Invalid size [%1$d] passed to text-size\n"
-msgstr "مرّر حجم غير صالح [%d] إلى 'حجم النص'\n"
-
-#, fuzzy, c-format
-msgid "Invalid size [%1$d] passed to snap-size\n"
-msgstr "مرّر حجم غير صالح [%d] إلى 'حجم الجذب'\n"
-
-#, fuzzy, c-format
-msgid "Invalid num levels [%1$d] passed to undo-levels\n"
-msgstr "مرّر عدد مستويات غير صالح [%d] إلى 'مستويات التراجع'\n"
-
-#, fuzzy, c-format
-msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
-msgstr "مرّر حجم غير صالح [%d] إلى 'حجم كسار الناقل'\n"
-
-#, fuzzy, c-format
-msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
-msgstr "مرّر حجم نقط غير صالح [%d] إلى 'حجم النقط للشبيكة النقطية'\n"
-
-#, fuzzy, c-format
-msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
-msgstr "مرّر تباعد بكسل غير صالح [%d] إلى 'العتبة الثابتة للشبيكة النقطية'\n"
-
-#, fuzzy, c-format
-msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
-msgstr "مرّر تباعد بكسل غير صالح [%d] إلى 'عتبة العرض لشبيكة الشُرَط'\n"
-
-#, fuzzy, c-format
-msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
-msgstr "مرّر عدد ثواني غير صالح [%d] إلى 'مدّة الحفظ الآلي'\n"
-
-#, fuzzy, c-format
-msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
-msgstr "مرّر معامل ربح غير صالح [%d] إلى 'معامل ربح الفأرة'\n"
-
-#, fuzzy, c-format
-msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
-msgstr "مرّر معامل ربح غير صالح [%d] إلى 'معامل ربح لوحة المفاتيح'\n"
-
-#, fuzzy, c-format
-msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
-msgstr "مرّر عدد بكسلات غير صالح [%d] إلى 'بكسلات مهملة للانتقاء'\n"
-
-#, fuzzy, c-format
-msgid "Invalid gain [%1$d] passed to zoom-gain\n"
-msgstr "مرّر معامل ربح غير صالح [%d] إلى 'معامل ربح التقريب'\n"
-
-#, fuzzy, c-format
-msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
-msgstr "مرّر عدد خطوات غير صالح [%d] إلى 'خطوات شريط التمرير'\n"
-
 msgid "Object ~A is not directly included in a page."
 msgstr ""
 
 msgid "Could not launch URI ~S: ~A"
 msgstr ""
 
-msgid "Found invalid gschem window smob ~S"
+msgid "Found invalid lepton-schematic window smob ~S"
 msgstr ""
 
 #, fuzzy, c-format
@@ -179,7 +135,7 @@ msgstr "gEDA: GPL Electronic Design Automation (أتمتة التصميم الإ
 
 msgid ""
 "Copyright © 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright © 2017-2019 Lepton Developers.\n"
+"Copyright © 2017-2020 Lepton Developers.\n"
 "See AUTHORS, ChangeLog files and consult 'git log' history for details."
 msgstr ""
 
@@ -662,7 +618,8 @@ msgid ""
 "\n"
 "Are you sure you want to revert this page?\n"
 "All unsaved changes in current schematic will be\n"
-"discarded and page file will be reloaded from disk."
+"discarded and page file will be reloaded from disk.\n"
+"This action will also reload all component libraries."
 msgstr ""
 
 #, fuzzy
@@ -773,10 +730,6 @@ msgid_plural "Delete %1$u locked objects?"
 msgstr[0] "الكائنات المنتقاة"
 msgstr[1] "الكائنات المنتقاة"
 
-#, c-format
-msgid "Got an unexpected NULL in o_edit\n"
-msgstr "حصلت على NULL غير متوقع في o_edit\n"
-
 #, fuzzy
 msgid "Hidden text is now visible"
 msgstr "أصبح الآن النص المخفي ظاهرا\n"
@@ -790,7 +743,7 @@ msgid "Could not find symbol [%1$s] in library. Update failed."
 msgstr "﻿تعذر العثور على الرمز [%s] في المكتبة. فشل التحديث.\n"
 
 #, fuzzy, c-format
-msgid "o_autosave_backups: Can't get the real filename of %1$s."
+msgid "Can't get the real filename of %1$s."
 msgstr "﻿‏o_autosave_backups: تعذر الحصول على اسم الحقيقي للملف %s."
 
 #, fuzzy, c-format
@@ -804,10 +757,6 @@ msgstr "تعذر تعيين الملف الاحتياطي [‎%s‬] للقرا�
 #, fuzzy, c-format
 msgid "Could NOT save backup file [%1$s]"
 msgstr "تعذر حفظ الملف الاحتياطي [‎%s‬]\n"
-
-#, c-format
-msgid "ERROR: NULL object in o_move_end!\n"
-msgstr "﻿خطأ: كائن فارغ (NULL) في o_move_end!\n"
 
 #, c-format
 msgid "DOH! tried to find the whichone, but didn't find it!\n"
@@ -862,7 +811,7 @@ msgid "New slot number out of range"
 msgstr "عدد شق جديد خارج النطاق\n"
 
 #, fuzzy
-msgid "Undo/Redo disabled in rc file"
+msgid "Undo/Redo is disabled in configuration"
 msgstr "التراجع/الإعادة معطلين في الملف rc\n"
 
 #, c-format
@@ -883,28 +832,13 @@ msgid ""
 "  -h, --help               Help; this message.\n"
 "  --                       Treat all remaining arguments as filenames.\n"
 "\n"
-"Report bugs at <https://github.com/lepton-eda/lepton-eda/issues>\n"
-"Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"Lepton EDA %1$s (git: %2$.7s)\n"
-"Copyright (C) 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright (C) 2017-2019 Lepton Developers.\n"
-"This is free software, and you are welcome to redistribute it under\n"
-"certain conditions. For details, see the file `COPYING', which is\n"
-"included in the Lepton EDA distribution.\n"
-"There is NO WARRANTY, to the extent permitted by law.\n"
+"Report bugs at <%2$s>\n"
+"Lepton EDA homepage: <%3$s>\n"
 msgstr ""
 
 #, c-format
 msgid "Got invalid show option; defaulting to show both\n"
 msgstr "﻿حصلت على خيار عرض غير صحيح ؛تعيين الافتراضي لإظهار كليهما\n"
-
-#, c-format
-msgid "ERROR: NULL object!\n"
-msgstr "﻿خطأ: كائن فارغ (NULL)!\n"
 
 msgid "Single Attribute Editor"
 msgstr "محرّر سمة منفردة"
@@ -964,7 +898,7 @@ msgid ""
 msgstr "﻿شقّ مكرر قد يسبب مشاكل: [اسم​الرمز=%s، العدد=%d، الشقّ=%d]\n"
 
 #, fuzzy
-msgid "No searchstring given in autonumber text."
+msgid "No search string given in autonumber text."
 msgstr "لا يوجد نص بحث في نص الترقيم الآلي.\n"
 
 #, fuzzy
@@ -1040,24 +974,6 @@ msgstr ""
 
 msgid "Clipboard insertion failed"
 msgstr ""
-
-#, fuzzy, c-format
-msgid "Could not allocate the color %1$s!\n"
-msgstr "﻿تعذر تعيين اللون %s!\n"
-
-msgid "black"
-msgstr "أسود"
-
-msgid "white"
-msgstr "أبيض"
-
-#, fuzzy, c-format
-msgid "Could not allocate display color %1$i!\n"
-msgstr "﻿تعذر تعيين لون العرض %i!\n"
-
-#, fuzzy, c-format
-msgid "Could not allocate outline color %1$i!\n"
-msgstr "﻿تعذر تعيين لون الخط الخارجي %i!\n"
 
 #, fuzzy, c-format
 msgid "Tried to get an invalid color: %1$d\n"
@@ -1204,13 +1120,16 @@ msgstr ""
 msgid "Invalid Attribute"
 msgstr "﻿سمة غير صالحة"
 
-msgid "Schematics"
+#, fuzzy
+msgid "Schematics (*.sch)"
 msgstr "مخططات"
 
-msgid "Symbols"
+#, fuzzy
+msgid "Symbols (*.sym)"
 msgstr "رموز"
 
-msgid "Schematics and symbols"
+#, fuzzy
+msgid "Schematics and symbols (*.sch *.sym)"
 msgstr "مخططات و رموز"
 
 msgid "All files"
@@ -1247,7 +1166,7 @@ msgid "Hatch"
 msgstr "تهشير"
 
 #, fuzzy, c-format
-msgid "x_image_lowlevel: Unable to write %1$s file %2$s."
+msgid "Unable to write %1$s file %2$s."
 msgstr "‏﻿x_image_lowlevel: غير قادر على كتابة ملف ‬%s %s.\n"
 
 #, fuzzy, c-format
@@ -1271,7 +1190,7 @@ msgid "Wrote black and white image to [%1$s] [%2$d x %3$d]"
 msgstr "﻿كتب صورة بالأبيض والأسود إلى [%s] [%d x %d]\n"
 
 #, fuzzy
-msgid "x_image_lowlevel: Unable to get pixbuf from gschem's window."
+msgid "Unable to get pixbuf from lepton-schematic's window."
 msgstr "﻿‏x_image_lowlevel: تعذر الحصول على pixbuf من نافذة gschem.\n"
 
 msgid "NOTE: print-color-map will be used for PDF export"
@@ -1321,74 +1240,60 @@ msgid "Phantom"
 msgstr "وهم"
 
 #, fuzzy
-msgid "Add Net"
-msgstr "/أضف شبكة"
-
-msgid "Add Attribute"
-msgstr "أضف سمة"
-
-#, fuzzy
-msgid "Add Component"
+msgid "Add Co_mponent..."
 msgstr "/أضف مكونا..."
 
 #, fuzzy
-msgid "Add Bus"
+msgid "Add Te_xt..."
+msgstr "أضف نصا..."
+
+#, fuzzy
+msgid "Add _Attribute..."
+msgstr "/أضف سمة..."
+
+#, fuzzy
+msgid "Add _Net"
+msgstr "/أضف شبكة"
+
+#, fuzzy
+msgid "Add _Bus"
 msgstr "/أضف ناقلا"
 
-#, fuzzy
-msgid "Add Text"
-msgstr "/أضف نصا"
+msgid "Cu_t"
+msgstr "_قصّ"
+
+msgid "_Copy"
+msgstr "ا_نسخ"
+
+msgid "_Paste"
+msgstr "أ_لصق"
+
+msgid "_Delete"
+msgstr "ا_حذف"
 
 #, fuzzy
-msgid "Zoom In"
-msgstr "/قرّب"
-
-#, fuzzy
-msgid "Zoom Out"
-msgstr "/بعّد"
-
-#, fuzzy
-msgid "Zoom Extents"
-msgstr "/قرّب مع شمل الامتدادات"
-
-msgid "Select"
-msgstr "انتق"
-
-msgid "Edit..."
+msgid "_Edit..."
 msgstr "حرّر..."
 
 #, fuzzy
-msgid "Object Properties..."
-msgstr "<b>خصائص النص</b>"
-
-msgid "Copy"
-msgstr "انسخ"
-
-msgid "Move"
-msgstr "حرّك"
-
-msgid "Delete"
-msgstr "احذف"
+msgid "Ed_it Text..."
+msgstr "حرّر النص..."
 
 #, fuzzy
-msgid "Down Schematic"
+msgid "_Object Properties..."
+msgstr "<b>خصائص النص</b>"
+
+#, fuzzy
+msgid "Hierarchy: Down _Schematic"
 msgstr "/انزل إلى المخطط"
 
 #, fuzzy
-msgid "Down Symbol"
+msgid "Hierarchy: Down S_ymbol"
 msgstr "/انزل إلى الرمز"
 
 #, fuzzy
-msgid "Up"
-msgstr "/اصعد"
-
-#, fuzzy, c-format
-msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
-msgstr "محاولة تعيين الحساسية على عنصر قائمة غير موجود '%s'\n"
-
-#, c-format
-msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
-msgstr "محاولة تعيين الحساسية على عنصر قائمة غير موجود '%s'\n"
+msgid "Hierarchy: _Up"
+msgstr "تسلسل​_هرمي"
 
 msgid "The operating system is out of memory or resources."
 msgstr ""
@@ -1411,6 +1316,9 @@ msgstr "رَقِّ"
 msgid "Duplicate"
 msgstr "ضاعف"
 
+msgid "Delete"
+msgstr "احذف"
+
 #, fuzzy
 msgid "Copy to all"
 msgstr "انسخ إلى 1"
@@ -1430,6 +1338,9 @@ msgstr "V"
 #, fuzzy
 msgid "Sho_w inherited attributes"
 msgstr "أظهر السمات الموروثة"
+
+msgid "Add Attribute"
+msgstr "أضف سمة"
 
 #, fuzzy
 msgid "_Name:"
@@ -1540,6 +1451,25 @@ msgstr "تسلسل​_هرمي"
 #, fuzzy
 msgid "Hierarchy up"
 msgstr "تسلسل​_هرمي"
+
+msgid "_New"
+msgstr "_جديد"
+
+msgid "_Open..."
+msgstr "ا_فتح..."
+
+msgid "_Save"
+msgstr "ا_حفظ"
+
+msgid "Save _As..."
+msgstr "احفظ _ك‍..."
+
+#, fuzzy
+msgid "Page _Manager..."
+msgstr "مدير الصفحات"
+
+msgid "_Close"
+msgstr "أ_غلق"
 
 msgid "Options"
 msgstr "خيارات"
@@ -1661,6 +1591,9 @@ msgstr ""
 msgid "Add Text..."
 msgstr "أضف نصا..."
 
+msgid "Select"
+msgstr "انتق"
+
 msgid "Select mode"
 msgstr "وضع الإنتقاء"
 
@@ -1726,20 +1659,8 @@ msgstr "محرّر المخططات gEDA"
 msgid "Create and edit electrical schematics and symbols with lepton-schematic"
 msgstr "أنشء و حرّر المخططات الكهربائية والرموز مع gschem"
 
-msgid "_New"
-msgstr "_جديد"
-
-msgid "_Open..."
-msgstr "ا_فتح..."
-
 msgid "Open Recen_t"
 msgstr "افتح الأح_دث"
-
-msgid "_Save"
-msgstr "ا_حفظ"
-
-msgid "Save _As..."
-msgstr "احفظ _ك‍..."
 
 msgid "Save All"
 msgstr "احفظ الكل"
@@ -1774,18 +1695,6 @@ msgstr "ت_راجع"
 msgid "_Redo"
 msgstr "_كرّر"
 
-msgid "Cu_t"
-msgstr "_قصّ"
-
-msgid "_Copy"
-msgstr "ا_نسخ"
-
-msgid "_Paste"
-msgstr "أ_لصق"
-
-msgid "_Delete"
-msgstr "ا_حذف"
-
 #, fuzzy
 msgid "Select All"
 msgstr "انتق"
@@ -1796,6 +1705,13 @@ msgstr "انتق"
 
 msgid "Rotate 90 Mode"
 msgstr "وضع الاستدارة 90"
+
+#, fuzzy
+msgid "Object Properties..."
+msgstr "<b>خصائص النص</b>"
+
+msgid "Edit..."
+msgstr "حرّر..."
 
 msgid "Edit Text..."
 msgstr "حرّر النص..."
@@ -1920,9 +1836,6 @@ msgstr "ال_سّابقة"
 msgid "_Next"
 msgstr "ال_تّالية"
 
-msgid "_Close"
-msgstr "أ_غلق"
-
 #, fuzzy
 msgid "_Revert..."
 msgstr "ت_راجع"
@@ -2034,6 +1947,9 @@ msgid "Grid Style: Cycle Dots/Mesh/Off"
 msgstr ""
 
 msgid "Grid Snap: Cycle Grid/Resnap/Off"
+msgstr ""
+
+msgid "Grips: On/Off"
 msgstr ""
 
 #, fuzzy
@@ -2186,6 +2102,9 @@ msgstr "أظهر/أخف النص الخفي"
 msgid "Cut"
 msgstr "_قصّ"
 
+msgid "Copy"
+msgstr "انسخ"
+
 #, fuzzy
 msgid "Paste"
 msgstr "أ_لصق"
@@ -2215,6 +2134,18 @@ msgstr ""
 #, fuzzy
 msgid "Pan Down"
 msgstr "وضع الإنتقال الإختياري"
+
+#, fuzzy
+msgid "Zoom Extents"
+msgstr "/قرّب مع شمل الامتدادات"
+
+#, fuzzy
+msgid "Zoom In"
+msgstr "/قرّب"
+
+#, fuzzy
+msgid "Zoom Out"
+msgstr "/بعّد"
 
 #, fuzzy
 msgid "Zoom Full"
@@ -2252,6 +2183,22 @@ msgid "Print Page"
 msgstr "ال_سّابقة"
 
 #, fuzzy
+msgid "Add Component"
+msgstr "/أضف مكونا..."
+
+#, fuzzy
+msgid "Add Net"
+msgstr "/أضف شبكة"
+
+#, fuzzy
+msgid "Add Bus"
+msgstr "/أضف ناقلا"
+
+#, fuzzy
+msgid "Add Text"
+msgstr "/أضف نصا"
+
+#, fuzzy
 msgid "Add Line"
 msgstr "خط"
 
@@ -2277,6 +2224,14 @@ msgstr ""
 #, fuzzy
 msgid "Add Picture"
 msgstr "صورة"
+
+#, fuzzy
+msgid "Down Schematic"
+msgstr "/انزل إلى المخطط"
+
+#, fuzzy
+msgid "Down Symbol"
+msgstr "/انزل إلى الرمز"
 
 #, fuzzy
 msgid "Up Hierarchy"
@@ -2369,6 +2324,10 @@ msgid "Show Coordinate Window"
 msgstr "أظهر نافذة الم_علم..."
 
 #, fuzzy
+msgid "Toggle Grips"
+msgstr "_بدل الرؤية"
+
+#, fuzzy
 msgid "Component Documentation"
 msgstr "توثيق الم_كونات"
 
@@ -2407,10 +2366,6 @@ msgstr ""
 msgid "About lepton-schematic"
 msgstr "عن gschem"
 
-#, scheme-format
-msgid "Invalid text alignment ~A."
-msgstr ""
-
 #, fuzzy
 msgid "Could not show documentation:"
 msgstr "توثيق الم_كونات"
@@ -2426,6 +2381,107 @@ msgstr ""
 #, scheme-format
 msgid "~S is not a prefix key sequence."
 msgstr ""
+
+#, scheme-format
+msgid "Invalid text alignment ~A."
+msgstr ""
+
+#, fuzzy
+#~ msgid "Save settings to:"
+#~ msgstr "إعدادات"
+
+#, fuzzy
+#~ msgid "Invalid size [%1$d] passed to text-size\n"
+#~ msgstr "مرّر حجم غير صالح [%d] إلى 'حجم النص'\n"
+
+#, fuzzy
+#~ msgid "Invalid size [%1$d] passed to snap-size\n"
+#~ msgstr "مرّر حجم غير صالح [%d] إلى 'حجم الجذب'\n"
+
+#, fuzzy
+#~ msgid "Invalid num levels [%1$d] passed to undo-levels\n"
+#~ msgstr "مرّر عدد مستويات غير صالح [%d] إلى 'مستويات التراجع'\n"
+
+#, fuzzy
+#~ msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
+#~ msgstr "مرّر حجم غير صالح [%d] إلى 'حجم كسار الناقل'\n"
+
+#, fuzzy
+#~ msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
+#~ msgstr "مرّر حجم نقط غير صالح [%d] إلى 'حجم النقط للشبيكة النقطية'\n"
+
+#, fuzzy
+#~ msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
+#~ msgstr "مرّر تباعد بكسل غير صالح [%d] إلى 'العتبة الثابتة للشبيكة النقطية'\n"
+
+#, fuzzy
+#~ msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
+#~ msgstr "مرّر تباعد بكسل غير صالح [%d] إلى 'عتبة العرض لشبيكة الشُرَط'\n"
+
+#, fuzzy
+#~ msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
+#~ msgstr "مرّر عدد ثواني غير صالح [%d] إلى 'مدّة الحفظ الآلي'\n"
+
+#, fuzzy
+#~ msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
+#~ msgstr "مرّر معامل ربح غير صالح [%d] إلى 'معامل ربح الفأرة'\n"
+
+#, fuzzy
+#~ msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
+#~ msgstr "مرّر معامل ربح غير صالح [%d] إلى 'معامل ربح لوحة المفاتيح'\n"
+
+#, fuzzy
+#~ msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
+#~ msgstr "مرّر عدد بكسلات غير صالح [%d] إلى 'بكسلات مهملة للانتقاء'\n"
+
+#, fuzzy
+#~ msgid "Invalid gain [%1$d] passed to zoom-gain\n"
+#~ msgstr "مرّر معامل ربح غير صالح [%d] إلى 'معامل ربح التقريب'\n"
+
+#, fuzzy
+#~ msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
+#~ msgstr "مرّر عدد خطوات غير صالح [%d] إلى 'خطوات شريط التمرير'\n"
+
+#~ msgid "Got an unexpected NULL in o_edit\n"
+#~ msgstr "حصلت على NULL غير متوقع في o_edit\n"
+
+#~ msgid "ERROR: NULL object in o_move_end!\n"
+#~ msgstr "﻿خطأ: كائن فارغ (NULL) في o_move_end!\n"
+
+#~ msgid "ERROR: NULL object!\n"
+#~ msgstr "﻿خطأ: كائن فارغ (NULL)!\n"
+
+#, fuzzy
+#~ msgid "Could not allocate the color %1$s!\n"
+#~ msgstr "﻿تعذر تعيين اللون %s!\n"
+
+#~ msgid "black"
+#~ msgstr "أسود"
+
+#~ msgid "white"
+#~ msgstr "أبيض"
+
+#, fuzzy
+#~ msgid "Could not allocate display color %1$i!\n"
+#~ msgstr "﻿تعذر تعيين لون العرض %i!\n"
+
+#, fuzzy
+#~ msgid "Could not allocate outline color %1$i!\n"
+#~ msgstr "﻿تعذر تعيين لون الخط الخارجي %i!\n"
+
+#~ msgid "Move"
+#~ msgstr "حرّك"
+
+#, fuzzy
+#~ msgid "Up"
+#~ msgstr "/اصعد"
+
+#, fuzzy
+#~ msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
+#~ msgstr "محاولة تعيين الحساسية على عنصر قائمة غير موجود '%s'\n"
+
+#~ msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
+#~ msgstr "محاولة تعيين الحساسية على عنصر قائمة غير موجود '%s'\n"
 
 #, fuzzy
 #~ msgid "Invalid offset [%1$d] passed to add-attribute-offset\n"
@@ -2724,9 +2780,6 @@ msgstr ""
 
 #~ msgid "Function"
 #~ msgstr "وظيفة"
-
-#~ msgid "/Add Attribute..."
-#~ msgstr "/أضف سمة..."
 
 #~ msgid "/Zoom Box"
 #~ msgstr "/قرب الإطار"

--- a/schematic/po/bg.po
+++ b/schematic/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-10-03 23:34+0300\n"
+"POT-Creation-Date: 2020-03-18 20:44+0300\n"
 "PO-Revision-Date: 2012-01-27 14:23+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -19,6 +19,13 @@ msgstr ""
 "X-Generator: Launchpad (build 16265)\n"
 
 msgid "Zoom too small!  Cannot zoom further."
+msgstr ""
+
+msgid ""
+"Save your color scheme to a file by clicking on the \"Save As...\"\n"
+"button. It can be loaded on startup with the following\n"
+"expression in the gschemrc configuration file:\n"
+"( primitive-load \"/path/to/saved-color-scheme-file\" )"
 msgstr ""
 
 #, c-format
@@ -46,6 +53,11 @@ msgstr ""
 msgid "Sa_ve..."
 msgstr ""
 
+msgid ""
+"After you're done choosing the font, it's recommended\n"
+"to reopen schematics or restart the application."
+msgstr ""
+
 #, c-format
 msgid "<b>Current:</b> %s"
 msgstr ""
@@ -53,23 +65,20 @@ msgstr ""
 msgid "Save configuration"
 msgstr ""
 
-msgid "Save settings to:"
+msgid "Local configuration file:"
 msgstr ""
 
-msgid "Local configuration file (in current directory)"
+msgid "User configuration file:"
 msgstr ""
 
-msgid "User configuration file (geda-user.conf)"
-msgstr ""
-
-msgid "Object ~A is not included in the current gschem page."
+msgid "Object ~A is not included in the current lepton-schematic page."
 msgstr ""
 
 msgid "Invalid text name/value visibility ~A."
 msgstr ""
 
 #, c-format
-msgid "You are running gEDA/gaf version [%1$s%2$s.%3$s],\n"
+msgid "You are running lepton-schematic version [%1$s%2$s.%3$s],\n"
 msgstr ""
 
 #, c-format
@@ -82,65 +91,13 @@ msgstr ""
 msgid "Please be sure that you have the latest rc file.\n"
 msgstr ""
 
-#, c-format
-msgid "Invalid size [%1$d] passed to text-size\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid size [%1$d] passed to snap-size\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid num levels [%1$d] passed to undo-levels\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid gain [%1$d] passed to zoom-gain\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
-msgstr ""
-
 msgid "Object ~A is not directly included in a page."
 msgstr ""
 
 msgid "Could not launch URI ~S: ~A"
 msgstr ""
 
-msgid "Found invalid gschem window smob ~S"
+msgid "Found invalid lepton-schematic window smob ~S"
 msgstr ""
 
 #, c-format
@@ -171,7 +128,7 @@ msgstr ""
 
 msgid ""
 "Copyright © 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright © 2017-2019 Lepton Developers.\n"
+"Copyright © 2017-2020 Lepton Developers.\n"
 "See AUTHORS, ChangeLog files and consult 'git log' history for details."
 msgstr ""
 
@@ -611,7 +568,8 @@ msgid ""
 "\n"
 "Are you sure you want to revert this page?\n"
 "All unsaved changes in current schematic will be\n"
-"discarded and page file will be reloaded from disk."
+"discarded and page file will be reloaded from disk.\n"
+"This action will also reload all component libraries."
 msgstr ""
 
 msgid "Revert"
@@ -704,10 +662,6 @@ msgid_plural "Delete %1$u locked objects?"
 msgstr[0] ""
 msgstr[1] ""
 
-#, c-format
-msgid "Got an unexpected NULL in o_edit\n"
-msgstr ""
-
 msgid "Hidden text is now visible"
 msgstr ""
 
@@ -719,7 +673,7 @@ msgid "Could not find symbol [%1$s] in library. Update failed."
 msgstr ""
 
 #, c-format
-msgid "o_autosave_backups: Can't get the real filename of %1$s."
+msgid "Can't get the real filename of %1$s."
 msgstr ""
 
 #, c-format
@@ -732,10 +686,6 @@ msgstr ""
 
 #, c-format
 msgid "Could NOT save backup file [%1$s]"
-msgstr ""
-
-#, c-format
-msgid "ERROR: NULL object in o_move_end!\n"
 msgstr ""
 
 #, c-format
@@ -783,7 +733,7 @@ msgstr ""
 msgid "New slot number out of range"
 msgstr ""
 
-msgid "Undo/Redo disabled in rc file"
+msgid "Undo/Redo is disabled in configuration"
 msgstr ""
 
 #, c-format
@@ -804,27 +754,12 @@ msgid ""
 "  -h, --help               Help; this message.\n"
 "  --                       Treat all remaining arguments as filenames.\n"
 "\n"
-"Report bugs at <https://github.com/lepton-eda/lepton-eda/issues>\n"
-"Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"Lepton EDA %1$s (git: %2$.7s)\n"
-"Copyright (C) 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright (C) 2017-2019 Lepton Developers.\n"
-"This is free software, and you are welcome to redistribute it under\n"
-"certain conditions. For details, see the file `COPYING', which is\n"
-"included in the Lepton EDA distribution.\n"
-"There is NO WARRANTY, to the extent permitted by law.\n"
+"Report bugs at <%2$s>\n"
+"Lepton EDA homepage: <%3$s>\n"
 msgstr ""
 
 #, c-format
 msgid "Got invalid show option; defaulting to show both\n"
-msgstr ""
-
-#, c-format
-msgid "ERROR: NULL object!\n"
 msgstr ""
 
 msgid "Single Attribute Editor"
@@ -879,7 +814,7 @@ msgid ""
 "duplicate slot may cause problems: [symbolname=%1$s, number=%2$d, slot=%3$d]"
 msgstr ""
 
-msgid "No searchstring given in autonumber text."
+msgid "No search string given in autonumber text."
 msgstr ""
 
 msgid "No '*' or '?' given at the end of the autonumber text."
@@ -953,24 +888,6 @@ msgid ""
 msgstr ""
 
 msgid "Clipboard insertion failed"
-msgstr ""
-
-#, c-format
-msgid "Could not allocate the color %1$s!\n"
-msgstr ""
-
-msgid "black"
-msgstr ""
-
-msgid "white"
-msgstr ""
-
-#, c-format
-msgid "Could not allocate display color %1$i!\n"
-msgstr ""
-
-#, c-format
-msgid "Could not allocate outline color %1$i!\n"
 msgstr ""
 
 #, c-format
@@ -1108,13 +1025,13 @@ msgstr ""
 msgid "Invalid Attribute"
 msgstr ""
 
-msgid "Schematics"
+msgid "Schematics (*.sch)"
 msgstr ""
 
-msgid "Symbols"
+msgid "Symbols (*.sym)"
 msgstr ""
 
-msgid "Schematics and symbols"
+msgid "Schematics and symbols (*.sch *.sym)"
 msgstr ""
 
 msgid "All files"
@@ -1150,7 +1067,7 @@ msgid "Hatch"
 msgstr ""
 
 #, c-format
-msgid "x_image_lowlevel: Unable to write %1$s file %2$s."
+msgid "Unable to write %1$s file %2$s."
 msgstr ""
 
 #, c-format
@@ -1169,7 +1086,7 @@ msgstr ""
 msgid "Wrote black and white image to [%1$s] [%2$d x %3$d]"
 msgstr ""
 
-msgid "x_image_lowlevel: Unable to get pixbuf from gschem's window."
+msgid "Unable to get pixbuf from lepton-schematic's window."
 msgstr ""
 
 msgid "NOTE: print-color-map will be used for PDF export"
@@ -1218,65 +1135,54 @@ msgstr ""
 msgid "Phantom"
 msgstr ""
 
-msgid "Add Net"
-msgstr ""
-
-msgid "Add Attribute"
-msgstr ""
-
 #, fuzzy
-msgid "Add Component"
+msgid "Add Co_mponent..."
 msgstr "Обнови Компонент"
 
-msgid "Add Bus"
+#, fuzzy
+msgid "Add Te_xt..."
+msgstr "Редактирай Текст..."
+
+msgid "Add _Attribute..."
 msgstr ""
 
 #, fuzzy
-msgid "Add Text"
+msgid "Add _Net"
 msgstr "Редактирай Текст..."
 
-msgid "Zoom In"
+msgid "Add _Bus"
 msgstr ""
 
-msgid "Zoom Out"
+msgid "Cu_t"
 msgstr ""
 
-msgid "Zoom Extents"
+msgid "_Copy"
 msgstr ""
 
-msgid "Select"
+msgid "_Paste"
 msgstr ""
 
-msgid "Edit..."
+msgid "_Delete"
+msgstr ""
+
+#, fuzzy
+msgid "_Edit..."
 msgstr "Редактирай..."
 
-msgid "Object Properties..."
+#, fuzzy
+msgid "Ed_it Text..."
+msgstr "Редактирай Текст..."
+
+msgid "_Object Properties..."
 msgstr ""
 
-msgid "Copy"
+msgid "Hierarchy: Down _Schematic"
 msgstr ""
 
-msgid "Move"
+msgid "Hierarchy: Down S_ymbol"
 msgstr ""
 
-msgid "Delete"
-msgstr "Изтрий"
-
-msgid "Down Schematic"
-msgstr ""
-
-msgid "Down Symbol"
-msgstr ""
-
-msgid "Up"
-msgstr ""
-
-#, c-format
-msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
-msgstr ""
-
-#, c-format
-msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
+msgid "Hierarchy: _Up"
 msgstr ""
 
 msgid "The operating system is out of memory or resources."
@@ -1300,6 +1206,9 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
+msgid "Delete"
+msgstr "Изтрий"
+
 #, fuzzy
 msgid "Copy to all"
 msgstr "Копирен Режим"
@@ -1317,6 +1226,9 @@ msgid "V"
 msgstr ""
 
 msgid "Sho_w inherited attributes"
+msgstr ""
+
+msgid "Add Attribute"
 msgstr ""
 
 msgid "_Name:"
@@ -1427,6 +1339,24 @@ msgstr ""
 msgid "Hierarchy up"
 msgstr ""
 
+msgid "_New"
+msgstr ""
+
+msgid "_Open..."
+msgstr ""
+
+msgid "_Save"
+msgstr ""
+
+msgid "Save _As..."
+msgstr ""
+
+msgid "Page _Manager..."
+msgstr ""
+
+msgid "_Close"
+msgstr ""
+
 msgid "Options"
 msgstr ""
 
@@ -1535,6 +1465,9 @@ msgstr ""
 msgid "Add Text..."
 msgstr ""
 
+msgid "Select"
+msgstr ""
+
 msgid "Select mode"
 msgstr ""
 
@@ -1595,19 +1528,7 @@ msgstr ""
 msgid "Create and edit electrical schematics and symbols with lepton-schematic"
 msgstr ""
 
-msgid "_New"
-msgstr ""
-
-msgid "_Open..."
-msgstr ""
-
 msgid "Open Recen_t"
-msgstr ""
-
-msgid "_Save"
-msgstr ""
-
-msgid "Save _As..."
 msgstr ""
 
 msgid "Save All"
@@ -1641,18 +1562,6 @@ msgstr ""
 msgid "_Redo"
 msgstr ""
 
-msgid "Cu_t"
-msgstr ""
-
-msgid "_Copy"
-msgstr ""
-
-msgid "_Paste"
-msgstr ""
-
-msgid "_Delete"
-msgstr ""
-
 msgid "Select All"
 msgstr ""
 
@@ -1661,6 +1570,12 @@ msgstr ""
 
 msgid "Rotate 90 Mode"
 msgstr "Завърти 90 Режим"
+
+msgid "Object Properties..."
+msgstr ""
+
+msgid "Edit..."
+msgstr "Редактирай..."
 
 msgid "Edit Text..."
 msgstr "Редактирай Текст..."
@@ -1780,9 +1695,6 @@ msgstr ""
 msgid "_Next"
 msgstr ""
 
-msgid "_Close"
-msgstr ""
-
 msgid "_Revert..."
 msgstr ""
 
@@ -1888,6 +1800,9 @@ msgid "Grid Style: Cycle Dots/Mesh/Off"
 msgstr ""
 
 msgid "Grid Snap: Cycle Grid/Resnap/Off"
+msgstr ""
+
+msgid "Grips: On/Off"
 msgstr ""
 
 msgid "Feedback Mode: Outline/Box"
@@ -2026,6 +1941,9 @@ msgstr ""
 msgid "Cut"
 msgstr ""
 
+msgid "Copy"
+msgstr ""
+
 msgid "Paste"
 msgstr ""
 
@@ -2049,6 +1967,15 @@ msgid "Pan Up"
 msgstr ""
 
 msgid "Pan Down"
+msgstr ""
+
+msgid "Zoom Extents"
+msgstr ""
+
+msgid "Zoom In"
+msgstr ""
+
+msgid "Zoom Out"
 msgstr ""
 
 msgid "Zoom Full"
@@ -2081,6 +2008,20 @@ msgstr "Нова Страница"
 msgid "Print Page"
 msgstr "Затвори Страницата"
 
+#, fuzzy
+msgid "Add Component"
+msgstr "Обнови Компонент"
+
+msgid "Add Net"
+msgstr ""
+
+msgid "Add Bus"
+msgstr ""
+
+#, fuzzy
+msgid "Add Text"
+msgstr "Редактирай Текст..."
+
 msgid "Add Line"
 msgstr ""
 
@@ -2100,6 +2041,12 @@ msgid "Add Pin"
 msgstr ""
 
 msgid "Add Picture"
+msgstr ""
+
+msgid "Down Schematic"
+msgstr ""
+
+msgid "Down Symbol"
 msgstr ""
 
 msgid "Up Hierarchy"
@@ -2174,6 +2121,9 @@ msgstr "Нов Прозорец"
 msgid "Show Coordinate Window"
 msgstr ""
 
+msgid "Toggle Grips"
+msgstr ""
+
 msgid "Component Documentation"
 msgstr ""
 
@@ -2208,10 +2158,6 @@ msgstr ""
 msgid "About lepton-schematic"
 msgstr ""
 
-#, scheme-format
-msgid "Invalid text alignment ~A."
-msgstr ""
-
 msgid "Could not show documentation:"
 msgstr ""
 
@@ -2224,6 +2170,10 @@ msgstr ""
 
 #, scheme-format
 msgid "~S is not a prefix key sequence."
+msgstr ""
+
+#, scheme-format
+msgid "Invalid text alignment ~A."
 msgstr ""
 
 #~ msgid "Edit"

--- a/schematic/po/bs.po
+++ b/schematic/po/bs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-10-03 23:34+0300\n"
+"POT-Creation-Date: 2020-03-18 20:44+0300\n"
 "PO-Revision-Date: 2012-01-27 14:18+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: Bosnian <bs@li.org>\n"
@@ -19,6 +19,13 @@ msgstr ""
 "X-Generator: Launchpad (build 16265)\n"
 
 msgid "Zoom too small!  Cannot zoom further."
+msgstr ""
+
+msgid ""
+"Save your color scheme to a file by clicking on the \"Save As...\"\n"
+"button. It can be loaded on startup with the following\n"
+"expression in the gschemrc configuration file:\n"
+"( primitive-load \"/path/to/saved-color-scheme-file\" )"
 msgstr ""
 
 #, c-format
@@ -46,6 +53,11 @@ msgstr ""
 msgid "Sa_ve..."
 msgstr ""
 
+msgid ""
+"After you're done choosing the font, it's recommended\n"
+"to reopen schematics or restart the application."
+msgstr ""
+
 #, c-format
 msgid "<b>Current:</b> %s"
 msgstr ""
@@ -53,23 +65,20 @@ msgstr ""
 msgid "Save configuration"
 msgstr ""
 
-msgid "Save settings to:"
+msgid "Local configuration file:"
 msgstr ""
 
-msgid "Local configuration file (in current directory)"
+msgid "User configuration file:"
 msgstr ""
 
-msgid "User configuration file (geda-user.conf)"
-msgstr ""
-
-msgid "Object ~A is not included in the current gschem page."
+msgid "Object ~A is not included in the current lepton-schematic page."
 msgstr ""
 
 msgid "Invalid text name/value visibility ~A."
 msgstr ""
 
 #, fuzzy, c-format
-msgid "You are running gEDA/gaf version [%1$s%2$s.%3$s],\n"
+msgid "You are running lepton-schematic version [%1$s%2$s.%3$s],\n"
 msgstr "gEDA/gschem verzija %s%s.%s\n"
 
 #, c-format
@@ -82,65 +91,13 @@ msgstr ""
 msgid "Please be sure that you have the latest rc file.\n"
 msgstr ""
 
-#, c-format
-msgid "Invalid size [%1$d] passed to text-size\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid size [%1$d] passed to snap-size\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid num levels [%1$d] passed to undo-levels\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid gain [%1$d] passed to zoom-gain\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
-msgstr ""
-
 msgid "Object ~A is not directly included in a page."
 msgstr ""
 
 msgid "Could not launch URI ~S: ~A"
 msgstr ""
 
-msgid "Found invalid gschem window smob ~S"
+msgid "Found invalid lepton-schematic window smob ~S"
 msgstr ""
 
 #, fuzzy, c-format
@@ -171,7 +128,7 @@ msgstr ""
 
 msgid ""
 "Copyright © 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright © 2017-2019 Lepton Developers.\n"
+"Copyright © 2017-2020 Lepton Developers.\n"
 "See AUTHORS, ChangeLog files and consult 'git log' history for details."
 msgstr ""
 
@@ -610,7 +567,8 @@ msgid ""
 "\n"
 "Are you sure you want to revert this page?\n"
 "All unsaved changes in current schematic will be\n"
-"discarded and page file will be reloaded from disk."
+"discarded and page file will be reloaded from disk.\n"
+"This action will also reload all component libraries."
 msgstr ""
 
 #, fuzzy
@@ -705,10 +663,6 @@ msgid_plural "Delete %1$u locked objects?"
 msgstr[0] ""
 msgstr[1] ""
 
-#, c-format
-msgid "Got an unexpected NULL in o_edit\n"
-msgstr ""
-
 msgid "Hidden text is now visible"
 msgstr ""
 
@@ -720,7 +674,7 @@ msgid "Could not find symbol [%1$s] in library. Update failed."
 msgstr ""
 
 #, c-format
-msgid "o_autosave_backups: Can't get the real filename of %1$s."
+msgid "Can't get the real filename of %1$s."
 msgstr ""
 
 #, c-format
@@ -733,10 +687,6 @@ msgstr ""
 
 #, c-format
 msgid "Could NOT save backup file [%1$s]"
-msgstr ""
-
-#, c-format
-msgid "ERROR: NULL object in o_move_end!\n"
 msgstr ""
 
 #, c-format
@@ -785,7 +735,7 @@ msgstr ""
 msgid "New slot number out of range"
 msgstr ""
 
-msgid "Undo/Redo disabled in rc file"
+msgid "Undo/Redo is disabled in configuration"
 msgstr ""
 
 #, c-format
@@ -806,27 +756,12 @@ msgid ""
 "  -h, --help               Help; this message.\n"
 "  --                       Treat all remaining arguments as filenames.\n"
 "\n"
-"Report bugs at <https://github.com/lepton-eda/lepton-eda/issues>\n"
-"Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"Lepton EDA %1$s (git: %2$.7s)\n"
-"Copyright (C) 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright (C) 2017-2019 Lepton Developers.\n"
-"This is free software, and you are welcome to redistribute it under\n"
-"certain conditions. For details, see the file `COPYING', which is\n"
-"included in the Lepton EDA distribution.\n"
-"There is NO WARRANTY, to the extent permitted by law.\n"
+"Report bugs at <%2$s>\n"
+"Lepton EDA homepage: <%3$s>\n"
 msgstr ""
 
 #, c-format
 msgid "Got invalid show option; defaulting to show both\n"
-msgstr ""
-
-#, c-format
-msgid "ERROR: NULL object!\n"
 msgstr ""
 
 msgid "Single Attribute Editor"
@@ -881,7 +816,7 @@ msgid ""
 "duplicate slot may cause problems: [symbolname=%1$s, number=%2$d, slot=%3$d]"
 msgstr ""
 
-msgid "No searchstring given in autonumber text."
+msgid "No search string given in autonumber text."
 msgstr ""
 
 msgid "No '*' or '?' given at the end of the autonumber text."
@@ -955,24 +890,6 @@ msgid ""
 msgstr ""
 
 msgid "Clipboard insertion failed"
-msgstr ""
-
-#, c-format
-msgid "Could not allocate the color %1$s!\n"
-msgstr ""
-
-msgid "black"
-msgstr ""
-
-msgid "white"
-msgstr ""
-
-#, c-format
-msgid "Could not allocate display color %1$i!\n"
-msgstr ""
-
-#, c-format
-msgid "Could not allocate outline color %1$i!\n"
 msgstr ""
 
 #, c-format
@@ -1113,13 +1030,13 @@ msgstr ""
 msgid "Invalid Attribute"
 msgstr ""
 
-msgid "Schematics"
+msgid "Schematics (*.sch)"
 msgstr ""
 
-msgid "Symbols"
+msgid "Symbols (*.sym)"
 msgstr ""
 
-msgid "Schematics and symbols"
+msgid "Schematics and symbols (*.sch *.sym)"
 msgstr ""
 
 msgid "All files"
@@ -1155,7 +1072,7 @@ msgid "Hatch"
 msgstr ""
 
 #, c-format
-msgid "x_image_lowlevel: Unable to write %1$s file %2$s."
+msgid "Unable to write %1$s file %2$s."
 msgstr ""
 
 #, c-format
@@ -1174,7 +1091,7 @@ msgstr ""
 msgid "Wrote black and white image to [%1$s] [%2$d x %3$d]"
 msgstr ""
 
-msgid "x_image_lowlevel: Unable to get pixbuf from gschem's window."
+msgid "Unable to get pixbuf from lepton-schematic's window."
 msgstr ""
 
 msgid "NOTE: print-color-map will be used for PDF export"
@@ -1223,72 +1140,59 @@ msgstr ""
 msgid "Phantom"
 msgstr ""
 
-msgid "Add Net"
-msgstr ""
-
-msgid "Add Attribute"
-msgstr ""
-
 #, fuzzy
-msgid "Add Component"
+msgid "Add Co_mponent..."
 msgstr "Komponenta"
 
-msgid "Add Bus"
-msgstr ""
-
 #, fuzzy
-msgid "Add Text"
+msgid "Add Te_xt..."
 msgstr "Izmijeni tekst"
 
 #, fuzzy
-msgid "Zoom In"
-msgstr "_Uvećaj"
+msgid "Add _Attribute..."
+msgstr "_Atribut..."
 
 #, fuzzy
-msgid "Zoom Out"
-msgstr "U_manji"
+msgid "Add _Net"
+msgstr "Izmijeni tekst"
 
-#, fuzzy
-msgid "Zoom Extents"
-msgstr "Okvir zooma"
-
-msgid "Select"
+msgid "Add _Bus"
 msgstr ""
 
-msgid "Edit..."
+msgid "Cu_t"
+msgstr "_Isijeci"
+
+msgid "_Copy"
+msgstr "_Kopiraj"
+
+msgid "_Paste"
+msgstr "_Umetni"
+
+msgid "_Delete"
+msgstr "_Obriši"
+
+#, fuzzy
+msgid "_Edit..."
 msgstr "Izmijeni..."
 
-msgid "Object Properties..."
+#, fuzzy
+msgid "Ed_it Text..."
+msgstr "Izmijeni tekst..."
+
+msgid "_Object Properties..."
 msgstr ""
 
-msgid "Copy"
-msgstr "Kopiraj"
-
-msgid "Move"
-msgstr "Premjesti"
-
-msgid "Delete"
-msgstr "Obriši"
-
 #, fuzzy
-msgid "Down Schematic"
+msgid "Hierarchy: Down _Schematic"
 msgstr "_Dolje Shemu"
 
 #, fuzzy
-msgid "Down Symbol"
+msgid "Hierarchy: Down S_ymbol"
 msgstr "Doljen _Simbol"
 
 #, fuzzy
-msgid "Up"
-msgstr "_Gore"
-
-#, c-format
-msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
-msgstr ""
-
-#, c-format
-msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
-msgstr ""
+msgid "Hierarchy: _Up"
+msgstr "Hije_rarhija"
 
 msgid "The operating system is out of memory or resources."
 msgstr ""
@@ -1311,6 +1215,9 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
+msgid "Delete"
+msgstr "Obriši"
+
 #, fuzzy
 msgid "Copy to all"
 msgstr "Kopiraj u 1"
@@ -1330,6 +1237,9 @@ msgstr ""
 #, fuzzy
 msgid "Sho_w inherited attributes"
 msgstr "Atribut"
+
+msgid "Add Attribute"
+msgstr ""
 
 msgid "_Name:"
 msgstr ""
@@ -1441,6 +1351,24 @@ msgstr "Hije_rarhija"
 msgid "Hierarchy up"
 msgstr "Hije_rarhija"
 
+msgid "_New"
+msgstr "_Nova"
+
+msgid "_Open..."
+msgstr "_Otvori..."
+
+msgid "_Save"
+msgstr "_Snimi"
+
+msgid "Save _As..."
+msgstr "Snimi _kao..."
+
+msgid "Page _Manager..."
+msgstr ""
+
+msgid "_Close"
+msgstr "_Zatvori"
+
 #, fuzzy
 msgid "Options"
 msgstr "_Opcije"
@@ -1550,6 +1478,9 @@ msgstr ""
 msgid "Add Text..."
 msgstr ""
 
+msgid "Select"
+msgstr ""
+
 msgid "Select mode"
 msgstr ""
 
@@ -1611,20 +1542,8 @@ msgstr ""
 msgid "Create and edit electrical schematics and symbols with lepton-schematic"
 msgstr ""
 
-msgid "_New"
-msgstr "_Nova"
-
-msgid "_Open..."
-msgstr "_Otvori..."
-
 msgid "Open Recen_t"
 msgstr "O_tvori ranije"
-
-msgid "_Save"
-msgstr "_Snimi"
-
-msgid "Save _As..."
-msgstr "Snimi _kao..."
 
 msgid "Save All"
 msgstr "Snimi sve"
@@ -1657,18 +1576,6 @@ msgstr "_Poništi"
 msgid "_Redo"
 msgstr "_Vrati"
 
-msgid "Cu_t"
-msgstr "_Isijeci"
-
-msgid "_Copy"
-msgstr "_Kopiraj"
-
-msgid "_Paste"
-msgstr "_Umetni"
-
-msgid "_Delete"
-msgstr "_Obriši"
-
 msgid "Select All"
 msgstr ""
 
@@ -1677,6 +1584,12 @@ msgstr ""
 
 msgid "Rotate 90 Mode"
 msgstr "Režim rotacije 90 stepeni"
+
+msgid "Object Properties..."
+msgstr ""
+
+msgid "Edit..."
+msgstr "Izmijeni..."
 
 msgid "Edit Text..."
 msgstr "Izmijeni tekst..."
@@ -1796,9 +1709,6 @@ msgstr "_Prethodna"
 msgid "_Next"
 msgstr "_Naredna"
 
-msgid "_Close"
-msgstr "_Zatvori"
-
 #, fuzzy
 msgid "_Revert..."
 msgstr "_Vrati"
@@ -1908,6 +1818,9 @@ msgid "Grid Style: Cycle Dots/Mesh/Off"
 msgstr ""
 
 msgid "Grid Snap: Cycle Grid/Resnap/Off"
+msgstr ""
+
+msgid "Grips: On/Off"
 msgstr ""
 
 msgid "Feedback Mode: Outline/Box"
@@ -2052,6 +1965,9 @@ msgstr ""
 msgid "Cut"
 msgstr "_Isijeci"
 
+msgid "Copy"
+msgstr "Kopiraj"
+
 #, fuzzy
 msgid "Paste"
 msgstr "_Umetni"
@@ -2078,6 +1994,18 @@ msgstr ""
 
 msgid "Pan Down"
 msgstr ""
+
+#, fuzzy
+msgid "Zoom Extents"
+msgstr "Okvir zooma"
+
+#, fuzzy
+msgid "Zoom In"
+msgstr "_Uvećaj"
+
+#, fuzzy
+msgid "Zoom Out"
+msgstr "U_manji"
 
 #, fuzzy
 msgid "Zoom Full"
@@ -2110,6 +2038,20 @@ msgid "Print Page"
 msgstr "_Prethodna"
 
 #, fuzzy
+msgid "Add Component"
+msgstr "Komponenta"
+
+msgid "Add Net"
+msgstr ""
+
+msgid "Add Bus"
+msgstr ""
+
+#, fuzzy
+msgid "Add Text"
+msgstr "Izmijeni tekst"
+
+#, fuzzy
 msgid "Add Line"
 msgstr "Linija"
 
@@ -2132,6 +2074,14 @@ msgstr ""
 #, fuzzy
 msgid "Add Picture"
 msgstr "Sli_ka..."
+
+#, fuzzy
+msgid "Down Schematic"
+msgstr "_Dolje Shemu"
+
+#, fuzzy
+msgid "Down Symbol"
+msgstr "Doljen _Simbol"
 
 #, fuzzy
 msgid "Up Hierarchy"
@@ -2211,6 +2161,9 @@ msgstr "Novi prozor"
 msgid "Show Coordinate Window"
 msgstr ""
 
+msgid "Toggle Grips"
+msgstr ""
+
 msgid "Component Documentation"
 msgstr ""
 
@@ -2245,10 +2198,6 @@ msgstr ""
 msgid "About lepton-schematic"
 msgstr ""
 
-#, scheme-format
-msgid "Invalid text alignment ~A."
-msgstr ""
-
 msgid "Could not show documentation:"
 msgstr ""
 
@@ -2262,6 +2211,17 @@ msgstr ""
 #, scheme-format
 msgid "~S is not a prefix key sequence."
 msgstr ""
+
+#, scheme-format
+msgid "Invalid text alignment ~A."
+msgstr ""
+
+#~ msgid "Move"
+#~ msgstr "Premjesti"
+
+#, fuzzy
+#~ msgid "Up"
+#~ msgstr "_Gore"
 
 #~ msgid "Edit"
 #~ msgstr "Izmijeni"

--- a/schematic/po/de.po
+++ b/schematic/po/de.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-10-03 23:34+0300\n"
+"POT-Creation-Date: 2020-03-18 20:44+0300\n"
 "PO-Revision-Date: 2012-04-12 22:09+0000\n"
 "Last-Translator: Dennis Baudys <Unknown>\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -22,6 +22,13 @@ msgstr ""
 #, fuzzy
 msgid "Zoom too small!  Cannot zoom further."
 msgstr "Bereich zu klein! Eine weitere Vergrößerung ist nicht möglich.\n"
+
+msgid ""
+"Save your color scheme to a file by clicking on the \"Save As...\"\n"
+"button. It can be loaded on startup with the following\n"
+"expression in the gschemrc configuration file:\n"
+"( primitive-load \"/path/to/saved-color-scheme-file\" )"
+msgstr ""
 
 #, fuzzy, c-format
 msgid ""
@@ -52,6 +59,11 @@ msgstr ""
 msgid "Sa_ve..."
 msgstr ""
 
+msgid ""
+"After you're done choosing the font, it's recommended\n"
+"to reopen schematics or restart the application."
+msgstr ""
+
 #, c-format
 msgid "<b>Current:</b> %s"
 msgstr ""
@@ -59,24 +71,21 @@ msgstr ""
 msgid "Save configuration"
 msgstr ""
 
+msgid "Local configuration file:"
+msgstr ""
+
+msgid "User configuration file:"
+msgstr ""
+
 #, fuzzy
-msgid "Save settings to:"
-msgstr "Einstellungen"
-
-msgid "Local configuration file (in current directory)"
-msgstr ""
-
-msgid "User configuration file (geda-user.conf)"
-msgstr ""
-
-msgid "Object ~A is not included in the current gschem page."
+msgid "Object ~A is not included in the current lepton-schematic page."
 msgstr "Das Objekt ~A ist im aktuellen Schaltplan nicht enthalten."
 
 msgid "Invalid text name/value visibility ~A."
 msgstr "Ungültiger Wert für das Sichtbarkeitsattribut von  ~A."
 
 #, fuzzy, c-format
-msgid "You are running gEDA/gaf version [%1$s%2$s.%3$s],\n"
+msgid "You are running lepton-schematic version [%1$s%2$s.%3$s],\n"
 msgstr "gEDA/gschem Version %s%s.%s\n"
 
 #, c-format
@@ -89,74 +98,15 @@ msgstr ""
 msgid "Please be sure that you have the latest rc file.\n"
 msgstr ""
 
-#, fuzzy, c-format
-msgid "Invalid size [%1$d] passed to text-size\n"
-msgstr "Eine ungültige Größe [%d] wurde an text-size übergeben.\n"
-
-#, fuzzy, c-format
-msgid "Invalid size [%1$d] passed to snap-size\n"
-msgstr "Eine ungültige Größe [%d] wurde an snap-size übergeben.\n"
-
-#, fuzzy, c-format
-msgid "Invalid num levels [%1$d] passed to undo-levels\n"
-msgstr "Eine ungültige Ebenenanzahl [%d] wurde an undo-levels übergeben.\n"
-
-#, fuzzy, c-format
-msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
-msgstr "Eine ungültige Größe [%d] wurde an bus-ripper-size übergeben.\n"
-
-#, fuzzy, c-format
-msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
-msgstr "An \"grid-dot-size\" wurde eine falsche Punktgröße [%d] übergeben\n"
-
-#, fuzzy, c-format
-msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
-msgstr ""
-"An \"grid-fixed-threshold\" wurde ein falscher Punktabstand [%d] übergeben\n"
-
-#, fuzzy, c-format
-msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
-msgstr ""
-"An \"mesh-grid-display-treshold\" wurde ein falscher Punktabstand [%d] "
-"übergeben.\n"
-
-#, fuzzy, c-format
-msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
-msgstr ""
-"An \"auto-save-interval\" wurde eine ungültige Sekundenanzahl [%d] "
-"übergeben\n"
-
-#, fuzzy, c-format
-msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
-msgstr "Ein ungültiger Werte [%d] wurde an mousepan-gain übergeben.\n"
-
-#, fuzzy, c-format
-msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
-msgstr "Ein ungültiger Wert [%d] wurde an keyboardpan-gain übergeben.\n"
-
-#, fuzzy, c-format
-msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
-msgstr ""
-"An \"select-slack-pixels\" wurde eine ungültige Pixelzahl [%d] übergeben\n"
-
-#, fuzzy, c-format
-msgid "Invalid gain [%1$d] passed to zoom-gain\n"
-msgstr "Ein unzulässiger Wert [%d] wurde an zoom-gain übergeben\n"
-
-#, fuzzy, c-format
-msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
-msgstr ""
-"Eine unzulässige Anzahl von Schritten [%d] wurde an scrollpan-steps "
-"übergeben\n"
-
 msgid "Object ~A is not directly included in a page."
 msgstr "Das Objekt ~A ist in keiner Schaltplanseite direkt eingebunden."
 
 msgid "Could not launch URI ~S: ~A"
 msgstr "Die URI ~S konnte nicht geladen werden: ~A"
 
-msgid "Found invalid gschem window smob ~S"
-msgstr ""
+#, fuzzy
+msgid "Found invalid lepton-schematic window smob ~S"
+msgstr "~S ist keine gültige Tasten-Kombination."
 
 #, fuzzy, c-format
 msgid "Lepton EDA/lepton-schematic version %1$s%2$s.%3$s git: %4$.7s"
@@ -191,7 +141,7 @@ msgstr "gEDA: GPL Electronic Design Automation"
 #, fuzzy
 msgid ""
 "Copyright © 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright © 2017-2019 Lepton Developers.\n"
+"Copyright © 2017-2020 Lepton Developers.\n"
 "See AUTHORS, ChangeLog files and consult 'git log' history for details."
 msgstr ""
 "Copyright © 1998-2012 Ales Hvezda <ahvezda@geda.seul.org>\n"
@@ -687,7 +637,8 @@ msgid ""
 "\n"
 "Are you sure you want to revert this page?\n"
 "All unsaved changes in current schematic will be\n"
-"discarded and page file will be reloaded from disk."
+"discarded and page file will be reloaded from disk.\n"
+"This action will also reload all component libraries."
 msgstr ""
 
 #, fuzzy
@@ -801,10 +752,6 @@ msgid_plural "Delete %1$u locked objects?"
 msgstr[0] "Ausgewählte Objekte"
 msgstr[1] "Ausgewählte Objekte"
 
-#, c-format
-msgid "Got an unexpected NULL in o_edit\n"
-msgstr "Der Rückgabewert von o_edit war unerwartet NULL\n"
-
 #, fuzzy
 msgid "Hidden text is now visible"
 msgstr "Verborgener Text ist jetzt sichtbar.\n"
@@ -820,7 +767,7 @@ msgstr ""
 "fehlgeschlagen.\n"
 
 #, fuzzy, c-format
-msgid "o_autosave_backups: Can't get the real filename of %1$s."
+msgid "Can't get the real filename of %1$s."
 msgstr ""
 "o_autosave_backups: Konnte den tatsächlichen Dateinamen von %s nicht "
 "ermitteln."
@@ -837,10 +784,6 @@ msgstr "Die Backup-Datei [%s] konnte nicht auf readonly gesetzt werden.\n"
 #, fuzzy, c-format
 msgid "Could NOT save backup file [%1$s]"
 msgstr "Die Backup-Datei [%s] konnte nicht gespeichert werden.\n"
-
-#, c-format
-msgid "ERROR: NULL object in o_move_end!\n"
-msgstr "FEHLER: NULL Objekt innerhalb von o_move_end.\n"
 
 #, c-format
 msgid "DOH! tried to find the whichone, but didn't find it!\n"
@@ -900,7 +843,7 @@ msgid "New slot number out of range"
 msgstr "Neue slot Nummer außerhalb des gültigen Wertebereichs\n"
 
 #, fuzzy
-msgid "Undo/Redo disabled in rc file"
+msgid "Undo/Redo is disabled in configuration"
 msgstr "Rückgängig/Wiederherstellen wurde in der rc Datei deaktiviert.\n"
 
 #, c-format
@@ -921,28 +864,13 @@ msgid ""
 "  -h, --help               Help; this message.\n"
 "  --                       Treat all remaining arguments as filenames.\n"
 "\n"
-"Report bugs at <https://github.com/lepton-eda/lepton-eda/issues>\n"
-"Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"Lepton EDA %1$s (git: %2$.7s)\n"
-"Copyright (C) 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright (C) 2017-2019 Lepton Developers.\n"
-"This is free software, and you are welcome to redistribute it under\n"
-"certain conditions. For details, see the file `COPYING', which is\n"
-"included in the Lepton EDA distribution.\n"
-"There is NO WARRANTY, to the extent permitted by law.\n"
+"Report bugs at <%2$s>\n"
+"Lepton EDA homepage: <%3$s>\n"
 msgstr ""
 
 #, c-format
 msgid "Got invalid show option; defaulting to show both\n"
 msgstr "Ungültige Anzeigeoption; »Beide anzeigen« wird zur Vorgabe\n"
-
-#, c-format
-msgid "ERROR: NULL object!\n"
-msgstr "FEHLER: NULL Objekt!\n"
 
 msgid "Single Attribute Editor"
 msgstr "Einzel-Attributebearbeitung"
@@ -1005,7 +933,7 @@ msgstr ""
 "%d, slot=%d]\n"
 
 #, fuzzy
-msgid "No searchstring given in autonumber text."
+msgid "No search string given in autonumber text."
 msgstr "Es wurde kein Suchstring im Dialog eingegeben.\n"
 
 #, fuzzy
@@ -1084,24 +1012,6 @@ msgstr ""
 
 msgid "Clipboard insertion failed"
 msgstr "Einfügen von der Ablage scheiterte."
-
-#, fuzzy, c-format
-msgid "Could not allocate the color %1$s!\n"
-msgstr "Konnte die Farbe %s nicht zuteilen!\n"
-
-msgid "black"
-msgstr "schwarz"
-
-msgid "white"
-msgstr "weiss"
-
-#, fuzzy, c-format
-msgid "Could not allocate display color %1$i!\n"
-msgstr "Konnte die Bildschirmfarbe %i nicht allokieren!\n"
-
-#, fuzzy, c-format
-msgid "Could not allocate outline color %1$i!\n"
-msgstr "Konnte die Umrissfarbe %i nicht allokieren!\n"
 
 #, fuzzy, c-format
 msgid "Tried to get an invalid color: %1$d\n"
@@ -1249,13 +1159,16 @@ msgstr ""
 msgid "Invalid Attribute"
 msgstr "Fehlerhaftes Attribut"
 
-msgid "Schematics"
+#, fuzzy
+msgid "Schematics (*.sch)"
 msgstr "Schaltpläne"
 
-msgid "Symbols"
+#, fuzzy
+msgid "Symbols (*.sym)"
 msgstr "Symbole"
 
-msgid "Schematics and symbols"
+#, fuzzy
+msgid "Schematics and symbols (*.sch *.sym)"
 msgstr "Schaltpläne und Symbole"
 
 msgid "All files"
@@ -1292,7 +1205,7 @@ msgid "Hatch"
 msgstr "Schraffiert"
 
 #, fuzzy, c-format
-msgid "x_image_lowlevel: Unable to write %1$s file %2$s."
+msgid "Unable to write %1$s file %2$s."
 msgstr "x_image_lowlevel: Konnte %s-Datei %s nicht schreiben.\n"
 
 #, fuzzy, c-format
@@ -1316,7 +1229,7 @@ msgid "Wrote black and white image to [%1$s] [%2$d x %3$d]"
 msgstr "Schwarz & weiß Bild als [%s] gespeichert. Größe [%d x %d]\n"
 
 #, fuzzy
-msgid "x_image_lowlevel: Unable to get pixbuf from gschem's window."
+msgid "Unable to get pixbuf from lepton-schematic's window."
 msgstr "x_image_lowlevel: konnte kein Bild vom gschem-Fenster bekommen.\n"
 
 msgid "NOTE: print-color-map will be used for PDF export"
@@ -1366,78 +1279,60 @@ msgid "Phantom"
 msgstr "Strich-Zwei-Punkt"
 
 #, fuzzy
-msgid "Add Net"
-msgstr "/Netz einfügen"
-
-msgid "Add Attribute"
-msgstr "Attribut hinzufügen"
-
-#, fuzzy
-msgid "Add Component"
+msgid "Add Co_mponent..."
 msgstr "/Bauteil hinzufügen …"
 
 #, fuzzy
-msgid "Add Bus"
+msgid "Add Te_xt..."
+msgstr "Text hinzufügen …"
+
+#, fuzzy
+msgid "Add _Attribute..."
+msgstr "/Attribut hinzufügen …"
+
+#, fuzzy
+msgid "Add _Net"
+msgstr "/Netz einfügen"
+
+#, fuzzy
+msgid "Add _Bus"
 msgstr "/Bus einfügen"
 
-#, fuzzy
-msgid "Add Text"
-msgstr "/Text einfügen"
+msgid "Cu_t"
+msgstr "_Ausschneiden"
+
+msgid "_Copy"
+msgstr "_Kopieren"
+
+msgid "_Paste"
+msgstr "E_infügen"
+
+msgid "_Delete"
+msgstr "_Löschen"
 
 #, fuzzy
-msgid "Zoom In"
-msgstr "/Vergrößern"
-
-#, fuzzy
-msgid "Zoom Out"
-msgstr "/Verkleinern"
-
-#, fuzzy
-msgid "Zoom Extents"
-msgstr "/Automatisch"
-
-msgid "Select"
-msgstr "Auswählen"
-
-msgid "Edit..."
+msgid "_Edit..."
 msgstr "Bearbeiten …"
 
 #, fuzzy
-msgid "Object Properties..."
-msgstr "<b>Texteigenschaften</b>"
-
-msgid "Copy"
-msgstr "Kopieren"
-
-msgid "Move"
-msgstr "Verschieben"
-
-msgid "Delete"
-msgstr "Löschen"
+msgid "Ed_it Text..."
+msgstr "Text bearbeiten …"
 
 #, fuzzy
-msgid "Down Schematic"
+msgid "_Object Properties..."
+msgstr "<b>Texteigenschaften</b>"
+
+#, fuzzy
+msgid "Hierarchy: Down _Schematic"
 msgstr "/Zum Schaltplan hinab"
 
 #, fuzzy
-msgid "Down Symbol"
+msgid "Hierarchy: Down S_ymbol"
 msgstr "/Zum Symbol hinab"
 
 #, fuzzy
-msgid "Up"
-msgstr "/Hinauf"
-
-#, fuzzy, c-format
-msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
-msgstr ""
-"Es wurde versucht die Empfindlichkeit des nicht existenten Menueintrags '%s' "
-"zu setzen\n"
-
-#, c-format
-msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
-msgstr ""
-"Es wurde versucht die Empfindlichkeit des nicht existenten Menueintrags '%s' "
-"zu setzen\n"
+msgid "Hierarchy: _Up"
+msgstr "Hie_rarchie"
 
 msgid "The operating system is out of memory or resources."
 msgstr "Zu wenig Speicher, oder andere Resoucen."
@@ -1461,6 +1356,9 @@ msgstr "Einsetzen"
 msgid "Duplicate"
 msgstr "Duplizieren"
 
+msgid "Delete"
+msgstr "Löschen"
+
 #, fuzzy
 msgid "Copy to all"
 msgstr "Kopieren in 1"
@@ -1480,6 +1378,9 @@ msgstr "Wert"
 #, fuzzy
 msgid "Sho_w inherited attributes"
 msgstr "Geerbte Attribute anzeigen"
+
+msgid "Add Attribute"
+msgstr "Attribut hinzufügen"
 
 #, fuzzy
 msgid "_Name:"
@@ -1596,6 +1497,25 @@ msgstr "Hie_rarchie"
 #, fuzzy
 msgid "Hierarchy up"
 msgstr "Hie_rarchie"
+
+msgid "_New"
+msgstr "_Neu"
+
+msgid "_Open..."
+msgstr "Ö_ffnen …"
+
+msgid "_Save"
+msgstr "_Speichern"
+
+msgid "Save _As..."
+msgstr "Speichern _unter …"
+
+#, fuzzy
+msgid "Page _Manager..."
+msgstr "Seitenverwaltung"
+
+msgid "_Close"
+msgstr "S_chließen"
 
 #, fuzzy
 msgid "Options"
@@ -1717,6 +1637,9 @@ msgstr ""
 msgid "Add Text..."
 msgstr "Text hinzufügen …"
 
+msgid "Select"
+msgstr "Auswählen"
+
 msgid "Select mode"
 msgstr "Auswahlmodus"
 
@@ -1788,20 +1711,8 @@ msgstr ""
 "Erstellen oder editieren eines elektrischen Schaltplans oder Symbols mit "
 "gschem"
 
-msgid "_New"
-msgstr "_Neu"
-
-msgid "_Open..."
-msgstr "Ö_ffnen …"
-
 msgid "Open Recen_t"
 msgstr "_Zuletzt  geöffnet"
-
-msgid "_Save"
-msgstr "_Speichern"
-
-msgid "Save _As..."
-msgstr "Speichern _unter …"
 
 msgid "Save All"
 msgstr "_Alles speichern"
@@ -1835,18 +1746,6 @@ msgstr "_Rückgängig"
 msgid "_Redo"
 msgstr "_Wiederherstellen"
 
-msgid "Cu_t"
-msgstr "_Ausschneiden"
-
-msgid "_Copy"
-msgstr "_Kopieren"
-
-msgid "_Paste"
-msgstr "E_infügen"
-
-msgid "_Delete"
-msgstr "_Löschen"
-
 msgid "Select All"
 msgstr "Alles auswählen"
 
@@ -1855,6 +1754,13 @@ msgstr "Auswahl aufheben"
 
 msgid "Rotate 90 Mode"
 msgstr "Drehmodus (90°)"
+
+#, fuzzy
+msgid "Object Properties..."
+msgstr "<b>Texteigenschaften</b>"
+
+msgid "Edit..."
+msgstr "Bearbeiten …"
 
 msgid "Edit Text..."
 msgstr "Text bearbeiten …"
@@ -1979,9 +1885,6 @@ msgstr "_Vorherige"
 msgid "_Next"
 msgstr "_Nächste"
 
-msgid "_Close"
-msgstr "S_chließen"
-
 #, fuzzy
 msgid "_Revert..."
 msgstr "Neu _laden"
@@ -2093,6 +1996,9 @@ msgid "Grid Style: Cycle Dots/Mesh/Off"
 msgstr ""
 
 msgid "Grid Snap: Cycle Grid/Resnap/Off"
+msgstr ""
+
+msgid "Grips: On/Off"
 msgstr ""
 
 #, fuzzy
@@ -2245,6 +2151,9 @@ msgstr "Unsichtbaren Text anzeigen/verbergen"
 msgid "Cut"
 msgstr "_Ausschneiden"
 
+msgid "Copy"
+msgstr "Kopieren"
+
 #, fuzzy
 msgid "Paste"
 msgstr "E_infügen"
@@ -2274,6 +2183,18 @@ msgstr ""
 #, fuzzy
 msgid "Pan Down"
 msgstr "Ausschnittmodus"
+
+#, fuzzy
+msgid "Zoom Extents"
+msgstr "/Automatisch"
+
+#, fuzzy
+msgid "Zoom In"
+msgstr "/Vergrößern"
+
+#, fuzzy
+msgid "Zoom Out"
+msgstr "/Verkleinern"
 
 #, fuzzy
 msgid "Zoom Full"
@@ -2311,6 +2232,22 @@ msgid "Print Page"
 msgstr "_Vorherige"
 
 #, fuzzy
+msgid "Add Component"
+msgstr "/Bauteil hinzufügen …"
+
+#, fuzzy
+msgid "Add Net"
+msgstr "/Netz einfügen"
+
+#, fuzzy
+msgid "Add Bus"
+msgstr "/Bus einfügen"
+
+#, fuzzy
+msgid "Add Text"
+msgstr "/Text einfügen"
+
+#, fuzzy
 msgid "Add Line"
 msgstr "Linie"
 
@@ -2336,6 +2273,14 @@ msgstr ""
 #, fuzzy
 msgid "Add Picture"
 msgstr "Bild"
+
+#, fuzzy
+msgid "Down Schematic"
+msgstr "/Zum Schaltplan hinab"
+
+#, fuzzy
+msgid "Down Symbol"
+msgstr "/Zum Symbol hinab"
 
 #, fuzzy
 msgid "Up Hierarchy"
@@ -2428,6 +2373,10 @@ msgid "Show Coordinate Window"
 msgstr "K_oordinatenfenster anzeigen …"
 
 #, fuzzy
+msgid "Toggle Grips"
+msgstr "Sichtbarkeit _umschalten"
+
+#, fuzzy
 msgid "Component Documentation"
 msgstr "Bauteil-D_okumentation …"
 
@@ -2465,10 +2414,6 @@ msgstr ""
 msgid "About lepton-schematic"
 msgstr "Über gschem"
 
-#, scheme-format
-msgid "Invalid text alignment ~A."
-msgstr "Ungültige Ausrichtung: ~A."
-
 #, fuzzy
 msgid "Could not show documentation:"
 msgstr "Bauteil-D_okumentation …"
@@ -2483,6 +2428,120 @@ msgstr "~S ist keine gültige Tasten-Kombination."
 #, scheme-format
 msgid "~S is not a prefix key sequence."
 msgstr "~S ist kein gültiger erster Teil einer Tastenkombination."
+
+#, scheme-format
+msgid "Invalid text alignment ~A."
+msgstr "Ungültige Ausrichtung: ~A."
+
+#, fuzzy
+#~ msgid "Save settings to:"
+#~ msgstr "Einstellungen"
+
+#, fuzzy
+#~ msgid "Invalid size [%1$d] passed to text-size\n"
+#~ msgstr "Eine ungültige Größe [%d] wurde an text-size übergeben.\n"
+
+#, fuzzy
+#~ msgid "Invalid size [%1$d] passed to snap-size\n"
+#~ msgstr "Eine ungültige Größe [%d] wurde an snap-size übergeben.\n"
+
+#, fuzzy
+#~ msgid "Invalid num levels [%1$d] passed to undo-levels\n"
+#~ msgstr "Eine ungültige Ebenenanzahl [%d] wurde an undo-levels übergeben.\n"
+
+#, fuzzy
+#~ msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
+#~ msgstr "Eine ungültige Größe [%d] wurde an bus-ripper-size übergeben.\n"
+
+#, fuzzy
+#~ msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
+#~ msgstr "An \"grid-dot-size\" wurde eine falsche Punktgröße [%d] übergeben\n"
+
+#, fuzzy
+#~ msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
+#~ msgstr ""
+#~ "An \"grid-fixed-threshold\" wurde ein falscher Punktabstand [%d] "
+#~ "übergeben\n"
+
+#, fuzzy
+#~ msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
+#~ msgstr ""
+#~ "An \"mesh-grid-display-treshold\" wurde ein falscher Punktabstand [%d] "
+#~ "übergeben.\n"
+
+#, fuzzy
+#~ msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
+#~ msgstr ""
+#~ "An \"auto-save-interval\" wurde eine ungültige Sekundenanzahl [%d] "
+#~ "übergeben\n"
+
+#, fuzzy
+#~ msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
+#~ msgstr "Ein ungültiger Werte [%d] wurde an mousepan-gain übergeben.\n"
+
+#, fuzzy
+#~ msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
+#~ msgstr "Ein ungültiger Wert [%d] wurde an keyboardpan-gain übergeben.\n"
+
+#, fuzzy
+#~ msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
+#~ msgstr ""
+#~ "An \"select-slack-pixels\" wurde eine ungültige Pixelzahl [%d] übergeben\n"
+
+#, fuzzy
+#~ msgid "Invalid gain [%1$d] passed to zoom-gain\n"
+#~ msgstr "Ein unzulässiger Wert [%d] wurde an zoom-gain übergeben\n"
+
+#, fuzzy
+#~ msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
+#~ msgstr ""
+#~ "Eine unzulässige Anzahl von Schritten [%d] wurde an scrollpan-steps "
+#~ "übergeben\n"
+
+#~ msgid "Got an unexpected NULL in o_edit\n"
+#~ msgstr "Der Rückgabewert von o_edit war unerwartet NULL\n"
+
+#~ msgid "ERROR: NULL object in o_move_end!\n"
+#~ msgstr "FEHLER: NULL Objekt innerhalb von o_move_end.\n"
+
+#~ msgid "ERROR: NULL object!\n"
+#~ msgstr "FEHLER: NULL Objekt!\n"
+
+#, fuzzy
+#~ msgid "Could not allocate the color %1$s!\n"
+#~ msgstr "Konnte die Farbe %s nicht zuteilen!\n"
+
+#~ msgid "black"
+#~ msgstr "schwarz"
+
+#~ msgid "white"
+#~ msgstr "weiss"
+
+#, fuzzy
+#~ msgid "Could not allocate display color %1$i!\n"
+#~ msgstr "Konnte die Bildschirmfarbe %i nicht allokieren!\n"
+
+#, fuzzy
+#~ msgid "Could not allocate outline color %1$i!\n"
+#~ msgstr "Konnte die Umrissfarbe %i nicht allokieren!\n"
+
+#~ msgid "Move"
+#~ msgstr "Verschieben"
+
+#, fuzzy
+#~ msgid "Up"
+#~ msgstr "/Hinauf"
+
+#, fuzzy
+#~ msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
+#~ msgstr ""
+#~ "Es wurde versucht die Empfindlichkeit des nicht existenten Menueintrags "
+#~ "'%s' zu setzen\n"
+
+#~ msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
+#~ msgstr ""
+#~ "Es wurde versucht die Empfindlichkeit des nicht existenten Menueintrags "
+#~ "'%s' zu setzen\n"
 
 #, fuzzy
 #~ msgid "Invalid offset [%1$d] passed to add-attribute-offset\n"
@@ -2791,9 +2850,6 @@ msgstr "~S ist kein gültiger erster Teil einer Tastenkombination."
 
 #~ msgid "Function"
 #~ msgstr "Funktion"
-
-#~ msgid "/Add Attribute..."
-#~ msgstr "/Attribut hinzufügen …"
 
 #~ msgid "/Zoom Box"
 #~ msgstr "/Ausschnitt wählen"

--- a/schematic/po/el.po
+++ b/schematic/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-10-03 23:34+0300\n"
+"POT-Creation-Date: 2020-03-18 20:44+0300\n"
 "PO-Revision-Date: 2012-09-01 20:41+0000\n"
 "Last-Translator: Panos Bouklis <panos@echidna-band.com>\n"
 "Language-Team: Greek <el@li.org>\n"
@@ -19,6 +19,13 @@ msgstr ""
 "X-Generator: Launchpad (build 16265)\n"
 
 msgid "Zoom too small!  Cannot zoom further."
+msgstr ""
+
+msgid ""
+"Save your color scheme to a file by clicking on the \"Save As...\"\n"
+"button. It can be loaded on startup with the following\n"
+"expression in the gschemrc configuration file:\n"
+"( primitive-load \"/path/to/saved-color-scheme-file\" )"
 msgstr ""
 
 #, fuzzy, c-format
@@ -50,6 +57,11 @@ msgstr ""
 msgid "Sa_ve..."
 msgstr ""
 
+msgid ""
+"After you're done choosing the font, it's recommended\n"
+"to reopen schematics or restart the application."
+msgstr ""
+
 #, c-format
 msgid "<b>Current:</b> %s"
 msgstr ""
@@ -57,24 +69,21 @@ msgstr ""
 msgid "Save configuration"
 msgstr ""
 
+msgid "Local configuration file:"
+msgstr ""
+
+msgid "User configuration file:"
+msgstr ""
+
 #, fuzzy
-msgid "Save settings to:"
-msgstr "Ρυθμίσεις"
-
-msgid "Local configuration file (in current directory)"
-msgstr ""
-
-msgid "User configuration file (geda-user.conf)"
-msgstr ""
-
-msgid "Object ~A is not included in the current gschem page."
+msgid "Object ~A is not included in the current lepton-schematic page."
 msgstr "Το αντικείμενο ~A δεν περιλαμβάνεται στην τρέχουσα gschem."
 
 msgid "Invalid text name/value visibility ~A."
 msgstr "Μη έγκυρο όνομα/τιμή ορατότητας ~A."
 
 #, fuzzy, c-format
-msgid "You are running gEDA/gaf version [%1$s%2$s.%3$s],\n"
+msgid "You are running lepton-schematic version [%1$s%2$s.%3$s],\n"
 msgstr "gEDA/gschem έκδοση %s%s.%s\n"
 
 #, c-format
@@ -87,74 +96,15 @@ msgstr ""
 msgid "Please be sure that you have the latest rc file.\n"
 msgstr ""
 
-#, fuzzy, c-format
-msgid "Invalid size [%1$d] passed to text-size\n"
-msgstr "Δόθηκε μη έγκυρο μέγεθος [%d] στο μέγεθος κειμένου\n"
-
-#, fuzzy, c-format
-msgid "Invalid size [%1$d] passed to snap-size\n"
-msgstr "Δόθηκε μη έγκυρο μέγεθος [%d] στο μέγεθος κειμένου\n"
-
-#, fuzzy, c-format
-msgid "Invalid num levels [%1$d] passed to undo-levels\n"
-msgstr ""
-"Δόθηκε μη έγκυρος αριθμός δευτερολέπτων [%d] στο διάστημα αυτόματης "
-"αποθήκευσης\n"
-
-#, fuzzy, c-format
-msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
-msgstr "Δόθηκε μη έγκυρο μέγεθος [%d] στο μέγεθος κειμένου\n"
-
-#, fuzzy, c-format
-msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
-msgstr "Δόθηκε μη έγκυρο μέγεθος [%d] στο μέγεθος κειμένου\n"
-
-#, fuzzy, c-format
-msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
-msgstr "Δόθηκε μη έγκυρο μέγεθος [%d] στο μέγεθος κειμένου\n"
-
-#, c-format
-msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
-msgstr ""
-
-#, fuzzy, c-format
-msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
-msgstr ""
-"Δόθηκε μη έγκυρος αριθμός δευτερολέπτων [%d] στο διάστημα αυτόματης "
-"αποθήκευσης\n"
-
-#, fuzzy, c-format
-msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
-msgstr "Δόθηκε μη έγκυρο μέγεθος [%d] στο μέγεθος κειμένου\n"
-
-#, fuzzy, c-format
-msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
-msgstr "Δόθηκε μη έγκυρο μέγεθος [%d] στο μέγεθος κειμένου\n"
-
-#, fuzzy, c-format
-msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
-msgstr ""
-"Δόθηκε μη έγκυρος αριθμός δευτερολέπτων [%d] στο διάστημα αυτόματης "
-"αποθήκευσης\n"
-
-#, fuzzy, c-format
-msgid "Invalid gain [%1$d] passed to zoom-gain\n"
-msgstr "Δόθηκε μη έγκυρο μέγεθος [%d] στο μέγεθος κειμένου\n"
-
-#, fuzzy, c-format
-msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
-msgstr ""
-"Δόθηκε μη έγκυρος αριθμός δευτερολέπτων [%d] στο διάστημα αυτόματης "
-"αποθήκευσης\n"
-
 msgid "Object ~A is not directly included in a page."
 msgstr "Το αντικείμενο ~A δεν περιλαμβάνεται άμεσα σε μια σελίδα."
 
 msgid "Could not launch URI ~S: ~A"
 msgstr "Αδυναμία εκτέλεσης URI ~S: ~A"
 
-msgid "Found invalid gschem window smob ~S"
-msgstr ""
+#, fuzzy
+msgid "Found invalid lepton-schematic window smob ~S"
+msgstr "Το ~S δεν είναι έγκυρος συνδιασμός πλήκτρων."
 
 #, fuzzy, c-format
 msgid "Lepton EDA/lepton-schematic version %1$s%2$s.%3$s git: %4$.7s"
@@ -189,7 +139,7 @@ msgstr "gEDA: Ηλεκτρονικός Αυτοματισμός Σχεδίαση
 #, fuzzy
 msgid ""
 "Copyright © 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright © 2017-2019 Lepton Developers.\n"
+"Copyright © 2017-2020 Lepton Developers.\n"
 "See AUTHORS, ChangeLog files and consult 'git log' history for details."
 msgstr ""
 "Πνευματικά δικαιώματα © 1998-2012 Ales Hvezda <ahvezda@geda.seul.org>\n"
@@ -669,7 +619,8 @@ msgid ""
 "\n"
 "Are you sure you want to revert this page?\n"
 "All unsaved changes in current schematic will be\n"
-"discarded and page file will be reloaded from disk."
+"discarded and page file will be reloaded from disk.\n"
+"This action will also reload all component libraries."
 msgstr ""
 
 #, fuzzy
@@ -774,10 +725,6 @@ msgid_plural "Delete %1$u locked objects?"
 msgstr[0] "Επιλεγμένα αντικείμενα"
 msgstr[1] "Επιλεγμένα αντικείμενα"
 
-#, c-format
-msgid "Got an unexpected NULL in o_edit\n"
-msgstr "Λήφθηκε απροσδόκητο NULL στο o_edit\n"
-
 #, fuzzy
 msgid "Hidden text is now visible"
 msgstr "Το κρυφό κείμενο είναι πλέον ορατό\n"
@@ -791,7 +738,7 @@ msgid "Could not find symbol [%1$s] in library. Update failed."
 msgstr "Αδυναμία εύρεσης συμβόλου [%s] στη βιβλιοθήκη. Η ενημέρωση απέτυχε.\n"
 
 #, fuzzy, c-format
-msgid "o_autosave_backups: Can't get the real filename of %1$s."
+msgid "Can't get the real filename of %1$s."
 msgstr ""
 "o_autosave_backups: Αδυναμία λήψης του πραγματικού ονόματος αρχείου για το "
 "%s."
@@ -810,10 +757,6 @@ msgstr ""
 #, fuzzy, c-format
 msgid "Could NOT save backup file [%1$s]"
 msgstr "ΔΕΝ ήταν δυνατή η αποθήκευση του αντιγράφου ασφαλείας [%s]\n"
-
-#, c-format
-msgid "ERROR: NULL object in o_move_end!\n"
-msgstr "ERROR: Αντικείμενο NULL στο o_move_end!\n"
 
 #, c-format
 msgid "DOH! tried to find the whichone, but didn't find it!\n"
@@ -866,7 +809,7 @@ msgstr "Οι υποδοχές δεν επιτρέπονται σε αυτό το
 msgid "New slot number out of range"
 msgstr "Νέος αριθμός υποδοχής εκτός εύρους\n"
 
-msgid "Undo/Redo disabled in rc file"
+msgid "Undo/Redo is disabled in configuration"
 msgstr ""
 
 #, c-format
@@ -887,35 +830,14 @@ msgid ""
 "  -h, --help               Help; this message.\n"
 "  --                       Treat all remaining arguments as filenames.\n"
 "\n"
-"Report bugs at <https://github.com/lepton-eda/lepton-eda/issues>\n"
-"Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>\n"
+"Report bugs at <%2$s>\n"
+"Lepton EDA homepage: <%3$s>\n"
 msgstr ""
-
-#, fuzzy, c-format
-msgid ""
-"Lepton EDA %1$s (git: %2$.7s)\n"
-"Copyright (C) 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright (C) 2017-2019 Lepton Developers.\n"
-"This is free software, and you are welcome to redistribute it under\n"
-"certain conditions. For details, see the file `COPYING', which is\n"
-"included in the Lepton EDA distribution.\n"
-"There is NO WARRANTY, to the extent permitted by law.\n"
-msgstr ""
-"gEDA %s (g%.7s)\n"
-"Πνευματικά δικαιώματα (C) 1998-2012 προγραμματιστές του gEDA\n"
-"Αυτό είναι δωρεάν λογισμικό, και μπορείτε να το αναδιανείμετε ελεύθερα υπό\n"
-"συγκεκριμένους όρους. Για λεπτομέρειες, δείτε το αρχείο `COPYING', το οποίο\n"
-"συμπεριλαμβάνεται στη διανομή του gEDA.\n"
-"Δεν υπάρχει ΚΑΜΙΑ ΕΓΓΥΗΣΗ, στα πλαίσια που επιτρέπει ο νόμος.\n"
 
 #, c-format
 msgid "Got invalid show option; defaulting to show both\n"
 msgstr ""
 "Λήφθηκε μη έγκυρη επιλογή εμφάνισης. Προεπιλεγμένη εμφάνιση και των δύο\n"
-
-#, c-format
-msgid "ERROR: NULL object!\n"
-msgstr "ΣΦΑΛΜΑ: Αντικείμενο NULL!\n"
 
 msgid "Single Attribute Editor"
 msgstr "Επεξεργαστής ενός γνωρίσματος"
@@ -974,7 +896,7 @@ msgstr ""
 "οι διπλές υποδοχές μπορεί να προκαλέσουν προβλήματα: [σύμβολο=%s, αριθμός="
 "%d, υποδοχή=%d]\n"
 
-msgid "No searchstring given in autonumber text."
+msgid "No search string given in autonumber text."
 msgstr ""
 
 msgid "No '*' or '?' given at the end of the autonumber text."
@@ -1052,24 +974,6 @@ msgstr ""
 
 msgid "Clipboard insertion failed"
 msgstr "Η εισαγωγή από το πρόχειρο απέτυχε"
-
-#, fuzzy, c-format
-msgid "Could not allocate the color %1$s!\n"
-msgstr "Αδυναμία εντοπισμού χρώματος %s!\n"
-
-msgid "black"
-msgstr "μαύρο"
-
-msgid "white"
-msgstr "άσπρο"
-
-#, fuzzy, c-format
-msgid "Could not allocate display color %1$i!\n"
-msgstr "Αδυναμία εντοπισμού χρώματος εμφάνισης %i!\n"
-
-#, fuzzy, c-format
-msgid "Could not allocate outline color %1$i!\n"
-msgstr "Αδυναμία εντοπισμού χρώματος περιγράμματος %i!\n"
 
 #, fuzzy, c-format
 msgid "Tried to get an invalid color: %1$d\n"
@@ -1218,13 +1122,16 @@ msgstr ""
 msgid "Invalid Attribute"
 msgstr "Μη έγκυρο γνώρισμα"
 
-msgid "Schematics"
+#, fuzzy
+msgid "Schematics (*.sch)"
 msgstr "Σχεδιαγράμματα"
 
-msgid "Symbols"
+#, fuzzy
+msgid "Symbols (*.sym)"
 msgstr "Σύμβολα"
 
-msgid "Schematics and symbols"
+#, fuzzy
+msgid "Schematics and symbols (*.sch *.sym)"
 msgstr "Σχεδιαγράμματα και σύμβολα"
 
 msgid "All files"
@@ -1261,7 +1168,7 @@ msgid "Hatch"
 msgstr ""
 
 #, fuzzy, c-format
-msgid "x_image_lowlevel: Unable to write %1$s file %2$s."
+msgid "Unable to write %1$s file %2$s."
 msgstr "x_image_lowlevel: Αδυναμία εγγραφής του αρχείου %s %s.\n"
 
 #, fuzzy, c-format
@@ -1286,7 +1193,7 @@ msgid "Wrote black and white image to [%1$s] [%2$d x %3$d]"
 msgstr "Εγγράφηκε ασπρόμαυρη εικόνα στο [%s] [%d x %d]\n"
 
 #, fuzzy
-msgid "x_image_lowlevel: Unable to get pixbuf from gschem's window."
+msgid "Unable to get pixbuf from lepton-schematic's window."
 msgstr "x_image_lowlevel: Αδυναμία λήψης pixbuf από το παράθυρο του gschem.\n"
 
 msgid "NOTE: print-color-map will be used for PDF export"
@@ -1336,71 +1243,60 @@ msgid "Phantom"
 msgstr "Φάντασμα"
 
 #, fuzzy
-msgid "Add Net"
-msgstr "/Προσθήκη δικτύου"
-
-msgid "Add Attribute"
-msgstr "Προσθήκη γνωρίσματος"
-
-#, fuzzy
-msgid "Add Component"
+msgid "Add Co_mponent..."
 msgstr "/Προσθήκη στοιχείου..."
 
 #, fuzzy
-msgid "Add Bus"
-msgstr "/Προσθήκη διαύλου"
+msgid "Add Te_xt..."
+msgstr "Προσθήκη κειμένου..."
 
 #, fuzzy
-msgid "Add Text"
-msgstr "/Προσθήκη κειμένου"
+msgid "Add _Attribute..."
+msgstr "/Προσθήκη γνωρίσματος..."
 
-msgid "Zoom In"
-msgstr ""
+#, fuzzy
+msgid "Add _Net"
+msgstr "/Προσθήκη δικτύου"
 
-msgid "Zoom Out"
-msgstr ""
+#, fuzzy
+msgid "Add _Bus"
+msgstr "/Προσθήκη διαύλου"
 
-msgid "Zoom Extents"
-msgstr ""
+msgid "Cu_t"
+msgstr "Α_ποκοπή"
 
-msgid "Select"
-msgstr "Επιλογή"
+msgid "_Copy"
+msgstr "Α_ντιγραφή"
 
-msgid "Edit..."
+msgid "_Paste"
+msgstr "Ε_πικόλληση"
+
+msgid "_Delete"
+msgstr "_Διαγραφή"
+
+#, fuzzy
+msgid "_Edit..."
 msgstr "Επεξεργασία..."
 
 #, fuzzy
-msgid "Object Properties..."
-msgstr "<b>Ιδιότητες κειμένου</b>"
-
-msgid "Copy"
-msgstr "Αντιγραφή"
-
-msgid "Move"
-msgstr "Μετακίνηση"
-
-msgid "Delete"
-msgstr "Διαγραφή"
+msgid "Ed_it Text..."
+msgstr "Επεξεργασία κειμένου..."
 
 #, fuzzy
-msgid "Down Schematic"
+msgid "_Object Properties..."
+msgstr "<b>Ιδιότητες κειμένου</b>"
+
+#, fuzzy
+msgid "Hierarchy: Down _Schematic"
 msgstr "/Κάτω σχεδιάγραμμα"
 
 #, fuzzy
-msgid "Down Symbol"
+msgid "Hierarchy: Down S_ymbol"
 msgstr "/Κάτω σύμβολο"
 
 #, fuzzy
-msgid "Up"
-msgstr "/Πάνω"
-
-#, fuzzy, c-format
-msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
-msgstr "Προσπάθεια ρύθμισης ευαισθησίας σε ανύπαρκτο αντικείμενο μενού '%s'\n"
-
-#, c-format
-msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
-msgstr "Προσπάθεια ρύθμισης ευαισθησίας σε ανύπαρκτο αντικείμενο μενού '%s'\n"
+msgid "Hierarchy: _Up"
+msgstr "_Ιεραρχία"
 
 msgid "The operating system is out of memory or resources."
 msgstr "Το λειτουργικό σύστημα είναι εκτός ορίων μνήμης ή πηγών."
@@ -1424,6 +1320,9 @@ msgstr "Προώθηση"
 msgid "Duplicate"
 msgstr "Αντίγραφο"
 
+msgid "Delete"
+msgstr "Διαγραφή"
+
 #, fuzzy
 msgid "Copy to all"
 msgstr "Αντιγραφή σε 1"
@@ -1443,6 +1342,9 @@ msgstr ""
 #, fuzzy
 msgid "Sho_w inherited attributes"
 msgstr "Εμφάνιση κληρονομημένων γνωρισμάτων"
+
+msgid "Add Attribute"
+msgstr "Προσθήκη γνωρίσματος"
 
 #, fuzzy
 msgid "_Name:"
@@ -1562,6 +1464,25 @@ msgstr "_Ιεραρχία"
 #, fuzzy
 msgid "Hierarchy up"
 msgstr "_Ιεραρχία"
+
+msgid "_New"
+msgstr "_Νέο"
+
+msgid "_Open..."
+msgstr "_Άνοιγμα..."
+
+msgid "_Save"
+msgstr "_Αποθήκευση"
+
+msgid "Save _As..."
+msgstr "Αποθήκευση _ως..."
+
+#, fuzzy
+msgid "Page _Manager..."
+msgstr "Διαχειριστής σελίδων"
+
+msgid "_Close"
+msgstr "_Κλείσιμο"
 
 #, fuzzy
 msgid "Options"
@@ -1683,6 +1604,9 @@ msgstr ""
 msgid "Add Text..."
 msgstr "Προσθήκη κειμένου..."
 
+msgid "Select"
+msgstr "Επιλογή"
+
 msgid "Select mode"
 msgstr "Λειτουργία επιλογής"
 
@@ -1754,20 +1678,8 @@ msgstr ""
 "Δημιουργείστε και επεξεργαστείτε ηλεκτρικά σχεδιαγράμματα και σύμβολα με το "
 "gschem"
 
-msgid "_New"
-msgstr "_Νέο"
-
-msgid "_Open..."
-msgstr "_Άνοιγμα..."
-
 msgid "Open Recen_t"
 msgstr "Άνοιγμα _προσφάτου"
-
-msgid "_Save"
-msgstr "_Αποθήκευση"
-
-msgid "Save _As..."
-msgstr "Αποθήκευση _ως..."
 
 msgid "Save All"
 msgstr "Αποθήκευση όλων"
@@ -1800,18 +1712,6 @@ msgstr "_Αναίρεση"
 msgid "_Redo"
 msgstr "Ε_παναφορά"
 
-msgid "Cu_t"
-msgstr "Α_ποκοπή"
-
-msgid "_Copy"
-msgstr "Α_ντιγραφή"
-
-msgid "_Paste"
-msgstr "Ε_πικόλληση"
-
-msgid "_Delete"
-msgstr "_Διαγραφή"
-
 msgid "Select All"
 msgstr "Επιλογή όλων"
 
@@ -1820,6 +1720,13 @@ msgstr "Αποεπιλογή"
 
 msgid "Rotate 90 Mode"
 msgstr "Λειτουργία περιστροφής 90"
+
+#, fuzzy
+msgid "Object Properties..."
+msgstr "<b>Ιδιότητες κειμένου</b>"
+
+msgid "Edit..."
+msgstr "Επεξεργασία..."
 
 msgid "Edit Text..."
 msgstr "Επεξεργασία κειμένου..."
@@ -1944,9 +1851,6 @@ msgstr "_Προηγούμενο"
 msgid "_Next"
 msgstr "_Επόμενο"
 
-msgid "_Close"
-msgstr "_Κλείσιμο"
-
 #, fuzzy
 msgid "_Revert..."
 msgstr "_Επαναφορά"
@@ -2058,6 +1962,9 @@ msgid "Grid Style: Cycle Dots/Mesh/Off"
 msgstr ""
 
 msgid "Grid Snap: Cycle Grid/Resnap/Off"
+msgstr ""
+
+msgid "Grips: On/Off"
 msgstr ""
 
 #, fuzzy
@@ -2208,6 +2115,9 @@ msgstr ""
 msgid "Cut"
 msgstr "Α_ποκοπή"
 
+msgid "Copy"
+msgstr "Αντιγραφή"
+
 #, fuzzy
 msgid "Paste"
 msgstr "Ε_πικόλληση"
@@ -2234,6 +2144,15 @@ msgid "Pan Up"
 msgstr ""
 
 msgid "Pan Down"
+msgstr ""
+
+msgid "Zoom Extents"
+msgstr ""
+
+msgid "Zoom In"
+msgstr ""
+
+msgid "Zoom Out"
 msgstr ""
 
 msgid "Zoom Full"
@@ -2271,6 +2190,22 @@ msgid "Print Page"
 msgstr "_Προηγούμενο"
 
 #, fuzzy
+msgid "Add Component"
+msgstr "/Προσθήκη στοιχείου..."
+
+#, fuzzy
+msgid "Add Net"
+msgstr "/Προσθήκη δικτύου"
+
+#, fuzzy
+msgid "Add Bus"
+msgstr "/Προσθήκη διαύλου"
+
+#, fuzzy
+msgid "Add Text"
+msgstr "/Προσθήκη κειμένου"
+
+#, fuzzy
 msgid "Add Line"
 msgstr "Γραμμή"
 
@@ -2296,6 +2231,14 @@ msgstr ""
 #, fuzzy
 msgid "Add Picture"
 msgstr "Εικόνα"
+
+#, fuzzy
+msgid "Down Schematic"
+msgstr "/Κάτω σχεδιάγραμμα"
+
+#, fuzzy
+msgid "Down Symbol"
+msgstr "/Κάτω σύμβολο"
 
 #, fuzzy
 msgid "Up Hierarchy"
@@ -2384,6 +2327,10 @@ msgid "Show Coordinate Window"
 msgstr "Εμφάνιση παραθύρου συντεταγμένων..."
 
 #, fuzzy
+msgid "Toggle Grips"
+msgstr "Εναλλαγή ορατότητας"
+
+#, fuzzy
 msgid "Component Documentation"
 msgstr "Τεκμηρίωση _στοιχείων"
 
@@ -2421,10 +2368,6 @@ msgstr ""
 msgid "About lepton-schematic"
 msgstr "Σχετικά με το gschem"
 
-#, scheme-format
-msgid "Invalid text alignment ~A."
-msgstr "Μη έγκυρη στοίχιση κειμένου ~A."
-
 #, fuzzy
 msgid "Could not show documentation:"
 msgstr "Τεκμηρίωση _στοιχείων"
@@ -2439,6 +2382,133 @@ msgstr "Το ~S δεν είναι έγκυρος συνδιασμός πλήκτ
 #, scheme-format
 msgid "~S is not a prefix key sequence."
 msgstr ""
+
+#, scheme-format
+msgid "Invalid text alignment ~A."
+msgstr "Μη έγκυρη στοίχιση κειμένου ~A."
+
+#, fuzzy
+#~ msgid "Save settings to:"
+#~ msgstr "Ρυθμίσεις"
+
+#, fuzzy
+#~ msgid "Invalid size [%1$d] passed to text-size\n"
+#~ msgstr "Δόθηκε μη έγκυρο μέγεθος [%d] στο μέγεθος κειμένου\n"
+
+#, fuzzy
+#~ msgid "Invalid size [%1$d] passed to snap-size\n"
+#~ msgstr "Δόθηκε μη έγκυρο μέγεθος [%d] στο μέγεθος κειμένου\n"
+
+#, fuzzy
+#~ msgid "Invalid num levels [%1$d] passed to undo-levels\n"
+#~ msgstr ""
+#~ "Δόθηκε μη έγκυρος αριθμός δευτερολέπτων [%d] στο διάστημα αυτόματης "
+#~ "αποθήκευσης\n"
+
+#, fuzzy
+#~ msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
+#~ msgstr "Δόθηκε μη έγκυρο μέγεθος [%d] στο μέγεθος κειμένου\n"
+
+#, fuzzy
+#~ msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
+#~ msgstr "Δόθηκε μη έγκυρο μέγεθος [%d] στο μέγεθος κειμένου\n"
+
+#, fuzzy
+#~ msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
+#~ msgstr "Δόθηκε μη έγκυρο μέγεθος [%d] στο μέγεθος κειμένου\n"
+
+#, fuzzy
+#~ msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
+#~ msgstr ""
+#~ "Δόθηκε μη έγκυρος αριθμός δευτερολέπτων [%d] στο διάστημα αυτόματης "
+#~ "αποθήκευσης\n"
+
+#, fuzzy
+#~ msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
+#~ msgstr "Δόθηκε μη έγκυρο μέγεθος [%d] στο μέγεθος κειμένου\n"
+
+#, fuzzy
+#~ msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
+#~ msgstr "Δόθηκε μη έγκυρο μέγεθος [%d] στο μέγεθος κειμένου\n"
+
+#, fuzzy
+#~ msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
+#~ msgstr ""
+#~ "Δόθηκε μη έγκυρος αριθμός δευτερολέπτων [%d] στο διάστημα αυτόματης "
+#~ "αποθήκευσης\n"
+
+#, fuzzy
+#~ msgid "Invalid gain [%1$d] passed to zoom-gain\n"
+#~ msgstr "Δόθηκε μη έγκυρο μέγεθος [%d] στο μέγεθος κειμένου\n"
+
+#, fuzzy
+#~ msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
+#~ msgstr ""
+#~ "Δόθηκε μη έγκυρος αριθμός δευτερολέπτων [%d] στο διάστημα αυτόματης "
+#~ "αποθήκευσης\n"
+
+#~ msgid "Got an unexpected NULL in o_edit\n"
+#~ msgstr "Λήφθηκε απροσδόκητο NULL στο o_edit\n"
+
+#~ msgid "ERROR: NULL object in o_move_end!\n"
+#~ msgstr "ERROR: Αντικείμενο NULL στο o_move_end!\n"
+
+#, fuzzy
+#~ msgid ""
+#~ "Lepton EDA %1$s (git: %2$.7s)\n"
+#~ "Copyright (C) 1998-2017 by Ales Hvezda and the respective original "
+#~ "authors.\n"
+#~ "Copyright (C) 2017-2019 Lepton Developers.\n"
+#~ "This is free software, and you are welcome to redistribute it under\n"
+#~ "certain conditions. For details, see the file `COPYING', which is\n"
+#~ "included in the Lepton EDA distribution.\n"
+#~ "There is NO WARRANTY, to the extent permitted by law.\n"
+#~ msgstr ""
+#~ "gEDA %s (g%.7s)\n"
+#~ "Πνευματικά δικαιώματα (C) 1998-2012 προγραμματιστές του gEDA\n"
+#~ "Αυτό είναι δωρεάν λογισμικό, και μπορείτε να το αναδιανείμετε ελεύθερα "
+#~ "υπό\n"
+#~ "συγκεκριμένους όρους. Για λεπτομέρειες, δείτε το αρχείο `COPYING', το "
+#~ "οποίο\n"
+#~ "συμπεριλαμβάνεται στη διανομή του gEDA.\n"
+#~ "Δεν υπάρχει ΚΑΜΙΑ ΕΓΓΥΗΣΗ, στα πλαίσια που επιτρέπει ο νόμος.\n"
+
+#~ msgid "ERROR: NULL object!\n"
+#~ msgstr "ΣΦΑΛΜΑ: Αντικείμενο NULL!\n"
+
+#, fuzzy
+#~ msgid "Could not allocate the color %1$s!\n"
+#~ msgstr "Αδυναμία εντοπισμού χρώματος %s!\n"
+
+#~ msgid "black"
+#~ msgstr "μαύρο"
+
+#~ msgid "white"
+#~ msgstr "άσπρο"
+
+#, fuzzy
+#~ msgid "Could not allocate display color %1$i!\n"
+#~ msgstr "Αδυναμία εντοπισμού χρώματος εμφάνισης %i!\n"
+
+#, fuzzy
+#~ msgid "Could not allocate outline color %1$i!\n"
+#~ msgstr "Αδυναμία εντοπισμού χρώματος περιγράμματος %i!\n"
+
+#~ msgid "Move"
+#~ msgstr "Μετακίνηση"
+
+#, fuzzy
+#~ msgid "Up"
+#~ msgstr "/Πάνω"
+
+#, fuzzy
+#~ msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
+#~ msgstr ""
+#~ "Προσπάθεια ρύθμισης ευαισθησίας σε ανύπαρκτο αντικείμενο μενού '%s'\n"
+
+#~ msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
+#~ msgstr ""
+#~ "Προσπάθεια ρύθμισης ευαισθησίας σε ανύπαρκτο αντικείμενο μενού '%s'\n"
 
 #, fuzzy
 #~ msgid "Invalid offset [%1$d] passed to add-attribute-offset\n"
@@ -2701,9 +2771,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Embed Component/Pictore"
 #~ msgstr "Ενσωμάτωση στοιχείου/εικόνας"
-
-#~ msgid "/Add Attribute..."
-#~ msgstr "/Προσθήκη γνωρίσματος..."
 
 #~ msgid "/Select"
 #~ msgstr "/Επιλογή"

--- a/schematic/po/en_GB.po
+++ b/schematic/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-10-03 23:34+0300\n"
+"POT-Creation-Date: 2020-03-18 20:44+0300\n"
 "PO-Revision-Date: 2012-01-31 12:14+0000\n"
 "Last-Translator: Peter TB Brett <Unknown>\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -21,6 +21,13 @@ msgstr ""
 #, fuzzy
 msgid "Zoom too small!  Cannot zoom further."
 msgstr "Zoom too small!  Cannot zoom further.\n"
+
+msgid ""
+"Save your color scheme to a file by clicking on the \"Save As...\"\n"
+"button. It can be loaded on startup with the following\n"
+"expression in the gschemrc configuration file:\n"
+"( primitive-load \"/path/to/saved-color-scheme-file\" )"
+msgstr ""
 
 #, fuzzy, c-format
 msgid ""
@@ -51,6 +58,11 @@ msgstr ""
 msgid "Sa_ve..."
 msgstr ""
 
+msgid ""
+"After you're done choosing the font, it's recommended\n"
+"to reopen schematics or restart the application."
+msgstr ""
+
 #, c-format
 msgid "<b>Current:</b> %s"
 msgstr ""
@@ -58,24 +70,21 @@ msgstr ""
 msgid "Save configuration"
 msgstr ""
 
+msgid "Local configuration file:"
+msgstr ""
+
+msgid "User configuration file:"
+msgstr ""
+
 #, fuzzy
-msgid "Save settings to:"
-msgstr "Settings"
-
-msgid "Local configuration file (in current directory)"
-msgstr ""
-
-msgid "User configuration file (geda-user.conf)"
-msgstr ""
-
-msgid "Object ~A is not included in the current gschem page."
+msgid "Object ~A is not included in the current lepton-schematic page."
 msgstr "Object ~A is not included in the current gschem page."
 
 msgid "Invalid text name/value visibility ~A."
 msgstr "Invalid text name/value visibility ~A."
 
 #, fuzzy, c-format
-msgid "You are running gEDA/gaf version [%1$s%2$s.%3$s],\n"
+msgid "You are running lepton-schematic version [%1$s%2$s.%3$s],\n"
 msgstr "gEDA/gschem version %s%s.%s\n"
 
 #, c-format
@@ -88,65 +97,14 @@ msgstr ""
 msgid "Please be sure that you have the latest rc file.\n"
 msgstr ""
 
-#, fuzzy, c-format
-msgid "Invalid size [%1$d] passed to text-size\n"
-msgstr "Invalid size [%d] passed to text-size\n"
-
-#, fuzzy, c-format
-msgid "Invalid size [%1$d] passed to snap-size\n"
-msgstr "Invalid size [%d] passed to snap-size\n"
-
-#, fuzzy, c-format
-msgid "Invalid num levels [%1$d] passed to undo-levels\n"
-msgstr "Invalid num levels [%d] passed to undo-levels\n"
-
-#, fuzzy, c-format
-msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
-msgstr "Invalid size [%d] passed to bus-ripper-size\n"
-
-#, fuzzy, c-format
-msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
-msgstr "Invalid dot size [%d] passed to dots-grid-dot-size\n"
-
-#, fuzzy, c-format
-msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
-msgstr "Invalid pixel spacing [%d] passed to dots-grid-fixed-threshold\n"
-
-#, fuzzy, c-format
-msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
-msgstr "Invalid pixel spacing [%d] passed to mesh-grid-display-threshold\n"
-
-#, fuzzy, c-format
-msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
-msgstr "Invalid number of seconds [%d] passed to auto-save-interval\n"
-
-#, fuzzy, c-format
-msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
-msgstr "Invalid gain [%d] passed to mousepan-gain\n"
-
-#, fuzzy, c-format
-msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
-msgstr "Invalid gain [%d] passed to keyboardpan-gain\n"
-
-#, fuzzy, c-format
-msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
-msgstr "Invalid number of pixels [%d] passed to select-slack-pixels\n"
-
-#, fuzzy, c-format
-msgid "Invalid gain [%1$d] passed to zoom-gain\n"
-msgstr "Invalid gain [%d] passed to zoom-gain\n"
-
-#, fuzzy, c-format
-msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
-msgstr "Invalid number of steps [%d] scrollpan-steps\n"
-
 msgid "Object ~A is not directly included in a page."
 msgstr "Object ~A is not directly included in a page."
 
 msgid "Could not launch URI ~S: ~A"
 msgstr "Could not launch URI ~S: ~A"
 
-msgid "Found invalid gschem window smob ~S"
+#, fuzzy
+msgid "Found invalid lepton-schematic window smob ~S"
 msgstr "Found invalid gschem window smob ~S"
 
 #, fuzzy, c-format
@@ -182,7 +140,7 @@ msgstr "gEDA: GPL Electronic Design Automation"
 #, fuzzy
 msgid ""
 "Copyright © 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright © 2017-2019 Lepton Developers.\n"
+"Copyright © 2017-2020 Lepton Developers.\n"
 "See AUTHORS, ChangeLog files and consult 'git log' history for details."
 msgstr ""
 "Copyright © 1998-2012 Ales Hvezda <ahvezda@geda.seul.org>\n"
@@ -670,7 +628,8 @@ msgid ""
 "\n"
 "Are you sure you want to revert this page?\n"
 "All unsaved changes in current schematic will be\n"
-"discarded and page file will be reloaded from disk."
+"discarded and page file will be reloaded from disk.\n"
+"This action will also reload all component libraries."
 msgstr ""
 
 #, fuzzy
@@ -784,10 +743,6 @@ msgid_plural "Delete %1$u locked objects?"
 msgstr[0] "Selected objects"
 msgstr[1] "Selected objects"
 
-#, c-format
-msgid "Got an unexpected NULL in o_edit\n"
-msgstr "Got an unexpected NULL in o_edit\n"
-
 #, fuzzy
 msgid "Hidden text is now visible"
 msgstr "Hidden text is now visible\n"
@@ -801,7 +756,7 @@ msgid "Could not find symbol [%1$s] in library. Update failed."
 msgstr "Could not find symbol [%s] in library. Update failed.\n"
 
 #, fuzzy, c-format
-msgid "o_autosave_backups: Can't get the real filename of %1$s."
+msgid "Can't get the real filename of %1$s."
 msgstr "o_autosave_backups: Can't get the real filename of %s."
 
 #, fuzzy, c-format
@@ -815,10 +770,6 @@ msgstr "Could NOT set backup file [%s] readonly\n"
 #, fuzzy, c-format
 msgid "Could NOT save backup file [%1$s]"
 msgstr "Could NOT save backup file [%s]\n"
-
-#, c-format
-msgid "ERROR: NULL object in o_move_end!\n"
-msgstr "ERROR: NULL object in o_move_end!\n"
 
 #, c-format
 msgid "DOH! tried to find the whichone, but didn't find it!\n"
@@ -873,7 +824,7 @@ msgid "New slot number out of range"
 msgstr "New slot number out of range\n"
 
 #, fuzzy
-msgid "Undo/Redo disabled in rc file"
+msgid "Undo/Redo is disabled in configuration"
 msgstr "Undo/Redo disabled in rc file\n"
 
 #, fuzzy, c-format
@@ -894,8 +845,8 @@ msgid ""
 "  -h, --help               Help; this message.\n"
 "  --                       Treat all remaining arguments as filenames.\n"
 "\n"
-"Report bugs at <https://github.com/lepton-eda/lepton-eda/issues>\n"
-"Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>\n"
+"Report bugs at <%2$s>\n"
+"Lepton EDA homepage: <%3$s>\n"
 msgstr ""
 "Usage: %s [OPTION ...] [--] [FILE ...]\n"
 "\n"
@@ -919,30 +870,9 @@ msgstr ""
 "Report bugs at <https://bugs.launchpad.net/geda>\n"
 "gEDA/gaf homepage: <http://www.geda-project.org/>\n"
 
-#, fuzzy, c-format
-msgid ""
-"Lepton EDA %1$s (git: %2$.7s)\n"
-"Copyright (C) 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright (C) 2017-2019 Lepton Developers.\n"
-"This is free software, and you are welcome to redistribute it under\n"
-"certain conditions. For details, see the file `COPYING', which is\n"
-"included in the Lepton EDA distribution.\n"
-"There is NO WARRANTY, to the extent permitted by law.\n"
-msgstr ""
-"gEDA %s (g%.7s)\n"
-"Copyright (C) 1998-2012 gEDA developers\n"
-"This is free software, and you are welcome to redistribute it under\n"
-"certain conditions. For details, see the file `COPYING', which is\n"
-"included in the gEDA distribution.\n"
-"There is NO WARRANTY, to the extent permitted by law.\n"
-
 #, c-format
 msgid "Got invalid show option; defaulting to show both\n"
 msgstr "Got invalid show option; defaulting to show both\n"
-
-#, c-format
-msgid "ERROR: NULL object!\n"
-msgstr "ERROR: NULL object!\n"
 
 msgid "Single Attribute Editor"
 msgstr "Single Attribute Editor"
@@ -1004,7 +934,7 @@ msgstr ""
 "duplicate slot may cause problems: [symbolname=%s, number=%d, slot=%d]\n"
 
 #, fuzzy
-msgid "No searchstring given in autonumber text."
+msgid "No search string given in autonumber text."
 msgstr "No searchstring given in autonumber text.\n"
 
 #, fuzzy
@@ -1083,24 +1013,6 @@ msgstr ""
 
 msgid "Clipboard insertion failed"
 msgstr "Clipboard insertion failed"
-
-#, fuzzy, c-format
-msgid "Could not allocate the color %1$s!\n"
-msgstr "Could not allocate the colour %s!\n"
-
-msgid "black"
-msgstr "black"
-
-msgid "white"
-msgstr "white"
-
-#, fuzzy, c-format
-msgid "Could not allocate display color %1$i!\n"
-msgstr "Could not allocate display colour %i!\n"
-
-#, fuzzy, c-format
-msgid "Could not allocate outline color %1$i!\n"
-msgstr "Could not allocate outline colour %i!\n"
 
 #, fuzzy, c-format
 msgid "Tried to get an invalid color: %1$d\n"
@@ -1247,13 +1159,16 @@ msgstr ""
 msgid "Invalid Attribute"
 msgstr "Invalid Attribute"
 
-msgid "Schematics"
+#, fuzzy
+msgid "Schematics (*.sch)"
 msgstr "Schematics"
 
-msgid "Symbols"
+#, fuzzy
+msgid "Symbols (*.sym)"
 msgstr "Symbols"
 
-msgid "Schematics and symbols"
+#, fuzzy
+msgid "Schematics and symbols (*.sch *.sym)"
 msgstr "Schematics and symbols"
 
 msgid "All files"
@@ -1290,7 +1205,7 @@ msgid "Hatch"
 msgstr "Hatch"
 
 #, fuzzy, c-format
-msgid "x_image_lowlevel: Unable to write %1$s file %2$s."
+msgid "Unable to write %1$s file %2$s."
 msgstr "x_image_lowlevel: Unable to write %s file %s.\n"
 
 #, fuzzy, c-format
@@ -1314,7 +1229,7 @@ msgid "Wrote black and white image to [%1$s] [%2$d x %3$d]"
 msgstr "Wrote black and white image to [%s] [%d x %d]\n"
 
 #, fuzzy
-msgid "x_image_lowlevel: Unable to get pixbuf from gschem's window."
+msgid "Unable to get pixbuf from lepton-schematic's window."
 msgstr "x_image_lowlevel: Unable to get pixbuf from gschem's window.\n"
 
 msgid "NOTE: print-color-map will be used for PDF export"
@@ -1364,74 +1279,60 @@ msgid "Phantom"
 msgstr "Phantom"
 
 #, fuzzy
-msgid "Add Net"
-msgstr "/Add Net"
-
-msgid "Add Attribute"
-msgstr "Add Attribute"
-
-#, fuzzy
-msgid "Add Component"
+msgid "Add Co_mponent..."
 msgstr "/Add Component..."
 
 #, fuzzy
-msgid "Add Bus"
+msgid "Add Te_xt..."
+msgstr "Add Text..."
+
+#, fuzzy
+msgid "Add _Attribute..."
+msgstr "/Add Attribute..."
+
+#, fuzzy
+msgid "Add _Net"
+msgstr "/Add Net"
+
+#, fuzzy
+msgid "Add _Bus"
 msgstr "/Add Bus"
 
-#, fuzzy
-msgid "Add Text"
-msgstr "/Add Text"
+msgid "Cu_t"
+msgstr "Cu_t"
+
+msgid "_Copy"
+msgstr "_Copy"
+
+msgid "_Paste"
+msgstr "_Paste"
+
+msgid "_Delete"
+msgstr "_Delete"
 
 #, fuzzy
-msgid "Zoom In"
-msgstr "/Zoom In"
-
-#, fuzzy
-msgid "Zoom Out"
-msgstr "/Zoom Out"
-
-#, fuzzy
-msgid "Zoom Extents"
-msgstr "/Zoom Extents"
-
-msgid "Select"
-msgstr "Select"
-
-msgid "Edit..."
+msgid "_Edit..."
 msgstr "Edit..."
 
 #, fuzzy
-msgid "Object Properties..."
-msgstr "<b>Text Properties</b>"
-
-msgid "Copy"
-msgstr "Copy"
-
-msgid "Move"
-msgstr "Move"
-
-msgid "Delete"
-msgstr "Delete"
+msgid "Ed_it Text..."
+msgstr "Edit Text..."
 
 #, fuzzy
-msgid "Down Schematic"
+msgid "_Object Properties..."
+msgstr "<b>Text Properties</b>"
+
+#, fuzzy
+msgid "Hierarchy: Down _Schematic"
 msgstr "/Down Schematic"
 
 #, fuzzy
-msgid "Down Symbol"
+msgid "Hierarchy: Down S_ymbol"
 msgstr "/Down Symbol"
 
 #, fuzzy
-msgid "Up"
-msgstr "/Up"
-
-#, fuzzy, c-format
-msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
-msgstr "Tried to set the sensitivity on non-existent menu item '%s'\n"
-
-#, c-format
-msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
-msgstr "Tried to set the sensitivity on non-existent menu item '%s'\n"
+msgid "Hierarchy: _Up"
+msgstr "Hie_rarchy"
 
 msgid "The operating system is out of memory or resources."
 msgstr "The operating system is out of memory or resources."
@@ -1454,6 +1355,9 @@ msgstr "Promote"
 msgid "Duplicate"
 msgstr "Duplicate"
 
+msgid "Delete"
+msgstr "Delete"
+
 #, fuzzy
 msgid "Copy to all"
 msgstr "Copy into 1"
@@ -1473,6 +1377,9 @@ msgstr "V"
 #, fuzzy
 msgid "Sho_w inherited attributes"
 msgstr "Show inherited attributes"
+
+msgid "Add Attribute"
+msgstr "Add Attribute"
 
 #, fuzzy
 msgid "_Name:"
@@ -1592,6 +1499,25 @@ msgstr "Hie_rarchy"
 #, fuzzy
 msgid "Hierarchy up"
 msgstr "Hie_rarchy"
+
+msgid "_New"
+msgstr "_New"
+
+msgid "_Open..."
+msgstr "_Open..."
+
+msgid "_Save"
+msgstr "_Save"
+
+msgid "Save _As..."
+msgstr "Save _As..."
+
+#, fuzzy
+msgid "Page _Manager..."
+msgstr "Page Manager"
+
+msgid "_Close"
+msgstr "_Close"
 
 #, fuzzy
 msgid "Options"
@@ -1713,6 +1639,9 @@ msgstr ""
 msgid "Add Text..."
 msgstr "Add Text..."
 
+msgid "Select"
+msgstr "Select"
+
 msgid "Select mode"
 msgstr "Select mode"
 
@@ -1781,20 +1710,8 @@ msgstr "gEDA Schematic Editor"
 msgid "Create and edit electrical schematics and symbols with lepton-schematic"
 msgstr "Create and edit electrical schematics and symbols with gschem"
 
-msgid "_New"
-msgstr "_New"
-
-msgid "_Open..."
-msgstr "_Open..."
-
 msgid "Open Recen_t"
 msgstr "Open Recen_t"
-
-msgid "_Save"
-msgstr "_Save"
-
-msgid "Save _As..."
-msgstr "Save _As..."
 
 msgid "Save All"
 msgstr "Save All"
@@ -1828,18 +1745,6 @@ msgstr "_Undo"
 msgid "_Redo"
 msgstr "_Redo"
 
-msgid "Cu_t"
-msgstr "Cu_t"
-
-msgid "_Copy"
-msgstr "_Copy"
-
-msgid "_Paste"
-msgstr "_Paste"
-
-msgid "_Delete"
-msgstr "_Delete"
-
 msgid "Select All"
 msgstr "Select All"
 
@@ -1848,6 +1753,13 @@ msgstr "Deselect"
 
 msgid "Rotate 90 Mode"
 msgstr "Rotate 90 Mode"
+
+#, fuzzy
+msgid "Object Properties..."
+msgstr "<b>Text Properties</b>"
+
+msgid "Edit..."
+msgstr "Edit..."
 
 msgid "Edit Text..."
 msgstr "Edit Text..."
@@ -1972,9 +1884,6 @@ msgstr "_Previous"
 msgid "_Next"
 msgstr "_Next"
 
-msgid "_Close"
-msgstr "_Close"
-
 #, fuzzy
 msgid "_Revert..."
 msgstr "_Revert"
@@ -2086,6 +1995,9 @@ msgid "Grid Style: Cycle Dots/Mesh/Off"
 msgstr ""
 
 msgid "Grid Snap: Cycle Grid/Resnap/Off"
+msgstr ""
+
+msgid "Grips: On/Off"
 msgstr ""
 
 #, fuzzy
@@ -2238,6 +2150,9 @@ msgstr "Show/Hide Inv Text"
 msgid "Cut"
 msgstr "Cu_t"
 
+msgid "Copy"
+msgstr "Copy"
+
 #, fuzzy
 msgid "Paste"
 msgstr "_Paste"
@@ -2267,6 +2182,18 @@ msgstr ""
 #, fuzzy
 msgid "Pan Down"
 msgstr "Pan Mode"
+
+#, fuzzy
+msgid "Zoom Extents"
+msgstr "/Zoom Extents"
+
+#, fuzzy
+msgid "Zoom In"
+msgstr "/Zoom In"
+
+#, fuzzy
+msgid "Zoom Out"
+msgstr "/Zoom Out"
 
 #, fuzzy
 msgid "Zoom Full"
@@ -2304,6 +2231,22 @@ msgid "Print Page"
 msgstr "_Previous"
 
 #, fuzzy
+msgid "Add Component"
+msgstr "/Add Component..."
+
+#, fuzzy
+msgid "Add Net"
+msgstr "/Add Net"
+
+#, fuzzy
+msgid "Add Bus"
+msgstr "/Add Bus"
+
+#, fuzzy
+msgid "Add Text"
+msgstr "/Add Text"
+
+#, fuzzy
 msgid "Add Line"
 msgstr "Line"
 
@@ -2329,6 +2272,14 @@ msgstr ""
 #, fuzzy
 msgid "Add Picture"
 msgstr "Picture"
+
+#, fuzzy
+msgid "Down Schematic"
+msgstr "/Down Schematic"
+
+#, fuzzy
+msgid "Down Symbol"
+msgstr "/Down Symbol"
 
 #, fuzzy
 msgid "Up Hierarchy"
@@ -2421,6 +2372,10 @@ msgid "Show Coordinate Window"
 msgstr "Show _Coord Window..."
 
 #, fuzzy
+msgid "Toggle Grips"
+msgstr "_Toggle Visibility"
+
+#, fuzzy
 msgid "Component Documentation"
 msgstr "Component D_ocumentation"
 
@@ -2458,10 +2413,6 @@ msgstr ""
 msgid "About lepton-schematic"
 msgstr "About gschem"
 
-#, scheme-format
-msgid "Invalid text alignment ~A."
-msgstr "Invalid text alignment ~A."
-
 #, fuzzy
 msgid "Could not show documentation:"
 msgstr "Component D_ocumentation"
@@ -2476,6 +2427,125 @@ msgstr "~S is not a valid key combination."
 #, scheme-format
 msgid "~S is not a prefix key sequence."
 msgstr "~S is not a prefix key sequence."
+
+#, scheme-format
+msgid "Invalid text alignment ~A."
+msgstr "Invalid text alignment ~A."
+
+#, fuzzy
+#~ msgid "Save settings to:"
+#~ msgstr "Settings"
+
+#, fuzzy
+#~ msgid "Invalid size [%1$d] passed to text-size\n"
+#~ msgstr "Invalid size [%d] passed to text-size\n"
+
+#, fuzzy
+#~ msgid "Invalid size [%1$d] passed to snap-size\n"
+#~ msgstr "Invalid size [%d] passed to snap-size\n"
+
+#, fuzzy
+#~ msgid "Invalid num levels [%1$d] passed to undo-levels\n"
+#~ msgstr "Invalid num levels [%d] passed to undo-levels\n"
+
+#, fuzzy
+#~ msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
+#~ msgstr "Invalid size [%d] passed to bus-ripper-size\n"
+
+#, fuzzy
+#~ msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
+#~ msgstr "Invalid dot size [%d] passed to dots-grid-dot-size\n"
+
+#, fuzzy
+#~ msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
+#~ msgstr "Invalid pixel spacing [%d] passed to dots-grid-fixed-threshold\n"
+
+#, fuzzy
+#~ msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
+#~ msgstr "Invalid pixel spacing [%d] passed to mesh-grid-display-threshold\n"
+
+#, fuzzy
+#~ msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
+#~ msgstr "Invalid number of seconds [%d] passed to auto-save-interval\n"
+
+#, fuzzy
+#~ msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
+#~ msgstr "Invalid gain [%d] passed to mousepan-gain\n"
+
+#, fuzzy
+#~ msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
+#~ msgstr "Invalid gain [%d] passed to keyboardpan-gain\n"
+
+#, fuzzy
+#~ msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
+#~ msgstr "Invalid number of pixels [%d] passed to select-slack-pixels\n"
+
+#, fuzzy
+#~ msgid "Invalid gain [%1$d] passed to zoom-gain\n"
+#~ msgstr "Invalid gain [%d] passed to zoom-gain\n"
+
+#, fuzzy
+#~ msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
+#~ msgstr "Invalid number of steps [%d] scrollpan-steps\n"
+
+#~ msgid "Got an unexpected NULL in o_edit\n"
+#~ msgstr "Got an unexpected NULL in o_edit\n"
+
+#~ msgid "ERROR: NULL object in o_move_end!\n"
+#~ msgstr "ERROR: NULL object in o_move_end!\n"
+
+#, fuzzy
+#~ msgid ""
+#~ "Lepton EDA %1$s (git: %2$.7s)\n"
+#~ "Copyright (C) 1998-2017 by Ales Hvezda and the respective original "
+#~ "authors.\n"
+#~ "Copyright (C) 2017-2019 Lepton Developers.\n"
+#~ "This is free software, and you are welcome to redistribute it under\n"
+#~ "certain conditions. For details, see the file `COPYING', which is\n"
+#~ "included in the Lepton EDA distribution.\n"
+#~ "There is NO WARRANTY, to the extent permitted by law.\n"
+#~ msgstr ""
+#~ "gEDA %s (g%.7s)\n"
+#~ "Copyright (C) 1998-2012 gEDA developers\n"
+#~ "This is free software, and you are welcome to redistribute it under\n"
+#~ "certain conditions. For details, see the file `COPYING', which is\n"
+#~ "included in the gEDA distribution.\n"
+#~ "There is NO WARRANTY, to the extent permitted by law.\n"
+
+#~ msgid "ERROR: NULL object!\n"
+#~ msgstr "ERROR: NULL object!\n"
+
+#, fuzzy
+#~ msgid "Could not allocate the color %1$s!\n"
+#~ msgstr "Could not allocate the colour %s!\n"
+
+#~ msgid "black"
+#~ msgstr "black"
+
+#~ msgid "white"
+#~ msgstr "white"
+
+#, fuzzy
+#~ msgid "Could not allocate display color %1$i!\n"
+#~ msgstr "Could not allocate display colour %i!\n"
+
+#, fuzzy
+#~ msgid "Could not allocate outline color %1$i!\n"
+#~ msgstr "Could not allocate outline colour %i!\n"
+
+#~ msgid "Move"
+#~ msgstr "Move"
+
+#, fuzzy
+#~ msgid "Up"
+#~ msgstr "/Up"
+
+#, fuzzy
+#~ msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
+#~ msgstr "Tried to set the sensitivity on non-existent menu item '%s'\n"
+
+#~ msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
+#~ msgstr "Tried to set the sensitivity on non-existent menu item '%s'\n"
 
 #, fuzzy
 #~ msgid "Invalid offset [%1$d] passed to add-attribute-offset\n"
@@ -2781,9 +2851,6 @@ msgstr "~S is not a prefix key sequence."
 
 #~ msgid "Function"
 #~ msgstr "Function"
-
-#~ msgid "/Add Attribute..."
-#~ msgstr "/Add Attribute..."
 
 #~ msgid "/Zoom Box"
 #~ msgstr "/Zoom Box"

--- a/schematic/po/es.po
+++ b/schematic/po/es.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gschem VERSION\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-10-03 23:34+0300\n"
+"POT-Creation-Date: 2020-03-18 20:44+0300\n"
 "PO-Revision-Date: 2012-03-23 03:04+0000\n"
 "Last-Translator: Adolfo Jayme Barrientos <fitoschido@gmail.com>\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -22,6 +22,13 @@ msgstr ""
 #, fuzzy
 msgid "Zoom too small!  Cannot zoom further."
 msgstr "¡Vista demasiado ampliada! No se puede ampliar más.\n"
+
+msgid ""
+"Save your color scheme to a file by clicking on the \"Save As...\"\n"
+"button. It can be loaded on startup with the following\n"
+"expression in the gschemrc configuration file:\n"
+"( primitive-load \"/path/to/saved-color-scheme-file\" )"
+msgstr ""
 
 #, fuzzy, c-format
 msgid ""
@@ -52,6 +59,11 @@ msgstr ""
 msgid "Sa_ve..."
 msgstr ""
 
+msgid ""
+"After you're done choosing the font, it's recommended\n"
+"to reopen schematics or restart the application."
+msgstr ""
+
 #, c-format
 msgid "<b>Current:</b> %s"
 msgstr ""
@@ -59,24 +71,21 @@ msgstr ""
 msgid "Save configuration"
 msgstr ""
 
+msgid "Local configuration file:"
+msgstr ""
+
+msgid "User configuration file:"
+msgstr ""
+
 #, fuzzy
-msgid "Save settings to:"
-msgstr "Opciones"
-
-msgid "Local configuration file (in current directory)"
-msgstr ""
-
-msgid "User configuration file (geda-user.conf)"
-msgstr ""
-
-msgid "Object ~A is not included in the current gschem page."
+msgid "Object ~A is not included in the current lepton-schematic page."
 msgstr "El objeto ~A no está en la página actual de gschem."
 
 msgid "Invalid text name/value visibility ~A."
 msgstr "Visibilidad de nombre/valor de texto inválida ~A"
 
 #, fuzzy, c-format
-msgid "You are running gEDA/gaf version [%1$s%2$s.%3$s],\n"
+msgid "You are running lepton-schematic version [%1$s%2$s.%3$s],\n"
 msgstr "Versión de gEDA/gschem %s%s.%s\n"
 
 #, c-format
@@ -89,80 +98,14 @@ msgstr ""
 msgid "Please be sure that you have the latest rc file.\n"
 msgstr ""
 
-#, fuzzy, c-format
-msgid "Invalid size [%1$d] passed to text-size\n"
-msgstr "Se ha especificado un tamaño no válido [%d] a la función text-size\n"
-
-#, fuzzy, c-format
-msgid "Invalid size [%1$d] passed to snap-size\n"
-msgstr "Se ha especificado un tamaño no válido [%d] a la función snap-size\n"
-
-#, fuzzy, c-format
-msgid "Invalid num levels [%1$d] passed to undo-levels\n"
-msgstr ""
-"Número de niveles [%d] no válidos especificados a la función undo-levels\n"
-
-#, fuzzy, c-format
-msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
-msgstr "Tamaño no válido [%d] especificado a la función bus-ripper-size\n"
-
-#, fuzzy, c-format
-msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
-msgstr ""
-"Tamaño de punto no válido [%d] especificado a la función dots-grid-dot-size\n"
-
-#, fuzzy, c-format
-msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
-msgstr ""
-"Espaciado de punto no válido [%d] especificado a la función dots-grid-fixed-"
-"threshold\n"
-
-#, fuzzy, c-format
-msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
-msgstr ""
-"Espaciado de punto no válido [%d] especificado a la función mesh-grid-"
-"display-threshold\n"
-
-#, fuzzy, c-format
-msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
-msgstr ""
-"Se ha especificado un número de segundos no válido [%d] a la función auto-"
-"save-interval\n"
-
-#, fuzzy, c-format
-msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
-msgstr ""
-"Se ha especificado un aumento no válido [%d] a la función mousepan-gain\n"
-
-#, fuzzy, c-format
-msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
-msgstr ""
-"Se ha especificado un aumento no válido [%d] a la función keyboardpan-gain\n"
-
-#, fuzzy, c-format
-msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
-msgstr ""
-"Se ha especificado un número de pixels no válido [%d] a la función select-"
-"slack-pixels\n"
-
-#, fuzzy, c-format
-msgid "Invalid gain [%1$d] passed to zoom-gain\n"
-msgstr ""
-"Se ha llamado a la función zoom-gain con un nivel de aumento [%d] no válido\n"
-
-#, fuzzy, c-format
-msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
-msgstr ""
-"Se ha llamado a la función scrollpan-steps con un número de pasos no válido "
-"[%d]\n"
-
 msgid "Object ~A is not directly included in a page."
 msgstr "El objeto ~A no está incluído directamente en una página."
 
 msgid "Could not launch URI ~S: ~A"
 msgstr "No se puede abrir la URI ~S: ~A"
 
-msgid "Found invalid gschem window smob ~S"
+#, fuzzy
+msgid "Found invalid lepton-schematic window smob ~S"
 msgstr "Se encontró `smob' de ventana de gschem inválido ~S"
 
 #, fuzzy, c-format
@@ -198,7 +141,7 @@ msgstr "gEDA: Automatización de Diseño Electrónico GPL"
 #, fuzzy
 msgid ""
 "Copyright © 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright © 2017-2019 Lepton Developers.\n"
+"Copyright © 2017-2020 Lepton Developers.\n"
 "See AUTHORS, ChangeLog files and consult 'git log' history for details."
 msgstr ""
 "Todos los derechos reservados © 1998-2012 Ales Hvezda <ahvezda@geda.seul."
@@ -693,7 +636,8 @@ msgid ""
 "\n"
 "Are you sure you want to revert this page?\n"
 "All unsaved changes in current schematic will be\n"
-"discarded and page file will be reloaded from disk."
+"discarded and page file will be reloaded from disk.\n"
+"This action will also reload all component libraries."
 msgstr ""
 
 #, fuzzy
@@ -807,10 +751,6 @@ msgid_plural "Delete %1$u locked objects?"
 msgstr[0] "Objetos seleccionados"
 msgstr[1] "Objetos seleccionados"
 
-#, c-format
-msgid "Got an unexpected NULL in o_edit\n"
-msgstr "Se ha recibido NULL (no esperado) en la función o_edit\n"
-
 #, fuzzy
 msgid "Hidden text is now visible"
 msgstr "El texto oculto es ahora visible\n"
@@ -825,7 +765,7 @@ msgstr ""
 "No se pudo encontrar el símbolo [%s] en la librería. Error al actualizar.\n"
 
 #, fuzzy, c-format
-msgid "o_autosave_backups: Can't get the real filename of %1$s."
+msgid "Can't get the real filename of %1$s."
 msgstr ""
 "o_autosave_backups: Imposible averiguar el nombre de archivo real de %s."
 
@@ -844,10 +784,6 @@ msgstr ""
 #, fuzzy, c-format
 msgid "Could NOT save backup file [%1$s]"
 msgstr "NO se ha podido guardar la copia de seguridad [%s]\n"
-
-#, c-format
-msgid "ERROR: NULL object in o_move_end!\n"
-msgstr "ERROR: en la función o_move_end, ¡el objeto es NULL!\n"
 
 #, c-format
 msgid "DOH! tried to find the whichone, but didn't find it!\n"
@@ -912,7 +848,7 @@ msgid "New slot number out of range"
 msgstr "El nuevo número de elemento está fuera de rango\n"
 
 #, fuzzy
-msgid "Undo/Redo disabled in rc file"
+msgid "Undo/Redo is disabled in configuration"
 msgstr "¡Deshacer/Rehacer deshabilitado en el fichero rc!\n"
 
 #, fuzzy, c-format
@@ -933,8 +869,8 @@ msgid ""
 "  -h, --help               Help; this message.\n"
 "  --                       Treat all remaining arguments as filenames.\n"
 "\n"
-"Report bugs at <https://github.com/lepton-eda/lepton-eda/issues>\n"
-"Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>\n"
+"Report bugs at <%2$s>\n"
+"Lepton EDA homepage: <%3$s>\n"
 msgstr ""
 "Uso: %s [OPCION ...] [--] [FICHERO ...]\n"
 "\n"
@@ -959,31 +895,10 @@ msgstr ""
 "Reportar errores a <https://bugs.launchpad.net/geda>\n"
 "Sitio Web de gEDA/gaf: <http://www.geda-project.org/>\n"
 
-#, fuzzy, c-format
-msgid ""
-"Lepton EDA %1$s (git: %2$.7s)\n"
-"Copyright (C) 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright (C) 2017-2019 Lepton Developers.\n"
-"This is free software, and you are welcome to redistribute it under\n"
-"certain conditions. For details, see the file `COPYING', which is\n"
-"included in the Lepton EDA distribution.\n"
-"There is NO WARRANTY, to the extent permitted by law.\n"
-msgstr ""
-"gEDA %s (g%.7s)\n"
-"Derechos Reservados (C) 1998-2012 desarrolladores de gEDA\n"
-"Esto es software libre, y eres bienvenido a redistribuirlo bajo\n"
-"ciertas condiciones. Para más detalles, revisa el fichero `COPYING', que se\n"
-"incluye en la distribución de gEDA.\n"
-"NO EXISTEN GARANTIAS, dentro de lo que la ley permite.\n"
-
 #, c-format
 msgid "Got invalid show option; defaulting to show both\n"
 msgstr ""
 "Se ha recibido una opción de mostrar no válida; mostrando ambos por defecto\n"
-
-#, c-format
-msgid "ERROR: NULL object!\n"
-msgstr "ERROR: ¡objeto vacío (NULL)!\n"
 
 msgid "Single Attribute Editor"
 msgstr "Editor de una única propiedad"
@@ -1046,7 +961,7 @@ msgstr ""
 "símbolo=%s, número=%d, slot=%d]\n"
 
 #, fuzzy
-msgid "No searchstring given in autonumber text."
+msgid "No search string given in autonumber text."
 msgstr "No se ha especificado una cadena de búsqueda para autonumerar texto.\n"
 
 #, fuzzy
@@ -1125,24 +1040,6 @@ msgstr ""
 
 msgid "Clipboard insertion failed"
 msgstr "Fallo al insertar el contenido del portapapeles"
-
-#, fuzzy, c-format
-msgid "Could not allocate the color %1$s!\n"
-msgstr "¡No se puede reservar memoria para el color %s!\n"
-
-msgid "black"
-msgstr "negro"
-
-msgid "white"
-msgstr "blanco"
-
-#, fuzzy, c-format
-msgid "Could not allocate display color %1$i!\n"
-msgstr "¡No se puede reservar memoria para el color %i!\n"
-
-#, fuzzy, c-format
-msgid "Could not allocate outline color %1$i!\n"
-msgstr "¡No se puede reservar memoria para el color del contorno %i!\n"
 
 #, fuzzy, c-format
 msgid "Tried to get an invalid color: %1$d\n"
@@ -1290,13 +1187,16 @@ msgstr ""
 msgid "Invalid Attribute"
 msgstr "Propiedad incorrecta"
 
-msgid "Schematics"
+#, fuzzy
+msgid "Schematics (*.sch)"
 msgstr "Esquemas"
 
-msgid "Symbols"
+#, fuzzy
+msgid "Symbols (*.sym)"
 msgstr "Símbolos"
 
-msgid "Schematics and symbols"
+#, fuzzy
+msgid "Schematics and symbols (*.sch *.sym)"
 msgstr "Esquemas y símbolos"
 
 msgid "All files"
@@ -1333,7 +1233,7 @@ msgid "Hatch"
 msgstr "Trama"
 
 #, fuzzy, c-format
-msgid "x_image_lowlevel: Unable to write %1$s file %2$s."
+msgid "Unable to write %1$s file %2$s."
 msgstr "x_image_lowlevel: Imposible escribir archivo %s: %s.\n"
 
 #, fuzzy, c-format
@@ -1357,7 +1257,7 @@ msgid "Wrote black and white image to [%1$s] [%2$d x %3$d]"
 msgstr "Se ha guardado la imagen en blanco y negro en [%s] [%d x %d]\n"
 
 #, fuzzy
-msgid "x_image_lowlevel: Unable to get pixbuf from gschem's window."
+msgid "Unable to get pixbuf from lepton-schematic's window."
 msgstr "x_image_lowlevel: Imposible obtener pixbuf de la ventana de gschem.\n"
 
 msgid "NOTE: print-color-map will be used for PDF export"
@@ -1407,78 +1307,60 @@ msgid "Phantom"
 msgstr "Fantasma"
 
 #, fuzzy
-msgid "Add Net"
-msgstr "/Añadir conexión..."
-
-msgid "Add Attribute"
-msgstr "Añadir propiedad"
-
-#, fuzzy
-msgid "Add Component"
+msgid "Add Co_mponent..."
 msgstr "/Añadir componente..."
 
 #, fuzzy
-msgid "Add Bus"
+msgid "Add Te_xt..."
+msgstr "Añadir texto..."
+
+#, fuzzy
+msgid "Add _Attribute..."
+msgstr "/Añadir propiedad"
+
+#, fuzzy
+msgid "Add _Net"
+msgstr "/Añadir conexión..."
+
+#, fuzzy
+msgid "Add _Bus"
 msgstr "/Añadir bus"
 
-#, fuzzy
-msgid "Add Text"
-msgstr "/Añadir texto"
+msgid "Cu_t"
+msgstr "Cor_tar"
+
+msgid "_Copy"
+msgstr "_Copiar"
+
+msgid "_Paste"
+msgstr "_Pegar"
+
+msgid "_Delete"
+msgstr "_Borrar"
 
 #, fuzzy
-msgid "Zoom In"
-msgstr "/Aumentar ampliación"
-
-#, fuzzy
-msgid "Zoom Out"
-msgstr "/Disminuir ampliación"
-
-#, fuzzy
-msgid "Zoom Extents"
-msgstr "/Mostrar todo"
-
-msgid "Select"
-msgstr "Seleccionar"
-
-msgid "Edit..."
+msgid "_Edit..."
 msgstr "Editar..."
 
 #, fuzzy
-msgid "Object Properties..."
-msgstr "<b>Propiedades del texto</b>"
-
-msgid "Copy"
-msgstr "Copiar"
-
-msgid "Move"
-msgstr "Mover"
-
-msgid "Delete"
-msgstr "Borrar"
+msgid "Ed_it Text..."
+msgstr "Editar texto..."
 
 #, fuzzy
-msgid "Down Schematic"
+msgid "_Object Properties..."
+msgstr "<b>Propiedades del texto</b>"
+
+#, fuzzy
+msgid "Hierarchy: Down _Schematic"
 msgstr "/Descender en esquema"
 
 #, fuzzy
-msgid "Down Symbol"
+msgid "Hierarchy: Down S_ymbol"
 msgstr "/Descender en símbolo"
 
 #, fuzzy
-msgid "Up"
-msgstr "/Arriba"
-
-#, fuzzy, c-format
-msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
-msgstr ""
-"Se ha intentado modificar la sensibilidad de una opción de menú que no "
-"existe '%s'\n"
-
-#, c-format
-msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
-msgstr ""
-"Se ha intentado modificar la sensibilidad de una opción de menú que no "
-"existe '%s'\n"
+msgid "Hierarchy: _Up"
+msgstr "Je_rarquía"
 
 msgid "The operating system is out of memory or resources."
 msgstr "El sistema se encuentra sin memoria o recursos suficientes."
@@ -1502,6 +1384,9 @@ msgstr "Promocionar"
 msgid "Duplicate"
 msgstr "Duplicar"
 
+msgid "Delete"
+msgstr "Borrar"
+
 #, fuzzy
 msgid "Copy to all"
 msgstr "Copiar en memoria intermedia 1"
@@ -1521,6 +1406,9 @@ msgstr "V"
 #, fuzzy
 msgid "Sho_w inherited attributes"
 msgstr "Mostrar propiedades heredadas"
+
+msgid "Add Attribute"
+msgstr "Añadir propiedad"
 
 #, fuzzy
 msgid "_Name:"
@@ -1643,6 +1531,25 @@ msgstr "Je_rarquía"
 msgid "Hierarchy up"
 msgstr "Je_rarquía"
 
+msgid "_New"
+msgstr "_Nuevo"
+
+msgid "_Open..."
+msgstr "_Abrir..."
+
+msgid "_Save"
+msgstr "_Guardar"
+
+msgid "Save _As..."
+msgstr "Guardar _como..."
+
+#, fuzzy
+msgid "Page _Manager..."
+msgstr "Administrador de páginas"
+
+msgid "_Close"
+msgstr "C_errar"
+
 #, fuzzy
 msgid "Options"
 msgstr "_Opciones"
@@ -1763,6 +1670,9 @@ msgstr ""
 msgid "Add Text..."
 msgstr "Añadir texto..."
 
+msgid "Select"
+msgstr "Seleccionar"
+
 msgid "Select mode"
 msgstr "Seleccionar"
 
@@ -1832,20 +1742,8 @@ msgstr "Editor de esquemas gEDA"
 msgid "Create and edit electrical schematics and symbols with lepton-schematic"
 msgstr "Crear y modificar esquemas y símbolos con gschem"
 
-msgid "_New"
-msgstr "_Nuevo"
-
-msgid "_Open..."
-msgstr "_Abrir..."
-
 msgid "Open Recen_t"
 msgstr "Abrir recien_te"
-
-msgid "_Save"
-msgstr "_Guardar"
-
-msgid "Save _As..."
-msgstr "Guardar _como..."
 
 msgid "Save All"
 msgstr "Guardar todo"
@@ -1879,18 +1777,6 @@ msgstr "_Deshacer"
 msgid "_Redo"
 msgstr "_Rehacer"
 
-msgid "Cu_t"
-msgstr "Cor_tar"
-
-msgid "_Copy"
-msgstr "_Copiar"
-
-msgid "_Paste"
-msgstr "_Pegar"
-
-msgid "_Delete"
-msgstr "_Borrar"
-
 msgid "Select All"
 msgstr "Seleccionar todo"
 
@@ -1899,6 +1785,13 @@ msgstr "Deseleccionar"
 
 msgid "Rotate 90 Mode"
 msgstr "Rotar 90º"
+
+#, fuzzy
+msgid "Object Properties..."
+msgstr "<b>Propiedades del texto</b>"
+
+msgid "Edit..."
+msgstr "Editar..."
 
 msgid "Edit Text..."
 msgstr "Editar texto..."
@@ -2023,9 +1916,6 @@ msgstr "_Anterior"
 msgid "_Next"
 msgstr "_Siguiente"
 
-msgid "_Close"
-msgstr "C_errar"
-
 #, fuzzy
 msgid "_Revert..."
 msgstr "_Recargar"
@@ -2137,6 +2027,9 @@ msgid "Grid Style: Cycle Dots/Mesh/Off"
 msgstr ""
 
 msgid "Grid Snap: Cycle Grid/Resnap/Off"
+msgstr ""
+
+msgid "Grips: On/Off"
 msgstr ""
 
 #, fuzzy
@@ -2289,6 +2182,9 @@ msgstr "Mostrar/Ocultar texto oculto"
 msgid "Cut"
 msgstr "Cor_tar"
 
+msgid "Copy"
+msgstr "Copiar"
+
 #, fuzzy
 msgid "Paste"
 msgstr "_Pegar"
@@ -2318,6 +2214,18 @@ msgstr ""
 #, fuzzy
 msgid "Pan Down"
 msgstr "Modo Centrar"
+
+#, fuzzy
+msgid "Zoom Extents"
+msgstr "/Mostrar todo"
+
+#, fuzzy
+msgid "Zoom In"
+msgstr "/Aumentar ampliación"
+
+#, fuzzy
+msgid "Zoom Out"
+msgstr "/Disminuir ampliación"
 
 #, fuzzy
 msgid "Zoom Full"
@@ -2355,6 +2263,22 @@ msgid "Print Page"
 msgstr "_Anterior"
 
 #, fuzzy
+msgid "Add Component"
+msgstr "/Añadir componente..."
+
+#, fuzzy
+msgid "Add Net"
+msgstr "/Añadir conexión..."
+
+#, fuzzy
+msgid "Add Bus"
+msgstr "/Añadir bus"
+
+#, fuzzy
+msgid "Add Text"
+msgstr "/Añadir texto"
+
+#, fuzzy
 msgid "Add Line"
 msgstr "Línea"
 
@@ -2380,6 +2304,14 @@ msgstr ""
 #, fuzzy
 msgid "Add Picture"
 msgstr "Imagen"
+
+#, fuzzy
+msgid "Down Schematic"
+msgstr "/Descender en esquema"
+
+#, fuzzy
+msgid "Down Symbol"
+msgstr "/Descender en símbolo"
 
 #, fuzzy
 msgid "Up Hierarchy"
@@ -2472,6 +2404,10 @@ msgid "Show Coordinate Window"
 msgstr "Mostrar ventana de _coordenadas..."
 
 #, fuzzy
+msgid "Toggle Grips"
+msgstr "Cambiar v_isibilidad"
+
+#, fuzzy
 msgid "Component Documentation"
 msgstr "D_ocumentación del componente..."
 
@@ -2509,10 +2445,6 @@ msgstr ""
 msgid "About lepton-schematic"
 msgstr "Acerca de gschem"
 
-#, scheme-format
-msgid "Invalid text alignment ~A."
-msgstr "Alineación de texto inválida ~A"
-
 #, fuzzy
 msgid "Could not show documentation:"
 msgstr "D_ocumentación del componente..."
@@ -2527,6 +2459,150 @@ msgstr "~S no es una combinación de teclas válida."
 #, scheme-format
 msgid "~S is not a prefix key sequence."
 msgstr "~S no es una secuencia de teclas válida como prefijo."
+
+#, scheme-format
+msgid "Invalid text alignment ~A."
+msgstr "Alineación de texto inválida ~A"
+
+#, fuzzy
+#~ msgid "Save settings to:"
+#~ msgstr "Opciones"
+
+#, fuzzy
+#~ msgid "Invalid size [%1$d] passed to text-size\n"
+#~ msgstr ""
+#~ "Se ha especificado un tamaño no válido [%d] a la función text-size\n"
+
+#, fuzzy
+#~ msgid "Invalid size [%1$d] passed to snap-size\n"
+#~ msgstr ""
+#~ "Se ha especificado un tamaño no válido [%d] a la función snap-size\n"
+
+#, fuzzy
+#~ msgid "Invalid num levels [%1$d] passed to undo-levels\n"
+#~ msgstr ""
+#~ "Número de niveles [%d] no válidos especificados a la función undo-levels\n"
+
+#, fuzzy
+#~ msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
+#~ msgstr "Tamaño no válido [%d] especificado a la función bus-ripper-size\n"
+
+#, fuzzy
+#~ msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
+#~ msgstr ""
+#~ "Tamaño de punto no válido [%d] especificado a la función dots-grid-dot-"
+#~ "size\n"
+
+#, fuzzy
+#~ msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
+#~ msgstr ""
+#~ "Espaciado de punto no válido [%d] especificado a la función dots-grid-"
+#~ "fixed-threshold\n"
+
+#, fuzzy
+#~ msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
+#~ msgstr ""
+#~ "Espaciado de punto no válido [%d] especificado a la función mesh-grid-"
+#~ "display-threshold\n"
+
+#, fuzzy
+#~ msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
+#~ msgstr ""
+#~ "Se ha especificado un número de segundos no válido [%d] a la función auto-"
+#~ "save-interval\n"
+
+#, fuzzy
+#~ msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
+#~ msgstr ""
+#~ "Se ha especificado un aumento no válido [%d] a la función mousepan-gain\n"
+
+#, fuzzy
+#~ msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
+#~ msgstr ""
+#~ "Se ha especificado un aumento no válido [%d] a la función keyboardpan-"
+#~ "gain\n"
+
+#, fuzzy
+#~ msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
+#~ msgstr ""
+#~ "Se ha especificado un número de pixels no válido [%d] a la función select-"
+#~ "slack-pixels\n"
+
+#, fuzzy
+#~ msgid "Invalid gain [%1$d] passed to zoom-gain\n"
+#~ msgstr ""
+#~ "Se ha llamado a la función zoom-gain con un nivel de aumento [%d] no "
+#~ "válido\n"
+
+#, fuzzy
+#~ msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
+#~ msgstr ""
+#~ "Se ha llamado a la función scrollpan-steps con un número de pasos no "
+#~ "válido [%d]\n"
+
+#~ msgid "Got an unexpected NULL in o_edit\n"
+#~ msgstr "Se ha recibido NULL (no esperado) en la función o_edit\n"
+
+#~ msgid "ERROR: NULL object in o_move_end!\n"
+#~ msgstr "ERROR: en la función o_move_end, ¡el objeto es NULL!\n"
+
+#, fuzzy
+#~ msgid ""
+#~ "Lepton EDA %1$s (git: %2$.7s)\n"
+#~ "Copyright (C) 1998-2017 by Ales Hvezda and the respective original "
+#~ "authors.\n"
+#~ "Copyright (C) 2017-2019 Lepton Developers.\n"
+#~ "This is free software, and you are welcome to redistribute it under\n"
+#~ "certain conditions. For details, see the file `COPYING', which is\n"
+#~ "included in the Lepton EDA distribution.\n"
+#~ "There is NO WARRANTY, to the extent permitted by law.\n"
+#~ msgstr ""
+#~ "gEDA %s (g%.7s)\n"
+#~ "Derechos Reservados (C) 1998-2012 desarrolladores de gEDA\n"
+#~ "Esto es software libre, y eres bienvenido a redistribuirlo bajo\n"
+#~ "ciertas condiciones. Para más detalles, revisa el fichero `COPYING', que "
+#~ "se\n"
+#~ "incluye en la distribución de gEDA.\n"
+#~ "NO EXISTEN GARANTIAS, dentro de lo que la ley permite.\n"
+
+#~ msgid "ERROR: NULL object!\n"
+#~ msgstr "ERROR: ¡objeto vacío (NULL)!\n"
+
+#, fuzzy
+#~ msgid "Could not allocate the color %1$s!\n"
+#~ msgstr "¡No se puede reservar memoria para el color %s!\n"
+
+#~ msgid "black"
+#~ msgstr "negro"
+
+#~ msgid "white"
+#~ msgstr "blanco"
+
+#, fuzzy
+#~ msgid "Could not allocate display color %1$i!\n"
+#~ msgstr "¡No se puede reservar memoria para el color %i!\n"
+
+#, fuzzy
+#~ msgid "Could not allocate outline color %1$i!\n"
+#~ msgstr "¡No se puede reservar memoria para el color del contorno %i!\n"
+
+#~ msgid "Move"
+#~ msgstr "Mover"
+
+#, fuzzy
+#~ msgid "Up"
+#~ msgstr "/Arriba"
+
+#, fuzzy
+#~ msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
+#~ msgstr ""
+#~ "Se ha intentado modificar la sensibilidad de una opción de menú que no "
+#~ "existe '%s'\n"
+
+#~ msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
+#~ msgstr ""
+#~ "Se ha intentado modificar la sensibilidad de una opción de menú que no "
+#~ "existe '%s'\n"
 
 #, fuzzy
 #~ msgid "Invalid offset [%1$d] passed to add-attribute-offset\n"
@@ -2834,9 +2910,6 @@ msgstr "~S no es una secuencia de teclas válida como prefijo."
 
 #~ msgid "Function"
 #~ msgstr "Función"
-
-#~ msgid "/Add Attribute..."
-#~ msgstr "/Añadir propiedad"
 
 #~ msgid "/Zoom Box"
 #~ msgstr "/Ampliar zona"

--- a/schematic/po/fa.po
+++ b/schematic/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-10-03 23:34+0300\n"
+"POT-Creation-Date: 2020-03-18 20:44+0300\n"
 "PO-Revision-Date: 2012-01-27 14:22+0000\n"
 "Last-Translator: Sasan Jafarnejad <Unknown>\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -19,6 +19,13 @@ msgstr ""
 "X-Generator: Launchpad (build 16265)\n"
 
 msgid "Zoom too small!  Cannot zoom further."
+msgstr ""
+
+msgid ""
+"Save your color scheme to a file by clicking on the \"Save As...\"\n"
+"button. It can be loaded on startup with the following\n"
+"expression in the gschemrc configuration file:\n"
+"( primitive-load \"/path/to/saved-color-scheme-file\" )"
 msgstr ""
 
 #, c-format
@@ -46,6 +53,11 @@ msgstr ""
 msgid "Sa_ve..."
 msgstr ""
 
+msgid ""
+"After you're done choosing the font, it's recommended\n"
+"to reopen schematics or restart the application."
+msgstr ""
+
 #, c-format
 msgid "<b>Current:</b> %s"
 msgstr ""
@@ -53,23 +65,20 @@ msgstr ""
 msgid "Save configuration"
 msgstr ""
 
-msgid "Save settings to:"
+msgid "Local configuration file:"
 msgstr ""
 
-msgid "Local configuration file (in current directory)"
+msgid "User configuration file:"
 msgstr ""
 
-msgid "User configuration file (geda-user.conf)"
-msgstr ""
-
-msgid "Object ~A is not included in the current gschem page."
+msgid "Object ~A is not included in the current lepton-schematic page."
 msgstr ""
 
 msgid "Invalid text name/value visibility ~A."
 msgstr ""
 
 #, c-format
-msgid "You are running gEDA/gaf version [%1$s%2$s.%3$s],\n"
+msgid "You are running lepton-schematic version [%1$s%2$s.%3$s],\n"
 msgstr ""
 
 #, c-format
@@ -82,65 +91,13 @@ msgstr ""
 msgid "Please be sure that you have the latest rc file.\n"
 msgstr ""
 
-#, c-format
-msgid "Invalid size [%1$d] passed to text-size\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid size [%1$d] passed to snap-size\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid num levels [%1$d] passed to undo-levels\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid gain [%1$d] passed to zoom-gain\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
-msgstr ""
-
 msgid "Object ~A is not directly included in a page."
 msgstr ""
 
 msgid "Could not launch URI ~S: ~A"
 msgstr ""
 
-msgid "Found invalid gschem window smob ~S"
+msgid "Found invalid lepton-schematic window smob ~S"
 msgstr ""
 
 #, c-format
@@ -171,7 +128,7 @@ msgstr ""
 
 msgid ""
 "Copyright © 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright © 2017-2019 Lepton Developers.\n"
+"Copyright © 2017-2020 Lepton Developers.\n"
 "See AUTHORS, ChangeLog files and consult 'git log' history for details."
 msgstr ""
 
@@ -610,7 +567,8 @@ msgid ""
 "\n"
 "Are you sure you want to revert this page?\n"
 "All unsaved changes in current schematic will be\n"
-"discarded and page file will be reloaded from disk."
+"discarded and page file will be reloaded from disk.\n"
+"This action will also reload all component libraries."
 msgstr ""
 
 msgid "Revert"
@@ -703,10 +661,6 @@ msgid_plural "Delete %1$u locked objects?"
 msgstr[0] ""
 msgstr[1] ""
 
-#, c-format
-msgid "Got an unexpected NULL in o_edit\n"
-msgstr ""
-
 msgid "Hidden text is now visible"
 msgstr ""
 
@@ -718,7 +672,7 @@ msgid "Could not find symbol [%1$s] in library. Update failed."
 msgstr ""
 
 #, c-format
-msgid "o_autosave_backups: Can't get the real filename of %1$s."
+msgid "Can't get the real filename of %1$s."
 msgstr ""
 
 #, c-format
@@ -731,10 +685,6 @@ msgstr ""
 
 #, c-format
 msgid "Could NOT save backup file [%1$s]"
-msgstr ""
-
-#, c-format
-msgid "ERROR: NULL object in o_move_end!\n"
 msgstr ""
 
 #, c-format
@@ -783,7 +733,7 @@ msgstr ""
 msgid "New slot number out of range"
 msgstr ""
 
-msgid "Undo/Redo disabled in rc file"
+msgid "Undo/Redo is disabled in configuration"
 msgstr ""
 
 #, c-format
@@ -804,27 +754,12 @@ msgid ""
 "  -h, --help               Help; this message.\n"
 "  --                       Treat all remaining arguments as filenames.\n"
 "\n"
-"Report bugs at <https://github.com/lepton-eda/lepton-eda/issues>\n"
-"Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"Lepton EDA %1$s (git: %2$.7s)\n"
-"Copyright (C) 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright (C) 2017-2019 Lepton Developers.\n"
-"This is free software, and you are welcome to redistribute it under\n"
-"certain conditions. For details, see the file `COPYING', which is\n"
-"included in the Lepton EDA distribution.\n"
-"There is NO WARRANTY, to the extent permitted by law.\n"
+"Report bugs at <%2$s>\n"
+"Lepton EDA homepage: <%3$s>\n"
 msgstr ""
 
 #, c-format
 msgid "Got invalid show option; defaulting to show both\n"
-msgstr ""
-
-#, c-format
-msgid "ERROR: NULL object!\n"
 msgstr ""
 
 msgid "Single Attribute Editor"
@@ -879,7 +814,7 @@ msgid ""
 "duplicate slot may cause problems: [symbolname=%1$s, number=%2$d, slot=%3$d]"
 msgstr ""
 
-msgid "No searchstring given in autonumber text."
+msgid "No search string given in autonumber text."
 msgstr ""
 
 msgid "No '*' or '?' given at the end of the autonumber text."
@@ -953,24 +888,6 @@ msgid ""
 msgstr ""
 
 msgid "Clipboard insertion failed"
-msgstr ""
-
-#, c-format
-msgid "Could not allocate the color %1$s!\n"
-msgstr ""
-
-msgid "black"
-msgstr ""
-
-msgid "white"
-msgstr ""
-
-#, c-format
-msgid "Could not allocate display color %1$i!\n"
-msgstr ""
-
-#, c-format
-msgid "Could not allocate outline color %1$i!\n"
 msgstr ""
 
 #, c-format
@@ -1110,13 +1027,13 @@ msgstr ""
 msgid "Invalid Attribute"
 msgstr ""
 
-msgid "Schematics"
+msgid "Schematics (*.sch)"
 msgstr ""
 
-msgid "Symbols"
+msgid "Symbols (*.sym)"
 msgstr ""
 
-msgid "Schematics and symbols"
+msgid "Schematics and symbols (*.sch *.sym)"
 msgstr ""
 
 msgid "All files"
@@ -1152,7 +1069,7 @@ msgid "Hatch"
 msgstr ""
 
 #, c-format
-msgid "x_image_lowlevel: Unable to write %1$s file %2$s."
+msgid "Unable to write %1$s file %2$s."
 msgstr ""
 
 #, c-format
@@ -1171,7 +1088,7 @@ msgstr ""
 msgid "Wrote black and white image to [%1$s] [%2$d x %3$d]"
 msgstr ""
 
-msgid "x_image_lowlevel: Unable to get pixbuf from gschem's window."
+msgid "Unable to get pixbuf from lepton-schematic's window."
 msgstr ""
 
 msgid "NOTE: print-color-map will be used for PDF export"
@@ -1220,68 +1137,55 @@ msgstr ""
 msgid "Phantom"
 msgstr ""
 
-msgid "Add Net"
-msgstr ""
-
-msgid "Add Attribute"
-msgstr ""
-
 #, fuzzy
-msgid "Add Component"
+msgid "Add Co_mponent..."
 msgstr "Update Component"
 
-msgid "Add Bus"
-msgstr ""
-
 #, fuzzy
-msgid "Add Text"
+msgid "Add Te_xt..."
 msgstr "Edit Text..."
 
 #, fuzzy
-msgid "Zoom In"
-msgstr "Zoom Box"
+msgid "Add _Attribute..."
+msgstr "Attributes"
 
 #, fuzzy
-msgid "Zoom Out"
-msgstr "Zoom Box"
+msgid "Add _Net"
+msgstr "Edit Text..."
 
-#, fuzzy
-msgid "Zoom Extents"
-msgstr "Zoom Box"
-
-msgid "Select"
+msgid "Add _Bus"
 msgstr ""
 
-msgid "Edit..."
+msgid "Cu_t"
+msgstr ""
+
+msgid "_Copy"
+msgstr ""
+
+msgid "_Paste"
+msgstr ""
+
+msgid "_Delete"
+msgstr ""
+
+#, fuzzy
+msgid "_Edit..."
 msgstr "Edit..."
 
-msgid "Object Properties..."
+#, fuzzy
+msgid "Ed_it Text..."
+msgstr "Edit Text..."
+
+msgid "_Object Properties..."
 msgstr ""
 
-msgid "Copy"
+msgid "Hierarchy: Down _Schematic"
 msgstr ""
 
-msgid "Move"
+msgid "Hierarchy: Down S_ymbol"
 msgstr ""
 
-msgid "Delete"
-msgstr "Delete"
-
-msgid "Down Schematic"
-msgstr ""
-
-msgid "Down Symbol"
-msgstr ""
-
-msgid "Up"
-msgstr ""
-
-#, c-format
-msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
-msgstr ""
-
-#, c-format
-msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
+msgid "Hierarchy: _Up"
 msgstr ""
 
 msgid "The operating system is out of memory or resources."
@@ -1305,6 +1209,9 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
+msgid "Delete"
+msgstr "Delete"
+
 #, fuzzy
 msgid "Copy to all"
 msgstr "Copy into 1"
@@ -1324,6 +1231,9 @@ msgstr ""
 #, fuzzy
 msgid "Sho_w inherited attributes"
 msgstr "Attributes"
+
+msgid "Add Attribute"
+msgstr ""
 
 msgid "_Name:"
 msgstr ""
@@ -1431,6 +1341,24 @@ msgid "Hierarchy up: %s"
 msgstr ""
 
 msgid "Hierarchy up"
+msgstr ""
+
+msgid "_New"
+msgstr ""
+
+msgid "_Open..."
+msgstr ""
+
+msgid "_Save"
+msgstr ""
+
+msgid "Save _As..."
+msgstr ""
+
+msgid "Page _Manager..."
+msgstr ""
+
+msgid "_Close"
 msgstr ""
 
 msgid "Options"
@@ -1541,6 +1469,9 @@ msgstr ""
 msgid "Add Text..."
 msgstr ""
 
+msgid "Select"
+msgstr ""
+
 msgid "Select mode"
 msgstr ""
 
@@ -1601,19 +1532,7 @@ msgstr ""
 msgid "Create and edit electrical schematics and symbols with lepton-schematic"
 msgstr ""
 
-msgid "_New"
-msgstr ""
-
-msgid "_Open..."
-msgstr ""
-
 msgid "Open Recen_t"
-msgstr ""
-
-msgid "_Save"
-msgstr ""
-
-msgid "Save _As..."
 msgstr ""
 
 msgid "Save All"
@@ -1647,18 +1566,6 @@ msgstr ""
 msgid "_Redo"
 msgstr ""
 
-msgid "Cu_t"
-msgstr ""
-
-msgid "_Copy"
-msgstr ""
-
-msgid "_Paste"
-msgstr ""
-
-msgid "_Delete"
-msgstr ""
-
 msgid "Select All"
 msgstr ""
 
@@ -1667,6 +1574,12 @@ msgstr ""
 
 msgid "Rotate 90 Mode"
 msgstr "Rotate 90 Mode"
+
+msgid "Object Properties..."
+msgstr ""
+
+msgid "Edit..."
+msgstr "Edit..."
 
 msgid "Edit Text..."
 msgstr "Edit Text..."
@@ -1786,9 +1699,6 @@ msgstr ""
 msgid "_Next"
 msgstr ""
 
-msgid "_Close"
-msgstr ""
-
 msgid "_Revert..."
 msgstr ""
 
@@ -1896,6 +1806,9 @@ msgid "Grid Style: Cycle Dots/Mesh/Off"
 msgstr ""
 
 msgid "Grid Snap: Cycle Grid/Resnap/Off"
+msgstr ""
+
+msgid "Grips: On/Off"
 msgstr ""
 
 msgid "Feedback Mode: Outline/Box"
@@ -2036,6 +1949,9 @@ msgstr "Show/Hide Inv Text"
 msgid "Cut"
 msgstr "Cut into 1"
 
+msgid "Copy"
+msgstr ""
+
 #, fuzzy
 msgid "Paste"
 msgstr "Paste from 1"
@@ -2061,6 +1977,18 @@ msgstr ""
 
 msgid "Pan Down"
 msgstr ""
+
+#, fuzzy
+msgid "Zoom Extents"
+msgstr "Zoom Box"
+
+#, fuzzy
+msgid "Zoom In"
+msgstr "Zoom Box"
+
+#, fuzzy
+msgid "Zoom Out"
+msgstr "Zoom Box"
 
 msgid "Zoom Full"
 msgstr ""
@@ -2093,6 +2021,20 @@ msgid "Print Page"
 msgstr "Close Page"
 
 #, fuzzy
+msgid "Add Component"
+msgstr "Update Component"
+
+msgid "Add Net"
+msgstr ""
+
+msgid "Add Bus"
+msgstr ""
+
+#, fuzzy
+msgid "Add Text"
+msgstr "Edit Text..."
+
+#, fuzzy
 msgid "Add Line"
 msgstr "Line"
 
@@ -2113,6 +2055,12 @@ msgid "Add Pin"
 msgstr ""
 
 msgid "Add Picture"
+msgstr ""
+
+msgid "Down Schematic"
+msgstr ""
+
+msgid "Down Symbol"
 msgstr ""
 
 msgid "Up Hierarchy"
@@ -2192,6 +2140,9 @@ msgstr "New Window"
 msgid "Show Coordinate Window"
 msgstr ""
 
+msgid "Toggle Grips"
+msgstr ""
+
 msgid "Component Documentation"
 msgstr ""
 
@@ -2227,10 +2178,6 @@ msgstr ""
 msgid "About lepton-schematic"
 msgstr "About gschem"
 
-#, scheme-format
-msgid "Invalid text alignment ~A."
-msgstr ""
-
 msgid "Could not show documentation:"
 msgstr ""
 
@@ -2243,6 +2190,10 @@ msgstr ""
 
 #, scheme-format
 msgid "~S is not a prefix key sequence."
+msgstr ""
+
+#, scheme-format
+msgid "Invalid text alignment ~A."
 msgstr ""
 
 #~ msgid "Edit"

--- a/schematic/po/fi.po
+++ b/schematic/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-10-03 23:34+0300\n"
+"POT-Creation-Date: 2020-03-18 20:44+0300\n"
 "PO-Revision-Date: 2012-01-27 14:18+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: Finnish <fi@li.org>\n"
@@ -19,6 +19,13 @@ msgstr ""
 "X-Generator: Launchpad (build 16265)\n"
 
 msgid "Zoom too small!  Cannot zoom further."
+msgstr ""
+
+msgid ""
+"Save your color scheme to a file by clicking on the \"Save As...\"\n"
+"button. It can be loaded on startup with the following\n"
+"expression in the gschemrc configuration file:\n"
+"( primitive-load \"/path/to/saved-color-scheme-file\" )"
 msgstr ""
 
 #, c-format
@@ -46,6 +53,11 @@ msgstr ""
 msgid "Sa_ve..."
 msgstr ""
 
+msgid ""
+"After you're done choosing the font, it's recommended\n"
+"to reopen schematics or restart the application."
+msgstr ""
+
 #, c-format
 msgid "<b>Current:</b> %s"
 msgstr ""
@@ -53,23 +65,20 @@ msgstr ""
 msgid "Save configuration"
 msgstr ""
 
-msgid "Save settings to:"
+msgid "Local configuration file:"
 msgstr ""
 
-msgid "Local configuration file (in current directory)"
+msgid "User configuration file:"
 msgstr ""
 
-msgid "User configuration file (geda-user.conf)"
-msgstr ""
-
-msgid "Object ~A is not included in the current gschem page."
+msgid "Object ~A is not included in the current lepton-schematic page."
 msgstr ""
 
 msgid "Invalid text name/value visibility ~A."
 msgstr ""
 
 #, c-format
-msgid "You are running gEDA/gaf version [%1$s%2$s.%3$s],\n"
+msgid "You are running lepton-schematic version [%1$s%2$s.%3$s],\n"
 msgstr ""
 
 #, c-format
@@ -82,65 +91,13 @@ msgstr ""
 msgid "Please be sure that you have the latest rc file.\n"
 msgstr ""
 
-#, fuzzy, c-format
-msgid "Invalid size [%1$d] passed to text-size\n"
-msgstr "Virheellinen koko [%d] annettu tekstin kooksi.\n"
-
-#, fuzzy, c-format
-msgid "Invalid size [%1$d] passed to snap-size\n"
-msgstr "virheellinen koko [%d] annettu apuruudukonkooksi.\n"
-
-#, fuzzy, c-format
-msgid "Invalid num levels [%1$d] passed to undo-levels\n"
-msgstr "Virheellinen määrä [%d] kumoamistasoja.\n"
-
-#, fuzzy, c-format
-msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
-msgstr "virheellinen koko [%d] annettu apuruudukonkooksi.\n"
-
-#, fuzzy, c-format
-msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
-msgstr "Virheellinen koko [%d] annettu tekstin kooksi.\n"
-
-#, fuzzy, c-format
-msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
-msgstr "Virheellinen määrä [%d] kumoamistasoja.\n"
-
-#, c-format
-msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
-msgstr ""
-
-#, fuzzy, c-format
-msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
-msgstr "Virheellinen määrä [%d] kumoamistasoja.\n"
-
-#, fuzzy, c-format
-msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
-msgstr "virheellinen koko [%d] annettu apuruudukonkooksi.\n"
-
-#, fuzzy, c-format
-msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
-msgstr "virheellinen koko [%d] annettu apuruudukonkooksi.\n"
-
-#, fuzzy, c-format
-msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
-msgstr "Virheellinen määrä [%d] kumoamistasoja.\n"
-
-#, fuzzy, c-format
-msgid "Invalid gain [%1$d] passed to zoom-gain\n"
-msgstr "Virheellinen koko [%d] annettu tekstin kooksi.\n"
-
-#, c-format
-msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
-msgstr ""
-
 msgid "Object ~A is not directly included in a page."
 msgstr ""
 
 msgid "Could not launch URI ~S: ~A"
 msgstr ""
 
-msgid "Found invalid gschem window smob ~S"
+msgid "Found invalid lepton-schematic window smob ~S"
 msgstr ""
 
 #, c-format
@@ -171,7 +128,7 @@ msgstr ""
 
 msgid ""
 "Copyright © 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright © 2017-2019 Lepton Developers.\n"
+"Copyright © 2017-2020 Lepton Developers.\n"
 "See AUTHORS, ChangeLog files and consult 'git log' history for details."
 msgstr ""
 
@@ -615,7 +572,8 @@ msgid ""
 "\n"
 "Are you sure you want to revert this page?\n"
 "All unsaved changes in current schematic will be\n"
-"discarded and page file will be reloaded from disk."
+"discarded and page file will be reloaded from disk.\n"
+"This action will also reload all component libraries."
 msgstr ""
 
 #, fuzzy
@@ -709,10 +667,6 @@ msgid_plural "Delete %1$u locked objects?"
 msgstr[0] ""
 msgstr[1] ""
 
-#, c-format
-msgid "Got an unexpected NULL in o_edit\n"
-msgstr ""
-
 msgid "Hidden text is now visible"
 msgstr ""
 
@@ -724,7 +678,7 @@ msgid "Could not find symbol [%1$s] in library. Update failed."
 msgstr ""
 
 #, c-format
-msgid "o_autosave_backups: Can't get the real filename of %1$s."
+msgid "Can't get the real filename of %1$s."
 msgstr ""
 
 #, c-format
@@ -737,10 +691,6 @@ msgstr ""
 
 #, c-format
 msgid "Could NOT save backup file [%1$s]"
-msgstr ""
-
-#, c-format
-msgid "ERROR: NULL object in o_move_end!\n"
 msgstr ""
 
 #, c-format
@@ -789,7 +739,7 @@ msgstr ""
 msgid "New slot number out of range"
 msgstr ""
 
-msgid "Undo/Redo disabled in rc file"
+msgid "Undo/Redo is disabled in configuration"
 msgstr ""
 
 #, c-format
@@ -810,27 +760,12 @@ msgid ""
 "  -h, --help               Help; this message.\n"
 "  --                       Treat all remaining arguments as filenames.\n"
 "\n"
-"Report bugs at <https://github.com/lepton-eda/lepton-eda/issues>\n"
-"Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"Lepton EDA %1$s (git: %2$.7s)\n"
-"Copyright (C) 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright (C) 2017-2019 Lepton Developers.\n"
-"This is free software, and you are welcome to redistribute it under\n"
-"certain conditions. For details, see the file `COPYING', which is\n"
-"included in the Lepton EDA distribution.\n"
-"There is NO WARRANTY, to the extent permitted by law.\n"
+"Report bugs at <%2$s>\n"
+"Lepton EDA homepage: <%3$s>\n"
 msgstr ""
 
 #, c-format
 msgid "Got invalid show option; defaulting to show both\n"
-msgstr ""
-
-#, c-format
-msgid "ERROR: NULL object!\n"
 msgstr ""
 
 msgid "Single Attribute Editor"
@@ -886,7 +821,7 @@ msgid ""
 "duplicate slot may cause problems: [symbolname=%1$s, number=%2$d, slot=%3$d]"
 msgstr ""
 
-msgid "No searchstring given in autonumber text."
+msgid "No search string given in autonumber text."
 msgstr ""
 
 msgid "No '*' or '?' given at the end of the autonumber text."
@@ -960,24 +895,6 @@ msgid ""
 msgstr ""
 
 msgid "Clipboard insertion failed"
-msgstr ""
-
-#, c-format
-msgid "Could not allocate the color %1$s!\n"
-msgstr ""
-
-msgid "black"
-msgstr ""
-
-msgid "white"
-msgstr ""
-
-#, c-format
-msgid "Could not allocate display color %1$i!\n"
-msgstr ""
-
-#, c-format
-msgid "Could not allocate outline color %1$i!\n"
 msgstr ""
 
 #, c-format
@@ -1118,13 +1035,13 @@ msgstr ""
 msgid "Invalid Attribute"
 msgstr ""
 
-msgid "Schematics"
+msgid "Schematics (*.sch)"
 msgstr ""
 
-msgid "Symbols"
+msgid "Symbols (*.sym)"
 msgstr ""
 
-msgid "Schematics and symbols"
+msgid "Schematics and symbols (*.sch *.sym)"
 msgstr ""
 
 msgid "All files"
@@ -1160,7 +1077,7 @@ msgid "Hatch"
 msgstr ""
 
 #, c-format
-msgid "x_image_lowlevel: Unable to write %1$s file %2$s."
+msgid "Unable to write %1$s file %2$s."
 msgstr ""
 
 #, c-format
@@ -1179,7 +1096,7 @@ msgstr ""
 msgid "Wrote black and white image to [%1$s] [%2$d x %3$d]"
 msgstr ""
 
-msgid "x_image_lowlevel: Unable to get pixbuf from gschem's window."
+msgid "Unable to get pixbuf from lepton-schematic's window."
 msgstr ""
 
 msgid "NOTE: print-color-map will be used for PDF export"
@@ -1228,69 +1145,55 @@ msgstr ""
 msgid "Phantom"
 msgstr ""
 
-msgid "Add Net"
-msgstr ""
-
-msgid "Add Attribute"
-msgstr ""
-
 #, fuzzy
-msgid "Add Component"
+msgid "Add Co_mponent..."
 msgstr "Päivitä komponentti"
 
-msgid "Add Bus"
-msgstr ""
-
 #, fuzzy
-msgid "Add Text"
+msgid "Add Te_xt..."
 msgstr "Muokkaa tekstiä..."
 
 #, fuzzy
-msgid "Zoom In"
-msgstr "_Lähennä"
+msgid "Add _Attribute..."
+msgstr "_Määrite..."
 
 #, fuzzy
-msgid "Zoom Out"
-msgstr "L_oitonna"
+msgid "Add _Net"
+msgstr "Muokkaa tekstiä..."
 
-#, fuzzy
-msgid "Zoom Extents"
-msgstr "_Lähennä"
-
-msgid "Select"
+msgid "Add _Bus"
 msgstr ""
 
-msgid "Edit..."
+msgid "Cu_t"
+msgstr "_Leikkaa"
+
+msgid "_Copy"
+msgstr "_Kopioi"
+
+msgid "_Paste"
+msgstr "L_iitä"
+
+msgid "_Delete"
+msgstr "_Poista"
+
+#, fuzzy
+msgid "_Edit..."
 msgstr "Muokkaa..."
 
-msgid "Object Properties..."
-msgstr ""
-
-msgid "Copy"
-msgstr ""
-
-msgid "Move"
-msgstr ""
-
-msgid "Delete"
-msgstr ""
-
-msgid "Down Schematic"
-msgstr ""
-
-msgid "Down Symbol"
-msgstr ""
-
 #, fuzzy
-msgid "Up"
-msgstr "_Ylös"
+msgid "Ed_it Text..."
+msgstr "Muokkaa tekstiä..."
 
-#, c-format
-msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
+msgid "_Object Properties..."
 msgstr ""
 
-#, c-format
-msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
+msgid "Hierarchy: Down _Schematic"
+msgstr ""
+
+msgid "Hierarchy: Down S_ymbol"
+msgstr ""
+
+msgid "Hierarchy: _Up"
 msgstr ""
 
 msgid "The operating system is out of memory or resources."
@@ -1314,6 +1217,9 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
+msgid "Delete"
+msgstr ""
+
 #, fuzzy
 msgid "Copy to all"
 msgstr "Kopioi puskuriin 1"
@@ -1333,6 +1239,9 @@ msgstr ""
 #, fuzzy
 msgid "Sho_w inherited attributes"
 msgstr "Määri_tteet..."
+
+msgid "Add Attribute"
+msgstr ""
 
 #, fuzzy
 msgid "_Name:"
@@ -1444,6 +1353,24 @@ msgstr ""
 msgid "Hierarchy up"
 msgstr ""
 
+msgid "_New"
+msgstr "_Uusi"
+
+msgid "_Open..."
+msgstr "_Avaa…"
+
+msgid "_Save"
+msgstr "_Tallenna"
+
+msgid "Save _As..."
+msgstr "Tallenna _nimellä..."
+
+msgid "Page _Manager..."
+msgstr ""
+
+msgid "_Close"
+msgstr "Sul_je"
+
 msgid "Options"
 msgstr ""
 
@@ -1552,6 +1479,9 @@ msgstr ""
 msgid "Add Text..."
 msgstr ""
 
+msgid "Select"
+msgstr ""
+
 msgid "Select mode"
 msgstr ""
 
@@ -1612,20 +1542,8 @@ msgstr ""
 msgid "Create and edit electrical schematics and symbols with lepton-schematic"
 msgstr ""
 
-msgid "_New"
-msgstr "_Uusi"
-
-msgid "_Open..."
-msgstr "_Avaa…"
-
 msgid "Open Recen_t"
 msgstr "_Viimeisimmät tiedostot"
-
-msgid "_Save"
-msgstr "_Tallenna"
-
-msgid "Save _As..."
-msgstr "Tallenna _nimellä..."
 
 msgid "Save All"
 msgstr "Tallenna _kaikki"
@@ -1659,18 +1577,6 @@ msgstr "K_umoa"
 msgid "_Redo"
 msgstr "_Tee uudelleen"
 
-msgid "Cu_t"
-msgstr "_Leikkaa"
-
-msgid "_Copy"
-msgstr "_Kopioi"
-
-msgid "_Paste"
-msgstr "L_iitä"
-
-msgid "_Delete"
-msgstr "_Poista"
-
 msgid "Select All"
 msgstr ""
 
@@ -1679,6 +1585,12 @@ msgstr ""
 
 msgid "Rotate 90 Mode"
 msgstr "Käännä 90 astetta"
+
+msgid "Object Properties..."
+msgstr ""
+
+msgid "Edit..."
+msgstr "Muokkaa..."
 
 msgid "Edit Text..."
 msgstr "Muokkaa tekstiä..."
@@ -1798,9 +1710,6 @@ msgstr "_Edellinen"
 msgid "_Next"
 msgstr "_Seuraava"
 
-msgid "_Close"
-msgstr "Sul_je"
-
 #, fuzzy
 msgid "_Revert..."
 msgstr "_Hylkää muutokset"
@@ -1910,6 +1819,9 @@ msgid "Grid Style: Cycle Dots/Mesh/Off"
 msgstr ""
 
 msgid "Grid Snap: Cycle Grid/Resnap/Off"
+msgstr ""
+
+msgid "Grips: On/Off"
 msgstr ""
 
 #, fuzzy
@@ -2056,6 +1968,9 @@ msgstr ""
 msgid "Cut"
 msgstr "_Leikkaa"
 
+msgid "Copy"
+msgstr ""
+
 #, fuzzy
 msgid "Paste"
 msgstr "L_iitä"
@@ -2082,6 +1997,18 @@ msgstr ""
 
 msgid "Pan Down"
 msgstr ""
+
+#, fuzzy
+msgid "Zoom Extents"
+msgstr "_Lähennä"
+
+#, fuzzy
+msgid "Zoom In"
+msgstr "_Lähennä"
+
+#, fuzzy
+msgid "Zoom Out"
+msgstr "L_oitonna"
 
 #, fuzzy
 msgid "Zoom Full"
@@ -2114,6 +2041,20 @@ msgid "Print Page"
 msgstr "_Edellinen"
 
 #, fuzzy
+msgid "Add Component"
+msgstr "Päivitä komponentti"
+
+msgid "Add Net"
+msgstr ""
+
+msgid "Add Bus"
+msgstr ""
+
+#, fuzzy
+msgid "Add Text"
+msgstr "Muokkaa tekstiä..."
+
+#, fuzzy
 msgid "Add Line"
 msgstr "_Viiva"
 
@@ -2136,6 +2077,12 @@ msgstr ""
 #, fuzzy
 msgid "Add Picture"
 msgstr "Kuva..."
+
+msgid "Down Schematic"
+msgstr ""
+
+msgid "Down Symbol"
+msgstr ""
 
 msgid "Up Hierarchy"
 msgstr ""
@@ -2225,6 +2172,10 @@ msgid "Show Coordinate Window"
 msgstr "Näytä _Koordinaatti-ikkuna..."
 
 #, fuzzy
+msgid "Toggle Grips"
+msgstr "Vaihda Näk_yvyys"
+
+#, fuzzy
 msgid "Component Documentation"
 msgstr "Komponentin D_okumentaatio..."
 
@@ -2261,10 +2212,6 @@ msgstr ""
 msgid "About lepton-schematic"
 msgstr ""
 
-#, scheme-format
-msgid "Invalid text alignment ~A."
-msgstr ""
-
 #, fuzzy
 msgid "Could not show documentation:"
 msgstr "Komponentin D_okumentaatio..."
@@ -2279,6 +2226,58 @@ msgstr ""
 #, scheme-format
 msgid "~S is not a prefix key sequence."
 msgstr ""
+
+#, scheme-format
+msgid "Invalid text alignment ~A."
+msgstr ""
+
+#, fuzzy
+#~ msgid "Invalid size [%1$d] passed to text-size\n"
+#~ msgstr "Virheellinen koko [%d] annettu tekstin kooksi.\n"
+
+#, fuzzy
+#~ msgid "Invalid size [%1$d] passed to snap-size\n"
+#~ msgstr "virheellinen koko [%d] annettu apuruudukonkooksi.\n"
+
+#, fuzzy
+#~ msgid "Invalid num levels [%1$d] passed to undo-levels\n"
+#~ msgstr "Virheellinen määrä [%d] kumoamistasoja.\n"
+
+#, fuzzy
+#~ msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
+#~ msgstr "virheellinen koko [%d] annettu apuruudukonkooksi.\n"
+
+#, fuzzy
+#~ msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
+#~ msgstr "Virheellinen koko [%d] annettu tekstin kooksi.\n"
+
+#, fuzzy
+#~ msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
+#~ msgstr "Virheellinen määrä [%d] kumoamistasoja.\n"
+
+#, fuzzy
+#~ msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
+#~ msgstr "Virheellinen määrä [%d] kumoamistasoja.\n"
+
+#, fuzzy
+#~ msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
+#~ msgstr "virheellinen koko [%d] annettu apuruudukonkooksi.\n"
+
+#, fuzzy
+#~ msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
+#~ msgstr "virheellinen koko [%d] annettu apuruudukonkooksi.\n"
+
+#, fuzzy
+#~ msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
+#~ msgstr "Virheellinen määrä [%d] kumoamistasoja.\n"
+
+#, fuzzy
+#~ msgid "Invalid gain [%1$d] passed to zoom-gain\n"
+#~ msgstr "Virheellinen koko [%d] annettu tekstin kooksi.\n"
+
+#, fuzzy
+#~ msgid "Up"
+#~ msgstr "_Ylös"
 
 #, fuzzy
 #~ msgid "Invalid offset [%1$d] passed to add-attribute-offset\n"

--- a/schematic/po/fr.po
+++ b/schematic/po/fr.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fr_FR\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-10-03 23:34+0300\n"
+"POT-Creation-Date: 2020-03-18 20:44+0300\n"
 "PO-Revision-Date: 2012-10-28 15:46+0000\n"
 "Last-Translator: Penegal <Unknown>\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -24,6 +24,13 @@ msgstr ""
 #, fuzzy
 msgid "Zoom too small!  Cannot zoom further."
 msgstr "Agrandissement maximum ! Impossible d'agrandir plus.\n"
+
+msgid ""
+"Save your color scheme to a file by clicking on the \"Save As...\"\n"
+"button. It can be loaded on startup with the following\n"
+"expression in the gschemrc configuration file:\n"
+"( primitive-load \"/path/to/saved-color-scheme-file\" )"
+msgstr ""
 
 #, fuzzy, c-format
 msgid ""
@@ -54,6 +61,11 @@ msgstr ""
 msgid "Sa_ve..."
 msgstr ""
 
+msgid ""
+"After you're done choosing the font, it's recommended\n"
+"to reopen schematics or restart the application."
+msgstr ""
+
 #, c-format
 msgid "<b>Current:</b> %s"
 msgstr ""
@@ -61,24 +73,21 @@ msgstr ""
 msgid "Save configuration"
 msgstr ""
 
+msgid "Local configuration file:"
+msgstr ""
+
+msgid "User configuration file:"
+msgstr ""
+
 #, fuzzy
-msgid "Save settings to:"
-msgstr "Configuration"
-
-msgid "Local configuration file (in current directory)"
-msgstr ""
-
-msgid "User configuration file (geda-user.conf)"
-msgstr ""
-
-msgid "Object ~A is not included in the current gschem page."
+msgid "Object ~A is not included in the current lepton-schematic page."
 msgstr "L'objet ~A n'est pas inclus dans la page gschem courante."
 
 msgid "Invalid text name/value visibility ~A."
 msgstr ""
 
 #, fuzzy, c-format
-msgid "You are running gEDA/gaf version [%1$s%2$s.%3$s],\n"
+msgid "You are running lepton-schematic version [%1$s%2$s.%3$s],\n"
 msgstr "gEDA/gschem version %s%s.%s\n"
 
 #, c-format
@@ -91,67 +100,15 @@ msgstr ""
 msgid "Please be sure that you have the latest rc file.\n"
 msgstr ""
 
-#, fuzzy, c-format
-msgid "Invalid size [%1$d] passed to text-size\n"
-msgstr "Taille [%d] passée à text-size invalide\n"
-
-#, fuzzy, c-format
-msgid "Invalid size [%1$d] passed to snap-size\n"
-msgstr "Taille [%d] passée à snap-size invalide\n"
-
-#, fuzzy, c-format
-msgid "Invalid num levels [%1$d] passed to undo-levels\n"
-msgstr "Nombre de niveaux [%d] passé à undo-levels invalide\n"
-
-#, fuzzy, c-format
-msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
-msgstr "Taille [%d] passée à bus-ripper-size invalide\n"
-
-#, fuzzy, c-format
-msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
-msgstr "Taille de point [%d] invalide passé à dots-grid-dot-size\n"
-
-#, fuzzy, c-format
-msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
-msgstr "Espace de pixel [%d] invalide passé à dots-grid-fixed-threshold\n"
-
-#, fuzzy, c-format
-msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
-msgstr ""
-"Espacement [%d] de pixel invalide passé à mesh-grid-display-threshold\n"
-
-#, fuzzy, c-format
-msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
-msgstr "Nombre de secondes [%d] passé  auto-save-interval invalide\n"
-
-#, fuzzy, c-format
-msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
-msgstr "Gain [%d] passé à mousepan-gain invalide\n"
-
-#, fuzzy, c-format
-msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
-msgstr "Gain [%d] passé à keyboardpan-gain invalide\n"
-
-#, fuzzy, c-format
-msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
-msgstr "Nombre [%d] de pixels invalides passés à select-slack-pixels\n"
-
-#, fuzzy, c-format
-msgid "Invalid gain [%1$d] passed to zoom-gain\n"
-msgstr "Gain [%d] invalide passé à zoom-gain\n"
-
-#, fuzzy, c-format
-msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
-msgstr "Nombre d'étapes [%d] scrollpan-steps invalide\n"
-
 msgid "Object ~A is not directly included in a page."
 msgstr "L'objet ~A n'est inclus directement par aucune page."
 
 msgid "Could not launch URI ~S: ~A"
 msgstr "Impossible de lancer l'URI ~S: ~A"
 
-msgid "Found invalid gschem window smob ~S"
-msgstr ""
+#, fuzzy
+msgid "Found invalid lepton-schematic window smob ~S"
+msgstr "~S n'est pas une combinaison de touches valide."
 
 #, fuzzy, c-format
 msgid "Lepton EDA/lepton-schematic version %1$s%2$s.%3$s git: %4$.7s"
@@ -185,7 +142,7 @@ msgstr ""
 #, fuzzy
 msgid ""
 "Copyright © 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright © 2017-2019 Lepton Developers.\n"
+"Copyright © 2017-2020 Lepton Developers.\n"
 "See AUTHORS, ChangeLog files and consult 'git log' history for details."
 msgstr ""
 "Copyright © 1998-2012 Ales Hvezda <ahvezda@geda.seul.org>\n"
@@ -680,7 +637,8 @@ msgid ""
 "\n"
 "Are you sure you want to revert this page?\n"
 "All unsaved changes in current schematic will be\n"
-"discarded and page file will be reloaded from disk."
+"discarded and page file will be reloaded from disk.\n"
+"This action will also reload all component libraries."
 msgstr ""
 
 #, fuzzy
@@ -794,10 +752,6 @@ msgid_plural "Delete %1$u locked objects?"
 msgstr[0] "les objets sélectionnés"
 msgstr[1] "les objets sélectionnés"
 
-#, c-format
-msgid "Got an unexpected NULL in o_edit\n"
-msgstr "o_current==NULL dans o_edit()\n"
-
 #, fuzzy
 msgid "Hidden text is now visible"
 msgstr "Le texte normalement caché est maintenant visible\n"
@@ -813,7 +767,7 @@ msgstr ""
 "à jour.\n"
 
 #, fuzzy, c-format
-msgid "o_autosave_backups: Can't get the real filename of %1$s."
+msgid "Can't get the real filename of %1$s."
 msgstr ""
 "o_autosave_backups() : Impossible de récupérer le véritable nom du fichier %s"
 
@@ -831,10 +785,6 @@ msgstr ""
 #, fuzzy, c-format
 msgid "Could NOT save backup file [%1$s]"
 msgstr "Échec lors de la création de la copie de sauvegarde [%s]\n"
-
-#, c-format
-msgid "ERROR: NULL object in o_move_end!\n"
-msgstr "ERREUR : object==NULL dans o_move_end !\n"
 
 #, c-format
 msgid "DOH! tried to find the whichone, but didn't find it!\n"
@@ -893,7 +843,7 @@ msgid "New slot number out of range"
 msgstr "Nouvelle valeur de slot hors plage\n"
 
 #, fuzzy
-msgid "Undo/Redo disabled in rc file"
+msgid "Undo/Redo is disabled in configuration"
 msgstr "Opérations Défaire/Refaire désactivées dans fichier rc\n"
 
 #, fuzzy, c-format
@@ -914,8 +864,8 @@ msgid ""
 "  -h, --help               Help; this message.\n"
 "  --                       Treat all remaining arguments as filenames.\n"
 "\n"
-"Report bugs at <https://github.com/lepton-eda/lepton-eda/issues>\n"
-"Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>\n"
+"Report bugs at <%2$s>\n"
+"Lepton EDA homepage: <%3$s>\n"
 msgstr ""
 "Usage: %s [OPTION ...] [--] [FICHIER ...]\n"
 "\n"
@@ -941,33 +891,11 @@ msgstr ""
 "En cas de bug, prévenir <https://bugs.launchpad.net/geda>\n"
 "Page d'accueil gEDA/gaf: <http://www.geda-project.org/>\n"
 
-#, fuzzy, c-format
-msgid ""
-"Lepton EDA %1$s (git: %2$.7s)\n"
-"Copyright (C) 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright (C) 2017-2019 Lepton Developers.\n"
-"This is free software, and you are welcome to redistribute it under\n"
-"certain conditions. For details, see the file `COPYING', which is\n"
-"included in the Lepton EDA distribution.\n"
-"There is NO WARRANTY, to the extent permitted by law.\n"
-msgstr ""
-"gEDA %s (g%.7s)\n"
-"Copyright (C) 1998-2012 gEDA developers\n"
-"Ceci est un logiciel libre, et vous êtes invité à le diffuser sous\n"
-"certaines conditions. Pour plus de détails, reportez-vous au fichier "
-"`COPYING',\n"
-"inclus dans la distribution gEDA.\n"
-"Il n'y a AUCUNE GARANTIE autre que celles prévues par la loi.\n"
-
 #, c-format
 msgid "Got invalid show option; defaulting to show both\n"
 msgstr ""
 "Option d'affichage invalide ; changement pour affichage du nom et de la "
 "valeur\n"
-
-#, c-format
-msgid "ERROR: NULL object!\n"
-msgstr "ERREUR : object==NULL !\n"
 
 msgid "Single Attribute Editor"
 msgstr "Éditeur d'attribut"
@@ -1030,7 +958,7 @@ msgstr ""
 "%s, number=%d, slot=%d]\n"
 
 #, fuzzy
-msgid "No searchstring given in autonumber text."
+msgid "No search string given in autonumber text."
 msgstr "Pas de motif de recherche fourni pour l'annotation automatique.\n"
 
 #, fuzzy
@@ -1111,24 +1039,6 @@ msgstr ""
 
 msgid "Clipboard insertion failed"
 msgstr "Échec de l'insertion du contenu copié"
-
-#, fuzzy, c-format
-msgid "Could not allocate the color %1$s!\n"
-msgstr "Impossible d'allouer la couleur %s !\n"
-
-msgid "black"
-msgstr "noir"
-
-msgid "white"
-msgstr "blanc"
-
-#, fuzzy, c-format
-msgid "Could not allocate display color %1$i!\n"
-msgstr "Impossible d'allouer la couleur affichée %i!\n"
-
-#, fuzzy, c-format
-msgid "Could not allocate outline color %1$i!\n"
-msgstr "Impossible d'allouer la couleur de contour %i!\n"
 
 #, fuzzy, c-format
 msgid "Tried to get an invalid color: %1$d\n"
@@ -1276,13 +1186,16 @@ msgstr ""
 msgid "Invalid Attribute"
 msgstr "Attribut invalide"
 
-msgid "Schematics"
+#, fuzzy
+msgid "Schematics (*.sch)"
 msgstr "sch - Schémas"
 
-msgid "Symbols"
+#, fuzzy
+msgid "Symbols (*.sym)"
 msgstr "sym - Symboles"
 
-msgid "Schematics and symbols"
+#, fuzzy
+msgid "Schematics and symbols (*.sch *.sym)"
 msgstr "sym/sch - Schémas et symboles"
 
 msgid "All files"
@@ -1319,7 +1232,7 @@ msgid "Hatch"
 msgstr "Rayures"
 
 #, fuzzy, c-format
-msgid "x_image_lowlevel: Unable to write %1$s file %2$s."
+msgid "Unable to write %1$s file %2$s."
 msgstr "x_image_lowlevel: Impossible d'écrire le %s fichier %s.\n"
 
 #, fuzzy, c-format
@@ -1344,7 +1257,7 @@ msgid "Wrote black and white image to [%1$s] [%2$d x %3$d]"
 msgstr "Image noire et blanche exportée dans fichier [%s] [%d x %d]\n"
 
 #, fuzzy
-msgid "x_image_lowlevel: Unable to get pixbuf from gschem's window."
+msgid "Unable to get pixbuf from lepton-schematic's window."
 msgstr ""
 "x_image_lowlevel(): Impossible de récupérer le pixbuf depuis la fenêtre de "
 "gschem.\n"
@@ -1396,76 +1309,60 @@ msgid "Phantom"
 msgstr "Fantôme"
 
 #, fuzzy
-msgid "Add Net"
-msgstr "/Ajouter une piste"
-
-msgid "Add Attribute"
-msgstr "Ajouter un attribut"
-
-#, fuzzy
-msgid "Add Component"
+msgid "Add Co_mponent..."
 msgstr "/Ajouter un composant..."
 
 #, fuzzy
-msgid "Add Bus"
+msgid "Add Te_xt..."
+msgstr "Ajouter du texte..."
+
+#, fuzzy
+msgid "Add _Attribute..."
+msgstr "/Ajouter un attribut..."
+
+#, fuzzy
+msgid "Add _Net"
+msgstr "/Ajouter une piste"
+
+#, fuzzy
+msgid "Add _Bus"
 msgstr "/Ajouter un bus"
 
-#, fuzzy
-msgid "Add Text"
-msgstr "/Ajouter du texte"
+msgid "Cu_t"
+msgstr "Co_uper"
+
+msgid "_Copy"
+msgstr "_Copier"
+
+msgid "_Paste"
+msgstr "C_oller"
+
+msgid "_Delete"
+msgstr "_Supprimer"
 
 #, fuzzy
-msgid "Zoom In"
-msgstr "/Zoom avant"
-
-#, fuzzy
-msgid "Zoom Out"
-msgstr "/Zoom arrière"
-
-#, fuzzy
-msgid "Zoom Extents"
-msgstr "/Agrandissement auto"
-
-msgid "Select"
-msgstr "Sélectionner"
-
-msgid "Edit..."
+msgid "_Edit..."
 msgstr "Éditer"
 
 #, fuzzy
-msgid "Object Properties..."
-msgstr "<b>Propriétés du texte</b>"
-
-msgid "Copy"
-msgstr "Copier"
-
-msgid "Move"
-msgstr "Déplacer"
-
-msgid "Delete"
-msgstr "Supprimer"
+msgid "Ed_it Text..."
+msgstr "Éditer le texte..."
 
 #, fuzzy
-msgid "Down Schematic"
+msgid "_Object Properties..."
+msgstr "<b>Propriétés du texte</b>"
+
+#, fuzzy
+msgid "Hierarchy: Down _Schematic"
 msgstr "/Descendre dans le schéma"
 
 #, fuzzy
-msgid "Down Symbol"
+msgid "Hierarchy: Down S_ymbol"
 msgstr "/Descendre dans le symbole"
 
 #, fuzzy
-msgid "Up"
-msgstr "/Remonter"
-
-#, fuzzy, c-format
-msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
-msgstr ""
-"Tentative de valider la sensibilité ou un menu inexistant d'un objet '%s'\n"
-
-#, c-format
-msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
-msgstr ""
-"Tentative de valider la sensibilité ou un menu inexistant d'un objet '%s'\n"
+msgid "Hierarchy: _Up"
+msgstr "Hié_rarchie"
 
 msgid "The operating system is out of memory or resources."
 msgstr "Le système d'exploitation n'a plus assez de mémoire ou de ressources."
@@ -1488,6 +1385,9 @@ msgstr "Promouvoir"
 msgid "Duplicate"
 msgstr "Cloner"
 
+msgid "Delete"
+msgstr "Supprimer"
+
 #, fuzzy
 msgid "Copy to all"
 msgstr "Copier dans 1"
@@ -1507,6 +1407,9 @@ msgstr "V"
 #, fuzzy
 msgid "Sho_w inherited attributes"
 msgstr "Montrer les attributs hérités"
+
+msgid "Add Attribute"
+msgstr "Ajouter un attribut"
 
 #, fuzzy
 msgid "_Name:"
@@ -1630,6 +1533,25 @@ msgstr "Hié_rarchie"
 msgid "Hierarchy up"
 msgstr "Hié_rarchie"
 
+msgid "_New"
+msgstr "_Nouveau"
+
+msgid "_Open..."
+msgstr "_Ouvrir..."
+
+msgid "_Save"
+msgstr "_Enregistrer"
+
+msgid "Save _As..."
+msgstr "Enregistrer _sous..."
+
+#, fuzzy
+msgid "Page _Manager..."
+msgstr "Gestionnaire de pages"
+
+msgid "_Close"
+msgstr "_Fermer"
+
 #, fuzzy
 msgid "Options"
 msgstr "_Options"
@@ -1750,6 +1672,9 @@ msgstr ""
 msgid "Add Text..."
 msgstr "Ajouter du texte..."
 
+msgid "Select"
+msgstr "Sélectionner"
+
 msgid "Select mode"
 msgstr "Mode sélection"
 
@@ -1819,20 +1744,8 @@ msgstr "Éditeur de schémas gEDA"
 msgid "Create and edit electrical schematics and symbols with lepton-schematic"
 msgstr "Créer et éditer des schémas électriques et des symboles avec gschem"
 
-msgid "_New"
-msgstr "_Nouveau"
-
-msgid "_Open..."
-msgstr "_Ouvrir..."
-
 msgid "Open Recen_t"
 msgstr "_Récemment ouverts"
-
-msgid "_Save"
-msgstr "_Enregistrer"
-
-msgid "Save _As..."
-msgstr "Enregistrer _sous..."
 
 msgid "Save All"
 msgstr "Enregistrer toutes les pages"
@@ -1866,18 +1779,6 @@ msgstr "A_nnuler"
 msgid "_Redo"
 msgstr "_Rétablir"
 
-msgid "Cu_t"
-msgstr "Co_uper"
-
-msgid "_Copy"
-msgstr "_Copier"
-
-msgid "_Paste"
-msgstr "C_oller"
-
-msgid "_Delete"
-msgstr "_Supprimer"
-
 msgid "Select All"
 msgstr "Sélectionner tout"
 
@@ -1886,6 +1787,13 @@ msgstr "Dé-sélectionner"
 
 msgid "Rotate 90 Mode"
 msgstr "Mode Rotation 90"
+
+#, fuzzy
+msgid "Object Properties..."
+msgstr "<b>Propriétés du texte</b>"
+
+msgid "Edit..."
+msgstr "Éditer"
 
 msgid "Edit Text..."
 msgstr "Éditer le texte..."
@@ -2010,9 +1918,6 @@ msgstr "_Précédent"
 msgid "_Next"
 msgstr "_Suivant"
 
-msgid "_Close"
-msgstr "_Fermer"
-
 #, fuzzy
 msgid "_Revert..."
 msgstr "_Rétablir"
@@ -2124,6 +2029,9 @@ msgid "Grid Style: Cycle Dots/Mesh/Off"
 msgstr ""
 
 msgid "Grid Snap: Cycle Grid/Resnap/Off"
+msgstr ""
+
+msgid "Grips: On/Off"
 msgstr ""
 
 #, fuzzy
@@ -2276,6 +2184,9 @@ msgstr "Afficher/Cacher le texte invisible"
 msgid "Cut"
 msgstr "Co_uper"
 
+msgid "Copy"
+msgstr "Copier"
+
 #, fuzzy
 msgid "Paste"
 msgstr "C_oller"
@@ -2305,6 +2216,18 @@ msgstr ""
 #, fuzzy
 msgid "Pan Down"
 msgstr "Mode Panoramique"
+
+#, fuzzy
+msgid "Zoom Extents"
+msgstr "/Agrandissement auto"
+
+#, fuzzy
+msgid "Zoom In"
+msgstr "/Zoom avant"
+
+#, fuzzy
+msgid "Zoom Out"
+msgstr "/Zoom arrière"
 
 #, fuzzy
 msgid "Zoom Full"
@@ -2342,6 +2265,22 @@ msgid "Print Page"
 msgstr "_Précédent"
 
 #, fuzzy
+msgid "Add Component"
+msgstr "/Ajouter un composant..."
+
+#, fuzzy
+msgid "Add Net"
+msgstr "/Ajouter une piste"
+
+#, fuzzy
+msgid "Add Bus"
+msgstr "/Ajouter un bus"
+
+#, fuzzy
+msgid "Add Text"
+msgstr "/Ajouter du texte"
+
+#, fuzzy
 msgid "Add Line"
 msgstr "Ligne"
 
@@ -2367,6 +2306,14 @@ msgstr ""
 #, fuzzy
 msgid "Add Picture"
 msgstr "Image"
+
+#, fuzzy
+msgid "Down Schematic"
+msgstr "/Descendre dans le schéma"
+
+#, fuzzy
+msgid "Down Symbol"
+msgstr "/Descendre dans le symbole"
 
 #, fuzzy
 msgid "Up Hierarchy"
@@ -2459,6 +2406,10 @@ msgid "Show Coordinate Window"
 msgstr "Afficher les _coordonnées"
 
 #, fuzzy
+msgid "Toggle Grips"
+msgstr "_Inverser la visibilité"
+
+#, fuzzy
 msgid "Component Documentation"
 msgstr "Documentation du composant"
 
@@ -2496,10 +2447,6 @@ msgstr ""
 msgid "About lepton-schematic"
 msgstr "À propos de gschem"
 
-#, scheme-format
-msgid "Invalid text alignment ~A."
-msgstr "Alignement du paragraphe invalide ~A."
-
 #, fuzzy
 msgid "Could not show documentation:"
 msgstr "Documentation du composant"
@@ -2514,6 +2461,131 @@ msgstr "~S n'est pas une combinaison de touches valide."
 #, scheme-format
 msgid "~S is not a prefix key sequence."
 msgstr "~S n'est pas un préfixe valide."
+
+#, scheme-format
+msgid "Invalid text alignment ~A."
+msgstr "Alignement du paragraphe invalide ~A."
+
+#, fuzzy
+#~ msgid "Save settings to:"
+#~ msgstr "Configuration"
+
+#, fuzzy
+#~ msgid "Invalid size [%1$d] passed to text-size\n"
+#~ msgstr "Taille [%d] passée à text-size invalide\n"
+
+#, fuzzy
+#~ msgid "Invalid size [%1$d] passed to snap-size\n"
+#~ msgstr "Taille [%d] passée à snap-size invalide\n"
+
+#, fuzzy
+#~ msgid "Invalid num levels [%1$d] passed to undo-levels\n"
+#~ msgstr "Nombre de niveaux [%d] passé à undo-levels invalide\n"
+
+#, fuzzy
+#~ msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
+#~ msgstr "Taille [%d] passée à bus-ripper-size invalide\n"
+
+#, fuzzy
+#~ msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
+#~ msgstr "Taille de point [%d] invalide passé à dots-grid-dot-size\n"
+
+#, fuzzy
+#~ msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
+#~ msgstr "Espace de pixel [%d] invalide passé à dots-grid-fixed-threshold\n"
+
+#, fuzzy
+#~ msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
+#~ msgstr ""
+#~ "Espacement [%d] de pixel invalide passé à mesh-grid-display-threshold\n"
+
+#, fuzzy
+#~ msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
+#~ msgstr "Nombre de secondes [%d] passé  auto-save-interval invalide\n"
+
+#, fuzzy
+#~ msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
+#~ msgstr "Gain [%d] passé à mousepan-gain invalide\n"
+
+#, fuzzy
+#~ msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
+#~ msgstr "Gain [%d] passé à keyboardpan-gain invalide\n"
+
+#, fuzzy
+#~ msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
+#~ msgstr "Nombre [%d] de pixels invalides passés à select-slack-pixels\n"
+
+#, fuzzy
+#~ msgid "Invalid gain [%1$d] passed to zoom-gain\n"
+#~ msgstr "Gain [%d] invalide passé à zoom-gain\n"
+
+#, fuzzy
+#~ msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
+#~ msgstr "Nombre d'étapes [%d] scrollpan-steps invalide\n"
+
+#~ msgid "Got an unexpected NULL in o_edit\n"
+#~ msgstr "o_current==NULL dans o_edit()\n"
+
+#~ msgid "ERROR: NULL object in o_move_end!\n"
+#~ msgstr "ERREUR : object==NULL dans o_move_end !\n"
+
+#, fuzzy
+#~ msgid ""
+#~ "Lepton EDA %1$s (git: %2$.7s)\n"
+#~ "Copyright (C) 1998-2017 by Ales Hvezda and the respective original "
+#~ "authors.\n"
+#~ "Copyright (C) 2017-2019 Lepton Developers.\n"
+#~ "This is free software, and you are welcome to redistribute it under\n"
+#~ "certain conditions. For details, see the file `COPYING', which is\n"
+#~ "included in the Lepton EDA distribution.\n"
+#~ "There is NO WARRANTY, to the extent permitted by law.\n"
+#~ msgstr ""
+#~ "gEDA %s (g%.7s)\n"
+#~ "Copyright (C) 1998-2012 gEDA developers\n"
+#~ "Ceci est un logiciel libre, et vous êtes invité à le diffuser sous\n"
+#~ "certaines conditions. Pour plus de détails, reportez-vous au fichier "
+#~ "`COPYING',\n"
+#~ "inclus dans la distribution gEDA.\n"
+#~ "Il n'y a AUCUNE GARANTIE autre que celles prévues par la loi.\n"
+
+#~ msgid "ERROR: NULL object!\n"
+#~ msgstr "ERREUR : object==NULL !\n"
+
+#, fuzzy
+#~ msgid "Could not allocate the color %1$s!\n"
+#~ msgstr "Impossible d'allouer la couleur %s !\n"
+
+#~ msgid "black"
+#~ msgstr "noir"
+
+#~ msgid "white"
+#~ msgstr "blanc"
+
+#, fuzzy
+#~ msgid "Could not allocate display color %1$i!\n"
+#~ msgstr "Impossible d'allouer la couleur affichée %i!\n"
+
+#, fuzzy
+#~ msgid "Could not allocate outline color %1$i!\n"
+#~ msgstr "Impossible d'allouer la couleur de contour %i!\n"
+
+#~ msgid "Move"
+#~ msgstr "Déplacer"
+
+#, fuzzy
+#~ msgid "Up"
+#~ msgstr "/Remonter"
+
+#, fuzzy
+#~ msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
+#~ msgstr ""
+#~ "Tentative de valider la sensibilité ou un menu inexistant d'un objet "
+#~ "'%s'\n"
+
+#~ msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
+#~ msgstr ""
+#~ "Tentative de valider la sensibilité ou un menu inexistant d'un objet "
+#~ "'%s'\n"
 
 #, fuzzy
 #~ msgid "Invalid offset [%1$d] passed to add-attribute-offset\n"
@@ -2814,9 +2886,6 @@ msgstr "~S n'est pas un préfixe valide."
 
 #~ msgid "Function"
 #~ msgstr "Fonction"
-
-#~ msgid "/Add Attribute..."
-#~ msgstr "/Ajouter un attribut..."
 
 #~ msgid "/Zoom Box"
 #~ msgstr "/Zoom boîte"

--- a/schematic/po/he.po
+++ b/schematic/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-10-03 23:34+0300\n"
+"POT-Creation-Date: 2020-03-18 20:44+0300\n"
 "PO-Revision-Date: 2012-01-27 14:23+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -19,6 +19,13 @@ msgstr ""
 "X-Generator: Launchpad (build 16265)\n"
 
 msgid "Zoom too small!  Cannot zoom further."
+msgstr ""
+
+msgid ""
+"Save your color scheme to a file by clicking on the \"Save As...\"\n"
+"button. It can be loaded on startup with the following\n"
+"expression in the gschemrc configuration file:\n"
+"( primitive-load \"/path/to/saved-color-scheme-file\" )"
 msgstr ""
 
 #, c-format
@@ -46,6 +53,11 @@ msgstr ""
 msgid "Sa_ve..."
 msgstr ""
 
+msgid ""
+"After you're done choosing the font, it's recommended\n"
+"to reopen schematics or restart the application."
+msgstr ""
+
 #, c-format
 msgid "<b>Current:</b> %s"
 msgstr ""
@@ -53,23 +65,20 @@ msgstr ""
 msgid "Save configuration"
 msgstr ""
 
-msgid "Save settings to:"
+msgid "Local configuration file:"
 msgstr ""
 
-msgid "Local configuration file (in current directory)"
+msgid "User configuration file:"
 msgstr ""
 
-msgid "User configuration file (geda-user.conf)"
-msgstr ""
-
-msgid "Object ~A is not included in the current gschem page."
+msgid "Object ~A is not included in the current lepton-schematic page."
 msgstr ""
 
 msgid "Invalid text name/value visibility ~A."
 msgstr ""
 
 #, c-format
-msgid "You are running gEDA/gaf version [%1$s%2$s.%3$s],\n"
+msgid "You are running lepton-schematic version [%1$s%2$s.%3$s],\n"
 msgstr ""
 
 #, c-format
@@ -82,65 +91,13 @@ msgstr ""
 msgid "Please be sure that you have the latest rc file.\n"
 msgstr ""
 
-#, c-format
-msgid "Invalid size [%1$d] passed to text-size\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid size [%1$d] passed to snap-size\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid num levels [%1$d] passed to undo-levels\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid gain [%1$d] passed to zoom-gain\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
-msgstr ""
-
 msgid "Object ~A is not directly included in a page."
 msgstr ""
 
 msgid "Could not launch URI ~S: ~A"
 msgstr ""
 
-msgid "Found invalid gschem window smob ~S"
+msgid "Found invalid lepton-schematic window smob ~S"
 msgstr ""
 
 #, c-format
@@ -171,7 +128,7 @@ msgstr ""
 
 msgid ""
 "Copyright © 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright © 2017-2019 Lepton Developers.\n"
+"Copyright © 2017-2020 Lepton Developers.\n"
 "See AUTHORS, ChangeLog files and consult 'git log' history for details."
 msgstr ""
 
@@ -611,7 +568,8 @@ msgid ""
 "\n"
 "Are you sure you want to revert this page?\n"
 "All unsaved changes in current schematic will be\n"
-"discarded and page file will be reloaded from disk."
+"discarded and page file will be reloaded from disk.\n"
+"This action will also reload all component libraries."
 msgstr ""
 
 msgid "Revert"
@@ -704,10 +662,6 @@ msgid_plural "Delete %1$u locked objects?"
 msgstr[0] ""
 msgstr[1] ""
 
-#, c-format
-msgid "Got an unexpected NULL in o_edit\n"
-msgstr ""
-
 msgid "Hidden text is now visible"
 msgstr ""
 
@@ -719,7 +673,7 @@ msgid "Could not find symbol [%1$s] in library. Update failed."
 msgstr ""
 
 #, c-format
-msgid "o_autosave_backups: Can't get the real filename of %1$s."
+msgid "Can't get the real filename of %1$s."
 msgstr ""
 
 #, c-format
@@ -732,10 +686,6 @@ msgstr ""
 
 #, c-format
 msgid "Could NOT save backup file [%1$s]"
-msgstr ""
-
-#, c-format
-msgid "ERROR: NULL object in o_move_end!\n"
 msgstr ""
 
 #, c-format
@@ -784,7 +734,7 @@ msgstr ""
 msgid "New slot number out of range"
 msgstr ""
 
-msgid "Undo/Redo disabled in rc file"
+msgid "Undo/Redo is disabled in configuration"
 msgstr ""
 
 #, c-format
@@ -805,27 +755,12 @@ msgid ""
 "  -h, --help               Help; this message.\n"
 "  --                       Treat all remaining arguments as filenames.\n"
 "\n"
-"Report bugs at <https://github.com/lepton-eda/lepton-eda/issues>\n"
-"Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"Lepton EDA %1$s (git: %2$.7s)\n"
-"Copyright (C) 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright (C) 2017-2019 Lepton Developers.\n"
-"This is free software, and you are welcome to redistribute it under\n"
-"certain conditions. For details, see the file `COPYING', which is\n"
-"included in the Lepton EDA distribution.\n"
-"There is NO WARRANTY, to the extent permitted by law.\n"
+"Report bugs at <%2$s>\n"
+"Lepton EDA homepage: <%3$s>\n"
 msgstr ""
 
 #, c-format
 msgid "Got invalid show option; defaulting to show both\n"
-msgstr ""
-
-#, c-format
-msgid "ERROR: NULL object!\n"
 msgstr ""
 
 msgid "Single Attribute Editor"
@@ -880,7 +815,7 @@ msgid ""
 "duplicate slot may cause problems: [symbolname=%1$s, number=%2$d, slot=%3$d]"
 msgstr ""
 
-msgid "No searchstring given in autonumber text."
+msgid "No search string given in autonumber text."
 msgstr ""
 
 msgid "No '*' or '?' given at the end of the autonumber text."
@@ -954,24 +889,6 @@ msgid ""
 msgstr ""
 
 msgid "Clipboard insertion failed"
-msgstr ""
-
-#, c-format
-msgid "Could not allocate the color %1$s!\n"
-msgstr ""
-
-msgid "black"
-msgstr ""
-
-msgid "white"
-msgstr ""
-
-#, c-format
-msgid "Could not allocate display color %1$i!\n"
-msgstr ""
-
-#, c-format
-msgid "Could not allocate outline color %1$i!\n"
 msgstr ""
 
 #, c-format
@@ -1111,13 +1028,13 @@ msgstr ""
 msgid "Invalid Attribute"
 msgstr ""
 
-msgid "Schematics"
+msgid "Schematics (*.sch)"
 msgstr ""
 
-msgid "Symbols"
+msgid "Symbols (*.sym)"
 msgstr ""
 
-msgid "Schematics and symbols"
+msgid "Schematics and symbols (*.sch *.sym)"
 msgstr ""
 
 msgid "All files"
@@ -1153,7 +1070,7 @@ msgid "Hatch"
 msgstr ""
 
 #, c-format
-msgid "x_image_lowlevel: Unable to write %1$s file %2$s."
+msgid "Unable to write %1$s file %2$s."
 msgstr ""
 
 #, c-format
@@ -1172,7 +1089,7 @@ msgstr ""
 msgid "Wrote black and white image to [%1$s] [%2$d x %3$d]"
 msgstr ""
 
-msgid "x_image_lowlevel: Unable to get pixbuf from gschem's window."
+msgid "Unable to get pixbuf from lepton-schematic's window."
 msgstr ""
 
 msgid "NOTE: print-color-map will be used for PDF export"
@@ -1221,69 +1138,57 @@ msgstr ""
 msgid "Phantom"
 msgstr ""
 
-msgid "Add Net"
-msgstr ""
-
-msgid "Add Attribute"
-msgstr ""
-
 #, fuzzy
-msgid "Add Component"
+msgid "Add Co_mponent..."
 msgstr "עדכן רכיב"
 
-msgid "Add Bus"
-msgstr ""
-
 #, fuzzy
-msgid "Add Text"
+msgid "Add Te_xt..."
 msgstr "ערוך טקסט"
 
 #, fuzzy
-msgid "Zoom In"
-msgstr "תיבת תקריב"
+msgid "Add _Attribute..."
+msgstr "מאפיינים"
 
 #, fuzzy
-msgid "Zoom Out"
-msgstr "תיבת תקריב"
+msgid "Add _Net"
+msgstr "ערוך טקסט"
 
-#, fuzzy
-msgid "Zoom Extents"
-msgstr "תיבת תקריב"
-
-msgid "Select"
+msgid "Add _Bus"
 msgstr ""
 
-msgid "Edit..."
+msgid "Cu_t"
+msgstr ""
+
+msgid "_Copy"
+msgstr ""
+
+msgid "_Paste"
+msgstr ""
+
+msgid "_Delete"
+msgstr ""
+
+#, fuzzy
+msgid "_Edit..."
 msgstr "ערוך..."
 
-msgid "Object Properties..."
+#, fuzzy
+msgid "Ed_it Text..."
+msgstr "ערוך טקסט"
+
+msgid "_Object Properties..."
 msgstr ""
 
-msgid "Copy"
+msgid "Hierarchy: Down _Schematic"
 msgstr ""
 
-msgid "Move"
+msgid "Hierarchy: Down S_ymbol"
 msgstr ""
 
-msgid "Delete"
-msgstr "מחק"
-
-msgid "Down Schematic"
-msgstr ""
-
-msgid "Down Symbol"
-msgstr ""
-
-msgid "Up"
-msgstr ""
-
-#, c-format
-msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
-msgstr ""
-
-#, c-format
-msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
-msgstr ""
+#, fuzzy
+msgid "Hierarchy: _Up"
+msgstr "היררכיה"
 
 msgid "The operating system is out of memory or resources."
 msgstr ""
@@ -1306,6 +1211,9 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
+msgid "Delete"
+msgstr "מחק"
+
 #, fuzzy
 msgid "Copy to all"
 msgstr "העתק אל 1"
@@ -1325,6 +1233,9 @@ msgstr ""
 #, fuzzy
 msgid "Sho_w inherited attributes"
 msgstr "מאפיינים"
+
+msgid "Add Attribute"
+msgstr ""
 
 msgid "_Name:"
 msgstr ""
@@ -1435,6 +1346,24 @@ msgstr "היררכיה"
 msgid "Hierarchy up"
 msgstr "היררכיה"
 
+msgid "_New"
+msgstr ""
+
+msgid "_Open..."
+msgstr ""
+
+msgid "_Save"
+msgstr ""
+
+msgid "Save _As..."
+msgstr ""
+
+msgid "Page _Manager..."
+msgstr ""
+
+msgid "_Close"
+msgstr ""
+
 #, fuzzy
 msgid "Options"
 msgstr "הגדרות"
@@ -1544,6 +1473,9 @@ msgstr ""
 msgid "Add Text..."
 msgstr ""
 
+msgid "Select"
+msgstr ""
+
 msgid "Select mode"
 msgstr ""
 
@@ -1604,19 +1536,7 @@ msgstr ""
 msgid "Create and edit electrical schematics and symbols with lepton-schematic"
 msgstr ""
 
-msgid "_New"
-msgstr ""
-
-msgid "_Open..."
-msgstr ""
-
 msgid "Open Recen_t"
-msgstr ""
-
-msgid "_Save"
-msgstr ""
-
-msgid "Save _As..."
 msgstr ""
 
 msgid "Save All"
@@ -1650,18 +1570,6 @@ msgstr ""
 msgid "_Redo"
 msgstr ""
 
-msgid "Cu_t"
-msgstr ""
-
-msgid "_Copy"
-msgstr ""
-
-msgid "_Paste"
-msgstr ""
-
-msgid "_Delete"
-msgstr ""
-
 msgid "Select All"
 msgstr ""
 
@@ -1670,6 +1578,12 @@ msgstr ""
 
 msgid "Rotate 90 Mode"
 msgstr "מצב סיבוב 90"
+
+msgid "Object Properties..."
+msgstr ""
+
+msgid "Edit..."
+msgstr "ערוך..."
 
 msgid "Edit Text..."
 msgstr "ערוך טקסט"
@@ -1789,9 +1703,6 @@ msgstr ""
 msgid "_Next"
 msgstr ""
 
-msgid "_Close"
-msgstr ""
-
 msgid "_Revert..."
 msgstr ""
 
@@ -1900,6 +1811,9 @@ msgid "Grid Style: Cycle Dots/Mesh/Off"
 msgstr ""
 
 msgid "Grid Snap: Cycle Grid/Resnap/Off"
+msgstr ""
+
+msgid "Grips: On/Off"
 msgstr ""
 
 msgid "Feedback Mode: Outline/Box"
@@ -2040,6 +1954,9 @@ msgstr "הראה/הסתר טקסט חבוי"
 msgid "Cut"
 msgstr "גזור אל 1"
 
+msgid "Copy"
+msgstr ""
+
 #, fuzzy
 msgid "Paste"
 msgstr "הדבק מ-1"
@@ -2065,6 +1982,18 @@ msgstr ""
 
 msgid "Pan Down"
 msgstr ""
+
+#, fuzzy
+msgid "Zoom Extents"
+msgstr "תיבת תקריב"
+
+#, fuzzy
+msgid "Zoom In"
+msgstr "תיבת תקריב"
+
+#, fuzzy
+msgid "Zoom Out"
+msgstr "תיבת תקריב"
 
 msgid "Zoom Full"
 msgstr ""
@@ -2097,6 +2026,20 @@ msgid "Print Page"
 msgstr "סגור דף"
 
 #, fuzzy
+msgid "Add Component"
+msgstr "עדכן רכיב"
+
+msgid "Add Net"
+msgstr ""
+
+msgid "Add Bus"
+msgstr ""
+
+#, fuzzy
+msgid "Add Text"
+msgstr "ערוך טקסט"
+
+#, fuzzy
 msgid "Add Line"
 msgstr "קו"
 
@@ -2117,6 +2060,12 @@ msgid "Add Pin"
 msgstr ""
 
 msgid "Add Picture"
+msgstr ""
+
+msgid "Down Schematic"
+msgstr ""
+
+msgid "Down Symbol"
 msgstr ""
 
 #, fuzzy
@@ -2196,6 +2145,9 @@ msgstr "חלון חדש"
 msgid "Show Coordinate Window"
 msgstr ""
 
+msgid "Toggle Grips"
+msgstr ""
+
 msgid "Component Documentation"
 msgstr ""
 
@@ -2230,10 +2182,6 @@ msgstr ""
 msgid "About lepton-schematic"
 msgstr ""
 
-#, scheme-format
-msgid "Invalid text alignment ~A."
-msgstr ""
-
 msgid "Could not show documentation:"
 msgstr ""
 
@@ -2246,6 +2194,10 @@ msgstr ""
 
 #, scheme-format
 msgid "~S is not a prefix key sequence."
+msgstr ""
+
+#, scheme-format
+msgid "Invalid text alignment ~A."
 msgstr ""
 
 #~ msgid "Edit"

--- a/schematic/po/hu.po
+++ b/schematic/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-10-03 23:34+0300\n"
+"POT-Creation-Date: 2020-03-18 20:44+0300\n"
 "PO-Revision-Date: 2012-01-27 14:23+0000\n"
 "Last-Translator: kop <Unknown>\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -21,6 +21,13 @@ msgstr ""
 #, fuzzy
 msgid "Zoom too small!  Cannot zoom further."
 msgstr "Túl nagy nagyítás! Nem tudok tovább nagyítani.\n"
+
+msgid ""
+"Save your color scheme to a file by clicking on the \"Save As...\"\n"
+"button. It can be loaded on startup with the following\n"
+"expression in the gschemrc configuration file:\n"
+"( primitive-load \"/path/to/saved-color-scheme-file\" )"
+msgstr ""
 
 #, fuzzy, c-format
 msgid ""
@@ -50,6 +57,11 @@ msgstr ""
 msgid "Sa_ve..."
 msgstr ""
 
+msgid ""
+"After you're done choosing the font, it's recommended\n"
+"to reopen schematics or restart the application."
+msgstr ""
+
 #, c-format
 msgid "<b>Current:</b> %s"
 msgstr ""
@@ -57,24 +69,21 @@ msgstr ""
 msgid "Save configuration"
 msgstr ""
 
+msgid "Local configuration file:"
+msgstr ""
+
+msgid "User configuration file:"
+msgstr ""
+
 #, fuzzy
-msgid "Save settings to:"
-msgstr "Beállitások"
-
-msgid "Local configuration file (in current directory)"
-msgstr ""
-
-msgid "User configuration file (geda-user.conf)"
-msgstr ""
-
-msgid "Object ~A is not included in the current gschem page."
+msgid "Object ~A is not included in the current lepton-schematic page."
 msgstr "A ~A objektum nem tálható a jelen gschem lapon."
 
 msgid "Invalid text name/value visibility ~A."
 msgstr "Érvénytelen szöveg név/érték megjelenés ~A."
 
 #, fuzzy, c-format
-msgid "You are running gEDA/gaf version [%1$s%2$s.%3$s],\n"
+msgid "You are running lepton-schematic version [%1$s%2$s.%3$s],\n"
 msgstr "gEDA/gschem verzió %s%s.%s\n"
 
 #, c-format
@@ -87,65 +96,13 @@ msgstr ""
 msgid "Please be sure that you have the latest rc file.\n"
 msgstr ""
 
-#, fuzzy, c-format
-msgid "Invalid size [%1$d] passed to text-size\n"
-msgstr "Érvénytelen méret [%d] szöveg méretként\n"
-
-#, fuzzy, c-format
-msgid "Invalid size [%1$d] passed to snap-size\n"
-msgstr "Érvénytelen méret [%d] snap méretként\n"
-
-#, fuzzy, c-format
-msgid "Invalid num levels [%1$d] passed to undo-levels\n"
-msgstr "Érvénytelen méret [%d] snap méretként\n"
-
-#, fuzzy, c-format
-msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
-msgstr "Érvénytelen méret [%d] snap méretként\n"
-
-#, fuzzy, c-format
-msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
-msgstr "Érvénytelen méret [%d] szöveg méretként\n"
-
-#, fuzzy, c-format
-msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
-msgstr "Érvénytelen méret [%d] szöveg méretként\n"
-
-#, c-format
-msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
-msgstr ""
-
-#, fuzzy, c-format
-msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
-msgstr "Érvénytelen méret [%d] szöveg méretként\n"
-
-#, fuzzy, c-format
-msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
-msgstr "Érvénytelen méret [%d] snap méretként\n"
-
-#, fuzzy, c-format
-msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
-msgstr "Érvénytelen méret [%d] snap méretként\n"
-
-#, fuzzy, c-format
-msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
-msgstr "Érvénytelen méret [%d] szöveg méretként\n"
-
-#, fuzzy, c-format
-msgid "Invalid gain [%1$d] passed to zoom-gain\n"
-msgstr "Érvénytelen méret [%d] szöveg méretként\n"
-
-#, c-format
-msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
-msgstr ""
-
 msgid "Object ~A is not directly included in a page."
 msgstr ""
 
 msgid "Could not launch URI ~S: ~A"
 msgstr ""
 
-msgid "Found invalid gschem window smob ~S"
+msgid "Found invalid lepton-schematic window smob ~S"
 msgstr ""
 
 #, fuzzy, c-format
@@ -176,7 +133,7 @@ msgstr ""
 
 msgid ""
 "Copyright © 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright © 2017-2019 Lepton Developers.\n"
+"Copyright © 2017-2020 Lepton Developers.\n"
 "See AUTHORS, ChangeLog files and consult 'git log' history for details."
 msgstr ""
 
@@ -653,7 +610,8 @@ msgid ""
 "\n"
 "Are you sure you want to revert this page?\n"
 "All unsaved changes in current schematic will be\n"
-"discarded and page file will be reloaded from disk."
+"discarded and page file will be reloaded from disk.\n"
+"This action will also reload all component libraries."
 msgstr ""
 
 #, fuzzy
@@ -752,10 +710,6 @@ msgid_plural "Delete %1$u locked objects?"
 msgstr[0] "Kiválasztott objektumok"
 msgstr[1] "Kiválasztott objektumok"
 
-#, c-format
-msgid "Got an unexpected NULL in o_edit\n"
-msgstr ""
-
 msgid "Hidden text is now visible"
 msgstr ""
 
@@ -767,7 +721,7 @@ msgid "Could not find symbol [%1$s] in library. Update failed."
 msgstr "Nem találom a(z) [%s] szimbólumot. A frissítés nem sikerült.\n"
 
 #, c-format
-msgid "o_autosave_backups: Can't get the real filename of %1$s."
+msgid "Can't get the real filename of %1$s."
 msgstr ""
 
 #, c-format
@@ -781,10 +735,6 @@ msgstr "A [%s] rajz mentése nem sikerült.\n"
 #, fuzzy, c-format
 msgid "Could NOT save backup file [%1$s]"
 msgstr "A [%s] rajz mentése nem sikerült.\n"
-
-#, c-format
-msgid "ERROR: NULL object in o_move_end!\n"
-msgstr ""
 
 #, c-format
 msgid "DOH! tried to find the whichone, but didn't find it!\n"
@@ -835,7 +785,7 @@ msgid "New slot number out of range"
 msgstr ""
 
 #, fuzzy
-msgid "Undo/Redo disabled in rc file"
+msgid "Undo/Redo is disabled in configuration"
 msgstr "A visszavonás/újra művelet nem használható rc fájlban.\n"
 
 #, c-format
@@ -856,27 +806,12 @@ msgid ""
 "  -h, --help               Help; this message.\n"
 "  --                       Treat all remaining arguments as filenames.\n"
 "\n"
-"Report bugs at <https://github.com/lepton-eda/lepton-eda/issues>\n"
-"Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"Lepton EDA %1$s (git: %2$.7s)\n"
-"Copyright (C) 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright (C) 2017-2019 Lepton Developers.\n"
-"This is free software, and you are welcome to redistribute it under\n"
-"certain conditions. For details, see the file `COPYING', which is\n"
-"included in the Lepton EDA distribution.\n"
-"There is NO WARRANTY, to the extent permitted by law.\n"
+"Report bugs at <%2$s>\n"
+"Lepton EDA homepage: <%3$s>\n"
 msgstr ""
 
 #, c-format
 msgid "Got invalid show option; defaulting to show both\n"
-msgstr ""
-
-#, c-format
-msgid "ERROR: NULL object!\n"
 msgstr ""
 
 msgid "Single Attribute Editor"
@@ -935,7 +870,7 @@ msgid ""
 msgstr ""
 
 #, fuzzy
-msgid "No searchstring given in autonumber text."
+msgid "No search string given in autonumber text."
 msgstr "Nincs keresőszöveg megadva az újraszámozáshoz.\n"
 
 #, fuzzy
@@ -1011,24 +946,6 @@ msgstr ""
 
 msgid "Clipboard insertion failed"
 msgstr ""
-
-#, fuzzy, c-format
-msgid "Could not allocate the color %1$s!\n"
-msgstr "Nem találom a(z) %s színt!\n"
-
-msgid "black"
-msgstr "fekete"
-
-msgid "white"
-msgstr "fehér"
-
-#, fuzzy, c-format
-msgid "Could not allocate display color %1$i!\n"
-msgstr "Nem találom a(z) %s színt!\n"
-
-#, fuzzy, c-format
-msgid "Could not allocate outline color %1$i!\n"
-msgstr "Nem találom a(z) %s színt!\n"
 
 #, c-format
 msgid "Tried to get an invalid color: %1$d\n"
@@ -1172,13 +1089,16 @@ msgstr ""
 msgid "Invalid Attribute"
 msgstr "Hibás attribútum"
 
-msgid "Schematics"
+#, fuzzy
+msgid "Schematics (*.sch)"
 msgstr "rajzok"
 
-msgid "Symbols"
+#, fuzzy
+msgid "Symbols (*.sym)"
 msgstr "szimbólumok"
 
-msgid "Schematics and symbols"
+#, fuzzy
+msgid "Schematics and symbols (*.sch *.sym)"
 msgstr "rajzok és szimbólumok"
 
 msgid "All files"
@@ -1214,9 +1134,9 @@ msgstr "Háló"
 msgid "Hatch"
 msgstr "Sraffozott"
 
-#, c-format
-msgid "x_image_lowlevel: Unable to write %1$s file %2$s."
-msgstr ""
+#, fuzzy, c-format
+msgid "Unable to write %1$s file %2$s."
+msgstr "[%s] init scm fájl olvasása sikertelen.\n"
 
 #, fuzzy, c-format
 msgid ""
@@ -1239,7 +1159,7 @@ msgstr "Színes kép kiírva: [%s] [%d x %d]\n"
 msgid "Wrote black and white image to [%1$s] [%2$d x %3$d]"
 msgstr "Fekete-fehér kép kiírva: [%s] [%d x %d]\n"
 
-msgid "x_image_lowlevel: Unable to get pixbuf from gschem's window."
+msgid "Unable to get pixbuf from lepton-schematic's window."
 msgstr ""
 
 msgid "NOTE: print-color-map will be used for PDF export"
@@ -1289,74 +1209,60 @@ msgid "Phantom"
 msgstr ""
 
 #, fuzzy
-msgid "Add Net"
-msgstr "/Összeköttetés hozzáadása"
-
-msgid "Add Attribute"
-msgstr "Attribútum hozzáadása"
-
-#, fuzzy
-msgid "Add Component"
+msgid "Add Co_mponent..."
 msgstr "/Alkatrész hozzáadása"
 
 #, fuzzy
-msgid "Add Bus"
+msgid "Add Te_xt..."
+msgstr "Szöveg hozzáadása"
+
+#, fuzzy
+msgid "Add _Attribute..."
+msgstr "/Attribútum hozzáadása"
+
+#, fuzzy
+msgid "Add _Net"
+msgstr "/Összeköttetés hozzáadása"
+
+#, fuzzy
+msgid "Add _Bus"
 msgstr "/Busz hozzáadása"
 
-#, fuzzy
-msgid "Add Text"
-msgstr "/Szöveg hozzáadása"
+msgid "Cu_t"
+msgstr "Kivágás"
+
+msgid "_Copy"
+msgstr "Másolás (_C)"
+
+msgid "_Paste"
+msgstr "Beillesztés (_P)"
+
+msgid "_Delete"
+msgstr "Törlés (_D)"
 
 #, fuzzy
-msgid "Zoom In"
-msgstr "/Nagyítás"
-
-#, fuzzy
-msgid "Zoom Out"
-msgstr "/Kicsinyítés"
-
-#, fuzzy
-msgid "Zoom Extents"
-msgstr "/Teljes rajz"
-
-msgid "Select"
-msgstr "Kiválasztás"
-
-msgid "Edit..."
+msgid "_Edit..."
 msgstr "Szerkesztés..."
 
 #, fuzzy
-msgid "Object Properties..."
-msgstr "<b>Szöveg tulajdonságai</b>"
-
-msgid "Copy"
-msgstr "Másolás"
-
-msgid "Move"
-msgstr "Mozgatás"
-
-msgid "Delete"
-msgstr "Törlés"
+msgid "Ed_it Text..."
+msgstr "Szöveg szerkesztése..."
 
 #, fuzzy
-msgid "Down Schematic"
+msgid "_Object Properties..."
+msgstr "<b>Szöveg tulajdonságai</b>"
+
+#, fuzzy
+msgid "Hierarchy: Down _Schematic"
 msgstr "Rajz szerkesztése"
 
 #, fuzzy
-msgid "Down Symbol"
+msgid "Hierarchy: Down S_ymbol"
 msgstr "/Szimbólum szerkesztése"
 
 #, fuzzy
-msgid "Up"
-msgstr "/Fel"
-
-#, c-format
-msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
-msgstr ""
-
-#, c-format
-msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
-msgstr ""
+msgid "Hierarchy: _Up"
+msgstr "Hie_rarchia"
 
 msgid "The operating system is out of memory or resources."
 msgstr ""
@@ -1381,6 +1287,9 @@ msgstr ""
 msgid "Duplicate"
 msgstr "Megkettőzés"
 
+msgid "Delete"
+msgstr "Törlés"
+
 #, fuzzy
 msgid "Copy to all"
 msgstr "Másolás 1-be"
@@ -1400,6 +1309,9 @@ msgstr "É"
 #, fuzzy
 msgid "Sho_w inherited attributes"
 msgstr "Attribútumok szerkesztése"
+
+msgid "Add Attribute"
+msgstr "Attribútum hozzáadása"
 
 #, fuzzy
 msgid "_Name:"
@@ -1511,6 +1423,25 @@ msgstr "Hie_rarchia"
 #, fuzzy
 msgid "Hierarchy up"
 msgstr "Hie_rarchia"
+
+msgid "_New"
+msgstr "_Új"
+
+msgid "_Open..."
+msgstr "_Megnyitás..."
+
+msgid "_Save"
+msgstr "Menté_s"
+
+msgid "Save _As..."
+msgstr "Mentés másként"
+
+#, fuzzy
+msgid "Page _Manager..."
+msgstr "Oldalkiválasztó"
+
+msgid "_Close"
+msgstr "_Bezárás"
 
 #, fuzzy
 msgid "Options"
@@ -1627,6 +1558,9 @@ msgstr "Busz hozzáadása mód"
 msgid "Add Text..."
 msgstr "Szöveg hozzáadása"
 
+msgid "Select"
+msgstr "Kiválasztás"
+
 msgid "Select mode"
 msgstr "Kiválasztás mód"
 
@@ -1694,20 +1628,8 @@ msgstr ""
 "Elektromos kapcsolási rajzok és szimbólumok készítése és szerkesztése a "
 "gschemmel"
 
-msgid "_New"
-msgstr "_Új"
-
-msgid "_Open..."
-msgstr "_Megnyitás..."
-
 msgid "Open Recen_t"
 msgstr "Legutóbbi megnyitása"
-
-msgid "_Save"
-msgstr "Menté_s"
-
-msgid "Save _As..."
-msgstr "Mentés másként"
 
 msgid "Save All"
 msgstr "Mind mentése"
@@ -1741,18 +1663,6 @@ msgstr "_Visszavonás"
 msgid "_Redo"
 msgstr "Új_ra"
 
-msgid "Cu_t"
-msgstr "Kivágás"
-
-msgid "_Copy"
-msgstr "Másolás (_C)"
-
-msgid "_Paste"
-msgstr "Beillesztés (_P)"
-
-msgid "_Delete"
-msgstr "Törlés (_D)"
-
 msgid "Select All"
 msgstr ""
 
@@ -1761,6 +1671,13 @@ msgstr ""
 
 msgid "Rotate 90 Mode"
 msgstr "Elforgatás 90 fokkal"
+
+#, fuzzy
+msgid "Object Properties..."
+msgstr "<b>Szöveg tulajdonságai</b>"
+
+msgid "Edit..."
+msgstr "Szerkesztés..."
 
 msgid "Edit Text..."
 msgstr "Szöveg szerkesztése..."
@@ -1885,9 +1802,6 @@ msgstr "Előző"
 msgid "_Next"
 msgstr "Következő"
 
-msgid "_Close"
-msgstr "_Bezárás"
-
 #, fuzzy
 msgid "_Revert..."
 msgstr "_Visszaállítás"
@@ -1999,6 +1913,9 @@ msgid "Grid Style: Cycle Dots/Mesh/Off"
 msgstr ""
 
 msgid "Grid Snap: Cycle Grid/Resnap/Off"
+msgstr ""
+
+msgid "Grips: On/Off"
 msgstr ""
 
 msgid "Feedback Mode: Outline/Box"
@@ -2149,6 +2066,9 @@ msgstr "Láthatatlan szöveg mutatása/elrejtése"
 msgid "Cut"
 msgstr "Kivágás"
 
+msgid "Copy"
+msgstr "Másolás"
+
 #, fuzzy
 msgid "Paste"
 msgstr "Beillesztés (_P)"
@@ -2178,6 +2098,18 @@ msgstr ""
 #, fuzzy
 msgid "Pan Down"
 msgstr "\"Középre\" üzemmód"
+
+#, fuzzy
+msgid "Zoom Extents"
+msgstr "/Teljes rajz"
+
+#, fuzzy
+msgid "Zoom In"
+msgstr "/Nagyítás"
+
+#, fuzzy
+msgid "Zoom Out"
+msgstr "/Kicsinyítés"
 
 #, fuzzy
 msgid "Zoom Full"
@@ -2215,6 +2147,22 @@ msgid "Print Page"
 msgstr "Előző"
 
 #, fuzzy
+msgid "Add Component"
+msgstr "/Alkatrész hozzáadása"
+
+#, fuzzy
+msgid "Add Net"
+msgstr "/Összeköttetés hozzáadása"
+
+#, fuzzy
+msgid "Add Bus"
+msgstr "/Busz hozzáadása"
+
+#, fuzzy
+msgid "Add Text"
+msgstr "/Szöveg hozzáadása"
+
+#, fuzzy
 msgid "Add Line"
 msgstr "Vonal"
 
@@ -2240,6 +2188,14 @@ msgstr ""
 #, fuzzy
 msgid "Add Picture"
 msgstr "Kép"
+
+#, fuzzy
+msgid "Down Schematic"
+msgstr "Rajz szerkesztése"
+
+#, fuzzy
+msgid "Down Symbol"
+msgstr "/Szimbólum szerkesztése"
 
 #, fuzzy
 msgid "Up Hierarchy"
@@ -2328,6 +2284,10 @@ msgid "Show Coordinate Window"
 msgstr "Jelenlegi nézet"
 
 #, fuzzy
+msgid "Toggle Grips"
+msgstr "Lá_thatóság váltása"
+
+#, fuzzy
 msgid "Component Documentation"
 msgstr "Alkatrész dokumentáció"
 
@@ -2365,10 +2325,6 @@ msgstr ""
 msgid "About lepton-schematic"
 msgstr "Névjegy"
 
-#, scheme-format
-msgid "Invalid text alignment ~A."
-msgstr ""
-
 #, fuzzy
 msgid "Could not show documentation:"
 msgstr "Alkatrész dokumentáció"
@@ -2383,6 +2339,83 @@ msgstr ""
 #, scheme-format
 msgid "~S is not a prefix key sequence."
 msgstr ""
+
+#, scheme-format
+msgid "Invalid text alignment ~A."
+msgstr ""
+
+#, fuzzy
+#~ msgid "Save settings to:"
+#~ msgstr "Beállitások"
+
+#, fuzzy
+#~ msgid "Invalid size [%1$d] passed to text-size\n"
+#~ msgstr "Érvénytelen méret [%d] szöveg méretként\n"
+
+#, fuzzy
+#~ msgid "Invalid size [%1$d] passed to snap-size\n"
+#~ msgstr "Érvénytelen méret [%d] snap méretként\n"
+
+#, fuzzy
+#~ msgid "Invalid num levels [%1$d] passed to undo-levels\n"
+#~ msgstr "Érvénytelen méret [%d] snap méretként\n"
+
+#, fuzzy
+#~ msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
+#~ msgstr "Érvénytelen méret [%d] snap méretként\n"
+
+#, fuzzy
+#~ msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
+#~ msgstr "Érvénytelen méret [%d] szöveg méretként\n"
+
+#, fuzzy
+#~ msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
+#~ msgstr "Érvénytelen méret [%d] szöveg méretként\n"
+
+#, fuzzy
+#~ msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
+#~ msgstr "Érvénytelen méret [%d] szöveg méretként\n"
+
+#, fuzzy
+#~ msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
+#~ msgstr "Érvénytelen méret [%d] snap méretként\n"
+
+#, fuzzy
+#~ msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
+#~ msgstr "Érvénytelen méret [%d] snap méretként\n"
+
+#, fuzzy
+#~ msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
+#~ msgstr "Érvénytelen méret [%d] szöveg méretként\n"
+
+#, fuzzy
+#~ msgid "Invalid gain [%1$d] passed to zoom-gain\n"
+#~ msgstr "Érvénytelen méret [%d] szöveg méretként\n"
+
+#, fuzzy
+#~ msgid "Could not allocate the color %1$s!\n"
+#~ msgstr "Nem találom a(z) %s színt!\n"
+
+#~ msgid "black"
+#~ msgstr "fekete"
+
+#~ msgid "white"
+#~ msgstr "fehér"
+
+#, fuzzy
+#~ msgid "Could not allocate display color %1$i!\n"
+#~ msgstr "Nem találom a(z) %s színt!\n"
+
+#, fuzzy
+#~ msgid "Could not allocate outline color %1$i!\n"
+#~ msgstr "Nem találom a(z) %s színt!\n"
+
+#~ msgid "Move"
+#~ msgstr "Mozgatás"
+
+#, fuzzy
+#~ msgid "Up"
+#~ msgstr "/Fel"
 
 #, fuzzy
 #~ msgid "Invalid offset [%1$d] passed to add-attribute-offset\n"
@@ -2605,9 +2638,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Embed Component/Pictore"
 #~ msgstr "Alkatrész/kép beágyazása"
-
-#~ msgid "/Add Attribute..."
-#~ msgstr "/Attribútum hozzáadása"
 
 #~ msgid "/Select"
 #~ msgstr "/Kiválasztás"

--- a/schematic/po/it.po
+++ b/schematic/po/it.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-10-03 23:34+0300\n"
+"POT-Creation-Date: 2020-03-18 20:44+0300\n"
 "PO-Revision-Date: 2014-12-29 20:06+0300\n"
 "Last-Translator: Marco Ciampa <ciampix@libero.it>\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -25,6 +25,13 @@ msgstr ""
 msgid "Zoom too small!  Cannot zoom further."
 msgstr ""
 "Eccessiva riduzione dell'immagine!  Non è possibile ridurla ulteriormente.\n"
+
+msgid ""
+"Save your color scheme to a file by clicking on the \"Save As...\"\n"
+"button. It can be loaded on startup with the following\n"
+"expression in the gschemrc configuration file:\n"
+"( primitive-load \"/path/to/saved-color-scheme-file\" )"
+msgstr ""
 
 #, fuzzy, c-format
 msgid ""
@@ -54,6 +61,11 @@ msgstr ""
 msgid "Sa_ve..."
 msgstr ""
 
+msgid ""
+"After you're done choosing the font, it's recommended\n"
+"to reopen schematics or restart the application."
+msgstr ""
+
 #, c-format
 msgid "<b>Current:</b> %s"
 msgstr ""
@@ -61,23 +73,21 @@ msgstr ""
 msgid "Save configuration"
 msgstr ""
 
-msgid "Save settings to:"
+msgid "Local configuration file:"
 msgstr ""
 
-msgid "Local configuration file (in current directory)"
+msgid "User configuration file:"
 msgstr ""
 
-msgid "User configuration file (geda-user.conf)"
-msgstr ""
-
-msgid "Object ~A is not included in the current gschem page."
+#, fuzzy
+msgid "Object ~A is not included in the current lepton-schematic page."
 msgstr "L'oggetto ~A non è incluso nella pagina di gschem corrente."
 
 msgid "Invalid text name/value visibility ~A."
 msgstr "Visibilità nome/valore testo non valida ~A."
 
 #, fuzzy, c-format
-msgid "You are running gEDA/gaf version [%1$s%2$s.%3$s],\n"
+msgid "You are running lepton-schematic version [%1$s%2$s.%3$s],\n"
 msgstr "Stai usando gEDA/gaf versione [%s%s.%s],\n"
 
 #, fuzzy, c-format
@@ -92,69 +102,14 @@ msgstr ""
 msgid "Please be sure that you have the latest rc file.\n"
 msgstr "Assicurarsi di avere l'ultimo file rc.\n"
 
-#, fuzzy, c-format
-msgid "Invalid size [%1$d] passed to text-size\n"
-msgstr "Grandezza [%d] passata alla dimensione del testo, non valida\n"
-
-#, fuzzy, c-format
-msgid "Invalid size [%1$d] passed to snap-size\n"
-msgstr "Ampiezza non valida [%d], passata alla dimensione magnetismo\n"
-
-#, fuzzy, c-format
-msgid "Invalid num levels [%1$d] passed to undo-levels\n"
-msgstr ""
-"Il numero di livelli non valido [%d] passato ai livelli di annullamento\n"
-
-#, fuzzy, c-format
-msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
-msgstr "Dimensione non valida [%d] passata a bus-ripper-size\n"
-
-#, fuzzy, c-format
-msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
-msgstr "Dimensione punto non valida [%d] passata a dots-grid-dot-size\n"
-
-#, fuzzy, c-format
-msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
-msgstr "Spaziatura pixel non valida [%d] passata a dots-grid-fixed-threshold\n"
-
-#, fuzzy, c-format
-msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
-msgstr ""
-"Spaziatura pixel non valida [%d] passata a mesh-grid-display-threshold\n"
-
-#, fuzzy, c-format
-msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
-msgstr ""
-"Il numero di secondi indicati [%d] non è valido ai fini dell'intervallo di "
-"auto salvataggio\n"
-
-#, fuzzy, c-format
-msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
-msgstr "Guadagno non valido [%d] passato a mousepan-gain\n"
-
-#, fuzzy, c-format
-msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
-msgstr "Guadagno non valido [%d] passato a keyboardpan-gain\n"
-
-#, fuzzy, c-format
-msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
-msgstr "Il numero [%d] di pixel indicati non è valido\n"
-
-#, fuzzy, c-format
-msgid "Invalid gain [%1$d] passed to zoom-gain\n"
-msgstr "Guadagno non valido [%d] passato a zoom-gain\n"
-
-#, fuzzy, c-format
-msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
-msgstr "Numero passi non valido [%d] scrollpan-steps\n"
-
 msgid "Object ~A is not directly included in a page."
 msgstr "L'oggetto ~A non è direttamente incluso in una pagina."
 
 msgid "Could not launch URI ~S: ~A"
 msgstr "Impossibile avviare l'URI ~S: ~A"
 
-msgid "Found invalid gschem window smob ~S"
+#, fuzzy
+msgid "Found invalid lepton-schematic window smob ~S"
 msgstr "Trovato smob finestra gschem non valido ~S"
 
 #, fuzzy, c-format
@@ -190,7 +145,7 @@ msgstr "gEDA: GPL Electronic Design Automation"
 #, fuzzy
 msgid ""
 "Copyright © 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright © 2017-2019 Lepton Developers.\n"
+"Copyright © 2017-2020 Lepton Developers.\n"
 "See AUTHORS, ChangeLog files and consult 'git log' history for details."
 msgstr ""
 "Copyright © 1998-2012 Ales Hvezda <ahvezda@geda.seul.org>\n"
@@ -678,7 +633,8 @@ msgid ""
 "\n"
 "Are you sure you want to revert this page?\n"
 "All unsaved changes in current schematic will be\n"
-"discarded and page file will be reloaded from disk."
+"discarded and page file will be reloaded from disk.\n"
+"This action will also reload all component libraries."
 msgstr ""
 
 #, fuzzy
@@ -790,10 +746,6 @@ msgid_plural "Delete %1$u locked objects?"
 msgstr[0] "Cancellare l'oggetto bloccato?"
 msgstr[1] "Cancellare i %u oggetti bloccati?"
 
-#, c-format
-msgid "Got an unexpected NULL in o_edit\n"
-msgstr "Ottenuto un NULL inaspettato in o_edit\n"
-
 #, fuzzy
 msgid "Hidden text is now visible"
 msgstr "Il testo nascosto è ora visibile\n"
@@ -809,7 +761,7 @@ msgstr ""
 "fallito.\n"
 
 #, fuzzy, c-format
-msgid "o_autosave_backups: Can't get the real filename of %1$s."
+msgid "Can't get the real filename of %1$s."
 msgstr "o_autosave_backups: Non è possibile ottenere il vero nome del file %s."
 
 #, fuzzy, c-format
@@ -827,10 +779,6 @@ msgstr ""
 #, fuzzy, c-format
 msgid "Could NOT save backup file [%1$s]"
 msgstr "Non è possibile salvare il file di ripristino [%s]\n"
-
-#, c-format
-msgid "ERROR: NULL object in o_move_end!\n"
-msgstr "ERRORE: oggetto NULLO in o_move_end!\n"
 
 #, c-format
 msgid "DOH! tried to find the whichone, but didn't find it!\n"
@@ -885,7 +833,7 @@ msgid "New slot number out of range"
 msgstr "Numero del nuovo slot fuori dal limite\n"
 
 #, fuzzy
-msgid "Undo/Redo disabled in rc file"
+msgid "Undo/Redo is disabled in configuration"
 msgstr "Cancella/Ripristina disabilitato nel file rc\n"
 
 #, fuzzy, c-format
@@ -906,8 +854,8 @@ msgid ""
 "  -h, --help               Help; this message.\n"
 "  --                       Treat all remaining arguments as filenames.\n"
 "\n"
-"Report bugs at <https://github.com/lepton-eda/lepton-eda/issues>\n"
-"Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>\n"
+"Report bugs at <%2$s>\n"
+"Lepton EDA homepage: <%3$s>\n"
 msgstr ""
 "Uso: %s [OPZIONE ...] [--] [FILE ...]\n"
 "\n"
@@ -932,30 +880,9 @@ msgstr ""
 "Riportare eventuali difetti su <https://bugs.launchpad.net/geda>\n"
 "Homepage di gEDA/gaf: <http://www.geda-project.org/>\n"
 
-#, fuzzy, c-format
-msgid ""
-"Lepton EDA %1$s (git: %2$.7s)\n"
-"Copyright (C) 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright (C) 2017-2019 Lepton Developers.\n"
-"This is free software, and you are welcome to redistribute it under\n"
-"certain conditions. For details, see the file `COPYING', which is\n"
-"included in the Lepton EDA distribution.\n"
-"There is NO WARRANTY, to the extent permitted by law.\n"
-msgstr ""
-"gEDA %s (g%.7s)\n"
-"Copyright (C) 1998-2012 sviluppatori gEDA\n"
-"Questo è software libero, è possibile la sua ridistribuzione sotto\n"
-"certe condizioni. Per i dettagli, vedere il file `COPYING', incluso\n"
-"nella distribuzione di gEDA.\n"
-"Non c'è ALCUNA GARANZIA, nei limiti di legge.\n"
-
 #, c-format
 msgid "Got invalid show option; defaulting to show both\n"
 msgstr "Ottenuta opzione mostra non valida; ritorno a mostra entrambi\n"
-
-#, c-format
-msgid "ERROR: NULL object!\n"
-msgstr "ERRORE: oggetto NULLO!\n"
 
 msgid "Single Attribute Editor"
 msgstr "Editor Singola Caratteristica"
@@ -1018,7 +945,7 @@ msgstr ""
 "slot=%d]\n"
 
 #, fuzzy
-msgid "No searchstring given in autonumber text."
+msgid "No search string given in autonumber text."
 msgstr "Nessuna stringa di ricerca nel testo di autonumerazione.\n"
 
 #, fuzzy
@@ -1097,24 +1024,6 @@ msgstr ""
 
 msgid "Clipboard insertion failed"
 msgstr "Inserimento appunti fallito"
-
-#, fuzzy, c-format
-msgid "Could not allocate the color %1$s!\n"
-msgstr "Non è possibile inserire il colore %s!\n"
-
-msgid "black"
-msgstr "nero"
-
-msgid "white"
-msgstr "bianco"
-
-#, fuzzy, c-format
-msgid "Could not allocate display color %1$i!\n"
-msgstr "Impossibile allocare il colore display %i!\n"
-
-#, fuzzy, c-format
-msgid "Could not allocate outline color %1$i!\n"
-msgstr "Impossibile allocare il colore outline %i!\n"
 
 #, fuzzy, c-format
 msgid "Tried to get an invalid color: %1$d\n"
@@ -1269,13 +1178,16 @@ msgstr ""
 msgid "Invalid Attribute"
 msgstr "Attributo non valido"
 
-msgid "Schematics"
+#, fuzzy
+msgid "Schematics (*.sch)"
 msgstr "Schemi"
 
-msgid "Symbols"
+#, fuzzy
+msgid "Symbols (*.sym)"
 msgstr "Simboli"
 
-msgid "Schematics and symbols"
+#, fuzzy
+msgid "Schematics and symbols (*.sch *.sym)"
 msgstr "Schemi e simboli"
 
 msgid "All files"
@@ -1317,7 +1229,7 @@ msgid "Hatch"
 msgstr ""
 
 #, fuzzy, c-format
-msgid "x_image_lowlevel: Unable to write %1$s file %2$s."
+msgid "Unable to write %1$s file %2$s."
 msgstr "x_image_lowlevel: impossibile scrivere %s file %s.\n"
 
 #, fuzzy, c-format
@@ -1342,7 +1254,7 @@ msgid "Wrote black and white image to [%1$s] [%2$d x %3$d]"
 msgstr "Scritta immagine in bianco e nero per [%s] [%d x %d]\n"
 
 #, fuzzy
-msgid "x_image_lowlevel: Unable to get pixbuf from gschem's window."
+msgid "Unable to get pixbuf from lepton-schematic's window."
 msgstr ""
 "x_image_lowlevel: incapace ad ottenere immagine pixbuf dalla finestra di "
 "gschem.\n"
@@ -1393,69 +1305,61 @@ msgstr ""
 msgid "Phantom"
 msgstr ""
 
-msgid "Add Net"
-msgstr "Aggiungi net"
-
-msgid "Add Attribute"
-msgstr "Aggiungi attributo"
-
-msgid "Add Component"
+#, fuzzy
+msgid "Add Co_mponent..."
 msgstr "Aggiungi componente"
 
-msgid "Add Bus"
+#, fuzzy
+msgid "Add Te_xt..."
+msgstr "Aggiungi Testo..."
+
+#, fuzzy
+msgid "Add _Attribute..."
+msgstr "_Attributo..."
+
+#, fuzzy
+msgid "Add _Net"
+msgstr "Aggiungi net"
+
+#, fuzzy
+msgid "Add _Bus"
 msgstr "Aggiungi bus"
 
-msgid "Add Text"
-msgstr "Aggiungi testo"
+msgid "Cu_t"
+msgstr "_Taglia"
 
-msgid "Zoom In"
-msgstr "Zoom In"
+msgid "_Copy"
+msgstr "_Copia"
 
-msgid "Zoom Out"
-msgstr "Zoom Out"
+msgid "_Paste"
+msgstr "_Incolla"
 
-msgid "Zoom Extents"
-msgstr "Zoom alla pagina"
+msgid "_Delete"
+msgstr "_Elimina"
 
-msgid "Select"
-msgstr "Seleziona"
-
-msgid "Edit..."
+#, fuzzy
+msgid "_Edit..."
 msgstr "Modifica..."
 
 #, fuzzy
-msgid "Object Properties..."
+msgid "Ed_it Text..."
+msgstr "Modifica il testo..."
+
+#, fuzzy
+msgid "_Object Properties..."
 msgstr "<b>Opzioni</b>"
 
-msgid "Copy"
-msgstr "Copia"
-
-msgid "Move"
-msgstr "Sposta"
-
-msgid "Delete"
-msgstr "Cancella"
-
-msgid "Down Schematic"
+#, fuzzy
+msgid "Hierarchy: Down _Schematic"
 msgstr "Giu nello schema"
 
-msgid "Down Symbol"
+#, fuzzy
+msgid "Hierarchy: Down S_ymbol"
 msgstr "Giu nel simbolo"
 
-msgid "Up"
-msgstr "Su"
-
-#, fuzzy, c-format
-msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
-msgstr ""
-"Si è tentato di regolare la sensitività su un oggetto di menu inesistente "
-"%s\n"
-
-#, c-format
-msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
-msgstr ""
-"Si è tentato di regolare la sensitività su un oggetto di menu inesistente "
-"%s\n"
+#, fuzzy
+msgid "Hierarchy: _Up"
+msgstr "Ge_rarchia"
 
 msgid "The operating system is out of memory or resources."
 msgstr "Il sistema operativo ha terminato le risorse di memoria."
@@ -1478,6 +1382,9 @@ msgstr "Promuovi"
 msgid "Duplicate"
 msgstr "Duplica"
 
+msgid "Delete"
+msgstr "Cancella"
+
 msgid "Copy to all"
 msgstr "Copia in tutti"
 
@@ -1496,6 +1403,9 @@ msgstr "V"
 #, fuzzy
 msgid "Sho_w inherited attributes"
 msgstr "Mostra gli attributi ereditati"
+
+msgid "Add Attribute"
+msgstr "Aggiungi attributo"
 
 #, fuzzy
 msgid "_Name:"
@@ -1622,6 +1532,25 @@ msgstr "Ge_rarchia"
 msgid "Hierarchy up"
 msgstr "Ge_rarchia"
 
+msgid "_New"
+msgstr "_Nuovo"
+
+msgid "_Open..."
+msgstr "_Apri..."
+
+msgid "_Save"
+msgstr "_Salva"
+
+msgid "Save _As..."
+msgstr "Salva _come..."
+
+#, fuzzy
+msgid "Page _Manager..."
+msgstr "Gestore Pagina"
+
+msgid "_Close"
+msgstr "_Chiudi"
+
 #, fuzzy
 msgid "Options"
 msgstr "_Opzioni"
@@ -1745,6 +1674,9 @@ msgstr ""
 msgid "Add Text..."
 msgstr "Aggiungi Testo..."
 
+msgid "Select"
+msgstr "Seleziona"
+
 msgid "Select mode"
 msgstr "Modalità Selezione"
 
@@ -1814,20 +1746,8 @@ msgstr "Editor di schemi gEDA"
 msgid "Create and edit electrical schematics and symbols with lepton-schematic"
 msgstr "Crea e modifica schemi elettrici e simboli con gschem"
 
-msgid "_New"
-msgstr "_Nuovo"
-
-msgid "_Open..."
-msgstr "_Apri..."
-
 msgid "Open Recen_t"
 msgstr "Apri recen_ti"
-
-msgid "_Save"
-msgstr "_Salva"
-
-msgid "Save _As..."
-msgstr "Salva _come..."
 
 msgid "Save All"
 msgstr "Salva tutto"
@@ -1861,18 +1781,6 @@ msgstr "Ann_ulla"
 msgid "_Redo"
 msgstr "_Ripeti"
 
-msgid "Cu_t"
-msgstr "_Taglia"
-
-msgid "_Copy"
-msgstr "_Copia"
-
-msgid "_Paste"
-msgstr "_Incolla"
-
-msgid "_Delete"
-msgstr "_Elimina"
-
 msgid "Select All"
 msgstr "Seleziona tutto"
 
@@ -1881,6 +1789,13 @@ msgstr "Deseleziona"
 
 msgid "Rotate 90 Mode"
 msgstr "Ruota di 90 gradi"
+
+#, fuzzy
+msgid "Object Properties..."
+msgstr "<b>Opzioni</b>"
+
+msgid "Edit..."
+msgstr "Modifica..."
 
 msgid "Edit Text..."
 msgstr "Modifica il testo..."
@@ -2005,9 +1920,6 @@ msgstr "_Precedente"
 msgid "_Next"
 msgstr "_Successivo"
 
-msgid "_Close"
-msgstr "_Chiudi"
-
 #, fuzzy
 msgid "_Revert..."
 msgstr "_Ripristina"
@@ -2119,6 +2031,9 @@ msgid "Grid Style: Cycle Dots/Mesh/Off"
 msgstr ""
 
 msgid "Grid Snap: Cycle Grid/Resnap/Off"
+msgstr ""
+
+msgid "Grips: On/Off"
 msgstr ""
 
 #, fuzzy
@@ -2261,6 +2176,9 @@ msgstr "Mostra/Nascondi testo invisibile"
 msgid "Cut"
 msgstr "Taglia"
 
+msgid "Copy"
+msgstr "Copia"
+
 msgid "Paste"
 msgstr "Incolla"
 
@@ -2285,6 +2203,15 @@ msgstr "Trascina in su"
 
 msgid "Pan Down"
 msgstr "Trascina in giù"
+
+msgid "Zoom Extents"
+msgstr "Zoom alla pagina"
+
+msgid "Zoom In"
+msgstr "Zoom In"
+
+msgid "Zoom Out"
+msgstr "Zoom Out"
 
 msgid "Zoom Full"
 msgstr "Zoom tutto"
@@ -2314,6 +2241,18 @@ msgstr "Pagina successiva"
 msgid "Print Page"
 msgstr "Stampa pagina"
 
+msgid "Add Component"
+msgstr "Aggiungi componente"
+
+msgid "Add Net"
+msgstr "Aggiungi net"
+
+msgid "Add Bus"
+msgstr "Aggiungi bus"
+
+msgid "Add Text"
+msgstr "Aggiungi testo"
+
 msgid "Add Line"
 msgstr "Aggiungi linea"
 
@@ -2334,6 +2273,12 @@ msgstr "Aggiungi pin"
 
 msgid "Add Picture"
 msgstr "Aggiungi immagine"
+
+msgid "Down Schematic"
+msgstr "Giu nello schema"
+
+msgid "Down Symbol"
+msgstr "Giu nel simbolo"
 
 msgid "Up Hierarchy"
 msgstr "Su nella gerarchia"
@@ -2406,6 +2351,10 @@ msgstr "Mostra la finestra di log"
 msgid "Show Coordinate Window"
 msgstr "Mostra la finestra coordinate"
 
+#, fuzzy
+msgid "Toggle Grips"
+msgstr "Commu_ta Visibilità"
+
 msgid "Component Documentation"
 msgstr "Documentazione componente"
 
@@ -2449,10 +2398,6 @@ msgstr "Visualizza la pagina principale del wiki di gEDA in un browser."
 msgid "About lepton-schematic"
 msgstr "Informazioni su gschem"
 
-#, scheme-format
-msgid "Invalid text alignment ~A."
-msgstr "Allineamento testo non valido ~A."
-
 #, fuzzy
 msgid "Could not show documentation:"
 msgstr ""
@@ -2469,6 +2414,129 @@ msgstr "~S non è una combinazione di tasti valida."
 #, scheme-format
 msgid "~S is not a prefix key sequence."
 msgstr "~S non è un prefisso di sequenza di tasti."
+
+#, scheme-format
+msgid "Invalid text alignment ~A."
+msgstr "Allineamento testo non valido ~A."
+
+#, fuzzy
+#~ msgid "Invalid size [%1$d] passed to text-size\n"
+#~ msgstr "Grandezza [%d] passata alla dimensione del testo, non valida\n"
+
+#, fuzzy
+#~ msgid "Invalid size [%1$d] passed to snap-size\n"
+#~ msgstr "Ampiezza non valida [%d], passata alla dimensione magnetismo\n"
+
+#, fuzzy
+#~ msgid "Invalid num levels [%1$d] passed to undo-levels\n"
+#~ msgstr ""
+#~ "Il numero di livelli non valido [%d] passato ai livelli di annullamento\n"
+
+#, fuzzy
+#~ msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
+#~ msgstr "Dimensione non valida [%d] passata a bus-ripper-size\n"
+
+#, fuzzy
+#~ msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
+#~ msgstr "Dimensione punto non valida [%d] passata a dots-grid-dot-size\n"
+
+#, fuzzy
+#~ msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
+#~ msgstr ""
+#~ "Spaziatura pixel non valida [%d] passata a dots-grid-fixed-threshold\n"
+
+#, fuzzy
+#~ msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
+#~ msgstr ""
+#~ "Spaziatura pixel non valida [%d] passata a mesh-grid-display-threshold\n"
+
+#, fuzzy
+#~ msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
+#~ msgstr ""
+#~ "Il numero di secondi indicati [%d] non è valido ai fini dell'intervallo "
+#~ "di auto salvataggio\n"
+
+#, fuzzy
+#~ msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
+#~ msgstr "Guadagno non valido [%d] passato a mousepan-gain\n"
+
+#, fuzzy
+#~ msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
+#~ msgstr "Guadagno non valido [%d] passato a keyboardpan-gain\n"
+
+#, fuzzy
+#~ msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
+#~ msgstr "Il numero [%d] di pixel indicati non è valido\n"
+
+#, fuzzy
+#~ msgid "Invalid gain [%1$d] passed to zoom-gain\n"
+#~ msgstr "Guadagno non valido [%d] passato a zoom-gain\n"
+
+#, fuzzy
+#~ msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
+#~ msgstr "Numero passi non valido [%d] scrollpan-steps\n"
+
+#~ msgid "Got an unexpected NULL in o_edit\n"
+#~ msgstr "Ottenuto un NULL inaspettato in o_edit\n"
+
+#~ msgid "ERROR: NULL object in o_move_end!\n"
+#~ msgstr "ERRORE: oggetto NULLO in o_move_end!\n"
+
+#, fuzzy
+#~ msgid ""
+#~ "Lepton EDA %1$s (git: %2$.7s)\n"
+#~ "Copyright (C) 1998-2017 by Ales Hvezda and the respective original "
+#~ "authors.\n"
+#~ "Copyright (C) 2017-2019 Lepton Developers.\n"
+#~ "This is free software, and you are welcome to redistribute it under\n"
+#~ "certain conditions. For details, see the file `COPYING', which is\n"
+#~ "included in the Lepton EDA distribution.\n"
+#~ "There is NO WARRANTY, to the extent permitted by law.\n"
+#~ msgstr ""
+#~ "gEDA %s (g%.7s)\n"
+#~ "Copyright (C) 1998-2012 sviluppatori gEDA\n"
+#~ "Questo è software libero, è possibile la sua ridistribuzione sotto\n"
+#~ "certe condizioni. Per i dettagli, vedere il file `COPYING', incluso\n"
+#~ "nella distribuzione di gEDA.\n"
+#~ "Non c'è ALCUNA GARANZIA, nei limiti di legge.\n"
+
+#~ msgid "ERROR: NULL object!\n"
+#~ msgstr "ERRORE: oggetto NULLO!\n"
+
+#, fuzzy
+#~ msgid "Could not allocate the color %1$s!\n"
+#~ msgstr "Non è possibile inserire il colore %s!\n"
+
+#~ msgid "black"
+#~ msgstr "nero"
+
+#~ msgid "white"
+#~ msgstr "bianco"
+
+#, fuzzy
+#~ msgid "Could not allocate display color %1$i!\n"
+#~ msgstr "Impossibile allocare il colore display %i!\n"
+
+#, fuzzy
+#~ msgid "Could not allocate outline color %1$i!\n"
+#~ msgstr "Impossibile allocare il colore outline %i!\n"
+
+#~ msgid "Move"
+#~ msgstr "Sposta"
+
+#~ msgid "Up"
+#~ msgstr "Su"
+
+#, fuzzy
+#~ msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
+#~ msgstr ""
+#~ "Si è tentato di regolare la sensitività su un oggetto di menu inesistente "
+#~ "%s\n"
+
+#~ msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
+#~ msgstr ""
+#~ "Si è tentato di regolare la sensitività su un oggetto di menu inesistente "
+#~ "%s\n"
 
 #, fuzzy
 #~ msgid "Invalid offset [%1$d] passed to add-attribute-offset\n"

--- a/schematic/po/ja.po
+++ b/schematic/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-10-03 23:34+0300\n"
+"POT-Creation-Date: 2020-03-18 20:44+0300\n"
 "PO-Revision-Date: 2012-01-31 12:07+0000\n"
 "Last-Translator: Peter TB Brett <Unknown>\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -21,6 +21,13 @@ msgstr ""
 #, fuzzy
 msgid "Zoom too small!  Cannot zoom further."
 msgstr "これ以上ズームできません。\n"
+
+msgid ""
+"Save your color scheme to a file by clicking on the \"Save As...\"\n"
+"button. It can be loaded on startup with the following\n"
+"expression in the gschemrc configuration file:\n"
+"( primitive-load \"/path/to/saved-color-scheme-file\" )"
+msgstr ""
 
 #, fuzzy, c-format
 msgid ""
@@ -48,6 +55,11 @@ msgstr ""
 msgid "Sa_ve..."
 msgstr ""
 
+msgid ""
+"After you're done choosing the font, it's recommended\n"
+"to reopen schematics or restart the application."
+msgstr ""
+
 #, c-format
 msgid "<b>Current:</b> %s"
 msgstr ""
@@ -55,23 +67,20 @@ msgstr ""
 msgid "Save configuration"
 msgstr ""
 
-msgid "Save settings to:"
+msgid "Local configuration file:"
 msgstr ""
 
-msgid "Local configuration file (in current directory)"
+msgid "User configuration file:"
 msgstr ""
 
-msgid "User configuration file (geda-user.conf)"
-msgstr ""
-
-msgid "Object ~A is not included in the current gschem page."
+msgid "Object ~A is not included in the current lepton-schematic page."
 msgstr ""
 
 msgid "Invalid text name/value visibility ~A."
 msgstr ""
 
 #, c-format
-msgid "You are running gEDA/gaf version [%1$s%2$s.%3$s],\n"
+msgid "You are running lepton-schematic version [%1$s%2$s.%3$s],\n"
 msgstr ""
 
 #, c-format
@@ -84,65 +93,13 @@ msgstr ""
 msgid "Please be sure that you have the latest rc file.\n"
 msgstr ""
 
-#, fuzzy, c-format
-msgid "Invalid size [%1$d] passed to text-size\n"
-msgstr "無効なサイズ[%d]がtext-sizeに指定されました。\n"
-
-#, fuzzy, c-format
-msgid "Invalid size [%1$d] passed to snap-size\n"
-msgstr "無効なサイズ[%d]がsnap-sizeに指定されました。\n"
-
-#, fuzzy, c-format
-msgid "Invalid num levels [%1$d] passed to undo-levels\n"
-msgstr "無効なアンドゥレベル[%d]がundo-levelsに指定されました。\n"
-
-#, fuzzy, c-format
-msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
-msgstr "無効なサイズ[%d]がbus-ripperに指定されました。\n"
-
-#, fuzzy, c-format
-msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
-msgstr "無効なサイズ[%d]がtext-sizeに指定されました。\n"
-
-#, fuzzy, c-format
-msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
-msgstr "無効なサイズ[%d]がbus-ripperに指定されました。\n"
-
-#, fuzzy, c-format
-msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
-msgstr "無効なサイズ[%d]がbus-ripperに指定されました。\n"
-
-#, fuzzy, c-format
-msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
-msgstr "無効なアンドゥレベル[%d]がundo-levelsに指定されました。\n"
-
-#, fuzzy, c-format
-msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
-msgstr "無効なサイズ[%d]がsnap-sizeに指定されました。\n"
-
-#, fuzzy, c-format
-msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
-msgstr "無効なサイズ[%d]がsnap-sizeに指定されました。\n"
-
-#, fuzzy, c-format
-msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
-msgstr "無効なアンドゥレベル[%d]がundo-levelsに指定されました。\n"
-
-#, fuzzy, c-format
-msgid "Invalid gain [%1$d] passed to zoom-gain\n"
-msgstr "無効なサイズ[%d]がtext-sizeに指定されました。\n"
-
-#, c-format
-msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
-msgstr ""
-
 msgid "Object ~A is not directly included in a page."
 msgstr ""
 
 msgid "Could not launch URI ~S: ~A"
 msgstr ""
 
-msgid "Found invalid gschem window smob ~S"
+msgid "Found invalid lepton-schematic window smob ~S"
 msgstr ""
 
 #, c-format
@@ -173,7 +130,7 @@ msgstr ""
 
 msgid ""
 "Copyright © 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright © 2017-2019 Lepton Developers.\n"
+"Copyright © 2017-2020 Lepton Developers.\n"
 "See AUTHORS, ChangeLog files and consult 'git log' history for details."
 msgstr ""
 
@@ -633,7 +590,8 @@ msgid ""
 "\n"
 "Are you sure you want to revert this page?\n"
 "All unsaved changes in current schematic will be\n"
-"discarded and page file will be reloaded from disk."
+"discarded and page file will be reloaded from disk.\n"
+"This action will also reload all component libraries."
 msgstr ""
 
 #, fuzzy
@@ -736,10 +694,6 @@ msgid_plural "Delete %1$u locked objects?"
 msgstr[0] ""
 msgstr[1] ""
 
-#, c-format
-msgid "Got an unexpected NULL in o_edit\n"
-msgstr ""
-
 #, fuzzy
 msgid "Hidden text is now visible"
 msgstr "隠しテキストが表示されました。\n"
@@ -753,7 +707,7 @@ msgid "Could not find symbol [%1$s] in library. Update failed."
 msgstr ""
 
 #, c-format
-msgid "o_autosave_backups: Can't get the real filename of %1$s."
+msgid "Can't get the real filename of %1$s."
 msgstr ""
 
 #, c-format
@@ -766,10 +720,6 @@ msgstr ""
 
 #, c-format
 msgid "Could NOT save backup file [%1$s]"
-msgstr ""
-
-#, c-format
-msgid "ERROR: NULL object in o_move_end!\n"
 msgstr ""
 
 #, c-format
@@ -822,7 +772,7 @@ msgid "New slot number out of range"
 msgstr "スロット番号が範囲を越えています。\n"
 
 #, fuzzy
-msgid "Undo/Redo disabled in rc file"
+msgid "Undo/Redo is disabled in configuration"
 msgstr "アンドゥ/リドゥはrcファイルで無効に設定されています。\n"
 
 #, c-format
@@ -843,27 +793,12 @@ msgid ""
 "  -h, --help               Help; this message.\n"
 "  --                       Treat all remaining arguments as filenames.\n"
 "\n"
-"Report bugs at <https://github.com/lepton-eda/lepton-eda/issues>\n"
-"Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"Lepton EDA %1$s (git: %2$.7s)\n"
-"Copyright (C) 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright (C) 2017-2019 Lepton Developers.\n"
-"This is free software, and you are welcome to redistribute it under\n"
-"certain conditions. For details, see the file `COPYING', which is\n"
-"included in the Lepton EDA distribution.\n"
-"There is NO WARRANTY, to the extent permitted by law.\n"
+"Report bugs at <%2$s>\n"
+"Lepton EDA homepage: <%3$s>\n"
 msgstr ""
 
 #, c-format
 msgid "Got invalid show option; defaulting to show both\n"
-msgstr ""
-
-#, c-format
-msgid "ERROR: NULL object!\n"
 msgstr ""
 
 msgid "Single Attribute Editor"
@@ -921,7 +856,7 @@ msgid ""
 "duplicate slot may cause problems: [symbolname=%1$s, number=%2$d, slot=%3$d]"
 msgstr ""
 
-msgid "No searchstring given in autonumber text."
+msgid "No search string given in autonumber text."
 msgstr ""
 
 msgid "No '*' or '?' given at the end of the autonumber text."
@@ -996,24 +931,6 @@ msgstr ""
 
 msgid "Clipboard insertion failed"
 msgstr ""
-
-#, fuzzy, c-format
-msgid "Could not allocate the color %1$s!\n"
-msgstr "指定できない色[%s]です!\n"
-
-msgid "black"
-msgstr "黒"
-
-msgid "white"
-msgstr "白"
-
-#, fuzzy, c-format
-msgid "Could not allocate display color %1$i!\n"
-msgstr "指定できない色[%s]です!\n"
-
-#, fuzzy, c-format
-msgid "Could not allocate outline color %1$i!\n"
-msgstr "指定できない色[%s]です!\n"
 
 #, fuzzy, c-format
 msgid "Tried to get an invalid color: %1$d\n"
@@ -1154,13 +1071,13 @@ msgstr ""
 msgid "Invalid Attribute"
 msgstr ""
 
-msgid "Schematics"
+msgid "Schematics (*.sch)"
 msgstr ""
 
-msgid "Symbols"
+msgid "Symbols (*.sym)"
 msgstr ""
 
-msgid "Schematics and symbols"
+msgid "Schematics and symbols (*.sch *.sym)"
 msgstr ""
 
 msgid "All files"
@@ -1195,9 +1112,9 @@ msgstr "メッシュ"
 msgid "Hatch"
 msgstr "ハッチ"
 
-#, c-format
-msgid "x_image_lowlevel: Unable to write %1$s file %2$s."
-msgstr ""
+#, fuzzy, c-format
+msgid "Unable to write %1$s file %2$s."
+msgstr "初期化scmファイルの読み込みに失敗。[%s]\n"
 
 #, c-format
 msgid ""
@@ -1215,7 +1132,7 @@ msgstr "カラーイメージを出力しました。[%s] [%d x %d]\n"
 msgid "Wrote black and white image to [%1$s] [%2$d x %3$d]"
 msgstr "白黒イメージを出力しました。[%s] [%d x %d]\n"
 
-msgid "x_image_lowlevel: Unable to get pixbuf from gschem's window."
+msgid "Unable to get pixbuf from lepton-schematic's window."
 msgstr ""
 
 msgid "NOTE: print-color-map will be used for PDF export"
@@ -1265,69 +1182,56 @@ msgid "Phantom"
 msgstr "ファントム"
 
 #, fuzzy
-msgid "Add Net"
-msgstr "テキスト追加..."
-
-msgid "Add Attribute"
-msgstr ""
-
-#, fuzzy
-msgid "Add Component"
+msgid "Add Co_mponent..."
 msgstr "部品"
 
-msgid "Add Bus"
-msgstr ""
-
 #, fuzzy
-msgid "Add Text"
+msgid "Add Te_xt..."
 msgstr "テキスト追加..."
 
 #, fuzzy
-msgid "Zoom In"
-msgstr "拡大(_I)"
+msgid "Add _Attribute..."
+msgstr "アトリビュート(_A)"
 
 #, fuzzy
-msgid "Zoom Out"
-msgstr "縮小(_O)"
+msgid "Add _Net"
+msgstr "テキスト追加..."
+
+msgid "Add _Bus"
+msgstr ""
+
+msgid "Cu_t"
+msgstr "切り取り(_T)"
+
+msgid "_Copy"
+msgstr "コピー(_C)"
+
+msgid "_Paste"
+msgstr "貼り付け(_P)"
+
+msgid "_Delete"
+msgstr "削除(_D)"
 
 #, fuzzy
-msgid "Zoom Extents"
-msgstr "回路全体の表示(_E)"
-
-msgid "Select"
-msgstr "選択"
-
-msgid "Edit..."
+msgid "_Edit..."
 msgstr "編集..."
 
-msgid "Object Properties..."
+#, fuzzy
+msgid "Ed_it Text..."
+msgstr "テキスト編集..."
+
+msgid "_Object Properties..."
 msgstr ""
 
-msgid "Copy"
-msgstr "コピー"
-
-msgid "Move"
-msgstr "移動"
-
-msgid "Delete"
-msgstr "削除"
-
-msgid "Down Schematic"
+msgid "Hierarchy: Down _Schematic"
 msgstr ""
 
-msgid "Down Symbol"
+msgid "Hierarchy: Down S_ymbol"
 msgstr ""
 
-msgid "Up"
-msgstr ""
-
-#, c-format
-msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
-msgstr ""
-
-#, c-format
-msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
-msgstr ""
+#, fuzzy
+msgid "Hierarchy: _Up"
+msgstr "階層"
 
 msgid "The operating system is out of memory or resources."
 msgstr ""
@@ -1350,6 +1254,9 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
+msgid "Delete"
+msgstr "削除"
+
 #, fuzzy
 msgid "Copy to all"
 msgstr "コピー1"
@@ -1369,6 +1276,9 @@ msgstr "値"
 #, fuzzy
 msgid "Sho_w inherited attributes"
 msgstr "アトリビュート編集"
+
+msgid "Add Attribute"
+msgstr ""
 
 #, fuzzy
 msgid "_Name:"
@@ -1479,6 +1389,25 @@ msgstr "階層"
 #, fuzzy
 msgid "Hierarchy up"
 msgstr "階層"
+
+msgid "_New"
+msgstr "新規(_N)"
+
+msgid "_Open..."
+msgstr "開く(_O)..."
+
+msgid "_Save"
+msgstr "保存(_S)"
+
+msgid "Save _As..."
+msgstr "別名で保存(_A)..."
+
+#, fuzzy
+msgid "Page _Manager..."
+msgstr "ページマネージャ"
+
+msgid "_Close"
+msgstr "閉じる(_C)"
 
 #, fuzzy
 msgid "Options"
@@ -1599,6 +1528,9 @@ msgstr ""
 msgid "Add Text..."
 msgstr "テキスト追加..."
 
+msgid "Select"
+msgstr "選択"
+
 msgid "Select mode"
 msgstr "選択モード"
 
@@ -1662,20 +1594,8 @@ msgstr ""
 msgid "Create and edit electrical schematics and symbols with lepton-schematic"
 msgstr ""
 
-msgid "_New"
-msgstr "新規(_N)"
-
-msgid "_Open..."
-msgstr "開く(_O)..."
-
 msgid "Open Recen_t"
 msgstr "最近使用したファイル(_T)"
-
-msgid "_Save"
-msgstr "保存(_S)"
-
-msgid "Save _As..."
-msgstr "別名で保存(_A)..."
 
 msgid "Save All"
 msgstr "すべて保存"
@@ -1709,18 +1629,6 @@ msgstr "元に戻す(_U)"
 msgid "_Redo"
 msgstr "やり直す(_R)"
 
-msgid "Cu_t"
-msgstr "切り取り(_T)"
-
-msgid "_Copy"
-msgstr "コピー(_C)"
-
-msgid "_Paste"
-msgstr "貼り付け(_P)"
-
-msgid "_Delete"
-msgstr "削除(_D)"
-
 msgid "Select All"
 msgstr ""
 
@@ -1729,6 +1637,12 @@ msgstr ""
 
 msgid "Rotate 90 Mode"
 msgstr "90度回転モード"
+
+msgid "Object Properties..."
+msgstr ""
+
+msgid "Edit..."
+msgstr "編集..."
 
 msgid "Edit Text..."
 msgstr "テキスト編集..."
@@ -1852,9 +1766,6 @@ msgstr "前のページ(_P)"
 msgid "_Next"
 msgstr "次のページ(_N)"
 
-msgid "_Close"
-msgstr "閉じる(_C)"
-
 #, fuzzy
 msgid "_Revert..."
 msgstr "再読み込み(_R)"
@@ -1966,6 +1877,9 @@ msgid "Grid Style: Cycle Dots/Mesh/Off"
 msgstr ""
 
 msgid "Grid Snap: Cycle Grid/Resnap/Off"
+msgstr ""
+
+msgid "Grips: On/Off"
 msgstr ""
 
 msgid "Feedback Mode: Outline/Box"
@@ -2114,6 +2028,9 @@ msgstr "テキスト表示/非表示"
 msgid "Cut"
 msgstr "切り取り(_T)"
 
+msgid "Copy"
+msgstr "コピー"
+
 #, fuzzy
 msgid "Paste"
 msgstr "貼り付け(_P)"
@@ -2143,6 +2060,18 @@ msgstr ""
 #, fuzzy
 msgid "Pan Down"
 msgstr "パンモード"
+
+#, fuzzy
+msgid "Zoom Extents"
+msgstr "回路全体の表示(_E)"
+
+#, fuzzy
+msgid "Zoom In"
+msgstr "拡大(_I)"
+
+#, fuzzy
+msgid "Zoom Out"
+msgstr "縮小(_O)"
 
 #, fuzzy
 msgid "Zoom Full"
@@ -2179,6 +2108,21 @@ msgid "Print Page"
 msgstr "前のページ(_P)"
 
 #, fuzzy
+msgid "Add Component"
+msgstr "部品"
+
+#, fuzzy
+msgid "Add Net"
+msgstr "テキスト追加..."
+
+msgid "Add Bus"
+msgstr ""
+
+#, fuzzy
+msgid "Add Text"
+msgstr "テキスト追加..."
+
+#, fuzzy
 msgid "Add Line"
 msgstr "線"
 
@@ -2201,6 +2145,12 @@ msgstr ""
 #, fuzzy
 msgid "Add Picture"
 msgstr "画像(_R)"
+
+msgid "Down Schematic"
+msgstr ""
+
+msgid "Down Symbol"
+msgstr ""
 
 #, fuzzy
 msgid "Up Hierarchy"
@@ -2282,6 +2232,9 @@ msgstr "新規ウィンドウ"
 msgid "Show Coordinate Window"
 msgstr "現在のウィンドウ"
 
+msgid "Toggle Grips"
+msgstr ""
+
 #, fuzzy
 msgid "Component Documentation"
 msgstr "部品モード"
@@ -2317,10 +2270,6 @@ msgstr ""
 msgid "About lepton-schematic"
 msgstr ""
 
-#, scheme-format
-msgid "Invalid text alignment ~A."
-msgstr ""
-
 #, fuzzy
 msgid "Could not show documentation:"
 msgstr "部品モード"
@@ -2335,6 +2284,79 @@ msgstr ""
 #, scheme-format
 msgid "~S is not a prefix key sequence."
 msgstr ""
+
+#, scheme-format
+msgid "Invalid text alignment ~A."
+msgstr ""
+
+#, fuzzy
+#~ msgid "Invalid size [%1$d] passed to text-size\n"
+#~ msgstr "無効なサイズ[%d]がtext-sizeに指定されました。\n"
+
+#, fuzzy
+#~ msgid "Invalid size [%1$d] passed to snap-size\n"
+#~ msgstr "無効なサイズ[%d]がsnap-sizeに指定されました。\n"
+
+#, fuzzy
+#~ msgid "Invalid num levels [%1$d] passed to undo-levels\n"
+#~ msgstr "無効なアンドゥレベル[%d]がundo-levelsに指定されました。\n"
+
+#, fuzzy
+#~ msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
+#~ msgstr "無効なサイズ[%d]がbus-ripperに指定されました。\n"
+
+#, fuzzy
+#~ msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
+#~ msgstr "無効なサイズ[%d]がtext-sizeに指定されました。\n"
+
+#, fuzzy
+#~ msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
+#~ msgstr "無効なサイズ[%d]がbus-ripperに指定されました。\n"
+
+#, fuzzy
+#~ msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
+#~ msgstr "無効なサイズ[%d]がbus-ripperに指定されました。\n"
+
+#, fuzzy
+#~ msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
+#~ msgstr "無効なアンドゥレベル[%d]がundo-levelsに指定されました。\n"
+
+#, fuzzy
+#~ msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
+#~ msgstr "無効なサイズ[%d]がsnap-sizeに指定されました。\n"
+
+#, fuzzy
+#~ msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
+#~ msgstr "無効なサイズ[%d]がsnap-sizeに指定されました。\n"
+
+#, fuzzy
+#~ msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
+#~ msgstr "無効なアンドゥレベル[%d]がundo-levelsに指定されました。\n"
+
+#, fuzzy
+#~ msgid "Invalid gain [%1$d] passed to zoom-gain\n"
+#~ msgstr "無効なサイズ[%d]がtext-sizeに指定されました。\n"
+
+#, fuzzy
+#~ msgid "Could not allocate the color %1$s!\n"
+#~ msgstr "指定できない色[%s]です!\n"
+
+#~ msgid "black"
+#~ msgstr "黒"
+
+#~ msgid "white"
+#~ msgstr "白"
+
+#, fuzzy
+#~ msgid "Could not allocate display color %1$i!\n"
+#~ msgstr "指定できない色[%s]です!\n"
+
+#, fuzzy
+#~ msgid "Could not allocate outline color %1$i!\n"
+#~ msgstr "指定できない色[%s]です!\n"
+
+#~ msgid "Move"
+#~ msgstr "移動"
 
 #, fuzzy
 #~ msgid "Invalid offset [%1$d] passed to add-attribute-offset\n"

--- a/schematic/po/lepton-schematic.pot
+++ b/schematic/po/lepton-schematic.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lepton-eda 1.9.9\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-10-03 23:34+0300\n"
+"POT-Creation-Date: 2020-03-18 20:44+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -22,18 +22,26 @@ msgstr ""
 msgid "Zoom too small!  Cannot zoom further."
 msgstr ""
 
-#: schematic/src/color_edit_widget.c:399
+#: schematic/src/color_edit_widget.c:227
+msgid ""
+"Save your color scheme to a file by clicking on the \"Save As...\"\n"
+"button. It can be loaded on startup with the following\n"
+"expression in the gschemrc configuration file:\n"
+"( primitive-load \"/path/to/saved-color-scheme-file\" )"
+msgstr ""
+
+#: schematic/src/color_edit_widget.c:411
 #, c-format
 msgid ""
 "Could not save file [%s]:\n"
 "%s"
 msgstr ""
 
-#: schematic/src/color_edit_widget.c:434
+#: schematic/src/color_edit_widget.c:446
 msgid "Save Color Scheme As..."
 msgstr ""
 
-#: schematic/src/color_edit_widget.c:482 schematic/src/x_fileselect.c:407
+#: schematic/src/color_edit_widget.c:494 schematic/src/x_fileselect.c:505
 #, c-format
 msgid ""
 "The selected file `%1$s' already exists.\n"
@@ -41,7 +49,7 @@ msgid ""
 "Would you like to overwrite it?"
 msgstr ""
 
-#: schematic/src/color_edit_widget.c:486 schematic/src/x_fileselect.c:411
+#: schematic/src/color_edit_widget.c:498 schematic/src/x_fileselect.c:509
 msgid "Overwrite file?"
 msgstr ""
 
@@ -53,128 +61,65 @@ msgstr ""
 msgid "Sa_ve..."
 msgstr ""
 
-#: schematic/src/font_select_widget.c:283
+#: schematic/src/font_select_widget.c:237
+msgid ""
+"After you're done choosing the font, it's recommended\n"
+"to reopen schematics or restart the application."
+msgstr ""
+
+#: schematic/src/font_select_widget.c:292
 #, c-format
 msgid "<b>Current:</b> %s"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:470
+#: schematic/src/font_select_widget.c:479
 msgid "Save configuration"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:478
-msgid "Save settings to:"
+#: schematic/src/font_select_widget.c:492
+msgid "Local configuration file:"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:482
-msgid "Local configuration file (in current directory)"
+#: schematic/src/font_select_widget.c:498
+msgid "User configuration file:"
 msgstr ""
 
-#: schematic/src/font_select_widget.c:484
-msgid "User configuration file (geda-user.conf)"
+#: schematic/src/g_attrib.c:93
+msgid "Object ~A is not included in the current lepton-schematic page."
 msgstr ""
 
-#: schematic/src/g_attrib.c:90
-msgid "Object ~A is not included in the current gschem page."
-msgstr ""
-
-#: schematic/src/g_attrib.c:110
+#: schematic/src/g_attrib.c:113
 msgid "Invalid text name/value visibility ~A."
 msgstr ""
 
-#: schematic/src/g_rc.c:107
+#: schematic/src/g_rc.c:89
 #, c-format
-msgid "You are running gEDA/gaf version [%1$s%2$s.%3$s],\n"
+msgid "You are running lepton-schematic version [%1$s%2$s.%3$s],\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:111
+#: schematic/src/g_rc.c:93
 #, c-format
 msgid ""
 "but you have a version [%1$s] gschemrc file:\n"
 "[%2$s]\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:114
+#: schematic/src/g_rc.c:96
 #, c-format
 msgid "Please be sure that you have the latest rc file.\n"
 msgstr ""
 
-#: schematic/src/g_rc.c:240
-#, c-format
-msgid "Invalid size [%1$d] passed to text-size\n"
-msgstr ""
-
-#: schematic/src/g_rc.c:283
-#, c-format
-msgid "Invalid size [%1$d] passed to snap-size\n"
-msgstr ""
-
-#: schematic/src/g_rc.c:560
-#, c-format
-msgid "Invalid num levels [%1$d] passed to undo-levels\n"
-msgstr ""
-
-#: schematic/src/g_rc.c:755
-#, c-format
-msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
-msgstr ""
-
-#: schematic/src/g_rc.c:855
-#, c-format
-msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
-msgstr ""
-
-#: schematic/src/g_rc.c:896
-#, c-format
-msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
-msgstr ""
-
-#: schematic/src/g_rc.c:922
-#, c-format
-msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
-msgstr ""
-
-#: schematic/src/g_rc.c:946
-#, c-format
-msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
-msgstr ""
-
-#: schematic/src/g_rc.c:970
-#, c-format
-msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
-msgstr ""
-
-#: schematic/src/g_rc.c:993
-#, c-format
-msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
-msgstr ""
-
-#: schematic/src/g_rc.c:1017
-#, c-format
-msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
-msgstr ""
-
-#: schematic/src/g_rc.c:1043
-#, c-format
-msgid "Invalid gain [%1$d] passed to zoom-gain\n"
-msgstr ""
-
-#: schematic/src/g_rc.c:1068
-#, c-format
-msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
-msgstr ""
-
-#: schematic/src/g_select.c:78 schematic/src/g_select.c:115
+#: schematic/src/g_select.c:79 schematic/src/g_select.c:116
 #: schematic/src/g_select.c:151
 msgid "Object ~A is not directly included in a page."
 msgstr ""
 
-#: schematic/src/g_util.c:54
+#: schematic/src/g_util.c:56
 msgid "Could not launch URI ~S: ~A"
 msgstr ""
 
-#: schematic/src/g_window.c:139
-msgid "Found invalid gschem window smob ~S"
+#: schematic/src/g_window.c:141
+msgid "Found invalid lepton-schematic window smob ~S"
 msgstr ""
 
 #: schematic/src/lepton-schematic.c:208
@@ -205,14 +150,14 @@ msgstr ""
 msgid "%s (git: %.7s)"
 msgstr ""
 
-#: schematic/src/gschem_about_dialog.c:73
+#: schematic/src/gschem_about_dialog.c:78
 msgid "Lepton Electronic Design Automation"
 msgstr ""
 
-#: schematic/src/gschem_about_dialog.c:81
+#: schematic/src/gschem_about_dialog.c:86
 msgid ""
 "Copyright © 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright © 2017-2019 Lepton Developers.\n"
+"Copyright © 2017-2020 Lepton Developers.\n"
 "See AUTHORS, ChangeLog files and consult 'git log' history for details."
 msgstr ""
 
@@ -354,14 +299,14 @@ msgstr ""
 msgid "World"
 msgstr ""
 
-#: schematic/src/gschem_find_text_state.c:809
-#: schematic/src/page_select_widget.c:501
+#: schematic/src/gschem_find_text_state.c:810
+#: schematic/src/page_select_widget.c:506
 msgid "Filename"
 msgstr ""
 
-#: schematic/src/gschem_find_text_state.c:821 schematic/src/x_colorcb.c:154
-#: schematic/src/x_widgets.c:175 schematic/src/x_window.c:1201
-#: schematic/src/x_window.c:1450
+#: schematic/src/gschem_find_text_state.c:822 schematic/src/x_colorcb.c:154
+#: schematic/src/x_widgets.c:174 schematic/src/x_window.c:1199
+#: schematic/src/x_window.c:1448
 msgid "Text"
 msgstr ""
 
@@ -403,7 +348,7 @@ msgstr ""
 msgid "_Filter:"
 msgstr ""
 
-#: schematic/src/gschem_hotkey_dialog.c:244 schematic/src/x_window.c:1319
+#: schematic/src/gschem_hotkey_dialog.c:244 schematic/src/x_window.c:1317
 msgid "Action"
 msgstr ""
 
@@ -415,15 +360,15 @@ msgstr ""
 msgid "** Invalid UTF-8 in log message. See stderr or gschem.log.\n"
 msgstr ""
 
-#: schematic/src/gschem_log_widget.c:392
+#: schematic/src/gschem_log_widget.c:386
 msgid "Clear log window?"
 msgstr ""
 
-#: schematic/src/gschem_log_widget.c:463
+#: schematic/src/gschem_log_widget.c:457
 msgid "_Wrap Long Lines"
 msgstr ""
 
-#: schematic/src/gschem_log_widget.c:484
+#: schematic/src/gschem_log_widget.c:478
 msgid "Clea_r Log Window"
 msgstr ""
 
@@ -575,12 +520,12 @@ msgid "Preview Buffer"
 msgstr ""
 
 #: schematic/src/gschem_show_hide_text_widget.c:148
-#: schematic/src/x_window.c:1243
+#: schematic/src/x_window.c:1241
 msgid "Hide"
 msgstr ""
 
 #: schematic/src/gschem_show_hide_text_widget.c:157
-#: schematic/src/x_window.c:1244
+#: schematic/src/x_window.c:1242
 msgid "Hide text starting with:"
 msgstr ""
 
@@ -629,9 +574,9 @@ msgstr ""
 msgid "Translate"
 msgstr ""
 
-#: schematic/src/i_basic.c:65 schematic/src/x_window.c:1379
-#: schematic/scheme/conf/schematic/menu.scm:59
-#: schematic/scheme/gschem/builtins.scm:102
+#: schematic/src/i_basic.c:65 schematic/src/x_window.c:1377
+#: schematic/scheme/conf/schematic/menu.scm:61
+#: schematic/scheme/schematic/builtins.scm:103
 msgid "Select Mode"
 msgstr ""
 
@@ -680,13 +625,13 @@ msgstr ""
 msgid "Component Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:83 schematic/scheme/conf/schematic/menu.scm:62
-#: schematic/scheme/gschem/builtins.scm:117
+#: schematic/src/i_basic.c:83 schematic/scheme/conf/schematic/menu.scm:64
+#: schematic/scheme/schematic/builtins.scm:118
 msgid "Copy Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:84 schematic/scheme/conf/schematic/menu.scm:63
-#: schematic/scheme/gschem/builtins.scm:120
+#: schematic/src/i_basic.c:84 schematic/scheme/conf/schematic/menu.scm:65
+#: schematic/scheme/schematic/builtins.scm:121
 msgid "Multiple Copy Mode"
 msgstr ""
 
@@ -694,13 +639,13 @@ msgstr ""
 msgid "Line Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:86 schematic/scheme/conf/schematic/menu.scm:66
-#: schematic/scheme/gschem/builtins.scm:126
+#: schematic/src/i_basic.c:86 schematic/scheme/conf/schematic/menu.scm:68
+#: schematic/scheme/schematic/builtins.scm:127
 msgid "Mirror Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:87 schematic/scheme/conf/schematic/menu.scm:64
-#: schematic/scheme/gschem/builtins.scm:114
+#: schematic/src/i_basic.c:87 schematic/scheme/conf/schematic/menu.scm:66
+#: schematic/scheme/schematic/builtins.scm:115
 msgid "Move Mode"
 msgstr ""
 
@@ -716,7 +661,7 @@ msgstr ""
 msgid "Pin Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:91 schematic/scheme/gschem/builtins.scm:123
+#: schematic/src/i_basic.c:91 schematic/scheme/schematic/builtins.scm:124
 msgid "Rotate Mode"
 msgstr ""
 
@@ -724,8 +669,7 @@ msgstr ""
 msgid "Modify Mode"
 msgstr ""
 
-#: schematic/src/i_basic.c:93 schematic/src/x_menus.c:49
-#: schematic/scheme/gschem/builtins.scm:207
+#: schematic/src/i_basic.c:93 schematic/scheme/schematic/builtins.scm:208
 msgid "Zoom Box"
 msgstr ""
 
@@ -786,7 +730,7 @@ msgid ""
 "should be set to 100"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1522
+#: schematic/src/i_callbacks.c:1530
 #, c-format
 msgid ""
 "<b>Revert page:</b>\n"
@@ -794,27 +738,28 @@ msgid ""
 "\n"
 "Are you sure you want to revert this page?\n"
 "All unsaved changes in current schematic will be\n"
-"discarded and page file will be reloaded from disk."
+"discarded and page file will be reloaded from disk.\n"
+"This action will also reload all component libraries."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1540
+#: schematic/src/i_callbacks.c:1549
 msgid "Revert"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1671
+#: schematic/src/i_callbacks.c:1680
 msgid "Empty clipboard"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:1743
+#: schematic/src/i_callbacks.c:1752
 msgid "Empty buffer"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2135
+#: schematic/src/i_callbacks.c:2144
 #, c-format
 msgid "Searching for source [%1$s]"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2167
+#: schematic/src/i_callbacks.c:2176
 #, c-format
 msgid ""
 "Failed to descend hierarchy into '%1$s': %2$s\n"
@@ -822,86 +767,86 @@ msgid ""
 "The lepton-schematic log may contain more information."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2171
+#: schematic/src/i_callbacks.c:2180
 #, c-format
 msgid "Failed to descend into '%1$s': %2$s"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2178
+#: schematic/src/i_callbacks.c:2187
 msgid "Failed to descend hierarchy."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2256
+#: schematic/src/i_callbacks.c:2265
 #, c-format
 msgid "Searching for symbol [%1$s]"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2264
+#: schematic/src/i_callbacks.c:2274
 msgid "Symbol is not a real file. Symbol cannot be loaded."
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2311 schematic/src/x_tabs.c:1068
+#: schematic/src/i_callbacks.c:2324 schematic/src/x_tabs.c:1097
 msgid "Cannot find any schematics above the current one!"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2469
+#: schematic/src/i_callbacks.c:2482
 #, c-format
 msgid "Sorry but this is a non-functioning menu option\n"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2529
+#: schematic/src/i_callbacks.c:2542
 msgid "Action feedback mode set to OUTLINE"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2532
+#: schematic/src/i_callbacks.c:2545
 msgid "Action feedback mode set to BOUNDINGBOX"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2556
+#: schematic/src/i_callbacks.c:2569
 msgid "Grid OFF"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2557
+#: schematic/src/i_callbacks.c:2570
 msgid "Dot grid selected"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2558
+#: schematic/src/i_callbacks.c:2571
 msgid "Mesh grid selected"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2559
+#: schematic/src/i_callbacks.c:2572
 msgid "Invalid grid mode"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2581
+#: schematic/src/i_callbacks.c:2594
 msgid "Snap OFF (CAUTION!)"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2584
+#: schematic/src/i_callbacks.c:2597
 msgid "Snap ON"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2587
+#: schematic/src/i_callbacks.c:2600
 msgid "Snap back to the grid (CAUTION!)"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2616
+#: schematic/src/i_callbacks.c:2629
 msgid "Rubber band ON"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2618
+#: schematic/src/i_callbacks.c:2631
 msgid "Rubber band OFF"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2637
+#: schematic/src/i_callbacks.c:2650
 msgid "magnetic net mode: ON"
 msgstr ""
 
-#: schematic/src/i_callbacks.c:2640
+#: schematic/src/i_callbacks.c:2653
 msgid "magnetic net mode: OFF"
 msgstr ""
 
-#: schematic/src/o_complex.c:192 schematic/src/o_complex.c:195
+#: schematic/src/o_component.c:198 schematic/src/o_component.c:201
 #, c-format
 msgid "Translating schematic [%1$d %2$d]"
 msgstr ""
@@ -913,27 +858,22 @@ msgid_plural "Delete %1$u locked objects?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: schematic/src/o_misc.c:55
-#, c-format
-msgid "Got an unexpected NULL in o_edit\n"
-msgstr ""
-
-#: schematic/src/o_misc.c:361
+#: schematic/src/o_misc.c:360
 msgid "Hidden text is now visible"
 msgstr ""
 
-#: schematic/src/o_misc.c:363
+#: schematic/src/o_misc.c:362
 msgid "Hidden text is now invisible"
 msgstr ""
 
-#: schematic/src/o_misc.c:471
+#: schematic/src/o_misc.c:470
 #, c-format
 msgid "Could not find symbol [%1$s] in library. Update failed."
 msgstr ""
 
 #: schematic/src/o_misc.c:587
 #, c-format
-msgid "o_autosave_backups: Can't get the real filename of %1$s."
+msgid "Can't get the real filename of %1$s."
 msgstr ""
 
 #: schematic/src/o_misc.c:631
@@ -951,17 +891,12 @@ msgstr ""
 msgid "Could NOT save backup file [%1$s]"
 msgstr ""
 
-#: schematic/src/o_move.c:192
-#, c-format
-msgid "ERROR: NULL object in o_move_end!\n"
-msgstr ""
-
-#: schematic/src/o_move.c:519
+#: schematic/src/o_move.c:516
 #, c-format
 msgid "DOH! tried to find the whichone, but didn't find it!\n"
 msgstr ""
 
-#: schematic/src/o_move.c:546
+#: schematic/src/o_move.c:543
 #, c-format
 msgid "Got a non line object in o_move_check_endpoint\n"
 msgstr ""
@@ -974,13 +909,13 @@ msgstr ""
 msgid "Warning: Ending net at off grid coordinate"
 msgstr ""
 
-#: schematic/src/o_net.c:858 schematic/src/o_net.c:895
-#: schematic/src/o_net.c:966 schematic/src/o_net.c:1002
+#: schematic/src/o_net.c:858 schematic/src/o_net.c:894
+#: schematic/src/o_net.c:964 schematic/src/o_net.c:999
 #, c-format
 msgid "Tried to add more than two bus rippers. Internal gschem error.\n"
 msgstr ""
 
-#: schematic/src/o_net.c:1070
+#: schematic/src/o_net.c:1066
 #, c-format
 msgid "Bus ripper symbol [%1$s] was not found in any component library"
 msgstr ""
@@ -999,27 +934,27 @@ msgstr ""
 msgid "Failed to replace pictures: %s"
 msgstr ""
 
-#: schematic/src/o_slot.c:80
+#: schematic/src/o_slot.c:81
 msgid "Slot attribute malformed"
 msgstr ""
 
-#: schematic/src/o_slot.c:88
+#: schematic/src/o_slot.c:89
 msgid "numslots attribute missing"
 msgstr ""
 
-#: schematic/src/o_slot.c:89
+#: schematic/src/o_slot.c:90
 msgid "Slotting not allowed for this component"
 msgstr ""
 
-#: schematic/src/o_slot.c:104
+#: schematic/src/o_slot.c:105
 msgid "New slot number out of range"
 msgstr ""
 
-#: schematic/src/o_undo.c:398
-msgid "Undo/Redo disabled in rc file"
+#: schematic/src/o_undo.c:397
+msgid "Undo/Redo is disabled in configuration"
 msgstr ""
 
-#: schematic/src/parsecmd.c:73
+#: schematic/src/parsecmd.c:70
 #, c-format
 msgid ""
 "Usage: %1$s [OPTION ...] [--] [FILE ...]\n"
@@ -1038,30 +973,13 @@ msgid ""
 "  -h, --help               Help; this message.\n"
 "  --                       Treat all remaining arguments as filenames.\n"
 "\n"
-"Report bugs at <https://github.com/lepton-eda/lepton-eda/issues>\n"
-"Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>\n"
-msgstr ""
-
-#: schematic/src/parsecmd.c:104
-#, c-format
-msgid ""
-"Lepton EDA %1$s (git: %2$.7s)\n"
-"Copyright (C) 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright (C) 2017-2019 Lepton Developers.\n"
-"This is free software, and you are welcome to redistribute it under\n"
-"certain conditions. For details, see the file `COPYING', which is\n"
-"included in the Lepton EDA distribution.\n"
-"There is NO WARRANTY, to the extent permitted by law.\n"
+"Report bugs at <%2$s>\n"
+"Lepton EDA homepage: <%3$s>\n"
 msgstr ""
 
 #: schematic/src/x_attribedit.c:125
 #, c-format
 msgid "Got invalid show option; defaulting to show both\n"
-msgstr ""
-
-#: schematic/src/x_attribedit.c:139
-#, c-format
-msgid "ERROR: NULL object!\n"
 msgstr ""
 
 #: schematic/src/x_attribedit.c:328
@@ -1080,45 +998,45 @@ msgstr ""
 msgid "N_ame:"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:396 schematic/src/x_multiattrib.c:2262
+#: schematic/src/x_attribedit.c:397 schematic/src/x_multiattrib.c:2262
 msgid "_Value:"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:415 schematic/src/x_multiattrib.c:2321
+#: schematic/src/x_attribedit.c:416 schematic/src/x_multiattrib.c:2321
 msgid "Vi_sible"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:434
+#: schematic/src/x_attribedit.c:435
 msgid "Show Value Only"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:436
+#: schematic/src/x_attribedit.c:437
 msgid "Show Name Only"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:438 schematic/src/x_multiattrib.c:1660
-#: schematic/scheme/gschem/builtins.scm:443
+#: schematic/src/x_attribedit.c:439 schematic/src/x_multiattrib.c:1660
+#: schematic/scheme/schematic/builtins.scm:444
 msgid "Show Name & Value"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:445
+#: schematic/src/x_attribedit.c:446
 msgid "<b>Attach Options</b>"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:460
+#: schematic/src/x_attribedit.c:461
 msgid "All"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:476 schematic/src/x_compselect.c:986
+#: schematic/src/x_attribedit.c:477 schematic/src/x_compselect.c:986
 #: schematic/src/x_compselect.c:1100
 msgid "Components"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:492 schematic/src/x_window.c:1189
+#: schematic/src/x_attribedit.c:493 schematic/src/x_window.c:1187
 msgid "Nets"
 msgstr ""
 
-#: schematic/src/x_attribedit.c:508
+#: schematic/src/x_attribedit.c:509
 msgid "Replace existing attributes"
 msgstr ""
 
@@ -1135,7 +1053,7 @@ msgid ""
 msgstr ""
 
 #: schematic/src/x_autonumber.c:675
-msgid "No searchstring given in autonumber text."
+msgid "No search string given in autonumber text."
 msgstr ""
 
 #: schematic/src/x_autonumber.c:728
@@ -1166,59 +1084,59 @@ msgstr ""
 msgid "File order"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1214
+#: schematic/src/x_autonumber.c:1215
 msgid "Autonumber text"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1237
+#: schematic/src/x_autonumber.c:1238
 msgid "<b>Scope</b>"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1259
+#: schematic/src/x_autonumber.c:1260
 msgid "Search for:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1273
+#: schematic/src/x_autonumber.c:1274
 msgid "Autonumber text in:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1280
+#: schematic/src/x_autonumber.c:1281
 msgid "Skip numbers found in:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1292 schematic/src/x_autonumber.c:1301
+#: schematic/src/x_autonumber.c:1293 schematic/src/x_autonumber.c:1302
 msgid "Selected objects"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1293 schematic/src/x_autonumber.c:1302
+#: schematic/src/x_autonumber.c:1294 schematic/src/x_autonumber.c:1303
 msgid "Current page"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1294 schematic/src/x_autonumber.c:1303
+#: schematic/src/x_autonumber.c:1295 schematic/src/x_autonumber.c:1304
 msgid "Whole hierarchy"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1305
+#: schematic/src/x_autonumber.c:1306
 msgid "Overwrite existing numbers"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1310
+#: schematic/src/x_autonumber.c:1311
 msgid "<b>Options</b>"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1332
+#: schematic/src/x_autonumber.c:1333
 msgid "Starting number:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1339
+#: schematic/src/x_autonumber.c:1340
 msgid "Sort order:"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1371
+#: schematic/src/x_autonumber.c:1372
 msgid "Remove numbers"
 msgstr ""
 
-#: schematic/src/x_autonumber.c:1375
+#: schematic/src/x_autonumber.c:1376
 msgid "Automatic slotting"
 msgstr ""
 
@@ -1234,30 +1152,7 @@ msgstr ""
 msgid "Clipboard insertion failed"
 msgstr ""
 
-#: schematic/src/x_color.c:89 schematic/src/x_color.c:98
-#, c-format
-msgid "Could not allocate the color %1$s!\n"
-msgstr ""
-
-#: schematic/src/x_color.c:89
-msgid "black"
-msgstr ""
-
-#: schematic/src/x_color.c:98
-msgid "white"
-msgstr ""
-
-#: schematic/src/x_color.c:120
-#, c-format
-msgid "Could not allocate display color %1$i!\n"
-msgstr ""
-
-#: schematic/src/x_color.c:142
-#, c-format
-msgid "Could not allocate outline color %1$i!\n"
-msgstr ""
-
-#: schematic/src/x_color.c:159
+#: schematic/src/x_color.c:160
 #, c-format
 msgid "Tried to get an invalid color: %1$d\n"
 msgstr ""
@@ -1298,7 +1193,7 @@ msgstr ""
 msgid "Detached attribute"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:155 schematic/src/x_window.c:1197
+#: schematic/src/x_colorcb.c:155 schematic/src/x_window.c:1195
 msgid "Bus"
 msgstr ""
 
@@ -1314,12 +1209,12 @@ msgstr ""
 msgid "Zoom box"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:159 schematic/src/x_window.c:1315
+#: schematic/src/x_colorcb.c:159 schematic/src/x_window.c:1313
 msgid "Stroke"
 msgstr ""
 
-#: schematic/src/x_colorcb.c:160 schematic/scheme/conf/schematic/menu.scm:73
-#: schematic/scheme/gschem/builtins.scm:144
+#: schematic/src/x_colorcb.c:160 schematic/scheme/conf/schematic/menu.scm:75
+#: schematic/scheme/schematic/builtins.scm:145
 msgid "Lock"
 msgstr ""
 
@@ -1395,7 +1290,7 @@ msgstr ""
 msgid "Lib_raries"
 msgstr ""
 
-#: schematic/src/x_compselect.c:1484 schematic/src/x_fileselect.c:197
+#: schematic/src/x_compselect.c:1484 schematic/src/x_fileselect.c:283
 msgid "Preview"
 msgstr ""
 
@@ -1434,34 +1329,34 @@ msgid "Invalid Attribute"
 msgstr ""
 
 #: schematic/src/x_fileselect.c:57
-msgid "Schematics"
+msgid "Schematics (*.sch)"
 msgstr ""
 
 #: schematic/src/x_fileselect.c:69
-msgid "Symbols"
+msgid "Symbols (*.sym)"
 msgstr ""
 
 #: schematic/src/x_fileselect.c:79
-msgid "Schematics and symbols"
+msgid "Schematics and symbols (*.sch *.sym)"
 msgstr ""
 
 #: schematic/src/x_fileselect.c:90
 msgid "All files"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:247
+#: schematic/src/x_fileselect.c:333
 msgid "Open..."
 msgstr ""
 
-#: schematic/src/x_fileselect.c:328
+#: schematic/src/x_fileselect.c:418
 msgid "Save as..."
 msgstr ""
 
-#: schematic/src/x_fileselect.c:415
+#: schematic/src/x_fileselect.c:513
 msgid "Save cancelled on user request"
 msgstr ""
 
-#: schematic/src/x_fileselect.c:468
+#: schematic/src/x_fileselect.c:566
 msgid ""
 "\n"
 "If you load the original file, the backup file will be overwritten in the "
@@ -1486,12 +1381,12 @@ msgstr ""
 msgid "Hatch"
 msgstr ""
 
-#: schematic/src/x_image.c:406
+#: schematic/src/x_image.c:407
 #, c-format
-msgid "x_image_lowlevel: Unable to write %1$s file %2$s."
+msgid "Unable to write %1$s file %2$s."
 msgstr ""
 
-#: schematic/src/x_image.c:416
+#: schematic/src/x_image.c:417
 #, c-format
 msgid ""
 "There was the following error when saving image with type %1$s to filename:\n"
@@ -1500,45 +1395,45 @@ msgid ""
 "%3$s.\n"
 msgstr ""
 
-#: schematic/src/x_image.c:436
+#: schematic/src/x_image.c:437
 #, c-format
 msgid "Wrote color image to [%1$s] [%2$d x %3$d]"
 msgstr ""
 
-#: schematic/src/x_image.c:438
+#: schematic/src/x_image.c:439
 #, c-format
 msgid "Wrote black and white image to [%1$s] [%2$d x %3$d]"
 msgstr ""
 
-#: schematic/src/x_image.c:446
-msgid "x_image_lowlevel: Unable to get pixbuf from gschem's window."
+#: schematic/src/x_image.c:448
+msgid "Unable to get pixbuf from lepton-schematic's window."
 msgstr ""
 
-#: schematic/src/x_image.c:487
+#: schematic/src/x_image.c:489
 msgid "NOTE: print-color-map will be used for PDF export"
 msgstr ""
 
-#: schematic/src/x_image.c:496
+#: schematic/src/x_image.c:498
 msgid "Width x Height"
 msgstr ""
 
-#: schematic/src/x_image.c:512
+#: schematic/src/x_image.c:514
 msgid "Image type"
 msgstr ""
 
-#: schematic/src/x_image.c:527
+#: schematic/src/x_image.c:529
 msgid "Color mode"
 msgstr ""
 
-#: schematic/src/x_image.c:534
+#: schematic/src/x_image.c:536
 msgid "Color"
 msgstr ""
 
-#: schematic/src/x_image.c:535
+#: schematic/src/x_image.c:537
 msgid "Grayscale"
 msgstr ""
 
-#: schematic/src/x_image.c:551
+#: schematic/src/x_image.c:553
 msgid "Write image..."
 msgstr ""
 
@@ -1574,85 +1469,64 @@ msgstr ""
 msgid "Phantom"
 msgstr ""
 
-#: schematic/src/x_menus.c:41 schematic/scheme/gschem/builtins.scm:270
-msgid "Add Net"
+#: schematic/src/x_menus.c:43
+msgid "Add Co_mponent..."
 msgstr ""
 
-#: schematic/src/x_menus.c:42 schematic/src/x_multiattrib.c:2227
-#: schematic/scheme/gschem/builtins.scm:267
-msgid "Add Attribute"
+#: schematic/src/x_menus.c:44
+msgid "Add Te_xt..."
 msgstr ""
 
-#: schematic/src/x_menus.c:43 schematic/scheme/gschem/builtins.scm:264
-msgid "Add Component"
+#: schematic/src/x_menus.c:45
+msgid "Add _Attribute..."
 msgstr ""
 
-#: schematic/src/x_menus.c:44 schematic/scheme/gschem/builtins.scm:273
-msgid "Add Bus"
+#: schematic/src/x_menus.c:47
+msgid "Add _Net"
 msgstr ""
 
-#: schematic/src/x_menus.c:45 schematic/scheme/gschem/builtins.scm:276
-msgid "Add Text"
+#: schematic/src/x_menus.c:48
+msgid "Add _Bus"
 msgstr ""
 
-#: schematic/src/x_menus.c:47 schematic/scheme/gschem/builtins.scm:213
-msgid "Zoom In"
+#: schematic/src/x_menus.c:50 schematic/scheme/conf/schematic/menu.scm:56
+msgid "Cu_t"
 msgstr ""
 
-#: schematic/src/x_menus.c:48 schematic/scheme/gschem/builtins.scm:216
-msgid "Zoom Out"
+#: schematic/src/x_menus.c:51 schematic/scheme/conf/schematic/menu.scm:57
+msgid "_Copy"
 msgstr ""
 
-#: schematic/src/x_menus.c:50 schematic/scheme/gschem/builtins.scm:210
-msgid "Zoom Extents"
+#: schematic/src/x_menus.c:52 schematic/scheme/conf/schematic/menu.scm:58
+msgid "_Paste"
 msgstr ""
 
-#: schematic/src/x_menus.c:52 schematic/src/x_window.c:1208
-msgid "Select"
+#: schematic/src/x_menus.c:53 schematic/scheme/conf/schematic/menu.scm:59
+msgid "_Delete"
 msgstr ""
 
-#: schematic/src/x_menus.c:53 schematic/scheme/conf/schematic/menu.scm:69
-#: schematic/scheme/gschem/builtins.scm:129
-msgid "Edit..."
-msgstr ""
-
-#: schematic/src/x_menus.c:54 schematic/scheme/conf/schematic/menu.scm:68
-msgid "Object Properties..."
-msgstr ""
-
-#: schematic/src/x_menus.c:55 schematic/scheme/gschem/builtins.scm:171
-msgid "Copy"
+#: schematic/src/x_menus.c:55
+msgid "_Edit..."
 msgstr ""
 
 #: schematic/src/x_menus.c:56
-msgid "Move"
+msgid "Ed_it Text..."
 msgstr ""
 
-#: schematic/src/x_menus.c:57 schematic/src/x_multiattrib.c:1696
-#: schematic/scheme/gschem/builtins.scm:111
-msgid "Delete"
+#: schematic/src/x_menus.c:57
+msgid "_Object Properties..."
 msgstr ""
 
-#: schematic/src/x_menus.c:59 schematic/scheme/gschem/builtins.scm:303
-msgid "Down Schematic"
+#: schematic/src/x_menus.c:59
+msgid "Hierarchy: Down _Schematic"
 msgstr ""
 
-#: schematic/src/x_menus.c:60 schematic/scheme/gschem/builtins.scm:306
-msgid "Down Symbol"
+#: schematic/src/x_menus.c:60
+msgid "Hierarchy: Down S_ymbol"
 msgstr ""
 
 #: schematic/src/x_menus.c:61
-msgid "Up"
-msgstr ""
-
-#: schematic/src/x_menus.c:354
-#, c-format
-msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
-msgstr ""
-
-#: schematic/src/x_menus.c:378
-#, c-format
-msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
+msgid "Hierarchy: _Up"
 msgstr ""
 
 #: schematic/src/x_misc.c:70
@@ -1683,6 +1557,11 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
+#: schematic/src/x_multiattrib.c:1696
+#: schematic/scheme/schematic/builtins.scm:112
+msgid "Delete"
+msgstr ""
+
 #: schematic/src/x_multiattrib.c:1697
 msgid "Copy to all"
 msgstr ""
@@ -1705,6 +1584,11 @@ msgstr ""
 
 #: schematic/src/x_multiattrib.c:2210
 msgid "Sho_w inherited attributes"
+msgstr ""
+
+#: schematic/src/x_multiattrib.c:2227
+#: schematic/scheme/schematic/builtins.scm:268
+msgid "Add Attribute"
 msgstr ""
 
 #: schematic/src/x_multiattrib.c:2237
@@ -1754,28 +1638,28 @@ msgstr[1] ""
 msgid "Text Entry..."
 msgstr ""
 
-#: schematic/src/page_select_widget.c:388
+#: schematic/src/page_select_widget.c:393
 msgid "Refresh"
 msgstr ""
 
-#: schematic/src/page_select_widget.c:390
+#: schematic/src/page_select_widget.c:395
 msgid "New Page"
 msgstr ""
 
-#: schematic/src/page_select_widget.c:391
+#: schematic/src/page_select_widget.c:396
 msgid "Open Page..."
 msgstr ""
 
-#: schematic/src/page_select_widget.c:393
+#: schematic/src/page_select_widget.c:398
 msgid "Save Page"
 msgstr ""
 
-#: schematic/src/page_select_widget.c:394
-#: schematic/scheme/gschem/builtins.scm:249
+#: schematic/src/page_select_widget.c:399
+#: schematic/scheme/schematic/builtins.scm:250
 msgid "Close Page"
 msgstr ""
 
-#: schematic/src/page_select_widget.c:517
+#: schematic/src/page_select_widget.c:522
 msgid "Changed"
 msgstr ""
 
@@ -1789,7 +1673,7 @@ msgstr ""
 msgid "Failed to write PDF to '%1$s': %2$s\n"
 msgstr ""
 
-#: schematic/src/x_print.c:452
+#: schematic/src/x_print.c:456
 #, c-format
 msgid ""
 "Error printing file:\n"
@@ -1824,7 +1708,7 @@ msgstr ""
 msgid "Cannot load lepton-schematic configuration."
 msgstr ""
 
-#: schematic/src/x_script.c:42 schematic/scheme/conf/schematic/menu.scm:39
+#: schematic/src/x_script.c:42 schematic/scheme/conf/schematic/menu.scm:41
 msgid "Execute Script..."
 msgstr ""
 
@@ -1833,126 +1717,150 @@ msgstr ""
 msgid "Executing guile script [%1$s]"
 msgstr ""
 
-#: schematic/src/x_tabs.c:868
+#: schematic/src/x_tabs.c:886
 #, c-format
 msgid "Hierarchy up: %s"
 msgstr ""
 
-#: schematic/src/x_tabs.c:871
+#: schematic/src/x_tabs.c:889
 msgid "Hierarchy up"
 msgstr ""
 
-#: schematic/src/x_widgets.c:154 schematic/src/x_window.c:1454
+#: schematic/src/x_tabs.c:1562 schematic/scheme/conf/schematic/menu.scm:29
+msgid "_New"
+msgstr ""
+
+#: schematic/src/x_tabs.c:1563 schematic/scheme/conf/schematic/menu.scm:30
+msgid "_Open..."
+msgstr ""
+
+#: schematic/src/x_tabs.c:1565 schematic/scheme/conf/schematic/menu.scm:33
+msgid "_Save"
+msgstr ""
+
+#: schematic/src/x_tabs.c:1566 schematic/scheme/conf/schematic/menu.scm:34
+msgid "Save _As..."
+msgstr ""
+
+#: schematic/src/x_tabs.c:1568
+msgid "Page _Manager..."
+msgstr ""
+
+#: schematic/src/x_tabs.c:1570 schematic/scheme/conf/schematic/menu.scm:209
+msgid "_Close"
+msgstr ""
+
+#: schematic/src/x_widgets.c:153 schematic/src/x_window.c:1452
 msgid "Options"
 msgstr ""
 
-#: schematic/src/x_widgets.c:199 schematic/src/x_window.c:1446
+#: schematic/src/x_widgets.c:198 schematic/src/x_window.c:1444
 msgid "Object"
 msgstr ""
 
-#: schematic/src/x_widgets.c:220
+#: schematic/src/x_widgets.c:219
 msgid "Log"
 msgstr ""
 
-#: schematic/src/x_widgets.c:241 schematic/src/x_window.c:1476
+#: schematic/src/x_widgets.c:240 schematic/src/x_window.c:1474
 msgid "Find Text"
 msgstr ""
 
-#: schematic/src/x_widgets.c:255
+#: schematic/src/x_widgets.c:254
 msgid "Color Scheme Editor"
 msgstr ""
 
-#: schematic/src/x_widgets.c:268 schematic/scheme/gschem/builtins.scm:497
+#: schematic/src/x_widgets.c:267 schematic/scheme/schematic/builtins.scm:498
 msgid "Select Schematic Font"
 msgstr ""
 
-#: schematic/src/x_widgets.c:281 schematic/scheme/gschem/builtins.scm:240
+#: schematic/src/x_widgets.c:280 schematic/scheme/schematic/builtins.scm:241
 msgid "Page Manager"
 msgstr ""
 
-#: schematic/src/x_window.c:738
+#: schematic/src/x_window.c:736
 #, c-format
 msgid "Loading schematic [%1$s]"
 msgstr ""
 
-#: schematic/src/x_window.c:839
+#: schematic/src/x_window.c:837
 #, c-format
 msgid "Could NOT save page [%1$s]\n"
 msgstr ""
 
-#: schematic/src/x_window.c:840
+#: schematic/src/x_window.c:838
 msgid "Error while trying to save"
 msgstr ""
 
-#: schematic/src/x_window.c:850
+#: schematic/src/x_window.c:848
 msgid "Failed to save file"
 msgstr ""
 
-#: schematic/src/x_window.c:860
+#: schematic/src/x_window.c:858
 #, c-format
 msgid "Saved as [%1$s]"
 msgstr ""
 
-#: schematic/src/x_window.c:862
+#: schematic/src/x_window.c:860
 #, c-format
 msgid "Saved [%1$s]"
 msgstr ""
 
-#: schematic/src/x_window.c:864
+#: schematic/src/x_window.c:862
 msgid "Saved"
 msgstr ""
 
-#: schematic/src/x_window.c:941
+#: schematic/src/x_window.c:939
 #, c-format
 msgid "Discarding page [%1$s]"
 msgstr ""
 
-#: schematic/src/x_window.c:941
+#: schematic/src/x_window.c:939
 #, c-format
 msgid "Closing [%1$s]"
 msgstr ""
 
-#: schematic/src/x_window.c:1150
+#: schematic/src/x_window.c:1148
 msgid "New"
 msgstr ""
 
-#: schematic/src/x_window.c:1150
+#: schematic/src/x_window.c:1148
 msgid "New file"
 msgstr ""
 
-#: schematic/src/x_window.c:1154
+#: schematic/src/x_window.c:1152
 msgid "Open"
 msgstr ""
 
-#: schematic/src/x_window.c:1154
+#: schematic/src/x_window.c:1152
 msgid "Open file"
 msgstr ""
 
-#: schematic/src/x_window.c:1158 schematic/scheme/gschem/builtins.scm:62
+#: schematic/src/x_window.c:1156 schematic/scheme/schematic/builtins.scm:63
 msgid "Save"
 msgstr ""
 
-#: schematic/src/x_window.c:1158
+#: schematic/src/x_window.c:1156
 msgid "Save file"
 msgstr ""
 
-#: schematic/src/x_window.c:1164 schematic/scheme/gschem/builtins.scm:96
+#: schematic/src/x_window.c:1162 schematic/scheme/schematic/builtins.scm:97
 msgid "Undo"
 msgstr ""
 
-#: schematic/src/x_window.c:1164
+#: schematic/src/x_window.c:1162
 msgid "Undo last operation"
 msgstr ""
 
-#: schematic/src/x_window.c:1168 schematic/scheme/gschem/builtins.scm:99
+#: schematic/src/x_window.c:1166 schematic/scheme/schematic/builtins.scm:100
 msgid "Redo"
 msgstr ""
 
-#: schematic/src/x_window.c:1168
+#: schematic/src/x_window.c:1166
 msgid "Redo last undo"
 msgstr ""
 
-#: schematic/src/x_window.c:1173
+#: schematic/src/x_window.c:1171
 msgid ""
 "Add component...\n"
 "Select library and component from list, move the mouse into main window, "
@@ -1960,73 +1868,77 @@ msgid ""
 "Right mouse button to cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1178
+#: schematic/src/x_window.c:1176
 msgid "Component"
 msgstr ""
 
-#: schematic/src/x_window.c:1184
+#: schematic/src/x_window.c:1182
 msgid ""
 "Add nets mode\n"
 "Right mouse button to cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1192
+#: schematic/src/x_window.c:1190
 msgid ""
 "Add buses mode\n"
 "Right mouse button to cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1201
+#: schematic/src/x_window.c:1199
 msgid "Add Text..."
 msgstr ""
 
-#: schematic/src/x_window.c:1208
+#: schematic/src/x_window.c:1206
+msgid "Select"
+msgstr ""
+
+#: schematic/src/x_window.c:1206
 msgid "Select mode"
 msgstr ""
 
-#: schematic/src/x_window.c:1263
+#: schematic/src/x_window.c:1261
 msgid "Show"
 msgstr ""
 
-#: schematic/src/x_window.c:1264
+#: schematic/src/x_window.c:1262
 msgid "Show text starting with:"
 msgstr ""
 
-#: schematic/src/x_window.c:1311 schematic/src/x_window.c:1346
+#: schematic/src/x_window.c:1309 schematic/src/x_window.c:1344
 msgid "none"
 msgstr ""
 
-#: schematic/src/x_window.c:1322
+#: schematic/src/x_window.c:1320
 msgid "Repeat"
 msgstr ""
 
-#: schematic/src/x_window.c:1325 schematic/src/x_window.c:1342
-#: schematic/scheme/gschem/builtins.scm:192
+#: schematic/src/x_window.c:1323 schematic/src/x_window.c:1340
+#: schematic/scheme/schematic/builtins.scm:193
 msgid "Pan"
 msgstr ""
 
-#: schematic/src/x_window.c:1328 schematic/src/x_window.c:1337
+#: schematic/src/x_window.c:1326 schematic/src/x_window.c:1335
 msgid "Menu"
 msgstr ""
 
-#: schematic/src/x_window.c:1351
+#: schematic/src/x_window.c:1349
 msgid "/Cancel"
 msgstr ""
 
-#: schematic/src/x_window.c:1369
+#: schematic/src/x_window.c:1367
 msgid "Pick"
 msgstr ""
 
-#: schematic/src/x_window.c:1480 schematic/scheme/gschem/builtins.scm:183
+#: schematic/src/x_window.c:1478 schematic/scheme/schematic/builtins.scm:184
 msgid "Status"
 msgstr ""
 
-#: schematic/src/x_window.c:1578
+#: schematic/src/x_window.c:1576
 #, c-format
 msgid "New file [%s]"
 msgstr ""
 
-#: schematic/src/x_window.c:1608
+#: schematic/src/x_window.c:1606
 #, c-format
 msgid ""
 "<b>An error occurred while loading the requested file.</b>\n"
@@ -2040,11 +1952,11 @@ msgid ""
 "monitor program's output in terminal window."
 msgstr ""
 
-#: schematic/src/x_window.c:1627
+#: schematic/src/x_window.c:1625
 msgid "Failed to load file"
 msgstr ""
 
-#: schematic/src/x_window.c:1726
+#: schematic/src/x_window.c:1724
 #, c-format
 msgid "Skipping existing file [%s]"
 msgstr ""
@@ -2057,830 +1969,851 @@ msgstr ""
 msgid "Create and edit electrical schematics and symbols with lepton-schematic"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:27
-msgid "_New"
-msgstr ""
-
-#: schematic/scheme/conf/schematic/menu.scm:28
-msgid "_Open..."
-msgstr ""
-
-#: schematic/scheme/conf/schematic/menu.scm:29
+#: schematic/scheme/conf/schematic/menu.scm:31
 msgid "Open Recen_t"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:31
-msgid "_Save"
-msgstr ""
-
-#: schematic/scheme/conf/schematic/menu.scm:32
-msgid "Save _As..."
-msgstr ""
-
-#: schematic/scheme/conf/schematic/menu.scm:33
-#: schematic/scheme/gschem/builtins.scm:68
+#: schematic/scheme/conf/schematic/menu.scm:35
+#: schematic/scheme/schematic/builtins.scm:69
 msgid "Save All"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:35
+#: schematic/scheme/conf/schematic/menu.scm:37
 msgid "_Print..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:36
+#: schematic/scheme/conf/schematic/menu.scm:38
 msgid "Write _Image..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:38
+#: schematic/scheme/conf/schematic/menu.scm:40
 msgid "Invoke Macro..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:40
+#: schematic/scheme/conf/schematic/menu.scm:42
 msgid "REPL..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:42
-#: schematic/scheme/gschem/builtins.scm:80
+#: schematic/scheme/conf/schematic/menu.scm:44
+#: schematic/scheme/schematic/builtins.scm:81
 msgid "New Window"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:43
+#: schematic/scheme/conf/schematic/menu.scm:45
 msgid "_Close Window"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:44
+#: schematic/scheme/conf/schematic/menu.scm:46
 msgid "_Quit"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:51
+#: schematic/scheme/conf/schematic/menu.scm:53
 msgid "_Undo"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:52
+#: schematic/scheme/conf/schematic/menu.scm:54
 msgid "_Redo"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:54
-msgid "Cu_t"
-msgstr ""
-
-#: schematic/scheme/conf/schematic/menu.scm:55
-msgid "_Copy"
-msgstr ""
-
-#: schematic/scheme/conf/schematic/menu.scm:56
-msgid "_Paste"
-msgstr ""
-
-#: schematic/scheme/conf/schematic/menu.scm:57
-msgid "_Delete"
-msgstr ""
-
-#: schematic/scheme/conf/schematic/menu.scm:60
-#: schematic/scheme/gschem/builtins.scm:105
+#: schematic/scheme/conf/schematic/menu.scm:62
+#: schematic/scheme/schematic/builtins.scm:106
 msgid "Select All"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:61
-#: schematic/scheme/gschem/builtins.scm:108
+#: schematic/scheme/conf/schematic/menu.scm:63
+#: schematic/scheme/schematic/builtins.scm:109
 msgid "Deselect"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:65
+#: schematic/scheme/conf/schematic/menu.scm:67
 msgid "Rotate 90 Mode"
 msgstr ""
 
 #: schematic/scheme/conf/schematic/menu.scm:70
-msgid "Edit Text..."
+msgid "Object Properties..."
 msgstr ""
 
 #: schematic/scheme/conf/schematic/menu.scm:71
+#: schematic/scheme/schematic/builtins.scm:130
+msgid "Edit..."
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:72
+msgid "Edit Text..."
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:73
 msgid "Slot..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:74
-#: schematic/scheme/gschem/builtins.scm:147
+#: schematic/scheme/conf/schematic/menu.scm:76
+#: schematic/scheme/schematic/builtins.scm:148
 msgid "Unlock"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:76
-#: schematic/scheme/gschem/builtins.scm:153
+#: schematic/scheme/conf/schematic/menu.scm:78
+#: schematic/scheme/schematic/builtins.scm:154
 msgid "Embed Component/Picture"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:77
-#: schematic/scheme/gschem/builtins.scm:156
+#: schematic/scheme/conf/schematic/menu.scm:79
+#: schematic/scheme/schematic/builtins.scm:157
 msgid "Unembed Component/Picture"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:78
-#: schematic/scheme/gschem/builtins.scm:159
+#: schematic/scheme/conf/schematic/menu.scm:80
+#: schematic/scheme/schematic/builtins.scm:160
 msgid "Update Component"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:79
+#: schematic/scheme/conf/schematic/menu.scm:81
 msgid "Symbol Translate..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:86
+#: schematic/scheme/conf/schematic/menu.scm:88
 msgid "Copy into 1"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:87
+#: schematic/scheme/conf/schematic/menu.scm:89
 msgid "Copy into 2"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:88
+#: schematic/scheme/conf/schematic/menu.scm:90
 msgid "Copy into 3"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:89
+#: schematic/scheme/conf/schematic/menu.scm:91
 msgid "Copy into 4"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:90
+#: schematic/scheme/conf/schematic/menu.scm:92
 msgid "Copy into 5"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:91
+#: schematic/scheme/conf/schematic/menu.scm:93
 msgid "Cut into 1"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:92
+#: schematic/scheme/conf/schematic/menu.scm:94
 msgid "Cut into 2"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:93
+#: schematic/scheme/conf/schematic/menu.scm:95
 msgid "Cut into 3"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:94
+#: schematic/scheme/conf/schematic/menu.scm:96
 msgid "Cut into 4"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:95
+#: schematic/scheme/conf/schematic/menu.scm:97
 msgid "Cut into 5"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:96
+#: schematic/scheme/conf/schematic/menu.scm:98
 msgid "Paste from 1"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:97
+#: schematic/scheme/conf/schematic/menu.scm:99
 msgid "Paste from 2"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:98
+#: schematic/scheme/conf/schematic/menu.scm:100
 msgid "Paste from 3"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:99
+#: schematic/scheme/conf/schematic/menu.scm:101
 msgid "Paste from 4"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:100
+#: schematic/scheme/conf/schematic/menu.scm:102
 msgid "Paste from 5"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:124
+#: schematic/scheme/conf/schematic/menu.scm:144
 msgid "Side Dock"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:125
+#: schematic/scheme/conf/schematic/menu.scm:145
 msgid "Bottom Dock"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:127
+#: schematic/scheme/conf/schematic/menu.scm:147
 msgid "Find Text Results"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:129
+#: schematic/scheme/conf/schematic/menu.scm:149
 msgid "_Redraw"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:130
+#: schematic/scheme/conf/schematic/menu.scm:150
 msgid "_Pan"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:131
+#: schematic/scheme/conf/schematic/menu.scm:151
 msgid "Zoom _Box"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:132
+#: schematic/scheme/conf/schematic/menu.scm:152
 msgid "Zoom _Extents"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:133
+#: schematic/scheme/conf/schematic/menu.scm:153
 msgid "Zoom _In"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:134
+#: schematic/scheme/conf/schematic/menu.scm:154
 msgid "Zoom _Out"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:135
+#: schematic/scheme/conf/schematic/menu.scm:155
 msgid "Zoom _Full"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:137
+#: schematic/scheme/conf/schematic/menu.scm:157
 msgid "_Dark Color Scheme"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:138
+#: schematic/scheme/conf/schematic/menu.scm:158
 msgid "_Light Color Scheme"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:139
+#: schematic/scheme/conf/schematic/menu.scm:159
 msgid "B_W Color Scheme"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:141
+#: schematic/scheme/conf/schematic/menu.scm:161
 msgid "Color Scheme Editor..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:167
+#: schematic/scheme/conf/schematic/menu.scm:205
 msgid "_Manager..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:169
+#: schematic/scheme/conf/schematic/menu.scm:207
 msgid "_Previous"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:170
+#: schematic/scheme/conf/schematic/menu.scm:208
 msgid "_Next"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:171
-msgid "_Close"
-msgstr ""
-
-#: schematic/scheme/conf/schematic/menu.scm:173
+#: schematic/scheme/conf/schematic/menu.scm:211
 msgid "_Revert..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:175
-#: schematic/scheme/gschem/builtins.scm:252
+#: schematic/scheme/conf/schematic/menu.scm:213
+#: schematic/scheme/schematic/builtins.scm:253
 msgid "Next Tab"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:176
-#: schematic/scheme/gschem/builtins.scm:255
+#: schematic/scheme/conf/schematic/menu.scm:214
+#: schematic/scheme/schematic/builtins.scm:256
 msgid "Previous Tab"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:185
+#: schematic/scheme/conf/schematic/menu.scm:223
 msgid "_Component..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:187
+#: schematic/scheme/conf/schematic/menu.scm:225
 msgid "_Net"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:188
+#: schematic/scheme/conf/schematic/menu.scm:226
 msgid "B_us"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:190
+#: schematic/scheme/conf/schematic/menu.scm:228
 msgid "_Attribute..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:191
+#: schematic/scheme/conf/schematic/menu.scm:229
 msgid "_Text..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:193
+#: schematic/scheme/conf/schematic/menu.scm:231
 msgid "_Line"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:194
+#: schematic/scheme/conf/schematic/menu.scm:232
 msgid "Pat_h"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:195
+#: schematic/scheme/conf/schematic/menu.scm:233
 msgid "_Box"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:196
+#: schematic/scheme/conf/schematic/menu.scm:234
 msgid "C_ircle"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:197
+#: schematic/scheme/conf/schematic/menu.scm:235
 msgid "A_rc"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:198
+#: schematic/scheme/conf/schematic/menu.scm:236
 msgid "_Pin"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:200
+#: schematic/scheme/conf/schematic/menu.scm:238
 msgid "Pictu_re..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:207
+#: schematic/scheme/conf/schematic/menu.scm:245
 msgid "_Up"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:209
+#: schematic/scheme/conf/schematic/menu.scm:247
 msgid "_Down Schematic"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:210
+#: schematic/scheme/conf/schematic/menu.scm:248
 msgid "Down _Symbol"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:217
+#: schematic/scheme/conf/schematic/menu.scm:255
 msgid "_Attach"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:218
+#: schematic/scheme/conf/schematic/menu.scm:256
 msgid "_Detach"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:220
+#: schematic/scheme/conf/schematic/menu.scm:258
 msgid "Show _Value"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:221
+#: schematic/scheme/conf/schematic/menu.scm:259
 msgid "Show _Name"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:222
+#: schematic/scheme/conf/schematic/menu.scm:260
 msgid "Show _Both"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:223
+#: schematic/scheme/conf/schematic/menu.scm:261
 msgid "_Toggle Visibility"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:225
+#: schematic/scheme/conf/schematic/menu.scm:263
 msgid "_Hide Specific Text..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:226
+#: schematic/scheme/conf/schematic/menu.scm:264
 msgid "_Show Specific Text..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:227
+#: schematic/scheme/conf/schematic/menu.scm:265
 msgid "Show/Hide Hidden Text"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:229
+#: schematic/scheme/conf/schematic/menu.scm:267
 msgid "_Find Text/Check Symbol..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:230
+#: schematic/scheme/conf/schematic/menu.scm:268
 msgid "A_utonumber Text..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:237
+#: schematic/scheme/conf/schematic/menu.scm:275
 msgid "_Options..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:238
+#: schematic/scheme/conf/schematic/menu.scm:276
 msgid "_Font..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:240
+#: schematic/scheme/conf/schematic/menu.scm:278
 msgid "Grid +"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:241
+#: schematic/scheme/conf/schematic/menu.scm:279
 msgid "Grid -"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:243
+#: schematic/scheme/conf/schematic/menu.scm:281
 msgid "Grid Style: Cycle Dots/Mesh/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:244
+#: schematic/scheme/conf/schematic/menu.scm:282
 msgid "Grid Snap: Cycle Grid/Resnap/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:246
+#: schematic/scheme/conf/schematic/menu.scm:284
+msgid "Grips: On/Off"
+msgstr ""
+
+#: schematic/scheme/conf/schematic/menu.scm:285
 msgid "Feedback Mode: Outline/Box"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:247
+#: schematic/scheme/conf/schematic/menu.scm:286
 msgid "Net: Rubberband On/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:248
+#: schematic/scheme/conf/schematic/menu.scm:287
 msgid "Net: Magnetic On/Off"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:250
+#: schematic/scheme/conf/schematic/menu.scm:289
 msgid "_Coord Window"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:251
+#: schematic/scheme/conf/schematic/menu.scm:290
 msgid "_Log Window"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:258
+#: schematic/scheme/conf/schematic/menu.scm:297
 msgid "_1 allegro"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:265
+#: schematic/scheme/conf/schematic/menu.scm:304
 msgid "User _Guide"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:266
+#: schematic/scheme/conf/schematic/menu.scm:305
 msgid "_FAQ"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:267
+#: schematic/scheme/conf/schematic/menu.scm:306
 msgid "Docu_mentation"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:268
+#: schematic/scheme/conf/schematic/menu.scm:307
 msgid "_Wiki"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:270
+#: schematic/scheme/conf/schematic/menu.scm:309
 msgid "Find Component D_ocumentation"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:272
+#: schematic/scheme/conf/schematic/menu.scm:311
 msgid "_Hotkeys..."
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:273
+#: schematic/scheme/conf/schematic/menu.scm:312
 msgid "_About"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:283
+#: schematic/scheme/conf/schematic/menu.scm:322
 msgid "_File"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:284
+#: schematic/scheme/conf/schematic/menu.scm:323
 msgid "_Edit"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:286
+#: schematic/scheme/conf/schematic/menu.scm:325
 msgid "_View"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:287
+#: schematic/scheme/conf/schematic/menu.scm:326
 msgid "_Page"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:288
+#: schematic/scheme/conf/schematic/menu.scm:327
 msgid "_Add"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:289
+#: schematic/scheme/conf/schematic/menu.scm:328
 msgid "Hie_rarchy"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:290
+#: schematic/scheme/conf/schematic/menu.scm:329
 msgid "A_ttributes"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:291
+#: schematic/scheme/conf/schematic/menu.scm:330
 msgid "_Options"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:292
+#: schematic/scheme/conf/schematic/menu.scm:331
 msgid "_Netlist"
 msgstr ""
 
-#: schematic/scheme/conf/schematic/menu.scm:293
+#: schematic/scheme/conf/schematic/menu.scm:332
 msgid "_Help"
 msgstr ""
 
-#: schematic/scheme/gschem/action.scm:43
+#: schematic/scheme/schematic/action.scm:45
 #, scheme-format
 msgid "[~A] is not a valid lepton-schematic action."
 msgstr ""
 
-#: schematic/scheme/gschem/action.scm:45
+#: schematic/scheme/schematic/action.scm:47
 msgid "There is no last action to repeat."
 msgstr ""
 
-#: schematic/scheme/gschem/action.scm:166
+#: schematic/scheme/schematic/action.scm:168
 msgid "Repeat Last Action"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:50
+#: schematic/scheme/schematic/builtins.scm:51
 msgid "Cancel"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:56
+#: schematic/scheme/schematic/builtins.scm:57
 msgid "New File"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:59
+#: schematic/scheme/schematic/builtins.scm:60
 msgid "Open File"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:65
+#: schematic/scheme/schematic/builtins.scm:66
 msgid "Save As"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:71
+#: schematic/scheme/schematic/builtins.scm:72
 msgid "Print"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:74
+#: schematic/scheme/schematic/builtins.scm:75
 msgid "Export Image"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:77
+#: schematic/scheme/schematic/builtins.scm:78
 msgid "Run Script"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:83
+#: schematic/scheme/schematic/builtins.scm:84
 msgid "Close Window"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:86
+#: schematic/scheme/schematic/builtins.scm:87
 msgid "Quit"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:90
+#: schematic/scheme/schematic/builtins.scm:91
 msgid "Terminal REPL"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:132
+#: schematic/scheme/schematic/builtins.scm:133
 msgid "Edit Text"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:135
+#: schematic/scheme/schematic/builtins.scm:136
 msgid "Choose Slot"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:138
+#: schematic/scheme/schematic/builtins.scm:139
 msgid "Edit Object Properties"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:141
+#: schematic/scheme/schematic/builtins.scm:142
 msgid "Translate Symbol"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:150
+#: schematic/scheme/schematic/builtins.scm:151
 msgid "Invoke Macro"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:162
+#: schematic/scheme/schematic/builtins.scm:163
 msgid "Show/Hide Invisible Text"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:168
+#: schematic/scheme/schematic/builtins.scm:169
 msgid "Cut"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:174
+#: schematic/scheme/schematic/builtins.scm:172
+msgid "Copy"
+msgstr ""
+
+#: schematic/scheme/schematic/builtins.scm:175
 msgid "Paste"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:180
+#: schematic/scheme/schematic/builtins.scm:181
 msgid "Sidebar"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:186
+#: schematic/scheme/schematic/builtins.scm:187
 msgid "Find Text State"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:189
+#: schematic/scheme/schematic/builtins.scm:190
 msgid "Redraw"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:195
+#: schematic/scheme/schematic/builtins.scm:196
 msgid "Pan Left"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:198
+#: schematic/scheme/schematic/builtins.scm:199
 msgid "Pan Right"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:201
+#: schematic/scheme/schematic/builtins.scm:202
 msgid "Pan Up"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:204
+#: schematic/scheme/schematic/builtins.scm:205
 msgid "Pan Down"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:219
+#: schematic/scheme/schematic/builtins.scm:211
+msgid "Zoom Extents"
+msgstr ""
+
+#: schematic/scheme/schematic/builtins.scm:214
+msgid "Zoom In"
+msgstr ""
+
+#: schematic/scheme/schematic/builtins.scm:217
+msgid "Zoom Out"
+msgstr ""
+
+#: schematic/scheme/schematic/builtins.scm:220
 msgid "Zoom Full"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:222
+#: schematic/scheme/schematic/builtins.scm:223
 msgid "Dark Color Scheme"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:225
+#: schematic/scheme/schematic/builtins.scm:226
 msgid "Light Color Scheme"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:228
+#: schematic/scheme/schematic/builtins.scm:229
 msgid "Monochrome Color Scheme"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:231
+#: schematic/scheme/schematic/builtins.scm:232
 msgid "Show Color Scheme Editor"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:237
+#: schematic/scheme/schematic/builtins.scm:238
 msgid "Revert Changes"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:243
+#: schematic/scheme/schematic/builtins.scm:244
 msgid "Previous Page"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:246
+#: schematic/scheme/schematic/builtins.scm:247
 msgid "Next Page"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:258
+#: schematic/scheme/schematic/builtins.scm:259
 msgid "Print Page"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:279
+#: schematic/scheme/schematic/builtins.scm:265
+msgid "Add Component"
+msgstr ""
+
+#: schematic/scheme/schematic/builtins.scm:271
+msgid "Add Net"
+msgstr ""
+
+#: schematic/scheme/schematic/builtins.scm:274
+msgid "Add Bus"
+msgstr ""
+
+#: schematic/scheme/schematic/builtins.scm:277
+msgid "Add Text"
+msgstr ""
+
+#: schematic/scheme/schematic/builtins.scm:280
 msgid "Add Line"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:282
+#: schematic/scheme/schematic/builtins.scm:283
 msgid "Add Path"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:285
+#: schematic/scheme/schematic/builtins.scm:286
 msgid "Add Box"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:288
+#: schematic/scheme/schematic/builtins.scm:289
 msgid "Add Circle"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:291
+#: schematic/scheme/schematic/builtins.scm:292
 msgid "Add Arc"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:294
+#: schematic/scheme/schematic/builtins.scm:295
 msgid "Add Pin"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:297
+#: schematic/scheme/schematic/builtins.scm:298
 msgid "Add Picture"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:309
+#: schematic/scheme/schematic/builtins.scm:304
+msgid "Down Schematic"
+msgstr ""
+
+#: schematic/scheme/schematic/builtins.scm:307
+msgid "Down Symbol"
+msgstr ""
+
+#: schematic/scheme/schematic/builtins.scm:310
 msgid "Up Hierarchy"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:317
+#: schematic/scheme/schematic/builtins.scm:318
 msgid "Attach Attributes"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:346
+#: schematic/scheme/schematic/builtins.scm:347
 #, scheme-format
 msgid "Attribute attached: [~a]"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:389
+#: schematic/scheme/schematic/builtins.scm:390
 msgid "Detach Attributes"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:410
+#: schematic/scheme/schematic/builtins.scm:411
 #, scheme-format
 msgid "Attribute detached: [~a]"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:437
+#: schematic/scheme/schematic/builtins.scm:438
 msgid "Show Attribute Value"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:440
+#: schematic/scheme/schematic/builtins.scm:441
 msgid "Show Attribute Name"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:446
+#: schematic/scheme/schematic/builtins.scm:447
 msgid "Toggle Text Visibility"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:449
+#: schematic/scheme/schematic/builtins.scm:450
 msgid "Find Specific Text"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:452
+#: schematic/scheme/schematic/builtins.scm:453
 msgid "Hide Specific Text"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:455
+#: schematic/scheme/schematic/builtins.scm:456
 msgid "Show Specific Text"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:458
+#: schematic/scheme/schematic/builtins.scm:459
 msgid "Autonumber Text"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:464
+#: schematic/scheme/schematic/builtins.scm:465
 msgid "Show Hotkeys"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:467
+#: schematic/scheme/schematic/builtins.scm:468
 msgid "Switch Grid Style"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:470
+#: schematic/scheme/schematic/builtins.scm:471
 msgid "Switch Snap Mode"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:473
+#: schematic/scheme/schematic/builtins.scm:474
 msgid "Set Grid Spacing"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:476
+#: schematic/scheme/schematic/builtins.scm:477
 msgid "Increase Grid Spacing"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:479
+#: schematic/scheme/schematic/builtins.scm:480
 msgid "Decrease Grid Spacing"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:482
+#: schematic/scheme/schematic/builtins.scm:483
 msgid "Toggle Outline Drawing"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:485
+#: schematic/scheme/schematic/builtins.scm:486
 msgid "Toggle Net Rubber Band"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:488
+#: schematic/scheme/schematic/builtins.scm:489
 msgid "Toggle Magnetic Nets"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:491
+#: schematic/scheme/schematic/builtins.scm:492
 msgid "Show Log Window"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:494
+#: schematic/scheme/schematic/builtins.scm:495
 msgid "Show Coordinate Window"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:504
+#: schematic/scheme/schematic/builtins.scm:501
+msgid "Toggle Grips"
+msgstr ""
+
+#: schematic/scheme/schematic/builtins.scm:508
 msgid "Component Documentation"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:506
+#: schematic/scheme/schematic/builtins.scm:510
 msgid "View documentation for selected component"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:519
+#: schematic/scheme/schematic/builtins.scm:523
 msgid "Lepton EDA Manuals"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:520
+#: schematic/scheme/schematic/builtins.scm:524
 msgid "View the front page of the Lepton EDA documentation in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:525
+#: schematic/scheme/schematic/builtins.scm:529
 msgid "lepton-schematic User Guide"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:526
+#: schematic/scheme/schematic/builtins.scm:530
 msgid "View the lepton-schematic User Guide in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:531
+#: schematic/scheme/schematic/builtins.scm:535
 msgid "lepton-schematic FAQ"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:532
+#: schematic/scheme/schematic/builtins.scm:536
 msgid "Frequently Asked Questions about using lepton-schematic."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:537
+#: schematic/scheme/schematic/builtins.scm:541
 msgid "Lepton EDA wiki"
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:538
+#: schematic/scheme/schematic/builtins.scm:542
 msgid "View the front page of the Lepton EDA wiki in a browser."
 msgstr ""
 
-#: schematic/scheme/gschem/builtins.scm:542
+#: schematic/scheme/schematic/builtins.scm:546
 msgid "About lepton-schematic"
 msgstr ""
 
-#: schematic/scheme/gschem/deprecated.scm:104
-#, scheme-format
-msgid "Invalid text alignment ~A."
-msgstr ""
-
-#: schematic/scheme/gschem/gschemdoc.scm.in:53
+#: schematic/scheme/schematic/gschemdoc.scm.in:66
 msgid "Could not show documentation:"
 msgstr ""
 
-#: schematic/scheme/gschem/gschemdoc.scm.in:256
+#: schematic/scheme/schematic/gschemdoc.scm.in:268
 msgid "No documentation found"
 msgstr ""
 
-#: schematic/scheme/gschem/keymap.scm:40
+#: schematic/scheme/schematic/keymap.scm:43
 #, scheme-format
 msgid "~S is not a valid key combination."
 msgstr ""
 
-#: schematic/scheme/gschem/keymap.scm:157
+#: schematic/scheme/schematic/keymap.scm:160
 #, scheme-format
 msgid "~S is not a prefix key sequence."
+msgstr ""
+
+#: schematic/scheme/gschem/deprecated.scm:103
+#, scheme-format
+msgid "Invalid text alignment ~A."
 msgstr ""

--- a/schematic/po/ml.po
+++ b/schematic/po/ml.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-10-03 23:34+0300\n"
+"POT-Creation-Date: 2020-03-18 20:44+0300\n"
 "PO-Revision-Date: 2012-01-27 14:23+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -19,6 +19,13 @@ msgstr ""
 "X-Generator: Launchpad (build 16265)\n"
 
 msgid "Zoom too small!  Cannot zoom further."
+msgstr ""
+
+msgid ""
+"Save your color scheme to a file by clicking on the \"Save As...\"\n"
+"button. It can be loaded on startup with the following\n"
+"expression in the gschemrc configuration file:\n"
+"( primitive-load \"/path/to/saved-color-scheme-file\" )"
 msgstr ""
 
 #, c-format
@@ -46,6 +53,11 @@ msgstr ""
 msgid "Sa_ve..."
 msgstr ""
 
+msgid ""
+"After you're done choosing the font, it's recommended\n"
+"to reopen schematics or restart the application."
+msgstr ""
+
 #, c-format
 msgid "<b>Current:</b> %s"
 msgstr ""
@@ -53,23 +65,20 @@ msgstr ""
 msgid "Save configuration"
 msgstr ""
 
-msgid "Save settings to:"
+msgid "Local configuration file:"
 msgstr ""
 
-msgid "Local configuration file (in current directory)"
+msgid "User configuration file:"
 msgstr ""
 
-msgid "User configuration file (geda-user.conf)"
-msgstr ""
-
-msgid "Object ~A is not included in the current gschem page."
+msgid "Object ~A is not included in the current lepton-schematic page."
 msgstr ""
 
 msgid "Invalid text name/value visibility ~A."
 msgstr ""
 
 #, c-format
-msgid "You are running gEDA/gaf version [%1$s%2$s.%3$s],\n"
+msgid "You are running lepton-schematic version [%1$s%2$s.%3$s],\n"
 msgstr ""
 
 #, c-format
@@ -82,65 +91,13 @@ msgstr ""
 msgid "Please be sure that you have the latest rc file.\n"
 msgstr ""
 
-#, c-format
-msgid "Invalid size [%1$d] passed to text-size\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid size [%1$d] passed to snap-size\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid num levels [%1$d] passed to undo-levels\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid gain [%1$d] passed to zoom-gain\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
-msgstr ""
-
 msgid "Object ~A is not directly included in a page."
 msgstr ""
 
 msgid "Could not launch URI ~S: ~A"
 msgstr ""
 
-msgid "Found invalid gschem window smob ~S"
+msgid "Found invalid lepton-schematic window smob ~S"
 msgstr ""
 
 #, c-format
@@ -171,7 +128,7 @@ msgstr ""
 
 msgid ""
 "Copyright © 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright © 2017-2019 Lepton Developers.\n"
+"Copyright © 2017-2020 Lepton Developers.\n"
 "See AUTHORS, ChangeLog files and consult 'git log' history for details."
 msgstr ""
 
@@ -609,7 +566,8 @@ msgid ""
 "\n"
 "Are you sure you want to revert this page?\n"
 "All unsaved changes in current schematic will be\n"
-"discarded and page file will be reloaded from disk."
+"discarded and page file will be reloaded from disk.\n"
+"This action will also reload all component libraries."
 msgstr ""
 
 msgid "Revert"
@@ -702,10 +660,6 @@ msgid_plural "Delete %1$u locked objects?"
 msgstr[0] ""
 msgstr[1] ""
 
-#, c-format
-msgid "Got an unexpected NULL in o_edit\n"
-msgstr ""
-
 msgid "Hidden text is now visible"
 msgstr ""
 
@@ -717,7 +671,7 @@ msgid "Could not find symbol [%1$s] in library. Update failed."
 msgstr ""
 
 #, c-format
-msgid "o_autosave_backups: Can't get the real filename of %1$s."
+msgid "Can't get the real filename of %1$s."
 msgstr ""
 
 #, c-format
@@ -730,10 +684,6 @@ msgstr ""
 
 #, c-format
 msgid "Could NOT save backup file [%1$s]"
-msgstr ""
-
-#, c-format
-msgid "ERROR: NULL object in o_move_end!\n"
 msgstr ""
 
 #, c-format
@@ -781,7 +731,7 @@ msgstr ""
 msgid "New slot number out of range"
 msgstr ""
 
-msgid "Undo/Redo disabled in rc file"
+msgid "Undo/Redo is disabled in configuration"
 msgstr ""
 
 #, c-format
@@ -802,27 +752,12 @@ msgid ""
 "  -h, --help               Help; this message.\n"
 "  --                       Treat all remaining arguments as filenames.\n"
 "\n"
-"Report bugs at <https://github.com/lepton-eda/lepton-eda/issues>\n"
-"Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"Lepton EDA %1$s (git: %2$.7s)\n"
-"Copyright (C) 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright (C) 2017-2019 Lepton Developers.\n"
-"This is free software, and you are welcome to redistribute it under\n"
-"certain conditions. For details, see the file `COPYING', which is\n"
-"included in the Lepton EDA distribution.\n"
-"There is NO WARRANTY, to the extent permitted by law.\n"
+"Report bugs at <%2$s>\n"
+"Lepton EDA homepage: <%3$s>\n"
 msgstr ""
 
 #, c-format
 msgid "Got invalid show option; defaulting to show both\n"
-msgstr ""
-
-#, c-format
-msgid "ERROR: NULL object!\n"
 msgstr ""
 
 msgid "Single Attribute Editor"
@@ -877,7 +812,7 @@ msgid ""
 "duplicate slot may cause problems: [symbolname=%1$s, number=%2$d, slot=%3$d]"
 msgstr ""
 
-msgid "No searchstring given in autonumber text."
+msgid "No search string given in autonumber text."
 msgstr ""
 
 msgid "No '*' or '?' given at the end of the autonumber text."
@@ -951,24 +886,6 @@ msgid ""
 msgstr ""
 
 msgid "Clipboard insertion failed"
-msgstr ""
-
-#, c-format
-msgid "Could not allocate the color %1$s!\n"
-msgstr ""
-
-msgid "black"
-msgstr ""
-
-msgid "white"
-msgstr ""
-
-#, c-format
-msgid "Could not allocate display color %1$i!\n"
-msgstr ""
-
-#, c-format
-msgid "Could not allocate outline color %1$i!\n"
 msgstr ""
 
 #, c-format
@@ -1107,13 +1024,13 @@ msgstr ""
 msgid "Invalid Attribute"
 msgstr ""
 
-msgid "Schematics"
+msgid "Schematics (*.sch)"
 msgstr ""
 
-msgid "Symbols"
+msgid "Symbols (*.sym)"
 msgstr ""
 
-msgid "Schematics and symbols"
+msgid "Schematics and symbols (*.sch *.sym)"
 msgstr ""
 
 msgid "All files"
@@ -1149,7 +1066,7 @@ msgid "Hatch"
 msgstr ""
 
 #, c-format
-msgid "x_image_lowlevel: Unable to write %1$s file %2$s."
+msgid "Unable to write %1$s file %2$s."
 msgstr ""
 
 #, c-format
@@ -1168,7 +1085,7 @@ msgstr ""
 msgid "Wrote black and white image to [%1$s] [%2$d x %3$d]"
 msgstr ""
 
-msgid "x_image_lowlevel: Unable to get pixbuf from gschem's window."
+msgid "Unable to get pixbuf from lepton-schematic's window."
 msgstr ""
 
 msgid "NOTE: print-color-map will be used for PDF export"
@@ -1217,67 +1134,53 @@ msgstr ""
 msgid "Phantom"
 msgstr ""
 
-msgid "Add Net"
-msgstr ""
-
-msgid "Add Attribute"
-msgstr ""
-
 #, fuzzy
-msgid "Add Component"
+msgid "Add Co_mponent..."
 msgstr "സാധനത്തിലെ മാറ്റങ്ങള്‍ നടപ്പില്‍ വരുത്തുക"
 
-msgid "Add Bus"
+msgid "Add Te_xt..."
 msgstr ""
 
-msgid "Add Text"
+msgid "Add _Attribute..."
 msgstr ""
 
 #, fuzzy
-msgid "Zoom In"
-msgstr "വലുതാക്കി കാണിക്കുന്ന പെട്ടി"
+msgid "Add _Net"
+msgstr "രേഖ"
 
-#, fuzzy
-msgid "Zoom Out"
-msgstr "വലുതാക്കി കാണിക്കുന്ന പെട്ടി"
-
-#, fuzzy
-msgid "Zoom Extents"
-msgstr "വലുതാക്കി കാണിക്കുന്ന പെട്ടി"
-
-msgid "Select"
+msgid "Add _Bus"
 msgstr ""
 
-msgid "Edit..."
+msgid "Cu_t"
+msgstr ""
+
+msgid "_Copy"
+msgstr ""
+
+msgid "_Paste"
+msgstr ""
+
+msgid "_Delete"
+msgstr ""
+
+#, fuzzy
+msgid "_Edit..."
 msgstr "മാറ്റം വരുത്തുക..."
 
-msgid "Object Properties..."
+#, fuzzy
+msgid "Ed_it Text..."
+msgstr "മാറ്റം വരുത്തുക..."
+
+msgid "_Object Properties..."
 msgstr ""
 
-msgid "Copy"
+msgid "Hierarchy: Down _Schematic"
 msgstr ""
 
-msgid "Move"
+msgid "Hierarchy: Down S_ymbol"
 msgstr ""
 
-msgid "Delete"
-msgstr "മായ്ക്കുക"
-
-msgid "Down Schematic"
-msgstr ""
-
-msgid "Down Symbol"
-msgstr ""
-
-msgid "Up"
-msgstr ""
-
-#, c-format
-msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
-msgstr ""
-
-#, c-format
-msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
+msgid "Hierarchy: _Up"
 msgstr ""
 
 msgid "The operating system is out of memory or resources."
@@ -1301,6 +1204,9 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
+msgid "Delete"
+msgstr "മായ്ക്കുക"
+
 #, fuzzy
 msgid "Copy to all"
 msgstr "പകര്‍ത്തുക 1ലേക്ക്"
@@ -1318,6 +1224,9 @@ msgid "V"
 msgstr ""
 
 msgid "Sho_w inherited attributes"
+msgstr ""
+
+msgid "Add Attribute"
 msgstr ""
 
 msgid "_Name:"
@@ -1428,6 +1337,24 @@ msgstr ""
 msgid "Hierarchy up"
 msgstr ""
 
+msgid "_New"
+msgstr ""
+
+msgid "_Open..."
+msgstr ""
+
+msgid "_Save"
+msgstr ""
+
+msgid "Save _As..."
+msgstr ""
+
+msgid "Page _Manager..."
+msgstr ""
+
+msgid "_Close"
+msgstr ""
+
 msgid "Options"
 msgstr ""
 
@@ -1536,6 +1463,9 @@ msgstr ""
 msgid "Add Text..."
 msgstr ""
 
+msgid "Select"
+msgstr ""
+
 msgid "Select mode"
 msgstr ""
 
@@ -1596,19 +1526,7 @@ msgstr ""
 msgid "Create and edit electrical schematics and symbols with lepton-schematic"
 msgstr ""
 
-msgid "_New"
-msgstr ""
-
-msgid "_Open..."
-msgstr ""
-
 msgid "Open Recen_t"
-msgstr ""
-
-msgid "_Save"
-msgstr ""
-
-msgid "Save _As..."
 msgstr ""
 
 msgid "Save All"
@@ -1641,18 +1559,6 @@ msgstr ""
 msgid "_Redo"
 msgstr ""
 
-msgid "Cu_t"
-msgstr ""
-
-msgid "_Copy"
-msgstr ""
-
-msgid "_Paste"
-msgstr ""
-
-msgid "_Delete"
-msgstr ""
-
 msgid "Select All"
 msgstr ""
 
@@ -1661,6 +1567,12 @@ msgstr ""
 
 msgid "Rotate 90 Mode"
 msgstr ""
+
+msgid "Object Properties..."
+msgstr ""
+
+msgid "Edit..."
+msgstr "മാറ്റം വരുത്തുക..."
 
 msgid "Edit Text..."
 msgstr ""
@@ -1779,9 +1691,6 @@ msgstr ""
 msgid "_Next"
 msgstr ""
 
-msgid "_Close"
-msgstr ""
-
 msgid "_Revert..."
 msgstr ""
 
@@ -1887,6 +1796,9 @@ msgid "Grid Style: Cycle Dots/Mesh/Off"
 msgstr ""
 
 msgid "Grid Snap: Cycle Grid/Resnap/Off"
+msgstr ""
+
+msgid "Grips: On/Off"
 msgstr ""
 
 msgid "Feedback Mode: Outline/Box"
@@ -2026,6 +1938,9 @@ msgstr ""
 msgid "Cut"
 msgstr "കട്ട് ചെയുക  1 ലേക്ക്"
 
+msgid "Copy"
+msgstr ""
+
 #, fuzzy
 msgid "Paste"
 msgstr "പകര്‍ത്തി എടുക്കുക 1 ല്‍ നിന്നും"
@@ -2050,6 +1965,18 @@ msgstr ""
 
 msgid "Pan Down"
 msgstr ""
+
+#, fuzzy
+msgid "Zoom Extents"
+msgstr "വലുതാക്കി കാണിക്കുന്ന പെട്ടി"
+
+#, fuzzy
+msgid "Zoom In"
+msgstr "വലുതാക്കി കാണിക്കുന്ന പെട്ടി"
+
+#, fuzzy
+msgid "Zoom Out"
+msgstr "വലുതാക്കി കാണിക്കുന്ന പെട്ടി"
 
 msgid "Zoom Full"
 msgstr ""
@@ -2082,6 +2009,19 @@ msgid "Print Page"
 msgstr "പേജ് അടയ്ക്കുക"
 
 #, fuzzy
+msgid "Add Component"
+msgstr "സാധനത്തിലെ മാറ്റങ്ങള്‍ നടപ്പില്‍ വരുത്തുക"
+
+msgid "Add Net"
+msgstr ""
+
+msgid "Add Bus"
+msgstr ""
+
+msgid "Add Text"
+msgstr ""
+
+#, fuzzy
 msgid "Add Line"
 msgstr "രേഖ"
 
@@ -2102,6 +2042,12 @@ msgid "Add Pin"
 msgstr ""
 
 msgid "Add Picture"
+msgstr ""
+
+msgid "Down Schematic"
+msgstr ""
+
+msgid "Down Symbol"
 msgstr ""
 
 msgid "Up Hierarchy"
@@ -2176,6 +2122,9 @@ msgstr "പുതിയ ജാലകം"
 msgid "Show Coordinate Window"
 msgstr ""
 
+msgid "Toggle Grips"
+msgstr ""
+
 msgid "Component Documentation"
 msgstr ""
 
@@ -2210,10 +2159,6 @@ msgstr ""
 msgid "About lepton-schematic"
 msgstr ""
 
-#, scheme-format
-msgid "Invalid text alignment ~A."
-msgstr ""
-
 msgid "Could not show documentation:"
 msgstr ""
 
@@ -2226,6 +2171,10 @@ msgstr ""
 
 #, scheme-format
 msgid "~S is not a prefix key sequence."
+msgstr ""
+
+#, scheme-format
+msgid "Invalid text alignment ~A."
 msgstr ""
 
 #~ msgid "Edit"

--- a/schematic/po/nl.po
+++ b/schematic/po/nl.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda-gschem\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-10-03 23:34+0300\n"
+"POT-Creation-Date: 2020-03-18 20:44+0300\n"
 "PO-Revision-Date: 2014-08-31 22:35+0100\n"
 "Last-Translator: Bert Timmerman <bert.timmerman@xs4all.nl>\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -21,6 +21,13 @@ msgstr ""
 #, fuzzy
 msgid "Zoom too small!  Cannot zoom further."
 msgstr "Vergroting te klein! Kan niet verder vergroten.\n"
+
+msgid ""
+"Save your color scheme to a file by clicking on the \"Save As...\"\n"
+"button. It can be loaded on startup with the following\n"
+"expression in the gschemrc configuration file:\n"
+"( primitive-load \"/path/to/saved-color-scheme-file\" )"
+msgstr ""
 
 #, fuzzy, c-format
 msgid ""
@@ -51,6 +58,11 @@ msgstr ""
 msgid "Sa_ve..."
 msgstr ""
 
+msgid ""
+"After you're done choosing the font, it's recommended\n"
+"to reopen schematics or restart the application."
+msgstr ""
+
 #, c-format
 msgid "<b>Current:</b> %s"
 msgstr ""
@@ -58,24 +70,21 @@ msgstr ""
 msgid "Save configuration"
 msgstr ""
 
+msgid "Local configuration file:"
+msgstr ""
+
+msgid "User configuration file:"
+msgstr ""
+
 #, fuzzy
-msgid "Save settings to:"
-msgstr "Instellingen"
-
-msgid "Local configuration file (in current directory)"
-msgstr ""
-
-msgid "User configuration file (geda-user.conf)"
-msgstr ""
-
-msgid "Object ~A is not included in the current gschem page."
+msgid "Object ~A is not included in the current lepton-schematic page."
 msgstr "Objekt ~A is niet bijgevoegd in de huidige gschem pagina."
 
 msgid "Invalid text name/value visibility ~A."
 msgstr "Ongeldige tekst naam/waarde zichtbaarheid ~A."
 
 #, fuzzy, c-format
-msgid "You are running gEDA/gaf version [%1$s%2$s.%3$s],\n"
+msgid "You are running lepton-schematic version [%1$s%2$s.%3$s],\n"
 msgstr "U gebruikt gEDA/gaf versie [%s%s.%s],\n"
 
 #, fuzzy, c-format
@@ -90,69 +99,14 @@ msgstr ""
 msgid "Please be sure that you have the latest rc file.\n"
 msgstr "Wees alstublieft zeker dat U het laatste rc bestand heeft.\n"
 
-#, fuzzy, c-format
-msgid "Invalid size [%1$d] passed to text-size\n"
-msgstr "Ongeldige waarde [%d] overgedragen aan text-size\n"
-
-#, fuzzy, c-format
-msgid "Invalid size [%1$d] passed to snap-size\n"
-msgstr "Ongeldige waarde [%d] overgedragen aan snap-size\n"
-
-#, fuzzy, c-format
-msgid "Invalid num levels [%1$d] passed to undo-levels\n"
-msgstr "Ongeldige num niveaus [%d] overgedragen naar undo-levels\n"
-
-#, fuzzy, c-format
-msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
-msgstr "Ongeldige afmeting [%d] overgedragen aan bus-ripper-size\n"
-
-#, fuzzy, c-format
-msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
-msgstr "Ongeldige punt afmeting [%d] overgedragen aan dots-grid-dot-size\n"
-
-#, fuzzy, c-format
-msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
-msgstr ""
-"Ongeldige beeldpunt ruimte [%d] overgedragen aan dots-grid-fixed-threshold\n"
-
-#, fuzzy, c-format
-msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
-msgstr ""
-"Ongeldige beeldpunt ruimte [%d] overgedragen aan mesh-grid-display-"
-"threshold\n"
-
-#, fuzzy, c-format
-msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
-msgstr "Ongeldig aantal seconden [%d] overgedragen naar auto-save-interval\n"
-
-#, fuzzy, c-format
-msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
-msgstr "Ongeldige versterking [%d] overgedragen aan mousepan-gain\n"
-
-#, fuzzy, c-format
-msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
-msgstr "Ongeldige versterking [%d] overgedragen aan keyboardpan-gain\n"
-
-#, fuzzy, c-format
-msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
-msgstr ""
-"Ongeldig aantal beeldpunten [%d] overgedragen aan select-slack-pixels\n"
-
-#, fuzzy, c-format
-msgid "Invalid gain [%1$d] passed to zoom-gain\n"
-msgstr "Ongeldige versterking [%d] overgedragen aan zoom-gain\n"
-
-#, fuzzy, c-format
-msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
-msgstr "Ongeldig aantal stappen [%d] scrollpan-steps\n"
-
 msgid "Object ~A is not directly included in a page."
 msgstr "Object ~A is niet direct bijgevoegd in een pagina."
 
 msgid "Could not launch URI ~S: ~A"
 msgstr "Kan URI ~S: ~A niet starten"
 
-msgid "Found invalid gschem window smob ~S"
+#, fuzzy
+msgid "Found invalid lepton-schematic window smob ~S"
 msgstr "Ongeldige gschem venster smob ~S gevonden"
 
 #, fuzzy, c-format
@@ -188,7 +142,7 @@ msgstr "gEDA: GPL Elektronische Ontwerp Automatisering"
 #, fuzzy
 msgid ""
 "Copyright © 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright © 2017-2019 Lepton Developers.\n"
+"Copyright © 2017-2020 Lepton Developers.\n"
 "See AUTHORS, ChangeLog files and consult 'git log' history for details."
 msgstr ""
 "Copyright © 1998-2012 Ales Hvezda <ahvezda@geda.seul.org>\n"
@@ -675,7 +629,8 @@ msgid ""
 "\n"
 "Are you sure you want to revert this page?\n"
 "All unsaved changes in current schematic will be\n"
-"discarded and page file will be reloaded from disk."
+"discarded and page file will be reloaded from disk.\n"
+"This action will also reload all component libraries."
 msgstr ""
 
 #, fuzzy
@@ -787,10 +742,6 @@ msgid_plural "Delete %1$u locked objects?"
 msgstr[0] "Verwijder vergrendeld object?"
 msgstr[1] "Verwijder %u vergrendelde objecten?"
 
-#, c-format
-msgid "Got an unexpected NULL in o_edit\n"
-msgstr "Ontving een onverwachte NULL in o_edit\n"
-
 #, fuzzy
 msgid "Hidden text is now visible"
 msgstr "Verborgen tekst is nu zichtbaar\n"
@@ -804,7 +755,7 @@ msgid "Could not find symbol [%1$s] in library. Update failed."
 msgstr "Kan symbool [%s] niet in bibliotheek vinden. Vernieuwen faalde.\n"
 
 #, fuzzy, c-format
-msgid "o_autosave_backups: Can't get the real filename of %1$s."
+msgid "Can't get the real filename of %1$s."
 msgstr "o_autosave_backups: Kan de echte bestandsnaam van %s niet krijgen."
 
 #, fuzzy, c-format
@@ -820,10 +771,6 @@ msgstr "Reserve bestand [%s] kan NIET op alleen-lezen ingesteld worden\n"
 #, fuzzy, c-format
 msgid "Could NOT save backup file [%1$s]"
 msgstr "Reserve bestand [%s] kan NIET opgeslagen worden\n"
-
-#, c-format
-msgid "ERROR: NULL object in o_move_end!\n"
-msgstr "FOUT: NULL object in o_move_end!\n"
 
 #, c-format
 msgid "DOH! tried to find the whichone, but didn't find it!\n"
@@ -879,7 +826,7 @@ msgid "New slot number out of range"
 msgstr "Nieuw slotnummer buiten het bereik\n"
 
 #, fuzzy
-msgid "Undo/Redo disabled in rc file"
+msgid "Undo/Redo is disabled in configuration"
 msgstr "Ongedaan/Opnieuw doen uitgeschakeld in rc bestand\n"
 
 #, fuzzy, c-format
@@ -900,8 +847,8 @@ msgid ""
 "  -h, --help               Help; this message.\n"
 "  --                       Treat all remaining arguments as filenames.\n"
 "\n"
-"Report bugs at <https://github.com/lepton-eda/lepton-eda/issues>\n"
-"Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>\n"
+"Report bugs at <%2$s>\n"
+"Lepton EDA homepage: <%3$s>\n"
 msgstr ""
 "Gebruik: %s [OPTIE ...] [--] [BESTAND ...]\n"
 "\n"
@@ -927,30 +874,9 @@ msgstr ""
 "Rapporteer fouten aan <https://bugs.launchpad.net/geda>\n"
 "gEDA/gaf startpagina: <http://www.geda-project.org/>\n"
 
-#, fuzzy, c-format
-msgid ""
-"Lepton EDA %1$s (git: %2$.7s)\n"
-"Copyright (C) 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright (C) 2017-2019 Lepton Developers.\n"
-"This is free software, and you are welcome to redistribute it under\n"
-"certain conditions. For details, see the file `COPYING', which is\n"
-"included in the Lepton EDA distribution.\n"
-"There is NO WARRANTY, to the extent permitted by law.\n"
-msgstr ""
-"gEDA %s (g%.7s)\n"
-"Copyright (C) 1998-2012 gEDA developers\n"
-"Dit is vrije software, en U bent welkom om deze te herdistribueren onder\n"
-"bepaalde condities. Voor details, zie het bestand `COPYING', welke is\n"
-"bijgevoegd in de gEDA distributie.\n"
-"Er is GEEN GARANTIE, voor zover de wet dit toelaat.\n"
-
 #, c-format
 msgid "Got invalid show option; defaulting to show both\n"
 msgstr "Kreeg ongeldige toon optie; standaardwaarde is toon beide\n"
-
-#, c-format
-msgid "ERROR: NULL object!\n"
-msgstr "FOUT: NULL object!\n"
 
 msgid "Single Attribute Editor"
 msgstr "Enkelvoudige Attribuut Bewerking"
@@ -1012,7 +938,7 @@ msgstr ""
 "een dubbel slot kan een probleem geven: [symbolname=%s, number=%d, slot=%d]\n"
 
 #, fuzzy
-msgid "No searchstring given in autonumber text."
+msgid "No search string given in autonumber text."
 msgstr "Geen zoektekst gegeven in automatisch nummeren tekst.\n"
 
 #, fuzzy
@@ -1092,24 +1018,6 @@ msgstr ""
 
 msgid "Clipboard insertion failed"
 msgstr "Klembord invoegen faalde"
-
-#, fuzzy, c-format
-msgid "Could not allocate the color %1$s!\n"
-msgstr "Kan de kleur %s niet toewijzen!\n"
-
-msgid "black"
-msgstr "zwart"
-
-msgid "white"
-msgstr "wit"
-
-#, fuzzy, c-format
-msgid "Could not allocate display color %1$i!\n"
-msgstr "Kan scherm kleur %i niet toewijzen!\n"
-
-#, fuzzy, c-format
-msgid "Could not allocate outline color %1$i!\n"
-msgstr "Kan de omlijning kleur %i niet toewijzen!\n"
 
 #, fuzzy, c-format
 msgid "Tried to get an invalid color: %1$d\n"
@@ -1258,13 +1166,16 @@ msgstr ""
 msgid "Invalid Attribute"
 msgstr "Ongeldig Attribuut"
 
-msgid "Schematics"
+#, fuzzy
+msgid "Schematics (*.sch)"
 msgstr "Schema's"
 
-msgid "Symbols"
+#, fuzzy
+msgid "Symbols (*.sym)"
 msgstr "Symbolen"
 
-msgid "Schematics and symbols"
+#, fuzzy
+msgid "Schematics and symbols (*.sch *.sym)"
 msgstr "Schema's en symbolen"
 
 msgid "All files"
@@ -1306,7 +1217,7 @@ msgid "Hatch"
 msgstr "Arcering"
 
 #, fuzzy, c-format
-msgid "x_image_lowlevel: Unable to write %1$s file %2$s."
+msgid "Unable to write %1$s file %2$s."
 msgstr "x_image_lowlevel: Kan %s bestand %s niet schrijven.\n"
 
 #, fuzzy, c-format
@@ -1331,7 +1242,7 @@ msgid "Wrote black and white image to [%1$s] [%2$d x %3$d]"
 msgstr "Schreef zwart/wit afbeelding naar [%s] [%d x %d]\n"
 
 #, fuzzy
-msgid "x_image_lowlevel: Unable to get pixbuf from gschem's window."
+msgid "Unable to get pixbuf from lepton-schematic's window."
 msgstr "x_image_lowlevel: Kan geen pixbuf krijgen van gschem's venster.\n"
 
 msgid "NOTE: print-color-map will be used for PDF export"
@@ -1380,67 +1291,61 @@ msgstr "Hart"
 msgid "Phantom"
 msgstr "Begrenzing"
 
-msgid "Add Net"
-msgstr "Voeg Draad Toe"
-
-msgid "Add Attribute"
-msgstr "Plaats Attribuut"
-
-msgid "Add Component"
+#, fuzzy
+msgid "Add Co_mponent..."
 msgstr "Voeg Component Toe"
 
-msgid "Add Bus"
+#, fuzzy
+msgid "Add Te_xt..."
+msgstr "Plaats een tekst..."
+
+#, fuzzy
+msgid "Add _Attribute..."
+msgstr "/Plaats Attribuut..."
+
+#, fuzzy
+msgid "Add _Net"
+msgstr "Voeg Draad Toe"
+
+#, fuzzy
+msgid "Add _Bus"
 msgstr "Voeg Bus Toe"
 
-msgid "Add Text"
-msgstr "Voeg Tekst Toe"
+msgid "Cu_t"
+msgstr "K_nip"
 
-msgid "Zoom In"
-msgstr "Vergroot"
+msgid "_Copy"
+msgstr "_Kopieer"
 
-msgid "Zoom Out"
-msgstr "Verklein"
+msgid "_Paste"
+msgstr "_Plak"
 
-msgid "Zoom Extents"
-msgstr "Toon Alles"
+msgid "_Delete"
+msgstr "Verwij_der"
 
-msgid "Select"
-msgstr "Selecteer"
-
-msgid "Edit..."
+#, fuzzy
+msgid "_Edit..."
 msgstr "Bewerk..."
 
 #, fuzzy
-msgid "Object Properties..."
+msgid "Ed_it Text..."
+msgstr "Bewerk Tekst..."
+
+#, fuzzy
+msgid "_Object Properties..."
 msgstr "<b>Tekst Eigenschappen</b>"
 
-msgid "Copy"
-msgstr "Kopieer"
-
-msgid "Move"
-msgstr "Verplaats"
-
-msgid "Delete"
-msgstr "Verwijder"
-
-msgid "Down Schematic"
+#, fuzzy
+msgid "Hierarchy: Down _Schematic"
 msgstr "Naar Schema"
 
-msgid "Down Symbol"
+#, fuzzy
+msgid "Hierarchy: Down S_ymbol"
 msgstr "Naar Symbool"
 
-msgid "Up"
-msgstr "Omhoog"
-
-#, fuzzy, c-format
-msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
-msgstr ""
-"Probeerde de gevoeligheid in te stellen op een niet bestaand menu_item '%s'\n"
-
-#, c-format
-msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
-msgstr ""
-"Probeerde de gevoeligheid in te stellen op een niet bestaand menu_item '%s'\n"
+#, fuzzy
+msgid "Hierarchy: _Up"
+msgstr "Hie_rarchie"
 
 msgid "The operating system is out of memory or resources."
 msgstr "Het besturingssysteem heeft niet meer geheugen of bronnen."
@@ -1463,6 +1368,9 @@ msgstr "Promoot"
 msgid "Duplicate"
 msgstr "Dupliceer"
 
+msgid "Delete"
+msgstr "Verwijder"
+
 msgid "Copy to all"
 msgstr "Kopieer naar alles"
 
@@ -1482,6 +1390,9 @@ msgstr "W"
 #, fuzzy
 msgid "Sho_w inherited attributes"
 msgstr "Toon geërfde attributen"
+
+msgid "Add Attribute"
+msgstr "Plaats Attribuut"
 
 #, fuzzy
 msgid "_Name:"
@@ -1606,6 +1517,25 @@ msgstr "Hie_rarchie"
 msgid "Hierarchy up"
 msgstr "Hie_rarchie"
 
+msgid "_New"
+msgstr "_Nieuw"
+
+msgid "_Open..."
+msgstr "_Open..."
+
+msgid "_Save"
+msgstr "Op_slaan"
+
+msgid "Save _As..."
+msgstr "Opslaan _Als..."
+
+#, fuzzy
+msgid "Page _Manager..."
+msgstr "Pagina Manager"
+
+msgid "_Close"
+msgstr "S_luit"
+
 #, fuzzy
 msgid "Options"
 msgstr "_Opties"
@@ -1726,6 +1656,9 @@ msgstr ""
 msgid "Add Text..."
 msgstr "Plaats een tekst..."
 
+msgid "Select"
+msgstr "Selecteer"
+
 msgid "Select mode"
 msgstr "Selectie mode"
 
@@ -1794,20 +1727,8 @@ msgstr "gEDA schema bewerking"
 msgid "Create and edit electrical schematics and symbols with lepton-schematic"
 msgstr "Creer en bewerk elektrische schema's en symbolen met gschem"
 
-msgid "_New"
-msgstr "_Nieuw"
-
-msgid "_Open..."
-msgstr "_Open..."
-
 msgid "Open Recen_t"
 msgstr "Open Recen_t"
-
-msgid "_Save"
-msgstr "Op_slaan"
-
-msgid "Save _As..."
-msgstr "Opslaan _Als..."
 
 msgid "Save All"
 msgstr "Alles Opslaan"
@@ -1841,18 +1762,6 @@ msgstr "_Ongedaan maken"
 msgid "_Redo"
 msgstr "He_rstel"
 
-msgid "Cu_t"
-msgstr "K_nip"
-
-msgid "_Copy"
-msgstr "_Kopieer"
-
-msgid "_Paste"
-msgstr "_Plak"
-
-msgid "_Delete"
-msgstr "Verwij_der"
-
 msgid "Select All"
 msgstr "Selecteer Alles"
 
@@ -1861,6 +1770,13 @@ msgstr "Deselecteer"
 
 msgid "Rotate 90 Mode"
 msgstr "Rotatie 90 Mode"
+
+#, fuzzy
+msgid "Object Properties..."
+msgstr "<b>Tekst Eigenschappen</b>"
+
+msgid "Edit..."
+msgstr "Bewerk..."
 
 msgid "Edit Text..."
 msgstr "Bewerk Tekst..."
@@ -1985,9 +1901,6 @@ msgstr "_Vorige"
 msgid "_Next"
 msgstr "Volge_nde"
 
-msgid "_Close"
-msgstr "S_luit"
-
 #, fuzzy
 msgid "_Revert..."
 msgstr "Te_rughalen"
@@ -2099,6 +2012,9 @@ msgid "Grid Style: Cycle Dots/Mesh/Off"
 msgstr ""
 
 msgid "Grid Snap: Cycle Grid/Resnap/Off"
+msgstr ""
+
+msgid "Grips: On/Off"
 msgstr ""
 
 #, fuzzy
@@ -2241,6 +2157,9 @@ msgstr "Zichtbaar/Verborgen Onzichtbare Tekst"
 msgid "Cut"
 msgstr "Knip"
 
+msgid "Copy"
+msgstr "Kopieer"
+
 msgid "Paste"
 msgstr "Plak"
 
@@ -2265,6 +2184,15 @@ msgstr "Verschuif Omhoog"
 
 msgid "Pan Down"
 msgstr "Verschuif Omlaag"
+
+msgid "Zoom Extents"
+msgstr "Toon Alles"
+
+msgid "Zoom In"
+msgstr "Vergroot"
+
+msgid "Zoom Out"
+msgstr "Verklein"
 
 msgid "Zoom Full"
 msgstr "Toon Volledig"
@@ -2294,6 +2222,18 @@ msgstr "Volgende Pagina"
 msgid "Print Page"
 msgstr "Druk Pagina Af"
 
+msgid "Add Component"
+msgstr "Voeg Component Toe"
+
+msgid "Add Net"
+msgstr "Voeg Draad Toe"
+
+msgid "Add Bus"
+msgstr "Voeg Bus Toe"
+
+msgid "Add Text"
+msgstr "Voeg Tekst Toe"
+
 msgid "Add Line"
 msgstr "Voeg Lijn Toe"
 
@@ -2314,6 +2254,12 @@ msgstr "Voeg Pen Toe"
 
 msgid "Add Picture"
 msgstr "Voeg Afbeelding Toe"
+
+msgid "Down Schematic"
+msgstr "Naar Schema"
+
+msgid "Down Symbol"
+msgstr "Naar Symbool"
 
 msgid "Up Hierarchy"
 msgstr "Hierarchie Omhoog"
@@ -2386,6 +2332,10 @@ msgstr "Toon Logboek Venster"
 msgid "Show Coordinate Window"
 msgstr "Toon Coordinaten Venster"
 
+#, fuzzy
+msgid "Toggle Grips"
+msgstr "Schakel Zich_tbaarheid"
+
 msgid "Component Documentation"
 msgstr "Component Documentatie"
 
@@ -2428,10 +2378,6 @@ msgstr "Toon de voorpagina van de gEDA wiki in een browser."
 msgid "About lepton-schematic"
 msgstr "Over gschem"
 
-#, scheme-format
-msgid "Invalid text alignment ~A."
-msgstr "Ongeldige tekst uitlijning ~A."
-
 #, fuzzy
 msgid "Could not show documentation:"
 msgstr ""
@@ -2448,6 +2394,134 @@ msgstr "~S is geen geldige toetsencombinatie."
 #, scheme-format
 msgid "~S is not a prefix key sequence."
 msgstr "~S is geen voorafgaande toetsen combinatie."
+
+#, scheme-format
+msgid "Invalid text alignment ~A."
+msgstr "Ongeldige tekst uitlijning ~A."
+
+#, fuzzy
+#~ msgid "Save settings to:"
+#~ msgstr "Instellingen"
+
+#, fuzzy
+#~ msgid "Invalid size [%1$d] passed to text-size\n"
+#~ msgstr "Ongeldige waarde [%d] overgedragen aan text-size\n"
+
+#, fuzzy
+#~ msgid "Invalid size [%1$d] passed to snap-size\n"
+#~ msgstr "Ongeldige waarde [%d] overgedragen aan snap-size\n"
+
+#, fuzzy
+#~ msgid "Invalid num levels [%1$d] passed to undo-levels\n"
+#~ msgstr "Ongeldige num niveaus [%d] overgedragen naar undo-levels\n"
+
+#, fuzzy
+#~ msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
+#~ msgstr "Ongeldige afmeting [%d] overgedragen aan bus-ripper-size\n"
+
+#, fuzzy
+#~ msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
+#~ msgstr "Ongeldige punt afmeting [%d] overgedragen aan dots-grid-dot-size\n"
+
+#, fuzzy
+#~ msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
+#~ msgstr ""
+#~ "Ongeldige beeldpunt ruimte [%d] overgedragen aan dots-grid-fixed-"
+#~ "threshold\n"
+
+#, fuzzy
+#~ msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
+#~ msgstr ""
+#~ "Ongeldige beeldpunt ruimte [%d] overgedragen aan mesh-grid-display-"
+#~ "threshold\n"
+
+#, fuzzy
+#~ msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
+#~ msgstr ""
+#~ "Ongeldig aantal seconden [%d] overgedragen naar auto-save-interval\n"
+
+#, fuzzy
+#~ msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
+#~ msgstr "Ongeldige versterking [%d] overgedragen aan mousepan-gain\n"
+
+#, fuzzy
+#~ msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
+#~ msgstr "Ongeldige versterking [%d] overgedragen aan keyboardpan-gain\n"
+
+#, fuzzy
+#~ msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
+#~ msgstr ""
+#~ "Ongeldig aantal beeldpunten [%d] overgedragen aan select-slack-pixels\n"
+
+#, fuzzy
+#~ msgid "Invalid gain [%1$d] passed to zoom-gain\n"
+#~ msgstr "Ongeldige versterking [%d] overgedragen aan zoom-gain\n"
+
+#, fuzzy
+#~ msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
+#~ msgstr "Ongeldig aantal stappen [%d] scrollpan-steps\n"
+
+#~ msgid "Got an unexpected NULL in o_edit\n"
+#~ msgstr "Ontving een onverwachte NULL in o_edit\n"
+
+#~ msgid "ERROR: NULL object in o_move_end!\n"
+#~ msgstr "FOUT: NULL object in o_move_end!\n"
+
+#, fuzzy
+#~ msgid ""
+#~ "Lepton EDA %1$s (git: %2$.7s)\n"
+#~ "Copyright (C) 1998-2017 by Ales Hvezda and the respective original "
+#~ "authors.\n"
+#~ "Copyright (C) 2017-2019 Lepton Developers.\n"
+#~ "This is free software, and you are welcome to redistribute it under\n"
+#~ "certain conditions. For details, see the file `COPYING', which is\n"
+#~ "included in the Lepton EDA distribution.\n"
+#~ "There is NO WARRANTY, to the extent permitted by law.\n"
+#~ msgstr ""
+#~ "gEDA %s (g%.7s)\n"
+#~ "Copyright (C) 1998-2012 gEDA developers\n"
+#~ "Dit is vrije software, en U bent welkom om deze te herdistribueren onder\n"
+#~ "bepaalde condities. Voor details, zie het bestand `COPYING', welke is\n"
+#~ "bijgevoegd in de gEDA distributie.\n"
+#~ "Er is GEEN GARANTIE, voor zover de wet dit toelaat.\n"
+
+#~ msgid "ERROR: NULL object!\n"
+#~ msgstr "FOUT: NULL object!\n"
+
+#, fuzzy
+#~ msgid "Could not allocate the color %1$s!\n"
+#~ msgstr "Kan de kleur %s niet toewijzen!\n"
+
+#~ msgid "black"
+#~ msgstr "zwart"
+
+#~ msgid "white"
+#~ msgstr "wit"
+
+#, fuzzy
+#~ msgid "Could not allocate display color %1$i!\n"
+#~ msgstr "Kan scherm kleur %i niet toewijzen!\n"
+
+#, fuzzy
+#~ msgid "Could not allocate outline color %1$i!\n"
+#~ msgstr "Kan de omlijning kleur %i niet toewijzen!\n"
+
+#~ msgid "Move"
+#~ msgstr "Verplaats"
+
+#~ msgid "Up"
+#~ msgstr "Omhoog"
+
+#, fuzzy
+#~ msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
+#~ msgstr ""
+#~ "Probeerde de gevoeligheid in te stellen op een niet bestaand menu_item "
+#~ "'%s'\n"
+
+#~ msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
+#~ msgstr ""
+#~ "Probeerde de gevoeligheid in te stellen op een niet bestaand menu_item "
+#~ "'%s'\n"
 
 #, fuzzy
 #~ msgid "Invalid offset [%1$d] passed to add-attribute-offset\n"
@@ -2750,9 +2824,6 @@ msgstr "~S is geen voorafgaande toetsen combinatie."
 
 #~ msgid "Function"
 #~ msgstr "Funktie"
-
-#~ msgid "/Add Attribute..."
-#~ msgstr "/Plaats Attribuut..."
 
 #~ msgid "/Zoom Box"
 #~ msgstr "/Vergroot Venster"

--- a/schematic/po/pl.po
+++ b/schematic/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-10-03 23:34+0300\n"
+"POT-Creation-Date: 2020-03-18 20:44+0300\n"
 "PO-Revision-Date: 2012-02-04 00:18+0000\n"
 "Last-Translator: Krzysztof Kościuszkiewicz <Unknown>\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -21,6 +21,13 @@ msgstr ""
 #, fuzzy
 msgid "Zoom too small!  Cannot zoom further."
 msgstr "Zbyt mały obszar! Osiągnięto maksymalny stopień powiększenia.\n"
+
+msgid ""
+"Save your color scheme to a file by clicking on the \"Save As...\"\n"
+"button. It can be loaded on startup with the following\n"
+"expression in the gschemrc configuration file:\n"
+"( primitive-load \"/path/to/saved-color-scheme-file\" )"
+msgstr ""
 
 #, fuzzy, c-format
 msgid ""
@@ -51,6 +58,11 @@ msgstr ""
 msgid "Sa_ve..."
 msgstr ""
 
+msgid ""
+"After you're done choosing the font, it's recommended\n"
+"to reopen schematics or restart the application."
+msgstr ""
+
 #, c-format
 msgid "<b>Current:</b> %s"
 msgstr ""
@@ -58,24 +70,21 @@ msgstr ""
 msgid "Save configuration"
 msgstr ""
 
+msgid "Local configuration file:"
+msgstr ""
+
+msgid "User configuration file:"
+msgstr ""
+
 #, fuzzy
-msgid "Save settings to:"
-msgstr "Ustawienia"
-
-msgid "Local configuration file (in current directory)"
-msgstr ""
-
-msgid "User configuration file (geda-user.conf)"
-msgstr ""
-
-msgid "Object ~A is not included in the current gschem page."
+msgid "Object ~A is not included in the current lepton-schematic page."
 msgstr "Obiekt ~A nie występuje w bieżącym arkuszu."
 
 msgid "Invalid text name/value visibility ~A."
 msgstr "Nieprawidłowe ustawienie widoczności tekstu: ~A."
 
 #, fuzzy, c-format
-msgid "You are running gEDA/gaf version [%1$s%2$s.%3$s],\n"
+msgid "You are running lepton-schematic version [%1$s%2$s.%3$s],\n"
 msgstr "gEDA/gschem, wersja %s%s.%s\n"
 
 #, c-format
@@ -88,72 +97,14 @@ msgstr ""
 msgid "Please be sure that you have the latest rc file.\n"
 msgstr ""
 
-#, fuzzy, c-format
-msgid "Invalid size [%1$d] passed to text-size\n"
-msgstr "Nieprawidłowy rozmiar [%d] przekazany do funkcji text-size\n"
-
-#, fuzzy, c-format
-msgid "Invalid size [%1$d] passed to snap-size\n"
-msgstr "Nieprawidłowy rozmiar [%d] przekazany do funkcji snap-size\n"
-
-#, fuzzy, c-format
-msgid "Invalid num levels [%1$d] passed to undo-levels\n"
-msgstr "Nieprawidłowa liczba poziomów [%d] przekazana do funkcji undo-levels\n"
-
-#, fuzzy, c-format
-msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
-msgstr "Nieprawidłowy rozmiar [%d] przekazany do funkcji bus-ripper-size\n"
-
-#, fuzzy, c-format
-msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
-msgstr ""
-"Nieprawidłowy rozmiar punktu [%d] przekazany do funkcji dots-grid-dot-size\n"
-
-#, fuzzy, c-format
-msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
-msgstr ""
-"Nieprawidłowy odstęp pikseli [%d] przekazany do funkcji dots-grid-fixed-"
-"threshold\n"
-
-#, fuzzy, c-format
-msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
-msgstr ""
-"Nieprawidłowy odstęp pikseli [%d] przekazany do funkcji mesh-grid-display-"
-"threshold\n"
-
-#, fuzzy, c-format
-msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
-msgstr ""
-"Nieprawidłowa liczba sekund [%d] przekazana do funkcji auto-save-interval\n"
-
-#, fuzzy, c-format
-msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
-msgstr "Nieprawidłowa wartość [%d] przekazana do funkcji mousepan-gain\n"
-
-#, fuzzy, c-format
-msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
-msgstr "Nieprawidłowa wartość [%d] przekazana do funkcji keyboardpan-gain\n"
-
-#, fuzzy, c-format
-msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
-msgstr ""
-"Nieprawidłowa ilość pikseli [%d] przekazana do funkcji select-slack-pixels\n"
-
-#, fuzzy, c-format
-msgid "Invalid gain [%1$d] passed to zoom-gain\n"
-msgstr "Nieprawidłowa wartość [%d] przekazana do funkcji zoom-gain\n"
-
-#, fuzzy, c-format
-msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
-msgstr "Niepoprawna liczba kroków [%d] w funkcji scrollpan-steps\n"
-
 msgid "Object ~A is not directly included in a page."
 msgstr "Obiekt ~A nie jest przypisany do arkusza"
 
 msgid "Could not launch URI ~S: ~A"
 msgstr "Nie można otworzyć adresu URI ~S: ~A"
 
-msgid "Found invalid gschem window smob ~S"
+#, fuzzy
+msgid "Found invalid lepton-schematic window smob ~S"
 msgstr "Nieprawidłowy obiekt reprezentujący okno gschem: ~S"
 
 #, fuzzy, c-format
@@ -189,7 +140,7 @@ msgstr "gEDA: GPL Electronic Design Automation"
 #, fuzzy
 msgid ""
 "Copyright © 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright © 2017-2019 Lepton Developers.\n"
+"Copyright © 2017-2020 Lepton Developers.\n"
 "See AUTHORS, ChangeLog files and consult 'git log' history for details."
 msgstr ""
 "Copyright © 1998-2012 Ales Hvezda <ahvezda@geda.seul.org>\n"
@@ -671,7 +622,8 @@ msgid ""
 "\n"
 "Are you sure you want to revert this page?\n"
 "All unsaved changes in current schematic will be\n"
-"discarded and page file will be reloaded from disk."
+"discarded and page file will be reloaded from disk.\n"
+"This action will also reload all component libraries."
 msgstr ""
 
 #, fuzzy
@@ -785,10 +737,6 @@ msgid_plural "Delete %1$u locked objects?"
 msgstr[0] "Zaznaczonych elementach"
 msgstr[1] "Zaznaczonych elementach"
 
-#, c-format
-msgid "Got an unexpected NULL in o_edit\n"
-msgstr "Niespodziewany wskaźnik NULL w funkcji o_edit\n"
-
 #, fuzzy
 msgid "Hidden text is now visible"
 msgstr "Ukryty tekst jest teraz widoczny\n"
@@ -803,7 +751,7 @@ msgstr ""
 "Nie odnaleziono symbolu [%s] w bibliotece. Aktualizacja nie powiodła się.\n"
 
 #, fuzzy, c-format
-msgid "o_autosave_backups: Can't get the real filename of %1$s."
+msgid "Can't get the real filename of %1$s."
 msgstr ""
 "o_autosave_backups: Nie można określić rzeczywistej nazwy pliku dla %s."
 
@@ -819,10 +767,6 @@ msgstr ""
 #, fuzzy, c-format
 msgid "Could NOT save backup file [%1$s]"
 msgstr "Zapisywanie kopii zapasowej [%s] nie powiodło się\n"
-
-#, c-format
-msgid "ERROR: NULL object in o_move_end!\n"
-msgstr "BŁĄD: objekt NULL w funkcji o_move_end!\n"
 
 #, c-format
 msgid "DOH! tried to find the whichone, but didn't find it!\n"
@@ -876,7 +820,7 @@ msgid "New slot number out of range"
 msgstr ""
 
 #, fuzzy
-msgid "Undo/Redo disabled in rc file"
+msgid "Undo/Redo is disabled in configuration"
 msgstr ""
 "Funkcjonalność Cofnij/Powtórz zostały wyłączone w pliku konfiguracyjnym\n"
 
@@ -898,19 +842,8 @@ msgid ""
 "  -h, --help               Help; this message.\n"
 "  --                       Treat all remaining arguments as filenames.\n"
 "\n"
-"Report bugs at <https://github.com/lepton-eda/lepton-eda/issues>\n"
-"Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"Lepton EDA %1$s (git: %2$.7s)\n"
-"Copyright (C) 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright (C) 2017-2019 Lepton Developers.\n"
-"This is free software, and you are welcome to redistribute it under\n"
-"certain conditions. For details, see the file `COPYING', which is\n"
-"included in the Lepton EDA distribution.\n"
-"There is NO WARRANTY, to the extent permitted by law.\n"
+"Report bugs at <%2$s>\n"
+"Lepton EDA homepage: <%3$s>\n"
 msgstr ""
 
 #, c-format
@@ -918,10 +851,6 @@ msgid "Got invalid show option; defaulting to show both\n"
 msgstr ""
 "Nieprawidłowa opcja; przyjmuję domyślną wartość \"wyświetlaj nazwę i wartość"
 "\"\n"
-
-#, c-format
-msgid "ERROR: NULL object!\n"
-msgstr "BŁĄD: obiekt NULL!\n"
 
 msgid "Single Attribute Editor"
 msgstr "Edycja pojedyńczego atrybutu"
@@ -979,7 +908,7 @@ msgid ""
 msgstr ""
 
 #, fuzzy
-msgid "No searchstring given in autonumber text."
+msgid "No search string given in autonumber text."
 msgstr "Nie podano tekstu wyszukiwania.\n"
 
 #, fuzzy
@@ -1058,24 +987,6 @@ msgstr ""
 
 msgid "Clipboard insertion failed"
 msgstr "Błąd podczas wklejania"
-
-#, fuzzy, c-format
-msgid "Could not allocate the color %1$s!\n"
-msgstr "Nieudana alokacja koloru %s!\n"
-
-msgid "black"
-msgstr "czarny"
-
-msgid "white"
-msgstr "biały"
-
-#, fuzzy, c-format
-msgid "Could not allocate display color %1$i!\n"
-msgstr "Nie udało się przydzielić koloru %i!\n"
-
-#, fuzzy, c-format
-msgid "Could not allocate outline color %1$i!\n"
-msgstr "Nie udało się przydzielić koloru obwiedni %i!\n"
 
 #, fuzzy, c-format
 msgid "Tried to get an invalid color: %1$d\n"
@@ -1222,13 +1133,16 @@ msgstr ""
 msgid "Invalid Attribute"
 msgstr "Nieprawidłowy atrybut"
 
-msgid "Schematics"
+#, fuzzy
+msgid "Schematics (*.sch)"
 msgstr "Schematy"
 
-msgid "Symbols"
+#, fuzzy
+msgid "Symbols (*.sym)"
 msgstr "Symbole"
 
-msgid "Schematics and symbols"
+#, fuzzy
+msgid "Schematics and symbols (*.sch *.sym)"
 msgstr "Schematy i symbole"
 
 msgid "All files"
@@ -1265,7 +1179,7 @@ msgid "Hatch"
 msgstr "Kreskowanie"
 
 #, fuzzy, c-format
-msgid "x_image_lowlevel: Unable to write %1$s file %2$s."
+msgid "Unable to write %1$s file %2$s."
 msgstr "x_image_lowlevel: Nieudany zapis pliku %s o nazwie %s.\n"
 
 #, fuzzy, c-format
@@ -1289,7 +1203,7 @@ msgid "Wrote black and white image to [%1$s] [%2$d x %3$d]"
 msgstr "Zapisano czarno-biały obraz do [%s] [%d x %d]\n"
 
 #, fuzzy
-msgid "x_image_lowlevel: Unable to get pixbuf from gschem's window."
+msgid "Unable to get pixbuf from lepton-schematic's window."
 msgstr "x_image_lowlevel: Nieudane pobranie obrazu z okna gschem.\n"
 
 msgid "NOTE: print-color-map will be used for PDF export"
@@ -1339,74 +1253,60 @@ msgid "Phantom"
 msgstr "Kropka-kropka-kreska"
 
 #, fuzzy
-msgid "Add Net"
-msgstr "/Dodaj połączenie"
-
-msgid "Add Attribute"
-msgstr "Dodaj atrybut"
-
-#, fuzzy
-msgid "Add Component"
+msgid "Add Co_mponent..."
 msgstr "/Dodaj element..."
 
 #, fuzzy
-msgid "Add Bus"
+msgid "Add Te_xt..."
+msgstr "Dodaj tekst..."
+
+#, fuzzy
+msgid "Add _Attribute..."
+msgstr "/Dodaj atrybut..."
+
+#, fuzzy
+msgid "Add _Net"
+msgstr "/Dodaj połączenie"
+
+#, fuzzy
+msgid "Add _Bus"
 msgstr "/Dodaj magistralę"
 
-#, fuzzy
-msgid "Add Text"
-msgstr "/Dodaj tekst"
+msgid "Cu_t"
+msgstr "Wy_tnij"
+
+msgid "_Copy"
+msgstr "_Kopiuj"
+
+msgid "_Paste"
+msgstr "_Wklej"
+
+msgid "_Delete"
+msgstr "_Usuń"
 
 #, fuzzy
-msgid "Zoom In"
-msgstr "/Powiększ"
-
-#, fuzzy
-msgid "Zoom Out"
-msgstr "/Pomniejsz"
-
-#, fuzzy
-msgid "Zoom Extents"
-msgstr "/Dopasuj do ekranu"
-
-msgid "Select"
-msgstr "Zaznaczanie"
-
-msgid "Edit..."
+msgid "_Edit..."
 msgstr "Edytuj..."
 
 #, fuzzy
-msgid "Object Properties..."
-msgstr "<b>Właściwości tekstu</b>"
-
-msgid "Copy"
-msgstr "Kopiuj"
-
-msgid "Move"
-msgstr "Przesuń"
-
-msgid "Delete"
-msgstr "Usuń"
+msgid "Ed_it Text..."
+msgstr "Edytuj tekst..."
 
 #, fuzzy
-msgid "Down Schematic"
+msgid "_Object Properties..."
+msgstr "<b>Właściwości tekstu</b>"
+
+#, fuzzy
+msgid "Hierarchy: Down _Schematic"
 msgstr "/Wgłąb schematu"
 
 #, fuzzy
-msgid "Down Symbol"
+msgid "Hierarchy: Down S_ymbol"
 msgstr "/Wgłąb symbolu"
 
 #, fuzzy
-msgid "Up"
-msgstr "/Do góry"
-
-#, fuzzy, c-format
-msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
-msgstr "Próba aktywacji nieistniejącego elementu menu '%s'\n"
-
-#, c-format
-msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
-msgstr "Próba aktywacji nieistniejącego elementu menu '%s'\n"
+msgid "Hierarchy: _Up"
+msgstr "Hie_rarchia"
 
 msgid "The operating system is out of memory or resources."
 msgstr "Brak pamięci lub innych zasobów systemu operacyjnego."
@@ -1429,6 +1329,9 @@ msgstr "Promuj"
 msgid "Duplicate"
 msgstr "Duplikuj"
 
+msgid "Delete"
+msgstr "Usuń"
+
 #, fuzzy
 msgid "Copy to all"
 msgstr "Kopiuj do 1"
@@ -1448,6 +1351,9 @@ msgstr "W"
 #, fuzzy
 msgid "Sho_w inherited attributes"
 msgstr "Pokaż odziedziczone atrybuty"
+
+msgid "Add Attribute"
+msgstr "Dodaj atrybut"
 
 #, fuzzy
 msgid "_Name:"
@@ -1565,6 +1471,25 @@ msgstr "Hie_rarchia"
 #, fuzzy
 msgid "Hierarchy up"
 msgstr "Hie_rarchia"
+
+msgid "_New"
+msgstr "_Nowy"
+
+msgid "_Open..."
+msgstr "_Otwórz..."
+
+msgid "_Save"
+msgstr "Zapi_sz"
+
+msgid "Save _As..."
+msgstr "Zapisz j_ako..."
+
+#, fuzzy
+msgid "Page _Manager..."
+msgstr "Zarządzanie arkuszami"
+
+msgid "_Close"
+msgstr "_Zamknij"
 
 #, fuzzy
 msgid "Options"
@@ -1686,6 +1611,9 @@ msgstr ""
 msgid "Add Text..."
 msgstr "Dodaj tekst..."
 
+msgid "Select"
+msgstr "Zaznaczanie"
+
 msgid "Select mode"
 msgstr "Tryb zaznaczania"
 
@@ -1755,20 +1683,8 @@ msgstr "gEDA Edytor Schematów"
 msgid "Create and edit electrical schematics and symbols with lepton-schematic"
 msgstr "Projektuj i edytuj schematy i symbole elektroniczne za pomocą gschem"
 
-msgid "_New"
-msgstr "_Nowy"
-
-msgid "_Open..."
-msgstr "_Otwórz..."
-
 msgid "Open Recen_t"
 msgstr "Otwórz os_tatnio używane"
-
-msgid "_Save"
-msgstr "Zapi_sz"
-
-msgid "Save _As..."
-msgstr "Zapisz j_ako..."
 
 msgid "Save All"
 msgstr "Zapisz _wszystkie"
@@ -1802,18 +1718,6 @@ msgstr "_Cofnij"
 msgid "_Redo"
 msgstr "_Ponów"
 
-msgid "Cu_t"
-msgstr "Wy_tnij"
-
-msgid "_Copy"
-msgstr "_Kopiuj"
-
-msgid "_Paste"
-msgstr "_Wklej"
-
-msgid "_Delete"
-msgstr "_Usuń"
-
 msgid "Select All"
 msgstr ""
 
@@ -1822,6 +1726,13 @@ msgstr "Odznacz"
 
 msgid "Rotate 90 Mode"
 msgstr "Obróć o 90 stopni"
+
+#, fuzzy
+msgid "Object Properties..."
+msgstr "<b>Właściwości tekstu</b>"
+
+msgid "Edit..."
+msgstr "Edytuj..."
 
 msgid "Edit Text..."
 msgstr "Edytuj tekst..."
@@ -1946,9 +1857,6 @@ msgstr "_Poprzedni"
 msgid "_Next"
 msgstr "_Następny"
 
-msgid "_Close"
-msgstr "_Zamknij"
-
 #, fuzzy
 msgid "_Revert..."
 msgstr "P_rzywróć"
@@ -2060,6 +1968,9 @@ msgid "Grid Style: Cycle Dots/Mesh/Off"
 msgstr ""
 
 msgid "Grid Snap: Cycle Grid/Resnap/Off"
+msgstr ""
+
+msgid "Grips: On/Off"
 msgstr ""
 
 #, fuzzy
@@ -2212,6 +2123,9 @@ msgstr "Wyświetlaj/ukryj niewidoczny tekst"
 msgid "Cut"
 msgstr "Wy_tnij"
 
+msgid "Copy"
+msgstr "Kopiuj"
+
 #, fuzzy
 msgid "Paste"
 msgstr "_Wklej"
@@ -2241,6 +2155,18 @@ msgstr ""
 #, fuzzy
 msgid "Pan Down"
 msgstr "Tryb przesuwania widoku"
+
+#, fuzzy
+msgid "Zoom Extents"
+msgstr "/Dopasuj do ekranu"
+
+#, fuzzy
+msgid "Zoom In"
+msgstr "/Powiększ"
+
+#, fuzzy
+msgid "Zoom Out"
+msgstr "/Pomniejsz"
 
 #, fuzzy
 msgid "Zoom Full"
@@ -2278,6 +2204,22 @@ msgid "Print Page"
 msgstr "_Poprzedni"
 
 #, fuzzy
+msgid "Add Component"
+msgstr "/Dodaj element..."
+
+#, fuzzy
+msgid "Add Net"
+msgstr "/Dodaj połączenie"
+
+#, fuzzy
+msgid "Add Bus"
+msgstr "/Dodaj magistralę"
+
+#, fuzzy
+msgid "Add Text"
+msgstr "/Dodaj tekst"
+
+#, fuzzy
 msgid "Add Line"
 msgstr "Linię"
 
@@ -2303,6 +2245,14 @@ msgstr ""
 #, fuzzy
 msgid "Add Picture"
 msgstr "Obraz"
+
+#, fuzzy
+msgid "Down Schematic"
+msgstr "/Wgłąb schematu"
+
+#, fuzzy
+msgid "Down Symbol"
+msgstr "/Wgłąb symbolu"
 
 #, fuzzy
 msgid "Up Hierarchy"
@@ -2395,6 +2345,10 @@ msgid "Show Coordinate Window"
 msgstr "Pokaż okno współrzędnych..."
 
 #, fuzzy
+msgid "Toggle Grips"
+msgstr "Przełącz _widoczność"
+
+#, fuzzy
 msgid "Component Documentation"
 msgstr "Dokumentacja _elementu..."
 
@@ -2432,10 +2386,6 @@ msgstr ""
 msgid "About lepton-schematic"
 msgstr "O programie"
 
-#, scheme-format
-msgid "Invalid text alignment ~A."
-msgstr ""
-
 #, fuzzy
 msgid "Could not show documentation:"
 msgstr "Dokumentacja _elementu..."
@@ -2450,6 +2400,118 @@ msgstr ""
 #, scheme-format
 msgid "~S is not a prefix key sequence."
 msgstr ""
+
+#, scheme-format
+msgid "Invalid text alignment ~A."
+msgstr ""
+
+#, fuzzy
+#~ msgid "Save settings to:"
+#~ msgstr "Ustawienia"
+
+#, fuzzy
+#~ msgid "Invalid size [%1$d] passed to text-size\n"
+#~ msgstr "Nieprawidłowy rozmiar [%d] przekazany do funkcji text-size\n"
+
+#, fuzzy
+#~ msgid "Invalid size [%1$d] passed to snap-size\n"
+#~ msgstr "Nieprawidłowy rozmiar [%d] przekazany do funkcji snap-size\n"
+
+#, fuzzy
+#~ msgid "Invalid num levels [%1$d] passed to undo-levels\n"
+#~ msgstr ""
+#~ "Nieprawidłowa liczba poziomów [%d] przekazana do funkcji undo-levels\n"
+
+#, fuzzy
+#~ msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
+#~ msgstr "Nieprawidłowy rozmiar [%d] przekazany do funkcji bus-ripper-size\n"
+
+#, fuzzy
+#~ msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
+#~ msgstr ""
+#~ "Nieprawidłowy rozmiar punktu [%d] przekazany do funkcji dots-grid-dot-"
+#~ "size\n"
+
+#, fuzzy
+#~ msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
+#~ msgstr ""
+#~ "Nieprawidłowy odstęp pikseli [%d] przekazany do funkcji dots-grid-fixed-"
+#~ "threshold\n"
+
+#, fuzzy
+#~ msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
+#~ msgstr ""
+#~ "Nieprawidłowy odstęp pikseli [%d] przekazany do funkcji mesh-grid-display-"
+#~ "threshold\n"
+
+#, fuzzy
+#~ msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
+#~ msgstr ""
+#~ "Nieprawidłowa liczba sekund [%d] przekazana do funkcji auto-save-"
+#~ "interval\n"
+
+#, fuzzy
+#~ msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
+#~ msgstr "Nieprawidłowa wartość [%d] przekazana do funkcji mousepan-gain\n"
+
+#, fuzzy
+#~ msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
+#~ msgstr "Nieprawidłowa wartość [%d] przekazana do funkcji keyboardpan-gain\n"
+
+#, fuzzy
+#~ msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
+#~ msgstr ""
+#~ "Nieprawidłowa ilość pikseli [%d] przekazana do funkcji select-slack-"
+#~ "pixels\n"
+
+#, fuzzy
+#~ msgid "Invalid gain [%1$d] passed to zoom-gain\n"
+#~ msgstr "Nieprawidłowa wartość [%d] przekazana do funkcji zoom-gain\n"
+
+#, fuzzy
+#~ msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
+#~ msgstr "Niepoprawna liczba kroków [%d] w funkcji scrollpan-steps\n"
+
+#~ msgid "Got an unexpected NULL in o_edit\n"
+#~ msgstr "Niespodziewany wskaźnik NULL w funkcji o_edit\n"
+
+#~ msgid "ERROR: NULL object in o_move_end!\n"
+#~ msgstr "BŁĄD: objekt NULL w funkcji o_move_end!\n"
+
+#~ msgid "ERROR: NULL object!\n"
+#~ msgstr "BŁĄD: obiekt NULL!\n"
+
+#, fuzzy
+#~ msgid "Could not allocate the color %1$s!\n"
+#~ msgstr "Nieudana alokacja koloru %s!\n"
+
+#~ msgid "black"
+#~ msgstr "czarny"
+
+#~ msgid "white"
+#~ msgstr "biały"
+
+#, fuzzy
+#~ msgid "Could not allocate display color %1$i!\n"
+#~ msgstr "Nie udało się przydzielić koloru %i!\n"
+
+#, fuzzy
+#~ msgid "Could not allocate outline color %1$i!\n"
+#~ msgstr "Nie udało się przydzielić koloru obwiedni %i!\n"
+
+#~ msgid "Move"
+#~ msgstr "Przesuń"
+
+#, fuzzy
+#~ msgid "Up"
+#~ msgstr "/Do góry"
+
+#, fuzzy
+#~ msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
+#~ msgstr "Próba aktywacji nieistniejącego elementu menu '%s'\n"
+
+#~ msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
+#~ msgstr "Próba aktywacji nieistniejącego elementu menu '%s'\n"
 
 #, fuzzy
 #~ msgid "Invalid offset [%1$d] passed to add-attribute-offset\n"
@@ -2750,9 +2812,6 @@ msgstr ""
 
 #~ msgid "Function"
 #~ msgstr "Funkcja"
-
-#~ msgid "/Add Attribute..."
-#~ msgstr "/Dodaj atrybut..."
 
 #~ msgid "/Zoom Box"
 #~ msgstr "/Powiększ fragment"

--- a/schematic/po/pt.po
+++ b/schematic/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-10-03 23:34+0300\n"
+"POT-Creation-Date: 2020-03-18 20:44+0300\n"
 "PO-Revision-Date: 2012-01-27 14:23+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -21,6 +21,13 @@ msgstr ""
 #, fuzzy
 msgid "Zoom too small!  Cannot zoom further."
 msgstr "Ampliação ampliação pequena! Não é possível ampliar mais.\n"
+
+msgid ""
+"Save your color scheme to a file by clicking on the \"Save As...\"\n"
+"button. It can be loaded on startup with the following\n"
+"expression in the gschemrc configuration file:\n"
+"( primitive-load \"/path/to/saved-color-scheme-file\" )"
+msgstr ""
 
 #, fuzzy, c-format
 msgid ""
@@ -51,6 +58,11 @@ msgstr ""
 msgid "Sa_ve..."
 msgstr ""
 
+msgid ""
+"After you're done choosing the font, it's recommended\n"
+"to reopen schematics or restart the application."
+msgstr ""
+
 #, c-format
 msgid "<b>Current:</b> %s"
 msgstr ""
@@ -58,24 +70,20 @@ msgstr ""
 msgid "Save configuration"
 msgstr ""
 
-#, fuzzy
-msgid "Save settings to:"
-msgstr "Preferências"
-
-msgid "Local configuration file (in current directory)"
+msgid "Local configuration file:"
 msgstr ""
 
-msgid "User configuration file (geda-user.conf)"
+msgid "User configuration file:"
 msgstr ""
 
-msgid "Object ~A is not included in the current gschem page."
+msgid "Object ~A is not included in the current lepton-schematic page."
 msgstr ""
 
 msgid "Invalid text name/value visibility ~A."
 msgstr ""
 
 #, fuzzy, c-format
-msgid "You are running gEDA/gaf version [%1$s%2$s.%3$s],\n"
+msgid "You are running lepton-schematic version [%1$s%2$s.%3$s],\n"
 msgstr "gEDA/gschem versão %s%s.%s\n"
 
 #, c-format
@@ -88,69 +96,13 @@ msgstr ""
 msgid "Please be sure that you have the latest rc file.\n"
 msgstr ""
 
-#, fuzzy, c-format
-msgid "Invalid size [%1$d] passed to text-size\n"
-msgstr "Tamanho inválido [%d] passado a tamanho de texto\n"
-
-#, fuzzy, c-format
-msgid "Invalid size [%1$d] passed to snap-size\n"
-msgstr "Tamanho inválido [%d] passado a função snap-size\n"
-
-#, fuzzy, c-format
-msgid "Invalid num levels [%1$d] passed to undo-levels\n"
-msgstr "Numero de níveis inválidos [%d] passados a função undo-levels\n"
-
-#, fuzzy, c-format
-msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
-msgstr "Tamanho inválido [%d] passado a função bus-ripper-size\n"
-
-#, fuzzy, c-format
-msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
-msgstr "Tamanho de ponto inválido [%d] passado a função dots-grid-dot-size\n"
-
-#, fuzzy, c-format
-msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
-msgstr ""
-"Espaçamento de pixel inválido [%d] passado a função dots-grid-fixed-"
-"threshold\n"
-
-#, fuzzy, c-format
-msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
-msgstr ""
-"Espaçamento de pixel inválido [%d] passado a função mesh-grid-display-"
-"threshold\n"
-
-#, fuzzy, c-format
-msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
-msgstr "Numero de segundos inválido [%d] passado a função auto-save-interval\n"
-
-#, fuzzy, c-format
-msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
-msgstr "Ganho inválido [%d] passado a função mousepan-gain\n"
-
-#, fuzzy, c-format
-msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
-msgstr "Ganho inválido [%d] passado a função keyboardpan-gain\n"
-
-#, fuzzy, c-format
-msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
-msgstr "Número de pixeis inválido [%d] passado a função select-slack-pixels\n"
-
-#, fuzzy, c-format
-msgid "Invalid gain [%1$d] passed to zoom-gain\n"
-msgstr "Ganho inválido [%d] passado a função zoom-gain\n"
-
-#, fuzzy, c-format
-msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
-msgstr "Numero de passos inválido [%d] passado a função scrollpan-steps\n"
-
 msgid "Object ~A is not directly included in a page."
 msgstr ""
 
 msgid "Could not launch URI ~S: ~A"
 msgstr ""
 
-msgid "Found invalid gschem window smob ~S"
+msgid "Found invalid lepton-schematic window smob ~S"
 msgstr ""
 
 #, fuzzy, c-format
@@ -181,7 +133,7 @@ msgstr ""
 
 msgid ""
 "Copyright © 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright © 2017-2019 Lepton Developers.\n"
+"Copyright © 2017-2020 Lepton Developers.\n"
 "See AUTHORS, ChangeLog files and consult 'git log' history for details."
 msgstr ""
 
@@ -667,7 +619,8 @@ msgid ""
 "\n"
 "Are you sure you want to revert this page?\n"
 "All unsaved changes in current schematic will be\n"
-"discarded and page file will be reloaded from disk."
+"discarded and page file will be reloaded from disk.\n"
+"This action will also reload all component libraries."
 msgstr ""
 
 #, fuzzy
@@ -779,10 +732,6 @@ msgid_plural "Delete %1$u locked objects?"
 msgstr[0] "Objectos seleccionados"
 msgstr[1] "Objectos seleccionados"
 
-#, c-format
-msgid "Got an unexpected NULL in o_edit\n"
-msgstr "Foi obtido um NULL inesperado em o_edit\n"
-
 #, fuzzy
 msgid "Hidden text is now visible"
 msgstr "Texto escondido é agora visível\n"
@@ -797,7 +746,7 @@ msgstr ""
 "Não foi possível encontrar símbolo [%s] na biblioteca. Actualização falhou.\n"
 
 #, fuzzy, c-format
-msgid "o_autosave_backups: Can't get the real filename of %1$s."
+msgid "Can't get the real filename of %1$s."
 msgstr "o_autosave_backups: Não foi possível obter o verdadeiro nome de %s."
 
 #, fuzzy, c-format
@@ -814,10 +763,6 @@ msgstr ""
 #, fuzzy, c-format
 msgid "Could NOT save backup file [%1$s]"
 msgstr "Não foi possível guardar ficheiro de salvaguarda [%s]\n"
-
-#, c-format
-msgid "ERROR: NULL object in o_move_end!\n"
-msgstr "ERRO: Objecto NULL em o_move_end!\n"
 
 #, c-format
 msgid "DOH! tried to find the whichone, but didn't find it!\n"
@@ -877,7 +822,7 @@ msgid "New slot number out of range"
 msgstr "Novo numero de elemento fora de alcance\n"
 
 #, fuzzy
-msgid "Undo/Redo disabled in rc file"
+msgid "Undo/Redo is disabled in configuration"
 msgstr "Desfazer/Refazer não activo no ficheiro rc\n"
 
 #, c-format
@@ -898,29 +843,14 @@ msgid ""
 "  -h, --help               Help; this message.\n"
 "  --                       Treat all remaining arguments as filenames.\n"
 "\n"
-"Report bugs at <https://github.com/lepton-eda/lepton-eda/issues>\n"
-"Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"Lepton EDA %1$s (git: %2$.7s)\n"
-"Copyright (C) 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright (C) 2017-2019 Lepton Developers.\n"
-"This is free software, and you are welcome to redistribute it under\n"
-"certain conditions. For details, see the file `COPYING', which is\n"
-"included in the Lepton EDA distribution.\n"
-"There is NO WARRANTY, to the extent permitted by law.\n"
+"Report bugs at <%2$s>\n"
+"Lepton EDA homepage: <%3$s>\n"
 msgstr ""
 
 #, c-format
 msgid "Got invalid show option; defaulting to show both\n"
 msgstr ""
 "Obtida opção de visualização inválida; A alterar para visualizar ambos\n"
-
-#, c-format
-msgid "ERROR: NULL object!\n"
-msgstr "ERROR: Objecto NULL!\n"
 
 msgid "Single Attribute Editor"
 msgstr "Editor de único atributo"
@@ -983,7 +913,7 @@ msgstr ""
 "slot=%d]\n"
 
 #, fuzzy
-msgid "No searchstring given in autonumber text."
+msgid "No search string given in autonumber text."
 msgstr "Nenhuma frase de procura dada no texto de auto-numeração.\n"
 
 #, fuzzy
@@ -1059,24 +989,6 @@ msgstr ""
 
 msgid "Clipboard insertion failed"
 msgstr ""
-
-#, fuzzy, c-format
-msgid "Could not allocate the color %1$s!\n"
-msgstr "Não foi possível atribuir a cor %s!\n"
-
-msgid "black"
-msgstr "preto"
-
-msgid "white"
-msgstr "branco"
-
-#, fuzzy, c-format
-msgid "Could not allocate display color %1$i!\n"
-msgstr "Não foi possível atribuir cor do ecran %i!\n"
-
-#, fuzzy, c-format
-msgid "Could not allocate outline color %1$i!\n"
-msgstr "Não foi possível atribuir cor do contorno %i!\n"
 
 #, fuzzy, c-format
 msgid "Tried to get an invalid color: %1$d\n"
@@ -1224,13 +1136,16 @@ msgstr ""
 msgid "Invalid Attribute"
 msgstr "Atributo Inválido"
 
-msgid "Schematics"
+#, fuzzy
+msgid "Schematics (*.sch)"
 msgstr "Esquemas"
 
-msgid "Symbols"
+#, fuzzy
+msgid "Symbols (*.sym)"
 msgstr "Símbolos"
 
-msgid "Schematics and symbols"
+#, fuzzy
+msgid "Schematics and symbols (*.sch *.sym)"
 msgstr "Esquemas e símbolos"
 
 msgid "All files"
@@ -1267,7 +1182,7 @@ msgid "Hatch"
 msgstr "Escotilha"
 
 #, fuzzy, c-format
-msgid "x_image_lowlevel: Unable to write %1$s file %2$s."
+msgid "Unable to write %1$s file %2$s."
 msgstr "x_image_lowlevel: Não foi possível escrever %s no ficheiro %s.\n"
 
 #, fuzzy, c-format
@@ -1292,7 +1207,7 @@ msgid "Wrote black and white image to [%1$s] [%2$d x %3$d]"
 msgstr "Escreveu-se imagem a preto e branco em [%s] [%d x %d]\n"
 
 #, fuzzy
-msgid "x_image_lowlevel: Unable to get pixbuf from gschem's window."
+msgid "Unable to get pixbuf from lepton-schematic's window."
 msgstr ""
 "x_image_lowlevel: Não foi possível obter mapa de bits a partir janela do "
 "gschem.\n"
@@ -1344,74 +1259,60 @@ msgid "Phantom"
 msgstr "Fantasma"
 
 #, fuzzy
-msgid "Add Net"
-msgstr "/Adicionar Ligação"
-
-msgid "Add Attribute"
-msgstr "Adicionar Atributo"
-
-#, fuzzy
-msgid "Add Component"
+msgid "Add Co_mponent..."
 msgstr "/Adicionar Componente..."
 
 #, fuzzy
-msgid "Add Bus"
+msgid "Add Te_xt..."
+msgstr "Adicionar Texto..."
+
+#, fuzzy
+msgid "Add _Attribute..."
+msgstr "/Adicionar Atributo"
+
+#, fuzzy
+msgid "Add _Net"
+msgstr "/Adicionar Ligação"
+
+#, fuzzy
+msgid "Add _Bus"
 msgstr "/Adicionar Barramento"
 
-#, fuzzy
-msgid "Add Text"
-msgstr "/Adicionar Texto"
+msgid "Cu_t"
+msgstr "Cor_tar"
+
+msgid "_Copy"
+msgstr "_Copiar"
+
+msgid "_Paste"
+msgstr "C_olar"
+
+msgid "_Delete"
+msgstr "_Eliminar"
 
 #, fuzzy
-msgid "Zoom In"
-msgstr "/Ampliar"
-
-#, fuzzy
-msgid "Zoom Out"
-msgstr "/Diminuir"
-
-#, fuzzy
-msgid "Zoom Extents"
-msgstr "/Mostrar Tudo"
-
-msgid "Select"
-msgstr "Seleccionar"
-
-msgid "Edit..."
+msgid "_Edit..."
 msgstr "Editar..."
 
 #, fuzzy
-msgid "Object Properties..."
-msgstr "<b>Propriedades do Texto</b>"
-
-msgid "Copy"
-msgstr "Copiar"
-
-msgid "Move"
-msgstr "Mover"
-
-msgid "Delete"
-msgstr "Eliminar"
+msgid "Ed_it Text..."
+msgstr "Editar Texto..."
 
 #, fuzzy
-msgid "Down Schematic"
+msgid "_Object Properties..."
+msgstr "<b>Propriedades do Texto</b>"
+
+#, fuzzy
+msgid "Hierarchy: Down _Schematic"
 msgstr "/Baixar Esquema"
 
 #, fuzzy
-msgid "Down Symbol"
+msgid "Hierarchy: Down S_ymbol"
 msgstr "/Baixar Símbolo"
 
 #, fuzzy
-msgid "Up"
-msgstr "/Acima"
-
-#, fuzzy, c-format
-msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
-msgstr "Tentou-se definir a sensibilidade num menu_item não existente '%s'\n"
-
-#, c-format
-msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
-msgstr "Tentou-se definir a sensibilidade num menu_item não existente '%s'\n"
+msgid "Hierarchy: _Up"
+msgstr "Hie_rarquia"
 
 msgid "The operating system is out of memory or resources."
 msgstr ""
@@ -1435,6 +1336,9 @@ msgstr "Promover"
 msgid "Duplicate"
 msgstr "Duplicar"
 
+msgid "Delete"
+msgstr "Eliminar"
+
 #, fuzzy
 msgid "Copy to all"
 msgstr "Copiar para 1"
@@ -1454,6 +1358,9 @@ msgstr "V"
 #, fuzzy
 msgid "Sho_w inherited attributes"
 msgstr "Mostrar atributos inerentes"
+
+msgid "Add Attribute"
+msgstr "Adicionar Atributo"
 
 #, fuzzy
 msgid "_Name:"
@@ -1564,6 +1471,25 @@ msgstr "Hie_rarquia"
 #, fuzzy
 msgid "Hierarchy up"
 msgstr "Hie_rarquia"
+
+msgid "_New"
+msgstr "_Novo"
+
+msgid "_Open..."
+msgstr "_Abrir..."
+
+msgid "_Save"
+msgstr "_Guardar"
+
+msgid "Save _As..."
+msgstr "Gu_ardar como..."
+
+#, fuzzy
+msgid "Page _Manager..."
+msgstr "Gestor de Pagina"
+
+msgid "_Close"
+msgstr "Fe_char"
 
 #, fuzzy
 msgid "Options"
@@ -1685,6 +1611,9 @@ msgstr ""
 msgid "Add Text..."
 msgstr "Adicionar Texto..."
 
+msgid "Select"
+msgstr "Seleccionar"
+
 msgid "Select mode"
 msgstr "Seleccionar modo"
 
@@ -1750,20 +1679,8 @@ msgstr "gEDA - Editor Esquemático"
 msgid "Create and edit electrical schematics and symbols with lepton-schematic"
 msgstr "Crie e edite esquemas e símbolos eléctricos e electrónicos com gschem"
 
-msgid "_New"
-msgstr "_Novo"
-
-msgid "_Open..."
-msgstr "_Abrir..."
-
 msgid "Open Recen_t"
 msgstr "Abrir Recen_te"
-
-msgid "_Save"
-msgstr "_Guardar"
-
-msgid "Save _As..."
-msgstr "Gu_ardar como..."
 
 msgid "Save All"
 msgstr "Guardar Tudo"
@@ -1797,18 +1714,6 @@ msgstr "_Desfazer"
 msgid "_Redo"
 msgstr "_Refazer"
 
-msgid "Cu_t"
-msgstr "Cor_tar"
-
-msgid "_Copy"
-msgstr "_Copiar"
-
-msgid "_Paste"
-msgstr "C_olar"
-
-msgid "_Delete"
-msgstr "_Eliminar"
-
 msgid "Select All"
 msgstr ""
 
@@ -1817,6 +1722,13 @@ msgstr ""
 
 msgid "Rotate 90 Mode"
 msgstr "Modo rotação 90"
+
+#, fuzzy
+msgid "Object Properties..."
+msgstr "<b>Propriedades do Texto</b>"
+
+msgid "Edit..."
+msgstr "Editar..."
 
 msgid "Edit Text..."
 msgstr "Editar Texto..."
@@ -1941,9 +1853,6 @@ msgstr "_Anterior"
 msgid "_Next"
 msgstr "_Seguinte"
 
-msgid "_Close"
-msgstr "Fe_char"
-
 #, fuzzy
 msgid "_Revert..."
 msgstr "_Reverter"
@@ -2055,6 +1964,9 @@ msgid "Grid Style: Cycle Dots/Mesh/Off"
 msgstr ""
 
 msgid "Grid Snap: Cycle Grid/Resnap/Off"
+msgstr ""
+
+msgid "Grips: On/Off"
 msgstr ""
 
 #, fuzzy
@@ -2207,6 +2119,9 @@ msgstr "Mostrar/Esconder Texto Escondido"
 msgid "Cut"
 msgstr "Cor_tar"
 
+msgid "Copy"
+msgstr "Copiar"
+
 #, fuzzy
 msgid "Paste"
 msgstr "C_olar"
@@ -2236,6 +2151,18 @@ msgstr ""
 #, fuzzy
 msgid "Pan Down"
 msgstr "Modo Centrar"
+
+#, fuzzy
+msgid "Zoom Extents"
+msgstr "/Mostrar Tudo"
+
+#, fuzzy
+msgid "Zoom In"
+msgstr "/Ampliar"
+
+#, fuzzy
+msgid "Zoom Out"
+msgstr "/Diminuir"
 
 #, fuzzy
 msgid "Zoom Full"
@@ -2273,6 +2200,22 @@ msgid "Print Page"
 msgstr "_Anterior"
 
 #, fuzzy
+msgid "Add Component"
+msgstr "/Adicionar Componente..."
+
+#, fuzzy
+msgid "Add Net"
+msgstr "/Adicionar Ligação"
+
+#, fuzzy
+msgid "Add Bus"
+msgstr "/Adicionar Barramento"
+
+#, fuzzy
+msgid "Add Text"
+msgstr "/Adicionar Texto"
+
+#, fuzzy
 msgid "Add Line"
 msgstr "Linha"
 
@@ -2298,6 +2241,14 @@ msgstr ""
 #, fuzzy
 msgid "Add Picture"
 msgstr "Imagem"
+
+#, fuzzy
+msgid "Down Schematic"
+msgstr "/Baixar Esquema"
+
+#, fuzzy
+msgid "Down Symbol"
+msgstr "/Baixar Símbolo"
 
 #, fuzzy
 msgid "Up Hierarchy"
@@ -2390,6 +2341,10 @@ msgid "Show Coordinate Window"
 msgstr "Mostrar Janela de _Coordenadas..."
 
 #, fuzzy
+msgid "Toggle Grips"
+msgstr "Al_ternar Visibilidade"
+
+#, fuzzy
 msgid "Component Documentation"
 msgstr "Documentação de _Componente..."
 
@@ -2427,10 +2382,6 @@ msgstr ""
 msgid "About lepton-schematic"
 msgstr "Sobre gschem"
 
-#, scheme-format
-msgid "Invalid text alignment ~A."
-msgstr ""
-
 #, fuzzy
 msgid "Could not show documentation:"
 msgstr "Documentação de _Componente..."
@@ -2445,6 +2396,116 @@ msgstr ""
 #, scheme-format
 msgid "~S is not a prefix key sequence."
 msgstr ""
+
+#, scheme-format
+msgid "Invalid text alignment ~A."
+msgstr ""
+
+#, fuzzy
+#~ msgid "Save settings to:"
+#~ msgstr "Preferências"
+
+#, fuzzy
+#~ msgid "Invalid size [%1$d] passed to text-size\n"
+#~ msgstr "Tamanho inválido [%d] passado a tamanho de texto\n"
+
+#, fuzzy
+#~ msgid "Invalid size [%1$d] passed to snap-size\n"
+#~ msgstr "Tamanho inválido [%d] passado a função snap-size\n"
+
+#, fuzzy
+#~ msgid "Invalid num levels [%1$d] passed to undo-levels\n"
+#~ msgstr "Numero de níveis inválidos [%d] passados a função undo-levels\n"
+
+#, fuzzy
+#~ msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
+#~ msgstr "Tamanho inválido [%d] passado a função bus-ripper-size\n"
+
+#, fuzzy
+#~ msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
+#~ msgstr ""
+#~ "Tamanho de ponto inválido [%d] passado a função dots-grid-dot-size\n"
+
+#, fuzzy
+#~ msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
+#~ msgstr ""
+#~ "Espaçamento de pixel inválido [%d] passado a função dots-grid-fixed-"
+#~ "threshold\n"
+
+#, fuzzy
+#~ msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
+#~ msgstr ""
+#~ "Espaçamento de pixel inválido [%d] passado a função mesh-grid-display-"
+#~ "threshold\n"
+
+#, fuzzy
+#~ msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
+#~ msgstr ""
+#~ "Numero de segundos inválido [%d] passado a função auto-save-interval\n"
+
+#, fuzzy
+#~ msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
+#~ msgstr "Ganho inválido [%d] passado a função mousepan-gain\n"
+
+#, fuzzy
+#~ msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
+#~ msgstr "Ganho inválido [%d] passado a função keyboardpan-gain\n"
+
+#, fuzzy
+#~ msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
+#~ msgstr ""
+#~ "Número de pixeis inválido [%d] passado a função select-slack-pixels\n"
+
+#, fuzzy
+#~ msgid "Invalid gain [%1$d] passed to zoom-gain\n"
+#~ msgstr "Ganho inválido [%d] passado a função zoom-gain\n"
+
+#, fuzzy
+#~ msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
+#~ msgstr "Numero de passos inválido [%d] passado a função scrollpan-steps\n"
+
+#~ msgid "Got an unexpected NULL in o_edit\n"
+#~ msgstr "Foi obtido um NULL inesperado em o_edit\n"
+
+#~ msgid "ERROR: NULL object in o_move_end!\n"
+#~ msgstr "ERRO: Objecto NULL em o_move_end!\n"
+
+#~ msgid "ERROR: NULL object!\n"
+#~ msgstr "ERROR: Objecto NULL!\n"
+
+#, fuzzy
+#~ msgid "Could not allocate the color %1$s!\n"
+#~ msgstr "Não foi possível atribuir a cor %s!\n"
+
+#~ msgid "black"
+#~ msgstr "preto"
+
+#~ msgid "white"
+#~ msgstr "branco"
+
+#, fuzzy
+#~ msgid "Could not allocate display color %1$i!\n"
+#~ msgstr "Não foi possível atribuir cor do ecran %i!\n"
+
+#, fuzzy
+#~ msgid "Could not allocate outline color %1$i!\n"
+#~ msgstr "Não foi possível atribuir cor do contorno %i!\n"
+
+#~ msgid "Move"
+#~ msgstr "Mover"
+
+#, fuzzy
+#~ msgid "Up"
+#~ msgstr "/Acima"
+
+#, fuzzy
+#~ msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
+#~ msgstr ""
+#~ "Tentou-se definir a sensibilidade num menu_item não existente '%s'\n"
+
+#~ msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
+#~ msgstr ""
+#~ "Tentou-se definir a sensibilidade num menu_item não existente '%s'\n"
 
 #, fuzzy
 #~ msgid "Invalid offset [%1$d] passed to add-attribute-offset\n"
@@ -2742,9 +2803,6 @@ msgstr ""
 
 #~ msgid "Function"
 #~ msgstr "Função"
-
-#~ msgid "/Add Attribute..."
-#~ msgstr "/Adicionar Atributo"
 
 #~ msgid "/Zoom Box"
 #~ msgstr "/Zona de Ampliação"

--- a/schematic/po/pt_BR.po
+++ b/schematic/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-10-03 23:34+0300\n"
+"POT-Creation-Date: 2020-03-18 20:44+0300\n"
 "PO-Revision-Date: 2012-01-31 12:08+0000\n"
 "Last-Translator: Antonio Augusto Todo Bom Neto <atodobom@gmail.com>\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -22,6 +22,13 @@ msgstr ""
 #, fuzzy
 msgid "Zoom too small!  Cannot zoom further."
 msgstr "Zoom muito pequeno! Não posso diminuir.\n"
+
+msgid ""
+"Save your color scheme to a file by clicking on the \"Save As...\"\n"
+"button. It can be loaded on startup with the following\n"
+"expression in the gschemrc configuration file:\n"
+"( primitive-load \"/path/to/saved-color-scheme-file\" )"
+msgstr ""
 
 #, fuzzy, c-format
 msgid ""
@@ -52,6 +59,11 @@ msgstr ""
 msgid "Sa_ve..."
 msgstr ""
 
+msgid ""
+"After you're done choosing the font, it's recommended\n"
+"to reopen schematics or restart the application."
+msgstr ""
+
 #, c-format
 msgid "<b>Current:</b> %s"
 msgstr ""
@@ -59,23 +71,20 @@ msgstr ""
 msgid "Save configuration"
 msgstr ""
 
-msgid "Save settings to:"
+msgid "Local configuration file:"
 msgstr ""
 
-msgid "Local configuration file (in current directory)"
+msgid "User configuration file:"
 msgstr ""
 
-msgid "User configuration file (geda-user.conf)"
-msgstr ""
-
-msgid "Object ~A is not included in the current gschem page."
+msgid "Object ~A is not included in the current lepton-schematic page."
 msgstr ""
 
 msgid "Invalid text name/value visibility ~A."
 msgstr ""
 
 #, fuzzy, c-format
-msgid "You are running gEDA/gaf version [%1$s%2$s.%3$s],\n"
+msgid "You are running lepton-schematic version [%1$s%2$s.%3$s],\n"
 msgstr "gEDA/gschem versão %s%s.%s\n"
 
 #, c-format
@@ -88,67 +97,15 @@ msgstr ""
 msgid "Please be sure that you have the latest rc file.\n"
 msgstr ""
 
-#, fuzzy, c-format
-msgid "Invalid size [%1$d] passed to text-size\n"
-msgstr "Tamanho [%d] inválido (text-size)\n"
-
-#, fuzzy, c-format
-msgid "Invalid size [%1$d] passed to snap-size\n"
-msgstr "Tamanho [%d] inválido passado tamanho de grade\n"
-
-#, fuzzy, c-format
-msgid "Invalid num levels [%1$d] passed to undo-levels\n"
-msgstr ""
-"Número de níveis [%d] inválido para função desfaz passado para undo-level\n"
-
-#, fuzzy, c-format
-msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
-msgstr "Tamanho inválido [%d] passado para bus-ripper-size\n"
-
-#, fuzzy, c-format
-msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
-msgstr "Tamanho [%d] inválido (text-size)\n"
-
-#, fuzzy, c-format
-msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
-msgstr "Tamanho inválido [%d] passado para bus-ripper-size\n"
-
-#, fuzzy, c-format
-msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
-msgstr "Número de pixels inválido [%d] passado para select-slack-pixels\n"
-
-#, fuzzy, c-format
-msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
-msgstr "Número de segundos inválido [%d] passado para auto-save-interval\n"
-
-#, fuzzy, c-format
-msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
-msgstr "Ganho inválido [%d] passado para mousepan-gain\n"
-
-#, fuzzy, c-format
-msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
-msgstr "Ganho inválido [%d] passado para keyboardpan-gain\n"
-
-#, fuzzy, c-format
-msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
-msgstr "Número de pixels inválido [%d] passado para select-slack-pixels\n"
-
-#, fuzzy, c-format
-msgid "Invalid gain [%1$d] passed to zoom-gain\n"
-msgstr "Ganho inválido [%d] passado para mousepan-gain\n"
-
-#, fuzzy, c-format
-msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
-msgstr "Número de segundos inválido [%d] passado para auto-save-interval\n"
-
 msgid "Object ~A is not directly included in a page."
 msgstr ""
 
 msgid "Could not launch URI ~S: ~A"
 msgstr "Impossível lançar URI ~S: ~A"
 
-msgid "Found invalid gschem window smob ~S"
-msgstr ""
+#, fuzzy
+msgid "Found invalid lepton-schematic window smob ~S"
+msgstr "~S não é uma combinação válida."
 
 #, fuzzy, c-format
 msgid "Lepton EDA/lepton-schematic version %1$s%2$s.%3$s git: %4$.7s"
@@ -183,7 +140,7 @@ msgstr "gEDA: GPL Electronic Design Automation"
 #, fuzzy
 msgid ""
 "Copyright © 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright © 2017-2019 Lepton Developers.\n"
+"Copyright © 2017-2020 Lepton Developers.\n"
 "See AUTHORS, ChangeLog files and consult 'git log' history for details."
 msgstr ""
 "Copyright © 1998-2011 Ales Hvezda <ahvezda@geda.seul.org>\n"
@@ -671,7 +628,8 @@ msgid ""
 "\n"
 "Are you sure you want to revert this page?\n"
 "All unsaved changes in current schematic will be\n"
-"discarded and page file will be reloaded from disk."
+"discarded and page file will be reloaded from disk.\n"
+"This action will also reload all component libraries."
 msgstr ""
 
 #, fuzzy
@@ -784,10 +742,6 @@ msgid_plural "Delete %1$u locked objects?"
 msgstr[0] "Apagar objeto bloqueado?"
 msgstr[1] "Apagar %u objetos bloqueados?"
 
-#, c-format
-msgid "Got an unexpected NULL in o_edit\n"
-msgstr "Encontrado um NULL inesperado em o_edit\n"
-
 #, fuzzy
 msgid "Hidden text is now visible"
 msgstr "Texto oculto agora está visível\n"
@@ -801,7 +755,7 @@ msgid "Could not find symbol [%1$s] in library. Update failed."
 msgstr "Impossível encontrar simbolo [%s] na biblioteca. Atualização falhou.\n"
 
 #, fuzzy, c-format
-msgid "o_autosave_backups: Can't get the real filename of %1$s."
+msgid "Can't get the real filename of %1$s."
 msgstr "o_autosave_backups: Impossível pegar o nome real do arquivo de %s"
 
 #, fuzzy, c-format
@@ -815,10 +769,6 @@ msgstr "NÃO foi possível deixar arquivo backup [%s] apenas leitura\n"
 #, fuzzy, c-format
 msgid "Could NOT save backup file [%1$s]"
 msgstr "NÃO foi possível salvar  arquivo backup [%s] !\n"
-
-#, c-format
-msgid "ERROR: NULL object in o_move_end!\n"
-msgstr "ERRO: Objeto NULL em o_move_end!\n"
 
 #, c-format
 msgid "DOH! tried to find the whichone, but didn't find it!\n"
@@ -873,7 +823,7 @@ msgid "New slot number out of range"
 msgstr "Número de slot fora dos limites\n"
 
 #, fuzzy
-msgid "Undo/Redo disabled in rc file"
+msgid "Undo/Redo is disabled in configuration"
 msgstr "Desfaz e Refaz desabilitado no arquivo rc\n"
 
 #, fuzzy, c-format
@@ -894,8 +844,8 @@ msgid ""
 "  -h, --help               Help; this message.\n"
 "  --                       Treat all remaining arguments as filenames.\n"
 "\n"
-"Report bugs at <https://github.com/lepton-eda/lepton-eda/issues>\n"
-"Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>\n"
+"Report bugs at <%2$s>\n"
+"Lepton EDA homepage: <%3$s>\n"
 msgstr ""
 "Uso: %s [OPÇÃO ...] [--] [ARQUIVO ...]\n"
 "\n"
@@ -920,30 +870,9 @@ msgstr ""
 "Reportagens de bugs para <https://bugs.launchpad.net/geda>\n"
 "Homepage gEDA/gaf: <http://www.geda-project.org/>\n"
 
-#, fuzzy, c-format
-msgid ""
-"Lepton EDA %1$s (git: %2$.7s)\n"
-"Copyright (C) 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright (C) 2017-2019 Lepton Developers.\n"
-"This is free software, and you are welcome to redistribute it under\n"
-"certain conditions. For details, see the file `COPYING', which is\n"
-"included in the Lepton EDA distribution.\n"
-"There is NO WARRANTY, to the extent permitted by law.\n"
-msgstr ""
-"gEDA %s (g%.7s)\n"
-"Copyright (C) 1998-2011 gEDA developers\n"
-"Este é um software livre, e você é convidado a redistribui-lo sobcertas "
-"condições. Para detalhes, veja arquivo `COPYING', o qual\n"
-"é incluído na distribuição gEDA.\n"
-"Ele é SEM GARANTIA, dentro do permitido pela lei.\n"
-
 #, c-format
 msgid "Got invalid show option; defaulting to show both\n"
 msgstr "Opção Visualização inválida; redefinindo para Ambos\n"
-
-#, c-format
-msgid "ERROR: NULL object!\n"
-msgstr "ERRO: NENHUM objeto!\n"
 
 msgid "Single Attribute Editor"
 msgstr "Editor de atributo único"
@@ -1005,7 +934,7 @@ msgstr ""
 "Slots duplicados podem causar problemas: [símbolo=%s, número=%d, slot=%d]\n"
 
 #, fuzzy
-msgid "No searchstring given in autonumber text."
+msgid "No search string given in autonumber text."
 msgstr "Sem chave de pesquisa na autonumeração.\n"
 
 #, fuzzy
@@ -1084,24 +1013,6 @@ msgstr ""
 
 msgid "Clipboard insertion failed"
 msgstr "Inserção da área de tranferência falhou"
-
-#, fuzzy, c-format
-msgid "Could not allocate the color %1$s!\n"
-msgstr "Impossível alocar a cor %s!\n"
-
-msgid "black"
-msgstr "preto"
-
-msgid "white"
-msgstr "branco"
-
-#, fuzzy, c-format
-msgid "Could not allocate display color %1$i!\n"
-msgstr "Impossível alocar a cor à tela %i!\n"
-
-#, fuzzy, c-format
-msgid "Could not allocate outline color %1$i!\n"
-msgstr "Impossível alocar a cor de outline %i!\n"
 
 #, fuzzy, c-format
 msgid "Tried to get an invalid color: %1$d\n"
@@ -1251,13 +1162,16 @@ msgstr ""
 msgid "Invalid Attribute"
 msgstr "Atributo Inválido"
 
-msgid "Schematics"
+#, fuzzy
+msgid "Schematics (*.sch)"
 msgstr "Diagramas"
 
-msgid "Symbols"
+#, fuzzy
+msgid "Symbols (*.sym)"
 msgstr "Símbolos"
 
-msgid "Schematics and symbols"
+#, fuzzy
+msgid "Schematics and symbols (*.sch *.sym)"
 msgstr "Diagramas e Símbolos"
 
 msgid "All files"
@@ -1299,7 +1213,7 @@ msgid "Hatch"
 msgstr "Linhas"
 
 #, fuzzy, c-format
-msgid "x_image_lowlevel: Unable to write %1$s file %2$s."
+msgid "Unable to write %1$s file %2$s."
 msgstr "x_image_lowlevel: Impossível captura do pixbuf da janela gschem.\n"
 
 #, fuzzy, c-format
@@ -1323,7 +1237,7 @@ msgid "Wrote black and white image to [%1$s] [%2$d x %3$d]"
 msgstr "Imagem em preto e branco salva [%s] [%d x %d]\n"
 
 #, fuzzy
-msgid "x_image_lowlevel: Unable to get pixbuf from gschem's window."
+msgid "Unable to get pixbuf from lepton-schematic's window."
 msgstr "x_image_lowlevel: Impossível captura do pixbuf da janela gschem.\n"
 
 msgid "NOTE: print-color-map will be used for PDF export"
@@ -1373,74 +1287,60 @@ msgid "Phantom"
 msgstr "Fantasma"
 
 #, fuzzy
-msgid "Add Net"
-msgstr "/Inserir Conexão"
-
-msgid "Add Attribute"
-msgstr "Inserir atributo"
-
-#, fuzzy
-msgid "Add Component"
+msgid "Add Co_mponent..."
 msgstr "/Inserir Componente..."
 
 #, fuzzy
-msgid "Add Bus"
+msgid "Add Te_xt..."
+msgstr "Adicionar Texto..."
+
+#, fuzzy
+msgid "Add _Attribute..."
+msgstr "/Inserir Atributo..."
+
+#, fuzzy
+msgid "Add _Net"
+msgstr "/Inserir Conexão"
+
+#, fuzzy
+msgid "Add _Bus"
 msgstr "/Inserir Barramento"
 
-#, fuzzy
-msgid "Add Text"
-msgstr "/Inserir Texto"
+msgid "Cu_t"
+msgstr "Cor_tar"
+
+msgid "_Copy"
+msgstr "_Copiar"
+
+msgid "_Paste"
+msgstr "Co_lar"
+
+msgid "_Delete"
+msgstr "_Apagar"
 
 #, fuzzy
-msgid "Zoom In"
-msgstr "/Zoom maior"
-
-#, fuzzy
-msgid "Zoom Out"
-msgstr "/Zoom menor"
-
-#, fuzzy
-msgid "Zoom Extents"
-msgstr "/Zoom desenho"
-
-msgid "Select"
-msgstr "Selecionar"
-
-msgid "Edit..."
+msgid "_Edit..."
 msgstr "Editar..."
 
 #, fuzzy
-msgid "Object Properties..."
-msgstr "<b>Propriedades do Texto</b>"
-
-msgid "Copy"
-msgstr "Copiar"
-
-msgid "Move"
-msgstr "Mover"
-
-msgid "Delete"
-msgstr "Apagar"
+msgid "Ed_it Text..."
+msgstr "Editar Texto..."
 
 #, fuzzy
-msgid "Down Schematic"
+msgid "_Object Properties..."
+msgstr "<b>Propriedades do Texto</b>"
+
+#, fuzzy
+msgid "Hierarchy: Down _Schematic"
 msgstr "/Descer ao Esquemático"
 
 #, fuzzy
-msgid "Down Symbol"
+msgid "Hierarchy: Down S_ymbol"
 msgstr "/Descer ao Símbolo"
 
 #, fuzzy
-msgid "Up"
-msgstr "/Subir"
-
-#, fuzzy, c-format
-msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
-msgstr "Tentou-se dar sensibilidade a item não existente '%s'\n"
-
-#, c-format
-msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
-msgstr "Tentou-se dar sensibilidade a item não existente '%s'\n"
+msgid "Hierarchy: _Up"
+msgstr "Hie_rarquia"
 
 msgid "The operating system is out of memory or resources."
 msgstr "Sistema sem memória ou recursos suficientes."
@@ -1463,6 +1363,9 @@ msgstr "Promover"
 msgid "Duplicate"
 msgstr "Duplicar"
 
+msgid "Delete"
+msgstr "Apagar"
+
 #, fuzzy
 msgid "Copy to all"
 msgstr "Copiar para 1"
@@ -1482,6 +1385,9 @@ msgstr "V"
 #, fuzzy
 msgid "Sho_w inherited attributes"
 msgstr "Mostra atributos relativos"
+
+msgid "Add Attribute"
+msgstr "Inserir atributo"
 
 #, fuzzy
 msgid "_Name:"
@@ -1604,6 +1510,25 @@ msgstr "Hie_rarquia"
 msgid "Hierarchy up"
 msgstr "Hie_rarquia"
 
+msgid "_New"
+msgstr "_Novo"
+
+msgid "_Open..."
+msgstr "_Abrir..."
+
+msgid "_Save"
+msgstr "_Salvar"
+
+msgid "Save _As..."
+msgstr "Salvar _Como..."
+
+#, fuzzy
+msgid "Page _Manager..."
+msgstr "Gerenciador de Páginas"
+
+msgid "_Close"
+msgstr "_Fechar"
+
 #, fuzzy
 msgid "Options"
 msgstr "_Opções"
@@ -1724,6 +1649,9 @@ msgstr ""
 msgid "Add Text..."
 msgstr "Adicionar Texto..."
 
+msgid "Select"
+msgstr "Selecionar"
+
 msgid "Select mode"
 msgstr "Modo de Seleção"
 
@@ -1792,20 +1720,8 @@ msgstr "Editor de Esquemas gEDA"
 msgid "Create and edit electrical schematics and symbols with lepton-schematic"
 msgstr "Crie e edite esquemas elétricos e símbolos com o gschem"
 
-msgid "_New"
-msgstr "_Novo"
-
-msgid "_Open..."
-msgstr "_Abrir..."
-
 msgid "Open Recen_t"
 msgstr "Abrir Recent_e"
-
-msgid "_Save"
-msgstr "_Salvar"
-
-msgid "Save _As..."
-msgstr "Salvar _Como..."
 
 msgid "Save All"
 msgstr "Salvar _Tudo"
@@ -1839,18 +1755,6 @@ msgstr "_Desfazer"
 msgid "_Redo"
 msgstr "_Refazer"
 
-msgid "Cu_t"
-msgstr "Cor_tar"
-
-msgid "_Copy"
-msgstr "_Copiar"
-
-msgid "_Paste"
-msgstr "Co_lar"
-
-msgid "_Delete"
-msgstr "_Apagar"
-
 msgid "Select All"
 msgstr "_Selecionar Tudo"
 
@@ -1859,6 +1763,13 @@ msgstr "D_esselecionar"
 
 msgid "Rotate 90 Mode"
 msgstr "Modo de Rotação"
+
+#, fuzzy
+msgid "Object Properties..."
+msgstr "<b>Propriedades do Texto</b>"
+
+msgid "Edit..."
+msgstr "Editar..."
 
 msgid "Edit Text..."
 msgstr "Editar Texto..."
@@ -1983,9 +1894,6 @@ msgstr "_Anterior"
 msgid "_Next"
 msgstr "_Próximo"
 
-msgid "_Close"
-msgstr "_Fechar"
-
 #, fuzzy
 msgid "_Revert..."
 msgstr "_Recarregar"
@@ -2097,6 +2005,9 @@ msgid "Grid Style: Cycle Dots/Mesh/Off"
 msgstr ""
 
 msgid "Grid Snap: Cycle Grid/Resnap/Off"
+msgstr ""
+
+msgid "Grips: On/Off"
 msgstr ""
 
 #, fuzzy
@@ -2249,6 +2160,9 @@ msgstr "Exibir/Ocultar textos ocultos"
 msgid "Cut"
 msgstr "Cor_tar"
 
+msgid "Copy"
+msgstr "Copiar"
+
 #, fuzzy
 msgid "Paste"
 msgstr "Co_lar"
@@ -2278,6 +2192,18 @@ msgstr ""
 #, fuzzy
 msgid "Pan Down"
 msgstr "Modo Centrar"
+
+#, fuzzy
+msgid "Zoom Extents"
+msgstr "/Zoom desenho"
+
+#, fuzzy
+msgid "Zoom In"
+msgstr "/Zoom maior"
+
+#, fuzzy
+msgid "Zoom Out"
+msgstr "/Zoom menor"
 
 #, fuzzy
 msgid "Zoom Full"
@@ -2315,6 +2241,22 @@ msgid "Print Page"
 msgstr "_Anterior"
 
 #, fuzzy
+msgid "Add Component"
+msgstr "/Inserir Componente..."
+
+#, fuzzy
+msgid "Add Net"
+msgstr "/Inserir Conexão"
+
+#, fuzzy
+msgid "Add Bus"
+msgstr "/Inserir Barramento"
+
+#, fuzzy
+msgid "Add Text"
+msgstr "/Inserir Texto"
+
+#, fuzzy
 msgid "Add Line"
 msgstr "Linha"
 
@@ -2340,6 +2282,14 @@ msgstr ""
 #, fuzzy
 msgid "Add Picture"
 msgstr "Imagem"
+
+#, fuzzy
+msgid "Down Schematic"
+msgstr "/Descer ao Esquemático"
+
+#, fuzzy
+msgid "Down Symbol"
+msgstr "/Descer ao Símbolo"
 
 #, fuzzy
 msgid "Up Hierarchy"
@@ -2432,6 +2382,10 @@ msgid "Show Coordinate Window"
 msgstr "Mostra _Coordenadas"
 
 #, fuzzy
+msgid "Toggle Grips"
+msgstr "Al_ternar visibilidade"
+
+#, fuzzy
 msgid "Component Documentation"
 msgstr "_Documentação de componente"
 
@@ -2469,10 +2423,6 @@ msgstr ""
 msgid "About lepton-schematic"
 msgstr "Sobre gschem"
 
-#, scheme-format
-msgid "Invalid text alignment ~A."
-msgstr "Alinhamento de texto ~A inválido."
-
 #, fuzzy
 msgid "Could not show documentation:"
 msgstr "_Documentação de componente"
@@ -2487,6 +2437,123 @@ msgstr "~S não é uma combinação válida."
 #, scheme-format
 msgid "~S is not a prefix key sequence."
 msgstr "~S não é uma sequência de prefixo."
+
+#, scheme-format
+msgid "Invalid text alignment ~A."
+msgstr "Alinhamento de texto ~A inválido."
+
+#, fuzzy
+#~ msgid "Invalid size [%1$d] passed to text-size\n"
+#~ msgstr "Tamanho [%d] inválido (text-size)\n"
+
+#, fuzzy
+#~ msgid "Invalid size [%1$d] passed to snap-size\n"
+#~ msgstr "Tamanho [%d] inválido passado tamanho de grade\n"
+
+#, fuzzy
+#~ msgid "Invalid num levels [%1$d] passed to undo-levels\n"
+#~ msgstr ""
+#~ "Número de níveis [%d] inválido para função desfaz passado para undo-"
+#~ "level\n"
+
+#, fuzzy
+#~ msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
+#~ msgstr "Tamanho inválido [%d] passado para bus-ripper-size\n"
+
+#, fuzzy
+#~ msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
+#~ msgstr "Tamanho [%d] inválido (text-size)\n"
+
+#, fuzzy
+#~ msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
+#~ msgstr "Tamanho inválido [%d] passado para bus-ripper-size\n"
+
+#, fuzzy
+#~ msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
+#~ msgstr "Número de pixels inválido [%d] passado para select-slack-pixels\n"
+
+#, fuzzy
+#~ msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
+#~ msgstr "Número de segundos inválido [%d] passado para auto-save-interval\n"
+
+#, fuzzy
+#~ msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
+#~ msgstr "Ganho inválido [%d] passado para mousepan-gain\n"
+
+#, fuzzy
+#~ msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
+#~ msgstr "Ganho inválido [%d] passado para keyboardpan-gain\n"
+
+#, fuzzy
+#~ msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
+#~ msgstr "Número de pixels inválido [%d] passado para select-slack-pixels\n"
+
+#, fuzzy
+#~ msgid "Invalid gain [%1$d] passed to zoom-gain\n"
+#~ msgstr "Ganho inválido [%d] passado para mousepan-gain\n"
+
+#, fuzzy
+#~ msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
+#~ msgstr "Número de segundos inválido [%d] passado para auto-save-interval\n"
+
+#~ msgid "Got an unexpected NULL in o_edit\n"
+#~ msgstr "Encontrado um NULL inesperado em o_edit\n"
+
+#~ msgid "ERROR: NULL object in o_move_end!\n"
+#~ msgstr "ERRO: Objeto NULL em o_move_end!\n"
+
+#, fuzzy
+#~ msgid ""
+#~ "Lepton EDA %1$s (git: %2$.7s)\n"
+#~ "Copyright (C) 1998-2017 by Ales Hvezda and the respective original "
+#~ "authors.\n"
+#~ "Copyright (C) 2017-2019 Lepton Developers.\n"
+#~ "This is free software, and you are welcome to redistribute it under\n"
+#~ "certain conditions. For details, see the file `COPYING', which is\n"
+#~ "included in the Lepton EDA distribution.\n"
+#~ "There is NO WARRANTY, to the extent permitted by law.\n"
+#~ msgstr ""
+#~ "gEDA %s (g%.7s)\n"
+#~ "Copyright (C) 1998-2011 gEDA developers\n"
+#~ "Este é um software livre, e você é convidado a redistribui-lo sobcertas "
+#~ "condições. Para detalhes, veja arquivo `COPYING', o qual\n"
+#~ "é incluído na distribuição gEDA.\n"
+#~ "Ele é SEM GARANTIA, dentro do permitido pela lei.\n"
+
+#~ msgid "ERROR: NULL object!\n"
+#~ msgstr "ERRO: NENHUM objeto!\n"
+
+#, fuzzy
+#~ msgid "Could not allocate the color %1$s!\n"
+#~ msgstr "Impossível alocar a cor %s!\n"
+
+#~ msgid "black"
+#~ msgstr "preto"
+
+#~ msgid "white"
+#~ msgstr "branco"
+
+#, fuzzy
+#~ msgid "Could not allocate display color %1$i!\n"
+#~ msgstr "Impossível alocar a cor à tela %i!\n"
+
+#, fuzzy
+#~ msgid "Could not allocate outline color %1$i!\n"
+#~ msgstr "Impossível alocar a cor de outline %i!\n"
+
+#~ msgid "Move"
+#~ msgstr "Mover"
+
+#, fuzzy
+#~ msgid "Up"
+#~ msgstr "/Subir"
+
+#, fuzzy
+#~ msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
+#~ msgstr "Tentou-se dar sensibilidade a item não existente '%s'\n"
+
+#~ msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
+#~ msgstr "Tentou-se dar sensibilidade a item não existente '%s'\n"
 
 #, fuzzy
 #~ msgid "Invalid offset [%1$d] passed to add-attribute-offset\n"
@@ -2790,9 +2857,6 @@ msgstr "~S não é uma sequência de prefixo."
 
 #~ msgid "Function"
 #~ msgstr "Função"
-
-#~ msgid "/Add Attribute..."
-#~ msgstr "/Inserir Atributo..."
 
 #~ msgid "/Zoom Box"
 #~ msgstr "/Caixa de Zoom"

--- a/schematic/po/ru.po
+++ b/schematic/po/ru.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda gschem ru\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-10-03 23:34+0300\n"
+"POT-Creation-Date: 2020-03-18 20:44+0300\n"
 "PO-Revision-Date: 2015-09-13 16:05+0300\n"
 "Last-Translator: Sergey Alyoshin <alyoshin.s@gmail.com>\n"
 "Language-Team: geda-user@delorie.com\n"
@@ -25,6 +25,13 @@ msgstr ""
 #, fuzzy
 msgid "Zoom too small!  Cannot zoom further."
 msgstr "Масштаб слишком мал! Дальнейшее изменение невозможно.\n"
+
+msgid ""
+"Save your color scheme to a file by clicking on the \"Save As...\"\n"
+"button. It can be loaded on startup with the following\n"
+"expression in the gschemrc configuration file:\n"
+"( primitive-load \"/path/to/saved-color-scheme-file\" )"
+msgstr ""
 
 #, fuzzy, c-format
 msgid ""
@@ -56,6 +63,11 @@ msgstr ""
 msgid "Sa_ve..."
 msgstr ""
 
+msgid ""
+"After you're done choosing the font, it's recommended\n"
+"to reopen schematics or restart the application."
+msgstr ""
+
 #, c-format
 msgid "<b>Current:</b> %s"
 msgstr ""
@@ -63,23 +75,21 @@ msgstr ""
 msgid "Save configuration"
 msgstr ""
 
-msgid "Save settings to:"
+msgid "Local configuration file:"
 msgstr ""
 
-msgid "Local configuration file (in current directory)"
+msgid "User configuration file:"
 msgstr ""
 
-msgid "User configuration file (geda-user.conf)"
-msgstr ""
-
-msgid "Object ~A is not included in the current gschem page."
+#, fuzzy
+msgid "Object ~A is not included in the current lepton-schematic page."
 msgstr "Объект ~A не принадлежит текущей странице."
 
 msgid "Invalid text name/value visibility ~A."
 msgstr "Недопустимое сочетание видимости имени/значения ~A."
 
 #, fuzzy, c-format
-msgid "You are running gEDA/gaf version [%1$s%2$s.%3$s],\n"
+msgid "You are running lepton-schematic version [%1$s%2$s.%3$s],\n"
 msgstr "Вы работаете с gEDA/gschem версии %s%s.%s,\n"
 
 #, fuzzy, c-format
@@ -94,73 +104,6 @@ msgstr ""
 msgid "Please be sure that you have the latest rc file.\n"
 msgstr "Удостоверьтесь, что у вас последняя версия файла настроек.\n"
 
-#, fuzzy, c-format
-msgid "Invalid size [%1$d] passed to text-size\n"
-msgstr "text-size (размер текста по умолчанию): недопустимое значение «%d»\n"
-
-#, fuzzy, c-format
-msgid "Invalid size [%1$d] passed to snap-size\n"
-msgstr "snap-size (размер сетки привязки): недопустимое значение «%d»\n"
-
-#, fuzzy, c-format
-msgid "Invalid num levels [%1$d] passed to undo-levels\n"
-msgstr "undo-levels (количество шагов отмены): недопустимое значение «%d» \n"
-
-#, fuzzy, c-format
-msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
-msgstr ""
-"bus-ripper-size (размер ответвления от шины): недопустимое значение «%d»\n"
-
-#, fuzzy, c-format
-msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
-msgstr "dots-grid-dot-size (размер точки сетки): недопустимое значение «%d»\n"
-
-#, fuzzy, c-format
-msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
-msgstr ""
-"dots-grid-fixed-threshold (мин. интервал между точками сетки в пикселах): "
-"недопустимое значение «%d»\n"
-
-#, fuzzy, c-format
-msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
-msgstr ""
-"mesh-grid-display-threshold (мин. интервал между линиями сетки в пикселах): "
-"недопустимое значение «%d»\n"
-
-#, fuzzy, c-format
-msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
-msgstr ""
-"auto-save-interval (интервал автосохранения в секундах): недопустимое "
-"значение «%d»\n"
-
-#, fuzzy, c-format
-msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
-msgstr ""
-"mousepan-gain (смещение при панорамировании мышью): недопустимое значение "
-"«%d»\n"
-
-#, fuzzy, c-format
-msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
-msgstr ""
-"keyboardpan-gain (смещение при панорамировании клавишами): недопустимое "
-"значение «%d»\n"
-
-#, fuzzy, c-format
-msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
-msgstr ""
-"select-slack-pixels (число соседних пикселов для выделения): недопустимое "
-"значение «%d»\n"
-
-#, fuzzy, c-format
-msgid "Invalid gain [%1$d] passed to zoom-gain\n"
-msgstr "zoom-gain (процент увеличения масштаба): недопустимое значение «%d»\n"
-
-#, fuzzy, c-format
-msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
-msgstr ""
-"scrollpan-steps (число шагов сдвига области просмотра): недопустимое "
-"значение «%d»\n"
-
 # Данная ошибка возникает, например, в случае попытки отдельного выделения
 # объекта, не являющегося самостоятельной частью страницы, а входящего в
 # состав какого-то символа, то есть включенного в страницу косвенно.
@@ -171,7 +114,8 @@ msgid "Could not launch URI ~S: ~A"
 msgstr "Не удалось открыть URI ~S: ~A"
 
 # smob -- представление данных объекта для Scheme
-msgid "Found invalid gschem window smob ~S"
+#, fuzzy
+msgid "Found invalid lepton-schematic window smob ~S"
 msgstr "Обнаружена недопустимая структура данных smob окна gschem ~S"
 
 #, fuzzy, c-format
@@ -207,7 +151,7 @@ msgstr "gEDA: САПР электроники под лицензией GPL"
 #, fuzzy
 msgid ""
 "Copyright © 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright © 2017-2019 Lepton Developers.\n"
+"Copyright © 2017-2020 Lepton Developers.\n"
 "See AUTHORS, ChangeLog files and consult 'git log' history for details."
 msgstr ""
 "Copyright © 1998-2012 Ales Hvezda <ahvezda@geda.seul.org>\n"
@@ -683,7 +627,8 @@ msgid ""
 "\n"
 "Are you sure you want to revert this page?\n"
 "All unsaved changes in current schematic will be\n"
-"discarded and page file will be reloaded from disk."
+"discarded and page file will be reloaded from disk.\n"
+"This action will also reload all component libraries."
 msgstr ""
 
 #, fuzzy
@@ -800,10 +745,6 @@ msgstr[0] "Удалить %u заблокированный объект?"
 msgstr[1] "Удалить %u заблокированных объекта?"
 msgstr[2] "Удалить %u заблокированных объектов?"
 
-#, c-format
-msgid "Got an unexpected NULL in o_edit\n"
-msgstr "o_edit: неожиданный NULL вместо объекта\n"
-
 #, fuzzy
 msgid "Hidden text is now visible"
 msgstr "Скрытый текст теперь видим\n"
@@ -818,7 +759,7 @@ msgstr "Символ «%s» в библиотеке не найден. Обно�
 
 # Квадратные скобки добавлены для единообразия
 #, fuzzy, c-format
-msgid "o_autosave_backups: Can't get the real filename of %1$s."
+msgid "Can't get the real filename of %1$s."
 msgstr ""
 "o_autosave_backups: не удалось определить имя реального файла для «%s»."
 
@@ -837,10 +778,6 @@ msgstr ""
 #, fuzzy, c-format
 msgid "Could NOT save backup file [%1$s]"
 msgstr "Не удалось сохранить файл резервной копии «%s»\n"
-
-#, c-format
-msgid "ERROR: NULL object in o_move_end!\n"
-msgstr "o_move_end: ОШИБКА! NULL вместо объекта\n"
 
 # whichone -- флаг, определяющий подключаемый конец для соединения
 #, c-format
@@ -904,7 +841,7 @@ msgid "New slot number out of range"
 msgstr "Новый номер секции вне допустимого диапазона\n"
 
 #, fuzzy
-msgid "Undo/Redo disabled in rc file"
+msgid "Undo/Redo is disabled in configuration"
 msgstr "Отмена/повтор отключены в файле настроек\n"
 
 #, fuzzy, c-format
@@ -925,8 +862,8 @@ msgid ""
 "  -h, --help               Help; this message.\n"
 "  --                       Treat all remaining arguments as filenames.\n"
 "\n"
-"Report bugs at <https://github.com/lepton-eda/lepton-eda/issues>\n"
-"Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>\n"
+"Report bugs at <%2$s>\n"
+"Lepton EDA homepage: <%3$s>\n"
 msgstr ""
 "Использование: %s [КЛЮЧ ...] [--] [ФАЙЛ ...]\n"
 "\n"
@@ -951,33 +888,11 @@ msgstr ""
 "Отчёты об ошибках отправляйте по адресу <https://bugs.launchpad.net/geda>\n"
 "Домашняя страница gEDA/gaf: <http://www.geda-project.org/>\n"
 
-#, fuzzy, c-format
-msgid ""
-"Lepton EDA %1$s (git: %2$.7s)\n"
-"Copyright (C) 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright (C) 2017-2019 Lepton Developers.\n"
-"This is free software, and you are welcome to redistribute it under\n"
-"certain conditions. For details, see the file `COPYING', which is\n"
-"included in the Lepton EDA distribution.\n"
-"There is NO WARRANTY, to the extent permitted by law.\n"
-msgstr ""
-"gEDA %s (g%.7s)\n"
-"Copyright (C) 1998-2012 gEDA developers\n"
-"Это свободное программное обеспечение, и его можно распространять при\n"
-"определённых условиях. Подробности см. в файле COPYING\n"
-"в дистрибутиве gEDA.\n"
-"Нет НИКАКИХ ГАРАНТИЙ в рамках, допустимых имеющимся\n"
-"законодательством.\n"
-
 #, c-format
 msgid "Got invalid show option; defaulting to show both\n"
 msgstr ""
 "Выбран недопустимый способ отображения, установка отображения имени и "
 "значения\n"
-
-#, c-format
-msgid "ERROR: NULL object!\n"
-msgstr "ОШИБКА! NULL вместо объекта\n"
 
 msgid "Single Attribute Editor"
 msgstr "Редактор атрибута"
@@ -1049,7 +964,7 @@ msgstr ""
 "%d\n"
 
 #, fuzzy
-msgid "No searchstring given in autonumber text."
+msgid "No search string given in autonumber text."
 msgstr "Не задано выражение для автонумерации.\n"
 
 #, fuzzy
@@ -1134,34 +1049,6 @@ msgstr ""
 # Заголовок окна ошибки
 msgid "Clipboard insertion failed"
 msgstr "Ошибка вставки данных из буфера обмена"
-
-# Здесь я написал "Не удалось выделить цвет" вместо "назначить", так
-# как речь идёт о резервировании поля в colormap.
-# %s разместил по-другому, потому что будет выдаваться, например, "чёрный
-# цвет".
-#, fuzzy, c-format
-msgid "Could not allocate the color %1$s!\n"
-msgstr "Не удалось выделить %s цвет!\n"
-
-msgid "black"
-msgstr "чёрный"
-
-msgid "white"
-msgstr "белый"
-
-# См. перевод выше.
-# В этом случае речь идёт о выделении поля для цвета с указанным индексом.
-# Про "display color" и "outline color" см. примечания ниже
-#, fuzzy, c-format
-msgid "Could not allocate display color %1$i!\n"
-msgstr "Не удалось выделить цвет для индекса %i!\n"
-
-# "outline" ни к каким контурам отношения не имеет. Более того, ввиду ошибок
-# реализации вообще малоинформативное сообщение. См. примечания к
-# нижеследующим переводам.
-#, fuzzy, c-format
-msgid "Could not allocate outline color %1$i!\n"
-msgstr "Невозможно выделить цвет контура %i!\n"
 
 # "color" в данном случае означает цвет некоторых объектов
 # (точек соединения, маркеров привязки, ...), который в третьем случае
@@ -1323,13 +1210,16 @@ msgstr ""
 msgid "Invalid Attribute"
 msgstr "Недопустимый атрибут"
 
-msgid "Schematics"
+#, fuzzy
+msgid "Schematics (*.sch)"
 msgstr "Схемы"
 
-msgid "Symbols"
+#, fuzzy
+msgid "Symbols (*.sym)"
 msgstr "Символы"
 
-msgid "Schematics and symbols"
+#, fuzzy
+msgid "Schematics and symbols (*.sch *.sym)"
 msgstr "Схемы и символы"
 
 msgid "All files"
@@ -1373,7 +1263,7 @@ msgid "Hatch"
 msgstr "Штриховка"
 
 #, fuzzy, c-format
-msgid "x_image_lowlevel: Unable to write %1$s file %2$s."
+msgid "Unable to write %1$s file %2$s."
 msgstr "x_image_lowlevel: не удалось записать %s-файл %s.\n"
 
 #, fuzzy, c-format
@@ -1397,7 +1287,7 @@ msgid "Wrote black and white image to [%1$s] [%2$d x %3$d]"
 msgstr "Записано чёрно-белое изображение в «%s» [%d×%d]\n"
 
 #, fuzzy
-msgid "x_image_lowlevel: Unable to get pixbuf from gschem's window."
+msgid "Unable to get pixbuf from lepton-schematic's window."
 msgstr "x_image_lowlevel: не удалось получить растровую копию окна gschem.\n"
 
 msgid "NOTE: print-color-map will be used for PDF export"
@@ -1448,71 +1338,62 @@ msgstr "Штрих-пунктир"
 msgid "Phantom"
 msgstr "Двойной штрих-пунктир"
 
-# Контекстное меню, вызываемое по правой кнопке в основном окне.
-msgid "Add Net"
-msgstr "Добавить соединение"
-
-msgid "Add Attribute"
-msgstr "Добавить атрибут"
-
-msgid "Add Component"
+#, fuzzy
+msgid "Add Co_mponent..."
 msgstr "Добавить компонент"
 
-msgid "Add Bus"
+#, fuzzy
+msgid "Add Te_xt..."
+msgstr "Ввод текста..."
+
+#, fuzzy
+msgid "Add _Attribute..."
+msgstr "_Атрибут..."
+
+# Контекстное меню, вызываемое по правой кнопке в основном окне.
+#, fuzzy
+msgid "Add _Net"
+msgstr "Добавить соединение"
+
+#, fuzzy
+msgid "Add _Bus"
 msgstr "Добавить шину"
 
-msgid "Add Text"
-msgstr "Добавить текст"
+msgid "Cu_t"
+msgstr "_Вырезать"
 
-msgid "Zoom In"
-msgstr "Увеличить"
+msgid "_Copy"
+msgstr "С_копировать"
 
-msgid "Zoom Out"
-msgstr "Уменьшить"
+msgid "_Paste"
+msgstr "В_ставить"
 
-msgid "Zoom Extents"
-msgstr "Уместить в окне"
+msgid "_Delete"
+msgstr "_Удалить"
 
-msgid "Select"
-msgstr "Выделение"
-
-msgid "Edit..."
+#, fuzzy
+msgid "_Edit..."
 msgstr "Правка..."
 
 #, fuzzy
-msgid "Object Properties..."
+msgid "Ed_it Text..."
+msgstr "Правка текста..."
+
+#, fuzzy
+msgid "_Object Properties..."
 msgstr "<b>Текст</b>"
 
-# Это используется только в функциях обновления строки состояния, поэтому
-# переводится как существительное, а не глагол, так как означает режим работы.
-msgid "Copy"
-msgstr "Копирование"
-
-# См. примечание выше для "Copy"
-msgid "Move"
-msgstr "Перемещение"
-
-msgid "Delete"
-msgstr "Удалить"
-
-msgid "Down Schematic"
+#, fuzzy
+msgid "Hierarchy: Down _Schematic"
 msgstr "Войти в подсхему"
 
-msgid "Down Symbol"
+#, fuzzy
+msgid "Hierarchy: Down S_ymbol"
 msgstr "Войти в символ"
 
-msgid "Up"
-msgstr "Вверх"
-
-#, fuzzy, c-format
-msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
-msgstr ""
-"Попытка установки чувствительности несуществующего элемента меню «%s»\n"
-
-#, c-format
-msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
-msgstr ""
-"Попытка установки чувствительности несуществующего элемента меню «%s»\n"
+#, fuzzy
+msgid "Hierarchy: _Up"
+msgstr "_Иерархия"
 
 msgid "The operating system is out of memory or resources."
 msgstr "Операционной системе не хватает памяти или ресурсов."
@@ -1535,6 +1416,9 @@ msgstr "Вынести"
 msgid "Duplicate"
 msgstr "Дублировать"
 
+msgid "Delete"
+msgstr "Удалить"
+
 msgid "Copy to all"
 msgstr "Скопировать во все"
 
@@ -1553,6 +1437,9 @@ msgstr "З"
 #, fuzzy
 msgid "Sho_w inherited attributes"
 msgstr "Показать унаследованные атрибуты"
+
+msgid "Add Attribute"
+msgstr "Добавить атрибут"
 
 #, fuzzy
 msgid "_Name:"
@@ -1682,6 +1569,25 @@ msgstr "_Иерархия"
 msgid "Hierarchy up"
 msgstr "_Иерархия"
 
+msgid "_New"
+msgstr "_Новый"
+
+msgid "_Open..."
+msgstr "_Открыть..."
+
+msgid "_Save"
+msgstr "_Сохранить"
+
+msgid "Save _As..."
+msgstr "Сохранить _как..."
+
+#, fuzzy
+msgid "Page _Manager..."
+msgstr "Менеджер страниц"
+
+msgid "_Close"
+msgstr "_Закрыть"
+
 msgid "Options"
 msgstr "Настройки"
 
@@ -1801,6 +1707,9 @@ msgstr ""
 msgid "Add Text..."
 msgstr "Ввод текста..."
 
+msgid "Select"
+msgstr "Выделение"
+
 msgid "Select mode"
 msgstr "Режим выделения"
 
@@ -1876,20 +1785,8 @@ msgstr "Схемотехнический редактор gEDA"
 msgid "Create and edit electrical schematics and symbols with lepton-schematic"
 msgstr "Создание и редактирование электрических схем и символов в gschem"
 
-msgid "_New"
-msgstr "_Новый"
-
-msgid "_Open..."
-msgstr "_Открыть..."
-
 msgid "Open Recen_t"
 msgstr "Открыть не_давние"
-
-msgid "_Save"
-msgstr "_Сохранить"
-
-msgid "Save _As..."
-msgstr "Сохранить _как..."
 
 msgid "Save All"
 msgstr "Сохранить все"
@@ -1923,18 +1820,6 @@ msgstr "_Отменить"
 msgid "_Redo"
 msgstr "_Повторить"
 
-msgid "Cu_t"
-msgstr "_Вырезать"
-
-msgid "_Copy"
-msgstr "С_копировать"
-
-msgid "_Paste"
-msgstr "В_ставить"
-
-msgid "_Delete"
-msgstr "_Удалить"
-
 msgid "Select All"
 msgstr "Выделить всё"
 
@@ -1946,6 +1831,13 @@ msgstr "Снять выделение"
 # отображения в строке состояния.
 msgid "Rotate 90 Mode"
 msgstr "Поворот на 90°"
+
+#, fuzzy
+msgid "Object Properties..."
+msgstr "<b>Текст</b>"
+
+msgid "Edit..."
+msgstr "Правка..."
 
 msgid "Edit Text..."
 msgstr "Правка текста..."
@@ -2070,9 +1962,6 @@ msgstr "_Предыдущая"
 msgid "_Next"
 msgstr "_Следующая"
 
-msgid "_Close"
-msgstr "_Закрыть"
-
 #, fuzzy
 msgid "_Revert..."
 msgstr "_Возвратить"
@@ -2184,6 +2073,9 @@ msgid "Grid Style: Cycle Dots/Mesh/Off"
 msgstr ""
 
 msgid "Grid Snap: Cycle Grid/Resnap/Off"
+msgstr ""
+
+msgid "Grips: On/Off"
 msgstr ""
 
 #, fuzzy
@@ -2326,6 +2218,11 @@ msgstr "Показать/скрыть невидимый текст"
 msgid "Cut"
 msgstr "Вырезать"
 
+# Это используется только в функциях обновления строки состояния, поэтому
+# переводится как существительное, а не глагол, так как означает режим работы.
+msgid "Copy"
+msgstr "Копирование"
+
 msgid "Paste"
 msgstr "Вставить"
 
@@ -2350,6 +2247,15 @@ msgstr "Прокрутка вверх"
 
 msgid "Pan Down"
 msgstr "Прокрутка вниз"
+
+msgid "Zoom Extents"
+msgstr "Уместить в окне"
+
+msgid "Zoom In"
+msgstr "Увеличить"
+
+msgid "Zoom Out"
+msgstr "Уменьшить"
 
 msgid "Zoom Full"
 msgstr "Показать всё"
@@ -2379,6 +2285,19 @@ msgstr "Следующая страница"
 msgid "Print Page"
 msgstr "Печать страницы"
 
+msgid "Add Component"
+msgstr "Добавить компонент"
+
+# Контекстное меню, вызываемое по правой кнопке в основном окне.
+msgid "Add Net"
+msgstr "Добавить соединение"
+
+msgid "Add Bus"
+msgstr "Добавить шину"
+
+msgid "Add Text"
+msgstr "Добавить текст"
+
 msgid "Add Line"
 msgstr "Добавить линию"
 
@@ -2399,6 +2318,12 @@ msgstr "Добавить вывод"
 
 msgid "Add Picture"
 msgstr "Добавить изображение"
+
+msgid "Down Schematic"
+msgstr "Войти в подсхему"
+
+msgid "Down Symbol"
+msgstr "Войти в символ"
 
 msgid "Up Hierarchy"
 msgstr "Вверх по иерархии"
@@ -2471,6 +2396,10 @@ msgstr "Показать окно журнала"
 msgid "Show Coordinate Window"
 msgstr "Показать окно координат"
 
+#, fuzzy
+msgid "Toggle Grips"
+msgstr "Переключить _видимость"
+
 msgid "Component Documentation"
 msgstr "Документация на компонент"
 
@@ -2513,10 +2442,6 @@ msgstr "Открыть основную страницу gEDA wiki в брауз
 msgid "About lepton-schematic"
 msgstr "О программе..."
 
-#, scheme-format
-msgid "Invalid text alignment ~A."
-msgstr "Недопустимое выравнивание текста ~A."
-
 #, fuzzy
 msgid "Could not show documentation:"
 msgstr ""
@@ -2533,6 +2458,153 @@ msgstr "Недопустимая комбинация клавиш ~S."
 #, scheme-format
 msgid "~S is not a prefix key sequence."
 msgstr "~S не является префиксом клавишной последовательности."
+
+#, scheme-format
+msgid "Invalid text alignment ~A."
+msgstr "Недопустимое выравнивание текста ~A."
+
+#, fuzzy
+#~ msgid "Invalid size [%1$d] passed to text-size\n"
+#~ msgstr ""
+#~ "text-size (размер текста по умолчанию): недопустимое значение «%d»\n"
+
+#, fuzzy
+#~ msgid "Invalid size [%1$d] passed to snap-size\n"
+#~ msgstr "snap-size (размер сетки привязки): недопустимое значение «%d»\n"
+
+#, fuzzy
+#~ msgid "Invalid num levels [%1$d] passed to undo-levels\n"
+#~ msgstr ""
+#~ "undo-levels (количество шагов отмены): недопустимое значение «%d» \n"
+
+#, fuzzy
+#~ msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
+#~ msgstr ""
+#~ "bus-ripper-size (размер ответвления от шины): недопустимое значение «%d»\n"
+
+#, fuzzy
+#~ msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
+#~ msgstr ""
+#~ "dots-grid-dot-size (размер точки сетки): недопустимое значение «%d»\n"
+
+#, fuzzy
+#~ msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
+#~ msgstr ""
+#~ "dots-grid-fixed-threshold (мин. интервал между точками сетки в пикселах): "
+#~ "недопустимое значение «%d»\n"
+
+#, fuzzy
+#~ msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
+#~ msgstr ""
+#~ "mesh-grid-display-threshold (мин. интервал между линиями сетки в "
+#~ "пикселах): недопустимое значение «%d»\n"
+
+#, fuzzy
+#~ msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
+#~ msgstr ""
+#~ "auto-save-interval (интервал автосохранения в секундах): недопустимое "
+#~ "значение «%d»\n"
+
+#, fuzzy
+#~ msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
+#~ msgstr ""
+#~ "mousepan-gain (смещение при панорамировании мышью): недопустимое значение "
+#~ "«%d»\n"
+
+#, fuzzy
+#~ msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
+#~ msgstr ""
+#~ "keyboardpan-gain (смещение при панорамировании клавишами): недопустимое "
+#~ "значение «%d»\n"
+
+#, fuzzy
+#~ msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
+#~ msgstr ""
+#~ "select-slack-pixels (число соседних пикселов для выделения): недопустимое "
+#~ "значение «%d»\n"
+
+#, fuzzy
+#~ msgid "Invalid gain [%1$d] passed to zoom-gain\n"
+#~ msgstr ""
+#~ "zoom-gain (процент увеличения масштаба): недопустимое значение «%d»\n"
+
+#, fuzzy
+#~ msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
+#~ msgstr ""
+#~ "scrollpan-steps (число шагов сдвига области просмотра): недопустимое "
+#~ "значение «%d»\n"
+
+#~ msgid "Got an unexpected NULL in o_edit\n"
+#~ msgstr "o_edit: неожиданный NULL вместо объекта\n"
+
+#~ msgid "ERROR: NULL object in o_move_end!\n"
+#~ msgstr "o_move_end: ОШИБКА! NULL вместо объекта\n"
+
+#, fuzzy
+#~ msgid ""
+#~ "Lepton EDA %1$s (git: %2$.7s)\n"
+#~ "Copyright (C) 1998-2017 by Ales Hvezda and the respective original "
+#~ "authors.\n"
+#~ "Copyright (C) 2017-2019 Lepton Developers.\n"
+#~ "This is free software, and you are welcome to redistribute it under\n"
+#~ "certain conditions. For details, see the file `COPYING', which is\n"
+#~ "included in the Lepton EDA distribution.\n"
+#~ "There is NO WARRANTY, to the extent permitted by law.\n"
+#~ msgstr ""
+#~ "gEDA %s (g%.7s)\n"
+#~ "Copyright (C) 1998-2012 gEDA developers\n"
+#~ "Это свободное программное обеспечение, и его можно распространять при\n"
+#~ "определённых условиях. Подробности см. в файле COPYING\n"
+#~ "в дистрибутиве gEDA.\n"
+#~ "Нет НИКАКИХ ГАРАНТИЙ в рамках, допустимых имеющимся\n"
+#~ "законодательством.\n"
+
+#~ msgid "ERROR: NULL object!\n"
+#~ msgstr "ОШИБКА! NULL вместо объекта\n"
+
+# Здесь я написал "Не удалось выделить цвет" вместо "назначить", так
+# как речь идёт о резервировании поля в colormap.
+# %s разместил по-другому, потому что будет выдаваться, например, "чёрный
+# цвет".
+#, fuzzy
+#~ msgid "Could not allocate the color %1$s!\n"
+#~ msgstr "Не удалось выделить %s цвет!\n"
+
+#~ msgid "black"
+#~ msgstr "чёрный"
+
+#~ msgid "white"
+#~ msgstr "белый"
+
+# См. перевод выше.
+# В этом случае речь идёт о выделении поля для цвета с указанным индексом.
+# Про "display color" и "outline color" см. примечания ниже
+#, fuzzy
+#~ msgid "Could not allocate display color %1$i!\n"
+#~ msgstr "Не удалось выделить цвет для индекса %i!\n"
+
+# "outline" ни к каким контурам отношения не имеет. Более того, ввиду ошибок
+# реализации вообще малоинформативное сообщение. См. примечания к
+# нижеследующим переводам.
+#, fuzzy
+#~ msgid "Could not allocate outline color %1$i!\n"
+#~ msgstr "Невозможно выделить цвет контура %i!\n"
+
+# См. примечание выше для "Copy"
+#~ msgid "Move"
+#~ msgstr "Перемещение"
+
+#~ msgid "Up"
+#~ msgstr "Вверх"
+
+#, fuzzy
+#~ msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
+#~ msgstr ""
+#~ "Попытка установки чувствительности несуществующего элемента меню «%s»\n"
+
+#~ msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
+#~ msgstr ""
+#~ "Попытка установки чувствительности несуществующего элемента меню «%s»\n"
 
 #, fuzzy
 #~ msgid "Invalid offset [%1$d] passed to add-attribute-offset\n"

--- a/schematic/po/sl.po
+++ b/schematic/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-10-03 23:34+0300\n"
+"POT-Creation-Date: 2020-03-18 20:44+0300\n"
 "PO-Revision-Date: 2012-01-27 14:18+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: Slovenian <sl@li.org>\n"
@@ -19,6 +19,13 @@ msgstr ""
 "X-Generator: Launchpad (build 16265)\n"
 
 msgid "Zoom too small!  Cannot zoom further."
+msgstr ""
+
+msgid ""
+"Save your color scheme to a file by clicking on the \"Save As...\"\n"
+"button. It can be loaded on startup with the following\n"
+"expression in the gschemrc configuration file:\n"
+"( primitive-load \"/path/to/saved-color-scheme-file\" )"
 msgstr ""
 
 #, c-format
@@ -46,6 +53,11 @@ msgstr ""
 msgid "Sa_ve..."
 msgstr ""
 
+msgid ""
+"After you're done choosing the font, it's recommended\n"
+"to reopen schematics or restart the application."
+msgstr ""
+
 #, c-format
 msgid "<b>Current:</b> %s"
 msgstr ""
@@ -53,23 +65,20 @@ msgstr ""
 msgid "Save configuration"
 msgstr ""
 
-msgid "Save settings to:"
+msgid "Local configuration file:"
 msgstr ""
 
-msgid "Local configuration file (in current directory)"
+msgid "User configuration file:"
 msgstr ""
 
-msgid "User configuration file (geda-user.conf)"
-msgstr ""
-
-msgid "Object ~A is not included in the current gschem page."
+msgid "Object ~A is not included in the current lepton-schematic page."
 msgstr ""
 
 msgid "Invalid text name/value visibility ~A."
 msgstr ""
 
 #, c-format
-msgid "You are running gEDA/gaf version [%1$s%2$s.%3$s],\n"
+msgid "You are running lepton-schematic version [%1$s%2$s.%3$s],\n"
 msgstr ""
 
 #, c-format
@@ -82,65 +91,13 @@ msgstr ""
 msgid "Please be sure that you have the latest rc file.\n"
 msgstr ""
 
-#, c-format
-msgid "Invalid size [%1$d] passed to text-size\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid size [%1$d] passed to snap-size\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid num levels [%1$d] passed to undo-levels\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid gain [%1$d] passed to zoom-gain\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
-msgstr ""
-
 msgid "Object ~A is not directly included in a page."
 msgstr ""
 
 msgid "Could not launch URI ~S: ~A"
 msgstr ""
 
-msgid "Found invalid gschem window smob ~S"
+msgid "Found invalid lepton-schematic window smob ~S"
 msgstr ""
 
 #, c-format
@@ -171,7 +128,7 @@ msgstr ""
 
 msgid ""
 "Copyright © 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright © 2017-2019 Lepton Developers.\n"
+"Copyright © 2017-2020 Lepton Developers.\n"
 "See AUTHORS, ChangeLog files and consult 'git log' history for details."
 msgstr ""
 
@@ -600,7 +557,8 @@ msgid ""
 "\n"
 "Are you sure you want to revert this page?\n"
 "All unsaved changes in current schematic will be\n"
-"discarded and page file will be reloaded from disk."
+"discarded and page file will be reloaded from disk.\n"
+"This action will also reload all component libraries."
 msgstr ""
 
 #, fuzzy
@@ -694,10 +652,6 @@ msgid_plural "Delete %1$u locked objects?"
 msgstr[0] ""
 msgstr[1] ""
 
-#, c-format
-msgid "Got an unexpected NULL in o_edit\n"
-msgstr ""
-
 msgid "Hidden text is now visible"
 msgstr ""
 
@@ -709,7 +663,7 @@ msgid "Could not find symbol [%1$s] in library. Update failed."
 msgstr ""
 
 #, c-format
-msgid "o_autosave_backups: Can't get the real filename of %1$s."
+msgid "Can't get the real filename of %1$s."
 msgstr ""
 
 #, c-format
@@ -722,10 +676,6 @@ msgstr ""
 
 #, c-format
 msgid "Could NOT save backup file [%1$s]"
-msgstr ""
-
-#, c-format
-msgid "ERROR: NULL object in o_move_end!\n"
 msgstr ""
 
 #, c-format
@@ -773,7 +723,7 @@ msgstr ""
 msgid "New slot number out of range"
 msgstr ""
 
-msgid "Undo/Redo disabled in rc file"
+msgid "Undo/Redo is disabled in configuration"
 msgstr ""
 
 #, c-format
@@ -794,27 +744,12 @@ msgid ""
 "  -h, --help               Help; this message.\n"
 "  --                       Treat all remaining arguments as filenames.\n"
 "\n"
-"Report bugs at <https://github.com/lepton-eda/lepton-eda/issues>\n"
-"Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"Lepton EDA %1$s (git: %2$.7s)\n"
-"Copyright (C) 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright (C) 2017-2019 Lepton Developers.\n"
-"This is free software, and you are welcome to redistribute it under\n"
-"certain conditions. For details, see the file `COPYING', which is\n"
-"included in the Lepton EDA distribution.\n"
-"There is NO WARRANTY, to the extent permitted by law.\n"
+"Report bugs at <%2$s>\n"
+"Lepton EDA homepage: <%3$s>\n"
 msgstr ""
 
 #, c-format
 msgid "Got invalid show option; defaulting to show both\n"
-msgstr ""
-
-#, c-format
-msgid "ERROR: NULL object!\n"
 msgstr ""
 
 msgid "Single Attribute Editor"
@@ -869,7 +804,7 @@ msgid ""
 "duplicate slot may cause problems: [symbolname=%1$s, number=%2$d, slot=%3$d]"
 msgstr ""
 
-msgid "No searchstring given in autonumber text."
+msgid "No search string given in autonumber text."
 msgstr ""
 
 msgid "No '*' or '?' given at the end of the autonumber text."
@@ -943,24 +878,6 @@ msgid ""
 msgstr ""
 
 msgid "Clipboard insertion failed"
-msgstr ""
-
-#, c-format
-msgid "Could not allocate the color %1$s!\n"
-msgstr ""
-
-msgid "black"
-msgstr ""
-
-msgid "white"
-msgstr ""
-
-#, c-format
-msgid "Could not allocate display color %1$i!\n"
-msgstr ""
-
-#, c-format
-msgid "Could not allocate outline color %1$i!\n"
 msgstr ""
 
 #, c-format
@@ -1097,13 +1014,13 @@ msgstr ""
 msgid "Invalid Attribute"
 msgstr ""
 
-msgid "Schematics"
+msgid "Schematics (*.sch)"
 msgstr ""
 
-msgid "Symbols"
+msgid "Symbols (*.sym)"
 msgstr ""
 
-msgid "Schematics and symbols"
+msgid "Schematics and symbols (*.sch *.sym)"
 msgstr ""
 
 msgid "All files"
@@ -1139,7 +1056,7 @@ msgid "Hatch"
 msgstr ""
 
 #, c-format
-msgid "x_image_lowlevel: Unable to write %1$s file %2$s."
+msgid "Unable to write %1$s file %2$s."
 msgstr ""
 
 #, c-format
@@ -1158,7 +1075,7 @@ msgstr ""
 msgid "Wrote black and white image to [%1$s] [%2$d x %3$d]"
 msgstr ""
 
-msgid "x_image_lowlevel: Unable to get pixbuf from gschem's window."
+msgid "Unable to get pixbuf from lepton-schematic's window."
 msgstr ""
 
 msgid "NOTE: print-color-map will be used for PDF export"
@@ -1206,63 +1123,50 @@ msgstr ""
 msgid "Phantom"
 msgstr ""
 
-msgid "Add Net"
+msgid "Add Co_mponent..."
 msgstr ""
 
-msgid "Add Attribute"
+msgid "Add Te_xt..."
 msgstr ""
 
-msgid "Add Component"
+msgid "Add _Attribute..."
 msgstr ""
 
-msgid "Add Bus"
+msgid "Add _Net"
 msgstr ""
 
-msgid "Add Text"
+msgid "Add _Bus"
 msgstr ""
 
-msgid "Zoom In"
+msgid "Cu_t"
 msgstr ""
 
-msgid "Zoom Out"
+msgid "_Copy"
 msgstr ""
 
-msgid "Zoom Extents"
+msgid "_Paste"
 msgstr ""
 
-msgid "Select"
+msgid "_Delete"
 msgstr ""
 
-msgid "Edit..."
+#, fuzzy
+msgid "_Edit..."
+msgstr "_Uredi"
+
+msgid "Ed_it Text..."
 msgstr ""
 
-msgid "Object Properties..."
+msgid "_Object Properties..."
 msgstr ""
 
-msgid "Copy"
+msgid "Hierarchy: Down _Schematic"
 msgstr ""
 
-msgid "Move"
+msgid "Hierarchy: Down S_ymbol"
 msgstr ""
 
-msgid "Delete"
-msgstr ""
-
-msgid "Down Schematic"
-msgstr ""
-
-msgid "Down Symbol"
-msgstr ""
-
-msgid "Up"
-msgstr ""
-
-#, c-format
-msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
-msgstr ""
-
-#, c-format
-msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
+msgid "Hierarchy: _Up"
 msgstr ""
 
 msgid "The operating system is out of memory or resources."
@@ -1286,6 +1190,9 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
+msgid "Delete"
+msgstr ""
+
 msgid "Copy to all"
 msgstr ""
 
@@ -1302,6 +1209,9 @@ msgid "V"
 msgstr ""
 
 msgid "Sho_w inherited attributes"
+msgstr ""
+
+msgid "Add Attribute"
 msgstr ""
 
 msgid "_Name:"
@@ -1412,6 +1322,24 @@ msgstr ""
 msgid "Hierarchy up"
 msgstr ""
 
+msgid "_New"
+msgstr "_Nova"
+
+msgid "_Open..."
+msgstr "_Odpri ..."
+
+msgid "_Save"
+msgstr "_Shrani"
+
+msgid "Save _As..."
+msgstr "Shrani _kot ..."
+
+msgid "Page _Manager..."
+msgstr ""
+
+msgid "_Close"
+msgstr "_Zapri"
+
 msgid "Options"
 msgstr ""
 
@@ -1519,6 +1447,9 @@ msgstr ""
 msgid "Add Text..."
 msgstr ""
 
+msgid "Select"
+msgstr ""
+
 msgid "Select mode"
 msgstr ""
 
@@ -1579,20 +1510,8 @@ msgstr ""
 msgid "Create and edit electrical schematics and symbols with lepton-schematic"
 msgstr ""
 
-msgid "_New"
-msgstr "_Nova"
-
-msgid "_Open..."
-msgstr "_Odpri ..."
-
 msgid "Open Recen_t"
 msgstr "Odpri nedav_no"
-
-msgid "_Save"
-msgstr "_Shrani"
-
-msgid "Save _As..."
-msgstr "Shrani _kot ..."
 
 msgid "Save All"
 msgstr "Shrani vse"
@@ -1624,18 +1543,6 @@ msgstr "_Razveljavi"
 msgid "_Redo"
 msgstr ""
 
-msgid "Cu_t"
-msgstr ""
-
-msgid "_Copy"
-msgstr ""
-
-msgid "_Paste"
-msgstr ""
-
-msgid "_Delete"
-msgstr ""
-
 msgid "Select All"
 msgstr ""
 
@@ -1643,6 +1550,12 @@ msgid "Deselect"
 msgstr ""
 
 msgid "Rotate 90 Mode"
+msgstr ""
+
+msgid "Object Properties..."
+msgstr ""
+
+msgid "Edit..."
 msgstr ""
 
 msgid "Edit Text..."
@@ -1762,9 +1675,6 @@ msgstr ""
 msgid "_Next"
 msgstr ""
 
-msgid "_Close"
-msgstr "_Zapri"
-
 #, fuzzy
 msgid "_Revert..."
 msgstr "_Povrni"
@@ -1870,6 +1780,9 @@ msgid "Grid Style: Cycle Dots/Mesh/Off"
 msgstr ""
 
 msgid "Grid Snap: Cycle Grid/Resnap/Off"
+msgstr ""
+
+msgid "Grips: On/Off"
 msgstr ""
 
 msgid "Feedback Mode: Outline/Box"
@@ -2009,6 +1922,9 @@ msgstr ""
 msgid "Cut"
 msgstr ""
 
+msgid "Copy"
+msgstr ""
+
 msgid "Paste"
 msgstr ""
 
@@ -2031,6 +1947,15 @@ msgid "Pan Up"
 msgstr ""
 
 msgid "Pan Down"
+msgstr ""
+
+msgid "Zoom Extents"
+msgstr ""
+
+msgid "Zoom In"
+msgstr ""
+
+msgid "Zoom Out"
 msgstr ""
 
 msgid "Zoom Full"
@@ -2061,6 +1986,18 @@ msgstr ""
 msgid "Print Page"
 msgstr "Na_tisni ..."
 
+msgid "Add Component"
+msgstr ""
+
+msgid "Add Net"
+msgstr ""
+
+msgid "Add Bus"
+msgstr ""
+
+msgid "Add Text"
+msgstr ""
+
 msgid "Add Line"
 msgstr ""
 
@@ -2080,6 +2017,12 @@ msgid "Add Pin"
 msgstr ""
 
 msgid "Add Picture"
+msgstr ""
+
+msgid "Down Schematic"
+msgstr ""
+
+msgid "Down Symbol"
 msgstr ""
 
 msgid "Up Hierarchy"
@@ -2154,6 +2097,9 @@ msgstr "Novo okno"
 msgid "Show Coordinate Window"
 msgstr ""
 
+msgid "Toggle Grips"
+msgstr ""
+
 msgid "Component Documentation"
 msgstr ""
 
@@ -2187,10 +2133,6 @@ msgstr ""
 msgid "About lepton-schematic"
 msgstr ""
 
-#, scheme-format
-msgid "Invalid text alignment ~A."
-msgstr ""
-
 msgid "Could not show documentation:"
 msgstr ""
 
@@ -2203,4 +2145,8 @@ msgstr ""
 
 #, scheme-format
 msgid "~S is not a prefix key sequence."
+msgstr ""
+
+#, scheme-format
+msgid "Invalid text alignment ~A."
 msgstr ""

--- a/schematic/po/sr.po
+++ b/schematic/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-10-03 23:34+0300\n"
+"POT-Creation-Date: 2020-03-18 20:44+0300\n"
 "PO-Revision-Date: 2012-01-27 14:18+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: Serbian <sr@li.org>\n"
@@ -19,6 +19,13 @@ msgstr ""
 "X-Generator: Launchpad (build 16265)\n"
 
 msgid "Zoom too small!  Cannot zoom further."
+msgstr ""
+
+msgid ""
+"Save your color scheme to a file by clicking on the \"Save As...\"\n"
+"button. It can be loaded on startup with the following\n"
+"expression in the gschemrc configuration file:\n"
+"( primitive-load \"/path/to/saved-color-scheme-file\" )"
 msgstr ""
 
 #, c-format
@@ -46,6 +53,11 @@ msgstr ""
 msgid "Sa_ve..."
 msgstr ""
 
+msgid ""
+"After you're done choosing the font, it's recommended\n"
+"to reopen schematics or restart the application."
+msgstr ""
+
 #, c-format
 msgid "<b>Current:</b> %s"
 msgstr ""
@@ -53,23 +65,20 @@ msgstr ""
 msgid "Save configuration"
 msgstr ""
 
-msgid "Save settings to:"
+msgid "Local configuration file:"
 msgstr ""
 
-msgid "Local configuration file (in current directory)"
+msgid "User configuration file:"
 msgstr ""
 
-msgid "User configuration file (geda-user.conf)"
-msgstr ""
-
-msgid "Object ~A is not included in the current gschem page."
+msgid "Object ~A is not included in the current lepton-schematic page."
 msgstr ""
 
 msgid "Invalid text name/value visibility ~A."
 msgstr ""
 
 #, c-format
-msgid "You are running gEDA/gaf version [%1$s%2$s.%3$s],\n"
+msgid "You are running lepton-schematic version [%1$s%2$s.%3$s],\n"
 msgstr ""
 
 #, c-format
@@ -82,65 +91,13 @@ msgstr ""
 msgid "Please be sure that you have the latest rc file.\n"
 msgstr ""
 
-#, c-format
-msgid "Invalid size [%1$d] passed to text-size\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid size [%1$d] passed to snap-size\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid num levels [%1$d] passed to undo-levels\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid gain [%1$d] passed to zoom-gain\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
-msgstr ""
-
 msgid "Object ~A is not directly included in a page."
 msgstr ""
 
 msgid "Could not launch URI ~S: ~A"
 msgstr ""
 
-msgid "Found invalid gschem window smob ~S"
+msgid "Found invalid lepton-schematic window smob ~S"
 msgstr ""
 
 #, c-format
@@ -171,7 +128,7 @@ msgstr ""
 
 msgid ""
 "Copyright © 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright © 2017-2019 Lepton Developers.\n"
+"Copyright © 2017-2020 Lepton Developers.\n"
 "See AUTHORS, ChangeLog files and consult 'git log' history for details."
 msgstr ""
 
@@ -600,7 +557,8 @@ msgid ""
 "\n"
 "Are you sure you want to revert this page?\n"
 "All unsaved changes in current schematic will be\n"
-"discarded and page file will be reloaded from disk."
+"discarded and page file will be reloaded from disk.\n"
+"This action will also reload all component libraries."
 msgstr ""
 
 #, fuzzy
@@ -694,10 +652,6 @@ msgid_plural "Delete %1$u locked objects?"
 msgstr[0] ""
 msgstr[1] ""
 
-#, c-format
-msgid "Got an unexpected NULL in o_edit\n"
-msgstr ""
-
 msgid "Hidden text is now visible"
 msgstr ""
 
@@ -709,7 +663,7 @@ msgid "Could not find symbol [%1$s] in library. Update failed."
 msgstr ""
 
 #, c-format
-msgid "o_autosave_backups: Can't get the real filename of %1$s."
+msgid "Can't get the real filename of %1$s."
 msgstr ""
 
 #, c-format
@@ -722,10 +676,6 @@ msgstr ""
 
 #, c-format
 msgid "Could NOT save backup file [%1$s]"
-msgstr ""
-
-#, c-format
-msgid "ERROR: NULL object in o_move_end!\n"
 msgstr ""
 
 #, c-format
@@ -773,7 +723,7 @@ msgstr ""
 msgid "New slot number out of range"
 msgstr ""
 
-msgid "Undo/Redo disabled in rc file"
+msgid "Undo/Redo is disabled in configuration"
 msgstr ""
 
 #, c-format
@@ -794,27 +744,12 @@ msgid ""
 "  -h, --help               Help; this message.\n"
 "  --                       Treat all remaining arguments as filenames.\n"
 "\n"
-"Report bugs at <https://github.com/lepton-eda/lepton-eda/issues>\n"
-"Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"Lepton EDA %1$s (git: %2$.7s)\n"
-"Copyright (C) 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright (C) 2017-2019 Lepton Developers.\n"
-"This is free software, and you are welcome to redistribute it under\n"
-"certain conditions. For details, see the file `COPYING', which is\n"
-"included in the Lepton EDA distribution.\n"
-"There is NO WARRANTY, to the extent permitted by law.\n"
+"Report bugs at <%2$s>\n"
+"Lepton EDA homepage: <%3$s>\n"
 msgstr ""
 
 #, c-format
 msgid "Got invalid show option; defaulting to show both\n"
-msgstr ""
-
-#, c-format
-msgid "ERROR: NULL object!\n"
 msgstr ""
 
 msgid "Single Attribute Editor"
@@ -869,7 +804,7 @@ msgid ""
 "duplicate slot may cause problems: [symbolname=%1$s, number=%2$d, slot=%3$d]"
 msgstr ""
 
-msgid "No searchstring given in autonumber text."
+msgid "No search string given in autonumber text."
 msgstr ""
 
 msgid "No '*' or '?' given at the end of the autonumber text."
@@ -943,24 +878,6 @@ msgid ""
 msgstr ""
 
 msgid "Clipboard insertion failed"
-msgstr ""
-
-#, c-format
-msgid "Could not allocate the color %1$s!\n"
-msgstr ""
-
-msgid "black"
-msgstr ""
-
-msgid "white"
-msgstr ""
-
-#, c-format
-msgid "Could not allocate display color %1$i!\n"
-msgstr ""
-
-#, c-format
-msgid "Could not allocate outline color %1$i!\n"
 msgstr ""
 
 #, c-format
@@ -1097,13 +1014,13 @@ msgstr ""
 msgid "Invalid Attribute"
 msgstr ""
 
-msgid "Schematics"
+msgid "Schematics (*.sch)"
 msgstr ""
 
-msgid "Symbols"
+msgid "Symbols (*.sym)"
 msgstr ""
 
-msgid "Schematics and symbols"
+msgid "Schematics and symbols (*.sch *.sym)"
 msgstr ""
 
 msgid "All files"
@@ -1139,7 +1056,7 @@ msgid "Hatch"
 msgstr ""
 
 #, c-format
-msgid "x_image_lowlevel: Unable to write %1$s file %2$s."
+msgid "Unable to write %1$s file %2$s."
 msgstr ""
 
 #, c-format
@@ -1158,7 +1075,7 @@ msgstr ""
 msgid "Wrote black and white image to [%1$s] [%2$d x %3$d]"
 msgstr ""
 
-msgid "x_image_lowlevel: Unable to get pixbuf from gschem's window."
+msgid "Unable to get pixbuf from lepton-schematic's window."
 msgstr ""
 
 msgid "NOTE: print-color-map will be used for PDF export"
@@ -1206,63 +1123,50 @@ msgstr ""
 msgid "Phantom"
 msgstr ""
 
-msgid "Add Net"
+msgid "Add Co_mponent..."
 msgstr ""
 
-msgid "Add Attribute"
+msgid "Add Te_xt..."
 msgstr ""
 
-msgid "Add Component"
+msgid "Add _Attribute..."
 msgstr ""
 
-msgid "Add Bus"
+msgid "Add _Net"
 msgstr ""
 
-msgid "Add Text"
+msgid "Add _Bus"
 msgstr ""
 
-msgid "Zoom In"
+msgid "Cu_t"
 msgstr ""
 
-msgid "Zoom Out"
+msgid "_Copy"
 msgstr ""
 
-msgid "Zoom Extents"
+msgid "_Paste"
 msgstr ""
 
-msgid "Select"
+msgid "_Delete"
 msgstr ""
 
-msgid "Edit..."
+#, fuzzy
+msgid "_Edit..."
+msgstr "_Штампај..."
+
+msgid "Ed_it Text..."
 msgstr ""
 
-msgid "Object Properties..."
+msgid "_Object Properties..."
 msgstr ""
 
-msgid "Copy"
+msgid "Hierarchy: Down _Schematic"
 msgstr ""
 
-msgid "Move"
+msgid "Hierarchy: Down S_ymbol"
 msgstr ""
 
-msgid "Delete"
-msgstr ""
-
-msgid "Down Schematic"
-msgstr ""
-
-msgid "Down Symbol"
-msgstr ""
-
-msgid "Up"
-msgstr ""
-
-#, c-format
-msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
-msgstr ""
-
-#, c-format
-msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
+msgid "Hierarchy: _Up"
 msgstr ""
 
 msgid "The operating system is out of memory or resources."
@@ -1286,6 +1190,9 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
+msgid "Delete"
+msgstr ""
+
 msgid "Copy to all"
 msgstr ""
 
@@ -1302,6 +1209,9 @@ msgid "V"
 msgstr ""
 
 msgid "Sho_w inherited attributes"
+msgstr ""
+
+msgid "Add Attribute"
 msgstr ""
 
 msgid "_Name:"
@@ -1412,6 +1322,24 @@ msgstr ""
 msgid "Hierarchy up"
 msgstr ""
 
+msgid "_New"
+msgstr "Но_во"
+
+msgid "_Open..."
+msgstr "Отв_ори..."
+
+msgid "_Save"
+msgstr "Сачу_вај"
+
+msgid "Save _As..."
+msgstr ""
+
+msgid "Page _Manager..."
+msgstr ""
+
+msgid "_Close"
+msgstr ""
+
 msgid "Options"
 msgstr ""
 
@@ -1519,6 +1447,9 @@ msgstr ""
 msgid "Add Text..."
 msgstr ""
 
+msgid "Select"
+msgstr ""
+
 msgid "Select mode"
 msgstr ""
 
@@ -1579,19 +1510,7 @@ msgstr ""
 msgid "Create and edit electrical schematics and symbols with lepton-schematic"
 msgstr ""
 
-msgid "_New"
-msgstr "Но_во"
-
-msgid "_Open..."
-msgstr "Отв_ори..."
-
 msgid "Open Recen_t"
-msgstr ""
-
-msgid "_Save"
-msgstr "Сачу_вај"
-
-msgid "Save _As..."
 msgstr ""
 
 msgid "Save All"
@@ -1624,18 +1543,6 @@ msgstr ""
 msgid "_Redo"
 msgstr ""
 
-msgid "Cu_t"
-msgstr ""
-
-msgid "_Copy"
-msgstr ""
-
-msgid "_Paste"
-msgstr ""
-
-msgid "_Delete"
-msgstr ""
-
 msgid "Select All"
 msgstr ""
 
@@ -1643,6 +1550,12 @@ msgid "Deselect"
 msgstr ""
 
 msgid "Rotate 90 Mode"
+msgstr ""
+
+msgid "Object Properties..."
+msgstr ""
+
+msgid "Edit..."
 msgstr ""
 
 msgid "Edit Text..."
@@ -1762,9 +1675,6 @@ msgstr ""
 msgid "_Next"
 msgstr ""
 
-msgid "_Close"
-msgstr ""
-
 #, fuzzy
 msgid "_Revert..."
 msgstr "_Врати"
@@ -1870,6 +1780,9 @@ msgid "Grid Style: Cycle Dots/Mesh/Off"
 msgstr ""
 
 msgid "Grid Snap: Cycle Grid/Resnap/Off"
+msgstr ""
+
+msgid "Grips: On/Off"
 msgstr ""
 
 msgid "Feedback Mode: Outline/Box"
@@ -2008,6 +1921,9 @@ msgstr ""
 msgid "Cut"
 msgstr ""
 
+msgid "Copy"
+msgstr ""
+
 msgid "Paste"
 msgstr ""
 
@@ -2030,6 +1946,15 @@ msgid "Pan Up"
 msgstr ""
 
 msgid "Pan Down"
+msgstr ""
+
+msgid "Zoom Extents"
+msgstr ""
+
+msgid "Zoom In"
+msgstr ""
+
+msgid "Zoom Out"
 msgstr ""
 
 msgid "Zoom Full"
@@ -2060,6 +1985,18 @@ msgstr ""
 msgid "Print Page"
 msgstr "_Штампај..."
 
+msgid "Add Component"
+msgstr ""
+
+msgid "Add Net"
+msgstr ""
+
+msgid "Add Bus"
+msgstr ""
+
+msgid "Add Text"
+msgstr ""
+
 msgid "Add Line"
 msgstr ""
 
@@ -2079,6 +2016,12 @@ msgid "Add Pin"
 msgstr ""
 
 msgid "Add Picture"
+msgstr ""
+
+msgid "Down Schematic"
+msgstr ""
+
+msgid "Down Symbol"
 msgstr ""
 
 msgid "Up Hierarchy"
@@ -2153,6 +2096,9 @@ msgstr "Нови прозор"
 msgid "Show Coordinate Window"
 msgstr ""
 
+msgid "Toggle Grips"
+msgstr ""
+
 msgid "Component Documentation"
 msgstr ""
 
@@ -2186,10 +2132,6 @@ msgstr ""
 msgid "About lepton-schematic"
 msgstr ""
 
-#, scheme-format
-msgid "Invalid text alignment ~A."
-msgstr ""
-
 msgid "Could not show documentation:"
 msgstr ""
 
@@ -2202,4 +2144,8 @@ msgstr ""
 
 #, scheme-format
 msgid "~S is not a prefix key sequence."
+msgstr ""
+
+#, scheme-format
+msgid "Invalid text alignment ~A."
 msgstr ""

--- a/schematic/po/tr.po
+++ b/schematic/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-10-03 23:34+0300\n"
+"POT-Creation-Date: 2020-03-18 20:44+0300\n"
 "PO-Revision-Date: 2012-01-27 14:22+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -19,6 +19,13 @@ msgstr ""
 "X-Generator: Launchpad (build 16265)\n"
 
 msgid "Zoom too small!  Cannot zoom further."
+msgstr ""
+
+msgid ""
+"Save your color scheme to a file by clicking on the \"Save As...\"\n"
+"button. It can be loaded on startup with the following\n"
+"expression in the gschemrc configuration file:\n"
+"( primitive-load \"/path/to/saved-color-scheme-file\" )"
 msgstr ""
 
 #, c-format
@@ -46,6 +53,11 @@ msgstr ""
 msgid "Sa_ve..."
 msgstr ""
 
+msgid ""
+"After you're done choosing the font, it's recommended\n"
+"to reopen schematics or restart the application."
+msgstr ""
+
 #, c-format
 msgid "<b>Current:</b> %s"
 msgstr ""
@@ -53,23 +65,20 @@ msgstr ""
 msgid "Save configuration"
 msgstr ""
 
-msgid "Save settings to:"
+msgid "Local configuration file:"
 msgstr ""
 
-msgid "Local configuration file (in current directory)"
+msgid "User configuration file:"
 msgstr ""
 
-msgid "User configuration file (geda-user.conf)"
-msgstr ""
-
-msgid "Object ~A is not included in the current gschem page."
+msgid "Object ~A is not included in the current lepton-schematic page."
 msgstr ""
 
 msgid "Invalid text name/value visibility ~A."
 msgstr ""
 
 #, c-format
-msgid "You are running gEDA/gaf version [%1$s%2$s.%3$s],\n"
+msgid "You are running lepton-schematic version [%1$s%2$s.%3$s],\n"
 msgstr ""
 
 #, c-format
@@ -82,65 +91,13 @@ msgstr ""
 msgid "Please be sure that you have the latest rc file.\n"
 msgstr ""
 
-#, c-format
-msgid "Invalid size [%1$d] passed to text-size\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid size [%1$d] passed to snap-size\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid num levels [%1$d] passed to undo-levels\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid gain [%1$d] passed to zoom-gain\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
-msgstr ""
-
 msgid "Object ~A is not directly included in a page."
 msgstr ""
 
 msgid "Could not launch URI ~S: ~A"
 msgstr ""
 
-msgid "Found invalid gschem window smob ~S"
+msgid "Found invalid lepton-schematic window smob ~S"
 msgstr ""
 
 #, c-format
@@ -171,7 +128,7 @@ msgstr ""
 
 msgid ""
 "Copyright © 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright © 2017-2019 Lepton Developers.\n"
+"Copyright © 2017-2020 Lepton Developers.\n"
 "See AUTHORS, ChangeLog files and consult 'git log' history for details."
 msgstr ""
 
@@ -612,7 +569,8 @@ msgid ""
 "\n"
 "Are you sure you want to revert this page?\n"
 "All unsaved changes in current schematic will be\n"
-"discarded and page file will be reloaded from disk."
+"discarded and page file will be reloaded from disk.\n"
+"This action will also reload all component libraries."
 msgstr ""
 
 msgid "Revert"
@@ -705,10 +663,6 @@ msgid_plural "Delete %1$u locked objects?"
 msgstr[0] ""
 msgstr[1] ""
 
-#, c-format
-msgid "Got an unexpected NULL in o_edit\n"
-msgstr ""
-
 msgid "Hidden text is now visible"
 msgstr ""
 
@@ -720,7 +674,7 @@ msgid "Could not find symbol [%1$s] in library. Update failed."
 msgstr ""
 
 #, c-format
-msgid "o_autosave_backups: Can't get the real filename of %1$s."
+msgid "Can't get the real filename of %1$s."
 msgstr ""
 
 #, c-format
@@ -733,10 +687,6 @@ msgstr ""
 
 #, c-format
 msgid "Could NOT save backup file [%1$s]"
-msgstr ""
-
-#, c-format
-msgid "ERROR: NULL object in o_move_end!\n"
 msgstr ""
 
 #, c-format
@@ -785,7 +735,7 @@ msgstr ""
 msgid "New slot number out of range"
 msgstr ""
 
-msgid "Undo/Redo disabled in rc file"
+msgid "Undo/Redo is disabled in configuration"
 msgstr ""
 
 #, c-format
@@ -806,27 +756,12 @@ msgid ""
 "  -h, --help               Help; this message.\n"
 "  --                       Treat all remaining arguments as filenames.\n"
 "\n"
-"Report bugs at <https://github.com/lepton-eda/lepton-eda/issues>\n"
-"Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"Lepton EDA %1$s (git: %2$.7s)\n"
-"Copyright (C) 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright (C) 2017-2019 Lepton Developers.\n"
-"This is free software, and you are welcome to redistribute it under\n"
-"certain conditions. For details, see the file `COPYING', which is\n"
-"included in the Lepton EDA distribution.\n"
-"There is NO WARRANTY, to the extent permitted by law.\n"
+"Report bugs at <%2$s>\n"
+"Lepton EDA homepage: <%3$s>\n"
 msgstr ""
 
 #, c-format
 msgid "Got invalid show option; defaulting to show both\n"
-msgstr ""
-
-#, c-format
-msgid "ERROR: NULL object!\n"
 msgstr ""
 
 msgid "Single Attribute Editor"
@@ -881,7 +816,7 @@ msgid ""
 "duplicate slot may cause problems: [symbolname=%1$s, number=%2$d, slot=%3$d]"
 msgstr ""
 
-msgid "No searchstring given in autonumber text."
+msgid "No search string given in autonumber text."
 msgstr ""
 
 msgid "No '*' or '?' given at the end of the autonumber text."
@@ -955,24 +890,6 @@ msgid ""
 msgstr ""
 
 msgid "Clipboard insertion failed"
-msgstr ""
-
-#, c-format
-msgid "Could not allocate the color %1$s!\n"
-msgstr ""
-
-msgid "black"
-msgstr ""
-
-msgid "white"
-msgstr ""
-
-#, c-format
-msgid "Could not allocate display color %1$i!\n"
-msgstr ""
-
-#, c-format
-msgid "Could not allocate outline color %1$i!\n"
 msgstr ""
 
 #, c-format
@@ -1111,13 +1028,13 @@ msgstr ""
 msgid "Invalid Attribute"
 msgstr ""
 
-msgid "Schematics"
+msgid "Schematics (*.sch)"
 msgstr ""
 
-msgid "Symbols"
+msgid "Symbols (*.sym)"
 msgstr ""
 
-msgid "Schematics and symbols"
+msgid "Schematics and symbols (*.sch *.sym)"
 msgstr ""
 
 msgid "All files"
@@ -1153,7 +1070,7 @@ msgid "Hatch"
 msgstr ""
 
 #, c-format
-msgid "x_image_lowlevel: Unable to write %1$s file %2$s."
+msgid "Unable to write %1$s file %2$s."
 msgstr ""
 
 #, c-format
@@ -1172,7 +1089,7 @@ msgstr ""
 msgid "Wrote black and white image to [%1$s] [%2$d x %3$d]"
 msgstr ""
 
-msgid "x_image_lowlevel: Unable to get pixbuf from gschem's window."
+msgid "Unable to get pixbuf from lepton-schematic's window."
 msgstr ""
 
 msgid "NOTE: print-color-map will be used for PDF export"
@@ -1221,67 +1138,58 @@ msgstr ""
 msgid "Phantom"
 msgstr ""
 
-msgid "Add Net"
-msgstr ""
-
-msgid "Add Attribute"
-msgstr ""
-
 #, fuzzy
-msgid "Add Component"
+msgid "Add Co_mponent..."
 msgstr "Bileşen Güncelle"
 
-msgid "Add Bus"
-msgstr ""
-
 #, fuzzy
-msgid "Add Text"
+msgid "Add Te_xt..."
 msgstr "Metni Düzenle"
 
-msgid "Zoom In"
-msgstr ""
-
-msgid "Zoom Out"
-msgstr ""
-
-msgid "Zoom Extents"
-msgstr ""
-
-msgid "Select"
-msgstr ""
-
-msgid "Edit..."
-msgstr "Düzenle..."
-
-msgid "Object Properties..."
-msgstr ""
-
-msgid "Copy"
-msgstr "Kopyala"
-
-msgid "Move"
-msgstr "Taşı"
-
-msgid "Delete"
-msgstr "Sil"
+#, fuzzy
+msgid "Add _Attribute..."
+msgstr "Öznitelikler"
 
 #, fuzzy
-msgid "Down Schematic"
+msgid "Add _Net"
+msgstr "Metni Düzenle"
+
+msgid "Add _Bus"
+msgstr ""
+
+msgid "Cu_t"
+msgstr ""
+
+msgid "_Copy"
+msgstr ""
+
+msgid "_Paste"
+msgstr ""
+
+msgid "_Delete"
+msgstr ""
+
+#, fuzzy
+msgid "_Edit..."
+msgstr "Düzenle..."
+
+#, fuzzy
+msgid "Ed_it Text..."
+msgstr "Metin Düzenle..."
+
+msgid "_Object Properties..."
+msgstr ""
+
+#, fuzzy
+msgid "Hierarchy: Down _Schematic"
 msgstr "gEDA Şematik Editörü"
 
-msgid "Down Symbol"
+msgid "Hierarchy: Down S_ymbol"
 msgstr ""
 
-msgid "Up"
-msgstr ""
-
-#, c-format
-msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
-msgstr ""
-
-#, c-format
-msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
-msgstr ""
+#, fuzzy
+msgid "Hierarchy: _Up"
+msgstr "Hiyerarşi"
 
 msgid "The operating system is out of memory or resources."
 msgstr ""
@@ -1304,6 +1212,9 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
+msgid "Delete"
+msgstr "Sil"
+
 #, fuzzy
 msgid "Copy to all"
 msgstr "1'e kopyala"
@@ -1323,6 +1234,9 @@ msgstr ""
 #, fuzzy
 msgid "Sho_w inherited attributes"
 msgstr "Öznitelikler"
+
+msgid "Add Attribute"
+msgstr ""
 
 msgid "_Name:"
 msgstr ""
@@ -1432,6 +1346,24 @@ msgstr "Hiyerarşi"
 #, fuzzy
 msgid "Hierarchy up"
 msgstr "Hiyerarşi"
+
+msgid "_New"
+msgstr ""
+
+msgid "_Open..."
+msgstr ""
+
+msgid "_Save"
+msgstr ""
+
+msgid "Save _As..."
+msgstr ""
+
+msgid "Page _Manager..."
+msgstr ""
+
+msgid "_Close"
+msgstr ""
 
 #, fuzzy
 msgid "Options"
@@ -1543,6 +1475,9 @@ msgstr ""
 msgid "Add Text..."
 msgstr ""
 
+msgid "Select"
+msgstr ""
+
 msgid "Select mode"
 msgstr ""
 
@@ -1604,19 +1539,7 @@ msgstr "gEDA Şematik Editörü"
 msgid "Create and edit electrical schematics and symbols with lepton-schematic"
 msgstr ""
 
-msgid "_New"
-msgstr ""
-
-msgid "_Open..."
-msgstr ""
-
 msgid "Open Recen_t"
-msgstr ""
-
-msgid "_Save"
-msgstr ""
-
-msgid "Save _As..."
 msgstr ""
 
 msgid "Save All"
@@ -1650,18 +1573,6 @@ msgstr ""
 msgid "_Redo"
 msgstr ""
 
-msgid "Cu_t"
-msgstr ""
-
-msgid "_Copy"
-msgstr ""
-
-msgid "_Paste"
-msgstr ""
-
-msgid "_Delete"
-msgstr ""
-
 msgid "Select All"
 msgstr ""
 
@@ -1670,6 +1581,12 @@ msgstr ""
 
 msgid "Rotate 90 Mode"
 msgstr "90 derece döndür kipi"
+
+msgid "Object Properties..."
+msgstr ""
+
+msgid "Edit..."
+msgstr "Düzenle..."
 
 msgid "Edit Text..."
 msgstr "Metin Düzenle..."
@@ -1789,9 +1706,6 @@ msgstr ""
 msgid "_Next"
 msgstr ""
 
-msgid "_Close"
-msgstr ""
-
 msgid "_Revert..."
 msgstr ""
 
@@ -1900,6 +1814,9 @@ msgid "Grid Style: Cycle Dots/Mesh/Off"
 msgstr ""
 
 msgid "Grid Snap: Cycle Grid/Resnap/Off"
+msgstr ""
+
+msgid "Grips: On/Off"
 msgstr ""
 
 msgid "Feedback Mode: Outline/Box"
@@ -2042,6 +1959,9 @@ msgstr "Metni Göster/Gizle"
 msgid "Cut"
 msgstr "1'e Kes"
 
+msgid "Copy"
+msgstr "Kopyala"
+
 #, fuzzy
 msgid "Paste"
 msgstr "1'den yapıştır"
@@ -2066,6 +1986,15 @@ msgid "Pan Up"
 msgstr ""
 
 msgid "Pan Down"
+msgstr ""
+
+msgid "Zoom Extents"
+msgstr ""
+
+msgid "Zoom In"
+msgstr ""
+
+msgid "Zoom Out"
 msgstr ""
 
 msgid "Zoom Full"
@@ -2099,6 +2028,20 @@ msgid "Print Page"
 msgstr "Sayfayı Kapat"
 
 #, fuzzy
+msgid "Add Component"
+msgstr "Bileşen Güncelle"
+
+msgid "Add Net"
+msgstr ""
+
+msgid "Add Bus"
+msgstr ""
+
+#, fuzzy
+msgid "Add Text"
+msgstr "Metni Düzenle"
+
+#, fuzzy
 msgid "Add Line"
 msgstr "Satır"
 
@@ -2119,6 +2062,13 @@ msgid "Add Pin"
 msgstr ""
 
 msgid "Add Picture"
+msgstr ""
+
+#, fuzzy
+msgid "Down Schematic"
+msgstr "gEDA Şematik Editörü"
+
+msgid "Down Symbol"
 msgstr ""
 
 #, fuzzy
@@ -2199,6 +2149,9 @@ msgstr "Yeni pencere"
 msgid "Show Coordinate Window"
 msgstr ""
 
+msgid "Toggle Grips"
+msgstr ""
+
 msgid "Component Documentation"
 msgstr ""
 
@@ -2235,10 +2188,6 @@ msgstr ""
 msgid "About lepton-schematic"
 msgstr "gschem Hakkında"
 
-#, scheme-format
-msgid "Invalid text alignment ~A."
-msgstr ""
-
 msgid "Could not show documentation:"
 msgstr ""
 
@@ -2252,6 +2201,13 @@ msgstr ""
 #, scheme-format
 msgid "~S is not a prefix key sequence."
 msgstr ""
+
+#, scheme-format
+msgid "Invalid text alignment ~A."
+msgstr ""
+
+#~ msgid "Move"
+#~ msgstr "Taşı"
 
 #~ msgid "Multiple Copy"
 #~ msgstr "Çoklu kopyala"

--- a/schematic/po/zh_CN.po
+++ b/schematic/po/zh_CN.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-10-03 23:34+0300\n"
+"POT-Creation-Date: 2020-03-18 20:44+0300\n"
 "PO-Revision-Date: 2010-02-11 03:18+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -19,6 +19,13 @@ msgstr ""
 "X-Generator: Launchpad (build Unknown)\n"
 
 msgid "Zoom too small!  Cannot zoom further."
+msgstr ""
+
+msgid ""
+"Save your color scheme to a file by clicking on the \"Save As...\"\n"
+"button. It can be loaded on startup with the following\n"
+"expression in the gschemrc configuration file:\n"
+"( primitive-load \"/path/to/saved-color-scheme-file\" )"
 msgstr ""
 
 #, c-format
@@ -46,6 +53,11 @@ msgstr ""
 msgid "Sa_ve..."
 msgstr ""
 
+msgid ""
+"After you're done choosing the font, it's recommended\n"
+"to reopen schematics or restart the application."
+msgstr ""
+
 #, c-format
 msgid "<b>Current:</b> %s"
 msgstr ""
@@ -53,23 +65,20 @@ msgstr ""
 msgid "Save configuration"
 msgstr ""
 
-msgid "Save settings to:"
+msgid "Local configuration file:"
 msgstr ""
 
-msgid "Local configuration file (in current directory)"
+msgid "User configuration file:"
 msgstr ""
 
-msgid "User configuration file (geda-user.conf)"
-msgstr ""
-
-msgid "Object ~A is not included in the current gschem page."
+msgid "Object ~A is not included in the current lepton-schematic page."
 msgstr ""
 
 msgid "Invalid text name/value visibility ~A."
 msgstr ""
 
 #, c-format
-msgid "You are running gEDA/gaf version [%1$s%2$s.%3$s],\n"
+msgid "You are running lepton-schematic version [%1$s%2$s.%3$s],\n"
 msgstr ""
 
 #, c-format
@@ -82,65 +91,13 @@ msgstr ""
 msgid "Please be sure that you have the latest rc file.\n"
 msgstr ""
 
-#, c-format
-msgid "Invalid size [%1$d] passed to text-size\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid size [%1$d] passed to snap-size\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid num levels [%1$d] passed to undo-levels\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid gain [%1$d] passed to zoom-gain\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
-msgstr ""
-
 msgid "Object ~A is not directly included in a page."
 msgstr ""
 
 msgid "Could not launch URI ~S: ~A"
 msgstr ""
 
-msgid "Found invalid gschem window smob ~S"
+msgid "Found invalid lepton-schematic window smob ~S"
 msgstr ""
 
 #, c-format
@@ -171,7 +128,7 @@ msgstr ""
 
 msgid ""
 "Copyright © 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright © 2017-2019 Lepton Developers.\n"
+"Copyright © 2017-2020 Lepton Developers.\n"
 "See AUTHORS, ChangeLog files and consult 'git log' history for details."
 msgstr ""
 
@@ -613,7 +570,8 @@ msgid ""
 "\n"
 "Are you sure you want to revert this page?\n"
 "All unsaved changes in current schematic will be\n"
-"discarded and page file will be reloaded from disk."
+"discarded and page file will be reloaded from disk.\n"
+"This action will also reload all component libraries."
 msgstr ""
 
 #, fuzzy
@@ -707,10 +665,6 @@ msgid_plural "Delete %1$u locked objects?"
 msgstr[0] ""
 msgstr[1] ""
 
-#, c-format
-msgid "Got an unexpected NULL in o_edit\n"
-msgstr ""
-
 msgid "Hidden text is now visible"
 msgstr ""
 
@@ -722,7 +676,7 @@ msgid "Could not find symbol [%1$s] in library. Update failed."
 msgstr ""
 
 #, c-format
-msgid "o_autosave_backups: Can't get the real filename of %1$s."
+msgid "Can't get the real filename of %1$s."
 msgstr ""
 
 #, c-format
@@ -735,10 +689,6 @@ msgstr ""
 
 #, c-format
 msgid "Could NOT save backup file [%1$s]"
-msgstr ""
-
-#, c-format
-msgid "ERROR: NULL object in o_move_end!\n"
 msgstr ""
 
 #, c-format
@@ -787,7 +737,7 @@ msgstr ""
 msgid "New slot number out of range"
 msgstr ""
 
-msgid "Undo/Redo disabled in rc file"
+msgid "Undo/Redo is disabled in configuration"
 msgstr ""
 
 #, c-format
@@ -808,27 +758,12 @@ msgid ""
 "  -h, --help               Help; this message.\n"
 "  --                       Treat all remaining arguments as filenames.\n"
 "\n"
-"Report bugs at <https://github.com/lepton-eda/lepton-eda/issues>\n"
-"Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"Lepton EDA %1$s (git: %2$.7s)\n"
-"Copyright (C) 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright (C) 2017-2019 Lepton Developers.\n"
-"This is free software, and you are welcome to redistribute it under\n"
-"certain conditions. For details, see the file `COPYING', which is\n"
-"included in the Lepton EDA distribution.\n"
-"There is NO WARRANTY, to the extent permitted by law.\n"
+"Report bugs at <%2$s>\n"
+"Lepton EDA homepage: <%3$s>\n"
 msgstr ""
 
 #, c-format
 msgid "Got invalid show option; defaulting to show both\n"
-msgstr ""
-
-#, c-format
-msgid "ERROR: NULL object!\n"
 msgstr ""
 
 msgid "Single Attribute Editor"
@@ -884,7 +819,7 @@ msgid ""
 "duplicate slot may cause problems: [symbolname=%1$s, number=%2$d, slot=%3$d]"
 msgstr ""
 
-msgid "No searchstring given in autonumber text."
+msgid "No search string given in autonumber text."
 msgstr ""
 
 msgid "No '*' or '?' given at the end of the autonumber text."
@@ -958,24 +893,6 @@ msgid ""
 msgstr ""
 
 msgid "Clipboard insertion failed"
-msgstr ""
-
-#, c-format
-msgid "Could not allocate the color %1$s!\n"
-msgstr ""
-
-msgid "black"
-msgstr ""
-
-msgid "white"
-msgstr ""
-
-#, c-format
-msgid "Could not allocate display color %1$i!\n"
-msgstr ""
-
-#, c-format
-msgid "Could not allocate outline color %1$i!\n"
 msgstr ""
 
 #, c-format
@@ -1116,13 +1033,13 @@ msgstr ""
 msgid "Invalid Attribute"
 msgstr ""
 
-msgid "Schematics"
+msgid "Schematics (*.sch)"
 msgstr ""
 
-msgid "Symbols"
+msgid "Symbols (*.sym)"
 msgstr ""
 
-msgid "Schematics and symbols"
+msgid "Schematics and symbols (*.sch *.sym)"
 msgstr ""
 
 msgid "All files"
@@ -1158,7 +1075,7 @@ msgid "Hatch"
 msgstr ""
 
 #, c-format
-msgid "x_image_lowlevel: Unable to write %1$s file %2$s."
+msgid "Unable to write %1$s file %2$s."
 msgstr ""
 
 #, c-format
@@ -1177,7 +1094,7 @@ msgstr ""
 msgid "Wrote black and white image to [%1$s] [%2$d x %3$d]"
 msgstr ""
 
-msgid "x_image_lowlevel: Unable to get pixbuf from gschem's window."
+msgid "Unable to get pixbuf from lepton-schematic's window."
 msgstr ""
 
 msgid "NOTE: print-color-map will be used for PDF export"
@@ -1226,69 +1143,61 @@ msgstr ""
 msgid "Phantom"
 msgstr ""
 
-msgid "Add Net"
-msgstr ""
-
-msgid "Add Attribute"
-msgstr ""
-
 #, fuzzy
-msgid "Add Component"
+msgid "Add Co_mponent..."
 msgstr "更新组件"
 
-msgid "Add Bus"
-msgstr ""
-
 #, fuzzy
-msgid "Add Text"
+msgid "Add Te_xt..."
 msgstr "编辑文本..."
 
 #, fuzzy
-msgid "Zoom In"
-msgstr "放大"
+msgid "Add _Attribute..."
+msgstr "属性..."
 
 #, fuzzy
-msgid "Zoom Out"
-msgstr "缩小"
+msgid "Add _Net"
+msgstr "编辑文本..."
+
+msgid "Add _Bus"
+msgstr ""
 
 #, fuzzy
-msgid "Zoom Extents"
-msgstr "放大"
+msgid "Cu_t"
+msgstr "剪切"
 
-msgid "Select"
-msgstr ""
-
-msgid "Edit..."
-msgstr "编辑..."
-
-msgid "Object Properties..."
-msgstr ""
-
-msgid "Copy"
+#, fuzzy
+msgid "_Copy"
 msgstr "复制"
 
-msgid "Move"
-msgstr ""
+#, fuzzy
+msgid "_Paste"
+msgstr "粘贴"
 
-msgid "Delete"
+#, fuzzy
+msgid "_Delete"
 msgstr "删除"
 
-msgid "Down Schematic"
+#, fuzzy
+msgid "_Edit..."
+msgstr "编辑..."
+
+#, fuzzy
+msgid "Ed_it Text..."
+msgstr "编辑文本..."
+
+msgid "_Object Properties..."
 msgstr ""
 
-msgid "Down Symbol"
+msgid "Hierarchy: Down _Schematic"
 msgstr ""
 
-msgid "Up"
+msgid "Hierarchy: Down S_ymbol"
 msgstr ""
 
-#, c-format
-msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
-msgstr ""
-
-#, c-format
-msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
-msgstr ""
+#, fuzzy
+msgid "Hierarchy: _Up"
+msgstr "层次"
 
 msgid "The operating system is out of memory or resources."
 msgstr ""
@@ -1311,6 +1220,9 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
+msgid "Delete"
+msgstr "删除"
+
 #, fuzzy
 msgid "Copy to all"
 msgstr "复制到 1"
@@ -1330,6 +1242,9 @@ msgstr ""
 #, fuzzy
 msgid "Sho_w inherited attributes"
 msgstr "属性"
+
+msgid "Add Attribute"
+msgstr ""
 
 #, fuzzy
 msgid "_Name:"
@@ -1442,6 +1357,30 @@ msgstr "层次"
 msgid "Hierarchy up"
 msgstr "层次"
 
+#, fuzzy
+msgid "_New"
+msgstr "新建"
+
+#, fuzzy
+msgid "_Open..."
+msgstr "打开页面..."
+
+#, fuzzy
+msgid "_Save"
+msgstr "全部保存"
+
+#, fuzzy
+msgid "Save _As..."
+msgstr "页面保存为..."
+
+#, fuzzy
+msgid "Page _Manager..."
+msgstr "打开页面..."
+
+#, fuzzy
+msgid "_Close"
+msgstr "关闭"
+
 msgid "Options"
 msgstr ""
 
@@ -1551,6 +1490,9 @@ msgstr ""
 msgid "Add Text..."
 msgstr ""
 
+msgid "Select"
+msgstr ""
+
 msgid "Select mode"
 msgstr ""
 
@@ -1611,24 +1553,8 @@ msgstr ""
 msgid "Create and edit electrical schematics and symbols with lepton-schematic"
 msgstr ""
 
-#, fuzzy
-msgid "_New"
-msgstr "新建"
-
-#, fuzzy
-msgid "_Open..."
-msgstr "打开页面..."
-
 msgid "Open Recen_t"
 msgstr ""
-
-#, fuzzy
-msgid "_Save"
-msgstr "全部保存"
-
-#, fuzzy
-msgid "Save _As..."
-msgstr "页面保存为..."
 
 msgid "Save All"
 msgstr "全部保存"
@@ -1667,22 +1593,6 @@ msgid "_Redo"
 msgstr "重做"
 
 #, fuzzy
-msgid "Cu_t"
-msgstr "剪切"
-
-#, fuzzy
-msgid "_Copy"
-msgstr "复制"
-
-#, fuzzy
-msgid "_Paste"
-msgstr "粘贴"
-
-#, fuzzy
-msgid "_Delete"
-msgstr "删除"
-
-#, fuzzy
 msgid "Select All"
 msgstr "选择模式"
 
@@ -1691,6 +1601,12 @@ msgstr ""
 
 msgid "Rotate 90 Mode"
 msgstr "旋转 90 度"
+
+msgid "Object Properties..."
+msgstr ""
+
+msgid "Edit..."
+msgstr "编辑..."
 
 msgid "Edit Text..."
 msgstr "编辑文本..."
@@ -1820,10 +1736,6 @@ msgid "_Next"
 msgstr "下一个"
 
 #, fuzzy
-msgid "_Close"
-msgstr "关闭"
-
-#, fuzzy
 msgid "_Revert..."
 msgstr "翻转页面"
 
@@ -1944,6 +1856,9 @@ msgid "Grid Style: Cycle Dots/Mesh/Off"
 msgstr ""
 
 msgid "Grid Snap: Cycle Grid/Resnap/Off"
+msgstr ""
+
+msgid "Grips: On/Off"
 msgstr ""
 
 msgid "Feedback Mode: Outline/Box"
@@ -2096,6 +2011,9 @@ msgstr ""
 msgid "Cut"
 msgstr "剪切"
 
+msgid "Copy"
+msgstr "复制"
+
 #, fuzzy
 msgid "Paste"
 msgstr "粘贴"
@@ -2122,6 +2040,18 @@ msgstr ""
 
 msgid "Pan Down"
 msgstr ""
+
+#, fuzzy
+msgid "Zoom Extents"
+msgstr "放大"
+
+#, fuzzy
+msgid "Zoom In"
+msgstr "放大"
+
+#, fuzzy
+msgid "Zoom Out"
+msgstr "缩小"
 
 #, fuzzy
 msgid "Zoom Full"
@@ -2154,6 +2084,20 @@ msgstr "新建页面"
 msgid "Print Page"
 msgstr "上一个"
 
+#, fuzzy
+msgid "Add Component"
+msgstr "更新组件"
+
+msgid "Add Net"
+msgstr ""
+
+msgid "Add Bus"
+msgstr ""
+
+#, fuzzy
+msgid "Add Text"
+msgstr "编辑文本..."
+
 msgid "Add Line"
 msgstr ""
 
@@ -2176,6 +2120,12 @@ msgstr ""
 #, fuzzy
 msgid "Add Picture"
 msgstr "图片..."
+
+msgid "Down Schematic"
+msgstr ""
+
+msgid "Down Symbol"
+msgstr ""
 
 #, fuzzy
 msgid "Up Hierarchy"
@@ -2257,6 +2207,10 @@ msgid "Show Coordinate Window"
 msgstr ""
 
 #, fuzzy
+msgid "Toggle Grips"
+msgstr "变换可见性"
+
+#, fuzzy
 msgid "Component Documentation"
 msgstr "文档"
 
@@ -2291,10 +2245,6 @@ msgstr ""
 msgid "About lepton-schematic"
 msgstr ""
 
-#, scheme-format
-msgid "Invalid text alignment ~A."
-msgstr ""
-
 #, fuzzy
 msgid "Could not show documentation:"
 msgstr "文档"
@@ -2309,6 +2259,10 @@ msgstr ""
 
 #, scheme-format
 msgid "~S is not a prefix key sequence."
+msgstr ""
+
+#, scheme-format
+msgid "Invalid text alignment ~A."
 msgstr ""
 
 #~ msgid "Edit"

--- a/schematic/po/zh_TW.po
+++ b/schematic/po/zh_TW.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geda\n"
 "Report-Msgid-Bugs-To: https://github.com/lepton-eda/lepton-eda/issues\n"
-"POT-Creation-Date: 2019-10-03 23:34+0300\n"
+"POT-Creation-Date: 2020-03-18 20:44+0300\n"
 "PO-Revision-Date: 2012-01-27 14:22+0000\n"
 "Last-Translator: Launchpad Translators\n"
 "Language-Team: gEDA developers <geda-dev@seul.org>\n"
@@ -21,6 +21,13 @@ msgstr ""
 #, fuzzy
 msgid "Zoom too small!  Cannot zoom further."
 msgstr "已經縮到最小了，無法再縮小囉！\n"
+
+msgid ""
+"Save your color scheme to a file by clicking on the \"Save As...\"\n"
+"button. It can be loaded on startup with the following\n"
+"expression in the gschemrc configuration file:\n"
+"( primitive-load \"/path/to/saved-color-scheme-file\" )"
+msgstr ""
 
 #, fuzzy, c-format
 msgid ""
@@ -48,6 +55,11 @@ msgstr ""
 msgid "Sa_ve..."
 msgstr ""
 
+msgid ""
+"After you're done choosing the font, it's recommended\n"
+"to reopen schematics or restart the application."
+msgstr ""
+
 #, c-format
 msgid "<b>Current:</b> %s"
 msgstr ""
@@ -55,23 +67,20 @@ msgstr ""
 msgid "Save configuration"
 msgstr ""
 
-msgid "Save settings to:"
+msgid "Local configuration file:"
 msgstr ""
 
-msgid "Local configuration file (in current directory)"
+msgid "User configuration file:"
 msgstr ""
 
-msgid "User configuration file (geda-user.conf)"
-msgstr ""
-
-msgid "Object ~A is not included in the current gschem page."
+msgid "Object ~A is not included in the current lepton-schematic page."
 msgstr ""
 
 msgid "Invalid text name/value visibility ~A."
 msgstr ""
 
 #, fuzzy, c-format
-msgid "You are running gEDA/gaf version [%1$s%2$s.%3$s],\n"
+msgid "You are running lepton-schematic version [%1$s%2$s.%3$s],\n"
 msgstr "gEDA/gschem 版本 %s%s.%s\n"
 
 #, c-format
@@ -84,65 +93,13 @@ msgstr ""
 msgid "Please be sure that you have the latest rc file.\n"
 msgstr ""
 
-#, c-format
-msgid "Invalid size [%1$d] passed to text-size\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid size [%1$d] passed to snap-size\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid num levels [%1$d] passed to undo-levels\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid size [%1$d] passed to bus-ripper-size\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid dot size [%1$d] passed to dots-grid-dot-size\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid pixel spacing [%1$d] passed to dots-grid-fixed-threshold\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid pixel spacing [%1$d] passed to mesh-grid-display-threshold\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid number of seconds [%1$d] passed to auto-save-interval\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid gain [%1$d] passed to mousepan-gain\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid gain [%1$d] passed to keyboardpan-gain\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid number of pixels [%1$d] passed to select-slack-pixels\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid gain [%1$d] passed to zoom-gain\n"
-msgstr ""
-
-#, c-format
-msgid "Invalid number of steps [%1$d] scrollpan-steps\n"
-msgstr ""
-
 msgid "Object ~A is not directly included in a page."
 msgstr ""
 
 msgid "Could not launch URI ~S: ~A"
 msgstr ""
 
-msgid "Found invalid gschem window smob ~S"
+msgid "Found invalid lepton-schematic window smob ~S"
 msgstr ""
 
 #, fuzzy, c-format
@@ -173,7 +130,7 @@ msgstr ""
 
 msgid ""
 "Copyright © 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright © 2017-2019 Lepton Developers.\n"
+"Copyright © 2017-2020 Lepton Developers.\n"
 "See AUTHORS, ChangeLog files and consult 'git log' history for details."
 msgstr ""
 
@@ -623,7 +580,8 @@ msgid ""
 "\n"
 "Are you sure you want to revert this page?\n"
 "All unsaved changes in current schematic will be\n"
-"discarded and page file will be reloaded from disk."
+"discarded and page file will be reloaded from disk.\n"
+"This action will also reload all component libraries."
 msgstr ""
 
 #, fuzzy
@@ -719,10 +677,6 @@ msgid_plural "Delete %1$u locked objects?"
 msgstr[0] "選擇物件"
 msgstr[1] "選擇物件"
 
-#, c-format
-msgid "Got an unexpected NULL in o_edit\n"
-msgstr ""
-
 #, fuzzy
 msgid "Hidden text is now visible"
 msgstr "隱藏的文字現在已經可以看見\n"
@@ -736,7 +690,7 @@ msgid "Could not find symbol [%1$s] in library. Update failed."
 msgstr ""
 
 #, c-format
-msgid "o_autosave_backups: Can't get the real filename of %1$s."
+msgid "Can't get the real filename of %1$s."
 msgstr ""
 
 #, fuzzy, c-format
@@ -750,10 +704,6 @@ msgstr "無法設定備份檔[%s]為唯讀\n"
 #, fuzzy, c-format
 msgid "Could NOT save backup file [%1$s]"
 msgstr "無法儲存備份檔 [%s]\n"
-
-#, c-format
-msgid "ERROR: NULL object in o_move_end!\n"
-msgstr ""
 
 #, c-format
 msgid "DOH! tried to find the whichone, but didn't find it!\n"
@@ -801,7 +751,7 @@ msgstr ""
 msgid "New slot number out of range"
 msgstr ""
 
-msgid "Undo/Redo disabled in rc file"
+msgid "Undo/Redo is disabled in configuration"
 msgstr ""
 
 #, c-format
@@ -822,27 +772,12 @@ msgid ""
 "  -h, --help               Help; this message.\n"
 "  --                       Treat all remaining arguments as filenames.\n"
 "\n"
-"Report bugs at <https://github.com/lepton-eda/lepton-eda/issues>\n"
-"Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>\n"
-msgstr ""
-
-#, c-format
-msgid ""
-"Lepton EDA %1$s (git: %2$.7s)\n"
-"Copyright (C) 1998-2017 by Ales Hvezda and the respective original authors.\n"
-"Copyright (C) 2017-2019 Lepton Developers.\n"
-"This is free software, and you are welcome to redistribute it under\n"
-"certain conditions. For details, see the file `COPYING', which is\n"
-"included in the Lepton EDA distribution.\n"
-"There is NO WARRANTY, to the extent permitted by law.\n"
+"Report bugs at <%2$s>\n"
+"Lepton EDA homepage: <%3$s>\n"
 msgstr ""
 
 #, c-format
 msgid "Got invalid show option; defaulting to show both\n"
-msgstr ""
-
-#, c-format
-msgid "ERROR: NULL object!\n"
 msgstr ""
 
 msgid "Single Attribute Editor"
@@ -899,7 +834,7 @@ msgid ""
 "duplicate slot may cause problems: [symbolname=%1$s, number=%2$d, slot=%3$d]"
 msgstr ""
 
-msgid "No searchstring given in autonumber text."
+msgid "No search string given in autonumber text."
 msgstr ""
 
 msgid "No '*' or '?' given at the end of the autonumber text."
@@ -973,24 +908,6 @@ msgid ""
 msgstr ""
 
 msgid "Clipboard insertion failed"
-msgstr ""
-
-#, c-format
-msgid "Could not allocate the color %1$s!\n"
-msgstr ""
-
-msgid "black"
-msgstr ""
-
-msgid "white"
-msgstr ""
-
-#, c-format
-msgid "Could not allocate display color %1$i!\n"
-msgstr ""
-
-#, c-format
-msgid "Could not allocate outline color %1$i!\n"
 msgstr ""
 
 #, c-format
@@ -1130,13 +1047,13 @@ msgstr ""
 msgid "Invalid Attribute"
 msgstr ""
 
-msgid "Schematics"
+msgid "Schematics (*.sch)"
 msgstr ""
 
-msgid "Symbols"
+msgid "Symbols (*.sym)"
 msgstr ""
 
-msgid "Schematics and symbols"
+msgid "Schematics and symbols (*.sch *.sym)"
 msgstr ""
 
 msgid "All files"
@@ -1171,9 +1088,9 @@ msgstr ""
 msgid "Hatch"
 msgstr ""
 
-#, c-format
-msgid "x_image_lowlevel: Unable to write %1$s file %2$s."
-msgstr ""
+#, fuzzy, c-format
+msgid "Unable to write %1$s file %2$s."
+msgstr "無法讀取圖片: %s"
 
 #, c-format
 msgid ""
@@ -1191,7 +1108,7 @@ msgstr ""
 msgid "Wrote black and white image to [%1$s] [%2$d x %3$d]"
 msgstr ""
 
-msgid "x_image_lowlevel: Unable to get pixbuf from gschem's window."
+msgid "Unable to get pixbuf from lepton-schematic's window."
 msgstr ""
 
 msgid "NOTE: print-color-map will be used for PDF export"
@@ -1242,70 +1159,56 @@ msgid "Phantom"
 msgstr ""
 
 #, fuzzy
-msgid "Add Net"
-msgstr "新增文字"
-
-msgid "Add Attribute"
-msgstr ""
-
-#, fuzzy
-msgid "Add Component"
+msgid "Add Co_mponent..."
 msgstr "元件"
 
-msgid "Add Bus"
-msgstr ""
-
 #, fuzzy
-msgid "Add Text"
+msgid "Add Te_xt..."
 msgstr "新增文字"
 
 #, fuzzy
-msgid "Zoom In"
-msgstr "放大檢視"
+msgid "Add _Attribute..."
+msgstr "屬性"
 
 #, fuzzy
-msgid "Zoom Out"
-msgstr "縮小檢視"
+msgid "Add _Net"
+msgstr "新增文字"
 
-#, fuzzy
-msgid "Zoom Extents"
-msgstr "放大檢視"
+msgid "Add _Bus"
+msgstr ""
 
-msgid "Select"
-msgstr "選擇"
+msgid "Cu_t"
+msgstr "剪下"
 
-msgid "Edit..."
-msgstr "編輯"
-
-#, fuzzy
-msgid "Object Properties..."
-msgstr "<b>選項</b>"
-
-msgid "Copy"
+msgid "_Copy"
 msgstr "複製"
 
-msgid "Move"
-msgstr "搬移"
+msgid "_Paste"
+msgstr "貼上"
 
-msgid "Delete"
+msgid "_Delete"
 msgstr "刪除"
 
 #, fuzzy
-msgid "Down Schematic"
+msgid "_Edit..."
+msgstr "編輯"
+
+#, fuzzy
+msgid "Ed_it Text..."
+msgstr "編輯文字"
+
+#, fuzzy
+msgid "_Object Properties..."
+msgstr "<b>選項</b>"
+
+#, fuzzy
+msgid "Hierarchy: Down _Schematic"
 msgstr "gEDA 電路圖編輯器"
 
-msgid "Down Symbol"
+msgid "Hierarchy: Down S_ymbol"
 msgstr ""
 
-msgid "Up"
-msgstr ""
-
-#, c-format
-msgid "Tried to set the sensitivity on non-existent menu item '%1$s'"
-msgstr ""
-
-#, c-format
-msgid "Tried to set the sensitivity on non-existent menu item '%s'\n"
+msgid "Hierarchy: _Up"
 msgstr ""
 
 msgid "The operating system is out of memory or resources."
@@ -1329,6 +1232,9 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
+msgid "Delete"
+msgstr "刪除"
+
 #, fuzzy
 msgid "Copy to all"
 msgstr "複製到 緩衝區1"
@@ -1348,6 +1254,9 @@ msgstr ""
 #, fuzzy
 msgid "Sho_w inherited attributes"
 msgstr "屬性"
+
+msgid "Add Attribute"
+msgstr ""
 
 #, fuzzy
 msgid "_Name:"
@@ -1458,6 +1367,25 @@ msgstr ""
 
 msgid "Hierarchy up"
 msgstr ""
+
+msgid "_New"
+msgstr "新增檔案"
+
+msgid "_Open..."
+msgstr "開啟舊檔"
+
+msgid "_Save"
+msgstr "儲存檔案"
+
+msgid "Save _As..."
+msgstr "另存新檔"
+
+#, fuzzy
+msgid "Page _Manager..."
+msgstr "管理分頁"
+
+msgid "_Close"
+msgstr "關閉視窗"
 
 #, fuzzy
 msgid "Options"
@@ -1570,6 +1498,9 @@ msgstr ""
 msgid "Add Text..."
 msgstr "新增文字"
 
+msgid "Select"
+msgstr "選擇"
+
 msgid "Select mode"
 msgstr "選擇模式"
 
@@ -1632,20 +1563,8 @@ msgstr "gEDA 電路圖編輯器"
 msgid "Create and edit electrical schematics and symbols with lepton-schematic"
 msgstr "用 gschem 建立並編輯電子電路圖表及符號"
 
-msgid "_New"
-msgstr "新增檔案"
-
-msgid "_Open..."
-msgstr "開啟舊檔"
-
 msgid "Open Recen_t"
 msgstr "最近的檔案"
-
-msgid "_Save"
-msgstr "儲存檔案"
-
-msgid "Save _As..."
-msgstr "另存新檔"
 
 msgid "Save All"
 msgstr "儲存全部"
@@ -1678,18 +1597,6 @@ msgstr "還原"
 msgid "_Redo"
 msgstr "取消還原"
 
-msgid "Cu_t"
-msgstr "剪下"
-
-msgid "_Copy"
-msgstr "複製"
-
-msgid "_Paste"
-msgstr "貼上"
-
-msgid "_Delete"
-msgstr "刪除"
-
 msgid "Select All"
 msgstr ""
 
@@ -1698,6 +1605,13 @@ msgstr ""
 
 msgid "Rotate 90 Mode"
 msgstr "逆時針旋轉90度"
+
+#, fuzzy
+msgid "Object Properties..."
+msgstr "<b>選項</b>"
+
+msgid "Edit..."
+msgstr "編輯"
 
 msgid "Edit Text..."
 msgstr "編輯文字"
@@ -1821,9 +1735,6 @@ msgstr "上一個分頁"
 msgid "_Next"
 msgstr "下一個分頁"
 
-msgid "_Close"
-msgstr "關閉視窗"
-
 #, fuzzy
 msgid "_Revert..."
 msgstr "還原"
@@ -1934,6 +1845,9 @@ msgid "Grid Style: Cycle Dots/Mesh/Off"
 msgstr ""
 
 msgid "Grid Snap: Cycle Grid/Resnap/Off"
+msgstr ""
+
+msgid "Grips: On/Off"
 msgstr ""
 
 msgid "Feedback Mode: Outline/Box"
@@ -2079,6 +1993,9 @@ msgstr ""
 msgid "Cut"
 msgstr "剪下"
 
+msgid "Copy"
+msgstr "複製"
+
 #, fuzzy
 msgid "Paste"
 msgstr "貼上"
@@ -2104,6 +2021,18 @@ msgstr ""
 
 msgid "Pan Down"
 msgstr ""
+
+#, fuzzy
+msgid "Zoom Extents"
+msgstr "放大檢視"
+
+#, fuzzy
+msgid "Zoom In"
+msgstr "放大檢視"
+
+#, fuzzy
+msgid "Zoom Out"
+msgstr "縮小檢視"
 
 #, fuzzy
 msgid "Zoom Full"
@@ -2140,6 +2069,21 @@ msgid "Print Page"
 msgstr "上一個分頁"
 
 #, fuzzy
+msgid "Add Component"
+msgstr "元件"
+
+#, fuzzy
+msgid "Add Net"
+msgstr "新增文字"
+
+msgid "Add Bus"
+msgstr ""
+
+#, fuzzy
+msgid "Add Text"
+msgstr "新增文字"
+
+#, fuzzy
 msgid "Add Line"
 msgstr "直線"
 
@@ -2162,6 +2106,13 @@ msgstr ""
 #, fuzzy
 msgid "Add Picture"
 msgstr "圖片"
+
+#, fuzzy
+msgid "Down Schematic"
+msgstr "gEDA 電路圖編輯器"
+
+msgid "Down Symbol"
+msgstr ""
 
 msgid "Up Hierarchy"
 msgstr ""
@@ -2240,6 +2191,9 @@ msgstr "開新視窗"
 msgid "Show Coordinate Window"
 msgstr ""
 
+msgid "Toggle Grips"
+msgstr ""
+
 #, fuzzy
 msgid "Component Documentation"
 msgstr "元件模式"
@@ -2277,10 +2231,6 @@ msgstr ""
 msgid "About lepton-schematic"
 msgstr "關於 gschem"
 
-#, scheme-format
-msgid "Invalid text alignment ~A."
-msgstr ""
-
 #, fuzzy
 msgid "Could not show documentation:"
 msgstr "元件模式"
@@ -2295,6 +2245,13 @@ msgstr ""
 #, scheme-format
 msgid "~S is not a prefix key sequence."
 msgstr ""
+
+#, scheme-format
+msgid "Invalid text alignment ~A."
+msgstr ""
+
+#~ msgid "Move"
+#~ msgstr "搬移"
 
 #, fuzzy
 #~ msgid "Failed to read init scm file [%1$s]"

--- a/schematic/scheme/pcb.scm
+++ b/schematic/scheme/pcb.scm
@@ -2,7 +2,7 @@
 ;;
 ;; Copyright (C) 2006-2010 Dan McMahill
 ;; Copyright (C) 2006-2011 gEDA Contributors
-;; Copyright (C) 2019 Lepton EDA Contributors
+;; Copyright (C) 2019-2020 Lepton EDA Contributors
 ;;
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/schematic/src/g_rc.c
+++ b/schematic/src/g_rc.c
@@ -86,7 +86,7 @@ SCM g_rc_gschem_version(SCM scm_version)
     sourcefile = scm_to_utf8_string (rc_filename);
     scm_dynwind_free (sourcefile);
     fprintf(stderr,
-            _("You are running gEDA/gaf version [%1$s%2$s.%3$s],\n"),
+            _("You are running lepton-schematic version [%1$s%2$s.%3$s],\n"),
             PREPEND_VERSION_STRING, PACKAGE_DOTTED_VERSION,
             PACKAGE_DATE_VERSION);
     fprintf(stderr,

--- a/schematic/src/o_misc.c
+++ b/schematic/src/o_misc.c
@@ -52,8 +52,7 @@ void o_edit(GschemToplevel *w_current, GList *list)
 
   o_current = (OBJECT *) list->data;
   if (o_current == NULL) {
-    fprintf(stderr, "o_edit: ");
-    fprintf(stderr, _("Got an unexpected NULL\n"));
+    fprintf (stderr, "o_edit: ERROR: Got an unexpected NULL\n");
     exit(-1);
   }
 

--- a/schematic/src/o_misc.c
+++ b/schematic/src/o_misc.c
@@ -52,7 +52,8 @@ void o_edit(GschemToplevel *w_current, GList *list)
 
   o_current = (OBJECT *) list->data;
   if (o_current == NULL) {
-    fprintf(stderr, _("Got an unexpected NULL in o_edit\n"));
+    fprintf(stderr, "o_edit: ");
+    fprintf(stderr, _("Got an unexpected NULL\n"));
     exit(-1);
   }
 
@@ -583,7 +584,8 @@ void o_autosave_backups(GschemToplevel *w_current)
       real_filename = follow_symlinks (s_page_get_filename (p_current), NULL);
 
       if (real_filename == NULL) {
-        s_log_message (_("o_autosave_backups: Can't get the real filename of %1$s."), s_page_get_filename (p_current));
+        s_log_message ("o_autosave_backups: ");
+        s_log_message (_("Can't get the real filename of %1$s."), s_page_get_filename (p_current));
       } else {
         /* Get the directory in which the real filename lives */
         dirname = g_path_get_dirname (real_filename);

--- a/schematic/src/o_move.c
+++ b/schematic/src/o_move.c
@@ -190,7 +190,7 @@ void o_move_end(GschemToplevel *w_current)
     object = (OBJECT *) s_current->data;
 
     if (object == NULL) {
-      fprintf(stderr, _("ERROR: NULL object in o_move_end!\n"));
+      fprintf (stderr, "o_move_end: ERROR: Got an unexpected NULL\n");
       exit(-1);
     }
 

--- a/schematic/src/x_attribedit.c
+++ b/schematic/src/x_attribedit.c
@@ -136,7 +136,7 @@ void attrib_edit_dialog_ok(GtkWidget * w, GschemToplevel *w_current)
     while (s_current != NULL) {
       object = (OBJECT *)s_current->data;
       if (object == NULL) {
-	fprintf(stderr, _("ERROR: NULL object!\n"));
+	fprintf (stderr, "attrib_edit_dialog_ok: ERROR: Got an unexpected NULL\n");
 	exit(-1);
       }
       if (!object->attached_to) {

--- a/schematic/src/x_autonumber.c
+++ b/schematic/src/x_autonumber.c
@@ -672,7 +672,7 @@ void autonumber_text_autonumber(AUTONUMBER_TEXT *autotext)
      in the searchtext list */
 
   if (strlen(scope_text) == 0) {
-    s_log_message(_("No searchstring given in autonumber text."));
+    s_log_message(_("No search string given in autonumber text."));
     return; /* error */
   }
   else if (g_str_has_suffix(scope_text,"?") == TRUE) {

--- a/schematic/src/x_color.c
+++ b/schematic/src/x_color.c
@@ -86,7 +86,7 @@ void x_color_allocate (void)
                                  &black,
                                  FALSE,
                                  TRUE)) {
-    fprintf (stderr, _("Could not allocate the color %1$s!\n"), _("black"));
+    fprintf (stderr, "Could not allocate the color %1$s!\n", "black");
     exit (-1);
   }
 
@@ -95,7 +95,7 @@ void x_color_allocate (void)
                                  &white,
                                  FALSE,
                                  TRUE)) {
-    fprintf (stderr, _("Could not allocate the color %1$s!\n"), _("white"));
+    fprintf (stderr, "Could not allocate the color %1$s!\n", "white");
     exit (-1);
   }
 
@@ -117,7 +117,7 @@ void x_color_allocate (void)
       error = gdk_color_alloc(colormap, gdk_colors[i]);
 
       if (error == FALSE) {
-        g_error (_("Could not allocate display color %1$i!\n"), i);
+        g_error ("Could not allocate display color %1$i!\n", i);
       }
     } else {
       gdk_colors[i] = NULL;
@@ -139,7 +139,7 @@ void x_color_allocate (void)
       error = gdk_color_alloc(colormap, gdk_outline_colors[i]);
 
       if (error == FALSE) {
-        g_error (_("Could not allocate outline color %1$i!\n"), i);
+        g_error ("Could not allocate outline color %1$i!\n", i);
       }
     } else {
       gdk_outline_colors[i] = NULL;

--- a/schematic/src/x_color.c
+++ b/schematic/src/x_color.c
@@ -1,6 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
- * Copyright (C) 1998-2010 gEDA Contributors (see ChangeLog for details)
+ * Copyright (C) 1998-2016 gEDA Contributors
+ * Copyright (C) 2017-2020 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/schematic/src/x_image.c
+++ b/schematic/src/x_image.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2016 gEDA Contributors
- * Copyright (C) 2017-2019 Lepton EDA Contributors
+ * Copyright (C) 2017-2020 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/schematic/src/x_image.c
+++ b/schematic/src/x_image.c
@@ -403,9 +403,10 @@ void x_image_lowlevel(GschemToplevel *w_current, const char* filename,
     pixbuf = x_image_get_pixbuf(w_current, width, height, is_color);
     if (pixbuf != NULL) {
       if (!gdk_pixbuf_save(pixbuf, filename, filetype, &gerror, NULL)) {
-        s_log_message(_("x_image_lowlevel: Unable to write %1$s file %2$s."),
-            filetype, filename);
-        s_log_message("%s", gerror->message);
+        s_log_message ("x_image_lowlevel: ");
+        s_log_message (_("Unable to write %1$s file %2$s."),
+                       filetype, filename);
+        s_log_message ("%s", gerror->message);
 
         /* Warn the user */
         dialog = gtk_message_dialog_new (GTK_WINDOW(w_current->main_window),
@@ -443,7 +444,8 @@ void x_image_lowlevel(GschemToplevel *w_current, const char* filename,
         g_object_unref(pixbuf);
     }
     else {
-      s_log_message(_("x_image_lowlevel: Unable to get pixbuf from gschem's window."));
+      s_log_message ("x_image_lowlevel: ");
+      s_log_message (_("Unable to get pixbuf from lepton-schematic's window."));
     }
   }
 

--- a/schematic/src/x_menus.c
+++ b/schematic/src/x_menus.c
@@ -376,7 +376,7 @@ x_menus_sensitivity (GtkWidget*   menu,
   }
   else
   {
-    g_debug(_("x_menus_sensitivity(): cannot find action [%s]"), action_name);
+    g_debug ("x_menus_sensitivity(): cannot find action [%s]", action_name);
   }
 }
 


### PR DESCRIPTION
- Fix translation strings so that they do not contain function names.
- Fix program name in some messages.
- Avoid translating messages by `g_debug()`.
- Avoid translating fatal programming messages.
- Update PO file for `lepton-schematic`.
