### PR TITLE
Do not install old changelog files

### DIFF
--- a/docs/changelogs/Makefile.am
+++ b/docs/changelogs/Makefile.am
@@ -1,5 +1,3 @@
-docsdir = $(docdir)/changelogs
-
 changelogs = \
 	changelog.docs \
 	changelog.examples \
@@ -14,6 +12,4 @@ changelogs = \
 	changelog.tragesym \
 	changelog.utils
 
-docs_DATA = $(changelogs)
-
-EXTRA_DIST = $(docs_DATA)
+EXTRA_DIST = $(changelogs)


### PR DESCRIPTION
Do not install (with `make install`) old (<= 2007) changelogs
from `docs/changelogs/`.
It's unlikely that they could be of any interest to the end user.
