### PR TITLE
Get rid of deprecated gtk_stock*() functions and macros

### DIFF
--- a/libleptonattrib/src/x_dialog.c
+++ b/libleptonattrib/src/x_dialog.c
@@ -73,10 +73,10 @@ void x_dialog_newattrib()
 
   /* Create the dialog */
   dialog = gtk_dialog_new_with_buttons(_("Add new attribute"), NULL,
-				       GTK_DIALOG_MODAL,
-				       GTK_STOCK_OK, GTK_RESPONSE_OK,
-				       GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL,
-				       NULL);
+                                       GTK_DIALOG_MODAL,
+                                       _("_OK"), GTK_RESPONSE_OK,
+                                       _("_Cancel"), GTK_RESPONSE_CANCEL,
+                                       NULL);
 
   gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_OK);
 
@@ -190,9 +190,9 @@ void x_dialog_missing_sym()
                                   "%s", string);
 
   gtk_dialog_add_buttons(GTK_DIALOG(dialog),
-                  GTK_STOCK_QUIT, GTK_RESPONSE_REJECT,
-                  GTK_STOCK_GO_FORWARD, GTK_RESPONSE_ACCEPT,
-                  NULL);
+                         _("_Quit"), GTK_RESPONSE_REJECT,
+                         _("_Forward"), GTK_RESPONSE_ACCEPT,
+                         NULL);
 
   gtk_window_set_title(GTK_WINDOW(dialog), _("Missing symbol file found for component!"));
   gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_REJECT);
@@ -235,8 +235,8 @@ void x_dialog_unsaved_data()
   gtk_message_dialog_set_markup (GTK_MESSAGE_DIALOG (dialog), str);
   gtk_dialog_add_buttons (GTK_DIALOG (dialog),
                           _("Close without saving"), GTK_RESPONSE_NO,
-                          GTK_STOCK_CANCEL,          GTK_RESPONSE_CANCEL,
-                          GTK_STOCK_SAVE,            GTK_RESPONSE_YES,
+                          _("_Cancel"),          GTK_RESPONSE_CANCEL,
+                          _("_Save"),            GTK_RESPONSE_YES,
                           NULL);
 
   /* Set the alternative button order (ok, cancel, help) for other systems */
@@ -403,10 +403,10 @@ void x_dialog_export_file()
   GtkWidget *dialog;
 
   dialog = gtk_file_chooser_dialog_new(_("Export CSV"), NULL,
-      GTK_FILE_CHOOSER_ACTION_SAVE,
-      GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL,
-      GTK_STOCK_SAVE, GTK_RESPONSE_ACCEPT,
-      NULL);
+                                       GTK_FILE_CHOOSER_ACTION_SAVE,
+                                       _("_Cancel"), GTK_RESPONSE_CANCEL,
+                                       _("_Save"), GTK_RESPONSE_ACCEPT,
+                                       NULL);
 
   gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_ACCEPT);
 
@@ -430,4 +430,3 @@ void x_dialog_export_file()
 
   gtk_widget_destroy(dialog);
 }
-

--- a/libleptonattrib/src/x_fileselect.c
+++ b/libleptonattrib/src/x_fileselect.c
@@ -126,8 +126,8 @@ x_fileselect_open (void)
   dialog = gtk_file_chooser_dialog_new (_("Open..."),
                                         GTK_WINDOW(window),
                                         GTK_FILE_CHOOSER_ACTION_OPEN,
-                                        GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL,
-                                        GTK_STOCK_OPEN,   GTK_RESPONSE_ACCEPT,
+                                        _("_Cancel"), GTK_RESPONSE_CANCEL,
+                                        _("_Open"),   GTK_RESPONSE_ACCEPT,
                                         NULL);
 
   /* Set the alternative button order (ok, cancel, help) for other systems */

