### PR TITLE
Fix liblepton unit tests for Guile 3.0.5 on Debian

### DIFF
--- a/liblepton/scheme/unit-tests/geda-config.scm
+++ b/liblepton/scheme/unit-tests/geda-config.scm
@@ -57,7 +57,8 @@
 (test-end "geda:user-config-context")
 
 
-(test-group-with-cleanup "geda:path-config-context"
+(test-begin "geda:default-config-context")
+(test-group-with-cleanup "geda:path-config-context-grp"
   (config-geda-test-setup)
   ;; Unfortunately, there's no reliable way of testing the "recurse
   ;; all the way to root and then give up" functionality, because we
@@ -81,9 +82,11 @@
     (test-equal #f (geda:config-trusted? a)))
   ;; Clean up.
   (config-geda-test-teardown))
+(test-end "geda:default-config-context")
 
 
-(test-group-with-cleanup "geda:config-load"
+(test-begin "geda:config-load")
+(test-group-with-cleanup "geda:config-load-grp"
   (config-geda-test-setup)
   (let ((a (geda:path-config-context *testdir-geda-A*)))
     (test-equal #f (geda:config-loaded? a))
@@ -95,9 +98,11 @@
   (test-assert-thrown 'system-error (geda:config-load! (geda:default-config-context) #:force-load #t))
   ;; Clean up.
   (config-geda-test-teardown))
+(test-end "geda:config-load")
 
 
-(test-group-with-cleanup "geda:config-save"
+(test-begin "geda:config-save")
+(test-group-with-cleanup "geda:config-save-grp"
   (config-geda-test-setup)
   (let ((a (geda:path-config-context *testdir-geda-A*)))
     (test-equal a (geda:config-save! a)))
@@ -106,9 +111,11 @@
   ;; FIXME test writing a file without permissions to write it.
   ;; Clean up.
   (config-geda-test-teardown))
+(test-end "geda:config-save")
 
 
-(test-group-with-cleanup "geda:config-parent"
+(test-begin "geda:config-parent")
+(test-group-with-cleanup "geda:config-parent-grp"
   (config-geda-test-setup)
   (let ((a (geda:path-config-context *testdir-geda-A*))
         (b (geda:path-config-context *testdir-geda*)))
@@ -135,9 +142,11 @@
     )
   ;; Clean up.
   (config-geda-test-teardown))
+(test-end "geda:config-parent")
 
 
-(test-group-with-cleanup "geda:config-trust"
+(test-begin "geda:config-trust")
+(test-group-with-cleanup "geda:config-trust-end"
   (config-geda-test-setup)
   (let ((a (geda:path-config-context *testdir-geda-A*)))
     (test-equal #f (geda:config-trusted? a))
@@ -153,9 +162,11 @@
     (test-equal #f (geda:config-trusted? a)))
     ;; Clean up.
   (config-geda-test-teardown))
+(test-end "geda:config-trust")
 
 
-(test-group-with-cleanup "geda:config-changed"
+(test-begin "geda:config-changed")
+(test-group-with-cleanup "geda:config-changed-grp"
   (config-geda-test-setup)
   (let ((a (geda:path-config-context *testdir-geda-A*)))
     (geda:config-load! a #:force-load #t)
@@ -170,9 +181,11 @@
     (test-equal #f (geda:config-changed? a)))
   ;; Clean up.
   (config-geda-test-teardown))
+(test-end "geda:config-changed")
 
 
-(test-group-with-cleanup "geda:config-groups"
+(test-begin "geda:config-groups")
+(test-group-with-cleanup "geda:config-groups-grp"
   (config-geda-test-setup)
   (let ((a (geda:path-config-context *testdir-geda*))
         (b (geda:path-config-context *testdir-geda-A*)))
@@ -203,9 +216,11 @@
        (lambda () (geda:set-config-parent! b (geda:user-config-context)))))
   ;; Clean up.
   (config-geda-test-teardown))
+(test-end "geda:config-groups")
 
 
-(test-group-with-cleanup "geda:config-source"
+(test-begin "geda:config-source")
+(test-group-with-cleanup "geda:config-source-grp"
   (config-geda-test-setup)
   (let ((a (geda:path-config-context *testdir-geda*))
         (b (geda:path-config-context *testdir-geda-A*)))
@@ -224,9 +239,11 @@
         (lambda () (geda:set-config-parent! b (geda:user-config-context)))))
   ;; Clean up.
   (config-geda-test-teardown))
+(test-end "geda:config-source")
 
 
-(test-group-with-cleanup "geda:config-keys"
+(test-begin "geda:config-keys")
+(test-group-with-cleanup "geda:config-keys-grp"
   (config-geda-test-setup)
   (let ((a (geda:path-config-context *testdir-geda*))
         (b (geda:path-config-context *testdir-geda-A*)))
@@ -256,9 +273,11 @@
        (lambda () (geda:set-config-parent! b (geda:user-config-context)))))
   ;; Clean up.
   (config-geda-test-teardown))
+(test-end "geda:config-keys")
 
 
-(test-group-with-cleanup "geda:config-boolean"
+(test-begin "geda:config-boolean")
+(test-group-with-cleanup "geda:config-boolean-grp"
   (config-geda-test-setup)
   (let ((a (geda:path-config-context *testdir-geda*)))
     (geda:config-load! a)
@@ -272,9 +291,11 @@
     (test-equal '(#t #f) (geda:config-boolean-list a "foo" "bar")))
   ;; Clean up.
   (config-geda-test-teardown))
+(test-end "geda:config-boolean")
 
 
-(test-group-with-cleanup "geda:config-int"
+(test-begin "geda:config-int")
+(test-group-with-cleanup "geda:config-int-grp"
   (config-geda-test-setup)
   (let ((a (geda:path-config-context *testdir-geda*)))
     (geda:config-load! a)
@@ -286,9 +307,11 @@
     (test-equal '(42 144) (geda:config-int-list a "foo" "bar")))
   ;; Clean up.
   (config-geda-test-teardown))
+(test-end "geda:config-int")
 
 
-(test-group-with-cleanup "geda:config-real"
+(test-begin "geda:config-real")
+(test-group-with-cleanup "geda:config-real-grp"
   (config-geda-test-setup)
   (let ((a (geda:path-config-context *testdir-geda*)))
     (geda:config-load! a)
@@ -300,9 +323,11 @@
     (test-equal '(42.0 144.0) (geda:config-real-list a "foo" "bar")))
   ;; Clean up.
   (config-geda-test-teardown))
+(test-end "geda:config-real")
 
 
-(test-group-with-cleanup "geda:config-string"
+(test-begin "geda:config-string")
+(test-group-with-cleanup "geda:config-string-grp"
   (config-geda-test-setup)
   (let ((a (geda:path-config-context *testdir-geda*)))
     (geda:config-load! a)
@@ -314,9 +339,11 @@
     (test-equal '("wib;ble" "wobble") (geda:config-string-list a "foo" "bar")))
   ;; Clean up.
   (config-geda-test-teardown))
+(test-end "geda:config-string")
 
 
-(test-group-with-cleanup "geda:config-get-set-errors"
+(test-begin "geda:config-get-set-errors")
+(test-group-with-cleanup "geda:config-get-set-errors-grp"
   (config-geda-test-setup)
   (let ((a (geda:path-config-context *testdir-geda*)))
     (geda:config-load! a)
@@ -330,9 +357,11 @@
     (test-assert-thrown 'config-error (geda:config-real a "foo" "bar")))
   ;; Clean up.
   (config-geda-test-teardown))
+(test-end "geda:config-get-set-errors")
 
 
-(test-group-with-cleanup "geda:config-events"
+(test-begin "geda:config-events")
+(test-group-with-cleanup "geda:config-events-grp"
   (config-geda-test-setup)
   (let* ((a (geda:path-config-context *testdir-geda*))
          (call-count 0)
@@ -354,12 +383,14 @@
     (test-equal 2 call-count))
   ;; Clean up.
   (config-geda-test-teardown))
+(test-end "geda:config-events")
 
 
 
 ; Unit test for geda:config-remove-key! function:
 ;
-(test-group-with-cleanup "geda:config-remove-key"
+(test-begin "geda:config-remove-key")
+(test-group-with-cleanup "geda:config-remove-key-grp"
   (config-geda-test-setup)
 ( let*
   (
@@ -406,12 +437,14 @@
 ) ; let
   ;; Clean up.
   (config-geda-test-teardown)) ; 'config-remove-key()
+(test-end "geda:config-remove-key")
 
 
 
 ; Unit test for geda:config-remove-group! function:
 ;
-(test-group-with-cleanup "geda:config-remove-group"
+(test-begin "geda:config-remove-group")
+(test-group-with-cleanup "geda:config-remove-group-grp"
   (config-geda-test-setup)
 ( let*
   (
@@ -458,3 +491,4 @@
 ) ; let
   ;; Clean up.
   (config-geda-test-teardown)) ; 'config-remove-group()
+(test-end "geda:config-remove-group")

--- a/liblepton/scheme/unit-tests/geda-object-component.scm
+++ b/liblepton/scheme/unit-tests/geda-object-component.scm
@@ -252,6 +252,7 @@
 (reset-component-library)
 
 ;;; Test component file names.
+(test-begin "geda:component-filename")
 (let*
     (
      ( fname1  ( format #f "~a.sym" (tmpnam) ) )
@@ -304,7 +305,7 @@
   ( set! comp1 ( mk-comp1 ) )
   ( set! comp2 ( mk-comp2 ) )
 
-  (test-group-with-cleanup "geda:component-filename"
+  (test-group-with-cleanup "geda:component-filename-grp"
 
     (test-equal (geda:component-filename comp1) fname1)
     (test-assert (not (geda:component-filename comp2)))
@@ -312,3 +313,4 @@
     (begin
       (reset-component-library)
       (delete-file fname1))))
+(test-end "geda:component-filename")

--- a/liblepton/scheme/unit-tests/lepton-config.scm
+++ b/liblepton/scheme/unit-tests/lepton-config.scm
@@ -57,7 +57,8 @@
 (test-end "user-config-context")
 
 
-(test-group-with-cleanup "path-config-context"
+(test-begin "path-config-context")
+(test-group-with-cleanup "path-config-context-grp"
   (config-test-setup)
   ;; Unfortunately, there's no reliable way of testing the "recurse
   ;; all the way to root and then give up" functionality, because we
@@ -81,9 +82,11 @@
     (test-equal #f (config-trusted? a)))
   ;; Clean up.
   (config-test-teardown))
+(test-end "path-config-context")
 
 
-(test-group-with-cleanup "config-load"
+(test-begin "config-load")
+(test-group-with-cleanup "config-load-grp"
   (config-test-setup)
   (let ((a (path-config-context *testdirA*)))
     (test-equal #f (config-loaded? a))
@@ -95,9 +98,11 @@
   (test-assert-thrown 'system-error (config-load! (default-config-context) #:force-load #t))
   ;; Clean up.
   (config-test-teardown))
+(test-end "config-load")
 
 
-(test-group-with-cleanup "config-save"
+(test-begin "config-save")
+(test-group-with-cleanup "config-save-grp"
   (config-test-setup)
   (let ((a (path-config-context *testdirA*)))
     (test-equal a (config-save! a)))
@@ -106,9 +111,11 @@
   ;; FIXME test writing a file without permissions to write it.
   ;; Clean up.
   (config-test-teardown))
+(test-end "config-save")
 
 
-(test-group-with-cleanup "config-parent"
+(test-begin "config-parent")
+(test-group-with-cleanup "config-parent-grp"
   (config-test-setup)
   (let ((a (path-config-context *testdirA*))
         (b (path-config-context *testdir*)))
@@ -134,9 +141,11 @@
     (test-equal (user-config-context) (config-parent a)))
   ;; Clean up.
   (config-test-teardown))
+(test-end "config-parent")
 
 
-(test-group-with-cleanup "config-trust"
+(test-begin "config-trust")
+(test-group-with-cleanup "config-trust-grp"
   (config-test-setup)
   (let ((a (path-config-context *testdirA*)))
     (test-equal #f (config-trusted? a))
@@ -152,9 +161,11 @@
     (test-equal #f (config-trusted? a)))
   ;; Clean up.
   (config-test-teardown))
+(test-end "config-trust")
 
 
-(test-group-with-cleanup "config-changed"
+(test-begin "config-changed")
+(test-group-with-cleanup "config-changed-grp"
   (config-test-setup)
   (let ((a (path-config-context *testdirA*)))
     (config-load! a #:force-load #t)
@@ -169,9 +180,11 @@
     (test-equal #f (config-changed? a)))
   ;; Clean up.
   (config-test-teardown))
+(test-end "config-changed")
 
 
-(test-group-with-cleanup "config-groups"
+(test-begin "config-groups")
+(test-group-with-cleanup "config-groups-grp"
   (config-test-setup)
   (let ((a (path-config-context *testdir*))
         (b (path-config-context *testdirA*)))
@@ -202,9 +215,11 @@
       (lambda () (set-config-parent! b (user-config-context)))))
   ;; Clean up.
   (config-test-teardown))
+(test-end "config-groups")
 
 
-(test-group-with-cleanup "config-source"
+(test-begin "config-source")
+(test-group-with-cleanup "config-source-grp"
   (config-test-setup)
   (let ((a (path-config-context *testdir*))
         (b (path-config-context *testdirA*)))
@@ -223,9 +238,11 @@
       (lambda () (set-config-parent! b (user-config-context)))))
   ;; Clean up.
   (config-test-teardown))
+(test-end "config-source")
 
 
-(test-group-with-cleanup "config-keys"
+(test-begin "config-keys")
+(test-group-with-cleanup "config-keys-grp"
   (config-test-setup)
   (let ((a (path-config-context *testdir*))
         (b (path-config-context *testdirA*)))
@@ -255,9 +272,11 @@
       (lambda () (set-config-parent! b (user-config-context)))))
   ;; Clean up.
   (config-test-teardown))
+(test-end "config-keys")
 
 
-(test-group-with-cleanup "config-boolean"
+(test-begin "config-boolean")
+(test-group-with-cleanup "config-boolean-grp"
   (config-test-setup)
   (let ((a (path-config-context *testdir*)))
     (config-load! a)
@@ -271,9 +290,11 @@
     (test-equal '(#t #f) (config-boolean-list a "foo" "bar")))
   ;; Clean up.
   (config-test-teardown))
+(test-end "config-boolean")
 
 
-(test-group-with-cleanup "config-int"
+(test-begin "config-int")
+(test-group-with-cleanup "config-int-grp"
   (config-test-setup)
   (let ((a (path-config-context *testdir*)))
     (config-load! a)
@@ -285,9 +306,11 @@
     (test-equal '(42 144) (config-int-list a "foo" "bar")))
   ;; Clean up.
   (config-test-teardown))
+(test-end "config-int")
 
 
-(test-group-with-cleanup "config-real"
+(test-begin "config-real")
+(test-group-with-cleanup "config-real-grp"
   (config-test-setup)
   (let ((a (path-config-context *testdir*)))
     (config-load! a)
@@ -299,9 +322,11 @@
     (test-equal '(42.0 144.0) (config-real-list a "foo" "bar")))
   ;; Clean up.
   (config-test-teardown))
+(test-end "config-real")
 
 
-(test-group-with-cleanup "config-string"
+(test-begin "config-string")
+(test-group-with-cleanup "config-string-grp"
   (config-test-setup)
   (let ((a (path-config-context *testdir*)))
     (config-load! a)
@@ -313,9 +338,11 @@
     (test-equal '("wib;ble" "wobble") (config-string-list a "foo" "bar")))
   ;; Clean up.
   (config-test-teardown))
+(test-end "config-string")
 
 
-(test-group-with-cleanup "config-get-set-errors"
+(test-begin "config-get-set-errors")
+(test-group-with-cleanup "config-get-set-errors-grp"
   (config-test-setup)
   (let ((a (path-config-context *testdir*)))
     (config-load! a)
@@ -329,9 +356,11 @@
     (test-assert-thrown 'config-error (config-real a "foo" "bar")))
   ;; Clean up.
   (config-test-teardown))
+(test-end "config-get-set-errors")
 
 
-(test-group-with-cleanup "config-events"
+(test-begin "config-events")
+(test-group-with-cleanup "config-events-grp"
   (config-test-setup)
   (let* ((a (path-config-context *testdir*))
          (call-count 0)
@@ -353,11 +382,13 @@
     (test-equal 2 call-count))
   ;; Clean up.
   (config-test-teardown))
+(test-end "config-events")
 
 
 ; Unit test for config-remove-key! function:
 ;
-(test-group-with-cleanup "config-remove-key"
+(test-begin "config-remove-key")
+(test-group-with-cleanup "config-remove-key-grp"
   (config-test-setup)
 ( let*
   (
@@ -405,11 +436,13 @@
   ;; Clean up.
   (config-test-teardown)
 ) ; 'config-remove-key()
+(test-end "config-remove-key")
 
 
 ; Unit test for config-remove-group! function:
 ;
-(test-group-with-cleanup "config-remove-group"
+(test-begin "config-remove-group")
+(test-group-with-cleanup "config-remove-group-grp"
   (config-test-setup)
 ( let*
   (
@@ -457,3 +490,4 @@
   ;; Clean up.
   (config-test-teardown)
 ) ; 'config-remove-group()
+(test-end "config-remove-group")

--- a/liblepton/scheme/unit-tests/lepton-object-component.scm
+++ b/liblepton/scheme/unit-tests/lepton-object-component.scm
@@ -254,6 +254,7 @@
 
 
 ;;; Test component file names.
+(test-begin "component-filename")
 (let* ((fname1  (format #f "~a.sym" (tmpnam)))
        (symdir (dirname  fname1))
        (basename1 (basename fname1))
@@ -300,7 +301,7 @@
   (let ((temp-component (make-real-component))
         (non-existing-component (make-bogus-component)))
 
-    (test-group-with-cleanup "component-filename"
+    (test-group-with-cleanup "component-filename-grp"
 
       (test-equal (component-filename temp-component) fname1)
       (test-assert (not (component-filename non-existing-component)))
@@ -308,6 +309,7 @@
       (begin
         (reset-component-library)
         (delete-file fname1)))))
+(test-end "component-filename")
 
 
 ;;; Test component-library-command().
@@ -316,6 +318,7 @@
                                        "/docs/manual/cmd-component.sh")
     read-string))
 
+(test-begin "component-library-command")
 (let* ((script-name (tmpnam))
        (get-command script-name)
        (list-command (string-append script-name " -l")))
@@ -330,9 +333,10 @@
   (let ((C1 (make-component/library "symname1.sym" '(0 . 0) 0 #f #f))
         (C2 (make-component/library "symname2.sym" '(1000 . 1000) 0 #f #f)))
 
-    (test-group-with-cleanup "component-library-command"
+    (test-group-with-cleanup "component-library-command-grp"
 
       (test-assert (component? C1))
       (test-assert (component? C2))
       ;; Clean up.
       (delete-file get-command))))
+(test-end "component-library-command")


### PR DESCRIPTION
Make sure calls to `test-group-with-cleanup()` are
nested inside `test-begin`/`test-end` blocks
(see [`srfi-64` reference](https://srfi.schemers.org/srfi-64/srfi-64.html)).
Otherwise, the following unit tests fails with
Guile 3.0.5 on recent versions of Debian Linux
(upcoming release 11 "bullseye"):

- `geda-config.scm`
- `lepton-config.scm`
- `geda-object-component.scm`
- `lepton-object-component.scm`

See the discussion on gitter and Debian bug report #982726:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=982726

The full Debian build log:
http://qa-logs.debian.net/2021/02/13/lepton-eda_1.9.13-3_unstable.log

Tested on Debian bullseye snapshot from 15/02/2021 downloaded
from [here](https://cdimage.debian.org/mirror/cdimage/daily-builds/daily/current/amd64/iso-cd/).
