### PR TITLE
Introduce a new enum type: SchematicActionMode

### DIFF
--- a/libleptongui/include/Makefile.am
+++ b/libleptongui/include/Makefile.am
@@ -1,9 +1,9 @@
 noinst_HEADERS = \
+	action_mode.h \
 	globals.h \
 	i_vars.h \
 	prototype.h \
 	x_dialog.h \
-	x_states.h \
 	gettext.h \
 	x_compselect.h \
 	x_multiattrib.h \

--- a/libleptongui/include/action_mode.h
+++ b/libleptongui/include/action_mode.h
@@ -16,8 +16,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef X_STATES_H
-#define X_STATES_H
+#ifndef ACTION_MODE_H
+#define ACTION_MODE_H
 
 #undef NONE
 
@@ -53,5 +53,4 @@ enum x_states {
   ROTATEMODE,
 };
 
-
-#endif
+#endif /* ACTION_MODE_H */

--- a/libleptongui/include/action_mode.h
+++ b/libleptongui/include/action_mode.h
@@ -1,5 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
+ * Copyright (C) 1998-2015 gEDA Contributors
+ * Copyright (C) 2022 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -23,7 +25,7 @@
 
 /* NOTE: when adding states, also update i_status_string() function */
 
-enum x_states {
+enum _SchematicActionMode {
   /* Basic modes */
   SELECT,
   GRIPS,
@@ -52,5 +54,7 @@ enum x_states {
   MIRRORMODE,
   ROTATEMODE,
 };
+
+typedef enum _SchematicActionMode SchematicActionMode;
 
 #endif /* ACTION_MODE_H */

--- a/libleptongui/include/action_mode.h
+++ b/libleptongui/include/action_mode.h
@@ -21,7 +21,7 @@
 #ifndef ACTION_MODE_H
 #define ACTION_MODE_H
 
-#undef NONE
+G_BEGIN_DECLS
 
 /* NOTE: when adding states, also update i_status_string() function */
 
@@ -56,5 +56,14 @@ enum _SchematicActionMode {
 };
 
 typedef enum _SchematicActionMode SchematicActionMode;
+
+
+SchematicActionMode
+schematic_action_mode_from_string (char *s);
+
+const char*
+schematic_action_mode_to_string (SchematicActionMode mode);
+
+G_END_DECLS
 
 #endif /* ACTION_MODE_H */

--- a/libleptongui/include/globals.h
+++ b/libleptongui/include/globals.h
@@ -62,6 +62,6 @@ extern int verbose_mode;
 #endif
 
 /*EK* used by prototype.h */
-#include "../include/x_states.h"
+#include "../include/action_mode.h"
 
 #endif

--- a/libleptongui/include/globals.h
+++ b/libleptongui/include/globals.h
@@ -47,18 +47,4 @@ extern int verbose_mode;
 # define N_(String) (String)
 #endif
 
-/*
- * __attribute__((unused)) is a gcc extension so define
- * a portable macro, ATTRIBUTE_UNUSED, to use instead
- */
-#ifndef GCC_VERSION
-#define GCC_VERSION (__GNUC__ * 1000 + __GNUC_MINOR__)
-#endif /* GCC_VERSION */
-
-#if GCC_VERSION > 2007
-#define ATTRIBUTE_UNUSED __attribute__((unused))
-#else
-#define ATTRIBUTE_UNUSED
-#endif
-
 #endif

--- a/libleptongui/include/globals.h
+++ b/libleptongui/include/globals.h
@@ -61,7 +61,4 @@ extern int verbose_mode;
 #define ATTRIBUTE_UNUSED
 #endif
 
-/*EK* used by prototype.h */
-#include "../include/action_mode.h"
-
 #endif

--- a/libleptongui/include/gschem.h
+++ b/libleptongui/include/gschem.h
@@ -17,6 +17,7 @@ typedef struct st_gschem_toplevel GschemToplevel;
 typedef void (*i_callback_func) (gpointer, guint, GtkWidget*);
 
 /* gschem headers */
+#include "action_mode.h"
 #include "gschem_defines.h"
 #include "gschem_bin.h"
 #include "gschem_bottom_widget.h"
@@ -42,7 +43,6 @@ typedef void (*i_callback_func) (gpointer, guint, GtkWidget*);
 #include "gschem_preview.h"
 #include "x_compselect.h"
 #include "x_dialog.h"
-#include "x_states.h"
 #include "gschem_swatch_column_renderer.h"
 #include "gschem_fill_swatch_cell_renderer.h"
 #include "globals.h"
@@ -65,4 +65,3 @@ typedef void (*i_callback_func) (gpointer, guint, GtkWidget*);
 
 
 #endif /* LEPTON_MAIN_HEADER_H_ */
-

--- a/libleptongui/include/gschem_toplevel.h
+++ b/libleptongui/include/gschem_toplevel.h
@@ -313,4 +313,12 @@ schematic_window_update_keyaccel_string (GschemToplevel *w_current,
 void
 schematic_window_update_keyaccel_timer (GschemToplevel *w_current,
                                         gboolean start_timer);
+
+SchematicActionMode
+schematic_window_get_action_mode (GschemToplevel *w_current);
+
+void
+schematic_window_set_action_mode (GschemToplevel *w_current,
+                                  SchematicActionMode mode);
+
 G_END_DECLS

--- a/libleptongui/include/gschem_toplevel.h
+++ b/libleptongui/include/gschem_toplevel.h
@@ -169,7 +169,7 @@ struct st_gschem_toplevel {
   /* Gschem internal state */
   /* --------------------- */
   int num_untitled;                     /* keep track of untitled wins */
-  int event_state;                      /* Current event state */
+  int action_mode;                      /* Current action mode */
   int min_zoom;                         /* minimum zoom factor */
   int max_zoom;                         /* maximum zoom factor */
   int drawbounding_action_mode;         /* outline vs bounding box */

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -62,8 +62,15 @@ void i_action_start(GschemToplevel *w_current);
 void i_action_stop(GschemToplevel *w_current);
 void i_action_update_status(GschemToplevel *w_current,gboolean inside_action);
 void i_show_state(GschemToplevel *w_current, const char *message);
-void i_set_state(GschemToplevel *w_current, enum x_states newstate);
-void i_set_state_msg(GschemToplevel *w_current, enum x_states newstate, const char *message);
+
+void
+i_set_state (GschemToplevel *w_current,
+             SchematicActionMode newstate);
+void
+i_set_state_msg (GschemToplevel *w_current,
+                 SchematicActionMode newstate,
+                 const char *message);
+
 void i_update_toolbar(GschemToplevel *w_current);
 void i_update_menus(GschemToplevel *w_current);
 void i_set_filename(GschemToplevel *w_current, const gchar *filename, gboolean changed);

--- a/libleptongui/src/Makefile.am
+++ b/libleptongui/src/Makefile.am
@@ -2,6 +2,7 @@ lib_LTLIBRARIES = libleptongui.la
 
 libleptongui_la_SOURCES = \
 	a_zoom.c \
+	action_mode.c \
 	g_action.c \
 	g_hook.c \
 	g_window.c \

--- a/libleptongui/src/action_mode.c
+++ b/libleptongui/src/action_mode.c
@@ -1,0 +1,105 @@
+/* Lepton EDA Schematic Capture
+ * Copyright (C) 2022 Lepton EDA Contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include <config.h>
+
+#include "gschem.h"
+
+
+/*! \brief Return an action mode enum value from string.
+ * \par Function Description
+ * Given a string \a s, returns the #SchematicActionMode enum value
+ * corresponding to it.  This is mainly intended to be used for
+ * value conversion in Scheme FFI functions.
+ *
+ * \param [in] s The string.
+ */
+SchematicActionMode
+schematic_action_mode_from_string (char *s)
+{
+  SchematicActionMode result = SELECT;
+
+  if      (strcmp (s, "select-mode") == 0) {result = SELECT; }
+  else if (strcmp (s, "grips-mode") == 0) {result = GRIPS; }
+  else if (strcmp (s, "arc-mode") == 0) {result = ARCMODE; }
+  else if (strcmp (s, "box-mode") == 0) {result = BOXMODE; }
+  else if (strcmp (s, "bus-mode") == 0) {result = BUSMODE; }
+  else if (strcmp (s, "circle-mode") == 0) {result = CIRCLEMODE; }
+  else if (strcmp (s, "line-mode") == 0) {result = LINEMODE; }
+  else if (strcmp (s, "net-mode") == 0) {result = NETMODE; }
+  else if (strcmp (s, "path-mode") == 0) {result = PATHMODE; }
+  else if (strcmp (s, "picture-mode") == 0) {result = PICTUREMODE; }
+  else if (strcmp (s, "pin-mode") == 0) {result = PINMODE; }
+  else if (strcmp (s, "component-mode") == 0) {result = COMPMODE; }
+  else if (strcmp (s, "copy-mode") == 0) {result = COPYMODE; }
+  else if (strcmp (s, "multiple-copy-mode") == 0) {result = MCOPYMODE; }
+  else if (strcmp (s, "move-mode") == 0) {result = MOVEMODE; }
+  else if (strcmp (s, "paste-mode") == 0) {result = PASTEMODE; }
+  else if (strcmp (s, "text-mode") == 0) {result = TEXTMODE; }
+  else if (strcmp (s, "box-select-mode") == 0) {result = SBOX; }
+  else if (strcmp (s, "zoom-box-mode") == 0) {result = ZOOMBOX; }
+  else if (strcmp (s, "pan-mode") == 0) {result = PAN; }
+  else if (strcmp (s, "mirror-mode") == 0) {result = MIRRORMODE; }
+  else if (strcmp (s, "rotate-mode") == 0) {result = ROTATEMODE; }
+
+  return result;
+}
+
+
+/*! \brief Return a string holding the representation of #SchematicActionMode value.
+ * \par Function Description
+ * Given a #SchematicActionMode value, returns its external
+ * representation as a string.  This is mainly intended to be used
+ * for value conversion in Scheme FFI functions.
+ *
+ *  \param [in] code The #SchematicActionMode value.
+ */
+const char*
+schematic_action_mode_to_string (SchematicActionMode mode)
+{
+  const char *result = NULL;
+
+  switch (mode)
+  {
+  case SELECT: result = "select-mode"; break;
+  case GRIPS: result = "grips-mode"; break;
+  case ARCMODE: result = "arc-mode"; break;
+  case BOXMODE: result = "box-mode"; break;
+  case BUSMODE: result = "bus-mode"; break;
+  case CIRCLEMODE: result = "circle-mode"; break;
+  case LINEMODE: result = "line-mode"; break;
+  case NETMODE: result = "net-mode"; break;
+  case PATHMODE: result = "path-mode"; break;
+  case PICTUREMODE: result = "picture-mode"; break;
+  case PINMODE: result = "pin-mode"; break;
+  case COMPMODE: result = "component-mode"; break;
+  case COPYMODE: result = "copy-mode"; break;
+  case MCOPYMODE: result = "multiple-copy-mode"; break;
+  case MOVEMODE: result = "move-mode"; break;
+  case PASTEMODE: result = "paste-mode"; break;
+  case TEXTMODE: result = "text-mode"; break;
+  case SBOX: result = "box-select-mode"; break;
+  case ZOOMBOX: result = "zoom-box-mode"; break;
+  case PAN: result = "pan-mode"; break;
+  case MIRRORMODE: result = "mirror-mode"; break;
+  case ROTATEMODE: result = "rotate-mode"; break;
+  default: break;
+  }
+
+  return result;
+}

--- a/libleptongui/src/gschem_toplevel.c
+++ b/libleptongui/src/gschem_toplevel.c
@@ -289,7 +289,7 @@ GschemToplevel *gschem_toplevel_new ()
   /* Gschem internal state */
   /* --------------------- */
   w_current->num_untitled = 0;
-  w_current->event_state = SELECT;
+  w_current->action_mode = SELECT;
   w_current->min_zoom = 0;
   w_current->max_zoom = 8;
   w_current->drawbounding_action_mode = FREE;

--- a/libleptongui/src/gschem_toplevel.c
+++ b/libleptongui/src/gschem_toplevel.c
@@ -950,3 +950,39 @@ schematic_window_update_keyaccel_timer (GschemToplevel *w_current,
       g_timeout_add (400, clear_keyaccel_string, w_current);
   }
 }
+
+
+/*! \brief Get action mode for this schematic window.
+ *
+ * \par Function Description
+ * Returns the current action mode value for \a w_current.
+ *
+ * \param [in] w_current The #GschemToplevel instance.
+ * \return The current action mode value.
+ */
+SchematicActionMode
+schematic_window_get_action_mode (GschemToplevel *w_current)
+{
+  g_return_val_if_fail (w_current != NULL, SELECT);
+
+  return (SchematicActionMode) w_current->action_mode;
+}
+
+
+/*! \brief Set action mode for this schematic window.
+ *
+ * \par Function Description
+ * Sets the current action mode value for \a w_current to the
+ * given value.
+ *
+ * \param [in] w_current The #GschemToplevel instance.
+ * \param [in] mode The new action mode value.
+ */
+void
+schematic_window_set_action_mode (GschemToplevel *w_current,
+                                  SchematicActionMode mode)
+{
+  g_return_if_fail (w_current != NULL);
+
+  w_current->action_mode = (int) mode;
+}

--- a/libleptongui/src/gschem_toplevel.c
+++ b/libleptongui/src/gschem_toplevel.c
@@ -289,7 +289,7 @@ GschemToplevel *gschem_toplevel_new ()
   /* Gschem internal state */
   /* --------------------- */
   w_current->num_untitled = 0;
-  w_current->action_mode = SELECT;
+  schematic_window_set_action_mode (w_current, SELECT);
   w_current->min_zoom = 0;
   w_current->max_zoom = 8;
   w_current->drawbounding_action_mode = FREE;

--- a/libleptongui/src/i_basic.c
+++ b/libleptongui/src/i_basic.c
@@ -229,33 +229,9 @@ i_set_state (GschemToplevel *w_current,
 {
   i_set_state_msg(w_current, newstate, NULL);
 
-  const gchar* mode = "select-mode";
-    switch (newstate) {
-      case SELECT: mode="select-mode"; break;
-      case GRIPS: mode="grips-mode"; break;
-      case ARCMODE: mode="arc-mode"; break;
-      case BOXMODE: mode="box-mode"; break;
-      case BUSMODE: mode="bus-mode"; break;
-      case CIRCLEMODE: mode="circle-mode"; break;
-      case LINEMODE: mode="line-mode"; break;
-      case NETMODE: mode="net-mode"; break;
-      case PATHMODE: mode="path-mode"; break;
-      case PICTUREMODE: mode="picture-mode"; break;
-      case PINMODE: mode="pin-mode"; break;
-      case COMPMODE: mode="component-mode"; break;
-      case COPYMODE: mode="copy-mode"; break;
-      case MCOPYMODE: mode="multiple-copy-mode"; break;
-      case MOVEMODE: mode="move-mode"; break;
-      case PASTEMODE: mode="paste-mode"; break;
-      case TEXTMODE: mode="text-mode"; break;
-      case SBOX: mode="box-select-mode"; break;
-      case ZOOMBOX: mode="zoom-box-mode"; break;
-      case PAN: mode="pan-mode"; break;
-      case MIRRORMODE: mode="mirror-mode"; break;
-      case ROTATEMODE: mode="rotate-mode"; break;
-    }
-
   update_state_menu_items (w_current, newstate);
+
+  const gchar* mode = schematic_action_mode_to_string (newstate);
 
   g_run_hook_action_mode (w_current, "switch-action-mode-hook", mode);
 }

--- a/libleptongui/src/i_basic.c
+++ b/libleptongui/src/i_basic.c
@@ -204,7 +204,8 @@ void i_action_update_status (GschemToplevel *w_current, gboolean inside_action)
  *  \param [in] newstate   The new state
  */
 static void
-update_state_menu_items (GschemToplevel* w_current, enum x_states newstate)
+update_state_menu_items (GschemToplevel* w_current,
+                         SchematicActionMode newstate)
 {
   x_menus_sensitivity (w_current->menubar, "&edit-select", newstate != SELECT);
 }
@@ -221,7 +222,9 @@ update_state_menu_items (GschemToplevel* w_current, enum x_states newstate)
  *  \param [in] newstate The new state
  *   *EK* Egil Kvaleberg
  */
-void i_set_state(GschemToplevel *w_current, enum x_states newstate)
+void
+i_set_state (GschemToplevel *w_current,
+             SchematicActionMode newstate)
 {
   i_set_state_msg(w_current, newstate, NULL);
 
@@ -268,8 +271,10 @@ void i_set_state(GschemToplevel *w_current, enum x_states newstate)
  *  \param [in] message Message to be shown
  *   *EK* Egil Kvaleberg
  */
-void i_set_state_msg(GschemToplevel *w_current, enum x_states newstate,
-                     const char *message)
+void
+i_set_state_msg (GschemToplevel *w_current,
+                 SchematicActionMode newstate,
+                 const char *message)
 {
   if ((newstate != w_current->event_state) || (message != NULL)) {
     w_current->event_state = newstate;
@@ -418,7 +423,7 @@ void i_update_menus (GschemToplevel* w_current)
   */
   x_clipboard_query_usable (w_current, clipboard_usable_cb, w_current);
 
-  update_state_menu_items (w_current, (enum x_states) w_current->event_state);
+  update_state_menu_items (w_current, (SchematicActionMode) w_current->event_state);
 
   gboolean selected      = o_select_selected (w_current);
   gboolean text_selected = selected && obj_selected (page, OBJ_TEXT);

--- a/libleptongui/src/i_basic.c
+++ b/libleptongui/src/i_basic.c
@@ -61,7 +61,7 @@ static const char *i_status_string(GschemToplevel *w_current)
 {
   static char *buf = 0;
 
-  switch ( w_current->action_mode )
+  switch (schematic_window_get_action_mode (w_current))
   {
     case SELECT     : return _("Select Mode");
     case SBOX       : return _("Select Box Mode");
@@ -277,9 +277,9 @@ i_set_state_msg (GschemToplevel *w_current,
                  SchematicActionMode newstate,
                  const char *message)
 {
-  if ((newstate != w_current->action_mode) || (message != NULL))
+  if ((newstate != schematic_window_get_action_mode (w_current)) || (message != NULL))
   {
-    w_current->action_mode = newstate;
+    schematic_window_set_action_mode (w_current, newstate);
     i_update_toolbar (w_current);
   }
   i_show_state(w_current, message);
@@ -295,7 +295,7 @@ void i_update_toolbar(GschemToplevel *w_current)
   if (!w_current->toolbars)
     return;
 
-  switch (w_current->action_mode)
+  switch (schematic_window_get_action_mode (w_current))
   {
     case(SELECT):
       gtk_toggle_tool_button_set_active (GTK_TOGGLE_TOOL_BUTTON (w_current->toolbar_select),
@@ -426,7 +426,7 @@ void i_update_menus (GschemToplevel* w_current)
   */
   x_clipboard_query_usable (w_current, clipboard_usable_cb, w_current);
 
-  update_state_menu_items (w_current, (SchematicActionMode) w_current->action_mode);
+  update_state_menu_items (w_current, schematic_window_get_action_mode (w_current));
 
   gboolean selected      = o_select_selected (w_current);
   gboolean text_selected = selected && obj_selected (page, OBJ_TEXT);

--- a/libleptongui/src/i_basic.c
+++ b/libleptongui/src/i_basic.c
@@ -61,7 +61,8 @@ static const char *i_status_string(GschemToplevel *w_current)
 {
   static char *buf = 0;
 
-  switch ( w_current->event_state ) {
+  switch ( w_current->action_mode )
+  {
     case SELECT     : return _("Select Mode");
     case SBOX       : return _("Select Box Mode");
     case TEXTMODE   : return _("Text Mode");
@@ -276,8 +277,9 @@ i_set_state_msg (GschemToplevel *w_current,
                  SchematicActionMode newstate,
                  const char *message)
 {
-  if ((newstate != w_current->event_state) || (message != NULL)) {
-    w_current->event_state = newstate;
+  if ((newstate != w_current->action_mode) || (message != NULL))
+  {
+    w_current->action_mode = newstate;
     i_update_toolbar (w_current);
   }
   i_show_state(w_current, message);
@@ -293,7 +295,8 @@ void i_update_toolbar(GschemToplevel *w_current)
   if (!w_current->toolbars)
     return;
 
-  switch(w_current->event_state) {
+  switch (w_current->action_mode)
+  {
     case(SELECT):
       gtk_toggle_tool_button_set_active (GTK_TOGGLE_TOOL_BUTTON (w_current->toolbar_select),
                                          TRUE);
@@ -423,7 +426,7 @@ void i_update_menus (GschemToplevel* w_current)
   */
   x_clipboard_query_usable (w_current, clipboard_usable_cb, w_current);
 
-  update_state_menu_items (w_current, (SchematicActionMode) w_current->event_state);
+  update_state_menu_items (w_current, (SchematicActionMode) w_current->action_mode);
 
   gboolean selected      = o_select_selected (w_current);
   gboolean text_selected = selected && obj_selected (page, OBJ_TEXT);

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -2546,7 +2546,7 @@ i_callback_cancel (GtkWidget *widget, gpointer data)
 
   g_return_if_fail (w_current != NULL);
 
-  if (w_current->event_state == COMPMODE &&
+  if (w_current->action_mode == COMPMODE &&
       w_current->cswindow) {
     /* user hit escape key when placing components */
 
@@ -2571,7 +2571,8 @@ i_callback_cancel (GtkWidget *widget, gpointer data)
 
     /* If we're cancelling from a grip action, call the specific cancel
      * routine to reset the visibility of the object being modified */
-  if (w_current->event_state == GRIPS) {
+  if (w_current->action_mode == GRIPS)
+  {
     o_grips_cancel (w_current);
   }
 

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -2546,7 +2546,10 @@ i_callback_cancel (GtkWidget *widget, gpointer data)
 
   g_return_if_fail (w_current != NULL);
 
-  if (w_current->action_mode == COMPMODE &&
+  SchematicActionMode action_mode =
+    schematic_window_get_action_mode (w_current);
+
+  if (action_mode == COMPMODE &&
       w_current->cswindow) {
     /* user hit escape key when placing components */
 
@@ -2571,7 +2574,7 @@ i_callback_cancel (GtkWidget *widget, gpointer data)
 
     /* If we're cancelling from a grip action, call the specific cancel
      * routine to reset the visibility of the object being modified */
-  if (w_current->action_mode == GRIPS)
+  if (action_mode == GRIPS)
   {
     o_grips_cancel (w_current);
   }

--- a/libleptongui/src/o_basic.c
+++ b/libleptongui/src/o_basic.c
@@ -187,9 +187,12 @@ void o_redraw_rect (GschemToplevel *w_current,
                       rectangle->width, rectangle->height);
 #endif
 
+  SchematicActionMode action_mode =
+    schematic_window_get_action_mode (w_current);
+
   /* Determine whether we should draw the selection at all */
   draw_selected = !(w_current->inside_action &&
-                    (w_current->action_mode == MOVEMODE));
+                    (action_mode == MOVEMODE));
 
   /* First pass -- render non-selected objects */
   for (iter = obj_list; iter != NULL; iter = g_list_next (iter)) {
@@ -240,7 +243,7 @@ void o_redraw_rect (GschemToplevel *w_current,
 
     /* Redraw the rubberband objects (if they were previously visible) */
     if (page->place_list != NULL) {
-      switch (w_current->action_mode)
+      switch (action_mode)
       {
         case COMPMODE:
         case TEXTMODE:
@@ -275,7 +278,7 @@ void o_redraw_rect (GschemToplevel *w_current,
     }
 
     if (w_current->rubber_visible) {
-      switch (w_current->action_mode)
+      switch (action_mode)
       {
         case ARCMODE    : o_arc_draw_rubber (w_current, renderer); break;
         case BOXMODE    : o_box_draw_rubber (w_current, renderer); break;
@@ -335,7 +338,7 @@ int o_invalidate_rubber (GschemToplevel *w_current)
   if (!w_current->inside_action)
     return(FALSE);
 
-  switch(w_current->action_mode)
+  switch (schematic_window_get_action_mode (w_current))
   {
     case (ARCMODE)    : o_arc_invalidate_rubber (w_current); break;
     case (BOXMODE)    : o_box_invalidate_rubber (w_current); break;
@@ -374,7 +377,10 @@ int o_redraw_cleanstates(GschemToplevel *w_current)
     return FALSE;
   }
 
-  switch (w_current->action_mode)
+  SchematicActionMode action_mode =
+    schematic_window_get_action_mode (w_current);
+
+  switch (action_mode)
   {
     /* all states with something on the dc */
     case(COMPMODE):
@@ -403,15 +409,17 @@ int o_redraw_cleanstates(GschemToplevel *w_current)
 
       /* If we're cancelling from a move action, re-wind the
        * page contents back to their state before we started. */
-      if (w_current->action_mode == MOVEMODE)
+      if (action_mode == MOVEMODE)
       {
         o_move_cancel (w_current);
       }
 
       /* If we're cancelling from a grip action, call the specific cancel
        * routine to reset the visibility of the object being modified */
-      if (w_current->action_mode == GRIPS)
+      if (action_mode == GRIPS)
+      {
         o_grips_cancel (w_current);
+      }
 
       /* Free the place list and its contents. If we were in a move
        * action, the list (refering to objects on the page) would

--- a/libleptongui/src/o_basic.c
+++ b/libleptongui/src/o_basic.c
@@ -189,7 +189,7 @@ void o_redraw_rect (GschemToplevel *w_current,
 
   /* Determine whether we should draw the selection at all */
   draw_selected = !(w_current->inside_action &&
-                    (w_current->event_state == MOVEMODE));
+                    (w_current->action_mode == MOVEMODE));
 
   /* First pass -- render non-selected objects */
   for (iter = obj_list; iter != NULL; iter = g_list_next (iter)) {
@@ -240,7 +240,8 @@ void o_redraw_rect (GschemToplevel *w_current,
 
     /* Redraw the rubberband objects (if they were previously visible) */
     if (page->place_list != NULL) {
-      switch (w_current->event_state) {
+      switch (w_current->action_mode)
+      {
         case COMPMODE:
         case TEXTMODE:
         case COPYMODE:
@@ -274,7 +275,8 @@ void o_redraw_rect (GschemToplevel *w_current,
     }
 
     if (w_current->rubber_visible) {
-      switch (w_current->event_state) {
+      switch (w_current->action_mode)
+      {
         case ARCMODE    : o_arc_draw_rubber (w_current, renderer); break;
         case BOXMODE    : o_box_draw_rubber (w_current, renderer); break;
         case CIRCLEMODE : o_circle_draw_rubber (w_current, renderer); break;
@@ -333,8 +335,8 @@ int o_invalidate_rubber (GschemToplevel *w_current)
   if (!w_current->inside_action)
     return(FALSE);
 
-  switch(w_current->event_state) {
-
+  switch(w_current->action_mode)
+  {
     case (ARCMODE)    : o_arc_invalidate_rubber (w_current); break;
     case (BOXMODE)    : o_box_invalidate_rubber (w_current); break;
     case (BUSMODE)    : o_bus_invalidate_rubber (w_current); break;
@@ -357,7 +359,7 @@ int o_invalidate_rubber (GschemToplevel *w_current)
 /*! \todo Finish function documentation!!!
  *  \brief
  *  \par Function Description
- *  This function is neccesary to make jumps between event_states.
+ *  This function is neccesary to make jumps between action modes.
  *  If we are inside an drawing action that created something on the dc,
  *  e.g. if we are drawing a box and then jump to line drawing without
  *  leaving the box drawing mode, there will remain some rubberbands on the
@@ -372,7 +374,8 @@ int o_redraw_cleanstates(GschemToplevel *w_current)
     return FALSE;
   }
 
-  switch (w_current->event_state) {
+  switch (w_current->action_mode)
+  {
     /* all states with something on the dc */
     case(COMPMODE):
       /* De-select the lists in the component selector */
@@ -400,13 +403,14 @@ int o_redraw_cleanstates(GschemToplevel *w_current)
 
       /* If we're cancelling from a move action, re-wind the
        * page contents back to their state before we started. */
-      if (w_current->event_state == MOVEMODE) {
+      if (w_current->action_mode == MOVEMODE)
+      {
         o_move_cancel (w_current);
       }
 
       /* If we're cancelling from a grip action, call the specific cancel
        * routine to reset the visibility of the object being modified */
-      if (w_current->event_state == GRIPS)
+      if (w_current->action_mode == GRIPS)
         o_grips_cancel (w_current);
 
       /* Free the place list and its contents. If we were in a move

--- a/libleptongui/src/o_copy.c
+++ b/libleptongui/src/o_copy.c
@@ -74,6 +74,6 @@ void o_copy_start(GschemToplevel *w_current, int w_x, int w_y)
 void o_copy_end(GschemToplevel *w_current)
 {
   o_place_end (w_current, w_current->second_wx, w_current->second_wy,
-               (w_current->action_mode == MCOPYMODE),
+               (schematic_window_get_action_mode (w_current) == MCOPYMODE),
                "paste-objects-hook");
 }

--- a/libleptongui/src/o_copy.c
+++ b/libleptongui/src/o_copy.c
@@ -74,6 +74,6 @@ void o_copy_start(GschemToplevel *w_current, int w_x, int w_y)
 void o_copy_end(GschemToplevel *w_current)
 {
   o_place_end (w_current, w_current->second_wx, w_current->second_wy,
-               (w_current->event_state == MCOPYMODE),
+               (w_current->action_mode == MCOPYMODE),
                "paste-objects-hook");
 }

--- a/libleptongui/src/o_delete.c
+++ b/libleptongui/src/o_delete.c
@@ -121,7 +121,8 @@ void o_delete_selected (GschemToplevel *w_current)
 
   g_run_hook_object_list (w_current, "remove-objects-hook", to_remove);
 
-  if (w_current->inside_action && w_current->action_mode == MOVEMODE)
+  if (w_current->inside_action
+      && schematic_window_get_action_mode (w_current) == MOVEMODE)
   {
     /* In MOVEMODE selection is equal to the place list and we
      * have to remove the place list as well. o_move_cancel will

--- a/libleptongui/src/o_delete.c
+++ b/libleptongui/src/o_delete.c
@@ -121,7 +121,8 @@ void o_delete_selected (GschemToplevel *w_current)
 
   g_run_hook_object_list (w_current, "remove-objects-hook", to_remove);
 
-  if (w_current->inside_action && w_current->event_state == MOVEMODE) {
+  if (w_current->inside_action && w_current->action_mode == MOVEMODE)
+  {
     /* In MOVEMODE selection is equal to the place list and we
      * have to remove the place list as well. o_move_cancel will
      * do it for us. */

--- a/libleptongui/src/o_misc.c
+++ b/libleptongui/src/o_misc.c
@@ -249,7 +249,7 @@ void o_rotate_world_update(GschemToplevel *w_current,
     o_undo_savestate_old(w_current, UNDO_ALL);
   }
 
-  if (w_current->action_mode == ROTATEMODE)
+  if (schematic_window_get_action_mode (w_current) == ROTATEMODE)
   {
     i_set_state(w_current, SELECT);
   }
@@ -303,7 +303,7 @@ void o_mirror_world_update(GschemToplevel *w_current, int centerx, int centery, 
   schematic_window_active_page_changed (w_current);
   o_undo_savestate_old(w_current, UNDO_ALL);
 
-  if (w_current->action_mode == MIRRORMODE)
+  if (schematic_window_get_action_mode (w_current) == MIRRORMODE)
   {
     i_set_state(w_current, SELECT);
   }

--- a/libleptongui/src/o_misc.c
+++ b/libleptongui/src/o_misc.c
@@ -249,7 +249,8 @@ void o_rotate_world_update(GschemToplevel *w_current,
     o_undo_savestate_old(w_current, UNDO_ALL);
   }
 
-  if (w_current->event_state == ROTATEMODE) {
+  if (w_current->action_mode == ROTATEMODE)
+  {
     i_set_state(w_current, SELECT);
   }
 }
@@ -302,7 +303,8 @@ void o_mirror_world_update(GschemToplevel *w_current, int centerx, int centery, 
   schematic_window_active_page_changed (w_current);
   o_undo_savestate_old(w_current, UNDO_ALL);
 
-  if (w_current->event_state == MIRRORMODE) {
+  if (w_current->action_mode == MIRRORMODE)
+  {
     i_set_state(w_current, SELECT);
   }
 }

--- a/libleptongui/src/o_place.c
+++ b/libleptongui/src/o_place.c
@@ -222,9 +222,9 @@ void o_place_invalidate_rubber (GschemToplevel *w_current, int drawing)
      * drawn when the invalidate call below causes an expose event. */
     w_current->last_drawb_mode = w_current->actionfeedback_mode;
     w_current->drawbounding_action_mode = (w_current->CONTROLKEY &&
-                                           ! ((w_current->event_state == PASTEMODE) ||
-                                              (w_current->event_state == COMPMODE) ||
-                                              (w_current->event_state == TEXTMODE)))
+                                           ! ((w_current->action_mode == PASTEMODE) ||
+                                              (w_current->action_mode == COMPMODE) ||
+                                              (w_current->action_mode == TEXTMODE)))
                                           ? CONSTRAINED : FREE;
   }
 
@@ -301,9 +301,9 @@ o_place_draw_rubber (GschemToplevel *w_current, EdaRenderer *renderer)
    * constraints, use with the current settings */
   w_current->last_drawb_mode = w_current->actionfeedback_mode;
   w_current->drawbounding_action_mode = (w_current->CONTROLKEY &&
-                                         ! ((w_current->event_state == PASTEMODE) ||
-                                            (w_current->event_state == COMPMODE) ||
-                                            (w_current->event_state == TEXTMODE)))
+                                         ! ((w_current->action_mode == PASTEMODE) ||
+                                            (w_current->action_mode == COMPMODE) ||
+                                            (w_current->action_mode == TEXTMODE)))
                                         ? CONSTRAINED : FREE;
 
   /* Calculate delta of X-Y positions from buffer's origin */

--- a/libleptongui/src/o_place.c
+++ b/libleptongui/src/o_place.c
@@ -218,13 +218,15 @@ void o_place_invalidate_rubber (GschemToplevel *w_current, int drawing)
   /* If drawing is true, then don't worry about the previous drawing
    * method and movement constraints, use with the current settings */
   if (drawing) {
+    SchematicActionMode action_mode =
+      schematic_window_get_action_mode (w_current);
     /* Ensure we set this to flag there is "something" supposed to be
      * drawn when the invalidate call below causes an expose event. */
     w_current->last_drawb_mode = w_current->actionfeedback_mode;
     w_current->drawbounding_action_mode = (w_current->CONTROLKEY &&
-                                           ! ((w_current->action_mode == PASTEMODE) ||
-                                              (w_current->action_mode == COMPMODE) ||
-                                              (w_current->action_mode == TEXTMODE)))
+                                           ! (   (action_mode == PASTEMODE)
+                                              || (action_mode == COMPMODE)
+                                              || (action_mode == TEXTMODE)))
                                           ? CONSTRAINED : FREE;
   }
 
@@ -297,13 +299,15 @@ o_place_draw_rubber (GschemToplevel *w_current, EdaRenderer *renderer)
   gboolean show_hidden_text =
     gschem_toplevel_get_show_hidden_text (w_current);
 
+  SchematicActionMode action_mode =
+    schematic_window_get_action_mode (w_current);
   /* Don't worry about the previous drawing method and movement
    * constraints, use with the current settings */
   w_current->last_drawb_mode = w_current->actionfeedback_mode;
   w_current->drawbounding_action_mode = (w_current->CONTROLKEY &&
-                                         ! ((w_current->action_mode == PASTEMODE) ||
-                                            (w_current->action_mode == COMPMODE) ||
-                                            (w_current->action_mode == TEXTMODE)))
+                                         ! (   (action_mode == PASTEMODE)
+                                            || (action_mode == COMPMODE)
+                                            || (action_mode == TEXTMODE)))
                                         ? CONSTRAINED : FREE;
 
   /* Calculate delta of X-Y positions from buffer's origin */

--- a/libleptongui/src/o_select.c
+++ b/libleptongui/src/o_select.c
@@ -59,7 +59,8 @@ void o_select_start (GschemToplevel *w_current, int wx, int wy)
   /* look for grips or fall through if not enabled */
   o_grips_start(w_current, wx, wy);
 
-  if (w_current->event_state != GRIPS) {
+  if (w_current->action_mode != GRIPS)
+  {
     /* now go into normal SELECT */
     i_action_start (w_current);
     w_current->first_wx = w_current->second_wx = wx;

--- a/libleptongui/src/o_select.c
+++ b/libleptongui/src/o_select.c
@@ -59,7 +59,7 @@ void o_select_start (GschemToplevel *w_current, int wx, int wy)
   /* look for grips or fall through if not enabled */
   o_grips_start(w_current, wx, wy);
 
-  if (w_current->action_mode != GRIPS)
+  if (schematic_window_get_action_mode (w_current) != GRIPS)
   {
     /* now go into normal SELECT */
     i_action_start (w_current);

--- a/libleptongui/src/x_compselect.c
+++ b/libleptongui/src/x_compselect.c
@@ -132,7 +132,8 @@ x_compselect_callback_response (GtkDialog *dialog,
               g_assert_not_reached ();
         }
 
-        if (w_current->event_state == COMPMODE) {
+        if (w_current->action_mode == COMPMODE)
+        {
           /* Delete the component which was being placed */
           if (w_current->rubber_visible)
             o_place_invalidate_rubber (w_current, FALSE);
@@ -174,8 +175,8 @@ x_compselect_callback_response (GtkDialog *dialog,
         gtk_widget_destroy (GTK_WIDGET (dialog));
         w_current->cswindow = NULL;
 
-        if (w_current->event_state == COMPMODE) {
-
+        if (w_current->action_mode == COMPMODE)
+        {
           /* Cancel the place operation currently in progress */
           o_redraw_cleanstates (w_current);
 

--- a/libleptongui/src/x_compselect.c
+++ b/libleptongui/src/x_compselect.c
@@ -108,6 +108,9 @@ x_compselect_callback_response (GtkDialog *dialog,
   GschemToplevel *w_current = (GschemToplevel *)user_data;
   LeptonToplevel *toplevel = gschem_toplevel_get_toplevel (w_current);
 
+  SchematicActionMode action_mode =
+    schematic_window_get_action_mode (w_current);
+
   switch (arg1) {
       case COMPSELECT_RESPONSE_PLACE: {
         CLibSymbol *symbol = NULL;
@@ -132,7 +135,7 @@ x_compselect_callback_response (GtkDialog *dialog,
               g_assert_not_reached ();
         }
 
-        if (w_current->action_mode == COMPMODE)
+        if (action_mode == COMPMODE)
         {
           /* Delete the component which was being placed */
           if (w_current->rubber_visible)
@@ -175,7 +178,7 @@ x_compselect_callback_response (GtkDialog *dialog,
         gtk_widget_destroy (GTK_WIDGET (dialog));
         w_current->cswindow = NULL;
 
-        if (w_current->action_mode == COMPMODE)
+        if (action_mode == COMPMODE)
         {
           /* Cancel the place operation currently in progress */
           o_redraw_cleanstates (w_current);

--- a/libleptongui/src/x_event.c
+++ b/libleptongui/src/x_event.c
@@ -101,7 +101,7 @@ x_event_button_pressed(GschemPageView *page_view, GdkEventButton *event, GschemT
 #if DEBUG
   printf("pressed button %d! \n", event->button);
   printf("event state: %d \n", event->state);
-  printf("w_current state: %d \n", w_current->event_state);
+  printf("w_current state: %d \n", w_current->action_mode);
   printf("Selection is:\n");
   o_selection_print_all(&(page->selection_list));
   printf("\n");
@@ -113,7 +113,8 @@ x_event_button_pressed(GschemPageView *page_view, GdkEventButton *event, GschemT
   w_y = snap_grid (w_current, unsnapped_wy);
 
   if (event->type == GDK_2BUTTON_PRESS &&
-      w_current->event_state == SELECT) {
+      w_current->action_mode == SELECT)
+  {
     /* Don't re-select an object (lp-912978) */
     /* o_find_object(w_current, w_x, w_y, TRUE); */
 
@@ -141,7 +142,8 @@ x_event_button_pressed(GschemPageView *page_view, GdkEventButton *event, GschemT
     if (w_current->inside_action) {
       /* End action */
       if (page->place_list != NULL) {
-        switch(w_current->event_state) {
+        switch(w_current->action_mode)
+        {
           case (COMPMODE)   : o_place_end(w_current, w_x, w_y, w_current->continue_component_place,
                                 "add-objects-hook"); break;
           case (TEXTMODE)   : o_place_end(w_current, w_x, w_y, FALSE,
@@ -151,7 +153,8 @@ x_event_button_pressed(GschemPageView *page_view, GdkEventButton *event, GschemT
           default: break;
         }
       } else {
-        switch(w_current->event_state) {
+        switch(w_current->action_mode)
+        {
           case (ARCMODE)    : o_arc_end1(w_current, w_x, w_y); break;
           case (BOXMODE)    : o_box_end(w_current, w_x, w_y); break;
           case (BUSMODE)    : o_bus_end(w_current, w_x, w_y); break;
@@ -166,7 +169,8 @@ x_event_button_pressed(GschemPageView *page_view, GdkEventButton *event, GschemT
       }
     } else {
       /* Start action */
-      switch(w_current->event_state) {
+      switch(w_current->action_mode)
+      {
         case (ARCMODE)    : o_arc_start(w_current, w_x, w_y); break;
         case (BOXMODE)    : o_box_start(w_current, w_x, w_y); break;
         case (BUSMODE)    : o_bus_start(w_current, w_x, w_y); break;
@@ -186,7 +190,8 @@ x_event_button_pressed(GschemPageView *page_view, GdkEventButton *event, GschemT
       }
     }
 
-    switch(w_current->event_state) {
+    switch(w_current->action_mode)
+    {
       case(ROTATEMODE):   o_rotate_world_update(w_current, w_x, w_y, 90,
                             lepton_list_get_glist(page->selection_list)); break;
       case(MIRRORMODE):   o_mirror_world_update(w_current, w_x, w_y,
@@ -201,12 +206,13 @@ x_event_button_pressed(GschemPageView *page_view, GdkEventButton *event, GschemT
 
     /* try this out and see how it behaves */
     if (w_current->inside_action) {
-      if (!(w_current->event_state == COMPMODE||
-            w_current->event_state == TEXTMODE||
-            w_current->event_state == MOVEMODE||
-            w_current->event_state == COPYMODE  ||
-            w_current->event_state == MCOPYMODE ||
-            w_current->event_state == PASTEMODE )) {
+      if (!(w_current->action_mode == COMPMODE||
+            w_current->action_mode == TEXTMODE||
+            w_current->action_mode == MOVEMODE||
+            w_current->action_mode == COPYMODE  ||
+            w_current->action_mode == MCOPYMODE ||
+            w_current->action_mode == PASTEMODE ))
+      {
         i_callback_cancel (NULL, w_current);
       }
       goto end_button_pressed;
@@ -282,8 +288,8 @@ x_event_button_pressed(GschemPageView *page_view, GdkEventButton *event, GschemT
 
         /* reset all draw and place actions */
 
-        switch (w_current->event_state) {
-
+        switch (w_current->action_mode)
+        {
           case (ARCMODE)    : o_arc_invalidate_rubber     (w_current); break;
           case (BOXMODE)    : o_box_invalidate_rubber     (w_current); break;
           case (BUSMODE)    : o_bus_reset                 (w_current); break;
@@ -328,7 +334,7 @@ x_event_button_released (GschemPageView *page_view, GdkEventButton *event, Gsche
   }
 
 #if DEBUG
-  printf("released! %d \n", w_current->event_state);
+  printf("released! %d \n", w_current->action_mode);
 #endif
 
   w_current->SHIFTKEY   = (event->state & GDK_SHIFT_MASK  ) ? 1 : 0;
@@ -350,14 +356,16 @@ x_event_button_released (GschemPageView *page_view, GdkEventButton *event, Gsche
 
     if (w_current->inside_action) {
       if (page->place_list != NULL) {
-        switch(w_current->event_state) {
+        switch(w_current->action_mode)
+        {
           case (COPYMODE)  :
           case (MCOPYMODE) : o_copy_end(w_current); break;
           case (MOVEMODE)  : o_move_end(w_current); break;
           default: break;
         }
       } else {
-        switch(w_current->event_state) {
+        switch(w_current->action_mode)
+        {
           case (GRIPS)     : o_grips_end(w_current); break;
           case (PATHMODE)  : o_path_end (w_current, w_x, w_y); break;
           case (SBOX)      : o_select_box_end(w_current, unsnapped_wx, unsnapped_wy); break;
@@ -370,14 +378,15 @@ x_event_button_released (GschemPageView *page_view, GdkEventButton *event, Gsche
   } else if (event->button == 2) {
 
     if (w_current->inside_action) {
-      if (w_current->event_state == COMPMODE||
-          w_current->event_state == TEXTMODE||
-          w_current->event_state == MOVEMODE||
-          w_current->event_state == COPYMODE  ||
-          w_current->event_state == MCOPYMODE ||
-          w_current->event_state == PASTEMODE ) {
-
-        if (w_current->event_state == MOVEMODE) {
+      if (w_current->action_mode == COMPMODE||
+          w_current->action_mode == TEXTMODE||
+          w_current->action_mode == MOVEMODE||
+          w_current->action_mode == COPYMODE  ||
+          w_current->action_mode == MCOPYMODE ||
+          w_current->action_mode == PASTEMODE )
+      {
+        if (w_current->action_mode == MOVEMODE)
+        {
           o_move_invalidate_rubber (w_current, FALSE);
         } else {
           o_place_invalidate_rubber (w_current, FALSE);
@@ -386,11 +395,13 @@ x_event_button_released (GschemPageView *page_view, GdkEventButton *event, Gsche
 
         o_place_rotate(w_current);
 
-        if (w_current->event_state == COMPMODE) {
+        if (w_current->action_mode == COMPMODE)
+        {
           o_component_place_changed_run_hook (w_current);
         }
 
-        if (w_current->event_state == MOVEMODE) {
+        if (w_current->action_mode == MOVEMODE)
+        {
           o_move_invalidate_rubber (w_current, TRUE);
         } else {
           o_place_invalidate_rubber (w_current, TRUE);
@@ -403,7 +414,8 @@ x_event_button_released (GschemPageView *page_view, GdkEventButton *event, Gsche
     switch(w_current->middle_button) {
       case(MOUSEBTN_DO_ACTION):
         if (w_current->inside_action && (page->place_list != NULL)) {
-          switch(w_current->event_state) {
+          switch(w_current->action_mode)
+          {
             case (COPYMODE): o_copy_end(w_current); break;
             case (MOVEMODE): o_move_end(w_current); break;
           }
@@ -505,7 +517,8 @@ x_event_motion (GschemPageView *page_view, GdkEventMotion *event, GschemToplevel
 
   if (w_current->inside_action) {
     if (page->place_list != NULL) {
-      switch(w_current->event_state) {
+      switch (w_current->action_mode)
+      {
         case (COPYMODE)   :
         case (MCOPYMODE)  :
         case (COMPMODE)   :
@@ -515,7 +528,8 @@ x_event_motion (GschemPageView *page_view, GdkEventMotion *event, GschemToplevel
         default: break;
       }
     } else {
-      switch(w_current->event_state) {
+      switch (w_current->action_mode)
+      {
         case (ARCMODE)    : o_arc_motion (w_current, w_x, w_y, ARC_RADIUS); break;
         case (BOXMODE)    : o_box_motion  (w_current, w_x, w_y); break;
         case (BUSMODE)    : o_bus_motion (w_current, w_x, w_y); break;
@@ -533,7 +547,8 @@ x_event_motion (GschemPageView *page_view, GdkEventMotion *event, GschemToplevel
       }
     }
   } else {
-    switch(w_current->event_state) {
+    switch (w_current->action_mode)
+    {
       case(NETMODE)    :   o_net_start_magnetic(w_current, w_x, w_y); break;
       default: break;
     }

--- a/libleptongui/src/x_event.c
+++ b/libleptongui/src/x_event.c
@@ -204,6 +204,7 @@ x_event_button_pressed(GschemPageView *page_view, GdkEventButton *event, GschemT
         gschem_page_view_pan (page_view, w_x, w_y);
         i_set_state(w_current, SELECT);
         break;
+    default: break;
     }
   } else if (event->button == 2) {
 
@@ -424,6 +425,7 @@ x_event_button_released (GschemPageView *page_view, GdkEventButton *event, Gsche
           {
             case (COPYMODE): o_copy_end(w_current); break;
             case (MOVEMODE): o_move_end(w_current); break;
+            default: break;
           }
         }
       break;

--- a/libleptongui/src/x_tabs.c
+++ b/libleptongui/src/x_tabs.c
@@ -1161,7 +1161,10 @@ x_tabs_hdr_on_btn_save (GtkToolButton* btn, gpointer p)
 static void
 x_tabs_cancel_all (GschemToplevel* w_current)
 {
-  if (w_current->action_mode == COMPMODE && w_current->cswindow)
+  SchematicActionMode action_mode =
+    schematic_window_get_action_mode (w_current);
+
+  if (action_mode == COMPMODE && w_current->cswindow)
   {
     o_place_invalidate_rubber (w_current, FALSE);
     w_current->rubber_visible = 0;
@@ -1179,7 +1182,7 @@ x_tabs_cancel_all (GschemToplevel* w_current)
     o_move_cancel (w_current);
   }
 
-  if (w_current->action_mode == GRIPS)
+  if (action_mode == GRIPS)
   {
     o_grips_cancel (w_current);
   }

--- a/libleptongui/src/x_tabs.c
+++ b/libleptongui/src/x_tabs.c
@@ -1161,7 +1161,7 @@ x_tabs_hdr_on_btn_save (GtkToolButton* btn, gpointer p)
 static void
 x_tabs_cancel_all (GschemToplevel* w_current)
 {
-  if (w_current->event_state == COMPMODE && w_current->cswindow)
+  if (w_current->action_mode == COMPMODE && w_current->cswindow)
   {
     o_place_invalidate_rubber (w_current, FALSE);
     w_current->rubber_visible = 0;
@@ -1179,7 +1179,7 @@ x_tabs_cancel_all (GschemToplevel* w_current)
     o_move_cancel (w_current);
   }
 
-  if (w_current->event_state == GRIPS)
+  if (w_current->action_mode == GRIPS)
   {
     o_grips_cancel (w_current);
   }


### PR DESCRIPTION
Well, it just replaces the `x_states` enum.  However, the following changes have been made:
- The new name better reflects the aim of the type, and we already have a hook with name containing `action_mode` as a suffix.
- Accessors for the corresponding window's field have been added and are now utilized in the code.
- Several minor clean-ups have been made.
- Functions for conversion of the enum values between C and Scheme code have been added (I'm going to utilize them in ensuing commits). 