### PR TITLE
gh: Fix lepton-eda-ci.yml.

### DIFF
--- a/.github/workflows/lepton-eda-ci.yml
+++ b/.github/workflows/lepton-eda-ci.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       # Checks-out repository under $GITHUB_WORKSPACE:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: apt-get update
         run: sudo apt-get update


### PR DESCRIPTION
Switch from github/checkout @v2 to @v3 in order to fix GH actions.