### PR TITLE
Backward-compatible color-map.scm file

### DIFF
--- a/liblepton/lib/print-colormap-darkbg
+++ b/liblepton/lib/print-colormap-darkbg
@@ -1,4 +1,5 @@
-;                                                         -*-Scheme-*-
+( use-modules ( lepton color-map ) )
+
 ;
 ; Dark background color map for printing
 ;

--- a/liblepton/lib/print-colormap-lightbg
+++ b/liblepton/lib/print-colormap-lightbg
@@ -1,4 +1,5 @@
-;                                                         -*-Scheme-*-
+( use-modules ( lepton color-map ) )
+
 ;
 ; Light background color map for lepton-schematic
 ;

--- a/liblepton/scheme/Makefile.am
+++ b/liblepton/scheme/Makefile.am
@@ -2,6 +2,7 @@ scmdatadir = $(LEPTONDATADIR)/scheme
 nobase_dist_scmdata_DATA = \
 	geda.scm \
 	geda-deprecated-config.scm \
+	color-map.scm \
 	geda/object.scm \
 	geda/page.scm \
 	geda/attrib.scm \

--- a/liblepton/scheme/color-map.scm
+++ b/liblepton/scheme/color-map.scm
@@ -15,23 +15,11 @@
 )
 
 
-; Function: color-map-name-to-index()
-;
-; Returns an integer index given one of a color
-; symbols like 'background, 'net, 'text, etc.
-; Returns #f (false) if wrong symbol is specified.
-;
 ( define color-map-name-to-index
   ( @ (lepton color-map) color-map-name-to-index )
 )
 
 
-; Function: color-map-name-from-index()
-;
-; Returns one of a color symbols like 'background,
-; 'net, 'text, etc., given an integer index.
-; Returns #f (false) if wrong index is specified.
-;
 ( define color-map-name-from-index
   ( @ (lepton color-map) color-map-name-from-index )
 )

--- a/liblepton/scheme/color-map.scm
+++ b/liblepton/scheme/color-map.scm
@@ -1,0 +1,38 @@
+; Lepton EDA
+; Backward-compatible color-map.scm file
+; Copyright (C) 2020 Lepton EDA Contributors
+; License: GPLv2+. See the COPYING file
+
+( use-modules ( lepton color-map ) )
+
+
+; Function: color-map-name-to-index()
+;
+; Returns an integer index given one of a color
+; symbols like 'background, 'net, 'text, etc.
+; Returns #f (false) if wrong symbol is specified.
+;
+( define ( color-map-name-to-index sym-name )
+  ; return:
+  ( assoc-ref %color-name-map sym-name )
+)
+
+
+; Function: color-map-name-from-index()
+;
+; Returns one of a color symbols like 'background,
+; 'net, 'text, etc., given an integer index.
+; Returns #f (false) if index is out of bounds.
+;
+( define ( color-map-name-from-index index )
+  ( define ( swap-pair ent )
+    ( cons (cdr ent) (car ent) )
+  )
+  ( define ( invert-mapping )
+    ( map swap-pair %color-name-map )
+  )
+
+  ; return:
+  ( assoc-ref (invert-mapping) index )
+)
+

--- a/liblepton/scheme/color-map.scm
+++ b/liblepton/scheme/color-map.scm
@@ -36,3 +36,15 @@
   ( assoc-ref (invert-mapping) index )
 )
 
+
+
+; Top-level code:
+;
+( format (current-error-port)
+"
+WARNING: You are loading color-map.scm file, which is deprecated.
+Please use the new (lepton color-map) module instead.
+
+"
+)
+

--- a/liblepton/scheme/color-map.scm
+++ b/liblepton/scheme/color-map.scm
@@ -4,24 +4,16 @@
 ; License: GPLv2+. See the COPYING file
 
 
