### PR TITLE
Get rid of warnings on some deprecated gtk_misc*() functions when building with GTK3 enabled

### DIFF
--- a/libleptongui/src/gschem_bottom_widget.c
+++ b/libleptongui/src/gschem_bottom_widget.c
@@ -854,15 +854,36 @@ gschem_bottom_widget_init (GschemBottomWidget *widget)
 
   widget->left_button_label = gtk_label_new (NULL);
   gtk_widget_set_tooltip_text (widget->left_button_label, _("Left mouse button"));
+#ifdef ENABLE_GTK3
+  gtk_widget_set_margin_left (GTK_WIDGET (widget->left_button_label), LABEL_XPAD);
+  gtk_widget_set_margin_right (GTK_WIDGET (widget->left_button_label), LABEL_XPAD);
+  gtk_widget_set_margin_top (GTK_WIDGET (widget->left_button_label), LABEL_YPAD);
+  gtk_widget_set_margin_bottom (GTK_WIDGET (widget->left_button_label), LABEL_YPAD);
+#else
   gtk_misc_set_padding (GTK_MISC (widget->left_button_label), LABEL_XPAD, LABEL_YPAD);
+#endif
 
   widget->middle_button_label = gtk_label_new (NULL);
   gtk_widget_set_tooltip_text (widget->middle_button_label, _("Middle mouse button"));
+#ifdef ENABLE_GTK3
+  gtk_widget_set_margin_left (GTK_WIDGET (widget->middle_button_label), LABEL_XPAD);
+  gtk_widget_set_margin_right (GTK_WIDGET (widget->middle_button_label), LABEL_XPAD);
+  gtk_widget_set_margin_top (GTK_WIDGET (widget->middle_button_label), LABEL_YPAD);
+  gtk_widget_set_margin_bottom (GTK_WIDGET (widget->middle_button_label), LABEL_YPAD);
+#else
   gtk_misc_set_padding (GTK_MISC (widget->middle_button_label), LABEL_XPAD, LABEL_YPAD);
+#endif
 
   widget->right_button_label = gtk_label_new (NULL);
   gtk_widget_set_tooltip_text (widget->right_button_label, _("Right mouse button"));
+#ifdef ENABLE_GTK3
+  gtk_widget_set_margin_left (GTK_WIDGET (widget->right_button_label), LABEL_XPAD);
+  gtk_widget_set_margin_right (GTK_WIDGET (widget->right_button_label), LABEL_XPAD);
+  gtk_widget_set_margin_top (GTK_WIDGET (widget->right_button_label), LABEL_YPAD);
+  gtk_widget_set_margin_bottom (GTK_WIDGET (widget->right_button_label), LABEL_YPAD);
+#else
   gtk_misc_set_padding (GTK_MISC (widget->right_button_label), LABEL_XPAD, LABEL_YPAD);
+#endif
 
 
   /* default values for configuration settings: */
@@ -964,7 +985,14 @@ gschem_bottom_widget_init (GschemBottomWidget *widget)
   gtk_widget_set_tooltip_text (widget->rubber_band_label,
                                _("Net rubber band mode.\n"
                                  "Click to toggle ON/OFF."));
+#ifdef ENABLE_GTK3
+  gtk_widget_set_margin_left (GTK_WIDGET (widget->rubber_band_label), LABEL_XPAD);
+  gtk_widget_set_margin_right (GTK_WIDGET (widget->rubber_band_label), LABEL_XPAD);
+  gtk_widget_set_margin_top (GTK_WIDGET (widget->rubber_band_label), LABEL_YPAD);
+  gtk_widget_set_margin_bottom (GTK_WIDGET (widget->rubber_band_label), LABEL_YPAD);
+#else
   gtk_misc_set_padding (GTK_MISC (widget->rubber_band_label), LABEL_XPAD, LABEL_YPAD);
