### PR TITLE
Allow changing of bus colors in lepton-schematic GUI

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -44,8 +44,8 @@ Notable changes in Lepton EDA 1.9.12 (upcoming)
   filters can work with file names matching the following
   shell patterns: `*.[sS][cC][hH]` and `*.[sS][yY][mM]`.
 
-- It is now possible to change a color of net objects in
-  the `Object Properties` dialog.
+- It is now possible to change a color of net and bus objects
+  in the `Object Properties` dialog.
 
 
 Notable changes in Lepton EDA 1.9.11 (20200604)

--- a/libleptongui/src/gschem_selection_adapter.c
+++ b/libleptongui/src/gschem_selection_adapter.c
@@ -653,7 +653,8 @@ gschem_selection_adapter_get_object_color (GschemSelectionAdapter *adapter)
         (object->type == OBJ_LINE)   ||
         (object->type == OBJ_PATH)   ||
         (object->type == OBJ_TEXT)   ||
-        (object->type == OBJ_NET))) {
+        (object->type == OBJ_NET)    ||
+        (object->type == OBJ_BUS))) {
       color = geda_object_get_color (object);
       break;
     }


### PR DESCRIPTION
Allow users to change a color of bus objects
via the standard color selection combo box of the
"Object Properties" dialog in lepton-schematic GUI.

In #692 support for changing a color of net objects has
been added. I think it won't hurt to allow changing of
bus colors, too.
