### PR TITLE
Several fixes in lepton-schematic GUI

### DIFF
--- a/libleptongui/src/color_edit_widget.c
+++ b/libleptongui/src/color_edit_widget.c
@@ -1,6 +1,6 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 2018-2020 dmn <graahnul.grom@gmail.com>
- * Copyright (C) 2018-2020 Lepton EDA Contributors
+ * Copyright (C) 2018-2021 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -422,7 +422,7 @@ on_btn_save (GtkWidget* btn, gpointer p)
 
   if (!ok)
   {
-    gtk_message_dialog_new(
+    GtkWidget* dlg = gtk_message_dialog_new(
       GTK_WINDOW (widget->toplevel_->main_window),
       GTK_DIALOG_MODAL,
       GTK_MESSAGE_ERROR,
@@ -430,6 +430,10 @@ on_btn_save (GtkWidget* btn, gpointer p)
       _("Could not save file [%s]:\n%s"),
       fname,
       err->message);
+
+    gtk_window_set_title (GTK_WINDOW (dlg), _("Failed to save file"));
+    gtk_dialog_run (GTK_DIALOG (dlg));
+    gtk_widget_destroy (dlg);
   }
 
   g_clear_error (&err);

--- a/libleptongui/src/color_edit_widget.c
+++ b/libleptongui/src/color_edit_widget.c
@@ -515,6 +515,7 @@ dlg_confirm_overwrite (GtkWidget* parent, const gchar* fname)
     fname);
 
   gtk_window_set_title (GTK_WINDOW (dlg), _("Overwrite file?"));
+  gtk_dialog_set_default_response (GTK_DIALOG (dlg), GTK_RESPONSE_NO);
 
   gint res = gtk_dialog_run (GTK_DIALOG (dlg));
   gtk_widget_destroy (dlg);

