### PR TITLE
Improvements in color related code and a new GTK3 color chooser widget

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -101,9 +101,9 @@ fi
 AS_CASE(["$with_gtk3"],
 dnl Use GTK3.
   [yes],
-    [PKG_CHECK_MODULES(GTK, [gtk+-3.0 >= 3.2.0],
+    [PKG_CHECK_MODULES(GTK, [gtk+-3.0 >= 3.4.0],
       [WITH_GTK3=1],
-      AC_MSG_ERROR([GTK+ 3.2.0 or later is required.]))],
+      AC_MSG_ERROR([GTK+ 3.4.0 or later is required.]))],
 dnl Default case: use GTK2.
   [PKG_CHECK_MODULES(GTK, [gtk+-2.0 >= 2.24.0],
     [WITH_GTK3=0],
@@ -114,8 +114,8 @@ AM_CONDITIONAL([ENABLE_GTK3], [test "x$WITH_GTK3" = x1])
 AS_CASE(["$with_gtk3"],
 dnl Use GDK3.
   [yes],
-    [PKG_CHECK_MODULES(GDK, [gdk-3.0 >= 3.2.0], ,
-      AC_MSG_ERROR([GDK 3.2.0 or later is required.]))],
+    [PKG_CHECK_MODULES(GDK, [gdk-3.0 >= 3.4.0], ,
+      AC_MSG_ERROR([GDK 3.4.0 or later is required.]))],
 dnl Default case: use GDK2.
   [PKG_CHECK_MODULES(GDK, [gdk-2.0 >= 2.24.0], ,
     AC_MSG_ERROR([GDK+ 2.24.0 or later is required.]))])

--- a/liblepton/include/liblepton/color.h
+++ b/liblepton/include/liblepton/color.h
@@ -93,6 +93,9 @@ lepton_colormap_color_by_id (const LeptonColor *color_map,
 void
 lepton_colormap_disable_color (LeptonColor *color_map,
                                size_t id);
+gboolean
+lepton_color_enabled (const LeptonColor *color);
+
 void
 lepton_colormap_set_color (LeptonColor *color_map,
                            size_t id,

--- a/liblepton/include/liblepton/color.h
+++ b/liblepton/include/liblepton/color.h
@@ -27,7 +27,6 @@ G_BEGIN_DECLS
 struct st_color
 {
   guint8 r, g, b, a;
-  gboolean enabled;
 };
 
 typedef struct st_color LeptonColor;

--- a/liblepton/include/liblepton/color.h
+++ b/liblepton/include/liblepton/color.h
@@ -26,7 +26,7 @@ G_BEGIN_DECLS
 
 struct st_color
 {
-  guint8 r, g, b, a;
+  gdouble red, green, blue, alpha;
 };
 
 typedef struct st_color LeptonColor;

--- a/liblepton/include/liblepton/export.h
+++ b/liblepton/include/liblepton/export.h
@@ -92,4 +92,7 @@ lepton_export_settings_set_font (const char *font);
 void
 lepton_export_settings_reset_paper_size ();
 
+GArray*
+lepton_export_make_color_map (gboolean color,
+                              size_t background_color);
 G_END_DECLS

--- a/liblepton/src/color.c
+++ b/liblepton/src/color.c
@@ -107,6 +107,12 @@ lepton_colormap_disable_color (LeptonColor *color_map,
   color_map[id].enabled = FALSE;
 }
 
+gboolean
+lepton_color_enabled (const LeptonColor *color)
+{
+  return color->enabled;
+}
+
 void
 lepton_colormap_set_color (LeptonColor *color_map,
                            size_t id,

--- a/liblepton/src/color.c
+++ b/liblepton/src/color.c
@@ -35,9 +35,9 @@ LeptonColorMap display_colors;
 LeptonColorMap display_outline_colors;
 
 
-#define WHITE   {0xff, 0xff, 0xff, 0xff}
-#define GRAY    {0x88, 0x88, 0x88, 0xff}
-#define BLACK   {0x00, 0x00, 0x00, 0xff}
+#define WHITE   {1.0, 1.0, 1.0, 1.0}
+#define GRAY    {0.5, 0.5, 0.5, 1.0}
+#define BLACK   {0.0, 0.0, 0.0, 1.0}
 
 static LeptonColor default_colors[] =
 {
@@ -104,27 +104,27 @@ void
 lepton_colormap_disable_color (LeptonColor *color_map,
                                size_t id)
 {
-  color_map[id].a = 0;
+  color_map[id].alpha = 0.0;
 }
 
 gboolean
 lepton_color_enabled (const LeptonColor *color)
 {
-  return (color->a != 0);
+  return (color->alpha != 0.0);
 }
 
 void
 lepton_colormap_set_color (LeptonColor *color_map,
                            size_t id,
-                           guint8 r,
-                           guint8 g,
-                           guint8 b,
-                           guint8 a)
+                           guint8 red,
+                           guint8 green,
+                           guint8 blue,
+                           guint8 alpha)
 {
-  color_map[id].r = r;
-  color_map[id].g = g;
-  color_map[id].b = b;
-  color_map[id].a = a;
+  color_map[id].red = (gdouble) (red / 255.0);
+  color_map[id].green = (gdouble) (green / 255.0);
+  color_map[id].blue = (gdouble) (blue / 255.0);
+  color_map[id].alpha = (gdouble) (alpha / 255.0);
 }
 
 
@@ -140,7 +140,7 @@ lepton_color_get_blue_double (const LeptonColor *color)
 {
   g_return_val_if_fail (color != NULL, 1.0);
 
-  return color->b / 255.0;
+  return color->blue;
 }
 
 /*! \brief Get the color green value as a double
@@ -155,7 +155,7 @@ lepton_color_get_green_double (const LeptonColor *color)
 {
   g_return_val_if_fail (color != NULL, 1.0);
 
-  return color->g / 255.0;
+  return color->green;
 }
 
 /*! \brief Get the color red value as a double
@@ -170,7 +170,7 @@ lepton_color_get_red_double (const LeptonColor *color)
 {
   g_return_val_if_fail (color != NULL, 1.0);
 
-  return color->r / 255.0;
+  return color->red;
 }
 
 /*! \brief Get the color alpha value as a double
@@ -185,7 +185,7 @@ lepton_color_get_alpha_double (const LeptonColor *color)
 {
   g_return_val_if_fail (color != NULL, 1.0);
 
-  return color->a / 255.0;
+  return color->alpha;
 }
 
 

--- a/liblepton/src/color.c
+++ b/liblepton/src/color.c
@@ -35,9 +35,9 @@ LeptonColorMap display_colors;
 LeptonColorMap display_outline_colors;
 
 
-#define WHITE   {0xff, 0xff, 0xff, 0xff, TRUE}
-#define GRAY    {0x88, 0x88, 0x88, 0xff, TRUE}
-#define BLACK   {0x00, 0x00, 0x00, 0xff, TRUE}
+#define WHITE   {0xff, 0xff, 0xff, 0xff}
+#define GRAY    {0x88, 0x88, 0x88, 0xff}
+#define BLACK   {0x00, 0x00, 0x00, 0xff}
 
 static LeptonColor default_colors[] =
 {
@@ -104,13 +104,13 @@ void
 lepton_colormap_disable_color (LeptonColor *color_map,
                                size_t id)
 {
-  color_map[id].enabled = FALSE;
+  color_map[id].a = 0;
 }
 
 gboolean
 lepton_color_enabled (const LeptonColor *color)
 {
-  return color->enabled;
+  return (color->a != 0);
 }
 
 void
@@ -121,7 +121,6 @@ lepton_colormap_set_color (LeptonColor *color_map,
                            guint8 b,
                            guint8 a)
 {
-  color_map[id].enabled = TRUE;
   color_map[id].r = r;
   color_map[id].g = g;
   color_map[id].b = b;

--- a/liblepton/src/edacairo.c
+++ b/liblepton/src/edacairo.c
@@ -65,10 +65,10 @@ eda_cairo_set_source_color (cairo_t *cr, int color, GArray *map)
 
   c = g_array_index (map, LeptonColor, color);
 
-  cairo_set_source_rgba (cr, (double)c.r / 255.0,
-                             (double)c.g / 255.0,
-                             (double)c.b / 255.0,
-                             (double)c.a / 255.0);
+  cairo_set_source_rgba (cr, c.red,
+                             c.green,
+                             c.blue,
+                             c.alpha);
 }
 
 void

--- a/liblepton/src/edarenderer.c
+++ b/liblepton/src/edarenderer.c
@@ -545,7 +545,7 @@ eda_renderer_is_drawable_color (EdaRenderer *renderer, int color,
   g_return_val_if_fail ((color >= 0) || (color < (int) map->len), FALSE);
 
   /* Otherwise, return enabled flag of object's color */
-  return (&g_array_index (map, LeptonColor, color))->enabled;
+  return lepton_color_enabled (&g_array_index (map, LeptonColor, color));
 }
 
 static int

--- a/liblepton/src/export.c
+++ b/liblepton/src/export.c
@@ -219,7 +219,7 @@ lepton_export_set_renderer_color_map (EdaRenderer *renderer,
     LeptonColor black = {0, 0, 0, 255, TRUE};
     for (i = 0; i < colors_count(); i++) {
       LeptonColor *c = &g_array_index (render_color_map, LeptonColor, i);
-      if (!c->enabled) continue;
+      if (!lepton_color_enabled (c)) continue;
 
       if (c->a == 0) {
         c->enabled = FALSE;

--- a/liblepton/src/export.c
+++ b/liblepton/src/export.c
@@ -489,6 +489,7 @@ lepton_export_png (void)
   export_cairo_check_error (status);
 
   g_object_unref (G_OBJECT (renderer));
+  g_array_free (color_map, TRUE);
 }
 
 /* Worker function used by both lepton_export_ps and export_eps */
@@ -556,6 +557,7 @@ export_postscript (gboolean is_eps)
   cairo_surface_finish (surface);
   export_cairo_check_error (cairo_surface_status (surface));
   g_object_unref (G_OBJECT (renderer));
+  g_array_free (color_map, TRUE);
 }
 
 void
@@ -611,6 +613,7 @@ lepton_export_pdf (void)
   cairo_surface_finish (surface);
   export_cairo_check_error (cairo_surface_status (surface));
   g_object_unref (G_OBJECT (renderer));
+  g_array_free (color_map, TRUE);
 }
 
 void
@@ -656,6 +659,7 @@ lepton_export_svg ()
   export_cairo_check_error (cairo_surface_status (surface));
 
   g_object_unref (G_OBJECT (renderer));
+  g_array_free (color_map, TRUE);
 }
 
 /* Parse a distance specification. A distance specification consists

--- a/liblepton/src/export.c
+++ b/liblepton/src/export.c
@@ -199,9 +199,9 @@ lepton_export_set_renderer_font (EdaRenderer *renderer,
 }
 
 
-static void
-lepton_export_set_renderer_color_map (EdaRenderer *renderer,
-                                      gboolean color)
+GArray*
+lepton_export_make_color_map (EdaRenderer *renderer,
+                              gboolean color)
 {
   size_t i;
   GArray *render_color_map = NULL;
@@ -229,7 +229,7 @@ lepton_export_set_renderer_color_map (EdaRenderer *renderer,
       }
     }
   }
-  eda_renderer_set_color_map (renderer, render_color_map);
+  return render_color_map;
 }
 
 
@@ -439,7 +439,8 @@ lepton_export_png (void)
     lepton_export_set_renderer_font (renderer, settings.font);
   }
 
-  lepton_export_set_renderer_color_map (renderer, settings.color);
+  GArray *color_map = lepton_export_make_color_map (renderer, settings.color);
+  eda_renderer_set_color_map (renderer, color_map);
 
   /* Create a dummy context to permit calculating extents taking text
    * into account. */
@@ -501,7 +502,8 @@ export_postscript (gboolean is_eps)
     lepton_export_set_renderer_font (renderer, settings.font);
   }
 
-  lepton_export_set_renderer_color_map (renderer, settings.color);
+  GArray *color_map = lepton_export_make_color_map (renderer, settings.color);
+  eda_renderer_set_color_map (renderer, color_map);
 
   /* Create a surface. To begin with, we don't know the size. */
   surface = cairo_ps_surface_create (settings.outfile, 1, 1);
@@ -577,7 +579,8 @@ lepton_export_pdf (void)
     lepton_export_set_renderer_font (renderer, settings.font);
   }
 
-  lepton_export_set_renderer_color_map (renderer, settings.color);
+  GArray *color_map = lepton_export_make_color_map (renderer, settings.color);
+  eda_renderer_set_color_map (renderer, color_map);
 
   /* Create a surface. To begin with, we don't know the size. */
   surface = cairo_pdf_surface_create (settings.outfile, 1, 1);
@@ -615,7 +618,8 @@ lepton_export_svg ()
     lepton_export_set_renderer_font (renderer, settings.font);
   }
 
-  lepton_export_set_renderer_color_map (renderer, settings.color);
+  GArray *color_map = lepton_export_make_color_map (renderer, settings.color);
+  eda_renderer_set_color_map (renderer, color_map);
 
   /* Create a surface and run export_layout_page() to figure out
    * the picture extents and set up the cairo transformation

--- a/liblepton/src/export.c
+++ b/liblepton/src/export.c
@@ -215,16 +215,13 @@ lepton_export_set_renderer_color_map (EdaRenderer *renderer,
   if (!color) {
     /* Create a black and white color map.  All non-background colors
      * are black. */
-    LeptonColor white = {255, 255, 255, 255, TRUE};
-    LeptonColor black = {0, 0, 0, 255, TRUE};
+    LeptonColor white = {255, 255, 255, 255};
+    LeptonColor black = {0, 0, 0, 255};
     for (i = 0; i < colors_count(); i++) {
       LeptonColor *c = &g_array_index (render_color_map, LeptonColor, i);
+      /* Skip disabled (fully-transparent) colors. */
       if (!lepton_color_enabled (c)) continue;
 
-      if (c->a == 0) {
-        c->enabled = FALSE;
-        continue;
-      }
       if (i == OUTPUT_BACKGROUND_COLOR) {
         *c = white;
       } else {

--- a/liblepton/src/export.c
+++ b/liblepton/src/export.c
@@ -200,8 +200,8 @@ lepton_export_set_renderer_font (EdaRenderer *renderer,
 
 
 GArray*
-lepton_export_make_color_map (EdaRenderer *renderer,
-                              gboolean color)
+lepton_export_make_color_map (gboolean color,
+                              size_t background_color)
 {
   size_t i;
   GArray *render_color_map = NULL;
@@ -212,6 +212,11 @@ lepton_export_make_color_map (EdaRenderer *renderer,
   LeptonColor* print_colors = print_colors_array();
   render_color_map =
     g_array_append_vals (render_color_map, print_colors, colors_count());
+
+  /* If no color exporting is desired, transform the color map
+   * into a black-and-white color map by making the background
+   * color white and replacing all other enabled colors with solid
+   * black. */
   if (!color) {
     /* Create a black and white color map.  All non-background colors
      * are black. */
@@ -222,7 +227,8 @@ lepton_export_make_color_map (EdaRenderer *renderer,
       /* Skip disabled (fully-transparent) colors. */
       if (!lepton_color_enabled (c)) continue;
 
-      if (i == OUTPUT_BACKGROUND_COLOR) {
+      if (i == background_color)
+      {
         *c = white;
       } else {
         *c = black;
@@ -439,7 +445,8 @@ lepton_export_png (void)
     lepton_export_set_renderer_font (renderer, settings.font);
   }
 
-  GArray *color_map = lepton_export_make_color_map (renderer, settings.color);
+  GArray *color_map = lepton_export_make_color_map (settings.color,
+                                                    OUTPUT_BACKGROUND_COLOR);
   eda_renderer_set_color_map (renderer, color_map);
 
   /* Create a dummy context to permit calculating extents taking text
@@ -502,7 +509,8 @@ export_postscript (gboolean is_eps)
     lepton_export_set_renderer_font (renderer, settings.font);
   }
 
-  GArray *color_map = lepton_export_make_color_map (renderer, settings.color);
+  GArray *color_map = lepton_export_make_color_map (settings.color,
+                                                    OUTPUT_BACKGROUND_COLOR);
   eda_renderer_set_color_map (renderer, color_map);
 
   /* Create a surface. To begin with, we don't know the size. */
@@ -579,7 +587,8 @@ lepton_export_pdf (void)
     lepton_export_set_renderer_font (renderer, settings.font);
   }
 
-  GArray *color_map = lepton_export_make_color_map (renderer, settings.color);
+  GArray *color_map = lepton_export_make_color_map (settings.color,
+                                                    OUTPUT_BACKGROUND_COLOR);
   eda_renderer_set_color_map (renderer, color_map);
 
   /* Create a surface. To begin with, we don't know the size. */
@@ -618,7 +627,8 @@ lepton_export_svg ()
     lepton_export_set_renderer_font (renderer, settings.font);
   }
 
-  GArray *color_map = lepton_export_make_color_map (renderer, settings.color);
+  GArray *color_map = lepton_export_make_color_map (settings.color,
+                                                    OUTPUT_BACKGROUND_COLOR);
   eda_renderer_set_color_map (renderer, color_map);
 
   /* Create a surface and run export_layout_page() to figure out

--- a/liblepton/src/export.c
+++ b/liblepton/src/export.c
@@ -220,8 +220,8 @@ lepton_export_make_color_map (gboolean color,
   if (!color) {
     /* Create a black and white color map.  All non-background colors
      * are black. */
-    LeptonColor white = {255, 255, 255, 255};
-    LeptonColor black = {0, 0, 0, 255};
+    LeptonColor white = {1.0, 1.0, 1.0, 1.0};
+    LeptonColor black = {0.0, 0.0, 0.0, 1.0};
     for (i = 0; i < colors_count(); i++) {
       LeptonColor *c = &g_array_index (render_color_map, LeptonColor, i);
       /* Skip disabled (fully-transparent) colors. */

--- a/libleptongui/include/color_edit_widget.h
+++ b/libleptongui/include/color_edit_widget.h
@@ -1,6 +1,6 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 2018 dmn <graahnul.grom@gmail.com>
- * Copyright (C) 2018-2021 Lepton EDA Contributors
+ * Copyright (C) 2018-2022 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -52,7 +52,7 @@ struct _ColorEditWidget
 #ifdef ENABLE_GTK3
   GtkWidget* color_chooser;
   GtkWidget* btn_apply;
-  GtkWidget* btn_back;
+  GtkWidget* btn_toggle;
 #else
   GtkWidget* color_sel_;
 #endif

--- a/libleptongui/include/color_edit_widget.h
+++ b/libleptongui/include/color_edit_widget.h
@@ -51,6 +51,7 @@ struct _ColorEditWidget
   GtkWidget* color_cb_;
 #ifdef ENABLE_GTK3
   GtkWidget* color_chooser;
+  GtkWidget* btn_apply;
 #else
   GtkWidget* color_sel_;
 #endif

--- a/libleptongui/include/color_edit_widget.h
+++ b/libleptongui/include/color_edit_widget.h
@@ -52,6 +52,7 @@ struct _ColorEditWidget
 #ifdef ENABLE_GTK3
   GtkWidget* color_chooser;
   GtkWidget* btn_apply;
+  GtkWidget* btn_back;
 #else
   GtkWidget* color_sel_;
 #endif

--- a/libleptongui/include/color_edit_widget.h
+++ b/libleptongui/include/color_edit_widget.h
@@ -1,5 +1,6 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 2018 dmn <graahnul.grom@gmail.com>
+ * Copyright (C) 2018-2021 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -48,7 +49,11 @@ struct _ColorEditWidget
   GschemToplevel* toplevel_;
 
   GtkWidget* color_cb_;
+#ifdef ENABLE_GTK3
+  GtkWidget* color_chooser;
+#else
   GtkWidget* color_sel_;
+#endif
   GtkWidget* btn_save_;
 };
 
@@ -64,4 +69,3 @@ color_edit_widget_get_type();
 
 
 #endif /* LEPTON_COLOR_EDIT_WIDGET_H_ */
-

--- a/libleptongui/include/globals.h
+++ b/libleptongui/include/globals.h
@@ -25,10 +25,6 @@
 /* window list */
 extern GList *global_window_list;
 
-/* colors */
-extern GdkColor white;
-extern GdkColor black;
-
 extern int do_logging;
 
 

--- a/libleptongui/include/gschem_swatch_column_renderer.h
+++ b/libleptongui/include/gschem_swatch_column_renderer.h
@@ -1,6 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 2013 Ales Hvezda
- * Copyright (C) 2013 gEDA Contributors (see ChangeLog for details)
+ * Copyright (C) 2013 gEDA Contributors
+ * Copyright (C) 2021 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -39,7 +40,11 @@ struct _GschemSwatchColumnRenderer
 {
   GtkCellRendererText parent;
 
+#ifdef ENABLE_GTK3
+  GdkRGBA color;
+#else
   GdkColor color;
+#endif
   gboolean enabled;
 };
 

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -443,11 +443,22 @@ gboolean x_clipboard_set (GschemToplevel *w_current, const GList *object_list);
 GList *x_clipboard_get (GschemToplevel *w_current);
 /* x_color.c */
 void x_color_init();
+#ifdef ENABLE_GTK3
+GdkRGBA *x_color_lookup_gdk_rgba (size_t color_id);
+#else
 GdkColor *x_color_lookup_gdk(size_t color_id);
+#endif
 LeptonColor *x_color_lookup(size_t color_id);
 gboolean x_color_display_enabled (size_t color_id);
+#ifdef ENABLE_GTK3
+void x_color_set_display_color (size_t color_id,
+                                GdkRGBA* color);
+void x_color_set_outline_color (size_t color_id,
+                                GdkRGBA* color);
+#else
 void x_color_set_display (size_t color_id, GdkColor* color);
 void x_color_set_outline (size_t color_id, GdkColor* color);
+#endif
 GString* x_color_map2str_display();
 GString* x_color_map2str_outline();
 
@@ -456,7 +467,11 @@ GtkWidget* x_colorcb_new ();
 int x_colorcb_get_index (GtkWidget *widget);
 void x_colorcb_set_index (GtkWidget *widget, int color_index);
 void x_colorcb_update_colors();
+#ifdef ENABLE_GTK3
+void x_colorcb_set_rgba_color (GtkTreeIter* iter, GdkRGBA* color);
+#else
 void x_colorcb_set_color (GtkTreeIter* iter, GdkColor* color);
+#endif
 
 /* x_dialog.c */
 int text_view_calculate_real_tab_width(GtkTextView *textview, int tab_size);

--- a/libleptongui/src/color_edit_widget.c
+++ b/libleptongui/src/color_edit_widget.c
@@ -1,6 +1,6 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 2018-2020 dmn <graahnul.grom@gmail.com>
- * Copyright (C) 2018-2021 Lepton EDA Contributors
+ * Copyright (C) 2018-2022 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -75,7 +75,7 @@ static void
 on_btn_apply (GtkWidget* btn, gpointer p);
 
 static void
-on_btn_back (GtkWidget* btn, gpointer p);
+on_btn_toggle (GtkWidget* btn, gpointer p);
 
 #else /* GTK2 */
 
@@ -224,8 +224,8 @@ color_edit_widget_create (ColorEditWidget* widget)
 
 #ifdef ENABLE_GTK3
   /* "Back" button: */
-  widget->btn_back = gtk_button_new_with_mnemonic (_("_Back"));
-  gtk_box_pack_start (GTK_BOX (hbox), widget->btn_back, FALSE, FALSE, 0);
+  widget->btn_toggle = gtk_button_new_with_mnemonic (_("Toggle _Editor"));
+  gtk_box_pack_start (GTK_BOX (hbox), widget->btn_toggle, FALSE, FALSE, 0);
 #endif
 
   /* color selection combo box: */
@@ -312,9 +312,9 @@ color_edit_widget_create (ColorEditWidget* widget)
                     "clicked",
                     G_CALLBACK (&on_btn_apply),
                     widget);
-  g_signal_connect (G_OBJECT (widget->btn_back),
+  g_signal_connect (G_OBJECT (widget->btn_toggle),
                     "clicked",
-                    G_CALLBACK (&on_btn_back),
+                    G_CALLBACK (&on_btn_toggle),
                     widget);
 #endif
 
@@ -525,9 +525,9 @@ on_btn_apply (GtkWidget* btn, gpointer p)
   gtk_widget_queue_draw (GTK_WIDGET (gschem_toplevel_get_current_page_view (widget->toplevel_)));
 }
 
-/*! \brief "Back" button "clicked" signal handler. */
+/*! \brief "Toggle Editor" button "clicked" signal handler. */
 static void
-on_btn_back (GtkWidget* btn, gpointer p)
+on_btn_toggle (GtkWidget* btn, gpointer p)
 {
   ColorEditWidget* widget = (ColorEditWidget*) p;
 

--- a/libleptongui/src/color_edit_widget.c
+++ b/libleptongui/src/color_edit_widget.c
@@ -512,6 +512,7 @@ on_btn_apply (GtkWidget* btn, gpointer p)
 
   int color_index = x_colorcb_get_index (GTK_WIDGET (widget->color_cb_));
   x_color_set_display_color (color_index, &color);
+  x_color_set_outline_color (color_index, &color);
 
   /* Update current combo box color. */
   GtkComboBox* combo = GTK_COMBO_BOX (widget->color_cb_);

--- a/libleptongui/src/color_edit_widget.c
+++ b/libleptongui/src/color_edit_widget.c
@@ -536,7 +536,7 @@ on_btn_toggle (GtkWidget* btn, gpointer p)
   GtkColorChooser* chooser = GTK_COLOR_CHOOSER (widget->color_chooser);
 
   gboolean show_editor;
-  g_object_get (chooser, "show_editor", &show_editor, NULL);
+  g_object_get (chooser, "show-editor", &show_editor, NULL);
   g_object_set (chooser, "show-editor", !show_editor, NULL);
 }
 #endif

--- a/libleptongui/src/color_edit_widget.c
+++ b/libleptongui/src/color_edit_widget.c
@@ -352,7 +352,7 @@ on_color_sel_changed (GtkColorSelection* csel, gpointer p)
   g_return_if_fail (widget != NULL);
   g_return_if_fail (widget->toplevel_ != NULL);
 
-  int color_index = x_colorcb_get_index (widget->color_cb_);
+  int color_index = x_colorcb_get_index (GTK_WIDGET (widget->color_cb_));
   g_return_if_fail (color_index >= 0);
 
   GdkColor color;

--- a/libleptongui/src/color_edit_widget.c
+++ b/libleptongui/src/color_edit_widget.c
@@ -75,6 +75,11 @@ static void
 on_color_sel_changed (GtkColorSelection* csel, gpointer p);
 #endif
 
+#ifdef ENABLE_GTK3
+static void
+on_btn_apply (GtkWidget* btn, gpointer p);
+#endif
+
 static void
 on_btn_save(GtkWidget* btn, gpointer p);
 
@@ -218,6 +223,12 @@ color_edit_widget_create (ColorEditWidget* widget)
   widget->color_cb_ = x_colorcb_new();
   gtk_box_pack_start (GTK_BOX (hbox), widget->color_cb_, TRUE, TRUE, 0);
 
+#ifdef ENABLE_GTK3
+  /* "Apply" button: */
+  widget->btn_apply = gtk_button_new_with_mnemonic (_("_Apply"));
+  gtk_box_pack_start (GTK_BOX (hbox), widget->btn_apply, FALSE, FALSE, 0);
+#endif
+
   /* "save as..." button: */
   widget->btn_save_ = gtk_button_new_with_mnemonic (_("Save As.._."));
   gtk_box_pack_start (GTK_BOX (hbox), widget->btn_save_, FALSE, FALSE, 0);
@@ -287,6 +298,12 @@ color_edit_widget_create (ColorEditWidget* widget)
                     G_CALLBACK (&on_btn_save),
                     widget);
 
+#ifdef ENABLE_GTK3
+  g_signal_connect (G_OBJECT (widget->btn_apply),
+                    "clicked",
+                    G_CALLBACK (&on_btn_apply),
+                    widget);
+#endif
 
   x_colorcb_set_index (widget->color_cb_, BACKGROUND_COLOR);
 
@@ -463,6 +480,26 @@ on_color_sel_changed (GtkColorSelection* csel, gpointer p)
 
 } /* on_color_sel_changed() */
 
+#endif
+
+
+#ifdef ENABLE_GTK3
+/*! \brief "Apply" button "clicked" signal handler. */
+static void
+on_btn_apply (GtkWidget* btn, gpointer p)
+{
+  ColorEditWidget* widget = (ColorEditWidget*) p;
+
+  g_return_if_fail (widget != NULL);
+  g_return_if_fail (widget->toplevel_ != NULL);
+
+  GtkColorChooser* chooser = GTK_COLOR_CHOOSER (widget->color_chooser);
+  GdkRGBA color;
+  gtk_color_chooser_get_rgba (chooser, &color);
+
+  int color_index = x_colorcb_get_index (GTK_WIDGET (widget->color_cb_));
+  x_color_set_display_color (color_index, &color);
+}
 #endif
 
 

--- a/libleptongui/src/color_edit_widget.c
+++ b/libleptongui/src/color_edit_widget.c
@@ -80,6 +80,11 @@ static void
 on_btn_apply (GtkWidget* btn, gpointer p);
 #endif
 
+#ifdef ENABLE_GTK3
+static void
+on_btn_back (GtkWidget* btn, gpointer p);
+#endif
+
 static void
 on_btn_save(GtkWidget* btn, gpointer p);
 
@@ -219,6 +224,12 @@ color_edit_widget_create (ColorEditWidget* widget)
 #endif
   gtk_box_pack_start (GTK_BOX (vbox), hbox, FALSE, TRUE, 0);
 
+#ifdef ENABLE_GTK3
+  /* "Back" button: */
+  widget->btn_back = gtk_button_new_with_mnemonic (_("_Back"));
+  gtk_box_pack_start (GTK_BOX (hbox), widget->btn_back, FALSE, FALSE, 0);
+#endif
+
   /* color selection combo box: */
   widget->color_cb_ = x_colorcb_new();
   gtk_box_pack_start (GTK_BOX (hbox), widget->color_cb_, TRUE, TRUE, 0);
@@ -302,6 +313,10 @@ color_edit_widget_create (ColorEditWidget* widget)
   g_signal_connect (G_OBJECT (widget->btn_apply),
                     "clicked",
                     G_CALLBACK (&on_btn_apply),
+                    widget);
+  g_signal_connect (G_OBJECT (widget->btn_back),
+                    "clicked",
+                    G_CALLBACK (&on_btn_back),
                     widget);
 #endif
 
@@ -500,6 +515,21 @@ on_btn_apply (GtkWidget* btn, gpointer p)
   int color_index = x_colorcb_get_index (GTK_WIDGET (widget->color_cb_));
   x_color_set_display_color (color_index, &color);
   gtk_widget_queue_draw (GTK_WIDGET (gschem_toplevel_get_current_page_view (widget->toplevel_)));
+}
+
+/*! \brief "Back" button "clicked" signal handler. */
+static void
+on_btn_back (GtkWidget* btn, gpointer p)
+{
+  ColorEditWidget* widget = (ColorEditWidget*) p;
+
+  g_return_if_fail (widget != NULL);
+
+  GtkColorChooser* chooser = GTK_COLOR_CHOOSER (widget->color_chooser);
+
+  gboolean show_editor;
+  g_object_get (chooser, "show_editor", &show_editor, NULL);
+  g_object_set (chooser, "show-editor", !show_editor, NULL);
 }
 #endif
 

--- a/libleptongui/src/color_edit_widget.c
+++ b/libleptongui/src/color_edit_widget.c
@@ -514,6 +514,15 @@ on_btn_apply (GtkWidget* btn, gpointer p)
 
   int color_index = x_colorcb_get_index (GTK_WIDGET (widget->color_cb_));
   x_color_set_display_color (color_index, &color);
+
+  /* Update current combo box color. */
+  GtkComboBox* combo = GTK_COMBO_BOX (widget->color_cb_);
+  GtkTreeIter iter;
+  if (gtk_combo_box_get_active_iter (combo, &iter))
+  {
+    x_colorcb_set_rgba_color (&iter, &color);
+  }
+
   gtk_widget_queue_draw (GTK_WIDGET (gschem_toplevel_get_current_page_view (widget->toplevel_)));
 }
 

--- a/libleptongui/src/color_edit_widget.c
+++ b/libleptongui/src/color_edit_widget.c
@@ -70,19 +70,17 @@ on_color_cb_changed (GtkWidget* cb, gpointer p);
 #ifdef ENABLE_GTK3
 static void
 on_color_activated (GtkColorChooser* csel, GdkRGBA *color, gpointer p);
-#else
-static void
-on_color_sel_changed (GtkColorSelection* csel, gpointer p);
-#endif
 
-#ifdef ENABLE_GTK3
 static void
 on_btn_apply (GtkWidget* btn, gpointer p);
-#endif
 
-#ifdef ENABLE_GTK3
 static void
 on_btn_back (GtkWidget* btn, gpointer p);
+
+#else /* GTK2 */
+
+static void
+on_color_sel_changed (GtkColorSelection* csel, gpointer p);
 #endif
 
 static void

--- a/libleptongui/src/color_edit_widget.c
+++ b/libleptongui/src/color_edit_widget.c
@@ -499,6 +499,7 @@ on_btn_apply (GtkWidget* btn, gpointer p)
 
   int color_index = x_colorcb_get_index (GTK_WIDGET (widget->color_cb_));
   x_color_set_display_color (color_index, &color);
+  gtk_widget_queue_draw (GTK_WIDGET (gschem_toplevel_get_current_page_view (widget->toplevel_)));
 }
 #endif
 

--- a/libleptongui/src/gschem_swatch_column_renderer.c
+++ b/libleptongui/src/gschem_swatch_column_renderer.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 2013 Ales Hvezda
  * Copyright (C) 2016 gEDA Contributors
- * Copyright (C) 2017-2020 Lepton EDA Contributors
+ * Copyright (C) 2017-2021 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -100,11 +100,18 @@ get_property (GObject    *object,
 
   switch (param_id) {
     case PROP_COLOR: {
+#ifdef ENABLE_GTK3
+        GdkRGBA color;
+#else
         GdkColor color;
+#endif
 
         color.red = swatch->color.red;
         color.green = swatch->color.green;
         color.blue = swatch->color.blue;
+#ifdef ENABLE_GTK3
+        color.alpha = swatch->color.alpha;
+#endif
 
         g_value_set_boxed (value, &color);
       }
@@ -141,7 +148,11 @@ swatchcr_class_init (GschemSwatchColumnRendererClass *klass)
                                    g_param_spec_boxed ("color",
                                                        "Swatch Color",
                                                        "Swatch Color",
+#ifdef ENABLE_GTK3
+                                                       GDK_TYPE_RGBA,
+#else
                                                        GDK_TYPE_COLOR,
+#endif
                                                        G_PARAM_READWRITE));
   g_object_class_install_property (object_class,
                                    PROP_ENABLED,
@@ -161,9 +172,16 @@ swatchcr_class_init (GschemSwatchColumnRendererClass *klass)
 static void
 swatchcr_init (GschemSwatchColumnRenderer *swatch)
 {
+#ifdef ENABLE_GTK3
+  swatch->color.red = 0.0;
+  swatch->color.green = 0.0;
+  swatch->color.blue = 0.0;
+  swatch->color.alpha = 1.0;
+#else
   swatch->color.red = 0;
   swatch->color.green = 0;
   swatch->color.blue = 0;
+#endif
 
   swatch->enabled = TRUE;
 
@@ -233,14 +251,26 @@ render (GtkCellRenderer      *cell,
 
     cairo_set_line_width (cr, SWATCH_BORDER_WIDTH);
 
+#ifdef ENABLE_GTK3
+    cairo_set_source_rgba (cr,
+                           swatch->color.red,
+                           swatch->color.green,
+                           swatch->color.blue,
+                           swatch->color.alpha);
+#else
     cairo_set_source_rgb (cr,
                           swatch->color.red   / 65535.0,
                           swatch->color.green / 65535.0,
                           swatch->color.blue  / 65535.0);
+#endif
 
     cairo_fill_preserve (cr);
 
+#ifdef ENABLE_GTK3
+    cairo_set_source_rgba (cr, 0.0, 0.0, 0.0, 1.0);
+#else
     cairo_set_source_rgb (cr, 0.0, 0.0, 0.0);
+#endif
 
     cairo_stroke (cr);
 #ifndef ENABLE_GTK3
@@ -258,12 +288,19 @@ render (GtkCellRenderer      *cell,
  *  \param [in]     color  The color of the swatch
  */
 static void
+#ifdef ENABLE_GTK3
+set_color (GschemSwatchColumnRenderer *swatch, const GdkRGBA *color)
+#else
 set_color (GschemSwatchColumnRenderer *swatch, const GdkColor *color)
+#endif
 {
   if (color) {
     swatch->color.red = color->red;
     swatch->color.green = color->green;
     swatch->color.blue = color->blue;
+#ifdef ENABLE_GTK3
+    swatch->color.alpha = color->alpha;
+#endif
   }
 }
 
@@ -287,7 +324,11 @@ set_property (GObject      *object,
 
   switch (param_id) {
     case PROP_COLOR:
+#ifdef ENABLE_GTK3
+      set_color (swatch, (const GdkRGBA*) g_value_get_boxed (value));
+#else
       set_color (swatch, (const GdkColor*) g_value_get_boxed (value));
+#endif
       break;
 
     case PROP_ENABLED:

--- a/libleptongui/src/x_color.c
+++ b/libleptongui/src/x_color.c
@@ -79,7 +79,7 @@ x_color_lookup (size_t color_id)
 gboolean
 x_color_display_enabled (size_t color_id)
 {
-  return display_colors[ color_id ].enabled;
+  return lepton_color_enabled (&display_colors [color_id]);
 }
 
 
@@ -126,7 +126,7 @@ x_color_map2str (LeptonColorMap cmap)
 
     const gchar* scm_str = color_get_name (color_index);
 
-    if (color.enabled)
+    if (lepton_color_enabled (&color))
     {
       guint8 r = color.r;
       guint8 g = color.g;

--- a/libleptongui/src/x_color.c
+++ b/libleptongui/src/x_color.c
@@ -39,6 +39,30 @@ x_color_init()
 
 
 
+#ifdef ENABLE_GTK3
+/*! \brief Get a display color map color for specified \a color_id
+ *  as GdkRGBA.
+ *
+ *  \note Caller must gdk_rgba_free() the returned value.
+ */
+GdkRGBA*
+x_color_lookup_gdk_rgba (size_t color_id)
+{
+  LeptonColor *color = x_color_lookup (color_id);
+
+  /* Extrapolate 8-bpp color into GDK color:
+  */
+  GdkRGBA color_gdk;
+  color_gdk.red   = color->red;
+  color_gdk.green = color->green;
+  color_gdk.blue  = color->blue;
+  color_gdk.alpha = color->alpha;
+
+  return gdk_rgba_copy (&color_gdk);
+}
+
+#else /* GTK2 */
+
 /*! \brief Get a display color map color for specified \a color_id as GdkColor.
  *
  *  \note Caller must gdk_color_free() the returned value.
@@ -57,6 +81,7 @@ x_color_lookup_gdk (size_t color_id)
 
   return gdk_color_copy (&color_gdk);
 }
+#endif
 
 
 
@@ -82,7 +107,35 @@ x_color_display_enabled (size_t color_id)
   return lepton_color_enabled (&display_colors [color_id]);
 }
 
+#ifdef ENABLE_GTK3
+/*! \brief: Set new color value for a color with given index in
+ *  the display color map.
+ */
+void
+x_color_set_display_color (size_t color_id,
+                           GdkRGBA* color)
+{
+  display_colors[color_id].red = color->red;
+  display_colors[color_id].green = color->green;
+  display_colors[color_id].blue = color->blue;
+  display_colors[color_id].alpha = color->alpha;
+}
 
+
+/*! \brief: Set new color value for a color with given index in
+ *  the display color map.
+ */
+void
+x_color_set_outline_color (size_t color_id,
+                           GdkRGBA* color)
+{
+  display_outline_colors[color_id].red = color->red;
+  display_outline_colors[color_id].green = color->green;
+  display_outline_colors[color_id].blue = color->blue;
+  display_outline_colors[color_id].alpha = color->alpha;
+}
+
+#else /* GTK2 */
 
 /*! \brief: Change a color in the display color map
  */
@@ -107,6 +160,7 @@ x_color_set_outline (size_t color_id, GdkColor* color)
   display_outline_colors[color_id].blue  = (gdouble) color->blue  / 65535.0;
   display_outline_colors[color_id].alpha = 1.0;
 }
+#endif
 
 
 

--- a/libleptongui/src/x_color.c
+++ b/libleptongui/src/x_color.c
@@ -50,15 +50,7 @@ x_color_lookup_gdk_rgba (size_t color_id)
 {
   LeptonColor *color = x_color_lookup (color_id);
 
-  /* Extrapolate 8-bpp color into GDK color:
-  */
-  GdkRGBA color_gdk;
-  color_gdk.red   = color->red;
-  color_gdk.green = color->green;
-  color_gdk.blue  = color->blue;
-  color_gdk.alpha = color->alpha;
-
-  return gdk_rgba_copy (&color_gdk);
+  return gdk_rgba_copy ((GdkRGBA *) color);
 }
 
 #else /* GTK2 */

--- a/libleptongui/src/x_color.c
+++ b/libleptongui/src/x_color.c
@@ -187,17 +187,24 @@ x_color_map2str (LeptonColorMap cmap)
       guint8 r = (guint8) (color.red * 255);
       guint8 g = (guint8) (color.green * 255);
       guint8 b = (guint8) (color.blue * 255);
+      guint8 a = (guint8) (color.alpha * 255);
 
       /* the line will look like:
-       * (background "#AABBCC")
+       * (background "#RRGGBBAA")
+       * or
+       * (background "#RRGGBB")
       */
-      g_string_append_printf (str, "  (%-20s \"#%.2x%.2x%.2x\")",
-                             scm_str,
-                             r, g, b);
-    }
-    else
-    {
-      g_string_append_printf (str, "  (%-20s #f)", scm_str);
+      if (color.alpha != 1.0) {
+        g_string_append_printf (str, "  (%-20s \"#%.2x%.2x%.2x%.2x\")",
+                                scm_str,
+                                r, g, b, a);
+      }
+      else
+      {
+        g_string_append_printf (str, "  (%-20s \"#%.2x%.2x%.2x\")",
+                                scm_str,
+                                r, g, b);
+      }
     }
 
     g_string_append (str, "\n");

--- a/libleptongui/src/x_color.c
+++ b/libleptongui/src/x_color.c
@@ -51,9 +51,9 @@ x_color_lookup_gdk (size_t color_id)
   /* Extrapolate 8-bpp color into 16-bpp GDK color:
   */
   GdkColor color_gdk;
-  color_gdk.red   = color->r + (color->r << 8);
-  color_gdk.green = color->g + (color->g << 8);
-  color_gdk.blue  = color->b + (color->b << 8);
+  color_gdk.red   = (guint16) (color->red   * 65535);
+  color_gdk.green = (guint16) (color->green * 65535);
+  color_gdk.blue  = (guint16) (color->blue  * 65535);
 
   return gdk_color_copy (&color_gdk);
 }
@@ -89,9 +89,10 @@ x_color_display_enabled (size_t color_id)
 void
 x_color_set_display (size_t color_id, GdkColor* color)
 {
-  display_colors[ color_id ].r = color->red   >> 8;
-  display_colors[ color_id ].g = color->green >> 8;
-  display_colors[ color_id ].b = color->blue  >> 8;
+  display_colors[color_id].red   = (gdouble) color->red   / 65535.0;
+  display_colors[color_id].green = (gdouble) color->green / 65535.0;
+  display_colors[color_id].blue  = (gdouble) color->blue  / 65535.0;
+  display_colors[color_id].alpha = 1.0;
 }
 
 
@@ -101,9 +102,10 @@ x_color_set_display (size_t color_id, GdkColor* color)
 void
 x_color_set_outline (size_t color_id, GdkColor* color)
 {
-  display_outline_colors[ color_id ].r = color->red   >> 8;
-  display_outline_colors[ color_id ].g = color->green >> 8;
-  display_outline_colors[ color_id ].b = color->blue  >> 8;
+  display_outline_colors[color_id].red   = (gdouble) color->red   / 65535.0;
+  display_outline_colors[color_id].green = (gdouble) color->green / 65535.0;
+  display_outline_colors[color_id].blue  = (gdouble) color->blue  / 65535.0;
+  display_outline_colors[color_id].alpha = 1.0;
 }
 
 
@@ -128,9 +130,9 @@ x_color_map2str (LeptonColorMap cmap)
 
     if (lepton_color_enabled (&color))
     {
-      guint8 r = color.r;
-      guint8 g = color.g;
-      guint8 b = color.b;
+      guint8 r = (guint8) (color.red * 255);
+      guint8 g = (guint8) (color.green * 255);
+      guint8 b = (guint8) (color.blue * 255);
 
       /* the line will look like:
        * (background "#AABBCC")

--- a/libleptongui/src/x_colorcb.c
+++ b/libleptongui/src/x_colorcb.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2015 gEDA Contributors
- * Copyright (C) 2017-2020 Lepton EDA Contributors
+ * Copyright (C) 2017-2021 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -58,7 +58,11 @@ create_color_list_store ()
   GtkTreeIter iter;
   GtkListStore *store;
 
+#ifdef ENABLE_GTK3
+  store = gtk_list_store_new (COLUMN_COUNT, G_TYPE_STRING, G_TYPE_INT, GDK_TYPE_RGBA);
+#else
   store = gtk_list_store_new (COLUMN_COUNT, G_TYPE_STRING, G_TYPE_INT, GDK_TYPE_COLOR);
+#endif
 
   for (size_t color_index = 0; color_index < colors_count(); color_index++)
   {
@@ -69,7 +73,11 @@ create_color_list_store ()
                  ? g_strdup (name)
                  : g_strdup_printf (_("%s [ disabled ]"), name);
 
+#ifdef ENABLE_GTK3
+    GdkRGBA *color = x_color_lookup_gdk_rgba (color_index);
+#else
     GdkColor* color = x_color_lookup_gdk (color_index);
+#endif
 
     gtk_list_store_set (store, &iter,
       COLUMN_NAME,  str,
@@ -77,7 +85,11 @@ create_color_list_store ()
       COLUMN_COLOR, color,
       -1);
 
+#ifdef ENABLE_GTK3
+    gdk_rgba_free (color);
+#else
     gdk_color_free (color);
+#endif
     g_free (str);
   }
 
@@ -124,9 +136,15 @@ x_colorcb_update_colors()
       color_index = default_color_id();
     }
 
+#ifdef ENABLE_GTK3
+    GdkRGBA* color = x_color_lookup_gdk_rgba (color_index);
+    x_colorcb_set_rgba_color (&iter, color);
+    gdk_rgba_free (color);
+#else
     GdkColor* color = x_color_lookup_gdk (color_index);
     x_colorcb_set_color (&iter, color);
     gdk_color_free (color);
+#endif
 
     res = gtk_tree_model_iter_next (model, &iter);
   }
@@ -138,10 +156,15 @@ x_colorcb_update_colors()
 /*! \brief Set color for combo box entry
  *
  *  \param  iter  Iterator pointing to combo box entry to be modified
- *  \param  color A pointer to GdkColor struture
+ *  \param color  A pointer to GdkColor (GTK2) or GdkRGBA (GTK3)
+ *                struture.
  */
 void
+#ifdef ENABLE_GTK3
+x_colorcb_set_rgba_color (GtkTreeIter* iter, GdkRGBA* color)
+#else
 x_colorcb_set_color (GtkTreeIter* iter, GdkColor* color)
+#endif
 {
   gtk_list_store_set (color_list_store, iter, COLUMN_COLOR, color, -1);
 }

--- a/libleptongui/src/x_print.c
+++ b/libleptongui/src/x_print.c
@@ -172,7 +172,7 @@ x_print_draw_page (LeptonPage *page,
   if (!is_color) {
     for (size_t i = 0; i < colors_count(); i++) {
       LeptonColor *c = &g_array_index (color_map, LeptonColor, i);
-      if (!c->enabled) continue;
+      if (!lepton_color_enabled (c)) continue;
 
       /* Disable background color & fully-transparent colors */
       if (c->a == 0 || i == BACKGROUND_COLOR) {

--- a/libleptongui/src/x_print.c
+++ b/libleptongui/src/x_print.c
@@ -172,13 +172,10 @@ x_print_draw_page (LeptonPage *page,
   if (!is_color) {
     for (size_t i = 0; i < colors_count(); i++) {
       LeptonColor *c = &g_array_index (color_map, LeptonColor, i);
-      if (!lepton_color_enabled (c)) continue;
 
-      /* Disable background color & fully-transparent colors */
-      if (c->a == 0 || i == BACKGROUND_COLOR) {
-        c->enabled = FALSE;
+      /* Skip background color & fully-transparent colors. */
+      if (!lepton_color_enabled (c) || i == BACKGROUND_COLOR)
         continue;
-      }
 
       /* Set any remaining colors solid black */
       c->r = 0;

--- a/libleptongui/src/x_print.c
+++ b/libleptongui/src/x_print.c
@@ -162,30 +162,10 @@ x_print_draw_page (LeptonPage *page,
                      - (wx_min + 0.5*w_width) * scale + 0.5*cr_width,
                      (wy_min + 0.5*w_height) * scale + 0.5*cr_height);
 
-  /* Second, build the color map.  If no color printing is desired,
-   * transform the print color map into a black-and-white color map by
-   * making the background color transparent and replacing all other
-   * enabled colors with solid black. */
-  color_map = g_array_sized_new (FALSE, FALSE, sizeof(LeptonColor), colors_count());
-  LeptonColor *print_colors = print_colors_array ();
-  color_map = g_array_append_vals (color_map, print_colors, colors_count());
-  if (!is_color) {
-    for (size_t i = 0; i < colors_count(); i++) {
-      LeptonColor *c = &g_array_index (color_map, LeptonColor, i);
-
-      /* Skip background color & fully-transparent colors. */
-      if (!lepton_color_enabled (c) || i == BACKGROUND_COLOR)
-        continue;
-
-      /* Set any remaining colors solid black */
-      c->r = 0;
-      c->g = 0;
-      c->b = 0;
-      c->a = ~0;
-    }
-  }
-
-  /* Thirdly, create and initialise a renderer */
+  /* Build color map. */
+  color_map = lepton_export_make_color_map (is_color,
+                                            BACKGROUND_COLOR);
+  /* Create and initialise a renderer. */
   renderer = EDA_RENDERER (g_object_new (EDA_TYPE_RENDERER,
                                          "cairo-context", cr,
                                          "pango-context", pc,


### PR DESCRIPTION
- The type `LeptonColor` has been amended so that, internally, it
  has the same structure as `GdkRGBA` which is used to represent a
  (possibly translucent) color in a way that is compatible with
  `cairo`'s notion of color.  More definitely, the field `enabled`
  of the `LeptonColor` type has been removed, and other fields
  that represent the color channels now have the type `double`.
  Instead of using the `enabled` field, disabling colors specified
  on Scheme side with the value `#f`, is now done in C by making
  them fully transparent, that is, by setting their alpha channel
  value to zero.

- A new color chooser widget for GTK 3 version of
  `lepton-schematic` has been introduced.  Apart from basic GTK
  functionality and a combobox for color selection, as in GTK2
  version, it has two buttons: *Apply* and *Back*.  The former is
  used to apply a selected color to immediately see the changes on
  the opened schematic page, and the latter is used to toggle
  between palette swatch view and color editor in the widget.
  Besides, it supports displaying translucent colors.

- Swatch rendering in the new color chooser and in some other
  widgets now also supports displaying non-opaque, translucent
  colors the same way the color chooser does, by showing such
  colors applied to a checkered background pattern.

- Functions, used for exporting a current color map for later
  including in Scheme RC scripts (typically, `gschemrc`), now
  support output of translucent colors by adding alpha channel
  values for colors that are not fully opaque.

- Color map creation code in export and GUI print functions has
  been unified.

- Provisions have been added against potential memory leaks in
  export functions in case they are called multiple times in
  Scheme scripts.

- Several build warnings have been eliminated due to the above
  changes.

- The minimal version of GTK3 has been bumped to 3.4.

**Palette swatch view**

![palette-swatch-view](https://user-images.githubusercontent.com/1515901/147817812-bcf4876b-c8e2-429e-ae55-be55f6b0ff71.png)

**Color editor view**

![color-editor-view](https://user-images.githubusercontent.com/1515901/147817855-9129c368-a235-4ade-b7cc-773aaeb971f5.png)
