### PR TITLE
Fix placeholder rendering on export

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4,7 +4,7 @@ endif
 if ENABLE_CONTRIB
 CONTRIB_DIR=contrib
 endif
-SUBDIRS = liblepton libleptonrenderer cli schematic ${ATTRIB_DIR} \
+SUBDIRS = libleptonrenderer liblepton cli schematic ${ATTRIB_DIR} \
 	symcheck netlist utils symbols docs examples ${CONTRIB_DIR}
 
 ACLOCAL_AMFLAGS = -I m4

--- a/cli/export.c
+++ b/cli/export.c
@@ -166,6 +166,11 @@ cmd_export_impl (void *data, int argc, char **argv)
   gtk_init_check (&argc, &argv);
   scm_init_guile ();
   liblepton_init ();
+
+  /* Enable rendering of placeholders. Otherwise the user won't
+     see what's wrong. */
+  set_render_placeholders ();
+
   scm_dynwind_begin ((scm_t_dynwind_flags) 0);
   toplevel = s_toplevel_new ();
   edascm_dynwind_toplevel (toplevel);

--- a/cli/export.c
+++ b/cli/export.c
@@ -42,14 +42,6 @@
 #include <cairo-pdf.h>
 #include <cairo-ps.h>
 
-static gboolean
-export_text_rendered_bounds (void *user_data,
-                             const GedaObject *object,
-                             gint *left,
-                             gint *top,
-                             gint *right,
-                             gint *bottom);
-
 static void export_layout_page (PAGE *page,
                                 cairo_rectangle_t *extents,
                                 cairo_matrix_t *mtx,
@@ -264,7 +256,7 @@ cmd_export_impl (void *data, int argc, char **argv)
   /* Make sure libgeda knows how to calculate the bounds of text
    * taking into account font etc. */
   o_text_set_rendered_bounds_func (toplevel,
-                                   export_text_rendered_bounds,
+                                   o_text_get_rendered_bounds,
                                    renderer);
 
   /* Create color map */
@@ -300,29 +292,6 @@ cmd_export_impl (void *data, int argc, char **argv)
 
   scm_dynwind_end ();
   exit (0);
-}
-
-/* Callback function registered with libgeda to allow the libgeda
- * "bounds" functions to get text bounds using the renderer.  If a
- * "rendered bounds" function isn't provided, text objects don't get
- * used when calculating the extents of the drawing. */
-static gboolean
-export_text_rendered_bounds (void *user_data,
-                             const GedaObject *object,
-                             gint *left,
-                             gint *top,
-                             gint *right,
-                             gint *bottom)
-{
-  int result;
-  double t, l, r, b;
-  EdaRenderer *renderer = EDA_RENDERER (user_data);
-  result = eda_renderer_get_user_bounds (renderer, object, &l, &t, &r, &b);
-  *left = lrint (fmin (l,r));
-  *top = lrint (fmin (t, b));
-  *right = lrint (fmax (l, r));
-  *bottom = lrint (fmax (t, b));
-  return result;
 }
 
 /* Prints a message and quits with error status if a cairo status

--- a/cli/export.c
+++ b/cli/export.c
@@ -231,7 +231,7 @@ cmd_export_impl (void *data, int argc, char **argv)
     g_object_set (renderer, "font-name", settings.font, NULL);
   }
 
-  /* Make sure libgeda knows how to calculate the bounds of text
+  /* Make sure liblepton knows how to calculate the bounds of text
    * taking into account font etc. */
   o_text_set_rendered_bounds_func (toplevel, renderer);
 

--- a/cli/export.c
+++ b/cli/export.c
@@ -225,28 +225,6 @@ cmd_export_impl (void *data, int argc, char **argv)
     exit (1);
   }
 
