### PR TITLE
Redefine basic object functions using Scheme FFI

### DIFF
--- a/liblepton/include/liblepton/object.h
+++ b/liblepton/include/liblepton/object.h
@@ -302,4 +302,11 @@ void
 lepton_object_remove_weak_ptr (LeptonObject *object,
                                void *weak_pointer_loc);
 
+/* object.c */
+void
+lepton_object_emit_pre_change_notify (LeptonObject *object);
+
+void
+lepton_object_emit_change_notify (LeptonObject *object);
+
 G_END_DECLS

--- a/liblepton/include/prototype_priv.h
+++ b/liblepton/include/prototype_priv.h
@@ -21,10 +21,6 @@ o_read_attribs (LeptonPage *page,
                 GError **err);
 LeptonObject *o_attrib_find_attrib_by_name (const GList *list, const char *name, int count);
 
-/* object.c */
-void lepton_object_emit_pre_change_notify (LeptonObject *object);
-void lepton_object_emit_change_notify (LeptonObject *object);
-
 /* o_selection.c */
 void o_selection_select (LeptonObject *object);
 void o_selection_unselect (LeptonObject *object);

--- a/liblepton/scheme/lepton/ffi.scm.in
+++ b/liblepton/scheme/lepton/ffi.scm.in
@@ -33,6 +33,7 @@
             lepton_object_get_color
             lepton_object_set_color
             lepton_object_get_id
+            lepton_object_get_parent
             lepton_object_get_selectable
             lepton_object_set_selectable
             lepton_object_get_type
