### PR TITLE
Get rid of some fields of the TOPLEVEL structure

### DIFF
--- a/liblepton/include/i_vars_priv.h
+++ b/liblepton/include/i_vars_priv.h
@@ -3,3 +3,4 @@ extern int default_promote_invisible;
 extern int default_keep_invisible;
 
 extern int default_make_backup_files;
+extern int default_net_consolidate;

--- a/liblepton/include/liblepton/geda_object.h
+++ b/liblepton/include/liblepton/geda_object.h
@@ -31,7 +31,6 @@ struct st_object
   PAGE *page; /* Parent page */
 
   GedaBounds bounds;
-  TOPLEVEL *w_bounds_valid_for;
 
   COMPONENT *component;
   GedaLine *line;

--- a/liblepton/include/liblepton/geda_toplevel.h
+++ b/liblepton/include/liblepton/geda_toplevel.h
@@ -54,9 +54,6 @@ struct st_toplevel
   /* controls if the net consolidation code is used */
   int net_consolidate;
 
-  /* controls the generation of backup (~) files */
-  int make_backup_files;
-
   /* controls if the whole bounding box is used in the auto whichend code */
   int force_boundingbox;
 

--- a/liblepton/include/liblepton/geda_toplevel.h
+++ b/liblepton/include/liblepton/geda_toplevel.h
@@ -54,9 +54,6 @@ struct st_toplevel
   /* controls if the net consolidation code is used */
   int net_consolidate;
 
-  /* controls if invisible attribs are promoted */
-  int promote_invisible;
-
   /* controls the generation of backup (~) files */
   int make_backup_files;
 

--- a/liblepton/include/liblepton/geda_toplevel.h
+++ b/liblepton/include/liblepton/geda_toplevel.h
@@ -51,9 +51,6 @@ struct st_toplevel
   int auto_save_interval;
   gint auto_save_timeout;
 
-  /* controls if the net consolidation code is used */
-  int net_consolidate;
-
   /* controls if the whole bounding box is used in the auto whichend code */
   int force_boundingbox;
 

--- a/liblepton/include/liblepton/geda_toplevel.h
+++ b/liblepton/include/liblepton/geda_toplevel.h
@@ -54,9 +54,6 @@ struct st_toplevel
   /* controls if the net consolidation code is used */
   int net_consolidate;
 
-  /*controls if attribute promotion happens */
-  int attribute_promotion;
-
   /* controls if invisible attribs are promoted */
   int promote_invisible;
 

--- a/liblepton/include/liblepton/geda_toplevel.h
+++ b/liblepton/include/liblepton/geda_toplevel.h
@@ -57,9 +57,6 @@ struct st_toplevel
   /* controls if the whole bounding box is used in the auto whichend code */
   int force_boundingbox;
 
-  /* List of attributes to always promote */
-  GPtrArray *always_promote_attributes;
-
   /* Callback function for calculating text bounds */
   RenderedBoundsFunc rendered_text_bounds_func;
   void *rendered_text_bounds_data;

--- a/liblepton/include/liblepton/geda_toplevel.h
+++ b/liblepton/include/liblepton/geda_toplevel.h
@@ -57,9 +57,6 @@ struct st_toplevel
   /* controls if invisible attribs are promoted */
   int promote_invisible;
 
-  /* controls if invisible attribs are kept and not deleted */
-  int keep_invisible;
-
   /* controls the generation of backup (~) files */
   int make_backup_files;
 

--- a/liblepton/include/liblepton/prototype.h
+++ b/liblepton/include/liblepton/prototype.h
@@ -160,4 +160,55 @@ const gchar *s_textbuffer_next (TextBuffer *tb, const gssize count);
 const gchar *s_textbuffer_next_line (TextBuffer *tb);
 gsize s_textbuffer_linenum (TextBuffer* tb);
 
+/* i_vars.c */
+
+
+/* \struct OptionStringInt
+ * \brief  A mapping of a string option's value to an int value.
+ */
+struct OptionStringInt
+{
+  const gchar* str_; /* a string value of an option */
+  gint         int_; /* an int value of an option */
+};
+
+gboolean
+cfg_read_bool (const gchar* group,
+               const gchar* key,
+               gboolean defval,
+               gboolean* result);
+
+gboolean
+cfg_read_int (const gchar* group,
+              const gchar* key,
+              gint defval,
+              gint* result);
+
+gboolean
+cfg_check_int_not_0 (gint val);
+
+gboolean
+cfg_check_int_greater_0 (gint val);
+
+gboolean
+cfg_check_int_greater_eq_0 (gint val);
+
+gboolean
+cfg_check_int_text_size (gint val);
+
+gboolean
+cfg_read_int_with_check (const gchar* group,
+                         const gchar* key,
+                         gint         defval,
+                         gint*        result,
+                         gboolean     (*pfn_check)(int));
+
+gboolean
+cfg_read_string2int (const gchar* group,
+                     const gchar* key,
+                     gint         defval,
+                     const struct OptionStringInt* vals,
+                     size_t       nvals,
+                     gint*        result);
+
 G_END_DECLS

--- a/liblepton/include/prototype_priv.h
+++ b/liblepton/include/prototype_priv.h
@@ -23,7 +23,6 @@ GList *o_read_attribs(TOPLEVEL *toplevel,
 OBJECT *o_attrib_find_attrib_by_name (const GList *list, const char *name, int count);
 
 /* geda_object.c */
-void o_bounds_invalidate(TOPLEVEL *toplevel, OBJECT *object);
 void o_emit_pre_change_notify(TOPLEVEL *toplevel, OBJECT *object);
 void o_emit_change_notify(TOPLEVEL *toplevel, OBJECT *object);
 

--- a/liblepton/scheme/unit-tests/t0402-config.scm
+++ b/liblepton/scheme/unit-tests/t0402-config.scm
@@ -397,7 +397,7 @@
 ) ; let
 ) ; 'config-remove-group()
 
-;;; The same tests for the deprecated (geda object) module
+;;; The same tests for the deprecated (geda config) module
 ;;; functions.
 
 (define *testdir-geda*      (string-append (getcwd)   file-name-separator-string "t0402-tmp-geda"))

--- a/liblepton/src/a_basic.c
+++ b/liblepton/src/a_basic.c
@@ -287,8 +287,6 @@ GList *o_read_buffer (TOPLEVEL *toplevel, GList *object_list,
             tmp->parent = new_obj;
           }
 
-          new_obj->w_bounds_valid_for = NULL;
-
           embedded_level--;
         } else {
           g_set_error (err, EDA_ERROR, EDA_ERROR_PARSE, _("Read unexpected embedded "

--- a/liblepton/src/f_basic.c
+++ b/liblepton/src/f_basic.c
@@ -51,41 +51,6 @@
 
 #include "libgeda_priv.h"
 
-/* \brief Read a boolean configuration key.
- *
- * \par Function Description
- * On success, set \a result to the value of the
- * configuration key, otherwise set it to \a defval.
- *
- * \todo  Refactoring: this function was copied as is from schematic/src/i_vars.c.
- *
- * \param [in]       group   Configuration group name
- * \param [in]       key     Configuration key name
- * \param [in]       defval  Default value
- * \param [in, out]  result  Result
- *
- * \return  TRUE if a specified config parameter was successfully read
- */
-static gboolean
-cfg_read_bool (const gchar* group,
-               const gchar* key,
-               gboolean     defval,
-               gboolean*    result)
-{
-  gchar*     cwd = g_get_current_dir();
-  EdaConfig* cfg = eda_config_get_context_for_path (cwd);
-  g_free (cwd);
-
-  GError*  err = NULL;
-  gboolean val = eda_config_get_boolean (cfg, group, key, &err);
-
-  gboolean success = err == NULL;
-  g_clear_error (&err);
-
-  *result = success ? val : defval;
-  return success;
-}
-
 
 /*! \brief Get the autosave filename for a file
  *  \par Function description

--- a/liblepton/src/geda_arc_object.c
+++ b/liblepton/src/geda_arc_object.c
@@ -95,10 +95,6 @@ geda_arc_object_new (TOPLEVEL *toplevel,
   o_set_fill_options(toplevel, new_node,
                      FILLING_HOLLOW, -1, -1, -1, -1, -1);
 
-  new_node->w_bounds_valid_for = NULL;
-
-  /* new_node->graphical = arc; eventually */
-
   return new_node;
 }
 
@@ -353,7 +349,6 @@ geda_arc_object_modify (TOPLEVEL *toplevel, OBJECT *object, int x, int y, int wh
 	}
 
 	/* update the screen coords and the bounding box */
-	object->w_bounds_valid_for = NULL;
 	o_emit_change_notify (toplevel, object);
 }
 
@@ -515,10 +510,6 @@ geda_arc_object_translate (GedaObject *object, int dx, int dy)
   /* Do world coords */
   object->arc->x = object->arc->x + dx;
   object->arc->y = object->arc->y + dy;
-
-
-  /* Recalculate screen coords from new world coords */
-  object->w_bounds_valid_for = NULL;
 }
 
 /*! \brief
@@ -572,10 +563,6 @@ void geda_arc_object_rotate (TOPLEVEL *toplevel,
   /* translate object to its previous place */
   object->arc->x += world_centerx;
   object->arc->y += world_centery;
