### PR TITLE
Fix file filters in the "Save As" dialog

### DIFF
--- a/schematic/src/x_fileselect.c
+++ b/schematic/src/x_fileselect.c
@@ -46,6 +46,22 @@ add_filter (GtkFileChooser* filechooser,
 
 
 
+static gboolean
+filename_sym (const gchar* fname)
+{
+  return g_str_has_suffix (fname, ".sym");
+}
+
+
+
+static gboolean
+filename_sch (const gchar* fname)
+{
+  return g_str_has_suffix (fname, ".sch");
+}
+
+
+
 /*! \brief Creates filter for file chooser.
  *  \par Function Description
  *  This function adds file filters to <B>filechooser</B>.
@@ -150,12 +166,12 @@ on_filter_changed (GtkFileChooserDialog* dialog, gpointer data)
 
   gchar* bname = NULL;
 
-  if (filter == filter_sch && g_str_has_suffix (fname, ".sym"))
+  if (filter == filter_sch && filename_sym (fname))
   {
     bname = basename_switch_suffix (fname, "sch");
   }
   else
-  if (filter == filter_sym && g_str_has_suffix (fname, ".sch"))
+  if (filter == filter_sym && filename_sch (fname))
   {
     bname = basename_switch_suffix (fname, "sym");
   }
@@ -398,13 +414,27 @@ x_fileselect_save (GschemToplevel *w_current, PAGE* page, gboolean* result)
   /* add file filters to dialog:
   */
   setup_filters (GTK_FILE_CHOOSER (dialog));
+  const gchar* fname = s_page_get_filename (page);
+
+  if (filename_sch (fname))
+  {
+    gtk_file_chooser_set_filter (GTK_FILE_CHOOSER (dialog), filter_sch);
+  }
+  else
+  if (filename_sym (fname))
+  {
+    gtk_file_chooser_set_filter (GTK_FILE_CHOOSER (dialog), filter_sym);
+  }
+  else
+  {
+    gtk_file_chooser_set_filter (GTK_FILE_CHOOSER (dialog), filter_all);
+  }
 
   /* set the current filename or directory name if new document:
   */
-  if (g_file_test (s_page_get_filename (page), G_FILE_TEST_EXISTS))
+  if (g_file_test (fname, G_FILE_TEST_EXISTS))
   {
-    gtk_file_chooser_set_filename (GTK_FILE_CHOOSER (dialog),
-                                   s_page_get_filename (page));
+    gtk_file_chooser_set_filename (GTK_FILE_CHOOSER (dialog), fname);
   }
   else
   {
@@ -417,7 +447,6 @@ x_fileselect_save (GschemToplevel *w_current, PAGE* page, gboolean* result)
 
     /* set page file's basename as the current filename:
     */
-    const gchar* fname = s_page_get_filename (page);
     gchar* bname = g_path_get_basename (fname);
     gtk_file_chooser_set_current_name (GTK_FILE_CHOOSER (dialog), bname);
     g_free (bname);

--- a/schematic/src/x_fileselect.c
+++ b/schematic/src/x_fileselect.c
@@ -33,7 +33,6 @@ static GtkFileFilter* filter_all      = NULL;
 /*! Remember the last used filters
  */
 static GtkFileFilter* filter_last_opendlg = NULL;
-static GtkFileFilter* filter_last_savedlg = NULL;
 
 static int
 x_fileselect_load_backup (GschemToplevel *w_current,
@@ -110,11 +109,6 @@ x_fileselect_setup_filechooser_filters (GtkFileChooser *filechooser)
     filter_last_opendlg = filter_sch;
   }
 
-  if (filter_last_savedlg == NULL)
-  {
-    filter_last_savedlg = filter_sch;
-  }
-
   /* restore last used filters:
   */
   GtkFileChooserAction type = gtk_file_chooser_get_action (filechooser);
@@ -126,7 +120,6 @@ x_fileselect_setup_filechooser_filters (GtkFileChooser *filechooser)
   else
   if (type == GTK_FILE_CHOOSER_ACTION_SAVE)
   {
-    gtk_file_chooser_set_filter (filechooser, filter_last_savedlg);
   }
   else
   {
@@ -488,10 +481,6 @@ x_fileselect_save (GschemToplevel *w_current, PAGE* page, gboolean* result)
   gtk_widget_show (dialog);
   if (gtk_dialog_run ((GtkDialog*)dialog) == GTK_RESPONSE_ACCEPT)
   {
-    /* remember current filter:
-    */
-    filter_last_savedlg = gtk_file_chooser_get_filter (GTK_FILE_CHOOSER (dialog));
-
     gchar *filename = gtk_file_chooser_get_filename (GTK_FILE_CHOOSER (dialog));
 
     /* If the file already exists, display a dialog box to check if

--- a/schematic/src/x_fileselect.c
+++ b/schematic/src/x_fileselect.c
@@ -80,23 +80,6 @@ setup_filters (GtkFileChooser *filechooser)
     filter_last_opendlg = filter_sch;
   }
 
-  /* restore last used filters:
-  */
-  GtkFileChooserAction type = gtk_file_chooser_get_action (filechooser);
-
-  if (type == GTK_FILE_CHOOSER_ACTION_OPEN)
-  {
-    gtk_file_chooser_set_filter (filechooser, filter_last_opendlg);
-  }
-  else
-  if (type == GTK_FILE_CHOOSER_ACTION_SAVE)
-  {
-  }
-  else
-  {
-    g_assert (FALSE && "Trying to set filter for unsupported dialog type");
-  }
-
 } /* x_fileselect_setup_filechooser_filters() */
 
 
@@ -319,8 +302,12 @@ x_fileselect_open(GschemToplevel *w_current)
                 /* GtkFileChooser */
                 "select-multiple", TRUE,
                 NULL);
+
   /* add file filters to dialog */
   setup_filters (GTK_FILE_CHOOSER (dialog));
+  /* restore last filter: */
+  gtk_file_chooser_set_filter (GTK_FILE_CHOOSER (dialog), filter_last_opendlg);
+
   /* force start in current working directory, not in 'Recently Used' */
   cwd = g_get_current_dir ();
   gtk_file_chooser_set_current_folder (GTK_FILE_CHOOSER (dialog), cwd);


### PR DESCRIPTION
Decide what filter to use based on file name of the current page,
if it is e.g. `file.sym`, activate filter "Symbols (\*.sym)" and
"Schematics (\*.sch)" for `file.sch`.
Previously, the last chosen filter was set in the dialog (for example,
it's quite confusing when you try to "Save As" an `sch` file, but
the filter is set to "Symbols (\*.sym)").

Thanks to Matthew (@zo0om) for reporting it on gitter.

Probably, affects issue #649 (I'm not sure I understand what 
that issue is about).
