### PR TITLE
Small improvements in lepton-attrib GUI

### DIFF
--- a/libleptonattrib/include/prototype.h
+++ b/libleptonattrib/include/prototype.h
@@ -159,6 +159,7 @@ void x_dialog_about_dialog();
 void x_dialog_export_file();
 
 /* ------------- x_gtksheet.c ------------- */
+void x_gtksheet_set_saved();
 void x_gtksheet_init();
 void x_gtksheet_add_row_labels(GtkSheet *sheet, int count, STRING_LIST *list_head);
 void x_gtksheet_add_col_labels(GtkSheet *sheet, int count, STRING_LIST *list_head);

--- a/libleptonattrib/include/prototype.h
+++ b/libleptonattrib/include/prototype.h
@@ -21,6 +21,8 @@ int s_attrib_name_in_list(STRING_LIST *name_value_list, char *name);
 char *s_attrib_get_refdes(OBJECT *object);
 
 /* ------------- s_sheet_data.c ------------- */
+int s_sheet_data_changed (const SHEET_DATA* data);
+void s_sheet_data_set_changed (SHEET_DATA* data, int changed);
 SHEET_DATA *s_sheet_data_new();
 
 void s_sheet_data_add_master_comp_list_items(const GList *obj_list);

--- a/libleptonattrib/include/prototype.h
+++ b/libleptonattrib/include/prototype.h
@@ -180,5 +180,7 @@ TOPLEVEL*
 x_window_get_toplevel ();
 void
 lepton_attrib_window ();
+void
+x_window_set_title_changed (int changed);
 
 G_END_DECLS

--- a/libleptonattrib/lepton-attrib.scm
+++ b/libleptonattrib/lepton-attrib.scm
@@ -94,23 +94,6 @@ Options:
   -V, --version          Show version information
   -h, --help             This help menu
 
-FAQ:
-  *  What do the colors of the cell text mean?
-     The cell colors indicate the visibility of the attribute.
-     Black = Visible attribute, value displayed only.
-     Grey  = Invisible attribute.
-     Red   = Visible attribute, name displayed only.
-     Blue  = Visible attribute, both name and value displayed.
-
-  *  What does the period (\".\") at the end of some component refdeses mean?
-     The period is placed after the refdeses of slotted components.
-     If slots are present on the component, then the different slots appear
-     in different rows with the slot number after the period.  Example:  C101.2.
-
-Copyright (C) 2003-2006 Stuart D. Brorson.
-Copyright (C) 2007-2016 gEDA Contributors.
-Copyright (C) 2017-2020 Lepton EDA Contributors.
-
 Report bugs at ~S
 Lepton EDA homepage: ~S
 ")

--- a/libleptonattrib/src/attrib.c
+++ b/libleptonattrib/src/attrib.c
@@ -108,7 +108,7 @@ gboolean attrib_really_quit(void)
   }
 
 