-
-  /* update the screen coords and the bounding box */
-  object->w_bounds_valid_for = NULL;
-
 }
 
 /*! \brief Mirror the WORLD coordinates of an ARC.
@@ -616,10 +603,6 @@ void geda_arc_object_mirror (TOPLEVEL *toplevel,
 
   /* translate object back to its previous position */
   object->arc->x += world_centerx;
-
-  /* update the screen coords and bounding box */
-  object->w_bounds_valid_for = NULL;
-
 }
 
 

--- a/liblepton/src/geda_arc_object.c
+++ b/liblepton/src/geda_arc_object.c
@@ -1,7 +1,7 @@
-/* gEDA - GPL Electronic Design Automation
- * libgeda - gEDA's library
+/* Lepton EDA library
  * Copyright (C) 1998-2010 Ales Hvezda
- * Copyright (C) 1998-2010 gEDA Contributors (see ChangeLog for details)
+ * Copyright (C) 1998-2016 gEDA Contributors
+ * Copyright (C) 2017-2020 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/liblepton/src/geda_box_object.c
+++ b/liblepton/src/geda_box_object.c
@@ -1,7 +1,7 @@
-/* gEDA - GPL Electronic Design Automation
- * libgeda - gEDA's library
+/* Lepton EDA library
  * Copyright (C) 1998-2010 Ales Hvezda
- * Copyright (C) 1998-2010 gEDA Contributors (see ChangeLog for details)
+ * Copyright (C) 1998-2016 gEDA Contributors
+ * Copyright (C) 2017-2020 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/liblepton/src/geda_box_object.c
+++ b/liblepton/src/geda_box_object.c
@@ -85,9 +85,6 @@ geda_box_object_new (TOPLEVEL *toplevel, char type, int color,
   o_set_fill_options(toplevel, new_node,
 		     FILLING_HOLLOW, -1, -1, -1, -1, -1);
 
-  /* compute the bounding box */
-  new_node->w_bounds_valid_for = NULL;
-
   return new_node;
 }
 
@@ -127,10 +124,6 @@ geda_box_object_copy(TOPLEVEL *toplevel, OBJECT *o_current)
 		     o_current->fill_pitch1, o_current->fill_angle1,
 		     o_current->fill_pitch2, o_current->fill_angle2);
 
-  new_obj->w_bounds_valid_for = NULL;
-
-  /* new_obj->attribute = 0;*/
-
   return new_obj;
 }
 
@@ -159,8 +152,6 @@ geda_box_object_modify_all (TOPLEVEL *toplevel, OBJECT *object,
   object->box->upper_x = (x1 > x2) ? x2 : x1;
   object->box->upper_y = (y1 > y2) ? y1 : y2;
 
-  /* recalculate the world coords and bounds */
-  object->w_bounds_valid_for = NULL;
   o_emit_change_notify (toplevel, object);
 }
 
@@ -234,8 +225,6 @@ geda_box_object_modify (TOPLEVEL *toplevel, OBJECT *object, int x, int y, int wh
 		object->box->lower_y = tmp;
 	}
 
-	/* recalculate the world coords and the boundings */
-	object->w_bounds_valid_for = NULL;
 	o_emit_change_notify (toplevel, object);
 
 }
@@ -456,9 +445,6 @@ geda_box_object_translate (GedaObject *object, int dx, int dy)
   object->box->upper_y = object->box->upper_y + dy;
   object->box->lower_x = object->box->lower_x + dx;
   object->box->lower_y = object->box->lower_y + dy;
-
-  /* recalc the screen coords and the bounding box */
-  object->w_bounds_valid_for = NULL;
 }
 
 /*! \brief Rotate BOX OBJECT using WORLD coordinates.
@@ -526,9 +512,6 @@ void geda_box_object_rotate (TOPLEVEL *toplevel,
   object->box->upper_y += world_centery;
   object->box->lower_x += world_centerx;
   object->box->lower_y += world_centery;
-
-  /* recalc boundings and world coords */
-  object->w_bounds_valid_for = NULL;
 }
 
 /*! \brief Mirror BOX using WORLD coordinates.
@@ -578,10 +561,6 @@ void geda_box_object_mirror (TOPLEVEL *toplevel,
   object->box->upper_y += world_centery;
   object->box->lower_x += world_centerx;
   object->box->lower_y += world_centery;
-
-  /* recalc boundings and world coords */
-  object->w_bounds_valid_for = NULL;
-
 }
 
 /*! \brief Get BOX bounding rectangle in WORLD coordinates.

--- a/liblepton/src/geda_bus_object.c
+++ b/liblepton/src/geda_bus_object.c
@@ -309,8 +309,6 @@ geda_bus_object_new (TOPLEVEL *toplevel,
 
   new_node->bus_ripper_direction = bus_ripper_direction;
 
-  new_node->w_bounds_valid_for = NULL;
-
   return new_node;
 }
 
@@ -422,9 +420,6 @@ geda_bus_object_translate (GedaObject *object, gint dx, gint dy)
   object->line->y[0] = object->line->y[0] + dy;
   object->line->x[1] = object->line->x[1] + dx;
   object->line->y[1] = object->line->y[1] + dy;
-
-  /* Update bounding box */
-  object->w_bounds_valid_for = NULL;
 }
 
 /*! \brief create a copy of a bus object
@@ -595,6 +590,4 @@ geda_bus_object_modify (TOPLEVEL *toplevel,
 
   object->line->x[whichone] = x;
   object->line->y[whichone] = y;
-
-  object->w_bounds_valid_for = NULL;
 }

--- a/liblepton/src/geda_bus_object.c
+++ b/liblepton/src/geda_bus_object.c
@@ -1,7 +1,7 @@
-/* gEDA - GPL Electronic Design Automation
- * libgeda - gEDA's library
+/* Lepton EDA library
  * Copyright (C) 1998-2010 Ales Hvezda
- * Copyright (C) 1998-2010 gEDA Contributors (see ChangeLog for details)
+ * Copyright (C) 1998-2016 gEDA Contributors
+ * Copyright (C) 2017-2020 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/liblepton/src/geda_circle_object.c
+++ b/liblepton/src/geda_circle_object.c
@@ -94,9 +94,6 @@ geda_circle_object_new (TOPLEVEL *toplevel,
                       -1,
                       -1);
 
-  /* compute the bounding box coords */
-  new_node->w_bounds_valid_for = NULL;
-
   return new_node;
 }
 
@@ -140,10 +137,6 @@ geda_circle_object_copy (TOPLEVEL *toplevel, const GedaObject *object)
                       object->fill_angle1,
                       object->fill_pitch2,
                       object->fill_angle2);
-
-  new_obj->w_bounds_valid_for = NULL;
-
-  /*	new_obj->attribute = 0;*/
 
   return new_obj;
 }
@@ -292,8 +285,6 @@ geda_circle_object_modify (TOPLEVEL *toplevel,
       break;
   }
 
