### PR TITLE
sch2pcb: Rewrite project loading functions in Scheme.

### DIFF
--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -146,9 +146,6 @@ sch2pcb_get_schematics ();
 void
 sch2pcb_extra_gnetlist_list_append (char *arg);
 
-void
-sch2pcb_load_project (const gchar * path);
-
 int
 sch2pcb_get_n_added_ef ();
 

--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -147,9 +147,6 @@ void
 sch2pcb_extra_gnetlist_list_append (char *arg);
 
 void
-sch2pcb_load_extra_project_files (void);
-
-void
 sch2pcb_load_project (const gchar * path);
 
 int

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -42,7 +42,6 @@
             sch2pcb_set_fix_elements
             sch2pcb_set_force_element_files
             sch2pcb_increment_verbose_mode
-            sch2pcb_load_extra_project_files
             sch2pcb_load_project
             sch2pcb_set_m4_pcbdir
             sch2pcb_make_pcb_element_list
@@ -98,7 +97,6 @@
 (define-lff sch2pcb_set_fix_elements void (list int))
 (define-lff sch2pcb_set_force_element_files void (list int))
 (define-lff sch2pcb_increment_verbose_mode void '())
-(define-lff sch2pcb_load_extra_project_files void '())
 (define-lff sch2pcb_load_project void '(*))
 (define-lff sch2pcb_set_m4_pcbdir void '(*))
 (define-lff sch2pcb_make_pcb_element_list void '(*))

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -42,7 +42,6 @@
             sch2pcb_set_fix_elements
             sch2pcb_set_force_element_files
             sch2pcb_increment_verbose_mode
-            sch2pcb_load_project
             sch2pcb_set_m4_pcbdir
             sch2pcb_make_pcb_element_list
             sch2pcb_get_n_PKG_removed_new
@@ -58,6 +57,7 @@
             sch2pcb_get_n_preserved
             sch2pcb_get_n_unknown
             sch2pcb_get_need_PKG_purge
+            sch2pcb_parse_config
             sch2pcb_get_pcb_element_list
             sch2pcb_set_preserve
             sch2pcb_prune_elements
@@ -97,7 +97,6 @@
 (define-lff sch2pcb_set_fix_elements void (list int))
 (define-lff sch2pcb_set_force_element_files void (list int))
 (define-lff sch2pcb_increment_verbose_mode void '())
-(define-lff sch2pcb_load_project void '(*))
 (define-lff sch2pcb_set_m4_pcbdir void '(*))
 (define-lff sch2pcb_make_pcb_element_list void '(*))
 (define-lff sch2pcb_get_n_PKG_removed_new int '())
@@ -113,6 +112,7 @@
 (define-lff sch2pcb_get_n_preserved int '())
 (define-lff sch2pcb_get_n_unknown int '())
 (define-lff sch2pcb_get_need_PKG_purge int '())
+(define-lff sch2pcb_parse_config int '(* *))
 (define-lff sch2pcb_get_pcb_element_list '* '())
 (define-lff sch2pcb_set_preserve void (list int))
 (define-lff sch2pcb_prune_elements void '(* *))

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1698,7 +1698,7 @@ sch2pcb_load_project (const gchar * path)
   f = fopen (path, "r");
   if (!f)
     return;
-  if (verbose)
+  if (sch2pcb_get_verbose_mode () != 0)
     printf ("Reading project file: %s\n", path);
   while (fgets (buf, sizeof (buf), f)) {
     for (s = buf; *s == ' ' || *s == '\t' || *s == '\n'; ++s);

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1710,30 +1710,3 @@ sch2pcb_load_project (const gchar * path)
   }
   fclose (f);
 }
-
-void
-sch2pcb_load_extra_project_files (void)
-{
-  gchar *path;
-  static gboolean done = FALSE;
-
-  if (done)
-    return;
-
-  /* TODO: rename project files ("gsch2pcb") */
-
-  /* TODO: consider linking sch2pcb with liblepton and
-   *       using eda_get_system_config_dirs() here:
-  */
-  sch2pcb_load_project ("/etc/gsch2pcb");
-  sch2pcb_load_project ("/usr/local/etc/gsch2pcb");
-
-  path = g_build_filename (g_get_user_config_dir(),
-                           PACKAGE,
-                           "gsch2pcb",
-                           NULL);
-  sch2pcb_load_project (path);
-  g_free (path);
-
-  done = TRUE;
-}

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1688,25 +1688,3 @@ sch2pcb_parse_config (gchar *config,
 
   return 1;
 }
-
-void
-sch2pcb_load_project (const gchar * path)
-{
-  FILE *f;
-  gchar *s, buf[1024], config[32], arg[768];
-
-  f = fopen (path, "r");
-  if (!f)
-    return;
-  if (sch2pcb_get_verbose_mode () != 0)
-    printf ("Reading project file: %s\n", path);
-  while (fgets (buf, sizeof (buf), f)) {
-    for (s = buf; *s == ' ' || *s == '\t' || *s == '\n'; ++s);
-    if (!*s || *s == '#' || *s == '/' || *s == ';')
-      continue;
-    arg[0] = '\0';
-    sscanf (s, "%31s %767[^\n]", config, arg);
-    sch2pcb_parse_config (config, arg);
-  }
-  fclose (f);
-}

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -17,16 +17,22 @@
 ;;; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 
-(use-modules (srfi srfi-1)
+(use-modules (ice-9 rdelim)
+             (srfi srfi-1)
              (srfi srfi-26)
              (system foreign)
              (lepton ffi boolean)
              (lepton ffi sch2pcb)
+             (lepton file-system)
              (lepton gettext)
              (lepton m4)
              (lepton os)
              (lepton srfi-37)
              (lepton version))
+
+(define-syntax-rule (verbose-format arg ...)
+  (when (> (sch2pcb_get_verbose_mode) 0)
+    (format (current-output-port) arg ...)))
 
 (define %sch2pcb (basename (car (program-arguments))))
 
@@ -55,8 +61,47 @@
 (sch2pcb_set_m4_pcbdir *%pcb-m4-path)
 
 
+(define (string->pair str)
+  (define s (string-trim-both str char-set:whitespace))
+  (define break-pos (string-index s char-set:whitespace))
+  (if break-pos
+      (cons (string-take s break-pos)
+            (string-trim (string-drop s break-pos)
+                         char-set:whitespace))
+      (cons s #f)))
+
+
 (define (load-project-file path)
-  (sch2pcb_load_project (string->pointer path)))
+  (if (file-readable? path)
+      (with-input-from-file path
+        (lambda ()
+          (verbose-format (G_ "Reading project file: ~A\n") path)
+          (let loop ((s (read-line)))
+            (and (not (eof-object? s))
+                 (let ((s (string-trim-both s char-set:whitespace)))
+                   ;; Skip empty lines or lines consisting only of
+                   ;; whitespaces.
+                   (and (not (string-null? s))
+                        (let ((first-char (string-ref s 0)))
+                          ;; Skip comments started with #, ;, or /.
+                          (and (not (char=? first-char #\#))
+                               (not (char=? first-char #\/))
+                               (not (char=? first-char #\;))
+                               (let* ((args (string->pair s))
+                                      (key (car args))
+                                      (value (cdr args))
+                                      (*key (string->pointer key))
+                                      (*value (if value
+                                                  (string->pointer value)
+                                                  (string->pointer ""))))
+                                 (or (sch2pcb_parse_config *key *value)
+                                     (format (current-error-port)
+                                             (G_ "Wrong line in ~S: ~S\n")
+                                             path
+                                             s))))))
+                   (loop (read-line)))))))
+      (when (> (sch2pcb_get_verbose_mode) 0)
+        (format (current-error-port) (G_ "Skip missing or unreadable file: ~A\n") path))))
 
 (define (load-extra-project-files)
   (define (build-filename dir filename)

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -56,19 +56,22 @@
 
 (define %loading-done? #f)
 
+(define (load-project-file path)
+  (sch2pcb_load_project (string->pointer path)))
+
 (define (load-extra-project-files)
   (unless %loading-done?
     ;; TODO: rename project files ("gsch2pcb")
     ;; TODO: consider linking sch2pcb with liblepton and
     ;;       using eda_get_system_config_dirs() here:
 
-    (sch2pcb_load_project (string->pointer "/etc/gsch2pcb"))
-    (sch2pcb_load_project (string->pointer "/usr/local/etc/gsch2pcb"))
+    (load-project-file "/etc/gsch2pcb")
+    (load-project-file "/usr/local/etc/gsch2pcb")
 
     (let ((path (string-append (user-config-dir)
                                file-name-separator-string
                                "gsch2pcb")))
-      (sch2pcb_load_project (string->pointer path)))
+      (load-project-file path))
     (set! %loading-done? #t)))
 
 
@@ -286,7 +289,7 @@ Lepton EDA homepage: <~A>
             (cons op seeds))
           (begin
             (load-extra-project-files)
-            (sch2pcb_load_project (string->pointer op))
+            (load-project-file op)
             seeds)))
     '())))
 

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -227,10 +227,6 @@ Lepton EDA homepage: <~A>
              (lambda (opt name arg seeds)
                (sch2pcb_set_sch_basename (string->pointer arg))
                seeds))
-     (option '("schematics") #t #f
-             (lambda (opt name arg seeds)
-               (sch2pcb_add_multiple_schematics (string->pointer arg))
-               seeds))
      (option '("m4-pcbdir") #t #f
              (lambda (opt name arg seeds)
                (sch2pcb_set_m4_pcbdir (string->pointer arg))

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -54,25 +54,21 @@
 (sch2pcb_set_m4_pcbdir *%pcb-m4-path)
 
 
-(define %loading-done? #f)
-
 (define (load-project-file path)
   (sch2pcb_load_project (string->pointer path)))
 
 (define (load-extra-project-files)
-  (unless %loading-done?
-    ;; TODO: rename project files ("gsch2pcb")
-    ;; TODO: consider linking sch2pcb with liblepton and
-    ;;       using eda_get_system_config_dirs() here:
+  ;; TODO: rename project files ("gsch2pcb")
+  ;; TODO: consider linking sch2pcb with liblepton and
+  ;;       using eda_get_system_config_dirs() here:
 
-    (load-project-file "/etc/gsch2pcb")
-    (load-project-file "/usr/local/etc/gsch2pcb")
+  (load-project-file "/etc/gsch2pcb")
+  (load-project-file "/usr/local/etc/gsch2pcb")
 
-    (let ((path (string-append (user-config-dir)
-                               file-name-separator-string
-                               "gsch2pcb")))
-      (load-project-file path))
-    (set! %loading-done? #t)))
+  (let ((path (string-append (user-config-dir)
+                             file-name-separator-string
+                             "gsch2pcb")))
+    (load-project-file path)))
 
 
 (define (usage)
@@ -288,7 +284,6 @@ Lepton EDA homepage: <~A>
             (sch2pcb_add_schematic (string->pointer op))
             (cons op seeds))
           (begin
-            (load-extra-project-files)
             (load-project-file op)
             seeds)))
     '())))
@@ -433,6 +428,9 @@ Lepton EDA homepage: <~A>
           (format #t "    to update the pin names of all footprints.\n\n")))))
 
 
+;;; Load system and user config files once.
+(load-extra-project-files)
+
 (let ((number-of-args (length (program-arguments))))
   (if (= 1 number-of-args)
       (usage)
@@ -440,7 +438,6 @@ Lepton EDA homepage: <~A>
         ;; Parse command line arguments and set up internal
         ;; variables.
         (parse-command-line)
-        (load-extra-project-files)
         (sch2pcb_add_default_m4_files)
         (if (null-pointer? (sch2pcb_get_schematics))
             (usage)

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -23,6 +23,7 @@
              (lepton ffi sch2pcb)
              (lepton gettext)
              (lepton m4)
+             (lepton os)
              (lepton srfi-37)
              (lepton version))
 
@@ -51,6 +52,24 @@
 (define *%pcb-m4-path (string->pointer %pcb-m4-path))
 (sch2pcb_set_default_m4_pcbdir *%pcb-m4-path)
 (sch2pcb_set_m4_pcbdir *%pcb-m4-path)
+
+
+(define %loading-done? #f)
+
+(define (load-extra-project-files)
+  (unless %loading-done?
+    ;; TODO: rename project files ("gsch2pcb")
+    ;; TODO: consider linking sch2pcb with liblepton and
+    ;;       using eda_get_system_config_dirs() here:
+
+    (sch2pcb_load_project (string->pointer "/etc/gsch2pcb"))
+    (sch2pcb_load_project (string->pointer "/usr/local/etc/gsch2pcb"))
+
+    (let ((path (string-append (user-config-dir)
+                               file-name-separator-string
+                               "gsch2pcb")))
+      (sch2pcb_load_project (string->pointer path)))
+    (set! %loading-done? #t)))
 
 
 (define (usage)
@@ -266,7 +285,7 @@ Lepton EDA homepage: <~A>
             (sch2pcb_add_schematic (string->pointer op))
             (cons op seeds))
           (begin
-            (sch2pcb_load_extra_project_files)
+            (load-extra-project-files)
             (sch2pcb_load_project (string->pointer op))
             seeds)))
     '())))
@@ -418,7 +437,7 @@ Lepton EDA homepage: <~A>
         ;; Parse command line arguments and set up internal
         ;; variables.
         (parse-command-line)
-        (sch2pcb_load_extra_project_files)
+        (load-extra-project-files)
         (sch2pcb_add_default_m4_files)
         (if (null-pointer? (sch2pcb_get_schematics))
             (usage)

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -18,6 +18,7 @@
 
 
 (use-modules (srfi srfi-1)
+             (srfi srfi-26)
              (system foreign)
              (lepton ffi boolean)
              (lepton ffi sch2pcb)
@@ -58,17 +59,14 @@
   (sch2pcb_load_project (string->pointer path)))
 
 (define (load-extra-project-files)
+  (define (build-filename dir filename)
+    (string-append dir file-name-separator-string filename))
+
   ;; TODO: rename project files ("gsch2pcb")
-  ;; TODO: consider linking sch2pcb with liblepton and
-  ;;       using eda_get_system_config_dirs() here:
 
-  (load-project-file "/etc/gsch2pcb")
-  (load-project-file "/usr/local/etc/gsch2pcb")
-
-  (let ((path (string-append (user-config-dir)
-                             file-name-separator-string
-                             "gsch2pcb")))
-    (load-project-file path)))
+  (for-each load-project-file
+            (map (cut build-filename <> "gsch2pcb")
+                 (append (sys-config-dirs) (list (user-config-dir))))))
 
 
 (define (usage)


### PR DESCRIPTION
- Two functions, `sch2pcb_load_project()` and
  `sch2pcb_load_extra_project_files()`, have been rewritten in
  Scheme.
  
- To simplify things a bit, a new syntax for outputting messages
  in verbose mode, `verbose-format()`, has been added.
  
- The option `--schematics` has been removed.  The prerequisites
  for this are as follows:
  
  - The option was not intended to be used in command line, it was
    intended for use only in project files.
  - It is not documented both in program code and in manual.
  - It was introduced only as a convenient way to factor out C code
    that works both with options and project file keys.
  - The current Scheme code for option processing is just a loan
    translation from the code of project file processing function.
  - Having said all this, it is safe to remove it.

- Additional project files are now loaded from Lepton system and
  user configuration directories.  It was a long standing to-do
  mentioned in the code.  Now, standard XDG config directories are
  used for loading "gsch2pcb" files instead of two predefined ones
  (`/etc/gsch2pcb` and `/usr/local/etc/gsch2pcb`) as it was
  previously.

- Extra system and user project files are now loaded once in a
  predefined point of time: just before any other files and before
  processing options.  This should be done this way because the
  files were previously processed once anyway, and it should be
  strongly definite when this happens in the sequence of actions.
