### PR TITLE
Simplify GObject implementation in lepton-schematic

### DIFF
--- a/libleptongui/src/gschem_bin.c
+++ b/libleptongui/src/gschem_bin.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2015 gEDA Contributors
- * Copyright (C) 2017-2020 Lepton EDA Contributors
+ * Copyright (C) 2017-2022 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -28,12 +28,17 @@
  */
 
 #include <config.h>
-
 #include "gschem.h"
 
 
+G_DEFINE_TYPE(GschemBin, gschem_bin, GTK_TYPE_BIN);
+
+
 static void
-class_init (GschemBinClass *klass);
+gschem_bin_class_init (GschemBinClass *klass);
+
+static void
+gschem_bin_init (GschemBin *klass);
 
 static void
 size_allocate (GtkWidget *widget, GtkAllocation *allocation);
@@ -43,35 +48,6 @@ static void
 size_request (GtkWidget *widget, GtkRequisition *requisition);
 #endif
 
-
-/*! \brief register/get class
- */
-GType
-gschem_bin_get_type ()
-{
-  static GType type = 0;
-
-  if (type == 0) {
-    static const GTypeInfo info = {
-      sizeof(GschemBinClass),
-      NULL,                                 /* base_init */
-      NULL,                                 /* base_finalize */
-      (GClassInitFunc) class_init,
-      NULL,                                 /* class_finalize */
-      NULL,                                 /* class_data */
-      sizeof(GschemBin),
-      0,                                    /* n_preallocs */
-      NULL,
-    };
-
-    type = g_type_register_static (GTK_TYPE_BIN,
-                                   "GschemBin",
-                                   &info,
-                                   (GTypeFlags) 0);
-  }
-
-  return type;
-}
 
 
 /*! \brief create a new status log widget
@@ -125,7 +101,7 @@ lepton_bin_get_preferred_height (GtkWidget *widget,
 /*! \brief initialize class
  */
 static void
-class_init (GschemBinClass *klass)
+gschem_bin_class_init (GschemBinClass *klass)
 {
   GtkWidgetClass *widget_klass = GTK_WIDGET_CLASS (klass);
 
@@ -140,6 +116,10 @@ class_init (GschemBinClass *klass)
 #endif
 }
 
+static void
+gschem_bin_init (GschemBin *klass)
+{
+}
 
 /*! \private
  *  \brief forward size allocation to child

--- a/libleptongui/src/gschem_binding.c
+++ b/libleptongui/src/gschem_binding.c
@@ -1,6 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 2014 Ales Hvezda
- * Copyright (C) 2014 gEDA Contributors (see ChangeLog for details)
+ * Copyright (C) 2014 gEDA Contributors
+ * Copyright (C) 2022 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -36,8 +37,11 @@ enum
 
 
 
+G_DEFINE_TYPE(GschemBinding, gschem_binding, G_TYPE_OBJECT);
+
+
 static void
-class_init (GschemBindingClass *klass);
+gschem_binding_class_init (GschemBindingClass *klass);
 
 static void
 get_property (GObject    *object,
@@ -46,7 +50,7 @@ get_property (GObject    *object,
               GParamSpec *pspec);
 
 static void
-instance_init (GschemBinding *binding);
+gschem_binding_init (GschemBinding *binding);
 
 static void
 set_property (GObject      *object,
@@ -66,37 +70,6 @@ update_widget (GschemBinding *binding);
 //gschem_binding_get_model_object (GschemBinding *binding)
 //{
 //}
-
-
-
-/*! \brief Get/register GschemBinding type.
- */
-GType
-gschem_binding_get_type()
-{
-  static GType type = 0;
-
-  if (type == 0) {
-    static const GTypeInfo info = {
-      sizeof(GschemBindingClass),
-      NULL,                                         /* base_init */
-      NULL,                                         /* base_finalize */
-      (GClassInitFunc) class_init,
-      NULL,                                         /* class_finalize */
-      NULL,                                         /* class_data */
-      sizeof(GschemBinding),
-      0,                                            /* n_preallocs */
-      (GInstanceInitFunc) instance_init,
-    };
-
-    type = g_type_register_static (G_TYPE_OBJECT,
-                                   "GschemBinding",
-                                   &info,
-                                   (GTypeFlags) 0);
-  }
-
-  return type;
-}
 
 
 
@@ -157,7 +130,7 @@ gschem_binding_update_widget (GschemBinding *binding)
  *  \param [in,out] klass The GschemBindingClass class
  */
 static void
