### PR TITLE
Get rid of warnings on gtk_dialog_set_alternative_button_order() in GTK3 port

### DIFF
--- a/libleptonattrib/src/x_dialog.c
+++ b/libleptonattrib/src/x_dialog.c
@@ -239,12 +239,14 @@ void x_dialog_unsaved_data()
                           _("_Save"),            GTK_RESPONSE_YES,
                           NULL);
 
+#ifndef ENABLE_GTK3
   /* Set the alternative button order (ok, cancel, help) for other systems */
   gtk_dialog_set_alternative_button_order(GTK_DIALOG(dialog),
                                           GTK_RESPONSE_YES,
                                           GTK_RESPONSE_NO,
                                           GTK_RESPONSE_CANCEL,
                                           -1);
+#endif
 
   gtk_dialog_set_default_response (GTK_DIALOG (dialog), GTK_RESPONSE_YES);
 

--- a/libleptonattrib/src/x_fileselect.c
+++ b/libleptonattrib/src/x_fileselect.c
@@ -130,11 +130,13 @@ x_fileselect_open (void)
                                         _("_Open"),   GTK_RESPONSE_ACCEPT,
                                         NULL);
 
+#ifndef ENABLE_GTK3
   /* Set the alternative button order (ok, cancel, help) for other systems */
   gtk_dialog_set_alternative_button_order(GTK_DIALOG(dialog),
                                           GTK_RESPONSE_ACCEPT,
                                           GTK_RESPONSE_CANCEL,
                                           -1);
+#endif
 
   g_object_set (dialog,
                 /* GtkFileChooser */

--- a/libleptongui/src/color_edit_widget.c
+++ b/libleptongui/src/color_edit_widget.c
@@ -631,11 +631,13 @@ dlg_save_as (GtkWidget* parent)
     _("_Cancel"), GTK_RESPONSE_CANCEL,
     NULL);
 
+#ifndef ENABLE_GTK3
   gtk_dialog_set_alternative_button_order(
     GTK_DIALOG (dlg),
     GTK_RESPONSE_ACCEPT,
     GTK_RESPONSE_CANCEL,
     -1);
+#endif
 
   gtk_dialog_set_default_response (GTK_DIALOG (dlg),
                                    GTK_RESPONSE_ACCEPT);

--- a/libleptongui/src/gschem_arc_dialog.c
+++ b/libleptongui/src/gschem_arc_dialog.c
@@ -108,11 +108,13 @@ void arc_angle_dialog (GschemToplevel *w_current, LeptonObject *arc_object)
                                                          _("_OK"), GTK_RESPONSE_ACCEPT,
                                                          NULL);
 
+#ifndef ENABLE_GTK3
   /* Set the alternative button order (ok, cancel, help) for other systems */
     gtk_dialog_set_alternative_button_order(GTK_DIALOG(w_current->aawindow),
                                             GTK_RESPONSE_ACCEPT,
                                             GTK_RESPONSE_REJECT,
                                             -1);
+#endif
 
     gtk_window_set_position (GTK_WINDOW (w_current->aawindow), GTK_WIN_POS_MOUSE);
 

--- a/libleptongui/src/gschem_close_confirmation_dialog.c
+++ b/libleptongui/src/gschem_close_confirmation_dialog.c
@@ -587,12 +587,14 @@ close_confirmation_dialog_constructor (GType type,
                           _("_Save"), GTK_RESPONSE_YES,
                           NULL);
 
+#ifndef ENABLE_GTK3
   /* Set the alternative button order (ok, cancel, help) for other systems */
   gtk_dialog_set_alternative_button_order(GTK_DIALOG(dialog),
                                           GTK_RESPONSE_YES,
                                           GTK_RESPONSE_NO,
                                           GTK_RESPONSE_CANCEL,
                                           -1);
+#endif
 
   gtk_dialog_set_default_response (GTK_DIALOG (dialog), GTK_RESPONSE_YES);
 

--- a/libleptongui/src/gschem_log_widget.c
+++ b/libleptongui/src/gschem_log_widget.c
@@ -398,11 +398,12 @@ log_window_clear (GtkMenuItem* item, gpointer data)
   gtk_window_set_title (GTK_WINDOW (dlg), _("Clear Log"));
   gtk_dialog_set_default_response (GTK_DIALOG (dlg), GTK_RESPONSE_CANCEL);
 
