### PR TITLE
Fix font rendering issues

### DIFF
--- a/cli/export.c
+++ b/cli/export.c
@@ -231,10 +231,6 @@ cmd_export_impl (void *data, int argc, char **argv)
     g_object_set (renderer, "font-name", settings.font, NULL);
   }
 
-  /* Make sure liblepton knows how to calculate the bounds of text
-   * taking into account font etc. */
-  o_text_set_rendered_bounds_func (toplevel, renderer);
-
   /* Create color map */
   render_color_map =
     g_array_sized_new (FALSE, FALSE, sizeof(GedaColor), MAX_COLORS);

--- a/liblepton/include/liblepton/geda_text_object.h
+++ b/liblepton/include/liblepton/geda_text_object.h
@@ -122,10 +122,6 @@ void
 o_text_set_string (OBJECT *obj,
                    const gchar *new_string);
 
-void
-o_text_set_rendered_bounds_func (TOPLEVEL *toplevel,
-                                 void *user_data);
-
 OBJECT*
 o_text_read (const char *first_line,
              TextBuffer *tb,

--- a/liblepton/include/liblepton/geda_text_object.h
+++ b/liblepton/include/liblepton/geda_text_object.h
@@ -46,8 +46,8 @@ geda_text_object_copy (const GedaObject *object);
 /* methods */
 
 gboolean
-geda_text_object_calculate_bounds (TOPLEVEL *toplevel,
-                                   const GedaObject *object,
+geda_text_object_calculate_bounds (const GedaObject *object,
+                                   gboolean include_hidden,
                                    GedaBounds *bounds);
 
 gint

--- a/liblepton/include/liblepton/geda_toplevel.h
+++ b/liblepton/include/liblepton/geda_toplevel.h
@@ -51,9 +51,6 @@ struct st_toplevel
   int auto_save_interval;
   gint auto_save_timeout;
 
-  /* Renderer for calculating text bounds */
-  void *rendered_text_bounds_data;
-
   /* Callback functions for object change notification */
   GList *change_notify_funcs;
 

--- a/liblepton/scheme/unit-tests/t0106-object-bounds.scm
+++ b/liblepton/scheme/unit-tests/t0106-object-bounds.scm
@@ -19,9 +19,9 @@
     ;; Multiple arguments
     (assert-equal '((-5 . 8) . (8 . -5)) (object-bounds x y))
 
-    ;; Unfortunately, libgeda has no text renderer, so text never has
-    ;; any bounds.  What a shame.
-    (assert-true (not (object-bounds t)))
+    ;; We do not know the size of resulting text, so it is enough
+    ;; to check that text object bounds are not #f.
+    (assert-true (object-bounds t))
 
     ;; Empty components should have no bounds...
     (assert-equal '() (component-contents C))
@@ -71,9 +71,9 @@
     ;; Multiple arguments
     (assert-equal '((-5 . 8) . (8 . -5)) (geda:object-bounds x y))
 
-    ;; Unfortunately, libgeda has no text renderer, so text never has
-    ;; any bounds.  What a shame.
-    (assert-true (not (geda:object-bounds t)))
+    ;; We do not know the size of resulting text, so it is enough
+    ;; to check that text object bounds are not #f.
+    (assert-true (geda:object-bounds t))
 
     ;; Empty components should have no bounds...
     (assert-equal '() (geda:component-contents C))

--- a/liblepton/src/geda_component_object.c
+++ b/liblepton/src/geda_component_object.c
@@ -481,8 +481,8 @@ static void create_placeholder(TOPLEVEL * toplevel, OBJECT * new_node, int x, in
     g_free(not_found_text);
 
     /* figure out where to put the hazard triangle */
-    geda_text_object_calculate_bounds (toplevel,
-                                       new_prim_obj,
+    geda_text_object_calculate_bounds (new_prim_obj,
+                                       FALSE,
                                        &bounds);
     x_offset = (bounds.max_x - bounds.min_x) / 4;
     y_offset = bounds.max_y - bounds.min_y + 100;  /* 100 is just an additional offset */

--- a/liblepton/src/geda_object.c
+++ b/liblepton/src/geda_object.c
@@ -1197,7 +1197,9 @@ geda_object_calculate_visible_bounds (TOPLEVEL *toplevel,
     break;
 
   case(OBJ_TEXT):
-    if (!geda_text_object_calculate_bounds(toplevel, o_current, &bounds)) {
+    if (!geda_text_object_calculate_bounds (o_current,
+                                            toplevel->show_hidden_text,
+                                            &bounds)) {
       return 0;
     }
     break;

--- a/liblepton/src/geda_text_object.c
+++ b/liblepton/src/geda_text_object.c
@@ -114,9 +114,9 @@ geda_text_object_calculate_bounds (TOPLEVEL *toplevel,
                 NULL);
 
   /* Use the new renderer to calculate text bounds */
-  result = eda_renderer_get_user_bounds (renderer,
-                                         object,
-                                         &l, &t, &r, &b);
+  result = eda_renderer_get_text_user_bounds (renderer,
+                                              object,
+                                              &l, &t, &r, &b);
 
   /* Clean up */
   eda_renderer_destroy (renderer);

--- a/liblepton/src/geda_text_object.c
+++ b/liblepton/src/geda_text_object.c
@@ -78,14 +78,15 @@ int tab_in_chars = 8;
  *  be moved to EdaRenderer. And, this method should not be a virtual method
  *  of GedaObject.
  *
- *  \param [in]  toplevel  The TOPLEVEL object.
- *  \param [in]  object    a text object
- *  \param [out] bounds    the bounds of the text
+ *  \param [in]  object         a text object
+ *  \param [in]  include_hidden if hidden text should be taken into
+ *                              account
+ *  \param [out] bounds         the bounds of the text
  *  \return TRUE if successful, FALSE if unsuccessful
  */
 gboolean
-geda_text_object_calculate_bounds (TOPLEVEL *toplevel,
-                                   const GedaObject *object,
+geda_text_object_calculate_bounds (const GedaObject *object,
+                                   gboolean include_hidden,
                                    GedaBounds *bounds)
 {
   geda_bounds_init (bounds);
@@ -93,15 +94,11 @@ geda_text_object_calculate_bounds (TOPLEVEL *toplevel,
   g_return_val_if_fail (object != NULL, FALSE);
   g_return_val_if_fail (object->text != NULL, FALSE);
   g_return_val_if_fail (object->type == OBJ_TEXT, FALSE);
-  g_return_val_if_fail (toplevel != NULL, FALSE);
 
-  gboolean result = FALSE;
   double t, l, r, b;
-
-  /* Use the new renderer to calculate text bounds */
-  result = eda_renderer_get_text_user_bounds (object,
-                                              toplevel->show_hidden_text,
-                                              &l, &t, &r, &b);
+  gboolean result = eda_renderer_get_text_user_bounds (object,
+                                                       include_hidden,
+                                                       &l, &t, &r, &b);
 
   /* Round bounds to nearest integer */
   bounds->min_x = lrint (fmin (l, r));

--- a/liblepton/src/geda_text_object.c
+++ b/liblepton/src/geda_text_object.c
@@ -102,26 +102,10 @@ geda_text_object_calculate_bounds (TOPLEVEL *toplevel,
     return result;
   }
 
-  /* Use dummy zero-sized surface */
-  cairo_surface_t *surface =
-    cairo_image_surface_create (CAIRO_FORMAT_ARGB32, 0, 0);
-  cairo_t *cr = cairo_create (surface);
-
-  EdaRenderer *renderer = eda_renderer_new (NULL, NULL);
-  g_object_set (G_OBJECT (renderer),
-                "cairo-context", cr,
-                "render-flags", toplevel->show_hidden_text ? EDA_RENDERER_FLAG_TEXT_HIDDEN : 0,
-                NULL);
-
   /* Use the new renderer to calculate text bounds */
-  result = eda_renderer_get_text_user_bounds (renderer,
-                                              object,
+  result = eda_renderer_get_text_user_bounds (object,
+                                              toplevel->show_hidden_text,
                                               &l, &t, &r, &b);
-
-  /* Clean up */
-  eda_renderer_destroy (renderer);
-  cairo_surface_destroy (surface);
-  cairo_destroy (cr);
 
   /* Round bounds to nearest integer */
   bounds->min_x = lrint (fmin (l, r));

--- a/liblepton/src/geda_text_object.c
+++ b/liblepton/src/geda_text_object.c
@@ -98,10 +98,6 @@ geda_text_object_calculate_bounds (TOPLEVEL *toplevel,
   gboolean result = FALSE;
   double t, l, r, b;
 
-  if (toplevel->rendered_text_bounds_data == NULL) {
-    return result;
-  }
-
   /* Use the new renderer to calculate text bounds */
   result = eda_renderer_get_text_user_bounds (object,
                                               toplevel->show_hidden_text,
@@ -909,19 +905,4 @@ o_text_set_string (OBJECT *obj,
   obj->text->string = g_strdup (new_string);
 
   o_text_recreate (obj);
-}
-
-/*! \brief Set the font-renderer-specific bounds function.
- *  \par Function Description
- *  Set the function to be used to calculate text bounds for a given
- *  #TOPLEVEL.
- *
- *  \param [in] toplevel     The TOPLEVEL object
- *  \param [in] user_data User data to be passed to the function.
- */
-void
-o_text_set_rendered_bounds_func (TOPLEVEL *toplevel,
-                                 void *user_data)
-{
-  toplevel->rendered_text_bounds_data = user_data;
 }

--- a/liblepton/src/geda_text_object.c
+++ b/liblepton/src/geda_text_object.c
@@ -107,10 +107,10 @@ geda_text_object_calculate_bounds (TOPLEVEL *toplevel,
     cairo_image_surface_create (CAIRO_FORMAT_ARGB32, 0, 0);
   cairo_t *cr = cairo_create (surface);
 
-  EdaRenderer *renderer =
-    EDA_RENDERER (toplevel->rendered_text_bounds_data);
+  EdaRenderer *renderer = eda_renderer_new (NULL, NULL);
   g_object_set (G_OBJECT (renderer),
                 "cairo-context", cr,
+                "render-flags", toplevel->show_hidden_text ? EDA_RENDERER_FLAG_TEXT_HIDDEN : 0,
                 NULL);
 
   /* Use the new renderer to calculate text bounds */
@@ -119,6 +119,7 @@ geda_text_object_calculate_bounds (TOPLEVEL *toplevel,
                                          &l, &t, &r, &b);
 
   /* Clean up */
+  eda_renderer_destroy (renderer);
   cairo_surface_destroy (surface);
   cairo_destroy (cr);
 

--- a/liblepton/src/geda_toplevel.c
+++ b/liblepton/src/geda_toplevel.c
@@ -68,8 +68,6 @@ TOPLEVEL *s_toplevel_new (void)
 
   /* The following is an attempt at getting (deterministic) defaults */
   /* for the following variables */
-  toplevel->rendered_text_bounds_data = NULL;
-
   toplevel->change_notify_funcs = NULL;
 
   toplevel->load_newer_backup_func = NULL;

--- a/libleptonrenderer/edapangorenderer.c
+++ b/libleptonrenderer/edapangorenderer.c
@@ -34,7 +34,6 @@
 #define _(x) (x)
 
 #define MAGIC_OVERBAR_POS_CONSTANT 0.8
-#define MAGIC_OVERBAR_WIDTH_CONSTANT 0.03
 
 enum {
   PROP_CAIRO_CONTEXT = 1
@@ -199,6 +198,7 @@ eda_pango_renderer_draw_glyphs (PangoRenderer *renderer,
   cairo_t *cr = eda_renderer->priv->cr;
 
   if (eda_renderer->priv->overbar) {
+    PangoFontMetrics *metrics;
     double rx, ry;
     double rwidth;
     double rheight;
@@ -210,7 +210,9 @@ eda_pango_renderer_draw_glyphs (PangoRenderer *renderer,
     rwidth = glyphs_extents.width / PANGO_SCALE;
 
     /* Make the thickness the same as for the font's underline */
-    rheight = glyphs_extents.height * MAGIC_OVERBAR_WIDTH_CONSTANT / PANGO_SCALE;
+    metrics = pango_font_get_metrics (font, NULL);
+    rheight = pango_font_metrics_get_underline_thickness (metrics) / PANGO_SCALE;
+    pango_font_metrics_unref (metrics);
 
     /* Allow the overbar to fade out as it becomes < 1px high */
     if (rheight > 1.0) {

--- a/libleptonrenderer/edapangorenderer.c
+++ b/libleptonrenderer/edapangorenderer.c
@@ -34,6 +34,7 @@
 #define _(x) (x)
 
 #define MAGIC_OVERBAR_POS_CONSTANT 0.8
+#define MAGIC_OVERBAR_WIDTH_CONSTANT 0.03
 
 enum {
   PROP_CAIRO_CONTEXT = 1
@@ -198,7 +199,6 @@ eda_pango_renderer_draw_glyphs (PangoRenderer *renderer,
   cairo_t *cr = eda_renderer->priv->cr;
 
   if (eda_renderer->priv->overbar) {
-    PangoFontMetrics *metrics;
     double rx, ry;
     double rwidth;
     double rheight;
@@ -210,9 +210,7 @@ eda_pango_renderer_draw_glyphs (PangoRenderer *renderer,
     rwidth = glyphs_extents.width / PANGO_SCALE;
 
     /* Make the thickness the same as for the font's underline */
-    metrics = pango_font_get_metrics (font, NULL);
-    rheight = pango_font_metrics_get_underline_thickness (metrics) / PANGO_SCALE;
-    pango_font_metrics_unref (metrics);
+    rheight = glyphs_extents.height * MAGIC_OVERBAR_WIDTH_CONSTANT / PANGO_SCALE;
 
     /* Allow the overbar to fade out as it becomes < 1px high */
     if (rheight > 1.0) {

--- a/libleptonrenderer/edarenderer.c
+++ b/libleptonrenderer/edarenderer.c
@@ -1523,10 +1523,10 @@ eda_renderer_get_text_user_bounds (EdaRenderer *renderer,
    * device coordinates, but we need world coordinates. */
   pango_layout_get_pixel_extents (renderer->priv->pl,
                                   &inked_rect, &logical_rect);
-  *left = (double) inked_rect.x;
-  *top = (double) inked_rect.y;
-  *right = (double) inked_rect.x + inked_rect.width;
-  *bottom = (double) inked_rect.y + inked_rect.height;
+  *left = (double) logical_rect.x;
+  *top = (double) logical_rect.y;
+  *right = (double) logical_rect.x + logical_rect.width;
+  *bottom = (double) logical_rect.y + logical_rect.height;
   cairo_user_to_device (renderer->priv->cr, left, top);
   cairo_user_to_device (renderer->priv->cr, right, bottom);
 

--- a/libleptonrenderer/edarenderer.c
+++ b/libleptonrenderer/edarenderer.c
@@ -972,17 +972,9 @@ eda_renderer_calc_text_position (EdaRenderer *renderer, const GedaObject *object
   x_middle = -logical_rect.width / 2.0;
   x_right = -logical_rect.width;
 
-  /*! \note Ideally, we would be using just font / logical metrics for vertical
-   *        alignment, however this way seems to be more backward compatible
-   *        with the old gschem rendering.
-   *
-   *        Lower alignment is at the baseline of the bottom text line, whereas
-   *        middle and upper alignment is based upon the inked extents of the
-   *        entire text block.
-   */
-  y_upper  = -inked_rect.y;                     /* Top of inked extents */
-  y_middle = y_upper - inked_rect.height / 2.;  /* Middle of inked extents */
-  y_lower  = descent - logical_rect.height;     /* Baseline of bottom line */
+  y_upper  = -logical_rect.y;                     /* Top of inked extents */
+  y_middle = y_upper - logical_rect.height / 2.;  /* Middle of inked extents */
+  y_lower  = y_upper - logical_rect.height;       /* Baseline of bottom line */
 
   /* Special case flips attachment point to opposite corner when
    * the text is rotated to 180 degrees, since the drawing code

--- a/libleptonrenderer/edarenderer.c
+++ b/libleptonrenderer/edarenderer.c
@@ -172,14 +172,6 @@ eda_renderer_default_get_user_bounds (EdaRenderer *renderer,
                                       double *right,
                                       double *bottom);
 
-static gboolean
-eda_renderer_get_text_user_bounds (EdaRenderer *renderer,
-                                   const GedaObject *object,
-                                   double *left,
-                                   double *top,
-                                   double *right,
-                                   double *bottom);
-
 G_DEFINE_TYPE_WITH_PRIVATE (EdaRenderer, eda_renderer, G_TYPE_OBJECT);
 
 GType
@@ -1493,7 +1485,7 @@ eda_renderer_default_get_user_bounds (EdaRenderer *renderer,
   }
 }
 
-static gboolean
+gboolean
 eda_renderer_get_text_user_bounds (EdaRenderer *renderer,
                                    const GedaObject *object,
                                    double *left,

--- a/libleptonrenderer/edarenderer.c
+++ b/libleptonrenderer/edarenderer.c
@@ -1516,6 +1516,14 @@ eda_renderer_get_text_user_bounds (const GedaObject *object,
   g_object_set (G_OBJECT (renderer),
                 "cairo-context", cr,
                 NULL);
+  EdaConfig *cfg = eda_config_get_context_for_file (NULL);
+  gchar *font_name = eda_config_get_string (cfg, "schematic.gui", "font", NULL);
+  if (font_name != NULL) {
+    g_object_set (G_OBJECT (renderer),
+                  "font-name", font_name,
+                  NULL);
+  }
+  g_free (font_name);
 
   cairo_save (renderer->priv->cr);
 

--- a/libleptonrenderer/edarenderer.c
+++ b/libleptonrenderer/edarenderer.c
@@ -918,7 +918,6 @@ eda_renderer_prepare_text (EdaRenderer *renderer, const GedaObject *object)
     cairo_translate (renderer->priv->cr, dx, dy);
   }
 
-  pango_cairo_update_layout (renderer->priv->cr, renderer->priv->pl);
   return TRUE;
 }
 
@@ -933,6 +932,9 @@ eda_renderer_calc_text_position (EdaRenderer *renderer, const GedaObject *object
   double y_lower, y_middle, y_upper;
   double x_left, x_middle, x_right;
 
+  cairo_save (renderer->priv->cr);
+  cairo_identity_matrix (renderer->priv->cr);
+  pango_cairo_update_layout (renderer->priv->cr, renderer->priv->pl);
   pango_layout_get_extents (renderer->priv->pl,
                             &inked_rect, &logical_rect);
 
@@ -969,6 +971,7 @@ eda_renderer_calc_text_position (EdaRenderer *renderer, const GedaObject *object
 
   *x /= PANGO_SCALE;
   *y /= PANGO_SCALE;
+  cairo_restore (renderer->priv->cr);
 }
 
 static void

--- a/libleptonrenderer/edarenderer.h
+++ b/libleptonrenderer/edarenderer.h
@@ -96,6 +96,14 @@ eda_renderer_get_user_bounds (EdaRenderer *renderer,
                               double *right,
                               double *bottom);
 
+gboolean
+eda_renderer_get_text_user_bounds (EdaRenderer *renderer,
+                                   const GedaObject *object,
+                                   double *left,
+                                   double *top,
+                                   double *right,
+                                   double *bottom);
+
 G_END_DECLS
 
 #endif /* !__EDA_RENDERER_H__ */

--- a/libleptonrenderer/edarenderer.h
+++ b/libleptonrenderer/edarenderer.h
@@ -97,8 +97,8 @@ eda_renderer_get_user_bounds (EdaRenderer *renderer,
                               double *bottom);
 
 gboolean
-eda_renderer_get_text_user_bounds (EdaRenderer *renderer,
-                                   const GedaObject *object,
+eda_renderer_get_text_user_bounds (const GedaObject *object,
+                                   gboolean enable_hidden,
                                    double *left,
                                    double *top,
                                    double *right,

--- a/netlist/scheme/backend/gnet-geda.scm
+++ b/netlist/scheme/backend/gnet-geda.scm
@@ -61,7 +61,7 @@ END header
     (format #f
             "Component without refdes: ~A at ~A"
             (component-basename object)
-            (object-bounds object)))
+            (component-position object)))
 
   (define (graphical-info package)
     (or (schematic-component-refdes package)

--- a/netlist/tests/common/JD-geda.out
+++ b/netlist/tests/common/JD-geda.out
@@ -7,7 +7,7 @@ END header
 
 START graphical symbols
 
-Component without refdes: title-bordered-A.sym at ((5200 . 88900) 16200 . 80400)
+Component without refdes: title-bordered-A.sym at (5200 . 80400)
 
 END graphical symbols
 

--- a/netlist/tests/common/SlottedOpamps-geda.out
+++ b/netlist/tests/common/SlottedOpamps-geda.out
@@ -7,7 +7,7 @@ END header
 
 START graphical symbols
 
-Component without refdes: title-B.sym at ((40000 . 51000) 57000 . 40000)
+Component without refdes: title-B.sym at (40000 . 40000)
 
 END graphical symbols
 

--- a/netlist/tests/common/TwoStageAmp-geda.out
+++ b/netlist/tests/common/TwoStageAmp-geda.out
@@ -7,7 +7,7 @@ END header
 
 START graphical symbols
 
-Component without refdes: title-B.sym at ((26000 . 57000) 43000 . 46000)
+Component without refdes: title-B.sym at (26000 . 46000)
 
 END graphical symbols
 

--- a/netlist/tests/common/cascade-geda.out
+++ b/netlist/tests/common/cascade-geda.out
@@ -7,7 +7,7 @@ END header
 
 START graphical symbols
 
-Component without refdes: title-B.sym at ((40000 . 51000) 57000 . 40000)
+Component without refdes: title-B.sym at (40000 . 40000)
 
 END graphical symbols
 

--- a/netlist/tests/common/powersupply-geda.out
+++ b/netlist/tests/common/powersupply-geda.out
@@ -7,7 +7,7 @@ END header
 
 START graphical symbols
 
-Component without refdes: title-C.sym at ((51800 . 66900) 73800 . 49900)
+Component without refdes: title-C.sym at (51800 . 49900)
 
 END graphical symbols
 

--- a/netlist/tests/drc2/connected-noconnects-geda.out
+++ b/netlist/tests/drc2/connected-noconnects-geda.out
@@ -7,7 +7,7 @@ END header
 
 START graphical symbols
 
-Component without refdes: title-B.sym at ((40000 . 51000) 57000 . 40000)
+Component without refdes: title-B.sym at (40000 . 40000)
 
 END graphical symbols
 

--- a/netlist/tests/hierarchy2-geda.out
+++ b/netlist/tests/hierarchy2-geda.out
@@ -7,11 +7,11 @@ END header
 
 START graphical symbols
 
-Component without refdes: title-B.sym at ((40000 . 51000) 57000 . 40000)
-Component without refdes: title-B.sym at ((40000 . 51000) 57000 . 40000)
-Component without refdes: under.sym at ((51092 . 46900) 53208 . 45800)
-Component without refdes: title-B.sym at ((40000 . 51000) 57000 . 40000)
-Component without refdes: under.sym at ((51092 . 46900) 53208 . 45800)
+Component without refdes: title-B.sym at (40000 . 40000)
+Component without refdes: title-B.sym at (40000 . 40000)
+Component without refdes: under.sym at (51100 . 45800)
+Component without refdes: title-B.sym at (40000 . 40000)
+Component without refdes: under.sym at (51100 . 45800)
 
 END graphical symbols
 

--- a/netlist/tests/stack_1-geda.out
+++ b/netlist/tests/stack_1-geda.out
@@ -7,9 +7,9 @@ END header
 
 START graphical symbols
 
-Component without refdes: title-C.sym at ((17100 . 33500) 39100 . 16500)
-Component without refdes: decon-1.sym at ((21600 . 19400) 21750 . 19300)
-Component without refdes: decon-1.sym at ((21700 . 24300) 21850 . 24200)
+Component without refdes: title-C.sym at (17100 . 16500)
+Component without refdes: decon-1.sym at (21600 . 19300)
+Component without refdes: decon-1.sym at (21700 . 24200)
 
 END graphical symbols
 

--- a/schematic/src/gschem_preview.c
+++ b/schematic/src/gschem_preview.c
@@ -302,8 +302,6 @@ gschem_preview_init (GschemPreview *preview)
     x_fileselect_load_backup;
   preview_w_current->toplevel->load_newer_backup_data =
     preview_w_current;
-  o_text_set_rendered_bounds_func (preview_w_current->toplevel,
-                                   preview_w_current->renderer);
 
   i_vars_set (preview_w_current);
 

--- a/schematic/src/x_window.c
+++ b/schematic/src/x_window.c
@@ -1020,9 +1020,6 @@ GschemToplevel* x_window_new (TOPLEVEL *toplevel)
   gschem_toplevel_get_toplevel (w_current)->load_newer_backup_func = x_fileselect_load_backup;
   gschem_toplevel_get_toplevel (w_current)->load_newer_backup_data = w_current;
 
-  o_text_set_rendered_bounds_func (gschem_toplevel_get_toplevel (w_current),
-                                   w_current->renderer);
-
   /* Damage notifications should invalidate the object on screen */
   o_add_change_notify (gschem_toplevel_get_toplevel (w_current),
                        (ChangeNotifyFunc) o_invalidate,


### PR DESCRIPTION
The branch fixes rendering issues that manifest themselves when new Pango library (1.44) is used:
- issue with different sizes of overbars on zooming (first reported by @rgilton on gitter)
- issue with wrong alignment of lower aligned text in printed output (#622)
- issue with changing vertical spacing between paragraphs of text separated with empty lines on zooming.

Besides, functionality of text bounds calculation no longer depends on `TOPLEVEL` and it has been moved to `libleptonrenderer` from `liblepton`.

Closes #622.