### PR TITLE
Make Lepton work under Cygwin again

### DIFF
--- a/liblepton/scheme/.gitignore
+++ b/liblepton/scheme/.gitignore
@@ -2,4 +2,6 @@ Makefile
 Makefile.in
 test-suite.log
 lepton/core/gettext.scm
+lepton/ffi.scm
+lepton/log.scm
 *~

--- a/liblepton/scheme/Makefile.am
+++ b/liblepton/scheme/Makefile.am
@@ -14,11 +14,9 @@ nobase_dist_scmdata_DATA = \
 	lepton/color-map.scm \
 	lepton/config.scm \
 	lepton/eval.scm \
-	lepton/ffi.scm \
 	lepton/file-system.scm \
 	lepton/library.scm \
 	lepton/library/component.scm \
-	lepton/log.scm \
 	lepton/log-rotate.scm \
 	lepton/object.scm \
 	lepton/option.scm \
@@ -83,7 +81,10 @@ nobase_dist_scmdata_DATA = \
 	symcheck/option.scm \
 	symcheck/report.scm
 
-nobase_scmdata_DATA = lepton/core/gettext.scm
+nobase_scmdata_DATA = \
+	lepton/core/gettext.scm \
+	lepton/ffi.scm \
+	lepton/log.scm
 
 TESTS = \
 	unit-tests/backend-spice-noqsi.scm \
@@ -171,7 +172,20 @@ SCM_LOG_DRIVER = \
 	-L $(abs_top_builddir)/symcheck/scheme \
 	--no-auto-compile -e main/with-toplevel -s $(abs_top_srcdir)/liblepton/scheme/unit-test.scm
 
-dist_noinst_DATA = lepton/core/gettext.scm.in unit-test.scm $(TESTS)
+dist_noinst_DATA = \
+	lepton/core/gettext.scm.in \
+	unit-test.scm \
+	$(TESTS) \
+	lepton/ffi.scm.in \
+	lepton/log.scm.in
+
+if CYGWIN
+LIBLEPTON=cyglepton-7
+LIBGLIB=cygglib-2.0-0
+else
+LIBLEPTON=liblepton
+LIBGLIB=libglib-2.0
+endif
 
 lepton/core/gettext.scm: $(srcdir)/lepton/core/gettext.scm.in Makefile
 	@domain=$(LIBLEPTON_GETTEXT_DOMAIN); \
@@ -183,4 +197,17 @@ lepton/core/gettext.scm: $(srcdir)/lepton/core/gettext.scm.in Makefile
 	  echo "Recreating $@"; mv $@.new $@; \
 	fi
 
-CLEANFILES = lepton/core/gettext.scm unit-tests/dummy.sym unit-tests/dummy.xpm
+lepton/ffi.scm: $(srcdir)/lepton/ffi.scm.in
+	$(MKDIR_P) lepton/; \
+	sed -e 's,[@]LIBLEPTON[@],$(LIBLEPTON),g' < $(srcdir)/$@.in > $@
+
+lepton/log.scm: $(srcdir)/lepton/log.scm.in
+	$(MKDIR_P) lepton/; \
+	sed -e 's,[@]LIBGLIB[@],$(LIBGLIB),g' < $(srcdir)/$@.in > $@
+
+CLEANFILES = \
+	lepton/core/gettext.scm \
+	unit-tests/dummy.sym \
+	unit-tests/dummy.xpm \
+	lepton/ffi.scm \
+	lepton/log.scm

--- a/liblepton/scheme/lepton/ffi.scm.in
+++ b/liblepton/scheme/lepton/ffi.scm.in
@@ -21,4 +21,4 @@
   #:export (liblepton))
 
 (define liblepton
-  (dynamic-link (or (getenv "LIBLEPTON") "liblepton")))
+  (dynamic-link (or (getenv "LIBLEPTON") "@LIBLEPTON@")))

--- a/liblepton/scheme/lepton/log.scm.in
+++ b/liblepton/scheme/lepton/log.scm.in
@@ -31,7 +31,7 @@
 ;; Logging messages
 ;; ================================================================
 
