### PR TITLE
Rewrite callbacks i_callback_options_*() using Scheme FFI.

### DIFF
--- a/libleptongui/include/Makefile.am
+++ b/libleptongui/include/Makefile.am
@@ -1,6 +1,7 @@
 noinst_HEADERS = \
 	action_mode.h \
 	globals.h \
+	grid_mode.h \
 	i_vars.h \
 	prototype.h \
 	x_dialog.h \

--- a/libleptongui/include/Makefile.am
+++ b/libleptongui/include/Makefile.am
@@ -42,4 +42,5 @@ noinst_HEADERS = \
 	color_edit_widget.h \
 	font_select_widget.h \
 	page_select_widget.h \
+	snap_mode.h \
 	toolbar.h

--- a/libleptongui/include/grid_mode.h
+++ b/libleptongui/include/grid_mode.h
@@ -1,0 +1,43 @@
+/* Lepton EDA Schematic Capture
+ * Copyright (C) 2022 Lepton EDA Contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef GRID_MODE_H
+#define GRID_MODE_H
+
+enum _SchematicGridMode
+{
+  GRID_MODE_NONE,
+  GRID_MODE_DOTS,
+  GRID_MODE_MESH,
+  GRID_MODE_COUNT
+};
+
+typedef enum _SchematicGridMode SchematicGridMode;
+
+
+G_BEGIN_DECLS
+
+SchematicGridMode
+schematic_grid_mode_from_string (char *s);
+
+const char*
+schematic_grid_mode_to_string (SchematicGridMode mode);
+
+G_END_DECLS
+
+#endif /* GRID_MODE_H */

--- a/libleptongui/include/gschem.h
+++ b/libleptongui/include/gschem.h
@@ -18,6 +18,7 @@ typedef void (*i_callback_func) (gpointer, guint, GtkWidget*);
 
 /* gschem headers */
 #include "action_mode.h"
+#include "snap_mode.h"
 #include "gschem_defines.h"
 #include "gschem_bin.h"
 #include "gschem_bottom_widget.h"

--- a/libleptongui/include/gschem.h
+++ b/libleptongui/include/gschem.h
@@ -18,6 +18,7 @@ typedef void (*i_callback_func) (gpointer, guint, GtkWidget*);
 
 /* gschem headers */
 #include "action_mode.h"
+#include "grid_mode.h"
 #include "snap_mode.h"
 #include "gschem_defines.h"
 #include "gschem_bin.h"

--- a/libleptongui/include/gschem_defines.h
+++ b/libleptongui/include/gschem_defines.h
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2014 gEDA Contributors
- * Copyright (C) 2017-2020 Lepton EDA Contributors
+ * Copyright (C) 2017-2022 Lepton EDA Contributors
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -37,7 +37,7 @@
 #define ZOOM_EXTENTS_PADDING_PX 5
 
 /* For grip size in pixels (i.e. device units) */
-#define GRIP_SIZE		10.0
+#define GRIP_SIZE               10.0
 
 /* for bus_ripper_type */
 #define COMP_BUS_RIPPER         0
@@ -51,8 +51,8 @@
 #define CONSTRAINED 2
 
 /* for attrib_edit_dialog invocation flag */
-#define FROM_MENU		0
-#define FROM_HOTKEY		1
+#define FROM_MENU               0
+#define FROM_HOTKEY             1
 
 /* for text cap style */
 #define LOWER 0
@@ -71,26 +71,17 @@
 #define LAST_DRAWB_MODE_NONE -1
 
 /* used in o_undo_callback */
-#define UNDO_ACTION		0
-#define REDO_ACTION		1
+#define UNDO_ACTION             0
+#define REDO_ACTION             1
 
 /* used for undo_type */
-#define UNDO_DISK		0
-#define UNDO_MEMORY		1
+#define UNDO_DISK               0
+#define UNDO_MEMORY             1
 
 /* selection types */
 /* used in o_select_object */
 #define SINGLE                  0
 #define MULTIPLE                1
-
-/* for grid */
-typedef enum
-{
-  GRID_MODE_NONE,
-  GRID_MODE_DOTS,
-  GRID_MODE_MESH,
-  GRID_MODE_COUNT
-} GRID_MODE;
 
 /* for dots_grid_mode */
 #define DOTS_GRID_VARIABLE_MODE 0
@@ -108,9 +99,9 @@ typedef enum
 #define SCROLL_WHEEL_GTK     1
 
 /* for selected_from */
-#define DONTCARE		0
-#define MENU			1
-#define HOTKEY			2
+#define DONTCARE                0
+#define MENU                    1
+#define HOTKEY                  2
 
 /* The prefix of the default filename used for newly created pages
  *

--- a/libleptongui/include/gschem_options.h
+++ b/libleptongui/include/gschem_options.h
@@ -132,9 +132,6 @@ GschemOptions*
 gschem_options_new ();
 
 void
-gschem_options_scale_snap_down (GschemOptions *options);
-
-void
 gschem_options_set_grid_mode (GschemOptions *options, GRID_MODE grid_mode);
 
 void

--- a/libleptongui/include/gschem_options.h
+++ b/libleptongui/include/gschem_options.h
@@ -92,7 +92,7 @@ struct _GschemOptions {
   int        grid_mode;
   gboolean   magnetic_net_mode;
   gboolean   net_rubber_band_mode;
-  SNAP_STATE snap_mode;
+  SchematicSnapMode snap_mode;
   int        snap_size;
 };
 
@@ -119,7 +119,7 @@ gschem_options_get_magnetic_net_mode (GschemOptions *options);
 gboolean
 gschem_options_get_net_rubber_band_mode (GschemOptions *options);
 
-SNAP_STATE
+SchematicSnapMode
 gschem_options_get_snap_mode (GschemOptions *options);
 
 int
@@ -141,9 +141,15 @@ void
 gschem_options_set_net_rubber_band_mode (GschemOptions *options, gboolean enabled);
 
 void
-gschem_options_set_snap_mode (GschemOptions *options, SNAP_STATE snap_mode);
+gschem_options_set_snap_mode (GschemOptions *options, SchematicSnapMode snap_mode);
 
 void
 gschem_options_set_snap_size (GschemOptions *options, int snap_size);
+
+SchematicSnapMode
+schematic_snap_mode_from_string (char *s);
+
+const char*
+schematic_snap_mode_to_string (SchematicSnapMode mode);
 
 G_END_DECLS

--- a/libleptongui/include/gschem_options.h
+++ b/libleptongui/include/gschem_options.h
@@ -110,7 +110,7 @@ gschem_options_cycle_net_rubber_band_mode (GschemOptions *options);
 void
 gschem_options_cycle_snap_mode (GschemOptions *options);
 
-GRID_MODE
+SchematicGridMode
 gschem_options_get_grid_mode (GschemOptions *options);
 
 gboolean
@@ -132,8 +132,8 @@ GschemOptions*
 gschem_options_new ();
 
 void
-gschem_options_set_grid_mode (GschemOptions *options, GRID_MODE grid_mode);
-
+gschem_options_set_grid_mode (GschemOptions *options,
+                              SchematicGridMode grid_mode);
 void
 gschem_options_set_magnetic_net_mode (GschemOptions *options, gboolean enabled);
 

--- a/libleptongui/include/gschem_options.h
+++ b/libleptongui/include/gschem_options.h
@@ -135,9 +135,6 @@ void
 gschem_options_scale_snap_down (GschemOptions *options);
 
 void
-gschem_options_scale_snap_up (GschemOptions *options);
-
-void
 gschem_options_set_grid_mode (GschemOptions *options, GRID_MODE grid_mode);
 
 void

--- a/libleptongui/include/gschem_options.h
+++ b/libleptongui/include/gschem_options.h
@@ -146,10 +146,4 @@ gschem_options_set_snap_mode (GschemOptions *options, SchematicSnapMode snap_mod
 void
 gschem_options_set_snap_size (GschemOptions *options, int snap_size);
 
-SchematicSnapMode
-schematic_snap_mode_from_string (char *s);
-
-const char*
-schematic_snap_mode_to_string (SchematicSnapMode mode);
-
 G_END_DECLS

--- a/libleptongui/include/gschem_options_widget.h
+++ b/libleptongui/include/gschem_options_widget.h
@@ -1,6 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 2013 Ales Hvezda
- * Copyright (C) 2013 gEDA Contributors (see ChangeLog for details)
+ * Copyright (C) 2013-2015 gEDA Contributors
+ * Copyright (C) 2017-2022 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -49,7 +50,7 @@ struct _GschemOptionsWidget {
   GtkWidget *snap_size;
 
   GtkWidget *grid_radio[GRID_MODE_COUNT];
-  GtkWidget *snap_radio[SNAP_STATE_COUNT];
+  GtkWidget *snap_radio[SNAP_MODE_COUNT];
 };
 
 void
@@ -60,4 +61,3 @@ gschem_options_widget_get_type ();
 
 GtkWidget*
 gschem_options_widget_new (GschemToplevel *w_current);
-

--- a/libleptongui/include/gschem_struct.h
+++ b/libleptongui/include/gschem_struct.h
@@ -1,6 +1,3 @@
-/*! \brief different kind of snapping mechanisms used in LeptonToplevel */
-typedef enum {SNAP_OFF, SNAP_GRID, SNAP_RESNAP, SNAP_STATE_COUNT} SNAP_STATE;
-
 typedef struct st_stretch STRETCH;
 
 struct st_stretch

--- a/libleptongui/include/gschem_toplevel.h
+++ b/libleptongui/include/gschem_toplevel.h
@@ -329,4 +329,10 @@ schematic_window_get_draw_grips (GschemToplevel *w_current);
 void
 schematic_window_set_draw_grips (GschemToplevel *w_current,
                                  gboolean draw_grips);
+int
+schematic_window_get_actionfeedback_mode (GschemToplevel *w_current);
+
+void
+schematic_window_set_actionfeedback_mode (GschemToplevel *w_current,
+                                          int actionfeedback_mode);
 G_END_DECLS

