### PR TITLE
Get rid of several i_callback_*() functions

### DIFF
--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -89,7 +89,6 @@ void i_callback_edit_delete (GtkWidget *widget, gpointer data);
 void i_callback_edit_edit (GtkWidget *widget, gpointer data);
 void i_callback_edit_text (GtkWidget *widget, gpointer data);
 void i_callback_edit_slot (GtkWidget *widget, gpointer data);
-void i_callback_edit_object_properties (GtkWidget *widget, gpointer data);
 void i_callback_edit_rotate_90 (GtkWidget *widget, gpointer data);
 void i_callback_edit_mirror (GtkWidget *widget, gpointer data);
 void i_callback_edit_lock (GtkWidget *widget, gpointer data);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -77,7 +77,6 @@ void i_callback_file_script (GtkWidget *widget, gpointer data);
 void i_callback_file_save (GtkWidget *widget, gpointer data);
 void i_callback_file_save_all (GtkWidget *widget, gpointer data);
 void i_callback_file_save_as (GtkWidget *widget, gpointer data);
-void i_callback_file_print (GtkWidget *widget, gpointer data);
 void i_callback_file_write_png (GtkWidget *widget, gpointer data);
 void i_callback_file_close (GtkWidget *widget, gpointer data);
 void i_callback_edit_undo (GtkWidget *widget, gpointer data);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -180,7 +180,6 @@ void i_callback_options_show_log_window (GtkWidget *widget, gpointer data);
 void i_callback_cancel (GtkWidget *widget, gpointer data);
 void i_callback_help_about (GtkWidget *widget, gpointer data);
 void i_callback_help_hotkeys (GtkWidget *widget, gpointer data);
-void i_callback_options_show_coord_window (GtkWidget *widget, gpointer data);
 void i_callback_options_select_font (GtkWidget *widget, gpointer data);
 void i_callback_options_draw_grips (GtkWidget *widget, gpointer data);
 gboolean i_callback_close_wm(GtkWidget *widget, GdkEvent *event, gpointer data);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -80,7 +80,6 @@ void i_callback_file_save_as (GtkWidget *widget, gpointer data);
 void i_callback_file_print (GtkWidget *widget, gpointer data);
 void i_callback_file_write_png (GtkWidget *widget, gpointer data);
 void i_callback_file_close (GtkWidget *widget, gpointer data);
-void i_callback_file_quit (GtkWidget *widget, gpointer data);
 void i_callback_edit_undo (GtkWidget *widget, gpointer data);
 void i_callback_edit_redo (GtkWidget *widget, gpointer data);
 void i_callback_edit_select (GtkWidget *widget, gpointer data);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -180,7 +180,6 @@ void i_callback_options_show_log_window (GtkWidget *widget, gpointer data);
 void i_callback_cancel (GtkWidget *widget, gpointer data);
 void i_callback_help_about (GtkWidget *widget, gpointer data);
 void i_callback_help_hotkeys (GtkWidget *widget, gpointer data);
-void i_callback_options_select_font (GtkWidget *widget, gpointer data);
 void i_callback_options_draw_grips (GtkWidget *widget, gpointer data);
 gboolean i_callback_close_wm(GtkWidget *widget, GdkEvent *event, gpointer data);
 /* i_vars.c */

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -87,7 +87,6 @@ void i_callback_edit_mcopy (GtkWidget *widget, gpointer data);
 void i_callback_edit_move (GtkWidget *widget, gpointer data);
 void i_callback_edit_delete (GtkWidget *widget, gpointer data);
 void i_callback_edit_edit (GtkWidget *widget, gpointer data);
-void i_callback_edit_text (GtkWidget *widget, gpointer data);
 void i_callback_edit_slot (GtkWidget *widget, gpointer data);
 void i_callback_edit_rotate_90 (GtkWidget *widget, gpointer data);
 void i_callback_edit_mirror (GtkWidget *widget, gpointer data);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -76,7 +76,6 @@ void i_callback_file_open (GtkWidget *widget, gpointer data);
 void i_callback_file_script (GtkWidget *widget, gpointer data);
 void i_callback_file_save (GtkWidget *widget, gpointer data);
 void i_callback_file_save_all (GtkWidget *widget, gpointer data);
