### PR TITLE
Get rid of geda.scm

### DIFF
--- a/liblepton/lib/system-gafrc
+++ b/liblepton/lib/system-gafrc
@@ -3,6 +3,9 @@
 ;;; Common init file for gaf
 ;;;
 
+(use-modules (lepton library)
+             (lepton log-rotate))
+
 ; The following global variables are defined by libgeda:
 ;
 ; path-sep       -- system path separator
@@ -15,9 +18,9 @@
 (debug-enable 'backtrace)
 (read-enable 'positions)
 
-; The libgeda Scheme library provides a number of useful functions for
-; writing Scheme code for embedding in gaf.
-(load-from-path "geda.scm")
+; Clean up logfiles:
+;
+(cleanup-old-logs!)
 
 ;; Import deprecated Scheme functions
 (load-from-path "geda-deprecated-config.scm")

--- a/liblepton/scheme/Makefile.am
+++ b/liblepton/scheme/Makefile.am
@@ -2,7 +2,6 @@ scmdatadir = $(LEPTONDATADIR)/scheme
 godir = $(LEPTONDATADIR)/ccache
 
 nobase_dist_scmdata_DATA = \
-	geda.scm \
 	geda-deprecated-config.scm \
 	color-map.scm \
 	geda/object.scm \

--- a/liblepton/scheme/geda.scm
+++ b/liblepton/scheme/geda.scm
@@ -1,7 +1,0 @@
-; -*-Scheme-*-
-(use-modules (lepton library))
-
-; Clean up logfiles:
-;
-(use-modules (lepton log-rotate))
-(cleanup-old-logs!)


### PR DESCRIPTION
Inline the contents of the file into `system-gafrc`.

The file did nothing but running log rotation which, IMO, suites well for the `system-gafrc` config file in which the system administrator can disable/re-enable it.

Removing the file a little bit reduces the compilation time during the first run of `lepton-schematic` or any other Lepton tool.