--- a/libleptonattrib/src/x_window.c
+++ b/libleptonattrib/src/x_window.c
@@ -320,16 +320,16 @@ static const GtkActionEntry actions[] = {
   /* name, stock-id, label, accelerator, tooltip, callback function */
   /* File menu */
   { "file", NULL, "_File"},
-  { "file-save", GTK_STOCK_SAVE, "Save", "<Control>S", "", s_toplevel_save_sheet},
+  { "file-save", "document-save", "Save", "<Control>S", "", s_toplevel_save_sheet},
   { "file-export-csv", NULL, "Export CSV", "", "", menu_file_export_csv},
-  /* { "file-print", GTK_STOCK_PRINT, "Print", "<Control>P", "", x_dialog_unimplemented_feature}, */
-  { "file-quit", GTK_STOCK_QUIT, "Quit", "<Control>Q", "", G_CALLBACK(attrib_really_quit)},
+  /* { "file-print", "document-print", "Print", "<Control>P", "", x_dialog_unimplemented_feature}, */
+  { "file-quit", "application-exit", "Quit", "<Control>Q", "", G_CALLBACK(attrib_really_quit)},
 
   /* Edit menu */
   { "edit", NULL, "_Edit"},
   { "edit-add-attrib", NULL, "Add new attrib column", "", "", menu_edit_newattrib},
   { "edit-delete-attrib", NULL, "Delete attrib column", "", "", menu_edit_delattrib},
-  /* { "edit-find-attrib", GTK_STOCK_FIND, "Find attrib value", "<Control>F", "", x_dialog_unimplemented_feature}, */
+  /* { "edit-find-attrib", "edit-find", "Find attrib value", "<Control>F", "", x_dialog_unimplemented_feature}, */
   /* { "edit-search-replace-attrib-value", NULL, "Search and replace attrib value", "", "", x_dialog_unimplemented_feature}, */
   /* { "edit-search-for-refdes", NULL, "Search for refdes", "", "", x_dialog_unimplemented_feature}, */
 
@@ -342,7 +342,7 @@ static const GtkActionEntry actions[] = {
 
   /* Help menu */
   { "help", NULL, "_Help"},
-  { "help-about", GTK_STOCK_ABOUT, "About", "", "", x_dialog_about_dialog},
+  { "help-about", "help-about", "About", "", "", x_dialog_about_dialog},
 };
 
 

--- a/libleptongui/src/color_edit_widget.c
+++ b/libleptongui/src/color_edit_widget.c
@@ -640,8 +640,8 @@ dlg_save_as (GtkWidget* parent)
     _("Save Color Scheme"),
     GTK_WINDOW (parent),
     GTK_FILE_CHOOSER_ACTION_SAVE,
-    GTK_STOCK_SAVE,   GTK_RESPONSE_ACCEPT,
-    GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL,
+    _("_Save"), GTK_RESPONSE_ACCEPT,
+    _("_Cancel"), GTK_RESPONSE_CANCEL,
     NULL);
 
   gtk_dialog_set_alternative_button_order(

--- a/libleptongui/src/font_select_widget.c
+++ b/libleptongui/src/font_select_widget.c
@@ -585,8 +585,8 @@ save_settings_dlg (FontSelectWidget* widget)
     _("Save configuration"),
     GTK_WINDOW (widget->toplevel_->main_window),
     GTK_DIALOG_MODAL,
-    GTK_STOCK_OK,     GTK_RESPONSE_ACCEPT,
-    GTK_STOCK_CANCEL, GTK_RESPONSE_REJECT,
+    _("_OK"), GTK_RESPONSE_ACCEPT,
+    _("_Cancel"), GTK_RESPONSE_REJECT,
     NULL);
 
   /* text for radio buttons: */

--- a/libleptongui/src/gschem_arc_dialog.c
+++ b/libleptongui/src/gschem_arc_dialog.c
@@ -104,10 +104,8 @@ void arc_angle_dialog (GschemToplevel *w_current, LeptonObject *arc_object)
                                                          GTK_WINDOW(w_current->main_window),
                                                          GTK_DIALOG_MODAL,
                                                          "arc-angle", w_current,
-                                                         GTK_STOCK_CANCEL,
-                                                         GTK_RESPONSE_REJECT,
-                                                         GTK_STOCK_OK,
-                                                         GTK_RESPONSE_ACCEPT,
+                                                         _("_Cancel"), GTK_RESPONSE_REJECT,
+                                                         _("_OK"), GTK_RESPONSE_ACCEPT,
                                                          NULL);
 
   /* Set the alternative button order (ok, cancel, help) for other systems */

--- a/libleptongui/src/gschem_close_confirmation_dialog.c
+++ b/libleptongui/src/gschem_close_confirmation_dialog.c
@@ -583,8 +583,8 @@ close_confirmation_dialog_constructor (GType type,
   /* add buttons to dialog action area */
   gtk_dialog_add_buttons (GTK_DIALOG (dialog),
                           _("Close _without saving"), GTK_RESPONSE_NO,
-                          GTK_STOCK_CANCEL,           GTK_RESPONSE_CANCEL,
-                          GTK_STOCK_SAVE,             GTK_RESPONSE_YES,
+                          _("_Cancel"), GTK_RESPONSE_CANCEL,
+                          _("_Save"), GTK_RESPONSE_YES,
                           NULL);
 
   /* Set the alternative button order (ok, cancel, help) for other systems */

--- a/libleptongui/src/gschem_close_confirmation_dialog.c
+++ b/libleptongui/src/gschem_close_confirmation_dialog.c
@@ -496,7 +496,7 @@ close_confirmation_dialog_constructor (GType type,
                                     "xalign",    0.5,
                                     "yalign",    0.0,
                                     /* GtkImage */
-                                    "stock",     GTK_STOCK_DIALOG_WARNING,
+                                    "icon-name", "dialog-warning",
                                     "icon-size", GTK_ICON_SIZE_DIALOG,
                                     NULL));
   gtk_box_pack_start (GTK_BOX (hbox), image,

--- a/libleptongui/src/gschem_coord_dialog.c
+++ b/libleptongui/src/gschem_coord_dialog.c
@@ -87,8 +87,7 @@ void coord_dialog (GschemToplevel *w_current, int x, int y)
                                                          GTK_WINDOW(w_current->main_window),
                                                          (GtkDialogFlags) 0, /* Not modal GTK_DIALOG_MODAL */
                                                          "coord", w_current,
-                                                         GTK_STOCK_CLOSE,
-                                                         GTK_RESPONSE_REJECT,
+                                                         _("_Close"), GTK_RESPONSE_REJECT,
                                                          NULL);
 
     gtk_window_set_position (GTK_WINDOW (w_current->cowindow), GTK_WIN_POS_NONE);

