### PR TITLE
Several little clean-ups

### DIFF
--- a/liblepton/include/liblepton/object.h
+++ b/liblepton/include/liblepton/object.h
@@ -66,10 +66,6 @@ struct st_object
   /* 1 for up, -1 for down (vertial bus) */
   int bus_ripper_direction;             /* only valid on buses */
 
-
-  int font_text_size;                   /* used only with fonts defs */
-  GList *font_prim_objs;                /* used only with fonts defs */
-
   int whichend;    /* for pins only, either 0 or 1 */
   int pin_type;    /* for pins only, either NET or BUS */
 

--- a/liblepton/include/liblepton/object.h
+++ b/liblepton/include/liblepton/object.h
@@ -41,8 +41,8 @@ struct st_object
   LeptonPicture *picture;
   LeptonPath *path;
 
-  GList *conn_list;                     /* List of connections */
-  /* to and from this object */
+  /* List of connections to and from this object. */
+  GList *conn_list;
 
   /* Visible appearance of lines in graphical primitives. */
   LeptonStroke *stroke;

--- a/liblepton/include/liblepton/stroke.h
+++ b/liblepton/include/liblepton/stroke.h
@@ -27,8 +27,7 @@ enum _LeptonStrokeCapType
 {
   END_NONE,
   END_SQUARE,
-  END_ROUND,
-  END_VOID
+  END_ROUND
 };
 
 typedef enum _LeptonStrokeCapType LeptonStrokeCapType;
@@ -39,8 +38,7 @@ enum _LeptonStrokeType
   TYPE_DOTTED,
   TYPE_DASHED,
   TYPE_CENTER,
-  TYPE_PHANTOM,
-  TYPE_ERASE
+  TYPE_PHANTOM
 };
 
 typedef enum _LeptonStrokeType LeptonStrokeType;

--- a/libleptonattrib/src/x_gtksheet.c
+++ b/libleptonattrib/src/x_gtksheet.c
@@ -236,11 +236,11 @@ x_gtksheet_add_row_labels(GtkSheet *sheet, int count, STRING_LIST *list_head)
   /* Leave if no items to add are available */
   if ((count == 0) || (list_head == NULL)) return;
 
+  #ifndef ENABLE_GTK3
   /* Get character width based upon "X", which is a large char.
    * font_combo is a global.  Where is it set?  */
   GtkStyle *style = gtk_widget_get_style (GTK_WIDGET (sheet));
 
-  #ifndef ENABLE_GTK3
   if (style->private_font)
     char_width = gdk_char_width (style->private_font, (gchar) 'X');
   else


### PR DESCRIPTION
- Fix a comment in `st_object` definition.
- Get rid of unused enum values belonging to strokes.
- Get rid of two obsolete and unused fields of `st_object`.
- Fix one warning when compiling with gtk3 support.