-void i_callback_file_save_as (GtkWidget *widget, gpointer data);
 void i_callback_edit_undo (GtkWidget *widget, gpointer data);
 void i_callback_edit_redo (GtkWidget *widget, gpointer data);
 void i_callback_edit_select (GtkWidget *widget, gpointer data);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -77,7 +77,6 @@ void i_callback_file_script (GtkWidget *widget, gpointer data);
 void i_callback_file_save (GtkWidget *widget, gpointer data);
 void i_callback_file_save_all (GtkWidget *widget, gpointer data);
 void i_callback_file_save_as (GtkWidget *widget, gpointer data);
-void i_callback_file_write_png (GtkWidget *widget, gpointer data);
 void i_callback_file_close (GtkWidget *widget, gpointer data);
 void i_callback_edit_undo (GtkWidget *widget, gpointer data);
 void i_callback_edit_redo (GtkWidget *widget, gpointer data);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -77,7 +77,6 @@ void i_callback_file_script (GtkWidget *widget, gpointer data);
 void i_callback_file_save (GtkWidget *widget, gpointer data);
 void i_callback_file_save_all (GtkWidget *widget, gpointer data);
 void i_callback_file_save_as (GtkWidget *widget, gpointer data);
-void i_callback_file_close (GtkWidget *widget, gpointer data);
 void i_callback_edit_undo (GtkWidget *widget, gpointer data);
 void i_callback_edit_redo (GtkWidget *widget, gpointer data);
 void i_callback_edit_select (GtkWidget *widget, gpointer data);

--- a/libleptongui/scheme/Makefile.am
+++ b/libleptongui/scheme/Makefile.am
@@ -37,6 +37,7 @@ nobase_dist_scmdata_DATA = \
 	schematic/util.scm \
 	schematic/undo.scm \
 	schematic/window.scm \
+	schematic/window/foreign.scm \
 	conf/schematic/attribs.scm \
 	conf/schematic/deprecated.scm \
 	conf/schematic/keys.scm \

--- a/libleptongui/scheme/schematic/attrib.scm
+++ b/libleptongui/scheme/schematic/attrib.scm
@@ -31,6 +31,7 @@
 
   #:use-module (schematic core gettext)
   #:use-module (schematic ffi)
+  #:use-module (schematic window foreign)
   #:use-module (schematic window)
 
   #:export (add-attrib!
@@ -71,6 +72,10 @@ error will be raised.  If TARGET is #f, the new attribute will be
 floating in lepton-schematic's current active page.  The initial
 value of the attribute will be set then to (0 . 0).  See also
 active-page() in the (schematic window) module."
