### PR TITLE
Fixes in the module (lepton os)

### DIFF
--- a/liblepton/scheme/lepton/file-system.scm
+++ b/liblepton/scheme/lepton/file-system.scm
@@ -25,8 +25,12 @@
             file-readable?))
 
 (define (regular-file? path)
-  "Returns #t if the given path exists and is a regular file, otherwise #f."
+  "Returns #t if the given path exists and is a regular file,
+otherwise #f.  Symlinks to regular files are considered regular
+files as well."
   (and (file-exists? path)
+       ;; Use stat() here instead of lstat() to let symlinks to
+       ;; regular files be treated as plain regular files.
        (eqv? (stat:type (stat path)) 'regular)))
 
 (define (directory? path)

--- a/liblepton/scheme/lepton/os.scm
+++ b/liblepton/scheme/lepton/os.scm
@@ -105,12 +105,18 @@ is stored."
       ;; set.
       (passwd:dir (getpwuid (getuid)))))
 
+
 (define expand-env-variables
   ;; Only compile regular expression once
   (let ((rx (make-regexp "\\$\\{(\\w*)\\}")))
     ;; This is the actual expand-env-variables function -- it's a
     ;; closure around rx.
     (lambda (str)
+      "Expands environment variables in STR usually representing a
+path and returns the result of expansion.  To be expanded, a
+variable must be enclosed in curly braces and prefixed with the
+dollar sign (e.g. ${HOME}).  Additionally, the function replaces
+tilda prefix (~) with the user home directory."
       ;; Returns result of expanding the environment variable name
       ;; found in match, or "".
       (define (match-getenv m)

--- a/liblepton/scheme/lepton/os.scm
+++ b/liblepton/scheme/lepton/os.scm
@@ -1,6 +1,6 @@
 ;;; Lepton EDA library - Scheme API
 ;;; Copyright (C) 2011 Peter Brett <peter@peter-b.co.uk>
-;;; Copyright (C) 2019-2021 Lepton EDA Contributors
+;;; Copyright (C) 2019-2022 Lepton EDA Contributors
 ;;;
 ;;; This program is free software; you can redistribute it and/or modify
 ;;; it under the terms of the GNU General Public License as published by
@@ -95,6 +95,16 @@ is stored."
   "Returns the directory where per-user cache data are stored."
   (pointer->string (eda_get_user_cache_dir)))
 
+
+;;; To get the user home directory, the recommended approach is
+;;; to first check the $HOME environment variable and use
+;;; getpwuid() as a last resort only.
+(define (user-home-dir)
+  (or (getenv "HOME")
+      ;; Fall back to using low level functions if $HOME is not
+      ;; set.
+      (passwd:dir (getpwuid (getuid)))))
+
 (define expand-env-variables
   ;; Only compile regular expression once
   (let ((rx (make-regexp "\\$\\{(\\w*)\\}")))
@@ -114,7 +124,7 @@ is stored."
       (define (tilda-prefix->home-prefix s)
         (if (and (char=? (string-ref s 0) #\~)
                  (file-name-separator? (string-ref s 1)))
-            (string-append "${HOME}"
+            (string-append (user-home-dir)
                            file-name-separator-string
                            (substring s 2))
             s))


### PR DESCRIPTION
- Determining the user home directory has been improved in the
  function `expand-env-variable()`.  The function will now fall
  back to lower level functions to determine the path if the
  `$HOME` environment variable is not set.
  
- A new local function, `user-home-dir()`, has been created just
  for the above task.  While it is not yet exported in the module,
  this may be easily done at any time in future.

- Docstrings and comments have been improved or added for the
  functions `expand-env-variables()` and `regular-file?()`.
