### PR TITLE
Rewrite three SCM_DEFINE'd arc functions in Scheme

### DIFF
--- a/liblepton/include/liblepton/arc_object.h
+++ b/liblepton/include/liblepton/arc_object.h
@@ -112,9 +112,9 @@ lepton_arc_object_translate (LeptonObject *object,
                              int dx,
                              int dy);
 LeptonObject*
-o_arc_read (const char buf[],
-            unsigned int release_ver,
-            unsigned int fileformat_ver,
-            GError **err);
+lepton_arc_object_read (const char buf[],
+                        unsigned int release_ver,
+                        unsigned int fileformat_ver,
+                        GError **err);
 
 G_END_DECLS

--- a/liblepton/scheme/lepton/ffi.scm.in
+++ b/liblepton/scheme/lepton/ffi.scm.in
@@ -63,6 +63,7 @@
             lepton_arc_object_get_radius
             lepton_arc_object_get_start_angle
             lepton_arc_object_get_sweep_angle
+            lepton_arc_object_new
 
             lepton_component_object_get_embedded
             lepton_component_object_embed
@@ -74,6 +75,7 @@
 
             set_render_placeholders
             colors_count
+            default_color_id
             g_rc_parse
             lepton_colormap_color_by_id
             lepton_colormap_disable_color
