### PR TITLE
Correctly set GUILE_PKG_NAME when detecting Guile version

### DIFF
--- a/m4/geda-guile.m4
+++ b/m4/geda-guile.m4
@@ -37,12 +37,17 @@ AC_DEFUN([AX_CHECK_GUILE],
   GUILE_MIN_TEENY=`echo ${GUILE_MIN_VER} | sed -e 's;.*\.;;'`
 
   _found_pkg_config_guile=yes
+
   PKG_CHECK_MODULES(GUILE, [guile-3.0 >= $GUILE_MIN_VER],
-                           [GUILE_PKG_NAME=guile-3.0], [_found_pkg_config_guile=no])
+                           [_found_pkg_config_guile=yes
+                            GUILE_PKG_NAME=guile-3.0],
+                           [_found_pkg_config_guile=no])
 
   if test "${_found_pkg_config_guile}" = "no" ; then
     PKG_CHECK_MODULES(GUILE, [guile-2.2 >= $GUILE_MIN_VER],
-                             [GUILE_PKG_NAME=guile-2.2], [_found_pkg_config_guile=no])
+                             [_found_pkg_config_guile=yes
+                              GUILE_PKG_NAME=guile-2.2],
+                             [_found_pkg_config_guile=no])
   fi
 
   if test "${_found_pkg_config_guile}" = "no" ; then


### PR DESCRIPTION
Fix Guile version detection in `m4/geda-guile.m4`
by setting `_found_pkg_config_guile` variable in
each `PKG_CHECK_MODULES` statement, so that if one
of them is successful, the consequent ones are
bypassed.
No doing so may result in incorrect Guile version
in `lib/pkgconfig/*.pc` files.
