### PR TITLE
Improve handling of symversion changes in lepton-schematic

### DIFF
--- a/liblepton/include/liblepton/geda_page.h
+++ b/liblepton/include/liblepton/geda_page.h
@@ -59,6 +59,11 @@ struct st_page
   gint ops_since_last_backup;
   gchar do_autosave_backup;
 
+  /* list of 'symbol version changed' info messages, e.g.:
+   * "refdes: R1 (resistor.sym)"
+  */
+  GList* major_changed_refdes;
+
   GList *weak_refs; /* Weak references */
 };
 

--- a/liblepton/include/liblepton/geda_toplevel.h
+++ b/liblepton/include/liblepton/geda_toplevel.h
@@ -44,9 +44,6 @@ struct st_toplevel
      lepton-schematic */
   int show_hidden_text;
 
-  GList* major_changed_refdes;          /* A list of all refdes's that have */
-                                        /* major symbol version changes */
-
   /* backup variables */
   int auto_save_interval;
   gint auto_save_timeout;

--- a/liblepton/src/geda_component_object.c
+++ b/liblepton/src/geda_component_object.c
@@ -1132,13 +1132,29 @@ o_component_check_symversion (TOPLEVEL* toplevel, OBJECT* object)
                       "instantiated %2$.3f, %3$s)!"),
                     inside_value, outside_value, refdes);
 
-      /* add the refdes to the major_changed_refdes GList */
-      /* make sure refdes_copy is freed somewhere */
-      refdes_copy = g_strconcat ("refdes: ", refdes, " (",
-                                 object->component_basename,
-                                 ")", NULL);
-      toplevel->major_changed_refdes =
-        g_list_append(toplevel->major_changed_refdes, refdes_copy);
+
+      /* add the refdes and basename to the page's major_changed_refdes GList:
+      */
+      if (toplevel->page_current != NULL)
+      {
+        /* make sure refdes_copy is freed somewhere:
+        */
+        refdes_copy = g_strconcat ("refdes: ",
+                                   refdes,
+                                   " (",
+                                   object->component_basename,
+                                   ")",
+                                   NULL);
+
+        toplevel->page_current->major_changed_refdes =
+          g_list_append (toplevel->page_current->major_changed_refdes,
+                         refdes_copy);
+      }
+      else
+      {
+        g_warning (" >> o_complex_check_symversion(): !page_current");
+      }
+
 
       /* don't bother checking minor changes if there are major ones*/
       goto done;

--- a/liblepton/src/geda_component_object.c
+++ b/liblepton/src/geda_component_object.c
@@ -1013,7 +1013,7 @@ o_component_check_symversion (TOPLEVEL* toplevel, OBJECT* object)
 
   /* No need to check symversion if symbol is not found in libraries:
   */
-  GList* symlist = s_clib_search (object->complex_basename, CLIB_EXACT);
+  GList* symlist = s_clib_search (object->component_basename, CLIB_EXACT);
   if (symlist == NULL)
   {
     return;
@@ -1134,7 +1134,7 @@ o_component_check_symversion (TOPLEVEL* toplevel, OBJECT* object)
 
       /* add the refdes to the major_changed_refdes GList */
       /* make sure refdes_copy is freed somewhere */
-      refdes_copy = g_strconcat (refdes, " (",
+      refdes_copy = g_strconcat ("refdes: ", refdes, " (",
                                  object->component_basename,
                                  ")", NULL);
       toplevel->major_changed_refdes =

--- a/liblepton/src/geda_component_object.c
+++ b/liblepton/src/geda_component_object.c
@@ -1010,6 +1010,17 @@ o_component_check_symversion (TOPLEVEL* toplevel, OBJECT* object)
 		     object->type == OBJ_PLACEHOLDER));
   g_return_if_fail (object->component != NULL);
 
+
+  /* No need to check symversion if symbol is not found in libraries:
+  */
+  GList* symlist = s_clib_search (object->complex_basename, CLIB_EXACT);
+  if (symlist == NULL)
+  {
+    return;
+  }
+  g_list_free (symlist);
+
+
   /* first look on the inside for the symversion= attribute */
   inside = o_attrib_search_inherited_attribs_by_name (object, "symversion", 0);
 

