### PR TITLE
symcheck: Fix random ITS test failures.

### DIFF
--- a/liblepton/scheme/symcheck/check.scm
+++ b/liblepton/scheme/symcheck/check.scm
@@ -69,8 +69,7 @@ Lepton EDA homepage: <~A>
   (define (report-symbol-statistics page)
     (unless (symcheck-option-ref 'quiet)
       (check-log! 'message (G_ "Checking: ~A\n") (page-filename page)))
-    (check-symbol page)
-    (check-report `(,page . ,(page-contents page))))
+    (check-report `(,page . ,(check-symbol page))))
 
   (define (error-no-files-specified)
     (format #t


### PR DESCRIPTION
This is an issue that started to suddenly appear on my system after
merging patches from PR #942.  I suppose it is due to fixed time 
between GC cycles and less resources for each test after adding 
new ones.  I could be wrong about the reasons but anyway, the
one-liner here fixed the issue on my system.

The commit description is below.

In some circumstances, `lepton-symcheck` integration tests might
fail due to two steps of reifying objects from C lists in
`page-contents()` and thus garbage collecting some of them in
between.  The first call of the procedure is in `check-symbol()`,
and the second one is just before producing a report.  As
`check-symbol()` already returns page objects, there is no point to
obtain them again from C lists.  As Scheme objects still exist and
none of them is garbage collected, their so named blaming info
cannot be lost, which might occur before as it is implemented as
*object-property* and hence a weak reference disappearing along
with its Scheme owner.  Rewriting the code in the way that
`page-contents()` is used once and `check-report()` retrieves objects
from `check-symbol()` itself thus protecting them from GC, makes the
code more functional and fixes the tests.