### PR TITLE
Rewrite page view color setting callbacks in Scheme

### DIFF
--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -141,7 +141,6 @@ void i_callback_view_pan_left (GtkWidget *widget, gpointer data);
 void i_callback_view_pan_right (GtkWidget *widget, gpointer data);
 void i_callback_view_pan_up (GtkWidget *widget, gpointer data);
 void i_callback_view_pan_down (GtkWidget *widget, gpointer data);
-void i_callback_view_dark_colors (GtkWidget *widget, gpointer data);
 void i_callback_view_light_colors (GtkWidget *widget, gpointer data);
 void i_callback_view_bw_colors (GtkWidget *widget, gpointer data);
 void i_callback_view_color_edit (GtkWidget *widget, gpointer data);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -141,7 +141,6 @@ void i_callback_view_pan_left (GtkWidget *widget, gpointer data);
 void i_callback_view_pan_right (GtkWidget *widget, gpointer data);
 void i_callback_view_pan_up (GtkWidget *widget, gpointer data);
 void i_callback_view_pan_down (GtkWidget *widget, gpointer data);
-void i_callback_view_bw_colors (GtkWidget *widget, gpointer data);
 void i_callback_view_color_edit (GtkWidget *widget, gpointer data);
 void i_callback_page_next (GtkWidget *widget, gpointer data);
 void i_callback_page_prev (GtkWidget *widget, gpointer data);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -141,7 +141,6 @@ void i_callback_view_pan_left (GtkWidget *widget, gpointer data);
 void i_callback_view_pan_right (GtkWidget *widget, gpointer data);
 void i_callback_view_pan_up (GtkWidget *widget, gpointer data);
 void i_callback_view_pan_down (GtkWidget *widget, gpointer data);
