### PR TITLE
Install Lepton reference manual images into the info directory

### DIFF
--- a/docs/manual/Makefile.am
+++ b/docs/manual/Makefile.am
@@ -23,6 +23,9 @@ schematics_png = ${schematics:.sch=.png}
 
 PICTURES = $(schematics) $(schematics_eps) $(schematics_png)
 
+infoimagesdir = $(infodir)
+infoimages_DATA = $(schematics_png)
+
 # lepton-cli export --no-color -k 0,5cm -o coordinate-space.png coordinate-space.sch
 # lepton-cli export --no-color -o coordinate-space.pdf coordinate-space.sch && pdftops -eps coordinate-space.pdf coordinate-space.eps
 # lepton-cli export -k 1cm -o text-layout.png text-layout.sch


### PR DESCRIPTION
`make install` should copy image files into the info
directory, too (usually, `/usr/share/info/`).

Thank you, Bdale (@bdale), for reporting this on gitter.