@@ -107,6 +109,7 @@
 
 (define-lff set_render_placeholders void '())
 (define-lff colors_count size_t '())
+(define-lff default_color_id int '())
 (define-lff lepton_colormap_color_by_id '* (list '* size_t))
 (define-lff lepton_colormap_disable_color void (list '* size_t))
 (define-lff lepton_colormap_set_color void (list '* size_t uint8 uint8 uint8 uint8))
@@ -165,6 +168,7 @@
 (define-lff lepton_arc_object_get_radius int '(*))
 (define-lff lepton_arc_object_get_start_angle int '(*))
 (define-lff lepton_arc_object_get_sweep_angle int '(*))
+(define-lff lepton_arc_object_new '* (list int int int int int int))
 
 (define-lff lepton_component_object_get_embedded int '(*))
 (define-lff lepton_component_object_embed void '(*))

--- a/liblepton/scheme/lepton/ffi.scm.in
+++ b/liblepton/scheme/lepton/ffi.scm.in
@@ -58,6 +58,12 @@
             lepton_object_rotate
             lepton_object_translate
 
+            lepton_arc_object_get_center_x
+            lepton_arc_object_get_center_y
+            lepton_arc_object_get_radius
+            lepton_arc_object_get_start_angle
+            lepton_arc_object_get_sweep_angle
+
             lepton_component_object_get_embedded
             lepton_component_object_embed
             lepton_component_object_unembed
@@ -153,6 +159,12 @@
 (define-lff lepton_object_translate void (list '* int int))
 
 (define-lff lepton_object_page_set_changed void '(*))
+
+(define-lff lepton_arc_object_get_center_x int '(*))
+(define-lff lepton_arc_object_get_center_y int '(*))
+(define-lff lepton_arc_object_get_radius int '(*))
+(define-lff lepton_arc_object_get_start_angle int '(*))
+(define-lff lepton_arc_object_get_sweep_angle int '(*))
 
 (define-lff lepton_component_object_get_embedded int '(*))
 (define-lff lepton_component_object_embed void '(*))

--- a/liblepton/scheme/lepton/ffi.scm.in
+++ b/liblepton/scheme/lepton/ffi.scm.in
@@ -59,10 +59,15 @@
             lepton_object_translate
 
             lepton_arc_object_get_center_x
+            lepton_arc_object_set_center_x
             lepton_arc_object_get_center_y
+            lepton_arc_object_set_center_y
             lepton_arc_object_get_radius
+            lepton_arc_object_set_radius
             lepton_arc_object_get_start_angle
+            lepton_arc_object_set_start_angle
             lepton_arc_object_get_sweep_angle
+            lepton_arc_object_set_sweep_angle
             lepton_arc_object_new
 
             lepton_component_object_get_embedded
@@ -164,10 +169,15 @@
 (define-lff lepton_object_page_set_changed void '(*))
 
 (define-lff lepton_arc_object_get_center_x int '(*))
+(define-lff lepton_arc_object_set_center_x void (list '* int))
 (define-lff lepton_arc_object_get_center_y int '(*))
+(define-lff lepton_arc_object_set_center_y void (list '* int))
 (define-lff lepton_arc_object_get_radius int '(*))
+(define-lff lepton_arc_object_set_radius void (list '* int))
 (define-lff lepton_arc_object_get_start_angle int '(*))
+(define-lff lepton_arc_object_set_start_angle void (list '* int))
 (define-lff lepton_arc_object_get_sweep_angle int '(*))
+(define-lff lepton_arc_object_set_sweep_angle void (list '* int))
 (define-lff lepton_arc_object_new '* (list int int int int int int))
 
 (define-lff lepton_component_object_get_embedded int '(*))

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -53,7 +53,14 @@
             object-embedded?
             set-object-embedded!
             object-selectable?
-            set-object-selectable!))
+            set-object-selectable!
+
+            arc-info
+            arc-center
+            arc-radius
+            arc-start-angle
+            arc-sweep-angle
+            arc-end-angle))
 
 (define (object? object)
   "Returns #t if OBJECT is a #<geda-object> instance, otherwise
@@ -285,27 +292,45 @@ If OBJECT is not part of a component, returns #f."
   (let ((c (%make-arc)))
     (set-arc! c center radius start-angle sweep-angle color)))
 
-(define-public (arc-info c)
-  (let* ((params (%arc-info c))
-         (tail (cddr params)))
-    (cons (cons (list-ref params 0)
-                (list-ref params 1))
-          tail)))
+(define-public (arc-info object)
+  "Returns the parameters of arc OBJECT as a list of its center
+coordinate, radius, start and sweep angles, and color in the form:
+'((center-x . center-y) radius start-angle sweep-angle color)"
+  (list (arc-center object)
+        (arc-radius object)
+        (arc-start-angle object)
+        (arc-sweep-angle object)
+        (object-color object)))
 
-(define-public (arc-center a)
-  (list-ref (arc-info a) 0))
+(define (arc-center object)
+  "Returns the position of the center of arc OBJECT as a pair of
+two integers in the form '(x . y)."
+  (define pointer (geda-object->pointer* object 1))
+  (cons (lepton_arc_object_get_center_x pointer)
+        (lepton_arc_object_get_center_y pointer)))
 
-(define-public (arc-radius a)
-  (list-ref (arc-info a) 1))
+(define (arc-radius object)
+  "Returns the radius of arc OBJECT as an integer."
+  (define pointer (geda-object->pointer* object 1))
+  (lepton_arc_object_get_radius pointer))
 
-(define-public (arc-start-angle a)
-  (list-ref (arc-info a) 2))
+(define (arc-start-angle object)
+  "Returns the start angle of arc OBJECT as an integer number of
+degrees."
+  (define pointer (geda-object->pointer* object 1))
+  (lepton_arc_object_get_start_angle pointer))
 
-(define-public (arc-sweep-angle a)
-  (list-ref (arc-info a) 3))
+(define (arc-sweep-angle object)
+  "Returns the sweep angle of arc OBJECT as an integer number of
+degrees."
+  (define pointer (geda-object->pointer* object 1))
+  (lepton_arc_object_get_sweep_angle pointer))
 
-(define-public (arc-end-angle a)
-  (+ (arc-start-angle a) (arc-sweep-angle a)))
+(define (arc-end-angle object)
+  "Returns the end angle of arc OBJECT as an integer number of
+degrees.  The end angle is the sum of the start and sweep angles
+of the arc."
+  (+ (arc-start-angle object) (arc-sweep-angle object)))
 
 ;;;; Paths
 

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -60,7 +60,8 @@
             arc-radius
             arc-start-angle
             arc-sweep-angle
-            arc-end-angle))
+            arc-end-angle
+            make-arc))
 
 (define (object? object)
   "Returns #t if OBJECT is a #<geda-object> instance, otherwise
@@ -288,9 +289,35 @@ If OBJECT is not part of a component, returns #f."
                  (object-color a)
                  color)))
 
-(define*-public (make-arc center radius start-angle sweep-angle #:optional color)
-  (let ((c (%make-arc)))
-    (set-arc! c center radius start-angle sweep-angle color)))
+(define* (make-arc center radius start-angle sweep-angle #:optional color)
+  "Creates and returns a new arc object with given parameters.
+CENTER is the position of the center of the new arc in the form
+'(x . y), and RADIUS is the integer radius of the arc.
+START-ANGLE is the angle at which to start the arc, in degrees.
+SWEEP-ANGLE is the number of degrees between the start and end
+angles.  If optional COLOR is specified, it should be the integer
+color map index of the color with which to draw the arc.  If COLOR
+is not specified, the default arc color is used."
+
+  (let* ((init-color (default_color_id))
+         (init-center-x 0)
+         (init-center-y 0)
+         (init-radius 1)
+         (init-start-angle 0)
+         (init-sweep-angle 0)
+         (object (pointer->geda-object
+                  (lepton_arc_object_new init-color
+                                         init-center-x
+                                         init-center-y
+                                         init-radius
+                                         init-start-angle
+                                         init-sweep-angle))))
+    (set-arc! object
+              center
+              radius
+              start-angle
+              sweep-angle
+              (or color init-color))))
 
 (define-public (arc-info object)
   "Returns the parameters of arc OBJECT as a list of its center

--- a/liblepton/scheme/unit-tests/geda-page-dirty.scm
+++ b/liblepton/scheme/unit-tests/geda-page-dirty.scm
@@ -66,7 +66,7 @@
       (geda:assert-dirties P (apply set-line! l (line-info l)))
       (geda:assert-dirties P (apply set-box! b (box-info b)))
       (geda:assert-dirties P (apply set-circle! c (circle-info c)))
-      (geda:assert-dirties P (apply set-arc! a (arc-info a)))
+      (geda:assert-not-dirties P (apply set-arc! a (arc-info a)))
       (geda:assert-dirties P (apply set-text! t (text-info t)))
       (geda:assert-dirties P (apply set-component! C
                                     (list-tail (component-info C) 1)))
@@ -86,7 +86,7 @@
       (geda:assert-dirties P (apply set-line! l (line-info l)))
       (geda:assert-dirties P (apply set-box! b (box-info b)))
       (geda:assert-dirties P (apply set-circle! c (circle-info c)))
-      (geda:assert-dirties P (apply set-arc! a (arc-info a)))
+      (geda:assert-not-dirties P (apply set-arc! a (arc-info a)))
       (geda:assert-dirties P (apply set-text! t (text-info t)))
 
       (geda:assert-dirties P (apply set-object-stroke! l (object-stroke l)))

--- a/liblepton/scheme/unit-tests/geda-page-dirty.scm
+++ b/liblepton/scheme/unit-tests/geda-page-dirty.scm
@@ -12,6 +12,13 @@
             (test-assert (geda:page-dirty? P))
             (geda:set-page-dirty! P #f)))))
 
+(define-syntax geda:assert-not-dirties
+  (syntax-rules ()
+    ((_ P . test-forms)
+     (begin (begin . test-forms)
+            (test-assert (not (geda:page-dirty? P)))))))
+
+
 (test-begin "geda:page-dirty")
 
 (let ((P (geda:make-page "/test/page/A"))

--- a/liblepton/scheme/unit-tests/lepton-object-arc.scm
+++ b/liblepton/scheme/unit-tests/lepton-object-arc.scm
@@ -56,18 +56,25 @@
   ;; Wrong object.
   (test-assert-thrown 'wrong-type-arg (set-arc! 'a '(1 . 2) 3 45 90 3))
   ;; Wrong coord.
+  (test-assert-thrown 'wrong-type-arg (make-arc 'c 3 45 90 3))
   (test-assert-thrown 'wrong-type-arg (set-arc! a 'c 3 45 90 3))
   ;; Wrong x.
+  (test-assert-thrown 'wrong-type-arg (make-arc '(x . 2) 3 45 90 3))
   (test-assert-thrown 'wrong-type-arg (set-arc! a '(x . 2) 3 45 90 3))
   ;; Wrong y.
+  (test-assert-thrown 'wrong-type-arg (make-arc '(1 . y) 3 45 90 3))
   (test-assert-thrown 'wrong-type-arg (set-arc! a '(1 . y) 3 45 90 3))
   ;; Wrong radius.
+  (test-assert-thrown 'wrong-type-arg (make-arc '(1 . 2) 'r 45 90 3))
   (test-assert-thrown 'wrong-type-arg (set-arc! a '(1 . 2) 'r 45 90 3))
   ;; Wrong start angle.
+  (test-assert-thrown 'wrong-type-arg (make-arc '(1 . 2) 3 'start 90 3))
   (test-assert-thrown 'wrong-type-arg (set-arc! a '(1 . 2) 3 'start 90 3))
   ;; Wrong sweep angle.
+  (test-assert-thrown 'wrong-type-arg (make-arc '(1 . 2) 3 45 'sweep 3))
   (test-assert-thrown 'wrong-type-arg (set-arc! a '(1 . 2) 3 45 'sweep 3))
   ;; Wrong color.
+  (test-assert-thrown 'wrong-type-arg (make-arc '(1 . 2) 3 45 90 'color))
   (test-assert-thrown 'wrong-type-arg (set-arc! a '(1 . 2) 3 45 90 'color)))
 
 (test-end "arc-wrong-argument")

--- a/liblepton/scheme/unit-tests/lepton-object-arc.scm
+++ b/liblepton/scheme/unit-tests/lepton-object-arc.scm
@@ -42,3 +42,14 @@
   )
 
 (test-end "arcs")
+
+(test-begin "arc-wrong-argument")
+
+(test-assert-thrown 'wrong-type-arg (arc-info 'a))
+(test-assert-thrown 'wrong-type-arg (arc-center 'a))
+(test-assert-thrown 'wrong-type-arg (arc-radius 'a))
+(test-assert-thrown 'wrong-type-arg (arc-start-angle 'a))
+(test-assert-thrown 'wrong-type-arg (arc-sweep-angle 'a))
+(test-assert-thrown 'wrong-type-arg (arc-end-angle 'a))
+
+(test-end "arc-wrong-argument")

--- a/liblepton/scheme/unit-tests/lepton-object-arc.scm
+++ b/liblepton/scheme/unit-tests/lepton-object-arc.scm
@@ -52,6 +52,24 @@
 (test-assert-thrown 'wrong-type-arg (arc-sweep-angle 'a))
 (test-assert-thrown 'wrong-type-arg (arc-end-angle 'a))
 
+(let ((a (make-arc '(1 . 2) 3 45 90 3)))
+  ;; Wrong object.
+  (test-assert-thrown 'wrong-type-arg (set-arc! 'a '(1 . 2) 3 45 90 3))
+  ;; Wrong coord.
+  (test-assert-thrown 'wrong-type-arg (set-arc! a 'c 3 45 90 3))
+  ;; Wrong x.
+  (test-assert-thrown 'wrong-type-arg (set-arc! a '(x . 2) 3 45 90 3))
+  ;; Wrong y.
+  (test-assert-thrown 'wrong-type-arg (set-arc! a '(1 . y) 3 45 90 3))
+  ;; Wrong radius.
+  (test-assert-thrown 'wrong-type-arg (set-arc! a '(1 . 2) 'r 45 90 3))
+  ;; Wrong start angle.
+  (test-assert-thrown 'wrong-type-arg (set-arc! a '(1 . 2) 3 'start 90 3))
+  ;; Wrong sweep angle.
+  (test-assert-thrown 'wrong-type-arg (set-arc! a '(1 . 2) 3 45 'sweep 3))
+  ;; Wrong color.
+  (test-assert-thrown 'wrong-type-arg (set-arc! a '(1 . 2) 3 45 90 'color)))
+
 (test-end "arc-wrong-argument")
 
 

--- a/liblepton/scheme/unit-tests/lepton-page-dirty.scm
+++ b/liblepton/scheme/unit-tests/lepton-page-dirty.scm
@@ -12,6 +12,12 @@
             (test-assert (page-dirty? P))
             (set-page-dirty! P #f)))))
 
+(define-syntax assert-not-dirties
+  (syntax-rules ()
+    ((_ P . test-forms)
+     (begin (begin . test-forms)
+            (test-assert (not (page-dirty? P)))))))
+
 (test-begin "page-dirty")
 
 (let ((P (make-page "/test/page/A"))

--- a/liblepton/scheme/unit-tests/lepton-page-dirty.scm
+++ b/liblepton/scheme/unit-tests/lepton-page-dirty.scm
@@ -61,11 +61,27 @@
       ;; Add everything to the page
       (assert-dirties P (for-each (lambda (x) (page-append! P x))
                                   (list l b c a t C)))
+      ;; Arc.
+      ;; The same parameters do not modify the page.
+      (assert-not-dirties P (apply set-arc! a (arc-info a)))
+      ;; Set color explicitly to facilitate next tests.
+      (set-arc! a '(1 . 2) 3 45 90 3)
+      ;; Change center-x.
+      (assert-dirties P (apply set-arc! a '((2 . 2) 3 45 90 3)))
+      ;; Change center-y.
+      (assert-dirties P (apply set-arc! a '((2 . 3) 3 45 90 3)))
+      ;; Change radius.
+      (assert-dirties P (apply set-arc! a '((2 . 3) 4 45 90 3)))
+      ;; Change start-angle.
+      (assert-dirties P (apply set-arc! a '((2 . 3) 4 90 90 3)))
+      ;; Change sweep-angle.
+      (assert-dirties P (apply set-arc! a '((2 . 3) 4 90 45 3)))
+      ;; Change color.
+      (assert-dirties P (apply set-arc! a '((2 . 3) 4 90 45 4)))
 
       (assert-dirties P (apply set-line! l (line-info l)))
       (assert-dirties P (apply set-box! b (box-info b)))
       (assert-dirties P (apply set-circle! c (circle-info c)))
-      (assert-dirties P (apply set-arc! a (arc-info a)))
       (assert-dirties P (apply set-text! t (text-info t)))
       (assert-dirties P (apply set-component! C
                                (list-tail (component-info C) 1)))
@@ -82,10 +98,28 @@
                 (list l b c a t))
 
       ;; Modify primitives within component
+
+      ;; Arc.
+      ;; The same parameters do not modify the page.
+      (assert-not-dirties P (apply set-arc! a (arc-info a)))
+      ;; Set color explicitly to facilitate next tests.
+      (set-arc! a '(1 . 2) 3 45 90 3)
+      ;; Change center-x.
+      (assert-dirties P (apply set-arc! a '((2 . 2) 3 45 90 3)))
+      ;; Change center-y.
+      (assert-dirties P (apply set-arc! a '((2 . 3) 3 45 90 3)))
+      ;; Change radius.
+      (assert-dirties P (apply set-arc! a '((2 . 3) 4 45 90 3)))
+      ;; Change start-angle.
+      (assert-dirties P (apply set-arc! a '((2 . 3) 4 90 90 3)))
+      ;; Change sweep-angle.
+      (assert-dirties P (apply set-arc! a '((2 . 3) 4 90 45 3)))
+      ;; Change color.
+      (assert-dirties P (apply set-arc! a '((2 . 3) 4 90 45 4)))
+
       (assert-dirties P (apply set-line! l (line-info l)))
       (assert-dirties P (apply set-box! b (box-info b)))
       (assert-dirties P (apply set-circle! c (circle-info c)))
-      (assert-dirties P (apply set-arc! a (arc-info a)))
       (assert-dirties P (apply set-text! t (text-info t)))
 
       (assert-dirties P (apply set-object-stroke! l (object-stroke l)))

--- a/liblepton/src/a_basic.c
+++ b/liblepton/src/a_basic.c
@@ -214,7 +214,7 @@ GList
         break;
 
       case(OBJ_ARC):
-        if ((new_obj = o_arc_read (line, release_ver, fileformat_ver, err)) == NULL)
+        if ((new_obj = lepton_arc_object_read (line, release_ver, fileformat_ver, err)) == NULL)
           goto error;
         new_object_list = g_list_prepend (new_object_list, new_obj);
         break;

--- a/liblepton/src/arc_object.c
+++ b/liblepton/src/arc_object.c
@@ -114,11 +114,11 @@ lepton_arc_object_copy (const LeptonObject *object)
   g_return_val_if_fail (object->arc != NULL, NULL);
 
   new_object = lepton_arc_object_new (lepton_object_get_color (object),
-                                      object->arc->x,
-                                      object->arc->y,
-                                      object->arc->radius,
-                                      object->arc->start_angle,
-                                      object->arc->sweep_angle);
+                                      lepton_arc_object_get_center_x (object),
+                                      lepton_arc_object_get_center_y (object),
+                                      lepton_arc_object_get_radius (object),
+                                      lepton_arc_object_get_start_angle (object),
+                                      lepton_arc_object_get_sweep_angle (object));
 
   lepton_object_set_line_options (new_object,
                                   lepton_object_get_stroke_cap_type (object),

--- a/liblepton/src/arc_object.c
+++ b/liblepton/src/arc_object.c
@@ -648,12 +648,12 @@ lepton_arc_object_calculate_bounds (const LeptonObject *object,
 
   halfwidth = lepton_object_get_stroke_width (object) / 2;
 
-  radius      = object->arc->radius;
-  start_angle = object->arc->start_angle;
-  sweep_angle = object->arc->sweep_angle;
+  radius      = lepton_arc_object_get_radius (object);
+  start_angle = lepton_arc_object_get_start_angle (object);
+  sweep_angle = lepton_arc_object_get_sweep_angle (object);
 
-  x1 = object->arc->x;
-  y1 = object->arc->y;
+  x1 = lepton_arc_object_get_center_x (object);
+  y1 = lepton_arc_object_get_center_y (object);
   x2 = x1 + radius * cos(start_angle * M_PI / 180);
   y2 = y1 + radius * sin(start_angle * M_PI / 180);
   x3 = x1 + radius * cos((start_angle + sweep_angle) * M_PI / 180);

--- a/liblepton/src/arc_object.c
+++ b/liblepton/src/arc_object.c
@@ -553,12 +553,9 @@ lepton_arc_object_rotate (int world_centerx,
   g_return_if_fail (lepton_object_is_arc (object));
   g_return_if_fail (object->arc != NULL);
 
-  x = lepton_arc_object_get_center_x (object);
-  y = lepton_arc_object_get_center_y (object);
-
-  /* translate center coords to origin */
-  x -= world_centerx;
-  y -= world_centery;
+  /* Get arc coords and translate them to origin. */
+  x = lepton_arc_object_get_center_x (object) - world_centerx;
+  y = lepton_arc_object_get_center_y (object) - world_centery;
 
   /* rotate center coords */
   if(angle % 90 == 0) {
@@ -566,17 +563,13 @@ lepton_arc_object_rotate (int world_centerx,
   } else {
     lepton_point_rotate (x, y, angle % 360, &newx, &newy);
   }
-  x = newx;
-  y = newy;
 
   /* apply rotation to angles */
   object->arc->start_angle = (object->arc->start_angle + angle) % 360;
 
-  /* translate coords to their previous place */
-  x += world_centerx;
-  y += world_centery;
-  lepton_arc_object_set_center_x (object, x);
-  lepton_arc_object_set_center_y (object, y);
+  /* Translate new coords to the previous place. */
+  lepton_arc_object_set_center_x (object, newx + world_centerx);
+  lepton_arc_object_set_center_y (object, newy + world_centery);
 }
 
 /*! \brief Mirror the WORLD coordinates of an ARC.

--- a/liblepton/src/arc_object.c
+++ b/liblepton/src/arc_object.c
@@ -548,7 +548,7 @@ lepton_arc_object_rotate (int world_centerx,
                           int angle,
                           LeptonObject *object)
 {
-  int x, y, newx, newy;
+  int x, y, newx, newy, old_start_angle;
 
   g_return_if_fail (lepton_object_is_arc (object));
   g_return_if_fail (object->arc != NULL);
@@ -564,8 +564,10 @@ lepton_arc_object_rotate (int world_centerx,
     lepton_point_rotate (x, y, angle % 360, &newx, &newy);
   }
 
-  /* apply rotation to angles */
-  object->arc->start_angle = (object->arc->start_angle + angle) % 360;
+  /* Apply rotation to angles.  Only start angle changes, sweep
+   * angle remains the same. */
+  old_start_angle = lepton_arc_object_get_start_angle (object);
+  lepton_arc_object_set_start_angle (object, (old_start_angle + angle) % 360);
 
   /* Translate new coords to the previous place. */
   lepton_arc_object_set_center_x (object, newx + world_centerx);

--- a/liblepton/src/arc_object.c
+++ b/liblepton/src/arc_object.c
@@ -594,14 +594,16 @@ lepton_arc_object_mirror (int world_centerx,
                           int world_centery,
                           LeptonObject *object)
 {
+  int x;
   g_return_if_fail (lepton_object_is_arc (object));
   g_return_if_fail (object->arc != NULL);
 
   /* translate object to origin */
-  object->arc->x -= world_centerx;
+  x = lepton_arc_object_get_center_x (object);
+  x -= world_centerx;
 
   /* get center, and mirror it (vertical mirror) */
-  object->arc->x = -object->arc->x;
+  x = -x;
 
   /* apply mirror to angles (vertical mirror) */
   object->arc->start_angle = (180 - object->arc->start_angle) % 360;
@@ -610,7 +612,8 @@ lepton_arc_object_mirror (int world_centerx,
   object->arc->sweep_angle = -object->arc->sweep_angle;
 
   /* translate object back to its previous position */
-  object->arc->x += world_centerx;
+  x += world_centerx;
+  lepton_arc_object_set_center_x (object, x);
 }
 
 

--- a/liblepton/src/arc_object.c
+++ b/liblepton/src/arc_object.c
@@ -510,12 +510,17 @@ lepton_arc_object_translate (LeptonObject *object,
                              int dx,
                              int dy)
 {
+  int x, y;
+
   g_return_if_fail (lepton_object_is_arc (object));
   g_return_if_fail (object->arc != NULL);
 
+  x = lepton_arc_object_get_center_x (object);
+  y = lepton_arc_object_get_center_y (object);
+
   /* Do world coords */
-  object->arc->x = object->arc->x + dx;
-  object->arc->y = object->arc->y + dy;
+  lepton_arc_object_set_center_x (object, x + dx);
+  lepton_arc_object_set_center_y (object, y + dy);
 }
 
 /*! \brief

--- a/liblepton/src/arc_object.c
+++ b/liblepton/src/arc_object.c
@@ -379,11 +379,11 @@ lepton_arc_object_modify (LeptonObject *object,
  *  \param [in] fileformat_ver
  *  \return The ARC LeptonObject that was created, or NULL on error.
  */
-LeptonObject
-*o_arc_read (const char buf[],
-             unsigned int release_ver,
-             unsigned int fileformat_ver,
-             GError **err)
+LeptonObject*
+lepton_arc_object_read (const char buf[],
+                        unsigned int release_ver,
+                        unsigned int fileformat_ver,
+                        GError **err)
 {
   LeptonObject *new_obj;
   char type;

--- a/liblepton/src/arc_object.c
+++ b/liblepton/src/arc_object.c
@@ -324,23 +324,23 @@ lepton_arc_object_modify (LeptonObject *object,
   switch(whichone) {
   case ARC_CENTER:
     /* modify the center of arc object */
-    object->arc->x = x;
-    object->arc->y = y;
+    lepton_arc_object_set_center_x (object, x);
+    lepton_arc_object_set_center_y (object, y);
     break;
 
   case ARC_RADIUS:
     /* modify the radius of arc object */
-    object->arc->radius = x;
+    lepton_arc_object_set_radius (object, x);
     break;
 
   case ARC_START_ANGLE:
     /* modify the start angle of the arc object */
-    object->arc->start_angle = x;
+    lepton_arc_object_set_start_angle (object, x);
     break;
 
   case ARC_SWEEP_ANGLE:
     /* modify the end angle of the arc object */
-    object->arc->sweep_angle = x;
+    lepton_arc_object_set_sweep_angle (object, x);
     break;
 
   default:

--- a/liblepton/src/arc_object.c
+++ b/liblepton/src/arc_object.c
@@ -716,11 +716,11 @@ lepton_arc_object_get_position (const LeptonObject *object,
   g_return_val_if_fail (object->arc != NULL, FALSE);
 
   if (x != NULL) {
-    *x = object->arc->x;
+    *x = lepton_arc_object_get_center_x (object);
   }
 
   if (y != NULL) {
-    *y = object->arc->y;
+    *y = lepton_arc_object_get_center_y (object);
   }
 
   return TRUE;

--- a/liblepton/src/arc_object.c
+++ b/liblepton/src/arc_object.c
@@ -594,17 +594,26 @@ lepton_arc_object_mirror (int world_centerx,
                           int world_centery,
                           LeptonObject *object)
 {
+  int start_angle, sweep_angle;
+
   g_return_if_fail (lepton_object_is_arc (object));
   g_return_if_fail (object->arc != NULL);
 
   lepton_arc_object_set_center_x (object, (2 * world_centerx -
                                            lepton_arc_object_get_center_x (object)));
 
+  start_angle = lepton_arc_object_get_start_angle (object);
+  sweep_angle = lepton_arc_object_get_sweep_angle (object);
+
   /* apply mirror to angles (vertical mirror) */
-  object->arc->start_angle = (180 - object->arc->start_angle) % 360;
+  start_angle = (180 - start_angle) % 360;
   /* start_angle *MUST* be positive */
-  if(object->arc->start_angle < 0) object->arc->start_angle += 360;
-  object->arc->sweep_angle = -object->arc->sweep_angle;
+  if (start_angle < 0) start_angle += 360;
+  /* Reverse sweep direction. */
+  sweep_angle = -sweep_angle;
+
+  lepton_arc_object_set_start_angle (object, start_angle);
+  lepton_arc_object_set_sweep_angle (object, sweep_angle);
 }
 
 

--- a/liblepton/src/arc_object.c
+++ b/liblepton/src/arc_object.c
@@ -746,17 +746,25 @@ lepton_arc_object_shortest_distance (LeptonObject *object,
 {
   double shortest_distance;
   double radius;
+  double center_x, center_y;
+  double start_angle, sweep_angle;
 
   g_return_val_if_fail (lepton_object_is_arc (object), G_MAXDOUBLE);
   g_return_val_if_fail (object->arc != NULL, G_MAXDOUBLE);
 
-  radius = (double)object->arc->radius;
+  radius = (double) lepton_arc_object_get_radius (object);
+
+  center_x = (double) lepton_arc_object_get_center_x (object);
+  center_y = (double) lepton_arc_object_get_center_y (object);
+
+  start_angle = (double) lepton_arc_object_get_start_angle (object);
+  sweep_angle = (double) lepton_arc_object_get_sweep_angle (object);
 
   if (lepton_arc_within_sweep (object->arc, x, y))
   {
     double distance_to_center;
 
-    distance_to_center = hypot (x - object->arc->x, y - object->arc->y);
+    distance_to_center = hypot (x - center_x, y - center_y);
 
     shortest_distance = fabs (distance_to_center - radius);
 
@@ -766,17 +774,17 @@ lepton_arc_object_shortest_distance (LeptonObject *object,
     double distance_to_end1;
     double dx, dy;
 
-    angle = G_PI * ((double)object->arc->start_angle) / 180;
+    angle = G_PI * start_angle / 180;
 
-    dx = ((double)x) - radius * cos (angle) - ((double)object->arc->x);
-    dy = ((double)y) - radius * sin (angle) - ((double)object->arc->y);
+    dx = ((double)x) - radius * cos (angle) - center_x;
+    dy = ((double)y) - radius * sin (angle) - center_y;
 
     distance_to_end0 = hypot (dx, dy);
 
-    angle += G_PI * ((double)object->arc->sweep_angle) / 180;
+    angle += G_PI * sweep_angle / 180;
 
-    dx = ((double)x) - radius * cos (angle) - ((double)object->arc->x);
-    dy = ((double)y) - radius * sin (angle) - ((double)object->arc->y);
+    dx = ((double)x) - radius * cos (angle) - center_x;
+    dy = ((double)y) - radius * sin (angle) - center_y;
 
     distance_to_end1 = hypot (dx, dy);
 

--- a/liblepton/src/arc_object.c
+++ b/liblepton/src/arc_object.c
@@ -594,26 +594,17 @@ lepton_arc_object_mirror (int world_centerx,
                           int world_centery,
                           LeptonObject *object)
 {
-  int x;
   g_return_if_fail (lepton_object_is_arc (object));
   g_return_if_fail (object->arc != NULL);
 
-  /* translate object to origin */
-  x = lepton_arc_object_get_center_x (object);
-  x -= world_centerx;
-
-  /* get center, and mirror it (vertical mirror) */
-  x = -x;
+  lepton_arc_object_set_center_x (object, (2 * world_centerx -
+                                           lepton_arc_object_get_center_x (object)));
 
   /* apply mirror to angles (vertical mirror) */
   object->arc->start_angle = (180 - object->arc->start_angle) % 360;
   /* start_angle *MUST* be positive */
   if(object->arc->start_angle < 0) object->arc->start_angle += 360;
   object->arc->sweep_angle = -object->arc->sweep_angle;
-
-  /* translate object back to its previous position */
-  x += world_centerx;
-  lepton_arc_object_set_center_x (object, x);
 }
 
 

--- a/liblepton/src/arc_object.c
+++ b/liblepton/src/arc_object.c
@@ -67,9 +67,9 @@ lepton_arc_object_new (gint color,
    */
 
   /* World coordinates */
-  new_node->arc->x      = center_x;
-  new_node->arc->y      = center_y;
-  new_node->arc->radius = radius;
+  lepton_arc_object_set_center_x (new_node, center_x);
+  lepton_arc_object_set_center_y (new_node, center_y);
+  lepton_arc_object_set_radius (new_node, radius);
 
   /* must check the sign of start_angle, sweep_angle ... */
   if(sweep_angle < 0) {
@@ -78,8 +78,8 @@ lepton_arc_object_new (gint color,
   }
   if(start_angle < 0) start_angle = 360 + start_angle;
 
-  new_node->arc->start_angle = start_angle;
-  new_node->arc->sweep_angle = sweep_angle;
+  lepton_arc_object_set_start_angle (new_node, start_angle);
+  lepton_arc_object_set_sweep_angle (new_node, sweep_angle);
 
   /* Default init */
   lepton_object_set_line_options (new_node,

--- a/liblepton/src/arc_object.c
+++ b/liblepton/src/arc_object.c
@@ -553,27 +553,30 @@ lepton_arc_object_rotate (int world_centerx,
   g_return_if_fail (lepton_object_is_arc (object));
   g_return_if_fail (object->arc != NULL);
 
-  /* translate object to origin */
-  object->arc->x -= world_centerx;
-  object->arc->y -= world_centery;
+  x = lepton_arc_object_get_center_x (object);
+  y = lepton_arc_object_get_center_y (object);
 
-  /* get center, and rotate center */
-  x = object->arc->x;
-  y = object->arc->y;
+  /* translate center coords to origin */
+  x -= world_centerx;
+  y -= world_centery;
+
+  /* rotate center coords */
   if(angle % 90 == 0) {
     lepton_point_rotate_90 (x, y, angle % 360, &newx, &newy);
   } else {
     lepton_point_rotate (x, y, angle % 360, &newx, &newy);
   }
-  object->arc->x = newx;
-  object->arc->y = newy;
+  x = newx;
+  y = newy;
 
   /* apply rotation to angles */
   object->arc->start_angle = (object->arc->start_angle + angle) % 360;
 
-  /* translate object to its previous place */
-  object->arc->x += world_centerx;
-  object->arc->y += world_centery;
+  /* translate coords to their previous place */
+  x += world_centerx;
+  y += world_centery;
+  lepton_arc_object_set_center_x (object, x);
+  lepton_arc_object_set_center_y (object, y);
 }
 
 /*! \brief Mirror the WORLD coordinates of an ARC.

--- a/liblepton/src/arc_object.c
+++ b/liblepton/src/arc_object.c
@@ -747,6 +747,7 @@ lepton_arc_object_shortest_distance (LeptonObject *object,
   double shortest_distance;
   double radius;
 
+  g_return_val_if_fail (lepton_object_is_arc (object), G_MAXDOUBLE);
   g_return_val_if_fail (object->arc != NULL, G_MAXDOUBLE);
 
   radius = (double)object->arc->radius;

--- a/liblepton/src/o_attrib.c
+++ b/liblepton/src/o_attrib.c
@@ -274,7 +274,7 @@ o_read_attribs (LeptonPage *page,
         break;
 
       case(OBJ_ARC):
-        if ((new_obj = o_arc_read (line, release_ver, fileformat_ver, err)) == NULL)
+        if ((new_obj = lepton_arc_object_read (line, release_ver, fileformat_ver, err)) == NULL)
           goto error;
         object_list = g_list_prepend (object_list, new_obj);
         break;

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -981,35 +981,6 @@ SCM_DEFINE (circle_info, "%circle-info", 1, 0, 0,
                      SCM_UNDEFINED);
 }
 
-/*! \brief Create a new arc.
- * \par Function Description
- * Creates a new arc object, with all its parameters set to default
- * values.
- *
- * \note Scheme API: Implements the %make-arc procedure in the
- * (lepton core object) module.
- *
- * \return a newly-created arc object.
- */
-SCM_DEFINE (make_arc, "%make-arc", 0, 0, 0,
-            (), "Create a new arc object.")
-{
-  LeptonObject *object = lepton_arc_object_new (default_color_id(),
-                                                0,
-                                                0,
-                                                1,
-                                                0,
-                                                0);
-
-  SCM result = edascm_from_object (object);
-
-  /* At the moment, the only pointer to the object is owned by the
-   * smob. */
-  edascm_c_set_gc (result, 1);
-
-  return result;
-}
-
 /*! \brief Set arc parameters.
  * \par Function Description
  * Modifies a arc object by setting its parameters to new values.
@@ -1852,7 +1823,6 @@ init_module_lepton_core_object (void *unused)
                 s_make_circle,
                 s_set_circle_x,
                 s_circle_info,
-                s_make_arc,
                 s_set_arc_x,
                 s_make_text,
                 s_set_text_x,

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -1045,10 +1045,11 @@ SCM_DEFINE (set_arc_x, "%set-arc!", 7, 0, 0,
                                   end_angle_s, SCM_ARG6, s_set_arc_x);
 
   LeptonObject *obj = edascm_to_object (arc_s);
-  lepton_arc_object_modify (obj, scm_to_int(x_s), scm_to_int(y_s), ARC_CENTER);
-  lepton_arc_object_modify (obj, scm_to_int(r_s), 0, ARC_RADIUS);
-  lepton_arc_object_modify (obj, scm_to_int(start_angle_s), 0, ARC_START_ANGLE);
-  lepton_arc_object_modify (obj, scm_to_int(end_angle_s), 0, ARC_SWEEP_ANGLE);
+  lepton_arc_object_set_center_x (obj, scm_to_int(x_s));
+  lepton_arc_object_set_center_y (obj, scm_to_int(y_s));
+  lepton_arc_object_set_radius (obj, scm_to_int(r_s));
+  lepton_arc_object_set_start_angle (obj, scm_to_int(start_angle_s));
+  lepton_arc_object_set_sweep_angle (obj, scm_to_int(end_angle_s));
   lepton_object_set_color (obj, scm_to_int (color_s));
 
   lepton_object_page_set_changed (obj);

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -1057,41 +1057,6 @@ SCM_DEFINE (set_arc_x, "%set-arc!", 7, 0, 0,
   return arc_s;
 }
 
-/*! \brief Get arc parameters.
- * \par Function Description
- * Retrieves the parameters of a arc object. The return value is a
- * list of parameters:
- *
- * -# X-coordinate of center of arc
- * -# Y-coordinate of center of arc
- * -# Radius of arc
- * -# Start angle of arc
- * -# End angle of arc
- * -# Colormap index of color to be used for drawing the arc
- *
- * \note Scheme API: Implements the %arc-info procedure in the
- * (lepton core object) module.
- *
- * \param arc_s the arc object to inspect.
- * \return a list of arc parameters.
- */
-SCM_DEFINE (arc_info, "%arc-info", 1, 0, 0,
-            (SCM arc_s), "Get arc parameters.")
-{
-  SCM_ASSERT (edascm_is_object_type (arc_s, OBJ_ARC),
-              arc_s, SCM_ARG1, s_arc_info);
-
-  LeptonObject *obj = edascm_to_object (arc_s);
-
-  return scm_list_n (scm_from_int (lepton_arc_object_get_center_x (obj)),
-                     scm_from_int (lepton_arc_object_get_center_y (obj)),
-                     scm_from_int (lepton_arc_object_get_radius (obj)),
-                     scm_from_int (lepton_arc_object_get_start_angle (obj)),
-                     scm_from_int (lepton_arc_object_get_sweep_angle (obj)),
-                     scm_from_int (lepton_object_get_color (obj)),
-                     SCM_UNDEFINED);
-}
-
 /*! \brief Create a new text item.
  * \par Function Description
  * Creates a new text object, with all its parameters set to default
@@ -1889,7 +1854,6 @@ init_module_lepton_core_object (void *unused)
                 s_circle_info,
                 s_make_arc,
                 s_set_arc_x,
-                s_arc_info,
                 s_make_text,
                 s_set_text_x,
                 s_text_info,

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -981,52 +981,6 @@ SCM_DEFINE (circle_info, "%circle-info", 1, 0, 0,
                      SCM_UNDEFINED);
 }
 
-/*! \brief Set arc parameters.
- * \par Function Description
- * Modifies a arc object by setting its parameters to new values.
- *
- * \note Scheme API: Implements the %set-arc! procedure in the
- * (lepton core object) module.
- *
- * \param arc_s         the arc object to modify.
- * \param x_s           the new x-coordinate of the center of the arc.
- * \param y_s           the new y-coordinate of the center of the arc.
- * \param r_s           the new radius of the arc.
- * \param start_angle_s the start angle of the arc.
- * \param end_angle_s   the start angle of the arc.
- * \param color_s       the colormap index of the color to be used for
- *                      drawing the arc.
- *
- * \return the modified arc object.
- */
-SCM_DEFINE (set_arc_x, "%set-arc!", 7, 0, 0,
-            (SCM arc_s, SCM x_s, SCM y_s, SCM r_s, SCM start_angle_s,
-             SCM end_angle_s, SCM color_s),
-            "Set arc parameters")
-{
-  SCM_ASSERT (edascm_is_object_type (arc_s, OBJ_ARC), arc_s,
-              SCM_ARG1, s_set_arc_x);
-  SCM_ASSERT (scm_is_integer (x_s),     x_s,     SCM_ARG2, s_set_arc_x);
-  SCM_ASSERT (scm_is_integer (y_s),     y_s,     SCM_ARG3, s_set_arc_x);
-  SCM_ASSERT (scm_is_integer (r_s),     r_s,     SCM_ARG4, s_set_arc_x);
-  SCM_ASSERT (scm_is_integer (color_s), color_s, SCM_ARG7, s_set_arc_x);
-  SCM_ASSERT (scm_is_integer (start_angle_s),
-                                  start_angle_s, SCM_ARG5, s_set_arc_x);
-  SCM_ASSERT (scm_is_integer (end_angle_s),
-                                  end_angle_s, SCM_ARG6, s_set_arc_x);
-
-  LeptonObject *obj = edascm_to_object (arc_s);
-  lepton_arc_object_set_center_x (obj, scm_to_int(x_s));
-  lepton_arc_object_set_center_y (obj, scm_to_int(y_s));
-  lepton_arc_object_set_radius (obj, scm_to_int(r_s));
-  lepton_arc_object_set_start_angle (obj, scm_to_int(start_angle_s));
-  lepton_arc_object_set_sweep_angle (obj, scm_to_int(end_angle_s));
-  lepton_object_set_color (obj, scm_to_int (color_s));
-
-  lepton_object_page_set_changed (obj);
-
-  return arc_s;
-}
 
 /*! \brief Create a new text item.
  * \par Function Description
@@ -1823,7 +1777,6 @@ init_module_lepton_core_object (void *unused)
                 s_make_circle,
                 s_set_circle_x,
                 s_circle_info,
-                s_set_arc_x,
                 s_make_text,
                 s_set_text_x,
                 s_text_info,

--- a/liblepton/tests/test_arc_object.c
+++ b/liblepton/tests/test_arc_object.c
@@ -136,10 +136,10 @@ check_serialization ()
     lepton_object_delete (object0);
     g_assert (buffer0 != NULL);
 
-    LeptonObject *object1 = o_arc_read (buffer0,
-                                      version,
-                                      FILEFORMAT_VERSION,
-                                      NULL);
+    LeptonObject *object1 = lepton_arc_object_read (buffer0,
+                                                    version,
+                                                    FILEFORMAT_VERSION,
+                                                    NULL);
 
     g_assert (object1 != NULL);
 


### PR DESCRIPTION
- The functions `arc-info()`, `make-arc()`, and `set-arc!()` have been rewritten using Scheme FFI
- Many C functions related to arc objects (accessors and other) have been renamed and now have the prefix `lepton_arc_object_`.
- Some of the C functions have been simplified.
- Lots of new tests for arcs have been added.

(Well, there's always room for improvements, e.g. I don't like docstrings I've written).