### PR TITLE
netlist: Fix error output if a schematic file has not been found.

### DIFF
--- a/liblepton/scheme/netlist.scm
+++ b/liblepton/scheme/netlist.scm
@@ -851,7 +851,14 @@ Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>
   (and (eq? (netlist-mode) 'spice)
        (set! get-uref get-spice-refdes))
   (for-each process-gafrc* files)
-  (set-toplevel-schematic! (make-toplevel-schematic files)))
+  (catch 'system-error
+    (lambda () (set-toplevel-schematic! (make-toplevel-schematic files)))
+    (lambda (key subr message args rest)
+      (netlist-error 1
+                     (format #f
+                             (G_ "Failed to open schematic files: ~?\n")
+                             message
+                             args)))))
 
 
 (define (catch-handler tag . args)


### PR DESCRIPTION
When a system error occurs, display a message about it instead of backtrace.

Discussed in #937