### PR TITLE
Rewrite some functions from (lepton core object) using Scheme FFI

### DIFF
--- a/liblepton/scheme/Makefile.am
+++ b/liblepton/scheme/Makefile.am
@@ -141,6 +141,7 @@ TESTS = \
 	unit-tests/lepton-object-stroke.scm \
 	unit-tests/lepton-object-text.scm \
 	unit-tests/lepton-object-transform.scm \
+	unit-tests/lepton-object-wrong.scm \
 	unit-tests/lepton-os-basic.scm \
 	unit-tests/lepton-os-expand-env-variables.scm \
 	unit-tests/lepton-page-basic.scm \

--- a/liblepton/scheme/lepton/ffi.scm.in
+++ b/liblepton/scheme/lepton/ffi.scm.in
@@ -25,6 +25,9 @@
             edascm_is_page
             edascm_from_object
             edascm_to_object
+
+            lepton_object_get_id
+
             set_render_placeholders
             colors_count
             g_rc_parse
@@ -80,3 +83,6 @@
 (define-lff edascm_is_page int '(*))
 (define-lff edascm_to_object '* '(*))
 (define-lff edascm_from_object '* '(*))
+
+;;; object.c
+(define-lff lepton_object_get_id int '(*))

--- a/liblepton/scheme/lepton/ffi.scm.in
+++ b/liblepton/scheme/lepton/ffi.scm.in
@@ -19,12 +19,15 @@
   #:use-module (system foreign)
 
   #:export (liblepton
+            ;; Helpers.
             true?
+            geda-object->pointer
+            pointer->geda-object
+
+            ;; Foreign functions.
             edascm_is_config
             edascm_is_object
             edascm_is_page
-            edascm_from_object
-            edascm_to_object
 
             lepton_object_get_id
             lepton_object_get_type
@@ -88,3 +91,13 @@
 ;;; object.c
 (define-lff lepton_object_get_id int '(*))
 (define-lff lepton_object_get_type int '(*))
+
+
+
+;;; Helper transformers between #<geda-object> smobs and C object
+;;; pointers.
+(define (geda-object->pointer smob)
+  (edascm_to_object (scm->pointer smob)))
+
+(define (pointer->geda-object pointer)
+  (pointer->scm (edascm_from_object pointer)))

--- a/liblepton/scheme/lepton/ffi.scm.in
+++ b/liblepton/scheme/lepton/ffi.scm.in
@@ -27,6 +27,7 @@
             edascm_to_object
 
             lepton_object_get_id
+            lepton_object_get_type
 
             set_render_placeholders
             colors_count
@@ -86,3 +87,4 @@
 
 ;;; object.c
 (define-lff lepton_object_get_id int '(*))
+(define-lff lepton_object_get_type int '(*))

--- a/liblepton/scheme/lepton/ffi.scm.in
+++ b/liblepton/scheme/lepton/ffi.scm.in
@@ -120,7 +120,10 @@
 ;;; Helper transformers between #<geda-object> smobs and C object
 ;;; pointers.
 (define (geda-object->pointer smob)
-  (edascm_to_object (scm->pointer smob)))
+  (or (false-if-exception (edascm_to_object (scm->pointer smob)))
+      ;; Return NULL if the SMOB is not the #<geda-object> smob.
+      %null-pointer))
 
 (define (pointer->geda-object pointer)
-  (pointer->scm (edascm_from_object pointer)))
+  ;; Return #f if the pointer is wrong.
+  (false-if-exception (pointer->scm (edascm_from_object pointer))))

--- a/liblepton/scheme/lepton/ffi.scm.in
+++ b/liblepton/scheme/lepton/ffi.scm.in
@@ -23,6 +23,7 @@
             true?
             geda-object->pointer
             pointer->geda-object
+            check-object-type
 
             ;; Foreign functions.
             edascm_is_config
@@ -101,3 +102,15 @@
 
 (define (pointer->geda-object pointer)
   (pointer->scm (edascm_from_object pointer)))
+
+
+;;; Helper syntax rule for object type checking.
+(define-syntax-rule
+  (check-object-type <object> <check-proc-name>)
+  (let ((proc (delay (pointer->procedure
+                      int
+                      (dynamic-func (symbol->string (quote <check-proc-name>))
+                                    liblepton)
+                      '(*))))
+        (*object (geda-object->pointer <object>)))
+    (true? ((force proc) *object))))

--- a/liblepton/scheme/lepton/ffi.scm.in
+++ b/liblepton/scheme/lepton/ffi.scm.in
@@ -23,7 +23,6 @@
             true?
             geda-object->pointer
             pointer->geda-object
-            check-object-type
 
             ;; Foreign functions.
             edascm_is_config
@@ -32,6 +31,18 @@
 
             lepton_object_get_id
             lepton_object_get_type
+
+            lepton_object_is_arc
+            lepton_object_is_box
+            lepton_object_is_bus
+            lepton_object_is_circle
+            lepton_object_is_component
+            lepton_object_is_line
+            lepton_object_is_net
+            lepton_object_is_path
+            lepton_object_is_picture
+            lepton_object_is_pin
+            lepton_object_is_text
 
             set_render_placeholders
             colors_count
@@ -93,6 +104,17 @@
 (define-lff lepton_object_get_id int '(*))
 (define-lff lepton_object_get_type int '(*))
 
+(define-lff lepton_object_is_arc int '(*))
+(define-lff lepton_object_is_box int '(*))
+(define-lff lepton_object_is_bus int '(*))
+(define-lff lepton_object_is_circle int '(*))
+(define-lff lepton_object_is_component int '(*))
+(define-lff lepton_object_is_line int '(*))
+(define-lff lepton_object_is_net int '(*))
+(define-lff lepton_object_is_path int '(*))
+(define-lff lepton_object_is_picture int '(*))
+(define-lff lepton_object_is_pin int '(*))
+(define-lff lepton_object_is_text int '(*))
 
 
 ;;; Helper transformers between #<geda-object> smobs and C object
@@ -102,15 +124,3 @@
 
 (define (pointer->geda-object pointer)
   (pointer->scm (edascm_from_object pointer)))
-
-
-;;; Helper syntax rule for object type checking.
-(define-syntax-rule
-  (check-object-type <object> <check-proc-name>)
-  (let ((proc (delay (pointer->procedure
-                      int
-                      (dynamic-func (symbol->string (quote <check-proc-name>))
-                                    liblepton)
-                      '(*))))
-        (*object (geda-object->pointer <object>)))
-    (true? ((force proc) *object))))

--- a/liblepton/scheme/lepton/ffi.scm.in
+++ b/liblepton/scheme/lepton/ffi.scm.in
@@ -23,6 +23,8 @@
             edascm_is_config
             edascm_is_object
             edascm_is_page
+            edascm_from_object
+            edascm_to_object
             set_render_placeholders
             colors_count
             g_rc_parse
@@ -76,3 +78,5 @@
 (define-lff edascm_is_config int '(*))
 (define-lff edascm_is_object int '(*))
 (define-lff edascm_is_page int '(*))
+(define-lff edascm_to_object '* '(*))
+(define-lff edascm_from_object '* '(*))

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -33,6 +33,7 @@
   #:export (object?
             object-id
             object-type
+            object-type?
             arc?
             box?
             bus?
@@ -95,7 +96,7 @@ returns #f."
                 object
                 (integer->char (lepton_object_get_type object))))))
 
-(define-public (object-type? x type)
+(define (object-type? x type)
   (if (object? x)
       (eq? (object-type x) type)
       #f))

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -36,6 +36,14 @@
 returns #f."
   (true? (edascm_is_object (scm->pointer object))))
 
+;;; Helper transformers between #<geda-object> smobs and C object
+;;; pointers.
+(define (geda-object->pointer smob)
+  (edascm_to_object (scm->pointer smob)))
+
+(define (pointer->geda-object pointer)
+  (pointer->scm (edascm_from_object pointer)))
+
 (define-public object-type %object-type)
 (define-public object-id %object-id)
 

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -29,7 +29,8 @@
   #:use-module (lepton core object)
   #:use-module (lepton ffi)
 
-  #:export (object?))
+  #:export (object?
+            object-id))
 
 (define (object? object)
   "Returns #t if OBJECT is a #<geda-object> instance, otherwise
@@ -45,7 +46,12 @@ returns #f."
   (pointer->scm (edascm_from_object pointer)))
 
 (define-public object-type %object-type)
-(define-public object-id %object-id)
+
+(define (object-id object)
+  "Returns an internal id number of the OBJECT."
+  (let ((id (lepton_object_get_id (geda-object->pointer object))))
+    (and (not (= id -1))
+         id)))
 
 (define-public (object-type? x type)
   (if (object? x)

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -51,14 +51,6 @@
 returns #f."
   (true? (edascm_is_object (scm->pointer object))))
 
-;;; Helper transformers between #<geda-object> smobs and C object
-;;; pointers.
-(define (geda-object->pointer smob)
-  (edascm_to_object (scm->pointer smob)))
-
-(define (pointer->geda-object pointer)
-  (pointer->scm (edascm_from_object pointer)))
-
 
 (define (object-id object)
   "Returns an internal id number of the OBJECT."

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -97,9 +97,8 @@ returns #f."
                 (integer->char (lepton_object_get_type object))))))
 
 (define (object-type? x type)
-  (if (object? x)
-      (eq? (object-type x) type)
-      #f))
+  (and (object? x)
+       (eq? (object-type x) type)))
 
 (define-public copy-object %copy-object)
 

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -59,17 +59,6 @@ returns #f."
          id)))
 
 
-(define-syntax-rule
-  (check-object-type <object> <check-proc-name>)
-  (let ((proc (delay (pointer->procedure
-                      int
-                      (dynamic-func (symbol->string (quote <check-proc-name>))
-                                    liblepton)
-                      '(*))))
-        (*object (geda-object->pointer <object>)))
-    (true? ((force proc) *object))))
-
-
 (define (object-type object)
   "Returns a Scheme symbol representing the type of OBJECT."
   (cond

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -94,7 +94,7 @@ returns #f."
 
 (define (line? object)
   "Returns #t if OBJECT is a line object, otherwise returns #f."
-  (check-object-type object lepton_object_is_line))
+  (true? (lepton_object_is_line (geda-object->pointer object))))
 
 (define*-public (set-line! l start end #:optional color)
   (%set-line! l
@@ -126,7 +126,7 @@ returns #f."
 
 (define-public (net? object)
   "Returns #t if OBJECT is a net object, otherwise returns #f."
-  (check-object-type object lepton_object_is_net))
+  (true? (lepton_object_is_net (geda-object->pointer object))))
 
 (define*-public (make-net start end #:optional color)
   (let ((l (%make-net)))
@@ -136,7 +136,7 @@ returns #f."
 
 (define (bus? object)
   "Returns #t if OBJECT is a bus object, otherwise returns #f."
-  (check-object-type object lepton_object_is_bus))
+  (true? (lepton_object_is_bus (geda-object->pointer object))))
 
 (define*-public (make-bus start end #:optional color)
   (let ((l (%make-bus)))
@@ -146,7 +146,7 @@ returns #f."
 
 (define (pin? object)
   "Returns #t if OBJECT is a pin object, otherwise returns #f."
-  (check-object-type object lepton_object_is_pin))
+  (true? (lepton_object_is_pin (geda-object->pointer object))))
 
 (define-public (net-pin? l)
   (and (pin? l) (equal? (%pin-type l) 'net)))
@@ -167,7 +167,7 @@ returns #f."
 
 (define (box? object)
   "Returns #t if OBJECT is a box object, otherwise returns #f."
-  (check-object-type object lepton_object_is_box))
+  (true? (lepton_object_is_box (geda-object->pointer object))))
 
 (define*-public (set-box! b top-left bottom-right #:optional color)
   (%set-box! b
@@ -199,7 +199,7 @@ returns #f."
 
 (define (circle? object)
   "Returns #t if OBJECT is a circle object, otherwise returns #f."
-  (check-object-type object lepton_object_is_circle))
+  (true? (lepton_object_is_circle (geda-object->pointer object))))
 
 (define*-public (set-circle! c center radius #:optional color)
   (%set-circle! c
@@ -230,7 +230,7 @@ returns #f."
 
 (define (arc? object)
   "Returns #t if OBJECT is a arc object, otherwise returns #f."
-  (check-object-type object lepton_object_is_arc))
+  (true? (lepton_object_is_arc (geda-object->pointer object))))
 
 (define*-public (set-arc! a center radius start-angle sweep-angle
                           #:optional color)
@@ -271,7 +271,7 @@ returns #f."
 
 (define (path? object)
   "Returns #t if OBJECT is a path object, otherwise returns #f."
-  (check-object-type object lepton_object_is_path))
+  (true? (lepton_object_is_path (geda-object->pointer object))))
 
 (define*-public (make-path #:optional color)
   (let ((p (%make-path)))
@@ -318,7 +318,7 @@ returns #f."
 
 (define (picture? object)
   "Returns #t if OBJECT is a picture object, otherwise returns #f."
-  (check-object-type object lepton_object_is_picture))
+  (true? (lepton_object_is_picture (geda-object->pointer object))))
 
 (define-public (set-picture! p top-left bottom-right angle mirror)
   (%set-picture! p (car top-left) (cdr top-left)
@@ -359,7 +359,7 @@ returns #f."
 
 (define (text? object)
   "Returns #t if OBJECT is a text object, otherwise returns #f."
-  (check-object-type object lepton_object_is_text))
+  (true? (lepton_object_is_text (geda-object->pointer object))))
 
 (define*-public (set-text! t anchor align angle string size visible show
                            #:optional color)
@@ -412,7 +412,7 @@ returns #f."
 
 (define (component? object)
   "Returns #t if OBJECT is a component object, otherwise returns #f."
-  (check-object-type object lepton_object_is_component))
+  (true? (lepton_object_is_component (geda-object->pointer object))))
 
 (define-public (set-component! c position angle mirror locked)
   (%set-component! c (car position) (cdr position) angle mirror locked))

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -61,21 +61,24 @@ returns #f."
 
 (define (object-type object)
   "Returns a Scheme symbol representing the type of OBJECT."
-  (cond
-   ((arc? object) 'arc)
-   ((box? object) 'box)
-   ((bus? object) 'bus)
-   ((circle? object) 'circle)
-   ((component? object) 'complex)
-   ((line? object) 'line)
-   ((net? object) 'net)
-   ((path? object) 'path)
-   ((picture? object) 'picture)
-   ((pin? object) 'pin)
-   ((text? object) 'text)
-   (else (error (G_ "Object ~A has bad type '~A'")
-                object
-                (integer->char (lepton_object_get_type object))))))
+  (if (object? object)
+      (cond
+       ((arc? object) 'arc)
+       ((box? object) 'box)
+       ((bus? object) 'bus)
+       ((circle? object) 'circle)
+       ((component? object) 'complex)
+       ((line? object) 'line)
+       ((net? object) 'net)
+       ((path? object) 'path)
+       ((picture? object) 'picture)
+       ((pin? object) 'pin)
+       ((text? object) 'text)
+       (else (error (G_ "Object ~A has bad type '~A'")
+                    object
+                    (integer->char (lepton_object_get_type object)))))
+      (throw 'wrong-type-arg (G_ "object-type: Wrong type argument: ~A")
+             object)))
 
 (define (object-type? x type)
   (and (object? x)

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -93,6 +93,7 @@ returns #f."
 ;;;; Lines
 
 (define (line? object)
+  "Returns #t if OBJECT is a line object, otherwise returns #f."
   (check-object-type object lepton_object_is_line))
 
 (define*-public (set-line! l start end #:optional color)
@@ -124,6 +125,7 @@ returns #f."
 ;;;; Nets
 
 (define-public (net? object)
+  "Returns #t if OBJECT is a net object, otherwise returns #f."
   (check-object-type object lepton_object_is_net))
 
 (define*-public (make-net start end #:optional color)
@@ -133,6 +135,7 @@ returns #f."
 ;;;; Buses
 
 (define (bus? object)
+  "Returns #t if OBJECT is a bus object, otherwise returns #f."
   (check-object-type object lepton_object_is_bus))
 
 (define*-public (make-bus start end #:optional color)
@@ -142,6 +145,7 @@ returns #f."
 ;;;; Pins
 
 (define (pin? object)
+  "Returns #t if OBJECT is a pin object, otherwise returns #f."
   (check-object-type object lepton_object_is_pin))
 
 (define-public (net-pin? l)
@@ -162,6 +166,7 @@ returns #f."
 
 
 (define (box? object)
+  "Returns #t if OBJECT is a box object, otherwise returns #f."
   (check-object-type object lepton_object_is_box))
 
 (define*-public (set-box! b top-left bottom-right #:optional color)
@@ -193,6 +198,7 @@ returns #f."
 ;;;; Circles
 
 (define (circle? object)
+  "Returns #t if OBJECT is a circle object, otherwise returns #f."
   (check-object-type object lepton_object_is_circle))
 
 (define*-public (set-circle! c center radius #:optional color)
@@ -223,6 +229,7 @@ returns #f."
 ;;;; Arcs
 
 (define (arc? object)
+  "Returns #t if OBJECT is a arc object, otherwise returns #f."
   (check-object-type object lepton_object_is_arc))
 
 (define*-public (set-arc! a center radius start-angle sweep-angle
@@ -263,6 +270,7 @@ returns #f."
 ;;;; Paths
 
 (define (path? object)
+  "Returns #t if OBJECT is a path object, otherwise returns #f."
   (check-object-type object lepton_object_is_path))
 
 (define*-public (make-path #:optional color)
@@ -309,6 +317,7 @@ returns #f."
 ;;;; Pictures
 
 (define (picture? object)
+  "Returns #t if OBJECT is a picture object, otherwise returns #f."
   (check-object-type object lepton_object_is_picture))
 
 (define-public (set-picture! p top-left bottom-right angle mirror)
@@ -349,6 +358,7 @@ returns #f."
 ;;;; Text
 
 (define (text? object)
+  "Returns #t if OBJECT is a text object, otherwise returns #f."
   (check-object-type object lepton_object_is_text))
 
 (define*-public (set-text! t anchor align angle string size visible show
@@ -401,6 +411,7 @@ returns #f."
 ;;;; Component objects
 
 (define (component? object)
+  "Returns #t if OBJECT is a component object, otherwise returns #f."
   (check-object-type object lepton_object_is_component))
 
 (define-public (set-component! c position angle mirror locked)

--- a/liblepton/scheme/unit-tests/lepton-object-arc.scm
+++ b/liblepton/scheme/unit-tests/lepton-object-arc.scm
@@ -9,6 +9,7 @@
 
   (test-equal 'arc (object-type a))
   (test-assert (object-type? a 'arc))
+  (test-assert (not (object-type? a 'x)))
 
   (test-assert (arc? a))
   (test-assert (arc? b))

--- a/liblepton/scheme/unit-tests/lepton-object-arc.scm
+++ b/liblepton/scheme/unit-tests/lepton-object-arc.scm
@@ -8,6 +8,7 @@
        (b (copy-object a)))
 
   (test-equal 'arc (object-type a))
+  (test-assert (object-type? a 'arc))
 
   (test-assert (arc? a))
   (test-assert (arc? b))

--- a/liblepton/scheme/unit-tests/lepton-object-box.scm
+++ b/liblepton/scheme/unit-tests/lepton-object-box.scm
@@ -8,6 +8,7 @@
        (b (copy-object a)))
 
   (test-equal 'box (object-type a))
+  (test-assert (object-type? a 'box))
 
   (test-assert (box? a))
   (test-assert (box? b))

--- a/liblepton/scheme/unit-tests/lepton-object-box.scm
+++ b/liblepton/scheme/unit-tests/lepton-object-box.scm
@@ -9,6 +9,7 @@
 
   (test-equal 'box (object-type a))
   (test-assert (object-type? a 'box))
+  (test-assert (not (object-type? a 'x)))
 
   (test-assert (box? a))
   (test-assert (box? b))

--- a/liblepton/scheme/unit-tests/lepton-object-circle.scm
+++ b/liblepton/scheme/unit-tests/lepton-object-circle.scm
@@ -8,6 +8,7 @@
        (b (copy-object a)))
 
   (test-equal 'circle (object-type a))
+  (test-assert (object-type? a 'circle))
 
   (test-assert (circle? a))
   (test-assert (circle? b))

--- a/liblepton/scheme/unit-tests/lepton-object-circle.scm
+++ b/liblepton/scheme/unit-tests/lepton-object-circle.scm
@@ -9,6 +9,7 @@
 
   (test-equal 'circle (object-type a))
   (test-assert (object-type? a 'circle))
+  (test-assert (not (object-type? a 'x)))
 
   (test-assert (circle? a))
   (test-assert (circle? b))

--- a/liblepton/scheme/unit-tests/lepton-object-component.scm
+++ b/liblepton/scheme/unit-tests/lepton-object-component.scm
@@ -12,6 +12,7 @@
 
   (test-equal 'complex (object-type a))
   (test-assert (object-type? a 'complex))
+  (test-assert (not (object-type? a 'x)))
 
   (test-assert (component? a))
 

--- a/liblepton/scheme/unit-tests/lepton-object-component.scm
+++ b/liblepton/scheme/unit-tests/lepton-object-component.scm
@@ -11,6 +11,7 @@
 (let ((a (make-component "test component" '(1 . 2) 0 #t #f)))
 
   (test-equal 'complex (object-type a))
+  (test-assert (object-type? a 'complex))
 
   (test-assert (component? a))
 

--- a/liblepton/scheme/unit-tests/lepton-object-line.scm
+++ b/liblepton/scheme/unit-tests/lepton-object-line.scm
@@ -9,6 +9,7 @@
       (b (make-line '(1 . 2) '(3 . 4))))
 
   (test-equal 'line (object-type a))
+  (test-assert (object-type? a 'line))
 
   (test-assert (line? a))
 
@@ -39,6 +40,7 @@
       (b (make-net '(1 . 2) '(3 . 4))))
 
   (test-equal 'net (object-type a))
+  (test-assert (object-type? a 'net))
 
   (test-assert (net? a))
 
@@ -69,6 +71,7 @@
       (b (make-bus '(1 . 2) '(3 . 4))))
 
   (test-equal 'bus (object-type a))
+  (test-assert (object-type? a 'bus))
 
   (test-assert (bus? a))
 
@@ -99,6 +102,7 @@
       (b (make-net-pin '(1 . 2) '(3 . 4))))
 
   (test-equal 'pin (object-type a))
+  (test-assert (object-type? a 'pin))
 
   (test-assert (pin? a))
   (test-assert (net-pin? a))
@@ -131,6 +135,7 @@
       (b (make-bus-pin '(1 . 2) '(3 . 4))))
 
   (test-equal 'pin (object-type a))
+  (test-assert (object-type? a 'pin))
 
   (test-assert (pin? a))
   (test-assert (bus-pin? a))

--- a/liblepton/scheme/unit-tests/lepton-object-line.scm
+++ b/liblepton/scheme/unit-tests/lepton-object-line.scm
@@ -10,6 +10,7 @@
 
   (test-equal 'line (object-type a))
   (test-assert (object-type? a 'line))
+  (test-assert (not (object-type? a 'x)))
 
   (test-assert (line? a))
 
@@ -41,6 +42,7 @@
 
   (test-equal 'net (object-type a))
   (test-assert (object-type? a 'net))
+  (test-assert (not (object-type? a 'x)))
 
   (test-assert (net? a))
 
@@ -72,6 +74,7 @@
 
   (test-equal 'bus (object-type a))
   (test-assert (object-type? a 'bus))
+  (test-assert (not (object-type? a 'x)))
 
   (test-assert (bus? a))
 
@@ -103,6 +106,7 @@
 
   (test-equal 'pin (object-type a))
   (test-assert (object-type? a 'pin))
+  (test-assert (not (object-type? a 'x)))
 
   (test-assert (pin? a))
   (test-assert (net-pin? a))
@@ -136,6 +140,7 @@
 
   (test-equal 'pin (object-type a))
   (test-assert (object-type? a 'pin))
+  (test-assert (not (object-type? a 'x)))
 
   (test-assert (pin? a))
   (test-assert (bus-pin? a))

--- a/liblepton/scheme/unit-tests/lepton-object-path.scm
+++ b/liblepton/scheme/unit-tests/lepton-object-path.scm
@@ -9,6 +9,7 @@
 
   (test-equal 'path (object-type a))
   (test-assert (object-type? a 'path))
+  (test-assert (not (object-type? a 'x)))
   (test-assert (path? a))
   (test-equal 0 (path-length a))
   (test-assert-thrown 'out-of-range (path-ref a 0))

--- a/liblepton/scheme/unit-tests/lepton-object-path.scm
+++ b/liblepton/scheme/unit-tests/lepton-object-path.scm
@@ -8,6 +8,7 @@
        (b (make-path 21)))
 
   (test-equal 'path (object-type a))
+  (test-assert (object-type? a 'path))
   (test-assert (path? a))
   (test-equal 0 (path-length a))
   (test-assert-thrown 'out-of-range (path-ref a 0))

--- a/liblepton/scheme/unit-tests/lepton-object-picture.scm
+++ b/liblepton/scheme/unit-tests/lepton-object-picture.scm
@@ -19,6 +19,7 @@ static char * test_image_xpm[] = {
 
   (test-equal 'picture (object-type a))
   (test-assert (object-type? a 'picture))
+  (test-assert (not (object-type? a 'x)))
   (test-assert (picture? a))
 
   (test-equal "test_image.xpm" (picture-filename a))

--- a/liblepton/scheme/unit-tests/lepton-object-picture.scm
+++ b/liblepton/scheme/unit-tests/lepton-object-picture.scm
@@ -18,6 +18,7 @@ static char * test_image_xpm[] = {
        (b (copy-object a)))
 
   (test-equal 'picture (object-type a))
+  (test-assert (object-type? a 'picture))
   (test-assert (picture? a))
 
   (test-equal "test_image.xpm" (picture-filename a))

--- a/liblepton/scheme/unit-tests/lepton-object-text.scm
+++ b/liblepton/scheme/unit-tests/lepton-object-text.scm
@@ -8,6 +8,7 @@
       (b (make-text '(1 . 2) 'lower-left 0 "test text" 10 #t 'both)))
 
   (test-equal 'text (object-type a))
+  (test-assert (object-type? a 'text))
 
   (test-assert (text? a))
   (test-assert (text? b))

--- a/liblepton/scheme/unit-tests/lepton-object-text.scm
+++ b/liblepton/scheme/unit-tests/lepton-object-text.scm
@@ -9,6 +9,7 @@
 
   (test-equal 'text (object-type a))
   (test-assert (object-type? a 'text))
+  (test-assert (not (object-type? a 'x)))
 
   (test-assert (text? a))
   (test-assert (text? b))

--- a/liblepton/scheme/unit-tests/lepton-object-wrong.scm
+++ b/liblepton/scheme/unit-tests/lepton-object-wrong.scm
@@ -1,0 +1,11 @@
+;;; Test basic object procedures with wrong arguments.
+
+(use-modules (lepton object))
+
+(test-begin "non-object")
+
+(test-assert (not (object? 'a)))
+(test-assert-thrown 'wrong-type-arg (object-type 'a))
+(test-assert (not (object-type? 'a 'a)))
+
+(test-end "non-object")

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -233,27 +233,6 @@ SCM_DEFINE (object_type, "%object-type", 1, 0, 0,
   return result;
 }
 
-/*! \brief Get the internal id of an object.
- * \par Function Description
- * Returns an internal id number of the #LeptonObject smob \a obj_s.
- *
- * \note Scheme API: Implements the %object-id procedure in the
- * (lepton core object) module.
- *
- * \param [in] obj_s an #LeptonObject smob.
- * \return a Scheme symbol representing the object type.
- */
-SCM_DEFINE (object_id, "%object-id", 1, 0, 0,
-            (SCM obj_s), "Get an object smob's id")
-{
-  SCM_ASSERT (EDASCM_OBJECTP (obj_s), obj_s,
-              SCM_ARG1, s_object_type);
-
-  LeptonObject *obj = edascm_to_object (obj_s);
-
-  return scm_from_int (lepton_object_get_id (obj));
-}
-
 /*! \brief Get the bounds of a list of objects
  * \par Function Description
  * Returns the bounds of the objects in the variable-length argument
@@ -2361,8 +2340,7 @@ init_module_lepton_core_object (void *unused)
   #include "scheme_object.x"
 
   /* Add them to the module's public definitions. */
-  scm_c_export (s_object_id,
-                s_object_type,
+  scm_c_export (s_object_type,
                 s_copy_object,
                 s_object_bounds,
                 s_object_stroke,

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -29,17 +29,8 @@
 #include "libleptonguile_priv.h"
 
 SCM_SYMBOL (wrong_type_arg_sym , "wrong-type-arg");
-SCM_SYMBOL (line_sym , "line");
 SCM_SYMBOL (net_sym , "net");
 SCM_SYMBOL (bus_sym , "bus");
-SCM_SYMBOL (box_sym , "box");
-SCM_SYMBOL (picture_sym , "picture");
-SCM_SYMBOL (circle_sym , "circle");
-SCM_SYMBOL (complex_sym , "complex");
-SCM_SYMBOL (text_sym , "text");
-SCM_SYMBOL (path_sym , "path");
-SCM_SYMBOL (pin_sym , "pin");
-SCM_SYMBOL (arc_sym , "arc");
 
 SCM_SYMBOL (lower_left_sym , "lower-left");
 SCM_SYMBOL (middle_left_sym , "middle-left");
@@ -188,47 +179,6 @@ SCM_DEFINE (copy_object, "%copy-object", 1, 0, 0,
   /* At the moment, the only pointer to the object is owned by the
    * smob. */
   edascm_c_set_gc (result, TRUE);
-
-  return result;
-}
-
-/*! \brief Get the type of an object.
- * \par Function Description
- * Returns a symbol describing the type of the #LeptonObject smob \a obj_s.
- *
- * \note Scheme API: Implements the %object-type procedure in the
- * (lepton core object) module.
- *
- * \param [in] obj_s an #LeptonObject smob.
- * \return a Scheme symbol representing the object type.
- */
-SCM_DEFINE (object_type, "%object-type", 1, 0, 0,
-            (SCM obj_s), "Get an object smob's type")
-{
-  SCM result;
-
-  SCM_ASSERT (EDASCM_OBJECTP (obj_s), obj_s,
-              SCM_ARG1, s_object_type);
-
-  LeptonObject *obj = edascm_to_object (obj_s);
-  switch (lepton_object_get_type (obj)) {
-  case OBJ_LINE:    result = line_sym;       break;
-  case OBJ_NET:     result = net_sym;        break;
-  case OBJ_BUS:     result = bus_sym;        break;
-  case OBJ_BOX:     result = box_sym;        break;
-  case OBJ_PICTURE: result = picture_sym;    break;
-  case OBJ_CIRCLE:  result = circle_sym;     break;
-  case OBJ_TEXT:    result = text_sym;       break;
-  case OBJ_PATH:    result = path_sym;       break;
-  case OBJ_PIN:     result = pin_sym;        break;
-  case OBJ_ARC:     result = arc_sym;        break;
-  case OBJ_COMPONENT:
-                    result = complex_sym;    break;
-  default:
-    scm_misc_error (s_object_type, _("Object ~A has bad type '~A'"),
-                    scm_list_2 (obj_s,
-                                scm_integer_to_char (scm_from_int (lepton_object_get_type (obj)))));
-  }
 
   return result;
 }
@@ -2340,8 +2290,7 @@ init_module_lepton_core_object (void *unused)
   #include "scheme_object.x"
 
   /* Add them to the module's public definitions. */
-  scm_c_export (s_object_type,
-                s_copy_object,
+  scm_c_export (s_copy_object,
                 s_object_bounds,
                 s_object_stroke,
                 s_set_object_stroke_x,


### PR DESCRIPTION
Those functions are `object?()`, `object-type()`, `object-type?()`, `object-id()`.  Type checkers such as `arc?()` and the like have been redefined as well.  Plus, I added some more tests for the functions.  And docstrings you could refer in Lepton's REPL.