+#endif
   if (show_rubber_band_indicator)
   {
     GtkWidget* ebox_rubber_band = gtk_event_box_new();
@@ -987,7 +1015,14 @@ gschem_bottom_widget_init (GschemBottomWidget *widget)
   gtk_widget_set_tooltip_text (widget->magnetic_net_label,
                                _("Magnetic net mode.\n"
                                  "Click to toggle ON/OFF."));
+#ifdef ENABLE_GTK3
+  gtk_widget_set_margin_left (GTK_WIDGET (widget->magnetic_net_label), LABEL_XPAD);
+  gtk_widget_set_margin_right (GTK_WIDGET (widget->magnetic_net_label), LABEL_XPAD);
+  gtk_widget_set_margin_top (GTK_WIDGET (widget->magnetic_net_label), LABEL_YPAD);
+  gtk_widget_set_margin_bottom (GTK_WIDGET (widget->magnetic_net_label), LABEL_YPAD);
+#else
   gtk_misc_set_padding (GTK_MISC (widget->magnetic_net_label), LABEL_XPAD, LABEL_YPAD);
+#endif
   if (show_magnetic_net_indicator)
   {
     GtkWidget* ebox_magnetic_net = gtk_event_box_new();
@@ -1004,7 +1039,14 @@ gschem_bottom_widget_init (GschemBottomWidget *widget)
 
   widget->status_label = gtk_label_new (NULL);
   gtk_widget_set_tooltip_text (widget->status_label, _("Current action mode"));
+#ifdef ENABLE_GTK3
+  gtk_widget_set_margin_left (GTK_WIDGET (widget->status_label), LABEL_XPAD);
+  gtk_widget_set_margin_right (GTK_WIDGET (widget->status_label), LABEL_XPAD);
+  gtk_widget_set_margin_top (GTK_WIDGET (widget->status_label), LABEL_YPAD);
+  gtk_widget_set_margin_bottom (GTK_WIDGET (widget->status_label), LABEL_YPAD);
+#else
   gtk_misc_set_padding (GTK_MISC (widget->status_label), LABEL_XPAD, LABEL_YPAD);
+#endif
   gtk_box_pack_end (GTK_BOX (widget), widget->status_label, FALSE, FALSE, 0);
 
   separator = separator_new ();

--- a/libleptongui/src/gschem_bottom_widget.c
+++ b/libleptongui/src/gschem_bottom_widget.c
@@ -855,8 +855,8 @@ gschem_bottom_widget_init (GschemBottomWidget *widget)
   widget->left_button_label = gtk_label_new (NULL);
   gtk_widget_set_tooltip_text (widget->left_button_label, _("Left mouse button"));
 #ifdef ENABLE_GTK3
-  gtk_widget_set_margin_left (GTK_WIDGET (widget->left_button_label), LABEL_XPAD);
-  gtk_widget_set_margin_right (GTK_WIDGET (widget->left_button_label), LABEL_XPAD);
+  gtk_widget_set_margin_start (GTK_WIDGET (widget->left_button_label), LABEL_XPAD);
+  gtk_widget_set_margin_end (GTK_WIDGET (widget->left_button_label), LABEL_XPAD);
   gtk_widget_set_margin_top (GTK_WIDGET (widget->left_button_label), LABEL_YPAD);
   gtk_widget_set_margin_bottom (GTK_WIDGET (widget->left_button_label), LABEL_YPAD);
 #else
@@ -866,8 +866,8 @@ gschem_bottom_widget_init (GschemBottomWidget *widget)
   widget->middle_button_label = gtk_label_new (NULL);
   gtk_widget_set_tooltip_text (widget->middle_button_label, _("Middle mouse button"));
 #ifdef ENABLE_GTK3
-  gtk_widget_set_margin_left (GTK_WIDGET (widget->middle_button_label), LABEL_XPAD);
-  gtk_widget_set_margin_right (GTK_WIDGET (widget->middle_button_label), LABEL_XPAD);
+  gtk_widget_set_margin_start (GTK_WIDGET (widget->middle_button_label), LABEL_XPAD);
+  gtk_widget_set_margin_end (GTK_WIDGET (widget->middle_button_label), LABEL_XPAD);
   gtk_widget_set_margin_top (GTK_WIDGET (widget->middle_button_label), LABEL_YPAD);
   gtk_widget_set_margin_bottom (GTK_WIDGET (widget->middle_button_label), LABEL_YPAD);
 #else
@@ -877,8 +877,8 @@ gschem_bottom_widget_init (GschemBottomWidget *widget)
   widget->right_button_label = gtk_label_new (NULL);
   gtk_widget_set_tooltip_text (widget->right_button_label, _("Right mouse button"));
 #ifdef ENABLE_GTK3
-  gtk_widget_set_margin_left (GTK_WIDGET (widget->right_button_label), LABEL_XPAD);
-  gtk_widget_set_margin_right (GTK_WIDGET (widget->right_button_label), LABEL_XPAD);
+  gtk_widget_set_margin_start (GTK_WIDGET (widget->right_button_label), LABEL_XPAD);
+  gtk_widget_set_margin_end (GTK_WIDGET (widget->right_button_label), LABEL_XPAD);
   gtk_widget_set_margin_top (GTK_WIDGET (widget->right_button_label), LABEL_YPAD);
   gtk_widget_set_margin_bottom (GTK_WIDGET (widget->right_button_label), LABEL_YPAD);
 #else
@@ -986,8 +986,8 @@ gschem_bottom_widget_init (GschemBottomWidget *widget)
                                _("Net rubber band mode.\n"
                                  "Click to toggle ON/OFF."));
 #ifdef ENABLE_GTK3
-  gtk_widget_set_margin_left (GTK_WIDGET (widget->rubber_band_label), LABEL_XPAD);
-  gtk_widget_set_margin_right (GTK_WIDGET (widget->rubber_band_label), LABEL_XPAD);
+  gtk_widget_set_margin_start (GTK_WIDGET (widget->rubber_band_label), LABEL_XPAD);
+  gtk_widget_set_margin_end (GTK_WIDGET (widget->rubber_band_label), LABEL_XPAD);
   gtk_widget_set_margin_top (GTK_WIDGET (widget->rubber_band_label), LABEL_YPAD);
   gtk_widget_set_margin_bottom (GTK_WIDGET (widget->rubber_band_label), LABEL_YPAD);
 #else
@@ -1016,8 +1016,8 @@ gschem_bottom_widget_init (GschemBottomWidget *widget)
                                _("Magnetic net mode.\n"
                                  "Click to toggle ON/OFF."));
 #ifdef ENABLE_GTK3
