### PR TITLE
Fix lepton-schematic --command

### DIFF
--- a/libleptongui/docs/lepton-schematic.1.in
+++ b/libleptongui/docs/lepton-schematic.1.in
@@ -36,7 +36,7 @@ Scheme files.
 \fB-s\fR \fIFILE\fR
 Specify a Scheme script to be executed at startup.
 .TP 8
-\fB-c\fR \fIEXPR\fR
+\fB-c\fR \fIEXPR\fR, \fB--command\fR=\fIEXPR\fR
 Specify a Scheme expression to be evaluated at startup.
 .TP 8
 \fB-h\fR, \fB--help\fR

--- a/schematic/lepton-schematic.scm
+++ b/schematic/lepton-schematic.scm
@@ -118,7 +118,7 @@ Options:
   -q, --quiet              Quiet mode.
   -v, --verbose            Verbose mode.
   -L DIR                   Add DIR to Scheme search path.
-  -c EXPR                  Scheme expression to run at startup.
+  -c EXPR, --command=EXPR  Scheme expression to run at startup.
   -s FILE                  Scheme script to run at startup.
   -V, --version            Show version information.
   -h, --help               Help; this message.
@@ -156,7 +156,7 @@ Lepton EDA homepage: ~S\n")
              (lambda (opt name arg seeds)
                (add-post-load-expr! arg #t)
                seeds))
-     (option '(#\c) #t #f
+     (option '(#\c "command") #t #f
              (lambda (opt name arg seeds)
                (add-post-load-expr! arg #f)
                seeds))


### PR DESCRIPTION
This command line option was introduced in 1.9.12 (7ca7c7d)
as an alias for `-c EXPR` (execute Scheme `EXPR`), but
now it's missing. Fix it, and document it in the
lepton-schematic man page.

I doubt that it's worth switching to `srfi-37` to process
command line options. It is ugly,
it can't understand `--option VALUE`, only `--option=VALUE`
and unable to handle the case when required argument
is missing, launch `lepton-schematic -c` and you get:

```
Backtrace:
           5 (primitive-load "/home/dmn/lepton/bin.tb/bin/lepton-sch…")
In ice-9/eval.scm:
   293:34  4 (_ #<directory (guile-user) 800731140>)
    155:9  3 (_ #(#(#<directory (guile-user) 800731140>)))
In srfi/srfi-37.scm:
   169:19  2 (next-arg)
   132:41  1 (invoke-option-processor #<srfi-37:option names: (#\c …> …)
In unknown file:
           0 (scm-error misc-error "args-fold" "Missing required ar…" …)

ERROR: In procedure scm-error:
In procedure args-fold: Missing required argument after `-c'
```

In this case it only raises an exception (look at the source code),
which is undocumented.