-  /* recalculate the boundings */
-  object->w_bounds_valid_for = NULL;
   o_emit_change_notify (toplevel, object);
 }
 
@@ -476,10 +467,6 @@ geda_circle_object_translate (GedaObject *object, gint dx, gint dy)
   /* Do world coords */
   object->circle->center_x = object->circle->center_x + dx;
   object->circle->center_y = object->circle->center_y + dy;
-
-  /* recalc the screen coords and the bounding box */
-  object->w_bounds_valid_for = NULL;
-
 }
 
 /*! \brief Rotate Circle OBJECT using WORLD coordinates.
@@ -536,8 +523,6 @@ geda_circle_object_rotate (TOPLEVEL *toplevel,
   /* translate back in position */
   object->circle->center_x += world_centerx;
   object->circle->center_y += world_centery;
-
-  object->w_bounds_valid_for = NULL;
 }
 
 /*! \brief Mirror circle using WORLD coordinates.
@@ -571,9 +556,6 @@ geda_circle_object_mirror (TOPLEVEL *toplevel,
 
   /* translate back in position */
   object->circle->center_x += world_centerx;
-
-  /* recalc boundings and screen coords */
-  object->w_bounds_valid_for = NULL;
 }
 
 /*! \brief Get circle bounding rectangle in WORLD coordinates.

--- a/liblepton/src/geda_circle_object.c
+++ b/liblepton/src/geda_circle_object.c
@@ -1,7 +1,7 @@
-/* gEDA - GPL Electronic Design Automation
- * libgeda - gEDA's library
+/* Lepton EDA library
  * Copyright (C) 1998-2010 Ales Hvezda
- * Copyright (C) 1998-2010 gEDA Contributors (see ChangeLog for details)
+ * Copyright (C) 1998-2016 gEDA Contributors
+ * Copyright (C) 2017-2020 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/liblepton/src/geda_component_object.c
+++ b/liblepton/src/geda_component_object.c
@@ -310,13 +310,17 @@ GList *o_component_promote_attribs (TOPLEVEL *toplevel, OBJECT *object)
   GList *promoted = NULL;
   GList *promotable = NULL;
   GList *iter = NULL;
+  gboolean keep_invisible;
+
+  cfg_read_bool ("schematic.attrib", "keep-invisible",
+                 default_keep_invisible, &keep_invisible);
 
   promotable = o_component_get_promotable (toplevel, object, FALSE);
 
   /* Run through the attributes deciding if we want to keep them (in
    * which case we copy them and make them invisible) or if we want to
    * remove them. */
-  if (toplevel->keep_invisible) {
+  if (keep_invisible) {
     for (iter = promotable; iter != NULL; iter = g_list_next (iter)) {
       OBJECT *o_kept = (OBJECT *) iter->data;
       OBJECT *o_copy = o_object_copy (toplevel, o_kept);
@@ -351,9 +355,10 @@ GList *o_component_promote_attribs (TOPLEVEL *toplevel, OBJECT *object)
  *  disk. The schematic will already contain local copies of symbol's
  *  promotable objects, so we delete or hide the symbol's copies.
  *
- *  Deletion / hiding is dependant on the setting of
- *  toplevel->keep_invisible. If true, attributes eligible for
- *  promotion are kept in memory but flagged as invisible.
+ *  Deletion / hiding is dependant on the setting of the
+ *  "schematic.attrib::keep-invisible" config setting.  If it is
+ *  true, attributes eligible for promotion are kept in memory but
+ *  flagged as invisible.
  *
  *  \param [in]  toplevel The toplevel environment.
  *  \param [in]  object   The component object being altered.
@@ -361,15 +366,19 @@ GList *o_component_promote_attribs (TOPLEVEL *toplevel, OBJECT *object)
 static void o_component_remove_promotable_attribs (TOPLEVEL *toplevel, OBJECT *object)
 {
   GList *promotable, *iter;
+  gboolean keep_invisible;
 
   promotable = o_component_get_promotable (toplevel, object, FALSE);
 
   if (promotable == NULL)
     return;
 
+  cfg_read_bool ("schematic.attrib", "keep-invisible",
+                 default_keep_invisible, &keep_invisible);
+
   for (iter = promotable; iter != NULL; iter = g_list_next (iter)) {
     OBJECT *a_object = (OBJECT*) iter->data;
-    if (toplevel->keep_invisible == TRUE) {   /* Hide promotable attributes */
+    if (keep_invisible == TRUE) {   /* Hide promotable attributes */
       o_set_visibility (toplevel, a_object, INVISIBLE);
     } else {                                /* Delete promotable attributes */
       object->component->prim_objs =

--- a/liblepton/src/geda_component_object.c
+++ b/liblepton/src/geda_component_object.c
@@ -292,9 +292,6 @@ GList *o_component_promote_attribs (TOPLEVEL *toplevel, OBJECT *object)
         g_list_remove (object->component->prim_objs, o_removed);
     }
     promoted = promotable;
-    /* Invalidate the object's bounds since we may have
-     * stolen objects from inside it. */
-    o_bounds_invalidate (toplevel, object);
   }
 
   /* Attach promoted attributes to the original component
@@ -340,7 +337,6 @@ static void o_component_remove_promotable_attribs (TOPLEVEL *toplevel, OBJECT *o
     }
   }
 
-  o_bounds_invalidate (toplevel, object);
   g_list_free (promotable);
 }
 
@@ -508,8 +504,6 @@ OBJECT *o_component_new (TOPLEVEL *toplevel,
     OBJECT *tmp = (OBJECT*) iter->data;
     tmp->parent = new_node;
   }
-
-  new_node->w_bounds_valid_for = NULL;
 
   return new_node;
 }
@@ -707,8 +701,6 @@ geda_component_object_translate (GedaObject *object, int dx, int dy)
   object->component->y = object->component->y + dy;
 
   geda_object_list_translate (object->component->prim_objs, dx, dy);
-
-  object->w_bounds_valid_for = NULL;
 }
 
 /*! \brief Create a copy of a component object
@@ -749,9 +741,6 @@ OBJECT *o_component_copy(TOPLEVEL *toplevel, OBJECT *o_current)
        iter = g_list_next (iter)) {
     ((OBJECT*) iter->data)->parent = o_new;
   }
-
-  /* Recalculate bounds */
-  o_new->w_bounds_valid_for = NULL;
 
   /* Delete or hide attributes eligible for promotion inside the
      component. */

--- a/liblepton/src/geda_component_object.c
+++ b/liblepton/src/geda_component_object.c
@@ -190,8 +190,12 @@ geda_component_object_get_position (const GedaObject *object, gint *x, gint *y)
 static int
 o_component_is_eligible_attribute (TOPLEVEL *toplevel, OBJECT *object)
 {
+  gboolean promote_invisible;
   g_return_val_if_fail (toplevel, FALSE);
   g_return_val_if_fail (object, FALSE);
+
+  cfg_read_bool ("schematic.attrib", "promote-invisible",
+                 default_promote_invisible, &promote_invisible);
 
   const gchar *name = o_attrib_get_name (object);
   if (!name) return FALSE;
@@ -212,7 +216,7 @@ o_component_is_eligible_attribute (TOPLEVEL *toplevel, OBJECT *object)
 
   /* object is invisible and we do not want to promote invisible text */
   if ((!o_is_visible (toplevel, object)) &&
-      (toplevel->promote_invisible == FALSE))
+      (promote_invisible == FALSE))
     return FALSE; /* attribute not eligible for promotion */
 
   /* yup, attribute can be promoted */

--- a/liblepton/src/geda_component_object.c
+++ b/liblepton/src/geda_component_object.c
@@ -38,42 +38,6 @@
 #include "libgeda_priv.h"
 
 
-/* \brief Read a boolean configuration key.
- *
- * \par Function Description
- * On success, set \a result to the value of the
- * configuration key, otherwise set it to \a defval.
- *
- * \todo  Refactoring: this function was copied as is from schematic/src/i_vars.c.
- *
- * \param [in]       group   Configuration group name
- * \param [in]       key     Configuration key name
- * \param [in]       defval  Default value
- * \param [in, out]  result  Result
- *
- * \return  TRUE if a specified config parameter was successfully read
- */
-static gboolean
-cfg_read_bool (const gchar* group,
-               const gchar* key,
-               gboolean     defval,
-               gboolean*    result)
-{
-  gchar*     cwd = g_get_current_dir();
-  EdaConfig* cfg = eda_config_get_context_for_path (cwd);
-  g_free (cwd);
-
-  GError*  err = NULL;
-  gboolean val = eda_config_get_boolean (cfg, group, key, &err);
-
-  gboolean success = err == NULL;
-  g_clear_error (&err);
-
-  *result = success ? val : defval;
-  return success;
-}
-
-
 /*! \brief Return the array of attributes to always promote. */
 static GPtrArray*
 always_promote_attributes ()

--- a/liblepton/src/geda_line_object.c
+++ b/liblepton/src/geda_line_object.c
@@ -1,7 +1,7 @@
-/* gEDA - GPL Electronic Design Automation
- * libgeda - gEDA's library
+/* Lepton EDA library
  * Copyright (C) 1998-2010 Ales Hvezda
- * Copyright (C) 1998-2010 gEDA Contributors (see ChangeLog for details)
+ * Copyright (C) 1998-2016 gEDA Contributors
+ * Copyright (C) 2017-2020 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/liblepton/src/geda_line_object.c
+++ b/liblepton/src/geda_line_object.c
@@ -97,9 +97,6 @@ geda_line_object_new (TOPLEVEL *toplevel,
                       -1,
                       -1);
 
-  /* compute bounding box */
-  new_node->w_bounds_valid_for = NULL;
-
   return new_node;
 }
 
@@ -141,8 +138,6 @@ geda_line_object_copy (TOPLEVEL *toplevel, OBJECT *o_current)
                      o_current->fill_angle1,
                      o_current->fill_pitch2,
                      o_current->fill_angle2);
-
-  o_current->w_bounds_valid_for = NULL;
 
   return new_obj;
 }
@@ -342,8 +337,6 @@ geda_line_object_modify (TOPLEVEL *toplevel, OBJECT *object,
       return;
   }
 
-  /* recalculate the bounding box */
-  object->w_bounds_valid_for = NULL;
   o_emit_change_notify (toplevel, object);
 }
 
@@ -513,9 +506,6 @@ geda_line_object_translate (GedaObject *object, int dx, int dy)
   object->line->y[0] = object->line->y[0] + dy;
   object->line->x[1] = object->line->x[1] + dx;
   object->line->y[1] = object->line->y[1] + dy;
-
-  /* Update bounding box */
-  object->w_bounds_valid_for = NULL;
 }
 
 /*! \brief Rotate Line OBJECT using WORLD coordinates.

--- a/liblepton/src/geda_net_object.c
+++ b/liblepton/src/geda_net_object.c
@@ -24,6 +24,42 @@
 
 #include "libgeda_priv.h"
 
+/* \brief Read a boolean configuration key.
+ *
+ * \par Function Description
+ * On success, set \a result to the value of the
+ * configuration key, otherwise set it to \a defval.
+ *
+ * \todo  Refactoring: this function was copied as is from schematic/src/i_vars.c.
+ *
+ * \param [in]       group   Configuration group name
+ * \param [in]       key     Configuration key name
+ * \param [in]       defval  Default value
+ * \param [in, out]  result  Result
+ *
+ * \return  TRUE if a specified config parameter was successfully read
+ */
+static gboolean
+cfg_read_bool (const gchar* group,
+               const gchar* key,
+               gboolean     defval,
+               gboolean*    result)
+{
+  gchar*     cwd = g_get_current_dir();
+  EdaConfig* cfg = eda_config_get_context_for_path (cwd);
+  g_free (cwd);
+
+  GError*  err = NULL;
+  gboolean val = eda_config_get_boolean (cfg, group, key, &err);
+
+  gboolean success = err == NULL;
+  g_clear_error (&err);
+
+  *result = success ? val : defval;
+  return success;
+}
+
+
 /*! \file o_net_basic.c
  *  \brief functions for the net object
  */
