### PR TITLE
Do not hard-code build date and time in lepton-renum exe

### DIFF
--- a/utils/renum/src/lepton-renum.c
+++ b/utils/renum/src/lepton-renum.c
@@ -396,5 +396,4 @@ void printver()
 	printf("This is lepton-renum, an advanced refdes renumber utility for Lepton EDA's lepton-schematic.\n");
 	printf("Version %s.  Lepton EDA version %s.%s\n",GRVERSION,
                PACKAGE_DOTTED_VERSION, PACKAGE_DATE_VERSION);
-	printf("Compiled on %s at %s\n",COMP_DATE,COMP_TIME);
 	}

--- a/utils/renum/src/lepton-renum.h
+++ b/utils/renum/src/lepton-renum.h
@@ -1,7 +1,5 @@
 #include <stdio.h>
 #define GRVERSION "24052006"
-#define COMP_DATE __DATE__
-#define COMP_TIME __TIME__
 #define MAX_PREFIX_COUNT 50 /*This specifies the maximum number of different prefixes. e.g. Ux Rx Qx...*/
 #define PAGE_JMP 100	/*There will be R101 R102 on page 1, R201 R202 on page 2.*/
 #define COUNT_START 0	/*Start the counting from this number+1*/


### PR DESCRIPTION
It's not necessary.
Should aid "reproducible builds".
