### PR TITLE
Fix visual representation of arcs.

### DIFF
--- a/liblepton/src/edacairo.c
+++ b/liblepton/src/edacairo.c
@@ -297,7 +297,7 @@ eda_cairo_arc (cairo_t *cr, int flags,
   cairo_device_to_user_distance (cr, &offset, &dummy);
   cairo_device_to_user_distance (cr, &s_radius, &dummy);
 
-  do_arc (cr, s_x + offset, s_y + offset,
+  do_arc (cr, s_x + offset, s_y - offset,
           s_radius, start_angle, sweep_angle);
 }
 


### PR DESCRIPTION
The one-liner fixes a long standing bug in arc representation on screen and in exported raster graphics reported several years ago by @NoSuchProcess for gschem on launchpad: [here](https://bugs.launchpad.net/geda/+bug/1504277).  There is a test symbol there to check how it looks like.

I attach here my own schematic and PNG files to test how it looks like before and after the change:
- [7400.sch.gz](https://github.com/lepton-eda/lepton-eda/files/6642469/7400.sch.gz)

- before:
![7400-before](https://user-images.githubusercontent.com/1515901/121781813-2e36f100-cbaf-11eb-9df1-de298fdeff78.png)

- after: 
![7400-after](https://user-images.githubusercontent.com/1515901/121781820-3a22b300-cbaf-11eb-9cac-1af90dcb788b.png)


