### PR TITLE
Rewrite object-connections() using Scheme FFI

### DIFF
--- a/liblepton/scheme/Makefile.am
+++ b/liblepton/scheme/Makefile.am
@@ -21,6 +21,7 @@ nobase_dist_scmdata_DATA = \
 	lepton/log.scm \
 	lepton/log-rotate.scm \
 	lepton/object.scm \
+	lepton/object/foreign.scm \
 	lepton/object/type.scm \
 	lepton/option.scm \
 	lepton/os.scm \

--- a/liblepton/scheme/lepton/ffi.scm.in
+++ b/liblepton/scheme/lepton/ffi.scm.in
@@ -240,6 +240,7 @@
             s_clib_init
 
             s_conn_remove_object_connections
+            s_conn_return_others
             s_conn_update_object
 
             s_toplevel_page_current))
@@ -509,6 +510,7 @@
 
 ;; s_conn.c
 (define-lff s_conn_remove_object_connections void '(*))
+(define-lff s_conn_return_others '* '(* *))
 (define-lff s_conn_update_object void '(* *))
 
 (define (check-boolean val pos)

--- a/liblepton/scheme/lepton/ffi.scm.in
+++ b/liblepton/scheme/lepton/ffi.scm.in
@@ -16,6 +16,7 @@
 ;;; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 (define-module (lepton ffi)
+  #:use-module (ice-9 match)
   #:use-module (system foreign)
   #:use-module (srfi srfi-1)
 
@@ -31,8 +32,13 @@
             check-vector
 
             ;; glib, gobject.
+            g_list_free
             g_log
             g_object_unref
+            ;; Mock glib functions.
+            glist-data
+            glist-next
+            glist-prev
 
             ;; Foreign functions.
             edascm_is_config
@@ -266,8 +272,33 @@
                            args))))
          (force proc))))))
 
