### PR TITLE
Fix the lepton-archive log file name

### DIFF
--- a/utils/scripts/lepton-archive.in
+++ b/utils/scripts/lepton-archive.in
@@ -861,5 +861,5 @@ the file manually.\n"))
     ((@@ (guile-user) parse-rc) "lepton-archive" "gafrc" )
     ;; Init log domain and create log file right away even if
     ;; logging is enabled.
-    (init-log "lepton-archive")
+    (init-log "archive")
     (main)))


### PR DESCRIPTION
Do not use the "lepton-" prefix for log files generated by `lepton-archive`
for consistency with the other tools in the suite.
BTW, `lepton-archive`doesn't seem to write anything to the log...