### PR TITLE
Rewrite x_window_open_page() and some related functions in Scheme.

### DIFF
--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -416,7 +416,8 @@ int generic_confirm_dialog(const char *);
 
 void
 generic_error_dialog (const char *primary_message,
-                      const char *secondary_message);
+                      const char *secondary_message,
+                      const char *title);
 
 char * generic_filesel_dialog(const char *, const char *, gint);
 

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -535,7 +535,9 @@ lepton_menu_set_action_data (GtkWidget *menu,
                              gpointer action);
 void
 x_menu_attach_recent_files_submenu (GschemToplevel* w_current,
-                                    GtkWidget*      menuitem);
+                                    GtkWidget* menuitem,
+                                    gint max_items);
+
 /* x_multiattrib.c */
 void x_multiattrib_open (GschemToplevel *w_current);
 void x_multiattrib_close (GschemToplevel *w_current);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -634,9 +634,6 @@ GschemToplevel*
 schematic_window_set_main_window (GschemToplevel *w_current,
                                   GtkWidget *main_window);
 LeptonPage*
-x_window_open_page (GschemToplevel *w_current,
-                    const gchar *filename);
-LeptonPage*
 x_window_open_page_impl (GschemToplevel *w_current,
                          const gchar *filename);
 void

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -534,8 +534,12 @@ lepton_menu_set_action_data (GtkWidget *menu,
                              GtkWidget *menu_item,
                              gpointer action);
 void
+recent_chooser_item_activated (GtkRecentChooser *chooser,
+                               GschemToplevel *w_current);
+void
 x_menu_attach_recent_files_submenu (GschemToplevel* w_current,
                                     GtkWidget* menuitem,
+                                    GCallback callback_item_activated,
                                     gint max_items);
 
 /* x_multiattrib.c */

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -533,9 +533,9 @@ lepton_menu_set_action_data (GtkWidget *menu,
                              const char *action_name,
                              GtkWidget *menu_item,
                              gpointer action);
-void
-recent_chooser_item_activated (GtkRecentChooser *chooser,
-                               GschemToplevel *w_current);
+char*
+schematic_menu_recent_chooser_get_filename (GtkRecentChooser *chooser,
+                                            GschemToplevel *w_current);
 void
 x_menu_attach_recent_files_submenu (GschemToplevel* w_current,
                                     GtkWidget* menuitem,

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -455,8 +455,11 @@ gboolean x_event_get_pointer_position (GschemToplevel *w_current, gboolean snapp
 /* x_compselect.c */
 void x_compselect_open (GschemToplevel *w_current);
 void x_compselect_deselect (GschemToplevel *w_current);
+
 /* x_fileselect.c */
-void x_fileselect_open(GschemToplevel *w_current);
+GSList*
+x_fileselect_open (GschemToplevel *w_current);
+
 gboolean
 x_fileselect_save (GschemToplevel *w_current,
                    LeptonPage* page,

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -634,8 +634,8 @@ GschemToplevel*
 schematic_window_set_main_window (GschemToplevel *w_current,
                                   GtkWidget *main_window);
 LeptonPage*
-x_window_open_page_impl (GschemToplevel *w_current,
-                         const gchar *filename);
+x_window_open_page (GschemToplevel *w_current,
+                    const gchar *filename);
 void
 x_window_set_current_page (GschemToplevel *w_current,
                            LeptonPage *page);

--- a/libleptongui/scheme/Makefile.am
+++ b/libleptongui/scheme/Makefile.am
@@ -20,6 +20,7 @@ nobase_dist_scmdata_DATA = \
 	schematic/callback.scm \
 	schematic/gettext.scm \
 	schematic/dialog.scm \
+	schematic/dialog/file-select.scm \
 	schematic/dialog/slot-edit.scm \
 	schematic/ffi.scm \
 	schematic/ffi/gobject.scm \

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -1106,9 +1106,9 @@ the snap grid size should be set to 100")))
                                       (G_ "Unknown error.")
                                       (gerror-message (dereference-pointer *error))))))
 
-    (generic_error_dialog (string->pointer (G_ "Failed to descend hierarchy."))
-                          (string->pointer secondary-message)
-                          %null-pointer)
+    (schematic-error-dialog (G_ "Failed to descend hierarchy.")
+                            secondary-message
+                            %null-pointer)
 
     (g_clear_error *error)))
 

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -93,7 +93,7 @@
 
 
 (define-action-public (&file-open #:label (G_ "Open File") #:icon "gtk-open")
-  (file-select-dialog (*current-window)))
+  (file-select-dialog (current-window)))
 
 (define-action-public (&file-save #:label (G_ "Save") #:icon "gtk-save")
   (run-callback i_callback_file_save "&file-save"))

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -1107,7 +1107,8 @@ the snap grid size should be set to 100")))
                                       (gerror-message (dereference-pointer *error))))))
 
     (generic_error_dialog (string->pointer (G_ "Failed to descend hierarchy."))
-                          (string->pointer secondary-message))
+                          (string->pointer secondary-message)
+                          %null-pointer)
 
     (g_clear_error *error)))
 

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -43,6 +43,7 @@
   #:use-module (schematic gettext)
   #:use-module (schematic ffi)
   #:use-module (schematic dialog)
+  #:use-module (schematic dialog file-select)
   #:use-module (schematic dialog slot-edit)
   #:use-module (schematic doc)
   #:use-module (schematic gui keymap)
