### PR TITLE
Do not generate ChangeLog files

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,0 +1,14 @@
+We do not longer maintain ChangeLog files used to
+be generated from the git history.
+User-visible changes can be found in the NEWS.md file
+distributed with the Lepton EDA suite and installed
+to $PREFIX/share/doc/lepton-eda/.
+Consult the detailed history on github project's
+page [1] or clone the repository [2] and use
+'git log' and 'git whatchanged' commands.
+Old changelogs (<= 2007) are stored in the
+docs/changelogs/ directory in the source tree.
+
+[1] https://github.com/lepton-eda/lepton-eda
+[2] Described in README.md
+

--- a/Makefile.am
+++ b/Makefile.am
@@ -31,8 +31,18 @@ DISTCHECK_CONFIGURE_FLAGS = \
 	--disable-update-xdg-database
 
 BUILT_SOURCES = version.h
-EXTRA_DIST = autogen.sh version.h version.h.in CODE_OF_CONDUCT.md \
-	CONTRIBUTING.md COPYING COPYING.LGPL NEWS.md README.md
+
+EXTRA_DIST = \
+	autogen.sh \
+	version.h \
+	version.h.in \
+	CODE_OF_CONDUCT.md \
+	CONTRIBUTING.md \
+	COPYING \
+	COPYING.LGPL \
+	NEWS.md \
+	README.md \
+	ChangeLog
 
 # Generate version.h. This works by looking at any git repository that
 # is present in the source directory (detected at configure time). If

--- a/configure.ac
+++ b/configure.ac
@@ -31,9 +31,6 @@ AC_GNU_SOURCE # FIXME for some reason this is needed?
 
 AX_GIT_VERSION([20201211])
 
-# This is used for keeping the ChangeLog files up-to-date
-AC_SUBST([CHANGELOG_BASE], [1.0-20070526])
-
 #####################################################################
 # Windows/MinGW/Cygwin support
 #####################################################################

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -12,4 +12,3 @@ install-sh
 missing
 mkinstalldirs
 *~
-ChangeLog

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -1,12 +1,1 @@
 SUBDIRS = wiki scheme-api changelogs manual news design
-
-EXTRA_DIST = ChangeLog
-
-if HAVE_GIT_REPO
-ChangeLog: $(top_builddir)/stamp-git
-	( \
-	  cd $(srcdir) && \
-	  $(GIT) log --pretty=medium $(CHANGELOG_BASE).. -- . || \
-	  echo "WARNING: ChangeLog information not available from git" >&2 ; \
-	) > $@
-endif HAVE_GIT_REPO

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -12,4 +12,3 @@ install-sh
 missing
 mkinstalldirs
 *~
-ChangeLog

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -4,13 +4,4 @@ exampledir = $(docdir)/examples/
 
 example_DATA = README
 
-EXTRA_DIST = ChangeLog $(example_DATA)
-
-if HAVE_GIT_REPO
-ChangeLog: $(top_builddir)/stamp-git
-	( \
-	  cd $(srcdir) && \
-	  $(GIT) log --pretty=medium $(CHANGELOG_BASE).. -- . || \
-	  echo "WARNING: ChangeLog information not available from git" >&2 ; \
-	) > $@
-endif HAVE_GIT_REPO
+EXTRA_DIST = $(example_DATA)

