### PR TITLE
Use Ubuntu Xenial for continuous integration builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@
 # some basic Linux-based continuous integration testing (for free).
 
 sudo: required
-dist: trusty
-group: deprecated-2017Q2
+dist: xenial
 
 language: c
 
@@ -19,12 +18,6 @@ before_install:
   - sudo apt-get install -y libgtk2.0-dev autopoint libgettextpo-dev
     libstroke0-dev guile-2.0-dev flex bison groff texinfo texlive-base
     texlive-generic-recommended texlive-latex-base
-
-  # FIXME[2017-02-15] This is required because Ubuntu Trusty only has
-  # Guile-2.0.9, which doesn't include SRFI-64
-  - sudo mkdir -p /usr/share/guile/2.0/srfi/srfi-64
-  - sudo curl http://git.savannah.gnu.org/cgit/guile.git/plain/module/srfi/srfi-64.scm -o /usr/share/guile/2.0/srfi/srfi-64.scm 
-  - sudo curl http://git.savannah.gnu.org/cgit/guile.git/plain/module/srfi/srfi-64/testing.scm -o /usr/share/guile/2.0/srfi/srfi-64/testing.scm
 
 # Set up the source tree by running autotools
 #


### PR DESCRIPTION
Xenial is used as default build environment on travis-ci.com since
about a year:
https://changelog.travis-ci.com/xenial-as-the-default-build-environment-99476

Switching to it allows to get rid of additional installation of SRFI-64 Scheme modules that are missing in Ubuntu Trusty due to old Guile version 2.0.9 being used.