### PR TITLE
Get rid of three C functions related to object locking

### DIFF
--- a/liblepton/include/liblepton/object_list.h
+++ b/liblepton/include/liblepton/object_list.h
@@ -1,7 +1,7 @@
 /* Lepton EDA library
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2016 gEDA Contributors
- * Copyright (C) 2017-2021 Lepton EDA Contributors
+ * Copyright (C) 2017-2022 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -40,9 +40,6 @@ lepton_object_list_rotate (const GList *objects,
 void
 lepton_object_list_set_color (const GList *objects,
                               int color);
-void
-lepton_object_list_set_selectable (const GList *objects,
-                                   gboolean selectable);
 gchar*
 lepton_object_list_to_buffer (const GList *objects);
 

--- a/liblepton/src/object_list.c
+++ b/liblepton/src/object_list.c
@@ -289,24 +289,6 @@ lepton_object_list_set_color (const GList *objects,
   }
 }
 
-/*! \brief Set a list of objects as selectable or not
- *
- *  \param [in] objects the list of objects to set as selectable or not
- *  \param [in] selectable the new state of the objects
- */
-void
-lepton_object_list_set_selectable (const GList *objects,
-                                   gboolean selectable)
-{
-  const GList *iter = objects;
-
-  while (iter != NULL) {
-    LeptonObject *object = (LeptonObject*)iter->data;
-
-    lepton_object_set_selectable (object, selectable);
-    iter = g_list_next (iter);
-  }
-}
 
 /*! \brief "Save" a file into a string buffer
  *  \par Function Description

--- a/libleptongui/include/gschem_toplevel.h
+++ b/libleptongui/include/gschem_toplevel.h
@@ -353,4 +353,10 @@ schematic_window_set_selection_list (GschemToplevel *w_current,
 GtkWidget*
 schematic_window_get_macro_widget (GschemToplevel *w_current);
 
+int
+schematic_window_get_shift_key_pressed (GschemToplevel *w_current);
+
+void
+schematic_window_set_shift_key_pressed (GschemToplevel *w_current,
+                                        int state);
 G_END_DECLS

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -289,7 +289,6 @@ o_line_visible (GschemToplevel *w_current,
                 int *y2);
 /* o_misc.c */
 void o_edit(GschemToplevel *w_current, GList *list);
-void o_unlock(GschemToplevel *w_current);
 void o_rotate_world_update(GschemToplevel *w_current, int centerx, int centery, int angle, GList *list);
 void o_mirror_world_update(GschemToplevel *w_current, int centerx, int centery, GList *list);
 void o_edit_show_hidden_lowlevel(GschemToplevel *w_current, const GList *o_list);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -374,7 +374,6 @@ void o_select_connected_nets(GschemToplevel *w_current, LeptonObject* o_current)
 LeptonObject *o_select_return_first_object(GschemToplevel *w_current);
 int o_select_selected(GschemToplevel *w_current);
 void o_select_unselect_all(GschemToplevel *w_current);
-void o_select_visible_unlocked(GschemToplevel *w_current);
 void o_select_move_to_place_list(GschemToplevel *w_current);
 /* o_slot.c */
 void o_slot_end(GschemToplevel *w_current, LeptonObject *object, const char *string);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -289,7 +289,6 @@ o_line_visible (GschemToplevel *w_current,
                 int *y2);
 /* o_misc.c */
 void o_edit(GschemToplevel *w_current, GList *list);
-void o_lock(GschemToplevel *w_current);
 void o_unlock(GschemToplevel *w_current);
 void o_rotate_world_update(GschemToplevel *w_current, int centerx, int centery, int angle, GList *list);
 void o_mirror_world_update(GschemToplevel *w_current, int centerx, int centery, GList *list);

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -397,9 +397,28 @@ the snap grid size should be set to 100")))
 
 
 ;;; Unlock all objects in selection list.
