### PR TITLE
Clickable status bar indicators

### DIFF
--- a/libleptongui/include/gschem_bottom_widget.h
+++ b/libleptongui/include/gschem_bottom_widget.h
@@ -64,6 +64,8 @@ struct _GschemBottomWidget
   GdkColor  status_active_color;
 #endif
   gboolean  status_bold_font;
+
+  GschemToplevel* toplevel;
 };
 
 

--- a/libleptongui/src/gschem_bottom_widget.c
+++ b/libleptongui/src/gschem_bottom_widget.c
@@ -119,6 +119,24 @@ on_click_rubber_band (GtkWidget* ebox, GdkEvent* e, gpointer data)
 
 
 
+static gboolean
+on_click_magnetic_net (GtkWidget* ebox, GdkEvent* e, gpointer data)
+{
+  GschemBottomWidget* widget = (GschemBottomWidget*) data;
+  g_return_val_if_fail (widget != NULL, FALSE);
+
+  GdkEventButton* ebtn = (GdkEventButton*) e;
+  if (ebtn->type == GDK_BUTTON_PRESS && ebtn->button == 1)
+  {
+    gschem_options_cycle_magnetic_net_mode (widget->toplevel->options);
+    return TRUE;
+  }
+
+  return FALSE;
+}
+
+
+
 /*! \brief Dispose of the object
  */
 static void
@@ -895,8 +913,17 @@ gschem_bottom_widget_init (GschemBottomWidget *widget)
   gtk_misc_set_padding (GTK_MISC (widget->magnetic_net_label), LABEL_XPAD, LABEL_YPAD);
   if (show_magnetic_net_indicator)
   {
-    gtk_box_pack_start (GTK_BOX (widget), widget->magnetic_net_label, FALSE, FALSE, 0);
+    GtkWidget* ebox_magnetic_net = gtk_event_box_new();
+    gtk_container_add (GTK_CONTAINER (ebox_magnetic_net), widget->magnetic_net_label);
+    gtk_widget_show_all (ebox_magnetic_net);
+    gtk_box_pack_start (GTK_BOX (widget), ebox_magnetic_net, FALSE, FALSE, 0);
+
+    g_signal_connect (G_OBJECT (ebox_magnetic_net),
+                      "button-press-event",
+                      G_CALLBACK (&on_click_magnetic_net),
+                      widget);
   }
+
 
   widget->status_label = gtk_label_new (NULL);
   gtk_widget_set_tooltip_text (widget->status_label, _("Current action mode"));

--- a/libleptongui/src/gschem_bottom_widget.c
+++ b/libleptongui/src/gschem_bottom_widget.c
@@ -101,6 +101,24 @@ G_DEFINE_TYPE (GschemBottomWidget, gschem_bottom_widget, GTK_TYPE_HBOX);
 
 
 
+static gboolean
+on_click_rubber_band (GtkWidget* ebox, GdkEvent* e, gpointer data)
+{
+  GschemBottomWidget* widget = (GschemBottomWidget*) data;
+  g_return_val_if_fail (widget != NULL, FALSE);
+
+  GdkEventButton* ebtn = (GdkEventButton*) e;
+  if (ebtn->type == GDK_BUTTON_PRESS && ebtn->button == 1)
+  {
+    gschem_options_cycle_net_rubber_band_mode (widget->toplevel->options);
+    return TRUE;
+  }
+
+  return FALSE;
+}
+
+
+
 /*! \brief Dispose of the object
  */
 static void
@@ -860,6 +878,11 @@ gschem_bottom_widget_init (GschemBottomWidget *widget)
     gtk_container_add (GTK_CONTAINER (ebox_rubber_band), widget->rubber_band_label);
     gtk_widget_show_all (ebox_rubber_band);
     gtk_box_pack_start (GTK_BOX (widget), ebox_rubber_band, FALSE, FALSE, 0);