+  (define *window
+    (or (and=> (current-window) window->pointer)
+        (error "~S: Current window is unavailable." 'add-attrib!)))
+
   (check-attrib-target target 1)
   (check-string name 2)
   (check-string value 3)
@@ -84,7 +89,7 @@ active-page() in the (schematic window) module."
         (show? (symbol->text-attribute-show-mode show))
         (*str (string->pointer (string-append name "=" value))))
     (pointer->object
-     (o_attrib_add_attrib (current-window)
+     (o_attrib_add_attrib *window
                           *str
                           visibility
                           show?

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -99,7 +99,7 @@
   (x_print (*current-window)))
 
 (define-action-public (&file-image #:label (G_ "Export Image"))
-  (run-callback i_callback_file_write_png "&file-image"))
+  (x_image_setup (*current-window)))
 
 (define-action-public (&file-script #:label (G_ "Run Script") #:icon "gtk-execute")
   (run-callback i_callback_file_script "&file-script"))

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -120,7 +120,8 @@
                          (lepton_toplevel_new)))
 
 (define-action-public (&file-close-window #:label (G_ "Close Window") #:icon "gtk-close")
-  (run-callback i_callback_file_close "&file-close-window"))
+  (log! 'message (G_ "Closing Window"))
+  (x_window_close (*current-window)))
 
 (define-action-public (&file-quit #:label (G_ "Quit") #:icon "gtk-quit")
   (lepton-repl-save-history)

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -64,6 +64,13 @@
              (log! 'critical "~S: Current window is unavailable." action-name)
              #f))))))
 
+(define-syntax *current-window
+  (syntax-rules ()
+    ((_)
+     (let ((*window (and=> (current-window) window->pointer)))
+       (or *window
+           (error "Current window is unavailable."))))))
+
 ;; -------------------------------------------------------------------
 ;;;; Special actions
 

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -178,8 +178,9 @@
 (define-action-public (&edit-slot #:label (G_ "Choose Slot"))
   (run-callback i_callback_edit_slot "&edit-slot"))
 
+;;; Show "object properties" widget.
 (define-action-public (&edit-object-properties #:label (G_ "Edit Object Properties") #:icon "gtk-properties")
-  (run-callback i_callback_edit_object_properties "&edit-object-properties"))
+  (x_widgets_show_object_properties (*current-window)))
 
 (define-action-public (&edit-translate #:label (G_ "Translate Symbol"))
   (run-callback i_callback_edit_translate "&edit-translate"))

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -90,7 +90,10 @@
   (run-callback i_callback_file_save "&file-save"))
 
 (define-action-public (&file-save-as #:label (G_ "Save As") #:icon "gtk-save-as")
-  (run-callback i_callback_file_save_as "&file-save-as"))
+  (define *window (*current-window))
+  (x_fileselect_save *window
+                     (schematic_window_get_active_page *window)
+                     %null-pointer))
 
 (define-action-public (&file-save-all #:label (G_ "Save All") #:icon "gtk-save")
   (run-callback i_callback_file_save_all "&file-save-all"))

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -96,7 +96,7 @@
   (run-callback i_callback_file_save_all "&file-save-all"))
 
 (define-action-public (&file-print #:label (G_ "Print") #:icon "gtk-print")
-  (run-callback i_callback_file_print "&file-print"))
+  (x_print (*current-window)))
 
 (define-action-public (&file-image #:label (G_ "Export Image"))
   (run-callback i_callback_file_write_png "&file-image"))

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -539,7 +539,7 @@
   (coord_dialog (*current-window) 0 0))
 
 (define-action-public (&options-select-font #:label (G_ "Select Schematic Font"))
-  (run-callback i_callback_options_select_font "&options-select-font"))
+  (x_widgets_show_font_select (*current-window)))
 
 (define-action-public (&options-draw-grips #:label (G_ "Toggle Grips"))
   (run-callback i_callback_options_draw_grips "&options-draw-grips"))

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -124,7 +124,7 @@
 
 (define-action-public (&file-quit #:label (G_ "Quit") #:icon "gtk-quit")
   (lepton-repl-save-history)
-  (run-callback i_callback_file_quit "&file-quit"))
+  (x_window_close_all (*current-window)))
 
 (define-action-public (&file-repl #:label (G_ "Terminal REPL") #:icon "gtk-execute")
   (start-repl-in-background-terminal))

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -39,6 +39,7 @@
   #:use-module (schematic repl)
   #:use-module (schematic selection)
   #:use-module (schematic undo)
+  #:use-module (schematic window foreign)
   #:use-module (schematic window))
 
 
@@ -56,12 +57,12 @@
 (define-syntax run-callback
   (syntax-rules ()
     ((_ c-callback action-name)
-     (let ((window (current-window)))
-       (if (null-pointer? window)
+     (let ((*window (and=> (current-window) window->pointer)))
+       (if *window
+           (c-callback %null-pointer *window)
            (begin
-             (log! 'critical "NULL window in ~S()." action-name)
-             #f)
-           (c-callback %null-pointer window))))))
+             (log! 'critical "~S: Current window is unavailable." action-name)
+             #f))))))
 
 ;; -------------------------------------------------------------------
 ;;;; Special actions

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -536,7 +536,7 @@
   (run-callback i_callback_options_show_log_window "&options-show-log-window"))
 
 (define-action-public (&options-show-coord-window #:label (G_ "Show Coordinate Window"))
-  (run-callback i_callback_options_show_coord_window "&options-show-coord-window"))
+  (coord_dialog (*current-window) 0 0))
 
 (define-action-public (&options-select-font #:label (G_ "Select Schematic Font"))
   (run-callback i_callback_options_select_font "&options-select-font"))

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -173,7 +173,7 @@
   (run-callback i_callback_edit_edit "&edit-edit"))
 
 (define-action-public (&edit-text #:label (G_ "Edit Text") #:icon "gtk-edit")
-  (run-callback i_callback_edit_text "&edit-text"))
+  (text_edit_dialog (*current-window)))
 
 (define-action-public (&edit-slot #:label (G_ "Choose Slot"))
   (run-callback i_callback_edit_slot "&edit-slot"))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -62,7 +62,6 @@
             i_callback_edit_mcopy
             i_callback_edit_mirror
             i_callback_edit_move
-            i_callback_edit_object_properties
             i_callback_edit_redo
             i_callback_edit_rotate_90
             i_callback_edit_select
@@ -135,7 +134,10 @@
             x_menu_attach_recent_files_submenu
             x_show_uri
             x_stroke_init
+
             x_widgets_show_log
+            x_widgets_show_object_properties
+
             x_window_create_main
             x_window_close
             x_window_close_all
@@ -206,7 +208,10 @@
 (define-lff set_quiet_mode void '())
 (define-lff set_verbose_mode void '())
 (define-lff x_color_init void '())
-(define-lff x_widgets_show_log void (list '*))
+
+;;; x_widgets.c
+(define-lff x_widgets_show_log void '(*))
+(define-lff x_widgets_show_object_properties void '(*))
 
 ;;; keys.c
 (define-lff schematic_keys_get_event_keyval int '(*))
@@ -286,7 +291,6 @@
 (define-lff i_callback_edit_mcopy void '(* *))
 (define-lff i_callback_edit_mirror void '(* *))
 (define-lff i_callback_edit_move void '(* *))
-(define-lff i_callback_edit_object_properties void '(* *))
 (define-lff i_callback_edit_redo void '(* *))
 (define-lff i_callback_edit_rotate_90 void '(* *))
 (define-lff i_callback_edit_select void '(* *))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -80,7 +80,6 @@
             i_callback_file_open
             i_callback_file_save
             i_callback_file_save_all
-            i_callback_file_save_as
             i_callback_file_script
             i_callback_help_about
             i_callback_help_hotkeys
@@ -169,6 +168,8 @@
 
             x_event_get_pointer_position
             x_event_key
+
+            x_fileselect_save
 
             x_image_setup
 
@@ -303,7 +304,6 @@
 (define-lff i_callback_file_open void '(* *))
 (define-lff i_callback_file_save void '(* *))
 (define-lff i_callback_file_save_all void '(* *))
-(define-lff i_callback_file_save_as void '(* *))
 (define-lff i_callback_file_script void '(* *))
 (define-lff i_callback_help_about void '(* *))
 (define-lff i_callback_help_hotkeys void '(* *))
@@ -355,6 +355,9 @@
 
 ;;; x_event.c
 (define-lff x_event_key '* '(* * *))
+
+;;; x_fileselect.c
+(define-lff x_fileselect_save int '(* * *))
 
 ;;; x_image.c
 (define-lff x_image_setup void '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -83,7 +83,6 @@
             i_callback_file_save_all
             i_callback_file_save_as
             i_callback_file_script
-            i_callback_file_write_png
             i_callback_help_about
             i_callback_help_hotkeys
             i_callback_hierarchy_down_schematic
@@ -170,6 +169,8 @@
 
             x_event_get_pointer_position
             x_event_key
+
+            x_image_setup
 
             x_print
 
@@ -304,7 +305,6 @@
 (define-lff i_callback_file_save_all void '(* *))
 (define-lff i_callback_file_save_as void '(* *))
 (define-lff i_callback_file_script void '(* *))
-(define-lff i_callback_file_write_png void '(* *))
 (define-lff i_callback_help_about void '(* *))
 (define-lff i_callback_help_hotkeys void '(* *))
 (define-lff i_callback_hierarchy_down_schematic void '(* *))
@@ -355,6 +355,9 @@
 
 ;;; x_event.c
 (define-lff x_event_key '* '(* * *))
+
+;;; x_image.c
+(define-lff x_image_setup void '(*))
 
 ;;; x_print.c
 (define-lff x_print void '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -80,7 +80,6 @@
             i_callback_file_new
             i_callback_file_open
             i_callback_file_print
-            i_callback_file_quit
             i_callback_file_save
             i_callback_file_save_all
             i_callback_file_save_as
@@ -142,6 +141,7 @@
             x_stroke_init
             x_widgets_show_log
             x_window_create_main
+            x_window_close_all
             x_window_close_page
             x_window_new
             x_window_open_page
@@ -241,6 +241,7 @@
 (define-lff x_window_set_current_page void '(* *))
 (define-lff x_window_setup '* '(*))
 (define-lff x_window_create_main '* '(* * * *))
+(define-lff x_window_close_all void '(*))
 (define-lff x_window_close_page void '(* *))
 
 ;;; x_dialog.c
@@ -299,7 +300,6 @@
 (define-lff i_callback_file_new void '(* *))
 (define-lff i_callback_file_open void '(* *))
 (define-lff i_callback_file_print void '(* *))
-(define-lff i_callback_file_quit void '(* *))
 (define-lff i_callback_file_save void '(* *))
 (define-lff i_callback_file_save_all void '(* *))
 (define-lff i_callback_file_save_as void '(* *))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -76,7 +76,6 @@
             i_callback_edit_unembed
             i_callback_edit_unlock
             i_callback_edit_update
-            i_callback_file_close
             i_callback_file_new
             i_callback_file_open
             i_callback_file_save
@@ -139,6 +138,7 @@
             x_stroke_init
             x_widgets_show_log
             x_window_create_main
+            x_window_close
             x_window_close_all
             x_window_close_page
             x_window_new
@@ -243,6 +243,7 @@
 (define-lff x_window_set_current_page void '(* *))
 (define-lff x_window_setup '* '(*))
 (define-lff x_window_create_main '* '(* * * *))
+(define-lff x_window_close void '(*))
 (define-lff x_window_close_all void '(*))
 (define-lff x_window_close_page void '(* *))
 
@@ -298,7 +299,6 @@
 (define-lff i_callback_edit_unembed void '(* *))
 (define-lff i_callback_edit_unlock void '(* *))
 (define-lff i_callback_edit_update void '(* *))
-(define-lff i_callback_file_close void '(* *))
 (define-lff i_callback_file_new void '(* *))
 (define-lff i_callback_file_open void '(* *))
 (define-lff i_callback_file_save void '(* *))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -69,7 +69,6 @@
             i_callback_edit_show_hidden
             i_callback_edit_show_text
             i_callback_edit_slot
-            i_callback_edit_text
             i_callback_edit_translate
             i_callback_edit_undo
             i_callback_edit_unembed
@@ -167,6 +166,8 @@
 
             gschem_options_get_snap_size
 
+            text_edit_dialog
+
             o_undo_savestate
 
             x_event_get_pointer_position
@@ -238,6 +239,9 @@
 ;;; gschem_options.c
 (define-lff gschem_options_get_snap_size int '(*))
 
+;;; gschem_text_properties_widget.c
+(define-lff text_edit_dialog void '(*))
+
 ;;; x_menus.c
 (define-lff make_separator_menu_item '* '())
 (define-lff make_menu_action '* '(* * * * *))
@@ -303,7 +307,6 @@
 (define-lff i_callback_edit_show_hidden void '(* *))
 (define-lff i_callback_edit_show_text void '(* *))
 (define-lff i_callback_edit_slot void '(* *))
-(define-lff i_callback_edit_text void '(* *))
 (define-lff i_callback_edit_translate void '(* *))
 (define-lff i_callback_edit_undo void '(* *))
 (define-lff i_callback_edit_unembed void '(* *))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -92,7 +92,6 @@
             i_callback_options_rubberband
             i_callback_options_scale_down_snap_size
             i_callback_options_scale_up_snap_size
-            i_callback_options_select_font
             i_callback_options_show_log_window
             i_callback_options_snap
             i_callback_options_snap_size
@@ -134,6 +133,7 @@
             x_show_uri
             x_stroke_init
 
+            x_widgets_show_font_select
             x_widgets_show_log
             x_widgets_show_object_properties
 
@@ -211,6 +211,7 @@
 (define-lff x_color_init void '())
 
 ;;; x_widgets.c
+(define-lff x_widgets_show_font_select void '(*))
 (define-lff x_widgets_show_log void '(*))
 (define-lff x_widgets_show_object_properties void '(*))
 
@@ -325,7 +326,6 @@
 (define-lff i_callback_options_rubberband void '(* *))
 (define-lff i_callback_options_scale_down_snap_size void '(* *))
 (define-lff i_callback_options_scale_up_snap_size void '(* *))
-(define-lff i_callback_options_select_font void '(* *))
 (define-lff i_callback_options_show_log_window void '(* *))
 (define-lff i_callback_options_snap void '(* *))
 (define-lff i_callback_options_snap_size void '(* *))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -79,7 +79,6 @@
             i_callback_file_close
             i_callback_file_new
             i_callback_file_open
-            i_callback_file_print
             i_callback_file_save
             i_callback_file_save_all
             i_callback_file_save_as
@@ -171,6 +170,8 @@
 
             x_event_get_pointer_position
             x_event_key
+
+            x_print
 
             parse-gschemrc
             ))
@@ -299,7 +300,6 @@
 (define-lff i_callback_file_close void '(* *))
 (define-lff i_callback_file_new void '(* *))
 (define-lff i_callback_file_open void '(* *))
-(define-lff i_callback_file_print void '(* *))
 (define-lff i_callback_file_save void '(* *))
 (define-lff i_callback_file_save_all void '(* *))
 (define-lff i_callback_file_save_as void '(* *))
@@ -355,6 +355,9 @@
 
 ;;; x_event.c
 (define-lff x_event_key '* '(* * *))
+
+;;; x_print.c
+(define-lff x_print void '(*))
 
 ;;; o_undo.c
 (define-lff o_undo_init void '())

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -93,7 +93,6 @@
             i_callback_options_scale_down_snap_size
             i_callback_options_scale_up_snap_size
             i_callback_options_select_font
-            i_callback_options_show_coord_window
             i_callback_options_show_log_window
             i_callback_options_snap
             i_callback_options_snap_size
@@ -146,6 +145,8 @@
             x_window_open_page
             x_window_set_current_page
             x_window_setup
+
+            coord_dialog
 
             schematic_keys_get_event_keyval
             schematic_keys_get_event_modifiers
@@ -217,6 +218,9 @@
 (define-lff schematic_keys_get_event_keyval int '(*))
 (define-lff schematic_keys_get_event_modifiers int '(*))
 (define-lff schematic_keys_verify_keyval int (list int))
+
+;;; gschem_coord_dialog.c
+(define-lff coord_dialog void (list '* int int))
 
 ;;; gschem_page_view.c
 (define-lff gschem_page_view_get_page '* '(*))
@@ -322,7 +326,6 @@
 (define-lff i_callback_options_scale_down_snap_size void '(* *))
 (define-lff i_callback_options_scale_up_snap_size void '(* *))
 (define-lff i_callback_options_select_font void '(* *))
-(define-lff i_callback_options_show_coord_window void '(* *))
 (define-lff i_callback_options_show_log_window void '(* *))
 (define-lff i_callback_options_snap void '(* *))
 (define-lff i_callback_options_snap_size void '(* *))

--- a/libleptongui/scheme/schematic/undo.scm
+++ b/libleptongui/scheme/schematic/undo.scm
@@ -22,6 +22,7 @@
   #:use-module (system foreign)
 
   #:use-module (schematic ffi)
+  #:use-module (schematic window foreign)
   #:use-module (schematic window)
 
     ; public:
@@ -38,7 +39,9 @@
 (define (undo-save-state)
   "Saves current state onto the undo stack.  Returns #t on
 success, #f on failure."
-  (define *window (current-window))
+  (define *window
+    (or (and=> (current-window) window->pointer)
+        (error "~S: Current window is unavailable." 'undo-save-state)))
 
   (let ((*view (gschem_toplevel_get_current_page_view *window)))
     (and (not (null-pointer? *view))

--- a/libleptongui/scheme/schematic/util.scm
+++ b/libleptongui/scheme/schematic/util.scm
@@ -26,6 +26,7 @@
 
   #:use-module (schematic core gettext)
   #:use-module (schematic ffi)
+  #:use-module (schematic window foreign)
   #:use-module (schematic window)
 
   #:export (show-file
@@ -34,6 +35,10 @@
 (define (show-uri uri)
   "Shows URI in the associated default application.  Raises an
 error on failure."
+  (define *window
+    (or (and=> (current-window) window->pointer)
+        (error "~S: Current window is unavailable." 'show-uri)))
+
   (define unknown-error (G_ "Unknown error"))
 
   (define (get-gerror-msg *error)
@@ -52,7 +57,7 @@ error on failure."
   (check-string uri 1)
 
   (let ((*error (bytevector->pointer (make-bytevector (sizeof '*) 0))))
-    (unless (true? (x_show_uri (current-window)
+    (unless (true? (x_show_uri *window
                                (string->pointer uri)
                                *error))
 

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -54,16 +54,6 @@
 ;;; exactly to it.
 (define %lepton-window (make-fluid))
 
-;;; Define a wrapped pointer type.
-(define-wrapped-pointer-type <schematic-window>
-  schematic-window?
-  wrap-schematic-window
-  unwrap-schematic-window
-  ;; Printer.
-  (lambda (window port)
-    (format port "#<schematic-window-0x~x>"
-            (pointer-address (unwrap-schematic-window window)))))
-
 
 ;;; Execute forms in the dynamic context of WINDOW and its
 ;;; toplevel.  We have to dynwind LeptonToplevel here as well

--- a/libleptongui/scheme/schematic/window/foreign.scm
+++ b/libleptongui/scheme/schematic/window/foreign.scm
@@ -1,0 +1,74 @@
+;;; Lepton EDA library - Scheme API
+;;; Copyright (C) 2022 Lepton EDA Contributors
+;;;
+;;; This program is free software; you can redistribute it and/or modify
+;;; it under the terms of the GNU General Public License as published by
+;;; the Free Software Foundation; either version 2 of the License, or
+;;; (at your option) any later version.
+;;;
+;;; This program is distributed in the hope that it will be useful,
+;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;; GNU General Public License for more details.
+;;;
+;;; You should have received a copy of the GNU General Public License
+;;; along with this program; if not, write to the Free Software
+;;; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
+(define-module (schematic window foreign)
+  #:use-module (ice-9 format)
+  #:use-module (system foreign)
+
+  #:use-module (lepton ffi)
+
+  #:export (is-window?
+            check-window
+            window->pointer
+            pointer->window))
+
+
+;;; Define a wrapped pointer type.
+(define-wrapped-pointer-type <window>
+  is-window?
+  wrap-window
+  unwrap-window
+  ;; Printer.
+  (lambda (window port)
+    (format port "#<window-0x~x>"
+            (pointer-address (unwrap-window window)))))
+
+
+;;; Helper transformers between the <window> type and C window
+;;; pointers.
+(define (window->pointer window)
+  "Transforms WINDOW which should be an instance of the <window>
+type into a foreign C pointer.  If WINDOW has another type, raises
+a 'wrong-type-arg error."
+  (if (is-window? window)
+      (unwrap-window window)
+      (error-wrong-type-arg 1 '<window> window)))
+
+
+(define (pointer->window pointer)
+  "Transforms POINTER to a <window> type instance. Raises a
+'wrong-type-arg error if POINTER is not a foreign C pointer.
+Raises a 'misc-error error if the pointer is a NULL pointer."
+  (if (pointer? pointer)
+      (if (null-pointer? pointer)
+          (error "Cannot convert NULL pointer to <window>.")
+          (wrap-window pointer))
+      (error-wrong-type-arg 1 'pointer pointer)))
+
+
+;;; Syntax rules to check <window> instances.  The same as for
+;;; <object> in the module (lepton object foreign).
+(define-syntax check-window
+  (syntax-rules ()
+    ((_ window pos)
+     (let ((pointer (and (is-window? window)
+                         (unwrap-window window))))
+       (if (or (not pointer)
+               (null-pointer? pointer))
+           (error-wrong-type-arg pos '<window> window)
+           pointer)))))

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -2640,19 +2640,6 @@ i_callback_help_hotkeys (GtkWidget *widget, gpointer data)
   x_dialog_hotkeys(w_current);
 }
 
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
-void
-i_callback_options_show_coord_window (GtkWidget *widget, gpointer data)
-{
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-
-  g_return_if_fail (w_current != NULL);
-  coord_dialog (w_current, 0, 0);
-}
 
 void
 i_callback_options_select_font (GtkWidget *widget, gpointer data)

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -240,21 +240,6 @@ i_callback_file_save_as (GtkWidget *widget, gpointer data)
  *  \brief
  *  \par Function Description
  *
- */
-void
-i_callback_file_write_png (GtkWidget *widget, gpointer data)
-{
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-
-  g_return_if_fail (w_current != NULL);
-
-  x_image_setup(w_current);
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
  *  \note
  *  don't use the widget parameter on this function, or do some
  *  checking...

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -2640,17 +2640,6 @@ i_callback_help_hotkeys (GtkWidget *widget, gpointer data)
   x_dialog_hotkeys(w_current);
 }
 
-
-void
-i_callback_options_select_font (GtkWidget *widget, gpointer data)
-{
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-
-  g_return_if_fail (w_current != NULL);
-
-  x_widgets_show_font_select (w_current);
-}
-
 void
 i_callback_options_draw_grips (GtkWidget *widget, gpointer data)
 {

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -283,20 +283,6 @@ i_callback_file_close (GtkWidget *widget, gpointer data)
   x_window_close(w_current);
 }
 
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
-void
-i_callback_file_quit (GtkWidget *widget, gpointer data)
-{
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-
-  g_return_if_fail (w_current != NULL);
-  x_window_close_all(w_current);
-}
-
 /*! \section edit-menu Edit Menu Callback Functions */
 /*! \todo Finish function documentation!!!
  *  \brief

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -235,17 +235,6 @@ i_callback_file_save_as (GtkWidget *widget, gpointer data)
   x_fileselect_save (w_current, page, NULL);
 }
 
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
-void
-i_callback_file_print (GtkWidget *widget, gpointer data)
-{
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-  x_print (w_current);
-}
 
 /*! \todo Finish function documentation!!!
  *  \brief

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -236,27 +236,6 @@ i_callback_file_save_as (GtkWidget *widget, gpointer data)
 }
 
 
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- *  \note
- *  don't use the widget parameter on this function, or do some
- *  checking...
- *  since there is a call: widget = NULL, data = 0 (will be w_current)
- *  this function closes a window
- */
-void
-i_callback_file_close (GtkWidget *widget, gpointer data)
-{
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-
-  g_return_if_fail (w_current != NULL);
-
-  g_message (_("Closing Window"));
-  x_window_close(w_current);
-}
-
 /*! \section edit-menu Edit Menu Callback Functions */
 /*! \todo Finish function documentation!!!
  *  \brief

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -217,25 +217,6 @@ i_callback_file_save_all (GtkWidget *widget, gpointer data)
 } /* i_callback_file_save_all() */
 
 
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
-void
-i_callback_file_save_as (GtkWidget *widget, gpointer data)
-{
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-
-  g_return_if_fail (w_current != NULL);
-
-  LeptonPage* page = schematic_window_get_active_page (w_current);
-
-  x_fileselect_save (w_current, page, NULL);
-}
-
-
 /*! \section edit-menu Edit Menu Callback Functions */
 /*! \todo Finish function documentation!!!
  *  \brief

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -495,19 +495,6 @@ i_callback_edit_slot (GtkWidget *widget, gpointer data)
   }
 }
 
-/*! \brief Show "object properties" widget
- *
- */
-void
-i_callback_edit_object_properties (GtkWidget *widget, gpointer data)
-{
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-
-  g_return_if_fail (w_current != NULL);
-
-  x_widgets_show_object_properties (w_current);
-}
-
 /*! \todo Finish function documentation!!!
  *  \brief
  *  \par Function Description

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -460,20 +460,6 @@ i_callback_edit_edit (GtkWidget *widget, gpointer data)
   o_edit(w_current, lepton_list_get_glist (active_page->selection_list));
 }
 
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
-void
-i_callback_edit_text (GtkWidget *widget, gpointer data)
-{
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-
-  g_return_if_fail (w_current != NULL);
-
-  text_edit_dialog (w_current);
-}
 
 /*! \todo Finish function documentation!!!
  *  \brief


### PR DESCRIPTION
The commit set introduces the changes as follows:
- It introduces the module `(schematic window foreign)` with foreign wrappers and functions for `w_current` similar to what we have in `(lepton toplevel foreign)` for `toplevel` structs.
- `current-window()` now returns a wrapped pointer to `GschemToplevel` aka `w_current`.
- Scheme functions calling that function have been amended to take into account this fact.
- A syntax rule has been added to check the result of `current-window()` in the `(schematic builtins)` module.
- Several actions in the module have been simplified so that several intermediate `i_callback_*()` functions are no longer used.
It's just a start of work in that direction.  I believe much more intermediate C code can be removed this way.