-  /* Load schematic files */
-  while (optind < argc) {
-    PAGE *page;
-    tmp = argv[optind++];
-
-    page = s_page_new (toplevel, tmp);
-    if (!f_open (toplevel, page, tmp, &err)) {
-      fprintf (stderr,
-               /* TRANSLATORS: The first string is the filename, the second
-                * is the detailed error message */
-               _("ERROR: Failed to load '%1$s': %2$s\n"), tmp,
-               err->message);
-      exit (1);
-    }
-    if (g_chdir (original_cwd) != 0) {
-      fprintf (stderr,
-               _("ERROR: Failed to change directory to '%1$s': %2$s\n"),
-               original_cwd, g_strerror (errno));
-      exit (1);
-    }
-  }
-
   /* Create renderer */
   renderer = eda_renderer_new (NULL, NULL);
   if (settings.font != NULL) {
@@ -286,6 +264,28 @@ cmd_export_impl (void *data, int argc, char **argv)
     }
   }
   eda_renderer_set_color_map (renderer, render_color_map);
+
+  /* Load schematic files */
+  while (optind < argc) {
+    PAGE *page;
+    tmp = argv[optind++];
+
+    page = s_page_new (toplevel, tmp);
+    if (!f_open (toplevel, page, tmp, &err)) {
+      fprintf (stderr,
+               /* TRANSLATORS: The first string is the filename, the second
+                * is the detailed error message */
+               _("ERROR: Failed to load '%1$s': %2$s\n"), tmp,
+               err->message);
+      exit (1);
+    }
+    if (g_chdir (original_cwd) != 0) {
+      fprintf (stderr,
+               _("ERROR: Failed to change directory to '%1$s': %2$s\n"),
+               original_cwd, g_strerror (errno));
+      exit (1);
+    }
+  }
 
   /* Render */
   exporter->func ();

--- a/cli/export.c
+++ b/cli/export.c
@@ -233,9 +233,7 @@ cmd_export_impl (void *data, int argc, char **argv)
 
   /* Make sure libgeda knows how to calculate the bounds of text
    * taking into account font etc. */
-  o_text_set_rendered_bounds_func (toplevel,
-                                   o_text_get_rendered_bounds,
-                                   renderer);
+  o_text_set_rendered_bounds_func (toplevel, renderer);
 
   /* Create color map */
   render_color_map =

--- a/liblepton/include/liblepton/geda_component_object.h
+++ b/liblepton/include/liblepton/geda_component_object.h
@@ -77,4 +77,7 @@ geda_component_object_get_position (const GedaObject *object, gint *x, gint *y);
 GList*
 o_component_get_promotable (TOPLEVEL *toplevel, OBJECT *object, int detach);
 
+void
+set_render_placeholders();
+
 G_END_DECLS

--- a/liblepton/include/liblepton/geda_text_object.h
+++ b/liblepton/include/liblepton/geda_text_object.h
@@ -126,7 +126,6 @@ o_text_set_string (TOPLEVEL *toplevel, OBJECT *obj, const gchar *new_string);
 
 void
 o_text_set_rendered_bounds_func (TOPLEVEL *toplevel,
-                                 RenderedBoundsFunc func,
                                  void *user_data);
 
 OBJECT*

--- a/liblepton/include/liblepton/geda_text_object.h
+++ b/liblepton/include/liblepton/geda_text_object.h
@@ -136,12 +136,4 @@ o_text_read (TOPLEVEL *toplevel,
              unsigned int fileformat_ver,
              GError **err);
 
-gboolean
-o_text_get_rendered_bounds (void *user_data,
-                            const GedaObject *o_current,
-                            gint *min_x,
-                            gint *min_y,
-                            gint *max_x,
-                            gint *max_y);
-
 G_END_DECLS

--- a/liblepton/include/liblepton/geda_text_object.h
+++ b/liblepton/include/liblepton/geda_text_object.h
@@ -137,4 +137,12 @@ o_text_read (TOPLEVEL *toplevel,
              unsigned int fileformat_ver,
              GError **err);
 
+gboolean
+o_text_get_rendered_bounds (void *user_data,
+                            const GedaObject *o_current,
+                            gint *min_x,
+                            gint *min_y,
+                            gint *max_x,
+                            gint *max_y);
+
 G_END_DECLS