+
+    g_signal_connect (G_OBJECT (ebox_rubber_band),
+                      "button-press-event",
+                      G_CALLBACK (&on_click_rubber_band),
+                      widget);
   }
 
 

--- a/libleptongui/src/gschem_bottom_widget.c
+++ b/libleptongui/src/gschem_bottom_widget.c
@@ -60,7 +60,8 @@ enum
   PROP_STATUS_TEXT,
   PROP_STATUS_TEXT_COLOR,
   PROP_RUBBER_BAND_MODE,
-  PROP_MAGNETIC_NET_MODE
+  PROP_MAGNETIC_NET_MODE,
+  PROP_TOPLEVEL
 };
 
 
@@ -143,6 +144,10 @@ get_property (GObject *object, guint param_id, GValue *value, GParamSpec *pspec)
   GschemBottomWidget *widget = GSCHEM_BOTTOM_WIDGET (object);
 
   switch (param_id) {
+    case PROP_TOPLEVEL:
+          g_value_set_pointer (value, widget->toplevel);
+          break;
+
     case PROP_GRID_MODE:
       g_value_set_int (value, gschem_bottom_widget_get_grid_mode (widget));
       break;
@@ -202,6 +207,10 @@ gschem_bottom_widget_class_init (GschemBottomWidgetClass *klass)
 
   G_OBJECT_CLASS (klass)->get_property = get_property;
   G_OBJECT_CLASS (klass)->set_property = set_property;
+
+  GParamFlags flags = (GParamFlags) (G_PARAM_CONSTRUCT_ONLY | G_PARAM_READWRITE);
+  GParamSpec* spec  = g_param_spec_pointer ("toplevel", "", "", flags);
+  g_object_class_install_property (G_OBJECT_CLASS (klass), PROP_TOPLEVEL, spec);
 
   g_object_class_install_property (G_OBJECT_CLASS (klass),
                                    PROP_GRID_MODE,
@@ -1122,6 +1131,10 @@ set_property (GObject *object, guint param_id, const GValue *value, GParamSpec *
   GschemBottomWidget *widget = GSCHEM_BOTTOM_WIDGET (object);
 
   switch (param_id) {
+    case PROP_TOPLEVEL:
+          widget->toplevel = GSCHEM_TOPLEVEL (g_value_get_pointer (value));
+          break;
+
     case PROP_GRID_MODE:
       gschem_bottom_widget_set_grid_mode (widget, g_value_get_int (value));
       break;

--- a/libleptongui/src/gschem_bottom_widget.c
+++ b/libleptongui/src/gschem_bottom_widget.c
@@ -850,16 +850,22 @@ gschem_bottom_widget_init (GschemBottomWidget *widget)
   separator = gtk_vseparator_new ();
   gtk_box_pack_start (GTK_BOX (widget), separator, FALSE, FALSE, 0);
 
+
   widget->rubber_band_label = gtk_label_new (NULL);
   gtk_widget_set_tooltip_text (widget->rubber_band_label, _("Net rubber band mode"));
   gtk_misc_set_padding (GTK_MISC (widget->rubber_band_label), LABEL_XPAD, LABEL_YPAD);
   if (show_rubber_band_indicator)
   {
-    gtk_box_pack_start (GTK_BOX (widget), widget->rubber_band_label, FALSE, FALSE, 0);
+    GtkWidget* ebox_rubber_band = gtk_event_box_new();
+    gtk_container_add (GTK_CONTAINER (ebox_rubber_band), widget->rubber_band_label);
+    gtk_widget_show_all (ebox_rubber_band);
+    gtk_box_pack_start (GTK_BOX (widget), ebox_rubber_band, FALSE, FALSE, 0);
   }
+
 
   separator = gtk_vseparator_new ();
   gtk_box_pack_start (GTK_BOX (widget), separator, FALSE, FALSE, 0);
+
 
   widget->magnetic_net_label = gtk_label_new (NULL);
   gtk_widget_set_tooltip_text (widget->magnetic_net_label, _("Magnetic net mode"));

--- a/libleptongui/src/gschem_bottom_widget.c
+++ b/libleptongui/src/gschem_bottom_widget.c
@@ -155,6 +155,24 @@ on_click_grid_size (GtkWidget* ebox, GdkEvent* e, gpointer data)
 
 
 
+static gboolean
+on_click_snap_info (GtkWidget* ebox, GdkEvent* e, gpointer data)
+{
+  GschemBottomWidget* widget = (GschemBottomWidget*) data;
+  g_return_val_if_fail (widget != NULL, FALSE);
+
+  GdkEventButton* ebtn = (GdkEventButton*) e;
+  if (ebtn->type == GDK_BUTTON_PRESS && ebtn->button == 1)
+  {
+    gschem_options_cycle_snap_mode (widget->toplevel->options);
+    return TRUE;
+  }
+
+  return FALSE;
+}
+
+
+
 /*! \brief Dispose of the object
  */
 static void
@@ -715,6 +733,10 @@ create_snap_info_widget (GschemBottomWidget* widget)
 
   widget->grid_snap_widget = gtk_label_new (NULL);
 
+  GtkWidget* ebox = gtk_event_box_new();
+  gtk_container_add (GTK_CONTAINER (ebox), widget->grid_snap_widget);
+  gtk_widget_show_all (ebox);
+
   gchar* str = g_strdup_printf ("Snap: <b>%d</b>", widget->snap_size);
   gtk_label_set_markup (GTK_LABEL(widget->grid_snap_widget), str);
   g_free (str);
@@ -722,8 +744,14 @@ create_snap_info_widget (GschemBottomWidget* widget)
   gtk_misc_set_padding (GTK_MISC (widget->grid_snap_widget),
                         LABEL_XPAD,
                         LABEL_YPAD);
-  gtk_box_pack_start (GTK_BOX (widget), widget->grid_snap_widget, FALSE, FALSE, 0);
+  gtk_box_pack_start (GTK_BOX (widget), ebox, FALSE, FALSE, 0);
+
   gtk_box_pack_start (GTK_BOX (widget), gtk_vseparator_new(), FALSE, FALSE, 0);
+
+  g_signal_connect (G_OBJECT (ebox),
+                    "button-press-event",
+                    G_CALLBACK (&on_click_snap_info),
+                    widget);
 }
 
 

--- a/libleptongui/src/gschem_bottom_widget.c
+++ b/libleptongui/src/gschem_bottom_widget.c
@@ -137,6 +137,24 @@ on_click_magnetic_net (GtkWidget* ebox, GdkEvent* e, gpointer data)
 
 
 
+static gboolean
+on_click_grid_size (GtkWidget* ebox, GdkEvent* e, gpointer data)
+{
+  GschemBottomWidget* widget = (GschemBottomWidget*) data;
+  g_return_val_if_fail (widget != NULL, FALSE);
+
+  GdkEventButton* ebtn = (GdkEventButton*) e;
+  if (ebtn->type == GDK_BUTTON_PRESS && ebtn->button == 1)
+  {
+    gschem_options_cycle_grid_mode (widget->toplevel->options);
+    return TRUE;
+  }
+
+  return FALSE;
+}
+
+
+
 /*! \brief Dispose of the object
  */
 static void
@@ -754,6 +772,10 @@ create_grid_size_widget (GschemBottomWidget* widget)
 
   widget->grid_size_widget = gtk_label_new (NULL);
 
+  GtkWidget* ebox = gtk_event_box_new();
+  gtk_container_add (GTK_CONTAINER (ebox), widget->grid_size_widget);
+  gtk_widget_show_all (ebox);
+
   gchar* str = g_strdup_printf ("Grid: %d", widget->grid_size);
   gtk_label_set_markup (GTK_LABEL(widget->grid_size_widget),
                         str);
@@ -762,8 +784,14 @@ create_grid_size_widget (GschemBottomWidget* widget)
   gtk_misc_set_padding (GTK_MISC (widget->grid_size_widget),
                         LABEL_XPAD,
                         LABEL_YPAD);
-  gtk_box_pack_start (GTK_BOX (widget), widget->grid_size_widget, FALSE, FALSE, 0);
+  gtk_box_pack_start (GTK_BOX (widget), ebox, FALSE, FALSE, 0);
+
   gtk_box_pack_start (GTK_BOX (widget), gtk_vseparator_new(), FALSE, FALSE, 0);
+
+  g_signal_connect (G_OBJECT (ebox),
+                    "button-press-event",
+                    G_CALLBACK (&on_click_grid_size),
+                    widget);
 }
 
 

--- a/libleptongui/src/gschem_bottom_widget.c
+++ b/libleptongui/src/gschem_bottom_widget.c
@@ -703,19 +703,21 @@ update_snap_info_widget (GschemBottomWidget* widget)
   {
     gchar* tooltip = g_strdup_printf(
       _("Snap size.\n"
+        "Click to change the snapping mode.\n"
         "Attention: current snap size (%d) differs\n"
         "from the value set in configuration: %d."),
         widget->snap_size,
         default_snap_size);
 
     gtk_widget_set_tooltip_text (widget->grid_snap_widget,
-                                   tooltip);
+                                 tooltip);
     g_free (tooltip);
   }
   else
   {
     gtk_widget_set_tooltip_text (widget->grid_snap_widget,
-                                 _("Snap size"));
+                                 _("Snap size.\n"
+                                   "Click to change the snapping mode."));
   }
 
 } /* update_snap_info_widget() */
