### PR TITLE
Gtk3: Fix log and macro widgets fonts

### DIFF
--- a/libleptongui/src/gschem_log_widget.c
+++ b/libleptongui/src/gschem_log_widget.c
@@ -321,7 +321,7 @@ gschem_log_widget_init (GschemLogWidget *widget)
       char *textview_font =
         g_strdup_printf ("textview {"
                          "  font-family: %s;"
-                         "  font-size: %dpx;"
+                         "  font-size: %dpt;"
                          "  font-style: %s;"
                          "  font-weight: %d;"
                          "}",

--- a/libleptongui/src/gschem_macro_widget.c
+++ b/libleptongui/src/gschem_macro_widget.c
@@ -697,7 +697,7 @@ command_entry_set_font (GtkWidget* entry)
     char *entry_font =
       g_strdup_printf ("entry {"
                        "  font-family: %s;"
-                       "  font-size: %dpx;"
+                       "  font-size: %dpt;"
                        "  font-style: %s;"
                        "  font-weight: %d;"
                        "}",


### PR DESCRIPTION
The bug was reported by @graahnul-grom in #914.

I'll repeat the link here: [gtk3 css issue](https://stackoverflow.com/questions/41257101/setting-gtkentry-font-from-pango-fontdescription).  A comment in the code says they broke gtk3 theming in gtk 3.22. Indeed, the fix found there (replacing *px* units with *pt*)  fixes font sizes in the widgets on my system.