--- a/libleptongui/src/gschem_find_text_widget.c
+++ b/libleptongui/src/gschem_find_text_widget.c
@@ -443,7 +443,7 @@ gschem_find_text_widget_init (GschemFindTextWidget *widget)
   gtk_widget_set_visible (widget->find_button, TRUE);
   gtk_box_pack_start (GTK_BOX (button_box), widget->find_button, FALSE, FALSE, 0);
 
-  cancel_button = gtk_button_new_from_stock (GTK_STOCK_CANCEL);
+  cancel_button = gtk_button_new_with_label (_("_Cancel"));
   gtk_widget_set_visible (cancel_button, TRUE);
   gtk_box_pack_start (GTK_BOX (button_box), cancel_button, FALSE, FALSE, 0);
 

--- a/libleptongui/src/gschem_find_text_widget.c
+++ b/libleptongui/src/gschem_find_text_widget.c
@@ -443,7 +443,7 @@ gschem_find_text_widget_init (GschemFindTextWidget *widget)
   gtk_widget_set_visible (widget->find_button, TRUE);
   gtk_box_pack_start (GTK_BOX (button_box), widget->find_button, FALSE, FALSE, 0);
 
-  cancel_button = gtk_button_new_with_label (_("_Cancel"));
+  cancel_button = gtk_button_new_with_mnemonic (_("_Cancel"));
   gtk_widget_set_visible (cancel_button, TRUE);
   gtk_box_pack_start (GTK_BOX (button_box), cancel_button, FALSE, FALSE, 0);
 

--- a/libleptongui/src/gschem_hotkey_dialog.c
+++ b/libleptongui/src/gschem_hotkey_dialog.c
@@ -194,7 +194,7 @@ void x_dialog_hotkeys (GschemToplevel *w_current)
     GTK_WINDOW (w_current->main_window),
     (GtkDialogFlags) 0, /* not modal */
     "hotkeys", w_current,
