### PR TITLE
Create main lepton-schematic widgets in Scheme

### DIFF
--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -700,9 +700,11 @@ void
 schematic_window_create_notebooks (GschemToplevel *w_current,
                                    GtkWidget *main_box,
                                    GtkWidget *work_box);
+void
+schematic_window_create_statusbar (GschemToplevel *w_current,
+                                   GtkWidget *main_box);
 GschemToplevel*
 x_window_create_main (GtkWidget *main_window,
-                      GtkWidget *main_box,
                       GschemToplevel *w_current);
 
 void x_window_close(GschemToplevel *w_current);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -666,6 +666,9 @@ void
 schematic_window_create_menubar (GschemToplevel *w_current,
                                  GtkWidget *main_box,
                                  GtkWidget *menubar);
+void
+schematic_window_create_toolbar (GschemToplevel *w_current,
+                                 GtkWidget *main_box);
 GschemToplevel*
 x_window_create_main (GtkWidget *main_window,
                       GtkWidget *main_box,

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -665,6 +665,9 @@ schematic_window_create_app_window (gpointer app);
 GtkWidget*
 schematic_window_create_main_box (GtkWidget *main_window);
 
+GtkWidget*
+schematic_window_create_work_box ();
+
 void
 schematic_window_create_menubar (GschemToplevel *w_current,
                                  GtkWidget *main_box,

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -696,10 +696,13 @@ schematic_window_create_macro_widget (GschemToplevel *w_current,
 void
 schematic_window_create_translate_widget (GschemToplevel *w_current,
                                           GtkWidget *work_box);
+void
+schematic_window_create_notebooks (GschemToplevel *w_current,
+                                   GtkWidget *main_box,
+                                   GtkWidget *work_box);
 GschemToplevel*
 x_window_create_main (GtkWidget *main_window,
                       GtkWidget *main_box,
-                      GtkWidget *work_box,
                       GschemToplevel *w_current);
 
 void x_window_close(GschemToplevel *w_current);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -703,6 +703,9 @@ schematic_window_create_notebooks (GschemToplevel *w_current,
 void
 schematic_window_create_statusbar (GschemToplevel *w_current,
                                    GtkWidget *main_box);
+void
+schematic_window_restore_geometry (GschemToplevel* w_current,
+                                   GtkWidget* main_window);
 GschemToplevel*
 x_window_create_main (GtkWidget *main_window,
                       GschemToplevel *w_current);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -662,6 +662,10 @@ schematic_window_create_app_window (gpointer app);
 GtkWidget*
 schematic_window_create_main_box (GtkWidget *main_window);
 
+void
+schematic_window_create_menubar (GschemToplevel *w_current,
+                                 GtkWidget *main_box,
+                                 GtkWidget *menubar);
 GschemToplevel*
 x_window_create_main (GtkWidget *main_window,
                       GtkWidget *main_box,

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -706,9 +706,12 @@ schematic_window_create_statusbar (GschemToplevel *w_current,
 void
 schematic_window_restore_geometry (GschemToplevel* w_current,
                                    GtkWidget* main_window);
+void
+schematic_window_show_all (GschemToplevel *w_current,
+                           GtkWidget *main_window);
 GschemToplevel*
-x_window_create_main (GtkWidget *main_window,
-                      GschemToplevel *w_current);
+schematic_window_set_main_window (GschemToplevel *w_current,
+                                  GtkWidget *main_window);
 
 void x_window_close(GschemToplevel *w_current);
 void x_window_close_all(GschemToplevel *w_current);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -681,6 +681,21 @@ schematic_window_create_toolbar (GschemToplevel *w_current,
 void
 schematic_window_set_key_event_callback (gpointer key_event_callback);
 
+void
+schematic_window_create_find_text_widget (GschemToplevel *w_current,
+                                          GtkWidget *work_box);
+void
+schematic_window_create_hide_text_widget (GschemToplevel *w_current,
+                                          GtkWidget *work_box);
+void
+schematic_window_create_show_text_widget (GschemToplevel *w_current,
+                                          GtkWidget *work_box);
+void
+schematic_window_create_macro_widget (GschemToplevel *w_current,
+                                      GtkWidget *work_box);
+void
+schematic_window_create_translate_widget (GschemToplevel *w_current,
+                                          GtkWidget *work_box);
 GschemToplevel*
 x_window_create_main (GtkWidget *main_window,
                       GtkWidget *main_box,

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -670,7 +670,6 @@ GschemToplevel*
 x_window_create_main (GtkWidget *main_window,
                       GtkWidget *main_box,
                       GschemToplevel *w_current,
-                      GtkWidget *menubar,
                       gpointer key_event_callback);
 
 void x_window_close(GschemToplevel *w_current);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -592,8 +592,11 @@ int x_linetypecb_get_index (GtkWidget *widget);
 void x_linetypecb_set_index (GtkWidget *widget, int index);
 /* x_misc.c */
 gboolean x_show_uri (GschemToplevel *w_current, const gchar *buf, GError **err);
+
 /* x_menus.c */
-GtkWidget *get_main_popup(GschemToplevel *w_current);
+GtkWidget*
+schematic_window_create_main_popup_menu (GschemToplevel *w_current);
+
 gint do_popup(GschemToplevel *w_current, GdkEventButton *event);
 void x_menus_sensitivity (GtkWidget* menu, const gchar* action_name, gboolean sensitive);
 GtkWidget*

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -656,6 +656,9 @@ void x_window_setup_draw_events_main_wnd (GschemToplevel* w_current,
                                           GtkWidget*      main_window);
 void x_window_setup_draw_events_drawing_area (GschemToplevel* w_current,
                                               GschemPageView* drawing_area);
+GtkWidget*
+schematic_window_create_app_window (gpointer app);
+
 GschemToplevel*
 x_window_create_main (gpointer app,
                       GschemToplevel *w_current,

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -664,6 +664,7 @@ schematic_window_create_main_box (GtkWidget *main_window);
 
 GschemToplevel*
 x_window_create_main (GtkWidget *main_window,
+                      GtkWidget *main_box,
                       GschemToplevel *w_current,
                       GtkWidget *menubar,
                       gpointer key_event_callback);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -678,12 +678,14 @@ schematic_window_create_menubar (GschemToplevel *w_current,
 void
 schematic_window_create_toolbar (GschemToplevel *w_current,
                                  GtkWidget *main_box);
+void
+schematic_window_set_key_event_callback (gpointer key_event_callback);
+
 GschemToplevel*
 x_window_create_main (GtkWidget *main_window,
                       GtkWidget *main_box,
                       GtkWidget *work_box,
-                      GschemToplevel *w_current,
-                      gpointer key_event_callback);
+                      GschemToplevel *w_current);
 
 void x_window_close(GschemToplevel *w_current);
 void x_window_close_all(GschemToplevel *w_current);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -660,7 +660,7 @@ GtkWidget*
 schematic_window_create_app_window (gpointer app);
 
 GschemToplevel*
-x_window_create_main (gpointer app,
+x_window_create_main (GtkWidget *main_window,
                       GschemToplevel *w_current,
                       GtkWidget *menubar,
                       gpointer key_event_callback);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -659,6 +659,9 @@ void x_window_setup_draw_events_drawing_area (GschemToplevel* w_current,
 GtkWidget*
 schematic_window_create_app_window (gpointer app);
 
+GtkWidget*
+schematic_window_create_main_box (GtkWidget *main_window);
+
 GschemToplevel*
 x_window_create_main (GtkWidget *main_window,
                       GschemToplevel *w_current,

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -678,6 +678,7 @@ schematic_window_create_toolbar (GschemToplevel *w_current,
 GschemToplevel*
 x_window_create_main (GtkWidget *main_window,
                       GtkWidget *main_box,
+                      GtkWidget *work_box,
                       GschemToplevel *w_current,
                       gpointer key_event_callback);
 

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -668,6 +668,9 @@ schematic_window_create_main_box (GtkWidget *main_window);
 GtkWidget*
 schematic_window_create_work_box ();
 
+GschemPageView*
+schematic_window_create_page_view (GschemToplevel *w_current,
+                                   GtkWidget *work_box);
 void
 schematic_window_create_menubar (GschemToplevel *w_current,
                                  GtkWidget *main_box,

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -110,20 +110,11 @@
 (define-action-public (&file-script #:label (G_ "Run Script") #:icon "gtk-execute")
   (run-callback i_callback_file_script "&file-script"))
 
-(define (make-schematic-window app toplevel)
-  (define new-window
-    (x_window_setup (x_window_new (parse-gschemrc toplevel))))
-
-  (x_window_open_page
-   (x_window_create_main app
-                         new-window
-                         (make-main-menu new-window)
-                         *process-key-event)
-   %null-pointer))
-
 (define-action-public (&file-new-window #:label (G_ "New Window") #:icon "window-new")
-  (make-schematic-window (lepton_schematic_app)
-                         (lepton_toplevel_new)))
+  (x_window_open_page
+   (make-schematic-window (lepton_schematic_app)
+                          (lepton_toplevel_new))
+   %null-pointer))
 
 (define-action-public (&file-close-window #:label (G_ "Close Window") #:icon "gtk-close")
   (log! 'message (G_ "Closing Window"))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -151,6 +151,7 @@
             schematic_window_create_app_window
             schematic_window_create_main_box
             schematic_window_create_menubar
+            schematic_window_create_toolbar
 
             about_dialog
 
@@ -320,6 +321,7 @@
 (define-lff schematic_window_create_app_window '* '(*))
 (define-lff schematic_window_create_main_box '* '(*))
 (define-lff schematic_window_create_menubar void '(* * *))
+(define-lff schematic_window_create_toolbar void '(* *))
 
 ;;; x_dialog.c
 (define-lff generic_confirm_dialog int '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -159,6 +159,11 @@
             schematic_window_create_toolbar
             schematic_window_set_key_event_callback
             schematic_window_create_page_view
+            schematic_window_create_find_text_widget
+            schematic_window_create_hide_text_widget
+            schematic_window_create_show_text_widget
+            schematic_window_create_macro_widget
+            schematic_window_create_translate_widget
 
             x_tabs_create
             x_tabs_enabled
@@ -338,6 +343,11 @@
 (define-lff schematic_window_create_toolbar void '(* *))
 (define-lff schematic_window_set_key_event_callback void '(*))
 (define-lff schematic_window_create_page_view '* '(* *))
+(define-lff schematic_window_create_find_text_widget void '(* *))
+(define-lff schematic_window_create_hide_text_widget void '(* *))
+(define-lff schematic_window_create_show_text_widget void '(* *))
+(define-lff schematic_window_create_macro_widget void '(* *))
+(define-lff schematic_window_create_translate_widget void '(* *))
 
 ;;; x_tabs.c
 (define-lff x_tabs_create void '(* *))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -168,6 +168,7 @@
             schematic_window_create_translate_widget
             schematic_window_create_notebooks
             schematic_window_create_statusbar
+            schematic_window_restore_geometry
 
             x_tabs_create
             x_tabs_enabled
@@ -356,6 +357,7 @@
 (define-lff schematic_window_create_translate_widget void '(* *))
 (define-lff schematic_window_create_notebooks void '(* * *))
 (define-lff schematic_window_create_statusbar void '(* *))
+(define-lff schematic_window_restore_geometry void '(* *))
 
 ;;; x_tabs.c
 (define-lff x_tabs_create void '(* *))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -144,7 +144,6 @@
             x_widgets_show_object_properties
             x_widgets_show_page_select
 
-            x_window_create_main
             x_window_close
             x_window_close_all
             x_window_close_page
@@ -169,6 +168,8 @@
             schematic_window_create_notebooks
             schematic_window_create_statusbar
             schematic_window_restore_geometry
+            schematic_window_show_all
+            schematic_window_set_main_window
 
             x_tabs_create
             x_tabs_enabled
@@ -339,7 +340,6 @@
 (define-lff x_window_setup '* '(*))
 (define-lff x_window_setup_draw_events_drawing_area void '(* *))
 (define-lff x_window_setup_draw_events_main_wnd void '(* *))
-(define-lff x_window_create_main '* '(* *))
 (define-lff x_window_close void '(*))
 (define-lff x_window_close_all void '(*))
 (define-lff x_window_close_page void '(* *))
@@ -358,6 +358,8 @@
 (define-lff schematic_window_create_notebooks void '(* * *))
 (define-lff schematic_window_create_statusbar void '(* *))
 (define-lff schematic_window_restore_geometry void '(* *))
+(define-lff schematic_window_show_all void '(* *))
+(define-lff schematic_window_set_main_window '* '(* *))
 
 ;;; x_tabs.c
 (define-lff x_tabs_create void '(* *))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -150,6 +150,7 @@
             x_window_setup
             schematic_window_create_app_window
             schematic_window_create_main_box
+            schematic_window_create_menubar
 
             about_dialog
 
@@ -312,12 +313,13 @@
 (define-lff x_window_open_page '* '(* *))
 (define-lff x_window_set_current_page void '(* *))
 (define-lff x_window_setup '* '(*))
-(define-lff x_window_create_main '* '(* * * * *))
+(define-lff x_window_create_main '* '(* * * *))
 (define-lff x_window_close void '(*))
 (define-lff x_window_close_all void '(*))
 (define-lff x_window_close_page void '(* *))
 (define-lff schematic_window_create_app_window '* '(*))
 (define-lff schematic_window_create_main_box '* '(*))
+(define-lff schematic_window_create_menubar void '(* * *))
 
 ;;; x_dialog.c
 (define-lff generic_confirm_dialog int '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -167,6 +167,7 @@
             schematic_window_create_macro_widget
             schematic_window_create_translate_widget
             schematic_window_create_notebooks
+            schematic_window_create_statusbar
 
             x_tabs_create
             x_tabs_enabled
@@ -337,7 +338,7 @@
 (define-lff x_window_setup '* '(*))
 (define-lff x_window_setup_draw_events_drawing_area void '(* *))
 (define-lff x_window_setup_draw_events_main_wnd void '(* *))
-(define-lff x_window_create_main '* '(* * *))
+(define-lff x_window_create_main '* '(* *))
 (define-lff x_window_close void '(*))
 (define-lff x_window_close_all void '(*))
 (define-lff x_window_close_page void '(* *))
@@ -354,6 +355,7 @@
 (define-lff schematic_window_create_macro_widget void '(* *))
 (define-lff schematic_window_create_translate_widget void '(* *))
 (define-lff schematic_window_create_notebooks void '(* * *))
+(define-lff schematic_window_create_statusbar void '(* *))
 
 ;;; x_tabs.c
 (define-lff x_tabs_create void '(* *))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -136,6 +136,8 @@
             slot_edit_dialog_get_text
             slot_edit_dialog_quit
 
+            x_widgets_create
+            x_widgets_init
             x_widgets_show_find_text_state
             x_widgets_show_font_select
             x_widgets_show_log
@@ -269,6 +271,8 @@
 (define-lff x_color_init void '())
 
 ;;; x_widgets.c
+(define-lff x_widgets_create void '(*))
+(define-lff x_widgets_init void '())
 (define-lff x_widgets_show_find_text_state void '(*))
 (define-lff x_widgets_show_font_select void '(*))
 (define-lff x_widgets_show_log void '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -49,6 +49,7 @@
             i_callback_clipboard_copy
             i_callback_clipboard_cut
             i_callback_clipboard_paste
+            i_callback_close_wm
             i_callback_edit_autonumber_text
             i_callback_edit_copy
             i_callback_edit_delete
@@ -341,6 +342,7 @@
 (define-lff i_callback_clipboard_copy void '(* *))
 (define-lff i_callback_clipboard_cut void '(* *))
 (define-lff i_callback_clipboard_paste void '(* *))
+(define-lff i_callback_close_wm int '(* * *))
 (define-lff i_callback_edit_autonumber_text void '(* *))
 (define-lff i_callback_edit_copy void '(* *))
 (define-lff i_callback_edit_delete void '(* *))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -149,6 +149,7 @@
             x_window_set_current_page
             x_window_setup
             schematic_window_create_app_window
+            schematic_window_create_main_box
 
             about_dialog
 
@@ -311,11 +312,12 @@
 (define-lff x_window_open_page '* '(* *))
 (define-lff x_window_set_current_page void '(* *))
 (define-lff x_window_setup '* '(*))
-(define-lff x_window_create_main '* '(* * * *))
+(define-lff x_window_create_main '* '(* * * * *))
 (define-lff x_window_close void '(*))
 (define-lff x_window_close_all void '(*))
 (define-lff x_window_close_page void '(* *))
 (define-lff schematic_window_create_app_window '* '(*))
+(define-lff schematic_window_create_main_box '* '(*))
 
 ;;; x_dialog.c
 (define-lff generic_confirm_dialog int '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -151,6 +151,7 @@
             x_window_set_current_page
             x_window_setup
             x_window_setup_draw_events_drawing_area
+            x_window_setup_draw_events_main_wnd
             schematic_window_create_app_window
             schematic_window_create_main_box
             schematic_window_create_work_box
@@ -325,6 +326,7 @@
 (define-lff x_window_set_current_page void '(* *))
 (define-lff x_window_setup '* '(*))
 (define-lff x_window_setup_draw_events_drawing_area void '(* *))
+(define-lff x_window_setup_draw_events_main_wnd void '(* *))
 (define-lff x_window_create_main '* '(* * * *))
 (define-lff x_window_close void '(*))
 (define-lff x_window_close_all void '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -150,12 +150,17 @@
             x_window_open_page
             x_window_set_current_page
             x_window_setup
+            x_window_setup_draw_events_drawing_area
             schematic_window_create_app_window
             schematic_window_create_main_box
             schematic_window_create_work_box
             schematic_window_create_menubar
             schematic_window_create_toolbar
             schematic_window_set_key_event_callback
+            schematic_window_create_page_view
+
+            x_tabs_create
+            x_tabs_enabled
 
             about_dialog
 
@@ -319,6 +324,7 @@
 (define-lff x_window_open_page '* '(* *))
 (define-lff x_window_set_current_page void '(* *))
 (define-lff x_window_setup '* '(*))
+(define-lff x_window_setup_draw_events_drawing_area void '(* *))
 (define-lff x_window_create_main '* '(* * * *))
 (define-lff x_window_close void '(*))
 (define-lff x_window_close_all void '(*))
@@ -329,6 +335,11 @@
 (define-lff schematic_window_create_menubar void '(* * *))
 (define-lff schematic_window_create_toolbar void '(* *))
 (define-lff schematic_window_set_key_event_callback void '(*))
+(define-lff schematic_window_create_page_view '* '(* *))
+
+;;; x_tabs.c
+(define-lff x_tabs_create void '(* *))
+(define-lff x_tabs_enabled int '())
 
 ;;; x_dialog.c
 (define-lff generic_confirm_dialog int '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -147,6 +147,7 @@
             x_window_open_page
             x_window_set_current_page
             x_window_setup
+            schematic_window_create_app_window
 
             about_dialog
 
@@ -313,6 +314,7 @@
 (define-lff x_window_close void '(*))
 (define-lff x_window_close_all void '(*))
 (define-lff x_window_close_page void '(* *))
+(define-lff schematic_window_create_app_window '* '(*))
 
 ;;; x_dialog.c
 (define-lff generic_confirm_dialog int '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -166,6 +166,7 @@
             schematic_window_create_show_text_widget
             schematic_window_create_macro_widget
             schematic_window_create_translate_widget
+            schematic_window_create_notebooks
 
             x_tabs_create
             x_tabs_enabled
@@ -336,7 +337,7 @@
 (define-lff x_window_setup '* '(*))
 (define-lff x_window_setup_draw_events_drawing_area void '(* *))
 (define-lff x_window_setup_draw_events_main_wnd void '(* *))
-(define-lff x_window_create_main '* '(* * * *))
+(define-lff x_window_create_main '* '(* * *))
 (define-lff x_window_close void '(*))
 (define-lff x_window_close_all void '(*))
 (define-lff x_window_close_page void '(* *))
@@ -352,6 +353,7 @@
 (define-lff schematic_window_create_show_text_widget void '(* *))
 (define-lff schematic_window_create_macro_widget void '(* *))
 (define-lff schematic_window_create_translate_widget void '(* *))
+(define-lff schematic_window_create_notebooks void '(* * *))
 
 ;;; x_tabs.c
 (define-lff x_tabs_create void '(* *))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -152,6 +152,7 @@
             x_window_setup
             schematic_window_create_app_window
             schematic_window_create_main_box
+            schematic_window_create_work_box
             schematic_window_create_menubar
             schematic_window_create_toolbar
 
@@ -317,12 +318,13 @@
 (define-lff x_window_open_page '* '(* *))
 (define-lff x_window_set_current_page void '(* *))
 (define-lff x_window_setup '* '(*))
-(define-lff x_window_create_main '* '(* * * *))
+(define-lff x_window_create_main '* '(* * * * *))
 (define-lff x_window_close void '(*))
 (define-lff x_window_close_all void '(*))
 (define-lff x_window_close_page void '(* *))
 (define-lff schematic_window_create_app_window '* '(*))
 (define-lff schematic_window_create_main_box '* '(*))
+(define-lff schematic_window_create_work_box '* '())
 (define-lff schematic_window_create_menubar void '(* * *))
 (define-lff schematic_window_create_toolbar void '(* *))
 

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -112,9 +112,10 @@
             i_callback_view_zoom_full
             i_callback_view_zoom_in
             i_callback_view_zoom_out
+
             make_menu_action
             make_separator_menu_item
-            get_main_popup
+            schematic_window_create_main_popup_menu
 
             o_attrib_add_attrib
 
@@ -306,7 +307,7 @@
 (define-lff x_menu_attach_recent_files_submenu void '(* *))
 (define-lff lepton_action_create_menu_item '* '(* * *))
 (define-lff lepton_menu_set_action_data void '(* * * *))
-(define-lff get_main_popup '* '(*))
+(define-lff schematic_window_create_main_popup_menu '* '(*))
 
 ;;; x_rc.c
 (define-lff x_rc_parse_gschem void '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -114,6 +114,7 @@
             i_callback_view_zoom_out
             make_menu_action
             make_separator_menu_item
+            get_main_popup
 
             o_attrib_add_attrib
 
@@ -305,6 +306,7 @@
 (define-lff x_menu_attach_recent_files_submenu void '(* *))
 (define-lff lepton_action_create_menu_item '* '(* * *))
 (define-lff lepton_menu_set_action_data void '(* * * *))
+(define-lff get_main_popup '* '(*))
 
 ;;; x_rc.c
 (define-lff x_rc_parse_gschem void '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -155,6 +155,7 @@
             schematic_window_create_work_box
             schematic_window_create_menubar
             schematic_window_create_toolbar
+            schematic_window_set_key_event_callback
 
             about_dialog
 
@@ -318,7 +319,7 @@
 (define-lff x_window_open_page '* '(* *))
 (define-lff x_window_set_current_page void '(* *))
 (define-lff x_window_setup '* '(*))
-(define-lff x_window_create_main '* '(* * * * *))
+(define-lff x_window_create_main '* '(* * * *))
 (define-lff x_window_close void '(*))
 (define-lff x_window_close_all void '(*))
 (define-lff x_window_close_page void '(* *))
@@ -327,6 +328,7 @@
 (define-lff schematic_window_create_work_box '* '())
 (define-lff schematic_window_create_menubar void '(* * *))
 (define-lff schematic_window_create_toolbar void '(* *))
+(define-lff schematic_window_set_key_event_callback void '(*))
 
 ;;; x_dialog.c
 (define-lff generic_confirm_dialog int '(*))

--- a/libleptongui/scheme/schematic/gui/keymap.scm
+++ b/libleptongui/scheme/schematic/gui/keymap.scm
@@ -27,7 +27,6 @@
   #:use-module (schematic action)
   #:use-module (schematic ffi)
   #:use-module (schematic keymap)
-  #:use-module (schematic window)
 
   #:export (%global-keymap
             current-keymap
@@ -35,7 +34,7 @@
             reset-keys
             find-key
             %gschem-hotkey-store/dump-global-keymap
-            *process-key-event))
+            eval-press-key-event))
 
 ;;; Key event processing.
 
@@ -88,14 +87,6 @@
   (boolean->c-boolean
    (and key
         (update-keyaccel-timer (protected-eval-key-press key)))))
-
-
-(define (process-key-event *page_view *event *window)
-  (with-window *window
-    (eval-press-key-event *event *page_view *window)))
-
-(define *process-key-event
-  (procedure->pointer int process-key-event '(* * *)))
 
 
 ;; -------------------------------------------------------------------

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -105,11 +105,13 @@ GtkApplication structure of the program (when compiled with
       ;; Make main popup menu.
       (schematic_window_create_main_popup_menu *window)
 
+      ;; Set up key event processing function.
+      (schematic_window_set_key_event_callback *process-key-event)
+
       (x_window_create_main *main-window
                             *main-box
                             *work-box
-                            *window
-                            *process-key-event))))
+                            *window))))
 
 
 (define (active-page)

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -91,7 +91,7 @@ GtkApplication structure of the program (when compiled with
   (define new-window
     (x_window_setup (x_window_new (parse-gschemrc *toplevel))))
 
-  (x_window_create_main *app
+  (x_window_create_main (schematic_window_create_app_window *app)
                         new-window
                         (make-main-menu new-window)
                         *process-key-event))

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -118,6 +118,13 @@ GtkApplication structure of the program (when compiled with
       ;; Setup callbacks for main window draw events.
       (x_window_setup_draw_events_main_wnd *window *main-window)
 
+      ;; Setup hidden infowidgets.
+      (schematic_window_create_find_text_widget *window *work-box)
+      (schematic_window_create_hide_text_widget *window *work-box)
+      (schematic_window_create_show_text_widget *window *work-box)
+      (schematic_window_create_macro_widget *window *work-box)
+      (schematic_window_create_translate_widget *window *work-box)
+
       (x_window_create_main *main-window
                             *main-box
                             *work-box

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -132,9 +132,10 @@ GtkApplication structure of the program (when compiled with
       ;; Setup layout of notebooks.
       (schematic_window_create_notebooks *window *main-box *work-box)
 
-      (x_window_create_main *main-window
-                            *main-box
-                            *window))))
+      ;; Setup statusbar.
+      (schematic_window_create_statusbar *window *main-box)
+
+      (x_window_create_main *main-window *window))))
 
 
 (define (active-page)

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -97,11 +97,12 @@ GtkApplication structure of the program (when compiled with
                               (procedure->pointer int i_callback_close_wm '(* * *))
                               *window)
 
-    (let ((*main-box (schematic_window_create_main_box *main-window)))
+    (let ((*main-box (schematic_window_create_main_box *main-window))
+          (*menubar (make-main-menu *window)))
+      (schematic_window_create_menubar *window *main-box *menubar)
       (x_window_create_main *main-window
                             *main-box
                             *window
-                            (make-main-menu *window)
                             *process-key-event))))
 
 

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -114,6 +114,10 @@ GtkApplication structure of the program (when compiled with
             ;; Setup callbacks for page view draw events.
             (x_window_setup_draw_events_drawing_area *window *page-view)))
 
+
+      ;; Setup callbacks for main window draw events.
+      (x_window_setup_draw_events_main_wnd *window *main-window)
+
       (x_window_create_main *main-window
                             *main-box
                             *work-box

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -97,10 +97,12 @@ GtkApplication structure of the program (when compiled with
                               (procedure->pointer int i_callback_close_wm '(* * *))
                               *window)
 
-    (x_window_create_main *main-window
-                          *window
-                          (make-main-menu *window)
-                          *process-key-event)))
+    (let ((*main-box (schematic_window_create_main_box *main-window)))
+      (x_window_create_main *main-window
+                            *main-box
+                            *window
+                            (make-main-menu *window)
+                            *process-key-event))))
 
 
 (define (active-page)

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -32,11 +32,14 @@
   #:use-module (lepton toplevel)
 
   #:use-module (schematic ffi)
+  #:use-module (schematic gui keymap)
+  #:use-module (schematic menu)
   #:use-module (schematic window foreign)
 
   #:export (%lepton-window
             current-window
             with-window
+            make-schematic-window
             active-page
             set-active-page!
             pointer-position
@@ -71,6 +74,27 @@
   "Returns the <window> instance associated with the current
 dynamic context."
   (and=> (fluid-ref %lepton-window) pointer->window))
+
+
+(define (process-key-event *page_view *event *window)
+  (with-window *window
+    (eval-press-key-event *event *page_view *window)))
+
+(define *process-key-event
+  (procedure->pointer int process-key-event '(* * *)))
+
+
+(define (make-schematic-window *app *toplevel)
+  "Creates a new lepton-schematic window.  APP is a pointer to the
+GtkApplication structure of the program (when compiled with
+--with-gtk3).  TOPLEVEL is a foreign LeptonToplevel structure."
+  (define new-window
+    (x_window_setup (x_window_new (parse-gschemrc *toplevel))))
+
+  (x_window_create_main *app
+                        new-window
+                        (make-main-menu new-window)
+                        *process-key-event))
 
 
 (define (active-page)

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -125,6 +125,10 @@ GtkApplication structure of the program (when compiled with
       (schematic_window_create_macro_widget *window *work-box)
       (schematic_window_create_translate_widget *window *work-box)
 
+      ;; Setup various widgets.
+      (x_widgets_init)
+      (x_widgets_create *window)
+
       (x_window_create_main *main-window
                             *main-box
                             *work-box

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -91,10 +91,16 @@ GtkApplication structure of the program (when compiled with
   (define new-window
     (x_window_setup (x_window_new (parse-gschemrc *toplevel))))
 
-  (x_window_create_main (schematic_window_create_app_window *app)
-                        new-window
-                        (make-main-menu new-window)
-                        *process-key-event))
+  (let ((*main-window (schematic_window_create_app_window *app)))
+    (schematic_signal_connect *main-window
+                              (string->pointer "delete-event")
+                              (procedure->pointer int i_callback_close_wm '(* * *))
+                              new-window)
+
+    (x_window_create_main *main-window
+                          new-window
+                          (make-main-menu new-window)
+                          *process-key-event)))
 
 
 (define (active-page)

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -137,7 +137,9 @@ GtkApplication structure of the program (when compiled with
 
       (schematic_window_restore_geometry *window *main-window)
 
-      (x_window_create_main *main-window *window))))
+      (schematic_window_show_all *window *main-window)
+      ;; Returns *window.
+      (schematic_window_set_main_window *window *main-window))))
 
 
 (define (active-page)

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -102,7 +102,7 @@ GtkApplication structure of the program (when compiled with
       (schematic_window_create_menubar *window *main-box *menubar)
       (schematic_window_create_toolbar *window *main-box)
       ;; Make main popup menu.
-      (get_main_popup *window)
+      (schematic_window_create_main_popup_menu *window)
 
       (x_window_create_main *main-window
                             *main-box

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -88,18 +88,18 @@ dynamic context."
   "Creates a new lepton-schematic window.  APP is a pointer to the
 GtkApplication structure of the program (when compiled with
 --with-gtk3).  TOPLEVEL is a foreign LeptonToplevel structure."
-  (define new-window
+  (define *window
     (x_window_setup (x_window_new (parse-gschemrc *toplevel))))
 
   (let ((*main-window (schematic_window_create_app_window *app)))
     (schematic_signal_connect *main-window
                               (string->pointer "delete-event")
                               (procedure->pointer int i_callback_close_wm '(* * *))
-                              new-window)
+                              *window)
 
     (x_window_create_main *main-window
-                          new-window
-                          (make-main-menu new-window)
+                          *window
+                          (make-main-menu *window)
                           *process-key-event)))
 
 

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -108,6 +108,12 @@ GtkApplication structure of the program (when compiled with
       ;; Set up key event processing function.
       (schematic_window_set_key_event_callback *process-key-event)
 
+      (if (true? (x_tabs_enabled))
+          (x_tabs_create *window *work-box)
+          (let ((*page-view (schematic_window_create_page_view *window *work-box)))
+            ;; Setup callbacks for page view draw events.
+            (x_window_setup_draw_events_drawing_area *window *page-view)))
+
       (x_window_create_main *main-window
                             *main-box
                             *work-box

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -135,6 +135,8 @@ GtkApplication structure of the program (when compiled with
       ;; Setup statusbar.
       (schematic_window_create_statusbar *window *main-box)
 
+      (schematic_window_restore_geometry *window *main-window)
+
       (x_window_create_main *main-window *window))))
 
 

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -100,6 +100,8 @@ GtkApplication structure of the program (when compiled with
     (let ((*main-box (schematic_window_create_main_box *main-window))
           (*menubar (make-main-menu *window)))
       (schematic_window_create_menubar *window *main-box *menubar)
+      (schematic_window_create_toolbar *window *main-box)
+
       (x_window_create_main *main-window
                             *main-box
                             *window

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -98,7 +98,8 @@ GtkApplication structure of the program (when compiled with
                               *window)
 
     (let ((*main-box (schematic_window_create_main_box *main-window))
-          (*menubar (make-main-menu *window)))
+          (*menubar (make-main-menu *window))
+          (*work-box (schematic_window_create_work_box)))
       (schematic_window_create_menubar *window *main-box *menubar)
       (schematic_window_create_toolbar *window *main-box)
       ;; Make main popup menu.
@@ -106,6 +107,7 @@ GtkApplication structure of the program (when compiled with
 
       (x_window_create_main *main-window
                             *main-box
+                            *work-box
                             *window
                             *process-key-event))))
 

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -101,6 +101,8 @@ GtkApplication structure of the program (when compiled with
           (*menubar (make-main-menu *window)))
       (schematic_window_create_menubar *window *main-box *menubar)
       (schematic_window_create_toolbar *window *main-box)
+      ;; Make main popup menu.
+      (get_main_popup *window)
 
       (x_window_create_main *main-window
                             *main-box

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -129,9 +129,11 @@ GtkApplication structure of the program (when compiled with
       (x_widgets_init)
       (x_widgets_create *window)
 
+      ;; Setup layout of notebooks.
+      (schematic_window_create_notebooks *window *main-box *work-box)
+
       (x_window_create_main *main-window
                             *main-box
-                            *work-box
                             *window))))
 
 

--- a/libleptongui/src/x_menus.c
+++ b/libleptongui/src/x_menus.c
@@ -281,6 +281,8 @@ get_main_popup (GschemToplevel* w_current)
 
   gtk_widget_show_all (menu);
 
+  w_current->popup_menu = menu;
+
   return menu;
 }
 

--- a/libleptongui/src/x_menus.c
+++ b/libleptongui/src/x_menus.c
@@ -232,7 +232,7 @@ lepton_menu_set_action_data (GtkWidget *menu,
  *  - value: pointer to a corresponding GschemAction object
  */
 GtkWidget*
-get_main_popup (GschemToplevel* w_current)
+schematic_window_create_main_popup_menu (GschemToplevel* w_current)
 {
   GtkWidget *menu_item;
   GtkWidget *menu;

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -544,29 +544,23 @@ schematic_window_create_page_view (GschemToplevel *w_current,
 }
 
 
-/*! \todo Finish function documentation!!!
- *  \brief
+/*! \brief Create paned widgets with notebooks
  *  \par Function Description
+ *  Creates bottom and right notebooks and two paned widgets for
+ *  them.
  *
+ * \param [in] w_current The #GschemToplevel object.
+ * \param [in] main_box The top level box container widget.
+ * \param [in] work_box The working area widget.
  */
-GschemToplevel*
-x_window_create_main (GtkWidget *main_window,
-                      GtkWidget *main_box,
-                      GtkWidget *work_box,
-                      GschemToplevel *w_current)
+void
+schematic_window_create_notebooks (GschemToplevel *w_current,
+                                   GtkWidget *main_box,
+                                   GtkWidget *work_box)
 {
   GtkWidget *hpaned = NULL;
   GtkWidget *vpaned = NULL;
 
-  /* We want the widgets to flow around the drawing area, so we don't
-   * set a size of the main window.  The drawing area's size is fixed,
-   * see below
-   */
-
-
-  /*
-  *  windows layout:
-  */
 #ifdef ENABLE_GTK3
   vpaned = gtk_paned_new (GTK_ORIENTATION_VERTICAL);
   hpaned = gtk_paned_new (GTK_ORIENTATION_HORIZONTAL);
@@ -594,6 +588,23 @@ x_window_create_main (GtkWidget *main_window,
 
   gtk_paned_pack2 (GTK_PANED (hpaned), w_current->right_notebook,
                    FALSE, TRUE);
+}
+
+
+/*! \todo Finish function documentation!!!
+ *  \brief
+ *  \par Function Description
+ *
+ */
+GschemToplevel*
+x_window_create_main (GtkWidget *main_window,
+                      GtkWidget *main_box,
+                      GschemToplevel *w_current)
+{
+  /* We want the widgets to flow around the drawing area, so we don't
+   * set a size of the main window.  The drawing area's size is fixed,
+   * see below
+   */
 
 
   /*

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -446,6 +446,33 @@ x_window_translate_response (GschemTranslateWidget *widget, gint response, Gsche
 }
 
 
+/*! \brief Creates a new main window widget.
+ *  \par Function Description
+ * Creates a new lepton-schematic window and initializes some of
+ * its properties.
+ *
+ * \param app Pointer to the GtkApplication (for GTK3).
+ * \return Pointer to the new GtkWidget object.
+ */
+GtkWidget*
+schematic_window_create_app_window (gpointer app)
+{
+  GtkWidget *main_window = NULL;
+
+#ifdef ENABLE_GTK3
+  g_return_val_if_fail (app != NULL, NULL);
+  main_window = gtk_application_window_new (GTK_APPLICATION (app));
+#else
+  main_window = GTK_WIDGET (gschem_main_window_new ());
+#endif
+
+  gtk_widget_set_name (main_window, "lepton-schematic");
+  gtk_window_set_resizable (GTK_WINDOW (main_window), TRUE);
+
+  return main_window;
+}
+
+
 
 /*! \todo Finish function documentation!!!
  *  \brief
@@ -458,21 +485,13 @@ x_window_create_main (gpointer app,
                       GtkWidget *menubar,
                       gpointer key_event_callback)
 {
-  GtkWidget *main_window = NULL;
   GtkWidget *main_box = NULL;
   GtkWidget *hpaned = NULL;
   GtkWidget *vpaned = NULL;
   GtkWidget *work_box = NULL;
   GtkWidget *scrolled = NULL;
 
-#ifdef ENABLE_GTK3
-  main_window = gtk_application_window_new (GTK_APPLICATION (app));
-#else
-  main_window = GTK_WIDGET (gschem_main_window_new ());
-#endif
-
-  gtk_widget_set_name (main_window, "lepton-schematic");
-  gtk_window_set_resizable (GTK_WINDOW (main_window), TRUE);
+  GtkWidget *main_window = schematic_window_create_app_window (app);
 
   /* We want the widgets to flow around the drawing area, so we don't
    * set a size of the main window.  The drawing area's size is fixed,

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -578,9 +578,6 @@ x_window_create_main (GtkWidget *main_window,
    * see below
    */
 
-  /* setup callbacks for draw events - main window: */
-  x_window_setup_draw_events_main_wnd (w_current, main_window);
-
 
   /*
   *  hidden infowidgets:

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -56,8 +56,8 @@ static void
 geometry_save (GschemToplevel* w_current);
 
 static void
-geometry_restore (GtkWidget* main_window,
-                  GtkWidget *find_text_state);
+geometry_restore (GschemToplevel* w_current,
+                  GtkWidget* main_window);
 
 static void
 open_page_error_dialog (GschemToplevel* w_current,
@@ -596,7 +596,7 @@ GschemToplevel*
 x_window_create_main (GtkWidget *main_window,
                       GschemToplevel *w_current)
 {
-  geometry_restore (main_window, w_current->find_text_state);
+  geometry_restore (w_current, main_window);
 
   /* show all widgets: */
   gtk_widget_show_all (main_window);
@@ -1859,8 +1859,8 @@ geometry_save (GschemToplevel* w_current)
  *  \param find_text_state The find text state widget.
  */
 static void
-geometry_restore (GtkWidget* main_window,
-                  GtkWidget *find_text_state)
+geometry_restore (GschemToplevel *w_current,
+                  GtkWidget* main_window)
 {
   gchar* cwd = g_get_current_dir();
   EdaConfig* cfg = eda_config_get_context_for_path (cwd);
@@ -1911,7 +1911,7 @@ geometry_restore (GtkWidget* main_window,
 
   if (x_widgets_use_docks())
   {
-    gtk_widget_set_size_request (find_text_state,
+    gtk_widget_set_size_request (w_current->find_text_state,
                                  -1,
                                  height / 4);
   }

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -523,6 +523,7 @@ schematic_window_create_work_box ()
 GschemToplevel*
 x_window_create_main (GtkWidget *main_window,
                       GtkWidget *main_box,
+                      GtkWidget *work_box,
                       GschemToplevel *w_current,
                       gpointer key_event_callback)
 {
@@ -534,8 +535,6 @@ x_window_create_main (GtkWidget *main_window,
    * set a size of the main window.  The drawing area's size is fixed,
    * see below
    */
-
-  GtkWidget *work_box = schematic_window_create_work_box ();
 
   _key_event_callback = key_event_callback;
 

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -583,15 +583,21 @@ schematic_window_create_notebooks (GschemToplevel *w_current,
 }
 
 
-/*! \todo Finish function documentation!!!
- *  \brief
+/*! \brief Show widgets of schematic window
  *  \par Function Description
+ *  Shows widgets of schematic window, sets visibility of right
+ *  and bottom notebooks, and sets focus to the drawing area.
  *
+ * \param [in] w_current The #GschemToplevel object.
+ * \param [in] main_window The main window widget.
  */
-GschemToplevel*
-x_window_create_main (GtkWidget *main_window,
-                      GschemToplevel *w_current)
+void
+schematic_window_show_all (GschemToplevel *w_current,
+                           GtkWidget *main_window)
 {
+  g_return_if_fail (w_current != NULL);
+  g_return_if_fail (main_window != NULL);
+
   /* show all widgets: */
   gtk_widget_show_all (main_window);
 
@@ -605,11 +611,28 @@ x_window_create_main (GtkWidget *main_window,
 
   /* focus page view: */
   gtk_widget_grab_focus (w_current->drawing_area);
+}
+
+
+/*! \brief Set main window widget of schematic window
+ *  \par Function Description
+ *  Sets the main window widget of #GschemToplevel instance \a
+ *  w_current to \a main_window.
+ *
+ * \param [in] w_current The #GschemToplevel object.
+ * \param [in] main_window The main window widget.
+ */
+GschemToplevel*
+schematic_window_set_main_window (GschemToplevel *w_current,
+                                  GtkWidget *main_window)
+{
+  g_return_val_if_fail (w_current != NULL, NULL);
+  g_return_val_if_fail (main_window != NULL, NULL);
 
   w_current->main_window = main_window;
 
   return w_current;
-} /* x_window_create_main() */
+}
 
 
 

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -514,12 +514,6 @@ x_window_create_main (GtkWidget *main_window,
    */
 
   /*
-  *  toolbar:
-  */
-  schematic_window_create_toolbar (w_current, main_box);
-
-
-  /*
   *  popup menu:
   */
   w_current->popup_menu = (GtkWidget*) get_main_popup (w_current);
@@ -1142,8 +1136,9 @@ create_toolbar_separator (GtkWidget *toolbar, gint pos)
 
 
 
-static void
-schematic_window_create_toolbar( GschemToplevel *w_current, GtkWidget *main_box )
+void
+schematic_window_create_toolbar (GschemToplevel *w_current,
+                                 GtkWidget *main_box)
 {
   if (w_current->toolbars == 0)
   {

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -515,6 +515,36 @@ schematic_window_create_work_box ()
 }
 
 
+/*! \brief Create a page view
+ *  \par Function Description
+ *  Creates a scrolled #GschemPageView widget in the working area
+ *  \a work_box.  This function is used when tabs are disabled.
+ *
+ * \param w_current The #GschemToplevel object.
+ * \param work_box The working area widget.
+ * \return Pointer to the new GtkWidget object.
+ */
+GschemPageView*
+schematic_window_create_page_view (GschemToplevel *w_current,
+                                   GtkWidget *work_box)
+{
+  GtkWidget *scrolled = NULL;
+
+  g_return_val_if_fail (w_current != NULL, NULL);
+  g_return_val_if_fail (work_box != NULL, NULL);
+
+  /* scrolled window (parent of page view): */
+  scrolled = gtk_scrolled_window_new (NULL, NULL);
+  gtk_container_add (GTK_CONTAINER (work_box), scrolled);
+
+  /* create page view: */
+  x_window_create_drawing (scrolled, w_current);
+  x_window_setup_scrolling (w_current, scrolled);
+
+  return GSCHEM_PAGE_VIEW (w_current->drawing_area);
+}
+
+
 /*! \todo Finish function documentation!!!
  *  \brief
  *  \par Function Description
@@ -529,7 +559,6 @@ x_window_create_main (GtkWidget *main_window,
 {
   GtkWidget *hpaned = NULL;
   GtkWidget *vpaned = NULL;
-  GtkWidget *scrolled = NULL;
 
   /* We want the widgets to flow around the drawing area, so we don't
    * set a size of the main window.  The drawing area's size is fixed,
@@ -544,16 +573,10 @@ x_window_create_main (GtkWidget *main_window,
   }
   else
   {
-    /* scrolled window (parent of page view): */
-    scrolled = gtk_scrolled_window_new (NULL, NULL);
-    gtk_container_add (GTK_CONTAINER (work_box), scrolled);
-
-    /* create page view: */
-    x_window_create_drawing (scrolled, w_current);
-    x_window_setup_scrolling (w_current, scrolled);
+    GschemPageView* pview =
+      schematic_window_create_page_view (w_current, work_box);
 
     /* setup callbacks for draw events - page view: */
-    GschemPageView* pview = GSCHEM_PAGE_VIEW (w_current->drawing_area);
     x_window_setup_draw_events_drawing_area (w_current, pview);
   }
 

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -516,7 +516,7 @@ x_window_create_main (GtkWidget *main_window,
   /*
   *  popup menu:
   */
-  w_current->popup_menu = (GtkWidget*) get_main_popup (w_current);
+  w_current->popup_menu = get_main_popup (w_current);
 
 
   /*

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -84,8 +84,8 @@ static void
 geometry_save (GschemToplevel* w_current);
 
 static void
-geometry_restore (GschemToplevel* w_current);
-
+geometry_restore (GtkWidget* main_window,
+                  GtkWidget *find_text_state);
 
 static void
 open_page_error_dialog (GschemToplevel* w_current,
@@ -605,7 +605,7 @@ x_window_create_main (gpointer app,
   */
   create_bottom_widget (w_current, main_box);
 
-  geometry_restore (w_current);
+  geometry_restore (main_window, w_current->find_text_state);
 
   /* show all widgets: */
   gtk_widget_show_all (main_window);
@@ -1845,10 +1845,12 @@ geometry_save (GschemToplevel* w_current)
  *  Unless valid configuration values are read, use default width
  *  and height.
  *
- *  \param w_current The toplevel environment.
+ *  \param main_window The main window widget of lepton-schematic.
+ *  \param find_text_state The find text state widget.
  */
 static void
-geometry_restore (GschemToplevel* w_current)
+geometry_restore (GtkWidget* main_window,
+                  GtkWidget *find_text_state)
 {
   gchar* cwd = g_get_current_dir();
   EdaConfig* cfg = eda_config_get_context_for_path (cwd);
@@ -1880,7 +1882,7 @@ geometry_restore (GschemToplevel* w_current)
 
     if (x > 0 && y > 0)
     {
-      gtk_window_move (GTK_WINDOW (w_current->main_window), x, y);
+      gtk_window_move (GTK_WINDOW (main_window), x, y);
     }
 
     width  = eda_config_get_int (ccfg, "schematic.window-geometry", "width",  NULL);
@@ -1894,12 +1896,12 @@ geometry_restore (GschemToplevel* w_current)
     height = default_height;
   }
 
-  gtk_window_resize (GTK_WINDOW (w_current->main_window), width, height);
+  gtk_window_resize (GTK_WINDOW (main_window), width, height);
 
 
   if (x_widgets_use_docks())
   {
-    gtk_widget_set_size_request (w_current->find_text_state,
+    gtk_widget_set_size_request (find_text_state,
                                  -1,
                                  height / 4);
   }

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -24,11 +24,6 @@
 
 
 static void
-create_menubar (GschemToplevel *w_current,
-                GtkWidget *main_box,
-                GtkWidget *menubar);
-
-static void
 create_toolbar_button (GschemToplevel *w_current,
                        GtkWidget *toolbar,
                        const gchar *pixmap_name,
@@ -526,7 +521,7 @@ x_window_create_main (GtkWidget *main_window,
   /*
   *  main menu:
   */
-  create_menubar (w_current, main_box, menubar);
+  schematic_window_create_menubar (w_current, main_box, menubar);
 
 
   /*
@@ -1061,9 +1056,21 @@ GschemToplevel* x_window_new (LeptonToplevel *toplevel)
 
 
 
-static void
-create_menubar (GschemToplevel *w_current, GtkWidget *main_box, GtkWidget *menubar)
+/*! \brief Add a menubar widget to the main container of a window.
+ *  \par Function Description
+ *  Adds a menubar at the top of the program window.  GTK2 version
+ *  of the widget may have 'handle boxes' depending on configuration.
+ *
+ *  \param [in] w_current The toplevel GUI window structure.
+ *  \param [in] main_box The main container of the app window.
+ *  \param [in] menubar The menubar widget created elsewhere.
+ */
+void
+schematic_window_create_menubar (GschemToplevel *w_current,
+                                 GtkWidget *main_box,
+                                 GtkWidget *menubar)
 {
+  g_return_if_fail (w_current != NULL);
 
 #ifdef ENABLE_GTK3
   gtk_box_pack_start (GTK_BOX (main_box), menubar, FALSE, FALSE, 0);

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -190,6 +190,20 @@ void x_window_setup_draw_events_main_wnd (GschemToplevel* w_current,
 
 gpointer _key_event_callback = NULL;
 
+/*! \brief Set key event callback
+ *  \par Function Description
+ *  Sets key event processing callback to a given function
+ *  pointer.  Currently it is necessary as key event processing is
+ *  handled in Scheme.
+ *
+ * \param [in] key_event_callback The pointer to the callback.
+ */
+void
+schematic_window_set_key_event_callback (gpointer key_event_callback)
+{
+  _key_event_callback = key_event_callback;
+}
+
 
 /*! \brief Set up callbacks for the drawing area.
  *  \par Function Description
@@ -554,8 +568,7 @@ GschemToplevel*
 x_window_create_main (GtkWidget *main_window,
                       GtkWidget *main_box,
                       GtkWidget *work_box,
-                      GschemToplevel *w_current,
-                      gpointer key_event_callback)
+                      GschemToplevel *w_current)
 {
   GtkWidget *hpaned = NULL;
   GtkWidget *vpaned = NULL;
@@ -564,8 +577,6 @@ x_window_create_main (GtkWidget *main_window,
    * set a size of the main window.  The drawing area's size is fixed,
    * see below
    */
-
-  _key_event_callback = key_event_callback;
 
   if (x_tabs_enabled())
   {

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -458,6 +458,7 @@ x_window_create_main (gpointer app,
                       GtkWidget *menubar,
                       gpointer key_event_callback)
 {
+  GtkWidget *main_window = NULL;
   GtkWidget *main_box = NULL;
   GtkWidget *hpaned = NULL;
   GtkWidget *vpaned = NULL;
@@ -465,13 +466,13 @@ x_window_create_main (gpointer app,
   GtkWidget *scrolled = NULL;
 
 #ifdef ENABLE_GTK3
-  w_current->main_window = gtk_application_window_new (GTK_APPLICATION (app));
+  main_window = gtk_application_window_new (GTK_APPLICATION (app));
 #else
-  w_current->main_window = GTK_WIDGET (gschem_main_window_new ());
+  main_window = GTK_WIDGET (gschem_main_window_new ());
 #endif
 
-  gtk_widget_set_name (w_current->main_window, "lepton-schematic");
-  gtk_window_set_resizable (GTK_WINDOW (w_current->main_window), TRUE);
+  gtk_widget_set_name (main_window, "lepton-schematic");
+  gtk_window_set_resizable (GTK_WINDOW (main_window), TRUE);
 
   /* We want the widgets to flow around the drawing area, so we don't
    * set a size of the main window.  The drawing area's size is fixed,
@@ -479,7 +480,7 @@ x_window_create_main (gpointer app,
    */
 
   /* this should work fine */
-  g_signal_connect (G_OBJECT (w_current->main_window), "delete_event",
+  g_signal_connect (G_OBJECT (main_window), "delete_event",
                     G_CALLBACK (i_callback_close_wm),
                     w_current);
 
@@ -493,7 +494,7 @@ x_window_create_main (gpointer app,
   main_box = gtk_vbox_new (FALSE, 1);
 #endif
   gtk_container_set_border_width (GTK_CONTAINER (main_box), 0);
-  gtk_container_add (GTK_CONTAINER (w_current->main_window), main_box);
+  gtk_container_add (GTK_CONTAINER (main_window), main_box);
 
 
   /*
@@ -547,7 +548,7 @@ x_window_create_main (gpointer app,
 
 
   /* setup callbacks for draw events - main window: */
-  x_window_setup_draw_events_main_wnd (w_current, w_current->main_window);
+  x_window_setup_draw_events_main_wnd (w_current, main_window);
 
 
   /*
@@ -607,7 +608,7 @@ x_window_create_main (gpointer app,
   geometry_restore (w_current);
 
   /* show all widgets: */
-  gtk_widget_show_all (w_current->main_window);
+  gtk_widget_show_all (main_window);
 
 
   if ( !x_widgets_use_docks() )
@@ -619,6 +620,8 @@ x_window_create_main (gpointer app,
 
   /* focus page view: */
   gtk_widget_grab_focus (w_current->drawing_area);
+
+  w_current->main_window = main_window;
 
   return w_current;
 } /* x_window_create_main() */

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -46,21 +46,6 @@ static void
 create_toolbar_separator (GtkWidget *toolbar, gint pos);
 
 static void
-create_find_text_widget (GschemToplevel *w_current, GtkWidget *work_box);
-
-static void
-create_hide_text_widget (GschemToplevel *w_current, GtkWidget *work_box);
-
-static void
-create_show_text_widget (GschemToplevel *w_current, GtkWidget *work_box);
-
-static void
-create_macro_widget (GschemToplevel *w_current, GtkWidget *work_box);
-
-static void
-create_translate_widget (GschemToplevel *w_current, GtkWidget *work_box);
-
-static void
 create_bottom_widget (GschemToplevel *w_current, GtkWidget *main_box);
 
 
@@ -577,16 +562,6 @@ x_window_create_main (GtkWidget *main_window,
    * set a size of the main window.  The drawing area's size is fixed,
    * see below
    */
-
-
-  /*
-  *  hidden infowidgets:
-  */
-  create_find_text_widget (w_current, work_box);
-  create_hide_text_widget (w_current, work_box);
-  create_show_text_widget (w_current, work_box);
-  create_macro_widget (w_current, work_box);
-  create_translate_widget (w_current, work_box);
 
 
   /*
@@ -1263,8 +1238,9 @@ schematic_window_create_toolbar (GschemToplevel *w_current,
 
 
 
-static void
-create_find_text_widget (GschemToplevel *w_current, GtkWidget *work_box)
+void
+schematic_window_create_find_text_widget (GschemToplevel *w_current,
+                                          GtkWidget *work_box)
 {
   gpointer obj = g_object_new (GSCHEM_TYPE_FIND_TEXT_WIDGET, NULL);
 
@@ -1280,8 +1256,9 @@ create_find_text_widget (GschemToplevel *w_current, GtkWidget *work_box)
 
 
 
-static void
-create_hide_text_widget (GschemToplevel *w_current, GtkWidget *work_box)
+void
+schematic_window_create_hide_text_widget (GschemToplevel *w_current,
+                                          GtkWidget *work_box)
 {
   gpointer obj = g_object_new (GSCHEM_TYPE_SHOW_HIDE_TEXT_WIDGET,
                                "button-text", _("Hide"),
@@ -1300,8 +1277,9 @@ create_hide_text_widget (GschemToplevel *w_current, GtkWidget *work_box)
 
 
 
-static void
-create_show_text_widget (GschemToplevel *w_current, GtkWidget *work_box)
+void
+schematic_window_create_show_text_widget (GschemToplevel *w_current,
+                                          GtkWidget *work_box)
 {
   gpointer obj = g_object_new (GSCHEM_TYPE_SHOW_HIDE_TEXT_WIDGET,
                                "button-text", _("Show"),
@@ -1320,8 +1298,9 @@ create_show_text_widget (GschemToplevel *w_current, GtkWidget *work_box)
 
 
 
-static void
-create_macro_widget (GschemToplevel *w_current, GtkWidget *work_box)
+void
+schematic_window_create_macro_widget (GschemToplevel *w_current,
+                                      GtkWidget *work_box)
 {
   w_current->macro_widget = macro_widget_new (w_current);
 
@@ -1332,8 +1311,9 @@ create_macro_widget (GschemToplevel *w_current, GtkWidget *work_box)
 
 
 
-static void
-create_translate_widget (GschemToplevel *w_current, GtkWidget *work_box)
+void
+schematic_window_create_translate_widget (GschemToplevel *w_current,
+                                          GtkWidget *work_box)
 {
   gpointer obj = g_object_new (GSCHEM_TYPE_TRANSLATE_WIDGET, NULL);
 

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -46,10 +46,6 @@ static void
 create_toolbar_separator (GtkWidget *toolbar, gint pos);
 
 static void
-create_toolbar (GschemToplevel *w_current, GtkWidget *main_box);
-
-
-static void
 create_find_text_widget (GschemToplevel *w_current, GtkWidget *work_box);
 
 static void
@@ -520,7 +516,7 @@ x_window_create_main (GtkWidget *main_window,
   /*
   *  toolbar:
   */
-  create_toolbar (w_current, main_box);
+  schematic_window_create_toolbar (w_current, main_box);
 
 
   /*
@@ -1147,7 +1143,7 @@ create_toolbar_separator (GtkWidget *toolbar, gint pos)
 
 
 static void
-create_toolbar( GschemToplevel *w_current, GtkWidget *main_box )
+schematic_window_create_toolbar( GschemToplevel *w_current, GtkWidget *main_box )
 {
   if (w_current->toolbars == 0)
   {
@@ -1244,7 +1240,7 @@ create_toolbar( GschemToplevel *w_current, GtkWidget *main_box )
   gtk_toggle_tool_button_set_active(
     GTK_TOGGLE_TOOL_BUTTON (w_current->toolbar_select), TRUE);
 
-} /* create_toolbar() */
+} /* schematic_window_create_toolbar() */
 
 
 

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -578,20 +578,6 @@ x_window_create_main (GtkWidget *main_window,
    * see below
    */
 
-  if (x_tabs_enabled())
-  {
-    x_tabs_create (w_current, work_box);
-  }
-  else
-  {
-    GschemPageView* pview =
-      schematic_window_create_page_view (w_current, work_box);
-
-    /* setup callbacks for draw events - page view: */
-    x_window_setup_draw_events_drawing_area (w_current, pview);
-  }
-
-
   /* setup callbacks for draw events - main window: */
   x_window_setup_draw_events_main_wnd (w_current, main_window);
 

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -596,12 +596,6 @@ GschemToplevel*
 x_window_create_main (GtkWidget *main_window,
                       GschemToplevel *w_current)
 {
-  /* We want the widgets to flow around the drawing area, so we don't
-   * set a size of the main window.  The drawing area's size is fixed,
-   * see below
-   */
-
-
   geometry_restore (main_window, w_current->find_text_state);
 
   /* show all widgets: */

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -45,10 +45,6 @@ create_toolbar_radio_button (GSList** group,
 static void
 create_toolbar_separator (GtkWidget *toolbar, gint pos);
 
-static void
-create_bottom_widget (GschemToplevel *w_current, GtkWidget *main_box);
-
-
 static GtkWidget*
 create_notebook_right (GschemToplevel *w_current);
 
@@ -598,7 +594,6 @@ schematic_window_create_notebooks (GschemToplevel *w_current,
  */
 GschemToplevel*
 x_window_create_main (GtkWidget *main_window,
-                      GtkWidget *main_box,
                       GschemToplevel *w_current)
 {
   /* We want the widgets to flow around the drawing area, so we don't
@@ -606,11 +601,6 @@ x_window_create_main (GtkWidget *main_window,
    * see below
    */
 
-
-  /*
-  *  status bar aka 'bottom widget':
-  */
-  create_bottom_widget (w_current, main_box);
 
   geometry_restore (main_window, w_current->find_text_state);
 
@@ -1333,8 +1323,9 @@ schematic_window_create_translate_widget (GschemToplevel *w_current,
 
 
 
-static void
-create_bottom_widget (GschemToplevel *w_current, GtkWidget *main_box)
+void
+schematic_window_create_statusbar (GschemToplevel *w_current,
+                                   GtkWidget *main_box)
 {
   const char* text_mid_button = _("none");
 
@@ -1421,7 +1412,7 @@ create_bottom_widget (GschemToplevel *w_current, GtkWidget *main_box)
                       w_current->bottom_widget,
                       FALSE, FALSE, 0);
 
-} /* create_bottom_widget */
+} /* schematic_window_create_statusbar */
 
 
 

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -473,6 +473,33 @@ schematic_window_create_app_window (gpointer app)
 }
 
 
+/*! \brief Create a top level box container for widgets.
+ *  \par Function Description
+ * In the main window widget of a lepton-schematic window, creates
+ * a top level box container which will contain the menubar,
+ * toolbar and other widgets.
+ *
+ * \param main_window The main window widget.
+ * \return Pointer to the new GtkWidget object.
+ */
+GtkWidget*
+schematic_window_create_main_box (GtkWidget *main_window)
+{
+  GtkWidget *main_box = NULL;
+
+  g_return_val_if_fail (main_window != NULL, NULL);
+
+#ifdef ENABLE_GTK3
+  main_box = gtk_box_new (GTK_ORIENTATION_VERTICAL, 1);
+#else
+  main_box = gtk_vbox_new (FALSE, 1);
+#endif
+  gtk_container_set_border_width (GTK_CONTAINER (main_box), 0);
+  gtk_container_add (GTK_CONTAINER (main_window), main_box);
+
+  return main_box;
+}
+
 
 /*! \todo Finish function documentation!!!
  *  \brief
@@ -485,28 +512,17 @@ x_window_create_main (GtkWidget *main_window,
                       GtkWidget *menubar,
                       gpointer key_event_callback)
 {
-  GtkWidget *main_box = NULL;
   GtkWidget *hpaned = NULL;
   GtkWidget *vpaned = NULL;
   GtkWidget *work_box = NULL;
   GtkWidget *scrolled = NULL;
 
+  GtkWidget *main_box = schematic_window_create_main_box (main_window);
+
   /* We want the widgets to flow around the drawing area, so we don't
    * set a size of the main window.  The drawing area's size is fixed,
    * see below
    */
-
-  /*
-  *  top level container:
-  */
-#ifdef ENABLE_GTK3
-  main_box = gtk_box_new (GTK_ORIENTATION_VERTICAL, 1);
-#else
-  main_box = gtk_vbox_new (FALSE, 1);
-#endif
-  gtk_container_set_border_width (GTK_CONTAINER (main_box), 0);
-  gtk_container_add (GTK_CONTAINER (main_window), main_box);
-
 
   /*
   *  main menu:

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -56,10 +56,6 @@ static void
 geometry_save (GschemToplevel* w_current);
 
 static void
-geometry_restore (GschemToplevel* w_current,
-                  GtkWidget* main_window);
-
-static void
 open_page_error_dialog (GschemToplevel* w_current,
                         const gchar*    filename,
                         GError*         err);
@@ -596,8 +592,6 @@ GschemToplevel*
 x_window_create_main (GtkWidget *main_window,
                       GschemToplevel *w_current)
 {
-  geometry_restore (w_current, main_window);
-
   /* show all widgets: */
   gtk_widget_show_all (main_window);
 
@@ -1858,9 +1852,9 @@ geometry_save (GschemToplevel* w_current)
  *  \param main_window The main window widget of lepton-schematic.
  *  \param find_text_state The find text state widget.
  */
-static void
-geometry_restore (GschemToplevel *w_current,
-                  GtkWidget* main_window)
+void
+schematic_window_restore_geometry (GschemToplevel *w_current,
+                                   GtkWidget* main_window)
 {
   gchar* cwd = g_get_current_dir();
   EdaConfig* cfg = eda_config_get_context_for_path (cwd);

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -496,12 +496,6 @@ x_window_create_main (GtkWidget *main_window,
    * see below
    */
 
-  /* this should work fine */
-  g_signal_connect (G_OBJECT (main_window), "delete_event",
-                    G_CALLBACK (i_callback_close_wm),
-                    w_current);
-
-
   /*
   *  top level container:
   */

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -565,13 +565,6 @@ x_window_create_main (GtkWidget *main_window,
 
 
   /*
-  *  widgets:
-  */
-  x_widgets_init();
-  x_widgets_create (w_current);
-
-
-  /*
   *  windows layout:
   */
 #ifdef ENABLE_GTK3

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -505,7 +505,6 @@ GschemToplevel*
 x_window_create_main (GtkWidget *main_window,
                       GtkWidget *main_box,
                       GschemToplevel *w_current,
-                      GtkWidget *menubar,
                       gpointer key_event_callback)
 {
   GtkWidget *hpaned = NULL;
@@ -517,12 +516,6 @@ x_window_create_main (GtkWidget *main_window,
    * set a size of the main window.  The drawing area's size is fixed,
    * see below
    */
-
-  /*
-  *  main menu:
-  */
-  schematic_window_create_menubar (w_current, main_box, menubar);
-
 
   /*
   *  toolbar:

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -480,7 +480,7 @@ schematic_window_create_app_window (gpointer app)
  *
  */
 GschemToplevel*
-x_window_create_main (gpointer app,
+x_window_create_main (GtkWidget *main_window,
                       GschemToplevel *w_current,
                       GtkWidget *menubar,
                       gpointer key_event_callback)
@@ -490,8 +490,6 @@ x_window_create_main (gpointer app,
   GtkWidget *vpaned = NULL;
   GtkWidget *work_box = NULL;
   GtkWidget *scrolled = NULL;
-
-  GtkWidget *main_window = schematic_window_create_app_window (app);
 
   /* We want the widgets to flow around the drawing area, so we don't
    * set a size of the main window.  The drawing area's size is fixed,

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -514,12 +514,6 @@ x_window_create_main (GtkWidget *main_window,
    */
 
   /*
-  *  popup menu:
-  */
-  w_current->popup_menu = get_main_popup (w_current);
-
-
-  /*
   *  container for scrolled window and bottom infowidgets;
   *  when tabbed GUI is enabled, it will contain the notebook:
   */

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -492,6 +492,29 @@ schematic_window_create_main_box (GtkWidget *main_window)
 }
 
 
+/*! \brief Create a container for scrolled window and bottom infowidgets
+ *  \par Function Description
+ *  Creates a container for scrolled canvas and bottom
+ *  infowidgets.  When tabbed GUI is enabled, it will contain the
+ *  tabs notebook.
+ *
+ * \return Pointer to the new GtkWidget object.
+ */
+GtkWidget*
+schematic_window_create_work_box ()
+{
+  GtkWidget *work_box = NULL;
+
+#ifdef ENABLE_GTK3
+  work_box = gtk_box_new (GTK_ORIENTATION_VERTICAL, 0);
+#else
+  work_box = gtk_vbox_new (FALSE, 0);
+#endif
+
+  return work_box;
+}
+
+
 /*! \todo Finish function documentation!!!
  *  \brief
  *  \par Function Description
@@ -505,7 +528,6 @@ x_window_create_main (GtkWidget *main_window,
 {
   GtkWidget *hpaned = NULL;
   GtkWidget *vpaned = NULL;
-  GtkWidget *work_box = NULL;
   GtkWidget *scrolled = NULL;
 
   /* We want the widgets to flow around the drawing area, so we don't
@@ -513,15 +535,7 @@ x_window_create_main (GtkWidget *main_window,
    * see below
    */
 
-  /*
-  *  container for scrolled window and bottom infowidgets;
-  *  when tabbed GUI is enabled, it will contain the notebook:
-  */
-#ifdef ENABLE_GTK3
-  work_box = gtk_box_new (GTK_ORIENTATION_VERTICAL, 0);
-#else
-  work_box = gtk_vbox_new (FALSE, 0);
-#endif
+  GtkWidget *work_box = schematic_window_create_work_box ();
 
   _key_event_callback = key_event_callback;
 

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -508,6 +508,7 @@ schematic_window_create_main_box (GtkWidget *main_window)
  */
 GschemToplevel*
 x_window_create_main (GtkWidget *main_window,
+                      GtkWidget *main_box,
                       GschemToplevel *w_current,
                       GtkWidget *menubar,
                       gpointer key_event_callback)
@@ -516,8 +517,6 @@ x_window_create_main (GtkWidget *main_window,
   GtkWidget *vpaned = NULL;
   GtkWidget *work_box = NULL;
   GtkWidget *scrolled = NULL;
-
-  GtkWidget *main_box = schematic_window_create_main_box (main_window);
 
   /* We want the widgets to flow around the drawing area, so we don't
    * set a size of the main window.  The drawing area's size is fixed,

--- a/schematic/lepton-schematic.scm
+++ b/schematic/lepton-schematic.scm
@@ -35,7 +35,6 @@
              (schematic ffi)
              (schematic ffi gtk)
              (schematic gui keymap)
-             (schematic menu)
              (schematic window))
 
 ;;; Initialize liblepton library.
@@ -236,16 +235,6 @@ Run `~A --help' for more information.\n")
                        filename)))
 
   (map get-absolute-filename filename-list))
-
-;;; Creates a new window in lepton-schematic.
-(define (make-schematic-window app toplevel)
-  (define new-window
-    (x_window_setup (x_window_new (parse-gschemrc toplevel))))
-
-  (x_window_create_main app
-                        new-window
-                        (make-main-menu new-window)
-                        *process-key-event))
 
 (define (main app file-list)
   ;; Create a new window and associated LeptonToplevel object.


### PR DESCRIPTION
In future, it will allow for extending our Scheme API wrt `lepton-schematic`.  The changes are as follows:
- A new Scheme function, `make-schematic-window()`, has been factored out
  for creating a new main `lepton-schematic` window. The function
  now lives in the module `(schematic window)`.
- The function `x_window_create_main()` has been split up to
  allow dealing with pointers of different program widgets.
- The signal "delete-event" of `lepton-schematic` is now connected
  in Scheme code.
- Key event processing callback is now also assigned in Scheme.
- Several functions have been renamed by adding the `schematic_`
  prefix and made available for dlopening.
- Many top level widgets are now set up in Scheme and their
  pointers are available for Scheme code.
- Added or improved doxygen comments for several functions.
