### PR TITLE
Split up the module (lepton ffi) and improve foreign function definitions.

### DIFF
--- a/liblepton/scheme/Makefile.am
+++ b/liblepton/scheme/Makefile.am
@@ -20,6 +20,7 @@ nobase_dist_scmdata_DATA = \
 	lepton/eval.scm \
 	lepton/ffi.scm \
 	lepton/ffi/boolean.scm \
+	lepton/ffi/check-args.scm \
 	lepton/ffi/glib.scm \
 	lepton/ffi/gobject.scm \
 	lepton/ffi/lff.scm \

--- a/liblepton/scheme/Makefile.am
+++ b/liblepton/scheme/Makefile.am
@@ -19,6 +19,7 @@ nobase_dist_scmdata_DATA = \
 	lepton/gettext.scm \
 	lepton/eval.scm \
 	lepton/ffi.scm \
+	lepton/ffi/boolean.scm \
 	lepton/ffi/lib.scm \
 	lepton/file-system.scm \
 	lepton/gerror.scm \

--- a/liblepton/scheme/Makefile.am
+++ b/liblepton/scheme/Makefile.am
@@ -20,6 +20,7 @@ nobase_dist_scmdata_DATA = \
 	lepton/eval.scm \
 	lepton/ffi.scm \
 	lepton/ffi/boolean.scm \
+	lepton/ffi/gobject.scm \
 	lepton/ffi/lff.scm \
 	lepton/ffi/lib.scm \
 	lepton/file-system.scm \

--- a/liblepton/scheme/Makefile.am
+++ b/liblepton/scheme/Makefile.am
@@ -20,6 +20,7 @@ nobase_dist_scmdata_DATA = \
 	lepton/eval.scm \
 	lepton/ffi.scm \
 	lepton/ffi/boolean.scm \
+	lepton/ffi/glib.scm \
 	lepton/ffi/gobject.scm \
 	lepton/ffi/lff.scm \
 	lepton/ffi/lib.scm \

--- a/liblepton/scheme/Makefile.am
+++ b/liblepton/scheme/Makefile.am
@@ -20,6 +20,7 @@ nobase_dist_scmdata_DATA = \
 	lepton/eval.scm \
 	lepton/ffi.scm \
 	lepton/ffi/boolean.scm \
+	lepton/ffi/lff.scm \
 	lepton/ffi/lib.scm \
 	lepton/file-system.scm \
 	lepton/gerror.scm \

--- a/liblepton/scheme/geda/deprecated.scm
+++ b/liblepton/scheme/geda/deprecated.scm
@@ -26,6 +26,7 @@
  #:use-module (system foreign)
 
  #:use-module (lepton attrib)
+ #:use-module (lepton ffi check-args)
  #:use-module (lepton ffi)
  #:use-module (lepton gettext)
  #:use-module (lepton log)

--- a/liblepton/scheme/lepton/attrib.scm
+++ b/liblepton/scheme/lepton/attrib.scm
@@ -25,6 +25,7 @@
 
   #:use-module (lepton color-map)
   #:use-module (lepton ffi boolean)
+  #:use-module (lepton ffi glib)
   #:use-module (lepton ffi)
   #:use-module (lepton gettext)
   #:use-module (lepton object)

--- a/liblepton/scheme/lepton/attrib.scm
+++ b/liblepton/scheme/lepton/attrib.scm
@@ -25,6 +25,7 @@
 
   #:use-module (lepton color-map)
   #:use-module (lepton ffi boolean)
+  #:use-module (lepton ffi check-args)
   #:use-module (lepton ffi glib)
   #:use-module (lepton ffi)
   #:use-module (lepton gettext)

--- a/liblepton/scheme/lepton/attrib.scm
+++ b/liblepton/scheme/lepton/attrib.scm
@@ -24,6 +24,7 @@
   #:use-module (system foreign)
 
   #:use-module (lepton color-map)
+  #:use-module (lepton ffi boolean)
   #:use-module (lepton ffi)
   #:use-module (lepton gettext)
   #:use-module (lepton object)

--- a/liblepton/scheme/lepton/config.scm
+++ b/liblepton/scheme/lepton/config.scm
@@ -23,6 +23,7 @@
   #:use-module (rnrs bytevectors)
   #:use-module (system foreign)
 
+  #:use-module (lepton ffi boolean)
   #:use-module (lepton ffi)
   #:use-module (lepton gerror)
 

--- a/liblepton/scheme/lepton/config.scm
+++ b/liblepton/scheme/lepton/config.scm
@@ -24,6 +24,7 @@
   #:use-module (system foreign)
 
   #:use-module (lepton ffi boolean)
+  #:use-module (lepton ffi check-args)
   #:use-module (lepton ffi glib)
   #:use-module (lepton ffi)
   #:use-module (lepton gerror)

--- a/liblepton/scheme/lepton/config.scm
+++ b/liblepton/scheme/lepton/config.scm
@@ -24,6 +24,7 @@
   #:use-module (system foreign)
 
   #:use-module (lepton ffi boolean)
+  #:use-module (lepton ffi glib)
   #:use-module (lepton ffi)
   #:use-module (lepton gerror)
 

--- a/liblepton/scheme/lepton/ffi.scm
+++ b/liblepton/scheme/lepton/ffi.scm
@@ -21,6 +21,7 @@
   #:use-module (system foreign)
   #:use-module (srfi srfi-1)
   #:use-module (lepton ffi lib)
+  #:use-module (lepton ffi lff)
 
   #:re-export (libgtk
                liblepton)
@@ -377,24 +378,6 @@
 
             lepton_coord_snap))
 
-
-;;; Brief syntax macro for defining lazy foreign functions.
-(define-syntax define-lff
-  (syntax-rules ()
-    ((_ name type args)
-     (define name
-       (let ((proc (delay (pointer->procedure
-                           type
-                           (dynamic-func (symbol->string (quote name)) liblepton)
-                           args))))
-         (force proc))))
-    ((_ name type args lib)
-     (define name
-       (let ((proc (delay (pointer->procedure
-                           type
-                           (dynamic-func (symbol->string (quote name)) lib)
-                           args))))
-         (force proc))))))
 
 (define-lff g_clear_error void '(*) libglib)
 (define-lff g_free void '(*) libglib)

--- a/liblepton/scheme/lepton/ffi.scm
+++ b/liblepton/scheme/lepton/ffi.scm
@@ -30,11 +30,6 @@
             c-string-array->list
             register-data-dirs
 
-            ;; Helpers.
-            true?
-            TRUE
-            FALSE
-
             error-wrong-type-arg
             check-boolean
             check-coord
@@ -382,11 +377,6 @@
 
             lepton_coord_snap))
 