-; Association list: %color-name-map
-;
-; Defines mapping between color symbols
-; like 'background, 'net, 'text, etc.
-; and integer values.
-;
-( define %color-name-map
-  ( @ (lepton color-map) %color-name-map )
+( use-modules
+(
+  ( lepton color-map )
+  #:select
+  (
+    %color-name-map
+    color-map-name-to-index
+    color-map-name-from-index
+  )
 )
-
-
-( define color-map-name-to-index
-  ( @ (lepton color-map) color-map-name-to-index )
-)
-
-
-( define color-map-name-from-index
-  ( @ (lepton color-map) color-map-name-from-index )
 )
 
 

--- a/liblepton/scheme/color-map.scm
+++ b/liblepton/scheme/color-map.scm
@@ -19,7 +19,7 @@
 ;
 ; Returns an integer index given one of a color
 ; symbols like 'background, 'net, 'text, etc.
-; Returns its argument if wrong symbol is specified.
+; Returns #f (false) if wrong symbol is specified.
 ;
 ( define color-map-name-to-index
   ( @ (lepton color-map) color-map-name-to-index )
@@ -30,7 +30,7 @@
 ;
 ; Returns one of a color symbols like 'background,
 ; 'net, 'text, etc., given an integer index.
-; Returns its argument if wrong index is specified.
+; Returns #f (false) if wrong index is specified.
 ;
 ( define color-map-name-from-index
   ( @ (lepton color-map) color-map-name-from-index )

--- a/liblepton/scheme/color-map.scm
+++ b/liblepton/scheme/color-map.scm
@@ -3,18 +3,26 @@
 ; Copyright (C) 2020 Lepton EDA Contributors
 ; License: GPLv2+. See the COPYING file
 
-( use-modules ( lepton color-map ) )
+
+; Association list: %color-name-map
+;
+; Defines mapping between color symbols
+; like 'background, 'net, 'text, etc.
+; and integer values.
+;
+( define %color-name-map
+  ( @ (lepton color-map) %color-name-map )
+)
 
 
 ; Function: color-map-name-to-index()
 ;
 ; Returns an integer index given one of a color
 ; symbols like 'background, 'net, 'text, etc.
-; Returns #f (false) if wrong symbol is specified.
+; Returns its argument if wrong symbol is specified.
 ;
-( define ( color-map-name-to-index sym-name )
-  ; return:
-  ( assoc-ref %color-name-map sym-name )
+( define color-map-name-to-index
+  ( @ (lepton color-map) color-map-name-to-index )
 )
 
 
@@ -22,18 +30,10 @@
 ;
 ; Returns one of a color symbols like 'background,
 ; 'net, 'text, etc., given an integer index.
-; Returns #f (false) if index is out of bounds.
+; Returns its argument if wrong index is specified.
 ;
-( define ( color-map-name-from-index index )
-  ( define ( swap-pair ent )
-    ( cons (cdr ent) (car ent) )
-  )
-  ( define ( invert-mapping )
-    ( map swap-pair %color-name-map )
-  )
-
-  ; return:
-  ( assoc-ref (invert-mapping) index )
+( define color-map-name-from-index
+  ( @ (lepton color-map) color-map-name-from-index )
 )
 
 

--- a/liblepton/scheme/lepton/color-map.scm
+++ b/liblepton/scheme/lepton/color-map.scm
@@ -31,7 +31,9 @@
   #:export (%color-name-map
             display-color-map
             display-outline-color-map
-            print-color-map))
+            print-color-map
+            color-map-name-to-index
+            color-map-name-from-index))
 
 ;;; Map between color index numbers and symbolic color names.
 (define %color-name-map
@@ -64,6 +66,20 @@
   (map (lambda (x) (cons (cdr x) (car x))) %color-name-map))
 
 
+;; Look up the internal system ID for a symbolic color.
+(define (color-map-name-to-index x)
+  (if (symbol? x)
+      (assq-ref %color-name-map x)
+      x))
+
+
+;; Look up the symbolic color for an internal system ID.
+(define (color-map-name-from-index id)
+  (or (assq-ref %color-name-reverse-map id)
+      ;; Fall back to the index if no symbol found.
+      id))
+
+
 (define colors-count
   (pointer->procedure
    size_t
@@ -93,11 +109,6 @@
 ;;; "#RRGGBB" or "#RRGGBBAA" code. The shorter form is used when
 ;;; the alpha component is 0xff.
 (define (color-map->scm color-map)
-  ;; Look up the symbolic color for an internal system ID.
-  (define (color-map-name-from-index id)
-    (or (assq-ref %color-name-reverse-map id)
-        ;; Fall back to the index if no symbol found.
-        id))
 
   (define (id->color id)
     (let ((color (parse-c-struct (color-map-id->color color-map id)
@@ -151,11 +162,6 @@
        (< id (colors-count))))
 
 (define (scm->color-map color-map ls)
-  ;; Look up the internal system ID for a symbolic color.
-  (define (color-map-name-to-index x)
-    (if (symbol? x)
-        (assq-ref %color-name-map x)
-        x))
 
   (define (parse-entry entry)
     ;; Check if map entry has correct type.

--- a/liblepton/scheme/lepton/color-map.scm
+++ b/liblepton/scheme/lepton/color-map.scm
@@ -68,16 +68,12 @@
 
 ;; Look up the internal system ID for a symbolic color.
 (define (color-map-name-to-index x)
-  (if (symbol? x)
-      (assq-ref %color-name-map x)
-      x))
+  (assq-ref %color-name-map x))
 
 
 ;; Look up the symbolic color for an internal system ID.
 (define (color-map-name-from-index id)
-  (or (assq-ref %color-name-reverse-map id)
-      ;; Fall back to the index if no symbol found.
-      id))
+  (assq-ref %color-name-reverse-map id))
 
 
 (define colors-count

--- a/liblepton/scheme/lepton/color-map.scm
+++ b/liblepton/scheme/lepton/color-map.scm
@@ -66,13 +66,18 @@
   (map (lambda (x) (cons (cdr x) (car x))) %color-name-map))
 
 
-;; Look up the internal system ID for a symbolic color.
 (define (color-map-name-to-index x)
+  "Returns an integer index given one of a color
+symbols like 'background, 'net, 'text, etc.
+Returns #f (false) if wrong symbol is specified."
   (assq-ref %color-name-map x))
 
 
 ;; Look up the symbolic color for an internal system ID.
 (define (color-map-name-from-index id)
+  "Returns one of a color symbols like 'background,
+'net, 'text, etc., given an integer index.
+Returns #f (false) if wrong index is specified."
   (assq-ref %color-name-reverse-map id))
 
 

--- a/libleptongui/lib/gschem-colormap-bw
+++ b/libleptongui/lib/gschem-colormap-bw
@@ -1,4 +1,5 @@
-;                                                         -*-Scheme-*-
+( use-modules ( lepton color-map ) )
+
 ;
 ; Light background color map for gschem
 ;

--- a/libleptongui/lib/gschem-colormap-darkbg
+++ b/libleptongui/lib/gschem-colormap-darkbg
@@ -1,4 +1,5 @@
-;                                                         -*-Scheme-*-
+( use-modules ( lepton color-map ) )
+
 ;
 ; Dark background color map for gschem
 ;

--- a/libleptongui/lib/gschem-colormap-lightbg
+++ b/libleptongui/lib/gschem-colormap-lightbg
@@ -1,4 +1,5 @@
-;                                                         -*-Scheme-*-
+( use-modules ( lepton color-map ) )
+
 ;
 ; Light background color map for gschem
 ;


### PR DESCRIPTION
Add `color-map.scm` file with functions:
  - `color-map-name-to-index()`
  - `color-map-name-from-index()`

It makes code calling these functions and
`(load-from-path "color-map.scm")` work again.
Warn that this file is deprecated upon loading.

Closes #707.
