### PR TITLE
Fix the (schematic attrib) and (schematic menu) modules

### DIFF
--- a/libleptongui/scheme/schematic/attrib.scm
+++ b/libleptongui/scheme/schematic/attrib.scm
@@ -25,7 +25,7 @@
   #:use-module (lepton log)
   #:use-module (schematic core attrib)
   #:use-module (schematic core gettext)
-  #:use-module (schematic ffi)
+  #:use-module (lepton ffi)
 
   #:export (attribute-name
             init-schematic-attribs!))
@@ -51,7 +51,7 @@
   (let ((proc (delay
                 (pointer->procedure
                  int
-                 (dynamic-func "s_attrib_uniq" libleptongui)
+                 (dynamic-func "s_attrib_uniq" liblepton)
                  (list '*)))))
     (force proc)))
 
@@ -59,7 +59,7 @@
   (let ((proc (delay
                 (pointer->procedure
                  int
-                 (dynamic-func "s_attrib_add_entry" libleptongui)
+                 (dynamic-func "s_attrib_add_entry" liblepton)
                  (list '*)))))
     (force proc)))
 

--- a/libleptongui/scheme/schematic/menu.scm
+++ b/libleptongui/scheme/schematic/menu.scm
@@ -21,14 +21,14 @@
 (define-module (schematic menu)
   #:use-module (system foreign)
 
-  #:use-module (schematic ffi)
+  #:use-module (lepton ffi)
 
   #:export (add-menu))
 
 (define add-menu-entry!
   (pointer->procedure
    int
-   (dynamic-func "s_menu_add_entry" libleptongui)
+   (dynamic-func "s_menu_add_entry" liblepton)
    (list '* '*)))
 
 (define (add-menu name items)


### PR DESCRIPTION
Functions used in these modules are exported
from `liblepton`, not `libleptongui`:
- `s_attrib_uniq()`
- `s_attrib_add_entry()`
- `s_menu_add_entry()`

Change `dynamic-func()` calls accordingly,
use proper module: `(lepton ffi)`.