@@ -693,9 +729,16 @@ geda_net_object_consolidate (TOPLEVEL *toplevel, PAGE *page)
   OBJECT *o_current;
   const GList *iter;
   int status = 0;
+  gboolean net_consolidate;
 
   g_return_if_fail (toplevel != NULL);
   g_return_if_fail (page != NULL);
+
+  cfg_read_bool ("schematic", "net-consolidate",
+                 default_net_consolidate, &net_consolidate);
+
+  if (!net_consolidate)
+    return;
 
   iter = s_page_objects (page);
 

--- a/liblepton/src/geda_net_object.c
+++ b/liblepton/src/geda_net_object.c
@@ -24,41 +24,6 @@
 
 #include "libgeda_priv.h"
 
-/* \brief Read a boolean configuration key.
- *
- * \par Function Description
- * On success, set \a result to the value of the
- * configuration key, otherwise set it to \a defval.
- *
- * \todo  Refactoring: this function was copied as is from schematic/src/i_vars.c.
- *
- * \param [in]       group   Configuration group name
- * \param [in]       key     Configuration key name
- * \param [in]       defval  Default value
- * \param [in, out]  result  Result
- *
- * \return  TRUE if a specified config parameter was successfully read
- */
-static gboolean
-cfg_read_bool (const gchar* group,
-               const gchar* key,
-               gboolean     defval,
-               gboolean*    result)
-{
-  gchar*     cwd = g_get_current_dir();
-  EdaConfig* cfg = eda_config_get_context_for_path (cwd);
-  g_free (cwd);
-
-  GError*  err = NULL;
-  gboolean val = eda_config_get_boolean (cfg, group, key, &err);
-
-  gboolean success = err == NULL;
-  g_clear_error (&err);
-
-  *result = success ? val : defval;
-  return success;
-}
-
 
 /*! \file o_net_basic.c
  *  \brief functions for the net object

--- a/liblepton/src/geda_net_object.c
+++ b/liblepton/src/geda_net_object.c
@@ -266,8 +266,6 @@ geda_net_object_new (TOPLEVEL *toplevel, char type,
   new_node->line->y[1] = y2;
   new_node->line_width = NET_WIDTH;
 
-  new_node->w_bounds_valid_for = NULL;
-
   return new_node;
 }
 
@@ -359,9 +357,6 @@ geda_net_object_translate (GedaObject *object, int dx, int dy)
   object->line->y[0] = object->line->y[0] + dy;
   object->line->x[1] = object->line->x[1] + dx;
   object->line->y[1] = object->line->y[1] + dy;
-
-  /* Update bounding box */
-  object->w_bounds_valid_for = NULL;
 }
 
 /*! \brief create a copy of a net object
@@ -671,7 +666,6 @@ static int o_net_consolidate_segments (TOPLEVEL *toplevel, OBJECT *object)
           }
 
           s_delete_object (toplevel, other_object);
-          object->w_bounds_valid_for = NULL;
           s_conn_update_object (page, object);
           return(-1);
         }
@@ -740,6 +734,4 @@ geda_net_object_modify (TOPLEVEL *toplevel, OBJECT *object,
 {
   object->line->x[whichone] = x;
   object->line->y[whichone] = y;
-
-  object->w_bounds_valid_for = NULL;
 }

--- a/liblepton/src/geda_path_object.c
+++ b/liblepton/src/geda_path_object.c
@@ -1,7 +1,7 @@
-/* gEDA - GPL Electronic Design Automation
- * libgeda - gEDA's library
+/* Lepton EDA library
  * Copyright (C) 1998-2010 Ales Hvezda
- * Copyright (C) 1998-2010 gEDA Contributors (see ChangeLog for details)
+ * Copyright (C) 1998-2016 gEDA Contributors
+ * Copyright (C) 2017-2020 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/liblepton/src/geda_path_object.c
+++ b/liblepton/src/geda_path_object.c
@@ -112,9 +112,6 @@ geda_path_object_new_take_path (TOPLEVEL *toplevel,
   o_set_fill_options (toplevel, new_node,
                       FILLING_HOLLOW, -1, -1, -1, -1, -1);
 
-  /* compute bounding box */
-  new_node->w_bounds_valid_for = NULL;
-
   return new_node;
 }
 
