### PR TITLE
Rewrite i_callback_attributes_*() functions in Scheme

### DIFF
--- a/docs/scheme-api/lepton-scheme.texi
+++ b/docs/scheme-api/lepton-scheme.texi
@@ -1378,6 +1378,13 @@ will be one of the following symbols:
 @end itemize
 @end defun
 
+@defun set-text-attribute-mode! text
+Sets the attribute mode of @var{text} to @var{mode} which should be
+one of the symbols @samp{'name}, @samp{'value}, or @samp{'both}.
+Returns the modified text object.
+@end defun
+
+
 @node Components
 @subsection Components
 

--- a/liblepton/scheme/lepton/object.scm
+++ b/liblepton/scheme/lepton/object.scm
@@ -135,6 +135,7 @@
             text-visible?
             make-text
             set-text!
+            set-text-attribute-mode!
             set-text-string!
             set-text-visibility!
 
@@ -1342,6 +1343,25 @@ value will be one of the following symbols:
                    (string->symbol (pointer->string string-pointer)))))
     (or (check-text-attribute-show-mode sym)
         (error "Text object ~A has invalid text attribute visibility ~A" object sym))))
+
+
+(define (set-text-attribute-mode! object mode)
+  "Sets the attribute mode of text OBJECT to MODE which should be
+one of 'name, 'value, or 'both.  Returns the modified OBJECT."
+  (define pointer (check-object object 1 text? 'text))
+
+  (check-text-show mode 2)
+
+  (unless (eq? mode (text-attribute-mode object))
+    (let ((show-mode (symbol->text-attribute-show-mode mode)))
+      (lepton_object_emit_pre_change_notify pointer)
+
+      (lepton_text_object_set_show pointer show-mode)
+      (lepton_object_page_set_changed pointer)
+
+      (lepton_object_emit_change_notify pointer)))
+
+  object)
 
 
 ;;;; Component objects

--- a/liblepton/scheme/unit-tests/lepton-object-text.scm
+++ b/liblepton/scheme/unit-tests/lepton-object-text.scm
@@ -108,6 +108,29 @@
 (test-end "set-text-visibility!")
 
 
+(test-begin "set-text-attribute-mode!")
+
+(let* ((t (make-text '(1 . 2) 'lower-left 0 "test text" 10 #t 'both))
+       (info (text-info t)))
+
+  (test-eq (text-attribute-mode t) 'both)
+  (set-text-attribute-mode! t 'name)
+  (test-eq (text-attribute-mode t) 'name)
+  (set-text-attribute-mode! t 'value)
+  (test-eq (text-attribute-mode t) 'value)
+
+  (test-equal (text-info (set-text-attribute-mode! t 'both)) info)
+
+  (test-assert-thrown 'misc-error
+                      (set-text-attribute-mode! t 'unknown))
+  (test-assert-thrown 'wrong-type-arg
+                      (set-text-attribute-mode! t #f))
+  (test-assert-thrown 'wrong-type-arg
+                      (set-text-attribute-mode! t "both")))
+
+(test-end "set-text-attribute-mode!")
+
+
 (test-begin "set-text-string!" 4)
 
 (let ((a (make-text '(1 . 2) 'lower-left 0 "test text" 10 #t 'both 21))

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -138,7 +138,6 @@ void i_callback_buffer_paste5 (GtkWidget *widget, gpointer data);
 void i_callback_hierarchy_down_schematic (GtkWidget *widget, gpointer data);
 void i_callback_hierarchy_down_symbol (GtkWidget *widget, gpointer data);
 void i_callback_hierarchy_up (GtkWidget *widget, gpointer data);
-void i_callback_attributes_show_both (GtkWidget *widget, gpointer data);
 void i_callback_attributes_visibility_toggle (GtkWidget *widget, gpointer data);
 void i_callback_cancel (GtkWidget *widget, gpointer data);
 gboolean i_callback_close_wm(GtkWidget *widget, GdkEvent *event, gpointer data);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -138,7 +138,6 @@ void i_callback_buffer_paste5 (GtkWidget *widget, gpointer data);
 void i_callback_hierarchy_down_schematic (GtkWidget *widget, gpointer data);
 void i_callback_hierarchy_down_symbol (GtkWidget *widget, gpointer data);
 void i_callback_hierarchy_up (GtkWidget *widget, gpointer data);
-void i_callback_attributes_show_name (GtkWidget *widget, gpointer data);
 void i_callback_attributes_show_value (GtkWidget *widget, gpointer data);
 void i_callback_attributes_show_both (GtkWidget *widget, gpointer data);
 void i_callback_attributes_visibility_toggle (GtkWidget *widget, gpointer data);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -138,7 +138,6 @@ void i_callback_buffer_paste5 (GtkWidget *widget, gpointer data);
 void i_callback_hierarchy_down_schematic (GtkWidget *widget, gpointer data);
 void i_callback_hierarchy_down_symbol (GtkWidget *widget, gpointer data);
 void i_callback_hierarchy_up (GtkWidget *widget, gpointer data);
-void i_callback_attributes_visibility_toggle (GtkWidget *widget, gpointer data);
 void i_callback_cancel (GtkWidget *widget, gpointer data);
 gboolean i_callback_close_wm(GtkWidget *widget, GdkEvent *event, gpointer data);
 /* i_vars.c */

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -170,8 +170,6 @@ o_attrib_select_invisible (GschemToplevel *w_current,
                            LeptonSelection *selection,
                            LeptonObject *selected);
 void o_attrib_toggle_visibility(GschemToplevel *w_current, LeptonObject *object);
-void o_attrib_toggle_show_name_value(GschemToplevel *w_current, LeptonObject *object, int new_show_name_value);
-
 LeptonObject*
 o_attrib_add_attrib (GschemToplevel *w_current,
                      const char *text_string,

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -168,7 +168,6 @@ void
 o_attrib_select_invisible (GschemToplevel *w_current,
                            LeptonSelection *selection,
                            LeptonObject *selected);
-void o_attrib_toggle_visibility(GschemToplevel *w_current, LeptonObject *object);
 LeptonObject*
 o_attrib_add_attrib (GschemToplevel *w_current,
                      const char *text_string,

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -138,7 +138,6 @@ void i_callback_buffer_paste5 (GtkWidget *widget, gpointer data);
 void i_callback_hierarchy_down_schematic (GtkWidget *widget, gpointer data);
 void i_callback_hierarchy_down_symbol (GtkWidget *widget, gpointer data);
 void i_callback_hierarchy_up (GtkWidget *widget, gpointer data);
-void i_callback_attributes_show_value (GtkWidget *widget, gpointer data);
 void i_callback_attributes_show_both (GtkWidget *widget, gpointer data);
 void i_callback_attributes_visibility_toggle (GtkWidget *widget, gpointer data);
 void i_callback_cancel (GtkWidget *widget, gpointer data);

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -993,7 +993,8 @@ the snap grid size should be set to 100")))
 
 
 (define-action-public (&attributes-show-value #:label (G_ "Show Attribute Value") #:icon "attribute-show-value")
-  (run-callback i_callback_attributes_show_value "&attributes-show-value"))
+  (unless (true? (schematic_window_get_inside_action (*current-window)))
+    (set-selected-attribs-show-mode! 'value)))
 
 
 (define-action-public (&attributes-show-name #:label (G_ "Show Attribute Name") #:icon "attribute-show-name")

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -987,8 +987,17 @@ the snap grid size should be set to 100")))
 (define-action-public (&attributes-show-value #:label (G_ "Show Attribute Value") #:icon "attribute-show-value")
   (run-callback i_callback_attributes_show_value "&attributes-show-value"))
 
+
 (define-action-public (&attributes-show-name #:label (G_ "Show Attribute Name") #:icon "attribute-show-name")
-  (run-callback i_callback_attributes_show_name "&attributes-show-name"))
+  (define (set-show-name! object)
+    (set-text-attribute-mode! object 'name))
+
+  (unless (true? (schematic_window_get_inside_action (*current-window)))
+    (let ((attribs (filter attribute? (page-selection (active-page)))))
+      (unless (null? attribs)
+        (for-each set-show-name! attribs)
+        (undo-save-state)))))
+
 
 (define-action-public (&attributes-show-both #:label (G_ "Show Name & Value") #:icon "attribute-show-both")
   (run-callback i_callback_attributes_show_both "&attributes-show-both"))

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -1008,7 +1008,14 @@ the snap grid size should be set to 100")))
 
 
 (define-action-public (&attributes-visibility-toggle #:label (G_ "Toggle Text Visibility"))
-  (run-callback i_callback_attributes_visibility_toggle "&attributes-visibility-toggle"))
+  (define (toggle-visibility! object)
+    (set-text-visibility! object (not (text-visible? object))))
+
+  (unless (true? (schematic_window_get_inside_action (*current-window)))
+    (let ((attribs (filter attribute? (page-selection (active-page)))))
+      (unless (null? attribs)
+        (for-each toggle-visibility! attribs)
+        (undo-save-state)))))
 
 
 (define-action-public (&edit-find-text #:label (G_ "Find Specific Text") #:icon "gtk-find")

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -983,20 +983,22 @@ the snap grid size should be set to 100")))
 ) ; &attributes-detach action
 
 
+(define (set-selected-attribs-show-mode! mode)
+  (define (set-show-mode! object)
+    (set-text-attribute-mode! object mode))
+  (let ((attribs (filter attribute? (page-selection (active-page)))))
+    (unless (null? attribs)
+      (for-each set-show-mode! attribs)
+      (undo-save-state))))
+
 
 (define-action-public (&attributes-show-value #:label (G_ "Show Attribute Value") #:icon "attribute-show-value")
   (run-callback i_callback_attributes_show_value "&attributes-show-value"))
 
 
 (define-action-public (&attributes-show-name #:label (G_ "Show Attribute Name") #:icon "attribute-show-name")
-  (define (set-show-name! object)
-    (set-text-attribute-mode! object 'name))
-
   (unless (true? (schematic_window_get_inside_action (*current-window)))
-    (let ((attribs (filter attribute? (page-selection (active-page)))))
-      (unless (null? attribs)
-        (for-each set-show-name! attribs)
-        (undo-save-state)))))
+    (set-selected-attribs-show-mode! 'name)))
 
 
 (define-action-public (&attributes-show-both #:label (G_ "Show Name & Value") #:icon "attribute-show-both")

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -1003,7 +1003,9 @@ the snap grid size should be set to 100")))
 
 
 (define-action-public (&attributes-show-both #:label (G_ "Show Name & Value") #:icon "attribute-show-both")
-  (run-callback i_callback_attributes_show_both "&attributes-show-both"))
+  (unless (true? (schematic_window_get_inside_action (*current-window)))
+    (set-selected-attribs-show-mode! 'both)))
+
 
 (define-action-public (&attributes-visibility-toggle #:label (G_ "Toggle Text Visibility"))
   (run-callback i_callback_attributes_visibility_toggle "&attributes-visibility-toggle"))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -32,7 +32,6 @@
             generic_msg_dialog
 
             i_callback_attributes_show_both
-            i_callback_attributes_show_value
             i_callback_attributes_visibility_toggle
             i_callback_cancel
             i_callback_clipboard_copy
@@ -511,7 +510,6 @@
 (define-lff generic_msg_dialog void '(*))
 ;;; i_callbacks.c
 (define-lff i_callback_attributes_show_both void '(* *))
-(define-lff i_callback_attributes_show_value void '(* *))
 (define-lff i_callback_attributes_visibility_toggle void '(* *))
 (define-lff i_callback_cancel void '(* *))
 (define-lff i_callback_clipboard_copy void '(* *))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -32,7 +32,6 @@
             generic_msg_dialog
 
             i_callback_attributes_show_both
-            i_callback_attributes_show_name
             i_callback_attributes_show_value
             i_callback_attributes_visibility_toggle
             i_callback_cancel
@@ -512,7 +511,6 @@
 (define-lff generic_msg_dialog void '(*))
 ;;; i_callbacks.c
 (define-lff i_callback_attributes_show_both void '(* *))
-(define-lff i_callback_attributes_show_name void '(* *))
 (define-lff i_callback_attributes_show_value void '(* *))
 (define-lff i_callback_attributes_visibility_toggle void '(* *))
 (define-lff i_callback_cancel void '(* *))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -31,7 +31,6 @@
             generic_filesel_dialog
             generic_msg_dialog
 
-            i_callback_attributes_show_both
             i_callback_attributes_visibility_toggle
             i_callback_cancel
             i_callback_clipboard_copy
@@ -509,7 +508,6 @@
 (define-lff generic_filesel_dialog '* (list '* '* int))
 (define-lff generic_msg_dialog void '(*))
 ;;; i_callbacks.c
-(define-lff i_callback_attributes_show_both void '(* *))
 (define-lff i_callback_attributes_visibility_toggle void '(* *))
 (define-lff i_callback_cancel void '(* *))
 (define-lff i_callback_clipboard_copy void '(* *))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -31,7 +31,6 @@
             generic_filesel_dialog
             generic_msg_dialog
 
-            i_callback_attributes_visibility_toggle
             i_callback_cancel
             i_callback_clipboard_copy
             i_callback_clipboard_cut
@@ -508,7 +507,6 @@
 (define-lff generic_filesel_dialog '* (list '* '* int))
 (define-lff generic_msg_dialog void '(*))
 ;;; i_callbacks.c
-(define-lff i_callback_attributes_visibility_toggle void '(* *))
 (define-lff i_callback_cancel void '(* *))
 (define-lff i_callback_clipboard_copy void '(* *))
 (define-lff i_callback_clipboard_cut void '(* *))

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -983,42 +983,6 @@ i_callback_hierarchy_up (GtkWidget *widget, gpointer data)
  *
  */
 void
-i_callback_attributes_show_both (GtkWidget *widget, gpointer data)
-{
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-
-  g_return_if_fail (w_current != NULL);
-
-  /* This is a new addition 3/15 to prevent this from executing
-   * inside an action */
-  if (schematic_window_get_inside_action (w_current))
-  {
-    return;
-  }
-
-  if (o_select_selected (w_current)) {
-    LeptonPage *active_page = schematic_window_get_active_page (w_current);
-    LeptonSelection *selection = active_page->selection_list;
-    GList *s_current;
-
-    for (s_current = lepton_list_get_glist (selection);
-         s_current != NULL;
-         s_current = g_list_next (s_current)) {
-      LeptonObject *object = (LeptonObject*)s_current->data;
-      if (lepton_object_is_text (object))
-        o_attrib_toggle_show_name_value (w_current, object, SHOW_NAME_VALUE);
-    }
-
-    o_undo_savestate_old (w_current, UNDO_ALL);
-  }
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
-void
 i_callback_attributes_visibility_toggle (GtkWidget *widget, gpointer data)
 {
   GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -976,42 +976,6 @@ i_callback_hierarchy_up (GtkWidget *widget, gpointer data)
   }
 }
 
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
-void
-i_callback_attributes_show_name (GtkWidget *widget, gpointer data)
-{
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-
-  g_return_if_fail (w_current != NULL);
-
-  /* This is a new addition 3/15 to prevent this from executing
-   * inside an action */
-  if (schematic_window_get_inside_action (w_current))
-  {
-    return;
-  }
-
-  if (o_select_selected (w_current))
-  {
-    LeptonPage *active_page = schematic_window_get_active_page (w_current);
-    LeptonSelection *selection = active_page->selection_list;
-    GList *s_current;
-
-    for (s_current = lepton_list_get_glist (selection);
-         s_current != NULL;
-         s_current = g_list_next (s_current)) {
-      LeptonObject *object = (LeptonObject*)s_current->data;
-      if (lepton_object_is_text (object))
-        o_attrib_toggle_show_name_value (w_current, object, SHOW_NAME);
-    }
-
-    o_undo_savestate_old (w_current, UNDO_ALL);
-  }
-}
 
 /*! \todo Finish function documentation!!!
  *  \brief

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -981,44 +981,6 @@ i_callback_hierarchy_up (GtkWidget *widget, gpointer data)
  *  \brief
  *  \par Function Description
  *
- */
-void
-i_callback_attributes_visibility_toggle (GtkWidget *widget, gpointer data)
-{
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-
-  g_return_if_fail (w_current != NULL);
-
-  /* This is a new addition 3/15 to prevent this from executing
-   * inside an action */
-  if (schematic_window_get_inside_action (w_current))
-  {
-    return;
-  }
-
-  if (o_select_selected (w_current))
-  {
-    LeptonPage *active_page = schematic_window_get_active_page (w_current);
-    LeptonSelection *selection = active_page->selection_list;
-    GList *s_current;
-
-    for (s_current = lepton_list_get_glist (selection);
-         s_current != NULL;
-         s_current = g_list_next (s_current)) {
-      LeptonObject *object = (LeptonObject*)s_current->data;
-      if (lepton_object_is_text (object))
-        o_attrib_toggle_visibility (w_current, object);
-    }
-
-    o_undo_savestate_old (w_current, UNDO_ALL);
-  }
-}
-
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
  *  \note
  *  HACK: be sure that you don't use the widget parameter in this one,
  *  since it is being called with a null, I suppose we should call it

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -983,43 +983,6 @@ i_callback_hierarchy_up (GtkWidget *widget, gpointer data)
  *
  */
 void
-i_callback_attributes_show_value (GtkWidget *widget, gpointer data)
-{
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-
-  g_return_if_fail (w_current != NULL);
-
-  /* This is a new addition 3/15 to prevent this from executing
-   * inside an action */
-  if (schematic_window_get_inside_action (w_current))
-  {
-    return;
-  }
-
-  if (o_select_selected (w_current))
-  {
-    LeptonPage *active_page = schematic_window_get_active_page (w_current);
-    LeptonSelection *selection = active_page->selection_list;
-    GList *s_current;
-
-    for (s_current = lepton_list_get_glist (selection);
-         s_current != NULL;
-         s_current = g_list_next (s_current)) {
-      LeptonObject *object = (LeptonObject*)s_current->data;
-      if (lepton_object_is_text (object))
-        o_attrib_toggle_show_name_value (w_current, object, SHOW_VALUE);
-    }
-
-    o_undo_savestate_old (w_current, UNDO_ALL);
-  }
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
-void
 i_callback_attributes_show_both (GtkWidget *widget, gpointer data)
 {
   GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);

--- a/libleptongui/src/o_attrib.c
+++ b/libleptongui/src/o_attrib.c
@@ -206,28 +206,6 @@ void o_attrib_toggle_visibility(GschemToplevel *w_current, LeptonObject *object)
   schematic_window_active_page_changed (w_current);
 }
 
-/*! \brief Set what part of an attribute is shown.
- *  \par Function Description
- *  This function changes what part (name, value or both) of an
- *  attribute is shown by its attribute object. The attribute object
- *  is erased, updated and finally redrawn.
- *
- *  \param [in] w_current  The GschemToplevel object.
- *  \param [in] object     The attribute object.
- *  \param [in] show_name_value  The new display flag for attribute.
- */
-void o_attrib_toggle_show_name_value(GschemToplevel *w_current,
-                                     LeptonObject *object, int show_name_value)
-{
-  g_return_if_fail (lepton_object_is_text (object));
-
-  o_invalidate (w_current, object);
-  lepton_text_object_set_show (object, show_name_value);
-  lepton_text_object_recreate (object);
-
-  schematic_window_active_page_changed (w_current);
-}
-
 
 /*! \brief Adds an attribute with given parameters to the active page
  *  \par Function Description

--- a/libleptongui/src/o_attrib.c
+++ b/libleptongui/src/o_attrib.c
@@ -163,49 +163,6 @@ o_attrib_select_invisible (GschemToplevel *w_current,
   }
 }
 
-/*! \brief Change visibility status of attribute object.
- *  \par Function Description
- *  This function toggles the visibility status of the attribute \a
- *  object and updates it. The object is erased or redrawn if
- *  necessary.
- *
- *  \param [in] w_current  The GschemToplevel object.
- *  \param [in] object     The attribute object.
- */
-void o_attrib_toggle_visibility(GschemToplevel *w_current, LeptonObject *object)
-{
-  g_return_if_fail (lepton_object_is_text (object));
-
-  gboolean show_hidden_text =
-    gschem_toplevel_get_show_hidden_text (w_current);
-
-  if (lepton_text_object_is_visible (object)) {
-    /* only erase if we are not showing hidden text */
-    if (!show_hidden_text) {
-      o_invalidate (w_current, object);
-    }
-
-    lepton_text_object_set_visibility (object, INVISIBLE);
-
-    if (show_hidden_text) {
-      /* draw text so that little I is drawn */
-      o_invalidate (w_current, object);
-    }
-
-  } else {
-    /* if we are in the special show hidden mode, then erase text first */
-    /* to get rid of the little I */
-    if (show_hidden_text) {
-      o_invalidate (w_current, object);
-    }
-
-    lepton_text_object_set_visibility (object, VISIBLE);
-    lepton_text_object_recreate (object);
-  }
-
-  schematic_window_active_page_changed (w_current);
-}
-
 
 /*! \brief Adds an attribute with given parameters to the active page
  *  \par Function Description


### PR DESCRIPTION
- A new Scheme procedure has been introduced in the module
  `(lepton object)`: `set-text-attribute-mode!()`.  The procedure
  sets a desired mode for an object and emits change
  notifications.

- A few C functions, in particular `i_callback_attributes_*()`
  ones have been rewritten in Scheme.
  
- A couple of no longer needed C functions have been thrown away.