### PR TITLE
Fix lepton-attrib code that removes an attribute column

### DIFF
--- a/libleptonattrib/include/prototype.h
+++ b/libleptonattrib/include/prototype.h
@@ -53,6 +53,7 @@ void s_string_list_sort_master_pin_attrib_list();
 /* ------------- s_table.c ------------- */
 void s_table_print (TABLE** src, int rows, int cols);
 TABLE **s_table_new(int rows, int cols);
+TABLE **s_table_copy (TABLE** src, int col_skip, int rows, int cols);
 TABLE **s_table_resize(TABLE **table,
                        int rows, int old_cols, int new_cols);
 void s_table_destroy(TABLE **table, int row_count, int col_count);

--- a/libleptonattrib/include/prototype.h
+++ b/libleptonattrib/include/prototype.h
@@ -51,6 +51,7 @@ void s_string_list_sort_master_pin_attrib_list();
 
 
 /* ------------- s_table.c ------------- */
+void s_table_print (TABLE** src, int rows, int cols);
 TABLE **s_table_new(int rows, int cols);
 TABLE **s_table_resize(TABLE **table,
                        int rows, int old_cols, int new_cols);

--- a/libleptonattrib/src/s_table.c
+++ b/libleptonattrib/src/s_table.c
@@ -49,6 +49,43 @@
 
 /* ===================  Public Functions  ====================== */
 