@@ -148,9 +145,6 @@ geda_path_object_copy (TOPLEVEL *toplevel, OBJECT *o_current)
                       o_current->fill_type, o_current->fill_width,
                       o_current->fill_pitch1, o_current->fill_angle1,
                       o_current->fill_pitch2, o_current->fill_angle2);
-
-  /* calc the bounding box */
-  o_current->w_bounds_valid_for = NULL;
 
   /* return the new tail of the object list */
   return new_obj;
@@ -372,8 +366,6 @@ geda_path_object_modify (TOPLEVEL *toplevel, OBJECT *object,
     }
   }
 
-  /* Update bounding box */
-  object->w_bounds_valid_for = NULL;
   o_emit_change_notify (toplevel, object);
 }
 
@@ -417,9 +409,6 @@ geda_path_object_translate (GedaObject *object, int dx, int dy)
       break;
     }
   }
-
-  /* Update bounding box */
-  object->w_bounds_valid_for = NULL;
 }
 
 
@@ -472,7 +461,6 @@ void geda_path_object_rotate (TOPLEVEL *toplevel,
       break;
     }
   }
-  object->w_bounds_valid_for = NULL;
 }
 
 
@@ -515,8 +503,6 @@ void geda_path_object_mirror (TOPLEVEL *toplevel, int world_centerx,
       break;
     }
   }
-
-  object->w_bounds_valid_for = NULL;
 }
 
 

--- a/liblepton/src/geda_picture_object.c
+++ b/liblepton/src/geda_picture_object.c
@@ -624,9 +624,6 @@ OBJECT *o_picture_new (TOPLEVEL *toplevel,
     }
   }
 
-  /* compute the bounding picture */
-  new_node->w_bounds_valid_for = NULL;
-
   return new_node;
 }
 
@@ -799,8 +796,6 @@ void o_picture_modify(TOPLEVEL *toplevel, OBJECT *object,
     object->picture->lower_y = tmp;
   }
 
-  /* recalculate the screen coords and the boundings */
-  object->w_bounds_valid_for = NULL;
   o_emit_change_notify (toplevel, object);
 }
 
@@ -830,8 +825,6 @@ o_picture_modify_all (TOPLEVEL *toplevel, OBJECT *object,
   object->picture->upper_x = (x1 > x2) ? x2 : x1;
   object->picture->upper_y = (y1 > y2) ? y1 : y2;
 
-  /* recalculate the world coords and bounds */
-  object->w_bounds_valid_for = NULL;
   o_emit_change_notify (toplevel, object);
 }
 
@@ -899,10 +892,6 @@ void geda_picture_object_rotate (TOPLEVEL *toplevel,
   object->picture->upper_y += world_centery;
   object->picture->lower_x += world_centerx;
   object->picture->lower_y += world_centery;
-
-  /* recalc boundings and screen coords */
-  object->w_bounds_valid_for = NULL;
-
 }
 
 /*! \brief Mirror a picture using WORLD coordinates.
@@ -964,10 +953,6 @@ void geda_picture_object_mirror(TOPLEVEL *toplevel,
   object->picture->upper_y += world_centery;
   object->picture->lower_x += world_centerx;
   object->picture->lower_y += world_centery;
-
-  /* recalc boundings and screen coords */
-  object->w_bounds_valid_for = NULL;
-
 }
 
 /*! \brief Translate a picture position in WORLD coordinates by a delta.
@@ -991,9 +976,6 @@ geda_picture_object_translate (GedaObject *object, int dx, int dy)
   object->picture->upper_y = object->picture->upper_y + dy;
   object->picture->lower_x = object->picture->lower_x + dx;
   object->picture->lower_y = object->picture->lower_y + dy;
-
-  /* recalc the screen coords and the bounding picture */
-  object->w_bounds_valid_for = NULL;
 }
 
 /*! \brief Create a copy of a picture.
@@ -1041,9 +1023,6 @@ OBJECT *o_picture_copy(TOPLEVEL *toplevel, OBJECT *object)
 
   /* Get the picture data */
   picture->pixbuf = o_picture_get_pixbuf (toplevel, object);
-
-  /* compute the bounding picture */
-  new_node->w_bounds_valid_for = NULL;
 
   return new_node;
 }

--- a/liblepton/src/geda_pin_object.c
+++ b/liblepton/src/geda_pin_object.c
@@ -311,8 +311,6 @@ geda_pin_object_new (TOPLEVEL *toplevel,
 
   geda_pin_object_set_type (toplevel, new_node, pin_type);
 
-  new_node->w_bounds_valid_for = NULL;
-
   new_node->whichend = whichend;
 
   return new_node;
@@ -434,9 +432,6 @@ geda_pin_object_translate (GedaObject *object, int dx, int dy)
   object->line->y[0] = object->line->y[0] + dy;
   object->line->x[1] = object->line->x[1] + dx;
   object->line->y[1] = object->line->y[1] + dy;
-
-  /* Update bounding box */
-  object->w_bounds_valid_for = NULL;
 }
 
 /*! \brief create a copy of a pin object
@@ -562,8 +557,6 @@ geda_pin_object_modify(TOPLEVEL *toplevel, OBJECT *object, int x, int y, int whi
 
   object->line->x[whichone] = x;
   object->line->y[whichone] = y;
-
-  object->w_bounds_valid_for = NULL;
 }
 
 /*! \brief guess the whichend of pins of object list

--- a/liblepton/src/geda_pin_object.c
+++ b/liblepton/src/geda_pin_object.c
@@ -1,7 +1,7 @@
-/* gEDA - GPL Electronic Design Automation
- * libgeda - gEDA's library
+/* Lepton EDA library
  * Copyright (C) 1998-2010 Ales Hvezda
- * Copyright (C) 1998-2010 gEDA Contributors (see ChangeLog for details)
+ * Copyright (C) 1998-2016 gEDA Contributors
+ * Copyright (C) 2017-2020 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/liblepton/src/geda_text_object.c
+++ b/liblepton/src/geda_text_object.c
@@ -1,7 +1,7 @@
-/* gEDA - GPL Electronic Design Automation
- * libgeda - gEDA's library
+/* Lepton EDA library
  * Copyright (C) 1998-2010 Ales Hvezda
- * Copyright (C) 1998-2010 gEDA Contributors (see ChangeLog for details)
+ * Copyright (C) 1998-2016 gEDA Contributors
+ * Copyright (C) 2017-2020 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/liblepton/src/geda_text_object.c
+++ b/liblepton/src/geda_text_object.c
@@ -445,9 +445,6 @@ geda_text_object_new (TOPLEVEL *toplevel,
 
   update_disp_string (new_node);
 
-  /* Update bounding box */
-  new_node->w_bounds_valid_for = NULL;
-
   return new_node;
 }
 
@@ -658,7 +655,6 @@ o_text_recreate (TOPLEVEL *toplevel, OBJECT *o_current)
 {
   o_emit_pre_change_notify (toplevel, o_current);
   update_disp_string (o_current);
-  o_current->w_bounds_valid_for = NULL;
   o_emit_change_notify (toplevel, o_current);
 }
 
@@ -679,9 +675,6 @@ geda_text_object_translate (GedaObject *object, int dx, int dy)
 
   object->text->x = object->text->x + dx;
   object->text->y = object->text->y + dy;
-
-  /* Update bounding box */
-  object->w_bounds_valid_for = NULL;
 }
 
 /*! \brief create a copy of a text object

--- a/liblepton/src/geda_toplevel.c
+++ b/liblepton/src/geda_toplevel.c
@@ -70,7 +70,6 @@ TOPLEVEL *s_toplevel_new (void)
 
   /* The following is an attempt at getting (deterministic) defaults */
   /* for the following variables */
