### PR TITLE
Fix exception in lepton-upcfg when invoked with file path

### DIFF
--- a/utils/scripts/lepton-upcfg.in
+++ b/utils/scripts/lepton-upcfg.in
@@ -219,7 +219,13 @@ Lepton EDA homepage: <~a>
   )
 
 
-  ( upcfg-log "ii: upgrading config in [~a]...~%" (config-file-path cfg-id) )
+  ( upcfg-log
+    "ii: upgrading config in [~a]...~%"
+    ( if cfg-id
+      ( config-file-path cfg-id ) ; if
+      ( list-ref files 0 )        ; else
+    )
+  )
 
   ( if ( null? files )
     ( or (config-upgrade cfg-id #:copy copy #:overwrite overwrite) (failure) ) ; if


### PR DESCRIPTION
The utility writes a message to the log with info
on which configuration is being converted.
When `lepton-upcfg` is invoked with some file path
rather than options, the message should include
that file path, which of course is known from the
command line parameter. So, `config-file-path()`
function should not be used. Otherwise, this
function will throw an exception, since it
expects to receive a configuration id, not a string.
