### PR TITLE
Rewrite undo callbacks in Scheme

### DIFF
--- a/libleptongui/include/gschem_defines.h
+++ b/libleptongui/include/gschem_defines.h
@@ -70,10 +70,6 @@
  * constants, so be sure not to clash with those */
 #define LAST_DRAWB_MODE_NONE -1
 
-/* used in o_undo_callback */
-#define UNDO_ACTION             0
-#define REDO_ACTION             1
-
 /* used for undo_type */
 #define UNDO_DISK               0
 #define UNDO_MEMORY             1

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -100,7 +100,6 @@ void i_update_net_options_status (GschemToplevel* w_current);
 /* i_callbacks.c */
 void i_callback_file_script (GtkWidget *widget, gpointer data);
 void i_callback_file_save (GtkWidget *widget, gpointer data);
-void i_callback_edit_redo (GtkWidget *widget, gpointer data);
 void i_callback_edit_select (GtkWidget *widget, gpointer data);
 void i_callback_toolbar_edit_select(GtkWidget *widget, gpointer data);
 void i_callback_edit_select_all (GtkWidget *widget, gpointer data);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -423,7 +423,7 @@ o_undo_find_prev_object_head (LeptonUndo *start);
 void
 o_undo_callback (GschemToplevel *w_current,
                  LeptonPage *page,
-                 int type);
+                 gboolean redo);
 void o_undo_cleanup(void);
 /* s_stretch.c */
 GList *s_stretch_add(GList *list, LeptonObject *object, int whichone);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -100,7 +100,6 @@ void i_update_net_options_status (GschemToplevel* w_current);
 /* i_callbacks.c */
 void i_callback_file_script (GtkWidget *widget, gpointer data);
 void i_callback_file_save (GtkWidget *widget, gpointer data);
-void i_callback_edit_undo (GtkWidget *widget, gpointer data);
 void i_callback_edit_redo (GtkWidget *widget, gpointer data);
 void i_callback_edit_select (GtkWidget *widget, gpointer data);
 void i_callback_toolbar_edit_select(GtkWidget *widget, gpointer data);

--- a/libleptongui/scheme/Makefile.am
+++ b/libleptongui/scheme/Makefile.am
@@ -42,6 +42,7 @@ nobase_dist_scmdata_DATA = \
 	schematic/undo.scm \
 	schematic/window.scm \
 	schematic/window/foreign.scm \
