### PR TITLE
lepton-schematic widgets as top-level windows

### DIFF
--- a/schematic/include/gschem_find_text_state.h
+++ b/schematic/include/gschem_find_text_state.h
@@ -22,11 +22,15 @@
  * \brief
  */
 
-#define GSCHEM_TYPE_FIND_TEXT_STATE           (gschem_find_text_state_get_type())
-#define GSCHEM_FIND_TEXT_STATE(obj)           (G_TYPE_CHECK_INSTANCE_CAST ((obj), GSCHEM_TYPE_FIND_TEXT_STATE, GschemFindTextState))
-#define GSCHEM_FIND_TEXT_STATE_CLASS(klass)   (G_TYPE_CHECK_CLASS_CAST ((klass),  GSCHEM_TYPE_FIND_TEXT_STATE, GschemFindTextStateClass))
-#define GSCHEM_IS_FIND_TEXT_STATE(obj)        (G_TYPE_CHECK_INSTANCE_TYPE ((obj), GSCHEM_TYPE_FIND_TEXT_STATE))
-#define GSCHEM_FIND_TEXT_STATE_GET_CLASS(obj) (G_TYPE_INSTANCE_GET_CLASS ((obj), GSCHEM_TYPE_FIND_TEXT_STATE, GschemFindTextStateClass))
+#ifndef GSCHEM_FIND_TEXT_STATE_H_
+#define GSCHEM_FIND_TEXT_STATE_H_
+
+
+#define GSCHEM_FIND_TEXT_STATE_TYPE           (gschem_find_text_state_get_type())
+#define GSCHEM_FIND_TEXT_STATE(obj)           (G_TYPE_CHECK_INSTANCE_CAST ((obj), GSCHEM_FIND_TEXT_STATE_TYPE, GschemFindTextState))
+#define GSCHEM_FIND_TEXT_STATE_CLASS(klass)   (G_TYPE_CHECK_CLASS_CAST ((klass),  GSCHEM_FIND_TEXT_STATE_TYPE, GschemFindTextStateClass))
+#define IS_GSCHEM_FIND_TEXT_STATE(obj)        (G_TYPE_CHECK_INSTANCE_TYPE ((obj), GSCHEM_FIND_TEXT_STATE_TYPE))
+#define GSCHEM_FIND_TEXT_STATE_GET_CLASS(obj) (G_TYPE_INSTANCE_GET_CLASS ((obj), GSCHEM_FIND_TEXT_STATE_TYPE, GschemFindTextStateClass))
 
 
 enum
@@ -62,3 +66,6 @@ gschem_find_text_state_get_type ();
 
 GtkWidget*
 gschem_find_text_state_new ();
+
+
+#endif /* GSCHEM_FIND_TEXT_STATE_H_ */

--- a/schematic/include/prototype.h
+++ b/schematic/include/prototype.h
@@ -698,6 +698,7 @@ void x_widgets_show_find_text_state (GschemToplevel* w_current);
 void x_widgets_show_color_edit (GschemToplevel* w_current);
 void x_widgets_show_font_select (GschemToplevel* w_current);
 void x_widgets_show_page_select (GschemToplevel* w_current);
+void x_widgets_destroy_dialogs (GschemToplevel* w_current);
 
 /* x_tabs.c */
 gboolean x_tabs_enabled();

--- a/schematic/src/x_widgets.c
+++ b/schematic/src/x_widgets.c
@@ -75,26 +75,36 @@ x_widgets_use_toplevel_windows()
 
 
 
-/*! \par Function Description
+/*! \brief Initialize widgets management
  *
- * Initialize widgets management.
+ * \par Function Description
+ *
+ * Read widgets configuration.
  * Call this before any other functions from this file.
- * This function reads the value of "use-docks" configuration
- * setting in "schematic.gui" group, which determines
- * if widgets will be shown in docks (if true) or as
- * dialog boxes (if false).
  *
- * Configuration setting description:
+ * Configuration settings for widgets:
+ *
  * key:   use-docks
  * group: schematic.gui
  * type:  boolean
  * default value: false
+ * description: whether to use docking GUI
  *
+ * key:   use-toplevel-windows
+ * group: schematic.gui
+ * type:  boolean
+ * default value: false
+ * description: when docking GUI is off, whether to display
+ *              widgets as toplevel windows (true) or
+ *              dialogs (false)
  */
 void x_widgets_init()
 {
   cfg_read_bool ("schematic.gui", "use-docks",
                  FALSE, &g_x_widgets_use_docks);
+
+  cfg_read_bool ("schematic.gui", "use-toplevel-windows",
+                 FALSE, &g_x_widgets_use_toplevel_windows);
 }
 
 

