### PR TITLE
schematic: Use the same font for printing and rendering on the screen.

### DIFF
--- a/schematic/src/x_print.c
+++ b/schematic/src/x_print.c
@@ -188,6 +188,14 @@ x_print_draw_page (TOPLEVEL *toplevel, PAGE *page,
                                          "render-flags", is_raster ? EDA_RENDERER_FLAG_HINTING : 0,
                                          NULL));
 
+  EdaConfig *cfg = eda_config_get_context_for_file (NULL);
+  gchar *fontstr = eda_config_get_string (cfg, "schematic.gui", "font", NULL);
+
+  if (fontstr != NULL) {
+    g_object_set (renderer, "font-name", fontstr, NULL);
+    g_free (fontstr);
+  }
+
   /* Finally, actually do drawing */
   cairo_save (cr);
   cairo_transform (cr, &mtx);


### PR DESCRIPTION
Affects #622.
Incorrect font rendering issue on printing may be caused by different fonts used in GUI and for printing.