### PR TITLE
Implement opacity control in the color edit widget [GTK2]

### DIFF
--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -456,8 +456,8 @@ void x_color_set_display_color (size_t color_id,
 void x_color_set_outline_color (size_t color_id,
                                 GdkRGBA* color);
 #else
-void x_color_set_display (size_t color_id, GdkColor* color);
-void x_color_set_outline (size_t color_id, GdkColor* color);
+void x_color_set_display (size_t color_id, GdkColor* color, guint16 alpha);
+void x_color_set_outline (size_t color_id, GdkColor* color, guint16 alpha);
 #endif
 GString* x_color_map2str_display();
 GString* x_color_map2str_outline();

--- a/libleptongui/src/color_edit_widget.c
+++ b/libleptongui/src/color_edit_widget.c
@@ -54,13 +54,6 @@ typedef enum
 static void
 color_edit_widget_create (ColorEditWidget* widget);
 
-/* \todo Currently unused; see todo in commented out function implementation
- *
-static void
-mk_opacity_box (GtkWidget* vbox);
- *
- */
-
 static void
 color_sel_update (ColorEditWidget* widget);
 
@@ -244,17 +237,6 @@ color_edit_widget_create (ColorEditWidget* widget)
 
   /* separator: */
   gtk_box_pack_start (GTK_BOX (vbox), separator_new(), FALSE, FALSE, 5);
-
-
-  /* \todo opacity control:
-  *
-  * An idea here is to make outline color scheme the same
-  * as display one, but allow it to be slightly more transparent
-  *
-  mk_opacity_box (vbox);
-  *
-  */
-
 
 #ifdef ENABLE_GTK3
   /* standard color chooser widget: */
@@ -698,39 +680,3 @@ dlg_confirm_overwrite (GtkWidget* parent, const gchar* fname)
   return res == GTK_RESPONSE_YES;
 
 } /* dlg_confirm_overwrite() */
-
-
-
-/*! \brief Create GUI for transparency control
- *  \note  Currently unused
- *  \todo  Implement transparency for outline color map
- *
- *  \param vbox Parent widget
- *
-
-static void
-mk_opacity_box (GtkWidget* vbox)
-{
-#ifdef ENABLE_GTK3
-  GtkWidget* hbox2 = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 0);
-#else
-  GtkWidget* hbox2 = gtk_hbox_new (FALSE, 0);
-#endif
-  gtk_box_pack_start (GTK_BOX (vbox), hbox2, TRUE, TRUE, 0);
-
-  GtkWidget* label = gtk_label_new (_("Opacity for outline color scheme:"));
-
-  GtkObject* adj = gtk_adjustment_new (255, 0, 255, 1, 10, 0);
-  GtkWidget* scale = gtk_hscale_new (GTK_ADJUSTMENT (adj));
-
-  gtk_scale_set_digits (GTK_SCALE (scale), 0);
-  gtk_scale_set_value_pos (GTK_SCALE (scale), GTK_POS_LEFT);
-
-  gtk_box_pack_start (GTK_BOX (hbox2), label, TRUE, TRUE, 0);
-  gtk_box_pack_start (GTK_BOX (hbox2), scale, TRUE, TRUE, 0);
-
-  gtk_box_pack_start (GTK_BOX (vbox), separator_new(), FALSE, FALSE, 5);
-
-}
-
-*/

--- a/libleptongui/src/color_edit_widget.c
+++ b/libleptongui/src/color_edit_widget.c
@@ -456,9 +456,10 @@ on_color_sel_changed (GtkColorSelection* csel, gpointer p)
   gtk_color_selection_get_current_color (csel, &color);
 
   /* adjust a color in display and outline color maps: */
-  x_color_set_display (color_index, &color);
-  x_color_set_outline (color_index, &color);
+  guint16 alpha = gtk_color_selection_get_current_alpha (csel);
 
+  x_color_set_display (color_index, &color, alpha);
+  x_color_set_outline (color_index, &color, alpha);
 
   /* update current combo box color: */
   GtkComboBox* combo = GTK_COMBO_BOX (widget->color_cb_);

--- a/libleptongui/src/color_edit_widget.c
+++ b/libleptongui/src/color_edit_widget.c
@@ -247,7 +247,7 @@ color_edit_widget_create (ColorEditWidget* widget)
   widget->color_sel_ = gtk_color_selection_new();
   gtk_color_selection_set_has_opacity_control(
     GTK_COLOR_SELECTION (widget->color_sel_),
-    FALSE); /* do not support opacity yet */
+    TRUE);
   gtk_box_pack_start (GTK_BOX (vbox), widget->color_sel_, TRUE, TRUE, 0);
 #endif
 

--- a/libleptongui/src/color_edit_widget.c
+++ b/libleptongui/src/color_edit_widget.c
@@ -355,6 +355,10 @@ color_sel_update (ColorEditWidget* widget)
   gtk_color_selection_set_current_color (csel, color);
   gdk_color_free (color);
 
+  LeptonColor* lc = x_color_lookup (ndx);
+  gtk_color_selection_set_current_alpha (csel,
+                                         (guint16) (lc->alpha * 65535.0));
+
   g_signal_handlers_unblock_by_func (G_OBJECT (csel),
                                      (gpointer) &on_color_sel_changed,
                                      widget);

--- a/libleptongui/src/x_color.c
+++ b/libleptongui/src/x_color.c
@@ -132,12 +132,12 @@ x_color_set_outline_color (size_t color_id,
 /*! \brief: Change a color in the display color map
  */
 void
-x_color_set_display (size_t color_id, GdkColor* color)
+x_color_set_display (size_t color_id, GdkColor* color, guint16 alpha)
 {
   display_colors[color_id].red   = (gdouble) color->red   / 65535.0;
   display_colors[color_id].green = (gdouble) color->green / 65535.0;
   display_colors[color_id].blue  = (gdouble) color->blue  / 65535.0;
-  display_colors[color_id].alpha = 1.0;
+  display_colors[color_id].alpha = (gdouble) alpha        / 65535.0;
 }
 
 
@@ -145,12 +145,12 @@ x_color_set_display (size_t color_id, GdkColor* color)
 /*! \brief: Change a color in the outline color map
  */
 void
-x_color_set_outline (size_t color_id, GdkColor* color)
+x_color_set_outline (size_t color_id, GdkColor* color, guint16 alpha)
 {
   display_outline_colors[color_id].red   = (gdouble) color->red   / 65535.0;
   display_outline_colors[color_id].green = (gdouble) color->green / 65535.0;
   display_outline_colors[color_id].blue  = (gdouble) color->blue  / 65535.0;
-  display_outline_colors[color_id].alpha = 1.0;
+  display_outline_colors[color_id].alpha = (gdouble) alpha        / 65535.0;
 }
 #endif
 


### PR DESCRIPTION
![color_edit_opacity](https://user-images.githubusercontent.com/26083750/148576744-dc26a095-c378-43db-be0d-03983fdc16d5.png)
