### PR TITLE
Fix two issues with gtk3

### DIFF
--- a/libleptongui/src/x_event.c
+++ b/libleptongui/src/x_event.c
@@ -859,7 +859,7 @@ x_event_get_pointer_position (GschemToplevel *w_current, gboolean snapped, gint 
   GdkSeat *seat = gdk_display_get_default_seat (display);
   GdkDevice *pointer = gdk_seat_get_pointer (seat);
 
-  gdk_device_get_position (pointer, NULL, &sx, &sy);
+  gdk_window_get_device_position (window, pointer, &sx, &sy, NULL);
 #else
   gtk_widget_get_pointer(GTK_WIDGET (page_view), &sx, &sy);
 #endif
@@ -909,7 +909,7 @@ x_event_faked_motion (GschemPageView *view, GdkEventKey *event) {
   GdkSeat *seat = gdk_display_get_default_seat (display);
   GdkDevice *pointer = gdk_seat_get_pointer (seat);
 
-  gdk_device_get_position (pointer, NULL, &x, &y);
+  gdk_window_get_device_position (window, pointer, &x, &y, NULL);
 #else
   gtk_widget_get_pointer (GTK_WIDGET (view), &x, &y);
 #endif

--- a/libleptongui/src/x_event.c
+++ b/libleptongui/src/x_event.c
@@ -855,7 +855,7 @@ x_event_get_pointer_position (GschemToplevel *w_current, gboolean snapped, gint 
   height = gdk_window_get_height (window);
 
 #ifdef ENABLE_GTK3
-  GdkDisplay *display = gdk_display_get_default ();
+  GdkDisplay *display = gdk_window_get_display (window);
   GdkSeat *seat = gdk_display_get_default_seat (display);
   GdkDevice *pointer = gdk_seat_get_pointer (seat);
 
@@ -902,7 +902,10 @@ x_event_faked_motion (GschemPageView *view, GdkEventKey *event) {
   GdkEventMotion *newevent;
 
 #ifdef ENABLE_GTK3
-  GdkDisplay *display = gdk_display_get_default ();
+  GdkWindow *window = gtk_widget_get_window (GTK_WIDGET (view));
+  g_return_val_if_fail (window != NULL, FALSE);
+
+  GdkDisplay *display = gdk_window_get_display (window);
   GdkSeat *seat = gdk_display_get_default_seat (display);
   GdkDevice *pointer = gdk_seat_get_pointer (seat);
 

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -248,6 +248,9 @@ void x_window_setup_draw_events_drawing_area (GschemToplevel* w_current,
                          GDK_EXPOSURE_MASK |
                          GDK_POINTER_MOTION_MASK |
                          GDK_BUTTON_PRESS_MASK   |
+#if GTK_CHECK_VERSION(3,4,0)
+                         GDK_SMOOTH_SCROLL_MASK |
+#endif
                          GDK_ENTER_NOTIFY_MASK |
                          GDK_KEY_PRESS_MASK |
                          GDK_BUTTON_RELEASE_MASK


### PR DESCRIPTION
- Add initial support for *smooth* scrolling and fix a warning about it.
- Fix issue with jumping of objects on zooming reported by @graahnul-grom in #840.