### PR TITLE
Avoid build deprecation warnings on g_pattern_match_string().

### DIFF
--- a/liblepton/include/liblepton/glib_compat.h
+++ b/liblepton/include/liblepton/glib_compat.h
@@ -27,6 +27,12 @@ g_memdup2(gconstpointer mem, gsize byte_size)
 }
 #endif
 
+
+#if !GLIB_CHECK_VERSION (2, 70, 0)
+#define g_pattern_spec_match_string g_pattern_match_string
+#endif
+
+
 G_END_DECLS
 
 #endif /* GLIB_COMPAT_H */

--- a/liblepton/src/s_clib.c
+++ b/liblepton/src/s_clib.c
@@ -129,6 +129,7 @@
 #include <time.h>
 
 #include "liblepton_priv.h"
+#include <liblepton/glib_compat.h>
 
 /* Constant definitions
  * ===================
@@ -1297,7 +1298,8 @@ GList *s_clib_search (const gchar *pattern, const CLibSearchMode mode)
           }
           break;
         case CLIB_GLOB:
-          if (g_pattern_match_string (globpattern, symbol->name)) {
+          if (g_pattern_spec_match_string (globpattern, symbol->name))
+          {
             result = g_list_prepend (result, symbol);
           }
           break;

--- a/libleptongui/src/gschem_find_text_state.c
+++ b/libleptongui/src/gschem_find_text_state.c
@@ -25,6 +25,7 @@
 
 #include <config.h>
 #include "gschem.h"
+#include <liblepton/glib_compat.h>
 
 
 enum
@@ -386,7 +387,8 @@ find_objects_using_pattern (GSList *pages,
         continue;
       }
 
-      if (g_pattern_match_string (pattern, str)) {
+      if (g_pattern_spec_match_string (pattern, str))
+      {
         object_list = g_slist_prepend (object_list, object);
       }
     }


### PR DESCRIPTION
The function is deprecated since Glib 2.70 so you can see such compilation warnings if you have Glib of that version or more recent.