### PR TITLE
Amend behavior of component-library() called with non-existent path

### DIFF
--- a/liblepton/scheme/lepton/file-system.scm
+++ b/liblepton/scheme/lepton/file-system.scm
@@ -1,6 +1,6 @@
 ;;; Lepton EDA library - Scheme API
 ;;; Copyright (C) 2007-2016 gEDA Contributors
-;;; Copyright (C) 2017-2019 Lepton EDA Contributors
+;;; Copyright (C) 2017-2022 Lepton EDA Contributors
 ;;;
 ;;; This program is free software; you can redistribute it and/or modify
 ;;; it under the terms of the GNU General Public License as published by
@@ -25,12 +25,14 @@
             file-readable?))
 
 (define (regular-file? path)
-  "Returns #t if the given path is a regular file, otherwise #f."
-  (eqv? (stat:type (stat path)) 'regular))
+  "Returns #t if the given path exists and is a regular file, otherwise #f."
+  (and (file-exists? path)
+       (eqv? (stat:type (stat path)) 'regular)))
 
 (define (directory? path)
-  "Returns #t if the given path is a directory file, otherwise #f."
-  (eqv? (stat:type (stat path)) 'directory ))
+  "Returns #t if the given path exists and is a directory file, otherwise #f."
+  (and (file-exists? path)
+       (eqv? (stat:type (stat path)) 'directory)))
 
 (define (file-readable? filename)
   "Returns #t if file FILENAME is readable with current user's

--- a/liblepton/scheme/lepton/library/component.scm
+++ b/liblepton/scheme/lepton/library/component.scm
@@ -98,7 +98,7 @@ library directory."
                                     (string->pointer name))))
         ;; Report that path is invalid.
         (log! 'warning
-              (G_ "Invalid path ~S passed to component-library.\n")
+              (G_ "Invalid path ~S passed to component-library.")
               expanded-path))))
 
 


### PR DESCRIPTION
Fix use of `stat()` in the `(lepton file-system)`
module: `regular-file?()` and `directory?()` functions
uses `stat()`, but do not check whether a path passed
to it exist or not. Call to `stat()` with non-existent
path throws an exception.

It affects the behavior of `component-library()`.
When it called with the wrong path in `gafrc`,
parsing of `gafrc` stops and backtrace is printed
to the log.

I think it's better to continue processing of `gafrc`
file and just report the failed call to `component-library()`.
