### PR TITLE
Fix environment variable expansion in source-library-search()

### DIFF
--- a/liblepton/scheme/lepton/library.scm
+++ b/liblepton/scheme/lepton/library.scm
@@ -124,21 +124,6 @@ set-library-contents! instead."
   %default-source-library)
 
 
-;;; Transforms the tree of directories into a plain list of paths,
-;;; filtering out plain files and some VCS related directories.
-(define get-tree
-  (match-lambda
-    ((name stat)                        ; flat file
-     #f)
-    ((name stat children ...)           ; directory
-     (and (not (member name '(".git" ".svn" "CVS")))
-          (let ((contents (filter-map get-tree children)))
-            (if (null? contents)
-                (list name)
-                (cons name
-                      (map (lambda (x) (string-append name file-name-separator-string x))
-                      (apply append contents)))))))))
-
 (define (source-library-search path)
   "Recursively prepends the contents of given path to the default
 source library.  Returns %default-source-library.
@@ -151,6 +136,21 @@ set-library-contents! instead."
       (if (string-suffix? file-name-separator-string s)
           (loop (string-drop-right s sep-len))
           s)))
+
+  ;; Transforms the tree of directories into a plain list of paths,
+  ;; filtering out plain files and some VCS related directories.
+  (define get-tree
+    (match-lambda
+      ((name stat)                      ; flat file
+       #f)
+      ((name stat children ...)         ; directory
+       (and (not (member name '(".git" ".svn" "CVS")))
+            (let ((contents (filter-map get-tree children)))
+              (if (null? contents)
+                  (list name)
+                  (cons name
+                        (map (lambda (x) (string-append name file-name-separator-string x))
+                             (apply append contents)))))))))
 
   (define (add-source-library sl)
     (source-library sl))

--- a/liblepton/scheme/lepton/library.scm
+++ b/liblepton/scheme/lepton/library.scm
@@ -108,7 +108,9 @@ set-library-contents! instead."
                                      (string-append (getcwd)
                                                     file-name-separator-string
                                                     expanded-path)))
-        (log! 'critical (G_ "Invalid path ~S or source not readable.\n") path))
+        (log! 'critical
+              (G_ "Invalid path ~S or source not readable.\n")
+              expanded-path))
     %default-source-library))
 
 
@@ -165,8 +167,11 @@ set-library-contents! instead."
     (if tree
         (for-each add-source-library (map (lambda (x) (string-append (dirname expanded-path)
                                                                 file-name-separator-string
-                                                                x)) (get-tree tree)))
-        (log! 'critical (G_ "Invalid path ~S or source not readable.\n") path))
+                                                                x))
+                                          (get-tree tree)))
+        (log! 'critical
+              (G_ "Invalid path ~S or source not readable.\n")
+              expanded-path))
     ;; Return value.
     %default-source-library))
 

--- a/liblepton/scheme/lepton/library.scm
+++ b/liblepton/scheme/lepton/library.scm
@@ -137,7 +137,7 @@ set-library-contents! instead."
   ;; filtering out plain files and some VCS related directories.
   (define filter-tree
     (match-lambda
-      ;; Flat files. Skip them.
+      ;; Flat files and empty directories. Skip them.
       ((name stat) #f)
       ;; Directories.
       ((name stat children ...)

--- a/liblepton/scheme/lepton/library.scm
+++ b/liblepton/scheme/lepton/library.scm
@@ -137,7 +137,7 @@ set-library-contents! instead."
                 (list name)
                 (cons name
                       (map (lambda (x) (string-append name file-name-separator-string x))
-                      (append-map identity contents)))))))))
+                      (apply append contents)))))))))
 
 (define (source-library-search path)
   "Recursively prepends the contents of given path to the default

--- a/liblepton/scheme/unit-tests/lepton-library-source-library.scm
+++ b/liblepton/scheme/unit-tests/lepton-library-source-library.scm
@@ -86,7 +86,8 @@
     (test-equal (source-library-contents lib) (list *testdir*/a))
     ;; Test expansion of environment variables.
     (putenv (string-append "MYDIR=" *testdir*/b))
-    (test-eq (source-library *testdir*/b) lib)
+    (test-assert (getenv "MYDIR"))
+    (test-eq (source-library "${MYDIR}") lib)
     (test-equal (source-library-contents lib) (list *testdir*/b *testdir*/a))
     ;; Test for non-existing directory.
     (test-eq (source-library *testdir*/a/non-existing-dir) lib)
@@ -155,7 +156,8 @@
     (test-equal (source-library-contents lib) (list *testdir*/a))
     ;; Test expansion of environment variables.
     (putenv (string-append "MYDIR=" *testdir*/b))
-    (test-eq (source-library-search *testdir*/b) lib)
+    (test-assert (getenv "MYDIR"))
+    (test-eq (source-library-search "${MYDIR}") lib)
     (test-equal (source-library-contents lib)
       (list *testdir*/b/b/c *testdir*/b/b *testdir*/b *testdir*/a))
     ;; Test for non-existing directory.


### PR DESCRIPTION
While in #823 I fixed the function and added several tests, the test for env var expansion was incomplete: I only set a variable though never used it.
This commit set actually fixes expansion of environment variables in the function, adds tests for it, and includes some refactoring of the function.

Affects #823