### PR TITLE
Rename the (schematic core gettext) module to (schematic gettext)

### DIFF
--- a/libleptongui/scheme/Makefile.am
+++ b/libleptongui/scheme/Makefile.am
@@ -16,7 +16,7 @@ nobase_dist_scmdata_DATA = \
 	schematic/action.scm \
 	schematic/attrib.scm \
 	schematic/builtins.scm \
-	schematic/core/gettext.scm \
+	schematic/gettext.scm \
 	schematic/dialog.scm \
 	schematic/ffi.scm \
 	schematic/ffi/gobject.scm \

--- a/libleptongui/scheme/gschem/deprecated.scm
+++ b/libleptongui/scheme/gschem/deprecated.scm
@@ -2,7 +2,7 @@
 ;; Scheme API
 ;; Copyright (C) 2010-2011 Peter Brett
 ;; Copyright (C) 2010-2012 gEDA Contributors
-;; Copyright (C) 2017-2020 Lepton EDA Contributors
+;; Copyright (C) 2017-2022 Lepton EDA Contributors
 ;;
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -33,7 +33,7 @@
   #:use-module (lepton page)
 
   #:use-module (schematic attrib)
-  #:use-module (schematic core gettext)
+  #:use-module (schematic gettext)
   #:use-module (schematic dialog)
   #:use-module (schematic hook)
   #:use-module (schematic selection)

--- a/libleptongui/scheme/schematic/action.scm
+++ b/libleptongui/scheme/schematic/action.scm
@@ -1,7 +1,7 @@
 ;; Lepton EDA Schematic Capture
 ;; Scheme API
 ;; Copyright (C) 2013 Peter Brett <peter@peter-b.co.uk>
-;; Copyright (C) 2017-2020 Lepton EDA Contributors
+;; Copyright (C) 2017-2022 Lepton EDA Contributors
 ;;
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -22,7 +22,7 @@
   #:use-module (lepton log)
   #:use-module (ice-9 optargs)
 
-  #:use-module (schematic core gettext)
+  #:use-module (schematic gettext)
   #:use-module (schematic hook)
   #:use-module (schematic window)
 

--- a/libleptongui/scheme/schematic/attrib.scm
+++ b/libleptongui/scheme/schematic/attrib.scm
@@ -29,7 +29,7 @@
   #:use-module (lepton object text)
   #:use-module (lepton page)
 
-  #:use-module (schematic core gettext)
+  #:use-module (schematic gettext)
   #:use-module (schematic ffi)
   #:use-module (schematic window foreign)
   #:use-module (schematic window)

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -30,7 +30,7 @@
   #:use-module (lepton repl)
 
   #:use-module (schematic action)
-  #:use-module (schematic core gettext)
+  #:use-module (schematic gettext)
   #:use-module (schematic ffi)
   #:use-module (schematic doc)
   #:use-module (schematic gui keymap)

--- a/libleptongui/scheme/schematic/doc.scm
+++ b/libleptongui/scheme/schematic/doc.scm
@@ -29,7 +29,7 @@
   #:use-module (lepton object)
   #:use-module (lepton os)
 
-  #:use-module (schematic core gettext)
+  #:use-module (schematic gettext)
   #:use-module (schematic dialog)
   #:use-module (schematic util)
 

--- a/libleptongui/scheme/schematic/gettext.scm
+++ b/libleptongui/scheme/schematic/gettext.scm
@@ -2,7 +2,7 @@
 ;; Scheme API
 ;; Copyright (C) 2011 Peter Brett <peter@peter-b.co.uk>
 ;; Copyright (C) 2011-2012 gEDA Contributors
-;; Copyright (C) 2017-2021 Lepton EDA Contributors
+;; Copyright (C) 2017-2022 Lepton EDA Contributors
 ;;
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -23,7 +23,7 @@
 ;;
 ;; This module is for internal use only.
 
-(define-module (schematic core gettext)
+(define-module (schematic gettext)
   #:export (%schematic-gettext-domain
             G_))
 

--- a/libleptongui/scheme/schematic/keymap.scm
+++ b/libleptongui/scheme/schematic/keymap.scm
@@ -30,7 +30,7 @@
 
   #:use-module (lepton ffi)
 
-  #:use-module (schematic core gettext)
+  #:use-module (schematic gettext)
   #:use-module (schematic ffi)
   #:use-module (schematic ffi gtk)
   #:use-module (schematic hook)

--- a/libleptongui/scheme/schematic/symbol/check.scm
+++ b/libleptongui/scheme/schematic/symbol/check.scm
@@ -23,7 +23,7 @@
   #:use-module (lepton object foreign)
   #:use-module (lepton page)
 
-  #:use-module (schematic core gettext)
+  #:use-module (schematic gettext)
   #:use-module (schematic dialog)
   #:use-module (schematic window)
   #:use-module (symbol blame)

--- a/libleptongui/scheme/schematic/util.scm
+++ b/libleptongui/scheme/schematic/util.scm
@@ -24,7 +24,7 @@
   #:use-module (lepton ffi)
   #:use-module (lepton gerror)
 
-  #:use-module (schematic core gettext)
+  #:use-module (schematic gettext)
   #:use-module (schematic ffi)
   #:use-module (schematic window foreign)
   #:use-module (schematic window)

--- a/schematic/lepton-schematic.scm
+++ b/schematic/lepton-schematic.scm
@@ -31,7 +31,7 @@
              (lepton page foreign)
              (lepton srfi-37)
              (lepton version)
-             (schematic core gettext)
+             (schematic gettext)
              (schematic ffi)
              (schematic ffi gtk)
              (schematic gui keymap)


### PR DESCRIPTION
Changes similar to 044790a608dd, but for schematic.
