### PR TITLE
Add missing (use-modules (ice-9 format)) to several netlist files

### DIFF
--- a/liblepton/scheme/netlist.scm
+++ b/liblepton/scheme/netlist.scm
@@ -20,6 +20,7 @@
 (define-module (netlist)
   #:use-module (srfi srfi-1)
   #:use-module (srfi srfi-26)
+  #:use-module (ice-9 format)
   #:use-module (ice-9 match)
   #:use-module ((ice-9 rdelim) #:select (read-string) #:prefix rdelim:)
   #:use-module (ice-9 ftw)

--- a/netlist/examples/vams/generate_netlist.scm
+++ b/netlist/examples/vams/generate_netlist.scm
@@ -24,7 +24,8 @@
 ;; This function only put together the gnetlist command for the
 ;; generating-netlist-call.
 
-(use-modules (lepton attrib)
+(use-modules (ice-9 format)
+             (lepton attrib)
              (lepton log)
              (lepton object)
              (lepton page))

--- a/netlist/scheme/backend/gnet-vams.scm
+++ b/netlist/scheme/backend/gnet-vams.scm
@@ -26,6 +26,7 @@
 
 (use-modules (srfi srfi-1)
              (srfi srfi-26)
+             (ice-9 format)
              (netlist port)
              (netlist schematic-component)
              (netlist schematic)


### PR DESCRIPTION
In order to use certain `format()` features, e.g.
line continuation, the `(ice-9 format)` module
should be included.
Add `(use-modules (ice-9 format))` where appropriate.