-  if (sheet_head->CHANGED == TRUE) {
+  if (s_sheet_data_changed (sheet_head)) {
     x_dialog_unsaved_data();
   } else {
     attrib_quit(0);

--- a/libleptonattrib/src/s_attrib.c
+++ b/libleptonattrib/src/s_attrib.c
@@ -121,8 +121,14 @@ char *s_attrib_get_refdes(OBJECT *object)
   if (numslots_value != NULL) {  /* this is a slotted component; 
 				    append slot number to refdes. */
     slot_value = s_slot_search_slot (object, &slot_text_object);
-    g_debug ("  Found slotted component with slot = %s\n", slot_value);
-    temp_uref = g_strconcat(temp_uref, ".", slot_value, NULL);
+
+    /* Mark component as slotted only if it has a "slot" attribute:
+    */
+    if (slot_value != NULL)
+    {
+      g_debug ("  Found slotted component with slot = %s\n", slot_value);
+      temp_uref = g_strconcat (temp_uref, ".", slot_value, NULL);
+    }
   }
 
   g_debug ("  Return refdes %s.\n", temp_uref);

--- a/libleptonattrib/src/s_attrib.c
+++ b/libleptonattrib/src/s_attrib.c
@@ -127,7 +127,7 @@ char *s_attrib_get_refdes(OBJECT *object)
     if (slot_value != NULL)
     {
       g_debug ("  Found slotted component with slot = %s\n", slot_value);
-      temp_uref = g_strconcat (temp_uref, ".", slot_value, NULL);
+      temp_uref = g_strdup_printf (_("%s (slot %s)"), temp_uref, slot_value);
     }
   }
 

--- a/libleptonattrib/src/s_sheet_data.c
+++ b/libleptonattrib/src/s_sheet_data.c
@@ -61,7 +61,13 @@ void
 s_sheet_data_set_changed (SHEET_DATA* data, int changed)
 {
   data->CHANGED = changed;
+
   x_window_set_title_changed (changed);
+
+  if (!changed)
+  {
+    x_gtksheet_set_saved(); /* see comments in x_gtksheet_set_saved() */
+  }
 }
 
 

--- a/libleptonattrib/src/s_sheet_data.c
+++ b/libleptonattrib/src/s_sheet_data.c
@@ -61,6 +61,7 @@ void
 s_sheet_data_set_changed (SHEET_DATA* data, int changed)
 {
   data->CHANGED = changed;
+  x_window_set_title_changed (changed);
 }
 
 

--- a/libleptonattrib/src/s_sheet_data.c
+++ b/libleptonattrib/src/s_sheet_data.c
@@ -50,6 +50,20 @@
 #include "../include/gettext.h"
 
 
+int
+s_sheet_data_changed (const SHEET_DATA* data)
+{
+  return data->CHANGED;
+}
+
+
+void
+s_sheet_data_set_changed (SHEET_DATA* data, int changed)
+{
+  data->CHANGED = changed;
+}
+
+
 /*------------------------------------------------------------------*/
 /*!
  * \brief Create a SHEET_DATA struct.

--- a/libleptonattrib/src/s_toplevel.c
+++ b/libleptonattrib/src/s_toplevel.c
@@ -200,7 +200,7 @@ s_toplevel_save_sheet ()
 
   /* Save all pages in design. */
   s_page_save_all (toplevel);
-  sheet_head->CHANGED = FALSE;
+  s_sheet_data_set_changed (sheet_head, FALSE);
 
   return;
 }
@@ -400,7 +400,8 @@ void s_toplevel_delete_attrib_col() {
   gtk_sheet_delete_columns (sheet, mincol, 1);
   g_debug ("s_toplevel_delete_attrib_col: Done deleting col in gtksheet.\n");
 
-  sheet_head->CHANGED = TRUE;  /* Set changed flag so user is prompted when exiting */
+  /* Set changed flag so user is prompted when exiting */
+  s_sheet_data_set_changed (sheet_head, TRUE);
 
   return;
 }

--- a/libleptonattrib/src/s_visibility.c
+++ b/libleptonattrib/src/s_visibility.c
@@ -361,11 +361,13 @@ void s_visibility_set_cell(gint cur_page, gint row, gint col,
 
   /* Question:  how to sanity check (row, col) selection? */
   local_table[row][col].visibility = visibility;
-  sheet_head->CHANGED = 1;  /* cell has been updated.  */
+  /* cell has been updated.  */
+  s_sheet_data_set_changed (sheet_head, TRUE);
 
   if (show_name_value != LEAVE_NAME_VALUE_ALONE) { 
     local_table[row][col].show_name_value = show_name_value;
-    sheet_head->CHANGED = 1;  /* cell has been updated.  */
+    /* cell has been updated.  */
+    s_sheet_data_set_changed (sheet_head, TRUE);
   }
 }
 

--- a/libleptonattrib/src/x_dialog.c
+++ b/libleptonattrib/src/x_dialog.c
@@ -149,6 +149,8 @@ void x_dialog_delattrib()
                                   _("Are you sure you want to delete this attribute?"));
   
   gtk_window_set_title(GTK_WINDOW(dialog), _("Delete attribute"));
