### PR TITLE
"Save" buttons on tabs

### DIFF
--- a/libleptongui/src/x_tabs.c
+++ b/libleptongui/src/x_tabs.c
@@ -901,7 +901,7 @@ x_tabs_hdr_create (TabInfo* nfo)
   if (nfo->page_->CHANGED)
   {
     gtk_widget_set_tooltip_text (btn_save, _("Save"));
-    gtk_box_pack_start (GTK_BOX (box_btns_left), btn_save, FALSE, FALSE, 0);
+    gtk_box_pack_end (GTK_BOX (box_btns_left), btn_save, FALSE, FALSE, 0);
 
     g_signal_connect (btn_save,
                       "clicked",

--- a/libleptongui/src/x_tabs.c
+++ b/libleptongui/src/x_tabs.c
@@ -893,6 +893,15 @@ x_tabs_hdr_create (TabInfo* nfo)
   gtk_box_pack_start (GTK_BOX (box_hdr), box_btns_right, FALSE, FALSE, 0);
 
 
+  /* setup "save" btn:
+  */
+  if (nfo->page_->CHANGED)
+  {
+    gtk_widget_set_tooltip_text (btn_save, _("Save"));
+    gtk_box_pack_start (GTK_BOX (box_btns_left), btn_save, FALSE, FALSE, 0);
+  }
+
+
   /* setup "up" btn:
   */
   LeptonToplevel* toplevel = gschem_toplevel_get_toplevel (nfo->tl_);

--- a/libleptongui/src/x_tabs.c
+++ b/libleptongui/src/x_tabs.c
@@ -315,6 +315,9 @@ x_tabs_hdr_on_btn_close (GtkToolButton* btn, gpointer p);
 static void
 x_tabs_hdr_on_btn_up (GtkToolButton* btn, gpointer p);
 
+static void
+x_tabs_hdr_on_btn_save (GtkToolButton* btn, gpointer p);
+
 
 
 /* helpers: */
@@ -899,6 +902,11 @@ x_tabs_hdr_create (TabInfo* nfo)
   {
     gtk_widget_set_tooltip_text (btn_save, _("Save"));
     gtk_box_pack_start (GTK_BOX (box_btns_left), btn_save, FALSE, FALSE, 0);
+
+    g_signal_connect (btn_save,
+                      "clicked",
+                      G_CALLBACK (&x_tabs_hdr_on_btn_save),
+                      nfo->tl_);
   }
 
 
@@ -1041,6 +1049,18 @@ x_tabs_hdr_on_btn_up (GtkToolButton* btn, gpointer p)
   }
 
 } /* x_tabs_hdr_on_btn_up() */
+
+
+
+static void
+x_tabs_hdr_on_btn_save (GtkToolButton* btn, gpointer p)
+{
+  GschemToplevel* toplevel    = (GschemToplevel*) p;
+  const gchar*    action_name = "&file-save";
+
+  g_action_eval_by_name (toplevel, action_name);
+
+} /* x_tabs_hdr_on_btn_save() */
 
 
 

--- a/libleptongui/src/x_tabs.c
+++ b/libleptongui/src/x_tabs.c
@@ -874,6 +874,18 @@ x_tabs_hdr_create (TabInfo* nfo)
   gtk_container_add (GTK_CONTAINER (btn_up), img_up);
 
 
+  /* "save" btn:
+  */
+  GtkWidget* btn_save = gtk_button_new();
+  gtk_widget_set_name (btn_save, "lepton-tab-btn");
+  gtk_button_set_relief (GTK_BUTTON (btn_save), GTK_RELIEF_NONE);
+  gtk_button_set_focus_on_click (GTK_BUTTON (btn_save), FALSE);
+
+  GtkWidget* img_save = gtk_image_new_from_stock (GTK_STOCK_SAVE,
+                                                  GTK_ICON_SIZE_MENU);
+  gtk_container_add (GTK_CONTAINER (btn_save), img_save);
+
+
   /* pack button boxes and label box to hdr box:
   */
   gtk_box_pack_start (GTK_BOX (box_hdr), box_btns_left,  FALSE, FALSE, 0);

