### PR TITLE
Get rid of some simple i_callback_*() functions

### DIFF
--- a/libleptongui/include/page_select_widget.h
+++ b/libleptongui/include/page_select_widget.h
@@ -46,6 +46,7 @@ struct _PageSelectWidget
 typedef struct _PageSelectWidgetClass PageSelectWidgetClass;
 typedef struct _PageSelectWidget      PageSelectWidget;
 
+G_BEGIN_DECLS
 
 GtkWidget*
 page_select_widget_new (GschemToplevel* w_current);
@@ -57,5 +58,6 @@ page_select_widget_update (GschemToplevel* w_current);
 GType
 page_select_widget_get_type();
 
-#endif /* LEPTON_PAGE_SELECT_WIDGET_H_ */
+G_END_DECLS
 
+#endif /* LEPTON_PAGE_SELECT_WIDGET_H_ */

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -125,7 +125,6 @@ void i_callback_view_dark_colors (GtkWidget *widget, gpointer data);
 void i_callback_view_light_colors (GtkWidget *widget, gpointer data);
 void i_callback_view_bw_colors (GtkWidget *widget, gpointer data);
 void i_callback_view_color_edit (GtkWidget *widget, gpointer data);
-void i_callback_page_manager (GtkWidget *widget, gpointer data);
 void i_callback_page_next (GtkWidget *widget, gpointer data);
 void i_callback_page_prev (GtkWidget *widget, gpointer data);
 void i_callback_page_close (GtkWidget *widget, gpointer data);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -178,7 +178,6 @@ void i_callback_options_snap (GtkWidget *widget, gpointer data);
 void i_callback_options_rubberband (GtkWidget *widget, gpointer data);
 void i_callback_options_magneticnet (GtkWidget *widget, gpointer data);
 void i_callback_cancel (GtkWidget *widget, gpointer data);
-void i_callback_help_hotkeys (GtkWidget *widget, gpointer data);
 void i_callback_options_draw_grips (GtkWidget *widget, gpointer data);
 gboolean i_callback_close_wm(GtkWidget *widget, GdkEvent *event, gpointer data);
 /* i_vars.c */

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -178,7 +178,6 @@ void i_callback_options_snap (GtkWidget *widget, gpointer data);
 void i_callback_options_rubberband (GtkWidget *widget, gpointer data);
 void i_callback_options_magneticnet (GtkWidget *widget, gpointer data);
 void i_callback_cancel (GtkWidget *widget, gpointer data);
-void i_callback_help_about (GtkWidget *widget, gpointer data);
 void i_callback_help_hotkeys (GtkWidget *widget, gpointer data);
 void i_callback_options_draw_grips (GtkWidget *widget, gpointer data);
 gboolean i_callback_close_wm(GtkWidget *widget, GdkEvent *event, gpointer data);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -128,7 +128,6 @@ void i_callback_view_color_edit (GtkWidget *widget, gpointer data);
 void i_callback_page_next (GtkWidget *widget, gpointer data);
 void i_callback_page_prev (GtkWidget *widget, gpointer data);
 void i_callback_page_close (GtkWidget *widget, gpointer data);
-void i_callback_page_prev_tab (GtkWidget *widget, gpointer data);
 void i_callback_page_revert (GtkWidget *widget, gpointer data);
 void i_callback_page_print (GtkWidget *widget, gpointer data);
 void i_callback_clipboard_copy (GtkWidget *widget, gpointer data);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -128,7 +128,6 @@ void i_callback_view_color_edit (GtkWidget *widget, gpointer data);
 void i_callback_page_next (GtkWidget *widget, gpointer data);
 void i_callback_page_prev (GtkWidget *widget, gpointer data);
 void i_callback_page_close (GtkWidget *widget, gpointer data);
