### PR TITLE
"Leptonize" texinfo manual

### DIFF
--- a/docs/scheme-api/lepton-scheme.texi
+++ b/docs/scheme-api/lepton-scheme.texi
@@ -1695,12 +1695,12 @@ Normally, you shouldn't create a configuration context directly; you
 should obtain the configuration context associated with a @var{path}.
 
 @code{path-config-context} looks for a configuration file named
-@file{geda.conf}.  If @var{path} is not a directory, it is truncated,
-and then a file named @file{geda.conf} is looked for in that
+@file{lepton.conf}.  If @var{path} is not a directory, it is truncated,
+and then a file named @file{lepton.conf} is looked for in that
 directory.  If none is found, the parent directory is checked, and so
 on until a configuration file is found or the filesystem root is
 reached.  If no configuration file was found, the returned context
-will be associated with a @file{geda.conf} in the same directory as
+will be associated with a @file{lepton.conf} in the same directory as
 @var{path}.
 
 @strong{Warning}: Do not assume that the configuration file associated

--- a/docs/scheme-api/lepton-scheme.texi
+++ b/docs/scheme-api/lepton-scheme.texi
@@ -1731,14 +1731,15 @@ Since 1.10.
 @defun system-config-context
 The system context is used for system-wide configuration.  Its parent
 context is the default context.  It is located by searching
-@code{sys-config-dirs} for a @file{gEDA/geda-system.conf} file.
+@code{sys-config-dirs} for a
+@file{$@{prefix@}/share/lepton-eda/lepton-system.conf} file.
 
 Since 1.10.
 @end defun
 
 @defun user-config-context
 The user context is used for user-specific configuration, and is
-loaded from @file{geda-user.conf} in @code{user-config-dir}.
+loaded from @file{lepton-user.conf} in @code{user-config-dir}.
 Its parent context is the system context.
 
 Since 1.10.

--- a/docs/scheme-api/lepton-scheme.texi
+++ b/docs/scheme-api/lepton-scheme.texi
@@ -109,13 +109,13 @@ If you think you have found a bug, please file a bug report:
 @samp{scheme-api}.  It will help us to fix your bug quickly if you can
 describe in detail how to reproduce the bug.
 
