### PR TITLE
Partial support of GTK3.4 functions

### DIFF
--- a/libleptongui/src/gschem_bottom_widget.c
+++ b/libleptongui/src/gschem_bottom_widget.c
@@ -759,7 +759,7 @@ create_snap_info_widget (GschemBottomWidget* widget)
                         LABEL_YPAD);
   gtk_box_pack_start (GTK_BOX (widget), ebox, FALSE, FALSE, 0);
 
-  gtk_box_pack_start (GTK_BOX (widget), gtk_vseparator_new(), FALSE, FALSE, 0);
+  gtk_box_pack_start (GTK_BOX (widget), separator_new(), FALSE, FALSE, 0);
 
   g_signal_connect (G_OBJECT (ebox),
                     "button-press-event",
@@ -828,7 +828,7 @@ create_grid_size_widget (GschemBottomWidget* widget)
                         LABEL_YPAD);
   gtk_box_pack_start (GTK_BOX (widget), ebox, FALSE, FALSE, 0);
 
-  gtk_box_pack_start (GTK_BOX (widget), gtk_vseparator_new(), FALSE, FALSE, 0);
+  gtk_box_pack_start (GTK_BOX (widget), separator_new(), FALSE, FALSE, 0);
 
   g_signal_connect (G_OBJECT (ebox),
                     "button-press-event",

--- a/libleptongui/src/gschem_bottom_widget.c
+++ b/libleptongui/src/gschem_bottom_widget.c
@@ -97,8 +97,11 @@ update_magnetic_net_label (GschemBottomWidget *widget, GParamSpec *pspec, gpoint
 
 /* convenience macro - gobject type implementation:
 */
+#ifdef ENABLE_GTK3
+G_DEFINE_TYPE (GschemBottomWidget, gschem_bottom_widget, GTK_TYPE_BOX);
+#else
 G_DEFINE_TYPE (GschemBottomWidget, gschem_bottom_widget, GTK_TYPE_HBOX);
-
+#endif
 
 
 static gboolean

--- a/libleptongui/src/gschem_dialog_misc.c
+++ b/libleptongui/src/gschem_dialog_misc.c
@@ -74,6 +74,38 @@ GtkWidget*
 gschem_dialog_misc_create_property_table (GtkWidget *label[], GtkWidget *widget[], int count)
 {
   int index;
+#ifdef ENABLE_GTK3
+  GtkWidget *grid = gtk_grid_new ();
+
+  gtk_grid_set_row_spacing (GTK_GRID (grid), DIALOG_V_SPACING);
+  gtk_grid_set_column_spacing (GTK_GRID (grid), DIALOG_H_SPACING);
+
+  for (index=0; index<count; index++) {
+    gtk_grid_attach (GTK_GRID (grid),
+                     label[index],
+                     0,
+                     index,
+                     1,
+                     1);
+
+    gtk_grid_attach (GTK_GRID (grid),
+                     widget[index],
+                     1,
+                     index,
+                     1,
+                     1);
+
+    if (GTK_IS_LABEL (label[index]) &&
+        gtk_label_get_mnemonic_keyval (GTK_LABEL (label[index])) != GDK_KEY_VoidSymbol)
+    {
+      gtk_label_set_mnemonic_widget (GTK_LABEL (label[index]), widget[index]);
+    }
+  }
+
+  return grid;
+
+#else /* GTK2 */
+
   GtkWidget *table = gtk_table_new (count, 2, FALSE);
 
   gtk_table_set_row_spacings (GTK_TABLE (table), DIALOG_V_SPACING);
@@ -106,6 +138,7 @@ gschem_dialog_misc_create_property_table (GtkWidget *label[], GtkWidget *widget[
   }
 
   return table;
+#endif
 }
 
 

--- a/libleptongui/src/o_misc.c
+++ b/libleptongui/src/o_misc.c
@@ -515,7 +515,6 @@ o_update_component (GschemToplevel *w_current, LeptonObject *o_current)
 
     value = o_attrib_search_attached_attribs_by_name (o_current, name, 0);
 
-    GList *attribs = lepton_object_get_attribs (o_new);
     if (value != NULL) {
       lepton_object_delete (attr_new);
       iter->data = NULL;

--- a/libleptongui/src/x_attribedit.c
+++ b/libleptongui/src/x_attribedit.c
@@ -273,7 +273,7 @@ void attrib_edit_dialog (GschemToplevel *w_current, LeptonObject *attr_obj, int 
 {
   LeptonToplevel *toplevel = gschem_toplevel_get_toplevel (w_current);
   GtkWidget *aewindow;
-  GtkWidget *vbox, *label, *table, *alignment;
+  GtkWidget *vbox, *label, *alignment;
   GtkWidget *show_options;
   GtkWidget *attrib_combo_box_entry;
   GtkWidget *attrib_combo_entry;
@@ -352,26 +352,41 @@ void attrib_edit_dialog (GschemToplevel *w_current, LeptonObject *attr_obj, int 
                             DIALOG_INDENTATION, 0);
   gtk_box_pack_start(GTK_BOX(vbox), alignment, TRUE, TRUE, 0);
 
-  table = gtk_table_new (3, 2, FALSE);
+#ifdef ENABLE_GTK3
+  GtkWidget *grid = gtk_grid_new ();
+  gtk_grid_set_row_spacing (GTK_GRID (grid), DIALOG_V_SPACING);
+  gtk_grid_set_column_spacing (GTK_GRID (grid), DIALOG_H_SPACING);
+  gtk_container_add (GTK_CONTAINER (alignment), grid);
+#else
+  GtkWidget *table = gtk_table_new (3, 2, FALSE);
   gtk_table_set_row_spacings(GTK_TABLE(table), DIALOG_V_SPACING);
   gtk_table_set_col_spacings(GTK_TABLE(table), DIALOG_H_SPACING);
   gtk_container_add (GTK_CONTAINER (alignment), table);
+#endif
 
   /* Name selection */
   label = gtk_label_new_with_mnemonic (_("N_ame:"));
   gtk_misc_set_alignment (GTK_MISC (label), 0, 0.5);
+#ifdef ENABLE_GTK3
+  gtk_grid_attach (GTK_GRID (grid), label, 0, 0, 1, 1);
+#else
   gtk_table_attach (GTK_TABLE (table), label, 0, 1, 0, 1,
                     (GtkAttachOptions) (GTK_FILL),
                     (GtkAttachOptions) (GTK_FILL), 0, 0);
+#endif
 
   attrib_combo_box_entry = gtk_combo_box_text_new_with_entry ();
   attrib_combo_entry = gtk_bin_get_child(GTK_BIN(attrib_combo_box_entry));
 
   gtk_label_set_mnemonic_widget (GTK_LABEL (label), attrib_combo_box_entry);
 
+#ifdef ENABLE_GTK3
+  gtk_grid_attach (GTK_GRID (grid), attrib_combo_box_entry, 1, 0, 1, 1);
+#else
   gtk_table_attach (GTK_TABLE (table), attrib_combo_box_entry, 1, 2, 0, 1,
                     (GtkAttachOptions) (GTK_EXPAND | GTK_FILL),
                     (GtkAttachOptions) (0), 0, 0);
+#endif
   g_object_ref (attrib_combo_entry);
   g_object_set_data_full (G_OBJECT (aewindow),
                          "attrib_combo_entry", attrib_combo_entry,
@@ -381,9 +396,13 @@ void attrib_edit_dialog (GschemToplevel *w_current, LeptonObject *attr_obj, int 
   /* Value entry */
   label = gtk_label_new_with_mnemonic (_("_Value:"));
   gtk_misc_set_alignment (GTK_MISC (label), 0, 0.5);
+#ifdef ENABLE_GTK3
+  gtk_grid_attach (GTK_GRID (grid), label, 0, 1, 1, 1);
+#else
   gtk_table_attach (GTK_TABLE (table), label, 0, 1, 1, 2,
                     (GtkAttachOptions) (GTK_FILL),
                     (GtkAttachOptions) (0), 0, 0);
+#endif
 
   value_entry = gtk_entry_new ();
   g_object_ref (value_entry);
@@ -392,9 +411,13 @@ void attrib_edit_dialog (GschemToplevel *w_current, LeptonObject *attr_obj, int 
 
   gtk_label_set_mnemonic_widget (GTK_LABEL (label), value_entry);
 
+#ifdef ENABLE_GTK3
+  gtk_grid_attach (GTK_GRID (grid), value_entry, 1, 1, 1, 1);
+#else
   gtk_table_attach (GTK_TABLE (table), value_entry, 1, 2, 1, 2,
                     (GtkAttachOptions) (GTK_EXPAND | GTK_FILL),
                     (GtkAttachOptions) (0), 0, 0);
+#endif
   gtk_entry_set_activates_default(GTK_ENTRY(value_entry), TRUE);
 
   /* Visibility */
@@ -404,9 +427,13 @@ void attrib_edit_dialog (GschemToplevel *w_current, LeptonObject *attr_obj, int 
                           (GDestroyNotify) g_object_unref);
 
   gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (visbutton), TRUE);
+#ifdef ENABLE_GTK3
+  gtk_grid_attach (GTK_GRID (grid), visbutton, 0, 2, 1, 1);
+#else
   gtk_table_attach (GTK_TABLE (table), visbutton, 0, 1, 2, 3,
                     (GtkAttachOptions) (GTK_FILL),
                     (GtkAttachOptions) (0), 0, 0);
+#endif
 
   show_options = gtk_combo_box_text_new ();
   GtkListStore *store = gtk_list_store_new (1, G_TYPE_STRING);
@@ -416,9 +443,13 @@ void attrib_edit_dialog (GschemToplevel *w_current, LeptonObject *attr_obj, int 
   g_object_set_data_full (G_OBJECT (aewindow), "show_options", show_options,
                           (GDestroyNotify) g_object_unref);
 
+#ifdef ENABLE_GTK3
+  gtk_grid_attach (GTK_GRID (grid), show_options, 1, 2, 1, 1);
+#else
   gtk_table_attach (GTK_TABLE (table), show_options, 1, 2, 2, 3,
                     (GtkAttachOptions) (GTK_FILL | GTK_EXPAND),
                     (GtkAttachOptions) (0), 0, 0);
+#endif
 
   gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (show_options),
                                   _("Show Value Only"));
@@ -440,16 +471,26 @@ void attrib_edit_dialog (GschemToplevel *w_current, LeptonObject *attr_obj, int 
                               DIALOG_INDENTATION, 0);
     gtk_box_pack_start(GTK_BOX(vbox), alignment, TRUE, TRUE, 0);
 
+#ifdef ENABLE_GTK3
+    grid = gtk_grid_new ();
+    gtk_grid_set_row_spacing (GTK_GRID (grid), DIALOG_V_SPACING);
+    gtk_grid_set_column_spacing (GTK_GRID (grid), DIALOG_H_SPACING);
+    gtk_container_add (GTK_CONTAINER (alignment), grid);
+#else
     table = gtk_table_new (2, 3, FALSE);
     gtk_table_set_row_spacings(GTK_TABLE(table), DIALOG_V_SPACING);
     gtk_table_set_col_spacings(GTK_TABLE(table), DIALOG_H_SPACING);
     gtk_container_add (GTK_CONTAINER (alignment), table);
+#endif
 
     addtoallbutton = gtk_radio_button_new_with_label (hbox2_group, _("All"));
     hbox2_group = gtk_radio_button_get_group (GTK_RADIO_BUTTON (addtoallbutton));
     g_object_ref (addtoallbutton);
     g_object_set_data_full (G_OBJECT (aewindow), "addtoallbutton", addtoallbutton,
                             (GDestroyNotify) g_object_unref);
+#ifdef ENABLE_GTK3
+    gtk_grid_attach (GTK_GRID (grid), addtoallbutton, 0, 0, 1, 1);
+#else
     gtk_table_attach(GTK_TABLE(table),
                      addtoallbutton,
                      0,
@@ -460,12 +501,16 @@ void attrib_edit_dialog (GschemToplevel *w_current, LeptonObject *attr_obj, int 
                      (GtkAttachOptions) 0,
                      0,
                      0);
+#endif
 
     addtocompsbutton = gtk_radio_button_new_with_label (hbox2_group, _("Components"));
     hbox2_group = gtk_radio_button_get_group (GTK_RADIO_BUTTON (addtocompsbutton));
     g_object_ref (addtocompsbutton);
     g_object_set_data_full (G_OBJECT (aewindow), "addtocompsbutton", addtocompsbutton,
                             (GDestroyNotify) g_object_unref);
+#ifdef ENABLE_GTK3
+    gtk_grid_attach (GTK_GRID (grid), addtocompsbutton, 1, 0, 1, 1);
+#else
     gtk_table_attach(GTK_TABLE(table),
                      addtocompsbutton,
                      1,
@@ -476,12 +521,16 @@ void attrib_edit_dialog (GschemToplevel *w_current, LeptonObject *attr_obj, int 
                      (GtkAttachOptions) 0,
                      0,
                      0);
+#endif
 
     addtonetsbutton = gtk_radio_button_new_with_label (hbox2_group, _("Nets"));
     hbox2_group = gtk_radio_button_get_group (GTK_RADIO_BUTTON (addtonetsbutton));
     g_object_ref (addtonetsbutton);
     g_object_set_data_full (G_OBJECT (aewindow), "addtonetsbutton", addtonetsbutton,
                             (GDestroyNotify) g_object_unref);
+#ifdef ENABLE_GTK3
+    gtk_grid_attach (GTK_GRID (grid), addtonetsbutton, 2, 0, 1, 1);
+#else
     gtk_table_attach(GTK_TABLE(table),
                      addtonetsbutton,
                      2,
@@ -492,12 +541,16 @@ void attrib_edit_dialog (GschemToplevel *w_current, LeptonObject *attr_obj, int 
                      (GtkAttachOptions) 0,
                      0,
                      0);
+#endif
 
     overwritebutton = gtk_check_button_new_with_label (_("Replace existing attributes"));
     gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON(overwritebutton), TRUE);
     g_object_ref (overwritebutton);
     g_object_set_data_full (G_OBJECT (aewindow), "overwritebutton", overwritebutton,
                             (GDestroyNotify) g_object_unref);
+#ifdef ENABLE_GTK3
+    gtk_grid_attach (GTK_GRID (grid), overwritebutton, 0, 1, 1, 1);
+#else
     gtk_table_attach(GTK_TABLE(table),
                      overwritebutton,
                      0,
@@ -508,6 +561,7 @@ void attrib_edit_dialog (GschemToplevel *w_current, LeptonObject *attr_obj, int 
                      (GtkAttachOptions) 0,
                      0,
                      0);
+#endif
   }
 
   /* gschem specific */

--- a/libleptongui/src/x_autonumber.c
+++ b/libleptongui/src/x_autonumber.c
@@ -1197,7 +1197,6 @@ GtkWidget* autonumber_create_dialog(GschemToplevel *w_current)
   GtkWidget *vbox1;
   GtkWidget *alignment1;
   GtkWidget *vbox3;
-  GtkWidget *table1;
   GtkWidget *label4;
   GtkWidget *scope_text;
   GtkWidget *label8;
@@ -1208,7 +1207,6 @@ GtkWidget* autonumber_create_dialog(GschemToplevel *w_current)
   GtkWidget *label1;
   GtkWidget *alignment3;
   GtkWidget *vbox4;
-  GtkWidget *table3;
   GtkWidget *label12;
   GtkWidget *label13;
   GtkWidget *opt_startnum;
@@ -1261,54 +1259,86 @@ GtkWidget* autonumber_create_dialog(GschemToplevel *w_current)
   gtk_widget_show (vbox3);
   gtk_container_add (GTK_CONTAINER (alignment1), vbox3);
 
-  table1 = gtk_table_new (3, 2, FALSE);
+#ifdef ENABLE_GTK3
+  GtkWidget* grid1 = gtk_grid_new ();
+  gtk_widget_show (grid1);
+  gtk_box_pack_start (GTK_BOX (vbox3), grid1, TRUE, TRUE, 0);
+  gtk_grid_set_row_spacing (GTK_GRID (grid1), DIALOG_V_SPACING);
+  gtk_grid_set_column_spacing (GTK_GRID (grid1), DIALOG_H_SPACING);
+#else
+  GtkWidget *table1 = gtk_table_new (3, 2, FALSE);
   gtk_widget_show (table1);
   gtk_box_pack_start (GTK_BOX (vbox3), table1, TRUE, TRUE, 0);
   gtk_table_set_row_spacings (GTK_TABLE (table1), DIALOG_V_SPACING);
   gtk_table_set_col_spacings (GTK_TABLE (table1), DIALOG_H_SPACING);
+#endif
 
   label4 = gtk_label_new (_("Search for:"));
   gtk_widget_show (label4);
+#ifdef ENABLE_GTK3
+  gtk_grid_attach (GTK_GRID (grid1), label4, 0, 0, 1, 1);
+#else
   gtk_table_attach (GTK_TABLE (table1), label4, 0, 1, 0, 1,
                     (GtkAttachOptions) (GTK_FILL),
                     (GtkAttachOptions) (0), 0, 0);
+#endif
   gtk_misc_set_alignment (GTK_MISC (label4), 0, 0.5);
 
   scope_text = gtk_combo_box_text_new_with_entry ();
   gtk_entry_set_activates_default(GTK_ENTRY(gtk_bin_get_child(GTK_BIN(scope_text))), TRUE);
   gtk_widget_show (scope_text);
+#ifdef ENABLE_GTK3
+  gtk_grid_attach (GTK_GRID (grid1), scope_text, 1, 0, 1, 1);
+#else
   gtk_table_attach (GTK_TABLE (table1), scope_text, 1, 2, 0, 1,
                     (GtkAttachOptions) (GTK_EXPAND | GTK_FILL),
                     (GtkAttachOptions) (GTK_FILL), 0, 0);
+#endif
 
   label8 = gtk_label_new (_("Autonumber text in:"));
   gtk_widget_show (label8);
+#ifdef ENABLE_GTK3
+  gtk_grid_attach (GTK_GRID (grid1), label8, 0, 1, 1, 1);
+#else
   gtk_table_attach (GTK_TABLE (table1), label8, 0, 1, 1, 2,
                     (GtkAttachOptions) (GTK_FILL),
                     (GtkAttachOptions) (0), 0, 0);
+#endif
   gtk_misc_set_alignment (GTK_MISC (label8), 0, 0.5);
 
   label6 = gtk_label_new (_("Skip numbers found in:"));
   gtk_widget_show (label6);
+#ifdef ENABLE_GTK3
+  gtk_grid_attach (GTK_GRID (grid1), label6, 0, 2, 1, 1);
+#else
   gtk_table_attach (GTK_TABLE (table1), label6, 0, 1, 2, 3,
                     (GtkAttachOptions) (GTK_FILL),
                     (GtkAttachOptions) (0), 0, 0);
+#endif
   gtk_misc_set_alignment (GTK_MISC (label6), 0, 0.5);
 
   scope_number = gtk_combo_box_text_new ();
   gtk_widget_show (scope_number);
+#ifdef ENABLE_GTK3
+  gtk_grid_attach (GTK_GRID (grid1), scope_number, 1, 1, 1, 1);
+#else
   gtk_table_attach (GTK_TABLE (table1), scope_number, 1, 2, 1, 2,
                     (GtkAttachOptions) (GTK_FILL),
                     (GtkAttachOptions) (GTK_FILL), 0, 0);
+#endif
   gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (scope_number), _("Selected objects"));
   gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (scope_number), _("Current page"));
   gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (scope_number), _("Whole hierarchy"));
 
   scope_skip = gtk_combo_box_text_new ();
   gtk_widget_show (scope_skip);
+#ifdef ENABLE_GTK3
+  gtk_grid_attach (GTK_GRID (grid1), scope_skip, 1, 2, 1, 1);
+#else
   gtk_table_attach (GTK_TABLE (table1), scope_skip, 1, 2, 2, 3,
                     (GtkAttachOptions) (GTK_FILL),
                     (GtkAttachOptions) (GTK_FILL), 0, 0);
+#endif
   gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (scope_skip), _("Selected objects"));
   gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (scope_skip), _("Current page"));
   gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (scope_skip), _("Whole hierarchy"));
@@ -1338,24 +1368,40 @@ GtkWidget* autonumber_create_dialog(GschemToplevel *w_current)
   gtk_widget_show (vbox4);
   gtk_container_add (GTK_CONTAINER (alignment3), vbox4);
 
-  table3 = gtk_table_new (2, 2, FALSE);
+#ifdef ENABLE_GTK3
+  GtkWidget *grid3 = gtk_grid_new ();
+  gtk_widget_show (grid3);
+  gtk_box_pack_start (GTK_BOX (vbox4), grid3, TRUE, TRUE, 0);
+  gtk_grid_set_row_spacing (GTK_GRID (grid3), DIALOG_V_SPACING);
+  gtk_grid_set_column_spacing (GTK_GRID (grid3), DIALOG_H_SPACING);
+#else
+  GtkWidget *table3 = gtk_table_new (2, 2, FALSE);
   gtk_widget_show (table3);
   gtk_box_pack_start (GTK_BOX (vbox4), table3, TRUE, TRUE, 0);
   gtk_table_set_row_spacings (GTK_TABLE (table3), DIALOG_V_SPACING);
   gtk_table_set_col_spacings (GTK_TABLE (table3), DIALOG_H_SPACING);
+#endif
 
   label12 = gtk_label_new (_("Starting number:"));
   gtk_widget_show (label12);
+#ifdef ENABLE_GTK3
+  gtk_grid_attach (GTK_GRID (grid3), label12, 0, 0, 1, 1);
+#else
   gtk_table_attach (GTK_TABLE (table3), label12, 0, 1, 0, 1,
                     (GtkAttachOptions) (GTK_FILL),
                     (GtkAttachOptions) (0), 0, 0);
+#endif
   gtk_misc_set_alignment (GTK_MISC (label12), 0, 0.5);
 
   label13 = gtk_label_new (_("Sort order:"));
   gtk_widget_show (label13);
+#ifdef ENABLE_GTK3
+  gtk_grid_attach (GTK_GRID (grid3), label13, 0, 1, 1, 1);
+#else
   gtk_table_attach (GTK_TABLE (table3), label13, 0, 1, 1, 2,
                     (GtkAttachOptions) (GTK_FILL),
                     (GtkAttachOptions) (0), 0, 0);
+#endif
   gtk_misc_set_alignment (GTK_MISC (label13), 0, 0.5);
 
 
@@ -1373,15 +1419,23 @@ GtkWidget* autonumber_create_dialog(GschemToplevel *w_current)
 
   gtk_entry_set_activates_default(GTK_ENTRY(opt_startnum), TRUE);
   gtk_widget_show (opt_startnum);
+#ifdef ENABLE_GTK3
+  gtk_grid_attach (GTK_GRID (grid3), opt_startnum, 1, 0, 1, 1);
+#else
   gtk_table_attach (GTK_TABLE (table3), opt_startnum, 1, 2, 0, 1,
                     (GtkAttachOptions) (GTK_EXPAND | GTK_FILL),
                     (GtkAttachOptions) (0), 0, 0);
+#endif
 
   sort_order = gtk_combo_box_new();
   gtk_widget_show (sort_order);
+#ifdef ENABLE_GTK3
+  gtk_grid_attach (GTK_GRID (grid3), sort_order, 1, 1, 1, 1);
+#else
   gtk_table_attach (GTK_TABLE (table3), sort_order, 1, 2, 1, 2,
                     (GtkAttachOptions) (GTK_FILL),
                     (GtkAttachOptions) (GTK_FILL), 0, 0);
+#endif
 
   opt_removenum = gtk_check_button_new_with_mnemonic (_("Remove numbers"));
   gtk_widget_show (opt_removenum);

--- a/libleptongui/src/x_event.c
+++ b/libleptongui/src/x_event.c
@@ -854,7 +854,15 @@ x_event_get_pointer_position (GschemToplevel *w_current, gboolean snapped, gint 
   width = gdk_window_get_width (window);
   height = gdk_window_get_height (window);
 
+#ifdef ENABLE_GTK3
+  GdkDisplay *display = gdk_display_get_default ();
+  GdkSeat *seat = gdk_display_get_default_seat (display);
+  GdkDevice *pointer = gdk_seat_get_pointer (seat);
+
+  gdk_device_get_position (pointer, NULL, &sx, &sy);
+#else
   gtk_widget_get_pointer(GTK_WIDGET (page_view), &sx, &sy);
+#endif
 
   /* check if we are inside the drawing area */
   if ((sx < 0) || (sx >= width) || (sy < 0) || (sy >= height)) {
@@ -893,7 +901,15 @@ x_event_faked_motion (GschemPageView *view, GdkEventKey *event) {
   gboolean ret;
   GdkEventMotion *newevent;
 
+#ifdef ENABLE_GTK3
+  GdkDisplay *display = gdk_display_get_default ();
+  GdkSeat *seat = gdk_display_get_default_seat (display);
+  GdkDevice *pointer = gdk_seat_get_pointer (seat);
+
+  gdk_device_get_position (pointer, NULL, &x, &y);
+#else
   gtk_widget_get_pointer (GTK_WIDGET (view), &x, &y);
+#endif
   newevent = (GdkEventMotion*)gdk_event_new(GDK_MOTION_NOTIFY);
   newevent->x = x;
   newevent->y = y;

--- a/libleptongui/src/x_multiattrib.c
+++ b/libleptongui/src/x_multiattrib.c
@@ -2064,7 +2064,7 @@ static void
 multiattrib_init (Multiattrib *multiattrib)
 {
   GtkWidget *label, *scrolled_win, *treeview;
-  GtkWidget *table, *textview, *combo, *optionm, *button;
+  GtkWidget *textview, *combo, *optionm, *button;
   GtkWidget *attrib_vbox, *show_inherited;
   GtkTreeModel *store;
   GtkCellRenderer *renderer;
@@ -2288,13 +2288,16 @@ multiattrib_init (Multiattrib *multiattrib)
                       TRUE, TRUE, 1);
   gtk_widget_show_all (multiattrib->list_frame);
 
-
-  table = GTK_WIDGET (g_object_new (GTK_TYPE_TABLE,
-                                    /* GtkTable */
-                                    "n-rows",      4,
-                                    "n-columns",   2,
-                                    "homogeneous", FALSE,
-                                    NULL));
+#ifdef ENABLE_GTK3
+  GtkWidget *grid = gtk_grid_new ();
+#else
+  GtkWidget *table = GTK_WIDGET (g_object_new (GTK_TYPE_TABLE,
+                                               /* GtkTable */
+                                               "n-rows",      4,
+                                               "n-columns",   2,
+                                               "homogeneous", FALSE,
+                                               NULL));
+#endif
 
   /*   - the name entry: a GtkComboBoxEntry */
   label = gtk_label_new_with_mnemonic (_("_Name:"));
@@ -2308,6 +2311,10 @@ multiattrib_init (Multiattrib *multiattrib)
   gtk_label_set_mnemonic_widget (GTK_LABEL (label),
                                  GTK_WIDGET (multiattrib->combo_name));
 
+#ifdef ENABLE_GTK3
+  gtk_grid_attach (GTK_GRID (grid), label, 0, 0, 1, 1);
+  gtk_grid_attach (GTK_GRID (grid), combo, 1, 0, 1, 1);
+#else
   gtk_table_attach (GTK_TABLE (table), label,
                     0, 1, 0, 1,
                     (GtkAttachOptions) 0,
@@ -2318,6 +2325,7 @@ multiattrib_init (Multiattrib *multiattrib)
                     (GtkAttachOptions) (GTK_EXPAND | GTK_FILL),
                     (GtkAttachOptions) 0,
                     6, 3);
+#endif
 
   /*   - the value entry: a GtkEntry */
   label = gtk_label_new_with_mnemonic (_("_Value:"));
@@ -2389,6 +2397,10 @@ multiattrib_init (Multiattrib *multiattrib)
 
   gtk_container_add (GTK_CONTAINER (scrolled_win), textview);
   multiattrib->textview_value = GTK_TEXT_VIEW (textview);
+#ifdef ENABLE_GTK3
+  gtk_grid_attach (GTK_GRID (grid), label, 0, 1, 1, 1);
+  gtk_grid_attach (GTK_GRID (grid), scrolled_win, 1, 1, 1, 1);
+#else
   gtk_table_attach (GTK_TABLE (table), label,
                     0, 1, 1, 2,
                     (GtkAttachOptions) 0,
@@ -2399,28 +2411,38 @@ multiattrib_init (Multiattrib *multiattrib)
                     (GtkAttachOptions) (GTK_EXPAND | GTK_FILL),
                     (GtkAttachOptions) 0,
                     6, 3);
+#endif
 
   /*   - the visible status */
   button = gtk_check_button_new_with_mnemonic (_("Vi_sible"));
   gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (button), TRUE);
 
   multiattrib->button_visible = GTK_CHECK_BUTTON (button);
+#ifdef ENABLE_GTK3
+  gtk_grid_attach (GTK_GRID (grid), button, 0, 2, 1, 1);
+#else
   gtk_table_attach (GTK_TABLE (table), button,
                     0, 1, 2, 3,
                     GTK_FILL,
                     (GtkAttachOptions) 0,
                     3, 0);
+#endif
 
   /*   - the visibility type */
   optionm = gtk_combo_box_text_new ();
   multiattrib_init_visible_types (GTK_COMBO_BOX_TEXT (optionm));
   multiattrib->optionmenu_shownv = GTK_COMBO_BOX_TEXT (optionm);
+#ifdef ENABLE_GTK3
+  gtk_grid_attach (GTK_GRID (grid), optionm, 1, 2, 1, 1);
+  gtk_widget_show_all (grid);
+#else
   gtk_table_attach (GTK_TABLE (table), optionm,
                     1, 2, 2, 3,
                     (GtkAttachOptions) (GTK_EXPAND | GTK_FILL),
                     (GtkAttachOptions) 0,
                     6, 3);
   gtk_widget_show_all (table);
+#endif
 
   /* create the add button */
   button = gtk_button_new_from_stock (GTK_STOCK_ADD);
@@ -2428,6 +2450,13 @@ multiattrib_init (Multiattrib *multiattrib)
                     "clicked",
                     G_CALLBACK (multiattrib_callback_button_add),
                     multiattrib);
+#ifdef ENABLE_GTK3
+  gtk_grid_attach (GTK_GRID (grid), button, 2, 0, 1, 1);
+
+  multiattrib->add_frame =
+    gschem_dialog_misc_create_section_widget(
+      _("<b>Add Attribute</b>"), grid);
+#else
   gtk_table_attach (GTK_TABLE (table), button,
                     2, 3, 0, 3,
                     (GtkAttachOptions) 0,
@@ -2438,6 +2467,7 @@ multiattrib_init (Multiattrib *multiattrib)
   multiattrib->add_frame =
     gschem_dialog_misc_create_section_widget(
       _("<b>Add Attribute</b>"), table);
+#endif
 
   g_signal_connect (multiattrib->add_frame,
                     "activate",

--- a/libleptongui/src/x_newtext.c
+++ b/libleptongui/src/x_newtext.c
@@ -218,7 +218,11 @@ static void newtext_init(NewText *dialog)
   GtkWidget *scrolled_window = NULL;
   PangoTabArray *tab_array;
   int real_tab_width;
+#ifdef ENABLE_GTK3
+  GtkWidget *grid;
+#else
   GtkWidget *table;
+#endif
 
   gtk_dialog_add_button (GTK_DIALOG (dialog),
                          GTK_STOCK_CLOSE,
@@ -246,9 +250,15 @@ static void newtext_init(NewText *dialog)
   vbox = gtk_dialog_get_content_area (GTK_DIALOG (dialog));
   gtk_box_set_spacing(GTK_BOX(vbox),DIALOG_V_SPACING);
 
+#ifdef ENABLE_GTK3
+  grid = gtk_grid_new ();
+  gtk_grid_set_row_spacing (GTK_GRID (grid), DIALOG_V_SPACING);
+  gtk_grid_set_column_spacing (GTK_GRID (grid), DIALOG_H_SPACING);
+#else
   table = gtk_table_new(4, 2, FALSE);
   gtk_table_set_row_spacings(GTK_TABLE(table), DIALOG_V_SPACING);
   gtk_table_set_col_spacings(GTK_TABLE(table), DIALOG_H_SPACING);
+#endif
 
   label = gtk_label_new(_("<b>Text Properties</b>"));
   gtk_label_set_use_markup(GTK_LABEL(label), TRUE);
@@ -260,7 +270,11 @@ static void newtext_init(NewText *dialog)
                             DIALOG_INDENTATION, 0);
   gtk_box_pack_start(GTK_BOX(vbox), alignment, FALSE, FALSE, 0);
 
+#ifdef ENABLE_GTK3
+  gtk_container_add (GTK_CONTAINER (alignment), grid);
+#else
   gtk_container_add(GTK_CONTAINER(alignment), table);
+#endif
 
   label = gtk_label_new (_("<b>Text Content</b>"));
   gtk_label_set_use_markup (GTK_LABEL (label), TRUE);
@@ -270,6 +284,9 @@ static void newtext_init(NewText *dialog)
 
   label = gtk_label_new_with_mnemonic (_("Colo_r:"));
   gtk_misc_set_alignment(GTK_MISC(label),0,0);
+#ifdef ENABLE_GTK3
+  gtk_grid_attach (GTK_GRID (grid), label, 0, 0, 1, 1);
+#else
   gtk_table_attach (GTK_TABLE(table),
                     label,
                     0,
@@ -280,16 +297,24 @@ static void newtext_init(NewText *dialog)
                     (GtkAttachOptions) 0,
                     0,
                     0);
+#endif
 
   dialog->colorcb = x_colorcb_new ();
   x_colorcb_set_index(dialog->colorcb, TEXT_COLOR);
 
   gtk_label_set_mnemonic_widget (GTK_LABEL (label), dialog->colorcb);
 
+#ifdef ENABLE_GTK3
+  gtk_grid_attach (GTK_GRID (grid), dialog->colorcb, 1, 0, 1, 1);
+#else
   gtk_table_attach_defaults(GTK_TABLE(table), dialog->colorcb, 1,2,0,1);
+#endif
 
   label = gtk_label_new_with_mnemonic (_("_Size:"));
   gtk_misc_set_alignment(GTK_MISC(label),0,0);
+#ifdef ENABLE_GTK3
+  gtk_grid_attach (GTK_GRID (grid), label, 0, 1, 1, 1);
+#else
   gtk_table_attach (GTK_TABLE(table),
                     label,
                     0,
@@ -300,15 +325,23 @@ static void newtext_init(NewText *dialog)
                     (GtkAttachOptions) 0,
                     0,
                     0);
+#endif
 
   dialog->textsizecb = gschem_integer_combo_box_new();
 
   gtk_label_set_mnemonic_widget (GTK_LABEL (label), dialog->textsizecb);
 
+#ifdef ENABLE_GTK3
+  gtk_grid_attach (GTK_GRID (grid), dialog->textsizecb, 1, 1, 1, 1);
+#else
   gtk_table_attach_defaults(GTK_TABLE(table), dialog->textsizecb, 1,2,1,2);
+#endif
 
   label = gtk_label_new_with_mnemonic (_("Ali_gnment:"));
   gtk_misc_set_alignment(GTK_MISC(label),0,0);
+#ifdef ENABLE_GTK3
+  gtk_grid_attach (GTK_GRID (grid), label, 0, 2, 1, 1);
+#else
   gtk_table_attach (GTK_TABLE(table),
                     label,
                     0,
@@ -319,16 +352,24 @@ static void newtext_init(NewText *dialog)
                     (GtkAttachOptions) 0,
                     0,
                     0);
+#endif
 
   dialog->aligncb = gschem_alignment_combo_new ();
   gschem_alignment_combo_set_align(dialog->aligncb, LOWER_LEFT);
 
   gtk_label_set_mnemonic_widget (GTK_LABEL (label), dialog->aligncb);
 
+#ifdef ENABLE_GTK3
+  gtk_grid_attach (GTK_GRID (grid), dialog->aligncb, 1, 2, 1, 1);
+#else
   gtk_table_attach_defaults(GTK_TABLE(table), dialog->aligncb, 1,2,2,3);
+#endif
 
   label = gtk_label_new_with_mnemonic (_("Ro_tation:"));
   gtk_misc_set_alignment(GTK_MISC(label),0,0);
+#ifdef ENABLE_GTK3
+  gtk_grid_attach (GTK_GRID (grid), label, 0, 3, 1, 1);
+#else
   gtk_table_attach (GTK_TABLE(table),
                     label,
                     0,
@@ -339,14 +380,18 @@ static void newtext_init(NewText *dialog)
                     (GtkAttachOptions) 0,
                     0,
                     0);
+#endif
 
   dialog->rotatecb = gschem_rotation_combo_new ();
   gschem_rotation_combo_set_angle(dialog->rotatecb, 0);
 
   gtk_label_set_mnemonic_widget (GTK_LABEL (label), dialog->rotatecb);
 
+#ifdef ENABLE_GTK3
+  gtk_grid_attach (GTK_GRID (grid), dialog->rotatecb, 1, 3, 1, 1);
+#else
   gtk_table_attach_defaults(GTK_TABLE(table), dialog->rotatecb, 1,2,3,4);
-
+#endif
 
   viewport1 = gtk_viewport_new (NULL, NULL);
   gtk_widget_show (viewport1);


### PR DESCRIPTION
Apart from deprecation warnings on color selection/chooser widget functions, most of other pre-3.4 function warnings have been eliminated as well as some warnings from lastly applied code.