### PR TITLE
Assign Page manager callbacks in Scheme

### DIFF
--- a/libleptongui/include/page_select_widget.h
+++ b/libleptongui/include/page_select_widget.h
@@ -60,7 +60,7 @@ page_select_widget_update (GschemToplevel* w_current);
 void
 schematic_page_select_widget_set_callback (char *name,
                                            GCallback callback);
-void
+LeptonPage*
 pagesel_callback_selection_changed (GtkTreeSelection* selection,
                                     gpointer data);
 GType

--- a/libleptongui/include/page_select_widget.h
+++ b/libleptongui/include/page_select_widget.h
@@ -57,6 +57,9 @@ page_select_widget_update (GschemToplevel* w_current);
 void
 schematic_page_select_widget_set_callback (char *name,
                                            GCallback callback);
+void
+pagesel_callback_selection_changed (GtkTreeSelection* selection,
+                                    gpointer data);
 GType
 page_select_widget_get_type();
 

--- a/libleptongui/include/page_select_widget.h
+++ b/libleptongui/include/page_select_widget.h
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 2012 gEDA Contributors
- * Copyright (C) 2017-2019 Lepton EDA Contributors
+ * Copyright (C) 2017-2022 Lepton EDA Contributors
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -49,15 +49,14 @@ typedef struct _PageSelectWidget      PageSelectWidget;
 G_BEGIN_DECLS
 
 GtkWidget*
-page_select_widget_new (GschemToplevel* w_current,
-                        GCallback page_new_callback,
-                        GCallback page_open_callback,
-                        GCallback page_save_callback,
-                        GCallback page_close_callback);
+page_select_widget_new (GschemToplevel* w_current);
+
 void
 page_select_widget_update (GschemToplevel* w_current);
 
-
+void
+schematic_page_select_widget_set_callback (char *name,
+                                           GCallback callback);
 GType
 page_select_widget_get_type();
 

--- a/libleptongui/include/page_select_widget.h
+++ b/libleptongui/include/page_select_widget.h
@@ -48,6 +48,9 @@ typedef struct _PageSelectWidget      PageSelectWidget;
 
 G_BEGIN_DECLS
 
+GschemToplevel*
+schematic_page_select_widget_get_window (PageSelectWidget* pagesel);
+
 GtkWidget*
 page_select_widget_new (GschemToplevel* w_current);
 

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -637,9 +637,6 @@ LeptonPage*
 x_window_open_page (GschemToplevel *w_current,
                     const gchar *filename);
 void
-x_window_set_current_page (GschemToplevel *w_current,
-                           LeptonPage *page);
-void
 x_window_set_current_page_impl (GschemToplevel *w_current,
                                 LeptonPage *page);
 gint

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -637,8 +637,8 @@ LeptonPage*
 x_window_open_page (GschemToplevel *w_current,
                     const gchar *filename);
 void
