### PR TITLE
Reduce the number of Scheme compilation warnings

### DIFF
--- a/libleptongui/scheme/conf/schematic/keys.scm
+++ b/libleptongui/scheme/conf/schematic/keys.scm
@@ -2,6 +2,8 @@
 ; Start of keymapping related keywords
 ;
 
+(use-modules (schematic gui keymap))
+
 ;;;; Keymapping
 ;;
 ;; Everything is case-sensitive.  Any number of keys may be bound in

--- a/libleptongui/scheme/conf/schematic/menu.scm
+++ b/libleptongui/scheme/conf/schematic/menu.scm
@@ -12,8 +12,9 @@
 ; The SEPARATOR keyword is case sensitive and puts a separator into the menu.
 ;
 
-( use-modules ( ice-9 format ) )
-( use-modules ( lepton config ) )
+(use-modules (ice-9 format)
+             (lepton config)
+             (schematic menu))
 
 ;; Define a no-op macro for flagging strings as translatable.
 (define-syntax N_

--- a/libleptongui/scheme/pcb.scm
+++ b/libleptongui/scheme/pcb.scm
@@ -2,7 +2,7 @@
 ;;
 ;; Copyright (C) 2006-2010 Dan McMahill
 ;; Copyright (C) 2006-2011 gEDA Contributors
-;; Copyright (C) 2019-2020 Lepton EDA Contributors
+;; Copyright (C) 2019-2022 Lepton EDA Contributors
 ;;
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -53,8 +53,11 @@
 ;;
 
 (use-modules (ice-9 popen)
+             (geda deprecated)
              (lepton log)
-             (schematic dialog))
+             (gschem deprecated)
+             (schematic dialog)
+             (schematic menu))
 
 (log! 'message "Loading the PCB major mode\n")
 ;; (log! 'message "PCB-mode version $Id$\n")


### PR DESCRIPTION
Please note that this commit set does not fix the broken `pcb.scm` script.  It only eliminates some Scheme compilation warnings (several dozens of them). This corner of code needs more time and special TLC.