### PR TITLE
lepton-symcheck: Fix 'make check'

### DIFF
--- a/symcheck/tests/runtest.sh
+++ b/symcheck/tests/runtest.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+export LANG=C
 
 INPUT=$1
 rundir=${abs_builddir}/run


### PR DESCRIPTION
'make check' failed on systems, where localised messages were
output (found that after adding  l10n support and Russian translation).