-x_window_set_current_page_impl (GschemToplevel *w_current,
-                                LeptonPage *page);
+x_window_set_current_page (GschemToplevel *w_current,
+                           LeptonPage *page);
 gint
 x_window_save_page (GschemToplevel *w_current,
                     LeptonPage *page,

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -855,8 +855,8 @@ the snap grid size should be set to 100")))
                            (page->pointer (window-open-page! (current-window) #f))
                            %null-pointer)))
       (unless (null-pointer? *dummy-page)
-        (x_window_set_current_page *window *dummy-page)
-        (x_window_set_current_page *window *page_current))
+        (set-window-page! *window *dummy-page)
+        (set-window-page! *window *page_current))
 
       (let ((page-control (lepton_page_get_page_control *page_current))
             (up (lepton_page_get_up *page_current)))
@@ -878,14 +878,14 @@ the snap grid size should be set to 100")))
           (lepton_page_set_page_control *page page-control)
           (lepton_page_set_up *page up)
 
-          (x_window_set_current_page *window *page)
+          (set-window-page! *window *page)
 
           ;; Close dummy page, if it exists.
           (unless (null-pointer? *dummy-page)
-            (x_window_set_current_page *window *dummy-page)
+            (set-window-page! *window *dummy-page)
             (window-close-page! (current-window)
                                 (pointer->page *dummy-page))
-            (x_window_set_current_page *window *page))
+            (set-window-page! *window *page))
 
           (when (true? (x_tabs_enabled))
             ;; Page hierarchy info was changed after the page is
@@ -919,7 +919,7 @@ the snap grid size should be set to 100")))
 
   (let ((found-page (find-page next-pages)))
     (when found-page
-      (x_window_set_current_page *window (page->pointer found-page)))))
+      (set-window-page! *window (page->pointer found-page)))))
 
 ;;; Search for a page preceding a given page in hierarchy.
 (define-action-public (&page-prev #:label (G_ "Previous Page") #:icon "gtk-go-back")
@@ -1135,7 +1135,7 @@ the snap grid size should be set to 100")))
               ;; Tabbed GUI is used.  Create a tab for every
               ;; subpage loaded.  Zoom will be set in
               ;; x_tabs_page_set_cur().
-              (x_window_set_current_page *window *child)
+              (set-window-page! *window *child)
               ;; s_hierarchy_down_schematic_single() does not zoom
               ;; the loaded page, so zoom it here.
               (zoom-child-page *window *parent *child))
@@ -1186,7 +1186,7 @@ the snap grid size should be set to 100")))
        (unless (null? pages)
          ;; If the list of resulting pages is not empty, make the
          ;; first page active.
-         (x_window_set_current_page *window (car pages)))))
+         (set-window-page! *window (car pages)))))
     (_ (schematic-message-dialog (G_ "Please first select a component!")))))
 
 
@@ -1245,8 +1245,8 @@ the snap grid size should be set to 100")))
 
                ;; Get active page once again, it should now be the symbol
                ;; page.
-               (x_window_set_current_page *window
-                                          (schematic_window_get_active_page *window))
+               (set-window-page! *window
+                                 (schematic_window_get_active_page *window))
 
                ;; s_hierarchy_down_symbol() will not zoom the loaded page.
                ;; Tabbed GUI: zoom is set in x_tabs_page_set_cur().
@@ -1276,7 +1276,7 @@ the snap grid size should be set to 100")))
                       ;; really close it.
                       (true? (x_dialog_close_changed_page *window *page)))
               (window-close-page! (current-window) (active-page))
-              (x_window_set_current_page *window *upper-page)))))))
+              (set-window-page! *window *upper-page)))))))
 
 
 ;; -------------------------------------------------------------------

--- a/libleptongui/scheme/schematic/callback.scm
+++ b/libleptongui/scheme/schematic/callback.scm
@@ -57,7 +57,7 @@
     (if (null-pointer? *page)
         (error (G_ "Could not create a new page."))
         (begin
-          (x_window_set_current_page *window *page)
+          (set-window-page! *window *page)
           (log! 'message
                 (G_ "New page created: ~S")
                 (pointer->string (lepton_page_get_filename *page)))))))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -172,7 +172,7 @@
             x_window_open_page
             x_window_save_page
             *x_window_select_object
-            x_window_set_current_page_impl
+            x_window_set_current_page
             x_window_setup_draw_events_drawing_area
             x_window_setup_draw_events_main_wnd
             x_window_untitled_page
