### PR TITLE
Customize guild compilation messages

### DIFF
--- a/liblepton/scheme/Makefile.am
+++ b/liblepton/scheme/Makefile.am
@@ -235,6 +235,12 @@ CLEANFILES = \
 	unit-tests/dummy.xpm \
 	$(nobase_scmdata_DATA)
 
+# To check it all thoroughly, you could add:
+# -Wunused-format -- to test issues with the built-in format()
+#  function.
+# -Wunused-toplevel -- to test for toplevel exported vars.
+# -Wunused-variable -- to test for other unused vars (there are
+#  some in (match ...) and other code).
 
 GUILE_WARNINGS = \
 	-Warity-mismatch \

--- a/liblepton/scheme/Makefile.am
+++ b/liblepton/scheme/Makefile.am
@@ -236,7 +236,17 @@ CLEANFILES = \
 	$(nobase_scmdata_DATA)
 
 
-GUILE_WARNINGS = -Wunbound-variable -Warity-mismatch -Wformat
+GUILE_WARNINGS = \
+	-Warity-mismatch \
+	-Wbad-case-datum \
+	-Wduplicate-case-datum \
+	-Wformat \
+	-Wmacro-use-before-definition \
+	-Wshadowed-toplevel \
+	-Wunbound-variable \
+	-Wunsupported-warning \
+	-Wunused-toplevel \
+	-Wunused-variable
 
 SOURCES = $(nobase_dist_scmdata_DATA)
 GOBJECTS = $(SOURCES:%.scm=%.go)

--- a/liblepton/scheme/Makefile.am
+++ b/liblepton/scheme/Makefile.am
@@ -240,7 +240,6 @@ GUILE_WARNINGS = \
 	-Warity-mismatch \
 	-Wbad-case-datum \
 	-Wduplicate-case-datum \
-	-Wformat \
 	-Wmacro-use-before-definition \
 	-Wshadowed-toplevel \
 	-Wunbound-variable \

--- a/liblepton/scheme/Makefile.am
+++ b/liblepton/scheme/Makefile.am
@@ -243,8 +243,7 @@ GUILE_WARNINGS = \
 	-Wmacro-use-before-definition \
 	-Wshadowed-toplevel \
 	-Wunbound-variable \
-	-Wunsupported-warning \
-	-Wunused-variable
+	-Wunsupported-warning
 
 SOURCES = $(nobase_dist_scmdata_DATA)
 GOBJECTS = $(SOURCES:%.scm=%.go)

--- a/liblepton/scheme/Makefile.am
+++ b/liblepton/scheme/Makefile.am
@@ -244,7 +244,6 @@ GUILE_WARNINGS = \
 	-Wshadowed-toplevel \
 	-Wunbound-variable \
 	-Wunsupported-warning \
-	-Wunused-toplevel \
 	-Wunused-variable
 
 SOURCES = $(nobase_dist_scmdata_DATA)


### PR DESCRIPTION
Allow `guild` report more issues while, OTOH, suppressing not very important warnings.