### PR TITLE
Get rid of several warnings when building with gtk3

### DIFF
--- a/libleptonattrib/src/x_window.c
+++ b/libleptonattrib/src/x_window.c
@@ -158,6 +158,20 @@ x_window_init ()
 
   gtk_box_pack_start (GTK_BOX (marea), label_name_val, FALSE, TRUE, 0);
 
+#ifdef ENABLE_GTK3
+  GdkRGBA color;
+  gdk_rgba_parse (&color, "grey");
+  gtk_widget_override_color (label_inv, GTK_STATE_FLAG_NORMAL, &color);
+
+  gdk_rgba_parse (&color, "black");
+  gtk_widget_override_color (label_val, GTK_STATE_FLAG_NORMAL, &color);
+
+  gdk_rgba_parse (&color, "red");
+  gtk_widget_override_color (label_name, GTK_STATE_FLAG_NORMAL, &color);
+
+  gdk_rgba_parse (&color, "blue");
+  gtk_widget_override_color (label_name_val, GTK_STATE_FLAG_NORMAL, &color);
+#else
   GdkColor color;
   gdk_color_parse ("grey", &color);
   gtk_widget_modify_fg (label_inv, GTK_STATE_NORMAL, &color);
@@ -170,6 +184,7 @@ x_window_init ()
 
   gdk_color_parse ("blue", &color);
   gtk_widget_modify_fg (label_name_val, GTK_STATE_NORMAL, &color);
+#endif
 
 
   /* -----  Now malloc -- but don't fill out -- space for sheets  ----- */

--- a/libleptongui/include/gschem_bottom_widget.h
+++ b/libleptongui/include/gschem_bottom_widget.h
@@ -1,6 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
- * Copyright (C) 1998-2010 gEDA Contributors (see ChangeLog for details)
+ * Copyright (C) 1998-2015 gEDA Contributors
+ * Copyright (C) 2017-2021 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -53,8 +54,13 @@ struct _GschemBottomWidget
   GtkWidget *rubber_band_label;
   gboolean  magnetic_net_mode;
   GtkWidget *magnetic_net_label;
+#ifdef ENABLE_GTK3
+  GdkRGBA   status_inactive_color;
+  GdkRGBA   status_active_color;
+#else
   GdkColor  status_inactive_color;
   GdkColor  status_active_color;
+#endif
   gboolean  status_bold_font;
 };
 