-void i_callback_page_next_tab (GtkWidget *widget, gpointer data);
 void i_callback_page_prev_tab (GtkWidget *widget, gpointer data);
 void i_callback_page_revert (GtkWidget *widget, gpointer data);
 void i_callback_page_print (GtkWidget *widget, gpointer data);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -111,7 +111,6 @@ void i_callback_edit_show_text (GtkWidget *widget, gpointer data);
 void i_callback_edit_autonumber_text (GtkWidget *widget, gpointer data);
 void i_callback_view_sidebar (GtkWidget *widget, gpointer data);
 void i_callback_view_status (GtkWidget *widget, gpointer data);
-void i_callback_view_find_text_state (GtkWidget *widget, gpointer data);
 void i_callback_view_redraw (GtkWidget *widget, gpointer data);
 void i_callback_view_zoom_full (GtkWidget *widget, gpointer data);
 void i_callback_view_zoom_extents (GtkWidget *widget, gpointer data);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -111,7 +111,6 @@ void i_callback_edit_show_text (GtkWidget *widget, gpointer data);
 void i_callback_edit_autonumber_text (GtkWidget *widget, gpointer data);
 void i_callback_view_sidebar (GtkWidget *widget, gpointer data);
 void i_callback_view_status (GtkWidget *widget, gpointer data);
-void i_callback_view_redraw (GtkWidget *widget, gpointer data);
 void i_callback_view_zoom_full (GtkWidget *widget, gpointer data);
 void i_callback_view_zoom_extents (GtkWidget *widget, gpointer data);
 void i_callback_view_zoom_box (GtkWidget *widget, gpointer data);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -94,7 +94,6 @@ void i_callback_edit_mcopy (GtkWidget *widget, gpointer data);
 void i_callback_edit_move (GtkWidget *widget, gpointer data);
 void i_callback_edit_delete (GtkWidget *widget, gpointer data);
 void i_callback_edit_edit (GtkWidget *widget, gpointer data);
-void i_callback_edit_slot (GtkWidget *widget, gpointer data);
 void i_callback_edit_rotate_90 (GtkWidget *widget, gpointer data);
 void i_callback_edit_mirror (GtkWidget *widget, gpointer data);
 void i_callback_edit_lock (GtkWidget *widget, gpointer data);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -177,7 +177,6 @@ void i_callback_options_grid (GtkWidget *widget, gpointer data);
 void i_callback_options_snap (GtkWidget *widget, gpointer data);
 void i_callback_options_rubberband (GtkWidget *widget, gpointer data);
 void i_callback_options_magneticnet (GtkWidget *widget, gpointer data);
