### PR TITLE
Rewrite object fill related functions using Scheme FFI

### DIFF
--- a/liblepton/include/Makefile.am
+++ b/liblepton/include/Makefile.am
@@ -22,7 +22,7 @@ libleptoninclude_HEADERS = \
 	liblepton/component.h \
 	liblepton/coord.h \
 	liblepton/forward.h \
-	liblepton/fill_type.h \
+	liblepton/fill.h \
 	liblepton/line.h \
 	liblepton/list.h \
 	liblepton/page.h \

--- a/liblepton/include/liblepton/fill.h
+++ b/liblepton/include/liblepton/fill.h
@@ -17,7 +17,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
-/*! \file fill_type.h
+/*! \file fill.h
  */
 
 G_BEGIN_DECLS

--- a/liblepton/include/liblepton/fill_type.h
+++ b/liblepton/include/liblepton/fill_type.h
@@ -38,6 +38,68 @@ enum _LeptonFillType
 
 typedef enum _LeptonFillType LeptonFillType;
 
+typedef struct _LeptonFill LeptonFill;
+
+struct _LeptonFill
+{
+  LeptonFillType type;
+  int width;
+  int pitch1;
+  int angle1;
+  int pitch2;
+  int angle2;
+};
+
+
+
+LeptonFill*
+lepton_fill_new ();
+
+void
+lepton_fill_free (LeptonFill *fill);
+
+LeptonFillType
+lepton_fill_get_type (const LeptonFill *fill);
+
+void
+lepton_fill_set_type (LeptonFill *fill,
+                      LeptonFillType type);
+int
+lepton_fill_get_width (const LeptonFill *fill);
+
+void
+lepton_fill_set_width (LeptonFill *fill,
+                       int width);
+int
+lepton_fill_get_pitch1 (const LeptonFill *fill);
+
+void
+lepton_fill_set_pitch1 (LeptonFill *fill,
+                        int pitch);
+int
+lepton_fill_get_angle1 (const LeptonFill *fill);
+
+void
+lepton_fill_set_angle1 (LeptonFill *fill,
+                        int angle);
+int
+lepton_fill_get_pitch2 (const LeptonFill *fill);
+
+void
+lepton_fill_set_pitch2 (LeptonFill *fill,
+                        int pitch);
+int
+lepton_fill_get_angle2 (const LeptonFill *fill);
+
+void
+lepton_fill_set_angle2 (LeptonFill *fill,
+                        int angle);
+const char*
+lepton_fill_type_to_string (LeptonFillType type);
+
+LeptonFillType
+lepton_fill_type_from_string (char *s);
+
 gboolean
 lepton_fill_type_draw_first_hatch (int fill_type);
 

--- a/liblepton/include/liblepton/liblepton.h
+++ b/liblepton/include/liblepton/liblepton.h
@@ -32,7 +32,7 @@ G_BEGIN_DECLS
 #include <liblepton/defines.h>
 
 #include <liblepton/color.h>
-#include <liblepton/fill_type.h>
+#include <liblepton/fill.h>
 #include <liblepton/stroke.h>
 #include <liblepton/point.h>
 #include <liblepton/str.h>

--- a/liblepton/include/liblepton/object.h
+++ b/liblepton/include/liblepton/object.h
@@ -47,10 +47,8 @@ struct st_object
   /* Visible appearance of lines in graphical primitives. */
   LeptonStroke *stroke;
 
-  LeptonFillType fill_type;
-  int fill_width;
-  int fill_angle1, fill_pitch1;
-  int fill_angle2, fill_pitch2;
+  /* Visible appearance of filling of graphical primitives. */
+  LeptonFill *fill;
 
   gchar *component_basename;            /* Component Library Symbol name */
   LeptonObject *parent;                 /* Parent object pointer */