+(define-lff g_list_free void '(*) libglib)
 (define-lff g_log void (list '* int '* '*) libglib)
 (define-lff g_object_unref void '(*) libgobject)
+
+;;; Glist struct is {data*, next*, prev*}.  We could use libglib
+;;; functions to get data, but it's easier to parse the struct
+;;; directly.
+(define (parse-glist gls)
+  (parse-c-struct gls '(* * *)))
+
+(define (glist-next gls)
+  (let ((pointer-ls (parse-glist gls)))
+    (match pointer-ls
+      ((data next prev) next)
+      (_ (error "Wrong Glist in glist-next()")))))
+
+(define (glist-prev gls)
+  (let ((pointer-ls (parse-glist gls)))
+    (match pointer-ls
+      ((data next prev) prev)
+      (_ (error "Wrong Glist in glist-prev()")))))
+
+(define (glist-data gls)
+  (let ((pointer-ls (parse-glist gls)))
+    (match pointer-ls
+      ((data next prev) data)
+      (_ (error "Wrong Glist in glist-data()")))))
 
 ;;; Basic lepton initialisation function.
 (define-lff liblepton_init void '())

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -41,6 +41,7 @@
             object-color
             set-object-color!
             object-component
+            object-connections
             object-embedded?
             set-object-embedded!
             object-id
@@ -174,7 +175,26 @@ Returns OBJECT."
   object)
 
 
-(define-public object-connections %object-connections)
+(define (object-connections object)
+  "Returns a list of other objects that are directly connected to
+OBJECT.  If OBJECT is not included in a page, raises an
+'object-state error.  The connections reported are independent of
+inclusion in components and includes only primitive objects such
+as pins, nets, or buses."
+  (define pointer (geda-object->pointer* object 1))
+
+  (when (null-pointer? (lepton_object_get_page pointer))
+    (scm-error 'object-state
+               'object-connections
+               "Object ~A is not included in a page."
+               (list object)
+               '()))
+
+  (let* ((gls (s_conn_return_others %null-pointer pointer))
+         (ls (glist->object-list gls)))
+
+    (g_list_free gls)
+    ls))
 
 
 (define (object-component object)

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -33,6 +33,7 @@
 
   #:use-module (lepton color-map)
   #:use-module (lepton ffi)
+  #:use-module (lepton object foreign)
   #:use-module (lepton object type)
 
   #:export (copy-object

--- a/liblepton/scheme/lepton/object/foreign.scm
+++ b/liblepton/scheme/lepton/object/foreign.scm
@@ -1,0 +1,37 @@
+;;; Lepton EDA library - Scheme API
+;;; Copyright (C) 2021 Lepton EDA Contributors
+;;;
+;;; This program is free software; you can redistribute it and/or modify
+;;; it under the terms of the GNU General Public License as published by
+;;; the Free Software Foundation; either version 2 of the License, or
+;;; (at your option) any later version.
+;;;
+;;; This program is distributed in the hope that it will be useful,
+;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;; GNU General Public License for more details.
+;;;
+;;; You should have received a copy of the GNU General Public License
+;;; along with this program; if not, write to the Free Software
+;;; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
+(define-module (lepton object foreign)
+  #:use-module (system foreign)
+
+  #:use-module (lepton ffi)
+
+  #:export (geda-object->pointer
+            pointer->geda-object))
+
+
+;;; Helper transformers between #<geda-object> smobs and C object
+;;; pointers.
+(define (geda-object->pointer smob)
+  (or (false-if-exception (edascm_to_object (scm->pointer smob)))
+      ;; Return NULL if the SMOB is not the #<geda-object> smob.
+      %null-pointer))
+
+(define (pointer->geda-object pointer)
+  ;; Return #f if the pointer is wrong.
+  (false-if-exception (pointer->scm (edascm_from_object pointer))))

--- a/liblepton/scheme/lepton/object/foreign.scm
+++ b/liblepton/scheme/lepton/object/foreign.scm
@@ -22,8 +22,8 @@
   #:use-module (lepton ffi)
 
   #:export (geda-object->pointer
-            pointer->geda-object))
-
+            pointer->geda-object
+            glist->object-list))
 
 ;;; Helper transformers between #<geda-object> smobs and C object
 ;;; pointers.
@@ -35,3 +35,13 @@
 (define (pointer->geda-object pointer)
   ;; Return #f if the pointer is wrong.
   (false-if-exception (pointer->scm (edascm_from_object pointer))))
+
+(define (glist->object-list gls)
+  "Convert a GList of objects GLS into a Scheme list.  Returns the
+Scheme list."
+  (let loop ((gls gls)
+             (ls '()))
+    (if (null-pointer? gls)
+        (reverse ls)
+        (loop (glist-next gls)
+              (cons (pointer->geda-object (glist-data gls)) ls)))))

--- a/liblepton/scheme/lepton/object/foreign.scm
+++ b/liblepton/scheme/lepton/object/foreign.scm
@@ -21,7 +21,8 @@
 
   #:use-module (lepton ffi)
 
-  #:export (geda-object->pointer
+  #:export (geda-object-pointer?
+            geda-object->pointer
             pointer->geda-object
             glist->object-list))
 
@@ -35,6 +36,9 @@
 (define (pointer->geda-object pointer)
   ;; Return #f if the pointer is wrong.
   (false-if-exception (pointer->scm (edascm_from_object pointer))))
+
+(define (geda-object-pointer? pointer)
+  (true? (edascm_is_object pointer)))
 
 (define (glist->object-list gls)
   "Converts a GList of foreign object pointers GLS into a Scheme

--- a/liblepton/scheme/lepton/object/foreign.scm
+++ b/liblepton/scheme/lepton/object/foreign.scm
@@ -37,8 +37,8 @@
   (false-if-exception (pointer->scm (edascm_from_object pointer))))
 
 (define (glist->object-list gls)
-  "Convert a GList of objects GLS into a Scheme list.  Returns the
-Scheme list."
+  "Converts a GList of foreign object pointers GLS into a Scheme
+list.  Returns the Scheme list of objects."
   (let loop ((gls gls)
              (ls '()))
     (if (null-pointer? gls)

--- a/liblepton/scheme/lepton/object/type.scm
+++ b/liblepton/scheme/lepton/object/type.scm
@@ -22,9 +22,9 @@
   #:use-module (system foreign)
 
   #:use-module (lepton ffi)
+  #:use-module (lepton object foreign)
 
   #:export (geda-object->pointer*
-            pointer->geda-object
 
             arc?
             box?
@@ -43,18 +43,6 @@
             object?
             object-type
             object-type?))
-
-
-;;; Helper transformers between #<geda-object> smobs and C object
-;;; pointers.
-(define (geda-object->pointer smob)
-  (or (false-if-exception (edascm_to_object (scm->pointer smob)))
-      ;; Return NULL if the SMOB is not the #<geda-object> smob.
-      %null-pointer))
-
-(define (pointer->geda-object pointer)
-  ;; Return #f if the pointer is wrong.
-  (false-if-exception (pointer->scm (edascm_from_object pointer))))
 
 ;;; This syntax rule is intended for use in toplevel 'define' or
 ;;; 'let' forms in the functions where the check for wrong type of

--- a/liblepton/scheme/lepton/object/type.scm
+++ b/liblepton/scheme/lepton/object/type.scm
@@ -96,7 +96,7 @@
 (define (object? object)
   "Returns #t if OBJECT is a #<geda-object> instance, otherwise
 returns #f."
-  (true? (edascm_is_object (scm->pointer object))))
+  (geda-object-pointer? (scm->pointer object)))
 
 
 (define (arc? object)

--- a/liblepton/scheme/unit-tests/lepton-object-connections.scm
+++ b/liblepton/scheme/unit-tests/lepton-object-connections.scm
@@ -105,3 +105,10 @@
     (close-page! Q)))
 
 (test-end "object-connection-functions")
+
+
+(test-begin "object-connections-wrong-argument")
+
+(test-assert-thrown 'wrong-type-arg (object-connections 'x))
+
+(test-end "object-connections-wrong-argument")

--- a/liblepton/scheme/unit-tests/lepton-object-type.scm
+++ b/liblepton/scheme/unit-tests/lepton-object-type.scm
@@ -3,6 +3,7 @@
 (use-modules (srfi srfi-1)
              (srfi srfi-26)
              (system foreign)
+             (lepton object foreign)
              (lepton object type)
              (lepton object))
 

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -117,39 +117,6 @@ edascm_is_object_type (SCM smob, int type)
   return (lepton_object_get_type (obj) == type);
 }
 
-/*! \brief Get objects that are connected to an object.
- * \par Function Description
- * Returns a list of all objects directly connected to \a obj_s.  If
- * \a obj_s is not included in a page, throws a Scheme error.  If \a
- * obj_s is not a pin, net, bus, or component object, returns the empty
- * list.
- *
- * \note Scheme API: Implements the %object-connections procedure of
- * the (lepton core object) module.
- *
- * \param obj_s #LeptonObject smob for object to get connections for.
- * \return a list of #LeptonObject smobs.
- */
-SCM_DEFINE (object_connections, "%object-connections", 1, 0, 0,
-            (SCM obj_s), "Get objects that are connected to an object.")
-{
-  /* Ensure that the argument is an object smob */
-  SCM_ASSERT (edascm_is_object (obj_s), obj_s,
-              SCM_ARG1, s_object_connections);
-
-  LeptonObject *obj = edascm_to_object (obj_s);
-  if (lepton_object_get_page (obj) == NULL) {
-    scm_error (edascm_object_state_sym,
-               s_object_connections,
-               _("Object ~A is not included in a page."),
-               scm_list_1 (obj_s), SCM_EOL);
-  }
-
-  GList *lst = s_conn_return_others (NULL, obj);
-  SCM result = edascm_from_object_glist (lst);
-  g_list_free (lst);
-  return result;
-}
 
 /*!
  * \brief Create the (lepton core object) Scheme module.
@@ -164,8 +131,7 @@ init_module_lepton_core_object (void *unused)
   #include "scheme_object.x"
 
   /* Add them to the module's public definitions. */
-  scm_c_export (s_object_connections,
-                NULL);
+  scm_c_export (NULL);
 }
 
 /*!

--- a/utils/netlist/tests/hierarchy-config_mangle_net_attribute_false_1.out
+++ b/utils/netlist/tests/hierarchy-config_mangle_net_attribute_false_1.out
@@ -24,15 +24,15 @@ Utop/middleA -> U1_2_to_B
 Uunder/middleA -> U1_2_to_B
 Utop/Umiddle/rockA -> U1_2_to_B
 Uunder/Umiddle/rockA -> U1_2_to_B
-Utop/Umiddle/Urock/unnamed_net_at_18600x38200 -> U1_2_to_B
-Uunder/Umiddle/Urock/unnamed_net_at_18600x38200 -> U1_2_to_B
+Utop/Umiddle/Urock/unnamed_net_at_5900x4500 -> U1_2_to_B
+Uunder/Umiddle/Urock/unnamed_net_at_5900x4500 -> U1_2_to_B
 U2_1_to_E -> U2_1_to_E-net
 Utop/middleB -> U2_1_to_E-net
 Uunder/middleB -> U2_1_to_E-net
 Utop/Umiddle/rockB -> U2_1_to_E-net
 Uunder/Umiddle/rockB -> U2_1_to_E-net
-Utop/Umiddle/Urock/unnamed_net_at_22100x37700 -> U2_1_to_E-net
-Uunder/Umiddle/Urock/unnamed_net_at_22100x37700 -> U2_1_to_E-net
+Utop/Umiddle/Urock/unnamed_net_at_8300x4500 -> U2_1_to_E-net
+Uunder/Umiddle/Urock/unnamed_net_at_8300x4500 -> U2_1_to_E-net
 
 END renamed-nets
 

--- a/utils/netlist/tests/hierarchy-config_mangle_net_attribute_false_2.out
+++ b/utils/netlist/tests/hierarchy-config_mangle_net_attribute_false_2.out
@@ -24,15 +24,15 @@ Utop/middleA -> U1_2_to_B
 Uunder/middleA -> U1_2_to_B
 Utop/Umiddle/rockA -> U1_2_to_B
 Uunder/Umiddle/rockA -> U1_2_to_B
-Utop/Umiddle/Urock/unnamed_net_at_18600x38200 -> U1_2_to_B
-Uunder/Umiddle/Urock/unnamed_net_at_18600x38200 -> U1_2_to_B
+Utop/Umiddle/Urock/unnamed_net_at_5900x4500 -> U1_2_to_B
+Uunder/Umiddle/Urock/unnamed_net_at_5900x4500 -> U1_2_to_B
 U2_1_to_E -> U2_1_to_E-net
 Utop/middleB -> U2_1_to_E-net
 Uunder/middleB -> U2_1_to_E-net
 Utop/Umiddle/rockB -> U2_1_to_E-net
 Uunder/Umiddle/rockB -> U2_1_to_E-net
-Utop/Umiddle/Urock/unnamed_net_at_22100x37700 -> U2_1_to_E-net
-Uunder/Umiddle/Urock/unnamed_net_at_22100x37700 -> U2_1_to_E-net
+Utop/Umiddle/Urock/unnamed_net_at_8300x4500 -> U2_1_to_E-net
+Uunder/Umiddle/Urock/unnamed_net_at_8300x4500 -> U2_1_to_E-net
 
 END renamed-nets
 

--- a/utils/netlist/tests/hierarchy-config_mangle_netname_attribute_false_1.out
+++ b/utils/netlist/tests/hierarchy-config_mangle_netname_attribute_false_1.out
@@ -24,15 +24,15 @@ middleA -> U1_2_to_B
 middleA -> U1_2_to_B
 rockA -> U1_2_to_B
 rockA -> U1_2_to_B
-unnamed_net_at_18600x38200 -> U1_2_to_B
-unnamed_net_at_18600x38200 -> U1_2_to_B
+unnamed_net_at_5900x4500 -> U1_2_to_B
+unnamed_net_at_5900x4500 -> U1_2_to_B
 U2_1_to_E -> U2_1_to_E-net
 middleB -> U2_1_to_E-net
 middleB -> U2_1_to_E-net
 rockB -> U2_1_to_E-net
 rockB -> U2_1_to_E-net
-unnamed_net_at_22100x37700 -> U2_1_to_E-net
-unnamed_net_at_22100x37700 -> U2_1_to_E-net
+unnamed_net_at_8300x4500 -> U2_1_to_E-net
+unnamed_net_at_8300x4500 -> U2_1_to_E-net
 
 END renamed-nets
 

--- a/utils/netlist/tests/hierarchy-config_mangle_netname_attribute_false_2.out
+++ b/utils/netlist/tests/hierarchy-config_mangle_netname_attribute_false_2.out
@@ -24,15 +24,15 @@ middleA -> U1_2_to_B
 middleA -> U1_2_to_B
 rockA -> U1_2_to_B
 rockA -> U1_2_to_B
-unnamed_net_at_18600x38200 -> U1_2_to_B
-unnamed_net_at_18600x38200 -> U1_2_to_B
+unnamed_net_at_5900x4500 -> U1_2_to_B
+unnamed_net_at_5900x4500 -> U1_2_to_B
 U2_1_to_E -> U2_1_to_E-net
 middleB -> U2_1_to_E-net
 middleB -> U2_1_to_E-net
 rockB -> U2_1_to_E-net
 rockB -> U2_1_to_E-net
-unnamed_net_at_22100x37700 -> U2_1_to_E-net
-unnamed_net_at_22100x37700 -> U2_1_to_E-net
+unnamed_net_at_8300x4500 -> U2_1_to_E-net
+unnamed_net_at_8300x4500 -> U2_1_to_E-net
 
 END renamed-nets
 

--- a/utils/netlist/tests/hierarchy-config_mangle_refdes_attribute_false_1.out
+++ b/utils/netlist/tests/hierarchy-config_mangle_refdes_attribute_false_1.out
@@ -23,15 +23,15 @@ Utop/middleA -> U1_2_to_B
 Uunder/middleA -> U1_2_to_B
 Utop/Umiddle/rockA -> U1_2_to_B
 Uunder/Umiddle/rockA -> U1_2_to_B
-Utop/Umiddle/Urock/unnamed_net_at_18600x38200 -> U1_2_to_B
-Uunder/Umiddle/Urock/unnamed_net_at_18600x38200 -> U1_2_to_B
+Utop/Umiddle/Urock/unnamed_net_at_5900x4500 -> U1_2_to_B
+Uunder/Umiddle/Urock/unnamed_net_at_5900x4500 -> U1_2_to_B
 U2_1_to_E -> U2_1_to_E-net
 Utop/middleB -> U2_1_to_E-net
 Uunder/middleB -> U2_1_to_E-net
 Utop/Umiddle/rockB -> U2_1_to_E-net
 Uunder/Umiddle/rockB -> U2_1_to_E-net
-Utop/Umiddle/Urock/unnamed_net_at_22100x37700 -> U2_1_to_E-net
-Uunder/Umiddle/Urock/unnamed_net_at_22100x37700 -> U2_1_to_E-net
+Utop/Umiddle/Urock/unnamed_net_at_8300x4500 -> U2_1_to_E-net
+Uunder/Umiddle/Urock/unnamed_net_at_8300x4500 -> U2_1_to_E-net
 
 END renamed-nets
 

--- a/utils/netlist/tests/hierarchy-config_mangle_refdes_attribute_false_2.out
+++ b/utils/netlist/tests/hierarchy-config_mangle_refdes_attribute_false_2.out
@@ -23,15 +23,15 @@ Utop/middleA -> U1_2_to_B
 Uunder/middleA -> U1_2_to_B
 Utop/Umiddle/rockA -> U1_2_to_B
 Uunder/Umiddle/rockA -> U1_2_to_B
-Utop/Umiddle/Urock/unnamed_net_at_18600x38200 -> U1_2_to_B
-Uunder/Umiddle/Urock/unnamed_net_at_18600x38200 -> U1_2_to_B
+Utop/Umiddle/Urock/unnamed_net_at_5900x4500 -> U1_2_to_B
+Uunder/Umiddle/Urock/unnamed_net_at_5900x4500 -> U1_2_to_B
 U2_1_to_E -> U2_1_to_E-net
 Utop/middleB -> U2_1_to_E-net
 Uunder/middleB -> U2_1_to_E-net
 Utop/Umiddle/rockB -> U2_1_to_E-net
 Uunder/Umiddle/rockB -> U2_1_to_E-net
-Utop/Umiddle/Urock/unnamed_net_at_22100x37700 -> U2_1_to_E-net
-Uunder/Umiddle/Urock/unnamed_net_at_22100x37700 -> U2_1_to_E-net
+Utop/Umiddle/Urock/unnamed_net_at_8300x4500 -> U2_1_to_E-net
+Uunder/Umiddle/Urock/unnamed_net_at_8300x4500 -> U2_1_to_E-net
 
 END renamed-nets
 

--- a/utils/netlist/tests/hierarchy-config_mangle_refdes_attribute_true.out
+++ b/utils/netlist/tests/hierarchy-config_mangle_refdes_attribute_true.out
@@ -24,15 +24,15 @@ Utop/middleA -> U1_2_to_B
 Uunder/middleA -> U1_2_to_B
 Utop/Umiddle/rockA -> U1_2_to_B
 Uunder/Umiddle/rockA -> U1_2_to_B
-Utop/Umiddle/Urock/unnamed_net_at_18600x38200 -> U1_2_to_B
-Uunder/Umiddle/Urock/unnamed_net_at_18600x38200 -> U1_2_to_B
+Utop/Umiddle/Urock/unnamed_net_at_5900x4500 -> U1_2_to_B
+Uunder/Umiddle/Urock/unnamed_net_at_5900x4500 -> U1_2_to_B
 U2_1_to_E -> U2_1_to_E-net
 Utop/middleB -> U2_1_to_E-net
 Uunder/middleB -> U2_1_to_E-net
 Utop/Umiddle/rockB -> U2_1_to_E-net
 Uunder/Umiddle/rockB -> U2_1_to_E-net
-Utop/Umiddle/Urock/unnamed_net_at_22100x37700 -> U2_1_to_E-net
-Uunder/Umiddle/Urock/unnamed_net_at_22100x37700 -> U2_1_to_E-net
+Utop/Umiddle/Urock/unnamed_net_at_8300x4500 -> U2_1_to_E-net
+Uunder/Umiddle/Urock/unnamed_net_at_8300x4500 -> U2_1_to_E-net
 
 END renamed-nets
 

--- a/utils/netlist/tests/hierarchy-config_net_attribute_order_false.out
+++ b/utils/netlist/tests/hierarchy-config_net_attribute_order_false.out
@@ -24,15 +24,15 @@ Utop/middleA -> U1_2_to_B
 Uunder/middleA -> U1_2_to_B
 Utop/Umiddle/rockA -> U1_2_to_B
 Uunder/Umiddle/rockA -> U1_2_to_B
-Utop/Umiddle/Urock/unnamed_net_at_18600x38200 -> U1_2_to_B
-Uunder/Umiddle/Urock/unnamed_net_at_18600x38200 -> U1_2_to_B
+Utop/Umiddle/Urock/unnamed_net_at_5900x4500 -> U1_2_to_B
+Uunder/Umiddle/Urock/unnamed_net_at_5900x4500 -> U1_2_to_B
 U2_1_to_E -> U2_1_to_E-net
 Utop/middleB -> U2_1_to_E-net
 Uunder/middleB -> U2_1_to_E-net
 Utop/Umiddle/rockB -> U2_1_to_E-net
 Uunder/Umiddle/rockB -> U2_1_to_E-net
-Utop/Umiddle/Urock/unnamed_net_at_22100x37700 -> U2_1_to_E-net
-Uunder/Umiddle/Urock/unnamed_net_at_22100x37700 -> U2_1_to_E-net
+Utop/Umiddle/Urock/unnamed_net_at_8300x4500 -> U2_1_to_E-net
+Uunder/Umiddle/Urock/unnamed_net_at_8300x4500 -> U2_1_to_E-net
 
 END renamed-nets
 

--- a/utils/netlist/tests/hierarchy-config_net_attribute_order_true.out
+++ b/utils/netlist/tests/hierarchy-config_net_attribute_order_true.out
@@ -24,15 +24,15 @@ Utop/middleA -> U1_2_to_B
 Uunder/middleA -> U1_2_to_B
 Utop/Umiddle/rockA -> U1_2_to_B
 Uunder/Umiddle/rockA -> U1_2_to_B
-Utop/Umiddle/Urock/unnamed_net_at_18600x38200 -> U1_2_to_B
-Uunder/Umiddle/Urock/unnamed_net_at_18600x38200 -> U1_2_to_B
+Utop/Umiddle/Urock/unnamed_net_at_5900x4500 -> U1_2_to_B
+Uunder/Umiddle/Urock/unnamed_net_at_5900x4500 -> U1_2_to_B
 U2_1_to_E -> U2_1_to_E-net
 Utop/middleB -> U2_1_to_E-net
 Uunder/middleB -> U2_1_to_E-net
 Utop/Umiddle/rockB -> U2_1_to_E-net
 Uunder/Umiddle/rockB -> U2_1_to_E-net
-Utop/Umiddle/Urock/unnamed_net_at_22100x37700 -> U2_1_to_E-net
-Uunder/Umiddle/Urock/unnamed_net_at_22100x37700 -> U2_1_to_E-net
+Utop/Umiddle/Urock/unnamed_net_at_8300x4500 -> U2_1_to_E-net
+Uunder/Umiddle/Urock/unnamed_net_at_8300x4500 -> U2_1_to_E-net
 
 END renamed-nets
 

--- a/utils/netlist/tests/hierarchy-config_net_attribute_separator_1.out
+++ b/utils/netlist/tests/hierarchy-config_net_attribute_separator_1.out
@@ -24,15 +24,15 @@ Utop/middleA -> U1_2_to_B
 Uunder/middleA -> U1_2_to_B
 Utop/Umiddle/rockA -> U1_2_to_B
 Uunder/Umiddle/rockA -> U1_2_to_B
-Utop/Umiddle/Urock/unnamed_net_at_18600x38200 -> U1_2_to_B
-Uunder/Umiddle/Urock/unnamed_net_at_18600x38200 -> U1_2_to_B
+Utop/Umiddle/Urock/unnamed_net_at_5900x4500 -> U1_2_to_B
+Uunder/Umiddle/Urock/unnamed_net_at_5900x4500 -> U1_2_to_B
 U2_1_to_E -> U2_1_to_E-net
 Utop/middleB -> U2_1_to_E-net
 Uunder/middleB -> U2_1_to_E-net
 Utop/Umiddle/rockB -> U2_1_to_E-net
 Uunder/Umiddle/rockB -> U2_1_to_E-net
-Utop/Umiddle/Urock/unnamed_net_at_22100x37700 -> U2_1_to_E-net
-Uunder/Umiddle/Urock/unnamed_net_at_22100x37700 -> U2_1_to_E-net
+Utop/Umiddle/Urock/unnamed_net_at_8300x4500 -> U2_1_to_E-net
+Uunder/Umiddle/Urock/unnamed_net_at_8300x4500 -> U2_1_to_E-net
 
 END renamed-nets
 

--- a/utils/netlist/tests/hierarchy-config_net_attribute_separator_2.out
+++ b/utils/netlist/tests/hierarchy-config_net_attribute_separator_2.out
@@ -24,15 +24,15 @@ Utop/middleA -> U1_2_to_B
 Uunder/middleA -> U1_2_to_B
 Utop/Umiddle/rockA -> U1_2_to_B
 Uunder/Umiddle/rockA -> U1_2_to_B
-Utop/Umiddle/Urock/unnamed_net_at_18600x38200 -> U1_2_to_B
-Uunder/Umiddle/Urock/unnamed_net_at_18600x38200 -> U1_2_to_B
+Utop/Umiddle/Urock/unnamed_net_at_5900x4500 -> U1_2_to_B
+Uunder/Umiddle/Urock/unnamed_net_at_5900x4500 -> U1_2_to_B
 U2_1_to_E -> U2_1_to_E-net
 Utop/middleB -> U2_1_to_E-net
 Uunder/middleB -> U2_1_to_E-net
 Utop/Umiddle/rockB -> U2_1_to_E-net
 Uunder/Umiddle/rockB -> U2_1_to_E-net
-Utop/Umiddle/Urock/unnamed_net_at_22100x37700 -> U2_1_to_E-net
-Uunder/Umiddle/Urock/unnamed_net_at_22100x37700 -> U2_1_to_E-net
+Utop/Umiddle/Urock/unnamed_net_at_8300x4500 -> U2_1_to_E-net
+Uunder/Umiddle/Urock/unnamed_net_at_8300x4500 -> U2_1_to_E-net
 
 END renamed-nets
 

--- a/utils/netlist/tests/hierarchy-config_net_naming_priority_net.out
+++ b/utils/netlist/tests/hierarchy-config_net_naming_priority_net.out
@@ -24,15 +24,15 @@ Utop/middleA -> U1_2_to_B
 Uunder/middleA -> U1_2_to_B
 Utop/Umiddle/rockA -> U1_2_to_B
 Uunder/Umiddle/rockA -> U1_2_to_B
-Utop/Umiddle/Urock/unnamed_net_at_18600x38200 -> U1_2_to_B
-Uunder/Umiddle/Urock/unnamed_net_at_18600x38200 -> U1_2_to_B
+Utop/Umiddle/Urock/unnamed_net_at_5900x4500 -> U1_2_to_B
+Uunder/Umiddle/Urock/unnamed_net_at_5900x4500 -> U1_2_to_B
 U2_1_to_E -> U2_1_to_E-net
 Utop/middleB -> U2_1_to_E-net
 Uunder/middleB -> U2_1_to_E-net
 Utop/Umiddle/rockB -> U2_1_to_E-net
 Uunder/Umiddle/rockB -> U2_1_to_E-net
-Utop/Umiddle/Urock/unnamed_net_at_22100x37700 -> U2_1_to_E-net
-Uunder/Umiddle/Urock/unnamed_net_at_22100x37700 -> U2_1_to_E-net
+Utop/Umiddle/Urock/unnamed_net_at_8300x4500 -> U2_1_to_E-net
+Uunder/Umiddle/Urock/unnamed_net_at_8300x4500 -> U2_1_to_E-net
 
 END renamed-nets
 

--- a/utils/netlist/tests/hierarchy-config_net_naming_priority_netname.out
+++ b/utils/netlist/tests/hierarchy-config_net_naming_priority_netname.out
@@ -24,15 +24,15 @@ Utop/middleA -> U1_2_to_B
 Uunder/middleA -> U1_2_to_B
 Utop/Umiddle/rockA -> U1_2_to_B
 Uunder/Umiddle/rockA -> U1_2_to_B
-Utop/Umiddle/Urock/unnamed_net_at_18600x38200 -> U1_2_to_B
-Uunder/Umiddle/Urock/unnamed_net_at_18600x38200 -> U1_2_to_B
+Utop/Umiddle/Urock/unnamed_net_at_5900x4500 -> U1_2_to_B
+Uunder/Umiddle/Urock/unnamed_net_at_5900x4500 -> U1_2_to_B
 U2_1_to_E-net -> U2_1_to_E
 Utop/middleB -> U2_1_to_E
 Uunder/middleB -> U2_1_to_E
 Utop/Umiddle/rockB -> U2_1_to_E
 Uunder/Umiddle/rockB -> U2_1_to_E
-Utop/Umiddle/Urock/unnamed_net_at_22100x37700 -> U2_1_to_E
-Uunder/Umiddle/Urock/unnamed_net_at_22100x37700 -> U2_1_to_E
+Utop/Umiddle/Urock/unnamed_net_at_8300x4500 -> U2_1_to_E
+Uunder/Umiddle/Urock/unnamed_net_at_8300x4500 -> U2_1_to_E
 
 END renamed-nets
 

--- a/utils/netlist/tests/hierarchy-config_netname_attribute_order_false.out
+++ b/utils/netlist/tests/hierarchy-config_netname_attribute_order_false.out
@@ -24,15 +24,15 @@ Utop/middleA -> U1_2_to_B
 Uunder/middleA -> U1_2_to_B
 Utop/Umiddle/rockA -> U1_2_to_B
 Uunder/Umiddle/rockA -> U1_2_to_B
-Utop/Umiddle/Urock/unnamed_net_at_18600x38200 -> U1_2_to_B
-Uunder/Umiddle/Urock/unnamed_net_at_18600x38200 -> U1_2_to_B
+Utop/Umiddle/Urock/unnamed_net_at_5900x4500 -> U1_2_to_B
+Uunder/Umiddle/Urock/unnamed_net_at_5900x4500 -> U1_2_to_B
 U2_1_to_E -> U2_1_to_E-net
 Utop/middleB -> U2_1_to_E-net
 Uunder/middleB -> U2_1_to_E-net
 Utop/Umiddle/rockB -> U2_1_to_E-net
 Uunder/Umiddle/rockB -> U2_1_to_E-net
-Utop/Umiddle/Urock/unnamed_net_at_22100x37700 -> U2_1_to_E-net
-Uunder/Umiddle/Urock/unnamed_net_at_22100x37700 -> U2_1_to_E-net
+Utop/Umiddle/Urock/unnamed_net_at_8300x4500 -> U2_1_to_E-net
+Uunder/Umiddle/Urock/unnamed_net_at_8300x4500 -> U2_1_to_E-net
 
 END renamed-nets
 

--- a/utils/netlist/tests/hierarchy-config_netname_attribute_order_true.out
+++ b/utils/netlist/tests/hierarchy-config_netname_attribute_order_true.out
@@ -24,15 +24,15 @@ middleA/Utop -> U1_2_to_B
 middleA/Uunder -> U1_2_to_B
 rockA/Umiddle/Utop -> U1_2_to_B
 rockA/Umiddle/Uunder -> U1_2_to_B
-unnamed_net_at_18600x38200/Urock/Umiddle/Utop -> U1_2_to_B
-unnamed_net_at_18600x38200/Urock/Umiddle/Uunder -> U1_2_to_B
+unnamed_net_at_5900x4500/Urock/Umiddle/Utop -> U1_2_to_B
+unnamed_net_at_5900x4500/Urock/Umiddle/Uunder -> U1_2_to_B
 U2_1_to_E -> U2_1_to_E-net
 middleB/Utop -> U2_1_to_E-net
 middleB/Uunder -> U2_1_to_E-net
 rockB/Umiddle/Utop -> U2_1_to_E-net
 rockB/Umiddle/Uunder -> U2_1_to_E-net
-unnamed_net_at_22100x37700/Urock/Umiddle/Utop -> U2_1_to_E-net
-unnamed_net_at_22100x37700/Urock/Umiddle/Uunder -> U2_1_to_E-net
+unnamed_net_at_8300x4500/Urock/Umiddle/Utop -> U2_1_to_E-net
+unnamed_net_at_8300x4500/Urock/Umiddle/Uunder -> U2_1_to_E-net
 
 END renamed-nets
 

--- a/utils/netlist/tests/hierarchy-config_netname_attribute_separator_1.out
+++ b/utils/netlist/tests/hierarchy-config_netname_attribute_separator_1.out
@@ -24,15 +24,15 @@ Utop:middleA -> U1_2_to_B
 Uunder:middleA -> U1_2_to_B
 Utop:Umiddle:rockA -> U1_2_to_B
 Uunder:Umiddle:rockA -> U1_2_to_B
-Utop:Umiddle:Urock:unnamed_net_at_18600x38200 -> U1_2_to_B
-Uunder:Umiddle:Urock:unnamed_net_at_18600x38200 -> U1_2_to_B
+Utop:Umiddle:Urock:unnamed_net_at_5900x4500 -> U1_2_to_B
+Uunder:Umiddle:Urock:unnamed_net_at_5900x4500 -> U1_2_to_B
 U2_1_to_E -> U2_1_to_E-net
 Utop:middleB -> U2_1_to_E-net
 Uunder:middleB -> U2_1_to_E-net
 Utop:Umiddle:rockB -> U2_1_to_E-net
 Uunder:Umiddle:rockB -> U2_1_to_E-net
-Utop:Umiddle:Urock:unnamed_net_at_22100x37700 -> U2_1_to_E-net
-Uunder:Umiddle:Urock:unnamed_net_at_22100x37700 -> U2_1_to_E-net
+Utop:Umiddle:Urock:unnamed_net_at_8300x4500 -> U2_1_to_E-net
+Uunder:Umiddle:Urock:unnamed_net_at_8300x4500 -> U2_1_to_E-net
 
 END renamed-nets
 

--- a/utils/netlist/tests/hierarchy-config_netname_attribute_separator_2.out
+++ b/utils/netlist/tests/hierarchy-config_netname_attribute_separator_2.out
@@ -24,15 +24,15 @@ middleA -> U1_2_to_B
 middleA -> U1_2_to_B
 rockA -> U1_2_to_B
 rockA -> U1_2_to_B
-unnamed_net_at_18600x38200 -> U1_2_to_B
-unnamed_net_at_18600x38200 -> U1_2_to_B
+unnamed_net_at_5900x4500 -> U1_2_to_B
+unnamed_net_at_5900x4500 -> U1_2_to_B
 U2_1_to_E -> U2_1_to_E-net
 middleB -> U2_1_to_E-net
 middleB -> U2_1_to_E-net
 rockB -> U2_1_to_E-net
 rockB -> U2_1_to_E-net
-unnamed_net_at_22100x37700 -> U2_1_to_E-net
-unnamed_net_at_22100x37700 -> U2_1_to_E-net
+unnamed_net_at_8300x4500 -> U2_1_to_E-net
+unnamed_net_at_8300x4500 -> U2_1_to_E-net
 
 END renamed-nets
 

--- a/utils/netlist/tests/hierarchy-config_refdes_attribute_order_false.out
+++ b/utils/netlist/tests/hierarchy-config_refdes_attribute_order_false.out
@@ -24,15 +24,15 @@ Utop/middleA -> U1_2_to_B
 Uunder/middleA -> U1_2_to_B
 Utop/Umiddle/rockA -> U1_2_to_B
 Uunder/Umiddle/rockA -> U1_2_to_B
-Utop/Umiddle/Urock/unnamed_net_at_18600x38200 -> U1_2_to_B
-Uunder/Umiddle/Urock/unnamed_net_at_18600x38200 -> U1_2_to_B
+Utop/Umiddle/Urock/unnamed_net_at_5900x4500 -> U1_2_to_B
+Uunder/Umiddle/Urock/unnamed_net_at_5900x4500 -> U1_2_to_B
 U2_1_to_E -> U2_1_to_E-net
 Utop/middleB -> U2_1_to_E-net
 Uunder/middleB -> U2_1_to_E-net
 Utop/Umiddle/rockB -> U2_1_to_E-net
 Uunder/Umiddle/rockB -> U2_1_to_E-net
-Utop/Umiddle/Urock/unnamed_net_at_22100x37700 -> U2_1_to_E-net
-Uunder/Umiddle/Urock/unnamed_net_at_22100x37700 -> U2_1_to_E-net
+Utop/Umiddle/Urock/unnamed_net_at_8300x4500 -> U2_1_to_E-net
+Uunder/Umiddle/Urock/unnamed_net_at_8300x4500 -> U2_1_to_E-net
 
 END renamed-nets
 

--- a/utils/netlist/tests/hierarchy-config_refdes_attribute_order_true.out
+++ b/utils/netlist/tests/hierarchy-config_refdes_attribute_order_true.out
@@ -24,15 +24,15 @@ Utop/middleA -> U1_2_to_B
 Uunder/middleA -> U1_2_to_B
 Utop/Umiddle/rockA -> U1_2_to_B
 Uunder/Umiddle/rockA -> U1_2_to_B
-Utop/Umiddle/Urock/unnamed_net_at_18600x38200 -> U1_2_to_B
-Uunder/Umiddle/Urock/unnamed_net_at_18600x38200 -> U1_2_to_B
+Utop/Umiddle/Urock/unnamed_net_at_5900x4500 -> U1_2_to_B
+Uunder/Umiddle/Urock/unnamed_net_at_5900x4500 -> U1_2_to_B
 U2_1_to_E -> U2_1_to_E-net
 Utop/middleB -> U2_1_to_E-net
 Uunder/middleB -> U2_1_to_E-net
 Utop/Umiddle/rockB -> U2_1_to_E-net
 Uunder/Umiddle/rockB -> U2_1_to_E-net
-Utop/Umiddle/Urock/unnamed_net_at_22100x37700 -> U2_1_to_E-net
-Uunder/Umiddle/Urock/unnamed_net_at_22100x37700 -> U2_1_to_E-net
+Utop/Umiddle/Urock/unnamed_net_at_8300x4500 -> U2_1_to_E-net
+Uunder/Umiddle/Urock/unnamed_net_at_8300x4500 -> U2_1_to_E-net
 
 END renamed-nets
 

--- a/utils/netlist/tests/hierarchy-geda.out
+++ b/utils/netlist/tests/hierarchy-geda.out
@@ -24,15 +24,15 @@ Utop/middleA -> U1_2_to_B
 Uunder/middleA -> U1_2_to_B
 Utop/Umiddle/rockA -> U1_2_to_B
 Uunder/Umiddle/rockA -> U1_2_to_B
-Utop/Umiddle/Urock/unnamed_net_at_18600x38200 -> U1_2_to_B
-Uunder/Umiddle/Urock/unnamed_net_at_18600x38200 -> U1_2_to_B
+Utop/Umiddle/Urock/unnamed_net_at_5900x4500 -> U1_2_to_B
+Uunder/Umiddle/Urock/unnamed_net_at_5900x4500 -> U1_2_to_B
 U2_1_to_E -> U2_1_to_E-net
 Utop/middleB -> U2_1_to_E-net
 Uunder/middleB -> U2_1_to_E-net
 Utop/Umiddle/rockB -> U2_1_to_E-net
 Uunder/Umiddle/rockB -> U2_1_to_E-net
-Utop/Umiddle/Urock/unnamed_net_at_22100x37700 -> U2_1_to_E-net
-Uunder/Umiddle/Urock/unnamed_net_at_22100x37700 -> U2_1_to_E-net
+Utop/Umiddle/Urock/unnamed_net_at_8300x4500 -> U2_1_to_E-net
+Uunder/Umiddle/Urock/unnamed_net_at_8300x4500 -> U2_1_to_E-net
 
 END renamed-nets
 

--- a/utils/netlist/tests/hierarchy2-geda.out
+++ b/utils/netlist/tests/hierarchy2-geda.out
@@ -26,7 +26,7 @@ No "no-connect" nets found
 
 START renamed-nets
 
-U100/unnamed_net_at_45900x47500 -> one
+U100/unnamed_net_at_43400x44700 -> one
 U102/unnamed_net_at_45900x47500 -> two
 
 END renamed-nets

--- a/utils/netlist/tests/hierarchy3-geda.out
+++ b/utils/netlist/tests/hierarchy3-geda.out
@@ -29,14 +29,14 @@ Utop/middleA -> U1_2_to_B
 Uunder/middleA -> U1_2_to_B
 Utop/Umiddle/rockA -> U1_2_to_B
 Uunder/Umiddle/rockA -> U1_2_to_B
-Utop/Umiddle/Urock/unnamed_net_at_18600x38200 -> U1_2_to_B
-Uunder/Umiddle/Urock/unnamed_net_at_18600x38200 -> U1_2_to_B
+Utop/Umiddle/Urock/unnamed_net_at_5900x4500 -> U1_2_to_B
+Uunder/Umiddle/Urock/unnamed_net_at_5900x4500 -> U1_2_to_B
 Utop/middleB -> U2_1_to_E
 Uunder/middleB -> U2_1_to_E
 Utop/Umiddle/rockB -> U2_1_to_E
 Uunder/Umiddle/rockB -> U2_1_to_E
-Utop/Umiddle/Urock/unnamed_net_at_22100x37700 -> U2_1_to_E
-Uunder/Umiddle/Urock/unnamed_net_at_22100x37700 -> U2_1_to_E
+Utop/Umiddle/Urock/unnamed_net_at_8300x4500 -> U2_1_to_E
+Uunder/Umiddle/Urock/unnamed_net_at_8300x4500 -> U2_1_to_E
 
 END renamed-nets
 

--- a/utils/netlist/tests/hierarchy5-geda.out
+++ b/utils/netlist/tests/hierarchy5-geda.out
@@ -22,7 +22,7 @@ START renamed-nets
 Z2/A -> GND
 Z2/B -> GND
 Z1/B -> Z1/A
-unnamed_net_at_1400x2000 -> Z1/A
+unnamed_net_at_1100x2000 -> Z1/A
 Z3/A -> Z3/A
 Z3/B -> Z3/A
 


### PR DESCRIPTION
This was the last function defined in the `(lepton core object)` module.  Now, it has been rewritten in Scheme as all others functions from the module.  As my first naive approach of parsing *GList*s in Scheme appeared to be significantly slower than the corresponding C code, I utilized *memoization* for the function using the Guile facility named `object-property`, which restored the speed of test suite passing.

As always, some new tests have been added, and the docstring for the function has been added.