### PR TITLE
Alternative placeholders for missing symbols

### DIFF
--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -46,6 +46,7 @@ dots-grid-mode=variable
 net-selection-mode=enabled_net
 default-titleblock=title-B.sym
 use-toplevel-windows=false
+small-placeholders=true
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/geda-system.conf
+++ b/liblepton/lib/geda-system.conf
@@ -45,6 +45,7 @@ grid-mode=mesh
 dots-grid-mode=variable
 net-selection-mode=enabled_net
 default-titleblock=title-B.sym
+use-toplevel-windows=false
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -46,6 +46,7 @@ dots-grid-mode=variable
 net-selection-mode=enabled_net
 default-titleblock=title-B.sym
 use-toplevel-windows=false
+small-placeholders=true
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/lib/lepton-system.conf
+++ b/liblepton/lib/lepton-system.conf
@@ -45,6 +45,7 @@ grid-mode=mesh
 dots-grid-mode=variable
 net-selection-mode=enabled_net
 default-titleblock=title-B.sym
+use-toplevel-windows=false
 
 [schematic.tabs]
 show-close-button=true

--- a/liblepton/src/geda_component_object.c
+++ b/liblepton/src/geda_component_object.c
@@ -452,6 +452,90 @@ render_placeholders()
   return placeholder_rendering;
 }
 
+
+
+/*! \brief Create a placeholder symbol.
+ *
+ *  \par Function Description
+ *  Create a smaller placeholder which looks like this:
+ *
+ *     |
+ *     | missing-symbol.sym
+ *     |____________________
+ *    /
+ *  \/
+ *  /\
+ *
+ *  \param node  Placeholder object.
+ *  \param x     Placeholder's origin X.
+ *  \param y     Placeholder's origin Y.
+ *
+ */
+static void
+create_placeholder_small (OBJECT* node, int x, int y)
+{
+  node->type = OBJ_PLACEHOLDER;
+
+  if (!render_placeholders())
+    return;
+
+  const gint color = DETACHED_ATTRIBUTE_COLOR;
+  const gint text_size = 6;
+
+  /* two crossed lines to mark component's origin:
+  */
+  OBJECT* line1 = geda_line_object_new (color,
+                                        x - 30, y + 30,
+                                        x + 30, y - 30 );
+  OBJECT* line2 = geda_line_object_new (color,
+                                        x - 30, y - 30,
+                                        x + 50, y + 50 );
+
+  /* text - symbol file name:
+  */
+  OBJECT* txt = geda_text_object_new (color,
+                                      x + 100, y + 100,
+                                      LOWER_LEFT,
+                                      0,
+                                      node->component_basename,
+                                      text_size,
+                                      VISIBLE,
+                                      SHOW_NAME_VALUE);
+
+  GedaBounds bounds;
+  geda_text_object_calculate_bounds (txt, FALSE, &bounds);
+
+  bounds.max_x = geda_coord_snap (bounds.max_x, 100);
+  bounds.max_y = geda_coord_snap (bounds.max_y, 100);
+
+  /* two lines at the left and bottom sides of the text:
+  */
+  OBJECT* line3 = geda_line_object_new (color,
+                                        x + 50, y + 50,
+                                        x + 50, bounds.max_y + 10 );
+  OBJECT* line4 = geda_line_object_new (color,
+                                        x + 50, y + 50,
+                                        bounds.max_x + 10, y + 50 );
+
+  OBJECT* objs[] =
+  {
+      line1,
+      line2,
+      txt,
+      line3,
+      line4
+  };
+
+  for ( size_t i = 0; i < sizeof(objs) / sizeof(objs[0]); ++i )
+  {
+      node->component->prim_objs =
+        g_list_append (node->component->prim_objs, objs[i]);
+  }
+
+} /* create_placeholder_small() */
+
+
+
 static void
 create_placeholder (OBJECT *new_node,
                     int x,

--- a/liblepton/src/geda_component_object.c
+++ b/liblepton/src/geda_component_object.c
@@ -661,9 +661,9 @@ create_placeholder (OBJECT* node, int x, int y)
       return;
     }
 
-    gboolean small_placeholders = FALSE;
+    gboolean small_placeholders = TRUE;
     cfg_read_bool ("schematic.gui", "small-placeholders",
-                   FALSE, &small_placeholders);
+                   TRUE, &small_placeholders);
 
     if (small_placeholders)
     {


### PR DESCRIPTION
Draw either new (smaller) or classic placeholders (giant
red triangles with an exclamation mark and two lines of
text :) for missing schematic symbols, depending on value
of the `schematic.gui::draw-smaller-placeholders`
configuration key (`false` by default).
It's an open question how placeholders should look like to
not turn a schematic with missing symbols into incomprehensible
bloody mess... :-) It's just an attempt. Any ideas are welcome.

Two types of placeholders (to scale):

![3-placeholder-cmp-dmn](https://user-images.githubusercontent.com/26083750/81336695-504f6d00-9099-11ea-93f6-fc3a10eed0f0.png)
![4-placeholder-cmp-dmn](https://user-images.githubusercontent.com/26083750/81336709-56dde480-9099-11ea-85d9-9a48fd5d90b2.png)

A small (!) example schematic (real schematics are hard
to look at without `Volidol`, in either case):

![0-placeholder-test-dmn](https://user-images.githubusercontent.com/26083750/81337248-437f4900-909a-11ea-8abc-4e1bd9023b67.png)

![1-placeholder-test-dmn](https://user-images.githubusercontent.com/26083750/81337260-4843fd00-909a-11ea-8e35-cc8ea5c00186.png)

![2-placeholder-test-dmn](https://user-images.githubusercontent.com/26083750/81337279-4da14780-909a-11ea-905e-383e01eba8db.png)

[placeholder-test-dmn.tar.gz](https://github.com/lepton-eda/lepton-eda/files/4595351/placeholder-test-dmn.tar.gz)