--- a/schematic/src/x_widgets.c
+++ b/schematic/src/x_widgets.c
@@ -41,6 +41,9 @@
 static gboolean
 g_x_widgets_use_docks = FALSE;
 
+static gboolean
+g_x_widgets_use_toplevel_windows = FALSE;
+
 
 
 static void
@@ -59,6 +62,14 @@ x_widgets_show_in_dialog (GschemToplevel* w_current,
 gboolean x_widgets_use_docks()
 {
   return g_x_widgets_use_docks;
+}
+
+
+
+static gboolean
+x_widgets_use_toplevel_windows()
+{
+  return !x_widgets_use_docks() && g_x_widgets_use_toplevel_windows;
 }
 
 
@@ -335,6 +346,16 @@ x_widgets_show_in_dialog (GschemToplevel* w_current,
     w_current,
     GTK_STOCK_CLOSE, GTK_RESPONSE_NONE,
     NULL);
+
+
+
+  if (x_widgets_use_toplevel_windows())
+  {
+    gtk_window_set_transient_for (GTK_WINDOW (dlg), NULL);
+    gtk_window_set_type_hint (GTK_WINDOW (dlg), GDK_WINDOW_TYPE_HINT_NORMAL);
+  }
+
+
 
   g_signal_connect (G_OBJECT (dlg),
                     "response",

--- a/schematic/src/x_widgets.c
+++ b/schematic/src/x_widgets.c
@@ -1,5 +1,6 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 2017-2019 dmn <graahnul.grom@gmail.com>
+ * Copyright (C) 2020 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -347,15 +348,11 @@ x_widgets_show_in_dialog (GschemToplevel* w_current,
     GTK_STOCK_CLOSE, GTK_RESPONSE_NONE,
     NULL);
 
-
-
   if (x_widgets_use_toplevel_windows())
   {
     gtk_window_set_transient_for (GTK_WINDOW (dlg), NULL);
     gtk_window_set_type_hint (GTK_WINDOW (dlg), GDK_WINDOW_TYPE_HINT_NORMAL);
   }
-
-
 
   g_signal_connect (G_OBJECT (dlg),
                     "response",
@@ -376,3 +373,68 @@ x_widgets_show_in_dialog (GschemToplevel* w_current,
   *dialog = dlg;
 
 } /* x_widgets_show_in_dialog() */
+
+
+
+/*! \brief Destroy dialogs created in "toplevel" mode
+ *
+ *  \param [in] w_current  The toplevel environment.
+ */
+void
+x_widgets_destroy_dialogs (GschemToplevel* w_current)
+{
+  g_return_if_fail (w_current != NULL);
+
+  if (!x_widgets_use_toplevel_windows())
+    return;
+
+  if (w_current->options_widget_dialog != NULL)
+  {
+    gtk_widget_destroy (w_current->options_widget_dialog);
+    w_current->options_widget_dialog = NULL;
+  }
+
+  if (w_current->text_properties_dialog != NULL)
+  {
+    gtk_widget_destroy (w_current->text_properties_dialog);
+    w_current->text_properties_dialog = NULL;
+  }
+
+  if (w_current->object_properties_dialog != NULL)
+  {
+    gtk_widget_destroy (w_current->object_properties_dialog);
+    w_current->object_properties_dialog = NULL;
+  }
+
+  if (w_current->log_widget_dialog != NULL)
+  {
+    gtk_widget_destroy (w_current->log_widget_dialog);
+    w_current->log_widget_dialog = NULL;
+  }
+
+  if (w_current->find_text_state_dialog != NULL)
+  {
+    gtk_widget_destroy (w_current->find_text_state_dialog);
+    w_current->find_text_state_dialog = NULL;
+  }
+
+  if (w_current->color_edit_dialog != NULL)
+  {
+    gtk_widget_destroy (w_current->color_edit_dialog);
+    w_current->color_edit_dialog = NULL;
+  }
+
+  if (w_current->font_select_dialog != NULL)
+  {
+    gtk_widget_destroy (w_current->font_select_dialog);
+    w_current->font_select_dialog = NULL;
+  }
+
+  if (w_current->page_select_dialog != NULL)
+  {
+    gtk_widget_destroy (w_current->page_select_dialog);
+    w_current->page_select_dialog = NULL;
+  }
+
+} /* x_widgets_destroy_dialogs */
+

--- a/schematic/src/x_widgets.c
+++ b/schematic/src/x_widgets.c
@@ -22,18 +22,22 @@
  *
  * \brief Widgets management
  *
- * Now there are 5 of them:
- * - in right dock:
- *   - obj props
- *   - txt props
- *   - options
- * - in bottom dock:
- *   - find text results
- *   - log
+ * lepton-schematic widgets:
+ *
+ * - object properties    (GschemObjectPropertiesWidget)  [right dock]
+ * - text properties      (GschemTextPropertiesWidget)    [right dock]
+ * - options              (GschemOptionsWidget)           [right dock]
+ *
+ * - find text results    (GschemFindTextState)           [bottom dock]
+ * - log                  (GschemLogWidget)               [bottom dock]
+ *
+ * - page manager         (PageSelectWidget)
+ * - font selector        (FontSelectWidget)
+ * - color scheme editor  (ColorEditWidget)
+ *
  */
 
 #include "config.h"
-
 #include "gschem.h"
 
 
@@ -435,5 +439,5 @@ x_widgets_destroy_dialogs (GschemToplevel* w_current)
     w_current->page_select_dialog = NULL;
   }
 
-} /* x_widgets_destroy_dialogs */
+} /* x_widgets_destroy_dialogs() */
 

