### PR TITLE
Basename in the --help output; unify/add missing version messages

### DIFF
--- a/liblepton/scheme/netlist.scm
+++ b/liblepton/scheme/netlist.scm
@@ -817,7 +817,7 @@ General options:
 Report bugs at <https://github.com/lepton-eda/lepton-eda/issues>
 Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>
 ")
-          (car (program-arguments)))
+          (basename (car (program-arguments))))
   (primitive-exit 0))
 
 

--- a/liblepton/scheme/netlist.scm
+++ b/liblepton/scheme/netlist.scm
@@ -969,7 +969,7 @@ Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>
   )
 
   ( when opt-version
-    ( display-lepton-version #:print-name #t )
+    ( display-lepton-version #:print-name #t #:copyright #t )
     ( primitive-exit 0 )
   )
 

--- a/liblepton/scheme/symcheck/check.scm
+++ b/liblepton/scheme/symcheck/check.scm
@@ -50,7 +50,7 @@ General options:
 Report bugs at <~A>
 Lepton EDA homepage: <~A>
 ")
-          (car (program-arguments))
+          (basename (car (program-arguments)))
           (lepton-version-ref 'bugs)
           (lepton-version-ref 'url))
   (primitive-exit 0))

--- a/liblepton/scheme/symcheck/check.scm
+++ b/liblepton/scheme/symcheck/check.scm
@@ -87,7 +87,7 @@ Run `~A --help' for more information.\n")
         (version (symcheck-option-ref 'version))
         (interactive (symcheck-option-ref 'interactive)))
     (when version
-      (display-lepton-version #:print-name #t)
+      (display-lepton-version #:print-name #t #:copyright #t)
       (primitive-exit 0))
     (if help
         (usage))

--- a/schematic/lepton-schematic.scm
+++ b/schematic/lepton-schematic.scm
@@ -110,7 +110,6 @@ exec @GUILE@ -s "$0" "$@"
   (format #t
           (G_ "Usage: ~A [OPTION ...] [--] [FILE ...]
 
-
 Interactively edit Lepton EDA schematics or symbols.
 If one or more FILEs are specified, open them for
 editing; otherwise, create a new, empty schematic.
@@ -127,7 +126,7 @@ Options:
 
 Report bugs at ~S
 Lepton EDA homepage: ~S\n")
-          (car (program-arguments))
+          (basename (car (program-arguments)))
           (lepton-version-ref 'bugs)
           (lepton-version-ref 'url))
   (exit 0))

--- a/utils/archive/lepton-archive.in
+++ b/utils/archive/lepton-archive.in
@@ -86,6 +86,7 @@ exec @GUILE@ -s "$0" "$@"
                (lepton os)
                (lepton page)
                (lepton rc)
+               (lepton version)
                (netlist schematic)
                (netlist schematic-component)))
 
@@ -114,6 +115,7 @@ archive.  The two modes of operation are \"archive mode\"
 
 Command line switches:
   -h,--help             -- Print usage information.
+  -V,--version          -- Print version information.
   -v,--verbose          -- Verbose mode.
   -f,--files-from=FILE  -- Additionally read filenames to archive
                            from FILE.
@@ -146,9 +148,13 @@ Example usage:
           default-archive-name
           default-archive-name))
 
+(define (print-version)
+  (display-lepton-version #:print-name #t #:copyright #t))
+
 (define %option-spec
   '((help (single-char #\h) (value #f))
     (files-from (single-char #\f) (value #t))
+    (version (single-char #\V) (value #f))
     (verbose (single-char #\v) (value #f))
     (extract (single-char #\e) (value #f))
     (archive (single-char #\a) (value #f))
@@ -179,6 +185,7 @@ Example usage:
 (define output-archive-name (option-ref %options 'output #f))
 (define archiverc-name (option-ref %options 'files-from #f))
 (define help-mode? (option-ref %options 'help #f))
+(define version-mode? (option-ref %options 'version #f))
 (define verbose-mode? (option-ref %options 'verbose #f))
 (define command-line-file-list (option-ref %options '() '()))
 
@@ -841,6 +848,10 @@ the file manually.\n"))
 (define (main)
   (when help-mode?
     (display usage-info)
+    (primitive-exit 0))
+
+  (when version-mode?
+    (print-version)
     (primitive-exit 0))
 
   (if (and extract-mode? archive-mode?)

--- a/utils/attrib/lepton-attrib.scm
+++ b/utils/attrib/lepton-attrib.scm
@@ -84,7 +84,7 @@ exec @GUILE@ -s "$0" "$@"
 
 (define (usage)
   (format #t
-          (G_ "Usage: ~A [OPTIONS] filename1 ... filenameN
+          (G_ "Usage: ~A [OPTIONS] FILE ...
 
 lepton-attrib: Lepton EDA attribute editor.
 Presents schematic attributes in easy-to-edit spreadsheet format.
@@ -97,7 +97,7 @@ Options:
 Report bugs at ~S
 Lepton EDA homepage: ~S
 ")
-          (car (program-arguments))
+          (basename (car (program-arguments)))
           (lepton-version-ref 'bugs)
           (lepton-version-ref 'url))
 

--- a/utils/embed/lepton-embed.in
+++ b/utils/embed/lepton-embed.in
@@ -99,7 +99,7 @@ Lepton EDA homepage: <~a>
 
 
 ( define ( version )
-  ( display-lepton-version )
+  ( display-lepton-version #:print-name #t #:copyright #t )
   ( primitive-exit 0 )
 )
 

--- a/utils/symfix/lepton-symfix
+++ b/utils/symfix/lepton-symfix
@@ -225,7 +225,15 @@ sub usage {
 sub version {
   my $pname = $0;
   $pname =~ s/.*\///g;
-  print "$pname ($0):  Version $version\n";
+
+  print "Lepton EDA 1.9.13.20201211\n";
+  print "$pname was written by Mike Skerritt <mike\@acornpacket.com>\n";
+
+  print "Copyright (C) 2004      Mike Skerritt\n";
+  print "Copyright (C) 2004-2016 gEDA Contributors\n";
+  print "Copyright (C) 2017-2021 Lepton EDA Contributors\n";
+
+  exit(0);
 }
 
 

--- a/utils/symfix/lepton-symfix
+++ b/utils/symfix/lepton-symfix
@@ -11,7 +11,7 @@ use Getopt::Long;
 # don't allow -he to be interpreted as --help
 $Getopt::Long::autoabbrev=0;
 
-&GetOptions(("help|h" => \&usage, 
+&GetOptions(("help|h" => \&usage,
 	     "verbose" => \$verbose,
 	     "vverbose" => \$vverbose,
 	     "version" => \&version
@@ -53,17 +53,17 @@ while($line = <NETLIST>) {
   $file_line++;
   #==========================
   if( $state == $st_scan ) {
-    if( $line =~ /^P/) { 
-      $state = $st_pin_start; 
+    if( $line =~ /^P/) {
+      $state = $st_pin_start;
       if($vverbose){print "Pin start...\n";}
     }
-    elsif( $line =~ /^numslots=/) { 
+    elsif( $line =~ /^numslots=/) {
       $found_numslots_attr = 1;
     }
-    elsif( $line =~ /^device=/) { 
+    elsif( $line =~ /^device=/) {
       $found_device_attr = 1;
     }
-    elsif( $line =~ /^footprint=/) { 
+    elsif( $line =~ /^footprint=/) {
       $found_footprint_attr = 1;
     }
     print OUTNET $line;
@@ -77,7 +77,7 @@ while($line = <NETLIST>) {
       $found_pintype_attr = 0;
       $found_pinlabel_attr = 0;
       print OUTNET $line;
-    } 
+    }
     else {
       print STDERR "*** ERROR: No pin left bracket found at line $file_line\n";
       exit(-1);

--- a/utils/tragesym/lepton-tragesym.in
+++ b/utils/tragesym/lepton-tragesym.in
@@ -294,7 +294,7 @@ Cheat fraudulent label names for them to sort them properly."))
 Based on original \"tragesym\" version
 (C) 2001,2002,2003,2004,2006,2007 by Werner Hoch <werner.ho@gmx.de>
 "
-        (car (command-line))))
+        (basename (car (command-line)))))
 
 
 (define (parse-label s)

--- a/utils/tragesym/lepton-tragesym.in
+++ b/utils/tragesym/lepton-tragesym.in
@@ -44,6 +44,7 @@ exec @GUILE@ -s "$0" "$@"
                               (lepton attrib)
                               (lepton object)
                               (lepton page)
+                              (lepton version)
                               (netlist attrib compare)))
 
 (use-modules (ice-9 getopt-long)
@@ -55,7 +56,8 @@ exec @GUILE@ -s "$0" "$@"
              (sxml match))
 
 (define %option-spec
-  '((help    (single-char #\h) (value #f))))
+  '((help    (single-char #\h) (value #f))
+   (version (single-char #\V) (value #f))))
 
 (define %options
   (getopt-long (command-line) %option-spec))
@@ -295,6 +297,9 @@ Based on original \"tragesym\" version
 (C) 2001,2002,2003,2004,2006,2007 by Werner Hoch <werner.ho@gmx.de>
 "
         (basename (car (command-line)))))
+
+(define (print-version)
+  (display-lepton-version #:print-name #t #:copyright #t))
 
 
 (define (parse-label s)
@@ -987,6 +992,10 @@ which values are equal in terms of F-EQUAL?."
 
 (when (option-ref %options 'help #f)
   (usage)
+  (primitive-exit 0))
+
+(when (option-ref %options 'version #f)
+  (print-version)
   (primitive-exit 0))
 
 (unless (= (length file-args) 2)

--- a/utils/upcfg/lepton-upcfg.in
+++ b/utils/upcfg/lepton-upcfg.in
@@ -104,7 +104,7 @@ Lepton EDA homepage: <~a>
 
 
 ( define ( version )
-  ( display-lepton-version )
+  ( display-lepton-version #:print-name #t #:copyright #t )
   ( primitive-exit 0 )
 )
 


### PR DESCRIPTION
This is yet another attempt to bring order into the
`--help` and `--version` things, please see #534 :-).

- Several tools in the suite tries to display their full path
in the --help output. Use program's `basename` instead.
- Add missing version messages to `archive` and `tragesym`.
- Fix version output in `symfix` Perl script (like in #765).
- Unify version output, use
`(display-lepton-version #:print-name #t #:copyright #t)`,
e.g.:

```
$ lepton-schematic -V
Lepton EDA/lepton-schematic 1.9.13.20201211 (git: afef811)
Copyright (C) 1998-2016 gEDA developers
Copyright (C) 2017-2021 Lepton EDA developers
This is free software, and you are welcome to redistribute it
under certain conditions. For details, see the file `COPYING',
which is included in the Lepton EDA distribution.
There is NO WARRANTY, to the extent permitted by law
```
