### PR TITLE
Delete superfluous gafrc files in netlist analog examples

### DIFF
--- a/utils/netlist/examples/analog/bandpass/Makefile.am
+++ b/utils/netlist/examples/analog/bandpass/Makefile.am
@@ -2,4 +2,4 @@ sch_files = sch/frg_band_pass.sch
 
 model_files = models/D1N4148.sp
 
-EXTRA_DIST = README gafrc ngspice.cmd $(sch_files) $(model_files)
+EXTRA_DIST = README ngspice.cmd $(sch_files) $(model_files)

--- a/utils/netlist/examples/analog/bandpass/gafrc
+++ b/utils/netlist/examples/analog/bandpass/gafrc
@@ -1,4 +1,0 @@
-(component-library "./sym")
-;;; Verilog symbol library in the lepton repository.
-;;; Fix the path if you move the example somewhere else.
-(component-library "../../../../../symbols/sym-verilog/")

--- a/utils/netlist/examples/analog/varactor_osc/gafrc
+++ b/utils/netlist/examples/analog/varactor_osc/gafrc
@@ -1,5 +1,1 @@
 (component-library "./sym")
-(component-library-search "./sym")
-;;; Verilog symbol library in the lepton repository.
-;;; Fix the path if you move the example somewhere else.
-(component-library "../../../../../symbols/sym-verilog/")

--- a/utils/netlist/examples/analog/voltage_doubler/Makefile.am
+++ b/utils/netlist/examples/analog/voltage_doubler/Makefile.am
@@ -5,5 +5,5 @@ sch_files = \
 
 model_files = models/D1N4148.sp
 
-EXTRA_DIST = README gafrc ngspice.cmd \
+EXTRA_DIST = README ngspice.cmd \
 	$(sch_files) $(model_files)

--- a/utils/netlist/examples/analog/voltage_doubler/gafrc
+++ b/utils/netlist/examples/analog/voltage_doubler/gafrc
@@ -1,4 +1,0 @@
-(component-library "./sym")
-;;; Verilog symbol library in the lepton repository.
-;;; Fix the path if you move the example somewhere else.
-(component-library "../../../../../symbols/sym-verilog/")


### PR DESCRIPTION
Remove unneeded (and erroneous) `gafrc` files,
which were, apparently, mistakenly copied/pasted
from the `verilog` example.