--- a/schematic/src/x_widgets.c
+++ b/schematic/src/x_widgets.c
@@ -93,26 +93,8 @@ x_widgets_use_toplevel_windows()
  */
 void x_widgets_init()
 {
-  gchar* cwd = g_get_current_dir();
-
-  EdaConfig* cfg = eda_config_get_context_for_path (cwd);
-
-  g_free (cwd);
-
-  if (cfg != NULL)
-  {
-    GError* err = NULL;
-    gboolean val = eda_config_get_boolean (cfg,
-                                           "schematic.gui",
-                                           "use-docks",
-                                           &err);
-    if (err == NULL)
-    {
-      g_x_widgets_use_docks = val;
-    }
-
-    g_clear_error (&err);
-  }
+  cfg_read_bool ("schematic.gui", "use-docks",
+                 FALSE, &g_x_widgets_use_docks);
 }
 
 

--- a/schematic/src/x_widgets.c
+++ b/schematic/src/x_widgets.c
@@ -100,11 +100,18 @@ x_widgets_use_toplevel_windows()
  */
 void x_widgets_init()
 {
-  cfg_read_bool ("schematic.gui", "use-docks",
-                 FALSE, &g_x_widgets_use_docks);
+  static gsize initialized = 0;
 
-  cfg_read_bool ("schematic.gui", "use-toplevel-windows",
-                 FALSE, &g_x_widgets_use_toplevel_windows);
+  if (g_once_init_enter (&initialized))
+  {
+    cfg_read_bool ("schematic.gui", "use-docks",
+                   FALSE, &g_x_widgets_use_docks);
+
+    cfg_read_bool ("schematic.gui", "use-toplevel-windows",
+                   FALSE, &g_x_widgets_use_toplevel_windows);
+
+    g_once_init_leave (&initialized, 1);
+  }
 }
 
 

--- a/schematic/src/x_window.c
+++ b/schematic/src/x_window.c
@@ -587,6 +587,8 @@ void x_window_close(GschemToplevel *w_current)
 
   w_current->dont_invalidate = TRUE;
 
+  x_widgets_destroy_dialogs (w_current);
+
   /* close all the dialog boxes */
   if (w_current->sowindow)
   gtk_widget_destroy(w_current->sowindow);


### PR DESCRIPTION
Allow widgets to behave like top-level windows in non-docking GUI.
Add a new configuration key to turn it on and off:
`schematic.gui::use-toplevel-windows` (`false` by default).
This feature was requested by Girvin Herr on the geda-user
mailing list [1]. Quote:

> BTW: Another annoying thing I noticed about lepton-schematic is that the
> additional windows (i.e. status and page manager) do not honor window
> focus - they stay on top, which makes it difficult to work in the
> schematic editing main window without moving them aside. I do believe
> that gEDA 1.8 did honor window focus and the same windows went to the
> background when focus was changed to the main window. Fixing that could
> be an enhancement for a subsequent lepton release.

@vzh Could you please verify will this work with a tiling window manager?
Perhaps, you could suggest a more appropriate name than `use-toplevel-windows`.

[1] http://www.delorie.com/archives/browse.cgi?p=geda-user/2020/01/21/15:31:24