--- a/libleptongui/include/gschem_toplevel.h
+++ b/libleptongui/include/gschem_toplevel.h
@@ -210,7 +210,7 @@ struct st_gschem_toplevel {
   int undo_control;       /* sets if undo is enabled or not */
   int undo_type;          /* type of undo (disk/memory) */
   int undo_panzoom;       /* sets if pan / zoom info is saved in undo */
-  int draw_grips;         /* sets if grips are enabled or not */
+  gboolean draw_grips;    /* sets if grips are enabled or not */
 
   int warp_cursor;        /* warp the cursor when zooming */
   int toolbars;           /* sets if the toolbar(s) are enabled or disabled */

--- a/libleptongui/include/gschem_toplevel.h
+++ b/libleptongui/include/gschem_toplevel.h
@@ -320,4 +320,7 @@ schematic_window_set_action_mode (GschemToplevel *w_current,
 void
 schematic_window_set_toolbar (GschemToplevel *w_current,
                               GtkWidget *toolbar);
+int
+schematic_window_get_inside_action (GschemToplevel *w_current);
+
 G_END_DECLS

--- a/libleptongui/include/gschem_toplevel.h
+++ b/libleptongui/include/gschem_toplevel.h
@@ -335,4 +335,7 @@ schematic_window_get_actionfeedback_mode (GschemToplevel *w_current);
 void
 schematic_window_set_actionfeedback_mode (GschemToplevel *w_current,
                                           int actionfeedback_mode);
+GList*
+schematic_window_get_place_list (GschemToplevel *w_current);
+
 G_END_DECLS

--- a/libleptongui/include/gschem_toplevel.h
+++ b/libleptongui/include/gschem_toplevel.h
@@ -323,4 +323,10 @@ schematic_window_set_toolbar (GschemToplevel *w_current,
 int
 schematic_window_get_inside_action (GschemToplevel *w_current);
 
+gboolean
+schematic_window_get_draw_grips (GschemToplevel *w_current);
+
+void
+schematic_window_set_draw_grips (GschemToplevel *w_current,
+                                 gboolean draw_grips);
 G_END_DECLS

--- a/libleptongui/include/i_vars.h
+++ b/libleptongui/include/i_vars.h
@@ -1,4 +1,3 @@
-
 extern int default_text_size;
 extern int default_text_caps;
 extern gchar *default_print_command;
@@ -29,7 +28,6 @@ extern int default_undo_levels;
 extern int default_undo_control;
 extern int default_undo_type;
 extern int default_undo_panzoom;
-extern int default_draw_grips;
 extern int default_netconn_rubberband;
 extern int default_magnetic_net_mode;
 extern int default_warp_cursor;
@@ -51,6 +49,7 @@ extern int default_keyboardpan_gain;
 extern int default_select_slack_pixels;
 extern int default_zoom_gain;
 extern int default_scrollpan_steps;
+extern gboolean default_draw_grips;
 extern gboolean default_tabs_enabled;
 extern gboolean default_tabs_show_close_button;
 extern gboolean default_tabs_show_up_button;

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -186,7 +186,6 @@ void i_callback_attributes_show_value (GtkWidget *widget, gpointer data);
 void i_callback_attributes_show_both (GtkWidget *widget, gpointer data);
 void i_callback_attributes_visibility_toggle (GtkWidget *widget, gpointer data);
 void i_callback_options_afeedback (GtkWidget *widget, gpointer data);
-void i_callback_options_grid (GtkWidget *widget, gpointer data);
 void i_callback_cancel (GtkWidget *widget, gpointer data);
 gboolean i_callback_close_wm(GtkWidget *widget, GdkEvent *event, gpointer data);
 /* i_vars.c */

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -188,7 +188,6 @@ void i_callback_attributes_visibility_toggle (GtkWidget *widget, gpointer data);
 void i_callback_options_afeedback (GtkWidget *widget, gpointer data);
 void i_callback_options_grid (GtkWidget *widget, gpointer data);
 void i_callback_cancel (GtkWidget *widget, gpointer data);
-void i_callback_options_draw_grips (GtkWidget *widget, gpointer data);
 gboolean i_callback_close_wm(GtkWidget *widget, GdkEvent *event, gpointer data);
 /* i_vars.c */
 void i_vars_set(GschemToplevel *w_current);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -187,7 +187,6 @@ void i_callback_attributes_show_both (GtkWidget *widget, gpointer data);
 void i_callback_attributes_visibility_toggle (GtkWidget *widget, gpointer data);
 void i_callback_options_afeedback (GtkWidget *widget, gpointer data);
 void i_callback_options_grid (GtkWidget *widget, gpointer data);
-void i_callback_options_snap (GtkWidget *widget, gpointer data);
 void i_callback_options_rubberband (GtkWidget *widget, gpointer data);
 void i_callback_options_magneticnet (GtkWidget *widget, gpointer data);
 void i_callback_cancel (GtkWidget *widget, gpointer data);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -187,7 +187,6 @@ void i_callback_attributes_show_both (GtkWidget *widget, gpointer data);
 void i_callback_attributes_visibility_toggle (GtkWidget *widget, gpointer data);
 void i_callback_options_afeedback (GtkWidget *widget, gpointer data);
 void i_callback_options_grid (GtkWidget *widget, gpointer data);
-void i_callback_options_rubberband (GtkWidget *widget, gpointer data);
 void i_callback_options_magneticnet (GtkWidget *widget, gpointer data);
 void i_callback_cancel (GtkWidget *widget, gpointer data);
 void i_callback_options_draw_grips (GtkWidget *widget, gpointer data);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -185,7 +185,6 @@ void i_callback_attributes_show_name (GtkWidget *widget, gpointer data);
 void i_callback_attributes_show_value (GtkWidget *widget, gpointer data);
 void i_callback_attributes_show_both (GtkWidget *widget, gpointer data);
 void i_callback_attributes_visibility_toggle (GtkWidget *widget, gpointer data);
-void i_callback_options_snap_size (GtkWidget *widget, gpointer data);
 void i_callback_options_scale_up_snap_size (GtkWidget *widget, gpointer data);
 void i_callback_options_scale_down_snap_size (GtkWidget *widget, gpointer data);
 void i_callback_options_afeedback (GtkWidget *widget, gpointer data);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -185,7 +185,6 @@ void i_callback_attributes_show_name (GtkWidget *widget, gpointer data);
 void i_callback_attributes_show_value (GtkWidget *widget, gpointer data);
 void i_callback_attributes_show_both (GtkWidget *widget, gpointer data);
 void i_callback_attributes_visibility_toggle (GtkWidget *widget, gpointer data);
-void i_callback_options_scale_up_snap_size (GtkWidget *widget, gpointer data);
 void i_callback_options_scale_down_snap_size (GtkWidget *widget, gpointer data);
 void i_callback_options_afeedback (GtkWidget *widget, gpointer data);
 void i_callback_options_grid (GtkWidget *widget, gpointer data);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -187,7 +187,6 @@ void i_callback_attributes_show_both (GtkWidget *widget, gpointer data);
 void i_callback_attributes_visibility_toggle (GtkWidget *widget, gpointer data);
 void i_callback_options_afeedback (GtkWidget *widget, gpointer data);
 void i_callback_options_grid (GtkWidget *widget, gpointer data);
-void i_callback_options_magneticnet (GtkWidget *widget, gpointer data);
 void i_callback_cancel (GtkWidget *widget, gpointer data);
 void i_callback_options_draw_grips (GtkWidget *widget, gpointer data);
 gboolean i_callback_close_wm(GtkWidget *widget, GdkEvent *event, gpointer data);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -185,7 +185,6 @@ void i_callback_attributes_show_name (GtkWidget *widget, gpointer data);
 void i_callback_attributes_show_value (GtkWidget *widget, gpointer data);
 void i_callback_attributes_show_both (GtkWidget *widget, gpointer data);
 void i_callback_attributes_visibility_toggle (GtkWidget *widget, gpointer data);
-void i_callback_options_afeedback (GtkWidget *widget, gpointer data);
 void i_callback_cancel (GtkWidget *widget, gpointer data);
 gboolean i_callback_close_wm(GtkWidget *widget, GdkEvent *event, gpointer data);
 /* i_vars.c */

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -185,7 +185,6 @@ void i_callback_attributes_show_name (GtkWidget *widget, gpointer data);
 void i_callback_attributes_show_value (GtkWidget *widget, gpointer data);
 void i_callback_attributes_show_both (GtkWidget *widget, gpointer data);
 void i_callback_attributes_visibility_toggle (GtkWidget *widget, gpointer data);
-void i_callback_options_scale_down_snap_size (GtkWidget *widget, gpointer data);
 void i_callback_options_afeedback (GtkWidget *widget, gpointer data);
 void i_callback_options_grid (GtkWidget *widget, gpointer data);
 void i_callback_options_snap (GtkWidget *widget, gpointer data);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -498,7 +498,6 @@ void select_all_text_in_textview(GtkTextView *textview);
 void text_input_dialog(GschemToplevel *w_current);
 void text_edit_dialog(GschemToplevel *w_current);
 void arc_angle_dialog(GschemToplevel *w_current, LeptonObject *arc_object);
-void snap_size_dialog(GschemToplevel *w_current);
 void about_dialog(GschemToplevel *w_current);
 void coord_display_update(GschemToplevel *w_current, int x, int y);
 void coord_dialog(GschemToplevel *w_current, int x, int y);

--- a/libleptongui/include/snap_mode.h
+++ b/libleptongui/include/snap_mode.h
@@ -1,0 +1,42 @@
+/* Lepton EDA Schematic Capture
+ * Copyright (C) 2022 Lepton EDA Contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef SNAP_MODE_H
+#define SNAP_MODE_H
+
+enum _SchematicSnapMode {
+  SNAP_OFF,
+  SNAP_GRID,
+  SNAP_RESNAP,
+  SNAP_MODE_COUNT
+};
+
+typedef enum _SchematicSnapMode SchematicSnapMode;
+
+
+G_BEGIN_DECLS
+
+SchematicSnapMode
+schematic_snap_mode_from_string (char *s);
+
+const char*
+schematic_snap_mode_to_string (SchematicSnapMode mode);
+
+G_END_DECLS
+
+#endif /* SNAP_MODE_H */

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -524,20 +524,10 @@
 (define-action-public (&help-hotkeys #:label (G_ "Show Hotkeys") #:icon "preferences-desktop-keyboard-shortcuts")
   (x_dialog_hotkeys (*current-window)))
 
+
+;;; Cycle grid mode.
 (define-action-public (&options-grid #:label (G_ "Switch Grid Style"))
-  (define *window (*current-window))
-  (define *options (schematic_window_get_options *window))
-
-  (gschem_options_cycle_grid_mode *options)
-
-  (let ((grid-mode (pointer->string
-                    (schematic_grid_mode_to_string
-                     (gschem_options_get_grid_mode *options)))))
-    (match grid-mode
-      ("none" (log! 'message (G_ "Grid OFF")))
-      ("dots" (log! 'message (G_ "Dot grid selected")))
-      ("mesh" (log! 'message (G_ "Mesh grid selected")))
-      (_ (error "Invalid grid mode: ~S" grid-mode)))))
+  (gschem_options_cycle_grid_mode (schematic_window_get_options (*current-window))))
 
 
 (define-action-public (&options-snap #:label (G_ "Switch Snap Mode"))

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -589,8 +589,15 @@
 (define-action-public (&options-select-font #:label (G_ "Select Schematic Font"))
   (x_widgets_show_font_select (*current-window)))
 
+
 (define-action-public (&options-draw-grips #:label (G_ "Toggle Grips"))
-  (run-callback i_callback_options_draw_grips "&options-draw-grips"))
+  (define *window (*current-window))
+  (define draw-grips (true? (schematic_window_get_draw_grips *window)))
+
+  (schematic_window_set_draw_grips *window (if draw-grips FALSE TRUE))
+  (gschem_page_view_invalidate_all
+   (gschem_toplevel_get_current_page_view *window)))
+
 
 ;; -------------------------------------------------------------------
 ;;;; Documentation-related actions

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -525,7 +525,19 @@
   (x_dialog_hotkeys (*current-window)))
 
 (define-action-public (&options-grid #:label (G_ "Switch Grid Style"))
-  (run-callback i_callback_options_grid "&options-grid"))
+  (define *window (*current-window))
+  (define *options (schematic_window_get_options *window))
+
+  (gschem_options_cycle_grid_mode *options)
+
+  (let ((grid-mode (pointer->string
+                    (schematic_grid_mode_to_string
+                     (gschem_options_get_grid_mode *options)))))
+    (match grid-mode
+      ("none" (log! 'message (G_ "Grid OFF")))
+      ("dots" (log! 'message (G_ "Dot grid selected")))
+      ("mesh" (log! 'message (G_ "Mesh grid selected")))
+      (_ (error "Invalid grid mode: ~S" grid-mode)))))
 
 
 (define-action-public (&options-snap #:label (G_ "Switch Snap Mode"))

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -579,8 +579,29 @@
     (gschem_options_set_snap_size *options (/ snap-size 2))))
 
 
+;;; Toggles visibility of currently selected objects between
+;;; outline mode (fully visible) and bounding box mode
+;;; (displaying bounding box rectangle).
 (define-action-public (&options-action-feedback #:label (G_ "Toggle Outline Drawing"))
-  (run-callback i_callback_options_afeedback "&options-action-feedback"))
+  (define *window (*current-window))
+
+  ;; Definitions from "gschem_defines.h".
+  (define OUTLINE 0)
+  (define BOUNDINGBOX 1)
+
+  (if (= (schematic_window_get_actionfeedback_mode *window) BOUNDINGBOX)
+      (begin
+        (schematic_window_set_actionfeedback_mode *window OUTLINE)
+        (log! 'message (G_ "Action feedback mode set to OUTLINE")))
+
+      (begin
+        (schematic_window_set_actionfeedback_mode *window BOUNDINGBOX)
+        (log! 'message (G_ "Action feedback mode set to BOUNDINGBOX"))))
+
+  (when (and (true? (schematic_window_get_inside_action *window))
+             (not (null-pointer? (schematic_window_get_place_list *window))))
+    (o_place_invalidate_rubber *window FALSE)))
+
 
 (define-action-public (&options-rubberband #:label (G_ "Toggle Net Rubber Band"))
   (gschem_options_cycle_net_rubber_band_mode

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -539,8 +539,9 @@
 (define-action-public (&options-scale-up-snap-size #:label (G_ "Increase Grid Spacing"))
   (gschem_options_scale_snap_up (schematic_window_get_options (*current-window))))
 
+;;; Divides by two the snap grid size (if it's and even number).
 (define-action-public (&options-scale-down-snap-size #:label (G_ "Decrease Grid Spacing"))
-  (run-callback i_callback_options_scale_down_snap_size "&options-scale-down-snap-size"))
+  (gschem_options_scale_snap_down (schematic_window_get_options (*current-window))))
 
 (define-action-public (&options-action-feedback #:label (G_ "Toggle Outline Drawing"))
   (run-callback i_callback_options_afeedback "&options-action-feedback"))

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -539,6 +539,10 @@
   (let ((snap-mode (pointer->string
                     (schematic_snap_mode_to_string
                      (gschem_options_get_snap_mode *options)))))
+    ;; FIXME: the user should be always aware of snap mode change,
+    ;; no matter what is used to switch the mode, a hotkey or a
+    ;; mouse click on the status bar.  May be show the messages
+    ;; below in the status bar?
     (match snap-mode
       ("off" (log! 'message (G_ "Snap OFF (CAUTION!)")))
       ("grid" (log! 'message (G_ "Snap ON")))

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -527,8 +527,25 @@
 (define-action-public (&options-grid #:label (G_ "Switch Grid Style"))
   (run-callback i_callback_options_grid "&options-grid"))
 
+
 (define-action-public (&options-snap #:label (G_ "Switch Snap Mode"))
-  (run-callback i_callback_options_snap "&options-snap"))
+  (define *window (*current-window))
+  (define *options (schematic_window_get_options *window))
+
+  (gschem_options_cycle_snap_mode *options)
+
+  (let ((snap-mode (pointer->string
+                    (schematic_snap_mode_to_string
+                     (gschem_options_get_snap_mode *options)))))
+    (match snap-mode
+      ("off" (log! 'message (G_ "Snap OFF (CAUTION!)")))
+      ("grid" (log! 'message (G_ "Snap ON")))
+      ("resnap" (log! 'message (G_ "Snap back to the grid (CAUTION!)")))
+      (_ (error "Invalid snap_mode: ~S" snap-mode))))
+
+  (i_show_state *window %null-pointer)
+  (i_update_grid_info *window))
+
 
 ;;; Shows the options widget.
 (define-action-public (&options-snap-size #:label (G_ "Set Grid Spacing"))

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -535,8 +535,9 @@
   (x_widgets_show_options (*current-window)))
 
 
+;;; Multiplies by two the snap grid size.
 (define-action-public (&options-scale-up-snap-size #:label (G_ "Increase Grid Spacing"))
-  (run-callback i_callback_options_scale_up_snap_size "&options-scale-up-snap-size"))
+  (gschem_options_scale_snap_up (schematic_window_get_options (*current-window))))
 
 (define-action-public (&options-scale-down-snap-size #:label (G_ "Decrease Grid Spacing"))
   (run-callback i_callback_options_scale_down_snap_size "&options-scale-down-snap-size"))

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -537,7 +537,10 @@
 
 ;;; Multiplies by two the snap grid size.
 (define-action-public (&options-scale-up-snap-size #:label (G_ "Increase Grid Spacing"))
-  (gschem_options_scale_snap_up (schematic_window_get_options (*current-window))))
+  (define *options (schematic_window_get_options (*current-window)))
+  (gschem_options_set_snap_size *options
+                                (* (gschem_options_get_snap_size *options) 2)))
+
 
 ;;; Divides by two the snap grid size (if it's and even number).
 (define-action-public (&options-scale-down-snap-size #:label (G_ "Decrease Grid Spacing"))

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -571,7 +571,13 @@
   (run-callback i_callback_options_afeedback "&options-action-feedback"))
 
 (define-action-public (&options-rubberband #:label (G_ "Toggle Net Rubber Band"))
-  (run-callback i_callback_options_rubberband "&options-rubberband"))
+  (let ((*options (schematic_window_get_options (*current-window))))
+    (gschem_options_cycle_net_rubber_band_mode *options)
+    (log! 'message
+          (string-append (G_ "Rubber band: ")
+                         (if (true? (gschem_options_get_net_rubber_band_mode *options))
+                             (G_ "ON")
+                             (G_ "OFF"))))))
 
 (define-action-public (&options-magneticnet #:label (G_ "Toggle Magnetic Nets"))
   (run-callback i_callback_options_magneticnet "&options-magneticnet"))

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -544,7 +544,11 @@
 
 ;;; Divides by two the snap grid size (if it's and even number).
 (define-action-public (&options-scale-down-snap-size #:label (G_ "Decrease Grid Spacing"))
-  (gschem_options_scale_snap_down (schematic_window_get_options (*current-window))))
+  (define *options (schematic_window_get_options (*current-window)))
+  (define snap-size (gschem_options_get_snap_size *options))
+  (when (even? snap-size)
+    (gschem_options_set_snap_size *options (/ snap-size 2))))
+
 
 (define-action-public (&options-action-feedback #:label (G_ "Toggle Outline Drawing"))
   (run-callback i_callback_options_afeedback "&options-action-feedback"))

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -571,23 +571,12 @@
   (run-callback i_callback_options_afeedback "&options-action-feedback"))
 
 (define-action-public (&options-rubberband #:label (G_ "Toggle Net Rubber Band"))
-  (let ((*options (schematic_window_get_options (*current-window))))
-    (gschem_options_cycle_net_rubber_band_mode *options)
-    (log! 'message
-          (string-append (G_ "Rubber band: ")
-                         (if (true? (gschem_options_get_net_rubber_band_mode *options))
-                             (G_ "ON")
-                             (G_ "OFF"))))))
+  (gschem_options_cycle_net_rubber_band_mode
+   (schematic_window_get_options (*current-window))))
 
 (define-action-public (&options-magneticnet #:label (G_ "Toggle Magnetic Nets"))
   (define *window (*current-window))
-  (define *options (schematic_window_get_options *window))
-  (gschem_options_cycle_magnetic_net_mode *options)
-  (log! 'message
-        (string-append (G_ "Magnetic net mode: ")
-                       (if (true? (gschem_options_get_magnetic_net_mode *options))
-                           (G_ "ON")
-                           (G_ "OFF"))))
+  (gschem_options_cycle_magnetic_net_mode (schematic_window_get_options *window))
   (i_show_state *window %null-pointer))
 
 

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -580,7 +580,16 @@
                              (G_ "OFF"))))))
 
 (define-action-public (&options-magneticnet #:label (G_ "Toggle Magnetic Nets"))
-  (run-callback i_callback_options_magneticnet "&options-magneticnet"))
+  (define *window (*current-window))
+  (define *options (schematic_window_get_options *window))
+  (gschem_options_cycle_magnetic_net_mode *options)
+  (log! 'message
+        (string-append (G_ "Magnetic net mode: ")
+                       (if (true? (gschem_options_get_magnetic_net_mode *options))
+                           (G_ "ON")
+                           (G_ "OFF"))))
+  (i_show_state *window %null-pointer))
+
 
 (define-action-public (&options-show-log-window #:label (G_ "Show Log Window"))
   (x_widgets_show_log (*current-window)))

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -530,8 +530,10 @@
 (define-action-public (&options-snap #:label (G_ "Switch Snap Mode"))
   (run-callback i_callback_options_snap "&options-snap"))
 
+;;; Shows the options widget.
 (define-action-public (&options-snap-size #:label (G_ "Set Grid Spacing"))
-  (snap_size_dialog (*current-window)))
+  (x_widgets_show_options (*current-window)))
+
 
 (define-action-public (&options-scale-up-snap-size #:label (G_ "Increase Grid Spacing"))
   (run-callback i_callback_options_scale_up_snap_size "&options-scale-up-snap-size"))

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -531,7 +531,7 @@
   (run-callback i_callback_options_snap "&options-snap"))
 
 (define-action-public (&options-snap-size #:label (G_ "Set Grid Spacing"))
-  (run-callback i_callback_options_snap_size "&options-snap-size"))
+  (snap_size_dialog (*current-window)))
 
 (define-action-public (&options-scale-up-snap-size #:label (G_ "Increase Grid Spacing"))
   (run-callback i_callback_options_scale_up_snap_size "&options-scale-up-snap-size"))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -88,7 +88,6 @@
             i_callback_options_magneticnet
             i_callback_options_rubberband
             i_callback_options_scale_down_snap_size
-            i_callback_options_scale_up_snap_size
             i_callback_options_snap
             i_callback_page_close
             i_callback_page_next
@@ -219,6 +218,7 @@
             schematic_window_update_keyaccel_timer
 
             gschem_options_get_snap_size
+            gschem_options_scale_snap_up
 
             text_edit_dialog
 
@@ -343,6 +343,7 @@
 
 ;;; gschem_options.c
 (define-lff gschem_options_get_snap_size int '(*))
+(define-lff gschem_options_scale_snap_up void '(*))
 
 ;;; gschem_text_properties_widget.c
 (define-lff text_edit_dialog void '(*))
@@ -468,7 +469,6 @@
 (define-lff i_callback_options_magneticnet void '(* *))
 (define-lff i_callback_options_rubberband void '(* *))
 (define-lff i_callback_options_scale_down_snap_size void '(* *))
-(define-lff i_callback_options_scale_up_snap_size void '(* *))
 (define-lff i_callback_options_snap void '(* *))
 (define-lff i_callback_view_color_edit void '(* *))
 (define-lff i_callback_view_pan void '(* *))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -83,7 +83,6 @@
             i_callback_hierarchy_down_symbol
             i_callback_hierarchy_up
             i_callback_options_afeedback
-            i_callback_options_draw_grips
             i_callback_options_grid
             i_callback_page_close
             i_callback_page_next
@@ -214,6 +213,8 @@
             gschem_toplevel_get_current_page_view
             gschem_toplevel_get_toplevel
             schematic_window_get_active_page
+            schematic_window_get_draw_grips
+            schematic_window_set_draw_grips
             schematic_window_get_gdk_display
             schematic_window_get_options
             schematic_window_update_keyaccel_string
@@ -346,6 +347,8 @@
 (define-lff gschem_toplevel_get_current_page_view '* '(*))
 (define-lff gschem_toplevel_get_toplevel '* '(*))
 (define-lff schematic_window_get_active_page '* '(*))
+(define-lff schematic_window_get_draw_grips int '(*))
+(define-lff schematic_window_set_draw_grips void (list '* int))
 (define-lff schematic_window_get_gdk_display '* '(*))
 (define-lff schematic_window_get_options '* '(*))
 (define-lff schematic_window_update_keyaccel_string void '(* *))
@@ -478,7 +481,6 @@
 (define-lff i_callback_hierarchy_down_symbol void '(* *))
 (define-lff i_callback_hierarchy_up void '(* *))
 (define-lff i_callback_options_afeedback void '(* *))
-(define-lff i_callback_options_draw_grips void '(* *))
 (define-lff i_callback_options_grid void '(* *))
 (define-lff i_callback_view_color_edit void '(* *))
 (define-lff i_callback_view_pan void '(* *))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -85,7 +85,6 @@
             i_callback_options_afeedback
             i_callback_options_draw_grips
             i_callback_options_grid
-            i_callback_options_magneticnet
             i_callback_page_close
             i_callback_page_next
             i_callback_page_prev
@@ -220,6 +219,8 @@
             schematic_window_update_keyaccel_string
             schematic_window_update_keyaccel_timer
 
+            gschem_options_cycle_magnetic_net_mode
+            gschem_options_get_magnetic_net_mode
             gschem_options_cycle_net_rubber_band_mode
             gschem_options_get_net_rubber_band_mode
             gschem_options_cycle_snap_mode
@@ -353,6 +354,8 @@
 (define-lff schematic_window_update_keyaccel_timer void (list '* int))
 
 ;;; gschem_options.c
+(define-lff gschem_options_cycle_magnetic_net_mode void '(*))
+(define-lff gschem_options_get_magnetic_net_mode int '(*))
 (define-lff gschem_options_cycle_net_rubber_band_mode void '(*))
 (define-lff gschem_options_get_net_rubber_band_mode int '(*))
 (define-lff gschem_options_cycle_snap_mode void '(*))
@@ -481,7 +484,6 @@
 (define-lff i_callback_options_afeedback void '(* *))
 (define-lff i_callback_options_draw_grips void '(* *))
 (define-lff i_callback_options_grid void '(* *))
-(define-lff i_callback_options_magneticnet void '(* *))
 (define-lff i_callback_view_color_edit void '(* *))
 (define-lff i_callback_view_pan void '(* *))
 (define-lff i_callback_view_pan_down void '(* *))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -90,7 +90,6 @@
             i_callback_options_scale_down_snap_size
             i_callback_options_scale_up_snap_size
             i_callback_options_snap
-            i_callback_options_snap_size
             i_callback_page_close
             i_callback_page_next
             i_callback_page_prev
@@ -220,6 +219,8 @@
 
             gschem_options_get_snap_size
 
+            snap_size_dialog
+
             text_edit_dialog
 
             o_slot_end
@@ -342,6 +343,9 @@
 
 ;;; gschem_options.c
 (define-lff gschem_options_get_snap_size int '(*))
+
+;;; gschem_options_widget.c
+(define-lff snap_size_dialog void '(*))
 
 ;;; gschem_text_properties_widget.c
 (define-lff text_edit_dialog void '(*))
@@ -469,7 +473,6 @@
 (define-lff i_callback_options_scale_down_snap_size void '(* *))
 (define-lff i_callback_options_scale_up_snap_size void '(* *))
 (define-lff i_callback_options_snap void '(* *))
-(define-lff i_callback_options_snap_size void '(* *))
 (define-lff i_callback_view_color_edit void '(* *))
 (define-lff i_callback_view_pan void '(* *))
 (define-lff i_callback_view_pan_down void '(* *))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -87,7 +87,6 @@
             i_callback_options_grid
             i_callback_options_magneticnet
             i_callback_options_rubberband
-            i_callback_options_scale_down_snap_size
             i_callback_options_snap
             i_callback_page_close
             i_callback_page_next
@@ -219,6 +218,7 @@
 
             gschem_options_get_snap_size
             gschem_options_scale_snap_up
+            gschem_options_scale_snap_down
 
             text_edit_dialog
 
@@ -344,6 +344,7 @@
 ;;; gschem_options.c
 (define-lff gschem_options_get_snap_size int '(*))
 (define-lff gschem_options_scale_snap_up void '(*))
+(define-lff gschem_options_scale_snap_down void '(*))
 
 ;;; gschem_text_properties_widget.c
 (define-lff text_edit_dialog void '(*))
@@ -468,7 +469,6 @@
 (define-lff i_callback_options_grid void '(* *))
 (define-lff i_callback_options_magneticnet void '(* *))
 (define-lff i_callback_options_rubberband void '(* *))
-(define-lff i_callback_options_scale_down_snap_size void '(* *))
 (define-lff i_callback_options_snap void '(* *))
 (define-lff i_callback_view_color_edit void '(* *))
 (define-lff i_callback_view_pan void '(* *))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -87,7 +87,6 @@
             i_callback_options_grid
             i_callback_options_magneticnet
             i_callback_options_rubberband
-            i_callback_options_snap
             i_callback_page_close
             i_callback_page_next
             i_callback_page_prev
@@ -109,6 +108,9 @@
             i_callback_view_zoom_full
             i_callback_view_zoom_in
             i_callback_view_zoom_out
+
+            i_show_state
+            i_update_grid_info
 
             make_menu_action
             make_separator_menu_item
@@ -190,6 +192,9 @@
             x_tabs_create
             x_tabs_enabled
 
+            schematic_snap_mode_from_string
+            schematic_snap_mode_to_string
+
             about_dialog
 
             coord_dialog
@@ -216,6 +221,8 @@
             schematic_window_update_keyaccel_string
             schematic_window_update_keyaccel_timer
 
+            gschem_options_cycle_snap_mode
+            gschem_options_get_snap_mode
             gschem_options_get_snap_size
             gschem_options_set_snap_size
 
@@ -331,6 +338,10 @@
 (define-lff slot_edit_dialog_get_text '* '(*))
 (define-lff slot_edit_dialog_quit void '(*))
 
+;;; snap_mode.c
+(define-lff schematic_snap_mode_from_string int '(*))
+(define-lff schematic_snap_mode_to_string '* (list int))
+
 ;;; gschem_toplevel.c
 (define-lff gschem_toplevel_get_current_page_view '* '(*))
 (define-lff gschem_toplevel_get_toplevel '* '(*))
@@ -341,6 +352,8 @@
 (define-lff schematic_window_update_keyaccel_timer void (list '* int))
 
 ;;; gschem_options.c
+(define-lff gschem_options_cycle_snap_mode void '(*))
+(define-lff gschem_options_get_snap_mode int '(*))
 (define-lff gschem_options_get_snap_size int '(*))
 (define-lff gschem_options_set_snap_size void (list '* int))
 
@@ -467,7 +480,6 @@
 (define-lff i_callback_options_grid void '(* *))
 (define-lff i_callback_options_magneticnet void '(* *))
 (define-lff i_callback_options_rubberband void '(* *))
-(define-lff i_callback_options_snap void '(* *))
 (define-lff i_callback_view_color_edit void '(* *))
 (define-lff i_callback_view_pan void '(* *))
 (define-lff i_callback_view_pan_down void '(* *))
@@ -489,6 +501,10 @@
 (define-lff i_callback_toolbar_add_bus void '(* *))
 (define-lff i_callback_toolbar_add_net void '(* *))
 (define-lff i_callback_toolbar_edit_select void '(* *))
+
+;;; i_basic.c
+(define-lff i_show_state void '(* *))
+(define-lff i_update_grid_info void '(*))
 
 ;;; x_misc.c
 (define-lff x_show_uri int '(* * *))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -86,7 +86,6 @@
             i_callback_options_draw_grips
             i_callback_options_grid
             i_callback_options_magneticnet
-            i_callback_options_rubberband
             i_callback_page_close
             i_callback_page_next
             i_callback_page_prev
@@ -221,6 +220,8 @@
             schematic_window_update_keyaccel_string
             schematic_window_update_keyaccel_timer
 
+            gschem_options_cycle_net_rubber_band_mode
+            gschem_options_get_net_rubber_band_mode
             gschem_options_cycle_snap_mode
             gschem_options_get_snap_mode
             gschem_options_get_snap_size
@@ -352,6 +353,8 @@
 (define-lff schematic_window_update_keyaccel_timer void (list '* int))
 
 ;;; gschem_options.c
+(define-lff gschem_options_cycle_net_rubber_band_mode void '(*))
+(define-lff gschem_options_get_net_rubber_band_mode int '(*))
 (define-lff gschem_options_cycle_snap_mode void '(*))
 (define-lff gschem_options_get_snap_mode int '(*))
 (define-lff gschem_options_get_snap_size int '(*))
@@ -479,7 +482,6 @@
 (define-lff i_callback_options_draw_grips void '(* *))
 (define-lff i_callback_options_grid void '(* *))
 (define-lff i_callback_options_magneticnet void '(* *))
-(define-lff i_callback_options_rubberband void '(* *))
 (define-lff i_callback_view_color_edit void '(* *))
 (define-lff i_callback_view_pan void '(* *))
 (define-lff i_callback_view_pan_down void '(* *))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -82,7 +82,6 @@
             i_callback_hierarchy_down_schematic
             i_callback_hierarchy_down_symbol
             i_callback_hierarchy_up
-            i_callback_options_afeedback
             i_callback_page_close
             i_callback_page_next
             i_callback_page_prev
@@ -116,6 +115,8 @@
 
             o_buffer_init
             o_undo_init
+
+            o_place_invalidate_rubber
 
             page_select_widget_update
 
@@ -214,11 +215,14 @@
 
             gschem_toplevel_get_current_page_view
             gschem_toplevel_get_toplevel
+            schematic_window_get_actionfeedback_mode
+            schematic_window_set_actionfeedback_mode
             schematic_window_get_active_page
             schematic_window_get_draw_grips
             schematic_window_set_draw_grips
             schematic_window_get_gdk_display
             schematic_window_get_options
+            schematic_window_get_place_list
             schematic_window_update_keyaccel_string
             schematic_window_update_keyaccel_timer
 
@@ -354,11 +358,14 @@
 ;;; gschem_toplevel.c
 (define-lff gschem_toplevel_get_current_page_view '* '(*))
 (define-lff gschem_toplevel_get_toplevel '* '(*))
+(define-lff schematic_window_get_actionfeedback_mode int '(*))
+(define-lff schematic_window_set_actionfeedback_mode void (list '* int))
 (define-lff schematic_window_get_active_page '* '(*))
 (define-lff schematic_window_get_draw_grips int '(*))
 (define-lff schematic_window_set_draw_grips void (list '* int))
 (define-lff schematic_window_get_gdk_display '* '(*))
 (define-lff schematic_window_get_options '* '(*))
+(define-lff schematic_window_get_place_list '* '(*))
 (define-lff schematic_window_update_keyaccel_string void '(* *))
 (define-lff schematic_window_update_keyaccel_timer void (list '* int))
 
@@ -490,7 +497,6 @@
 (define-lff i_callback_hierarchy_down_schematic void '(* *))
 (define-lff i_callback_hierarchy_down_symbol void '(* *))
 (define-lff i_callback_hierarchy_up void '(* *))
-(define-lff i_callback_options_afeedback void '(* *))
 (define-lff i_callback_view_color_edit void '(* *))
 (define-lff i_callback_view_pan void '(* *))
 (define-lff i_callback_view_pan_down void '(* *))
@@ -516,6 +522,9 @@
 ;;; i_basic.c
 (define-lff i_show_state void '(* *))
 (define-lff i_update_grid_info void '(*))
+
+;;; o_place.c
+(define-lff o_place_invalidate_rubber void (list '* int))
 
 ;;; x_misc.c
 (define-lff x_show_uri int '(* * *))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -146,6 +146,7 @@
             x_widgets_show_font_select
             x_widgets_show_log
             x_widgets_show_object_properties
+            x_widgets_show_options
             x_widgets_show_page_select
 
             x_window_close
@@ -218,8 +219,6 @@
             schematic_window_update_keyaccel_timer
 
             gschem_options_get_snap_size
-
-            snap_size_dialog
 
             text_edit_dialog
 
@@ -306,6 +305,7 @@
 (define-lff x_widgets_show_font_select void '(*))
 (define-lff x_widgets_show_log void '(*))
 (define-lff x_widgets_show_object_properties void '(*))
+(define-lff x_widgets_show_options void '(*))
 (define-lff x_widgets_show_page_select void '(*))
 
 ;;; keys.c
@@ -343,9 +343,6 @@
 
 ;;; gschem_options.c
 (define-lff gschem_options_get_snap_size int '(*))
-
-;;; gschem_options_widget.c
-(define-lff snap_size_dialog void '(*))
 
 ;;; gschem_text_properties_widget.c
 (define-lff text_edit_dialog void '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -162,6 +162,7 @@
             schematic_window_create_main_box
             schematic_window_create_work_box
             schematic_window_create_menubar
+            schematic_window_get_inside_action
             schematic_window_set_key_event_callback
             schematic_window_create_page_view
             schematic_window_create_find_text_widget
@@ -370,6 +371,7 @@
 (define-lff schematic_window_create_main_box '* '(*))
 (define-lff schematic_window_create_work_box '* '())
 (define-lff schematic_window_create_menubar void '(* * *))
+(define-lff schematic_window_get_inside_action int '(*))
 (define-lff schematic_window_set_key_event_callback void '(*))
 (define-lff schematic_window_create_page_view '* '(* *))
 (define-lff schematic_window_create_find_text_widget void '(* *))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -217,7 +217,7 @@
             schematic_window_update_keyaccel_timer
 
             gschem_options_get_snap_size
-            gschem_options_scale_snap_up
+            gschem_options_set_snap_size
             gschem_options_scale_snap_down
 
             text_edit_dialog
@@ -343,7 +343,7 @@
 
 ;;; gschem_options.c
 (define-lff gschem_options_get_snap_size int '(*))
-(define-lff gschem_options_scale_snap_up void '(*))
+(define-lff gschem_options_set_snap_size void (list '* int))
 (define-lff gschem_options_scale_snap_down void '(*))
 
 ;;; gschem_text_properties_widget.c

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -218,7 +218,6 @@
 
             gschem_options_get_snap_size
             gschem_options_set_snap_size
-            gschem_options_scale_snap_down
 
             text_edit_dialog
 
@@ -344,7 +343,6 @@
 ;;; gschem_options.c
 (define-lff gschem_options_get_snap_size int '(*))
 (define-lff gschem_options_set_snap_size void (list '* int))
-(define-lff gschem_options_scale_snap_down void '(*))
 
 ;;; gschem_text_properties_widget.c
 (define-lff text_edit_dialog void '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -220,9 +220,7 @@
             schematic_window_update_keyaccel_timer
 
             gschem_options_cycle_magnetic_net_mode
-            gschem_options_get_magnetic_net_mode
             gschem_options_cycle_net_rubber_band_mode
-            gschem_options_get_net_rubber_band_mode
             gschem_options_cycle_snap_mode
             gschem_options_get_snap_mode
             gschem_options_get_snap_size
@@ -355,9 +353,7 @@
 
 ;;; gschem_options.c
 (define-lff gschem_options_cycle_magnetic_net_mode void '(*))
-(define-lff gschem_options_get_magnetic_net_mode int '(*))
 (define-lff gschem_options_cycle_net_rubber_band_mode void '(*))
-(define-lff gschem_options_get_net_rubber_band_mode int '(*))
 (define-lff gschem_options_cycle_snap_mode void '(*))
 (define-lff gschem_options_get_snap_mode int '(*))
 (define-lff gschem_options_get_snap_size int '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -83,7 +83,6 @@
             i_callback_hierarchy_down_symbol
             i_callback_hierarchy_up
             i_callback_options_afeedback
-            i_callback_options_grid
             i_callback_page_close
             i_callback_page_next
             i_callback_page_prev
@@ -189,6 +188,9 @@
             x_tabs_create
             x_tabs_enabled
 
+            schematic_grid_mode_from_string
+            schematic_grid_mode_to_string
+
             schematic_snap_mode_from_string
             schematic_snap_mode_to_string
 
@@ -220,6 +222,8 @@
             schematic_window_update_keyaccel_string
             schematic_window_update_keyaccel_timer
 
+            gschem_options_cycle_grid_mode
+            gschem_options_get_grid_mode
             gschem_options_cycle_magnetic_net_mode
             gschem_options_cycle_net_rubber_band_mode
             gschem_options_cycle_snap_mode
@@ -315,6 +319,10 @@
 (define-lff x_widgets_show_options void '(*))
 (define-lff x_widgets_show_page_select void '(*))
 
+;;; grid_mode.c
+(define-lff schematic_grid_mode_from_string int '(*))
+(define-lff schematic_grid_mode_to_string '* (list int))
+
 ;;; keys.c
 (define-lff schematic_keys_get_event_keyval int '(*))
 (define-lff schematic_keys_get_event_modifiers int '(*))
@@ -355,6 +363,8 @@
 (define-lff schematic_window_update_keyaccel_timer void (list '* int))
 
 ;;; gschem_options.c
+(define-lff gschem_options_cycle_grid_mode void '(*))
+(define-lff gschem_options_get_grid_mode int '(*))
 (define-lff gschem_options_cycle_magnetic_net_mode void '(*))
 (define-lff gschem_options_cycle_net_rubber_band_mode void '(*))
 (define-lff gschem_options_cycle_snap_mode void '(*))
@@ -481,7 +491,6 @@
 (define-lff i_callback_hierarchy_down_symbol void '(* *))
 (define-lff i_callback_hierarchy_up void '(* *))
 (define-lff i_callback_options_afeedback void '(* *))
-(define-lff i_callback_options_grid void '(* *))
 (define-lff i_callback_view_color_edit void '(* *))
 (define-lff i_callback_view_pan void '(* *))
 (define-lff i_callback_view_pan_down void '(* *))

--- a/libleptongui/src/Makefile.am
+++ b/libleptongui/src/Makefile.am
@@ -7,6 +7,7 @@ libleptongui_la_SOURCES = \
 	g_hook.c \
 	g_window.c \
 	globals.c \
+	grid_mode.c \
 	lepton-schematic.c \
 	gschemhotkeystore.c \
 	gschem_about_dialog.c \

--- a/libleptongui/src/Makefile.am
+++ b/libleptongui/src/Makefile.am
@@ -77,6 +77,7 @@ libleptongui_la_SOURCES = \
 	s_stretch.c \
 	schematic_hierarchy.c \
 	slot_edit_dialog.c \
+	snap_mode.c \
 	x_attribedit.c \
 	x_autonumber.c \
 	x_basic.c \

--- a/libleptongui/src/grid_mode.c
+++ b/libleptongui/src/grid_mode.c
@@ -1,0 +1,70 @@
+/* Lepton EDA Schematic Capture
+ * Copyright (C) 2022 Lepton EDA Contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include <config.h>
+
+#include "gschem.h"
+
+
+/*! \brief Return a grid mode enum value from string.
+ * \par Function Description
+ *
+ * Given a string \a s, returns the #SchematicGridMode enum value
+ * corresponding to it.  This is mainly intended to be used for
+ * value conversion in Scheme FFI functions.
+ *
+ * \param [in] s The string.
+ * \return The enum value corresponding to the string.
+ */
+SchematicGridMode
+schematic_grid_mode_from_string (char *s)
+{
+  SchematicGridMode result = GRID_MODE_NONE;
+
+  if      (strcmp (s, "none") == 0) {result = GRID_MODE_NONE; }
+  else if (strcmp (s, "dots") == 0) {result = GRID_MODE_DOTS; }
+  else if (strcmp (s, "mesh") == 0) {result = GRID_MODE_MESH; }
+
+  return result;
+}
+
+
+/*! \brief Return a string holding the representation of #SchematicGridMode value.
+ * \par Function Description
+ *
+ * Given a #SchematicGridMode value, returns its external
+ * representation as a string.  This is mainly intended to be used
+ * for value conversion in Scheme FFI functions.
+ *
+ *  \param [in] code The #SchematicGridMode value.
+ *  \return The string representation of the given mode.
+ */
+const char*
+schematic_grid_mode_to_string (SchematicGridMode mode)
+{
+  const char *result = "dots";
+  switch (mode)
+  {
+  case GRID_MODE_NONE: result = "none"; break;
+  case GRID_MODE_DOTS: result = "dots"; break;
+  case GRID_MODE_MESH: result = "mesh"; break;
+  default: break;
+  }
+
+  return result;
+}

--- a/libleptongui/src/gschem_options.c
+++ b/libleptongui/src/gschem_options.c
@@ -75,11 +75,11 @@ set_property (GObject *object, guint param_id, const GValue *value, GParamSpec *
 void
 gschem_options_cycle_grid_mode (GschemOptions *options)
 {
-  GRID_MODE next_grid_mode;
+  SchematicGridMode next_grid_mode;
 
   g_return_if_fail (options != NULL);
 
-  next_grid_mode = (GRID_MODE) ((options->grid_mode + 1) % GRID_MODE_COUNT);
+  next_grid_mode = (SchematicGridMode) ((options->grid_mode + 1) % GRID_MODE_COUNT);
 
   gschem_options_set_grid_mode (options, next_grid_mode);
 }
@@ -146,12 +146,12 @@ gschem_options_cycle_snap_mode (GschemOptions *options)
  *  \param [in] options These options
  *  \return The grid mode
  */
-GRID_MODE
+SchematicGridMode
 gschem_options_get_grid_mode (GschemOptions *options)
 {
   g_return_val_if_fail (options != NULL, GRID_MODE_MESH);
 
-  return (GRID_MODE) options->grid_mode;
+  return (SchematicGridMode) options->grid_mode;
 }
 
 
@@ -235,7 +235,7 @@ gschem_options_new ()
  *  \param [in] grid_mode The grid mode
  */
 void
-gschem_options_set_grid_mode (GschemOptions *options, GRID_MODE grid_mode)
+gschem_options_set_grid_mode (GschemOptions *options, SchematicGridMode grid_mode)
 {
   g_return_if_fail (options != NULL);
 
@@ -472,7 +472,7 @@ set_property (GObject *object, guint param_id, const GValue *value, GParamSpec *
 
   switch (param_id) {
     case PROP_GRID_MODE:
-      gschem_options_set_grid_mode (options, (GRID_MODE) g_value_get_int (value));
+      gschem_options_set_grid_mode (options, (SchematicGridMode) g_value_get_int (value));
       break;
 
     case PROP_MAGNETIC_NET_MODE:

--- a/libleptongui/src/gschem_options.c
+++ b/libleptongui/src/gschem_options.c
@@ -129,12 +129,12 @@ gschem_options_cycle_net_rubber_band_mode (GschemOptions *options)
 void
 gschem_options_cycle_snap_mode (GschemOptions *options)
 {
-  SNAP_STATE next_snap_mode;
+  SchematicSnapMode next_snap_mode;
 
   g_return_if_fail (options != NULL);
 
   /* toggle to the next snap state */
-  next_snap_mode = (SNAP_STATE) ((options->snap_mode + 1) % SNAP_STATE_COUNT);
+  next_snap_mode = (SchematicSnapMode) ((options->snap_mode + 1) % SNAP_MODE_COUNT);
 
   gschem_options_set_snap_mode (options, next_snap_mode);
 }
@@ -191,7 +191,7 @@ gschem_options_get_net_rubber_band_mode (GschemOptions *options)
  *  \param [in] options These options
  *  \return The snap mode
  */
-SNAP_STATE
+SchematicSnapMode
 gschem_options_get_snap_mode (GschemOptions *options)
 {
   g_return_val_if_fail (options != NULL, SNAP_GRID);
@@ -297,7 +297,7 @@ gschem_options_set_net_rubber_band_mode (GschemOptions *options, gboolean enable
  *  \param [in] snap_mode The snap mode
  */
 void
-gschem_options_set_snap_mode (GschemOptions *options, SNAP_STATE snap_mode)
+gschem_options_set_snap_mode (GschemOptions *options, SchematicSnapMode snap_mode)
 {
   g_return_if_fail (options != NULL);
 
@@ -385,7 +385,7 @@ gschem_options_class_init (GschemOptionsClass *klass)
                                                      "Snap Mode",
                                                      "Snap Mode",
                                                      0,
-                                                     SNAP_STATE_COUNT - 1,
+                                                     SNAP_MODE_COUNT - 1,
                                                      SNAP_GRID,
                                                      (GParamFlags) (G_PARAM_READWRITE
                                                                     | G_PARAM_STATIC_STRINGS
@@ -484,7 +484,7 @@ set_property (GObject *object, guint param_id, const GValue *value, GParamSpec *
       break;
 
     case PROP_SNAP_MODE:
-      gschem_options_set_snap_mode (options, (SNAP_STATE) g_value_get_int (value));
+      gschem_options_set_snap_mode (options, (SchematicSnapMode) g_value_get_int (value));
       break;
 
     case PROP_SNAP_SIZE:

--- a/libleptongui/src/gschem_options.c
+++ b/libleptongui/src/gschem_options.c
@@ -246,22 +246,6 @@ gschem_options_scale_snap_down (GschemOptions *options)
 
 
 
-/*! \brief Scale the snap size up
- *
- *  \param [in] options These options
- */
-void
-gschem_options_scale_snap_up (GschemOptions *options)
-{
-  g_return_if_fail (options != NULL);
-
-  int snap_size = gschem_options_get_snap_size (options);
-
-  gschem_options_set_snap_size (options, snap_size * 2);
-}
-
-
-
 /*! \brief Set the grid mode
  *
  *  If the grid mode is invalid the default grid mode is set.

--- a/libleptongui/src/gschem_options.c
+++ b/libleptongui/src/gschem_options.c
@@ -227,25 +227,6 @@ gschem_options_new ()
 }
 
 
-/*! \brief Scale the snap size down
- *
- *  \param [in] options These options
- */
-void
-gschem_options_scale_snap_down (GschemOptions *options)
-{
-  g_return_if_fail (options != NULL);
-
-  int snap_size = gschem_options_get_snap_size (options);
-
-  if ((snap_size % 2) == 0)
-  {
-    gschem_options_set_snap_size (options, snap_size / 2);
-  }
-}
-
-
-
 /*! \brief Set the grid mode
  *
  *  If the grid mode is invalid the default grid mode is set.

--- a/libleptongui/src/gschem_options.c
+++ b/libleptongui/src/gschem_options.c
@@ -236,8 +236,11 @@ gschem_options_scale_snap_down (GschemOptions *options)
 {
   g_return_if_fail (options != NULL);
 
-  if ((options->snap_size % 2) == 0) {
-    gschem_options_set_snap_size (options, options->snap_size / 2);
+  int snap_size = gschem_options_get_snap_size (options);
+
+  if ((snap_size % 2) == 0)
+  {
+    gschem_options_set_snap_size (options, snap_size / 2);
   }
 }
 
@@ -252,7 +255,9 @@ gschem_options_scale_snap_up (GschemOptions *options)
 {
   g_return_if_fail (options != NULL);
 
-  gschem_options_set_snap_size (options, options->snap_size * 2);
+  int snap_size = gschem_options_get_snap_size (options);
+
+  gschem_options_set_snap_size (options, snap_size * 2);
 }
 
 

--- a/libleptongui/src/gschem_options_widget.c
+++ b/libleptongui/src/gschem_options_widget.c
@@ -316,7 +316,8 @@ create_snap_mode_widget (GschemOptionsWidget *widget)
   box = gtk_hbox_new (FALSE, FALSE);
 #endif
 
-  for (index=0; index<SNAP_STATE_COUNT; index++) {
+  for (index = 0; index < SNAP_MODE_COUNT; index++)
+  {
     widget->snap_radio[index] = gtk_toggle_button_new_with_mnemonic (NULL);
 
     gtk_box_pack_start (GTK_BOX (box),                           /* box     */
@@ -727,9 +728,10 @@ update_snap_mode_model (GschemOptionsWidget *widget, GtkWidget *button)
   if (widget->options != NULL) {
     int index;
 
-    for (index = 0; index < SNAP_STATE_COUNT; index++) {
+    for (index = 0; index < SNAP_MODE_COUNT; index++)
+    {
       if (widget->snap_radio[index] == button) {
-        gschem_options_set_snap_mode (widget->options, (SNAP_STATE) index);
+        gschem_options_set_snap_mode (widget->options, (SchematicSnapMode) index);
         break;
       }
     }
@@ -750,22 +752,25 @@ update_snap_mode_widget (GschemOptionsWidget *widget)
 
   if (widget->options != NULL) {
     int index;
-    SNAP_STATE snap_mode;
+    SchematicSnapMode snap_mode;
 
     snap_mode = gschem_options_get_snap_mode (widget->options);
 
-    for (index=0; index<SNAP_STATE_COUNT; index++) {
+    for (index = 0; index < SNAP_MODE_COUNT; index++)
+    {
       g_signal_handlers_block_by_func (G_OBJECT (widget->snap_radio[index]),
                                        (gpointer) update_snap_mode_model,
                                        widget);
     }
 
-    for (index=0; index<SNAP_STATE_COUNT; index++) {
+    for (index = 0; index < SNAP_MODE_COUNT; index++)
+    {
       gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (widget->snap_radio[index]),
                                     (snap_mode == index));
   }
 
-    for (index=0; index<SNAP_STATE_COUNT; index++) {
+    for (index = 0; index < SNAP_MODE_COUNT; index++)
+    {
       g_signal_handlers_unblock_by_func (G_OBJECT (widget->snap_radio[index]),
                                          (gpointer) update_snap_mode_model,
                                          widget);

--- a/libleptongui/src/gschem_options_widget.c
+++ b/libleptongui/src/gschem_options_widget.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2015 gEDA Contributors
- * Copyright (C) 2017-2020 Lepton EDA Contributors
+ * Copyright (C) 2017-2022 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -133,16 +133,6 @@ gschem_options_widget_new (GschemToplevel *w_current)
   return GTK_WIDGET (g_object_new (GSCHEM_TYPE_OPTIONS_WIDGET,
                                    "gschem-toplevel",  w_current,
                                    NULL));
-}
-
-
-
-/*! \brief Shows the options widget
- */
-void
-snap_size_dialog (GschemToplevel *w_current)
-{
-  x_widgets_show_options (w_current);
 }
 
 

--- a/libleptongui/src/gschem_options_widget.c
+++ b/libleptongui/src/gschem_options_widget.c
@@ -568,7 +568,7 @@ update_grid_mode_model (GschemOptionsWidget *widget, GtkWidget *button)
 
     for (index = 0; index < GRID_MODE_COUNT; index++) {
       if (widget->grid_radio[index] == button) {
-        gschem_options_set_grid_mode (widget->options, (GRID_MODE) index);
+        gschem_options_set_grid_mode (widget->options, (SchematicGridMode) index);
         break;
       }
     }
@@ -588,7 +588,7 @@ update_grid_mode_widget (GschemOptionsWidget *widget)
   g_return_if_fail (widget != NULL);
 
   if (widget->options != NULL) {
-    GRID_MODE grid_mode;
+    SchematicGridMode grid_mode;
     int index;
 
     grid_mode = gschem_options_get_grid_mode (widget->options);

--- a/libleptongui/src/gschem_toplevel.c
+++ b/libleptongui/src/gschem_toplevel.c
@@ -1071,3 +1071,22 @@ schematic_window_set_actionfeedback_mode (GschemToplevel *w_current,
 
   w_current->actionfeedback_mode = actionfeedback_mode;
 }
+
+
+
+/*! \brief Get the list of objects to place for this schematic window.
+ *
+ *  \param [in] w_current The schematic window.
+ *  \return The list of objects.
+ */
+GList*
+schematic_window_get_place_list (GschemToplevel *w_current)
+{
+  g_return_val_if_fail (w_current != NULL, NULL);
+
+  LeptonPage *active_page = schematic_window_get_active_page (w_current);
+
+  g_return_val_if_fail (active_page != NULL, NULL);
+
+  return lepton_page_get_place_list (active_page);
+}

--- a/libleptongui/src/gschem_toplevel.c
+++ b/libleptongui/src/gschem_toplevel.c
@@ -1013,3 +1013,32 @@ schematic_window_get_inside_action (GschemToplevel *w_current)
 
   return w_current->inside_action;
 }
+
+
+/*! \brief Get the 'draw grips' setting of a schematic window structure.
+ *
+ *  \param [in] w_current The schematic window.
+ *  \return TRUE if drawing grips enabled, FALSE otherwise.
+ */
+gboolean
+schematic_window_get_draw_grips (GschemToplevel *w_current)
+{
+  g_return_val_if_fail (w_current != NULL, TRUE);
+
+  return w_current->draw_grips;
+}
+
+
+/*! \brief Set the 'draw grips' setting of a schematic window structure.
+ *
+ *  \param [in] w_current The schematic window.
+ *  \param [in] draw_grips The new value.
+ */
+void
+schematic_window_set_draw_grips (GschemToplevel *w_current,
+                                 gboolean draw_grips)
+{
+  g_return_if_fail (w_current != NULL);
+
+  w_current->draw_grips = draw_grips;
+}

--- a/libleptongui/src/gschem_toplevel.c
+++ b/libleptongui/src/gschem_toplevel.c
@@ -1042,3 +1042,32 @@ schematic_window_set_draw_grips (GschemToplevel *w_current,
 
   w_current->draw_grips = draw_grips;
 }
+
+
+/*! \brief Get the action feedback mode for this schematic window.
+ *
+ *  \param [in] w_current The schematic window.
+ *  \return The action feedback mode.
+ */
+int
+schematic_window_get_actionfeedback_mode (GschemToplevel *w_current)
+{
+  g_return_val_if_fail (w_current != NULL, OUTLINE);
+
+  return w_current->actionfeedback_mode;
+}
+
+
+/*! \brief Set the action feedback mode for this schematic window.
+ *
+ *  \param [in] w_current The schematic window.
+ *  \param [in] actionfeedback_mode The current action feedback mode.
+ */
+void
+schematic_window_set_actionfeedback_mode (GschemToplevel *w_current,
+                                          int actionfeedback_mode)
+{
+  g_return_if_fail (w_current != NULL);
+
+  w_current->actionfeedback_mode = actionfeedback_mode;
+}

--- a/libleptongui/src/gschem_toplevel.c
+++ b/libleptongui/src/gschem_toplevel.c
@@ -999,3 +999,17 @@ schematic_window_set_toolbar (GschemToplevel *w_current,
 {
   w_current->toolbar = toolbar;
 }
+
+
+/*! \brief Get the 'inside_action' field of a schematic window structure.
+ *
+ * \param [in] w_current The #GschemToplevel instance.
+ * \return TRUE if the window is inside action.
+ */
+gboolean
+schematic_window_get_inside_action (GschemToplevel *w_current)
+{
+  g_return_val_if_fail (w_current != NULL, FALSE);
+
+  return w_current->inside_action;
+}

--- a/libleptongui/src/i_basic.c
+++ b/libleptongui/src/i_basic.c
@@ -111,7 +111,7 @@ void i_show_state(GschemToplevel *w_current, const char *message)
   gchar *what_to_say;
   const gchar *array[5] = { NULL };
   int i = 3; /* array[4] must be NULL */
-  SNAP_STATE snap_mode;
+  SchematicSnapMode snap_mode;
 
   gboolean show_hidden_text =
     gschem_toplevel_get_show_hidden_text (w_current);

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -2203,21 +2203,6 @@ i_callback_attributes_visibility_toggle (GtkWidget *widget, gpointer data)
 }
 
 
-/*! \brief Multiply by two the snap grid size.
- *  \par Function Description
- *  Callback function for the scale-up snap grid size hotkey.
- *  Multiply by two the snap grid size.
- */
-void
-i_callback_options_scale_up_snap_size (GtkWidget *widget, gpointer data)
-{
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-
-  g_return_if_fail (w_current != NULL);
-
-  gschem_options_scale_snap_up (w_current->options);
-}
-
 /*! \brief Divide by two the snap grid size.
  *  \par Function Description
  *  Callback function for the scale-down snap grid size hotkey.

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -2256,43 +2256,6 @@ i_callback_options_grid (GtkWidget *widget, gpointer data)
   }
 }
 
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
-void
-i_callback_options_snap (GtkWidget *widget, gpointer data)
-{
-  SchematicSnapMode snap_mode;
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-
-  g_return_if_fail (w_current != NULL);
-
-  GschemOptions* options = schematic_window_get_options (w_current);
-
-  gschem_options_cycle_snap_mode (options);
-
-  snap_mode = gschem_options_get_snap_mode (options);
-
-  switch (snap_mode) {
-  case SNAP_OFF:
-    g_message (_("Snap OFF (CAUTION!)"));
-    break;
-  case SNAP_GRID:
-    g_message (_("Snap ON"));
-    break;
-  case SNAP_RESNAP:
-    g_message (_("Snap back to the grid (CAUTION!)"));
-    break;
-  default:
-    g_critical("options_snap: Invalid snap_mode: %1$d\n",
-               snap_mode);
-  }
-
-  i_show_state(w_current, NULL); /* update status on screen */
-  i_update_grid_info (w_current);
-}
 
 /*! \todo Finish function documentation!!!
  *  \brief

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -2269,9 +2269,11 @@ i_callback_options_snap (GtkWidget *widget, gpointer data)
 
   g_return_if_fail (w_current != NULL);
 
-  gschem_options_cycle_snap_mode (w_current->options);
+  GschemOptions* options = schematic_window_get_options (w_current);
 
-  snap_mode = gschem_options_get_snap_mode (w_current->options);
+  gschem_options_cycle_snap_mode (options);
+
+  snap_mode = gschem_options_get_snap_mode (options);
 
   switch (snap_mode) {
   case SNAP_OFF:

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -237,7 +237,8 @@ i_callback_edit_undo (GtkWidget *widget, gpointer data)
    * Since they are also contained in the schematic page, a
    * crash occurs when the page objects are free'd.
    * */
-  if (w_current->inside_action) {
+  if (schematic_window_get_inside_action (w_current))
+  {
     i_callback_cancel (widget, w_current);
   } else {
     GschemPageView *page_view = gschem_toplevel_get_current_page_view (w_current);
@@ -485,7 +486,8 @@ i_callback_edit_rotate_90 (GtkWidget *widget, gpointer data)
     return;
   }
 
-  if (w_current->inside_action && (active_page->place_list != NULL))
+  if (schematic_window_get_inside_action (w_current) &&
+      (active_page->place_list != NULL))
   {
     o_place_rotate (w_current);
     return;
@@ -529,7 +531,9 @@ i_callback_edit_mirror (GtkWidget *widget, gpointer data)
     return;
   }
 
-  if (w_current->inside_action && (active_page->place_list != NULL)) {
+  if (schematic_window_get_inside_action (w_current) &&
+      (active_page->place_list != NULL))
+  {
     o_place_mirror (w_current);
     return;
   }
@@ -793,7 +797,7 @@ i_callback_edit_find (GtkWidget *widget, gpointer data)
 
   /* This is a new addition 3/15 to prevent this from executing
    * inside an action */
-  if (w_current->inside_action)
+  if (schematic_window_get_inside_action (w_current))
     return;
 
   find_text_dialog(w_current);
@@ -813,7 +817,7 @@ i_callback_edit_hide_text (GtkWidget *widget, gpointer data)
 
   /* This is a new addition 3/15 to prevent this from executing
    * inside an action */
-  if (w_current->inside_action)
+  if (schematic_window_get_inside_action (w_current))
     return;
 
   hide_text_dialog(w_current);
@@ -833,7 +837,7 @@ i_callback_edit_show_text (GtkWidget *widget, gpointer data)
 
   /* This is a new addition 3/15 to prevent this from executing
    * inside an action */
-  if (w_current->inside_action)
+  if (schematic_window_get_inside_action (w_current))
     return;
 
   show_text_dialog(w_current);
@@ -853,7 +857,7 @@ i_callback_edit_autonumber_text (GtkWidget *widget, gpointer data)
 
   /* This is a new addition 3/15 to prevent this from executing
    * inside an action */
-  if (w_current->inside_action)
+  if (schematic_window_get_inside_action (w_current))
     return;
 
   autonumber_text_dialog(w_current);
@@ -2065,7 +2069,8 @@ i_callback_attributes_show_name (GtkWidget *widget, gpointer data)
 
   /* This is a new addition 3/15 to prevent this from executing
    * inside an action */
-  if (w_current->inside_action) {
+  if (schematic_window_get_inside_action (w_current))
+  {
     return;
   }
 
@@ -2101,7 +2106,8 @@ i_callback_attributes_show_value (GtkWidget *widget, gpointer data)
 
   /* This is a new addition 3/15 to prevent this from executing
    * inside an action */
-  if (w_current->inside_action) {
+  if (schematic_window_get_inside_action (w_current))
+  {
     return;
   }
 
@@ -2137,7 +2143,8 @@ i_callback_attributes_show_both (GtkWidget *widget, gpointer data)
 
   /* This is a new addition 3/15 to prevent this from executing
    * inside an action */
-  if (w_current->inside_action) {
+  if (schematic_window_get_inside_action (w_current))
+  {
     return;
   }
 
@@ -2172,7 +2179,8 @@ i_callback_attributes_visibility_toggle (GtkWidget *widget, gpointer data)
 
   /* This is a new addition 3/15 to prevent this from executing
    * inside an action */
-  if (w_current->inside_action) {
+  if (schematic_window_get_inside_action (w_current))
+  {
     return;
   }
 
@@ -2261,7 +2269,7 @@ i_callback_options_afeedback (GtkWidget *widget, gpointer data)
     g_message (_("Action feedback mode set to BOUNDINGBOX"));
   }
   LeptonPage *active_page = schematic_window_get_active_page (w_current);
-  if (w_current->inside_action &&
+  if (schematic_window_get_inside_action (w_current) &&
       active_page->place_list != NULL)
     o_place_invalidate_rubber (w_current, FALSE);
 }
@@ -2416,7 +2424,8 @@ i_callback_cancel (GtkWidget *widget, gpointer data)
     g_object_set_property (G_OBJECT(w_current->cswindow), "hidden", &value);
   }
 
-  if (w_current->inside_action) {
+  if (schematic_window_get_inside_action (w_current))
+  {
     /* If we're cancelling from a move action, re-wind the
      * page contents back to their state before we started */
     o_move_cancel (w_current);

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -2258,31 +2258,6 @@ i_callback_options_grid (GtkWidget *widget, gpointer data)
 
 
 
-/*! \brief callback function for setting the magnetic net option
- *  \par Function Description
- *  This function just toggles a variable to switch the magnetic net
- *  mode ON and OFF
- */
-void
-i_callback_options_magneticnet (GtkWidget *widget, gpointer data)
-{
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-
-  g_return_if_fail (w_current != NULL);
-
-  gschem_options_cycle_magnetic_net_mode (w_current->options);
-
-  if (gschem_options_get_magnetic_net_mode (w_current->options)) {
-    g_message (_("magnetic net mode: ON"));
-  }
-  else {
-    g_message (_("magnetic net mode: OFF"));
-  }
-
-  i_show_state(w_current, NULL);
-}
-
-
 /*! \todo Finish function documentation!!!
  *  \brief
  *  \par Function Description

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -2228,9 +2228,8 @@ i_callback_options_afeedback (GtkWidget *widget, gpointer data)
     schematic_window_set_actionfeedback_mode (w_current, BOUNDINGBOX);
     g_message (_("Action feedback mode set to BOUNDINGBOX"));
   }
-  LeptonPage *active_page = schematic_window_get_active_page (w_current);
   if (schematic_window_get_inside_action (w_current) &&
-      active_page->place_list != NULL)
+      schematic_window_get_place_list (w_current) != NULL)
     o_place_invalidate_rubber (w_current, FALSE);
 }
 

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -2239,7 +2239,7 @@ i_callback_options_afeedback (GtkWidget *widget, gpointer data)
 void
 i_callback_options_grid (GtkWidget *widget, gpointer data)
 {
-  GRID_MODE grid_mode;
+  SchematicGridMode grid_mode;
   GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
 
   g_return_if_fail (w_current != NULL);

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -2338,7 +2338,8 @@ i_callback_options_draw_grips (GtkWidget *widget, gpointer data)
   GschemToplevel* w_current = GSCHEM_TOPLEVEL (data);
   g_return_if_fail (w_current != NULL);
 
-  w_current->draw_grips = !w_current->draw_grips;
+  gboolean draw_grips = schematic_window_get_draw_grips (w_current);
+  schematic_window_set_draw_grips (w_current, !draw_grips);
 
   GschemPageView* view = gschem_toplevel_get_current_page_view (w_current);
   gschem_page_view_invalidate_all (view);

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -596,7 +596,7 @@ i_callback_edit_unlock (GtkWidget *widget, gpointer data)
 void
 i_callback_edit_translate (GtkWidget *widget, gpointer data)
 {
-  SNAP_STATE snap_mode;
+  SchematicSnapMode snap_mode;
   GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
 
   g_return_if_fail (w_current != NULL);
@@ -2264,7 +2264,7 @@ i_callback_options_grid (GtkWidget *widget, gpointer data)
 void
 i_callback_options_snap (GtkWidget *widget, gpointer data)
 {
-  SNAP_STATE snap_mode;
+  SchematicSnapMode snap_mode;
   GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
 
   g_return_if_fail (w_current != NULL);

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -2202,19 +2202,6 @@ i_callback_attributes_visibility_toggle (GtkWidget *widget, gpointer data)
   }
 }
 
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
-void
-i_callback_options_snap_size (GtkWidget *widget, gpointer data)
-{
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-
-  g_return_if_fail (w_current != NULL);
-  snap_size_dialog(w_current);
-}
 
 /*! \brief Multiply by two the snap grid size.
  *  \par Function Description

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -2244,9 +2244,9 @@ i_callback_options_grid (GtkWidget *widget, gpointer data)
 
   g_return_if_fail (w_current != NULL);
 
-  gschem_options_cycle_grid_mode (w_current->options);
+  gschem_options_cycle_grid_mode (schematic_window_get_options (w_current));
 
-  grid_mode = gschem_options_get_grid_mode (w_current->options);
+  grid_mode = gschem_options_get_grid_mode (schematic_window_get_options (w_current));
 
   switch (grid_mode) {
     case GRID_MODE_NONE: g_message (_("Grid OFF"));           break;

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -2332,19 +2332,6 @@ i_callback_cancel (GtkWidget *widget, gpointer data)
   i_action_stop (w_current);
 }
 
-void
-i_callback_options_draw_grips (GtkWidget *widget, gpointer data)
-{
-  GschemToplevel* w_current = GSCHEM_TOPLEVEL (data);
-  g_return_if_fail (w_current != NULL);
-
-  gboolean draw_grips = schematic_window_get_draw_grips (w_current);
-  schematic_window_set_draw_grips (w_current, !draw_grips);
-
-  GschemPageView* view = gschem_toplevel_get_current_page_view (w_current);
-  gschem_page_view_invalidate_all (view);
-}
-
 
 /*! \todo Finish function documentation!!!
  *  \brief

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -2208,38 +2208,6 @@ i_callback_attributes_visibility_toggle (GtkWidget *widget, gpointer data)
  *  \par Function Description
  *
  *  \note
- *  repeat last command doesn't make sense on options either??? (does
- *  it?)
- */
-void
-i_callback_options_afeedback (GtkWidget *widget, gpointer data)
-{
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-
-  g_return_if_fail (w_current != NULL);
-
-  if (schematic_window_get_actionfeedback_mode (w_current) == BOUNDINGBOX)
-  {
-    schematic_window_set_actionfeedback_mode (w_current, OUTLINE);
-    g_message (_("Action feedback mode set to OUTLINE"));
-  }
-  else
-  {
-    schematic_window_set_actionfeedback_mode (w_current, BOUNDINGBOX);
-    g_message (_("Action feedback mode set to BOUNDINGBOX"));
-  }
-  if (schematic_window_get_inside_action (w_current) &&
-      schematic_window_get_place_list (w_current) != NULL)
-    o_place_invalidate_rubber (w_current, FALSE);
-}
-
-
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- *  \note
  *  HACK: be sure that you don't use the widget parameter in this one,
  *  since it is being called with a null, I suppose we should call it
  *  with the right param.

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -2231,31 +2231,6 @@ i_callback_options_afeedback (GtkWidget *widget, gpointer data)
     o_place_invalidate_rubber (w_current, FALSE);
 }
 
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
-void
-i_callback_options_grid (GtkWidget *widget, gpointer data)
-{
-  SchematicGridMode grid_mode;
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-
-  g_return_if_fail (w_current != NULL);
-
-  gschem_options_cycle_grid_mode (schematic_window_get_options (w_current));
-
-  grid_mode = gschem_options_get_grid_mode (schematic_window_get_options (w_current));
-
-  switch (grid_mode) {
-    case GRID_MODE_NONE: g_message (_("Grid OFF"));           break;
-    case GRID_MODE_DOTS: g_message (_("Dot grid selected"));  break;
-    case GRID_MODE_MESH: g_message (_("Mesh grid selected")); break;
-    default:             g_message (_("Invalid grid mode"));
-  }
-}
-
 
 
 /*! \todo Finish function documentation!!!

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -2203,21 +2203,6 @@ i_callback_attributes_visibility_toggle (GtkWidget *widget, gpointer data)
 }
 
 
-/*! \brief Divide by two the snap grid size.
- *  \par Function Description
- *  Callback function for the scale-down snap grid size hotkey.
- *  Divide by two the snap grid size (if it's and even number).
- */
-void
-i_callback_options_scale_down_snap_size (GtkWidget *widget, gpointer data)
-{
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-
-  g_return_if_fail (w_current != NULL);
-
-  gschem_options_scale_snap_down (w_current->options);
-}
-
 /*! \todo Finish function documentation!!!
  *  \brief
  *  \par Function Description

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -2257,31 +2257,6 @@ i_callback_options_grid (GtkWidget *widget, gpointer data)
 }
 
 
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- *  \note
- *  Rubber band is cool !
- *  Added on/off option from the pull down menu
- *  Chris Ellec - January 2001
- */
-void
-i_callback_options_rubberband (GtkWidget *widget, gpointer data)
-{
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-
-  g_return_if_fail (w_current != NULL);
-
-  gschem_options_cycle_net_rubber_band_mode (w_current->options);
-
-  if (gschem_options_get_net_rubber_band_mode (w_current->options)) {
-    g_message (_("Rubber band ON"));
-  } else {
-    g_message (_("Rubber band OFF"));
-  }
-}
-
 
 /*! \brief callback function for setting the magnetic net option
  *  \par Function Description

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -2218,11 +2218,14 @@ i_callback_options_afeedback (GtkWidget *widget, gpointer data)
 
   g_return_if_fail (w_current != NULL);
 
-  if (w_current->actionfeedback_mode == BOUNDINGBOX) {
-    w_current->actionfeedback_mode = OUTLINE;
+  if (schematic_window_get_actionfeedback_mode (w_current) == BOUNDINGBOX)
+  {
+    schematic_window_set_actionfeedback_mode (w_current, OUTLINE);
     g_message (_("Action feedback mode set to OUTLINE"));
-  } else {
-    w_current->actionfeedback_mode = BOUNDINGBOX;
+  }
+  else
+  {
+    schematic_window_set_actionfeedback_mode (w_current, BOUNDINGBOX);
     g_message (_("Action feedback mode set to BOUNDINGBOX"));
   }
   LeptonPage *active_page = schematic_window_get_active_page (w_current);

--- a/libleptongui/src/i_vars.c
+++ b/libleptongui/src/i_vars.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2016 gEDA Contributors
- * Copyright (C) 2017-2021 Lepton EDA Contributors
+ * Copyright (C) 2017-2022 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -48,7 +48,6 @@ int   default_undo_levels = 20;
 int   default_undo_control = TRUE;
 int   default_undo_type = UNDO_DISK;
 int   default_undo_panzoom = FALSE;
-int   default_draw_grips = TRUE;
 int   default_netconn_rubberband = DEFAULT_NET_RUBBER_BAND_MODE;
 int   default_magnetic_net_mode = DEFAULT_MAGNETIC_NET_MODE;
 int   default_warp_cursor = FALSE;
@@ -64,6 +63,7 @@ int   default_dots_grid_dot_size = 1;
 int   default_dots_grid_mode = DOTS_GRID_VARIABLE_MODE;
 int   default_dots_grid_fixed_threshold = 10;
 int   default_mesh_grid_display_threshold = 3;
+gboolean default_draw_grips = TRUE;
 
 int   default_auto_save_interval = 120;
 

--- a/libleptongui/src/i_vars.c
+++ b/libleptongui/src/i_vars.c
@@ -108,7 +108,7 @@ i_vars_set_options (GschemOptions* opts)
                        sizeof( vals_gm ) / sizeof( vals_gm[0] ),
                        &grid_mode);
 
-  gschem_options_set_grid_mode (opts, (GRID_MODE) grid_mode);
+  gschem_options_set_grid_mode (opts, (SchematicGridMode) grid_mode);
 
 
   gboolean val = FALSE;

--- a/libleptongui/src/m_basic.c
+++ b/libleptongui/src/m_basic.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2015 gEDA Contributors
- * Copyright (C) 2021 Lepton EDA Contributors
+ * Copyright (C) 2021-2022 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -35,7 +35,7 @@
  */
 int snap_grid(GschemToplevel *w_current, int coord)
 {
-  SNAP_STATE snap_mode;
+  SchematicSnapMode snap_mode;
 
   g_return_val_if_fail (w_current != NULL, coord);
 

--- a/libleptongui/src/o_move.c
+++ b/libleptongui/src/o_move.c
@@ -297,7 +297,7 @@ void o_move_motion (GschemToplevel *w_current, int w_x, int w_y)
   GList *selection, *s_current;
   LeptonObject *object = NULL;
   gint object_x, object_y;
-  SNAP_STATE snap_mode;
+  SchematicSnapMode snap_mode;
 
   g_assert (w_current->inside_action != 0);
 

--- a/libleptongui/src/snap_mode.c
+++ b/libleptongui/src/snap_mode.c
@@ -36,9 +36,9 @@ schematic_snap_mode_from_string (char *s)
 {
   SchematicSnapMode result = SNAP_OFF;
 
-  if      (strcmp (s, "snap-off-mode") == 0) {result = SNAP_OFF; }
-  else if (strcmp (s, "snap-grid-mode") == 0) {result = SNAP_GRID; }
-  else if (strcmp (s, "snap-resnap-mode") == 0) {result = SNAP_RESNAP; }
+  if      (strcmp (s, "off") == 0) {result = SNAP_OFF; }
+  else if (strcmp (s, "grid") == 0) {result = SNAP_GRID; }
+  else if (strcmp (s, "resnap") == 0) {result = SNAP_RESNAP; }
 
   return result;
 }
@@ -57,12 +57,12 @@ schematic_snap_mode_from_string (char *s)
 const char*
 schematic_snap_mode_to_string (SchematicSnapMode mode)
 {
-  const char *result = "snap-grid-mode";
+  const char *result = "grid";
   switch (mode)
   {
-  case SNAP_OFF: result = "snap-off-mode"; break;
-  case SNAP_GRID: result = "snap-grid-mode"; break;
-  case SNAP_RESNAP: result = "snap-resnap-mode"; break;
+  case SNAP_OFF: result = "off"; break;
+  case SNAP_GRID: result = "grid"; break;
+  case SNAP_RESNAP: result = "resnap"; break;
   default: break;
   }
 

--- a/libleptongui/src/snap_mode.c
+++ b/libleptongui/src/snap_mode.c
@@ -1,0 +1,70 @@
+/* Lepton EDA Schematic Capture
+ * Copyright (C) 2022 Lepton EDA Contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include <config.h>
+
+#include "gschem.h"
+
+
+/*! \brief Return an snap mode enum value from string.
+ * \par Function Description
+ *
+ * Given a string \a s, returns the #SchematicSnapMode enum value
+ * corresponding to it.  This is mainly intended to be used for
+ * value conversion in Scheme FFI functions.
+ *
+ * \param [in] s The string.
+ * \return The enum value corresponding to the string.
+ */
+SchematicSnapMode
+schematic_snap_mode_from_string (char *s)
+{
+  SchematicSnapMode result = SNAP_OFF;
+
+  if      (strcmp (s, "snap-off-mode") == 0) {result = SNAP_OFF; }
+  else if (strcmp (s, "snap-grid-mode") == 0) {result = SNAP_GRID; }
+  else if (strcmp (s, "snap-resnap-mode") == 0) {result = SNAP_RESNAP; }
+
+  return result;
+}
+
+
+/*! \brief Return a string holding the representation of #SchematicSnapMode value.
+ * \par Function Description
+ *
+ * Given a #SchematicSnapMode value, returns its external
+ * representation as a string.  This is mainly intended to be used
+ * for value conversion in Scheme FFI functions.
+ *
+ *  \param [in] code The #SchematicSnapMode value.
+ *  \return The string representation of the given mode.
+ */
+const char*
+schematic_snap_mode_to_string (SchematicSnapMode mode)
+{
+  const char *result = "snap-grid-mode";
+  switch (mode)
+  {
+  case SNAP_OFF: result = "snap-off-mode"; break;
+  case SNAP_GRID: result = "snap-grid-mode"; break;
+  case SNAP_RESNAP: result = "snap-resnap-mode"; break;
+  default: break;
+  }
+
+  return result;
+}

--- a/libleptongui/src/x_grid.c
+++ b/libleptongui/src/x_grid.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2016 gEDA Contributors
- * Copyright (C) 2017-2021 Lepton EDA Contributors
+ * Copyright (C) 2017-2022 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -363,7 +363,7 @@ void x_grid_draw_region (GschemToplevel *w_current,
                          int width,
                          int height)
 {
-  GRID_MODE grid_mode;
+  SchematicGridMode grid_mode;
 
   g_return_if_fail (w_current != NULL);
 
@@ -398,7 +398,7 @@ void x_grid_draw_region (GschemToplevel *w_current,
  */
 int x_grid_query_drawn_spacing (GschemToplevel *w_current)
 {
-  GRID_MODE grid_mode;
+  SchematicGridMode grid_mode;
 
   g_return_val_if_fail (w_current != NULL, -1);
 


### PR DESCRIPTION
- Several C functions have been thrown out.
- Accessors for several fields of the struct `GschemToplevel` have
  been added to be used in Scheme code.
- The type `GRID_MODE` has been renamed and accessors for it have
  been added.  Related definitions have been moved to separate
  files.
- The enum type `SNAP_STATE` has been renamed and C-Scheme
  conversion functions for it have been added.
- Toggling of magnetic and rubberband net modes is no longer
  logged.  The modes are pretty well visible for the user in the
  status bar.  Moreover, logging the events of toggling just
  increases log size without adding any useful info.
