### PR TITLE
Make 'make check' C tests pass after 'make CC=g++'.

### DIFF
--- a/liblepton/include/liblepton/angle.h
+++ b/liblepton/include/liblepton/angle.h
@@ -22,6 +22,8 @@
  *  \brief Functions for working with angles
  */
 
+G_BEGIN_DECLS
+
 gboolean
 lepton_angle_is_normal (gint angle);
 
@@ -33,3 +35,5 @@ lepton_angle_make_ortho (gint angle);
 
 gint
 lepton_angle_normalize (gint angle);
+
+G_END_DECLS

--- a/liblepton/include/liblepton/point.h
+++ b/liblepton/include/liblepton/point.h
@@ -28,6 +28,8 @@ struct st_point
   gint y;
 };
 
+G_BEGIN_DECLS
+
 void
 lepton_point_rotate (int x,
                      int y,
@@ -40,3 +42,5 @@ lepton_point_rotate_90 (int x,
                         int angle,
                         int *newx,
                         int *newy);
+
+G_END_DECLS


### PR DESCRIPTION
Strange, I've never ever tested it in such a way before.  Now, I found some C code tests do not pass if I do something like:
```
./autogen.sh &&
./configure --with-gtk3 --enable-contrib CC=g++ &&
make CC=g++ all &&
sudo make install &&
LEPTON_SUDO_TESTS=yes make -j3 check
```

This commit fixes the issue on my system(s).