### PR TITLE
Fix tabbed GUI initialization

### DIFF
--- a/libleptongui/src/lepton-schematic.c
+++ b/libleptongui/src/lepton-schematic.c
@@ -142,17 +142,14 @@ main_prog (SCM file_list_s)
   /* Set up atexit handlers */
   gschem_atexit (i_vars_atexit_save_cache_config, NULL);
 
-  /* Now read in RC files. */
+  /* Parse custom GTK resource files: */
   g_rc_parse_gtkrc();
 
   /* Set default icon theme and make sure we can find our own icons */
   x_window_set_default_icon();
   x_window_init_icons ();
 
-  /* Initialize tabbed GUI: */
-  x_tabs_init();
-
-  /* Allocate w_current */
+  /* Create a new window and associated TOPLEVEL object: */
   w_current = x_window_new ();
 
   /* Enable rendering of placeholders */

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -991,18 +991,21 @@ x_window_init_icons (void)
  */
 GschemToplevel* x_window_new ()
 {
-  GschemToplevel *w_current;
   TOPLEVEL *toplevel = s_toplevel_new ();
 
+  /* Load old (*rc files) and new (*.conf) configuration: */
   x_rc_parse_gschem (toplevel, NULL);
 
-  w_current = gschem_toplevel_new ();
+  GschemToplevel *w_current = gschem_toplevel_new ();
   gschem_toplevel_set_toplevel (w_current, toplevel);
 
   /* Damage notifications should invalidate the object on screen */
   o_add_change_notify (toplevel,
                        (ChangeNotifyFunc) o_invalidate,
                        (ChangeNotifyFunc) o_invalidate, w_current);
+
+  /* Initialize tabbed GUI: */
+  x_tabs_init();
 
   x_window_setup (w_current);
 


### PR DESCRIPTION
`x_tabs_init()` should be called after the
configuration is read, but before a new window
construction is started (`x_window_setup()`).
Move call to `x_tabs_init()` to `x_window_new()`.
