### PR TITLE
Get rid of the 'type' argument in several functions

### DIFF
--- a/liblepton/include/liblepton/box_object.h
+++ b/liblepton/include/liblepton/box_object.h
@@ -32,8 +32,7 @@ G_BEGIN_DECLS
 /* construction, destruction */
 
 LeptonObject*
-lepton_box_object_new (char type,
-                       int color,
+lepton_box_object_new (int color,
                        int x1,
                        int y1,
                        int x2,

--- a/liblepton/include/liblepton/net_object.h
+++ b/liblepton/include/liblepton/net_object.h
@@ -32,8 +32,7 @@ G_BEGIN_DECLS
 /* construction, destruction */
 
 LeptonObject*
-lepton_net_object_new (char type,
-                       int color,
+lepton_net_object_new (int color,
                        int x1,
                        int y1,
                        int x2,

--- a/liblepton/include/liblepton/path_object.h
+++ b/liblepton/include/liblepton/path_object.h
@@ -28,8 +28,7 @@ LeptonObject*
 lepton_path_object_new (int color,
                         const char *path_string);
 LeptonObject*
-lepton_path_object_new_take_path (char type,
-                                  int color,
+lepton_path_object_new_take_path (int color,
                                   LeptonPath *path_data);
 LeptonObject*
 lepton_path_object_copy (LeptonObject *o_current);

--- a/liblepton/include/liblepton/path_object.h
+++ b/liblepton/include/liblepton/path_object.h
@@ -25,8 +25,7 @@
 G_BEGIN_DECLS
 
 LeptonObject*
-lepton_path_object_new (char type,
-                        int color,
+lepton_path_object_new (int color,
                         const char *path_string);
 LeptonObject*
 lepton_path_object_new_take_path (char type,

--- a/liblepton/src/box_object.c
+++ b/liblepton/src/box_object.c
@@ -46,7 +46,6 @@
  *  #lepton_object_set_line_options() and
  *  #lepton_object_set_fill_options().
  *
- *  \param [in]     type         Box type.
  *  \param [in]     color        Box border color.
  *  \param [in]     x1           Upper x coordinate.
  *  \param [in]     y1           Upper y coordinate.
@@ -55,8 +54,7 @@
  *  \return The new LeptonObject
  */
 LeptonObject*
-lepton_box_object_new (char type,
-                       int color,
+lepton_box_object_new (int color,
                        int x1,
                        int y1,
                        int x2,
@@ -66,7 +64,7 @@ lepton_box_object_new (char type,
   LeptonBox *box;
 
   /* create the object */
-  new_node = lepton_object_new (type, "box");
+  new_node = lepton_object_new (OBJ_BOX, "box");
   lepton_object_set_color (new_node, color);
 
   box = lepton_box_new ();
@@ -112,8 +110,7 @@ lepton_box_object_copy (LeptonObject *o_current)
 
   /* A new box object is created with #lepton_box_object_new().
    * Values for its fields are default and need to be modified. */
-  new_obj = lepton_box_object_new (OBJ_BOX,
-                                   lepton_object_get_color (o_current),
+  new_obj = lepton_box_object_new (lepton_object_get_color (o_current),
                                    0, 0, 0, 0);
 
   /*
@@ -360,7 +357,7 @@ o_box_read (const char buf[],
   d_y2 = y1;
 
   /* create a new box */
-  new_obj = lepton_box_object_new (type, color, d_x1, d_y1, d_x2, d_y2);
+  new_obj = lepton_box_object_new (color, d_x1, d_y1, d_x2, d_y2);
   /* set its line options */
   lepton_object_set_line_options (new_obj,
                                   (LeptonLineCapType) box_end,

--- a/liblepton/src/net_object.c
+++ b/liblepton/src/net_object.c
@@ -235,7 +235,6 @@ lepton_net_object_calculate_bounds (const LeptonObject *object,
  *  \par Function Description
  *  This function creates and returns a new net object.
  *
- *  \param [in]     type        The LeptonObject type (usually OBJ_NET)
  *  \param [in]     color       The color of the net
  *  \param [in]     x1          x-coord of the first point
  *  \param [in]     y1          y-coord of the first point
@@ -244,8 +243,7 @@ lepton_net_object_calculate_bounds (const LeptonObject *object,
  *  \return A new net LeptonObject
  */
 LeptonObject*
-lepton_net_object_new (char type,
-                       int color,
+lepton_net_object_new (int color,
                        int x1,
                        int y1,
                        int x2,
@@ -253,7 +251,7 @@ lepton_net_object_new (char type,
 {
   LeptonObject *new_node;
 
-  new_node = lepton_object_new (type, "net");
+  new_node = lepton_object_new (OBJ_NET, "net");
   lepton_object_set_color (new_node, color);
 
   new_node->line = lepton_line_new ();
@@ -308,7 +306,7 @@ o_net_read (const char buf[],
     color = default_color_id();
   }
 
-  new_obj = lepton_net_object_new (type, color, x1, y1, x2, y2);
+  new_obj = lepton_net_object_new (color, x1, y1, x2, y2);
 
   return new_obj;
 }
@@ -375,8 +373,7 @@ lepton_net_object_copy (LeptonObject *o_current)
   /* still doesn't work... you need to pass in the new values */
   /* or don't update and update later */
   /* I think for now I'll disable the update and manually update */
-  new_obj = lepton_net_object_new (OBJ_NET,
-                                   lepton_object_get_color (o_current),
+  new_obj = lepton_net_object_new (lepton_object_get_color (o_current),
                                    o_current->line->x[0],
                                    o_current->line->y[0],
                                    o_current->line->x[1],

--- a/liblepton/src/path_object.c
+++ b/liblepton/src/path_object.c
@@ -61,7 +61,7 @@ LeptonObject*
 lepton_path_object_new (int color,
                         const char *path_string)
 {
-  return lepton_path_object_new_take_path (OBJ_PATH, color,
+  return lepton_path_object_new_take_path (color,
                                            s_path_parse (path_string));
 }
 
@@ -74,20 +74,18 @@ lepton_path_object_new (int color,
  *
  *  \see lepton_path_object_new().
  *
- *  \param [in]     type         Must be OBJ_PATH.
  *  \param [in]     color        The path color.
  *  \param [in]     path_data    The #LeptonPath data structure to use.
  *  \return A pointer to the new end of the object list.
  */
 LeptonObject*
-lepton_path_object_new_take_path (char type,
-                                  int color,
+lepton_path_object_new_take_path (int color,
                                   LeptonPath *path_data)
 {
   LeptonObject *new_node;
 
   /* create the object */
-  new_node        = lepton_object_new (type, "path");
+  new_node        = lepton_object_new (OBJ_PATH, "path");
   lepton_object_set_color (new_node, color);
 
   new_node->path  = path_data;

--- a/liblepton/src/path_object.c
+++ b/liblepton/src/path_object.c
@@ -53,17 +53,15 @@
  *  The object is added to the end of the list described by the
  *  <B>object_list</B> parameter by the #s_basic_link_object().
  *
- *  \param [in]     type         Must be OBJ_PATH.
  *  \param [in]     color        The path color.
  *  \param [in]     path_string  The string representation of the path
  *  \return A pointer to the new end of the object list.
  */
 LeptonObject*
-lepton_path_object_new (char type,
-                        int color,
+lepton_path_object_new (int color,
                         const char *path_string)
 {
-  return lepton_path_object_new_take_path (type, color,
+  return lepton_path_object_new_take_path (OBJ_PATH, color,
                                            s_path_parse (path_string));
 }
 
@@ -131,8 +129,7 @@ lepton_path_object_copy (LeptonObject *o_current)
   char *path_string;
 
   path_string = s_path_string_from_path (o_current->path);
-  new_obj = lepton_path_object_new (OBJ_PATH,
-                                    lepton_object_get_color (o_current),
+  new_obj = lepton_path_object_new (lepton_object_get_color (o_current),
                                     path_string);
   g_free (path_string);
 
@@ -242,7 +239,7 @@ o_path_read (const char *first_line,
   string = lepton_str_remove_ending_newline (string);
 
   /* create a new path */
-  new_obj = lepton_path_object_new (type, color, string);
+  new_obj = lepton_path_object_new (color, string);
   g_free (string);
 
   /* set its line options */

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -1687,7 +1687,7 @@ SCM_DEFINE (object_component, "%object-component", 1, 0, 0,
 SCM_DEFINE (make_path, "%make-path", 0, 0, 0,
             (), "Create a new path object")
 {
-  LeptonObject *obj = lepton_path_object_new (OBJ_PATH, default_color_id(), "");
+  LeptonObject *obj = lepton_path_object_new (default_color_id(), "");
 
   SCM result = edascm_from_object (obj);
 

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -1092,7 +1092,7 @@ SCM_DEFINE (pin_type, "%pin-type", 1, 0, 0,
 SCM_DEFINE (make_box, "%make-box", 0, 0, 0,
             (), "Create a new box object.")
 {
-  LeptonObject *obj = lepton_box_object_new (OBJ_BOX, default_color_id(),
+  LeptonObject *obj = lepton_box_object_new (default_color_id(),
                                              0, 0, 0, 0);
 
   SCM result = edascm_from_object (obj);

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -954,7 +954,7 @@ SCM_DEFINE (make_net, "%make-net", 0, 0, 0,
   LeptonObject *obj;
   SCM result;
 
-  obj = lepton_net_object_new (OBJ_NET, NET_COLOR, 0, 0, 0, 0);
+  obj = lepton_net_object_new (NET_COLOR, 0, 0, 0, 0);
 
 
   result = edascm_from_object (obj);

--- a/liblepton/tests/test_net_object.c
+++ b/liblepton/tests/test_net_object.c
@@ -14,8 +14,7 @@ check_construction ()
     gint y1 = g_test_rand_int ();
     gint color = g_test_rand_int_range (0, colors_count());
 
-    LeptonObject *object0 = lepton_net_object_new (OBJ_NET,
-                                                   color,
+    LeptonObject *object0 = lepton_net_object_new (color,
                                                    x0,
                                                    y0,
                                                    x1,
@@ -63,8 +62,7 @@ check_accessors ()
     gint y1 = g_test_rand_int ();
     gint color = g_test_rand_int_range (0, colors_count());
 
-    LeptonObject *object0 = lepton_net_object_new (OBJ_NET,
-                                                   color,
+    LeptonObject *object0 = lepton_net_object_new (color,
                                                    x0,
                                                    y0,
                                                    x1,
@@ -115,8 +113,7 @@ check_serialization ()
     gint y1 = g_test_rand_int ();
     gint color = g_test_rand_int_range (0, colors_count());
 
-    LeptonObject *object0 = lepton_net_object_new (OBJ_NET,
-                                                   color,
+    LeptonObject *object0 = lepton_net_object_new (color,
                                                    x0,
                                                    y0,
                                                    x1,

--- a/libleptongui/src/o_box.c
+++ b/libleptongui/src/o_box.c
@@ -135,9 +135,11 @@ void o_box_end(GschemToplevel *w_current, int w_x, int w_y)
   } else {
 
     /* create the object */
-    new_obj = lepton_box_object_new (OBJ_BOX, GRAPHIC_COLOR,
-                                     box_left, box_top,
-                                     box_left + box_width, box_top - box_height);
+    new_obj = lepton_box_object_new (GRAPHIC_COLOR,
+                                     box_left,
+                                     box_top,
+                                     box_left + box_width,
+                                     box_top - box_height);
     s_page_append (page, new_obj);
 
 #if DEBUG

--- a/libleptongui/src/o_move.c
+++ b/libleptongui/src/o_move.c
@@ -573,9 +573,11 @@ void o_move_check_endpoint(GschemToplevel *w_current, LeptonObject * object)
 
       LeptonObject *new_net;
       /* other object is a pin, insert a net */
-      new_net = lepton_net_object_new (OBJ_NET, NET_COLOR,
-                                       c_current->x, c_current->y,
-                                       c_current->x, c_current->y);
+      new_net = lepton_net_object_new (NET_COLOR,
+                                       c_current->x,
+                                       c_current->y,
+                                       c_current->x,
+                                       c_current->y);
       s_page_append (page, new_net);
       /* This new net object is only picked up for stretching later,
        * somewhat of a kludge. If the move operation is cancelled, these

--- a/libleptongui/src/o_net.c
+++ b/libleptongui/src/o_net.c
@@ -517,9 +517,11 @@ void o_net_end(GschemToplevel *w_current, int w_x, int w_y)
 
   if (!primary_zero_length ) {
   /* create primary net */
-    new_net = lepton_net_object_new (OBJ_NET, NET_COLOR,
-                                     w_current->first_wx, w_current->first_wy,
-                                     w_current->second_wx, w_current->second_wy);
+    new_net = lepton_net_object_new (NET_COLOR,
+                                     w_current->first_wx,
+                                     w_current->first_wy,
+                                     w_current->second_wx,
+                                     w_current->second_wy);
       s_page_append (page, new_net);
 
       added_objects = g_list_prepend (added_objects, new_net);
@@ -552,9 +554,11 @@ void o_net_end(GschemToplevel *w_current, int w_x, int w_y)
   if (!secondary_zero_length && !found_primary_connection) {
 
       /* Add secondary net */
-    new_net = lepton_net_object_new (OBJ_NET, NET_COLOR,
-                                     w_current->second_wx, w_current->second_wy,
-                                     w_current->third_wx, w_current->third_wy);
+    new_net = lepton_net_object_new (NET_COLOR,
+                                     w_current->second_wx,
+                                     w_current->second_wy,
+                                     w_current->third_wx,
+                                     w_current->third_wy);
       s_page_append (page, new_net);
 
       added_objects = g_list_prepend (added_objects, new_net);
@@ -1054,9 +1058,11 @@ int o_net_add_busrippers(GschemToplevel *w_current, LeptonObject *net_obj,
 
     for (i = 0; i < ripper_count; i++) {
       if (w_current->bus_ripper_type == NET_BUS_RIPPER) {
-        new_obj = lepton_net_object_new (OBJ_NET, NET_COLOR,
-                                         rippers[i].x[0], rippers[i].y[0],
-                                         rippers[i].x[1], rippers[i].y[1]);
+        new_obj = lepton_net_object_new (NET_COLOR,
+                                         rippers[i].x[0],
+                                         rippers[i].y[0],
+                                         rippers[i].x[1],
+                                         rippers[i].y[1]);
         s_page_append (page, new_obj);
       } else {
 

--- a/libleptongui/src/o_path.c
+++ b/libleptongui/src/o_path.c
@@ -499,8 +499,7 @@ o_path_end(GschemToplevel *w_current, int w_x, int w_y)
 
   if (end_path || close_path) {
     /* Add object to page and clean up path drawing state */
-    LeptonObject *obj = lepton_path_object_new_take_path (OBJ_PATH,
-                                                          GRAPHIC_COLOR, p);
+    LeptonObject *obj = lepton_path_object_new_take_path (GRAPHIC_COLOR, p);
     w_current->temp_path = NULL;
     w_current->first_wx = -1;
     w_current->first_wy = -1;


### PR DESCRIPTION
The `type` argument was used for creating some objects while was missing for others.  There's no point to use it if we know what object is really created.