### PR TITLE
Drop support for Guile 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
 before_install:
   - sudo apt-get update
   - sudo apt-get install -y libgtk2.0-dev autopoint libgettextpo-dev
-    libstroke0-dev guile-2.0-dev flex bison groff texinfo texlive-base
+    libstroke0-dev guile-2.2-dev flex bison groff texinfo texlive-base
     texlive-generic-recommended texlive-latex-base texlive-fonts-recommended
     libgtkextra-dev
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ installed:
   <http://pkgconfig.freedesktop.org/>
 
 - Guile ("GNU's Ubiquitous Intelligent Language for Extensions"),
-  version 2.0.0 or later.  <http://www.gnu.org/software/guile/>
+  version 2.2.0 or later.  <http://www.gnu.org/software/guile/>
 
 - GTK+ (the Gimp Toolkit), version 2.24.0 or later.
   <http://www.gtk.org/>
@@ -159,7 +159,7 @@ necessary `dev` or `devel` packages installed.
 
 Specify right `guile` binary on the `configure` stage, e.g.:
 
-    ./configure GUILE=/usr/bin/guile-2.0
+    ./configure GUILE=/usr/bin/guile-2.2
 
 Installation from a source archive
 ----------------------------------

--- a/configure.ac
+++ b/configure.ac
@@ -75,7 +75,7 @@ AX_DESKTOP_I18N
 
 PKG_PROG_PKG_CONFIG
 
-AX_CHECK_GUILE([2.0.0])
+AX_CHECK_GUILE([2.2.0])
 
 PKG_CHECK_MODULES(GLIB, [glib-2.0 >= 2.38.0], ,
   AC_MSG_ERROR([GLib 2.38.0 or later is required.]))

