### PR TITLE
Rename s_page_*() functions

### DIFF
--- a/liblepton/include/liblepton/page.h
+++ b/liblepton/include/liblepton/page.h
@@ -100,9 +100,6 @@ void
 lepton_page_remove_weak_ptr (LeptonPage *page,
                              void *weak_pointer_loc);
 LeptonPage*
-s_page_search (LeptonToplevel *toplevel,
-               const gchar *filename);
-LeptonPage*
 s_page_search_by_basename (LeptonToplevel *toplevel,
                            const gchar *filename);
 LeptonPage*

--- a/liblepton/include/liblepton/page.h
+++ b/liblepton/include/liblepton/page.h
@@ -97,8 +97,8 @@ void
 lepton_page_add_weak_ptr (LeptonPage *page,
                           void *weak_pointer_loc);
 void
-s_page_remove_weak_ptr (LeptonPage *page,
-                        void *weak_pointer_loc);
+lepton_page_remove_weak_ptr (LeptonPage *page,
+                             void *weak_pointer_loc);
 void
 s_page_goto (LeptonToplevel *toplevel,
              LeptonPage *p_new);

--- a/liblepton/include/liblepton/page.h
+++ b/liblepton/include/liblepton/page.h
@@ -99,10 +99,6 @@ lepton_page_add_weak_ptr (LeptonPage *page,
 void
 lepton_page_remove_weak_ptr (LeptonPage *page,
                              void *weak_pointer_loc);
-LeptonPage*
-s_page_search_by_page_id (LeptonPageList *list,
-                          int pid);
-
 void
 s_page_print_all (LeptonToplevel *toplevel);
 

--- a/liblepton/include/liblepton/page.h
+++ b/liblepton/include/liblepton/page.h
@@ -34,7 +34,7 @@ struct st_page
   GList *connectible_list;  /* connectible page objects */
 
   /* The page filename. You must access this field only via the
-   * accessor functions s_page_set_filename() and
+   * accessor functions lepton_page_set_filename() and
    * lepton_page_get_filename() */
   char *_filename;
 
@@ -159,8 +159,8 @@ const gchar*
 lepton_page_get_filename (const LeptonPage *page);
 
 void
-s_page_set_filename (LeptonPage *page,
-                     const char *filename);
+lepton_page_set_filename (LeptonPage *page,
+                          const char *filename);
 GList*
 lepton_page_list_get_glist (LeptonPageList *page_list);
 

--- a/liblepton/include/liblepton/page.h
+++ b/liblepton/include/liblepton/page.h
@@ -86,9 +86,6 @@ void
 lepton_page_delete (LeptonToplevel *toplevel,
                     LeptonPage *page);
 void
-s_page_delete_list(LeptonToplevel *toplevel);
-
-void
 s_page_weak_ref (LeptonPage *page,
                  void (*notify_func)(void *, void *),
                  void *user_data);

--- a/liblepton/include/liblepton/page.h
+++ b/liblepton/include/liblepton/page.h
@@ -102,9 +102,6 @@ lepton_page_remove_weak_ptr (LeptonPage *page,
 void
 s_page_print_all (LeptonToplevel *toplevel);
 
-gboolean
-s_page_check_changed (LeptonPageList *list);
-
 void
 s_page_autosave_init (LeptonToplevel *toplevel);
 

--- a/liblepton/include/liblepton/page.h
+++ b/liblepton/include/liblepton/page.h
@@ -118,8 +118,8 @@ void
 lepton_page_append_list (LeptonPage *page,
                          GList *obj_list);
 void
-s_page_remove (LeptonPage *page,
-               LeptonObject *object);
+lepton_page_remove (LeptonPage *page,
+                    LeptonObject *object);
 void
 s_page_replace (LeptonPage *page,
                 LeptonObject *object1,

--- a/liblepton/include/liblepton/page.h
+++ b/liblepton/include/liblepton/page.h
@@ -106,9 +106,6 @@ gboolean
 s_page_check_changed (LeptonPageList *list);
 
 void
-s_page_clear_changed (LeptonPageList *list);
-
-void
 s_page_autosave_init (LeptonToplevel *toplevel);
 
 gint

--- a/liblepton/include/liblepton/page.h
+++ b/liblepton/include/liblepton/page.h
@@ -112,8 +112,8 @@ gint
 s_page_autosave (LeptonToplevel *toplevel);
 
 void
-s_page_append (LeptonPage *page,
-               LeptonObject *object);
+lepton_page_append (LeptonPage *page,
+                    LeptonObject *object);
 void
 s_page_append_list (LeptonPage *page,
                     GList *obj_list);

--- a/liblepton/include/liblepton/page.h
+++ b/liblepton/include/liblepton/page.h
@@ -131,11 +131,11 @@ const GList*
 s_page_objects (LeptonPage *page);
 
 GList*
-s_page_objects_in_regions (LeptonToplevel *toplevel,
-                           LeptonPage *page,
-                           LeptonBox *rects,
-                           int n_rects,
-                           gboolean include_hidden);
+lepton_page_objects_in_regions (LeptonToplevel *toplevel,
+                                LeptonPage *page,
+                                LeptonBox *rects,
+                                int n_rects,
+                                gboolean include_hidden);
 const gchar*
 lepton_page_get_filename (const LeptonPage *page);
 

--- a/liblepton/include/liblepton/page.h
+++ b/liblepton/include/liblepton/page.h
@@ -100,12 +100,6 @@ void
 lepton_page_remove_weak_ptr (LeptonPage *page,
                              void *weak_pointer_loc);
 void
-s_page_autosave_init (LeptonToplevel *toplevel);
-
-gint
-s_page_autosave (LeptonToplevel *toplevel);
-
-void
 lepton_page_append (LeptonPage *page,
                     LeptonObject *object);
 void

--- a/liblepton/include/liblepton/page.h
+++ b/liblepton/include/liblepton/page.h
@@ -100,9 +100,6 @@ void
 lepton_page_remove_weak_ptr (LeptonPage *page,
                              void *weak_pointer_loc);
 void
-s_page_print_all (LeptonToplevel *toplevel);
-
-void
 s_page_autosave_init (LeptonToplevel *toplevel);
 
 gint

--- a/liblepton/include/liblepton/page.h
+++ b/liblepton/include/liblepton/page.h
@@ -94,8 +94,8 @@ lepton_page_weak_unref (LeptonPage *page,
                         void (*notify_func)(void *, void *),
                         void *user_data);
 void
-s_page_add_weak_ptr (LeptonPage *page,
-                     void *weak_pointer_loc);
+lepton_page_add_weak_ptr (LeptonPage *page,
+                          void *weak_pointer_loc);
 void
 s_page_remove_weak_ptr (LeptonPage *page,
                         void *weak_pointer_loc);

--- a/liblepton/include/liblepton/page.h
+++ b/liblepton/include/liblepton/page.h
@@ -100,9 +100,6 @@ void
 lepton_page_remove_weak_ptr (LeptonPage *page,
                              void *weak_pointer_loc);
 LeptonPage*
-s_page_search_by_basename (LeptonToplevel *toplevel,
-                           const gchar *filename);
-LeptonPage*
 s_page_search_by_page_id (LeptonPageList *list,
                           int pid);
 

--- a/liblepton/include/liblepton/page.h
+++ b/liblepton/include/liblepton/page.h
@@ -115,8 +115,8 @@ void
 lepton_page_append (LeptonPage *page,
                     LeptonObject *object);
 void
-s_page_append_list (LeptonPage *page,
-                    GList *obj_list);
+lepton_page_append_list (LeptonPage *page,
+                         GList *obj_list);
 void
 s_page_remove (LeptonPage *page,
                LeptonObject *object);

--- a/liblepton/include/liblepton/page.h
+++ b/liblepton/include/liblepton/page.h
@@ -125,7 +125,7 @@ lepton_page_replace (LeptonPage *page,
                      LeptonObject *object1,
                      LeptonObject *object2);
 void
-s_page_delete_objects (LeptonPage *page);
+lepton_page_delete_objects (LeptonPage *page);
 
 const GList*
 s_page_objects (LeptonPage *page);

--- a/liblepton/include/liblepton/page.h
+++ b/liblepton/include/liblepton/page.h
@@ -121,9 +121,9 @@ void
 lepton_page_remove (LeptonPage *page,
                     LeptonObject *object);
 void
-s_page_replace (LeptonPage *page,
-                LeptonObject *object1,
-                LeptonObject *object2);
+lepton_page_replace (LeptonPage *page,
+                     LeptonObject *object1,
+                     LeptonObject *object2);
 void
 s_page_delete_objects (LeptonPage *page);
 

--- a/liblepton/include/liblepton/page.h
+++ b/liblepton/include/liblepton/page.h
@@ -80,8 +80,8 @@ void
 lepton_page_set_selection_list (LeptonPage *page,
                                 LeptonSelection *selection_list);
 LeptonPage*
-s_page_new (LeptonToplevel *toplevel,
-            const gchar *filename);
+lepton_page_new (LeptonToplevel *toplevel,
+                 const gchar *filename);
 void
 s_page_delete (LeptonToplevel *toplevel,
                LeptonPage *page);

--- a/liblepton/include/liblepton/page.h
+++ b/liblepton/include/liblepton/page.h
@@ -128,7 +128,7 @@ void
 lepton_page_delete_objects (LeptonPage *page);
 
 const GList*
-s_page_objects (LeptonPage *page);
+lepton_page_objects (LeptonPage *page);
 
 GList*
 lepton_page_objects_in_regions (LeptonToplevel *toplevel,

--- a/liblepton/include/liblepton/page.h
+++ b/liblepton/include/liblepton/page.h
@@ -83,8 +83,8 @@ LeptonPage*
 lepton_page_new (LeptonToplevel *toplevel,
                  const gchar *filename);
 void
-s_page_delete (LeptonToplevel *toplevel,
-               LeptonPage *page);
+lepton_page_delete (LeptonToplevel *toplevel,
+                    LeptonPage *page);
 void
 s_page_delete_list(LeptonToplevel *toplevel);
 

--- a/liblepton/include/liblepton/page.h
+++ b/liblepton/include/liblepton/page.h
@@ -99,9 +99,6 @@ lepton_page_add_weak_ptr (LeptonPage *page,
 void
 lepton_page_remove_weak_ptr (LeptonPage *page,
                              void *weak_pointer_loc);
-void
-s_page_goto (LeptonToplevel *toplevel,
-             LeptonPage *p_new);
 LeptonPage*
 s_page_search (LeptonToplevel *toplevel,
                const gchar *filename);

--- a/liblepton/include/liblepton/page.h
+++ b/liblepton/include/liblepton/page.h
@@ -86,9 +86,9 @@ void
 lepton_page_delete (LeptonToplevel *toplevel,
                     LeptonPage *page);
 void
-s_page_weak_ref (LeptonPage *page,
-                 void (*notify_func)(void *, void *),
-                 void *user_data);
+lepton_page_weak_ref (LeptonPage *page,
+                      void (*notify_func)(void *, void *),
+                      void *user_data);
 void
 s_page_weak_unref (LeptonPage *page,
                    void (*notify_func)(void *, void *),

--- a/liblepton/include/liblepton/page.h
+++ b/liblepton/include/liblepton/page.h
@@ -35,7 +35,7 @@ struct st_page
 
   /* The page filename. You must access this field only via the
    * accessor functions s_page_set_filename() and
-   * s_page_get_filename() */
+   * lepton_page_get_filename() */
   char *_filename;
 
   int CHANGED;                  /* changed flag */
@@ -156,7 +156,7 @@ s_page_objects_in_regions (LeptonToplevel *toplevel,
                            int n_rects,
                            gboolean include_hidden);
 const gchar*
-s_page_get_filename (const LeptonPage *page);
+lepton_page_get_filename (const LeptonPage *page);
 
 void
 s_page_set_filename (LeptonPage *page,

--- a/liblepton/include/liblepton/page.h
+++ b/liblepton/include/liblepton/page.h
@@ -90,9 +90,9 @@ lepton_page_weak_ref (LeptonPage *page,
                       void (*notify_func)(void *, void *),
                       void *user_data);
 void
-s_page_weak_unref (LeptonPage *page,
-                   void (*notify_func)(void *, void *),
-                   void *user_data);
+lepton_page_weak_unref (LeptonPage *page,
+                        void (*notify_func)(void *, void *),
+                        void *user_data);
 void
 s_page_add_weak_ptr (LeptonPage *page,
                      void *weak_pointer_loc);

--- a/liblepton/include/liblepton/toplevel.h
+++ b/liblepton/include/liblepton/toplevel.h
@@ -77,4 +77,7 @@ s_toplevel_weak_unref (LeptonToplevel *toplevel,
 void
 lepton_toplevel_goto_page (LeptonToplevel *toplevel,
                            LeptonPage *p_new);
+LeptonPage*
+lepton_toplevel_search_page (LeptonToplevel *toplevel,
+                             const gchar *filename);
 G_END_DECLS

--- a/liblepton/include/liblepton/toplevel.h
+++ b/liblepton/include/liblepton/toplevel.h
@@ -74,5 +74,7 @@ void
 s_toplevel_weak_unref (LeptonToplevel *toplevel,
                        void (*notify_func)(void *, void *),
                        void *user_data);
-
+void
+lepton_toplevel_goto_page (LeptonToplevel *toplevel,
+                           LeptonPage *p_new);
 G_END_DECLS

--- a/liblepton/include/liblepton/toplevel.h
+++ b/liblepton/include/liblepton/toplevel.h
@@ -80,4 +80,7 @@ lepton_toplevel_goto_page (LeptonToplevel *toplevel,
 LeptonPage*
 lepton_toplevel_search_page (LeptonToplevel *toplevel,
                              const gchar *filename);
+LeptonPage*
+lepton_toplevel_search_page_by_basename (LeptonToplevel *toplevel,
+                                         const gchar *filename);
 G_END_DECLS

--- a/liblepton/include/liblepton/toplevel.h
+++ b/liblepton/include/liblepton/toplevel.h
@@ -86,4 +86,7 @@ lepton_toplevel_search_page_by_basename (LeptonToplevel *toplevel,
 LeptonPage*
 lepton_toplevel_search_page_by_id (LeptonPageList *list,
                                    int pid);
+void
+lepton_toplevel_print_all (LeptonToplevel *toplevel);
+
 G_END_DECLS

--- a/liblepton/include/liblepton/toplevel.h
+++ b/liblepton/include/liblepton/toplevel.h
@@ -83,4 +83,7 @@ lepton_toplevel_search_page (LeptonToplevel *toplevel,
 LeptonPage*
 lepton_toplevel_search_page_by_basename (LeptonToplevel *toplevel,
                                          const gchar *filename);
+LeptonPage*
+lepton_toplevel_search_page_by_id (LeptonPageList *list,
+                                   int pid);
 G_END_DECLS

--- a/liblepton/include/liblepton/toplevel.h
+++ b/liblepton/include/liblepton/toplevel.h
@@ -92,7 +92,4 @@ lepton_toplevel_print_all (LeptonToplevel *toplevel);
 void
 lepton_toplevel_init_autosave (LeptonToplevel *toplevel);
 
-gint
-lepton_toplevel_autosave (LeptonToplevel *toplevel);
-
 G_END_DECLS

--- a/liblepton/include/liblepton/toplevel.h
+++ b/liblepton/include/liblepton/toplevel.h
@@ -89,4 +89,10 @@ lepton_toplevel_search_page_by_id (LeptonPageList *list,
 void
 lepton_toplevel_print_all (LeptonToplevel *toplevel);
 
+void
+lepton_toplevel_init_autosave (LeptonToplevel *toplevel);
+
+gint
+lepton_toplevel_autosave (LeptonToplevel *toplevel);
+
 G_END_DECLS

--- a/liblepton/scheme/lepton/ffi.scm.in
+++ b/liblepton/scheme/lepton/ffi.scm.in
@@ -286,7 +286,7 @@
             lepton_page_get_changed
             lepton_page_set_changed
             lepton_page_get_selection_list
-            s_page_append
+            lepton_page_append
             s_page_append_list
             lepton_page_delete
             lepton_page_get_filename
@@ -615,7 +615,7 @@
 (define-lff lepton_page_get_changed int '(*))
 (define-lff lepton_page_set_changed void (list '* int))
 (define-lff lepton_page_get_selection_list '* '(*))
-(define-lff s_page_append void '(* *))
+(define-lff lepton_page_append void '(* *))
 (define-lff s_page_append_list void '(* *))
 (define-lff lepton_page_delete void '(* *))
 (define-lff lepton_page_get_filename '* '(*))

--- a/liblepton/scheme/lepton/ffi.scm.in
+++ b/liblepton/scheme/lepton/ffi.scm.in
@@ -291,7 +291,7 @@
             s_page_delete
             lepton_page_get_filename
             lepton_page_set_filename
-            s_page_new
+            lepton_page_new
             s_page_objects
             s_page_remove
             lepton_page_list_get_glist
@@ -620,7 +620,7 @@
 (define-lff s_page_delete void '(* *))
 (define-lff lepton_page_get_filename '* '(*))
 (define-lff lepton_page_set_filename void '(* *))
-(define-lff s_page_new '* '(* *))
+(define-lff lepton_page_new '* '(* *))
 (define-lff s_page_objects '* '(*))
 (define-lff s_page_remove void '(* *))
 (define-lff lepton_page_list_get_glist '* '(*))

--- a/liblepton/scheme/lepton/ffi.scm.in
+++ b/liblepton/scheme/lepton/ffi.scm.in
@@ -288,7 +288,7 @@
             lepton_page_get_selection_list
             s_page_append
             s_page_append_list
-            s_page_delete
+            lepton_page_delete
             lepton_page_get_filename
             lepton_page_set_filename
             lepton_page_new
@@ -617,7 +617,7 @@
 (define-lff lepton_page_get_selection_list '* '(*))
 (define-lff s_page_append void '(* *))
 (define-lff s_page_append_list void '(* *))
-(define-lff s_page_delete void '(* *))
+(define-lff lepton_page_delete void '(* *))
 (define-lff lepton_page_get_filename '* '(*))
 (define-lff lepton_page_set_filename void '(* *))
 (define-lff lepton_page_new '* '(* *))

--- a/liblepton/scheme/lepton/ffi.scm.in
+++ b/liblepton/scheme/lepton/ffi.scm.in
@@ -293,7 +293,7 @@
             lepton_page_set_filename
             lepton_page_new
             s_page_objects
-            s_page_remove
+            lepton_page_remove
             lepton_page_list_get_glist
 
             o_selection_remove
@@ -622,7 +622,7 @@
 (define-lff lepton_page_set_filename void '(* *))
 (define-lff lepton_page_new '* '(* *))
 (define-lff s_page_objects '* '(*))
-(define-lff s_page_remove void '(* *))
+(define-lff lepton_page_remove void '(* *))
 (define-lff lepton_page_list_get_glist '* '(*))
 
 ;;; o_selection.c

--- a/liblepton/scheme/lepton/ffi.scm.in
+++ b/liblepton/scheme/lepton/ffi.scm.in
@@ -292,7 +292,7 @@
             lepton_page_get_filename
             lepton_page_set_filename
             lepton_page_new
-            s_page_objects
+            lepton_page_objects
             lepton_page_remove
             lepton_page_list_get_glist
 
@@ -621,7 +621,7 @@
 (define-lff lepton_page_get_filename '* '(*))
 (define-lff lepton_page_set_filename void '(* *))
 (define-lff lepton_page_new '* '(* *))
-(define-lff s_page_objects '* '(*))
+(define-lff lepton_page_objects '* '(*))
 (define-lff lepton_page_remove void '(* *))
 (define-lff lepton_page_list_get_glist '* '(*))
 

--- a/liblepton/scheme/lepton/ffi.scm.in
+++ b/liblepton/scheme/lepton/ffi.scm.in
@@ -287,7 +287,7 @@
             lepton_page_set_changed
             lepton_page_get_selection_list
             lepton_page_append
-            s_page_append_list
+            lepton_page_append_list
             lepton_page_delete
             lepton_page_get_filename
             lepton_page_set_filename
@@ -616,7 +616,7 @@
 (define-lff lepton_page_set_changed void (list '* int))
 (define-lff lepton_page_get_selection_list '* '(*))
 (define-lff lepton_page_append void '(* *))
-(define-lff s_page_append_list void '(* *))
+(define-lff lepton_page_append_list void '(* *))
 (define-lff lepton_page_delete void '(* *))
 (define-lff lepton_page_get_filename '* '(*))
 (define-lff lepton_page_set_filename void '(* *))

--- a/liblepton/scheme/lepton/ffi.scm.in
+++ b/liblepton/scheme/lepton/ffi.scm.in
@@ -290,7 +290,7 @@
             s_page_append_list
             s_page_delete
             lepton_page_get_filename
-            s_page_set_filename
+            lepton_page_set_filename
             s_page_new
             s_page_objects
             s_page_remove
@@ -619,7 +619,7 @@
 (define-lff s_page_append_list void '(* *))
 (define-lff s_page_delete void '(* *))
 (define-lff lepton_page_get_filename '* '(*))
-(define-lff s_page_set_filename void '(* *))
+(define-lff lepton_page_set_filename void '(* *))
 (define-lff s_page_new '* '(* *))
 (define-lff s_page_objects '* '(*))
 (define-lff s_page_remove void '(* *))

--- a/liblepton/scheme/lepton/ffi.scm.in
+++ b/liblepton/scheme/lepton/ffi.scm.in
@@ -289,7 +289,7 @@
             s_page_append
             s_page_append_list
             s_page_delete
-            s_page_get_filename
+            lepton_page_get_filename
             s_page_set_filename
             s_page_new
             s_page_objects
@@ -618,7 +618,7 @@
 (define-lff s_page_append void '(* *))
 (define-lff s_page_append_list void '(* *))
 (define-lff s_page_delete void '(* *))
-(define-lff s_page_get_filename '* '(*))
+(define-lff lepton_page_get_filename '* '(*))
 (define-lff s_page_set_filename void '(* *))
 (define-lff s_page_new '* '(* *))
 (define-lff s_page_objects '* '(*))

--- a/liblepton/scheme/lepton/page.scm
+++ b/liblepton/scheme/lepton/page.scm
@@ -97,7 +97,7 @@ PAGE after calling this function will cause an error."
   "Returns the filename associated with PAGE as a string."
   (define pointer (geda-page->pointer* page 1))
 
-  (pointer->string (s_page_get_filename pointer)))
+  (pointer->string (lepton_page_get_filename pointer)))
 
 
 (define (set-page-filename! page filename)
@@ -180,7 +180,7 @@ syntax."
                                  %null-pointer
                                  (string->pointer str)
                                  (string-length str)
-                                 (s_page_get_filename pointer)
+                                 (lepton_page_get_filename pointer)
                                  *error)))
     (gerror-error *error)
 

--- a/liblepton/scheme/lepton/page.scm
+++ b/liblepton/scheme/lepton/page.scm
@@ -105,7 +105,7 @@ PAGE after calling this function will cause an error."
   (define pointer (geda-page->pointer* page 1))
   (check-string filename 2)
 
-  (s_page_set_filename pointer (string->pointer filename))
+  (lepton_page_set_filename pointer (string->pointer filename))
   page)
 
 

--- a/liblepton/scheme/lepton/page.scm
+++ b/liblepton/scheme/lepton/page.scm
@@ -80,8 +80,8 @@ belong to a page, returns #f."
 that this does not check that a file exists with that name, or
 attempt to load any data from it."
   (check-string filename 1)
-  (pointer->geda-page (s_page_new (edascm_c_current_toplevel)
-                                  (string->pointer filename))))
+  (pointer->geda-page (lepton_page_new (edascm_c_current_toplevel)
+                                       (string->pointer filename))))
 
 
 (define (close-page! page)
@@ -174,8 +174,8 @@ syntax."
   (check-string str 2)
 
   (let* ((*error (bytevector->pointer (make-bytevector (sizeof '*) 0)))
-         (pointer (s_page_new (edascm_c_current_toplevel)
-                              (string->pointer filename)))
+         (pointer (lepton_page_new (edascm_c_current_toplevel)
+                                   (string->pointer filename)))
          (objects (o_read_buffer pointer
                                  %null-pointer
                                  (string->pointer str)

--- a/liblepton/scheme/lepton/page.scm
+++ b/liblepton/scheme/lepton/page.scm
@@ -212,7 +212,7 @@ syntax."
 
         (begin
           (lepton_object_emit_pre_change_notify object-pointer)
-          (s_page_append page-pointer object-pointer)
+          (lepton_page_append page-pointer object-pointer)
           (lepton_object_emit_change_notify object-pointer)
           (lepton_page_set_changed page-pointer 1)
 

--- a/liblepton/scheme/lepton/page.scm
+++ b/liblepton/scheme/lepton/page.scm
@@ -268,7 +268,7 @@ PAGE are ignored.  Returns PAGE."
 
         (begin
           (lepton_object_emit_pre_change_notify object-pointer)
-          (s_page_remove page-pointer object-pointer)
+          (lepton_page_remove page-pointer object-pointer)
           (lepton_page_set_changed page-pointer 1)
           ;; If the object is currently selected unselect it.
           (o_selection_remove (lepton_page_get_selection_list page-pointer)

--- a/liblepton/scheme/lepton/page.scm
+++ b/liblepton/scheme/lepton/page.scm
@@ -89,8 +89,8 @@ attempt to load any data from it."
 PAGE after calling this function will cause an error."
   (define pointer (geda-page->pointer* page 1))
 
-  (s_page_delete (edascm_c_current_toplevel)
-                 pointer))
+  (lepton_page_delete (edascm_c_current_toplevel)
+                      pointer))
 
 
 (define (page-filename page)

--- a/liblepton/scheme/lepton/page.scm
+++ b/liblepton/scheme/lepton/page.scm
@@ -184,7 +184,7 @@ syntax."
                                  *error)))
     (gerror-error *error)
 
-    (s_page_append_list pointer objects)
+    (lepton_page_append_list pointer objects)
 
     (pointer->geda-page pointer)))
 

--- a/liblepton/scheme/lepton/page.scm
+++ b/liblepton/scheme/lepton/page.scm
@@ -113,7 +113,7 @@ PAGE after calling this function will cause an error."
   "Returns the contents of PAGE as a list of objects."
   (define pointer (geda-page->pointer* page 1))
 
-  (glist->object-list (s_page_objects pointer)))
+  (glist->object-list (lepton_page_objects pointer)))
 
 
 (define (page-dirty? page)
@@ -138,7 +138,7 @@ Otherwise, flags PAGE as having been modified.  Returns PAGE."
   "Returns a string representation of the contents of PAGE."
   (define pointer (geda-page->pointer* page 1))
   (pointer->string
-   (lepton_object_list_to_buffer (s_page_objects pointer))))
+   (lepton_object_list_to_buffer (lepton_page_objects pointer))))
 
 
 (define (string->page filename str)

--- a/liblepton/src/a_basic.c
+++ b/liblepton/src/a_basic.c
@@ -405,7 +405,7 @@ o_read (LeptonPage *page,
   objects = o_read_buffer (page, NULL, buffer, size, filename, err);
   g_free (buffer);
 
-  s_page_append_list (page, objects);
+  lepton_page_append_list (page, objects);
 
   return page;
 }

--- a/liblepton/src/f_basic.c
+++ b/liblepton/src/f_basic.c
@@ -248,7 +248,7 @@ f_open_flags (LeptonToplevel *toplevel,
   }
 
   /* write full, absolute filename into page->page_filename */
-  s_page_set_filename (page, full_filename);
+  lepton_page_set_filename (page, full_filename);
 
   /* Before we open the page, let's load the corresponding gafrc. */
   /* First cd into file's directory. */

--- a/liblepton/src/f_basic.c
+++ b/liblepton/src/f_basic.c
@@ -467,8 +467,8 @@ f_save (LeptonPage *page,
   g_free (dirname);
   g_free (only_filename);
 
-  if (o_save (s_page_objects (page), real_filename, &tmp_err)) {
-
+  if (o_save (lepton_page_objects (page), real_filename, &tmp_err))
+  {
     page->saved_since_first_loaded = 1;
 
     /* Reset the last saved timer */

--- a/liblepton/src/net_object.c
+++ b/liblepton/src/net_object.c
@@ -710,7 +710,7 @@ lepton_net_object_consolidate (LeptonPage *page)
   if (!net_consolidate)
     return;
 
-  iter = s_page_objects (page);
+  iter = lepton_page_objects (page);
 
   while (iter != NULL) {
     o_current = (LeptonObject *)iter->data;
@@ -721,7 +721,7 @@ lepton_net_object_consolidate (LeptonPage *page)
     }
 
     if (status == -1) {
-      iter = s_page_objects (page);
+      iter = lepton_page_objects (page);
       status = 0;
     } else {
       iter = g_list_next (iter);

--- a/liblepton/src/object.c
+++ b/liblepton/src/object.c
@@ -930,7 +930,7 @@ lepton_object_delete (LeptonObject *o_current)
   if (o_current != NULL) {
     /* If currently attached to a page, remove it from the page */
     if (o_current->page != NULL) {
-      s_page_remove (o_current->page, o_current);
+      lepton_page_remove (o_current->page, o_current);
     }
 
     s_conn_remove_object_connections (o_current);

--- a/liblepton/src/object.c
+++ b/liblepton/src/object.c
@@ -1568,8 +1568,6 @@ lepton_object_set_color (LeptonObject *object,
  * \param [in] object The LeptonObject for which to retrieve the
  *                    parent LeptonPage.
  * \return The LeptonPage which owns \a object or NULL.
- *
- * \sa s_page_append_object() s_page_append() s_page_remove()
  */
 LeptonPage *
 lepton_object_get_page (LeptonObject *object)

--- a/liblepton/src/page.c
+++ b/liblepton/src/page.c
@@ -249,7 +249,7 @@ lepton_page_delete (LeptonToplevel *toplevel,
     tmp = NULL;
   } else {
     tmp = toplevel->page_current;
-    s_page_goto (toplevel, page);
+    lepton_toplevel_goto_page (toplevel, page);
   }
 
   /* Get the real filename and file permissions */
@@ -320,7 +320,7 @@ lepton_page_delete (LeptonToplevel *toplevel,
 
   /* restore page_current */
   if (tmp != NULL) {
-    s_page_goto (toplevel, tmp);
+    lepton_toplevel_goto_page (toplevel, tmp);
   } else {
     /* page was page_current */
     lepton_toplevel_set_page_current (toplevel, NULL);
@@ -409,32 +409,6 @@ lepton_page_remove_weak_ptr (LeptonPage *page,
                                           (void**) weak_pointer_loc);
 }
 
-/*! \brief changes the current page in toplevel
- *  \par Function Description
- *  Changes the current page in \a toplevel to the page \a p_new.
- *
- *  \param toplevel  The LeptonToplevel object
- *  \param p_new     The LeptonPage to go to
- */
-void
-s_page_goto (LeptonToplevel *toplevel,
-             LeptonPage *p_new)
-{
-  gchar *dirname;
-
-  lepton_toplevel_set_page_current (toplevel, p_new);
-
-  dirname = g_path_get_dirname (lepton_page_get_filename (p_new));
-  if (chdir (dirname)) {
-    /* An error occured with chdir */
-    /* FIXME[2017-02-21] Libraries should not be changing the
-     * current working directory.  If it is not possible to avoid a
-     * chdir() call, then the error needs to be handled and/or
-     * reported. */
-  }
-  g_free (dirname);
-
-}
 
 /*! \brief Search for pages by filename.
  *  \par Function Description

--- a/liblepton/src/page.c
+++ b/liblepton/src/page.c
@@ -281,7 +281,7 @@ lepton_page_delete (LeptonToplevel *toplevel,
   g_object_unref( page->selection_list );
 
   /* then delete objects of page */
-  s_page_delete_objects (page);
+  lepton_page_delete_objects (page);
 
   /* Free the objects in the place list. */
   lepton_object_list_delete (page->place_list);
@@ -613,7 +613,7 @@ lepton_page_replace (LeptonPage *page,
  *  \param [in] page      The LeptonPage being cleared.
  */
 void
-s_page_delete_objects (LeptonPage *page)
+lepton_page_delete_objects (LeptonPage *page)
 {
   GList *objects = page->_object_list;
   GList *iter;

--- a/liblepton/src/page.c
+++ b/liblepton/src/page.c
@@ -377,7 +377,7 @@ lepton_page_weak_unref (LeptonPage *page,
  * value of \a weak_pointer_loc will be set to NULL when \a page is
  * destroyed.
  *
- * \sa s_page_remove_weak_ptr
+ * \sa lepton_page_remove_weak_ptr
  *
  * \param [in,out] page          Page to weak-reference.
  * \param [in] weak_pointer_loc  Memory address of a pointer.
@@ -401,8 +401,8 @@ lepton_page_add_weak_ptr (LeptonPage *page,
  * \param [in] weak_pointer_loc  Memory address of a pointer.
  */
 void
-s_page_remove_weak_ptr (LeptonPage *page,
-                        void *weak_pointer_loc)
+lepton_page_remove_weak_ptr (LeptonPage *page,
+                             void *weak_pointer_loc)
 {
   g_return_if_fail (page != NULL);
   page->weak_refs = s_weakref_remove_ptr (page->weak_refs,

--- a/liblepton/src/page.c
+++ b/liblepton/src/page.c
@@ -255,12 +255,12 @@ s_page_delete (LeptonToplevel *toplevel,
   }
 
   /* Get the real filename and file permissions */
-  real_filename = follow_symlinks (s_page_get_filename(page), NULL);
+  real_filename = follow_symlinks (lepton_page_get_filename(page), NULL);
 
   if (real_filename == NULL) {
     g_message ("s_page_delete:");
     g_message (_("Can't get the real filename of %1$s."),
-               s_page_get_filename (page));
+               lepton_page_get_filename (page));
   }
   else {
     backup_filename = f_get_autosave_filename (real_filename);
@@ -454,7 +454,7 @@ s_page_goto (LeptonToplevel *toplevel,
 
   lepton_toplevel_set_page_current (toplevel, p_new);
 
-  dirname = g_path_get_dirname (s_page_get_filename(p_new));
+  dirname = g_path_get_dirname (lepton_page_get_filename (p_new));
   if (chdir (dirname)) {
     /* An error occured with chdir */
     /* FIXME[2017-02-21] Libraries should not be changing the
@@ -490,7 +490,7 @@ s_page_search (LeptonToplevel *toplevel,
     page = (LeptonPage *)iter->data;
     /* FIXME this may not be correct on platforms with
      * case-insensitive filesystems. */
-    if ( strcmp( s_page_get_filename (page), filename ) == 0 )
+    if (strcmp (lepton_page_get_filename (page), filename) == 0)
       return page;
   }
   return NULL;
@@ -520,7 +520,7 @@ s_page_search_by_basename (LeptonToplevel *toplevel,
   {
     page = (LeptonPage*) iter->data;
 
-    const gchar* fname = s_page_get_filename (page);
+    const gchar* fname = lepton_page_get_filename (page);
     gchar* bname = g_path_get_basename (fname);
 
     /* FIXME this may not be correct on platforms with
@@ -585,7 +585,7 @@ s_page_print_all (LeptonToplevel *toplevel)
         iter = g_list_next( iter ) ) {
 
     page = (LeptonPage *) iter->data;
-    printf ("FILENAME: %1$s\n", s_page_get_filename (page));
+    printf ("FILENAME: %1$s\n", lepton_page_get_filename (page));
     lepton_object_list_print (page->_object_list);
   }
 }
@@ -880,7 +880,7 @@ s_page_objects_in_regions (LeptonToplevel *toplevel,
  * \return the full path to the underlying file of the \a page
  */
 const gchar *
-s_page_get_filename (const LeptonPage *page)
+lepton_page_get_filename (const LeptonPage *page)
 {
   g_return_val_if_fail (page, "");
   g_return_val_if_fail (page->_filename, "");

--- a/liblepton/src/page.c
+++ b/liblepton/src/page.c
@@ -343,9 +343,9 @@ lepton_page_delete (LeptonToplevel *toplevel,
  * \param [in] user_data      Data to be passed to \a notify_func.
  */
 void
-s_page_weak_ref (LeptonPage *page,
-                 void (*notify_func)(void *, void *),
-                 void *user_data)
+lepton_page_weak_ref (LeptonPage *page,
+                      void (*notify_func)(void *, void *),
+                      void *user_data)
 {
   g_return_if_fail (page != NULL);
   page->weak_refs = s_weakref_add (page->weak_refs, notify_func, user_data);
@@ -355,7 +355,7 @@ s_page_weak_ref (LeptonPage *page,
  * \par Function Description
  * Removes the weak reference callback \a notify_func from \a page.
  *
- * \sa s_page_weak_ref()
+ * \sa lepton_page_weak_ref()
  *
  * \param [in,out] page       Page to weak-reference.
  * \param [in] notify_func    Notify function to search for.

--- a/liblepton/src/page.c
+++ b/liblepton/src/page.c
@@ -535,8 +535,8 @@ s_page_autosave (LeptonToplevel *toplevel)
  *  \param [in] object    The LeptonObject being added to the page.
  */
 void
-s_page_append (LeptonPage *page,
-               LeptonObject *object)
+lepton_page_append (LeptonPage *page,
+                    LeptonObject *object)
 {
   page->_object_list = g_list_append (page->_object_list, object);
   object_added (page, object);
@@ -599,7 +599,7 @@ s_page_replace (LeptonPage *page,
 
   /* If object1 not found, append object2 */
   if (iter == NULL) {
-    s_page_append (page, object2);
+    lepton_page_append (page, object2);
     return;
   }
 

--- a/liblepton/src/page.c
+++ b/liblepton/src/page.c
@@ -183,7 +183,7 @@ s_page_new (LeptonToplevel *toplevel,
   page->CHANGED = 0;
 
   /* big assumption here that page_filename isn't null */
-  s_page_set_filename (page, filename);
+  lepton_page_set_filename (page, filename);
 
   page->up = -2;
   page->page_control = 0;
@@ -898,8 +898,8 @@ lepton_page_get_filename (const LeptonPage *page)
  * \param filename  The new file path for \a page
  */
 void
-s_page_set_filename (LeptonPage *page,
-                     const char *filename)
+lepton_page_set_filename (LeptonPage *page,
+                          const char *filename)
 {
   g_return_if_fail (page);
   g_return_if_fail (filename);

--- a/liblepton/src/page.c
+++ b/liblepton/src/page.c
@@ -410,49 +410,6 @@ lepton_page_remove_weak_ptr (LeptonPage *page,
 }
 
 
-/*! \brief Search for page by its filename's basename.
- *  \par Function Description
- *  Searches in \a toplevel's list of pages for a page with
- *  basename( filename ) equal to \a filename.
- *
- *  \param toplevel  The LeptonToplevel object
- *  \param filename  The filename string to search for
- *
- *  \return LeptonPage pointer to a matching page, NULL otherwise.
- */
-LeptonPage*
-s_page_search_by_basename (LeptonToplevel *toplevel,
-                           const gchar *filename)
-{
-  const GList* iter   = NULL;
-  LeptonPage*  page   = NULL;
-  LeptonPage*  result = NULL;
-
-  for ( iter = lepton_list_get_glist( toplevel->pages );
-        iter != NULL;
-        iter = g_list_next( iter ) )
-  {
-    page = (LeptonPage*) iter->data;
-
-    const gchar* fname = lepton_page_get_filename (page);
-    gchar* bname = g_path_get_basename (fname);
-
-    /* FIXME this may not be correct on platforms with
-     * case-insensitive filesystems. */
-
-    if ( strcmp( bname, filename ) == 0 )
-    {
-      result = page;
-      g_free (bname);
-      break;
-    }
-
-    g_free (bname);
-  }
-
-  return result;
-}
-
 /*! \brief Search for a page given its page id in a page list.
  *  \par Function Description
  *  This functions returns the page that have the page id \a pid in

--- a/liblepton/src/page.c
+++ b/liblepton/src/page.c
@@ -591,9 +591,9 @@ lepton_page_remove (LeptonPage *page,
  * \param [in] object2   The LeptonObject being added to the page.
  */
 void
-s_page_replace (LeptonPage *page,
-                LeptonObject *object1,
-                LeptonObject *object2)
+lepton_page_replace (LeptonPage *page,
+                     LeptonObject *object1,
+                     LeptonObject *object2)
 {
   GList *iter = g_list_find (page->_object_list, object1);
 

--- a/liblepton/src/page.c
+++ b/liblepton/src/page.c
@@ -461,26 +461,6 @@ s_page_check_changed (LeptonPageList *list)
   return FALSE;
 }
 
-/*! \brief Reset the CHANGED flag of all pages.
- *  \par Function Description
- *  This function resets the CHANGED flag of each page following \a head.
- *
- *  \param [in,out] list  LeptonPage list to set CHANGED flags in.
- */
-void
-s_page_clear_changed (LeptonPageList *list)
-{
-  const GList *iter;
-  LeptonPage *p_current;
-
-  for ( iter = lepton_list_get_glist( list );
-        iter != NULL;
-        iter = g_list_next( iter ) ) {
-
-    p_current = (LeptonPage *) iter->data;
-    p_current->CHANGED = 0;
-  }
-}
 
 /*! \brief Autosave initialization function.
  *  \par Function Description

--- a/liblepton/src/page.c
+++ b/liblepton/src/page.c
@@ -552,8 +552,8 @@ lepton_page_append (LeptonPage *page,
  *  \param [in] obj_list  The LeptonObject list being added to the page.
  */
 void
-s_page_append_list (LeptonPage *page,
-                    GList *obj_list)
+lepton_page_append_list (LeptonPage *page,
+                         GList *obj_list)
 {
   GList *iter;
   page->_object_list = g_list_concat (page->_object_list, obj_list);

--- a/liblepton/src/page.c
+++ b/liblepton/src/page.c
@@ -656,11 +656,11 @@ const GList *s_page_objects (LeptonPage *page)
  *  \return The GList of LeptonObjects in the region.
  */
 GList*
-s_page_objects_in_regions (LeptonToplevel *toplevel,
-                           LeptonPage *page,
-                           LeptonBox *rects,
-                           int n_rects,
-                           gboolean include_hidden)
+lepton_page_objects_in_regions (LeptonToplevel *toplevel,
+                                LeptonPage *page,
+                                LeptonBox *rects,
+                                int n_rects,
+                                gboolean include_hidden)
 {
   GList *iter;
   GList *list = NULL;

--- a/liblepton/src/page.c
+++ b/liblepton/src/page.c
@@ -231,8 +231,8 @@ lepton_page_new (LeptonToplevel *toplevel,
  *  struct to NULL.
  */
 void
-s_page_delete (LeptonToplevel *toplevel,
-               LeptonPage *page)
+lepton_page_delete (LeptonToplevel *toplevel,
+                    LeptonPage *page)
 {
   LeptonPage *tmp;
   gchar *backup_filename;
@@ -258,7 +258,7 @@ s_page_delete (LeptonToplevel *toplevel,
   real_filename = follow_symlinks (lepton_page_get_filename(page), NULL);
 
   if (real_filename == NULL) {
-    g_message ("s_page_delete:");
+    g_message ("lepton_page_delete:");
     g_message (_("Can't get the real filename of %1$s."),
                lepton_page_get_filename (page));
   }
@@ -270,7 +270,7 @@ s_page_delete (LeptonToplevel *toplevel,
          (!g_file_test(backup_filename, G_FILE_TEST_IS_DIR)) )
     {
       if (unlink(backup_filename) != 0) {
-        g_message ("s_page_delete:");
+        g_message ("lepton_page_delete:");
         g_message (_("Unable to delete backup file %1$s."),
                    backup_filename);
       }
@@ -345,13 +345,13 @@ s_page_delete_list(LeptonToplevel *toplevel)
   GList *list_copy, *iter;
   LeptonPage *page;
 
-  /* s_page_delete removes items from the page list, so make a copy */
+  /* lepton_page_delete removes items from the page list, so make a copy */
   list_copy = g_list_copy (lepton_list_get_glist (toplevel->pages));
 
   for (iter = list_copy; iter != NULL; iter = g_list_next (iter)) {
     page = (LeptonPage *)iter->data;
 
-    s_page_delete (toplevel, page);
+    lepton_page_delete (toplevel, page);
   }
 
   g_list_free (list_copy);

--- a/liblepton/src/page.c
+++ b/liblepton/src/page.c
@@ -636,7 +636,8 @@ lepton_page_delete_objects (LeptonPage *page)
  *  \param [in] page      The LeptonPage to get objects on.
  *  \returns a const pointer to the LeptonPage's GList of objects
  */
-const GList *s_page_objects (LeptonPage *page)
+const GList*
+lepton_page_objects (LeptonPage *page)
 {
   return page->_object_list;
 }

--- a/liblepton/src/page.c
+++ b/liblepton/src/page.c
@@ -434,34 +434,6 @@ s_page_print_all (LeptonToplevel *toplevel)
 }
 
 
-/*! \brief Check if CHANGED flag is set for any page in list.
- *  \par Function Description
- *  This function checks the CHANGED flag for all pages in the <B>list</B>
- *  object.
- *
- *  \param [in] list  LeptonPageList to check CHANGED flag in.
- *  \return 1 if any page has the CHANGED flag set, 0 otherwise.
- */
-gboolean
-s_page_check_changed (LeptonPageList *list)
-{
-  const GList *iter;
-  LeptonPage *p_current;
-
-  for ( iter = lepton_list_get_glist( list );
-        iter != NULL;
-        iter = g_list_next( iter ) ) {
-
-    p_current = (LeptonPage *)iter->data;
-    if (p_current->CHANGED) {
-      return TRUE;
-    }
-  }
-
-  return FALSE;
-}
-
-
 /*! \brief Autosave initialization function.
  *  \par Function Description
  *  This function sets up the autosave callback function.

--- a/liblepton/src/page.c
+++ b/liblepton/src/page.c
@@ -336,7 +336,7 @@ lepton_page_delete (LeptonToplevel *toplevel,
  * \a page is destroyed, \a notify_func will be called with two
  * arguments: the \a page, and the \a user_data.
  *
- * \sa s_page_weak_unref
+ * \sa lepton_page_weak_unref
  *
  * \param [in,out] page       Page to weak-reference.
  * \param [in] notify_func    Weak reference notify function.
@@ -362,9 +362,9 @@ lepton_page_weak_ref (LeptonPage *page,
  * \param [in] user_data      Data to to search for.
  */
 void
-s_page_weak_unref (LeptonPage *page,
-                   void (*notify_func)(void *, void *),
-                   void *user_data)
+lepton_page_weak_unref (LeptonPage *page,
+                        void (*notify_func)(void *, void *),
+                        void *user_data)
 {
   g_return_if_fail (page != NULL);
   page->weak_refs = s_weakref_remove (page->weak_refs,

--- a/liblepton/src/page.c
+++ b/liblepton/src/page.c
@@ -410,36 +410,6 @@ lepton_page_remove_weak_ptr (LeptonPage *page,
 }
 
 
-/*! \brief Search for pages by filename.
- *  \par Function Description
- *  Searches in \a toplevel's list of pages for a page with a filename
- *  equal to \a filename.
- *
- *  \param toplevel  The LeptonToplevel object
- *  \param filename  The filename string to search for
- *
- *  \return LeptonPage pointer to a matching page, NULL otherwise.
- */
-LeptonPage*
-s_page_search (LeptonToplevel *toplevel,
-               const gchar *filename)
-{
-  const GList *iter;
-  LeptonPage *page;
-
-  for ( iter = lepton_list_get_glist( toplevel->pages );
-        iter != NULL;
-        iter = g_list_next( iter ) ) {
-
-    page = (LeptonPage *)iter->data;
-    /* FIXME this may not be correct on platforms with
-     * case-insensitive filesystems. */
-    if (strcmp (lepton_page_get_filename (page), filename) == 0)
-      return page;
-  }
-  return NULL;
-}
-
 /*! \brief Search for page by its filename's basename.
  *  \par Function Description
  *  Searches in \a toplevel's list of pages for a page with

--- a/liblepton/src/page.c
+++ b/liblepton/src/page.c
@@ -224,8 +224,6 @@ lepton_page_new (LeptonToplevel *toplevel,
  *  \par Function Description
  *  Deletes a single page <B>page</B> from <B>toplevel</B>'s list of pages.
  *
- *  See #s_page_delete_list() to delete all pages of a <B>toplevel</B>
- *
  *  If the current page of toplevel is given as parameter <B>page</B>,
  *  the function sets the field <B>page_current</B> of the LeptonToplevel
  *  struct to NULL.
@@ -331,34 +329,6 @@ lepton_page_delete (LeptonToplevel *toplevel,
 
 }
 
-
-/*! \brief Deletes the list of pages of <B>toplevel</B>.
- *  \par Function Description
- *  Deletes the list of pages of <B>toplevel</B>.
- *  This function should only be called when you are finishing up.
- *
- *  \param toplevel  The LeptonToplevel object.
- */
-void
-s_page_delete_list(LeptonToplevel *toplevel)
-{
-  GList *list_copy, *iter;
-  LeptonPage *page;
-
-  /* lepton_page_delete removes items from the page list, so make a copy */
-  list_copy = g_list_copy (lepton_list_get_glist (toplevel->pages));
-
-  for (iter = list_copy; iter != NULL; iter = g_list_next (iter)) {
-    page = (LeptonPage *)iter->data;
-
-    lepton_page_delete (toplevel, page);
-  }
-
-  g_list_free (list_copy);
-
-  /* reset toplevel fields */
-  lepton_toplevel_set_page_current (toplevel, NULL);
-}
 
 /*! \brief Add a weak reference watcher to an LeptonPage.
  * \par Function Description

--- a/liblepton/src/page.c
+++ b/liblepton/src/page.c
@@ -383,8 +383,8 @@ lepton_page_weak_unref (LeptonPage *page,
  * \param [in] weak_pointer_loc  Memory address of a pointer.
  */
 void
-s_page_add_weak_ptr (LeptonPage *page,
-                     void *weak_pointer_loc)
+lepton_page_add_weak_ptr (LeptonPage *page,
+                          void *weak_pointer_loc)
 {
   g_return_if_fail (page != NULL);
   page->weak_refs = s_weakref_add_ptr (page->weak_refs,
@@ -395,7 +395,7 @@ s_page_add_weak_ptr (LeptonPage *page,
  * \par Function Description
  * Removes the weak pointer at \a weak_pointer_loc from \a page.
  *
- * \sa s_page_add_weak_ptr()
+ * \sa lepton_page_add_weak_ptr()
  *
  * \param [in,out] page          Page to weak-reference.
  * \param [in] weak_pointer_loc  Memory address of a pointer.

--- a/liblepton/src/page.c
+++ b/liblepton/src/page.c
@@ -410,34 +410,6 @@ lepton_page_remove_weak_ptr (LeptonPage *page,
 }
 
 
-/*! \brief Search for a page given its page id in a page list.
- *  \par Function Description
- *  This functions returns the page that have the page id \a pid in
- *  the list of pages starting at \a page_list, or NULL if there is no
- *  such page.
- *
- *  \param [in] list      The list of page to search the page in.
- *  \param [in] pid       The ID of the page to find.
- *  \returns A pointer on the page found or NULL if not found.
- */
-LeptonPage*
-s_page_search_by_page_id (LeptonPageList *list,
-                          int pid)
-{
-  const GList *iter;
-
-  for ( iter = lepton_list_get_glist (list);
-        iter != NULL;
-        iter = g_list_next (iter) ) {
-    LeptonPage *page = (LeptonPage *)iter->data;
-    if (page->pid == pid) {
-      return page;
-    }
-  }
-
-  return NULL;
-}
-
 /*! \brief Print full LeptonToplevel structure.
  *  \par Function Description
  *  This function prints the internal structure of <B>toplevel</B>'s

--- a/liblepton/src/page.c
+++ b/liblepton/src/page.c
@@ -167,8 +167,8 @@ pre_object_removed (LeptonPage *page,
  *  current page is not changed by this function.
  */
 LeptonPage*
-s_page_new (LeptonToplevel *toplevel,
-            const gchar *filename)
+lepton_page_new (LeptonToplevel *toplevel,
+                 const gchar *filename)
 {
   g_return_val_if_fail (toplevel, NULL);
   g_return_val_if_fail (filename, NULL);

--- a/liblepton/src/page.c
+++ b/liblepton/src/page.c
@@ -410,30 +410,6 @@ lepton_page_remove_weak_ptr (LeptonPage *page,
 }
 
 
-/*! \brief Print full LeptonToplevel structure.
- *  \par Function Description
- *  This function prints the internal structure of <B>toplevel</B>'s
- *  list of pages.
- *
- *  \param [in] toplevel  The LeptonToplevel object to print.
- */
-void
-s_page_print_all (LeptonToplevel *toplevel)
-{
-  const GList *iter;
-  LeptonPage *page;
-
-  for ( iter = lepton_list_get_glist( toplevel->pages );
-        iter != NULL;
-        iter = g_list_next( iter ) ) {
-
-    page = (LeptonPage *) iter->data;
-    printf ("FILENAME: %1$s\n", lepton_page_get_filename (page));
-    lepton_object_list_print (page->_object_list);
-  }
-}
-
-
 /*! \brief Autosave initialization function.
  *  \par Function Description
  *  This function sets up the autosave callback function.

--- a/liblepton/src/page.c
+++ b/liblepton/src/page.c
@@ -572,8 +572,8 @@ lepton_page_append_list (LeptonPage *page,
  *  \param [in] object    The LeptonObject being removed from the page.
  */
 void
-s_page_remove (LeptonPage *page,
-               LeptonObject *object)
+lepton_page_remove (LeptonPage *page,
+                    LeptonObject *object)
 {
   pre_object_removed (page, object);
   page->_object_list = g_list_remove (page->_object_list, object);

--- a/liblepton/src/page.c
+++ b/liblepton/src/page.c
@@ -410,69 +410,6 @@ lepton_page_remove_weak_ptr (LeptonPage *page,
 }
 
 
-/*! \brief Autosave initialization function.
- *  \par Function Description
- *  This function sets up the autosave callback function.
- *
- *  \param [in] toplevel  The LeptonToplevel object.
- */
-void
-s_page_autosave_init (LeptonToplevel *toplevel)
-{
-  if (toplevel->auto_save_interval != 0) {
-
-    /* 1000 converts seconds into milliseconds */
-    toplevel->auto_save_timeout =
-      g_timeout_add(toplevel->auto_save_interval*1000,
-                    (GSourceFunc) s_page_autosave,
-                    toplevel);
-  }
-}
-
-/*! \brief Autosave callback function.
- *  \par Function Description
- *  This function is a callback of the glib g_timeout functions.
- *  It is called every "interval" milliseconds and it sets a flag to save
- *  a backup copy of the opened pages.
- *
- *  \param [in] toplevel  The LeptonToplevel object.
- *  \return The length in milliseconds to set for next interval.
- */
-gint
-s_page_autosave (LeptonToplevel *toplevel)
-{
-  const GList *iter;
-  LeptonPage *p_current;
-
-  if (toplevel == NULL) {
-    return 0;
-  }
-
-  /* Do nothing if the interval is 0 */
-  if (toplevel->auto_save_interval == 0) {
-    return toplevel->auto_save_interval;
-  }
-
-  /* Should we just disable the autosave timeout returning 0 or
-     just wait for more pages to be added? */
-  if ( toplevel->pages == NULL)
-    return toplevel->auto_save_interval;
-
-  for ( iter = lepton_list_get_glist( toplevel->pages );
-        iter != NULL;
-        iter = g_list_next( iter ) ) {
-
-    p_current = (LeptonPage *) iter->data;
-
-    if (p_current->ops_since_last_backup != 0) {
-      /* Real autosave is done in o_undo_savestate */
-      p_current->do_autosave_backup = 1;
-    }
-  }
-
-  return toplevel->auto_save_interval;
-}
-
 /*! \brief Append an LeptonObject to the LeptonPage
  *
  *  \par Function Description

--- a/liblepton/src/s_clib.c
+++ b/liblepton/src/s_clib.c
@@ -1445,7 +1445,7 @@ s_toplevel_get_symbols (const LeptonToplevel *toplevel)
         p_iter != NULL;
         p_iter = g_list_next( p_iter )) {
     page = (LeptonPage *) p_iter->data;
-    for (o_iter = s_page_objects (page);
+    for (o_iter = lepton_page_objects (page);
          o_iter != NULL;
          o_iter = g_list_next (o_iter)) {
       o = (LeptonObject *)o_iter->data;

--- a/liblepton/src/scheme_smob.c
+++ b/liblepton/src/scheme_smob.c
@@ -440,8 +440,9 @@ edascm_from_page (LeptonPage *page)
   SCM_SET_SMOB_FLAGS (smob, GEDA_SMOB_PAGE);
 
   /* Set weak reference */
-  s_page_weak_ref (page, smob_weakref_notify,
-                   unpack_as_pointer (smob));
+  lepton_page_weak_ref (page,
+                        smob_weakref_notify,
+                        unpack_as_pointer (smob));
 
   smob_cache_add (page, smob);
 

--- a/liblepton/src/scheme_smob.c
+++ b/liblepton/src/scheme_smob.c
@@ -264,8 +264,9 @@ smob_free (SCM smob)
                            unpack_as_pointer (smob));
     break;
   case GEDA_SMOB_PAGE:
-    s_page_weak_unref ((LeptonPage *) data, smob_weakref_notify,
-                       unpack_as_pointer (smob));
+    lepton_page_weak_unref ((LeptonPage *) data,
+                            smob_weakref_notify,
+                            unpack_as_pointer (smob));
     break;
   case GEDA_SMOB_OBJECT:
     /* See edascm_from_object() for an explanation of why LeptonObject

--- a/liblepton/src/toplevel.c
+++ b/liblepton/src/toplevel.c
@@ -420,3 +420,68 @@ lepton_toplevel_print_all (LeptonToplevel *toplevel)
     lepton_object_list_print (page->_object_list);
   }
 }
+
+
+/*! \brief Autosave callback function.
+ *  \par Function Description
+ *  This function is a callback of the glib g_timeout functions.
+ *  It is called every "interval" milliseconds and it sets a flag to save
+ *  a backup copy of the opened pages.
+ *
+ *  \param [in] toplevel  The LeptonToplevel object.
+ *  \return The length in milliseconds to set for next interval.
+ */
+gint
+lepton_toplevel_autosave (LeptonToplevel *toplevel)
+{
+  const GList *iter;
+  LeptonPage *p_current;
+
+  if (toplevel == NULL) {
+    return 0;
+  }
+
+  /* Do nothing if the interval is 0 */
+  if (toplevel->auto_save_interval == 0) {
+    return toplevel->auto_save_interval;
+  }
+
+  /* Should we just disable the autosave timeout returning 0 or
+     just wait for more pages to be added? */
+  if ( toplevel->pages == NULL)
+    return toplevel->auto_save_interval;
+
+  for ( iter = lepton_list_get_glist( toplevel->pages );
+        iter != NULL;
+        iter = g_list_next( iter ) ) {
+
+    p_current = (LeptonPage *) iter->data;
+
+    if (p_current->ops_since_last_backup != 0) {
+      /* Real autosave is done in o_undo_savestate */
+      p_current->do_autosave_backup = 1;
+    }
+  }
+
+  return toplevel->auto_save_interval;
+}
+
+
+/*! \brief Autosave initialization function.
+ *  \par Function Description
+ *  This function sets up the autosave callback function.
+ *
+ *  \param [in] toplevel  The LeptonToplevel object.
+ */
+void
+lepton_toplevel_init_autosave (LeptonToplevel *toplevel)
+{
+  if (toplevel->auto_save_interval != 0) {
+
+    /* 1000 converts seconds into milliseconds */
+    toplevel->auto_save_timeout =
+      g_timeout_add(toplevel->auto_save_interval*1000,
+                    (GSourceFunc) lepton_toplevel_autosave,
+                    toplevel);
+  }
+}

--- a/liblepton/src/toplevel.c
+++ b/liblepton/src/toplevel.c
@@ -244,6 +244,50 @@ lepton_toplevel_search_page (LeptonToplevel *toplevel,
 }
 
 
+/*! \brief Search for page by its filename's basename.
+ *  \par Function Description
+ *  Searches in \a toplevel's list of pages for a page with
+ *  basename( filename ) equal to \a filename.
+ *
+ *  \param toplevel  The LeptonToplevel object
+ *  \param filename  The filename string to search for
+ *
+ *  \return LeptonPage pointer to a matching page, NULL otherwise.
+ */
+LeptonPage*
+lepton_toplevel_search_page_by_basename (LeptonToplevel *toplevel,
+                                         const gchar *filename)
+{
+  const GList* iter   = NULL;
+  LeptonPage*  page   = NULL;
+  LeptonPage*  result = NULL;
+
+  for ( iter = lepton_list_get_glist( toplevel->pages );
+        iter != NULL;
+        iter = g_list_next( iter ) )
+  {
+    page = (LeptonPage*) iter->data;
+
+    const gchar* fname = lepton_page_get_filename (page);
+    gchar* bname = g_path_get_basename (fname);
+
+    /* FIXME this may not be correct on platforms with
+     * case-insensitive filesystems. */
+
+    if ( strcmp( bname, filename ) == 0 )
+    {
+      result = page;
+      g_free (bname);
+      break;
+    }
+
+    g_free (bname);
+  }
+
+  return result;
+}
+
+
 /*! \brief Add a weak reference watcher to an LeptonToplevel.
  * \par Function Description
  * Adds the weak reference callback \a notify_func to \a toplevel.  When

--- a/liblepton/src/toplevel.c
+++ b/liblepton/src/toplevel.c
@@ -63,6 +63,36 @@ s_toplevel_new ()
   return toplevel;
 }
 
+
+/*! \brief Deletes the list of pages of <B>toplevel</B>.
+ *  \par Function Description
+ *  Deletes the list of pages of <B>toplevel</B>.
+ *  This function should only be called when you are finishing up.
+ *
+ *  \param toplevel  The LeptonToplevel object.
+ */
+static void
+lepton_toplevel_delete_pages (LeptonToplevel *toplevel)
+{
+  GList *list_copy, *iter;
+  LeptonPage *page;
+
+  /* lepton_page_delete removes items from the page list, so make a copy */
+  list_copy = g_list_copy (lepton_list_get_glist (toplevel->pages));
+
+  for (iter = list_copy; iter != NULL; iter = g_list_next (iter)) {
+    page = (LeptonPage *)iter->data;
+
+    lepton_page_delete (toplevel, page);
+  }
+
+  g_list_free (list_copy);
+
+  /* reset toplevel fields */
+  lepton_toplevel_set_page_current (toplevel, NULL);
+}
+
+
 /*! \todo Finish function documentation!!!
  *  \brief
  *  \par Function Description
@@ -79,7 +109,7 @@ s_toplevel_delete (LeptonToplevel *toplevel)
   }
 
   /* delete all pages */
-  s_page_delete_list (toplevel);
+  lepton_toplevel_delete_pages (toplevel);
 
   /* Delete the page list */
   g_object_unref(toplevel->pages);

--- a/liblepton/src/toplevel.c
+++ b/liblepton/src/toplevel.c
@@ -185,6 +185,34 @@ lepton_toplevel_set_pages (LeptonToplevel *toplevel,
 }
 
 
+/*! \brief changes the current page in toplevel
+ *  \par Function Description
+ *  Changes the current page in \a toplevel to the page \a p_new.
+ *
+ *  \param toplevel  The LeptonToplevel object
+ *  \param p_new     The LeptonPage to go to
+ */
+void
+lepton_toplevel_goto_page (LeptonToplevel *toplevel,
+                           LeptonPage *p_new)
+{
+  gchar *dirname;
+
+  lepton_toplevel_set_page_current (toplevel, p_new);
+
+  dirname = g_path_get_dirname (lepton_page_get_filename (p_new));
+  if (chdir (dirname)) {
+    /* An error occured with chdir */
+    /* FIXME[2017-02-21] Libraries should not be changing the
+     * current working directory.  If it is not possible to avoid a
+     * chdir() call, then the error needs to be handled and/or
+     * reported. */
+  }
+  g_free (dirname);
+
+}
+
+
 /*! \brief Add a weak reference watcher to an LeptonToplevel.
  * \par Function Description
  * Adds the weak reference callback \a notify_func to \a toplevel.  When

--- a/liblepton/src/toplevel.c
+++ b/liblepton/src/toplevel.c
@@ -431,7 +431,7 @@ lepton_toplevel_print_all (LeptonToplevel *toplevel)
  *  \param [in] toplevel  The LeptonToplevel object.
  *  \return The length in milliseconds to set for next interval.
  */
-gint
+static gint
 lepton_toplevel_autosave (LeptonToplevel *toplevel)
 {
   const GList *iter;

--- a/liblepton/src/toplevel.c
+++ b/liblepton/src/toplevel.c
@@ -288,6 +288,35 @@ lepton_toplevel_search_page_by_basename (LeptonToplevel *toplevel,
 }
 
 
+/*! \brief Search for a page given its page id in a page list.
+ *  \par Function Description
+ *  This functions returns the page that have the page id \a pid in
+ *  the list of pages starting at \a page_list, or NULL if there is no
+ *  such page.
+ *
+ *  \param [in] list      The list of page to search the page in.
+ *  \param [in] pid       The ID of the page to find.
+ *  \returns A pointer on the page found or NULL if not found.
+ */
+LeptonPage*
+lepton_toplevel_search_page_by_id (LeptonPageList *list,
+                                   int pid)
+{
+  const GList *iter;
+
+  for ( iter = lepton_list_get_glist (list);
+        iter != NULL;
+        iter = g_list_next (iter) ) {
+    LeptonPage *page = (LeptonPage *)iter->data;
+    if (page->pid == pid) {
+      return page;
+    }
+  }
+
+  return NULL;
+}
+
+
 /*! \brief Add a weak reference watcher to an LeptonToplevel.
  * \par Function Description
  * Adds the weak reference callback \a notify_func to \a toplevel.  When

--- a/liblepton/src/toplevel.c
+++ b/liblepton/src/toplevel.c
@@ -396,3 +396,27 @@ s_toplevel_remove_weak_ptr (LeptonToplevel *toplevel,
   toplevel->weak_refs = s_weakref_remove_ptr (toplevel->weak_refs,
                                               (void**) weak_pointer_loc);
 }
+
+
+/*! \brief Print full LeptonToplevel structure.
+ *  \par Function Description
+ *  This function prints the internal structure of <B>toplevel</B>'s
+ *  list of pages.
+ *
+ *  \param [in] toplevel  The LeptonToplevel object to print.
+ */
+void
+lepton_toplevel_print_all (LeptonToplevel *toplevel)
+{
+  const GList *iter;
+  LeptonPage *page;
+
+  for ( iter = lepton_list_get_glist( toplevel->pages );
+        iter != NULL;
+        iter = g_list_next( iter ) ) {
+
+    page = (LeptonPage *) iter->data;
+    printf ("FILENAME: %1$s\n", lepton_page_get_filename (page));
+    lepton_object_list_print (page->_object_list);
+  }
+}

--- a/liblepton/src/toplevel.c
+++ b/liblepton/src/toplevel.c
@@ -213,6 +213,37 @@ lepton_toplevel_goto_page (LeptonToplevel *toplevel,
 }
 
 
+/*! \brief Search for pages by filename.
+ *  \par Function Description
+ *  Searches in \a toplevel's list of pages for a page with a filename
+ *  equal to \a filename.
+ *
+ *  \param toplevel  The LeptonToplevel object
+ *  \param filename  The filename string to search for
+ *
+ *  \return LeptonPage pointer to a matching page, NULL otherwise.
+ */
+LeptonPage*
+lepton_toplevel_search_page (LeptonToplevel *toplevel,
+                             const gchar *filename)
+{
+  const GList *iter;
+  LeptonPage *page;
+
+  for ( iter = lepton_list_get_glist( toplevel->pages );
+        iter != NULL;
+        iter = g_list_next( iter ) ) {
+
+    page = (LeptonPage *)iter->data;
+    /* FIXME this may not be correct on platforms with
+     * case-insensitive filesystems. */
+    if (strcmp (lepton_page_get_filename (page), filename) == 0)
+      return page;
+  }
+  return NULL;
+}
+
+
 /*! \brief Add a weak reference watcher to an LeptonToplevel.
  * \par Function Description
  * Adds the weak reference callback \a notify_func to \a toplevel.  When

--- a/libleptonattrib/include/prototype.h
+++ b/libleptonattrib/include/prototype.h
@@ -100,9 +100,6 @@ s_toplevel_update_pin_attribs_in_toplevel (LeptonToplevel *toplevel,
                                            char *refdes,
                                            LeptonObject *pin,
                                            STRING_LIST *new_pin_attrib_list);
-gint
-s_page_save_all (LeptonToplevel *toplevel);
-
 
 /* ------------- s_object.c ------------- */
 void

--- a/libleptonattrib/include/prototype.h
+++ b/libleptonattrib/include/prototype.h
@@ -75,9 +75,6 @@ void s_table_gtksheet_to_table(GtkSheet *local_gtk_sheet,
                                TABLE **local_table, int num_rows, int num_cols);
 
 /* ------------- s_toplevel.c ------------- */
-int
-s_toplevel_read_page (LeptonToplevel *toplevel,
-                      char *filename);
 void
 s_toplevel_verify_design (LeptonToplevel *toplevel);
 

--- a/libleptonattrib/src/s_object.c
+++ b/libleptonattrib/src/s_object.c
@@ -389,7 +389,7 @@ void
 s_object_delete_text_object_in_object (LeptonToplevel *toplevel,
                                        LeptonObject * text_object)
 {
-  s_page_remove (toplevel->page_current, text_object);
+  lepton_page_remove (toplevel->page_current, text_object);
   lepton_object_delete (text_object);
   toplevel->page_current->CHANGED = 1;
 }

--- a/libleptonattrib/src/s_object.c
+++ b/libleptonattrib/src/s_object.c
@@ -357,7 +357,7 @@ s_object_attrib_add_attrib_in_object (LeptonToplevel *toplevel,
                                     DEFAULT_TEXT_SIZE,
                                     visibility,
                                     show_name_value);
-  s_page_append (toplevel->page_current, new_obj);
+  lepton_page_append (toplevel->page_current, new_obj);
 
   /* now toplevel->page_current->object_tail contains new text item */
 

--- a/libleptonattrib/src/s_toplevel.c
+++ b/libleptonattrib/src/s_toplevel.c
@@ -50,39 +50,6 @@
 
 /* ===================  Public Functions  ====================== */
 
-
-/*! \brief Read a schematic page
- *
- * Reads in a schematic page & calls f_open, which fills out the
- * toplevel structure.
- *
- *  \param toplevel LeptonToplevel structure
- *  \param filename file to be opened
- *  \returns 1 on success, 0 on failure
- */
-int
-s_toplevel_read_page (LeptonToplevel *toplevel,
-                      char *filename)
-{
-  int file_return_code;
-  GError *err = NULL;
-
-  /* Set the new filename */
-  s_page_set_filename (toplevel->page_current, filename);
-
-  /* read in and fill out toplevel using f_open and its callees */
-  file_return_code = f_open (toplevel, toplevel->page_current, filename, &err);
-
-  /* If an error occurred, print message */
-  if (err != NULL) {
-    g_warning ("%s", err->message);
-    g_error_free (err);
-  }
-
-  return file_return_code;
-}
-
-
 /*! \brief Verify the entire design
  *
  * This function loops through all objects in the design looking

--- a/libleptonattrib/src/s_toplevel.c
+++ b/libleptonattrib/src/s_toplevel.c
@@ -70,7 +70,7 @@ void s_toplevel_verify_design (LeptonToplevel *toplevel)
        p_iter = g_list_next (p_iter)) {
     LeptonPage *p_current = (LeptonPage*) p_iter->data;
 
-    for (o_iter = s_page_objects (p_current);
+    for (o_iter = lepton_page_objects (p_current);
          o_iter != NULL;
          o_iter = g_list_next (o_iter)) {
       LeptonObject *o_current = (LeptonObject*) o_iter->data;
@@ -412,7 +412,7 @@ s_toplevel_sheetdata_to_toplevel (LeptonToplevel *toplevel,
    * from the list during iteration over the list.
    */
   /* NB: g_list_copy doesn't declare its input const, so we cast */
-  copy_list = g_list_copy ((GList *)s_page_objects (page));
+  copy_list = g_list_copy ((GList *) lepton_page_objects (page));
 
   /* Iterate backwards since attributes are attached after their
    * parent objects in the list. Attributes can get deleted during
@@ -477,7 +477,7 @@ s_toplevel_sheetdata_to_toplevel (LeptonToplevel *toplevel,
    * deleted from the list during its iteration.
    */
   /* NB: g_list_copy doesn't declare its input const, so we cast */
-  copy_list = g_list_copy ((GList *)s_page_objects (page));
+  copy_list = g_list_copy ((GList *) lepton_page_objects (page));
 
   for (o_iter = g_list_last (copy_list);
        o_iter != NULL;

--- a/libleptonattrib/src/s_toplevel.c
+++ b/libleptonattrib/src/s_toplevel.c
@@ -97,8 +97,8 @@ void s_toplevel_verify_design (LeptonToplevel *toplevel)
  *  \param [in] toplevel  The LeptonToplevel to save pages from.
  *  \return The number of failed tries to save a page.
  */
-gint
-s_page_save_all (LeptonToplevel *toplevel)
+static gint
+save_toplevel_pages (LeptonToplevel *toplevel)
 {
   const GList *iter;
   LeptonPage *p_current;
@@ -169,7 +169,7 @@ s_toplevel_save_sheet ()
            "Done writing SHEEET_DATA text back into pr_currnet.\n");
 
   /* Save all pages in design. */
-  s_page_save_all (toplevel);
+  save_toplevel_pages (toplevel);
   s_sheet_data_set_changed (sheet_head, FALSE);
 
   return;

--- a/libleptonattrib/src/s_toplevel.c
+++ b/libleptonattrib/src/s_toplevel.c
@@ -143,15 +143,16 @@ s_page_save_all (LeptonToplevel *toplevel)
 
     p_current = (LeptonPage *)iter->data;
 
-    if (f_save (p_current, s_page_get_filename (p_current), NULL)) {
+    if (f_save (p_current, lepton_page_get_filename (p_current), NULL))
+    {
       g_message (_("Saved [%1$s]"),
-                 s_page_get_filename (p_current));
+                 lepton_page_get_filename (p_current));
       /* reset the CHANGED flag of p_current */
       p_current->CHANGED = 0;
 
     } else {
       g_message (_("Could NOT save [%1$s]"),
-                 s_page_get_filename (p_current));
+                 lepton_page_get_filename (p_current));
       /* increase the error counter */
       status++;
     }

--- a/libleptonattrib/src/x_window.c
+++ b/libleptonattrib/src/x_window.c
@@ -549,7 +549,7 @@ x_window_set_title (GList* plist)
 
   if (g_list_length (plist) == 1)
   {
-    const gchar* fpath = s_page_get_filename ((LeptonPage *) plist->data);
+    const gchar* fpath = lepton_page_get_filename ((LeptonPage *) plist->data);
     gchar* fname = g_path_get_basename (fpath);
 
     title = g_strdup_printf ("%s - %s", fname, prog_name);

--- a/libleptonattrib/src/x_window.c
+++ b/libleptonattrib/src/x_window.c
@@ -629,8 +629,8 @@ lepton_attrib_window ()
     lepton_toplevel_set_page_current (toplevel, p_local);
 
     /* Now add all items found to the master lists */
-    s_sheet_data_add_master_comp_list_items (s_page_objects (p_local));
-    s_sheet_data_add_master_comp_attrib_list_items (s_page_objects (p_local));
+    s_sheet_data_add_master_comp_list_items (lepton_page_objects (p_local));
+    s_sheet_data_add_master_comp_attrib_list_items (lepton_page_objects (p_local));
 #if 0
     /* Note that this must be changed.  We need to input the entire project
      * before doing anything with the nets because we need to first
@@ -639,8 +639,8 @@ lepton_attrib_window ()
     s_sheet_data_add_master_net_attrib_list_items (p_local->object_list);
 #endif
 
-    s_sheet_data_add_master_pin_list_items (s_page_objects (p_local));
-    s_sheet_data_add_master_pin_attrib_list_items (s_page_objects (p_local));
+    s_sheet_data_add_master_pin_list_items (lepton_page_objects (p_local));
+    s_sheet_data_add_master_pin_attrib_list_items (lepton_page_objects (p_local));
   }     /* end of loop over files     */
 
   /* ---------- Sort the master lists  ---------- */
@@ -672,7 +672,7 @@ lepton_attrib_window ()
     /* only traverse pages which are toplevel */
     if (p_local->page_control == 0) {
       /* adds all components from page to comp_table */
-      s_table_add_toplevel_comp_items_to_comp_table (s_page_objects (p_local));
+      s_table_add_toplevel_comp_items_to_comp_table (lepton_page_objects (p_local));
 #if 0
       /* Note that this must be changed.  We need to input the entire project
        * before doing anything with the nets because we need to first
@@ -683,7 +683,7 @@ lepton_attrib_window ()
 #endif
 
       /* adds all pins from page to pin_table */
-      s_table_add_toplevel_pin_items_to_pin_table (s_page_objects (p_local));
+      s_table_add_toplevel_pin_items_to_pin_table (lepton_page_objects (p_local));
     }
   } /* for loop over pages */
 

--- a/libleptongui/src/gschem_close_confirmation_dialog.c
+++ b/libleptongui/src/gschem_close_confirmation_dialog.c
@@ -216,8 +216,8 @@ get_page_name (GtkTreeModel *model, GtkTreeIter *piter, gboolean full_path)
                       -1);
   g_assert (page != NULL);
 
-  return full_path ? g_strdup (s_page_get_filename (page))
-                   : g_path_get_basename (s_page_get_filename (page));
+  return full_path ? g_strdup (lepton_page_get_filename (page))
+                   : g_path_get_basename (lepton_page_get_filename (page));
 }
 
 /*! \brief Sets the contents of the name cell in the treeview of dialog.

--- a/libleptongui/src/gschem_close_confirmation_dialog.c
+++ b/libleptongui/src/gschem_close_confirmation_dialog.c
@@ -779,7 +779,7 @@ x_dialog_close_changed_page (GschemToplevel *w_current, LeptonPage *page)
 
       case GTK_RESPONSE_YES:
         /* action selected: save */
-        s_page_goto (w_current->toplevel, page);
+        lepton_toplevel_goto_page (w_current->toplevel, page);
         gschem_toplevel_page_changed (w_current);
         i_callback_file_save (NULL, w_current);
         /* has the page been really saved? */
@@ -804,7 +804,7 @@ x_dialog_close_changed_page (GschemToplevel *w_current, LeptonPage *page)
   /* Switch back to the page we were on if it wasn't the one being closed */
   g_return_val_if_fail (keep_page != NULL, result);
   if (keep_page != page) {
-    s_page_goto (w_current->toplevel, keep_page);
+    lepton_toplevel_goto_page (w_current->toplevel, keep_page);
     gschem_toplevel_page_changed (w_current);
   }
   return result;
@@ -880,7 +880,7 @@ x_dialog_close_window (GschemToplevel *w_current)
              p_unsaved = g_list_next (p_unsaved)) {
           p_current = (LeptonPage*) p_unsaved->data;
 
-          s_page_goto (toplevel, p_current);
+          lepton_toplevel_goto_page (toplevel, p_current);
           gschem_toplevel_page_changed (w_current);
 
           i_callback_file_save (NULL, w_current);
@@ -903,7 +903,7 @@ x_dialog_close_window (GschemToplevel *w_current)
 
   /* Switch back to the page we were on */
   g_return_val_if_fail (keep_page != NULL, ret);
-  s_page_goto (toplevel, keep_page);
+  lepton_toplevel_goto_page (toplevel, keep_page);
   gschem_toplevel_page_changed (w_current);
 
   return ret;

--- a/libleptongui/src/gschem_find_text_state.c
+++ b/libleptongui/src/gschem_find_text_state.c
@@ -357,7 +357,7 @@ find_objects_using_pattern (GSList *pages,
       continue;
     }
 
-    object_iter = s_page_objects (page);
+    object_iter = lepton_page_objects (page);
 
     while (object_iter != NULL) {
       LeptonObject *object = (LeptonObject*) object_iter->data;
@@ -437,7 +437,7 @@ find_objects_using_regex (GSList *pages,
       continue;
     }
 
-    object_iter = s_page_objects (page);
+    object_iter = lepton_page_objects (page);
 
     while (object_iter != NULL) {
       LeptonObject *object = (LeptonObject*) object_iter->data;
@@ -506,7 +506,7 @@ find_objects_using_substring (GSList *pages,
       continue;
     }
 
-    object_iter = s_page_objects (page);
+    object_iter = lepton_page_objects (page);
 
     while (object_iter != NULL) {
       LeptonObject *object = (LeptonObject*) object_iter->data;
@@ -679,7 +679,7 @@ get_subpages (GschemToplevel *w_current,
 
   g_return_val_if_fail (page != NULL, NULL);
 
-  object_iter = s_page_objects (page);
+  object_iter = lepton_page_objects (page);
 
   while (object_iter != NULL) {
     char *attrib;

--- a/libleptongui/src/gschem_find_text_state.c
+++ b/libleptongui/src/gschem_find_text_state.c
@@ -223,7 +223,7 @@ assign_store (GschemFindTextState *state, GSList *objects, gboolean filter_text)
 
     gtk_list_store_append (state->store, &tree_iter);
 
-    basename = g_path_get_basename (s_page_get_filename (object->page));
+    basename = g_path_get_basename (lepton_page_get_filename (object->page));
 
     gtk_list_store_set (state->store,
                         &tree_iter,

--- a/libleptongui/src/gschem_page_view.c
+++ b/libleptongui/src/gschem_page_view.c
@@ -1054,7 +1054,7 @@ gschem_page_view_set_page (GschemPageView *view,
       lepton_page_add_weak_ptr (view->_page, &view->_page);
 
       g_return_if_fail (page->toplevel != NULL);
-      s_page_goto (page->toplevel, page);
+      lepton_toplevel_goto_page (page->toplevel, page);
 
       /* redraw the current page and update UI */
       gschem_page_view_invalidate_all (view);

--- a/libleptongui/src/gschem_page_view.c
+++ b/libleptongui/src/gschem_page_view.c
@@ -1655,7 +1655,7 @@ geometry_cache_insert (GschemPageView *view,
   g_return_if_fail (geometry);
   g_return_if_fail (!g_hash_table_contains (view->_geometry_cache, page));
 
-  s_page_weak_ref (page, geometry_cache_page_weak_ref_notify, view);
+  lepton_page_weak_ref (page, geometry_cache_page_weak_ref_notify, view);
   g_hash_table_insert (view->_geometry_cache, page, geometry);
 }
 

--- a/libleptongui/src/gschem_page_view.c
+++ b/libleptongui/src/gschem_page_view.c
@@ -174,7 +174,7 @@ dispose (GObject *object)
   g_return_if_fail (view != NULL);
 
   if (view->_page) {
-    s_page_remove_weak_ptr (view->_page, &view->_page);
+    lepton_page_remove_weak_ptr (view->_page, &view->_page);
     view->_page = NULL;
   }
 
@@ -1045,7 +1045,7 @@ gschem_page_view_set_page (GschemPageView *view,
   if (page != view->_page) {
 
     if (view->_page) {
-      s_page_remove_weak_ptr (view->_page, &view->_page);
+      lepton_page_remove_weak_ptr (view->_page, &view->_page);
       view->_page = NULL;
     }
 

--- a/libleptongui/src/gschem_page_view.c
+++ b/libleptongui/src/gschem_page_view.c
@@ -1051,7 +1051,7 @@ gschem_page_view_set_page (GschemPageView *view,
 
     if (page) {
       view->_page = page;
-      s_page_add_weak_ptr (view->_page, &view->_page);
+      lepton_page_add_weak_ptr (view->_page, &view->_page);
 
       g_return_if_fail (page->toplevel != NULL);
       s_page_goto (page->toplevel, page);

--- a/libleptongui/src/gschem_page_view.c
+++ b/libleptongui/src/gschem_page_view.c
@@ -529,7 +529,7 @@ gschem_page_view_get_page_geometry (GschemPageView *view)
     geometry_cache_insert (view, page, geometry);
 
     gschem_page_geometry_zoom_extents (geometry,
-                                       s_page_objects (page),
+                                       lepton_page_objects (page),
                                        view->show_hidden_text);
   }
   else {
@@ -1488,7 +1488,7 @@ gschem_page_view_zoom_extents (GschemPageView *view, const GList *objects)
   g_return_if_fail (geometry != NULL);
 
   if (temp == NULL) {
-    temp = s_page_objects (gschem_page_view_get_page (view));
+    temp = lepton_page_objects (gschem_page_view_get_page (view));
   }
 
   gschem_page_geometry_zoom_extents (geometry, temp, view->show_hidden_text);

--- a/libleptongui/src/gschem_page_view.c
+++ b/libleptongui/src/gschem_page_view.c
@@ -1664,7 +1664,9 @@ geometry_cache_dispose_func (gpointer key,
                              gpointer value,
                              gpointer user_data)
 {
-  s_page_weak_unref ((LeptonPage*) key, geometry_cache_page_weak_ref_notify, user_data);
+  lepton_page_weak_unref ((LeptonPage*) key,
+                          geometry_cache_page_weak_ref_notify,
+                          user_data);
   gschem_page_geometry_free ((GschemPageGeometry*) value);
   return TRUE;
 }

--- a/libleptongui/src/gschem_preview.c
+++ b/libleptongui/src/gschem_preview.c
@@ -200,16 +200,16 @@ preview_update (GschemPreview *preview)
         s_page_append_list (preview_page, objects);
       }
       else {
-        s_page_append (preview_page,
-                       lepton_text_object_new (2,
-                                               100,
-                                               100,
-                                               LOWER_MIDDLE,
-                                               0,
-                                               err->message,
-                                               10,
-                                               VISIBLE,
-                                               SHOW_NAME_VALUE));
+        lepton_page_append (preview_page,
+                            lepton_text_object_new (2,
+                                                    100,
+                                                    100,
+                                                    LOWER_MIDDLE,
+                                                    0,
+                                                    err->message,
+                                                    10,
+                                                    VISIBLE,
+                                                    SHOW_NAME_VALUE));
         g_error_free(err);
       }
     }

--- a/libleptongui/src/gschem_preview.c
+++ b/libleptongui/src/gschem_preview.c
@@ -215,7 +215,7 @@ preview_update (GschemPreview *preview)
     }
   }
 
-  if (world_get_object_glist_bounds (s_page_objects (preview_page),
+  if (world_get_object_glist_bounds (lepton_page_objects (preview_page),
                                      /* Do not include hidden text. */
                                      FALSE,
                                      &left, &top,

--- a/libleptongui/src/gschem_preview.c
+++ b/libleptongui/src/gschem_preview.c
@@ -79,7 +79,7 @@ preview_get_filename (GschemPreview *preview)
 
   g_return_val_if_fail (page != NULL, "");
 
-  return s_page_get_filename (page);
+  return lepton_page_get_filename (page);
 }
 
 

--- a/libleptongui/src/gschem_preview.c
+++ b/libleptongui/src/gschem_preview.c
@@ -178,7 +178,7 @@ preview_update (GschemPreview *preview)
   LeptonToplevel *preview_toplevel = preview_page->toplevel;
 
   /* delete old preview */
-  s_page_delete_objects (preview_page);
+  lepton_page_delete_objects (preview_page);
 
   if (preview->active) {
     g_assert ((preview->filename == NULL) || (preview->buffer == NULL));

--- a/libleptongui/src/gschem_preview.c
+++ b/libleptongui/src/gschem_preview.c
@@ -197,7 +197,7 @@ preview_update (GschemPreview *preview)
                                        _("Preview Buffer"), &err);
 
       if (err == NULL) {
-        s_page_append_list (preview_page, objects);
+        lepton_page_append_list (preview_page, objects);
       }
       else {
         lepton_page_append (preview_page,

--- a/libleptongui/src/gschem_preview.c
+++ b/libleptongui/src/gschem_preview.c
@@ -326,8 +326,8 @@ gschem_preview_init (GschemPreview *preview)
   preview->buffer   = NULL;
 
   gschem_page_view_set_page (GSCHEM_PAGE_VIEW (preview),
-                             s_page_new (preview->preview_w_current->toplevel,
-                                         "preview"));
+                             lepton_page_new (preview->preview_w_current->toplevel,
+                                              "preview"));
 
   gtk_widget_set_events (GTK_WIDGET (preview),
                          GDK_EXPOSURE_MASK |

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -1612,7 +1612,7 @@ i_callback_page_print (GtkWidget *widget, gpointer data)
 {
   GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
 
-  s_page_print_all(gschem_toplevel_get_toplevel (w_current));
+  lepton_toplevel_print_all (gschem_toplevel_get_toplevel (w_current));
 }
 
 /*! \section clipboard-menu Clipboard Menu Callback Functions */

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -2122,12 +2122,12 @@ i_callback_hierarchy_down_schematic (GtkWidget *widget, gpointer data)
       */
       if (child != NULL && !x_tabs_enabled())
       {
-        s_page_goto (gschem_toplevel_get_toplevel (w_current), child);
+        lepton_toplevel_goto_page (gschem_toplevel_get_toplevel (w_current), child);
         gschem_toplevel_page_changed (w_current);
         gschem_page_view_zoom_extents (gschem_toplevel_get_current_page_view (w_current),
                                        NULL);
         o_undo_savestate_old(w_current, UNDO_ALL);
-        s_page_goto (gschem_toplevel_get_toplevel (w_current), parent);
+        lepton_toplevel_goto_page (gschem_toplevel_get_toplevel (w_current), parent);
         gschem_toplevel_page_changed (w_current);
       }
 

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -336,7 +336,7 @@ i_callback_edit_undo (GtkWidget *widget, gpointer data)
    *
    * It "might" be nice to sub-undo rotates / zoom changes
    * made whilst moving components, but when the undo code
-   * hits s_page_delete(), the place list objects are free'd.
+   * hits lepton_page_delete(), the place list objects are free'd.
    * Since they are also contained in the schematic page, a
    * crash occurs when the page objects are free'd.
    * */

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -47,7 +47,7 @@ i_callback_file_new (GtkWidget *widget, gpointer data)
   g_return_if_fail (page != NULL);
 
   x_window_set_current_page (w_current, page);
-  g_message (_("New page created [%1$s]"), s_page_get_filename (page));
+  g_message (_("New page created [%1$s]"), lepton_page_get_filename (page));
 }
 
 
@@ -70,7 +70,7 @@ i_callback_file_new_window (GtkWidget* widget, gpointer data)
 
   x_window_set_current_page (w_current, page);
 
-  g_message (_("New Window created [%1$s]"), s_page_get_filename (page));
+  g_message (_("New Window created [%1$s]"), lepton_page_get_filename (page));
 }
 
 /*! \todo Finish function documentation!!!
@@ -176,7 +176,7 @@ i_callback_file_save (GtkWidget *widget, gpointer data)
   else
   {
     /* save page: */
-    const gchar* fname = s_page_get_filename (page);
+    const gchar* fname = lepton_page_get_filename (page);
     x_window_save_page (w_current, page, fname);
   }
 
@@ -212,7 +212,7 @@ i_callback_file_save_all (GtkWidget *widget, gpointer data)
     else
     {
       /* save page: */
-      const gchar* fname = s_page_get_filename (page);
+      const gchar* fname = lepton_page_get_filename (page);
       res = x_window_save_page (w_current, page, fname);
       result = result && res;
     }
@@ -1513,7 +1513,7 @@ i_callback_page_revert (GtkWidget *widget, gpointer data)
     return;
   }
 
-  filename = g_strdup (s_page_get_filename (page_current));
+  filename = g_strdup (lepton_page_get_filename (page_current));
 
   const gchar* msg =
     _("<b>Revert page:</b>"

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -926,7 +926,7 @@ i_callback_edit_show_hidden (GtkWidget *widget, gpointer data)
   g_return_if_fail (w_current != NULL);
 
   o_edit_show_hidden (w_current,
-                      s_page_objects (gschem_toplevel_get_toplevel (w_current)->page_current));
+                      lepton_page_objects (gschem_toplevel_get_toplevel (w_current)->page_current));
 }
 
 /*! \todo Finish function documentation!!!

--- a/libleptongui/src/o_arc.c
+++ b/libleptongui/src/o_arc.c
@@ -147,7 +147,7 @@ void o_arc_end4(GschemToplevel *w_current, int radius,
                                    start_angle,
                                    sweep_angle);
 
-  s_page_append (page, new_obj);
+  lepton_page_append (page, new_obj);
 
   w_current->first_wx  = -1;
   w_current->first_wy  = -1;

--- a/libleptongui/src/o_attrib.c
+++ b/libleptongui/src/o_attrib.c
@@ -353,7 +353,7 @@ o_attrib_add_attrib (GschemToplevel *w_current,
         break;
     }
   } else {
-    world_get_object_glist_bounds (s_page_objects (toplevel->page_current),
+    world_get_object_glist_bounds (lepton_page_objects (toplevel->page_current),
                                    /* Don't include hidden objects. */
                                    FALSE,
                                    &left,

--- a/libleptongui/src/o_attrib.c
+++ b/libleptongui/src/o_attrib.c
@@ -381,7 +381,7 @@ o_attrib_add_attrib (GschemToplevel *w_current,
                                     w_current->text_size, /* current text size */
                                     visibility,
                                     show_name_value);
-  s_page_append (toplevel->page_current, new_obj);
+  lepton_page_append (toplevel->page_current, new_obj);
 
   /* now attach the attribute to the object (if o_current is not NULL) */
   /* remember that o_current contains the object to get the attribute */

--- a/libleptongui/src/o_basic.c
+++ b/libleptongui/src/o_basic.c
@@ -124,11 +124,11 @@ void o_redraw_rect (GschemToplevel *w_current,
   gboolean show_hidden_text =
     gschem_toplevel_get_show_hidden_text (w_current);
 
-  obj_list = s_page_objects_in_regions (toplevel,
-                                        page,
-                                        world_rect,
-                                        1,
-                                        show_hidden_text);
+  obj_list = lepton_page_objects_in_regions (toplevel,
+                                             page,
+                                             world_rect,
+                                             1,
+                                             show_hidden_text);
 
   g_free (world_rect);
 

--- a/libleptongui/src/o_box.c
+++ b/libleptongui/src/o_box.c
@@ -140,7 +140,7 @@ void o_box_end(GschemToplevel *w_current, int w_x, int w_y)
                                      box_top,
                                      box_left + box_width,
                                      box_top - box_height);
-    s_page_append (page, new_obj);
+    lepton_page_append (page, new_obj);
 
 #if DEBUG
   printf("coords: %d %d %d %d\n", box_left, box_top, box_width, box_height);

--- a/libleptongui/src/o_bus.c
+++ b/libleptongui/src/o_bus.c
@@ -86,7 +86,7 @@ void o_bus_end(GschemToplevel *w_current, int w_x, int w_y)
                                      w_current->second_wx,
                                      w_current->second_wy,
                                      0);
-    s_page_append (page, new_obj);
+    lepton_page_append (page, new_obj);
 
     /* connect the new bus to the other busses */
     prev_conn_objects = s_conn_return_others (prev_conn_objects, new_obj);

--- a/libleptongui/src/o_circle.c
+++ b/libleptongui/src/o_circle.c
@@ -119,7 +119,7 @@ void o_circle_end(GschemToplevel *w_current, int w_x, int w_y)
                                       w_current->first_wy,
                                       w_current->distance);
 
-  s_page_append (page, new_obj);
+  lepton_page_append (page, new_obj);
 
   /* Call add-objects-hook */
   g_run_hook_object (w_current, "%add-objects-hook", new_obj);

--- a/libleptongui/src/o_component.c
+++ b/libleptongui/src/o_component.c
@@ -185,7 +185,7 @@ o_component_translate_all (GschemToplevel *w_current, int offset)
   gschem_page_view_zoom_extents (view, NULL);
   gschem_page_view_invalidate_all (view);
 
-  world_get_object_glist_bounds (s_page_objects (toplevel->page_current),
+  world_get_object_glist_bounds (lepton_page_objects (toplevel->page_current),
                                  show_hidden_text,
                                  &w_rleft,  &w_rtop,
                                  &w_rright, &w_rbottom);
@@ -198,7 +198,7 @@ o_component_translate_all (GschemToplevel *w_current, int offset)
    * the correct sense) were in use . */
   y = snap_grid (w_current, w_rtop);
 
-  for (iter = s_page_objects (toplevel->page_current);
+  for (iter = lepton_page_objects (toplevel->page_current);
        iter != NULL; iter = g_list_next (iter)) {
     o_current = (LeptonObject*) iter->data;
     s_conn_remove_object_connections (o_current);
@@ -206,14 +206,14 @@ o_component_translate_all (GschemToplevel *w_current, int offset)
 
   if (offset == 0) {
     g_message (_("Translating schematic [%1$d %2$d]"), -x, -y);
-    lepton_object_list_translate (s_page_objects (toplevel->page_current), -x, -y);
+    lepton_object_list_translate (lepton_page_objects (toplevel->page_current), -x, -y);
   } else {
     g_message (_("Translating schematic [%1$d %2$d]"),
                offset, offset);
-    lepton_object_list_translate (s_page_objects (toplevel->page_current), offset, offset);
+    lepton_object_list_translate (lepton_page_objects (toplevel->page_current), offset, offset);
   }
 
-  for (iter = s_page_objects (toplevel->page_current);
+  for (iter = lepton_page_objects (toplevel->page_current);
        iter != NULL;  iter = g_list_next (iter)) {
     o_current = (LeptonObject*) iter->data;
     s_conn_update_object (toplevel->page_current, o_current);

--- a/libleptongui/src/o_delete.c
+++ b/libleptongui/src/o_delete.c
@@ -39,7 +39,7 @@ void o_delete (GschemToplevel *w_current, LeptonObject *object)
   g_return_if_fail (page != NULL);
 
   o_selection_remove (page->selection_list, object);
-  s_page_remove (page, object);
+  lepton_page_remove (page, object);
   g_run_hook_object (w_current, "%remove-objects-hook", object);
   lepton_object_delete (object);
 
@@ -116,7 +116,7 @@ void o_delete_selected (GschemToplevel *w_current)
   for (iter = to_remove; iter != NULL; iter = g_list_next (iter)) {
     obj = (LeptonObject *) iter->data;
     o_selection_remove (selection, obj);
-    s_page_remove (toplevel->page_current, obj);
+    lepton_page_remove (toplevel->page_current, obj);
   }
 
   g_run_hook_object_list (w_current, "%remove-objects-hook", to_remove);

--- a/libleptongui/src/o_find.c
+++ b/libleptongui/src/o_find.c
@@ -158,7 +158,7 @@ gboolean o_find_object (GschemToplevel *w_current, int w_x, int w_y,
      at the same place multiple times. */
   if (toplevel->page_current->object_lastplace != NULL) {
     /* NB: g_list_find doesn't declare its input const, so we cast */
-    iter = g_list_find ((GList *)s_page_objects (toplevel->page_current),
+    iter = g_list_find ((GList *) lepton_page_objects (toplevel->page_current),
                         toplevel->page_current->object_lastplace);
     iter = g_list_next (iter);
   }
@@ -174,7 +174,7 @@ gboolean o_find_object (GschemToplevel *w_current, int w_x, int w_y,
   }
 
   /* now search from the beginning up until the object_lastplace */
-  for (iter = s_page_objects (toplevel->page_current);
+  for (iter = lepton_page_objects (toplevel->page_current);
        iter != NULL; iter = g_list_next (iter)) {
     LeptonObject *o_current = (LeptonObject*) iter->data;
     if (find_single_object (w_current, o_current,

--- a/libleptongui/src/o_line.c
+++ b/libleptongui/src/o_line.c
@@ -110,7 +110,7 @@ void o_line_end(GschemToplevel *w_current, int w_x, int w_y)
                                       w_current->second_wx,
                                       w_current->second_wy);
 
-    s_page_append (page, new_obj);
+    lepton_page_append (page, new_obj);
 
     /* Call add-objects-hook */
     g_run_hook_object (w_current, "%add-objects-hook", new_obj);

--- a/libleptongui/src/o_misc.c
+++ b/libleptongui/src/o_misc.c
@@ -540,7 +540,7 @@ o_update_component (GschemToplevel *w_current, LeptonObject *o_current)
   s_slot_update_object (o_new);
 
   /* Replace old LeptonObject with new LeptonObject */
-  s_page_replace (page, o_current, o_new);
+  lepton_page_replace (page, o_current, o_new);
   lepton_object_delete (o_current);
 
   /* Select new LeptonObject */

--- a/libleptongui/src/o_misc.c
+++ b/libleptongui/src/o_misc.c
@@ -587,7 +587,7 @@ void o_autosave_backups(GschemToplevel *w_current)
     }
     if (p_current->ops_since_last_backup != 0) {
       /* make p_current the current page of toplevel */
-      s_page_goto (toplevel, p_current);
+      lepton_toplevel_goto_page (toplevel, p_current);
       gschem_toplevel_page_changed (w_current);
 
       /* Get the real filename and file permissions */
@@ -672,6 +672,6 @@ void o_autosave_backups(GschemToplevel *w_current)
     }
   }
   /* restore current page */
-  s_page_goto (toplevel, p_save);
+  lepton_toplevel_goto_page (toplevel, p_save);
   gschem_toplevel_page_changed (w_current);
 }

--- a/libleptongui/src/o_misc.c
+++ b/libleptongui/src/o_misc.c
@@ -534,7 +534,7 @@ o_update_component (GschemToplevel *w_current, LeptonObject *o_current)
   g_list_free (old_attribs);
 
   /* Add new attributes to page */
-  s_page_append_list (page, new_attribs);
+  lepton_page_append_list (page, new_attribs);
 
   /* Update pinnumbers for current slot */
   s_slot_update_object (o_new);

--- a/libleptongui/src/o_misc.c
+++ b/libleptongui/src/o_misc.c
@@ -591,12 +591,12 @@ void o_autosave_backups(GschemToplevel *w_current)
       gschem_toplevel_page_changed (w_current);
 
       /* Get the real filename and file permissions */
-      real_filename = follow_symlinks (s_page_get_filename (p_current), NULL);
+      real_filename = follow_symlinks (lepton_page_get_filename (p_current), NULL);
 
       if (real_filename == NULL) {
         g_message ("o_autosave_backups: ");
         g_message (_("Can't get the real filename of %1$s."),
-                   s_page_get_filename (p_current));
+                   lepton_page_get_filename (p_current));
       } else {
         /* Get the directory in which the real filename lives */
         dirname = g_path_get_dirname (real_filename);

--- a/libleptongui/src/o_misc.c
+++ b/libleptongui/src/o_misc.c
@@ -646,7 +646,7 @@ void o_autosave_backups(GschemToplevel *w_current)
           umask(saved_umask);
         }
 
-        if (o_save (s_page_objects (toplevel->page_current),
+        if (o_save (lepton_page_objects (toplevel->page_current),
                     backup_filename, NULL)) {
 
           p_current->ops_since_last_backup = 0;

--- a/libleptongui/src/o_move.c
+++ b/libleptongui/src/o_move.c
@@ -586,7 +586,7 @@ void o_move_check_endpoint(GschemToplevel *w_current, LeptonObject * object)
                                        c_current->y,
                                        c_current->x,
                                        c_current->y);
-      s_page_append (page, new_net);
+      lepton_page_append (page, new_net);
       /* This new net object is only picked up for stretching later,
        * somewhat of a kludge. If the move operation is cancelled, these
        * new 0 length nets are removed by the "undo" operation invoked.

--- a/libleptongui/src/o_net.c
+++ b/libleptongui/src/o_net.c
@@ -522,7 +522,7 @@ void o_net_end(GschemToplevel *w_current, int w_x, int w_y)
                                      w_current->first_wy,
                                      w_current->second_wx,
                                      w_current->second_wy);
-      s_page_append (page, new_net);
+    lepton_page_append (page, new_net);
 
       added_objects = g_list_prepend (added_objects, new_net);
 
@@ -559,7 +559,7 @@ void o_net_end(GschemToplevel *w_current, int w_x, int w_y)
                                      w_current->second_wy,
                                      w_current->third_wx,
                                      w_current->third_wy);
-      s_page_append (page, new_net);
+    lepton_page_append (page, new_net);
 
       added_objects = g_list_prepend (added_objects, new_net);
 
@@ -1063,7 +1063,7 @@ int o_net_add_busrippers(GschemToplevel *w_current, LeptonObject *net_obj,
                                          rippers[i].y[0],
                                          rippers[i].x[1],
                                          rippers[i].y[1]);
-        s_page_append (page, new_obj);
+        lepton_page_append (page, new_obj);
       } else {
 
         if (rippersym != NULL) {
@@ -1078,7 +1078,7 @@ int o_net_add_busrippers(GschemToplevel *w_current, LeptonObject *net_obj,
                                           1);
           s_page_append_list (page,
                               lepton_component_promote_attribs (new_obj));
-          s_page_append (page, new_obj);
+          lepton_page_append (page, new_obj);
         } else {
           g_message (_("Bus ripper symbol [%1$s] was not found in any component library"),
                      w_current->bus_ripper_symname);

--- a/libleptongui/src/o_net.c
+++ b/libleptongui/src/o_net.c
@@ -1076,7 +1076,7 @@ int o_net_add_busrippers(GschemToplevel *w_current, LeptonObject *net_obj,
                                           rippersym,
                                           w_current->bus_ripper_symname,
                                           1);
-          s_page_append_list (page,
+          lepton_page_append_list (page,
                               lepton_component_promote_attribs (new_obj));
           lepton_page_append (page, new_obj);
         } else {

--- a/libleptongui/src/o_path.c
+++ b/libleptongui/src/o_path.c
@@ -508,7 +508,7 @@ o_path_end(GschemToplevel *w_current, int w_x, int w_y)
     w_current->third_wx = -1;
     w_current->third_wy = -1;
 
-    s_page_append (page, obj);
+    lepton_page_append (page, obj);
     g_run_hook_object (w_current, "%add-objects-hook", obj);
     gschem_toplevel_page_content_changed (w_current, page);
     o_undo_savestate (w_current, page, UNDO_ALL);

--- a/libleptongui/src/o_picture.c
+++ b/libleptongui/src/o_picture.c
@@ -112,7 +112,7 @@ void o_picture_end(GschemToplevel *w_current, int w_x, int w_y)
                                          0,
                                          FALSE,
                                          FALSE);
-    s_page_append (toplevel->page_current, new_obj);
+    lepton_page_append (toplevel->page_current, new_obj);
 
     /* Run %add-objects-hook */
     g_run_hook_object (w_current, "%add-objects-hook", new_obj);

--- a/libleptongui/src/o_pin.c
+++ b/libleptongui/src/o_pin.c
@@ -71,7 +71,7 @@ void o_pin_end(GschemToplevel *w_current, int x, int y)
                                    w_current->second_wy,
                                    PIN_TYPE_NET,
                                    0);
-  s_page_append (page, new_obj);
+  lepton_page_append (page, new_obj);
 
   /* Call add-objects-hook */
   g_run_hook_object (w_current, "%add-objects-hook", new_obj);

--- a/libleptongui/src/o_place.c
+++ b/libleptongui/src/o_place.c
@@ -110,7 +110,7 @@ void o_place_end (GschemToplevel *w_current,
   for (iter = temp_dest_list; iter != NULL; iter = g_list_next (iter)) {
     o_current = (LeptonObject*) iter->data;
 
-    s_page_append (page, o_current);
+    lepton_page_append (page, o_current);
 
     /* Update object connectivity */
     s_conn_update_object (page, o_current);

--- a/libleptongui/src/o_select.c
+++ b/libleptongui/src/o_select.c
@@ -397,7 +397,7 @@ void o_select_box_search(GschemToplevel *w_current)
   top = MIN(w_current->first_wy, w_current->second_wy);
   bottom = MAX(w_current->first_wy, w_current->second_wy);
 
-  iter = s_page_objects (toplevel->page_current);
+  iter = lepton_page_objects (toplevel->page_current);
   while (iter != NULL) {
     o_current = (LeptonObject*) iter->data;
     /* only select visible objects */
@@ -509,7 +509,7 @@ void o_select_connected_nets(GschemToplevel *w_current, LeptonObject* o_net)
       break; /* no new netnames in the stack --> finished */
 
     /* get all the nets of the stacked netnames */
-    for (o_iter = s_page_objects (toplevel->page_current);
+    for (o_iter = lepton_page_objects (toplevel->page_current);
          o_iter != NULL;
          o_iter = g_list_next (o_iter)) {
       o_current = (LeptonObject*) o_iter->data;
@@ -613,7 +613,7 @@ o_select_visible_unlocked (GschemToplevel *w_current)
     gschem_toplevel_get_show_hidden_text (w_current);
 
   o_select_unselect_all (w_current);
-  for (iter = s_page_objects (toplevel->page_current);
+  for (iter = lepton_page_objects (toplevel->page_current);
        iter != NULL;
        iter = g_list_next (iter)) {
     LeptonObject *obj = (LeptonObject *) iter->data;

--- a/libleptongui/src/o_slot.c
+++ b/libleptongui/src/o_slot.c
@@ -126,7 +126,7 @@ void o_slot_end(GschemToplevel *w_current, LeptonObject *object, const char *str
                                       10,
                                       INVISIBLE,
                                       SHOW_NAME_VALUE);
-    s_page_append (toplevel->page_current, new_obj);
+    lepton_page_append (toplevel->page_current, new_obj);
 
     /* manually attach attribute */
     o_attrib_attach (new_obj, object, FALSE);

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -471,9 +471,9 @@ o_undo_callback (GschemToplevel *w_current,
 
   } else if (w_current->undo_type == UNDO_MEMORY && u_current->object_list) {
 
-    s_page_append_list (page,
-                        o_glist_copy_all (u_current->object_list,
-                                          NULL));
+    lepton_page_append_list (page,
+                             o_glist_copy_all (u_current->object_list,
+                                               NULL));
   }
 
   page->page_control = u_current->page_control;

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -502,7 +502,7 @@ o_undo_callback (GschemToplevel *w_current,
   do_logging = save_logging;
 
   /* set filename right */
-  s_page_set_filename (page, save_filename);
+  lepton_page_set_filename (page, save_filename);
   g_free(save_filename);
 
   /* final redraw */

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -175,10 +175,10 @@ o_undo_savestate (GschemToplevel *w_current,
     /* f_save manages the creaton of backup copies.
        This way, f_save is called only when saving a file, and not when
        saving an undo backup copy */
-    o_save (s_page_objects (page), filename, NULL);
+    o_save (lepton_page_objects (page), filename, NULL);
 
   } else if (w_current->undo_type == UNDO_MEMORY && flag == UNDO_ALL) {
-    object_list = o_glist_copy_all (s_page_objects (page),
+    object_list = o_glist_copy_all (lepton_page_objects (page),
                                     object_list);
   }
 

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -448,7 +448,7 @@ o_undo_callback (GschemToplevel *w_current,
   if ((w_current->undo_type == UNDO_DISK && u_current->filename) ||
       (w_current->undo_type == UNDO_MEMORY && u_current->object_list)) {
     /* delete objects of page */
-    s_page_delete_objects (page);
+    lepton_page_delete_objects (page);
 
     /* Free the objects in the place list. */
     lepton_object_list_delete (page->place_list);

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -433,7 +433,7 @@ o_undo_callback (GschemToplevel *w_current,
   }
 
   /* save filename */
-  save_filename = g_strdup (s_page_get_filename (page));
+  save_filename = g_strdup (lepton_page_get_filename (page));
 
   /* save structure so it's not nuked */
   save_bottom = page->undo_bottom;

--- a/libleptongui/src/page_select_widget.c
+++ b/libleptongui/src/page_select_widget.c
@@ -742,8 +742,8 @@ pagesel_update (PageSelectWidget* pagesel)
     p_current = (LeptonPage *)iter->data;
     /* find every page that is not a hierarchy-down of another page */
     if (p_current->up < 0 ||
-        s_page_search_by_page_id (toplevel->pages,
-                                  p_current->up) == NULL) {
+        lepton_toplevel_search_page_by_id (toplevel->pages,
+                                           p_current->up) == NULL) {
       add_page (model, NULL, toplevel->pages, p_current, pagesel);
     }
   }

--- a/libleptongui/src/page_select_widget.c
+++ b/libleptongui/src/page_select_widget.c
@@ -167,7 +167,9 @@ page_select_widget_update (GschemToplevel* w_current)
     return;
   }
 
-  i_set_filename (w_current, s_page_get_filename (page), page->CHANGED);
+  i_set_filename (w_current,
+                  lepton_page_get_filename (page),
+                  page->CHANGED);
 
   if (x_tabs_enabled())
   {
@@ -630,7 +632,7 @@ add_page (GtkTreeModel *model,
                          &iter,
                          parent);
 
-  const gchar* page_filename = s_page_get_filename (page);
+  const gchar* page_filename = lepton_page_get_filename (page);
   gchar* display_filename = pagesel->show_paths_
                             ? g_strdup (page_filename)
                             : g_path_get_basename (page_filename);

--- a/libleptongui/src/schematic_hierarchy.c
+++ b/libleptongui/src/schematic_hierarchy.c
@@ -111,7 +111,7 @@ s_hierarchy_down_schematic_single (GschemToplevel *w_current,
         return found;
       }
 
-      found = s_page_new (toplevel, string);
+      found = lepton_page_new (toplevel, string);
 
       schematic_file_open (w_current,
                            found,
@@ -122,7 +122,7 @@ s_hierarchy_down_schematic_single (GschemToplevel *w_current,
 
   case HIERARCHY_FORCE_LOAD:
     {
-      found = s_page_new (toplevel, string);
+      found = lepton_page_new (toplevel, string);
       schematic_file_open (w_current,
                            found,
                            lepton_page_get_filename (found),
@@ -179,7 +179,7 @@ s_hierarchy_down_symbol (GschemToplevel *w_current,
     return;
   }
 
-  page = s_page_new (toplevel, filename);
+  page = lepton_page_new (toplevel, filename);
   g_free(filename);
 
   s_page_goto (toplevel, page);
@@ -268,7 +268,7 @@ s_hierarchy_load_subpage (GschemToplevel *w_current,
     if (subpage == NULL) {
       int success;
 
-      subpage = s_page_new (page->toplevel, string);
+      subpage = lepton_page_new (page->toplevel, string);
       success = schematic_file_open (w_current,
                                      subpage,
                                      lepton_page_get_filename (subpage),

--- a/libleptongui/src/schematic_hierarchy.c
+++ b/libleptongui/src/schematic_hierarchy.c
@@ -94,7 +94,7 @@ s_hierarchy_down_schematic_single (GschemToplevel *w_current,
         /* check whether this page is in the parents list */
         for (forbear = parent;
              forbear != NULL && found->pid != forbear->pid && forbear->up >= 0;
-             forbear = s_page_search_by_page_id (toplevel->pages, forbear->up))
+             forbear = lepton_toplevel_search_page_by_id (toplevel->pages, forbear->up))
           ; /* void */
 
         if (forbear != NULL && found->pid == forbear->pid) {
@@ -219,7 +219,7 @@ s_hierarchy_find_up_page (LeptonPageList *page_list,
     return NULL;
   }
 
-  return s_page_search_by_page_id (page_list, current_page->up);
+  return lepton_toplevel_search_page_by_id (page_list, current_page->up);
 }
 
 

--- a/libleptongui/src/schematic_hierarchy.c
+++ b/libleptongui/src/schematic_hierarchy.c
@@ -87,7 +87,7 @@ s_hierarchy_down_schematic_single (GschemToplevel *w_current,
   case HIERARCHY_NORMAL_LOAD:
     {
       gchar *filename = f_normalize_filename (string, NULL);
-      found = s_page_search (toplevel, filename);
+      found = lepton_toplevel_search_page (toplevel, filename);
       g_free (filename);
 
       if (found) {
@@ -168,7 +168,7 @@ s_hierarchy_down_symbol (GschemToplevel *w_current,
 
   filename = s_clib_symbol_get_filename (symbol);
 
-  page = s_page_search (toplevel, filename);
+  page = lepton_toplevel_search_page (toplevel, filename);
   if (page) {
     /* change link to parent page since we
      * can come here from any parent and must
@@ -263,7 +263,7 @@ s_hierarchy_load_subpage (GschemToplevel *w_current,
     string = scm_to_utf8_string (string_s);
     gchar *normalized = f_normalize_filename (string, error);
 
-    subpage = s_page_search (page->toplevel, normalized);
+    subpage = lepton_toplevel_search_page (page->toplevel, normalized);
 
     if (subpage == NULL) {
       int success;

--- a/libleptongui/src/schematic_hierarchy.c
+++ b/libleptongui/src/schematic_hierarchy.c
@@ -102,7 +102,7 @@ s_hierarchy_down_schematic_single (GschemToplevel *w_current,
                        _("Hierarchy contains a circular dependency."));
           return NULL;  /* error signal */
         }
-        s_page_goto (toplevel, found);
+        lepton_toplevel_goto_page (toplevel, found);
         if (page_control != 0) {
           found->page_control = page_control;
         }
@@ -174,7 +174,7 @@ s_hierarchy_down_symbol (GschemToplevel *w_current,
      * can come here from any parent and must
      * come back to the same page */
     page->up = parent->pid;
-    s_page_goto (toplevel, page);
+    lepton_toplevel_goto_page (toplevel, page);
     g_free (filename);
     return;
   }
@@ -182,7 +182,7 @@ s_hierarchy_down_symbol (GschemToplevel *w_current,
   page = lepton_page_new (toplevel, filename);
   g_free(filename);
 
-  s_page_goto (toplevel, page);
+  lepton_toplevel_goto_page (toplevel, page);
 
   schematic_file_open (w_current,
                        page,

--- a/libleptongui/src/schematic_hierarchy.c
+++ b/libleptongui/src/schematic_hierarchy.c
@@ -113,14 +113,20 @@ s_hierarchy_down_schematic_single (GschemToplevel *w_current,
 
       found = s_page_new (toplevel, string);
 
-      schematic_file_open (w_current, found, s_page_get_filename (found), NULL);
+      schematic_file_open (w_current,
+                           found,
+                           lepton_page_get_filename (found),
+                           NULL);
     }
     break;
 
   case HIERARCHY_FORCE_LOAD:
     {
       found = s_page_new (toplevel, string);
-      schematic_file_open (w_current, found, s_page_get_filename (found), NULL);
+      schematic_file_open (w_current,
+                           found,
+                           lepton_page_get_filename (found),
+                           NULL);
     }
     break;
 
@@ -178,7 +184,10 @@ s_hierarchy_down_symbol (GschemToplevel *w_current,
 
   s_page_goto (toplevel, page);
 
-  schematic_file_open (w_current, page, s_page_get_filename (page), NULL);
+  schematic_file_open (w_current,
+                       page,
+                       lepton_page_get_filename (page),
+                       NULL);
 
   page->up = parent->pid;
   page_control_counter++;
@@ -260,7 +269,10 @@ s_hierarchy_load_subpage (GschemToplevel *w_current,
       int success;
 
       subpage = s_page_new (page->toplevel, string);
-      success = schematic_file_open (w_current, subpage, s_page_get_filename (subpage), error);
+      success = schematic_file_open (w_current,
+                                     subpage,
+                                     lepton_page_get_filename (subpage),
+                                     error);
 
       if (success) {
         subpage->page_control = ++page_control_counter;
@@ -385,7 +397,7 @@ s_hierarchy_print_page (LeptonPage *p_current,
                         void * data)
 {
   printf("pagefilename: %s pageid: %d\n",
-         s_page_get_filename (p_current), p_current->pid);
+         lepton_page_get_filename (p_current), p_current->pid);
   return 0;
 }
 

--- a/libleptongui/src/schematic_hierarchy.c
+++ b/libleptongui/src/schematic_hierarchy.c
@@ -277,7 +277,7 @@ s_hierarchy_load_subpage (GschemToplevel *w_current,
       if (success) {
         subpage->page_control = ++page_control_counter;
       } else {
-        s_page_delete (page->toplevel, subpage);
+        lepton_page_delete (page->toplevel, subpage);
         subpage = NULL;
       }
     }

--- a/libleptongui/src/schematic_hierarchy.c
+++ b/libleptongui/src/schematic_hierarchy.c
@@ -334,7 +334,7 @@ s_hierarchy_traversepages (GschemToplevel *w_current,
   }
 
   /* walk throught the page objects and search for underlaying schematics */
-  for (iter = s_page_objects (p_current);
+  for (iter = lepton_page_objects (p_current);
        iter != NULL ;
        iter = g_list_next (iter)) {
     o_current = (LeptonObject *)iter->data;

--- a/libleptongui/src/x_autonumber.c
+++ b/libleptongui/src/x_autonumber.c
@@ -689,7 +689,7 @@ void autonumber_text_autonumber(AUTONUMBER_TEXT *autotext)
     searchtext = g_strndup(scope_text, strlen(scope_text)-1);
     /* collect all the possible searchtexts in all pages of the hierarchy */
     for (page_item = pages; page_item != NULL; page_item = g_list_next(page_item)) {
-      s_page_goto (w_current->toplevel, (LeptonPage*) page_item->data);
+      lepton_toplevel_goto_page (w_current->toplevel, (LeptonPage*) page_item->data);
       gschem_toplevel_page_changed (w_current);
       /* iterate over all objects an look for matching searchtext's */
       for (iter = s_page_objects (w_current->toplevel->page_current);
@@ -745,7 +745,8 @@ void autonumber_text_autonumber(AUTONUMBER_TEXT *autotext)
             && autotext->scope_overwrite)) {
         for (page_item = pages; page_item != NULL; page_item = g_list_next(page_item)) {
           autotext->root_page = (pages->data == page_item->data);
-          s_page_goto(w_current->toplevel, (LeptonPage*) page_item->data);
+          lepton_toplevel_goto_page (w_current->toplevel,
+                                     (LeptonPage*) page_item->data);
           gschem_toplevel_page_changed (w_current);
           autonumber_get_used(w_current, autotext);
         }
@@ -754,7 +755,8 @@ void autonumber_text_autonumber(AUTONUMBER_TEXT *autotext)
 
     /* renumber the elements */
     for (page_item = pages; page_item != NULL; page_item = g_list_next(page_item)) {
-      s_page_goto(w_current->toplevel, (LeptonPage*) page_item->data);
+      lepton_toplevel_goto_page (w_current->toplevel,
+                                 (LeptonPage*) page_item->data);
       gschem_toplevel_page_changed (w_current);
       autotext->root_page = (pages->data == page_item->data);
       /* build a page database if we're numbering pagebypage or selection only*/
@@ -825,7 +827,8 @@ void autonumber_text_autonumber(AUTONUMBER_TEXT *autotext)
   /* cleanup and redraw all*/
   g_list_foreach(searchtext_list, (GFunc) g_free, NULL);
   g_list_free(searchtext_list);
-  s_page_goto(w_current->toplevel, (LeptonPage*) pages->data); /* go back to the root page */
+  lepton_toplevel_goto_page (w_current->toplevel,
+                             (LeptonPage*) pages->data); /* go back to the root page */
   gschem_toplevel_page_changed (w_current);
   gschem_page_view_invalidate_all (gschem_toplevel_get_current_page_view (w_current));
   g_list_free(pages);

--- a/libleptongui/src/x_autonumber.c
+++ b/libleptongui/src/x_autonumber.c
@@ -393,7 +393,7 @@ void autonumber_get_used(GschemToplevel *w_current, AUTONUMBER_TEXT *autotext)
   char *numslot_str, *slot_str;
   const GList *iter;
 
-  for (iter = s_page_objects (w_current->toplevel->page_current);
+  for (iter = lepton_page_objects (w_current->toplevel->page_current);
        iter != NULL;
        iter = g_list_next (iter)) {
     o_current = (LeptonObject*) iter->data;
@@ -692,7 +692,7 @@ void autonumber_text_autonumber(AUTONUMBER_TEXT *autotext)
       lepton_toplevel_goto_page (w_current->toplevel, (LeptonPage*) page_item->data);
       gschem_toplevel_page_changed (w_current);
       /* iterate over all objects an look for matching searchtext's */
-      for (iter = s_page_objects (w_current->toplevel->page_current);
+      for (iter = lepton_page_objects (w_current->toplevel->page_current);
            iter != NULL;
            iter = g_list_next (iter)) {
         o_current = (LeptonObject*) iter->data;
@@ -766,7 +766,7 @@ void autonumber_text_autonumber(AUTONUMBER_TEXT *autotext)
 
       /* RENUMBER CODE FOR ONE PAGE AND ONE SEARCHTEXT*/
       /* 1. get objects to renumber */
-      for (iter = s_page_objects (w_current->toplevel->page_current);
+      for (iter = lepton_page_objects (w_current->toplevel->page_current);
            iter != NULL;
            iter = g_list_next (iter)) {
         o_current = (LeptonObject*) iter->data;

--- a/libleptongui/src/x_compselect.c
+++ b/libleptongui/src/x_compselect.c
@@ -473,8 +473,7 @@ update_attributes_model (Compselect *compselect,
     return;
   }
 
-  o_attrlist = o_attrib_find_floating_attribs (
-                              s_page_objects (preview_toplevel->page_current));
+  o_attrlist = o_attrib_find_floating_attribs (lepton_page_objects (preview_toplevel->page_current));
 
   cfg = eda_config_get_context_for_path (lepton_page_get_filename (preview_toplevel->page_current));
   filter_list = eda_config_get_string_list (cfg, "schematic.library",

--- a/libleptongui/src/x_compselect.c
+++ b/libleptongui/src/x_compselect.c
@@ -476,7 +476,7 @@ update_attributes_model (Compselect *compselect,
   o_attrlist = o_attrib_find_floating_attribs (
                               s_page_objects (preview_toplevel->page_current));
 
-  cfg = eda_config_get_context_for_path (s_page_get_filename (preview_toplevel->page_current));
+  cfg = eda_config_get_context_for_path (lepton_page_get_filename (preview_toplevel->page_current));
   filter_list = eda_config_get_string_list (cfg, "schematic.library",
                                             "component-attributes", &n, NULL);
 
@@ -856,7 +856,7 @@ create_lib_tree_model (Compselect *compselect)
   GtkTreeStore *store;
   GList *srchead, *srclist;
   LeptonPage *page = GSCHEM_DIALOG(compselect)->w_current->toplevel->page_current;
-  EdaConfig *cfg = eda_config_get_context_for_path (s_page_get_filename (page));
+  EdaConfig *cfg = eda_config_get_context_for_path (lepton_page_get_filename (page));
   gboolean sort = eda_config_get_boolean (cfg, "schematic.library", "sort", NULL);
 
   store = (GtkTreeStore*)gtk_tree_store_new (3, G_TYPE_POINTER,

--- a/libleptongui/src/x_dialog.c
+++ b/libleptongui/src/x_dialog.c
@@ -316,7 +316,7 @@ major_changed_dialog (GschemToplevel* w_current)
 
   /* label with page basename:
   */
-  const gchar* fname = s_page_get_filename (page);
+  const gchar* fname = lepton_page_get_filename (page);
   gchar* bname = g_path_get_basename (fname);
   gchar* text = g_strdup_printf(_("Schematic: %s"), bname);
   g_free (bname);

--- a/libleptongui/src/x_fileselect.c
+++ b/libleptongui/src/x_fileselect.c
@@ -446,7 +446,7 @@ x_fileselect_save (GschemToplevel *w_current,
   /* add file filters to dialog:
   */
   setup_filters (GTK_FILE_CHOOSER (dialog));
-  const gchar* fname = s_page_get_filename (page);
+  const gchar* fname = lepton_page_get_filename (page);
 
   if (filename_sch (fname))
   {

--- a/libleptongui/src/x_image.c
+++ b/libleptongui/src/x_image.c
@@ -774,11 +774,11 @@ GdkPixbuf
   gboolean show_hidden_text =
     gschem_toplevel_get_show_hidden_text (w_current);
 
-  obj_list = s_page_objects_in_regions (NULL, /* unused 'toplevel' parameter */
-                                        page,
-                                        world_rect,
-                                        1,
-                                        show_hidden_text);
+  obj_list = lepton_page_objects_in_regions (NULL, /* unused 'toplevel' parameter */
+                                             page,
+                                             world_rect,
+                                             1,
+                                             show_hidden_text);
 
   g_free (world_rect);
 

--- a/libleptongui/src/x_image.c
+++ b/libleptongui/src/x_image.c
@@ -310,7 +310,7 @@ x_image_update_dialog_filename (GtkComboBoxText *combo,
   /* Get the previous file name. If none, revert to the page filename */
   old_image_filename = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(file_chooser));
   if (!old_image_filename) {
-    old_image_filename = s_page_get_filename (toplevel->page_current);
+    old_image_filename = lepton_page_get_filename (toplevel->page_current);
   }
 
   /* Get the file name, without extension */

--- a/libleptongui/src/x_multiattrib.c
+++ b/libleptongui/src/x_multiattrib.c
@@ -678,7 +678,7 @@ multiattrib_action_promote_attributes (Multiattrib *multiattrib,
     } else {
         /* make a copy of the attribute object */
         o_new = lepton_object_copy (o_attrib);
-        s_page_append (toplevel->page_current, o_new);
+        lepton_page_append (toplevel->page_current, o_new);
         /* add the attribute its parent */
         o_attrib_attach (o_new, lepton_object_get_parent (o_attrib), TRUE);
         /* note: this object is unselected (not added to selection). */

--- a/libleptongui/src/x_print.c
+++ b/libleptongui/src/x_print.c
@@ -92,7 +92,7 @@ x_print_default_page_setup (LeptonToplevel *toplevel,
   } else if (orientation == NULL
              || g_strcmp0 (orientation, "auto") == 0) {
     /* Automatically choose the orientation that fits best */
-    status = world_get_object_glist_bounds (s_page_objects (page),
+    status = world_get_object_glist_bounds (lepton_page_objects (page),
                                             /* Don't include hidden objects */
                                             FALSE,
                                             &wx_min, &wy_min, &wx_max, &wy_max);
@@ -147,7 +147,7 @@ x_print_draw_page (LeptonToplevel *toplevel,
   /* First, calculate a transformation matrix for the cairo
    * context. We want to center the extents of the page in the
    * available page area. */
-  status = world_get_object_glist_bounds (s_page_objects (page),
+  status = world_get_object_glist_bounds (lepton_page_objects (page),
                                           /* Don't include hidden objects. */
                                           FALSE,
                                           &wx_min,
@@ -217,12 +217,12 @@ x_print_draw_page (LeptonToplevel *toplevel,
   cairo_paint (cr);
 
   /* Draw all objects and cues */
-  for (iter = (GList *) s_page_objects (page);
+  for (iter = (GList *) lepton_page_objects (page);
        iter != NULL;
        iter = g_list_next (iter)) {
     eda_renderer_draw (renderer, (LeptonObject *) iter->data);
   }
-  for (iter = (GList *) s_page_objects (page);
+  for (iter = (GList *) lepton_page_objects (page);
        iter != NULL;
        iter = g_list_next (iter)) {
     eda_renderer_draw_cues (renderer, (LeptonObject *) iter->data);
@@ -361,7 +361,7 @@ x_print_export_pdf (GschemToplevel *w_current,
   /* First, calculate a transformation matrix for the cairo
    * context. We want to center the extents of the page in the
    * available page area. */
-  status = world_get_object_glist_bounds (s_page_objects (w_current->toplevel->page_current),
+  status = world_get_object_glist_bounds (lepton_page_objects (w_current->toplevel->page_current),
                                           /* Don't include hidden objects. */
                                           FALSE,
                                           &wx_min, &wy_min, &wx_max, &wy_max);

--- a/libleptongui/src/x_print.c
+++ b/libleptongui/src/x_print.c
@@ -73,7 +73,7 @@ x_print_default_page_setup (LeptonToplevel *toplevel,
   gchar *paper, *orientation;
 
   /* Get configuration values */
-  cfg =         eda_config_get_context_for_path (s_page_get_filename (page));
+  cfg = eda_config_get_context_for_path (lepton_page_get_filename (page));
   paper =       eda_config_get_string (cfg, CFG_GROUP_PRINTING,
                                        CFG_KEY_PRINTING_PAPER, NULL);
   orientation = eda_config_get_string (cfg, CFG_GROUP_PRINTING,
@@ -262,7 +262,7 @@ draw_page__print_operation (GtkPrintOperation *print,
   height = gtk_print_context_get_height (context);
 
   /* Find out if colour printing is enabled */
-  cfg = eda_config_get_context_for_path (s_page_get_filename (page));
+  cfg = eda_config_get_context_for_path (lepton_page_get_filename (page));
   is_color = !eda_config_get_boolean (cfg, CFG_GROUP_PRINTING,
                                       CFG_KEY_PRINTING_MONOCHROME, NULL);
 
@@ -312,7 +312,7 @@ x_print_export_pdf_page (GschemToplevel *w_current,
   height = gtk_page_setup_get_page_height (setup, GTK_UNIT_POINTS);
 
   /* Find out if colour printing is enabled */
-  cfg = eda_config_get_context_for_path (s_page_get_filename (page));
+  cfg = eda_config_get_context_for_path (lepton_page_get_filename (page));
   is_color = !eda_config_get_boolean (cfg, CFG_GROUP_PRINTING,
                                       CFG_KEY_PRINTING_MONOCHROME, NULL);
 
@@ -446,7 +446,7 @@ x_print (GschemToplevel *w_current)
   LeptonPage* page = w_current->toplevel->page_current;
   if (page != NULL)
   {
-    const gchar* path = s_page_get_filename (page);
+    const gchar* path = lepton_page_get_filename (page);
     gchar* uri = g_strdup_printf ("file://%s.pdf", path);
 
     gtk_print_settings_set (settings, "output-uri", uri);

--- a/libleptongui/src/x_tabs.c
+++ b/libleptongui/src/x_tabs.c
@@ -420,7 +420,8 @@ x_tabs_dbg_pages_dump_simple (GschemToplevel* w_current)
         node = g_list_next( node ) )
   {
     LeptonPage* p = node->data;
-    printf( "    p: [%s]\n", g_path_get_basename( s_page_get_filename(p) ) );
+    printf ("    p: [%s]\n",
+            g_path_get_basename (lepton_page_get_filename (p)));
   }
 
   printf( "\n" );
@@ -834,7 +835,7 @@ x_tabs_hdr_create (TabInfo* nfo)
 
   /* label:
   */
-  const gchar* fname = s_page_get_filename (nfo->page_);
+  const gchar* fname = lepton_page_get_filename (nfo->page_);
   g_return_val_if_fail (fname != NULL, NULL);
 
   gchar* bname = g_path_get_basename (fname);
@@ -967,7 +968,7 @@ x_tabs_hdr_create (TabInfo* nfo)
 
   if (x_tabs_show_up_button() && parent != NULL)
   {
-    const gchar* parent_fname = s_page_get_filename (parent);
+    const gchar* parent_fname = lepton_page_get_filename (parent);
     gchar*       parent_bname = NULL;
     gchar*       ttip_btn_up  = NULL;
 
@@ -1704,8 +1705,8 @@ x_tabs_hdr_on_mouse_click (GtkWidget* hdr, GdkEvent* e, gpointer data)
   }
 
 #ifdef DEBUG
-  printf( "p: [%s]\n",   g_path_get_basename( s_page_get_filename(nfo->page_) ) );
-  printf( "C: [%s]\n\n", g_path_get_basename( s_page_get_filename(nfocur->page_) ) );
+  printf ("p: [%s]\n",   g_path_get_basename (lepton_page_get_filename(nfo->page_)));
+  printf ("C: [%s]\n\n", g_path_get_basename (lepton_page_get_filename(nfocur->page_)));
 #endif
 
   GdkEventButton* ebtn = (GdkEventButton*) e;

--- a/libleptongui/src/x_tabs.c
+++ b/libleptongui/src/x_tabs.c
@@ -1380,7 +1380,7 @@ x_tabs_page_open (GschemToplevel* w_current, const gchar* filename)
 
   LeptonPage* page = NULL;
   if (filename != NULL)
-    page = s_page_search (w_current->toplevel, filename);
+    page = lepton_toplevel_search_page (w_current->toplevel, filename);
 
 
   /* XXX: 2: [!pview] [!page] - either:

--- a/libleptongui/src/x_tabs.c
+++ b/libleptongui/src/x_tabs.c
@@ -585,9 +585,10 @@ static void
 x_tabs_tl_page_cur_set (GschemToplevel* w_current,
                         LeptonPage* page)
 {
-  s_page_goto (w_current->toplevel, page);
+  lepton_toplevel_goto_page (w_current->toplevel, page);
 
-  /* NOTE: gschem_toplevel_page_changed() after s_page_goto():
+  /* NOTE: gschem_toplevel_page_changed() after
+   * lepton_toplevel_goto_page():
   */
   gschem_toplevel_page_changed (w_current);
 }

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -747,7 +747,7 @@ x_window_open_page_impl (GschemToplevel *w_current,
 
 
   /* Create a new page: */
-  page = s_page_new (toplevel, filename);
+  page = lepton_page_new (toplevel, filename);
 
   /* Switch to a new page: */
   s_page_goto (toplevel, page); /* NOTE: sets toplevel->page_current */
@@ -1563,7 +1563,7 @@ x_window_new_page (GschemToplevel* w_current)
   gchar* filename = untitled_filename (w_current, TRUE);
 
   /* Create a new page: */
-  LeptonPage* page = s_page_new (toplevel, filename);
+  LeptonPage* page = lepton_page_new (toplevel, filename);
 
   /* Switch to a new page: */
   s_page_goto (toplevel, page);

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -750,7 +750,7 @@ x_window_open_page_impl (GschemToplevel *w_current,
   page = lepton_page_new (toplevel, filename);
 
   /* Switch to a new page: */
-  s_page_goto (toplevel, page); /* NOTE: sets toplevel->page_current */
+  lepton_toplevel_goto_page (toplevel, page); /* NOTE: sets toplevel->page_current */
   gschem_toplevel_page_changed (w_current);
 
   if (!quiet_mode)
@@ -1566,7 +1566,7 @@ x_window_new_page (GschemToplevel* w_current)
   LeptonPage* page = lepton_page_new (toplevel, filename);
 
   /* Switch to a new page: */
-  s_page_goto (toplevel, page);
+  lepton_toplevel_goto_page (toplevel, page);
   gschem_toplevel_page_changed (w_current);
 
   if (!quiet_mode)

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -870,7 +870,8 @@ x_window_save_page (GschemToplevel *w_current,
   } else {
     /* successful save of page to file, update page... */
     /* change page name if necessary and prepare log message */
-    if (g_ascii_strcasecmp (s_page_get_filename (page), filename) != 0) {
+    if (g_ascii_strcasecmp (lepton_page_get_filename (page), filename) != 0)
+    {
       s_page_set_filename (page, filename);
 
       log_msg = _("Saved as [%1$s]");
@@ -956,7 +957,7 @@ x_window_close_page_impl (GschemToplevel *w_current,
 
   g_message (page->CHANGED ?
              _("Discarding page [%1$s]") : _("Closing [%1$s]"),
-             s_page_get_filename (page));
+             lepton_page_get_filename (page));
   /* remove page from toplevel list of page and free */
   s_page_delete (toplevel, page);
   gschem_toplevel_page_changed (w_current);
@@ -1754,7 +1755,7 @@ x_window_untitled_page (LeptonPage* page)
 {
   g_return_val_if_fail (page != NULL, TRUE);
 
-  const gchar* fname = s_page_get_filename (page);
+  const gchar* fname = lepton_page_get_filename (page);
   gchar* uname = NULL;
 
   EdaConfig* cfg = eda_config_get_context_for_path (fname);

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -766,7 +766,7 @@ x_window_open_page_impl (GschemToplevel *w_current,
     g_clear_error (&err);
 
     /* Loading failed: delete page and open a blank one: */
-    s_page_delete (toplevel, page);
+    lepton_page_delete (toplevel, page);
     return x_window_new_page (w_current);
   }
 
@@ -959,7 +959,7 @@ x_window_close_page_impl (GschemToplevel *w_current,
              _("Discarding page [%1$s]") : _("Closing [%1$s]"),
              lepton_page_get_filename (page));
   /* remove page from toplevel list of page and free */
-  s_page_delete (toplevel, page);
+  lepton_page_delete (toplevel, page);
   gschem_toplevel_page_changed (w_current);
 
   /* Switch to a different page if we just removed the current */

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -937,7 +937,7 @@ x_window_close_page_impl (GschemToplevel *w_current,
   if (page == toplevel->page_current) {
     /* as it will delete current page, select new current page */
     /* first look up in page hierarchy */
-    new_current = s_page_search_by_page_id (toplevel->pages, page->up);
+    new_current = lepton_toplevel_search_page_by_id (toplevel->pages, page->up);
 
     if (new_current == NULL) {
       /* no up in hierarchy, choice is prev, next, new page */

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -1713,7 +1713,7 @@ untitled_filename (GschemToplevel* w_current, gboolean log_skipped)
     /* Avoid reusing names of already opened files:
     *  Avoid reusing names of existing files in current directory:
     */
-    if ( s_page_search_by_basename (toplevel, fname) ||
+    if ( lepton_toplevel_search_page_by_basename (toplevel, fname) ||
          g_file_test (fpath, G_FILE_TEST_EXISTS) )
     {
       if (log_skipped)

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -360,7 +360,7 @@ x_window_hide_text (GtkWidget *widget, gint response, GschemToplevel *w_current)
 
   if (response == GTK_RESPONSE_OK) {
     o_edit_hide_specific_text (w_current,
-                               s_page_objects (w_current->toplevel->page_current),
+                               lepton_page_objects (w_current->toplevel->page_current),
                                gschem_show_hide_text_widget_get_text_string (GSCHEM_SHOW_HIDE_TEXT_WIDGET (widget)));
   }
 
@@ -377,7 +377,7 @@ x_window_show_text (GtkWidget *widget, gint response, GschemToplevel *w_current)
 
   if (response == GTK_RESPONSE_OK) {
     o_edit_show_specific_text (w_current,
-                               s_page_objects (w_current->toplevel->page_current),
+                               lepton_page_objects (w_current->toplevel->page_current),
                                gschem_show_hide_text_widget_get_text_string (GSCHEM_SHOW_HIDE_TEXT_WIDGET (widget)));
   }
 

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -121,7 +121,7 @@ x_window_setup (GschemToplevel *w_current)
   i_vars_set(w_current);
 
   /* Initialize the autosave callback */
-  s_page_autosave_init(toplevel);
+  lepton_toplevel_init_autosave (toplevel);
 
   /* Initialize the clipboard callback */
   x_clipboard_init (w_current);

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -872,7 +872,7 @@ x_window_save_page (GschemToplevel *w_current,
     /* change page name if necessary and prepare log message */
     if (g_ascii_strcasecmp (lepton_page_get_filename (page), filename) != 0)
     {
-      s_page_set_filename (page, filename);
+      lepton_page_set_filename (page, filename);
 
       log_msg = _("Saved as [%1$s]");
     } else {

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -741,7 +741,7 @@ x_window_open_page_impl (GschemToplevel *w_current,
 
 
   /* Return existing page if it is already loaded: */
-  LeptonPage* page = s_page_search (toplevel, filename);
+  LeptonPage* page = lepton_toplevel_search_page (toplevel, filename);
   if (page != NULL)
     return page;
 

--- a/utils/cli/src/export.c
+++ b/utils/cli/src/export.c
@@ -343,7 +343,7 @@ export_layout_page (LeptonPage *page,
 
   /* Now calculate extents of objects within page. Hidden text is
      not taken into account. */
-  world_get_object_glist_bounds (s_page_objects (page),
+  world_get_object_glist_bounds (lepton_page_objects (page),
                                  FALSE,
                                  &wx_min,
                                  &wy_min,
@@ -466,7 +466,7 @@ export_draw_page (LeptonPage *page)
   cairo_paint (cr);
 
   /* Draw objects & cues */
-  contents = s_page_objects (page);
+  contents = lepton_page_objects (page);
   for (iter = (GList *) contents; iter != NULL; iter = g_list_next (iter))
     eda_renderer_draw (renderer, (LeptonObject *) iter->data);
   for (iter = (GList *) contents; iter != NULL; iter = g_list_next (iter))

--- a/utils/cli/src/export.c
+++ b/utils/cli/src/export.c
@@ -264,7 +264,7 @@ cmd_export_impl (void *data, int argc, char **argv)
     LeptonPage *page;
     tmp = argv[optind++];
 
-    page = s_page_new (toplevel, tmp);
+    page = lepton_page_new (toplevel, tmp);
     if (!f_open (toplevel, page, tmp, &err)) {
       fprintf (stderr,
                /* TRANSLATORS: The first string is the filename, the second


### PR DESCRIPTION
Several `s_page*()` functions have been renamed, some of them now live in `toplevel.c`, some unused ones have been removed.