@@ -783,7 +785,8 @@ update_grid_size_widget (GschemBottomWidget* widget)
 
   gtk_label_set_label (GTK_LABEL(widget->grid_size_widget), str);
   gtk_widget_set_tooltip_text (widget->grid_size_widget,
-                               _("Grid size"));
+                               _("Grid size.\n"
+                                 "Click to change the grid style."));
   g_free (str);
 }
 
@@ -944,7 +947,9 @@ gschem_bottom_widget_init (GschemBottomWidget *widget)
 
 
   widget->rubber_band_label = gtk_label_new (NULL);
-  gtk_widget_set_tooltip_text (widget->rubber_band_label, _("Net rubber band mode"));
+  gtk_widget_set_tooltip_text (widget->rubber_band_label,
+                               _("Net rubber band mode.\n"
+                                 "Click to toggle ON/OFF."));
   gtk_misc_set_padding (GTK_MISC (widget->rubber_band_label), LABEL_XPAD, LABEL_YPAD);
   if (show_rubber_band_indicator)
   {
@@ -965,7 +970,9 @@ gschem_bottom_widget_init (GschemBottomWidget *widget)
 
 
   widget->magnetic_net_label = gtk_label_new (NULL);
-  gtk_widget_set_tooltip_text (widget->magnetic_net_label, _("Magnetic net mode"));
+  gtk_widget_set_tooltip_text (widget->magnetic_net_label,
+                               _("Magnetic net mode.\n"
+                                 "Click to toggle ON/OFF."));
   gtk_misc_set_padding (GTK_MISC (widget->magnetic_net_label), LABEL_XPAD, LABEL_YPAD);
   if (show_magnetic_net_indicator)
   {

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -1332,6 +1332,8 @@ create_bottom_widget (GschemToplevel *w_current, GtkWidget *main_box)
                                        text_right_button_cancel);
 
   gpointer obj = g_object_new (GSCHEM_TYPE_BOTTOM_WIDGET,
+                               "toplevel",
+                               w_current,
                                "grid-mode",
                                gschem_options_get_grid_mode (w_current->options),
                                "grid-size",


### PR DESCRIPTION
Make the status bar labels clickable:
if you click with the left mouse button on the "rubber band"
label, it will change the rubber band mode, etc.
Now the following status bar indicators are interactive:
- rubber band
- magnetic net
- grid size
- snap size