+  gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_NO);
+
   switch(gtk_dialog_run(GTK_DIALOG(dialog))) {
     case GTK_RESPONSE_YES:
       /* call the fcn to actually delete the attrib column.  */

--- a/libleptonattrib/src/x_dialog.c
+++ b/libleptonattrib/src/x_dialog.c
@@ -326,25 +326,37 @@ void x_dialog_fatal_error(const gchar *string, gint return_code)
 /*! \brief The About dialog */
 void x_dialog_about_dialog()
 {
-  GtkWidget *dialog;
-  const char *string =
+  GtkWidget* dlg = gtk_about_dialog_new();
+  GtkAboutDialog* adlg = GTK_ABOUT_DIALOG (dlg);
+
+  gtk_about_dialog_set_program_name (adlg, "lepton-attrib");
+
+  gtk_about_dialog_set_comments (adlg,
     _("Lepton Electronic Design Automation\n\n"
-      "lepton-attrib - Lepton EDA attribute editor\n\n"
-      "lepton-attrib version: %1$s%2$s.%3$s\n\n"
-      "lepton-attrib is Lepton's successor of gEDA gattrib\n");
+      "lepton-attrib is Lepton's successor of gEDA gattrib"));
 
-  /* Create the dialog */
-  dialog = gtk_message_dialog_new (NULL, GTK_DIALOG_MODAL,
-                                   GTK_MESSAGE_INFO,
-                                   GTK_BUTTONS_OK,
-                                   string, PREPEND_VERSION_STRING, 
-                                   PACKAGE_DOTTED_VERSION,
-                                   PACKAGE_DATE_VERSION);
-  
-  gtk_window_set_title(GTK_WINDOW(dialog), _("About..."));
+  gchar* version_string = g_strdup_printf (_("%s (git: %.7s)"),
+                                           PACKAGE_DOTTED_VERSION,
+                                           PACKAGE_GIT_COMMIT);
+  gtk_about_dialog_set_version (adlg, version_string);
 
-  gtk_dialog_run(GTK_DIALOG(dialog));
-  gtk_widget_destroy(dialog);
+  gtk_about_dialog_set_copyright (adlg,
+    _("Copyright © 2003-2006 Stuart D. Brorson\n"
+      "Copyright © 2007-2016 gEDA Contributors\n"
+      "Copyright © 2017-2020 Lepton EDA Contributors"));
+
+  gtk_about_dialog_set_license (adlg,
+    _("Lepton EDA is freely distributable under the\n"
+    "GNU Public License (GPL) version 2.0 or (at your option) any later version.\n"
+    "See the COPYING file for the full text of the license."));
+
+  gtk_about_dialog_set_website (adlg, "http://github.com/lepton-eda/lepton-eda");
+
+  gtk_widget_show_all (dlg);
+  gtk_dialog_run (GTK_DIALOG (dlg));
+
+  gtk_widget_destroy (dlg);
+  g_free (version_string);
 }
 
 

--- a/libleptonattrib/src/x_dialog.c
+++ b/libleptonattrib/src/x_dialog.c
@@ -342,7 +342,7 @@ void x_dialog_about_dialog()
 
   gtk_about_dialog_set_copyright (adlg,
     _("Copyright © 2003-2006 Stuart D. Brorson\n"
-      "Copyright © 2007-2016 gEDA Contributors\n"
+      "Copyright © 2003-2016 gEDA Contributors\n"
       "Copyright © 2017-2020 Lepton EDA Contributors"));
 
   gtk_about_dialog_set_license (adlg,

--- a/libleptonattrib/src/x_dialog.c
+++ b/libleptonattrib/src/x_dialog.c
@@ -345,6 +345,39 @@ void x_dialog_about_dialog()
   gtk_widget_destroy(dialog);
 }
 
