### PR TITLE
Rewrite the function "add-menu()" using Scheme FFI.

### DIFF
--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -150,7 +150,6 @@ SCM g_keys_cancel(SCM rest);
 void g_init_keys ();
 /* g_rc.c */
 void g_rc_parse_gtkrc();
-SCM g_rc_add_menu(SCM menu_name, SCM menu_items);
 /* g_register.c */
 void g_register_funcs(void);
 /* g_select.c */

--- a/libleptongui/lib/system-gschemrc.scm
+++ b/libleptongui/lib/system-gschemrc.scm
@@ -9,6 +9,7 @@
              (schematic builtins)
              (schematic gui keymap)
              (schematic gui stroke)
+             (schematic menu)
              (schematic netlist)
              (lepton config))
 

--- a/libleptongui/scheme/Makefile.am
+++ b/libleptongui/scheme/Makefile.am
@@ -24,6 +24,7 @@ nobase_dist_scmdata_DATA = \
 	schematic/builtins.scm \
 	schematic/core/gettext.scm \
 	schematic/dialog.scm \
+	schematic/ffi.scm \
 	schematic/gui/keymap.scm \
 	schematic/gui/stroke.scm \
 	schematic/hook.scm \

--- a/libleptongui/scheme/Makefile.am
+++ b/libleptongui/scheme/Makefile.am
@@ -25,6 +25,7 @@ nobase_dist_scmdata_DATA = \
 	schematic/core/gettext.scm \
 	schematic/dialog.scm \
 	schematic/ffi.scm \
+	schematic/ffi/gtk.scm \
 	schematic/gui/keymap.scm \
 	schematic/gui/stroke.scm \
 	schematic/hook.scm \

--- a/libleptongui/scheme/Makefile.am
+++ b/libleptongui/scheme/Makefile.am
@@ -28,6 +28,7 @@ nobase_dist_scmdata_DATA = \
 	schematic/gui/stroke.scm \
 	schematic/hook.scm \
 	schematic/keymap.scm \
+	schematic/menu.scm \
 	schematic/netlist.scm \
 	schematic/precompile.scm \
 	schematic/repl.scm \

--- a/libleptongui/scheme/schematic/attrib.scm
+++ b/libleptongui/scheme/schematic/attrib.scm
@@ -25,6 +25,7 @@
   #:use-module (lepton log)
   #:use-module (schematic core attrib)
   #:use-module (schematic core gettext)
+  #:use-module (schematic ffi)
 
   #:export (attribute-name
             init-schematic-attribs!))
@@ -45,8 +46,6 @@
 ;; See also active-page in the (schematic window) module.
 (define-public add-attrib! %add-attrib!)
 
