### PR TITLE
Get rid of the Scheme-in-C module (schematic core window)

### DIFF
--- a/liblepton/scheme/lepton/ffi.scm
+++ b/liblepton/scheme/lepton/ffi.scm
@@ -384,7 +384,9 @@
 
             o_selection_remove
 
-            o_read_buffer))
+            o_read_buffer
+
+            lepton_coord_snap))
 
 ;;; Helper to check if result of C function is TRUE (non-zero).
 (define true? (negate zero?))
@@ -802,6 +804,8 @@
 (define-lff lepton_export_settings_set_font void '(*))
 (define-lff lepton_export_settings_set_format void '(*))
 (define-lff lepton_export_settings_set_outfile void '(*))
+
+(define-lff lepton_coord_snap int (list int int))
 
 (define (c-string-array->list pointer)
   "Returns a list of search directories for system data."

--- a/libleptongui/include/gschem_options.h
+++ b/libleptongui/include/gschem_options.h
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 2013 Ales Hvezda
  * Copyright (C) 2013-2014 gEDA Contributors
- * Copyright (C) 2017-2019 Lepton EDA Contributors
+ * Copyright (C) 2017-2022 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -96,6 +96,8 @@ struct _GschemOptions {
   int        snap_size;
 };
 
+G_BEGIN_DECLS
+
 void
 gschem_options_cycle_grid_mode (GschemOptions *options);
 
@@ -149,3 +151,5 @@ gschem_options_set_snap_mode (GschemOptions *options, SNAP_STATE snap_mode);
 
 void
 gschem_options_set_snap_size (GschemOptions *options, int snap_size);
+
+G_END_DECLS

--- a/libleptongui/include/gschem_toplevel.h
+++ b/libleptongui/include/gschem_toplevel.h
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2016 gEDA Contributors
- * Copyright (C) 2017-2021 Lepton EDA Contributors
+ * Copyright (C) 2017-2022 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -302,5 +302,8 @@ gschem_toplevel_get_show_hidden_text (GschemToplevel *w_current);
 
 LeptonPage*
 schematic_window_get_active_page (GschemToplevel *w_current);
+
+GschemOptions*
+schematic_window_get_options (GschemToplevel *w_current);
 
 G_END_DECLS

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -22,6 +22,7 @@
 
   #:export (g_init_keys
             g_init_window
+            g_current_window
             generic_confirm_dialog
             generic_filesel_dialog
             generic_msg_dialog
@@ -175,7 +176,11 @@
 
 
 (define-lff g_init_keys void '())
+
+;;; g_window.c
 (define-lff g_init_window void '())
+(define-lff g_current_window '* '())
+
 (define-lff o_attrib_add_attrib '* (list '* '* int int '*))
 (define-lff o_buffer_init void '())
 (define-lff set_quiet_mode void '())

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -25,7 +25,6 @@
             generic_confirm_dialog
             generic_filesel_dialog
             generic_msg_dialog
-            gschem_toplevel_get_toplevel
             i_callback_add_arc
             i_callback_add_attribute
             i_callback_add_box
@@ -148,6 +147,7 @@
             gschem_page_view_get_page
 
             gschem_toplevel_get_current_page_view
+            gschem_toplevel_get_toplevel
 
             o_undo_savestate
             ))
@@ -169,7 +169,6 @@
 
 (define-lff g_init_keys void '())
 (define-lff g_init_window void '())
-(define-lff gschem_toplevel_get_toplevel '* '(*))
 (define-lff o_attrib_add_attrib '* (list '* '* int int '*))
 (define-lff o_buffer_init void '())
 (define-lff set_quiet_mode void '())
@@ -182,6 +181,7 @@
 
 ;;; gschem_toplevel.c
 (define-lff gschem_toplevel_get_current_page_view '* '(*))
+(define-lff gschem_toplevel_get_toplevel '* '(*))
 
 ;;; x_menus.c
 (define-lff make_separator_menu_item '* '())

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -152,6 +152,8 @@
             schematic_window_get_active_page
 
             o_undo_savestate
+
+            x_event_get_pointer_position
             ))
 
 (define libleptongui
@@ -306,6 +308,8 @@
 (define-lff i_callback_page_revert void '(* *))
 ;;; x_misc.c
 (define-lff x_show_uri int '(* * *))
+;;; x_event.c
+(define-lff x_event_get_pointer_position int (list '* int '* '*))
 
 ;;; o_undo.c
 (define-lff o_undo_init void '())

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -150,6 +150,9 @@
             gschem_toplevel_get_current_page_view
             gschem_toplevel_get_toplevel
             schematic_window_get_active_page
+            schematic_window_get_options
+
+            gschem_options_get_snap_size
 
             o_undo_savestate
 
@@ -187,6 +190,10 @@
 (define-lff gschem_toplevel_get_current_page_view '* '(*))
 (define-lff gschem_toplevel_get_toplevel '* '(*))
 (define-lff schematic_window_get_active_page '* '(*))
+(define-lff schematic_window_get_options '* '(*))
+
+;;; gschem_options.c
+(define-lff gschem_options_get_snap_size int '(*))
 
 ;;; x_menus.c
 (define-lff make_separator_menu_item '* '())

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -139,6 +139,7 @@
             x_stroke_init
             x_widgets_show_log
             x_window_create_main
+            x_window_close_page
             x_window_new
             x_window_open_page
             x_window_set_current_page
@@ -148,6 +149,7 @@
 
             gschem_toplevel_get_current_page_view
             gschem_toplevel_get_toplevel
+            schematic_window_get_active_page
 
             o_undo_savestate
             ))
@@ -182,6 +184,7 @@
 ;;; gschem_toplevel.c
 (define-lff gschem_toplevel_get_current_page_view '* '(*))
 (define-lff gschem_toplevel_get_toplevel '* '(*))
+(define-lff schematic_window_get_active_page '* '(*))
 
 ;;; x_menus.c
 (define-lff make_separator_menu_item '* '())
@@ -193,6 +196,8 @@
 (define-lff x_window_set_current_page void '(* *))
 (define-lff x_window_setup '* '(*))
 (define-lff x_window_create_main '* '(* *))
+(define-lff x_window_close_page void '(* *))
+
 ;;; x_dialog.c
 (define-lff generic_confirm_dialog int '(*))
 (define-lff generic_filesel_dialog '* (list '* '* int))

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -32,7 +32,8 @@
 
   #:export (active-page
             set-active-page!
-            pointer-position)
+            pointer-position
+            snap-point)
 
   ;; Overrides the close-page! procedure in the (lepton page)
   ;; module.
@@ -97,5 +98,18 @@ schematic drawing area, returns #f."
 
 (define-public current-window %current-window)
 
-(define-public (snap-point point)
-  (%snap-point (car point) (cdr point)))
+
+(define (snap-point point)
+  "Snaps POINT in the form (X . Y) to the snap grid, returning the
+snapped point position as a pair in the same form.  This always
+snaps the given point to the grid, disregarding the current user
+snap settings."
+  ;; Mimic snap_grid() when snapping is not off.
+  (define (snap-grid coord)
+    (lepton_coord_snap coord
+                       (gschem_options_get_snap_size
+                        (schematic_window_get_options (current-window)))))
+
+  (check-coord point 1)
+
+  (cons (snap-grid (car point)) (snap-grid (cdr point))))

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -29,7 +29,8 @@
 
   #:use-module (schematic ffi)
 
-  #:export (active-page)
+  #:export (active-page
+            set-active-page!)
 
   ;; Overrides the close-page! procedure in the (lepton page)
   ;; module.
@@ -45,7 +46,15 @@ lepton-schematic window.  If there is no active page, returns #f."
     (and (not (null-pointer? *page))
          (pointer->geda-page *page))))
 
-(define-public set-active-page! %set-active-page!)
+
+(define (set-active-page! page)
+  "Sets the page which is active in the current lepton-schematic
+window to PAGE.  Returns PAGE."
+  (define *page (geda-page->pointer* page 1))
+  (x_window_set_current_page (current-window) *page)
+  page)
+
+
 (define-public pointer-position %pointer-position)
 (define-public current-window %current-window)
 

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -1,7 +1,7 @@
 ;; Lepton EDA Schematic Capture
 ;; Scheme API
 ;; Copyright (C) 2010-2011 Peter Brett <peter@peter-b.co.uk>
-;; Copyright (C) 2017-2021 Lepton EDA Contributors
+;; Copyright (C) 2017-2022 Lepton EDA Contributors
 ;;
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -19,18 +19,32 @@
 ;;
 
 (define-module (schematic window)
+  #:use-module (system foreign)
+
+  #:use-module (lepton ffi)
+  #:use-module (lepton page foreign)
 
   ; Import C procedures
   #:use-module (schematic core window)
 
   #:use-module (schematic ffi)
 
+  #:export (active-page)
+
   ;; Overrides the close-page! procedure in the (lepton page)
   ;; module.
   #:replace (close-page!))
 
 (define close-page! %close-page!)
-(define-public active-page %active-page)
+
+(define (active-page)
+  "Returns the page which is active in the current
+lepton-schematic window.  If there is no active page, returns #f."
+  (let ((*page (lepton_toplevel_get_page_current
+                (edascm_c_current_toplevel))))
+    (and (not (null-pointer? *page))
+         (pointer->geda-page *page))))
+
 (define-public set-active-page! %set-active-page!)
 (define-public pointer-position %pointer-position)
 (define-public current-window %current-window)

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -36,7 +36,6 @@
   ;; module.
   #:replace (close-page!))
 
-(define close-page! %close-page!)
 
 (define (active-page)
   "Returns the page which is active in the current
@@ -53,6 +52,28 @@ window to PAGE.  Returns PAGE."
   (define *page (geda-page->pointer* page 1))
   (x_window_set_current_page (current-window) *page)
   page)
+
+
+(define (close-page! page)
+  "Closes PAGE."
+  (define *page (geda-page->pointer* page 1))
+  (define *window (current-window))
+  ;; Currently active page.
+  (define *active_page
+    (schematic_window_get_active_page *window))
+
+  (if (eq? page (active-page))
+      (x_window_close_page *window *page)
+      ;; If the page is not active, make it active and close, then
+      ;; switch back to the previously active page.
+      (begin
+        (x_window_set_current_page *window *page)
+        (x_window_close_page *window
+                             (schematic_window_get_active_page *window))
+        (x_window_set_current_page *window *active_page)))
+
+  ;; Return value is unspecified.
+  (if #f #f))
 
 
 (define-public pointer-position %pointer-position)

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -30,7 +30,8 @@
 
   #:use-module (schematic ffi)
 
-  #:export (active-page
+  #:export (current-window
+            active-page
             set-active-page!
             pointer-position
             snap-point)
@@ -38,6 +39,12 @@
   ;; Overrides the close-page! procedure in the (lepton page)
   ;; module.
   #:replace (close-page!))
+
+
+(define (current-window)
+  "Return the value of the toplevel window structure fluid in the
+current dynamic context."
+  (g_current_window))
 
 
 (define (active-page)
@@ -94,9 +101,6 @@ schematic drawing area, returns #f."
     (and result
          (cons (bytevector-sint-ref x 0 (native-endianness) (sizeof int))
                (bytevector-sint-ref y 0 (native-endianness) (sizeof int))))))
-
-
-(define-public current-window %current-window)
 
 
 (define (snap-point point)

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -25,9 +25,6 @@
   #:use-module (lepton ffi)
   #:use-module (lepton page foreign)
 
-  ; Import C procedures
-  #:use-module (schematic core window)
-
   #:use-module (schematic ffi)
 
   #:export (current-window

--- a/libleptongui/src/Makefile.am
+++ b/libleptongui/src/Makefile.am
@@ -1,8 +1,7 @@
 lib_LTLIBRARIES = libleptongui.la
 
 BUILT_SOURCES = \
-	g_keys.x \
-	g_window.x
+	g_keys.x
 
 libleptongui_la_SOURCES = \
 	a_zoom.c \

--- a/libleptongui/src/g_window.c
+++ b/libleptongui/src/g_window.c
@@ -100,29 +100,6 @@ g_current_window ()
 }
 
 /*!
- * \brief Set the active page.
- * \par Function Description
- * Sets the page which is active in the current lepton-schematic
- * window to \a page_s.
- *
- * \note Scheme API: Implements the %set-active-page! procedure in the
- * (schematic core window) module.
- *
- * \param page_s Page to switch to.
- * \return \a page_s.
- */
-SCM_DEFINE (set_active_page_x, "%set-active-page!", 1, 0, 0,
-            (SCM page_s), "Set the active page.")
-{
-  SCM_ASSERT (edascm_is_page (page_s), page_s, SCM_ARG1, s_set_active_page_x);
-
-  LeptonPage *page = edascm_to_page (page_s);
-  x_window_set_current_page (g_current_window (), page);
-
-  return page_s;
-}
-
-/*!
  * \brief Close a page
  * \par Function Description
  * Closes the page \a page_s.
@@ -236,7 +213,7 @@ init_module_schematic_core_window (void *unused)
   #include "g_window.x"
 
   /* Add them to the module's public definitions. */
-  scm_c_export (s_current_window, s_set_active_page_x,
+  scm_c_export (s_current_window,
                 s_override_close_page_x, s_pointer_position,
                 s_snap_point, NULL);
 }

--- a/libleptongui/src/g_window.c
+++ b/libleptongui/src/g_window.c
@@ -65,19 +65,6 @@ g_dynwind_window (GschemToplevel *w_current)
 /*!
  * \brief Get the value of the #GschemToplevel fluid.
  * \par Function Description
- * Return the value of the #GschemToplevel fluid in the current
- * dynamic context.
- */
-SCM_DEFINE (current_window, "%current-window", 0, 0, 0,
-            (),
-            "Get the GschemToplevel for the current dynamic context.")
-{
-  return scm_fluid_ref (scheme_window_fluid);
-}
-
-/*!
- * \brief Get the value of the #GschemToplevel fluid.
- * \par Function Description
  * Return the value of the #GschemToplevel fluid in the current dynamic
  * context.
  * Signals an error if there is no valid window fluid
@@ -87,7 +74,7 @@ SCM_DEFINE (current_window, "%current-window", 0, 0, 0,
 GschemToplevel *
 g_current_window ()
 {
-  SCM window_s = current_window ();
+  SCM window_s = scm_fluid_ref (scheme_window_fluid);
   GschemToplevel *w_current = (GschemToplevel *) scm_to_pointer (window_s);
 
   if (w_current == NULL)
@@ -112,8 +99,7 @@ init_module_schematic_core_window (void *unused)
   #include "g_window.x"
 
   /* Add them to the module's public definitions. */
-  scm_c_export (s_current_window,
-                NULL);
+  scm_c_export (NULL);
 }
 
 /*!

--- a/libleptongui/src/g_window.c
+++ b/libleptongui/src/g_window.c
@@ -100,42 +100,6 @@ g_current_window ()
 }
 
 /*!
- * \brief Snap a point to the snap grid.
- * \par Function Description
- * Snaps the point (\a x_s, \a y_s) to the snap grid, returning the
- * snapped point position as a cons in the form:
- *
- * <code>(x . y)</code>
- *
- * This always snaps the given point to the grid, disregarding the
- * current user snap settings.
- *
- * \note Scheme API: Implements the %snap-point procedure in the
- * (schematic core window) module.
- *
- * \param x_s the x-coordinate of the point to be snapped to grid.
- * \param y_s the y-coordinate of the point to be snapped to grid.
- * \return the snapped coordinates.
- */
-SCM_DEFINE (snap_point, "%snap-point", 2, 0, 0,
-            (SCM x_s, SCM y_s), "Get the current snap grid size.")
-{
-  SCM_ASSERT (scm_is_integer (x_s), x_s, SCM_ARG1, s_snap_point);
-  SCM_ASSERT (scm_is_integer (y_s), y_s, SCM_ARG2, s_snap_point);
-
-  /* We save and restore the current snap setting, because we want to
-   * *always* snap the requested cordinates. */
-  GschemToplevel *w_current = g_current_window ();
-  SNAP_STATE save_snap = gschem_options_get_snap_mode (w_current->options);
-  gschem_options_set_snap_mode (w_current->options, SNAP_GRID);
-  int x = snap_grid (w_current, scm_to_int (x_s));
-  int y = snap_grid (w_current, scm_to_int (y_s));
-  gschem_options_set_snap_mode (w_current->options, save_snap);
-
-  return scm_cons (scm_from_int (x), scm_from_int (y));
-}
-
-/*!
  * \brief Create the (schematic core window) Scheme module
  * \par Function Description
  * Defines procedures in the (schematic core window) module. The module
@@ -149,7 +113,7 @@ init_module_schematic_core_window (void *unused)
 
   /* Add them to the module's public definitions. */
   scm_c_export (s_current_window,
-                s_snap_point, NULL);
+                NULL);
 }
 
 /*!

--- a/libleptongui/src/g_window.c
+++ b/libleptongui/src/g_window.c
@@ -100,44 +100,6 @@ g_current_window ()
 }
 
 /*!
- * \brief Close a page
- * \par Function Description
- * Closes the page \a page_s.
- *
- * \note Scheme API: Implements the %close-page! procedure in the
- * (schematic core window) module.
- *
- * \param page_s Page to close.
- * \return SCM_UNDEFINED
- */
-SCM_DEFINE (override_close_page_x, "%close-page!", 1, 0, 0,
-            (SCM page_s), "Close a page.")
-{
-  /* Ensure that the argument is a page smob */
-  SCM_ASSERT (edascm_is_page (page_s), page_s,
-              SCM_ARG1, s_override_close_page_x);
-
-  GschemToplevel *w_current = g_current_window ();
-  LeptonPage *page = edascm_to_page (page_s);
-
-  LeptonPage *active_page = schematic_window_get_active_page (w_current);
-
-  if (page != active_page)
-    /* If page is not the current page, switch pages, then switch
-     * back after closing page. */
-  {
-    x_window_set_current_page (w_current, page);
-    x_window_close_page (w_current, schematic_window_get_active_page (w_current));
-    x_window_set_current_page (w_current, active_page);
-  }
-  else
-  {
-    x_window_close_page (w_current, page);
-  }
-  return SCM_UNDEFINED;
-}
-
-/*!
  * \brief Get the current pointer position
  * \par Function Description
  * Returns the current mouse pointer position, expressed in world
@@ -214,7 +176,7 @@ init_module_schematic_core_window (void *unused)
 
   /* Add them to the module's public definitions. */
   scm_c_export (s_current_window,
-                s_override_close_page_x, s_pointer_position,
+                s_pointer_position,
                 s_snap_point, NULL);
 }
 

--- a/libleptongui/src/g_window.c
+++ b/libleptongui/src/g_window.c
@@ -87,22 +87,6 @@ g_current_window ()
 }
 
 /*!
- * \brief Create the (schematic core window) Scheme module
- * \par Function Description
- * Defines procedures in the (schematic core window) module. The module
- * can be accessed using (use-modules (schematic core window)).
- */
-static void
-init_module_schematic_core_window (void *unused)
-{
-  /* Register the functions */
-  #include "g_window.x"
-
-  /* Add them to the module's public definitions. */
-  scm_c_export (NULL);
-}
-
-/*!
  * \brief Initialise the GschemToplevel manipulation procedures.
  * \par Function Description
 
@@ -116,9 +100,4 @@ g_init_window ()
   /* Create fluid */
   scheme_window_fluid = scm_permanent_object (scm_make_fluid ());
   scm_c_define ("%lepton-window", scheme_window_fluid);
-
-  /* Define the (schematic core window) module */
-  scm_c_define_module ("schematic core window",
-                       (void (*)(void*)) init_module_schematic_core_window,
-                       NULL);
 }

--- a/libleptongui/src/g_window.c
+++ b/libleptongui/src/g_window.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 2010-2011 Peter Brett <peter@peter-b.co.uk>
  * Copyright (C) 2010-2015 gEDA Contributors
- * Copyright (C) 2017-2021 Lepton EDA Contributors
+ * Copyright (C) 2017-2022 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -97,30 +97,6 @@ g_current_window ()
   }
 
   return w_current;
-}
-
-/*!
- * \brief Get the active page.
- * \par Function Description
- * Returns the page which is active in the current
- * lepton-schematic window.  If there is no active page, returns
- * SCM_BOOL_F.
- *
- * \note Scheme API: Implements the %active-page procedure in the
- * (schematic core window) module.
- *
- * \return the active page.
- */
-SCM_DEFINE (active_page, "%active-page", 0, 0, 0,
-            (), "Get the active page.")
-{
-  LeptonToplevel *toplevel = edascm_c_current_toplevel ();
-  LeptonPage *page = lepton_toplevel_get_page_current (toplevel);
-  if (page != NULL) {
-    return edascm_from_page (page);
-  } else {
-    return SCM_BOOL_F;
-  }
 }
 
 /*!
@@ -260,7 +236,7 @@ init_module_schematic_core_window (void *unused)
   #include "g_window.x"
 
   /* Add them to the module's public definitions. */
-  scm_c_export (s_current_window, s_active_page, s_set_active_page_x,
+  scm_c_export (s_current_window, s_set_active_page_x,
                 s_override_close_page_x, s_pointer_position,
                 s_snap_point, NULL);
 }

--- a/libleptongui/src/g_window.c
+++ b/libleptongui/src/g_window.c
@@ -100,33 +100,6 @@ g_current_window ()
 }
 
 /*!
- * \brief Get the current pointer position
- * \par Function Description
- * Returns the current mouse pointer position, expressed in world
- * coordinates.  If the pointer is outside the schematic drawing area,
- * returns SCM_BOOL_F.
- *
- * The coordinates are returned as a cons:
- *
- * <code>(x . y)</code>
- *
- * \note Scheme API: Implements the %pointer-position procedure in the
- * (schematic core window) module.
- *
- * \return The current pointer position, or SCM_BOOL_F.
- */
-SCM_DEFINE (pointer_position, "%pointer-position", 0, 0, 0,
-            (), "Get the current pointer position.")
-{
-  int x, y;
-  GschemToplevel *w_current = g_current_window ();
-  if (x_event_get_pointer_position (w_current, FALSE, &x, &y)) {
-    return scm_cons (scm_from_int (x), scm_from_int (y));
-  }
-  return SCM_BOOL_F;
-}
-
-/*!
  * \brief Snap a point to the snap grid.
  * \par Function Description
  * Snaps the point (\a x_s, \a y_s) to the snap grid, returning the
@@ -176,7 +149,6 @@ init_module_schematic_core_window (void *unused)
 
   /* Add them to the module's public definitions. */
   scm_c_export (s_current_window,
-                s_pointer_position,
                 s_snap_point, NULL);
 }
 

--- a/libleptongui/src/gschem_toplevel.c
+++ b/libleptongui/src/gschem_toplevel.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2016 gEDA Contributors
- * Copyright (C) 2017-2021 Lepton EDA Contributors
+ * Copyright (C) 2017-2022 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -826,4 +826,18 @@ schematic_window_get_active_page (GschemToplevel *w_current)
   g_return_val_if_fail (toplevel != NULL, NULL);
 
   return toplevel->page_current;
+}
+
+
+/*! \brief Get the options for this schematic window.
+ *
+ *  \param [in] w_current The schematic window.
+ *  \return The options of the schematic window.
+ */
+GschemOptions*
+schematic_window_get_options (GschemToplevel *w_current)
+{
+  g_return_val_if_fail (w_current != NULL, NULL);
+
+  return w_current->options;
 }


### PR DESCRIPTION
Currently, the value returned by the `current-window()` procedure is just a foreign pointer.