### PR TITLE
GTK3 port: Get rid of deprecation warnings on gtk_action_*() functions

### DIFF
--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -611,6 +611,11 @@ lepton_action_create_menu_item (GtkAction *action,
                                 gpointer data);
 #endif
 void
+lepton_menu_set_action_data (GtkWidget *menu,
+                             const char *action_name,
+                             GtkWidget *menu_item,
+                             gpointer action);
+void
 x_menu_attach_recent_files_submenu (GschemToplevel* w_current,
                                     GtkWidget*      menuitem);
 /* x_multiattrib.c */

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -604,11 +604,13 @@ make_menu_action (const char *action_name,
 #ifdef ENABLE_GTK3
 GtkWidget*
 lepton_action_create_menu_item (GSimpleAction* action,
-                                gchar *label);
+                                char *label,
+                                char *shortcut);
 #else
 GtkWidget*
 lepton_action_create_menu_item (GtkAction *action,
-                                gpointer data);
+                                gpointer data1,
+                                gpointer data2);
 #endif
 void
 lepton_menu_set_action_data (GtkWidget *menu,

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -584,12 +584,25 @@ gint do_popup(GschemToplevel *w_current, GdkEventButton *event);
 void x_menus_sensitivity (GtkWidget* menu, const gchar* action_name, gboolean sensitive);
 GtkWidget*
 make_separator_menu_item ();
+#ifdef ENABLE_GTK3
+GSimpleAction*
+#else
 GschemAction*
+#endif
 make_menu_action (const char *action_name,
                   const char *menu_item_name,
                   const char *menu_item_keys,
                   const char *menu_item_stock,
                   GschemToplevel *w_current);
+#ifdef ENABLE_GTK3
+GtkWidget*
+lepton_action_create_menu_item (GSimpleAction* action,
+                                gchar *label);
+#else
+GtkWidget*
+lepton_action_create_menu_item (GtkAction *action,
+                                gpointer data);
+#endif
 void
 x_menu_attach_recent_files_submenu (GschemToplevel* w_current,
                                     GtkWidget*      menuitem);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -50,6 +50,13 @@ void
 set_verbose_mode ();
 void
 set_quiet_mode ();
+
+int
+lepton_schematic_run (gpointer activate);
+
+gpointer
+lepton_schematic_app ();
+
 /* i_basic.c */
 void i_action_start(GschemToplevel *w_current);
 void i_action_stop(GschemToplevel *w_current);
@@ -636,7 +643,8 @@ void x_window_setup_draw_events_main_wnd (GschemToplevel* w_current,
 void x_window_setup_draw_events_drawing_area (GschemToplevel* w_current,
                                               GschemPageView* drawing_area);
 GschemToplevel*
-x_window_create_main (GschemToplevel *w_current,
+x_window_create_main (gpointer app,
+                      GschemToplevel *w_current,
                       GtkWidget *menubar,
                       gpointer key_event_callback);
 

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -96,18 +96,19 @@
 (define-action-public (&file-script #:label (G_ "Run Script") #:icon "gtk-execute")
   (run-callback i_callback_file_script "&file-script"))
 
-(define (make-schematic-window)
+(define (make-schematic-window app)
   (define new-window (x_window_setup (x_window_new)))
 
 
   (x_window_open_page
-   (x_window_create_main new-window
+   (x_window_create_main app
+                         new-window
                          (make-main-menu new-window)
                          *process-key-event)
    %null-pointer))
 
 (define-action-public (&file-new-window #:label (G_ "New Window") #:icon "window-new")
-  (make-schematic-window))
+  (make-schematic-window (lepton_schematic_app)))
 
 (define-action-public (&file-close-window #:label (G_ "Close Window") #:icon "gtk-close")
   (run-callback i_callback_file_close "&file-close-window"))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -150,6 +150,8 @@
             schematic_keys_get_event_modifiers
             schematic_keys_verify_keyval
 
+            lepton_action_create_menu_item
+
             gschem_page_view_get_page
 
             gschem_toplevel_get_current_page_view
@@ -219,6 +221,8 @@
 (define-lff make_separator_menu_item '* '())
 (define-lff make_menu_action '* '(* * * * *))
 (define-lff x_menu_attach_recent_files_submenu void '(* *))
+(define-lff lepton_action_create_menu_item '* '(* *))
+
 ;;; x_window.c
 (define-lff x_window_new '* '())
 (define-lff x_window_open_page '* '(* *))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -153,6 +153,7 @@
             schematic_keys_verify_keyval
 
             lepton_action_create_menu_item
+            lepton_menu_set_action_data
 
             gschem_page_view_get_page
 
@@ -227,6 +228,7 @@
 (define-lff make_menu_action '* '(* * * * *))
 (define-lff x_menu_attach_recent_files_submenu void '(* *))
 (define-lff lepton_action_create_menu_item '* '(* *))
+(define-lff lepton_menu_set_action_data void '(* * * *))
 
 ;;; x_window.c
 (define-lff x_window_new '* '())

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -22,7 +22,9 @@
 
   #:use-module (lepton ffi lib)
 
-  #:export (g_init_window
+  #:export (lepton_schematic_run
+            lepton_schematic_app
+            g_init_window
             generic_confirm_dialog
             generic_filesel_dialog
             generic_msg_dialog
@@ -184,6 +186,9 @@
                            args))))
          (force proc))))))
 
+;;; lepton_schematic.c
+(define-lff lepton_schematic_run int '(*))
+(define-lff lepton_schematic_app '* '())
 
 ;;; g_window.c
 (define-lff g_init_window void '(*))
@@ -228,7 +233,7 @@
 (define-lff x_window_open_page '* '(* *))
 (define-lff x_window_set_current_page void '(* *))
 (define-lff x_window_setup '* '(*))
-(define-lff x_window_create_main '* '(* * *))
+(define-lff x_window_create_main '* '(* * * *))
 (define-lff x_window_close_page void '(* *))
 
 ;;; x_dialog.c

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -227,7 +227,7 @@
 (define-lff make_separator_menu_item '* '())
 (define-lff make_menu_action '* '(* * * * *))
 (define-lff x_menu_attach_recent_files_submenu void '(* *))
-(define-lff lepton_action_create_menu_item '* '(* *))
+(define-lff lepton_action_create_menu_item '* '(* * *))
 (define-lff lepton_menu_set_action_data void '(* * * *))
 
 ;;; x_window.c

--- a/libleptongui/scheme/schematic/ffi/gtk.scm
+++ b/libleptongui/scheme/schematic/ffi/gtk.scm
@@ -21,7 +21,6 @@
   #:use-module (lepton ffi)
 
   #:export (gtk_init
-            gtk_main
             gtk_accelerator_parse
             gtk_accelerator_name
             gtk_accelerator_get_label
@@ -52,12 +51,6 @@
    void
    (dynamic-func "gtk_init" libgtk)
    (list '* '*)))
-
-(define gtk_main
-  (pointer->procedure
-   void
-   (dynamic-func "gtk_main" libgtk)
-   '()))
 
 (define (gtk_rc_parse filename)
   (define proc

--- a/libleptongui/scheme/schematic/ffi/gtk.scm
+++ b/libleptongui/scheme/schematic/ffi/gtk.scm
@@ -34,7 +34,6 @@
             gtk_widget_show
             gtk_menu_new
             gtk_menu_bar_new
-            gtk_action_create_menu_item
             gtk_menu_item_set_submenu
             gtk_menu_shell_append))
 
@@ -107,6 +106,5 @@
 (define-lff gtk_tearoff_menu_item_new '* '())
 (define-lff gtk_menu_new '* '())
 (define-lff gtk_menu_bar_new '* '())
-(define-lff gtk_action_create_menu_item '* '(*))
 (define-lff gtk_menu_item_set_submenu void '(* *))
 (define-lff gtk_menu_shell_append void '(* *))

--- a/libleptongui/scheme/schematic/menu.scm
+++ b/libleptongui/scheme/schematic/menu.scm
@@ -65,7 +65,9 @@
                                          (string->pointer menu-item-keys)
                                          menu-item-stock
                                          window))
-               (menu-item (lepton_action_create_menu_item action (string->pointer name))))
+               (menu-item (lepton_action_create_menu_item action
+                                                          (string->pointer name)
+                                                          (string->pointer menu-item-keys))))
           (lepton_menu_set_action_data menu-bar action-name menu-item action)
           menu-item)))
 

--- a/libleptongui/scheme/schematic/menu.scm
+++ b/libleptongui/scheme/schematic/menu.scm
@@ -1,6 +1,6 @@
 ;;; Lepton EDA Schematic Capture
 ;;; Scheme API
-;;; Copyright (C) 2020 Lepton EDA Contributors
+;;; Copyright (C) 2020-2022 Lepton EDA Contributors
 ;;;
 ;;; This program is free software; you can redistribute it and/or modify
 ;;; it under the terms of the GNU General Public License as published by
@@ -65,8 +65,7 @@
                                          (string->pointer menu-item-keys)
                                          menu-item-stock
                                          window))