--- a/libleptongui/src/color_edit_widget.c
+++ b/libleptongui/src/color_edit_widget.c
@@ -462,7 +462,7 @@ static GtkWidget*
 dlg_save_as (GtkWidget* parent)
 {
   GtkWidget* dlg = gtk_file_chooser_dialog_new(
-    _("Save Color Scheme As..."),
+    _("Save Color Scheme"),
     GTK_WINDOW (parent),
     GTK_FILE_CHOOSER_ACTION_SAVE,
     GTK_STOCK_SAVE,   GTK_RESPONSE_ACCEPT,

--- a/libleptongui/src/gschem_about_dialog.c
+++ b/libleptongui/src/gschem_about_dialog.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2015 gEDA Contributors
- * Copyright (C) 2017-2020 Lepton EDA Contributors
+ * Copyright (C) 2017-2021 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -84,7 +84,7 @@ void about_dialog (GschemToplevel *w_current)
 
   gtk_about_dialog_set_copyright (adlg,
     _("Copyright © 1998-2017 by Ales Hvezda and the respective original authors.\n"
-      "Copyright © 2017-2020 Lepton Developers.\n"
+      "Copyright © 2017-2021 Lepton Developers.\n"
       "See AUTHORS, ChangeLog files and consult 'git log' history for details."));
 
   gtk_about_dialog_set_license (adlg,

--- a/libleptongui/src/gschem_about_dialog.c
+++ b/libleptongui/src/gschem_about_dialog.c
@@ -54,7 +54,6 @@ void about_dialog (GschemToplevel *w_current)
                            G_DIR_SEPARATOR_S, "gschem-about-logo.png", NULL);
 
   logo = gdk_pixbuf_new_from_file (logo_file, &error);
-  g_free (logo_file);
 
   if (error != NULL) {
     g_assert (logo == NULL);
@@ -62,6 +61,8 @@ void about_dialog (GschemToplevel *w_current)
                logo_file, error->message);
     g_error_free (error);
   }
+
+  g_free (logo_file);
 
 
   GtkWidget* dlg = gtk_about_dialog_new();

--- a/libleptongui/src/gschem_close_confirmation_dialog.c
+++ b/libleptongui/src/gschem_close_confirmation_dialog.c
@@ -762,6 +762,8 @@ x_dialog_close_changed_page (GschemToplevel *w_current, PAGE *page)
   dialog = GTK_WIDGET (g_object_new (TYPE_CLOSE_CONFIRMATION_DIALOG,
                                      "unsaved-page", page,
                                      NULL));
+
+  gtk_window_set_title (GTK_WINDOW (dialog), "lepton-schematic");
   /* set default response signal. This is usually triggered by the
      "Return" key */
   gtk_dialog_set_default_response(GTK_DIALOG(dialog),

--- a/libleptongui/src/gschem_log_widget.c
+++ b/libleptongui/src/gschem_log_widget.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2015 gEDA Contributors
- * Copyright (C) 2017-2020 Lepton EDA Contributors
+ * Copyright (C) 2017-2021 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -391,6 +391,7 @@ log_window_clear (GtkMenuItem* item, gpointer data)
                                            GTK_BUTTONS_OK_CANCEL,
                                            _("Clear log window?"));
 
+  gtk_window_set_title (GTK_WINDOW (dlg), _("Clear Log"));
   gtk_dialog_set_default_response (GTK_DIALOG (dlg), GTK_RESPONSE_CANCEL);
 
   gtk_dialog_set_alternative_button_order (GTK_DIALOG (dlg),

--- a/libleptongui/src/gschem_slot_edit_dialog.c
+++ b/libleptongui/src/gschem_slot_edit_dialog.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2015 gEDA Contributors
- * Copyright (C) 2017-2020 Lepton EDA Contributors
+ * Copyright (C) 2017-2021 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -88,7 +88,7 @@ void slot_edit_dialog (GschemToplevel *w_current, const char *count, const char 
   GtkWidget *widget[2];
 
   if (!w_current->sewindow) {
-    w_current->sewindow = gschem_dialog_new_with_buttons(_("Edit slot number"),
+    w_current->sewindow = gschem_dialog_new_with_buttons(_("Edit Slot"),
                                                          GTK_WINDOW(w_current->main_window),
                                                          GTK_DIALOG_MODAL,
                                                          "slot-edit", w_current,

--- a/libleptongui/src/x_autonumber.c
+++ b/libleptongui/src/x_autonumber.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2016 gEDA Contributors
- * Copyright (C) 2017-2020 Lepton EDA Contributors
+ * Copyright (C) 2017-2021 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1213,7 +1213,7 @@ GtkWidget* autonumber_create_dialog(GschemToplevel *w_current)
   GtkWidget *label3;
 
 
-  autonumber_text = gschem_dialog_new_with_buttons(_("Autonumber text"),
+  autonumber_text = gschem_dialog_new_with_buttons(_("Autonumber Text"),
                                                    GTK_WINDOW(w_current->main_window),
                                                    (GtkDialogFlags) 0, /* not modal */
                                                    "autonumber", w_current,

--- a/libleptongui/src/x_fileselect.c
+++ b/libleptongui/src/x_fileselect.c
@@ -516,6 +516,7 @@ x_fileselect_save (GschemToplevel *w_current, PAGE* page, gboolean* result)
                                 filename);
 
       gtk_window_set_title (GTK_WINDOW (checkdialog), _("Overwrite file?"));
+      gtk_dialog_set_default_response (GTK_DIALOG (checkdialog), GTK_RESPONSE_NO);
 
       if (gtk_dialog_run (GTK_DIALOG (checkdialog)) != GTK_RESPONSE_YES)
       {

--- a/libleptongui/src/x_fileselect.c
+++ b/libleptongui/src/x_fileselect.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2015 gEDA Contributors
- * Copyright (C) 2017-2020 Lepton EDA Contributors
+ * Copyright (C) 2017-2021 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -586,6 +586,7 @@ x_fileselect_load_backup (GschemToplevel *w_current,
                                    GTK_BUTTONS_YES_NO,
                                    "%s", message->str);
 
+  gtk_window_set_title (GTK_WINDOW (dialog), "Load Backup");
   /* Set the alternative button order (ok, cancel, help) for other systems */
   gtk_dialog_set_alternative_button_order(GTK_DIALOG(dialog),
 					  GTK_RESPONSE_YES,


### PR DESCRIPTION
- Fix window title in several dialogs to be in line with
other dialogs:
  - `Save Color Scheme As...` => `Save Color Scheme`
  - `Edit slot number` => `Edit Slot`
  - `Autonumber text` => `Autonumber Text`

- Fix title of the page close confirmation dialog: show
"lepton-schematic" instead of "\<unknown\>" (as in #694)

- Add missing title to some dialogs:
  - Clear log confirmation dialog
  - Load backup dialog

- Set default response to "No" in file overwrite
confirmation dialogs for:
  - `File->Save As`
  - `View->Color Scheme Editor->Save As`

- Fix save color scheme error dialog: actually show it :-)
