### PR TITLE
Avoid displaying backtraces on wrong command line options for lepton-schematic. 

### DIFF
--- a/liblepton/scheme/Makefile.am
+++ b/liblepton/scheme/Makefile.am
@@ -25,6 +25,7 @@ nobase_dist_scmdata_DATA = \
 	lepton/page.scm \
 	lepton/rc.scm \
 	lepton/repl.scm \
+	lepton/srfi-37.scm \
 	lepton/version.scm \
 	lepton/legacy-config/keylist.scm \
 	lepton/legacy-config.scm \

--- a/liblepton/scheme/lepton/eval.scm
+++ b/liblepton/scheme/lepton/eval.scm
@@ -1,5 +1,5 @@
 ;;; Lepton EDA library - Scheme API
-;;; Copyright (C) 2020 Lepton EDA Contributors
+;;; Copyright (C) 2020-2021 Lepton EDA Contributors
 ;;;
 ;;; This program is free software; you can redistribute it and/or modify
 ;;; it under the terms of the GNU General Public License as published by

--- a/liblepton/scheme/lepton/eval.scm
+++ b/liblepton/scheme/lepton/eval.scm
@@ -44,7 +44,8 @@
        ;; Send long message to log.
        (log! 'message "~A\n" long-message)
        (format #t (G_ "ERROR: ~A\nPlease see log file for more information.\n")
-               (apply format #f message message-args))))))
+               (apply format #f message message-args))))
+    (_ #f)))
 
 
 (define* (eval-protected exp #:optional env)

--- a/liblepton/scheme/lepton/srfi-37.scm
+++ b/liblepton/scheme/lepton/srfi-37.scm
@@ -46,8 +46,6 @@
             option-optional-arg? option-processor
             args-fold))
 
-(cond-expand-provide (current-module) '(srfi-37))
-
 ;;;; args-fold and periphery procedures
 
 ;;; An option as answered by `option'.  `names' is a list of

--- a/liblepton/scheme/lepton/srfi-37.scm
+++ b/liblepton/scheme/lepton/srfi-37.scm
@@ -97,16 +97,17 @@ encountered more than once."
      options)
     lookup))
 
+(define-syntax-rule (error msg arg ...)
+  (begin
+    (format (current-error-port) msg arg ...)
+    (exit 1)))
+
 (define (args-fold args options unrecognized-option-proc
                    operand-proc . seeds)
   "Answer the results of folding SEEDS as multiple values against the
 program-arguments in ARGS, as decided by the OPTIONS'
 `option-processor's, UNRECOGNIZED-OPTION-PROC, and OPERAND-PROC."
   (let ((lookup (build-options-lookup options)))
-    ;; I don't like Guile's `error' here
-    (define (error msg . args)
-      (scm-error 'misc-error "args-fold" msg args #f))
-
     (define (mutate-seeds! procedure . params)
       (set! seeds (call-with-values
                       (lambda ()

--- a/liblepton/scheme/lepton/srfi-37.scm
+++ b/liblepton/scheme/lepton/srfi-37.scm
@@ -42,6 +42,7 @@
 ;;;; Module definition & exports
 (define-module (lepton srfi-37)
   #:use-module (srfi srfi-9)
+  #:use-module (lepton core gettext)
   #:export (option option-names option-required-arg?
             option-optional-arg? option-processor
             args-fold))
@@ -99,7 +100,11 @@ encountered more than once."
 
 (define-syntax-rule (error msg arg ...)
   (begin
-    (format (current-error-port) msg arg ...)
+    (format (current-error-port)
+            (G_ "ERROR: ~A.
+Run `~A --help' for more information.\n")
+            (format #f (G_ msg) arg ...)
+            (basename (car (program-arguments))))
     (exit 1)))
 
 (define (args-fold args options unrecognized-option-proc

--- a/liblepton/scheme/lepton/srfi-37.scm
+++ b/liblepton/scheme/lepton/srfi-37.scm
@@ -1,3 +1,8 @@
+;;; Lepton EDA library - Scheme API
+;;; Copyright (C) 2021 Lepton EDA Contributors
+;;; This module has been copied from the Guile repository and modified
+;;; specially for Lepton EDA.
+
 ;;; srfi-37.scm --- args-fold
 
 ;;      Copyright (C) 2007, 2008, 2013 Free Software Foundation, Inc.

--- a/liblepton/scheme/lepton/srfi-37.scm
+++ b/liblepton/scheme/lepton/srfi-37.scm
@@ -103,13 +103,14 @@ encountered more than once."
      options)
     lookup))
 
-(define-syntax-rule (report-error msg arg ...)
-  (begin
+(define-syntax-rule (report-error msg arg)
+  (let ((message (format #f (G_ msg) arg))
+        (program-name (basename (car (program-arguments)))))
     (format (current-error-port)
             (G_ "ERROR: ~A.
 Run `~A --help' for more information.\n")
-            (format #f (G_ msg) arg ...)
-            (basename (car (program-arguments))))
+            message
+            program-name)
     (exit 1)))
 
 (define (args-fold args options unrecognized-option-proc

--- a/liblepton/scheme/lepton/srfi-37.scm
+++ b/liblepton/scheme/lepton/srfi-37.scm
@@ -1,0 +1,234 @@
+;;; srfi-37.scm --- args-fold
+
+;;      Copyright (C) 2007, 2008, 2013 Free Software Foundation, Inc.
+;;
+;; This library is free software; you can redistribute it and/or
+;; modify it under the terms of the GNU Lesser General Public
+;; License as published by the Free Software Foundation; either
+;; version 3 of the License, or (at your option) any later version.
+;;
+;; This library is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; Lesser General Public License for more details.
+;;
+;; You should have received a copy of the GNU Lesser General Public
+;; License along with this library; if not, write to the Free Software
+;; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+
+;;; Commentary:
+;;
+;; To use this module with Guile, use (cdr (program-arguments)) as
+;; the ARGS argument to `args-fold'.  Here is a short example:
+;;
+;;  (args-fold (cdr (program-arguments))
+;;          (let ((display-and-exit-proc
+;;                 (lambda (msg)
+;;                   (lambda (opt name arg)
+;;                     (display msg) (quit) (values)))))
+;;            (list (option '(#\v "version") #f #f
+;;                          (display-and-exit-proc "Foo version 42.0\n"))
+;;                  (option '(#\h "help") #f #f
+;;                          (display-and-exit-proc
+;;                           "Usage: foo scheme-file ..."))))
+;;          (lambda (opt name arg)
+;;            (error "Unrecognized option `~A'" name))
+;;          (lambda (op) (load op) (values)))
+;;
+;;; Code:
+
+
+;;;; Module definition & exports
+(define-module (srfi srfi-37)
+  #:use-module (srfi srfi-9)
+  #:export (option option-names option-required-arg?
+            option-optional-arg? option-processor
+            args-fold))
+
+(cond-expand-provide (current-module) '(srfi-37))
+
+;;;; args-fold and periphery procedures
+
+;;; An option as answered by `option'.  `names' is a list of
+;;; characters and strings, representing associated short-options and
+;;; long-options respectively that should use this option's
+;;; `processor' in an `args-fold' call.
+;;;
+;;; `required-arg?' and `optional-arg?' are mutually exclusive
+;;; booleans and indicate whether an argument must be or may be
+;;; provided.  Besides the obvious, this affects semantics of
+;;; short-options, as short-options with a required or optional
+;;; argument cannot be followed by other short options in the same
+;;; program-arguments string, as they will be interpreted collectively
+;;; as the option's argument.
+;;;
+;;; `processor' is called when this option is encountered.  It should
+;;; accept the containing option, the element of `names' (by `equal?')
+;;; encountered, the option's argument (or #f if none), and the seeds
+;;; as variadic arguments, answering the new seeds as values.
+(define-record-type srfi-37:option
+  (option names required-arg? optional-arg? processor)
+  option?
+  (names option-names)
+  (required-arg? option-required-arg?)
+  (optional-arg? option-optional-arg?)
+  (processor option-processor))
+
+(define (error-duplicate-option option-name)
+  (scm-error 'program-error "args-fold"
+             "Duplicate option name `~A~A'"
+             (list (if (char? option-name) #\- "--")
+                   option-name)
+             #f))
+
+(define (build-options-lookup options)
+  "Answer an `equal?' Guile hash-table that maps OPTIONS' names back
+to the containing options, signalling an error if a name is
+encountered more than once."
+  (let ((lookup (make-hash-table (* 2 (length options)))))
+    (for-each
+     (lambda (opt)
+       (for-each (lambda (name)
+                   (let ((assoc (hash-create-handle!
+                                 lookup name #f)))
+                     (if (cdr assoc)
+                         (error-duplicate-option (car assoc))
+                         (set-cdr! assoc opt))))
+                 (option-names opt)))
+     options)
+    lookup))
+
+(define (args-fold args options unrecognized-option-proc
+                   operand-proc . seeds)
+  "Answer the results of folding SEEDS as multiple values against the
+program-arguments in ARGS, as decided by the OPTIONS'
+`option-processor's, UNRECOGNIZED-OPTION-PROC, and OPERAND-PROC."
+  (let ((lookup (build-options-lookup options)))
+    ;; I don't like Guile's `error' here
+    (define (error msg . args)
+      (scm-error 'misc-error "args-fold" msg args #f))
+
+    (define (mutate-seeds! procedure . params)
+      (set! seeds (call-with-values
+                      (lambda ()
+                        (apply procedure (append params seeds)))
+                    list)))
+
+    ;; Clean up the rest of ARGS, assuming they're all operands.
+    (define (rest-operands)
+      (for-each (lambda (arg) (mutate-seeds! operand-proc arg))
+                args)
+      (set! args '()))
+
+    ;; Call OPT's processor with OPT, NAME, an argument to be decided,
+    ;; and the seeds.  Depending on OPT's *-arg? specification, get
+    ;; the parameter by calling REQ-ARG-PROC or OPT-ARG-PROC thunks;
+    ;; if no argument is allowed, call NO-ARG-PROC thunk.
+    (define (invoke-option-processor
+             opt name req-arg-proc opt-arg-proc no-arg-proc)
+      (mutate-seeds!
+       (option-processor opt) opt name
+       (cond ((option-required-arg? opt) (req-arg-proc))
+             ((option-optional-arg? opt) (opt-arg-proc))
+             (else (no-arg-proc) #f))))
+
+    ;; Compute and answer a short option argument, advancing ARGS as
+    ;; necessary, for the short option whose character is at POSITION
+    ;; in the current ARG.
+    (define (short-option-argument position)
+      (cond ((< (1+ position) (string-length (car args)))
+             (let ((result (substring (car args) (1+ position))))
+               (set! args (cdr args))
+               result))
+            ((pair? (cdr args))
+             (let ((result (cadr args)))
+               (set! args (cddr args))
+               result))
+            ((pair? args)
+             (set! args (cdr args))
+             #f)
+            (else #f)))
+
+    ;; Interpret the short-option at index POSITION in (car ARGS),
+    ;; followed by the remaining short options in (car ARGS).
+    (define (short-option position)
+      (if (>= position (string-length (car args)))
+          (begin
+            (set! args (cdr args))
+            (next-arg))
+          (let* ((opt-name (string-ref (car args) position))
+                 (option-here (hash-ref lookup opt-name)))
+            (cond ((not option-here)
+                   (mutate-seeds! unrecognized-option-proc
+                                  (option (list opt-name) #f #f
+                                          unrecognized-option-proc)
+                                  opt-name #f)
+                   (short-option (1+ position)))
+                  (else
+                   (invoke-option-processor
+                    option-here opt-name
+                    (lambda ()
+                      (or (short-option-argument position)
+                          (error "Missing required argument after `-~A'" opt-name)))
+                    (lambda ()
+                      ;; edge case: -xo -zf or -xo -- where opt-name=#\o
+                      ;; GNU getopt_long resolves these like I do
+                      (short-option-argument position))
+                    (lambda () #f))
+                   (if (not (or (option-required-arg? option-here)
+                                (option-optional-arg? option-here)))
+                       (short-option (1+ position))))))))
+
+    ;; Process the long option in (car ARGS).  We make the
+    ;; interesting, possibly non-standard assumption that long option
+    ;; names might contain #\=, so keep looking for more #\= in (car
+    ;; ARGS) until we find a named option in lookup.
+    (define (long-option)
+      (let ((arg (car args)))
+        (let place-=-after ((start-pos 2))
+          (let* ((index (string-index arg #\= start-pos))
+                 (opt-name (substring arg 2 (or index (string-length arg))))
+                 (option-here (hash-ref lookup opt-name)))
+            (if (not option-here)
+                ;; look for a later #\=, unless there can't be one
+                (if index
+                    (place-=-after (1+ index))
+                    (mutate-seeds!
+                     unrecognized-option-proc
+                     (option (list opt-name) #f #f unrecognized-option-proc)
+                     opt-name #f))
+                (invoke-option-processor
+                 option-here opt-name
+                 (lambda ()
+                   (if index
+                       (substring arg (1+ index))
+                       (error "Missing required argument after `--~A'" opt-name)))
+                 (lambda () (and index (substring arg (1+ index))))
+                 (lambda ()
+                   (if index
+                       (error "Extraneous argument after `--~A'" opt-name))))))))
+      (set! args (cdr args)))
+
+    ;; Process the remaining in ARGS.  Basically like calling
+    ;; `args-fold', but without having to regenerate `lookup' and the
+    ;; funcs above.
+    (define (next-arg)
+      (if (null? args)
+          (apply values seeds)
+          (let ((arg (car args)))
+            (cond ((or (string-null? arg)
+                       (not (char=? #\- (string-ref arg 0)))
+                       (= 1 (string-length arg))) ;"-"
+                   (mutate-seeds! operand-proc arg)
+                   (set! args (cdr args)))
+                  ((char=? #\- (string-ref arg 1))
+                   (if (= 2 (string-length arg)) ;"--"
+                       (begin (set! args (cdr args)) (rest-operands))
+                       (long-option)))
+                  (else (short-option 1)))
+            (next-arg))))
+
+    (next-arg)))
+
+;;; srfi-37.scm ends here

--- a/liblepton/scheme/lepton/srfi-37.scm
+++ b/liblepton/scheme/lepton/srfi-37.scm
@@ -98,7 +98,7 @@ encountered more than once."
      options)
     lookup))
 
-(define-syntax-rule (error msg arg ...)
+(define-syntax-rule (report-error msg arg ...)
   (begin
     (format (current-error-port)
             (G_ "ERROR: ~A.
@@ -174,7 +174,7 @@ program-arguments in ARGS, as decided by the OPTIONS'
                     option-here opt-name
                     (lambda ()
                       (or (short-option-argument position)
-                          (error "Missing required argument after `-~A'" opt-name)))
+                          (report-error "Missing required argument after `-~A'" opt-name)))
                     (lambda ()
                       ;; edge case: -xo -zf or -xo -- where opt-name=#\o
                       ;; GNU getopt_long resolves these like I do
@@ -207,11 +207,11 @@ program-arguments in ARGS, as decided by the OPTIONS'
                  (lambda ()
                    (if index
                        (substring arg (1+ index))
-                       (error "Missing required argument after `--~A'" opt-name)))
+                       (report-error "Missing required argument after `--~A'" opt-name)))
                  (lambda () (and index (substring arg (1+ index))))
                  (lambda ()
                    (if index
-                       (error "Extraneous argument after `--~A'" opt-name))))))))
+                       (report-error "Extraneous argument after `--~A'" opt-name))))))))
       (set! args (cdr args)))
 
     ;; Process the remaining in ARGS.  Basically like calling

--- a/liblepton/scheme/lepton/srfi-37.scm
+++ b/liblepton/scheme/lepton/srfi-37.scm
@@ -40,7 +40,7 @@
 
 
 ;;;; Module definition & exports
-(define-module (srfi srfi-37)
+(define-module (lepton srfi-37)
   #:use-module (srfi srfi-9)
   #:export (option option-names option-required-arg?
             option-optional-arg? option-processor

--- a/m4/lepton-data-dirs.m4
+++ b/m4/lepton-data-dirs.m4
@@ -1,9 +1,9 @@
 # lepton-data-dirs.m4                                   -*-Autoconf-*-
-# serial 1.0
+# serial 1.1
 
 dnl Lepton EDA data and configuration directories
 dnl Copyright (C) 2009, 2016  Peter Brett <peter@peter-b.co.uk>
-dnl Copyright (C) 2018-2020 Lepton EDA Contributors
+dnl Copyright (C) 2018-2021 Lepton EDA Contributors
 dnl
 dnl This program is free software; you can redistribute it and/or modify
 dnl it under the terms of the GNU General Public License as published by
@@ -57,4 +57,9 @@ Only liblepton should use this - apps should use eda_get_system_data_dirs()])
 
   AC_SUBST([BITMAP_DIRECTORY], ["$LEPTONDATADIR_expand/bitmap"])
 
+  AC_DEFINE_UNQUOTED([LEPTON_SCHEME_MODULE_DIRECTORY],
+                     ["$LEPTONDATADIR_expand/scheme"],
+                     [directory with scheme modules])
+
+  AC_SUBST([LEPTON_SCHEME_MODULE_DIRECTORY], ["$LEPTONDATADIR_expand/scheme"])
 ])dnl AX_DATA_DIRS

--- a/schematic/Makefile.am
+++ b/schematic/Makefile.am
@@ -4,6 +4,7 @@ EXTRA_DIST = lepton-schematic.scm
 
 do_subst = sed -e 's,[@]libdir[@],$(libdir),g' \
 	-e 's,[@]GUILE[@],$(GUILE),g' \
+	-e 's,[@]LEPTON_SCHEME_MODULE_DIRECTORY[@],$(LEPTON_SCHEME_MODULE_DIRECTORY),g' \
 	-e 's,[@]localedir[@],$(localedir),g' \
 	-e 's,[@]ccachedir[@],@LEPTON_SCM_PRECOMPILE_DIR@,g'
 

--- a/schematic/lepton-schematic.scm
+++ b/schematic/lepton-schematic.scm
@@ -25,7 +25,7 @@ exec @GUILE@ -s "$0" "$@"
 
 (use-modules (ice-9 match)
              (srfi srfi-1)
-             (srfi srfi-37)
+             (lepton srfi-37)
              (system foreign))
 
 ;;; Load and initialize liblepton library.

--- a/schematic/lepton-schematic.scm
+++ b/schematic/lepton-schematic.scm
@@ -135,7 +135,7 @@ Lepton EDA homepage: ~S\n")
 
 ;;; Parse lepton-schematic command-line options, displaying usage
 ;;; message or version information as required.
-(define (parse-commandline*)
+(define (parse-commandline)
   "Parse command line options.  Return the list of non-option
 arguments which should represent the list of schematics to open."
   (reverse
@@ -180,21 +180,6 @@ Run `~A --help' for more information.\n")
       (exit 1))
     (lambda (op seeds) (cons op seeds))
     '())))
-
-;;; Catch for errors in parse-commandline*().
-(define (parse-commandline)
-  (catch 'misc-error
-    parse-commandline*
-    (lambda (key . args)
-      ;; Throw away the first arg (function name: args-fold), and
-      ;; all the rest.
-      (let ((message (second args))
-            (option-name (third args)))
-        (format #t (G_ "ERROR: ~A.
-Run `~A --help' for more information.\n")
-                (apply format #f message option-name)
-                (basename (car (program-arguments))))
-        (exit 1)))))
 
 
 ;;; Load GTK resource files.

--- a/schematic/lepton-schematic.scm
+++ b/schematic/lepton-schematic.scm
@@ -129,7 +129,7 @@ Lepton EDA homepage: ~S\n")
           (car (program-arguments))
           (lepton-version-ref 'bugs)
           (lepton-version-ref 'url))
-  (primitive-exit 0))
+  (exit 0))
 
 
 ;;; Parse lepton-schematic command-line options, displaying usage
@@ -167,7 +167,7 @@ arguments which should represent the list of schematics to open."
      (option '(#\V "version") #f #f
              (lambda (opt name arg seeds)
                (display-lepton-version #:print-name #t #:copyright #t)
-               (primitive-exit 0))))
+               (exit 0))))
     (lambda (opt name arg seeds)
       (format #t
               (G_ "ERROR: Unknown option ~A.
@@ -176,7 +176,7 @@ Run `~A --help' for more information.\n")
                   (string-append "-" (char-set->string (char-set name)))
                   (string-append "--" name))
               (basename (car (program-arguments))))
-      (primitive-exit 1))
+      (exit 1))
     (lambda (op seeds) (cons op seeds))
     '())))
 
@@ -306,7 +306,7 @@ Run `~A --help' for more information.\n")
 ;;; If precompilation is requested, run it and exit.
 (when (precompile-mode)
   (precompile-prepare)
-  (primitive-exit (precompile-run)))
+  (exit (precompile-run)))
 
 ;;; Set up paths for Lepton's compiled Scheme modules.
 (set-guile-compiled-path)

--- a/schematic/lepton-schematic.scm
+++ b/schematic/lepton-schematic.scm
@@ -134,8 +134,9 @@ Lepton EDA homepage: ~S\n")
 
 ;;; Parse lepton-schematic command-line options, displaying usage
 ;;; message or version information as required.
-(define (parse-commandline)
-  "Parse command line options"
+(define (parse-commandline*)
+  "Parse command line options.  Return the list of non-option
+arguments which should represent the list of schematics to open."
   (reverse
    (args-fold
     (cdr (program-arguments))
@@ -178,6 +179,21 @@ Run `~A --help' for more information.\n")
       (primitive-exit 1))
     (lambda (op seeds) (cons op seeds))
     '())))
+
+;;; Catch for errors in parse-commandline*().
+(define (parse-commandline)
+  (catch 'misc-error
+    parse-commandline*
+    (lambda (key . args)
+      ;; Throw away the first arg (function name: args-fold), and
+      ;; all the rest.
+      (let ((message (second args))
+            (option-name (third args)))
+        (format #t (G_ "ERROR: ~A.
+Run `~A --help' for more information.\n")
+                (apply format #f message option-name)
+                (basename (car (program-arguments))))
+        (exit 1)))))
 
 
 ;;; Load GTK resource files.

--- a/schematic/lepton-schematic.scm
+++ b/schematic/lepton-schematic.scm
@@ -1,5 +1,6 @@
 #!/usr/bin/env sh
 export GUILE_LOAD_COMPILED_PATH="@ccachedir@:${GUILE_LOAD_COMPILED_PATH}"
+export GUILE_LOAD_PATH="@LEPTON_SCHEME_MODULE_DIRECTORY@:${GUILE_LOAD_PATH}"
 exec @GUILE@ -s "$0" "$@"
 !#
 

--- a/schematic/lepton-schematic.scm
+++ b/schematic/lepton-schematic.scm
@@ -6,7 +6,7 @@ exec @GUILE@ -s "$0" "$@"
 
 ;;; Lepton EDA attribute editor
 ;;; Copyright (C) 1998-2016 gEDA Contributors
-;;; Copyright (C) 2017-2020 Lepton EDA Contributors
+;;; Copyright (C) 2017-2021 Lepton EDA Contributors
 ;;;
 ;;; This program is free software; you can redistribute it and/or modify
 ;;; it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Instead, show a useful prompt.  Discussed in #729.

Another minor fix is a crash when the following code is used:
> lepton-schematic -c '(quit)'

Now it works OK (strangely, it doesn't lead to exit from the program, while if I use `(primitive-exit 0)` instead it does.