### PR TITLE
Rewrite some Page select widget's callbacks in Scheme

### DIFF
--- a/libleptongui/include/gschem_toplevel.h
+++ b/libleptongui/include/gschem_toplevel.h
@@ -338,4 +338,10 @@ schematic_window_set_actionfeedback_mode (GschemToplevel *w_current,
 GList*
 schematic_window_get_place_list (GschemToplevel *w_current);
 
+GtkWidget*
+schematic_window_get_page_select_widget (GschemToplevel *w_current);
+
+void
+schematic_window_set_page_select_widget (GschemToplevel *w_current,
+                                         GtkWidget* widget);
 G_END_DECLS

--- a/libleptongui/include/page_select_widget.h
+++ b/libleptongui/include/page_select_widget.h
@@ -51,7 +51,8 @@ G_BEGIN_DECLS
 GtkWidget*
 page_select_widget_new (GschemToplevel* w_current,
                         GCallback page_new_callback,
-                        GCallback page_open_callback);
+                        GCallback page_open_callback,
+                        GCallback page_save_callback);
 void
 page_select_widget_update (GschemToplevel* w_current);
 

--- a/libleptongui/include/page_select_widget.h
+++ b/libleptongui/include/page_select_widget.h
@@ -52,7 +52,8 @@ GtkWidget*
 page_select_widget_new (GschemToplevel* w_current,
                         GCallback page_new_callback,
                         GCallback page_open_callback,
-                        GCallback page_save_callback);
+                        GCallback page_save_callback,
+                        GCallback page_close_callback);
 void
 page_select_widget_update (GschemToplevel* w_current);
 

--- a/libleptongui/include/page_select_widget.h
+++ b/libleptongui/include/page_select_widget.h
@@ -50,7 +50,8 @@ G_BEGIN_DECLS
 
 GtkWidget*
 page_select_widget_new (GschemToplevel* w_current,
-                        GCallback page_new_callback);
+                        GCallback page_new_callback,
+                        GCallback page_open_callback);
 void
 page_select_widget_update (GschemToplevel* w_current);
 

--- a/libleptongui/include/page_select_widget.h
+++ b/libleptongui/include/page_select_widget.h
@@ -49,8 +49,8 @@ typedef struct _PageSelectWidget      PageSelectWidget;
 G_BEGIN_DECLS
 
 GtkWidget*
-page_select_widget_new (GschemToplevel* w_current);
-
+page_select_widget_new (GschemToplevel* w_current,
+                        GCallback page_new_callback);
 void
 page_select_widget_update (GschemToplevel* w_current);
 

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -100,7 +100,6 @@ void i_update_net_options_status (GschemToplevel* w_current);
 /* i_callbacks.c */
 void i_callback_file_script (GtkWidget *widget, gpointer data);
 void i_callback_file_save (GtkWidget *widget, gpointer data);
-void i_callback_file_save_all (GtkWidget *widget, gpointer data);
 void i_callback_edit_undo (GtkWidget *widget, gpointer data);
 void i_callback_edit_redo (GtkWidget *widget, gpointer data);
 void i_callback_edit_select (GtkWidget *widget, gpointer data);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -141,7 +141,6 @@ void i_callback_view_pan_down (GtkWidget *widget, gpointer data);
 void i_callback_view_color_edit (GtkWidget *widget, gpointer data);
 void i_callback_page_next (GtkWidget *widget, gpointer data);
 void i_callback_page_prev (GtkWidget *widget, gpointer data);
-void i_callback_page_close (GtkWidget *widget, gpointer data);
 void i_callback_page_revert (GtkWidget *widget, gpointer data);
 void i_callback_page_print (GtkWidget *widget, gpointer data);
 void i_callback_clipboard_copy (GtkWidget *widget, gpointer data);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -98,7 +98,6 @@ void i_update_grid_info(GschemToplevel *w_current);
 void i_update_grid_info_callback (GschemPageView *view, GschemToplevel *w_current);
 void i_update_net_options_status (GschemToplevel* w_current);
 /* i_callbacks.c */
-void i_callback_file_new (GtkWidget *widget, gpointer data);
 void i_callback_file_open (GtkWidget *widget, gpointer data);
 void i_callback_file_script (GtkWidget *widget, gpointer data);
 void i_callback_file_save (GtkWidget *widget, gpointer data);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -98,7 +98,6 @@ void i_update_grid_info(GschemToplevel *w_current);
 void i_update_grid_info_callback (GschemPageView *view, GschemToplevel *w_current);
 void i_update_net_options_status (GschemToplevel* w_current);
 /* i_callbacks.c */
-void i_callback_file_open (GtkWidget *widget, gpointer data);
 void i_callback_file_script (GtkWidget *widget, gpointer data);
 void i_callback_file_save (GtkWidget *widget, gpointer data);
 void i_callback_file_save_all (GtkWidget *widget, gpointer data);

