### PR TITLE
Fix several minor issues in liblepton Scheme modules

### DIFF
--- a/liblepton/scheme/lepton/config.scm
+++ b/liblepton/scheme/lepton/config.scm
@@ -18,6 +18,7 @@
 ;;; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 (define-module (lepton config)
+  #:use-module (ice-9 format)
   #:use-module (ice-9 match)
   #:use-module (rnrs bytevectors)
   #:use-module (system foreign)

--- a/liblepton/scheme/netlist.scm
+++ b/liblepton/scheme/netlist.scm
@@ -1,7 +1,7 @@
 ;;; Lepton EDA netlister
 ;;; Copyright (C) 1998-2010 Ales Hvezda
 ;;; Copyright (C) 1998-2017 gEDA Contributors
-;;; Copyright (C) 2017-2021 Lepton EDA Contributors
+;;; Copyright (C) 2017-2022 Lepton EDA Contributors
 ;;;
 ;;; This program is free software; you can redistribute it and/or modify
 ;;; it under the terms of the GNU General Public License as published by
@@ -738,10 +738,6 @@ other limitations imposed by this netlist format.
 ;; the given attribute of all the graphical objects connected to that
 ;; net name
 (define (gnetlist:graphical-objs-in-net-with-attrib-get-attrib netname in-attrib out-attrib-name)
-  (define (found? x)
-    (and x
-         (string=? x netname)))
-
   (define (has-netname? pin)
     (let ((name (package-pin-name pin)))
       (and name

--- a/liblepton/scheme/netlist/package.scm
+++ b/liblepton/scheme/netlist/package.scm
@@ -1,6 +1,6 @@
 ;;; Lepton EDA netlister
 ;;; Copyright (C) 2016-2017 gEDA Contributors
-;;; Copyright (C) 2017-2020 Lepton EDA Contributors
+;;; Copyright (C) 2017-2022 Lepton EDA Contributors
 ;;;
 ;;; This program is free software; you can redistribute it and/or modify
 ;;; it under the terms of the GNU General Public License as published by
@@ -181,7 +181,6 @@ a string."
                            (list ls-or-component)))
            (id (schematic-component-id (car components)))
            (refdes (schematic-component-refdes (car components)))
-           (composite (any schematic-component-sources components))
            (attribs (get-attribs components))
            (pins (merge-component-pins components)))
       (make-package id refdes attribs components pins)))

--- a/liblepton/scheme/symcheck/option.scm
+++ b/liblepton/scheme/symcheck/option.scm
@@ -1,6 +1,6 @@
 ;;; Lepton EDA Symbol Checker
 ;;; Scheme API
-;;; Copyright (C) 2017-2020 Lepton EDA Contributors
+;;; Copyright (C) 2017-2022 Lepton EDA Contributors
 ;;;
 ;;; This program is free software; you can redistribute it and/or modify
 ;;; it under the terms of the GNU General Public License as published by
@@ -18,7 +18,6 @@
 
 (define-module (symcheck option)
   #:use-module (ice-9 getopt-long)
-  #:use-module ((srfi srfi-1) #:select (filter-map))
   #:use-module (lepton option)
 
   #:export (%default-symcheck-options


### PR DESCRIPTION
I've found the issues when using native compilation with guild as implemented in #893. They are related to eliminating of unused code / variables or, vice versa, exporting missing dependencies.