### PR TITLE
Rewrite three SCM_DEFINE'd box functions using Scheme FFI

### DIFF
--- a/liblepton/include/liblepton/box_object.h
+++ b/liblepton/include/liblepton/box_object.h
@@ -103,9 +103,9 @@ lepton_box_object_translate (LeptonObject *object,
                              int dx,
                              int dy);
 LeptonObject*
-o_box_read (const char buf[],
-            unsigned int release_ver,
-            unsigned int fileformat_ver,
-            GError **err);
+lepton_box_object_read (const char buf[],
+                        unsigned int release_ver,
+                        unsigned int fileformat_ver,
+                        GError **err);
 
 G_END_DECLS

--- a/liblepton/include/liblepton/box_object.h
+++ b/liblepton/include/liblepton/box_object.h
@@ -85,12 +85,6 @@ lepton_box_object_modify (LeptonObject *object,
                           int y,
                           int whichone);
 void
-lepton_box_object_modify_all (LeptonObject *object,
-                              int x1,
-                              int y1,
-                              int x2,
-                              int y2);
-void
 lepton_box_object_rotate (int world_centerx,
                           int world_centery,
                           int angle,

--- a/liblepton/include/liblepton/box_object.h
+++ b/liblepton/include/liblepton/box_object.h
@@ -31,6 +31,32 @@ G_BEGIN_DECLS
 
 /* construction, destruction */
 
+
+int
+lepton_box_object_get_upper_x (const LeptonObject *object);
+
+int
+lepton_box_object_get_upper_y (const LeptonObject *object);
+
+int
+lepton_box_object_get_lower_x (const LeptonObject *object);
+
+int
+lepton_box_object_get_lower_y (const LeptonObject *object);
+
+void
+lepton_box_object_set_upper_x (LeptonObject *object,
+                               int val);
+void
+lepton_box_object_set_upper_y (LeptonObject *object,
+                               int val);
+void
+lepton_box_object_set_lower_x (LeptonObject *object,
+                               int val);
+void
+lepton_box_object_set_lower_y (LeptonObject *object,
+                               int val);
+
 LeptonObject*
 lepton_box_object_new (int color,
                        int x1,

--- a/liblepton/scheme/lepton/ffi.scm.in
+++ b/liblepton/scheme/lepton/ffi.scm.in
@@ -70,6 +70,8 @@
             lepton_arc_object_set_sweep_angle
             lepton_arc_object_new
 
+            lepton_box_object_new
+
             lepton_component_object_get_embedded
             lepton_component_object_embed
             lepton_component_object_unembed
@@ -179,6 +181,8 @@
 (define-lff lepton_arc_object_get_sweep_angle int '(*))
 (define-lff lepton_arc_object_set_sweep_angle void (list '* int))
 (define-lff lepton_arc_object_new '* (list int int int int int int))
+
+(define-lff lepton_box_object_new '* (list int int int int int))
 
 (define-lff lepton_component_object_get_embedded int '(*))
 (define-lff lepton_component_object_embed void '(*))

--- a/liblepton/scheme/lepton/ffi.scm.in
+++ b/liblepton/scheme/lepton/ffi.scm.in
@@ -222,17 +222,41 @@
 ;;;   (define (myfunc object)
 ;;;     (define pointer (geda-object->pointer* object 1))
 ;;;     (function-body))
-(define-syntax-rule (geda-object->pointer* object pos)
-  (let ((pointer (geda-object->pointer object)))
-    (if (null-pointer? pointer)
-        (let ((proc-name
-               ;; Provision agains Guile-2.0 that does not have the procedure.
-               (if (defined? 'frame-procedure-name)
-                   (frame-procedure-name (stack-ref (make-stack #t) 1))
-                   '??)))
-          (scm-error 'wrong-type-arg
-                     proc-name
-                     "Wrong type argument in position ~A: ~A"
-                     (list pos object)
-                     #f))
-        pointer)))
+(define-syntax geda-object->pointer*
+  (syntax-rules ()
+    ((_ object pos)
+     (let ((pointer (geda-object->pointer object)))
+       (if (null-pointer? pointer)
+           (let ((proc-name
+                  ;; Provision against Guile-2.0 that does not
+                  ;; have the procedure.
+                  (if (defined? 'frame-procedure-name)
+                      (frame-procedure-name (stack-ref (make-stack #t) 1))
+                      '??)))
+             (scm-error 'wrong-type-arg
+                        proc-name
+                        "Wrong type argument in position ~A: ~A"
+                        (list pos object)
+                        #f))
+           pointer)))
+    ((_ object pos object-check-func type)
+     (let ((pointer (geda-object->pointer object)))
+       (if (null-pointer? pointer)
+           (let ((proc-name
+                  ;; Provision against Guile-2.0 that does not
+                  ;; have the procedure.
+                  (if (defined? 'frame-procedure-name)
+                      (frame-procedure-name (stack-ref (make-stack #t) 1))
+                      '??)))
+             (scm-error 'wrong-type-arg
+                        proc-name
+                        "Wrong type argument in position ~A: ~A"
+                        (list pos object)
+                        #f))
+           (if (object-check-func object)
+               pointer
+               (scm-error 'wrong-type-arg
+                          proc-name
+                          "Wrong type argument in position ~A (expecting ~A object): ~A"
+                          (list pos type object)
+                          #f)))))))

--- a/liblepton/scheme/lepton/ffi.scm.in
+++ b/liblepton/scheme/lepton/ffi.scm.in
@@ -24,6 +24,8 @@
             geda-object->pointer
             geda-object->pointer*
             pointer->geda-object
+            check-coord
+            check-integer
 
             ;; Foreign functions.
             edascm_is_config
@@ -260,3 +262,29 @@
                           "Wrong type argument in position ~A (expecting ~A object): ~A"
                           (list pos type object)
                           #f)))))))
+
+
+
+(define-syntax-rule (check-integer val pos)
+  (unless (integer? val)
+    (scm-error 'wrong-type-arg
+               ;; Provision against Guile-2.0 that does not have the procedure.
+               (if (defined? 'frame-procedure-name)
+                   (frame-procedure-name (stack-ref (make-stack #t) 1))
+                   '??)
+               "Wrong type argument in position ~A (expecting integer): ~A"
+               (list pos val)
+               #f)))
+
+(define-syntax-rule (check-coord val pos)
+  (unless (and (pair? val)
+               (integer? (car val))
+               (integer? (cdr val)))
+    (scm-error 'wrong-type-arg
+               ;; Provision against Guile-2.0 that does not have the procedure.
+               (if (defined? 'frame-procedure-name)
+                   (frame-procedure-name (stack-ref (make-stack #t) 1))
+                   '??)
+               "Wrong type argument in position ~A (expecting a pair of integers): ~A"
+               (list pos val)
+               #f)))

--- a/liblepton/scheme/lepton/ffi.scm.in
+++ b/liblepton/scheme/lepton/ffi.scm.in
@@ -70,6 +70,10 @@
             lepton_arc_object_set_sweep_angle
             lepton_arc_object_new
 
+            lepton_box_object_get_upper_x
+            lepton_box_object_get_upper_y
+            lepton_box_object_get_lower_x
+            lepton_box_object_get_lower_y
             lepton_box_object_new
 
             lepton_component_object_get_embedded
@@ -182,6 +186,10 @@
 (define-lff lepton_arc_object_set_sweep_angle void (list '* int))
 (define-lff lepton_arc_object_new '* (list int int int int int int))
 
+(define-lff lepton_box_object_get_upper_x int '(*))
+(define-lff lepton_box_object_get_upper_y int '(*))
+(define-lff lepton_box_object_get_lower_x int '(*))
+(define-lff lepton_box_object_get_lower_y int '(*))
 (define-lff lepton_box_object_new '* (list int int int int int))
 
 (define-lff lepton_component_object_get_embedded int '(*))

--- a/liblepton/scheme/lepton/ffi.scm.in
+++ b/liblepton/scheme/lepton/ffi.scm.in
@@ -74,6 +74,7 @@
             lepton_box_object_get_upper_y
             lepton_box_object_get_lower_x
             lepton_box_object_get_lower_y
+            lepton_box_object_modify_all
             lepton_box_object_new
 
             lepton_component_object_get_embedded
@@ -190,6 +191,7 @@
 (define-lff lepton_box_object_get_upper_y int '(*))
 (define-lff lepton_box_object_get_lower_x int '(*))
 (define-lff lepton_box_object_get_lower_y int '(*))
+(define-lff lepton_box_object_modify_all void (list '* int int int int))
 (define-lff lepton_box_object_new '* (list int int int int int))
 
 (define-lff lepton_component_object_get_embedded int '(*))

--- a/liblepton/scheme/lepton/ffi.scm.in
+++ b/liblepton/scheme/lepton/ffi.scm.in
@@ -73,10 +73,13 @@
             lepton_arc_object_new
 
             lepton_box_object_get_upper_x
+            lepton_box_object_set_upper_x
             lepton_box_object_get_upper_y
+            lepton_box_object_set_upper_y
             lepton_box_object_get_lower_x
+            lepton_box_object_set_lower_x
             lepton_box_object_get_lower_y
-            lepton_box_object_modify_all
+            lepton_box_object_set_lower_y
             lepton_box_object_new
 
             lepton_component_object_get_embedded
@@ -190,10 +193,13 @@
 (define-lff lepton_arc_object_new '* (list int int int int int int))
 
 (define-lff lepton_box_object_get_upper_x int '(*))
+(define-lff lepton_box_object_set_upper_x void (list '* int))
 (define-lff lepton_box_object_get_upper_y int '(*))
+(define-lff lepton_box_object_set_upper_y void (list '* int))
 (define-lff lepton_box_object_get_lower_x int '(*))
+(define-lff lepton_box_object_set_lower_x void (list '* int))
 (define-lff lepton_box_object_get_lower_y int '(*))
-(define-lff lepton_box_object_modify_all void (list '* int int int int))
+(define-lff lepton_box_object_set_lower_y void (list '* int))
 (define-lff lepton_box_object_new '* (list int int int int int))
 
 (define-lff lepton_component_object_get_embedded int '(*))

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -62,7 +62,9 @@
             arc-sweep-angle
             arc-end-angle
             make-arc
-            set-arc!))
+            set-arc!
+
+            make-box))
 
 (define (object? object)
   "Returns #t if OBJECT is a #<geda-object> instance, otherwise
@@ -226,9 +228,28 @@ If OBJECT is not part of a component, returns #f."
                  (object-color b)
                  color)))
 
-(define*-public (make-box top-left bottom-right #:optional color)
-  (let ((l (%make-box)))
-    (set-box! l top-left bottom-right color)))
+(define* (make-box top-left bottom-right #:optional color)
+  "Creates and returns a new box object with given parameters.
+TOP-LEFT is the position of the top left of the new box in the
+form '(x . y), and BOTTOM-RIGHT is the position of the bottom
+right of the box.  If optional COLOR is specified, it should be
+the integer color map index of the color with which to draw the
+box.  If COLOR is not specified, the default box color is used."
+  (let* ((init-color (default_color_id))
+         (init-left-x 0)
+         (init-upper-y 0)
+         (init-right-x 0)
+         (init-bottom-y 0)
+         (object (pointer->geda-object
+                  (lepton_box_object_new init-color
+                                         init-left-x
+                                         init-upper-y
+                                         init-right-x
+                                         init-bottom-y))))
+    (set-box! object
+              top-left
+              bottom-right
+              (or color init-color))))
 
 (define-public (box-info b)
   (let ((params (%box-info b)))

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -458,7 +458,9 @@ degrees."
   "Returns the end angle of arc OBJECT as an integer number of
 degrees.  The end angle is the sum of the start and sweep angles
 of the arc."
-  (+ (arc-start-angle object) (arc-sweep-angle object)))
+  (define pointer (geda-object->pointer* object 1 arc? 'arc))
+  (+ (lepton_arc_object_get_start_angle pointer)
+     (lepton_arc_object_get_sweep_angle pointer)))
 
 ;;;; Paths
 

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -270,6 +270,10 @@ form '(x . y), and BOTTOM-RIGHT is the position of the bottom
 right of the box.  If optional COLOR is specified, it should be
 the integer color map index of the color with which to draw the
 box.  If COLOR is not specified, the default box color is used."
+  (check-coord top-left 1)
+  (check-coord bottom-right 2)
+  (and color (check-integer color 3))
+
   (let* ((init-color (default_color_id))
          (init-left-x 0)
          (init-upper-y 0)
@@ -296,7 +300,7 @@ OBJECT. The return value is a list of the parameters in the form:
 
 (define (box-top-left object)
   "Returns the top left corner coordinate of box OBJECT."
-  (define pointer (geda-object->pointer* object 1))
+  (define pointer (geda-object->pointer* object 1 box? 'box))
 
   (cons (lepton_box_object_get_upper_x pointer)
         (lepton_box_object_get_upper_y pointer)))
@@ -304,7 +308,7 @@ OBJECT. The return value is a list of the parameters in the form:
 
 (define (box-bottom-right object)
   "Returns the bottom right corner coordinate of box OBJECT."
-  (define pointer (geda-object->pointer* object 1))
+  (define pointer (geda-object->pointer* object 1 box? 'box))
 
   (cons (lepton_box_object_get_lower_x pointer)
         (lepton_box_object_get_lower_y pointer)))

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -359,7 +359,8 @@ center of the arc in the form '(x . y). RADIUS, START-ANGLE, and
 SWEEP-ANGLE correspondingly represent its radius, start and sweep
 angle.  If optional COLOR is specified, it should be the integer
 color map index of the color with which to draw the arc.  If COLOR
-is not specified, the default arc color is used."
+is not specified, the default arc color is used.  Returns the
+modified arc object."
   (define pointer (geda-object->pointer* object 1))
 
   (let ((info (arc-info object))

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -232,7 +232,7 @@ optional COLOR is specified, it shoud be the integer color map
 index of the color to be used for drawing the box.  If COLOR is
 not specified, the default box color is used.  Returns the
 modified box object."
-  (define pointer (geda-object->pointer* object 1))
+  (define pointer (geda-object->pointer* object 1 box? 'box))
 
   (let ((info (box-info object))
         (x1 (car top-left))

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -65,6 +65,8 @@
             set-arc!
 
             box-info
+            box-bottom-right
+            box-top-left
             make-box))
 
 (define (object? object)
@@ -256,23 +258,25 @@ box.  If COLOR is not specified, the default box color is used."
   "Retrieves and returns the coordinates and color of a box
 OBJECT. The return value is a list of the parameters in the form:
 '((upper_x . upper_y) (lower_x . lower_y) color)"
+  (list (box-top-left object)
+        (box-bottom-right object)
+        (object-color object)))
+
+(define (box-top-left object)
+  "Returns the top left corner coordinate of box OBJECT."
   (define pointer (geda-object->pointer* object 1))
 
-  (and (box? object)
-       (let ((upper-x (lepton_box_object_get_upper_x pointer))
-             (upper-y (lepton_box_object_get_upper_y pointer))
-             (lower-x (lepton_box_object_get_lower_x pointer))
-             (lower-y (lepton_box_object_get_lower_y pointer))
-             (color (lepton_object_get_color pointer)))
-         (list (cons upper-x upper-y)
-               (cons lower-x lower-y)
-               color))))
+  (cons (lepton_box_object_get_upper_x pointer)
+        (lepton_box_object_get_upper_y pointer)))
 
-(define-public (box-top-left l)
-  (list-ref (box-info l) 0))
 
-(define-public (box-bottom-right l)
-  (list-ref (box-info l) 1))
+(define (box-bottom-right object)
+  "Returns the bottom right corner coordinate of box OBJECT."
+  (define pointer (geda-object->pointer* object 1))
+
+  (cons (lepton_box_object_get_lower_x pointer)
+        (lepton_box_object_get_lower_y pointer)))
+
 
 ;;;; Circles
 

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -361,7 +361,13 @@ angle.  If optional COLOR is specified, it should be the integer
 color map index of the color with which to draw the arc.  If COLOR
 is not specified, the default arc color is used.  Returns the
 modified arc object."
-  (define pointer (geda-object->pointer* object 1))
+  (define pointer (geda-object->pointer* object 1 arc? 'arc))
+
+  (check-coord center 2)
+  (check-integer radius 3)
+  (check-integer start-angle 4)
+  (check-integer sweep-angle 5)
+  (and color (check-integer color 6))
 
   (let ((info (arc-info object))
         (center-x (car center))
@@ -388,6 +394,11 @@ SWEEP-ANGLE is the number of degrees between the start and end
 angles.  If optional COLOR is specified, it should be the integer
 color map index of the color with which to draw the arc.  If COLOR
 is not specified, the default arc color is used."
+  (check-coord center 1)
+  (check-integer radius 2)
+  (check-integer start-angle 3)
+  (check-integer sweep-angle 4)
+  (and color (check-integer color 5))
 
   (let* ((init-color (default_color_id))
          (init-center-x 0)
@@ -422,25 +433,25 @@ coordinate, radius, start and sweep angles, and color in the form:
 (define (arc-center object)
   "Returns the position of the center of arc OBJECT as a pair of
 two integers in the form '(x . y)."
-  (define pointer (geda-object->pointer* object 1))
+  (define pointer (geda-object->pointer* object 1 arc? 'arc))
   (cons (lepton_arc_object_get_center_x pointer)
         (lepton_arc_object_get_center_y pointer)))
 
 (define (arc-radius object)
   "Returns the radius of arc OBJECT as an integer."
-  (define pointer (geda-object->pointer* object 1))
+  (define pointer (geda-object->pointer* object 1 arc? 'arc))
   (lepton_arc_object_get_radius pointer))
 
 (define (arc-start-angle object)
   "Returns the start angle of arc OBJECT as an integer number of
 degrees."
-  (define pointer (geda-object->pointer* object 1))
+  (define pointer (geda-object->pointer* object 1 arc? 'arc))
   (lepton_arc_object_get_start_angle pointer))
 
 (define (arc-sweep-angle object)
   "Returns the sweep angle of arc OBJECT as an integer number of
 degrees."
-  (define pointer (geda-object->pointer* object 1))
+  (define pointer (geda-object->pointer* object 1 arc? 'arc))
   (lepton_arc_object_get_sweep_angle pointer))
 
 (define (arc-end-angle object)

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -234,6 +234,10 @@ not specified, the default box color is used.  Returns the
 modified box object."
   (define pointer (geda-object->pointer* object 1 box? 'box))
 
+  (check-coord top-left 2)
+  (check-coord bottom-right 3)
+  (and color (check-integer color 4))
+
   (let ((info (box-info object))
         (x1 (car top-left))
         (y1 (cdr top-left))

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -64,6 +64,7 @@
             make-arc
             set-arc!
 
+            box-info
             make-box))
 
 (define (object? object)
@@ -251,13 +252,21 @@ box.  If COLOR is not specified, the default box color is used."
               bottom-right
               (or color init-color))))
 
-(define-public (box-info b)
-  (let ((params (%box-info b)))
-    (list (cons (list-ref params 0)
-                (list-ref params 1))
-          (cons (list-ref params 2)
-                (list-ref params 3))
-          (list-ref params 4))))
+(define (box-info object)
+  "Retrieves and returns the coordinates and color of a box
+OBJECT. The return value is a list of the parameters in the form:
+'((upper_x . upper_y) (lower_x . lower_y) color)"
+  (define pointer (geda-object->pointer* object 1))
+
+  (and (box? object)
+       (let ((upper-x (lepton_box_object_get_upper_x pointer))
+             (upper-y (lepton_box_object_get_upper_y pointer))
+             (lower-x (lepton_box_object_get_lower_x pointer))
+             (lower-y (lepton_box_object_get_lower_y pointer))
+             (color (lepton_object_get_color pointer)))
+         (list (cons upper-x upper-y)
+               (cons lower-x lower-y)
+               color))))
 
 (define-public (box-top-left l)
   (list-ref (box-info l) 0))

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -245,7 +245,17 @@ modified box object."
         (y2 (cdr bottom-right))
         (color (or color
                    (lepton_object_get_color pointer))))
-    (lepton_box_object_modify_all pointer x1 y1 x2 y2)
+
+    (lepton_object_emit_pre_change_notify pointer)
+
+    (lepton_box_object_set_lower_x pointer (max x1 x2))
+    (lepton_box_object_set_lower_y pointer (min y1 y2))
+
+    (lepton_box_object_set_upper_x pointer (min x1 x2))
+    (lepton_box_object_set_upper_y pointer (max y1 y2))
+
+    (lepton_object_emit_change_notify pointer)
+
     (lepton_object_set_color pointer color)
 
     (unless (equal? info (box-info object))

--- a/liblepton/scheme/unit-tests/geda-page-dirty.scm
+++ b/liblepton/scheme/unit-tests/geda-page-dirty.scm
@@ -64,7 +64,7 @@
                                        (list l b c a t C)))
 
       (geda:assert-dirties P (apply set-line! l (line-info l)))
-      (geda:assert-dirties P (apply set-box! b (box-info b)))
+      (geda:assert-not-dirties P (apply set-box! b (box-info b)))
       (geda:assert-dirties P (apply set-circle! c (circle-info c)))
       (geda:assert-not-dirties P (apply set-arc! a (arc-info a)))
       (geda:assert-dirties P (apply set-text! t (text-info t)))
@@ -84,7 +84,7 @@
 
       ;; Modify primitives within component
       (geda:assert-dirties P (apply set-line! l (line-info l)))
-      (geda:assert-dirties P (apply set-box! b (box-info b)))
+      (geda:assert-not-dirties P (apply set-box! b (box-info b)))
       (geda:assert-dirties P (apply set-circle! c (circle-info c)))
       (geda:assert-not-dirties P (apply set-arc! a (arc-info a)))
       (geda:assert-dirties P (apply set-text! t (text-info t)))

--- a/liblepton/scheme/unit-tests/lepton-object-box.scm
+++ b/liblepton/scheme/unit-tests/lepton-object-box.scm
@@ -97,3 +97,21 @@
   '((-400 . -100) (-200 . -400)))
 
 (test-end "box-translation")
+
+
+(test-begin "box-mirror")
+
+(test-equal (stripped-info (car (mirror-objects! 0 (new-box))))
+  '((-300 . 400) (-100 . 100)))
+(test-equal (stripped-info (car (mirror-objects! 500 (new-box))))
+  '((700 . 400) (900 . 100)))
+(test-equal (stripped-info (car (mirror-objects! -500 (new-box))))
+  '((-1300 . 400) (-1100 . 100)))
+;;; Double mirror around the same point returns almost initial
+;;; result (coords returned for another pair of corners).
+(test-equal (stripped-info
+             (car (mirror-objects! 500
+                                   (car (mirror-objects! 500 (new-box))))))
+  '((100 . 400) (300 . 100)))
+
+(test-end "box-mirror")

--- a/liblepton/scheme/unit-tests/lepton-object-box.scm
+++ b/liblepton/scheme/unit-tests/lepton-object-box.scm
@@ -72,3 +72,28 @@
   (test-assert-thrown 'wrong-type-arg (set-box! b '(1 . 2) '(3 . 4) 'color)))
 
 (test-end "box-wrong-argument")
+
+
+;;; Common functions for transformations.
+;;; Make the same box every time.
+(define (new-box)
+  (make-box '(100 . 100) '(300 . 400)))
+;;; Arc info without unrelated colors.
+(define (stripped-info box)
+  (define (strip-color info)
+    (reverse (cdr (reverse info))))
+  (strip-color (box-info box)))
+
+
+(test-begin "box-translation")
+
+(test-equal (stripped-info (car (translate-objects! '(500 . 500) (new-box))))
+  '((600 . 900) (800 . 600)))
+(test-equal (stripped-info (car (translate-objects! '(-500 . 500) (new-box))))
+  '((-400 . 900) (-200 . 600)))
+(test-equal (stripped-info (car (translate-objects! '(500 . -500) (new-box))))
+  '((600 . -100) (800 . -400)))
+(test-equal (stripped-info (car (translate-objects! '(-500 . -500) (new-box))))
+  '((-400 . -100) (-200 . -400)))
+
+(test-end "box-translation")

--- a/liblepton/scheme/unit-tests/lepton-object-box.scm
+++ b/liblepton/scheme/unit-tests/lepton-object-box.scm
@@ -38,3 +38,37 @@
   )
 
 (test-end "boxes")
+
+
+(test-begin "box-wrong-argument")
+
+(test-assert-thrown 'wrong-type-arg (box-info 'b))
+(test-assert-thrown 'wrong-type-arg (box-top-left 'b))
+(test-assert-thrown 'wrong-type-arg (box-bottom-right 'b))
+
+(let ((b (make-box '(1 . 2) '(3 . 4) 3)))
+  ;; Wrong object.
+  (test-assert-thrown 'wrong-type-arg (set-box! 'b '(1 . 2) '(3 . 4) 3))
+  ;; Wrong first coord.
+  (test-assert-thrown 'wrong-type-arg (make-box 'c '(3 . 4) 3))
+  (test-assert-thrown 'wrong-type-arg (set-box! b 'c '(3 . 4) 3))
+  ;; Wrong first x.
+  (test-assert-thrown 'wrong-type-arg (make-box '(x . 2) '(3 . 4) 3))
+  (test-assert-thrown 'wrong-type-arg (set-box! b '(x . 2) '(3 . 4) 3))
+  ;; Wrong first y.
+  (test-assert-thrown 'wrong-type-arg (make-box '(1 . y) '(3 . 4) 3))
+  (test-assert-thrown 'wrong-type-arg (set-box! b '(1 . y) '(3 . 4) 3))
+  ;; Wrong second coord.
+  (test-assert-thrown 'wrong-type-arg (make-box '(1 . 2) 'c 3))
+  (test-assert-thrown 'wrong-type-arg (set-box! b '(1 . 2) 'c 3))
+  ;; Wrong second x.
+  (test-assert-thrown 'wrong-type-arg (make-box '(1 . 2) '(x . 4) 3))
+  (test-assert-thrown 'wrong-type-arg (set-box! b '(1 . 2) '(x . 4) 3))
+  ;; Wrong second y.
+  (test-assert-thrown 'wrong-type-arg (make-box '(1 . 2) '(3 . y) 3))
+  (test-assert-thrown 'wrong-type-arg (set-box! b '(1 . 2) '(3 . y) 3))
+  ;; Wrong color.
+  (test-assert-thrown 'wrong-type-arg (make-box '(1 . 2) '(3 . 4) 'color))
+  (test-assert-thrown 'wrong-type-arg (set-box! b '(1 . 2) '(3 . 4) 'color)))
+
+(test-end "box-wrong-argument")

--- a/liblepton/scheme/unit-tests/lepton-object-box.scm
+++ b/liblepton/scheme/unit-tests/lepton-object-box.scm
@@ -115,3 +115,81 @@
   '((100 . 400) (300 . 100)))
 
 (test-end "box-mirror")
+
+
+(test-begin "box-rotation")
+
+(define degree-ls
+  '(-900 -360 -270 -180 -90 0 90 180 270 360 900))
+
+(define (rotate-at+500+500 angle)
+  (stripped-info (car (rotate-objects! '(500 . 500) angle (new-box)))))
+(define (rotate-at-500+500 angle)
+  (stripped-info (car (rotate-objects! '(-500 . 500) angle (new-box)))))
+(define (rotate-at+500-500 angle)
+  (stripped-info (car (rotate-objects! '(500 . -500) angle (new-box)))))
+(define (rotate-at-500-500 angle)
+  (stripped-info (car (rotate-objects! '(-500 . -500) angle (new-box)))))
+
+;;; The output format is
+;;; '((center-x . center-y) radius start-angle sweep-angle)
+;;; Radius and sweep angle should never change.
+(test-equal (map rotate-at+500+500 degree-ls)
+  '(((700 . 900) (900 . 600))
+    ((100 . 400) (300 . 100))
+    ((600 . 300) (900 . 100))
+    ((700 . 900) (900 . 600))
+    ((100 . 900) (400 . 700))
+    ((100 . 400) (300 . 100))
+    ((600 . 300) (900 . 100))
+    ((700 . 900) (900 . 600))
+    ((100 . 900) (400 . 700))
+    ((100 . 400) (300 . 100))
+    ((700 . 900) (900 . 600))))
+
+(test-equal (map rotate-at-500+500 degree-ls)
+  '(((-1300 . 900) (-1100 . 600))
+    ((100 . 400) (300 . 100))
+    ((-400 . 1300) (-100 . 1100))
+    ((-1300 . 900) (-1100 . 600))
+    ((-900 . -100) (-600 . -300))
+    ((100 . 400) (300 . 100))
+    ((-400 . 1300) (-100 . 1100))
+    ((-1300 . 900) (-1100 . 600))
+    ((-900 . -100) (-600 . -300))
+    ((100 . 400) (300 . 100))
+    ((-1300 . 900) (-1100 . 600))))
+
+(test-equal (map rotate-at+500-500 degree-ls)
+  '(((700 . -1100) (900 . -1400))
+    ((100 . 400) (300 . 100))
+    ((-400 . -700) (-100 . -900))
+    ((700 . -1100) (900 . -1400))
+    ((1100 . -100) (1400 . -300))
+    ((100 . 400) (300 . 100))
+    ((-400 . -700) (-100 . -900))
+    ((700 . -1100) (900 . -1400))
+    ((1100 . -100) (1400 . -300))
+    ((100 . 400) (300 . 100))
+    ((700 . -1100) (900 . -1400))))
+
+(test-equal (map rotate-at-500-500 degree-ls)
+  '(((-1300 . -1100) (-1100 . -1400))
+    ((100 . 400) (300 . 100))
+    ((-1400 . 300) (-1100 . 100))
+    ((-1300 . -1100) (-1100 . -1400))
+    ((100 . -1100) (400 . -1300))
+    ((100 . 400) (300 . 100))
+    ((-1400 . 300) (-1100 . 100))
+    ((-1300 . -1100) (-1100 . -1400))
+    ((100 . -1100) (400 . -1300))
+    ((100 . 400) (300 . 100))
+    ((-1300 . -1100) (-1100 . -1400))))
+
+;;; Invalid rotation angles, not multiple of 90 degree.
+(test-assert-thrown 'misc-error (rotate-at+500+500 100))
+(test-assert-thrown 'misc-error (rotate-at+500+500 -100))
+(test-assert-thrown 'misc-error (rotate-at+500+500 3000))
+(test-assert-thrown 'misc-error (rotate-at+500+500 -3000))
+
+(test-end "box-rotation")

--- a/liblepton/scheme/unit-tests/lepton-page-dirty.scm
+++ b/liblepton/scheme/unit-tests/lepton-page-dirty.scm
@@ -79,8 +79,11 @@
       ;; Change color.
       (assert-dirties P (apply set-arc! a '((2 . 3) 4 90 45 4)))
 
+      ;; Box.
+      ;; The same parameters do not modify the page.
+      (assert-not-dirties P (apply set-box! b (box-info b)))
+
       (assert-dirties P (apply set-line! l (line-info l)))
-      (assert-dirties P (apply set-box! b (box-info b)))
       (assert-dirties P (apply set-circle! c (circle-info c)))
       (assert-dirties P (apply set-text! t (text-info t)))
       (assert-dirties P (apply set-component! C
@@ -117,8 +120,11 @@
       ;; Change color.
       (assert-dirties P (apply set-arc! a '((2 . 3) 4 90 45 4)))
 
+      ;; Box.
+      ;; The same parameters do not modify the page.
+      (assert-not-dirties P (apply set-box! b (box-info b)))
+
       (assert-dirties P (apply set-line! l (line-info l)))
-      (assert-dirties P (apply set-box! b (box-info b)))
       (assert-dirties P (apply set-circle! c (circle-info c)))
       (assert-dirties P (apply set-text! t (text-info t)))
 

--- a/liblepton/scheme/unit-tests/lepton-page-dirty.scm
+++ b/liblepton/scheme/unit-tests/lepton-page-dirty.scm
@@ -82,6 +82,18 @@
       ;; Box.
       ;; The same parameters do not modify the page.
       (assert-not-dirties P (apply set-box! b (box-info b)))
+      ;; Set color explicitly to facilitate next tests.
+      (set-box! b '(1 . 2) '(3 . 4) 3)
+      ;; Change x of the first corner.
+      (assert-dirties P (apply set-box! b '((2 . 2) (3 . 4) 3)))
+      ;; Change y of the first corner.
+      (assert-dirties P (apply set-box! b '((2 . 3) (3 . 4) 3)))
+      ;; Change x of the second corner.
+      (assert-dirties P (apply set-box! b '((2 . 3) (4 . 4) 3)))
+      ;; Change y of the second corner.
+      (assert-dirties P (apply set-box! b '((2 . 3) (4 . 5) 3)))
+      ;; Change color.
+      (assert-dirties P (apply set-box! b '((2 . 3) (4 . 5) 4)))
 
       (assert-dirties P (apply set-line! l (line-info l)))
       (assert-dirties P (apply set-circle! c (circle-info c)))
@@ -123,6 +135,18 @@
       ;; Box.
       ;; The same parameters do not modify the page.
       (assert-not-dirties P (apply set-box! b (box-info b)))
+      ;; Set color explicitly to facilitate next tests.
+      (set-box! b '(1 . 2) '(3 . 4) 3)
+      ;; Change x of the first corner.
+      (assert-dirties P (apply set-box! b '((2 . 2) (3 . 4) 3)))
+      ;; Change y of the first corner.
+      (assert-dirties P (apply set-box! b '((2 . 3) (3 . 4) 3)))
+      ;; Change x of the second corner.
+      (assert-dirties P (apply set-box! b '((2 . 3) (4 . 4) 3)))
+      ;; Change y of the second corner.
+      (assert-dirties P (apply set-box! b '((2 . 3) (4 . 5) 3)))
+      ;; Change color.
+      (assert-dirties P (apply set-box! b '((2 . 3) (4 . 5) 4)))
 
       (assert-dirties P (apply set-line! l (line-info l)))
       (assert-dirties P (apply set-circle! c (circle-info c)))

--- a/liblepton/src/a_basic.c
+++ b/liblepton/src/a_basic.c
@@ -165,7 +165,7 @@ GList
         break;
 
       case(OBJ_BOX):
-        if ((new_obj = o_box_read (line, release_ver, fileformat_ver, err)) == NULL)
+        if ((new_obj = lepton_box_object_read (line, release_ver, fileformat_ver, err)) == NULL)
           goto error;
         new_object_list = g_list_prepend (new_object_list, new_obj);
         break;

--- a/liblepton/src/box_object.c
+++ b/liblepton/src/box_object.c
@@ -28,6 +28,79 @@
 
 #include "liblepton_priv.h"
 
+int
+lepton_box_object_get_upper_x (const LeptonObject *object)
+{
+  g_return_val_if_fail (lepton_object_is_box (object), 0);
+  g_return_val_if_fail (object->box != NULL, 0);
+
+  return object->box->upper_x;
+}
+
+int
+lepton_box_object_get_upper_y (const LeptonObject *object)
+{
+  g_return_val_if_fail (lepton_object_is_box (object), 0);
+  g_return_val_if_fail (object->box != NULL, 0);
+
+  return object->box->upper_y;
+}
+
+int
+lepton_box_object_get_lower_x (const LeptonObject *object)
+{
+  g_return_val_if_fail (lepton_object_is_box (object), 0);
+  g_return_val_if_fail (object->box != NULL, 0);
+
+  return object->box->lower_x;
+}
+
+int
+lepton_box_object_get_lower_y (const LeptonObject *object)
+{
+  g_return_val_if_fail (lepton_object_is_box (object), 0);
+  g_return_val_if_fail (object->box != NULL, 0);
+
+  return object->box->lower_y;
+}
+
+
+void
+lepton_box_object_set_upper_x (LeptonObject *object, int val)
+{
+  g_return_if_fail (lepton_object_is_box (object));
+  g_return_if_fail (object->box != NULL);
+
+  object->box->upper_x = val;
+}
+
+void
+lepton_box_object_set_upper_y (LeptonObject *object, int val)
+{
+  g_return_if_fail (lepton_object_is_box (object));
+  g_return_if_fail (object->box != NULL);
+
+  object->box->upper_y = val;
+}
+
+void
+lepton_box_object_set_lower_x (LeptonObject *object, int val)
+{
+  g_return_if_fail (lepton_object_is_box (object));
+  g_return_if_fail (object->box != NULL);
+
+  object->box->lower_x = val;
+}
+
+void
+lepton_box_object_set_lower_y (LeptonObject *object, int val)
+{
+  g_return_if_fail (lepton_object_is_box (object));
+  g_return_if_fail (object->box != NULL);
+
+  object->box->lower_y = val;
+}
+
 /*! \brief Create a box LeptonObject
  *  \par Function Description
  *  This function creates a new object representing a box.

--- a/liblepton/src/box_object.c
+++ b/liblepton/src/box_object.c
@@ -360,10 +360,10 @@ lepton_box_object_modify (LeptonObject *object,
  *  \return The box LeptonObject that was created, or NULL on error.
  */
 LeptonObject*
-o_box_read (const char buf[],
-            unsigned int release_ver,
-            unsigned int fileformat_ver,
-            GError **err)
+lepton_box_object_read (const char buf[],
+                        unsigned int release_ver,
+                        unsigned int fileformat_ver,
+                        GError **err)
 {
   LeptonObject *new_obj;
   char type;

--- a/liblepton/src/box_object.c
+++ b/liblepton/src/box_object.c
@@ -259,36 +259,6 @@ lepton_box_object_copy (LeptonObject *o_current)
 }
 
 /*! \brief Modify a box LeptonObject's coordinates.
- * \par Function Description
- * Modifies the coordinates of all four corners of \a box, by setting
- * the box to the rectangle enclosed by the points (\a x1, \a y1) and
- * (\a x2, \a y2).
- *
- * \param [in,out] object   box #LeptonObject to be modified.
- * \param [in]     x1       x coordinate of first corner of box.
- * \param [in]     y1       y coordinate of first corner of box.
- * \param [in]     x2       x coordinate of second corner of box.
- * \param [in]     y2       y coordinate of second corner of box,
- */
-void
-lepton_box_object_modify_all (LeptonObject *object,
-                              int x1,
-                              int y1,
-                              int x2,
-                              int y2)
-{
-  lepton_object_emit_pre_change_notify (object);
-
-  lepton_box_object_set_lower_x (object, (x1 > x2) ? x1 : x2);
-  lepton_box_object_set_lower_y (object, (y1 > y2) ? y2 : y1);
-
-  lepton_box_object_set_upper_x (object, (x1 > x2) ? x2 : x1);
-  lepton_box_object_set_upper_y (object, (y1 > y2) ? y1 : y2);
-
-  lepton_object_emit_change_notify (object);
-}
-
-/*! \brief Modify a box LeptonObject's coordinates.
  *  \par Function Description
  *  This function modifies the coordinates of one of the four corner of
  *  the box. The new coordinates of the corner identified by <B>whichone</B>

--- a/liblepton/src/box_object.c
+++ b/liblepton/src/box_object.c
@@ -28,6 +28,11 @@
 
 #include "liblepton_priv.h"
 
+/*! \brief Get the upper x coordinate of a box object.
+ *
+ *  \param [in] object The box object.
+ *  \return The x coordinate of the upper corner of the box.
+ */
 int
 lepton_box_object_get_upper_x (const LeptonObject *object)
 {
@@ -37,6 +42,11 @@ lepton_box_object_get_upper_x (const LeptonObject *object)
   return object->box->upper_x;
 }
 
+/*! \brief Get the upper y coordinate of a box object.
+ *
+ *  \param [in] object The box object.
+ *  \return The y coordinate of the upper corner of the box.
+ */
 int
 lepton_box_object_get_upper_y (const LeptonObject *object)
 {
@@ -46,6 +56,11 @@ lepton_box_object_get_upper_y (const LeptonObject *object)
   return object->box->upper_y;
 }
 
+/*! \brief Get the lower x coordinate of a box object.
+ *
+ *  \param [in] object The box object.
+ *  \return The x coordinate of the lower corner of the box.
+ */
 int
 lepton_box_object_get_lower_x (const LeptonObject *object)
 {
@@ -55,6 +70,11 @@ lepton_box_object_get_lower_x (const LeptonObject *object)
   return object->box->lower_x;
 }
 
+/*! \brief Get the lower y coordinate of a box object.
+ *
+ *  \param [in] object The box object.
+ *  \return The y coordinate of the lower corner of the box.
+ */
 int
 lepton_box_object_get_lower_y (const LeptonObject *object)
 {
@@ -65,6 +85,11 @@ lepton_box_object_get_lower_y (const LeptonObject *object)
 }
 
 
+/*! \brief Set the value of the upper x coordinate of a box object.
+ *
+ *  \param [in,out] object The box object.
+ *  \param [in] x The new upper x coordinate of the box.
+ */
 void
 lepton_box_object_set_upper_x (LeptonObject *object, int val)
 {
@@ -74,6 +99,11 @@ lepton_box_object_set_upper_x (LeptonObject *object, int val)
   object->box->upper_x = val;
 }
 
+/*! \brief Set the value of the upper y coordinate of a box object.
+ *
+ *  \param [in,out] object The box object.
+ *  \param [in] y The new upper y coordinate of the box.
+ */
 void
 lepton_box_object_set_upper_y (LeptonObject *object, int val)
 {
@@ -83,6 +113,11 @@ lepton_box_object_set_upper_y (LeptonObject *object, int val)
   object->box->upper_y = val;
 }
 
+/*! \brief Set the value of the lower x coordinate of a box object.
+ *
+ *  \param [in,out] object The box object.
+ *  \param [in] x The new lower x coordinate of the box.
+ */
 void
 lepton_box_object_set_lower_x (LeptonObject *object, int val)
 {
@@ -92,6 +127,11 @@ lepton_box_object_set_lower_x (LeptonObject *object, int val)
   object->box->lower_x = val;
 }
 
+/*! \brief Set the value of the lower y coordinate of a box object.
+ *
+ *  \param [in,out] object The box object.
+ *  \param [in] y The new lower y coordinate of the box.
+ */
 void
 lepton_box_object_set_lower_y (LeptonObject *object, int val)
 {

--- a/liblepton/src/edarenderer.c
+++ b/liblepton/src/edarenderer.c
@@ -703,8 +703,10 @@ eda_renderer_draw_box (EdaRenderer *renderer, LeptonObject *object)
   /* Draw outline of box */
   eda_cairo_box (renderer->priv->cr, EDA_RENDERER_CAIRO_FLAGS (renderer),
                  lepton_object_get_stroke_width (object),
-                 object->box->lower_x, object->box->lower_y,
-                 object->box->upper_x, object->box->upper_y);
+                 lepton_box_object_get_lower_x (object),
+                 lepton_box_object_get_lower_y (object),
+                 lepton_box_object_get_upper_x (object),
+                 lepton_box_object_get_upper_y (object));
   if (fill_solid) cairo_fill_preserve (renderer->priv->cr);
   eda_cairo_stroke (renderer->priv->cr, EDA_RENDERER_CAIRO_FLAGS (renderer),
                     lepton_object_get_stroke_type (object),
@@ -1122,11 +1124,17 @@ eda_renderer_default_draw_grips (EdaRenderer *renderer, LeptonObject *object)
         object->line->x[1], object->line->y[1]);
     break;
   case OBJ_BOX:
-    eda_renderer_draw_grips_impl (renderer, GRIP_SQUARE, 4,
-        object->box->upper_x, object->box->upper_y,
-        object->box->lower_x, object->box->upper_y,
-        object->box->upper_x, object->box->lower_y,
-        object->box->lower_x, object->box->lower_y);
+    eda_renderer_draw_grips_impl (renderer,
+                                  GRIP_SQUARE,
+                                  4,
+                                  lepton_box_object_get_upper_x (object),
+                                  lepton_box_object_get_upper_y (object),
+                                  lepton_box_object_get_lower_x (object),
+                                  lepton_box_object_get_upper_y (object),
+                                  lepton_box_object_get_upper_x (object),
+                                  lepton_box_object_get_lower_y (object),
+                                  lepton_box_object_get_lower_x (object),
+                                  lepton_box_object_get_lower_y (object));
     break;
   case OBJ_ARC:
     eda_renderer_draw_arc_grips (renderer, object);

--- a/liblepton/src/o_attrib.c
+++ b/liblepton/src/o_attrib.c
@@ -243,7 +243,7 @@ o_read_attribs (LeptonPage *page,
         break;
 
       case(OBJ_BOX):
-        if ((new_obj = o_box_read (line, release_ver, fileformat_ver, err)) == NULL)
+        if ((new_obj = lepton_box_object_read (line, release_ver, fileformat_ver, err)) == NULL)
           goto error;
         object_list = g_list_prepend (object_list, new_obj);
         break;

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -791,46 +791,6 @@ SCM_DEFINE (pin_type, "%pin-type", 1, 0, 0,
   return result;
 }
 
-/*! \brief Set box parameters.
- * \par Function Description
- * Modifies a box object by setting its parameters to new values.
- *
- * \note Scheme API: Implements the %set-box! procedure in the
- * (lepton core object) module.
- *
- * \param box_s  the box object to modify.
- * \param x1_s   the new x-coordinate of the top left of the box.
- * \param y1_s   the new y-coordinate of the top left of the box.
- * \param x2_s   the new x-coordinate of the bottom right of the box.
- * \param y2_s   the new y-coordinate of the bottom right of the box.
- * \param color  the colormap index of the color to be used for
- *               drawing the box.
- *
- * \return the modified box object.
- */
-SCM_DEFINE (set_box_x, "%set-box!", 6, 0, 0,
-            (SCM box_s, SCM x1_s, SCM y1_s, SCM x2_s, SCM y2_s, SCM color_s),
-            "Set box parameters.")
-{
-  SCM_ASSERT (edascm_is_object_type (box_s, OBJ_BOX), box_s,
-              SCM_ARG1, s_set_box_x);
-  SCM_ASSERT (scm_is_integer (x1_s),    x1_s,    SCM_ARG2, s_set_box_x);
-  SCM_ASSERT (scm_is_integer (y1_s),    y1_s,    SCM_ARG3, s_set_box_x);
-  SCM_ASSERT (scm_is_integer (x2_s),    x2_s,    SCM_ARG4, s_set_box_x);
-  SCM_ASSERT (scm_is_integer (y2_s),    y2_s,    SCM_ARG5, s_set_box_x);
-  SCM_ASSERT (scm_is_integer (color_s), color_s, SCM_ARG6, s_set_box_x);
-
-  LeptonObject *obj = edascm_to_object (box_s);
-  lepton_box_object_modify_all (obj,
-                                scm_to_int (x1_s), scm_to_int (y1_s),
-                                scm_to_int (x2_s), scm_to_int (y2_s));
-  lepton_object_set_color (obj, scm_to_int (color_s));
-
-  lepton_object_page_set_changed (obj);
-
-  return box_s;
-}
-
 /*! \brief Create a new circle.
  * \par Function Description
 
@@ -1716,7 +1676,6 @@ init_module_lepton_core_object (void *unused)
                 s_pin_type,
                 s_set_line_x,
                 s_line_info,
-                s_set_box_x,
                 s_make_circle,
                 s_set_circle_x,
                 s_circle_info,

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -831,36 +831,6 @@ SCM_DEFINE (set_box_x, "%set-box!", 6, 0, 0,
   return box_s;
 }
 
-/*! \brief Get box parameters.
- * \par Function Description
- * Retrieves the parameters of a box object. The return value is a
- * list of parameters:
- *
- * -# X-coordinate of top left of box
- * -# Y-coordinate of top left of box
- * -# X-coordinate of bottom right of box
- * -# Y-coordinate of bottom right of box
- * -# Colormap index of color to be used for drawing the box
- *
- * \param box_s the box object to inspect.
- * \return a list of box parameters.
- */
-SCM_DEFINE (box_info, "%box-info", 1, 0, 0,
-            (SCM box_s), "Get box parameters.")
-{
-  SCM_ASSERT (edascm_is_object_type (box_s, OBJ_BOX), box_s,
-              SCM_ARG1, s_box_info);
-
-  LeptonObject *obj = edascm_to_object (box_s);
-
-  return scm_list_n (scm_from_int (lepton_box_object_get_upper_x (obj)),
-                     scm_from_int (lepton_box_object_get_upper_y (obj)),
-                     scm_from_int (lepton_box_object_get_lower_x (obj)),
-                     scm_from_int (lepton_box_object_get_lower_y (obj)),
-                     scm_from_int (lepton_object_get_color (obj)),
-                     SCM_UNDEFINED);
-}
-
 /*! \brief Create a new circle.
  * \par Function Description
 
@@ -1747,7 +1717,6 @@ init_module_lepton_core_object (void *unused)
                 s_set_line_x,
                 s_line_info,
                 s_set_box_x,
-                s_box_info,
                 s_make_circle,
                 s_set_circle_x,
                 s_circle_info,

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -791,31 +791,6 @@ SCM_DEFINE (pin_type, "%pin-type", 1, 0, 0,
   return result;
 }
 
-/*! \brief Create a new box.
- * \par Function Description
- * Creates a new box object, with all its parameters set to default
- * values.
- *
- * \note Scheme API: Implements the %make-box procedure in the
- * (lepton core object) module.
- *
- * \return a newly-created box object.
- */
-SCM_DEFINE (make_box, "%make-box", 0, 0, 0,
-            (), "Create a new box object.")
-{
-  LeptonObject *obj = lepton_box_object_new (default_color_id(),
-                                             0, 0, 0, 0);
-
-  SCM result = edascm_from_object (obj);
-
-  /* At the moment, the only pointer to the object is owned by the
-   * smob. */
-  edascm_c_set_gc (result, 1);
-
-  return result;
-}
-
 /*! \brief Set box parameters.
  * \par Function Description
  * Modifies a box object by setting its parameters to new values.
@@ -1771,7 +1746,6 @@ init_module_lepton_core_object (void *unused)
                 s_pin_type,
                 s_set_line_x,
                 s_line_info,
-                s_make_box,
                 s_set_box_x,
                 s_box_info,
                 s_make_circle,

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -878,10 +878,10 @@ SCM_DEFINE (box_info, "%box-info", 1, 0, 0,
 
   LeptonObject *obj = edascm_to_object (box_s);
 
-  return scm_list_n (scm_from_int (obj->box->upper_x),
-                     scm_from_int (obj->box->upper_y),
-                     scm_from_int (obj->box->lower_x),
-                     scm_from_int (obj->box->lower_y),
+  return scm_list_n (scm_from_int (lepton_box_object_get_upper_x (obj)),
+                     scm_from_int (lepton_box_object_get_upper_y (obj)),
+                     scm_from_int (lepton_box_object_get_lower_x (obj)),
+                     scm_from_int (lepton_box_object_get_lower_y (obj)),
                      scm_from_int (lepton_object_get_color (obj)),
                      SCM_UNDEFINED);
 }

--- a/libleptongui/src/o_attrib.c
+++ b/libleptongui/src/o_attrib.c
@@ -278,8 +278,8 @@ LeptonObject *o_attrib_add_attrib(GschemToplevel *w_current,
         break;
 
       case(OBJ_BOX):
-        world_x = o_current->box->upper_x;
-        world_y = o_current->box->upper_y;
+        world_x = lepton_box_object_get_upper_x (o_current);
+        world_y = lepton_box_object_get_upper_y (o_current);
         align = LOWER_LEFT;
         angle = 0;
         color = ATTRIBUTE_COLOR;

--- a/libleptongui/src/o_grips.c
+++ b/libleptongui/src/o_grips.c
@@ -273,34 +273,37 @@ LeptonObject *o_grips_search_arc_world(GschemToplevel *w_current, LeptonObject *
 LeptonObject *o_grips_search_box_world(GschemToplevel *w_current, LeptonObject *o_current,
                                  int x, int y, int size, int *whichone)
 {
+  int upper_x, upper_y, lower_x, lower_y;
+
+  upper_x = lepton_box_object_get_upper_x (o_current);
+  upper_y = lepton_box_object_get_upper_y (o_current);
+  lower_x = lepton_box_object_get_lower_x (o_current);
+  lower_y = lepton_box_object_get_lower_y (o_current);
+
   /* inside upper left grip ? */
-  if (inside_grip(x, y,
-                  o_current->box->upper_x,
-                  o_current->box->upper_y, size)) {
+  if (inside_grip (x, y, upper_x, upper_y, size))
+  {
     *whichone = BOX_UPPER_LEFT;
     return(o_current);
   }
 
   /* inside lower right grip ? */
-  if (inside_grip(x, y,
-                  o_current->box->lower_x,
-                  o_current->box->lower_y, size)) {
+  if (inside_grip (x, y, lower_x, lower_y, size))
+  {
     *whichone = BOX_LOWER_RIGHT;
     return(o_current);
   }
 
   /* inside upper right grip ? */
-  if (inside_grip(x, y,
-                  o_current->box->lower_x,
-                  o_current->box->upper_y, size)) {
+  if (inside_grip (x, y, lower_x, upper_y, size))
+  {
     *whichone = BOX_UPPER_RIGHT;
     return(o_current);
   }
 
   /* inside lower left grip ? */
-  if (inside_grip(x, y,
-                  o_current->box->upper_x,
-                  o_current->box->lower_y, size)) {
+  if (inside_grip (x, y, upper_x, lower_y, size))
+  {
     *whichone = BOX_LOWER_LEFT;
     return(o_current);
   }
@@ -601,34 +604,41 @@ static void o_grips_start_arc(GschemToplevel *w_current, LeptonObject *o_current
 static void o_grips_start_box(GschemToplevel *w_current, LeptonObject *o_current,
                               int x, int y, int whichone)
 {
+  int upper_x, upper_y, lower_x, lower_y;
+
   w_current->last_drawb_mode = LAST_DRAWB_MODE_NONE;
+
+  upper_x = lepton_box_object_get_upper_x (o_current);
+  upper_y = lepton_box_object_get_upper_y (o_current);
+  lower_x = lepton_box_object_get_lower_x (o_current);
+  lower_y = lepton_box_object_get_lower_y (o_current);
 
   /* (second_wx, second_wy) is the selected corner */
   /* (first_wx, first_wy) is the opposite corner */
   switch(whichone) {
     case BOX_UPPER_LEFT:
-      w_current->second_wx = o_current->box->upper_x;
-      w_current->second_wy = o_current->box->upper_y;
-      w_current->first_wx = o_current->box->lower_x;
-      w_current->first_wy = o_current->box->lower_y;
+      w_current->second_wx = upper_x;
+      w_current->second_wy = upper_y;
+      w_current->first_wx  = lower_x;
+      w_current->first_wy  = lower_y;
       break;
     case BOX_LOWER_RIGHT:
-      w_current->second_wx = o_current->box->lower_x;
-      w_current->second_wy = o_current->box->lower_y;
-      w_current->first_wx = o_current->box->upper_x;
-      w_current->first_wy = o_current->box->upper_y;
+      w_current->second_wx = lower_x;
+      w_current->second_wy = lower_y;
+      w_current->first_wx  = upper_x;
+      w_current->first_wy  = upper_y;
       break;
     case BOX_UPPER_RIGHT:
-      w_current->second_wx = o_current->box->lower_x;
-      w_current->second_wy = o_current->box->upper_y;
-      w_current->first_wx = o_current->box->upper_x;
-      w_current->first_wy = o_current->box->lower_y;
+      w_current->second_wx = lower_x;
+      w_current->second_wy = upper_y;
+      w_current->first_wx  = upper_x;
+      w_current->first_wy  = lower_y;
       break;
     case BOX_LOWER_LEFT:
-      w_current->second_wx = o_current->box->upper_x;
-      w_current->second_wy = o_current->box->lower_y;
-      w_current->first_wx = o_current->box->lower_x;
-      w_current->first_wy = o_current->box->upper_y;
+      w_current->second_wx = upper_x;
+      w_current->second_wy = lower_y;
+      w_current->first_wx  = lower_x;
+      w_current->first_wy  = upper_y;
       break;
     default:
       return; /* error */


### PR DESCRIPTION
Changes similar to #785 and some additions for that PR:
- The functions `box-info()`, `make-box()`, and `set-box!()` as well as getters for box coords and color have been rewritten using Scheme FFI
- Added accessors for box fields.
- Added lots of new tests for box functions.
- Added new type checkers that throw `'wrong-type-arg` errors.  They are now used both in box and arc functions and report errors similar to what core Guile functions do.