--- a/liblepton/.gitignore
+++ b/liblepton/.gitignore
@@ -11,4 +11,3 @@ GTAGS
 HTML
 docs/images/*png
 docs/images/*pdf
-ChangeLog

--- a/liblepton/Makefile.am
+++ b/liblepton/Makefile.am
@@ -1,19 +1,8 @@
 SUBDIRS = po data docs include lib src scheme tests
 
-EXTRA_DIST = ChangeLog
-
 pkgconfigdir            = $(libdir)/pkgconfig
 pkgconfig_DATA          = liblepton.pc
 
 liblepton-pc-install: liblepton.pc
 	$(mkinstalldirs) $(DESTDIR)$(pkgconfigdir)
 	$(INSTALL_DATA) liblepton.pc $(DESTDIR)$(pkgconfigdir)
-
-if HAVE_GIT_REPO
-ChangeLog: $(top_builddir)/stamp-git
-	( \
-	  cd $(srcdir) && \
-	  $(GIT) log --pretty=medium $(CHANGELOG_BASE).. -- . || \
-	  echo "WARNING: ChangeLog information not available from git" >&2 ; \
-	) > $@
-endif HAVE_GIT_REPO

--- a/libleptonattrib/.gitignore
+++ b/libleptonattrib/.gitignore
@@ -3,4 +3,3 @@ libleptonattrib.pc
 Makefile
 Makefile.in
 *~
-ChangeLog

--- a/libleptonattrib/Makefile.am
+++ b/libleptonattrib/Makefile.am
@@ -29,15 +29,6 @@ lepton-attrib: lepton-attrib.scm Makefile
 	$(do_subst) < $(srcdir)/$@.scm > $@
 	chmod +x $@
 
-if HAVE_GIT_REPO
-ChangeLog: $(top_builddir)/stamp-git
-	( \
-	  cd $(srcdir) && \
-	  $(GIT) log --pretty=medium $(CHANGELOG_BASE).. -- . || \
-	  echo "WARNING: ChangeLog information not available from git" >&2 ; \
-	) > $@
-endif HAVE_GIT_REPO
-
 do_subst = sed \
 	-e 's,[@]libdir[@],$(libdir),g' \
 	-e 's,[@]GUILE[@],$(GUILE),g' \
@@ -48,7 +39,6 @@ do_subst = sed \
 
 EXTRA_DIST = \
 	lepton-attrib.scm \
-	README \
-	ChangeLog
+	README
 
 CLEANFILES = $(bin_SCRIPTS)

--- a/libleptongui/.gitignore
+++ b/libleptongui/.gitignore
@@ -28,4 +28,3 @@ GTAGS
 HTML
 gschem.log
 .desktop-i18n
-ChangeLog

--- a/libleptongui/Makefile.am
+++ b/libleptongui/Makefile.am
@@ -9,17 +9,5 @@ libleptongui-pc-install: libleptongui.pc
 	$(mkinstalldirs) $(DESTDIR)$(pkgconfigdir)
 	$(INSTALL_DATA) libleptongui.pc $(DESTDIR)$(pkgconfigdir)
 
-
-EXTRA_DIST = ChangeLog
-
-if HAVE_GIT_REPO
-ChangeLog: $(top_builddir)/stamp-git
-	( \
-	  cd $(srcdir) && \
-	  $(GIT) log --pretty=medium $(CHANGELOG_BASE).. -- . || \
-	  echo "WARNING: ChangeLog information not available from git" >&2 ; \
-	) > $@
-endif HAVE_GIT_REPO
-
 maintainer-clean-local:
 	-rm -rf po/*.sed po/*.header po/*.sin po/*.template po/Rules-quot

--- a/symbols/.gitignore
+++ b/symbols/.gitignore
@@ -1,4 +1,3 @@
 Makefile
 Makefile.in
 *~
-ChangeLog

--- a/symbols/Makefile.am
+++ b/symbols/Makefile.am
@@ -5,15 +5,3 @@ SUBDIRS = \
 	sym-verilog \
 	sym-vhdl \
 	scheme
-
-EXTRA_DIST = \
-	ChangeLog
-
-if HAVE_GIT_REPO
-ChangeLog: $(top_builddir)/stamp-git
-	( \
-	  cd $(srcdir) && \
-	  $(GIT) log --pretty=medium $(CHANGELOG_BASE).. -- . || \
-	  echo "WARNING: ChangeLog information not available from git" >&2 ; \
-	) > $@
-endif HAVE_GIT_REPO

--- a/utils/.gitignore
+++ b/utils/.gitignore
@@ -17,4 +17,3 @@ mkinstalldirs
 compile
 *~
 ylwrap
-ChangeLog

--- a/utils/Makefile.am
+++ b/utils/Makefile.am
@@ -11,15 +11,3 @@ SUBDIRS = \
 	symcheck \
 	cli \
 	netlist
-
-EXTRA_DIST = \
-	ChangeLog
-
-if HAVE_GIT_REPO
-ChangeLog: $(top_builddir)/stamp-git
-	( \
-	  cd $(srcdir) && \
-	  $(GIT) log --pretty=medium $(CHANGELOG_BASE).. -- . || \
-	  echo "WARNING: ChangeLog information not available from git" >&2 ; \
-	) > $@
-endif HAVE_GIT_REPO

--- a/utils/cli/.gitignore
+++ b/utils/cli/.gitignore
@@ -1,4 +1,3 @@
 Makefile
 Makefile.in
 *~
-ChangeLog

--- a/utils/cli/Makefile.am
+++ b/utils/cli/Makefile.am
@@ -1,12 +1,1 @@
 SUBDIRS = po src docs
-
-EXTRA_DIST = ChangeLog
-
-if HAVE_GIT_REPO
-ChangeLog: $(top_builddir)/stamp-git
-	( \
-	  cd $(srcdir) && \
-	  $(GIT) log --pretty=medium $(CHANGELOG_BASE).. -- . || \
-	  echo "WARNING: ChangeLog information not available from git" >&2 ; \
-	) > $@
-endif HAVE_GIT_REPO

--- a/utils/netlist/.gitignore
+++ b/utils/netlist/.gitignore
@@ -27,4 +27,3 @@ GTAGS
 HTML
 gschem.log
 gnetlist.log
-ChangeLog

--- a/utils/netlist/Makefile.am
+++ b/utils/netlist/Makefile.am
@@ -4,17 +4,7 @@ bin_SCRIPTS = \
 	lepton-netlist
 
 EXTRA_DIST = \
-	ChangeLog \
 	lepton-netlist.in
-
-if HAVE_GIT_REPO
-ChangeLog: $(top_builddir)/stamp-git
-	( \
-	  cd $(srcdir) && \
-	  $(GIT) log --pretty=medium $(CHANGELOG_BASE).. -- . || \
-	  echo "WARNING: ChangeLog information not available from git" >&2 ; \
-	) > $@
-endif HAVE_GIT_REPO
 
 do_subst = sed -e 's,[@]libdir[@],$(libdir),g' \
 	-e 's,[@]GUILE[@],$(GUILE),g' \

--- a/utils/symcheck/Makefile.am
+++ b/utils/symcheck/Makefile.am
@@ -6,7 +6,6 @@ bin_SCRIPTS = \
 	lepton-symcheck
 
 EXTRA_DIST = \
-	ChangeLog \
 	lepton-symcheck.in
 
 do_subst = sed -e 's,[@]libdir[@],$(libdir),g' \
@@ -17,15 +16,6 @@ do_subst = sed -e 's,[@]libdir[@],$(libdir),g' \
 lepton-symcheck: lepton-symcheck.in
 	$(do_subst) < $(srcdir)/$@.in > $@
 	chmod +x $@
-
-if HAVE_GIT_REPO
-ChangeLog: $(top_builddir)/stamp-git
-	( \
-	  cd $(srcdir) && \
-	  $(GIT) log --pretty=medium $(CHANGELOG_BASE).. -- . || \
-	  echo "WARNING: ChangeLog information not available from git" >&2 ; \
-	) > $@
-endif HAVE_GIT_REPO
 
 CLEANFILES = \
 	lepton-symcheck


### PR DESCRIPTION
Add top-level `ChangeLog` file
informing the users that we do not generate
`ChangeLog` files anymore, and advise to
either refer to our `github` page or clone
the repo and use `git log` to see the detailed
history.

Affects #732.
