### PR TITLE
Fix two issues in the tEDAx backend

### DIFF
--- a/netlist/scheme/backend/gnet-tEDAx.scm
+++ b/netlist/scheme/backend/gnet-tEDAx.scm
@@ -24,6 +24,16 @@
 (use-modules (netlist schematic)
              (netlist schematic toplevel))
 
+;;; Escape spaces and tabs in string S.
+(define (escape-whitespaces s)
+  (define (escape-spaces s)
+    (string-join (string-split s #\space) "\\ "))
+
+  (define (escape-tabs s)
+    (string-join (string-split s #\tab) "\\\t"))
+
+  (escape-tabs (escape-spaces s)))
+
 ;;
 ;; return device attribute
 ;;
@@ -62,13 +72,17 @@
 (define (tEDAx:components ls)
   (for-each
    (lambda (package)
-     (format #t "\tfootprint ~A ~A\n\tdevice ~A ~A\n\tvalue ~A ~A\n\n"
-       package
-       (tEDAx:get-pattern package)
-       package
-       (tEDAx:get-device package)
-       package
-       (tEDAx:get-value package)))
+     (let ((package-name (escape-whitespaces package))
+           (pattern (escape-whitespaces (tEDAx:get-pattern package)))
+           (device (escape-whitespaces (tEDAx:get-device package)))
+           (value (escape-whitespaces (tEDAx:get-value package))))
+       (format #t "\tfootprint ~A ~A\n\tdevice ~A ~A\n\tvalue ~A ~A\n\n"
+               package-name
+               pattern
+               package-name
+               device
+               package-name
+               value)))
    ls))
 
 ;;
@@ -81,8 +95,8 @@
    (map
     (lambda (net)
       (format #f "\tconn ~A ~A ~A\n"
-	netname
-        (package net)
+	(escape-whitespaces netname)
+        (escape-whitespaces (package net))
         (pinnumber net)))
     nets)
    ""))

--- a/netlist/tests/common/JD-tEDAx.out
+++ b/netlist/tests/common/JD-tEDAx.out
@@ -35,11 +35,11 @@ begin netlist v1 netlist
 
 	footprint V1 none
 	device V1 vpulse
-	value V1 pulse 3.3 0 1u 10p 10p 1.25u 2.5u
+	value V1 pulse\ 3.3\ 0\ 1u\ 10p\ 10p\ 1.25u\ 2.5u
 
 	footprint Vdd none
 	device Vdd VOLTAGE_SOURCE
-	value Vdd DC 3.3V
+	value Vdd DC\ 3.3V
 
 	footprint X1 UNKNOWN
 	device X1 LVD

--- a/netlist/tests/common/TwoStageAmp-tEDAx.out
+++ b/netlist/tests/common/TwoStageAmp-tEDAx.out
@@ -11,7 +11,7 @@ begin netlist v1 netlist
 
 	footprint A3 UNKNOWN
 	device A3 directive
-	value A3 .options TEMP=25
+	value A3 .options\ TEMP=25
 
 	footprint C1 UNKNOWN
 	device C1 CAPACITOR
@@ -87,11 +87,11 @@ begin netlist v1 netlist
 
 	footprint VCC none
 	device VCC VOLTAGE_SOURCE
-	value VCC DC 15V
+	value VCC DC\ 15V
 
 	footprint Vinput none
 	device Vinput vsin
-	value Vinput DC 1.6V AC 10MV SIN(0 1MV 1KHZ)
+	value Vinput DC\ 1.6V\ AC\ 10MV\ SIN(0\ 1MV\ 1KHZ)
 
 	conn GND CE1 1
 	conn GND CE2 1

--- a/netlist/tests/common/multiequal-tEDAx.out
+++ b/netlist/tests/common/multiequal-tEDAx.out
@@ -11,7 +11,7 @@ begin netlist v1 netlist
 
 	footprint V1 none
 	device V1 VOLTAGE_SOURCE
-	value V1 DC 1V
+	value V1 DC\ 1V
 
 	conn GND R1 1
 	conn GND V1 2


### PR DESCRIPTION
- Fix escaping of whitespaces as reported in #686 (Closes #686)
- Fix output of `nettag` attributes (reported on the *geda-user* mailing list)