### PR TITLE
lib: Avoid Glib warnings on the vulnerable function g_memdup().

### DIFF
--- a/liblepton/include/Makefile.am
+++ b/liblepton/include/Makefile.am
@@ -22,6 +22,7 @@ libleptoninclude_HEADERS = \
 	liblepton/coord.h \
 	liblepton/forward.h \
 	liblepton/fill.h \
+	liblepton/glib_compat.h \
 	liblepton/line.h \
 	liblepton/list.h \
 	liblepton/page.h \

--- a/liblepton/include/liblepton/glib_compat.h
+++ b/liblepton/include/liblepton/glib_compat.h
@@ -1,0 +1,32 @@
+/*! \file glib_compat.h */
+
+#ifndef GLIB_COMPAT_H
+#define GLIB_COMPAT_H
+
+#include <glib.h>
+
+G_BEGIN_DECLS
+
+/* Obsolete Glib compatibility stuff.  For more information, please see
+https://discourse.gnome.org/t/port-your-module-from-g-memdup-to-g-memdup2-now/5538
+*/
+#if !GLIB_CHECK_VERSION(2, 68, 0)
+inline gpointer
+g_memdup2(gconstpointer mem, gsize byte_size)
+{
+  gpointer new_mem;
+
+  if (mem && byte_size != 0) {
+      new_mem = g_malloc(byte_size);
+      memcpy(new_mem, mem, byte_size);
+  }
+  else
+    new_mem = NULL;
+
+  return new_mem;
+}
+#endif
+
+G_END_DECLS
+
+#endif /* GLIB_COMPAT_H */

--- a/liblepton/include/liblepton/liblepton.h
+++ b/liblepton/include/liblepton/liblepton.h
@@ -30,6 +30,7 @@
 G_BEGIN_DECLS
 
 #include <liblepton/defines.h>
+#include <liblepton/glib_compat.h>
 
 #include <liblepton/color.h>
 #include <liblepton/fill.h>

--- a/liblepton/src/picture_object.c
+++ b/liblepton/src/picture_object.c
@@ -33,7 +33,7 @@
 #include <gio/gio.h>
 
 #include "liblepton_priv.h"
-
+#include <liblepton/glib_compat.h>
 
 
 /*! \brief Create picture LeptonObject from character string.
@@ -329,7 +329,7 @@ lepton_picture_object_new (const gchar *file_content,
 
       /* Force the data into the object anyway, so as to prevent data
        * loss of embedded images. */
-      picture->file_content = (gchar*) g_memdup (file_content, file_length);
+      picture->file_content = (gchar*) g_memdup2 (file_content, file_length);
       picture->file_length = file_length;
     }
   }
@@ -772,7 +772,7 @@ lepton_picture_object_copy (LeptonObject *object)
   lepton_picture_object_set_lower_y (new_node, lepton_picture_object_get_lower_y (object));
 
   if (object->picture->file_content != NULL) {
-    picture->file_content = (gchar*) g_memdup (object->picture->file_content,
+    picture->file_content = (gchar*) g_memdup2 (object->picture->file_content,
                                                object->picture->file_length);
   } else {
     picture->file_content = NULL;

--- a/libleptongui/src/gschem_page_geometry.c
+++ b/libleptongui/src/gschem_page_geometry.c
@@ -35,6 +35,7 @@
 
 #include <math.h>
 
+#include <liblepton/glib_compat.h>
 #include "gschem.h"
 
 
@@ -52,7 +53,7 @@ update_constants (GschemPageGeometry *geometry);
 GschemPageGeometry*
 gschem_page_geometry_copy (GschemPageGeometry *geometry)
 {
-  return (GschemPageGeometry*) g_memdup (geometry, sizeof (GschemPageGeometry));
+  return (GschemPageGeometry*) g_memdup2 (geometry, sizeof (GschemPageGeometry));
 }
 
 

--- a/libleptongui/src/x_autonumber.c
+++ b/libleptongui/src/x_autonumber.c
@@ -29,6 +29,7 @@
 #include <string.h>
 #endif
 
+#include <liblepton/glib_compat.h>
 #include "gschem.h"
 #include <gdk/gdkkeysyms.h>
 
@@ -445,7 +446,7 @@ void autonumber_get_used(GschemToplevel *w_current, AUTONUMBER_TEXT *autotext)
                   /* insert all slots to the list, except of the current one */
                   for (i=1; i <= numslots; i++) {
                     if (i != slotnr) {
-                      slot = (AUTONUMBER_SLOT*) g_memdup (slot, sizeof (AUTONUMBER_SLOT));
+                      slot = (AUTONUMBER_SLOT*) g_memdup2 (slot, sizeof (AUTONUMBER_SLOT));
                       slot->slotnr = i;
                       autotext->free_slots = g_list_insert_sorted(autotext->free_slots,
                                                                   slot,


### PR DESCRIPTION
Please see https://discourse.gnome.org/t/port-your-module-from-g-memdup-to-g-memdup2-now/5538