### PR TITLE
Document (relatively) new Scheme API functions

### DIFF
--- a/docs/scheme-api/lepton-scheme.texi
+++ b/docs/scheme-api/lepton-scheme.texi
@@ -2228,6 +2228,11 @@ Returns the directory in which to store user-specific Lepton
 configuration information.
 @end defun
 
+@defun user-cache-dir
+Returns the directory in which to store program-specific Lepton
+configuration information.
+@end defun
+
 @defun expand-env-variables str
 Recursively expands @var{str} until no more environment variables can be
 expanded, and return the expanded string. Environment variables are in

--- a/docs/scheme-api/lepton-scheme.texi
+++ b/docs/scheme-api/lepton-scheme.texi
@@ -1684,10 +1684,11 @@ Each configuration context may have a @dfn{parent context}.  If, when
 looking up a parameter, it has no value set in the selected context,
 the parent context is checked, and so on.
 
-Three special contexts are always automatically defined: the
-@dfn{default context}, the @dfn{system context} and the @dfn{user
-context}.  The user context is the default parent context for all
-other configuration contexts, including newly-created ones.
+Several special contexts are always automatically defined: the
+@dfn{default context}, the @dfn{system context}, the @dfn{user
+context} and the @dfn{cache context}.  The user context is the
+default parent context for all other configuration contexts,
+including newly-created ones.
 
 @subsubsection Obtaining a context
 @cindex System configuration context
@@ -1744,6 +1745,17 @@ loaded from @file{lepton-user.conf} in @code{user-config-dir}.
 Its parent context is the system context.
 
 Since 1.10.
+@end defun
+
+@defun cache-config-context
+The cache context is used to store program-specific settings,
+like dialog geometry and command history.
+It has no parent configuration context.
+The associated file is @file{gui.conf}
+in @file{$XDG_CACHE_HOME/lepton-eda/} directory (usually,
+@file{~/.cache/lepton-eda/}).
+That path can be determined by calling @code{user-cache-dir}
+function from the @code{(lepton os)} module.
 @end defun
 
 @subsubsection Loading and saving configuration files

--- a/docs/scheme-api/lepton-scheme.texi
+++ b/docs/scheme-api/lepton-scheme.texi
@@ -13,7 +13,7 @@ This manual is for Lepton EDA, version @value{VERSION}.
 
 Copyright @copyright{} 2011-2013 Peter TB Brett
 Copyright @copyright{} 2011-2017 gEDA developers
-Copyright @copyright{} 2017-2020 Lepton developers
+Copyright @copyright{} 2017-2021 Lepton developers
 
 The text of and illustrations in this document are licensed under a
 Creative Commons Attribution–Share Alike 3.0 Unported license
@@ -1756,6 +1756,15 @@ in @file{$XDG_CACHE_HOME/lepton-eda/} directory (usually,
 @file{~/.cache/lepton-eda/}).
 That path can be determined by calling @code{user-cache-dir}
 function from the @code{(lepton os)} module.
+@end defun
+
+@defun anyfile-config-context path [parent] [trusted]
+Returns the context associated with a configuration file
+given by @var{path}.
+It can be assigned a parent context @var{parent} (by default it
+has no parent context).
+The context is considered untrusted, unless the @var{trusted}
+parameter is set to @samp{#t}.
 @end defun
 
 @subsubsection Loading and saving configuration files


### PR DESCRIPTION
Add to the Lepton EDA Scheme API Reference Manual
documentation for the following functions:

- `user-cache-dir()`
- `cache-config-context()`
- `anyfile-config-context()`
