### PR TITLE
Rename object color accessors and actually use them in the code

### DIFF
--- a/liblepton/include/liblepton/geda_object.h
+++ b/liblepton/include/liblepton/geda_object.h
@@ -182,8 +182,8 @@ gboolean
 o_is_visible (const LeptonObject *object);
 
 void
-o_set_color (LeptonObject *object,
-             int color);
+lepton_object_set_color (LeptonObject *object,
+                         int color);
 
 void
 o_set_fill_options (LeptonObject *o_current,

--- a/liblepton/include/liblepton/geda_object.h
+++ b/liblepton/include/liblepton/geda_object.h
@@ -111,7 +111,7 @@ geda_object_calculate_visible_bounds (LeptonObject *o_current,
                                       gint *rbottom);
 
 gint
-geda_object_get_color (const LeptonObject *object);
+lepton_object_get_color (const LeptonObject *object);
 
 gint
 geda_object_get_drawing_color (const LeptonObject *object);

--- a/liblepton/include/liblepton/geda_object.h
+++ b/liblepton/include/liblepton/geda_object.h
@@ -114,7 +114,7 @@ gint
 lepton_object_get_color (const LeptonObject *object);
 
 gint
-geda_object_get_drawing_color (const LeptonObject *object);
+lepton_object_get_drawing_color (const LeptonObject *object);
 
 gboolean
 geda_object_get_position (const LeptonObject *object, gint *x, gint *y);

--- a/liblepton/src/edarenderer.c
+++ b/liblepton/src/edarenderer.c
@@ -519,7 +519,7 @@ eda_renderer_default_draw (EdaRenderer *renderer, LeptonObject *object)
     g_return_if_reached ();
   }
 
-  eda_renderer_set_color (renderer, geda_object_get_drawing_color (object));
+  eda_renderer_set_color (renderer, lepton_object_get_drawing_color (object));
   draw_func (renderer, object);
 }
 