-
-(define libleptongui (dynamic-link "libleptongui"))
 
 (define s_attrib_uniq
   (let ((proc (delay

--- a/libleptongui/scheme/schematic/dialog.scm
+++ b/libleptongui/scheme/schematic/dialog.scm
@@ -20,13 +20,13 @@
 (define-module (schematic dialog)
   #:use-module (srfi srfi-1)
   #:use-module (system foreign)
+
   #:use-module (lepton log)
+  #:use-module (schematic ffi)
 
   #:export (schematic-message-dialog
             schematic-confirm-dialog
             schematic-fileselect-dialog))
-
-(define libleptongui (dynamic-link "libleptongui"))
 
 (define generic-msg-dialog
   (pointer->procedure

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -16,24 +16,10 @@
 ;;; along with this program; if not, write to the Free Software
 ;;; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
-;;; Procedures for working with menus.
-
-(define-module (schematic menu)
+(define-module (schematic ffi)
   #:use-module (system foreign)
 
-  #:use-module (schematic ffi)
+  #:export (libleptongui))
 
-  #:export (add-menu))
-
-(define add-menu-entry!
-  (pointer->procedure
-   int
-   (dynamic-func "s_menu_add_entry" libleptongui)
-   (list '* '*)))
-
-(define (add-menu name items)
-  (and (string? name)
-       (list? items)
-       (add-menu-entry! (string->pointer name)
-                        (scm->pointer items))
-       #t))
+(define libleptongui
+  (dynamic-link (or (getenv "LIBLEPTONGUI") "libleptongui")))

--- a/libleptongui/scheme/schematic/ffi/gtk.scm
+++ b/libleptongui/scheme/schematic/ffi/gtk.scm
@@ -1,0 +1,37 @@
+;;; Lepton EDA Schematic Capture
+;;; Scheme API
+;;; Copyright (C) 2020 Lepton EDA Contributors
+;;;
+;;; This program is free software; you can redistribute it and/or modify
+;;; it under the terms of the GNU General Public License as published by
+;;; the Free Software Foundation; either version 2 of the License, or
+;;; (at your option) any later version.
+;;;
+;;; This program is distributed in the hope that it will be useful,
+;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;; GNU General Public License for more details.
+;;;
+;;; You should have received a copy of the GNU General Public License
+;;; along with this program; if not, write to the Free Software
+;;; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+(define-module (schematic ffi gtk)
+  #:use-module (system foreign)
+
+  #:export (gtk-init
+            gtk-main))
+
+(define libgtk (dynamic-link "libgtk-x11-2.0"))
+
+(define gtk-init
+  (pointer->procedure
+   void
+   (dynamic-func "gtk_init" libgtk)
+   (list '* '*)))
+
+(define gtk-main
+  (pointer->procedure
+   void
+   (dynamic-func "gtk_main" libgtk)
+   '()))

--- a/libleptongui/scheme/schematic/ffi/gtk.scm
+++ b/libleptongui/scheme/schematic/ffi/gtk.scm
@@ -19,18 +19,18 @@
 (define-module (schematic ffi gtk)
   #:use-module (system foreign)
 
-  #:export (gtk-init
-            gtk-main))
+  #:export (gtk_init
+            gtk_main))
 
 (define libgtk (dynamic-link "libgtk-x11-2.0"))
 
-(define gtk-init
+(define gtk_init
   (pointer->procedure
    void
    (dynamic-func "gtk_init" libgtk)
    (list '* '*)))
 
-(define gtk-main
+(define gtk_main
   (pointer->procedure
    void
    (dynamic-func "gtk_main" libgtk)

--- a/libleptongui/scheme/schematic/menu.scm
+++ b/libleptongui/scheme/schematic/menu.scm
@@ -1,0 +1,39 @@
+;;; Lepton EDA Schematic Capture
+;;; Scheme API
+;;; Copyright (C) 2020 Lepton EDA Contributors
+;;;
+;;; This program is free software; you can redistribute it and/or modify
+;;; it under the terms of the GNU General Public License as published by
+;;; the Free Software Foundation; either version 2 of the License, or
+;;; (at your option) any later version.
+;;;
+;;; This program is distributed in the hope that it will be useful,
+;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;; GNU General Public License for more details.
+;;;
+;;; You should have received a copy of the GNU General Public License
+;;; along with this program; if not, write to the Free Software
+;;; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+;;; Procedures for working with menus.
+
+(define-module (schematic menu)
+  #:use-module (system foreign)
+
+  #:export (add-menu))
+
+(define libleptongui (dynamic-link "libleptongui"))
+
+(define add-menu-entry!
+  (pointer->procedure
+   int
+   (dynamic-func "s_menu_add_entry" libleptongui)
+   (list '* '*)))
+
+(define (add-menu name items)
+  (and (string? name)
+       (list? items)
+       (add-menu-entry! (string->pointer name)
+                        (scm->pointer items))
+       #t))

--- a/libleptongui/src/g_rc.c
+++ b/libleptongui/src/g_rc.c
@@ -49,25 +49,3 @@ g_rc_parse_gtkrc()
   gtk_rc_parse (filename);
   g_free (filename);
 }
-
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
-SCM g_rc_add_menu(SCM scm_menu_name, SCM scm_menu_items)
-{
-  char *menu_name;
-
-  SCM_ASSERT (scm_is_string (scm_menu_name), scm_menu_name,
-              SCM_ARG1, "add-menu");
-  SCM_ASSERT (SCM_NIMP (scm_menu_items) && SCM_CONSP (scm_menu_items), scm_menu_items,
-              SCM_ARG2, "add-menu");
-
-  menu_name = scm_to_utf8_string (scm_menu_name);
-  s_menu_add_entry(menu_name, scm_menu_items);
-  free (menu_name);
-
-  return SCM_BOOL_T;
-}

--- a/libleptongui/src/g_register.c
+++ b/libleptongui/src/g_register.c
@@ -21,22 +21,6 @@
 #include <config.h>
 #include "gschem.h"
 
-/*! \brief */
-struct gsubr_t {
-  const char* name;
-  int req;
-  int opt;
-  int rst;
-  SCM (*fnc)();
-};
-
-/*! \brief */
-static struct gsubr_t gschem_funcs[] = {
-  /* rc file */
-  { "add-menu",                     2, 0, 0, (SCM (*) ()) g_rc_add_menu },
-
-  { NULL,                           0, 0, 0, NULL } };
-
 /*! \brief Define a hook.
  * \par Function Description
  * Creates a Guile new hook with \a n_args arguments, and binds it to
@@ -62,13 +46,6 @@ create_hook (const char *name, int n_args)
  */
 void g_register_funcs (void)
 {
-  struct gsubr_t *tmp = gschem_funcs;
-
-  while (tmp->name != NULL) {
-    scm_c_define_gsubr (tmp->name, tmp->req, tmp->opt, tmp->rst, (scm_t_subr) tmp->fnc);
-    tmp++;
-  }
-
   /* Hook stuff */
   complex_place_list_changed_hook = create_hook ("complex-place-list-changed-hook", 1);
 }

--- a/schematic/lepton-schematic.scm
+++ b/schematic/lepton-schematic.scm
@@ -34,11 +34,11 @@ exec @GUILE@ -s "$0" "$@"
                               (lepton eval)
                               (lepton log)
                               (lepton version)
-                              (schematic core gettext)))
+                              (schematic core gettext)
+                              (schematic ffi)))
 
 
 (define libgtk (dynamic-link "libgtk-x11-2.0"))
-(define libleptongui (dynamic-link "libleptongui"))
 
 (define gtk-init
   (pointer->procedure

--- a/schematic/lepton-schematic.scm
+++ b/schematic/lepton-schematic.scm
@@ -35,23 +35,8 @@ exec @GUILE@ -s "$0" "$@"
                               (lepton log)
                               (lepton version)
                               (schematic core gettext)
-                              (schematic ffi)))
-
-
-(define libgtk (dynamic-link "libgtk-x11-2.0"))
-
-(define gtk-init
-  (pointer->procedure
-   void
-   (dynamic-func "gtk_init" libgtk)
-   (list '* '*)))
-
-(define gtk-main
-  (pointer->procedure
-   void
-   (dynamic-func "gtk_main" libgtk)
-   '()))
-
+                              (schematic ffi)
+                              (schematic ffi gtk)))
 
 (define register-funcs
   (pointer->procedure

--- a/schematic/lepton-schematic.scm
+++ b/schematic/lepton-schematic.scm
@@ -285,7 +285,7 @@ Run `~A --help' for more information.\n")
   (primitive-exit (precompile-run)))
 
 ;;; Initialize GTK.
-(gtk-init %null-pointer %null-pointer)
+(gtk_init %null-pointer %null-pointer)
 
 ;;; Init global buffers.
 (init-buffers)
@@ -304,4 +304,4 @@ Run `~A --help' for more information.\n")
 (eval-post-load-expr!)
 
 ;;; Run main GTK loop.
-(gtk-main)
+(gtk_main)


### PR DESCRIPTION
- The C/Scheme function `add-menu()` has been rewritten using Scheme FFI.
- In order to not declare dynamic links to C libraries in each and every module they are used in, two new Scheme modules, `(schematic ffi)` and `(schematic ffi gtk)` have been added.  GTK functions, used in Lepton should now reside in the latter module.
- Two Scheme FFI functions have been renamed according to their C counterparts: `gtk_main()` and `gtk_init()`.
- A new environment variable, **LIBLEPTONGUI**, has been added in order the user to redefine the path to the `libleptongui` library "on the fly".  This can be used, e.g., for test suite or in development for testing changes without installation of the library.