### PR TITLE
Fix precompiled path substitution in utils/scripts/

### DIFF
--- a/utils/scripts/Makefile.am
+++ b/utils/scripts/Makefile.am
@@ -24,7 +24,7 @@ EXTRA_DIST = \
 
 do_subst = sed -e 's,[@]libdir[@],$(libdir),g' \
 	-e 's,[@]GUILE[@],$(GUILE),g' \
-	-e 's,[@]localedir[@],$(localedir),g'
+	-e 's,[@]localedir[@],$(localedir),g' \
 	-e 's,[@]ccachedir[@],@LEPTON_SCM_PRECOMPILE_DIR@,g'
 
 lepton-archive: lepton-archive.in


### PR DESCRIPTION
Fix a typo in `utils/scripts/Makefile.am`: make `sed` command
substitute `ccachedir` again.
