### PR TITLE
Fix processing of lepton-schematic -c and -s command line arguments

### DIFF
--- a/libleptongui/src/lepton-schematic.c
+++ b/libleptongui/src/lepton-schematic.c
@@ -137,8 +137,6 @@ main_prog (SCM file_list_s)
 
   cwd = g_get_current_dir();
 
-  scm_dynwind_begin ((scm_t_dynwind_flags) 0);
-
   /* Set up atexit handlers */
   gschem_atexit (i_vars_atexit_save_cache_config, NULL);
 
@@ -210,5 +208,4 @@ main_prog (SCM file_list_s)
     x_widgets_show_log (w_current);
   }
 
-  scm_dynwind_end ();
 }


### PR DESCRIPTION
@vzh Could you please explain (in technical terms)
to the general public, why does it fix the issue (#696)?
Taking into account [comments](https://github.com/lepton-eda/lepton-eda/blob/ea15637e5f3949fc6ed9aa615608e038dd895c70/libleptongui/src/g_window.c#L98)
in `g_dynwind_window()`.

Maybe a rush into FFI-ing and DBCS-ing everything
left and right, without considering whether it's
suitable or not in each particular case, was not
that good idea, after all? :-)
Here I can see (IMHO, of course) an example of,
so to say, a "refactoring backwards": instead of
keeping `lepton-schematic` initialisation code
together, it is now randomly scattered between C
and Guile code (with inconsistently named functions,
BTW), which is executed in different contexts.
Isn't it dangerous, WDYT?
