### PR TITLE
Improve the delete locked confirmation dialog

### DIFF
--- a/libleptongui/src/o_delete.c
+++ b/libleptongui/src/o_delete.c
@@ -79,16 +79,18 @@ void o_delete_selected (GschemToplevel *w_current)
       gtk_message_dialog_new (NULL,
                               (GtkDialogFlags) (GTK_DIALOG_MODAL
                                                 | GTK_DIALOG_DESTROY_WITH_PARENT),
-                              GTK_MESSAGE_QUESTION,
+                              GTK_MESSAGE_WARNING,
                               GTK_BUTTONS_NONE,
-                              ngettext ("Delete locked object?",
-                                        "Delete %1$u locked objects?",                                                                                        locked_num),
-                              locked_num);
+                              _("Warning: the selection contains locked objects.\n"
+                              "Please choose what objects you'd like to delete:"));
+
     gtk_dialog_add_buttons (GTK_DIALOG (dialog),
-        GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL,
-        GTK_STOCK_YES, GTK_RESPONSE_YES,
-        GTK_STOCK_NO, GTK_RESPONSE_NO, NULL);
-    gtk_dialog_set_default_response (GTK_DIALOG (dialog), GTK_RESPONSE_NO);
+        _("Delete _all"), GTK_RESPONSE_YES,
+        _("All, _except locked"), GTK_RESPONSE_NO,
+        GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL, NULL);
+
+    gtk_dialog_set_default_response (GTK_DIALOG (dialog), GTK_RESPONSE_CANCEL);
+    gtk_window_set_title (GTK_WINDOW (dialog), _("Delete"));
 
     resp = gtk_dialog_run (GTK_DIALOG (dialog));
     gtk_widget_destroy (dialog);


### PR DESCRIPTION
- give it a title
- make it a "warning" dialog
- extend the text message
- action text on buttons, rather than yes/no

old:
![del_locked_dlg_old](https://user-images.githubusercontent.com/26083750/100073196-1c6d4680-2e35-11eb-84c6-c717103c840a.png)

new:
![del_locked_dlg_new](https://user-images.githubusercontent.com/26083750/100073212-22632780-2e35-11eb-82f7-b33ec2e0345c.png)