-(define libglib (dynamic-link "libglib-2.0"))
+(define libglib (dynamic-link "@LIBGLIB@"))
 
 (define g_log
   (let ((proc (delay (pointer->procedure

--- a/libleptonattrib/Makefile.am
+++ b/libleptonattrib/Makefile.am
@@ -1,9 +1,19 @@
 bin_SCRIPTS = lepton-attrib
 
+if CYGWIN
+LIBLEPTONATTRIB=cygleptonattrib-2
+if ENABLE_GTK3
+LIBGTK = cyggtk-3-0
+else
+LIBGTK = cyggtk-x11-2.0-0
+endif
+else
+LIBLEPTONATTRIB=libleptonattrib
 if ENABLE_GTK3
 LIBGTK = libgtk-3
 else
 LIBGTK = libgtk-x11-2.0
+endif
 endif
 
 SUBDIRS = po src include design data docs
@@ -28,9 +38,11 @@ ChangeLog: $(top_builddir)/stamp-git
 	) > $@
 endif HAVE_GIT_REPO
 
-do_subst = sed -e 's,[@]libdir[@],$(libdir),g' \
+do_subst = sed \
+	-e 's,[@]libdir[@],$(libdir),g' \
 	-e 's,[@]GUILE[@],$(GUILE),g' \
 	-e 's,[@]LIBGTK[@],$(LIBGTK),g' \
+	-e 's,[@]LIBLEPTONATTRIB[@],$(LIBLEPTONATTRIB),g' \
 	-e 's,[@]localedir[@],$(localedir),g' \
 	-e 's,[@]ccachedir[@],@LEPTON_SCM_PRECOMPILE_DIR@,g'
 

--- a/libleptonattrib/lepton-attrib.scm
+++ b/libleptonattrib/lepton-attrib.scm
@@ -33,7 +33,7 @@ exec @GUILE@ -s "$0" "$@"
                 "liblepton_init")
 
 (define libgtk (dynamic-link "@LIBGTK@"))
-(define libleptonattrib (dynamic-link "libleptonattrib"))
+(define libleptonattrib (dynamic-link "@LIBLEPTONATTRIB@"))
 
 (define gtk-init
   (pointer->procedure

--- a/libleptongui/scheme/Makefile.am
+++ b/libleptongui/scheme/Makefile.am
@@ -24,7 +24,6 @@ nobase_dist_scmdata_DATA = \
 	schematic/builtins.scm \
 	schematic/core/gettext.scm \
 	schematic/dialog.scm \
-	schematic/ffi.scm \
 	schematic/gui/keymap.scm \
 	schematic/gui/stroke.scm \
 	schematic/hook.scm \
@@ -46,12 +45,23 @@ nobase_dist_scmdata_DATA = \
 
 nobase_scmdata_DATA = \
 	schematic/gschemdoc.scm \
-	schematic/ffi/gtk.scm
+	schematic/ffi/gtk.scm \
+	schematic/ffi.scm
 
+if CYGWIN
+LIBLEPTONGUI=cygleptongui-1
+if ENABLE_GTK3
+LIBGTK = cyggtk-3-0
+else
+LIBGTK = cyggtk-x11-2.0-0
+endif
+else
+LIBLEPTONGUI=libleptongui
 if ENABLE_GTK3
 LIBGTK = libgtk-3
 else
 LIBGTK = libgtk-x11-2.0
+endif
 endif
 
 schematic/gschemdoc.scm: schematic/gschemdoc.scm.in
@@ -62,12 +72,18 @@ schematic/ffi/gtk.scm: schematic/ffi/gtk.scm.in
 	$(MKDIR_P) schematic/ffi/; \
 	sed -e 's,[@]LIBGTK[@],$(LIBGTK),g' < $(srcdir)/$@.in > $@
 
+schematic/ffi.scm: schematic/ffi.scm.in
+	$(MKDIR_P) schematic/; \
+	sed -e 's,[@]LIBLEPTONGUI[@],$(LIBLEPTONGUI),g' < $(srcdir)/$@.in > $@
+
 
 EXTRA_DIST = \
 	schematic/gschemdoc.scm.in \
-	schematic/ffi/gtk.scm.in
+	schematic/ffi/gtk.scm.in \
+	schematic/ffi.scm.in
 
 CLEANFILES = \
 	schematic/gschemdoc.scm \
 	schematic/precompile-config.scm \
-	schematic/ffi/gtk.scm
+	schematic/ffi/gtk.scm \
+	schematic/ffi.scm

--- a/libleptongui/scheme/schematic/.gitignore
+++ b/libleptongui/scheme/schematic/.gitignore
@@ -1,3 +1,4 @@
 gschemdoc.scm
 precompile-config.scm
 ffi/gtk.scm
+ffi.scm

--- a/libleptongui/scheme/schematic/ffi.scm.in
+++ b/libleptongui/scheme/schematic/ffi.scm.in
@@ -22,4 +22,4 @@
   #:export (libleptongui))
 
 (define libleptongui
-  (dynamic-link (or (getenv "LIBLEPTONGUI") "libleptongui")))
+  (dynamic-link (or (getenv "LIBLEPTONGUI") "@LIBLEPTONGUI@")))

--- a/m4/geda-host.m4
+++ b/m4/geda-host.m4
@@ -48,6 +48,8 @@ AC_DEFUN([AX_HOST],
       ;;
   esac
 
+  AM_CONDITIONAL([CYGWIN], [test x$OS_CYGWIN = xyes])
+
   AC_MSG_CHECKING([for Linux host])
   AC_MSG_RESULT([$OS_LINUX])
 


### PR DESCRIPTION
Libraries loaded by `dynamic-load()` Guile function
should be named differently under Cygwin.
Adjust the build system so that, depending on the platform,
appropriate names are substituted.

It is now possible to build Lepton under Cygwin
(which was fixed in #700 and #701) and run
the GUI tools. I've even managed to compile it
with GTK3 (though `--without-attrib`).

What have to be done yet, is parsing of the
`xxx_SHLIB_VERSION` strings, because a cygwin
library name has the major version number appended.
For example, if `LIBLEPTON_SHLIB_VERSION='7:0:0'`,
Cygwin name should be `cyglepton-7`.
It's better to automate it, so we don't have to change
Cygwin names with every release.
