### PR TITLE
Remove redundant type names in liblepton

### DIFF
--- a/contrib/gmk_sym/convert_sym.c
+++ b/contrib/gmk_sym/convert_sym.c
@@ -203,7 +203,7 @@ struct FillStyle fillmap[26] =
 struct LineStyle {
   int line_width;             /* width of line */
   OBJECT_END line_capstyle;   /* gEDA line cap style (end style) */
-  OBJECT_TYPE line_dashstyle; /* gEDA line dash style */
+  LeptonLineType line_dashstyle; /* gEDA line dash style */
   int line_dashlength;        /* length of line dashes */
   int line_dashspace;         /* space between line dashes */
 };

--- a/contrib/gmk_sym/convert_sym.c
+++ b/contrib/gmk_sym/convert_sym.c
@@ -132,7 +132,7 @@ int colormap[16] =   /* index is viewlogic colour, entry is geda color */
 
 /* Fill style structure */
 struct FillStyle {
-  OBJECT_FILLING fill_type;  /* gEDA object fill type */
+  LeptonFillType fill_type;  /* gEDA object fill type */
   int fill_width;            /* width of the fill lines */
   int fill_angle1;           /* first angle of fill lines */
   int fill_pitch1;           /* first pitch/spacing of fill lines */

--- a/contrib/gmk_sym/convert_sym.c
+++ b/contrib/gmk_sym/convert_sym.c
@@ -202,7 +202,7 @@ struct FillStyle fillmap[26] =
 /* Line style structure */
 struct LineStyle {
   int line_width;             /* width of line */
-  OBJECT_END line_capstyle;   /* gEDA line cap style (end style) */
+  LeptonLineCapType line_capstyle;   /* gEDA line cap style (end style) */
   LeptonLineType line_dashstyle; /* gEDA line dash style */
   int line_dashlength;        /* length of line dashes */
   int line_dashspace;         /* space between line dashes */

--- a/liblepton/include/liblepton/box.h
+++ b/liblepton/include/liblepton/box.h
@@ -23,7 +23,6 @@
  */
 
 typedef struct _LeptonBox LeptonBox;
-typedef struct _LeptonBox BOX;
 
 struct _LeptonBox
 {

--- a/liblepton/include/liblepton/component.h
+++ b/liblepton/include/liblepton/component.h
@@ -20,7 +20,7 @@
 /*! \file component.h
  */
 
-typedef struct st_component COMPONENT;
+typedef struct st_component LeptonComponent;
 
 struct st_component
 {

--- a/liblepton/include/liblepton/edacairo.h
+++ b/liblepton/include/liblepton/edacairo.h
@@ -49,9 +49,12 @@ void eda_cairo_center_arc (cairo_t *cr, int flags, double center_width,
 
 void eda_cairo_stroke (cairo_t *cr, int flags, int line_type, int line_end,
                        double wwidth, double wlength, double wspace);
-
-void eda_cairo_path (cairo_t *cr, int flags, double line_width, int nsections,
-                     PATH_SECTION *sections);
+void
+eda_cairo_path (cairo_t *cr,
+                int flags,
+                double line_width,
+                int nsections,
+                LeptonPathSection *sections);
 
 G_END_DECLS
 #endif /* !__EDA_CAIRO_H__ */

--- a/liblepton/include/liblepton/fill_type.h
+++ b/liblepton/include/liblepton/fill_type.h
@@ -37,7 +37,6 @@ enum _LeptonFillType
 };
 
 typedef enum _LeptonFillType LeptonFillType;
-typedef enum _LeptonFillType OBJECT_FILLING;
 
 gboolean
 lepton_fill_type_draw_first_hatch (int fill_type);

--- a/liblepton/include/liblepton/forward.h
+++ b/liblepton/include/liblepton/forward.h
@@ -27,4 +27,3 @@ typedef struct st_page LeptonPage;
 typedef struct st_toplevel LeptonToplevel;
 
 typedef struct st_undo LeptonUndo;
-typedef struct st_undo UNDO;

--- a/liblepton/include/liblepton/line_cap_type.h
+++ b/liblepton/include/liblepton/line_cap_type.h
@@ -31,4 +31,3 @@ enum _LeptonLineCapType
 };
 
 typedef enum _LeptonLineCapType LeptonLineCapType;
-typedef enum _LeptonLineCapType OBJECT_END;

--- a/liblepton/include/liblepton/line_type.h
+++ b/liblepton/include/liblepton/line_type.h
@@ -36,4 +36,3 @@ enum _LeptonLineType
 };
 
 typedef enum _LeptonLineType LeptonLineType;
-typedef enum _LeptonLineType OBJECT_TYPE;

--- a/liblepton/include/liblepton/object.h
+++ b/liblepton/include/liblepton/object.h
@@ -39,7 +39,7 @@ struct st_object
   LeptonBox *box;
   LeptonText *text;
   LeptonPicture *picture;
-  PATH *path;
+  LeptonPath *path;
 
   GList *conn_list;                     /* List of connections */
   /* to and from this object */

--- a/liblepton/include/liblepton/object.h
+++ b/liblepton/include/liblepton/object.h
@@ -38,7 +38,7 @@ struct st_object
   LeptonArc *arc;
   LeptonBox *box;
   TEXT *text;
-  PICTURE *picture;
+  LeptonPicture *picture;
   PATH *path;
 
   GList *conn_list;                     /* List of connections */

--- a/liblepton/include/liblepton/object.h
+++ b/liblepton/include/liblepton/object.h
@@ -36,7 +36,7 @@ struct st_object
   LeptonLine *line;
   LeptonCircle *circle;
   LeptonArc *arc;
-  BOX *box;
+  LeptonBox *box;
   TEXT *text;
   PICTURE *picture;
   PATH *path;

--- a/liblepton/include/liblepton/object.h
+++ b/liblepton/include/liblepton/object.h
@@ -47,7 +47,7 @@ struct st_object
   /* every graphical primitive have more or less the same options. */
   /* depending on its nature a primitive is concerned with one or more */
   /* of these fields. If not, value must be ignored. */
-  OBJECT_END line_end;
+  LeptonLineCapType line_end;
   LeptonLineType line_type;
   int line_width;
   int line_space;
@@ -212,7 +212,7 @@ o_get_fill_options (LeptonObject *object,
 
 gboolean
 o_get_line_options (LeptonObject *object,
-                    OBJECT_END *end,
+                    LeptonLineCapType *end,
                     LeptonLineType *type,
                     int *width,
                     int *length,
@@ -242,7 +242,7 @@ o_set_fill_options (LeptonObject *o_current,
 
 void
 o_set_line_options (LeptonObject *o_current,
-                    OBJECT_END end,
+                    LeptonLineCapType end,
                     LeptonLineType type,
                     int width,
                     int length,

--- a/liblepton/include/liblepton/object.h
+++ b/liblepton/include/liblepton/object.h
@@ -37,7 +37,7 @@ struct st_object
   LeptonCircle *circle;
   LeptonArc *arc;
   LeptonBox *box;
-  TEXT *text;
+  LeptonText *text;
   LeptonPicture *picture;
   PATH *path;
 

--- a/liblepton/include/liblepton/object.h
+++ b/liblepton/include/liblepton/object.h
@@ -53,7 +53,7 @@ struct st_object
   int line_space;
   int line_length;
 
-  OBJECT_FILLING fill_type;
+  LeptonFillType fill_type;
   int fill_width;
   int fill_angle1, fill_pitch1;
   int fill_angle2, fill_pitch2;
@@ -203,7 +203,7 @@ lepton_object_translate (LeptonObject *object,
                          gint dy);
 gboolean
 o_get_fill_options (LeptonObject *object,
-                    OBJECT_FILLING *type,
+                    LeptonFillType *type,
                     int *width,
                     int *pitch1,
                     int *angle1,
@@ -233,7 +233,7 @@ lepton_object_set_color (LeptonObject *object,
 
 void
 o_set_fill_options (LeptonObject *o_current,
-                    OBJECT_FILLING type,
+                    LeptonFillType type,
                     int width,
                     int pitch1,
                     int angle1,

--- a/liblepton/include/liblepton/object.h
+++ b/liblepton/include/liblepton/object.h
@@ -48,7 +48,7 @@ struct st_object
   /* depending on its nature a primitive is concerned with one or more */
   /* of these fields. If not, value must be ignored. */
   OBJECT_END line_end;
-  OBJECT_TYPE line_type;
+  LeptonLineType line_type;
   int line_width;
   int line_space;
   int line_length;
@@ -213,7 +213,7 @@ o_get_fill_options (LeptonObject *object,
 gboolean
 o_get_line_options (LeptonObject *object,
                     OBJECT_END *end,
-                    OBJECT_TYPE *type,
+                    LeptonLineType *type,
                     int *width,
                     int *length,
                     int *space);
@@ -243,7 +243,7 @@ o_set_fill_options (LeptonObject *o_current,
 void
 o_set_line_options (LeptonObject *o_current,
                     OBJECT_END end,
-                    OBJECT_TYPE type,
+                    LeptonLineType type,
                     int width,
                     int length,
                     int space);

--- a/liblepton/include/liblepton/object.h
+++ b/liblepton/include/liblepton/object.h
@@ -32,7 +32,7 @@ struct st_object
 
   LeptonBounds bounds;
 
-  COMPONENT *component;
+  LeptonComponent *component;
   LeptonLine *line;
   LeptonCircle *circle;
   LeptonArc *arc;

--- a/liblepton/include/liblepton/page.h
+++ b/liblepton/include/liblepton/page.h
@@ -28,7 +28,7 @@ struct st_page
   int pid;
 
   GList *_object_list;
-  SELECTION *selection_list; /* new selection mechanism */
+  LeptonSelection *selection_list; /* selection mechanism */
   GList *place_list;
   LeptonObject *object_lastplace; /* the last found item */
   GList *connectible_list;  /* connectible page objects */

--- a/liblepton/include/liblepton/page.h
+++ b/liblepton/include/liblepton/page.h
@@ -42,9 +42,9 @@ struct st_page
 
   /* Undo/Redo Stacks and pointers */
   /* needs to go into page mechanism actually */
-  UNDO *undo_bottom;
-  UNDO *undo_current;
-  UNDO *undo_tos;       /* Top Of Stack */
+  LeptonUndo *undo_bottom;
+  LeptonUndo *undo_current;
+  LeptonUndo *undo_tos;       /* Top Of Stack */
 
   /* up and down the hierarchy */
   /* this holds the pid of the parent page */

--- a/liblepton/include/liblepton/page.h
+++ b/liblepton/include/liblepton/page.h
@@ -141,7 +141,7 @@ s_page_objects (LeptonPage *page);
 GList*
 s_page_objects_in_regions (LeptonToplevel *toplevel,
                            LeptonPage *page,
-                           BOX *rects,
+                           LeptonBox *rects,
                            int n_rects,
                            gboolean include_hidden);
 const gchar*

--- a/liblepton/include/liblepton/path.h
+++ b/liblepton/include/liblepton/path.h
@@ -23,7 +23,6 @@
 typedef struct st_path_section LeptonPathSection;
 
 typedef struct st_path LeptonPath;
-typedef struct st_path PATH;
 
 typedef enum
 {
@@ -55,14 +54,17 @@ struct st_path
 void
 lepton_path_free (LeptonPath *path);
 
-PATH*
+LeptonPath*
 s_path_parse (const char *path_str);
 
 double
-s_path_shortest_distance (PATH *path, int x, int y, int solid);
-
+s_path_shortest_distance (LeptonPath *path,
+                          int x,
+                          int y,
+                          int solid);
 char*
-s_path_string_from_path (const PATH *path);
+s_path_string_from_path (const LeptonPath *path);
 
 int
-s_path_to_polygon(PATH *path, GArray *points);
+s_path_to_polygon (LeptonPath *path,
+                   GArray *points);

--- a/liblepton/include/liblepton/path.h
+++ b/liblepton/include/liblepton/path.h
@@ -20,7 +20,7 @@
 /*! \file path.h
  */
 
-typedef struct st_path_section PATH_SECTION;
+typedef struct st_path_section LeptonPathSection;
 
 typedef struct st_path LeptonPath;
 typedef struct st_path PATH;
@@ -47,7 +47,7 @@ struct st_path_section
 
 struct st_path
 {
-  PATH_SECTION *sections; /* Bezier path segments  */
+  LeptonPathSection *sections; /* Bezier path segments  */
   int num_sections;       /* Number with data      */
   int num_sections_max;   /* Number allocated      */
 };

--- a/liblepton/include/liblepton/path_object.h
+++ b/liblepton/include/liblepton/path_object.h
@@ -31,7 +31,7 @@ lepton_path_object_new (char type,
 LeptonObject*
 lepton_path_object_new_take_path (char type,
                                   int color,
-                                  PATH *path_data);
+                                  LeptonPath *path_data);
 LeptonObject*
 lepton_path_object_copy (LeptonObject *o_current);
 

--- a/liblepton/include/liblepton/picture.h
+++ b/liblepton/include/liblepton/picture.h
@@ -21,7 +21,6 @@
  */
 
 typedef struct st_picture LeptonPicture;
-typedef struct st_picture PICTURE;
 
 struct st_picture
 {

--- a/liblepton/include/liblepton/point.h
+++ b/liblepton/include/liblepton/point.h
@@ -21,7 +21,6 @@
  */
 
 typedef struct st_point LeptonPoint;
-typedef struct st_point sPOINT;
 
 struct st_point
 {

--- a/liblepton/include/liblepton/prototype.h
+++ b/liblepton/include/liblepton/prototype.h
@@ -149,16 +149,17 @@ void o_embed (LeptonObject *o_current);
 void o_unembed (LeptonObject *o_current);
 
 /* o_selection.c */
-SELECTION *o_selection_new( void );
+LeptonSelection*
+o_selection_new ();
 
 void
-o_selection_add (SELECTION *selection,
+o_selection_add (LeptonSelection *selection,
                  LeptonObject *o_selected);
-
-void o_selection_print_all(const SELECTION *selection);
+void
+o_selection_print_all (const LeptonSelection *selection);
 
 void
-o_selection_remove (SELECTION *selection,
+o_selection_remove (LeptonSelection *selection,
                     LeptonObject *o_selected);
 
 /* s_attrib.c */

--- a/liblepton/include/liblepton/struct.h
+++ b/liblepton/include/liblepton/struct.h
@@ -28,7 +28,7 @@ typedef struct _LeptonList LeptonSelection;
 typedef struct _LeptonList LeptonPageList;
 
 /* lepton-schematic structures */
-typedef struct st_conn CONN;
+typedef struct st_conn LeptonConn;
 
 /* Managed text buffers */
 typedef struct _TextBuffer TextBuffer;

--- a/liblepton/include/liblepton/struct.h
+++ b/liblepton/include/liblepton/struct.h
@@ -24,7 +24,7 @@
 #include <glib.h>  /* Include needed to make GList work. */
 
 /* Wrappers around a new list mechanism */
-typedef struct _LeptonList SELECTION;
+typedef struct _LeptonList LeptonSelection;
 typedef struct _LeptonList LeptonPageList;
 
 /* lepton-schematic structures */

--- a/liblepton/include/liblepton/text.h
+++ b/liblepton/include/liblepton/text.h
@@ -21,7 +21,6 @@
  */
 
 typedef struct st_text LeptonText;
-typedef struct st_text TEXT;
 
 struct st_text
 {

--- a/liblepton/include/liblepton/undo.h
+++ b/liblepton/include/liblepton/undo.h
@@ -41,36 +41,43 @@ struct st_undo
   /* used to control which pages are viewable when moving around */
   int page_control;
 
-  UNDO *prev;
-  UNDO *next;
+  LeptonUndo *prev;
+  LeptonUndo *next;
 };
 
-UNDO*
-s_undo_return_tail (UNDO *head);
+LeptonUndo*
+s_undo_return_tail (LeptonUndo *head);
 
-UNDO *
-s_undo_return_head (UNDO *tail);
+LeptonUndo*
+s_undo_return_head (LeptonUndo *tail);
 
-UNDO *
+LeptonUndo*
 s_undo_new_head (void);
 
 void
-s_undo_destroy_head (UNDO *u_head);
+s_undo_destroy_head (LeptonUndo *u_head);
 
-UNDO *
-s_undo_add (UNDO *head, int type, char *filename, GList *object_list, int x, int y, double scale, int page_control, int up);
+LeptonUndo*
+s_undo_add (LeptonUndo *head,
+            int type,
+            char *filename,
+            GList *object_list,
+            int x,
+            int y,
+            double scale,
+            int page_control,
+            int up);
+void
+s_undo_print_all (LeptonUndo *head);
 
 void
-s_undo_print_all (UNDO *head);
+s_undo_destroy_all (LeptonUndo *head);
 
 void
-s_undo_destroy_all (UNDO *head);
-
-void
-s_undo_remove_rest (UNDO *head);
+s_undo_remove_rest (LeptonUndo *head);
 
 int
-s_undo_levels (UNDO *head);
+s_undo_levels (LeptonUndo *head);
 
 void
 s_undo_init (LeptonPage *p_current);

--- a/liblepton/include/prototype_priv.h
+++ b/liblepton/include/prototype_priv.h
@@ -30,8 +30,17 @@ void o_selection_select (LeptonObject *object);
 void o_selection_unselect (LeptonObject *object);
 
 /* s_conn.c */
-CONN *s_conn_return_new(LeptonObject *other_object, int type, int x, int y, int whichone, int other_whichone);
-int s_conn_uniq(GList *conn_list, CONN *input_conn);
+LeptonConn*
+s_conn_return_new (LeptonObject *other_object,
+                   int type,
+                   int x,
+                   int y,
+                   int whichone,
+                   int other_whichone);
+int
+s_conn_uniq (GList *conn_list,
+             LeptonConn *input_conn);
+
 int s_conn_remove_other (LeptonObject *other_object, LeptonObject *to_remove);
 LeptonObject *s_conn_check_midpoint(LeptonObject *o_current, int x, int y);
 void s_conn_print(GList *conn_list);

--- a/liblepton/src/arc_object.c
+++ b/liblepton/src/arc_object.c
@@ -439,7 +439,7 @@ LeptonObject
 
   o_set_line_options (new_obj,
                       (OBJECT_END) arc_end,
-                      (OBJECT_TYPE) arc_type,
+                      (LeptonLineType) arc_type,
                       arc_width,
                       arc_length,
                       arc_space);

--- a/liblepton/src/arc_object.c
+++ b/liblepton/src/arc_object.c
@@ -438,7 +438,7 @@ LeptonObject
                                    sweep_angle);
 
   o_set_line_options (new_obj,
-                      (OBJECT_END) arc_end,
+                      (LeptonLineCapType) arc_end,
                       (LeptonLineType) arc_type,
                       arc_width,
                       arc_length,

--- a/liblepton/src/box_object.c
+++ b/liblepton/src/box_object.c
@@ -357,7 +357,7 @@ o_box_read (const char buf[],
                       box_space);
   /* set its fill options */
   o_set_fill_options (new_obj,
-                      (OBJECT_FILLING) box_filling,
+                      (LeptonFillType) box_filling,
                       fill_width,
                       pitch1, angle1, pitch2, angle2);
 
@@ -386,7 +386,7 @@ lepton_box_object_to_buffer (const LeptonObject *object)
   int fill_width, angle1, pitch1, angle2, pitch2;
   LeptonLineCapType box_end;
   LeptonLineType box_type;
-  OBJECT_FILLING box_fill;
+  LeptonFillType box_fill;
   char *buf;
 
   /*! \note

--- a/liblepton/src/box_object.c
+++ b/liblepton/src/box_object.c
@@ -351,7 +351,7 @@ o_box_read (const char buf[],
   /* set its line options */
   o_set_line_options (new_obj,
                       (OBJECT_END) box_end,
-                      (OBJECT_TYPE) box_type,
+                      (LeptonLineType) box_type,
                       box_width,
                       box_length,
                       box_space);
@@ -385,7 +385,7 @@ lepton_box_object_to_buffer (const LeptonObject *object)
   int box_width, box_space, box_length;
   int fill_width, angle1, pitch1, angle2, pitch2;
   OBJECT_END box_end;
-  OBJECT_TYPE box_type;
+  LeptonLineType box_type;
   OBJECT_FILLING box_fill;
   char *buf;
 

--- a/liblepton/src/box_object.c
+++ b/liblepton/src/box_object.c
@@ -28,7 +28,7 @@
 
 #include "liblepton_priv.h"
 
-/*! \brief Create a BOX LeptonObject
+/*! \brief Create a box LeptonObject
  *  \par Function Description
  *  This function creates a new object representing a box.
  *
@@ -61,7 +61,7 @@ lepton_box_object_new (char type,
                        int y2)
 {
   LeptonObject *new_node;
-  BOX *box;
+  LeptonBox *box;
 
   /* create the object */
   new_node = s_basic_new_object(type, "box");
@@ -95,7 +95,7 @@ lepton_box_object_new (char type,
  *  The function #lepton_box_object_copy() creates a verbatim copy
  *  of the object pointed by <B>o_current</B> describing a box.
  *
- *  \param [in]      o_current  BOX LeptonObject to copy.
+ *  \param [in]      o_current  Box LeptonObject to copy.
  *  \return The new LeptonObject
  */
 LeptonObject*
@@ -130,7 +130,7 @@ lepton_box_object_copy (LeptonObject *o_current)
   return new_obj;
 }
 
-/*! \brief Modify a BOX LeptonObject's coordinates.
+/*! \brief Modify a box LeptonObject's coordinates.
  * \par Function Description
  * Modifies the coordinates of all four corners of \a box, by setting
  * the box to the rectangle enclosed by the points (\a x1, \a y1) and
@@ -160,7 +160,7 @@ lepton_box_object_modify_all (LeptonObject *object,
   o_emit_change_notify (object);
 }
 
-/*! \brief Modify a BOX LeptonObject's coordinates.
+/*! \brief Modify a box LeptonObject's coordinates.
  *  \par Function Description
  *  This function modifies the coordinates of one of the four corner of
  *  the box. The new coordinates of the corner identified by <B>whichone</B>
@@ -169,7 +169,7 @@ lepton_box_object_modify_all (LeptonObject *object,
  *  The coordinates of the corner is modified in the world coordinate system.
  *  Screen coordinates and boundings are then updated.
  *
- *  \param [in,out] object     BOX LeptonObject to be modified.
+ *  \param [in,out] object     Box LeptonObject to be modified.
  *  \param [in]     x          x coordinate.
  *  \param [in]     y          y coordinate.
  *  \param [in]     whichone   coordinate to change.
@@ -251,7 +251,7 @@ lepton_box_object_modify (LeptonObject *object,
  *  \param [in]     buf             Character string with box description.
  *  \param [in]     release_ver     libgeda release version number.
  *  \param [in]     fileformat_ver  libgeda file format version number.
- *  \return The BOX LeptonObject that was created, or NULL on error.
+ *  \return The box LeptonObject that was created, or NULL on error.
  */
 LeptonObject*
 o_box_read (const char buf[],
@@ -364,15 +364,15 @@ o_box_read (const char buf[],
   return new_obj;
 }
 
-/*! \brief Create a character string representation of a BOX.
+/*! \brief Create a character string representation of a box object.
  *  \par Function Description
  *  This function formats a string in the buffer <B>*buff</B> to describe the
  *  box object <B>*object</B>.
  *  It follows the post-20000704 release file format that handle the line type
  *  and fill options.
  *
- *  \param [in] object  The BOX LeptonObject to create string from.
- *  \return A pointer to the BOX character string.
+ *  \param [in] object  The box LeptonObject to create string from.
+ *  \return A pointer to the box character string.
  *
  *  \warning
  *  Caller must g_free returned character string.
@@ -432,12 +432,12 @@ lepton_box_object_to_buffer (const LeptonObject *object)
   return(buf);
 }
 
-/*! \brief Translate a BOX position in WORLD coordinates by a delta.
+/*! \brief Translate a box position in WORLD coordinates by a delta.
  *  \par Function Description
  *  This function applies a translation of (<B>x1</B>,<B>y1</B>) to the box
  *  described by <B>*object</B>. <B>x1</B> and <B>y1</B> are in world unit.
  *
- *  \param [in,out] object     BOX LeptonObject to translate.
+ *  \param [in,out] object     Box LeptonObject to translate.
  *  \param [in]     dx         x distance to move.
  *  \param [in]     dy         y distance to move.
  */
@@ -456,7 +456,7 @@ lepton_box_object_translate (LeptonObject *object,
   object->box->lower_y = object->box->lower_y + dy;
 }
 
-/*! \brief Rotate BOX LeptonObject using WORLD coordinates.
+/*! \brief Rotate box LeptonObject using WORLD coordinates.
  *  \par Function Description
  *  The function #o_box_rotate_world() rotate the box described by
  *  <B>*object</B> around the (<B>world_centerx</B>, <B>world_centery</B>) point by
@@ -466,7 +466,7 @@ lepton_box_object_translate (LeptonObject *object,
  *  \param [in]      world_centerx  Rotation center x coordinate in WORLD units.
  *  \param [in]      world_centery  Rotation center y coordinate in WORLD units.
  *  \param [in]      angle          Rotation angle in degrees (See note below).
- *  \param [in,out]  object         BOX LeptonObject to rotate.
+ *  \param [in,out]  object         Box LeptonObject to rotate.
  *
  */
 void
@@ -529,7 +529,7 @@ lepton_box_object_rotate (int world_centerx,
   object->box->lower_y += world_centery;
 }
 
-/*! \brief Mirror BOX using WORLD coordinates.
+/*! \brief Mirror box using WORLD coordinates.
  *  \par Function Description
  *  This function mirrors the box from the point
  *  (<B>world_centerx</B>,<B>world_centery</B>) in world unit.
@@ -539,7 +539,7 @@ lepton_box_object_rotate (int world_centerx,
  *
  *  \param [in]     world_centerx  Origin x coordinate in WORLD units.
  *  \param [in]     world_centery  Origin y coordinate in WORLD units.
- *  \param [in,out] object         BOX LeptonObject to mirror.
+ *  \param [in,out] object         Box LeptonObject to mirror.
  */
 void
 lepton_box_object_mirror (int world_centerx,
@@ -577,13 +577,13 @@ lepton_box_object_mirror (int world_centerx,
   object->box->lower_y += world_centery;
 }
 
-/*! \brief Get BOX bounding rectangle in WORLD coordinates.
+/*! \brief Get box bounding rectangle in WORLD coordinates.
  *  \par Function Description
  *  This function sets the <B>left</B>, <B>top</B>, <B>right</B> and <B>bottom</B>
  *  parameters to the boundings of the box object described in <B>*box</B>
  *  in world units.
  *
- *  \param [in]  object     BOX LeptonObject to read coordinates from.
+ *  \param [in]  object     Box LeptonObject to read coordinates from.
  *  \param [out] left       Left box coordinate in WORLD units.
  *  \param [out] top        Top box coordinate in WORLD units.
  *  \param [out] right      Right box coordinate in WORLD units.

--- a/liblepton/src/box_object.c
+++ b/liblepton/src/box_object.c
@@ -350,7 +350,7 @@ o_box_read (const char buf[],
   new_obj = lepton_box_object_new (type, color, d_x1, d_y1, d_x2, d_y2);
   /* set its line options */
   o_set_line_options (new_obj,
-                      (OBJECT_END) box_end,
+                      (LeptonLineCapType) box_end,
                       (LeptonLineType) box_type,
                       box_width,
                       box_length,
@@ -384,7 +384,7 @@ lepton_box_object_to_buffer (const LeptonObject *object)
   int width, height;
   int box_width, box_space, box_length;
   int fill_width, angle1, pitch1, angle2, pitch2;
-  OBJECT_END box_end;
+  LeptonLineCapType box_end;
   LeptonLineType box_type;
   OBJECT_FILLING box_fill;
   char *buf;

--- a/liblepton/src/circle_object.c
+++ b/liblepton/src/circle_object.c
@@ -376,7 +376,7 @@ o_circle_read (const char buf[],
 
   o_set_line_options (new_obj,
                       (OBJECT_END) circle_end,
-                      (OBJECT_TYPE) circle_type,
+                      (LeptonLineType) circle_type,
                       circle_width,
                       circle_length,
                       circle_space);

--- a/liblepton/src/circle_object.c
+++ b/liblepton/src/circle_object.c
@@ -381,7 +381,7 @@ o_circle_read (const char buf[],
                       circle_length,
                       circle_space);
   o_set_fill_options (new_obj,
-                      (OBJECT_FILLING) circle_fill,
+                      (LeptonFillType) circle_fill,
                       fill_width,
                       pitch1,
                       angle1,

--- a/liblepton/src/circle_object.c
+++ b/liblepton/src/circle_object.c
@@ -375,7 +375,7 @@ o_circle_read (const char buf[],
   new_obj = lepton_circle_object_new (color, x1, y1, radius);
 
   o_set_line_options (new_obj,
-                      (OBJECT_END) circle_end,
+                      (LeptonLineCapType) circle_end,
                       (LeptonLineType) circle_type,
                       circle_width,
                       circle_length,

--- a/liblepton/src/component_object.c
+++ b/liblepton/src/component_object.c
@@ -1424,7 +1424,7 @@ lepton_component_object_shortest_distance (LeptonObject *object,
   double shortest_distance = G_MAXDOUBLE;
   double distance;
   int found_line_bounds = 0;
-  BOX line_bounds;
+  LeptonBox line_bounds;
   GList *iter;
 
   g_return_val_if_fail (lepton_object_is_component (object), G_MAXDOUBLE);

--- a/liblepton/src/component_object.c
+++ b/liblepton/src/component_object.c
@@ -732,7 +732,7 @@ o_component_new (LeptonPage *page,
 
   new_node->selectable = selectable;
 
-  new_node->component = (COMPONENT *) g_malloc(sizeof(COMPONENT));
+  new_node->component = (LeptonComponent *) g_malloc (sizeof (LeptonComponent));
   new_node->component->prim_objs = NULL;
   new_node->component->angle = angle;
   new_node->component->mirror = mirror;
@@ -815,7 +815,7 @@ o_component_new_embedded (char type,
 
   new_node = s_basic_new_object(type, "complex");
 
-  new_node->component = (COMPONENT *) g_malloc(sizeof(COMPONENT));
+  new_node->component = (LeptonComponent *) g_malloc (sizeof (LeptonComponent));
   new_node->component->x = x;
   new_node->component->y = y;
 
@@ -1015,7 +1015,7 @@ o_component_copy (LeptonObject *o_current)
   o_new->selectable = o_current->selectable;
   o_new->component_basename = g_strdup(o_current->component_basename);
 
-  o_new->component = (COMPONENT*) g_malloc0 (sizeof (COMPONENT));
+  o_new->component = (LeptonComponent*) g_malloc0 (sizeof (LeptonComponent));
   o_new->component->x = o_current->component->x;
   o_new->component->y = o_current->component->y;
   o_new->component->angle = o_current->component->angle;

--- a/liblepton/src/edacairo.c
+++ b/liblepton/src/edacairo.c
@@ -495,8 +495,11 @@ eda_cairo_path_hint (cairo_t *cr, int flags,
 }
 
 void
-eda_cairo_path (cairo_t *cr, int flags, double line_width,
-                int nsections, PATH_SECTION *sections)
+eda_cairo_path (cairo_t *cr,
+                int flags,
+                double line_width,
+                int nsections,
+                LeptonPathSection *sections)
 {
   int i;
   int s_line_width;
@@ -514,7 +517,7 @@ eda_cairo_path (cairo_t *cr, int flags, double line_width,
   }
 
   for (i = 0; i < nsections; i++) {
-    PATH_SECTION *section = sections + i;
+    LeptonPathSection *section = sections + i;
     double x1 = section->x1;
     double x2 = section->x2;
     double x3 = section->x3;

--- a/liblepton/src/edarenderer.c
+++ b/liblepton/src/edarenderer.c
@@ -1371,7 +1371,7 @@ eda_renderer_draw_end_cues (EdaRenderer *renderer, LeptonObject *object, int end
                 && (object->pin_type == PIN_TYPE_BUS)));
 
   for (iter = object->conn_list; iter != NULL; iter = g_list_next (iter)) {
-    CONN *conn = (CONN *) iter->data;
+    LeptonConn *conn = (LeptonConn *) iter->data;
     if ((conn->x != x) || (conn->y != y)) continue;
 
     /* Check whether the connected object is a bus or bus pin */
@@ -1426,7 +1426,7 @@ eda_renderer_draw_mid_cues (EdaRenderer *renderer, LeptonObject *object)
 {
   GList *iter;
   for (iter = object->conn_list; iter != NULL; iter = g_list_next (iter)) {
-    CONN *conn = (CONN *) iter->data;
+    LeptonConn *conn = (LeptonConn *) iter->data;
 
     if (conn->type == CONN_MIDPOINT) {
       int is_bus = (lepton_object_is_bus (object)

--- a/liblepton/src/edarenderer.c
+++ b/liblepton/src/edarenderer.c
@@ -1220,7 +1220,7 @@ eda_renderer_draw_path_grips (EdaRenderer *renderer, LeptonObject *object)
 {
   int i, last_x = 0, last_y = 0, next_x, next_y;
   for (i = 0; i < object->path->num_sections; i++) {
-    PATH_SECTION *section = object->path->sections + i;
+    LeptonPathSection *section = object->path->sections + i;
 
     if (section->code != PATH_END) {
       next_x = section->x3;

--- a/liblepton/src/line_object.c
+++ b/liblepton/src/line_object.c
@@ -428,7 +428,7 @@ o_line_read (const char buf[],
   /* set its line options */
   o_set_line_options (new_obj,
                       (OBJECT_END) line_end,
-                      (OBJECT_TYPE) line_type,
+                      (LeptonLineType) line_type,
                       line_width,
                       line_length,
                       line_space);

--- a/liblepton/src/line_object.c
+++ b/liblepton/src/line_object.c
@@ -427,7 +427,7 @@ o_line_read (const char buf[],
 
   /* set its line options */
   o_set_line_options (new_obj,
-                      (OBJECT_END) line_end,
+                      (LeptonLineCapType) line_end,
                       (LeptonLineType) line_type,
                       line_width,
                       line_length,

--- a/liblepton/src/m_hatch.c
+++ b/liblepton/src/m_hatch.c
@@ -112,7 +112,11 @@ static gint compare_status(gconstpointer a, gconstpointer b)
  *  segments.  This function appends new line segments to the GArray and leaves
  *  existing GArray contents unchanged.
  */
-void m_hatch_box(BOX *box, gint angle, gint pitch, GArray *lines)
+void
+m_hatch_box (LeptonBox *box,
+             gint angle,
+             gint pitch,
+             GArray *lines)
 {
   GArray *corners;
   LeptonPoint point;

--- a/liblepton/src/m_hatch.c
+++ b/liblepton/src/m_hatch.c
@@ -115,12 +115,12 @@ static gint compare_status(gconstpointer a, gconstpointer b)
 void m_hatch_box(BOX *box, gint angle, gint pitch, GArray *lines)
 {
   GArray *corners;
-  sPOINT point;
+  LeptonPoint point;
 
   g_return_if_fail(box!=NULL);
   g_return_if_fail(lines!=NULL);
 
-  corners = g_array_sized_new(FALSE, FALSE, sizeof(sPOINT), 4);
+  corners = g_array_sized_new(FALSE, FALSE, sizeof (LeptonPoint), 4);
 
   point.x = box->upper_x;
   point.y = box->upper_y;
@@ -215,7 +215,7 @@ void m_hatch_path (PATH *path, gint angle, gint pitch, GArray *lines)
   g_return_if_fail (path != NULL);
   g_return_if_fail (lines != NULL);
 
-  points = g_array_new (FALSE, FALSE, sizeof (sPOINT));
+  points = g_array_new (FALSE, FALSE, sizeof (LeptonPoint));
 
   s_path_to_polygon (path, points);
   m_hatch_polygon (points, angle, pitch, lines);
@@ -253,7 +253,7 @@ void m_hatch_polygon(GArray *points, gint angle, gint pitch, GArray *lines)
   g_return_if_fail(lines!=NULL);
 
   events = g_array_new(FALSE, FALSE, sizeof(SWEEP_EVENT));
-  points2 = g_array_sized_new(FALSE, FALSE, sizeof(sPOINT), points->len);
+  points2 = g_array_sized_new (FALSE, FALSE, sizeof (LeptonPoint), points->len);
   status = g_array_new(FALSE, FALSE, sizeof(SWEEP_STATUS));
 
   lepton_transform_init(&transform);
@@ -267,9 +267,9 @@ void m_hatch_polygon(GArray *points, gint angle, gint pitch, GArray *lines)
   /* build list of sweep events */
   if ( points2->len > 1 ) {
     guint index;
-    sPOINT *p0 = &g_array_index(points2, sPOINT, points2->len-1);
+    LeptonPoint *p0 = &g_array_index (points2, LeptonPoint, points2->len-1);
     for (index=0; index<points2->len; index++) {
-      sPOINT *p1 = &g_array_index(points2, sPOINT, index);
+      LeptonPoint *p1 = &g_array_index (points2, LeptonPoint, index);
       if ( p0->y != p1->y ) {
         SWEEP_EVENT event;
         event.y0 = MIN(p0->y, p1->y);
@@ -285,7 +285,7 @@ void m_hatch_polygon(GArray *points, gint angle, gint pitch, GArray *lines)
   /* sort sweep events in ascending order by starting y coordinate */
   g_array_sort(events, compare_events);
 
-  lepton_bounds_of_points(&bounds, (sPOINT*)points2->data, points2->len);
+  lepton_bounds_of_points(&bounds, (LeptonPoint*) points2->data, points2->len);
   sweep_y = calculate_initial_sweep(10 * pitch, bounds.min_y, bounds.max_y);
 
   while ( events->len > 0 || status->len > 0 ) {

--- a/liblepton/src/m_hatch.c
+++ b/liblepton/src/m_hatch.c
@@ -212,7 +212,11 @@ m_hatch_circle (LeptonCircle *circle,
  *  segments.  This function appends new line segments to the GArray and leaves
  *  existing GArray contents unchanged.
  */
-void m_hatch_path (PATH *path, gint angle, gint pitch, GArray *lines)
+void
+m_hatch_path (LeptonPath *path,
+              gint angle,
+              gint pitch,
+              GArray *lines)
 {
   GArray *points;
 

--- a/liblepton/src/m_polygon.c
+++ b/liblepton/src/m_polygon.c
@@ -88,14 +88,15 @@ m_polygon_append_bezier (GArray *points,
  */
 void m_polygon_append_point (GArray *points, int x, int y)
 {
-  sPOINT point = { x, y };
+  LeptonPoint point = { x, y };
 
   point.x = x;
   point.y = y;
 
   if (points->len == 0 ||
-      memcmp (&g_array_index (points, sPOINT, points->len - 1),
-              &point, sizeof (sPOINT)) != 0) {
+      memcmp (&g_array_index (points, LeptonPoint, points->len - 1),
+              &point, sizeof (LeptonPoint)) != 0)
+  {
     g_array_append_val (points, point);
   }
 }
@@ -119,13 +120,13 @@ gboolean m_polygon_interior_point (GArray *points, int x, int y)
 
   if (points->len > 0) {
     guint i;
-    sPOINT p1 = g_array_index (points, sPOINT, points->len - 1);
+    LeptonPoint p1 = g_array_index (points, LeptonPoint, points->len - 1);
 
     for (i=0; i < points->len; i++) {
-      sPOINT p0 = p1;
+      LeptonPoint p0 = p1;
       double xi;
 
-      p1 = g_array_index (points, sPOINT, i);
+      p1 = g_array_index (points, LeptonPoint, i);
 
       if (y < p0.y && y < p1.y)
         continue;
@@ -161,12 +162,12 @@ double m_polygon_shortest_distance (GArray *points, int x, int y, gboolean close
 
   if (points->len > 0) {
     guint i = 0;
-    sPOINT point;
+    LeptonPoint point;
 
     if (closed) {
-      point = g_array_index (points, sPOINT, points->len - 1);
+      point = g_array_index (points, LeptonPoint, points->len - 1);
     } else {
-      point = g_array_index (points, sPOINT, i++);
+      point = g_array_index (points, LeptonPoint, i++);
     }
 
     while (i < points->len) {
@@ -176,7 +177,7 @@ double m_polygon_shortest_distance (GArray *points, int x, int y, gboolean close
       line.x[0] = point.x;
       line.y[0] = point.y;
 
-      point = g_array_index (points, sPOINT, i++);
+      point = g_array_index (points, LeptonPoint, i++);
 
       line.x[1] = point.x;
       line.y[1] = point.y;

--- a/liblepton/src/net_object.c
+++ b/liblepton/src/net_object.c
@@ -584,11 +584,11 @@ static void o_net_consolidate_lowlevel (LeptonObject *object,
 static int o_net_consolidate_nomidpoint (LeptonObject *object, int x, int y)
 {
   GList *c_current;
-  CONN *conn;
+  LeptonConn *conn;
 
   c_current = object->conn_list;
   while(c_current != NULL) {
-    conn = (CONN *) c_current->data;
+    conn = (LeptonConn *) c_current->data;
     if (conn->other_object) {
       if (lepton_object_get_id (conn->other_object) != lepton_object_get_id (object) &&
           conn->x == x && conn->y == y &&
@@ -621,7 +621,7 @@ o_net_consolidate_segments (LeptonObject *object)
   int object_orient;
   int other_orient;
   GList *c_current;
-  CONN *conn;
+  LeptonConn *conn;
   LeptonObject *other_object;
   LeptonPage *page;
   int changed = 0;
@@ -636,7 +636,7 @@ o_net_consolidate_segments (LeptonObject *object)
 
   c_current = object->conn_list;
   while(c_current != NULL) {
-    conn = (CONN *) c_current->data;
+    conn = (LeptonConn *) c_current->data;
     other_object = conn->other_object;
 
     /* only look at end points which have a valid end on the other side */

--- a/liblepton/src/o_selection.c
+++ b/liblepton/src/o_selection.c
@@ -27,13 +27,14 @@
 
 #include "liblepton_priv.h"
 
-/*! \brief Returns a pointer to a new SELECTION object.
- *  \par Returns a pointer to a new SELECTION object.
- *  \return pointer to the new SELECTION object.
+/*! \brief Returns a pointer to a new LeptonSelection object.
+ *  \par Returns a pointer to a new LeptonSelection object.
+ *  \return pointer to the new LeptonSelection object.
  */
-SELECTION *o_selection_new( void )
+LeptonSelection*
+o_selection_new ()
 {
-  return (SELECTION*)lepton_list_new();
+  return (LeptonSelection*) lepton_list_new ();
 }
 
 /*! \brief Selects the given object and adds it to the selection list
@@ -45,7 +46,7 @@ SELECTION *o_selection_new( void )
  *  \param [in] o_selected Object to select.
  */
 void
-o_selection_add (SELECTION *selection,
+o_selection_add (LeptonSelection *selection,
                  LeptonObject *o_selected)
 {
   if (o_selected->selected == FALSE)
@@ -65,7 +66,7 @@ o_selection_add (SELECTION *selection,
  *  \param [in] o_selected Object to unselect and remove from the list.
  */
 void
-o_selection_remove (SELECTION *selection,
+o_selection_remove (LeptonSelection *selection,
                     LeptonObject *o_selected)
 {
   if (o_selected == NULL) {
@@ -85,7 +86,8 @@ o_selection_remove (SELECTION *selection,
  *  \param [in] selection Pointer to selection list to print.
  *
  */
-void o_selection_print_all(const SELECTION *selection)
+void
+o_selection_print_all (const LeptonSelection *selection)
 {
   const GList *s_current;
 

--- a/liblepton/src/object.c
+++ b/liblepton/src/object.c
@@ -701,10 +701,10 @@ o_get_line_options (LeptonObject *object,
 /*! \brief Set #LeptonObject's fill options.
  *  \par Function Description
  *  This function allows an #LeptonObject's fill options to be configured.
- *  See #OBJECT_FILLING for information on valid fill types.
+ *  See #LeptonFillType for information on valid fill types.
  *
  *  \param [in,out]  o_current  LeptonObject to be updated.
- *  \param [in]      type       OBJECT_FILLING type.
+ *  \param [in]      type       LeptonFillType type.
  *  \param [in]      width      fill width.
  *  \param [in]      pitch1     cross hatch line distance
  *  \param [in]      angle1     cross hatch angle
@@ -714,7 +714,7 @@ o_get_line_options (LeptonObject *object,
  */
 void
 o_set_fill_options (LeptonObject *o_current,
-                    OBJECT_FILLING type,
+                    LeptonFillType type,
                     int width,
                     int pitch1,
                     int angle1,
@@ -773,10 +773,10 @@ o_set_fill_options (LeptonObject *o_current,
 /*! \brief get #LeptonObject's fill properties.
  *  \par Function Description
  *  This function get's the #LeptonObject's fill options.
- *  See #OBJECT_FILLING for information on valid fill types.
+ *  See #LeptonFillType for information on valid fill types.
  *
  *  \param [in]   object    LeptonObject to read the properties
- *  \param [out]  type      OBJECT_FILLING type
+ *  \param [out]  type      LeptonFillType type
  *  \param [out]  width     fill width.
  *  \param [out]  pitch1    cross hatch line distance
  *  \param [out]  angle1    cross hatch angle
@@ -785,10 +785,14 @@ o_set_fill_options (LeptonObject *o_current,
  *  \return TRUE on succes, FALSE otherwise
  *
  */
-gboolean o_get_fill_options(LeptonObject *object,
-                            OBJECT_FILLING *type, int *width,
-                            int *pitch1, int *angle1,
-                            int *pitch2, int *angle2)
+gboolean
+o_get_fill_options (LeptonObject *object,
+                    LeptonFillType *type,
+                    int *width,
+                    int *pitch1,
+                    int *angle1,
+                    int *pitch2,
+                    int *angle2)
 {
   if (!lepton_object_is_box (object)
       && !lepton_object_is_circle (object)

--- a/liblepton/src/object.c
+++ b/liblepton/src/object.c
@@ -596,11 +596,11 @@ s_object_remove_weak_ptr (LeptonObject *object,
 /*! \brief Set an #LeptonObject's line options.
  *  \par Function Description
  *  This function allows a line's end, type, width, length and space to be set.
- *  See #OBJECT_END and #LeptonLineType for information on valid
+ *  See #LeptonLineCapType and #LeptonLineType for information on valid
  *  object end and type values.
  *
  *  \param [in,out] o_current  LeptonObject to set line options on.
- *  \param [in]     end        An OBJECT_END.
+ *  \param [in]     end        An LeptonLineCapType.
  *  \param [in]     type       An LeptonLineType.
  *  \param [in]     width      Line width.
  *  \param [in]     length     Line length.
@@ -611,7 +611,7 @@ s_object_remove_weak_ptr (LeptonObject *object,
  */
 void
 o_set_line_options (LeptonObject *o_current,
-                    OBJECT_END end,
+                    LeptonLineCapType end,
                     LeptonLineType type,
                     int width,
                     int length,
@@ -662,11 +662,11 @@ o_set_line_options (LeptonObject *o_current,
 /*! \brief get #LeptonObject's line properties.
  *  \par Function Description
  *  This function get's the #LeptonObject's line options.
- *  See #OBJECT_END and #LeptonLineType for information on valid
+ *  See #LeptonLineCapType and #LeptonLineType for information on valid
  *  object end and type values.
  *
  *  \param [in]   object    LeptonObject to read the properties
- *  \param [out]  end       An OBJECT_END.
+ *  \param [out]  end       An LeptonLineCapType.
  *  \param [out]  type      An LeptonLineType.
  *  \param [out]  width     Line width.
  *  \param [out]  length    Line length.
@@ -674,9 +674,13 @@ o_set_line_options (LeptonObject *o_current,
  *  \return TRUE on succes, FALSE otherwise
  *
  */
-gboolean o_get_line_options(LeptonObject *object,
-                            OBJECT_END *end, LeptonLineType *type,
-                            int *width, int *length, int *space)
+gboolean
+o_get_line_options (LeptonObject *object,
+                    LeptonLineCapType *end,
+                    LeptonLineType *type,
+                    int *width,
+                    int *length,
+                    int *space)
 {
   if (!lepton_object_is_line (object)
       && !lepton_object_is_arc (object)

--- a/liblepton/src/object.c
+++ b/liblepton/src/object.c
@@ -596,12 +596,12 @@ s_object_remove_weak_ptr (LeptonObject *object,
 /*! \brief Set an #LeptonObject's line options.
  *  \par Function Description
  *  This function allows a line's end, type, width, length and space to be set.
- *  See #OBJECT_END and #OBJECT_TYPE for information on valid
+ *  See #OBJECT_END and #LeptonLineType for information on valid
  *  object end and type values.
  *
  *  \param [in,out] o_current  LeptonObject to set line options on.
  *  \param [in]     end        An OBJECT_END.
- *  \param [in]     type       An OBJECT_TYPE.
+ *  \param [in]     type       An LeptonLineType.
  *  \param [in]     width      Line width.
  *  \param [in]     length     Line length.
  *  \param [in]     space      Spacing between dashes/dots. Cannot be negative.
@@ -612,7 +612,7 @@ s_object_remove_weak_ptr (LeptonObject *object,
 void
 o_set_line_options (LeptonObject *o_current,
                     OBJECT_END end,
-                    OBJECT_TYPE type,
+                    LeptonLineType type,
                     int width,
                     int length,
                     int space)
@@ -662,12 +662,12 @@ o_set_line_options (LeptonObject *o_current,
 /*! \brief get #LeptonObject's line properties.
  *  \par Function Description
  *  This function get's the #LeptonObject's line options.
- *  See #OBJECT_END and #OBJECT_TYPE for information on valid
+ *  See #OBJECT_END and #LeptonLineType for information on valid
  *  object end and type values.
  *
  *  \param [in]   object    LeptonObject to read the properties
  *  \param [out]  end       An OBJECT_END.
- *  \param [out]  type      An OBJECT_TYPE.
+ *  \param [out]  type      An LeptonLineType.
  *  \param [out]  width     Line width.
  *  \param [out]  length    Line length.
  *  \param [out]  space     Spacing between dashes/dots.
@@ -675,7 +675,7 @@ o_set_line_options (LeptonObject *o_current,
  *
  */
 gboolean o_get_line_options(LeptonObject *object,
-                            OBJECT_END *end, OBJECT_TYPE *type,
+                            OBJECT_END *end, LeptonLineType *type,
                             int *width, int *length, int *space)
 {
   if (!lepton_object_is_line (object)

--- a/liblepton/src/page.c
+++ b/liblepton/src/page.c
@@ -771,7 +771,7 @@ const GList *s_page_objects (LeptonPage *page)
  *
  *  \param [in] toplevel  The LeptonToplevel object.
  *  \param [in] page      The LeptonPage to find objects on.
- *  \param [in] rects     The BOX regions to check.
+ *  \param [in] rects     The LeptonBox regions to check.
  *  \param [in] n_rects   The number of regions.
  *  \param [in] include_hidden Calculate bounds of hidden objects.
  *  \return The GList of LeptonObjects in the region.
@@ -779,7 +779,7 @@ const GList *s_page_objects (LeptonPage *page)
 GList*
 s_page_objects_in_regions (LeptonToplevel *toplevel,
                            LeptonPage *page,
-                           BOX *rects,
+                           LeptonBox *rects,
                            int n_rects,
                            gboolean include_hidden)
 {

--- a/liblepton/src/path.c
+++ b/liblepton/src/path.c
@@ -54,14 +54,14 @@ s_path_new (void)
   path = g_new (LeptonPath, 1);
   path->num_sections = 0;
   path->num_sections_max = 16;
-  path->sections = g_new (PATH_SECTION, path->num_sections_max);
+  path->sections = g_new (LeptonPathSection, path->num_sections_max);
 
   return path;
 }
 
 
 LeptonPath*
-s_path_new_from (PATH_SECTION *sections)
+s_path_new_from (LeptonPathSection *sections)
 {
   LeptonPath *path;
   int i;
@@ -76,9 +76,9 @@ s_path_new_from (PATH_SECTION *sections)
 
   path->num_sections = i;
   path->num_sections_max = i;
-  path->sections = g_new (PATH_SECTION, i);
+  path->sections = g_new (LeptonPathSection, i);
 
-  memcpy (path->sections, sections, i * sizeof (PATH_SECTION));
+  memcpy (path->sections, sections, i * sizeof (LeptonPathSection));
   return path;
 }
 
@@ -98,7 +98,7 @@ s_path_moveto (LeptonPath *path,
                double x,
                double y)
 {
-  PATH_SECTION *sections;
+  LeptonPathSection *sections;
   int num_sections;
 
   g_return_if_fail (path != NULL);
@@ -118,8 +118,10 @@ s_path_moveto (LeptonPath *path,
   num_sections = path->num_sections++;
 
   if (num_sections == path->num_sections_max)
-    path->sections = (PATH_SECTION*) g_realloc (path->sections,
-                                                (path->num_sections_max <<= 1) * sizeof (PATH_SECTION));
+    path->sections =
+      (LeptonPathSection*) g_realloc (path->sections,
+                                      (path->num_sections_max <<= 1) *
+                                      sizeof (LeptonPathSection));
   sections = path->sections;
   sections[num_sections].code = PATH_MOVETO_OPEN;
   sections[num_sections].x3 = x;
@@ -132,7 +134,7 @@ s_path_lineto (LeptonPath *path,
                double x,
                double y)
 {
-  PATH_SECTION *sections;
+  LeptonPathSection *sections;
   int num_sections;
 
   g_return_if_fail (path != NULL);
@@ -140,8 +142,10 @@ s_path_lineto (LeptonPath *path,
   num_sections = path->num_sections++;
 
   if (num_sections == path->num_sections_max)
-    path->sections = (PATH_SECTION*) g_realloc (path->sections,
-                                                (path->num_sections_max <<= 1) * sizeof (PATH_SECTION));
+    path->sections =
+      (LeptonPathSection*) g_realloc (path->sections,
+                                      (path->num_sections_max <<= 1) *
+                                      sizeof (LeptonPathSection));
   sections = path->sections;
   sections[num_sections].code = PATH_LINETO;
   sections[num_sections].x3 = x;
@@ -158,7 +162,7 @@ s_path_curveto (LeptonPath *path,
                 double x3,
                 double y3)
 {
-  PATH_SECTION *sections;
+  LeptonPathSection *sections;
   int num_sections;
 
   g_return_if_fail (path != NULL);
@@ -166,8 +170,10 @@ s_path_curveto (LeptonPath *path,
   num_sections = path->num_sections++;
 
   if (num_sections == path->num_sections_max)
-    path->sections = (PATH_SECTION*) g_realloc (path->sections,
-                                                (path->num_sections_max <<= 1) * sizeof (PATH_SECTION));
+    path->sections =
+      (LeptonPathSection*) g_realloc (path->sections,
+                                      (path->num_sections_max <<= 1) *
+                                      sizeof (LeptonPathSection));
   sections = path->sections;
   sections[num_sections].code = PATH_CURVETO;
   sections[num_sections].x1 = x1;
@@ -189,8 +195,10 @@ s_path_art_finish (LeptonPath * path)
   num_sections = path->num_sections++;
 
   if (num_sections == path->num_sections_max)
-    path->sections = (PATH_SECTION*) g_realloc (path->sections,
-                                                (path->num_sections_max <<= 1) * sizeof (PATH_SECTION));
+    path->sections =
+      (LeptonPathSection*) g_realloc (path->sections,
+                                      (path->num_sections_max <<= 1) *
+                                      sizeof (LeptonPathSection));
   path->sections[num_sections].code = PATH_END;
 }
 
@@ -681,7 +689,7 @@ s_path_parse (const char *path_str)
 char*
 s_path_string_from_path (const LeptonPath *path)
 {
-  PATH_SECTION *section;
+  LeptonPathSection *section;
   GString *path_string;
   int i;
 
@@ -743,7 +751,7 @@ s_path_to_polygon (LeptonPath *path,
 
   for (i = 0; i < path->num_sections; i++) {
     LeptonBezier bezier;
-    PATH_SECTION *section = &path->sections[i];
+    LeptonPathSection *section = &path->sections[i];
 
     switch (section->code) {
       case PATH_CURVETO:

--- a/liblepton/src/path.c
+++ b/liblepton/src/path.c
@@ -735,7 +735,7 @@ s_path_to_polygon (LeptonPath *path,
 {
   int closed = FALSE;
   int i;
-  sPOINT point = { 0, 0 };
+  LeptonPoint point = { 0, 0 };
 
   if (points->len > 0) {
     g_array_remove_range (points, 0, points->len - 1);
@@ -801,7 +801,7 @@ s_path_shortest_distance (LeptonPath *path,
   int closed;
   GArray *points;
 
-  points = g_array_new (FALSE, FALSE, sizeof (sPOINT));
+  points = g_array_new (FALSE, FALSE, sizeof (LeptonPoint));
 
   closed = s_path_to_polygon (path, points);
 

--- a/liblepton/src/path_object.c
+++ b/liblepton/src/path_object.c
@@ -330,7 +330,7 @@ lepton_path_object_modify (LeptonObject *object,
 {
   int i;
   int grip_no = 0;
-  PATH_SECTION *section;
+  LeptonPathSection *section;
 
   o_emit_pre_change_notify (object);
 
@@ -381,7 +381,7 @@ lepton_path_object_translate (LeptonObject *object,
                               int dx,
                               int dy)
 {
-  PATH_SECTION *section;
+  LeptonPathSection *section;
   int i;
 
   g_return_if_fail (lepton_object_is_path (object));
@@ -428,7 +428,7 @@ lepton_path_object_rotate (int world_centerx,
                            int angle,
                            LeptonObject *object)
 {
-  PATH_SECTION *section;
+  LeptonPathSection *section;
   int i;
 
   g_return_if_fail (lepton_object_is_path (object));
@@ -480,7 +480,7 @@ lepton_path_object_mirror (int world_centerx,
                            int world_centery,
                            LeptonObject *object)
 {
-  PATH_SECTION *section;
+  LeptonPathSection *section;
   int i;
 
   g_return_if_fail (lepton_object_is_path (object));
@@ -529,7 +529,7 @@ lepton_path_object_calculate_bounds (const LeptonObject *object,
 
   /* Find the bounds of the path region */
   for (i = 0; i < object->path->num_sections; i++) {
-    PATH_SECTION *section = &object->path->sections[i];
+    LeptonPathSection *section = &object->path->sections[i];
 
     switch (section->code) {
       case PATH_CURVETO:

--- a/liblepton/src/path_object.c
+++ b/liblepton/src/path_object.c
@@ -237,7 +237,7 @@ o_path_read (const char *first_line,
   /* set its line options */
   o_set_line_options (new_obj,
                       (OBJECT_END) line_end,
-                      (OBJECT_TYPE) line_type,
+                      (LeptonLineType) line_type,
                       line_width,
                       line_length,
                       line_space);
@@ -273,7 +273,7 @@ lepton_path_object_to_buffer (const LeptonObject *object)
   char *buf;
   int num_lines;
   OBJECT_END line_end;
-  OBJECT_TYPE line_type;
+  LeptonLineType line_type;
   OBJECT_FILLING fill_type;
   int fill_width, angle1, pitch1, angle2, pitch2;
   char *path_string;

--- a/liblepton/src/path_object.c
+++ b/liblepton/src/path_object.c
@@ -236,7 +236,7 @@ o_path_read (const char *first_line,
 
   /* set its line options */
   o_set_line_options (new_obj,
-                      (OBJECT_END) line_end,
+                      (LeptonLineCapType) line_end,
                       (LeptonLineType) line_type,
                       line_width,
                       line_length,
@@ -272,7 +272,7 @@ lepton_path_object_to_buffer (const LeptonObject *object)
   int line_width, line_space, line_length;
   char *buf;
   int num_lines;
-  OBJECT_END line_end;
+  LeptonLineCapType line_end;
   LeptonLineType line_type;
   OBJECT_FILLING fill_type;
   int fill_width, angle1, pitch1, angle2, pitch2;

--- a/liblepton/src/path_object.c
+++ b/liblepton/src/path_object.c
@@ -243,7 +243,7 @@ o_path_read (const char *first_line,
                       line_space);
   /* set its fill options */
   o_set_fill_options (new_obj,
-                      (OBJECT_FILLING) fill_type,
+                      (LeptonFillType) fill_type,
                       fill_width,
                       pitch1,
                       angle1,
@@ -274,7 +274,7 @@ lepton_path_object_to_buffer (const LeptonObject *object)
   int num_lines;
   LeptonLineCapType line_end;
   LeptonLineType line_type;
-  OBJECT_FILLING fill_type;
+  LeptonFillType fill_type;
   int fill_width, angle1, pitch1, angle2, pitch2;
   char *path_string;
 

--- a/liblepton/src/path_object.c
+++ b/liblepton/src/path_object.c
@@ -78,13 +78,13 @@ lepton_path_object_new (char type,
  *
  *  \param [in]     type         Must be OBJ_PATH.
  *  \param [in]     color        The path color.
- *  \param [in]     path_data    The #PATH data structure to use.
+ *  \param [in]     path_data    The #LeptonPath data structure to use.
  *  \return A pointer to the new end of the object list.
  */
 LeptonObject*
 lepton_path_object_new_take_path (char type,
                                   int color,
-                                  PATH *path_data)
+                                  LeptonPath *path_data)
 {
   LeptonObject *new_node;
 

--- a/liblepton/src/picture_object.c
+++ b/liblepton/src/picture_object.c
@@ -579,7 +579,7 @@ LeptonObject *o_picture_new (const gchar *file_content,
                        int embedded)
 {
   LeptonObject *new_node;
-  PICTURE *picture;
+  LeptonPicture *picture;
 
   /* create the object */
   new_node = s_basic_new_object(type, "picture");
@@ -1004,12 +1004,12 @@ LeptonObject*
 o_picture_copy (LeptonObject *object)
 {
   LeptonObject *new_node;
-  PICTURE *picture;
+  LeptonPicture *picture;
 
   /* create the object */
   new_node = s_basic_new_object (lepton_object_get_type (object), "picture");
 
-  picture = (PICTURE*) g_malloc (sizeof(PICTURE));
+  picture = (LeptonPicture*) g_malloc (sizeof (LeptonPicture));
   new_node->picture = picture;
 
   lepton_object_set_color (new_node, lepton_object_get_color (object));

--- a/liblepton/src/s_conn.c
+++ b/liblepton/src/s_conn.c
@@ -52,12 +52,17 @@
  *
  *  \return The new connection object
  */
-CONN *s_conn_return_new(LeptonObject * other_object, int type, int x, int y,
-                        int whichone, int other_whichone)
+LeptonConn*
+s_conn_return_new (LeptonObject *other_object,
+                   int type,
+                   int x,
+                   int y,
+                   int whichone,
+                   int other_whichone)
 {
-  CONN *new_conn;
+  LeptonConn *new_conn;
 
-  new_conn = (CONN *) g_malloc(sizeof(CONN));
+  new_conn = (LeptonConn *) g_malloc(sizeof(LeptonConn));
 
 #if DEBUG
   printf("** creating: %s %d %d\n", other_object->name, x, y);
@@ -79,16 +84,18 @@ CONN *s_conn_return_new(LeptonObject * other_object, int type, int x, int y,
  *  in the list of connections.
  *  \param conn_list list of connection objects
  *  \param input_conn single connection object.
- *  \return TRUE if the CONN structure is unique, FALSE otherwise.
+ *  \return TRUE if the LeptonConn structure is unique, FALSE otherwise.
  */
-int s_conn_uniq(GList * conn_list, CONN * input_conn)
+int
+s_conn_uniq (GList * conn_list,
+             LeptonConn * input_conn)
 {
   GList *c_current;
-  CONN *conn;
+  LeptonConn *conn;
 
   c_current = conn_list;
   while (c_current != NULL) {
-    conn = (CONN *) c_current->data;
+    conn = (LeptonConn *) c_current->data;
 
     if (conn->other_object == input_conn->other_object &&
         conn->x == input_conn->x && conn->y == input_conn->y &&
@@ -116,13 +123,13 @@ s_conn_remove_other (LeptonObject *other_object,
                      LeptonObject *to_remove)
 {
   GList *c_current = NULL;
-  CONN *conn = NULL;
+  LeptonConn *conn = NULL;
 
   o_emit_pre_change_notify (other_object);
 
   c_current = other_object->conn_list;
   while (c_current != NULL) {
-    conn = (CONN *) c_current->data;
+    conn = (LeptonConn *) c_current->data;
 
     if (conn->other_object == to_remove) {
       other_object->conn_list =
@@ -170,7 +177,7 @@ void
 s_conn_remove_object_connections (LeptonObject *to_remove)
 {
   GList *c_iter;
-  CONN *conn;
+  LeptonConn *conn;
   GList *iter;
   LeptonObject *o_current;
 
@@ -181,7 +188,7 @@ s_conn_remove_object_connections (LeptonObject *to_remove)
       for (c_iter = to_remove->conn_list;
            c_iter != NULL;
            c_iter = g_list_next (c_iter)) {
-        conn = (CONN *) c_iter->data;
+        conn = (LeptonConn *) c_iter->data;
 
         /* keep calling this till it returns false (all refs removed) */
         /* there is NO body to this while loop */
@@ -315,8 +322,8 @@ static void add_connection (LeptonObject *object, LeptonObject *other_object,
                             int whichone, int other_whichone)
 {
   /* Describe the connection */
-  CONN *new_conn = s_conn_return_new (other_object, type, x, y,
-                                      whichone, other_whichone);
+  LeptonConn *new_conn =
+    s_conn_return_new (other_object, type, x, y, whichone, other_whichone);
   /* Do uniqness check */
   if (s_conn_uniq (object->conn_list, new_conn)) {
     object->conn_list = g_list_append (object->conn_list, new_conn);
@@ -527,14 +534,14 @@ s_conn_update_object (LeptonPage* page,
  */
 void s_conn_print(GList * conn_list)
 {
-  CONN *conn;
+  LeptonConn *conn;
   GList *cl_current;
 
   printf("\nStarting s_conn_print\n");
   cl_current = conn_list;
   while (cl_current != NULL) {
 
-    conn = (CONN *) cl_current->data;
+    conn = (LeptonConn *) cl_current->data;
     printf("-----------------------------------\n");
     printf("other object: %s\n", conn->other_object->name);
     printf("type: %d\n", conn->type);
@@ -561,13 +568,13 @@ void s_conn_print(GList * conn_list)
  */
 int s_conn_net_search(LeptonObject* new_net, int whichone, GList * conn_list)
 {
-  CONN *conn;
+  LeptonConn *conn;
   GList *cl_current;
 
   cl_current = conn_list;
   while (cl_current != NULL) {
 
-    conn = (CONN *) cl_current->data;
+    conn = (LeptonConn *) cl_current->data;
     if (conn != NULL && conn->whichone == whichone &&
         conn->x == new_net->line->x[whichone] &&
         conn->y == new_net->line->y[whichone])
@@ -639,7 +646,7 @@ GList *s_conn_return_others(GList *input_list, LeptonObject *object)
     case OBJ_BUS:
       for (c_iter = object->conn_list;
            c_iter != NULL; c_iter = g_list_next (c_iter)) {
-        CONN *conn = (CONN *) c_iter->data;
+        LeptonConn *conn = (LeptonConn *) c_iter->data;
 
         if (conn->other_object && conn->other_object != object) {
           return_list = g_list_append(return_list, conn->other_object);

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -1959,7 +1959,7 @@ SCM_DEFINE (path_insert_x, "%path-insert", 3, 6, 0,
   SCM_ASSERT (scm_is_symbol (type_s), type_s, SCM_ARG3, s_path_insert_x);
 
   LeptonObject *obj = edascm_to_object (obj_s);
-  PATH *path = obj->path;
+  LeptonPath *path = obj->path;
   LeptonPathSection section = {(PATH_CODE) 0, 0, 0, 0, 0, 0, 0};
 
   /* Check & extract path element type. */

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -515,7 +515,7 @@ SCM_DEFINE (object_fill, "%object-fill", 1, 0, 0,
   LeptonObject *obj = edascm_to_object (obj_s);
 
   int type, width, pitch1, angle1, pitch2, angle2;
-  o_get_fill_options (obj, (OBJECT_FILLING *) &type, &width, &pitch1, &angle1,
+  o_get_fill_options (obj, (LeptonFillType *) &type, &width, &pitch1, &angle1,
                       &pitch2, &angle2);
 
   SCM width_s = scm_from_int (width);
@@ -635,7 +635,7 @@ SCM_DEFINE (set_object_fill_x, "%set-object-fill!", 2, 5, 0,
   }
 
   o_set_fill_options (obj,
-                      (OBJECT_FILLING) type,
+                      (LeptonFillType) type,
                       width,
                       space1,
                       angle1,

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -1832,7 +1832,7 @@ SCM_DEFINE (path_ref, "%path-ref", 2, 0, 0,
     scm_out_of_range (s_path_ref, index_s);
   }
 
-  PATH_SECTION *section = &obj->path->sections[idx];
+  LeptonPathSection *section = &obj->path->sections[idx];
 
   switch (section->code) {
   case PATH_MOVETO:
@@ -1905,7 +1905,7 @@ SCM_DEFINE (path_remove_x, "%path-remove!", 2, 0, 0,
      * location down. */
     memmove (&obj->path->sections[idx],
              &obj->path->sections[idx+1],
-             sizeof (PATH_SECTION) * (obj->path->num_sections - idx - 1));
+             sizeof (LeptonPathSection) * (obj->path->num_sections - idx - 1));
     obj->path->num_sections--;
   }
 
@@ -1960,7 +1960,7 @@ SCM_DEFINE (path_insert_x, "%path-insert", 3, 6, 0,
 
   LeptonObject *obj = edascm_to_object (obj_s);
   PATH *path = obj->path;
-  PATH_SECTION section = {(PATH_CODE) 0, 0, 0, 0, 0, 0, 0};
+  LeptonPathSection section = {(PATH_CODE) 0, 0, 0, 0, 0, 0, 0};
 
   /* Check & extract path element type. */
   if      (scm_is_eq (type_s, closepath_sym)) { section.code = PATH_END;     }
@@ -2006,8 +2006,10 @@ SCM_DEFINE (path_insert_x, "%path-insert", 3, 6, 0,
 
   /* Make sure there's enough space for the new element */
   if (path->num_sections == path->num_sections_max) {
-    path->sections = (PATH_SECTION*) g_realloc (path->sections,
-                                                (path->num_sections_max <<= 1) * sizeof (PATH_SECTION));
+    path->sections =
+      (LeptonPathSection*) g_realloc (path->sections,
+                                      (path->num_sections_max <<= 1) *
+                                      sizeof (LeptonPathSection));
   }
 
   /* Move path contents to make a gap in the right place. */
@@ -2017,7 +2019,7 @@ SCM_DEFINE (path_insert_x, "%path-insert", 3, 6, 0,
     idx = path->num_sections;
   } else {
     memmove (&path->sections[idx+1], &path->sections[idx],
-             sizeof (PATH_SECTION) * (path->num_sections - idx));
+             sizeof (LeptonPathSection) * (path->num_sections - idx));
   }
 
   path->num_sections++;

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -344,7 +344,7 @@ SCM_DEFINE (object_stroke, "%object-stroke", 1, 0, 0,
   LeptonObject *obj = edascm_to_object (obj_s);
 
   int end, type, width, length, space;
-  o_get_line_options (obj, (OBJECT_END *) &end, (LeptonLineType *) &type, &width,
+  o_get_line_options (obj, (LeptonLineCapType *) &end, (LeptonLineType *) &type, &width,
                       &length, &space);
 
   SCM width_s = scm_from_int (width);
@@ -475,7 +475,7 @@ SCM_DEFINE (set_object_stroke_x, "%set-object-stroke!", 4, 2, 0,
   }
 
   o_set_line_options (obj,
-                      (OBJECT_END) cap,
+                      (LeptonLineCapType) cap,
                       (LeptonLineType) type,
                       width,
                       length,

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -344,7 +344,7 @@ SCM_DEFINE (object_stroke, "%object-stroke", 1, 0, 0,
   LeptonObject *obj = edascm_to_object (obj_s);
 
   int end, type, width, length, space;
-  o_get_line_options (obj, (OBJECT_END *) &end, (OBJECT_TYPE *) &type, &width,
+  o_get_line_options (obj, (OBJECT_END *) &end, (LeptonLineType *) &type, &width,
                       &length, &space);
 
   SCM width_s = scm_from_int (width);
@@ -476,7 +476,7 @@ SCM_DEFINE (set_object_stroke_x, "%set-object-stroke!", 4, 2, 0,
 
   o_set_line_options (obj,
                       (OBJECT_END) cap,
-                      (OBJECT_TYPE) type,
+                      (LeptonLineType) type,
                       width,
                       length,
                       space);

--- a/liblepton/src/text_object.c
+++ b/liblepton/src/text_object.c
@@ -348,7 +348,7 @@ update_disp_string (LeptonObject *object)
 {
   char *name = NULL;
   char *value = NULL;
-  TEXT *text = object->text;
+  LeptonText *text = object->text;
 
   g_free (text->disp_string);
 
@@ -421,13 +421,13 @@ lepton_text_object_new (gint color,
                         gint show_name_value)
 {
   LeptonObject *new_node=NULL;
-  TEXT *text;
+  LeptonText *text;
 
   g_return_val_if_fail (string != NULL, NULL);
 
   new_node = s_basic_new_object (OBJ_TEXT, "text");
 
-  text = (TEXT *) g_malloc(sizeof(TEXT));
+  text = (LeptonText *) g_malloc (sizeof (LeptonText));
 
   text->string = g_strdup (string);
   text->disp_string = NULL; /* We'll fix this up later */

--- a/liblepton/src/transform.c
+++ b/liblepton/src/transform.c
@@ -156,7 +156,7 @@ lepton_transform_point (LeptonTransform *transform,
 /*! \brief Transforms a polyline or polygon
  *
  *  \param transform [in] The transform function.
- *  \param points [inout] The GArray of sPOINT to transform.
+ *  \param points [inout] The GArray of LeptonPoint to transform.
  */
 void
 lepton_transform_points (LeptonTransform *transform,
@@ -168,7 +168,7 @@ lepton_transform_points (LeptonTransform *transform,
   g_return_if_fail(points!=NULL);
 
   for (index=0; index<points->len; index++) {
-    sPOINT *point = &g_array_index(points, sPOINT, index);
+    LeptonPoint *point = &g_array_index(points, LeptonPoint, index);
     lepton_transform_point(transform, &(point->x), &(point->y));
   }
 }

--- a/liblepton/src/undo.c
+++ b/liblepton/src/undo.c
@@ -38,10 +38,11 @@
  *  \par Function Description
  *
  */
-UNDO *s_undo_return_tail(UNDO *head)
+LeptonUndo*
+s_undo_return_tail (LeptonUndo *head)
 {
-  UNDO *u_current=NULL;
-  UNDO *ret_struct=NULL;
+  LeptonUndo *u_current=NULL;
+  LeptonUndo *ret_struct=NULL;
 
   u_current = head;
   while ( u_current != NULL ) { /* goto end of list */
@@ -57,10 +58,11 @@ UNDO *s_undo_return_tail(UNDO *head)
  *  \par Function Description
  *
  */
-UNDO *s_undo_return_head(UNDO *tail)
+LeptonUndo*
+s_undo_return_head(LeptonUndo *tail)
 {
-  UNDO *u_current=NULL;
-  UNDO *ret_struct=NULL;
+  LeptonUndo *u_current=NULL;
+  LeptonUndo *ret_struct=NULL;
 
   u_current = tail;
   while ( u_current != NULL ) { /* goto end of list */
@@ -76,11 +78,12 @@ UNDO *s_undo_return_head(UNDO *tail)
  *  \par Function Description
  *
  */
-UNDO *s_undo_new_head(void)
+LeptonUndo*
+s_undo_new_head(void)
 {
-  UNDO *u_new;
+  LeptonUndo *u_new;
 
-  u_new = (UNDO *) g_malloc(sizeof(UNDO));
+  u_new = (LeptonUndo *) g_malloc (sizeof (LeptonUndo));
   u_new->type = -1;
   u_new->filename = NULL;
   u_new->object_list = NULL;
@@ -101,7 +104,8 @@ UNDO *s_undo_new_head(void)
  *  \par Function Description
  *
  */
-void s_undo_destroy_head(UNDO *u_head)
+void
+s_undo_destroy_head (LeptonUndo *u_head)
 {
   g_free(u_head);
 }
@@ -111,13 +115,21 @@ void s_undo_destroy_head(UNDO *u_head)
  *  \par Function Description
  *
  */
-UNDO *s_undo_add (UNDO *head, int type, char *filename, GList *object_list,
-                  int x, int y, double scale, int page_control, int up)
+LeptonUndo*
+s_undo_add (LeptonUndo *head,
+            int type,
+            char *filename,
+            GList *object_list,
+            int x,
+            int y,
+            double scale,
+            int page_control,
+            int up)
 {
-  UNDO *tail;
-  UNDO *u_new;
+  LeptonUndo *tail;
+  LeptonUndo *u_new;
 
-  u_new = (UNDO *) g_malloc(sizeof(UNDO));
+  u_new = (LeptonUndo *) g_malloc (sizeof (LeptonUndo));
 
   u_new->filename = g_strdup (filename);
 
@@ -150,9 +162,10 @@ UNDO *s_undo_add (UNDO *head, int type, char *filename, GList *object_list,
  *  \par Function Description
  *
  */
-void s_undo_print_all( UNDO *head )
+void
+s_undo_print_all (LeptonUndo *head)
 {
-  UNDO *u_current;
+  LeptonUndo *u_current;
 
   u_current = head;
 
@@ -182,10 +195,10 @@ void s_undo_print_all( UNDO *head )
  *
  */
 void
-s_undo_destroy_all (UNDO *head)
+s_undo_destroy_all (LeptonUndo *head)
 {
-  UNDO *u_current;
-  UNDO *u_prev;
+  LeptonUndo *u_current;
+  LeptonUndo *u_prev;
 
   u_current = s_undo_return_tail(head);
 
@@ -210,10 +223,10 @@ s_undo_destroy_all (UNDO *head)
  *
  */
 void
-s_undo_remove_rest (UNDO *head)
+s_undo_remove_rest (LeptonUndo *head)
 {
-  UNDO *u_current;
-  UNDO *u_next;
+  LeptonUndo *u_current;
+  LeptonUndo *u_next;
 
   u_current = head;
 
@@ -240,9 +253,10 @@ s_undo_remove_rest (UNDO *head)
  *  \par Function Description
  *
  */
-int s_undo_levels(UNDO *head)
+int
+s_undo_levels (LeptonUndo *head)
 {
-  UNDO *u_current;
+  LeptonUndo *u_current;
   int count = 0;
 
   u_current = head;

--- a/libleptongui/include/gschem_fill_swatch_cell_renderer.h
+++ b/libleptongui/include/gschem_fill_swatch_cell_renderer.h
@@ -40,7 +40,7 @@ struct _GschemFillSwatchCellRenderer
   GtkCellRendererText parent;
 
   gboolean enabled;
-  OBJECT_FILLING fill_type;
+  LeptonFillType fill_type;
 };
 
 GType

--- a/libleptongui/include/gschem_selection_adapter.h
+++ b/libleptongui/include/gschem_selection_adapter.h
@@ -51,7 +51,7 @@ struct _GschemSelectionAdapter
 {
   GObject parent;
 
-  SELECTION *selection;
+  LeptonSelection *selection;
   LeptonToplevel *toplevel;
 };
 
@@ -97,7 +97,7 @@ gschem_selection_adapter_get_object_color (GschemSelectionAdapter *adapter);
 int
 gschem_selection_adapter_get_pin_type (GschemSelectionAdapter *adapter);
 
-SELECTION *
+LeptonSelection *
 gschem_selection_adapter_get_selection (GschemSelectionAdapter *adapter);
 
 int
@@ -161,7 +161,8 @@ void
 gschem_selection_adapter_set_pin_type (GschemSelectionAdapter *adapter, int type);
 
 void
-gschem_selection_adapter_set_selection (GschemSelectionAdapter *adapter, SELECTION *selection);
+gschem_selection_adapter_set_selection (GschemSelectionAdapter *adapter,
+                                        LeptonSelection *selection);
 
 void
 gschem_selection_adapter_set_text_color (GschemSelectionAdapter *adapter, int color);

--- a/libleptongui/include/gschem_toplevel.h
+++ b/libleptongui/include/gschem_toplevel.h
@@ -157,7 +157,7 @@ struct st_gschem_toplevel {
                                            Its range of values depends on the
                                            type of object being manipulated. */
   LeptonObject *which_object;           /* Object being manipulated */
-  PATH *temp_path;                      /* Path being created */
+  LeptonPath *temp_path;                /* Path being created */
   gboolean pathcontrol;                 /* Set path control point while path creating */ /* FIXME: can we do without it? */
 
   /* ------------------ */

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -201,9 +201,18 @@ void o_arc_end4(GschemToplevel *w_current, int radius, int start_angle, int swee
 void o_arc_motion(GschemToplevel *w_current, int x, int y, int whichone);
 void o_arc_draw_rubber(GschemToplevel *w_current, EdaRenderer *renderer);
 /* o_attrib.c */
-void o_attrib_add_selected(GschemToplevel *w_current, SELECTION *selection, LeptonObject *selected);
-void o_attrib_deselect_invisible(GschemToplevel *w_current, SELECTION *selection, LeptonObject *selected);
-void o_attrib_select_invisible(GschemToplevel *w_current, SELECTION *selection, LeptonObject *selected);
+void
+o_attrib_add_selected (GschemToplevel *w_current,
+                       LeptonSelection *selection,
+                       LeptonObject *selected);
+void
+o_attrib_deselect_invisible (GschemToplevel *w_current,
+                             LeptonSelection *selection,
+                             LeptonObject *selected);
+void
+o_attrib_select_invisible (GschemToplevel *w_current,
+                           LeptonSelection *selection,
+                           LeptonObject *selected);
 void o_attrib_toggle_visibility(GschemToplevel *w_current, LeptonObject *object);
 void o_attrib_toggle_show_name_value(GschemToplevel *w_current, LeptonObject *object, int new_show_name_value);
 LeptonObject *o_attrib_add_attrib(GschemToplevel *w_current, const char *text_string, int visibility, int show_name_value, LeptonObject *object);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -399,8 +399,13 @@ o_undo_savestate (GschemToplevel *w_current,
                   LeptonPage *page,
                   int flag);
 void o_undo_savestate_old(GschemToplevel *w_current, int flag);
-char *o_undo_find_prev_filename(UNDO *start);
-GList *o_undo_find_prev_object_head(UNDO *start);
+
+char*
+o_undo_find_prev_filename (LeptonUndo *start);
+
+GList*
+o_undo_find_prev_object_head (LeptonUndo *start);
+
 void
 o_undo_callback (GschemToplevel *w_current,
                  LeptonPage *page,

--- a/libleptongui/src/gschem_fill_swatch_cell_renderer.c
+++ b/libleptongui/src/gschem_fill_swatch_cell_renderer.c
@@ -306,7 +306,7 @@ render (GtkCellRenderer      *cell,
 
     if (lepton_fill_type_draw_first_hatch (swatch->fill_type))
     {
-      BOX box;
+      LeptonBox box;
       guint index;
       GArray *lines = g_array_new (FALSE, FALSE, sizeof (LeptonLine));
       cairo_path_t *save_path = cairo_copy_path (cr);

--- a/libleptongui/src/gschem_fill_swatch_cell_renderer.c
+++ b/libleptongui/src/gschem_fill_swatch_cell_renderer.c
@@ -379,7 +379,7 @@ set_property (GObject      *object,
       break;
 
     case PROP_FILL_TYPE:
-      swatch->fill_type =  (OBJECT_FILLING) g_value_get_int (value);
+      swatch->fill_type =  (LeptonFillType) g_value_get_int (value);
       break;
 
     default:

--- a/libleptongui/src/gschem_selection_adapter.c
+++ b/libleptongui/src/gschem_selection_adapter.c
@@ -100,7 +100,7 @@ gschem_selection_adapter_get_cap_style (GschemSelectionAdapter *adapter)
   while (iter != NULL) {
     LeptonObject *object = (LeptonObject*) iter->data;
     gboolean success;
-    OBJECT_END temp_cap_style;
+    LeptonLineCapType temp_cap_style;
     gint temp_dash_length;
     gint temp_dash_space;
     LeptonLineType temp_line_type;
@@ -148,7 +148,7 @@ gschem_selection_adapter_get_dash_length (GschemSelectionAdapter *adapter)
   while (iter != NULL) {
     LeptonObject *object = (LeptonObject*) iter->data;
     gboolean success;
-    OBJECT_END temp_cap_style;
+    LeptonLineCapType temp_cap_style;
     gint temp_dash_length;
     gint temp_dash_space;
     LeptonLineType temp_line_type;
@@ -196,7 +196,7 @@ gschem_selection_adapter_get_dash_space (GschemSelectionAdapter *adapter)
   while (iter != NULL) {
     LeptonObject *object = (LeptonObject*) iter->data;
     gboolean success;
-    OBJECT_END temp_cap_style;
+    LeptonLineCapType temp_cap_style;
     gint temp_dash_length;
     gint temp_dash_space;
     LeptonLineType temp_line_type;
@@ -550,7 +550,7 @@ gschem_selection_adapter_get_line_type (GschemSelectionAdapter *adapter)
   while (iter != NULL) {
     LeptonObject *object = (LeptonObject*) iter->data;
     gboolean success;
-    OBJECT_END temp_cap_style;
+    LeptonLineCapType temp_cap_style;
     gint temp_dash_length;
     gint temp_dash_space;
     LeptonLineType temp_line_type;
@@ -598,7 +598,7 @@ gschem_selection_adapter_get_line_width (GschemSelectionAdapter *adapter)
   while (iter != NULL) {
     LeptonObject *object = (LeptonObject*) iter->data;
     gboolean success;
-    OBJECT_END temp_cap_style;
+    LeptonLineCapType temp_cap_style;
     gint temp_dash_length;
     gint temp_dash_space;
     LeptonLineType temp_line_type;
@@ -1383,7 +1383,7 @@ gschem_selection_adapter_set_line_type (GschemSelectionAdapter *adapter, int lin
   while (iter != NULL) {
     LeptonObject *object = (LeptonObject*) iter->data;
     gboolean success;
-    OBJECT_END temp_cap_style;
+    LeptonLineCapType temp_cap_style;
     int temp_dash_length;
     int temp_dash_space;
     LeptonLineType temp_line_type;
@@ -1442,7 +1442,7 @@ gschem_selection_adapter_set_line_width (GschemSelectionAdapter *adapter, int li
   while (iter != NULL) {
     LeptonObject *object = (LeptonObject*) iter->data;
     gboolean success;
-    OBJECT_END temp_cap_style;
+    LeptonLineCapType temp_cap_style;
     int temp_dash_length;
     int temp_dash_space;
     LeptonLineType temp_line_type;
@@ -1499,7 +1499,7 @@ gschem_selection_adapter_set_dash_length (GschemSelectionAdapter *adapter, int d
   while (iter != NULL) {
     LeptonObject *object = (LeptonObject*) iter->data;
     gboolean success;
-    OBJECT_END temp_cap_style;
+    LeptonLineCapType temp_cap_style;
     int temp_dash_length;
     int temp_dash_space;
     LeptonLineType temp_line_type;
@@ -1556,7 +1556,7 @@ gschem_selection_adapter_set_dash_space (GschemSelectionAdapter *adapter, int da
   while (iter != NULL) {
     LeptonObject *object = (LeptonObject*) iter->data;
     gboolean success;
-    OBJECT_END temp_cap_style;
+    LeptonLineCapType temp_cap_style;
     int temp_dash_length;
     int temp_dash_space;
     LeptonLineType temp_line_type;
@@ -1613,7 +1613,7 @@ gschem_selection_adapter_set_cap_style (GschemSelectionAdapter *adapter, int cap
   while (iter != NULL) {
     LeptonObject *object = (LeptonObject*) iter->data;
     gboolean success;
-    OBJECT_END temp_cap_style;
+    LeptonLineCapType temp_cap_style;
     int temp_dash_length;
     int temp_dash_space;
     LeptonLineType temp_line_type;
@@ -1628,7 +1628,7 @@ gschem_selection_adapter_set_cap_style (GschemSelectionAdapter *adapter, int cap
 
     if (success) {
       o_set_line_options (object,
-                          (OBJECT_END) cap_style,
+                          (LeptonLineCapType) cap_style,
                           temp_line_type,
                           temp_line_width,
                           temp_dash_length,

--- a/libleptongui/src/gschem_selection_adapter.c
+++ b/libleptongui/src/gschem_selection_adapter.c
@@ -246,7 +246,7 @@ gschem_selection_adapter_get_fill_angle1 (GschemSelectionAdapter *adapter)
     gboolean success;
     gint temp_angle1;
     gint temp_angle2;
-    OBJECT_FILLING temp_fill_type;
+    LeptonFillType temp_fill_type;
     gint temp_pitch1;
     gint temp_pitch2;
     gint temp_width;
@@ -297,7 +297,7 @@ gschem_selection_adapter_get_fill_angle2 (GschemSelectionAdapter *adapter)
     gboolean success;
     gint temp_angle1;
     gint temp_angle2;
-    OBJECT_FILLING temp_fill_type;
+    LeptonFillType temp_fill_type;
     gint temp_pitch1;
     gint temp_pitch2;
     gint temp_width;
@@ -348,7 +348,7 @@ gschem_selection_adapter_get_fill_pitch1 (GschemSelectionAdapter *adapter)
     gboolean success;
     gint temp_angle1;
     gint temp_angle2;
-    OBJECT_FILLING temp_fill_type;
+    LeptonFillType temp_fill_type;
     gint temp_pitch1;
     gint temp_pitch2;
     gint temp_width;
@@ -399,7 +399,7 @@ gschem_selection_adapter_get_fill_pitch2 (GschemSelectionAdapter *adapter)
     gboolean success;
     gint temp_angle1;
     gint temp_angle2;
-    OBJECT_FILLING temp_fill_type;
+    LeptonFillType temp_fill_type;
     gint temp_pitch1;
     gint temp_pitch2;
     gint temp_width;
@@ -450,7 +450,7 @@ gschem_selection_adapter_get_fill_type (GschemSelectionAdapter *adapter)
     gboolean success;
     gint temp_angle1;
     gint temp_angle2;
-    OBJECT_FILLING temp_fill_type;
+    LeptonFillType temp_fill_type;
     gint temp_pitch1;
     gint temp_pitch2;
     gint temp_width;
@@ -501,7 +501,7 @@ gschem_selection_adapter_get_fill_width (GschemSelectionAdapter *adapter)
     gboolean success;
     gint temp_angle1;
     gint temp_angle2;
-    OBJECT_FILLING temp_fill_type;
+    LeptonFillType temp_fill_type;
     gint temp_pitch1;
     gint temp_pitch2;
     gint temp_width;
@@ -1020,7 +1020,7 @@ gschem_selection_adapter_set_fill_angle1 (GschemSelectionAdapter *adapter, int a
     gboolean success;
     gint temp_angle1;
     gint temp_angle2;
-    OBJECT_FILLING temp_fill_type;
+    LeptonFillType temp_fill_type;
     gint temp_pitch1;
     gint temp_pitch2;
     gint temp_width;
@@ -1079,7 +1079,7 @@ gschem_selection_adapter_set_fill_angle2 (GschemSelectionAdapter *adapter, int a
     gboolean success;
     gint temp_angle1;
     gint temp_angle2;
-    OBJECT_FILLING temp_fill_type;
+    LeptonFillType temp_fill_type;
     gint temp_pitch1;
     gint temp_pitch2;
     gint temp_width;
@@ -1140,7 +1140,7 @@ gschem_selection_adapter_set_fill_pitch1 (GschemSelectionAdapter *adapter, int p
     gboolean success;
     gint temp_angle1;
     gint temp_angle2;
-    OBJECT_FILLING temp_fill_type;
+    LeptonFillType temp_fill_type;
     gint temp_pitch1;
     gint temp_pitch2;
     gint temp_width;
@@ -1199,7 +1199,7 @@ gschem_selection_adapter_set_fill_pitch2 (GschemSelectionAdapter *adapter, int p
     gboolean success;
     gint temp_angle1;
     gint temp_angle2;
-    OBJECT_FILLING temp_fill_type;
+    LeptonFillType temp_fill_type;
     gint temp_pitch1;
     gint temp_pitch2;
     gint temp_width;
@@ -1260,7 +1260,7 @@ gschem_selection_adapter_set_fill_type (GschemSelectionAdapter *adapter, int fil
     gboolean success;
     gint temp_angle1;
     gint temp_angle2;
-    OBJECT_FILLING temp_fill_type;
+    LeptonFillType temp_fill_type;
     gint temp_pitch1;
     gint temp_pitch2;
     gint temp_width;
@@ -1275,7 +1275,7 @@ gschem_selection_adapter_set_fill_type (GschemSelectionAdapter *adapter, int fil
 
     if (success) {
       o_set_fill_options (object,
-                          (OBJECT_FILLING) fill_type,
+                          (LeptonFillType) fill_type,
                           temp_width,
                           temp_pitch1,
                           temp_angle1,
@@ -1325,7 +1325,7 @@ gschem_selection_adapter_set_fill_width (GschemSelectionAdapter *adapter, int fi
     gboolean success;
     gint temp_angle1;
     gint temp_angle2;
-    OBJECT_FILLING temp_fill_type;
+    LeptonFillType temp_fill_type;
     gint temp_pitch1;
     gint temp_pitch2;
     gint temp_width;

--- a/libleptongui/src/gschem_selection_adapter.c
+++ b/libleptongui/src/gschem_selection_adapter.c
@@ -734,7 +734,7 @@ gschem_selection_adapter_get_pin_type (GschemSelectionAdapter *adapter)
  *  \param [in] adapter This adapter
  *  \return The libgeda selection
  */
-SELECTION*
+LeptonSelection*
 gschem_selection_adapter_get_selection (GschemSelectionAdapter *adapter)
 {
   g_return_val_if_fail (adapter != NULL, NULL);
@@ -1708,7 +1708,8 @@ gschem_selection_adapter_set_pin_type (GschemSelectionAdapter *adapter, int type
  *  \param [in] selection
  */
 void
-gschem_selection_adapter_set_selection (GschemSelectionAdapter *adapter, SELECTION *selection)
+gschem_selection_adapter_set_selection (GschemSelectionAdapter *adapter,
+                                        LeptonSelection *selection)
 {
   g_return_if_fail (adapter != NULL);
 
@@ -2181,7 +2182,7 @@ static GList*
 get_selection_iter (GschemSelectionAdapter *adapter)
 {
   GList *iter = NULL;
-  SELECTION *selection = gschem_selection_adapter_get_selection (adapter);
+  LeptonSelection *selection = gschem_selection_adapter_get_selection (adapter);
 
   if (selection != NULL) {
     iter = lepton_list_get_glist (selection);

--- a/libleptongui/src/gschem_selection_adapter.c
+++ b/libleptongui/src/gschem_selection_adapter.c
@@ -103,7 +103,7 @@ gschem_selection_adapter_get_cap_style (GschemSelectionAdapter *adapter)
     OBJECT_END temp_cap_style;
     gint temp_dash_length;
     gint temp_dash_space;
-    OBJECT_TYPE temp_line_type;
+    LeptonLineType temp_line_type;
     gint temp_line_width;
 
     success = o_get_line_options (object,
@@ -151,7 +151,7 @@ gschem_selection_adapter_get_dash_length (GschemSelectionAdapter *adapter)
     OBJECT_END temp_cap_style;
     gint temp_dash_length;
     gint temp_dash_space;
-    OBJECT_TYPE temp_line_type;
+    LeptonLineType temp_line_type;
     gint temp_line_width;
 
     success = o_get_line_options (object,
@@ -199,7 +199,7 @@ gschem_selection_adapter_get_dash_space (GschemSelectionAdapter *adapter)
     OBJECT_END temp_cap_style;
     gint temp_dash_length;
     gint temp_dash_space;
-    OBJECT_TYPE temp_line_type;
+    LeptonLineType temp_line_type;
     gint temp_line_width;
 
     success = o_get_line_options (object,
@@ -553,7 +553,7 @@ gschem_selection_adapter_get_line_type (GschemSelectionAdapter *adapter)
     OBJECT_END temp_cap_style;
     gint temp_dash_length;
     gint temp_dash_space;
-    OBJECT_TYPE temp_line_type;
+    LeptonLineType temp_line_type;
     gint temp_line_width;
 
     success = o_get_line_options (object,
@@ -601,7 +601,7 @@ gschem_selection_adapter_get_line_width (GschemSelectionAdapter *adapter)
     OBJECT_END temp_cap_style;
     gint temp_dash_length;
     gint temp_dash_space;
-    OBJECT_TYPE temp_line_type;
+    LeptonLineType temp_line_type;
     gint temp_line_width;
 
     success = o_get_line_options (object,
@@ -1386,7 +1386,7 @@ gschem_selection_adapter_set_line_type (GschemSelectionAdapter *adapter, int lin
     OBJECT_END temp_cap_style;
     int temp_dash_length;
     int temp_dash_space;
-    OBJECT_TYPE temp_line_type;
+    LeptonLineType temp_line_type;
     int temp_line_width;
 
     success = o_get_line_options (object,
@@ -1399,7 +1399,7 @@ gschem_selection_adapter_set_line_type (GschemSelectionAdapter *adapter, int lin
     if (success) {
       o_set_line_options (object,
                           temp_cap_style,
-                          (OBJECT_TYPE) line_type,
+                          (LeptonLineType) line_type,
                           temp_line_width,
                           temp_dash_length,
                           temp_dash_space);
@@ -1445,7 +1445,7 @@ gschem_selection_adapter_set_line_width (GschemSelectionAdapter *adapter, int li
     OBJECT_END temp_cap_style;
     int temp_dash_length;
     int temp_dash_space;
-    OBJECT_TYPE temp_line_type;
+    LeptonLineType temp_line_type;
     int temp_line_width;
 
     success = o_get_line_options (object,
@@ -1502,7 +1502,7 @@ gschem_selection_adapter_set_dash_length (GschemSelectionAdapter *adapter, int d
     OBJECT_END temp_cap_style;
     int temp_dash_length;
     int temp_dash_space;
-    OBJECT_TYPE temp_line_type;
+    LeptonLineType temp_line_type;
     int temp_line_width;
 
     success = o_get_line_options (object,
@@ -1559,7 +1559,7 @@ gschem_selection_adapter_set_dash_space (GschemSelectionAdapter *adapter, int da
     OBJECT_END temp_cap_style;
     int temp_dash_length;
     int temp_dash_space;
-    OBJECT_TYPE temp_line_type;
+    LeptonLineType temp_line_type;
     int temp_line_width;
 
     success = o_get_line_options (object,
@@ -1616,7 +1616,7 @@ gschem_selection_adapter_set_cap_style (GschemSelectionAdapter *adapter, int cap
     OBJECT_END temp_cap_style;
     int temp_dash_length;
     int temp_dash_space;
-    OBJECT_TYPE temp_line_type;
+    LeptonLineType temp_line_type;
     int temp_line_width;
 
     success = o_get_line_options (object,

--- a/libleptongui/src/i_basic.c
+++ b/libleptongui/src/i_basic.c
@@ -355,7 +355,7 @@ obj_selected (LeptonPage *page,
               int type)
 {
   LeptonObject* result = FALSE;
-  SELECTION* selection = page->selection_list;
+  LeptonSelection* selection = page->selection_list;
 
   GList* gl = lepton_list_get_glist (selection);
   for ( ; gl != NULL; gl = g_list_next (gl) )

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -2317,7 +2317,7 @@ i_callback_attributes_show_name (GtkWidget *widget, gpointer data)
   }
 
   if (o_select_selected (w_current)) {
-    SELECTION *selection = toplevel->page_current->selection_list;
+    LeptonSelection *selection = toplevel->page_current->selection_list;
     GList *s_current;
 
     for (s_current = lepton_list_get_glist (selection);
@@ -2352,7 +2352,7 @@ i_callback_attributes_show_value (GtkWidget *widget, gpointer data)
   }
 
   if (o_select_selected (w_current)) {
-    SELECTION *selection = toplevel->page_current->selection_list;
+    LeptonSelection *selection = toplevel->page_current->selection_list;
     GList *s_current;
 
     for (s_current = lepton_list_get_glist (selection);
@@ -2387,7 +2387,7 @@ i_callback_attributes_show_both (GtkWidget *widget, gpointer data)
   }
 
   if (o_select_selected (w_current)) {
-    SELECTION *selection = toplevel->page_current->selection_list;
+    LeptonSelection *selection = toplevel->page_current->selection_list;
     GList *s_current;
 
     for (s_current = lepton_list_get_glist (selection);
@@ -2422,7 +2422,7 @@ i_callback_attributes_visibility_toggle (GtkWidget *widget, gpointer data)
   }
 
   if (o_select_selected (w_current)) {
-    SELECTION *selection = toplevel->page_current->selection_list;
+    LeptonSelection *selection = toplevel->page_current->selection_list;
     GList *s_current;
 
     for (s_current = lepton_list_get_glist (selection);

--- a/libleptongui/src/m_basic.c
+++ b/libleptongui/src/m_basic.c
@@ -79,8 +79,10 @@ struct st_halfspace {
  *
  *  \warning halfspace must be allocated before this function is called
  */
-static void WORLDencode_halfspace (GschemPageGeometry *geometry,
-                                   sPOINT *point, HALFSPACE *halfspace)
+static void
+WORLDencode_halfspace (GschemPageGeometry *geometry,
+                       LeptonPoint *point,
+                       HALFSPACE *halfspace)
 {
   halfspace->left = point->x < geometry->viewport_left;
   halfspace->right = point->x > geometry->viewport_right;
@@ -105,8 +107,8 @@ int clip_nochange (GschemPageGeometry *geometry, int x1, int y1, int x2, int y2)
 {
   HALFSPACE half1, half2;
   HALFSPACE tmp_half;
-  sPOINT tmp_point;
-  sPOINT point1, point2;
+  LeptonPoint tmp_point;
+  LeptonPoint point1, point2;
   float slope;
   int in1, in2, done;
   int visible;

--- a/libleptongui/src/o_attrib.c
+++ b/libleptongui/src/o_attrib.c
@@ -51,8 +51,10 @@
  *
  *  \todo get a better name
  */
-void o_attrib_add_selected(GschemToplevel *w_current, SELECTION *selection,
-                           LeptonObject *selected)
+void
+o_attrib_add_selected (GschemToplevel *w_current,
+                       LeptonSelection *selection,
+                       LeptonObject *selected)
 {
   LeptonObject *a_current;
   GList *a_iter;
@@ -87,12 +89,13 @@ void o_attrib_add_selected(GschemToplevel *w_current, SELECTION *selection,
  *  function returns immediately.
  *
  *  \param [in]     w_current  The GschemToplevel object.
- *  \param [in,out] selection  The SELECTION list to remove from.
+ *  \param [in,out] selection  The LeptonSelection list to remove from.
  *  \param [in]     object     The LeptonObject whose invisible attributes to remove.
  */
-void o_attrib_deselect_invisible (GschemToplevel *w_current,
-                                  SELECTION *selection,
-                                  LeptonObject *selected)
+void
+o_attrib_deselect_invisible (GschemToplevel *w_current,
+                             LeptonSelection *selection,
+                             LeptonObject *selected)
 {
   LeptonObject *a_current;
   GList *a_iter;
@@ -123,12 +126,13 @@ void o_attrib_deselect_invisible (GschemToplevel *w_current,
  *  function returns immediately.
  *
  *  \param [in]     w_current  The GschemToplevel object.
- *  \param [in,out] selection  The SELECTION list to add to.
+ *  \param [in,out] selection  The LeptonSelection list to add to.
  *  \param [in]     object     The LeptonObject whose invisible attributes to add.
  */
-void o_attrib_select_invisible (GschemToplevel *w_current,
-                                  SELECTION *selection,
-                                  LeptonObject *selected)
+void
+o_attrib_select_invisible (GschemToplevel *w_current,
+                           LeptonSelection *selection,
+                           LeptonObject *selected)
 {
   LeptonObject *a_current;
   GList *a_iter;

--- a/libleptongui/src/o_basic.c
+++ b/libleptongui/src/o_basic.c
@@ -59,7 +59,7 @@ void o_redraw_rect (GschemToplevel *w_current,
   double dummy = 0.0;
   GList *obj_list;
   GList *iter;
-  BOX *world_rect;
+  LeptonBox *world_rect;
   EdaRenderer *renderer;
   int render_flags;
   GArray *render_color_map = NULL;
@@ -89,7 +89,7 @@ void o_redraw_rect (GschemToplevel *w_current,
   bloat = MAX (grip_half_size, (int)cue_half_size);
 
 
-  world_rect = g_new (BOX, 1);
+  world_rect = g_new (LeptonBox, 1);
 
 #ifdef ENABLE_GTK3
   gint wx, wy;

--- a/libleptongui/src/o_delete.c
+++ b/libleptongui/src/o_delete.c
@@ -56,7 +56,7 @@ void o_delete (GschemToplevel *w_current, LeptonObject *object)
 void o_delete_selected (GschemToplevel *w_current)
 {
   LeptonToplevel *toplevel = gschem_toplevel_get_toplevel (w_current);
-  SELECTION *selection = toplevel->page_current->selection_list;
+  LeptonSelection *selection = toplevel->page_current->selection_list;
   GList *to_remove;
   GList *iter;
   LeptonObject *obj;

--- a/libleptongui/src/o_grips.c
+++ b/libleptongui/src/o_grips.c
@@ -338,7 +338,7 @@ LeptonObject *o_grips_search_box_world(GschemToplevel *w_current, LeptonObject *
 LeptonObject *o_grips_search_path_world(GschemToplevel *w_current, LeptonObject *o_current,
                                      int x, int y, int size, int *whichone)
 {
-  PATH_SECTION *section;
+  LeptonPathSection *section;
   int i;
   int grip_no = 0;
 
@@ -661,7 +661,7 @@ static void o_grips_start_box(GschemToplevel *w_current, LeptonObject *o_current
 static void o_grips_start_path(GschemToplevel *w_current, LeptonObject *o_current,
                                int x, int y, int whichone)
 {
-  PATH_SECTION *section;
+  LeptonPathSection *section;
   int i;
   int grip_no = 0;
   int gx = -1;

--- a/libleptongui/src/o_move.c
+++ b/libleptongui/src/o_move.c
@@ -525,7 +525,7 @@ int o_move_return_whichone(LeptonObject * object, int x, int y)
 void o_move_check_endpoint(GschemToplevel *w_current, LeptonObject * object)
 {
   GList *cl_current;
-  CONN *c_current;
+  LeptonConn *c_current;
   LeptonObject *other;
   int whichone;
 
@@ -544,7 +544,7 @@ void o_move_check_endpoint(GschemToplevel *w_current, LeptonObject * object)
        cl_current != NULL;
        cl_current = g_list_next(cl_current)) {
 
-    c_current = (CONN *) cl_current->data;
+    c_current = (LeptonConn *) cl_current->data;
     other = c_current->other_object;
 
     if (other == NULL)

--- a/libleptongui/src/o_net.c
+++ b/libleptongui/src/o_net.c
@@ -763,7 +763,7 @@ int o_net_add_busrippers(GschemToplevel *w_current, LeptonObject *net_obj,
   LeptonObject *new_obj;
   GList *cl_current = NULL;
   LeptonObject *bus_object = NULL;
-  CONN *found_conn = NULL;
+  LeptonConn *found_conn = NULL;
   int done;
   int otherone;
   BUS_RIPPER rippers[2];
@@ -805,11 +805,11 @@ int o_net_add_busrippers(GschemToplevel *w_current, LeptonObject *net_obj,
       int bus_orientation = lepton_net_object_orientation (bus_object);
       int net_orientation = lepton_net_object_orientation (net_obj);
 
-      /* find the CONN structure which is associated with this object */
+      /* find the LeptonConn structure which is associated with this object */
       GList *cl_current2 = net_obj->conn_list;
       done = FALSE;
       while (cl_current2 != NULL && !done) {
-        CONN *tmp_conn = (CONN *) cl_current2->data;
+        LeptonConn *tmp_conn = (LeptonConn *) cl_current2->data;
 
         if (tmp_conn && tmp_conn->other_object &&
             tmp_conn->other_object == bus_object) {

--- a/libleptongui/src/o_path.c
+++ b/libleptongui/src/o_path.c
@@ -37,13 +37,14 @@ static PATH *path_copy_modify (PATH *path, int dx, int dy,
   int grip_no = 0;
 
   new_path = (PATH*) g_malloc (sizeof (PATH));
-  new_path->sections = (PATH_SECTION*) g_malloc (path->num_sections * sizeof (PATH_SECTION));
+  new_path->sections =
+    (LeptonPathSection*) g_malloc (path->num_sections * sizeof (LeptonPathSection));
   new_path->num_sections = path->num_sections;
   new_path->num_sections_max = path->num_sections;
 
   for (i = 0; i <  path->num_sections; i++) {
-    PATH_SECTION *section     = &path->sections[i];
-    PATH_SECTION *new_section = &new_path->sections[i];
+    LeptonPathSection *section     = &path->sections[i];
+    LeptonPathSection *new_section = &new_path->sections[i];
 
     x1 = section->x1 + dx; y1 = section->y1 + dy;
     x2 = section->x2 + dx; y2 = section->y2 + dy;
@@ -107,7 +108,7 @@ path_rubber_bbox (GschemToplevel *w_current, PATH *path,
   whichone = w_current->which_grip;
 
   for (i = 0; i <  path->num_sections; i++) {
-    PATH_SECTION *section = &path->sections[i];
+    LeptonPathSection *section = &path->sections[i];
 
     x1 = section->x1; y1 = section->y1;
     x2 = section->x2; y2 = section->y2;
@@ -158,7 +159,7 @@ path_expand (GschemToplevel *w_current)
   PATH *p = w_current->temp_path;
   if (p->num_sections == p->num_sections_max) {
     p->num_sections_max *= 2;
-    p->sections = g_renew (PATH_SECTION, p->sections,
+    p->sections = g_renew (LeptonPathSection, p->sections,
                            p->num_sections_max);
   }
 }
@@ -191,7 +192,7 @@ path_next_sections (GschemToplevel *w_current)
 {
   gboolean cusp_point, cusp_prev, close_path, end_path, start_path;
   PATH *p;
-  PATH_SECTION *section, *prev_section;
+  LeptonPathSection *section, *prev_section;
   int x1, y1, x2, y2, x3, y3;
   int save_num_sections;
 
@@ -353,7 +354,7 @@ o_path_start(GschemToplevel *w_current, int w_x, int w_y)
     w_current->temp_path->num_sections = 0;
   } else {
     PATH *p = g_new0 (PATH, 1);
-    p->sections = g_new0 (PATH_SECTION, TEMP_PATH_DEFAULT_SIZE);
+    p->sections = g_new0 (LeptonPathSection, TEMP_PATH_DEFAULT_SIZE);
     p->num_sections = 0;
     p->num_sections_max = TEMP_PATH_DEFAULT_SIZE;
     w_current->temp_path = p;
@@ -440,7 +441,7 @@ o_path_end(GschemToplevel *w_current, int w_x, int w_y)
 {
   gboolean close_path, end_path, start_path;
   PATH *p;
-  PATH_SECTION *section, *prev_section;
+  LeptonPathSection *section, *prev_section;
   int x1, y1, x2, y2;
 
   g_assert (w_current);

--- a/libleptongui/src/o_path.c
+++ b/libleptongui/src/o_path.c
@@ -28,15 +28,20 @@
 #define NUM_BEZIER_SEGMENTS 100
 
 
-static PATH *path_copy_modify (PATH *path, int dx, int dy,
-                               int new_x, int new_y, int whichone)
+static LeptonPath*
+path_copy_modify (LeptonPath *path,
+                  int dx,
+                  int dy,
+                  int new_x,
+                  int new_y,
+                  int whichone)
 {
-  PATH *new_path;
+  LeptonPath *new_path;
   int x1, y1, x2, y2, x3, y3;
   int i;
   int grip_no = 0;
 
-  new_path = (PATH*) g_malloc (sizeof (PATH));
+  new_path = (LeptonPath*) g_malloc (sizeof (LeptonPath));
   new_path->sections =
     (LeptonPathSection*) g_malloc (path->num_sections * sizeof (LeptonPathSection));
   new_path->num_sections = path->num_sections;
@@ -83,12 +88,16 @@ static PATH *path_copy_modify (PATH *path, int dx, int dy,
  *  \par Function Description
  * Calculate the bounding box of \a path, returning its bounds in \a
  * min_x, \a max_y, \a max_x and \a min_y.  If \a path is NULL, the
- * PATH object currently being edited is used, with any required
+ * LeptonPath object currently being edited is used, with any required
  * control point changes applied.
  */
 static void
-path_rubber_bbox (GschemToplevel *w_current, PATH *path,
-                  int *min_x, int *max_y, int *max_x, int *min_y)
+path_rubber_bbox (GschemToplevel *w_current,
+                  LeptonPath *path,
+                  int *min_x,
+                  int *max_y,
+                  int *max_x,
+                  int *min_y)
 {
   int x1, y1, x2, y2, x3, y3;
   int new_x, new_y, whichone;
@@ -147,16 +156,16 @@ path_rubber_bbox (GschemToplevel *w_current, PATH *path,
  * sections. */
 #define TEMP_PATH_DEFAULT_SIZE 8
 
-/*! \brief Add elements to the temporary PATH.
+/*! \brief Add elements to the temporary LeptonPath.
  * \par Function Description
- * Check if the temporary #PATH object used when interactively
+ * Check if the temporary #LeptonPath object used when interactively
  * creating paths has room for additional sections.  If not, doubles
  * its capacity.
  */
 static void
 path_expand (GschemToplevel *w_current)
 {
-  PATH *p = w_current->temp_path;
+  LeptonPath *p = w_current->temp_path;
   if (p->num_sections == p->num_sections_max) {
     p->num_sections_max *= 2;
     p->sections = g_renew (LeptonPathSection, p->sections,
@@ -175,7 +184,7 @@ path_expand (GschemToplevel *w_current)
  *     point's control point.
  *   - third_wx and third_wy contain the location of the previous
  *     point's control point.
- *   - temp_path is the new #PATH object (i.e. sequence of path
+ *   - temp_path is the new #LeptonPath object (i.e. sequence of path
  *     sections that comprise the path drawn so far).
  *
  * path_next_sections() adds up to two additional sections to the
@@ -191,7 +200,7 @@ static int
 path_next_sections (GschemToplevel *w_current)
 {
   gboolean cusp_point, cusp_prev, close_path, end_path, start_path;
-  PATH *p;
+  LeptonPath *p;
   LeptonPathSection *section, *prev_section;
   int x1, y1, x2, y2, x3, y3;
   int save_num_sections;
@@ -353,7 +362,7 @@ o_path_start(GschemToplevel *w_current, int w_x, int w_y)
   if (w_current->temp_path != NULL) {
     w_current->temp_path->num_sections = 0;
   } else {
-    PATH *p = g_new0 (PATH, 1);
+    LeptonPath *p = g_new0 (LeptonPath, 1);
     p->sections = g_new0 (LeptonPathSection, TEMP_PATH_DEFAULT_SIZE);
     p->num_sections = 0;
     p->num_sections_max = TEMP_PATH_DEFAULT_SIZE;
@@ -440,7 +449,7 @@ void
 o_path_end(GschemToplevel *w_current, int w_x, int w_y)
 {
   gboolean close_path, end_path, start_path;
-  PATH *p;
+  LeptonPath *p;
   LeptonPathSection *section, *prev_section;
   int x1, y1, x2, y2;
 

--- a/libleptongui/src/o_select.c
+++ b/libleptongui/src/o_select.c
@@ -572,7 +572,7 @@ int o_select_selected(GschemToplevel *w_current)
 void o_select_unselect_all(GschemToplevel *w_current)
 {
   LeptonToplevel *toplevel = gschem_toplevel_get_toplevel (w_current);
-  SELECTION *selection = toplevel->page_current->selection_list;
+  LeptonSelection *selection = toplevel->page_current->selection_list;
   GList *removed = NULL;
   GList *iter;
 
@@ -599,7 +599,7 @@ void
 o_select_visible_unlocked (GschemToplevel *w_current)
 {
   LeptonToplevel *toplevel = gschem_toplevel_get_toplevel (w_current);
-  SELECTION *selection = toplevel->page_current->selection_list;
+  LeptonSelection *selection = toplevel->page_current->selection_list;
   const GList *iter;
   GList *added;
   gboolean show_hidden_text =

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -131,8 +131,8 @@ o_undo_savestate (GschemToplevel *w_current,
   char *filename = NULL;
   GList *object_list = NULL;
   int levels;
-  UNDO *u_current;
-  UNDO *u_current_next;
+  LeptonUndo *u_current;
+  LeptonUndo *u_current_next;
 
   GschemPageView *view = gschem_toplevel_get_current_page_view (w_current);
   g_return_if_fail (view != NULL);
@@ -330,9 +330,10 @@ o_undo_savestate_old (GschemToplevel *w_current, int flag)
  *  \par Function Description
  *
  */
-char *o_undo_find_prev_filename(UNDO *start)
+char*
+o_undo_find_prev_filename (LeptonUndo *start)
 {
-  UNDO *u_current;
+  LeptonUndo *u_current;
 
   u_current = start->prev;
 
@@ -351,9 +352,9 @@ char *o_undo_find_prev_filename(UNDO *start)
  *  \par Function Description
  *
  */
-GList *o_undo_find_prev_object_head (UNDO *start)
+GList *o_undo_find_prev_object_head (LeptonUndo *start)
 {
-  UNDO *u_current;
+  LeptonUndo *u_current;
 
   u_current = start->prev;
 
@@ -383,11 +384,11 @@ o_undo_callback (GschemToplevel *w_current,
                  int type)
 {
   LeptonToplevel *toplevel = gschem_toplevel_get_toplevel (w_current);
-  UNDO *u_current;
-  UNDO *u_next;
-  UNDO *save_bottom;
-  UNDO *save_tos;
-  UNDO *save_current;
+  LeptonUndo *u_current;
+  LeptonUndo *u_next;
+  LeptonUndo *save_bottom;
+  LeptonUndo *save_tos;
+  LeptonUndo *save_current;
   int save_logging;
   int find_prev_data=FALSE;
 

--- a/libleptongui/src/x_image.c
+++ b/libleptongui/src/x_image.c
@@ -715,7 +715,7 @@ GdkPixbuf
 
   GList *obj_list;
   GList *iter;
-  BOX *world_rect;
+  LeptonBox *world_rect;
   EdaRenderer *renderer;
   int render_flags;
   GArray *render_color_map = NULL;
@@ -756,7 +756,7 @@ GdkPixbuf
 
   cairo_set_matrix (cr, gschem_page_geometry_get_world_to_screen_matrix (new_geometry));
 
-  world_rect = g_new (BOX, 1);
+  world_rect = g_new (LeptonBox, 1);
 
   double lower_x = 0;
   double lower_y = height;

--- a/libleptongui/src/x_multiattrib.c
+++ b/libleptongui/src/x_multiattrib.c
@@ -126,7 +126,7 @@ x_multiattrib_close (GschemToplevel *w_current)
  *  \par Function Description
  *
  *  If the GschemToplevel has an open multiattrib dialog, switch to
- *  watching the current page's SELECTION object for changes.
+ *  watching the current page's LeptonSelection object for changes.
  *
  *  \param [in] w_current  The GschemToplevel object.
  */


### PR DESCRIPTION
- The following redundant types have been removed and replaced with their `Lepton`-prefixed siblings:
  - `BOX`
  - `OBJECT_END`
  - `OBJECT_FILLING`
  - `OBJECT_TYPE`
  - `PATH`
  - `PICTURE`
  - `SELECTION`
  - `TEXT`
  - `UNDO`
  - `sPOINT`
- The following types have been additionally renamed:
  - `COMPONENT` => `LeptonComponent`
  - `CONN` => `LeptonConn`
  - `PATH_SECTION` => `LeptonPathSection`
