### PR TITLE
Fix build compilation warnings when the USE_LDCONFIG variable is not defined on the ./configure stage

### DIFF
--- a/liblepton/scheme/Makefile.am
+++ b/liblepton/scheme/Makefile.am
@@ -199,6 +199,7 @@ USE_GTK3=f
 endif !ENABLE_GTK3
 
 # Work-around for Debian and its derivatives.
+# Example usage: ./configure USE_LDCONFIG=/sbin/ldconfig ...
 LIBGLIB := $(shell test -e "$(USE_LDCONFIG)" && $(USE_LDCONFIG) -p | awk '/libglib-2.0.so\./ {print $$1; exit}')
 LIBGOBJECT := $(shell test -e "$(USE_LDCONFIG)" && $(USE_LDCONFIG) -p | awk '/libgobject-2.0.so\./ {print $$1; exit}')
 LIBGTK2 := $(shell test -e "$(USE_LDCONFIG)" && $(USE_LDCONFIG) -p | awk '/libgtk-x11-2.0.so\./ {print $$1; exit}')

--- a/liblepton/scheme/Makefile.am
+++ b/liblepton/scheme/Makefile.am
@@ -199,10 +199,10 @@ USE_GTK3=f
 endif !ENABLE_GTK3
 
 # Work-around for Debian and its derivatives.
-LIBGLIB := $(shell $(USE_LDCONFIG) -p | awk '/libglib-2.0.so\./ {print $$1; exit}')
-LIBGOBJECT := $(shell $(USE_LDCONFIG) -p | awk '/libgobject-2.0.so\./ {print $$1; exit}')
-LIBGTK2 := $(shell $(USE_LDCONFIG) -p | awk '/libgtk-x11-2.0.so\./ {print $$1; exit}')
-LIBGTK3 := $(shell $(USE_LDCONFIG) -p | awk '/libgtk-3.so\./ {print $$1; exit}')
+LIBGLIB := $(shell test -e "$(USE_LDCONFIG)" && $(USE_LDCONFIG) -p | awk '/libglib-2.0.so\./ {print $$1; exit}')
+LIBGOBJECT := $(shell test -e "$(USE_LDCONFIG)" && $(USE_LDCONFIG) -p | awk '/libgobject-2.0.so\./ {print $$1; exit}')
+LIBGTK2 := $(shell test -e "$(USE_LDCONFIG)" && $(USE_LDCONFIG) -p | awk '/libgtk-x11-2.0.so\./ {print $$1; exit}')
+LIBGTK3 := $(shell test -e "$(USE_LDCONFIG)" && $(USE_LDCONFIG) -p | awk '/libgtk-3.so\./ {print $$1; exit}')
 
 lepton/m4.scm: Makefile
 	$(MKDIR_P) lepton/; \


### PR DESCRIPTION
This is a typical build case so the warnings are annoying.