### PR TITLE
Fix path to LINGUAS.

### DIFF
--- a/m4/lepton-desktop-i18n.m4
+++ b/m4/lepton-desktop-i18n.m4
@@ -55,7 +55,7 @@ gettext is correctly installed, and rerun configure.])
     --localedir=$(DESKTOP_I18N_LOCALE_DIR)/share/locale $(DESKTOP_I18N_LANGS)'
 
   DESKTOP_I18N_LANGS_RULE='DESKTOP_I18N_LANGS = $[$](echo "{ printf \"--lang=%s \", \$[$]1 }" \
-    | awk -f - $(abs_top_builddir)/$(DOMAIN)/po/LINGUAS)'
+    | awk -f - $(abs_top_srcdir)/$(DOMAIN)/po/LINGUAS)'
 
   DESKTOP_I18N_DESKTOP_RULE='.SUFFIXES: .desktop.in .desktop
 .desktop.in.desktop: ; $(DESKTOP_I18N_CREATE) $< [$]@'

--- a/m4/lepton-desktop-i18n.m4
+++ b/m4/lepton-desktop-i18n.m4
@@ -55,7 +55,7 @@ gettext is correctly installed, and rerun configure.])
     --localedir=$(DESKTOP_I18N_LOCALE_DIR)/share/locale $(DESKTOP_I18N_LANGS)'
 
   DESKTOP_I18N_LANGS_RULE='DESKTOP_I18N_LANGS = $[$](echo "{ printf \"--lang=%s \", \$[$]1 }" \
-    | awk -f - $(DESKTOP_I18N_LOCALE_DIR)/$(DOMAIN).LINGUAS)'
+    | awk -f - $(abs_top_builddir)/$(DOMAIN)/po/LINGUAS)'
 
   DESKTOP_I18N_DESKTOP_RULE='.SUFFIXES: .desktop.in .desktop
 .desktop.in.desktop: ; $(DESKTOP_I18N_CREATE) $< [$]@'


### PR DESCRIPTION
During compilation, I saw warnings like this for years:

awk: fatal: cannot open file `../../.desktop-i18n/libleptongui.LINGUAS' for reading: No such file or directory

It seemed to be harmless to me as nobody reported it is not so until recently.  John Doty (@noqsi) has reported that on one of Debian derivations a like warning breaks compilation.

I'm not aware for sure of what the code I've changed does, just fixed the path to the files `LINGUAS` and the warnings disappeared.