### PR TITLE
netlist: Enable loading Scheme scripts from %load-path.

### DIFF
--- a/liblepton/scheme/netlist.scm
+++ b/liblepton/scheme/netlist.scm
@@ -37,6 +37,7 @@
   #:use-module (lepton gettext)
   #:use-module (lepton library)
   #:use-module (lepton log)
+  #:use-module (lepton file-system)
   #:use-module (lepton object)
   #:use-module (lepton page)
   #:use-module (lepton rc)
@@ -878,6 +879,21 @@ Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>
         (backend-proc output-filename))))
 
 
+(define (load-scheme-script filename)
+  (define (load-and-log name)
+    (log! 'message (G_ "Loading ~S") name)
+    (primitive-load name))
+
+  ;; If the file exists in the current directory, or its name is
+  ;; absolute, just load it.
+  (if (file-readable? filename)
+      (load-and-log filename)
+      ;; Otherwise, try to find it in %load-path.
+      (let ((file (%search-load-path filename)))
+        (if file
+            (load-and-log file)
+            (log! 'warning (G_ "Could not find file ~S in %load-path.") filename)))))
+
 
 ;;; Main program
 ;;;
@@ -1017,7 +1033,7 @@ Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>
   ;
   ( catch #t
     ( lambda()
-      ( for-each primitive-load opt-pre-load )
+      (for-each load-scheme-script opt-pre-load)
     )
     ( lambda( tag . args )
       ( catch-handler tag args )
@@ -1059,7 +1075,7 @@ Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>
   ;
   ( catch #t
     ( lambda()
-      ( for-each primitive-load opt-post-load )
+      (for-each load-scheme-script opt-post-load)
     )
     ( lambda( tag . args )
       ( catch-handler tag args )


### PR DESCRIPTION
The issue pointed out by John Doty (@noqsi) on gitter.  He tried to load an add-on by its basename putting it to one of the lepton config dirs to no avail.  The commit here fixes only one part of the issue and its description is as follows:

Previously, scripts specified by the options `-m` and `-l` were required to be absolute file names or file names in the current directory.  It is no longer necessary and now the user can simply set the basename of a file to be loaded, possibly along with its relative path, and the name will be searched for in all paths set in the `%load-path` variable.  Thus, the directories set as user or system data paths and listed in the output of functions `user-data-dir` and `sys-data-dirs` can be used for these purposes.

The other side of the issue, AIUI, and it needs to be discussed, is whether we have to add support for directories dedicated for loading specific stuff.  E.g. directories for tool specific add-ons, for putting backends, and so on.