### PR TITLE
gui: Get rid of g_scm_from_window().

### DIFF
--- a/libleptongui/include/gschem_toplevel.h
+++ b/libleptongui/include/gschem_toplevel.h
@@ -241,8 +241,6 @@ struct st_gschem_toplevel {
   gchar* bus_ripper_symname; /* default bus ripper symbol file name */
 
   gboolean dont_invalidate;
-
-  SCM smob;               /* The Scheme representation of this window */
 };
 
 

--- a/libleptongui/src/g_window.c
+++ b/libleptongui/src/g_window.c
@@ -23,26 +23,6 @@
 
 SCM scheme_window_fluid = SCM_UNDEFINED;
 
-/*! \brief Get the smob for a #GschemToplevel.
- * \par Function Description
- * Return a smob representing \a window.
- *
- * \param window #GschemToplevel to obtain a smob for.
- * \param a smob representing \a window.
- */
-SCM
-g_scm_from_window (GschemToplevel *w_current)
-{
-  g_assert (w_current != NULL);
-
-  if (scm_is_eq (w_current->smob, SCM_UNDEFINED)) {
-    w_current->smob = scm_from_pointer (w_current, NULL);
-    scm_gc_protect_object (w_current->smob);
-  }
-
-  return w_current->smob;
-}
-
 /*!
  * \brief Set the #GschemToplevel fluid in the current dynamic context.
  * \par Function Description
@@ -57,7 +37,7 @@ void
 g_dynwind_window (GschemToplevel *w_current)
 {
   g_assert (w_current != NULL);
-  SCM window_s = g_scm_from_window (w_current);
+  SCM window_s = scm_from_pointer (w_current, NULL);
   scm_dynwind_fluid (scheme_window_fluid, window_s);
   edascm_dynwind_toplevel (w_current->toplevel);
 }

--- a/libleptongui/src/gschem_toplevel.c
+++ b/libleptongui/src/gschem_toplevel.c
@@ -352,8 +352,6 @@ GschemToplevel *gschem_toplevel_new ()
 
   w_current->bus_ripper_symname = NULL;
 
-  w_current->smob = SCM_UNDEFINED;
-
   return w_current;
 }
 

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -681,12 +681,6 @@ void x_window_close(GschemToplevel *w_current)
     o_buffer_free (w_current);
   }
 
-  /* Allow Scheme value for this window to be garbage-collected */
-  if (!scm_is_eq (w_current->smob, SCM_UNDEFINED)) {
-    scm_gc_unprotect_object (w_current->smob);
-    w_current->smob = SCM_UNDEFINED;
-  }
-
   /* finally close the main window */
   gtk_widget_destroy(w_current->main_window);
 


### PR DESCRIPTION
Instead of storing an SCM value representing a window in the
`GschemToplevel` structure of the window itself, just get it every
time from its pointer.  This adds nothing to garbage collection,
so corresponding code has been removed as well.