--- a/libleptongui/src/x_tabs.c
+++ b/libleptongui/src/x_tabs.c
@@ -863,6 +863,7 @@ x_tabs_hdr_create (TabInfo* nfo)
   GtkWidget* img_close = gtk_image_new_from_stock (GTK_STOCK_CLOSE,
                                                    GTK_ICON_SIZE_MENU);
   gtk_container_add (GTK_CONTAINER (btn_close), img_close);
+  gtk_widget_set_tooltip_text (btn_close, _("Close"));
 
 
   /* "up" btn:
@@ -887,6 +888,7 @@ x_tabs_hdr_create (TabInfo* nfo)
   GtkWidget* img_save = gtk_image_new_from_stock (GTK_STOCK_SAVE,
                                                   GTK_ICON_SIZE_MENU);
   gtk_container_add (GTK_CONTAINER (btn_save), img_save);
+  gtk_widget_set_tooltip_text (btn_save, _("Save"));
 
 
   /* pack button boxes and label box to hdr box:
@@ -900,7 +902,6 @@ x_tabs_hdr_create (TabInfo* nfo)
   */
   if (nfo->page_->CHANGED)
   {
-    gtk_widget_set_tooltip_text (btn_save, _("Save"));
     gtk_box_pack_end (GTK_BOX (box_btns_left), btn_save, FALSE, FALSE, 0);
 
     g_signal_connect (btn_save,

--- a/libleptongui/src/x_tabs.c
+++ b/libleptongui/src/x_tabs.c
@@ -906,7 +906,7 @@ x_tabs_hdr_create (TabInfo* nfo)
     g_signal_connect (btn_save,
                       "clicked",
                       G_CALLBACK (&x_tabs_hdr_on_btn_save),
-                      nfo->tl_);
+                      nfo);
   }
 
 
@@ -1055,10 +1055,11 @@ x_tabs_hdr_on_btn_up (GtkToolButton* btn, gpointer p)
 static void
 x_tabs_hdr_on_btn_save (GtkToolButton* btn, gpointer p)
 {
-  GschemToplevel* toplevel    = (GschemToplevel*) p;
-  const gchar*    action_name = "&file-save";
+  TabInfo* nfo = (TabInfo*) p;
+  g_return_if_fail (nfo != NULL);
 
-  g_action_eval_by_name (toplevel, action_name);
+  x_tabs_page_set_cur (nfo->tl_, nfo->page_);
+  g_action_eval_by_name (nfo->tl_, "&file-save");
 
 } /* x_tabs_hdr_on_btn_save() */
 

--- a/libleptongui/src/x_tabs.c
+++ b/libleptongui/src/x_tabs.c
@@ -815,7 +815,7 @@ x_tabs_hdr_create (TabInfo* nfo)
   gchar* lab_txt = NULL;
 
   if (nfo->page_->CHANGED)
-    lab_txt = g_strdup_printf ("* <b>%s</b>", bname);
+    lab_txt = g_strdup_printf ("<b>%s</b>", bname);
   else
     lab_txt = g_strdup (bname);
 


### PR DESCRIPTION
Show the "Save" button on tabs for modified schematics.
It replaces an asterisk (drawing the user's attention) and
allows one to quickly save a file with the mouse
if toolbars are turned off.
Also, a tool-tip is added for the "Close" tab button.

now:
![lepton_tab_without_save_btn](https://user-images.githubusercontent.com/26083750/110593978-27de4680-8174-11eb-9cc6-b10b4aab2cc5.png)

with buttons:
![lepton_tab_with_save_btn](https://user-images.githubusercontent.com/26083750/110593991-2b71cd80-8174-11eb-9a1e-ea8019169cc5.png)
