### PR TITLE
Fix: cancel bus drawing with the right mouse button

### DIFF
--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -236,6 +236,7 @@ void o_buffer_free(GschemToplevel *w_current);
 /* o_bus.c */
 void o_bus_start(GschemToplevel *w_current, int x, int y);
 void o_bus_end(GschemToplevel *w_current, int x, int y);
+void o_bus_reset(GschemToplevel *w_current);
 void o_bus_motion(GschemToplevel *w_current, int x, int y);
 void o_bus_draw_rubber (GschemToplevel *w_current, EdaRenderer *renderer);
 void o_bus_invalidate_rubber(GschemToplevel *w_current);

--- a/libleptongui/src/o_bus.c
+++ b/libleptongui/src/o_bus.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2016 gEDA Contributors
- * Copyright (C) 2017-2020 Lepton EDA Contributors
+ * Copyright (C) 2017-2021 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -192,4 +192,13 @@ o_bus_draw_rubber (GschemToplevel *w_current, EdaRenderer *renderer)
                   w_current->second_wx, w_current->second_wy);
   eda_cairo_set_source_color (cr, SELECT_COLOR, color_map);
   eda_cairo_stroke (cr, flags, TYPE_SOLID, END_NONE, size, -1, -1);
+}
+
+
+
+void
+o_bus_reset (GschemToplevel* w_current)
+{
+  o_bus_invalidate_rubber (w_current);
+  i_action_stop (w_current);
 }

--- a/libleptongui/src/x_event.c
+++ b/libleptongui/src/x_event.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2015 gEDA Contributors
- * Copyright (C) 2017-2020 Lepton EDA Contributors
+ * Copyright (C) 2017-2021 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -286,7 +286,7 @@ x_event_button_pressed(GschemPageView *page_view, GdkEventButton *event, GschemT
 
           case (ARCMODE)    : o_arc_invalidate_rubber     (w_current); break;
           case (BOXMODE)    : o_box_invalidate_rubber     (w_current); break;
-          case (BUSMODE)    : o_bus_invalidate_rubber     (w_current); break;
+          case (BUSMODE)    : o_bus_reset                 (w_current); break;
           case (CIRCLEMODE) : o_circle_invalidate_rubber  (w_current); break;
           case (LINEMODE)   : o_line_invalidate_rubber    (w_current); break;
           case (NETMODE)    : o_net_reset                 (w_current); break;


### PR DESCRIPTION
The bus drawing tool is supposed to behave like the
net tool: a click with the right mouse button should
cancel the current operation. It is even reflected in
the toolbar button's hint: "Add buses mode. Right mouse
button to cancel". However, the right mouse button does
nothing in the bus mode. Fix it.

I invite everybody to test the proposed patch.
For some strange reasons, it works for me. :-)
Happy New Year, friends!