-If you have a question about using gEDA, or about extending gEDA using
-Scheme, you may wish to send a message to one of the gEDA mailing
-lists.  You may also find additional information in the gEDA
-wiki.
-
-Both the mailing lists and wiki can be accessed from the main gEDA
-website: @uref{http://www.geda-project.org/}.
+If you have a question about using Lepton EDA, or about extending
+Lepton using Scheme, you may wish to send a message to one of the gEDA
+mailing lists (@samp{geda-user} or @samp{geda-help}) which can be
+accessed from the main gEDA website:
+@uref{http://www.geda-project.org/}.  Currently, Lepton doesn't have
+an own mailing list. You may also find additional information in the
+@url{https://github.com/lepton-eda/lepton-eda/wiki, Lepton EDA wiki}.
 
 @section We Need Feedback!
 

--- a/docs/scheme-api/lepton-scheme.texi
+++ b/docs/scheme-api/lepton-scheme.texi
@@ -59,6 +59,13 @@ must provide the URL for the original version.
 @node Introduction
 @unnumbered Introduction
 
+@section About Lepton EDA
+Lepton EDA is a suite of free software tools for designing
+electronics. It provides schematic capture, netlisting into over 30
+netlist formats, and many other features. It was forked from the
+@url{http://wiki.geda-project.org/geda:gaf, gEDA/gaf suite} (part of
+gEDA, please see below) by most of its main developers in late 2016.
+
 @section About gEDA
 
 @dfn{gEDA}, or @emph{GPL Electronic Design Automation}, is a suite of
@@ -66,11 +73,7 @@ free software tools for designing electronics.  The gEDA project has
 produced and continues working on a full GPL'd suite and toolkit of
 Electronic Design Automation (EDA) tools. These tools are used for
 electrical circuit design, schematic capture, simulation, prototyping,
-and production. Currently, the gEDA project offers a mature suite of
-free software applications for electronics design, including schematic
-capture, attribute management, bill of materials (BOM) generation,
-netlisting into over 20 netlist formats, analog and digital
-simulation, and printed circuit board (PCB) layout.
+and production.
 
 The gEDA project was started because of the lack of free EDA tools for
 POSIX systems with the primary purpose of advancing the state of free

--- a/docs/scheme-api/lepton-scheme.texi
+++ b/docs/scheme-api/lepton-scheme.texi
@@ -19,7 +19,7 @@ The text of and illustrations in this document are licensed under a
 Creative Commons Attribution–Share Alike 3.0 Unported license
 ("CC-BY-SA"). An explanation of CC-BY-SA is available at
 @uref{http://creativecommons.org/licenses/by-sa/3.0/}. The original
-authors of this document designate the gEDA Project as the
+authors of this document designate the Lepton EDA Project as the
 "Attribution Party" for purposes of CC-BY-SA. In accordance with
 CC-BY-SA, if you distribute this document or an adaptation of it, you
 must provide the URL for the original version.
@@ -81,10 +81,10 @@ hardware or open source hardware. The suite is mainly being developed
 on the GNU/Linux platform with some development effort going into
 making sure the tools run on other platforms as well.
 
-@section About the gEDA Scheme API
+@section About the Lepton EDA Scheme API
 
-The @dfn{gEDA Scheme API}, documented in this manual, is a set of
-Scheme functions which can be used to enhance gEDA applications by
+The @dfn{Lepton EDA Scheme API}, documented in this manual, is a set of
+Scheme functions which can be used to enhance Lepton applications by
 adding new functionality or modify existing behaviour.
 
 Lepton EDA (formerly gEDA) has always used a Scheme interpreter for
@@ -93,10 +93,10 @@ lepton-schemactic (formerly gschem), and implementing netlist exporter
 backends in gnetlist.  However, for a long time the utility of
 embedding a Scheme interpreter was diminished by the lack of a
 low-level API for inspecting and modifying schematic documents.  The
-Scheme types and functions documented here were added to gEDA to
-address that need.
+Scheme types and functions documented here were added to gEDA and
+later to Lepton to address that need.
 
-gEDA uses the @emph{Guile} Scheme implementation (otherwise known as
+Lepton uses the @emph{Guile} Scheme implementation (otherwise known as
 the @emph{GNU Ubiquitous Intelligent Language for Extensions}) as its
 embedded Scheme.  For more information about Guile, please visit
 @uref{http://www.gnu.org/s/guile/}.
@@ -137,8 +137,8 @@ schematics are then processed with the gnetlist tool to generate a
 @emph{netlist}.
 
 This chapter describes the different data types used by the Scheme API
-to represent gEDA documents (both schematics and symbols), and how
-they relate to each other.
+to represent Lepton EDA documents (both schematics and symbols), and
+how they relate to each other.
 
 @menu
 * Pages::
@@ -255,7 +255,7 @@ other types of @code{object}.
 @cindex Attribute
 @cindex Attribute format
 
-A gEDA user is able to annotate schematic elements with additional
+A Lepton user is able to annotate schematic elements with additional
 data, such as footprints for components or net names for nets.  This
 is carried out using @dfn{attributes}.
 
@@ -287,10 +287,10 @@ must not begin with a space (@samp{ }, Unicode @code{U+0020}).
 @end enumerate
 @end itemize
 
-@strong{Note}: Due to assumptions made by some gEDA tools, it is
-@emph{strongly recommended} that you use attribute @var{name}s which
-contain only lower-case Latin characters, decimal digits, full stops
-@samp{.}  (@code{U+002E}), and hyphens @samp{-} (@code{U+002D}).
+@strong{Note}: Due to assumptions made by some Lepton and gEDA tools,
+it is @emph{strongly recommended} that you use attribute @var{name}s
+which contain only lower-case Latin characters, decimal digits, full
+stops @samp{.}  (@code{U+002E}), and hyphens @samp{-} (@code{U+002D}).
 
 There are two types of attribute:
 
@@ -314,7 +314,7 @@ to find the component's data sheet.
 @node Coordinate system
 @section Coordinate system
 
-gEDA documents use a @dfn{coordinate system} (internally referred to
+Lepton documents use a @dfn{coordinate system} (internally referred to
 as `world' coordinates) with coordinates increasing upwards and to the
 right (i.e. a conventional right-handed Cartesian coordinate
 system).
@@ -346,7 +346,7 @@ the smaller and larger y coordinates.
 
 The Scheme modules and functions described in this chapter are
 primitive operations for working with schematics and symbols, and are
-available to be used in all gEDA applications.
+available to be used in all Lepton applications.
 
 @menu
 * Core page functions::
@@ -679,7 +679,7 @@ returned.
 @node Object color
 @subsubsection Object color
 
-Object colors in gEDA documents are specified as indices into a color
+Object colors in Lepton documents are specified as indices into a color
 map.  This allows users to specify the color map that suits them when
 viewing schematics and symbols.
 
@@ -1068,7 +1068,7 @@ Returns the end angle of @var{arc} as an integer number of degrees.
 Paths are arbitrary shapes comprised of straight lines and Bézier
 curves.  Each path contains a sequence of @emph{path elements}, each
 of which requires zero or more absolute position parameters.  The
-element types supported by gEDA are:
+element types supported by Lepton are:
 
 @itemize
 @item
@@ -1661,7 +1661,7 @@ To use the functions described in this section, you will need to load
 the @code{(lepton config)} module.
 
 This section describes some functions for accessing, monitoring and
-modifying the configuration of gEDA libraries and applications.
+modifying the configuration of Lepton libraries and applications.
 
 @menu
 * Configuration contexts::
@@ -1871,7 +1871,7 @@ Since 1.10.
 @cindex Configuration group
 @cindex Configuration value
 
-A gEDA @dfn{configuration parameter} consists of three components:
+A Lepton @dfn{configuration parameter} consists of three components:
 
 @table @dfn
 @item Group
@@ -2131,7 +2131,7 @@ the @code{(lepton os)} module.
 
 This section describes some functions and variables that are useful
 for Scheme code that needs to behave differently depending on which
-operating system gEDA is running on.
+operating system Lepton is running on.
 
 @defvar separator-char
 The directory separator character that should be used on the host
@@ -2185,20 +2185,20 @@ otherwise.
 
 @defun sys-data-dirs
 Returns an ordered list of directories in which to access system-wide
-gEDA data.
+Lepton data.
 @end defun
 
 @defun sys-config-dirs
 Returns an ordered list of directories in which to access system-wide
-gEDA configuration information.
+Lepton configuration information.
 @end defun
 
 @defun user-data-dir
-Returns the directory in which to store user-specific gEDA data.
+Returns the directory in which to store user-specific Lepton data.
 @end defun
 
 @defun user-config-dir
-Returns the directory in which to store user-specific gEDA
+Returns the directory in which to store user-specific Lepton
 configuration information.
 @end defun
 


### PR DESCRIPTION
- Use new configuration names (`lepton*.conf`) in the manual.
- Replace gEDA with Lepton (EDA) where appropriate.
- Add section 'About Lepton EDA', reduce 'About gEDA'.
- Amend info on getting additional information.
