### PR TITLE
Rewrite the action &file-script in Scheme

### DIFF
--- a/libleptongui/include/gschem.h
+++ b/libleptongui/include/gschem.h
@@ -13,8 +13,6 @@
 
 /* forward declaration, until everyone stops referencing it */
 typedef struct st_gschem_toplevel GschemToplevel;
-/* this is used both in gschem_toplevel.h and prototype.h */
-typedef void (*i_callback_func) (gpointer, guint, GtkWidget*);
 
 /* gschem headers */
 #include "action_mode.h"

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -12,9 +12,8 @@ void a_zoom_box_invalidate_rubber(GschemToplevel *w_current);
 void a_zoom_box_draw_rubber(GschemToplevel *w_current, EdaRenderer *renderer);
 
 /* execute_script.c */
-void
-schematic_execute_script (GtkWidget *widget,
-                          gpointer data);
+char*
+schematic_execute_script (GschemToplevel *w_current);
 
 /* g_action.c */
 gboolean g_action_eval_by_name (GschemToplevel *w_current, const gchar *action_name);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -10,6 +10,12 @@ void a_zoom_box_end(GschemToplevel *w_current, int x, int y);
 void a_zoom_box_motion(GschemToplevel *w_current, int x, int y);
 void a_zoom_box_invalidate_rubber(GschemToplevel *w_current);
 void a_zoom_box_draw_rubber(GschemToplevel *w_current, EdaRenderer *renderer);
+
+/* execute_script.c */
+void
+i_callback_file_script (GtkWidget *widget,
+                        gpointer data);
+
 /* g_action.c */
 gboolean g_action_eval_by_name (GschemToplevel *w_current, const gchar *action_name);
 gboolean
