### PR TITLE
Utilize accessors for LeptonComponent's fields

### DIFF
--- a/liblepton/include/liblepton/component.h
+++ b/liblepton/include/liblepton/component.h
@@ -37,4 +37,5 @@ struct st_component
 
   GList *prim_objs;    /* Primitive objects objects which make up */
                        /* the component */
+  gchar *basename;     /* Component Library Symbol name */
 };

--- a/liblepton/include/liblepton/object.h
+++ b/liblepton/include/liblepton/object.h
@@ -50,7 +50,6 @@ struct st_object
   /* Visible appearance of filling of graphical primitives. */
   LeptonFill *fill;
 
-  gchar *component_basename;            /* Component Library Symbol name */
   LeptonObject *parent;                 /* Parent object pointer */
 
   int color;                            /* Which color */

--- a/liblepton/src/component_object.c
+++ b/liblepton/src/component_object.c
@@ -1489,10 +1489,11 @@ o_component_check_symversion (LeptonPage* page,
   g_return_if_fail (lepton_object_is_component (object));
   g_return_if_fail (object->component != NULL);
 
+  gchar *basename = lepton_component_object_get_basename (object);
 
   /* No need to check symversion if symbol is not found in libraries:
   */
-  GList* symlist = s_clib_search (object->component_basename, CLIB_EXACT);
+  GList* symlist = s_clib_search (basename, CLIB_EXACT);
   if (symlist == NULL)
   {
     return;
@@ -1522,13 +1523,13 @@ o_component_check_symversion (LeptonPage* page,
       {
         g_message (_("WARNING: %s (%s): could not parse "
                      "symversion (%s) in symbol file"),
-                   object->component_basename,
+                   basename,
                    refdes,
                    inside);
       } else {
         g_message (_("WARNING: %s (%s): could not parse "
                      "symversion in symbol file"),
-                   object->component_basename,
+                   basename,
                    refdes);
       }
       goto done;
@@ -1545,7 +1546,7 @@ o_component_check_symversion (LeptonPage* page,
     {
       g_message (_("WARNING: %s (%s): could not parse "
                    "attached symversion (%s)"),
-                 object->component_basename,
+                 basename,
                  refdes,
                  outside);
       goto done;
@@ -1572,7 +1573,7 @@ o_component_check_symversion (LeptonPage* page,
   {
     g_message (_("WARNING: %s (%s): symversion attached, "
                  "but absent inside symbol file"),
-               object->component_basename,
+               basename,
                refdes);
     goto done;
   }
@@ -1610,7 +1611,7 @@ o_component_check_symversion (LeptonPage* page,
 
       g_message (_("WARNING: %s (%s): MAJOR symversion change "
                    "(attached: %.3f < library: %.3f)"),
-                 object->component_basename,
+                 basename,
                  refdes,
                  outside_value,
                  inside_value);
@@ -1624,7 +1625,7 @@ o_component_check_symversion (LeptonPage* page,
         refdes_copy = g_strconcat ("refdes: ",
                                    refdes,
                                    " (",
-                                   object->component_basename,
+                                   basename,
                                    ")",
                                    NULL);
 
@@ -1646,7 +1647,7 @@ o_component_check_symversion (LeptonPage* page,
     {
       g_message (_("WARNING: %s (%s): minor symversion change "
                    "(attached: %.3f < library: %.3f)"),
-                 object->component_basename,
+                 basename,
                  refdes,
                  outside_value,
                  inside_value);
@@ -1660,7 +1661,7 @@ o_component_check_symversion (LeptonPage* page,
   {
     g_message (_("WARNING: %s (%s): symbol is newer "
                  "than symbol in library (%.3f > %.3f)"),
-               object->component_basename,
+               basename,
                refdes,
                outside_value,
                inside_value);

--- a/liblepton/src/component_object.c
+++ b/liblepton/src/component_object.c
@@ -1218,7 +1218,7 @@ lepton_component_object_to_buffer (const LeptonObject *object)
 
   basename = g_strdup_printf ("%s%s",
                               lepton_component_object_get_embedded (object) ? "EMBEDDED" : "",
-                              object->component_basename);
+                              lepton_component_object_get_basename (object));
 
   /* We force the object type to be output as OBJ_COMPONENT for both these object
    * types.

--- a/liblepton/src/component_object.c
+++ b/liblepton/src/component_object.c
@@ -838,7 +838,7 @@ create_placeholder_classic (LeptonObject *new_node, int x, int y)
   /* Add some useful text */
   not_found_text =
     g_strdup_printf (_("Component not found:\n %1$s"),
-                     new_node->component_basename);
+                     lepton_component_object_get_basename (new_node));
   new_prim_obj = lepton_text_object_new (DETACHED_ATTRIBUTE_COLOR,
                                          x + NOT_FOUND_TEXT_X,
                                          y + NOT_FOUND_TEXT_Y,

--- a/liblepton/src/component_object.c
+++ b/liblepton/src/component_object.c
@@ -1016,7 +1016,7 @@ lepton_component_new (LeptonPage *page,
                                                          NULL,
                                                          buffer,
                                                          -1,
-                                                         new_node->component_basename,
+                                                         lepton_component_object_get_basename (new_node),
                                                          &err));
     if (err) {
       g_error_free(err);

--- a/liblepton/src/component_object.c
+++ b/liblepton/src/component_object.c
@@ -988,7 +988,7 @@ lepton_component_new (LeptonPage *page,
   new_node->component = (LeptonComponent *) g_malloc (sizeof (LeptonComponent));
   lepton_component_object_set_contents (new_node, NULL);
   lepton_component_object_set_angle (new_node, angle);
-  new_node->component->mirror = mirror;
+  lepton_component_object_set_mirror (new_node, mirror);
   lepton_component_object_set_x (new_node, x);
   lepton_component_object_set_y (new_node, y);
   /* Do setting color after initialization of prim_objs as the
@@ -1080,7 +1080,7 @@ lepton_component_new_embedded (int color,
   lepton_component_object_set_y (new_node, y);
 
   lepton_component_object_set_angle (new_node, angle);
-  new_node->component->mirror = mirror;
+  lepton_component_object_set_mirror (new_node, mirror);
 
   new_node->component_basename = g_strdup(basename);
 
@@ -1229,7 +1229,7 @@ lepton_component_object_to_buffer (const LeptonObject *object)
                             lepton_component_object_get_y (object),
                             lepton_object_get_selectable (object),
                             lepton_component_object_get_angle (object),
-                            object->component->mirror,
+                            lepton_component_object_get_mirror (object),
                             basename);
 
   g_free (basename);
@@ -1286,7 +1286,7 @@ o_component_copy (LeptonObject *o_current)
   lepton_component_object_set_x (o_new, lepton_component_object_get_x (o_current));
   lepton_component_object_set_y (o_new, lepton_component_object_get_y (o_current));
   lepton_component_object_set_angle (o_new, lepton_component_object_get_angle (o_current));
-  o_new->component->mirror = o_current->component->mirror;
+  lepton_component_object_set_mirror (o_new, lepton_component_object_get_mirror (o_current));
 
   /* Set prim_objs temporarily to NULL to prevent crashes on color
      initialization. */
@@ -1411,7 +1411,7 @@ lepton_component_object_mirror (int world_centerx,
 
   }
 
-  object->component->mirror = !object->component->mirror;
+  lepton_component_object_set_mirror (object, !lepton_component_object_get_mirror (object));
 
   lepton_component_object_translate (object, x, y);
 }

--- a/liblepton/src/component_object.c
+++ b/liblepton/src/component_object.c
@@ -982,9 +982,10 @@ lepton_component_new (LeptonPage *page,
   new_node->component = g_new0 (LeptonComponent, 1);
 
   if (clib != NULL) {
-    new_node->component->basename = g_strdup (s_clib_symbol_get_name (clib));
+    lepton_component_object_set_basename (new_node,
+                                          s_clib_symbol_get_name (clib));
   } else {
-    new_node->component->basename = g_strdup (basename);
+    lepton_component_object_set_basename (new_node, basename);
   }
 
   lepton_component_object_set_contents (new_node, NULL);

--- a/liblepton/src/component_object.c
+++ b/liblepton/src/component_object.c
@@ -51,7 +51,7 @@ lepton_component_object_get_basename (const LeptonObject *object)
   g_return_val_if_fail (lepton_object_is_component (object), NULL);
   g_return_val_if_fail (object->component != NULL, NULL);
 
-  return object->component_basename;
+  return object->component->basename;
 }
 
 
@@ -69,14 +69,14 @@ lepton_component_object_set_basename (LeptonObject *object,
   g_return_if_fail (lepton_object_is_component (object));
   g_return_if_fail (object->component != NULL);
 
-  g_free (object->component_basename);
+  g_free (object->component->basename);
   if (basename == NULL)
   {
-    object->component_basename = NULL;
+    object->component->basename = NULL;
   }
   else
   {
-    object->component_basename = g_strdup (basename);
+    object->component->basename = g_strdup (basename);
   }
 }
 
@@ -977,15 +977,16 @@ lepton_component_new (LeptonPage *page,
 
   new_node = lepton_object_new (OBJ_COMPONENT, "complex");
 
-  if (clib != NULL) {
-    new_node->component_basename = g_strdup (s_clib_symbol_get_name (clib));
-  } else {
-    new_node->component_basename = g_strdup (basename);
-  }
-
   new_node->selectable = selectable;
 
   new_node->component = g_new0 (LeptonComponent, 1);
+
+  if (clib != NULL) {
+    new_node->component->basename = g_strdup (s_clib_symbol_get_name (clib));
+  } else {
+    new_node->component->basename = g_strdup (basename);
+  }
+
   lepton_component_object_set_contents (new_node, NULL);
   lepton_component_object_set_angle (new_node, angle);
   lepton_component_object_set_mirror (new_node, mirror);

--- a/liblepton/src/component_object.c
+++ b/liblepton/src/component_object.c
@@ -750,7 +750,7 @@ create_placeholder_small (LeptonObject* node, int x, int y)
                                               x + 100, y + 100,
                                               LOWER_LEFT,
                                               0,
-                                              node->component_basename,
+                                              lepton_component_object_get_basename (node),
                                               text_size,
                                               VISIBLE,
                                               SHOW_NAME_VALUE);

--- a/liblepton/src/component_object.c
+++ b/liblepton/src/component_object.c
@@ -1082,7 +1082,7 @@ lepton_component_new_embedded (int color,
   lepton_component_object_set_angle (new_node, angle);
   lepton_component_object_set_mirror (new_node, mirror);
 
-  new_node->component_basename = g_strdup(basename);
+  lepton_component_object_set_basename (new_node, basename);
 
   new_node->selectable = selectable;
 

--- a/liblepton/src/component_object.c
+++ b/liblepton/src/component_object.c
@@ -1280,9 +1280,10 @@ o_component_copy (LeptonObject *o_current)
 
   o_new = lepton_object_new (lepton_object_get_type (o_current), "complex");
   o_new->selectable = o_current->selectable;
-  o_new->component_basename = g_strdup(o_current->component_basename);
 
   o_new->component = (LeptonComponent*) g_malloc0 (sizeof (LeptonComponent));
+  lepton_component_object_set_basename (o_new,
+                                        lepton_component_object_get_basename (o_current));
   lepton_component_object_set_x (o_new, lepton_component_object_get_x (o_current));
   lepton_component_object_set_y (o_new, lepton_component_object_get_y (o_current));
   lepton_component_object_set_angle (o_new, lepton_component_object_get_angle (o_current));

--- a/liblepton/src/component_object.c
+++ b/liblepton/src/component_object.c
@@ -435,11 +435,11 @@ lepton_component_object_get_position (const LeptonObject *object,
   g_return_val_if_fail (object->component != NULL, FALSE);
 
   if (x != NULL) {
-    *x = object->component->x;
+    *x = lepton_component_object_get_x (object);
   }
 
   if (y != NULL) {
-    *y = object->component->y;
+    *y = lepton_component_object_get_y (object);
   }
 
   return TRUE;
@@ -989,8 +989,8 @@ lepton_component_new (LeptonPage *page,
   lepton_component_object_set_contents (new_node, NULL);
   new_node->component->angle = angle;
   new_node->component->mirror = mirror;
-  new_node->component->x = x;
-  new_node->component->y = y;
+  lepton_component_object_set_x (new_node, x);
+  lepton_component_object_set_y (new_node, y);
   /* Do setting color after initialization of prim_objs as the
      function sets color of prim_objs as well. */
   lepton_object_set_color (new_node, color);
@@ -1076,8 +1076,8 @@ lepton_component_new_embedded (int color,
   new_node = lepton_object_new (OBJ_COMPONENT, "complex");
 
   new_node->component = (LeptonComponent *) g_malloc (sizeof (LeptonComponent));
-  new_node->component->x = x;
-  new_node->component->y = y;
+  lepton_component_object_set_x (new_node, x);
+  lepton_component_object_set_y (new_node, y);
 
   new_node->component->angle = angle;
   new_node->component->mirror = mirror;
@@ -1225,8 +1225,8 @@ lepton_component_object_to_buffer (const LeptonObject *object)
    */
   buffer = g_strdup_printf ("%c %d %d %d %d %d %s",
                             lepton_object_get_type (object),
-                            object->component->x,
-                            object->component->y,
+                            lepton_component_object_get_x (object),
+                            lepton_component_object_get_y (object),
                             lepton_object_get_selectable (object),
                             object->component->angle,
                             object->component->mirror,
@@ -1253,8 +1253,8 @@ lepton_component_object_translate (LeptonObject *object, int dx, int dy)
   g_return_if_fail (lepton_object_is_component (object));
   g_return_if_fail (object->component != NULL);
 
-  object->component->x = object->component->x + dx;
-  object->component->y = object->component->y + dy;
+  lepton_component_object_set_x (object, lepton_component_object_get_x (object) + dx);
+  lepton_component_object_set_y (object, lepton_component_object_get_y (object) + dy);
 
   primitives = lepton_component_object_get_contents (object);
   lepton_object_list_translate (primitives, dx, dy);
@@ -1283,8 +1283,8 @@ o_component_copy (LeptonObject *o_current)
   o_new->component_basename = g_strdup(o_current->component_basename);
 
   o_new->component = (LeptonComponent*) g_malloc0 (sizeof (LeptonComponent));
-  o_new->component->x = o_current->component->x;
-  o_new->component->y = o_current->component->y;
+  lepton_component_object_set_x (o_new, lepton_component_object_get_x (o_current));
+  lepton_component_object_set_y (o_new, lepton_component_object_get_y (o_current));
   o_new->component->angle = o_current->component->angle;
   o_new->component->mirror = o_current->component->mirror;
 
@@ -1349,21 +1349,23 @@ lepton_component_object_rotate (int centerx,
   g_return_if_fail (lepton_object_is_component (object));
   g_return_if_fail (object->component != NULL);
 
-  x = object->component->x + (-centerx);
-  y = object->component->y + (-centery);
+  x = lepton_component_object_get_x (object) + (-centerx);
+  y = lepton_component_object_get_y (object) + (-centery);
 
   lepton_point_rotate_90 (x, y, angle, &newx, &newy);
 
   x = newx + (centerx);
   y = newy + (centery);
 
-  lepton_component_object_translate (object, -object->component->x, -object->component->y);
+  lepton_component_object_translate (object,
+                                     -(lepton_component_object_get_x (object)),
+                                     -(lepton_component_object_get_y (object)));
 
   primitives = lepton_component_object_get_contents (object);
   lepton_object_list_rotate (primitives, 0, 0, angle);
 
-  object->component->x = 0;
-  object->component->y = 0;
+  lepton_component_object_set_x (object, 0);
+  lepton_component_object_set_y (object, 0);
 
   lepton_component_object_translate (object, x, y);
 
@@ -1387,10 +1389,12 @@ lepton_component_object_mirror (int world_centerx,
   g_return_if_fail (lepton_object_is_component (object));
   g_return_if_fail (object->component != NULL);
 
-  x = 2 * world_centerx - object->component->x;
-  y = object->component->y;
+  x = 2 * world_centerx - lepton_component_object_get_x (object);
+  y = lepton_component_object_get_y (object);
 
-  lepton_component_object_translate (object, -object->component->x, -object->component->y);
+  lepton_component_object_translate (object,
+                                     -(lepton_component_object_get_x (object)),
+                                     -(lepton_component_object_get_y (object)));
 
   primitives = lepton_component_object_get_contents (object);
   lepton_object_list_mirror (primitives, 0, 0);

--- a/liblepton/src/component_object.c
+++ b/liblepton/src/component_object.c
@@ -987,7 +987,7 @@ lepton_component_new (LeptonPage *page,
 
   new_node->component = (LeptonComponent *) g_malloc (sizeof (LeptonComponent));
   lepton_component_object_set_contents (new_node, NULL);
-  new_node->component->angle = angle;
+  lepton_component_object_set_angle (new_node, angle);
   new_node->component->mirror = mirror;
   lepton_component_object_set_x (new_node, x);
   lepton_component_object_set_y (new_node, y);
@@ -1079,7 +1079,7 @@ lepton_component_new_embedded (int color,
   lepton_component_object_set_x (new_node, x);
   lepton_component_object_set_y (new_node, y);
 
-  new_node->component->angle = angle;
+  lepton_component_object_set_angle (new_node, angle);
   new_node->component->mirror = mirror;
 
   new_node->component_basename = g_strdup(basename);
@@ -1228,7 +1228,7 @@ lepton_component_object_to_buffer (const LeptonObject *object)
                             lepton_component_object_get_x (object),
                             lepton_component_object_get_y (object),
                             lepton_object_get_selectable (object),
-                            object->component->angle,
+                            lepton_component_object_get_angle (object),
                             object->component->mirror,
                             basename);
 
@@ -1285,7 +1285,7 @@ o_component_copy (LeptonObject *o_current)
   o_new->component = (LeptonComponent*) g_malloc0 (sizeof (LeptonComponent));
   lepton_component_object_set_x (o_new, lepton_component_object_get_x (o_current));
   lepton_component_object_set_y (o_new, lepton_component_object_get_y (o_current));
-  o_new->component->angle = o_current->component->angle;
+  lepton_component_object_set_angle (o_new, lepton_component_object_get_angle (o_current));
   o_new->component->mirror = o_current->component->mirror;
 
   /* Set prim_objs temporarily to NULL to prevent crashes on color
@@ -1369,7 +1369,7 @@ lepton_component_object_rotate (int centerx,
 
   lepton_component_object_translate (object, x, y);
 
-  object->component->angle = ( object->component->angle + angle ) % 360;
+  lepton_component_object_set_angle (object, (lepton_component_object_get_angle (object) + angle) % 360);
 }
 
 
@@ -1399,13 +1399,14 @@ lepton_component_object_mirror (int world_centerx,
   primitives = lepton_component_object_get_contents (object);
   lepton_object_list_mirror (primitives, 0, 0);
 
-  switch(object->component->angle) {
+  switch (lepton_component_object_get_angle (object))
+  {
     case(90):
-      object->component->angle = 270;
+      lepton_component_object_set_angle (object, 270);
       break;
 
     case(270):
-      object->component->angle = 90;
+      lepton_component_object_set_angle (object, 90);
       break;
 
   }

--- a/liblepton/src/component_object.c
+++ b/liblepton/src/component_object.c
@@ -1806,7 +1806,7 @@ lepton_component_object_embed (LeptonObject *object)
   lepton_component_object_set_embedded (object, TRUE);
 
   g_message (_("Component [%1$s] has been embedded."),
-             object->component_basename);
+             lepton_component_object_get_basename (object));
   /* Page content has been modified. */
   if (page != NULL)
   {

--- a/liblepton/src/component_object.c
+++ b/liblepton/src/component_object.c
@@ -985,7 +985,7 @@ lepton_component_new (LeptonPage *page,
 
   new_node->selectable = selectable;
 
-  new_node->component = (LeptonComponent *) g_malloc (sizeof (LeptonComponent));
+  new_node->component = g_new0 (LeptonComponent, 1);
   lepton_component_object_set_contents (new_node, NULL);
   lepton_component_object_set_angle (new_node, angle);
   lepton_component_object_set_mirror (new_node, mirror);
@@ -1075,7 +1075,7 @@ lepton_component_new_embedded (int color,
 
   new_node = lepton_object_new (OBJ_COMPONENT, "complex");
 
-  new_node->component = (LeptonComponent *) g_malloc (sizeof (LeptonComponent));
+  new_node->component = g_new0 (LeptonComponent, 1);
   lepton_component_object_set_x (new_node, x);
   lepton_component_object_set_y (new_node, y);
 

--- a/liblepton/src/component_object.c
+++ b/liblepton/src/component_object.c
@@ -1837,14 +1837,14 @@ lepton_component_object_unembed (LeptonObject *object)
     return;
 
   /* Search for the symbol in the component library. */
-  sym = s_clib_get_symbol_by_name (object->component_basename);
+  sym = s_clib_get_symbol_by_name (lepton_component_object_get_basename (object));
 
   if (sym == NULL)
   {
     /* Symbol not found in the symbol library: signal an error. */
     g_message (_("Could not find component [%1$s], while trying to "
                  "unembed. Component is still embedded."),
-               object->component_basename);
+               lepton_component_object_get_basename (object));
   }
   else
   {
@@ -1852,7 +1852,7 @@ lepton_component_object_unembed (LeptonObject *object)
     lepton_component_object_set_embedded (object, FALSE);
 
     g_message (_("Component [%1$s] has been successfully unembedded."),
-               object->component_basename);
+               lepton_component_object_get_basename (object));
 
     /* Page content has been modified. */
     if (page != NULL)

--- a/liblepton/src/object.c
+++ b/liblepton/src/object.c
@@ -979,10 +979,6 @@ lepton_object_delete (LeptonObject *o_current)
     lepton_fill_free (o_current->fill);
     o_current->fill = NULL;
 
-    /* printf("sdeleting component_basename\n");*/
-    g_free(o_current->component_basename);
-    o_current->component_basename = NULL;
-
     if (o_current->component) {
 
       primitives = lepton_component_object_get_contents (o_current);
@@ -992,6 +988,9 @@ lepton_object_delete (LeptonObject *o_current)
         lepton_object_list_delete (primitives);
         lepton_component_object_set_contents (o_current, NULL);
       }
+
+      g_free (o_current->component->basename);
+      o_current->component->basename = NULL;
 
       g_free(o_current->component);
       o_current->component = NULL;
@@ -1975,7 +1974,6 @@ lepton_object_new (int type,
   new_node->stroke = lepton_stroke_new ();
   new_node->fill = lepton_fill_new ();
 
-  new_node->component_basename = NULL;
   lepton_object_set_parent (new_node, NULL);
 
   /* Setup the color */

--- a/liblepton/src/object.c
+++ b/liblepton/src/object.c
@@ -989,8 +989,9 @@ lepton_object_delete (LeptonObject *o_current)
         lepton_component_object_set_contents (o_current, NULL);
       }
 
-      g_free (o_current->component->basename);
-      o_current->component->basename = NULL;
+      /* The setter below frees the basename of the object if the
+       * given value is NULL. */
+      lepton_component_object_set_basename (o_current, NULL);
 
       g_free(o_current->component);
       o_current->component = NULL;

--- a/liblepton/src/s_clib.c
+++ b/liblepton/src/s_clib.c
@@ -1450,13 +1450,15 @@ s_toplevel_get_symbols (const LeptonToplevel *toplevel)
          o_iter = g_list_next (o_iter)) {
       o = (LeptonObject *)o_iter->data;
       if (!lepton_object_is_component (o)) continue;
-      if (o->component_basename == NULL)  continue;
+
+      gchar *basename = lepton_component_object_get_basename (o);
+      if (basename == NULL)  continue;
 
       /* Since we're not looking at embedded symbols, the first
        * component with the given name will be the one we need.
        * N.b. we don't use s_clib_get_symbol_by_name() because it's
        * spammeh. */
-      symlist = s_clib_search (o->component_basename, CLIB_EXACT);
+      symlist = s_clib_search (basename, CLIB_EXACT);
       if (symlist == NULL) continue;
       sym = (CLibSymbol *) symlist->data;
       g_list_free (symlist);

--- a/libleptonattrib/src/s_attrib.c
+++ b/libleptonattrib/src/s_attrib.c
@@ -106,7 +106,7 @@ char *s_attrib_get_refdes(LeptonObject *object)
     } else {        /* didn't find refdes.  Report error to log. */
       g_debug ("s_attrib_get_refdes: "
                "Found non-graphical component with no refdes: component_basename = %s\n",
-               object->component_basename);
+               lepton_component_object_get_basename (object));
       return NULL;
     }
   }

--- a/libleptonattrib/src/s_attrib.c
+++ b/libleptonattrib/src/s_attrib.c
@@ -105,7 +105,7 @@ char *s_attrib_get_refdes(LeptonObject *object)
                temp_uref);
     } else {        /* didn't find refdes.  Report error to log. */
       g_debug ("s_attrib_get_refdes: "
-               "Found non-graphical component with no refdes: component_basename = %s\n",
+               "Found non-graphical component with no refdes: component basename = %s\n",
                lepton_component_object_get_basename (object));
       return NULL;
     }

--- a/libleptonattrib/src/s_object.c
+++ b/libleptonattrib/src/s_object.c
@@ -406,7 +406,7 @@ int s_object_has_sym_file(LeptonObject *object)
 {
   char *filename;
 
-  filename = object->component_basename;
+  filename = lepton_component_object_get_basename (object);
   if (filename != NULL) {
     g_debug ("s_object_has_sym_file: Object has sym file = %s.\n", filename);
     return 0;

--- a/libleptonattrib/src/s_object.c
+++ b/libleptonattrib/src/s_object.c
@@ -322,14 +322,14 @@ s_object_attrib_add_attrib_in_object (LeptonToplevel *toplevel,
   /* get coordinates of where to place the text object */
   switch (lepton_object_get_type (o_current)) {
   case (OBJ_COMPONENT):
-    world_x = o_current->component->x;
-    world_y = o_current->component->y;
+    world_x = lepton_component_object_get_x (o_current);
+    world_y = lepton_component_object_get_y (o_current);
     color = ATTRIBUTE_COLOR;
     break;
 
   case (OBJ_NET):
-    world_x = o_current->component->x;
-    world_y = o_current->component->y;
+    world_x = lepton_component_object_get_x (o_current);
+    world_y = lepton_component_object_get_y (o_current);
     color = ATTRIBUTE_COLOR;
     break;
 

--- a/libleptonattrib/src/s_sheet_data.c
+++ b/libleptonattrib/src/s_sheet_data.c
@@ -150,8 +150,8 @@ void s_sheet_data_add_master_comp_list_items (const GList *obj_list) {
     {
 
         g_debug ("s_sheet_data_add_master_comp_list_items: "
-                 "Found component on page: component_basename = %s\n",
-                 o_current->component_basename);
+                 "Found component on page: component basename = %s\n",
+                 lepton_component_object_get_basename (o_current));
         verbose_print(" C");
 
         temp_uref = s_attrib_get_refdes(o_current);
@@ -349,8 +349,8 @@ void s_sheet_data_add_master_pin_list_items (const GList *obj_list) {
 
       } else {          /* didn't find refdes.  Report error to log. */
         g_debug ("s_sheet_data_add_master_pin_list_items: "
-                 "Found component with no refdes: component_basename = %s\n",
-                 o_current->component_basename);
+                 "Found component with no refdes: component basename = %s\n",
+                 lepton_component_object_get_basename (o_current));
       }
       g_free (temp_uref);
 

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -2230,9 +2230,10 @@ i_callback_hierarchy_down_symbol (GtkWidget *widget, gpointer data)
   if (!lepton_object_is_component (object))
     return;
 
-  g_message (_("Searching for symbol [%1$s]"), object->component_basename);
+  gchar *basename = lepton_component_object_get_basename (object);
+  g_message (_("Searching for symbol [%1$s]"), basename);
 
-  const CLibSymbol* sym = s_clib_get_symbol_by_name (object->component_basename);
+  const CLibSymbol* sym = s_clib_get_symbol_by_name (basename);
   if (sym == NULL)
     return;
 

--- a/libleptongui/src/o_attrib.c
+++ b/libleptongui/src/o_attrib.c
@@ -260,8 +260,8 @@ o_attrib_add_attrib (GschemToplevel *w_current,
     /* get coordinates of where to place the text object */
     switch (lepton_object_get_type (o_current)) {
       case(OBJ_COMPONENT):
-        world_x = o_current->component->x;
-        world_y = o_current->component->y;
+        world_x = lepton_component_object_get_x (o_current);
+        world_y = lepton_component_object_get_y (o_current);
         align = LOWER_LEFT;
         angle = 0;
         color = ATTRIBUTE_COLOR;

--- a/libleptongui/src/o_misc.c
+++ b/libleptongui/src/o_misc.c
@@ -486,7 +486,7 @@ o_update_component (GschemToplevel *w_current, LeptonObject *o_current)
                                 default_color_id(),
                                 lepton_component_object_get_x (o_current),
                                 lepton_component_object_get_y (o_current),
-                                o_current->component->angle,
+                                lepton_component_object_get_angle (o_current),
                                 o_current->component->mirror,
                                 clib,
                                 o_current->component_basename,

--- a/libleptongui/src/o_misc.c
+++ b/libleptongui/src/o_misc.c
@@ -484,8 +484,8 @@ o_update_component (GschemToplevel *w_current, LeptonObject *o_current)
   /* Create new object and set embedded */
   o_new = lepton_component_new (toplevel->page_current,
                                 default_color_id(),
-                                o_current->component->x,
-                                o_current->component->y,
+                                lepton_component_object_get_x (o_current),
+                                lepton_component_object_get_y (o_current),
                                 o_current->component->angle,
                                 o_current->component->mirror,
                                 clib,

--- a/libleptongui/src/o_misc.c
+++ b/libleptongui/src/o_misc.c
@@ -464,17 +464,19 @@ o_update_component (GschemToplevel *w_current, LeptonObject *o_current)
   const CLibSymbol *clib;
 
   g_return_val_if_fail (lepton_object_is_component (o_current), NULL);
-  g_return_val_if_fail (o_current->component_basename != NULL, NULL);
+
+  gchar *basename = lepton_component_object_get_basename (o_current);
+  g_return_val_if_fail (basename != NULL, NULL);
 
   page = lepton_object_get_page (o_current);
 
   /* Force symbol data to be reloaded from source */
-  clib = s_clib_get_symbol_by_name (o_current->component_basename);
+  clib = s_clib_get_symbol_by_name (basename);
   s_clib_symbol_invalidate_data (clib);
 
   if (clib == NULL) {
     g_message (_("Could not find symbol [%1$s] in library. Update failed."),
-                   o_current->component_basename);
+               basename);
     return NULL;
   }
 
@@ -489,7 +491,7 @@ o_update_component (GschemToplevel *w_current, LeptonObject *o_current)
                                 lepton_component_object_get_angle (o_current),
                                 lepton_component_object_get_mirror (o_current),
                                 clib,
-                                o_current->component_basename,
+                                basename,
                                 1);
   /* Embed new object if the old one is embedded. */
   if (lepton_component_object_get_embedded (o_current)) {

--- a/libleptongui/src/o_misc.c
+++ b/libleptongui/src/o_misc.c
@@ -487,7 +487,7 @@ o_update_component (GschemToplevel *w_current, LeptonObject *o_current)
                                 lepton_component_object_get_x (o_current),
                                 lepton_component_object_get_y (o_current),
                                 lepton_component_object_get_angle (o_current),
-                                o_current->component->mirror,
+                                lepton_component_object_get_mirror (o_current),
                                 clib,
                                 o_current->component_basename,
                                 1);

--- a/libleptongui/src/o_move.c
+++ b/libleptongui/src/o_move.c
@@ -201,8 +201,8 @@ void o_move_end(GschemToplevel *w_current)
 
         /* TODO: Fix so we can just pass the component to o_move_end_lowlevel,
          * IE.. by falling through the bottom of this case statement. */
-        object->component->x = object->component->x + diff_x;
-        object->component->y = object->component->y + diff_y;
+        lepton_component_object_set_x (object, lepton_component_object_get_x (object) + diff_x);
+        lepton_component_object_set_y (object, lepton_component_object_get_y (object) + diff_y);
 
         primitives = lepton_component_object_get_contents (object);
         o_move_end_lowlevel_glist (w_current,

--- a/libleptongui/src/o_slot.c
+++ b/libleptongui/src/o_slot.c
@@ -118,8 +118,8 @@ void o_slot_end(GschemToplevel *w_current, LeptonObject *object, const char *str
     /* here you need to do the add the slot
        attribute since it doesn't exist */
     new_obj = lepton_text_object_new (ATTRIBUTE_COLOR,
-                                      object->component->x,
-                                      object->component->y,
+                                      lepton_component_object_get_x (object),
+                                      lepton_component_object_get_y (object),
                                       LOWER_LEFT,
                                       0, /* zero is angle */
                                       string,

--- a/libleptongui/src/x_autonumber.c
+++ b/libleptongui/src/x_autonumber.c
@@ -419,7 +419,7 @@ void autonumber_get_used(GschemToplevel *w_current, AUTONUMBER_TEXT *autotext)
               slot = g_new(AUTONUMBER_SLOT,1);
               slot->number = number;
               slot->slotnr = slotnr;
-              slot->symbolname = o_parent->component_basename;
+              slot->symbolname = lepton_component_object_get_basename (o_parent);
 
 
               slot_item = g_list_find_custom(autotext->used_slots,

--- a/libleptongui/src/x_autonumber.c
+++ b/libleptongui/src/x_autonumber.c
@@ -495,7 +495,7 @@ void autonumber_get_new_numbers(AUTONUMBER_TEXT *autotext, LeptonObject *o_curre
   o_parent = lepton_object_get_attached_to (o_current);
   if (autotext->slotting && o_parent != NULL) {
     freeslot = g_new(AUTONUMBER_SLOT,1);
-    freeslot->symbolname = o_parent->component_basename;
+    freeslot->symbolname = lepton_component_object_get_basename (o_parent);
     freeslot->number = 0;
     freeslot->slotnr = 0;
     freeslot_item = g_list_find_custom(autotext->free_slots,

--- a/libleptongui/src/x_autonumber.c
+++ b/libleptongui/src/x_autonumber.c
@@ -545,7 +545,7 @@ void autonumber_get_new_numbers(AUTONUMBER_TEXT *autotext, LeptonObject *o_curre
         *slot = 1;
         for (i=2; i <=numslots; i++) {
           freeslot = g_new(AUTONUMBER_SLOT,1);
-          freeslot->symbolname = o_parent->component_basename;
+          freeslot->symbolname = lepton_component_object_get_basename (o_parent);
           freeslot->number = new_number;
           freeslot->slotnr = i;
           autotext->free_slots = g_list_insert_sorted(autotext->free_slots,

--- a/libleptongui/src/x_multiattrib.c
+++ b/libleptongui/src/x_multiattrib.c
@@ -2859,8 +2859,9 @@ multiattrib_update (Multiattrib *multiattrib)
       multiattrib->num_comp_in_list++;
 
       if (component_title_name == NULL)
-        component_title_name = object->component_basename;
-      else if (strcmp (component_title_name, object->component_basename) != 0)
+        component_title_name = lepton_component_object_get_basename (object);
+      else if (strcmp (component_title_name,
+                       lepton_component_object_get_basename (object)) != 0)
         component_title_name = _("<various>");
     }
 


### PR DESCRIPTION
- Several `LeptonComponent`'s field are no longer used directly as pointers.
- The `component_basename` field of the `LeptonObject` structure has been renamed and moved to `LeptonComponent` where it only really belongs to.