--- a/docs/manual/installation.texi
+++ b/docs/manual/installation.texi
@@ -120,7 +120,7 @@ are recommended, though you may use @command{clang} instead).
 managing shared libraries.
 @item
 @url{http://www.gnu.org/software/guile, Guile} ("GNU's Ubiquitous
-Intelligent Language for Extensions"), version 2.0.13 or later.
+Intelligent Language for Extensions"), version 2.2.0 or later.
 @item
 @url{http://www.gtk.org, GTK+} (the Gimp Toolkit), version 2.24.0 or
 later.

--- a/liblepton/scheme/lepton/ffi.scm
+++ b/liblepton/scheme/lepton/ffi.scm
@@ -688,10 +688,7 @@
 (define-syntax-rule (check-integer val pos)
   (unless (integer? val)
     (scm-error 'wrong-type-arg
-               ;; Provision against Guile-2.0 that does not have the procedure.
-               (if (defined? 'frame-procedure-name)
-                   (frame-procedure-name (stack-ref (make-stack #t) 1))
-                   '??)
+               (frame-procedure-name (stack-ref (make-stack #t) 1))
                "Wrong type argument in position ~A (expecting integer): ~A"
                (list pos val)
                #f)))
@@ -701,10 +698,7 @@
                (integer? (car val))
                (integer? (cdr val)))
     (scm-error 'wrong-type-arg
-               ;; Provision against Guile-2.0 that does not have the procedure.
-               (if (defined? 'frame-procedure-name)
-                   (frame-procedure-name (stack-ref (make-stack #t) 1))
-                   '??)
+               (frame-procedure-name (stack-ref (make-stack #t) 1))
                "Wrong type argument in position ~A (expecting a pair of integers): ~A"
                (list pos val)
                #f)))
@@ -712,10 +706,7 @@
 (define-syntax-rule (check-string val pos)
   (unless (string? val)
     (scm-error 'wrong-type-arg
-               ;; Provision against Guile-2.0 that does not have the procedure.
-               (if (defined? 'frame-procedure-name)
-                   (frame-procedure-name (stack-ref (make-stack #t) 1))
-                   '??)
+               (frame-procedure-name (stack-ref (make-stack #t) 1))
                "Wrong type argument in position ~A (expecting string): ~A"
                (list pos val)
                #f)))
@@ -723,10 +714,7 @@
 (define-syntax-rule (check-symbol val pos)
   (unless (symbol? val)
     (scm-error 'wrong-type-arg
-               ;; Provision against Guile-2.0 that does not have the procedure.
-               (if (defined? 'frame-procedure-name)
-                   (frame-procedure-name (stack-ref (make-stack #t) 1))
-                   '??)
+               (frame-procedure-name (stack-ref (make-stack #t) 1))
                "Wrong type argument in position ~A (expecting symbol): ~A"
                (list pos val)
                #f)))
@@ -735,10 +723,7 @@
   (unless (and (list? val)
                (every integer? val))
     (scm-error 'wrong-type-arg
-               ;; Provision against Guile-2.0 that does not have the procedure.
-               (if (defined? 'frame-procedure-name)
-                   (frame-procedure-name (stack-ref (make-stack #t) 1))
-                   '??)
+               (frame-procedure-name (stack-ref (make-stack #t) 1))
                "Wrong type argument in position ~A (expecting list of integers): ~A"
                (list pos val)
                #f)))

--- a/liblepton/scheme/lepton/object/type.scm
+++ b/liblepton/scheme/lepton/object/type.scm
@@ -60,11 +60,7 @@
      (let ((pointer (geda-object->pointer object)))
        (if (null-pointer? pointer)
            (let ((proc-name
-                  ;; Provision against Guile-2.0 that does not
-                  ;; have the procedure.
-                  (if (defined? 'frame-procedure-name)
-                      (frame-procedure-name (stack-ref (make-stack #t) 1))
-                      '??)))
+                  (frame-procedure-name (stack-ref (make-stack #t) 1))))
              (scm-error 'wrong-type-arg
                         proc-name
                         "Wrong type argument in position ~A: ~A"
@@ -73,12 +69,7 @@
            pointer)))
     ((_ object pos object-check-func type)
      (let ((pointer (geda-object->pointer object))
-           (proc-name
-            ;; Provision against Guile-2.0 that does not
-            ;; have the procedure.
-            (if (defined? 'frame-procedure-name)
-                (frame-procedure-name (stack-ref (make-stack #t) 1))
-                '??)))
+           (proc-name (frame-procedure-name (stack-ref (make-stack #t) 1))))
        (if (null-pointer? pointer)
            (scm-error 'wrong-type-arg
                       proc-name

--- a/liblepton/scheme/lepton/page/foreign.scm
+++ b/liblepton/scheme/lepton/page/foreign.scm
@@ -56,12 +56,7 @@ list.  Returns the Scheme list of pages."
     ((_ page pos)
      (let ((pointer (geda-page->pointer page)))
        (if (null-pointer? pointer)
-           (let ((proc-name
-                  ;; Provision against Guile-2.0 that does not
-                  ;; have the procedure.
-                  (if (defined? 'frame-procedure-name)
-                      (frame-procedure-name (stack-ref (make-stack #t) 1))
-                      '??)))
+           (let ((proc-name (frame-procedure-name (stack-ref (make-stack #t) 1))))
              (scm-error 'wrong-type-arg
                         proc-name
                         "Wrong type argument in position ~A: ~A"

--- a/m4/guile.m4
+++ b/m4/guile.m4
@@ -64,7 +64,7 @@ AC_DEFUN([GUILE_PKG],
   if test "x$PKG_CONFIG" = x; then
     AC_MSG_ERROR([pkg-config is missing, please install it])
   fi
-  _guile_versions_to_search="m4_default([$1], [3.0 2.2 2.0])"
+  _guile_versions_to_search="m4_default([$1], [3.0 2.2])"
   if test -n "$GUILE_EFFECTIVE_VERSION"; then
     _guile_tmp=""
     for v in $_guile_versions_to_search; do

--- a/m4/lepton-guile.m4
+++ b/m4/lepton-guile.m4
@@ -51,13 +51,6 @@ AC_DEFUN([AX_CHECK_GUILE],
   fi
 
   if test "${_found_pkg_config_guile}" = "no" ; then
-    PKG_CHECK_MODULES(GUILE, [guile-2.0 >= $GUILE_MIN_VER],
-                             [_found_pkg_config_guile=yes
-                              GUILE_PKG_NAME=guile-2.0],
-                             [_found_pkg_config_guile=no])
-  fi
-
-  if test "${_found_pkg_config_guile}" = "no" ; then
     AC_MSG_ERROR([you need at least version ${GUILE_MIN_VER} of guile])
   fi
 
@@ -66,7 +59,7 @@ AC_DEFUN([AX_CHECK_GUILE],
 
   GUILE_FLAGS
   GUILE_PROGS
-  GUILE_PKG([3.0 2.2 2.0])
+  GUILE_PKG([3.0 2.2])
 
 
   # Check for the `guile-snarf' build tool

--- a/utils/netlist/scheme/Makefile.am
+++ b/utils/netlist/scheme/Makefile.am
@@ -61,8 +61,6 @@ SCM_SRCS=	backend/gnet-gsch2pcb.scm.in
 
 BUILT_SCM=	backend/gnet-gsch2pcb.scm
 
-SETVBUF_MODE = `$(GUILE) -c '(display (if (and (string= (major-version) "2") (string= (minor-version) "0")) "_IONBF" (quote (quote none))))'`
-
 backend/gnet-gsch2pcb.scm: $(srcdir)/backend/gnet-gsch2pcb.scm.in
 	if test "$(srcdir)" != "@builddir@" ; then \
 		echo "creating directories" ; \
@@ -73,7 +71,6 @@ backend/gnet-gsch2pcb.scm: $(srcdir)/backend/gnet-gsch2pcb.scm.in
 	sed \
 		-e 's;@m4@;${M4};g' \
 		-e 's;@pcbm4dir@;${PCBM4DIR};g' \
-		-e "s;@mode@;${SETVBUF_MODE};g" \
 		$(srcdir)/backend/gnet-gsch2pcb.scm.in > $@
 
 CLEANFILES = backend/gnet-gsch2pcb.scm config-netlist.scm

--- a/utils/netlist/scheme/backend/gnet-gsch2pcb.scm.in
+++ b/utils/netlist/scheme/backend/gnet-gsch2pcb.scm.in
@@ -138,9 +138,6 @@
 (define-undefined gsch2pcb:pcb-m4-dir "@pcbm4dir@")
 (define-undefined gsch2pcb:m4-files "")
 
-;;; Use different port mode names for guile-2.0 and guile-2.2.
-(define setvbuf-mode @mode@)
-
 ;; Let the user override the m4 search path
 (define-undefined gsch2pcb:pcb-m4-path '("$HOME/.pcb" "."))
 
@@ -185,11 +182,10 @@
          (p2c (pipe))) ; parent to child
 
     ; setvbuf( port, mode ) function:
-    ; Guile 2.0: [mode] is an integer (either _IONBF, _IOLBF or _IOFBF)
-    ; Guile 2.2: [mode] is a  symbol  (either 'none,  'line  or 'block)
+    ; [mode] is a  symbol  (either 'none,  'line  or 'block)
     ;
-    (setvbuf (cdr c2p) setvbuf-mode)
-    (setvbuf (cdr p2c) setvbuf-mode)
+    (setvbuf (cdr c2p) 'none)
+    (setvbuf (cdr p2c) 'none)
 
     (let ((pid (primitive-fork)))
       (if (= pid 0)


### PR DESCRIPTION
Lepton's ITS already doesn't support Guile 2.0.  Since Guile 2.2 has been introduced a while ago and is widely adopted, it is time to reduce the burden on Lepton developers' shoulders and drop support for the previous stable version.  OTOH, it'll give us a chance of using more sophisticated modern Guile functions.