### PR TITLE
Update the Help menu

### DIFF
--- a/libleptongui/scheme/conf/schematic/keys.scm
+++ b/libleptongui/scheme/conf/schematic/keys.scm
@@ -95,8 +95,6 @@
 
 (global-set-key "H A" '&help-about)
 (global-set-key "H M" '&help-manual)
-(global-set-key "H F" '&help-faq)
-(global-set-key "H G" '&help-guide)
 (global-set-key "H W" '&help-wiki)
 (global-set-key "H H" '&help-hotkeys)
 (global-set-key "H C" '&hierarchy-documentation)

--- a/libleptongui/scheme/conf/schematic/menu.scm
+++ b/libleptongui/scheme/conf/schematic/menu.scm
@@ -301,8 +301,8 @@
 
 ( define help-menu-items
 ( list
-  ( list (N_ "Docu_mentation") '&help-manual "help-browser" )
-  ( list (N_ "_Wiki")          '&help-wiki   "web-browser" )
+  ( list (N_ "Lepton EDA Reference _Manual") '&help-manual "help-browser" )
+  ( list (N_ "gEDA _Wiki Documentation")     '&help-wiki   "web-browser" )
   ( list "SEPARATOR" #f #f )
   ( list (N_ "Find Component D_ocumentation") '&hierarchy-documentation "symbol-datasheet" )
   ( list "SEPARATOR" #f #f )

--- a/libleptongui/scheme/conf/schematic/menu.scm
+++ b/libleptongui/scheme/conf/schematic/menu.scm
@@ -301,8 +301,6 @@
 
 ( define help-menu-items
 ( list
-  ( list (N_ "User _Guide")    '&help-guide  "gtk-help" )
-  ( list (N_ "_FAQ")           '&help-faq    "help-faq" )
   ( list (N_ "Docu_mentation") '&help-manual "help-browser" )
   ( list (N_ "_Wiki")          '&help-wiki   "web-browser" )
   ( list "SEPARATOR" #f #f )

--- a/libleptongui/scheme/gschem/builtins.scm
+++ b/libleptongui/scheme/gschem/builtins.scm
@@ -120,8 +120,6 @@
                ;; Documentation-related actions
                &hierarchy-documentation
                &help-manual
-               &help-guide
-               &help-faq
                &help-wiki
                &help-about
                ;; Backward compatibility:

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -526,18 +526,6 @@ found, shows a dialog with an error message."
 
 
 (define-action-public
-    (&help-guide #:label (G_ "lepton-schematic User Guide") #:icon "gtk-help"
-                 #:tooltip (G_ "View the lepton-schematic User Guide in a browser."))
-  (show-wiki "geda:gschem_ug"))
-
-
-(define-action-public
-    (&help-faq #:label (G_ "lepton-schematic FAQ") #:icon "help-faq"
-     #:tooltip (G_ "Frequently Asked Questions about using lepton-schematic."))
-  (show-wiki "geda:faq-gschem"))
-
-
-(define-action-public
     (&help-wiki #:label (G_ "Lepton EDA wiki") #:icon "web-browser"
      #:tooltip (G_ "View the front page of the Lepton EDA wiki in a browser."))
   (show-wiki))

--- a/libleptongui/scheme/schematic/gschemdoc.scm.in
+++ b/libleptongui/scheme/schematic/gschemdoc.scm.in
@@ -99,7 +99,7 @@
        (else c)))
    name))
 
-(define* (show-wiki #:optional (page "index"))
+(define* (show-wiki #:optional (page "geda:documentation"))
   "show-wiki PAGE
 
 Launch a browser to display a page from the offline version of the


### PR DESCRIPTION
- Remove `help-guide` and `help-faq` actions and menu items.
These pages are not so relevant these days.
- Make `help-wiki` open the "gEDA Tool Suite documentation" page.
From this page one can get to the FAQ, gschem User's Guide and
many other documents. This is a local equivalent of [this page](http://wiki.geda-project.org/geda:documentation).
- Rename `Documentation` and `Wiki` menu items.
Give them more descriptive captions.

old:
![help_menu_old](https://user-images.githubusercontent.com/26083750/101361792-5d367800-3897-11eb-9e61-65b1b4a023c5.png)

new:
![help_menu_new](https://user-images.githubusercontent.com/26083750/101361820-6293c280-3897-11eb-9965-13f9cfb04e60.png)