+
+/*! \brief: If file \a fname exists, open confirmation dialog.
+ *
+ *  \return  Is it OK to overwrite file \a fname.
+ */
+static gboolean
+x_dialog_confirm_overwrite (const gchar* fname)
+{
+  if (!g_file_test (fname, G_FILE_TEST_EXISTS))
+  {
+    return TRUE;
+  }
+
+  GtkWidget* dlg = gtk_message_dialog_new(
+    NULL,
+    (GtkDialogFlags) (GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT),
+    GTK_MESSAGE_QUESTION,
+    GTK_BUTTONS_YES_NO,
+    _("The selected file `%1$s' already exists.\n\n"
+      "Would you like to overwrite it?"),
+    fname);
+
+  gtk_window_set_title (GTK_WINDOW (dlg), _("Overwrite file?"));
+  gtk_dialog_set_default_response (GTK_DIALOG (dlg), GTK_RESPONSE_NO);
+
+  gint res = gtk_dialog_run (GTK_DIALOG (dlg));
+  gtk_widget_destroy (dlg);
+
+  return res == GTK_RESPONSE_YES;
+
+}
+
+
 /*! \brief Export file dialog
  *
  * This asks for the filename for the CSV export file and then
@@ -367,7 +400,12 @@ void x_dialog_export_file()
     case GTK_RESPONSE_ACCEPT:
       filename = gtk_file_chooser_get_filename (GTK_FILE_CHOOSER (dialog));
       if(filename != NULL) {
-        f_export_components(filename);
+
+        if (x_dialog_confirm_overwrite (filename))
+        {
+          f_export_components (filename);
+        }
+
         g_free(filename);
       }
       break;

--- a/libleptonattrib/src/x_gtksheet.c
+++ b/libleptonattrib/src/x_gtksheet.c
@@ -85,7 +85,7 @@ on_deactivate (GtkSheet* sheet,
 
   if (strcmp (str, current_cell_text) != 0)
   {
-    sheet_head->CHANGED = TRUE;
+    s_sheet_data_set_changed (sheet_head, TRUE);
   }
 
   return TRUE; /* TRUE => allow deactivation */

--- a/libleptonattrib/src/x_gtksheet.c
+++ b/libleptonattrib/src/x_gtksheet.c
@@ -92,6 +92,28 @@ on_deactivate (GtkSheet* sheet,
 }
 
 
