### PR TITLE
Fix font output when exporting images from GTK3 GUI

### DIFF
--- a/libleptongui/src/x_image.c
+++ b/libleptongui/src/x_image.c
@@ -800,6 +800,14 @@ GdkPixbuf
                 "color-map", render_color_map,
                 NULL);
 
+  EdaConfig *cfg = eda_config_get_context_for_path (".");
+  gchar *fontstr = eda_config_get_string (cfg, "schematic.gui", "font", NULL);
+
+  if (fontstr != NULL) {
+    g_object_set (renderer, "font-name", fontstr, NULL);
+    g_free (fontstr);
+  }
+
   /* Paint background */
   LeptonColor *color = x_color_lookup (BACKGROUND_COLOR);
 


### PR DESCRIPTION
Previously, the code in question used some default font name and
this issue was only relevant for the GTK3 GUI.  Now, the font name
set up in configuration is used for exporting images.