--- a/libleptongui/scheme/Makefile.am
+++ b/libleptongui/scheme/Makefile.am
@@ -17,6 +17,7 @@ nobase_dist_scmdata_DATA = \
 	schematic/action-mode.scm \
 	schematic/attrib.scm \
 	schematic/builtins.scm \
+	schematic/callback.scm \
 	schematic/gettext.scm \
 	schematic/dialog.scm \
 	schematic/dialog/slot-edit.scm \

--- a/libleptongui/scheme/Makefile.am
+++ b/libleptongui/scheme/Makefile.am
@@ -14,6 +14,7 @@ nobase_dist_scmdata_DATA = \
 	gschem/window.scm \
 	gschem/deprecated.scm \
 	schematic/action.scm \
+	schematic/action-mode.scm \
 	schematic/attrib.scm \
 	schematic/builtins.scm \
 	schematic/gettext.scm \

--- a/libleptongui/scheme/schematic/action-mode.scm
+++ b/libleptongui/scheme/schematic/action-mode.scm
@@ -1,0 +1,34 @@
+;;; Lepton EDA Schematic Capture
+;;; Scheme API
+;;; Copyright (C) 2022 Lepton EDA Contributors
+;;;
+;;; This program is free software; you can redistribute it and/or modify
+;;; it under the terms of the GNU General Public License as published by
+;;; the Free Software Foundation; either version 2 of the License, or
+;;; (at your option) any later version.
+;;;
+;;; This program is distributed in the hope that it will be useful,
+;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;; GNU General Public License for more details.
+;;;
+;;; You should have received a copy of the GNU General Public License
+;;; along with this program; if not, write to the Free Software
+;;; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
+(define-module (schematic action-mode)
+  #:use-module (system foreign)
+
+  #:use-module (schematic ffi)
+
+  #:export (action-mode->symbol
+            symbol->action-mode))
+
+(define (action-mode->symbol mode)
+  "Returns a Scheme symbol corresponding to integer MODE value."
+  (string->symbol (pointer->string (schematic_action_mode_to_string mode))))
+
+(define (symbol->action-mode sym)
+  "Returns integer action mode value corresponding to symbol SYM."
+  (schematic_action_mode_from_string (string->pointer (symbol->string sym))))

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -32,6 +32,7 @@
   #:use-module (lepton repl)
 
   #:use-module (schematic action)
+  #:use-module (schematic callback)
   #:use-module (schematic gettext)
   #:use-module (schematic ffi)
   #:use-module (schematic dialog)
@@ -83,9 +84,9 @@
 
 ;; -------------------------------------------------------------------
 ;;;; File menu actions
