### PR TITLE
Use lepton.conf config files in examples

### DIFF
--- a/examples/gTAG/Makefile.am
+++ b/examples/gTAG/Makefile.am
@@ -11,7 +11,7 @@ nobase_example_DATA = \
 	gTAG-ucont.sch \
 	gTAG.bom \
 	gTAG.sch \
-	geda.conf \
+	lepton.conf \
 	README \
 	sym/7414-1.sym \
 	sym/copyleft.sym \

--- a/examples/gTAG/README
+++ b/examples/gTAG/README
@@ -41,5 +41,5 @@ The distribution of the schematics of gTAG should consist of:
   - gTAG-consio.[sym/sch]
   - gTAG-psu.[sym/sch]
 * gEDA rc-files for this project:
-  - geda.conf - Netlister settings.
+  - lepton.conf - Netlister settings.
   - gafrc     - Symbols and subschematics search paths.

--- a/examples/gTAG/lepton.conf
+++ b/examples/gTAG/lepton.conf
@@ -1,4 +1,4 @@
-[gnetlist.hierarchy]
+[netlist.hierarchy]
 mangle-net-attribute=false
 mangle-netname-attribute=false
 mangle-refdes-attribute=false

--- a/netlist/examples/vams/Makefile.am
+++ b/netlist/examples/vams/Makefile.am
@@ -17,5 +17,5 @@ sym_files = \
 
 SUBDIRS = vhdl
 
-EXTRA_DIST = README gschemrc geda.conf generate_netlist.scm \
+EXTRA_DIST = README gschemrc lepton.conf generate_netlist.scm \
 	$(sch_files) $(sym_files)

--- a/netlist/examples/vams/lepton.conf
+++ b/netlist/examples/vams/lepton.conf
@@ -1,2 +1,2 @@
-[gnetlist.hierarchy]
+[netlist.hierarchy]
 traverse-hierarchy=false


### PR DESCRIPTION
Replace legacy `geda.conf` config files with `lepton.conf`
in examples:
- netlist/examples/vams
- examples/gTAG
