### PR TITLE
Manual tweak

### DIFF
--- a/docs/manual/lepton-netlist-pads.texi
+++ b/docs/manual/lepton-netlist-pads.texi
@@ -8,6 +8,11 @@ This document is released under
 
 March 6th, 2003
 
+@menu
+* Forward annotation to PADS PowerPCB::
+* Back annotation from PADS PowerPCB::
+@end menu
+
 @node Forward annotation to PADS PowerPCB
 @subsection Forward annotation of lepton schematic changes to PADS PowerPCB layout
 

--- a/docs/manual/symbol-creation.texi
+++ b/docs/manual/symbol-creation.texi
@@ -604,7 +604,7 @@ doesn't make much sense anyway.
 @end itemize
 
 
-@node Symbol example
+@anchor{Symbol example}
 @subsection Symbol example
 
 This section provides a simple example which tries to follow all of


### PR DESCRIPTION
When building on an older CentOS (CentOS-7) that has GNU texinfo 5.1 I was getting some failures due to consistency checks on the up/prev/next links.  This PR makes some minor adjustments to get the manual to build.
