### PR TITLE
Fix adding of new attributes using the Add/Edit Attribute dialog.

### DIFF
--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -214,7 +214,17 @@ o_attrib_select_invisible (GschemToplevel *w_current,
                            LeptonObject *selected);
 void o_attrib_toggle_visibility(GschemToplevel *w_current, LeptonObject *object);
 void o_attrib_toggle_show_name_value(GschemToplevel *w_current, LeptonObject *object, int new_show_name_value);
-LeptonObject *o_attrib_add_attrib(GschemToplevel *w_current, const char *text_string, int visibility, int show_name_value, LeptonObject *object);
+
+LeptonObject*
+o_attrib_add_attrib (GschemToplevel *w_current,
+                     const char *text_string,
+                     int visibility,
+                     int show_name_value,
+                     LeptonObject *object,
+                     gboolean proposed_coord,
+                     int x,
+                     int y);
+
 /* o_basic.c */
 #ifdef ENABLE_GTK3
 void

--- a/libleptongui/scheme/schematic/attrib.scm
+++ b/libleptongui/scheme/schematic/attrib.scm
@@ -68,7 +68,8 @@ the symbols 'name, 'value or 'both.  If TARGET is specified and is
 a Lepton object, the new attribute will be attached to it. If the
 object is not in lepton-schematic's active page, an 'object-state
 error will be raised.  If TARGET is #f, the new attribute will be
-floating in lepton-schematic's current active page.  See also
+floating in lepton-schematic's current active page.  The initial
+value of the attribute will be set then to (0 . 0).  See also
 active-page() in the (schematic window) module."
   (check-attrib-target target 1)
   (check-string name 2)
@@ -86,7 +87,10 @@ active-page() in the (schematic window) module."
                                                *str
                                                visibility
                                                show?