-    GTK_STOCK_CLOSE, GTK_RESPONSE_REJECT,
+    _("_Close"), GTK_RESPONSE_REJECT,
     NULL);
 
   g_signal_connect (G_OBJECT (w_current->hkwindow), "response",

--- a/libleptongui/src/gschem_macro_widget.c
+++ b/libleptongui/src/gschem_macro_widget.c
@@ -403,7 +403,7 @@ macro_widget_create (GschemMacroWidget* widget)
   gtk_widget_set_visible (widget->evaluate_button, TRUE);
   gtk_box_pack_start (GTK_BOX (button_box), widget->evaluate_button, FALSE, FALSE, 0);
 
-  cancel_button = gtk_button_new_from_stock (GTK_STOCK_CANCEL);
+  cancel_button = gtk_button_new_with_label (_("_Cancel"));
   gtk_widget_set_visible (cancel_button, TRUE);
   gtk_box_pack_start (GTK_BOX (button_box), cancel_button, FALSE, FALSE, 0);
 

--- a/libleptongui/src/gschem_macro_widget.c
+++ b/libleptongui/src/gschem_macro_widget.c
@@ -403,7 +403,7 @@ macro_widget_create (GschemMacroWidget* widget)
   gtk_widget_set_visible (widget->evaluate_button, TRUE);
   gtk_box_pack_start (GTK_BOX (button_box), widget->evaluate_button, FALSE, FALSE, 0);
 
-  cancel_button = gtk_button_new_with_label (_("_Cancel"));
+  cancel_button = gtk_button_new_with_mnemonic (_("_Cancel"));
   gtk_widget_set_visible (cancel_button, TRUE);
   gtk_box_pack_start (GTK_BOX (button_box), cancel_button, FALSE, FALSE, 0);
 

--- a/libleptongui/src/gschem_show_hide_text_widget.c
+++ b/libleptongui/src/gschem_show_hide_text_widget.c
@@ -299,7 +299,7 @@ gschem_show_hide_text_widget_init (GschemShowHideTextWidget *widget)
   gtk_widget_set_visible (widget->ok_button, TRUE);
   gtk_box_pack_start (GTK_BOX (button_box), widget->ok_button, FALSE, FALSE, 0);
 
-  cancel_button = gtk_button_new_from_stock (GTK_STOCK_CANCEL);
+  cancel_button = gtk_button_new_with_label (_("_Cancel"));
   gtk_widget_set_visible (cancel_button, TRUE);
   gtk_box_pack_start (GTK_BOX (button_box), cancel_button, FALSE, FALSE, 0);
 

--- a/libleptongui/src/gschem_show_hide_text_widget.c
+++ b/libleptongui/src/gschem_show_hide_text_widget.c
@@ -299,7 +299,7 @@ gschem_show_hide_text_widget_init (GschemShowHideTextWidget *widget)
   gtk_widget_set_visible (widget->ok_button, TRUE);
   gtk_box_pack_start (GTK_BOX (button_box), widget->ok_button, FALSE, FALSE, 0);
 
-  cancel_button = gtk_button_new_with_label (_("_Cancel"));
+  cancel_button = gtk_button_new_with_mnemonic (_("_Cancel"));
   gtk_widget_set_visible (cancel_button, TRUE);
   gtk_box_pack_start (GTK_BOX (button_box), cancel_button, FALSE, FALSE, 0);
 

--- a/libleptongui/src/gschem_slot_edit_dialog.c
+++ b/libleptongui/src/gschem_slot_edit_dialog.c
@@ -92,10 +92,8 @@ void slot_edit_dialog (GschemToplevel *w_current, const char *count, const char 
                                                          GTK_WINDOW(w_current->main_window),
                                                          GTK_DIALOG_MODAL,
                                                          "slot-edit", w_current,
-                                                         GTK_STOCK_CANCEL,
-                                                         GTK_RESPONSE_REJECT,
-                                                         GTK_STOCK_OK,
-                                                         GTK_RESPONSE_ACCEPT,
+                                                         _("_Cancel"), GTK_RESPONSE_REJECT,
+                                                         _("_OK"), GTK_RESPONSE_ACCEPT,
                                                          NULL);
 
   /* Set the alternative button order (ok, cancel, help) for other systems */

--- a/libleptongui/src/gschem_text_properties_widget.c
+++ b/libleptongui/src/gschem_text_properties_widget.c
@@ -220,7 +220,7 @@ create_text_content_section (GschemTextPropertiesWidget *widget)
 
   gtk_button_box_set_layout (GTK_BUTTON_BOX (bbox), GTK_BUTTONBOX_END);
 
-  widget->apply_button = gtk_button_new_with_label (_("Apply"));
+  widget->apply_button = gtk_button_new_with_mnemonic (_("_Apply"));
 
   g_signal_connect_swapped (G_OBJECT (widget->apply_button),
                             "clicked",

--- a/libleptongui/src/gschem_text_properties_widget.c
+++ b/libleptongui/src/gschem_text_properties_widget.c
@@ -220,7 +220,7 @@ create_text_content_section (GschemTextPropertiesWidget *widget)
 
   gtk_button_box_set_layout (GTK_BUTTON_BOX (bbox), GTK_BUTTONBOX_END);
 
-  widget->apply_button = gtk_button_new_from_stock (GTK_STOCK_APPLY);
+  widget->apply_button = gtk_button_new_with_label (_("Apply"));
 
   g_signal_connect_swapped (G_OBJECT (widget->apply_button),
                             "clicked",

--- a/libleptongui/src/gschem_translate_widget.c
+++ b/libleptongui/src/gschem_translate_widget.c
@@ -412,7 +412,7 @@ instance_init (GschemTranslateWidget *widget)
   gtk_widget_set_visible (widget->evaluate_button, TRUE);
   gtk_box_pack_start (GTK_BOX (button_box), widget->evaluate_button, FALSE, FALSE, 0);
 
-  cancel_button = gtk_button_new_from_stock (GTK_STOCK_CANCEL);
+  cancel_button = gtk_button_new_with_label (_("_Cancel"));
   gtk_widget_set_visible (cancel_button, TRUE);
   gtk_box_pack_start (GTK_BOX (button_box), cancel_button, FALSE, FALSE, 0);
 

--- a/libleptongui/src/gschem_translate_widget.c
+++ b/libleptongui/src/gschem_translate_widget.c
@@ -412,7 +412,7 @@ instance_init (GschemTranslateWidget *widget)
   gtk_widget_set_visible (widget->evaluate_button, TRUE);
   gtk_box_pack_start (GTK_BOX (button_box), widget->evaluate_button, FALSE, FALSE, 0);
 
-  cancel_button = gtk_button_new_with_label (_("_Cancel"));
+  cancel_button = gtk_button_new_with_mnemonic (_("_Cancel"));
   gtk_widget_set_visible (cancel_button, TRUE);
   gtk_box_pack_start (GTK_BOX (button_box), cancel_button, FALSE, FALSE, 0);
 

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -106,8 +106,8 @@ i_callback_file_script (GtkWidget *widget, gpointer data)
     _("Execute Script"),
     GTK_WINDOW (w_current->main_window),
     GTK_FILE_CHOOSER_ACTION_OPEN,
-    GTK_STOCK_CANCEL,  GTK_RESPONSE_CANCEL,
-    GTK_STOCK_EXECUTE, GTK_RESPONSE_ACCEPT,
+    _("_Cancel"), GTK_RESPONSE_CANCEL,
+    _("_Run"), GTK_RESPONSE_ACCEPT,
     NULL);
 
   /* Filter for Scheme files:

--- a/libleptongui/src/o_delete.c
+++ b/libleptongui/src/o_delete.c
@@ -87,7 +87,7 @@ void o_delete_selected (GschemToplevel *w_current)
     gtk_dialog_add_buttons (GTK_DIALOG (dialog),
         _("Delete _all"), GTK_RESPONSE_YES,
         _("All, _except locked"), GTK_RESPONSE_NO,
-        GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL, NULL);
+        _("_Cancel"), GTK_RESPONSE_CANCEL, NULL);
 
     gtk_dialog_set_default_response (GTK_DIALOG (dialog), GTK_RESPONSE_CANCEL);
     gtk_window_set_title (GTK_WINDOW (dialog), _("Delete"));

--- a/libleptongui/src/o_picture.c
+++ b/libleptongui/src/o_picture.c
@@ -181,9 +181,9 @@ void picture_selection_dialog (GschemToplevel *w_current)
   GtkWidget* pfswindow = gtk_file_chooser_dialog_new (_("Add Picture"),
                                                       GTK_WINDOW(w_current->main_window),
                                                       GTK_FILE_CHOOSER_ACTION_OPEN,
-                                                      GTK_STOCK_CANCEL,
+                                                      _("_Cancel"),
                                                       GTK_RESPONSE_CANCEL,
-                                                      GTK_STOCK_OPEN,
+                                                      _("_Open"),
                                                       GTK_RESPONSE_ACCEPT,
                                                       NULL);
 
@@ -386,9 +386,9 @@ void picture_change_filename_dialog (GschemToplevel *w_current)
   GtkWidget* pfswindow = gtk_file_chooser_dialog_new (_("Select Picture"),
                                                       GTK_WINDOW(w_current->main_window),
                                                       GTK_FILE_CHOOSER_ACTION_OPEN,
-                                                      GTK_STOCK_CANCEL,
+                                                      _("_Cancel"),
                                                       GTK_RESPONSE_CANCEL,
-                                                      GTK_STOCK_OPEN,
+                                                      _("_Open"),
                                                       GTK_RESPONSE_ACCEPT,
                                                       NULL);
 

--- a/libleptongui/src/x_attribedit.c
+++ b/libleptongui/src/x_attribedit.c
@@ -313,10 +313,8 @@ void attrib_edit_dialog (GschemToplevel *w_current, LeptonObject *attr_obj, int 
                                             GTK_WINDOW(w_current->main_window),
                                             GTK_DIALOG_MODAL,
                                             "singleattrib", w_current,
-                                            GTK_STOCK_CANCEL,
-                                            GTK_RESPONSE_REJECT,
-                                            GTK_STOCK_OK,
-                                            GTK_RESPONSE_APPLY,
+                                            _("_Cancel"), GTK_RESPONSE_REJECT,
+                                            _("_OK"), GTK_RESPONSE_APPLY,
                                             NULL);
   /* Set the alternative button order (ok, cancel, help) for other systems */
   gtk_dialog_set_alternative_button_order(GTK_DIALOG(aewindow),

--- a/libleptongui/src/x_autonumber.c
+++ b/libleptongui/src/x_autonumber.c
@@ -1225,10 +1225,8 @@ GtkWidget* autonumber_create_dialog(GschemToplevel *w_current)
                                                    GTK_WINDOW(w_current->main_window),
                                                    (GtkDialogFlags) 0, /* not modal */
                                                    "autonumber", w_current,
-                                                   GTK_STOCK_CLOSE,
-                                                   GTK_RESPONSE_REJECT,
-                                                   GTK_STOCK_APPLY,
-                                                   GTK_RESPONSE_ACCEPT,
+                                                   _("_Close"), GTK_RESPONSE_REJECT,
+                                                   _("_Apply"), GTK_RESPONSE_ACCEPT,
                                                    NULL);
   /* Set the alternative button order (ok, cancel, help) for other systems */
   gtk_dialog_set_alternative_button_order(GTK_DIALOG(autonumber_text),

--- a/libleptongui/src/x_compselect.c
+++ b/libleptongui/src/x_compselect.c
@@ -1583,8 +1583,8 @@ compselect_constructor (GType type,
   /* now add buttons in the action area */
   gtk_dialog_add_buttons (GTK_DIALOG (compselect),
                           /*  - close button */
-                          GTK_STOCK_CLOSE, GTK_RESPONSE_CLOSE,
-                          GTK_STOCK_OK, COMPSELECT_RESPONSE_HIDE,
+                          _("_Close"), GTK_RESPONSE_CLOSE,
+                          _("_OK"), COMPSELECT_RESPONSE_HIDE,
                           NULL);
 
   /* Set the alternative button order (ok, cancel, help) for other systems */

--- a/libleptongui/src/x_compselect.c
+++ b/libleptongui/src/x_compselect.c
@@ -1033,8 +1033,8 @@ create_inuse_treeview (Compselect *compselect)
                                      "relief",    GTK_RELIEF_NONE,
                                      NULL));
   gtk_container_add (GTK_CONTAINER (button),
-                     gtk_image_new_from_stock (GTK_STOCK_REFRESH,
-                                            GTK_ICON_SIZE_SMALL_TOOLBAR));
+                     gtk_image_new_from_icon_name ("view-refresh",
+                                                   GTK_ICON_SIZE_SMALL_TOOLBAR));
   /* add the refresh button to the horizontal box at the end */
   gtk_box_pack_end (GTK_BOX (hbox), button, FALSE, FALSE, 0);
   g_signal_connect (button,
@@ -1201,8 +1201,8 @@ create_lib_treeview (Compselect *compselect)
                                      NULL));
 
   gtk_container_add (GTK_CONTAINER (button),
-                     gtk_image_new_from_stock (GTK_STOCK_CLEAR,
-                                               GTK_ICON_SIZE_SMALL_TOOLBAR));
+                     gtk_image_new_from_icon_name ("edit-clear",
+                                                   GTK_ICON_SIZE_SMALL_TOOLBAR));
 
   gtk_widget_set_tooltip_text (button, _("Reset filter"));
 
