### PR TITLE
build: Get rid of warnings about possibly uninitialized variables.

### DIFF
--- a/attrib/src/gtksheet_2_2.c
+++ b/attrib/src/gtksheet_2_2.c
@@ -8180,7 +8180,7 @@ gtk_sheet_attach_floating       (GtkSheet *sheet,
                                  GtkWidget *widget,
                                  gint row, gint col)
 {
-  GdkRectangle area;
+  GdkRectangle area = { 0, 0, 0, 0 };
   GtkSheetChild *child;
 
   if(row < 0 || col < 0){

--- a/schematic/src/gschem_page_view.c
+++ b/schematic/src/gschem_page_view.c
@@ -608,10 +608,10 @@ gschem_page_view_invalidate_screen_rect (GschemPageView *view, int left, int top
 void
 gschem_page_view_invalidate_world_rect (GschemPageView *view, int left, int top, int right, int bottom)
 {
-  int screen_bottom;
-  int screen_right;
-  int screen_left;
-  int screen_top;
+  int screen_bottom = 0;
+  int screen_right = 0;
+  int screen_left = 0;
+  int screen_top = 0;
 
   g_return_if_fail (view != NULL);
 


### PR DESCRIPTION
The report by @bdale:

I just found a patch in the Debian BTS from our Ubuntu friends.  It
turns out that if you compile lepton-eda wiht -O3, which they do on at
least one platform, you get warnings about possibly uninitialized
variables.  The diff they offered up is pretty trivial, I've added it to
my packaging of 1.9.10, you might want to merge it into your repo too.
