### PR TITLE
Rename the index file in the Lepton EDA Reference Manual

### DIFF
--- a/docs/manual/geda-file-format-spec.texi
+++ b/docs/manual/geda-file-format-spec.texi
@@ -1,4 +1,4 @@
-@node gEDA file format, Index, Development, Top
+@node gEDA file format, Topic Index, Development, Top
 @chapter gEDA/gaf File Format Document
 @cindex gEDA file format
 

--- a/docs/manual/index.texi
+++ b/docs/manual/index.texi
@@ -1,3 +1,3 @@
-@node Index, , gEDA file format, Top
-@unnumbered Index
+@node Topic Index, , gEDA file format, Top
+@unnumbered Topic Index
 @printindex cp

--- a/docs/manual/lepton-manual.texi
+++ b/docs/manual/lepton-manual.texi
@@ -52,7 +52,7 @@ Documentation License.''
 * Communication::               Places for discussions and chatting.
 * Development::                 Useful information for developers.
 * gEDA file format::            File format currently in use.
-* Index::
+* Topic Index::
 
 @detailmenu
  --- The Detailed Node Listing ---


### PR DESCRIPTION
Generated HTML files for index and the table
of contents have similar names: only case of
the first letter is different ("Index.html"
and "index.html"). On file systems that do not
distinguish lower- and upper-case file names,
"make" overwrites one or the other file.
Fix it by using a new name: "Topic Index".

Closes #715.
