### PR TITLE
libleptonrenderer: Get rid of glib warnings about G_ADD_PRIVATE

### DIFF
--- a/liblepton/src/edaconfig.c
+++ b/liblepton/src/edaconfig.c
@@ -237,9 +237,8 @@ eda_config_class_init (EdaConfigClass *klass)
 static void
 eda_config_init (EdaConfig *config)
 {
-  config->priv = G_TYPE_INSTANCE_GET_PRIVATE (config,
-                                              EDA_TYPE_CONFIG,
-                                              EdaConfigPrivate);
+  config->priv =
+    (EdaConfigPrivate*) eda_config_get_instance_private (config);
 
   config->priv->parent = NULL;
   config->priv->keyfile = g_key_file_new ();

--- a/liblepton/src/edascmhookproxy.c
+++ b/liblepton/src/edascmhookproxy.c
@@ -102,9 +102,8 @@ edascm_hook_proxy_init (EdascmHookProxy *proxy)
 {
   SCM proc = SCM_BOOL_F;
 
-  proxy->priv = G_TYPE_INSTANCE_GET_PRIVATE (proxy,
-                                             EDASCM_TYPE_HOOK_PROXY,
-                                             EdascmHookProxyPrivate);
+  proxy->priv =
+    (EdascmHookProxyPrivate*) edascm_hook_proxy_get_instance_private (proxy);
 
   proxy->priv->hook = SCM_UNDEFINED;
   proxy->priv->closure = SCM_UNDEFINED;

--- a/libleptonrenderer/edapangorenderer.c
+++ b/libleptonrenderer/edapangorenderer.c
@@ -119,9 +119,8 @@ eda_pango_renderer_class_init (EdaPangoRendererClass *klass)
 static void
 eda_pango_renderer_init (EdaPangoRenderer *renderer)
 {
-  renderer->priv = G_TYPE_INSTANCE_GET_PRIVATE (renderer,
-                                                EDA_TYPE_PANGO_RENDERER,
-                                                EdaPangoRendererPrivate);
+  renderer->priv =
+    (EdaPangoRendererPrivate*) eda_pango_renderer_get_instance_private (renderer);
 }
 
 static GObject *

--- a/libleptonrenderer/edarenderer.c
+++ b/libleptonrenderer/edarenderer.c
@@ -273,9 +273,8 @@ eda_renderer_class_init (EdaRendererClass *klass)
 static void
 eda_renderer_init (EdaRenderer *renderer)
 {
-  renderer->priv = G_TYPE_INSTANCE_GET_PRIVATE (renderer,
-                                                EDA_TYPE_RENDERER,
-                                                EdaRendererPrivate);
+  renderer->priv =
+    (EdaRendererPrivate*) eda_renderer_get_instance_private (renderer);
 
   /* Set some sensible default options */
   renderer->priv->font_name = g_strdup (DEFAULT_FONT_NAME);


### PR DESCRIPTION
The warnings without description appear at least on the x86
architecture with libglib 2.62.