### PR TITLE
Get rid of liblepton core modules

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -55,6 +55,7 @@ TESTS = \
 	tests/netlist.test \
 	tests/shell.test \
 	tests/symcheck.test \
+	tests/tragesym.test \
 	tests/update.test
 
 EXTRA_DIST = \

--- a/Makefile.am
+++ b/Makefile.am
@@ -56,6 +56,7 @@ TESTS = \
 	tests/shell.test \
 	tests/symcheck.test \
 	tests/tragesym.test \
+	tests/upcfg.test \
 	tests/update.test
 
 EXTRA_DIST = \

--- a/Makefile.am
+++ b/Makefile.am
@@ -47,6 +47,7 @@ AM_TESTS_ENVIRONMENT = env \
 	FILE='$(FILE)'
 
 TESTS = \
+	tests/archive.test \
 	tests/cli.test \
 	tests/config.test \
 	tests/export.test \

--- a/Makefile.am
+++ b/Makefile.am
@@ -50,6 +50,7 @@ TESTS = \
 	tests/archive.test \
 	tests/cli.test \
 	tests/config.test \
+	tests/embed.test \
 	tests/export.test \
 	tests/netlist.test \
 	tests/shell.test \

--- a/docs/manual/scm-component.scm
+++ b/docs/manual/scm-component.scm
@@ -1,7 +1,8 @@
 (use-modules (lepton core toplevel)
              (lepton object)
              (lepton attrib)
-             (lepton page))
+             (lepton page)
+             (lepton toplevel))
 
 (define (make-attribs)
   (list

--- a/docs/manual/scm-component.scm
+++ b/docs/manual/scm-component.scm
@@ -1,6 +1,5 @@
-(use-modules (lepton core toplevel)
+(use-modules (lepton attrib)
              (lepton object)
-             (lepton attrib)
              (lepton page)
              (lepton toplevel))
 

--- a/liblepton/include/liblepton/libleptonguile.h
+++ b/liblepton/include/liblepton/libleptonguile.h
@@ -1,6 +1,6 @@
 /* Lepton EDA library - Scheme API
  * Copyright (C) 2010-2014 Peter Brett <peter@peter-b.co.uk>
- * Copyright (C) 2017-2021 Lepton EDA Contributors
+ * Copyright (C) 2017-2022 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -32,6 +32,10 @@ void edascm_init ();
 
 /* Get the value of the #LeptonToplevel fluid. */
 LeptonToplevel *edascm_c_current_toplevel ();
+
+/* Create a Guile value from #LeptonToplevel structure. */
+SCM
+edascm_from_toplevel (LeptonToplevel *toplevel);
 
 /* Set the #LeptonToplevel fluid in the current dynamic context. */
 void edascm_dynwind_toplevel (LeptonToplevel *toplevel);

--- a/liblepton/include/liblepton/libleptonguile.h
+++ b/liblepton/include/liblepton/libleptonguile.h
@@ -44,6 +44,10 @@ edascm_from_toplevel (LeptonToplevel *toplevel);
 /* Set the #LeptonToplevel fluid in the current dynamic context. */
 void edascm_dynwind_toplevel (LeptonToplevel *toplevel);
 
+/* Get the value of the #LeptonToplevel fluid. */
+SCM
+edascm_with_toplevel (SCM toplevel, SCM thunk);
+
 /* Create a Guile value from a page structure. */
 SCM edascm_from_page (LeptonPage *page);
 

--- a/liblepton/include/liblepton/libleptonguile.h
+++ b/liblepton/include/liblepton/libleptonguile.h
@@ -31,6 +31,10 @@ G_BEGIN_DECLS
 void edascm_init ();
 
 /* Get the value of the #LeptonToplevel fluid. */
+SCM
+edascm_current_toplevel ();
+
+/* Get the value of the #LeptonToplevel fluid in C. */
 LeptonToplevel *edascm_c_current_toplevel ();
 
 /* Create a Guile value from #LeptonToplevel structure. */

--- a/liblepton/include/liblepton/toplevel.h
+++ b/liblepton/include/liblepton/toplevel.h
@@ -2,7 +2,7 @@
  * Copyright (C) 1998, 1999, 2000 Kazu Hirata / Ales Hvezda
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2016 gEDA Contributors
- * Copyright (C) 2017-2021 Lepton EDA Contributors
+ * Copyright (C) 2017-2022 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -49,7 +49,7 @@ void
 s_toplevel_delete (LeptonToplevel *toplevel);
 
 LeptonToplevel*
-s_toplevel_new (void);
+lepton_toplevel_new (void);
 
 void
 s_toplevel_remove_weak_ptr (LeptonToplevel *toplevel,

--- a/liblepton/scheme/Makefile.am
+++ b/liblepton/scheme/Makefile.am
@@ -33,6 +33,7 @@ nobase_dist_scmdata_DATA = \
 	lepton/rc.scm \
 	lepton/repl.scm \
 	lepton/srfi-37.scm \
+	lepton/toplevel.scm \
 	lepton/version.scm \
 	lepton/legacy-config/keylist.scm \
 	lepton/legacy-config.scm \

--- a/liblepton/scheme/lepton/ffi.scm
+++ b/liblepton/scheme/lepton/ffi.scm
@@ -56,6 +56,7 @@
             glist-prev
 
             ;; Foreign functions.
+            edascm_current_toplevel
             edascm_c_current_toplevel
             edascm_from_toplevel
             edascm_is_object
@@ -522,6 +523,7 @@
 (define-lff eda_renderer_set_color_map void '(* *))
 
 ;;; scheme_smob.c
+(define-lff edascm_current_toplevel '* '())
 (define-lff edascm_c_current_toplevel '* '())
 (define-lff edascm_from_toplevel '* '(*))
 (define-lff edascm_is_object int '(*))

--- a/liblepton/scheme/lepton/ffi.scm
+++ b/liblepton/scheme/lepton/ffi.scm
@@ -1,5 +1,5 @@
 ;;; Lepton EDA library - Scheme API
-;;; Copyright (C) 2020-2021 Lepton EDA Contributors
+;;; Copyright (C) 2020-2022 Lepton EDA Contributors
 ;;;
 ;;; This program is free software; you can redistribute it and/or modify
 ;;; it under the terms of the GNU General Public License as published by
@@ -57,6 +57,7 @@
 
             ;; Foreign functions.
             edascm_c_current_toplevel
+            edascm_from_toplevel
             edascm_is_object
             edascm_from_object
             edascm_to_object
@@ -354,6 +355,7 @@
             s_conn_return_others
             s_conn_update_object
 
+            s_toplevel_new
             lepton_toplevel_get_page_current
             lepton_toplevel_get_pages
 
@@ -452,6 +454,7 @@
 (define-lff s_clib_init void '())
 (define-lff s_clib_symbol_get_filename '* '(*))
 ;;; toplevel.c
+(define-lff s_toplevel_new '* '())
 (define-lff lepton_toplevel_get_page_current '* '(*))
 (define-lff lepton_toplevel_get_pages '* '(*))
 ;;; g_rc.c
@@ -520,6 +523,7 @@
 
 ;;; scheme_smob.c
 (define-lff edascm_c_current_toplevel '* '())
+(define-lff edascm_from_toplevel '* '(*))
 (define-lff edascm_is_object int '(*))
 (define-lff edascm_is_page int '(*))
 (define-lff edascm_from_object '* '(*))

--- a/liblepton/scheme/lepton/ffi.scm
+++ b/liblepton/scheme/lepton/ffi.scm
@@ -355,7 +355,7 @@
             s_conn_return_others
             s_conn_update_object
 
-            s_toplevel_new
+            lepton_toplevel_new
             lepton_toplevel_get_page_current
             lepton_toplevel_get_pages
 
@@ -454,7 +454,7 @@
 (define-lff s_clib_init void '())
 (define-lff s_clib_symbol_get_filename '* '(*))
 ;;; toplevel.c
-(define-lff s_toplevel_new '* '())
+(define-lff lepton_toplevel_new '* '())
 (define-lff lepton_toplevel_get_page_current '* '(*))
 (define-lff lepton_toplevel_get_pages '* '(*))
 ;;; g_rc.c

--- a/liblepton/scheme/lepton/ffi.scm
+++ b/liblepton/scheme/lepton/ffi.scm
@@ -59,6 +59,7 @@
             edascm_current_toplevel
             edascm_c_current_toplevel
             edascm_from_toplevel
+            edascm_with_toplevel
             edascm_is_object
             edascm_from_object
             edascm_to_object
@@ -526,6 +527,7 @@
 (define-lff edascm_current_toplevel '* '())
 (define-lff edascm_c_current_toplevel '* '())
 (define-lff edascm_from_toplevel '* '(*))
+(define-lff edascm_with_toplevel '* '(* *))
 (define-lff edascm_is_object int '(*))
 (define-lff edascm_is_page int '(*))
 (define-lff edascm_from_object '* '(*))

--- a/liblepton/scheme/lepton/toplevel.scm
+++ b/liblepton/scheme/lepton/toplevel.scm
@@ -21,7 +21,8 @@
   #:use-module (lepton ffi)
 
   #:export (%current-toplevel
-            %make-toplevel))
+            %make-toplevel
+            %with-toplevel))
 
 (define (pointer->geda-toplevel pointer)
   ;; Return #f if the pointer is wrong.
@@ -34,3 +35,8 @@
 (define (%current-toplevel)
   "Get toplevel for the current dynamic context."
   (false-if-exception (pointer->scm (edascm_current_toplevel))))
+
+(define (%with-toplevel toplevel thunk)
+  "Call THUNK, setting the toplevel fluid to TOPLEVEL."
+  (pointer->scm (edascm_with_toplevel (scm->pointer toplevel)
+                                      (scm->pointer thunk))))

--- a/liblepton/scheme/lepton/toplevel.scm
+++ b/liblepton/scheme/lepton/toplevel.scm
@@ -28,4 +28,4 @@
 
 (define (%make-toplevel)
   "Make new toplevel."
-  (pointer->geda-toplevel (s_toplevel_new)))
+  (pointer->geda-toplevel (lepton_toplevel_new)))

--- a/liblepton/scheme/lepton/toplevel.scm
+++ b/liblepton/scheme/lepton/toplevel.scm
@@ -1,0 +1,31 @@
+;;; Lepton EDA library - Scheme API
+;;; Copyright (C) 2022 Lepton EDA Contributors
+;;;
+;;; This program is free software; you can redistribute it and/or modify
+;;; it under the terms of the GNU General Public License as published by
+;;; the Free Software Foundation; either version 2 of the License, or
+;;; (at your option) any later version.
+;;;
+;;; This program is distributed in the hope that it will be useful,
+;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;; GNU General Public License for more details.
+;;;
+;;; You should have received a copy of the GNU General Public License
+;;; along with this program; if not, write to the Free Software
+;;; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
+(define-module (lepton toplevel)
+  #:use-module (system foreign)
+  #:use-module (lepton ffi)
+
+  #:export (%make-toplevel))
+
+(define (pointer->geda-toplevel pointer)
+  ;; Return #f if the pointer is wrong.
+  (false-if-exception (pointer->scm (edascm_from_toplevel pointer))))
+
+(define (%make-toplevel)
+  "Make new toplevel."
+  (pointer->geda-toplevel (s_toplevel_new)))

--- a/liblepton/scheme/lepton/toplevel.scm
+++ b/liblepton/scheme/lepton/toplevel.scm
@@ -20,7 +20,8 @@
   #:use-module (system foreign)
   #:use-module (lepton ffi)
 
-  #:export (%make-toplevel))
+  #:export (%current-toplevel
+            %make-toplevel))
 
 (define (pointer->geda-toplevel pointer)
   ;; Return #f if the pointer is wrong.
@@ -29,3 +30,7 @@
 (define (%make-toplevel)
   "Make new toplevel."
   (pointer->geda-toplevel (lepton_toplevel_new)))
+
+(define (%current-toplevel)
+  "Get toplevel for the current dynamic context."
+  (false-if-exception (pointer->scm (edascm_current_toplevel))))

--- a/liblepton/scheme/unit-test.scm
+++ b/liblepton/scheme/unit-test.scm
@@ -87,8 +87,6 @@
 ;;;     (register-data-dirs))
 (edascm_init)
 
-(define with-toplevel (@@ (lepton core toplevel) %with-toplevel))
-
 ;;; Syntax and procedure that check exception type and probably
 ;;; have no analogs in SRFI-64.
 (define (%assert-thrown key thunk)
@@ -238,5 +236,5 @@ Actual error:
 ;;; Wrapper for the main() function allowing using of liblepton
 ;;; variables, procedures, and modules.
 (define (main/with-toplevel args)
-  (with-toplevel (%make-toplevel)
+  (%with-toplevel (%make-toplevel)
    (lambda () (main args))))

--- a/liblepton/scheme/unit-test.scm
+++ b/liblepton/scheme/unit-test.scm
@@ -1,6 +1,6 @@
 ;;; Autotools compatible SRFI-64 Scheme unit-test framework
 ;;; Copyright (C) 2016 gEDA Contributors
-;;; Copyright (C) 2018-2021 Lepton EDA Contributors
+;;; Copyright (C) 2018-2022 Lepton EDA Contributors
 ;;;
 ;;; This program is free software; you can redistribute it and/or modify
 ;;; it under the terms of the GNU General Public License as published by
@@ -64,7 +64,8 @@
              (srfi srfi-26)
              (ice-9 getopt-long)
              (ice-9 pretty-print)
-             (lepton ffi))
+             (lepton ffi)
+             (lepton toplevel))
 
 ;;; In order to facilitate debugging, you can increase the pile of
 ;;; info reported on errors by setting the COLUMNS environment
@@ -87,8 +88,6 @@
 (edascm_init)
 
 (define with-toplevel (@@ (lepton core toplevel) %with-toplevel))
-(define make-toplevel (@@ (lepton core toplevel) %make-toplevel))
-
 
 ;;; Syntax and procedure that check exception type and probably
 ;;; have no analogs in SRFI-64.
@@ -239,5 +238,5 @@ Actual error:
 ;;; Wrapper for the main() function allowing using of liblepton
 ;;; variables, procedures, and modules.
 (define (main/with-toplevel args)
-  (with-toplevel (make-toplevel)
+  (with-toplevel (%make-toplevel)
    (lambda () (main args))))

--- a/liblepton/scheme/unit-tests/backend-spice-noqsi.scm
+++ b/liblepton/scheme/unit-tests/backend-spice-noqsi.scm
@@ -1,6 +1,7 @@
 (use-modules (ice-9 rdelim)
              (lepton core toplevel)
              (lepton library)
+             (lepton toplevel)
              (netlist))
 
 ;;; Helper functions.

--- a/liblepton/scheme/unit-tests/backend-spice-noqsi.scm
+++ b/liblepton/scheme/unit-tests/backend-spice-noqsi.scm
@@ -1,5 +1,4 @@
 (use-modules (ice-9 rdelim)
-             (lepton core toplevel)
              (lepton library)
              (lepton toplevel)
              (netlist))

--- a/liblepton/src/Makefile.am
+++ b/liblepton/src/Makefile.am
@@ -1,9 +1,6 @@
 # Build a libtool library for installation in libdir.
 lib_LTLIBRARIES = liblepton.la
 
-BUILT_SOURCES = \
-	scheme_toplevel.x
-
 scheme_api_sources = \
 	scheme_init.c \
 	scheme_smob.c \
@@ -89,8 +86,6 @@ snarf_cpp_opts = $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) \
 	$(liblepton_la_CPPFLAGS) $(AM_CFLAGS) $(liblepton_la_CFLAGS)
 .c.x:
 	$(AM_V_GEN) CPP="$(CPP)" $(GUILE_SNARF) -o $@ $< $(snarf_cpp_opts)
-
-CLEANFILES = $(BUILT_SOURCES)
 
 # Unfortunately, in order to test libtool thoroughly, we need access
 # to its private directory.

--- a/liblepton/src/Makefile.am
+++ b/liblepton/src/Makefile.am
@@ -2,7 +2,6 @@
 lib_LTLIBRARIES = liblepton.la
 
 BUILT_SOURCES = \
-	scheme_init.x \
 	scheme_toplevel.x
 
 scheme_api_sources = \

--- a/liblepton/src/scheme_init.c
+++ b/liblepton/src/scheme_init.c
@@ -1,7 +1,7 @@
 /* Lepton EDA library - Scheme API
  * Copyright (C) 2010-2013 Peter Brett <peter@peter-b.co.uk>
  * Copyright (C) 2010-2016 gEDA Contributors
- * Copyright (C) 2017-2021 Lepton EDA Contributors
+ * Copyright (C) 2017-2022 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -37,8 +37,6 @@ static gsize init_called = 0;
 static void *
 edascm_init_impl (void *data)
 {
-  #include "scheme_init.x"
-
   scm_setlocale (scm_variable_ref (scm_c_lookup ("LC_ALL")),
                  SCM_UNDEFINED);
   edascm_init_smob ();

--- a/liblepton/src/scheme_toplevel.c
+++ b/liblepton/src/scheme_toplevel.c
@@ -1,6 +1,6 @@
 /* Lepton EDA library - Scheme API
  * Copyright (C) 2010-2012 Peter Brett <peter@peter-b.co.uk>
- * Copyright (C) 2017-2021 Lepton EDA Contributors
+ * Copyright (C) 2017-2022 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -28,20 +28,6 @@
 #include "libleptonguile_priv.h"
 
 SCM scheme_toplevel_fluid = SCM_UNDEFINED;
-
-/*!
- * \brief Creates new toplevel.
- * \par Function Description
- * Creates and returns new toplevel variable.
- */
-SCM_DEFINE (edascm_make_toplevel, "%make-toplevel", 0, 0, 0,
-            (),
-            "Make new LeptonToplevel.")
-{
-  LeptonToplevel* toplevel = s_toplevel_new();
-  return edascm_from_toplevel (toplevel);
-}
-
 
 /*!
  * \brief Set the #LeptonToplevel fluid in the current dynamic context.
@@ -119,8 +105,7 @@ init_module_lepton_core_toplevel (void *unused)
   #include "scheme_toplevel.x"
 
   /* Add them to the module's public definitions. */
-  scm_c_export (s_edascm_make_toplevel,
-                s_edascm_with_toplevel,
+  scm_c_export (s_edascm_with_toplevel,
                 s_edascm_current_toplevel,
                 NULL);
 }

--- a/liblepton/src/scheme_toplevel.c
+++ b/liblepton/src/scheme_toplevel.c
@@ -90,21 +90,6 @@ edascm_with_toplevel (SCM toplevel, SCM thunk)
   return scm_with_fluid (scheme_toplevel_fluid, toplevel, thunk);
 }
 
-/*!
- * \brief Create the (lepton core toplevel) Scheme module
- * \par Function Description
- * Defines procedures in the (lepton core toplevel) module. The module
- * can be accessed using (use-modules (lepton core toplevel)).
- */
-static void
-init_module_lepton_core_toplevel (void *unused)
-{
-  /* Register the functions */
-  #include "scheme_toplevel.x"
-
-  /* Add them to the module's public definitions. */
-  scm_c_export (NULL);
-}
 
 /*!
  * \brief Initialise the LeptonToplevel manipulation procedures.
@@ -117,9 +102,4 @@ void
 edascm_init_toplevel ()
 {
   scheme_toplevel_fluid = scm_permanent_object (scm_make_fluid ());
-
-  /* Define the (lepton core toplevel) module */
-  scm_c_define_module ("lepton core toplevel",
-                       (void (*)(void*)) init_module_lepton_core_toplevel,
-                       NULL);
 }

--- a/liblepton/src/scheme_toplevel.c
+++ b/liblepton/src/scheme_toplevel.c
@@ -53,9 +53,8 @@ edascm_dynwind_toplevel (LeptonToplevel *toplevel)
  * Return the value of the #LeptonToplevel fluid in the current dynamic
  * context.
  */
-SCM_DEFINE (edascm_current_toplevel, "%current-toplevel", 0, 0, 0,
-            (),
-            "Get the LeptonToplevel for the current dynamic context.")
+SCM
+edascm_current_toplevel ()
 {
   return scm_fluid_ref (scheme_toplevel_fluid);
 }
@@ -106,7 +105,6 @@ init_module_lepton_core_toplevel (void *unused)
 
   /* Add them to the module's public definitions. */
   scm_c_export (s_edascm_with_toplevel,
-                s_edascm_current_toplevel,
                 NULL);
 }
 

--- a/liblepton/src/scheme_toplevel.c
+++ b/liblepton/src/scheme_toplevel.c
@@ -84,9 +84,8 @@ edascm_c_current_toplevel ()
  * \par Function Description
  * Set the #LeptonToplevel fluid to \a toplevel and call \a thunk.
  */
-SCM_DEFINE (edascm_with_toplevel, "%with-toplevel", 2, 0, 0,
-            (SCM toplevel, SCM thunk),
-            "Call `thunk', setting the LeptonToplevel fluid to `toplevel'.")
+SCM
+edascm_with_toplevel (SCM toplevel, SCM thunk)
 {
   return scm_with_fluid (scheme_toplevel_fluid, toplevel, thunk);
 }
@@ -104,8 +103,7 @@ init_module_lepton_core_toplevel (void *unused)
   #include "scheme_toplevel.x"
 
   /* Add them to the module's public definitions. */
-  scm_c_export (s_edascm_with_toplevel,
-                NULL);
+  scm_c_export (NULL);
 }
 
 /*!

--- a/liblepton/src/toplevel.c
+++ b/liblepton/src/toplevel.c
@@ -2,7 +2,7 @@
  * Copyright (C) 1998, 1999, 2000 Kazu Hirata / Ales Hvezda
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2017 gEDA Contributors
- * Copyright (C) 2017-2021 Lepton EDA Contributors
+ * Copyright (C) 2017-2022 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -42,7 +42,7 @@
  *  \returns the newly created LeptonToplevel.
  */
 LeptonToplevel*
-s_toplevel_new ()
+lepton_toplevel_new ()
 {
   LeptonToplevel *toplevel;
 

--- a/liblepton/tests/test_arc_object.c
+++ b/liblepton/tests/test_arc_object.c
@@ -5,7 +5,7 @@ void
 check_construction ()
 {
   gint count;
-  LeptonToplevel *toplevel = s_toplevel_new ();
+  LeptonToplevel *toplevel = lepton_toplevel_new ();
 
   for (count = 0; count < 1000; count++) {
     gint center_x = g_test_rand_int ();
@@ -57,7 +57,7 @@ void
 check_accessors ()
 {
   gint count;
-  LeptonToplevel *toplevel = s_toplevel_new ();
+  LeptonToplevel *toplevel = lepton_toplevel_new ();
 
   for (count = 0; count < 1000; count++) {
     gint center_x = g_test_rand_int ();
@@ -109,7 +109,7 @@ check_serialization ()
 {
   gint count;
   gint converted;
-  LeptonToplevel *toplevel = s_toplevel_new ();
+  LeptonToplevel *toplevel = lepton_toplevel_new ();
   guint version;
 
   converted = sscanf (PACKAGE_DATE_VERSION, "%u", &version);

--- a/liblepton/tests/test_bus_object.c
+++ b/liblepton/tests/test_bus_object.c
@@ -5,7 +5,7 @@ void
 check_construction ()
 {
   gint count;
-  LeptonToplevel *toplevel = s_toplevel_new ();
+  LeptonToplevel *toplevel = lepton_toplevel_new ();
 
   for (count = 0; count < 1000; count++) {
     gint x0 = g_test_rand_int ();
@@ -57,7 +57,7 @@ void
 check_accessors ()
 {
   gint count;
-  LeptonToplevel *toplevel = s_toplevel_new ();
+  LeptonToplevel *toplevel = lepton_toplevel_new ();
 
   for (count = 0; count < 1000; count++) {
     gint x0 = g_test_rand_int ();
@@ -109,7 +109,7 @@ check_serialization ()
 {
   gint count;
   gint converted;
-  LeptonToplevel *toplevel = s_toplevel_new ();
+  LeptonToplevel *toplevel = lepton_toplevel_new ();
   guint version;
 
   converted = sscanf (PACKAGE_DATE_VERSION, "%u", &version);

--- a/liblepton/tests/test_circle_object.c
+++ b/liblepton/tests/test_circle_object.c
@@ -5,7 +5,7 @@ void
 check_construction ()
 {
   gint count;
-  LeptonToplevel *toplevel = s_toplevel_new ();
+  LeptonToplevel *toplevel = lepton_toplevel_new ();
 
   for (count = 0; count < 1000; count++) {
     gint center_x = g_test_rand_int ();
@@ -49,7 +49,7 @@ void
 check_accessors ()
 {
   gint count;
-  LeptonToplevel *toplevel = s_toplevel_new ();
+  LeptonToplevel *toplevel = lepton_toplevel_new ();
 
   for (count = 0; count < 1000; count++) {
     gint center_x = g_test_rand_int ();
@@ -91,7 +91,7 @@ check_serialization ()
 {
   gint count;
   gint converted;
-  LeptonToplevel *toplevel = s_toplevel_new ();
+  LeptonToplevel *toplevel = lepton_toplevel_new ();
   guint version;
 
   converted = sscanf (PACKAGE_DATE_VERSION, "%u", &version);

--- a/liblepton/tests/test_line_object.c
+++ b/liblepton/tests/test_line_object.c
@@ -5,7 +5,7 @@ void
 check_construction ()
 {
   gint count;
-  LeptonToplevel *toplevel = s_toplevel_new ();
+  LeptonToplevel *toplevel = lepton_toplevel_new ();
 
   for (count = 0; count < 1000; count++) {
     gint x0 = g_test_rand_int ();
@@ -53,7 +53,7 @@ void
 check_accessors ()
 {
   gint count;
-  LeptonToplevel *toplevel = s_toplevel_new ();
+  LeptonToplevel *toplevel = lepton_toplevel_new ();
 
   for (count = 0; count < 1000; count++) {
     gint x0 = g_test_rand_int ();
@@ -100,7 +100,7 @@ check_serialization ()
 {
   gint count;
   gint converted;
-  LeptonToplevel *toplevel = s_toplevel_new ();
+  LeptonToplevel *toplevel = lepton_toplevel_new ();
   guint version;
 
   converted = sscanf (PACKAGE_DATE_VERSION, "%u", &version);

--- a/liblepton/tests/test_net_object.c
+++ b/liblepton/tests/test_net_object.c
@@ -5,7 +5,7 @@ void
 check_construction ()
 {
   gint count;
-  LeptonToplevel *toplevel = s_toplevel_new ();
+  LeptonToplevel *toplevel = lepton_toplevel_new ();
 
   for (count = 0; count < 1000; count++) {
     gint x0 = g_test_rand_int ();
@@ -53,7 +53,7 @@ void
 check_accessors ()
 {
   gint count;
-  LeptonToplevel *toplevel = s_toplevel_new ();
+  LeptonToplevel *toplevel = lepton_toplevel_new ();
 
   for (count = 0; count < 1000; count++) {
     gint x0 = g_test_rand_int ();
@@ -100,7 +100,7 @@ check_serialization ()
 {
   gint count;
   gint converted;
-  LeptonToplevel *toplevel = s_toplevel_new ();
+  LeptonToplevel *toplevel = lepton_toplevel_new ();
   guint version;
 
   converted = sscanf (PACKAGE_DATE_VERSION, "%u", &version);

--- a/liblepton/tests/test_pin_object.c
+++ b/liblepton/tests/test_pin_object.c
@@ -5,7 +5,7 @@ void
 check_construction ()
 {
   gint count;
-  LeptonToplevel *toplevel = s_toplevel_new ();
+  LeptonToplevel *toplevel = lepton_toplevel_new ();
 
   for (count = 0; count < 1000; count++) {
     gint x0 = g_test_rand_int ();
@@ -57,7 +57,7 @@ void
 check_accessors ()
 {
   gint count;
-  LeptonToplevel *toplevel = s_toplevel_new ();
+  LeptonToplevel *toplevel = lepton_toplevel_new ();
 
   for (count = 0; count < 1000; count++) {
     gint x0 = g_test_rand_int ();
@@ -108,7 +108,7 @@ check_serialization ()
 {
   gint count;
   gint converted;
-  LeptonToplevel *toplevel = s_toplevel_new ();
+  LeptonToplevel *toplevel = lepton_toplevel_new ();
   guint version;
 
   converted = sscanf (PACKAGE_DATE_VERSION, "%u", &version);

--- a/liblepton/tests/test_text_object.c
+++ b/liblepton/tests/test_text_object.c
@@ -19,7 +19,7 @@ void
 check_construction ()
 {
   gint count;
-  LeptonToplevel *toplevel = s_toplevel_new ();
+  LeptonToplevel *toplevel = lepton_toplevel_new ();
 
   for (count = 0; count < 1000; count++) {
     gint x = g_test_rand_int ();
@@ -81,7 +81,7 @@ void
 check_accessors ()
 {
   gint count;
-  LeptonToplevel *toplevel = s_toplevel_new ();
+  LeptonToplevel *toplevel = lepton_toplevel_new ();
 
   for (count = 0; count < 1000; count++) {
     gint x = g_test_rand_int ();
@@ -152,7 +152,7 @@ check_serialization ()
 {
   gint count;
   gint converted;
-  LeptonToplevel *toplevel = s_toplevel_new ();
+  LeptonToplevel *toplevel = lepton_toplevel_new ();
   guint version;
 
   converted = sscanf (PACKAGE_DATE_VERSION, "%u", &version);

--- a/libleptongui/scheme/schematic/symbol/check.scm
+++ b/libleptongui/scheme/schematic/symbol/check.scm
@@ -1,6 +1,6 @@
 ;; Lepton EDA Schematic Capture
 ;; Scheme API
-;; Copyright (C) 2017-2020 Lepton EDA Contributors
+;; Copyright (C) 2017-2022 Lepton EDA Contributors
 ;;
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -19,7 +19,6 @@
 
 (define-module (schematic symbol check)
   #:use-module (srfi srfi-1)
-  #:use-module (lepton core toplevel)
   #:use-module (lepton page)
   #:use-module (schematic core gettext)
   #:use-module (schematic dialog)

--- a/libleptongui/src/gschem_preview.c
+++ b/libleptongui/src/gschem_preview.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2016 gEDA Contributors
- * Copyright (C) 2017-2021 Lepton EDA Contributors
+ * Copyright (C) 2017-2022 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -304,7 +304,7 @@ gschem_preview_init (GschemPreview *preview)
 
   GschemToplevel *preview_w_current;
   preview_w_current = gschem_toplevel_new ();
-  gschem_toplevel_set_toplevel (preview_w_current, s_toplevel_new ());
+  gschem_toplevel_set_toplevel (preview_w_current, lepton_toplevel_new ());
 
   i_vars_set (preview_w_current);
 

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -2,7 +2,7 @@
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2016 gEDA Contributors
  * Copyright (C) 2016 Peter Brett <peter@peter-b.co.uk>
- * Copyright (C) 2017-2021 Lepton EDA Contributors
+ * Copyright (C) 2017-2022 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1002,7 +1002,7 @@ x_window_close_page_impl (GschemToplevel *w_current,
  */
 GschemToplevel* x_window_new ()
 {
-  LeptonToplevel *toplevel = s_toplevel_new ();
+  LeptonToplevel *toplevel = lepton_toplevel_new ();
 
   /* Load old (*rc files) and new (*.conf) configuration: */
   x_rc_parse_gschem (toplevel, NULL);

--- a/schematic/lepton-schematic.scm
+++ b/schematic/lepton-schematic.scm
@@ -4,7 +4,7 @@ exec @GUILE@ -s "$0" "$@"
 
 ;;; Lepton EDA attribute editor
 ;;; Copyright (C) 1998-2016 gEDA Contributors
-;;; Copyright (C) 2017-2021 Lepton EDA Contributors
+;;; Copyright (C) 2017-2022 Lepton EDA Contributors
 ;;;
 ;;; This program is free software; you can redistribute it and/or modify
 ;;; it under the terms of the GNU General Public License as published by
@@ -27,27 +27,26 @@ exec @GUILE@ -s "$0" "$@"
 
 (use-modules (ice-9 match)
              (srfi srfi-1)
-             (lepton srfi-37)
              (system foreign)
-             (lepton ffi))
+             (lepton color-map)
+             (lepton config)
+             (lepton eval)
+             (lepton ffi)
+             (lepton file-system)
+             (lepton log)
+             (lepton os)
+             (lepton srfi-37)
+             (lepton version)
+             (schematic core gettext)
+             (schematic ffi)
+             (schematic ffi gtk)
+             (schematic menu))
 
 ;;; Initialize liblepton library.
 (liblepton_init)
 (unless (getenv "LEPTON_INHIBIT_RC_FILES")
   (register-data-dirs))
 (edascm_init)
-
-(primitive-eval '(use-modules (lepton color-map)
-                              (lepton config)
-                              (lepton eval)
-                              (lepton file-system)
-                              (lepton log)
-                              (lepton os)
-                              (lepton version)
-                              (schematic core gettext)
-                              (schematic ffi)
-                              (schematic ffi gtk)
-                              (schematic menu)))
 
 
 ;;; Localization.

--- a/tests/archive.test
+++ b/tests/archive.test
@@ -1,0 +1,49 @@
+(use-modules (ice-9 receive))
+
+(load-from-path "env.scm")
+
+(define help-string "Usage: lepton-archive [OPTION...] FILES...")
+
+
+(test-begin "lepton-archive -h")
+
+(receive (<status> <stdout> <stderr>)
+    (command-values lepton-archive "-h")
+  (test-eq EXIT_SUCCESS <status>)
+  (test-assert (string-contains <stdout> help-string)))
+
+(test-end "lepton-archive -h")
+
+
+(test-begin "lepton-archive --help")
+
+(receive (<status> <stdout> <stderr>)
+    (command-values lepton-archive "--help")
+  (test-eq EXIT_SUCCESS <status>)
+  (test-assert (string-contains <stdout> help-string)))
+
+(test-end "lepton-archive --help")
+
+
+(test-begin "lepton-archive -V")
+
+(receive (<status> <stdout> <stderr>)
+    (command-values lepton-archive "-V")
+  (test-eq EXIT_SUCCESS <status>)
+  (test-assert (string-contains <stdout> "Lepton EDA"))
+  (test-assert (string-contains <stdout> "Copyright"))
+  (test-assert (string-contains <stdout> "There is NO WARRANTY")))
+
+(test-end "lepton-archive -V")
+
+
+(test-begin "lepton-archive --version")
+
+(receive (<status> <stdout> <stderr>)
+    (command-values lepton-archive "--version")
+  (test-eq EXIT_SUCCESS <status>)
+  (test-assert (string-contains <stdout> "Lepton EDA"))
+  (test-assert (string-contains <stdout> "Copyright"))
+  (test-assert (string-contains <stdout> "There is NO WARRANTY")))
+
+(test-end "lepton-archive --version")

--- a/tests/cli.test
+++ b/tests/cli.test
@@ -2,14 +2,6 @@
 
 (load-from-path "env.scm")
 
-
-(define lepton-shell
-  (build-filename *abs-top-builddir*
-                  "utils"
-                  "cli"
-                  "scheme"
-                  "lepton-shell"))
-
 (putenv (string-append "LEPTON_SHELL" "=" lepton-shell))
 
 
@@ -29,9 +21,6 @@
 (define help-string "Usage: lepton-cli [OPTION...] COMMAND [ARGS ...]")
 
 (define run-help-string "Run `lepton-cli --help' for more information.")
-
-
-(define help-string "Usage: lepton-cli [OPTION...] COMMAND [ARGS ...]")
 
 
 ;;; Test lepton-cli without args.

--- a/tests/embed.test
+++ b/tests/embed.test
@@ -1,0 +1,49 @@
+(use-modules (ice-9 receive))
+
+(load-from-path "env.scm")
+
+(define help-string "Usage: lepton-embed -e | -u [OPTIONS] FILE ...")
+
+
+(test-begin "lepton-embed -h")
+
+(receive (<status> <stdout> <stderr>)
+    (command-values lepton-embed "-h")
+  (test-eq EXIT_SUCCESS <status>)
+  (test-assert (string-contains <stdout> help-string)))
+
+(test-end "lepton-embed -h")
+
+
+(test-begin "lepton-embed --help")
+
+(receive (<status> <stdout> <stderr>)
+    (command-values lepton-embed "--help")
+  (test-eq EXIT_SUCCESS <status>)
+  (test-assert (string-contains <stdout> help-string)))
+
+(test-end "lepton-embed --help")
+
+
+(test-begin "lepton-embed -V")
+
+(receive (<status> <stdout> <stderr>)
+    (command-values lepton-embed "-V")
+  (test-eq EXIT_SUCCESS <status>)
+  (test-assert (string-contains <stdout> "Lepton EDA"))
+  (test-assert (string-contains <stdout> "Copyright"))
+  (test-assert (string-contains <stdout> "There is NO WARRANTY")))
+
+(test-end "lepton-embed -V")
+
+
+(test-begin "lepton-embed --version")
+
+(receive (<status> <stdout> <stderr>)
+    (command-values lepton-embed "--version")
+  (test-eq EXIT_SUCCESS <status>)
+  (test-assert (string-contains <stdout> "Lepton EDA"))
+  (test-assert (string-contains <stdout> "Copyright"))
+  (test-assert (string-contains <stdout> "There is NO WARRANTY")))
+
+(test-end "lepton-embed --version")

--- a/tests/env.scm
+++ b/tests/env.scm
@@ -165,6 +165,12 @@
                   "symcheck"
                   "lepton-symcheck"))
 
+(define lepton-tragesym
+  (build-filename *abs-top-builddir*
+                  "utils"
+                  "tragesym"
+                  "lepton-tragesym"))
+
 (putenv (string-append "LEPTON_CONFIG" "=" lepton-config))
 (putenv (string-append "LEPTON_EXPORT" "=" lepton-export))
 (putenv (string-append "LEPTON_SHELL" "=" lepton-shell))

--- a/tests/env.scm
+++ b/tests/env.scm
@@ -139,6 +139,12 @@
                   "scheme"
                   "lepton-config"))
 
+(define lepton-embed
+  (build-filename *abs-top-builddir*
+                  "utils"
+                  "embed"
+                  "lepton-embed"))
+
 (define lepton-export
   (build-filename *abs-top-builddir*
                   "utils"

--- a/tests/env.scm
+++ b/tests/env.scm
@@ -119,6 +119,12 @@
 ;;; defined.
 (putenv "LANG=C")
 
+(define lepton-archive
+  (build-filename *abs-top-builddir*
+                  "utils"
+                  "archive"
+                  "lepton-archive"))
+
 (define lepton-cli
   (build-filename *abs-top-builddir*
                   "utils"

--- a/tests/env.scm
+++ b/tests/env.scm
@@ -171,6 +171,12 @@
                   "tragesym"
                   "lepton-tragesym"))
 
+(define lepton-upcfg
+  (build-filename *abs-top-builddir*
+                  "utils"
+                  "upcfg"
+                  "lepton-upcfg"))
+
 (putenv (string-append "LEPTON_CONFIG" "=" lepton-config))
 (putenv (string-append "LEPTON_EXPORT" "=" lepton-export))
 (putenv (string-append "LEPTON_SHELL" "=" lepton-shell))

--- a/tests/shell.test
+++ b/tests/shell.test
@@ -233,7 +233,7 @@
 (test-group-with-cleanup "group: lepton-cli shell toplevel"
   (test-setup)
 
-  (let* ((scheme-code "(use-modules (lepton core toplevel)) (display (%current-toplevel))")
+  (let* ((scheme-code "(use-modules (lepton toplevel)) (display (%current-toplevel))")
          (scheme-code-w-exit (string-append scheme-code "(exit)"))
          (scheme-filename (string->file scheme-code-w-exit
                                         (build-filename *testdir* "file.scm"))))

--- a/tests/tragesym.test
+++ b/tests/tragesym.test
@@ -1,0 +1,49 @@
+(use-modules (ice-9 receive))
+
+(load-from-path "env.scm")
+
+(define help-string "lepton-tragesym INPUT-FILE OUTPUT-FILE")
+
+
+(test-begin "lepton-tragesym -h")
+
+(receive (<status> <stdout> <stderr>)
+    (command-values lepton-tragesym "-h")
+  (test-eq EXIT_SUCCESS <status>)
+  (test-assert (string-contains <stdout> help-string)))
+
+(test-end "lepton-tragesym -h")
+
+
+(test-begin "lepton-tragesym --help")
+
+(receive (<status> <stdout> <stderr>)
+    (command-values lepton-tragesym "--help")
+  (test-eq EXIT_SUCCESS <status>)
+  (test-assert (string-contains <stdout> help-string)))
+
+(test-end "lepton-tragesym --help")
+
+
+(test-begin "lepton-tragesym -V")
+
+(receive (<status> <stdout> <stderr>)
+    (command-values lepton-tragesym "-V")
+  (test-eq EXIT_SUCCESS <status>)
+  (test-assert (string-contains <stdout> "Lepton EDA"))
+  (test-assert (string-contains <stdout> "Copyright"))
+  (test-assert (string-contains <stdout> "There is NO WARRANTY")))
+
+(test-end "lepton-tragesym -V")
+
+
+(test-begin "lepton-tragesym --version")
+
+(receive (<status> <stdout> <stderr>)
+    (command-values lepton-tragesym "--version")
+  (test-eq EXIT_SUCCESS <status>)
+  (test-assert (string-contains <stdout> "Lepton EDA"))
+  (test-assert (string-contains <stdout> "Copyright"))
+  (test-assert (string-contains <stdout> "There is NO WARRANTY")))
+
+(test-end "lepton-tragesym --version")

--- a/tests/upcfg.test
+++ b/tests/upcfg.test
@@ -1,0 +1,49 @@
+(use-modules (ice-9 receive))
+
+(load-from-path "env.scm")
+
+(define help-string "Usage: lepton-upcfg [OPTIONS] | FILE")
+
+
+(test-begin "lepton-upcfg -h")
+
+(receive (<status> <stdout> <stderr>)
+    (command-values lepton-upcfg "-h")
+  (test-eq EXIT_SUCCESS <status>)
+  (test-assert (string-contains <stdout> help-string)))
+
+(test-end "lepton-upcfg -h")
+
+
+(test-begin "lepton-upcfg --help")
+
+(receive (<status> <stdout> <stderr>)
+    (command-values lepton-upcfg "--help")
+  (test-eq EXIT_SUCCESS <status>)
+  (test-assert (string-contains <stdout> help-string)))
+
+(test-end "lepton-upcfg --help")
+
+
+(test-begin "lepton-upcfg -V")
+
+(receive (<status> <stdout> <stderr>)
+    (command-values lepton-upcfg "-V")
+  (test-eq EXIT_SUCCESS <status>)
+  (test-assert (string-contains <stdout> "Lepton EDA"))
+  (test-assert (string-contains <stdout> "Copyright"))
+  (test-assert (string-contains <stdout> "There is NO WARRANTY")))
+
+(test-end "lepton-upcfg -V")
+
+
+(test-begin "lepton-upcfg --version")
+
+(receive (<status> <stdout> <stderr>)
+    (command-values lepton-upcfg "--version")
+  (test-eq EXIT_SUCCESS <status>)
+  (test-assert (string-contains <stdout> "Lepton EDA"))
+  (test-assert (string-contains <stdout> "Copyright"))
+  (test-assert (string-contains <stdout> "There is NO WARRANTY")))
+
+(test-end "lepton-upcfg --version")

--- a/utils/archive/lepton-archive.scm
+++ b/utils/archive/lepton-archive.scm
@@ -75,26 +75,24 @@ exec @GUILE@ -s "$0" "$@"
              (srfi srfi-1)
              (srfi srfi-26)
              (lepton ffi)
-             (lepton toplevel))
+             (lepton file-system)
+             (lepton library component)
+             (lepton library)
+             (lepton log)
+             (lepton object)
+             (lepton os)
+             (lepton page)
+             (lepton rc)
+             (lepton toplevel)
+             (lepton version)
+             (netlist schematic)
+             (netlist schematic-component))
 
 ;;; Initialize liblepton library.
 (liblepton_init)
 (unless (getenv "LEPTON_INHIBIT_RC_FILES")
   (register-data-dirs))
 (edascm_init)
-
-(primitive-eval
- '(use-modules (lepton log)
-               (lepton file-system)
-               (lepton library)
-               (lepton library component)
-               (lepton object)
-               (lepton os)
-               (lepton page)
-               (lepton rc)
-               (lepton version)
-               (netlist schematic)
-               (netlist schematic-component)))
 
 
 ;;; Helper functions and data structures.

--- a/utils/archive/lepton-archive.scm
+++ b/utils/archive/lepton-archive.scm
@@ -84,8 +84,7 @@ exec @GUILE@ -s "$0" "$@"
 (edascm_init)
 
 (primitive-eval
- '(use-modules (lepton core toplevel)
-               (lepton log)
+ '(use-modules (lepton log)
                (lepton file-system)
                (lepton library)
                (lepton library component)

--- a/utils/archive/lepton-archive.scm
+++ b/utils/archive/lepton-archive.scm
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 exec @GUILE@ -s "$0" "$@"
 !#
-;;; Copyright (C) 2019-2021 Lepton EDA Contributors
+;;; Copyright (C) 2019-2022 Lepton EDA Contributors
 ;;;
 ;;; Based on Python script by Stuart Brorson:
 ;;; Copyright (C) 2003 Stuart Brorson <sdb@cloud9.net>
@@ -74,7 +74,8 @@ exec @GUILE@ -s "$0" "$@"
              (ice-9 rdelim)
              (srfi srfi-1)
              (srfi srfi-26)
-             (lepton ffi))
+             (lepton ffi)
+             (lepton toplevel))
 
 ;;; Initialize liblepton library.
 (liblepton_init)

--- a/utils/attrib/lepton-attrib.scm
+++ b/utils/attrib/lepton-attrib.scm
@@ -5,7 +5,7 @@ exec @GUILE@ -s "$0" "$@"
 ;;; Lepton EDA attribute editor
 ;;; Copyright (C) 2003-2010 Stuart D. Brorson.
 ;;; Copyright (C) 2005-2016 gEDA Contributors
-;;; Copyright (C) 2017-2021 Lepton EDA Contributors
+;;; Copyright (C) 2017-2022 Lepton EDA Contributors
 ;;;
 ;;; This program is free software; you can redistribute it and/or modify
 ;;; it under the terms of the GNU General Public License as published by
@@ -31,7 +31,8 @@ exec @GUILE@ -s "$0" "$@"
              (srfi srfi-1)
              (system foreign)
              (lepton ffi)
-             (lepton ffi lib))
+             (lepton ffi lib)
+             (lepton toplevel))
 
 ;;; Initialize liblepton library.
 (liblepton_init)

--- a/utils/attrib/lepton-attrib.scm
+++ b/utils/attrib/lepton-attrib.scm
@@ -82,8 +82,7 @@ exec @GUILE@ -s "$0" "$@"
 
 (define (G_ msg) (gettext msg %textdomain))
 
-(primitive-eval '(use-modules (lepton core toplevel)
-                              (lepton file-system)
+(primitive-eval '(use-modules (lepton file-system)
                               (lepton log)
                               (lepton page)
                               (lepton rc)

--- a/utils/attrib/lepton-attrib.scm
+++ b/utils/attrib/lepton-attrib.scm
@@ -30,9 +30,14 @@ exec @GUILE@ -s "$0" "$@"
              (ice-9 receive)
              (srfi srfi-1)
              (system foreign)
-             (lepton ffi)
              (lepton ffi lib)
-             (lepton toplevel))
+             (lepton ffi)
+             (lepton file-system)
+             (lepton log)
+             (lepton page)
+             (lepton rc)
+             (lepton toplevel)
+             (lepton version))
 
 ;;; Initialize liblepton library.
 (liblepton_init)
@@ -81,12 +86,6 @@ exec @GUILE@ -s "$0" "$@"
 (setlocale LC_NUMERIC "C")
 
 (define (G_ msg) (gettext msg %textdomain))
-
-(primitive-eval '(use-modules (lepton file-system)
-                              (lepton log)
-                              (lepton page)
-                              (lepton rc)
-                              (lepton version)))
 
 (define (usage)
   (format #t

--- a/utils/cli/scheme/lepton-cli.scm
+++ b/utils/cli/scheme/lepton-cli.scm
@@ -5,7 +5,7 @@ exec @GUILE@ -s "$0" "$@"
 ;;; Lepton EDA command-line utility
 ;;; Copyright (C) 2012-2013 Peter Brett <peter@peter-b.co.uk>
 ;;; Copyright (C) 2012-2014 gEDA Contributors
-;;; Copyright (C) 2017-2021 Lepton EDA Contributors
+;;; Copyright (C) 2017-2022 Lepton EDA Contributors
 ;;;
 ;;; This program is free software; you can redistribute it and/or modify
 ;;; it under the terms of the GNU General Public License as published by
@@ -27,7 +27,9 @@ exec @GUILE@ -s "$0" "$@"
     (set! %load-compiled-path (cons "@ccachedir@" %load-compiled-path))))
 
 (use-modules (srfi srfi-37)
-             (lepton ffi))
+             (lepton core gettext)
+             (lepton ffi)
+             (lepton version))
 
 ;;; Initialize liblepton library.
 (liblepton_init)
@@ -35,8 +37,6 @@ exec @GUILE@ -s "$0" "$@"
   (register-data-dirs))
 (edascm_init)
 
-(primitive-eval '(use-modules (lepton core gettext)
-                              (lepton version)))
 
 (define %cli (basename (car (program-arguments))))
 (define %rest-args (cdr (program-arguments)))

--- a/utils/cli/scheme/lepton-config.scm
+++ b/utils/cli/scheme/lepton-config.scm
@@ -5,7 +5,7 @@ exec @GUILE@ -s "$0" "$@"
 ;;; Lepton EDA command-line utility
 ;;; Copyright (C) 2012 Peter Brett <peter@peter-b.co.uk>
 ;;; Copyright (C) 2015 gEDA Contributors
-;;; Copyright (C) 2017-2021 Lepton EDA Contributors
+;;; Copyright (C) 2017-2022 Lepton EDA Contributors
 ;;;
 ;;; This program is free software; you can redistribute it and/or modify
 ;;; it under the terms of the GNU General Public License as published by
@@ -29,7 +29,11 @@ exec @GUILE@ -s "$0" "$@"
 (use-modules (ice-9 match)
              (srfi srfi-1)
              (srfi srfi-37)
-             (lepton ffi))
+             (lepton config)
+             (lepton core gettext)
+             (lepton ffi)
+             (lepton file-system)
+             (lepton version))
 
 ;;; Initialize liblepton library.
 (liblepton_init)
@@ -37,10 +41,6 @@ exec @GUILE@ -s "$0" "$@"
   (register-data-dirs))
 (edascm_init)
 
-(primitive-eval '(use-modules (lepton core gettext)
-                              (lepton config)
-                              (lepton file-system)
-                              (lepton version)))
 
 (define cmd (basename (car (program-arguments))))
 (define cmd-args (cdr (program-arguments)))

--- a/utils/cli/scheme/lepton-export.scm
+++ b/utils/cli/scheme/lepton-export.scm
@@ -29,8 +29,12 @@ exec @GUILE@ -s "$0" "$@"
 (use-modules (srfi srfi-1)
              (srfi srfi-37)
              (system foreign)
+             (lepton core gettext)
              (lepton ffi)
-             (lepton toplevel))
+             (lepton page)
+             (lepton rc)
+             (lepton toplevel)
+             (lepton version))
 
 ;;; Initialize liblepton library.
 (liblepton_init)
@@ -38,10 +42,6 @@ exec @GUILE@ -s "$0" "$@"
   (register-data-dirs))
 (edascm_init)
 
-(primitive-eval '(use-modules (lepton core gettext)
-                              (lepton page)
-                              (lepton rc)
-                              (lepton version)))
 
 ;;; Each export format is a list of the form:
 ;;;   '(alias name multipage func)

--- a/utils/cli/scheme/lepton-export.scm
+++ b/utils/cli/scheme/lepton-export.scm
@@ -39,7 +39,6 @@ exec @GUILE@ -s "$0" "$@"
 (edascm_init)
 
 (primitive-eval '(use-modules (lepton core gettext)
-                              (lepton core toplevel)
                               (lepton page)
                               (lepton rc)
                               (lepton version)))

--- a/utils/cli/scheme/lepton-export.scm
+++ b/utils/cli/scheme/lepton-export.scm
@@ -5,7 +5,7 @@ exec @GUILE@ -s "$0" "$@"
 ;;; Lepton EDA command-line utility
 ;;; Copyright (C) 2012 Peter Brett <peter@peter-b.co.uk>
 ;;; Copyright (C) 2014-2016 gEDA Contributors
-;;; Copyright (C) 2017-2021 Lepton EDA Contributors
+;;; Copyright (C) 2017-2022 Lepton EDA Contributors
 ;;;
 ;;; This program is free software; you can redistribute it and/or modify
 ;;; it under the terms of the GNU General Public License as published by
@@ -29,7 +29,8 @@ exec @GUILE@ -s "$0" "$@"
 (use-modules (srfi srfi-1)
              (srfi srfi-37)
              (system foreign)
-             (lepton ffi))
+             (lepton ffi)
+             (lepton toplevel))
 
 ;;; Initialize liblepton library.
 (liblepton_init)

--- a/utils/cli/scheme/lepton-shell.scm
+++ b/utils/cli/scheme/lepton-shell.scm
@@ -39,7 +39,6 @@ exec @GUILE@ -e main -s "$0" "$@"
 (edascm_init)
 
 (primitive-eval '(use-modules (lepton core gettext)
-                              (lepton core toplevel)
                               (lepton rc)
                               (lepton repl)
                               (lepton version)))

--- a/utils/cli/scheme/lepton-shell.scm
+++ b/utils/cli/scheme/lepton-shell.scm
@@ -5,7 +5,7 @@ exec @GUILE@ -e main -s "$0" "$@"
 ;;; Lepton EDA command-line utility
 ;;; Copyright (C) 2012-2013 Peter Brett <peter@peter-b.co.uk>
 ;;; Copyright (C) 2012-2014 gEDA Contributors
-;;; Copyright (C) 2017-2021 Lepton EDA Contributors
+;;; Copyright (C) 2017-2022 Lepton EDA Contributors
 ;;;
 ;;; This program is free software; you can redistribute it and/or modify
 ;;; it under the terms of the GNU General Public License as published by
@@ -29,7 +29,8 @@ exec @GUILE@ -e main -s "$0" "$@"
 (use-modules (srfi srfi-37)
              (ice-9 eval-string)
              (ice-9 readline)
-             (lepton ffi))
+             (lepton ffi)
+             (lepton toplevel))
 
 ;;; Initialize liblepton library.
 (liblepton_init)

--- a/utils/cli/scheme/lepton-shell.scm
+++ b/utils/cli/scheme/lepton-shell.scm
@@ -29,8 +29,12 @@ exec @GUILE@ -e main -s "$0" "$@"
 (use-modules (srfi srfi-37)
              (ice-9 eval-string)
              (ice-9 readline)
+             (lepton core gettext)
              (lepton ffi)
-             (lepton toplevel))
+             (lepton rc)
+             (lepton repl)
+             (lepton toplevel)
+             (lepton version))
 
 ;;; Initialize liblepton library.
 (liblepton_init)
@@ -38,10 +42,6 @@ exec @GUILE@ -e main -s "$0" "$@"
   (register-data-dirs))
 (edascm_init)
 
-(primitive-eval '(use-modules (lepton core gettext)
-                              (lepton rc)
-                              (lepton repl)
-                              (lepton version)))
 
 (define cmd (basename (car (program-arguments))))
 (define cmd-args (cdr (program-arguments)))

--- a/utils/embed/lepton-embed.scm
+++ b/utils/embed/lepton-embed.scm
@@ -18,19 +18,17 @@ exec @GUILE@ "$0" "$@"
 (use-modules (ice-9 format)
              (ice-9 getopt-long)
              (lepton ffi)
-             (lepton toplevel))
+             (lepton object)
+             (lepton page)
+             (lepton rc)
+             (lepton toplevel)
+             (lepton version))
 
 ;; Initialize liblepton library.
 (liblepton_init)
 (unless (getenv "LEPTON_INHIBIT_RC_FILES")
   (register-data-dirs))
 (edascm_init)
-
-( primitive-eval '(use-modules (lepton object)) )
-( primitive-eval '(use-modules (lepton page)) )
-( primitive-eval '(use-modules (lepton rc)) )
-( primitive-eval '(use-modules (lepton version)) )
-
 
 
 ; command line options:

--- a/utils/embed/lepton-embed.scm
+++ b/utils/embed/lepton-embed.scm
@@ -26,7 +26,6 @@ exec @GUILE@ "$0" "$@"
   (register-data-dirs))
 (edascm_init)
 
-( primitive-eval '(use-modules (lepton core toplevel)) )
 ( primitive-eval '(use-modules (lepton object)) )
 ( primitive-eval '(use-modules (lepton page)) )
 ( primitive-eval '(use-modules (lepton rc)) )

--- a/utils/embed/lepton-embed.scm
+++ b/utils/embed/lepton-embed.scm
@@ -6,7 +6,7 @@ exec @GUILE@ "$0" "$@"
 ;; Lepton EDA
 ;; lepton-embed - schematic components and pictures embedding utility
 ;; Copyright (C) 2019 dmn <graahnul.grom@gmail.com>
-;; Copyright (C) 2019-2021 Lepton EDA Contributors
+;; Copyright (C) 2019-2022 Lepton EDA Contributors
 ;; License: GPLv2+. See the COPYING file
 ;;
 
@@ -17,7 +17,8 @@ exec @GUILE@ "$0" "$@"
 
 (use-modules (ice-9 format)
              (ice-9 getopt-long)
-             (lepton ffi))
+             (lepton ffi)
+             (lepton toplevel))
 
 ;; Initialize liblepton library.
 (liblepton_init)

--- a/utils/netlist/lepton-netlist.scm
+++ b/utils/netlist/lepton-netlist.scm
@@ -84,8 +84,7 @@ exec @GUILE@ -s "$0" "$@"
 ;;; Using of primitive-eval() here avoids Scheme errors when this
 ;;; program is compiled by Guile. The following modules are
 ;;; necessary to actually run the code below.
-(primitive-eval '(use-modules (lepton core toplevel)
-                              (geda deprecated)
+(primitive-eval '(use-modules (geda deprecated)
                               (lepton library)
                               (lepton log)
                               (lepton version)

--- a/utils/netlist/lepton-netlist.scm
+++ b/utils/netlist/lepton-netlist.scm
@@ -3,7 +3,7 @@ exec @GUILE@ -s "$0" "$@"
 !#
 ;;; Lepton EDA netlister
 ;;; Scheme API
-;;; Copyright (C) 2017-2021 Lepton EDA Contributors
+;;; Copyright (C) 2017-2022 Lepton EDA Contributors
 ;;;
 ;;; This program is free software; you can redistribute it and/or modify
 ;;; it under the terms of the GNU General Public License as published by
@@ -26,7 +26,8 @@ exec @GUILE@ -s "$0" "$@"
 
 (use-modules (ice-9 getopt-long)
              (srfi srfi-26)
-             (lepton ffi))
+             (lepton ffi)
+             (lepton toplevel))
 
 ;;; Initialize liblepton library.
 (liblepton_init)

--- a/utils/netlist/lepton-netlist.scm
+++ b/utils/netlist/lepton-netlist.scm
@@ -26,8 +26,14 @@ exec @GUILE@ -s "$0" "$@"
 
 (use-modules (ice-9 getopt-long)
              (srfi srfi-26)
+             (geda deprecated)
              (lepton ffi)
-             (lepton toplevel))
+             (lepton library)
+             (lepton log)
+             (lepton toplevel)
+             (lepton version)
+             (netlist option)
+             (netlist))
 
 ;;; Initialize liblepton library.
 (liblepton_init)
@@ -65,30 +71,12 @@ exec @GUILE@ -s "$0" "$@"
   (getopt-long (program-arguments) %option-spec))
 
 ;;; Initialize netlister options.
-
-;;; Using of primitive-eval() here avoids Scheme errors when this
-;;; program is compiled by Guile.
-(primitive-eval '(use-modules (netlist option)))
-
-;;; Actual initialization.
 (init-netlist-options! %options)
 
 ;;; Evaluate Scheme expressions that need to be run before rc
 ;;; files are loaded.
 (for-each (cut add-to-load-path <>)
           (netlist-option-ref/toplevel %options 'load-path '()))
-
-
-;;; Run netlister.
-
-;;; Using of primitive-eval() here avoids Scheme errors when this
-;;; program is compiled by Guile. The following modules are
-;;; necessary to actually run the code below.
-(primitive-eval '(use-modules (geda deprecated)
-                              (lepton library)
-                              (lepton log)
-                              (lepton version)
-                              (netlist)))
 
 ;;; Run netlister in new toplevel environment.
 (%with-toplevel (%make-toplevel)

--- a/utils/symcheck/lepton-symcheck.scm
+++ b/utils/symcheck/lepton-symcheck.scm
@@ -3,7 +3,7 @@ exec @GUILE@ -s "$0" "$@"
 !#
 ;;; Lepton EDA Symbol Checker
 ;;; Scheme API
-;;; Copyright (C) 2017-2021 Lepton EDA Contributors
+;;; Copyright (C) 2017-2022 Lepton EDA Contributors
 ;;;
 ;;; This program is free software; you can redistribute it and/or modify
 ;;; it under the terms of the GNU General Public License as published by
@@ -24,7 +24,8 @@ exec @GUILE@ -s "$0" "$@"
     (add-to-load-path "@LEPTON_SCHEME_MODULE_DIRECTORY@")
     (set! %load-compiled-path (cons "@ccachedir@" %load-compiled-path))))
 
-(use-modules (lepton ffi))
+(use-modules (lepton ffi)
+             (lepton toplevel))
 
 ;;; Initialize liblepton library.
 (liblepton_init)
@@ -42,8 +43,7 @@ exec @GUILE@ -s "$0" "$@"
 ;;; modules, since it compiles the code before loading the above
 ;;; extension. Let's make it quiet here.
 (define with-toplevel (@@ (lepton core toplevel) %with-toplevel))
-(define make-toplevel (@@ (lepton core toplevel) %make-toplevel))
 
 (primitive-eval '(use-modules (symcheck check)))
 
-(with-toplevel (make-toplevel) check-all-symbols)
+(with-toplevel (%make-toplevel) check-all-symbols)

--- a/utils/symcheck/lepton-symcheck.scm
+++ b/utils/symcheck/lepton-symcheck.scm
@@ -42,8 +42,7 @@ exec @GUILE@ -s "$0" "$@"
 ;;; At compile time of this program guile won't be aware of these
 ;;; modules, since it compiles the code before loading the above
 ;;; extension. Let's make it quiet here.
-(define with-toplevel (@@ (lepton core toplevel) %with-toplevel))
 
 (primitive-eval '(use-modules (symcheck check)))
 
-(with-toplevel (%make-toplevel) check-all-symbols)
+(%with-toplevel (%make-toplevel) check-all-symbols)

--- a/utils/symcheck/lepton-symcheck.scm
+++ b/utils/symcheck/lepton-symcheck.scm
@@ -25,7 +25,8 @@ exec @GUILE@ -s "$0" "$@"
     (set! %load-compiled-path (cons "@ccachedir@" %load-compiled-path))))
 
 (use-modules (lepton ffi)
-             (lepton toplevel))
+             (lepton toplevel)
+             (symcheck check))
 
 ;;; Initialize liblepton library.
 (liblepton_init)
@@ -38,11 +39,5 @@ exec @GUILE@ -s "$0" "$@"
 (textdomain %textdomain)
 (bindtextdomain %textdomain "@localedir@")
 (bind-textdomain-codeset %textdomain "UTF-8")
-
-;;; At compile time of this program guile won't be aware of these
-;;; modules, since it compiles the code before loading the above
-;;; extension. Let's make it quiet here.
-
-(primitive-eval '(use-modules (symcheck check)))
 
 (%with-toplevel (%make-toplevel) check-all-symbols)

--- a/utils/tragesym/lepton-tragesym.scm
+++ b/utils/tragesym/lepton-tragesym.scm
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 exec @GUILE@ -s "$0" "$@"
 !#
-;;; Copyright (C) 2019-2021 Lepton EDA Contributors
+;;; Copyright (C) 2019-2022 Lepton EDA Contributors
 ;;;
 ;;; Based on Python script by Werner Hoch
 ;;; Copyright (C) 2001,2002,2003,2004,2006,2007,2008 Werner Hoch <werner.ho@gmx.de>
@@ -47,7 +47,8 @@ exec @GUILE@ -s "$0" "$@"
              (srfi srfi-1)
              (srfi srfi-9)
              (sxml match)
-             (lepton ffi))
+             (lepton ffi)
+             (lepton toplevel))
 
 ;;; Initialize liblepton library.
 (liblepton_init)

--- a/utils/tragesym/lepton-tragesym.scm
+++ b/utils/tragesym/lepton-tragesym.scm
@@ -56,8 +56,7 @@ exec @GUILE@ -s "$0" "$@"
   (register-data-dirs))
 (edascm_init)
 
-(primitive-eval '(use-modules (lepton core toplevel)
-                              (lepton attrib)
+(primitive-eval '(use-modules (lepton attrib)
                               (lepton object)
                               (lepton page)
                               (lepton version)

--- a/utils/tragesym/lepton-tragesym.scm
+++ b/utils/tragesym/lepton-tragesym.scm
@@ -47,20 +47,19 @@ exec @GUILE@ -s "$0" "$@"
              (srfi srfi-1)
              (srfi srfi-9)
              (sxml match)
+             (lepton attrib)
              (lepton ffi)
-             (lepton toplevel))
+             (lepton object)
+             (lepton page)
+             (lepton toplevel)
+             (lepton version)
+             (netlist attrib compare))
 
 ;;; Initialize liblepton library.
 (liblepton_init)
 (unless (getenv "LEPTON_INHIBIT_RC_FILES")
   (register-data-dirs))
 (edascm_init)
-
-(primitive-eval '(use-modules (lepton attrib)
-                              (lepton object)
-                              (lepton page)
-                              (lepton version)
-                              (netlist attrib compare)))
 
 (define %option-spec
   '((help    (single-char #\h) (value #f))

--- a/utils/upcfg/lepton-upcfg.scm
+++ b/utils/upcfg/lepton-upcfg.scm
@@ -6,7 +6,7 @@ exec @GUILE@ "$0" "$@"
 ;; Lepton EDA
 ;; lepton-upcfg - gEDA => Lepton EDA configuration upgrade utility
 ;; Copyright (C) 2019 dmn <graahnul.grom@gmail.com>
-;; Copyright (C) 2019-2021 Lepton EDA Contributors
+;; Copyright (C) 2019-2022 Lepton EDA Contributors
 ;; License: GPLv2+. See the COPYING file
 ;;
 
@@ -18,21 +18,16 @@ exec @GUILE@ "$0" "$@"
 (use-modules (ice-9 format)
              (ice-9 rdelim) ; read-line()
              (ice-9 getopt-long)
-             (lepton ffi))
+             (lepton ffi)
+             (lepton legacy-config)
+             (lepton log)
+             (lepton version))
 
 ;; Initialize liblepton library.
 (liblepton_init)
 (unless (getenv "LEPTON_INHIBIT_RC_FILES")
   (register-data-dirs))
 (edascm_init)
-
-; Avoid Scheme compile-time errors using a clever trick
-; from netlist/scheme/lepton-netlist.scm (see comments there):
-;
-( primitive-eval '(use-modules (lepton legacy-config)) )
-( primitive-eval '(use-modules (lepton version)) )
-( primitive-eval '(use-modules (lepton log)) )
-
 
 
 ; command line options:

--- a/utils/update/lepton-update.scm
+++ b/utils/update/lepton-update.scm
@@ -5,7 +5,7 @@ exec @GUILE@ -s "$0" "$@"
 ;;; lepton-update - Update schematics and symbols in the gEDA/gaf
 ;;; file format.
 ;;;
-;;; Copyright (C) 2021 Lepton EDA Contributors.
+;;; Copyright (C) 2021-2022 Lepton EDA Contributors.
 ;;;
 ;;; This program is free software; you can redistribute it and/or modify
 ;;; it under the terms of the GNU General Public License as published by
@@ -31,7 +31,8 @@ exec @GUILE@ -s "$0" "$@"
              (ice-9 regex)
              (srfi srfi-11)
              (lepton ffi)
-             (lepton srfi-37))
+             (lepton srfi-37)
+             (lepton toplevel))
 
 ;;; Initialize liblepton library.
 (liblepton_init)
@@ -170,8 +171,6 @@ Command line switches:
 
 
 (define with-toplevel (@@ (lepton core toplevel) %with-toplevel))
-(define make-toplevel (@@ (lepton core toplevel) %make-toplevel))
-
 
 ;;; Main program.
 (when (= (length (program-arguments)) 1) (usage))
@@ -207,7 +206,7 @@ Run `~A --help' for more information.\n")
 
 
 (with-toplevel
- (make-toplevel)
+ (%make-toplevel)
  (lambda ()
    (let ((files (parse-commandline)))
      (for-each update files))))

--- a/utils/update/lepton-update.scm
+++ b/utils/update/lepton-update.scm
@@ -30,9 +30,15 @@ exec @GUILE@ -s "$0" "$@"
              (ice-9 rdelim)
              (ice-9 regex)
              (srfi srfi-11)
+             (lepton attrib)
              (lepton ffi)
+             (lepton file-system)
+             (lepton object)
+             (lepton page)
              (lepton srfi-37)
-             (lepton toplevel))
+             (lepton toplevel)
+             (lepton version)
+             (symbol check obsolete))
 
 ;;; Initialize liblepton library.
 (liblepton_init)
@@ -40,12 +46,6 @@ exec @GUILE@ -s "$0" "$@"
   (register-data-dirs))
 (edascm_init)
 
-(primitive-eval '(use-modules (lepton attrib)
-                              (lepton file-system)
-                              (lepton object)
-                              (lepton page)
-                              (lepton version)
-                              (symbol check obsolete)))
 
 (define (usage)
   (define program-name (basename (car (program-arguments))))

--- a/utils/update/lepton-update.scm
+++ b/utils/update/lepton-update.scm
@@ -170,8 +170,6 @@ Command line switches:
         (page->file page filename)))))
 
 
-(define with-toplevel (@@ (lepton core toplevel) %with-toplevel))
-
 ;;; Main program.
 (when (= (length (program-arguments)) 1) (usage))
 
@@ -205,7 +203,7 @@ Run `~A --help' for more information.\n")
     '())))
 
 
-(with-toplevel
+(%with-toplevel
  (%make-toplevel)
  (lambda ()
    (let ((files (parse-commandline)))


### PR DESCRIPTION
This commit set makes our Scheme modules independent of `liblepton` Scheme-in-C interface.  All functions are now implemented as true FFI functions.  Some artifacts and dependence on Guile lib are still there.  In spite of it, we can now pre-compile our `lepton` modules dependent on `liblepton` without any special tricks, that is, by using just generic Guile compiler `guild`. 