### PR TITLE
Bump required versions of GTK3 and GDK3 to 3.22

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -101,9 +101,9 @@ fi
 AS_CASE(["$with_gtk3"],
 dnl Use GTK3.
   [yes],
-    [PKG_CHECK_MODULES(GTK, [gtk+-3.0 >= 3.4.0],
+    [PKG_CHECK_MODULES(GTK, [gtk+-3.0 >= 3.22.0],
       [WITH_GTK3=1],
-      AC_MSG_ERROR([GTK+ 3.4.0 or later is required.]))],
+      AC_MSG_ERROR([GTK+ 3.22.0 or later is required.]))],
 dnl Default case: use GTK2.
   [PKG_CHECK_MODULES(GTK, [gtk+-2.0 >= 2.24.0],
     [WITH_GTK3=0],
@@ -114,8 +114,8 @@ AM_CONDITIONAL([ENABLE_GTK3], [test "x$WITH_GTK3" = x1])
 AS_CASE(["$with_gtk3"],
 dnl Use GDK3.
   [yes],
-    [PKG_CHECK_MODULES(GDK, [gdk-3.0 >= 3.4.0], ,
-      AC_MSG_ERROR([GDK 3.4.0 or later is required.]))],
+    [PKG_CHECK_MODULES(GDK, [gdk-3.0 >= 3.22.0], ,
+      AC_MSG_ERROR([GDK 3.22.0 or later is required.]))],
 dnl Default case: use GDK2.
   [PKG_CHECK_MODULES(GDK, [gdk-2.0 >= 2.24.0], ,
     AC_MSG_ERROR([GDK+ 2.24.0 or later is required.]))])


### PR DESCRIPTION
Today I stumbled upon quite an issue.  To check what minimal version of GTK3 is required for compilation of Lepton, I added the following lines to `configure.ac`:
```
AC_DEFINE(GDK_VERSION_MIN_REQUIRED,
GDK_VERSION_3_4, [Prevent post 3.4 deprecations])
AC_DEFINE(GDK_VERSION_MAX_ALLOWED,
GDK_VERSION_3_6, [Prevent post 3.6 deprecations])
```
and encountered some interesting warnings, e.g.:
```
...
x_event.c:943:56: warning: ‘GdkSeat* gdk_display_get_default_seat(GdkDisplay*)’ is deprecated: Not available before 3.20 [-Wdeprecated-declarations]
...
x_tabs.c:1719:39: warning: ‘void gtk_menu_popup_at_pointer(GtkMenu*, const GdkEvent*)’ is deprecated: Not available before 3.22 [-Wdeprecated-declarations]
```
What's more, the `gdk*seat*()` functions are available in Lepton already in the version 1.9.17.  So the change of the minimal required GTK3 version which we discussed in #864 is overdue.  I suggest to set it to the official stable version 3.24.  The fact that nobody reported the issue before reads that most current distributions support it for years and the users could never ever notice it.