### PR TITLE
Do not expose implementation details of the configuration API

### DIFF
--- a/cli/config.c
+++ b/cli/config.c
@@ -148,11 +148,14 @@ cmd_config_impl (void *data, int argc, char **argv)
 
   /* If no configuration is available yet, grab the project
    * configuration. */
-  if (cfg == NULL) {
+  if (cfg == NULL)
+  {
     if (project_store_path == NULL)
+    {
       project_store_path = ".";
-    GFile *project_store = g_file_new_for_commandline_arg (project_store_path);
-    cfg = eda_config_get_context_for_file (project_store);
+    }
+
+    cfg = eda_config_get_context_for_path (project_store_path);
   }
 
   /* If no further arguments were specified, output the configuration
@@ -163,11 +166,15 @@ cmd_config_impl (void *data, int argc, char **argv)
   }
 
   /* Attempt to load the file, and all its parents */
-  for (parent = cfg; parent != NULL; parent = eda_config_get_parent (parent)) {
-    GError *err = NULL;
+  for (parent = cfg; parent != NULL; parent = eda_config_get_parent (parent))
+  {
     if (eda_config_is_loaded (parent) ||
-        eda_config_get_file (parent) == NULL) continue;
+        eda_config_get_filename (parent) == NULL)
+    {
+      continue;
+    }
 
+    GError *err = NULL;
     if (!eda_config_load (parent, &err)) {
       if (!g_error_matches (err, G_IO_ERROR, G_IO_ERROR_NOT_FOUND)) {
         /* TRANSLATORS: The first string is the filename, the second is

--- a/cli/export.c
+++ b/cli/export.c
@@ -835,7 +835,7 @@ export_parse_scale (const gchar *scale)
 static void
 export_config (void)
 {
-  EdaConfig *cfg = eda_config_get_context_for_file (NULL);
+  EdaConfig *cfg = eda_config_get_context_for_path (".");
   gchar *str;
   gdouble *lst;
   gdouble dval;

--- a/liblepton/include/liblepton/edaconfig.h
+++ b/liblepton/include/liblepton/edaconfig.h
@@ -93,7 +93,6 @@ GType eda_config_get_type (void) G_GNUC_CONST;
 
 /* ---------------------------------------------------------------- */
 
-EdaConfig *eda_config_get_context_for_file (GFile *path) G_GNUC_WARN_UNUSED_RESULT;
 EdaConfig *eda_config_get_context_for_path (const gchar *path) G_GNUC_WARN_UNUSED_RESULT;
 
 EdaConfig *eda_config_get_cache_context (void);
@@ -101,7 +100,6 @@ EdaConfig *eda_config_get_default_context (void);
 EdaConfig *eda_config_get_system_context (void);
 EdaConfig *eda_config_get_user_context (void);
 
-GFile *eda_config_get_file (EdaConfig *cfg);
 const gchar *eda_config_get_filename (EdaConfig *cfg);
 gboolean eda_config_load (EdaConfig *cfg, GError **err);
 gboolean eda_config_is_loaded (EdaConfig *cfg);

--- a/liblepton/src/edaconfig.c
+++ b/liblepton/src/edaconfig.c
@@ -104,6 +104,11 @@ config_get_legacy_mode()
 
 
 
+static EdaConfig* eda_config_get_context_for_file (GFile* path);
+static GFile* eda_config_get_file (EdaConfig* cfg);
+
+
+
 /*! \brief Get filename for system configuration files
  */
 static const gchar*
@@ -664,7 +669,7 @@ find_project_root (GFile *path)
   return result;
 }
 
-/*! \public \memberof EdaConfig
+/*! \private \memberof EdaConfig
  * \brief Return a local configuration context.
  *
  * Looks for a configuration file named "geda.conf".  If \a path is
@@ -691,7 +696,7 @@ find_project_root (GFile *path)
  * \param [in] path    Path to search for configuration from.
  * \return a local #EdaConfig configuration context for \a path.
  */
-EdaConfig *
+static EdaConfig *
 eda_config_get_context_for_file (GFile *path)
 {
   static gsize initialized = 0;
@@ -776,7 +781,7 @@ eda_config_get_context_for_path (const gchar *path)
   return config;
 }
 
-/*! \public \memberof EdaConfig
+/*! \private \memberof EdaConfig
  * \brief Return underlying filename for configuration context.
  *
  * Return a GFile for the configuration file associated with the
@@ -787,7 +792,7 @@ eda_config_get_context_for_path (const gchar *path)
  * \param cfg  Configuration context.
  * \return Configuration file for \a cfg.
  */
-GFile *
+static GFile *
 eda_config_get_file (EdaConfig *cfg)
 {
   g_return_val_if_fail (EDA_IS_CONFIG (cfg), NULL);

--- a/liblepton/src/g_rc.c
+++ b/liblepton/src/g_rc.c
@@ -404,7 +404,7 @@ g_rc_parse_handler (TOPLEVEL *toplevel,
    * current working directory's configuration context here, no matter
    * where the rc file is located on disk. */
   if (rcfile != NULL) {
-    EdaConfig *cwd_cfg = eda_config_get_context_for_file (NULL);
+    EdaConfig *cwd_cfg = eda_config_get_context_for_path (".");
     g_rc_parse_file (toplevel, rcfile, cwd_cfg, &err); HANDLER_DISPATCH;
   }
 

--- a/liblepton/src/scheme_config.c
+++ b/liblepton/src/scheme_config.c
@@ -190,17 +190,14 @@ SCM_DEFINE (path_config_context, "%path-config-context", 1, 0, 0,
               s_path_config_context);
 
   scm_dynwind_begin ((scm_t_dynwind_flags) 0);
+
   char *path = scm_to_utf8_string (path_s);
   scm_dynwind_free (path);
-  GFile *file = g_file_parse_name (path);
-  scm_dynwind_unwind_handler (g_object_unref, file,
-                              SCM_F_WIND_EXPLICITLY);
 
-  EdaConfig *cfg = eda_config_get_context_for_file (file);
+  EdaConfig *cfg = eda_config_get_context_for_path (path);
   SCM result = edascm_from_config (cfg);
 
   scm_dynwind_end ();
-  scm_remember_upto_here_1 (path_s);
   return result;
 }
 

--- a/liblepton/src/scheme_config.c
+++ b/liblepton/src/scheme_config.c
@@ -226,7 +226,7 @@ SCM_DEFINE (cache_config_context, "%cache-config-context", 0, 0, 0,
  * Returns the underlying filename for the configuration context \a
  * cfg, or #f if it has no filename associated with it.
  *
- * \see eda_config_get_file().
+ * \see eda_config_get_filename().
  *
  * \note Scheme API: Implements the \%config-filename procedure in the
  * (lepton core config) module.
@@ -240,17 +240,11 @@ SCM_DEFINE (config_filename, "%config-filename", 1, 0, 0,
   SCM_ASSERT (EDASCM_CONFIGP (cfg_s), cfg_s, SCM_ARG1,
               s_config_filename);
 
-  scm_dynwind_begin ((scm_t_dynwind_flags) 0);
   EdaConfig *cfg = edascm_to_config (cfg_s);
-  GFile *file = eda_config_get_file (cfg);
-  gchar *path = NULL;
-  if (file != NULL) {
-    path = g_file_get_parse_name (file);
-    scm_dynwind_free (path);
-  }
 
+  const gchar* path = eda_config_get_filename (cfg);
   SCM result = (path == NULL) ? SCM_BOOL_F : scm_from_utf8_string (path);
-  scm_dynwind_end ();
+
   return result;
 }
 

--- a/libleptonrenderer/edarenderer.c
+++ b/libleptonrenderer/edarenderer.c
@@ -1516,7 +1516,7 @@ eda_renderer_get_text_user_bounds (const GedaObject *object,
   g_object_set (G_OBJECT (renderer),
                 "cairo-context", cr,
                 NULL);
-  EdaConfig *cfg = eda_config_get_context_for_file (NULL);
+  EdaConfig *cfg = eda_config_get_context_for_path (".");
   gchar *font_name = eda_config_get_string (cfg, "schematic.gui", "font", NULL);
   if (font_name != NULL) {
     g_object_set (G_OBJECT (renderer),

--- a/schematic/src/x_print.c
+++ b/schematic/src/x_print.c
@@ -198,7 +198,7 @@ x_print_draw_page (TOPLEVEL *toplevel, PAGE *page,
                                          "render-flags", is_raster ? EDA_RENDERER_FLAG_HINTING : 0,
                                          NULL));
 
-  EdaConfig *cfg = eda_config_get_context_for_file (NULL);
+  EdaConfig *cfg = eda_config_get_context_for_path (".");
   gchar *fontstr = eda_config_get_string (cfg, "schematic.gui", "font", NULL);
 
   if (fontstr != NULL) {


### PR DESCRIPTION
Make the following `liblepton` functions private:

```c
GFile*     eda_config_get_file( EdaConfig* );
EdaConfig* eda_config_get_context_for_file( GFile* );
```

`GFile` is used internally in the configuration API
implementation, and over time, this may change.
It's not worth providing direct access to it.
Use `eda_config_get_filename()` and
`eda_config_get_context_for_path()` instead.