-  gtk_widget_set_margin_left (GTK_WIDGET (widget->magnetic_net_label), LABEL_XPAD);
-  gtk_widget_set_margin_right (GTK_WIDGET (widget->magnetic_net_label), LABEL_XPAD);
+  gtk_widget_set_margin_start (GTK_WIDGET (widget->magnetic_net_label), LABEL_XPAD);
+  gtk_widget_set_margin_end (GTK_WIDGET (widget->magnetic_net_label), LABEL_XPAD);
   gtk_widget_set_margin_top (GTK_WIDGET (widget->magnetic_net_label), LABEL_YPAD);
   gtk_widget_set_margin_bottom (GTK_WIDGET (widget->magnetic_net_label), LABEL_YPAD);
 #else
@@ -1040,8 +1040,8 @@ gschem_bottom_widget_init (GschemBottomWidget *widget)
   widget->status_label = gtk_label_new (NULL);
   gtk_widget_set_tooltip_text (widget->status_label, _("Current action mode"));
 #ifdef ENABLE_GTK3
-  gtk_widget_set_margin_left (GTK_WIDGET (widget->status_label), LABEL_XPAD);
-  gtk_widget_set_margin_right (GTK_WIDGET (widget->status_label), LABEL_XPAD);
+  gtk_widget_set_margin_start (GTK_WIDGET (widget->status_label), LABEL_XPAD);
+  gtk_widget_set_margin_end (GTK_WIDGET (widget->status_label), LABEL_XPAD);
   gtk_widget_set_margin_top (GTK_WIDGET (widget->status_label), LABEL_YPAD);
   gtk_widget_set_margin_bottom (GTK_WIDGET (widget->status_label), LABEL_YPAD);
 #else

--- a/libleptongui/src/gschem_coord_dialog.c
+++ b/libleptongui/src/gschem_coord_dialog.c
@@ -106,16 +106,30 @@ void coord_dialog (GschemToplevel *w_current, int x, int y)
     frame = gtk_frame_new (_("Screen"));
     w_current->coord_screen = gtk_label_new("(########, ########)");
     gtk_label_set_justify( GTK_LABEL(w_current->coord_screen), GTK_JUSTIFY_LEFT);
+#ifdef ENABLE_GTK3
+    gtk_widget_set_margin_left (w_current->coord_screen, DIALOG_H_SPACING);
+    gtk_widget_set_margin_right (w_current->coord_screen, DIALOG_H_SPACING);
+    gtk_widget_set_margin_top (w_current->coord_screen, DIALOG_V_SPACING);
+    gtk_widget_set_margin_bottom (w_current->coord_screen, DIALOG_V_SPACING);
+#else
     gtk_misc_set_padding(GTK_MISC(w_current->coord_screen),
                          DIALOG_H_SPACING, DIALOG_V_SPACING);
+#endif
     gtk_container_add(GTK_CONTAINER (frame),
                       w_current->coord_screen);
     gtk_box_pack_start(GTK_BOX (vbox), frame, FALSE, FALSE, 0);
 
     frame = gtk_frame_new (_("World"));
     w_current->coord_world = gtk_label_new ("(########, ########)");
