### PR TITLE
Support native compilation of Scheme files in the 'schematic' namespace

### DIFF
--- a/liblepton/scheme/Makefile.am
+++ b/liblepton/scheme/Makefile.am
@@ -257,7 +257,7 @@ SOURCES = $(nobase_dist_scmdata_DATA)
 GOBJECTS = $(SOURCES:%.scm=%.go)
 
 
-# This part depends on the configure switch --enable-go.
+# This part depends on the configure switch --enable-guild.
 if ENABLE_GUILD
 
 $(GOBJECTS): lepton/m4.go

--- a/libleptongui/Makefile.am
+++ b/libleptongui/Makefile.am
@@ -6,8 +6,8 @@ SUBDIRS = \
 	include \
 	lib \
 	po \
-	scheme \
 	src \
+	scheme \
 	tests
 
 pkgconfigdir   = $(libdir)/pkgconfig

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -12,7 +12,11 @@ void a_zoom_box_invalidate_rubber(GschemToplevel *w_current);
 void a_zoom_box_draw_rubber(GschemToplevel *w_current, EdaRenderer *renderer);
 /* g_action.c */
 gboolean g_action_eval_by_name (GschemToplevel *w_current, const gchar *action_name);
-gboolean g_action_get_position (gboolean snap, int *x, int *y);
+gboolean
+g_action_get_position (GschemToplevel *w_current,
+                       gboolean snap,
+                       int *x,
+                       int *y);
 
 /* g_hook.c */
 void g_run_hook_object (GschemToplevel *w_current, const char *name, LeptonObject *obj);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -42,7 +42,8 @@ schematic_keys_reset (GschemToplevel *w_current);
 
 /* g_window.c */
 void g_dynwind_window (GschemToplevel *w_current);
-void g_init_window ();
+void g_init_window (SCM fluid);
+
 /* lepton-schematic.c */
 void gschem_quit(void);
 void

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -41,7 +41,6 @@ void
 schematic_keys_reset (GschemToplevel *w_current);
 
 /* g_window.c */
-GschemToplevel *g_current_window ();
 void g_dynwind_window (GschemToplevel *w_current);
 void g_init_window ();
 /* lepton-schematic.c */

--- a/libleptongui/scheme/Makefile.am
+++ b/libleptongui/scheme/Makefile.am
@@ -1,6 +1,6 @@
-## -*- Makefile -*-
-
 scmdatadir = $(LEPTONDATADIR)/scheme
+godir = $(LEPTONDATADIR)/ccache
+
 nobase_dist_scmdata_DATA = \
 	auto-refdes.scm \
 	auto-uref.scm \
@@ -46,3 +46,53 @@ nobase_dist_scmdata_DATA = \
 	conf/schematic/keys.scm \
 	conf/schematic/menu.scm \
 	conf/schematic/stroke.scm
+
+# To check it all thoroughly, you could add:
+# -Wunused-format -- to test issues with the built-in format()
+#  function.
+# -Wunused-toplevel -- to test for toplevel exported vars.
+# -Wunused-variable -- to test for other unused vars (there are
+#  some in (match ...) and other code).
+
+GUILE_WARNINGS = \
+	-Warity-mismatch \
+	-Wbad-case-datum \
+	-Wduplicate-case-datum \
+	-Wmacro-use-before-definition \
+	-Wshadowed-toplevel \
+	-Wunbound-variable \
+	-Wunsupported-warning
+
+SOURCES = $(nobase_dist_scmdata_DATA)
+
+
+# This part depends on the configure switch --enable-guild.
+if ENABLE_GUILD
+
+GOBJECTS = $(SOURCES:%.scm=%.go)
+
+SUFFIXES = .scm .go
+.scm.go:
+	LIBLEPTON="${abs_top_builddir}/liblepton/src/liblepton" \
+	LIBLEPTONGUI="${abs_top_builddir}/libleptongui/src/libleptongui" \
+	$(GUILD) compile \
+	-L . \
+	-L $(abs_top_srcdir)/liblepton/scheme \
+	-L $(abs_top_builddir)/liblepton/scheme \
+	-L $(abs_top_srcdir)/libleptongui/scheme \
+	-L $(abs_top_builddir)/libleptongui/scheme \
+	$(GUILE_WARNINGS) -o "$@" "$<"
+
+nobase_go_DATA = $(GOBJECTS)
+
+# Make sure source files are installed first, so that the mtime of
+# installed compiled files is greater than that of installed source
+# files.  See
+# <http://lists.gnu.org/archive/html/guile-devel/2010-07/msg00125.html>
+# for details.
+guile_install_go_files = install-nobase_goDATA
+$(guile_install_go_files): install-nobase_dist_scmdataDATA
+
+CLEANFILES = $(GOBJECTS)
+
+endif