@@ -92,7 +93,7 @@
 
 
 (define-action-public (&file-open #:label (G_ "Open File") #:icon "gtk-open")
-  (x_fileselect_open (*current-window)))
+  (file-select-open (*current-window)))
 
 (define-action-public (&file-save #:label (G_ "Save") #:icon "gtk-save")
   (run-callback i_callback_file_save "&file-save"))

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -166,10 +166,10 @@
 
 
 (define-action-public (&file-new-window #:label (G_ "New Window") #:icon "window-new")
-  (x_window_open_page
+  (window-open-page!
    (make-schematic-window (lepton_schematic_app)
                           (lepton_toplevel_new))
-   %null-pointer))
+   #f))
 
 (define-action-public (&file-close-window #:label (G_ "Close Window") #:icon "gtk-close")
   (log! 'message (G_ "Closing Window"))

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -842,10 +842,9 @@ the snap grid size should be set to 100")))
     (true? (x_window_untitled_page (page->pointer page))))
 
   (define filename (page-filename (active-page)))
-  (define *filename (string->pointer filename))
 
   (when (and (not (untitled-page? (active-page)))
-             (true? (schematic_page_revert_dialog *window *filename)))
+             (true? (schematic_page_revert_dialog *window (string->pointer filename))))
 
     (let ((*page_current (schematic_window_get_active_page *window))
           ;; If there's only one opened page, create a dummy page
@@ -853,7 +852,7 @@ the snap grid size should be set to 100")))
           ;; window-close-page!() from creating a stray blank
           ;; page.
           (*dummy-page (if (= 1 (length (active-pages)))
-                           (x_window_open_page *window %null-pointer)
+                           (page->pointer (window-open-page! (current-window) #f))
                            %null-pointer)))
       (unless (null-pointer? *dummy-page)
         (x_window_set_current_page *window *dummy-page)
@@ -868,7 +867,7 @@ the snap grid size should be set to 100")))
         ;; Force symbols to be re-loaded from disk.
         (s_clib_refresh)
 
-        (let ((*page (x_window_open_page *window *filename)))
+        (let ((*page (page->pointer (window-open-page! (current-window) filename))))
 
           ;; Raise an error if the page cannot be reloaded for
           ;; some reason.

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -93,7 +93,7 @@
 
 
 (define-action-public (&file-open #:label (G_ "Open File") #:icon "gtk-open")
-  (file-select-open (*current-window)))
+  (file-select-dialog (*current-window)))
 
 (define-action-public (&file-save #:label (G_ "Save") #:icon "gtk-save")
   (run-callback i_callback_file_save "&file-save"))

--- a/libleptongui/scheme/schematic/callback.scm
+++ b/libleptongui/scheme/schematic/callback.scm
@@ -53,7 +53,7 @@
 
 (define (callback-file-new *widget *window)
   ;; Create a new page.
-  (let ((*page (x_window_open_page *window %null-pointer)))
+  (let ((*page (page->pointer (window-open-page! (pointer->window *window) #f))))
     (if (null-pointer? *page)
         (error (G_ "Could not create a new page."))
         (begin

--- a/libleptongui/scheme/schematic/callback.scm
+++ b/libleptongui/scheme/schematic/callback.scm
@@ -67,7 +67,7 @@
 
 
 (define (callback-file-open *widget *window)
-  (file-select-dialog *window))
+  (file-select-dialog (pointer->window *window)))
 
 (define *callback-file-open
   (procedure->pointer void callback-file-open '(* *)))

--- a/libleptongui/scheme/schematic/callback.scm
+++ b/libleptongui/scheme/schematic/callback.scm
@@ -30,6 +30,7 @@
 
   #:use-module (schematic action)
   #:use-module (schematic action-mode)
+  #:use-module (schematic dialog file-select)
   #:use-module (schematic ffi)
   #:use-module (schematic window foreign)
   #:use-module (schematic window)
@@ -66,7 +67,7 @@
 
 
 (define (callback-file-open *widget *window)
-  (x_fileselect_open *window))
+  (file-select-open *window))
 
 (define *callback-file-open
   (procedure->pointer void callback-file-open '(* *)))

--- a/libleptongui/scheme/schematic/callback.scm
+++ b/libleptongui/scheme/schematic/callback.scm
@@ -67,7 +67,7 @@
 
 
 (define (callback-file-open *widget *window)
-  (file-select-open *window))
+  (file-select-dialog *window))
 
 (define *callback-file-open
   (procedure->pointer void callback-file-open '(* *)))

--- a/libleptongui/scheme/schematic/dialog.scm
+++ b/libleptongui/scheme/schematic/dialog.scm
@@ -28,6 +28,7 @@
 
   #:export (schematic-message-dialog
             schematic-confirm-dialog
+            schematic-error-dialog
             schematic-fileselect-dialog))
 
 (define (schematic-message-dialog message)
@@ -39,6 +40,19 @@
 NO.  Returns #t if the button YES was pressed.  Otherwise returns
 #f."
   (not (zero? (generic_confirm_dialog (string->pointer message)))))
+
+(define* (schematic-error-dialog text
+                                 #:key
+                                 (secondary-text #f)
+                                 (title #f))
+  "Opens GTK message dialog with TEXT as a primary text message,
+and SECONDARY-TEXT as a secondary message.  The dialog title text
+is set to the optional TITLE parameter."
+  (generic_error_dialog (string->pointer text)
+                        (or (and=> secondary-text string->pointer)
+                            %null-pointer)
+                        (or (and=> title string->pointer)
+                            %null-pointer)))
 
 (define (schematic-fileselect-dialog message template . flags)
   "Opens GTK file selection dialog with MESSAGE as dialog's title.

--- a/libleptongui/scheme/schematic/dialog/file-select.scm
+++ b/libleptongui/scheme/schematic/dialog/file-select.scm
@@ -1,0 +1,28 @@
+;;; Lepton EDA Schematic Capture
+;;; Scheme API
+;;; Copyright (C) 2022 Lepton EDA Contributors
+;;;
+;;; This program is free software; you can redistribute it and/or modify
+;;; it under the terms of the GNU General Public License as published by
+;;; the Free Software Foundation; either version 2 of the License, or
+;;; (at your option) any later version.
+;;;
+;;; This program is distributed in the hope that it will be useful,
+;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;; GNU General Public License for more details.
+;;;
+;;; You should have received a copy of the GNU General Public License
+;;; along with this program; if not, write to the Free Software
+;;; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
+(define-module (schematic dialog file-select)
+  #:use-module (schematic ffi)
+
+  #:export (file-select-open))
+
+
+(define (file-select-open *window)
+  "Opens file selection dialog in *WINDOW."
+  (x_fileselect_open *window))

--- a/libleptongui/scheme/schematic/dialog/file-select.scm
+++ b/libleptongui/scheme/schematic/dialog/file-select.scm
@@ -24,24 +24,26 @@
   #:use-module (lepton ffi glib)
 
   #:use-module (schematic ffi)
+  #:use-module (schematic window)
+  #:use-module (schematic window foreign)
 
   #:export (file-select-dialog))
 
 
-(define (file-select-dialog *window)
-  "Opens file selection dialog in *WINDOW.  Loads selected files as
+(define (file-select-dialog window)
+  "Opens file selection dialog in WINDOW.  Loads selected files as
 pages.  The current page of the window is set to the page of the
 last loaded page."
+  (define *window (check-window window 1))
+
   (define filenames
     (gslist->list (x_fileselect_open *window) pointer->string 'free))
 
   ;; Open each file.
-  (define *pages
-    (map
-     (lambda (filename)
-       (x_window_open_page *window (string->pointer filename)))
-     filenames))
+  (define pages
+    (map (lambda (filename) (window-open-page! window filename))
+         filenames))
 
   ;; Switch to the last page opened.
-  (unless (null? *pages)
-    (x_window_set_current_page *window (last *pages))))
+  (unless (null? pages)
+    (window-set-current-page! window (last pages))))

--- a/libleptongui/scheme/schematic/dialog/file-select.scm
+++ b/libleptongui/scheme/schematic/dialog/file-select.scm
@@ -25,10 +25,10 @@
 
   #:use-module (schematic ffi)
 
-  #:export (file-select-open))
+  #:export (file-select-dialog))
 
 
-(define (file-select-open *window)
+(define (file-select-dialog *window)
   "Opens file selection dialog in *WINDOW.  Loads selected files as
 pages.  The current page of the window is set to the page of the
 last loaded page."

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -694,7 +694,7 @@
 (define-lff x_event_key '* '(* * *))
 
 ;;; x_fileselect.c
-(define-lff x_fileselect_open void '(*))
+(define-lff x_fileselect_open '* '(*))
 (define-lff x_fileselect_save int '(* * *))
 (define-lff schematic_file_open int '(* * * *))
 

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -602,7 +602,7 @@
 
 ;;; x_dialog.c
 (define-lff generic_confirm_dialog int '(*))
-(define-lff generic_error_dialog void '(* *))
+(define-lff generic_error_dialog void '(* * *))
 (define-lff generic_filesel_dialog '* (list '* '* int))
 (define-lff generic_msg_dialog void '(*))
 

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -116,6 +116,7 @@
 
             x_colorcb_update_colors
 
+            *recent_chooser_item_activated
             x_menu_attach_recent_files_submenu
 
             attrib_edit_dialog
@@ -531,7 +532,8 @@
 ;;; x_menus.c
 (define-lff make_separator_menu_item '* '())
 (define-lff make_menu_action '* '(* * * * *))
-(define-lff x_menu_attach_recent_files_submenu void (list '* '* int))
+(define-lfc *recent_chooser_item_activated)
+(define-lff x_menu_attach_recent_files_submenu void (list '* '* '* int))
 (define-lff lepton_action_create_menu_item '* '(* * *))
 (define-lff lepton_menu_set_action_data void '(* * * *))
 (define-lff schematic_window_create_main_popup_menu '* '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -531,7 +531,7 @@
 ;;; x_menus.c
 (define-lff make_separator_menu_item '* '())
 (define-lff make_menu_action '* '(* * * * *))
-(define-lff x_menu_attach_recent_files_submenu void '(* *))
+(define-lff x_menu_attach_recent_files_submenu void (list '* '* int))
 (define-lff lepton_action_create_menu_item '* '(* * *))
 (define-lff lepton_menu_set_action_data void '(* * * *))
 (define-lff schematic_window_create_main_popup_menu '* '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -164,7 +164,7 @@
 
             x_window_close_page
             x_window_new
-            x_window_open_page_impl
+            x_window_open_page
             x_window_save_page
             x_window_set_current_page
             x_window_setup_draw_events_drawing_area
@@ -545,7 +545,7 @@
 
 ;;; x_window.c
 (define-lff x_window_new '* '(*))
-(define-lff x_window_open_page_impl '* '(* *))
+(define-lff x_window_open_page '* '(* *))
 (define-lff x_window_save_page int '(* * *))
 (define-lff x_window_set_current_page void '(* *))
 (define-lff x_window_setup_draw_events_drawing_area void '(* *))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -36,6 +36,7 @@
             generic_error_dialog
             generic_filesel_dialog
             generic_msg_dialog
+            major_changed_dialog
 
             schematic_execute_script
 
@@ -163,7 +164,7 @@
 
             x_window_close_page
             x_window_new
-            x_window_open_page
+            x_window_open_page_impl
             x_window_save_page
             x_window_set_current_page
             x_window_setup_draw_events_drawing_area
@@ -209,6 +210,7 @@
             x_tabs_enabled
             x_tabs_hdr_update
             x_tabs_page_close
+            x_tabs_page_open
 
             schematic_action_mode_from_string
             schematic_action_mode_to_string
@@ -543,7 +545,7 @@
 
 ;;; x_window.c
 (define-lff x_window_new '* '(*))
-(define-lff x_window_open_page '* '(* *))
+(define-lff x_window_open_page_impl '* '(* *))
 (define-lff x_window_save_page int '(* * *))
 (define-lff x_window_set_current_page void '(* *))
 (define-lff x_window_setup_draw_events_drawing_area void '(* *))
@@ -592,6 +594,7 @@
 (define-lff x_tabs_enabled int '())
 (define-lff x_tabs_hdr_update void '(* *))
 (define-lff x_tabs_page_close void '(* *))
+(define-lff x_tabs_page_open '* '(* *))
 
 ;;; gschem_find_text_widget.c
 (define-lff find_text_dialog void '(*))
@@ -605,6 +608,7 @@
 (define-lff generic_error_dialog void '(* * *))
 (define-lff generic_filesel_dialog '* (list '* '* int))
 (define-lff generic_msg_dialog void '(*))
+(define-lff major_changed_dialog void '(*))
 
 ;;; execute_script.c
 (define-lff schematic_execute_script '* '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -116,7 +116,7 @@
 
             x_colorcb_update_colors
 
-            *recent_chooser_item_activated
+            schematic_menu_recent_chooser_get_filename
             x_menu_attach_recent_files_submenu
 
             attrib_edit_dialog
@@ -532,7 +532,7 @@
 ;;; x_menus.c
 (define-lff make_separator_menu_item '* '())
 (define-lff make_menu_action '* '(* * * * *))
-(define-lfc *recent_chooser_item_activated)
+(define-lff schematic_menu_recent_chooser_get_filename '* '(* *))
 (define-lff x_menu_attach_recent_files_submenu void (list '* '* '* int))
 (define-lff lepton_action_create_menu_item '* '(* * *))
 (define-lff lepton_menu_set_action_data void '(* * * *))

--- a/libleptongui/scheme/schematic/menu.scm
+++ b/libleptongui/scheme/schematic/menu.scm
@@ -107,7 +107,7 @@
               (error (G_ "The value of \"max-recent-files\" must be a positive integer"))
               num)))
       (lambda (key subr message args rest)
-        (log! 'warning (G_ "ERROR: ~?.\n") message args)
+        (log! 'warning (G_ "ERROR: ~?.") message args)
         ;; Default value.
         10)))
 

--- a/libleptongui/scheme/schematic/menu.scm
+++ b/libleptongui/scheme/schematic/menu.scm
@@ -115,6 +115,7 @@
       (x_menu_attach_recent_files_submenu
        window
        menu-item
+       *recent_chooser_item_activated
        ;; Set maximum number of recent files from config.
        (get-max-recent-files))))
 

--- a/libleptongui/scheme/schematic/menu.scm
+++ b/libleptongui/scheme/schematic/menu.scm
@@ -98,11 +98,14 @@
   (define RECENT_MENU_ITEM_NAME "Open Recen_t")
 
   (define (get-max-recent-files)
-    (catch 'config-error
+    (catch #t
       (lambda ()
-        (config-int (path-config-context (getcwd))
-                    "schematic.gui"
-                    "max-recent-files"))
+        (let ((num (config-int (path-config-context (getcwd))
+                               "schematic.gui"
+                               "max-recent-files")))
+          (if (<= num 0)
+              (error (G_ "The value of \"max-recent-files\" must be a positive integer"))
+              num)))
       (lambda (key subr message args rest)
         (log! 'warning (G_ "ERROR: ~?.\n") message args)
         ;; Default value.

--- a/libleptongui/scheme/schematic/menu.scm
+++ b/libleptongui/scheme/schematic/menu.scm
@@ -24,7 +24,6 @@
 
   #:use-module (lepton config)
   #:use-module (lepton eval)
-  #:use-module (lepton ffi glib)
   #:use-module (lepton ffi)
   #:use-module (lepton gettext)
   #:use-module (lepton log)
@@ -50,24 +49,8 @@
        (set-main-menu-list!
         (append %main-menu-list (list (cons name items))))))
 
-;;; Opens file selected in recent-chooser.
-(define (recent-chooser-callback-item-activated *chooser *window)
-  (define *filename
-    (schematic_menu_recent_chooser_get_filename *chooser *window))
 
-  (x_window_set_current_page *window
-                             (x_window_open_page *window *filename))
-  ;; Free the returned C string.
-  (g_free *filename))
-
-;;; C callback for the above function.
-(define *recent-chooser-callback-item-activated
-  (procedure->pointer void
-                      recent-chooser-callback-item-activated
-                      '(* *)))
-
-
-(define (make-main-menu window)
+(define (make-main-menu window *callback-recent-chooser-item-activated)
   "Create and return the main menu widget for WINDOW."
   (define (make-menu-action-item func name stock menu-bar)
     (if (not func)
@@ -133,7 +116,7 @@
       (x_menu_attach_recent_files_submenu
        window
        menu-item
-       *recent-chooser-callback-item-activated
+       *callback-recent-chooser-item-activated
        ;; Set maximum number of recent files from config.
        (get-max-recent-files))))
 

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -55,7 +55,8 @@
             pointer-position
             snap-point
             window-close-page!
-            window-open-page!)
+            window-open-page!
+            window-set-current-page!)
 
   ;; Overrides the close-page! procedure in the (lepton page)
   ;; module.
@@ -319,6 +320,14 @@ window to PAGE.  Returns PAGE."
         %null-pointer))
 
   (pointer->page (x_window_open_page *window *filename)))
+
+
+(define (window-set-current-page! window page)
+  "Sets current page of WINDOW to PAGE."
+  (define *window (check-window window 1))
+  (define *page (check-page page 2))
+
+  (x_window_set_current_page *window *page))
 
 
 (define (pointer-position)

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -165,13 +165,17 @@
 
 ;;; Opens a file selected in recent-chooser.
 (define (callback-recent-chooser-item-activated *chooser *window)
+  (define window (pointer->window *window))
   (define *filename
     (schematic_menu_recent_chooser_get_filename *chooser *window))
+  (define filename (pointer->string *filename))
 
-  (x_window_set_current_page *window
-                             (x_window_open_page *window *filename))
   ;; Free the returned C string.
-  (g_free *filename))
+  (g_free *filename)
+
+  (window-set-current-page! window
+                            (window-open-page! window filename)))
+
 
 ;;; C callback for the above function.
 (define *callback-recent-chooser-item-activated

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -341,7 +341,18 @@ window to PAGE.  Returns PAGE."
              (string->pointer filename))
         %null-pointer))
 
-  (pointer->page (x_window_open_page *window *filename)))
+  (define *page
+    (if (true? (x_tabs_enabled))
+        (x_tabs_page_open *window *filename)
+        (x_window_open_page_impl *window *filename)))
+
+  (unless (or (null-pointer? *filename)
+              (null-pointer? *page))
+    ;; Check for symbol version changes, display an error dialog
+    ;; box, if necessary.
+    (major_changed_dialog *window))
+
+  (pointer->page *page))
 
 
 (define (window-set-current-page! window page)

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -54,7 +54,8 @@
             set-active-page!
             pointer-position
             snap-point
-            window-close-page!)
+            window-close-page!
+            window-open-page!)
 
   ;; Overrides the close-page! procedure in the (lepton page)
   ;; module.
@@ -303,6 +304,19 @@ window to PAGE.  Returns PAGE."
 
   ;; Return value is unspecified.
   (if #f #f))
+
+
+(define (window-open-page! window filename)
+  "Loads file FILENAME and opens a new page for it.  If FILENAME is
+#f, opens a new untitled page.  Returns the new page."
+  (define *window (check-window window 1))
+  (define *filename
+    (if filename
+        (and (check-string filename 1)
+             (string->pointer filename))
+        %null-pointer))
+
+  (pointer->page (x_window_open_page *window *filename)))
 
 
 (define (pointer-position)

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -246,7 +246,9 @@ GtkApplication structure of the program (when compiled with
 
       (schematic_window_show_all *window *main-window)
       ;; Returns *window.
-      (schematic_window_set_main_window *window *main-window))))
+      (schematic_window_set_main_window *window *main-window)))
+
+  (pointer->window *window))
 
 
 (define (active-page)

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -344,7 +344,7 @@ window to PAGE.  Returns PAGE."
   (define *page
     (if (true? (x_tabs_enabled))
         (x_tabs_page_open *window *filename)
-        (x_window_open_page_impl *window *filename)))
+        (x_window_open_page *window *filename)))
 
   (unless (or (null-pointer? *filename)
               (null-pointer? *page))

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -26,6 +26,7 @@
   #:use-module (lepton config)
   #:use-module (lepton ffi boolean)
   #:use-module (lepton ffi check-args)
+  #:use-module (lepton ffi glib)
   #:use-module (lepton ffi)
   #:use-module (lepton gettext)
   #:use-module (lepton log)
@@ -162,6 +163,23 @@
   (procedure->pointer int callback-close-schematic-window '(* * *)))
 
 
+;;; Opens a file selected in recent-chooser.
+(define (callback-recent-chooser-item-activated *chooser *window)
+  (define *filename
+    (schematic_menu_recent_chooser_get_filename *chooser *window))
+
+  (x_window_set_current_page *window
+                             (x_window_open_page *window *filename))
+  ;; Free the returned C string.
+  (g_free *filename))
+
+;;; C callback for the above function.
+(define *callback-recent-chooser-item-activated
+  (procedure->pointer void
+                      callback-recent-chooser-item-activated
+                      '(* *)))
+
+
 (define (make-schematic-window *app *toplevel)
   "Creates a new lepton-schematic window.  APP is a pointer to the
 GtkApplication structure of the program (when compiled with
@@ -193,7 +211,7 @@ GtkApplication structure of the program (when compiled with
                               *window)
 
     (let ((*main-box (schematic_window_create_main_box *main-window))
-          (*menubar (make-main-menu *window))
+          (*menubar (make-main-menu *window *callback-recent-chooser-item-activated))
           (*work-box (schematic_window_create_work_box)))
       (schematic_window_create_menubar *window *main-box *menubar)
 

--- a/libleptongui/src/x_dialog.c
+++ b/libleptongui/src/x_dialog.c
@@ -95,10 +95,12 @@ int generic_confirm_dialog (const char *msg)
  *
  * \param [in] primary_message The main error message.
  * \param [in] secondary_message The additional or detail message.
+ * \param [in] title The optional dialog title.
  */
 void
 generic_error_dialog (const char *primary_message,
-                      const char *secondary_message)
+                      const char *secondary_message,
+                      const char *title)
 {
   GtkWidget *dialog = gtk_message_dialog_new (NULL,
                                               GTK_DIALOG_MODAL,
@@ -109,6 +111,10 @@ generic_error_dialog (const char *primary_message,
                 "text", primary_message,
                 "secondary-text", secondary_message,
                 NULL);
+  if (title != NULL)
+  {
+    gtk_window_set_title (GTK_WINDOW (dialog), title);
+  }
   gtk_dialog_run (GTK_DIALOG (dialog));
   gtk_widget_destroy (dialog);
 }

--- a/libleptongui/src/x_fileselect.c
+++ b/libleptongui/src/x_fileselect.c
@@ -318,20 +318,17 @@ x_fileselect_add_preview (GtkFileChooser *filechooser)
 
 /*! \brief Opens a file chooser for opening one or more schematics.
  *  \par Function Description
- *  This function opens a file chooser dialog and wait for the user to
- *  select at least one file to load as <B>w_current</B>'s new pages.
  *
- *  The function updates the user interface.
- *
- *  At the end of the function, the w_current->toplevel's current page
- *  is set to the page of the last loaded page.
+ *  This function opens a file chooser dialog and waits for the
+ *  user to select at least one file to load.
  *
  *  \param [in] w_current The GschemToplevel environment.
+ *  \return The GSList of file names to open.
  */
-void
-x_fileselect_open(GschemToplevel *w_current)
+GSList*
+x_fileselect_open (GschemToplevel *w_current)
 {
-  LeptonPage *page = NULL;
+  GSList *filenames = NULL;
   GtkWidget *dialog;
   gchar *cwd;
 
@@ -375,23 +372,12 @@ x_fileselect_open(GschemToplevel *w_current)
     /* remember current filter: */
     filter_last_opendlg = gtk_file_chooser_get_filter (GTK_FILE_CHOOSER (dialog));
 
-    GSList *tmp, *filenames =
-      gtk_file_chooser_get_filenames (GTK_FILE_CHOOSER (dialog));
-
-    /* open each file */
-    for (tmp = filenames; tmp != NULL;tmp = g_slist_next (tmp)) {
-      page = x_window_open_page (w_current, (gchar*)tmp->data);
-    }
-    /* Switch to the last page opened */
-    if ( page != NULL )
-      x_window_set_current_page (w_current, page);
-
-    /* free the list of filenames */
-    g_slist_foreach (filenames, (GFunc)g_free, NULL);
-    g_slist_free (filenames);
+    filenames = gtk_file_chooser_get_filenames (GTK_FILE_CHOOSER (dialog));
   }
+
   gtk_widget_destroy (dialog);
 
+  return filenames;
 }
 
 

--- a/libleptongui/src/x_menus.c
+++ b/libleptongui/src/x_menus.c
@@ -28,7 +28,6 @@
 
 #include <glib/gstdio.h>
 
-#define DEFAULT_MAX_RECENT_FILES 10
 #define RECENT_MENU_ITEM_NAME "Open Recen_t"
 
 struct PopupEntry
@@ -385,7 +384,8 @@ recent_chooser_item_activated (GtkRecentChooser *chooser, GschemToplevel *w_curr
  */
 void
 x_menu_attach_recent_files_submenu (GschemToplevel* w_current,
-                                    GtkWidget*      menuitem)
+                                    GtkWidget*      menuitem,
+                                    gint max_items)
 {
   GtkRecentFilter *recent_filter;
   GtkWidget *menuitem_file_recent_items;
@@ -406,26 +406,6 @@ x_menu_attach_recent_files_submenu (GschemToplevel* w_current,
   gtk_recent_chooser_set_show_tips(GTK_RECENT_CHOOSER(menuitem_file_recent_items), TRUE);
   gtk_recent_chooser_set_sort_type(GTK_RECENT_CHOOSER(menuitem_file_recent_items),
                                    GTK_RECENT_SORT_MRU);
-
-  /* read configuration: maximum number of recent files: */
-  gchar* cwd = g_get_current_dir();
-  EdaConfig* cfg = eda_config_get_context_for_path (cwd);
-  g_free (cwd);
-
-  gint max_items = DEFAULT_MAX_RECENT_FILES;
-
-  if (cfg != NULL)
-  {
-    GError* err = NULL;
-    gint val = eda_config_get_int (cfg, "schematic.gui", "max-recent-files", &err);
-
-    if (err == NULL && val > 0)
-    {
-      max_items = val;
-    }
-
-    g_clear_error (&err);
-  }
 
   gtk_recent_chooser_set_limit(GTK_RECENT_CHOOSER(menuitem_file_recent_items), max_items);
 

--- a/libleptongui/src/x_menus.c
+++ b/libleptongui/src/x_menus.c
@@ -385,6 +385,7 @@ recent_chooser_item_activated (GtkRecentChooser *chooser, GschemToplevel *w_curr
 void
 x_menu_attach_recent_files_submenu (GschemToplevel* w_current,
                                     GtkWidget*      menuitem,
+                                    GCallback callback_item_activated,
                                     gint max_items)
 {
   GtkRecentFilter *recent_filter;
@@ -411,8 +412,10 @@ x_menu_attach_recent_files_submenu (GschemToplevel* w_current,
 
   gtk_recent_chooser_set_local_only(GTK_RECENT_CHOOSER(menuitem_file_recent_items), FALSE);
   gtk_recent_chooser_menu_set_show_numbers(GTK_RECENT_CHOOSER_MENU(menuitem_file_recent_items), TRUE);
-  g_signal_connect (G_OBJECT (menuitem_file_recent_items), "item-activated",
-                    G_CALLBACK (recent_chooser_item_activated), w_current);
+  g_signal_connect (G_OBJECT (menuitem_file_recent_items),
+                    "item-activated",
+                    callback_item_activated,
+                    w_current);
 
   if (menuitem == NULL)
     return;

--- a/libleptongui/src/x_menus.c
+++ b/libleptongui/src/x_menus.c
@@ -354,15 +354,21 @@ x_menus_sensitivity (GtkWidget*   menu,
 #endif
 }
 
-/*! \brief Callback for recent-chooser.
+/*! \brief Return selected filename in recent-chooser.
  *
  *  \par Function Description
- *  Will be called if element of recent-file-list is activated
+ *
+ *  Will be called if element of recent-file-list is activated.
+ *  Returns selected filename.  The caller must free the filename.
+ *
+ *  \param [in] chooser The recent-chooser instance.
+ *  \param [in] w_current The current schematic window.
+ *  \return The selected filename.
  */
-void
-recent_chooser_item_activated (GtkRecentChooser *chooser, GschemToplevel *w_current)
+char*
+schematic_menu_recent_chooser_get_filename (GtkRecentChooser *chooser,
+                                            GschemToplevel *w_current)
 {
-  LeptonPage *page;
   gchar *uri;
   gchar *filename;
 
@@ -371,11 +377,10 @@ recent_chooser_item_activated (GtkRecentChooser *chooser, GschemToplevel *w_curr
   if (w_current->recent_manager != NULL) {
     gtk_recent_manager_add_item (w_current->recent_manager, uri);
   }
-  page = x_window_open_page(w_current, (char *)filename);
-  x_window_set_current_page(w_current, page);
 
   g_free(uri);
-  g_free(filename);
+
+  return filename;
 }
 
 

--- a/libleptongui/src/x_tabs.c
+++ b/libleptongui/src/x_tabs.c
@@ -1394,7 +1394,7 @@ x_tabs_page_open (GschemToplevel* w_current, const gchar* filename)
     printf( "    x_tabs_page_open(): #1: [pview] [!page], fn: [%s] \n\n", filename );
 #endif
 
-    nfo_cur->page_ = x_window_open_page_impl (w_current, filename);
+    nfo_cur->page_ = x_window_open_page (w_current, filename);
     x_window_set_current_page_impl (w_current, nfo_cur->page_);
 
     x_tabs_hdr_set (w_current->xtabs_nbook, nfo_cur);
@@ -1426,7 +1426,7 @@ x_tabs_page_open (GschemToplevel* w_current, const gchar* filename)
 
     TabInfo* nfo_new = x_tabs_page_new (w_current, NULL);
 
-    nfo_new->page_ = x_window_open_page_impl (w_current, filename);
+    nfo_new->page_ = x_window_open_page (w_current, filename);
     x_window_set_current_page_impl (w_current, nfo_new->page_);
 
     x_tabs_hdr_set (w_current->xtabs_nbook, nfo_new);

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -585,8 +585,8 @@ schematic_window_set_main_window (GschemToplevel *w_current,
  *  does not conflict with a file on disk.
  */
 LeptonPage*
-x_window_open_page_impl (GschemToplevel *w_current,
-                         const gchar *filename)
+x_window_open_page (GschemToplevel *w_current,
+                    const gchar *filename)
 {
   LeptonToplevel *toplevel = gschem_toplevel_get_toplevel (w_current);
   g_return_val_if_fail (toplevel != NULL, NULL);
@@ -638,7 +638,7 @@ x_window_open_page_impl (GschemToplevel *w_current,
 
   return page;
 
-} /* x_window_open_page_impl() */
+} /* x_window_open_page() */
 
 
 
@@ -826,7 +826,7 @@ x_window_close_page (GschemToplevel *w_current,
     /* Create a new page if there wasn't another to switch to */
     if (new_current == NULL && !x_tabs_enabled())
     {
-      new_current = x_window_open_page_impl (w_current, NULL);
+      new_current = x_window_open_page (w_current, NULL);
     }
 
     /* change to new_current and update display */

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -1185,38 +1185,6 @@ create_notebook_bottom (GschemToplevel* w_current)
 
 
 
-/*! \brief Opens a new page from a file or a blank one if \a filename is NULL.
- *
- *  \see x_window_open_page_impl()
- *  \see x_tabs_page_open()
- */
-LeptonPage*
-x_window_open_page (GschemToplevel* w_current, const gchar* filename)
-{
-  LeptonPage* page = NULL;
-
-  if (x_tabs_enabled())
-  {
-    page = x_tabs_page_open (w_current, filename);
-  }
-  else
-  {
-    page = x_window_open_page_impl (w_current, filename);
-  }
-
-  if (filename != NULL && page != NULL)
-  {
-    /* check for symbol version changes, display
-     * an error dialog box, if necessary:
-    */
-    major_changed_dialog (w_current);
-  }
-
-  return page;
-}
-
-
-
 /*! \brief Changes the current page.
  *
  *  \see x_window_set_current_page_impl()

--- a/tools/schematic/lepton-schematic.scm
+++ b/tools/schematic/lepton-schematic.scm
@@ -241,19 +241,19 @@ Run `~A --help' for more information.\n")
 
 (define (main app file-list)
   ;; Create a new window and associated LeptonToplevel object.
-  (define window (make-schematic-window app
-                                        (lepton_toplevel_new)))
+  (define *window (make-schematic-window app
+                                         (lepton_toplevel_new)))
   ;; Current directory.
   (define cwd (getcwd))
 
   (define (open-page *filename)
-    (x_window_open_page window *filename))
+    (x_window_open_page *window *filename))
 
   (define (string-ls->pointer-ls ls)
     (map string->pointer ls))
 
   ;; Open up log window on startup if requested in config.
-  (open-log-window window)
+  (open-log-window *window)
 
   (let* ((filenames (get-absolute-filenames file-list cwd))
          (*filenames (if (null? filenames)
@@ -263,10 +263,10 @@ Run `~A --help' for more information.\n")
          (*current-page (last *pages)))
 
     ;; Update the window to show the current page:
-    (x_window_set_current_page window *current-page))
+    (x_window_set_current_page *window *current-page))
 
   ;; Return the new window.
-  window)
+  *window)
 
 
 ;;; Init logging.

--- a/tools/schematic/lepton-schematic.scm
+++ b/tools/schematic/lepton-schematic.scm
@@ -255,14 +255,12 @@ Run `~A --help' for more information.\n")
   ;; Open up log window on startup if requested in config.
   (open-log-window *window)
 
-  (let* ((filenames (if (null? file-list)
-                        (list #f)
-                        (get-absolute-filenames file-list cwd)))
-         (pages (map open-page filenames))
-         (*current-page (page->pointer (last pages))))
+  (let ((pages (map open-page (if (null? file-list)
+                                  (list #f)
+                                  (get-absolute-filenames file-list cwd)))))
 
     ;; Update the window to show the current page:
-    (x_window_set_current_page *window *current-page))
+    (window-set-current-page! window (last pages)))
 
   ;; Return the new window.
   *window)

--- a/tools/schematic/lepton-schematic.scm
+++ b/tools/schematic/lepton-schematic.scm
@@ -35,6 +35,7 @@
              (schematic ffi)
              (schematic ffi gtk)
              (schematic gui keymap)
+             (schematic window foreign)
              (schematic window))
 
 ;;; Initialize liblepton library.
@@ -241,8 +242,9 @@ Run `~A --help' for more information.\n")
 
 (define (main app file-list)
   ;; Create a new window and associated LeptonToplevel object.
-  (define *window (make-schematic-window app
-                                         (lepton_toplevel_new)))
+  (define *window
+    (window->pointer (make-schematic-window app (lepton_toplevel_new))))
+
   ;; Current directory.
   (define cwd (getcwd))
 

--- a/tools/schematic/lepton-schematic.scm
+++ b/tools/schematic/lepton-schematic.scm
@@ -242,27 +242,24 @@ Run `~A --help' for more information.\n")
 
 (define (main app file-list)
   ;; Create a new window and associated LeptonToplevel object.
-  (define *window
-    (window->pointer (make-schematic-window app (lepton_toplevel_new))))
+  (define window (make-schematic-window app (lepton_toplevel_new)))
+
+  (define *window (window->pointer window))
 
   ;; Current directory.
   (define cwd (getcwd))
 
-  (define (open-page *filename)
-    (x_window_open_page *window *filename))
-
-  (define (string-ls->pointer-ls ls)
-    (map string->pointer ls))
+  (define (open-page filename)
+    (window-open-page! window filename))
 
   ;; Open up log window on startup if requested in config.
   (open-log-window *window)
 
-  (let* ((filenames (get-absolute-filenames file-list cwd))
-         (*filenames (if (null? filenames)
-                         (list %null-pointer)
-                         (string-ls->pointer-ls filenames)))
-         (*pages (map open-page *filenames))
-         (*current-page (last *pages)))
+  (let* ((filenames (if (null? file-list)
+                        (list #f)
+                        (get-absolute-filenames file-list cwd)))
+         (pages (map open-page filenames))
+         (*current-page (page->pointer (last pages))))
 
     ;; Update the window to show the current page:
     (x_window_set_current_page *window *current-page))


### PR DESCRIPTION
- The recent chooser widget code has been amended as follows:
  - The callback for its signal `item-activated` is now assigned
    in Scheme.  It has been moved to the module `(schematic
    window)`
    for further code refactoring.
  - The maximal number of recent files which are displayed in the
     corresponding menu, is now processed in Scheme.  Unlike it
     was previously, if a `'config-error` error is raised while
     reading the config key `max-recent-files` the error is now
     reported to the log and is thus available in the log window
     of `lepton-schematic`.
  - Opening of a selected page is now handled in Scheme as well.

- A module for *File select* dialog functions has been created.
  It is called `(schematic dialog file-select)` and currently contains
  an only function, `file-select-dialog()`.

- The procedure `make-schematic-window()` now returns a `<window>`
  object representing the window created.

- A new procedure, `window-set-current-page!()`, has been
  introduced.  It replaces foreign calls to
  `x_window_set_current_page()` in Scheme code and works with
  `<window>` and `<page>` objects.

- A new Scheme function, `schematic-error-dialog()`, has been
  introduced to represent a generic error dialog window.  The C
  foreign function that launches the generic error dialog has been
  amended to allow for setting the title of the dialog.

- A new procedure, `window-open-page!()`, has been introduced.
  The calls to the foreign function `x_window_open_page()` have
  been replaced by calls to the Scheme procedure.  Finally, the
  function `x_window_open_page()` has been rewritten in Scheme and
  the function `x_window_open_page_impl()` has been renamed to
  `x_window_open_page()`.
