### PR TITLE
gui: Add gtk3 support in last modifications of lepton-schematic's bottom widget.

### DIFF
--- a/libleptongui/src/gschem_bottom_widget.c
+++ b/libleptongui/src/gschem_bottom_widget.c
@@ -492,11 +492,19 @@ set_snap_info_widget_color (GschemBottomWidget* widget,
 {
   g_return_if_fail (widget != NULL);
 
+#ifdef ENABLE_GTK3
+  GdkRGBA color;
+  gdk_rgba_parse (&color, color_name);
+  gtk_widget_override_color (GTK_WIDGET (widget->grid_snap_widget),
+                             GTK_STATE_FLAG_NORMAL,
+                             &color);
+#else
   GdkColor color;
   gdk_color_parse (color_name, &color);
   gtk_widget_modify_fg (GTK_WIDGET (widget->grid_snap_widget),
                         GTK_STATE_NORMAL,
                         &color);
+#endif
 }
 
 


### PR DESCRIPTION
The patch resolves the last warning in the build with g++ (I omit `GDK_SCROLL_SMOOTH` issue here as unresolved yet). The new code has been introduced in #812 so it needs corresponding changes for GTK3.

The changes I use in `configure.ac` to make sure our code is fully compatible with GTK3.0.0 and filter all other later GTK3 stuff are as follows:
```
AC_DEFINE(GDK_VERSION_MIN_REQUIRED, GDK_VERSION_3_0, [Ignore post 3.0 deprecations])
```

Of course, there are more things to be done in the gtk3 port code, and I have already done some work on this in my private repository.  I just believe this is a reasonable minimum we could start of and announce as a really working gtk3 port of Lepton.  Just GTK 3.0.0 yet :-)

Please let me know if something else should go in a (the?) new release which I'm planning to start working on just these days (hopefully, if nothing else in my private life stops me from that).