### PR TITLE
Disable GTK3 smooth scrolling if mouse pointer warping is enabled.

### DIFF
--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -250,16 +250,24 @@ void x_window_setup_draw_events_drawing_area (GschemToplevel* w_current,
                          GDK_EXPOSURE_MASK |
                          GDK_POINTER_MOTION_MASK |
                          GDK_BUTTON_PRESS_MASK   |
-#if GTK_CHECK_VERSION(3,4,0)
-                         GDK_SMOOTH_SCROLL_MASK |
-#endif
                          GDK_ENTER_NOTIFY_MASK |
                          GDK_KEY_PRESS_MASK |
-                         GDK_BUTTON_RELEASE_MASK
+                         GDK_BUTTON_RELEASE_MASK);
+
 #ifdef ENABLE_GTK3
-                         | GDK_SCROLL_MASK
+  gint events;
+
+  if (w_current->warp_cursor)
+  {
+    events = GDK_SCROLL_MASK;
+  }
+  else
+  {
+    events = GDK_SMOOTH_SCROLL_MASK | GDK_SCROLL_MASK;
+  }
+
+  gtk_widget_add_events (GTK_WIDGET (drawing_area), events);
 #endif
-                         );
 
   struct event_reg_t* tmp = NULL;
 


### PR DESCRIPTION
The function `gdk_device_warp()` seems to be incompatible with the smooth scroll events on zooming.  When it is used, event *delta*s (`delta_x`, `delta_y`) are set to zero if the function `gdk_device_warp()` function is called.  Along with the only possible event direction `GDK_SCROLL_SMOOTH` (all others, `GDK_SCROLL_UP`, `DOWN`, `LEFT`, and `RIGHT` are not working in this case) it makes impossible to choose correct direction for zooming. Either `delta_y` should be positive or negative, not zero, or one of `GDK_SCROLL_UP` or `GDK_SCROLL_DOWN` should be set in order to choose the correct zooming direction.  The issue has been fixed by disabling smooth events if the mouse cursor warping is enabled in configuration.

First discussed in #915 
Closes #918