### PR TITLE
Update URL in deprecated/obsolete options warning

### DIFF
--- a/liblepton/scheme/lepton/legacy-config.scm
+++ b/liblepton/scheme/lepton/legacy-config.scm
@@ -286,7 +286,7 @@ WARNING: The RC file function '~A' is deprecated
 and does nothing.
 RC configuration functions will be removed in an upcoming Lepton EDA
 release. Please use .conf configuration files instead:
-https://github.com/lepton-eda/lepton-eda/wiki/Configuration-Settings
+https://lepton-eda.github.io/lepton-manual.html/Configuration.html
 
 "
     old-name

--- a/liblepton/scheme/lepton/legacy-config.scm
+++ b/liblepton/scheme/lepton/legacy-config.scm
@@ -254,7 +254,7 @@
 WARNING: The RC file function '~A' is deprecated.
 RC configuration functions will be removed in an upcoming Lepton EDA
 release. Please use .conf configuration files instead:
-https://github.com/lepton-eda/lepton-eda/wiki/Configuration-Settings
+https://lepton-eda.github.io/lepton-manual.html/Configuration.html
 
 Put the following lines into the ~A file (in current directory)
 or ~A (in user's configuration directory, typically


### PR DESCRIPTION
Instead of pointing to (non-existent) wiki page
github.com/lepton-eda/lepton-eda/wiki/Configuration-Setting
show a link to the "Configuration" page on lepton-eda.github.io