### PR TITLE
Fix 'make check' under root account

### DIFF
--- a/liblepton/scheme/unit-tests/geda-config.scm
+++ b/liblepton/scheme/unit-tests/geda-config.scm
@@ -93,6 +93,13 @@
     (test-equal a (geda:config-load! a))
     (test-assert (geda:config-loaded? a))
     (chmod *testdir-geda-Aconf* #o000) ;; Make conf unreadable
+
+    ; the next test will fail under root account, skip it:
+    ;
+    ( if ( eq? (getuid) 0 )
+      ( test-skip 1 )
+    )
+
     (test-assert-thrown 'system-error (geda:config-load! a #:force-load #t)))
 
   (test-assert-thrown 'system-error (geda:config-load! (geda:default-config-context) #:force-load #t))

--- a/liblepton/scheme/unit-tests/lepton-config.scm
+++ b/liblepton/scheme/unit-tests/lepton-config.scm
@@ -93,6 +93,13 @@
     (test-equal a (config-load! a))
     (test-assert (config-loaded? a))
     (chmod *testdirAconf* #o000) ;; Make conf unreadable
+
+    ; the next test will fail under root account, skip it:
+    ;
+    ( if ( eq? (getuid) 0 )
+      ( test-skip 1 )
+    )
+
     (test-assert-thrown 'system-error (config-load! a #:force-load #t)))
 
   (test-assert-thrown 'system-error (config-load! (default-config-context) #:force-load #t))


### PR DESCRIPTION
When running 'make check' under root account, skip
two tests that tries to read config file with 000
permissions (and expected to fail).
However, root user still can read such a file, so
run those test only under normal user account.