-               (menu-item (gtk_action_create_menu_item action)))
-
+               (menu-item (lepton_action_create_menu_item action (string->pointer name))))
           (g_object_set_data menu-bar action-name action)
           menu-item)))
 

--- a/libleptongui/scheme/schematic/menu.scm
+++ b/libleptongui/scheme/schematic/menu.scm
@@ -66,7 +66,7 @@
                                          menu-item-stock
                                          window))
                (menu-item (lepton_action_create_menu_item action (string->pointer name))))
-          (g_object_set_data menu-bar action-name action)
+          (lepton_menu_set_action_data menu-bar action-name menu-item action)
           menu-item)))
 
   (define (item->menu-item item menu-bar)

--- a/libleptongui/src/gschem_action.c
+++ b/libleptongui/src/gschem_action.c
@@ -23,6 +23,7 @@
 #include "gschem.h"
 
 
+#ifndef ENABLE_GTK3
 enum {
   PROP_MULTIKEY_ACCEL = 1,
 };
@@ -195,11 +196,7 @@ static void gschem_action_class_init (GschemActionClass *klass)
 GschemAction *gschem_action_new (const gchar *name,
                                  const gchar *label,
                                  const gchar *tooltip,
-#ifdef ENABLE_GTK3
-                                 const gchar *icon_name,
-#else /* GTK2 */
                                  const gchar *stock_id,
-#endif
                                  const gchar *multikey_accel)
 {
   g_return_val_if_fail (name != NULL, NULL);
@@ -208,11 +205,8 @@ GschemAction *gschem_action_new (const gchar *name,
                                       "name", name,
                                       "label", label,
                                       "tooltip", tooltip,
-#ifdef ENABLE_GTK3
-                                      "icon-name", icon_name,
-#else /* GTK2 */
                                       "stock-id", stock_id,
-#endif
                                       "multikey-accel", multikey_accel,
                                       NULL));
 }