--- a/liblepton/include/liblepton/geda_toplevel.h
+++ b/liblepton/include/liblepton/geda_toplevel.h
@@ -54,8 +54,7 @@ struct st_toplevel
   /* controls if the whole bounding box is used in the auto whichend code */
   int force_boundingbox;
 
-  /* Callback function for calculating text bounds */
-  RenderedBoundsFunc rendered_text_bounds_func;
+  /* Renderer for calculating text bounds */
   void *rendered_text_bounds_data;
 
   /* Callback functions for object change notification */

--- a/liblepton/include/liblepton/struct.h
+++ b/liblepton/include/liblepton/struct.h
@@ -70,9 +70,6 @@ struct st_conn {
   int other_whichone;
 };
 
-/*! \brief Type of callback function for calculating text bounds */
-typedef gboolean(*RenderedBoundsFunc)(void*, const GedaObject*, gint*, gint*, gint*, gint*);
-
 /*! \brief Type of callback function for object damage notification */
 typedef int(*ChangeNotifyFunc)(void *, OBJECT *);
 

--- a/liblepton/liblepton.pc.in
+++ b/liblepton/liblepton.pc.in
@@ -5,7 +5,7 @@ includedir=@includedir@
 
 Name: liblepton
 Description: Lepton EDA core library
-Requires: glib-2.0 gdk-pixbuf-2.0 gio-2.0 @GUILE_PKG_NAME@
+Requires: libleptonrenderer glib-2.0 gdk-pixbuf-2.0 gio-2.0 @GUILE_PKG_NAME@
 Requires.private:
 Version: @DATE_VERSION@
 Libs: -L${libdir} -llepton

--- a/liblepton/src/Makefile.am
+++ b/liblepton/src/Makefile.am
@@ -105,6 +105,8 @@ liblepton_la_LDFLAGS = -version-info $(LIBLEPTON_SHLIB_VERSION) \
 	$(GLIB_LIBS) $(GDK_PIXBUF_LIBS)
 LIBTOOL=@LIBTOOL@ --silent
 
+liblepton_la_LIBADD = $(top_builddir)/libleptonrenderer/libleptonrenderer.la
+
 # This is used to generate boilerplate for defining Scheme functions
 # in C.
 SUFFIXES = .x

--- a/liblepton/src/Makefile.am
+++ b/liblepton/src/Makefile.am
@@ -99,10 +99,10 @@ liblepton_la_CPPFLAGS = -DLOCALEDIR=\"$(localedir)\"  $(DATADIR_DEFS) \
 	-I$(srcdir)/../include -I$(srcdir)/../include/liblepton -I$(top_srcdir)
 liblepton_la_CFLAGS = \
 	$(GCC_CFLAGS) $(MINGW_CFLAGS) $(GUILE_CFLAGS) $(GLIB_CFLAGS) \
-	$(GDK_PIXBUF_CFLAGS) $(CFLAGS)
+	$(GDK_PIXBUF_CFLAGS) $(CFLAGS) $(CAIRO_CFLAGS) $(PANGO_CFLAGS)
 liblepton_la_LDFLAGS = -version-info $(LIBLEPTON_SHLIB_VERSION) \
 	$(WINDOWS_LIBTOOL_FLAGS) $(MINGW_LDFLAGS) $(GUILE_LIBS) \
-	$(GLIB_LIBS) $(GDK_PIXBUF_LIBS)
+	$(GLIB_LIBS) $(GDK_PIXBUF_LIBS) $(CAIRO_LIBS) $(PANGO_LIBS)
 LIBTOOL=@LIBTOOL@ --silent
 
 liblepton_la_LIBADD = $(top_builddir)/libleptonrenderer/libleptonrenderer.la

--- a/liblepton/src/geda_component_object.c
+++ b/liblepton/src/geda_component_object.c
@@ -98,6 +98,8 @@ always_promote_attributes ()
   return attributes;
 }
 