+#ifdef ENABLE_GTK3
+    gtk_widget_set_margin_left (w_current->coord_world, DIALOG_H_SPACING);
+    gtk_widget_set_margin_right (w_current->coord_world, DIALOG_H_SPACING);
+    gtk_widget_set_margin_top (w_current->coord_world, DIALOG_V_SPACING);
+    gtk_widget_set_margin_bottom (w_current->coord_world, DIALOG_V_SPACING);
+#else
     gtk_misc_set_padding(GTK_MISC(w_current->coord_world),
                          DIALOG_H_SPACING, DIALOG_V_SPACING);
+#endif
     gtk_label_set_justify(GTK_LABEL(w_current->coord_world),
                           GTK_JUSTIFY_LEFT);
     gtk_container_add(GTK_CONTAINER (frame),

--- a/libleptongui/src/gschem_coord_dialog.c
+++ b/libleptongui/src/gschem_coord_dialog.c
@@ -107,8 +107,8 @@ void coord_dialog (GschemToplevel *w_current, int x, int y)
     w_current->coord_screen = gtk_label_new("(########, ########)");
     gtk_label_set_justify( GTK_LABEL(w_current->coord_screen), GTK_JUSTIFY_LEFT);
 #ifdef ENABLE_GTK3
-    gtk_widget_set_margin_left (w_current->coord_screen, DIALOG_H_SPACING);
-    gtk_widget_set_margin_right (w_current->coord_screen, DIALOG_H_SPACING);
+    gtk_widget_set_margin_start (w_current->coord_screen, DIALOG_H_SPACING);
+    gtk_widget_set_margin_end (w_current->coord_screen, DIALOG_H_SPACING);
     gtk_widget_set_margin_top (w_current->coord_screen, DIALOG_V_SPACING);
     gtk_widget_set_margin_bottom (w_current->coord_screen, DIALOG_V_SPACING);
 #else
@@ -122,8 +122,8 @@ void coord_dialog (GschemToplevel *w_current, int x, int y)
     frame = gtk_frame_new (_("World"));
     w_current->coord_world = gtk_label_new ("(########, ########)");
 #ifdef ENABLE_GTK3
-    gtk_widget_set_margin_left (w_current->coord_world, DIALOG_H_SPACING);
-    gtk_widget_set_margin_right (w_current->coord_world, DIALOG_H_SPACING);
+    gtk_widget_set_margin_start (w_current->coord_world, DIALOG_H_SPACING);
+    gtk_widget_set_margin_end (w_current->coord_world, DIALOG_H_SPACING);
     gtk_widget_set_margin_top (w_current->coord_world, DIALOG_V_SPACING);
     gtk_widget_set_margin_bottom (w_current->coord_world, DIALOG_V_SPACING);
 #else

--- a/libleptongui/src/gschem_dialog_misc.c
+++ b/libleptongui/src/gschem_dialog_misc.c
@@ -48,9 +48,14 @@ gschem_dialog_misc_create_property_label (const char *label)
 {
   GtkWidget *widget = gtk_label_new_with_mnemonic (label);
 
+#ifdef ENABLE_GTK3
+  gtk_label_set_xalign (GTK_LABEL (widget), 0.0);
+  gtk_label_set_yalign (GTK_LABEL (widget), 0.0);
+#else
   gtk_misc_set_alignment (GTK_MISC (widget),
                           0.0,                  /* xalign */
                           0.0);                 /* yalign */
+#endif
 
   return widget;
 }

--- a/libleptongui/src/x_attribedit.c
+++ b/libleptongui/src/x_attribedit.c
@@ -366,10 +366,12 @@ void attrib_edit_dialog (GschemToplevel *w_current, LeptonObject *attr_obj, int 
 
   /* Name selection */
   label = gtk_label_new_with_mnemonic (_("N_ame:"));
-  gtk_misc_set_alignment (GTK_MISC (label), 0, 0.5);
 #ifdef ENABLE_GTK3
+  gtk_label_set_xalign (GTK_LABEL (label), 0.0);
+  gtk_label_set_yalign (GTK_LABEL (label), 0.5);
   gtk_grid_attach (GTK_GRID (grid), label, 0, 0, 1, 1);
 #else
+  gtk_misc_set_alignment (GTK_MISC (label), 0, 0.5);
   gtk_table_attach (GTK_TABLE (table), label, 0, 1, 0, 1,
                     (GtkAttachOptions) (GTK_FILL),
                     (GtkAttachOptions) (GTK_FILL), 0, 0);
@@ -395,10 +397,12 @@ void attrib_edit_dialog (GschemToplevel *w_current, LeptonObject *attr_obj, int 
 
   /* Value entry */
   label = gtk_label_new_with_mnemonic (_("_Value:"));
-  gtk_misc_set_alignment (GTK_MISC (label), 0, 0.5);
 #ifdef ENABLE_GTK3
+  gtk_label_set_xalign (GTK_LABEL (label), 0.0);
+  gtk_label_set_yalign (GTK_LABEL (label), 0.5);
   gtk_grid_attach (GTK_GRID (grid), label, 0, 1, 1, 1);
 #else
+  gtk_misc_set_alignment (GTK_MISC (label), 0, 0.5);
   gtk_table_attach (GTK_TABLE (table), label, 0, 1, 1, 2,
                     (GtkAttachOptions) (GTK_FILL),
                     (GtkAttachOptions) (0), 0, 0);
@@ -463,7 +467,12 @@ void attrib_edit_dialog (GschemToplevel *w_current, LeptonObject *attr_obj, int 
 
     label = gtk_label_new(_("<b>Attach Options</b>"));
     gtk_label_set_use_markup (GTK_LABEL (label), TRUE);
+#ifdef ENABLE_GTK3
+    gtk_label_set_xalign (GTK_LABEL (label), 0.0);
+    gtk_label_set_yalign (GTK_LABEL (label), 0.0);
+#else
     gtk_misc_set_alignment(GTK_MISC(label),0,0);
+#endif
     gtk_box_pack_start(GTK_BOX(vbox), label, FALSE, FALSE, 0);
 
     alignment = gtk_alignment_new(0,0,1,1);

--- a/libleptongui/src/x_autonumber.c
+++ b/libleptongui/src/x_autonumber.c
@@ -1246,7 +1246,12 @@ GtkWidget* autonumber_create_dialog(GschemToplevel *w_current)
   /* scope section */
   label1 = gtk_label_new (_("<b>Scope</b>"));
   gtk_label_set_use_markup (GTK_LABEL (label1), TRUE);
+#ifdef ENABLE_GTK3
   gtk_misc_set_alignment (GTK_MISC(label1), 0, 0);
+#else
+  gtk_label_set_xalign (GTK_LABEL (label1), 0.0);
+  gtk_label_set_yalign (GTK_LABEL (label1), 0.0);
+#endif
   gtk_box_pack_start (GTK_BOX(vbox1), label1, TRUE, TRUE, 0);
   gtk_widget_show (label1);
 
@@ -1282,12 +1287,14 @@ GtkWidget* autonumber_create_dialog(GschemToplevel *w_current)
   gtk_widget_show (label4);
 #ifdef ENABLE_GTK3
   gtk_grid_attach (GTK_GRID (grid1), label4, 0, 0, 1, 1);
+  gtk_label_set_xalign (GTK_LABEL (label4), 0.0);
+  gtk_label_set_yalign (GTK_LABEL (label4), 0.5);
 #else
   gtk_table_attach (GTK_TABLE (table1), label4, 0, 1, 0, 1,
                     (GtkAttachOptions) (GTK_FILL),
                     (GtkAttachOptions) (0), 0, 0);
-#endif
   gtk_misc_set_alignment (GTK_MISC (label4), 0, 0.5);
+#endif
 
   scope_text = gtk_combo_box_text_new_with_entry ();
   gtk_entry_set_activates_default(GTK_ENTRY(gtk_bin_get_child(GTK_BIN(scope_text))), TRUE);
@@ -1305,22 +1312,26 @@ GtkWidget* autonumber_create_dialog(GschemToplevel *w_current)
 #ifdef ENABLE_GTK3
   gtk_grid_attach (GTK_GRID (grid1), label8, 0, 1, 1, 1);
 #else
+  gtk_label_set_xalign (GTK_LABEL (label8), 0.0);
+  gtk_label_set_yalign (GTK_LABEL (label8), 0.5);
   gtk_table_attach (GTK_TABLE (table1), label8, 0, 1, 1, 2,
                     (GtkAttachOptions) (GTK_FILL),
                     (GtkAttachOptions) (0), 0, 0);
-#endif
   gtk_misc_set_alignment (GTK_MISC (label8), 0, 0.5);
+#endif
 
   label6 = gtk_label_new (_("Skip numbers found in:"));
   gtk_widget_show (label6);
 #ifdef ENABLE_GTK3
   gtk_grid_attach (GTK_GRID (grid1), label6, 0, 2, 1, 1);
+  gtk_label_set_xalign (GTK_LABEL (label6), 0.0);
+  gtk_label_set_yalign (GTK_LABEL (label6), 0.5);
 #else
   gtk_table_attach (GTK_TABLE (table1), label6, 0, 1, 2, 3,
                     (GtkAttachOptions) (GTK_FILL),
                     (GtkAttachOptions) (0), 0, 0);
-#endif
   gtk_misc_set_alignment (GTK_MISC (label6), 0, 0.5);
+#endif
 
   scope_number = gtk_combo_box_text_new ();
   gtk_widget_show (scope_number);
@@ -1355,7 +1366,12 @@ GtkWidget* autonumber_create_dialog(GschemToplevel *w_current)
   /* Options section */
   label3 = gtk_label_new (_("<b>Options</b>"));
   gtk_label_set_use_markup (GTK_LABEL (label3), TRUE);
+#ifdef ENABLE_GTK3
   gtk_misc_set_alignment(GTK_MISC(label3), 0, 0);
+#else
+  gtk_label_set_xalign (GTK_LABEL (label3), 0.0);
+  gtk_label_set_yalign (GTK_LABEL (label3), 0.0);
+#endif
   gtk_widget_show (label3);
   gtk_box_pack_start(GTK_BOX(vbox1), label3, TRUE, TRUE, 0);
 
@@ -1391,23 +1407,27 @@ GtkWidget* autonumber_create_dialog(GschemToplevel *w_current)
   gtk_widget_show (label12);
 #ifdef ENABLE_GTK3
   gtk_grid_attach (GTK_GRID (grid3), label12, 0, 0, 1, 1);
+  gtk_label_set_xalign (GTK_LABEL (label12), 0.0);
+  gtk_label_set_yalign (GTK_LABEL (label12), 0.5);
 #else
   gtk_table_attach (GTK_TABLE (table3), label12, 0, 1, 0, 1,
                     (GtkAttachOptions) (GTK_FILL),
                     (GtkAttachOptions) (0), 0, 0);
-#endif
   gtk_misc_set_alignment (GTK_MISC (label12), 0, 0.5);
+#endif
 
   label13 = gtk_label_new (_("Sort order:"));
   gtk_widget_show (label13);
 #ifdef ENABLE_GTK3
   gtk_grid_attach (GTK_GRID (grid3), label13, 0, 1, 1, 1);
+  gtk_label_set_xalign (GTK_LABEL (label13), 0.0);
+  gtk_label_set_yalign (GTK_LABEL (label13), 0.5);
 #else
   gtk_table_attach (GTK_TABLE (table3), label13, 0, 1, 1, 2,
                     (GtkAttachOptions) (GTK_FILL),
                     (GtkAttachOptions) (0), 0, 0);
-#endif
   gtk_misc_set_alignment (GTK_MISC (label13), 0, 0.5);
+#endif
 
 
   /* this sets the page size to 10 (step * 10).

--- a/libleptongui/src/x_compselect.c
+++ b/libleptongui/src/x_compselect.c
@@ -1155,7 +1155,12 @@ create_lib_treeview (Compselect *compselect)
 
   /* create the entry label */
   label = gtk_label_new_with_mnemonic (_("_Filter:"));
+#ifdef ENABLE_GTK3
+  gtk_label_set_xalign (GTK_LABEL (label), 0.0);
+  gtk_label_set_yalign (GTK_LABEL (label), 0.5);
+#else
   gtk_misc_set_alignment (GTK_MISC (label), 0.0, 0.5);
+#endif
 
   /* add the search label to the filter area */
   gtk_box_pack_start (GTK_BOX (hbox), label,

--- a/libleptongui/src/x_dialog.c
+++ b/libleptongui/src/x_dialog.c
@@ -322,7 +322,12 @@ major_changed_dialog (GschemToplevel* w_current)
   g_free (bname);
 
   GtkWidget* label_page_bname = gtk_label_new (text);
+#ifdef ENABLE_GTK3
+  gtk_label_set_xalign (GTK_LABEL (label_page_bname), 0.0);
+  gtk_label_set_yalign (GTK_LABEL (label_page_bname), 0.0);
+#else
   gtk_misc_set_alignment (GTK_MISC (label_page_bname), 0.0, 0.0);
+#endif
   gtk_box_pack_start (GTK_BOX (vbox), label_page_bname, FALSE, FALSE, 0);
 
   g_free (text);

--- a/libleptongui/src/x_image.c
+++ b/libleptongui/src/x_image.c
@@ -513,8 +513,8 @@ void x_image_setup (GschemToplevel *w_current)
 #ifdef ENABLE_GTK3
   gtk_label_set_xalign (GTK_LABEL (label1), 0.0);
   gtk_label_set_yalign (GTK_LABEL (label1), 0.0);
-  gtk_widget_set_margin_left (label1, 0);
-  gtk_widget_set_margin_right (label1, 0);
+  gtk_widget_set_margin_start (label1, 0);
+  gtk_widget_set_margin_end (label1, 0);
   gtk_widget_set_margin_top (label1, 0);
   gtk_widget_set_margin_bottom (label1, 0);
 #else
@@ -542,8 +542,8 @@ void x_image_setup (GschemToplevel *w_current)
 #ifdef ENABLE_GTK3
   gtk_label_set_xalign (GTK_LABEL (label2), 0.0);
   gtk_label_set_yalign (GTK_LABEL (label2), 0.0);
-  gtk_widget_set_margin_left (label2, 0);
-  gtk_widget_set_margin_right (label2, 0);
+  gtk_widget_set_margin_start (label2, 0);
+  gtk_widget_set_margin_end (label2, 0);
   gtk_widget_set_margin_top (label2, 0);
   gtk_widget_set_margin_bottom (label2, 0);
 #else
@@ -569,8 +569,8 @@ void x_image_setup (GschemToplevel *w_current)
 #ifdef ENABLE_GTK3
   gtk_label_set_xalign (GTK_LABEL (label3), 0.0);
   gtk_label_set_yalign (GTK_LABEL (label3), 0.0);
-  gtk_widget_set_margin_left (label3, 0);
-  gtk_widget_set_margin_right (label3, 0);
+  gtk_widget_set_margin_start (label3, 0);
+  gtk_widget_set_margin_end (label3, 0);
   gtk_widget_set_margin_top (label3, 0);
   gtk_widget_set_margin_bottom (label3, 0);
 #else

--- a/libleptongui/src/x_image.c
+++ b/libleptongui/src/x_image.c
@@ -511,7 +511,14 @@ void x_image_setup (GschemToplevel *w_current)
   label1 = gtk_label_new (_("Width x Height"));
   gtk_widget_show (label1);
   gtk_misc_set_alignment( GTK_MISC (label1), 0, 0);
+#ifdef ENABLE_GTK3
+  gtk_widget_set_margin_left (label1, 0);
+  gtk_widget_set_margin_right (label1, 0);
+  gtk_widget_set_margin_top (label1, 0);
+  gtk_widget_set_margin_bottom (label1, 0);
+#else
   gtk_misc_set_padding (GTK_MISC (label1), 0, 0);
+#endif
   gtk_box_pack_start (GTK_BOX (vbox1),
       label1, FALSE, FALSE, 0);
 
@@ -531,7 +538,14 @@ void x_image_setup (GschemToplevel *w_current)
   label2 = gtk_label_new (_("Image type"));
   gtk_widget_show (label2);
   gtk_misc_set_alignment( GTK_MISC (label2), 0, 0);
+#ifdef ENABLE_GTK3
+  gtk_widget_set_margin_left (label2, 0);
+  gtk_widget_set_margin_right (label2, 0);
+  gtk_widget_set_margin_top (label2, 0);
+  gtk_widget_set_margin_bottom (label2, 0);
+#else
   gtk_misc_set_padding (GTK_MISC (label2), 0, 0);
+#endif
   gtk_box_pack_start (GTK_BOX (vbox2),
       label2, FALSE, FALSE, 0);
 
@@ -549,7 +563,14 @@ void x_image_setup (GschemToplevel *w_current)
 #endif
   GtkWidget* label3 = gtk_label_new (_("Color mode"));
   gtk_misc_set_alignment (GTK_MISC (label3), 0, 0);
+#ifdef ENABLE_GTK3
+  gtk_widget_set_margin_left (label3, 0);
+  gtk_widget_set_margin_right (label3, 0);
+  gtk_widget_set_margin_top (label3, 0);
+  gtk_widget_set_margin_bottom (label3, 0);
+#else
   gtk_misc_set_padding (GTK_MISC (label3), 0, 0);
+#endif
   gtk_box_pack_start (GTK_BOX (vbox3), label3, FALSE, FALSE, 0);
 
   GtkWidget* color_combo = gtk_combo_box_text_new();

--- a/libleptongui/src/x_image.c
+++ b/libleptongui/src/x_image.c
@@ -510,13 +510,15 @@ void x_image_setup (GschemToplevel *w_current)
 #endif
   label1 = gtk_label_new (_("Width x Height"));
   gtk_widget_show (label1);
-  gtk_misc_set_alignment( GTK_MISC (label1), 0, 0);
 #ifdef ENABLE_GTK3
+  gtk_label_set_xalign (GTK_LABEL (label1), 0.0);
+  gtk_label_set_yalign (GTK_LABEL (label1), 0.0);
   gtk_widget_set_margin_left (label1, 0);
   gtk_widget_set_margin_right (label1, 0);
   gtk_widget_set_margin_top (label1, 0);
   gtk_widget_set_margin_bottom (label1, 0);
 #else
+  gtk_misc_set_alignment( GTK_MISC (label1), 0, 0);
   gtk_misc_set_padding (GTK_MISC (label1), 0, 0);
 #endif
   gtk_box_pack_start (GTK_BOX (vbox1),
@@ -537,13 +539,15 @@ void x_image_setup (GschemToplevel *w_current)
 #endif
   label2 = gtk_label_new (_("Image type"));
   gtk_widget_show (label2);
-  gtk_misc_set_alignment( GTK_MISC (label2), 0, 0);
 #ifdef ENABLE_GTK3
+  gtk_label_set_xalign (GTK_LABEL (label2), 0.0);
+  gtk_label_set_yalign (GTK_LABEL (label2), 0.0);
   gtk_widget_set_margin_left (label2, 0);
   gtk_widget_set_margin_right (label2, 0);
   gtk_widget_set_margin_top (label2, 0);
   gtk_widget_set_margin_bottom (label2, 0);
 #else
+  gtk_misc_set_alignment( GTK_MISC (label2), 0, 0);
   gtk_misc_set_padding (GTK_MISC (label2), 0, 0);
 #endif
   gtk_box_pack_start (GTK_BOX (vbox2),
@@ -562,13 +566,15 @@ void x_image_setup (GschemToplevel *w_current)
   GtkWidget* vbox3 = gtk_vbox_new (TRUE, 0);
 #endif
   GtkWidget* label3 = gtk_label_new (_("Color mode"));
-  gtk_misc_set_alignment (GTK_MISC (label3), 0, 0);
 #ifdef ENABLE_GTK3
+  gtk_label_set_xalign (GTK_LABEL (label3), 0.0);
+  gtk_label_set_yalign (GTK_LABEL (label3), 0.0);
   gtk_widget_set_margin_left (label3, 0);
   gtk_widget_set_margin_right (label3, 0);
   gtk_widget_set_margin_top (label3, 0);
   gtk_widget_set_margin_bottom (label3, 0);
 #else
+  gtk_misc_set_alignment (GTK_MISC (label3), 0, 0);
   gtk_misc_set_padding (GTK_MISC (label3), 0, 0);
 #endif
   gtk_box_pack_start (GTK_BOX (vbox3), label3, FALSE, FALSE, 0);

--- a/libleptongui/src/x_multiattrib.c
+++ b/libleptongui/src/x_multiattrib.c
@@ -2308,7 +2308,12 @@ multiattrib_init (Multiattrib *multiattrib)
 
   /*   - the name entry: a GtkComboBoxEntry */
   label = gtk_label_new_with_mnemonic (_("_Name:"));
+#ifdef ENABLE_GTK3
+  gtk_label_set_xalign (GTK_LABEL (label), 0.0);
+  gtk_label_set_yalign (GTK_LABEL (label), 0.5);
+#else
   gtk_misc_set_alignment (GTK_MISC (label), 0.0, 0.5);
+#endif
 
   combo = gtk_combo_box_text_new_with_entry ();
 
@@ -2336,7 +2341,12 @@ multiattrib_init (Multiattrib *multiattrib)
 
   /*   - the value entry: a GtkEntry */
   label = gtk_label_new_with_mnemonic (_("_Value:"));
+#ifdef ENABLE_GTK3
+  gtk_label_set_xalign (GTK_LABEL (label), 0.0);
+  gtk_label_set_yalign (GTK_LABEL (label), 0.5);
+#else
   gtk_misc_set_alignment (GTK_MISC (label), 0.0, 0.5);
+#endif
 
   scrolled_win = GTK_WIDGET (
                              g_object_new (GTK_TYPE_SCROLLED_WINDOW,


### PR DESCRIPTION
On my system, this commit series reduces the number of build warnings by the amount more than 150.