### PR TITLE
Rewrite SCM_DEFINE'd object line stroke functions using Scheme FFI

### DIFF
--- a/liblepton/include/liblepton/stroke.h
+++ b/liblepton/include/liblepton/stroke.h
@@ -91,3 +91,16 @@ lepton_stroke_get_space_length (const LeptonStroke *stroke);
 void
 lepton_stroke_set_space_length (LeptonStroke *stroke,
                                 int space_length);
+
+/* Helpers for Scheme. */
+const char*
+lepton_stroke_cap_type_to_string (LeptonStrokeCapType cap_type);
+
+LeptonStrokeCapType
+lepton_stroke_cap_type_from_string (char *s);
+
+const char*
+lepton_stroke_type_to_string (LeptonStrokeType cap_type);
+
+LeptonStrokeType
+lepton_stroke_type_from_string (char *s);

--- a/liblepton/include/liblepton/stroke.h
+++ b/liblepton/include/liblepton/stroke.h
@@ -23,6 +23,8 @@
  *  \brief Line stroke style of objects such as arcs, boxes, circles, and lines.
  */
 
+G_BEGIN_DECLS
+
 enum _LeptonStrokeCapType
 {
   END_NONE,
@@ -104,3 +106,5 @@ lepton_stroke_type_to_string (LeptonStrokeType cap_type);
 
 LeptonStrokeType
 lepton_stroke_type_from_string (char *s);
+
+G_END_DECLS

--- a/liblepton/scheme/lepton/ffi.scm.in
+++ b/liblepton/scheme/lepton/ffi.scm.in
@@ -38,6 +38,11 @@
             lepton_object_get_parent
             lepton_object_get_selectable
             lepton_object_set_selectable
+            lepton_object_get_stroke_cap_type
+            lepton_object_get_stroke_type
+            lepton_object_get_stroke_width
+            lepton_object_get_stroke_dash_length
+            lepton_object_get_stroke_space_length
             lepton_object_get_type
 
             lepton_object_is_arc
@@ -89,6 +94,9 @@
             lepton_picture_object_get_embedded
             lepton_picture_object_embed
             lepton_picture_object_unembed
+
+            lepton_stroke_cap_type_to_string
+            lepton_stroke_type_to_string
 
             set_render_placeholders
             colors_count
@@ -156,6 +164,11 @@
 (define-lff lepton_object_get_parent '* '(*))
 (define-lff lepton_object_get_selectable int '(*))
 (define-lff lepton_object_set_selectable void (list '* int))
+(define-lff lepton_object_get_stroke_cap_type int '(*))
+(define-lff lepton_object_get_stroke_type int '(*))
+(define-lff lepton_object_get_stroke_width int '(*))
+(define-lff lepton_object_get_stroke_dash_length int '(*))
+(define-lff lepton_object_get_stroke_space_length int '(*))
 (define-lff lepton_object_get_type int '(*))
 
 (define-lff lepton_object_is_arc int '(*))
@@ -209,6 +222,9 @@
 (define-lff lepton_picture_object_get_embedded int '(*))
 (define-lff lepton_picture_object_embed void '(*))
 (define-lff lepton_picture_object_unembed void '(*))
+
+(define-lff lepton_stroke_cap_type_to_string '* (list int))
+(define-lff lepton_stroke_type_to_string '* (list int))
 
 ;;; Helper transformers between #<geda-object> smobs and C object
 ;;; pointers.

--- a/liblepton/scheme/lepton/ffi.scm.in
+++ b/liblepton/scheme/lepton/ffi.scm.in
@@ -26,6 +26,7 @@
             pointer->geda-object
             check-coord
             check-integer
+            check-symbol
 
             ;; Foreign functions.
             edascm_is_config
@@ -39,10 +40,15 @@
             lepton_object_get_selectable
             lepton_object_set_selectable
             lepton_object_get_stroke_cap_type
+            lepton_object_set_stroke_cap_type
             lepton_object_get_stroke_type
+            lepton_object_set_stroke_type
             lepton_object_get_stroke_width
+            lepton_object_set_stroke_width
             lepton_object_get_stroke_dash_length
+            lepton_object_set_stroke_dash_length
             lepton_object_get_stroke_space_length
+            lepton_object_set_stroke_space_length
             lepton_object_get_type
 
             lepton_object_is_arc
@@ -95,7 +101,9 @@
             lepton_picture_object_embed
             lepton_picture_object_unembed
 
+            lepton_stroke_cap_type_from_string
             lepton_stroke_cap_type_to_string
+            lepton_stroke_type_from_string
             lepton_stroke_type_to_string
 
             set_render_placeholders
@@ -165,10 +173,15 @@
 (define-lff lepton_object_get_selectable int '(*))
 (define-lff lepton_object_set_selectable void (list '* int))
 (define-lff lepton_object_get_stroke_cap_type int '(*))
+(define-lff lepton_object_set_stroke_cap_type void (list '* int))
 (define-lff lepton_object_get_stroke_type int '(*))
+(define-lff lepton_object_set_stroke_type void (list '* int))
 (define-lff lepton_object_get_stroke_width int '(*))
+(define-lff lepton_object_set_stroke_width void (list '* int))
 (define-lff lepton_object_get_stroke_dash_length int '(*))
+(define-lff lepton_object_set_stroke_dash_length void (list '* int))
 (define-lff lepton_object_get_stroke_space_length int '(*))
+(define-lff lepton_object_set_stroke_space_length void (list '* int))
 (define-lff lepton_object_get_type int '(*))
 
 (define-lff lepton_object_is_arc int '(*))
@@ -223,7 +236,9 @@
 (define-lff lepton_picture_object_embed void '(*))
 (define-lff lepton_picture_object_unembed void '(*))
 
+(define-lff lepton_stroke_cap_type_from_string int '(*))
 (define-lff lepton_stroke_cap_type_to_string '* (list int))
+(define-lff lepton_stroke_type_from_string int '(*))
 (define-lff lepton_stroke_type_to_string '* (list int))
 
 ;;; Helper transformers between #<geda-object> smobs and C object
@@ -308,5 +323,16 @@
                    (frame-procedure-name (stack-ref (make-stack #t) 1))
                    '??)
                "Wrong type argument in position ~A (expecting a pair of integers): ~A"
+               (list pos val)
+               #f)))
+
+(define-syntax-rule (check-symbol val pos)
+  (unless (symbol? val)
+    (scm-error 'wrong-type-arg
+               ;; Provision against Guile-2.0 that does not have the procedure.
+               (if (defined? 'frame-procedure-name)
+                   (frame-procedure-name (stack-ref (make-stack #t) 1))
+                   '??)
+               "Wrong type argument in position ~A (expecting symbol): ~A"
                (list pos val)
                #f)))

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -748,14 +748,26 @@ the dash style."
 
 (define-public set-object-stroke! %set-object-stroke!)
 
-(define-public (object-stroke-width obj)
-  (list-ref (object-stroke obj) 0))
+(define-public (object-stroke-width object)
+  "Returns the integer stroke width of OBJECT, which must be a
+line, box, circle, arc, or path object."
+  (list-ref (object-stroke object) 0))
 
-(define-public (object-stroke-cap obj)
-  (list-ref (object-stroke obj) 1))
+(define-public (object-stroke-cap object)
+  "Returns the stroke cap style of OBJECT, which must be a line,
+box, circle, arc, or path object.  The returned value is one of the
+symbols 'none, 'square or 'round."
+  (list-ref (object-stroke object) 1))
 
-(define-public (object-stroke-dash obj)
-  (list-tail (object-stroke obj) 2))
+(define-public (object-stroke-dash object)
+  "Returns the dash style of OBJECT, which must be a line, box,
+circle, arc, or path object.  The return value is a list of between
+one and three parameters:
+  - dash style, one of the symbols 'solid, 'dotted,
+    'dashed, 'center or 'phantom.
+  - for styles other than 'solid, dot/dash spacing;
+  - for 'dashed, 'center and 'phantom, dash length."
+  (list-tail (object-stroke object) 2))
 
 (define-public object-fill %object-fill)
 (define-public set-object-fill! %set-object-fill!)

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -20,6 +20,7 @@
 
 (define-module (lepton object)
   ;; Optional arguments
+  #:use-module (ice-9 match)
   #:use-module (ice-9 optargs)
   #:use-module (srfi srfi-1)
   #:use-module (system foreign)
@@ -683,6 +684,11 @@ of the arc."
       (arc? object)
       (path? object)))
 
+(define (stroke-cap-type? cap)
+  (match cap
+    ((or 'none 'square 'round) cap)
+    (_ #f)))
+
 (define (object-stroke object)
   "Returns the stroke properties of OBJECT.  If OBJECT is not a
 line, box, circle, arc, or path, throws a Scheme error.  The
@@ -732,12 +738,6 @@ optional.  The following parameters are used:
   - DASH-LENGTH is an integer dash length for dash styles other
     than 'solid or 'dotted.
 Returns modified OBJECT."
-
-  (define valid-cap-type?
-    (or (eq? cap-type 'none)
-        (eq? cap-type 'square)
-        (eq? cap-type 'round)))
-
   (define valid-dash-type?
     (or (eq? dash-type 'solid)
         (eq? dash-type 'dotted)
@@ -759,7 +759,7 @@ Returns modified OBJECT."
   (define pointer (geda-object->pointer* object 1 strokable? 'strokable))
 
   (check-symbol cap-type 3)
-  (unless valid-cap-type?
+  (unless (stroke-cap-type? cap-type)
     (error "Invalid stroke cap style ~A."
            cap-type))
 
@@ -816,9 +816,7 @@ box, circle, arc, or path object.  The returned value is one of the
 symbols 'none, 'square or 'round."
   ;; Check if CAP is a valid cap type symbol.
   (define (check-cap-type-symbol cap)
-    (if (or (eq? cap 'none)
-            (eq? cap 'square)
-            (eq? cap 'round))
+    (if (stroke-cap-type? cap)
         cap
         (error "Unsupported cap style for object ~A: ~A." object cap)))
 

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -55,6 +55,8 @@
             object-selectable?
             set-object-selectable!
 
+            object-stroke
+
             arc-info
             arc-center
             arc-radius
@@ -668,7 +670,82 @@ of the arc."
 
 ;;;; Fill and stroke
 
-(define-public object-stroke %object-stroke)
+;;; Helper function to check if OBJECT supports stroke
+;;; modification.
+(define (strokable? object)
+  (or (line? object)
+      (box? object)
+      (circle? object)
+      (arc? object)
+      (path? object)))
+
+(define (object-stroke object)
+  "Returns the stroke properties of OBJECT.  If OBJECT is not a
+line, box, circle, arc, or path, throws a Scheme error.  The
+return value is a list of parameters:
+  - stroke width
+  - cap style (a symbol: 'none, 'square or 'round)
+  - dash style (a symbol: 'solid, 'dotted, 'dashed, 'center, or
+    'phantom)
+  - up to two dash parameters, depending on the dash style:
+    - For solid lines, no parameters.
+    - For dotted lines, dot spacing.
+    - For other styles, dot/dash spacing and dash length.
+The dash parameters are ignored in case they are not supported for
+the dash style."
+
+  ;; Check if CAP is a valid cap type symbol.
+  (define (check-cap-type-symbol cap)
+    (if (or (eq? cap 'none)
+            (eq? cap 'square)
+            (eq? cap 'round))
+        cap
+        (error "Unsupported cap style for object ~A: ~A." object cap)))
+
+  ;; Check if STROKE-TYPE is a valid stroke type symbol.
+  (define (check-stroke-type-symbol stroke-type)
+    (if (or (eq? stroke-type 'solid)
+            (eq? stroke-type 'dotted)
+            (eq? stroke-type 'dashed)
+            (eq? stroke-type 'center)
+            (eq? stroke-type 'phantom))
+        stroke-type
+        (error "Unsupported line type for object ~A: ~A." object stroke-type)))
+
+  ;; Transforms cap type integer value obtained from C code into a
+  ;; symbol.  Reports an error if the value is invalid.
+  (define (cap-type->symbol cap-type)
+    (let ((c-string-pointer (lepton_stroke_cap_type_to_string cap-type)))
+      (if (null-pointer? c-string-pointer)
+          (error "Invalid stroke cap style for object ~A." object)
+          (check-cap-type-symbol
+           (string->symbol (pointer->string c-string-pointer))))))
+
+  ;; Transforms stroke type integer value obtained from C code
+  ;; into a symbol.  Reports an error if the value is invalid.
+  (define (stroke-type->symbol stroke-type)
+    (let ((c-string-pointer (lepton_stroke_type_to_string stroke-type)))
+      (if (null-pointer? c-string-pointer)
+          (error "Invalid stroke line type for object ~A." object)
+          (check-stroke-type-symbol
+           (string->symbol (pointer->string c-string-pointer))))))
+
+  (define pointer (geda-object->pointer* object 1 strokable? 'strokable))
+
+  (let ((cap-type
+         (cap-type->symbol (lepton_object_get_stroke_cap_type pointer)))
+        (line-type
+         (stroke-type->symbol (lepton_object_get_stroke_type pointer)))
+        (width (lepton_object_get_stroke_width pointer))
+        (dash-length (lepton_object_get_stroke_dash_length pointer))
+        (space-length (lepton_object_get_stroke_space_length pointer)))
+    (case line-type
+      ((solid) (list width cap-type line-type))
+      ((dotted) (list width cap-type line-type space-length))
+      ;; dashed, center, and phantom.
+      (else  (list width cap-type line-type space-length dash-length)))))
+
+
 (define-public set-object-stroke! %set-object-stroke!)
 
 (define-public (object-stroke-width obj)

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -834,7 +834,7 @@ symbols 'none, 'square or 'round."
 
 (define (object-stroke-line-type object)
   ;; Check if STROKE-TYPE is a valid stroke type symbol.
-  (define (check-stroke-type-symbol stroke-type)
+  (define (check-stroke-dash-type stroke-type)
     (if (stroke-dash-type? stroke-type)
         stroke-type
         (error "Unsupported line type for object ~A: ~A." object stroke-type)))
@@ -845,7 +845,7 @@ symbols 'none, 'square or 'round."
     (let ((c-string-pointer (lepton_stroke_type_to_string stroke-type)))
       (if (null-pointer? c-string-pointer)
           (error "Invalid stroke line type for object ~A." object)
-          (check-stroke-type-symbol
+          (check-stroke-dash-type
            (string->symbol (pointer->string c-string-pointer))))))
 
   (define pointer

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -56,6 +56,9 @@
             set-object-selectable!
 
             object-stroke
+            object-stroke-cap
+            object-stroke-dash
+            object-stroke-width
 
             arc-info
             arc-center
@@ -748,18 +751,18 @@ the dash style."
 
 (define-public set-object-stroke! %set-object-stroke!)
 
-(define-public (object-stroke-width object)
+(define (object-stroke-width object)
   "Returns the integer stroke width of OBJECT, which must be a
 line, box, circle, arc, or path object."
   (list-ref (object-stroke object) 0))
 
-(define-public (object-stroke-cap object)
+(define (object-stroke-cap object)
   "Returns the stroke cap style of OBJECT, which must be a line,
 box, circle, arc, or path object.  The returned value is one of the
 symbols 'none, 'square or 'round."
   (list-ref (object-stroke object) 1))
 
-(define-public (object-stroke-dash object)
+(define (object-stroke-dash object)
   "Returns the dash style of OBJECT, which must be a line, box,
 circle, arc, or path object.  The return value is a list of between
 one and three parameters:

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -697,14 +697,6 @@ return value is a list of parameters:
 The dash parameters are ignored in case they are not supported for
 the dash style."
 
-  ;; Check if CAP is a valid cap type symbol.
-  (define (check-cap-type-symbol cap)
-    (if (or (eq? cap 'none)
-            (eq? cap 'square)
-            (eq? cap 'round))
-        cap
-        (error "Unsupported cap style for object ~A: ~A." object cap)))
-
   ;; Check if STROKE-TYPE is a valid stroke type symbol.
   (define (check-stroke-type-symbol stroke-type)
     (if (or (eq? stroke-type 'solid)
@@ -714,15 +706,6 @@ the dash style."
             (eq? stroke-type 'phantom))
         stroke-type
         (error "Unsupported line type for object ~A: ~A." object stroke-type)))
-
-  ;; Transforms cap type integer value obtained from C code into a
-  ;; symbol.  Reports an error if the value is invalid.
-  (define (cap-type->symbol cap-type)
-    (let ((c-string-pointer (lepton_stroke_cap_type_to_string cap-type)))
-      (if (null-pointer? c-string-pointer)
-          (error "Invalid stroke cap style for object ~A." object)
-          (check-cap-type-symbol
-           (string->symbol (pointer->string c-string-pointer))))))
 
   ;; Transforms stroke type integer value obtained from C code
   ;; into a symbol.  Reports an error if the value is invalid.
@@ -735,8 +718,7 @@ the dash style."
 
   (define pointer (geda-object->pointer* object 1 strokable? 'strokable))
 
-  (let ((cap-type
-         (cap-type->symbol (lepton_object_get_stroke_cap_type pointer)))
+  (let ((cap-type (object-stroke-cap object))
         (line-type
          (stroke-type->symbol (lepton_object_get_stroke_type pointer)))
         (width (object-stroke-width object))
@@ -763,7 +745,27 @@ line, box, circle, arc, or path object."
   "Returns the stroke cap style of OBJECT, which must be a line,
 box, circle, arc, or path object.  The returned value is one of the
 symbols 'none, 'square or 'round."
-  (list-ref (object-stroke object) 1))
+  ;; Check if CAP is a valid cap type symbol.
+  (define (check-cap-type-symbol cap)
+    (if (or (eq? cap 'none)
+            (eq? cap 'square)
+            (eq? cap 'round))
+        cap
+        (error "Unsupported cap style for object ~A: ~A." object cap)))
+
+  ;; Transforms cap type integer value obtained from C code into a
+  ;; symbol.  Reports an error if the value is invalid.
+  (define (cap-type->symbol cap-type)
+    (let ((c-string-pointer (lepton_stroke_cap_type_to_string cap-type)))
+      (if (null-pointer? c-string-pointer)
+          (error "Invalid stroke cap style for object ~A." object)
+          (check-cap-type-symbol
+           (string->symbol (pointer->string c-string-pointer))))))
+
+  (define pointer
+    (geda-object->pointer* object 1 strokable? 'strokable))
+
+  (cap-type->symbol (lepton_object_get_stroke_cap_type pointer)))
 
 (define (object-stroke-dash object)
   "Returns the dash style of OBJECT, which must be a line, box,

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -739,7 +739,7 @@ the dash style."
          (cap-type->symbol (lepton_object_get_stroke_cap_type pointer)))
         (line-type
          (stroke-type->symbol (lepton_object_get_stroke_type pointer)))
-        (width (lepton_object_get_stroke_width pointer))
+        (width (object-stroke-width object))
         (dash-length (lepton_object_get_stroke_dash_length pointer))
         (space-length (lepton_object_get_stroke_space_length pointer)))
     (case line-type
@@ -754,7 +754,10 @@ the dash style."
 (define (object-stroke-width object)
   "Returns the integer stroke width of OBJECT, which must be a
 line, box, circle, arc, or path object."
-  (list-ref (object-stroke object) 0))
+  (define pointer
+    (geda-object->pointer* object 1 strokable? 'strokable))
+
+  (lepton_object_get_stroke_width pointer))
 
 (define (object-stroke-cap object)
   "Returns the stroke cap style of OBJECT, which must be a line,

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -689,6 +689,11 @@ of the arc."
     ((or 'none 'square 'round) cap)
     (_ #f)))
 
+(define (stroke-dash-type? dash)
+  (match dash
+    ((or 'solid 'dotted 'dashed 'center 'phantom) dash)
+    (_ #f)))
+
 (define (object-stroke object)
   "Returns the stroke properties of OBJECT.  If OBJECT is not a
 line, box, circle, arc, or path, throws a Scheme error.  The
@@ -738,13 +743,6 @@ optional.  The following parameters are used:
   - DASH-LENGTH is an integer dash length for dash styles other
     than 'solid or 'dotted.
 Returns modified OBJECT."
-  (define valid-dash-type?
-    (or (eq? dash-type 'solid)
-        (eq? dash-type 'dotted)
-        (eq? dash-type 'dashed)
-        (eq? dash-type 'center)
-        (eq? dash-type 'phantom)))
-
   (define with-dashes?
     (or (eq? dash-type 'dashed)
         (eq? dash-type 'center)
@@ -764,7 +762,7 @@ Returns modified OBJECT."
            cap-type))
 
   (check-symbol dash-type 4)
-  (unless valid-dash-type?
+  (unless (stroke-dash-type? dash-type)
     (error "Invalid stroke dash style ~A."
            dash-type))
 
@@ -837,11 +835,7 @@ symbols 'none, 'square or 'round."
 (define (object-stroke-line-type object)
   ;; Check if STROKE-TYPE is a valid stroke type symbol.
   (define (check-stroke-type-symbol stroke-type)
-    (if (or (eq? stroke-type 'solid)
-            (eq? stroke-type 'dotted)
-            (eq? stroke-type 'dashed)
-            (eq? stroke-type 'center)
-            (eq? stroke-type 'phantom))
+    (if (stroke-dash-type? stroke-type)
         stroke-type
         (error "Unsupported line type for object ~A: ~A." object stroke-type)))
 

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -780,7 +780,8 @@ Returns modified OBJECT."
              dash-length))
     (check-integer dash-length 6))
 
-  (let ((cap-type (lepton_stroke_cap_type_from_string
+  (let ((old-object-stroke (object-stroke object))
+        (cap-type (lepton_stroke_cap_type_from_string
                    (string->pointer (symbol->string cap-type))))
         (dash-type (lepton_stroke_type_from_string
                     (string->pointer (symbol->string dash-type)))))
@@ -794,7 +795,10 @@ Returns modified OBJECT."
     (when with-dashes?
       (lepton_object_set_stroke_dash_length pointer dash-length))
 
-    (lepton_object_page_set_changed pointer)
+    ;; Check if stroke info has been changed and update object's
+    ;; page.
+    (unless (equal? old-object-stroke (object-stroke object))
+      (lepton_object_page_set_changed pointer))
     ;; Return the modified object.
     object))
 

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -815,7 +815,7 @@ line, box, circle, arc, or path object."
 box, circle, arc, or path object.  The returned value is one of the
 symbols 'none, 'square or 'round."
   ;; Check if CAP is a valid cap type symbol.
-  (define (check-cap-type-symbol cap)
+  (define (check-stroke-cap-type cap)
     (if (stroke-cap-type? cap)
         cap
         (error "Unsupported cap style for object ~A: ~A." object cap)))
@@ -826,7 +826,7 @@ symbols 'none, 'square or 'round."
     (let ((c-string-pointer (lepton_stroke_cap_type_to_string cap-type)))
       (if (null-pointer? c-string-pointer)
           (error "Invalid stroke cap style for object ~A." object)
-          (check-cap-type-symbol
+          (check-stroke-cap-type
            (string->symbol (pointer->string c-string-pointer))))))
 
   (define pointer

--- a/liblepton/scheme/unit-tests/geda-page-dirty.scm
+++ b/liblepton/scheme/unit-tests/geda-page-dirty.scm
@@ -71,7 +71,7 @@
       (geda:assert-dirties P (apply set-component! C
                                     (list-tail (component-info C) 1)))
 
-      (geda:assert-dirties P (apply set-object-stroke! l (object-stroke l)))
+      (geda:assert-not-dirties P (apply set-object-stroke! l (object-stroke l)))
       (geda:assert-dirties P (apply set-object-fill! b (object-fill b)))
 
       ;; Remove primitives from page
@@ -89,7 +89,7 @@
       (geda:assert-not-dirties P (apply set-arc! a (arc-info a)))
       (geda:assert-dirties P (apply set-text! t (text-info t)))
 
-      (geda:assert-dirties P (apply set-object-stroke! l (object-stroke l)))
+      (geda:assert-not-dirties P (apply set-object-stroke! l (object-stroke l)))
       (geda:assert-dirties P (apply set-object-fill! b (object-fill b)))
 
       ;; Remove primitives from component

--- a/liblepton/scheme/unit-tests/lepton-object-stroke.scm
+++ b/liblepton/scheme/unit-tests/lepton-object-stroke.scm
@@ -97,6 +97,14 @@
                       (set-object-stroke! a 1 'BAD-VALUE 'solid))
   (test-assert-thrown 'misc-error
                       (set-object-stroke! a 1 'none 'BAD-VALUE))
+  ;; Invalid argument type.
+  (test-assert-thrown 'wrong-type-arg
+                      (set-object-stroke! (new-line) 1 'none 'dotted 'a))
+  (test-assert-thrown 'wrong-type-arg
+                      (set-object-stroke! (new-line) 1 'none 'dashed 'a 10))
+  (test-assert-thrown 'wrong-type-arg
+                      (set-object-stroke! (new-line) 1 'none 'dashed 10 'a))
+
   ;; Missing dash length/space arguments
   (test-assert-thrown 'misc-error
                       (set-object-stroke! a 1 'none 'dashed 5))
@@ -112,6 +120,10 @@
                       (set-object-stroke! a 1 'none 'phantom))
   (test-assert-thrown 'misc-error
                       (set-object-stroke! a 1 'none 'dotted))
+
+  ;; Invalid number of arguments.
+  (test-assert-thrown 'wrong-number-of-args
+                      (set-object-stroke! a 1 'none 'phantom 15 20 30))
   )
 
 (test-end "set-object-stroke-wrong-arguments")

--- a/liblepton/scheme/unit-tests/lepton-object-stroke.scm
+++ b/liblepton/scheme/unit-tests/lepton-object-stroke.scm
@@ -2,10 +2,11 @@
 
 (use-modules (lepton object))
 
+(define (new-line) (make-line '(1 . 2) '(3 . 4)))
 
 (test-begin "stroke" 24)
 
-(let ((a (make-line '(1 . 2) '(3 . 4))))
+(let ((a (new-line)))
 
   (test-equal a (set-object-stroke! a 1 'none 'solid 'foo 'bar))
   (test-equal 1 (object-stroke-width a))
@@ -30,27 +31,34 @@
   (set-object-stroke! a 1 'round 'phantom 7 8)
   (test-equal '(phantom 7 8) (object-stroke-dash a))
   (test-equal a (apply set-object-stroke! a (object-stroke a)))
-
-  ;; Invalid symbol arguments
-  (test-assert-thrown 'misc-error
-                 (set-object-stroke! a 1 'BAD-VALUE 'solid))
-  (test-assert-thrown 'misc-error
-                 (set-object-stroke! a 1 'none 'BAD-VALUE))
-  ;; Missing dash length/space arguments
-  (test-assert-thrown 'misc-error
-                 (set-object-stroke! a 1 'none 'dashed 5))
-  (test-assert-thrown 'misc-error
-                 (set-object-stroke! a 1 'none 'dashed))
-  (test-assert-thrown 'misc-error
-                 (set-object-stroke! a 1 'none 'center 5))
-  (test-assert-thrown 'misc-error
-                 (set-object-stroke! a 1 'none 'center))
-  (test-assert-thrown 'misc-error
-                 (set-object-stroke! a 1 'none 'phantom 5))
-  (test-assert-thrown 'misc-error
-                 (set-object-stroke! a 1 'none 'phantom))
-  (test-assert-thrown 'misc-error
-                 (set-object-stroke! a 1 'none 'dotted))
   )
 
 (test-end "stroke")
+
+
+(test-begin "set-object-stroke-wrong-arguments")
+
+(let ((a (new-line)))
+  ;; Invalid symbol arguments.
+  (test-assert-thrown 'misc-error
+                      (set-object-stroke! a 1 'BAD-VALUE 'solid))
+  (test-assert-thrown 'misc-error
+                      (set-object-stroke! a 1 'none 'BAD-VALUE))
+  ;; Missing dash length/space arguments
+  (test-assert-thrown 'misc-error
+                      (set-object-stroke! a 1 'none 'dashed 5))
+  (test-assert-thrown 'misc-error
+                      (set-object-stroke! a 1 'none 'dashed))
+  (test-assert-thrown 'misc-error
+                      (set-object-stroke! a 1 'none 'center 5))
+  (test-assert-thrown 'misc-error
+                      (set-object-stroke! a 1 'none 'center))
+  (test-assert-thrown 'misc-error
+                      (set-object-stroke! a 1 'none 'phantom 5))
+  (test-assert-thrown 'misc-error
+                      (set-object-stroke! a 1 'none 'phantom))
+  (test-assert-thrown 'misc-error
+                      (set-object-stroke! a 1 'none 'dotted))
+  )
+
+(test-end "set-object-stroke-wrong-arguments")

--- a/liblepton/scheme/unit-tests/lepton-object-stroke.scm
+++ b/liblepton/scheme/unit-tests/lepton-object-stroke.scm
@@ -3,6 +3,10 @@
 (use-modules (lepton object))
 
 (define (new-line) (make-line '(1 . 2) '(3 . 4)))
+(define (new-box) (make-box '(1 . 2) '(3 . 4)))
+(define (new-circle) (make-circle '(1 . 2) 100))
+(define (new-arc) (make-arc '(1 . 2) 100 0 90))
+(define new-path make-path)
 
 (test-begin "stroke" 24)
 
@@ -35,6 +39,55 @@
 
 (test-end "stroke")
 
+
+(test-begin "object-stroke")
+
+;;; Test allowable objects.
+(test-equal (object-stroke (new-box))
+  '(10 square solid))
+(test-equal (object-stroke (new-circle))
+  '(10 square solid))
+(test-equal (object-stroke (new-arc))
+  '(10 square solid))
+(test-equal (object-stroke (new-path))
+  '(10 square solid))
+(test-equal (object-stroke (new-line))
+  '(10 square solid))
+
+;;; Test combinations of stroke parameters.
+(test-equal (object-stroke (set-object-stroke! (new-line) 10 'square 'solid))
+  '(10 square solid))
+(test-equal (object-stroke (set-object-stroke! (new-line) 15 'square 'solid))
+  '(15 square solid))
+(test-equal (object-stroke (set-object-stroke! (new-line) 15 'round 'solid))
+  '(15 round solid))
+(test-equal (object-stroke (set-object-stroke! (new-line) 15 'none 'solid))
+  '(15 none solid))
+(test-equal (object-stroke (set-object-stroke! (new-line) 15 'none 'dotted 10))
+  '(15 none dotted 10))
+(test-equal (object-stroke (set-object-stroke! (new-line) 15 'none 'dotted 15))
+  '(15 none dotted 15))
+(test-equal (object-stroke (set-object-stroke! (new-line) 15 'none 'dotted 15 20))
+  '(15 none dotted 15))
+(test-equal (object-stroke (set-object-stroke! (new-line) 15 'none 'dashed 15 20))
+  '(15 none dashed 15 20))
+(test-equal (object-stroke (set-object-stroke! (new-line) 15 'none 'dashed 10 20))
+  '(15 none dashed 10 20))
+(test-equal (object-stroke (set-object-stroke! (new-line) 15 'none 'center 10 20))
+  '(15 none center 10 20))
+(test-equal (object-stroke (set-object-stroke! (new-line) 15 'none 'phantom 10 20))
+  '(15 none phantom 10 20))
+
+(test-end "object-stroke")
+
+(test-begin "object-stroke-wrong-arguments")
+
+(test-assert-thrown 'wrong-type-arg (object-stroke 'a))
+(test-assert-thrown 'wrong-type-arg (object-stroke 1))
+(test-assert-thrown 'wrong-number-of-args (object-stroke))
+(test-assert-thrown 'wrong-number-of-args (object-stroke (new-line) 1))
+
+(test-end "object-stroke-wrong-arguments")
 
 (test-begin "set-object-stroke-wrong-arguments")
 

--- a/liblepton/scheme/unit-tests/lepton-object-stroke.scm
+++ b/liblepton/scheme/unit-tests/lepton-object-stroke.scm
@@ -2,7 +2,6 @@
 
 (use-modules (lepton object))
 
-(use-modules ((geda object) #:renamer (symbol-prefix-proc 'geda:)))
 
 (test-begin "stroke" 24)
 

--- a/liblepton/scheme/unit-tests/lepton-object-stroke.scm
+++ b/liblepton/scheme/unit-tests/lepton-object-stroke.scm
@@ -127,3 +127,12 @@
   )
 
 (test-end "set-object-stroke-wrong-arguments")
+
+
+(test-begin "object-stroke-param-wrong-arguments")
+
+(test-assert-thrown 'wrong-type-arg (object-stroke-width 'a))
+(test-assert-thrown 'wrong-type-arg (object-stroke-cap 'a))
+(test-assert-thrown 'wrong-type-arg (object-stroke-dash 'a))
+
+(test-end "object-stroke-param-wrong-arguments")

--- a/liblepton/scheme/unit-tests/lepton-page-dirty.scm
+++ b/liblepton/scheme/unit-tests/lepton-page-dirty.scm
@@ -101,7 +101,25 @@
       (assert-dirties P (apply set-component! C
                                (list-tail (component-info C) 1)))
 
-      (assert-dirties P (apply set-object-stroke! l (object-stroke l)))
+      ;; The same stroke parameters do not modify the page.
+      (assert-not-dirties P (apply set-object-stroke! l (object-stroke l)))
+
+      (set-object-stroke! l 1 'none 'solid)
+      ;; Reset dirty flag if it was set.
+      (set-page-dirty! P #f)
+      ;; Change stroke width.
+      (assert-dirties P (set-object-stroke! l 2 'none 'solid))
+      ;; Change cap style.
+      (assert-dirties P (set-object-stroke! l 2 'round 'solid))
+      ;; Change dash style.
+      (assert-dirties P (set-object-stroke! l 2 'round 'dotted 1))
+      ;; Change space between dots/dashes.
+      (assert-dirties P (set-object-stroke! l 2 'round 'dotted 2))
+      ;; Change dash style once again to check other parameters.
+      (assert-dirties P (set-object-stroke! l 2 'round 'dashed 1 1))
+      ;; Change dash length.
+      (assert-dirties P (set-object-stroke! l 2 'round 'dashed 1 2))
+
       (assert-dirties P (apply set-object-fill! b (object-fill b)))
 
       ;; Remove primitives from page
@@ -152,7 +170,25 @@
       (assert-dirties P (apply set-circle! c (circle-info c)))
       (assert-dirties P (apply set-text! t (text-info t)))
 
-      (assert-dirties P (apply set-object-stroke! l (object-stroke l)))
+      ;; The same stroke parameters do not modify the page.
+      (assert-not-dirties P (apply set-object-stroke! l (object-stroke l)))
+
+      (set-object-stroke! l 1 'none 'solid)
+      ;; Reset dirty flag if it was set.
+      (set-page-dirty! P #f)
+      ;; Change stroke width.
+      (assert-dirties P (set-object-stroke! l 2 'none 'solid))
+      ;; Change cap style.
+      (assert-dirties P (set-object-stroke! l 2 'round 'solid))
+      ;; Change dash style.
+      (assert-dirties P (set-object-stroke! l 2 'round 'dotted 1))
+      ;; Change space between dots/dashes.
+      (assert-dirties P (set-object-stroke! l 2 'round 'dotted 2))
+      ;; Change dash style once again to check other parameters.
+      (assert-dirties P (set-object-stroke! l 2 'round 'dashed 1 1))
+      ;; Change dash length.
+      (assert-dirties P (set-object-stroke! l 2 'round 'dashed 1 2))
+
       (assert-dirties P (apply set-object-fill! b (object-fill b)))
 
       ;; Remove primitives from component

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -46,16 +46,7 @@ SCM_SYMBOL (name_sym , "name");
 SCM_SYMBOL (value_sym , "value");
 SCM_SYMBOL (both_sym , "both");
 
-SCM_SYMBOL (none_sym, "none");
-SCM_SYMBOL (square_sym , "square");
-SCM_SYMBOL (round_sym , "round");
-
 SCM_SYMBOL (solid_sym , "solid");
-SCM_SYMBOL (dotted_sym , "dotted");
-SCM_SYMBOL (dashed_sym , "dashed");
-SCM_SYMBOL (center_sym , "center");
-SCM_SYMBOL (phantom_sym , "phantom");
-
 SCM_SYMBOL (hollow_sym , "hollow");
 SCM_SYMBOL (mesh_sym , "mesh");
 SCM_SYMBOL (hatch_sym , "hatch");

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -154,86 +154,6 @@ edascm_is_object_type (SCM smob, int type)
   return (lepton_object_get_type (obj) == type);
 }
 
-/*! \brief Get the stroke properties of an object.
- * \par Function Description
- * Returns the stroke settings of the object \a obj_s.  If \a obj_s is
- * not a line, box, circle, arc, or path, throws a Scheme error.  The
- * return value is a list of parameters:
- *
- * -# stroke width
- * -# cap style (a symbol: none, square or round)
- * -# dash style (a symbol: solid, dotted, dashed, center or phantom)
- * -# up to two dash parameters, depending on dash style:
- *    -# For solid lines, no parameters.
- *    -# For dotted lines, dot spacing.
- *    -# For other styles, dot/dash spacing and dash length.
- *
- * \note Scheme API: Implements the %object-stroke procedure in the
- * (lepton core object) module.
- *
- * \param obj_s object to get stroke settings for.
- * \return a list of stroke parameters.
- */
-SCM_DEFINE (object_stroke, "%object-stroke", 1, 0, 0,
-            (SCM obj_s), "Get the stroke properties of an object.")
-{
-  SCM_ASSERT ((edascm_is_object_type (obj_s, OBJ_LINE)
-               || edascm_is_object_type (obj_s, OBJ_BOX)
-               || edascm_is_object_type (obj_s, OBJ_CIRCLE)
-               || edascm_is_object_type (obj_s, OBJ_ARC)
-               || edascm_is_object_type (obj_s, OBJ_PATH)),
-              obj_s, SCM_ARG1, s_object_stroke);
-
-  LeptonObject *obj = edascm_to_object (obj_s);
-
-  int end, type, width, length, space;
-  lepton_object_get_line_options (obj,
-                                  (LeptonStrokeCapType *) &end,
-                                  (LeptonStrokeType *) &type,
-                                  &width,
-                                  &length,
-                                  &space);
-
-  SCM width_s = scm_from_int (width);
-  SCM length_s = scm_from_int (length);
-  SCM space_s = scm_from_int (space);
-
-  SCM cap_s;
-  switch (end) {
-  case END_NONE: cap_s = none_sym; break;
-  case END_SQUARE: cap_s = square_sym; break;
-  case END_ROUND: cap_s = round_sym; break;
-  default:
-    scm_misc_error (s_object_stroke,
-                    _("Object ~A has invalid stroke cap style ~A"),
-                    scm_list_2 (obj_s, scm_from_int (end)));
-  }
-
-  SCM dash_s;
-  switch (type) {
-  case TYPE_SOLID: dash_s = solid_sym; break;
-  case TYPE_DOTTED: dash_s = dotted_sym; break;
-  case TYPE_DASHED: dash_s = dashed_sym; break;
-  case TYPE_CENTER: dash_s = center_sym; break;
-  case TYPE_PHANTOM: dash_s = phantom_sym; break;
-  default:
-    scm_misc_error (s_object_stroke,
-                    _("Object ~A has invalid stroke dash style ~A"),
-                    scm_list_2 (obj_s, scm_from_int (type)));
-  }
-
-  switch (type) {
-  case TYPE_DASHED:
-  case TYPE_CENTER:
-  case TYPE_PHANTOM:
-    return scm_list_5 (width_s, cap_s, dash_s, space_s, length_s);
-  case TYPE_DOTTED:
-    return scm_list_4 (width_s, cap_s, dash_s, space_s);
-  default:
-    return scm_list_3 (width_s, cap_s, dash_s);
-  }
-}
-
 /*! \brief Set the stroke properties of an object.
  * \par Function Description
  * Updates the stroke settings of the object \a obj_s.  If \a obj_s is
@@ -1668,8 +1588,7 @@ init_module_lepton_core_object (void *unused)
   #include "scheme_object.x"
 
   /* Add them to the module's public definitions. */
-  scm_c_export (s_object_stroke,
-                s_set_object_stroke_x,
+  scm_c_export (s_set_object_stroke_x,
                 s_object_fill,
                 s_set_object_fill_x,
                 s_make_line,

--- a/liblepton/src/stroke.c
+++ b/liblepton/src/stroke.c
@@ -190,3 +190,67 @@ lepton_stroke_set_space_length (LeptonStroke *stroke,
 
   stroke->space_length = space_length;
 }
+
+
+const char*
+lepton_stroke_cap_type_to_string (LeptonStrokeCapType cap_type)
+{
+  const char *result = NULL;
+
+  switch (cap_type)
+  {
+  case END_NONE:   result = "none";   break;
+  case END_SQUARE: result = "square"; break;
+  case END_ROUND:  result = "round";  break;
+  default: break;
+  }
+
+  return result;
+}
+
+
+LeptonStrokeCapType
+lepton_stroke_cap_type_from_string (char *s)
+{
+  LeptonStrokeCapType result = END_NONE;
+
+  if      (strcmp (s, "none")   == 0) { result = END_NONE;   }
+  else if (strcmp (s, "square") == 0) { result = END_SQUARE; }
+  else if (strcmp (s, "round")  == 0) { result = END_ROUND;  }
+
+  return result;
+}
+
+
+const char*
+lepton_stroke_type_to_string (LeptonStrokeType stroke_type)
+{
+  const char *result = NULL;
+
+  switch (stroke_type)
+  {
+  case TYPE_SOLID:   result = "solid";   break;
+  case TYPE_DOTTED:  result = "dotted";  break;
+  case TYPE_DASHED:  result = "dashed";  break;
+  case TYPE_CENTER:  result = "center";  break;
+  case TYPE_PHANTOM: result = "phantom"; break;
+  default: break;
+  }
+
+  return result;
+}
+
+
+LeptonStrokeType
+lepton_stroke_type_from_string (char *s)
+{
+  LeptonStrokeType result = TYPE_SOLID;
+
+  if      (strcmp (s, "solid")   == 0) { result = TYPE_SOLID;   }
+  else if (strcmp (s, "dotted")  == 0) { result = TYPE_DOTTED;  }
+  else if (strcmp (s, "dashed")  == 0) { result = TYPE_DASHED;  }
+  else if (strcmp (s, "center")  == 0) { result = TYPE_CENTER;  }
+  else if (strcmp (s, "phantom") == 0) { result = TYPE_PHANTOM; }
+
+  return result;
+}

--- a/liblepton/src/stroke.c
+++ b/liblepton/src/stroke.c
@@ -192,6 +192,14 @@ lepton_stroke_set_space_length (LeptonStroke *stroke,
 }
 
 
+/*! \brief Return a string holding the representation of a stroke cap type.
+ * \par Function Description
+ * Given a #LeptonStrokeCapType value, returns its external
+ * representation as a string.  This is mainly intended to be used
+ * in Scheme FFI functions.
+ *
+ *  \param [in] cap_type The cap type of a stroke.
+ */
 const char*
 lepton_stroke_cap_type_to_string (LeptonStrokeCapType cap_type)
 {
@@ -209,6 +217,14 @@ lepton_stroke_cap_type_to_string (LeptonStrokeCapType cap_type)
 }
 
 
+/*! \brief Return a stroke cap type from a string.
+ * \par Function Description
+ * Given a string \a s, returns the #LeptonStrokeCapType enum
+ * value corresponding to it.  This is mainly intended to be used
+ * for value conversion in Scheme FFI functions.
+ *
+ *  \param [in] s The string.
+ */
 LeptonStrokeCapType
 lepton_stroke_cap_type_from_string (char *s)
 {
@@ -222,6 +238,14 @@ lepton_stroke_cap_type_from_string (char *s)
 }
 
 
+/*! \brief Return a string holding the representation of a stroke type.
+ * \par Function Description
+ * Given a #LeptonStrokeType value, returns its external
+ * representation as a string.  This is mainly intended to be used
+ * in Scheme FFI functions.
+ *
+ *  \param [in] stroke_type The type of a stroke.
+ */
 const char*
 lepton_stroke_type_to_string (LeptonStrokeType stroke_type)
 {
@@ -241,6 +265,14 @@ lepton_stroke_type_to_string (LeptonStrokeType stroke_type)
 }
 
 
+/*! \brief Return a stroke type from a string.
+ * \par Function Description
+ * Given a string \a s, returns the #LeptonStrokeType enum value
+ * corresponding to it.  This is mainly intended to be used for
+ * value conversion in Scheme FFI functions.
+ *
+ *  \param [in] s The string.
+ */
 LeptonStrokeType
 lepton_stroke_type_from_string (char *s)
 {


### PR DESCRIPTION
- `object-stroke()` and `set-object-stroke!` and stroke field getters have been rewritten using FFI.
- Added new tests.
- Added docstrings for the above funcs.
- I had to add some C layer functions to convert stroke enum values to Scheme symbols and vice versa.