+static gboolean placeholder_rendering = FALSE;
+
 
 /*! \brief Return the bounds of the given GList of objects.
  *  \par Given a list of objects, calcule the bounds coordinates.
@@ -421,6 +423,23 @@ static void o_component_remove_promotable_attribs (TOPLEVEL *toplevel, OBJECT *o
   g_list_free (promotable);
 }
 
+/*! \brief Enable rendering of placeholders */
+void
+set_render_placeholders()
+{
+  placeholder_rendering = TRUE;
+}
+
+/*! \brief If placeholders have to be rendered
+ *  \return TRUE if placeholders have to be rendered, otherwise
+ *          FALSE
+ */
+static gboolean
+render_placeholders()
+{
+  return placeholder_rendering;
+}
+
 static void create_placeholder(TOPLEVEL * toplevel, OBJECT * new_node, int x, int y)
 {
     GedaBounds bounds;
@@ -435,7 +454,7 @@ static void create_placeholder(TOPLEVEL * toplevel, OBJECT * new_node, int x, in
 
     /* Some programs (e.g. netlister) don't need to render
      * anything, so we just return here. */
-    if (!toplevel->rendered_text_bounds_func) {
+    if (!render_placeholders()) {
       return;
     }
 

--- a/liblepton/src/geda_text_object.c
+++ b/liblepton/src/geda_text_object.c
@@ -961,14 +961,11 @@ o_text_set_string (TOPLEVEL *toplevel, OBJECT *obj, const gchar *new_string)
  *  #TOPLEVEL.
  *
  *  \param [in] toplevel     The TOPLEVEL object
- *  \param [in] func      Function to use.
  *  \param [in] user_data User data to be passed to the function.
  */
 void
 o_text_set_rendered_bounds_func (TOPLEVEL *toplevel,
-                                 RenderedBoundsFunc func,
                                  void *user_data)
 {
-  toplevel->rendered_text_bounds_func = func;
   toplevel->rendered_text_bounds_data = user_data;
 }

--- a/liblepton/src/geda_text_object.c
+++ b/liblepton/src/geda_text_object.c
@@ -138,14 +138,13 @@ geda_text_object_calculate_bounds (TOPLEVEL *toplevel,
   g_return_val_if_fail (object->text != NULL, FALSE);
   g_return_val_if_fail (object->type == OBJ_TEXT, FALSE);
   g_return_val_if_fail (toplevel != NULL, FALSE);
-  g_return_val_if_fail (toplevel->rendered_text_bounds_func != NULL, FALSE);
 
-  return toplevel->rendered_text_bounds_func (toplevel->rendered_text_bounds_data,
-                                              object,
-                                              &bounds->min_x,
-                                              &bounds->min_y,
-                                              &bounds->max_x,
-                                              &bounds->max_y);
+  return o_text_get_rendered_bounds (toplevel->rendered_text_bounds_data,
+                                     object,
+                                     &bounds->min_x,
+                                     &bounds->min_y,
+                                     &bounds->max_x,
+                                     &bounds->max_y);
 }
 
 /*! \brief Get the text alignment

--- a/liblepton/src/geda_text_object.c
+++ b/liblepton/src/geda_text_object.c
@@ -51,6 +51,52 @@
 #endif
 
 #include "libgeda_priv.h"
+#include "libleptonrenderer/libleptonrenderer.h"
+
+/*! \todo Finish function documentation!!!
+ *  \brief
+ *  \par Function Description
+ *
+ */
+gboolean
+o_text_get_rendered_bounds (void *user_data,
+                            const GedaObject *o_current,
+                            gint *min_x,
+                            gint *min_y,
+                            gint *max_x,
+                            gint *max_y)
+{
+  gboolean result = FALSE;
+  double t, l, r, b;
+
+  /* Use dummy zero-sized surface */
+  cairo_surface_t *surface =
+    cairo_image_surface_create (CAIRO_FORMAT_ARGB32, 0, 0);
+  cairo_t *cr = cairo_create (surface);
+
+  EdaRenderer *renderer = EDA_RENDERER (user_data);
+  g_object_set (G_OBJECT (renderer),
+                "cairo-context", cr,
+                NULL);
+
+  /* Use the new renderer to calculate text bounds */
+  result = eda_renderer_get_user_bounds (renderer,
+                                         o_current,
+                                         &l, &t, &r, &b);
+
+  /* Clean up */
+  cairo_surface_destroy (surface);
+  cairo_destroy (cr);
+
+  /* Round bounds to nearest integer */
+  *min_x = lrint (fmin (l, r));
+  *min_y = lrint (fmin (t, b));
+  *max_x = lrint (fmax (l, r));
+  *max_y = lrint (fmax (t, b));
+
+  return result;
+}
+
 
 /*! \brief Scale factor between legacy lepton-schematic font units
  *  and postscript points.

--- a/liblepton/src/geda_text_object.c
+++ b/liblepton/src/geda_text_object.c
@@ -69,6 +69,10 @@ o_text_get_rendered_bounds (void *user_data,
   gboolean result = FALSE;
   double t, l, r, b;
 
+  if (user_data == NULL) {
+    return result;
+  }
+
   /* Use dummy zero-sized surface */
   cairo_surface_t *surface =
     cairo_image_surface_create (CAIRO_FORMAT_ARGB32, 0, 0);

--- a/liblepton/src/geda_toplevel.c
+++ b/liblepton/src/geda_toplevel.c
@@ -70,7 +70,6 @@ TOPLEVEL *s_toplevel_new (void)
   /* for the following variables */
   toplevel->force_boundingbox = FALSE;
 
-  toplevel->rendered_text_bounds_func = NULL;
   toplevel->rendered_text_bounds_data = NULL;
 
   toplevel->change_notify_funcs = NULL;

--- a/libleptonrenderer/README
+++ b/libleptonrenderer/README
@@ -10,7 +10,7 @@ Cairo-based schematic and symbol renderer
 
 The libleptonrenderer library provides a renderer for schematics and
 symbols based on the Cairo vector graphics library and the Pango font
-library.  Data for rendering is loaded using libgeda.
+library.  Data for rendering is loaded using liblepton.
 
 The library does *not* provide a rendering widget for programs
 (although it could be used to implement one).  It is intended for more
@@ -50,7 +50,7 @@ Header files
 The main header file for the library is
 `libleptonrenderer/libleptonrenderer.h'.
 
-It makes two main groups of API functions and and types available: the
+It makes two main groups of API functions and types available: the
 main EdaRenderer class (based on GObject), and a set of hinted
 rendering functions.
 
@@ -69,7 +69,7 @@ The EdaRenderer class
 ---------------------
 
 The EdaRenderer class is the main interface to the library.  It uses
-information from libgeda OBJECT structures to draw various schematic
+information from liblepton OBJECT structures to draw various schematic
 elements, control grips, and cues.
 
 EdaRenderer is a GObject class, with several properties that control
@@ -84,7 +84,7 @@ its behaviour:
   "font-name"  [string]
       The font to use when drawing text.  By default, this is "Arial".
   "color-map"  [pointer]
-      A GArray of libgeda `COLOR' structures which is used as the
+      A GArray of liblepton `COLOR' structures which is used as the
       color map for drawing.  Note that the EdaRenderer does not make
       a copy of this array, and doesn't free it when the EdaRenderer
       is destroyed.
@@ -174,7 +174,7 @@ To actually do the drawing, there are two additional functions:
       Use a colour map index and a GArray of COLOR structures to set
       the current Cairo drawing colour.
   eda_cairo_stroke()
-      Stroke the current Cairo path, with libgeda-compatible stroke
+      Stroke the current Cairo path, with liblepton-compatible stroke
       parameters.
 
 ..

--- a/libleptonrenderer/libleptonrenderer.h
+++ b/libleptonrenderer/libleptonrenderer.h
@@ -20,7 +20,6 @@
 #ifndef __LIBLEPTONRENDERER_H__
 #define __LIBLEPTONRENDERER_H__
 
-#include <liblepton/liblepton.h>
 #include <cairo.h>
 #include <pango/pangocairo.h>
 

--- a/libleptonrenderer/libleptonrenderer.pc.in
+++ b/libleptonrenderer/libleptonrenderer.pc.in
@@ -5,7 +5,7 @@ includedir=@includedir@
 
 Name: libleptonrenderer
 Description: Lepton EDA schematic renderer library
-Requires: liblepton glib-2.0 gobject-2.0 gdk-2.0 gdk-pixbuf-2.0 cairo pangocairo
+Requires: glib-2.0 gobject-2.0 gdk-2.0 gdk-pixbuf-2.0 cairo pangocairo
 Requires.private:
 Version: @DATE_VERSION@
 Libs: -L${libdir} -lleptonrenderer -lm

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -508,13 +508,6 @@ void o_select_move_to_place_list(GschemToplevel *w_current);
 void o_slot_start(GschemToplevel *w_current, OBJECT *object);
 void o_slot_end(GschemToplevel *w_current, OBJECT *object, const char *string);
 /* o_text.c */
-gboolean
-o_text_get_rendered_bounds (void *user_data,
-                            const GedaObject *o_current,
-                            gint *min_x,
-                            gint *min_y,
-                            gint *max_x,
-                            gint *max_y);
 void o_text_prepare_place(GschemToplevel *w_current, char *text, int color, int align, int rotate, int size);
 void o_text_change(GschemToplevel *w_current, OBJECT *object, char *string, int visibility, int show);
 /* o_undo.c */

--- a/schematic/src/gschem_preview.c
+++ b/schematic/src/gschem_preview.c
@@ -306,7 +306,7 @@ gschem_preview_init (GschemPreview *preview)
     preview_w_current;
   o_text_set_rendered_bounds_func (preview_w_current->toplevel,
                                    o_text_get_rendered_bounds,
-                                   preview_w_current);
+                                   preview_w_current->renderer);
 
   i_vars_set (preview_w_current);
 

--- a/schematic/src/gschem_preview.c
+++ b/schematic/src/gschem_preview.c
@@ -305,7 +305,6 @@ gschem_preview_init (GschemPreview *preview)
   preview_w_current->toplevel->load_newer_backup_data =
     preview_w_current;
   o_text_set_rendered_bounds_func (preview_w_current->toplevel,
-                                   o_text_get_rendered_bounds,
                                    preview_w_current->renderer);
 
   i_vars_set (preview_w_current);

--- a/schematic/src/lepton-schematic.c
+++ b/schematic/src/lepton-schematic.c
@@ -273,6 +273,9 @@ void main_prog(void *closure, int argc, char *argv[])
   /* Allocate w_current */
   w_current = x_window_new (toplevel);
 
+  /* Enable rendering of placeholders */
+  set_render_placeholders();
+
   g_dynwind_window (w_current);
 
 #ifdef HAVE_LIBSTROKE

--- a/schematic/src/o_text.c
+++ b/schematic/src/o_text.c
@@ -43,40 +43,25 @@ o_text_get_rendered_bounds (void *user_data,
                             gint *max_x,
                             gint *max_y)
 {
-  TOPLEVEL *toplevel;
-  EdaRenderer *renderer;
-  cairo_t *cr;
-  cairo_surface_t *surface;
-  int result, render_flags = 0;
+  gboolean result = FALSE;
   double t, l, r, b;
-  GschemToplevel *w_current = (GschemToplevel *) user_data;
-  g_return_val_if_fail ((w_current != NULL), FALSE);
-
-  toplevel = gschem_toplevel_get_toplevel (w_current);
-  g_return_val_if_fail ((toplevel != NULL), FALSE);
 
   /* Use dummy zero-sized surface */
-  surface =
+  cairo_surface_t *surface =
     cairo_image_surface_create (CAIRO_FORMAT_ARGB32, 0, 0);
-  cr = cairo_create (surface);
+  cairo_t *cr = cairo_create (surface);
 
-  /* Set up renderer based on configuration in w_current. Note that we
-   * *don't* enable hinting, because if its enabled the calculated
-   * bounds are zoom-level-dependent. */
-  if (toplevel->show_hidden_text)
-    render_flags |= EDA_RENDERER_FLAG_TEXT_HIDDEN;
-  renderer = EDA_RENDERER (g_object_ref (w_current->renderer));
+  EdaRenderer *renderer = EDA_RENDERER (user_data);
   g_object_set (G_OBJECT (renderer),
                 "cairo-context", cr,
-                "render-flags", render_flags,
                 NULL);
 
-  /* Use the renderer to calculate text bounds */
-  result = eda_renderer_get_user_bounds (renderer, o_current, &l, &t, &r, &b);
+  /* Use the new renderer to calculate text bounds */
+  result = eda_renderer_get_user_bounds (renderer,
+                                         o_current,
+                                         &l, &t, &r, &b);
 
   /* Clean up */
-  eda_renderer_destroy (renderer);
-
   cairo_surface_destroy (surface);
   cairo_destroy (cr);
 

--- a/schematic/src/o_text.c
+++ b/schematic/src/o_text.c
@@ -35,50 +35,6 @@
  *  \par Function Description
  *
  */
-gboolean
-o_text_get_rendered_bounds (void *user_data,
-                            const GedaObject *o_current,
-                            gint *min_x,
-                            gint *min_y,
-                            gint *max_x,
-                            gint *max_y)
-{
-  gboolean result = FALSE;
-  double t, l, r, b;
-
-  /* Use dummy zero-sized surface */
-  cairo_surface_t *surface =
-    cairo_image_surface_create (CAIRO_FORMAT_ARGB32, 0, 0);
-  cairo_t *cr = cairo_create (surface);
-
-  EdaRenderer *renderer = EDA_RENDERER (user_data);
-  g_object_set (G_OBJECT (renderer),
-                "cairo-context", cr,
-                NULL);
-
-  /* Use the new renderer to calculate text bounds */
-  result = eda_renderer_get_user_bounds (renderer,
-                                         o_current,
-                                         &l, &t, &r, &b);
-
-  /* Clean up */
-  cairo_surface_destroy (surface);
-  cairo_destroy (cr);
-
-  /* Round bounds to nearest integer */
-  *min_x = lrint (fmin (l, r));
-  *min_y = lrint (fmin (t, b));
-  *max_x = lrint (fmax (l, r));
-  *max_y = lrint (fmax (t, b));
-
-  return result;
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
 void o_text_prepare_place(GschemToplevel *w_current, char *text, int color, int align, int rotate, int size)
 {
   GschemPageView *page_view = gschem_toplevel_get_current_page_view (w_current);

--- a/schematic/src/x_window.c
+++ b/schematic/src/x_window.c
@@ -1021,7 +1021,8 @@ GschemToplevel* x_window_new (TOPLEVEL *toplevel)
   gschem_toplevel_get_toplevel (w_current)->load_newer_backup_data = w_current;
 
   o_text_set_rendered_bounds_func (gschem_toplevel_get_toplevel (w_current),
-                                   o_text_get_rendered_bounds, w_current);
+                                   o_text_get_rendered_bounds,
+                                   w_current->renderer);
 
   /* Damage notifications should invalidate the object on screen */
   o_add_change_notify (gschem_toplevel_get_toplevel (w_current),

--- a/schematic/src/x_window.c
+++ b/schematic/src/x_window.c
@@ -1021,7 +1021,6 @@ GschemToplevel* x_window_new (TOPLEVEL *toplevel)
   gschem_toplevel_get_toplevel (w_current)->load_newer_backup_data = w_current;
 
   o_text_set_rendered_bounds_func (gschem_toplevel_get_toplevel (w_current),
-                                   o_text_get_rendered_bounds,
                                    w_current->renderer);
 
   /* Damage notifications should invalidate the object on screen */


### PR DESCRIPTION
The commit set includes changes and fixes as follows:
- Fixed placeholder rendering in the output of `lepton-cli export`.
- Moved text bounds calculation code from `lepton-cli` and `lepton-schematic` to `liblepton` and simplified it.
- Fixed assertion failures when calculating text object bounds, but no renderer is available, e.g. when a Scheme script was evaluated by `lepton-cli`.
- Removed `TOPLEVEL` field `rendered_text_bounds_func`.
- Changed build order: `libleptonrenderer` is now compiled before liblepton.
- Fixed library names in some docs and comments.