-class_init (GschemBindingClass *klass)
+gschem_binding_class_init (GschemBindingClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
 
@@ -194,7 +167,7 @@ class_init (GschemBindingClass *klass)
  *  \param [in,out] binding The GschemBinding
  */
 static void
-instance_init (GschemBinding *binding)
+gschem_binding_init (GschemBinding *binding)
 {
 }
 

--- a/libleptongui/src/gschem_binding_integer.c
+++ b/libleptongui/src/gschem_binding_integer.c
@@ -1,6 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 2014 Ales Hvezda
- * Copyright (C) 2014 gEDA Contributors (see ChangeLog for details)
+ * Copyright (C) 2014 gEDA Contributors
+ * Copyright (C) 2022 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -37,8 +38,11 @@ enum
 
 
 
+G_DEFINE_TYPE(GschemBindingInteger, gschem_binding_integer, GSCHEM_TYPE_BINDING);
+
+
 static void
-class_init (GschemBindingIntegerClass *klass);
+gschem_binding_integer_class_init (GschemBindingIntegerClass *klass);
 
 static void
 get_property (GObject    *object,
@@ -47,7 +51,7 @@ get_property (GObject    *object,
               GParamSpec *pspec);
 
 static void
-instance_init (GschemBindingInteger *swatch);
+gschem_binding_integer_init (GschemBindingInteger *swatch);
 
 static void
 model_notify (GObject *object, GParamSpec *pspec, GschemBindingInteger *binding);
@@ -75,37 +79,6 @@ widget_apply (GtkWidget *widget, GschemBindingInteger *binding);
 
 
 
-/*! \brief Get/register GschemBindingInteger type.
- */
-GType
-gschem_binding_integer_get_type()
-{
-  static GType type = 0;
-
-  if (type == 0) {
-    static const GTypeInfo info = {
-      sizeof(GschemBindingIntegerClass),
-      NULL,                                         /* base_init */
-      NULL,                                         /* base_finalize */
-      (GClassInitFunc) class_init,
-      NULL,                                         /* class_finalize */
-      NULL,                                         /* class_data */
-      sizeof(GschemBindingInteger),
-      0,                                            /* n_preallocs */
-      (GInstanceInitFunc) instance_init,
-    };
-
-    type = g_type_register_static (GSCHEM_TYPE_BINDING,
-                                   "GschemBindingInteger",
-                                   &info,
-                                   (GTypeFlags) 0);
-  }
-
-  return type;
-}
-
-
-
 /*! \brief Create a new GschemFillSwatchCellRenderer
  *
  *  \return The new cell renderer
@@ -127,7 +100,7 @@ gschem_binding_integer_new (const gchar *param_name, GtkWidget *widget)
  *  \param [in,out] klass The swatch cell renderer class
  */
 static void
-class_init (GschemBindingIntegerClass *klass)
+gschem_binding_integer_class_init (GschemBindingIntegerClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
 
@@ -162,7 +135,7 @@ class_init (GschemBindingIntegerClass *klass)
  *  \param [in,out] renderer The fill swatch cell renderer
  */
 static void
-instance_init (GschemBindingInteger *binding)
+gschem_binding_integer_init (GschemBindingInteger *binding)
 {
 }
 

--- a/libleptongui/src/gschem_close_confirmation_dialog.c
+++ b/libleptongui/src/gschem_close_confirmation_dialog.c
@@ -64,7 +64,7 @@ enum {
 };
 
 
-static gpointer close_confirmation_dialog_parent_class = NULL;
+G_DEFINE_TYPE (CloseConfirmationDialog, close_confirmation_dialog, GTK_TYPE_DIALOG);
 
 
 static void close_confirmation_dialog_class_init (CloseConfirmationDialogClass *klass);
@@ -85,40 +85,10 @@ GList *close_confirmation_dialog_get_selected_pages (CloseConfirmationDialog *di
 
 
 
-GType
-close_confirmation_dialog_get_type ()
-{
-  static GType close_confirmation_dialog_type = 0;
-
-  if (!close_confirmation_dialog_type) {
-    static const GTypeInfo close_confirmation_dialog_info = {
-      sizeof(CloseConfirmationDialogClass),
-      NULL, /* base_init */
-      NULL, /* base_finalize */
-      (GClassInitFunc) close_confirmation_dialog_class_init,
-      NULL, /* class_finalize */
-      NULL, /* class_data */
-      sizeof(CloseConfirmationDialog),
-      0,    /* n_preallocs */
-      (GInstanceInitFunc) close_confirmation_dialog_init,
-    };
-
-    close_confirmation_dialog_type =
-      g_type_register_static (GTK_TYPE_DIALOG,
-                              "CloseConfirmationDialog",
-                              &close_confirmation_dialog_info,
-                              (GTypeFlags) 0);
-  }
-
-  return close_confirmation_dialog_type;
-}
-
 static void
 close_confirmation_dialog_class_init (CloseConfirmationDialogClass *klass)
 {
   GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
-
-  close_confirmation_dialog_parent_class = g_type_class_peek_parent (klass);
 
   gobject_class->constructor  = close_confirmation_dialog_constructor;
   gobject_class->set_property = close_confirmation_dialog_set_property;

--- a/libleptongui/src/gschem_fill_swatch_cell_renderer.c
+++ b/libleptongui/src/gschem_fill_swatch_cell_renderer.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 2013 Ales Hvezda
  * Copyright (C) 2013-2016 gEDA Contributors
- * Copyright (C) 2017-2021 Lepton EDA Contributors
+ * Copyright (C) 2017-2022 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -52,8 +52,13 @@ enum
 
 
 
+G_DEFINE_TYPE (GschemFillSwatchCellRenderer,
+               gschem_fill_swatch_cell_renderer,
+               GTK_TYPE_CELL_RENDERER_TEXT);
+
+
 static void
-class_init (GschemFillSwatchCellRendererClass *klass);
+gschem_fill_swatch_cell_renderer_class_init (GschemFillSwatchCellRendererClass *klass);
 
 static void
 get_property (GObject    *object,
@@ -62,7 +67,7 @@ get_property (GObject    *object,
               GParamSpec *pspec);
 
 static void
-instance_init (GschemFillSwatchCellRenderer *swatch);
+gschem_fill_swatch_cell_renderer_init (GschemFillSwatchCellRenderer *swatch);
 
 #ifdef ENABLE_GTK3
 static void
@@ -91,37 +96,6 @@ set_property (GObject      *object,
 
 
 
-/*! \brief Get/register GschemFillSwatchCellRenderer type.
- */
-GType
-gschem_fill_swatch_cell_renderer_get_type ()
-{
-  static GType type = 0;
-
-  if (type == 0) {
-    static const GTypeInfo info = {
-      sizeof (GschemFillSwatchCellRendererClass),
-      NULL,                                         /* base_init */
-      NULL,                                         /* base_finalize */
-      (GClassInitFunc) class_init,
-      NULL,                                         /* class_finalize */
-      NULL,                                         /* class_data */
-      sizeof (GschemFillSwatchCellRenderer),
-      0,                                            /* n_preallocs */
-      (GInstanceInitFunc) instance_init,
-    };
-
-    type = g_type_register_static (GTK_TYPE_CELL_RENDERER_TEXT,
-                                   "GschemFillSwatchCellRenderer",
-                                   &info,
-                                   (GTypeFlags) 0);
-  }
-
-  return type;
-}
-
-
-
 /*! \brief Create a new GschemFillSwatchCellRenderer
  *
  *  \return The new cell renderer
@@ -140,7 +114,7 @@ gschem_fill_swatch_cell_renderer_new ()
  *  \param [in,out] klass The swatch cell renderer class
  */
 static void
-class_init (GschemFillSwatchCellRendererClass *klass)
+gschem_fill_swatch_cell_renderer_class_init (GschemFillSwatchCellRendererClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
 
@@ -176,7 +150,7 @@ class_init (GschemFillSwatchCellRendererClass *klass)
  *  \param [in,out] renderer The fill swatch cell renderer
  */
 static void
-instance_init (GschemFillSwatchCellRenderer *swatch)
+gschem_fill_swatch_cell_renderer_init (GschemFillSwatchCellRenderer *swatch)
 {
   swatch->enabled = TRUE;
   swatch->fill_type = FILLING_HOLLOW;

--- a/libleptongui/src/gschem_find_text_widget.c
+++ b/libleptongui/src/gschem_find_text_widget.c
@@ -24,18 +24,6 @@
  */
 
 #include <config.h>
-
-#include <stdio.h>
-#ifdef HAVE_STDLIB_H
-#include <stdlib.h>
-#endif
-#ifdef HAVE_STRING_H
-#include <string.h>
-#endif
-#ifdef HAVE_MATH_H
-#include <math.h>
-#endif
-
 #include "gschem.h"
 
 

--- a/libleptongui/src/gschem_find_text_widget.c
+++ b/libleptongui/src/gschem_find_text_widget.c
@@ -99,7 +99,9 @@ notify_entry_text (GtkWidget *entry, GParamSpec *pspec, GschemFindTextWidget *wi
 
 
 
-static GObjectClass *gschem_find_text_widget_parent_class = NULL;
+G_DEFINE_TYPE (GschemFindTextWidget,
+               gschem_find_text_widget,
+               GTK_TYPE_INFO_BAR);
 
 
 
@@ -170,8 +172,9 @@ dispose (GObject *object)
 {
   /* lastly, chain up to the parent dispose */
 
-  g_return_if_fail (gschem_find_text_widget_parent_class != NULL);
-  gschem_find_text_widget_parent_class->dispose (object);
+  GschemFindTextWidgetClass* cls = GSCHEM_FIND_TEXT_WIDGET_GET_CLASS (object);
+  GObjectClass* parent_cls = (GObjectClass*) g_type_class_peek_parent (cls);
+  parent_cls->dispose (object);
 }
 
 
@@ -183,8 +186,9 @@ finalize (GObject *object)
 {
   /* lastly, chain up to the parent finalize */
 
-  g_return_if_fail (gschem_find_text_widget_parent_class != NULL);
-  gschem_find_text_widget_parent_class->finalize (object);
+  GschemFindTextWidgetClass* cls = GSCHEM_FIND_TEXT_WIDGET_GET_CLASS (object);
+  GObjectClass* parent_cls = (GObjectClass*) g_type_class_peek_parent (cls);
+  parent_cls->finalize (object);
 }
 
 
@@ -254,8 +258,6 @@ get_property (GObject *object, guint param_id, GValue *value, GParamSpec *pspec)
 static void
 gschem_find_text_widget_class_init (GschemFindTextWidgetClass *klass)
 {
-  gschem_find_text_widget_parent_class = G_OBJECT_CLASS (g_type_class_peek_parent (klass));
-
   G_OBJECT_CLASS (klass)->dispose  = dispose;
   G_OBJECT_CLASS (klass)->finalize = finalize;
 
@@ -360,37 +362,6 @@ gschem_find_text_widget_get_find_text_string (GschemFindTextWidget *widget)
   g_return_val_if_fail (widget != NULL, NULL);
 
   return gtk_entry_get_text (GTK_ENTRY (widget->entry));
-}
-
-
-
-/*! \brief Get/register GschemFindTextWidget type.
- */
-GType
-gschem_find_text_widget_get_type ()
-{
-  static GType type = 0;
-
-  if (type == 0) {
-    static const GTypeInfo info = {
-      sizeof(GschemFindTextWidgetClass),
-      NULL,                                                    /* base_init */
-      NULL,                                                    /* base_finalize */
-      (GClassInitFunc) gschem_find_text_widget_class_init,
-      NULL,                                                    /* class_finalize */
-      NULL,                                                    /* class_data */
-      sizeof(GschemFindTextWidget),
-      0,                                                       /* n_preallocs */
-      (GInstanceInitFunc) gschem_find_text_widget_init,
-    };
-
-    type = g_type_register_static (GTK_TYPE_INFO_BAR,
-                                   "GschemFindTextWidget",
-                                   &info,
-                                   (GTypeFlags) 0);
-  }
-
-  return type;
 }
 
 

--- a/libleptongui/src/gschem_integer_combo_box.c
+++ b/libleptongui/src/gschem_integer_combo_box.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2015 gEDA Contributors
- * Copyright (C) 2017-2020 Lepton EDA Contributors
+ * Copyright (C) 2017-2022 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -39,6 +39,17 @@
 
 #include "gschem.h"
 
+
+
+#if GTK_CHECK_VERSION (2, 24, 0)
+G_DEFINE_TYPE (GschemIntegerComboBox,
+               gschem_integer_combo_box,
+               GTK_TYPE_COMBO_BOX);
+#else
+G_DEFINE_TYPE (GschemIntegerComboBox,
+               gschem_integer_combo_box,
+               GTK_TYPE_COMBO_BOX_ENTRY);
+#endif
 
 
 static void
@@ -130,42 +141,6 @@ gschem_integer_combo_box_class_init (GschemIntegerComboBoxClass *klass)
                 );
 }
 
-
-
-/*! \brief Get the GschemIntegerComboBox type
- *
- *  \return The GschemIntegerComboBox type
- */
-GType
-gschem_integer_combo_box_get_type()
-{
-  static GType type = 0;
-
-  if (type == 0) {
-    static const GTypeInfo info = {
-      sizeof(GschemIntegerComboBoxClass),
-      NULL,                                                    /* base_init */
-      NULL,                                                    /* base_finalize */
-      (GClassInitFunc) gschem_integer_combo_box_class_init,
-      NULL,                                                    /* class_finalize */
-      NULL,                                                    /* class_data */
-      sizeof(GschemIntegerComboBox),
-      0,                                                       /* n_preallocs */
-      (GInstanceInitFunc) gschem_integer_combo_box_init,
-    };
-
-#if GTK_CHECK_VERSION (2, 24, 0)
-    type = g_type_register_static (GTK_TYPE_COMBO_BOX,
-                                   "GschemIntegerComboBox",
-                                   &info,
-                                   (GTypeFlags) 0);
-#else
-    type = g_type_register_static (GTK_TYPE_COMBO_BOX_ENTRY, "GschemIntegerComboBox", &info, 0);
-#endif
-  }
-
-  return type;
-}
 
 
 /*! \brief Get the entry associated with this combo box

--- a/libleptongui/src/gschem_integer_combo_box.c
+++ b/libleptongui/src/gschem_integer_combo_box.c
@@ -25,18 +25,12 @@
  *  integer value from a drop down menu.
  */
 #include <config.h>
-
 #ifdef HAVE_ERRNO_H
 #include <errno.h>
 #endif
-#include <stdio.h>
 #ifdef HAVE_STDLIB_H
 #include <stdlib.h>
 #endif
-#ifdef HAVE_STRING_H
-#include <string.h>
-#endif
-
 #include "gschem.h"
 
 

--- a/libleptongui/src/gschem_main_window.c
+++ b/libleptongui/src/gschem_main_window.c
@@ -1,6 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
- * Copyright (C) 1998-2010 gEDA Contributors (see ChangeLog for details)
+ * Copyright (C) 1998-2010 gEDA Contributors
+ * Copyright (C) 2022 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -30,36 +31,10 @@ G_DEFINE_TYPE(GschemMainWindow, gschem_main_window, GTK_TYPE_WINDOW);
 
 
 static void
-get_property (GObject *object, guint param_id, GValue *value, GParamSpec *pspec);
-
-static void
 gschem_main_window_class_init (GschemMainWindowClass *klass);
 
 static void
 gschem_main_window_init (GschemMainWindow *window);
-
-static void
-set_property (GObject *object, guint param_id, const GValue *value, GParamSpec *pspec);
-
-
-
-/*! \brief Get a property
- *
- *  \param [in]     object
- *  \param [in]     param_id
- *  \param [in,out] value
- *  \param [in]     pspec
- */
-static void
-get_property (GObject *object, guint param_id, GValue *value, GParamSpec *pspec)
-{
-  //GschemMainWindow *window = GSCHEM_MAIN_WINDOW (object);
-
-  switch (param_id) {
-    default:
-      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, param_id, pspec);
-  }
-}
 
 
 
@@ -70,15 +45,13 @@ get_property (GObject *object, guint param_id, GValue *value, GParamSpec *pspec)
 static void
 gschem_main_window_class_init (GschemMainWindowClass *klass)
 {
-  G_OBJECT_CLASS (klass)->get_property = get_property;
-  G_OBJECT_CLASS (klass)->set_property = set_property;
 }
 
 
 
-/*! \brief Initialize GschemSelection instance
+/*! \brief Initialize GschemMainWindow instance
  *
- *  \param [in,out] selection
+ *  \param [in,out] GschemMainWindow object
  */
 static void
 gschem_main_window_init (GschemMainWindow *window)
@@ -87,7 +60,7 @@ gschem_main_window_init (GschemMainWindow *window)
 
 
 
-/*! \brief Create a new instanceof the GschemMainWindow
+/*! \brief Create a new instance of the GschemMainWindow
  *
  *  \return A new instanceof the GschemMainWindow
  */
@@ -97,24 +70,4 @@ gschem_main_window_new ()
   return GSCHEM_MAIN_WINDOW (g_object_new (GSCHEM_TYPE_MAIN_WINDOW,
                                            "type", GTK_WINDOW_TOPLEVEL,
                                            NULL));
-}
-
-
-
-/*! \brief Set a property
- *
- *  \param [in,out] object
- *  \param [in]     param_id
- *  \param [in]     value
- *  \param [in]     pspec
- */
-static void
-set_property (GObject *object, guint param_id, const GValue *value, GParamSpec *pspec)
-{
-  //GschemMainWindow *window = GSCHEM_MAIN_WINDOW (object);
-
-  switch (param_id) {
-    default:
-      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, param_id, pspec);
-  }
 }

--- a/libleptongui/src/gschem_main_window.c
+++ b/libleptongui/src/gschem_main_window.c
@@ -35,6 +35,10 @@
 #include "gschem.h"
 #include <gdk/gdkkeysyms.h>
 
+
+G_DEFINE_TYPE(GschemMainWindow, gschem_main_window, GTK_TYPE_WINDOW);
+
+
 static void
 get_property (GObject *object, guint param_id, GValue *value, GParamSpec *pspec);
 
@@ -78,37 +82,6 @@ gschem_main_window_class_init (GschemMainWindowClass *klass)
 {
   G_OBJECT_CLASS (klass)->get_property = get_property;
   G_OBJECT_CLASS (klass)->set_property = set_property;
-}
-
-
-
-/*! \brief Get/register GschemSelection type.
- */
-GType
-gschem_main_window_get_type ()
-{
-  static GType type = 0;
-
-  if (type == 0) {
-    static const GTypeInfo info = {
-      sizeof(GschemMainWindowClass),
-      NULL,                                                    /* base_init */
-      NULL,                                                    /* base_finalize */
-      (GClassInitFunc) gschem_main_window_class_init,
-      NULL,                                                    /* class_finalize */
-      NULL,                                                    /* class_data */
-      sizeof(GschemMainWindow),
-      0,                                                       /* n_preallocs */
-      (GInstanceInitFunc) gschem_main_window_init,
-    };
-
-    type = g_type_register_static (GTK_TYPE_WINDOW,
-                                   "GschemMainWindow",
-                                   &info,
-                                   (GTypeFlags) 0);
-  }
-
-  return type;
 }
 
 

--- a/libleptongui/src/gschem_main_window.c
+++ b/libleptongui/src/gschem_main_window.c
@@ -23,17 +23,7 @@
  */
 
 #include <config.h>
-
-#include <stdio.h>
-#ifdef HAVE_STDLIB_H
-#include <stdlib.h>
-#endif
-#ifdef HAVE_STRING_H
-#include <string.h>
-#endif
-
 #include "gschem.h"
-#include <gdk/gdkkeysyms.h>
 
 
 G_DEFINE_TYPE(GschemMainWindow, gschem_main_window, GTK_TYPE_WINDOW);

--- a/libleptongui/src/gschem_options.c
+++ b/libleptongui/src/gschem_options.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2014 gEDA Contributors
- * Copyright (C) 2017-2020 Lepton EDA Contributors
+ * Copyright (C) 2017-2022 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -51,14 +51,17 @@ enum
 
 
 
+G_DEFINE_TYPE (GschemOptions, gschem_options, G_TYPE_OBJECT);
+
+
 static void
-class_init (GschemOptionsClass *klass);
+gschem_options_class_init (GschemOptionsClass *klass);
 
 static void
 get_property (GObject *object, guint param_id, GValue *value, GParamSpec *pspec);
 
 static void
-instance_init (GschemOptions *adapter);
+gschem_options_init (GschemOptions *adapter);
 
 static void
 set_property (GObject *object, guint param_id, const GValue *value, GParamSpec *pspec);
@@ -209,37 +212,6 @@ gschem_options_get_snap_size (GschemOptions *options)
   g_return_val_if_fail (options != NULL, DEFAULT_SNAP_SIZE);
 
   return options->snap_size;
-}
-
-
-
-/*! \brief Get/register GschemSelection type.
- */
-GType
-gschem_options_get_type ()
-{
-  static GType type = 0;
-
-  if (type == 0) {
-    static const GTypeInfo info = {
-      sizeof(GschemOptionsClass),
-      NULL,                                  /* base_init */
-      NULL,                                  /* base_finalize */
-      (GClassInitFunc) class_init,
-      NULL,                                  /* class_finalize */
-      NULL,                                  /* class_data */
-      sizeof(GschemOptions),
-      0,                                     /* n_preallocs */
-      (GInstanceInitFunc) instance_init,
-    };
-
-    type = g_type_register_static (G_TYPE_OBJECT,
-                                   "GschemOptions",
-                                   &info,
-                                   (GTypeFlags) 0);
-  }
-
-  return type;
 }
 
 
@@ -400,7 +372,7 @@ gschem_options_set_snap_size (GschemOptions *options, int snap_size)
  *  \param [in] klass The class for the gschem options
  */
 static void
-class_init (GschemOptionsClass *klass)
+gschem_options_class_init (GschemOptionsClass *klass)
 {
   G_OBJECT_CLASS (klass)->get_property = get_property;
   G_OBJECT_CLASS (klass)->set_property = set_property;
@@ -510,7 +482,7 @@ get_property (GObject *object, guint param_id, GValue *value, GParamSpec *pspec)
  *  \param [in,out] selection
  */
 static void
-instance_init (GschemOptions *options)
+gschem_options_init (GschemOptions *options)
 {
 }
 

--- a/libleptongui/src/gschem_selection_adapter.c
+++ b/libleptongui/src/gschem_selection_adapter.c
@@ -24,17 +24,7 @@
  */
 
 #include <config.h>
-
-#include <stdio.h>
-#ifdef HAVE_STDLIB_H
-#include <stdlib.h>
-#endif
-#ifdef HAVE_STRING_H
-#include <string.h>
-#endif
-
 #include "gschem.h"
-#include <gdk/gdkkeysyms.h>
 
 /*! \private
  */

--- a/libleptongui/src/gschem_selection_adapter.c
+++ b/libleptongui/src/gschem_selection_adapter.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2016 gEDA Contributors
- * Copyright (C) 2017-2021 Lepton EDA Contributors
+ * Copyright (C) 2017-2022 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -63,8 +63,13 @@ enum
 
 
 
+G_DEFINE_TYPE (GschemSelectionAdapter,
+               gschem_selection_adapter,
+               G_TYPE_OBJECT);
+
+
 static void
-class_init (GschemSelectionAdapterClass *klass);
+gschem_selection_adapter_class_init (GschemSelectionAdapterClass *klass);
 
 static GList*
 get_selection_iter (GschemSelectionAdapter *adapter);
@@ -73,7 +78,7 @@ static void
 get_property (GObject *object, guint param_id, GValue *value, GParamSpec *pspec);
 
 static void
-instance_init (GschemSelectionAdapter *adapter);
+gschem_selection_adapter_init (GschemSelectionAdapter *adapter);
 
 static void
 selection_changed (LeptonList *selection,
@@ -946,37 +951,6 @@ gschem_selection_adapter_get_toplevel (GschemSelectionAdapter *adapter)
   g_return_val_if_fail (adapter != NULL, NULL);
 
   return adapter->toplevel;
-}
-
-
-
-/*! \brief Get/register GschemSelection type.
- */
-GType
-gschem_selection_adapter_get_type ()
-{
-  static GType type = 0;
-
-  if (type == 0) {
-    static const GTypeInfo info = {
-      sizeof(GschemSelectionAdapterClass),
-      NULL,                                  /* base_init */
-      NULL,                                  /* base_finalize */
-      (GClassInitFunc) class_init,
-      NULL,                                  /* class_finalize */
-      NULL,                                  /* class_data */
-      sizeof(GschemSelectionAdapter),
-      0,                                     /* n_preallocs */
-      (GInstanceInitFunc) instance_init,
-    };
-
-    type = g_type_register_static (G_TYPE_OBJECT,
-                                   "GschemSelectionAdapter",
-                                   &info,
-                                   (GTypeFlags) 0);
-  }
-
-  return type;
 }
 
 
@@ -1956,7 +1930,7 @@ gschem_selection_adapter_set_toplevel (GschemSelectionAdapter *adapter,
  *  \param [in] klass The class for the GschemSelectionAdapter
  */
 static void
-class_init (GschemSelectionAdapterClass *klass)
+gschem_selection_adapter_class_init (GschemSelectionAdapterClass *klass)
 {
   G_OBJECT_CLASS (klass)->get_property = get_property;
   G_OBJECT_CLASS (klass)->set_property = set_property;
@@ -2293,7 +2267,7 @@ get_property (GObject *object, guint param_id, GValue *value, GParamSpec *pspec)
  *  \param [in,out] selection
  */
 static void
-instance_init (GschemSelectionAdapter *adapter)
+gschem_selection_adapter_init (GschemSelectionAdapter *adapter)
 {
 }
 

--- a/libleptongui/src/gschem_show_hide_text_widget.c
+++ b/libleptongui/src/gschem_show_hide_text_widget.c
@@ -44,6 +44,11 @@ enum
 };
 
 
+G_DEFINE_TYPE (GschemShowHideTextWidget,
+               gschem_show_hide_text_widget,
+               GTK_TYPE_INFO_BAR);
+
+
 static void
 activate_entry (GtkWidget *entry, GschemShowHideTextWidget *widget);
 
@@ -74,8 +79,6 @@ set_property (GObject *object, guint param_id, const GValue *value, GParamSpec *
 static void
 notify_entry_text (GtkWidget *entry, GParamSpec *pspec, GschemShowHideTextWidget *widget);
 
-
-static GObjectClass *gschem_show_hide_text_widget_parent_class = NULL;
 
 
 /*! \brief Show the hide text widget
@@ -135,8 +138,6 @@ void show_text_dialog (GschemToplevel *w_current)
 static void
 gschem_show_hide_text_widget_class_init (GschemShowHideTextWidgetClass *klass)
 {
-  gschem_show_hide_text_widget_parent_class = G_OBJECT_CLASS (g_type_class_peek_parent (klass));
-
   G_OBJECT_CLASS (klass)->dispose  = dispose;
   G_OBJECT_CLASS (klass)->finalize = finalize;
 
@@ -227,37 +228,6 @@ gschem_show_hide_text_widget_get_text_string (GschemShowHideTextWidget *widget)
   g_return_val_if_fail (widget != NULL, NULL);
 
   return gtk_entry_get_text (GTK_ENTRY (widget->entry));
-}
-
-
-
-/*! \brief Get/register GschemShowHideTextWidget type.
- */
-GType
-gschem_show_hide_text_widget_get_type ()
-{
-  static GType type = 0;
-
-  if (type == 0) {
-    static const GTypeInfo info = {
-      sizeof(GschemShowHideTextWidgetClass),
-      NULL,                                                    /* base_init */
-      NULL,                                                    /* base_finalize */
-      (GClassInitFunc) gschem_show_hide_text_widget_class_init,
-      NULL,                                                    /* class_finalize */
-      NULL,                                                    /* class_data */
-      sizeof(GschemShowHideTextWidget),
-      0,                                                       /* n_preallocs */
-      (GInstanceInitFunc) gschem_show_hide_text_widget_init,
-    };
-
-    type = g_type_register_static (GTK_TYPE_INFO_BAR,
-                                   "GschemShowHideTextWidget",
-                                   &info,
-                                   (GTypeFlags) 0);
-  }
-
-  return type;
 }
 
 
@@ -428,8 +398,9 @@ dispose (GObject *object)
 {
   /* lastly, chain up to the parent dispose */
 
-  g_return_if_fail (gschem_show_hide_text_widget_parent_class != NULL);
-  gschem_show_hide_text_widget_parent_class->dispose (object);
+  GschemShowHideTextWidgetClass* cls = GSCHEM_SHOW_HIDE_TEXT_WIDGET_GET_CLASS (object);
+  GObjectClass* parent_cls = (GObjectClass*) g_type_class_peek_parent (cls);
+  parent_cls->dispose (object);
 }
 
 
@@ -441,8 +412,9 @@ finalize (GObject *object)
 {
   /* lastly, chain up to the parent finalize */
 
-  g_return_if_fail (gschem_show_hide_text_widget_parent_class != NULL);
-  gschem_show_hide_text_widget_parent_class->finalize (object);
+  GschemShowHideTextWidgetClass* cls = GSCHEM_SHOW_HIDE_TEXT_WIDGET_GET_CLASS (object);
+  GObjectClass* parent_cls = (GObjectClass*) g_type_class_peek_parent (cls);
+  parent_cls->finalize (object);
 }
 
 

--- a/libleptongui/src/gschem_show_hide_text_widget.c
+++ b/libleptongui/src/gschem_show_hide_text_widget.c
@@ -24,14 +24,6 @@
  */
 
 #include <config.h>
-
-#ifdef HAVE_STDLIB_H
-#include <stdlib.h>
-#endif
-#ifdef HAVE_STRING_H
-#include <string.h>
-#endif
-
 #include "gschem.h"
 
 

--- a/libleptongui/src/gschem_swatch_column_renderer.c
+++ b/libleptongui/src/gschem_swatch_column_renderer.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 2013 Ales Hvezda
  * Copyright (C) 2016 gEDA Contributors
- * Copyright (C) 2017-2021 Lepton EDA Contributors
+ * Copyright (C) 2017-2022 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -48,6 +48,11 @@ enum
   PROP_ENABLED
 };
 
+
+
+G_DEFINE_TYPE (GschemSwatchColumnRenderer,
+               gschem_swatch_column_renderer,
+               GTK_TYPE_CELL_RENDERER_TEXT);
 
 
 static void
@@ -134,7 +139,7 @@ get_property (GObject    *object,
  *  \param [in,out] klass The swatch cell renderer class
  */
 static void
-swatchcr_class_init (GschemSwatchColumnRendererClass *klass)
+gschem_swatch_column_renderer_class_init (GschemSwatchColumnRendererClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
 
@@ -170,7 +175,7 @@ swatchcr_class_init (GschemSwatchColumnRendererClass *klass)
  *  \param [in,out] swatch The swatch cell renderer
  */
 static void
-swatchcr_init (GschemSwatchColumnRenderer *swatch)
+gschem_swatch_column_renderer_init (GschemSwatchColumnRenderer *swatch)
 {
 #ifdef ENABLE_GTK3
   swatch->color.red = 0.0;
@@ -376,37 +381,6 @@ set_property (GObject      *object,
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, param_id, pspec);
       break;
   }
-}
-
-
-
-/*! \brief Get/register Swatchcr type.
- */
-GType
-gschem_swatch_column_renderer_get_type()
-{
-  static GType type = 0;
-
-  if (type == 0) {
-    static const GTypeInfo info = {
-      sizeof(GschemSwatchColumnRendererClass),
-      NULL,                                   /* base_init */
-      NULL,                                   /* base_finalize */
-      (GClassInitFunc) swatchcr_class_init,
-      NULL,                                   /* class_finalize */
-      NULL,                                   /* class_data */
-      sizeof(GschemSwatchColumnRenderer),
-      0,                                      /* n_preallocs */
-      (GInstanceInitFunc) swatchcr_init,
-    };
-
-    type = g_type_register_static (GTK_TYPE_CELL_RENDERER_TEXT,
-                                   "GschemSwatchColumnRenderer",
-                                   &info,
-                                   (GTypeFlags) 0);
-  }
-
-  return type;
 }
 
 

--- a/libleptongui/src/gschem_swatch_column_renderer.c
+++ b/libleptongui/src/gschem_swatch_column_renderer.c
@@ -24,15 +24,6 @@
  */
 
 #include <config.h>
-
-#include <stdio.h>
-#ifdef HAVE_STDLIB_H
-#include <stdlib.h>
-#endif
-#ifdef HAVE_STRING_H
-#include <string.h>
-#endif
-
 #include "gschem.h"
 
 

--- a/libleptongui/src/gschem_translate_widget.c
+++ b/libleptongui/src/gschem_translate_widget.c
@@ -43,11 +43,16 @@ enum
 };
 
 
+G_DEFINE_TYPE (GschemTranslateWidget,
+               gschem_translate_widget,
+               GTK_TYPE_INFO_BAR);
+
+
 static void
 activate_entry (GtkWidget *entry, GschemTranslateWidget *widget);
 
 static void
-class_init (GschemTranslateWidgetClass *klass);
+gschem_translate_widget_class_init (GschemTranslateWidgetClass *klass);
 
 static void
 click_cancel (GtkWidget *button, GschemTranslateWidget *widget);
@@ -68,7 +73,7 @@ static void
 get_property (GObject *object, guint param_id, GValue *value, GParamSpec *pspec);
 
 static void
-instance_init (GschemTranslateWidget *view);
+gschem_translate_widget_init (GschemTranslateWidget *view);
 
 static void
 set_property (GObject *object, guint param_id, const GValue *value, GParamSpec *pspec);
@@ -76,8 +81,6 @@ set_property (GObject *object, guint param_id, const GValue *value, GParamSpec *
 static void
 notify_entry_text (GtkWidget *entry, GParamSpec *pspec, GschemTranslateWidget *widget);
 
-
-static GObjectClass *gschem_translate_widget_parent_class = NULL;
 
 
 /*! \brief Get the entry
@@ -106,36 +109,6 @@ gschem_translate_widget_get_label_text (GschemTranslateWidget *widget)
   g_return_val_if_fail (widget != NULL, NULL);
 
   return gtk_label_get_text (GTK_LABEL (widget->label));
-}
-
-
-/*! \brief Get/register GschemTranslateWidget type.
- */
-GType
-gschem_translate_widget_get_type ()
-{
-  static GType type = 0;
-
-  if (type == 0) {
-    static const GTypeInfo info = {
-      sizeof(GschemTranslateWidgetClass),
-      NULL,                                  /* base_init */
-      NULL,                                  /* base_finalize */
-      (GClassInitFunc) class_init,
-      NULL,                                  /* class_finalize */
-      NULL,                                  /* class_data */
-      sizeof(GschemTranslateWidget),
-      0,                                     /* n_preallocs */
-      (GInstanceInitFunc) instance_init,
-    };
-
-    type = g_type_register_static (GTK_TYPE_INFO_BAR,
-                                   "GschemTranslateWidget",
-                                   &info,
-                                   (GTypeFlags) 0);
-  }
-
-  return type;
 }
 
 
@@ -221,10 +194,8 @@ activate_entry (GtkWidget *entry, GschemTranslateWidget *widget)
  *  \param [in] klass The class for the GschemTranslateWidget
  */
 static void
-class_init (GschemTranslateWidgetClass *klass)
+gschem_translate_widget_class_init (GschemTranslateWidgetClass *klass)
 {
-  gschem_translate_widget_parent_class = G_OBJECT_CLASS (g_type_class_peek_parent (klass));
-
   G_OBJECT_CLASS (klass)->dispose  = dispose;
   G_OBJECT_CLASS (klass)->finalize = finalize;
 
@@ -333,8 +304,9 @@ dispose (GObject *object)
 {
   /* lastly, chain up to the parent dispose */
 
-  g_return_if_fail (gschem_translate_widget_parent_class != NULL);
-  gschem_translate_widget_parent_class->dispose (object);
+  GschemTranslateWidgetClass* cls = GSCHEM_TRANSLATE_WIDGET_GET_CLASS (object);
+  GObjectClass* parent_cls = (GObjectClass*) g_type_class_peek_parent (cls);
+  parent_cls->dispose (object);
 }
 
 
@@ -346,8 +318,9 @@ finalize (GObject *object)
 {
   /* lastly, chain up to the parent finalize */
 
-  g_return_if_fail (gschem_translate_widget_parent_class != NULL);
-  gschem_translate_widget_parent_class->finalize (object);
+  GschemTranslateWidgetClass* cls = GSCHEM_TRANSLATE_WIDGET_GET_CLASS (object);
+  GObjectClass* parent_cls = (GObjectClass*) g_type_class_peek_parent (cls);
+  parent_cls->finalize (object);
 }
 
 
@@ -380,7 +353,7 @@ get_property (GObject *object, guint param_id, GValue *value, GParamSpec *pspec)
  *  \param [in,out] widget the GschemTranslateWidget
  */
 static void
-instance_init (GschemTranslateWidget *widget)
+gschem_translate_widget_init (GschemTranslateWidget *widget)
 {
   GtkWidget *action = gtk_info_bar_get_action_area (GTK_INFO_BAR (widget));
   GtkWidget *button_box;

--- a/libleptongui/src/x_compselect.c
+++ b/libleptongui/src/x_compselect.c
@@ -58,6 +58,9 @@ enum compselect_view {
 };
 
 
+G_DEFINE_TYPE (Compselect, compselect, GSCHEM_TYPE_DIALOG);
+
+
 /*! \brief Return currently active component-selector view
  *
  *  \par Function Description
@@ -268,10 +271,11 @@ enum {
   PROP_HIDDEN
 };
 
-static GObjectClass *compselect_parent_class = NULL;
-
 
 static void compselect_class_init      (CompselectClass *klass);
+static void compselect_init            (Compselect *compselect)
+{
+}
 static GObject *compselect_constructor (GType type,
                                         guint n_construct_properties,
                                         GObjectConstructParam *construct_params);
@@ -1330,33 +1334,6 @@ create_behaviors_combo_box (void)
   gtk_combo_box_set_active (GTK_COMBO_BOX (combobox), 0);
 
   return combobox;
-}
-
-GType
-compselect_get_type ()
-{
-  static GType compselect_type = 0;
-
-  if (!compselect_type) {
-    static const GTypeInfo compselect_info = {
-      sizeof (CompselectClass),
-      NULL, /* base_init */
-      NULL, /* base_finalize */
-      (GClassInitFunc) compselect_class_init,
-      NULL, /* class_finalize */
-      NULL, /* class_data */
-      sizeof (Compselect),
-      0,    /* n_preallocs */
-      NULL  /* instance_init */
-    };
-
-    compselect_type = g_type_register_static (GSCHEM_TYPE_DIALOG,
-                                              "Compselect",
-                                              &compselect_info,
-                                              (GTypeFlags) 0);
-  }
-
-  return compselect_type;
 }
 
 

--- a/libleptongui/src/x_multiattrib.c
+++ b/libleptongui/src/x_multiattrib.c
@@ -18,15 +18,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 #include <config.h>
-
-#include <stdio.h>
-#ifdef HAVE_STDLIB_H
-#include <stdlib.h>
-#endif
-#ifdef HAVE_STRING_H
-#include <string.h>
-#endif
-
 #include "gschem.h"
 #include "x_multiattrib.h"
 #include <gdk/gdkkeysyms.h>

--- a/libleptongui/src/x_multiattrib.c
+++ b/libleptongui/src/x_multiattrib.c
@@ -155,6 +155,19 @@ static void celltextview_class_init (CellTextViewClass *klass);
 static void celltextview_init       (CellTextView *self);
 static void celltextview_cell_editable_init (GtkCellEditableIface *iface);
 
+G_DEFINE_TYPE_EXTENDED
+(
+  CellTextView,
+  celltextview,
+  GTK_TYPE_TEXT_VIEW,
+  0,
+  G_IMPLEMENT_INTERFACE
+  (
+    GTK_TYPE_CELL_EDITABLE,
+    celltextview_cell_editable_init
+  )
+);
+
 enum {
     PROP_EDIT_CANCELED = 1
 };
@@ -244,47 +257,6 @@ celltextview_start_editing (GtkCellEditable *cell_editable,
  *  \par Function Description
  *
  */
-GType
-celltextview_get_type ()
-{
-  static GType celltextview_type = 0;
-
-  if (!celltextview_type) {
-    static const GTypeInfo celltextview_info = {
-      sizeof(CellTextViewClass),
-      NULL, /* base_init */
-      NULL, /* base_finalize */
-      (GClassInitFunc) celltextview_class_init,
-      NULL, /* class_finalize */
-      NULL, /* class_data */
-      sizeof(CellTextView),
-      0,    /* n_preallocs */
-      (GInstanceInitFunc) celltextview_init,
-    };
-
-    static const GInterfaceInfo cell_editable_info = {
-      (GInterfaceInitFunc) celltextview_cell_editable_init,
-      NULL, /* interface_finalize */
-      NULL  /* interface_data */
-    };
-
-    celltextview_type = g_type_register_static (GTK_TYPE_TEXT_VIEW,
-                                                "CellTextView",
-                                                &celltextview_info,
-                                                (GTypeFlags) 0);
-    g_type_add_interface_static (celltextview_type,
-                                 GTK_TYPE_CELL_EDITABLE,
-                                 &cell_editable_info);
-  }
-
-  return celltextview_type;
-}
-
-/*! \todo Finish function documentation
- *  \brief
- *  \par Function Description
- *
- */
 static void
 celltextview_class_init (CellTextViewClass *klass)
 {
@@ -330,7 +302,15 @@ celltextview_cell_editable_init (GtkCellEditableIface *iface)
  * in gschem code. It is inspired by the 'GtkCellRendererCombo' renderer
  * of GTK 2.4 (LGPL).
  */
+
+G_DEFINE_TYPE (CellRendererMultiLineText,
+               cellrenderermultilinetext,
+               GTK_TYPE_CELL_RENDERER_TEXT);
+
 static void cellrenderermultilinetext_class_init (CellRendererMultiLineTextClass *klass);
+static void cellrenderermultilinetext_init (CellRendererMultiLineText *obj)
+{
+}
 static void cellrenderermultilinetext_editing_done (GtkCellEditable *cell_editable,
                                                     gpointer         user_data);
 static gboolean cellrenderermultilinetext_focus_out_event (GtkWidget *widget,
@@ -482,39 +462,6 @@ cellrenderermultilinetext_focus_out_event (GtkWidget *widget,
  *  \par Function Description
  *
  */
-GType
-cellrenderermultilinetext_get_type ()
-{
-  static GType cellrenderermultilinetext_type = 0;
-
-  if (!cellrenderermultilinetext_type) {
-    static const GTypeInfo cellrenderermultilinetext_info = {
-      sizeof(CellRendererMultiLineTextClass),
-      NULL, /* base_init */
-      NULL, /* base_finalize */
-      (GClassInitFunc) cellrenderermultilinetext_class_init,
-      NULL, /* class_finalize */
-      NULL, /* class_data */
-      sizeof(CellRendererMultiLineText),
-      0,    /* n_preallocs */
-      NULL, /* instance_init */
-    };
-
-    cellrenderermultilinetext_type = g_type_register_static (
-      GTK_TYPE_CELL_RENDERER_TEXT,
-      "CellRendererMultiLineText",
-      &cellrenderermultilinetext_info,
-      (GTypeFlags) 0);
-  }
-
-  return cellrenderermultilinetext_type;
-}
-
-/*! \todo Finish function documentation
- *  \brief
- *  \par Function Description
- *
- */
 static void
 cellrenderermultilinetext_class_init (CellRendererMultiLineTextClass *klass)
 {
@@ -544,7 +491,9 @@ enum {
   NUM_COLUMNS
 };
 
-static GObjectClass *multiattrib_parent_class = NULL;
+G_DEFINE_TYPE (Multiattrib,
+               multiattrib,
+               GSCHEM_TYPE_DIALOG);
 
 static void multiattrib_class_init (MultiattribClass *klass);
 static void multiattrib_init       (Multiattrib *multiattrib);
@@ -1867,44 +1816,6 @@ multiattrib_geometry_restore (GschemDialog *dialog, EdaConfig *cfg, gchar *group
   g_clear_error (&error);
   gtk_expander_set_expanded (GTK_EXPANDER (MULTIATTRIB (dialog)->add_frame),
                              expand_add_attr);
-}
-
-
-/*! \brief Function to retrieve Multiattrib's GType identifier.
- *
- *  \par Function Description
- *
- *  Function to retrieve Multiattrib's GType identifier.
- *  Upon first call, this registers Multiattrib in the GType system.
- *  Subsequently it returns the saved value from its first execution.
- *
- *  \return the GType identifier associated with Multiattrib.
- */
-GType
-multiattrib_get_type ()
-{
-  static GType multiattrib_type = 0;
-
-  if (!multiattrib_type) {
-    static const GTypeInfo multiattrib_info = {
-      sizeof(MultiattribClass),
-      NULL, /* base_init */
-      NULL, /* base_finalize */
-      (GClassInitFunc) multiattrib_class_init,
-      NULL, /* class_finalize */
-      NULL, /* class_data */
-      sizeof(Multiattrib),
-      0,    /* n_preallocs */
-      (GInstanceInitFunc) multiattrib_init,
-    };
-
-    multiattrib_type = g_type_register_static (GSCHEM_TYPE_DIALOG,
-                                               "Multiattrib",
-                                               &multiattrib_info,
-                                               (GTypeFlags) 0);
-  }
-
-  return multiattrib_type;
 }
 
 

--- a/libleptongui/src/x_newtext.c
+++ b/libleptongui/src/x_newtext.c
@@ -61,6 +61,8 @@ struct _NewText {
 };
 
 
+G_DEFINE_TYPE (NewText, newtext, GSCHEM_TYPE_DIALOG);
+
 
 /*! \brief Handles the user response when apply is selected
  *
@@ -440,37 +442,6 @@ static void newtext_init(NewText *dialog)
   pango_tab_array_free (tab_array);
   gtk_container_add(GTK_CONTAINER(scrolled_window), dialog->text_view);
 }
-
-
-
-/*! \brief Get/register NewText type.
- */
-GType newtext_get_type()
-{
-  static GType type = 0;
-
-  if (type == 0) {
-    static const GTypeInfo info = {
-      sizeof(NewTextClass),
-      NULL,                                   /* base_init */
-      NULL,                                   /* base_finalize */
-      (GClassInitFunc) newtext_class_init,
-      NULL,                                   /* class_finalize */
-      NULL,                                   /* class_data */
-      sizeof(NewText),
-      0,                                      /* n_preallocs */
-      (GInstanceInitFunc) newtext_init,
-    };
-
-    type = g_type_register_static (GSCHEM_TYPE_DIALOG,
-                                   "NewText",
-                                   &info,
-                                   (GTypeFlags) 0);
-  }
-
-  return type;
-}
-
 
 
 /*! \brief Open the dialog box to add new text


### PR DESCRIPTION
- Use `G_DEFINE_TYPE` macros instead of manually written
`xxx_get_type()` functions.
- Also remove unneeded `#include` directives in several files.
