### PR TITLE
Rewrite i_callback_edit_*() functions in Scheme

### DIFF
--- a/libleptongui/include/gschem_macro_widget.h
+++ b/libleptongui/include/gschem_macro_widget.h
@@ -66,13 +66,15 @@ struct _GschemMacroWidget
 GtkWidget*
 macro_widget_new (GschemToplevel* toplevel);
 
+G_BEGIN_DECLS
+
 void
 macro_widget_show (GtkWidget* widget);
 
+G_END_DECLS
 
 GType
 gschem_macro_widget_get_type();
 
 
 #endif /* LEPTON_MACRO_WIDGET_H_ */
-

--- a/libleptongui/include/gschem_toplevel.h
+++ b/libleptongui/include/gschem_toplevel.h
@@ -344,4 +344,10 @@ schematic_window_get_page_select_widget (GschemToplevel *w_current);
 void
 schematic_window_set_page_select_widget (GschemToplevel *w_current,
                                          GtkWidget* widget);
+LeptonSelection*
+schematic_window_get_selection_list (GschemToplevel *w_current);
+
+void
+schematic_window_set_selection_list (GschemToplevel *w_current,
+                                     LeptonSelection *place_list);
 G_END_DECLS

--- a/libleptongui/include/gschem_toplevel.h
+++ b/libleptongui/include/gschem_toplevel.h
@@ -350,4 +350,7 @@ schematic_window_get_selection_list (GschemToplevel *w_current);
 void
 schematic_window_set_selection_list (GschemToplevel *w_current,
                                      LeptonSelection *place_list);
+GtkWidget*
+schematic_window_get_macro_widget (GschemToplevel *w_current);
+
 G_END_DECLS

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -102,7 +102,6 @@ void i_callback_file_script (GtkWidget *widget, gpointer data);
 void i_callback_file_save (GtkWidget *widget, gpointer data);
 void i_callback_edit_translate (GtkWidget *widget, gpointer data);
 void i_callback_edit_invoke_macro (GtkWidget *widget, gpointer data);
-void i_callback_edit_embed (GtkWidget *widget, gpointer data);
 void i_callback_edit_unembed (GtkWidget *widget, gpointer data);
 void i_callback_edit_update (GtkWidget *widget, gpointer data);
 void i_callback_view_sidebar (GtkWidget *widget, gpointer data);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -109,7 +109,6 @@ void i_callback_edit_embed (GtkWidget *widget, gpointer data);
 void i_callback_edit_unembed (GtkWidget *widget, gpointer data);
 void i_callback_edit_update (GtkWidget *widget, gpointer data);
 void i_callback_edit_show_hidden (GtkWidget *widget, gpointer data);
-void i_callback_edit_show_text (GtkWidget *widget, gpointer data);
 void i_callback_edit_autonumber_text (GtkWidget *widget, gpointer data);
 void i_callback_view_sidebar (GtkWidget *widget, gpointer data);
 void i_callback_view_status (GtkWidget *widget, gpointer data);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -100,7 +100,6 @@ void i_update_net_options_status (GschemToplevel* w_current);
 /* i_callbacks.c */
 void i_callback_file_script (GtkWidget *widget, gpointer data);
 void i_callback_file_save (GtkWidget *widget, gpointer data);
-void i_callback_edit_deselect (GtkWidget *widget, gpointer data);
 void i_callback_edit_copy (GtkWidget *widget, gpointer data);
 void i_callback_edit_mcopy (GtkWidget *widget, gpointer data);
 void i_callback_edit_move (GtkWidget *widget, gpointer data);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -102,7 +102,6 @@ void i_callback_file_script (GtkWidget *widget, gpointer data);
 void i_callback_file_save (GtkWidget *widget, gpointer data);
 void i_callback_edit_select (GtkWidget *widget, gpointer data);
 void i_callback_toolbar_edit_select(GtkWidget *widget, gpointer data);
-void i_callback_edit_select_all (GtkWidget *widget, gpointer data);
 void i_callback_edit_deselect (GtkWidget *widget, gpointer data);
 void i_callback_edit_copy (GtkWidget *widget, gpointer data);
 void i_callback_edit_mcopy (GtkWidget *widget, gpointer data);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -100,7 +100,6 @@ void i_update_net_options_status (GschemToplevel* w_current);
 /* i_callbacks.c */
 void i_callback_file_script (GtkWidget *widget, gpointer data);
 void i_callback_file_save (GtkWidget *widget, gpointer data);
-void i_callback_edit_update (GtkWidget *widget, gpointer data);
 void i_callback_view_sidebar (GtkWidget *widget, gpointer data);
 void i_callback_view_status (GtkWidget *widget, gpointer data);
 void i_callback_view_zoom_full (GtkWidget *widget, gpointer data);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -109,7 +109,6 @@ void i_callback_edit_embed (GtkWidget *widget, gpointer data);
 void i_callback_edit_unembed (GtkWidget *widget, gpointer data);
 void i_callback_edit_update (GtkWidget *widget, gpointer data);
 void i_callback_edit_show_hidden (GtkWidget *widget, gpointer data);
-void i_callback_edit_hide_text (GtkWidget *widget, gpointer data);
 void i_callback_edit_show_text (GtkWidget *widget, gpointer data);
 void i_callback_edit_autonumber_text (GtkWidget *widget, gpointer data);
 void i_callback_view_sidebar (GtkWidget *widget, gpointer data);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -100,7 +100,6 @@ void i_update_net_options_status (GschemToplevel* w_current);
 /* i_callbacks.c */
 void i_callback_file_script (GtkWidget *widget, gpointer data);
 void i_callback_file_save (GtkWidget *widget, gpointer data);
-void i_callback_edit_select (GtkWidget *widget, gpointer data);
 void i_callback_edit_deselect (GtkWidget *widget, gpointer data);
 void i_callback_edit_copy (GtkWidget *widget, gpointer data);
 void i_callback_edit_mcopy (GtkWidget *widget, gpointer data);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -100,7 +100,6 @@ void i_update_net_options_status (GschemToplevel* w_current);
 /* i_callbacks.c */
 void i_callback_file_script (GtkWidget *widget, gpointer data);
 void i_callback_file_save (GtkWidget *widget, gpointer data);
-void i_callback_edit_translate (GtkWidget *widget, gpointer data);
 void i_callback_edit_update (GtkWidget *widget, gpointer data);
 void i_callback_view_sidebar (GtkWidget *widget, gpointer data);
 void i_callback_view_status (GtkWidget *widget, gpointer data);
