### PR TITLE
Fix coverity scan issue 204294 - set_guile_compiled_path()

### DIFF
--- a/liblepton/src/liblepton.c
+++ b/liblepton/src/liblepton.c
@@ -57,31 +57,38 @@ void liblepton_init(void)
 
 
 
-/*! \brief Add Lepton compiled path to Guile compiled paths env var.
+/*! \brief Prepend Lepton compiled path to Guile compiled paths env var.
  *  \note  To take effect, must be called before scm_boot_guile().
  */
 void
 set_guile_compiled_path()
 {
-  char* path = getenv ("GUILE_LOAD_COMPILED_PATH");
-  char buf[ PATH_MAX ] = "";
+  const char  varname[] = "GUILE_LOAD_COMPILED_PATH";
+  const char* lepton_precompile_dir = LEPTON_SCM_PRECOMPILE_DIR;
+  const char* value = getenv (varname);
 
-  if (path != NULL && strlen (path) > 0)
+  if (value == NULL || strlen (value) == 0)
   {
-    /* preserve already set $GUILE_LOAD_COMPILED_PATH:
-    */
-    snprintf (buf, sizeof (buf),
-              "%s:%s",
-              LEPTON_SCM_PRECOMPILE_DIR, path);
-    path = buf;
+    setenv (varname, lepton_precompile_dir, 1);
   }
   else
   {
-    path = (char*) LEPTON_SCM_PRECOMPILE_DIR;
+    const size_t len = strlen (lepton_precompile_dir)
+                       + 1  /* ":" */
+                       + strlen (value)
+                       + 1; /* \0  */
+    char* buffer = (char*) malloc (len);
+
+    strcpy (buffer, lepton_precompile_dir);
+    strcat (buffer, ":");
+    strcat (buffer, value);
+
+    setenv (varname, buffer, 1);
+
+    free (buffer);
   }
 
-  setenv ("GUILE_LOAD_COMPILED_PATH", path, 1);
-}
+} /* set_guile_compiled_path() */
 
 
 


### PR DESCRIPTION
`set_guile_compiled_path()` in `liblepton/src/liblepton.c`:

Coverity scan analysis ([issue 204294](https://scan9.coverity.com/reports.htm#v39680/p11510/fileInstanceId=66025513&defectInstanceId=7729048&mergedDefectId=204294))
rightfully warns that the value of the `$GUILE_LOAD_COMPILED_PATH`
environment variable (obtained by `getenv()`) could contain anything
and should be checked somehow.
Moreover, existing code assumes that variable's value is small
enough to fit into a buffer of size `PATH_MAX` (typically, 1024).

- Dynamically allocate a large enough string to hold both Lepton
pre-compiled path and existing contents of the
`$GUILE_LOAD_COMPILED_PATH` variable.
- Check if that value consists of valid UTF-8 characters with
`g_utf8_validate()`.

The question is: what else can we do to ensure that env var value
is correct? check its size? if so, what size should be considered
as "maximum"?
