### PR TITLE
gui: Rewrite i_callback_close_wm() in Scheme.

### DIFF
--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -143,7 +143,7 @@ void i_callback_attributes_show_value (GtkWidget *widget, gpointer data);
 void i_callback_attributes_show_both (GtkWidget *widget, gpointer data);
 void i_callback_attributes_visibility_toggle (GtkWidget *widget, gpointer data);
 void i_callback_cancel (GtkWidget *widget, gpointer data);
-gboolean i_callback_close_wm(GtkWidget *widget, GdkEvent *event, gpointer data);
+
 /* i_vars.c */
 void i_vars_set(GschemToplevel *w_current);
 void i_vars_atexit_save_cache_config (gpointer user_data);

--- a/libleptongui/scheme/schematic/callback.scm
+++ b/libleptongui/scheme/schematic/callback.scm
@@ -37,6 +37,7 @@
             callback-add-component
             callback-add-net
             callback-add-text
+            *callback-close-schematic-window
             callback-file-new
             *callback-file-new
             callback-file-open
@@ -146,3 +147,24 @@
   (i_set_state *window (symbol->action-mode 'select-mode))
 
   (text_input_dialog *window))
+
+
+(define (callback-close-schematic-window *widget *event *window)
+  (if (null-pointer? *window)
+      (error "NULL window.")
+      (x_window_close *window))
+  ;; Stop further propagation of the "delete-event" signal for
+  ;; window:
+  ;;   - if the user has cancelled closing, the window should
+  ;;     obviously not be destroyed
+  ;;   - otherwise the window has already been destroyed, nothing
+  ;;     more to do
+  TRUE)
+
+
+;;; When invoked via signal "delete-event", the function closes
+;;; the current window and, if this is the last window, quits
+;;; lepton-schematic.  The signal is emitted when you click the
+;;; close button on the window.
+(define *callback-close-schematic-window
+  (procedure->pointer int callback-close-schematic-window '(* * *)))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -23,6 +23,7 @@
   #:use-module (lepton ffi lff)
   #:use-module (lepton ffi lib)
   #:use-module (lepton ffi)
+  #:use-module (lepton log)
 
   #:export (lepton_schematic_run
             lepton_schematic_app
@@ -39,7 +40,6 @@
             i_callback_clipboard_copy
             i_callback_clipboard_cut
             i_callback_clipboard_paste
-            i_callback_close_wm
             i_callback_file_save
             *i_callback_file_save
             i_callback_file_script
@@ -519,7 +519,6 @@
 (define-lff i_callback_clipboard_copy void '(* *))
 (define-lff i_callback_clipboard_cut void '(* *))
 (define-lff i_callback_clipboard_paste void '(* *))
-(define-lff i_callback_close_wm int '(* * *))
 (define-lff i_callback_file_save void '(* *))
 (define-lfc *i_callback_file_save)
 (define-lff i_callback_file_script void '(* *))

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -75,7 +75,7 @@ GtkApplication structure of the program (when compiled with
   (let ((*main-window (schematic_window_create_app_window *app)))
     (schematic_signal_connect *main-window
                               (string->pointer "delete-event")
-                              (procedure->pointer int i_callback_close_wm '(* * *))
+                              *callback-close-schematic-window
                               *window)
 
     (let ((*main-box (schematic_window_create_main_box *main-window))

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -1197,31 +1197,3 @@ i_callback_cancel (GtkWidget *widget, gpointer data)
 
   i_action_stop (w_current);
 }
-
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- *  \note
- *  When invoked (via signal delete_event), closes the current window
- *  if this is the last window, quit gschem
- *  used when you click the close button on the window which sends a DELETE
- *  signal to the app
- */
-gboolean i_callback_close_wm ( GtkWidget *widget, GdkEvent *event,
-                           gpointer data )
-{
-
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-  g_return_val_if_fail ((w_current != NULL), TRUE);
-
-  x_window_close(w_current);
-
-  /* stop further propagation of the delete_event signal for window: */
-  /*   - if user has cancelled the close the window should obvioulsy */
-  /*   not be destroyed */
-  /*   - otherwise window has already been destroyed, nothing more to */
-  /*   do */
-  return TRUE;
-}


### PR DESCRIPTION
This makes it available to further refactor `x_window_close()` in Scheme.