@@ -652,6 +651,9 @@ schematic_window_create_macro_widget (GschemToplevel *w_current,
 void
 schematic_window_create_translate_widget (GschemToplevel *w_current,
                                           GtkWidget *work_box);
+void
+schematic_window_show_translate_widget (GschemToplevel *w_current);
+
 void
 schematic_window_create_notebooks (GschemToplevel *w_current,
                                    GtkWidget *main_box,

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -101,7 +101,6 @@ void i_update_net_options_status (GschemToplevel* w_current);
 void i_callback_file_script (GtkWidget *widget, gpointer data);
 void i_callback_file_save (GtkWidget *widget, gpointer data);
 void i_callback_edit_select (GtkWidget *widget, gpointer data);
-void i_callback_toolbar_edit_select(GtkWidget *widget, gpointer data);
 void i_callback_edit_deselect (GtkWidget *widget, gpointer data);
 void i_callback_edit_copy (GtkWidget *widget, gpointer data);
 void i_callback_edit_mcopy (GtkWidget *widget, gpointer data);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -109,7 +109,6 @@ void i_callback_edit_embed (GtkWidget *widget, gpointer data);
 void i_callback_edit_unembed (GtkWidget *widget, gpointer data);
 void i_callback_edit_update (GtkWidget *widget, gpointer data);
 void i_callback_edit_show_hidden (GtkWidget *widget, gpointer data);
-void i_callback_edit_find (GtkWidget *widget, gpointer data);
 void i_callback_edit_hide_text (GtkWidget *widget, gpointer data);
 void i_callback_edit_show_text (GtkWidget *widget, gpointer data);
 void i_callback_edit_autonumber_text (GtkWidget *widget, gpointer data);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -105,7 +105,6 @@ void i_callback_edit_invoke_macro (GtkWidget *widget, gpointer data);
 void i_callback_edit_embed (GtkWidget *widget, gpointer data);
 void i_callback_edit_unembed (GtkWidget *widget, gpointer data);
 void i_callback_edit_update (GtkWidget *widget, gpointer data);
-void i_callback_edit_show_hidden (GtkWidget *widget, gpointer data);
 void i_callback_edit_autonumber_text (GtkWidget *widget, gpointer data);
 void i_callback_view_sidebar (GtkWidget *widget, gpointer data);
 void i_callback_view_status (GtkWidget *widget, gpointer data);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -100,7 +100,6 @@ void i_update_net_options_status (GschemToplevel* w_current);
 /* i_callbacks.c */
 void i_callback_file_script (GtkWidget *widget, gpointer data);
 void i_callback_file_save (GtkWidget *widget, gpointer data);
-void i_callback_edit_edit (GtkWidget *widget, gpointer data);
 void i_callback_edit_rotate_90 (GtkWidget *widget, gpointer data);
 void i_callback_edit_mirror (GtkWidget *widget, gpointer data);
 void i_callback_edit_translate (GtkWidget *widget, gpointer data);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -101,7 +101,6 @@ void i_update_net_options_status (GschemToplevel* w_current);
 void i_callback_file_script (GtkWidget *widget, gpointer data);
 void i_callback_file_save (GtkWidget *widget, gpointer data);
 void i_callback_edit_translate (GtkWidget *widget, gpointer data);
-void i_callback_edit_invoke_macro (GtkWidget *widget, gpointer data);
 void i_callback_edit_update (GtkWidget *widget, gpointer data);
 void i_callback_view_sidebar (GtkWidget *widget, gpointer data);
 void i_callback_view_status (GtkWidget *widget, gpointer data);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -103,7 +103,6 @@ void i_callback_file_save (GtkWidget *widget, gpointer data);
 void i_callback_edit_edit (GtkWidget *widget, gpointer data);
 void i_callback_edit_rotate_90 (GtkWidget *widget, gpointer data);
 void i_callback_edit_mirror (GtkWidget *widget, gpointer data);
-void i_callback_edit_lock (GtkWidget *widget, gpointer data);
 void i_callback_edit_unlock (GtkWidget *widget, gpointer data);
 void i_callback_edit_translate (GtkWidget *widget, gpointer data);
 void i_callback_edit_invoke_macro (GtkWidget *widget, gpointer data);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -105,7 +105,6 @@ void i_callback_edit_invoke_macro (GtkWidget *widget, gpointer data);
 void i_callback_edit_embed (GtkWidget *widget, gpointer data);
 void i_callback_edit_unembed (GtkWidget *widget, gpointer data);
 void i_callback_edit_update (GtkWidget *widget, gpointer data);
-void i_callback_edit_autonumber_text (GtkWidget *widget, gpointer data);
 void i_callback_view_sidebar (GtkWidget *widget, gpointer data);
 void i_callback_view_status (GtkWidget *widget, gpointer data);
 void i_callback_view_zoom_full (GtkWidget *widget, gpointer data);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -100,7 +100,6 @@ void i_update_net_options_status (GschemToplevel* w_current);
 /* i_callbacks.c */
 void i_callback_file_script (GtkWidget *widget, gpointer data);
 void i_callback_file_save (GtkWidget *widget, gpointer data);
-void i_callback_edit_delete (GtkWidget *widget, gpointer data);
 void i_callback_edit_edit (GtkWidget *widget, gpointer data);
 void i_callback_edit_rotate_90 (GtkWidget *widget, gpointer data);
 void i_callback_edit_mirror (GtkWidget *widget, gpointer data);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -100,7 +100,6 @@ void i_update_net_options_status (GschemToplevel* w_current);
 /* i_callbacks.c */
 void i_callback_file_script (GtkWidget *widget, gpointer data);
 void i_callback_file_save (GtkWidget *widget, gpointer data);
-void i_callback_edit_move (GtkWidget *widget, gpointer data);
 void i_callback_edit_delete (GtkWidget *widget, gpointer data);
 void i_callback_edit_edit (GtkWidget *widget, gpointer data);
 void i_callback_edit_rotate_90 (GtkWidget *widget, gpointer data);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -103,7 +103,6 @@ void i_callback_file_save (GtkWidget *widget, gpointer data);
 void i_callback_edit_edit (GtkWidget *widget, gpointer data);
 void i_callback_edit_rotate_90 (GtkWidget *widget, gpointer data);
 void i_callback_edit_mirror (GtkWidget *widget, gpointer data);
-void i_callback_edit_unlock (GtkWidget *widget, gpointer data);
 void i_callback_edit_translate (GtkWidget *widget, gpointer data);
 void i_callback_edit_invoke_macro (GtkWidget *widget, gpointer data);
 void i_callback_edit_embed (GtkWidget *widget, gpointer data);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -100,7 +100,6 @@ void i_update_net_options_status (GschemToplevel* w_current);
 /* i_callbacks.c */
 void i_callback_file_script (GtkWidget *widget, gpointer data);
 void i_callback_file_save (GtkWidget *widget, gpointer data);
-void i_callback_edit_rotate_90 (GtkWidget *widget, gpointer data);
 void i_callback_edit_mirror (GtkWidget *widget, gpointer data);
 void i_callback_edit_translate (GtkWidget *widget, gpointer data);
 void i_callback_edit_invoke_macro (GtkWidget *widget, gpointer data);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -100,7 +100,6 @@ void i_update_net_options_status (GschemToplevel* w_current);
 /* i_callbacks.c */
 void i_callback_file_script (GtkWidget *widget, gpointer data);
 void i_callback_file_save (GtkWidget *widget, gpointer data);
-void i_callback_edit_copy (GtkWidget *widget, gpointer data);
 void i_callback_edit_mcopy (GtkWidget *widget, gpointer data);
 void i_callback_edit_move (GtkWidget *widget, gpointer data);
 void i_callback_edit_delete (GtkWidget *widget, gpointer data);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -100,7 +100,6 @@ void i_update_net_options_status (GschemToplevel* w_current);
 /* i_callbacks.c */
 void i_callback_file_script (GtkWidget *widget, gpointer data);
 void i_callback_file_save (GtkWidget *widget, gpointer data);
-void i_callback_edit_mcopy (GtkWidget *widget, gpointer data);
 void i_callback_edit_move (GtkWidget *widget, gpointer data);
 void i_callback_edit_delete (GtkWidget *widget, gpointer data);
 void i_callback_edit_edit (GtkWidget *widget, gpointer data);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -100,7 +100,6 @@ void i_update_net_options_status (GschemToplevel* w_current);
 /* i_callbacks.c */
 void i_callback_file_script (GtkWidget *widget, gpointer data);
 void i_callback_file_save (GtkWidget *widget, gpointer data);
-void i_callback_edit_mirror (GtkWidget *widget, gpointer data);
 void i_callback_edit_translate (GtkWidget *widget, gpointer data);
 void i_callback_edit_invoke_macro (GtkWidget *widget, gpointer data);
 void i_callback_edit_embed (GtkWidget *widget, gpointer data);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -102,7 +102,6 @@ void i_callback_file_script (GtkWidget *widget, gpointer data);
 void i_callback_file_save (GtkWidget *widget, gpointer data);
 void i_callback_edit_translate (GtkWidget *widget, gpointer data);
 void i_callback_edit_invoke_macro (GtkWidget *widget, gpointer data);
-void i_callback_edit_unembed (GtkWidget *widget, gpointer data);
 void i_callback_edit_update (GtkWidget *widget, gpointer data);
 void i_callback_view_sidebar (GtkWidget *widget, gpointer data);
 void i_callback_view_status (GtkWidget *widget, gpointer data);

--- a/libleptongui/include/toolbar.h
+++ b/libleptongui/include/toolbar.h
@@ -59,6 +59,9 @@ schematic_toolbar_insert_separator (GtkWidget *toolbar,
 void
 schematic_toolbar_update (GtkWidget *toolbar,
                           SchematicActionMode action_mode);
+gboolean
+schematic_toolbar_toggle_tool_button_get_active (GtkWidget *button);
+
 G_END_DECLS
 
 #endif /* __TOOLBAR_H__ */

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -211,8 +211,22 @@
 (define-action-public (&edit-move #:label (G_ "Move Mode"))
   (run-callback i_callback_edit_move "&edit-move"))
 
+
 (define-action-public (&edit-copy #:label (G_ "Copy Mode") #:icon "clone")
-  (run-callback i_callback_edit_copy "&edit-copy"))
+  (define *window (*current-window))
+
+  (if (null? (page-selection (active-page)))
+      (i_set_state_msg *window
+                       (symbol->action-mode 'select-mode)
+                       (string->pointer (G_ "Select objs first")))
+      (let ((position (action-position)))
+        (o_redraw_cleanstates *window)
+        (and position
+             (match (snap-point position)
+               ((x . y) (o_copy_start *window x y))
+               (_ #f)))
+        (i_set_state *window (symbol->action-mode 'copy-mode)))))
+
 
 (define-action-public (&edit-mcopy #:label (G_ "Multiple Copy Mode") #:icon "multi-clone")
   (run-callback i_callback_edit_mcopy "&edit-mcopy"))

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -629,7 +629,10 @@
 
 
 (define-action-public (&edit-hide-text #:label (G_ "Hide Specific Text"))
-  (run-callback i_callback_edit_hide_text "&edit-hide-text"))
+  (define *window (*current-window))
+  (unless (true? (schematic_window_get_inside_action *window))
+    (hide_text_dialog *window)))
+
 
 (define-action-public (&edit-show-text #:label (G_ "Show Specific Text"))
   (run-callback i_callback_edit_show_text "&edit-show-text"))

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -177,7 +177,7 @@
   (redo!))
 
 (define-action-public (&edit-select #:label (G_ "Select Mode") #:icon "select")
-  (run-callback i_callback_edit_select "&edit-select"))
+  (callback-edit-select (*current-window)))
 
 ;;; Select all objects on the active page.
 (define-action-public (&edit-select-all #:label (G_ "Select All") #:icon "gtk-select-all")

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -291,8 +291,12 @@
 (define-action-public (&edit-translate #:label (G_ "Translate Symbol"))
   (run-callback i_callback_edit_translate "&edit-translate"))
 
+
+;;; Lock all objects in selection list.
 (define-action-public (&edit-lock #:label (G_ "Lock"))
-  (run-callback i_callback_edit_lock "&edit-lock"))
+  (unless (null? (page-selection (active-page)))
+    (o_lock (*current-window))))
+
 
 (define-action-public (&edit-unlock #:label (G_ "Unlock"))
   (run-callback i_callback_edit_unlock "&edit-unlock"))

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -698,7 +698,10 @@
 
 
 (define-action-public (&edit-autonumber #:label (G_ "Autonumber Text"))
-  (run-callback i_callback_edit_autonumber_text "&edit-autonumber"))
+  (define *window (*current-window))
+  (unless (true? (schematic_window_get_inside_action *window))
+    (autonumber_text_dialog *window)))
+
 
 ;; -------------------------------------------------------------------
 ;;;; Configuration actions

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -191,8 +191,19 @@
   (i_action_stop *window)
   (i_update_menus *window))
 
+
+;;; Deselect all objects on the active page.
 (define-action-public (&edit-deselect #:label (G_ "Deselect"))
-  (run-callback i_callback_edit_deselect "&edit-deselect"))
+  (define *window (*current-window))
+
+  (o_redraw_cleanstates *window)
+
+  (o_select_unselect_all *window)
+
+  (i_set_state *window (symbol->action-mode 'select-mode))
+  (i_action_stop *window)
+  (i_update_menus *window))
+
 
 (define-action-public (&edit-delete #:label (G_ "Delete") #:icon "gtk-delete")
   (run-callback i_callback_edit_delete "&edit-delete"))

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -356,7 +356,7 @@
 
 
 (define-action-public (&edit-invoke-macro #:label (G_ "Invoke Macro"))
-  (run-callback i_callback_edit_invoke_macro "&edit-invoke-macro"))
+  (macro_widget_show (schematic_window_get_macro_widget (*current-window))))
 
 
 ;;; Embed all objects in the current selection list.

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -635,7 +635,10 @@
 
 
 (define-action-public (&edit-show-text #:label (G_ "Show Specific Text"))
-  (run-callback i_callback_edit_show_text "&edit-show-text"))
+  (define *window (*current-window))
+  (unless (true? (schematic_window_get_inside_action *window))
+    (show_text_dialog *window)))
+
 
 (define-action-public (&edit-autonumber #:label (G_ "Autonumber Text"))
   (run-callback i_callback_edit_autonumber_text "&edit-autonumber"))

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -621,8 +621,12 @@
 (define-action-public (&attributes-visibility-toggle #:label (G_ "Toggle Text Visibility"))
   (run-callback i_callback_attributes_visibility_toggle "&attributes-visibility-toggle"))
 
+
 (define-action-public (&edit-find-text #:label (G_ "Find Specific Text") #:icon "gtk-find")
-  (run-callback i_callback_edit_find "&edit-find-text"))
+  (define *window (*current-window))
+  (unless (true? (schematic_window_get_inside_action *window))
+    (find_text_dialog *window)))
+
 
 (define-action-public (&edit-hide-text #:label (G_ "Hide Specific Text"))
   (run-callback i_callback_edit_hide_text "&edit-hide-text"))

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -358,8 +358,29 @@
 (define-action-public (&edit-invoke-macro #:label (G_ "Invoke Macro"))
   (run-callback i_callback_edit_invoke_macro "&edit-invoke-macro"))
 
+
+;;; Embed all objects in the current selection list.
 (define-action-public (&edit-embed #:label (G_ "Embed Component/Picture"))
-  (run-callback i_callback_edit_embed "&edit-embed"))
+  (define *window (*current-window))
+
+  (define (embed! object)
+    (set-object-embedded! object #t))
+
+  (let ((selection (page-selection (active-page))))
+    ;; Is anything selected?
+    (if (null? selection)
+        ;; Nothing selected, go back to select state.
+        (begin
+          (o_redraw_cleanstates *window)
+          (i_action_stop *window)
+          (i_set_state *window (symbol->action-mode 'select-mode)))
+
+        ;; Embed all selected components and pictures.
+        (begin
+          (for-each embed! selection)
+          (undo-save-state)
+          (page_select_widget_update *window)))))
+
 
 (define-action-public (&edit-unembed #:label (G_ "Unembed Component/Picture"))
   (run-callback i_callback_edit_unembed "&edit-unembed"))

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -367,8 +367,14 @@
 (define-action-public (&edit-update #:label (G_ "Update Component") #:icon "gtk-refresh")
   (run-callback i_callback_edit_update "&edit-update"))
 
+
 (define-action-public (&edit-show-hidden #:label (G_ "Show/Hide Invisible Text"))
-  (run-callback i_callback_edit_show_hidden "&edit-show-hidden"))
+  (define *window (*current-window))
+  (define *page (and=> (active-page) page->pointer))
+  (when *page
+    (o_edit_show_hidden *window
+                        (lepton_page_objects *page))))
+
 
 ;; -------------------------------------------------------------------
 ;;;; Clipboard actions

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -208,8 +208,21 @@
 (define-action-public (&edit-delete #:label (G_ "Delete") #:icon "gtk-delete")
   (run-callback i_callback_edit_delete "&edit-delete"))
 
+
 (define-action-public (&edit-move #:label (G_ "Move Mode"))
-  (run-callback i_callback_edit_move "&edit-move"))
+  (define *window (*current-window))
+
+  (if (null? (page-selection (active-page)))
+      (i_set_state_msg *window
+                       (symbol->action-mode 'select-mode)
+                       (string->pointer (G_ "Select objs first")))
+      (let ((position (action-position)))
+        (o_redraw_cleanstates *window)
+        (and position
+             (match (snap-point position)
+               ((x . y) (o_move_start *window x y))
+               (_ #f)))
+        (i_set_state *window (symbol->action-mode 'move-mode)))))
 
 
 (define-action-public (&edit-copy #:label (G_ "Copy Mode") #:icon "clone")

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -229,7 +229,20 @@
 
 
 (define-action-public (&edit-mcopy #:label (G_ "Multiple Copy Mode") #:icon "multi-clone")
-  (run-callback i_callback_edit_mcopy "&edit-mcopy"))
+  (define *window (*current-window))
+
+  (if (null? (page-selection (active-page)))
+      (i_set_state_msg *window
+                       (symbol->action-mode 'select-mode)
+                       (string->pointer (G_ "Select objs first")))
+      (let ((position (action-position)))
+        (o_redraw_cleanstates *window)
+        (and position
+             (match (snap-point position)
+               ((x . y) (o_copy_start *window x y))
+               (_ #f)))
+        (i_set_state *window (symbol->action-mode 'multiple-copy-mode)))))
+
 
 (define-action-public (&edit-rotate-90 #:label (G_ "Rotate Mode") #:icon "object-rotate-left")
   (run-callback i_callback_edit_rotate_90 "&edit-rotate-90"))

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -28,6 +28,7 @@
   #:use-module (lepton ffi boolean)
   #:use-module (lepton ffi)
   #:use-module (lepton log)
+  #:use-module (lepton object foreign)
   #:use-module (lepton object)
   #:use-module (lepton page foreign)
   #:use-module (lepton page)
@@ -428,7 +429,21 @@ the snap grid size should be set to 100")))
 
 
 (define-action-public (&edit-update #:label (G_ "Update Component") #:icon "gtk-refresh")
-  (run-callback i_callback_edit_update "&edit-update"))
+  (define *window (*current-window))
+
+  (define selected-components (filter component? (page-selection (active-page))))
+
+  ;; Update only selected components.
+  (if (null? selected-components)
+      (begin
+        ;; Nothing selected, go back to select state.
+        (o_redraw_cleanstates *window)
+        (i_action_stop *window)
+        (i_set_state *window (symbol->action-mode 'select-mode)))
+      (for-each
+       (lambda (component)
+         (o_update_component *window (object->pointer component)))
+       selected-components)))
 
 
 (define-action-public (&edit-show-hidden #:label (G_ "Show/Hide Invisible Text"))

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -382,8 +382,28 @@
           (page_select_widget_update *window)))))
 
 
+;;; Unembed all objects in the current selection list.
 (define-action-public (&edit-unembed #:label (G_ "Unembed Component/Picture"))
-  (run-callback i_callback_edit_unembed "&edit-unembed"))
+  (define *window (*current-window))
+
+  (define (unembed! object)
+    (set-object-embedded! object #f))
+
+  (let ((selection (page-selection (active-page))))
+    ;; Is anything selected?
+    (if (null? selection)
+        ;; Nothing selected, go back to select state.
+        (begin
+          (o_redraw_cleanstates *window)
+          (i_action_stop *window)
+          (i_set_state *window (symbol->action-mode 'select-mode)))
+
+        ;; Unembed all selected components and pictures.
+        (begin
+          (for-each unembed! selection)
+          (undo-save-state)
+          (page_select_widget_update *window)))))
+
 
 (define-action-public (&edit-update #:label (G_ "Update Component") #:icon "gtk-refresh")
   (run-callback i_callback_edit_update "&edit-update"))

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -179,8 +179,17 @@
 (define-action-public (&edit-select #:label (G_ "Select Mode") #:icon "select")
   (run-callback i_callback_edit_select "&edit-select"))
 
+;;; Select all objects on the active page.
 (define-action-public (&edit-select-all #:label (G_ "Select All") #:icon "gtk-select-all")
-  (run-callback i_callback_edit_select_all "&edit-select-all"))
+  (define *window (*current-window))
+
+  (o_redraw_cleanstates *window)
+
+  (o_select_visible_unlocked *window)
+
+  (i_set_state *window (symbol->action-mode 'select-mode))
+  (i_action_stop *window)
+  (i_update_menus *window))
 
 (define-action-public (&edit-deselect #:label (G_ "Deselect"))
   (run-callback i_callback_edit_deselect "&edit-deselect"))

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -298,8 +298,11 @@
     (o_lock (*current-window))))
 
 
+;;; Unlock all objects in selection list.
 (define-action-public (&edit-unlock #:label (G_ "Unlock"))
-  (run-callback i_callback_edit_unlock "&edit-unlock"))
+  (unless (null? (page-selection (active-page)))
+    (o_unlock (*current-window))))
+
 
 (define-action-public (&edit-invoke-macro #:label (G_ "Invoke Macro"))
   (run-callback i_callback_edit_invoke_macro "&edit-invoke-macro"))

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -272,8 +272,12 @@
 (define-action-public (&edit-mirror #:label (G_ "Mirror Mode") #:icon "object-flip-horizontal")
   (run-callback i_callback_edit_mirror "&edit-mirror"))
 
+
 (define-action-public (&edit-edit #:label (G_ "Edit..."))
-  (run-callback i_callback_edit_edit "&edit-edit"))
+  (define *window (*current-window))
+  (define *selection (schematic_window_get_selection_list *window))
+  (o_edit *window (lepton_list_get_glist *selection)))
+
 
 (define-action-public (&edit-text #:label (G_ "Edit Text") #:icon "gtk-edit")
   (text_edit_dialog (*current-window)))

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -339,8 +339,30 @@
 (define-action-public (&edit-object-properties #:label (G_ "Edit Object Properties") #:icon "gtk-properties")
   (x_widgets_show_object_properties (*current-window)))
 
+
 (define-action-public (&edit-translate #:label (G_ "Translate Symbol"))
-  (run-callback i_callback_edit_translate "&edit-translate"))
+  (define *window (*current-window))
+  (define *options (schematic_window_get_options *window))
+  (define snap-mode
+    (string->symbol
+     (pointer->string
+      (schematic_snap_mode_to_string
+       (gschem_options_get_snap_mode *options)))))
+
+  (when (eq? snap-mode 'off)
+    (log! 'message (G_ "WARNING: Do not translate with snap off!"))
+    (log! 'message (G_ "WARNING: Turning snap on and continuing with translate."))
+    (gschem_options_set_snap_mode *options
+                                  (schematic_snap_mode_from_string (string->pointer "grid")))
+    ;; Update status on screen.
+    (i_show_state *window %null-pointer))
+
+  (when (not (= 100 (gschem_options_get_snap_size *options)))
+    (log! 'message (G_ "WARNING: Snap grid size is not equal to 100!"))
+    (log! 'message (G_ "WARNING: If you are translating a symbol to the origin,
+the snap grid size should be set to 100")))
+
+  (schematic_window_show_translate_widget *window))
 
 
 ;;; Lock all objects in selection list.

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -206,7 +206,16 @@
 
 
 (define-action-public (&edit-delete #:label (G_ "Delete") #:icon "gtk-delete")
-  (run-callback i_callback_edit_delete "&edit-delete"))
+  (define *window (*current-window))
+
+  (unless (null? (page-selection (active-page)))
+    (o_redraw_cleanstates *window)
+    (o_delete_selected *window)
+    ;; If you delete the objects you must go into select mode
+    ;; after the delete.
+    (i_action_stop *window)
+    (i_set_state *window (symbol->action-mode 'select-mode))
+    (i_update_menus *window)))
 
 
 (define-action-public (&edit-move #:label (G_ "Move Mode"))

--- a/libleptongui/scheme/schematic/callback.scm
+++ b/libleptongui/scheme/schematic/callback.scm
@@ -26,6 +26,7 @@
   #:use-module (lepton gettext)
   #:use-module (lepton log)
 
+  #:use-module (schematic action-mode)
   #:use-module (schematic ffi)
   #:use-module (schematic window foreign)
 
@@ -35,6 +36,7 @@
             *callback-file-open
             callback-page-close
             *callback-page-close
+            callback-edit-select
             callback-toolbar-edit-select))
 
 
@@ -71,8 +73,14 @@
   (procedure->pointer void callback-page-close '(* *)))
 
 
+(define (callback-edit-select *window)
+  (o_redraw_cleanstates *window)
+  (i_set_state *window (symbol->action-mode 'select-mode))
+  (i_action_stop *window))
+
+
 (define (callback-toolbar-edit-select *widget *window)
   (when (true? (schematic_toolbar_toggle_tool_button_get_active *widget))
     (unless (true? (o_invalidate_rubber *window))
       (i_callback_cancel *widget *window))
-    (i_callback_edit_select *widget *window)))
+    (callback-edit-select *window)))

--- a/libleptongui/scheme/schematic/callback.scm
+++ b/libleptongui/scheme/schematic/callback.scm
@@ -34,7 +34,8 @@
             callback-file-open
             *callback-file-open
             callback-page-close
-            *callback-page-close))
+            *callback-page-close
+            callback-toolbar-edit-select))
 
 
 (define (callback-file-new *widget *window)
@@ -68,3 +69,10 @@
 
 (define *callback-page-close
   (procedure->pointer void callback-page-close '(* *)))
+
+
+(define (callback-toolbar-edit-select *widget *window)
+  (when (true? (schematic_toolbar_toggle_tool_button_get_active *widget))
+    (unless (true? (o_invalidate_rubber *window))
+      (i_callback_cancel *widget *window))
+    (i_callback_edit_select *widget *window)))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -60,7 +60,6 @@
             i_callback_edit_invoke_macro
             i_callback_edit_lock
             i_callback_edit_mirror
-            i_callback_edit_move
             i_callback_edit_rotate_90
             i_callback_edit_show_hidden
             i_callback_edit_show_text
@@ -114,6 +113,8 @@
             o_invalidate_rubber
 
             o_copy_start
+
+            o_move_start
 
             o_place_invalidate_rubber
 
@@ -497,7 +498,6 @@
 (define-lff i_callback_edit_invoke_macro void '(* *))
 (define-lff i_callback_edit_lock void '(* *))
 (define-lff i_callback_edit_mirror void '(* *))
-(define-lff i_callback_edit_move void '(* *))
 (define-lff i_callback_edit_rotate_90 void '(* *))
 (define-lff i_callback_edit_show_hidden void '(* *))
 (define-lff i_callback_edit_show_text void '(* *))
@@ -545,6 +545,9 @@
 
 ;;; o_copy.c
 (define-lff o_copy_start void (list '* int int))
+
+;;; o_move.c
+(define-lff o_move_start void (list '* int int))
 
 ;;; o_place.c
 (define-lff o_place_invalidate_rubber void (list '* int))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -52,7 +52,6 @@
             i_callback_clipboard_paste
             i_callback_close_wm
             i_callback_edit_autonumber_text
-            i_callback_edit_copy
             i_callback_edit_delete
             i_callback_edit_edit
             i_callback_edit_embed
@@ -114,6 +113,8 @@
 
             o_redraw_cleanstates
             o_invalidate_rubber
+
+            o_copy_start
 
             o_place_invalidate_rubber
 
@@ -489,7 +490,6 @@
 (define-lff i_callback_clipboard_paste void '(* *))
 (define-lff i_callback_close_wm int '(* * *))
 (define-lff i_callback_edit_autonumber_text void '(* *))
-(define-lff i_callback_edit_copy void '(* *))
 (define-lff i_callback_edit_delete void '(* *))
 (define-lff i_callback_edit_edit void '(* *))
 (define-lff i_callback_edit_embed void '(* *))
@@ -544,6 +544,9 @@
 ;;; o_basic.c
 (define-lff o_redraw_cleanstates int '(*))
 (define-lff o_invalidate_rubber int '(*))
+
+;;; o_copy.c
+(define-lff o_copy_start void (list '* int int))
 
 ;;; o_place.c
 (define-lff o_place_invalidate_rubber void (list '* int))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -54,7 +54,6 @@
             i_callback_edit_autonumber_text
             i_callback_edit_embed
             i_callback_edit_invoke_macro
-            i_callback_edit_mirror
             i_callback_edit_show_hidden
             i_callback_edit_translate
             i_callback_edit_unembed
@@ -111,11 +110,13 @@
             o_edit
             o_lock
             o_unlock
+            o_mirror_world_update
             o_rotate_world_update
 
             o_move_start
 
             o_place_invalidate_rubber
+            o_place_mirror
             o_place_rotate
 
             page_select_widget_new
@@ -505,7 +506,6 @@
 (define-lff i_callback_edit_autonumber_text void '(* *))
 (define-lff i_callback_edit_embed void '(* *))
 (define-lff i_callback_edit_invoke_macro void '(* *))
-(define-lff i_callback_edit_mirror void '(* *))
 (define-lff i_callback_edit_show_hidden void '(* *))
 (define-lff i_callback_edit_translate void '(* *))
 (define-lff i_callback_edit_unembed void '(* *))
@@ -558,6 +558,7 @@
 (define-lff o_edit void '(* *))
 (define-lff o_lock void '(*))
 (define-lff o_unlock void '(*))
+(define-lff o_mirror_world_update void (list '* int int '*))
 (define-lff o_rotate_world_update void (list '* int int int '*))
 
 ;;; o_move.c
@@ -565,6 +566,7 @@
 
 ;;; o_place.c
 (define-lff o_place_invalidate_rubber void (list '* int))
+(define-lff o_place_mirror void '(*))
 (define-lff o_place_rotate void '(*))
 
 ;;; x_misc.c

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -57,7 +57,6 @@
             i_callback_edit_find
             i_callback_edit_hide_text
             i_callback_edit_invoke_macro
-            i_callback_edit_lock
             i_callback_edit_mirror
             i_callback_edit_rotate_90
             i_callback_edit_show_hidden
@@ -114,6 +113,8 @@
             o_copy_start
 
             o_delete_selected
+
+            o_lock
 
             o_move_start
 
@@ -496,7 +497,6 @@
 (define-lff i_callback_edit_find void '(* *))
 (define-lff i_callback_edit_hide_text void '(* *))
 (define-lff i_callback_edit_invoke_macro void '(* *))
-(define-lff i_callback_edit_lock void '(* *))
 (define-lff i_callback_edit_mirror void '(* *))
 (define-lff i_callback_edit_rotate_90 void '(* *))
 (define-lff i_callback_edit_show_hidden void '(* *))
@@ -548,6 +548,9 @@
 
 ;;; o_delete.c
 (define-lff o_delete_selected void '(*))
+
+;;; o_misc.c
+(define-lff o_lock void '(*))
 
 ;;; o_move.c
 (define-lff o_move_start void (list '* int int))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -59,7 +59,6 @@
             i_callback_edit_hide_text
             i_callback_edit_invoke_macro
             i_callback_edit_lock
-            i_callback_edit_mcopy
             i_callback_edit_mirror
             i_callback_edit_move
             i_callback_edit_rotate_90
@@ -497,7 +496,6 @@
 (define-lff i_callback_edit_hide_text void '(* *))
 (define-lff i_callback_edit_invoke_macro void '(* *))
 (define-lff i_callback_edit_lock void '(* *))
-(define-lff i_callback_edit_mcopy void '(* *))
 (define-lff i_callback_edit_mirror void '(* *))
 (define-lff i_callback_edit_move void '(* *))
 (define-lff i_callback_edit_rotate_90 void '(* *))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -66,7 +66,6 @@
             i_callback_edit_move
             i_callback_edit_rotate_90
             i_callback_edit_select
-            i_callback_edit_select_all
             i_callback_edit_show_hidden
             i_callback_edit_show_text
             i_callback_edit_translate
@@ -100,6 +99,8 @@
             i_callback_view_zoom_in
             i_callback_view_zoom_out
 
+            i_action_stop
+            i_set_state
             i_set_state_msg
             i_show_state
             i_update_grid_info
@@ -113,6 +114,8 @@
 
             o_buffer_init
             o_undo_init
+
+            o_redraw_cleanstates
 
             o_place_invalidate_rubber
 
@@ -244,6 +247,9 @@
             gschem_options_set_snap_size
 
             text_edit_dialog
+
+            o_select_return_first_object
+            o_select_visible_unlocked
 
             o_slot_end
 
@@ -496,7 +502,6 @@
 (define-lff i_callback_edit_move void '(* *))
 (define-lff i_callback_edit_rotate_90 void '(* *))
 (define-lff i_callback_edit_select void '(* *))
-(define-lff i_callback_edit_select_all void '(* *))
 (define-lff i_callback_edit_show_hidden void '(* *))
 (define-lff i_callback_edit_show_text void '(* *))
 (define-lff i_callback_edit_translate void '(* *))
@@ -531,10 +536,15 @@
 (define-lff i_callback_toolbar_edit_select void '(* *))
 
 ;;; i_basic.c
+(define-lff i_action_stop void '(*))
+(define-lff i_set_state void (list '* int))
 (define-lff i_set_state_msg void (list '* int '*))
 (define-lff i_show_state void '(* *))
 (define-lff i_update_grid_info void '(*))
 (define-lff i_update_menus void '(*))
+
+;;; o_basic.c
+(define-lff o_redraw_cleanstates int '(*))
 
 ;;; o_place.c
 (define-lff o_place_invalidate_rubber void (list '* int))
@@ -556,6 +566,10 @@
 
 ;;; x_print.c
 (define-lff x_print void '(*))
+
+;;; o_select.c
+(define-lff o_select_return_first_object '* '(*))
+(define-lff o_select_visible_unlocked void '(*))
 
 ;;; o_slot.c
 (define-lff o_slot_end void '(* * *))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -54,7 +54,6 @@
             i_callback_edit_autonumber_text
             i_callback_edit_edit
             i_callback_edit_embed
-            i_callback_edit_hide_text
             i_callback_edit_invoke_macro
             i_callback_edit_mirror
             i_callback_edit_rotate_90
@@ -135,6 +134,7 @@
             x_stroke_init
 
             find_text_dialog
+            hide_text_dialog
 
             slot_edit_dialog
             slot_edit_dialog_response
@@ -469,6 +469,9 @@
 ;;; gschem_find_text_widget.c
 (define-lff find_text_dialog void '(*))
 
+;;; gschem_show_hide_text_widget.c
+(define-lff hide_text_dialog void '(*))
+
 ;;; x_dialog.c
 (define-lff generic_confirm_dialog int '(*))
 (define-lff generic_filesel_dialog '* (list '* '* int))
@@ -498,7 +501,6 @@
 (define-lff i_callback_edit_autonumber_text void '(* *))
 (define-lff i_callback_edit_edit void '(* *))
 (define-lff i_callback_edit_embed void '(* *))
-(define-lff i_callback_edit_hide_text void '(* *))
 (define-lff i_callback_edit_invoke_macro void '(* *))
 (define-lff i_callback_edit_mirror void '(* *))
 (define-lff i_callback_edit_rotate_90 void '(* *))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -54,7 +54,6 @@
             i_callback_edit_autonumber_text
             i_callback_edit_embed
             i_callback_edit_invoke_macro
-            i_callback_edit_show_hidden
             i_callback_edit_translate
             i_callback_edit_unembed
             i_callback_edit_update
@@ -108,6 +107,7 @@
             o_delete_selected
 
             o_edit
+            o_edit_show_hidden
             o_lock
             o_unlock
             o_mirror_world_update
@@ -506,7 +506,6 @@
 (define-lff i_callback_edit_autonumber_text void '(* *))
 (define-lff i_callback_edit_embed void '(* *))
 (define-lff i_callback_edit_invoke_macro void '(* *))
-(define-lff i_callback_edit_show_hidden void '(* *))
 (define-lff i_callback_edit_translate void '(* *))
 (define-lff i_callback_edit_unembed void '(* *))
 (define-lff i_callback_edit_update void '(* *))
@@ -556,6 +555,7 @@
 
 ;;; o_misc.c
 (define-lff o_edit void '(* *))
+(define-lff o_edit_show_hidden void '(* *))
 (define-lff o_lock void '(*))
 (define-lff o_unlock void '(*))
 (define-lff o_mirror_world_update void (list '* int int '*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -52,7 +52,6 @@
             i_callback_clipboard_paste
             i_callback_close_wm
             i_callback_edit_autonumber_text
-            i_callback_edit_delete
             i_callback_edit_edit
             i_callback_edit_embed
             i_callback_edit_find
@@ -113,6 +112,8 @@
             o_invalidate_rubber
 
             o_copy_start
+
+            o_delete_selected
 
             o_move_start
 
@@ -490,7 +491,6 @@
 (define-lff i_callback_clipboard_paste void '(* *))
 (define-lff i_callback_close_wm int '(* * *))
 (define-lff i_callback_edit_autonumber_text void '(* *))
-(define-lff i_callback_edit_delete void '(* *))
 (define-lff i_callback_edit_edit void '(* *))
 (define-lff i_callback_edit_embed void '(* *))
 (define-lff i_callback_edit_find void '(* *))
@@ -545,6 +545,9 @@
 
 ;;; o_copy.c
 (define-lff o_copy_start void (list '* int int))
+
+;;; o_delete.c
+(define-lff o_delete_selected void '(*))
 
 ;;; o_move.c
 (define-lff o_move_start void (list '* int int))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -51,7 +51,6 @@
             i_callback_clipboard_cut
             i_callback_clipboard_paste
             i_callback_close_wm
-            i_callback_edit_update
             i_callback_file_save
             *i_callback_file_save
             i_callback_file_script
@@ -107,6 +106,7 @@
             o_unlock
             o_mirror_world_update
             o_rotate_world_update
+            o_update_component
 
             o_move_start
 
@@ -512,7 +512,6 @@
 (define-lff i_callback_clipboard_cut void '(* *))
 (define-lff i_callback_clipboard_paste void '(* *))
 (define-lff i_callback_close_wm int '(* * *))
-(define-lff i_callback_edit_update void '(* *))
 (define-lff i_callback_file_save void '(* *))
 (define-lfc *i_callback_file_save)
 (define-lff i_callback_file_script void '(* *))
@@ -564,6 +563,7 @@
 (define-lff o_unlock void '(*))
 (define-lff o_mirror_world_update void (list '* int int '*))
 (define-lff o_rotate_world_update void (list '* int int int '*))
+(define-lff o_update_component '* '(* *))
 
 ;;; o_move.c
 (define-lff o_move_start void (list '* int int))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -51,7 +51,6 @@
             i_callback_clipboard_cut
             i_callback_clipboard_paste
             i_callback_close_wm
-            i_callback_edit_embed
             i_callback_edit_invoke_macro
             i_callback_edit_translate
             i_callback_edit_unembed
@@ -505,7 +504,6 @@
 (define-lff i_callback_clipboard_cut void '(* *))
 (define-lff i_callback_clipboard_paste void '(* *))
 (define-lff i_callback_close_wm int '(* * *))
-(define-lff i_callback_edit_embed void '(* *))
 (define-lff i_callback_edit_invoke_macro void '(* *))
 (define-lff i_callback_edit_translate void '(* *))
 (define-lff i_callback_edit_unembed void '(* *))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -52,7 +52,6 @@
             i_callback_clipboard_paste
             i_callback_close_wm
             i_callback_edit_autonumber_text
-            i_callback_edit_edit
             i_callback_edit_embed
             i_callback_edit_invoke_macro
             i_callback_edit_mirror
@@ -110,6 +109,7 @@
 
             o_delete_selected
 
+            o_edit
             o_lock
             o_unlock
 
@@ -237,6 +237,7 @@
             schematic_window_get_gdk_display
             schematic_window_get_options
             schematic_window_get_place_list
+            schematic_window_get_selection_list
             schematic_window_update_keyaccel_string
             schematic_window_update_keyaccel_timer
 
@@ -388,6 +389,7 @@
 (define-lff schematic_window_get_gdk_display '* '(*))
 (define-lff schematic_window_get_options '* '(*))
 (define-lff schematic_window_get_place_list '* '(*))
+(define-lff schematic_window_get_selection_list '* '(*))
 (define-lff schematic_window_update_keyaccel_string void '(* *))
 (define-lff schematic_window_update_keyaccel_timer void (list '* int))
 
@@ -500,7 +502,6 @@
 (define-lff i_callback_clipboard_paste void '(* *))
 (define-lff i_callback_close_wm int '(* * *))
 (define-lff i_callback_edit_autonumber_text void '(* *))
-(define-lff i_callback_edit_edit void '(* *))
 (define-lff i_callback_edit_embed void '(* *))
 (define-lff i_callback_edit_invoke_macro void '(* *))
 (define-lff i_callback_edit_mirror void '(* *))
@@ -554,6 +555,7 @@
 (define-lff o_delete_selected void '(*))
 
 ;;; o_misc.c
+(define-lff o_edit void '(* *))
 (define-lff o_lock void '(*))
 (define-lff o_unlock void '(*))
 

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -51,7 +51,6 @@
             i_callback_clipboard_cut
             i_callback_clipboard_paste
             i_callback_close_wm
-            i_callback_edit_invoke_macro
             i_callback_edit_translate
             i_callback_edit_update
             i_callback_file_save
@@ -217,6 +216,8 @@
 
             x_dialog_hotkeys
 
+            macro_widget_show
+
             schematic_keys_get_event_keyval
             schematic_keys_get_event_modifiers
             schematic_keys_verify_keyval
@@ -237,6 +238,7 @@
             schematic_window_get_draw_grips
             schematic_window_set_draw_grips
             schematic_window_get_gdk_display
+            schematic_window_get_macro_widget
             schematic_window_get_options
             schematic_window_get_place_list
             schematic_window_get_selection_list
@@ -366,6 +368,9 @@
 ;;; gschem_hotkey_dialog.c
 (define-lff x_dialog_hotkeys void '(*))
 
+;;; gschem_macro_widget.c
+(define-lff macro_widget_show void '(*))
+
 ;;; gschem_page_view.c
 (define-lff gschem_page_view_get_page '* '(*))
 (define-lff gschem_page_view_invalidate_all void '(*))
@@ -389,6 +394,7 @@
 (define-lff schematic_window_get_draw_grips int '(*))
 (define-lff schematic_window_set_draw_grips void (list '* int))
 (define-lff schematic_window_get_gdk_display '* '(*))
+(define-lff schematic_window_get_macro_widget '* '(*))
 (define-lff schematic_window_get_options '* '(*))
 (define-lff schematic_window_get_place_list '* '(*))
 (define-lff schematic_window_get_selection_list '* '(*))
@@ -503,7 +509,6 @@
 (define-lff i_callback_clipboard_cut void '(* *))
 (define-lff i_callback_clipboard_paste void '(* *))
 (define-lff i_callback_close_wm int '(* * *))
-(define-lff i_callback_edit_invoke_macro void '(* *))
 (define-lff i_callback_edit_translate void '(* *))
 (define-lff i_callback_edit_update void '(* *))
 (define-lff i_callback_file_save void '(* *))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -51,7 +51,6 @@
             i_callback_clipboard_cut
             i_callback_clipboard_paste
             i_callback_close_wm
-            i_callback_edit_translate
             i_callback_edit_update
             i_callback_file_save
             *i_callback_file_save
@@ -176,6 +175,7 @@
             schematic_window_create_show_text_widget
             schematic_window_create_macro_widget
             schematic_window_create_translate_widget
+            schematic_window_show_translate_widget
             schematic_window_create_notebooks
             schematic_window_create_statusbar
             schematic_window_restore_geometry
@@ -251,6 +251,7 @@
             gschem_options_cycle_net_rubber_band_mode
             gschem_options_cycle_snap_mode
             gschem_options_get_snap_mode
+            gschem_options_set_snap_mode
             gschem_options_get_snap_size
             gschem_options_set_snap_size
 
@@ -408,6 +409,7 @@
 (define-lff gschem_options_cycle_net_rubber_band_mode void '(*))
 (define-lff gschem_options_cycle_snap_mode void '(*))
 (define-lff gschem_options_get_snap_mode int '(*))
+(define-lff gschem_options_set_snap_mode void (list '* int))
 (define-lff gschem_options_get_snap_size int '(*))
 (define-lff gschem_options_set_snap_size void (list '* int))
 
@@ -451,6 +453,7 @@
 (define-lff schematic_window_create_show_text_widget void '(* *))
 (define-lff schematic_window_create_macro_widget void '(* *))
 (define-lff schematic_window_create_translate_widget void '(* *))
+(define-lff schematic_window_show_translate_widget void '(*))
 (define-lff schematic_window_create_notebooks void '(* * *))
 (define-lff schematic_window_create_statusbar void '(* *))
 (define-lff schematic_window_restore_geometry void '(* *))
@@ -509,7 +512,6 @@
 (define-lff i_callback_clipboard_cut void '(* *))
 (define-lff i_callback_clipboard_paste void '(* *))
 (define-lff i_callback_close_wm int '(* * *))
-(define-lff i_callback_edit_translate void '(* *))
 (define-lff i_callback_edit_update void '(* *))
 (define-lff i_callback_file_save void '(* *))
 (define-lfc *i_callback_file_save)

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -53,7 +53,6 @@
             i_callback_close_wm
             i_callback_edit_invoke_macro
             i_callback_edit_translate
-            i_callback_edit_unembed
             i_callback_edit_update
             i_callback_file_save
             *i_callback_file_save
@@ -506,7 +505,6 @@
 (define-lff i_callback_close_wm int '(* * *))
 (define-lff i_callback_edit_invoke_macro void '(* *))
 (define-lff i_callback_edit_translate void '(* *))
-(define-lff i_callback_edit_unembed void '(* *))
 (define-lff i_callback_edit_update void '(* *))
 (define-lff i_callback_file_save void '(* *))
 (define-lfc *i_callback_file_save)

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -84,7 +84,6 @@
             i_callback_page_revert
             i_callback_toolbar_add_bus
             i_callback_toolbar_add_net
-            i_callback_toolbar_edit_select
             i_callback_view_color_edit
             i_callback_view_pan
             i_callback_view_pan_down
@@ -116,6 +115,7 @@
             o_undo_init
 
             o_redraw_cleanstates
+            o_invalidate_rubber
 
             o_place_invalidate_rubber
 
@@ -163,6 +163,7 @@
             schematic_window_create_main_box
             schematic_window_create_work_box
             schematic_window_create_menubar
+            schematic_toolbar_toggle_tool_button_get_active
             schematic_window_get_inside_action
             schematic_window_set_key_event_callback
             schematic_window_set_page_select_widget
@@ -427,6 +428,7 @@
 (define-lff schematic_window_create_main_box '* '(*))
 (define-lff schematic_window_create_work_box '* '())
 (define-lff schematic_window_create_menubar void '(* * *))
+(define-lff schematic_toolbar_toggle_tool_button_get_active int '(*))
 (define-lff schematic_window_get_inside_action int '(*))
 (define-lff schematic_window_set_key_event_callback void '(*))
 (define-lff schematic_window_set_page_select_widget void '(* *))
@@ -533,7 +535,6 @@
 (define-lff i_callback_page_revert void '(* *))
 (define-lff i_callback_toolbar_add_bus void '(* *))
 (define-lff i_callback_toolbar_add_net void '(* *))
-(define-lff i_callback_toolbar_edit_select void '(* *))
 
 ;;; i_basic.c
 (define-lff i_action_stop void '(*))
@@ -545,6 +546,7 @@
 
 ;;; o_basic.c
 (define-lff o_redraw_cleanstates int '(*))
+(define-lff o_invalidate_rubber int '(*))
 
 ;;; o_place.c
 (define-lff o_place_invalidate_rubber void (list '* int))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -58,7 +58,6 @@
             i_callback_edit_mirror
             i_callback_edit_rotate_90
             i_callback_edit_show_hidden
-            i_callback_edit_show_text
             i_callback_edit_translate
             i_callback_edit_unembed
             i_callback_edit_update
@@ -135,6 +134,7 @@
 
             find_text_dialog
             hide_text_dialog
+            show_text_dialog
 
             slot_edit_dialog
             slot_edit_dialog_response
@@ -471,6 +471,7 @@
 
 ;;; gschem_show_hide_text_widget.c
 (define-lff hide_text_dialog void '(*))
+(define-lff show_text_dialog void '(*))
 
 ;;; x_dialog.c
 (define-lff generic_confirm_dialog int '(*))
@@ -505,7 +506,6 @@
 (define-lff i_callback_edit_mirror void '(* *))
 (define-lff i_callback_edit_rotate_90 void '(* *))
 (define-lff i_callback_edit_show_hidden void '(* *))
-(define-lff i_callback_edit_show_text void '(* *))
 (define-lff i_callback_edit_translate void '(* *))
 (define-lff i_callback_edit_unembed void '(* *))
 (define-lff i_callback_edit_update void '(* *))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -51,7 +51,6 @@
             i_callback_clipboard_cut
             i_callback_clipboard_paste
             i_callback_close_wm
-            i_callback_edit_autonumber_text
             i_callback_edit_embed
             i_callback_edit_invoke_macro
             i_callback_edit_translate
@@ -131,6 +130,9 @@
             x_colorcb_update_colors
 
             x_menu_attach_recent_files_submenu
+
+            autonumber_text_dialog
+
             x_show_uri
             x_stroke_init
 
@@ -503,7 +505,6 @@
 (define-lff i_callback_clipboard_cut void '(* *))
 (define-lff i_callback_clipboard_paste void '(* *))
 (define-lff i_callback_close_wm int '(* * *))
-(define-lff i_callback_edit_autonumber_text void '(* *))
 (define-lff i_callback_edit_embed void '(* *))
 (define-lff i_callback_edit_invoke_macro void '(* *))
 (define-lff i_callback_edit_translate void '(* *))
@@ -568,6 +569,9 @@
 (define-lff o_place_invalidate_rubber void (list '* int))
 (define-lff o_place_mirror void '(*))
 (define-lff o_place_rotate void '(*))
+
+;;; x_autonumber.c
+(define-lff autonumber_text_dialog void '(*))
 
 ;;; x_misc.c
 (define-lff x_show_uri int '(* * *))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -54,7 +54,6 @@
             i_callback_edit_autonumber_text
             i_callback_edit_edit
             i_callback_edit_embed
-            i_callback_edit_find
             i_callback_edit_hide_text
             i_callback_edit_invoke_macro
             i_callback_edit_mirror
@@ -134,6 +133,8 @@
             x_menu_attach_recent_files_submenu
             x_show_uri
             x_stroke_init
+
+            find_text_dialog
 
             slot_edit_dialog
             slot_edit_dialog_response
@@ -465,6 +466,9 @@
 (define-lff x_tabs_enabled int '())
 (define-lff x_tabs_hdr_update void '(* *))
 
+;;; gschem_find_text_widget.c
+(define-lff find_text_dialog void '(*))
+
 ;;; x_dialog.c
 (define-lff generic_confirm_dialog int '(*))
 (define-lff generic_filesel_dialog '* (list '* '* int))
@@ -494,7 +498,6 @@
 (define-lff i_callback_edit_autonumber_text void '(* *))
 (define-lff i_callback_edit_edit void '(* *))
 (define-lff i_callback_edit_embed void '(* *))
-(define-lff i_callback_edit_find void '(* *))
 (define-lff i_callback_edit_hide_text void '(* *))
 (define-lff i_callback_edit_invoke_macro void '(* *))
 (define-lff i_callback_edit_mirror void '(* *))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -63,7 +63,6 @@
             i_callback_edit_show_text
             i_callback_edit_translate
             i_callback_edit_unembed
-            i_callback_edit_unlock
             i_callback_edit_update
             i_callback_file_save
             *i_callback_file_save
@@ -115,6 +114,7 @@
             o_delete_selected
 
             o_lock
+            o_unlock
 
             o_move_start
 
@@ -503,7 +503,6 @@
 (define-lff i_callback_edit_show_text void '(* *))
 (define-lff i_callback_edit_translate void '(* *))
 (define-lff i_callback_edit_unembed void '(* *))
-(define-lff i_callback_edit_unlock void '(* *))
 (define-lff i_callback_edit_update void '(* *))
 (define-lff i_callback_file_save void '(* *))
 (define-lfc *i_callback_file_save)
@@ -551,6 +550,7 @@
 
 ;;; o_misc.c
 (define-lff o_lock void '(*))
+(define-lff o_unlock void '(*))
 
 ;;; o_move.c
 (define-lff o_move_start void (list '* int int))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -54,7 +54,6 @@
             i_callback_edit_autonumber_text
             i_callback_edit_copy
             i_callback_edit_delete
-            i_callback_edit_deselect
             i_callback_edit_edit
             i_callback_edit_embed
             i_callback_edit_find
@@ -249,6 +248,7 @@
             text_edit_dialog
 
             o_select_return_first_object
+            o_select_unselect_all
             o_select_visible_unlocked
 
             o_slot_end
@@ -491,7 +491,6 @@
 (define-lff i_callback_edit_autonumber_text void '(* *))
 (define-lff i_callback_edit_copy void '(* *))
 (define-lff i_callback_edit_delete void '(* *))
-(define-lff i_callback_edit_deselect void '(* *))
 (define-lff i_callback_edit_edit void '(* *))
 (define-lff i_callback_edit_embed void '(* *))
 (define-lff i_callback_edit_find void '(* *))
@@ -569,6 +568,7 @@
 
 ;;; o_select.c
 (define-lff o_select_return_first_object '* '(*))
+(define-lff o_select_unselect_all void '(*))
 (define-lff o_select_visible_unlocked void '(*))
 
 ;;; o_slot.c

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -65,7 +65,6 @@
             i_callback_edit_mirror
             i_callback_edit_move
             i_callback_edit_rotate_90
-            i_callback_edit_select
             i_callback_edit_show_hidden
             i_callback_edit_show_text
             i_callback_edit_translate
@@ -503,7 +502,6 @@
 (define-lff i_callback_edit_mirror void '(* *))
 (define-lff i_callback_edit_move void '(* *))
 (define-lff i_callback_edit_rotate_90 void '(* *))
-(define-lff i_callback_edit_select void '(* *))
 (define-lff i_callback_edit_show_hidden void '(* *))
 (define-lff i_callback_edit_show_text void '(* *))
 (define-lff i_callback_edit_translate void '(* *))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -55,7 +55,6 @@
             i_callback_edit_embed
             i_callback_edit_invoke_macro
             i_callback_edit_mirror
-            i_callback_edit_rotate_90
             i_callback_edit_show_hidden
             i_callback_edit_translate
             i_callback_edit_unembed
@@ -112,10 +111,12 @@
             o_edit
             o_lock
             o_unlock
+            o_rotate_world_update
 
             o_move_start
 
             o_place_invalidate_rubber
+            o_place_rotate
 
             page_select_widget_new
             page_select_widget_update
@@ -505,7 +506,6 @@
 (define-lff i_callback_edit_embed void '(* *))
 (define-lff i_callback_edit_invoke_macro void '(* *))
 (define-lff i_callback_edit_mirror void '(* *))
-(define-lff i_callback_edit_rotate_90 void '(* *))
 (define-lff i_callback_edit_show_hidden void '(* *))
 (define-lff i_callback_edit_translate void '(* *))
 (define-lff i_callback_edit_unembed void '(* *))
@@ -558,12 +558,14 @@
 (define-lff o_edit void '(* *))
 (define-lff o_lock void '(*))
 (define-lff o_unlock void '(*))
+(define-lff o_rotate_world_update void (list '* int int int '*))
 
 ;;; o_move.c
 (define-lff o_move_start void (list '* int int))
 
 ;;; o_place.c
 (define-lff o_place_invalidate_rubber void (list '* int))
+(define-lff o_place_rotate void '(*))
 
 ;;; x_misc.c
 (define-lff x_show_uri int '(* * *))

--- a/libleptongui/scheme/schematic/toolbar.scm
+++ b/libleptongui/scheme/schematic/toolbar.scm
@@ -200,7 +200,7 @@ Right mouse button to cancel"
                                           "select"
                                           "Select"
                                           "Select mode"
-                                          i_callback_toolbar_edit_select
+                                          callback-toolbar-edit-select
                                           12)))
 
           (schematic_toolbar_insert_separator *toolbar 13)

--- a/libleptongui/src/gschem_toplevel.c
+++ b/libleptongui/src/gschem_toplevel.c
@@ -1156,3 +1156,17 @@ schematic_window_set_selection_list (GschemToplevel *w_current,
 
   lepton_page_set_selection_list (active_page, selection_list);
 }
+
+
+/*! \brief Get the macro widget for this schematic window.
+ *
+ *  \param [in] w_current The schematic window.
+ *  \return The macro widget pointer.
+ */
+GtkWidget*
+schematic_window_get_macro_widget (GschemToplevel *w_current)
+{
+  g_return_val_if_fail (w_current != NULL, NULL);
+
+  return w_current->macro_widget;
+}

--- a/libleptongui/src/gschem_toplevel.c
+++ b/libleptongui/src/gschem_toplevel.c
@@ -1119,3 +1119,40 @@ schematic_window_set_page_select_widget (GschemToplevel *w_current,
 
   w_current->page_select_widget = widget;
 }
+
+
+/*! \brief Get the list of selected objects for this schematic window.
+ *
+ *  \param [in] w_current The schematic window.
+ *  \return The list of objects.
+ */
+LeptonSelection*
+schematic_window_get_selection_list (GschemToplevel *w_current)
+{
+  g_return_val_if_fail (w_current != NULL, NULL);
+
+  LeptonPage *active_page = schematic_window_get_active_page (w_current);
+
+  g_return_val_if_fail (active_page != NULL, NULL);
+
+  return lepton_page_get_selection_list (active_page);
+}
+
+
+/*! \brief Set the list of selected objects for this schematic window.
+ *
+ *  \param [in] w_current The schematic window.
+ *  \param [in] selection_list The new list of objects to select.
+ */
+void
+schematic_window_set_selection_list (GschemToplevel *w_current,
+                                     LeptonSelection *selection_list)
+{
+  g_return_if_fail (w_current != NULL);
+
+  LeptonPage *active_page = schematic_window_get_active_page (w_current);
+
+  g_return_if_fail (active_page != NULL);
+
+  lepton_page_set_selection_list (active_page, selection_list);
+}

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -295,26 +295,6 @@ i_callback_edit_update (GtkWidget *widget, gpointer data)
 }
 
 
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
-void
-i_callback_edit_autonumber_text (GtkWidget *widget, gpointer data)
-{
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-
-  g_return_if_fail (w_current != NULL);
-
-  /* This is a new addition 3/15 to prevent this from executing
-   * inside an action */
-  if (schematic_window_get_inside_action (w_current))
-    return;
-
-  autonumber_text_dialog(w_current);
-}
-
 /*! \section view-menu View Menu Callback Functions */
 /*! \brief Toggle the visibility of the sidebar
  */

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -119,55 +119,6 @@ i_callback_file_save (GtkWidget *widget, gpointer data)
 /*! \todo Finish function documentation!!!
  *  \brief
  *  \par Function Description
- *  This function rotate all objects in the selection list by 90 degrees.
- *
- */
-void
-i_callback_edit_rotate_90 (GtkWidget *widget, gpointer data)
-{
-  gint wx, wy;
-  GList *object_list;
-  GschemToplevel *w_current = NULL;
-  LeptonPage* active_page = NULL;
-
-  w_current = GSCHEM_TOPLEVEL (data);
-  g_return_if_fail (w_current != NULL);
-
-  active_page = schematic_window_get_active_page (w_current);
-
-  if (active_page == NULL)
-  {
-    return;
-  }
-
-  if (schematic_window_get_inside_action (w_current) &&
-      schematic_window_get_place_list (w_current) != NULL)
-  {
-    o_place_rotate (w_current);
-    return;
-  }
-
-  if (!g_action_get_position (w_current, TRUE, &wx, &wy))
-  {
-    i_set_state(w_current, ROTATEMODE);
-    return;
-  }
-
-  o_redraw_cleanstates(w_current);
-
-  LeptonSelection *selection = schematic_window_get_selection_list (w_current);
-
-  object_list = lepton_list_get_glist (selection);
-
-  if (object_list) {
-    /* Allow o_rotate_world_update to redraw the objects */
-    o_rotate_world_update(w_current, wx, wy, 90, object_list);
-  }
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
  *
  */
 void

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -116,23 +116,6 @@ i_callback_file_save (GtkWidget *widget, gpointer data)
 
 /*! \section edit-menu Edit Menu Callback Functions */
 
-/*! \brief Deselect all objects on page.
- * \par Function Description
- * Sets all objects on page as deselected.
- */
-void
-i_callback_edit_deselect (GtkWidget *widget, gpointer data)
-{
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-  o_redraw_cleanstates (w_current);
-
-  o_select_unselect_all (w_current);
-
-  i_set_state (w_current, SELECT);
-  i_action_stop (w_current);
-  i_update_menus (w_current);
-}
-
 /*! \todo Finish function documentation!!!
  *  \brief
  *  \par Function Description

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -139,7 +139,7 @@ i_callback_edit_mirror (GtkWidget *widget, gpointer data)
   }
 
   if (schematic_window_get_inside_action (w_current) &&
-      (active_page->place_list != NULL))
+      schematic_window_get_place_list (w_current) != NULL)
   {
     o_place_mirror (w_current);
     return;

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -155,7 +155,9 @@ i_callback_edit_rotate_90 (GtkWidget *widget, gpointer data)
 
   o_redraw_cleanstates(w_current);
 
-  object_list = lepton_list_get_glist (active_page->selection_list);
+  LeptonSelection *selection = schematic_window_get_selection_list (w_current);
+
+  object_list = lepton_list_get_glist (selection);
 
   if (object_list) {
     /* Allow o_rotate_world_update to redraw the objects */

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -428,26 +428,6 @@ i_callback_edit_show_hidden (GtkWidget *widget, gpointer data)
  *
  */
 void
-i_callback_edit_hide_text (GtkWidget *widget, gpointer data)
-{
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-
-  g_return_if_fail (w_current != NULL);
-
-  /* This is a new addition 3/15 to prevent this from executing
-   * inside an action */
-  if (schematic_window_get_inside_action (w_current))
-    return;
-
-  hide_text_dialog(w_current);
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
-void
 i_callback_edit_show_text (GtkWidget *widget, gpointer data)
 {
   GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -122,31 +122,6 @@ i_callback_file_save (GtkWidget *widget, gpointer data)
  *
  */
 void
-i_callback_edit_copy (GtkWidget *widget, gpointer data)
-{
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-  gint wx, wy;
-
-  g_return_if_fail (w_current != NULL);
-
-  if (o_select_return_first_object(w_current)) {
-    o_redraw_cleanstates(w_current);
-    if (g_action_get_position (w_current, TRUE, &wx, &wy))
-    {
-      o_copy_start(w_current, wx, wy);
-    }
-    i_set_state (w_current, COPYMODE);
-  } else {
-    i_set_state_msg(w_current, SELECT, _("Select objs first"));
-  }
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
-void
 i_callback_edit_mcopy (GtkWidget *widget, gpointer data)
 {
   GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -122,29 +122,6 @@ i_callback_file_save (GtkWidget *widget, gpointer data)
  *
  */
 void
-i_callback_edit_delete (GtkWidget *widget, gpointer data)
-{
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-
-  g_return_if_fail (w_current != NULL);
-
-  if (o_select_return_first_object(w_current)) {
-    o_redraw_cleanstates(w_current);
-    o_delete_selected(w_current);
-    /* if you delete the objects you must go into select
-     * mode after the delete */
-    i_action_stop (w_current);
-    i_set_state(w_current, SELECT);
-    i_update_menus(w_current);
-  }
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
-void
 i_callback_edit_edit (GtkWidget *widget, gpointer data)
 {
   GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -428,26 +428,6 @@ i_callback_edit_show_hidden (GtkWidget *widget, gpointer data)
  *
  */
 void
-i_callback_edit_show_text (GtkWidget *widget, gpointer data)
-{
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-
-  g_return_if_fail (w_current != NULL);
-
-  /* This is a new addition 3/15 to prevent this from executing
-   * inside an action */
-  if (schematic_window_get_inside_action (w_current))
-    return;
-
-  show_text_dialog(w_current);
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
-void
 i_callback_edit_autonumber_text (GtkWidget *widget, gpointer data)
 {
   GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -225,22 +225,6 @@ i_callback_edit_mirror (GtkWidget *widget, gpointer data)
   }
 }
 
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *  Thus function unlocks all objects in selection list.
- */
-void
-i_callback_edit_unlock (GtkWidget *widget, gpointer data)
-{
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-
-  g_return_if_fail (w_current != NULL);
-
-  if (o_select_return_first_object(w_current)) {
-    o_unlock(w_current);
-  }
-}
 
 /*! \todo Finish function documentation!!!
  *  \brief

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -421,25 +421,6 @@ i_callback_edit_show_hidden (GtkWidget *widget, gpointer data)
   o_edit_show_hidden (w_current, lepton_page_objects (active_page));
 }
 
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
-void
-i_callback_edit_find (GtkWidget *widget, gpointer data)
-{
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-
-  g_return_if_fail (w_current != NULL);
-
-  /* This is a new addition 3/15 to prevent this from executing
-   * inside an action */
-  if (schematic_window_get_inside_action (w_current))
-    return;
-
-  find_text_dialog(w_current);
-}
 
 /*! \todo Finish function documentation!!!
  *  \brief

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -147,7 +147,8 @@ void i_callback_toolbar_edit_select(GtkWidget* widget, gpointer data)
   GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
   g_return_if_fail (w_current != NULL);
 
-  if (gtk_toggle_tool_button_get_active (GTK_TOGGLE_TOOL_BUTTON (widget))) {
+  if (schematic_toolbar_toggle_tool_button_get_active (widget))
+  {
     if (!o_invalidate_rubber (w_current)) {
       i_callback_cancel (widget, w_current);
     }
@@ -1380,7 +1381,8 @@ void i_callback_toolbar_add_net(GtkWidget* widget, gpointer data)
   GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
   scm_dynwind_begin ((scm_t_dynwind_flags) 0);
   g_dynwind_window (w_current);
-  if (gtk_toggle_tool_button_get_active (GTK_TOGGLE_TOOL_BUTTON (widget))) {
+  if (schematic_toolbar_toggle_tool_button_get_active (widget))
+  {
     i_callback_add_net (widget, w_current);
   }
   scm_dynwind_end ();
@@ -1423,7 +1425,8 @@ void i_callback_toolbar_add_bus(GtkWidget* widget, gpointer data)
   GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
   scm_dynwind_begin ((scm_t_dynwind_flags) 0);
   g_dynwind_window (w_current);
-  if (gtk_toggle_tool_button_get_active (GTK_TOGGLE_TOOL_BUTTON (widget))) {
+  if (schematic_toolbar_toggle_tool_button_get_active (widget))
+  {
     i_callback_add_bus (widget, w_current);
   }
   scm_dynwind_end ();

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -294,23 +294,6 @@ i_callback_edit_update (GtkWidget *widget, gpointer data)
 
 }
 
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
-void
-i_callback_edit_show_hidden (GtkWidget *widget, gpointer data)
-{
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-
-  g_return_if_fail (w_current != NULL);
-
-  LeptonPage *active_page = schematic_window_get_active_page (w_current);
-
-  o_edit_show_hidden (w_current, lepton_page_objects (active_page));
-}
-
 
 /*! \todo Finish function documentation!!!
  *  \brief

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -128,9 +128,9 @@ i_callback_edit_edit (GtkWidget *widget, gpointer data)
 
   g_return_if_fail (w_current != NULL);
 
-  LeptonPage *active_page = schematic_window_get_active_page (w_current);
+  LeptonSelection *selection = schematic_window_get_selection_list (w_current);
 
-  o_edit(w_current, lepton_list_get_glist (active_page->selection_list));
+  o_edit (w_current, lepton_list_get_glist (selection));
 }
 
 

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -114,54 +114,6 @@ i_callback_file_save (GtkWidget *widget, gpointer data)
 } /* i_callback_file_save() */
 
 
-/*! \section edit-menu Edit Menu Callback Functions */
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *  This function updates components
- *
- */
-void
-i_callback_edit_update (GtkWidget *widget, gpointer data)
-{
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-  GList *selected_components = NULL;
-  GList *iter;
-
-  g_return_if_fail (w_current != NULL);
-
-  if (o_select_selected(w_current)) {
-
-    /* Updating components modifies the selection. Therefore,
-     * create a new list of only the LeptonObjects we want to
-     * update from the current selection, then iterate over that
-     * new list to perform the update. */
-    LeptonSelection *selection = schematic_window_get_selection_list (w_current);
-    GList *s_current = lepton_list_get_glist (selection);
-    for (iter = s_current; iter != NULL; iter = g_list_next (iter))
-    {
-      LeptonObject *o_current = (LeptonObject *) iter->data;
-      if (lepton_object_is_component (o_current)) {
-        selected_components = g_list_prepend (selected_components, o_current);
-      }
-    }
-    for (iter = selected_components; iter != NULL; iter = g_list_next (iter)) {
-      LeptonObject *o_current = (LeptonObject *) iter->data;
-      iter->data = o_update_component (w_current, o_current);
-    }
-    g_list_free (selected_components);
-
-  } else {
-    /* nothing selected, go back to select state */
-    o_redraw_cleanstates(w_current);
-    i_action_stop (w_current);
-    i_set_state(w_current, SELECT);
-  }
-
-}
-
-
 /*! \section view-menu View Menu Callback Functions */
 /*! \brief Toggle the visibility of the sidebar
  */

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -122,31 +122,6 @@ i_callback_file_save (GtkWidget *widget, gpointer data)
  *
  */
 void
-i_callback_edit_move (GtkWidget *widget, gpointer data)
-{
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-  gint wx, wy;
-
-  g_return_if_fail (w_current != NULL);
-
-  if (o_select_return_first_object(w_current)) {
-    o_redraw_cleanstates(w_current);
-    if (g_action_get_position (w_current, TRUE, &wx, &wy))
-    {
-      o_move_start(w_current, wx, wy);
-    }
-    i_set_state (w_current, MOVEMODE);
-  } else {
-    i_set_state_msg(w_current, SELECT, _("Select objs first"));
-  }
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
-void
 i_callback_edit_delete (GtkWidget *widget, gpointer data)
 {
   GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -134,28 +134,6 @@ i_callback_edit_select (GtkWidget *widget, gpointer data)
   i_action_stop (w_current);
 }
 
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- *  \note
- *  don't use the widget parameter on this function, or do some checking...
- * since there is a call: widget = NULL, data = 0 (will be w_current hack)
- */
-void i_callback_toolbar_edit_select(GtkWidget* widget, gpointer data)
-{
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-  g_return_if_fail (w_current != NULL);
-
-  if (schematic_toolbar_toggle_tool_button_get_active (widget))
-  {
-    if (!o_invalidate_rubber (w_current)) {
-      i_callback_cancel (widget, w_current);
-    }
-    i_callback_edit_select (widget, data);
-  }
-}
-
 
 /*! \brief Deselect all objects on page.
  * \par Function Description

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -122,31 +122,6 @@ i_callback_file_save (GtkWidget *widget, gpointer data)
  *
  */
 void
-i_callback_edit_mcopy (GtkWidget *widget, gpointer data)
-{
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-  gint wx, wy;
-
-  g_return_if_fail (w_current != NULL);
-
-  if (o_select_return_first_object(w_current)) {
-    o_redraw_cleanstates(w_current);
-    if (g_action_get_position (w_current, TRUE, &wx, &wy))
-    {
-      o_copy_start(w_current, wx, wy);
-    }
-    i_set_state (w_current, MCOPYMODE);
-  } else {
-    i_set_state_msg(w_current, SELECT, _("Select objs first"));
-  }
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
-void
 i_callback_edit_move (GtkWidget *widget, gpointer data)
 {
   GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -116,25 +116,6 @@ i_callback_file_save (GtkWidget *widget, gpointer data)
 
 /*! \section edit-menu Edit Menu Callback Functions */
 
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- *  \note
- *  Select also does not update the middle button shortcut.
- */
-void
-i_callback_edit_select (GtkWidget *widget, gpointer data)
-{
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-  o_redraw_cleanstates(w_current);
-
-  /* this is probably the only place this should be */
-  i_set_state(w_current, SELECT);
-  i_action_stop (w_current);
-}
-
-
 /*! \brief Deselect all objects on page.
  * \par Function Description
  * Sets all objects on page as deselected.

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -179,8 +179,8 @@ i_callback_edit_unembed (GtkWidget *widget, gpointer data)
   /* anything selected ? */
   if (o_select_selected(w_current)) {
     /* yes, unembed each selected component */
-    LeptonPage* active_page = schematic_window_get_active_page (w_current);
-    GList* s_current = lepton_list_get_glist (active_page->selection_list);
+    LeptonSelection *selection = schematic_window_get_selection_list (w_current);
+    GList* s_current = lepton_list_get_glist (selection);
 
     while (s_current != NULL) {
       o_current = (LeptonObject *) s_current->data;

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -119,42 +119,6 @@ i_callback_file_save (GtkWidget *widget, gpointer data)
 /*! \todo Finish function documentation!!!
  *  \brief
  *  \par Function Description
- *
- */
-void
-i_callback_edit_translate (GtkWidget *widget, gpointer data)
-{
-  SchematicSnapMode snap_mode;
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-
-  g_return_if_fail (w_current != NULL);
-
-  snap_mode = gschem_options_get_snap_mode (w_current->options);
-
-  if (snap_mode == SNAP_OFF) {
-    g_message (_("WARNING: Do not translate with snap off!"));
-    g_message (_("WARNING: Turning snap on and continuing "
-                 "with translate."));
-    gschem_options_set_snap_mode (w_current->options, SNAP_GRID);
-    i_show_state(w_current, NULL); /* update status on screen */
-  }
-
-  if (gschem_options_get_snap_size (w_current->options) != 100) {
-    g_message (_("WARNING: Snap grid size is "
-                 "not equal to 100!"));
-    g_message (_("WARNING: If you are translating a symbol "
-                 "to the origin, the snap grid size should be "
-                 "set to 100"));
-  }
-
-  gtk_widget_show (w_current->translate_widget);
-  gtk_widget_grab_focus (gschem_translate_widget_get_entry (GSCHEM_TRANSLATE_WIDGET (w_current->translate_widget)));
-}
-
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
  *  This function updates components
  *
  */

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -158,7 +158,7 @@ i_callback_edit_invoke_macro (GtkWidget *widget, gpointer data)
 
   g_return_if_fail (w_current != NULL);
 
-  macro_widget_show (w_current->macro_widget);
+  macro_widget_show (schematic_window_get_macro_widget (w_current));
 }
 
 

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -161,49 +161,6 @@ i_callback_edit_invoke_macro (GtkWidget *widget, gpointer data)
   macro_widget_show (w_current->macro_widget);
 }
 
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *  This function embedds all objects in selection list
- *
- */
-void
-i_callback_edit_embed (GtkWidget *widget, gpointer data)
-{
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-  LeptonObject *o_current;
-
-  g_return_if_fail (w_current != NULL);
-
-  /* anything selected ? */
-  if (o_select_selected(w_current)) {
-    /* yes, embed each selected component */
-    LeptonSelection *selection = schematic_window_get_selection_list (w_current);
-    GList* s_current = lepton_list_get_glist (selection);
-
-    while (s_current != NULL) {
-      o_current = (LeptonObject *) s_current->data;
-      g_assert (o_current != NULL);
-
-      if (lepton_object_is_component (o_current))
-        lepton_component_object_embed (o_current);
-      else if (lepton_object_is_picture (o_current))
-        lepton_picture_object_embed (o_current);
-
-      s_current = g_list_next(s_current);
-    }
-
-    o_undo_savestate_old(w_current, UNDO_ALL);
-    page_select_widget_update (w_current);
-
-  } else {
-    /* nothing selected, go back to select state */
-    o_redraw_cleanstates(w_current);
-    i_action_stop (w_current);
-    i_set_state(w_current, SELECT);
-  }
-
-}
 
 /*! \todo Finish function documentation!!!
  *  \brief

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -122,51 +122,6 @@ i_callback_file_save (GtkWidget *widget, gpointer data)
  *
  */
 void
-i_callback_edit_mirror (GtkWidget *widget, gpointer data)
-{
-  gint wx, wy;
-  GList *object_list;
-  GschemToplevel *w_current = NULL;
-  LeptonPage* active_page = NULL;
-
-  w_current = GSCHEM_TOPLEVEL (data);
-  g_return_if_fail (w_current != NULL);
-
-  active_page = schematic_window_get_active_page (w_current);
-
-  if (active_page == NULL) {
-    return;
-  }
-
-  if (schematic_window_get_inside_action (w_current) &&
-      schematic_window_get_place_list (w_current) != NULL)
-  {
-    o_place_mirror (w_current);
-    return;
-  }
-
-  if (!g_action_get_position (w_current, TRUE, &wx, &wy))
-  {
-    i_set_state(w_current, MIRRORMODE);
-    return;
-  }
-
-  o_redraw_cleanstates(w_current);
-
-  object_list = lepton_list_get_glist (schematic_window_get_selection_list (w_current));
-
-  if (object_list) {
-    o_mirror_world_update(w_current, wx, wy, object_list);
-  }
-}
-
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
-void
 i_callback_edit_translate (GtkWidget *widget, gpointer data)
 {
   SchematicSnapMode snap_mode;

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -141,7 +141,7 @@ i_callback_edit_rotate_90 (GtkWidget *widget, gpointer data)
   }
 
   if (schematic_window_get_inside_action (w_current) &&
-      (active_page->place_list != NULL))
+      schematic_window_get_place_list (w_current) != NULL)
   {
     o_place_rotate (w_current);
     return;

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -178,8 +178,8 @@ i_callback_edit_embed (GtkWidget *widget, gpointer data)
   /* anything selected ? */
   if (o_select_selected(w_current)) {
     /* yes, embed each selected component */
-    LeptonPage* active_page = schematic_window_get_active_page (w_current);
-    GList* s_current = lepton_list_get_glist (active_page->selection_list);
+    LeptonSelection *selection = schematic_window_get_selection_list (w_current);
+    GList* s_current = lepton_list_get_glist (selection);
 
     while (s_current != NULL) {
       o_current = (LeptonObject *) s_current->data;

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -228,24 +228,6 @@ i_callback_edit_mirror (GtkWidget *widget, gpointer data)
 /*! \todo Finish function documentation!!!
  *  \brief
  *  \par Function Description
- *  This function locks all objects in selection list.
- *
- */
-void
-i_callback_edit_lock (GtkWidget *widget, gpointer data)
-{
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-
-  g_return_if_fail (w_current != NULL);
-
-  if (o_select_return_first_object(w_current)) {
-    o_lock(w_current);
-  }
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
  *  Thus function unlocks all objects in selection list.
  */
 void

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -155,22 +155,6 @@ void i_callback_toolbar_edit_select(GtkWidget* widget, gpointer data)
   }
 }
 
-/*! \brief Select all objects on page.
- * \par Function Description
- * Sets all objects on page as selected.
- */
-void
-i_callback_edit_select_all (GtkWidget *widget, gpointer data)
-{
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-  o_redraw_cleanstates (w_current);
-
-  o_select_visible_unlocked (w_current);
-
-  i_set_state (w_current, SELECT);
-  i_action_stop (w_current);
-  i_update_menus (w_current);
-}
 
 /*! \brief Deselect all objects on page.
  * \par Function Description

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -165,50 +165,6 @@ i_callback_edit_invoke_macro (GtkWidget *widget, gpointer data)
 /*! \todo Finish function documentation!!!
  *  \brief
  *  \par Function Description
- *  This function unembedds all objects in selection list.
- *
- */
-void
-i_callback_edit_unembed (GtkWidget *widget, gpointer data)
-{
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-  LeptonObject *o_current;
-
-  g_return_if_fail (w_current != NULL);
-
-  /* anything selected ? */
-  if (o_select_selected(w_current)) {
-    /* yes, unembed each selected component */
-    LeptonSelection *selection = schematic_window_get_selection_list (w_current);
-    GList* s_current = lepton_list_get_glist (selection);
-
-    while (s_current != NULL) {
-      o_current = (LeptonObject *) s_current->data;
-      g_assert (o_current != NULL);
-
-      if (lepton_object_is_component (o_current))
-        lepton_component_object_unembed (o_current);
-      else if (lepton_object_is_picture (o_current))
-        lepton_picture_object_unembed (o_current);
-
-      s_current = g_list_next(s_current);
-    }
-
-    o_undo_savestate_old(w_current, UNDO_ALL);
-    page_select_widget_update (w_current);
-
-  } else {
-    /* nothing selected, go back to select state */
-    o_redraw_cleanstates(w_current);
-    i_action_stop (w_current);
-    i_set_state(w_current, SELECT);
-  }
-
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
  *  This function updates components
  *
  */

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -151,16 +151,6 @@ i_callback_edit_translate (GtkWidget *widget, gpointer data)
   gtk_widget_grab_focus (gschem_translate_widget_get_entry (GSCHEM_TRANSLATE_WIDGET (w_current->translate_widget)));
 }
 
-void
-i_callback_edit_invoke_macro (GtkWidget *widget, gpointer data)
-{
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-
-  g_return_if_fail (w_current != NULL);
-
-  macro_widget_show (schematic_window_get_macro_widget (w_current));
-}
-
 
 /*! \todo Finish function documentation!!!
  *  \brief

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -126,7 +126,6 @@ void
 i_callback_edit_update (GtkWidget *widget, gpointer data)
 {
   GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-  GList *selection;
   GList *selected_components = NULL;
   GList *iter;
 
@@ -138,9 +137,10 @@ i_callback_edit_update (GtkWidget *widget, gpointer data)
      * create a new list of only the LeptonObjects we want to
      * update from the current selection, then iterate over that
      * new list to perform the update. */
-    LeptonPage *active_page = schematic_window_get_active_page (w_current);
-    selection = lepton_list_get_glist (active_page->selection_list);
-    for (iter = selection; iter != NULL; iter = g_list_next (iter)) {
+    LeptonSelection *selection = schematic_window_get_selection_list (w_current);
+    GList *s_current = lepton_list_get_glist (selection);
+    for (iter = s_current; iter != NULL; iter = g_list_next (iter))
+    {
       LeptonObject *o_current = (LeptonObject *) iter->data;
       if (lepton_object_is_component (o_current)) {
         selected_components = g_list_prepend (selected_components, o_current);

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -119,24 +119,6 @@ i_callback_file_save (GtkWidget *widget, gpointer data)
 /*! \todo Finish function documentation!!!
  *  \brief
  *  \par Function Description
- *
- */
-void
-i_callback_edit_edit (GtkWidget *widget, gpointer data)
-{
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-
-  g_return_if_fail (w_current != NULL);
-
-  LeptonSelection *selection = schematic_window_get_selection_list (w_current);
-
-  o_edit (w_current, lepton_list_get_glist (selection));
-}
-
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
  *  This function rotate all objects in the selection list by 90 degrees.
  *
  */

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -153,7 +153,7 @@ i_callback_edit_mirror (GtkWidget *widget, gpointer data)
 
   o_redraw_cleanstates(w_current);
 
-  object_list = lepton_list_get_glist (active_page->selection_list );
+  object_list = lepton_list_get_glist (schematic_window_get_selection_list (w_current));
 
   if (object_list) {
     o_mirror_world_update(w_current, wx, wy, object_list);

--- a/libleptongui/src/toolbar.c
+++ b/libleptongui/src/toolbar.c
@@ -345,3 +345,19 @@ schematic_toolbar_update (GtkWidget *toolbar,
     gtk_toggle_tool_button_set_active (GTK_TOGGLE_TOOL_BUTTON (button), TRUE);
   }
 }
+
+
+/*! \brief Return the state of a toolbar toggle button.
+ *  \par Function Description
+ *
+ * Queries the state of a toggle button and returns TRUE if it is
+ * pressed in and FALSE if it is raised.
+ *
+ * \param [in] The button widget.
+ * \return TRUE if the button is active, FALSE if not.
+ */
+gboolean
+schematic_toolbar_toggle_tool_button_get_active (GtkWidget *button)
+{
+  return gtk_toggle_tool_button_get_active (GTK_TOGGLE_TOOL_BUTTON (button));
+}

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -1109,6 +1109,14 @@ schematic_window_create_translate_widget (GschemToplevel *w_current,
 }
 
 
+void
+schematic_window_show_translate_widget (GschemToplevel *w_current)
+{
+  gtk_widget_show (w_current->translate_widget);
+  gtk_widget_grab_focus (gschem_translate_widget_get_entry (GSCHEM_TRANSLATE_WIDGET (w_current->translate_widget)));
+}
+
+
 
 void
 schematic_window_create_statusbar (GschemToplevel *w_current,


### PR DESCRIPTION
Apart from reducing the code base of Lepton, it allows for further refactoring in Scheme as several lower level functions gets available there.