### PR TITLE
utils: Fix compilation warnings on launching Lepton Scheme tools.

### DIFF
--- a/utils/archive/lepton-archive.scm
+++ b/utils/archive/lepton-archive.scm
@@ -61,8 +61,9 @@ exec @GUILE@ -s "$0" "$@"
 ;;;   Before each move, make sure that no overwrite of existing
 ;;;   files will occur.
 
-(unless (getenv "LIBLEPTON")
-  (add-to-load-path "@LEPTON_SCHEME_MODULE_DIRECTORY@"))
+(eval-when (expand load eval)
+  (unless (getenv "LIBLEPTON")
+    (add-to-load-path "@LEPTON_SCHEME_MODULE_DIRECTORY@")))
 
 (use-modules (ice-9 ftw)
              (ice-9 getopt-long)

--- a/utils/attrib/lepton-attrib.scm
+++ b/utils/attrib/lepton-attrib.scm
@@ -22,8 +22,9 @@ exec @GUILE@ -s "$0" "$@"
 ;;; along with this program; if not, write to the Free Software
 ;;; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-(unless (getenv "LIBLEPTON")
-  (add-to-load-path "@LEPTON_SCHEME_MODULE_DIRECTORY@"))
+(eval-when (expand load eval)
+  (unless (getenv "LIBLEPTON")
+    (add-to-load-path "@LEPTON_SCHEME_MODULE_DIRECTORY@")))
 
 (use-modules (ice-9 getopt-long)
              (ice-9 receive)

--- a/utils/embed/lepton-embed.scm
+++ b/utils/embed/lepton-embed.scm
@@ -11,8 +11,9 @@ exec @GUILE@ "$0" "$@"
 ;; License: GPLv2+. See the COPYING file
 ;;
 
-(unless (getenv "LIBLEPTON")
-  (add-to-load-path "@LEPTON_SCHEME_MODULE_DIRECTORY@"))
+(eval-when (expand load eval)
+  (unless (getenv "LIBLEPTON")
+    (add-to-load-path "@LEPTON_SCHEME_MODULE_DIRECTORY@")))
 
 (use-modules (ice-9 format)
              (ice-9 getopt-long)

--- a/utils/netlist/lepton-netlist.scm
+++ b/utils/netlist/lepton-netlist.scm
@@ -20,8 +20,9 @@ exec @GUILE@ -s "$0" "$@"
 ;;; along with this program; if not, write to the Free Software
 ;;; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
-(unless (getenv "LIBLEPTON")
-  (add-to-load-path "@LEPTON_SCHEME_MODULE_DIRECTORY@"))
+(eval-when (expand load eval)
+  (unless (getenv "LIBLEPTON")
+    (add-to-load-path "@LEPTON_SCHEME_MODULE_DIRECTORY@")))
 
 (use-modules (ice-9 getopt-long)
              (srfi srfi-26)

--- a/utils/symcheck/lepton-symcheck.scm
+++ b/utils/symcheck/lepton-symcheck.scm
@@ -20,8 +20,9 @@ exec @GUILE@ -s "$0" "$@"
 ;;; along with this program; if not, write to the Free Software
 ;;; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
-(unless (getenv "LIBLEPTON")
-  (add-to-load-path "@LEPTON_SCHEME_MODULE_DIRECTORY@"))
+(eval-when (expand load eval)
+  (unless (getenv "LIBLEPTON")
+    (add-to-load-path "@LEPTON_SCHEME_MODULE_DIRECTORY@")))
 
 (use-modules (lepton ffi))
 

--- a/utils/tragesym/lepton-tragesym.scm
+++ b/utils/tragesym/lepton-tragesym.scm
@@ -36,8 +36,9 @@ exec @GUILE@ -s "$0" "$@"
 ;;;   defined by the greater number of pins at the top or at the
 ;;;   bottom of the symbol, and the width requested.
 
-(unless (getenv "LIBLEPTON")
-  (add-to-load-path "@LEPTON_SCHEME_MODULE_DIRECTORY@"))
+(eval-when (expand load eval)
+  (unless (getenv "LIBLEPTON")
+    (add-to-load-path "@LEPTON_SCHEME_MODULE_DIRECTORY@")))
 
 (use-modules (ice-9 getopt-long)
              (ice-9 match)

--- a/utils/upcfg/lepton-upcfg.scm
+++ b/utils/upcfg/lepton-upcfg.scm
@@ -11,8 +11,9 @@ exec @GUILE@ "$0" "$@"
 ;; License: GPLv2+. See the COPYING file
 ;;
 
-(unless (getenv "LIBLEPTON")
-  (add-to-load-path "@LEPTON_SCHEME_MODULE_DIRECTORY@"))
+(eval-when (expand load eval)
+  (unless (getenv "LIBLEPTON")
+    (add-to-load-path "@LEPTON_SCHEME_MODULE_DIRECTORY@")))
 
 (use-modules (ice-9 format)
              (ice-9 rdelim) ; read-line()


### PR DESCRIPTION
This was discussed recently on gitter.  The issue has been introduced in the last release 1.9.15.

The patch fixes the warnings as follows:
```
WARNING: compilation of /usr/local/bin/lepton-netlist failed:
no code for module (lepton ffi)
```