+#endif

--- a/libleptongui/src/lepton-schematic.c
+++ b/libleptongui/src/lepton-schematic.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2016 gEDA Contributors
- * Copyright (C) 2017-2020 Lepton EDA Contributors
+ * Copyright (C) 2017-2022 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -76,4 +76,45 @@ void gschem_quit(void)
   {
     gtk_main_quit();
   }
+}
+
+#ifdef ENABLE_GTK3
+static GtkApplication *app = NULL;
+#endif
+
+gpointer
+lepton_schematic_app ()
+{
+#ifdef ENABLE_GTK3
+  return app;
+#else
+  return NULL;
+#endif
+}
+
+
+/*! \brief Start lepton-schematic.
+ *
+ * The function initializes the structures of the program and runs
+ * main gtk loop.
+ */
+int
+lepton_schematic_run (gpointer activate)
+{
+#ifdef ENABLE_GTK3
+  int status;
+
+  app = gtk_application_new ("com.github.lepton_eda.lepton_schematic",
+                             G_APPLICATION_FLAGS_NONE);
+
+  g_signal_connect (app, "activate", G_CALLBACK (activate), NULL);
+
+  status = g_application_run (G_APPLICATION (app), 0, NULL);
+  g_object_unref (app);
+  return status;
+#else
+  /* Run main GTK loop. */
+  gtk_main ();
+  return 0;
+#endif
 }