--- a/liblepton/src/geda_component_object.c
+++ b/liblepton/src/geda_component_object.c
@@ -1031,7 +1031,7 @@ o_component_check_symversion (TOPLEVEL* toplevel, OBJECT* object)
   refdes = o_attrib_search_object_attribs_by_name(object, "refdes", 0);
   if (!refdes)
   {
-    refdes = g_strdup ("unknown");
+    refdes = g_strdup ("no refdes");
   }
 
   if (inside)
@@ -1041,12 +1041,15 @@ o_component_check_symversion (TOPLEVEL* toplevel, OBJECT* object)
     {
       if (inside)
       {
-        s_log_message(_("WARNING: Symbol version parse error on refdes %1$s:\n"
-                        "\tCould not parse symbol file symversion=%2$s"),
-                      refdes, inside);
+        s_log_message(_("WARNING: %s (%s): could not parse "
+                        "symversion (%s) in symbol file"),
+                      object->component_basename,
+                      refdes,
+                      inside);
       } else {
-        s_log_message(_("WARNING: Symbol version parse error on refdes %1$s:\n"
-                        "\tCould not parse symbol file symversion="),
+        s_log_message(_("WARNING: %s (%s): could not parse "
+                        "symversion in symbol file"),
+                      object->component_basename,
                       refdes);
       }
       goto done;
@@ -1061,9 +1064,11 @@ o_component_check_symversion (TOPLEVEL* toplevel, OBJECT* object)
     outside_value = strtod(outside, &err_check);
     if (outside_value == 0 && outside == err_check)
     {
-      s_log_message(_("WARNING: Symbol version parse error on refdes %1$s:\n"
-                      "\tCould not parse attached symversion=%2$s"),
-                    refdes, outside);
+      s_log_message(_("WARNING: %s (%s): could not parse "
+                      "attached symversion (%s)"),
+                    object->component_basename,
+                    refdes,
+                    outside);
       goto done;
     }
     outside_present = TRUE;
@@ -1086,10 +1091,10 @@ o_component_check_symversion (TOPLEVEL* toplevel, OBJECT* object)
   /* No symversion inside, but a version is outside, this is a weird case */
   if (!inside_present && outside_present)
   {
-    s_log_message(_("WARNING: Symbol version oddity on refdes %1$s:\n"
-                    "\tsymversion=%2$s attached to instantiated symbol, "
-                    "but no symversion= inside symbol file."),
-                  refdes, outside);
+    s_log_message(_("WARNING: %s (%s): symversion attached, "
+                    "but absent inside symbol file"),
+                  object->component_basename,
+                  refdes);
     goto done;
   }
 
@@ -1099,11 +1104,6 @@ o_component_check_symversion (TOPLEVEL* toplevel, OBJECT* object)
   if ((inside_present && !outside_present) ||
       ((inside_present && outside_present) && (inside_value > outside_value)))
   {
-
-    s_log_message(_("WARNING: Symbol version mismatch on refdes %1$s (%2$s):\n"
-                    "\tSymbol in library is newer than "
-                    "instantiated symbol."),
-                  refdes, object->component_basename);
 
     /* break up the version values into major.minor numbers */
     inside_major = floor(inside_value);
@@ -1128,10 +1128,13 @@ o_component_check_symversion (TOPLEVEL* toplevel, OBJECT* object)
     if (inside_major > outside_major)
     {
       char* refdes_copy;
-      s_log_message(_("\tMAJOR VERSION CHANGE (file %1$.3f, "
-                      "instantiated %2$.3f, %3$s)!"),
-                    inside_value, outside_value, refdes);
 
+      s_log_message(_("WARNING: %s (%s): MAJOR symversion change "
+                      "(attached: %.3f < library: %.3f)"),
+                    object->component_basename,
+                    refdes,
+                    outside_value,
+                    inside_value);
 
       /* add the refdes and basename to the page's major_changed_refdes GList:
       */
@@ -1162,9 +1165,12 @@ o_component_check_symversion (TOPLEVEL* toplevel, OBJECT* object)
 
     if (inside_minor > outside_minor)
     {
-      s_log_message(_("\tMinor version change (file %1$.3f, "
-                      "instantiated %2$.3f)"),
-                    inside_value, outside_value);
+      s_log_message(_("WARNING: %s (%s): minor symversion change "
+                      "(attached: %.3f < library: %.3f)"),
+                    object->component_basename,
+                    refdes,
+                    outside_value,
+                    inside_value);
     }
 
     goto done;
@@ -1173,10 +1179,12 @@ o_component_check_symversion (TOPLEVEL* toplevel, OBJECT* object)
   /* outside value is greater than inside value, this is weird case */
   if ((inside_present && outside_present) && (outside_value > inside_value))
   {
-    s_log_message(_("WARNING: Symbol version oddity on refdes %1$s:\n"
-                    "\tInstantiated symbol is newer than "
-                    "symbol in library."),
-                  refdes);
+    s_log_message(_("WARNING: %s (%s): symbol is newer "
+                    "than symbol in library (%.3f > %.3f)"),
+                  object->component_basename,
+                  refdes,
+                  outside_value,
+                  inside_value);
     goto done;
   }
 

--- a/liblepton/src/geda_page.c
+++ b/liblepton/src/geda_page.c
@@ -150,6 +150,8 @@ PAGE *s_page_new (TOPLEVEL *toplevel, const gchar *filename)
   page->saved_since_first_loaded = 0;
   page->do_autosave_backup = 0;
 
+  page->major_changed_refdes = NULL;
+
   /* now append page to page list of toplevel */
   geda_list_add( toplevel->pages, page );
   page->toplevel = toplevel;
@@ -245,6 +247,13 @@ void s_page_delete (TOPLEVEL *toplevel, PAGE *page)
   geda_list_remove( toplevel->pages, page );
 
   page->weak_refs = s_weakref_notify (page, page->weak_refs);
+
+
+  if (page->major_changed_refdes)
+  {
+    g_list_free_full (page->major_changed_refdes, &g_free);
+  }
+
 
   g_free (page);
 

--- a/liblepton/src/geda_toplevel.c
+++ b/liblepton/src/geda_toplevel.c
@@ -64,8 +64,6 @@ TOPLEVEL *s_toplevel_new (void)
 
   toplevel->show_hidden_text = 0;
 
-  toplevel->major_changed_refdes = NULL;
-
   /* The following is an attempt at getting (deterministic) defaults */
   /* for the following variables */
   toplevel->change_notify_funcs = NULL;

--- a/liblepton/src/o_attrib.c
+++ b/liblepton/src/o_attrib.c
@@ -28,7 +28,7 @@
  *
  *  Attributes are attached to OBJECTs (st_object). Each attribute has
  *  a reference to the object it is attached to. Each object that has
- *  attributes has a list of pionters to its attributes.
+ *  attributes has a list of pointers to its attributes.
  *
  *  \image html o_attrib_overview.png
  *  \image latex o_attrib_overview.pdf "attribute overview" width=14cm
@@ -52,12 +52,9 @@
 
 
 /*! \brief Add an attribute to an existing attribute list.
- *  \par Function Description
- *  Add an attribute to an existing attribute list.
  *
  *  \param [in]  object     The OBJECT we're adding the attribute to.
  *  \param [in]  item       The item you want to add as an attribute.
- *  \return nothing.
  */
 void
 o_attrib_add (OBJECT *object, OBJECT *item)
@@ -69,8 +66,6 @@ o_attrib_add (OBJECT *object, OBJECT *item)
 
 
 /*! \brief Attach existing attribute to an object.
- *  \par Function Description
- *  Attach existing attribute to an object.
  *
  *  \param [in]  attrib       The attribute to be added.
  *  \param [out] object       The object where you want to add item as an attribute.
@@ -114,8 +109,6 @@ o_attrib_attach (OBJECT *attrib,
 
 
 /*! \brief Attach list of existing attributes to an object.
- *  \par Function Description
- *  Attach list of existing attributes to an object.
  *
  *  \param [in]  attr_list  The list of attributes to be added.
  *  \param [out] object     The object where you want to add item as an attribute.
@@ -133,11 +126,9 @@ o_attrib_attach_list (GList *attr_list,
 }
 
 
-/*! \brief Detach all attribute items in a list.
- *  \par Function Description
- *  Detach all attributes from an object.
+/*! \brief Detach all attributes from an object.
  *
- *  \param [in,out] object    The object whos attributes to detach.
+ *  \param [in,out] object    The object whose attributes to detach.
  */
 void
 o_attrib_detach_all (OBJECT *object)
@@ -158,8 +149,6 @@ o_attrib_detach_all (OBJECT *object)
 }
 
 /*! \brief Print all attributes to a Postscript document.
- *  \par Function Description
- *  Print all attributes to a Postscript document.
  *
  *  \param [in] attributes  List of attributes to print.
  */
@@ -201,9 +190,7 @@ o_attrib_remove (GList **list,
   *list = g_list_remove (*list, remove);
 }
 
-/*! \brief Read attributes from a buffer.
- *  \par Function Description
- *  Read attributes from a TextBuffer.
+/*! \brief Read attributes from a TextBuffer.
  *
  *  \param [in]  toplevel               The TOPLEVEL object.
  *  \param [in]  object_to_get_attribs  Object which gets these attribs.
@@ -322,6 +309,7 @@ error:
 
 
 /*! \brief Get name and value from an attribute 'name=value' string.
+ *
  *  \par Function Description
  *  This function parses the character string \a string expected to be
  *  an attribute string of the form 'name=value'.
@@ -380,10 +368,11 @@ o_attrib_string_get_name_value (const gchar *string, gchar **name_ptr, gchar **v
 
 
 /*! \brief Get name and value from an attribute OBJECT
+ *
  *  \par Function Description
  *  See o_attrib_string_get_name_value() for more details
  *
- *  \param [in]  attrib     The attribute OBJECT whos name/value to return.
+ *  \param [in]  attrib     The attribute OBJECT whose name/value to return.
  *  \param [out] name_ptr   The return location for the name, or NULL.
  *  \param [out] value_ptr  The return location for the value, or NULL.
  *  \return TRUE on success, FALSE otherwise.
@@ -400,6 +389,7 @@ o_attrib_get_name_value (const OBJECT *attrib,
 }
 
 /*! \brief Get the name from an attribute
+ *
  * \par Function Description
  * Get an interned string for the attribute name of the attribute text
  * object \a attrib.  If \a attrib is an invalid attribute, returns
@@ -417,14 +407,11 @@ o_attrib_get_name (const OBJECT *attrib)
 }
 
 /*! \brief Find all floating attributes in the given object list.
- *  \par Function Description
- *  Find all floating attributes in the given object list.
  *
  *  \param [in] list  GList of OBJECTs to search for floating attributes.
  *  \return GList of floating attributes from the input list
  *
- *  \warning
- *  Caller must g_list_free returned list.
+ *  Caller must g_list_free() the returned list.
  */
 GList *o_attrib_find_floating_attribs (const GList *list)
 {
@@ -453,12 +440,12 @@ GList *o_attrib_find_floating_attribs (const GList *list)
  *  \par Function Description
  *  Search for attribute by name.
  *
- *  Counter is the n'th occurance of the attribute, and starts searching
- *  from zero.  Zero is the first occurance of an attribute.
+ *  Counter is the n'th occurrence of the attribute, and starts searching
+ *  from zero.  Zero is the first occurrence of an attribute.
  *
  *  \param [in] list     GList of attributes to search.
  *  \param [in] name     Character string with attribute name to search for.
- *  \param [in] count    Which occurance to return.
+ *  \param [in] count    Which occurrence to return.
  *  \return The n'th attribute object in the given list with the given name.
  */
 OBJECT *o_attrib_find_attrib_by_name (const GList *list,
@@ -488,12 +475,12 @@ OBJECT *o_attrib_find_attrib_by_name (const GList *list,
  *  \par Function Description
  *  Search for attribute by name.
  *
- *  Counter is the n'th occurance of the attribute, and starts searching
- *  from zero.  Zero is the first occurance of an attribute.
+ *  Counter is the n'th occurrence of the attribute, and starts searching
+ *  from zero.  Zero is the first occurrence of an attribute.
  *
  *  \param [in] list     GList of attributes to search.
  *  \param [in] name     Character string with attribute name to search for.
- *  \param [in] counter  Which occurance to return.
+ *  \param [in] counter  Which occurrence to return.
  *  \return Character string with attribute value, NULL otherwise.
  */
 static char *o_attrib_search_attrib_list_by_name (const GList *list,
@@ -516,12 +503,12 @@ static char *o_attrib_search_attrib_list_by_name (const GList *list,
  *  \par Function Description
  *  Search for attribute by name.
  *
- *  Counter is the n'th occurance of the attribute, and starts searching
- *  from zero.  Zero is the first occurance of an attribute.
+ *  Counter is the n'th occurrence of the attribute, and starts searching
+ *  from zero.  Zero is the first occurrence of an attribute.
  *
  *  \param [in] list     GList of OBJECTs to search for floating attributes.
  *  \param [in] name     Character string with attribute name to search for.
- *  \param [in] counter  Which occurance to return.
+ *  \param [in] counter  Which occurrence to return.
  *  \return Character string with attribute value, NULL otherwise.
  *
  *  \warning
@@ -546,12 +533,12 @@ char *o_attrib_search_floating_attribs_by_name (const GList *list,
  *  \par Function Description
  *  Search for attribute by name.
  *
- *  Counter is the n'th occurance of the attribute, and starts searching
- *  from zero.  Zero is the first occurance of an attribute.
+ *  Counter is the n'th occurrence of the attribute, and starts searching
+ *  from zero.  Zero is the first occurrence of an attribute.
  *
- *  \param [in] object   The OBJECT whos attached attributes to search.
+ *  \param [in] object   The OBJECT whose attached attributes to search.
  *  \param [in] name     Character string with attribute name to search for.
- *  \param [in] counter  Which occurance to return.
+ *  \param [in] counter  Which occurrence to return.
  *  \return Character string with attribute value, NULL otherwise.
  *
  *  \warning
@@ -569,12 +556,12 @@ char *o_attrib_search_attached_attribs_by_name (OBJECT *object,
  *  \par Function Description
  *  Search for attribute by name.
  *
- *  Counter is the n'th occurance of the attribute, and starts searching
- *  from zero.  Zero is the first occurance of an attribute.
+ *  Counter is the n'th occurrence of the attribute, and starts searching
+ *  from zero.  Zero is the first occurrence of an attribute.
  *
- *  \param [in] object   The OBJECT whos inherited attributes to search.
+ *  \param [in] object   The OBJECT whose inherited attributes to search.
  *  \param [in] name     Character string with attribute name to search for.
- *  \param [in] counter  Which occurance to return.
+ *  \param [in] counter  Which occurrence to return.
  *  \return Character string with attribute value, NULL otherwise.
  *
  *  \warning
@@ -591,20 +578,19 @@ char *o_attrib_search_inherited_attribs_by_name (OBJECT *object,
 }
 
 
-/*! \brief Search attributes of object by name.
- *  \par Function Description
- *  Search for attribute by name.
+/*! \brief Search attached and inherited attributes of object by name.
  *
- *  Counter is the n'th occurance of the attribute, and starts searching
- *  from zero.  Zero is the first occurance of an attribute.
+ *  \par Function Description
+ *
+ *  Counter is the n'th occurrence of the attribute, and starts searching
+ *  from zero.  Zero is the first occurrence of an attribute.
+ *
+ *  Caller must g_free() the returned character string.
  *
  *  \param [in] object   OBJECT who's attributes to search.
  *  \param [in] name     Character string with attribute name to search for.
- *  \param [in] counter  Which occurance to return.
- *  \return Character string with attribute value, NULL otherwise.
- *
- *  \warning
- *  Caller must g_free returned character string.
+ *  \param [in] counter  Which occurrence to return.
+ *  \return              Attribute value, NULL if not found.
  */
 char *o_attrib_search_object_attribs_by_name (OBJECT *object,
                                               const char *name,
@@ -621,19 +607,19 @@ char *o_attrib_search_object_attribs_by_name (OBJECT *object,
 }
 
 
-/*! \brief Get all attached attributes of the specified OBJECT.
- *  \par Function Description
- *  This function returns all attributes of the specified object.
+/*! \brief Get object's attached and inherited attributes.
  *
- *  The returned GList should be freed using the #g_list_free().
+ *  \par Function Description
  *
  *  This function aggregates the attached and inherited attributes
- *  belonging to a given OBJECT. (inherited attributes are those
- *  which live as toplevel un-attached attributes inside in a
- *  component OBJECT's prim_objs).
+ *  belonging to a given OBJECT into one GList and returns it.
+ *  Inherited attributes are those which live as toplevel un-attached
+ *  attributes inside in a component OBJECT's prim_objs.
  *
- *  \param [in] object       OBJECT whos attributes to return.
- *  \return A GList of attributes belinging to the passed object.
+ *  Caller must g_list_free() the returned GList.
+ *
+ *  \param [in] object  OBJECT whose attributes to return.
+ *  \return             A GList of attached and inherited attributes.
  */
 GList * o_attrib_return_attribs (OBJECT *object)
 {
@@ -675,13 +661,14 @@ GList * o_attrib_return_attribs (OBJECT *object)
 }
 
 
-/*! \brief Query whether a given attribute OBJECT is "inherited"
+/*! \brief Query whether a given attribute OBJECT is "inherited".
+ *
  *  \par Function Description
  *  This function returns TRUE if the given attribute OBJECT is a
  *  toplevel un-attached attribute inside a component's prim_objs.
  *
  *  \param [in] attrib       OBJECT who's status to query.
- *  \return TRUE if the given attribute is inside a symbol
+ *  \return TRUE if the attribute is inherited, FALSE otherwise.
  */
 int o_attrib_is_inherited (const OBJECT *attrib)
 {
@@ -689,9 +676,9 @@ int o_attrib_is_inherited (const OBJECT *attrib)
           attrib->parent != NULL);
 }
 
-/*! \brief Query whether an object is an attribute
- * \par Function Description
- * Return #TRUE if \a obj is a text attribute, and #FALSE otherwise.
+/*! \brief Query whether an object is an attribute.
+ *
+ *  \return  TRUE if \a obj is an attribute, FALSE otherwise.
  */
 gboolean
 o_attrib_is_attrib (const OBJECT *obj)

--- a/schematic/src/lepton-schematic.c
+++ b/schematic/src/lepton-schematic.c
@@ -335,10 +335,6 @@ void main_prog(void *closure, int argc, char *argv[])
     x_widgets_show_log (w_current);
   }
 
-  /* if there were any symbols which had major changes, put up an error */
-  /* dialog box */
-  major_changed_dialog(w_current);
-
   scm_dynwind_end ();
 
   /* enter main loop */

--- a/schematic/src/x_dialog.c
+++ b/schematic/src/x_dialog.c
@@ -241,15 +241,14 @@ major_changed_dialog (GschemToplevel* w_current)
                         -1);
   }
 
-  /*! \todo this would be much easier using
-   * gtk_message_dialog_get_message_area(). */
-  dialog = GTK_WIDGET (g_object_new (GTK_TYPE_DIALOG,
-                                     /* GtkContainer */
-                                     "border-width", 5,
-                                     NULL));
-  gtk_dialog_add_buttons (GTK_DIALOG (dialog),
-                          GTK_STOCK_OK, GTK_RESPONSE_OK,
-                          NULL);
+
+  dialog = gtk_dialog_new_with_buttons(
+    NULL,
+    GTK_WINDOW (w_current->main_window),
+    (GtkDialogFlags) GTK_DIALOG_DESTROY_WITH_PARENT,
+    GTK_STOCK_OK, GTK_RESPONSE_OK,
+    NULL);
+
   content_area = gtk_dialog_get_content_area (GTK_DIALOG (dialog));
   g_object_set (content_area,
                 /* GtkBox */
@@ -333,14 +332,20 @@ major_changed_dialog (GschemToplevel* w_current)
                                                      "text", 0,
                                                      NULL);
   gtk_tree_view_append_column (GTK_TREE_VIEW (tree_view), column);
+
+  g_signal_connect (G_OBJECT (dialog),
+                    "response",
+                    G_CALLBACK (&gtk_widget_hide),
+                    NULL);
+
+  g_signal_connect (G_OBJECT (dialog),
+                    "delete-event",
+                    G_CALLBACK (&gtk_widget_hide_on_delete),
+                    NULL);
+
   gtk_widget_show_all (dialog);
 
-  gtk_window_set_transient_for (GTK_WINDOW (dialog),
-                                GTK_WINDOW (w_current->main_window));
-
-  gtk_dialog_run (GTK_DIALOG (dialog));
-  gtk_widget_destroy (dialog);
-}
+} /* major_changed_dialog() */
 
 /*********** End of major symbol changed dialog box *******/
 

--- a/schematic/src/x_dialog.c
+++ b/schematic/src/x_dialog.c
@@ -208,10 +208,7 @@ int text_view_calculate_real_tab_width(GtkTextView *textview, int tab_size)
 
 /*********** Start of major symbol changed dialog box *******/
 
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
+/*! \brief Show the "Symbol version changes" dialog box.
  */
 void
 major_changed_dialog (GschemToplevel* w_current)
@@ -225,6 +222,8 @@ major_changed_dialog (GschemToplevel* w_current)
   char* tmp;
   GList *curr;
   PAGE* page = w_current->toplevel->page_current;
+
+  g_return_if_fail (page != NULL);
 
   if (page->major_changed_refdes == NULL)
   {
@@ -248,7 +247,7 @@ major_changed_dialog (GschemToplevel* w_current)
 
 
   dialog = gtk_dialog_new_with_buttons(
-    NULL,
+    _("Symbol version changes"),
     GTK_WINDOW (w_current->main_window),
     (GtkDialogFlags) GTK_DIALOG_DESTROY_WITH_PARENT,
     GTK_STOCK_OK, GTK_RESPONSE_OK,

--- a/schematic/src/x_dialog.c
+++ b/schematic/src/x_dialog.c
@@ -283,7 +283,7 @@ major_changed_dialog (GschemToplevel* w_current)
                                    "homogeneous", FALSE,
                                    "spacing", 12,
                                    NULL));
-  gtk_box_pack_start (GTK_BOX (hbox), vbox, FALSE, FALSE, 0);
+  gtk_box_pack_start (GTK_BOX (hbox), vbox, TRUE, TRUE, 0);
   /* Primary label */
   tmp = g_strconcat ("<big><b>",
                      _("Major symbol version changes detected."),

--- a/schematic/src/x_dialog.c
+++ b/schematic/src/x_dialog.c
@@ -283,7 +283,7 @@ major_changed_dialog (GschemToplevel* w_current)
   gtk_box_pack_start (GTK_BOX (hbox), vbox, FALSE, FALSE, 0);
   /* Primary label */
   tmp = g_strconcat ("<big><b>",
-                     _("Major symbol changes detected."),
+                     _("Major symbol version changes detected."),
                      "</b></big>", NULL);
   label = GTK_WIDGET (g_object_new (GTK_TYPE_LABEL,
                                     /* GtkMisc */
@@ -307,8 +307,9 @@ major_changed_dialog (GschemToplevel* w_current)
                                     "wrap", TRUE,
                                     "use-markup", TRUE,
                                     "label",
-                                    _("Changes have occurred to the symbols shown below.\n\n"
-                                      "Be sure to verify each of these symbols."),
+                                    _("Changes have occurred to the symbols shown\n"
+                                      "below, be sure to verify each of these symbols.\n"
+                                      "Consult lepton-schematic log for details."),
                                     NULL));
   gtk_box_pack_start (GTK_BOX (vbox), label, FALSE, FALSE, 0);
   /* List of changed symbols */

--- a/schematic/src/x_dialog.c
+++ b/schematic/src/x_dialog.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2015 gEDA Contributors
- * Copyright (C) 2017-2019 Lepton EDA Contributors
+ * Copyright (C) 2017-2020 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -225,13 +225,17 @@ major_changed_dialog (GschemToplevel* w_current)
   char* tmp;
   GList *curr;
 
-  if (w_current->toplevel->major_changed_refdes == NULL) return;
+  if (w_current->toplevel->page_current->major_changed_refdes == NULL)
+  {
+    return;
+  }
 
   list_store = gtk_list_store_new (1, G_TYPE_STRING);
 
-  for (curr = w_current->toplevel->major_changed_refdes;
+  for (curr = w_current->toplevel->page_current->major_changed_refdes;
        curr != NULL;
-       curr = g_list_next (curr)) {
+       curr = g_list_next (curr))
+  {
     char *value = (char *) curr->data;
     GtkTreeIter iter;
 

--- a/schematic/src/x_dialog.c
+++ b/schematic/src/x_dialog.c
@@ -224,15 +224,16 @@ major_changed_dialog (GschemToplevel* w_current)
   GtkTreeViewColumn *column;
   char* tmp;
   GList *curr;
+  PAGE* page = w_current->toplevel->page_current;
 
-  if (w_current->toplevel->page_current->major_changed_refdes == NULL)
+  if (page->major_changed_refdes == NULL)
   {
     return;
   }
 
   list_store = gtk_list_store_new (1, G_TYPE_STRING);
 
-  for (curr = w_current->toplevel->page_current->major_changed_refdes;
+  for (curr = page->major_changed_refdes;
        curr != NULL;
        curr = g_list_next (curr))
   {
@@ -300,6 +301,20 @@ major_changed_dialog (GschemToplevel* w_current)
                                     NULL));
   gtk_box_pack_start (GTK_BOX (vbox), label, FALSE, FALSE, 0);
   g_free (tmp);
+
+  /* label with page basename:
+  */
+  const gchar* fname = s_page_get_filename (page);
+  gchar* bname = g_path_get_basename (fname);
+  gchar* text = g_strdup_printf(_("Schematic: %s"), bname);
+  g_free (bname);
+
+  GtkWidget* label_page_bname = gtk_label_new (text);
+  gtk_misc_set_alignment (GTK_MISC (label_page_bname), 0.0, 0.0);
+  gtk_box_pack_start (GTK_BOX (vbox), label_page_bname, FALSE, FALSE, 0);
+
+  g_free (text);
+
   /* Secondary label */
   label = GTK_WIDGET (g_object_new (GTK_TYPE_LABEL,
                                     /* GtkMisc */

--- a/schematic/src/x_window.c
+++ b/schematic/src/x_window.c
@@ -1492,14 +1492,26 @@ create_notebook_bottom (GschemToplevel* w_current)
 PAGE*
 x_window_open_page (GschemToplevel* w_current, const gchar* filename)
 {
+  PAGE* page = NULL;
+
   if (x_tabs_enabled())
   {
-    return x_tabs_page_open (w_current, filename);
+    page = x_tabs_page_open (w_current, filename);
   }
   else
   {
-    return x_window_open_page_impl (w_current, filename);
+    page = x_window_open_page_impl (w_current, filename);
   }
+
+  if (filename != NULL && page != NULL)
+  {
+    /* check for symbol version changes, display
+     * an error dialog box, if necessary:
+    */
+    major_changed_dialog (w_current);
+  }
+
+  return page;
 }
 
 

--- a/schematic/src/x_window.c
+++ b/schematic/src/x_window.c
@@ -569,7 +569,6 @@ void x_window_create_main(GschemToplevel *w_current)
  */
 void x_window_close(GschemToplevel *w_current)
 {
-  TOPLEVEL *toplevel = gschem_toplevel_get_toplevel (w_current);
   gboolean last_window = FALSE;
 
   /* If we're closing whilst inside an action, re-wind the
@@ -623,17 +622,6 @@ void x_window_close(GschemToplevel *w_current)
   if (last_window)
   {
     geometry_save (w_current);
-  }
-
-  if (toplevel->major_changed_refdes) {
-    GList* current = toplevel->major_changed_refdes;
-    while (current)
-    {
-      /* printf("yeah freeing: %s\n", (char*) current->data); */
-      g_free(current->data);
-      current = g_list_next(current);
-    }
-    g_list_free(toplevel->major_changed_refdes);
   }
 
   /* stuff that has to be done before we free w_current */


### PR DESCRIPTION
- Do not perform `symversion` check for missing symbols,
  it's pointless and just floods the log with erroneous
  messages.
- Check for symbol version changes when opening a page.
  Previous behavior was to check just the first page
  passed on the `lepton-schematic` command line.
- Store version changes data (`major_changed_refdes`) in the
  page structure, not globally (i.e. in `st_toplevel`).
- Improve the "Major symbol changes" dialog:
  - Make it non-modal
  - Add title
  - Make the list box resizable in both directions
  - Show schematic file name
  - Indicate that changes are related to symbol versions
  - Offer to consult the log
  - Prefix lines in the list with "refdes: " string to
    avoid confusion if symbols have no "refdes"
    attributes (i.e. show "refdes: unknown" rather
    than just "unknown"):

![old_dlg](https://user-images.githubusercontent.com/26083750/80922702-57f7d480-8d6e-11ea-9f1c-ea7e0a0c64e9.png)
=>
![new_dlg_2](https://user-images.githubusercontent.com/26083750/80959810-18c19600-8df7-11ea-85a7-5770e9f7b1d1.png)

- Make `symversion`-related log messages more compact, more
  human- and parser-friendly. Here's an example schematic, old
and new log messages for comparison:

![symversion-test-dmn](https://user-images.githubusercontent.com/26083750/80922732-7cec4780-8d6e-11ea-9fc1-b66d404c8c2d.png)

![old_log](https://user-images.githubusercontent.com/26083750/80922736-82e22880-8d6e-11ea-9138-8503148118b3.png)
=>
![new_log_2](https://user-images.githubusercontent.com/26083750/80959831-237c2b00-8df7-11ea-876b-2bc2df5edba7.png)

[symversion-test-dmn.tar.gz](https://github.com/lepton-eda/lepton-eda/files/4571415/symversion-test-dmn.tar.gz)