+
+#ifdef DEBUG
+
+/*! \brief Debug: print table's contents to STDOUT
+ *
+ * \param src   2-dimensional array of TABLE structures to print
+ * \param rows  number of rows in src
+ * \param cols  number of columns in src
+ */
+void
+s_table_print (TABLE** src, int rows, int cols)
+{
+  printf( "\n\n ++ ++ s_table_print( rows: [%d] cols: [%d] )\n", rows, cols );
+
+  for ( int j = 0; j < rows; j++ )
+  {
+    printf( "== row: [%d] name: [%s]\n", j, src[j][0].row_name );
+
+    for ( int k = 0; k < cols; k++ )
+    {
+      printf( "  -- col: [%d] [%s] == [%s]\n", k,
+                                               src[j][k].col_name,
+                                               src[j][k].attrib_value );
+
+      printf( "     ->row: [%d] ->col: [%d]\n", src[j][k].row,
+                                                src[j][k].col );
+      printf( "     ->vis: [%d] ->sho: [%d]\n", src[j][k].visibility,
+                                                src[j][k].show_name_value );
+    }
+  }
+
+  printf( "\n" );
+}
+
+#endif
+
+
 /*------------------------------------------------------------------*/
 /*! \brief Create a new table
  *

--- a/libleptonattrib/src/s_table.c
+++ b/libleptonattrib/src/s_table.c
@@ -131,6 +131,62 @@ TABLE **s_table_new(int rows, int cols)
 }
 
 
+/*! \brief Make a copy of the \a src array
+ *
+ * \par Function Description
+ * Returns a copy of the 2-dimensional array of the TABLE
+ * structures \a src, excluding data in the culumn \a col_skip.
+ * It's a helper function to be used in the "delete attrib
+ * column" operation: s_toplevel_delete_attrib_col().
+ * The resulting array has a dimensions of \a rows x \a cols - 1.
+ *
+ * \param src       an array of the TABLE structures to copy
+ * \param col_skip  index of the column to skip (0-based)
+ * \param rows      number of rows in \a src
+ * \param cols      number of columns in \a src
+ *
+ * \return          a copy of \a src, minus data in the \a col_skip column
+ */
+TABLE**
+s_table_copy (TABLE** src, int col_skip, int rows, int cols)
+{
+  g_return_val_if_fail (src != NULL, NULL);
+  g_return_val_if_fail (col_skip < cols, NULL);
+
+  TABLE** dst = s_table_new (rows, cols - 1);
+  g_return_val_if_fail (dst != NULL, NULL);
+
+  for (int j = 0; j < rows; j++)
+  {
+    int K = 0;
+
+    for (int k = 0; k < cols - 1; k++)
+    {
+      if (k == col_skip)
+      {
+        K ++ ;
+      }
+
+      dst[j][k].row             = j;
+      dst[j][k].col             = k;
+      dst[j][k].visibility      = src[j][ K ].visibility;
+      dst[j][k].show_name_value = src[j][ K ].show_name_value;
+
+      dst[j][k].row_name     = g_strdup( src[j][ K ].row_name );
+      dst[j][k].col_name     = g_strdup( src[j][ K ].col_name );
+      dst[j][k].attrib_value = g_strdup( src[j][ K ].attrib_value );
+
+      K ++ ;
+
+    } /* for: columns */
+
+  } /* for: rows */
+
+  return dst;
+
+} /* s_table_copy() */
+
+
 /*------------------------------------------------------------------*/
 /*! \brief Resize a TABLE
  *

--- a/libleptonattrib/src/s_toplevel.c
+++ b/libleptonattrib/src/s_toplevel.c
@@ -328,6 +328,8 @@ void s_toplevel_delete_attrib_col() {
   g_debug ("s_toplevel_delete_attrib_col: "
            "Checks were OK, now do real work\n");
 
+  TABLE** table_new = NULL;
+
   /*  Rebuild the gattrib-specific data structures  */
   switch (cur_page) {
 
@@ -348,26 +350,37 @@ void s_toplevel_delete_attrib_col() {
       fprintf (stderr, _("Can't get attrib name\n"));
       return;
     }
+
+    /* Make a copy of the TABLE array, minus data in col to delete:
+    */
+    table_new = s_table_copy (sheet_head->component_table,
+                              mincol,
+                              sheet_head->comp_count,
+                              sheet_head->comp_attrib_count);
     
+    /* Destroy the current TABLE array:
+    */
     s_table_destroy(sheet_head->component_table,
         sheet_head->comp_count, sheet_head->comp_attrib_count);
 
     g_debug ("s_toplevel_delete_attrib_col: "
             "Before deleting comp attrib: comp_attrib_count = %d\n",
             sheet_head->comp_attrib_count);
+
     s_string_list_delete_item(&(sheet_head->master_comp_attrib_list_head),
 			      &(sheet_head->comp_attrib_count), 
 			      attrib_name);
     s_string_list_sort_master_comp_attrib_list(); /* this renumbers list also */
+
     g_free(attrib_name);
     
     g_debug ("s_toplevel_delete_attrib_col: "
             "Just updated comp_attrib string list: new comp_attrib_count = %d\n",
             sheet_head->comp_attrib_count);
 
-    /* Now create new table with new attrib count*/
-    sheet_head->component_table = s_table_new(sheet_head->comp_count, 
-					      sheet_head->comp_attrib_count);
+    /* Use the copy made above as the current TABLE array:
+    */
+    sheet_head->component_table = table_new;
 
     g_debug ("s_toplevel_delete_attrib_col: Updated SHEET_DATA info.\n");
     break;

--- a/libleptonattrib/src/s_toplevel.c
+++ b/libleptonattrib/src/s_toplevel.c
@@ -337,9 +337,6 @@ void s_toplevel_delete_attrib_col() {
      *  attrib.  However, that is difficult.  Therefore, I will just
      *  destroy the old table and recreate it for now. */
 
-    s_table_destroy(sheet_head->component_table, 
-		    sheet_head->comp_count, sheet_head->comp_attrib_count);
-
     /*  Get name (label) of the col to delete from the gtk sheet */
     attrib_name = g_strdup( gtk_sheet_column_button_get_label(sheet, mincol) );
     
@@ -352,6 +349,9 @@ void s_toplevel_delete_attrib_col() {
       return;
     }
     
+    s_table_destroy(sheet_head->component_table,
+        sheet_head->comp_count, sheet_head->comp_attrib_count);
+
     g_debug ("s_toplevel_delete_attrib_col: "
             "Before deleting comp attrib: comp_attrib_count = %d\n",
             sheet_head->comp_attrib_count);


### PR DESCRIPTION
Problem: after deleting an attribute column and saving
changes, all invisible attributes becomes visible.

Such a data mangling resulted from destroying
the cell data without saving its contents first.
It was reconstructed with default values, leading
to messed up schematic with ALL attributes'
visibility reset to "visible" and "value only"
after save.

Fix it by saving the cell data and restoring it after
an attribute is deleted.