--- a/libleptongui/src/x_menus.c
+++ b/libleptongui/src/x_menus.c
@@ -163,7 +163,8 @@ on_menu_item_activate (GtkMenuItem *item,
 
 GtkWidget*
 lepton_action_create_menu_item (GSimpleAction* action,
-                                gchar *label)
+                                gchar *label,
+                                gchar *shortcut)
 {
   GtkWidget *item = gtk_menu_item_new_with_mnemonic (label);
 
@@ -171,13 +172,37 @@ lepton_action_create_menu_item (GSimpleAction* action,
                     "activate",
                     G_CALLBACK (&on_menu_item_activate),
                     action);
+
+  GtkWidget *item_label = gtk_bin_get_child (GTK_BIN (item));
+
+  /* make sure item_label is a GschemAccelLabel */
+  if (item_label && !GSCHEM_IS_ACCEL_LABEL (item_label)) {
+    gtk_container_remove (GTK_CONTAINER (item), item_label);
+    item_label = NULL;
+  }
+
+  if (item_label == NULL) {
+    /* char *label_string; */
+    /* g_object_get (action, "label", &label_string, NULL); */
+    g_object_new (GSCHEM_TYPE_ACCEL_LABEL,
+                  "use-underline", TRUE,
+                  "xalign", 0.0,
+                  "visible", TRUE,
+                  "parent", item,
+                  "label", label,
+                  "accel-string", shortcut,
+                  NULL);
+    /* g_free (label_string); */
+  }
+
   return item;
 }
 
 #else
 GtkWidget*
 lepton_action_create_menu_item (GtkAction *action,
-                                gpointer data)
+                                gpointer data1,
+                                gpointer data2)
 {
   return gtk_action_create_menu_item (GTK_ACTION (action));
 }
@@ -228,7 +253,7 @@ get_main_popup (GschemToplevel* w_current)
 
 #ifdef ENABLE_GTK3
     GSimpleAction* action = g_simple_action_new (e.action, NULL);