-  toplevel->attribute_promotion = FALSE;
   toplevel->promote_invisible   = FALSE;
   toplevel->keep_invisible      = FALSE;
 

--- a/liblepton/src/geda_toplevel.c
+++ b/liblepton/src/geda_toplevel.c
@@ -72,8 +72,6 @@ TOPLEVEL *s_toplevel_new (void)
   /* for the following variables */
   toplevel->force_boundingbox = FALSE;
 
-  toplevel->always_promote_attributes = NULL;
-
   toplevel->rendered_text_bounds_func = NULL;
   toplevel->rendered_text_bounds_data = NULL;
 

--- a/liblepton/src/geda_toplevel.c
+++ b/liblepton/src/geda_toplevel.c
@@ -70,8 +70,6 @@ TOPLEVEL *s_toplevel_new (void)
 
   /* The following is an attempt at getting (deterministic) defaults */
   /* for the following variables */
-  toplevel->promote_invisible   = FALSE;
-
   toplevel->make_backup_files = TRUE;
 
   toplevel->force_boundingbox = FALSE;

--- a/liblepton/src/geda_toplevel.c
+++ b/liblepton/src/geda_toplevel.c
@@ -71,7 +71,6 @@ TOPLEVEL *s_toplevel_new (void)
   /* The following is an attempt at getting (deterministic) defaults */
   /* for the following variables */
   toplevel->promote_invisible   = FALSE;
-  toplevel->keep_invisible      = FALSE;
 
   toplevel->make_backup_files = TRUE;
 

--- a/liblepton/src/geda_toplevel.c
+++ b/liblepton/src/geda_toplevel.c
@@ -66,8 +66,6 @@ TOPLEVEL *s_toplevel_new (void)
 
   toplevel->major_changed_refdes = NULL;
 
-  toplevel->net_consolidate = FALSE;
-
   /* The following is an attempt at getting (deterministic) defaults */
   /* for the following variables */
   toplevel->force_boundingbox = FALSE;

--- a/liblepton/src/geda_toplevel.c
+++ b/liblepton/src/geda_toplevel.c
@@ -70,8 +70,6 @@ TOPLEVEL *s_toplevel_new (void)
 
   /* The following is an attempt at getting (deterministic) defaults */
   /* for the following variables */
-  toplevel->make_backup_files = TRUE;
-
   toplevel->force_boundingbox = FALSE;
 
   toplevel->always_promote_attributes = NULL;

