### PR TITLE
Rewrite x_widgets_create() in Scheme

### DIFF
--- a/libleptongui/include/color_edit_widget.h
+++ b/libleptongui/include/color_edit_widget.h
@@ -63,11 +63,14 @@ typedef struct _ColorEditWidgetClass ColorEditWidgetClass;
 typedef struct _ColorEditWidget      ColorEditWidget;
 
 
-GtkWidget*
-color_edit_widget_new (GschemToplevel* w_current);
-
 GType
 color_edit_widget_get_type();
 
+G_BEGIN_DECLS
+
+GtkWidget*
+color_edit_widget_new (GschemToplevel* w_current);
+
+G_END_DECLS
 
 #endif /* LEPTON_COLOR_EDIT_WIDGET_H_ */

--- a/libleptongui/include/font_select_widget.h
+++ b/libleptongui/include/font_select_widget.h
@@ -1,6 +1,6 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 2018 dmn <graahnul.grom@gmail.com>
- * Copyright (C) 2018-2021 Lepton EDA Contributors
+ * Copyright (C) 2018-2022 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -60,11 +60,14 @@ typedef struct _FontSelectWidgetClass FontSelectWidgetClass;
 typedef struct _FontSelectWidget      FontSelectWidget;
 
 
-GtkWidget*
-font_select_widget_new (GschemToplevel* w_current);
-
 GType
 font_select_widget_get_type();
 
+G_BEGIN_DECLS
+
+GtkWidget*
+font_select_widget_new (GschemToplevel* w_current);
+
+G_END_DECLS
 
 #endif /* LEPTON_FONT_SELECT_WIDGET_H_ */