-
 (define-action-public (&file-new #:label (G_ "New File") #:icon "gtk-new")
-  (run-callback i_callback_file_new "&file-new"))
+  (callback-file-new %null-pointer (*current-window)))
+
 
 (define-action-public (&file-open #:label (G_ "Open File") #:icon "gtk-open")
   (run-callback i_callback_file_open "&file-open"))

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -308,7 +308,7 @@
   (run-callback i_callback_page_next "&page-next"))
 
 (define-action-public (&page-close #:label (G_ "Close Page") #:icon "gtk-close")
-  (run-callback i_callback_page_close "&page-close"))
+  (callback-page-close %null-pointer (*current-window)))
 
 (define-action-public (&page-next-tab #:label (G_ "Next Tab") #:icon "gtk-go-forward")
   (x_tabs_next (*current-window)))

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -89,7 +89,7 @@
 
 
 (define-action-public (&file-open #:label (G_ "Open File") #:icon "gtk-open")
-  (run-callback i_callback_file_open "&file-open"))
+  (x_fileselect_open (*current-window)))
 
 (define-action-public (&file-save #:label (G_ "Save") #:icon "gtk-save")
   (run-callback i_callback_file_save "&file-save"))

--- a/libleptongui/scheme/schematic/callback.scm
+++ b/libleptongui/scheme/schematic/callback.scm
@@ -30,7 +30,9 @@
   #:export (callback-file-new
             *callback-file-new
             callback-file-open
-            *callback-file-open))
+            *callback-file-open
+            callback-page-close
+            *callback-page-close))
 
 
 (define (callback-file-new *widget *window)
@@ -53,3 +55,14 @@
 
 (define *callback-file-open
   (procedure->pointer void callback-file-open '(* *)))
+
+
+(define (callback-page-close *widget *window)
+  (let ((*page (schematic_window_get_active_page *window)))
+    (unless (or (null-pointer? *page)
+                (and (true? (lepton_page_get_changed *page))
+                     (not (true? (x_dialog_close_changed_page *window *page)))))
+      (x_window_close_page *window *page))))
+
+(define *callback-page-close
+  (procedure->pointer void callback-page-close '(* *)))

--- a/libleptongui/scheme/schematic/callback.scm
+++ b/libleptongui/scheme/schematic/callback.scm
@@ -28,7 +28,9 @@
   #:use-module (schematic window foreign)
 
   #:export (callback-file-new
-            *callback-file-new))
+            *callback-file-new
+            callback-file-open
+            *callback-file-open))
 
 
 (define (callback-file-new *widget *window)
@@ -44,3 +46,10 @@
 
 (define *callback-file-new
   (procedure->pointer void callback-file-new '(* *)))
+
+
+(define (callback-file-open *widget *window)
+  (x_fileselect_open *window))
+
+(define *callback-file-open
+  (procedure->pointer void callback-file-open '(* *)))

--- a/libleptongui/scheme/schematic/callback.scm
+++ b/libleptongui/scheme/schematic/callback.scm
@@ -1,0 +1,46 @@
+;;; Lepton EDA Schematic Capture
+;;; Scheme API
+;;; Copyright (C) 2022 Lepton EDA Contributors
+;;;
+;;; This program is free software; you can redistribute it and/or modify
+;;; it under the terms of the GNU General Public License as published by
+;;; the Free Software Foundation; either version 2 of the License, or
+;;; (at your option) any later version.
+;;;
+;;; This program is distributed in the hope that it will be useful,
+;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;; GNU General Public License for more details.
+;;;
+;;; You should have received a copy of the GNU General Public License
+;;; along with this program; if not, write to the Free Software
+;;; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
+(define-module (schematic callback)
+  #:use-module (system foreign)
+
+  #:use-module (lepton ffi)
+  #:use-module (lepton gettext)
+  #:use-module (lepton log)
+
+  #:use-module (schematic ffi)
+  #:use-module (schematic window foreign)
+
+  #:export (callback-file-new
+            *callback-file-new))
+
+
+(define (callback-file-new *widget *window)
+  ;; Create a new page.
+  (let ((*page (x_window_open_page *window %null-pointer)))
+    (if (null-pointer? *page)
+        (error (G_ "Could not create a new page."))
+        (begin
+          (x_window_set_current_page *window *page)
+          (log! 'message
+                (G_ "New page created: ~S")
+                (pointer->string (lepton_page_get_filename *page)))))))
+
+(define *callback-file-new
+  (procedure->pointer void callback-file-new '(* *)))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -74,8 +74,6 @@
             i_callback_edit_unembed
             i_callback_edit_unlock
             i_callback_edit_update
-            i_callback_file_open
-            *i_callback_file_open
             i_callback_file_save
             *i_callback_file_save
             i_callback_file_save_all
@@ -251,6 +249,7 @@
             x_event_get_pointer_position
             x_event_key
 
+            x_fileselect_open
             x_fileselect_save
 
             x_image_setup
@@ -502,8 +501,6 @@
 (define-lff i_callback_edit_unembed void '(* *))
 (define-lff i_callback_edit_unlock void '(* *))
 (define-lff i_callback_edit_update void '(* *))
-(define-lff i_callback_file_open void '(* *))
-(define-lfc *i_callback_file_open)
 (define-lff i_callback_file_save void '(* *))
 (define-lfc *i_callback_file_save)
 (define-lff i_callback_file_save_all void '(* *))
@@ -550,6 +547,7 @@
 (define-lff x_event_key '* '(* * *))
 
 ;;; x_fileselect.c
+(define-lff x_fileselect_open void '(*))
 (define-lff x_fileselect_save int '(* * *))
 
 ;;; x_image.c

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -81,8 +81,6 @@
             i_callback_hierarchy_down_schematic
             i_callback_hierarchy_down_symbol
             i_callback_hierarchy_up
-            i_callback_page_close
-            *i_callback_page_close
             i_callback_page_next
             i_callback_page_prev
             i_callback_page_print
@@ -201,6 +199,8 @@
             schematic_snap_mode_to_string
 
             about_dialog
+
+            x_dialog_close_changed_page
 
             coord_dialog
 
@@ -345,6 +345,9 @@
 
 ;;; gschem_about_dialog.c
 (define-lff about_dialog void '(*))
+
+;;; gschem_close_confirmation_dialog.c
+(define-lff x_dialog_close_changed_page int '(* *))
 
 ;;; gschem_coord_dialog.c
 (define-lff coord_dialog void (list '* int int))
@@ -521,8 +524,6 @@
 (define-lff i_callback_view_zoom_full void '(* *))
 (define-lff i_callback_view_zoom_in void '(* *))
 (define-lff i_callback_view_zoom_out void '(* *))
-(define-lff i_callback_page_close void '(* *))
-(define-lfc *i_callback_page_close)
 (define-lff i_callback_page_next void '(* *))
 (define-lff i_callback_page_prev void '(* *))
 (define-lff i_callback_page_print void '(* *))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -74,8 +74,6 @@
             i_callback_edit_unembed
             i_callback_edit_unlock
             i_callback_edit_update
-            i_callback_file_new
-            *i_callback_file_new
             i_callback_file_open
             *i_callback_file_open
             i_callback_file_save
@@ -504,8 +502,6 @@
 (define-lff i_callback_edit_unembed void '(* *))
 (define-lff i_callback_edit_unlock void '(* *))
 (define-lff i_callback_edit_update void '(* *))
-(define-lff i_callback_file_new void '(* *))
-(define-lfc *i_callback_file_new)
 (define-lff i_callback_file_open void '(* *))
 (define-lfc *i_callback_file_open)
 (define-lff i_callback_file_save void '(* *))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -86,6 +86,7 @@
             i_callback_hierarchy_down_symbol
             i_callback_hierarchy_up
             i_callback_page_close
+            *i_callback_page_close
             i_callback_page_next
             i_callback_page_prev
             i_callback_page_print
@@ -309,7 +310,7 @@
 
 ;;; page_select_widget.c
 (define-lff page_select_widget_update void '(*))
-(define-lff page_select_widget_new '* '(* * * *))
+(define-lff page_select_widget_new '* '(* * * * *))
 
 (define-lff o_buffer_init void '())
 (define-lff set_quiet_mode void '())
@@ -528,6 +529,7 @@
 (define-lff i_callback_view_zoom_in void '(* *))
 (define-lff i_callback_view_zoom_out void '(* *))
 (define-lff i_callback_page_close void '(* *))
+(define-lfc *i_callback_page_close)
 (define-lff i_callback_page_next void '(* *))
 (define-lff i_callback_page_prev void '(* *))
 (define-lff i_callback_page_print void '(* *))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -77,6 +77,7 @@
             i_callback_file_new
             *i_callback_file_new
             i_callback_file_open
+            *i_callback_file_open
             i_callback_file_save
             i_callback_file_save_all
             i_callback_file_script
@@ -307,7 +308,7 @@
 
 ;;; page_select_widget.c
 (define-lff page_select_widget_update void '(*))
-(define-lff page_select_widget_new '* '(* *))
+(define-lff page_select_widget_new '* '(* * *))
 
 (define-lff o_buffer_init void '())
 (define-lff set_quiet_mode void '())
@@ -504,6 +505,7 @@
 (define-lff i_callback_file_new void '(* *))
 (define-lfc *i_callback_file_new)
 (define-lff i_callback_file_open void '(* *))
+(define-lfc *i_callback_file_open)
 (define-lff i_callback_file_save void '(* *))
 (define-lff i_callback_file_save_all void '(* *))
 (define-lff i_callback_file_script void '(* *))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -75,6 +75,7 @@
             i_callback_edit_unlock
             i_callback_edit_update
             i_callback_file_new
+            *i_callback_file_new
             i_callback_file_open
             i_callback_file_save
             i_callback_file_save_all
@@ -118,6 +119,7 @@
 
             o_place_invalidate_rubber
 
+            page_select_widget_new
             page_select_widget_update
 
             set_quiet_mode
@@ -161,6 +163,7 @@
             schematic_window_create_menubar
             schematic_window_get_inside_action
             schematic_window_set_key_event_callback
+            schematic_window_set_page_select_widget
             schematic_window_create_page_view
             schematic_window_create_find_text_widget
             schematic_window_create_hide_text_widget
@@ -304,6 +307,7 @@
 
 ;;; page_select_widget.c
 (define-lff page_select_widget_update void '(*))
+(define-lff page_select_widget_new '* '(* *))
 
 (define-lff o_buffer_init void '())
 (define-lff set_quiet_mode void '())
@@ -416,6 +420,7 @@
 (define-lff schematic_window_create_menubar void '(* * *))
 (define-lff schematic_window_get_inside_action int '(*))
 (define-lff schematic_window_set_key_event_callback void '(*))
+(define-lff schematic_window_set_page_select_widget void '(* *))
 (define-lff schematic_window_create_page_view '* '(* *))
 (define-lff schematic_window_create_find_text_widget void '(* *))
 (define-lff schematic_window_create_hide_text_widget void '(* *))
@@ -497,6 +502,7 @@
 (define-lff i_callback_edit_unlock void '(* *))
 (define-lff i_callback_edit_update void '(* *))
 (define-lff i_callback_file_new void '(* *))
+(define-lfc *i_callback_file_new)
 (define-lff i_callback_file_open void '(* *))
 (define-lff i_callback_file_save void '(* *))
 (define-lff i_callback_file_save_all void '(* *))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -76,7 +76,6 @@
             i_callback_edit_update
             i_callback_file_save
             *i_callback_file_save
-            i_callback_file_save_all
             i_callback_file_script
             i_callback_hierarchy_down_schematic
             i_callback_hierarchy_down_symbol
@@ -102,8 +101,10 @@
             i_callback_view_zoom_in
             i_callback_view_zoom_out
 
+            i_set_state_msg
             i_show_state
             i_update_grid_info
+            i_update_menus
 
             make_menu_action
             make_separator_menu_item
@@ -150,10 +151,12 @@
             x_window_close_page
             x_window_new
             x_window_open_page
+            x_window_save_page
             x_window_set_current_page
             x_window_setup
             x_window_setup_draw_events_drawing_area
             x_window_setup_draw_events_main_wnd
+            x_window_untitled_page
             schematic_window_create_app_window
             schematic_window_create_main_box
             schematic_window_create_work_box
@@ -188,6 +191,7 @@
 
             x_tabs_create
             x_tabs_enabled
+            x_tabs_hdr_update
 
             schematic_action_mode_from_string
             schematic_action_mode_to_string
@@ -410,10 +414,12 @@
 ;;; x_window.c
 (define-lff x_window_new '* '(*))
 (define-lff x_window_open_page '* '(* *))
+(define-lff x_window_save_page int '(* * *))
 (define-lff x_window_set_current_page void '(* *))
 (define-lff x_window_setup '* '(*))
 (define-lff x_window_setup_draw_events_drawing_area void '(* *))
 (define-lff x_window_setup_draw_events_main_wnd void '(* *))
+(define-lff x_window_untitled_page int '(*))
 (define-lff x_window_close void '(*))
 (define-lff x_window_close_all void '(*))
 (define-lff x_window_close_page void '(* *))
@@ -453,6 +459,7 @@
 ;;; x_tabs.c
 (define-lff x_tabs_create void '(* *))
 (define-lff x_tabs_enabled int '())
+(define-lff x_tabs_hdr_update void '(* *))
 
 ;;; x_dialog.c
 (define-lff generic_confirm_dialog int '(*))
@@ -506,7 +513,6 @@
 (define-lff i_callback_edit_update void '(* *))
 (define-lff i_callback_file_save void '(* *))
 (define-lfc *i_callback_file_save)
-(define-lff i_callback_file_save_all void '(* *))
 (define-lff i_callback_file_script void '(* *))
 (define-lff i_callback_hierarchy_down_schematic void '(* *))
 (define-lff i_callback_hierarchy_down_symbol void '(* *))
@@ -533,8 +539,10 @@
 (define-lff i_callback_toolbar_edit_select void '(* *))
 
 ;;; i_basic.c
+(define-lff i_set_state_msg void (list '* int '*))
 (define-lff i_show_state void '(* *))
 (define-lff i_update_grid_info void '(*))
+(define-lff i_update_menus void '(*))
 
 ;;; o_place.c
 (define-lff o_place_invalidate_rubber void (list '* int))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -79,6 +79,7 @@
             i_callback_file_open
             *i_callback_file_open
             i_callback_file_save
+            *i_callback_file_save
             i_callback_file_save_all
             i_callback_file_script
             i_callback_hierarchy_down_schematic
@@ -308,7 +309,7 @@
 
 ;;; page_select_widget.c
 (define-lff page_select_widget_update void '(*))
-(define-lff page_select_widget_new '* '(* * *))
+(define-lff page_select_widget_new '* '(* * * *))
 
 (define-lff o_buffer_init void '())
 (define-lff set_quiet_mode void '())
@@ -507,6 +508,7 @@
 (define-lff i_callback_file_open void '(* *))
 (define-lfc *i_callback_file_open)
 (define-lff i_callback_file_save void '(* *))
+(define-lfc *i_callback_file_save)
 (define-lff i_callback_file_save_all void '(* *))
 (define-lff i_callback_file_script void '(* *))
 (define-lff i_callback_hierarchy_down_schematic void '(* *))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -189,6 +189,9 @@
             x_tabs_create
             x_tabs_enabled
 
+            schematic_action_mode_from_string
+            schematic_action_mode_to_string
+
             schematic_grid_mode_from_string
             schematic_grid_mode_to_string
 
@@ -322,6 +325,10 @@
 (define-lff x_widgets_show_object_properties void '(*))
 (define-lff x_widgets_show_options void '(*))
 (define-lff x_widgets_show_page_select void '(*))
+
+;;; action_mode.c
+(define-lff schematic_action_mode_from_string int '(*))
+(define-lff schematic_action_mode_to_string '* (list int))
 
 ;;; grid_mode.c
 (define-lff schematic_grid_mode_from_string int '(*))

--- a/libleptongui/scheme/schematic/toolbar.scm
+++ b/libleptongui/scheme/schematic/toolbar.scm
@@ -124,7 +124,7 @@
                          "document-open"
                          "Open"
                          "Open file"
-                         i_callback_file_open
+                         callback-file-open
                          1)
     (make-toolbar-button *window *toolbar
                          "document-save"

--- a/libleptongui/scheme/schematic/toolbar.scm
+++ b/libleptongui/scheme/schematic/toolbar.scm
@@ -25,6 +25,7 @@
   #:use-module (lepton ffi)
   #:use-module (lepton gettext)
 
+  #:use-module (schematic callback)
   #:use-module (schematic ffi)
 
   #:export (make-toolbar))
@@ -116,7 +117,7 @@
                          "document-new"
                          "New"
                          "New file"
-                         i_callback_file_new
+                         callback-file-new
                          0)
     (make-toolbar-button *window
                          *toolbar

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -142,7 +142,7 @@ GtkApplication structure of the program (when compiled with
       (schematic_window_set_page_select_widget *window
                                                (page_select_widget_new *window
                                                                        *callback-file-new
-                                                                       *i_callback_file_open
+                                                                       *callback-file-open
                                                                        *i_callback_file_save
                                                                        *i_callback_page_close))
       ;; Setup layout of notebooks.

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -141,7 +141,8 @@ GtkApplication structure of the program (when compiled with
       (schematic_window_set_page_select_widget *window
                                                (page_select_widget_new *window
                                                                        *i_callback_file_new
-                                                                       *i_callback_file_open))
+                                                                       *i_callback_file_open
+                                                                       *i_callback_file_save))
       ;; Setup layout of notebooks.
       (schematic_window_create_notebooks *window *main-box *work-box)
 

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -142,7 +142,8 @@ GtkApplication structure of the program (when compiled with
                                                (page_select_widget_new *window
                                                                        *i_callback_file_new
                                                                        *i_callback_file_open
-                                                                       *i_callback_file_save))
+                                                                       *i_callback_file_save
+                                                                       *i_callback_page_close))
       ;; Setup layout of notebooks.
       (schematic_window_create_notebooks *window *main-box *work-box)
 

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -138,7 +138,9 @@ GtkApplication structure of the program (when compiled with
       ;; Setup various widgets.
       (x_widgets_init)
       (x_widgets_create *window)
-
+      (schematic_window_set_page_select_widget *window
+                                               (page_select_widget_new *window
+                                                                       *i_callback_file_new))
       ;; Setup layout of notebooks.
       (schematic_window_create_notebooks *window *main-box *work-box)
 

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -140,7 +140,8 @@ GtkApplication structure of the program (when compiled with
       (x_widgets_create *window)
       (schematic_window_set_page_select_widget *window
                                                (page_select_widget_new *window
-                                                                       *i_callback_file_new))
+                                                                       *i_callback_file_new
+                                                                       *i_callback_file_open))
       ;; Setup layout of notebooks.
       (schematic_window_create_notebooks *window *main-box *work-box)
 

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -144,7 +144,7 @@ GtkApplication structure of the program (when compiled with
                                                                        *callback-file-new
                                                                        *callback-file-open
                                                                        *i_callback_file_save
-                                                                       *i_callback_page_close))
+                                                                       *callback-page-close))
       ;; Setup layout of notebooks.
       (schematic_window_create_notebooks *window *main-box *work-box)
 

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -32,6 +32,7 @@
   #:use-module (lepton toplevel foreign)
   #:use-module (lepton toplevel)
 
+  #:use-module (schematic callback)
   #:use-module (schematic ffi)
   #:use-module (schematic gui keymap)
   #:use-module (schematic menu)
@@ -140,7 +141,7 @@ GtkApplication structure of the program (when compiled with
       (x_widgets_create *window)
       (schematic_window_set_page_select_widget *window
                                                (page_select_widget_new *window
-                                                                       *i_callback_file_new
+                                                                       *callback-file-new
                                                                        *i_callback_file_open
                                                                        *i_callback_file_save
                                                                        *i_callback_page_close))

--- a/libleptongui/src/gschem_toplevel.c
+++ b/libleptongui/src/gschem_toplevel.c
@@ -1090,3 +1090,32 @@ schematic_window_get_place_list (GschemToplevel *w_current)
 
   return lepton_page_get_place_list (active_page);
 }
+
+
+/*! \brief Get Page select widget for this schematic window.
+ *
+ * \param [in] w_current The #GschemToplevel instance.
+ * \return The current Page select widget.
+ */
+GtkWidget*
+schematic_window_get_page_select_widget (GschemToplevel *w_current)
+{
+  g_return_val_if_fail (w_current != NULL, NULL);
+
+  return w_current->page_select_widget;
+}
+
+
+/*! \brief Set Page select widget for this schematic window.
+ *
+ * \param [in] w_current The #GschemToplevel instance.
+ * \param [in] widget The Page select widget.
+ */
+void
+schematic_window_set_page_select_widget (GschemToplevel *w_current,
+                                         GtkWidget* widget)
+{
+  g_return_if_fail (w_current != NULL);
+
+  w_current->page_select_widget = widget;
+}

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -1152,32 +1152,6 @@ i_callback_page_prev (GtkWidget *widget, gpointer data)
   x_window_set_current_page (w_current, p_new);
 }
 
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
-void
-i_callback_page_close (GtkWidget *widget, gpointer data)
-{
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-  g_return_if_fail (w_current != NULL);
-
-  LeptonPage *page = schematic_window_get_active_page (w_current);
-
-  if (page == NULL) {
-    return;
-  }
-
-  if (lepton_page_get_changed (page)
-      && !x_dialog_close_changed_page (w_current, page)) {
-    return;
-  }
-
-  x_window_close_page (w_current, page);
-}
-
-
 
 /*! \todo Finish function documentation!!!
  *  \brief

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -114,62 +114,6 @@ i_callback_file_save (GtkWidget *widget, gpointer data)
 } /* i_callback_file_save() */
 
 
-/*! \brief Save all opened pages
- */
-void
-i_callback_file_save_all (GtkWidget *widget, gpointer data)
-{
-  GschemToplevel* w_current = GSCHEM_TOPLEVEL (data);
-  g_return_if_fail (w_current != NULL);
-
-  LeptonToplevel* toplevel = gschem_toplevel_get_toplevel (w_current);
-  GList*    pages    = lepton_list_get_glist (toplevel->pages);
-
-  gboolean result = TRUE;
-  gboolean res    = FALSE;
-
-  for ( ; pages != NULL; pages = g_list_next (pages) )
-  {
-    LeptonPage* page = (LeptonPage*) pages->data;
-
-    if (x_window_untitled_page (page))
-    {
-      /* open "save as..." dialog: */
-      if (x_fileselect_save (w_current, page, &res))
-      {
-        result = result && res;
-      }
-    }
-    else
-    {
-      /* save page: */
-      const gchar* fname = lepton_page_get_filename (page);
-      res = x_window_save_page (w_current, page, fname);
-      result = result && res;
-    }
-
-
-    if (x_tabs_enabled())
-    {
-      x_tabs_hdr_update (w_current, page);
-    }
-
-    if (result)
-    {
-      i_set_state_msg(w_current, SELECT, _("Saved All"));
-    }
-    else
-    {
-      i_set_state_msg(w_current, SELECT, _("Failed to Save All"));
-    }
-  }
-
-  page_select_widget_update (w_current);
-  i_update_menus(w_current);
-
-} /* i_callback_file_save_all() */
-
-
 /*! \section edit-menu Edit Menu Callback Functions */
 /*! \todo Finish function documentation!!!
  *  \brief

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -25,30 +25,6 @@
 /*! \section callback-intro Callback Functions */
 
 /*! \section file-menu File Menu Callback Functions */
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- *  \note
- *  don't use the widget parameter on this function, or do some checking...
- *  since there is a call: widget = NULL, data = 0 (will be w_current hack)
- *  \todo This should be renamed to page_new perhaps...
- */
-void
-i_callback_file_new (GtkWidget *widget, gpointer data)
-{
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-  LeptonPage *page;
-
-  g_return_if_fail (w_current != NULL);
-
-  /* create a new page */
-  page = x_window_open_page (w_current, NULL);
-  g_return_if_fail (page != NULL);
-
-  x_window_set_current_page (w_current, page);
-  g_message (_("New page created [%1$s]"), lepton_page_get_filename (page));
-}
 
 /*! \todo Finish function documentation!!!
  *  \brief

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -24,29 +24,6 @@
 
 /*! \section callback-intro Callback Functions */
 
-/*! \section file-menu File Menu Callback Functions */
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- *  \note
- *  don't use the widget parameter on this function, or do some
- *  checking...
- *  since there is a call: widget = NULL, data = 0 (will be w_current)
- *  \todo This should be renamed to page_open perhaps...
- */
-void
-i_callback_file_open (GtkWidget *widget, gpointer data)
-{
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-
-  g_return_if_fail (w_current != NULL);
-
-  x_fileselect_open (w_current);
-}
-
-
 /*! \brief Open the "Execute Script" dialog, execute the selected Scheme file
  */
 void

--- a/libleptongui/src/page_select_widget.c
+++ b/libleptongui/src/page_select_widget.c
@@ -60,6 +60,7 @@ widget_create (PageSelectWidget *pagesel);
 static GCallback callback_page_new = NULL;
 static GCallback callback_page_open = NULL;
 static GCallback callback_page_save = NULL;
+static GCallback callback_page_close = NULL;
 
 /*! \brief Create new PageSelectWidget object.
  *  \public
@@ -68,7 +69,8 @@ GtkWidget*
 page_select_widget_new (GschemToplevel* w_current,
                         GCallback page_new_callback,
                         GCallback page_open_callback,
-                        GCallback page_save_callback)
+                        GCallback page_save_callback,
+                        GCallback page_close_callback)
 {
   gpointer obj = g_object_new (PAGE_SELECT_WIDGET_TYPE,
                                "toplevel", w_current,
@@ -76,6 +78,7 @@ page_select_widget_new (GschemToplevel* w_current,
   callback_page_new = G_CALLBACK (page_new_callback);
   callback_page_open = G_CALLBACK (page_open_callback);
   callback_page_save = G_CALLBACK (page_save_callback);
+  callback_page_close = G_CALLBACK (page_close_callback);
   return GTK_WIDGET (obj);
 }
 
@@ -339,8 +342,7 @@ pagesel_callback_popup_close_page (GtkMenuItem* mitem, gpointer data)
 {
   PageSelectWidget* pagesel = (PageSelectWidget*) data;
   GschemToplevel* toplevel = pagesel->toplevel_;
-
-  i_callback_page_close (NULL, toplevel);
+  ((void (*) (GtkWidget*, GschemToplevel*)) callback_page_close) (NULL, toplevel);
 }
 
 

--- a/libleptongui/src/page_select_widget.c
+++ b/libleptongui/src/page_select_widget.c
@@ -58,18 +58,21 @@ static void
 widget_create (PageSelectWidget *pagesel);
 
 static GCallback callback_page_new = NULL;
+static GCallback callback_page_open = NULL;
 
 /*! \brief Create new PageSelectWidget object.
  *  \public
  */
 GtkWidget*
 page_select_widget_new (GschemToplevel* w_current,
-                        GCallback page_new_callback)
+                        GCallback page_new_callback,
+                        GCallback page_open_callback)
 {
   gpointer obj = g_object_new (PAGE_SELECT_WIDGET_TYPE,
                                "toplevel", w_current,
                                NULL);
   callback_page_new = G_CALLBACK (page_new_callback);
+  callback_page_open = G_CALLBACK (page_open_callback);
   return GTK_WIDGET (obj);
 }
 
@@ -309,8 +312,7 @@ pagesel_callback_popup_open_page (GtkMenuItem* mitem, gpointer data)
 {
   PageSelectWidget* pagesel = (PageSelectWidget*) data;
   GschemToplevel* toplevel = pagesel->toplevel_;
-
-  i_callback_file_open (NULL, toplevel);
+  ((void (*) (GtkWidget*, GschemToplevel*)) callback_page_open) (NULL, toplevel);
 }
 
 

--- a/libleptongui/src/page_select_widget.c
+++ b/libleptongui/src/page_select_widget.c
@@ -57,17 +57,19 @@ pagesel_popup_menu (PageSelectWidget* pagesel, GdkEventButton* event);
 static void
 widget_create (PageSelectWidget *pagesel);
 
-
+static GCallback callback_page_new = NULL;
 
 /*! \brief Create new PageSelectWidget object.
  *  \public
  */
 GtkWidget*
-page_select_widget_new (GschemToplevel* w_current)
+page_select_widget_new (GschemToplevel* w_current,
+                        GCallback page_new_callback)
 {
   gpointer obj = g_object_new (PAGE_SELECT_WIDGET_TYPE,
                                "toplevel", w_current,
                                NULL);
+  callback_page_new = G_CALLBACK (page_new_callback);
   return GTK_WIDGET (obj);
 }
 
@@ -295,8 +297,7 @@ pagesel_callback_popup_new_page (GtkMenuItem* mitem, gpointer data)
 {
   PageSelectWidget* pagesel = (PageSelectWidget*) data;
   GschemToplevel* toplevel = pagesel->toplevel_;
-
-  i_callback_file_new (NULL, toplevel);
+  ((void (*) (GtkWidget*, GschemToplevel*)) callback_page_new) (NULL, toplevel);
 }
 
 

--- a/libleptongui/src/page_select_widget.c
+++ b/libleptongui/src/page_select_widget.c
@@ -59,6 +59,7 @@ widget_create (PageSelectWidget *pagesel);
 
 static GCallback callback_page_new = NULL;
 static GCallback callback_page_open = NULL;
+static GCallback callback_page_save = NULL;
 
 /*! \brief Create new PageSelectWidget object.
  *  \public
@@ -66,13 +67,15 @@ static GCallback callback_page_open = NULL;
 GtkWidget*
 page_select_widget_new (GschemToplevel* w_current,
                         GCallback page_new_callback,
-                        GCallback page_open_callback)
+                        GCallback page_open_callback,
+                        GCallback page_save_callback)
 {
   gpointer obj = g_object_new (PAGE_SELECT_WIDGET_TYPE,
                                "toplevel", w_current,
                                NULL);
   callback_page_new = G_CALLBACK (page_new_callback);
   callback_page_open = G_CALLBACK (page_open_callback);
+  callback_page_save = G_CALLBACK (page_save_callback);
   return GTK_WIDGET (obj);
 }
 
@@ -324,8 +327,7 @@ pagesel_callback_popup_save_page (GtkMenuItem* mitem, gpointer data)
 {
   PageSelectWidget* pagesel = (PageSelectWidget*) data;
   GschemToplevel* toplevel = pagesel->toplevel_;
-
-  i_callback_file_save (NULL, toplevel);
+  ((void (*) (GtkWidget*, GschemToplevel*)) callback_page_save) (NULL, toplevel);
 }
 
 

--- a/libleptongui/src/x_widgets.c
+++ b/libleptongui/src/x_widgets.c
@@ -147,8 +147,6 @@ void x_widgets_create (GschemToplevel* w_current)
 
   w_current->font_select_widget = font_select_widget_new (w_current);
 
-  w_current->page_select_widget = page_select_widget_new (w_current);
-
 } /* x_widgets_create() */
 
 


### PR DESCRIPTION
- C functions for translating action mode between C and Scheme have been added.
- Accessors for window's Page select widgets have been added.
- Several C callbacks for the widget have been rewritten in Scheme.
- A new module, `(schematic callback)`, has been added to allow for calling the callbacks from both Scheme and C.
