### PR TITLE
Simplify some object creation functions in `(lepton object)`

### DIFF
--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -433,25 +433,27 @@ form '(x . y), and BOTTOM-RIGHT is the position of the bottom
 right of the box.  If optional COLOR is specified, it should be
 the integer color map index of the color with which to draw the
 box.  If COLOR is not specified, the default box color is used."
+  (define default-box-color (default_color_id))
+
   (check-coord top-left 1)
   (check-coord bottom-right 2)
   (and color (check-integer color 3))
 
-  (let* ((init-color (default_color_id))
-         (init-left-x 0)
-         (init-upper-y 0)
-         (init-right-x 0)
-         (init-bottom-y 0)
-         (object (pointer->geda-object
-                  (lepton_box_object_new init-color
-                                         init-left-x
-                                         init-upper-y
-                                         init-right-x
-                                         init-bottom-y))))
-    (set-box! object
-              top-left
-              bottom-right
-              (or color init-color))))
+  (let* ((x0 (car top-left))
+         (y0 (cdr top-left))
+         (x1 (car bottom-right))
+         (y1 (cdr bottom-right))
+         (left-x (min x0 x1))
+         (right-x (max x0 x1))
+         (bottom-y (min y0 y1))
+         (top-y (max y0 y1))
+         (color (or color default-box-color)))
+    (pointer->geda-object
+     (lepton_box_object_new color
+                            left-x
+                            top-y
+                            right-x
+                            bottom-y))))
 
 (define (box-info object)
   "Retrieves and returns the coordinates and color of a box

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -342,6 +342,22 @@ values."
 
 (define default-pin-color (color-map-name-to-index 'pin))
 
+;;; Creates a new pin object of given CONNECTION-TYPE with
+;;; coordinates START and END and optional COLOR.  If the
+;;; connection type is 'bus, a bus pin will be created, otherwise
+;;; a net pin.
+(define* (make-pin connection-type start end #:optional color)
+  (let ((make-func (if (eq? connection-type 'bus)
+                       lepton_pin_object_new_bus_pin
+                       lepton_pin_object_new_net_pin)))
+    (pointer->geda-object (make-func (or color
+                                         default-pin-color)
+                                     (car start)
+                                     (cdr start)
+                                     (car end)
+                                     (cdr end)
+                                     default-pin-whichend))))
+
 (define* (make-net-pin start end #:optional color)
   "Creates and returns a new net pin object with given parameters.
 START is the position of the start of the new pin (its connectible
@@ -353,14 +369,7 @@ not specified, the default pin color is used."
   (check-coord end 2)
   (and color (check-integer color 3))
 
-  (pointer->geda-object
-   (lepton_pin_object_new_net_pin (or color
-                                      default-pin-color)
-                                  (car start)
-                                  (cdr start)
-                                  (car end)
-                                  (cdr end)
-                                  default-pin-whichend)))
+  (make-pin 'net start end color))
 
 (define* (make-bus-pin start end #:optional color)
   "Creates and returns a new bus pin object with given parameters.
@@ -373,15 +382,7 @@ not specified, the default pin color is used."
   (check-coord end 2)
   (and color (check-integer color 3))
 
-  (pointer->geda-object
-   (lepton_pin_object_new_bus_pin (or color
-                                      default-pin-color)
-                                  (car start)
-                                  (cdr start)
-                                  (car end)
-                                  (cdr end)
-                                  default-pin-whichend)))
-
+  (make-pin 'bus start end color))
 
 
 ;;;; Boxes

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -373,23 +373,14 @@ not specified, the default pin color is used."
   (check-coord end 2)
   (and color (check-integer color 3))
 
-  (let* ((init-color (color-map-name-to-index 'pin))
-         (init-start-x 0)
-         (init-start-y 0)
-         (init-end-x 0)
-         (init-end-y 0)
-         (init-whichend 0)
-         (object (pointer->geda-object
-                  (lepton_pin_object_new_bus_pin init-color
-                                                 init-start-x
-                                                 init-start-y
-                                                 init-end-x
-                                                 init-end-y
-                                                 init-whichend))))
-    (set-line! object
-               start
-               end
-               (or color init-color))))
+  (pointer->geda-object
+   (lepton_pin_object_new_bus_pin (or color
+                                      default-pin-color)
+                                  (car start)
+                                  (cdr start)
+                                  (car end)
+                                  (cdr end)
+                                  default-pin-whichend)))
 
 
 

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -552,31 +552,24 @@ SWEEP-ANGLE is the number of degrees between the start and end
 angles.  If optional COLOR is specified, it should be the integer
 color map index of the color with which to draw the arc.  If COLOR
 is not specified, the default arc color is used."
+  (define default-arc-color (default_color_id))
+
   (check-coord center 1)
   (check-integer radius 2)
   (check-integer start-angle 3)
   (check-integer sweep-angle 4)
   (and color (check-integer color 5))
 
-  (let* ((init-color (default_color_id))
-         (init-center-x 0)
-         (init-center-y 0)
-         (init-radius 1)
-         (init-start-angle 0)
-         (init-sweep-angle 0)
-         (object (pointer->geda-object
-                  (lepton_arc_object_new init-color
-                                         init-center-x
-                                         init-center-y
-                                         init-radius
-                                         init-start-angle
-                                         init-sweep-angle))))
-    (set-arc! object
-              center
-              radius
-              start-angle
-              sweep-angle
-              (or color init-color))))
+  (pointer->geda-object
+   (lepton_arc_object_new (or color
+                              default-arc-color)
+                          ;; Center X.
+                          (car center)
+                          ;; Center Y.
+                          (cdr center)
+                          radius
+                          start-angle
+                          sweep-angle)))
 
 (define-public (arc-info object)
   "Returns the parameters of arc OBJECT as a list of its center

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -337,6 +337,11 @@ values."
 
 ;;;; Pins
 
+;;; This is always 0 in recent file format versions.
+(define default-pin-whichend 0)
+
+(define default-pin-color (color-map-name-to-index 'pin))
+
 (define* (make-net-pin start end #:optional color)
   "Creates and returns a new net pin object with given parameters.
 START is the position of the start of the new pin (its connectible
@@ -348,23 +353,14 @@ not specified, the default pin color is used."
   (check-coord end 2)
   (and color (check-integer color 3))
 
-  (let* ((init-color (color-map-name-to-index 'pin))
-         (init-start-x 0)
-         (init-start-y 0)
-         (init-end-x 0)
-         (init-end-y 0)
-         (init-whichend 0)
-         (object (pointer->geda-object
-                  (lepton_pin_object_new_net_pin init-color
-                                                 init-start-x
-                                                 init-start-y
-                                                 init-end-x
-                                                 init-end-y
-                                                 init-whichend))))
-    (set-line! object
-               start
-               end
-               (or color init-color))))
+  (pointer->geda-object
+   (lepton_pin_object_new_net_pin (or color
+                                      default-pin-color)
+                                  (car start)
+                                  (cdr start)
+                                  (car end)
+                                  (cdr end)
+                                  default-pin-whichend)))
 
 (define* (make-bus-pin start end #:optional color)
   "Creates and returns a new bus pin object with given parameters.


### PR DESCRIPTION
- I've thrown out setters from several `make-<object-type>()` functions recently created, e.g. in #797.  
- Another change is introducing a generic pin creation function.

Both changes simplify and reduce code a little.