### PR TITLE
Get rid of the module (lepton core object)

### DIFF
--- a/liblepton/include/libleptonguile_priv.h
+++ b/liblepton/include/libleptonguile_priv.h
@@ -199,8 +199,6 @@ SCM edascm_from_toplevel (LeptonToplevel *toplevel);
 
 /* ---------------------------------------- */
 
-GList *edascm_to_object_glist (SCM objs, const char *subr)
-  G_GNUC_WARN_UNUSED_RESULT;
 SCM edascm_from_object_glist (const GList *objs);
 int edascm_is_object_type (SCM smob, int type);
 

--- a/liblepton/include/libleptonguile_priv.h
+++ b/liblepton/include/libleptonguile_priv.h
@@ -89,7 +89,6 @@
 
 void edascm_init_smob ();
 void edascm_init_toplevel ();
-void edascm_init_object ();
 void edascm_init_component ();
 void edascm_init_page ();
 void edascm_init_attrib ();

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -28,7 +28,6 @@
 
   ;; Import C procedures
   #:use-module (lepton core component)
-  #:use-module (lepton core object)
 
   #:use-module (lepton color-map)
   #:use-module (lepton ffi)

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -21,7 +21,6 @@
 (define-module (lepton object)
   ;; Optional arguments
   #:use-module (ice-9 match)
-  #:use-module (ice-9 optargs)
   #:use-module (srfi srfi-1)
   #:use-module (srfi srfi-4 gnu)
   #:use-module (system foreign)

--- a/liblepton/src/Makefile.am
+++ b/liblepton/src/Makefile.am
@@ -4,7 +4,6 @@ lib_LTLIBRARIES = liblepton.la
 BUILT_SOURCES = \
 	scheme_init.x \
 	scheme_toplevel.x \
-	scheme_object.x \
 	scheme_component.x \
 	scheme_page.x \
 	scheme_attrib.x \

--- a/liblepton/src/scheme_deprecated.c
+++ b/liblepton/src/scheme_deprecated.c
@@ -29,8 +29,8 @@
 /*! \brief Get the width of line used to draw an object
  * \par Function Description
  * Returns the line width used to draw an object. Deprecated because
- * it doesn't respect type restrictions, unlike the %object-stroke
- * function in (lepton core object).
+ * it doesn't respect type restrictions, unlike the object-stroke
+ * function in (lepton object).
  *
  * \param obj_s the object to get line width for.
  * \return the line width.

--- a/liblepton/src/scheme_init.c
+++ b/liblepton/src/scheme_init.c
@@ -45,7 +45,6 @@ edascm_init_impl (void *data)
                  SCM_UNDEFINED);
   edascm_init_smob ();
   edascm_init_toplevel ();
-  edascm_init_object ();
   edascm_init_component ();
   edascm_init_page ();
   edascm_init_attrib ();

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -28,45 +28,6 @@
 #include "liblepton_priv.h"
 #include "libleptonguile_priv.h"
 
-/*! \brief Convert a Scheme object list to a GList.
- * \par Function Description
- * Takes a Scheme list of #LeptonObject smobs, and returns a GList
- * containing the objects. If \a objs is not a list of #LeptonObject smobs,
- * throws a Scheme error.
- *
- * \warning If the #LeptonObject structures in the GList are to be stored by
- * C code and later free()'d directly, the smobs must be marked as
- * unsafe for garbage collection (by calling edascm_c_set_gc()).
- *
- * \param [in] objs a Scheme list of #LeptonObject smobs.
- * \param [in] subr the name of the Scheme subroutine (used for error
- *                  messages).
- * \return a #GList of #LeptonObject.
- */
-GList *
-edascm_to_object_glist (SCM objs, const char *subr)
-{
-  GList *result = NULL;
-  SCM lst;
-
-  SCM_ASSERT (scm_is_true (scm_list_p (objs)), objs, SCM_ARGn, subr);
-
-  scm_dynwind_begin ((scm_t_dynwind_flags) 0);
-  scm_dynwind_unwind_handler ((void (*)(void *)) g_list_free,
-                              result,
-                              (scm_t_wind_flags) 0);
-
-  for (lst = objs; !scm_is_null (lst); lst = SCM_CDR (lst)) {
-    SCM smob = SCM_CAR (lst);
-    result = g_list_prepend (result, (gpointer) edascm_to_object (smob));
-  }
-
-  scm_remember_upto_here_1 (lst);
-
-  scm_dynwind_end ();
-
-  return g_list_reverse (result);
-}
 
 /*! \brief Convert a GList of objects into a Scheme list.
  * \par Function Description

--- a/liblepton/src/scheme_object.c
+++ b/liblepton/src/scheme_object.c
@@ -77,35 +77,3 @@ edascm_is_object_type (SCM smob, int type)
   LeptonObject *obj = edascm_to_object (smob);
   return (lepton_object_get_type (obj) == type);
 }
-
-
-/*!
- * \brief Create the (lepton core object) Scheme module.
- * \par Function Description
- * Defines procedures in the (lepton core object) module. The module can
- * be accessed using (use-modules (lepton core object)).
- */
-static void
-init_module_lepton_core_object (void *unused)
-{
-  /* Register the functions and symbols */
-  #include "scheme_object.x"
-
-  /* Add them to the module's public definitions. */
-  scm_c_export (NULL);
-}
-
-/*!
- * \brief Initialise the basic Lepton EDA object manipulation procedures.
- * \par Function Description
- * Registers some Scheme procedures for working with #LeptonObject
- * smobs. Should only be called by edascm_init().
- */
-void
-edascm_init_object ()
-{
-  /* Define the (lepton core object) module */
-  scm_c_define_module ("lepton core object",
-                       (void (*) (void*)) init_module_lepton_core_object,
-                       NULL);
-}


### PR DESCRIPTION
This commit set finishes rewriting of the module using Scheme FFI and actually gets rid of it and its infrastructure along with unused Scheme-in-C function `edascm_to_object_glist()`.