### PR TITLE
Allow changing of net colors in lepton-schematic GUI

### DIFF
--- a/libleptongui/src/gschem_selection_adapter.c
+++ b/libleptongui/src/gschem_selection_adapter.c
@@ -652,7 +652,8 @@ gschem_selection_adapter_get_object_color (GschemSelectionAdapter *adapter)
         (object->type == OBJ_CIRCLE) ||
         (object->type == OBJ_LINE)   ||
         (object->type == OBJ_PATH)   ||
-        (object->type == OBJ_TEXT))) {
+        (object->type == OBJ_TEXT)   ||
+        (object->type == OBJ_NET))) {
       color = geda_object_get_color (object);
       break;
     }


### PR DESCRIPTION
Allow users to change a color of net objects
via the standard color selection combo box of the
"Object Properties" dialog in lepton-schematic GUI.