+	schematic/window/global.scm \
 	conf/schematic/attribs.scm \
 	conf/schematic/deprecated.scm \
 	conf/schematic/keys.scm \

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -179,7 +179,7 @@
   (callback-edit-undo %null-pointer (*current-window)))
 
 (define-action-public (&edit-redo #:label (G_ "Redo") #:icon "gtk-redo")
-  (run-callback i_callback_edit_redo "&edit-redo"))
+  (callback-edit-redo %null-pointer (*current-window)))
 
 (define-action-public (&edit-select #:label (G_ "Select Mode") #:icon "select")
   (run-callback i_callback_edit_select "&edit-select"))

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -176,10 +176,10 @@
 ;;;; General editing actions
 
 (define-action-public (&edit-undo #:label (G_ "Undo") #:icon "gtk-undo")
-  (callback-edit-undo %null-pointer (*current-window)))
+  (undo!))
 
 (define-action-public (&edit-redo #:label (G_ "Redo") #:icon "gtk-redo")
-  (callback-edit-redo %null-pointer (*current-window)))
+  (redo!))
 
 (define-action-public (&edit-select #:label (G_ "Select Mode") #:icon "select")
   (run-callback i_callback_edit_select "&edit-select"))

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -176,7 +176,7 @@
 ;;;; General editing actions
 
 (define-action-public (&edit-undo #:label (G_ "Undo") #:icon "gtk-undo")
-  (run-callback i_callback_edit_undo "&edit-undo"))
+  (callback-edit-undo %null-pointer (*current-window)))
 
 (define-action-public (&edit-redo #:label (G_ "Redo") #:icon "gtk-redo")
   (run-callback i_callback_edit_redo "&edit-redo"))

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -48,6 +48,7 @@
   #:use-module (schematic repl)
   #:use-module (schematic selection)
   #:use-module (schematic undo)
+  #:use-module (schematic window global)
   #:use-module (schematic window foreign)
   #:use-module (schematic window))
 
@@ -73,12 +74,6 @@
              (log! 'critical "~S: Current window is unavailable." action-name)
              #f))))))
 
-(define-syntax *current-window
-  (syntax-rules ()
-    ((_)
-     (let ((*window (and=> (current-window) window->pointer)))
-       (or *window
-           (error "Current window is unavailable."))))))
 
 ;; -------------------------------------------------------------------
 ;;;; Special actions

--- a/libleptongui/scheme/schematic/callback.scm
+++ b/libleptongui/scheme/schematic/callback.scm
@@ -42,8 +42,13 @@
 (define REDO_ACTION 1)
 
 
-(define (undo-callback *window *page action-type)
-  (o_undo_callback *window *page action-type))
+(define (undo-callback *window action-type)
+  (let ((*page-view (gschem_toplevel_get_current_page_view *window)))
+    (if (null-pointer? *page-view)
+        (log! 'warning "undo-callback: NULL page view.")
+        (let ((*page (gschem_page_view_get_page *page-view)))
+          (unless (null-pointer? *page)
+            (o_undo_callback *window *page action-type))))))
 
 
 (define (callback-edit-undo *widget *window)
@@ -57,21 +62,11 @@
   ;; crash occurs when the page objects are free'd.
   (if (true? (schematic_window_get_inside_action *window))
       (i_callback_cancel *widget *window)
-      (let ((*page-view (gschem_toplevel_get_current_page_view *window)))
-        (if (null-pointer? *page-view)
-            (log! 'warning "callback-edit-undo: NULL page view.")
-            (let ((*page (gschem_page_view_get_page *page-view)))
-              (unless (null-pointer? *page)
-                (undo-callback *window *page UNDO_ACTION)))))))
+      (undo-callback *window UNDO_ACTION)))
 
 
 (define (callback-edit-redo *widget *window)
-  (let ((*page-view (gschem_toplevel_get_current_page_view *window)))
-    (if (null-pointer? *page-view)
-        (log! 'warning "callback-edit-redo: NULL page view.")
-        (let ((*page (gschem_page_view_get_page *page-view)))
-          (unless (null-pointer? *page)
-            (undo-callback *window *page REDO_ACTION))))))
+  (undo-callback *window REDO_ACTION))
 
 
 (define (callback-file-new *widget *window)

--- a/libleptongui/scheme/schematic/callback.scm
+++ b/libleptongui/scheme/schematic/callback.scm
@@ -29,6 +29,7 @@
   #:use-module (schematic window foreign)
 
   #:export (callback-edit-undo
+            callback-edit-redo
             callback-file-new
             *callback-file-new
             callback-file-open
@@ -36,10 +37,11 @@
             callback-page-close
             *callback-page-close))
 
+;; The same definitions as in gschem_defines.h.
+(define UNDO_ACTION 0)
+(define REDO_ACTION 1)
 
 (define (callback-edit-undo *widget *window)
-  ;; The same definition as in gschem_defines.h.
-  (define UNDO_ACTION 0)
   ;; If we're cancelling from a move action, re-wind the
   ;; page contents back to their state before we started.
   ;;
@@ -56,6 +58,15 @@
             (let ((*page (gschem_page_view_get_page *page-view)))
               (unless (null-pointer? *page)
                 (o_undo_callback *window *page UNDO_ACTION)))))))
+
+
+(define (callback-edit-redo *widget *window)
+  (let ((*page-view (gschem_toplevel_get_current_page_view *window)))
+    (if (null-pointer? *page-view)
+        (log! 'warning "callback-edit-redo: NULL page view.")
+        (let ((*page (gschem_page_view_get_page *page-view)))
+          (unless (null-pointer? *page)
+            (o_undo_callback *window *page REDO_ACTION))))))
 
 
 (define (callback-file-new *widget *window)

--- a/libleptongui/scheme/schematic/callback.scm
+++ b/libleptongui/scheme/schematic/callback.scm
@@ -29,50 +29,12 @@
   #:use-module (schematic ffi)
   #:use-module (schematic window foreign)
 
-  #:export (callback-edit-undo
-            callback-edit-redo
-            callback-file-new
+  #:export (callback-file-new
             *callback-file-new
             callback-file-open
             *callback-file-open
             callback-page-close
             *callback-page-close))
