### PR TITLE
Fix the close confirmation dialog's title

### DIFF
--- a/libleptongui/src/gschem_close_confirmation_dialog.c
+++ b/libleptongui/src/gschem_close_confirmation_dialog.c
@@ -831,6 +831,7 @@ x_dialog_close_window (GschemToplevel *w_current)
                                      "unsaved-pages", unsaved_pages,
                                      NULL));
 
+  gtk_window_set_title (GTK_WINDOW (dialog), "lepton-schematic");
   gtk_window_set_transient_for (GTK_WINDOW (dialog),
                                 GTK_WINDOW (w_current->main_window));
 


### PR DESCRIPTION
Show "lepton-schematic" in the title, instead of "\<unknown\>".
I wonder why nobody noticed this before. :-)