@@ -204,6 +202,45 @@ lepton_object_set_stroke_space_length (LeptonObject *object,
 int
 lepton_object_get_stroke_space_length (const LeptonObject *object);
 
+LeptonFill*
+lepton_object_get_fill (const LeptonObject *object);
+
+LeptonFillType
+lepton_object_get_fill_type (const LeptonObject *object);
+
+int
+lepton_object_get_fill_width (const LeptonObject *object);
+
+int
+lepton_object_get_fill_pitch1 (const LeptonObject *object);
+
+int
+lepton_object_get_fill_angle1 (const LeptonObject *object);
+
+int
+lepton_object_get_fill_pitch2 (const LeptonObject *object);
+
+int
+lepton_object_get_fill_angle2 (const LeptonObject *object);
+
+void
+lepton_object_set_fill_type (LeptonObject *object,
+                             LeptonFillType fill_type);
+void
+lepton_object_set_fill_width (LeptonObject *object,
+                              int width);
+void
+lepton_object_set_fill_pitch1 (LeptonObject *object,
+                               int pitch1);
+void
+lepton_object_set_fill_angle1 (LeptonObject *object,
+                               int angle1);
+void
+lepton_object_set_fill_pitch2 (LeptonObject *object,
+                               int pitch2);
+void
+lepton_object_set_fill_angle2 (LeptonObject *object,
+                               int angle2);
 double
 lepton_object_shortest_distance (LeptonObject *object,
                                  int x,

--- a/liblepton/include/liblepton_priv.h
+++ b/liblepton/include/liblepton_priv.h
@@ -14,7 +14,7 @@
 #include "defines.h"
 
 #include "color.h"
-#include "fill_type.h"
+#include "fill.h"
 #include "point.h"
 #include "str.h"
 #include "stroke.h"

--- a/liblepton/po/POTFILES.in
+++ b/liblepton/po/POTFILES.in
@@ -18,7 +18,6 @@ liblepton/src/text_object.c
 liblepton/src/f_basic.c
 liblepton/src/g_basic.c
 liblepton/src/g_rc.c
-liblepton/src/fill_type.c
 liblepton/src/page.c
 liblepton/src/o_attrib.c
 liblepton/src/object.c

--- a/liblepton/scheme/lepton/ffi.scm.in
+++ b/liblepton/scheme/lepton/ffi.scm.in
@@ -47,6 +47,7 @@
             lepton_object_get_fill_pitch2
             lepton_object_get_fill_type
             lepton_object_get_fill_width
+            lepton_object_set_fill_options
             lepton_object_get_id
             lepton_object_get_parent
             lepton_object_get_selectable
@@ -113,6 +114,7 @@
             lepton_picture_object_embed
             lepton_picture_object_unembed
 
+            lepton_fill_type_from_string
             lepton_fill_type_to_string
 
             lepton_stroke_cap_type_from_string
@@ -195,6 +197,7 @@
 (define-lff lepton_object_get_fill_pitch2 int '(*))
 (define-lff lepton_object_get_fill_type int '(*))
 (define-lff lepton_object_get_fill_width int '(*))
+(define-lff lepton_object_set_fill_options void (list '* int int int int int int))
 (define-lff lepton_object_get_id int '(*))
 (define-lff lepton_object_get_parent '* '(*))
 (define-lff lepton_object_get_selectable int '(*))
@@ -263,6 +266,7 @@
 (define-lff lepton_picture_object_embed void '(*))
 (define-lff lepton_picture_object_unembed void '(*))
 
+(define-lff lepton_fill_type_from_string int '(*))
 (define-lff lepton_fill_type_to_string '* (list int))
 
 (define-lff lepton_stroke_cap_type_from_string int '(*))

--- a/liblepton/scheme/lepton/ffi.scm.in
+++ b/liblepton/scheme/lepton/ffi.scm.in
@@ -41,6 +41,12 @@
 
             lepton_object_get_color
             lepton_object_set_color
+            lepton_object_get_fill_angle1
+            lepton_object_get_fill_angle2
+            lepton_object_get_fill_pitch1
+            lepton_object_get_fill_pitch2
+            lepton_object_get_fill_type
+            lepton_object_get_fill_width
             lepton_object_get_id
             lepton_object_get_parent
             lepton_object_get_selectable
@@ -106,6 +112,8 @@
             lepton_picture_object_get_embedded
             lepton_picture_object_embed
             lepton_picture_object_unembed
+
+            lepton_fill_type_to_string
 
             lepton_stroke_cap_type_from_string
             lepton_stroke_cap_type_to_string
@@ -181,6 +189,12 @@
 ;;; object.c
 (define-lff lepton_object_get_color int '(*))
 (define-lff lepton_object_set_color void (list '* int))
+(define-lff lepton_object_get_fill_angle1 int '(*))
+(define-lff lepton_object_get_fill_angle2 int '(*))
+(define-lff lepton_object_get_fill_pitch1 int '(*))
+(define-lff lepton_object_get_fill_pitch2 int '(*))
+(define-lff lepton_object_get_fill_type int '(*))
+(define-lff lepton_object_get_fill_width int '(*))
 (define-lff lepton_object_get_id int '(*))
 (define-lff lepton_object_get_parent '* '(*))
 (define-lff lepton_object_get_selectable int '(*))
@@ -248,6 +262,8 @@
 (define-lff lepton_picture_object_get_embedded int '(*))
 (define-lff lepton_picture_object_embed void '(*))
 (define-lff lepton_picture_object_unembed void '(*))
+
+(define-lff lepton_fill_type_to_string '* (list int))
 
 (define-lff lepton_stroke_cap_type_from_string int '(*))
 (define-lff lepton_stroke_cap_type_to_string '* (list int))

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -892,10 +892,9 @@ one and three parameters:
       (path? object)))
 
 (define (fill-type? type)
-  (or (eq? type 'hollow)
-      (eq? type 'solid)
-      (eq? type 'hatch)
-      (eq? type 'mesh)))
+  (match type
+    ((or 'hollow 'solid 'hatch 'mesh) type)
+    (_ #f)))
 
 (define (object-fill object)
   "Returns the fill properties of OBJECT.  If OBJECT is

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -891,6 +891,12 @@ one and three parameters:
       (circle? object)
       (path? object)))
 
+(define (fill-type? type)
+  (or (eq? type 'hollow)
+      (eq? type 'solid)
+      (eq? type 'hatch)
+      (eq? type 'mesh)))
+
 (define (object-fill object)
   "Returns the fill properties of OBJECT.  If OBJECT is
 not a box, circle, or path, throws a Scheme error.  The return
@@ -906,10 +912,7 @@ value is a list of parameters:
       (if (null-pointer? c_string)
           (error ("Invalid fill type for object ~A.") object)
           (let ((fill-type (string->symbol (pointer->string c_string))))
-            (if (or (eq? fill-type 'hollow)
-                    (eq? fill-type 'solid)
-                    (eq? fill-type 'mesh)
-                    (eq? fill-type 'hatch))
+            (if (fill-type? fill-type)
                 fill-type
                 (error ("Unsupported fill type for object ~A: ~A." object fill-type)))))))
 
@@ -923,10 +926,7 @@ value is a list of parameters:
         (pitch2 (lepton_object_get_fill_pitch2 pointer))
         (angle2 (lepton_object_get_fill_angle2 pointer)))
 
-    (unless (or (eq? fill-type 'hollow)
-                (eq? fill-type 'solid)
-                (eq? fill-type 'mesh)
-                (eq? fill-type 'hatch))
+    (unless (fill-type? fill-type)
       (error "Object ~A has invalid fill style ~A"
              object fill-type))
 
@@ -952,12 +952,6 @@ used. WIDTH defines the width of the strokes, ANGLE1 and SPACE1
 define the angle and pitch of the first hatch lines, ANGLE2 and
 SPACE2 define the angle and pitch of the second hatch lines.  The
 second hatch is used for the 'mesh type only.  Returns OBJECT."
-  (define valid-filling-type?
-    (or (eq? type 'hollow)
-        (eq? type 'solid)
-        (eq? type 'hatch)
-        (eq? type 'mesh)))
-
   (define with-first-hatch?
     (or (eq? type 'mesh)
         (eq? type 'hatch)))
@@ -967,7 +961,7 @@ second hatch is used for the 'mesh type only.  Returns OBJECT."
 
   (define pointer (geda-object->pointer* object 1 fillable? 'fillable))
 
-  (unless valid-filling-type?
+  (unless (fill-type? type)
     (error "Invalid fill style ~A." type))
 
   (when with-first-hatch?

--- a/liblepton/scheme/unit-tests/lepton-object-fill.scm
+++ b/liblepton/scheme/unit-tests/lepton-object-fill.scm
@@ -21,7 +21,34 @@
   (test-equal a (set-object-fill! a 'mesh 4 5 6 7 8))
   (test-equal '(mesh 4 5 6 7 8) (object-fill a))
   (test-equal a (apply set-object-fill! a (object-fill a)))
+  )
 
+(test-end "fill")
+
+
+(test-begin "object-fill")
+
+;;; Test allowable objects.
+(test-equal (object-fill (make-box '(1 . 2) '(3 . 4))) '(hollow))
+(test-equal (object-fill (make-circle '(1 . 2) 100)) '(hollow))
+(test-equal (object-fill (make-path)) '(hollow))
+
+(test-end "object-fill")
+
+
+(test-begin "object-fill-wrong-arguments")
+
+(test-assert-thrown 'wrong-type-arg (object-fill 'a))
+(test-assert-thrown 'wrong-type-arg (object-fill 1))
+(test-assert-thrown 'wrong-number-of-args (object-fill))
+(test-assert-thrown 'wrong-number-of-args (object-fill (make-path) 1))
+
+(test-end "object-fill-wrong-arguments")
+
+
+(test-begin "set-object-fill-wrong-arguments")
+
+(let ((a (make-box '(1 . 2) '(3 . 4))))
   ;; Invalid symbol arguments
   (test-assert-thrown 'misc-error
                       (set-object-fill! a 'BAD-VALUE))
@@ -56,27 +83,6 @@
                       (set-object-fill! a 'mesh 10 100 30 50 'a))
   ;; Invalid number of arguments.
   (test-assert-thrown 'wrong-number-of-args
-                      (set-object-fill! a 'mesh 2 3 4 5 6 7))
-  )
+                      (set-object-fill! a 'mesh 2 3 4 5 6 7)))
 
-(test-end "fill")
-
-
-(test-begin "object-fill")
-
-;;; Test allowable objects.
-(test-equal (object-fill (make-box '(1 . 2) '(3 . 4))) '(hollow))
-(test-equal (object-fill (make-circle '(1 . 2) 100)) '(hollow))
-(test-equal (object-fill (make-path)) '(hollow))
-
-(test-end "object-fill")
-
-
-(test-begin "object-fill-wrong-arguments")
-
-(test-assert-thrown 'wrong-type-arg (object-fill 'a))
-(test-assert-thrown 'wrong-type-arg (object-fill 1))
-(test-assert-thrown 'wrong-number-of-args (object-fill))
-(test-assert-thrown 'wrong-number-of-args (object-fill (make-path) 1))
-
-(test-end "object-fill-wrong-arguments")
+(test-end "set-object-fill-wrong-arguments")

--- a/liblepton/scheme/unit-tests/lepton-object-fill.scm
+++ b/liblepton/scheme/unit-tests/lepton-object-fill.scm
@@ -55,3 +55,13 @@
 (test-equal (object-fill (make-path)) '(hollow))
 
 (test-end "object-fill")
+
+
+(test-begin "object-fill-wrong-arguments")
+
+(test-assert-thrown 'wrong-type-arg (object-fill 'a))
+(test-assert-thrown 'wrong-type-arg (object-fill 1))
+(test-assert-thrown 'wrong-number-of-args (object-fill))
+(test-assert-thrown 'wrong-number-of-args (object-fill (make-path) 1))
+
+(test-end "object-fill-wrong-arguments")

--- a/liblepton/scheme/unit-tests/lepton-object-fill.scm
+++ b/liblepton/scheme/unit-tests/lepton-object-fill.scm
@@ -24,24 +24,24 @@
 
   ;; Invalid symbol arguments
   (test-assert-thrown 'misc-error
-                 (set-object-fill! a 'BAD-VALUE))
+                      (set-object-fill! a 'BAD-VALUE))
   ;; Missing fill width/angle/space arguments
   (test-assert-thrown 'misc-error
-                 (set-object-fill! a 'hatch))
+                      (set-object-fill! a 'hatch))
   (test-assert-thrown 'misc-error
-                 (set-object-fill! a 'hatch 1))
+                      (set-object-fill! a 'hatch 1))
   (test-assert-thrown 'misc-error
-                 (set-object-fill! a 'hatch 1 2))
+                      (set-object-fill! a 'hatch 1 2))
   (test-assert-thrown 'misc-error
-                 (set-object-fill! a 'mesh))
+                      (set-object-fill! a 'mesh))
   (test-assert-thrown 'misc-error
-                 (set-object-fill! a 'mesh 1))
+                      (set-object-fill! a 'mesh 1))
   (test-assert-thrown 'misc-error
-                 (set-object-fill! a 'mesh 1 2))
+                      (set-object-fill! a 'mesh 1 2))
   (test-assert-thrown 'misc-error
-                 (set-object-fill! a 'mesh 1 2 3))
+                      (set-object-fill! a 'mesh 1 2 3))
   (test-assert-thrown 'misc-error
-                 (set-object-fill! a 'mesh 1 2 3 4))
+                      (set-object-fill! a 'mesh 1 2 3 4))
   )
 
 (test-end "fill")

--- a/liblepton/scheme/unit-tests/lepton-object-fill.scm
+++ b/liblepton/scheme/unit-tests/lepton-object-fill.scm
@@ -45,3 +45,13 @@
   )
 
 (test-end "fill")
+
+
+(test-begin "object-fill")
+
+;;; Test allowable objects.
+(test-equal (object-fill (make-box '(1 . 2) '(3 . 4))) '(hollow))
+(test-equal (object-fill (make-circle '(1 . 2) 100)) '(hollow))
+(test-equal (object-fill (make-path)) '(hollow))
+
+(test-end "object-fill")

--- a/liblepton/scheme/unit-tests/lepton-object-fill.scm
+++ b/liblepton/scheme/unit-tests/lepton-object-fill.scm
@@ -2,8 +2,6 @@
 
 (use-modules (lepton object))
 
-(use-modules ((geda object) #:renamer (symbol-prefix-proc 'geda:)))
-
 (test-begin "fill" 21)
 
 (let ((a (make-box '(1 . 2) '(3 . 4))))

--- a/liblepton/scheme/unit-tests/lepton-object-fill.scm
+++ b/liblepton/scheme/unit-tests/lepton-object-fill.scm
@@ -42,6 +42,21 @@
                       (set-object-fill! a 'mesh 1 2 3))
   (test-assert-thrown 'misc-error
                       (set-object-fill! a 'mesh 1 2 3 4))
+
+  ;; Invalid argument type.
+  (test-assert-thrown 'wrong-type-arg
+                      (set-object-fill! a 'mesh 'a 100 30 50 120))
+  (test-assert-thrown 'wrong-type-arg
+                      (set-object-fill! a 'mesh 10 'a 30 50 120))
+  (test-assert-thrown 'wrong-type-arg
+                      (set-object-fill! a 'mesh 10 100 'a 50 120))
+  (test-assert-thrown 'wrong-type-arg
+                      (set-object-fill! a 'mesh 10 100 30 'a 120))
+  (test-assert-thrown 'wrong-type-arg
+                      (set-object-fill! a 'mesh 10 100 30 50 'a))
+  ;; Invalid number of arguments.
+  (test-assert-thrown 'wrong-number-of-args
+                      (set-object-fill! a 'mesh 2 3 4 5 6 7))
   )
 
 (test-end "fill")

--- a/liblepton/src/Makefile.am
+++ b/liblepton/src/Makefile.am
@@ -48,7 +48,7 @@ liblepton_la_SOURCES = \
 	color.c \
 	circle.c \
 	coord.c \
-	fill_type.c \
+	fill.c \
 	line.c \
 	list.c \
 	page.c \

--- a/liblepton/src/box_object.c
+++ b/liblepton/src/box_object.c
@@ -248,12 +248,12 @@ lepton_box_object_copy (LeptonObject *o_current)
                                   lepton_object_get_stroke_dash_length (o_current),
                                   lepton_object_get_stroke_space_length (o_current));
   lepton_object_set_fill_options (new_obj,
-                                  o_current->fill_type,
-                                  o_current->fill_width,
-                                  o_current->fill_pitch1,
-                                  o_current->fill_angle1,
-                                  o_current->fill_pitch2,
-                                  o_current->fill_angle2);
+                                  lepton_object_get_fill_type (o_current),
+                                  lepton_object_get_fill_width (o_current),
+                                  lepton_object_get_fill_pitch1 (o_current),
+                                  lepton_object_get_fill_angle1 (o_current),
+                                  lepton_object_get_fill_pitch2 (o_current),
+                                  lepton_object_get_fill_angle2 (o_current));
 
   return new_obj;
 }
@@ -530,12 +530,12 @@ lepton_box_object_to_buffer (const LeptonObject *object)
   box_space  = lepton_object_get_stroke_space_length (object);
 
   /* description of the filling of the box */
-  box_fill   = object->fill_type;
-  fill_width = object->fill_width;
-  angle1     = object->fill_angle1;
-  pitch1     = object->fill_pitch1;
-  angle2     = object->fill_angle2;
-  pitch2     = object->fill_pitch2;
+  box_fill   = lepton_object_get_fill_type (object);
+  fill_width = lepton_object_get_fill_width (object);
+  angle1     = lepton_object_get_fill_angle1 (object);
+  pitch1     = lepton_object_get_fill_pitch1 (object);
+  angle2     = lepton_object_get_fill_angle2 (object);
+  pitch2     = lepton_object_get_fill_pitch2 (object);
 
   buf = g_strdup_printf("%c %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d",
                         lepton_object_get_type (object),
@@ -775,7 +775,8 @@ lepton_box_object_shortest_distance (LeptonObject *object,
 
   g_return_val_if_fail (object->box != NULL, G_MAXDOUBLE);
 
-  solid = force_solid || object->fill_type != FILLING_HOLLOW;
+  solid = force_solid ||
+    lepton_object_get_fill_type (object) != FILLING_HOLLOW;
 
   return lepton_box_shortest_distance (object->box, x, y, solid);
 }

--- a/liblepton/src/circle_object.c
+++ b/liblepton/src/circle_object.c
@@ -124,12 +124,12 @@ lepton_circle_object_copy (const LeptonObject *object)
                                   lepton_object_get_stroke_space_length (object));
 
   lepton_object_set_fill_options (new_obj,
-                                  object->fill_type,
-                                  object->fill_width,
-                                  object->fill_pitch1,
-                                  object->fill_angle1,
-                                  object->fill_pitch2,
-                                  object->fill_angle2);
+                                  lepton_object_get_fill_type (object),
+                                  lepton_object_get_fill_width (object),
+                                  lepton_object_get_fill_pitch1 (object),
+                                  lepton_object_get_fill_angle1 (object),
+                                  lepton_object_get_fill_pitch2 (object),
+                                  lepton_object_get_fill_angle2 (object));
 
   return new_obj;
 }
@@ -423,12 +423,12 @@ lepton_circle_object_to_buffer (const LeptonObject *object)
                           lepton_object_get_stroke_type (object),
                           lepton_object_get_stroke_dash_length (object),
                           lepton_object_get_stroke_space_length (object),
-                          object->fill_type,
-                          object->fill_width,
-                          object->fill_angle1,
-                          object->fill_pitch1,
-                          object->fill_angle2,
-                          object->fill_pitch2);
+                          lepton_object_get_fill_type (object),
+                          lepton_object_get_fill_width (object),
+                          lepton_object_get_fill_angle1 (object),
+                          lepton_object_get_fill_pitch1 (object),
+                          lepton_object_get_fill_angle2 (object),
+                          lepton_object_get_fill_pitch2 (object));
 }
 
 /*! \brief Translate a circle position in WORLD coordinates by a delta.
@@ -616,7 +616,8 @@ lepton_circle_object_shortest_distance (LeptonObject *object,
   g_return_val_if_fail (lepton_object_is_circle (object), FALSE);
   g_return_val_if_fail (object->circle != NULL, G_MAXDOUBLE);
 
-  solid = force_solid || object->fill_type != FILLING_HOLLOW;
+  solid = force_solid ||
+    lepton_object_get_fill_type (object) != FILLING_HOLLOW;
 
   return lepton_circle_shortest_distance (object->circle, x, y, solid);
 }

--- a/liblepton/src/edarenderer.c
+++ b/liblepton/src/edarenderer.c
@@ -588,7 +588,8 @@ eda_renderer_draw_hatch (EdaRenderer *renderer, LeptonObject *object)
   }
 
   /* Handle solid and hollow fill types */
-  switch (object->fill_type) {
+  switch (lepton_object_get_fill_type (object))
+  {
   case FILLING_MESH:
   case FILLING_HATCH:
     break;
@@ -602,26 +603,41 @@ eda_renderer_draw_hatch (EdaRenderer *renderer, LeptonObject *object)
 
   /* Handle mesh and hatch fill types */
   fill_lines = g_array_new (FALSE, FALSE, sizeof (LeptonLine));
-  if (lepton_fill_type_draw_first_hatch (object->fill_type))
+  if (lepton_fill_type_draw_first_hatch (lepton_object_get_fill_type (object)))
   {
-    hatch_func (hatch_data, object->fill_angle1, object->fill_pitch1, fill_lines);
+    hatch_func (hatch_data,
+                lepton_object_get_fill_angle1 (object),
+                lepton_object_get_fill_pitch1 (object),
+                fill_lines);
   }
-  if (lepton_fill_type_draw_second_hatch (object->fill_type))
+  if (lepton_fill_type_draw_second_hatch (lepton_object_get_fill_type (object)))
   {
-    hatch_func (hatch_data, object->fill_angle2, object->fill_pitch2, fill_lines);
+    hatch_func (hatch_data,
+                lepton_object_get_fill_angle2 (object),
+                lepton_object_get_fill_pitch2 (object),
+                fill_lines);
   }
 
   /* Draw fill pattern */
   for (i = 0; i < fill_lines->len; i++) {
     LeptonLine *line = &g_array_index (fill_lines, LeptonLine, i);
-    eda_cairo_line (renderer->priv->cr, EDA_RENDERER_CAIRO_FLAGS (renderer),
-                    END_NONE, object->fill_width,
-                    line->x[0], line->y[0], line->x[1], line->y[1]);
+    eda_cairo_line (renderer->priv->cr,
+                    EDA_RENDERER_CAIRO_FLAGS (renderer),
+                    END_NONE,
+                    lepton_object_get_fill_width (object),
+                    line->x[0],
+                    line->y[0],
+                    line->x[1],
+                    line->y[1]);
   }
-  eda_cairo_stroke (renderer->priv->cr, EDA_RENDERER_CAIRO_FLAGS (renderer),
-                    TYPE_SOLID, END_NONE,
-                    EDA_RENDERER_STROKE_WIDTH (renderer, object->fill_width),
-                    -1, -1);
+  eda_cairo_stroke (renderer->priv->cr,
+                    EDA_RENDERER_CAIRO_FLAGS (renderer),
+                    TYPE_SOLID,
+                    END_NONE,
+                    EDA_RENDERER_STROKE_WIDTH (renderer,
+                    lepton_object_get_fill_width (object)),
+                    -1,
+                    -1);
 
   g_array_free (fill_lines, TRUE);
   return FALSE;

--- a/liblepton/src/fill.c
+++ b/liblepton/src/fill.c
@@ -22,8 +22,8 @@
 #include "liblepton_priv.h"
 
 /*!
- * \file  fill_type.c
- * \brief Filling types.
+ * \file  fill.c
+ * \brief Functions for working with object filling.
  */
 
 

--- a/liblepton/src/fill_type.c
+++ b/liblepton/src/fill_type.c
@@ -27,6 +27,232 @@
  */
 
 
+/*! \brief Init a new #LeptonFill.
+ */
+LeptonFill*
+lepton_fill_new ()
+{
+  LeptonFill *fill;
+
+  fill = g_new (LeptonFill, 1);
+  fill->type = FILLING_HOLLOW;
+  fill->width = 0;
+  fill->pitch1 = 0;
+  fill->angle1 = 0;
+  fill->pitch2 = 0;
+  fill->angle2 = 0;
+
+  return fill;
+}
+
+/*! \brief Free a #LeptonFill.
+ */
+void
+lepton_fill_free (LeptonFill *fill)
+{
+  g_free (fill);
+}
+
+
+/*! \brief Get the type of a fill.
+ *
+ *  \param [in] fill The fill.
+ *  \return type The line type of the fill.
+ */
+LeptonFillType
+lepton_fill_get_type (const LeptonFill *fill)
+{
+  g_return_val_if_fail (fill != NULL, FILLING_HOLLOW);
+
+  return fill->type;
+}
+
+/*! \brief Set the type of a fill.
+ *
+ *  \param [in] fill The fill.
+ *  \param [in] type The new fill type.
+ */
+void
+lepton_fill_set_type (LeptonFill *fill,
+                      LeptonFillType type)
+{
+  g_return_if_fail (fill != NULL);
+
+  fill->type = type;
+}
+
+
+/*! \brief Get the width of a fill.
+ *
+ *  \param [in] fill The fill.
+ *  \return The width of lines of the fill.
+ */
+int
+lepton_fill_get_width (const LeptonFill *fill)
+{
+  g_return_val_if_fail (fill != NULL, FILLING_HOLLOW);
+
+  return fill->width;
+}
+
+/*! \brief Set the width of lines of a fill.
+ *
+ *  \param [in] fill The fill.
+ *  \param [in] width The new fill line width.
+ */
+void
+lepton_fill_set_width (LeptonFill *fill,
+                       int width)
+{
+  g_return_if_fail (fill != NULL);
+
+  fill->width = width;
+}
+
+
+/*! \brief Get the first pitch of a fill.
+ *
+ *  \param [in] fill The fill.
+ *  \return The first pitch of the fill.
+ */
+int
+lepton_fill_get_pitch1 (const LeptonFill *fill)
+{
+  g_return_val_if_fail (fill != NULL, FILLING_HOLLOW);
+
+  return fill->pitch1;
+}
+
+/*! \brief Set the pitch1 of a fill.
+ *
+ *  \param [in] fill   The fill.
+ *  \param [in] pitch  The new fill first pitch.
+ */
+void
+lepton_fill_set_pitch1 (LeptonFill *fill,
+                        int pitch)
+{
+  g_return_if_fail (fill != NULL);
+
+  fill->pitch1 = pitch;
+}
+
+/*! \brief Get the first angle of a fill.
+ *
+ *  \param [in] fill The fill.
+ *  \return The first angle of the fill.
+ */
+int
+lepton_fill_get_angle1 (const LeptonFill *fill)
+{
+  g_return_val_if_fail (fill != NULL, 0);
+
+  return fill->angle1;
+}
+
+/*! \brief Set the first angle of a fill.
+ *
+ *  \param [in] fill  The fill.
+ *  \param [in] angle The new fill first angle.
+ */
+void
+lepton_fill_set_angle1 (LeptonFill *fill,
+                        int angle)
+{
+  g_return_if_fail (fill != NULL);
+
+  fill->angle1 = angle;
+}
+
+
+/*! \brief Get the second pitch of a fill.
+ *
+ *  \param [in] fill The fill.
+ *  \return The second pitch of the fill.
+ */
+int
+lepton_fill_get_pitch2 (const LeptonFill *fill)
+{
+  g_return_val_if_fail (fill != NULL, FILLING_HOLLOW);
+
+  return fill->pitch2;
+}
+
+/*! \brief Set the second pitch of a fill.
+ *
+ *  \param [in] fill   The fill.
+ *  \param [in] angle2 The new fill second pitch.
+ */
+void
+lepton_fill_set_pitch2 (LeptonFill *fill,
+                        int pitch)
+{
+  g_return_if_fail (fill != NULL);
+
+  fill->pitch2 = pitch;
+}
+
+
+/*! \brief Get the second angle of a fill.
+ *
+ *  \param [in] fill The fill.
+ *  \return The second angle of the fill.
+ */
+int
+lepton_fill_get_angle2 (const LeptonFill *fill)
+{
+  g_return_val_if_fail (fill != NULL, 0);
+
+  return fill->angle2;
+}
+
+/*! \brief Set the second angle of a fill.
+ *
+ *  \param [in] fill  The fill.
+ *  \param [in] angle The new second angle of the fill.
+ */
+void
+lepton_fill_set_angle2 (LeptonFill *fill,
+                        int angle)
+{
+  g_return_if_fail (fill != NULL);
+
+  fill->angle2 = angle;
+}
+
+
+const char*
+lepton_fill_type_to_string (LeptonFillType fill_type)
+{
+  const char *result = NULL;
+
+  switch (fill_type)
+  {
+  case FILLING_HOLLOW: result = "hollow"; break;
+  case FILLING_FILL:   result = "solid";  break;
+  case FILLING_MESH:   result = "mesh";   break;
+  case FILLING_HATCH:  result = "hatch";  break;
+  default: break;
+  }
+
+  return result;
+}
+
+
+LeptonFillType
+lepton_fill_type_from_string (char *s)
+{
+  LeptonFillType result = FILLING_HOLLOW;
+
+  if      (strcmp (s, "hollow") == 0) { result = FILLING_HOLLOW; }
+  else if (strcmp (s, "solid")  == 0) { result = FILLING_FILL;   }
+  else if (strcmp (s, "mesh")   == 0) { result = FILLING_MESH;   }
+  else if (strcmp (s, "hatch")  == 0) { result = FILLING_HATCH;  }
+
+  return result;
+}
+
+
 /*! \brief Check if the first hatch pattern needs to be drawn
  *
  *  \param [in] fill_type The fill type

--- a/liblepton/src/line_object.c
+++ b/liblepton/src/line_object.c
@@ -124,12 +124,12 @@ lepton_line_object_copy (LeptonObject *o_current)
                                   lepton_object_get_stroke_space_length (o_current));
 
   lepton_object_set_fill_options (new_obj,
-                                  o_current->fill_type,
-                                  o_current->fill_width,
-                                  o_current->fill_pitch1,
-                                  o_current->fill_angle1,
-                                  o_current->fill_pitch2,
-                                  o_current->fill_angle2);
+                                  lepton_object_get_fill_type (o_current),
+                                  lepton_object_get_fill_width (o_current),
+                                  lepton_object_get_fill_pitch1 (o_current),
+                                  lepton_object_get_fill_angle1 (o_current),
+                                  lepton_object_get_fill_pitch2 (o_current),
+                                  lepton_object_get_fill_angle2 (o_current));
 
   return new_obj;
 }

--- a/liblepton/src/object.c
+++ b/liblepton/src/object.c
@@ -506,6 +506,192 @@ lepton_object_set_stroke_space_length (LeptonObject *object,
 }
 
 
+/*! \brief Get the fill of an object.
+ *
+ *  \param [in] object The object.
+ *  \return Object's #LeptonFill pointer.
+ */
+LeptonFill*
+lepton_object_get_fill (const LeptonObject *object)
+{
+  g_return_val_if_fail (object != NULL, NULL);
+
+  return object->fill;
+}
+
+
+/*! \brief Get the fill type of an object.
+ *
+ *  \param [in] object The object.
+ *  \return The fill type of the object.
+ */
+LeptonFillType
+lepton_object_get_fill_type (const LeptonObject *object)
+{
+  g_return_val_if_fail (object != NULL, FILLING_HOLLOW);
+
+  LeptonFill *fill = lepton_object_get_fill (object);
+
+  return lepton_fill_get_type (fill);
+}
+
+/*! \brief Get the fill width of an object.
+ *
+ * \note Fill width is meaningful only for some types of fill.
+ *
+ *  \param [in] object The object.
+ *  \return The fill width of the object.
+ */
+int
+lepton_object_get_fill_width (const LeptonObject *object)
+{
+  g_return_val_if_fail (object != NULL, 0);
+
+  LeptonFill *fill = lepton_object_get_fill (object);
+
+  return lepton_fill_get_width (fill);
+}
+
+/*! \brief Get the first pitch of the fill of an object.
+ *
+ *  \param [in] object The object.
+ *  \return The first pitch of the fill of the object.
+ */
+int
+lepton_object_get_fill_pitch1 (const LeptonObject *object)
+{
+  g_return_val_if_fail (object != NULL, 0);
+
+  LeptonFill *fill = lepton_object_get_fill (object);
+
+  return lepton_fill_get_pitch1 (fill);
+}
+
+/*! \brief Get the first pitch angle of the fill of an object.
+ *
+ *  \param [in] object The object.
+ *  \return The first pitch angle of the fill of the object.
+ */
+int
+lepton_object_get_fill_angle1 (const LeptonObject *object)
+{
+  g_return_val_if_fail (object != NULL, 0);
+
+  LeptonFill *fill = lepton_object_get_fill (object);
+
+  return lepton_fill_get_angle1 (fill);
+}
+
+/*! \brief Get the second pitch of the fill of an object.
+ *
+ *  \param [in] object The object.
+ *  \return The second pitch of the fill of the object.
+ */
+int
+lepton_object_get_fill_pitch2 (const LeptonObject *object)
+{
+  g_return_val_if_fail (object != NULL, 0);
+
+  LeptonFill *fill = lepton_object_get_fill (object);
+
+  return lepton_fill_get_pitch2 (fill);
+}
+
+/*! \brief Get the second pitch angle of the fill of an object.
+ *
+ *  \param [in] object The object.
+ *  \return The second pitch angle of the fill of the object.
+ */
+int
+lepton_object_get_fill_angle2 (const LeptonObject *object)
+{
+  g_return_val_if_fail (object != NULL, 0);
+
+  LeptonFill *fill = lepton_object_get_fill (object);
+
+  return lepton_fill_get_angle2 (fill);
+}
+
+
+void
+lepton_object_set_fill_type (LeptonObject *object,
+                             LeptonFillType fill_type)
+{
+  g_return_if_fail (object != NULL);
+
+  LeptonFill *fill = lepton_object_get_fill (object);
+
+  g_return_if_fail (fill != NULL);
+
+  lepton_fill_set_type (fill, fill_type);
+}
+
+void
+lepton_object_set_fill_width (LeptonObject *object,
+                              int width)
+{
+  g_return_if_fail (object != NULL);
+
+  LeptonFill *fill = lepton_object_get_fill (object);
+
+  g_return_if_fail (fill != NULL);
+
+  lepton_fill_set_width (fill, width);
+}
+
+void
+lepton_object_set_fill_pitch1 (LeptonObject *object,
+                               int pitch)
+{
+  g_return_if_fail (object != NULL);
+
+  LeptonFill *fill = lepton_object_get_fill (object);
+
+  g_return_if_fail (fill != NULL);
+
+  lepton_fill_set_pitch1 (fill, pitch);
+}
+
+void
+lepton_object_set_fill_angle1 (LeptonObject *object,
+                               int angle)
+{
+  g_return_if_fail (object != NULL);
+
+  LeptonFill *fill = lepton_object_get_fill (object);
+
+  g_return_if_fail (fill != NULL);
+
+  lepton_fill_set_angle1 (fill, angle);
+}
+
+void
+lepton_object_set_fill_pitch2 (LeptonObject *object,
+                               int pitch)
+{
+  g_return_if_fail (object != NULL);
+
+  LeptonFill *fill = lepton_object_get_fill (object);
+
+  g_return_if_fail (fill != NULL);
+
+  lepton_fill_set_pitch2 (fill, pitch);
+}
+
+void
+lepton_object_set_fill_angle2 (LeptonObject *object,
+                               int angle)
+{
+  g_return_if_fail (object != NULL);
+
+  LeptonFill *fill = lepton_object_get_fill (object);
+
+  g_return_if_fail (fill != NULL);
+
+  lepton_fill_set_angle2 (fill, angle);
+}
+
+
 /*! \brief Make and return a copy of an object.
  *
  *  \par Function Description
@@ -646,6 +832,9 @@ lepton_object_delete (LeptonObject *o_current)
 
     lepton_stroke_free (o_current->stroke);
     o_current->stroke = NULL;
+
+    lepton_fill_free (o_current->fill);
+    o_current->fill = NULL;
 
     /* printf("sdeleting component_basename\n");*/
     g_free(o_current->component_basename);
@@ -917,14 +1106,14 @@ lepton_object_set_fill_options (LeptonObject *o_current,
 
   lepton_object_emit_pre_change_notify (o_current);
 
-  o_current->fill_type = type;
-  o_current->fill_width = width;
+  lepton_object_set_fill_type (o_current, type);
+  lepton_object_set_fill_width (o_current, width);
 
-  o_current->fill_pitch1 = pitch1;
-  o_current->fill_angle1 = angle1;
+  lepton_object_set_fill_pitch1 (o_current, pitch1);
+  lepton_object_set_fill_angle1 (o_current, angle1);
 
-  o_current->fill_pitch2 = pitch2;
-  o_current->fill_angle2 = angle2;
+  lepton_object_set_fill_pitch2 (o_current, pitch2);
+  lepton_object_set_fill_angle2 (o_current, angle2);
 
   lepton_object_emit_change_notify (o_current);
 }
@@ -958,12 +1147,12 @@ lepton_object_get_fill_options (LeptonObject *object,
       && !lepton_object_is_path (object))
     return FALSE;
 
-  *type = object->fill_type;
-  *width = object->fill_width;
-  *pitch1 = object->fill_pitch1;
-  *angle1 = object->fill_angle1;
-  *pitch2 = object->fill_pitch2;
-  *angle2 = object->fill_angle2;
+  *type = lepton_object_get_fill_type (object);
+  *width = lepton_object_get_fill_width (object);
+  *pitch1 = lepton_object_get_fill_pitch1 (object);
+  *angle1 = lepton_object_get_fill_angle1 (object);
+  *pitch2 = lepton_object_get_fill_pitch2 (object);
+  *angle2 = lepton_object_get_fill_angle2 (object);
 
   return TRUE;
 }
@@ -1617,6 +1806,7 @@ lepton_object_new (int type,
   new_node->conn_list = NULL;
 
   new_node->stroke = lepton_stroke_new ();
+  new_node->fill = lepton_fill_new ();
 
   new_node->component_basename = NULL;
   new_node->parent = NULL;
@@ -1628,12 +1818,6 @@ lepton_object_new (int type,
   new_node->selected = FALSE;
 
   new_node->bus_ripper_direction = 0;
-
-  new_node->fill_width = 0;
-  new_node->fill_angle1 = 0;
-  new_node->fill_angle2 = 0;
-  new_node->fill_pitch1 = 0;
-  new_node->fill_pitch2 = 0;
 
   new_node->attribs = NULL;
   new_node->attached_to = NULL;

--- a/liblepton/src/path_object.c
+++ b/liblepton/src/path_object.c
@@ -139,12 +139,12 @@ lepton_path_object_copy (LeptonObject *o_current)
                                   lepton_object_get_stroke_dash_length (o_current),
                                   lepton_object_get_stroke_space_length (o_current));
   lepton_object_set_fill_options (new_obj,
-                                  o_current->fill_type,
-                                  o_current->fill_width,
-                                  o_current->fill_pitch1,
-                                  o_current->fill_angle1,
-                                  o_current->fill_pitch2,
-                                  o_current->fill_angle2);
+                                  lepton_object_get_fill_type (o_current),
+                                  lepton_object_get_fill_width (o_current),
+                                  lepton_object_get_fill_pitch1 (o_current),
+                                  lepton_object_get_fill_angle1 (o_current),
+                                  lepton_object_get_fill_pitch2 (o_current),
+                                  lepton_object_get_fill_angle2 (o_current));
 
   /* return the new tail of the object list */
   return new_obj;
@@ -292,12 +292,12 @@ lepton_path_object_to_buffer (const LeptonObject *object)
   line_space  = lepton_object_get_stroke_space_length (object);
 
   /* filling parameters */
-  fill_type    = object->fill_type;
-  fill_width   = object->fill_width;
-  angle1       = object->fill_angle1;
-  pitch1       = object->fill_pitch1;
-  angle2       = object->fill_angle2;
-  pitch2       = object->fill_pitch2;
+  fill_type    = lepton_object_get_fill_type (object);
+  fill_width   = lepton_object_get_fill_width (object);
+  angle1       = lepton_object_get_fill_angle1 (object);
+  pitch1       = lepton_object_get_fill_pitch1 (object);
+  angle2       = lepton_object_get_fill_angle2 (object);
+  pitch2       = lepton_object_get_fill_pitch2 (object);
 
   path_string = s_path_string_from_path (object->path);
   num_lines = o_text_num_lines (path_string);
@@ -621,7 +621,8 @@ lepton_path_object_shortest_distance (LeptonObject *object,
 {
   int solid;
 
-  solid = force_solid || object->fill_type != FILLING_HOLLOW;
+  solid = force_solid ||
+    lepton_object_get_fill_type (object) != FILLING_HOLLOW;
 
   return s_path_shortest_distance (object->path, x, y, solid);
 }

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -146,106 +146,6 @@ edascm_is_object_type (SCM smob, int type)
 }
 
 
-/*! \brief Set the fill properties of an object.
- * \par Function Description
-
- * Updates the fill settings of the object \a obj_s.  If \a obj_s is
- * not a box, circle, or path, throws a Scheme error.  The optional
- * parameters \a width_s, \a angle1_s, \a space1_s, \a angle2_s and
- * space2_s
- *
- * \note Scheme API: Implements the %object-fill procedure in the
- * (lepton core object) module.
- *
- * \param obj_s object to set fill settings for.
- * \return \a obj_s.
- */
-SCM_DEFINE (set_object_fill_x, "%set-object-fill!", 2, 5, 0,
-            (SCM obj_s, SCM type_s, SCM width_s, SCM space1_s, SCM angle1_s,
-             SCM space2_s, SCM angle2_s),
-            "Set the fill properties of an object.")
-{
-  SCM_ASSERT ((edascm_is_object_type (obj_s, OBJ_BOX)
-               || edascm_is_object_type (obj_s, OBJ_CIRCLE)
-               || edascm_is_object_type (obj_s, OBJ_PATH)),
-              obj_s, SCM_ARG1, s_set_object_fill_x);
-
-  LeptonObject *obj = edascm_to_object (obj_s);
-  int type, width = -1, angle1 = -1, space1 = -1, angle2 = -1, space2 = -1;
-
-  if      (scm_is_eq (type_s, hollow_sym)) { type = FILLING_HOLLOW;   }
-  else if (scm_is_eq (type_s, solid_sym))  { type = FILLING_FILL; }
-  else if (scm_is_eq (type_s, hatch_sym))  { type = FILLING_HATCH;  }
-  else if (scm_is_eq (type_s, mesh_sym))   { type = FILLING_MESH;  }
-  else {
-    scm_misc_error (s_set_object_fill_x,
-                    _("Invalid fill style ~A."),
-                    scm_list_1 (type_s));
-  }
-
-  switch (type) {
-  case FILLING_MESH:
-    if (!edascm_is_defined (space2_s)) {
-      scm_misc_error (s_set_object_fill_x,
-                      _("Missing second space parameter for fill style ~A."),
-                      scm_list_1 (space2_s));
-    }
-    SCM_ASSERT (scm_is_integer (space2_s), space2_s,
-                SCM_ARG6, s_set_object_fill_x);
-    space2 = scm_to_int (space2_s);
-
-    if (!edascm_is_defined (angle2_s)) {
-      scm_misc_error (s_set_object_fill_x,
-                      _("Missing second angle parameter for fill style ~A."),
-                      scm_list_1 (angle2_s));
-    }
-    SCM_ASSERT (scm_is_integer (angle2_s), angle2_s,
-                SCM_ARG7, s_set_object_fill_x);
-    angle2 = scm_to_int (angle2_s);
-    /* This case intentionally falls through */
-  case FILLING_HATCH:
-    if (!edascm_is_defined (width_s)) {
-      scm_misc_error (s_set_object_fill_x,
-                      _("Missing stroke width parameter for fill style ~A."),
-                      scm_list_1 (width_s));
-    }
-    SCM_ASSERT (scm_is_integer (width_s), width_s,
-                SCM_ARG3, s_set_object_fill_x);
-    width = scm_to_int (width_s);
-
-    if (!edascm_is_defined (space1_s)) {
-      scm_misc_error (s_set_object_fill_x,
-                      _("Missing space parameter for fill style ~A."),
-                      scm_list_1 (space1_s));
-    }
-    SCM_ASSERT (scm_is_integer (space1_s), space1_s,
-                SCM_ARG4, s_set_object_fill_x);
-    space1 = scm_to_int (space1_s);
-
-    if (!edascm_is_defined(angle1_s)) {
-      scm_misc_error (s_set_object_fill_x,
-                      _("Missing angle parameter for fill style ~A."),
-                      scm_list_1 (angle1_s));
-    }
-    SCM_ASSERT (scm_is_integer (angle1_s), angle1_s,
-                SCM_ARG5, s_set_object_fill_x);
-    angle1 = scm_to_int (angle1_s);
-    /* This case intentionally falls through */
-  }
-
-  lepton_object_set_fill_options (obj,
-                                  (LeptonFillType) type,
-                                  width,
-                                  space1,
-                                  angle1,
-                                  space2,
-                                  angle2);
-  lepton_object_page_set_changed (obj);
-
-  return obj_s;
-}
-
-
 /*! \brief Create a new line.
  * \par Function Description
  * Creates a new line object, with all its parameters set to default
@@ -1415,8 +1315,7 @@ init_module_lepton_core_object (void *unused)
   #include "scheme_object.x"
 
   /* Add them to the module's public definitions. */
-  scm_c_export (s_set_object_fill_x,
-                s_make_line,
+  scm_c_export (s_make_line,
                 s_make_net,
                 s_make_bus,
                 s_make_pin,

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -45,11 +45,6 @@ SCM_SYMBOL (name_sym , "name");
 SCM_SYMBOL (value_sym , "value");
 SCM_SYMBOL (both_sym , "both");
 
-SCM_SYMBOL (solid_sym , "solid");
-SCM_SYMBOL (hollow_sym , "hollow");
-SCM_SYMBOL (mesh_sym , "mesh");
-SCM_SYMBOL (hatch_sym , "hatch");
-
 SCM_SYMBOL (moveto_sym , "moveto");
 SCM_SYMBOL (lineto_sym , "lineto");
 SCM_SYMBOL (curveto_sym , "curveto");

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -28,7 +28,6 @@
 #include "liblepton_priv.h"
 #include "libleptonguile_priv.h"
 
-SCM_SYMBOL (wrong_type_arg_sym , "wrong-type-arg");
 SCM_SYMBOL (net_sym , "net");
 SCM_SYMBOL (bus_sym , "bus");
 

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -145,72 +145,6 @@ edascm_is_object_type (SCM smob, int type)
   return (lepton_object_get_type (obj) == type);
 }
 
-/*! \brief Get the fill properties of an object.
- * \par Function Description
- * Returns the fill settings of the object \a obj_s.  If \a obj_s is
- * not a box, circle, or path, throws a Scheme error.  The return
- * value is a list of parameters:
- *
- * -# fill style (a symbol: hollow, solid, mesh or hatch)
- * -# up to five fill parameters, depending on fill style:
- *   -# none for hollow or solid fills
- *   -# line width, line angle, and line spacing for hatch fills.
- *   -# line width, first angle and spacing, and second angle and
- *      spacing for mesh fills.
- *
- * \note Scheme API: Implements the %object-fill procedure in the
- * (lepton core object) module.
- *
- * \param obj_s object to get fill settings for.
- * \return a list of fill parameters.
- */
-SCM_DEFINE (object_fill, "%object-fill", 1, 0, 0,
-            (SCM obj_s), "Get the fill properties of an object.")
-{
-  SCM_ASSERT ((edascm_is_object_type (obj_s, OBJ_BOX)
-               || edascm_is_object_type (obj_s, OBJ_CIRCLE)
-               || edascm_is_object_type (obj_s, OBJ_PATH)),
-              obj_s, SCM_ARG1, s_object_fill);
-
-  LeptonObject *obj = edascm_to_object (obj_s);
-
-  int type, width, pitch1, angle1, pitch2, angle2;
-  lepton_object_get_fill_options (obj,
-                                  (LeptonFillType *) &type,
-                                  &width,
-                                  &pitch1,
-                                  &angle1,
-                                  &pitch2,
-                                  &angle2);
-
-  SCM width_s = scm_from_int (width);
-  SCM pitch1_s = scm_from_int (pitch1);
-  SCM angle1_s = scm_from_int (angle1);
-  SCM pitch2_s = scm_from_int (pitch2);
-  SCM angle2_s = scm_from_int (angle2);
-
-  SCM type_s;
-  switch (type) {
-  case FILLING_HOLLOW: type_s = hollow_sym; break;
-  case FILLING_FILL: type_s = solid_sym; break;
-  case FILLING_MESH: type_s = mesh_sym; break;
-  case FILLING_HATCH: type_s = hatch_sym; break;
-  default:
-    scm_misc_error (s_object_fill,
-                    _("Object ~A has invalid fill style ~A"),
-                    scm_list_2 (obj_s, scm_from_int (type)));
-  }
-
-  switch (type) {
-  case FILLING_MESH:
-    return scm_list_n (type_s, width_s, pitch1_s, angle1_s, pitch2_s, angle2_s,
-                       SCM_UNDEFINED);
-  case FILLING_HATCH:
-    return scm_list_4 (type_s, width_s, pitch1_s, angle1_s);
-  default:
-    return scm_list_1 (type_s);
-  }
-}
 
 /*! \brief Set the fill properties of an object.
  * \par Function Description
@@ -1481,8 +1415,7 @@ init_module_lepton_core_object (void *unused)
   #include "scheme_object.x"
 
   /* Add them to the module's public definitions. */
-  scm_c_export (s_object_fill,
-                s_set_object_fill_x,
+  scm_c_export (s_set_object_fill_x,
                 s_make_line,
                 s_make_net,
                 s_make_bus,


### PR DESCRIPTION
- Introduce new type for object filling: `LeptonFill`.  It encapsulates all filling properties for which several fields of `LeptonObject` were previously used.
- Add accessors for those properties.
- As always, get rid of Scheme-in-C code related to object filling.
- Add more tests.
- Add docstrings to new Scheme functions.