### PR TITLE
Fix several potential memory leaks in liblepton and attrib

### DIFF
--- a/attrib/src/x_gtksheet.c
+++ b/attrib/src/x_gtksheet.c
@@ -71,7 +71,6 @@ x_gtksheet_init()
   const gchar *folder[]= {_("Components"),
                           _("Nets"),
                           _("Pins")};
-  GtkWidget **scrolled_windows = NULL;
 
   /* ---  Create three new sheets.   were malloc'ed in x_window_init  --- */
 
@@ -117,11 +116,9 @@ x_gtksheet_init()
     if (sheets[i] != NULL) {  /* is this check needed? 
 			       * Yes, it prevents us from segfaulting on empty nets sheet. */
 
-
-      scrolled_windows=(GtkWidget **)realloc(scrolled_windows, (i+1)*sizeof(GtkWidget *));
-      scrolled_windows[i]=gtk_scrolled_window_new(NULL, NULL);
+      GtkWidget* scrolled_window = gtk_scrolled_window_new (NULL, NULL);
       
-      gtk_container_add( GTK_CONTAINER(scrolled_windows[i]), GTK_WIDGET(sheets[i]) );
+      gtk_container_add( GTK_CONTAINER(scrolled_window), GTK_WIDGET(sheets[i]) );
 
       /* First remove old notebook page.  I should probably do some checking here. */
       if (notebook != NULL) 
@@ -131,11 +128,11 @@ x_gtksheet_init()
       /* Then add new, updated notebook page */
       label= gtk_label_new(folder[i]);
 
-      gtk_notebook_append_page(GTK_NOTEBOOK(notebook), GTK_WIDGET(scrolled_windows[i]),
+      gtk_notebook_append_page(GTK_NOTEBOOK(notebook), scrolled_window,
 			       GTK_WIDGET(label) );
 
       gtk_widget_show( GTK_WIDGET(sheets[i]) );
-      gtk_widget_show( GTK_WIDGET(scrolled_windows[i]) );
+      gtk_widget_show( scrolled_window );
       gtk_widget_show( GTK_WIDGET(notebook) );  /* show updated notebook  */
 
 

--- a/liblepton/src/geda_component_object.c
+++ b/liblepton/src/geda_component_object.c
@@ -673,6 +673,7 @@ OBJECT *o_component_read (TOPLEVEL *toplevel,
   if (sscanf(buf, "%c %d %d %d %d %d %s\n",
 	     &type, &x1, &y1, &selectable, &angle, &mirror, basename) != 7) {
     g_set_error(err, EDA_ERROR, EDA_ERROR_PARSE, _("Failed to parse component object"));
+    g_free (basename);
     return NULL;
   }
 

--- a/liblepton/src/s_encoding.c
+++ b/liblepton/src/s_encoding.c
@@ -253,6 +253,7 @@ gchar *s_encoding_base64_decode (gchar* src, guint srclen, guint* dstlenp)
 	{
 	case 0:             /* Invalid = in first position */
 	case 1:             /* Invalid = in second position */
+	  g_free(dst);
 	  return NULL;
 	case 2:             /* Valid, means one byte of info */
                                 /* Skip any number of spaces. */


### PR DESCRIPTION
Interestingly, these were detected by the `scan-build` static
code analysis tool (part of `clang`), but I can't find them
 among the coverity scan issues.

@vzh `scan-build` generates html output very similar to what we see
on scan.coverity.com. If need be, I can send it by e-mail (my first
intention was to upload it to my lepton page, until I `du -hsx` it:
almost 80 Mb :-), though in compressed form it takes about 400 Kb).