-    menu_item = gtk_menu_item_new_with_mnemonic (gettext (e.name));
+    menu_item = lepton_action_create_menu_item (action, gettext (e.name), NULL);
 
     g_signal_connect (menu_item,
                       "activate",

--- a/libleptongui/src/x_tabs.c
+++ b/libleptongui/src/x_tabs.c
@@ -281,15 +281,16 @@ x_tabs_menu_create_item_separ (GtkWidget* menu);
 
 #ifdef ENABLE_GTK3
 static void
-x_tabs_menu_item_on_activate (GSimpleAction* action,
-                              GVariant *parameter,
-                              gpointer data);
+x_tabs_menu_action_on_activate (GSimpleAction* action,
+                                GVariant *parameter,
+                                gpointer data);
 static void
-x_tabs_menu_item_on_activate_action (GtkMenuItem *item,
-                                     gpointer data);
+x_tabs_menu_item_on_activate (GtkMenuItem *item,
+                              gpointer data);
 #else /* GTK2 */
 static void
-x_tabs_menu_item_on_activate (GtkAction* action, gpointer data);
+x_tabs_menu_action_on_activate (GtkAction* action,
+                                gpointer data);
 #endif
 
 
@@ -1746,9 +1747,9 @@ x_tabs_hdr_on_mouse_click (GtkWidget* hdr, GdkEvent* e, gpointer data)
  */
 #ifdef ENABLE_GTK3
 static void
-x_tabs_menu_item_on_activate (GSimpleAction* action,
-                              GVariant *parameter,
-                              gpointer data)
+x_tabs_menu_action_on_activate (GSimpleAction* action,
+                                GVariant *parameter,
+                                gpointer data)
 {
   GschemToplevel* toplevel    = (GschemToplevel*) data;
   const gchar*    action_name = g_action_get_name (G_ACTION (action));
@@ -1757,8 +1758,8 @@ x_tabs_menu_item_on_activate (GSimpleAction* action,
 }
 
 static void
-x_tabs_menu_item_on_activate_action (GtkMenuItem *item,
-                                     gpointer data)
+x_tabs_menu_item_on_activate (GtkMenuItem *item,
+                              gpointer data)
 {
   g_signal_emit_by_name (G_ACTION (data), "activate");
 }
@@ -1766,7 +1767,8 @@ x_tabs_menu_item_on_activate_action (GtkMenuItem *item,
 #else /* GTK2 */
 
 static void
-x_tabs_menu_item_on_activate (GtkAction* action, gpointer data)
+x_tabs_menu_action_on_activate (GtkAction* action,
+                                gpointer data)
 {
   GschemToplevel* toplevel    = (GschemToplevel*) data;
   const gchar*    action_name = gtk_action_get_name (action);
@@ -1804,7 +1806,7 @@ x_tabs_menu_create_item (GschemToplevel* toplevel,
 
   g_signal_connect (item,
                     "activate",
-                    G_CALLBACK (&x_tabs_menu_item_on_activate_action),
+                    G_CALLBACK (&x_tabs_menu_item_on_activate),
                     action);
 #else /* GTK2 */
 
@@ -1821,7 +1823,7 @@ x_tabs_menu_create_item (GschemToplevel* toplevel,
 
   g_signal_connect (action,
                     "activate",
-                    G_CALLBACK (&x_tabs_menu_item_on_activate),
+                    G_CALLBACK (&x_tabs_menu_action_on_activate),
                     toplevel);
 
 } /* x_tabs_menu_create_item() */

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -445,7 +445,8 @@ x_window_translate_response (GschemTranslateWidget *widget, gint response, Gsche
  *
  */
 GschemToplevel*
-x_window_create_main (GschemToplevel *w_current,
+x_window_create_main (gpointer app,
+                      GschemToplevel *w_current,
                       GtkWidget *menubar,
                       gpointer key_event_callback)
 {
@@ -455,7 +456,11 @@ x_window_create_main (GschemToplevel *w_current,
   GtkWidget *work_box = NULL;
   GtkWidget *scrolled = NULL;
 
+#ifdef ENABLE_GTK3
+  w_current->main_window = gtk_application_window_new (GTK_APPLICATION (app));
+#else
   w_current->main_window = GTK_WIDGET (gschem_main_window_new ());
+#endif
 
   gtk_widget_set_name (w_current->main_window, "lepton-schematic");
   gtk_window_set_resizable (GTK_WINDOW (w_current->main_window), TRUE);


### PR DESCRIPTION
The functions are deprecated since GTK 3.10.

Apart from missing icons (and it is not the merit of this commit
set), the menus in the GTK3 port do look and behave (e.g. may be
tear-off'ed) the same way as those in the GTK2 port.

Another innovation in `lepton-schematic` related to GTK3 is
creating a `GtkApplication` structure when starting the program.
This is the way GTK people recommend to build GTK (3 and 4) apps
these days, and I find it a bit more convenient than our current
approach --- dealing with every program window separately.



