### PR TITLE
Separate snap size and grid size status bar labels

### DIFF
--- a/libleptongui/include/gschem_bottom_widget.h
+++ b/libleptongui/include/gschem_bottom_widget.h
@@ -41,6 +41,8 @@ struct _GschemBottomWidget
 {
   GtkHBox parent;
 
+  GtkWidget *grid_snap_widget;
+
   GtkWidget *grid_label;
   int       grid_mode;
   int       grid_size;

--- a/libleptongui/include/gschem_bottom_widget.h
+++ b/libleptongui/include/gschem_bottom_widget.h
@@ -42,6 +42,7 @@ struct _GschemBottomWidget
   GtkHBox parent;
 
   GtkWidget *grid_snap_widget;
+  GtkWidget *grid_size_widget;
 
   GtkWidget *grid_label;
   int       grid_mode;

--- a/libleptongui/include/gschem_bottom_widget.h
+++ b/libleptongui/include/gschem_bottom_widget.h
@@ -44,7 +44,6 @@ struct _GschemBottomWidget
   GtkWidget *grid_snap_widget;
   GtkWidget *grid_size_widget;
 
-  GtkWidget *grid_label;
   int       grid_mode;
   int       grid_size;
   GtkWidget *left_button_label;

--- a/libleptongui/src/gschem_bottom_widget.c
+++ b/libleptongui/src/gschem_bottom_widget.c
@@ -93,7 +93,10 @@ static void
 update_magnetic_net_label (GschemBottomWidget *widget, GParamSpec *pspec, gpointer unused);
 
 
-static GObjectClass *gschem_bottom_widget_parent_class = NULL;
+
+/* convenience macro - gobject type implementation:
+*/
+G_DEFINE_TYPE (GschemBottomWidget, gschem_bottom_widget, GTK_TYPE_HBOX);
 
 
 
@@ -104,8 +107,10 @@ dispose (GObject *object)
 {
   /* lastly, chain up to the parent dispose */
 
-  g_return_if_fail (gschem_bottom_widget_parent_class != NULL);
-  gschem_bottom_widget_parent_class->dispose (object);
+  GschemBottomWidgetClass* cls = GSCHEM_BOTTOM_WIDGET_GET_CLASS (object);
+  GObjectClass* parent_cls = (GObjectClass*) g_type_class_peek_parent (cls);
+
+  parent_cls->dispose (object);
 }
 
 
@@ -117,8 +122,10 @@ finalize (GObject *object)
 {
   /* lastly, chain up to the parent finalize */
 
-  g_return_if_fail (gschem_bottom_widget_parent_class != NULL);
-  gschem_bottom_widget_parent_class->finalize (object);
+  GschemBottomWidgetClass* cls = GSCHEM_BOTTOM_WIDGET_GET_CLASS (object);
+  GObjectClass* parent_cls = (GObjectClass*) g_type_class_peek_parent (cls);
+
+  parent_cls->finalize (object);
 }
 
 
@@ -190,8 +197,6 @@ get_property (GObject *object, guint param_id, GValue *value, GParamSpec *pspec)
 static void
 gschem_bottom_widget_class_init (GschemBottomWidgetClass *klass)
 {
-  gschem_bottom_widget_parent_class = G_OBJECT_CLASS (g_type_class_peek_parent (klass));
-
   G_OBJECT_CLASS (klass)->dispose  = dispose;
   G_OBJECT_CLASS (klass)->finalize = finalize;
 
@@ -455,42 +460,6 @@ gschem_bottom_widget_get_magnetic_net_mode (GschemBottomWidget *widget)
   g_return_val_if_fail (widget != NULL, 0);
 
   return widget->magnetic_net_mode;
-}
-
-
-
-/*! \brief Get/register GschemBottomWidget type.
- */
-GType
-gschem_bottom_widget_get_type ()
-{
-  static GType type = 0;
-
-  if (type == 0) {
-    static const GTypeInfo info = {
-      sizeof(GschemBottomWidgetClass),
-      NULL,                                                    /* base_init */
-      NULL,                                                    /* base_finalize */
-      (GClassInitFunc) gschem_bottom_widget_class_init,
-      NULL,                                                    /* class_finalize */
-      NULL,                                                    /* class_data */
-      sizeof(GschemBottomWidget),
-      0,                                                       /* n_preallocs */
-      (GInstanceInitFunc) gschem_bottom_widget_init,
-    };
-
-    type = g_type_register_static (
-#ifdef ENABLE_GTK3
-                                   GTK_TYPE_BOX,
-#else
-                                   GTK_TYPE_HBOX,
-#endif
-                                   "GschemBottomWidget",
-                                   &info,
-                                   (GTypeFlags) 0);
-  }
-
-  return type;
 }
 
 

--- a/libleptongui/src/gschem_bottom_widget.c
+++ b/libleptongui/src/gschem_bottom_widget.c
@@ -603,7 +603,7 @@ update_snap_info_widget (GschemBottomWidget* widget)
   }
   else
   {
-    g_critical ("%s: update_grid_label(): widget->snap_mode out of range: %d\n",
+    g_critical ("%s: update_snap_info_widget(): widget->snap_mode out of range: %d\n",
                 __FILE__,
                 widget->snap_mode);
   }

--- a/libleptongui/src/gschem_bottom_widget.c
+++ b/libleptongui/src/gschem_bottom_widget.c
@@ -555,7 +555,7 @@ update_snap_info_widget (GschemBottomWidget* widget)
   EdaConfig* cfg = eda_config_get_context_for_path (cwd);
   g_free (cwd);
 
-  gint default_snap_size = 100;
+  gint default_snap_size = DEFAULT_SNAP_SIZE;
 
   if (cfg != NULL)
   {

--- a/libleptongui/src/gschem_bottom_widget.c
+++ b/libleptongui/src/gschem_bottom_widget.c
@@ -621,7 +621,7 @@ update_snap_info_widget (GschemBottomWidget* widget)
   if (widget->snap_mode != SNAP_OFF &&
       widget->snap_size != default_snap_size)
   {
-    gchar* tooltip = tooltip = g_strdup_printf(
+    gchar* tooltip = g_strdup_printf(
       _("Snap size.\n"
         "Attention: current snap size (%d) differs\n"
         "from the value set in configuration: %d."),
@@ -655,6 +655,56 @@ create_snap_info_widget (GschemBottomWidget* widget)
                         LABEL_XPAD,
                         LABEL_YPAD);
   gtk_box_pack_start (GTK_BOX (widget), widget->grid_snap_widget, FALSE, FALSE, 0);
+  gtk_box_pack_start (GTK_BOX (widget), gtk_vseparator_new(), FALSE, FALSE, 0);
+}
+
+
+
+static void
+update_grid_size_widget (GschemBottomWidget* widget)
+{
+  g_return_if_fail (widget != NULL);
+
+  gchar* str = NULL;
+
+  if (widget->grid_mode == GRID_MODE_NONE)
+  {
+    str = g_strdup (_("Grid: OFF"));
+  }
+  else
+  if (widget->grid_size <= 0)
+  {
+    str = g_strdup (_("Grid: NONE"));
+  }
+  else
+  {
+    str = g_strdup_printf ("Grid: %d", widget->grid_size);
+  }
+
+  gtk_label_set_label (GTK_LABEL(widget->grid_size_widget), str);
+  gtk_widget_set_tooltip_text (widget->grid_size_widget,
+                               _("Grid size"));
+  g_free (str);
+}
+
+
+
+static void
+create_grid_size_widget (GschemBottomWidget* widget)
+{
+  g_return_if_fail (widget != NULL);
+
+  widget->grid_size_widget = gtk_label_new (NULL);
+
+  gchar* str = g_strdup_printf ("Grid: %d", widget->grid_size);
+  gtk_label_set_markup (GTK_LABEL(widget->grid_size_widget),
+                        str);
+  g_free (str);
+
+  gtk_misc_set_padding (GTK_MISC (widget->grid_size_widget),
+                        LABEL_XPAD,
+                        LABEL_YPAD);
+  gtk_box_pack_start (GTK_BOX (widget), widget->grid_size_widget, FALSE, FALSE, 0);
   gtk_box_pack_start (GTK_BOX (widget), gtk_vseparator_new(), FALSE, FALSE, 0);
 }
 
@@ -772,6 +822,7 @@ gschem_bottom_widget_init (GschemBottomWidget *widget)
 
 
   create_snap_info_widget (widget);
+  create_grid_size_widget (widget);
 
 
   widget->grid_label = gtk_label_new (NULL);
@@ -1124,6 +1175,7 @@ static void
 update_grid_label (GschemBottomWidget *widget, GParamSpec *pspec, gpointer unused)
 {
   update_snap_info_widget (widget);
+  update_grid_size_widget (widget);
 
 
   if (widget->grid_label != NULL) {

--- a/libleptongui/src/gschem_bottom_widget.c
+++ b/libleptongui/src/gschem_bottom_widget.c
@@ -495,6 +495,11 @@ gschem_bottom_widget_get_type ()
 
 
 
+/*! \brief Set grid_snap_widget text
+ *
+ *  \param  widget  This GschemBottomWidget
+ *  \param  str     Text to set. Newly-allocated string. Will be g_free()'d
+ */
 static void
 set_snap_info_widget_text (GschemBottomWidget* widget,
                            gchar* str)
@@ -507,6 +512,11 @@ set_snap_info_widget_text (GschemBottomWidget* widget,
 
 
 
+/*! \brief Set grid_snap_widget color
+ *
+ *  \param  widget      This GschemBottomWidget
+ *  \param  color_name  Color name, e.g. "red", "blue"
+ */
 static void
 set_snap_info_widget_color (GschemBottomWidget* widget,
                             const gchar* color_name)
@@ -522,6 +532,12 @@ set_snap_info_widget_color (GschemBottomWidget* widget,
 
 
 
+/*! \brief Set grid_snap_widget text and color
+ *
+ *  \param  widget      This GschemBottomWidget
+ *  \param  str         Text to set. Newly-allocated string. Will be g_free()'d
+ *  \param  color_name  Color name, e.g. "red", "blue"
+ */
 static void
 set_snap_info_widget (GschemBottomWidget* widget,
                       gchar* str,
@@ -535,6 +551,13 @@ set_snap_info_widget (GschemBottomWidget* widget,
 
 
 
+/*! \brief Reset grid_snap_widget visual state
+ *
+ *  \par Function Description
+ *  Remove any text decorations, reset text color to black
+ *
+ *  \param  widget  This GschemBottomWidget
+ */
 static void
 reset_snap_info_widget (GschemBottomWidget* widget)
 {
@@ -546,6 +569,10 @@ reset_snap_info_widget (GschemBottomWidget* widget)
 
 
 
+/*! \brief Update info in the grid_snap_widget depending on current snap settings
+ *
+ *  \param  widget  This GschemBottomWidget
+ */
 static void
 update_snap_info_widget (GschemBottomWidget* widget)
 {
@@ -637,6 +664,10 @@ update_snap_info_widget (GschemBottomWidget* widget)
 
 
 
+/*! \brief Create grid_snap_widget
+ *
+ *  \param  widget  This GschemBottomWidget
+ */
 static void
 create_snap_info_widget (GschemBottomWidget* widget)
 {
@@ -655,6 +686,10 @@ create_snap_info_widget (GschemBottomWidget* widget)
 
 
 
+/*! \brief Update info in the grid_size_widget depending on current grid settings
+ *
+ *  \param  widget  This GschemBottomWidget
+ */
 static void
 update_grid_size_widget (GschemBottomWidget* widget)
 {
@@ -684,6 +719,10 @@ update_grid_size_widget (GschemBottomWidget* widget)
 
 
 
+/*! \brief Create grid_size_widget
+ *
+ *  \param  widget  This GschemBottomWidget
+ */
 static void
 create_grid_size_widget (GschemBottomWidget* widget)
 {

--- a/libleptongui/src/gschem_bottom_widget.c
+++ b/libleptongui/src/gschem_bottom_widget.c
@@ -643,8 +643,10 @@ create_snap_info_widget (GschemBottomWidget* widget)
   g_return_if_fail (widget != NULL);
 
   widget->grid_snap_widget = gtk_label_new (NULL);
-  gtk_label_set_markup (GTK_LABEL(widget->grid_snap_widget),
-                        "Snap: <b>100</b>");
+
+  gchar* str = g_strdup_printf ("Snap: <b>%d</b>", widget->snap_size);
+  gtk_label_set_markup (GTK_LABEL(widget->grid_snap_widget), str);
+  g_free (str);
 
   gtk_misc_set_padding (GTK_MISC (widget->grid_snap_widget),
                         LABEL_XPAD,

--- a/libleptongui/src/gschem_bottom_widget.c
+++ b/libleptongui/src/gschem_bottom_widget.c
@@ -590,10 +590,6 @@ update_snap_info_widget (GschemBottomWidget* widget)
       txt = g_strdup_printf (_("Snap: <b>%d</b>"), widget->snap_size);
       set_snap_info_widget (widget, txt, "red");
     }
-    else
-    {
-      reset_snap_info_widget (widget);
-    }
   }
   else
   if (widget->snap_mode == SNAP_RESNAP)
@@ -601,8 +597,7 @@ update_snap_info_widget (GschemBottomWidget* widget)
     if (widget->snap_size != default_snap_size)
     {
       txt = g_strdup_printf (_("<u>Re</u>snap: <b>%d</b>"), widget->snap_size);
-      set_snap_info_widget_text(widget, txt);
-      set_snap_info_widget_color(widget, "red");
+      set_snap_info_widget(widget, txt, "red");
     }
     else
     {

--- a/libleptongui/src/gschem_bottom_widget.c
+++ b/libleptongui/src/gschem_bottom_widget.c
@@ -825,11 +825,6 @@ gschem_bottom_widget_init (GschemBottomWidget *widget)
   create_grid_size_widget (widget);
 
 
-  widget->grid_label = gtk_label_new (NULL);
-  gtk_widget_set_tooltip_text (widget->grid_label, _("(Snap size, Grid size)"));
-  gtk_misc_set_padding (GTK_MISC (widget->grid_label), LABEL_XPAD, LABEL_YPAD);
-  gtk_box_pack_start (GTK_BOX (widget), widget->grid_label, FALSE, FALSE, 0);
-
   separator = gtk_vseparator_new ();
   gtk_box_pack_start (GTK_BOX (widget), separator, FALSE, FALSE, 0);
 
@@ -1165,7 +1160,7 @@ set_property (GObject *object, guint param_id, const GValue *value, GParamSpec *
 
 
 
-/*! \brief Write the grid settings to the gschem "status bar."
+/*! \brief Write the snap and grid settings to the status bar.
  *
  *  \param [in] widget This GschemBottomWidget
  *  \param [in] pspec  The parameter that changed
@@ -1176,48 +1171,6 @@ update_grid_label (GschemBottomWidget *widget, GParamSpec *pspec, gpointer unuse
 {
   update_snap_info_widget (widget);
   update_grid_size_widget (widget);
-
-
-  if (widget->grid_label != NULL) {
-    gchar *grid_text = NULL;
-    gchar *label_text = NULL;
-    gchar *snap_text = NULL;
-
-    switch (widget->snap_mode) {
-      case SNAP_OFF:
-        snap_text = g_strdup (_("OFF"));
-        break;
-
-      case SNAP_GRID:
-        snap_text = g_strdup_printf ("%d", widget->snap_size);
-        break;
-
-      case SNAP_RESNAP:
-        snap_text = g_strdup_printf ("%dR", widget->snap_size);
-        break;
-
-      default:
-        g_critical ("%s: update_grid_label(): widget->snap_mode out of range: %d\n", __FILE__, widget->snap_mode);
-    }
-
-    if (widget->grid_mode == GRID_MODE_NONE) {
-      grid_text = g_strdup (_("OFF"));
-    } else {
-      if (widget->grid_size <= 0) {
-        grid_text = g_strdup (_("NONE"));
-      } else {
-        grid_text = g_strdup_printf ("%d", widget->grid_size);
-      }
-    }
-
-    label_text = g_strdup_printf (_("Grid(%1$s, %2$s)"), snap_text, grid_text);
-
-    gtk_label_set_text (GTK_LABEL (widget->grid_label), label_text);
-
-    g_free (grid_text);
-    g_free (label_text);
-    g_free (snap_text);
-  }
 }
 
 

--- a/libleptongui/src/gschem_bottom_widget.c
+++ b/libleptongui/src/gschem_bottom_widget.c
@@ -550,7 +550,6 @@ static void
 update_snap_info_widget (GschemBottomWidget* widget)
 {
   g_return_if_fail (widget != NULL);
-//  g_return_if_fail ( && "widget->snap_mode out of range");
 
   gchar* cwd = g_get_current_dir();
   EdaConfig* cfg = eda_config_get_context_for_path (cwd);
@@ -588,7 +587,7 @@ update_snap_info_widget (GschemBottomWidget* widget)
   {
     if (widget->snap_size != default_snap_size)
     {
-      txt = g_strdup_printf ("Snap: <b>%d</b>", widget->snap_size);
+      txt = g_strdup_printf (_("Snap: <b>%d</b>"), widget->snap_size);
       set_snap_info_widget (widget, txt, "red");
     }
     else
@@ -601,13 +600,13 @@ update_snap_info_widget (GschemBottomWidget* widget)
   {
     if (widget->snap_size != default_snap_size)
     {
-      txt = g_strdup_printf ("<u>Re</u>snap: <b>%d</b>", widget->snap_size);
+      txt = g_strdup_printf (_("<u>Re</u>snap: <b>%d</b>"), widget->snap_size);
       set_snap_info_widget_text(widget, txt);
       set_snap_info_widget_color(widget, "red");
     }
     else
     {
-      txt = g_strdup_printf ("<u>Re</u>snap: %d", widget->snap_size);
+      txt = g_strdup_printf (_("<u>Re</u>snap: %d"), widget->snap_size);
       set_snap_info_widget_text(widget, txt);
     }
   }
@@ -616,6 +615,27 @@ update_snap_info_widget (GschemBottomWidget* widget)
     g_critical ("%s: update_grid_label(): widget->snap_mode out of range: %d\n",
                 __FILE__,
                 widget->snap_mode);
+  }
+
+
+  if (widget->snap_mode != SNAP_OFF &&
+      widget->snap_size != default_snap_size)
+  {
+    gchar* tooltip = tooltip = g_strdup_printf(
+      _("Snap size.\n"
+        "Attention: current snap size (%d) differs\n"
+        "from the value set in configuration: %d."),
+        widget->snap_size,
+        default_snap_size);
+
+    gtk_widget_set_tooltip_text (widget->grid_snap_widget,
+                                   tooltip);
+    g_free (tooltip);
+  }
+  else
+  {
+    gtk_widget_set_tooltip_text (widget->grid_snap_widget,
+                                 _("Snap size"));
   }
 
 } /* update_snap_info_widget() */


### PR DESCRIPTION
Separate snap size and grid size status bar labels, draw user's
attention by setting snap size label text decoration and color
when grid size is differs from the value set in configuration
(how many times did I screw up my symbols while grid size
was not set properly!).

old:

![0](https://user-images.githubusercontent.com/26083750/122861482-1417b400-d30f-11eb-91ee-ea1c77379090.png)

new:

![1](https://user-images.githubusercontent.com/26083750/122859883-3fe56a80-d30c-11eb-86dc-831e0d7c842d.png)

![2](https://user-images.githubusercontent.com/26083750/122859892-4542b500-d30c-11eb-836d-9b2209f5893b.png)

![3](https://user-images.githubusercontent.com/26083750/122859904-4a076900-d30c-11eb-8a24-0df172ad74e5.png)

![4](https://user-images.githubusercontent.com/26083750/122859912-4d9af000-d30c-11eb-8bf3-30c211fc82d1.png)

![5](https://user-images.githubusercontent.com/26083750/122859921-5095e080-d30c-11eb-9721-27557588c953.png)
