### PR TITLE
Move two fields of LeptonObject to LeptonText

### DIFF
--- a/liblepton/include/liblepton/object.h
+++ b/liblepton/include/liblepton/object.h
@@ -70,7 +70,6 @@ struct st_object
   int pin_type;    /* for pins only, either NET or BUS */
 
   GList *attribs;       /* attribute stuff */
-  int show_name_value;
   int visibility;
   LeptonObject *attached_to;  /* when object is an attribute */
   LeptonObject *copied_to;    /* used when copying attributes */

--- a/liblepton/include/liblepton/object.h
+++ b/liblepton/include/liblepton/object.h
@@ -70,7 +70,6 @@ struct st_object
   int pin_type;    /* for pins only, either NET or BUS */
 
   GList *attribs;       /* attribute stuff */
-  int visibility;
   LeptonObject *attached_to;  /* when object is an attribute */
   LeptonObject *copied_to;    /* used when copying attributes */
 
@@ -160,9 +159,6 @@ lepton_object_get_position (const LeptonObject *object,
 gboolean
 lepton_object_get_selectable (const LeptonObject *object);
 
-gint
-lepton_object_get_visibility (const LeptonObject *object);
-
 void
 lepton_object_rotate (int world_centerx,
                       int world_centery,
@@ -247,9 +243,6 @@ lepton_object_page_set_changed (LeptonObject *object);
 LeptonObject*
 lepton_object_get_parent (LeptonObject *object);
 
-gboolean
-lepton_object_is_visible (const LeptonObject *object);
-
 void
 lepton_object_set_color (LeptonObject *object,
                          int color);
@@ -269,9 +262,6 @@ lepton_object_set_line_options (LeptonObject *o_current,
                                 int width,
                                 int length,
                                 int space);
-void
-lepton_object_set_visibility (LeptonObject *object,
-                              int visibility);
 void
 lepton_object_add_change_notify (LeptonToplevel *toplevel,
                                  ChangeNotifyFunc pre_change_func,

--- a/liblepton/include/liblepton/text.h
+++ b/liblepton/include/liblepton/text.h
@@ -20,9 +20,9 @@
 /*! \file text.h
  */
 
-typedef struct st_text LeptonText;
+typedef struct _LeptonText LeptonText;
 
-struct st_text
+struct _LeptonText
 {
   int x, y;             /* world origin */
 
@@ -32,7 +32,7 @@ struct st_text
   int size;
   int alignment;
   int angle;
-  const gchar *name;    /* not owned by st_text */
+  const gchar *name;    /* not owned by _LeptonText */
 
   /* Attribute stuff. */
   int show;

--- a/liblepton/include/liblepton/text.h
+++ b/liblepton/include/liblepton/text.h
@@ -36,4 +36,5 @@ struct st_text
 
   /* Attribute stuff. */
   int show;
+  int visibility;
 };

--- a/liblepton/include/liblepton/text.h
+++ b/liblepton/include/liblepton/text.h
@@ -33,4 +33,7 @@ struct st_text
   int alignment;
   int angle;
   const gchar *name;    /* not owned by st_text */
+
+  /* Attribute stuff. */
+  int show_name_value;
 };

--- a/liblepton/include/liblepton/text.h
+++ b/liblepton/include/liblepton/text.h
@@ -35,5 +35,5 @@ struct st_text
   const gchar *name;    /* not owned by st_text */
 
   /* Attribute stuff. */
-  int show_name_value;
+  int show;
 };

--- a/liblepton/include/liblepton/text_object.h
+++ b/liblepton/include/liblepton/text_object.h
@@ -131,5 +131,13 @@ lepton_text_object_read (const char *first_line,
                          unsigned int release_ver,
                          unsigned int fileformat_ver,
                          GError **err);
+gboolean
+lepton_text_object_is_visible (const LeptonObject *object);
+
+void
+lepton_text_object_set_visibility (LeptonObject *object,
+                                   int visibility);
+gint
+lepton_text_object_get_visibility (const LeptonObject *object);
 
 G_END_DECLS

--- a/liblepton/include/liblepton/text_object.h
+++ b/liblepton/include/liblepton/text_object.h
@@ -114,7 +114,7 @@ lepton_text_object_translate (LeptonObject *object,
 /* older methods, need renaming */
 
 void
-o_text_recreate (LeptonObject *o_current);
+lepton_text_object_recreate (LeptonObject *o_current);
 
 void
 o_text_set_string (LeptonObject *obj,

--- a/liblepton/include/liblepton/text_object.h
+++ b/liblepton/include/liblepton/text_object.h
@@ -73,6 +73,9 @@ lepton_text_object_get_x (const LeptonObject *object);
 gint
 lepton_text_object_get_y (const LeptonObject *object);
 
+gint
+lepton_text_object_get_show_name_value (const LeptonObject *object);
+
 void
 lepton_text_object_mirror (int world_centerx,
                            int world_centery,
@@ -97,6 +100,9 @@ lepton_text_object_set_x (LeptonObject *object,
 void
 lepton_text_object_set_y (LeptonObject *object,
                           gint y);
+void
+lepton_text_object_set_show_name_value (LeptonObject *object,
+                                        gint show);
 double
 lepton_text_object_shortest_distance (LeptonObject *object,
                                       int x,

--- a/liblepton/include/liblepton/text_object.h
+++ b/liblepton/include/liblepton/text_object.h
@@ -117,8 +117,8 @@ void
 lepton_text_object_recreate (LeptonObject *o_current);
 
 void
-o_text_set_string (LeptonObject *obj,
-                   const gchar *new_string);
+lepton_text_object_set_string (LeptonObject *obj,
+                               const gchar *new_string);
 LeptonObject*
 lepton_text_object_read (const char *first_line,
                          TextBuffer *tb,

--- a/liblepton/include/liblepton/text_object.h
+++ b/liblepton/include/liblepton/text_object.h
@@ -119,12 +119,11 @@ o_text_recreate (LeptonObject *o_current);
 void
 o_text_set_string (LeptonObject *obj,
                    const gchar *new_string);
-
 LeptonObject*
-o_text_read (const char *first_line,
-             TextBuffer *tb,
-             unsigned int release_ver,
-             unsigned int fileformat_ver,
-             GError **err);
+lepton_text_object_read (const char *first_line,
+                         TextBuffer *tb,
+                         unsigned int release_ver,
+                         unsigned int fileformat_ver,
+                         GError **err);
 
 G_END_DECLS

--- a/liblepton/include/liblepton/text_object.h
+++ b/liblepton/include/liblepton/text_object.h
@@ -74,7 +74,7 @@ gint
 lepton_text_object_get_y (const LeptonObject *object);
 
 gint
-lepton_text_object_get_show_name_value (const LeptonObject *object);
+lepton_text_object_get_show (const LeptonObject *object);
 
 void
 lepton_text_object_mirror (int world_centerx,
@@ -101,8 +101,8 @@ void
 lepton_text_object_set_y (LeptonObject *object,
                           gint y);
 void
-lepton_text_object_set_show_name_value (LeptonObject *object,
-                                        gint show);
+lepton_text_object_set_show (LeptonObject *object,
+                             gint show);
 double
 lepton_text_object_shortest_distance (LeptonObject *object,
                                       int x,

--- a/liblepton/src/a_basic.c
+++ b/liblepton/src/a_basic.c
@@ -193,7 +193,7 @@ GList
         break;
 
       case(OBJ_TEXT):
-        new_obj = o_text_read (line, tb, release_ver, fileformat_ver, err);
+        new_obj = lepton_text_object_read (line, tb, release_ver, fileformat_ver, err);
         if (new_obj == NULL)
           goto error;
         new_object_list = g_list_prepend (new_object_list, new_obj);

--- a/liblepton/src/component_object.c
+++ b/liblepton/src/component_object.c
@@ -231,7 +231,7 @@ static int
 o_component_is_eligible_attribute (LeptonObject *object)
 {
   gboolean promote_invisible;
-  g_return_val_if_fail (object, FALSE);
+  g_return_val_if_fail (o_attrib_is_attrib (object), FALSE);
 
   cfg_read_bool ("schematic.attrib", "promote-invisible",
                  default_promote_invisible, &promote_invisible);

--- a/liblepton/src/component_object.c
+++ b/liblepton/src/component_object.c
@@ -256,7 +256,7 @@ o_component_is_eligible_attribute (LeptonObject *object)
   }
 
   /* object is invisible and we do not want to promote invisible text */
-  if ((!lepton_object_is_visible (object)) &&
+  if ((!lepton_text_object_is_visible (object)) &&
       (promote_invisible == FALSE))
     return FALSE; /* attribute not eligible for promotion */
 
@@ -389,7 +389,7 @@ o_component_promote_attribs (LeptonObject *object)
     for (iter = promotable; iter != NULL; iter = g_list_next (iter)) {
       LeptonObject *o_kept = (LeptonObject *) iter->data;
       LeptonObject *o_copy = lepton_object_copy (o_kept);
-      lepton_object_set_visibility (o_kept, INVISIBLE);
+      lepton_text_object_set_visibility (o_kept, INVISIBLE);
       o_copy->parent = NULL;
       promoted = g_list_prepend (promoted, o_copy);
     }
@@ -444,7 +444,7 @@ o_component_remove_promotable_attribs (LeptonObject *object)
   for (iter = promotable; iter != NULL; iter = g_list_next (iter)) {
     LeptonObject *a_object = (LeptonObject*) iter->data;
     if (keep_invisible == TRUE) {   /* Hide promotable attributes */
-      lepton_object_set_visibility (a_object, INVISIBLE);
+      lepton_text_object_set_visibility (a_object, INVISIBLE);
     } else {                                /* Delete promotable attributes */
       object->component->prim_objs =
         g_list_remove (object->component->prim_objs, a_object);

--- a/liblepton/src/edarenderer.c
+++ b/liblepton/src/edarenderer.c
@@ -792,6 +792,9 @@ eda_renderer_draw_text (EdaRenderer *renderer, LeptonObject *object)
   double x, y;
   double dummy = 0, small_dist = TEXT_MARKER_SIZE;
 
+  g_return_if_fail (lepton_object_is_text (object));
+  g_return_if_fail (object->text != NULL);
+
   /* First check if this is hidden text. */
   if (!lepton_text_object_is_visible (object)
       && !EDA_RENDERER_CHECK_FLAG (renderer, FLAG_TEXT_HIDDEN)) {
@@ -1295,6 +1298,9 @@ eda_renderer_draw_path_grips (EdaRenderer *renderer, LeptonObject *object)
 static void
 eda_renderer_draw_text_grips (EdaRenderer *renderer, LeptonObject *object)
 {
+  g_return_if_fail (lepton_object_is_text (object));
+  g_return_if_fail (object->text != NULL);
+
   double dummy = 0, small_dist = TEXT_MARKER_SIZE;
   int x = object->text->x;
   int y = object->text->y;
@@ -1546,6 +1552,9 @@ eda_renderer_get_text_user_bounds (const LeptonObject *object,
                                    double *right,
                                    double *bottom)
 {
+  g_return_val_if_fail (lepton_object_is_text (object), FALSE);
+  g_return_val_if_fail (object->text != NULL, FALSE);
+
   PangoRectangle inked_rect, logical_rect;
   gboolean result = FALSE;
 

--- a/liblepton/src/edarenderer.c
+++ b/liblepton/src/edarenderer.c
@@ -793,7 +793,7 @@ eda_renderer_draw_text (EdaRenderer *renderer, LeptonObject *object)
   double dummy = 0, small_dist = TEXT_MARKER_SIZE;
 
   /* First check if this is hidden text. */
-  if (!lepton_object_is_visible (object)
+  if (!lepton_text_object_is_visible (object)
       && !EDA_RENDERER_CHECK_FLAG (renderer, FLAG_TEXT_HIDDEN)) {
     return;
   }
@@ -827,7 +827,7 @@ eda_renderer_draw_text (EdaRenderer *renderer, LeptonObject *object)
 
   /* If the text is flagged invisible, and we're showing hidden text,
    * draw a little "I". */
-  if (lepton_object_is_visible (object))
+  if (lepton_text_object_is_visible (object))
     return;
 
   /* Check that color is enabled */
@@ -1300,7 +1300,7 @@ eda_renderer_draw_text_grips (EdaRenderer *renderer, LeptonObject *object)
   int y = object->text->y;
 
   /* First check if this is hidden text. */
-  if (!lepton_object_is_visible (object)
+  if (!lepton_text_object_is_visible (object)
       && !EDA_RENDERER_CHECK_FLAG (renderer, FLAG_TEXT_HIDDEN)) {
     return;
   }
@@ -1550,7 +1550,7 @@ eda_renderer_get_text_user_bounds (const LeptonObject *object,
   gboolean result = FALSE;
 
   /* First check if this is hidden text. */
-  if (!lepton_object_is_visible (object) && !enable_hidden) {
+  if (!lepton_text_object_is_visible (object) && !enable_hidden) {
     return FALSE;
   }
 

--- a/liblepton/src/edarenderer.c
+++ b/liblepton/src/edarenderer.c
@@ -793,7 +793,7 @@ eda_renderer_draw_text (EdaRenderer *renderer, LeptonObject *object)
   double dummy = 0, small_dist = TEXT_MARKER_SIZE;
 
   /* First check if this is hidden text. */
-  if (object->visibility == INVISIBLE
+  if (!lepton_object_is_visible (object)
       && !EDA_RENDERER_CHECK_FLAG (renderer, FLAG_TEXT_HIDDEN)) {
     return;
   }
@@ -827,7 +827,7 @@ eda_renderer_draw_text (EdaRenderer *renderer, LeptonObject *object)
 
   /* If the text is flagged invisible, and we're showing hidden text,
    * draw a little "I". */
-  if (object->visibility != INVISIBLE)
+  if (lepton_object_is_visible (object))
     return;
 
   /* Check that color is enabled */
@@ -1300,7 +1300,7 @@ eda_renderer_draw_text_grips (EdaRenderer *renderer, LeptonObject *object)
   int y = object->text->y;
 
   /* First check if this is hidden text. */
-  if (object->visibility == INVISIBLE
+  if (!lepton_object_is_visible (object)
       && !EDA_RENDERER_CHECK_FLAG (renderer, FLAG_TEXT_HIDDEN)) {
     return;
   }
@@ -1550,7 +1550,7 @@ eda_renderer_get_text_user_bounds (const LeptonObject *object,
   gboolean result = FALSE;
 
   /* First check if this is hidden text. */
-  if (object->visibility == INVISIBLE && !enable_hidden) {
+  if (!lepton_object_is_visible (object) && !enable_hidden) {
     return FALSE;
   }
 

--- a/liblepton/src/o_attrib.c
+++ b/liblepton/src/o_attrib.c
@@ -280,7 +280,7 @@ o_read_attribs (LeptonPage *page,
         break;
 
       case(OBJ_TEXT):
-        new_obj = o_text_read (line, tb, release_ver, fileformat_ver, err);
+        new_obj = lepton_text_object_read (line, tb, release_ver, fileformat_ver, err);
         if (new_obj == NULL)
           goto error;
         object_list = g_list_prepend (object_list, new_obj);

--- a/liblepton/src/object.c
+++ b/liblepton/src/object.c
@@ -1678,7 +1678,7 @@ lepton_object_new (int type,
   new_node->attribs = NULL;
   new_node->attached_to = NULL;
   new_node->copied_to = NULL;
-  new_node->visibility = VISIBLE;
+  lepton_object_set_visibility (new_node, VISIBLE);
 
   new_node->pin_type = PIN_TYPE_NET;
   new_node->whichend = -1;

--- a/liblepton/src/object.c
+++ b/liblepton/src/object.c
@@ -1678,7 +1678,6 @@ lepton_object_new (int type,
   new_node->attribs = NULL;
   new_node->attached_to = NULL;
   new_node->copied_to = NULL;
-  new_node->show_name_value = SHOW_NAME_VALUE;
   new_node->visibility = VISIBLE;
 
   new_node->pin_type = PIN_TYPE_NET;

--- a/liblepton/src/object.c
+++ b/liblepton/src/object.c
@@ -1428,46 +1428,6 @@ lepton_object_emit_change_notify (LeptonObject *object)
   }
 }
 
-/*! \brief Query visibility of the object.
- *  \par Function Description
- *  Attribute getter for the visible field within the object.
- *
- *  \param object   The LeptonObject structure to be queried
- *  \return TRUE when VISIBLE, FALSE otherwise
- */
-gboolean
-lepton_object_is_visible (const LeptonObject *object)
-{
-  g_return_val_if_fail (object != NULL, FALSE);
-  return object->visibility == VISIBLE;
-}
-
-/*! \brief Get the visibility of an object
- *
- *  \param [in] object The LeptonObject structure to be queried
- *  \return VISIBLE or INVISIBLE
- */
-gint
-lepton_object_get_visibility (const LeptonObject *object)
-{
-  g_return_val_if_fail (object != NULL, VISIBLE);
-
-  return object->visibility;
-}
-
-/*! \brief Set visibility of the object.
- *
- *  \param object     The #LeptonObject structure to be modified
- *  \param visibility If the object should be visible
- */
-void
-lepton_object_set_visibility (LeptonObject *object,
-                              int visibility)
-{
-  g_return_if_fail (object != NULL);
-  object->visibility = visibility;
-}
-
 /*! \brief Return the bounds of the given object.
  *  \par Given an object, calculate the bounds coordinates.
  *
@@ -1497,7 +1457,7 @@ lepton_object_calculate_visible_bounds (LeptonObject *o_current,
   /* only do bounding boxes for visible or doing show_hidden_text*/
   /* you might lose some attrs though */
   if (lepton_object_is_text (o_current) &&
-      ! (lepton_object_is_visible (o_current) || include_hidden)) {
+      ! (lepton_text_object_is_visible (o_current) || include_hidden)) {
     return 0;
   }
 
@@ -1678,7 +1638,6 @@ lepton_object_new (int type,
   new_node->attribs = NULL;
   new_node->attached_to = NULL;
   new_node->copied_to = NULL;
-  lepton_object_set_visibility (new_node, VISIBLE);
 
   new_node->pin_type = PIN_TYPE_NET;
   new_node->whichend = -1;

--- a/liblepton/src/s_slot.c
+++ b/liblepton/src/s_slot.c
@@ -199,8 +199,8 @@ s_slot_update_object (LeptonObject *object)
       g_list_free (attributes);
 
       if (o_pinnum_attrib != NULL) {
-        o_text_set_string (o_pinnum_attrib,
-                           g_strdup_printf ("pinnumber=%s", current_pin));
+        lepton_text_object_set_string (o_pinnum_attrib,
+                                       g_strdup_printf ("pinnumber=%s", current_pin));
       }
 
       pin_counter++;

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -1026,7 +1026,7 @@ SCM_DEFINE (set_text_x, "%set-text!", 10, 0, 0,
   lepton_text_object_set_angle (obj, angle);
 
   lepton_text_object_set_size (obj, scm_to_int (size_s));
-  obj->visibility = visibility;
+  lepton_object_set_visibility (obj, visibility);
   lepton_text_object_set_show (obj, show);
 
   lepton_object_emit_change_notify (obj);
@@ -1091,13 +1091,14 @@ SCM_DEFINE (text_info, "%text-info", 1, 0, 0,
                     scm_list_2 (text_s, scm_from_int (lepton_text_object_get_alignment (obj))));
   }
 
-  switch (obj->visibility) {
+  switch (lepton_object_get_visibility (obj))
+  {
   case VISIBLE:   visible_s = SCM_BOOL_T; break;
   case INVISIBLE: visible_s = SCM_BOOL_F; break;
   default:
     scm_misc_error (s_text_info,
                     _("Text object ~A has invalid visibility ~A"),
-                    scm_list_2 (text_s, scm_from_int (obj->visibility)));
+                    scm_list_2 (text_s, scm_from_int (lepton_object_get_visibility (obj))));
   }
 
   switch (lepton_text_object_get_show (obj))

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -1035,7 +1035,7 @@ SCM_DEFINE (set_text_x, "%set-text!", 10, 0, 0,
   o_text_set_string (obj, tmp);
   free (tmp);
 
-  o_text_recreate (obj);
+  lepton_text_object_recreate (obj);
 
   /* Color */
   lepton_object_set_color (obj, scm_to_int (color_s));

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -1027,7 +1027,7 @@ SCM_DEFINE (set_text_x, "%set-text!", 10, 0, 0,
 
   lepton_text_object_set_size (obj, scm_to_int (size_s));
   obj->visibility = visibility;
-  lepton_text_object_set_show_name_value (obj, show);
+  lepton_text_object_set_show (obj, show);
 
   lepton_object_emit_change_notify (obj);
 
@@ -1100,7 +1100,7 @@ SCM_DEFINE (text_info, "%text-info", 1, 0, 0,
                     scm_list_2 (text_s, scm_from_int (obj->visibility)));
   }
 
-  switch (lepton_text_object_get_show_name_value (obj))
+  switch (lepton_text_object_get_show (obj))
   {
   case SHOW_NAME:       show_s = name_sym;  break;
   case SHOW_VALUE:      show_s = value_sym; break;
@@ -1109,7 +1109,7 @@ SCM_DEFINE (text_info, "%text-info", 1, 0, 0,
     scm_misc_error (s_text_info,
                     _("Text object ~A has invalid text attribute visibility ~A"),
                     scm_list_2 (text_s,
-                                scm_from_int (lepton_text_object_get_show_name_value (obj))));
+                                scm_from_int (lepton_text_object_get_show (obj))));
   }
 
   return scm_list_n (scm_from_int (obj->text->x),

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -1027,7 +1027,7 @@ SCM_DEFINE (set_text_x, "%set-text!", 10, 0, 0,
 
   lepton_text_object_set_size (obj, scm_to_int (size_s));
   obj->visibility = visibility;
-  obj->show_name_value = show;
+  lepton_text_object_set_show_name_value (obj, show);
 
   lepton_object_emit_change_notify (obj);
 

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -1032,7 +1032,7 @@ SCM_DEFINE (set_text_x, "%set-text!", 10, 0, 0,
   lepton_object_emit_change_notify (obj);
 
   char *tmp = scm_to_utf8_string (string_s);
-  o_text_set_string (obj, tmp);
+  lepton_text_object_set_string (obj, tmp);
   free (tmp);
 
   lepton_text_object_recreate (obj);

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -1026,7 +1026,7 @@ SCM_DEFINE (set_text_x, "%set-text!", 10, 0, 0,
   lepton_text_object_set_angle (obj, angle);
 
   lepton_text_object_set_size (obj, scm_to_int (size_s));
-  lepton_object_set_visibility (obj, visibility);
+  lepton_text_object_set_visibility (obj, visibility);
   lepton_text_object_set_show (obj, show);
 
   lepton_object_emit_change_notify (obj);
@@ -1091,14 +1091,14 @@ SCM_DEFINE (text_info, "%text-info", 1, 0, 0,
                     scm_list_2 (text_s, scm_from_int (lepton_text_object_get_alignment (obj))));
   }
 
-  switch (lepton_object_get_visibility (obj))
+  switch (lepton_text_object_get_visibility (obj))
   {
   case VISIBLE:   visible_s = SCM_BOOL_T; break;
   case INVISIBLE: visible_s = SCM_BOOL_F; break;
   default:
     scm_misc_error (s_text_info,
                     _("Text object ~A has invalid visibility ~A"),
-                    scm_list_2 (text_s, scm_from_int (lepton_object_get_visibility (obj))));
+                    scm_list_2 (text_s, scm_from_int (lepton_text_object_get_visibility (obj))));
   }
 
   switch (lepton_text_object_get_show (obj))

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -1100,14 +1100,16 @@ SCM_DEFINE (text_info, "%text-info", 1, 0, 0,
                     scm_list_2 (text_s, scm_from_int (obj->visibility)));
   }
 
-  switch (obj->show_name_value) {
+  switch (lepton_text_object_get_show_name_value (obj))
+  {
   case SHOW_NAME:       show_s = name_sym;  break;
   case SHOW_VALUE:      show_s = value_sym; break;
   case SHOW_NAME_VALUE: show_s = both_sym;  break;
   default:
     scm_misc_error (s_text_info,
                     _("Text object ~A has invalid text attribute visibility ~A"),
-                    scm_list_2 (text_s, scm_from_int (obj->show_name_value)));
+                    scm_list_2 (text_s,
+                                scm_from_int (lepton_text_object_get_show_name_value (obj))));
   }
 
   return scm_list_n (scm_from_int (obj->text->x),

--- a/liblepton/src/text_object.c
+++ b/liblepton/src/text_object.c
@@ -383,7 +383,8 @@ update_disp_string (LeptonObject *object)
   g_free (text->disp_string);
 
   if (o_attrib_get_name_value (object, &name, &value)) {
-    switch (object->show_name_value) {
+    switch (lepton_text_object_get_show_name_value (object))
+    {
       case (SHOW_NAME_VALUE):
         text->disp_string = g_strdup (text->string);
         break;
@@ -664,7 +665,7 @@ lepton_text_object_to_buffer (const LeptonObject *object)
                           lepton_object_get_color (object),
                           lepton_text_object_get_size (object),
                           lepton_object_get_visibility (object),
-                          object->show_name_value,
+                          lepton_text_object_get_show_name_value (object),
                           lepton_text_object_get_angle (object),
                           lepton_text_object_get_alignment (object),
                           o_text_num_lines (string),
@@ -729,7 +730,7 @@ lepton_text_object_copy (const LeptonObject *object)
                                     object->text->string,
                                     object->text->size,
                                     lepton_object_get_visibility (object),
-                                    object->show_name_value);
+                                    lepton_text_object_get_show_name_value (object));
 
   return new_obj;
 }

--- a/liblepton/src/text_object.c
+++ b/liblepton/src/text_object.c
@@ -944,7 +944,9 @@ lepton_text_object_set_string (LeptonObject *obj,
 gboolean
 lepton_text_object_is_visible (const LeptonObject *object)
 {
-  g_return_val_if_fail (object != NULL, FALSE);
+  g_return_val_if_fail (lepton_object_is_text (object), FALSE);
+  g_return_val_if_fail (object->text != NULL, FALSE);
+
   return object->text->visibility == VISIBLE;
 }
 
@@ -956,7 +958,8 @@ lepton_text_object_is_visible (const LeptonObject *object)
 gint
 lepton_text_object_get_visibility (const LeptonObject *object)
 {
-  g_return_val_if_fail (object != NULL, VISIBLE);
+  g_return_val_if_fail (lepton_object_is_text (object), VISIBLE);
+  g_return_val_if_fail (object->text != NULL, VISIBLE);
 
   return object->text->visibility;
 }
@@ -970,6 +973,8 @@ void
 lepton_text_object_set_visibility (LeptonObject *object,
                                    int visibility)
 {
-  g_return_if_fail (object != NULL);
+  g_return_if_fail (lepton_object_is_text (object));
+  g_return_if_fail (object->text != NULL);
+
   object->text->visibility = visibility;
 }

--- a/liblepton/src/text_object.c
+++ b/liblepton/src/text_object.c
@@ -255,7 +255,7 @@ lepton_text_object_get_show_name_value (const LeptonObject *object)
   g_return_val_if_fail (lepton_object_is_text (object), VISIBLE);
   g_return_val_if_fail (object->text != NULL, VISIBLE);
 
-  return object->show_name_value;
+  return object->text->show_name_value;
 }
 
 /*! \brief Set the text alignment
@@ -361,7 +361,7 @@ lepton_text_object_set_show_name_value (LeptonObject *object,
   g_return_if_fail (lepton_object_is_text (object));
   g_return_if_fail (object->text != NULL);
 
-  object->show_name_value = show;
+  object->text->show_name_value = show;
 }
 
 /*! \brief update the visible part of a string

--- a/liblepton/src/text_object.c
+++ b/liblepton/src/text_object.c
@@ -89,13 +89,13 @@ lepton_text_object_calculate_bounds (const LeptonObject *object,
                                      gboolean include_hidden,
                                      LeptonBounds *bounds)
 {
+  g_return_val_if_fail (lepton_object_is_text (object), FALSE);
+  g_return_val_if_fail (object->text != NULL, FALSE);
+
   if (! (lepton_text_object_is_visible (object) || include_hidden))
     return FALSE;
 
   lepton_bounds_init (bounds);
-
-  g_return_val_if_fail (lepton_object_is_text (object), FALSE);
-  g_return_val_if_fail (object->text != NULL, FALSE);
 
   double t, l, r, b;
   gboolean result = eda_renderer_get_text_user_bounds (object,

--- a/liblepton/src/text_object.c
+++ b/liblepton/src/text_object.c
@@ -464,11 +464,11 @@ lepton_text_object_new (gint color,
  *  \return The object list, or NULL on error.
  */
 LeptonObject*
-o_text_read (const char *first_line,
-             TextBuffer *tb,
-             unsigned int release_ver,
-             unsigned int fileformat_ver,
-             GError **err)
+lepton_text_object_read (const char *first_line,
+                         TextBuffer *tb,
+                         unsigned int release_ver,
+                         unsigned int fileformat_ver,
+                         GError **err)
 {
   LeptonObject *new_obj;
   char type;

--- a/liblepton/src/text_object.c
+++ b/liblepton/src/text_object.c
@@ -889,8 +889,8 @@ lepton_text_object_shortest_distance (LeptonObject *object,
  *  \param [in]  new_string            The new value.
  */
 void
-o_text_set_string (LeptonObject *obj,
-                   const gchar *new_string)
+lepton_text_object_set_string (LeptonObject *obj,
+                               const gchar *new_string)
 {
   g_return_if_fail (lepton_object_is_text (obj));
   g_return_if_fail (obj->text != NULL);

--- a/liblepton/src/text_object.c
+++ b/liblepton/src/text_object.c
@@ -649,7 +649,7 @@ lepton_text_object_to_buffer (const LeptonObject *object)
  *  \param o_current The text object to update
  */
 void
-o_text_recreate (LeptonObject *o_current)
+lepton_text_object_recreate (LeptonObject *o_current)
 {
   lepton_object_emit_pre_change_notify (o_current);
   update_disp_string (o_current);
@@ -740,7 +740,7 @@ lepton_text_object_rotate (int world_centerx,
 
   lepton_text_object_translate (object, x-object->text->x, y-object->text->y);
 
-  o_text_recreate (object);
+  lepton_text_object_recreate (object);
 }
 
 
@@ -833,7 +833,7 @@ lepton_text_object_mirror (int world_centerx,
   object->text->x = -x + (world_centerx);
   object->text->y =  y + (world_centery);
 
-  o_text_recreate (object);
+  lepton_text_object_recreate (object);
 }
 
 /*! \brief Calculates the distance between the given point and the closest
@@ -899,5 +899,5 @@ o_text_set_string (LeptonObject *obj,
   g_free (obj->text->string);
   obj->text->string = g_strdup (new_string);
 
-  o_text_recreate (obj);
+  lepton_text_object_recreate (obj);
 }

--- a/liblepton/src/text_object.c
+++ b/liblepton/src/text_object.c
@@ -244,18 +244,18 @@ lepton_text_object_get_y (const LeptonObject *object)
   return object->text->y;
 }
 
-/*! \brief Get the \a show_name_value field of a text object.
+/*! \brief Get the \a show field of a text object.
  *
  *  \param [in] object The text object.
- *  \return The value of the field \a show_name_value.
+ *  \return The value of the field \a show.
  */
 gint
-lepton_text_object_get_show_name_value (const LeptonObject *object)
+lepton_text_object_get_show (const LeptonObject *object)
 {
   g_return_val_if_fail (lepton_object_is_text (object), VISIBLE);
   g_return_val_if_fail (object->text != NULL, VISIBLE);
 
-  return object->text->show_name_value;
+  return object->text->show;
 }
 
 /*! \brief Set the text alignment
@@ -349,19 +349,19 @@ lepton_text_object_set_y (LeptonObject *object,
 }
 
 
-/*! \brief Set \a show_name_value field of a text object.
+/*! \brief Set \a show field of a text object.
  *
  *  \param object The #LeptonObject structure to be modified.
- *  \param show The new value of the field \a show_name_value.
+ *  \param show The new value of the field \a show.
  */
 void
-lepton_text_object_set_show_name_value (LeptonObject *object,
-                                        gint show)
+lepton_text_object_set_show (LeptonObject *object,
+                             gint show)
 {
   g_return_if_fail (lepton_object_is_text (object));
   g_return_if_fail (object->text != NULL);
 
-  object->text->show_name_value = show;
+  object->text->show = show;
 }
 
 /*! \brief update the visible part of a string
@@ -369,7 +369,7 @@ lepton_text_object_set_show_name_value (LeptonObject *object,
  *  If a string is an attribute, then it is possible to hide
  *  the name or the value part of the attribute string.
  *  This functions updates the text->disp_string according
- *  to the object->show_name_value settings
+ *  to the object->text->show settings
  *
  *  \param [in] object  The LeptonObject to update
  */
@@ -383,7 +383,7 @@ update_disp_string (LeptonObject *object)
   g_free (text->disp_string);
 
   if (o_attrib_get_name_value (object, &name, &value)) {
-    switch (lepton_text_object_get_show_name_value (object))
+    switch (lepton_text_object_get_show (object))
     {
       case (SHOW_NAME_VALUE):
         text->disp_string = g_strdup (text->string);
@@ -474,7 +474,7 @@ lepton_text_object_new (gint color,
 
   lepton_object_set_color (new_node, color);
   lepton_object_set_visibility (new_node, visibility);
-  lepton_text_object_set_show_name_value (new_node, show_name_value);
+  lepton_text_object_set_show (new_node, show_name_value);
 
   update_disp_string (new_node);
 
@@ -665,7 +665,7 @@ lepton_text_object_to_buffer (const LeptonObject *object)
                           lepton_object_get_color (object),
                           lepton_text_object_get_size (object),
                           lepton_object_get_visibility (object),
-                          lepton_text_object_get_show_name_value (object),
+                          lepton_text_object_get_show (object),
                           lepton_text_object_get_angle (object),
                           lepton_text_object_get_alignment (object),
                           o_text_num_lines (string),
@@ -730,7 +730,7 @@ lepton_text_object_copy (const LeptonObject *object)
                                     object->text->string,
                                     object->text->size,
                                     lepton_object_get_visibility (object),
-                                    lepton_text_object_get_show_name_value (object));
+                                    lepton_text_object_get_show (object));
 
   return new_obj;
 }

--- a/liblepton/src/text_object.c
+++ b/liblepton/src/text_object.c
@@ -244,6 +244,20 @@ lepton_text_object_get_y (const LeptonObject *object)
   return object->text->y;
 }
 
+/*! \brief Get the \a show_name_value field of a text object.
+ *
+ *  \param [in] object The text object.
+ *  \return The value of the field \a show_name_value.
+ */
+gint
+lepton_text_object_get_show_name_value (const LeptonObject *object)
+{
+  g_return_val_if_fail (lepton_object_is_text (object), VISIBLE);
+  g_return_val_if_fail (object->text != NULL, VISIBLE);
+
+  return object->show_name_value;
+}
+
 /*! \brief Set the text alignment
  *
  *  In case of an invalid text alignment, the property remains unchanged.
@@ -332,6 +346,22 @@ lepton_text_object_set_y (LeptonObject *object,
   g_return_if_fail (object->text != NULL);
 
   object->text->y = y;
+}
+
+
+/*! \brief Set \a show_name_value field of a text object.
+ *
+ *  \param object The #LeptonObject structure to be modified.
+ *  \param show The new value of the field \a show_name_value.
+ */
+void
+lepton_text_object_set_show_name_value (LeptonObject *object,
+                                        gint show)
+{
+  g_return_if_fail (lepton_object_is_text (object));
+  g_return_if_fail (object->text != NULL);
+
+  object->show_name_value = show;
 }
 
 /*! \brief update the visible part of a string

--- a/liblepton/src/text_object.c
+++ b/liblepton/src/text_object.c
@@ -89,7 +89,7 @@ lepton_text_object_calculate_bounds (const LeptonObject *object,
                                      gboolean include_hidden,
                                      LeptonBounds *bounds)
 {
-  if (! (lepton_object_is_visible (object) || include_hidden))
+  if (! (lepton_text_object_is_visible (object) || include_hidden))
     return FALSE;
 
   lepton_bounds_init (bounds);
@@ -473,7 +473,7 @@ lepton_text_object_new (gint color,
   new_node->text = text;
 
   lepton_object_set_color (new_node, color);
-  lepton_object_set_visibility (new_node, visibility);
+  lepton_text_object_set_visibility (new_node, visibility);
   lepton_text_object_set_show (new_node, show_name_value);
 
   update_disp_string (new_node);
@@ -664,7 +664,7 @@ lepton_text_object_to_buffer (const LeptonObject *object)
                           lepton_text_object_get_y (object),
                           lepton_object_get_color (object),
                           lepton_text_object_get_size (object),
-                          lepton_object_get_visibility (object),
+                          lepton_text_object_get_visibility (object),
                           lepton_text_object_get_show (object),
                           lepton_text_object_get_angle (object),
                           lepton_text_object_get_alignment (object),
@@ -729,7 +729,7 @@ lepton_text_object_copy (const LeptonObject *object)
                                     object->text->angle,
                                     object->text->string,
                                     object->text->size,
-                                    lepton_object_get_visibility (object),
+                                    lepton_text_object_get_visibility (object),
                                     lepton_text_object_get_show (object));
 
   return new_obj;
@@ -931,4 +931,45 @@ lepton_text_object_set_string (LeptonObject *obj,
   obj->text->string = g_strdup (new_string);
 
   lepton_text_object_recreate (obj);
+}
+
+
+/*! \brief Query visibility of a text object.
+ *  \par Function Description
+ *  Attribute getter for the visible field within the object.
+ *
+ *  \param object The text #LeptonObject structure to be queried.
+ *  \return TRUE when VISIBLE, FALSE otherwise.
+ */
+gboolean
+lepton_text_object_is_visible (const LeptonObject *object)
+{
+  g_return_val_if_fail (object != NULL, FALSE);
+  return object->text->visibility == VISIBLE;
+}
+
+/*! \brief Get the visibility of a text object.
+ *
+ *  \param [in] object The text #LeptonObject structure to be queried.
+ *  \return VISIBLE or INVISIBLE
+ */
+gint
+lepton_text_object_get_visibility (const LeptonObject *object)
+{
+  g_return_val_if_fail (object != NULL, VISIBLE);
+
+  return object->text->visibility;
+}
+
+/*! \brief Set visibility of a text object.
+ *
+ *  \param object     The text #LeptonObject structure to be modified.
+ *  \param visibility If the object should be visible.
+ */
+void
+lepton_text_object_set_visibility (LeptonObject *object,
+                                   int visibility)
+{
+  g_return_if_fail (object != NULL);
+  object->text->visibility = visibility;
 }

--- a/liblepton/src/text_object.c
+++ b/liblepton/src/text_object.c
@@ -682,6 +682,9 @@ lepton_text_object_to_buffer (const LeptonObject *object)
 void
 lepton_text_object_recreate (LeptonObject *o_current)
 {
+  g_return_if_fail (lepton_object_is_text (o_current));
+  g_return_if_fail (o_current->text != NULL);
+
   lepton_object_emit_pre_change_notify (o_current);
   update_disp_string (o_current);
   lepton_object_emit_change_notify (o_current);
@@ -893,6 +896,7 @@ lepton_text_object_shortest_distance (LeptonObject *object,
   int left, top, right, bottom;
   double dx, dy;
 
+  g_return_val_if_fail (lepton_object_is_text (object), G_MAXDOUBLE);
   g_return_val_if_fail (object->text != NULL, G_MAXDOUBLE);
 
   if (!lepton_object_calculate_visible_bounds (object,

--- a/liblepton/src/text_object.c
+++ b/liblepton/src/text_object.c
@@ -474,7 +474,7 @@ lepton_text_object_new (gint color,
 
   lepton_object_set_color (new_node, color);
   lepton_object_set_visibility (new_node, visibility);
-  new_node->show_name_value = show_name_value;
+  lepton_text_object_set_show_name_value (new_node, show_name_value);
 
   update_disp_string (new_node);
 

--- a/liblepton/tests/test_text_object.c
+++ b/liblepton/tests/test_text_object.c
@@ -189,11 +189,11 @@ check_serialization ()
                                        "test_text_object.c::check_serialization()");
     const gchar *line = s_textbuffer_next_line (tb);
 
-    LeptonObject *object1 = o_text_read (line,
-                                       tb,
-                                       version,
-                                       FILEFORMAT_VERSION,
-                                       NULL);
+    LeptonObject *object1 = lepton_text_object_read (line,
+                                                     tb,
+                                                     version,
+                                                     FILEFORMAT_VERSION,
+                                                     NULL);
 
     g_assert (object1 != NULL);
     s_textbuffer_free (tb);

--- a/liblepton/tests/test_text_object.c
+++ b/liblepton/tests/test_text_object.c
@@ -51,7 +51,7 @@ check_construction ()
     g_assert_cmpint (angle, ==, lepton_text_object_get_angle (object0));
     g_assert_cmpint (size, ==, lepton_text_object_get_size (object0));
     g_assert_cmpint (color, ==, lepton_object_get_color (object0));
-    g_assert_cmpint (visible, ==, lepton_object_get_visibility (object0));
+    g_assert_cmpint (visible, ==, lepton_text_object_get_visibility (object0));
     g_assert_cmpstr (string, ==, lepton_text_object_get_string (object0));
 
     LeptonObject *object1 = lepton_text_object_copy (object0);
@@ -68,7 +68,7 @@ check_construction ()
     g_assert_cmpint (angle, ==, lepton_text_object_get_angle (object1));
     g_assert_cmpint (size, ==, lepton_text_object_get_size (object1));
     g_assert_cmpint (color, ==, lepton_object_get_color (object1));
-    g_assert_cmpint (visible, ==, lepton_object_get_visibility (object1));
+    g_assert_cmpint (visible, ==, lepton_text_object_get_visibility (object1));
     g_assert_cmpstr (string, ==, lepton_text_object_get_string (object1));
 
     lepton_object_delete (object1);
@@ -123,7 +123,7 @@ check_accessors ()
     lepton_text_object_set_angle (object0, angle);
     lepton_text_object_set_size (object0, size);
     lepton_object_set_color (object0, color);
-    lepton_object_set_visibility (object0, visible);
+    lepton_text_object_set_visibility (object0, visible);
     lepton_text_object_set_string (object0, string);
 
     g_assert_cmpint (x, ==, lepton_text_object_get_x (object0));
@@ -132,7 +132,7 @@ check_accessors ()
     g_assert_cmpint (angle, ==, lepton_text_object_get_angle (object0));
     g_assert_cmpint (size, ==, lepton_text_object_get_size (object0));
     g_assert_cmpint (color, ==, lepton_object_get_color (object0));
-    g_assert_cmpint (visible, ==, lepton_object_get_visibility (object0));
+    g_assert_cmpint (visible, ==, lepton_text_object_get_visibility (object0));
     g_assert_cmpstr (string, ==, lepton_text_object_get_string (object0));
 
     gint temp_x;
@@ -204,7 +204,7 @@ check_serialization ()
     g_assert_cmpint (angle, ==, lepton_text_object_get_angle (object1));
     g_assert_cmpint (size, ==, lepton_text_object_get_size (object1));
     g_assert_cmpint (color, ==, lepton_object_get_color (object1));
-    g_assert_cmpint (visible, ==, lepton_object_get_visibility (object1));
+    g_assert_cmpint (visible, ==, lepton_text_object_get_visibility (object1));
     g_assert_cmpstr (string, ==, lepton_text_object_get_string (object1));
 
     gchar *buffer1 = lepton_text_object_to_buffer (object1);

--- a/liblepton/tests/test_text_object.c
+++ b/liblepton/tests/test_text_object.c
@@ -124,7 +124,7 @@ check_accessors ()
     lepton_text_object_set_size (object0, size);
     lepton_object_set_color (object0, color);
     lepton_object_set_visibility (object0, visible);
-    o_text_set_string (object0, string);
+    lepton_text_object_set_string (object0, string);
 
     g_assert_cmpint (x, ==, lepton_text_object_get_x (object0));
     g_assert_cmpint (y, ==, lepton_text_object_get_y (object0));

--- a/libleptonattrib/src/s_object.c
+++ b/libleptonattrib/src/s_object.c
@@ -201,7 +201,7 @@ s_object_replace_attrib_in_object(LeptonObject *o_current,
         if (visibility != LEAVE_VISIBILITY_ALONE)
           lepton_object_set_visibility (a_current, visibility);
         if (show_name_value != LEAVE_NAME_VALUE_ALONE)
-          lepton_text_object_set_show_name_value (a_current, show_name_value);
+          lepton_text_object_set_show (a_current, show_name_value);
         g_free(new_attrib_text);
         g_free(old_attrib_text);
         g_free(old_attrib_name);

--- a/libleptonattrib/src/s_object.c
+++ b/libleptonattrib/src/s_object.c
@@ -197,7 +197,7 @@ s_object_replace_attrib_in_object(LeptonObject *o_current,
       if (strcmp(old_attrib_name, new_attrib_name) == 0) {
         /* create attrib=value text string */
         new_attrib_text = g_strconcat(new_attrib_name, "=", new_attrib_value, NULL);
-        o_text_set_string (a_current, new_attrib_text);
+        lepton_text_object_set_string (a_current, new_attrib_text);
         if (visibility != LEAVE_VISIBILITY_ALONE)
           lepton_object_set_visibility (a_current, visibility);
         if (show_name_value != LEAVE_NAME_VALUE_ALONE)

--- a/libleptonattrib/src/s_object.c
+++ b/libleptonattrib/src/s_object.c
@@ -201,7 +201,7 @@ s_object_replace_attrib_in_object(LeptonObject *o_current,
         if (visibility != LEAVE_VISIBILITY_ALONE)
           lepton_object_set_visibility (a_current, visibility);
         if (show_name_value != LEAVE_NAME_VALUE_ALONE)
-          a_current->show_name_value = show_name_value;
+          lepton_text_object_set_show_name_value (a_current, show_name_value);
         g_free(new_attrib_text);
         g_free(old_attrib_text);
         g_free(old_attrib_name);

--- a/libleptonattrib/src/s_object.c
+++ b/libleptonattrib/src/s_object.c
@@ -199,7 +199,7 @@ s_object_replace_attrib_in_object(LeptonObject *o_current,
         new_attrib_text = g_strconcat(new_attrib_name, "=", new_attrib_value, NULL);
         lepton_text_object_set_string (a_current, new_attrib_text);
         if (visibility != LEAVE_VISIBILITY_ALONE)
-          lepton_object_set_visibility (a_current, visibility);
+          lepton_text_object_set_visibility (a_current, visibility);
         if (show_name_value != LEAVE_NAME_VALUE_ALONE)
           lepton_text_object_set_show (a_current, show_name_value);
         g_free(new_attrib_text);

--- a/libleptonattrib/src/s_table.c
+++ b/libleptonattrib/src/s_table.c
@@ -415,7 +415,7 @@ void s_table_add_toplevel_comp_items_to_comp_table (const GList *obj_list) {
             attrib_value = s_misc_remaining_string(attrib_text, '=', 1);
             old_visibility = lepton_object_is_visible (a_current)
               ? VISIBLE : INVISIBLE;
-            old_show_name_value = a_current->show_name_value;
+            old_show_name_value = lepton_text_object_get_show_name_value (a_current);
 
             /* Don't include "refdes" or "slot" because they form the row name. */
             /* Also don't include "net" per bug found by Steve W.  4.3.2007 -- SDB */

--- a/libleptonattrib/src/s_table.c
+++ b/libleptonattrib/src/s_table.c
@@ -415,7 +415,7 @@ void s_table_add_toplevel_comp_items_to_comp_table (const GList *obj_list) {
             attrib_value = s_misc_remaining_string(attrib_text, '=', 1);
             old_visibility = lepton_object_is_visible (a_current)
               ? VISIBLE : INVISIBLE;
-            old_show_name_value = lepton_text_object_get_show_name_value (a_current);
+            old_show_name_value = lepton_text_object_get_show (a_current);
 
             /* Don't include "refdes" or "slot" because they form the row name. */
             /* Also don't include "net" per bug found by Steve W.  4.3.2007 -- SDB */

--- a/libleptonattrib/src/s_table.c
+++ b/libleptonattrib/src/s_table.c
@@ -413,7 +413,7 @@ void s_table_add_toplevel_comp_items_to_comp_table (const GList *obj_list) {
             attrib_text = g_strdup (lepton_text_object_get_string (a_current));
             attrib_name = u_basic_breakup_string(attrib_text, '=', 0);
             attrib_value = s_misc_remaining_string(attrib_text, '=', 1);
-            old_visibility = lepton_object_is_visible (a_current)
+            old_visibility = lepton_text_object_is_visible (a_current)
               ? VISIBLE : INVISIBLE;
             old_show_name_value = lepton_text_object_get_show (a_current);
 

--- a/libleptongui/src/gschem_find_text_state.c
+++ b/libleptongui/src/gschem_find_text_state.c
@@ -375,7 +375,7 @@ find_objects_using_pattern (GSList *pages,
         continue;
       }
 
-      if (!(lepton_object_is_visible (object) || include_hidden)) {
+      if (!(lepton_text_object_is_visible (object) || include_hidden)) {
         continue;
       }
 
@@ -455,7 +455,7 @@ find_objects_using_regex (GSList *pages,
         continue;
       }
 
-      if (!(lepton_object_is_visible (object) || include_hidden)) {
+      if (!(lepton_text_object_is_visible (object) || include_hidden)) {
         continue;
       }
 
@@ -524,7 +524,7 @@ find_objects_using_substring (GSList *pages,
         continue;
       }
 
-      if (!(lepton_object_is_visible (object) || include_hidden)) {
+      if (!(lepton_text_object_is_visible (object) || include_hidden)) {
         continue;
       }
 

--- a/libleptongui/src/gschem_selection_adapter.c
+++ b/libleptongui/src/gschem_selection_adapter.c
@@ -1771,7 +1771,7 @@ gschem_selection_adapter_set_text_alignment (GschemSelectionAdapter *adapter, in
     if (lepton_object_is_text (object))
     {
       lepton_text_object_set_alignment (object, alignment);
-      o_text_recreate (object);
+      lepton_text_object_recreate (object);
     }
 
     iter = g_list_next (iter);
@@ -1840,7 +1840,7 @@ gschem_selection_adapter_set_text_rotation (GschemSelectionAdapter *adapter, int
     if (lepton_object_is_text (object))
     {
       lepton_text_object_set_angle (object, angle);
-      o_text_recreate (object);
+      lepton_text_object_recreate (object);
     }
 
     iter = g_list_next (iter);
@@ -1875,7 +1875,7 @@ gschem_selection_adapter_set_text_size (GschemSelectionAdapter *adapter, int siz
     if (lepton_object_is_text (object))
     {
       lepton_text_object_set_size (object, size);
-      o_text_recreate (object);
+      lepton_text_object_recreate (object);
     }
 
     iter = g_list_next (iter);
@@ -1918,7 +1918,7 @@ gschem_selection_adapter_set_text_string (GschemSelectionAdapter *adapter, const
         o_slot_end (w_current, object->attached_to, string);
       }
 
-      o_text_recreate (object);
+      lepton_text_object_recreate (object);
     }
 
     iter = g_list_next (iter);

--- a/libleptongui/src/gschem_selection_adapter.c
+++ b/libleptongui/src/gschem_selection_adapter.c
@@ -1911,7 +1911,7 @@ gschem_selection_adapter_set_text_string (GschemSelectionAdapter *adapter, const
 
     if (lepton_object_is_text (object))
     {
-      o_text_set_string (object, string);
+      lepton_text_object_set_string (object, string);
 
       /* handle slot= attribute, it's a special case */
       if (object->attached_to != NULL && g_ascii_strncasecmp (string, "slot=", 5) == 0) {

--- a/libleptongui/src/o_attrib.c
+++ b/libleptongui/src/o_attrib.c
@@ -112,7 +112,7 @@ o_attrib_deselect_invisible (GschemToplevel *w_current,
        a_iter = g_list_next (a_iter)) {
     a_current = (LeptonObject*) a_iter->data;
 
-    if (a_current->selected && !lepton_object_is_visible (a_current)) {
+    if (a_current->selected && !lepton_text_object_is_visible (a_current)) {
       o_selection_remove (selection, a_current);
     }
   }
@@ -149,7 +149,7 @@ o_attrib_select_invisible (GschemToplevel *w_current,
        a_iter = g_list_next (a_iter)) {
     a_current = (LeptonObject*) a_iter->data;
 
-    if (!a_current->selected && !lepton_object_is_visible (a_current)) {
+    if (!a_current->selected && !lepton_text_object_is_visible (a_current)) {
       o_selection_add (selection, a_current);
     }
   }
@@ -173,13 +173,13 @@ void o_attrib_toggle_visibility(GschemToplevel *w_current, LeptonObject *object)
   gboolean show_hidden_text =
     gschem_toplevel_get_show_hidden_text (w_current);
 
-  if (lepton_object_is_visible (object)) {
+  if (lepton_text_object_is_visible (object)) {
     /* only erase if we are not showing hidden text */
     if (!show_hidden_text) {
       o_invalidate (w_current, object);
     }
 
-    lepton_object_set_visibility (object, INVISIBLE);
+    lepton_text_object_set_visibility (object, INVISIBLE);
 
     if (show_hidden_text) {
       /* draw text so that little I is drawn */
@@ -193,7 +193,7 @@ void o_attrib_toggle_visibility(GschemToplevel *w_current, LeptonObject *object)
       o_invalidate (w_current, object);
     }
 
-    lepton_object_set_visibility (object, VISIBLE);
+    lepton_text_object_set_visibility (object, VISIBLE);
     lepton_text_object_recreate (object);
   }
 

--- a/libleptongui/src/o_attrib.c
+++ b/libleptongui/src/o_attrib.c
@@ -194,7 +194,7 @@ void o_attrib_toggle_visibility(GschemToplevel *w_current, LeptonObject *object)
     }
 
     lepton_object_set_visibility (object, VISIBLE);
-    o_text_recreate (object);
+    lepton_text_object_recreate (object);
   }
 
   gschem_toplevel_page_content_changed (w_current, toplevel->page_current);
@@ -219,7 +219,7 @@ void o_attrib_toggle_show_name_value(GschemToplevel *w_current,
 
   o_invalidate (w_current, object);
   object->show_name_value = show_name_value;
-  o_text_recreate (object);
+  lepton_text_object_recreate (object);
 
   gschem_toplevel_page_content_changed (w_current, toplevel->page_current);
 }

--- a/libleptongui/src/o_attrib.c
+++ b/libleptongui/src/o_attrib.c
@@ -218,7 +218,7 @@ void o_attrib_toggle_show_name_value(GschemToplevel *w_current,
   g_return_if_fail (lepton_object_is_text (object));
 
   o_invalidate (w_current, object);
-  lepton_text_object_set_show_name_value (object, show_name_value);
+  lepton_text_object_set_show (object, show_name_value);
   lepton_text_object_recreate (object);
 
   gschem_toplevel_page_content_changed (w_current, toplevel->page_current);

--- a/libleptongui/src/o_attrib.c
+++ b/libleptongui/src/o_attrib.c
@@ -218,7 +218,7 @@ void o_attrib_toggle_show_name_value(GschemToplevel *w_current,
   g_return_if_fail (lepton_object_is_text (object));
 
   o_invalidate (w_current, object);
-  object->show_name_value = show_name_value;
+  lepton_text_object_set_show_name_value (object, show_name_value);
   lepton_text_object_recreate (object);
 
   gschem_toplevel_page_content_changed (w_current, toplevel->page_current);

--- a/libleptongui/src/o_find.c
+++ b/libleptongui/src/o_find.c
@@ -56,7 +56,7 @@ is_object_hit (GschemToplevel *w_current, LeptonObject *object,
 
   /* We can't hit invisible (text) objects unless show_hidden_text is active.
    */
-  if (!lepton_object_is_visible (object) &&
+  if (!lepton_text_object_is_visible (object) &&
       !show_hidden_text)
     return FALSE;
 

--- a/libleptongui/src/o_find.c
+++ b/libleptongui/src/o_find.c
@@ -56,7 +56,8 @@ is_object_hit (GschemToplevel *w_current, LeptonObject *object,
 
   /* We can't hit invisible (text) objects unless show_hidden_text is active.
    */
-  if (!lepton_text_object_is_visible (object) &&
+  if (lepton_object_is_text (object) &&
+      !lepton_text_object_is_visible (object) &&
       !show_hidden_text)
     return FALSE;
 

--- a/libleptongui/src/o_misc.c
+++ b/libleptongui/src/o_misc.c
@@ -322,7 +322,7 @@ void o_edit_show_hidden_lowlevel (GschemToplevel *w_current,
   while (iter != NULL) {
     o_current = (LeptonObject *)iter->data;
     if (lepton_object_is_text (o_current) &&
-        !lepton_object_is_visible (o_current))
+        !lepton_text_object_is_visible (o_current))
     {
 
       /* don't toggle the visibility flag */
@@ -386,8 +386,8 @@ void o_edit_hide_specific_text (GschemToplevel *w_current,
     {
       const gchar *str = lepton_text_object_get_string (o_current);
       if (!strncmp (stext, str, strlen (stext))) {
-        if (lepton_object_is_visible (o_current)) {
-          lepton_object_set_visibility (o_current, INVISIBLE);
+        if (lepton_text_object_is_visible (o_current)) {
+          lepton_text_object_set_visibility (o_current, INVISIBLE);
           lepton_text_object_recreate (o_current);
 
           gschem_toplevel_page_content_changed (w_current, toplevel->page_current);
@@ -421,8 +421,8 @@ void o_edit_show_specific_text (GschemToplevel *w_current,
     {
       const gchar *str = lepton_text_object_get_string (o_current);
       if (!strncmp (stext, str, strlen (stext))) {
-        if (!lepton_object_is_visible (o_current)) {
-          lepton_object_set_visibility (o_current, VISIBLE);
+        if (!lepton_text_object_is_visible (o_current)) {
+          lepton_text_object_set_visibility (o_current, VISIBLE);
           lepton_text_object_recreate (o_current);
 
           gschem_toplevel_page_content_changed (w_current, toplevel->page_current);

--- a/libleptongui/src/o_misc.c
+++ b/libleptongui/src/o_misc.c
@@ -326,7 +326,7 @@ void o_edit_show_hidden_lowlevel (GschemToplevel *w_current,
     {
 
       /* don't toggle the visibility flag */
-      o_text_recreate (o_current);
+      lepton_text_object_recreate (o_current);
     }
 
     if (lepton_object_is_component (o_current))
@@ -388,7 +388,7 @@ void o_edit_hide_specific_text (GschemToplevel *w_current,
       if (!strncmp (stext, str, strlen (stext))) {
         if (lepton_object_is_visible (o_current)) {
           lepton_object_set_visibility (o_current, INVISIBLE);
-          o_text_recreate (o_current);
+          lepton_text_object_recreate (o_current);
 
           gschem_toplevel_page_content_changed (w_current, toplevel->page_current);
         }
@@ -423,7 +423,7 @@ void o_edit_show_specific_text (GschemToplevel *w_current,
       if (!strncmp (stext, str, strlen (stext))) {
         if (!lepton_object_is_visible (o_current)) {
           lepton_object_set_visibility (o_current, VISIBLE);
-          o_text_recreate (o_current);
+          lepton_text_object_recreate (o_current);
 
           gschem_toplevel_page_content_changed (w_current, toplevel->page_current);
         }

--- a/libleptongui/src/o_select.c
+++ b/libleptongui/src/o_select.c
@@ -401,7 +401,10 @@ void o_select_box_search(GschemToplevel *w_current)
   while (iter != NULL) {
     o_current = (LeptonObject*) iter->data;
     /* only select visible objects */
-    if (lepton_text_object_is_visible (o_current) || show_hidden_text) {
+    if (!lepton_object_is_text (o_current) ||
+        lepton_text_object_is_visible (o_current) ||
+        show_hidden_text)
+    {
       int cleft, ctop, cright, cbottom;
 
       if (lepton_object_calculate_visible_bounds (o_current,

--- a/libleptongui/src/o_select.c
+++ b/libleptongui/src/o_select.c
@@ -614,8 +614,10 @@ o_select_visible_unlocked (GschemToplevel *w_current)
        iter = g_list_next (iter)) {
     LeptonObject *obj = (LeptonObject *) iter->data;
 
-    /* Skip invisible objects. */
-    if (!lepton_text_object_is_visible (obj) && !show_hidden_text)
+    /* Skip invisible text objects. */
+    if (lepton_object_is_text (obj) &&
+        !lepton_text_object_is_visible (obj) &&
+        !show_hidden_text)
       continue;
 
     /* Skip locked objects. */

--- a/libleptongui/src/o_select.c
+++ b/libleptongui/src/o_select.c
@@ -401,7 +401,7 @@ void o_select_box_search(GschemToplevel *w_current)
   while (iter != NULL) {
     o_current = (LeptonObject*) iter->data;
     /* only select visible objects */
-    if (lepton_object_is_visible (o_current) || show_hidden_text) {
+    if (lepton_text_object_is_visible (o_current) || show_hidden_text) {
       int cleft, ctop, cright, cbottom;
 
       if (lepton_object_calculate_visible_bounds (o_current,
@@ -612,7 +612,7 @@ o_select_visible_unlocked (GschemToplevel *w_current)
     LeptonObject *obj = (LeptonObject *) iter->data;
 
     /* Skip invisible objects. */
-    if (!lepton_object_is_visible (obj) && !show_hidden_text)
+    if (!lepton_text_object_is_visible (obj) && !show_hidden_text)
       continue;
 
     /* Skip locked objects. */

--- a/libleptongui/src/o_slot.c
+++ b/libleptongui/src/o_slot.c
@@ -113,7 +113,7 @@ void o_slot_end(GschemToplevel *w_current, LeptonObject *object, const char *str
   g_free (slot_value);
 
   if (o_slot != NULL && !o_attrib_is_inherited (o_slot)) {
-    o_text_set_string (o_slot, string);
+    lepton_text_object_set_string (o_slot, string);
   } else {
     /* here you need to do the add the slot
        attribute since it doesn't exist */

--- a/libleptongui/src/o_text.c
+++ b/libleptongui/src/o_text.c
@@ -109,7 +109,7 @@ void o_text_change(GschemToplevel *w_current, LeptonObject *object, char *string
 
   lepton_text_object_set_string (object, string);
 
-  lepton_object_set_visibility (object, visibility);
+  lepton_text_object_set_visibility (object, visibility);
   lepton_text_object_set_show (object, show);
   lepton_text_object_recreate (object);
 

--- a/libleptongui/src/o_text.c
+++ b/libleptongui/src/o_text.c
@@ -110,7 +110,7 @@ void o_text_change(GschemToplevel *w_current, LeptonObject *object, char *string
   lepton_text_object_set_string (object, string);
 
   lepton_object_set_visibility (object, visibility);
-  lepton_text_object_set_show_name_value (object, show);
+  lepton_text_object_set_show (object, show);
   lepton_text_object_recreate (object);
 
   /* handle slot= attribute, it's a special case */

--- a/libleptongui/src/o_text.c
+++ b/libleptongui/src/o_text.c
@@ -111,7 +111,7 @@ void o_text_change(GschemToplevel *w_current, LeptonObject *object, char *string
 
   lepton_object_set_visibility (object, visibility);
   object->show_name_value = show;
-  o_text_recreate (object);
+  lepton_text_object_recreate (object);
 
   /* handle slot= attribute, it's a special case */
   if (object->attached_to != NULL &&

--- a/libleptongui/src/o_text.c
+++ b/libleptongui/src/o_text.c
@@ -110,7 +110,7 @@ void o_text_change(GschemToplevel *w_current, LeptonObject *object, char *string
   lepton_text_object_set_string (object, string);
 
   lepton_object_set_visibility (object, visibility);
-  object->show_name_value = show;
+  lepton_text_object_set_show_name_value (object, show);
   lepton_text_object_recreate (object);
 
   /* handle slot= attribute, it's a special case */

--- a/libleptongui/src/o_text.c
+++ b/libleptongui/src/o_text.c
@@ -107,7 +107,7 @@ void o_text_change(GschemToplevel *w_current, LeptonObject *object, char *string
     return;
   }
 
-  o_text_set_string (object, string);
+  lepton_text_object_set_string (object, string);
 
   lepton_object_set_visibility (object, visibility);
   object->show_name_value = show;

--- a/libleptongui/src/x_attribedit.c
+++ b/libleptongui/src/x_attribedit.c
@@ -518,11 +518,16 @@ void attrib_edit_dialog (GschemToplevel *w_current, LeptonObject *attr_obj, int 
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(visbutton), FALSE);
     }
 
-    if (attrib->show_name_value == SHOW_VALUE) {
+    if (lepton_text_object_get_show_name_value (attrib) == SHOW_VALUE)
+    {
       gtk_combo_box_set_active (GTK_COMBO_BOX (show_options), 0);
-    } else if (attrib->show_name_value == SHOW_NAME) {
+    }
+    else if (lepton_text_object_get_show_name_value (attrib) == SHOW_NAME)
+    {
       gtk_combo_box_set_active (GTK_COMBO_BOX (show_options), 1);
-    } else {
+    }
+    else
+    {
       gtk_combo_box_set_active (GTK_COMBO_BOX (show_options), 2);
     }
   } else {

--- a/libleptongui/src/x_attribedit.c
+++ b/libleptongui/src/x_attribedit.c
@@ -222,7 +222,7 @@ void attrib_edit_dialog_ok(GtkWidget * w, GschemToplevel *w_current)
         o_invalidate (w_current, new_object);
         new_object->text->x = wx;
         new_object->text->y = wy;
-        o_text_recreate (new_object);
+        lepton_text_object_recreate (new_object);
     gschem_toplevel_page_content_changed (w_current, toplevel->page_current);
         o_undo_savestate_old(w_current, UNDO_ALL);
       }

--- a/libleptongui/src/x_attribedit.c
+++ b/libleptongui/src/x_attribedit.c
@@ -518,11 +518,11 @@ void attrib_edit_dialog (GschemToplevel *w_current, LeptonObject *attr_obj, int 
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(visbutton), FALSE);
     }
 
-    if (lepton_text_object_get_show_name_value (attrib) == SHOW_VALUE)
+    if (lepton_text_object_get_show (attrib) == SHOW_VALUE)
     {
       gtk_combo_box_set_active (GTK_COMBO_BOX (show_options), 0);
     }
-    else if (lepton_text_object_get_show_name_value (attrib) == SHOW_NAME)
+    else if (lepton_text_object_get_show (attrib) == SHOW_NAME)
     {
       gtk_combo_box_set_active (GTK_COMBO_BOX (show_options), 1);
     }

--- a/libleptongui/src/x_attribedit.c
+++ b/libleptongui/src/x_attribedit.c
@@ -512,7 +512,7 @@ void attrib_edit_dialog (GschemToplevel *w_current, LeptonObject *attr_obj, int 
   if (attr_obj) {
     o_attrib_get_name_value (attr_obj, &name, &val);
     attrib = attr_obj;
-    if (lepton_object_is_visible (attrib)) {
+    if (lepton_text_object_is_visible (attrib)) {
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(visbutton), TRUE);
     } else {
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(visbutton), FALSE);

--- a/libleptongui/src/x_autonumber.c
+++ b/libleptongui/src/x_autonumber.c
@@ -571,7 +571,7 @@ void autonumber_remove_number(AUTONUMBER_TEXT * autotext, LeptonObject *o_curren
 
   /* replace old text */
   str = g_strdup_printf("%s?", autotext->current_searchtext);
-  o_text_set_string (o_current, str);
+  lepton_text_object_set_string (o_current, str);
   g_free (str);
 
   /* remove the slot attribute if slotting is active */
@@ -613,7 +613,7 @@ void autonumber_apply_new_text(AUTONUMBER_TEXT * autotext, LeptonObject *o_curre
 
   /* replace old text */
   str = g_strdup_printf("%s%d", autotext->current_searchtext, number);
-  o_text_set_string (o_current, str);
+  lepton_text_object_set_string (o_current, str);
   g_free (str);
 
   gschem_toplevel_page_content_changed (autotext->w_current,

--- a/libleptongui/src/x_multiattrib.c
+++ b/libleptongui/src/x_multiattrib.c
@@ -641,7 +641,7 @@ multiattrib_action_duplicate_attributes (Multiattrib *multiattrib,
     o_attrib_add_attrib (w_current,
                          lepton_text_object_get_string (o_attrib),
                          lepton_object_is_visible (o_attrib),
-                         o_attrib->show_name_value,
+                         lepton_text_object_get_show_name_value (o_attrib),
                          o_attrib->attached_to);
   }
 
@@ -673,7 +673,7 @@ multiattrib_action_promote_attributes (Multiattrib *multiattrib,
       o_attrib_add_attrib (w_current,
                            lepton_text_object_get_string (o_attrib),
                            VISIBLE,
-                           o_attrib->show_name_value,
+                           lepton_text_object_get_show_name_value (o_attrib),
                            o_attrib->parent);
     } else {
         /* make a copy of the attribute object */
@@ -754,7 +754,7 @@ multiattrib_action_copy_attribute_to_all (Multiattrib *multiattrib,
       o_attrib_add_attrib (w_current,
                            lepton_text_object_get_string (attrib_to_copy),
                            visibility,
-                           attrib_to_copy->show_name_value,
+                           lepton_text_object_get_show_name_value (attrib_to_copy),
                            object);
     }
   }
@@ -1007,8 +1007,11 @@ multiattrib_callback_edited_name (GtkCellRendererText *cellrenderertext,
         ? VISIBLE : INVISIBLE;
 
     /* actually modifies the attribute */
-    o_text_change (w_current, o_attrib,
-                   newtext, visibility, o_attrib->show_name_value);
+    o_text_change (w_current,
+                   o_attrib,
+                   newtext,
+                   visibility,
+                   lepton_text_object_get_show_name_value (o_attrib));
   }
 
   g_object_unref (attr_list);
@@ -1094,8 +1097,11 @@ multiattrib_callback_edited_value (GtkCellRendererText *cell_renderer,
         ? VISIBLE : INVISIBLE;
 
     /* actually modifies the attribute */
-    o_text_change (w_current, o_attrib,
-                   newtext, visibility, o_attrib->show_name_value);
+    o_text_change (w_current,
+                   o_attrib,
+                   newtext,
+                   visibility,
+                   lepton_text_object_get_show_name_value (o_attrib));
   }
 
   g_object_unref (attr_list);
@@ -1205,7 +1211,7 @@ multiattrib_callback_toggled_show_name (GtkCellRendererToggle *cell_renderer,
        a_iter = g_list_next (a_iter)) {
     LeptonObject *o_attrib = (LeptonObject *)a_iter->data;
 
-    gboolean value_visible = snv_shows_value (o_attrib->show_name_value);
+    gboolean value_visible = snv_shows_value (lepton_text_object_get_show_name_value (o_attrib));
 
     /* If we switch off the name visibility, but the value was not previously visible, make it so now */
     if (new_name_visible)
@@ -1269,7 +1275,7 @@ multiattrib_callback_toggled_show_value (GtkCellRendererToggle *cell_renderer,
        a_iter = g_list_next (a_iter)) {
     LeptonObject *o_attrib = (LeptonObject *)a_iter->data;
 
-    gboolean name_visible = snv_shows_name (o_attrib->show_name_value);
+    gboolean name_visible = snv_shows_name (lepton_text_object_get_show_name_value (o_attrib));
 
     /* If we switch off the name visibility, but the value was not previously visible, make it so now */
     if (new_value_visible)
@@ -2532,7 +2538,7 @@ object_attributes_to_model_rows (Multiattrib *multiattrib, LeptonObject *object)
     m_row->inherited = o_attrib_is_inherited (a_current);
     o_attrib_get_name_value (a_current, &m_row->name, &m_row->value);
     m_row->visibility = lepton_object_is_visible (a_current);
-    m_row->show_name_value = a_current->show_name_value;
+    m_row->show_name_value = lepton_text_object_get_show_name_value (a_current);
     m_row->nth_with_name = 0; /* Provisional value until we check below */
 
     /* The following fields are always true for a single LeptonObject */
@@ -2604,7 +2610,7 @@ lone_attributes_to_model_rows (Multiattrib *multiattrib)
     m_row->inherited = o_attrib_is_inherited (object);
     o_attrib_get_name_value (object, &m_row->name, &m_row->value);
     m_row->visibility = lepton_object_is_visible (object);
-    m_row->show_name_value = object->show_name_value;
+    m_row->show_name_value = lepton_text_object_get_show_name_value (object);
     m_row->nth_with_name = 0; /* All selected attributes are treated individually */
 
     /* The following fields are always true for a single attribute */

--- a/libleptongui/src/x_multiattrib.c
+++ b/libleptongui/src/x_multiattrib.c
@@ -1222,7 +1222,7 @@ multiattrib_callback_toggled_show_name (GtkCellRendererToggle *cell_renderer,
     o_invalidate (w_current, o_attrib);
 
     /* actually modifies the attribute */
-    o_attrib->show_name_value = new_snv;
+    lepton_text_object_set_show_name_value (o_attrib, new_snv);
     lepton_text_object_recreate (o_attrib);
   }
 
@@ -1286,7 +1286,7 @@ multiattrib_callback_toggled_show_value (GtkCellRendererToggle *cell_renderer,
     o_invalidate (w_current, o_attrib);
 
     /* actually modifies the attribute */
-    o_attrib->show_name_value = new_snv;
+    lepton_text_object_set_show_name_value (o_attrib, new_snv);
     lepton_text_object_recreate (o_attrib);
   }
 

--- a/libleptongui/src/x_multiattrib.c
+++ b/libleptongui/src/x_multiattrib.c
@@ -1153,7 +1153,7 @@ multiattrib_callback_toggled_visible (GtkCellRendererToggle *cell_renderer,
     /* actually modifies the attribute */
     o_invalidate (w_current, o_attrib);
     lepton_object_set_visibility (o_attrib, new_visibility ? VISIBLE : INVISIBLE);
-    o_text_recreate (o_attrib);
+    lepton_text_object_recreate (o_attrib);
   }
 
   g_object_unref (attr_list);
@@ -1217,7 +1217,7 @@ multiattrib_callback_toggled_show_name (GtkCellRendererToggle *cell_renderer,
 
     /* actually modifies the attribute */
     o_attrib->show_name_value = new_snv;
-    o_text_recreate (o_attrib);
+    lepton_text_object_recreate (o_attrib);
   }
 
   g_object_unref (attr_list);
@@ -1281,7 +1281,7 @@ multiattrib_callback_toggled_show_value (GtkCellRendererToggle *cell_renderer,
 
     /* actually modifies the attribute */
     o_attrib->show_name_value = new_snv;
-    o_text_recreate (o_attrib);
+    lepton_text_object_recreate (o_attrib);
   }
 
   g_object_unref (attr_list);

--- a/libleptongui/src/x_multiattrib.c
+++ b/libleptongui/src/x_multiattrib.c
@@ -640,7 +640,7 @@ multiattrib_action_duplicate_attributes (Multiattrib *multiattrib,
     /* create a new attribute and link it */
     o_attrib_add_attrib (w_current,
                          lepton_text_object_get_string (o_attrib),
-                         lepton_object_is_visible (o_attrib),
+                         lepton_text_object_is_visible (o_attrib),
                          lepton_text_object_get_show (o_attrib),
                          o_attrib->attached_to);
   }
@@ -668,7 +668,7 @@ multiattrib_action_promote_attributes (Multiattrib *multiattrib,
        iter = g_list_next (iter)) {
     LeptonObject *o_attrib = (LeptonObject *)iter->data;
 
-    if (lepton_object_is_visible (o_attrib)) {
+    if (lepton_text_object_is_visible (o_attrib)) {
       /* If the attribute we're promoting is visible, don't clone its location */
       o_attrib_add_attrib (w_current,
                            lepton_text_object_get_string (o_attrib),
@@ -747,7 +747,7 @@ multiattrib_action_copy_attribute_to_all (Multiattrib *multiattrib,
       /* Pick the first instance to copy from */
       LeptonObject *attrib_to_copy = (LeptonObject*) attr_list->data;
 
-      int visibility = lepton_object_is_visible (attrib_to_copy)
+      int visibility = lepton_text_object_is_visible (attrib_to_copy)
           ? VISIBLE : INVISIBLE;
 
       /* create a new attribute and link it */
@@ -1003,7 +1003,7 @@ multiattrib_callback_edited_name (GtkCellRendererText *cellrenderertext,
        a_iter = g_list_next (a_iter)) {
     o_attrib = (LeptonObject*) a_iter->data;
 
-    visibility = lepton_object_is_visible (o_attrib)
+    visibility = lepton_text_object_is_visible (o_attrib)
         ? VISIBLE : INVISIBLE;
 
     /* actually modifies the attribute */
@@ -1093,7 +1093,7 @@ multiattrib_callback_edited_value (GtkCellRendererText *cell_renderer,
        a_iter = g_list_next (a_iter)) {
     o_attrib = (LeptonObject *)a_iter->data;
 
-    visibility = lepton_object_is_visible (o_attrib)
+    visibility = lepton_text_object_is_visible (o_attrib)
         ? VISIBLE : INVISIBLE;
 
     /* actually modifies the attribute */
@@ -1158,7 +1158,7 @@ multiattrib_callback_toggled_visible (GtkCellRendererToggle *cell_renderer,
 
     /* actually modifies the attribute */
     o_invalidate (w_current, o_attrib);
-    lepton_object_set_visibility (o_attrib, new_visibility ? VISIBLE : INVISIBLE);
+    lepton_text_object_set_visibility (o_attrib, new_visibility ? VISIBLE : INVISIBLE);
     lepton_text_object_recreate (o_attrib);
   }
 
@@ -2537,7 +2537,7 @@ object_attributes_to_model_rows (Multiattrib *multiattrib, LeptonObject *object)
 
     m_row->inherited = o_attrib_is_inherited (a_current);
     o_attrib_get_name_value (a_current, &m_row->name, &m_row->value);
-    m_row->visibility = lepton_object_is_visible (a_current);
+    m_row->visibility = lepton_text_object_is_visible (a_current);
     m_row->show_name_value = lepton_text_object_get_show (a_current);
     m_row->nth_with_name = 0; /* Provisional value until we check below */
 
@@ -2609,7 +2609,7 @@ lone_attributes_to_model_rows (Multiattrib *multiattrib)
     m_row = g_new0 (MODEL_ROW, 1);
     m_row->inherited = o_attrib_is_inherited (object);
     o_attrib_get_name_value (object, &m_row->name, &m_row->value);
-    m_row->visibility = lepton_object_is_visible (object);
+    m_row->visibility = lepton_text_object_is_visible (object);
     m_row->show_name_value = lepton_text_object_get_show (object);
     m_row->nth_with_name = 0; /* All selected attributes are treated individually */
 

--- a/libleptongui/src/x_multiattrib.c
+++ b/libleptongui/src/x_multiattrib.c
@@ -641,7 +641,7 @@ multiattrib_action_duplicate_attributes (Multiattrib *multiattrib,
     o_attrib_add_attrib (w_current,
                          lepton_text_object_get_string (o_attrib),
                          lepton_object_is_visible (o_attrib),
-                         lepton_text_object_get_show_name_value (o_attrib),
+                         lepton_text_object_get_show (o_attrib),
                          o_attrib->attached_to);
   }
 
@@ -673,7 +673,7 @@ multiattrib_action_promote_attributes (Multiattrib *multiattrib,
       o_attrib_add_attrib (w_current,
                            lepton_text_object_get_string (o_attrib),
                            VISIBLE,
-                           lepton_text_object_get_show_name_value (o_attrib),
+                           lepton_text_object_get_show (o_attrib),
                            o_attrib->parent);
     } else {
         /* make a copy of the attribute object */
@@ -754,7 +754,7 @@ multiattrib_action_copy_attribute_to_all (Multiattrib *multiattrib,
       o_attrib_add_attrib (w_current,
                            lepton_text_object_get_string (attrib_to_copy),
                            visibility,
-                           lepton_text_object_get_show_name_value (attrib_to_copy),
+                           lepton_text_object_get_show (attrib_to_copy),
                            object);
     }
   }
@@ -1011,7 +1011,7 @@ multiattrib_callback_edited_name (GtkCellRendererText *cellrenderertext,
                    o_attrib,
                    newtext,
                    visibility,
-                   lepton_text_object_get_show_name_value (o_attrib));
+                   lepton_text_object_get_show (o_attrib));
   }
 
   g_object_unref (attr_list);
@@ -1101,7 +1101,7 @@ multiattrib_callback_edited_value (GtkCellRendererText *cell_renderer,
                    o_attrib,
                    newtext,
                    visibility,
-                   lepton_text_object_get_show_name_value (o_attrib));
+                   lepton_text_object_get_show (o_attrib));
   }
 
   g_object_unref (attr_list);
@@ -1211,7 +1211,7 @@ multiattrib_callback_toggled_show_name (GtkCellRendererToggle *cell_renderer,
        a_iter = g_list_next (a_iter)) {
     LeptonObject *o_attrib = (LeptonObject *)a_iter->data;
 
-    gboolean value_visible = snv_shows_value (lepton_text_object_get_show_name_value (o_attrib));
+    gboolean value_visible = snv_shows_value (lepton_text_object_get_show (o_attrib));
 
     /* If we switch off the name visibility, but the value was not previously visible, make it so now */
     if (new_name_visible)
@@ -1222,7 +1222,7 @@ multiattrib_callback_toggled_show_name (GtkCellRendererToggle *cell_renderer,
     o_invalidate (w_current, o_attrib);
 
     /* actually modifies the attribute */
-    lepton_text_object_set_show_name_value (o_attrib, new_snv);
+    lepton_text_object_set_show (o_attrib, new_snv);
     lepton_text_object_recreate (o_attrib);
   }
 
@@ -1275,7 +1275,7 @@ multiattrib_callback_toggled_show_value (GtkCellRendererToggle *cell_renderer,
        a_iter = g_list_next (a_iter)) {
     LeptonObject *o_attrib = (LeptonObject *)a_iter->data;
 
-    gboolean name_visible = snv_shows_name (lepton_text_object_get_show_name_value (o_attrib));
+    gboolean name_visible = snv_shows_name (lepton_text_object_get_show (o_attrib));
 
     /* If we switch off the name visibility, but the value was not previously visible, make it so now */
     if (new_value_visible)
@@ -1286,7 +1286,7 @@ multiattrib_callback_toggled_show_value (GtkCellRendererToggle *cell_renderer,
     o_invalidate (w_current, o_attrib);
 
     /* actually modifies the attribute */
-    lepton_text_object_set_show_name_value (o_attrib, new_snv);
+    lepton_text_object_set_show (o_attrib, new_snv);
     lepton_text_object_recreate (o_attrib);
   }
 
@@ -2538,7 +2538,7 @@ object_attributes_to_model_rows (Multiattrib *multiattrib, LeptonObject *object)
     m_row->inherited = o_attrib_is_inherited (a_current);
     o_attrib_get_name_value (a_current, &m_row->name, &m_row->value);
     m_row->visibility = lepton_object_is_visible (a_current);
-    m_row->show_name_value = lepton_text_object_get_show_name_value (a_current);
+    m_row->show_name_value = lepton_text_object_get_show (a_current);
     m_row->nth_with_name = 0; /* Provisional value until we check below */
 
     /* The following fields are always true for a single LeptonObject */
@@ -2610,7 +2610,7 @@ lone_attributes_to_model_rows (Multiattrib *multiattrib)
     m_row->inherited = o_attrib_is_inherited (object);
     o_attrib_get_name_value (object, &m_row->name, &m_row->value);
     m_row->visibility = lepton_object_is_visible (object);
-    m_row->show_name_value = lepton_text_object_get_show_name_value (object);
+    m_row->show_name_value = lepton_text_object_get_show (object);
     m_row->nth_with_name = 0; /* All selected attributes are treated individually */
 
     /* The following fields are always true for a single attribute */


### PR DESCRIPTION
- Move two fields of `LeptonObject`, namely `show_name_value` and `visibility`, to `LeptonText` and shorten the name of the former one.
- Move accessors to them to `text_object.c`.
- Leptonize names of some text object related functions.
- Rename the `st_text` struct to `_LeptonText`.