### PR TITLE
Rewrite Scheme-in-C functions related to linear primitives using Scheme FFI

### DIFF
--- a/liblepton/include/liblepton/object.h
+++ b/liblepton/include/liblepton/object.h
@@ -337,4 +337,7 @@ lepton_object_emit_pre_change_notify (LeptonObject *object);
 void
 lepton_object_emit_change_notify (LeptonObject *object);
 
+int
+lepton_object_get_whichend (LeptonObject *object);
+
 G_END_DECLS

--- a/liblepton/include/liblepton/pin_object.h
+++ b/liblepton/include/liblepton/pin_object.h
@@ -101,9 +101,9 @@ void
 lepton_pin_object_update_whichend (GList *object_list,
                                    int num_pins);
 LeptonObject*
-o_pin_read (const char buf[],
-            unsigned int release_ver,
-            unsigned int fileformat_ver,
-            GError **err);
+lepton_pin_object_read (const char buf[],
+                        unsigned int release_ver,
+                        unsigned int fileformat_ver,
+                        GError **err);
 
 G_END_DECLS

--- a/liblepton/include/liblepton/pin_object.h
+++ b/liblepton/include/liblepton/pin_object.h
@@ -51,6 +51,13 @@ lepton_pin_object_new_bus_pin (int color,
 LeptonObject*
 lepton_pin_object_copy (LeptonObject *o_current);
 
+/* Helpers. */
+gboolean
+lepton_pin_object_is_bus_pin (const LeptonObject *object);
+
+gboolean
+lepton_pin_object_is_net_pin (const LeptonObject *object);
+
 /* methods */
 
 void

--- a/liblepton/include/liblepton/pin_object.h
+++ b/liblepton/include/liblepton/pin_object.h
@@ -35,6 +35,20 @@ lepton_pin_object_new (int color,
                        int pin_type,
                        int whichend);
 LeptonObject*
+lepton_pin_object_new_net_pin (int color,
+                               int x1,
+                               int y1,
+                               int x2,
+                               int y2,
+                               int whichend);
+LeptonObject*
+lepton_pin_object_new_bus_pin (int color,
+                               int x1,
+                               int y1,
+                               int x2,
+                               int y2,
+                               int whichend);
+LeptonObject*
 lepton_pin_object_copy (LeptonObject *o_current);
 
 /* methods */

--- a/liblepton/scheme/Makefile.am
+++ b/liblepton/scheme/Makefile.am
@@ -154,6 +154,7 @@ TESTS = \
 	unit-tests/lepton-page-parse-ordering.scm \
 	unit-tests/lepton-page-parse-unterminated-attrib.scm \
 	unit-tests/lepton-page-string.scm \
+	unit-tests/lepton-pin-whichend.scm \
 	unit-tests/lepton-promotable-attribs.scm \
 	unit-tests/lepton-rc-build-path.scm \
 	unit-tests/lepton-version.scm \

--- a/liblepton/scheme/lepton/ffi.scm.in
+++ b/liblepton/scheme/lepton/ffi.scm.in
@@ -109,6 +109,8 @@
             lepton_component_object_embed
             lepton_component_object_unembed
 
+            lepton_line_object_new
+
             lepton_picture_object_get_embedded
             lepton_picture_object_embed
             lepton_picture_object_unembed
@@ -260,6 +262,8 @@
 (define-lff lepton_component_object_get_embedded int '(*))
 (define-lff lepton_component_object_embed void '(*))
 (define-lff lepton_component_object_unembed void '(*))
+
+(define-lff lepton_line_object_new '* (list int int int int int))
 
 (define-lff lepton_picture_object_get_embedded int '(*))
 (define-lff lepton_picture_object_embed void '(*))

--- a/liblepton/scheme/lepton/ffi.scm.in
+++ b/liblepton/scheme/lepton/ffi.scm.in
@@ -124,6 +124,8 @@
             lepton_picture_object_embed
             lepton_picture_object_unembed
 
+            lepton_pin_object_is_bus_pin
+            lepton_pin_object_is_net_pin
             lepton_pin_object_new_bus_pin
             lepton_pin_object_new_net_pin
 
@@ -291,6 +293,8 @@
 (define-lff lepton_picture_object_embed void '(*))
 (define-lff lepton_picture_object_unembed void '(*))
 
+(define-lff lepton_pin_object_is_bus_pin int '(*))
+(define-lff lepton_pin_object_is_net_pin int '(*))
 (define-lff lepton_pin_object_new_bus_pin '* (list int int int int int int))
 (define-lff lepton_pin_object_new_net_pin '* (list int int int int int int))
 

--- a/liblepton/scheme/lepton/ffi.scm.in
+++ b/liblepton/scheme/lepton/ffi.scm.in
@@ -111,6 +111,8 @@
 
             lepton_line_object_new
 
+            lepton_net_object_new
+
             lepton_picture_object_get_embedded
             lepton_picture_object_embed
             lepton_picture_object_unembed
@@ -264,6 +266,8 @@
 (define-lff lepton_component_object_unembed void '(*))
 
 (define-lff lepton_line_object_new '* (list int int int int int))
+
+(define-lff lepton_net_object_new '* (list int int int int int))
 
 (define-lff lepton_picture_object_get_embedded int '(*))
 (define-lff lepton_picture_object_embed void '(*))

--- a/liblepton/scheme/lepton/ffi.scm.in
+++ b/liblepton/scheme/lepton/ffi.scm.in
@@ -124,6 +124,9 @@
             lepton_picture_object_embed
             lepton_picture_object_unembed
 
+            lepton_pin_object_new_bus_pin
+            lepton_pin_object_new_net_pin
+
             lepton_fill_type_from_string
             lepton_fill_type_to_string
 
@@ -287,6 +290,9 @@
 (define-lff lepton_picture_object_get_embedded int '(*))
 (define-lff lepton_picture_object_embed void '(*))
 (define-lff lepton_picture_object_unembed void '(*))
+
+(define-lff lepton_pin_object_new_bus_pin '* (list int int int int int int))
+(define-lff lepton_pin_object_new_net_pin '* (list int int int int int int))
 
 (define-lff lepton_fill_type_from_string int '(*))
 (define-lff lepton_fill_type_to_string '* (list int))

--- a/liblepton/scheme/lepton/ffi.scm.in
+++ b/liblepton/scheme/lepton/ffi.scm.in
@@ -105,6 +105,8 @@
             lepton_box_object_set_lower_y
             lepton_box_object_new
 
+            lepton_bus_object_new
+
             lepton_component_object_get_embedded
             lepton_component_object_embed
             lepton_component_object_unembed
@@ -260,6 +262,8 @@
 (define-lff lepton_box_object_get_lower_y int '(*))
 (define-lff lepton_box_object_set_lower_y void (list '* int))
 (define-lff lepton_box_object_new '* (list int int int int int))
+
+(define-lff lepton_bus_object_new '* (list int int int int int int))
 
 (define-lff lepton_component_object_get_embedded int '(*))
 (define-lff lepton_component_object_embed void '(*))

--- a/liblepton/scheme/lepton/ffi.scm.in
+++ b/liblepton/scheme/lepton/ffi.scm.in
@@ -48,6 +48,7 @@
             lepton_object_get_fill_width
             lepton_object_set_fill_options
             lepton_object_get_id
+            lepton_object_get_page
             lepton_object_get_parent
             lepton_object_get_selectable
             lepton_object_set_selectable
@@ -106,6 +107,7 @@
             lepton_box_object_set_lower_y
             lepton_box_object_new
 
+            lepton_bus_object_modify
             lepton_bus_object_new
 
             lepton_component_object_get_embedded
@@ -116,8 +118,10 @@
             lepton_line_object_get_y0
             lepton_line_object_get_x1
             lepton_line_object_get_y1
+            lepton_line_object_modify
             lepton_line_object_new
 
+            lepton_net_object_modify
             lepton_net_object_new
 
             lepton_picture_object_get_embedded
@@ -128,6 +132,7 @@
             lepton_pin_object_is_net_pin
             lepton_pin_object_new_bus_pin
             lepton_pin_object_new_net_pin
+            lepton_pin_object_modify
 
             lepton_fill_type_from_string
             lepton_fill_type_to_string
@@ -152,6 +157,10 @@
             s_clib_add_directory
             s_clib_add_scm
             s_clib_init
+
+            s_conn_remove_object_connections
+            s_conn_update_object
+
             s_toplevel_page_current))
 
 ;;; Helper to check if result of C function is TRUE (non-zero).
@@ -214,6 +223,7 @@
 (define-lff lepton_object_get_fill_width int '(*))
 (define-lff lepton_object_set_fill_options void (list '* int int int int int int))
 (define-lff lepton_object_get_id int '(*))
+(define-lff lepton_object_get_page '* '(*))
 (define-lff lepton_object_get_parent '* '(*))
 (define-lff lepton_object_get_selectable int '(*))
 (define-lff lepton_object_set_selectable void (list '* int))
@@ -274,6 +284,7 @@
 (define-lff lepton_box_object_set_lower_y void (list '* int))
 (define-lff lepton_box_object_new '* (list int int int int int))
 
+(define-lff lepton_bus_object_modify void (list '* int int int))
 (define-lff lepton_bus_object_new '* (list int int int int int int))
 
 (define-lff lepton_component_object_get_embedded int '(*))
@@ -284,9 +295,10 @@
 (define-lff lepton_line_object_get_y0 int '(*))
 (define-lff lepton_line_object_get_x1 int '(*))
 (define-lff lepton_line_object_get_y1 int '(*))
-
+(define-lff lepton_line_object_modify void (list '* int int int))
 (define-lff lepton_line_object_new '* (list int int int int int))
 
+(define-lff lepton_net_object_modify void (list '* int int int))
 (define-lff lepton_net_object_new '* (list int int int int int))
 
 (define-lff lepton_picture_object_get_embedded int '(*))
@@ -297,6 +309,7 @@
 (define-lff lepton_pin_object_is_net_pin int '(*))
 (define-lff lepton_pin_object_new_bus_pin '* (list int int int int int int))
 (define-lff lepton_pin_object_new_net_pin '* (list int int int int int int))
+(define-lff lepton_pin_object_modify void (list '* int int int))
 
 (define-lff lepton_fill_type_from_string int '(*))
 (define-lff lepton_fill_type_to_string '* (list int))
@@ -306,6 +319,9 @@
 (define-lff lepton_stroke_type_from_string int '(*))
 (define-lff lepton_stroke_type_to_string '* (list int))
 
+;; s_conn.c
+(define-lff s_conn_remove_object_connections void '(*))
+(define-lff s_conn_update_object void '(* *))
 
 (define-syntax-rule (check-integer val pos)
   (unless (integer? val)

--- a/liblepton/scheme/lepton/ffi.scm.in
+++ b/liblepton/scheme/lepton/ffi.scm.in
@@ -62,6 +62,7 @@
             lepton_object_get_stroke_space_length
             lepton_object_set_stroke_space_length
             lepton_object_get_type
+            lepton_object_get_whichend
 
             lepton_object_is_arc
             lepton_object_is_box
@@ -111,6 +112,10 @@
             lepton_component_object_embed
             lepton_component_object_unembed
 
+            lepton_line_object_get_x0
+            lepton_line_object_get_y0
+            lepton_line_object_get_x1
+            lepton_line_object_get_y1
             lepton_line_object_new
 
             lepton_net_object_new
@@ -218,6 +223,7 @@
 (define-lff lepton_object_get_stroke_space_length int '(*))
 (define-lff lepton_object_set_stroke_space_length void (list '* int))
 (define-lff lepton_object_get_type int '(*))
+(define-lff lepton_object_get_whichend int '(*))
 
 (define-lff lepton_object_is_arc int '(*))
 (define-lff lepton_object_is_box int '(*))
@@ -268,6 +274,11 @@
 (define-lff lepton_component_object_get_embedded int '(*))
 (define-lff lepton_component_object_embed void '(*))
 (define-lff lepton_component_object_unembed void '(*))
+
+(define-lff lepton_line_object_get_x0 int '(*))
+(define-lff lepton_line_object_get_y0 int '(*))
+(define-lff lepton_line_object_get_x1 int '(*))
+(define-lff lepton_line_object_get_y1 int '(*))
 
 (define-lff lepton_line_object_new '* (list int int int int int))
 

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -250,6 +250,10 @@ values."
 
 
 (define (line-start object)
+  "Returns the coordinate of the start of linear OBJECT (which may
+be a line, net, bus, or pin object) as a pair '(x . y).  For pin
+objects, this is the position of the connectable point on the
+pin."
   (define pointer (geda-object->pointer* object 1 linear-object? 'line))
 
   (define swap-coords? (pin-swap-whichend? object))
@@ -261,6 +265,10 @@ values."
 
 
 (define (line-end object)
+  "Returns the coordinate of the end of linear OBJECT (which may
+be a line, net, bus, or pin object) as a pair '(x . y).  For pin
+objects, this is the position of the non-connectable point on the
+pin."
   (define pointer (geda-object->pointer* object 1 linear-object? 'line))
 
   (define swap-coords? (pin-swap-whichend? object))

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -65,7 +65,9 @@
             box-bottom-right
             box-top-left
             make-box
-            set-box!)
+            set-box!
+
+            make-line)
 
   #:re-export (arc?
                box?
@@ -143,9 +145,22 @@ If OBJECT is not part of a component, returns #f."
                   (object-color l)
                   color)))
 
-(define*-public (make-line start end #:optional color)
-  (let ((l (%make-line)))
-    (set-line! l start end color)))
+(define* (make-line start end #:optional color)
+  "Make and return a new line object with given START and END
+coordinates and given COLOR.  The coordinates must be pairs of the
+form '(x . y).  All its other parameters are set to default
+values."
+  (check-coord start 1)
+  (check-coord end 2)
+  (and color (check-integer color 3))
+
+  (let ((x1 (car start))
+        (y1 (cdr start))
+        (x2 (car end))
+        (y2 (cdr end))
+        (color (or color (default_color_id))))
+    (pointer->geda-object
+     (lepton_line_object_new color x1 y1 x2 y2))))
 
 (define-public (line-info l)
   (let ((params (%line-info l)))

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -236,24 +236,20 @@ coordinate of the end of the line, and colormap index of color to
 be used for drawing the line.  This function works on line, net,
 bus, and pin objects.  For pins, the start is the connectible
 point on the pin."
-  (define pointer (geda-object->pointer* object 1))
+  (define pointer (geda-object->pointer* object 1 linear-object? 'line))
 
-  (and (or (line? object)
-           (net? object)
-           (bus? object)
-           (pin? object))
-       (let ((x0 (lepton_line_object_get_x0 pointer))
-             (y0 (lepton_line_object_get_y0 pointer))
-             (x1 (lepton_line_object_get_x1 pointer))
-             (y1 (lepton_line_object_get_y1 pointer))
-             (color (lepton_object_get_color pointer))
-             (whichend (true? (lepton_object_get_whichend pointer))))
+  (let ((x0 (lepton_line_object_get_x0 pointer))
+        (y0 (lepton_line_object_get_y0 pointer))
+        (x1 (lepton_line_object_get_x1 pointer))
+        (y1 (lepton_line_object_get_y1 pointer))
+        (color (lepton_object_get_color pointer))
+        (whichend (true? (lepton_object_get_whichend pointer))))
 
-         (if (and (pin? object)
-                  whichend)
-             ;; Swap ends according to pin's whichend flag.
-             (list (cons x1 y1) (cons x0 y0) color)
-             (list (cons x0 y0) (cons x1 y1) color)))))
+    (if (and (pin? object)
+             whichend)
+        ;; Swap ends according to pin's whichend flag.
+        (list (cons x1 y1) (cons x0 y0) color)
+        (list (cons x0 y0) (cons x1 y1) color))))
 
 (define (line-start l)
   (list-ref (line-info l) 0))

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -29,6 +29,8 @@
   ;; Import C procedures
   #:use-module (lepton core component)
   #:use-module (lepton core object)
+
+  #:use-module (lepton color-map)
   #:use-module (lepton ffi)
   #:use-module (lepton object type)
 
@@ -67,7 +69,9 @@
             make-box
             set-box!
 
-            make-line)
+            make-line
+
+            make-net)
 
   #:re-export (arc?
                box?
@@ -179,9 +183,22 @@ values."
 
 ;;;; Nets
 
-(define*-public (make-net start end #:optional color)
-  (let ((l (%make-net)))
-    (set-line! l start end color)))
+(define* (make-net start end #:optional color)
+  "Make and return a new net object with given START and END
+coordinates and given COLOR.  The coordinates must be pairs of the
+form '(x . y).  All its other parameters are set to default
+values."
+  (check-coord start 1)
+  (check-coord end 2)
+  (and color (check-integer color 3))
+
+  (let ((x1 (car start))
+        (y1 (cdr start))
+        (x2 (car end))
+        (y2 (cdr end))
+        (color (or color (color-map-name-to-index 'net))))
+    (pointer->geda-object
+     (lepton_net_object_new color x1 y1 x2 y2))))
 
 
 ;;;; Buses

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -71,6 +71,7 @@
 
             make-bus
 
+            line-info
             make-line
             set-line!
 
@@ -224,7 +225,7 @@ values."
      (lepton_line_object_new color x1 y1 x2 y2))))
 
 
-(define-public (line-info object)
+(define (line-info object)
   "Retrieves and returns parameters of line OBJECT as a list of
 the form '((X0 . Y0) (X1 . Y1) COLOR). The return list includes
 parameters as follows: coordinate of the start of the line,

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -69,6 +69,8 @@
             make-box
             set-box!
 
+            make-bus
+
             make-line
 
             make-net)
@@ -203,9 +205,23 @@ values."
 
 ;;;; Buses
 
-(define*-public (make-bus start end #:optional color)
-  (let ((l (%make-bus)))
-    (set-line! l start end color)))
+(define* (make-bus start end #:optional color)
+  "Make and return a new bus object with given START and END
+coordinates and given COLOR.  The coordinates must be pairs of the
+form '(x . y).  All its other parameters are set to default
+values."
+  (check-coord start 1)
+  (check-coord end 2)
+  (and color (check-integer color 3))
+
+  (let ((x1 (car start))
+        (y1 (cdr start))
+        (x2 (car end))
+        (y2 (cdr end))
+        (color (or color (color-map-name-to-index 'bus)))
+        (ripper-direction 0))
+    (pointer->geda-object
+     (lepton_bus_object_new color x1 y1 x2 y2 ripper-direction))))
 
 
 ;;;; Pins

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -73,7 +73,10 @@
 
             make-line
 
-            make-net)
+            make-net
+
+            make-bus-pin
+            make-net-pin)
 
   #:re-export (arc?
                box?
@@ -252,13 +255,64 @@ values."
 (define-public (bus-pin? l)
   (and (pin? l) (equal? (%pin-type l) 'bus)))
 
-(define*-public (make-net-pin start end #:optional color)
-  (let ((l (%make-pin 'net)))
-    (set-line! l start end color)))
+(define* (make-net-pin start end #:optional color)
+  "Creates and returns a new net pin object with given parameters.
+START is the position of the start of the new pin (its connectible
+end) in the form '(x . y) and END is the position of the end of
+the pin.  If COLOR is specified, it should be the integer color
+map index of the color with which to draw the pin.  If COLOR is
+not specified, the default pin color is used."
+  (check-coord start 1)
+  (check-coord end 2)
+  (and color (check-integer color 3))
 
-(define*-public (make-bus-pin start end #:optional color)
-  (let ((l (%make-pin 'bus)))
-    (set-line! l start end color)))
+  (let* ((init-color (color-map-name-to-index 'pin))
+         (init-start-x 0)
+         (init-start-y 0)
+         (init-end-x 0)
+         (init-end-y 0)
+         (init-whichend 0)
+         (object (pointer->geda-object
+                  (lepton_pin_object_new_net_pin init-color
+                                                 init-start-x
+                                                 init-start-y
+                                                 init-end-x
+                                                 init-end-y
+                                                 init-whichend))))
+    (set-line! object
+               start
+               end
+               (or color init-color))))
+
+(define* (make-bus-pin start end #:optional color)
+  "Creates and returns a new bus pin object with given parameters.
+START is the position of the start of the new pin (its connectible
+end) in the form '(x . y) and END is the position of the end of
+the pin.  If COLOR is specified, it should be the integer color
+map index of the color with which to draw the pin.  If COLOR is
+not specified, the default pin color is used."
+  (check-coord start 1)
+  (check-coord end 2)
+  (and color (check-integer color 3))
+
+  (let* ((init-color (color-map-name-to-index 'pin))
+         (init-start-x 0)
+         (init-start-y 0)
+         (init-end-x 0)
+         (init-end-y 0)
+         (init-whichend 0)
+         (object (pointer->geda-object
+                  (lepton_pin_object_new_bus_pin init-color
+                                                 init-start-x
+                                                 init-start-y
+                                                 init-end-x
+                                                 init-end-y
+                                                 init-whichend))))
+    (set-line! object
+               start
+               end
+               (or color init-color))))
+
 
 
 ;;;; Boxes

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -88,6 +88,8 @@
                path?
                picture?
                pin?
+               bus-pin?
+               net-pin?
                text?
 
                object?
@@ -248,12 +250,6 @@ values."
 
 
 ;;;; Pins
-
-(define-public (net-pin? l)
-  (and (pin? l) (equal? (%pin-type l) 'net)))
-
-(define-public (bus-pin? l)
-  (and (pin? l) (equal? (%pin-type l) 'bus)))
 
 (define* (make-net-pin start end #:optional color)
   "Creates and returns a new net pin object with given parameters.

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -152,6 +152,13 @@ If OBJECT is not part of a component, returns #f."
 
 ;;;; Lines
 
+;;; Checks if OBJECT consist of a line segment.
+(define (linear-object? object)
+  (or (line? object)
+      (net? object)
+      (bus? object)
+      (pin? object)))
+
 (define* (set-line! object start end #:optional color)
   "Sets the parameters of line OBJECT (which may be a line, net,
 bus or pin object). START is the position of the start of the new
@@ -160,14 +167,8 @@ the line.  For pins,the start is the connectable point on the
 pin.  If COLOR is specified, it should be the integer color map
 index of the color with which to draw the line.  If COLOR is not
 specified, the default line color is used.  Returns OBJECT."
+  (define pointer (geda-object->pointer* object 1 linear-object? 'line))
 
-  (define (line-object? object)
-    (or (line? object)
-        (net? object)
-        (bus? object)
-        (pin? object)))
-
-  (define pointer (geda-object->pointer* object 1 line-object? 'line))
   (check-coord start 2)
   (check-coord end 3)
   (and color (check-integer color 4))

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -168,13 +168,33 @@ values."
     (pointer->geda-object
      (lepton_line_object_new color x1 y1 x2 y2))))
 
-(define-public (line-info l)
-  (let ((params (%line-info l)))
-    (list (cons (list-ref params 0)
-                (list-ref params 1))
-          (cons (list-ref params 2)
-                (list-ref params 3))
-          (list-ref params 4))))
+
+(define-public (line-info object)
+  "Retrieves and returns parameters of line OBJECT as a list of
+the form '((X0 . Y0) (X1 . Y1) COLOR). The return list includes
+parameters as follows: coordinate of the start of the line,
+coordinate of the end of the line, and colormap index of color to
+be used for drawing the line.  This function works on line, net,
+bus, and pin objects.  For pins, the start is the connectible
+point on the pin."
+  (define pointer (geda-object->pointer* object 1))
+
+  (and (or (line? object)
+           (net? object)
+           (bus? object)
+           (pin? object))
+       (let ((x0 (lepton_line_object_get_x0 pointer))
+             (y0 (lepton_line_object_get_y0 pointer))
+             (x1 (lepton_line_object_get_x1 pointer))
+             (y1 (lepton_line_object_get_y1 pointer))
+             (color (lepton_object_get_color pointer))
+             (whichend (true? (lepton_object_get_whichend pointer))))
+
+         (if (and (pin? object)
+                  whichend)
+             ;; Swap ends according to pin's whichend flag.
+             (list (cons x1 y1) (cons x0 y0) color)
+             (list (cons x0 y0) (cons x1 y1) color)))))
 
 (define-public (line-start l)
   (list-ref (line-info l) 0))

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -71,7 +71,9 @@
 
             make-bus
 
+            line-end
             line-info
+            line-start
             make-line
             set-line!
 
@@ -252,10 +254,10 @@ point on the pin."
              (list (cons x1 y1) (cons x0 y0) color)
              (list (cons x0 y0) (cons x1 y1) color)))))
 
-(define-public (line-start l)
+(define (line-start l)
   (list-ref (line-info l) 0))
 
-(define-public (line-end l)
+(define (line-end l)
   (list-ref (line-info l) 1))
 
 

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -176,7 +176,8 @@ specified, the default line color is used.  Returns OBJECT."
   ;; We may need to update connectivity.
   (s_conn_remove_object_connections pointer)
 
-  (let ((x1 (car start))
+  (let ((info (line-info object))
+        (x1 (car start))
         (y1 (cdr start))
         (x2 (car end))
         (y2 (cdr end))
@@ -206,7 +207,8 @@ specified, the default line color is used.  Returns OBJECT."
       (unless (null-pointer? page)
         (s_conn_update_object page pointer)
 
-        (lepton_object_page_set_changed pointer))
+        (unless (equal? info (line-info object))
+          (lepton_object_page_set_changed pointer)))
 
       object)))
 

--- a/liblepton/scheme/lepton/object/type.scm
+++ b/liblepton/scheme/lepton/object/type.scm
@@ -36,6 +36,8 @@
             path?
             picture?
             pin?
+            net-pin?
+            bus-pin?
             text?
 
             object?
@@ -148,6 +150,21 @@ returns #f."
 (define (pin? object)
   "Returns #t if OBJECT is a pin object, otherwise returns #f."
   (true? (lepton_object_is_pin (geda-object->pointer object))))
+
+(define (net-pin? object)
+  "Returns #t if OBJECT is a net pin object, otherwise returns
+#f."
+  (and (pin? object)
+       (true? (lepton_pin_object_is_net_pin
+               (geda-object->pointer object)))))
+
+(define (bus-pin? object)
+  "Returns #t if OBJECT is a bus pin object, otherwise returns
+#f."
+  (and (pin? object)
+       (true? (lepton_pin_object_is_bus_pin
+               (geda-object->pointer object)))))
+
 
 (define (text? object)
   "Returns #t if OBJECT is a text object, otherwise returns #f."

--- a/liblepton/scheme/unit-tests/geda-page-dirty.scm
+++ b/liblepton/scheme/unit-tests/geda-page-dirty.scm
@@ -63,7 +63,7 @@
       (geda:assert-dirties P (for-each (lambda (x) (geda:page-append! P x))
                                        (list l b c a t C)))
 
-      (geda:assert-dirties P (apply set-line! l (line-info l)))
+      (geda:assert-not-dirties P (apply set-line! l (line-info l)))
       (geda:assert-not-dirties P (apply set-box! b (box-info b)))
       (geda:assert-dirties P (apply set-circle! c (circle-info c)))
       (geda:assert-not-dirties P (apply set-arc! a (arc-info a)))
@@ -83,7 +83,7 @@
                 (list l b c a t))
 
       ;; Modify primitives within component
-      (geda:assert-dirties P (apply set-line! l (line-info l)))
+      (geda:assert-not-dirties P (apply set-line! l (line-info l)))
       (geda:assert-not-dirties P (apply set-box! b (box-info b)))
       (geda:assert-dirties P (apply set-circle! c (circle-info c)))
       (geda:assert-not-dirties P (apply set-arc! a (arc-info a)))

--- a/liblepton/scheme/unit-tests/lepton-object-line.scm
+++ b/liblepton/scheme/unit-tests/lepton-object-line.scm
@@ -1,6 +1,7 @@
 ;;; Test Scheme procedures related to line objects.
 
-(use-modules (lepton object))
+(use-modules (srfi srfi-26)
+             (lepton object))
 
 
 (test-begin "lines" 13)
@@ -33,6 +34,187 @@
   (test-equal 21 (list-ref (line-info a) 2)))
 
 (test-end "lines")
+
+(define object-func-list
+  `((,(make-bus '(1 . 2) '(3 . 4)) . ,make-bus)
+    (,(make-bus-pin '(1 . 2) '(3 . 4)) . ,make-bus-pin)
+    (,(make-net '(1 . 2) '(3 . 4)) . ,make-net)
+    (,(make-net-pin '(1 . 2) '(3 . 4)) . ,make-net-pin)
+    (,(make-line '(1 . 2) '(3 . 4) 3) . ,make-line)))
+
+(define func-list
+  (map cdr object-func-list))
+
+(test-begin "line-wrong-argument")
+
+(test-assert-thrown 'wrong-type-arg (line-info 'l))
+(test-assert-thrown 'wrong-type-arg (line-start 'l))
+(test-assert-thrown 'wrong-type-arg (line-end 'l))
+
+(for-each
+ (lambda (x)
+   (let ((object (car x))
+         (func (cdr x)))
+     ;; Wrong object.
+     (test-assert-thrown 'wrong-type-arg (set-line! 'l '(1 . 2) '(3 . 4) 3))
+     ;; Wrong first coord.
+     (test-assert-thrown 'wrong-type-arg (func 'c '(3 . 4) 3))
+     (test-assert-thrown 'wrong-type-arg (set-line! object 'c '(3 . 4) 3))
+     ;; Wrong first x.
+     (test-assert-thrown 'wrong-type-arg (func '(x . 2) '(3 . 4) 3))
+     (test-assert-thrown 'wrong-type-arg (set-line! object '(x . 2) '(3 . 4) 3))
+     ;; Wrong first y.
+     (test-assert-thrown 'wrong-type-arg (func '(1 . y) '(3 . 4) 3))
+     (test-assert-thrown 'wrong-type-arg (set-line! object '(1 . y) '(3 . 4) 3))
+     ;; Wrong second coord.
+     (test-assert-thrown 'wrong-type-arg (func '(1 . 2) 'c 3))
+     (test-assert-thrown 'wrong-type-arg (set-line! object '(1 . 2) 'c 3))
+     ;; Wrong second x.
+     (test-assert-thrown 'wrong-type-arg (func '(1 . 2) '(x . 4) 3))
+     (test-assert-thrown 'wrong-type-arg (set-line! object '(1 . 2) '(x . 4) 3))
+     ;; Wrong second y.
+     (test-assert-thrown 'wrong-type-arg (func '(1 . 2) '(3 . y) 3))
+     (test-assert-thrown 'wrong-type-arg (set-line! object '(1 . 2) '(3 . y) 3))
+     ;; Wrong color.
+     (test-assert-thrown 'wrong-type-arg (func '(1 . 2) '(3 . 4) 'color))
+     (test-assert-thrown 'wrong-type-arg (set-line! object '(1 . 2) '(3 . 4) 'color))))
+ object-func-list)
+
+(test-end "line-wrong-argument")
+
+
+;;; Common functions for transformations.
+
+;;; Line info without unrelated colors.
+(define (stripped-info line)
+  (define (strip-color info)
+    (reverse (cdr (reverse info))))
+  (strip-color (line-info line)))
+
+
+(test-begin "line-translation")
+
+(for-each
+ (lambda (func)
+   (let ((make-object (cut func '(100 . 100) '(300 . 400))))
+     (test-equal (stripped-info (car (translate-objects! '(500 . 500) (make-object))))
+       '((600 . 600) (800 . 900)))
+     (test-equal (stripped-info (car (translate-objects! '(-500 . 500) (make-object))))
+       '((-400 . 600) (-200 . 900)))
+     (test-equal (stripped-info (car (translate-objects! '(500 . -500) (make-object))))
+       '((600 . -400) (800 . -100)))
+     (test-equal (stripped-info (car (translate-objects! '(-500 . -500) (make-object))))
+       '((-400 . -400) (-200 . -100)))))
+ func-list)
+
+(test-end "line-translation")
+
+
+(test-begin "line-mirror")
+
+(for-each
+ (lambda (func)
+   (let ((make-object (cut func '(100 . 100) '(300 . 400))))
+     (test-equal (stripped-info (car (mirror-objects! 0 (make-object))))
+       '((-100 . 100) (-300 . 400)))
+     (test-equal (stripped-info (car (mirror-objects! 500 (make-object))))
+       '((900 . 100) (700 . 400)))
+     (test-equal (stripped-info (car (mirror-objects! -500 (make-object))))
+       '((-1100 . 100) (-1300 . 400)))
+     ;; Double mirror around the same point returns almost initial
+     ;; result (coords returned for another pair of corners).
+     (test-equal (stripped-info
+                  (car (mirror-objects! 500
+                                        (car (mirror-objects! 500 (make-object))))))
+       '((100 . 100) (300 . 400)))))
+ func-list)
+
+(test-end "line-mirror")
+
+
+(test-begin "line-rotation")
+
+(define degree-ls
+  '(-900 -360 -270 -180 -90 0 90 180 270 360 900))
+
+(for-each
+ (lambda (func)
+   (let ((make-object (cut func '(100 . 100) '(300 . 400))))
+
+     (define (rotate-at+500+500 angle)
+       (stripped-info (car (rotate-objects! '(500 . 500) angle (make-object)))))
+     (define (rotate-at-500+500 angle)
+       (stripped-info (car (rotate-objects! '(-500 . 500) angle (make-object)))))
+     (define (rotate-at+500-500 angle)
+       (stripped-info (car (rotate-objects! '(500 . -500) angle (make-object)))))
+     (define (rotate-at-500-500 angle)
+       (stripped-info (car (rotate-objects! '(-500 . -500) angle (make-object)))))
+
+     ;; The output format is
+     ;; '((center-x . center-y) radius start-angle sweep-angle)
+     ;; Radius and sweep angle should never change.
+     (test-equal (map rotate-at+500+500 degree-ls)
+       '(((900 . 900) (700 . 600))
+         ((100 . 100) (300 . 400))
+         ((900 . 100) (600 . 300))
+         ((900 . 900) (700 . 600))
+         ((100 . 900) (400 . 700))
+         ((100 . 100) (300 . 400))
+         ((900 . 100) (600 . 300))
+         ((900 . 900) (700 . 600))
+         ((100 . 900) (400 . 700))
+         ((100 . 100) (300 . 400))
+         ((900 . 900) (700 . 600))))
+
+     (test-equal (map rotate-at-500+500 degree-ls)
+       '(((-1100 . 900) (-1300 . 600))
+         ((100 . 100) (300 . 400))
+         ((-100 . 1100) (-400 . 1300))
+         ((-1100 . 900) (-1300 . 600))
+         ((-900 . -100) (-600 . -300))
+         ((100 . 100) (300 . 400))
+         ((-100 . 1100) (-400 . 1300))
+         ((-1100 . 900) (-1300 . 600))
+         ((-900 . -100) (-600 . -300))
+         ((100 . 100) (300 . 400))
+         ((-1100 . 900) (-1300 . 600))))
+
+     (test-equal (map rotate-at+500-500 degree-ls)
+       '(((900 . -1100) (700 . -1400))
+         ((100 . 100) (300 . 400))
+         ((-100 . -900) (-400 . -700))
+         ((900 . -1100) (700 . -1400))
+         ((1100 . -100) (1400 . -300))
+         ((100 . 100) (300 . 400))
+         ((-100 . -900) (-400 . -700))
+         ((900 . -1100) (700 . -1400))
+         ((1100 . -100) (1400 . -300))
+         ((100 . 100) (300 . 400))
+         ((900 . -1100) (700 . -1400))))
+
+     (test-equal (map rotate-at-500-500 degree-ls)
+       '(((-1100 . -1100) (-1300 . -1400))
+         ((100 . 100) (300 . 400))
+         ((-1100 . 100) (-1400 . 300))
+         ((-1100 . -1100) (-1300 . -1400))
+         ((100 . -1100) (400 . -1300))
+         ((100 . 100) (300 . 400))
+         ((-1100 . 100) (-1400 . 300))
+         ((-1100 . -1100) (-1300 . -1400))
+         ((100 . -1100) (400 . -1300))
+         ((100 . 100) (300 . 400))
+         ((-1100 . -1100) (-1300 . -1400))))
+
+     ;; Invalid rotation angles, not multiple of 90 degree.
+     (test-assert-thrown 'misc-error (rotate-at+500+500 100))
+     (test-assert-thrown 'misc-error (rotate-at+500+500 -100))
+     (test-assert-thrown 'misc-error (rotate-at+500+500 3000))
+     (test-assert-thrown 'misc-error (rotate-at+500+500 -3000))
+     ;; End of let.
+     ))
+ func-list)
+
+(test-end "line-rotation")
 
 
 (test-begin "nets" 13)

--- a/liblepton/scheme/unit-tests/lepton-object-line.scm
+++ b/liblepton/scheme/unit-tests/lepton-object-line.scm
@@ -294,6 +294,8 @@
   (test-assert (net-pin? a))
   (test-assert (not (bus-pin? a)))
 
+  (test-assert (not (net-pin? 'x)))
+
   (test-equal '(1 . 2) (line-start a))
   (test-equal '(3 . 4) (line-end a))
   (test-equal (line-start a) (line-start b))
@@ -327,6 +329,8 @@
   (test-assert (pin? a))
   (test-assert (bus-pin? a))
   (test-assert (not (net-pin? a)))
+
+  (test-assert (not (bus-pin? 'x)))
 
   (test-equal '(1 . 2) (line-start a))
   (test-equal '(3 . 4) (line-end a))

--- a/liblepton/scheme/unit-tests/lepton-object-type.scm
+++ b/liblepton/scheme/unit-tests/lepton-object-type.scm
@@ -30,7 +30,7 @@ static char * test_image_xpm[] = {
                                      0
                                      #f))
 (define bus-pin (make-bus-pin '(1 . 2) '(3 . 4)))
-(define net-pin (make-bus-pin '(1 . 2) '(3 . 4)))
+(define net-pin (make-net-pin '(1 . 2) '(3 . 4)))
 (define text (make-text '(1 . 2) 'lower-left 0 "text" 10 #t 'both))
 
 

--- a/liblepton/scheme/unit-tests/lepton-object-type.scm
+++ b/liblepton/scheme/unit-tests/lepton-object-type.scm
@@ -79,7 +79,9 @@ static char * test_image_xpm[] = {
     (,net . ,net?)
     (,picture . ,picture?)
     (,bus-pin . ,pin?)
+    (,bus-pin . ,bus-pin?)
     (,net-pin . ,pin?)
+    (,net-pin . ,net-pin?)
     (,path . ,path?)
     (,text . ,text?)))
 
@@ -105,7 +107,15 @@ static char * test_image_xpm[] = {
      ;; Test other objects, e.g. (arc? box).
      (for-each
       (lambda (func)
-        (test-assert (not (func object))))
+        (unless (or (and (equal? func pin?)
+                         (equal? check-func bus-pin?))
+                    (and (equal? func pin?)
+                         (equal? check-func net-pin?))
+                    (and (equal? func bus-pin?)
+                         (equal? check-func pin?))
+                    (and (equal? func net-pin?)
+                         (equal? check-func pin?)))
+          (test-assert (not (func object)))))
       other-funcs)
      ;; Test wrong objects.
      (for-each (lambda (x) (not (check-func x))) '(1 anything #t #f))))
@@ -142,8 +152,16 @@ static char * test_image_xpm[] = {
      ;; For example, (geda-object->pointer arc 1 box? 'anything).
      (for-each
       (lambda (func)
-        (test-assert-thrown 'wrong-type-arg
-                            (geda-object->pointer* object 1 func 'anything)))
+        (unless (or (and (equal? func pin?)
+                         (equal? check-func bus-pin?))
+                    (and (equal? func pin?)
+                         (equal? check-func net-pin?))
+                    (and (equal? func bus-pin?)
+                         (equal? check-func pin?))
+                    (and (equal? func net-pin?)
+                         (equal? check-func pin?)))
+          (test-assert-thrown 'wrong-type-arg
+                              (geda-object->pointer* object 1 func 'anything))))
       other-funcs)
 
      ;; Test pointer->geda-object().

--- a/liblepton/scheme/unit-tests/lepton-page-dirty.scm
+++ b/liblepton/scheme/unit-tests/lepton-page-dirty.scm
@@ -95,7 +95,22 @@
       ;; Change color.
       (assert-dirties P (apply set-box! b '((2 . 3) (4 . 5) 4)))
 
-      (assert-dirties P (apply set-line! l (line-info l)))
+      ;; Line.
+      ;; The same parameters do not modify the page.
+      (assert-not-dirties P (apply set-line! l (line-info l)))
+      ;; Set color explicitly to facilitate next tests.
+      (set-line! l '(1 . 2) '(3 . 4) 3)
+      ;; Change x of the first corner.
+      (assert-dirties P (apply set-line! l '((2 . 2) (3 . 4) 3)))
+      ;; Change y of the first corner.
+      (assert-dirties P (apply set-line! l '((2 . 3) (3 . 4) 3)))
+      ;; Change x of the second corner.
+      (assert-dirties P (apply set-line! l '((2 . 3) (4 . 4) 3)))
+      ;; Change y of the second corner.
+      (assert-dirties P (apply set-line! l '((2 . 3) (4 . 5) 3)))
+      ;; Change color.
+      (assert-dirties P (apply set-line! l '((2 . 3) (4 . 5) 4)))
+
       (assert-dirties P (apply set-circle! c (circle-info c)))
       (assert-dirties P (apply set-text! t (text-info t)))
       (assert-dirties P (apply set-component! C
@@ -166,7 +181,22 @@
       ;; Change color.
       (assert-dirties P (apply set-box! b '((2 . 3) (4 . 5) 4)))
 
-      (assert-dirties P (apply set-line! l (line-info l)))
+      ;; Line.
+      ;; The same parameters do not modify the page.
+      (assert-not-dirties P (apply set-line! l (line-info l)))
+      ;; Set color explicitly to facilitate next tests.
+      (set-line! l '(1 . 2) '(3 . 4) 3)
+      ;; Change x of the first corner.
+      (assert-dirties P (apply set-line! l '((2 . 2) (3 . 4) 3)))
+      ;; Change y of the first corner.
+      (assert-dirties P (apply set-line! l '((2 . 3) (3 . 4) 3)))
+      ;; Change x of the second corner.
+      (assert-dirties P (apply set-line! l '((2 . 3) (4 . 4) 3)))
+      ;; Change y of the second corner.
+      (assert-dirties P (apply set-line! l '((2 . 3) (4 . 5) 3)))
+      ;; Change color.
+      (assert-dirties P (apply set-line! l '((2 . 3) (4 . 5) 4)))
+
       (assert-dirties P (apply set-circle! c (circle-info c)))
       (assert-dirties P (apply set-text! t (text-info t)))
 

--- a/liblepton/scheme/unit-tests/lepton-pin-whichend.scm
+++ b/liblepton/scheme/unit-tests/lepton-pin-whichend.scm
@@ -1,0 +1,55 @@
+;;; Test Scheme procedures related to the "whichend" field of
+;;; pins.
+
+(use-modules (ice-9 match)
+             (lepton object)
+             (lepton page))
+
+;;; This is a very roundabout test.  We would add a setter for
+;;; pin's "whichend" field and use it directly.  However, no
+;;; Lepton code does use it.  The only place we encounter it is in
+;;; the gEDA file format parser.
+
+(test-begin "pin-whichend")
+
+(define old-pin (make-net-pin '(1 . 2) '(3 . 4)))
+
+(define old-page
+  (page-append! (make-page "dummy") old-pin))
+
+(define old-pin-string
+  (match (string-split (page->string old-page) #\newline)
+    ((version pin anything)
+     pin)
+    (_ #f)))
+
+;;; Transform "P 1 2 3 4 1 0 0" => "P 1 2 3 4 1 0 1".
+(define (toggle-whichend-field pin-str)
+  (match (string-split pin-str #\space)
+    ((object-type x0 y0 x1 y1 color pin-type whichend)
+     (if (zero? (string->number whichend))
+         (string-join (list object-type x0 y0 x1 y1 color pin-type "1"))
+         #f))
+    (_ #f)))
+
+(define new-page
+  (string->page
+   "dummy2"
+   (match (string-split (page->string old-page) #\newline)
+     ((version pin anything)
+      (string-join (list version
+                         (toggle-whichend-field pin)
+                         anything)
+                   (char-set->string (char-set #\newline))))
+     (_ #f))))
+
+(define new-pin (car (page-contents new-page)))
+
+(test-eq (object-color old-pin) (object-color new-pin))
+(test-equal (line-start old-pin) (line-end new-pin))
+(test-equal (line-end old-pin) (line-start new-pin))
+
+(close-page! old-page)
+(close-page! new-page)
+
+(test-end "pin-whichend")

--- a/liblepton/src/a_basic.c
+++ b/liblepton/src/a_basic.c
@@ -207,7 +207,7 @@ GList
         break;
 
       case(OBJ_PIN):
-        if ((new_obj = o_pin_read (line, release_ver, fileformat_ver, err)) == NULL)
+        if ((new_obj = lepton_pin_object_read (line, release_ver, fileformat_ver, err)) == NULL)
           goto error;
         new_object_list = g_list_prepend (new_object_list, new_obj);
         found_pin++;

--- a/liblepton/src/o_attrib.c
+++ b/liblepton/src/o_attrib.c
@@ -268,7 +268,7 @@ o_read_attribs (LeptonPage *page,
         break;
 
       case(OBJ_PIN):
-        if ((new_obj = o_pin_read (line, release_ver, fileformat_ver, err)) == NULL)
+        if ((new_obj = lepton_pin_object_read (line, release_ver, fileformat_ver, err)) == NULL)
           goto error;
         object_list = g_list_prepend (object_list, new_obj);
         break;

--- a/liblepton/src/object.c
+++ b/liblepton/src/object.c
@@ -724,6 +724,22 @@ lepton_object_set_fill_angle2 (LeptonObject *object,
 }
 
 
+/*! \brief Get object's 'whichend'.
+ *
+ *  \par Function Description
+ *  Obtains 'whichend' field of the #LeptonObject structure.  For
+ *  pins it defines which end of the pin is connectible.
+ *  \param [in] object The object to obtain the 'whichend' of.
+ *  \return The object 'whichend'.
+ */
+int
+lepton_object_get_whichend (LeptonObject *object)
+{
+  g_return_val_if_fail (object != NULL, -1);
+  return object->whichend;
+}
+
+
 /*! \brief Make and return a copy of an object.
  *
  *  \par Function Description

--- a/liblepton/src/pin_object.c
+++ b/liblepton/src/pin_object.c
@@ -307,6 +307,53 @@ lepton_pin_object_new (int color,
   return new_node;
 }
 
+/*! \brief Create a new net pin object.
+ *  \par Function Description
+ *  This function creates and returns a new net pin object.
+ *
+ *  \param [in] color    The color of the pin.
+ *  \param [in] x1       X-coord of the first point.
+ *  \param [in] y1       Y-coord of the first point.
+ *  \param [in] x2       X-coord of the second point.
+ *  \param [in] y2       Y-coord of the second point.
+ *  \param [in] whichend The connectible end of the pin.
+ *  \return A new pin LeptonObject
+ */
+LeptonObject*
+lepton_pin_object_new_net_pin (int color,
+                               int x1,
+                               int y1,
+                               int x2,
+                               int y2,
+                               int whichend)
+{
+  return lepton_pin_object_new (color, x1, y1, x2, y2, PIN_TYPE_NET, whichend);
+}
+
+
+/*! \brief Create a new bus pin object.
+ *  \par Function Description
+ *  This function creates and returns a new bus pin object.
+ *
+ *  \param [in] color    The color of the pin.
+ *  \param [in] x1       X-coord of the first point.
+ *  \param [in] y1       Y-coord of the first point.
+ *  \param [in] x2       X-coord of the second point.
+ *  \param [in] y2       Y-coord of the second point.
+ *  \param [in] whichend The connectible end of the pin.
+ *  \return A new pin LeptonObject
+ */
+LeptonObject*
+lepton_pin_object_new_bus_pin (int color,
+                               int x1,
+                               int y1,
+                               int x2,
+                               int y2,
+                               int whichend)
+{
+  return lepton_pin_object_new (color, x1, y1, x2, y2, PIN_TYPE_BUS, whichend);
+}
+
 /*! \brief read a pin object from a char buffer
  *  \par Function Description
  *  This function reads a pin object from the buffer \a buf.

--- a/liblepton/src/pin_object.c
+++ b/liblepton/src/pin_object.c
@@ -319,10 +319,10 @@ lepton_pin_object_new (int color,
  *  \return The object list, or NULL on error.
  */
 LeptonObject*
-o_pin_read (const char buf[],
-            unsigned int release_ver,
-            unsigned int fileformat_ver,
-            GError **err)
+lepton_pin_object_read (const char buf[],
+                        unsigned int release_ver,
+                        unsigned int fileformat_ver,
+                        GError **err)
 {
   LeptonObject *new_obj;
   char type;

--- a/liblepton/src/pin_object.c
+++ b/liblepton/src/pin_object.c
@@ -24,6 +24,35 @@
 
 #include "liblepton_priv.h"
 
+
+/*! \brief Test if object is a bus pin object.
+ *
+ *  \param [in] object The object to test.
+ *  \return TRUE, if the object is bus pin, otherwise FALSE.
+ */
+gboolean
+lepton_pin_object_is_bus_pin (const LeptonObject *object)
+{
+  g_return_val_if_fail (lepton_object_is_pin (object), FALSE);
+
+  return (object->pin_type == PIN_TYPE_BUS);
+}
+
+
+/*! \brief Test if object is a net pin object.
+ *
+ *  \param [in] object The object to test.
+ *  \return TRUE, if the object is net pin, otherwise FALSE.
+ */
+gboolean
+lepton_pin_object_is_net_pin (const LeptonObject *object)
+{
+  g_return_val_if_fail (lepton_object_is_pin (object), FALSE);
+
+  return (object->pin_type == PIN_TYPE_NET);
+}
+
+
 /*! \file pin_object.c
  *  \brief functions for the pin object
  */

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -219,50 +219,6 @@ SCM_DEFINE (set_line_x, "%set-line!", 6, 0, 0,
   return line_s;
 }
 
-/*! \brief Create a new pin.
- * \par Function description
- * Creates a new pin object, with all parameters set to default
- * values.  type_s is a Scheme symbol indicating whether the pin
- * should be a "net" pin or a "bus" pin.
- *
- * \note Scheme API: Implements the %make-pin procedure in the
- * (lepton core object) module.
- *
- * \return a newly-created pin object.
- */
-SCM_DEFINE (make_pin, "%make-pin", 1, 0, 0,
-            (SCM type_s), "Create a new pin object.")
-{
-  SCM_ASSERT (scm_is_symbol (type_s),
-              type_s, SCM_ARG1, s_make_pin);
-
-  int type;
-  if (scm_is_eq (type_s, net_sym)) {
-    type = PIN_TYPE_NET;
-  } else if (scm_is_eq (type_s, bus_sym)) {
-    type = PIN_TYPE_BUS;
-  } else {
-    scm_misc_error (s_make_pin,
-                    _("Invalid pin type ~A, must be 'net or 'bus"),
-                    scm_list_1 (type_s));
-  }
-
-  LeptonObject *obj = lepton_pin_object_new (PIN_COLOR,
-                                             0,
-                                             0,
-                                             0,
-                                             0,
-                                             type,
-                                             0);
-  SCM result = edascm_from_object (obj);
-
-  /* At the moment, the only pointer to the object is owned by the
-   * smob. */
-  edascm_c_set_gc (result, 1);
-
-  return result;
-}
-
 /*! \brief Get the type of a pin object.
  * \par Function Description
  * Returns a symbol describing the pin type of the pin object \a
@@ -1175,8 +1131,7 @@ init_module_lepton_core_object (void *unused)
   #include "scheme_object.x"
 
   /* Add them to the module's public definitions. */
-  scm_c_export (s_make_pin,
-                s_pin_type,
+  scm_c_export (s_pin_type,
                 s_set_line_x,
                 s_make_circle,
                 s_set_circle_x,

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -140,34 +140,6 @@ edascm_is_object_type (SCM smob, int type)
 }
 
 
-/*! \brief Create a new line.
- * \par Function Description
- * Creates a new line object, with all its parameters set to default
- * values.
- *
- * \note Scheme API: Implements the %make-line procedure in the
- * (lepton core object) module.
- *
- * \return a newly-created line object.
- */
-SCM_DEFINE (make_line, "%make-line", 0, 0, 0,
-            (), "Create a new line object.")
-{
-  LeptonObject *object = lepton_line_object_new (default_color_id(),
-                                                 0,
-                                                 0,
-                                                 0,
-                                                 0);
-
-  SCM result = edascm_from_object (object);
-
-  /* At the moment, the only pointer to the object is owned by the
-   * smob. */
-  edascm_c_set_gc (result, TRUE);
-
-  return result;
-}
-
 /*! \brief Set line parameters.
  * \par Function Description
  * Modifies a line object by setting its parameters to new values.
@@ -1309,8 +1281,7 @@ init_module_lepton_core_object (void *unused)
   #include "scheme_object.x"
 
   /* Add them to the module's public definitions. */
-  scm_c_export (s_make_line,
-                s_make_net,
+  scm_c_export (s_make_net,
                 s_make_bus,
                 s_make_pin,
                 s_pin_type,

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -263,40 +263,6 @@ SCM_DEFINE (line_info, "%line-info", 1, 0, 0,
   return scm_list_n (x1, y1, x2, y2, color, SCM_UNDEFINED);
 }
 
-/*! \brief Create a new bus.
- * \par Function Description
- * Creates a new bus object, with all its parameters set to default
- * values.
- *
- * \note Scheme API: Implements the %make-bus procedure in the
- * (lepton core object) module.
- *
- * \todo Do we need a way to get/set bus ripper direction?
- *
- * \return a newly-created bus object.
- */
-SCM_DEFINE (make_bus, "%make-bus", 0, 0, 0,
-            (), "Create a new bus object.")
-{
-  LeptonObject *obj;
-  SCM result;
-
-  obj = lepton_bus_object_new (BUS_COLOR,
-                             0,
-                             0,
-                             0,
-                             0,
-                             0); /* Bus ripper direction */
-
-  result = edascm_from_object (obj);
-
-  /* At the moment, the only pointer to the object is owned by the
-   * smob. */
-  edascm_c_set_gc (result, 1);
-
-  return result;
-}
-
 /*! \brief Create a new pin.
  * \par Function description
  * Creates a new pin object, with all parameters set to default
@@ -1253,8 +1219,7 @@ init_module_lepton_core_object (void *unused)
   #include "scheme_object.x"
 
   /* Add them to the module's public definitions. */
-  scm_c_export (s_make_bus,
-                s_make_pin,
+  scm_c_export (s_make_pin,
                 s_pin_type,
                 s_set_line_x,
                 s_line_info,

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -219,50 +219,6 @@ SCM_DEFINE (set_line_x, "%set-line!", 6, 0, 0,
   return line_s;
 }
 
-/*! \brief Get line parameters.
- * \par Function Description
- * Retrieves the parameters of a line object. The return value is a
- * list of parameters:
- *
- * -# X-coordinate of start of line
- * -# Y-coordinate of start of line
- * -# X-coordinate of end of line
- * -# Y-coordinate of end of line
- * -# Colormap index of color to be used for drawing the line
- *
- * This function also works on net, bus and pin objects.  For pins,
- * the start is the connectable point on the pin.
- *
- * \param line_s the line object to inspect.
- * \return a list of line parameters.
- */
-SCM_DEFINE (line_info, "%line-info", 1, 0, 0,
-            (SCM line_s), "Get line parameters.")
-{
-  SCM_ASSERT ((edascm_is_object_type (line_s, OBJ_LINE)
-               || edascm_is_object_type (line_s, OBJ_NET)
-               || edascm_is_object_type (line_s, OBJ_BUS)
-               || edascm_is_object_type (line_s, OBJ_PIN)),
-              line_s, SCM_ARG1, s_line_info);
-
-  LeptonObject *obj = edascm_to_object (line_s);
-  SCM x1 = scm_from_int (lepton_line_object_get_x0 (obj));
-  SCM y1 = scm_from_int (lepton_line_object_get_y0 (obj));
-  SCM x2 = scm_from_int (lepton_line_object_get_x1 (obj));
-  SCM y2 = scm_from_int (lepton_line_object_get_y1 (obj));
-  SCM color = scm_from_int (lepton_object_get_color (obj));
-
-  /* Swap ends according to pin's whichend flag. */
-  if (lepton_object_is_pin (obj) && obj->whichend)
-  {
-    SCM s;
-    s = x1; x1 = x2; x2 = s;
-    s = y1; y1 = y2; y2 = s;
-  }
-
-  return scm_list_n (x1, y1, x2, y2, color, SCM_UNDEFINED);
-}
-
 /*! \brief Create a new pin.
  * \par Function description
  * Creates a new pin object, with all parameters set to default
@@ -1222,7 +1178,6 @@ init_module_lepton_core_object (void *unused)
   scm_c_export (s_make_pin,
                 s_pin_type,
                 s_set_line_x,
-                s_line_info,
                 s_make_circle,
                 s_set_circle_x,
                 s_circle_info,

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -28,9 +28,6 @@
 #include "liblepton_priv.h"
 #include "libleptonguile_priv.h"
 
-SCM_SYMBOL (net_sym , "net");
-SCM_SYMBOL (bus_sym , "bus");
-
 SCM_SYMBOL (lower_left_sym , "lower-left");
 SCM_SYMBOL (middle_left_sym , "middle-left");
 SCM_SYMBOL (upper_left_sym , "upper-left");
@@ -217,41 +214,6 @@ SCM_DEFINE (set_line_x, "%set-line!", 6, 0, 0,
   lepton_object_page_set_changed (obj);
 
   return line_s;
-}
-
-/*! \brief Get the type of a pin object.
- * \par Function Description
- * Returns a symbol describing the pin type of the pin object \a
- * pin_s.
- *
- * \note Scheme API: Implements the %make-pin procedure in the
- * (lepton core object) module.
- *
- * \return the symbol 'pin or 'bus.
- */
-SCM_DEFINE (pin_type, "%pin-type", 1, 0, 0,
-            (SCM pin_s), "Get the type of a pin object.")
-{
-  SCM_ASSERT (edascm_is_object_type (pin_s, OBJ_PIN), pin_s,
-              SCM_ARG1, s_pin_type);
-
-  LeptonObject *obj = edascm_to_object (pin_s);
-  SCM result;
-
-  switch (obj->pin_type) {
-  case PIN_TYPE_NET:
-    result = net_sym;
-    break;
-  case PIN_TYPE_BUS:
-    result = bus_sym;
-    break;
-  default:
-    scm_misc_error (s_pin_type,
-                    _("Object ~A has invalid pin type."),
-                    scm_list_1 (pin_s));
-  }
-
-  return result;
 }
 
 /*! \brief Create a new circle.
@@ -1131,8 +1093,7 @@ init_module_lepton_core_object (void *unused)
   #include "scheme_object.x"
 
   /* Add them to the module's public definitions. */
-  scm_c_export (s_pin_type,
-                s_set_line_x,
+  scm_c_export (s_set_line_x,
                 s_make_circle,
                 s_set_circle_x,
                 s_circle_info,

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -290,7 +290,7 @@ SCM_DEFINE (pin_type, "%pin-type", 1, 0, 0,
     result = bus_sym;
     break;
   default:
-    scm_misc_error (s_make_pin,
+    scm_misc_error (s_pin_type,
                     _("Object ~A has invalid pin type."),
                     scm_list_1 (pin_s));
   }

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -263,34 +263,6 @@ SCM_DEFINE (line_info, "%line-info", 1, 0, 0,
   return scm_list_n (x1, y1, x2, y2, color, SCM_UNDEFINED);
 }
 
-/*! \brief Create a new net.
- * \par Function Description
- * Creates a new net object, with all its parameters set to default
- * values.
- *
- * \note Scheme API: Implements the %make-net procedure in the
- * (lepton core object) module.
- *
- * \return a newly-created net object.
- */
-SCM_DEFINE (make_net, "%make-net", 0, 0, 0,
-            (), "Create a new net object.")
-{
-  LeptonObject *obj;
-  SCM result;
-
-  obj = lepton_net_object_new (NET_COLOR, 0, 0, 0, 0);
-
-
-  result = edascm_from_object (obj);
-
-  /* At the moment, the only pointer to the object is owned by the
-   * smob. */
-  edascm_c_set_gc (result, 1);
-
-  return result;
-}
-
 /*! \brief Create a new bus.
  * \par Function Description
  * Creates a new bus object, with all its parameters set to default
@@ -1281,8 +1253,7 @@ init_module_lepton_core_object (void *unused)
   #include "scheme_object.x"
 
   /* Add them to the module's public definitions. */
-  scm_c_export (s_make_net,
-                s_make_bus,
+  scm_c_export (s_make_bus,
                 s_make_pin,
                 s_pin_type,
                 s_set_line_x,

--- a/liblepton/tests/test_pin_object.c
+++ b/liblepton/tests/test_pin_object.c
@@ -137,10 +137,10 @@ check_serialization ()
     lepton_object_delete (object0);
     g_assert (buffer0 != NULL);
 
-    LeptonObject *object1 = o_pin_read (buffer0,
-                                      version,
-                                      FILEFORMAT_VERSION,
-                                      NULL);
+    LeptonObject *object1 = lepton_pin_object_read (buffer0,
+                                                    version,
+                                                    FILEFORMAT_VERSION,
+                                                    NULL);
 
     g_assert (object1 != NULL);
 


### PR DESCRIPTION
- New accessors for necessary object fields have been added.
- Much more tests have been implemented to keep the functionality intact and anything was tested before applying changes in the code.
- 7 functions have been rewritten.  They all have docstrings now.