--- a/liblepton/src/i_vars.c
+++ b/liblepton/src/i_vars.c
@@ -80,9 +80,6 @@ cfg_read_bool (const gchar* group,
  */
 void i_vars_libgeda_set(TOPLEVEL *toplevel)
 {
-  cfg_read_bool ("schematic.attrib", "promote",
-                 default_attribute_promotion, &toplevel->attribute_promotion);
-
   cfg_read_bool ("schematic.attrib", "promote-invisible",
                  default_promote_invisible, &toplevel->promote_invisible);
 

--- a/liblepton/src/i_vars.c
+++ b/liblepton/src/i_vars.c
@@ -1,6 +1,4 @@
 /* Lepton EDA library
- * Copyright (C) 1998-2010 Ales Hvezda
- * Copyright (C) 1998-2017 gEDA Contributors
  * Copyright (C) 2017-2020 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
@@ -17,8 +15,6 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
-#include <config.h>
-#include <stdio.h>
 
 #include "libgeda_priv.h"
 
@@ -52,3 +48,184 @@ void i_vars_libgeda_set(TOPLEVEL *toplevel) {
 void i_vars_libgeda_freenames()
 {
 }
+
+/* \brief Read a boolean configuration key.
+ *
+ * \par Function Description
+ * On success, set \a result to the value of the
+ * configuration key, otherwise set it to \a defval.
+ *
+ * \param [in]       group   Configuration group name
+ * \param [in]       key     Configuration key name
+ * \param [in]       defval  Default value
+ * \param [in, out]  result  Result
+ *
+ * \return  TRUE if a specified config parameter was successfully read
+ */
+gboolean
+cfg_read_bool (const gchar* group,
+               const gchar* key,
+               gboolean     defval,
+               gboolean*    result)
+{
+  gchar*     cwd = g_get_current_dir();
+  EdaConfig* cfg = eda_config_get_context_for_path (cwd);
+  g_free (cwd);
+
+  GError*  err = NULL;
+  gboolean val = eda_config_get_boolean (cfg, group, key, &err);
+
+  gboolean success = err == NULL;
+  g_clear_error (&err);
+
+  *result = success ? val : defval;
+  return success;
+}
+
+
+/* \brief Read an int configuration key.
+ *
+ * \par Function Description
+ * On success, set \a result to the value of the
+ * configuration key, otherwise set it to \a defval.
+ *
+ * \param [in]       group   Configuration group name
+ * \param [in]       key     Configuration key name
+ * \param [in]       defval  Default value
+ * \param [in, out]  result  Result
+ *
+ * \return  TRUE if a specified config parameter was successfully read
+ */
+gboolean
+cfg_read_int (const gchar* group,
+              const gchar* key,
+              gint         defval,
+              gint*        result)
+{
+  gchar*     cwd = g_get_current_dir();
+  EdaConfig* cfg = eda_config_get_context_for_path (cwd);
+  g_free (cwd);
+
+  GError*  err = NULL;
+  gint val = eda_config_get_int (cfg, group, key, &err);
+
+  gboolean success = err == NULL;
+  g_clear_error (&err);
+
+  *result = success ? val : defval;
+  return success;
+}
+
+
+
+gboolean
+cfg_check_int_not_0 (gint val) { return val != 0; }
+
+gboolean
+cfg_check_int_greater_0 (gint val) { return val > 0; }
+
+gboolean
+cfg_check_int_greater_eq_0 (gint val) { return val >= 0; }
+
+gboolean
+cfg_check_int_text_size (gint val) { return val >= MINIMUM_TEXT_SIZE; }
+
+
+
+/* \brief Read an int configuration key, check read value.
+ *
+ * \par Function Description
+ * On success, set \a result to the value of the
+ * configuration key, otherwise set it to \a defval.
+ * Also, check read value with pfn_check() function, and
+ * if it returns FALSE, reset \a result to \a defval and
+ * print an error message to STDERR.
+ *
+ * \param [in]       group      Configuration group name
+ * \param [in]       key        Configuration key name
+ * \param [in]       defval     Default value
+ * \param [in, out]  result     Result
+ * \param [in]       pfn_check  Function to check if value is valid
+ *
+ * \return  TRUE if a specified config parameter was successfully read
+ */
+gboolean
+cfg_read_int_with_check (const gchar* group,
+                         const gchar* key,
+                         gint         defval,
+                         gint*        result,
+                         gboolean     (*pfn_check)(int))
+{
+  gint val = 0;
+  gboolean success = cfg_read_int (group, key, defval, &val);
+
+  if (pfn_check (val))
+  {
+    *result = val;
+  }
+  else
+  {
+    *result = defval;
+    const gchar* errmsg = _("Invalid [%s]::%s (%d) is set in configuration\n");
+    fprintf (stderr, errmsg, group, key, val);
+  }
+
+  return success;
+}
+
+
+/* \brief Read a string configuration key, set a corresponding int option.
+ *
+ * \par Function Description
+ * Read and compare a configuration value to the options passed
+ * as an array of OptionStringInt structures - the mapping of
+ * the string option values to the corresponding int values.
+ * On success, set the \a result to the int value of
+ * the option (if found), otherwise set it to \a defval.
+ *
+ * \param [in]       group      Configuration group name
+ * \param [in]       key        Configuration key name
+ * \param [in]       defval     Default value
+ * \param [in]       vals       An array of OptionStringInt structures
+ * \param [in]       nvals      A size of \a vals array
+ * \param [in, out]  result     Result
+ *
+ * \return  TRUE if a specified config parameter was successfully read
+ */
+gboolean
+cfg_read_string2int (const gchar* group,
+                     const gchar* key,
+                     gint         defval,
+                     const struct OptionStringInt* vals,
+                     size_t       nvals,
+                     gint*        result)
+{
+  gchar*     cwd = g_get_current_dir();
+  EdaConfig* cfg = eda_config_get_context_for_path (cwd);
+  g_free (cwd);
+
+  GError* err = NULL;
+  gchar*  str = eda_config_get_string (cfg, group, key, &err);
+
+  gboolean success = err == NULL;
+  g_clear_error (&err);
+
+  *result = defval;
+
+  if (success)
+  {
+    for (size_t i = 0; i < nvals; ++i)
+    {
+      if ( strcmp (vals[i].str_, str) == 0 )
+      {
+        *result = vals[i].int_;
+        break;
+      }
+    }
+
+    g_free (str);
+  }
+
+  return success;
+
+} /* cfg_read_string2int() */

--- a/liblepton/src/i_vars.c
+++ b/liblepton/src/i_vars.c
@@ -83,9 +83,6 @@ void i_vars_libgeda_set(TOPLEVEL *toplevel)
   cfg_read_bool ("schematic.attrib", "promote-invisible",
                  default_promote_invisible, &toplevel->promote_invisible);
 
-  cfg_read_bool ("schematic.attrib", "keep-invisible",
-                 default_keep_invisible, &toplevel->keep_invisible);
-
   cfg_read_bool ("schematic.backup", "create-files",
                  default_make_backup_files, &toplevel->make_backup_files);
 

--- a/liblepton/src/i_vars.c
+++ b/liblepton/src/i_vars.c
@@ -80,9 +80,6 @@ cfg_read_bool (const gchar* group,
  */
 void i_vars_libgeda_set(TOPLEVEL *toplevel)
 {
-  cfg_read_bool ("schematic.attrib", "promote-invisible",
-                 default_promote_invisible, &toplevel->promote_invisible);
-
   cfg_read_bool ("schematic.backup", "create-files",
                  default_make_backup_files, &toplevel->make_backup_files);
 

--- a/liblepton/src/i_vars.c
+++ b/liblepton/src/i_vars.c
@@ -34,6 +34,7 @@ int   default_promote_invisible = FALSE;
 int   default_keep_invisible = TRUE;
 
 int   default_make_backup_files = TRUE;
+int   default_net_consolidate = TRUE;
 
 
 

--- a/liblepton/src/i_vars.c
+++ b/liblepton/src/i_vars.c
@@ -37,43 +37,6 @@ int   default_make_backup_files = TRUE;
 
 
 
-/* \brief Read a boolean configuration key.
- *
- * \par Function Description
- * On success, set \a result to the value of the
- * configuration key, otherwise set it to \a defval.
- *
- * \todo  Refactoring: this function was copied as is from schematic/src/i_vars.c.
- *
- * \param [in]       group   Configuration group name
- * \param [in]       key     Configuration key name
- * \param [in]       defval  Default value
- * \param [in, out]  result  Result
- *
- * \return  TRUE if a specified config parameter was successfully read
- */
-static gboolean
-cfg_read_bool (const gchar* group,
-               const gchar* key,
-               gboolean     defval,
-               gboolean*    result)
-{
-  gchar*     cwd = g_get_current_dir();
-  EdaConfig* cfg = eda_config_get_context_for_path (cwd);
-  g_free (cwd);
-
-  GError*  err = NULL;
-  gboolean val = eda_config_get_boolean (cfg, group, key, &err);
-
-  gboolean success = err == NULL;
-  g_clear_error (&err);
-
-  *result = success ? val : defval;
-  return success;
-}
-
-
-
 /*! \brief Read configuration, initialize variables in TOPLEVEL object.
  *
  *  \param [in] toplevel  The TOPLEVEL object to be updated.

--- a/liblepton/src/i_vars.c
+++ b/liblepton/src/i_vars.c
@@ -41,51 +41,7 @@ int   default_make_backup_files = TRUE;
  *
  *  \param [in] toplevel  The TOPLEVEL object to be updated.
  */
-void i_vars_libgeda_set(TOPLEVEL *toplevel)
-{
-  if (toplevel->always_promote_attributes)
-  {
-    g_ptr_array_unref (toplevel->always_promote_attributes);
-    toplevel->always_promote_attributes = NULL;
-  }
-
-  toplevel->always_promote_attributes = g_ptr_array_new (); /* => refcnt == 1 */
-
-  gchar*     cwd = g_get_current_dir();
-  EdaConfig* cfg = eda_config_get_context_for_path (cwd);
-  g_free (cwd);
-
-  GError* err   = NULL;
-  gsize   size  = 0;
-  gchar** ppstr = eda_config_get_string_list (cfg,
-                                              "schematic.attrib",
-                                              "always-promote",
-                                              &size,
-                                              &err);
-  if (err == NULL && ppstr != NULL)
-  {
-    for (gsize i = 0; i < size; ++i)
-    {
-      gchar* attr = ppstr[i];
-
-      if (attr != NULL && strlen (attr) > 0)
-      {
-#ifdef DEBUG
-        printf( " >> always_promote_attributes += [%s]\n", attr );
-#endif
-        /* important: use g_intern_string() here, because attr strings are
-         * compared like pointers in o_component_is_eligible_attribute():
-         */
-        g_ptr_array_add (toplevel->always_promote_attributes,
-                         (gpointer) g_intern_string (attr));
-      }
-    }
-
-    g_strfreev (ppstr);
-  }
-
-  g_clear_error (&err);
-
+void i_vars_libgeda_set(TOPLEVEL *toplevel) {
 } /* i_vars_libgeda_set() */
 
 

--- a/liblepton/src/i_vars.c
+++ b/liblepton/src/i_vars.c
@@ -80,10 +80,6 @@ cfg_read_bool (const gchar* group,
  */
 void i_vars_libgeda_set(TOPLEVEL *toplevel)
 {
-  cfg_read_bool ("schematic.backup", "create-files",
-                 default_make_backup_files, &toplevel->make_backup_files);
-
-
   if (toplevel->always_promote_attributes)
   {
     g_ptr_array_unref (toplevel->always_promote_attributes);

--- a/liblepton/src/scheme_component.c
+++ b/liblepton/src/scheme_component.c
@@ -161,8 +161,6 @@ SCM_DEFINE (set_component_x, "%set-component!", 6, 0, 0,
   obj->component->mirror = scm_is_true (mirror_s);
   obj->selectable = scm_is_false (locked_s);
 
-  obj->w_bounds_valid_for = NULL; /* We need to do this explicitly... */
-
   o_emit_change_notify (toplevel, obj);
 
   o_page_changed (obj);
@@ -286,8 +284,6 @@ SCM_DEFINE (component_append_x, "%component-append!", 2, 0, 0,
   parent->component->prim_objs =
     g_list_append (parent->component->prim_objs, child);
   child->parent = parent;
-
-  parent->w_bounds_valid_for = NULL;
 
   PAGE* parent_page = o_get_page (parent);
   /* We may need to update connections */

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -298,23 +298,12 @@ SCM_DEFINE (object_bounds, "%object-bounds", 0, 0, 1,
     success = world_get_object_glist_bounds (toplevel, obj_list,
                                              &left, &top, &right, &bottom);
   } else {
-    GList *list;
     toplevel->show_hidden_text = TRUE;
-
-    for (list = obj_list; list != NULL; list = g_list_next(list)) {
-      OBJECT *o_current = (OBJECT *) list->data;
-      o_current->w_bounds_valid_for = NULL;
-    }
 
     success = world_get_object_glist_bounds (toplevel, obj_list,
                                              &left, &top, &right, &bottom);
 
     toplevel->show_hidden_text = FALSE;
-
-    for (list = obj_list; list != NULL; list = g_list_next(list)) {
-      OBJECT *o_current = (OBJECT *) list->data;
-      o_current->w_bounds_valid_for = NULL;
-    }
   }
 
   SCM result = SCM_BOOL_F;

--- a/schematic/include/i_vars.h
+++ b/schematic/include/i_vars.h
@@ -22,7 +22,6 @@ extern int default_third_button;
 extern int default_third_button_cancel;
 extern int default_middle_button;
 extern int default_scroll_wheel;
-extern int default_net_consolidate;
 extern int default_file_preview;
 extern int default_enforce_hierarchy;
 extern int default_fast_mousepan;

--- a/schematic/include/i_vars.h
+++ b/schematic/include/i_vars.h
@@ -53,3 +53,7 @@ extern int default_keyboardpan_gain;
 extern int default_select_slack_pixels;
 extern int default_zoom_gain;
 extern int default_scrollpan_steps;
+extern gboolean default_tabs_enabled;
+extern gboolean default_tabs_show_close_button;
+extern gboolean default_tabs_show_up_button;
+extern gboolean default_tabs_show_tooltips;

--- a/schematic/src/i_vars.c
+++ b/schematic/src/i_vars.c
@@ -41,7 +41,6 @@ int   default_third_button = MOUSEBTN_DO_POPUP;
 int   default_third_button_cancel = TRUE;
 int   default_middle_button = MOUSEBTN_DO_PAN;
 int   default_scroll_wheel = SCROLL_WHEEL_CLASSIC;
-int   default_net_consolidate = TRUE;
 int   default_file_preview = TRUE;
 int   default_enforce_hierarchy = TRUE;
 int   default_fast_mousepan = FALSE;
@@ -478,10 +477,6 @@ i_vars_set (GschemToplevel* w_current)
                        vals_sw,
                        sizeof( vals_sw ) / sizeof( vals_sw[0] ),
                        &w_current->scroll_wheel);
-
-
-  cfg_read_bool ("schematic", "net-consolidate",
-                 default_net_consolidate, &toplevel->net_consolidate);
 
   cfg_read_bool ("schematic.gui", "file-preview",
                  default_file_preview, &w_current->file_preview);

--- a/schematic/src/o_misc.c
+++ b/schematic/src/o_misc.c
@@ -331,7 +331,6 @@ void o_edit_show_hidden_lowlevel (GschemToplevel *w_current,
 
     if (o_current->type == OBJ_COMPONENT || o_current->type == OBJ_PLACEHOLDER) {
       o_edit_show_hidden_lowlevel(w_current, o_current->component->prim_objs);
-      o_current->w_bounds_valid_for = NULL;
     }
 
     iter = g_list_next (iter);

--- a/schematic/src/o_move.c
+++ b/schematic/src/o_move.c
@@ -206,7 +206,6 @@ void o_move_end(GschemToplevel *w_current)
 
         o_move_end_lowlevel_glist (w_current, object->component->prim_objs,
                                    diff_x, diff_y);
-        object->w_bounds_valid_for = NULL;
         break;
 
       default:
@@ -723,7 +722,6 @@ void o_move_end_rubberband (GschemToplevel *w_current,
         continue;
       }
 
-      object->w_bounds_valid_for = NULL;
       s_conn_update_object (page, object);
       *objects = g_list_append (*objects, object);
     }

--- a/schematic/src/o_net.c
+++ b/schematic/src/o_net.c
@@ -873,7 +873,6 @@ int o_net_add_busrippers(GschemToplevel *w_current, OBJECT *net_obj,
           }
 
           net_obj->line->y[found_conn->whichone] -= ripper_size;
-          net_obj->w_bounds_valid_for = NULL;
           rippers[ripper_count].x[0] =
             net_obj->line->x[found_conn->whichone];
           rippers[ripper_count].y[0] =
@@ -910,7 +909,6 @@ int o_net_add_busrippers(GschemToplevel *w_current, OBJECT *net_obj,
           }
 
           net_obj->line->y[found_conn->whichone] += ripper_size;
-          net_obj->w_bounds_valid_for = NULL;
           rippers[ripper_count].x[0] =
             net_obj->line->x[found_conn->whichone];
           rippers[ripper_count].y[0] =
@@ -981,7 +979,6 @@ int o_net_add_busrippers(GschemToplevel *w_current, OBJECT *net_obj,
           }
 
           net_obj->line->x[found_conn->whichone] -= ripper_size;
-          net_obj->w_bounds_valid_for = NULL;
           rippers[ripper_count].x[0] =
             net_obj->line->x[found_conn->whichone];
           rippers[ripper_count].y[0] =
@@ -1017,7 +1014,6 @@ int o_net_add_busrippers(GschemToplevel *w_current, OBJECT *net_obj,
           }
 
           net_obj->line->x[found_conn->whichone] += ripper_size;
-          net_obj->w_bounds_valid_for = NULL;
           rippers[ripper_count].x[0] =
             net_obj->line->x[found_conn->whichone];
           rippers[ripper_count].y[0] =

--- a/schematic/src/o_undo.c
+++ b/schematic/src/o_undo.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2015 gEDA Contributors
- * Copyright (C) 2017-2019 Lepton EDA Contributors
+ * Copyright (C) 2017-2020 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -160,8 +160,7 @@ o_undo_savestate (GschemToplevel *w_current, PAGE *page, int flag)
     /* This is where the net consolidation call would have been
      * triggered before it was removed from o_save_buffer().
      */
-    if (toplevel->net_consolidate == TRUE)
-      geda_net_object_consolidate (toplevel, page);
+    geda_net_object_consolidate (toplevel, page);
   }
 
   if (w_current->undo_type == UNDO_DISK && flag == UNDO_ALL) {

--- a/schematic/src/x_tabs.c
+++ b/schematic/src/x_tabs.c
@@ -80,17 +80,13 @@
 
 
 
-static gboolean
-g_x_tabs_enabled = TRUE;
+static gboolean g_x_tabs_enabled;
 
-static gboolean
-g_x_tabs_show_close_button = TRUE;
+static gboolean g_x_tabs_show_close_button;
 
-static gboolean
-g_x_tabs_show_up_button = TRUE;
+static gboolean g_x_tabs_show_up_button;
 
-static gboolean
-g_x_tabs_show_tooltips = TRUE;
+static gboolean g_x_tabs_show_tooltips;
 
 
 
@@ -128,26 +124,6 @@ x_tabs_show_tooltips()
 }
 
 
-
-static void
-cfg_read_bool (EdaConfig*   cfg,
-               const gchar* group,
-               const gchar* key,
-               gboolean*    result)
-{
-  GError*  err = NULL;
-  gboolean val = eda_config_get_boolean (cfg, group, key, &err);
-
-  if (err == NULL)
-  {
-    *result = val;
-  }
-
-  g_clear_error (&err);
-}
-
-
-
 /*! \brief Initialize tabbed GUI; read configuration
  *  \public
  *
@@ -157,25 +133,17 @@ cfg_read_bool (EdaConfig*   cfg,
 void
 x_tabs_init()
 {
-  gchar*     cwd = g_get_current_dir();
-  EdaConfig* cfg = eda_config_get_context_for_path (cwd);
-  g_free (cwd);
+  cfg_read_bool ("schematic.gui", "use-tabs",
+                 default_tabs_enabled, &g_x_tabs_enabled);
 
-  if (cfg != NULL)
-  {
-    cfg_read_bool (cfg, "schematic.gui", "use-tabs",
-                   &g_x_tabs_enabled);
+  cfg_read_bool ("schematic.tabs", "show-close-button",
+                 default_tabs_show_close_button, &g_x_tabs_show_close_button);
 
-    cfg_read_bool (cfg, "schematic.tabs", "show-close-button",
-                   &g_x_tabs_show_close_button);
+  cfg_read_bool ("schematic.tabs", "show-up-button",
+                 default_tabs_show_up_button, &g_x_tabs_show_up_button);
 
-    cfg_read_bool (cfg, "schematic.tabs", "show-up-button",
-                   &g_x_tabs_show_up_button);
-
-    cfg_read_bool (cfg, "schematic.tabs", "show-tooltips",
-                   &g_x_tabs_show_tooltips);
-  }
-
+  cfg_read_bool ("schematic.tabs", "show-tooltips",
+                 default_tabs_show_tooltips, &g_x_tabs_show_tooltips);
 } /* x_tabs_init() */
 
 


### PR DESCRIPTION
Reduce code dependency on `TOPLEVEL` by removing some of its fields. Instead, use new config settings to get same info.