@@ -1225,8 +1225,8 @@ create_lib_treeview (Compselect *compselect)
                                      "relief",    GTK_RELIEF_NONE,
                                      NULL));
   gtk_container_add (GTK_CONTAINER (button),
-                     gtk_image_new_from_stock (GTK_STOCK_REFRESH,
-                                            GTK_ICON_SIZE_SMALL_TOOLBAR));
+                     gtk_image_new_from_icon_name ("view-refresh",
+                                                   GTK_ICON_SIZE_SMALL_TOOLBAR));
   gtk_widget_set_tooltip_text (button, _("Reload all libraries"));
 
   /* add the refresh button to the filter area */

--- a/libleptongui/src/x_dialog.c
+++ b/libleptongui/src/x_dialog.c
@@ -110,8 +110,8 @@ char *generic_filesel_dialog (const char *msg, const char *templ, gint flags)
     dialog = gtk_file_chooser_dialog_new (title,
                                           NULL,
                                           GTK_FILE_CHOOSER_ACTION_OPEN,
-                                          GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL,
-                                          GTK_STOCK_OPEN, GTK_RESPONSE_OK,
+                                          _("_Cancel"), GTK_RESPONSE_CANCEL,
+                                          _("_Open"), GTK_RESPONSE_OK,
                                           NULL);
     /* Since this is a load dialog box, the file must exist! */
     flags = flags | FSB_MUST_EXIST;