@@ -125,4 +131,3 @@ gschem_bottom_widget_set_rubber_band_mode (GschemBottomWidget *widget, gboolean 
 
 void
 gschem_bottom_widget_set_magnetic_net_mode (GschemBottomWidget *widget, gboolean mode);
-

--- a/libleptongui/include/x_multiattrib.h
+++ b/libleptongui/include/x_multiattrib.h
@@ -63,10 +63,17 @@ struct _Multiattrib {
   GtkWidget       *list_frame;
   GtkWidget       *add_frame;
 
+#ifdef ENABLE_GTK3
+  GdkRGBA value_normal_text_color;
+  GdkRGBA insensitive_text_color;
+  GdkRGBA not_identical_value_text_color;
+  GdkRGBA not_present_in_all_text_color;
+#else
   GdkColor       value_normal_text_color;   /* Workaround for lameness in GtkTextView */
   GdkColor       insensitive_text_color;
   GdkColor       not_identical_value_text_color;
   GdkColor       not_present_in_all_text_color;
+#endif
 
   gulong object_list_changed_id;
 

--- a/libleptongui/src/gschem_bottom_widget.c
+++ b/libleptongui/src/gschem_bottom_widget.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2014 gEDA Contributors
- * Copyright (C) 2017-2020 Lepton EDA Contributors
+ * Copyright (C) 2017-2021 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -523,8 +523,13 @@ gschem_bottom_widget_init (GschemBottomWidget *widget)
   gboolean show_mouse_indicators       = TRUE;
   gboolean show_rubber_band_indicator  = FALSE;
   gboolean show_magnetic_net_indicator = FALSE;
+#ifdef ENABLE_GTK3
+  gdk_rgba_parse (&widget->status_inactive_color, "black");
+  gdk_rgba_parse (&widget->status_active_color, "green");
+#else
   gdk_color_parse ("black", &widget->status_inactive_color);
   gdk_color_parse ("green", &widget->status_active_color);
+#endif
   widget->status_bold_font = FALSE;
 
   gchar* cwd = g_get_current_dir();
@@ -570,7 +575,11 @@ gschem_bottom_widget_init (GschemBottomWidget *widget)
                                           &err);
     if (color != NULL)
     {
+#ifdef ENABLE_GTK3
+      gdk_rgba_parse (&widget->status_active_color, color);
+#else
       gdk_color_parse (color, &widget->status_active_color);
+#endif
       g_free (color);
     }
     g_clear_error (&err);
@@ -797,7 +806,11 @@ gschem_bottom_widget_set_status_text_color (GschemBottomWidget *widget, gboolean
 {
   g_return_if_fail (widget != NULL);
 
+#ifdef ENABLE_GTK3
+  const GdkRGBA* color = NULL;
+#else
   const GdkColor* color = NULL;
+#endif
 
   if (active) {
     color = &widget->status_active_color;
@@ -805,7 +818,15 @@ gschem_bottom_widget_set_status_text_color (GschemBottomWidget *widget, gboolean
     color = &widget->status_inactive_color;
   }
 
-  gtk_widget_modify_fg (GTK_WIDGET (widget->status_label), GTK_STATE_NORMAL, color);
+#ifdef ENABLE_GTK3
+  gtk_widget_override_color (GTK_WIDGET (widget->status_label),
+                             GTK_STATE_FLAG_NORMAL,
+                             color);
+#else
+  gtk_widget_modify_fg (GTK_WIDGET (widget->status_label),
+                        GTK_STATE_NORMAL,
+                        color);
+#endif
 }
 
 
@@ -989,12 +1010,19 @@ update_rubber_band_label (GschemBottomWidget *widget, GParamSpec *pspec, gpointe
 {
   g_return_if_fail (widget != NULL);
 
+#ifdef ENABLE_GTK3
+  GdkRGBA color;
+  gdk_rgba_parse (&color, widget->rubber_band_mode ? "green" : "blue");
+  gtk_widget_override_color (GTK_WIDGET (widget->rubber_band_label),
+                             GTK_STATE_FLAG_NORMAL,
+                             &color);
+#else
   GdkColor color;
   gdk_color_parse (widget->rubber_band_mode ? "green" : "blue", &color);
-
   gtk_widget_modify_fg (GTK_WIDGET (widget->rubber_band_label),
                         GTK_STATE_NORMAL,
                         &color);
+#endif
 
   gtk_label_set_markup (GTK_LABEL (widget->rubber_band_label),
                         widget->rubber_band_mode ?
@@ -1014,12 +1042,19 @@ update_magnetic_net_label (GschemBottomWidget *widget, GParamSpec *pspec, gpoint
 {
   g_return_if_fail (widget != NULL);
 
+#ifdef ENABLE_GTK3
+  GdkRGBA color;
+  gdk_rgba_parse (&color, widget->magnetic_net_mode ? "purple" : "darkgray");
+  gtk_widget_override_color (GTK_WIDGET (widget->magnetic_net_label),
+                             GTK_STATE_FLAG_NORMAL,
+                             &color);
+#else
   GdkColor color;
   gdk_color_parse (widget->magnetic_net_mode ? "purple" : "darkgray", &color);
-
   gtk_widget_modify_fg (GTK_WIDGET (widget->magnetic_net_label),
                         GTK_STATE_NORMAL,
                         &color);
+#endif
 
   gtk_label_set_markup (GTK_LABEL (widget->magnetic_net_label),
                     widget->magnetic_net_mode ?

--- a/libleptongui/src/gschem_fill_swatch_cell_renderer.c
+++ b/libleptongui/src/gschem_fill_swatch_cell_renderer.c
@@ -260,17 +260,25 @@ render (GtkCellRenderer      *cell,
   GschemFillSwatchCellRenderer *swatch = GSCHEM_FILL_SWATCH_CELL_RENDERER (cell);
 
   if (swatch->enabled) {
-    GdkColor color;
     double offset = SWATCH_BORDER_WIDTH / 2.0;
     gboolean success;
-#ifndef ENABLE_GTK3
+#ifdef ENABLE_GTK3
+    GdkRGBA color;
+
+    /* Paint the swatch using the text color to match the user's desktop theme.
+     */
+
+    success = gtk_style_context_lookup_color (gtk_widget_get_style_context (widget),
+                                              "text_color",
+                                              &color);
+#else /* GTK2 */
+    GdkColor color;
     cairo_t *cr = gdk_cairo_create (window);
 
     if (expose_area) {
       gdk_cairo_rectangle (cr, expose_area);
       cairo_clip (cr);
     }
-#endif
 
     /* Paint the swatch using the text color to match the user's desktop theme.
      */
@@ -278,12 +286,21 @@ render (GtkCellRenderer      *cell,
     success = gtk_style_lookup_color (gtk_widget_get_style (widget),
                                       "text_color",
                                       &color);
+#endif
 
     if (success) {
+#ifdef ENABLE_GTK3
+      cairo_set_source_rgba (cr,
+                             color.red,
+                             color.green,
+                             color.blue,
+                             color.alpha);
+#else
       cairo_set_source_rgb (cr,
                             color.red   / 65535.0,
                             color.green / 65535.0,
                             color.blue  / 65535.0);
+#endif
     }
 
     cairo_move_to (cr,

--- a/libleptongui/src/gschem_log_widget.c
+++ b/libleptongui/src/gschem_log_widget.c
@@ -301,7 +301,11 @@ gschem_log_widget_init (GschemLogWidget *widget)
     {
       PangoFontDescription* fdesc = pango_font_description_from_string (font);
 
+#ifdef ENABLE_GTK3
+      gtk_widget_override_font (GTK_WIDGET (widget->viewer), fdesc);
+#else
       gtk_widget_modify_font (GTK_WIDGET (widget->viewer), fdesc);
+#endif
 
       pango_font_description_free (fdesc);
       g_free (font);

--- a/libleptongui/src/gschem_macro_widget.c
+++ b/libleptongui/src/gschem_macro_widget.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2013 gEDA Contributors
- * Copyright (C) 2017-2020 Lepton EDA Contributors
+ * Copyright (C) 2017-2021 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -673,7 +673,11 @@ command_entry_set_font (GtkWidget* entry)
   {
     PangoFontDescription* fdesc = pango_font_description_from_string (font);
 
+#ifdef ENABLE_GTK3
+    gtk_widget_override_font (entry, fdesc);
+#else
     gtk_widget_modify_font (entry, fdesc);
+#endif
 
     pango_font_description_free (fdesc);
     g_free (font);
@@ -682,4 +686,3 @@ command_entry_set_font (GtkWidget* entry)
   g_clear_error (&err);
 
 } /* command_entry_set_font() */
-

--- a/libleptongui/src/x_basic.c
+++ b/libleptongui/src/x_basic.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2016 gEDA Contributors
- * Copyright (C) 2017-2020 Lepton EDA Contributors
+ * Copyright (C) 2017-2021 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -40,5 +40,11 @@ void x_basic_warp_cursor (GtkWidget* widget, gint x, gint y)
   screen = gtk_widget_get_screen (widget);
   display = gdk_screen_get_display (screen);
 
+#ifdef ENABLE_GTK3
+  GdkDeviceManager *device_manager = gdk_display_get_device_manager (display);
+  GdkDevice *pointer = gdk_device_manager_get_client_pointer (device_manager);
+  gdk_device_warp (pointer, screen, window_x + x, window_y + y);
+#else
   gdk_display_warp_pointer (display, screen, window_x + x, window_y + y);
+#endif
 }

--- a/libleptongui/src/x_tabs.c
+++ b/libleptongui/src/x_tabs.c
@@ -660,7 +660,34 @@ x_tabs_nbook_create (GschemToplevel* w_current, GtkWidget* work_box)
   *
   */
 
-#ifndef ENABLE_GTK3
+  gtk_widget_set_name (nbook, "lepton-nbook");
+
+#ifdef ENABLE_GTK3
+  GtkStyleContext *context;
+  GtkCssProvider *provider;
+
+  const char* style_string =
+    "#lepton-nbook tab {\n"
+    "  min-width: 0;\n"
+    "  border-color: #777777;\n"
+    "  border-top-left-radius: 10px;\n"
+    "  border-top-right-radius: 10px;\n"
+    "  border-style: outset;\n"
+    "}\n";
+
+  context = gtk_widget_get_style_context (nbook);
+  provider = gtk_css_provider_new ();
+
+  gtk_css_provider_load_from_data (GTK_CSS_PROVIDER (provider),
+                                   style_string,
+                                   -1,
+                                   NULL);
+  gtk_style_context_add_provider (context,
+                                  GTK_STYLE_PROVIDER (provider),
+                                  GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
+  g_object_unref (provider);
+
+#else
   /* wider horizontal space:
   */
   gtk_rc_parse_string
@@ -673,9 +700,6 @@ x_tabs_nbook_create (GschemToplevel* w_current, GtkWidget* work_box)
     "widget \"*.lepton-nbook\" style \"lepton-nbook-style\""
   );
 #endif
-
-  gtk_widget_set_name (nbook, "lepton-nbook");
-
 
   g_signal_connect (nbook, "switch-page",
                     G_CALLBACK (&x_tabs_page_on_sel), w_current);

--- a/libleptongui/src/x_tabs.c
+++ b/libleptongui/src/x_tabs.c
@@ -660,6 +660,7 @@ x_tabs_nbook_create (GschemToplevel* w_current, GtkWidget* work_box)
   *
   */
 
+#ifndef ENABLE_GTK3
   /* wider horizontal space:
   */
   gtk_rc_parse_string
@@ -671,6 +672,7 @@ x_tabs_nbook_create (GschemToplevel* w_current, GtkWidget* work_box)
     "\n"
     "widget \"*.lepton-nbook\" style \"lepton-nbook-style\""
   );
+#endif
 
   gtk_widget_set_name (nbook, "lepton-nbook");
 
@@ -820,6 +822,7 @@ x_tabs_hdr_create (TabInfo* nfo)
     lab_txt = g_strdup (bname);
 
   GtkWidget* lab = gtk_label_new (NULL);
+  gtk_widget_set_name (lab, "lepton-tab-label" );
   gtk_label_set_markup (GTK_LABEL (lab), lab_txt);
   gtk_box_pack_start (GTK_BOX (box_lab), lab, TRUE, TRUE, 0);
 
@@ -836,7 +839,36 @@ x_tabs_hdr_create (TabInfo* nfo)
     gtk_widget_set_tooltip_text (box_hdr, fname);
   }
 
+  /* "close" btn:
+  */
+  GtkWidget* btn_close = gtk_button_new();
+  gtk_widget_set_name (btn_close, "lepton-tab-btn" );
+  gtk_button_set_relief (GTK_BUTTON (btn_close), GTK_RELIEF_NONE);
+  gtk_button_set_focus_on_click (GTK_BUTTON (btn_close), FALSE);
 
+
+#ifdef ENABLE_GTK3
+  GtkStyleContext *context;
+  GtkCssProvider *provider;
+
+  const char* style_string =
+    "#lepton-tab-label {\n"
+    "  padding-right: 5px;\n"
+    "}\n";
+
+  context = gtk_widget_get_style_context (lab);
+  provider = gtk_css_provider_new ();
+
+  gtk_css_provider_load_from_data (GTK_CSS_PROVIDER (provider),
+                                   style_string,
+                                   -1,
+                                   NULL);
+  gtk_style_context_add_provider (context,
+                                  GTK_STYLE_PROVIDER (provider),
+                                  GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
+  g_object_unref (provider);
+
+#else
   /* make tab btns smaller => smaller tabs:
   */
   gtk_rc_parse_string
@@ -851,14 +883,7 @@ x_tabs_hdr_create (TabInfo* nfo)
     "\n"
     "widget \"*.lepton-tab-btn\" style \"lepton-tab-btn-style\""
   );
-
-
-  /* "close" btn:
-  */
-  GtkWidget* btn_close = gtk_button_new();
-  gtk_widget_set_name (btn_close, "lepton-tab-btn" );
-  gtk_button_set_relief (GTK_BUTTON (btn_close), GTK_RELIEF_NONE);
-  gtk_button_set_focus_on_click (GTK_BUTTON (btn_close), FALSE);
+#endif
 
   GtkWidget* img_close = gtk_image_new_from_stock (GTK_STOCK_CLOSE,
                                                    GTK_ICON_SIZE_MENU);

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -472,9 +472,6 @@ x_window_create_main (GschemToplevel *w_current, GtkWidget *menubar)
   create_menubar (w_current, main_box, menubar);
 
 
-  gtk_widget_realize (w_current->main_window);
-
-
   /*
   *  toolbar:
   */


### PR DESCRIPTION
- Fixed warnings on functions deprecated in gtk/gdk 3.0.0
- Fixed a bug of not showing text of hidden attributes in the Multiattrib dialog
- Show tabs visually distinct

Update: Incidentally, the branch also fixes displaying the Object properties dialog in the docked view.