### PR TITLE
Make lepton-attrib prompt to save changes on exit

### DIFF
--- a/libleptonattrib/src/attrib.c
+++ b/libleptonattrib/src/attrib.c
@@ -95,6 +95,19 @@ gboolean attrib_really_quit(void)
   eda_config_save (cfg, NULL);
 
 
+  /* Deactivate the current cell to trigger "deactivate" signal.
+   * This allows changing of the sheet_head->CHANGED flag in the
+   * on_deactivate() handler function if needed.
+  */
+  for (int i = 0; i < NUM_SHEETS; ++i)
+  {
+    if (sheets[i] != NULL)
+    {
+       gtk_sheet_set_active_cell (sheets[i], -1, -1);
+    }
+  }
+
+
   if (sheet_head->CHANGED == TRUE) {
     x_dialog_unsaved_data();
   } else {

--- a/libleptonattrib/src/x_gtksheet.c
+++ b/libleptonattrib/src/x_gtksheet.c
@@ -59,6 +59,39 @@
 
 static void show_entry(GtkWidget *widget, gpointer data);
 
+
+static gchar* current_cell_text = NULL;
+
+
+static gboolean
+on_activate (GtkSheet* sheet,
+             gint      row,
+             gint      column,
+             gpointer  data)
+{
+  current_cell_text = gtk_sheet_get_entry_text (sheet);
+
+  return FALSE; /* ignored */
+}
+
+
+static gboolean
+on_deactivate (GtkSheet* sheet,
+               gint      row,
+               gint      column,
+               gpointer  data)
+{
+  gchar* str = gtk_sheet_get_entry_text (sheet);
+
+  if (strcmp (str, current_cell_text) != 0)
+  {
+    sheet_head->CHANGED = TRUE;
+  }
+
+  return TRUE; /* TRUE => allow deactivation */
+}
+
+
 /*! \brief Create the GtkSheet
  *
  * Creates and initializes the GtkSheet widget, which is the
@@ -142,6 +175,18 @@ x_gtksheet_init()
        *  gattrib, but leave the code in just in case I want to put it back.  */
       g_signal_connect (gtk_sheet_get_entry (GTK_SHEET (sheets[i])),
                         "changed", (GCallback) show_entry, NULL);
+
+
+      g_signal_connect (sheets[i],
+                        "activate",
+                        G_CALLBACK (&on_activate),
+                        NULL);
+
+      g_signal_connect (sheets[i],
+                        "deactivate",
+                        G_CALLBACK (&on_deactivate),
+                        NULL);
+
     }
   }
 }


### PR DESCRIPTION
Track text value of the current cell, and if it's
modified after the cell is deactivated, mark the
schematic as changed, so that `lepton-attrib` prompt
the user to save changes on exit.

I do not set the "changed" flag in `s_toplevel_add_new_attrib()`,
because initially the new column is empty.

Closes #702.

It seems that I've discovered yet another bug: after deleting
an attribute column and saving changes, all invisible attributes
becomes visible. Could anyone confirm?
