### PR TITLE
Use (lepton srfi-37), especially crafted for Lepton, instead of (srfi srfi-37) in cli tools 

### DIFF
--- a/utils/cli/scheme/lepton-cli.scm
+++ b/utils/cli/scheme/lepton-cli.scm
@@ -26,9 +26,9 @@ exec @GUILE@ -s "$0" "$@"
     (add-to-load-path "@LEPTON_SCHEME_MODULE_DIRECTORY@")
     (set! %load-compiled-path (cons "@ccachedir@" %load-compiled-path))))
 
-(use-modules (srfi srfi-37)
-             (lepton core gettext)
+(use-modules (lepton core gettext)
              (lepton ffi)
+             (lepton srfi-37)
              (lepton version))
 
 ;;; Initialize liblepton library.

--- a/utils/cli/scheme/lepton-config.scm
+++ b/utils/cli/scheme/lepton-config.scm
@@ -28,11 +28,11 @@ exec @GUILE@ -s "$0" "$@"
 
 (use-modules (ice-9 match)
              (srfi srfi-1)
-             (srfi srfi-37)
              (lepton config)
              (lepton core gettext)
              (lepton ffi)
              (lepton file-system)
+             (lepton srfi-37)
              (lepton version))
 
 ;;; Initialize liblepton library.

--- a/utils/cli/scheme/lepton-export.scm
+++ b/utils/cli/scheme/lepton-export.scm
@@ -27,12 +27,12 @@ exec @GUILE@ -s "$0" "$@"
     (set! %load-compiled-path (cons "@ccachedir@" %load-compiled-path))))
 
 (use-modules (srfi srfi-1)
-             (srfi srfi-37)
              (system foreign)
              (lepton core gettext)
              (lepton ffi)
              (lepton page)
              (lepton rc)
+             (lepton srfi-37)
              (lepton toplevel)
              (lepton version))
 

--- a/utils/cli/scheme/lepton-shell.scm
+++ b/utils/cli/scheme/lepton-shell.scm
@@ -26,13 +26,13 @@ exec @GUILE@ -e main -s "$0" "$@"
     (add-to-load-path "@LEPTON_SCHEME_MODULE_DIRECTORY@")
     (set! %load-compiled-path (cons "@ccachedir@" %load-compiled-path))))
 
-(use-modules (srfi srfi-37)
-             (ice-9 eval-string)
+(use-modules (ice-9 eval-string)
              (ice-9 readline)
              (lepton core gettext)
              (lepton ffi)
              (lepton rc)
              (lepton repl)
+             (lepton srfi-37)
              (lepton toplevel)
              (lepton version))
 


### PR DESCRIPTION
It was my oversight when I rewrote the cli related programs.  I had to use `(lepton srfi-37)` when appropriate.