+;;; The function unlocks currenly selected objects.  Locked
+;;; objects can be selected with a bounding box.
 (define-action-public (&edit-unlock #:label (G_ "Unlock"))
-  (unless (null? (page-selection (active-page)))
-    (o_unlock (*current-window))))
+  (define *window (*current-window))
+  (define (unlock-object! object)
+    (set-object-selectable! object #t))
+  (define (unlock-object-with-attribs! object)
+    (unlock-object! object)
+    (for-each unlock-object! (object-attribs object)))
+
+  ;; Unlock selected objects with their attributes.
+  (for-each unlock-object-with-attribs! (page-selection (active-page)))
+
+  ;; Apart from setting the current page as changed, the function
+  ;; updates the Page manager.
+  (schematic_window_active_page_changed *window)
+
+  (undo-save-state)
+
+  ;; Refresh page view to properly restore attributes' colors.
+  (gschem_page_view_invalidate_all
+   (gschem_toplevel_get_current_page_view *window)))
 
 
 (define-action-public (&edit-invoke-macro #:label (G_ "Invoke Macro"))

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -186,17 +186,7 @@
 ;;; attached attributes whether visible or invisible.
 (define-action-public (&edit-select-all #:label (G_ "Select All")
                                         #:icon "gtk-select-all")
-  (define *window (*current-window))
-  (define show-hidden-text?
-    (true? (gschem_toplevel_get_show_hidden_text *window)))
-
-  (o_redraw_cleanstates *window)
-
-  (o_select_unselect_all *window)
-
-  (for-each
-
-   (lambda (object)
+   (define (select-visible-and-selectable! object)
      ;; Skip invisible text objects and locked objects.
      (unless (or (and (text? object)
                       (not (text-visible? object))
@@ -207,7 +197,16 @@
        ;; Add any attributes of object to selection as well.
        (for-each select-object! (object-attribs object))))
 
-   (page-contents (active-page)))
+  (define *window (*current-window))
+  (define show-hidden-text?
+    (true? (gschem_toplevel_get_show_hidden_text *window)))
+
+  (o_redraw_cleanstates *window)
+
+  (o_select_unselect_all *window)
+
+  (for-each select-visible-and-selectable!
+            (page-contents (active-page)))
 
   ;; Run hooks for all items selected.
   (let ((new-selection (page-selection (active-page))))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -230,6 +230,7 @@
 
             schematic_window_active_page_changed
             gschem_toplevel_get_current_page_view
+            gschem_toplevel_get_show_hidden_text
             gschem_toplevel_get_toplevel
             schematic_window_get_actionfeedback_mode
             schematic_window_set_actionfeedback_mode
@@ -259,7 +260,6 @@
 
             o_select_return_first_object
             o_select_unselect_all
-            o_select_visible_unlocked
 
             o_slot_end
 
@@ -389,6 +389,7 @@
 ;;; gschem_toplevel.c
 (define-lff schematic_window_active_page_changed void '(*))
 (define-lff gschem_toplevel_get_current_page_view '* '(*))
+(define-lff gschem_toplevel_get_show_hidden_text int '(*))
 (define-lff gschem_toplevel_get_toplevel '* '(*))
 (define-lff schematic_window_get_actionfeedback_mode int '(*))
 (define-lff schematic_window_set_actionfeedback_mode void (list '* int))
@@ -597,7 +598,6 @@
 ;;; o_select.c
 (define-lff o_select_return_first_object '* '(*))
 (define-lff o_select_unselect_all void '(*))
-(define-lff o_select_visible_unlocked void '(*))
 
 ;;; o_slot.c
 (define-lff o_slot_end void '(* * *))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -102,7 +102,6 @@
 
             o_edit
             o_edit_show_hidden
-            o_unlock
             o_mirror_world_update
             o_rotate_world_update
             o_update_component
@@ -562,7 +561,6 @@
 ;;; o_misc.c
 (define-lff o_edit void '(* *))
 (define-lff o_edit_show_hidden void '(* *))
-(define-lff o_unlock void '(*))
 (define-lff o_mirror_world_update void (list '* int int '*))
 (define-lff o_rotate_world_update void (list '* int int int '*))
 (define-lff o_update_component '* '(* *))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -102,7 +102,6 @@
 
             o_edit
             o_edit_show_hidden
-            o_lock
             o_unlock
             o_mirror_world_update
             o_rotate_world_update
@@ -230,6 +229,7 @@
 
             schematic_signal_connect
 
+            schematic_window_active_page_changed
             gschem_toplevel_get_current_page_view
             gschem_toplevel_get_toplevel
             schematic_window_get_actionfeedback_mode
@@ -244,6 +244,7 @@
             schematic_window_get_selection_list
             schematic_window_update_keyaccel_string
             schematic_window_update_keyaccel_timer
+            schematic_window_get_shift_key_pressed
 
             gschem_options_cycle_grid_mode
             gschem_options_get_grid_mode
@@ -387,6 +388,7 @@
 (define-lff schematic_snap_mode_to_string '* (list int))
 
 ;;; gschem_toplevel.c
+(define-lff schematic_window_active_page_changed void '(*))
 (define-lff gschem_toplevel_get_current_page_view '* '(*))
 (define-lff gschem_toplevel_get_toplevel '* '(*))
 (define-lff schematic_window_get_actionfeedback_mode int '(*))
@@ -401,6 +403,7 @@
 (define-lff schematic_window_get_selection_list '* '(*))
 (define-lff schematic_window_update_keyaccel_string void '(* *))
 (define-lff schematic_window_update_keyaccel_timer void (list '* int))
+(define-lff schematic_window_get_shift_key_pressed int '(*))
 
 ;;; gschem_options.c
 (define-lff gschem_options_cycle_grid_mode void '(*))
@@ -559,7 +562,6 @@
 ;;; o_misc.c
 (define-lff o_edit void '(* *))
 (define-lff o_edit_show_hidden void '(* *))
-(define-lff o_lock void '(*))
 (define-lff o_unlock void '(*))
 (define-lff o_mirror_world_update void (list '* int int '*))
 (define-lff o_rotate_world_update void (list '* int int int '*))

--- a/libleptongui/src/gschem_toplevel.c
+++ b/libleptongui/src/gschem_toplevel.c
@@ -1170,3 +1170,32 @@ schematic_window_get_macro_widget (GschemToplevel *w_current)
 
   return w_current->macro_widget;
 }
+
+
+/*! \brief Get stored state of schematic window's Shift key.
+ *
+ *  \param [in] w_current The schematic window.
+ *  \return 1 if the Shift key is pressed, 0 otherwise.
+ */
+int
+schematic_window_get_shift_key_pressed (GschemToplevel *w_current)
+{
+  g_return_val_if_fail (w_current != NULL, 0);
+
+  return w_current->SHIFTKEY;
+}
+
+
+/*! \brief Store current state of schematic window's Shift key.
+ *
+ *  \param [in] w_current The schematic window.
+ *  \param [in] state The state.
+ */
+void
+schematic_window_set_shift_key_pressed (GschemToplevel *w_current,
+                                        int state)
+{
+  g_return_if_fail (w_current != NULL);
+
+  w_current->SHIFTKEY = state;
+}

--- a/libleptongui/src/o_misc.c
+++ b/libleptongui/src/o_misc.c
@@ -103,10 +103,9 @@ void o_lock(GschemToplevel *w_current)
 {
   g_return_if_fail (w_current != NULL);
 
-  LeptonPage* active_page = schematic_window_get_active_page (w_current);
-  g_return_if_fail (active_page != NULL);
+  LeptonSelection *selection = schematic_window_get_selection_list (w_current);
 
-  GList* objs = lepton_list_get_glist (active_page->selection_list);
+  GList* objs = lepton_list_get_glist (selection);
 
   /* lock selected objects:
   */

--- a/libleptongui/src/o_misc.c
+++ b/libleptongui/src/o_misc.c
@@ -89,54 +89,6 @@ void o_edit(GschemToplevel *w_current, GList *list)
   /* some sort of redrawing? */
 }
 
-/*! \brief Lock selected objects
- *
- *  \par Function Description
- *  This locks the entire selected list. It does lock components,
- *  but does NOT change the color of primatives of the components.
- *
- *  \note This function cannot be called recursively.
- *
- *  \param w_current  The toplevel environment.
- */
-void o_lock(GschemToplevel *w_current)
-{
-  g_return_if_fail (w_current != NULL);
-
-  LeptonSelection *selection = schematic_window_get_selection_list (w_current);
-
-  GList* objs = lepton_list_get_glist (selection);
-
-  /* lock selected objects:
-  */
-  LeptonObject* obj = NULL;
-  for (GList* iter = objs; iter != NULL; iter = g_list_next (iter))
-  {
-    obj = (LeptonObject*) iter->data;
-    lepton_object_set_selectable (obj, FALSE);
-
-    /* for objects with attributes, also lock them:
-    */
-    GList *attribs = lepton_object_get_attribs (obj);
-    if (attribs != NULL)
-    {
-      lepton_object_list_set_selectable (attribs, FALSE);
-    }
-  }
-
-  schematic_window_active_page_changed (w_current);
-
-  if (!schematic_window_get_shift_key_pressed (w_current))
-    o_select_unselect_all(w_current);
-
-  o_undo_savestate_old(w_current, UNDO_ALL);
-  i_update_menus(w_current);
-
-  /* refresh view to properly restore attributes' colors:
-  */
-  GschemPageView* view = gschem_toplevel_get_current_page_view (w_current);
-  gschem_page_view_invalidate_all (view);
-}
 
 /*! \brief Unlock selected objects
  *

--- a/libleptongui/src/o_misc.c
+++ b/libleptongui/src/o_misc.c
@@ -90,50 +90,6 @@ void o_edit(GschemToplevel *w_current, GList *list)
 }
 
 
-/*! \brief Unlock selected objects
- *
- *  \par Function Description
- *  Unlock objects currenly selected.
- *  Locked objects can be selected with a bounding box.
- *
- *  \note This function cannot be called recursively.
- *
- *  \param w_current  The toplevel environment.
- */
-void o_unlock(GschemToplevel *w_current)
-{
-  g_return_if_fail (w_current != NULL);
-
-  LeptonSelection *selection = schematic_window_get_selection_list (w_current);
-
-  GList* objs = lepton_list_get_glist (selection);
-
-  /* unlock selected objects:
-  */
-  LeptonObject* obj = NULL;
-  for (GList* iter = objs; iter != NULL; iter = g_list_next (iter))
-  {
-    obj = (LeptonObject*) iter->data;
-    lepton_object_set_selectable (obj, TRUE);
-
-    /* for objects with attributes, also unlock them:
-    */
-    GList *attribs = lepton_object_get_attribs (obj);
-    if (attribs != NULL)
-    {
-      lepton_object_list_set_selectable (attribs, TRUE);
-    }
-  }
-
-  schematic_window_active_page_changed (w_current);
-  o_undo_savestate_old(w_current, UNDO_ALL);
-
-  /* refresh view to properly restore attributes' colors:
-  */
-  GschemPageView* view = gschem_toplevel_get_current_page_view (w_current);
-  gschem_page_view_invalidate_all (view);
-}
-
 /*! \brief Rotate all objects in list.
  *  \par Function Description
  *  Given an object <B>list</B>, and the center of rotation

--- a/libleptongui/src/o_misc.c
+++ b/libleptongui/src/o_misc.c
@@ -126,7 +126,7 @@ void o_lock(GschemToplevel *w_current)
 
   schematic_window_active_page_changed (w_current);
 
-  if (!w_current->SHIFTKEY)
+  if (!schematic_window_get_shift_key_pressed (w_current))
     o_select_unselect_all(w_current);
 
   o_undo_savestate_old(w_current, UNDO_ALL);

--- a/libleptongui/src/o_misc.c
+++ b/libleptongui/src/o_misc.c
@@ -152,10 +152,9 @@ void o_unlock(GschemToplevel *w_current)
 {
   g_return_if_fail (w_current != NULL);
 
-  LeptonPage* active_page = schematic_window_get_active_page (w_current);
-  g_return_if_fail (active_page != NULL);
+  LeptonSelection *selection = schematic_window_get_selection_list (w_current);
 
-  GList* objs = lepton_list_get_glist (active_page->selection_list);
+  GList* objs = lepton_list_get_glist (selection);
 
   /* unlock selected objects:
   */

--- a/libleptongui/src/o_select.c
+++ b/libleptongui/src/o_select.c
@@ -617,7 +617,7 @@ o_select_visible_unlocked (GschemToplevel *w_current)
     gschem_toplevel_get_show_hidden_text (w_current);
 
   LeptonPage *active_page = schematic_window_get_active_page (w_current);
-  LeptonSelection *selection = active_page->selection_list;
+  LeptonSelection *selection = lepton_page_get_selection_list (active_page);
 
   o_select_unselect_all (w_current);
   for (iter = lepton_page_objects (active_page);

--- a/libleptongui/src/o_select.c
+++ b/libleptongui/src/o_select.c
@@ -600,58 +600,6 @@ void o_select_unselect_all(GschemToplevel *w_current)
   }
 }
 
-/*! \brief Selects all visible objects on the current page.
- * \par Function Description
- * Clears any existing selection, then selects everything visible and
- * unlocked on the current page, and any attached attributes whether
- * visible or invisible..
- *
- * \param w_current  The current #GschemToplevel structure.
- */
-void
-o_select_visible_unlocked (GschemToplevel *w_current)
-{
-  const GList *iter;
-  GList *added;
-  gboolean show_hidden_text =
-    gschem_toplevel_get_show_hidden_text (w_current);
-
-  LeptonPage *active_page = schematic_window_get_active_page (w_current);
-  LeptonSelection *selection = lepton_page_get_selection_list (active_page);
-
-  o_select_unselect_all (w_current);
-  for (iter = lepton_page_objects (active_page);
-       iter != NULL;
-       iter = g_list_next (iter)) {
-    LeptonObject *obj = (LeptonObject *) iter->data;
-
-    /* Skip invisible text objects. */
-    if (lepton_object_is_text (obj) &&
-        !lepton_text_object_is_visible (obj) &&
-        !show_hidden_text)
-      continue;
-
-    /* Skip locked objects. */
-    if (!lepton_object_get_selectable(obj)) continue;
-
-    /* Add object to selection. */
-    /*! \bug We can't call o_select_object() because it
-     * behaves differently depending on the state of
-     * w_current->SHIFTKEY and w_current->CONTROLKEY, which may well
-     * be set if this function is called via a keystroke
-     * (e.g. Ctrl-A). */
-    o_selection_add (selection, obj);
-
-    /* Add any attributes of object to selection as well. */
-    o_attrib_add_selected (w_current, selection, obj);
-  }
-
-  /* Run hooks for all items selected */
-  added = lepton_list_get_glist (selection);
-  if (added != NULL) {
-    g_run_hook_object_list (w_current, "select-objects-hook", added);
-  }
-}
 
 /*! \todo Finish function documentation!!!
  *  \brief


### PR DESCRIPTION
- The amount of code has been reduced by rewriting in Scheme the
  contents of three C functions related to object locking.  Those
  are `o_lock()`, `o_unlock()`, and `o_select_visible_unlocked()`.

- To achieve this, accessors for `GschemToplevel`'s field
  `SHIFTKEY` have been added.

- Rewriting of the latter function allowed for improvement of the
  action `&edit-select-all`.  The previous C code used
  `o_attrib_add_selected()` to select attributes of every object
  on the current page.  The function ran the hook
  `select-objects-hook` for each set of attributes, which was
  obviously wrong, as in the end, `o_select_visible_unlocked()`
  ran the same hook again for all objects on the page including
  those attributes.  Now, the hook is called once for the whole
  resulting selection list.
