### PR TITLE
Fix formatting of the gafrc page in the reference manual

### DIFF
--- a/docs/manual/configuration.texi
+++ b/docs/manual/configuration.texi
@@ -122,6 +122,8 @@ directories where Lepton will search for symbol files (@file{*.sym}).
 search for @dfn{source files} (defined by the @attrib{source=}
 attribute) used in hierarchical schematics.
 
+@itemize @minus
+
 @item
 @code{(reset-component-library)}
 
@@ -159,6 +161,8 @@ Component" dialog prefixed with the string @var{prefix}, for example:
 @code{(source-library @var{path})}
 
 Add the directory @var{path} to the list of source libraries.
+
+@end itemize
 
 @item
 Color scheme used for exporting/printing by @code{lepton-cli export}


### PR DESCRIPTION
Add missing itemization. In the [original wiki document](https://github.com/lepton-eda/lepton-eda/wiki/Configuration-Settings#user-content-legacy-configuration-files-still-in-use) there are only two top-level items ("Component and source libraries" and "Color scheme"), but currently that [page in the manual](https://graahnul-grom.github.io/ref-manual/lepton/gafrc.html#gafrc) displays 7 items.
Yes, I've uploaded refman to my Lepton page. :-)