@@ -553,7 +553,7 @@ eda_renderer_is_drawable_color (EdaRenderer *renderer, int color,
 static int
 eda_renderer_is_drawable (EdaRenderer *renderer, LeptonObject *object)
 {
-  int color = geda_object_get_drawing_color (object);
+  int color = lepton_object_get_drawing_color (object);
 
   /* Always attempt to draw component objects */
   if ((object->type == OBJ_COMPONENT) || (object->type == OBJ_PLACEHOLDER)) {

--- a/liblepton/src/geda_arc_object.c
+++ b/liblepton/src/geda_arc_object.c
@@ -54,7 +54,7 @@ geda_arc_object_new (gint color,
 
   new_node = s_basic_new_object (OBJ_ARC, "arc");
 
-  new_node->color = color;
+  lepton_object_set_color (new_node, color);
 
   new_node->arc = geda_arc_new ();
 
@@ -109,7 +109,7 @@ geda_arc_object_copy (const LeptonObject *object)
   g_return_val_if_fail (object->arc != NULL, NULL);
   g_return_val_if_fail (object->type == OBJ_ARC, NULL);
 
-  new_object = geda_arc_object_new (object->color,
+  new_object = geda_arc_object_new (lepton_object_get_color (object),
                                     object->arc->x,
                                     object->arc->y,
                                     object->arc->radius,

--- a/liblepton/src/geda_arc_object.c
+++ b/liblepton/src/geda_arc_object.c
@@ -482,7 +482,7 @@ geda_arc_object_to_buffer (const LeptonObject *object)
                           geda_arc_object_get_radius (object),
                           geda_arc_object_get_start_angle (object),
                           geda_arc_object_get_sweep_angle (object),
-                          geda_object_get_color (object),
+                          lepton_object_get_color (object),
                           object->line_width,
                           object->line_end,
                           object->line_type,

--- a/liblepton/src/geda_box_object.c
+++ b/liblepton/src/geda_box_object.c
@@ -65,7 +65,7 @@ geda_box_object_new (char type,
 
   /* create the object */
   new_node = s_basic_new_object(type, "box");
-  new_node->color = color;
+  lepton_object_set_color (new_node, color);
 
   box = geda_box_new ();
   new_node->box   = box;
@@ -105,7 +105,9 @@ geda_box_object_copy (LeptonObject *o_current)
 
   /* A new box object is created with #geda_box_object_new().
    * Values for its fields are default and need to be modified. */
-  new_obj = geda_box_object_new (OBJ_BOX, o_current->color, 0, 0, 0, 0);
+  new_obj = geda_box_object_new (OBJ_BOX,
+                                 lepton_object_get_color (o_current),
+                                 0, 0, 0, 0);
 
   /*
    * The dimensions of the new box are set with the ones of the original box.

--- a/liblepton/src/geda_box_object.c
+++ b/liblepton/src/geda_box_object.c
@@ -422,7 +422,7 @@ geda_box_object_to_buffer (const LeptonObject *object)
 
   buf = g_strdup_printf("%c %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d",
                         object->type,
-                        x1, y1, width, height, geda_object_get_color (object),
+                        x1, y1, width, height, lepton_object_get_color (object),
                         box_width, box_end, box_type, box_length, box_space,
                         box_fill,
                         fill_width, angle1, pitch1, angle2, pitch2);

--- a/liblepton/src/geda_bus_object.c
+++ b/liblepton/src/geda_bus_object.c
@@ -292,7 +292,7 @@ geda_bus_object_new (gint color,
   LeptonObject *new_node;
 
   new_node = s_basic_new_object(OBJ_BUS, "bus");
-  new_node->color = color;
+  lepton_object_set_color (new_node, color);
 
   new_node->line = geda_line_new ();
   /* check for null */
@@ -436,7 +436,7 @@ geda_bus_object_copy (const LeptonObject *object)
   /* still doesn't work... you need to pass in the new values */
   /* or don't update and update later */
   /* I think for now I'll disable the update and manually update */
-  new_obj = geda_bus_object_new (object->color,
+  new_obj = geda_bus_object_new (lepton_object_get_color (object),
                                  object->line->x[0],
                                  object->line->y[0],
                                  object->line->x[1],

--- a/liblepton/src/geda_bus_object.c
+++ b/liblepton/src/geda_bus_object.c
@@ -390,7 +390,7 @@ geda_bus_object_to_buffer (const LeptonObject *object)
                           geda_bus_object_get_y0 (object),
                           geda_bus_object_get_x1 (object),
                           geda_bus_object_get_y1 (object),
-                          geda_object_get_color (object),
+                          lepton_object_get_color (object),
                           geda_bus_object_get_ripper_direction (object));
 }
 

--- a/liblepton/src/geda_circle_object.c
+++ b/liblepton/src/geda_circle_object.c
@@ -65,7 +65,7 @@ geda_circle_object_new (gint color,
 
   /* create the object */
   new_node = s_basic_new_object (OBJ_CIRCLE, "circle");
-  new_node->color  = color;
+  lepton_object_set_color (new_node, color);
 
   new_node->circle = geda_circle_new ();
 
@@ -110,7 +110,7 @@ geda_circle_object_copy (const LeptonObject *object)
   g_return_val_if_fail (object->circle != NULL, NULL);
   g_return_val_if_fail (object->type == OBJ_CIRCLE, NULL);
 
-  new_obj = geda_circle_object_new (object->color,
+  new_obj = geda_circle_object_new (lepton_object_get_color (object),
                                     object->circle->center_x,
                                     object->circle->center_y,
                                     object->circle->radius);

--- a/liblepton/src/geda_circle_object.c
+++ b/liblepton/src/geda_circle_object.c
@@ -420,7 +420,7 @@ geda_circle_object_to_buffer (const LeptonObject *object)
                           geda_circle_object_get_center_x (object),
                           geda_circle_object_get_center_y (object),
                           geda_circle_object_get_radius (object),
-                          geda_object_get_color (object),
+                          lepton_object_get_color (object),
                           object->line_width,
                           object->line_end,
                           object->line_type,

--- a/liblepton/src/geda_component_object.c
+++ b/liblepton/src/geda_component_object.c
@@ -704,7 +704,6 @@ LeptonObject *o_component_new (PAGE *page,
 
 
   new_node->component_embedded = FALSE;
-  new_node->color = color;
   new_node->selectable = selectable;
 
   new_node->component = (COMPONENT *) g_malloc(sizeof(COMPONENT));
@@ -713,6 +712,9 @@ LeptonObject *o_component_new (PAGE *page,
   new_node->component->mirror = mirror;
   new_node->component->x = x;
   new_node->component->y = y;
+  /* Do setting color after initialization of prim_objs as the
+     function sets color of prim_objs as well. */
+  lepton_object_set_color (new_node, color);
 
   /* get the symbol data */
   if (clib != NULL) {
@@ -793,10 +795,11 @@ o_component_new_embedded (char type,
 
   new_node->component_embedded = TRUE;
 
-  new_node->color = color;
   new_node->selectable = selectable;
 
   new_node->component->prim_objs = NULL;
+
+  lepton_object_set_color (new_node, color);
 
   /* don't have to translate/rotate/mirror here at all since the */
   /* object is in place */
@@ -978,7 +981,6 @@ o_component_copy (LeptonObject *o_current)
   g_return_val_if_fail(o_current != NULL, NULL);
 
   o_new = s_basic_new_object(o_current->type, "complex");
-  o_new->color = o_current->color;
   o_new->selectable = o_current->selectable;
   o_new->component_basename = g_strdup(o_current->component_basename);
   o_new->component_embedded = o_current->component_embedded;
@@ -988,6 +990,11 @@ o_component_copy (LeptonObject *o_current)
   o_new->component->y = o_current->component->y;
   o_new->component->angle = o_current->component->angle;
   o_new->component->mirror = o_current->component->mirror;
+
+  /* Set prim_objs temporarily to NULL to prevent crashes on color
+     initialization. */
+  o_new->component->prim_objs = NULL;
+  lepton_object_set_color (o_new, lepton_object_get_color (o_current));
 
   /* Copy contents and set the parent pointers on the copied objects. */
   o_new->component->prim_objs =

--- a/liblepton/src/geda_line_object.c
+++ b/liblepton/src/geda_line_object.c
@@ -468,7 +468,7 @@ geda_line_object_to_buffer (const LeptonObject *object)
                           geda_line_object_get_y0 (object),
                           geda_line_object_get_x1 (object),
                           geda_line_object_get_y1 (object),
-                          geda_object_get_color (object),
+                          lepton_object_get_color (object),
                           object->line_width,
                           object->line_end,
                           object->line_type,

--- a/liblepton/src/geda_line_object.c
+++ b/liblepton/src/geda_line_object.c
@@ -67,7 +67,7 @@ geda_line_object_new (gint color,
 
   /* create the object */
   new_node = s_basic_new_object (OBJ_LINE, "line");
-  new_node->color = color;
+  lepton_object_set_color (new_node, color);
 
   new_node->line  = geda_line_new ();
 
@@ -109,7 +109,7 @@ geda_line_object_copy (LeptonObject *o_current)
 {
   LeptonObject *new_obj;
 
-  new_obj = geda_line_object_new (o_current->color,
+  new_obj = geda_line_object_new (lepton_object_get_color (o_current),
                                   o_current->line->x[0],
                                   o_current->line->y[0],
                                   o_current->line->x[1],

--- a/liblepton/src/geda_net_object.c
+++ b/liblepton/src/geda_net_object.c
@@ -338,7 +338,7 @@ geda_net_object_to_buffer (const LeptonObject *object)
                           geda_net_object_get_y0 (object),
                           geda_net_object_get_x1 (object),
                           geda_net_object_get_y1 (object),
-                          geda_object_get_color (object));
+                          lepton_object_get_color (object));
 }
 
 /*! \brief move a net object

--- a/liblepton/src/geda_net_object.c
+++ b/liblepton/src/geda_net_object.c
@@ -258,7 +258,7 @@ geda_net_object_new (char type,
   LeptonObject *new_node;
 
   new_node = s_basic_new_object(type, "net");
-  new_node->color = color;
+  lepton_object_set_color (new_node, color);
 
   new_node->line = geda_line_new ();
 
@@ -380,7 +380,7 @@ geda_net_object_copy (LeptonObject *o_current)
   /* or don't update and update later */
   /* I think for now I'll disable the update and manually update */
   new_obj = geda_net_object_new (OBJ_NET,
-                                 o_current->color,
+                                 lepton_object_get_color (o_current),
                                  o_current->line->x[0],
                                  o_current->line->y[0],
                                  o_current->line->x[1],

--- a/liblepton/src/geda_object.c
+++ b/liblepton/src/geda_object.c
@@ -66,7 +66,7 @@ int global_sid=0;
  *  \return the color index of the object
  */
 gint
-geda_object_get_color (const LeptonObject *object)
+lepton_object_get_color (const LeptonObject *object)
 {
   g_return_val_if_fail (object != NULL, default_color_id());
   g_return_val_if_fail (color_id_valid (object->color), default_color_id());

--- a/liblepton/src/geda_object.c
+++ b/liblepton/src/geda_object.c
@@ -840,8 +840,8 @@ geda_object_shortest_distance_full (LeptonObject *object,
  *  \param [in] color     The new color.
  */
 void
-o_set_color (LeptonObject *object,
-             int color)
+lepton_object_set_color (LeptonObject *object,
+                         int color)
 {
   g_return_if_fail (object != NULL);
 

--- a/liblepton/src/geda_object.c
+++ b/liblepton/src/geda_object.c
@@ -86,7 +86,7 @@ lepton_object_get_color (const LeptonObject *object)
  *  \return the color index the draw the object
  */
 gint
-geda_object_get_drawing_color (const LeptonObject *object)
+lepton_object_get_drawing_color (const LeptonObject *object)
 {
   gint color;
 

--- a/liblepton/src/geda_object.c
+++ b/liblepton/src/geda_object.c
@@ -92,7 +92,7 @@ geda_object_get_drawing_color (const LeptonObject *object)
 
   g_return_val_if_fail (object != NULL, default_color_id());
 
-  color = object->selectable ? object->color : LOCK_COLOR;
+  color = object->selectable ? lepton_object_get_color (object) : LOCK_COLOR;
 
   g_return_val_if_fail (color_id_valid (color), default_color_id());
 
@@ -1276,7 +1276,7 @@ s_basic_init_object (LeptonObject *new_node, int type, char const *name)
   new_node->parent = NULL;
 
   /* Setup the color */
-  new_node->color = default_color_id();
+  lepton_object_set_color (new_node, default_color_id());
   new_node->dont_redraw = FALSE;
   new_node->selectable = TRUE;
   new_node->selected = FALSE;

--- a/liblepton/src/geda_object.c
+++ b/liblepton/src/geda_object.c
@@ -78,7 +78,7 @@ lepton_object_get_color (const LeptonObject *object)
  *
  *  If this function fails, it returns the default color ID.
  *
- *  The output of this funtion is ependent on other variables than just the
+ *  The output of this funtion is dependent on other variables than just the
  *  object color. If the object is locked, it will return the LOCK_COLOR.
  *  This value should not be used for saving or editing the object.
  *

--- a/liblepton/src/geda_object.c
+++ b/liblepton/src/geda_object.c
@@ -847,8 +847,9 @@ lepton_object_set_color (LeptonObject *object,
 
   object->color = color;
 
-  if (object->type == OBJ_COMPONENT ||
-      object->type == OBJ_PLACEHOLDER)
+  if ((object->type == OBJ_COMPONENT ||
+       object->type == OBJ_PLACEHOLDER)
+       && (object->component != NULL))
     geda_object_list_set_color (object->component->prim_objs, color);
 }
 

--- a/liblepton/src/geda_object_list.c
+++ b/liblepton/src/geda_object_list.c
@@ -267,7 +267,7 @@ geda_object_list_set_color (const GList *objects,
   while (iter != NULL) {
     LeptonObject *object = (LeptonObject*)iter->data;
 
-    o_set_color (object, color);
+    lepton_object_set_color (object, color);
     iter = g_list_next (iter);
   }
 }

--- a/liblepton/src/geda_path_object.c
+++ b/liblepton/src/geda_path_object.c
@@ -290,7 +290,7 @@ geda_path_object_to_buffer (const LeptonObject *object)
   path_string = s_path_string_from_path (object->path);
   num_lines = o_text_num_lines (path_string);
   buf = g_strdup_printf ("%c %d %d %d %d %d %d %d %d %d %d %d %d %d\n%s",
-                         object->type, geda_object_get_color (object), line_width, line_end,
+                         object->type, lepton_object_get_color (object), line_width, line_end,
                          line_type, line_length, line_space, fill_type,
                          fill_width, angle1, pitch1, angle2, pitch2,
                          num_lines, path_string);

--- a/liblepton/src/geda_path_object.c
+++ b/liblepton/src/geda_path_object.c
@@ -86,7 +86,7 @@ geda_path_object_new_take_path (char type,
 
   /* create the object */
   new_node        = s_basic_new_object (type, "path");
-  new_node->color = color;
+  lepton_object_set_color (new_node, color);
 
   new_node->path  = path_data;
 
@@ -122,7 +122,9 @@ geda_path_object_copy (LeptonObject *o_current)
   char *path_string;
 
   path_string = s_path_string_from_path (o_current->path);
-  new_obj = geda_path_object_new (OBJ_PATH, o_current->color, path_string);
+  new_obj = geda_path_object_new (OBJ_PATH,
+                                  lepton_object_get_color (o_current),
+                                  path_string);
   g_free (path_string);
 
   /* copy the path type and filling options */

--- a/liblepton/src/geda_picture_object.c
+++ b/liblepton/src/geda_picture_object.c
@@ -1007,7 +1007,7 @@ o_picture_copy (LeptonObject *object)
   picture = (PICTURE*) g_malloc (sizeof(PICTURE));
   new_node->picture = picture;
 
-  new_node->color = geda_object_get_color (object);
+  new_node->color = lepton_object_get_color (object);
   new_node->selectable = geda_object_get_selectable (object);
 
   /* describe the picture with its upper left and lower right corner */

--- a/liblepton/src/geda_picture_object.c
+++ b/liblepton/src/geda_picture_object.c
@@ -1007,7 +1007,7 @@ o_picture_copy (LeptonObject *object)
   picture = (PICTURE*) g_malloc (sizeof(PICTURE));
   new_node->picture = picture;
 
-  new_node->color = lepton_object_get_color (object);
+  lepton_object_set_color (new_node, lepton_object_get_color (object));
   new_node->selectable = geda_object_get_selectable (object);
 
   /* describe the picture with its upper left and lower right corner */

--- a/liblepton/src/geda_pin_object.c
+++ b/liblepton/src/geda_pin_object.c
@@ -296,7 +296,7 @@ geda_pin_object_new (int color,
   LeptonObject *new_node;
 
   new_node = s_basic_new_object(OBJ_PIN, "pin");
-  new_node->color = color;
+  lepton_object_set_color (new_node, color);
 
   new_node->line = geda_line_new ();
 
@@ -447,7 +447,7 @@ geda_pin_object_copy (LeptonObject *o_current)
   g_return_val_if_fail (o_current->line != NULL, NULL);
   g_return_val_if_fail (o_current->type == OBJ_PIN, NULL);
 
-  new_obj = geda_pin_object_new (o_current->color,
+  new_obj = geda_pin_object_new (lepton_object_get_color (o_current),
                                  o_current->line->x[0],
                                  o_current->line->y[0],
                                  o_current->line->x[1],

--- a/liblepton/src/geda_pin_object.c
+++ b/liblepton/src/geda_pin_object.c
@@ -404,7 +404,7 @@ geda_pin_object_to_buffer (const LeptonObject *object)
                           geda_pin_object_get_y0 (object),
                           geda_pin_object_get_x1 (object),
                           geda_pin_object_get_y1 (object),
-                          geda_object_get_color (object),
+                          lepton_object_get_color (object),
                           object->pin_type,
                           object->whichend);
 }

--- a/liblepton/src/geda_text_object.c
+++ b/liblepton/src/geda_text_object.c
@@ -447,7 +447,7 @@ geda_text_object_new (gint color,
 
   new_node->text = text;
 
-  new_node->color = color;
+  lepton_object_set_color (new_node, color);
   o_set_visibility (new_node, visibility);
   new_node->show_name_value = show_name_value;
 
@@ -697,7 +697,7 @@ geda_text_object_copy (const LeptonObject *object)
   g_return_val_if_fail (object->text != NULL, NULL);
   g_return_val_if_fail (object->type == OBJ_TEXT, NULL);
 
-  new_obj = geda_text_object_new (object->color,
+  new_obj = geda_text_object_new (lepton_object_get_color (object),
                                   object->text->x,
                                   object->text->y,
                                   object->text->alignment,

--- a/liblepton/src/geda_text_object.c
+++ b/liblepton/src/geda_text_object.c
@@ -637,7 +637,7 @@ geda_text_object_to_buffer (const LeptonObject *object)
                           OBJ_TEXT,
                           geda_text_object_get_x (object),
                           geda_text_object_get_y (object),
-                          geda_object_get_color (object),
+                          lepton_object_get_color (object),
                           geda_text_object_get_size (object),
                           geda_object_get_visible (object),
                           object->show_name_value,

--- a/liblepton/src/o_attrib.c
+++ b/liblepton/src/o_attrib.c
@@ -105,7 +105,7 @@ o_attrib_attach (LeptonObject *attrib,
   o_attrib_add (object, attrib);
 
   if (set_color)
-    o_set_color (attrib, ATTRIBUTE_COLOR);
+    lepton_object_set_color (attrib, ATTRIBUTE_COLOR);
 }
 
 
@@ -142,7 +142,7 @@ o_attrib_detach_all (LeptonObject *object)
     a_current = (LeptonObject*) a_iter->data;
 
     a_current->attached_to = NULL;
-    o_set_color (a_current, DETACHED_ATTRIBUTE_COLOR);
+    lepton_object_set_color (a_current, DETACHED_ATTRIBUTE_COLOR);
   }
 
   g_list_free (object->attribs);

--- a/liblepton/src/scheme_attrib.c
+++ b/liblepton/src/scheme_attrib.c
@@ -268,7 +268,7 @@ SCM_DEFINE (detach_attrib_x, "%detach-attrib!", 2, 0, 0,
   /* Detach object */
   o_emit_pre_change_notify (attrib);
   o_attrib_remove (&obj->attribs, attrib);
-  o_set_color (attrib, DETACHED_ATTRIBUTE_COLOR);
+  lepton_object_set_color (attrib, DETACHED_ATTRIBUTE_COLOR);
   o_emit_change_notify (attrib);
 
   o_page_changed (obj);

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -691,7 +691,7 @@ SCM_DEFINE (set_object_color_x, "%set-object-color!", 2, 0, 0,
               SCM_ARG2, s_set_object_color_x);
 
   LeptonObject *obj = edascm_to_object (obj_s);
-  o_set_color (obj, scm_to_int (color_s));
+  lepton_object_set_color (obj, scm_to_int (color_s));
 
   o_page_changed (obj);
 
@@ -950,7 +950,7 @@ SCM_DEFINE (set_line_x, "%set-line!", 6, 0, 0,
   default:
     return line_s;
   }
-  o_set_color (obj, scm_to_int (color_s));
+  lepton_object_set_color (obj, scm_to_int (color_s));
 
   /* We may need to update connectivity. */
   PAGE *page = o_get_page (obj);
@@ -1205,7 +1205,7 @@ SCM_DEFINE (set_box_x, "%set-box!", 6, 0, 0,
   geda_box_object_modify_all (obj,
                               scm_to_int (x1_s), scm_to_int (y1_s),
                               scm_to_int (x2_s), scm_to_int (y2_s));
-  o_set_color (obj, scm_to_int (color_s));
+  lepton_object_set_color (obj, scm_to_int (color_s));
 
   o_page_changed (obj);
 
@@ -1301,7 +1301,7 @@ SCM_DEFINE (set_circle_x, "%set-circle!", 5, 0, 0,
   geda_circle_object_modify (obj, scm_to_int(x_s), scm_to_int(y_s),
                              CIRCLE_CENTER);
   geda_circle_object_modify (obj, scm_to_int(r_s), 0, CIRCLE_RADIUS);
-  o_set_color (obj, scm_to_int (color_s));
+  lepton_object_set_color (obj, scm_to_int (color_s));
 
   o_page_changed (obj);
 
@@ -1405,7 +1405,7 @@ SCM_DEFINE (set_arc_x, "%set-arc!", 7, 0, 0,
   geda_arc_object_modify (obj, scm_to_int(r_s), 0, ARC_RADIUS);
   geda_arc_object_modify (obj, scm_to_int(start_angle_s), 0, ARC_START_ANGLE);
   geda_arc_object_modify (obj, scm_to_int(end_angle_s), 0, ARC_SWEEP_ANGLE);
-  o_set_color (obj, scm_to_int (color_s));
+  lepton_object_set_color (obj, scm_to_int (color_s));
 
   o_page_changed (obj);
 
@@ -1598,7 +1598,7 @@ SCM_DEFINE (set_text_x, "%set-text!", 10, 0, 0,
   o_text_recreate (obj);
 
   /* Color */
-  o_set_color (obj, scm_to_int (color_s));
+  lepton_object_set_color (obj, scm_to_int (color_s));
 
   o_page_changed (obj);
 

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -666,7 +666,7 @@ SCM_DEFINE (object_color, "%object-color", 1, 0, 0,
               SCM_ARG1, s_object_color);
 
   LeptonObject *obj = edascm_to_object (obj_s);
-  return scm_from_int (obj->color);
+  return scm_from_int (lepton_object_get_color (obj));
 }
 
 /*! \brief Set the color of an object.
@@ -994,7 +994,7 @@ SCM_DEFINE (line_info, "%line-info", 1, 0, 0,
   SCM y1 = scm_from_int (geda_line_object_get_y0 (obj));
   SCM x2 = scm_from_int (geda_line_object_get_x1 (obj));
   SCM y2 = scm_from_int (geda_line_object_get_y1 (obj));
-  SCM color = scm_from_int (obj->color);
+  SCM color = scm_from_int (lepton_object_get_color (obj));
 
   /* Swap ends according to pin's whichend flag. */
   if ((obj->type == OBJ_PIN) && obj->whichend) {
@@ -1238,7 +1238,7 @@ SCM_DEFINE (box_info, "%box-info", 1, 0, 0,
                      scm_from_int (obj->box->upper_y),
                      scm_from_int (obj->box->lower_x),
                      scm_from_int (obj->box->lower_y),
-                     scm_from_int (obj->color),
+                     scm_from_int (lepton_object_get_color (obj)),
                      SCM_UNDEFINED);
 }
 
@@ -1333,7 +1333,7 @@ SCM_DEFINE (circle_info, "%circle-info", 1, 0, 0,
   return scm_list_n (scm_from_int (geda_circle_object_get_center_x (obj)),
                      scm_from_int (geda_circle_object_get_center_y (obj)),
                      scm_from_int (geda_circle_object_get_radius (obj)),
-                     scm_from_int (obj->color),
+                     scm_from_int (lepton_object_get_color (obj)),
                      SCM_UNDEFINED);
 }
 
@@ -1443,7 +1443,7 @@ SCM_DEFINE (arc_info, "%arc-info", 1, 0, 0,
                      scm_from_int (geda_arc_object_get_radius (obj)),
                      scm_from_int (geda_arc_object_get_start_angle (obj)),
                      scm_from_int (geda_arc_object_get_sweep_angle (obj)),
-                     scm_from_int (obj->color),
+                     scm_from_int (lepton_object_get_color (obj)),
                      SCM_UNDEFINED);
 }
 
@@ -1678,7 +1678,7 @@ SCM_DEFINE (text_info, "%text-info", 1, 0, 0,
                      scm_from_int (geda_text_object_get_size (obj)),
                      visible_s,
                      show_s,
-                     scm_from_int (obj->color),
+                     scm_from_int (lepton_object_get_color (obj)),
                      SCM_UNDEFINED);
 }
 

--- a/liblepton/tests/test_arc_object.c
+++ b/liblepton/tests/test_arc_object.c
@@ -27,7 +27,7 @@ check_construction ()
 
     g_assert_cmpint (center_x, ==, geda_arc_object_get_center_x (object0));
     g_assert_cmpint (center_y, ==, geda_arc_object_get_center_y (object0));
-    g_assert_cmpint (color, ==, geda_object_get_color (object0));
+    g_assert_cmpint (color, ==, lepton_object_get_color (object0));
     g_assert_cmpint (radius, ==, geda_arc_object_get_radius (object0));
     g_assert_cmpint (start_angle, ==, geda_arc_object_get_start_angle (object0));
     g_assert_cmpint (sweep_angle, ==, geda_arc_object_get_sweep_angle (object0));
@@ -42,7 +42,7 @@ check_construction ()
 
     g_assert_cmpint (center_x, ==, geda_arc_object_get_center_x (object1));
     g_assert_cmpint (center_y, ==, geda_arc_object_get_center_y (object1));
-    g_assert_cmpint (color, ==, geda_object_get_color (object1));
+    g_assert_cmpint (color, ==, lepton_object_get_color (object1));
     g_assert_cmpint (radius, ==, geda_arc_object_get_radius (object1));
     g_assert_cmpint (start_angle, ==, geda_arc_object_get_start_angle (object1));
     g_assert_cmpint (sweep_angle, ==, geda_arc_object_get_sweep_angle (object1));
@@ -93,7 +93,7 @@ check_accessors ()
 
     g_assert_cmpint (center_x, ==, geda_arc_object_get_center_x (object0));
     g_assert_cmpint (center_y, ==, geda_arc_object_get_center_y (object0));
-    g_assert_cmpint (color, ==, geda_object_get_color (object0));
+    g_assert_cmpint (color, ==, lepton_object_get_color (object0));
     g_assert_cmpint (radius, ==, geda_arc_object_get_radius (object0));
     g_assert_cmpint (start_angle, ==, geda_arc_object_get_start_angle (object0));
     g_assert_cmpint (sweep_angle, ==, geda_arc_object_get_sweep_angle (object0));
@@ -145,7 +145,7 @@ check_serialization ()
 
     g_assert_cmpint (center_x, ==, geda_arc_object_get_center_x (object1));
     g_assert_cmpint (center_y, ==, geda_arc_object_get_center_y (object1));
-    g_assert_cmpint (color, ==, geda_object_get_color (object1));
+    g_assert_cmpint (color, ==, lepton_object_get_color (object1));
     g_assert_cmpint (radius, ==, geda_arc_object_get_radius (object1));
     g_assert_cmpint (start_angle, ==, geda_arc_object_get_start_angle (object1));
     g_assert_cmpint (sweep_angle, ==, geda_arc_object_get_sweep_angle (object1));

--- a/liblepton/tests/test_arc_object.c
+++ b/liblepton/tests/test_arc_object.c
@@ -86,7 +86,7 @@ check_accessors ()
 
     geda_arc_object_set_center_x (object0, center_x);
     geda_arc_object_set_center_y (object0, center_y);
-    o_set_color (object0, color);
+    lepton_object_set_color (object0, color);
     geda_arc_object_set_radius (object0, radius);
     geda_arc_object_set_start_angle (object0, start_angle);
     geda_arc_object_set_sweep_angle (object0, sweep_angle);

--- a/liblepton/tests/test_bus_object.c
+++ b/liblepton/tests/test_bus_object.c
@@ -88,7 +88,7 @@ check_accessors ()
     geda_bus_object_set_y0 (object0, y0);
     geda_bus_object_set_x1 (object0, x1);
     geda_bus_object_set_y1 (object0, y1);
-    o_set_color (object0, color);
+    lepton_object_set_color (object0, color);
     geda_bus_object_set_ripper_direction (object0, ripper);
 
     g_assert_cmpint (x0, ==, geda_bus_object_get_x0 (object0));

--- a/liblepton/tests/test_bus_object.c
+++ b/liblepton/tests/test_bus_object.c
@@ -29,7 +29,7 @@ check_construction ()
     g_assert_cmpint (y0, ==, geda_bus_object_get_y0 (object0));
     g_assert_cmpint (x1, ==, geda_bus_object_get_x1 (object0));
     g_assert_cmpint (y1, ==, geda_bus_object_get_y1 (object0));
-    g_assert_cmpint (color, ==, geda_object_get_color (object0));
+    g_assert_cmpint (color, ==, lepton_object_get_color (object0));
     g_assert_cmpint (ripper, ==, geda_bus_object_get_ripper_direction (object0));
 
     LeptonObject *object1 = geda_bus_object_copy (object0);
@@ -44,7 +44,7 @@ check_construction ()
     g_assert_cmpint (y0, ==, geda_bus_object_get_y0 (object1));
     g_assert_cmpint (x1, ==, geda_bus_object_get_x1 (object1));
     g_assert_cmpint (y1, ==, geda_bus_object_get_y1 (object1));
-    g_assert_cmpint (color, ==, geda_object_get_color (object1));
+    g_assert_cmpint (color, ==, lepton_object_get_color (object1));
     g_assert_cmpint (ripper, ==, geda_bus_object_get_ripper_direction (object1));
 
     s_delete_object (object1);
@@ -95,7 +95,7 @@ check_accessors ()
     g_assert_cmpint (y0, ==, geda_bus_object_get_y0 (object0));
     g_assert_cmpint (x1, ==, geda_bus_object_get_x1 (object0));
     g_assert_cmpint (y1, ==, geda_bus_object_get_y1 (object0));
-    g_assert_cmpint (color, ==, geda_object_get_color (object0));
+    g_assert_cmpint (color, ==, lepton_object_get_color (object0));
     g_assert_cmpint (ripper, ==, geda_bus_object_get_ripper_direction (object0));
 
     s_delete_object (object0);
@@ -147,7 +147,7 @@ check_serialization ()
     g_assert_cmpint (y0, ==, geda_bus_object_get_y0 (object1));
     g_assert_cmpint (x1, ==, geda_bus_object_get_x1 (object1));
     g_assert_cmpint (y1, ==, geda_bus_object_get_y1 (object1));
-    g_assert_cmpint (color, ==, geda_object_get_color (object1));
+    g_assert_cmpint (color, ==, lepton_object_get_color (object1));
     g_assert_cmpint (ripper, ==, geda_bus_object_get_ripper_direction (object1));
 
     gchar *buffer1 = geda_bus_object_to_buffer (object1);

--- a/liblepton/tests/test_circle_object.c
+++ b/liblepton/tests/test_circle_object.c
@@ -23,7 +23,7 @@ check_construction ()
 
     g_assert_cmpint (center_x, ==, geda_circle_object_get_center_x (object0));
     g_assert_cmpint (center_y, ==, geda_circle_object_get_center_y (object0));
-    g_assert_cmpint (color, ==, geda_object_get_color (object0));
+    g_assert_cmpint (color, ==, lepton_object_get_color (object0));
     g_assert_cmpint (radius, ==, geda_circle_object_get_radius (object0));
 
     LeptonObject *object1 = geda_circle_object_copy (object0);
@@ -36,7 +36,7 @@ check_construction ()
 
     g_assert_cmpint (center_x, ==, geda_circle_object_get_center_x (object1));
     g_assert_cmpint (center_y, ==, geda_circle_object_get_center_y (object1));
-    g_assert_cmpint (color, ==, geda_object_get_color (object1));
+    g_assert_cmpint (color, ==, lepton_object_get_color (object1));
     g_assert_cmpint (radius, ==, geda_circle_object_get_radius (object1));
 
     s_delete_object (object1);
@@ -77,7 +77,7 @@ check_accessors ()
 
     g_assert_cmpint (center_x, ==, geda_circle_object_get_center_x (object0));
     g_assert_cmpint (center_y, ==, geda_circle_object_get_center_y (object0));
-    g_assert_cmpint (color, ==, geda_object_get_color (object0));
+    g_assert_cmpint (color, ==, lepton_object_get_color (object0));
     g_assert_cmpint (radius, ==, geda_circle_object_get_radius (object0));
 
     s_delete_object (object0);
@@ -123,7 +123,7 @@ check_serialization ()
 
     g_assert_cmpint (center_x, ==, geda_circle_object_get_center_x (object1));
     g_assert_cmpint (center_y, ==, geda_circle_object_get_center_y (object1));
-    g_assert_cmpint (color, ==, geda_object_get_color (object1));
+    g_assert_cmpint (color, ==, lepton_object_get_color (object1));
     g_assert_cmpint (radius, ==, geda_circle_object_get_radius (object1));
 
     gchar *buffer1 = geda_circle_object_to_buffer (object1);

--- a/liblepton/tests/test_circle_object.c
+++ b/liblepton/tests/test_circle_object.c
@@ -72,7 +72,7 @@ check_accessors ()
 
     geda_circle_object_set_center_x (object0, center_x);
     geda_circle_object_set_center_y (object0, center_y);
-    o_set_color (object0, color);
+    lepton_object_set_color (object0, color);
     geda_circle_object_set_radius (object0, radius);
 
     g_assert_cmpint (center_x, ==, geda_circle_object_get_center_x (object0));

--- a/liblepton/tests/test_line_object.c
+++ b/liblepton/tests/test_line_object.c
@@ -27,7 +27,7 @@ check_construction ()
     g_assert_cmpint (y0, ==, geda_line_object_get_y0 (object0));
     g_assert_cmpint (x1, ==, geda_line_object_get_x1 (object0));
     g_assert_cmpint (y1, ==, geda_line_object_get_y1 (object0));
-    g_assert_cmpint (color, ==, geda_object_get_color (object0));
+    g_assert_cmpint (color, ==, lepton_object_get_color (object0));
 
     LeptonObject *object1 = geda_line_object_copy (object0);
 
@@ -41,7 +41,7 @@ check_construction ()
     g_assert_cmpint (y0, ==, geda_line_object_get_y0 (object1));
     g_assert_cmpint (x1, ==, geda_line_object_get_x1 (object1));
     g_assert_cmpint (y1, ==, geda_line_object_get_y1 (object1));
-    g_assert_cmpint (color, ==, geda_object_get_color (object1));
+    g_assert_cmpint (color, ==, lepton_object_get_color (object1));
 
     s_delete_object (object1);
   }
@@ -87,7 +87,7 @@ check_accessors ()
     g_assert_cmpint (y0, ==, geda_line_object_get_y0 (object0));
     g_assert_cmpint (x1, ==, geda_line_object_get_x1 (object0));
     g_assert_cmpint (y1, ==, geda_line_object_get_y1 (object0));
-    g_assert_cmpint (color, ==, geda_object_get_color (object0));
+    g_assert_cmpint (color, ==, lepton_object_get_color (object0));
 
     s_delete_object (object0);
   }
@@ -136,7 +136,7 @@ check_serialization ()
     g_assert_cmpint (y0, ==, geda_line_object_get_y0 (object1));
     g_assert_cmpint (x1, ==, geda_line_object_get_x1 (object1));
     g_assert_cmpint (y1, ==, geda_line_object_get_y1 (object1));
-    g_assert_cmpint (color, ==, geda_object_get_color (object1));
+    g_assert_cmpint (color, ==, lepton_object_get_color (object1));
 
     gchar *buffer1 = geda_line_object_to_buffer (object1);
     s_delete_object (object1);

--- a/liblepton/tests/test_line_object.c
+++ b/liblepton/tests/test_line_object.c
@@ -81,7 +81,7 @@ check_accessors ()
     geda_line_object_set_y0 (object0, y0);
     geda_line_object_set_x1 (object0, x1);
     geda_line_object_set_y1 (object0, y1);
-    o_set_color (object0, color);
+    lepton_object_set_color (object0, color);
 
     g_assert_cmpint (x0, ==, geda_line_object_get_x0 (object0));
     g_assert_cmpint (y0, ==, geda_line_object_get_y0 (object0));

--- a/liblepton/tests/test_net_object.c
+++ b/liblepton/tests/test_net_object.c
@@ -83,7 +83,7 @@ check_accessors ()
     geda_net_object_set_y0 (object0, y0);
     geda_net_object_set_x1 (object0, x1);
     geda_net_object_set_y1 (object0, y1);
-    o_set_color (object0, color);
+    lepton_object_set_color (object0, color);
 
     g_assert_cmpint (x0, ==, geda_net_object_get_x0 (object0));
     g_assert_cmpint (y0, ==, geda_net_object_get_y0 (object0));

--- a/liblepton/tests/test_net_object.c
+++ b/liblepton/tests/test_net_object.c
@@ -28,7 +28,7 @@ check_construction ()
     g_assert_cmpint (y0, ==, geda_net_object_get_y0 (object0));
     g_assert_cmpint (x1, ==, geda_net_object_get_x1 (object0));
     g_assert_cmpint (y1, ==, geda_net_object_get_y1 (object0));
-    g_assert_cmpint (color, ==, geda_object_get_color (object0));
+    g_assert_cmpint (color, ==, lepton_object_get_color (object0));
 
     LeptonObject *object1 = geda_net_object_copy (object0);
 
@@ -42,7 +42,7 @@ check_construction ()
     g_assert_cmpint (y0, ==, geda_net_object_get_y0 (object1));
     g_assert_cmpint (x1, ==, geda_net_object_get_x1 (object1));
     g_assert_cmpint (y1, ==, geda_net_object_get_y1 (object1));
-    g_assert_cmpint (color, ==, geda_object_get_color (object1));
+    g_assert_cmpint (color, ==, lepton_object_get_color (object1));
 
     s_delete_object (object1);
   }
@@ -89,7 +89,7 @@ check_accessors ()
     g_assert_cmpint (y0, ==, geda_net_object_get_y0 (object0));
     g_assert_cmpint (x1, ==, geda_net_object_get_x1 (object0));
     g_assert_cmpint (y1, ==, geda_net_object_get_y1 (object0));
-    g_assert_cmpint (color, ==, geda_object_get_color (object0));
+    g_assert_cmpint (color, ==, lepton_object_get_color (object0));
 
     s_delete_object (object0);
   }
@@ -139,7 +139,7 @@ check_serialization ()
     g_assert_cmpint (y0, ==, geda_net_object_get_y0 (object1));
     g_assert_cmpint (x1, ==, geda_net_object_get_x1 (object1));
     g_assert_cmpint (y1, ==, geda_net_object_get_y1 (object1));
-    g_assert_cmpint (color, ==, geda_object_get_color (object1));
+    g_assert_cmpint (color, ==, lepton_object_get_color (object1));
 
     gchar *buffer1 = geda_net_object_to_buffer (object1);
     s_delete_object (object1);

--- a/liblepton/tests/test_pin_object.c
+++ b/liblepton/tests/test_pin_object.c
@@ -31,7 +31,7 @@ check_construction ()
     g_assert_cmpint (y0, ==, geda_pin_object_get_y0 (object0));
     g_assert_cmpint (x1, ==, geda_pin_object_get_x1 (object0));
     g_assert_cmpint (y1, ==, geda_pin_object_get_y1 (object0));
-    g_assert_cmpint (color, ==, geda_object_get_color (object0));
+    g_assert_cmpint (color, ==, lepton_object_get_color (object0));
 
     LeptonObject *object1 = geda_pin_object_copy (object0);
 
@@ -45,7 +45,7 @@ check_construction ()
     g_assert_cmpint (y0, ==, geda_pin_object_get_y0 (object1));
     g_assert_cmpint (x1, ==, geda_pin_object_get_x1 (object1));
     g_assert_cmpint (y1, ==, geda_pin_object_get_y1 (object1));
-    g_assert_cmpint (color, ==, geda_object_get_color (object1));
+    g_assert_cmpint (color, ==, lepton_object_get_color (object1));
 
     s_delete_object (object1);
   }
@@ -95,7 +95,7 @@ check_accessors ()
     g_assert_cmpint (y0, ==, geda_pin_object_get_y0 (object0));
     g_assert_cmpint (x1, ==, geda_pin_object_get_x1 (object0));
     g_assert_cmpint (y1, ==, geda_pin_object_get_y1 (object0));
-    g_assert_cmpint (color, ==, geda_object_get_color (object0));
+    g_assert_cmpint (color, ==, lepton_object_get_color (object0));
 
     s_delete_object (object0);
   }
@@ -148,7 +148,7 @@ check_serialization ()
     g_assert_cmpint (y0, ==, geda_pin_object_get_y0 (object1));
     g_assert_cmpint (x1, ==, geda_pin_object_get_x1 (object1));
     g_assert_cmpint (y1, ==, geda_pin_object_get_y1 (object1));
-    g_assert_cmpint (color, ==, geda_object_get_color (object1));
+    g_assert_cmpint (color, ==, lepton_object_get_color (object1));
 
     gchar *buffer1 = geda_pin_object_to_buffer (object1);
     s_delete_object (object1);

--- a/liblepton/tests/test_pin_object.c
+++ b/liblepton/tests/test_pin_object.c
@@ -89,7 +89,7 @@ check_accessors ()
     geda_pin_object_set_y0 (object0, y0);
     geda_pin_object_set_x1 (object0, x1);
     geda_pin_object_set_y1 (object0, y1);
-    o_set_color (object0, color);
+    lepton_object_set_color (object0, color);
 
     g_assert_cmpint (x0, ==, geda_pin_object_get_x0 (object0));
     g_assert_cmpint (y0, ==, geda_pin_object_get_y0 (object0));

--- a/liblepton/tests/test_text_object.c
+++ b/liblepton/tests/test_text_object.c
@@ -122,7 +122,7 @@ check_accessors ()
     geda_text_object_set_alignment (object0, alignment);
     geda_text_object_set_angle (object0, angle);
     geda_text_object_set_size (object0, size);
-    o_set_color (object0, color);
+    lepton_object_set_color (object0, color);
     o_set_visibility (object0, visible);
     o_text_set_string (object0, string);
 

--- a/liblepton/tests/test_text_object.c
+++ b/liblepton/tests/test_text_object.c
@@ -50,7 +50,7 @@ check_construction ()
     g_assert_cmpint (alignment, ==, geda_text_object_get_alignment (object0));
     g_assert_cmpint (angle, ==, geda_text_object_get_angle (object0));
     g_assert_cmpint (size, ==, geda_text_object_get_size (object0));
-    g_assert_cmpint (color, ==, geda_object_get_color (object0));
+    g_assert_cmpint (color, ==, lepton_object_get_color (object0));
     g_assert_cmpint (visible, ==, geda_object_get_visible (object0));
     g_assert_cmpstr (string, ==, geda_text_object_get_string (object0));
 
@@ -67,7 +67,7 @@ check_construction ()
     g_assert_cmpint (alignment, ==, geda_text_object_get_alignment (object1));
     g_assert_cmpint (angle, ==, geda_text_object_get_angle (object1));
     g_assert_cmpint (size, ==, geda_text_object_get_size (object1));
-    g_assert_cmpint (color, ==, geda_object_get_color (object1));
+    g_assert_cmpint (color, ==, lepton_object_get_color (object1));
     g_assert_cmpint (visible, ==, geda_object_get_visible (object1));
     g_assert_cmpstr (string, ==, geda_text_object_get_string (object1));
 
@@ -131,7 +131,7 @@ check_accessors ()
     g_assert_cmpint (alignment, ==, geda_text_object_get_alignment (object0));
     g_assert_cmpint (angle, ==, geda_text_object_get_angle (object0));
     g_assert_cmpint (size, ==, geda_text_object_get_size (object0));
-    g_assert_cmpint (color, ==, geda_object_get_color (object0));
+    g_assert_cmpint (color, ==, lepton_object_get_color (object0));
     g_assert_cmpint (visible, ==, geda_object_get_visible (object0));
     g_assert_cmpstr (string, ==, geda_text_object_get_string (object0));
 
@@ -203,7 +203,7 @@ check_serialization ()
     g_assert_cmpint (alignment, ==, geda_text_object_get_alignment (object1));
     g_assert_cmpint (angle, ==, geda_text_object_get_angle (object1));
     g_assert_cmpint (size, ==, geda_text_object_get_size (object1));
-    g_assert_cmpint (color, ==, geda_object_get_color (object1));
+    g_assert_cmpint (color, ==, lepton_object_get_color (object1));
     g_assert_cmpint (visible, ==, geda_object_get_visible (object1));
     g_assert_cmpstr (string, ==, geda_text_object_get_string (object1));
 

--- a/libleptongui/src/gschem_selection_adapter.c
+++ b/libleptongui/src/gschem_selection_adapter.c
@@ -1790,7 +1790,7 @@ gschem_selection_adapter_set_text_color (GschemSelectionAdapter *adapter, int co
     LeptonObject *object = (LeptonObject*) iter->data;
 
     if (object->type == OBJ_TEXT) {
-      o_set_color (object, color);
+      lepton_object_set_color (object, color);
     }
 
     iter = g_list_next (iter);

--- a/libleptongui/src/gschem_selection_adapter.c
+++ b/libleptongui/src/gschem_selection_adapter.c
@@ -655,7 +655,7 @@ gschem_selection_adapter_get_object_color (GschemSelectionAdapter *adapter)
         (object->type == OBJ_TEXT)   ||
         (object->type == OBJ_NET)    ||
         (object->type == OBJ_BUS))) {
-      color = geda_object_get_color (object);
+      color = lepton_object_get_color (object);
       break;
     }
   }
@@ -671,7 +671,7 @@ gschem_selection_adapter_get_object_color (GschemSelectionAdapter *adapter)
         (object->type == OBJ_LINE)   ||
         (object->type == OBJ_PATH)   ||
         (object->type == OBJ_TEXT))) {
-      if (color != geda_object_get_color (object)) {
+      if (color != lepton_object_get_color (object)) {
         color = MULTIPLE_VALUES;
         break;
       }
@@ -795,7 +795,7 @@ gschem_selection_adapter_get_text_color (GschemSelectionAdapter *adapter)
     LeptonObject* object = (LeptonObject *) iter->data;
     iter = g_list_next (iter);
     if ((object != NULL) && (object->type == OBJ_TEXT)) {
-      color = geda_object_get_color (object);
+      color = lepton_object_get_color (object);
       break;
     }
   }
@@ -805,7 +805,7 @@ gschem_selection_adapter_get_text_color (GschemSelectionAdapter *adapter)
   while (iter != NULL) {
     LeptonObject* object = (LeptonObject *) iter->data;
     if ((object != NULL) && (object->type == OBJ_TEXT)) {
-      if (color != geda_object_get_color (object)) {
+      if (color != lepton_object_get_color (object)) {
         color = MULTIPLE_VALUES;
         break;
       }

--- a/libleptongui/src/o_path.c
+++ b/libleptongui/src/o_path.c
@@ -553,7 +553,7 @@ o_path_draw_rubber (GschemToplevel *w_current, EdaRenderer *renderer)
   /* Setup a fake object to pass the drawing routine */
   memset (&object, 0, sizeof (LeptonObject));
   object.type = OBJ_PATH;
-  object.color = SELECT_COLOR;
+  lepton_object_set_color (&object, SELECT_COLOR);
   object.line_width = 0; /* clamped to 1 pixel in circle_path */
   object.path = w_current->temp_path;
 
@@ -627,7 +627,7 @@ o_path_draw_rubber_grips (GschemToplevel *w_current, EdaRenderer *renderer)
   /* Setup a fake object to pass the drawing routine */
   memset (&object, 0, sizeof (LeptonObject));
   object.type = OBJ_PATH;
-  object.color = SELECT_COLOR;
+  lepton_object_set_color (&object, SELECT_COLOR);
   object.line_width = 0; /* clamped to 1 pixel in circle_path */
   object.path = path_copy_modify (w_current->which_object->path, 0, 0,
                                   w_current->second_wx,


### PR DESCRIPTION
Amend the code to get rid of direct using the `color` field of the `LeptonObject` structure.