### PR TITLE
Collapsible "Add Attribute" section in the "Edit Attributes" dialog

### DIFF
--- a/libleptongui/include/x_multiattrib.h
+++ b/libleptongui/include/x_multiattrib.h
@@ -69,6 +69,8 @@ struct _Multiattrib {
   GdkColor       not_present_in_all_text_color;
 
   gulong object_list_changed_id;
+
+  gboolean add_attr_section_expanded;
 };
 
 

--- a/libleptongui/src/x_multiattrib.c
+++ b/libleptongui/src/x_multiattrib.c
@@ -2245,10 +2245,7 @@ multiattrib_init (Multiattrib *multiattrib)
                       TRUE, TRUE, 1);
   gtk_widget_show_all (multiattrib->list_frame);
 
-  /* create the add/edit frame */
-  multiattrib->add_frame = GTK_WIDGET (g_object_new (GTK_TYPE_FRAME,
-                                       "label", _("Add Attribute"),
-                                       NULL));
+
   table = GTK_WIDGET (g_object_new (GTK_TYPE_TABLE,
                                     /* GtkTable */
                                     "n-rows",      4,
@@ -2372,8 +2369,12 @@ multiattrib_init (Multiattrib *multiattrib)
                     (GtkAttachOptions) 0,
                     6, 3);
 
-  /* add the table to the frame */
-  gtk_container_add (GTK_CONTAINER (multiattrib->add_frame), table);
+
+  multiattrib->add_frame =
+      gschem_dialog_misc_create_section_widget
+        ( _("<b>Add Attribute</b>"), table );
+
+
   /* pack the frame in the dialog */
   gtk_box_pack_start (GTK_BOX (gtk_dialog_get_content_area (GTK_DIALOG (multiattrib))),
                       multiattrib->add_frame,


### PR DESCRIPTION
Replace the static bottom "Add Attribute" frame in
the attributes editor dialog with a collapsible
section widget.
Most of the time this section is not used and,
on the other hand, often there's not enough room
to display all of the attributes (especially if
the "Show inherited attributes" check box is on).
The "expanded" state of the bottom section is
preserves across the dialog invocations and
program runs.

old version - static frame:
![multiattr_old](https://user-images.githubusercontent.com/26083750/110460680-6caba400-80c6-11eb-8574-a398d6604292.png)

new version - section expanded:
![multiattr_new_1](https://user-images.githubusercontent.com/26083750/110460767-8947dc00-80c6-11eb-9519-62f452161730.png)

new version - section collapsed:
![multiattr_new_2](https://user-images.githubusercontent.com/26083750/110460799-95339e00-80c6-11eb-927a-21c5e0d13e5f.png)
