### PR TITLE
Fix minor GUI inconsistencies in lepton-schematic

### DIFF
--- a/schematic/src/o_picture.c
+++ b/schematic/src/o_picture.c
@@ -130,7 +130,7 @@ void picture_selection_dialog (GschemToplevel *w_current)
   GdkPixbuf *pixbuf;
   GError *error = NULL;
 
-  w_current->pfswindow = gtk_file_chooser_dialog_new (_("Select a picture file..."),
+  w_current->pfswindow = gtk_file_chooser_dialog_new (_("Add Picture"),
 						      GTK_WINDOW(w_current->main_window),
 						      GTK_FILE_CHOOSER_ACTION_OPEN,
 						      GTK_STOCK_CANCEL,

--- a/schematic/src/x_attribedit.c
+++ b/schematic/src/x_attribedit.c
@@ -325,7 +325,7 @@ void attrib_edit_dialog (GschemToplevel *w_current, OBJECT *attr_obj, int flag)
     }
   }
 
-  aewindow = gschem_dialog_new_with_buttons(_("Single Attribute Editor"),
+  aewindow = gschem_dialog_new_with_buttons(NULL,
                                             GTK_WINDOW(w_current->main_window),
                                             GTK_DIALOG_MODAL,
                                             "singleattrib", w_current,
@@ -354,13 +354,14 @@ void attrib_edit_dialog (GschemToplevel *w_current, OBJECT *attr_obj, int flag)
 				 DIALOG_BORDER_SPACING);
   gtk_box_set_spacing(GTK_BOX(vbox), DIALOG_V_SPACING);
 
-  if (attr_obj)
-    label = gtk_label_new(_("<b>Edit Attribute</b>"));
+  if (attr_obj != NULL)
+  {
+    gtk_window_set_title (GTK_WINDOW(aewindow), _("Edit Attribute"));
+  }
   else
-    label = gtk_label_new(_("<b>Add Attribute</b>"));
-  gtk_label_set_use_markup (GTK_LABEL (label), TRUE);
-  gtk_misc_set_alignment(GTK_MISC(label),0,0);
-  gtk_box_pack_start(GTK_BOX(vbox), label, FALSE, FALSE, 0);
+  {
+    gtk_window_set_title (GTK_WINDOW(aewindow), _("Add Attribute"));
+  }
 
   alignment = gtk_alignment_new(0,0,1,1);
   gtk_alignment_set_padding(GTK_ALIGNMENT(alignment), 0, 0,

--- a/schematic/src/x_compselect.c
+++ b/schematic/src/x_compselect.c
@@ -1444,7 +1444,7 @@ compselect_constructor (GType type,
   /* dialog initialization */
   g_object_set (object,
                 /* GtkWindow */
-                "title",           _("Select Component..."),
+                "title",           _("Add Component"),
                 "default-height",  300,
                 "default-width",   400,
                 NULL);

--- a/schematic/src/x_fileselect.c
+++ b/schematic/src/x_fileselect.c
@@ -333,7 +333,7 @@ x_fileselect_open(GschemToplevel *w_current)
   GtkWidget *dialog;
   gchar *cwd;
 
-  dialog = gtk_file_chooser_dialog_new (_("Open..."),
+  dialog = gtk_file_chooser_dialog_new (_("Open"),
                                         GTK_WINDOW(w_current->main_window),
                                         GTK_FILE_CHOOSER_ACTION_OPEN,
                                         GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL,
@@ -418,7 +418,7 @@ x_fileselect_save (GschemToplevel *w_current, PAGE* page, gboolean* result)
   }
 
   GtkWidget* dialog = gtk_file_chooser_dialog_new(
-    _("Save as..."),
+    _("Save As"),
     GTK_WINDOW(w_current->main_window),
     GTK_FILE_CHOOSER_ACTION_SAVE,
     GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL,

--- a/schematic/src/x_image.c
+++ b/schematic/src/x_image.c
@@ -550,7 +550,7 @@ void x_image_setup (GschemToplevel *w_current)
   gtk_widget_show(vbox2);
 
   /* Create the dialog */
-  dialog = gtk_file_chooser_dialog_new (_("Write image..."),
+  dialog = gtk_file_chooser_dialog_new (_("Write Image"),
       GTK_WINDOW(w_current->main_window),
       GTK_FILE_CHOOSER_ACTION_SAVE,
       GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL,

--- a/schematic/src/x_newtext.c
+++ b/schematic/src/x_newtext.c
@@ -430,7 +430,7 @@ text_input_dialog (GschemToplevel *w_current)
                                 /* GtkContainer */
                                 "border-width",     DIALOG_BORDER_SPACING,
                                 /* GtkWindow */
-                                "title",            _("Text Entry..."),
+                                "title",            _("Add Text"),
                                 "default-width",    320,
                                 "default-height",   350,
                                 "window-position",  GTK_WIN_POS_MOUSE,

--- a/schematic/src/x_script.c
+++ b/schematic/src/x_script.c
@@ -39,7 +39,7 @@ void setup_script_selector (GschemToplevel *w_current)
   char *filename;
 
   w_current->sowindow =
-    gtk_file_chooser_dialog_new (_("Execute Script..."),
+    gtk_file_chooser_dialog_new (_("Execute Script"),
 				 GTK_WINDOW(w_current->main_window),
 				 GTK_FILE_CHOOSER_ACTION_OPEN,
 				 GTK_STOCK_CANCEL, 

--- a/schematic/src/x_widgets.c
+++ b/schematic/src/x_widgets.c
@@ -212,7 +212,7 @@ void x_widgets_show_object_properties (GschemToplevel* w_current)
     x_widgets_show_in_dialog (w_current,
                               w_current->object_properties,
                               &w_current->object_properties_dialog,
-                              _("Object"),
+                              _("Object Properties"),
                               "objprops");
   }
 }

--- a/schematic/src/x_widgets.c
+++ b/schematic/src/x_widgets.c
@@ -188,7 +188,7 @@ void x_widgets_show_text_properties (GschemToplevel* w_current)
     x_widgets_show_in_dialog (w_current,
                               w_current->text_properties,
                               &w_current->text_properties_dialog,
-                              _("Text"),
+                              _("Edit Text"),
                               "txtprops");
   }
 

--- a/schematic/src/x_window.c
+++ b/schematic/src/x_window.c
@@ -1456,7 +1456,7 @@ create_notebook_bottom (GschemToplevel* w_current)
 
     gtk_notebook_append_page (GTK_NOTEBOOK (notebook),
                               GTK_WIDGET (w_current->log_widget),
-                              gtk_label_new(_("Status")));
+                              gtk_label_new(_("Log")));
 
 
     gtk_container_set_border_width (GTK_CONTAINER (notebook),


### PR DESCRIPTION
Change titles of several dialogs:
- `Single Attribute Editor` => `Add Attribute` or `Edit Attribute`,
  depending on the action it was invoked for. Remove label, since
  add/edit is shown in the title.
- `Text entry...` => `Add Text`
- `Text` => `Edit Text`
- `Object` => `Object Properties`
- `Select Component...` => `Add Component`
- `Open...` => `Open`
- `Save as...` => `Save As`
- `Execute Script...` => `Execute Script`
- `Write image...` => `Write Image`
- `Select a picture file...` => `Add Picture`
- When docking windows GUI is enabled, use "Log"
  as a notebook tab's title in the bottom dock,
  instead of "Status".

`...` is used for buttons and menu items to indicate that
pressing them will show something (usually, a dialog box)
that needs direct user input to change some data.
