### PR TITLE
Remove redundant rc-config() Scheme function

### DIFF
--- a/liblepton/include/liblepton/prototype.h
+++ b/liblepton/include/liblepton/prototype.h
@@ -32,7 +32,6 @@ gboolean g_rc_load_cache_config (TOPLEVEL* toplevel, GError** err);
 void g_rc_parse(TOPLEVEL *toplevel, const gchar* pname, const gchar* rcname, const gchar* rcfile);
 void g_rc_parse_handler (TOPLEVEL *toplevel, const gchar *rcname, const gchar *rcfile, ConfigParseErrorFunc handler, void *user_data);
 SCM g_rc_rc_filename();
-SCM g_rc_rc_config ();
 SCM g_rc_parse_rc (SCM pname_s, SCM rcname_s);
 
 /* i_vars.c */

--- a/liblepton/scheme/geda-deprecated-config.scm
+++ b/liblepton/scheme/geda-deprecated-config.scm
@@ -31,6 +31,7 @@
 ;; ===================================================================
 
 
+( use-modules ( lepton config ) )
 ( use-modules ( lepton legacy-config ) )
 
 
@@ -73,8 +74,15 @@
     (lambda args
       (or warned?
           (begin (deprecation-warning) (set! warned? #t)))
-      ((@ (lepton config) set-config!)
-       (rc-config) group key (apply value-transformer args)))))
+      (set-config!
+        (path-config-context (getcwd))
+        group
+        key
+        (apply value-transformer args)
+      )
+    )
+  ) ; let
+)
 
 ;; Convenience macro for using rc-deprecated-config.
 ;;

--- a/liblepton/src/g_rc.c
+++ b/liblepton/src/g_rc.c
@@ -675,25 +675,6 @@ g_rc_rc_filename()
   return scm_source_property (source, scm_sym_filename);
 }
 
-/*!
- * \brief Get a configuration context for the current RC file.
- * \par Function Description
- * Returns the configuration context applicable to the RC file being
- * evaluated.  This function is intended to support gEDA transition
- * from functions in RC files to static configuration files.
- *
- * \returns An EdaConfig smob.
- */
-SCM
-g_rc_rc_config()
-{
-  SCM cfg_s = scm_fluid_ref (scheme_rc_config_fluid);
-  if (!scm_is_false (cfg_s)) return cfg_s;
-
-  EdaConfig *cfg = eda_config_get_context_for_file (NULL);
-  return edascm_from_config (cfg);
-}
-
 /*! \brief Add a directory to the Guile load path.
  * \par Function Description
  * Prepends \a s_path to the Guile system '%load-path', after

--- a/liblepton/src/g_register.c
+++ b/liblepton/src/g_register.c
@@ -2,7 +2,7 @@
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2016 gEDA Contributors
  * Copyright (C) 2016 Peter Brett <peter@peter-b.co.uk>
- * Copyright (C) 2017-2019 Lepton EDA Contributors
+ * Copyright (C) 2017-2020 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -47,7 +47,6 @@ static struct gsubr_t libgeda_funcs[] = {
   { "eval-string-protected",     1, 0, 0, (SCM (*) ()) g_scm_eval_string_protected },
 
   { "rc-filename",               0, 0, 0, (SCM (*) ()) g_rc_rc_filename },
-  { "rc-config",                 0, 0, 0, (SCM (*) ()) g_rc_rc_config },
   { "parse-rc",                  2, 0, 0, (SCM (*) ()) g_rc_parse_rc },
   { NULL,                        0, 0, 0, NULL } };
 


### PR DESCRIPTION
The expression `(rc-config)` has the same effect as
`(path-config-context ".")`.
Remove `rc-config()` Scheme function and its implementation in C.
It was used in one place only (geda-deprecated-config.scm).
