### PR TITLE
Turn off legacy configuration mode

### DIFF
--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -72,9 +72,6 @@ undo-type=disk
 undo-levels=20
 undo-panzoom=false
 
-[schematic]
-default-filename=untitled
-
 [schematic.library]
 component-attributes=*
 sort=false
@@ -85,6 +82,7 @@ monochrome=false
 paper=iso_a4
 
 [schematic]
+default-filename=untitled
 bus-ripper-size=200
 bus-ripper-type=component
 bus-ripper-rotation=non-symmetric

--- a/liblepton/scheme/geda-deprecated-config.scm
+++ b/liblepton/scheme/geda-deprecated-config.scm
@@ -159,15 +159,15 @@
 (define-rc-dead-config setpagedevice-pagesize)
 
 (define-rc-deprecated-config
- print-paper "gschem.printing" "paper"
+ print-paper "schematic.printing" "paper"
  rc-deprecated-string-transformer)
 
 (define-rc-deprecated-config
- print-orientation "gschem.printing" "layout"
+ print-orientation "schematic.printing" "layout"
  rc-deprecated-string-transformer)
 
 (define-rc-deprecated-config
- print-color "gschem.printing" "monochrome"
+ print-color "schematic.printing" "monochrome"
  (lambda (x) (not (rc-deprecated-string-boolean-transformer x))))
 
 (define-rc-dead-config net-style)
@@ -182,17 +182,17 @@
 (define-rc-dead-config text-feedback)
 
 (define-rc-deprecated-config
- untitled-name "gschem" "default-filename"
+ untitled-name "schematic" "default-filename"
  rc-deprecated-string-transformer)
 
 (define-rc-dead-config scrollbar-update)
 
 (define-rc-deprecated-config
- sort-component-library "gschem.library" "sort"
+ sort-component-library "schematic.library" "sort"
  rc-deprecated-string-boolean-transformer)
 
 (define-rc-deprecated-config
- component-dialog-attributes "gschem.library" "component-attributes"
+ component-dialog-attributes "schematic.library" "component-attributes"
  (lambda (x) x))
 
 (define-rc-dead-config add-attribute-offset)
