### PR TITLE
netlist: Fix test for 'missing-source.sch'.

### DIFF
--- a/netlist/tests/Makefile.am
+++ b/netlist/tests/Makefile.am
@@ -87,11 +87,11 @@ input_files = \
 	common/netattrib.sch \
 	common/powersupply.sch \
 	common/singlenet.sch \
+	missing-source.sch \
 	verilog_rip_test.sch \
 	verilog_rip_test-symbols/D_FF.sym
 
 XFAIL_TESTS = \
-	missing-source-geda.out \
 	common/netattrib-switcap.out \
 	common/SlottedOpamps-futurenet2.out \
 	common/SlottedOpamps-switcap.out

--- a/netlist/tests/missing-source-geda.out
+++ b/netlist/tests/missing-source-geda.out
@@ -1,0 +1,26 @@
+START header
+
+gEDA's netlist format
+(Initially created for testing of gnetlist)
+
+END header
+
+No graphical symbols found
+
+START components
+
+
+END components
+
+No "no-connect" nets found
+
+START renamed-nets
+
+
+END renamed-nets
+
+START nets
+
+
+END nets
+


### PR DESCRIPTION
Recent changes in the netlister code related to processing of
schematics with missing sources made the test pass without error
code.  This patch adds correct output for the test and removes it
from XFAILed ones.