@@ -121,8 +121,8 @@ char *generic_filesel_dialog (const char *msg, const char *templ, gint flags)
     dialog = gtk_file_chooser_dialog_new (title,
                                           NULL,
                                           GTK_FILE_CHOOSER_ACTION_SAVE,
-                                          GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL,
-                                          GTK_STOCK_SAVE, GTK_RESPONSE_OK,
+                                          _("_Cancel"), GTK_RESPONSE_CANCEL,
+                                          _("_Save"), GTK_RESPONSE_OK,
                                           NULL);
   }
 

--- a/libleptongui/src/x_dialog.c
+++ b/libleptongui/src/x_dialog.c
@@ -277,7 +277,7 @@ major_changed_dialog (GschemToplevel* w_current)
                                     "xalign", 0.5,
                                     "yalign", 0.0,
                                     /* GtkImage */
-                                    "stock", GTK_STOCK_DIALOG_WARNING,
+                                    "icon-name", "dialog-warning",
                                     "icon-size", GTK_ICON_SIZE_DIALOG,
                                     NULL));
   gtk_box_pack_start (GTK_BOX (hbox), image, FALSE, FALSE, 0);

--- a/libleptongui/src/x_dialog.c
+++ b/libleptongui/src/x_dialog.c
@@ -249,7 +249,7 @@ major_changed_dialog (GschemToplevel* w_current)
     _("Symbol version changes"),
     GTK_WINDOW (w_current->main_window),
     (GtkDialogFlags) GTK_DIALOG_DESTROY_WITH_PARENT,
-    GTK_STOCK_OK, GTK_RESPONSE_OK,
+    _("_OK"), GTK_RESPONSE_OK,
     NULL);
 
   content_area = gtk_dialog_get_content_area (GTK_DIALOG (dialog));

--- a/libleptongui/src/x_fileselect.c
+++ b/libleptongui/src/x_fileselect.c
@@ -329,8 +329,8 @@ x_fileselect_open(GschemToplevel *w_current)
   dialog = gtk_file_chooser_dialog_new (_("Open"),
                                         GTK_WINDOW(w_current->main_window),
                                         GTK_FILE_CHOOSER_ACTION_OPEN,
-                                        GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL,
-                                        GTK_STOCK_OPEN,   GTK_RESPONSE_ACCEPT,
+                                        _("_Cancel"), GTK_RESPONSE_CANCEL,
+                                        _("_Open"), GTK_RESPONSE_ACCEPT,
                                         NULL);
 
   /* Set the alternative button order (ok, cancel, help) for other systems */
@@ -420,8 +420,8 @@ x_fileselect_save (GschemToplevel *w_current,
     _("Save As"),
     GTK_WINDOW(w_current->main_window),
     GTK_FILE_CHOOSER_ACTION_SAVE,
-    GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL,
-    GTK_STOCK_SAVE,   GTK_RESPONSE_ACCEPT,
+    _("_Cancel"), GTK_RESPONSE_CANCEL,
+    _("_Save"),   GTK_RESPONSE_ACCEPT,
     NULL);
 
   /* Set the alternative button order (ok, cancel, help) for other systems:

--- a/libleptongui/src/x_image.c
+++ b/libleptongui/src/x_image.c
@@ -599,10 +599,10 @@ void x_image_setup (GschemToplevel *w_current)
 
   /* Create the dialog */
   dialog = gtk_file_chooser_dialog_new (_("Write Image"),
-      GTK_WINDOW(w_current->main_window),
-      GTK_FILE_CHOOSER_ACTION_SAVE,
-      GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL,
-      GTK_STOCK_SAVE,   GTK_RESPONSE_ACCEPT,
+                                        GTK_WINDOW(w_current->main_window),
+                                        GTK_FILE_CHOOSER_ACTION_SAVE,
+                                        _("_Cancel"), GTK_RESPONSE_CANCEL,
+                                        _("_Save"), GTK_RESPONSE_ACCEPT,
       NULL);
 
   /* Set the alternative button order (ok, cancel, help) for other systems */