--- a/libleptongui/include/gschem_find_text_state.h
+++ b/libleptongui/include/gschem_find_text_state.h
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2015 gEDA Contributors
- * Copyright (C) 2017-2020 Lepton EDA Contributors
+ * Copyright (C) 2017-2022 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -71,8 +71,11 @@ gschem_find_text_state_find (GschemToplevel *w_current,
 GType
 gschem_find_text_state_get_type ();
 
+G_BEGIN_DECLS
+
 GtkWidget*
 gschem_find_text_state_new ();
 
+G_END_DECLS
 
 #endif /* GSCHEM_FIND_TEXT_STATE_H_ */

--- a/libleptongui/include/gschem_log_widget.h
+++ b/libleptongui/include/gschem_log_widget.h
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2015 gEDA Contributors
- * Copyright (C) 2017-2019 Lepton EDA Contributors
+ * Copyright (C) 2017-2022 Lepton EDA Contributors
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -50,5 +50,9 @@ struct _GschemLogWidget {
 GType
 gschem_log_widget_get_type (void);
 
+G_BEGIN_DECLS
+
 GtkWidget*
 gschem_log_widget_new ();
+
+G_END_DECLS

--- a/libleptongui/include/gschem_object_properties_widget.h
+++ b/libleptongui/include/gschem_object_properties_widget.h
@@ -72,5 +72,9 @@ struct _GschemObjectPropertiesWidget
 GType
 gschem_object_properties_widget_get_type();
 
+G_BEGIN_DECLS
+
 GtkWidget*
 gschem_object_properties_widget_new (GschemToplevel *w_current);
+
+G_END_DECLS

--- a/libleptongui/include/gschem_options_widget.h
+++ b/libleptongui/include/gschem_options_widget.h
@@ -59,5 +59,9 @@ gschem_options_widget_adjust_focus (GschemOptionsWidget *dialog);
 GType
 gschem_options_widget_get_type ();
 
+G_BEGIN_DECLS
+
 GtkWidget*
 gschem_options_widget_new (GschemToplevel *w_current);
+
+G_END_DECLS

--- a/libleptongui/include/gschem_text_properties_widget.h
+++ b/libleptongui/include/gschem_text_properties_widget.h
@@ -59,5 +59,9 @@ gschem_text_properties_widget_adjust_focus (GschemTextPropertiesWidget *widget);
 GType
 gschem_text_properties_widget_get_type ();
 
+G_BEGIN_DECLS
+
 GtkWidget*
 gschem_text_properties_widget_new (GschemToplevel *w_current);
+
+G_END_DECLS

--- a/libleptongui/include/gschem_toplevel.h
+++ b/libleptongui/include/gschem_toplevel.h
@@ -476,4 +476,7 @@ schematic_window_set_find_text_state_widget (GschemToplevel *w_current,
 void
 schematic_window_set_color_edit_widget (GschemToplevel *w_current,
                                         GtkWidget *widget);
+void
+schematic_window_set_font_select_widget (GschemToplevel *w_current,
+                                         GtkWidget *widget);
 G_END_DECLS

--- a/libleptongui/include/gschem_toplevel.h
+++ b/libleptongui/include/gschem_toplevel.h
@@ -470,6 +470,9 @@ schematic_window_set_options_widget (GschemToplevel *w_current,
 void
 schematic_window_set_log_widget (GschemToplevel *w_current,
                                  GtkWidget *widget);
+GtkWidget*
+schematic_window_get_find_text_state_widget (GschemToplevel *w_current);
+
 void
 schematic_window_set_find_text_state_widget (GschemToplevel *w_current,
                                              GtkWidget *widget);

--- a/libleptongui/include/gschem_toplevel.h
+++ b/libleptongui/include/gschem_toplevel.h
@@ -473,4 +473,7 @@ schematic_window_set_log_widget (GschemToplevel *w_current,
 void
 schematic_window_set_find_text_state_widget (GschemToplevel *w_current,
                                              GtkWidget *widget);
+void
+schematic_window_set_color_edit_widget (GschemToplevel *w_current,
+                                        GtkWidget *widget);
 G_END_DECLS

--- a/libleptongui/include/gschem_toplevel.h
+++ b/libleptongui/include/gschem_toplevel.h
@@ -458,4 +458,7 @@ schematic_window_get_tab_info_list (GschemToplevel *w_current);
 GtkNotebook*
 schematic_window_get_tab_notebook (GschemToplevel *w_current);
 
+void
+schematic_window_set_object_properties_widget (GschemToplevel *w_current,
+                                               GtkWidget *widget);
 G_END_DECLS

--- a/libleptongui/include/gschem_toplevel.h
+++ b/libleptongui/include/gschem_toplevel.h
@@ -461,4 +461,7 @@ schematic_window_get_tab_notebook (GschemToplevel *w_current);
 void
 schematic_window_set_object_properties_widget (GschemToplevel *w_current,
                                                GtkWidget *widget);
+void
+schematic_window_set_text_properties_widget (GschemToplevel *w_current,
+                                             GtkWidget *widget);
 G_END_DECLS

--- a/libleptongui/include/gschem_toplevel.h
+++ b/libleptongui/include/gschem_toplevel.h
@@ -464,4 +464,7 @@ schematic_window_set_object_properties_widget (GschemToplevel *w_current,
 void
 schematic_window_set_text_properties_widget (GschemToplevel *w_current,
                                              GtkWidget *widget);
+void
+schematic_window_set_options_widget (GschemToplevel *w_current,
+                                     GtkWidget *widget);
 G_END_DECLS

--- a/libleptongui/include/gschem_toplevel.h
+++ b/libleptongui/include/gschem_toplevel.h
@@ -467,4 +467,7 @@ schematic_window_set_text_properties_widget (GschemToplevel *w_current,
 void
 schematic_window_set_options_widget (GschemToplevel *w_current,
                                      GtkWidget *widget);
+void
+schematic_window_set_log_widget (GschemToplevel *w_current,
+                                 GtkWidget *widget);
 G_END_DECLS

--- a/libleptongui/include/gschem_toplevel.h
+++ b/libleptongui/include/gschem_toplevel.h
@@ -470,4 +470,7 @@ schematic_window_set_options_widget (GschemToplevel *w_current,
 void
 schematic_window_set_log_widget (GschemToplevel *w_current,
                                  GtkWidget *widget);
+void
+schematic_window_set_find_text_state_widget (GschemToplevel *w_current,
+                                             GtkWidget *widget);
 G_END_DECLS

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -660,7 +660,6 @@ x_window_untitled_page (LeptonPage* page);
 /* x_widgets.c */
 gboolean x_widgets_use_docks();
 void x_widgets_init();
-void x_widgets_create (GschemToplevel* w_current);
 void x_widgets_show_options (GschemToplevel* w_current);
 void x_widgets_show_text_properties (GschemToplevel* w_current);
 void x_widgets_show_object_properties (GschemToplevel* w_current);

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -282,6 +282,7 @@
             schematic_window_get_draw_grips
             schematic_window_set_draw_grips
             schematic_window_get_enforce_hierarchy
+            schematic_window_set_font_select_widget
             schematic_window_get_gdk_display
             schematic_window_get_keyboardpan_gain
             schematic_window_get_macro_widget
@@ -308,6 +309,8 @@
             schematic_window_set_object_properties_widget
             schematic_window_set_options_widget
             schematic_window_set_text_properties_widget
+
+            font_select_widget_new
 
             gschem_log_widget_new
 
@@ -524,6 +527,7 @@
 (define-lff schematic_window_get_draw_grips int '(*))
 (define-lff schematic_window_set_draw_grips void (list '* int))
 (define-lff schematic_window_get_enforce_hierarchy int '(*))
+(define-lff schematic_window_set_font_select_widget void '(* *))
 (define-lff schematic_window_get_gdk_display '* '(*))
 (define-lff schematic_window_get_keyboardpan_gain int '(*))
 (define-lff schematic_window_get_macro_widget '* '(*))
@@ -550,6 +554,9 @@
 (define-lff schematic_window_set_object_properties_widget void '(* *))
 (define-lff schematic_window_set_options_widget void '(* *))
 (define-lff schematic_window_set_text_properties_widget void '(* *))
+
+;;; font_select_widget.c
+(define-lff font_select_widget_new '* '(*))
 
 ;;; gschem_log_widget.c
 (define-lff gschem_log_widget_new '* '())

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -304,9 +304,12 @@
             schematic_window_get_slot_edit_widget
             schematic_window_get_text_input_widget
             schematic_window_set_dont_invalidate
+            schematic_window_set_log_widget
             schematic_window_set_object_properties_widget
             schematic_window_set_options_widget
             schematic_window_set_text_properties_widget
+
+            gschem_log_widget_new
 
             gschem_object_properties_widget_new
 
@@ -543,9 +546,13 @@
 (define-lff schematic_window_get_slot_edit_widget '* '(*))
 (define-lff schematic_window_get_text_input_widget '* '(*))
 (define-lff schematic_window_set_dont_invalidate void (list '* int))
+(define-lff schematic_window_set_log_widget void '(* *))
 (define-lff schematic_window_set_object_properties_widget void '(* *))
 (define-lff schematic_window_set_options_widget void '(* *))
 (define-lff schematic_window_set_text_properties_widget void '(* *))
+
+;;; gschem_log_widget.c
+(define-lff gschem_log_widget_new '* '())
 
 ;;; gschem_object_properties_widget.c
 (define-lff gschem_object_properties_widget_new '* '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -113,6 +113,7 @@
             set_verbose_mode
             x_color_init
 
+            color_edit_widget_new
             color_edit_widget_update
 
             x_colorcb_update_colors
@@ -279,6 +280,7 @@
             schematic_window_get_active_page
             schematic_window_get_bottom_notebook
             schematic_window_set_bottom_notebook
+            schematic_window_set_color_edit_widget
             schematic_window_get_draw_grips
             schematic_window_set_draw_grips
             schematic_window_get_enforce_hierarchy
@@ -432,6 +434,7 @@
 (define-lff s_clib_free void '())
 
 ;;; color_edit_widget.c
+(define-lff color_edit_widget_new '* '(*))
 (define-lff color_edit_widget_update void '(*))
 
 ;;; x_colorcb.c
@@ -524,6 +527,7 @@
 (define-lff schematic_window_get_active_page '* '(*))
 (define-lff schematic_window_get_bottom_notebook '* '(*))
 (define-lff schematic_window_set_bottom_notebook void '(* *))
+(define-lff schematic_window_set_color_edit_widget void '(* *))
 (define-lff schematic_window_get_draw_grips int '(*))
 (define-lff schematic_window_set_draw_grips void (list '* int))
 (define-lff schematic_window_get_enforce_hierarchy int '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -133,6 +133,8 @@
             x_stroke_init
             x_stroke_free
 
+            gschem_find_text_state_new
+
             find_text_dialog
             hide_text_dialog
             show_text_dialog
@@ -151,7 +153,6 @@
 
             x_compselect_open
 
-            x_widgets_create
             x_widgets_destroy_dialogs
             x_widgets_init
             x_widgets_show_color_edit
@@ -167,6 +168,7 @@
             x_window_new
             x_window_open_page
             x_window_save_page
+            *x_window_select_object
             x_window_set_current_page
             x_window_set_current_page_impl
             x_window_setup_draw_events_drawing_area
@@ -284,6 +286,8 @@
             schematic_window_get_draw_grips
             schematic_window_set_draw_grips
             schematic_window_get_enforce_hierarchy
+            schematic_window_get_find_text_state_widget
+            schematic_window_set_find_text_state_widget
             schematic_window_set_font_select_widget
             schematic_window_get_gdk_display
             schematic_window_get_keyboardpan_gain
@@ -444,7 +448,6 @@
 (define-lff x_compselect_open void '(*))
 
 ;;; x_widgets.c
-(define-lff x_widgets_create void '(*))
 (define-lff x_widgets_destroy_dialogs void '(*))
 (define-lff x_widgets_init void '())
 (define-lff x_widgets_show_color_edit void '(*))
@@ -531,6 +534,8 @@
 (define-lff schematic_window_get_draw_grips int '(*))
 (define-lff schematic_window_set_draw_grips void (list '* int))
 (define-lff schematic_window_get_enforce_hierarchy int '(*))
+(define-lff schematic_window_get_find_text_state_widget '* '(*))
+(define-lff schematic_window_set_find_text_state_widget void '(* *))
 (define-lff schematic_window_set_font_select_widget void '(* *))
 (define-lff schematic_window_get_gdk_display '* '(*))
 (define-lff schematic_window_get_keyboardpan_gain int '(*))
@@ -602,6 +607,7 @@
 (define-lff x_window_new '* '(*))
 (define-lff x_window_open_page '* '(* *))
 (define-lff x_window_save_page int '(* * *))
+(define-lfc *x_window_select_object)
 (define-lff x_window_set_current_page void '(* *))
 (define-lff x_window_set_current_page_impl void '(* *))
 (define-lff x_window_setup_draw_events_drawing_area void '(* *))
@@ -667,6 +673,9 @@
 (define-lff schematic_tab_info_get_tab_widget '* '(*))
 (define-lff schematic_tab_info_get_window '* '(*))
 (define-lff schematic_tabs_set_callback void '(* *))
+
+;;; gschem_find_text_state.c
+(define-lff gschem_find_text_state_new '* '())
 
 ;;; gschem_find_text_widget.c
 (define-lff find_text_dialog void '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -305,6 +305,7 @@
             schematic_window_get_text_input_widget
             schematic_window_set_dont_invalidate
             schematic_window_set_object_properties_widget
+            schematic_window_set_options_widget
             schematic_window_set_text_properties_widget
 
             gschem_object_properties_widget_new
@@ -318,6 +319,8 @@
             gschem_options_set_snap_mode
             gschem_options_get_snap_size
             gschem_options_set_snap_size
+
+            gschem_options_widget_new
 
             gschem_text_properties_widget_new
             text_edit_dialog
@@ -541,6 +544,7 @@
 (define-lff schematic_window_get_text_input_widget '* '(*))
 (define-lff schematic_window_set_dont_invalidate void (list '* int))
 (define-lff schematic_window_set_object_properties_widget void '(* *))
+(define-lff schematic_window_set_options_widget void '(* *))
 (define-lff schematic_window_set_text_properties_widget void '(* *))
 
 ;;; gschem_object_properties_widget.c
@@ -556,6 +560,9 @@
 (define-lff gschem_options_set_snap_mode void (list '* int))
 (define-lff gschem_options_get_snap_size int '(*))
 (define-lff gschem_options_set_snap_size void (list '* int))
+
+;;; gschem_options_widget.c
+(define-lff gschem_options_widget_new '* '(*))
 
 ;;; gschem_text_properties_widget.c
 (define-lff gschem_text_properties_widget_new '* '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -305,6 +305,7 @@
             schematic_window_get_text_input_widget
             schematic_window_set_dont_invalidate
             schematic_window_set_object_properties_widget
+            schematic_window_set_text_properties_widget
 
             gschem_object_properties_widget_new
 
@@ -318,6 +319,7 @@
             gschem_options_get_snap_size
             gschem_options_set_snap_size
 
+            gschem_text_properties_widget_new
             text_edit_dialog
 
             text_input_dialog
@@ -539,6 +541,7 @@
 (define-lff schematic_window_get_text_input_widget '* '(*))
 (define-lff schematic_window_set_dont_invalidate void (list '* int))
 (define-lff schematic_window_set_object_properties_widget void '(* *))
+(define-lff schematic_window_set_text_properties_widget void '(* *))
 
 ;;; gschem_object_properties_widget.c
 (define-lff gschem_object_properties_widget_new '* '(*))
@@ -555,6 +558,7 @@
 (define-lff gschem_options_set_snap_size void (list '* int))
 
 ;;; gschem_text_properties_widget.c
+(define-lff gschem_text_properties_widget_new '* '(*))
 (define-lff text_edit_dialog void '(*))
 
 ;;; x_menus.c

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -304,6 +304,9 @@
             schematic_window_get_slot_edit_widget
             schematic_window_get_text_input_widget
             schematic_window_set_dont_invalidate
+            schematic_window_set_object_properties_widget
+
+            gschem_object_properties_widget_new
 
             gschem_options_cycle_grid_mode
             gschem_options_get_grid_mode
@@ -535,6 +538,10 @@
 (define-lff schematic_window_get_slot_edit_widget '* '(*))
 (define-lff schematic_window_get_text_input_widget '* '(*))
 (define-lff schematic_window_set_dont_invalidate void (list '* int))
+(define-lff schematic_window_set_object_properties_widget void '(* *))
+
+;;; gschem_object_properties_widget.c
+(define-lff gschem_object_properties_widget_new '* '(*))
 
 ;;; gschem_options.c
 (define-lff gschem_options_cycle_grid_mode void '(*))

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -480,7 +480,11 @@ GtkApplication structure of the program (when compiled with
                                            (gschem_options_widget_new *window))
       (schematic_window_set_log_widget *window
                                        (gschem_log_widget_new))
-      (x_widgets_create *window)
+      (schematic_window_set_find_text_state_widget *window (gschem_find_text_state_new))
+      (schematic_signal_connect (schematic_window_get_find_text_state_widget *window)
+                                (string->pointer "select-object")
+                                *x_window_select_object
+                                *window)
       (schematic_window_set_color_edit_widget *window
                                               (color_edit_widget_new *window))
       (schematic_window_set_font_select_widget *window

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -472,6 +472,8 @@ GtkApplication structure of the program (when compiled with
 
       ;; Setup various widgets.
       (x_widgets_init)
+      (schematic_window_set_object_properties_widget *window
+                                                     (gschem_object_properties_widget_new *window))
       (x_widgets_create *window)
       (schematic_window_set_page_select_widget *window
                                                (page_select_widget_new *window

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -481,6 +481,8 @@ GtkApplication structure of the program (when compiled with
       (schematic_window_set_log_widget *window
                                        (gschem_log_widget_new))
       (x_widgets_create *window)
+      (schematic_window_set_font_select_widget *window
+                                               (font_select_widget_new *window))
       (schematic_window_set_page_select_widget *window
                                                (page_select_widget_new *window
                                                                        *callback-file-new

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -478,6 +478,8 @@ GtkApplication structure of the program (when compiled with
                                                    (gschem_text_properties_widget_new *window))
       (schematic_window_set_options_widget *window
                                            (gschem_options_widget_new *window))
+      (schematic_window_set_log_widget *window
+                                       (gschem_log_widget_new))
       (x_widgets_create *window)
       (schematic_window_set_page_select_widget *window
                                                (page_select_widget_new *window

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -481,6 +481,8 @@ GtkApplication structure of the program (when compiled with
       (schematic_window_set_log_widget *window
                                        (gschem_log_widget_new))
       (x_widgets_create *window)
+      (schematic_window_set_color_edit_widget *window
+                                              (color_edit_widget_new *window))
       (schematic_window_set_font_select_widget *window
                                                (font_select_widget_new *window))
       (schematic_window_set_page_select_widget *window

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -476,6 +476,8 @@ GtkApplication structure of the program (when compiled with
                                                      (gschem_object_properties_widget_new *window))
       (schematic_window_set_text_properties_widget *window
                                                    (gschem_text_properties_widget_new *window))
+      (schematic_window_set_options_widget *window
+                                           (gschem_options_widget_new *window))
       (x_widgets_create *window)
       (schematic_window_set_page_select_widget *window
                                                (page_select_widget_new *window

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -474,6 +474,8 @@ GtkApplication structure of the program (when compiled with
       (x_widgets_init)
       (schematic_window_set_object_properties_widget *window
                                                      (gschem_object_properties_widget_new *window))
+      (schematic_window_set_text_properties_widget *window
+                                                   (gschem_text_properties_widget_new *window))
       (x_widgets_create *window)
       (schematic_window_set_page_select_widget *window
                                                (page_select_widget_new *window

--- a/libleptongui/src/gschem_toplevel.c
+++ b/libleptongui/src/gschem_toplevel.c
@@ -1666,3 +1666,18 @@ schematic_window_set_options_widget (GschemToplevel *w_current,
 
   w_current->options_widget = widget;
 }
+
+
+/*! \brief Set log widget for this schematic window.
+ *
+ *  \param [in] w_current The schematic window.
+ *  \param [in] widget The widget.
+ */
+void
+schematic_window_set_log_widget (GschemToplevel *w_current,
+                                 GtkWidget *widget)
+{
+  g_return_if_fail (w_current != NULL);
+
+  w_current->log_widget = widget;
+}

--- a/libleptongui/src/gschem_toplevel.c
+++ b/libleptongui/src/gschem_toplevel.c
@@ -1651,3 +1651,18 @@ schematic_window_set_text_properties_widget (GschemToplevel *w_current,
 
   w_current->text_properties = widget;
 }
+
+
+/*! \brief Set options widget for this schematic window.
+ *
+ *  \param [in] w_current The schematic window.
+ *  \param [in] widget The widget.
+ */
+void
+schematic_window_set_options_widget (GschemToplevel *w_current,
+                                     GtkWidget *widget)
+{
+  g_return_if_fail (w_current != NULL);
+
+  w_current->options_widget = widget;
+}

--- a/libleptongui/src/gschem_toplevel.c
+++ b/libleptongui/src/gschem_toplevel.c
@@ -1683,6 +1683,20 @@ schematic_window_set_log_widget (GschemToplevel *w_current,
 }
 
 
+/*! \brief Get find text state widget of this schematic window.
+ *
+ *  \param [in] w_current The schematic window.
+ *  \return The widget.
+ */
+GtkWidget*
+schematic_window_get_find_text_state_widget (GschemToplevel *w_current)
+{
+  g_return_val_if_fail (w_current != NULL, NULL);
+
+  return w_current->find_text_state;
+}
+
+
 /*! \brief Set find text state widget for this schematic window.
  *
  *  \param [in] w_current The schematic window.

--- a/libleptongui/src/gschem_toplevel.c
+++ b/libleptongui/src/gschem_toplevel.c
@@ -1636,3 +1636,18 @@ schematic_window_set_object_properties_widget (GschemToplevel *w_current,
 
   w_current->object_properties = widget;
 }
+
+
+/*! \brief Set text properties widget for this schematic window.
+ *
+ *  \param [in] w_current The schematic window.
+ *  \param [in] widget The widget.
+ */
+void
+schematic_window_set_text_properties_widget (GschemToplevel *w_current,
+                                             GtkWidget *widget)
+{
+  g_return_if_fail (w_current != NULL);
+
+  w_current->text_properties = widget;
+}

--- a/libleptongui/src/gschem_toplevel.c
+++ b/libleptongui/src/gschem_toplevel.c
@@ -1711,3 +1711,18 @@ schematic_window_set_color_edit_widget (GschemToplevel *w_current,
 
   w_current->color_edit_widget = widget;
 }
+
+
+/*! \brief Set font select widget for this schematic window.
+ *
+ *  \param [in] w_current The schematic window.
+ *  \param [in] widget The widget.
+ */
+void
+schematic_window_set_font_select_widget (GschemToplevel *w_current,
+                                         GtkWidget *widget)
+{
+  g_return_if_fail (w_current != NULL);
+
+  w_current->font_select_widget = widget;
+}

--- a/libleptongui/src/gschem_toplevel.c
+++ b/libleptongui/src/gschem_toplevel.c
@@ -1681,3 +1681,18 @@ schematic_window_set_log_widget (GschemToplevel *w_current,
 
   w_current->log_widget = widget;
 }
+
+
+/*! \brief Set find text state widget for this schematic window.
+ *
+ *  \param [in] w_current The schematic window.
+ *  \param [in] widget The widget.
+ */
+void
+schematic_window_set_find_text_state_widget (GschemToplevel *w_current,
+                                             GtkWidget *widget)
+{
+  g_return_if_fail (w_current != NULL);
+
+  w_current->find_text_state = widget;
+}

--- a/libleptongui/src/gschem_toplevel.c
+++ b/libleptongui/src/gschem_toplevel.c
@@ -1621,3 +1621,18 @@ schematic_window_get_tab_notebook (GschemToplevel *w_current)
 
   return w_current->xtabs_nbook;
 }
+
+
+/*! \brief Set object properties widget for this schematic window.
+ *
+ *  \param [in] w_current The schematic window.
+ *  \param [in] widget The widget.
+ */
+void
+schematic_window_set_object_properties_widget (GschemToplevel *w_current,
+                                               GtkWidget *widget)
+{
+  g_return_if_fail (w_current != NULL);
+
+  w_current->object_properties = widget;
+}

--- a/libleptongui/src/gschem_toplevel.c
+++ b/libleptongui/src/gschem_toplevel.c
@@ -1696,3 +1696,18 @@ schematic_window_set_find_text_state_widget (GschemToplevel *w_current,
 
   w_current->find_text_state = widget;
 }
+
+
+/*! \brief Set color edit widget for this schematic window.
+ *
+ *  \param [in] w_current The schematic window.
+ *  \param [in] widget The widget.
+ */
+void
+schematic_window_set_color_edit_widget (GschemToplevel *w_current,
+                                        GtkWidget *widget)
+{
+  g_return_if_fail (w_current != NULL);
+
+  w_current->color_edit_widget = widget;
+}

--- a/libleptongui/src/x_widgets.c
+++ b/libleptongui/src/x_widgets.c
@@ -124,9 +124,6 @@ void x_widgets_create (GschemToplevel* w_current)
 {
   g_return_if_fail (w_current != NULL);
 
-  w_current->log_widget =
-      gschem_log_widget_new();
-
   w_current->find_text_state =
       gschem_find_text_state_new();
 

--- a/libleptongui/src/x_widgets.c
+++ b/libleptongui/src/x_widgets.c
@@ -124,9 +124,6 @@ void x_widgets_create (GschemToplevel* w_current)
 {
   g_return_if_fail (w_current != NULL);
 
-  w_current->object_properties =
-      gschem_object_properties_widget_new (w_current);
-
   w_current->text_properties =
       gschem_text_properties_widget_new (w_current);
 

--- a/libleptongui/src/x_widgets.c
+++ b/libleptongui/src/x_widgets.c
@@ -130,8 +130,6 @@ void x_widgets_create (GschemToplevel* w_current)
   g_signal_connect (w_current->find_text_state, "select-object",
                     G_CALLBACK (&x_window_select_object), w_current);
 
-  w_current->color_edit_widget = color_edit_widget_new (w_current);
-
 } /* x_widgets_create() */
 
 

--- a/libleptongui/src/x_widgets.c
+++ b/libleptongui/src/x_widgets.c
@@ -120,20 +120,6 @@ void x_widgets_init()
 
 
 
-void x_widgets_create (GschemToplevel* w_current)
-{
-  g_return_if_fail (w_current != NULL);
-
-  w_current->find_text_state =
-      gschem_find_text_state_new();
-
-  g_signal_connect (w_current->find_text_state, "select-object",
-                    G_CALLBACK (&x_window_select_object), w_current);
-
-} /* x_widgets_create() */
-
-
-
 void x_widgets_show_options (GschemToplevel* w_current)
 {
   g_return_if_fail (w_current != NULL);

--- a/libleptongui/src/x_widgets.c
+++ b/libleptongui/src/x_widgets.c
@@ -124,10 +124,6 @@ void x_widgets_create (GschemToplevel* w_current)
 {
   g_return_if_fail (w_current != NULL);
 
-  w_current->options_widget =
-      gschem_options_widget_new (w_current);
-
-
   w_current->log_widget =
       gschem_log_widget_new();
 

--- a/libleptongui/src/x_widgets.c
+++ b/libleptongui/src/x_widgets.c
@@ -132,8 +132,6 @@ void x_widgets_create (GschemToplevel* w_current)
 
   w_current->color_edit_widget = color_edit_widget_new (w_current);
 
-  w_current->font_select_widget = font_select_widget_new (w_current);
-
 } /* x_widgets_create() */
 
 

--- a/libleptongui/src/x_widgets.c
+++ b/libleptongui/src/x_widgets.c
@@ -124,9 +124,6 @@ void x_widgets_create (GschemToplevel* w_current)
 {
   g_return_if_fail (w_current != NULL);
 
-  w_current->text_properties =
-      gschem_text_properties_widget_new (w_current);
-
   w_current->options_widget =
       gschem_options_widget_new (w_current);
 


### PR DESCRIPTION
The function `x_widgets_create()` has been rewritten in Scheme so
initialization of several widgets has been moved from C to Scheme:

- Color edit widget
- Find text state widget
- Font select widget
- Log widget
- Object properties widget
- Options widget
- Text properties widget

In order to achieve this, C accessors to corresponding fields of
the structure `GschemToplevel` have been added for all the
widgets.

The signal "select-object" for the Find text state widget is now
also assigned in Scheme.