@@ -97,8 +103,8 @@ void i_set_filename(GschemToplevel *w_current, const gchar *filename, gboolean c
 void i_update_grid_info(GschemToplevel *w_current);
 void i_update_grid_info_callback (GschemPageView *view, GschemToplevel *w_current);
 void i_update_net_options_status (GschemToplevel* w_current);
+
 /* i_callbacks.c */
-void i_callback_file_script (GtkWidget *widget, gpointer data);
 void i_callback_file_save (GtkWidget *widget, gpointer data);
 void i_callback_view_sidebar (GtkWidget *widget, gpointer data);
 void i_callback_view_status (GtkWidget *widget, gpointer data);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -13,8 +13,8 @@ void a_zoom_box_draw_rubber(GschemToplevel *w_current, EdaRenderer *renderer);
 
 /* execute_script.c */
 void
-i_callback_file_script (GtkWidget *widget,
-                        gpointer data);
+schematic_execute_script (GtkWidget *widget,
+                          gpointer data);
 
 /* g_action.c */
 gboolean g_action_eval_by_name (GschemToplevel *w_current, const gchar *action_name);

--- a/libleptongui/po/POTFILES.in
+++ b/libleptongui/po/POTFILES.in
@@ -1,5 +1,6 @@
 libleptongui/src/a_zoom.c
 libleptongui/src/color_edit_widget.c
+libleptongui/src/execute_script.c
 libleptongui/src/font_select_widget.c
 libleptongui/src/g_window.c
 libleptongui/src/globals.c

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -149,7 +149,7 @@
   (x_image_setup (*current-window)))
 
 (define-action-public (&file-script #:label (G_ "Run Script") #:icon "gtk-execute")
-  (run-callback i_callback_file_script "&file-script"))
+  (run-callback schematic_execute_script "&file-script"))
 
 (define-action-public (&file-new-window #:label (G_ "New Window") #:icon "window-new")
   (x_window_open_page

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -26,6 +26,7 @@
 
   #:use-module (lepton attrib)
   #:use-module (lepton ffi boolean)
+  #:use-module (lepton ffi glib)
   #:use-module (lepton ffi)
   #:use-module (lepton log)
   #:use-module (lepton object foreign)
@@ -148,8 +149,18 @@
 (define-action-public (&file-image #:label (G_ "Export Image"))
   (x_image_setup (*current-window)))
 
+
 (define-action-public (&file-script #:label (G_ "Run Script") #:icon "gtk-execute")
-  (run-callback schematic_execute_script "&file-script"))
+  (define *window (*current-window))
+  (define *filename (schematic_execute_script (*current-window)))
+
+  (unless (null-pointer? *filename)
+    (log! 'message (G_ "Executing Guile script: ~S") (pointer->string *filename))
+    (g_read_file (gschem_toplevel_get_toplevel *window)
+                 *filename
+                 %null-pointer)
+    (g_free *filename)))
+
 
 (define-action-public (&file-new-window #:label (G_ "New Window") #:icon "window-new")
   (x_window_open_page

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -506,6 +506,10 @@
 (define-lff generic_confirm_dialog int '(*))
 (define-lff generic_filesel_dialog '* (list '* '* int))
 (define-lff generic_msg_dialog void '(*))
+
+;;; execute_script.c
+(define-lff i_callback_file_script void '(* *))
+
 ;;; i_callbacks.c
 (define-lff i_callback_cancel void '(* *))
 (define-lff i_callback_clipboard_copy void '(* *))
@@ -513,7 +517,6 @@
 (define-lff i_callback_clipboard_paste void '(* *))
 (define-lff i_callback_file_save void '(* *))
 (define-lfc *i_callback_file_save)
-(define-lff i_callback_file_script void '(* *))
 (define-lff i_callback_hierarchy_down_schematic void '(* *))
 (define-lff i_callback_hierarchy_down_symbol void '(* *))
 (define-lff i_callback_hierarchy_up void '(* *))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -27,7 +27,11 @@
 
   #:export (lepton_schematic_run
             lepton_schematic_app
+
             g_init_window
+
+            g_read_file
+
             generic_confirm_dialog
             generic_filesel_dialog
             generic_msg_dialog
@@ -323,6 +327,9 @@
 (define-lff lepton_schematic_run int '(*))
 (define-lff lepton_schematic_app '* '())
 
+;;; g_basic.c
+(define-lff g_read_file int '(* * *))
+
 ;;; g_window.c
 (define-lff g_init_window void '(*))
 
@@ -509,7 +516,7 @@
 (define-lff generic_msg_dialog void '(*))
 
 ;;; execute_script.c
-(define-lff schematic_execute_script void '(* *))
+(define-lff schematic_execute_script '* '(*))
 
 ;;; i_callbacks.c
 (define-lff i_callback_cancel void '(* *))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -32,13 +32,14 @@
             generic_filesel_dialog
             generic_msg_dialog
 
+            schematic_execute_script
+
             i_callback_cancel
             i_callback_clipboard_copy
             i_callback_clipboard_cut
             i_callback_clipboard_paste
             i_callback_file_save
             *i_callback_file_save
-            i_callback_file_script
             i_callback_hierarchy_down_schematic
             i_callback_hierarchy_down_symbol
             i_callback_hierarchy_up
@@ -508,7 +509,7 @@
 (define-lff generic_msg_dialog void '(*))
 
 ;;; execute_script.c
-(define-lff i_callback_file_script void '(* *))
+(define-lff schematic_execute_script void '(* *))
 
 ;;; i_callbacks.c
 (define-lff i_callback_cancel void '(* *))

--- a/libleptongui/src/Makefile.am
+++ b/libleptongui/src/Makefile.am
@@ -3,6 +3,7 @@ lib_LTLIBRARIES = libleptongui.la
 libleptongui_la_SOURCES = \
 	a_zoom.c \
 	action_mode.c \
+	execute_script.c \
 	g_action.c \
 	g_hook.c \
 	g_window.c \

--- a/libleptongui/src/execute_script.c
+++ b/libleptongui/src/execute_script.c
@@ -25,7 +25,8 @@
 /*! \brief Open the "Execute Script" dialog, execute the selected Scheme file
  */
 void
-i_callback_file_script (GtkWidget *widget, gpointer data)
+schematic_execute_script (GtkWidget *widget,
+                          gpointer data)
 {
   GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
   g_return_if_fail (w_current != NULL);
@@ -72,4 +73,4 @@ i_callback_file_script (GtkWidget *widget, gpointer data)
 
   gtk_widget_destroy (dialog);
 
-} /* i_callback_file_script() */
+}

--- a/libleptongui/src/execute_script.c
+++ b/libleptongui/src/execute_script.c
@@ -1,0 +1,75 @@
+/* Lepton EDA Schematic Capture
+ * Copyright (C) 1998-2010 Ales Hvezda
+ * Copyright (C) 1998-2016 gEDA Contributors
+ * Copyright (C) 2017-2022 Lepton EDA Contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include <config.h>
+#include "gschem.h"
+
+
+/*! \brief Open the "Execute Script" dialog, execute the selected Scheme file
+ */
+void
+i_callback_file_script (GtkWidget *widget, gpointer data)
+{
+  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
+  g_return_if_fail (w_current != NULL);
+
+  GtkWidget* dialog = gtk_file_chooser_dialog_new(
+    _("Execute Script"),
+    GTK_WINDOW (w_current->main_window),
+    GTK_FILE_CHOOSER_ACTION_OPEN,
+    _("_Cancel"), GTK_RESPONSE_CANCEL,
+    _("_Run"), GTK_RESPONSE_ACCEPT,
+    NULL);
+
+  /* Filter for Scheme files:
+  */
+  GtkFileFilter* filter_scm = gtk_file_filter_new();
+  gtk_file_filter_set_name (filter_scm, _("Scheme files (*.scm)"));
+  gtk_file_filter_add_pattern (filter_scm, "*.scm");
+  gtk_file_chooser_add_filter (GTK_FILE_CHOOSER (dialog), filter_scm);
+
+  /* Filter for all files:
+  */
+  GtkFileFilter* filter_all = gtk_file_filter_new();
+  gtk_file_filter_set_name (filter_all, _("All files"));
+  gtk_file_filter_add_pattern (filter_all, "*");
+  gtk_file_chooser_add_filter (GTK_FILE_CHOOSER (dialog), filter_all);
+
+#ifndef ENABLE_GTK3
+  gtk_dialog_set_alternative_button_order(
+    GTK_DIALOG (dialog),
+    GTK_RESPONSE_ACCEPT,
+    GTK_RESPONSE_CANCEL,
+    -1);
+#endif
+
+  if (gtk_dialog_run (GTK_DIALOG (dialog)) == GTK_RESPONSE_ACCEPT)
+  {
+    gchar* filename = gtk_file_chooser_get_filename (GTK_FILE_CHOOSER (dialog));
+
+    g_message (_("Executing Guile script [%s]"), filename);
+    g_read_file (gschem_toplevel_get_toplevel (w_current), filename, NULL);
+
+    g_free (filename);
+  }
+
+  gtk_widget_destroy (dialog);
+
+} /* i_callback_file_script() */

--- a/libleptongui/src/execute_script.c
+++ b/libleptongui/src/execute_script.c
@@ -22,7 +22,16 @@
 #include "gschem.h"
 
 
-/*! \brief Open the "Execute Script" dialog, execute the selected Scheme file
+/*! \brief Open the "Execute Script" file chooser dialog
+ *  \par Function Description
+ *
+ *  This function opens a file chooser dialog where the user may
+ *  select a Scheme script file for execution.  If the "Run" key
+ *  is pressed, the dialog is destroyed, and the Scheme file is
+ *  executed.
+ *
+ *  \param [in] w_current The current schematic window structure.
+ *  \return TRUE if the dialog was closed with ACCEPT response, FALSE otherwise.
  */
 char*
 schematic_execute_script (GschemToplevel *w_current)

--- a/libleptongui/src/execute_script.c
+++ b/libleptongui/src/execute_script.c
@@ -24,12 +24,10 @@
 
 /*! \brief Open the "Execute Script" dialog, execute the selected Scheme file
  */
-void
-schematic_execute_script (GtkWidget *widget,
-                          gpointer data)
+char*
+schematic_execute_script (GschemToplevel *w_current)
 {
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-  g_return_if_fail (w_current != NULL);
+  char* filename = NULL;
 
   GtkWidget* dialog = gtk_file_chooser_dialog_new(
     _("Execute Script"),
@@ -63,14 +61,10 @@ schematic_execute_script (GtkWidget *widget,
 
   if (gtk_dialog_run (GTK_DIALOG (dialog)) == GTK_RESPONSE_ACCEPT)
   {
-    gchar* filename = gtk_file_chooser_get_filename (GTK_FILE_CHOOSER (dialog));
-
-    g_message (_("Executing Guile script [%s]"), filename);
-    g_read_file (gschem_toplevel_get_toplevel (w_current), filename, NULL);
-
-    g_free (filename);
+    filename = gtk_file_chooser_get_filename (GTK_FILE_CHOOSER (dialog));
   }
 
   gtk_widget_destroy (dialog);
 
+  return filename;
 }

--- a/libleptongui/src/i_callbacks.c
+++ b/libleptongui/src/i_callbacks.c
@@ -24,60 +24,6 @@
 
 /*! \section callback-intro Callback Functions */
 
-/*! \brief Open the "Execute Script" dialog, execute the selected Scheme file
- */
-void
-i_callback_file_script (GtkWidget *widget, gpointer data)
-{
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-  g_return_if_fail (w_current != NULL);
-
-  GtkWidget* dialog = gtk_file_chooser_dialog_new(
-    _("Execute Script"),
-    GTK_WINDOW (w_current->main_window),
-    GTK_FILE_CHOOSER_ACTION_OPEN,
-    _("_Cancel"), GTK_RESPONSE_CANCEL,
-    _("_Run"), GTK_RESPONSE_ACCEPT,
-    NULL);
-
-  /* Filter for Scheme files:
-  */
-  GtkFileFilter* filter_scm = gtk_file_filter_new();
-  gtk_file_filter_set_name (filter_scm, _("Scheme files (*.scm)"));
-  gtk_file_filter_add_pattern (filter_scm, "*.scm");
-  gtk_file_chooser_add_filter (GTK_FILE_CHOOSER (dialog), filter_scm);
-
-  /* Filter for all files:
-  */
-  GtkFileFilter* filter_all = gtk_file_filter_new();
-  gtk_file_filter_set_name (filter_all, _("All files"));
-  gtk_file_filter_add_pattern (filter_all, "*");
-  gtk_file_chooser_add_filter (GTK_FILE_CHOOSER (dialog), filter_all);
-
-#ifndef ENABLE_GTK3
-  gtk_dialog_set_alternative_button_order(
-    GTK_DIALOG (dialog),
-    GTK_RESPONSE_ACCEPT,
-    GTK_RESPONSE_CANCEL,
-    -1);
-#endif
-
-  if (gtk_dialog_run (GTK_DIALOG (dialog)) == GTK_RESPONSE_ACCEPT)
-  {
-    gchar* filename = gtk_file_chooser_get_filename (GTK_FILE_CHOOSER (dialog));
-
-    g_message (_("Executing Guile script [%s]"), filename);
-    g_read_file (gschem_toplevel_get_toplevel (w_current), filename, NULL);
-
-    g_free (filename);
-  }
-
-  gtk_widget_destroy (dialog);
-
-} /* i_callback_file_script() */
-
-
-
 /*! \todo Finish function documentation!!!
  *  \brief
  *  \par Function Description


### PR DESCRIPTION
- The GUI part of the code of the previous C callback has been moved into a separate file.
- Dealing with files is now done in Scheme.  The most notable part of this is moving a call to `g_read_file()` to Scheme, which is important for further refactoring of functions in `g_rc.c`, `f_basic.c`, and `g_basic.c`.