+#ifndef ENABLE_GTK3
   gtk_dialog_set_alternative_button_order (GTK_DIALOG (dlg),
                                            GTK_RESPONSE_OK,
                                            GTK_RESPONSE_CANCEL,
                                            -1);
-
+#endif
 
   if (gtk_dialog_run (GTK_DIALOG (dlg)) == GTK_RESPONSE_OK)
   {

--- a/libleptongui/src/gschem_slot_edit_dialog.c
+++ b/libleptongui/src/gschem_slot_edit_dialog.c
@@ -96,11 +96,13 @@ void slot_edit_dialog (GschemToplevel *w_current, const char *count, const char 
                                                          _("_OK"), GTK_RESPONSE_ACCEPT,
                                                          NULL);
 
+#ifndef ENABLE_GTK3
   /* Set the alternative button order (ok, cancel, help) for other systems */
     gtk_dialog_set_alternative_button_order(GTK_DIALOG(w_current->sewindow),
                                             GTK_RESPONSE_ACCEPT,
                                             GTK_RESPONSE_REJECT,
                                             -1);
+#endif
 
     gtk_window_set_position (GTK_WINDOW (w_current->sewindow), GTK_WIN_POS_MOUSE);
 

--- a/libleptongui/src/gschem_slot_edit_dialog.c
+++ b/libleptongui/src/gschem_slot_edit_dialog.c
@@ -124,21 +124,21 @@ void slot_edit_dialog (GschemToplevel *w_current, const char *count, const char 
     widget[0] = gtk_entry_new();
     gtk_entry_set_max_length(GTK_ENTRY(widget[0]), 80);
     gtk_editable_set_editable (GTK_EDITABLE(widget[0]), FALSE);
-	gtk_widget_set_sensitive (GTK_WIDGET(widget[0]), FALSE);
+    gtk_widget_set_sensitive (GTK_WIDGET(widget[0]), FALSE);
 
-	widget[1] = gtk_entry_new();
+    widget[1] = gtk_entry_new();
     gtk_entry_set_max_length(GTK_ENTRY(widget[1]), 80);
     gtk_entry_set_activates_default (GTK_ENTRY(widget[1]),TRUE);
 
     table = gschem_dialog_misc_create_property_table(label, widget, 2);
 
-	gtk_box_pack_start (GTK_BOX (vbox),                          /* box     */
+    gtk_box_pack_start (GTK_BOX (vbox),                          /* box     */
                         table,                                   /* child   */
                         FALSE,                                   /* expand  */
                         FALSE,                                   /* fill    */
                         0);                                      /* padding */
 
-	GLADE_HOOKUP_OBJECT(w_current->sewindow, widget[0], "countentry");
+    GLADE_HOOKUP_OBJECT(w_current->sewindow, widget[0], "countentry");
     GLADE_HOOKUP_OBJECT(w_current->sewindow, widget[1], "textentry");
     gtk_widget_show_all (w_current->sewindow);
   }

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -124,11 +124,13 @@ i_callback_file_script (GtkWidget *widget, gpointer data)
   gtk_file_filter_add_pattern (filter_all, "*");
   gtk_file_chooser_add_filter (GTK_FILE_CHOOSER (dialog), filter_all);
 
+#ifndef ENABLE_GTK3
   gtk_dialog_set_alternative_button_order(
     GTK_DIALOG (dialog),
     GTK_RESPONSE_ACCEPT,
     GTK_RESPONSE_CANCEL,
     -1);
+#endif
 
   if (gtk_dialog_run (GTK_DIALOG (dialog)) == GTK_RESPONSE_ACCEPT)
   {
@@ -1530,11 +1532,13 @@ i_callback_page_revert (GtkWidget *widget, gpointer data)
 
   gtk_window_set_title (GTK_WINDOW (dialog), _("Revert"));
 
+#ifndef ENABLE_GTK3
   /* Set the alternative button order (ok, cancel, help) for other systems */
   gtk_dialog_set_alternative_button_order(GTK_DIALOG(dialog),
                                           GTK_RESPONSE_YES,
                                           GTK_RESPONSE_NO,
                                           -1);
+#endif
 
   response = gtk_dialog_run (GTK_DIALOG (dialog));
   gtk_widget_destroy (dialog);

--- a/libleptongui/src/o_picture.c
+++ b/libleptongui/src/o_picture.c
@@ -189,11 +189,13 @@ void picture_selection_dialog (GschemToplevel *w_current)
 
   setup_filechooser_filters (GTK_FILE_CHOOSER (pfswindow));
 
+#ifndef ENABLE_GTK3
   /* Set the alternative button order (ok, cancel, help) for other systems */
   gtk_dialog_set_alternative_button_order(GTK_DIALOG(pfswindow),
                                           GTK_RESPONSE_ACCEPT,
                                           GTK_RESPONSE_CANCEL,
                                           -1);
+#endif
 
   if (w_current->pixbuf_filename)
     gtk_file_chooser_set_filename(GTK_FILE_CHOOSER(pfswindow),
@@ -394,11 +396,13 @@ void picture_change_filename_dialog (GschemToplevel *w_current)
 
   setup_filechooser_filters (GTK_FILE_CHOOSER (pfswindow));
 
+#ifndef ENABLE_GTK3
   /* Set the alternative button order (ok, cancel, help) for other systems */
   gtk_dialog_set_alternative_button_order(GTK_DIALOG(pfswindow),
                                           GTK_RESPONSE_ACCEPT,
                                           GTK_RESPONSE_CANCEL,
                                           -1);
+#endif
 
   if (w_current->pixbuf_filename)
     gtk_file_chooser_set_filename(GTK_FILE_CHOOSER(pfswindow),

--- a/libleptongui/src/x_attribedit.c
+++ b/libleptongui/src/x_attribedit.c
@@ -316,11 +316,13 @@ void attrib_edit_dialog (GschemToplevel *w_current, LeptonObject *attr_obj, int 
                                             _("_Cancel"), GTK_RESPONSE_REJECT,
                                             _("_OK"), GTK_RESPONSE_APPLY,
                                             NULL);
+#ifndef ENABLE_GTK3
   /* Set the alternative button order (ok, cancel, help) for other systems */
   gtk_dialog_set_alternative_button_order(GTK_DIALOG(aewindow),
                                           GTK_RESPONSE_APPLY,
                                           GTK_RESPONSE_REJECT,
                                           -1);
+#endif
 
   g_signal_connect (G_OBJECT (aewindow), "response",
                     G_CALLBACK (attribute_edit_dialog_response),

--- a/libleptongui/src/x_autonumber.c
+++ b/libleptongui/src/x_autonumber.c
@@ -1228,11 +1228,13 @@ GtkWidget* autonumber_create_dialog(GschemToplevel *w_current)
                                                    _("_Close"), GTK_RESPONSE_REJECT,
                                                    _("_Apply"), GTK_RESPONSE_ACCEPT,
                                                    NULL);
+#ifndef ENABLE_GTK3
   /* Set the alternative button order (ok, cancel, help) for other systems */
   gtk_dialog_set_alternative_button_order(GTK_DIALOG(autonumber_text),
                                           GTK_RESPONSE_ACCEPT,
                                           GTK_RESPONSE_REJECT,
                                           -1);
+#endif
 
   gtk_window_set_position (GTK_WINDOW (autonumber_text), GTK_WIN_POS_MOUSE);
 

--- a/libleptongui/src/x_compselect.c
+++ b/libleptongui/src/x_compselect.c
@@ -1587,11 +1587,13 @@ compselect_constructor (GType type,
                           _("_OK"), COMPSELECT_RESPONSE_HIDE,
                           NULL);
 
+#ifndef ENABLE_GTK3
   /* Set the alternative button order (ok, cancel, help) for other systems */
   gtk_dialog_set_alternative_button_order (GTK_DIALOG (compselect),
                                           COMPSELECT_RESPONSE_HIDE,
                                           GTK_RESPONSE_CLOSE,
                                           -1);
+#endif
 
   /* Initialize the hidden property */
   compselect->hidden = FALSE;

--- a/libleptongui/src/x_dialog.c
+++ b/libleptongui/src/x_dialog.c
@@ -126,11 +126,13 @@ char *generic_filesel_dialog (const char *msg, const char *templ, gint flags)
                                           NULL);
   }
 
+#ifndef ENABLE_GTK3
   /* Set the alternative button order (ok, cancel, help) for other systems */
   gtk_dialog_set_alternative_button_order(GTK_DIALOG(dialog),
                                           GTK_RESPONSE_OK,
                                           GTK_RESPONSE_CANCEL,
                                           -1);
+#endif
 
   gtk_dialog_set_default_response (GTK_DIALOG (dialog), GTK_RESPONSE_OK);
 

--- a/libleptongui/src/x_fileselect.c
+++ b/libleptongui/src/x_fileselect.c
@@ -333,11 +333,13 @@ x_fileselect_open(GschemToplevel *w_current)
                                         _("_Open"), GTK_RESPONSE_ACCEPT,
                                         NULL);
 
+#ifndef ENABLE_GTK3
   /* Set the alternative button order (ok, cancel, help) for other systems */
   gtk_dialog_set_alternative_button_order(GTK_DIALOG(dialog),
                                           GTK_RESPONSE_ACCEPT,
                                           GTK_RESPONSE_CANCEL,
                                           -1);
+#endif
 
   if (w_current->file_preview)
   {
@@ -424,12 +426,14 @@ x_fileselect_save (GschemToplevel *w_current,
     _("_Save"),   GTK_RESPONSE_ACCEPT,
     NULL);
 
+#ifndef ENABLE_GTK3
   /* Set the alternative button order (ok, cancel, help) for other systems:
   */
   gtk_dialog_set_alternative_button_order(GTK_DIALOG(dialog),
                                           GTK_RESPONSE_ACCEPT,
                                           GTK_RESPONSE_CANCEL,
                                           -1);
+#endif
 
   /* set default response signal. This is usually triggered by the
    * "Return" key:
@@ -589,11 +593,13 @@ x_fileselect_load_backup (GschemToplevel *w_current,
                                    "%s", message->str);
 
   gtk_window_set_title (GTK_WINDOW (dialog), "Load Backup");
+#ifndef ENABLE_GTK3
   /* Set the alternative button order (ok, cancel, help) for other systems */
   gtk_dialog_set_alternative_button_order(GTK_DIALOG(dialog),
                                           GTK_RESPONSE_YES,
                                           GTK_RESPONSE_NO,
                                           -1);
+#endif
 
   gtk_widget_show (dialog);
   if (gtk_dialog_run ((GtkDialog*)dialog) == GTK_RESPONSE_YES) {

--- a/libleptongui/src/x_image.c
+++ b/libleptongui/src/x_image.c
@@ -605,11 +605,13 @@ void x_image_setup (GschemToplevel *w_current)
                                         _("_Save"), GTK_RESPONSE_ACCEPT,
       NULL);
 
+#ifndef ENABLE_GTK3
   /* Set the alternative button order (ok, cancel, help) for other systems */
   gtk_dialog_set_alternative_button_order(GTK_DIALOG(dialog),
       GTK_RESPONSE_ACCEPT,
       GTK_RESPONSE_CANCEL,
       -1);
+#endif
 
   /* Add the extra widgets to the dialog*/
   gtk_box_pack_start(GTK_BOX(hbox), vbox1, FALSE, FALSE, 10);

--- a/libleptongui/src/x_newtext.c
+++ b/libleptongui/src/x_newtext.c
@@ -227,11 +227,13 @@ static void newtext_init(NewText *dialog)
   gtk_dialog_add_button (GTK_DIALOG (dialog),
                          _("_Apply"), GTK_RESPONSE_APPLY);
 
+#ifndef ENABLE_GTK3
   /* Set the alternative button order (ok, cancel, help) for other systems */
   gtk_dialog_set_alternative_button_order(GTK_DIALOG(dialog),
                                           GTK_RESPONSE_APPLY,
                                           GTK_RESPONSE_CLOSE,
                                           -1);
+#endif
 
   gtk_window_set_position (GTK_WINDOW (dialog), GTK_WIN_POS_NONE);
 


### PR DESCRIPTION
AFAIK, there is no replacement function for it in GTK3.