-
-;; The same definitions as in gschem_defines.h.
-(define UNDO_ACTION 0)
-(define REDO_ACTION 1)
-
-
-(define (undo-callback *window action-type)
-  (define undo? (config-boolean (path-config-context (getcwd))
-                                "schematic.undo"
-                                "undo-control"))
-  (if undo?
-      (let ((*page-view (gschem_toplevel_get_current_page_view *window)))
-        (if (null-pointer? *page-view)
-            (log! 'warning "undo-callback: NULL page view.")
-            (let ((*page (gschem_page_view_get_page *page-view)))
-              (unless (null-pointer? *page)
-                (o_undo_callback *window *page action-type)))))
-      (log! 'message (G_ "Undo/Redo is disabled in configuration"))))
-
-
-(define (callback-edit-undo *widget *window)
-  ;; If we're cancelling from a move action, re-wind the
-  ;; page contents back to their state before we started.
-  ;;
-  ;; It "might" be nice to sub-undo rotates / zoom changes
-  ;; made whilst moving components, but when the undo code
-  ;; hits lepton_page_delete(), the place list objects are free'd.
-  ;; Since they are also contained in the schematic page, a
-  ;; crash occurs when the page objects are free'd.
-  (if (true? (schematic_window_get_inside_action *window))
-      (i_callback_cancel *widget *window)
-      (undo-callback *window UNDO_ACTION)))
-
-
-(define (callback-edit-redo *widget *window)
-  (undo-callback *window REDO_ACTION))
 
 
 (define (callback-file-new *widget *window)

--- a/libleptongui/scheme/schematic/callback.scm
+++ b/libleptongui/scheme/schematic/callback.scm
@@ -28,12 +28,34 @@
   #:use-module (schematic ffi)
   #:use-module (schematic window foreign)
 
-  #:export (callback-file-new
+  #:export (callback-edit-undo
+            callback-file-new
             *callback-file-new
             callback-file-open
             *callback-file-open
             callback-page-close
             *callback-page-close))
+
+
+(define (callback-edit-undo *widget *window)
+  ;; The same definition as in gschem_defines.h.
+  (define UNDO_ACTION 0)
+  ;; If we're cancelling from a move action, re-wind the
+  ;; page contents back to their state before we started.
+  ;;
+  ;; It "might" be nice to sub-undo rotates / zoom changes
+  ;; made whilst moving components, but when the undo code
+  ;; hits lepton_page_delete(), the place list objects are free'd.
+  ;; Since they are also contained in the schematic page, a
+  ;; crash occurs when the page objects are free'd.
+  (if (true? (schematic_window_get_inside_action *window))
+      (i_callback_cancel *widget *window)
+      (let ((*page-view (gschem_toplevel_get_current_page_view *window)))
+        (if (null-pointer? *page-view)
+            (log! 'warning "callback-edit-undo: NULL page view.")
+            (let ((*page (gschem_page_view_get_page *page-view)))
+              (unless (null-pointer? *page)
+                (o_undo_callback *window *page UNDO_ACTION)))))))
 
 
 (define (callback-file-new *widget *window)

--- a/libleptongui/scheme/schematic/callback.scm
+++ b/libleptongui/scheme/schematic/callback.scm
@@ -41,6 +41,11 @@
 (define UNDO_ACTION 0)
 (define REDO_ACTION 1)
 
+
+(define (undo-callback *window *page action-type)
+  (o_undo_callback *window *page action-type))
+
+
 (define (callback-edit-undo *widget *window)
   ;; If we're cancelling from a move action, re-wind the
   ;; page contents back to their state before we started.
@@ -57,7 +62,7 @@
             (log! 'warning "callback-edit-undo: NULL page view.")
             (let ((*page (gschem_page_view_get_page *page-view)))
               (unless (null-pointer? *page)
-                (o_undo_callback *window *page UNDO_ACTION)))))))
+                (undo-callback *window *page UNDO_ACTION)))))))
 
 
 (define (callback-edit-redo *widget *window)
@@ -66,7 +71,7 @@
         (log! 'warning "callback-edit-redo: NULL page view.")
         (let ((*page (gschem_page_view_get_page *page-view)))
           (unless (null-pointer? *page)
-            (o_undo_callback *window *page REDO_ACTION))))))
+            (undo-callback *window *page REDO_ACTION))))))
 
 
 (define (callback-file-new *widget *window)

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -64,7 +64,6 @@
             i_callback_edit_mcopy
             i_callback_edit_mirror
             i_callback_edit_move
-            i_callback_edit_redo
             i_callback_edit_rotate_90
             i_callback_edit_select
             i_callback_edit_select_all
@@ -495,7 +494,6 @@
 (define-lff i_callback_edit_mcopy void '(* *))
 (define-lff i_callback_edit_mirror void '(* *))
 (define-lff i_callback_edit_move void '(* *))
-(define-lff i_callback_edit_redo void '(* *))
 (define-lff i_callback_edit_rotate_90 void '(* *))
 (define-lff i_callback_edit_select void '(* *))
 (define-lff i_callback_edit_select_all void '(* *))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -71,7 +71,6 @@
             i_callback_edit_show_hidden
             i_callback_edit_show_text
             i_callback_edit_translate
-            i_callback_edit_undo
             i_callback_edit_unembed
             i_callback_edit_unlock
             i_callback_edit_update
@@ -249,6 +248,7 @@
 
             o_slot_end
 
+            o_undo_callback
             o_undo_savestate
 
             x_event_get_pointer_position
@@ -502,7 +502,6 @@
 (define-lff i_callback_edit_show_hidden void '(* *))
 (define-lff i_callback_edit_show_text void '(* *))
 (define-lff i_callback_edit_translate void '(* *))
-(define-lff i_callback_edit_undo void '(* *))
 (define-lff i_callback_edit_unembed void '(* *))
 (define-lff i_callback_edit_unlock void '(* *))
 (define-lff i_callback_edit_update void '(* *))
@@ -572,6 +571,7 @@
 
 ;;; o_undo.c
 (define-lff o_undo_init void '())
+(define-lff o_undo_callback void (list '* '* int))
 (define-lff o_undo_savestate void (list '* '* int))
 
 ;;; This is a special case: the function may be not defined in C

--- a/libleptongui/scheme/schematic/toolbar.scm
+++ b/libleptongui/scheme/schematic/toolbar.scm
@@ -145,7 +145,7 @@
                          "edit-redo"
                          "Redo"
                          "Redo last undo"
-                         i_callback_edit_redo
+                         callback-edit-redo
                          5)
     (schematic_toolbar_insert_separator *toolbar 6)
     (make-toolbar-button *window

--- a/libleptongui/scheme/schematic/toolbar.scm
+++ b/libleptongui/scheme/schematic/toolbar.scm
@@ -138,7 +138,7 @@
                          "edit-undo"
                          "Undo"
                          "Undo last operation"
-                         i_callback_edit_undo
+                         callback-edit-undo
                          4)
     (make-toolbar-button *window
                          *toolbar

--- a/libleptongui/scheme/schematic/toolbar.scm
+++ b/libleptongui/scheme/schematic/toolbar.scm
@@ -27,6 +27,7 @@
 
   #:use-module (schematic callback)
   #:use-module (schematic ffi)
+  #:use-module (schematic undo)
 
   #:export (make-toolbar))
 

--- a/libleptongui/scheme/schematic/undo.scm
+++ b/libleptongui/scheme/schematic/undo.scm
@@ -33,6 +33,9 @@
     ; public:
     ;
   #:export (undo-save-state
+            undo!
+            redo!
+            ;; Toolbar callbacks.
             callback-edit-undo
             callback-edit-redo)
 
@@ -89,3 +92,19 @@ success, #f on failure."
 
 (define (callback-edit-redo *widget *window)
   (undo-callback *window TRUE))
+
+
+(define (undo!)
+  "Undo the last action done in the current window."
+  (define *window
+    (or (and=> (current-window) window->pointer)
+        (error "~S: Current window is unavailable." 'undo!)))
+  (with-window *window (callback-edit-undo %null-pointer *window)))
+
+
+(define (redo!)
+  "Redo the last action undone in the current window."
+  (define *window
+    (or (and=> (current-window) window->pointer)
+        (error "~S: Current window is unavailable." 'undo!)))
+  (with-window *window (callback-edit-redo %null-pointer *window)))

--- a/libleptongui/scheme/schematic/undo.scm
+++ b/libleptongui/scheme/schematic/undo.scm
@@ -64,10 +64,11 @@ success, #f on failure."
 
 
 (define (undo-callback *window action-type)
-  (define undo? (config-boolean (path-config-context (getcwd))
-                                "schematic.undo"
-                                "undo-control"))
-  (if undo?
+  (define undo-enabled?
+    (config-boolean (path-config-context (getcwd))
+                    "schematic.undo"
+                    "undo-control"))
+  (if undo-enabled?
       (let ((*page-view (gschem_toplevel_get_current_page_view *window)))
         (if (null-pointer? *page-view)
             (log! 'warning "undo-callback: NULL page view.")

--- a/libleptongui/scheme/schematic/undo.scm
+++ b/libleptongui/scheme/schematic/undo.scm
@@ -49,9 +49,7 @@
 (define (undo-save-state)
   "Saves current state onto the undo stack.  Returns #t on
 success, #f on failure."
-  (define *window
-    (or (and=> (current-window) window->pointer)
-        (error "~S: Current window is unavailable." 'undo-save-state)))
+  (define *window (*current-window))
 
   (let ((*view (gschem_toplevel_get_current_page_view *window)))
     (and (not (null-pointer? *view))
@@ -96,15 +94,9 @@ success, #f on failure."
 
 (define (undo!)
   "Undo the last action done in the current window."
-  (define *window
-    (or (and=> (current-window) window->pointer)
-        (error "~S: Current window is unavailable." 'undo!)))
-  (with-window *window (callback-edit-undo %null-pointer *window)))
+  (callback-edit-undo %null-pointer (*current-window)))
 
 
 (define (redo!)
   "Redo the last action undone in the current window."
-  (define *window
-    (or (and=> (current-window) window->pointer)
-        (error "~S: Current window is unavailable." 'undo!)))
-  (with-window *window (callback-edit-redo %null-pointer *window)))
+  (callback-edit-redo %null-pointer (*current-window)))

--- a/libleptongui/scheme/schematic/undo.scm
+++ b/libleptongui/scheme/schematic/undo.scm
@@ -58,12 +58,7 @@ success, #f on failure."
                 #t)))))
 
 
-;; The same definitions as in gschem_defines.h.
-(define UNDO_ACTION 0)
-(define REDO_ACTION 1)
-
-
-(define (undo-callback *window action-type)
+(define (undo-callback *window redo?)
   (define undo-enabled?
     (config-boolean (path-config-context (getcwd))
                     "schematic.undo"
@@ -74,7 +69,7 @@ success, #f on failure."
             (log! 'warning "undo-callback: NULL page view.")
             (let ((*page (gschem_page_view_get_page *page-view)))
               (unless (null-pointer? *page)
-                (o_undo_callback *window *page action-type)))))
+                (o_undo_callback *window *page redo?)))))
       (log! 'message (G_ "Undo/Redo is disabled in configuration"))))
 
 
@@ -89,8 +84,8 @@ success, #f on failure."
   ;; crash occurs when the page objects are free'd.
   (if (true? (schematic_window_get_inside_action *window))
       (i_callback_cancel *widget *window)
-      (undo-callback *window UNDO_ACTION)))
+      (undo-callback *window FALSE)))
 
 
 (define (callback-edit-redo *widget *window)
-  (undo-callback *window REDO_ACTION))
+  (undo-callback *window TRUE))

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -40,11 +40,13 @@
   #:use-module (schematic menu)
   #:use-module (schematic toolbar)
   #:use-module (schematic window foreign)
+  #:use-module (schematic window global)
 
-  #:export (%lepton-window
-            current-window
-            with-window
-            make-schematic-window
+  #:re-export (%lepton-window
+               current-window
+               with-window)
+
+  #:export (make-schematic-window
             active-page
             set-active-page!
             pointer-position
@@ -53,32 +55,6 @@
   ;; Overrides the close-page! procedure in the (lepton page)
   ;; module.
   #:replace (close-page!))
-
-
-;;; This is a fluid that is initialized with pointer to a new
-;;; lepton-schematic window when it is created.  Any Scheme
-;;; callback procedure called inside the window may use the value
-;;; of the fluid to reference its window, thus avoiding the need
-;;; of any additional arguments.  In any window, the fluid points
-;;; exactly to it.
-(define %lepton-window (make-fluid))
-
-
-;;; Execute forms in the dynamic context of WINDOW and its
-;;; toplevel.  We have to dynwind LeptonToplevel here as well
-;;; since there are functions that depend on it and should know
-;;; what its current value is.
-(define-syntax-rule (with-window window form form* ...)
-  (with-fluids ((%lepton-window window)
-                (%lepton-toplevel
-                 (gschem_toplevel_get_toplevel window)))
-    form form* ...))
-
-
-(define (current-window)
-  "Returns the <window> instance associated with the current
-dynamic context."
-  (and=> (fluid-ref %lepton-window) pointer->window))
 
 
 (define (process-key-event *page_view *event *window)

--- a/libleptongui/scheme/schematic/window/global.scm
+++ b/libleptongui/scheme/schematic/window/global.scm
@@ -25,6 +25,7 @@
 
   #:export (%lepton-window
             current-window
+            *current-window
             with-window))
 
 
@@ -52,3 +53,14 @@
   "Returns the <window> instance associated with the current
 dynamic context."
   (and=> (fluid-ref %lepton-window) pointer->window))
+
+
+;;; This macro checks if the current window is available and
+;;; produces a C pointer to its instance applicable for use in FFI
+;;; code.
+(define-syntax *current-window
+  (syntax-rules ()
+    ((_)
+     (let ((*window (and=> (current-window) window->pointer)))
+       (or *window
+           (error "Current window is unavailable."))))))

--- a/libleptongui/scheme/schematic/window/global.scm
+++ b/libleptongui/scheme/schematic/window/global.scm
@@ -1,0 +1,54 @@
+;;; Lepton EDA Schematic Capture
+;;; Scheme API
+;;; Copyright (C) 2022 Lepton EDA Contributors
+;;;
+;;; This program is free software; you can redistribute it and/or modify
+;;; it under the terms of the GNU General Public License as published by
+;;; the Free Software Foundation; either version 2 of the License, or
+;;; (at your option) any later version.
+;;;
+;;; This program is distributed in the hope that it will be useful,
+;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;; GNU General Public License for more details.
+;;;
+;;; You should have received a copy of the GNU General Public License
+;;; along with this program; if not, write to the Free Software
+;;; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
+(define-module (schematic window global)
+  #:use-module (lepton toplevel)
+
+  #:use-module (schematic ffi)
+  #:use-module (schematic window foreign)
+
+  #:export (%lepton-window
+            current-window
+            with-window))
+
+
+;;; This is a fluid that is initialized with pointer to a new
+;;; lepton-schematic window when it is created.  Any Scheme
+;;; callback procedure called inside the window may use the value
+;;; of the fluid to reference its window, thus avoiding the need
+;;; of any additional arguments.  In any window, the fluid points
+;;; exactly to it.
+(define %lepton-window (make-fluid))
+
+
+;;; Execute forms in the dynamic context of WINDOW and its
+;;; toplevel.  We have to dynwind LeptonToplevel here as well
+;;; since there are functions that depend on it and should know
+;;; what its current value is.
+(define-syntax-rule (with-window window form form* ...)
+  (with-fluids ((%lepton-window window)
+                (%lepton-toplevel
+                 (gschem_toplevel_get_toplevel window)))
+    form form* ...))
+
+
+(define (current-window)
+  "Returns the <window> instance associated with the current
+dynamic context."
+  (and=> (fluid-ref %lepton-window) pointer->window))

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -120,27 +120,6 @@ i_callback_file_save (GtkWidget *widget, gpointer data)
  *  \brief
  *  \par Function Description
  *
- */
-void
-i_callback_edit_redo (GtkWidget *widget, gpointer data)
-{
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-  g_return_if_fail (w_current != NULL);
-
-  GschemPageView *page_view = gschem_toplevel_get_current_page_view (w_current);
-  g_return_if_fail (page_view != NULL);
-
-  LeptonPage *page = gschem_page_view_get_page (page_view);
-
-  if (page != NULL) {
-    o_undo_callback (w_current, page, REDO_ACTION);
-  }
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
  *  \note
  *  Select also does not update the middle button shortcut.
  */

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -115,39 +115,6 @@ i_callback_file_save (GtkWidget *widget, gpointer data)
 
 
 /*! \section edit-menu Edit Menu Callback Functions */
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
-void
-i_callback_edit_undo (GtkWidget *widget, gpointer data)
-{
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-
-  /* If we're cancelling from a move action, re-wind the
-   * page contents back to their state before we started.
-   *
-   * It "might" be nice to sub-undo rotates / zoom changes
-   * made whilst moving components, but when the undo code
-   * hits lepton_page_delete(), the place list objects are free'd.
-   * Since they are also contained in the schematic page, a
-   * crash occurs when the page objects are free'd.
-   * */
-  if (schematic_window_get_inside_action (w_current))
-  {
-    i_callback_cancel (widget, w_current);
-  } else {
-    GschemPageView *page_view = gschem_toplevel_get_current_page_view (w_current);
-    g_return_if_fail (page_view != NULL);
-
-    LeptonPage *page = gschem_page_view_get_page (page_view);
-
-    if (page != NULL) {
-      o_undo_callback (w_current, page, UNDO_ACTION);
-    }
-  }
-}
 
 /*! \todo Finish function documentation!!!
  *  \brief

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -397,11 +397,6 @@ o_undo_callback (GschemToplevel *w_current,
   g_return_if_fail (w_current != NULL);
   g_return_if_fail (page != NULL);
 
-  if (w_current->undo_control == FALSE) {
-    g_message (_("Undo/Redo is disabled in configuration"));
-    return;
-  }
-
   if (page->undo_current == NULL) {
     return;
   }

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -372,16 +372,12 @@ GList *o_undo_find_prev_object_head (LeptonUndo *start)
  *  \brief
  *  \par Function Description
  *
- *  <B>type</B> can be one of the following values:
- *  <DL>
- *    <DT>*</DT><DD>UNDO_ACTION
- *    <DT>*</DT><DD>REDO_ACTION
- *  </DL>
+ *  If \a redo is TRUE, do "redo" instead of "undo".
  */
 void
 o_undo_callback (GschemToplevel *w_current,
                  LeptonPage *page,
-                 int type)
+                 gboolean redo)
 {
   LeptonToplevel *toplevel = gschem_toplevel_get_toplevel (w_current);
   LeptonUndo *u_current;
@@ -401,9 +397,14 @@ o_undo_callback (GschemToplevel *w_current,
     return;
   }
 
-  if (type == UNDO_ACTION) {
+  if (!redo)
+  {
+    /* Undo action. */
     u_current = page->undo_current->prev;
-  } else {
+  }
+  else
+  {
+    /* Redo action. */
     u_current = page->undo_current->next;
   }
 
@@ -510,14 +511,19 @@ o_undo_callback (GschemToplevel *w_current,
   page->undo_tos = save_tos;
   page->undo_current = save_current;
 
-  if (type == UNDO_ACTION) {
+  if (!redo)
+  {
+    /* Undo action. */
     if (page->undo_current) {
       page->undo_current = page->undo_current->prev;
       if (page->undo_current == NULL) {
         page->undo_current = page->undo_bottom;
       }
     }
-  } else { /* type is REDO_ACTION */
+  }
+  else
+  {
+    /* Redo action. */
     if (page->undo_current) {
       page->undo_current = page->undo_current->next;
       if (page->undo_current == NULL) {


### PR DESCRIPTION
- Two C callbacks, `i_callback_edit_redo()` and `i_callback_edit_undo()`, have been rewritten in Scheme.  As a result, two new Scheme functions, `undo!()` and `redo!()` have been introduced.  They are exported in the module `(schematic undo)`.
- Both callbacks do now check the config setting `undo-control` on the fly for current directory in order to do or skip the job.
- The fluid `%lepton-window` and functions related to it have been moved to a new module, `(schematic window global)`, in order to avoid circular dependencies between modules in the `schematic` namespace.
- Two global undo related variables have been eliminated.
- In order to facilitate the above, the `*current-window()` macro has been moved to `(schematic window global)`.  The macro is used to simplify the new undo procedures.