--- a/libleptongui/src/x_multiattrib.c
+++ b/libleptongui/src/x_multiattrib.c
@@ -2462,7 +2462,7 @@ multiattrib_init (Multiattrib *multiattrib)
 #endif
 
   /* create the add button */
-  button = gtk_button_new_from_stock (GTK_STOCK_ADD);
+  button = gtk_button_new_with_label (_("_Add"));
   g_signal_connect (button,
                     "clicked",
                     G_CALLBACK (multiattrib_callback_button_add),

--- a/libleptongui/src/x_multiattrib.c
+++ b/libleptongui/src/x_multiattrib.c
@@ -2501,7 +2501,7 @@ multiattrib_init (Multiattrib *multiattrib)
 
   /* now add the close button to the action area */
   gtk_dialog_add_button (GTK_DIALOG (multiattrib),
-                         GTK_STOCK_CLOSE, GTK_RESPONSE_CLOSE);
+                         _("_Close"), GTK_RESPONSE_CLOSE);
 
   multiattrib_update (multiattrib);
 }

--- a/libleptongui/src/x_multiattrib.c
+++ b/libleptongui/src/x_multiattrib.c
@@ -2462,7 +2462,7 @@ multiattrib_init (Multiattrib *multiattrib)
 #endif
 
   /* create the add button */