+/*! \brief Call it just after the sheet has been saved.
+ *
+ *  \par Function Description
+ *
+ *  Update the current_cell_text global variable, so that
+ *  on_deactivate() handler won't mark the sheet as modified
+ *  when the current cell is deactivated.
+ *
+ *  We need this to handle a particular use case:
+ *  while editing text in a cell, instead of pressing Enter
+ *  to commit the changes, the user presses Ctrl+S (Save).
+ *  If we do not update current_cell_text after that, the
+ *  consequent cell deactivation will mark the document as
+ *  dirty, while it is, in fact, just has been saved.
+ */
+void
+x_gtksheet_set_saved()
+{
+  current_cell_text = gtk_sheet_get_entry_text (sheets[0]);
+}
+
+
 /*! \brief Create the GtkSheet
  *
  * Creates and initializes the GtkSheet widget, which is the

--- a/libleptonattrib/src/x_window.c
+++ b/libleptonattrib/src/x_window.c
@@ -127,6 +127,49 @@ x_window_init ()
   gtk_notebook_set_tab_pos(GTK_NOTEBOOK(notebook), GTK_POS_BOTTOM);
   gtk_box_pack_start(GTK_BOX(main_vbox), notebook, TRUE, TRUE, 0);
 
+
+  /* Status bar:
+  */
+  GtkWidget* sbar = gtk_statusbar_new();
+  gtk_box_pack_start (GTK_BOX (main_vbox), sbar, FALSE, TRUE, 0);
+  GtkWidget* marea = gtk_statusbar_get_message_area (GTK_STATUSBAR (sbar));
+
+  GtkWidget* label_1 = gtk_label_new (NULL);
+  gtk_label_set_markup (GTK_LABEL (label_1), _("   Color Legend:  "));
+
+  GtkWidget* label_inv      = gtk_label_new (_(" Invisible ") );
+  GtkWidget* label_val      = gtk_label_new (_(" Show value "));
+  GtkWidget* label_name     = gtk_label_new (_(" Show name "));
+  GtkWidget* label_name_val = gtk_label_new (_(" Show name and value "));
+
+  gtk_box_pack_start (GTK_BOX (marea), label_1, FALSE, TRUE, 0);
+  gtk_box_pack_start (GTK_BOX (marea), gtk_vseparator_new() , FALSE, TRUE, 0);
+
+  gtk_box_pack_start (GTK_BOX (marea), label_inv, FALSE, TRUE, 0);
+  gtk_box_pack_start (GTK_BOX (marea), gtk_vseparator_new() , FALSE, TRUE, 0);
+
+  gtk_box_pack_start (GTK_BOX (marea), label_val, FALSE, TRUE, 0);
+  gtk_box_pack_start (GTK_BOX (marea), gtk_vseparator_new() , FALSE, TRUE, 0);
+
+  gtk_box_pack_start (GTK_BOX (marea), label_name, FALSE, TRUE, 0);
+  gtk_box_pack_start (GTK_BOX (marea), gtk_vseparator_new() , FALSE, TRUE, 0);
+
+  gtk_box_pack_start (GTK_BOX (marea), label_name_val, FALSE, TRUE, 0);
+
+  GdkColor color;
+  gdk_color_parse ("grey", &color);
+  gtk_widget_modify_fg (label_inv, GTK_STATE_NORMAL, &color);
+
+  gdk_color_parse ("black", &color);
+  gtk_widget_modify_fg (label_val, GTK_STATE_NORMAL, &color);
+
+  gdk_color_parse ("red", &color);
+  gtk_widget_modify_fg (label_name, GTK_STATE_NORMAL, &color);
+
+  gdk_color_parse ("blue", &color);
+  gtk_widget_modify_fg (label_name_val, GTK_STATE_NORMAL, &color);
+
+
   /* -----  Now malloc -- but don't fill out -- space for sheets  ----- */
   /* This basically sets up the overhead for the sheets, as I understand
    * it.  The memory for the actual sheet cells is allocated later,

--- a/libleptonattrib/src/x_window.c
+++ b/libleptonattrib/src/x_window.c
@@ -546,6 +546,35 @@ x_window_set_title (GList* plist)
 }
 
 
+/*! \brief Indicate if document has \a changed in the title.
+ */
+void
+x_window_set_title_changed (int changed)
+{
+  const gchar* title = gtk_window_get_title (GTK_WINDOW (window));
+  const gchar* prefix = "* ";
+
+  if (changed)
+  {
+    if (!g_str_has_prefix (title, prefix))
+    {
+      gchar* title_new = g_strdup_printf ("%s%s", prefix, title);
+      gtk_window_set_title (GTK_WINDOW (window), title_new);
+      g_free (title_new);
+    }
+  }
+  else
+  {
+    if (g_str_has_prefix (title, prefix))
+    {
+      gchar* title_new = g_strdup (title + strlen (prefix));
+      gtk_window_set_title (GTK_WINDOW (window), title_new);
+      g_free (title_new);
+    }
+  }
+}
+
+
 /*! \brief Open lepton-attrib window.
  *
  * The function populates the spreadsheet data structure and

--- a/libleptonattrib/src/x_window.c
+++ b/libleptonattrib/src/x_window.c
@@ -126,6 +126,7 @@ x_window_init ()
   /* -----  Now init notebook widget  ----- */
   notebook = gtk_notebook_new();
   gtk_notebook_set_tab_pos(GTK_NOTEBOOK(notebook), GTK_POS_BOTTOM);
+  gtk_notebook_set_show_tabs (GTK_NOTEBOOK (notebook), FALSE);
   gtk_box_pack_start(GTK_BOX(main_vbox), notebook, TRUE, TRUE, 0);
 
 

--- a/libleptonattrib/src/x_window.c
+++ b/libleptonattrib/src/x_window.c
@@ -68,6 +68,9 @@ x_window_create_menu(GtkWindow *window, GtkWidget **menubar);
 static void
 x_window_set_default_icon( void );
 
+static void
+x_window_set_title (GList* plist);
+
 static TOPLEVEL *window_toplevel = NULL;
 
 void
@@ -102,8 +105,6 @@ x_window_init ()
 
   /*  window is a global declared in globals.h.  */
   window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
-
-  gtk_window_set_title( GTK_WINDOW(window), _("lepton-attrib - Lepton EDA attribute editor"));
 
   g_signal_connect(window, "delete_event",
                    G_CALLBACK (attrib_really_quit), 0);