-                                               *object))))
+                                               *object
+                                               TRUE  ; let's be
+                                               0     ; specific
+                                               0))))
 
 
 (define (attribute-name name)

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -186,7 +186,9 @@
 ;;; g_window.c
 (define-lff g_init_window void '(*))
 
-(define-lff o_attrib_add_attrib '* (list '* '* int int '*))
+;;; o_attrib.c
+(define-lff o_attrib_add_attrib '* (list '* '* int int '* int int int))
+
 (define-lff o_buffer_init void '())
 (define-lff set_quiet_mode void '())
 (define-lff set_verbose_mode void '())

--- a/libleptongui/src/o_attrib.c
+++ b/libleptongui/src/o_attrib.c
@@ -229,13 +229,69 @@ void o_attrib_toggle_show_name_value(GschemToplevel *w_current,
 }
 
 
-/*! \todo Finish function documentation!!!
- *  \brief
+/*! \brief Adds an attribute with given parameters to the active page
  *  \par Function Description
+ *  This function creates and returns an attribute object with
+ *  given properties from \a text_string and adds it to the canvas
+ *  of the #GschemToplevel object \a w_current.  Depending on the
+ *  state of the objects on the page (selection, visibility), it
+ *  adds an attached or unattached attribute and selects an
+ *  appropriate place for it.  The strategy of choosing the place
+ *  and other features is rather complicated:
  *
+ * - First, the function checks if \a object is not NULL, and if
+ *   so, gets its coordinates to learn where to place the
+ *   attribute.  For most of primitives, the attribute becomes an
+ *   attached one, and its coords are set using the coords of \a
+ *   object.  For text, its coords are used in the calculations,
+ *   though the attribute gets unattached.
+ *
+ *   \bug Some objects, like paths or pictures, are not taken
+ *   into account in the code.
+ *
+ * - If there is no object to attach the attrib to, a toplevel
+ *   (floating) attribute is created.
+ *
+ * - If any cooordinate is proposed with \a proposed_coord, \a x,
+ *   and \a y, it becomes the coordinate of the new attrib.
+ *
+ * - Otherwise, if no coord is proposed, and no any visible object
+ *   exists on the page, the coordinate is set to the bottom-left
+ *   corner of the visible objects.
+ *
+ * - Then, if there is no visible object, and no coord is proposed,
+ *   the value of the center of the current page view becomes the
+ *   anchor of the attribute.
+ *
+ * - Eventually, if no one of the above conditions can be met,
+ *   when, for example, the program using this function, be it C
+ *   or Scheme code, misses a page view, the last resort is
+ *   setting the anchor to a specific value.  Currently, it is
+ *   (0,0).
+ *
+ * After creating a text item for the attribute with the coords
+ * and other parameters described above, it gets appended to the
+ * currently active page, attached to the given object if it
+ * exists, and selected in order to enable further GUI processing.
+ *
+ * \bug slot= attributes are processed specially in this function,
+ * which is wrong.
+ *
+ * Eventually, two Scheme hooks are evaluated, add-objects-hook()
+ * and select-objects-hook().  The user may set up some other
+ * script processing of newly added and hence selected attributes
+ * there.
+ *
+ *  \param [in] w_current The GschemToplevel object.
+ *  \param [in] text_string The text string of the attribute object.
+ *  \param [in] visibility If the attribute should be visible.
+ *  \param [in] show_name_value What combination of name-value to show.
+ *  \param [in] object The parent object to attach the new attribute to.
+ *  \param [in] proposed_coord If the proposed coord values can be used.
+ *  \param [in] x The proposed X coordinate.
+ *  \param [in] y The proposed Y coordinate.
+ *  \return The new attribute object.
  */
-/* This function no longer returns NULL, but will always return the new */
-/* text item */
 LeptonObject*
 o_attrib_add_attrib (GschemToplevel *w_current,
                      const char *text_string,

--- a/libleptongui/src/o_attrib.c
+++ b/libleptongui/src/o_attrib.c
@@ -260,9 +260,10 @@ o_attrib_add_attrib (GschemToplevel *w_current,
 
   o_current = object;
 
-  /* creating a toplevel or unattached attribute */
+  /* Creating an attribute for the given object, if it exists. */
   if (o_current) {
-    /* get coordinates of where to place the text object */
+    /* Get coordinates of where to place the text object and
+     * parameters of the new attribute. */
     switch (lepton_object_get_type (o_current)) {
       case(OBJ_COMPONENT):
         world_x = lepton_component_object_get_x (o_current);
@@ -348,6 +349,8 @@ o_attrib_add_attrib (GschemToplevel *w_current,
         }
         break;
 
+        /* We cannot attach an attribute to text, so create a
+         * toplevel attribute here. */
       case(OBJ_TEXT):
         world_x = lepton_text_object_get_x (o_current);
         world_y = lepton_text_object_get_y (o_current);
@@ -360,8 +363,7 @@ o_attrib_add_attrib (GschemToplevel *w_current,
   }
   else
   {
-    /* If there is no object to attach the attrib to, let's first
-     * set up its coordinate and other parameters. */
+    /* Creating a toplevel (unattached, floating) attribute. */
 
     /* If any coordinate is proposed, set the attrib anchor to it.  */
     if (proposed_coord)
@@ -435,6 +437,7 @@ o_attrib_add_attrib (GschemToplevel *w_current,
     o_attrib_attach (new_obj, o_current, FALSE);
   }
 
+  /* Select the attribute to enable its further processing. */
   o_selection_add (active_page->selection_list, new_obj);
 
   /* handle slot= attribute, it's a special case */

--- a/libleptongui/src/x_multiattrib.c
+++ b/libleptongui/src/x_multiattrib.c
@@ -615,8 +615,14 @@ multiattrib_action_add_attribute (Multiattrib *multiattrib,
     if (is_multiattrib_object (object)) {
 
       /* create a new attribute and link it */
-      o_attrib_add_attrib (w_current, newtext,
-                           visible, show_name_value, object);
+      o_attrib_add_attrib (w_current,
+                           newtext,
+                           visible,
+                           show_name_value,
+                           object,
+                           FALSE,
+                           0,
+                           0);
     }
   }
 
@@ -648,7 +654,10 @@ multiattrib_action_duplicate_attributes (Multiattrib *multiattrib,
                          lepton_text_object_get_string (o_attrib),
                          lepton_text_object_is_visible (o_attrib),
                          lepton_text_object_get_show (o_attrib),
-                         lepton_object_get_attached_to (o_attrib));
+                         lepton_object_get_attached_to (o_attrib),
+                         FALSE,
+                         0,
+                         0);
   }
 
   schematic_window_active_page_changed (w_current);
@@ -680,7 +689,10 @@ multiattrib_action_promote_attributes (Multiattrib *multiattrib,
                            lepton_text_object_get_string (o_attrib),
                            VISIBLE,
                            lepton_text_object_get_show (o_attrib),
-                           lepton_object_get_parent (o_attrib));
+                           lepton_object_get_parent (o_attrib),
+                           FALSE,
+                           0,
+                           0);
     } else {
         active_page = schematic_window_get_active_page (w_current);
         /* make a copy of the attribute object */
@@ -763,7 +775,10 @@ multiattrib_action_copy_attribute_to_all (Multiattrib *multiattrib,
                            lepton_text_object_get_string (attrib_to_copy),
                            visibility,
                            lepton_text_object_get_show (attrib_to_copy),
-                           object);
+                           object,
+                           FALSE,
+                           0,
+                           0);
     }
   }
 


### PR DESCRIPTION
In the case when there were no selected and visible objects on the `lepton-schematic` page, insertion of an attribute using the *Attrib Edit* dialog could lead to some strange result due to arbitrary (uninitialized) values of proposed coords for it.  The logic has been changed that reasonable defaults are set

Now, if there is no object visible on the canvas, and the mouse cursor does not point to the canvas (is out of the program window or over the menus) during insertion of an attribute, the program places a new attribute in the center of the canvas.

A last resort case has been added for cases when the attribute is placed from Scheme code when no GUI is available.  The attribute coord is set to `(0 . 0)` then.

The commit set also fixes the issue with overriding coordinate values set by related Scheme hooks in cases when the action is launched by hotkey when the mouse cursor is over the canvas.

The Scheme function `add-attrib!()` has been fixed as well so it always sets the zero value for coordinates (as they are missing in the set of its arguments) to ensure its proper behavior in custom Scheme scripts.

Closes #788 fixing the bug described there and another bug that I've discovered: `add-objects-hook` did not work due to its refinement overridden by improper C code later under some conditions.