-  button = gtk_button_new_with_label (_("_Add"));
+  button = gtk_button_new_with_mnemonic (_("_Add"));
   g_signal_connect (button,
                     "clicked",
                     G_CALLBACK (multiattrib_callback_button_add),

--- a/libleptongui/src/x_newtext.c
+++ b/libleptongui/src/x_newtext.c
@@ -222,12 +222,10 @@ static void newtext_init(NewText *dialog)
 #endif
 
   gtk_dialog_add_button (GTK_DIALOG (dialog),
-                         GTK_STOCK_CLOSE,
-                         GTK_RESPONSE_CLOSE);
+                         _("_Close"), GTK_RESPONSE_CLOSE);
 
   gtk_dialog_add_button (GTK_DIALOG (dialog),
-                         GTK_STOCK_APPLY,
-                         GTK_RESPONSE_APPLY);
+                         _("_Apply"), GTK_RESPONSE_APPLY);
 
   /* Set the alternative button order (ok, cancel, help) for other systems */
   gtk_dialog_set_alternative_button_order(GTK_DIALOG(dialog),

--- a/libleptongui/src/x_tabs.c
+++ b/libleptongui/src/x_tabs.c
@@ -936,7 +936,7 @@ x_tabs_hdr_create (TabInfo* nfo)
   gtk_button_set_relief (GTK_BUTTON (btn_save), GTK_RELIEF_NONE);
   gtk_button_set_focus_on_click (GTK_BUTTON (btn_save), FALSE);
 
-  GtkWidget* img_save = gtk_image_new_from_stock (GTK_STOCK_SAVE,
+  GtkWidget* img_save = gtk_image_new_from_stock ("document-save",
                                                   GTK_ICON_SIZE_MENU);
   gtk_container_add (GTK_CONTAINER (btn_save), img_save);
   gtk_widget_set_tooltip_text (btn_save, _("Save"));

--- a/libleptongui/src/x_tabs.c
+++ b/libleptongui/src/x_tabs.c
@@ -1668,15 +1668,15 @@ x_tabs_menu_create (TabInfo* nfo)
   g_return_val_if_fail (tl != NULL, NULL);
 
   GtkWidget* menu = gtk_menu_new();
-  x_tabs_menu_create_item (tl, menu, "&file-new", _("_New"), GTK_STOCK_NEW);
-  x_tabs_menu_create_item (tl, menu, "&file-open", _("_Open..."), GTK_STOCK_OPEN);
+  x_tabs_menu_create_item (tl, menu, "&file-new", _("_New"), "document-new");
+  x_tabs_menu_create_item (tl, menu, "&file-open", _("_Open..."), "document-open");
   x_tabs_menu_create_item_separ (menu);
-  x_tabs_menu_create_item (tl, menu, "&file-save", _("_Save"), GTK_STOCK_SAVE);
-  x_tabs_menu_create_item (tl, menu, "&file-save-as", _("Save _As..."), GTK_STOCK_SAVE_AS);
+  x_tabs_menu_create_item (tl, menu, "&file-save", _("_Save"), "document-save");
+  x_tabs_menu_create_item (tl, menu, "&file-save-as", _("Save _As..."), "document-save-as");
   x_tabs_menu_create_item_separ (menu);
   x_tabs_menu_create_item (tl, menu, "&page-manager", _("Page _Manager..."), NULL);
   x_tabs_menu_create_item_separ (menu);
-  x_tabs_menu_create_item (tl, menu, "&page-close", _("_Close"), GTK_STOCK_CLOSE);
+  x_tabs_menu_create_item (tl, menu, "&page-close", _("_Close"), "window-close");
 
   gtk_widget_show_all (menu);
   return GTK_MENU (menu);

--- a/libleptongui/src/x_tabs.c
+++ b/libleptongui/src/x_tabs.c
@@ -936,8 +936,8 @@ x_tabs_hdr_create (TabInfo* nfo)
   gtk_button_set_relief (GTK_BUTTON (btn_save), GTK_RELIEF_NONE);
   gtk_button_set_focus_on_click (GTK_BUTTON (btn_save), FALSE);
 
-  GtkWidget* img_save = gtk_image_new_from_stock ("document-save",
-                                                  GTK_ICON_SIZE_MENU);
+  GtkWidget* img_save = gtk_image_new_from_icon_name ("document-save",
+                                                      GTK_ICON_SIZE_MENU);
   gtk_container_add (GTK_CONTAINER (btn_save), img_save);
   gtk_widget_set_tooltip_text (btn_save, _("Save"));
 

--- a/libleptongui/src/x_tabs.c
+++ b/libleptongui/src/x_tabs.c
@@ -911,8 +911,8 @@ x_tabs_hdr_create (TabInfo* nfo)
   );
 #endif
 
-  GtkWidget* img_close = gtk_image_new_from_stock (GTK_STOCK_CLOSE,
-                                                   GTK_ICON_SIZE_MENU);
+  GtkWidget* img_close = gtk_image_new_from_icon_name ("window-close",
+                                                       GTK_ICON_SIZE_MENU);
   gtk_container_add (GTK_CONTAINER (btn_close), img_close);
   gtk_widget_set_tooltip_text (btn_close, _("Close"));
 
@@ -924,8 +924,8 @@ x_tabs_hdr_create (TabInfo* nfo)
   gtk_button_set_relief (GTK_BUTTON (btn_up), GTK_RELIEF_NONE);
   gtk_button_set_focus_on_click (GTK_BUTTON (btn_up), FALSE);
 
-  GtkWidget* img_up = gtk_image_new_from_stock (GTK_STOCK_GO_UP,
-                                                GTK_ICON_SIZE_MENU);
+  GtkWidget* img_up = gtk_image_new_from_icon_name ("go-up",
+                                                    GTK_ICON_SIZE_MENU);
   gtk_container_add (GTK_CONTAINER (btn_up), img_up);
 
 

--- a/libleptongui/src/x_widgets.c
+++ b/libleptongui/src/x_widgets.c
@@ -348,7 +348,7 @@ x_widgets_show_in_dialog (GschemToplevel* w_current,
     (GtkDialogFlags) GTK_DIALOG_DESTROY_WITH_PARENT,
     ini_group,
     w_current,
-    GTK_STOCK_CLOSE, GTK_RESPONSE_NONE,
+    _("_Close"), GTK_RESPONSE_NONE,
     NULL);
 
   if (x_widgets_use_toplevel_windows())

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -285,6 +285,11 @@ void x_window_setup_draw_events_drawing_area (GschemToplevel* w_current,
 static GtkWidget *x_window_stock_pixmap(const char *stock, GschemToplevel *w_current)
 {
   GtkWidget *wpixmap = NULL;
+#ifdef ENABLE_GTK3
+  /* Look up the icon in the icon theme. */
+  wpixmap = gtk_image_new_from_icon_name (stock,
+                                          GTK_ICON_SIZE_LARGE_TOOLBAR);
+#else
   GtkStockItem item;
 
   gchar *stockid=g_strconcat("gtk-", stock, NULL);
@@ -300,6 +305,7 @@ static GtkWidget *x_window_stock_pixmap(const char *stock, GschemToplevel *w_cur
   }
 
   g_free(stockid);
+#endif
 
   return wpixmap;
 }

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -1139,25 +1139,25 @@ create_toolbar( GschemToplevel *w_current, GtkWidget *main_box )
 #endif
 
   create_toolbar_button (w_current, toolbar,
-                         "new", _("New"), _("New file"),
+                         "document-new", _("New"), _("New file"),
                          G_CALLBACK (&i_callback_file_new), 0);
 
   create_toolbar_button (w_current, toolbar,
-                         "open", _("Open"), _("Open file"),
+                         "document-open", _("Open"), _("Open file"),
                          G_CALLBACK (&i_callback_file_open), 1);
 
   create_toolbar_button (w_current, toolbar,
-                         "save", _("Save"), _("Save file"),
+                         "document-save", _("Save"), _("Save file"),
                          G_CALLBACK (&i_callback_file_save), 2);
 
   create_toolbar_separator (toolbar, 3);
 
   create_toolbar_button (w_current, toolbar,
-                         "undo", _("Undo"), _("Undo last operation"),
+                         "edit-undo", _("Undo"), _("Undo last operation"),
                          G_CALLBACK (&i_callback_edit_undo), 4);
 
   create_toolbar_button (w_current, toolbar,
-                         "redo", _("Redo"), _("Redo last undo"),
+                         "edit-redo", _("Redo"), _("Redo last undo"),
                          G_CALLBACK (&i_callback_edit_redo), 5);
 
   create_toolbar_separator (toolbar, 6);


### PR DESCRIPTION
This commit set eliminates another bunch of warnings when Lepton is compiled with `--with-gtk3` option, about a hundred or so.