@@ -613,7 +613,7 @@
 (define-lff x_window_open_page '* '(* *))
 (define-lff x_window_save_page int '(* * *))
 (define-lfc *x_window_select_object)
-(define-lff x_window_set_current_page_impl void '(* *))
+(define-lff x_window_set_current_page void '(* *))
 (define-lff x_window_setup_draw_events_drawing_area void '(* *))
 (define-lff x_window_setup_draw_events_main_wnd void '(* *))
 (define-lff x_window_untitled_page int '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -172,7 +172,6 @@
             x_window_open_page
             x_window_save_page
             *x_window_select_object
-            x_window_set_current_page
             x_window_set_current_page_impl
             x_window_setup_draw_events_drawing_area
             x_window_setup_draw_events_main_wnd
@@ -614,7 +613,6 @@
 (define-lff x_window_open_page '* '(* *))
 (define-lff x_window_save_page int '(* * *))
 (define-lfc *x_window_select_object)
-(define-lff x_window_set_current_page void '(* *))
 (define-lff x_window_set_current_page_impl void '(* *))
 (define-lff x_window_setup_draw_events_drawing_area void '(* *))
 (define-lff x_window_setup_draw_events_main_wnd void '(* *))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -103,6 +103,7 @@
 
             page_select_widget_new
             page_select_widget_update
+            schematic_page_select_widget_set_callback
 
             s_attrib_free
 
@@ -417,7 +418,8 @@
 
 ;;; page_select_widget.c
 (define-lff page_select_widget_update void '(*))
-(define-lff page_select_widget_new '* '(* * * * *))
+(define-lff page_select_widget_new '* '(*))
+(define-lff schematic_page_select_widget_set_callback void '(* *))
 
 ;;; o_buffer.c
 (define-lff o_buffer_init void '())

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -104,6 +104,7 @@
             page_select_widget_new
             page_select_widget_update
             schematic_page_select_widget_set_callback
+            *pagesel_callback_selection_changed
 
             s_attrib_free
 
@@ -420,6 +421,7 @@
 (define-lff page_select_widget_update void '(*))
 (define-lff page_select_widget_new '* '(*))
 (define-lff schematic_page_select_widget_set_callback void '(* *))
+(define-lfc *pagesel_callback_selection_changed)
 
 ;;; o_buffer.c
 (define-lff o_buffer_init void '())

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -103,8 +103,9 @@
 
             page_select_widget_new
             page_select_widget_update
+            schematic_page_select_widget_get_window
             schematic_page_select_widget_set_callback
-            *pagesel_callback_selection_changed
+            pagesel_callback_selection_changed
 
             s_attrib_free
 
@@ -420,8 +421,9 @@
 ;;; page_select_widget.c
 (define-lff page_select_widget_update void '(*))
 (define-lff page_select_widget_new '* '(*))
+(define-lff schematic_page_select_widget_get_window '* '(*))
 (define-lff schematic_page_select_widget_set_callback void '(* *))
-(define-lfc *pagesel_callback_selection_changed)
+(define-lff pagesel_callback_selection_changed '* '(* *))
 
 ;;; o_buffer.c
 (define-lff o_buffer_init void '())

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -217,7 +217,7 @@ the new or found page."
   (define (open-new-page *tab-info)
     (let ((*page (x_window_open_page *window *filename)))
       (schematic_tab_info_set_page *tab-info *page)
-      (x_window_set_current_page_impl *window *page)
+      (x_window_set_current_page *window *page)
 
       (setup-tab-header *tab-info)
       (grab-focus *tab-info)
@@ -335,7 +335,7 @@ the new or found page."
   "Changes page in the active page view of *WINDOW to *PAGE."
   (if (true? (x_tabs_enabled))
       (x_tabs_page_set_cur *window *page)
-      (x_window_set_current_page_impl *window *page)))
+      (x_window_set_current_page *window *page)))
 
 
 (define (callback-tab-button-close *button *tab-info)

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -388,6 +388,18 @@ the new or found page."
   (procedure->pointer void callback-tab-button-up '(* *)))
 
 
+(define (callback-page-manager-selection-changed *selection *widget)
+  (define *page
+    (pagesel_callback_selection_changed *selection *widget))
+
+  (x_window_set_current_page
+   (schematic_page_select_widget_get_window *widget) *page))
+
+
+(define *callback-page-manager-selection-changed
+  (procedure->pointer void callback-page-manager-selection-changed '(* *)))
+
+
 (define (make-schematic-window *app *toplevel)
   "Creates a new lepton-schematic window.  APP is a pointer to the
 GtkApplication structure of the program (when compiled with
@@ -498,7 +510,7 @@ GtkApplication structure of the program (when compiled with
       (schematic_page_select_widget_set_callback (string->pointer "page-close")
                                                  *callback-page-close)
       (schematic_page_select_widget_set_callback (string->pointer "selection-changed")
-                                                 *pagesel_callback_selection_changed)
+                                                 *callback-page-manager-selection-changed)
       (schematic_window_set_page_select_widget *window
                                                (page_select_widget_new *window))
 

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -57,6 +57,7 @@
             snap-point
             window-close-page!
             window-open-page!
+            set-window-page!
             window-set-current-page!)
 
   ;; Overrides the close-page! procedure in the (lepton page)
@@ -330,6 +331,13 @@ the new or found page."
             (x_tabs_page_set_cur *window *new-current-page))))))
 
 
+(define (set-window-page! *window *page)
+  "Changes page in the active page view of *WINDOW to *PAGE."
+  (if (true? (x_tabs_enabled))
+      (x_tabs_page_set_cur *window *page)
+      (x_window_set_current_page_impl *window *page)))
+
+
 (define (callback-tab-button-close *button *tab-info)
   (if (null-pointer? *tab-info)
       (error "NULL TabInfo pointer.")
@@ -392,7 +400,7 @@ the new or found page."
   (define *page
     (pagesel_callback_selection_changed *selection *widget))
 
-  (x_window_set_current_page
+  (set-window-page!
    (schematic_page_select_widget_get_window *widget) *page))
 
 
@@ -547,7 +555,7 @@ window to PAGE.  Returns PAGE."
 
   (define *page (check-page page 1))
 
-  (x_window_set_current_page *window *page)
+  (set-window-page! *window *page)
   page)
 
 
@@ -577,10 +585,10 @@ window to PAGE.  Returns PAGE."
       ;; If the page is not active, make it active and close, then
       ;; switch back to the previously active page.
       (begin
-        (x_window_set_current_page *window *page)
+        (set-window-page! *window *page)
         (window-close-page! (current-window)
                              (pointer->page (schematic_window_get_active_page *window)))
-        (x_window_set_current_page *window *active_page)))
+        (set-window-page! *window *active_page)))
 
   ;; Return value is unspecified.
   (if #f #f))
@@ -615,7 +623,7 @@ window to PAGE.  Returns PAGE."
   (define *window (check-window window 1))
   (define *page (check-page page 2))
 
-  (x_window_set_current_page *window *page))
+  (set-window-page! *window *page))
 
 
 (define (pointer-position)

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -497,6 +497,8 @@ GtkApplication structure of the program (when compiled with
                                                  *i_callback_file_save)
       (schematic_page_select_widget_set_callback (string->pointer "page-close")
                                                  *callback-page-close)
+      (schematic_page_select_widget_set_callback (string->pointer "selection-changed")
+                                                 *pagesel_callback_selection_changed)
       (schematic_window_set_page_select_widget *window
                                                (page_select_widget_new *window))
 

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -490,11 +490,16 @@ GtkApplication structure of the program (when compiled with
       (schematic_window_set_font_select_widget *window
                                                (font_select_widget_new *window))
       (schematic_window_set_page_select_widget *window
-                                               (page_select_widget_new *window
-                                                                       *callback-file-new
-                                                                       *callback-file-open
-                                                                       *i_callback_file_save
-                                                                       *callback-page-close))
+                                               (page_select_widget_new *window))
+      (schematic_page_select_widget_set_callback (string->pointer "file-new")
+                                                 *callback-file-new)
+      (schematic_page_select_widget_set_callback (string->pointer "file-open")
+                                                 *callback-file-open)
+      (schematic_page_select_widget_set_callback (string->pointer "file-save")
+                                                 *i_callback_file_save)
+      (schematic_page_select_widget_set_callback (string->pointer "page-close")
+                                                 *callback-page-close)
+
       ;; Setup layout of notebooks.
       (schematic_window_create_notebooks *window *main-box *work-box)
 

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -489,8 +489,6 @@ GtkApplication structure of the program (when compiled with
                                               (color_edit_widget_new *window))
       (schematic_window_set_font_select_widget *window
                                                (font_select_widget_new *window))
-      (schematic_window_set_page_select_widget *window
-                                               (page_select_widget_new *window))
       (schematic_page_select_widget_set_callback (string->pointer "file-new")
                                                  *callback-file-new)
       (schematic_page_select_widget_set_callback (string->pointer "file-open")
@@ -499,6 +497,8 @@ GtkApplication structure of the program (when compiled with
                                                  *i_callback_file_save)
       (schematic_page_select_widget_set_callback (string->pointer "page-close")
                                                  *callback-page-close)
+      (schematic_window_set_page_select_widget *window
+                                               (page_select_widget_new *window))
 
       ;; Setup layout of notebooks.
       (schematic_window_create_notebooks *window *main-box *work-box)

--- a/libleptongui/src/page_select_widget.c
+++ b/libleptongui/src/page_select_widget.c
@@ -63,6 +63,16 @@ static GCallback callback_page_save = NULL;
 static GCallback callback_page_close = NULL;
 static GCallback callback_selection_changed = NULL;
 
+
+GschemToplevel*
+schematic_page_select_widget_get_window (PageSelectWidget* pagesel)
+{
+  g_return_val_if_fail (pagesel != NULL, NULL);
+
+  return pagesel->toplevel_;
+}
+
+
 /*! \brief Create new PageSelectWidget object.
  *  \public
  */

--- a/libleptongui/src/page_select_widget.c
+++ b/libleptongui/src/page_select_widget.c
@@ -66,22 +66,27 @@ static GCallback callback_page_close = NULL;
  *  \public
  */
 GtkWidget*
-page_select_widget_new (GschemToplevel* w_current,
-                        GCallback page_new_callback,
-                        GCallback page_open_callback,
-                        GCallback page_save_callback,
-                        GCallback page_close_callback)
+page_select_widget_new (GschemToplevel* w_current)
 {
   gpointer obj = g_object_new (PAGE_SELECT_WIDGET_TYPE,
                                "toplevel", w_current,
                                NULL);
-  callback_page_new = G_CALLBACK (page_new_callback);
-  callback_page_open = G_CALLBACK (page_open_callback);
-  callback_page_save = G_CALLBACK (page_save_callback);
-  callback_page_close = G_CALLBACK (page_close_callback);
   return GTK_WIDGET (obj);
 }
 
+
+void
+schematic_page_select_widget_set_callback (char *name,
+                                           GCallback callback)
+{
+  g_return_if_fail (name != NULL);
+  g_return_if_fail (callback != NULL);
+
+  if (strcmp (name, "page-close") == 0) {callback_page_close = callback;}
+  else if (strcmp (name, "file-new") == 0) {callback_page_new = callback;}
+  else if (strcmp (name, "file-save") == 0) {callback_page_save = callback;}
+  else if (strcmp (name, "file-open") == 0) {callback_page_open = callback;}
+}
 
 
 /* --------------------------------------------------------

--- a/libleptongui/src/page_select_widget.c
+++ b/libleptongui/src/page_select_widget.c
@@ -61,6 +61,7 @@ static GCallback callback_page_new = NULL;
 static GCallback callback_page_open = NULL;
 static GCallback callback_page_save = NULL;
 static GCallback callback_page_close = NULL;
+static GCallback callback_selection_changed = NULL;
 
 /*! \brief Create new PageSelectWidget object.
  *  \public
@@ -86,6 +87,7 @@ schematic_page_select_widget_set_callback (char *name,
   else if (strcmp (name, "file-new") == 0) {callback_page_new = callback;}
   else if (strcmp (name, "file-save") == 0) {callback_page_save = callback;}
   else if (strcmp (name, "file-open") == 0) {callback_page_open = callback;}
+  else if (strcmp (name, "selection-changed") == 0) {callback_selection_changed = callback;}
 }
 
 
@@ -197,7 +199,7 @@ page_select_widget_update (GschemToplevel* w_current)
 
 /*! \brief "changed" signal handler for GtkTreeSelection object.
  */
-static void
+void
 pagesel_callback_selection_changed (GtkTreeSelection* selection,
                                     gpointer data)
 {
@@ -516,7 +518,7 @@ widget_create (PageSelectWidget* pagesel)
                                GTK_SELECTION_SINGLE);
   g_signal_connect (selection,
                     "changed",
-                    G_CALLBACK (pagesel_callback_selection_changed),
+                    G_CALLBACK (callback_selection_changed),
                     pagesel);
   /*   - first column: page name */
   renderer = GTK_CELL_RENDERER (

--- a/libleptongui/src/page_select_widget.c
+++ b/libleptongui/src/page_select_widget.c
@@ -209,7 +209,7 @@ page_select_widget_update (GschemToplevel* w_current)
 
 /*! \brief "changed" signal handler for GtkTreeSelection object.
  */
-void
+LeptonPage*
 pagesel_callback_selection_changed (GtkTreeSelection* selection,
                                     gpointer data)
 {
@@ -221,7 +221,7 @@ pagesel_callback_selection_changed (GtkTreeSelection* selection,
 
   if (!gtk_tree_selection_get_selected (selection, &model, &iter))
   {
-    return;
+    return NULL;
   }
 
   w_current = pagesel->toplevel_;
@@ -235,10 +235,10 @@ pagesel_callback_selection_changed (GtkTreeSelection* selection,
    * if the newly-selected page is already the current page. */
   if (page == schematic_window_get_active_page (w_current))
   {
-    return;
+    return NULL;
   }
 
-  x_window_set_current_page (w_current, page);
+  return page;
 }
 
 

--- a/libleptongui/src/x_tabs.c
+++ b/libleptongui/src/x_tabs.c
@@ -1228,7 +1228,7 @@ x_tabs_page_on_sel (GtkNotebook* nbook,
   x_tabs_tl_pview_cur_set (w_current, nfo->pview_);
   x_tabs_tl_page_cur_set (w_current, nfo->page_);
 
-  x_window_set_current_page_impl (w_current, nfo->page_);
+  x_window_set_current_page (w_current, nfo->page_);
 
 } /* x_tabs_page_on_sel() */
 

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -1185,27 +1185,6 @@ create_notebook_bottom (GschemToplevel* w_current)
 
 
 
-/*! \brief Changes the current page.
- *
- *  \see x_window_set_current_page_impl()
- *  \see x_tabs_page_set_cur()
- */
-void
-x_window_set_current_page (GschemToplevel* w_current,
-                           LeptonPage* page)
-{
-  if (x_tabs_enabled())
-  {
-    x_tabs_page_set_cur (w_current, page);
-  }
-  else
-  {
-    x_window_set_current_page_impl (w_current, page);
-  }
-}
-
-
-
 /*! \brief Create new blank page.
  *
  * \todo Do further refactoring: this function should be used

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -657,8 +657,8 @@ x_window_open_page (GschemToplevel *w_current,
  *  \param [in] page      The page to become current page.
  */
 void
-x_window_set_current_page_impl (GschemToplevel *w_current,
-                                LeptonPage *page)
+x_window_set_current_page (GschemToplevel *w_current,
+                           LeptonPage *page)
 {
   GschemPageView *page_view = gschem_toplevel_get_current_page_view (w_current);
   g_return_if_fail (page_view != NULL);
@@ -675,7 +675,7 @@ x_window_set_current_page_impl (GschemToplevel *w_current,
   page_select_widget_update (w_current);
   x_multiattrib_update (w_current);
 
-} /* x_window_set_current_page_impl() */
+} /* x_window_set_current_page() */
 
 
 
@@ -832,7 +832,7 @@ x_window_close_page (GschemToplevel *w_current,
     /* change to new_current and update display */
     if (!x_tabs_enabled())
     {
-      x_window_set_current_page_impl (w_current, new_current);
+      x_window_set_current_page (w_current, new_current);
     }
 
   }


### PR DESCRIPTION
- The contents of the function `x_window_set_current_page()` has
  been moved to Scheme thus allowing for working on tabbed and
  non-tabbed GUI code separately.

- Page manager callbacks are now assigned in Scheme.