--- a/libleptongui/scheme/Makefile.am
+++ b/libleptongui/scheme/Makefile.am
@@ -73,6 +73,7 @@ GOBJECTS = $(SOURCES:%.scm=%.go)
 
 SUFFIXES = .scm .go
 .scm.go:
+	$(AM_V_GEN) \
 	LIBLEPTON="${abs_top_builddir}/liblepton/src/liblepton" \
 	LIBLEPTONGUI="${abs_top_builddir}/libleptongui/src/libleptongui" \
 	$(GUILD) compile \

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -184,7 +184,7 @@
 
 
 ;;; g_window.c
-(define-lff g_init_window void '())
+(define-lff g_init_window void '(*))
 
 (define-lff o_attrib_add_attrib '* (list '* '* int int '*))
 (define-lff o_buffer_init void '())

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -23,7 +23,6 @@
   #:use-module (lepton ffi lib)
 
   #:export (g_init_window
-            g_current_window
             generic_confirm_dialog
             generic_filesel_dialog
             generic_msg_dialog
@@ -186,7 +185,6 @@
 
 ;;; g_window.c
 (define-lff g_init_window void '())
-(define-lff g_current_window '* '())
 
 (define-lff o_attrib_add_attrib '* (list '* '* int int '*))
 (define-lff o_buffer_init void '())

--- a/libleptongui/scheme/schematic/gui/keymap.scm
+++ b/libleptongui/scheme/schematic/gui/keymap.scm
@@ -92,16 +92,8 @@
 
 
 (define (process-key-event *page_view *event *window)
-  ;; %lepton-window is defined in C code and is not visible at the
-  ;; moment the module is compiled.  Use last resort to refer to
-  ;; it.
-  (with-fluids ((%lepton-window *window))
-    ;; We have to dynwind LeptonToplevel as well since there are
-    ;; functions that depend on toplevel only and should know what
-    ;; its current value is.
-    (%with-toplevel
-     (pointer->geda-toplevel (gschem_toplevel_get_toplevel *window))
-     (lambda () (eval-press-key-event *event *page_view *window)))))
+  (with-window *window
+    (eval-press-key-event *event *page_view *window)))
 
 (define *process-key-event
   (procedure->pointer int process-key-event '(* * *)))

--- a/libleptongui/scheme/schematic/gui/keymap.scm
+++ b/libleptongui/scheme/schematic/gui/keymap.scm
@@ -23,7 +23,6 @@
 
   #:use-module (lepton ffi)
   #:use-module (lepton log)
-  #:use-module (lepton toplevel)
 
   #:use-module (schematic action)
   #:use-module (schematic ffi)

--- a/libleptongui/scheme/schematic/gui/keymap.scm
+++ b/libleptongui/scheme/schematic/gui/keymap.scm
@@ -28,6 +28,7 @@
   #:use-module (schematic action)
   #:use-module (schematic ffi)
   #:use-module (schematic keymap)
+  #:use-module (schematic window)
 
   #:export (%global-keymap
             current-keymap
@@ -94,7 +95,7 @@
   ;; %lepton-window is defined in C code and is not visible at the
   ;; moment the module is compiled.  Use last resort to refer to
   ;; it.
-  (with-fluids (((@@ (guile-user) %lepton-window) *window))
+  (with-fluids ((%lepton-window *window))
     ;; We have to dynwind LeptonToplevel as well since there are
     ;; functions that depend on toplevel only and should know what
     ;; its current value is.

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -24,6 +24,7 @@
   #:use-module (system foreign)
 
   #:use-module (lepton ffi)
+  #:use-module (lepton log)
   #:use-module (lepton page foreign)
 
   #:use-module (schematic ffi)
@@ -52,8 +53,13 @@
 
 (define (current-window)
   "Return the value of the toplevel window structure fluid in the
-current dynamic context."
-  (g_current_window))
+current dynamic context.  Signals an error if there is no valid
+window fluid or the fluid value is NULL.  Never returns NULL."
+  (let ((window (fluid-ref (@@ (guile-user) %lepton-window))))
+
+    (when (null-pointer? window)
+      (error (G_ "Found NULL lepton-schematic window.")))
+    window))
 
 
 (define (active-page)

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -29,7 +29,8 @@
 
   #:use-module (schematic ffi)
 
-  #:export (current-window
+  #:export (%lepton-window
+            current-window
             active-page
             set-active-page!
             pointer-position
@@ -39,6 +40,8 @@
   ;; module.
   #:replace (close-page!))
 
+
+(define %lepton-window (make-fluid))
 
 ;;; Define a wrapped pointer type.
 (define-wrapped-pointer-type <schematic-window>
@@ -55,7 +58,7 @@
   "Return the value of the toplevel window structure fluid in the
 current dynamic context.  Signals an error if there is no valid
 window fluid or the fluid value is NULL.  Never returns NULL."
-  (let ((window (fluid-ref (@@ (guile-user) %lepton-window))))
+  (let ((window (fluid-ref %lepton-window)))
 
     (when (null-pointer? window)
       (error (G_ "Found NULL lepton-schematic window.")))

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -31,6 +31,7 @@
 
   #:export (%lepton-window
             current-window
+            with-window
             active-page
             set-active-page!
             pointer-position
@@ -52,6 +53,16 @@
   (lambda (window port)
     (format port "#<schematic-window-0x~x>"
             (pointer-address (unwrap-schematic-window window)))))
+
+
+(define-syntax-rule (with-window window form form* ...)
+  (with-fluids ((%lepton-window window))
+    ;; We have to dynwind LeptonToplevel here since there are
+    ;; functions that depend on it and should know what its
+    ;; current value is.
+    (%with-toplevel
+     (pointer->geda-toplevel (gschem_toplevel_get_toplevel window))
+     (lambda () form form* ...))))
 
 
 (define (current-window)

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -19,6 +19,7 @@
 ;;
 
 (define-module (schematic window)
+  #:use-module (ice-9 format)
   #:use-module (rnrs bytevectors)
   #:use-module (system foreign)
 
@@ -36,6 +37,17 @@
   ;; Overrides the close-page! procedure in the (lepton page)
   ;; module.
   #:replace (close-page!))
+
+
+;;; Define a wrapped pointer type.
+(define-wrapped-pointer-type <schematic-window>
+  schematic-window?
+  wrap-schematic-window
+  unwrap-schematic-window
+  ;; Printer.
+  (lambda (window port)
+    (format port "#<schematic-window-0x~x>"
+            (pointer-address (unwrap-schematic-window window)))))
 
 
 (define (current-window)

--- a/libleptongui/src/g_action.c
+++ b/libleptongui/src/g_action.c
@@ -81,18 +81,21 @@ g_action_eval_by_name (GschemToplevel *w_current, const gchar *action_name)
  *
  * See also the (schematic action) Scheme module.
  *
- * \param snap         "Snap" returned coords to the grid.
- * \param x            Location to store x coordinate.
- * \param y            Location to store y coordinate.
+ * \param [in] w_current Active toplevel window structure.
+ * \param [in] snap      "Snap" returned coords to the grid.
+ * \param [in,out] x     Location to store x coordinate.
+ * \param [in,out] y     Location to store y coordinate.
  *
  * \return TRUE if current action position is set, FALSE otherwise.
  */
 gboolean
-g_action_get_position (gboolean snap, int *x, int *y)
+g_action_get_position (GschemToplevel *w_current,
+                       gboolean snap,
+                       int *x,
+                       int *y)
 {
   SCM s_action_position_proc;
   SCM s_point;
-  GschemToplevel *w_current = g_current_window ();
 
   g_assert (w_current);
 

--- a/libleptongui/src/g_window.c
+++ b/libleptongui/src/g_window.c
@@ -71,9 +71,8 @@ g_dynwind_window (GschemToplevel *w_current)
  * by main_prog().
  */
 void
-g_init_window ()
+g_init_window (SCM fluid)
 {
   /* Create fluid */
-  scheme_window_fluid = scm_permanent_object (scm_make_fluid ());
-  scm_c_define ("%lepton-window", scheme_window_fluid);
+  scheme_window_fluid = fluid;
 }

--- a/libleptongui/src/g_window.c
+++ b/libleptongui/src/g_window.c
@@ -63,30 +63,6 @@ g_dynwind_window (GschemToplevel *w_current)
 }
 
 /*!
- * \brief Get the value of the #GschemToplevel fluid.
- * \par Function Description
- * Return the value of the #GschemToplevel fluid in the current dynamic
- * context.
- * Signals an error if there is no valid window fluid
- * or the fluid value is NULL.
- * Never returns NULL.
- */
-GschemToplevel *
-g_current_window ()
-{
-  SCM window_s = scm_fluid_ref (scheme_window_fluid);
-  GschemToplevel *w_current = (GschemToplevel *) scm_to_pointer (window_s);
-
-  if (w_current == NULL)
-  {
-    scm_misc_error (NULL, _("Found invalid lepton-schematic window SCM: ~S"),
-                    scm_list_1 (window_s));
-  }
-
-  return w_current;
-}
-
-/*!
  * \brief Initialise the GschemToplevel manipulation procedures.
  * \par Function Description
 

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -463,7 +463,8 @@ i_callback_edit_copy (GtkWidget *widget, gpointer data)
 
   if (o_select_return_first_object(w_current)) {
     o_redraw_cleanstates(w_current);
-    if (g_action_get_position (TRUE, &wx, &wy)) {
+    if (g_action_get_position (w_current, TRUE, &wx, &wy))
+    {
       o_copy_start(w_current, wx, wy);
     }
     i_set_state (w_current, COPYMODE);
@@ -487,7 +488,8 @@ i_callback_edit_mcopy (GtkWidget *widget, gpointer data)
 
   if (o_select_return_first_object(w_current)) {
     o_redraw_cleanstates(w_current);
-    if (g_action_get_position (TRUE, &wx, &wy)) {
+    if (g_action_get_position (w_current, TRUE, &wx, &wy))
+    {
       o_copy_start(w_current, wx, wy);
     }
     i_set_state (w_current, MCOPYMODE);
@@ -511,7 +513,8 @@ i_callback_edit_move (GtkWidget *widget, gpointer data)
 
   if (o_select_return_first_object(w_current)) {
     o_redraw_cleanstates(w_current);
-    if (g_action_get_position (TRUE, &wx, &wy)) {
+    if (g_action_get_position (w_current, TRUE, &wx, &wy))
+    {
       o_move_start(w_current, wx, wy);
     }
     i_set_state (w_current, MOVEMODE);
@@ -638,7 +641,8 @@ i_callback_edit_rotate_90 (GtkWidget *widget, gpointer data)
     return;
   }
 
-  if (!g_action_get_position (TRUE, &wx, &wy)) {
+  if (!g_action_get_position (w_current, TRUE, &wx, &wy))
+  {
     i_set_state(w_current, ROTATEMODE);
     return;
   }
@@ -680,7 +684,8 @@ i_callback_edit_mirror (GtkWidget *widget, gpointer data)
     return;
   }
 
-  if (!g_action_get_position (TRUE, &wx, &wy)) {
+  if (!g_action_get_position (w_current, TRUE, &wx, &wy))
+  {
     i_set_state(w_current, MIRRORMODE);
     return;
   }
@@ -1128,7 +1133,8 @@ i_callback_view_zoom_box (GtkWidget *widget, gpointer data)
 
   i_set_state(w_current, ZOOMBOX);
 
-  if (g_action_get_position (FALSE, &wx, &wy)) {
+  if (g_action_get_position (w_current, FALSE, &wx, &wy))
+  {
     a_zoom_box_start(w_current, wx, wy);
   }
 }
@@ -1152,7 +1158,7 @@ i_callback_view_zoom_in (GtkWidget *widget, gpointer data)
   a_zoom (w_current,
           page_view,
           ZOOM_IN,
-          g_action_get_position (FALSE, NULL, NULL) ? HOTKEY : MENU);
+          g_action_get_position (w_current, FALSE, NULL, NULL) ? HOTKEY : MENU);
 
   if (w_current->undo_panzoom) {
     o_undo_savestate_old(w_current, UNDO_VIEWPORT_ONLY);
@@ -1178,7 +1184,7 @@ i_callback_view_zoom_out (GtkWidget *widget, gpointer data)
   a_zoom(w_current,
          page_view,
          ZOOM_OUT,
-         g_action_get_position (FALSE, NULL, NULL) ? HOTKEY : MENU);
+         g_action_get_position (w_current, FALSE, NULL, NULL) ? HOTKEY : MENU);
 
   if (w_current->undo_panzoom) {
     o_undo_savestate_old(w_current, UNDO_VIEWPORT_ONLY);
@@ -1201,7 +1207,8 @@ i_callback_view_pan (GtkWidget *widget, gpointer data)
   GschemPageView *page_view = gschem_toplevel_get_current_page_view (w_current);
   g_return_if_fail (page_view != NULL);
 
-  if (!g_action_get_position (FALSE, &wx, &wy)) {
+  if (!g_action_get_position (w_current, FALSE, &wx, &wy))
+  {
     o_redraw_cleanstates (w_current);
     i_action_stop (w_current);
     i_set_state (w_current, PAN);
@@ -1661,7 +1668,7 @@ i_callback_clipboard_paste (GtkWidget *widget, gpointer data)
 
   g_return_if_fail (w_current != NULL);
 
-  g_action_get_position (TRUE, &wx, &wy);
+  g_action_get_position (w_current, TRUE, &wx, &wy);
 
   o_redraw_cleanstates(w_current);
   empty = o_buffer_paste_start (w_current, wx, wy, CLIPBOARD_BUFFER);
@@ -1728,7 +1735,7 @@ buffer_paste (gpointer data, int n)
 
   g_return_if_fail (w_current != NULL);
 
-  g_action_get_position (TRUE, &wx, &wy);
+  g_action_get_position (w_current, TRUE, &wx, &wy);
 
   empty = o_buffer_paste_start (w_current, wx, wy, n-1);
 
@@ -1790,7 +1797,7 @@ i_callback_add_attribute (GtkWidget *widget, gpointer data)
   g_return_if_fail (w_current != NULL);
 
   attrib_edit_dialog(w_current, NULL,
-                     g_action_get_position (TRUE, NULL, NULL) ? FROM_HOTKEY : FROM_MENU);
+                     g_action_get_position (w_current, TRUE, NULL, NULL) ? FROM_HOTKEY : FROM_MENU);
 
   i_set_state(w_current, SELECT);
 }
@@ -1812,7 +1819,8 @@ i_callback_add_net (GtkWidget *widget, gpointer data)
 
   i_set_state(w_current, NETMODE);
 
-  if (g_action_get_position (TRUE, &wx, &wy)) {
+  if (g_action_get_position (w_current, TRUE, &wx, &wy))
+  {
     o_net_reset(w_current);
     o_net_start(w_current, wx, wy);
   }
@@ -1855,7 +1863,8 @@ i_callback_add_bus (GtkWidget *widget, gpointer data)
 
   i_set_state(w_current, BUSMODE);
 
-  if (g_action_get_position (TRUE, &wx, &wy)) {
+  if (g_action_get_position (w_current, TRUE, &wx, &wy))
+  {
     o_bus_start(w_current, wx, wy);
   }
 }
@@ -1918,7 +1927,8 @@ i_callback_add_line (GtkWidget *widget, gpointer data)
 
   i_set_state(w_current, LINEMODE);
 
-  if (g_action_get_position (TRUE, &wx, &wy)) {
+  if (g_action_get_position (w_current, TRUE, &wx, &wy))
+  {
     o_line_start(w_current, wx, wy);
   }
 }
@@ -1957,7 +1967,8 @@ i_callback_add_box (GtkWidget *widget, gpointer data)
 
   i_set_state(w_current, BOXMODE);
 
-  if (g_action_get_position (TRUE, &wx, &wy)) {
+  if (g_action_get_position (w_current, TRUE, &wx, &wy))
+  {
     o_box_start(w_current, wx, wy);
   }
 }
@@ -2000,7 +2011,8 @@ i_callback_add_circle (GtkWidget *widget, gpointer data)
 
   i_set_state(w_current, CIRCLEMODE);
 
-  if (g_action_get_position (TRUE, &wx, &wy)) {
+  if (g_action_get_position (w_current, TRUE, &wx, &wy))
+  {
     o_circle_start(w_current, wx, wy);
   }
 }
@@ -2023,7 +2035,8 @@ i_callback_add_arc (GtkWidget *widget, gpointer data)
 
   i_set_state(w_current, ARCMODE);
 
-  if (g_action_get_position (TRUE, &wx, &wy)) {
+  if (g_action_get_position (w_current, TRUE, &wx, &wy))
+  {
     o_arc_start(w_current, wx, wy);
   }
 }
@@ -2046,7 +2059,8 @@ i_callback_add_pin (GtkWidget *widget, gpointer data)
 
   i_set_state (w_current, PINMODE);
 
-  if (g_action_get_position (TRUE, &wx, &wy)) {
+  if (g_action_get_position (w_current, TRUE, &wx, &wy))
+  {
     o_pin_start(w_current, wx, wy);
   }
 }

--- a/schematic/lepton-schematic.scm
+++ b/schematic/lepton-schematic.scm
@@ -317,19 +317,9 @@ Run `~A --help' for more information.\n")
        ;; Foreign pointer to w_current.
        (window (main schematics)))
 
-  ;; %lepton-window is a fluid defined in C code, namely in
-  ;; g_window.c.  When a new lepton-schematic window is created,
-  ;; the fluid is initialized to the window's own pointer to
-  ;; itself.  Thus, any Scheme callback procedure called inside
-  ;; the window may use just the value of the fluid to reference
-  ;; its window, thus avoiding the need of any additional
-  ;; arguments.  Here we reference the fluid to enter into the
-  ;; dynamic state of the new window created above and eval
-  ;; post-load expressions (if any) within it.  'window' is
-  ;; already a Scheme pointer object (wrapping a C pointer), so we
-  ;; don't have to use pointer->scm to make the fluid happy.
-  (with-fluid* %lepton-window window
-               eval-post-load-expr!))
+  ;; Evaluate post load expression in the dynamic context of the
+  ;; new window.
+  (with-window window (eval-post-load-expr!)))
 
 ;;; Run main GTK loop.
 (gtk_main)

--- a/schematic/lepton-schematic.scm
+++ b/schematic/lepton-schematic.scm
@@ -32,7 +32,8 @@
              (schematic ffi)
              (schematic ffi gtk)
              (schematic gui keymap)
-             (schematic menu))
+             (schematic menu)
+             (schematic window))
 
 ;;; Initialize liblepton library.
 (liblepton_init)
@@ -61,7 +62,7 @@
   (set! %load-compiled-path (cons "@LEPTON_CCACHE_DIR@"
                                   %load-compiled-path)))
 (define (register-guile-funcs)
-  (g_init_window))
+  (g_init_window (scm->pointer %lepton-window)))
 
 (define (precompile-run)
   (let ((script (getenv "LEPTON_SCM_PRECOMPILE_SCRIPT")))


### PR DESCRIPTION
Apart from compilation, a new syntax, `with-window()` has been
introduced.  The code is responsible for dynwinding the current
window and its `LeptonToplevel` structure and executing statements
in their context.  `%lepton-window` fluid creation has been moved
to Scheme code thus reducing the amount of Scheme-in-C code.  A new
Scheme type, `#<schematic-window>`, has been added.  It represents
wrapped foreign pointers to schematic window structures.
