### PR TITLE
Fix option --extract of lepton-archive

### DIFF
--- a/tests/archive.test
+++ b/tests/archive.test
@@ -102,6 +102,8 @@
     (receive (<status> <stdout> <stderr>)
         (command-values lepton-archive "--extract" tarball)
       (test-eq EXIT_SUCCESS <status>)
+      ;; Tarball must not be deleted.
+      (test-assert (file-exists? tarball))
       (test-assert (file-exists? "./hierarchy/cache/subsub.sch"))
       (test-assert (file-exists? "./hierarchy/cache/resistor.sym"))
       (test-assert (file-exists? "./hierarchy/cache/in.sym"))
@@ -122,6 +124,8 @@
                         "--extract"
                         (build-filename ".." tarball))
       (test-eq EXIT_SUCCESS <status>)
+      ;; Tarball must not be deleted.
+      (test-assert (file-exists? (build-filename ".." tarball)))
       (test-assert (file-exists? "./hierarchy/cache/subsub.sch"))
       (test-assert (file-exists? "./hierarchy/cache/resistor.sym"))
       (test-assert (file-exists? "./hierarchy/cache/in.sym"))

--- a/tests/archive.test
+++ b/tests/archive.test
@@ -96,7 +96,41 @@
       (test-assert (string-contains <stdout> "hierarchy/cache/sub.sch"))
       (test-assert (string-contains <stdout> "hierarchy/cache/sub.sym"))
       (test-assert (string-contains <stdout> "hierarchy/gafrc"))
-      (test-assert (string-contains <stdout> "hierarchy/sch.sch"))))
+      (test-assert (string-contains <stdout> "hierarchy/sch.sch")))
+
+    ;; Test extracting the archive using lepton-archive.
+    (receive (<status> <stdout> <stderr>)
+        (command-values lepton-archive "--extract" tarball)
+      (test-eq EXIT_SUCCESS <status>)
+      (test-assert (file-exists? "./hierarchy/cache/subsub.sch"))
+      (test-assert (file-exists? "./hierarchy/cache/resistor.sym"))
+      (test-assert (file-exists? "./hierarchy/cache/in.sym"))
+      (test-assert (file-exists? "./hierarchy/cache/subsub.sym"))
+      (test-assert (file-exists? "./hierarchy/cache/out.sym"))
+      (test-assert (file-exists? "./hierarchy/cache/sub.sch"))
+      (test-assert (file-exists? "./hierarchy/cache/sub.sym"))
+      (test-assert (file-exists? "./hierarchy/gafrc"))
+      (test-assert (file-exists? "./hierarchy/sch.sch")))
+
+    ;; Test extracting the archive with relative paths.
+    (mkdir "EXT")
+    (chdir "EXT")
+    (test-assert (not (file-exists? "./hierarchy/")))
+    ;; Test extracting the archive using lepton-archive.
+    (receive (<status> <stdout> <stderr>)
+        (command-values lepton-archive
+                        "--extract"
+                        (build-filename ".." tarball))
+      (test-eq EXIT_SUCCESS <status>)
+      (test-assert (file-exists? "./hierarchy/cache/subsub.sch"))
+      (test-assert (file-exists? "./hierarchy/cache/resistor.sym"))
+      (test-assert (file-exists? "./hierarchy/cache/in.sym"))
+      (test-assert (file-exists? "./hierarchy/cache/subsub.sym"))
+      (test-assert (file-exists? "./hierarchy/cache/out.sym"))
+      (test-assert (file-exists? "./hierarchy/cache/sub.sch"))
+      (test-assert (file-exists? "./hierarchy/cache/sub.sym"))
+      (test-assert (file-exists? "./hierarchy/gafrc"))
+      (test-assert (file-exists? "./hierarchy/sch.sch"))))
 
   (test-teardown))
 

--- a/tools/archive/lepton-archive.scm
+++ b/tools/archive/lepton-archive.scm
@@ -800,9 +800,6 @@ Your new archive lives in ~S\n" temp/output.tar.gz))))
     (debug-format "Extracting ~S" filename)
     (system* "tar" "-f" archive-filename "-x" filename))
 
-  (define (is-simple-file? file)
-    (string=? (basename file) file))
-
   (define (extract-from-archive filename.tar.gz)
     (debug-format "Trying to extract archive ~S." filename.tar.gz)
 

--- a/tools/archive/lepton-archive.scm
+++ b/tools/archive/lepton-archive.scm
@@ -819,10 +819,10 @@ If this archive was created using lepton-archive, you can rename it using
 the file manually.\n"))
 
     ;; Gunzip the file.
-    (system* "gunzip" "-f" filename.tar.gz)
+    (system* "gunzip" "-f" (basename filename.tar.gz))
     (let* (
            ;; Get rid of the ".gz" suffix.
-           (filename.tar (string-drop-right filename.tar.gz 3))
+           (filename.tar (string-drop-right (basename filename.tar.gz) 3))
            ;; Get list of files in the archive.
            (return-string (get-command-output (string-append "tar -t -f " filename.tar)))
            (filename-list (filter string-not-null? (string-split return-string #\newline))))


### PR DESCRIPTION
- Fixed failures on extracting archives with relative paths.
- Removed temporary directory creation when extracting.
Closes #940