-void i_callback_view_light_colors (GtkWidget *widget, gpointer data);
 void i_callback_view_bw_colors (GtkWidget *widget, gpointer data);
 void i_callback_view_color_edit (GtkWidget *widget, gpointer data);
 void i_callback_page_next (GtkWidget *widget, gpointer data);

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -282,9 +282,9 @@
 (define-action-public (&view-light-colors #:label (G_ "Light Color Scheme"))
   (load-color-scheme (*current-window) "gschem-colormap-lightbg"))
 
-
 (define-action-public (&view-bw-colors #:label (G_ "Monochrome Color Scheme"))
-  (run-callback i_callback_view_bw_colors "&view-bw-colors"))
+  (load-color-scheme (*current-window) "gschem-colormap-bw"))
+
 
 (define-action-public (&view-color-edit #:label (G_ "Show Color Scheme Editor"))
   (run-callback i_callback_view_color_edit "&view-color-edit"))

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -28,6 +28,7 @@
   #:use-module (lepton log)
   #:use-module (lepton object)
   #:use-module (lepton page)
+  #:use-module (lepton rc)
   #:use-module (lepton repl)
 
   #:use-module (schematic action)
@@ -263,8 +264,19 @@
 (define-action-public (&view-zoom-full #:label (G_ "Zoom Full"))
   (run-callback i_callback_view_zoom_full "&view-zoom-full"))
 
+
+;;; Load the Dark color scheme.
 (define-action-public (&view-dark-colors #:label (G_ "Dark Color Scheme"))
-  (run-callback i_callback_view_dark_colors "&view-dark-colors"))
+  (define *window (*current-window))
+
+  (load-rc-from-sys-config-dirs "gschem-colormap-darkbg")
+
+  (x_colorcb_update_colors)
+  (color_edit_widget_update *window)
+
+  (gschem_page_view_invalidate_all
+   (gschem_toplevel_get_current_page_view *window)))
+
 
 (define-action-public (&view-light-colors #:label (G_ "Light Color Scheme"))
   (run-callback i_callback_view_light_colors "&view-light-colors"))

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -279,9 +279,9 @@
 (define-action-public (&view-dark-colors #:label (G_ "Dark Color Scheme"))
   (load-color-scheme (*current-window) "gschem-colormap-darkbg"))
 
-
 (define-action-public (&view-light-colors #:label (G_ "Light Color Scheme"))
-  (run-callback i_callback_view_light_colors "&view-light-colors"))
+  (load-color-scheme (*current-window) "gschem-colormap-lightbg"))
+
 
 (define-action-public (&view-bw-colors #:label (G_ "Monochrome Color Scheme"))
   (run-callback i_callback_view_bw_colors "&view-bw-colors"))

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -265,17 +265,19 @@
   (run-callback i_callback_view_zoom_full "&view-zoom-full"))
 
 
-;;; Load the Dark color scheme.
-(define-action-public (&view-dark-colors #:label (G_ "Dark Color Scheme"))
-  (define *window (*current-window))
-
-  (load-rc-from-sys-config-dirs "gschem-colormap-darkbg")
+(define (load-color-scheme *window color-scheme)
+  (load-rc-from-sys-config-dirs color-scheme)
 
   (x_colorcb_update_colors)
   (color_edit_widget_update *window)
 
   (gschem_page_view_invalidate_all
    (gschem_toplevel_get_current_page_view *window)))
+
+
+;;; Load the Dark color scheme.
+(define-action-public (&view-dark-colors #:label (G_ "Dark Color Scheme"))
+  (load-color-scheme (*current-window) "gschem-colormap-darkbg"))
 
 
 (define-action-public (&view-light-colors #:label (G_ "Light Color Scheme"))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -98,7 +98,6 @@
             i_callback_page_revert
             i_callback_view_bw_colors
             i_callback_view_color_edit
-            i_callback_view_dark_colors
             i_callback_view_light_colors
             i_callback_view_pan
             i_callback_view_pan_down
@@ -127,6 +126,11 @@
             set_quiet_mode
             set_verbose_mode
             x_color_init
+
+            color_edit_widget_update
+
+            x_colorcb_update_colors
+
             x_menu_attach_recent_files_submenu
             x_show_uri
             x_stroke_init
@@ -273,6 +277,12 @@
 (define-lff set_quiet_mode void '())
 (define-lff set_verbose_mode void '())
 (define-lff x_color_init void '())
+
+;;; color_edit_widget.c
+(define-lff color_edit_widget_update void '(*))
+
+;;; x_colorcb.c
+(define-lff x_colorcb_update_colors void '())
 
 ;;; x_widgets.c
 (define-lff x_widgets_create void '(*))
@@ -434,7 +444,6 @@
 (define-lff i_callback_options_snap_size void '(* *))
 (define-lff i_callback_view_bw_colors void '(* *))
 (define-lff i_callback_view_color_edit void '(* *))
-(define-lff i_callback_view_dark_colors void '(* *))
 (define-lff i_callback_view_light_colors void '(* *))
 (define-lff i_callback_view_pan void '(* *))
 (define-lff i_callback_view_pan_down void '(* *))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -98,7 +98,6 @@
             i_callback_page_revert
             i_callback_view_bw_colors
             i_callback_view_color_edit
-            i_callback_view_light_colors
             i_callback_view_pan
             i_callback_view_pan_down
             i_callback_view_pan_left
@@ -444,7 +443,6 @@
 (define-lff i_callback_options_snap_size void '(* *))
 (define-lff i_callback_view_bw_colors void '(* *))
 (define-lff i_callback_view_color_edit void '(* *))
-(define-lff i_callback_view_light_colors void '(* *))
 (define-lff i_callback_view_pan void '(* *))
 (define-lff i_callback_view_pan_down void '(* *))
 (define-lff i_callback_view_pan_left void '(* *))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -96,7 +96,6 @@
             i_callback_page_prev
             i_callback_page_print
             i_callback_page_revert
-            i_callback_view_bw_colors
             i_callback_view_color_edit
             i_callback_view_pan
             i_callback_view_pan_down
@@ -441,7 +440,6 @@
 (define-lff i_callback_options_scale_up_snap_size void '(* *))
 (define-lff i_callback_options_snap void '(* *))
 (define-lff i_callback_options_snap_size void '(* *))
-(define-lff i_callback_view_bw_colors void '(* *))
 (define-lff i_callback_view_color_edit void '(* *))
 (define-lff i_callback_view_pan void '(* *))
 (define-lff i_callback_view_pan_down void '(* *))

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -1110,23 +1110,6 @@ i_callback_view_pan_down (GtkWidget *widget, gpointer data)
 
 
 
-/*! \brief Load the Black & White color scheme
- */
-void
-i_callback_view_bw_colors (GtkWidget *widget, gpointer data)
-{
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-
-  g_scm_c_eval_string_protected ("(load-rc-from-sys-config-dirs \"gschem-colormap-bw\")");
-
-  x_colorcb_update_colors();
-  color_edit_widget_update (w_current);
-
-  gschem_page_view_invalidate_all (gschem_toplevel_get_current_page_view (w_current));
-}
-
-
-
 /*! \brief Show color scheme editor widget
  */
 void

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -1110,23 +1110,6 @@ i_callback_view_pan_down (GtkWidget *widget, gpointer data)
 
 
 
-/*! \brief Load the Dark color scheme
- */
-void
-i_callback_view_dark_colors (GtkWidget *widget, gpointer data)
-{
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-
-  g_scm_c_eval_string_protected ("(load-rc-from-sys-config-dirs \"gschem-colormap-darkbg\")");
-
-  x_colorcb_update_colors();
-  color_edit_widget_update (w_current);
-
-  gschem_page_view_invalidate_all (gschem_toplevel_get_current_page_view (w_current));
-}
-
-
-
 /*! \brief Load the Light color scheme
  */
 void

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -1110,23 +1110,6 @@ i_callback_view_pan_down (GtkWidget *widget, gpointer data)
 
 
 
-/*! \brief Load the Light color scheme
- */
-void
-i_callback_view_light_colors (GtkWidget *widget, gpointer data)
-{
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-
-  g_scm_c_eval_string_protected ("(load-rc-from-sys-config-dirs \"gschem-colormap-lightbg\")");
-
-  x_colorcb_update_colors();
-  color_edit_widget_update (w_current);
-
-  gschem_page_view_invalidate_all (gschem_toplevel_get_current_page_view (w_current));
-}
-
-
-
 /*! \brief Load the Black & White color scheme
  */
 void


### PR DESCRIPTION
Apart from simplifying the code a little, the commit set reduces the usage of the function `g_scm_c_eval_string_protected()` in the libraries.