### PR TITLE
Convert vams and vhdl netlist backend files to UTF-8

### DIFF
--- a/netlist/scheme/backend/gnet-vams.scm
+++ b/netlist/scheme/backend/gnet-vams.scm
@@ -383,7 +383,7 @@ END ENTITY ~A;
 ;;;    The disconnection specification will not be used.
 ;;;
 ;;;    The use clause will not be used since we pass the responsibility to the
-;;;    primary unit (where it ís not yet supported).
+;;;    primary unit (where it is not yet supported).
 ;;;
 ;;;    The signal declation will be used to convey signals held within the
 ;;;    architecture.

--- a/netlist/scheme/backend/gnet-vhdl.scm
+++ b/netlist/scheme/backend/gnet-vhdl.scm
@@ -408,7 +408,7 @@ ENTITY ~A IS
 ;;;    The disconnection specification will not be used.
 ;;;
 ;;;    The use clause will not be used since we pass the responsibility to the
-;;;    primary unit (where it ís not yet supported).
+;;;    primary unit (where it is not yet supported).
 ;;;
 ;;;    The signal declation will be used to convey signals held within the
 ;;;    architecture.


### PR DESCRIPTION
The encoding was CP-1251.
