### PR TITLE
Fix a clang warning in lepton-schematic GTK3 code

### DIFF
--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -603,8 +603,8 @@ make_menu_action (const char *action_name,
 #ifdef ENABLE_GTK3
 GtkWidget*
 lepton_action_create_menu_item (GSimpleAction* action,
-                                char *label,
-                                char *shortcut);
+                                const gchar *label,
+                                const gchar *shortcut);
 #else
 GtkWidget*
 lepton_action_create_menu_item (GtkAction *action,

--- a/libleptongui/src/x_menus.c
+++ b/libleptongui/src/x_menus.c
@@ -163,8 +163,8 @@ on_menu_item_activate (GtkMenuItem *item,
 
 GtkWidget*
 lepton_action_create_menu_item (GSimpleAction* action,
-                                gchar *label,
-                                gchar *shortcut)
+                                const gchar *label,
+                                const gchar *shortcut)
 {
   GtkWidget *item = gtk_menu_item_new_with_mnemonic (label);
 


### PR DESCRIPTION
"Passing 'const char *' to parameter
of type 'char *' discards qualifiers
[-Wincompatible-pointer-types-discards-qualifiers]"

[libleptongui/src/x_menus.c:256](https://github.com/lepton-eda/lepton-eda/blob/8a8e9e5a7223b0bdaebf817b63cdbcc012467221/libleptongui/src/x_menus.c#L256)