@@ -209,43 +209,43 @@
 (define-rc-dead-config gnetlist-version)
 
 (define-rc-deprecated-config
-  unnamed-netname "gnetlist" "default-net-name"
+  unnamed-netname "netlist" "default-net-name"
   rc-deprecated-string-transformer)
 (define-rc-deprecated-config
-  unnamed-busname "gnetlist" "default-bus-name"
+  unnamed-busname "netlist" "default-bus-name"
   rc-deprecated-string-transformer)
 (define-rc-deprecated-config
-  net-naming-priority "gnetlist" "net-naming-priority"
+  net-naming-priority "netlist" "net-naming-priority"
   (lambda (x) (if (string=? x "netname") "netname-attribute" "net-attribute")))
 (define-rc-deprecated-config
-  hierarchy-traversal "gnetlist.hierarchy" "traverse-hierarchy"
+  hierarchy-traversal "netlist.hierarchy" "traverse-hierarchy"
   rc-deprecated-string-boolean-transformer)
 (define-rc-deprecated-config
-  hierarchy-uref-mangle "gnetlist.hierarchy" "mangle-refdes-attribute"
+  hierarchy-uref-mangle "netlist.hierarchy" "mangle-refdes-attribute"
   rc-deprecated-string-boolean-transformer)
 (define-rc-deprecated-config
-  hierarchy-uref-order "gnetlist.hierarchy" "refdes-attribute-order"
+  hierarchy-uref-order "netlist.hierarchy" "refdes-attribute-order"
   (lambda (x) (string=? "prepend" x)))
 (define-rc-deprecated-config
-  hierarchy-uref-separator "gnetlist.hierarchy" "refdes-attribute-separator"
+  hierarchy-uref-separator "netlist.hierarchy" "refdes-attribute-separator"
   rc-deprecated-string-transformer)
 (define-rc-deprecated-config
-  hierarchy-netname-mangle "gnetlist.hierarchy" "mangle-netname-attribute"
+  hierarchy-netname-mangle "netlist.hierarchy" "mangle-netname-attribute"
   rc-deprecated-string-boolean-transformer)
 (define-rc-deprecated-config
-  hierarchy-netname-order "gnetlist.hierarchy" "netname-attribute-order"
+  hierarchy-netname-order "netlist.hierarchy" "netname-attribute-order"
   (lambda (x) (string=? "prepend" x)))
 (define-rc-deprecated-config
-  hierarchy-netname-separator "gnetlist.hierarchy" "netname-attribute-separator"
+  hierarchy-netname-separator "netlist.hierarchy" "netname-attribute-separator"
   rc-deprecated-string-transformer)
 (define-rc-deprecated-config
-  hierarchy-netattrib-mangle "gnetlist.hierarchy" "mangle-net-attribute"
+  hierarchy-netattrib-mangle "netlist.hierarchy" "mangle-net-attribute"
   rc-deprecated-string-boolean-transformer)
 (define-rc-deprecated-config
-  hierarchy-netattrib-order "gnetlist.hierarchy" "net-attribute-order"
+  hierarchy-netattrib-order "netlist.hierarchy" "net-attribute-order"
   (lambda (x) (string=? "prepend" x)))
 (define-rc-deprecated-config
-  hierarchy-netattrib-separator "gnetlist.hierarchy" "net-attribute-separator"
+  hierarchy-netattrib-separator "netlist.hierarchy" "net-attribute-separator"
   rc-deprecated-string-transformer)
 
 (define-rc-deprecated-config

--- a/liblepton/scheme/unit-tests/t0402-config.scm
+++ b/liblepton/scheme/unit-tests/t0402-config.scm
@@ -8,11 +8,11 @@
 
 
 (define *testdir*      (string-append (getcwd)   file-name-separator-string "t0402-tmp"))
-(define *testdirconf*  (string-append *testdir*  file-name-separator-string "geda.conf"))
+(define *testdirconf*  (string-append *testdir*  file-name-separator-string "lepton.conf"))
 (define *testdirA*     (string-append *testdir*  file-name-separator-string "A"))
-(define *testdirAconf* (string-append *testdirA* file-name-separator-string "geda.conf"))
+(define *testdirAconf* (string-append *testdirA* file-name-separator-string "lepton.conf"))
 (define *testdirB*     (string-append *testdir*  file-name-separator-string "B"))
-(define *testdirBconf* (string-append *testdirB* file-name-separator-string "geda.conf"))
+(define *testdirBconf* (string-append *testdirB* file-name-separator-string "lepton.conf"))
 
 ;; Setup/teardown of directories / files needed by tests
 (define (config-test-setup)
@@ -60,7 +60,7 @@
   ;; Unfortunately, there's no reliable way of testing the "recurse
   ;; all the way to root and then give up" functionality, because we
   ;; can't control the contents of the superdirectories of the CWD.
-  (assert-equal "/geda.conf"
+  (assert-equal "/lepton.conf"
                 (config-filename (path-config-context "/__missing/file/")))
   (let ((c (path-config-context *testdir*))
         (a (path-config-context *testdirA*))
@@ -401,11 +401,11 @@
 ;;; functions.
 
 (define *testdir-geda*      (string-append (getcwd)   file-name-separator-string "t0402-tmp-geda"))
-(define *testdir-geda-conf*  (string-append *testdir-geda*  file-name-separator-string "geda.conf"))
+(define *testdir-geda-conf*  (string-append *testdir-geda*  file-name-separator-string "lepton.conf"))
 (define *testdir-geda-A*     (string-append *testdir-geda*  file-name-separator-string "A"))
-(define *testdir-geda-Aconf* (string-append *testdir-geda-A* file-name-separator-string "geda.conf"))
+(define *testdir-geda-Aconf* (string-append *testdir-geda-A* file-name-separator-string "lepton.conf"))
 (define *testdir-geda-B*     (string-append *testdir-geda*  file-name-separator-string "B"))
-(define *testdir-geda-Bconf* (string-append *testdir-geda-B* file-name-separator-string "geda.conf"))
+(define *testdir-geda-Bconf* (string-append *testdir-geda-B* file-name-separator-string "lepton.conf"))
 
 ;; Setup/teardown of directories / files needed by tests
 (define (config-geda-test-setup)
@@ -453,7 +453,7 @@
   ;; Unfortunately, there's no reliable way of testing the "recurse
   ;; all the way to root and then give up" functionality, because we
   ;; can't control the contents of the superdirectories of the CWD.
-  (assert-equal "/geda.conf"
+  (assert-equal "/lepton.conf"
                 (geda:config-filename (geda:path-config-context "/__missing/file/")))
   (let ((c (geda:path-config-context *testdir-geda*))
         (a (geda:path-config-context *testdir-geda-A*))

--- a/liblepton/src/edaconfig.c
+++ b/liblepton/src/edaconfig.c
@@ -66,7 +66,7 @@ static EdaConfig* g_context_system_legacy = NULL;
  * Global variable declared in globals.h
  * Whether to use legacy configuration file names:
  */
-gboolean config_legacy_mode = TRUE;
+gboolean config_legacy_mode = FALSE;
 
 /*! \brief Set config_legacy_mode global variable
  */

--- a/netlist/scheme/netlist/config.scm
+++ b/netlist/scheme/netlist/config.scm
@@ -33,70 +33,70 @@
 
   ;; This is the default name used for nets for which the user has set
   ;; no explicit name via the netname= or net= attributes.
-  (set-config! cfg "gnetlist" "default-net-name" "unnamed_net")
+  (set-config! cfg "netlist" "default-net-name" "unnamed_net")
 
   ;; This is the default name used for buses for which the user has set
   ;; no explicit name via the netname= or net= attributes.
-  (set-config! cfg "gnetlist" "default-bus-name" "unnamed_bus")
+  (set-config! cfg "netlist" "default-bus-name" "unnamed_bus")
 
   ;; By default, net= attributes beat netname= attributes.
-  (set-config! cfg "gnetlist" "net-naming-priority" "net-attribute")
+  (set-config! cfg "netlist" "net-naming-priority" "net-attribute")
 
   ;; By default, hierarchy processing is enabled.
-  (set-config! cfg "gnetlist.hierarchy" "traverse-hierarchy" #t)
+  (set-config! cfg "netlist.hierarchy" "traverse-hierarchy" #t)
 
   ;; By default, sub-schematic attributes 'refdes' are built
   ;; accounting for the parent schematic's ones.
-  (set-config! cfg "gnetlist.hierarchy" "mangle-refdes-attribute" #t)
+  (set-config! cfg "netlist.hierarchy" "mangle-refdes-attribute" #t)
 
   ;; By default, sub-schematic attributes 'refdese' are appended to the parent
   ;; schematic's ones to build hierarchical attributes 'refdes'.
-  (set-config! cfg "gnetlist.hierarchy" "refdes-attribute-order" #f)
+  (set-config! cfg "netlist.hierarchy" "refdes-attribute-order" #f)
 
   ;; This is the default separator which is used to built hierarchical
   ;; refdeses of any component in sub-schematics.
-  (set-config! cfg "gnetlist.hierarchy" "refdes-attribute-separator" "/")
+  (set-config! cfg "netlist.hierarchy" "refdes-attribute-separator" "/")
 
   ;; By default, sub-schematic attributes 'netname' are built
   ;; accounting for the parent schematic's ones.
-  (set-config! cfg "gnetlist.hierarchy" "mangle-netname-attribute" #t)
+  (set-config! cfg "netlist.hierarchy" "mangle-netname-attribute" #t)
 
   ;; By default, sub-schematic attributes 'netname' are appended to the parent
   ;; schematic's ones to build hierarchical netnames.
-  (set-config! cfg "gnetlist.hierarchy" "netname-attribute-order" #f)
+  (set-config! cfg "netlist.hierarchy" "netname-attribute-order" #f)
 
   ;; This is the default separator which is used to built hierarchical
   ;; attributes 'netname' for nets in sub-schematics.
-  (set-config! cfg "gnetlist.hierarchy" "netname-attribute-separator" "/")
+  (set-config! cfg "netlist.hierarchy" "netname-attribute-separator" "/")
 
   ;; By default, sub-schematic attributes 'net' are built
   ;; accounting for the parent schematic's ones.
-  (set-config! cfg "gnetlist.hierarchy" "mangle-net-attribute" #t)
+  (set-config! cfg "netlist.hierarchy" "mangle-net-attribute" #t)
 
   ;; By default, sub-schematic attributes 'net' are appended to the parent
   ;; schematic's ones to build hierarchical netnames.
-  (set-config! cfg "gnetlist.hierarchy" "net-attribute-order" #f)
+  (set-config! cfg "netlist.hierarchy" "net-attribute-order" #f)
 
   ;; This is the default separator which is used to built hierarchical
   ;; attributes 'net' for nets in sub-schematics.
-  (set-config! cfg "gnetlist.hierarchy" "net-attribute-separator" "/"))
+  (set-config! cfg "netlist.hierarchy" "net-attribute-separator" "/"))
 
 (define %gnetlist-config-table
-  `((traverse-hierarchy    ,config-boolean "gnetlist.hierarchy" "traverse-hierarchy")
-    (reverse-refdes-order  ,config-boolean "gnetlist.hierarchy" "refdes-attribute-order")
-    (refdes-separator      ,config-string  "gnetlist.hierarchy" "refdes-attribute-separator")
-    (mangle-refdes         ,config-boolean "gnetlist.hierarchy" "mangle-refdes-attribute")
-    (reverse-net-order     ,config-boolean "gnetlist.hierarchy" "net-attribute-order")
-    (mangle-net            ,config-boolean "gnetlist.hierarchy" "mangle-net-attribute")
-    (net-separator         ,config-string  "gnetlist.hierarchy" "net-attribute-separator")
-    (reverse-netname-order ,config-boolean "gnetlist.hierarchy" "netname-attribute-order")
-    (mangle-netname        ,config-boolean "gnetlist.hierarchy" "mangle-netname-attribute")
-    (netname-separator     ,config-string  "gnetlist.hierarchy" "netname-attribute-separator")
+  `((traverse-hierarchy    ,config-boolean "netlist.hierarchy" "traverse-hierarchy")
+    (reverse-refdes-order  ,config-boolean "netlist.hierarchy" "refdes-attribute-order")
+    (refdes-separator      ,config-string  "netlist.hierarchy" "refdes-attribute-separator")
+    (mangle-refdes         ,config-boolean "netlist.hierarchy" "mangle-refdes-attribute")
+    (reverse-net-order     ,config-boolean "netlist.hierarchy" "net-attribute-order")
+    (mangle-net            ,config-boolean "netlist.hierarchy" "mangle-net-attribute")
+    (net-separator         ,config-string  "netlist.hierarchy" "net-attribute-separator")
+    (reverse-netname-order ,config-boolean "netlist.hierarchy" "netname-attribute-order")
+    (mangle-netname        ,config-boolean "netlist.hierarchy" "mangle-netname-attribute")
+    (netname-separator     ,config-string  "netlist.hierarchy" "netname-attribute-separator")
     (netname-attribute-priority
                            ,(lambda args (string=? "netname-attribute" (apply config-string args)))
-                                           "gnetlist"           "net-naming-priority")
-    (default-net-name      ,config-string  "gnetlist"           "default-net-name")
-    (default-bus-name      ,config-string  "gnetlist"           "default-bus-name")))
+                                           "netlist"           "net-naming-priority")
+    (default-net-name      ,config-string  "netlist"           "default-net-name")
+    (default-bus-name      ,config-string  "netlist"           "default-bus-name")))
 
 ;; Try to load a configuration file for gnetlist
 ;;
@@ -120,16 +120,16 @@
   (set! %gnetlist-config (map process %gnetlist-config-table)))
 
 (define (gnetlist-config-ref key)
-  "Returns value of gnetlist configuration KEY."
+  "Returns value of lepton-netlist configuration KEY."
   (car (assq-ref %gnetlist-config key)))
 
 (define (print-gnetlist-config)
-  "Displays gnetlist configuration settings."
+  "Displays lepton-netlist configuration settings."
   (define (source-string cfg)
     (if (equal? cfg (default-config-context))
         "(default)"
         (string-append "[" (config-filename cfg) "]")))
-  (display "Gnetlist settings:\n\n")
+  (display "lepton-netlist settings:\n\n")
   (for-each
    (lambda (x)
      (match x

--- a/netlist/tests/run-test
+++ b/netlist/tests/run-test
@@ -72,67 +72,67 @@ cmd="\"()\""
 args=
 case "${backend}" in
 config_refdes_attribute_order_true)
-    cat >> "${rundir}/geda.conf" << EOF
-[gnetlist.hierarchy]
+    cat >> "${rundir}/lepton.conf" << EOF
+[netlist.hierarchy]
 refdes-attribute-order=true
 EOF
     backend=geda
     ;;
 config_refdes_attribute_order_false)
-    cat >> "${rundir}/geda.conf" << EOF
-[gnetlist.hierarchy]
+    cat >> "${rundir}/lepton.conf" << EOF
+[netlist.hierarchy]
 refdes-attribute-order=false
 EOF
     backend=geda
     ;;
 config_mangle_refdes_attribute_false_1)
-    cat >> "${rundir}/geda.conf" << EOF
-[gnetlist.hierarchy]
+    cat >> "${rundir}/lepton.conf" << EOF
+[netlist.hierarchy]
 mangle-refdes-attribute=false
 refdes-attribute-order=false
 EOF
     backend=geda
     ;;
 config_mangle_refdes_attribute_false_2)
-    cat >> "${rundir}/geda.conf" << EOF
-[gnetlist.hierarchy]
+    cat >> "${rundir}/lepton.conf" << EOF
+[netlist.hierarchy]
 mangle-refdes-attribute=false
 refdes-attribute-order=true
 EOF
     backend=geda
     ;;
 config_mangle_refdes_attribute_true)
-    cat >> "${rundir}/geda.conf" << EOF
-[gnetlist.hierarchy]
+    cat >> "${rundir}/lepton.conf" << EOF
+[netlist.hierarchy]
 mangle-refdes-attribute=true
 EOF
     backend=geda
     ;;
 config_net_attribute_order_true)
-    cat >> "${rundir}/geda.conf" << EOF
-[gnetlist.hierarchy]
+    cat >> "${rundir}/lepton.conf" << EOF
+[netlist.hierarchy]
 net-attribute-order=true
 EOF
     backend=geda
     ;;
 config_net_attribute_order_false)
-    cat >> "${rundir}/geda.conf" << EOF
-[gnetlist.hierarchy]
+    cat >> "${rundir}/lepton.conf" << EOF
+[netlist.hierarchy]
 net-attribute-order=false
 EOF
     backend=geda
     ;;
 config_mangle_net_attribute_false_1)
-    cat >> "${rundir}/geda.conf" << EOF
-[gnetlist.hierarchy]
+    cat >> "${rundir}/lepton.conf" << EOF
+[netlist.hierarchy]
 mangle-net-attribute=false
 net-attribute-order=false
 EOF
     backend=geda
     ;;
 config_mangle_net_attribute_false_2)
-    cat >> "${rundir}/geda.conf" << EOF
-[gnetlist.hierarchy]
+    cat >> "${rundir}/lepton.conf" << EOF
+[netlist.hierarchy]
 mangle-net-attribute=false
 net-attribute-order=true
 EOF
@@ -140,46 +140,46 @@ EOF
     ;;
 # Default net-attribute-separator.
 config_net_attribute_separator_1)
-    cat >> "${rundir}/geda.conf" << EOF
-[gnetlist.hierarchy]
+    cat >> "${rundir}/lepton.conf" << EOF
+[netlist.hierarchy]
 mangle-net-attribute=true
 net-attribute-separator=:
 EOF
     backend=geda
     ;;
 config_net_attribute_separator_2)
-    cat >> "${rundir}/geda.conf" << EOF
-[gnetlist.hierarchy]
+    cat >> "${rundir}/lepton.conf" << EOF
+[netlist.hierarchy]
 mangle-net-attribute=false
 net-attribute-separator=:
 EOF
     backend=geda
     ;;
 config_netname_attribute_order_true)
-    cat >> "${rundir}/geda.conf" << EOF
-[gnetlist.hierarchy]
+    cat >> "${rundir}/lepton.conf" << EOF
+[netlist.hierarchy]
 netname-attribute-order=true
 EOF
     backend=geda
     ;;
 config_netname_attribute_order_false)
-    cat >> "${rundir}/geda.conf" << EOF
-[gnetlist.hierarchy]
+    cat >> "${rundir}/lepton.conf" << EOF
+[netlist.hierarchy]
 netname-attribute-order=false
 EOF
     backend=geda
     ;;
 config_mangle_netname_attribute_false_1)
-    cat >> "${rundir}/geda.conf" << EOF
-[gnetlist.hierarchy]
+    cat >> "${rundir}/lepton.conf" << EOF
+[netlist.hierarchy]
 mangle-netname-attribute=false
 netname-attribute-order=false
 EOF
     backend=geda
     ;;
 config_mangle_netname_attribute_false_2)
-    cat >> "${rundir}/geda.conf" << EOF
-[gnetlist.hierarchy]
+    cat >> "${rundir}/lepton.conf" << EOF
+[netlist.hierarchy]
 mangle-netname-attribute=false
 netname-attribute-order=true
 EOF
@@ -187,31 +187,31 @@ EOF
     ;;
 # Default netname-attribute-separator.
 config_netname_attribute_separator_1)
-    cat >> "${rundir}/geda.conf" << EOF
-[gnetlist.hierarchy]
+    cat >> "${rundir}/lepton.conf" << EOF
+[netlist.hierarchy]
 mangle-netname-attribute=true
 netname-attribute-separator=:
 EOF
     backend=geda
     ;;
 config_netname_attribute_separator_2)
-    cat >> "${rundir}/geda.conf" << EOF
-[gnetlist.hierarchy]
+    cat >> "${rundir}/lepton.conf" << EOF
+[netlist.hierarchy]
 mangle-netname-attribute=false
 netname-attribute-separator=:
 EOF
     backend=geda
     ;;
 config_net_naming_priority_net)
-    cat >> "${rundir}/geda.conf" << EOF
-[gnetlist]
+    cat >> "${rundir}/lepton.conf" << EOF
+[netlist]
 net-naming-priority=net-attribute
 EOF
     backend=geda
     ;;
 config_net_naming_priority_netname)
-    cat >> "${rundir}/geda.conf" << EOF
-[gnetlist]
+    cat >> "${rundir}/lepton.conf" << EOF
+[netlist]
 net-naming-priority=netname-attribute
 EOF
     backend=geda

--- a/schematic/src/x_compselect.c
+++ b/schematic/src/x_compselect.c
@@ -477,7 +477,7 @@ update_attributes_model (Compselect *compselect, TOPLEVEL *preview_toplevel)
                               s_page_objects (preview_toplevel->page_current));
 
   cfg = eda_config_get_context_for_path (s_page_get_filename (preview_toplevel->page_current));
-  filter_list = eda_config_get_string_list (cfg, "gschem.library",
+  filter_list = eda_config_get_string_list (cfg, "schematic.library",
                                             "component-attributes", &n, NULL);
 
   if (filter_list == NULL || (n > 0 && strcmp (filter_list[0], "*") == 0)) {
@@ -853,7 +853,7 @@ create_lib_tree_model (Compselect *compselect)
   GList *srchead, *srclist;
   PAGE *page = GSCHEM_DIALOG(compselect)->w_current->toplevel->page_current;
   EdaConfig *cfg = eda_config_get_context_for_path (s_page_get_filename (page));
-  gboolean sort = eda_config_get_boolean (cfg, "gschem.library", "sort", NULL);
+  gboolean sort = eda_config_get_boolean (cfg, "schematic.library", "sort", NULL);
 
   store = (GtkTreeStore*)gtk_tree_store_new (3, G_TYPE_POINTER,
                                                 G_TYPE_STRING,

--- a/schematic/src/x_print.c
+++ b/schematic/src/x_print.c
@@ -42,7 +42,7 @@
  * and set 1 gschem point = 1 mil, i.e. 1000 points = 1 inch */
 #define DEFAULT_GSCHEM_PPI 1000
 
-#define CFG_GROUP_PRINTING "gschem.printing"
+#define CFG_GROUP_PRINTING "schematic.printing"
 #define CFG_KEY_PRINTING_ORIENTATION "layout"
 #define CFG_KEY_PRINTING_PAPER "paper"
 #define CFG_KEY_PRINTING_MONOCHROME "monochrome"

--- a/schematic/src/x_window.c
+++ b/schematic/src/x_window.c
@@ -1692,7 +1692,7 @@ untitled_filename (GschemToplevel* w_current, gboolean log_skipped)
   EdaConfig* cfg = eda_config_get_context_for_path (cwd);
 
   gchar* name = eda_config_get_string (cfg,
-                                       "gschem",
+                                       "schematic",
                                        "default-filename",
                                        NULL);
 
@@ -1765,7 +1765,7 @@ x_window_untitled_page (PAGE* page)
   if (cfg != NULL)
   {
     uname = eda_config_get_string (cfg,
-                                   "gschem",
+                                   "schematic",
                                    "default-filename",
                                    NULL);
   }


### PR DESCRIPTION
Use new `lepton*.conf` configuration files by default.
Use new names for configuration parameters in `liblepton`,
`lepton-schematic` and `lepton-netlist`.