-;;; Helper to check if result of C function is TRUE (non-zero).
-(define true? (negate zero?))
-;;; Helpers to set results of boolean functions.
-(define TRUE 1)
-(define FALSE 0)
 
 ;;; Brief syntax macro for defining lazy foreign functions.
 (define-syntax define-lff

--- a/liblepton/scheme/lepton/ffi.scm
+++ b/liblepton/scheme/lepton/ffi.scm
@@ -40,7 +40,7 @@
             check-vector
             check-procedure
 
-            ;; glib, gobject.
+            ;; glib
             g_clear_error
             g_free
             g_list_append
@@ -48,7 +48,6 @@
             g_list_remove
             g_list_remove_all
             g_log
-            g_object_unref
             ;; Mock glib functions.
             glist-data
             glist-next
@@ -391,7 +390,6 @@
 (define-lff-lib g_list_remove '* '(* *) libglib)
 (define-lff-lib g_list_remove_all '* '(* *) libglib)
 (define-lff-lib g_log void (list '* int '* '*) libglib)
-(define-lff-lib g_object_unref void '(*) libgobject)
 
 ;;; Glist struct is {data*, next*, prev*}.  We could use libglib
 ;;; functions to get data, but it's easier to parse the struct

--- a/liblepton/scheme/lepton/ffi.scm
+++ b/liblepton/scheme/lepton/ffi.scm
@@ -378,15 +378,20 @@
 
             lepton_coord_snap))
 
+;;; Simplify definition of functions by omitting the library
+;;; argument.
+(define-syntax-rule (define-lff arg ...)
+  (define-lff-lib arg ... liblepton))
 
-(define-lff g_clear_error void '(*) libglib)
-(define-lff g_free void '(*) libglib)
-(define-lff g_list_append '* '(* *) libglib)
-(define-lff g_list_free void '(*) libglib)
-(define-lff g_list_remove '* '(* *) libglib)
-(define-lff g_list_remove_all '* '(* *) libglib)
-(define-lff g_log void (list '* int '* '*) libglib)
-(define-lff g_object_unref void '(*) libgobject)
+
+(define-lff-lib g_clear_error void '(*) libglib)
+(define-lff-lib g_free void '(*) libglib)
+(define-lff-lib g_list_append '* '(* *) libglib)
+(define-lff-lib g_list_free void '(*) libglib)
+(define-lff-lib g_list_remove '* '(* *) libglib)
+(define-lff-lib g_list_remove_all '* '(* *) libglib)
+(define-lff-lib g_log void (list '* int '* '*) libglib)
+(define-lff-lib g_object_unref void '(*) libgobject)
 
 ;;; Glist struct is {data*, next*, prev*}.  We could use libglib
 ;;; functions to get data, but it's easier to parse the struct

--- a/liblepton/scheme/lepton/ffi.scm
+++ b/liblepton/scheme/lepton/ffi.scm
@@ -30,15 +30,6 @@
             c-string-array->list
             register-data-dirs
 
-            error-wrong-type-arg
-            check-boolean
-            check-coord
-            check-integer
-            check-string
-            check-symbol
-            check-vector
-            check-procedure
-
             ;; Foreign functions.
             lepton_init_toplevel_fluid
 
@@ -752,47 +743,3 @@ by POINTER."
   (let ((sys-dirs (c-string-array->list (eda_get_system_data_dirs))))
     (for-each register-data-dir sys-dirs)
     (register-data-dir (pointer->string (eda_get_user_data_dir)))))
-
-
-(define-syntax-rule (error-wrong-type-arg pos type object)
-  (scm-error 'wrong-type-arg
-             (frame-procedure-name (stack-ref (make-stack #t) 1))
-             "Wrong type argument in position ~A (expecting ~A): ~A"
-             (list pos type object)
-             #f))
-
-(define (check-boolean val pos)
-  ;; This function is defined just for consistency.  Someone may
-  ;; get confused if we miss some argument checks. Since any value
-  ;; in Scheme is a boolean in a sense, that is, it is considered
-  ;; to be true if not #f, there is no point to check for real
-  ;; boolean values, #t and #f, using Scheme boolean? function.
-  ;; So we just return #t here.
-  #t)
-
-(define-syntax-rule (check-integer val pos)
-  (unless (integer? val)
-    (error-wrong-type-arg pos 'integer val)))
-
-(define-syntax-rule (check-coord val pos)
-  (unless (and (pair? val)
-               (integer? (car val))
-               (integer? (cdr val)))
-    (error-wrong-type-arg pos "a pair of integers" val)))
-
-(define-syntax-rule (check-string val pos)
-  (unless (string? val)
-    (error-wrong-type-arg pos 'string val)))
-
-(define-syntax-rule (check-symbol val pos)
-  (unless (symbol? val)
-    (error-wrong-type-arg pos 'symbol val)))
-
-(define-syntax-rule (check-vector val pos)
-  (unless (and (list? val)
-               (every integer? val))
-    (error-wrong-type-arg pos "list of integers" val)))
-
-(define-syntax-rule (check-procedure val pos)
-  (unless (procedure? val)
-    (error-wrong-type-arg pos 'procedure val)))

--- a/liblepton/scheme/lepton/ffi/boolean.scm
+++ b/liblepton/scheme/lepton/ffi/boolean.scm
@@ -1,0 +1,32 @@
+;;; Lepton EDA library - Scheme API
+;;; Copyright (C) 2020-2022 Lepton EDA Contributors
+;;;
+;;; This program is free software; you can redistribute it and/or modify
+;;; it under the terms of the GNU General Public License as published by
+;;; the Free Software Foundation; either version 2 of the License, or
+;;; (at your option) any later version.
+;;;
+;;; This program is distributed in the hope that it will be useful,
+;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;; GNU General Public License for more details.
+;;;
+;;; You should have received a copy of the GNU General Public License
+;;; along with this program; if not, write to the Free Software
+;;; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
+(define-module (lepton ffi boolean)
+  #:export (TRUE
+            FALSE
+            true?
+            false?))
+
+
+;;; Helpers to set results of boolean C functions.
+(define TRUE 1)
+(define FALSE 0)
+
+;;; Helpers to check boolean results of C functions.
+(define true? (negate zero?))
+(define false? zero?)

--- a/liblepton/scheme/lepton/ffi/check-args.scm
+++ b/liblepton/scheme/lepton/ffi/check-args.scm
@@ -1,0 +1,81 @@
+;;; Lepton EDA library - Scheme API
+;;; Copyright (C) 2020-2022 Lepton EDA Contributors
+;;;
+;;; This program is free software; you can redistribute it and/or modify
+;;; it under the terms of the GNU General Public License as published by
+;;; the Free Software Foundation; either version 2 of the License, or
+;;; (at your option) any later version.
+;;;
+;;; This program is distributed in the hope that it will be useful,
+;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;; GNU General Public License for more details.
+;;;
+;;; You should have received a copy of the GNU General Public License
+;;; along with this program; if not, write to the Free Software
+;;; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
+;;; Macros for verifying consistency of foreign function arguments.
+
+
+(define-module (lepton ffi check-args)
+  #:export (error-wrong-type-arg
+            check-boolean
+            check-coord
+            check-integer
+            check-string
+            check-symbol
+            check-vector
+            check-procedure))
+
+
+(define-syntax-rule (error-wrong-type-arg pos type object)
+  (scm-error 'wrong-type-arg
+             (frame-procedure-name (stack-ref (make-stack #t) 1))
+             "Wrong type argument in position ~A (expecting ~A): ~A"
+             (list pos type object)
+             #f))
+
+
+(define (check-boolean val pos)
+  ;; This function is defined just for consistency.  Someone may
+  ;; get confused if we miss some argument checks. Since any value
+  ;; in Scheme is a boolean in a sense, that is, it is considered
+  ;; to be true if not #f, there is no point to check for real
+  ;; boolean values, #t and #f, using Scheme boolean? function.
+  ;; So we just return #t here.
+  #t)
+
+
+(define-syntax-rule (check-integer val pos)
+  (unless (integer? val)
+    (error-wrong-type-arg pos 'integer val)))
+
+
+(define-syntax-rule (check-coord val pos)
+  (unless (and (pair? val)
+               (integer? (car val))
+               (integer? (cdr val)))
+    (error-wrong-type-arg pos "a pair of integers" val)))
+
+
+(define-syntax-rule (check-string val pos)
+  (unless (string? val)
+    (error-wrong-type-arg pos 'string val)))
+
+
+(define-syntax-rule (check-symbol val pos)
+  (unless (symbol? val)
+    (error-wrong-type-arg pos 'symbol val)))
+
+
+(define-syntax-rule (check-vector val pos)
+  (unless (and (list? val)
+               (every integer? val))
+    (error-wrong-type-arg pos "list of integers" val)))
+
+
+(define-syntax-rule (check-procedure val pos)
+  (unless (procedure? val)
+    (error-wrong-type-arg pos 'procedure val)))

--- a/liblepton/scheme/lepton/ffi/glib.scm
+++ b/liblepton/scheme/lepton/ffi/glib.scm
@@ -53,10 +53,14 @@
 
 (define-lff g_list_append '* '(* *))
 (define-lff g_list_free void '(*))
+(define-lff g_list_free_full void '(*))
 (define-lff g_list_remove '* '(* *))
 (define-lff g_list_remove_all '* '(* *))
 
 (define-lff g_log void (list '* int '* '*))
+
+(define-lff g_slist_free_full void '(*))
+
 
 ;;; GSList: singly-linked list.
 

--- a/liblepton/scheme/lepton/ffi/glib.scm
+++ b/liblepton/scheme/lepton/ffi/glib.scm
@@ -1,0 +1,90 @@
+;;; Lepton EDA library - Scheme API
+;;; Copyright (C) 2020-2022 Lepton EDA Contributors
+;;;
+;;; This program is free software; you can redistribute it and/or modify
+;;; it under the terms of the GNU General Public License as published by
+;;; the Free Software Foundation; either version 2 of the License, or
+;;; (at your option) any later version.
+;;;
+;;; This program is distributed in the hope that it will be useful,
+;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;; GNU General Public License for more details.
+;;;
+;;; You should have received a copy of the GNU General Public License
+;;; along with this program; if not, write to the Free Software
+;;; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+(define-module (lepton ffi glib)
+  #:use-module (ice-9 match)
+  #:use-module (system foreign)
+
+  #:use-module (lepton ffi lib)
+  #:use-module (lepton ffi lff)
+
+  #:export (g_clear_error
+            g_free
+            g_list_append
+            g_list_free
+            g_list_remove
+            g_list_remove_all
+            g_log
+
+            ;; Mock glib functions.
+            glist-data
+            glist-next
+            glist-prev
+            glist->list))
+
+;;; Simplify definition of functions by omitting the library
+;;; argument.
+(define-syntax-rule (define-lff arg ...)
+  (define-lff-lib arg ... libglib))
+
+
+(define-lff g_clear_error void '(*))
+
+(define-lff g_free void '(*))
+
+(define-lff g_list_append '* '(* *))
+(define-lff g_list_free void '(*))
+(define-lff g_list_remove '* '(* *))
+(define-lff g_list_remove_all '* '(* *))
+
+(define-lff g_log void (list '* int '* '*))
+
+
+;;; Glist struct is {data*, next*, prev*}.  We could use
+;;; functions to get data, but it's easier to parse the struct
+;;; directly.
+(define (parse-glist gls)
+  (parse-c-struct gls '(* * *)))
+
+(define (glist-next gls)
+  (let ((pointer-ls (parse-glist gls)))
+    (match pointer-ls
+      ((data next prev) next)
+      (_ (error "Wrong Glist in glist-next()")))))
+
+(define (glist-prev gls)
+  (let ((pointer-ls (parse-glist gls)))
+    (match pointer-ls
+      ((data next prev) prev)
+      (_ (error "Wrong Glist in glist-prev()")))))
+
+(define (glist-data gls)
+  (let ((pointer-ls (parse-glist gls)))
+    (match pointer-ls
+      ((data next prev) data)
+      (_ (error "Wrong Glist in glist-data()")))))
+
+(define (glist->list gls convert-func)
+  "Convert C GList GLS into Scheme list of objects using the
+function CONVERT-FUNC to transform foreign pointers to Scheme
+objects."
+  (let loop ((gls gls)
+             (ls '()))
+    (if (null-pointer? gls)
+        (reverse ls)
+        (loop (glist-next gls)
+              (cons (convert-func (glist-data gls)) ls)))))

--- a/liblepton/scheme/lepton/ffi/glib.scm
+++ b/liblepton/scheme/lepton/ffi/glib.scm
@@ -54,7 +54,7 @@
 (define-lff g_log void (list '* int '* '*))
 
 
-;;; Glist struct is {data*, next*, prev*}.  We could use
+;;; GList struct is {data*, next*, prev*}.  We could use
 ;;; functions to get data, but it's easier to parse the struct
 ;;; directly.
 (define (parse-glist gls)
@@ -64,19 +64,19 @@
   (let ((pointer-ls (parse-glist gls)))
     (match pointer-ls
       ((data next prev) next)
-      (_ (error "Wrong Glist in glist-next()")))))
+      (_ (error "Wrong GList in glist-next()")))))
 
 (define (glist-prev gls)
   (let ((pointer-ls (parse-glist gls)))
     (match pointer-ls
       ((data next prev) prev)
-      (_ (error "Wrong Glist in glist-prev()")))))
+      (_ (error "Wrong GList in glist-prev()")))))
 
 (define (glist-data gls)
   (let ((pointer-ls (parse-glist gls)))
     (match pointer-ls
       ((data next prev) data)
-      (_ (error "Wrong Glist in glist-data()")))))
+      (_ (error "Wrong GList in glist-data()")))))
 
 (define (glist->list gls convert-func)
   "Convert C GList GLS into Scheme list of objects using the

--- a/liblepton/scheme/lepton/ffi/glib.scm
+++ b/liblepton/scheme/lepton/ffi/glib.scm
@@ -81,14 +81,16 @@
       ((data next) data)
       (_ (error "Wrong GSList in gslist-data()")))))
 
-(define (gslist->list gsls convert-func)
+(define* (gslist->list gsls convert-func #:optional (free? #f))
   "Convert C GSList GSLS into Scheme list of objects using the
 function CONVERT-FUNC to transform foreign pointers to Scheme
 objects."
   (let loop ((gsls gsls)
              (ls '()))
     (if (null-pointer? gsls)
-        (reverse ls)
+        (begin
+          (when free? (g_slist_free_full gsls))
+          (reverse ls))
         (loop (gslist-next gsls)
               (cons (convert-func (gslist-data gsls)) ls)))))
 
@@ -119,13 +121,15 @@ objects."
       ((data next prev) data)
       (_ (error "Wrong GList in glist-data()")))))
 
-(define (glist->list gls convert-func)
+(define* (glist->list gls convert-func #:optional (free? #f))
   "Convert C GList GLS into Scheme list of objects using the
 function CONVERT-FUNC to transform foreign pointers to Scheme
 objects."
   (let loop ((gls gls)
              (ls '()))
     (if (null-pointer? gls)
-        (reverse ls)
+        (begin
+          (when free? (g_list_free_full gls))
+          (reverse ls))
         (loop (glist-next gls)
               (cons (convert-func (glist-data gls)) ls)))))

--- a/liblepton/scheme/lepton/ffi/glib.scm
+++ b/liblepton/scheme/lepton/ffi/glib.scm
@@ -31,6 +31,11 @@
             g_log
 
             ;; Mock glib functions.
+
+            gslist-data
+            gslist-next
+            gslist->list
+
             glist-data
             glist-next
             glist-prev
@@ -53,6 +58,38 @@
 
 (define-lff g_log void (list '* int '* '*))
 
+;;; GSList: singly-linked list.
+
+;;; GSList struct is {data*, next*}.  We could use functions to
+;;; get data, but it's easier to parse the struct directly.
+(define (parse-gslist gsls)
+  (parse-c-struct gsls '(* *)))
+
+(define (gslist-next gsls)
+  (let ((pointer-ls (parse-gslist gsls)))
+    (match pointer-ls
+      ((data next) next)
+      (_ (error "Wrong GSList in gslist-next()")))))
+
+(define (gslist-data gsls)
+  (let ((pointer-ls (parse-gslist gsls)))
+    (match pointer-ls
+      ((data next) data)
+      (_ (error "Wrong GSList in gslist-data()")))))
+
+(define (gslist->list gsls convert-func)
+  "Convert C GSList GSLS into Scheme list of objects using the
+function CONVERT-FUNC to transform foreign pointers to Scheme
+objects."
+  (let loop ((gsls gsls)
+             (ls '()))
+    (if (null-pointer? gsls)
+        (reverse ls)
+        (loop (gslist-next gsls)
+              (cons (convert-func (gslist-data gsls)) ls)))))
+
+
+;;; GList: doubly-linked list.
 
 ;;; GList struct is {data*, next*, prev*}.  We could use
 ;;; functions to get data, but it's easier to parse the struct

--- a/liblepton/scheme/lepton/ffi/gobject.scm
+++ b/liblepton/scheme/lepton/ffi/gobject.scm
@@ -1,0 +1,31 @@
+;;; Lepton EDA library - Scheme API
+;;; Copyright (C) 2020-2022 Lepton EDA Contributors
+;;;
+;;; This program is free software; you can redistribute it and/or modify
+;;; it under the terms of the GNU General Public License as published by
+;;; the Free Software Foundation; either version 2 of the License, or
+;;; (at your option) any later version.
+;;;
+;;; This program is distributed in the hope that it will be useful,
+;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;; GNU General Public License for more details.
+;;;
+;;; You should have received a copy of the GNU General Public License
+;;; along with this program; if not, write to the Free Software
+;;; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+(define-module (lepton ffi gobject)
+  #:use-module (system foreign)
+
+  #:use-module (lepton ffi lib)
+  #:use-module (lepton ffi lff)
+
+  #:export (g_object_unref))
+
+;;; Simplify definition of functions by omitting the library
+;;; argument.
+(define-syntax-rule (define-lff arg ...)
+  (define-lff-lib arg ... libgobject))
+
+(define-lff g_object_unref void '(*))

--- a/liblepton/scheme/lepton/ffi/lff.scm
+++ b/liblepton/scheme/lepton/ffi/lff.scm
@@ -1,0 +1,44 @@
+;;; Lepton EDA library - Scheme API
+;;; Copyright (C) 2020-2022 Lepton EDA Contributors
+;;;
+;;; This program is free software; you can redistribute it and/or modify
+;;; it under the terms of the GNU General Public License as published by
+;;; the Free Software Foundation; either version 2 of the License, or
+;;; (at your option) any later version.
+;;;
+;;; This program is distributed in the hope that it will be useful,
+;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;; GNU General Public License for more details.
+;;;
+;;; You should have received a copy of the GNU General Public License
+;;; along with this program; if not, write to the Free Software
+;;; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
+;;; Syntax macros for defining lazy foreign functions.
+
+(define-module (lepton ffi lff)
+  #:use-module (system foreign)
+
+  #:use-module (lepton ffi lib)
+
+  #:export (define-lff))
+
+
+(define-syntax define-lff
+  (syntax-rules ()
+    ((_ name type args)
+     (define name
+       (let ((proc (delay (pointer->procedure
+                           type
+                           (dynamic-func (symbol->string (quote name)) liblepton)
+                           args))))
+         (force proc))))
+    ((_ name type args lib)
+     (define name
+       (let ((proc (delay (pointer->procedure
+                           type
+                           (dynamic-func (symbol->string (quote name)) lib)
+                           args))))
+         (force proc))))))

--- a/liblepton/scheme/lepton/ffi/lff.scm
+++ b/liblepton/scheme/lepton/ffi/lff.scm
@@ -23,18 +23,12 @@
 
   #:use-module (lepton ffi lib)
 
-  #:export (define-lff))
+  #:export (define-lff-lib))
 
 
-(define-syntax define-lff
+;;; Syntax to define a lazy foreign function from given library.
+(define-syntax define-lff-lib
   (syntax-rules ()
-    ((_ name type args)
-     (define name
-       (let ((proc (delay (pointer->procedure
-                           type
-                           (dynamic-func (symbol->string (quote name)) liblepton)
-                           args))))
-         (force proc))))
     ((_ name type args lib)
      (define name
        (let ((proc (delay (pointer->procedure

--- a/liblepton/scheme/lepton/log.scm
+++ b/liblepton/scheme/lepton/log.scm
@@ -1,6 +1,6 @@
 ;;; Lepton EDA library - Scheme API
 ;;; Copyright (C) 2016 Peter Brett <peter@peter-b.co.uk>
-;;; Copyright (C) 2017-2021 Lepton EDA Contributors
+;;; Copyright (C) 2017-2022 Lepton EDA Contributors
 ;;;
 ;;; This program is free software; you can redistribute it and/or modify
 ;;; it under the terms of the GNU General Public License as published by
@@ -22,6 +22,7 @@
   #:use-module (ice-9 format)
   #:use-module (system foreign)
 
+  #:use-module (lepton ffi glib)
   #:use-module (lepton ffi)
 
   #:export (init-log

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -28,6 +28,7 @@
 
   #:use-module (lepton color-map)
   #:use-module (lepton ffi boolean)
+  #:use-module (lepton ffi gobject)
   #:use-module (lepton ffi)
   #:use-module (lepton object foreign)
   #:use-module (lepton object text)

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -28,6 +28,7 @@
 
   #:use-module (lepton color-map)
   #:use-module (lepton ffi boolean)
+  #:use-module (lepton ffi check-args)
   #:use-module (lepton ffi glib)
   #:use-module (lepton ffi gobject)
   #:use-module (lepton ffi)

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -27,6 +27,7 @@
   #:use-module (rnrs bytevectors)
 
   #:use-module (lepton color-map)
+  #:use-module (lepton ffi boolean)
   #:use-module (lepton ffi)
   #:use-module (lepton object foreign)
   #:use-module (lepton object text)

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -28,6 +28,7 @@
 
   #:use-module (lepton color-map)
   #:use-module (lepton ffi boolean)
+  #:use-module (lepton ffi glib)
   #:use-module (lepton ffi gobject)
   #:use-module (lepton ffi)
   #:use-module (lepton object foreign)

--- a/liblepton/scheme/lepton/object/foreign.scm
+++ b/liblepton/scheme/lepton/object/foreign.scm
@@ -20,6 +20,7 @@
   #:use-module (ice-9 format)
   #:use-module (system foreign)
 
+  #:use-module (lepton ffi check-args)
   #:use-module (lepton ffi)
 
   #:export (is-object?

--- a/liblepton/scheme/lepton/object/text.scm
+++ b/liblepton/scheme/lepton/object/text.scm
@@ -20,6 +20,8 @@
 (define-module (lepton object text)
   #:use-module (ice-9 match)
   #:use-module (system foreign)
+
+  #:use-module (lepton ffi check-args)
   #:use-module (lepton ffi)
 
   #:export (check-text-alignment

--- a/liblepton/scheme/lepton/object/type.scm
+++ b/liblepton/scheme/lepton/object/type.scm
@@ -21,6 +21,7 @@
 (define-module (lepton object type)
   #:use-module (system foreign)
 
+  #:use-module (lepton ffi boolean)
   #:use-module (lepton ffi)
   #:use-module (lepton object foreign)
 

--- a/liblepton/scheme/lepton/object/type.scm
+++ b/liblepton/scheme/lepton/object/type.scm
@@ -22,6 +22,7 @@
   #:use-module (system foreign)
 
   #:use-module (lepton ffi boolean)
+  #:use-module (lepton ffi check-args)
   #:use-module (lepton ffi)
   #:use-module (lepton object foreign)
 

--- a/liblepton/scheme/lepton/page.scm
+++ b/liblepton/scheme/lepton/page.scm
@@ -27,6 +27,7 @@
   #:use-module (rnrs bytevectors)
   #:use-module (system foreign)
 
+  #:use-module (lepton ffi boolean)
   #:use-module (lepton ffi)
   #:use-module (lepton gerror)
   #:use-module (lepton object type)

--- a/liblepton/scheme/lepton/page.scm
+++ b/liblepton/scheme/lepton/page.scm
@@ -28,6 +28,7 @@
   #:use-module (system foreign)
 
   #:use-module (lepton ffi boolean)
+  #:use-module (lepton ffi glib)
   #:use-module (lepton ffi)
   #:use-module (lepton gerror)
   #:use-module (lepton object type)

--- a/liblepton/scheme/lepton/page.scm
+++ b/liblepton/scheme/lepton/page.scm
@@ -28,6 +28,7 @@
   #:use-module (system foreign)
 
   #:use-module (lepton ffi boolean)
+  #:use-module (lepton ffi check-args)
   #:use-module (lepton ffi glib)
   #:use-module (lepton ffi)
   #:use-module (lepton gerror)

--- a/liblepton/scheme/lepton/page/foreign.scm
+++ b/liblepton/scheme/lepton/page/foreign.scm
@@ -20,6 +20,7 @@
   #:use-module (ice-9 format)
   #:use-module (system foreign)
 
+  #:use-module (lepton ffi check-args)
   #:use-module (lepton ffi)
 
   #:export (is-page?

--- a/liblepton/scheme/lepton/toplevel/foreign.scm
+++ b/liblepton/scheme/lepton/toplevel/foreign.scm
@@ -20,6 +20,7 @@
   #:use-module (ice-9 format)
   #:use-module (system foreign)
 
+  #:use-module (lepton ffi check-args)
   #:use-module (lepton ffi)
 
   #:export (is-toplevel?

--- a/libleptongui/scheme/schematic/attrib.scm
+++ b/libleptongui/scheme/schematic/attrib.scm
@@ -22,6 +22,7 @@
   #:use-module (system foreign)
 
   #:use-module (lepton config)
+  #:use-module (lepton ffi check-args)
   #:use-module (lepton ffi boolean)
   #:use-module (lepton ffi)
   #:use-module (lepton log)

--- a/libleptongui/scheme/schematic/attrib.scm
+++ b/libleptongui/scheme/schematic/attrib.scm
@@ -22,6 +22,7 @@
   #:use-module (system foreign)
 
   #:use-module (lepton config)
+  #:use-module (lepton ffi boolean)
   #:use-module (lepton ffi)
   #:use-module (lepton log)
   #:use-module (lepton object)

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -25,6 +25,7 @@
   #:use-module (system foreign)
 
   #:use-module (lepton attrib)
+  #:use-module (lepton ffi boolean)
   #:use-module (lepton ffi)
   #:use-module (lepton log)
   #:use-module (lepton object)

--- a/libleptongui/scheme/schematic/callback.scm
+++ b/libleptongui/scheme/schematic/callback.scm
@@ -20,6 +20,7 @@
 (define-module (schematic callback)
   #:use-module (system foreign)
 
+  #:use-module (lepton ffi boolean)
   #:use-module (lepton ffi)
   #:use-module (lepton gettext)
   #:use-module (lepton log)

--- a/libleptongui/scheme/schematic/dialog.scm
+++ b/libleptongui/scheme/schematic/dialog.scm
@@ -21,6 +21,7 @@
   #:use-module (srfi srfi-1)
   #:use-module (system foreign)
 
+  #:use-module (lepton ffi glib)
   #:use-module (lepton ffi)
   #:use-module (lepton log)
   #:use-module (schematic ffi)

--- a/libleptongui/scheme/schematic/dialog/slot-edit.scm
+++ b/libleptongui/scheme/schematic/dialog/slot-edit.scm
@@ -22,6 +22,7 @@
   #:use-module (system foreign)
 
   #:use-module (lepton attrib)
+  #:use-module (lepton ffi boolean)
   #:use-module (lepton ffi)
 
   #:use-module (schematic ffi)

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -20,6 +20,7 @@
   #:use-module (system foreign)
   #:use-module (srfi srfi-9)
 
+  #:use-module (lepton ffi lff)
   #:use-module (lepton ffi lib)
   #:use-module (lepton ffi)
 
@@ -269,16 +270,10 @@
 (define libleptongui
   (dynamic-link (or (getenv "LIBLEPTONGUI") %libleptongui)))
 
-;;; Brief syntax macro for defining lazy foreign functions.
-(define-syntax define-lff
-  (syntax-rules ()
-    ((_ name type args)
-     (define name
-       (let ((proc (delay (pointer->procedure
-                           type
-                           (dynamic-func (symbol->string (quote name)) libleptongui)
-                           args))))
-         (force proc))))))
+;;; Simplify definition of functions by omitting the library
+;;; argument.
+(define-syntax-rule (define-lff arg ...)
+  (define-lff-lib arg ... libleptongui))
 
 
 ;;; Brief syntax macro for defining lazy foreign callbacks.

--- a/libleptongui/scheme/schematic/ffi/gtk.scm
+++ b/libleptongui/scheme/schematic/ffi/gtk.scm
@@ -43,16 +43,6 @@
   (define-lff-lib arg ... libgtk))
 
 
-(define (gtk_window_set_default_icon_name name)
-  (let ((proc (delay
-                (pointer->procedure
-                 void
-                 (dynamic-func "gtk_window_set_default_icon_name"
-                               libgtk)
-                 (list '*)))))
-    ((force proc) (string->pointer name))))
-
-
 (define (gtk_icon_theme_append_search_path icon-theme path)
   (define proc
     (delay
@@ -82,3 +72,5 @@
 (define-lff gtk_tearoff_menu_item_new '* '())
 
 (define-lff gtk_widget_show void '(*))
+
+(define-lff gtk_window_set_default_icon_name void '(*))

--- a/libleptongui/scheme/schematic/ffi/gtk.scm
+++ b/libleptongui/scheme/schematic/ffi/gtk.scm
@@ -43,15 +43,6 @@
   (define-lff-lib arg ... libgtk))
 
 
-(define (gtk_rc_parse filename)
-  (define proc
-    (delay (pointer->procedure
-            void
-            (dynamic-func "gtk_rc_parse" libgtk)
-            (list '*))))
-  ((force proc) (string->pointer filename)))
-
-
 (define (gtk_window_set_default_icon_name name)
   (let ((proc (delay
                 (pointer->procedure
@@ -85,6 +76,8 @@
 (define-lff gtk_menu_bar_new '* '())
 (define-lff gtk_menu_item_set_submenu void '(* *))
 (define-lff gtk_menu_shell_append void '(* *))
+
+(define-lff gtk_rc_parse void '(*))
 
 (define-lff gtk_tearoff_menu_item_new '* '())
 

--- a/libleptongui/scheme/schematic/ffi/gtk.scm
+++ b/libleptongui/scheme/schematic/ffi/gtk.scm
@@ -18,6 +18,7 @@
 
 (define-module (schematic ffi gtk)
   #:use-module (system foreign)
+  #:use-module (lepton ffi lff)
   #:use-module (lepton ffi)
 
   #:export (gtk_init
@@ -36,15 +37,11 @@
             gtk_menu_item_set_submenu
             gtk_menu_shell_append))
 
-(define-syntax define-lff
-  (syntax-rules ()
-    ((_ name type args)
-     (define name
-       (let ((proc (delay (pointer->procedure
-                           type
-                           (dynamic-func (symbol->string (quote name)) libgtk)
-                           args))))
-         (force proc))))))
+;;; Simplify definition of functions by omitting the library
+;;; argument.
+(define-syntax-rule (define-lff arg ...)
+  (define-lff-lib arg ... libgtk))
+
 
 (define gtk_init
   (pointer->procedure

--- a/libleptongui/scheme/schematic/ffi/gtk.scm
+++ b/libleptongui/scheme/schematic/ffi/gtk.scm
@@ -43,12 +43,6 @@
   (define-lff-lib arg ... libgtk))
 
 
-(define gtk_init
-  (pointer->procedure
-   void
-   (dynamic-func "gtk_init" libgtk)
-   (list '* '*)))
-
 (define (gtk_rc_parse filename)
   (define proc
     (delay (pointer->procedure
@@ -68,16 +62,6 @@
     ((force proc) (string->pointer name))))
 
 
-(define (gtk_icon_theme_get_default)
-  (define proc
-    (delay
-      (pointer->procedure
-       '*
-       (dynamic-func "gtk_icon_theme_get_default" libgtk)
-       '())))
-  ((force proc)))
-
-
 (define (gtk_icon_theme_append_search_path icon-theme path)
   (define proc
     (delay
@@ -91,6 +75,11 @@
 (define GdkModifierType uint32)
 (define-lff gtk_accelerator_name '* (list int GdkModifierType))
 (define-lff gtk_accelerator_get_label '* (list int GdkModifierType))
+
+(define-lff gtk_icon_theme_get_default '* '())
+
+(define-lff gtk_init void '(* *))
+
 (define-lff gtk_menu_item_new_with_mnemonic '* '(*))
 (define-lff gtk_widget_show void '(*))
 (define-lff gtk_tearoff_menu_item_new '* '())

--- a/libleptongui/scheme/schematic/ffi/gtk.scm
+++ b/libleptongui/scheme/schematic/ffi/gtk.scm
@@ -81,9 +81,11 @@
 (define-lff gtk_init void '(* *))
 
 (define-lff gtk_menu_item_new_with_mnemonic '* '(*))
-(define-lff gtk_widget_show void '(*))
-(define-lff gtk_tearoff_menu_item_new '* '())
 (define-lff gtk_menu_new '* '())
 (define-lff gtk_menu_bar_new '* '())
 (define-lff gtk_menu_item_set_submenu void '(* *))
 (define-lff gtk_menu_shell_append void '(* *))
+
+(define-lff gtk_tearoff_menu_item_new '* '())
+
+(define-lff gtk_widget_show void '(*))

--- a/libleptongui/scheme/schematic/ffi/gtk.scm
+++ b/libleptongui/scheme/schematic/ffi/gtk.scm
@@ -43,20 +43,12 @@
   (define-lff-lib arg ... libgtk))
 
 
-(define (gtk_icon_theme_append_search_path icon-theme path)
-  (define proc
-    (delay
-      (pointer->procedure
-       void
-       (dynamic-func "gtk_icon_theme_append_search_path" libgtk)
-       (list '* '*))))
-  ((force proc) icon-theme (string->pointer path)))
-
 (define-lff gtk_accelerator_parse void '(* * *))
 (define GdkModifierType uint32)
 (define-lff gtk_accelerator_name '* (list int GdkModifierType))
 (define-lff gtk_accelerator_get_label '* (list int GdkModifierType))
 
+(define-lff gtk_icon_theme_append_search_path void '(* *))
 (define-lff gtk_icon_theme_get_default '* '())
 
 (define-lff gtk_init void '(* *))

--- a/libleptongui/scheme/schematic/gui/keymap.scm
+++ b/libleptongui/scheme/schematic/gui/keymap.scm
@@ -21,6 +21,7 @@
   #:use-module (srfi srfi-1)
   #:use-module (system foreign)
 
+  #:use-module (lepton ffi boolean)
   #:use-module (lepton ffi)
   #:use-module (lepton log)
 

--- a/libleptongui/scheme/schematic/keymap.scm
+++ b/libleptongui/scheme/schematic/keymap.scm
@@ -28,6 +28,7 @@
   #:use-module (srfi srfi-9 gnu)
   #:use-module (system foreign)
 
+  #:use-module (lepton ffi glib)
   #:use-module (lepton ffi)
 
   #:use-module (schematic gettext)

--- a/libleptongui/scheme/schematic/keymap.scm
+++ b/libleptongui/scheme/schematic/keymap.scm
@@ -28,6 +28,7 @@
   #:use-module (srfi srfi-9 gnu)
   #:use-module (system foreign)
 
+  #:use-module (lepton ffi check-args)
   #:use-module (lepton ffi glib)
   #:use-module (lepton ffi)
 

--- a/libleptongui/scheme/schematic/selection.scm
+++ b/libleptongui/scheme/schematic/selection.scm
@@ -21,6 +21,7 @@
 (define-module (schematic selection)
   #:use-module (system foreign)
 
+  #:use-module (lepton ffi boolean)
   #:use-module (lepton ffi)
   #:use-module (lepton page foreign)
   #:use-module (lepton object foreign)

--- a/libleptongui/scheme/schematic/selection.scm
+++ b/libleptongui/scheme/schematic/selection.scm
@@ -22,6 +22,7 @@
   #:use-module (system foreign)
 
   #:use-module (lepton ffi boolean)
+  #:use-module (lepton ffi glib)
   #:use-module (lepton ffi)
   #:use-module (lepton page foreign)
   #:use-module (lepton object foreign)

--- a/libleptongui/scheme/schematic/util.scm
+++ b/libleptongui/scheme/schematic/util.scm
@@ -22,6 +22,7 @@
   #:use-module (system foreign)
 
   #:use-module (lepton ffi boolean)
+  #:use-module (lepton ffi glib)
   #:use-module (lepton ffi)
   #:use-module (lepton gerror)
 

--- a/libleptongui/scheme/schematic/util.scm
+++ b/libleptongui/scheme/schematic/util.scm
@@ -21,6 +21,7 @@
   #:use-module (rnrs bytevectors)
   #:use-module (system foreign)
 
+  #:use-module (lepton ffi boolean)
   #:use-module (lepton ffi)
   #:use-module (lepton gerror)
 

--- a/libleptongui/scheme/schematic/util.scm
+++ b/libleptongui/scheme/schematic/util.scm
@@ -22,6 +22,7 @@
   #:use-module (system foreign)
 
   #:use-module (lepton ffi boolean)
+  #:use-module (lepton ffi check-args)
   #:use-module (lepton ffi glib)
   #:use-module (lepton ffi)
   #:use-module (lepton gerror)

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -24,6 +24,7 @@
   #:use-module (system foreign)
 
   #:use-module (lepton config)
+  #:use-module (lepton ffi boolean)
   #:use-module (lepton ffi)
   #:use-module (lepton gettext)
   #:use-module (lepton log)

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -25,6 +25,7 @@
 
   #:use-module (lepton config)
   #:use-module (lepton ffi boolean)
+  #:use-module (lepton ffi check-args)
   #:use-module (lepton ffi)
   #:use-module (lepton gettext)
   #:use-module (lepton log)

--- a/libleptongui/scheme/schematic/window/foreign.scm
+++ b/libleptongui/scheme/schematic/window/foreign.scm
@@ -20,6 +20,7 @@
   #:use-module (ice-9 format)
   #:use-module (system foreign)
 
+  #:use-module (lepton ffi check-args)
   #:use-module (lepton ffi)
 
   #:export (is-window?

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -21,6 +21,8 @@
              (ice-9 receive)
              (srfi srfi-1)
              (system foreign)
+
+             (lepton ffi glib)
              (lepton ffi lib)
              (lepton ffi)
              (lepton file-system)
@@ -100,16 +102,6 @@ Lepton EDA homepage: ~S
           "Could not open file ~S.\n"
           filename))
 
-(define (gslist->list gslist)
-  (let loop ((gsls gslist)
-             (ls '()))
-    (if (null-pointer? gsls)
-        ls
-        (let* ((elem (parse-c-struct gsls (list '* '*)))
-               (str (pointer->string (first elem)))
-               (gsls (second elem)))
-          (loop gsls (cons str ls))))))
-
 
 (define (process-gafrc* name)
   (process-gafrc "lepton-attrib" name))
@@ -147,7 +139,7 @@ Lepton EDA homepage: ~S
           (let ((files (if (null? readable-files)
                            ;; No files specified on the command
                            ;; line, pop up the File open dialog.
-                           (gslist->list (x_fileselect_open))
+                           (gslist->list (x_fileselect_open) pointer->string 'free)
                            readable-files)))
             (if (null? files)
                 (exit 0)

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -23,6 +23,7 @@
              (system foreign)
 
              (lepton ffi glib)
+             (lepton ffi lff)
              (lepton ffi lib)
              (lepton ffi)
              (lepton file-system)
@@ -39,31 +40,20 @@
   (register-data-dirs))
 
 
+;;; Simplify definition of functions by omitting the library
+;;; argument.
+(define-syntax-rule (define-lff arg ...)
+  (define-lff-lib arg ... libleptonattrib))
+
+
 (define libleptonattrib (dynamic-link %libleptonattrib))
 
-(define gtk_init
-  (pointer->procedure
-   void
-   (dynamic-func "gtk_init" libgtk)
-   (list '* '*)))
+(define-lff-lib gtk_init void '(* *) libgtk)
 
-(define set_verbose_mode
-  (pointer->procedure
-   void
-   (dynamic-func "set_verbose_mode" libleptonattrib)
-   '()))
+(define-lff set_verbose_mode void '())
+(define-lff x_fileselect_open '* '())
+(define-lff lepton_attrib_window int '(*))
 
-(define x_fileselect_open
-  (pointer->procedure
-   '*
-   (dynamic-func "x_fileselect_open" libleptonattrib)
-   '()))
-
-(define lepton_attrib_window
-  (pointer->procedure
-   int
-   (dynamic-func "lepton_attrib_window" libleptonattrib)
-   '(*)))
 
 ;;; Localization.
 (define %textdomain "libleptonattrib")

--- a/tools/schematic/lepton-schematic.scm
+++ b/tools/schematic/lepton-schematic.scm
@@ -212,7 +212,7 @@ Run `~A --help' for more information.\n")
                                        file-name-separator-string
                                        "icons")))
           (gtk_icon_theme_append_search_path (gtk_icon_theme_get_default)
-                                             icon-dir)
+                                             (string->pointer icon-dir))
           (loop (cdr sys-dirs))))))
 
 

--- a/tools/schematic/lepton-schematic.scm
+++ b/tools/schematic/lepton-schematic.scm
@@ -170,7 +170,8 @@ Run `~A --help' for more information.\n")
     '())))
 
 
-;;; Load GTK resource files.
+;;; Load GTK2 resource files.
+;;; TODO: disable it in GTK3 version.
 ;;; Search system and user configuration directories for
 ;;; lepton-gtkrc files and load them in sequence.
 (define (parse-gtkrc)
@@ -181,7 +182,7 @@ Run `~A --help' for more information.\n")
                                        file-name-separator-string
                                        "lepton-gtkrc")))
           (when (file-readable? filename)
-            (gtk_rc_parse filename))
+            (gtk_rc_parse (string->pointer filename)))
           (loop (cdr dirs))))))
 
 

--- a/tools/schematic/lepton-schematic.scm
+++ b/tools/schematic/lepton-schematic.scm
@@ -171,19 +171,21 @@ Run `~A --help' for more information.\n")
 
 
 ;;; Load GTK2 resource files.
-;;; TODO: disable it in GTK3 version.
 ;;; Search system and user configuration directories for
 ;;; lepton-gtkrc files and load them in sequence.
 (define (parse-gtkrc)
-  (let loop ((dirs (append (sys-config-dirs)
-                           (list (user-config-dir)))))
-    (or (null? dirs)
-        (let ((filename (string-append (car dirs)
-                                       file-name-separator-string
-                                       "lepton-gtkrc")))
-          (when (file-readable? filename)
-            (gtk_rc_parse (string->pointer filename)))
-          (loop (cdr dirs))))))
+  ;; Note: the function gtk_rc_parse() is deprecated in GTK3 so
+  ;; the code below is disabled in the GTK3 port.
+  (unless %m4-use-gtk3
+    (let loop ((dirs (append (sys-config-dirs)
+                             (list (user-config-dir)))))
+      (or (null? dirs)
+          (let ((filename (string-append (car dirs)
+                                         file-name-separator-string
+                                         "lepton-gtkrc")))
+            (when (file-readable? filename)
+              (gtk_rc_parse (string->pointer filename)))
+            (loop (cdr dirs)))))))
 
 
 
@@ -294,7 +296,7 @@ Run `~A --help' for more information.\n")
 (x_color_init)
 (o_undo_init)
 
-;;; Parse custom GTK resource files.
+;;; Parse custom GTK resource files.  Used only for GTK2.
 (parse-gtkrc)
 
 ;;; Set default icon theme and make sure we can find our own

--- a/tools/schematic/lepton-schematic.scm
+++ b/tools/schematic/lepton-schematic.scm
@@ -196,7 +196,7 @@ Run `~A --help' for more information.\n")
 (define (set-window-default-icon)
   (define %theme-icon-name "lepton-schematic")
 
-  (gtk_window_set_default_icon_name %theme-icon-name))
+  (gtk_window_set_default_icon_name (string->pointer %theme-icon-name)))
 
 ;;; Setup icon search paths.
 ;;; Add the icons installed by the program to the search path for


### PR DESCRIPTION
- A new module, `(lepton ffi boolean)`, has been created.  It
  contains variables and procedures for working with foreign C
  boolean values.
- A new module, `(lepton ffi lff)`, has been introduced.  The
  syntax `define-lff()` has been moved to it and renamed to
  `define-lff-lib()`.  The syntax has been splitted up and renamed
  in order to re-use it in different places for different goals
  without many changes in the code.  This allowed for simplifying
  several definitions in the module `(schematic ffi gtk)`, and in
  the tools `lepton-schematic` and `lepton-attrib`.
- The function `gtk_rc_parse()` deprecated in GTK3 is no longer
  called in Scheme for GTK3 port.
- Two new modules, `(lepton ffi gobject)` and `(lepton ffi glib)`,
  have been introduced to localize `libgobject` and `libglib`
  functions and separate their definitions from Lepton functions.
- A new module, `(lepton ffi check-args)`, now contains functions
  for checking arguments of foreign functions.
- Scheme accessors for `GSList` lists and foreign functions for
  freeing all memory of `GSList`s and `GList`s have been
  introduced in the module `(lepton ffi glib)`.  Along with a new
  optional argument that enables or disables memory freeing this
  allowed for simplifying some Scheme procedures working with
  lists in `lepton-attrib`.