### PR TITLE
gui: Fix behaviour of the lower combobox in the Component select dialog.

### DIFF
--- a/libleptongui/src/x_compselect.c
+++ b/libleptongui/src/x_compselect.c
@@ -683,10 +683,12 @@ compselect_callback_filter_button_clicked (GtkButton *button,
  *  that the requested behavior for the next adding of a component has
  *  been changed.
  *
+ *  \param [in] optionmenu The behavior option menu.
  *  \param [in] user_data  The component selection dialog.
  */
 static void
-compselect_callback_behavior_changed (gpointer user_data)
+compselect_callback_behavior_changed (GtkComboBox *widget,
+                                      gpointer user_data)
 {
   Compselect *compselect = (Compselect*)user_data;
 


### PR DESCRIPTION
I broke it myself in the commit e542a0a before 1.9.12.  While
getting rid of a wrong and deprecated type was OK, I shouldn't
have changed the number of callback arguments as the signal
"changed" requires exactly two.