@@ -507,6 +508,43 @@ x_window_set_default_icon( void )
 }
 
 
+/*! \brief Set the main window's title.
+ *
+ *  \param plist  The list of PAGE objects (opened pages).
+ */
+static void
+x_window_set_title (GList* plist)
+{
+  g_return_if_fail (plist != NULL);
+  g_return_if_fail (window != NULL);
+
+  const gchar* prog_name = "lepton-attrib";
+  gchar* title = NULL;
+
+  if (g_list_length (plist) == 1)
+  {
+    const gchar* fpath = s_page_get_filename (plist->data);
+    gchar* fname = g_path_get_basename (fpath);
+
+    title = g_strdup_printf ("%s - %s", fname, prog_name);
+
+    g_free (fname);
+  }
+  else
+  if (g_list_length (plist) > 1)
+  {
+    title = g_strdup_printf ("%s - %s", _("Multiple files"), prog_name);
+  }
+  else
+  {
+    title = g_strdup_printf ("%s", prog_name);
+  }
+
+  gtk_window_set_title (GTK_WINDOW (window), title);
+  g_free (title);
+}
+
+
 /*! \brief Open lepton-attrib window.
  *
  * The function populates the spreadsheet data structure and
@@ -601,4 +639,6 @@ lepton_attrib_window ()
 
   /* ---------- Now verify correctness of entire design.  ---------- */
   s_toplevel_verify_design(toplevel);  /* toplevel is a global */
+
+  x_window_set_title (geda_list_get_glist (toplevel->pages));
 }

--- a/libleptonattrib/src/x_window.c
+++ b/libleptonattrib/src/x_window.c
@@ -524,7 +524,7 @@ x_window_set_title (GList* plist)
 
   if (g_list_length (plist) == 1)
   {
-    const gchar* fpath = s_page_get_filename (plist->data);
+    const gchar* fpath = s_page_get_filename ((PAGE *) plist->data);
     gchar* fname = g_path_get_basename (fpath);
 
     title = g_strdup_printf ("%s - %s", fname, prog_name);


### PR DESCRIPTION
- Add status bar and show color legend there, designating
the meaning of different attributes' colors (visibility).
This information should be somewhere in the main window,
anyway; GUI app describing its user interface elements in
the `--help` output, is... not quite **G**UI. :-)
Please suggest a better way how to do it (now it's just
four strings in different colors).
- Display the current file name in the window's title, and
if the file is changed, prepend an asterisk to its name.
Show "Multiple files" if more than one are opened.
- Do not show the one and only `GtkNotebook`'s tab.
- Explicitly display slotted components in row headers,
e.g. show `U1 (slot 3)` instead of `U1.3`.
- Display components as slotted only if they have the
`slot` attribute.
- On `File->Export CSV`, show the overwrite confirmation
dialog if already existing file is selected.
- Default response in the `Delete Attribute` dialog:
focus the "No" button by default.
-  Improve the `About` dialog, use `GtkAboutDialog`, like
in `lepton-schematic`.
- Fix modification status update on `Ctrl+S`.

old:
![attrib_main_wnd_old](https://user-images.githubusercontent.com/26083750/103281137-fbff5180-49c9-11eb-8532-48bdec372e80.png)

new:
![attrib_main_wnd_new](https://user-images.githubusercontent.com/26083750/103281145-03bef600-49ca-11eb-8068-7eb6835ab5de.png)

old:
![attrib_about_dlg_old](https://user-images.githubusercontent.com/26083750/103281156-0ae60400-49ca-11eb-8b9f-13f0edb174b9.png)

new:
![attrib_about_dlg_new](https://user-images.githubusercontent.com/26083750/103281169-10434e80-49ca-11eb-8d44-507dcbcd82e7.png)

[a ~~sample schematic~~ clever circuit](https://graahnul-grom.github.io/sch/index.html#slots) used in screenshots:
![slots](https://user-images.githubusercontent.com/26083750/103281252-47196480-49ca-11eb-95f2-4950ad6c0bb3.png)