@@ -126,6 +127,7 @@
 (define-lff lepton_object_get_color int '(*))
 (define-lff lepton_object_set_color void (list '* int))
 (define-lff lepton_object_get_id int '(*))
+(define-lff lepton_object_get_parent '* '(*))
 (define-lff lepton_object_get_selectable int '(*))
 (define-lff lepton_object_set_selectable void (list '* int))
 (define-lff lepton_object_get_type int '(*))

--- a/liblepton/scheme/lepton/ffi.scm.in
+++ b/liblepton/scheme/lepton/ffi.scm.in
@@ -31,6 +31,7 @@
             edascm_is_page
 
             lepton_object_get_color
+            lepton_object_set_color
             lepton_object_get_id
             lepton_object_get_selectable
             lepton_object_set_selectable
@@ -110,6 +111,7 @@
 
 ;;; object.c
 (define-lff lepton_object_get_color int '(*))
+(define-lff lepton_object_set_color void (list '* int))
 (define-lff lepton_object_get_id int '(*))
 (define-lff lepton_object_get_selectable int '(*))
 (define-lff lepton_object_set_selectable void (list '* int))

--- a/liblepton/scheme/lepton/ffi.scm.in
+++ b/liblepton/scheme/lepton/ffi.scm.in
@@ -54,6 +54,7 @@
             lepton_object_emit_change_notify
             lepton_object_emit_pre_change_notify
             lepton_object_mirror
+            lepton_object_rotate
 
             lepton_component_object_get_embedded
             lepton_component_object_embed
@@ -145,6 +146,7 @@
 (define-lff lepton_object_emit_change_notify void '(*))
 (define-lff lepton_object_emit_pre_change_notify void '(*))
 (define-lff lepton_object_mirror void (list int int '*))
+(define-lff lepton_object_rotate void (list int int int '*))
 
 (define-lff lepton_object_page_set_changed void '(*))
 

--- a/liblepton/scheme/lepton/ffi.scm.in
+++ b/liblepton/scheme/lepton/ffi.scm.in
@@ -52,6 +52,9 @@
             lepton_object_calculate_visible_bounds
             lepton_object_copy
 
+            lepton_component_object_get_embedded
+            lepton_picture_object_get_embedded
+
             set_render_placeholders
             colors_count
             g_rc_parse
@@ -133,6 +136,9 @@
 (define-lff lepton_object_copy '* '(*))
 
 (define-lff lepton_object_page_set_changed void '(*))
+
+(define-lff lepton_component_object_get_embedded int '(*))
+(define-lff lepton_picture_object_get_embedded int '(*))
 
 ;;; Helper transformers between #<geda-object> smobs and C object
 ;;; pointers.

--- a/liblepton/scheme/lepton/ffi.scm.in
+++ b/liblepton/scheme/lepton/ffi.scm.in
@@ -30,6 +30,7 @@
             edascm_is_object
             edascm_is_page
 
+            lepton_object_get_color
             lepton_object_get_id
             lepton_object_get_selectable
             lepton_object_set_selectable
@@ -108,6 +109,7 @@
 (define-lff edascm_from_object '* '(*))
 
 ;;; object.c
+(define-lff lepton_object_get_color int '(*))
 (define-lff lepton_object_get_id int '(*))
 (define-lff lepton_object_get_selectable int '(*))
 (define-lff lepton_object_set_selectable void (list '* int))

--- a/liblepton/scheme/lepton/ffi.scm.in
+++ b/liblepton/scheme/lepton/ffi.scm.in
@@ -45,6 +45,7 @@
             lepton_object_is_pin
             lepton_object_is_text
 
+            lepton_object_calculate_visible_bounds
             lepton_object_copy
 
             set_render_placeholders
@@ -119,6 +120,7 @@
 (define-lff lepton_object_is_pin int '(*))
 (define-lff lepton_object_is_text int '(*))
 
+(define-lff lepton_object_calculate_visible_bounds int (list '* int '* '* '* '*))
 (define-lff lepton_object_copy '* '(*))
 
 ;;; Helper transformers between #<geda-object> smobs and C object

--- a/liblepton/scheme/lepton/ffi.scm.in
+++ b/liblepton/scheme/lepton/ffi.scm.in
@@ -31,6 +31,7 @@
             edascm_is_page
 
             lepton_object_get_id
+            lepton_object_get_selectable
             lepton_object_get_type
 
             lepton_object_is_arc
@@ -106,6 +107,7 @@
 
 ;;; object.c
 (define-lff lepton_object_get_id int '(*))
+(define-lff lepton_object_get_selectable int '(*))
 (define-lff lepton_object_get_type int '(*))
 
 (define-lff lepton_object_is_arc int '(*))

--- a/liblepton/scheme/lepton/ffi.scm.in
+++ b/liblepton/scheme/lepton/ffi.scm.in
@@ -32,6 +32,7 @@
 
             lepton_object_get_id
             lepton_object_get_selectable
+            lepton_object_set_selectable
             lepton_object_get_type
 
             lepton_object_is_arc
@@ -55,6 +56,7 @@
             lepton_colormap_color_by_id
             lepton_colormap_disable_color
             lepton_colormap_set_color
+            lepton_object_page_set_changed
             print_colors_array
             s_attrib_uniq
             s_attrib_add_entry
@@ -108,6 +110,7 @@
 ;;; object.c
 (define-lff lepton_object_get_id int '(*))
 (define-lff lepton_object_get_selectable int '(*))
+(define-lff lepton_object_set_selectable void (list '* int))
 (define-lff lepton_object_get_type int '(*))
 
 (define-lff lepton_object_is_arc int '(*))
@@ -124,6 +127,8 @@
 
 (define-lff lepton_object_calculate_visible_bounds int (list '* int '* '* '* '*))
 (define-lff lepton_object_copy '* '(*))
+
+(define-lff lepton_object_page_set_changed void '(*))
 
 ;;; Helper transformers between #<geda-object> smobs and C object
 ;;; pointers.

--- a/liblepton/scheme/lepton/ffi.scm.in
+++ b/liblepton/scheme/lepton/ffi.scm.in
@@ -51,6 +51,9 @@
 
             lepton_object_calculate_visible_bounds
             lepton_object_copy
+            lepton_object_emit_change_notify
+            lepton_object_emit_pre_change_notify
+            lepton_object_mirror
 
             lepton_component_object_get_embedded
             lepton_component_object_embed
@@ -139,6 +142,9 @@
 
 (define-lff lepton_object_calculate_visible_bounds int (list '* int '* '* '* '*))
 (define-lff lepton_object_copy '* '(*))
+(define-lff lepton_object_emit_change_notify void '(*))
+(define-lff lepton_object_emit_pre_change_notify void '(*))
+(define-lff lepton_object_mirror void (list int int '*))
 
 (define-lff lepton_object_page_set_changed void '(*))
 

--- a/liblepton/scheme/lepton/ffi.scm.in
+++ b/liblepton/scheme/lepton/ffi.scm.in
@@ -55,6 +55,7 @@
             lepton_object_emit_pre_change_notify
             lepton_object_mirror
             lepton_object_rotate
+            lepton_object_translate
 
             lepton_component_object_get_embedded
             lepton_component_object_embed
@@ -147,6 +148,7 @@
 (define-lff lepton_object_emit_pre_change_notify void '(*))
 (define-lff lepton_object_mirror void (list int int '*))
 (define-lff lepton_object_rotate void (list int int int '*))
+(define-lff lepton_object_translate void (list '* int int))
 
 (define-lff lepton_object_page_set_changed void '(*))
 

--- a/liblepton/scheme/lepton/ffi.scm.in
+++ b/liblepton/scheme/lepton/ffi.scm.in
@@ -45,6 +45,8 @@
             lepton_object_is_pin
             lepton_object_is_text
 
+            lepton_object_copy
+
             set_render_placeholders
             colors_count
             g_rc_parse
@@ -117,6 +119,7 @@
 (define-lff lepton_object_is_pin int '(*))
 (define-lff lepton_object_is_text int '(*))
 
+(define-lff lepton_object_copy '* '(*))
 
 ;;; Helper transformers between #<geda-object> smobs and C object
 ;;; pointers.

--- a/liblepton/scheme/lepton/ffi.scm.in
+++ b/liblepton/scheme/lepton/ffi.scm.in
@@ -22,6 +22,7 @@
             ;; Helpers.
             true?
             geda-object->pointer
+            geda-object->pointer*
             pointer->geda-object
 
             ;; Foreign functions.
@@ -127,3 +128,23 @@
 (define (pointer->geda-object pointer)
   ;; Return #f if the pointer is wrong.
   (false-if-exception (pointer->scm (edascm_from_object pointer))))
+
+;;; This syntax rule is intended for use in toplevel 'define' or
+;;; 'let' forms in the functions where the check for wrong type of
+;;; OBJECT is necessary.  The rule checks the object and, if it is
+;;; not #<geda-object>, throws an error with the 'wrong-type-arg
+;;; key reporting the function name and position POS of the
+;;; OBJECT argument.  In short, the usage is as follows:
+;;;   (define (myfunc object)
+;;;     (define pointer (geda-object->pointer* object 1))
+;;;     (function-body))
+(define-syntax-rule (geda-object->pointer* object pos)
+  (let ((pointer (geda-object->pointer object)))
+    (if (null-pointer? pointer)
+        (let ((proc-name (frame-procedure-name (stack-ref (make-stack #t) 1))))
+          (scm-error 'wrong-type-arg
+                     proc-name
+                     "Wrong type argument in position ~A: ~A"
+                     (list pos object)
+                     #f))
+        pointer)))

--- a/liblepton/scheme/lepton/ffi.scm.in
+++ b/liblepton/scheme/lepton/ffi.scm.in
@@ -185,7 +185,11 @@
 (define-syntax-rule (geda-object->pointer* object pos)
   (let ((pointer (geda-object->pointer object)))
     (if (null-pointer? pointer)
-        (let ((proc-name (frame-procedure-name (stack-ref (make-stack #t) 1))))
+        (let ((proc-name
+               ;; Provision agains Guile-2.0 that does not have the procedure.
+               (if (defined? 'frame-procedure-name)
+                   (frame-procedure-name (stack-ref (make-stack #t) 1))
+                   '??)))
           (scm-error 'wrong-type-arg
                      proc-name
                      "Wrong type argument in position ~A: ~A"

--- a/liblepton/scheme/lepton/ffi.scm.in
+++ b/liblepton/scheme/lepton/ffi.scm.in
@@ -53,7 +53,12 @@
             lepton_object_copy
 
             lepton_component_object_get_embedded
+            lepton_component_object_embed
+            lepton_component_object_unembed
+
             lepton_picture_object_get_embedded
+            lepton_picture_object_embed
+            lepton_picture_object_unembed
 
             set_render_placeholders
             colors_count
@@ -138,7 +143,12 @@
 (define-lff lepton_object_page_set_changed void '(*))
 
 (define-lff lepton_component_object_get_embedded int '(*))
+(define-lff lepton_component_object_embed void '(*))
+(define-lff lepton_component_object_unembed void '(*))
+
 (define-lff lepton_picture_object_get_embedded int '(*))
+(define-lff lepton_picture_object_embed void '(*))
+(define-lff lepton_picture_object_unembed void '(*))
 
 ;;; Helper transformers between #<geda-object> smobs and C object
 ;;; pointers.

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -452,7 +452,7 @@ Returns OBJECT."
 (define-public (set-component-with-transform! c position angle mirror locked)
   (let ((obj (%set-component! c 0 0 0 #f locked)))
     (%translate-object!
-      (%rotate-object!
+      (rotate-object!
         (if mirror (mirror-object! obj 0) obj)
         0 0 angle)
     (car position)
@@ -582,7 +582,7 @@ actual bounds of the objects, not the visible bounds."
 
 (define-public (rotate-objects! center angle . objects)
   (for-each
-   (lambda (x) (%rotate-object! x (car center) (cdr center) angle))
+   (lambda (x) (rotate-object! x (car center) (cdr center) angle))
    objects)
   objects)
 
@@ -657,3 +657,21 @@ nothing.  Returns OBJECT."
   (lepton_object_page_set_changed pointer)
 
   object)
+
+
+;;; Rotates OBJECT anti-clockwise by ANGLE about the coordinate of
+;;; centre of rotation specified by X and Y.  ANGLE must be an
+;;; integer multiple of 90 degrees.  Returns OBJECT.
+(define (rotate-object! object x y angle)
+  (define pointer (geda-object->pointer* object 1))
+
+  (let ((angle (euclidean-remainder angle 360)))
+    (when (not (zero? (euclidean-remainder angle 90)))
+      (error "Wrong rotation angle: ~A" angle))
+
+    (lepton_object_emit_pre_change_notify pointer)
+    (lepton_object_rotate x y angle pointer)
+    (lepton_object_emit_change_notify pointer)
+    (lepton_object_page_set_changed pointer)
+
+    object))

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -50,6 +50,7 @@
             object-color
             set-object-color!
             object-embedded?
+            set-object-embedded!
             object-selectable?
             set-object-selectable!))
 
@@ -622,4 +623,25 @@ Returns OBJECT."
   (or (true? (lepton_component_object_get_embedded pointer))
       (true? (lepton_picture_object_get_embedded pointer))))
 
-( define-public set-object-embedded! %set-object-embedded! )
+
+(define (set-object-embedded! object embed?)
+  "Unembeds OBJECT if EMBED? is #f, otherwise embeds it.  OBJECT
+must be a component or a picture, otherwise the procedure does
+nothing.  Returns OBJECT."
+  (define (embed-func embed unembed)
+    (if embed? embed unembed))
+
+  (define (embed-component x)
+    ((embed-func lepton_component_object_embed
+                 lepton_component_object_unembed) x))
+
+  (define (embed-picture x)
+    ((embed-func lepton_picture_object_embed
+                 lepton_picture_object_unembed) x))
+
+  (define pointer (geda-object->pointer* object 1))
+
+  (or (and (component? object) (embed-component pointer))
+      (and (picture? object) (embed-picture pointer)))
+
+  object)

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -26,7 +26,6 @@
 
   ;; Import C procedures
   #:use-module (lepton core component)
-  #:use-module (lepton core gettext)
   #:use-module (lepton core object)
   #:use-module (lepton ffi)
 
@@ -75,7 +74,7 @@ returns #f."
    ((picture? object) 'picture)
    ((pin? object) 'pin)
    ((text? object) 'text)
-   (else (error (G_ "Object ~A has bad type '~A'")
+   (else (error "Object ~A has bad type '~A'"
                 object
                 (integer->char (lepton_object_get_type pointer))))))
 

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -628,8 +628,10 @@ Returns OBJECT."
   "Check whether OBJECT is embedded."
   (define pointer (geda-object->pointer* object 1))
 
-  (or (true? (lepton_component_object_get_embedded pointer))
-      (true? (lepton_picture_object_get_embedded pointer))))
+  (or (and (component? object)
+           (true? (lepton_component_object_get_embedded pointer)))
+      (and (picture? object)
+           (true? (lepton_picture_object_get_embedded pointer)))))
 
 
 (define (set-object-embedded! object embed?)

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -49,6 +49,7 @@
             object-bounds
             object-color
             set-object-color!
+            object-component
             object-embedded?
             set-object-embedded!
             object-selectable?
@@ -120,7 +121,14 @@ Returns OBJECT."
 
 (define-public object-connections %object-connections)
 
-(define-public object-component %object-component)
+(define (object-component object)
+  "Returns the component object that contains OBJECT.
+If OBJECT is not part of a component, returns #f."
+  (define pointer (geda-object->pointer* object 1))
+
+  (let ((parent-pointer (lepton_object_get_parent pointer)))
+    (and (not (null-pointer? parent-pointer))
+         (pointer->geda-object parent-pointer))))
 
 ;;;; Lines
 

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -453,7 +453,7 @@ Returns OBJECT."
   (let ((obj (%set-component! c 0 0 0 #f locked)))
     (%translate-object!
       (%rotate-object!
-        (if mirror (%mirror-object! obj 0) obj)
+        (if mirror (mirror-object! obj 0) obj)
         0 0 angle)
     (car position)
     (cdr position))))
@@ -588,7 +588,7 @@ actual bounds of the objects, not the visible bounds."
 
 (define-public (mirror-objects! x . objects)
   (for-each
-   (lambda (obj) (%mirror-object! obj x))
+   (lambda (obj) (mirror-object! obj x))
    objects)
   objects)
 
@@ -643,5 +643,17 @@ nothing.  Returns OBJECT."
 
   (or (and (component? object) (embed-component pointer))
       (and (picture? object) (embed-picture pointer)))
+
+  object)
+
+;;; Mirrors OBJECT using X as x-coordinate of centre of rotation.
+;;; Returns OBJECT.
+(define (mirror-object! object x)
+  (define pointer (geda-object->pointer* object 1))
+
+  (lepton_object_emit_pre_change_notify pointer)
+  (lepton_object_mirror x 0 pointer)
+  (lepton_object_emit_change_notify pointer)
+  (lepton_object_page_set_changed pointer)
 
   object)

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -47,6 +47,7 @@
             text?
             copy-object
             object-bounds
+            object-color
             object-selectable?
             set-object-selectable!))
 
@@ -94,7 +95,15 @@ returns #f."
   (pointer->geda-object (lepton_object_copy pointer)))
 
 
-(define-public object-color %object-color)
+(define (object-color object)
+  "Returns the colormap index of the color used to draw
+OBJECT. Note that the color may not be meaningful for some object
+types."
+  (define pointer (geda-object->pointer* object 1))
+
+  (lepton_object_get_color pointer))
+
+
 (define-public set-object-color! %set-object-color!)
 
 (define-public object-connections %object-connections)

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -47,7 +47,8 @@
             text?
             copy-object
             object-bounds
-            object-selectable?))
+            object-selectable?
+            set-object-selectable!))
 
 (define (object? object)
   "Returns #t if OBJECT is a #<geda-object> instance, otherwise
@@ -580,7 +581,18 @@ Returns #t if OBJECT is selectable, otherwise returns #f."
   (true? (lepton_object_get_selectable pointer)))
 
 
-( define-public set-object-selectable! %set-object-selectable! )
+(define (set-object-selectable! object selectable?)
+  "Sets OBJECT's selectable flag to SELECTABLE?, thus locking or
+unlocking OBJECT.  Locked objects cannot be selected in GUI.
+Returns OBJECT."
+  (define pointer (geda-object->pointer* object 1))
+
+  (unless (eq? (object-selectable? object) selectable?)
+    (lepton_object_set_selectable pointer (if selectable? 1 0))
+    (lepton_object_page_set_changed pointer))
+
+  object)
+
 
 ( define-public object-embedded?     %object-embedded? )
 ( define-public set-object-embedded! %set-object-embedded! )

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -451,7 +451,7 @@ Returns OBJECT."
 
 (define-public (set-component-with-transform! c position angle mirror locked)
   (let ((obj (%set-component! c 0 0 0 #f locked)))
-    (%translate-object!
+    (translate-object!
       (rotate-object!
         (if mirror (mirror-object! obj 0) obj)
         0 0 angle)
@@ -576,7 +576,7 @@ actual bounds of the objects, not the visible bounds."
 
 (define-public (translate-objects! vector . objects)
   (for-each
-   (lambda (x) (%translate-object! x (car vector) (cdr vector)))
+   (lambda (x) (translate-object! x (car vector) (cdr vector)))
    objects)
   objects)
 
@@ -675,3 +675,16 @@ nothing.  Returns OBJECT."
     (lepton_object_page_set_changed pointer)
 
     object))
+
+;;; Translate OBJECT by DX in the x-axis and DY in the y-axis.  DX
+;;; and DY are integer distances along corresponding axes.
+;;; Returns OBJECT.
+(define (translate-object! object dx dy)
+  (define pointer (geda-object->pointer* object 1))
+
+  (lepton_object_emit_pre_change_notify pointer)
+  (lepton_object_translate pointer dx dy)
+  (lepton_object_emit_change_notify pointer)
+  (lepton_object_page_set_changed pointer)
+
+  object)

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -43,7 +43,8 @@
             path?
             picture?
             pin?
-            text?))
+            text?
+            copy-object))
 
 (define (object? object)
   "Returns #t if OBJECT is a #<geda-object> instance, otherwise
@@ -82,7 +83,12 @@ returns #f."
   (and (object? x)
        (eq? (object-type x) type)))
 
-(define-public copy-object %copy-object)
+(define (copy-object object)
+  "Returns a copy of OBJECT."
+  (define pointer (geda-object->pointer* object 1))
+
+  (pointer->geda-object (lepton_object_copy pointer)))
+
 
 (define-public object-color %object-color)
 (define-public set-object-color! %set-object-color!)

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -46,7 +46,8 @@
             pin?
             text?
             copy-object
-            object-bounds))
+            object-bounds
+            object-selectable?))
 
 (define (object? object)
   "Returns #t if OBJECT is a #<geda-object> instance, otherwise
@@ -569,7 +570,16 @@ actual bounds of the objects, not the visible bounds."
    objects)
   objects)
 
-( define-public object-selectable?     %object-selectable? )
+
+(define (object-selectable? object)
+  "Checks the state of OBJECT's selectable flag: if it's true, the
+object is considered to be unlocked, otherwise it is locked.
+Returns #t if OBJECT is selectable, otherwise returns #f."
+  (define pointer (geda-object->pointer* object 1))
+
+  (true? (lepton_object_get_selectable pointer)))
+
+
 ( define-public set-object-selectable! %set-object-selectable! )
 
 ( define-public object-embedded?     %object-embedded? )

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -48,6 +48,7 @@
             copy-object
             object-bounds
             object-color
+            set-object-color!
             object-selectable?
             set-object-selectable!))
 
@@ -104,7 +105,16 @@ types."
   (lepton_object_get_color pointer))
 
 
-(define-public set-object-color! %set-object-color!)
+(define (set-object-color! object color)
+  "Set the colormap index of the color used to draw OBJECT to COLOR.
+Note that the color may not be meaningful for some object types.
+Returns OBJECT."
+  (define pointer (geda-object->pointer* object 1))
+
+  (lepton_object_set_color pointer color)
+
+  object)
+
 
 (define-public object-connections %object-connections)
 

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -49,6 +49,7 @@
             object-bounds
             object-color
             set-object-color!
+            object-embedded?
             object-selectable?
             set-object-selectable!))
 
@@ -613,5 +614,12 @@ Returns OBJECT."
   object)
 
 
-( define-public object-embedded?     %object-embedded? )
+
+(define (object-embedded? object)
+  "Check whether OBJECT is embedded."
+  (define pointer (geda-object->pointer* object 1))
+
+  (or (true? (lepton_component_object_get_embedded pointer))
+      (true? (lepton_picture_object_get_embedded pointer))))
+
 ( define-public set-object-embedded! %set-object-embedded! )

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -61,24 +61,23 @@ returns #f."
 
 (define (object-type object)
   "Returns a Scheme symbol representing the type of OBJECT."
-  (if (object? object)
-      (cond
-       ((arc? object) 'arc)
-       ((box? object) 'box)
-       ((bus? object) 'bus)
-       ((circle? object) 'circle)
-       ((component? object) 'complex)
-       ((line? object) 'line)
-       ((net? object) 'net)
-       ((path? object) 'path)
-       ((picture? object) 'picture)
-       ((pin? object) 'pin)
-       ((text? object) 'text)
-       (else (error (G_ "Object ~A has bad type '~A'")
-                    object
-                    (integer->char (lepton_object_get_type object)))))
-      (throw 'wrong-type-arg (G_ "object-type: Wrong type argument: ~A")
-             object)))
+  (define pointer (geda-object->pointer* object 1))
+
+  (cond
+   ((arc? object) 'arc)
+   ((box? object) 'box)
+   ((bus? object) 'bus)
+   ((circle? object) 'circle)
+   ((component? object) 'complex)
+   ((line? object) 'line)
+   ((net? object) 'net)
+   ((path? object) 'path)
+   ((picture? object) 'picture)
+   ((pin? object) 'pin)
+   ((text? object) 'text)
+   (else (error (G_ "Object ~A has bad type '~A'")
+                object
+                (integer->char (lepton_object_get_type pointer))))))
 
 (define (object-type? x type)
   (and (object? x)

--- a/liblepton/scheme/unit-tests/lepton-object-bounds.scm
+++ b/liblepton/scheme/unit-tests/lepton-object-bounds.scm
@@ -56,3 +56,10 @@
     (test-equal #f (fold-bounds #f #f))))
 
 (test-end "fold-bounds")
+
+
+(test-begin "object-bounds-wrong-argument")
+
+(test-assert-thrown 'wrong-type-arg (object-bounds 'a))
+
+(test-end "object-bounds-wrong-argument")

--- a/liblepton/scheme/unit-tests/lepton-object-component.scm
+++ b/liblepton/scheme/unit-tests/lepton-object-component.scm
@@ -342,3 +342,9 @@
       ;; Clean up.
       (delete-file get-command))))
 (test-end "component-library-command")
+
+(test-begin "object-component-wrong-argument")
+
+(test-assert-thrown 'wrong-type-arg (object-component 'a))
+
+(test-end "object-component-wrong-argument")

--- a/liblepton/scheme/unit-tests/lepton-object-copy.scm
+++ b/liblepton/scheme/unit-tests/lepton-object-copy.scm
@@ -49,3 +49,7 @@
   (test-equal #f (member p (component-contents (copy-object A)))))
 
 (test-end "copy-object-deep-component")
+
+(test-begin "copy-object-wrong-argument")
+(test-assert-thrown 'wrong-type-arg (copy-object 'a))
+(test-end "copy-object-wrong-argument")

--- a/liblepton/scheme/unit-tests/lepton-object-embedded.scm
+++ b/liblepton/scheme/unit-tests/lepton-object-embedded.scm
@@ -155,3 +155,8 @@
   )
 
 (test-end "object-embedded")
+
+
+(test-begin "object-embedded-wrong-argument")
+(test-assert-thrown 'wrong-type-arg (object-embedded? 'a))
+(test-end "object-embedded-wrong-argument")

--- a/liblepton/scheme/unit-tests/lepton-object-embedded.scm
+++ b/liblepton/scheme/unit-tests/lepton-object-embedded.scm
@@ -158,5 +158,9 @@
 
 
 (test-begin "object-embedded-wrong-argument")
+
 (test-assert-thrown 'wrong-type-arg (object-embedded? 'a))
+(test-assert-thrown 'wrong-type-arg (set-object-embedded! 'a #t))
+(test-assert-thrown 'wrong-type-arg (set-object-embedded! 'a #f))
+
 (test-end "object-embedded-wrong-argument")

--- a/liblepton/scheme/unit-tests/lepton-object-selectable.scm
+++ b/liblepton/scheme/unit-tests/lepton-object-selectable.scm
@@ -77,3 +77,11 @@
   )
 
 (test-end "object-selectable")
+
+(test-begin "object-selectable-wrong-argument")
+
+(test-assert-thrown 'wrong-type-arg (object-selectable? 'a))
+(test-assert-thrown 'wrong-type-arg (set-object-selectable! 'a #t))
+(test-assert-thrown 'wrong-type-arg (set-object-selectable! 'a #f))
+
+(test-end "object-selectable-wrong-argument")

--- a/liblepton/scheme/unit-tests/lepton-object-wrong.scm
+++ b/liblepton/scheme/unit-tests/lepton-object-wrong.scm
@@ -9,5 +9,6 @@
 (test-assert (not (object-type? 'a 'a)))
 
 (test-assert-thrown 'wrong-type-arg (object-color 'a))
+(test-assert-thrown 'wrong-type-arg (set-object-color! 'a 3))
 
 (test-end "non-object")

--- a/liblepton/scheme/unit-tests/lepton-object-wrong.scm
+++ b/liblepton/scheme/unit-tests/lepton-object-wrong.scm
@@ -11,4 +11,5 @@
 (test-assert-thrown 'wrong-type-arg (object-color 'a))
 (test-assert-thrown 'wrong-type-arg (set-object-color! 'a 3))
 
+(test-assert-thrown 'wrong-type-arg (mirror-objects! 0 'a))
 (test-end "non-object")

--- a/liblepton/scheme/unit-tests/lepton-object-wrong.scm
+++ b/liblepton/scheme/unit-tests/lepton-object-wrong.scm
@@ -8,4 +8,6 @@
 (test-assert-thrown 'wrong-type-arg (object-type 'a))
 (test-assert (not (object-type? 'a 'a)))
 
+(test-assert-thrown 'wrong-type-arg (object-color 'a))
+
 (test-end "non-object")

--- a/liblepton/scheme/unit-tests/lepton-object-wrong.scm
+++ b/liblepton/scheme/unit-tests/lepton-object-wrong.scm
@@ -12,4 +12,5 @@
 (test-assert-thrown 'wrong-type-arg (set-object-color! 'a 3))
 
 (test-assert-thrown 'wrong-type-arg (mirror-objects! 0 'a))
+(test-assert-thrown 'wrong-type-arg (rotate-objects! '(0 . 0) 90 'a))
 (test-end "non-object")

--- a/liblepton/scheme/unit-tests/lepton-object-wrong.scm
+++ b/liblepton/scheme/unit-tests/lepton-object-wrong.scm
@@ -13,4 +13,6 @@
 
 (test-assert-thrown 'wrong-type-arg (mirror-objects! 0 'a))
 (test-assert-thrown 'wrong-type-arg (rotate-objects! '(0 . 0) 90 'a))
+(test-assert-thrown 'wrong-type-arg (translate-objects! '(100 . 100) 'a))
+
 (test-end "non-object")

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -154,35 +154,6 @@ edascm_is_object_type (SCM smob, int type)
   return (lepton_object_get_type (obj) == type);
 }
 
-/*! \brief Copy an object.
- * \par Function Description
- * Returns a copy of the #LeptonObject contained in smob \a obj_s as a new
- * smob.
- *
- * \note Scheme API: Implements the %copy-object procedure in the
- * (lepton core object) module.
- *
- * \param [in] obj_s an #LeptonObject smob.
- * \return a new #LeptonObject smob containing a copy of the #LeptonObject in \a obj_s.
- */
-SCM_DEFINE (copy_object, "%copy-object", 1, 0, 0,
-            (SCM obj_s), "Copy an object.")
-{
-  SCM result;
-  SCM_ASSERT (EDASCM_OBJECTP (obj_s), obj_s,
-              SCM_ARG1, s_copy_object);
-
-  LeptonObject *obj = edascm_to_object (obj_s);
-
-  result = edascm_from_object (lepton_object_copy (obj));
-
-  /* At the moment, the only pointer to the object is owned by the
-   * smob. */
-  edascm_c_set_gc (result, TRUE);
-
-  return result;
-}
-
 /*! \brief Get the bounds of a list of objects
  * \par Function Description
  * Returns the bounds of the objects in the variable-length argument
@@ -2296,8 +2267,7 @@ init_module_lepton_core_object (void *unused)
   #include "scheme_object.x"
 
   /* Add them to the module's public definitions. */
-  scm_c_export (s_copy_object,
-                s_object_bounds,
+  scm_c_export (s_object_bounds,
                 s_object_stroke,
                 s_set_object_stroke_x,
                 s_object_fill,

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -498,36 +498,6 @@ SCM_DEFINE (set_object_fill_x, "%set-object-fill!", 2, 5, 0,
   return obj_s;
 }
 
-/*! \brief Set the color of an object.
- * \par Function Description
- * Set the colormap index of the color used to draw the #LeptonObject smob
- * \a obj_s to \a color_s. Note that the color may not be meaningful
- * for some object types.
- *
- * \note Scheme API: Implements the %set-object-color! procedure in
- * the (lepton core object) module.
- *
- * \param obj_s   #LeptonObject smob to modify.
- * \param color_s new colormap index to use for \a obj_s.
- * \return the modified \a obj_s.
- */
-SCM_DEFINE (set_object_color_x, "%set-object-color!", 2, 0, 0,
-            (SCM obj_s, SCM color_s), "Set the color of an object.")
-{
-  SCM_ASSERT (EDASCM_OBJECTP (obj_s), obj_s,
-              SCM_ARG1, s_set_object_color_x);
-  SCM_ASSERT (scm_is_integer (color_s), color_s,
-              SCM_ARG2, s_set_object_color_x);
-
-  LeptonObject *obj = edascm_to_object (obj_s);
-  lepton_object_set_color (obj, scm_to_int (color_s));
-
-  lepton_object_page_set_changed (obj);
-
-  return obj_s;
-}
-
-
 /*! \brief Check whether an object is embedded.
  *
  * \note Scheme API: Implements the %object-embedded? procedure in the
@@ -2130,7 +2100,6 @@ init_module_lepton_core_object (void *unused)
                 s_set_object_stroke_x,
                 s_object_fill,
                 s_set_object_fill_x,
-                s_set_object_color_x,
                 s_make_line,
                 s_make_net,
                 s_make_bus,

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -1360,32 +1360,6 @@ SCM_DEFINE (object_connections, "%object-connections", 1, 0, 0,
   return result;
 }
 
-/*! \brief Get the component object that contains an object.
- * \par Function Description
- * Returns the component object that contains the object \a obj_s.
- * If \a obj_s is not part of a component, returns SCM_BOOL_F.
- *
- * \note Scheme API: Implements the %object-component procedure of the
- * (lepton core object) module.
- *
- * \param obj_s #LeptonObject smob for object to get component of.
- * \return the #LeptonObject smob of the containing component, or SCM_BOOL_F.
- */
-SCM_DEFINE (object_component, "%object-component", 1, 0, 0,
-            (SCM obj_s), "Get containing component object of an object.")
-{
-  /* Ensure that the argument is an object smob */
-  SCM_ASSERT (edascm_is_object (obj_s), obj_s,
-              SCM_ARG1, s_object_component);
-
-  LeptonObject *obj = edascm_to_object (obj_s);
-  LeptonObject *parent = lepton_object_get_parent (obj);
-
-  if (parent == NULL) return SCM_BOOL_F;
-
-  return edascm_from_object (parent);
-}
-
 /*! \brief Make a new, empty path object.
  * \par Function Description
  * Creates a new, empty path object with default color, stroke and
@@ -1919,7 +1893,6 @@ init_module_lepton_core_object (void *unused)
                 s_set_text_x,
                 s_text_info,
                 s_object_connections,
-                s_object_component,
                 s_make_path,
                 s_path_length,
                 s_path_ref,

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -154,57 +154,6 @@ edascm_is_object_type (SCM smob, int type)
   return (lepton_object_get_type (obj) == type);
 }
 
-/*! \brief Get the bounds of a list of objects
- * \par Function Description
- * Returns the bounds of the objects in the variable-length argument
- * list \a rst_s. The bounds are returned as a pair structure of the
- * form:
- *
- * \code
- * ((left . top) . (right . bottom))
- * \endcode
- *
- * If \a rst_s is empty, or none of the objects has any bounds
- * (e.g. because they are all empty components and/or text strings),
- * returns SCM_BOOL_F.
- *
- * \warning This function always returns the actual bounds of the
- * objects, not the visible bounds.
- *
- * \note Scheme API: Implements the %object-bounds procedure in the
- * (lepton core object) module.  The procedure takes any number of
- * #LeptonObject smobs as arguments.
- *
- * \param [in] rst_s Variable-length list of #LeptonObject arguments.
- * \return bounds of objects or SCM_BOOL_F.
- */
-SCM_DEFINE (object_bounds, "%object-bounds", 0, 0, 1,
-            (SCM rst_s), "Get the bounds of a list of objects")
-{
-  GList *obj_list = edascm_to_object_glist (rst_s, s_object_bounds);
-
-  int success, left, top, right, bottom;
-  success = world_get_object_glist_bounds (obj_list,
-                                           /* Include hidden text. */
-                                           TRUE,
-                                           &left,
-                                           &top,
-                                           &right,
-                                           &bottom);
-
-  SCM result = SCM_BOOL_F;
-  if (success) {
-    result = scm_cons (scm_cons (scm_from_int (MIN(left, right)),
-                                 scm_from_int (MAX(top, bottom))),
-                       scm_cons (scm_from_int (MAX(left, right)),
-                                 scm_from_int (MIN(top, bottom))));
-  }
-
-  scm_remember_upto_here_1 (rst_s);
-  return result;
-}
-
-
 /*! \brief Get the stroke properties of an object.
  * \par Function Description
  * Returns the stroke settings of the object \a obj_s.  If \a obj_s is
@@ -2267,8 +2216,7 @@ init_module_lepton_core_object (void *unused)
   #include "scheme_object.x"
 
   /* Add them to the module's public definitions. */
-  scm_c_export (s_object_bounds,
-                s_object_stroke,
+  scm_c_export (s_object_stroke,
                 s_set_object_stroke_x,
                 s_object_fill,
                 s_set_object_fill_x,

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -498,28 +498,6 @@ SCM_DEFINE (set_object_fill_x, "%set-object-fill!", 2, 5, 0,
   return obj_s;
 }
 
-/*! \brief Get the color of an object.
- * \par Function Description
- * Returns the colormap index of the color used to draw the #LeptonObject
- * smob \a obj_s. Note that the color may not be meaningful for some
- * object types.
- *
- * \note Scheme API: Implements the %object-color procedure in the
- * (lepton core object) module.
- *
- * \param [in] obj_s #LeptonObject smob to inspect.
- * \return The colormap index used by \a obj_s.
- */
-SCM_DEFINE (object_color, "%object-color", 1, 0, 0,
-            (SCM obj_s), "Get the color of an object.")
-{
-  SCM_ASSERT (EDASCM_OBJECTP (obj_s), obj_s,
-              SCM_ARG1, s_object_color);
-
-  LeptonObject *obj = edascm_to_object (obj_s);
-  return scm_from_int (lepton_object_get_color (obj));
-}
-
 /*! \brief Set the color of an object.
  * \par Function Description
  * Set the colormap index of the color used to draw the #LeptonObject smob
@@ -2152,7 +2130,6 @@ init_module_lepton_core_object (void *unused)
                 s_set_object_stroke_x,
                 s_object_fill,
                 s_set_object_fill_x,
-                s_object_color,
                 s_set_object_color_x,
                 s_make_line,
                 s_make_net,

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -498,39 +498,6 @@ SCM_DEFINE (set_object_fill_x, "%set-object-fill!", 2, 5, 0,
   return obj_s;
 }
 
-/*! \brief Check whether an object is embedded.
- *
- * \note Scheme API: Implements the %object-embedded? procedure in the
- * (lepton core object) module.
- *
- * \param obj_s  #LeptonObject smob to inspect.
- *
- * \return       Boolean value indicating whether \a obj_s is embedded.
- */
-SCM_DEFINE (object_embedded_p, "%object-embedded?", 1, 0, 0,
-            (SCM obj_s), "Check whether an object is embedded.")
-{
-  SCM_ASSERT (EDASCM_OBJECTP (obj_s), obj_s,
-              SCM_ARG1, s_object_embedded_p);
-
-  LeptonObject*  obj = edascm_to_object (obj_s);
-  gboolean ret = FALSE;
-
-  if (lepton_object_is_component (obj))
-  {
-    ret = lepton_component_object_get_embedded (obj);
-  }
-  else
-  if (lepton_object_is_picture (obj))
-  {
-    ret = lepton_picture_object_get_embedded (obj);
-  }
-
-  return scm_from_bool (ret);
-
-} /* object_embedded_p() */
-
-
 
 /*! \brief Embed or unembed an object.
  *
@@ -2133,7 +2100,6 @@ init_module_lepton_core_object (void *unused)
                 s_translate_object_x,
                 s_rotate_object_x,
                 s_mirror_object_x,
-                s_object_embedded_p,
                 s_set_object_embedded_x,
                 NULL);
 }

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -1920,56 +1920,6 @@ SCM_DEFINE (translate_object_x, "%translate-object!", 3, 0, 0,
   return obj_s;
 }
 
-/*! \brief Rotate an object.
- * \par Function Description
- * Rotates \a obj_s anti-clockwise by \a angle_s about the point
- * specified by \a x_s and \a y_s.  \a angle_s must be an integer
- * multiple of 90 degrees.
- *
- * \note Scheme API: Implements the %rotate-object! procedure of the
- * (lepton core object) module.
- *
- * \param obj_s    #LeptonObject smob for object to translate.
- * \param x_s      x-coordinate of centre of rotation.
- * \param y_s      y-coordinate of centre of rotation.
- * \param angle_s  Angle to rotate by.
- * \return \a obj_s.
- */
-SCM_DEFINE (rotate_object_x, "%rotate-object!", 4, 0, 0,
-            (SCM obj_s, SCM x_s, SCM y_s, SCM angle_s),
-            "Rotate an object.")
-{
-  /* Check argument types */
-  SCM_ASSERT (edascm_is_object (obj_s), obj_s,
-              SCM_ARG1, s_rotate_object_x);
-  SCM_ASSERT (scm_is_integer (x_s), x_s,
-              SCM_ARG2, s_rotate_object_x);
-  SCM_ASSERT (scm_is_integer (y_s), y_s,
-              SCM_ARG3, s_rotate_object_x);
-  SCM_ASSERT (scm_is_integer (angle_s), angle_s,
-              SCM_ARG4, s_rotate_object_x);
-
-  LeptonObject *obj = edascm_to_object (obj_s);
-  int x = scm_to_int (x_s);
-  int y = scm_to_int (y_s);
-  int angle = scm_to_int (angle_s);
-
-  /* FIXME Work around horribly broken liblepton behaviour.  Some
-   * liblepton functions treat a rotation of -90 degrees as a rotation
-   * of +90 degrees, etc., which is not sane. */
-  while (angle < 0) angle += 360;
-  while (angle >= 360) angle -= 360;
-  SCM_ASSERT (angle % 90 == 0, angle_s,
-              SCM_ARG4, s_rotate_object_x);
-
-  lepton_object_emit_pre_change_notify (obj);
-  lepton_object_rotate (x, y, angle, obj);
-  lepton_object_emit_change_notify (obj);
-  lepton_object_page_set_changed (obj);
-
-  return obj_s;
-}
-
 /*!
  * \brief Create the (lepton core object) Scheme module.
  * \par Function Description
@@ -2018,7 +1968,6 @@ init_module_lepton_core_object (void *unused)
                 s_set_picture_x,
                 s_set_picture_data_vector_x,
                 s_translate_object_x,
-                s_rotate_object_x,
                 NULL);
 }
 

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -550,47 +550,6 @@ SCM_DEFINE (set_object_color_x, "%set-object-color!", 2, 0, 0,
 }
 
 
-
-/*! \brief Lock or unlock an object.
- *
- * \par Function Description
- * Set object's selectable flag: locked objects cannot be selected.
- *
- * \note Scheme API: Implements the %set-object-selectable! procedure in
- * the (lepton core object) module.
- *
- * \param obj_s         #LeptonObject smob to modify.
- * \param selectable_s  boolean: object's selectable flag.
- *
- * \return          the object (\a obj_s).
- */
-SCM_DEFINE (set_object_selectable_x, "%set-object-selectable!", 2, 0, 0,
-            (SCM obj_s, SCM selectable_s), "Lock or unlock an object.")
-{
-  SCM_ASSERT (EDASCM_OBJECTP (obj_s), obj_s,
-              SCM_ARG1, s_set_object_selectable_x);
-  SCM_ASSERT (scm_is_bool (selectable_s), selectable_s,
-              SCM_ARG2, s_set_object_selectable_x);
-
-  LeptonObject* obj = edascm_to_object (obj_s);
-
-  int selectable = scm_is_true (selectable_s);
-
-  if (obj->selectable != selectable)
-  {
-    obj->selectable = selectable;
-
-    /* mark the page as changed:
-    */
-    lepton_object_page_set_changed (obj);
-  }
-
-  return obj_s;
-
-} /* set_object_selectable_x() */
-
-
-
 /*! \brief Check whether an object is embedded.
  *
  * \note Scheme API: Implements the %object-embedded? procedure in the
@@ -2228,7 +2187,6 @@ init_module_lepton_core_object (void *unused)
                 s_translate_object_x,
                 s_rotate_object_x,
                 s_mirror_object_x,
-                s_set_object_selectable_x,
                 s_object_embedded_p,
                 s_set_object_embedded_x,
                 NULL);

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -1970,38 +1970,6 @@ SCM_DEFINE (rotate_object_x, "%rotate-object!", 4, 0, 0,
   return obj_s;
 }
 
-/*! \brief Mirror an object.
- * \par Function Description
- * Mirrors \a obj_s in the line x = \a x_s.
- *
- * \note Scheme API: Implements the %mirror-object! procedure of the
- * (lepton core object) module.
- *
- * \param obj_s    #LeptonObject smob for object to translate.
- * \param x_s      x-coordinate of centre of rotation.
- * \return \a obj_s.
- */
-SCM_DEFINE (mirror_object_x, "%mirror-object!", 2, 0, 0,
-            (SCM obj_s, SCM x_s),
-            "Mirror an object.")
-{
-  /* Check argument types */
-  SCM_ASSERT (edascm_is_object (obj_s), obj_s,
-              SCM_ARG1, s_mirror_object_x);
-  SCM_ASSERT (scm_is_integer (x_s), x_s,
-              SCM_ARG2, s_mirror_object_x);
-
-  LeptonObject *obj = edascm_to_object (obj_s);
-  int x = scm_to_int (x_s);
-
-  lepton_object_emit_pre_change_notify (obj);
-  lepton_object_mirror (x, 0, obj);
-  lepton_object_emit_change_notify (obj);
-  lepton_object_page_set_changed (obj);
-
-  return obj_s;
-}
-
 /*!
  * \brief Create the (lepton core object) Scheme module.
  * \par Function Description
@@ -2051,7 +2019,6 @@ init_module_lepton_core_object (void *unused)
                 s_set_picture_data_vector_x,
                 s_translate_object_x,
                 s_rotate_object_x,
-                s_mirror_object_x,
                 NULL);
 }
 

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -1882,44 +1882,6 @@ SCM_DEFINE (set_picture_data_vector_x, "%set-picture-data/vector!",
   return obj_s;
 }
 
-
-
-/*! \brief Translate an object.
- * \par Function Description
- * Translates \a obj_s by \a dx_s in the x-axis and \a dy_s in the
- * y-axis.
- *
- * \note Scheme API: Implements the %translate-object! procedure of the
- * (lepton core object) module.
- *
- * \param obj_s  #LeptonObject smob for object to translate.
- * \param dx_s   Integer distance to translate along x-axis.
- * \param dy_s   Integer distance to translate along y-axis.
- * \return \a obj_s.
- */
-SCM_DEFINE (translate_object_x, "%translate-object!", 3, 0, 0,
-            (SCM obj_s, SCM dx_s, SCM dy_s), "Translate an object.")
-{
-  /* Check argument types */
-  SCM_ASSERT (edascm_is_object (obj_s), obj_s,
-              SCM_ARG1, s_translate_object_x);
-  SCM_ASSERT (scm_is_integer (dx_s), dx_s,
-              SCM_ARG2, s_translate_object_x);
-  SCM_ASSERT (scm_is_integer (dy_s), dy_s,
-              SCM_ARG3, s_translate_object_x);
-
-  LeptonObject *obj = edascm_to_object (obj_s);
-  int dx = scm_to_int (dx_s);
-  int dy = scm_to_int (dy_s);
-
-  lepton_object_emit_pre_change_notify (obj);
-  lepton_object_translate (obj, dx, dy);
-  lepton_object_emit_change_notify (obj);
-  lepton_object_page_set_changed (obj);
-
-  return obj_s;
-}
-
 /*!
  * \brief Create the (lepton core object) Scheme module.
  * \par Function Description
@@ -1967,7 +1929,6 @@ init_module_lepton_core_object (void *unused)
                 s_picture_info,
                 s_set_picture_x,
                 s_set_picture_data_vector_x,
-                s_translate_object_x,
                 NULL);
 }
 

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -499,54 +499,6 @@ SCM_DEFINE (set_object_fill_x, "%set-object-fill!", 2, 5, 0,
 }
 
 
-/*! \brief Embed or unembed an object.
- *
- * \par Function Description
- * Embeds (or unembeds) component or picture.
- * If either the object \a obj_s is already embedded and \a embed_s is #t,
- * or \a obj_s is not embedded and \a embed_s is #f,
- * or \a obj_s is not a component or picture, does nothing.
- *
- * \note Scheme API: Implements the %set-object-embedded! procedure in
- * the (lepton core object) module.
- *
- * \param obj_s    #LeptonObject smob to modify.
- * \param embed_s  boolean: whether to embed (#t) or unembed (#f) the object.
- *
- * \return         the object (\a obj_s).
- */
-SCM_DEFINE (set_object_embedded_x, "%set-object-embedded!", 2, 0, 0,
-            (SCM obj_s, SCM embed_s), "Embed or unembed an object.")
-{
-  SCM_ASSERT (EDASCM_OBJECTP (obj_s), obj_s,
-              SCM_ARG1, s_set_object_embedded_x);
-  SCM_ASSERT (scm_is_bool (embed_s), embed_s,
-              SCM_ARG2, s_set_object_embedded_x);
-
-  LeptonObject* obj   = edascm_to_object (obj_s);
-  int     embed = scm_is_true (embed_s);
-
-  if (lepton_object_is_component (obj))
-  {
-    if (embed)
-      lepton_component_object_embed (obj);
-    else
-      lepton_component_object_unembed (obj);
-  }
-  else if (lepton_object_is_picture (obj))
-  {
-    if (embed)
-      lepton_picture_object_embed (obj);
-    else
-      lepton_picture_object_unembed (obj);
-  }
-
-  return obj_s;
-
-} /* set_object_embedded_x() */
-
-
-
 /*! \brief Create a new line.
  * \par Function Description
  * Creates a new line object, with all its parameters set to default
@@ -2100,7 +2052,6 @@ init_module_lepton_core_object (void *unused)
                 s_translate_object_x,
                 s_rotate_object_x,
                 s_mirror_object_x,
-                s_set_object_embedded_x,
                 NULL);
 }
 

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -551,33 +551,6 @@ SCM_DEFINE (set_object_color_x, "%set-object-color!", 2, 0, 0,
 
 
 
-/*! \brief Check whether an object is locked.
- *
- * \par Function Description
- * Check the state of an object's selectable flag: if it's true, the
- * object is considered to be unlocked, otherwise it is locked.
- *
- * \note Scheme API: Implements the %object-selectable? procedure in the
- * (lepton core object) module.
- *
- * \param obj_s  #LeptonObject smob to inspect.
- *
- * \return       Boolean value indicating whether \a obj_s is selectable.
- */
-SCM_DEFINE (object_selectable_p, "%object-selectable?", 1, 0, 0,
-            (SCM obj_s), "Check whether an object is locked.")
-{
-  SCM_ASSERT (EDASCM_OBJECTP (obj_s), obj_s,
-              SCM_ARG1, s_object_selectable_p);
-
-  LeptonObject* obj = edascm_to_object (obj_s);
-
-  return scm_from_bool (obj->selectable);
-
-} /* object_selectable_p() */
-
-
-
 /*! \brief Lock or unlock an object.
  *
  * \par Function Description
@@ -2255,7 +2228,6 @@ init_module_lepton_core_object (void *unused)
                 s_translate_object_x,
                 s_rotate_object_x,
                 s_mirror_object_x,
-                s_object_selectable_p,
                 s_set_object_selectable_x,
                 s_object_embedded_p,
                 s_set_object_embedded_x,


### PR DESCRIPTION
- Several Scheme-in-C basic object functions defined in `scheme_object.c` have been rewritten in Scheme using FFI
- Added tests for wrong object type arguments for those functions