### PR TITLE
Move the variable representing the global window list of lepton-schematic to Scheme and introduce some functions for dealing with its windows.

### DIFF
--- a/docs/specifications/config-api.txt
+++ b/docs/specifications/config-api.txt
@@ -300,7 +300,7 @@ C function::
 
 Scheme function::
 
-  save-config! cfg
+  config-save! cfg
 
 Attempt to save configuration parameters for the context ``cfg`` to
 its associated file.  This function may generate a ``GIOError`` (in

--- a/liblepton/scheme/lepton/ffi.scm
+++ b/liblepton/scheme/lepton/ffi.scm
@@ -333,6 +333,7 @@
             lepton_toplevel_get_page_current
             lepton_toplevel_get_pages
             lepton_toplevel_goto_page
+            lepton_toplevel_init_autosave
             lepton_toplevel_search_page
 
             lepton_object_list_to_buffer
@@ -395,6 +396,7 @@
 (define-lff lepton_toplevel_get_page_current '* '(*))
 (define-lff lepton_toplevel_get_pages '* '(*))
 (define-lff lepton_toplevel_goto_page void '(* *))
+(define-lff lepton_toplevel_init_autosave void '(*))
 (define-lff lepton_toplevel_search_page '* '(* *))
 
 ;;; g_rc.c

--- a/liblepton/scheme/lepton/ffi/glib.scm
+++ b/liblepton/scheme/lepton/ffi/glib.scm
@@ -25,6 +25,7 @@
   #:export (g_clear_error
             g_free
             g_list_append
+            g_list_copy
             g_list_free
             g_list_remove
             g_list_remove_all
@@ -52,6 +53,7 @@
 (define-lff g_free void '(*))
 
 (define-lff g_list_append '* '(* *))
+(define-lff g_list_copy '* '(*))
 (define-lff g_list_free void '(*))
 (define-lff g_list_free_full void '(*))
 (define-lff g_list_remove '* '(* *))

--- a/libleptongui/include/globals.h
+++ b/libleptongui/include/globals.h
@@ -44,23 +44,4 @@ extern int verbose_mode;
 # define N_(String) (String)
 #endif
 
-G_BEGIN_DECLS
-
-GList*
-schematic_window_list ();
-
-GList*
-schematic_window_list_find (GschemToplevel *w_current);
-
-void
-schematic_window_list_remove (GschemToplevel *w_current);
-
-guint
-schematic_window_list_length ();
-
-void
-schematic_window_list_add (GschemToplevel *w_current);
-
-G_END_DECLS
-
 #endif

--- a/libleptongui/include/globals.h
+++ b/libleptongui/include/globals.h
@@ -22,9 +22,6 @@
 #define H_GSCHEM_GLOBALS_H
 
 
-/* window list */
-extern GList *global_window_list;
-
 extern int do_logging;
 
 

--- a/libleptongui/include/globals.h
+++ b/libleptongui/include/globals.h
@@ -61,6 +61,9 @@ schematic_window_list_remove (GschemToplevel *w_current);
 guint
 schematic_window_list_length ();
 
+void
+schematic_window_list_add (GschemToplevel *w_current);
+
 G_END_DECLS
 
 #endif

--- a/libleptongui/include/globals.h
+++ b/libleptongui/include/globals.h
@@ -47,4 +47,11 @@ extern int verbose_mode;
 # define N_(String) (String)
 #endif
 
+G_BEGIN_DECLS
+
+GList*
+schematic_window_list ();
+
+G_END_DECLS
+
 #endif

--- a/libleptongui/include/globals.h
+++ b/libleptongui/include/globals.h
@@ -58,6 +58,9 @@ schematic_window_list_find (GschemToplevel *w_current);
 void
 schematic_window_list_remove (GschemToplevel *w_current);
 
+guint
+schematic_window_list_length ();
+
 G_END_DECLS
 
 #endif

--- a/libleptongui/include/globals.h
+++ b/libleptongui/include/globals.h
@@ -55,6 +55,9 @@ schematic_window_list ();
 GList*
 schematic_window_list_find (GschemToplevel *w_current);
 
+void
+schematic_window_list_remove (GschemToplevel *w_current);
+
 G_END_DECLS
 
 #endif

--- a/libleptongui/include/globals.h
+++ b/libleptongui/include/globals.h
@@ -52,6 +52,9 @@ G_BEGIN_DECLS
 GList*
 schematic_window_list ();
 
+GList*
+schematic_window_list_find (GschemToplevel *w_current);
+
 G_END_DECLS
 
 #endif

--- a/libleptongui/include/gschem_toplevel.h
+++ b/libleptongui/include/gschem_toplevel.h
@@ -395,4 +395,10 @@ schematic_window_get_enforce_hierarchy (GschemToplevel *w_current);
 void
 schematic_window_set_enforce_hierarchy (GschemToplevel *w_current,
                                         int enforce);
+guint
+schematic_window_get_keyaccel_string_source_id (GschemToplevel *w_current);
+
+void
+schematic_window_set_keyaccel_string_source_id (GschemToplevel *w_current,
+                                                guint source_id);
 G_END_DECLS

--- a/libleptongui/include/gschem_toplevel.h
+++ b/libleptongui/include/gschem_toplevel.h
@@ -307,9 +307,6 @@ schematic_window_get_pages (GschemToplevel *w_current);
 GschemOptions*
 schematic_window_get_options (GschemToplevel *w_current);
 
-void
-schematic_window_update_keyaccel_string (GschemToplevel *w_current,
-                                         char *keystr);
 gboolean
 schematic_window_clear_keyaccel_string (gpointer data);
 

--- a/libleptongui/include/gschem_toplevel.h
+++ b/libleptongui/include/gschem_toplevel.h
@@ -434,4 +434,10 @@ schematic_window_get_attrib_edit_widget (GschemToplevel *w_current);
 void
 schematic_window_set_attrib_edit_widget (GschemToplevel *w_current,
                                          GtkWidget *widget);
+GtkWidget*
+schematic_window_get_hotkey_widget (GschemToplevel *w_current);
+
+void
+schematic_window_set_hotkey_widget (GschemToplevel *w_current,
+                                    GtkWidget *widget);
 G_END_DECLS

--- a/libleptongui/include/gschem_toplevel.h
+++ b/libleptongui/include/gschem_toplevel.h
@@ -411,9 +411,9 @@ void
 schematic_window_set_keyaccel_string (GschemToplevel *w_current,
                                       char *str);
 GtkWidget*
-schematic_window_get_compselect (GschemToplevel *w_current);
+schematic_window_get_compselect_widget (GschemToplevel *w_current);
 
 void
-schematic_window_set_compselect (GschemToplevel *w_current,
-                                 GtkWidget *widget);
+schematic_window_set_compselect_widget (GschemToplevel *w_current,
+                                        GtkWidget *widget);
 G_END_DECLS

--- a/libleptongui/include/gschem_toplevel.h
+++ b/libleptongui/include/gschem_toplevel.h
@@ -401,4 +401,10 @@ schematic_window_get_keyaccel_string_source_id (GschemToplevel *w_current);
 void
 schematic_window_set_keyaccel_string_source_id (GschemToplevel *w_current,
                                                 guint source_id);
+const char*
+schematic_window_get_keyaccel_string (GschemToplevel *w_current);
+
+void
+schematic_window_set_keyaccel_string (GschemToplevel *w_current,
+                                      char *str);
 G_END_DECLS

--- a/libleptongui/include/gschem_toplevel.h
+++ b/libleptongui/include/gschem_toplevel.h
@@ -386,6 +386,12 @@ schematic_window_get_keyboardpan_gain (GschemToplevel *w_current);
 void
 schematic_window_set_keyboardpan_gain (GschemToplevel *w_current,
                                        int keyboardpan_gain);
+gboolean
+schematic_window_get_dont_invalidate (GschemToplevel *w_current);
+
+void
+schematic_window_set_dont_invalidate (GschemToplevel *w_current,
+                                      gboolean val);
 int
 schematic_window_get_enforce_hierarchy (GschemToplevel *w_current);
 

--- a/libleptongui/include/gschem_toplevel.h
+++ b/libleptongui/include/gschem_toplevel.h
@@ -416,4 +416,10 @@ schematic_window_get_compselect_widget (GschemToplevel *w_current);
 void
 schematic_window_set_compselect_widget (GschemToplevel *w_current,
                                         GtkWidget *widget);
+GtkWidget*
+schematic_window_get_text_input_widget (GschemToplevel *w_current);
+
+void
+schematic_window_set_text_input_widget (GschemToplevel *w_current,
+                                        GtkWidget *widget);
 G_END_DECLS

--- a/libleptongui/include/gschem_toplevel.h
+++ b/libleptongui/include/gschem_toplevel.h
@@ -440,4 +440,10 @@ schematic_window_get_hotkey_widget (GschemToplevel *w_current);
 void
 schematic_window_set_hotkey_widget (GschemToplevel *w_current,
                                     GtkWidget *widget);
+GtkWidget*
+schematic_window_get_coord_widget (GschemToplevel *w_current);
+
+void
+schematic_window_set_coord_widget (GschemToplevel *w_current,
+                                   GtkWidget *widget);
 G_END_DECLS

--- a/libleptongui/include/gschem_toplevel.h
+++ b/libleptongui/include/gschem_toplevel.h
@@ -307,10 +307,13 @@ schematic_window_get_pages (GschemToplevel *w_current);
 GschemOptions*
 schematic_window_get_options (GschemToplevel *w_current);
 
+guint
+schematic_window_add_timer (guint interval,
+                            gpointer callback,
+                            gpointer data);
 void
-schematic_window_update_keyaccel_timer (GschemToplevel *w_current,
-                                        gpointer clear_keyaccel_callback,
-                                        gboolean start_timer);
+schematic_window_destroy_timer (guint source_id);
+
 SchematicActionMode
 schematic_window_get_action_mode (GschemToplevel *w_current);
 

--- a/libleptongui/include/gschem_toplevel.h
+++ b/libleptongui/include/gschem_toplevel.h
@@ -410,4 +410,10 @@ schematic_window_get_keyaccel_string (GschemToplevel *w_current);
 void
 schematic_window_set_keyaccel_string (GschemToplevel *w_current,
                                       char *str);
+GtkWidget*
+schematic_window_get_compselect (GschemToplevel *w_current);
+
+void
+schematic_window_set_compselect (GschemToplevel *w_current,
+                                 GtkWidget *widget);
 G_END_DECLS

--- a/libleptongui/include/gschem_toplevel.h
+++ b/libleptongui/include/gschem_toplevel.h
@@ -422,4 +422,10 @@ schematic_window_get_text_input_widget (GschemToplevel *w_current);
 void
 schematic_window_set_text_input_widget (GschemToplevel *w_current,
                                         GtkWidget *widget);
+GtkWidget*
+schematic_window_get_arc_edit_widget (GschemToplevel *w_current);
+
+void
+schematic_window_set_arc_edit_widget (GschemToplevel *w_current,
+                                      GtkWidget *widget);
 G_END_DECLS

--- a/libleptongui/include/gschem_toplevel.h
+++ b/libleptongui/include/gschem_toplevel.h
@@ -428,4 +428,10 @@ schematic_window_get_arc_edit_widget (GschemToplevel *w_current);
 void
 schematic_window_set_arc_edit_widget (GschemToplevel *w_current,
                                       GtkWidget *widget);
+GtkWidget*
+schematic_window_get_attrib_edit_widget (GschemToplevel *w_current);
+
+void
+schematic_window_set_attrib_edit_widget (GschemToplevel *w_current,
+                                         GtkWidget *widget);
 G_END_DECLS

--- a/libleptongui/include/gschem_toplevel.h
+++ b/libleptongui/include/gschem_toplevel.h
@@ -307,9 +307,6 @@ schematic_window_get_pages (GschemToplevel *w_current);
 GschemOptions*
 schematic_window_get_options (GschemToplevel *w_current);
 
-gboolean
-schematic_window_clear_keyaccel_string (gpointer data);
-
 void
 schematic_window_update_keyaccel_timer (GschemToplevel *w_current,
                                         gpointer clear_keyaccel_callback,

--- a/libleptongui/include/gschem_toplevel.h
+++ b/libleptongui/include/gschem_toplevel.h
@@ -310,10 +310,13 @@ schematic_window_get_options (GschemToplevel *w_current);
 void
 schematic_window_update_keyaccel_string (GschemToplevel *w_current,
                                          char *keystr);
+gboolean
+schematic_window_clear_keyaccel_string (gpointer data);
+
 void
 schematic_window_update_keyaccel_timer (GschemToplevel *w_current,
+                                        gpointer clear_keyaccel_callback,
                                         gboolean start_timer);
-
 SchematicActionMode
 schematic_window_get_action_mode (GschemToplevel *w_current);
 

--- a/libleptongui/include/gschem_toplevel.h
+++ b/libleptongui/include/gschem_toplevel.h
@@ -446,4 +446,10 @@ schematic_window_get_coord_widget (GschemToplevel *w_current);
 void
 schematic_window_set_coord_widget (GschemToplevel *w_current,
                                    GtkWidget *widget);
+GtkWidget*
+schematic_window_get_slot_edit_widget (GschemToplevel *w_current);
+
+void
+schematic_window_set_slot_edit_widget (GschemToplevel *w_current,
+                                       GtkWidget *widget);
 G_END_DECLS

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -624,8 +624,8 @@ GschemToplevel*
 schematic_window_set_main_window (GschemToplevel *w_current,
                                   GtkWidget *main_window);
 void
-x_window_close (GschemToplevel *w_current,
-                gboolean last_window);
+x_window_close (GschemToplevel *w_current);
+
 LeptonPage*
 x_window_open_page (GschemToplevel *w_current,
                     const gchar *filename);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -639,8 +639,8 @@ x_window_save_page (GschemToplevel *w_current,
                     LeptonPage *page,
                     const gchar *filename);
 LeptonPage*
-x_window_close_page_impl (GschemToplevel *w_current,
-                          LeptonPage *page);
+x_window_close_page (GschemToplevel *w_current,
+                     LeptonPage *page);
 GschemToplevel*
 x_window_new (LeptonToplevel *toplevel);
 

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -621,7 +621,7 @@ schematic_window_set_main_window (GschemToplevel *w_current,
                                   GtkWidget *main_window);
 
 void x_window_close(GschemToplevel *w_current);
-void x_window_close_all(GschemToplevel *w_current);
+
 LeptonPage*
 x_window_open_page (GschemToplevel *w_current,
                     const gchar *filename);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -108,8 +108,8 @@ void i_callback_cancel (GtkWidget *widget, gpointer data);
 
 /* i_vars.c */
 void i_vars_set(GschemToplevel *w_current);
-void i_vars_atexit_save_cache_config (gpointer user_data);
- /* m_basic.c */
+
+/* m_basic.c */
 int snap_grid(GschemToplevel *w_current, int input);
 int clip_nochange(GschemPageGeometry *geometry, int x1, int y1, int x2, int y2);
 int visible(GschemToplevel *w_current, int wleft, int wtop, int wright, int wbottom);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -623,9 +623,6 @@ schematic_window_get_main_window (GschemToplevel *w_current);
 GschemToplevel*
 schematic_window_set_main_window (GschemToplevel *w_current,
                                   GtkWidget *main_window);
-void
-x_window_close (GschemToplevel *w_current);
-
 LeptonPage*
 x_window_open_page (GschemToplevel *w_current,
                     const gchar *filename);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -618,9 +618,9 @@ schematic_window_show_all (GschemToplevel *w_current,
 GschemToplevel*
 schematic_window_set_main_window (GschemToplevel *w_current,
                                   GtkWidget *main_window);
-
-void x_window_close(GschemToplevel *w_current);
-
+void
+x_window_close (GschemToplevel *w_current,
+                gboolean last_window);
 LeptonPage*
 x_window_open_page (GschemToplevel *w_current,
                     const gchar *filename);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -612,6 +612,9 @@ void
 schematic_window_restore_geometry (GschemToplevel* w_current,
                                    GtkWidget* main_window);
 void
+schematic_window_save_geometry (GschemToplevel* w_current);
+
+void
 schematic_window_show_all (GschemToplevel *w_current,
                            GtkWidget *main_window);
 GtkWidget*

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -560,7 +560,6 @@ void x_stroke_record (GschemToplevel *w_current, gint x, gint y);
 gint x_stroke_translate_and_execute (GschemToplevel *w_current);
 
 /* x_window.c */
-GschemToplevel* x_window_setup (GschemToplevel *w_current);
 void x_window_create_drawing(GtkWidget *drawbox, GschemToplevel *w_current);
 void x_window_setup_draw_events_main_wnd (GschemToplevel* w_current,
                                           GtkWidget*      main_window);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -614,6 +614,9 @@ schematic_window_restore_geometry (GschemToplevel* w_current,
 void
 schematic_window_show_all (GschemToplevel *w_current,
                            GtkWidget *main_window);
+GtkWidget*
+schematic_window_get_main_window (GschemToplevel *w_current);
+
 GschemToplevel*
 schematic_window_set_main_window (GschemToplevel *w_current,
                                   GtkWidget *main_window);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -64,7 +64,6 @@ void g_dynwind_window (GschemToplevel *w_current);
 void g_init_window (SCM fluid);
 
 /* lepton-schematic.c */
-void gschem_quit(void);
 void
 set_verbose_mode ();
 void

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -638,9 +638,6 @@ gint
 x_window_save_page (GschemToplevel *w_current,
                     LeptonPage *page,
                     const gchar *filename);
-void
-x_window_close_page (GschemToplevel *w_current,
-                     LeptonPage *page);
 LeptonPage*
 x_window_close_page_impl (GschemToplevel *w_current,
                           LeptonPage *page);

--- a/libleptongui/scheme/Makefile.am
+++ b/libleptongui/scheme/Makefile.am
@@ -43,6 +43,7 @@ nobase_dist_scmdata_DATA = \
 	schematic/window.scm \
 	schematic/window/foreign.scm \
 	schematic/window/global.scm \
+	schematic/window/list.scm \
 	conf/schematic/attribs.scm \
 	conf/schematic/deprecated.scm \
 	conf/schematic/keys.scm \

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -171,7 +171,7 @@
 
 (define-action-public (&file-close-window #:label (G_ "Close Window") #:icon "gtk-close")
   (log! 'message (G_ "Closing Window"))
-  (x_window_close (*current-window)))
+  (close-window! (*current-window)))
 
 
 (define-action-public (&file-quit #:label (G_ "Quit") #:icon "gtk-quit")
@@ -181,7 +181,7 @@
       (if (null-pointer? *window-list)
           (g_list_free *list-copy)
           (begin
-            (x_window_close (glist-data *window-list))
+            (close-window! (glist-data *window-list))
             (loop (glist-next *window-list)))))))
 
 

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -53,6 +53,7 @@
   #:use-module (schematic undo)
   #:use-module (schematic window global)
   #:use-module (schematic window foreign)
+  #:use-module (schematic window list)
   #:use-module (schematic window))
 
 
@@ -171,18 +172,12 @@
 
 (define-action-public (&file-close-window #:label (G_ "Close Window") #:icon "gtk-close")
   (log! 'message (G_ "Closing Window"))
-  (close-window! (*current-window)))
+  (close-window! (pointer->window (*current-window))))
 
 
 (define-action-public (&file-quit #:label (G_ "Quit") #:icon "gtk-quit")
   (lepton-repl-save-history)
-  (let ((*list-copy (g_list_copy (schematic_window_list))))
-    (let loop ((*window-list *list-copy))
-      (if (null-pointer? *window-list)
-          (g_list_free *list-copy)
-          (begin
-            (close-window! (glist-data *window-list))
-            (loop (glist-next *window-list)))))))
+  (for-each close-window! (schematic-windows)))
 
 
 (define-action-public (&file-repl #:label (G_ "Terminal REPL") #:icon "gtk-execute")

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -846,7 +846,7 @@ the snap grid size should be set to 100")))
     (let ((*page_current (schematic_window_get_active_page *window))
           ;; If there's only one opened page, create a dummy page
           ;; (to be closed afterwards) to prevent
-          ;; x_window_close_page() from creating a stray blank
+          ;; window-close-page!() from creating a stray blank
           ;; page.
           (*dummy-page (if (= 1 (length (active-pages)))
                            (x_window_open_page *window %null-pointer)
@@ -859,7 +859,7 @@ the snap grid size should be set to 100")))
             (up (lepton_page_get_up *page_current)))
 
         ;; Delete the page then re-open the file as a new page.
-        (x_window_close_page *window *page_current)
+        (window-close-page! (current-window) (active-page))
 
         ;; Force symbols to be re-loaded from disk.
         (s_clib_refresh)
@@ -880,7 +880,8 @@ the snap grid size should be set to 100")))
           ;; Close dummy page, if it exists.
           (unless (null-pointer? *dummy-page)
             (x_window_set_current_page *window *dummy-page)
-            (x_window_close_page *window *dummy-page)
+            (window-close-page! (current-window)
+                                (pointer->page *dummy-page))
             (x_window_set_current_page *window *page))
 
           (when (true? (x_tabs_enabled))
@@ -1270,7 +1271,7 @@ the snap grid size should be set to 100")))
                       ;; If the page has changed, ask the user to
                       ;; really close it.
                       (true? (x_dialog_close_changed_page *window *page)))
-              (x_window_close_page *window *page)
+              (window-close-page! (current-window) (active-page))
               (x_window_set_current_page *window *upper-page)))))))
 
 

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -173,9 +173,17 @@
   (log! 'message (G_ "Closing Window"))
   (x_window_close (*current-window)))
 
+
 (define-action-public (&file-quit #:label (G_ "Quit") #:icon "gtk-quit")
   (lepton-repl-save-history)
-  (x_window_close_all (*current-window)))
+  (let ((*list-copy (g_list_copy (schematic_window_list))))
+    (let loop ((*window-list *list-copy))
+      (if (null-pointer? *window-list)
+          (g_list_free *list-copy)
+          (begin
+            (x_window_close (glist-data *window-list))
+            (loop (glist-next *window-list)))))))
+
 
 (define-action-public (&file-repl #:label (G_ "Terminal REPL") #:icon "gtk-execute")
   (start-repl-in-background-terminal))

--- a/libleptongui/scheme/schematic/callback.scm
+++ b/libleptongui/scheme/schematic/callback.scm
@@ -26,6 +26,7 @@
   #:use-module (lepton ffi)
   #:use-module (lepton gettext)
   #:use-module (lepton log)
+  #:use-module (lepton page foreign)
 
   #:use-module (schematic action)
   #:use-module (schematic action-mode)
@@ -77,7 +78,8 @@
     (unless (or (null-pointer? *page)
                 (and (true? (lepton_page_get_changed *page))
                      (not (true? (x_dialog_close_changed_page *window *page)))))
-      (x_window_close_page *window *page))))
+      (window-close-page! (pointer->window *window)
+                          (pointer->page *page)))))
 
 (define *callback-page-close
   (procedure->pointer void callback-page-close '(* *)))

--- a/libleptongui/scheme/schematic/callback.scm
+++ b/libleptongui/scheme/schematic/callback.scm
@@ -38,7 +38,6 @@
             callback-add-component
             callback-add-net
             callback-add-text
-            *callback-close-schematic-window
             callback-file-new
             *callback-file-new
             callback-file-open
@@ -149,24 +148,3 @@
   (i_set_state *window (symbol->action-mode 'select-mode))
 
   (text_input_dialog *window))
-
-
-(define (callback-close-schematic-window *widget *event *window)
-  (if (null-pointer? *window)
-      (error "NULL window.")
-      (x_window_close *window))
-  ;; Stop further propagation of the "delete-event" signal for
-  ;; window:
-  ;;   - if the user has cancelled closing, the window should
-  ;;     obviously not be destroyed
-  ;;   - otherwise the window has already been destroyed, nothing
-  ;;     more to do
-  TRUE)
-
-
-;;; When invoked via signal "delete-event", the function closes
-;;; the current window and, if this is the last window, quits
-;;; lepton-schematic.  The signal is emitted when you click the
-;;; close button on the window.
-(define *callback-close-schematic-window
-  (procedure->pointer int callback-close-schematic-window '(* * *)))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -27,7 +27,6 @@
 
   #:export (lepton_schematic_run
             lepton_schematic_app
-            gschem_quit
 
             g_init_window
 
@@ -51,6 +50,7 @@
             i_update_grid_info
             i_update_menus
 
+            i_vars_atexit_save_cache_config
             i_vars_set
 
             make_menu_action
@@ -63,8 +63,6 @@
             o_buffer_copy
             o_buffer_cut
             o_buffer_paste_start
-
-            o_undo_init
 
             o_redraw_cleanstates
             o_invalidate_rubber
@@ -105,7 +103,10 @@
             page_select_widget_new
             page_select_widget_update
 
+            s_attrib_free
+
             s_clib_refresh
+            s_clib_free
 
             set_quiet_mode
             set_verbose_mode
@@ -124,7 +125,9 @@
             x_clipboard_init
 
             x_show_uri
+
             x_stroke_init
+            x_stroke_free
 
             find_text_dialog
             hide_text_dialog
@@ -294,6 +297,8 @@
             s_slot_update_object
 
             o_undo_callback
+            o_undo_cleanup
+            o_undo_init
             o_undo_savestate
             o_undo_savestate_viewport
 
@@ -347,7 +352,6 @@
 ;;; lepton_schematic.c
 (define-lff lepton_schematic_run int '(*))
 (define-lff lepton_schematic_app '* '())
-(define-lff gschem_quit void '())
 
 ;;; g_basic.c
 (define-lff g_read_file int '(* * *))
@@ -372,8 +376,12 @@
 (define-lff set_verbose_mode void '())
 (define-lff x_color_init void '())
 
+;;; s_attrib.c
+(define-lff s_attrib_free void '())
+
 ;;; s_clib.c
 (define-lff s_clib_refresh void '())
+(define-lff s_clib_free void '())
 
 ;;; color_edit_widget.c
 (define-lff color_edit_widget_update void '(*))
@@ -595,6 +603,7 @@
 
 ;;; i_vars.c
 (define-lff i_vars_set void '(*))
+(define-lff i_vars_atexit_save_cache_config void '(*))
 
 ;;; o_basic.c
 (define-lff o_redraw_cleanstates int '(*))
@@ -696,6 +705,7 @@
 ;;; o_undo.c
 (define-lff o_undo_init void '())
 (define-lff o_undo_callback void (list '* '* int))
+(define-lff o_undo_cleanup void '())
 (define-lff o_undo_savestate void (list '* '* int))
 (define-lff o_undo_savestate_viewport void '(*))
 
@@ -707,6 +717,14 @@
 ;;; if libstroke was not found on the configure stage.
 (define (x_stroke_init)
   (let ((func (delay (false-if-exception (dynamic-func "x_stroke_init"
+                                                       libleptongui)))))
+    (and (force func)
+         (let ((proc (delay (pointer->procedure void (force func) '()))))
+           ((force proc))))))
+
+;;; The same as above.
+(define (x_stroke_free)
+  (let ((func (delay (false-if-exception (dynamic-func "x_stroke_free"
                                                        libleptongui)))))
     (and (force func)
          (let ((proc (delay (pointer->procedure void (force func) '()))))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -262,8 +262,9 @@
             schematic_window_get_keyaccel_string_source_id
             schematic_window_set_keyaccel_string_source_id
             schematic_window_update_keyaccel_timer
-            *schematic_window_clear_keyaccel_string
             schematic_window_get_shift_key_pressed
+
+            schematic_window_list_find
 
             gschem_options_cycle_grid_mode
             gschem_options_get_grid_mode
@@ -448,7 +449,6 @@
 (define-lff gschem_toplevel_get_toplevel '* '(*))
 (define-lff gschem_toplevel_page_changed void '(*))
 (define-lff gschem_toplevel_page_content_changed void '(* *))
-(define-lfc *schematic_window_clear_keyaccel_string)
 (define-lff schematic_window_get_actionfeedback_mode int '(*))
 (define-lff schematic_window_set_actionfeedback_mode void (list '* int))
 (define-lff schematic_window_get_active_page '* '(*))
@@ -472,6 +472,9 @@
 (define-lff schematic_window_set_keyaccel_string_source_id void (list '* int))
 (define-lff schematic_window_update_keyaccel_timer void (list '* '* int))
 (define-lff schematic_window_get_shift_key_pressed int '(*))
+
+;;; globals.c
+(define-lff schematic_window_list_find '* '(*))
 
 ;;; gschem_options.c
 (define-lff gschem_options_cycle_grid_mode void '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -217,6 +217,7 @@
             about_dialog
 
             x_dialog_close_changed_page
+            x_dialog_close_window
 
             coord_dialog
 
@@ -421,6 +422,7 @@
 
 ;;; gschem_close_confirmation_dialog.c
 (define-lff x_dialog_close_changed_page int '(* *))
+(define-lff x_dialog_close_window int '(*))
 
 ;;; gschem_coord_dialog.c
 (define-lff coord_dialog void (list '* int int))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -270,6 +270,7 @@
             schematic_window_list
             schematic_window_list_add
             schematic_window_list_find
+            schematic_window_list_length
 
             gschem_options_cycle_grid_mode
             gschem_options_get_grid_mode
@@ -483,6 +484,7 @@
 (define-lff schematic_window_list '* '())
 (define-lff schematic_window_list_add void '(*))
 (define-lff schematic_window_list_find '* '(*))
+(define-lff schematic_window_list_length int '())
 
 ;;; gschem_options.c
 (define-lff gschem_options_cycle_grid_mode void '(*))
@@ -517,7 +519,7 @@
 (define-lff x_window_setup_draw_events_drawing_area void '(* *))
 (define-lff x_window_setup_draw_events_main_wnd void '(* *))
 (define-lff x_window_untitled_page int '(*))
-(define-lff x_window_close void '(*))
+(define-lff x_window_close void (list '* int))
 (define-lff x_window_close_page '* '(* *))
 (define-lff schematic_window_create_app_window '* '(*))
 (define-lff schematic_window_create_main_box '* '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -272,12 +272,6 @@
             schematic_window_set_keyaccel_string_source_id
             schematic_window_get_shift_key_pressed
 
-            schematic_window_list
-            schematic_window_list_add
-            schematic_window_list_find
-            schematic_window_list_length
-            schematic_window_list_remove
-
             gschem_options_cycle_grid_mode
             gschem_options_get_grid_mode
             gschem_options_cycle_magnetic_net_mode
@@ -493,13 +487,6 @@
 (define-lff schematic_window_get_keyaccel_string_source_id int '(*))
 (define-lff schematic_window_set_keyaccel_string_source_id void (list '* int))
 (define-lff schematic_window_get_shift_key_pressed int '(*))
-
-;;; globals.c
-(define-lff schematic_window_list '* '())
-(define-lff schematic_window_list_add void '(*))
-(define-lff schematic_window_list_find '* '(*))
-(define-lff schematic_window_list_length int '())
-(define-lff schematic_window_list_remove void '(*))
 
 ;;; gschem_options.c
 (define-lff gschem_options_cycle_grid_mode void '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -151,7 +151,6 @@
             x_widgets_toggle_widget_visibility
 
             x_window_close
-            x_window_close_all
             x_window_close_page
             x_window_new
             x_window_open_page
@@ -265,6 +264,7 @@
             schematic_window_set_keyaccel_string_source_id
             schematic_window_get_shift_key_pressed
 
+            schematic_window_list
             schematic_window_list_find
 
             gschem_options_cycle_grid_mode
@@ -476,6 +476,7 @@
 (define-lff schematic_window_get_shift_key_pressed int '(*))
 
 ;;; globals.c
+(define-lff schematic_window_list '* '())
 (define-lff schematic_window_list_find '* '(*))
 
 ;;; gschem_options.c
@@ -513,7 +514,6 @@
 (define-lff x_window_setup_draw_events_main_wnd void '(* *))
 (define-lff x_window_untitled_page int '(*))
 (define-lff x_window_close void '(*))
-(define-lff x_window_close_all void '(*))
 (define-lff x_window_close_page '* '(* *))
 (define-lff schematic_window_create_app_window '* '(*))
 (define-lff schematic_window_create_main_box '* '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -235,6 +235,8 @@
             schematic_signal_connect
 
             schematic_window_active_page_changed
+            schematic_window_add_timer
+            schematic_window_destroy_timer
             gschem_toplevel_get_current_page_view
             gschem_toplevel_get_show_hidden_text
             gschem_toplevel_get_toplevel
@@ -261,7 +263,6 @@
             schematic_window_set_keyaccel_string
             schematic_window_get_keyaccel_string_source_id
             schematic_window_set_keyaccel_string_source_id
-            schematic_window_update_keyaccel_timer
             schematic_window_get_shift_key_pressed
 
             schematic_window_list_find
@@ -444,6 +445,8 @@
 
 ;;; gschem_toplevel.c
 (define-lff schematic_window_active_page_changed void '(*))
+(define-lff schematic_window_add_timer int (list int '* '*))
+(define-lff schematic_window_destroy_timer void (list int))
 (define-lff gschem_toplevel_get_current_page_view '* '(*))
 (define-lff gschem_toplevel_get_show_hidden_text int '(*))
 (define-lff gschem_toplevel_get_toplevel '* '(*))
@@ -470,7 +473,6 @@
 (define-lff schematic_window_set_keyaccel_string void '(* *))
 (define-lff schematic_window_get_keyaccel_string_source_id int '(*))
 (define-lff schematic_window_set_keyaccel_string_source_id void (list '* int))
-(define-lff schematic_window_update_keyaccel_timer void (list '* '* int))
 (define-lff schematic_window_get_shift_key_pressed int '(*))
 
 ;;; globals.c

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -61,6 +61,7 @@
             o_buffer_init
             o_buffer_copy
             o_buffer_cut
+            o_buffer_free
             o_buffer_paste_start
 
             o_redraw_cleanstates
@@ -184,6 +185,7 @@
             schematic_window_create_notebooks
             schematic_window_create_statusbar
             schematic_window_restore_geometry
+            schematic_window_save_geometry
             schematic_window_show_all
             schematic_window_get_main_window
             schematic_window_set_main_window
@@ -299,6 +301,8 @@
             o_undo_savestate
             o_undo_savestate_viewport
 
+            s_log_close
+
             x_event_get_pointer_position
             x_event_key
 
@@ -367,6 +371,7 @@
 (define-lff o_buffer_init void '())
 (define-lff o_buffer_copy void (list '* int))
 (define-lff o_buffer_cut void (list '* int))
+(define-lff o_buffer_free void '(*))
 (define-lff o_buffer_paste_start int (list '* int int int))
 
 (define-lff set_quiet_mode void '())
@@ -522,7 +527,7 @@
 (define-lff x_window_setup_draw_events_drawing_area void '(* *))
 (define-lff x_window_setup_draw_events_main_wnd void '(* *))
 (define-lff x_window_untitled_page int '(*))
-(define-lff x_window_close void (list '* int))
+(define-lff x_window_close void '(*))
 (define-lff x_window_close_page '* '(* *))
 (define-lff schematic_window_create_app_window '* '(*))
 (define-lff schematic_window_create_main_box '* '(*))
@@ -542,6 +547,7 @@
 (define-lff schematic_window_create_notebooks void '(* * *))
 (define-lff schematic_window_create_statusbar void '(* *))
 (define-lff schematic_window_restore_geometry void '(* *))
+(define-lff schematic_window_save_geometry void '(*))
 (define-lff schematic_window_show_all void '(* *))
 (define-lff schematic_window_get_main_window '* '(*))
 (define-lff schematic_window_set_main_window '* '(* *))
@@ -701,6 +707,9 @@
 (define-lff o_undo_cleanup void '())
 (define-lff o_undo_savestate void (list '* '* int))
 (define-lff o_undo_savestate_viewport void '(*))
+
+;;; s_log.c
+(define-lff s_log_close void '())
 
 ;;; a_zoom.c
 (define-lff a_zoom void (list '* '* int int))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -152,7 +152,7 @@
 
             x_window_close
             x_window_close_all
-            x_window_close_page_impl
+            x_window_close_page
             x_window_new
             x_window_open_page
             x_window_save_page
@@ -501,7 +501,7 @@
 (define-lff x_window_untitled_page int '(*))
 (define-lff x_window_close void '(*))
 (define-lff x_window_close_all void '(*))
-(define-lff x_window_close_page_impl '* '(* *))
+(define-lff x_window_close_page '* '(* *))
 (define-lff schematic_window_create_app_window '* '(*))
 (define-lff schematic_window_create_main_box '* '(*))
 (define-lff schematic_window_create_work_box '* '())

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -185,6 +185,7 @@
             schematic_window_create_statusbar
             schematic_window_restore_geometry
             schematic_window_show_all
+            schematic_window_get_main_window
             schematic_window_set_main_window
             schematic_window_set_toolbar
 
@@ -542,6 +543,7 @@
 (define-lff schematic_window_create_statusbar void '(* *))
 (define-lff schematic_window_restore_geometry void '(* *))
 (define-lff schematic_window_show_all void '(* *))
+(define-lff schematic_window_get_main_window '* '(*))
 (define-lff schematic_window_set_main_window '* '(* *))
 (define-lff schematic_window_set_toolbar void '(* *))
 

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -50,7 +50,6 @@
             i_update_grid_info
             i_update_menus
 
-            i_vars_atexit_save_cache_config
             i_vars_set
 
             make_menu_action
@@ -603,7 +602,6 @@
 
 ;;; i_vars.c
 (define-lff i_vars_set void '(*))
-(define-lff i_vars_atexit_save_cache_config void '(*))
 
 ;;; o_basic.c
 (define-lff o_redraw_cleanstates int '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -257,7 +257,10 @@
             schematic_window_set_right_notebook
             schematic_window_get_selection_list
             schematic_window_get_undo_panzoom
-            schematic_window_update_keyaccel_string
+            schematic_window_get_keyaccel_string
+            schematic_window_set_keyaccel_string
+            schematic_window_get_keyaccel_string_source_id
+            schematic_window_set_keyaccel_string_source_id
             schematic_window_update_keyaccel_timer
             *schematic_window_clear_keyaccel_string
             schematic_window_get_shift_key_pressed
@@ -463,7 +466,10 @@
 (define-lff schematic_window_set_right_notebook void '(* *))
 (define-lff schematic_window_get_selection_list '* '(*))
 (define-lff schematic_window_get_undo_panzoom int '(*))
-(define-lff schematic_window_update_keyaccel_string void '(* *))
+(define-lff schematic_window_get_keyaccel_string '* '(*))
+(define-lff schematic_window_set_keyaccel_string void '(* *))
+(define-lff schematic_window_get_keyaccel_string_source_id int '(*))
+(define-lff schematic_window_set_keyaccel_string_source_id void (list '* int))
 (define-lff schematic_window_update_keyaccel_timer void (list '* '* int))
 (define-lff schematic_window_get_shift_key_pressed int '(*))
 

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -27,6 +27,7 @@
 
   #:export (lepton_schematic_run
             lepton_schematic_app
+            gschem_quit
 
             g_init_window
 
@@ -346,6 +347,7 @@
 ;;; lepton_schematic.c
 (define-lff lepton_schematic_run int '(*))
 (define-lff lepton_schematic_app '* '())
+(define-lff gschem_quit void '())
 
 ;;; g_basic.c
 (define-lff g_read_file int '(* * *))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -152,7 +152,7 @@
 
             x_window_close
             x_window_close_all
-            x_window_close_page
+            x_window_close_page_impl
             x_window_new
             x_window_open_page
             x_window_save_page
@@ -198,6 +198,7 @@
             x_tabs_create
             x_tabs_enabled
             x_tabs_hdr_update
+            x_tabs_page_close
 
             schematic_action_mode_from_string
             schematic_action_mode_to_string
@@ -500,7 +501,7 @@
 (define-lff x_window_untitled_page int '(*))
 (define-lff x_window_close void '(*))
 (define-lff x_window_close_all void '(*))
-(define-lff x_window_close_page void '(* *))
+(define-lff x_window_close_page_impl '* '(* *))
 (define-lff schematic_window_create_app_window '* '(*))
 (define-lff schematic_window_create_main_box '* '(*))
 (define-lff schematic_window_create_work_box '* '())
@@ -540,6 +541,7 @@
 (define-lff x_tabs_create void '(* *))
 (define-lff x_tabs_enabled int '())
 (define-lff x_tabs_hdr_update void '(* *))
+(define-lff x_tabs_page_close void '(* *))
 
 ;;; gschem_find_text_widget.c
 (define-lff find_text_dialog void '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -243,6 +243,7 @@
             schematic_window_active_page_changed
             schematic_window_add_timer
             schematic_window_destroy_timer
+            gschem_toplevel_free
             gschem_toplevel_get_current_page_view
             gschem_toplevel_get_show_hidden_text
             gschem_toplevel_get_toplevel
@@ -275,6 +276,7 @@
             schematic_window_list_add
             schematic_window_list_find
             schematic_window_list_length
+            schematic_window_list_remove
 
             gschem_options_cycle_grid_mode
             gschem_options_get_grid_mode
@@ -463,6 +465,7 @@
 (define-lff schematic_window_active_page_changed void '(*))
 (define-lff schematic_window_add_timer int (list int '* '*))
 (define-lff schematic_window_destroy_timer void (list int))
+(define-lff gschem_toplevel_free void '(*))
 (define-lff gschem_toplevel_get_current_page_view '* '(*))
 (define-lff gschem_toplevel_get_show_hidden_text int '(*))
 (define-lff gschem_toplevel_get_toplevel '* '(*))
@@ -496,6 +499,7 @@
 (define-lff schematic_window_list_add void '(*))
 (define-lff schematic_window_list_find '* '(*))
 (define-lff schematic_window_list_length int '())
+(define-lff schematic_window_list_remove void '(*))
 
 ;;; gschem_options.c
 (define-lff gschem_options_cycle_grid_mode void '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -259,6 +259,7 @@
             schematic_window_get_undo_panzoom
             schematic_window_update_keyaccel_string
             schematic_window_update_keyaccel_timer
+            *schematic_window_clear_keyaccel_string
             schematic_window_get_shift_key_pressed
 
             gschem_options_cycle_grid_mode
@@ -444,6 +445,7 @@
 (define-lff gschem_toplevel_get_toplevel '* '(*))
 (define-lff gschem_toplevel_page_changed void '(*))
 (define-lff gschem_toplevel_page_content_changed void '(* *))
+(define-lfc *schematic_window_clear_keyaccel_string)
 (define-lff schematic_window_get_actionfeedback_mode int '(*))
 (define-lff schematic_window_set_actionfeedback_mode void (list '* int))
 (define-lff schematic_window_get_active_page '* '(*))
@@ -462,7 +464,7 @@
 (define-lff schematic_window_get_selection_list '* '(*))
 (define-lff schematic_window_get_undo_panzoom int '(*))
 (define-lff schematic_window_update_keyaccel_string void '(* *))
-(define-lff schematic_window_update_keyaccel_timer void (list '* int))
+(define-lff schematic_window_update_keyaccel_timer void (list '* '* int))
 (define-lff schematic_window_get_shift_key_pressed int '(*))
 
 ;;; gschem_options.c

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -122,6 +122,7 @@
 
             autonumber_text_dialog
 
+            x_clipboard_finish
             x_clipboard_init
 
             x_show_uri
@@ -660,6 +661,7 @@
 (define-lff autonumber_text_dialog void '(*))
 
 ;;; x_clipboard.c
+(define-lff x_clipboard_finish void '(*))
 (define-lff x_clipboard_init void '(*))
 
 ;;; x_misc.c

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -149,6 +149,7 @@
             x_compselect_open
 
             x_widgets_create
+            x_widgets_destroy_dialogs
             x_widgets_init
             x_widgets_show_color_edit
             x_widgets_show_find_text_state
@@ -159,7 +160,6 @@
             x_widgets_show_page_select
             x_widgets_toggle_widget_visibility
 
-            x_window_close
             x_window_close_page
             x_window_new
             x_window_open_page
@@ -275,6 +275,14 @@
             schematic_window_get_keyaccel_string_source_id
             schematic_window_set_keyaccel_string_source_id
             schematic_window_get_shift_key_pressed
+            schematic_window_get_arc_edit_widget
+            schematic_window_get_attrib_edit_widget
+            schematic_window_get_compselect_widget
+            schematic_window_get_coord_widget
+            schematic_window_get_hotkey_widget
+            schematic_window_get_slot_edit_widget
+            schematic_window_get_text_input_widget
+            schematic_window_set_dont_invalidate
 
             gschem_options_cycle_grid_mode
             gschem_options_get_grid_mode
@@ -312,6 +320,8 @@
             schematic_file_open
 
             x_image_setup
+
+            x_multiattrib_close
 
             x_print
 
@@ -397,6 +407,7 @@
 
 ;;; x_widgets.c
 (define-lff x_widgets_create void '(*))
+(define-lff x_widgets_destroy_dialogs void '(*))
 (define-lff x_widgets_init void '())
 (define-lff x_widgets_show_color_edit void '(*))
 (define-lff x_widgets_show_find_text_state void '(*))
@@ -494,6 +505,14 @@
 (define-lff schematic_window_get_keyaccel_string_source_id int '(*))
 (define-lff schematic_window_set_keyaccel_string_source_id void (list '* int))
 (define-lff schematic_window_get_shift_key_pressed int '(*))
+(define-lff schematic_window_get_arc_edit_widget '* '(*))
+(define-lff schematic_window_get_attrib_edit_widget '* '(*))
+(define-lff schematic_window_get_compselect_widget '* '(*))
+(define-lff schematic_window_get_coord_widget '* '(*))
+(define-lff schematic_window_get_hotkey_widget '* '(*))
+(define-lff schematic_window_get_slot_edit_widget '* '(*))
+(define-lff schematic_window_get_text_input_widget '* '(*))
+(define-lff schematic_window_set_dont_invalidate void (list '* int))
 
 ;;; gschem_options.c
 (define-lff gschem_options_cycle_grid_mode void '(*))
@@ -528,7 +547,6 @@
 (define-lff x_window_setup_draw_events_drawing_area void '(* *))
 (define-lff x_window_setup_draw_events_main_wnd void '(* *))
 (define-lff x_window_untitled_page int '(*))
-(define-lff x_window_close void '(*))
 (define-lff x_window_close_page '* '(* *))
 (define-lff schematic_window_create_app_window '* '(*))
 (define-lff schematic_window_create_main_box '* '(*))
@@ -680,6 +698,9 @@
 
 ;;; x_image.c
 (define-lff x_image_setup void '(*))
+
+;;; x_multiattrib.c
+(define-lff x_multiattrib_close void '(*))
 
 ;;; x_newtext.c
 (define-lff text_input_dialog void '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -50,6 +50,8 @@
             i_update_grid_info
             i_update_menus
 
+            i_vars_set
+
             make_menu_action
             make_separator_menu_item
             schematic_window_create_main_popup_menu
@@ -118,6 +120,8 @@
 
             autonumber_text_dialog
 
+            x_clipboard_init
+
             x_show_uri
             x_stroke_init
 
@@ -156,7 +160,6 @@
             x_window_open_page
             x_window_save_page
             x_window_set_current_page
-            x_window_setup
             x_window_setup_draw_events_drawing_area
             x_window_setup_draw_events_main_wnd
             x_window_untitled_page
@@ -265,6 +268,7 @@
             schematic_window_get_shift_key_pressed
 
             schematic_window_list
+            schematic_window_list_add
             schematic_window_list_find
 
             gschem_options_cycle_grid_mode
@@ -477,6 +481,7 @@
 
 ;;; globals.c
 (define-lff schematic_window_list '* '())
+(define-lff schematic_window_list_add void '(*))
 (define-lff schematic_window_list_find '* '(*))
 
 ;;; gschem_options.c
@@ -509,7 +514,6 @@
 (define-lff x_window_open_page '* '(* *))
 (define-lff x_window_save_page int '(* * *))
 (define-lff x_window_set_current_page void '(* *))
-(define-lff x_window_setup '* '(*))
 (define-lff x_window_setup_draw_events_drawing_area void '(* *))
 (define-lff x_window_setup_draw_events_main_wnd void '(* *))
 (define-lff x_window_untitled_page int '(*))
@@ -585,6 +589,9 @@
 (define-lff i_update_grid_info void '(*))
 (define-lff i_update_menus void '(*))
 
+;;; i_vars.c
+(define-lff i_vars_set void '(*))
+
 ;;; o_basic.c
 (define-lff o_redraw_cleanstates int '(*))
 (define-lff o_invalidate_rubber int '(*))
@@ -639,6 +646,9 @@
 
 ;;; x_autonumber.c
 (define-lff autonumber_text_dialog void '(*))
+
+;;; x_clipboard.c
+(define-lff x_clipboard_init void '(*))
 
 ;;; x_misc.c
 (define-lff x_show_uri int '(* * *))

--- a/libleptongui/scheme/schematic/ffi/gtk.scm
+++ b/libleptongui/scheme/schematic/ffi/gtk.scm
@@ -22,6 +22,8 @@
   #:use-module (lepton ffi)
 
   #:export (gtk_init
+            gtk_main_level
+            gtk_main_quit
             gtk_accelerator_parse
             gtk_accelerator_name
             gtk_accelerator_get_label
@@ -52,6 +54,9 @@
 (define-lff gtk_icon_theme_get_default '* '())
 
 (define-lff gtk_init void '(* *))
+
+(define-lff gtk_main_level int '())
+(define-lff gtk_main_quit void '())
 
 (define-lff gtk_menu_item_new_with_mnemonic '* '(*))
 (define-lff gtk_menu_new '* '())

--- a/libleptongui/scheme/schematic/ffi/gtk.scm
+++ b/libleptongui/scheme/schematic/ffi/gtk.scm
@@ -33,6 +33,7 @@
             gtk_window_set_default_icon_name
             gtk_tearoff_menu_item_new
             gtk_menu_item_new_with_mnemonic
+            gtk_widget_destroy
             gtk_widget_show
             gtk_menu_new
             gtk_menu_bar_new
@@ -68,6 +69,7 @@
 
 (define-lff gtk_tearoff_menu_item_new '* '())
 
+(define-lff gtk_widget_destroy void '(*))
 (define-lff gtk_widget_show void '(*))
 
 (define-lff gtk_window_set_default_icon_name void '(*))

--- a/libleptongui/scheme/schematic/gui/keymap.scm
+++ b/libleptongui/scheme/schematic/gui/keymap.scm
@@ -28,6 +28,8 @@
   #:use-module (schematic action)
   #:use-module (schematic ffi)
   #:use-module (schematic keymap)
+  #:use-module (schematic window list)
+  #:use-module (schematic window foreign)
 
   #:export (%global-keymap
             current-keymap
@@ -45,7 +47,7 @@
 ;;; function must stop GSource timer defined in C.
 (define (clear-key-accelerator-string *window)
   ;; If the window context has disappeared, do nothing.
-  (unless (null-pointer? (schematic_window_list_find *window))
+  (when (window-exists? (pointer->window *window))
     (schematic_window_set_keyaccel_string *window %null-pointer)
     (schematic_window_set_keyaccel_string_source_id *window 0)
     (i_show_state *window %null-pointer))

--- a/libleptongui/scheme/schematic/gui/keymap.scm
+++ b/libleptongui/scheme/schematic/gui/keymap.scm
@@ -41,19 +41,18 @@
 
 ;;; Clears the current keyboard accelerator string in the status
 ;;; bar of the relevant toplevel window *WINDOW.  Called some time
-;;; after a keystroke is pressed.  If the current key sequence was
-;;; a prefix, let it persist.
+;;; after a keystroke is pressed.  Always returns FALSE as this
+;;; function must stop GSource timer defined in C.
 (define (clear-key-accelerator-string *window)
   ;; If the window context has disappeared, do nothing.
   (unless (null-pointer? (schematic_window_list_find *window))
     (schematic_window_set_keyaccel_string *window %null-pointer)
     (schematic_window_set_keyaccel_string_source_id *window 0)
     (i_show_state *window %null-pointer))
-
-  ;; Return FALSE (this is a one-shot timer).
+  ;; Always return FALSE as this is one-shot timer.
   FALSE)
 
-
+;;; C callback function for the above procedure.
 (define *clear-keyaccelerator-string
   (procedure->pointer int clear-key-accelerator-string '(*)))
 
@@ -111,6 +110,7 @@
         (schematic_window_destroy_timer source-id)
         (schematic_window_set_keyaccel_string_source_id *window 0)))
 
+    ;; If the current key sequence was a prefix, let it persist.
     (unless (key-prefix? key-press-result)
       (schematic_window_set_keyaccel_string_source_id
        *window

--- a/libleptongui/scheme/schematic/gui/keymap.scm
+++ b/libleptongui/scheme/schematic/gui/keymap.scm
@@ -69,6 +69,7 @@
   (define (update-keyaccel-timer key-press-result)
     (schematic_window_update_keyaccel_timer
      *window
+     *schematic_window_clear_keyaccel_string
      (boolean->c-boolean (not (key-prefix? key-press-result))))
     ;; Return the key press result to process it further.
     key-press-result)

--- a/libleptongui/scheme/schematic/gui/keymap.scm
+++ b/libleptongui/scheme/schematic/gui/keymap.scm
@@ -105,10 +105,18 @@
   ;; keystroke was not part of a key sequence prefix, start a new
   ;; timer to clear the status bar display.
   (define (update-keyaccel-timer key-press-result)
-    (schematic_window_update_keyaccel_timer
-     *window
-     *clear-keyaccelerator-string
-     (boolean->c-boolean (not (key-prefix? key-press-result))))
+    (let ((source-id (schematic_window_get_keyaccel_string_source_id *window)))
+      (unless (zero? source-id)
+        ;; Cancel any existing timers that haven't fired yet.
+        (schematic_window_destroy_timer source-id)
+        (schematic_window_set_keyaccel_string_source_id *window 0)))
+
+    (unless (key-prefix? key-press-result)
+      (schematic_window_set_keyaccel_string_source_id
+       *window
+       ;; Fire up a new timer.
+       (schematic_window_add_timer 400 *clear-keyaccelerator-string *window)))
+
     ;; Return the key press result to process it further.
     key-press-result)
 

--- a/libleptongui/scheme/schematic/gui/keymap.scm
+++ b/libleptongui/scheme/schematic/gui/keymap.scm
@@ -39,6 +39,25 @@
 
 ;;; Key event processing.
 
+;;; Clears the current keyboard accelerator string in the status
+;;; bar of the relevant toplevel window *WINDOW.  Called some time
+;;; after a keystroke is pressed.  If the current key sequence was
+;;; a prefix, let it persist.
+(define (clear-key-accelerator-string *window)
+  ;; If the window context has disappeared, do nothing.
+  (unless (null-pointer? (schematic_window_list_find *window))
+    (schematic_window_set_keyaccel_string *window %null-pointer)
+    (schematic_window_set_keyaccel_string_source_id *window 0)
+    (i_show_state *window %null-pointer))
+
+  ;; Return FALSE (this is a one-shot timer).
+  FALSE)
+
+
+(define *clear-keyaccelerator-string
+  (procedure->pointer int clear-key-accelerator-string '(*)))
+
+
 (define (eval-press-key-event *event *page_view *window)
   (define (boolean->c-boolean x)
     (if x TRUE FALSE))
@@ -88,7 +107,7 @@
   (define (update-keyaccel-timer key-press-result)
     (schematic_window_update_keyaccel_timer
      *window
-     *schematic_window_clear_keyaccel_string
+     *clear-keyaccelerator-string
      (boolean->c-boolean (not (key-prefix? key-press-result))))
     ;; Return the key press result to process it further.
     key-press-result)

--- a/libleptongui/scheme/schematic/gui/keymap.scm
+++ b/libleptongui/scheme/schematic/gui/keymap.scm
@@ -43,10 +43,29 @@
   (define (boolean->c-boolean x)
     (if x TRUE FALSE))
 
+  ;; Update key accelerator string in status bar.
   (define (update-window-statusbar key)
-    (schematic_window_update_keyaccel_string
-     *window
-     (string->pointer (key->display-string key))))
+    ;; Given the key accelerator string previously set in the
+    ;; status bar, the function updates it by combining it with
+    ;; the new key label, or just sets the new value provided.
+    ;; The behaviour varies depending on whether the previously
+    ;; set string was a prefix in a key sequence or not.  If no
+    ;; current hint string, or the hint string is going to be
+    ;; cleared anyway, use key string directly.
+    (let ((new-key-string (key->display-string key))
+          (*current-key-string (schematic_window_get_keyaccel_string *window))
+          (source-id (schematic_window_get_keyaccel_string_source_id *window)))
+      (schematic_window_set_keyaccel_string
+       *window
+       (string->pointer
+        (string-join
+         (if (or (null-pointer? *current-key-string)
+                 (not (zero? source-id)))
+             (list new-key-string)
+             (list (pointer->string *current-key-string) new-key-string))))))
+
+    ;; Update status bar.
+    (i_show_state *window %null-pointer))
 
   (define (protected-eval-key-press key)
     ;; First update the status bar with the current key sequence.

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -66,6 +66,27 @@
   (procedure->pointer int process-key-event '(* * *)))
 
 
+(define (callback-close-schematic-window *widget *event *window)
+  (if (null-pointer? *window)
+      (error "NULL window.")
+      (x_window_close *window))
+  ;; Stop further propagation of the "delete-event" signal for
+  ;; window:
+  ;;   - if the user has cancelled closing, the window should
+  ;;     obviously not be destroyed
+  ;;   - otherwise the window has already been destroyed, nothing
+  ;;     more to do
+  TRUE)
+
+
+;;; When invoked via signal "delete-event", the function closes
+;;; the current window and, if this is the last window, quits
+;;; lepton-schematic.  The signal is emitted when you click the
+;;; close button on the window.
+(define *callback-close-schematic-window
+  (procedure->pointer int callback-close-schematic-window '(* * *)))
+
+
 (define (make-schematic-window *app *toplevel)
   "Creates a new lepton-schematic window.  APP is a pointer to the
 GtkApplication structure of the program (when compiled with

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -82,6 +82,8 @@
       (x_window_close *window
                       ;; Check if the window is the last one.
                       (if last-window? TRUE FALSE))
+      (schematic_window_list_remove *window)
+      (gschem_toplevel_free *window)
 
       ;; Just closed last window, so quit.
       (when (zero? (schematic_window_list_length))

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -46,7 +46,8 @@
                current-window
                with-window)
 
-  #:export (make-schematic-window
+  #:export (close-window!
+            make-schematic-window
             active-page
             set-active-page!
             pointer-position
@@ -66,10 +67,15 @@
   (procedure->pointer int process-key-event '(* * *)))
 
 
+(define (close-window! *window)
+  "Closes *WINDOW."
+  (x_window_close *window))
+
+
 (define (callback-close-schematic-window *widget *event *window)
   (if (null-pointer? *window)
       (error "NULL window.")
-      (x_window_close *window))
+      (close-window! *window))
   ;; Stop further propagation of the "delete-event" signal for
   ;; window:
   ;;   - if the user has cancelled closing, the window should

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -166,7 +166,7 @@ window to PAGE.  Returns PAGE."
   (define tabs-enabled? (true? (x_tabs_enabled)))
   (if tabs-enabled?
       (x_tabs_page_close *window *page)
-      (x_window_close_page_impl *window *page)))
+      (x_window_close_page *window *page)))
 
 
 (define (close-page! page)

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -69,7 +69,9 @@
 
 (define (close-window! *window)
   "Closes *WINDOW."
-  (x_window_close *window))
+  (x_window_close *window
+                  ;; Check if the window is the last one.
+                  (if (= (schematic_window_list_length) 1) TRUE FALSE)))
 
 
 (define (callback-close-schematic-window *widget *event *window)

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -82,9 +82,17 @@
     ;; Last chance to save possible unsaved pages.
     (when (true? (x_dialog_close_window *window))
       ;; Close the window if the user didn't cancel the close.
-      (x_window_close *window
-                      ;; Check if the window is the last one.
-                      (if last-window? TRUE FALSE))
+      (x_window_close *window)
+      ;; Check if the window is the last one and do jobs that have
+      ;; to be done before freeing its memory.
+      (when last-window?
+        ;; Save window geometry.
+        (schematic_window_save_geometry *window)
+        ;; Close the log file.
+        (s_log_close)
+        ;; free the buffers.
+        (o_buffer_free *window))
+
       ;; Destroy main widget of the window.
       (gtk_widget_destroy (schematic_window_get_main_window *window))
       (remove-window! (pointer->window *window))

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -85,6 +85,8 @@
       (x_window_close *window
                       ;; Check if the window is the last one.
                       (if last-window? TRUE FALSE))
+      ;; Destroy main widget of the window.
+      (gtk_widget_destroy (schematic_window_get_main_window *window))
       (remove-window! (pointer->window *window))
       (gschem_toplevel_free *window)
 

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -82,6 +82,7 @@
     ;; Last chance to save possible unsaved pages.
     (when (true? (x_dialog_close_window *window))
       ;; Close the window if the user didn't cancel the close.
+      (x_clipboard_finish *window)
       (x_window_close *window)
       ;; Check if the window is the last one and do jobs that have
       ;; to be done before freeing its memory.

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -36,6 +36,7 @@
 
   #:use-module (schematic callback)
   #:use-module (schematic ffi)
+  #:use-module (schematic ffi gtk)
   #:use-module (schematic gui keymap)
   #:use-module (schematic menu)
   #:use-module (schematic toolbar)
@@ -76,7 +77,18 @@
 
     ;; Just closed last window, so quit.
     (when (zero? (schematic_window_list_length))
-      (gschem_quit))))
+      ;; Clean up all memory objects allocated during the
+      ;; lepton-schematic runtime.
+      (i_vars_atexit_save_cache_config %null-pointer)
+      (s_clib_free)
+      (s_attrib_free)
+      (x_stroke_free)
+      (o_undo_cleanup)
+
+      ;; Check whether the main loop is running.
+      (if (zero? (gtk_main_level))
+          (primitive-exit 0)
+          (gtk_main_quit)))))
 
 
 (define (callback-close-schematic-window *widget *event *window)

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -50,7 +50,8 @@
             active-page
             set-active-page!
             pointer-position
-            snap-point)
+            snap-point
+            window-close-page!)
 
   ;; Overrides the close-page! procedure in the (lepton page)
   ;; module.
@@ -158,6 +159,16 @@ window to PAGE.  Returns PAGE."
   page)
 
 
+(define (window-close-page! window page)
+  "Closes PAGE of WINDOW."
+  (define *window (check-window window 1))
+  (define *page (check-page page 2))
+  (define tabs-enabled? (true? (x_tabs_enabled)))
+  (if tabs-enabled?
+      (x_tabs_page_close *window *page)
+      (x_window_close_page_impl *window *page)))
+
+
 (define (close-page! page)
   "Closes PAGE."
   (define *page (check-page page 1))
@@ -170,13 +181,13 @@ window to PAGE.  Returns PAGE."
     (schematic_window_get_active_page *window))
 
   (if (eq? page (active-page))
-      (x_window_close_page *window *page)
+      (window-close-page! (current-window) (active-page))
       ;; If the page is not active, make it active and close, then
       ;; switch back to the previously active page.
       (begin
         (x_window_set_current_page *window *page)
-        (x_window_close_page *window
-                             (schematic_window_get_active_page *window))
+        (window-close-page! (current-window)
+                             (pointer->page (schematic_window_get_active_page *window)))
         (x_window_set_current_page *window *active_page)))
 
   ;; Return value is unspecified.

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -69,9 +69,14 @@
 
 (define (close-window! *window)
   "Closes *WINDOW."
-  (x_window_close *window
-                  ;; Check if the window is the last one.
-                  (if (= (schematic_window_list_length) 1) TRUE FALSE)))
+  (let ((last-window? (= (schematic_window_list_length) 1)))
+    (x_window_close *window
+                    ;; Check if the window is the last one.
+                    (if last-window? TRUE FALSE))
+
+    ;; Just closed last window, so quit.
+    (when (zero? (schematic_window_list_length))
+      (gschem_quit))))
 
 
 (define (callback-close-schematic-window *widget *event *window)

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -79,7 +79,9 @@
     (when (zero? (schematic_window_list_length))
       ;; Clean up all memory objects allocated during the
       ;; lepton-schematic runtime.
-      (i_vars_atexit_save_cache_config %null-pointer)
+
+      ;; Save cache config on exit.
+      (config-save! (cache-config-context))
       (s_clib_free)
       (s_attrib_free)
       (x_stroke_free)

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -70,8 +70,25 @@
   "Creates a new lepton-schematic window.  APP is a pointer to the
 GtkApplication structure of the program (when compiled with
 --with-gtk3).  TOPLEVEL is a foreign LeptonToplevel structure."
+  (define (setup-window *window)
+    (let ((*toplevel (gschem_toplevel_get_toplevel *window)))
+      ;; Immediately setup user params.
+      (i_vars_set *window)
+
+      ;; Initialize the autosave callback.
+      (lepton_toplevel_init_autosave *toplevel)
+
+      ;; Initialize the clipboard callback.
+      (x_clipboard_init *window)
+
+      ;; Add to the list of windows.
+      (schematic_window_list_add *window)
+
+      ;; Return the window.
+      *window))
+
   (define *window
-    (x_window_setup (x_window_new (parse-gschemrc *toplevel))))
+    (setup-window (x_window_new (parse-gschemrc *toplevel))))
 
   (let ((*main-window (schematic_window_create_app_window *app)))
     (schematic_signal_connect *main-window

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -83,16 +83,38 @@
     (when (true? (x_dialog_close_window *window))
       ;; Close the window if the user didn't cancel the close.
       (x_clipboard_finish *window)
-      (x_window_close *window)
-      ;; Check if the window is the last one and do jobs that have
-      ;; to be done before freeing its memory.
-      (when last-window?
-        ;; Save window geometry.
-        (schematic_window_save_geometry *window)
-        ;; Close the log file.
-        (s_log_close)
-        ;; free the buffers.
-        (o_buffer_free *window))
+      (let ((*cswindow (schematic_window_get_compselect_widget *window))
+            (*tiwindow (schematic_window_get_text_input_widget *window))
+            (*aawindow (schematic_window_get_arc_edit_widget *window))
+            (*aewindow (schematic_window_get_attrib_edit_widget *window))
+            (*hkwindow (schematic_window_get_hotkey_widget *window))
+            (*cowindow (schematic_window_get_coord_widget *window))
+            (*sewindow (schematic_window_get_slot_edit_widget *window)))
+
+        (schematic_window_set_dont_invalidate *window TRUE)
+
+        (x_widgets_destroy_dialogs *window)
+
+        ;; Close all the dialog boxes.
+        (unless (null-pointer? *cswindow) (gtk_widget_destroy *cswindow))
+        (unless (null-pointer? *tiwindow) (gtk_widget_destroy *tiwindow))
+        (unless (null-pointer? *aawindow) (gtk_widget_destroy *aawindow))
+        (x_multiattrib_close *window)
+        (unless (null-pointer? *aewindow) (gtk_widget_destroy *aewindow))
+        (unless (null-pointer? *hkwindow) (gtk_widget_destroy *hkwindow))
+        (unless (null-pointer? *cowindow) (gtk_widget_destroy *cowindow))
+        (unless (null-pointer? *sewindow) (gtk_widget_destroy *sewindow))
+
+
+        ;; Check if the window is the last one and do jobs that have
+        ;; to be done before freeing its memory.
+        (when last-window?
+          ;; Save window geometry.
+          (schematic_window_save_geometry *window)
+          ;; Close the log file.
+          (s_log_close)
+          ;; free the buffers.
+          (o_buffer_free *window)))
 
       ;; Destroy main widget of the window.
       (gtk_widget_destroy (schematic_window_get_main_window *window))

--- a/libleptongui/scheme/schematic/window/list.scm
+++ b/libleptongui/scheme/schematic/window/list.scm
@@ -1,0 +1,47 @@
+;;; Lepton EDA Schematic Capture
+;;; Scheme API
+;;; Copyright (C) 2022 Lepton EDA Contributors
+;;;
+;;; This program is free software; you can redistribute it and/or modify
+;;; it under the terms of the GNU General Public License as published by
+;;; the Free Software Foundation; either version 2 of the License, or
+;;; (at your option) any later version.
+;;;
+;;; This program is distributed in the hope that it will be useful,
+;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;; GNU General Public License for more details.
+;;;
+;;; You should have received a copy of the GNU General Public License
+;;; along with this program; if not, write to the Free Software
+;;; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
+(define-module (schematic window list)
+  #:export (schematic-windows
+            window-exists?
+            add-window!
+            remove-window!))
+
+;;; List of lepton-schematic windows.
+(define %schematic-windows '())
+
+(define (schematic-windows)
+  "Returns the list of currently open windows."
+  %schematic-windows)
+
+
+(define (window-exists? window)
+  "Returns #t if *WINDOW exists in the set of currently open
+windows.  Otherwise returns #f."
+  (and (memq window (schematic-windows)) #t))
+
+
+(define (add-window! window)
+  "Adds *WINDOW to the list of currently open windows."
+  (set! %schematic-windows (cons window %schematic-windows)))
+
+
+(define (remove-window! window)
+  "Removes *WINDOW from the list of currently open windows."
+  (set! %schematic-windows (delq window %schematic-windows)))

--- a/libleptongui/src/globals.c
+++ b/libleptongui/src/globals.c
@@ -35,3 +35,12 @@ schematic_window_list ()
 {
   return global_window_list;
 }
+
+
+GList*
+schematic_window_list_find (GschemToplevel *w_current)
+{
+  GList *gwl = schematic_window_list ();
+
+  return (g_list_find (gwl, w_current));
+}

--- a/libleptongui/src/globals.c
+++ b/libleptongui/src/globals.c
@@ -51,3 +51,9 @@ schematic_window_list_remove (GschemToplevel *w_current)
 {
   global_window_list = g_list_remove (global_window_list, w_current);
 }
+
+guint
+schematic_window_list_length ()
+{
+  return g_list_length (global_window_list);
+}

--- a/libleptongui/src/globals.c
+++ b/libleptongui/src/globals.c
@@ -44,3 +44,10 @@ schematic_window_list_find (GschemToplevel *w_current)
 
   return (g_list_find (gwl, w_current));
 }
+
+
+void
+schematic_window_list_remove (GschemToplevel *w_current)
+{
+  global_window_list = g_list_remove (global_window_list, w_current);
+}

--- a/libleptongui/src/globals.c
+++ b/libleptongui/src/globals.c
@@ -28,3 +28,10 @@ GList *global_window_list = NULL;
 
 /* command line options */
 int quiet_mode = FALSE;
+
+
+GList*
+schematic_window_list ()
+{
+  return global_window_list;
+}

--- a/libleptongui/src/globals.c
+++ b/libleptongui/src/globals.c
@@ -57,3 +57,9 @@ schematic_window_list_length ()
 {
   return g_list_length (global_window_list);
 }
+
+void
+schematic_window_list_add (GschemToplevel *w_current)
+{
+  global_window_list = g_list_append (global_window_list, w_current);
+}

--- a/libleptongui/src/globals.c
+++ b/libleptongui/src/globals.c
@@ -24,7 +24,7 @@
 #include "gschem.h"
 
 /* window list */
-GList *global_window_list = NULL;
+static GList *global_window_list = NULL;
 
 /* command line options */
 int quiet_mode = FALSE;

--- a/libleptongui/src/globals.c
+++ b/libleptongui/src/globals.c
@@ -23,43 +23,5 @@
 
 #include "gschem.h"
 
-/* window list */
-static GList *global_window_list = NULL;
-
 /* command line options */
 int quiet_mode = FALSE;
-
-
-GList*
-schematic_window_list ()
-{
-  return global_window_list;
-}
-
-
-GList*
-schematic_window_list_find (GschemToplevel *w_current)
-{
-  GList *gwl = schematic_window_list ();
-
-  return (g_list_find (gwl, w_current));
-}
-
-
-void
-schematic_window_list_remove (GschemToplevel *w_current)
-{
-  global_window_list = g_list_remove (global_window_list, w_current);
-}
-
-guint
-schematic_window_list_length ()
-{
-  return g_list_length (global_window_list);
-}
-
-void
-schematic_window_list_add (GschemToplevel *w_current)
-{
-  global_window_list = g_list_append (global_window_list, w_current);
-}

--- a/libleptongui/src/gschem_toplevel.c
+++ b/libleptongui/src/gschem_toplevel.c
@@ -917,10 +917,8 @@ schematic_window_clear_keyaccel_string (gpointer data)
 {
   GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
 
-  GList *gwl = schematic_window_list ();
-
   /* If the window context has disappeared, do nothing. */
-  if (g_list_find (gwl, w_current) == NULL)
+  if (!schematic_window_list_find (w_current))
   {
     return FALSE;
   }

--- a/libleptongui/src/gschem_toplevel.c
+++ b/libleptongui/src/gschem_toplevel.c
@@ -209,7 +209,7 @@ GschemToplevel *gschem_toplevel_new ()
 
 
   w_current->keyaccel_string = NULL;
-  w_current->keyaccel_string_source_id = 0;
+  schematic_window_set_keyaccel_string_source_id (w_current, 0);
 
   /* ------------ */
   /* Dialog boxes */
@@ -886,7 +886,8 @@ schematic_window_update_keyaccel_string (GschemToplevel *w_current,
   /* If no current hint string, or the hint string is going to be
    * cleared anyway, use key string directly */
   if ((w_current->keyaccel_string == NULL) ||
-      w_current->keyaccel_string_source_id) {
+      schematic_window_get_keyaccel_string_source_id (w_current) != 0)
+  {
     g_free (w_current->keyaccel_string);
     w_current->keyaccel_string = g_strdup (keystr);
   }
@@ -925,7 +926,7 @@ schematic_window_clear_keyaccel_string (gpointer data)
 
   g_free(w_current->keyaccel_string);
   w_current->keyaccel_string = NULL;
-  w_current->keyaccel_string_source_id = 0;
+  schematic_window_set_keyaccel_string_source_id (w_current, 0);
   i_show_state(w_current, NULL);
   return FALSE;
 }
@@ -947,22 +948,24 @@ schematic_window_update_keyaccel_timer (GschemToplevel *w_current,
                                         gpointer clear_keyaccel_callback,
                                         gboolean start_timer)
 {
-  if (w_current->keyaccel_string_source_id)
+  guint source_id = schematic_window_get_keyaccel_string_source_id (w_current);
+  if (source_id != 0)
   {
     /* Cancel any existing timers that haven't fired yet. */
     GSource *timer =
-      g_main_context_find_source_by_id (NULL,
-                                        w_current->keyaccel_string_source_id);
+      g_main_context_find_source_by_id (NULL, source_id);
     if (timer != NULL)
     {
       g_source_destroy (timer);
     }
-    w_current->keyaccel_string_source_id = 0;
+    schematic_window_set_keyaccel_string_source_id (w_current, 0);
   }
   if (start_timer)
   {
-    w_current->keyaccel_string_source_id =
+    source_id =
       g_timeout_add (400, (GSourceFunc) clear_keyaccel_callback, w_current);
+
+    schematic_window_set_keyaccel_string_source_id (w_current, source_id);
   }
 }
 

--- a/libleptongui/src/gschem_toplevel.c
+++ b/libleptongui/src/gschem_toplevel.c
@@ -912,8 +912,8 @@ schematic_window_update_keyaccel_string (GschemToplevel *w_current,
  * \param [in] data a pointer to the GschemToplevel to update.
  * \return FALSE (this is a one-shot timer).
  */
-static gboolean
-clear_keyaccel_string (gpointer data)
+gboolean
+schematic_window_clear_keyaccel_string (gpointer data)
 {
   GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
 
@@ -943,6 +943,7 @@ clear_keyaccel_string (gpointer data)
  */
 void
 schematic_window_update_keyaccel_timer (GschemToplevel *w_current,
+                                        gpointer clear_keyaccel_callback,
                                         gboolean start_timer)
 {
   if (w_current->keyaccel_string_source_id)
@@ -960,7 +961,7 @@ schematic_window_update_keyaccel_timer (GschemToplevel *w_current,
   if (start_timer)
   {
     w_current->keyaccel_string_source_id =
-      g_timeout_add (400, clear_keyaccel_string, w_current);
+      g_timeout_add (400, (GSourceFunc) clear_keyaccel_callback, w_current);
   }
 }
 

--- a/libleptongui/src/gschem_toplevel.c
+++ b/libleptongui/src/gschem_toplevel.c
@@ -868,42 +868,6 @@ schematic_window_get_options (GschemToplevel *w_current)
 }
 
 
-/*! \brief Update key accelerator string in status bar.
- * \par Function Description
- * Given the key accelerator string previously set in the status
- * bar, updates it by combining it with the new key label, or just
- * sets the new value provided.  The behaviour varies depending on
- * whether the previously set string was a prefix in a key
- * sequence or not.
- *
- * \param [in] w_current The active #GschemToplevel context.
- * \param [in] keystr The new key label.
- */
-void
-schematic_window_update_keyaccel_string (GschemToplevel *w_current,
-                                         char *keystr)
-{
-  /* If no current hint string, or the hint string is going to be
-   * cleared anyway, use key string directly */
-  if (schematic_window_get_keyaccel_string (w_current) == NULL ||
-      schematic_window_get_keyaccel_string_source_id (w_current) != 0)
-  {
-    schematic_window_set_keyaccel_string (w_current, keystr);
-  }
-  else
-  {
-    const gchar *current_keystr =
-      schematic_window_get_keyaccel_string (w_current);
-    gchar *composed_keystr = g_strconcat (current_keystr, " ", keystr, NULL);
-    schematic_window_set_keyaccel_string (w_current, composed_keystr);
-    g_free (composed_keystr);
-  }
-
-  /* Update status bar */
-  i_show_state(w_current, NULL);
-}
-
-
 /*! \brief Clear the current key accelerator string.
  * \par Function Description
  * This function clears the current keyboard accelerator string in

--- a/libleptongui/src/gschem_toplevel.c
+++ b/libleptongui/src/gschem_toplevel.c
@@ -208,7 +208,7 @@ GschemToplevel *gschem_toplevel_new ()
   w_current->page_select_dialog       = NULL;
 
 
-  w_current->keyaccel_string = NULL;
+  schematic_window_set_keyaccel_string (w_current, NULL);
   schematic_window_set_keyaccel_string_source_id (w_current, 0);
 
   /* ------------ */
@@ -885,17 +885,18 @@ schematic_window_update_keyaccel_string (GschemToplevel *w_current,
 {
   /* If no current hint string, or the hint string is going to be
    * cleared anyway, use key string directly */
-  if ((w_current->keyaccel_string == NULL) ||
+  if (schematic_window_get_keyaccel_string (w_current) == NULL ||
       schematic_window_get_keyaccel_string_source_id (w_current) != 0)
   {
-    g_free (w_current->keyaccel_string);
-    w_current->keyaccel_string = g_strdup (keystr);
+    schematic_window_set_keyaccel_string (w_current, keystr);
   }
   else
   {
-    gchar *p = w_current->keyaccel_string;
-    w_current->keyaccel_string = g_strconcat (p, " ", keystr, NULL);
-    g_free (p);
+    const gchar *current_keystr =
+      schematic_window_get_keyaccel_string (w_current);
+    gchar *composed_keystr = g_strconcat (current_keystr, " ", keystr, NULL);
+    schematic_window_set_keyaccel_string (w_current, composed_keystr);
+    g_free (composed_keystr);
   }
 
   /* Update status bar */
@@ -924,8 +925,7 @@ schematic_window_clear_keyaccel_string (gpointer data)
     return FALSE;
   }
 
-  g_free(w_current->keyaccel_string);
-  w_current->keyaccel_string = NULL;
+  schematic_window_set_keyaccel_string (w_current, NULL);
   schematic_window_set_keyaccel_string_source_id (w_current, 0);
   i_show_state(w_current, NULL);
   return FALSE;

--- a/libleptongui/src/gschem_toplevel.c
+++ b/libleptongui/src/gschem_toplevel.c
@@ -1535,3 +1535,32 @@ schematic_window_set_hotkey_widget (GschemToplevel *w_current,
 
   w_current->hkwindow = widget;
 }
+
+
+/*! \brief Get coord widget of this schematic window.
+ *
+ *  \param [in] w_current The schematic window.
+ *  \return The Coord widget.
+ */
+GtkWidget*
+schematic_window_get_coord_widget (GschemToplevel *w_current)
+{
+  g_return_val_if_fail (w_current != NULL, NULL);
+
+  return w_current->cowindow;
+}
+
+
+/*! \brief Set coord widget for this schematic window.
+ *
+ *  \param [in] w_current The schematic window.
+ *  \param [in] widget The widget.
+ */
+void
+schematic_window_set_coord_widget (GschemToplevel *w_current,
+                                   GtkWidget *widget)
+{
+  g_return_if_fail (w_current != NULL);
+
+  w_current->cowindow = widget;
+}

--- a/libleptongui/src/gschem_toplevel.c
+++ b/libleptongui/src/gschem_toplevel.c
@@ -917,8 +917,11 @@ schematic_window_clear_keyaccel_string (gpointer data)
 {
   GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
 
+  GList *gwl = schematic_window_list ();
+
   /* If the window context has disappeared, do nothing. */
-  if (g_list_find(global_window_list, w_current) == NULL) {
+  if (g_list_find (gwl, w_current) == NULL)
+  {
     return FALSE;
   }
 

--- a/libleptongui/src/gschem_toplevel.c
+++ b/libleptongui/src/gschem_toplevel.c
@@ -1390,3 +1390,32 @@ schematic_window_set_keyaccel_string (GschemToplevel *w_current,
   g_free (w_current->keyaccel_string);
   w_current->keyaccel_string = g_strdup (str);
 }
+
+
+/*! \brief Get component selector widget of this schematic window.
+ *
+ *  \param [in] w_current The schematic window.
+ *  \return The Compselect widget.
+ */
+GtkWidget*
+schematic_window_get_compselect (GschemToplevel *w_current)
+{
+  g_return_val_if_fail (w_current != NULL, NULL);
+
+  return w_current->cswindow;
+}
+
+
+/*! \brief Set component selector widget for this schematic window.
+ *
+ *  \param [in] w_current The schematic window.
+ *  \param [in] widget The widget.
+ */
+void
+schematic_window_set_compselect (GschemToplevel *w_current,
+                                 GtkWidget *widget)
+{
+  g_return_if_fail (w_current != NULL);
+
+  w_current->cswindow = widget;
+}

--- a/libleptongui/src/gschem_toplevel.c
+++ b/libleptongui/src/gschem_toplevel.c
@@ -868,6 +868,26 @@ schematic_window_get_options (GschemToplevel *w_current)
 }
 
 
+static guint
+schematic_window_add_timer (guint interval,
+                            gpointer callback,
+                            gpointer data)
+{
+  return g_timeout_add (interval, (GSourceFunc) callback, data);
+}
+
+
+static void
+schematic_window_destroy_timer (guint source_id)
+{
+  GSource *timer = g_main_context_find_source_by_id (NULL, source_id);
+  if (timer != NULL)
+  {
+    g_source_destroy (timer);
+  }
+}
+
+
 /*! \brief Update timer for clearing the current key accelerator string.
  * \par Function Description
  * If a timer responsible for clearing key accelerator string in
@@ -888,18 +908,15 @@ schematic_window_update_keyaccel_timer (GschemToplevel *w_current,
   if (source_id != 0)
   {
     /* Cancel any existing timers that haven't fired yet. */
-    GSource *timer =
-      g_main_context_find_source_by_id (NULL, source_id);
-    if (timer != NULL)
-    {
-      g_source_destroy (timer);
-    }
+    schematic_window_destroy_timer (source_id);
     schematic_window_set_keyaccel_string_source_id (w_current, 0);
   }
   if (start_timer)
   {
     source_id =
-      g_timeout_add (400, (GSourceFunc) clear_keyaccel_callback, w_current);
+      schematic_window_add_timer (400,
+                                    (gpointer) clear_keyaccel_callback,
+                                    (gpointer) w_current);
 
     schematic_window_set_keyaccel_string_source_id (w_current, source_id);
   }

--- a/libleptongui/src/gschem_toplevel.c
+++ b/libleptongui/src/gschem_toplevel.c
@@ -868,6 +868,16 @@ schematic_window_get_options (GschemToplevel *w_current)
 }
 
 
+/*! \brief Add a new timer.
+ * \par Function Description
+ *
+ * Adds a new timer that should call \a callback with \a data
+ * argument after given time \a interval in milliseconds.
+ *
+ * \param [in] interval The time interval.
+ * \param [in] callback The callback.
+ * \param [in] data The data.
+ */
 static guint
 schematic_window_add_timer (guint interval,
                             gpointer callback,
@@ -877,6 +887,14 @@ schematic_window_add_timer (guint interval,
 }
 
 
+/*! \brief Destroy timer with given source id.
+ * \par Function Description
+ *
+ * Searches for a timer in the main GTK context having the given
+ * source id.  If such a timer exists, destroys it,
+ *
+ * \param [in] source_id The source id.
+ */
 static void
 schematic_window_destroy_timer (guint source_id)
 {

--- a/libleptongui/src/gschem_toplevel.c
+++ b/libleptongui/src/gschem_toplevel.c
@@ -878,7 +878,7 @@ schematic_window_get_options (GschemToplevel *w_current)
  * \param [in] callback The callback.
  * \param [in] data The data.
  */
-static guint
+guint
 schematic_window_add_timer (guint interval,
                             gpointer callback,
                             gpointer data)
@@ -895,48 +895,13 @@ schematic_window_add_timer (guint interval,
  *
  * \param [in] source_id The source id.
  */
-static void
+void
 schematic_window_destroy_timer (guint source_id)
 {
   GSource *timer = g_main_context_find_source_by_id (NULL, source_id);
   if (timer != NULL)
   {
     g_source_destroy (timer);
-  }
-}
-
-
-/*! \brief Update timer for clearing the current key accelerator string.
- * \par Function Description
- * If a timer responsible for clearing key accelerator string in
- * the status bar has been started, the function stops it.  If \a
- * start_timer is TRUE, it runs a new timer for this.  It should
- * be FALSE if the current key sequence is a prefix which should
- * persist.
- *
- * \param [in] w_current The GschemToplevel to update.
- * \param [in] start_timer If a new timer should be started.
- */
-void
-schematic_window_update_keyaccel_timer (GschemToplevel *w_current,
-                                        gpointer clear_keyaccel_callback,
-                                        gboolean start_timer)
-{
-  guint source_id = schematic_window_get_keyaccel_string_source_id (w_current);
-  if (source_id != 0)
-  {
-    /* Cancel any existing timers that haven't fired yet. */
-    schematic_window_destroy_timer (source_id);
-    schematic_window_set_keyaccel_string_source_id (w_current, 0);
-  }
-  if (start_timer)
-  {
-    source_id =
-      schematic_window_add_timer (400,
-                                    (gpointer) clear_keyaccel_callback,
-                                    (gpointer) w_current);
-
-    schematic_window_set_keyaccel_string_source_id (w_current, source_id);
   }
 }
 

--- a/libleptongui/src/gschem_toplevel.c
+++ b/libleptongui/src/gschem_toplevel.c
@@ -1398,7 +1398,7 @@ schematic_window_set_keyaccel_string (GschemToplevel *w_current,
  *  \return The Compselect widget.
  */
 GtkWidget*
-schematic_window_get_compselect (GschemToplevel *w_current)
+schematic_window_get_compselect_widget (GschemToplevel *w_current)
 {
   g_return_val_if_fail (w_current != NULL, NULL);
 
@@ -1412,8 +1412,8 @@ schematic_window_get_compselect (GschemToplevel *w_current)
  *  \param [in] widget The widget.
  */
 void
-schematic_window_set_compselect (GschemToplevel *w_current,
-                                 GtkWidget *widget)
+schematic_window_set_compselect_widget (GschemToplevel *w_current,
+                                        GtkWidget *widget)
 {
   g_return_if_fail (w_current != NULL);
 

--- a/libleptongui/src/gschem_toplevel.c
+++ b/libleptongui/src/gschem_toplevel.c
@@ -1564,3 +1564,32 @@ schematic_window_set_coord_widget (GschemToplevel *w_current,
 
   w_current->cowindow = widget;
 }
+
+
+/*! \brief Get slot edit widget of this schematic window.
+ *
+ *  \param [in] w_current The schematic window.
+ *  \return The Slot edit widget.
+ */
+GtkWidget*
+schematic_window_get_slot_edit_widget (GschemToplevel *w_current)
+{
+  g_return_val_if_fail (w_current != NULL, NULL);
+
+  return w_current->sewindow;
+}
+
+
+/*! \brief Set slot edit widget for this schematic window.
+ *
+ *  \param [in] w_current The schematic window.
+ *  \param [in] widget The widget.
+ */
+void
+schematic_window_set_slot_edit_widget (GschemToplevel *w_current,
+                                       GtkWidget *widget)
+{
+  g_return_if_fail (w_current != NULL);
+
+  w_current->sewindow = widget;
+}

--- a/libleptongui/src/gschem_toplevel.c
+++ b/libleptongui/src/gschem_toplevel.c
@@ -1506,3 +1506,32 @@ schematic_window_set_attrib_edit_widget (GschemToplevel *w_current,
 
   w_current->aewindow = widget;
 }
+
+
+/*! \brief Get hotkey widget of this schematic window.
+ *
+ *  \param [in] w_current The schematic window.
+ *  \return The Hotkey widget.
+ */
+GtkWidget*
+schematic_window_get_hotkey_widget (GschemToplevel *w_current)
+{
+  g_return_val_if_fail (w_current != NULL, NULL);
+
+  return w_current->hkwindow;
+}
+
+
+/*! \brief Set hotkey widget for this schematic window.
+ *
+ *  \param [in] w_current The schematic window.
+ *  \param [in] widget The widget.
+ */
+void
+schematic_window_set_hotkey_widget (GschemToplevel *w_current,
+                                    GtkWidget *widget)
+{
+  g_return_if_fail (w_current != NULL);
+
+  w_current->hkwindow = widget;
+}

--- a/libleptongui/src/gschem_toplevel.c
+++ b/libleptongui/src/gschem_toplevel.c
@@ -1363,3 +1363,32 @@ schematic_window_set_enforce_hierarchy (GschemToplevel *w_current,
 
   w_current->enforce_hierarchy = enforce;
 }
+
+
+/*! \brief Get the field 'keyaccel_string_source_id' for this schematic window.
+ *
+ *  \param [in] w_current The schematic window.
+ *  \return The field 'keyaccel_string_source_id'.
+ */
+guint
+schematic_window_get_keyaccel_string_source_id (GschemToplevel *w_current)
+{
+  g_return_val_if_fail (w_current != NULL, 0);
+
+  return w_current->keyaccel_string_source_id;
+}
+
+
+/*! \brief Set the field 'keyaccel_string_source_id' for this schematic window.
+ *
+ *  \param [in] w_current The schematic window.
+ *  \param [in] source_id The new value for the field 'keyaccel_string_source_id'.
+ */
+void
+schematic_window_set_keyaccel_string_source_id (GschemToplevel *w_current,
+                                                guint source_id)
+{
+  g_return_if_fail (w_current != NULL);
+
+  w_current->keyaccel_string_source_id = source_id;
+}

--- a/libleptongui/src/gschem_toplevel.c
+++ b/libleptongui/src/gschem_toplevel.c
@@ -1419,3 +1419,32 @@ schematic_window_set_compselect_widget (GschemToplevel *w_current,
 
   w_current->cswindow = widget;
 }
+
+
+/*! \brief Get text input widget of this schematic window.
+ *
+ *  \param [in] w_current The schematic window.
+ *  \return The Text input widget.
+ */
+GtkWidget*
+schematic_window_get_text_input_widget (GschemToplevel *w_current)
+{
+  g_return_val_if_fail (w_current != NULL, NULL);
+
+  return w_current->tiwindow;
+}
+
+
+/*! \brief Set text input widget for this schematic window.
+ *
+ *  \param [in] w_current The schematic window.
+ *  \param [in] widget The widget.
+ */
+void
+schematic_window_set_text_input_widget (GschemToplevel *w_current,
+                                        GtkWidget *widget)
+{
+  g_return_if_fail (w_current != NULL);
+
+  w_current->tiwindow = widget;
+}

--- a/libleptongui/src/gschem_toplevel.c
+++ b/libleptongui/src/gschem_toplevel.c
@@ -868,34 +868,6 @@ schematic_window_get_options (GschemToplevel *w_current)
 }
 
 
-/*! \brief Clear the current key accelerator string.
- * \par Function Description
- * This function clears the current keyboard accelerator string in
- * the status bar of the relevant toplevel.  Called some time after a
- * keystroke is pressed.  If the current key sequence was a prefix,
- * let it persist.
- *
- * \param [in] data a pointer to the GschemToplevel to update.
- * \return FALSE (this is a one-shot timer).
- */
-gboolean
-schematic_window_clear_keyaccel_string (gpointer data)
-{
-  GschemToplevel *w_current = GSCHEM_TOPLEVEL (data);
-
-  /* If the window context has disappeared, do nothing. */
-  if (!schematic_window_list_find (w_current))
-  {
-    return FALSE;
-  }
-
-  schematic_window_set_keyaccel_string (w_current, NULL);
-  schematic_window_set_keyaccel_string_source_id (w_current, 0);
-  i_show_state(w_current, NULL);
-  return FALSE;
-}
-
-
 /*! \brief Update timer for clearing the current key accelerator string.
  * \par Function Description
  * If a timer responsible for clearing key accelerator string in

--- a/libleptongui/src/gschem_toplevel.c
+++ b/libleptongui/src/gschem_toplevel.c
@@ -1477,3 +1477,32 @@ schematic_window_set_arc_edit_widget (GschemToplevel *w_current,
 
   w_current->aawindow = widget;
 }
+
+
+/*! \brief Get attrib edit widget of this schematic window.
+ *
+ *  \param [in] w_current The schematic window.
+ *  \return The Attrib edit widget.
+ */
+GtkWidget*
+schematic_window_get_attrib_edit_widget (GschemToplevel *w_current)
+{
+  g_return_val_if_fail (w_current != NULL, NULL);
+
+  return w_current->aewindow;
+}
+
+
+/*! \brief Set attrib edit widget for this schematic window.
+ *
+ *  \param [in] w_current The schematic window.
+ *  \param [in] widget The widget.
+ */
+void
+schematic_window_set_attrib_edit_widget (GschemToplevel *w_current,
+                                         GtkWidget *widget)
+{
+  g_return_if_fail (w_current != NULL);
+
+  w_current->aewindow = widget;
+}

--- a/libleptongui/src/gschem_toplevel.c
+++ b/libleptongui/src/gschem_toplevel.c
@@ -153,7 +153,7 @@ GschemToplevel *gschem_toplevel_new ()
 
   w_current->toplevel = NULL;
 
-  w_current->dont_invalidate = FALSE;
+  schematic_window_set_dont_invalidate (w_current, FALSE);
 
   /* ------------------- */
   /* main window widgets */
@@ -1272,6 +1272,35 @@ schematic_window_set_keyboardpan_gain (GschemToplevel *w_current,
   g_return_if_fail (w_current != NULL);
 
   w_current->keyboardpan_gain = keyboardpan_gain;
+}
+
+
+/*! \brief Get the field 'dont_invalidate' for this schematic window.
+ *
+ *  \param [in] w_current The schematic window.
+ *  \return The field 'dont_invalidate'.
+ */
+gboolean
+schematic_window_get_dont_invalidate (GschemToplevel *w_current)
+{
+  g_return_val_if_fail (w_current != NULL, FALSE);
+
+  return w_current->dont_invalidate;
+}
+
+
+/*! \brief Set the field 'dont_invalidate' for this schematic window.
+ *
+ *  \param [in] w_current The schematic window.
+ *  \param [in] val The new value for the field 'dont_invalidate'.
+ */
+void
+schematic_window_set_dont_invalidate (GschemToplevel *w_current,
+                                      gboolean val)
+{
+  g_return_if_fail (w_current != NULL);
+
+  w_current->dont_invalidate = val;
 }
 
 

--- a/libleptongui/src/gschem_toplevel.c
+++ b/libleptongui/src/gschem_toplevel.c
@@ -1395,3 +1395,33 @@ schematic_window_set_keyaccel_string_source_id (GschemToplevel *w_current,
 
   w_current->keyaccel_string_source_id = source_id;
 }
+
+
+/*! \brief Get the field 'keyaccel_string' for this schematic window.
+ *
+ *  \param [in] w_current The schematic window.
+ *  \return The field 'keyaccel_string'.
+ */
+const char*
+schematic_window_get_keyaccel_string (GschemToplevel *w_current)
+{
+  g_return_val_if_fail (w_current != NULL, NULL);
+
+  return w_current->keyaccel_string;
+}
+
+
+/*! \brief Set the field 'keyaccel_string' for this schematic window.
+ *
+ *  \param [in] w_current The schematic window.
+ *  \param [in] str The new value for the field 'keyaccel_string'.
+ */
+void
+schematic_window_set_keyaccel_string (GschemToplevel *w_current,
+                                      char *str)
+{
+  g_return_if_fail (w_current != NULL);
+
+  g_free (w_current->keyaccel_string);
+  w_current->keyaccel_string = g_strdup (str);
+}

--- a/libleptongui/src/gschem_toplevel.c
+++ b/libleptongui/src/gschem_toplevel.c
@@ -1448,3 +1448,32 @@ schematic_window_set_text_input_widget (GschemToplevel *w_current,
 
   w_current->tiwindow = widget;
 }
+
+
+/*! \brief Get arc edit widget of this schematic window.
+ *
+ *  \param [in] w_current The schematic window.
+ *  \return The Arc edit widget.
+ */
+GtkWidget*
+schematic_window_get_arc_edit_widget (GschemToplevel *w_current)
+{
+  g_return_val_if_fail (w_current != NULL, NULL);
+
+  return w_current->aawindow;
+}
+
+
+/*! \brief Set arc edit widget for this schematic window.
+ *
+ *  \param [in] w_current The schematic window.
+ *  \param [in] widget The widget.
+ */
+void
+schematic_window_set_arc_edit_widget (GschemToplevel *w_current,
+                                      GtkWidget *widget)
+{
+  g_return_if_fail (w_current != NULL);
+
+  w_current->aawindow = widget;
+}

--- a/libleptongui/src/i_basic.c
+++ b/libleptongui/src/i_basic.c
@@ -138,11 +138,15 @@ void i_show_state(GschemToplevel *w_current, const char *message)
 
   what_to_say = g_strjoinv(" - ", (gchar **) array + i);
 
-  if(w_current->keyaccel_string) {
+
+  if (schematic_window_get_keyaccel_string (w_current))
+  {
      gchar *p = what_to_say;
 
-     what_to_say = g_strdup_printf("%s \t\t %s", w_current->keyaccel_string,
-           what_to_say);
+     what_to_say =
+       g_strdup_printf("%s \t\t %s",
+                       schematic_window_get_keyaccel_string (w_current),
+                       what_to_say);
      g_free(p);
   }
 

--- a/libleptongui/src/i_vars.c
+++ b/libleptongui/src/i_vars.c
@@ -427,23 +427,3 @@ i_vars_set (GschemToplevel* w_current)
   g_clear_error (&err);
 
 } /* i_vars_set() */
-
-
-/*! \brief Save cache config on exit.
- */
-void
-i_vars_atexit_save_cache_config (gpointer user_data)
-{
-  EdaConfig* cfg = eda_config_get_cache_context();
-
-  GError* err = NULL;
-  eda_config_save (cfg, &err);
-
-  if (err != NULL)
-  {
-    g_warning ("Failed to save cache configuration to '%1$s': %2$s.",
-               eda_config_get_filename (cfg),
-               err->message);
-    g_clear_error (&err);
-  }
-}

--- a/libleptongui/src/keys.c
+++ b/libleptongui/src/keys.c
@@ -83,8 +83,7 @@ schematic_keys_reset (GschemToplevel *w_current)
   SCM s_expr = scm_list_1 (scm_from_utf8_symbol ("reset-keys"));
 
   /* Reset the status bar */
-  g_free (w_current->keyaccel_string);
-  w_current->keyaccel_string = NULL;
+  schematic_window_set_keyaccel_string (w_current, NULL);
   i_show_state(w_current, NULL);
 
   /* Reset the Scheme keybinding state */

--- a/libleptongui/src/lepton-schematic.c
+++ b/libleptongui/src/lepton-schematic.c
@@ -51,33 +51,6 @@ set_quiet_mode () {
 }
 
 
-/*! \brief Cleanup gSchem on exit.
- *  \par Function Description
- *  This function cleans up all memory objects allocated during the
- *  gSchem runtime.
- */
-void gschem_quit(void)
-{
-  i_vars_atexit_save_cache_config (NULL);
-  s_clib_free();
-  s_attrib_free();
-#ifdef HAVE_LIBSTROKE
-  x_stroke_free ();
-#endif /* HAVE_LIBSTROKE */
-  o_undo_cleanup();
-
-  /* Check whether the main loop is running:
-  */
-  if (gtk_main_level() == 0)
-  {
-    exit (0);
-  }
-  else
-  {
-    gtk_main_quit();
-  }
-}
-
 #ifdef ENABLE_GTK3
 static GtkApplication *app = NULL;
 #endif

--- a/libleptongui/src/o_basic.c
+++ b/libleptongui/src/o_basic.c
@@ -501,7 +501,11 @@ void o_invalidate_rect (GschemToplevel *w_current,
  */
 void o_invalidate (GschemToplevel *w_current, LeptonObject *object)
 {
-  if (w_current == NULL || w_current->dont_invalidate) return;
+  if (w_current == NULL
+      || schematic_window_get_dont_invalidate (w_current))
+  {
+    return;
+  }
 
   int left, top, bottom, right;
 

--- a/libleptongui/src/x_tabs.c
+++ b/libleptongui/src/x_tabs.c
@@ -1576,7 +1576,7 @@ x_tabs_page_close (GschemToplevel* w_current,
 
   /* page to be set as current after the [page] is closed:
   */
-  LeptonPage* new_cur_page = x_window_close_page_impl (w_current, nfo_cur->page_);
+  LeptonPage* new_cur_page = x_window_close_page (w_current, nfo_cur->page_);
 
   x_tabs_nbook_page_close (w_current, nfo_cur->page_);
 

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -570,6 +570,7 @@ void
 x_window_close (GschemToplevel *w_current)
 {
   GtkWidget *cswindow = schematic_window_get_compselect_widget (w_current);
+  GtkWidget *tiwindow = schematic_window_get_text_input_widget (w_current);
 
   schematic_window_set_dont_invalidate (w_current, TRUE);
 
@@ -578,8 +579,7 @@ x_window_close (GschemToplevel *w_current)
   /* close all the dialog boxes */
   if (cswindow) gtk_widget_destroy (cswindow);
 
-  if (w_current->tiwindow)
-  gtk_widget_destroy(w_current->tiwindow);
+  if (tiwindow) gtk_widget_destroy (tiwindow);
 
   if (w_current->aawindow)
   gtk_widget_destroy(w_current->aawindow);

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -1356,27 +1356,6 @@ x_window_set_current_page (GschemToplevel* w_current,
 
 
 
-/*! \brief Closes a page.
- *
- *  \see x_window_close_page_impl()
- *  \see x_tabs_page_close()
- */
-void
-x_window_close_page (GschemToplevel* w_current,
-                     LeptonPage* page)
-{
-  if (x_tabs_enabled())
-  {
-    x_tabs_page_close (w_current, page);
-  }
-  else
-  {
-    x_window_close_page_impl (w_current, page);
-  }
-}
-
-
-
 /*! \brief Create new blank page.
  *
  * \todo Do further refactoring: this function should be used

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -569,8 +569,6 @@ schematic_window_set_main_window (GschemToplevel *w_current,
 void
 x_window_close (GschemToplevel *w_current)
 {
-  x_clipboard_finish (w_current);
-
   w_current->dont_invalidate = TRUE;
 
   x_widgets_destroy_dialogs (w_current);

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -52,32 +52,6 @@ static LeptonPage*
 x_window_new_page (GschemToplevel* w_current);
 
 
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
-GschemToplevel*
-x_window_setup (GschemToplevel *w_current)
-{
-  LeptonToplevel *toplevel = gschem_toplevel_get_toplevel (w_current);
-
-  /* immediately setup user params */
-  i_vars_set(w_current);
-
-  /* Initialize the autosave callback */
-  lepton_toplevel_init_autosave (toplevel);
-
-  /* Initialize the clipboard callback */
-  x_clipboard_init (w_current);
-
-  /* Add to the list of windows */
-  schematic_window_list_add (w_current);
-
-  return w_current;
-}
-
 /*! \todo Finish function documentation!!!
  *  \brief
  *  \par Function Description

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -559,19 +559,6 @@ void
 x_window_close (GschemToplevel *w_current,
                 gboolean last_window)
 {
-  /* If we're closing whilst inside an action, re-wind the
-   * page contents back to their state before we started */
-  if (schematic_window_get_inside_action (w_current))
-  {
-    i_callback_cancel (NULL, w_current);
-  }
-
-  /* last chance to save possible unsaved pages */
-  if (!x_dialog_close_window (w_current)) {
-    /* user somehow cancelled the close */
-    return;
-  }
-
   x_clipboard_finish (w_current);
 
   w_current->dont_invalidate = TRUE;

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -567,8 +567,7 @@ schematic_window_set_main_window (GschemToplevel *w_current,
  *
  */
 void
-x_window_close (GschemToplevel *w_current,
-                gboolean last_window)
+x_window_close (GschemToplevel *w_current)
 {
   x_clipboard_finish (w_current);
 
@@ -599,19 +598,6 @@ x_window_close (GschemToplevel *w_current,
 
   if (w_current->sewindow)
   gtk_widget_destroy(w_current->sewindow);
-
-  if (last_window)
-  {
-    schematic_window_save_geometry (w_current);
-  }
-
-  /* stuff that has to be done before we free w_current */
-  if (last_window) {
-    /* close the log file */
-    s_log_close ();
-    /* free the buffers */
-    o_buffer_free (w_current);
-  }
 }
 
 

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -627,7 +627,8 @@ void x_window_close(GschemToplevel *w_current)
   if (w_current->sewindow)
   gtk_widget_destroy(w_current->sewindow);
 
-  if (g_list_length (global_window_list) == 1) {
+  if (schematic_window_list_length () == 1)
+  {
     /* no more window after this one, remember to quit */
     last_window = TRUE;
   }

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -569,13 +569,14 @@ schematic_window_set_main_window (GschemToplevel *w_current,
 void
 x_window_close (GschemToplevel *w_current)
 {
+  GtkWidget *cswindow = schematic_window_get_compselect_widget (w_current);
+
   schematic_window_set_dont_invalidate (w_current, TRUE);
 
   x_widgets_destroy_dialogs (w_current);
 
   /* close all the dialog boxes */
-  if (w_current->cswindow)
-  gtk_widget_destroy(w_current->cswindow);
+  if (cswindow) gtk_widget_destroy (cswindow);
 
   if (w_current->tiwindow)
   gtk_widget_destroy(w_current->tiwindow);

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -571,6 +571,7 @@ x_window_close (GschemToplevel *w_current)
 {
   GtkWidget *cswindow = schematic_window_get_compselect_widget (w_current);
   GtkWidget *tiwindow = schematic_window_get_text_input_widget (w_current);
+  GtkWidget *aawindow = schematic_window_get_arc_edit_widget (w_current);
 
   schematic_window_set_dont_invalidate (w_current, TRUE);
 
@@ -581,8 +582,7 @@ x_window_close (GschemToplevel *w_current)
 
   if (tiwindow) gtk_widget_destroy (tiwindow);
 
-  if (w_current->aawindow)
-  gtk_widget_destroy(w_current->aawindow);
+  if (aawindow) gtk_widget_destroy (aawindow);
 
   x_multiattrib_close (w_current);
 

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -73,7 +73,7 @@ x_window_setup (GschemToplevel *w_current)
   x_clipboard_init (w_current);
 
   /* Add to the list of windows */
-  global_window_list = g_list_append (global_window_list, w_current);
+  schematic_window_list_add (w_current);
 
   return w_current;
 }

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -604,9 +604,6 @@ x_window_close (GschemToplevel *w_current,
 
   /* finally close the main window */
   gtk_widget_destroy(w_current->main_window);
-
-  schematic_window_list_remove (w_current);
-  gschem_toplevel_free (w_current);
 }
 
 

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -615,9 +615,6 @@ x_window_close (GschemToplevel *w_current,
     /* free the buffers */
     o_buffer_free (w_current);
   }
-
-  /* finally close the main window */
-  gtk_widget_destroy (schematic_window_get_main_window (w_current));
 }
 
 

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -572,6 +572,7 @@ x_window_close (GschemToplevel *w_current)
   GtkWidget *cswindow = schematic_window_get_compselect_widget (w_current);
   GtkWidget *tiwindow = schematic_window_get_text_input_widget (w_current);
   GtkWidget *aawindow = schematic_window_get_arc_edit_widget (w_current);
+  GtkWidget *aewindow = schematic_window_get_attrib_edit_widget (w_current);
 
   schematic_window_set_dont_invalidate (w_current, TRUE);
 
@@ -586,8 +587,7 @@ x_window_close (GschemToplevel *w_current)
 
   x_multiattrib_close (w_current);
 
-  if (w_current->aewindow)
-  gtk_widget_destroy(w_current->aewindow);
+  if (aewindow) gtk_widget_destroy (aewindow);
 
   if (w_current->hkwindow)
   gtk_widget_destroy(w_current->hkwindow);

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -561,7 +561,8 @@ x_window_close (GschemToplevel *w_current,
 {
   /* If we're closing whilst inside an action, re-wind the
    * page contents back to their state before we started */
-  if (w_current->inside_action) {
+  if (schematic_window_get_inside_action (w_current))
+  {
     i_callback_cancel (NULL, w_current);
   }
 

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -573,6 +573,7 @@ x_window_close (GschemToplevel *w_current)
   GtkWidget *tiwindow = schematic_window_get_text_input_widget (w_current);
   GtkWidget *aawindow = schematic_window_get_arc_edit_widget (w_current);
   GtkWidget *aewindow = schematic_window_get_attrib_edit_widget (w_current);
+  GtkWidget *hkwindow = schematic_window_get_hotkey_widget (w_current);
 
   schematic_window_set_dont_invalidate (w_current, TRUE);
 
@@ -589,8 +590,7 @@ x_window_close (GschemToplevel *w_current)
 
   if (aewindow) gtk_widget_destroy (aewindow);
 
-  if (w_current->hkwindow)
-  gtk_widget_destroy(w_current->hkwindow);
+  if (hkwindow) gtk_widget_destroy (hkwindow);
 
   if (w_current->cowindow)
   gtk_widget_destroy(w_current->cowindow);

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -619,11 +619,6 @@ x_window_close (GschemToplevel *w_current,
 
   schematic_window_list_remove (w_current);
   gschem_toplevel_free (w_current);
-
-  /* just closed last window, so quit */
-  if (last_window) {
-    gschem_quit();
-  }
 }
 
 

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -575,6 +575,7 @@ x_window_close (GschemToplevel *w_current)
   GtkWidget *aewindow = schematic_window_get_attrib_edit_widget (w_current);
   GtkWidget *hkwindow = schematic_window_get_hotkey_widget (w_current);
   GtkWidget *cowindow = schematic_window_get_coord_widget (w_current);
+  GtkWidget *sewindow = schematic_window_get_slot_edit_widget (w_current);
 
   schematic_window_set_dont_invalidate (w_current, TRUE);
 
@@ -595,8 +596,7 @@ x_window_close (GschemToplevel *w_current)
 
   if (cowindow) gtk_widget_destroy (cowindow);
 
-  if (w_current->sewindow)
-  gtk_widget_destroy(w_current->sewindow);
+  if (sewindow) gtk_widget_destroy(sewindow);
 }
 
 

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -569,7 +569,7 @@ schematic_window_set_main_window (GschemToplevel *w_current,
 void
 x_window_close (GschemToplevel *w_current)
 {
-  w_current->dont_invalidate = TRUE;
+  schematic_window_set_dont_invalidate (w_current, TRUE);
 
   x_widgets_destroy_dialogs (w_current);
 

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -617,7 +617,7 @@ x_window_close (GschemToplevel *w_current,
   }
 
   /* finally close the main window */
-  gtk_widget_destroy(w_current->main_window);
+  gtk_widget_destroy (schematic_window_get_main_window (w_current));
 }
 
 

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -555,10 +555,10 @@ schematic_window_set_main_window (GschemToplevel *w_current,
  *  \par Function Description
  *
  */
-void x_window_close(GschemToplevel *w_current)
+void
+x_window_close (GschemToplevel *w_current,
+                gboolean last_window)
 {
-  gboolean last_window = FALSE;
-
   /* If we're closing whilst inside an action, re-wind the
    * page contents back to their state before we started */
   if (w_current->inside_action) {
@@ -600,12 +600,6 @@ void x_window_close(GschemToplevel *w_current)
 
   if (w_current->sewindow)
   gtk_widget_destroy(w_current->sewindow);
-
-  if (schematic_window_list_length () == 1)
-  {
-    /* no more window after this one, remember to quit */
-    last_window = TRUE;
-  }
 
   if (last_window)
   {

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -890,8 +890,8 @@ x_window_save_page (GschemToplevel *w_current,
  *  \return               Pointer to a new current LeptonPage object.
  */
 LeptonPage*
-x_window_close_page_impl (GschemToplevel *w_current,
-                          LeptonPage *page)
+x_window_close_page (GschemToplevel *w_current,
+                     LeptonPage *page)
 {
   LeptonToplevel *toplevel = gschem_toplevel_get_toplevel (w_current);
   LeptonPage *new_current = NULL;
@@ -957,7 +957,7 @@ x_window_close_page_impl (GschemToplevel *w_current,
 
   return new_current;
 
-} /* x_window_close_page_impl() */
+} /* x_window_close_page() */
 
 
 /*! \brief Creates and initializes a new lepton-schematic window.

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -648,7 +648,7 @@ void x_window_close(GschemToplevel *w_current)
   /* finally close the main window */
   gtk_widget_destroy(w_current->main_window);
 
-  global_window_list = g_list_remove (global_window_list, w_current);
+  schematic_window_list_remove (w_current);
   gschem_toplevel_free (w_current);
 
   /* just closed last window, so quit */

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -528,6 +528,20 @@ schematic_window_show_all (GschemToplevel *w_current,
 }
 
 
+/*! \brief Get the main window widget of this schematic window.
+ *
+ * \param [in] w_current The schematic window structure.
+ * \return The main window widget.
+ */
+GtkWidget*
+schematic_window_get_main_window (GschemToplevel *w_current)
+{
+  g_return_val_if_fail (w_current != NULL, NULL);
+
+  return w_current->main_window;
+}
+
+
 /*! \brief Set main window widget of schematic window
  *  \par Function Description
  *  Sets the main window widget of #GschemToplevel instance \a

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -668,7 +668,8 @@ void x_window_close_all(GschemToplevel *w_current)
   GschemToplevel *current;
   GList *list_copy, *iter;
 
-  iter = list_copy = g_list_copy (global_window_list);
+  GList *gwl = schematic_window_list ();
+  iter = list_copy = g_list_copy (gwl);
   while (iter != NULL ) {
     current = (GschemToplevel *)iter->data;
     iter = g_list_next (iter);

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -658,27 +658,6 @@ void x_window_close(GschemToplevel *w_current)
   }
 }
 
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
-void x_window_close_all(GschemToplevel *w_current)
-{
-  GschemToplevel *current;
-  GList *list_copy, *iter;
-
-  GList *gwl = schematic_window_list ();
-  iter = list_copy = g_list_copy (gwl);
-  while (iter != NULL ) {
-    current = (GschemToplevel *)iter->data;
-    iter = g_list_next (iter);
-    x_window_close (current);
-  }
-  g_list_free (list_copy);
-}
-
-
 
 /*! \brief Opens a new page from a file.
  *  \private

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -31,9 +31,6 @@ create_notebook_bottom (GschemToplevel *w_current);
 
 
 static void
-geometry_save (GschemToplevel* w_current);
-
-static void
 open_page_error_dialog (GschemToplevel* w_current,
                         const gchar*    filename,
                         GError*         err);
@@ -605,7 +602,7 @@ x_window_close (GschemToplevel *w_current,
 
   if (last_window)
   {
-    geometry_save (w_current);
+    schematic_window_save_geometry (w_current);
   }
 
   /* stuff that has to be done before we free w_current */
@@ -1543,8 +1540,8 @@ x_window_untitled_page (LeptonPage* page)
  *
  *  \param w_current The toplevel environment.
  */
-static void
-geometry_save (GschemToplevel* w_current)
+void
+schematic_window_save_geometry (GschemToplevel* w_current)
 {
   gint x = 0;
   gint y = 0;

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -574,6 +574,7 @@ x_window_close (GschemToplevel *w_current)
   GtkWidget *aawindow = schematic_window_get_arc_edit_widget (w_current);
   GtkWidget *aewindow = schematic_window_get_attrib_edit_widget (w_current);
   GtkWidget *hkwindow = schematic_window_get_hotkey_widget (w_current);
+  GtkWidget *cowindow = schematic_window_get_coord_widget (w_current);
 
   schematic_window_set_dont_invalidate (w_current, TRUE);
 
@@ -592,8 +593,7 @@ x_window_close (GschemToplevel *w_current)
 
   if (hkwindow) gtk_widget_destroy (hkwindow);
 
-  if (w_current->cowindow)
-  gtk_widget_destroy(w_current->cowindow);
+  if (cowindow) gtk_widget_destroy (cowindow);
 
   if (w_current->sewindow)
   gtk_widget_destroy(w_current->sewindow);

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -560,46 +560,6 @@ schematic_window_set_main_window (GschemToplevel *w_current,
 }
 
 
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
-void
-x_window_close (GschemToplevel *w_current)
-{
-  GtkWidget *cswindow = schematic_window_get_compselect_widget (w_current);
-  GtkWidget *tiwindow = schematic_window_get_text_input_widget (w_current);
-  GtkWidget *aawindow = schematic_window_get_arc_edit_widget (w_current);
-  GtkWidget *aewindow = schematic_window_get_attrib_edit_widget (w_current);
-  GtkWidget *hkwindow = schematic_window_get_hotkey_widget (w_current);
-  GtkWidget *cowindow = schematic_window_get_coord_widget (w_current);
-  GtkWidget *sewindow = schematic_window_get_slot_edit_widget (w_current);
-
-  schematic_window_set_dont_invalidate (w_current, TRUE);
-
-  x_widgets_destroy_dialogs (w_current);
-
-  /* close all the dialog boxes */
-  if (cswindow) gtk_widget_destroy (cswindow);
-
-  if (tiwindow) gtk_widget_destroy (tiwindow);
-
-  if (aawindow) gtk_widget_destroy (aawindow);
-
-  x_multiattrib_close (w_current);
-
-  if (aewindow) gtk_widget_destroy (aewindow);
-
-  if (hkwindow) gtk_widget_destroy (hkwindow);
-
-  if (cowindow) gtk_widget_destroy (cowindow);
-
-  if (sewindow) gtk_widget_destroy(sewindow);
-}
-
-
 /*! \brief Opens a new page from a file.
  *  \private
  *  \par Function Description


### PR DESCRIPTION
- Several C functions have been rewritten to make those lower
  level code available in Scheme: `x_window_close_page()`,
  `x_window_close_all()`, `x_window_setup()`, `gschem_quit()`,
  `i_vars_atexit_save_cache_config()`, and `x_window_close()`.
- To make it happen, many new accessors for several fields of the
  structure `GschemToplevel` have been added.  Functions working
  with key accelerator strings and timers, have been refactored or
  rewritten in Scheme to do it.
- A new Scheme module, `(schematic window list)`, has been
  introduced.  It contains new procedures for working with
  `lepton-schematic` windows in Scheme: `schematic-windows()`,
  `window-exists?()`, `add-window!()`, and `remove-window!()`.
  The functions allow for introspecting and modifying the list of
  currently opened windows in `lepton-schematic`.
- A new Scheme procedure has been introduced in the module
  `(schematic window)`: `close-window!()`.  It closes currently
  active window of the program destroying and freeing all its
  widgets and resources.