-void i_callback_options_show_log_window (GtkWidget *widget, gpointer data);
 void i_callback_cancel (GtkWidget *widget, gpointer data);
 void i_callback_help_about (GtkWidget *widget, gpointer data);
 void i_callback_help_hotkeys (GtkWidget *widget, gpointer data);

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -285,7 +285,9 @@
   (run-callback i_callback_page_revert "&page-revert"))
 
 (define-action-public (&page-manager #:label (G_ "Page Manager"))
-  (run-callback i_callback_page_manager "&page-manager"))
+  (define *window (*current-window))
+  (x_widgets_show_page_select *window)
+  (page_select_widget_update *window))
 
 (define-action-public (&page-prev #:label (G_ "Previous Page") #:icon "gtk-go-back")
   (run-callback i_callback_page_prev "&page-prev"))

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -580,7 +580,7 @@ found, shows a dialog with an error message."
 
 
 (define-action-public (&help-about #:label (G_ "About lepton-schematic") #:icon "gtk-about")
-  (run-callback i_callback_help_about "&help-about"))
+  (about_dialog (*current-window)))
 
 
 ; Backward compatibility:

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -299,7 +299,7 @@
   (run-callback i_callback_page_close "&page-close"))
 
 (define-action-public (&page-next-tab #:label (G_ "Next Tab") #:icon "gtk-go-forward")
-  (run-callback i_callback_page_next_tab "&page-next-tab"))
+  (x_tabs_next (*current-window)))
 
 (define-action-public (&page-prev-tab #:label (G_ "Previous Tab") #:icon "gtk-go-back")
   (run-callback i_callback_page_prev_tab "&page-prev-tab"))

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -176,7 +176,10 @@
   (text_edit_dialog (*current-window)))
 
 (define-action-public (&edit-slot #:label (G_ "Choose Slot"))
-  (run-callback i_callback_edit_slot "&edit-slot"))
+  (let* ((*window (*current-window))
+         (*object (o_select_return_first_object *window)))
+    (unless (null-pointer? *object)
+      (o_slot_start *window *object))))
 
 ;;; Show "object properties" widget.
 (define-action-public (&edit-object-properties #:label (G_ "Edit Object Properties") #:icon "gtk-properties")

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -227,8 +227,9 @@
 (define-action-public (&view-status #:label (G_ "Status"))
   (run-callback i_callback_view_status "&view-status"))
 
+;;; Show the find text state window.
 (define-action-public (&view-find-text-state #:label (G_ "Find Text State"))
-  (run-callback i_callback_view_find_text_state "&view-find-text-state"))
+  (x_widgets_show_find_text_state (*current-window)))
 
 (define-action-public (&view-redraw #:label (G_ "Redraw") #:icon "gtk-refresh")
   (run-callback i_callback_view_redraw "&view-redraw"))

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -538,7 +538,7 @@
   (run-callback i_callback_options_magneticnet "&options-magneticnet"))
 
 (define-action-public (&options-show-log-window #:label (G_ "Show Log Window"))
-  (run-callback i_callback_options_show_log_window "&options-show-log-window"))
+  (x_widgets_show_log (*current-window)))
 
 (define-action-public (&options-show-coord-window #:label (G_ "Show Coordinate Window"))
   (coord_dialog (*current-window) 0 0))

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -231,8 +231,10 @@
 (define-action-public (&view-find-text-state #:label (G_ "Find Text State"))
   (x_widgets_show_find_text_state (*current-window)))
 
+;;; Redraw canvas.
 (define-action-public (&view-redraw #:label (G_ "Redraw") #:icon "gtk-refresh")
-  (run-callback i_callback_view_redraw "&view-redraw"))
+  (gschem_page_view_invalidate_all
+   (gschem_toplevel_get_current_page_view (*current-window))))
 
 (define-action-public (&view-pan #:label (G_ "Pan"))
   (run-callback i_callback_view_pan "&view-pan"))

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -302,7 +302,7 @@
   (x_tabs_next (*current-window)))
 
 (define-action-public (&page-prev-tab #:label (G_ "Previous Tab") #:icon "gtk-go-back")
-  (run-callback i_callback_page_prev_tab "&page-prev-tab"))
+  (x_tabs_prev (*current-window)))
 
 (define-action-public (&page-print #:label (G_ "Print Page") #:icon "gtk-print")
   (run-callback i_callback_page_print "&page-print"))

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -511,7 +511,7 @@
 ;;;; Configuration actions
 
 (define-action-public (&help-hotkeys #:label (G_ "Show Hotkeys") #:icon "preferences-desktop-keyboard-shortcuts")
-  (run-callback i_callback_help_hotkeys "&help-hotkeys"))
+  (x_dialog_hotkeys (*current-window)))
 
 (define-action-public (&options-grid #:label (G_ "Switch Grid Style"))
   (run-callback i_callback_options_grid "&options-grid"))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -96,7 +96,6 @@
             i_callback_options_snap_size
             i_callback_page_close
             i_callback_page_next
-            i_callback_page_next_tab
             i_callback_page_prev
             i_callback_page_prev_tab
             i_callback_page_print
@@ -181,6 +180,8 @@
             x_image_setup
 
             x_print
+
+            x_tabs_next
 
             parse-gschemrc
             ))
@@ -359,7 +360,6 @@
 (define-lff i_callback_view_zoom_out void '(* *))
 (define-lff i_callback_page_close void '(* *))
 (define-lff i_callback_page_next void '(* *))
-(define-lff i_callback_page_next_tab void '(* *))
 (define-lff i_callback_page_prev void '(* *))
 (define-lff i_callback_page_prev_tab void '(* *))
 (define-lff i_callback_page_print void '(* *))
@@ -380,6 +380,9 @@
 
 ;;; x_print.c
 (define-lff x_print void '(*))
+
+;;; x_tabs.c
+(define-lff x_tabs_next void '(*))
 
 ;;; o_undo.c
 (define-lff o_undo_init void '())

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -105,7 +105,6 @@
             i_callback_view_bw_colors
             i_callback_view_color_edit
             i_callback_view_dark_colors
-            i_callback_view_find_text_state
             i_callback_view_light_colors
             i_callback_view_pan
             i_callback_view_pan_down
@@ -132,6 +131,7 @@
             x_show_uri
             x_stroke_init
 
+            x_widgets_show_find_text_state
             x_widgets_show_font_select
             x_widgets_show_log
             x_widgets_show_object_properties
@@ -212,6 +212,7 @@
 (define-lff x_color_init void '())
 
 ;;; x_widgets.c
+(define-lff x_widgets_show_find_text_state void '(*))
 (define-lff x_widgets_show_font_select void '(*))
 (define-lff x_widgets_show_log void '(*))
 (define-lff x_widgets_show_object_properties void '(*))
@@ -335,7 +336,6 @@
 (define-lff i_callback_view_bw_colors void '(* *))
 (define-lff i_callback_view_color_edit void '(* *))
 (define-lff i_callback_view_dark_colors void '(* *))
-(define-lff i_callback_view_find_text_state void '(* *))
 (define-lff i_callback_view_light_colors void '(* *))
 (define-lff i_callback_view_pan void '(* *))
 (define-lff i_callback_view_pan_down void '(* *))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -111,7 +111,6 @@
             i_callback_view_pan_left
             i_callback_view_pan_right
             i_callback_view_pan_up
-            i_callback_view_redraw
             i_callback_view_sidebar
             i_callback_view_status
             i_callback_view_zoom_box
@@ -155,6 +154,7 @@
             lepton_menu_set_action_data
 
             gschem_page_view_get_page
+            gschem_page_view_invalidate_all
 
             gschem_toplevel_get_current_page_view
             gschem_toplevel_get_toplevel
@@ -227,6 +227,7 @@
 
 ;;; gschem_page_view.c
 (define-lff gschem_page_view_get_page '* '(*))
+(define-lff gschem_page_view_invalidate_all void '(*))
 
 ;;; gschem_toplevel.c
 (define-lff gschem_toplevel_get_current_page_view '* '(*))
@@ -342,7 +343,6 @@
 (define-lff i_callback_view_pan_left void '(* *))
 (define-lff i_callback_view_pan_right void '(* *))
 (define-lff i_callback_view_pan_up void '(* *))
-(define-lff i_callback_view_redraw void '(* *))
 (define-lff i_callback_view_sidebar void '(* *))
 (define-lff i_callback_view_status void '(* *))
 (define-lff i_callback_view_zoom_box void '(* *))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -79,7 +79,6 @@
             i_callback_file_save
             i_callback_file_save_all
             i_callback_file_script
-            i_callback_help_hotkeys
             i_callback_hierarchy_down_schematic
             i_callback_hierarchy_down_symbol
             i_callback_hierarchy_up
@@ -146,6 +145,8 @@
             about_dialog
 
             coord_dialog
+
+            x_dialog_hotkeys
 
             schematic_keys_get_event_keyval
             schematic_keys_get_event_modifiers
@@ -235,6 +236,9 @@
 
 ;;; gschem_coord_dialog.c
 (define-lff coord_dialog void (list '* int int))
+
+;;; gschem_hotkey_dialog.c
+(define-lff x_dialog_hotkeys void '(*))
 
 ;;; gschem_page_view.c
 (define-lff gschem_page_view_get_page '* '(*))
@@ -330,7 +334,6 @@
 (define-lff i_callback_file_save void '(* *))
 (define-lff i_callback_file_save_all void '(* *))
 (define-lff i_callback_file_script void '(* *))
-(define-lff i_callback_help_hotkeys void '(* *))
 (define-lff i_callback_hierarchy_down_schematic void '(* *))
 (define-lff i_callback_hierarchy_down_symbol void '(* *))
 (define-lff i_callback_hierarchy_up void '(* *))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -95,7 +95,6 @@
             i_callback_options_snap
             i_callback_options_snap_size
             i_callback_page_close
-            i_callback_page_manager
             i_callback_page_next
             i_callback_page_next_tab
             i_callback_page_prev
@@ -123,6 +122,9 @@
             o_attrib_add_attrib
             o_buffer_init
             o_undo_init
+
+            page_select_widget_update
+
             set_quiet_mode
             set_verbose_mode
             x_color_init
@@ -134,6 +136,7 @@
             x_widgets_show_font_select
             x_widgets_show_log
             x_widgets_show_object_properties
+            x_widgets_show_page_select
 
             x_window_create_main
             x_window_close
@@ -206,6 +209,9 @@
 ;;; o_attrib.c
 (define-lff o_attrib_add_attrib '* (list '* '* int int '* int int int))
 
+;;; page_select_widget.c
+(define-lff page_select_widget_update void '(*))
+
 (define-lff o_buffer_init void '())
 (define-lff set_quiet_mode void '())
 (define-lff set_verbose_mode void '())
@@ -216,6 +222,7 @@
 (define-lff x_widgets_show_font_select void '(*))
 (define-lff x_widgets_show_log void '(*))
 (define-lff x_widgets_show_object_properties void '(*))
+(define-lff x_widgets_show_page_select void '(*))
 
 ;;; keys.c
 (define-lff schematic_keys_get_event_keyval int '(*))
@@ -351,7 +358,6 @@
 (define-lff i_callback_view_zoom_in void '(* *))
 (define-lff i_callback_view_zoom_out void '(* *))
 (define-lff i_callback_page_close void '(* *))
-(define-lff i_callback_page_manager void '(* *))
 (define-lff i_callback_page_next void '(* *))
 (define-lff i_callback_page_next_tab void '(* *))
 (define-lff i_callback_page_prev void '(* *))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -68,7 +68,6 @@
             i_callback_edit_select_all
             i_callback_edit_show_hidden
             i_callback_edit_show_text
-            i_callback_edit_slot
             i_callback_edit_translate
             i_callback_edit_undo
             i_callback_edit_unembed
@@ -169,6 +168,10 @@
             gschem_options_get_snap_size
 
             text_edit_dialog
+
+            o_select_return_first_object
+
+            o_slot_start
 
             o_undo_savestate
 
@@ -323,7 +326,6 @@
 (define-lff i_callback_edit_select_all void '(* *))
 (define-lff i_callback_edit_show_hidden void '(* *))
 (define-lff i_callback_edit_show_text void '(* *))
-(define-lff i_callback_edit_slot void '(* *))
 (define-lff i_callback_edit_translate void '(* *))
 (define-lff i_callback_edit_undo void '(* *))
 (define-lff i_callback_edit_unembed void '(* *))
@@ -383,6 +385,12 @@
 
 ;;; x_print.c
 (define-lff x_print void '(*))
+
+;;; o_slot.c
+(define-lff o_slot_start void '(* *))
+
+;;; o_select.c
+(define-lff o_select_return_first_object '* '(*))
 
 ;;; x_tabs.c
 (define-lff x_tabs_next void '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -97,7 +97,6 @@
             i_callback_page_close
             i_callback_page_next
             i_callback_page_prev
-            i_callback_page_prev_tab
             i_callback_page_print
             i_callback_page_revert
             i_callback_view_bw_colors
@@ -182,6 +181,7 @@
             x_print
 
             x_tabs_next
+            x_tabs_prev
 
             parse-gschemrc
             ))
@@ -361,7 +361,6 @@
 (define-lff i_callback_page_close void '(* *))
 (define-lff i_callback_page_next void '(* *))
 (define-lff i_callback_page_prev void '(* *))
-(define-lff i_callback_page_prev_tab void '(* *))
 (define-lff i_callback_page_print void '(* *))
 (define-lff i_callback_page_revert void '(* *))
 ;;; x_misc.c
@@ -383,6 +382,7 @@
 
 ;;; x_tabs.c
 (define-lff x_tabs_next void '(*))
+(define-lff x_tabs_prev void '(*))
 
 ;;; o_undo.c
 (define-lff o_undo_init void '())

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -91,7 +91,6 @@
             i_callback_options_rubberband
             i_callback_options_scale_down_snap_size
             i_callback_options_scale_up_snap_size
-            i_callback_options_show_log_window
             i_callback_options_snap
             i_callback_options_snap_size
             i_callback_page_close
@@ -339,7 +338,6 @@
 (define-lff i_callback_options_rubberband void '(* *))
 (define-lff i_callback_options_scale_down_snap_size void '(* *))
 (define-lff i_callback_options_scale_up_snap_size void '(* *))
-(define-lff i_callback_options_show_log_window void '(* *))
 (define-lff i_callback_options_snap void '(* *))
 (define-lff i_callback_options_snap_size void '(* *))
 (define-lff i_callback_view_bw_colors void '(* *))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -79,7 +79,6 @@
             i_callback_file_save
             i_callback_file_save_all
             i_callback_file_script
-            i_callback_help_about
             i_callback_help_hotkeys
             i_callback_hierarchy_down_schematic
             i_callback_hierarchy_down_symbol
@@ -143,6 +142,8 @@
             x_window_open_page
             x_window_set_current_page
             x_window_setup
+
+            about_dialog
 
             coord_dialog
 
@@ -228,6 +229,9 @@
 (define-lff schematic_keys_get_event_keyval int '(*))
 (define-lff schematic_keys_get_event_modifiers int '(*))
 (define-lff schematic_keys_verify_keyval int (list int))
+
+;;; gschem_about_dialog.c
+(define-lff about_dialog void '(*))
 
 ;;; gschem_coord_dialog.c
 (define-lff coord_dialog void (list '* int int))
@@ -326,7 +330,6 @@
 (define-lff i_callback_file_save void '(* *))
 (define-lff i_callback_file_save_all void '(* *))
 (define-lff i_callback_file_script void '(* *))
-(define-lff i_callback_help_about void '(* *))
 (define-lff i_callback_help_hotkeys void '(* *))
 (define-lff i_callback_hierarchy_down_schematic void '(* *))
 (define-lff i_callback_hierarchy_down_symbol void '(* *))

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -1294,16 +1294,6 @@ i_callback_page_close (GtkWidget *widget, gpointer data)
 
 
 void
-i_callback_page_next_tab (GtkWidget *widget, gpointer data)
-{
-  GschemToplevel* w_current = GSCHEM_TOPLEVEL (data);
-
-  x_tabs_next (w_current);
-}
-
-
-
-void
 i_callback_page_prev_tab (GtkWidget *widget, gpointer data)
 {
   GschemToplevel* w_current = GSCHEM_TOPLEVEL (data);

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -464,26 +464,6 @@ i_callback_edit_edit (GtkWidget *widget, gpointer data)
 /*! \todo Finish function documentation!!!
  *  \brief
  *  \par Function Description
- *
- */
-void
-i_callback_edit_slot (GtkWidget *widget, gpointer data)
-{
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-  LeptonObject *object;
-
-  g_return_if_fail (w_current != NULL);
-
-  object = o_select_return_first_object(w_current);
-
-  if (object) {
-    o_slot_start(w_current, object);
-  }
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
  *  This function rotate all objects in the selection list by 90 degrees.
  *
  */

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -908,18 +908,6 @@ i_callback_view_status (GtkWidget *widget, gpointer data)
   gtk_widget_set_visible (GTK_WIDGET (w_current->bottom_notebook), !visible);
 }
 
-/*! \brief Show the find text state window
- */
-void
-i_callback_view_find_text_state (GtkWidget *widget, gpointer data)
-{
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-
-  g_return_if_fail (w_current != NULL);
-
-  x_widgets_show_find_text_state (w_current);
-}
-
 /*! \todo Finish function documentation!!!
  *  \brief
  *  \par Function Description

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -1293,16 +1293,6 @@ i_callback_page_close (GtkWidget *widget, gpointer data)
 
 
 
-void
-i_callback_page_prev_tab (GtkWidget *widget, gpointer data)
-{
-  GschemToplevel* w_current = GSCHEM_TOPLEVEL (data);
-
-  x_tabs_prev (w_current);
-}
-
-
-
 /*! \todo Finish function documentation!!!
  *  \brief
  *  \par Function Description

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -2453,22 +2453,6 @@ i_callback_options_magneticnet (GtkWidget *widget, gpointer data)
  *  \brief
  *  \par Function Description
  *
- */
-void
-i_callback_options_show_log_window (GtkWidget *widget, gpointer data)
-{
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-
-  g_return_if_fail (w_current != NULL);
-
-  x_widgets_show_log (w_current);
-}
-
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
  *  \note
  *  HACK: be sure that you don't use the widget parameter in this one,
  *  since it is being called with a null, I suppose we should call it

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -2522,21 +2522,6 @@ i_callback_cancel (GtkWidget *widget, gpointer data)
   i_action_stop (w_current);
 }
 
-/*! \section help-menu Help Menu Callback Functions */
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
-void
-i_callback_help_hotkeys (GtkWidget *widget, gpointer data)
-{
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-
-  g_return_if_fail (w_current != NULL);
-  x_dialog_hotkeys(w_current);
-}
-
 void
 i_callback_options_draw_grips (GtkWidget *widget, gpointer data)
 {

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -2529,20 +2529,6 @@ i_callback_cancel (GtkWidget *widget, gpointer data)
  *
  */
 void
-i_callback_help_about (GtkWidget *widget, gpointer data)
-{
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-
-  g_return_if_fail (w_current != NULL);
-  about_dialog(w_current);
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
-void
 i_callback_help_hotkeys (GtkWidget *widget, gpointer data)
 {
   GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -908,22 +908,6 @@ i_callback_view_status (GtkWidget *widget, gpointer data)
   gtk_widget_set_visible (GTK_WIDGET (w_current->bottom_notebook), !visible);
 }
 
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- *  \note
- *  repeat middle shortcut doesn't make sense on redraw, just hit right
- *  button
- */
-void
-i_callback_view_redraw (GtkWidget *widget, gpointer data)
-{
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-  g_return_if_fail (w_current != NULL);
-
-  gschem_page_view_invalidate_all (gschem_toplevel_get_current_page_view (w_current));
-}
 
 /*! \todo Finish function documentation!!!
  *  \brief

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -1194,21 +1194,6 @@ i_callback_view_color_edit (GtkWidget *widget, gpointer data)
 }
 
 /*! \section page-menu Page Menu Callback Functions */
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
-void
-i_callback_page_manager (GtkWidget *widget, gpointer data)
-{
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-
-  g_return_if_fail (w_current != NULL);
-
-  x_widgets_show_page_select (w_current);
-  page_select_widget_update (w_current);
-}
 
 /*! \todo Finish function documentation!!!
  *  \brief


### PR DESCRIPTION
This is another set of low hanging of ~fruits~ callbacks that only take space in the code base.  Changes similar to those in #924.