### PR TITLE
Assign page view signals in Scheme.

### DIFF
--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -717,8 +717,7 @@ x_tabs_page_on_reordered (GtkNotebook* nbook,
                           gpointer     data);
 
 GschemPageView*
-x_tabs_pview_create (GschemToplevel* w_current,
-                     LeptonPage*     page,
+x_tabs_pview_create (LeptonPage*     page,
                      GtkWidget*      wtab);
 gboolean
 x_tabs_tl_page_find (GschemToplevel* w_current,

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -717,7 +717,7 @@ x_tabs_page_on_reordered (GtkNotebook* nbook,
                           gpointer     data);
 
 GschemPageView*
-x_tabs_pview_create (LeptonPage*     page,
+x_tabs_pview_create (GschemPageView* pview,
                      GtkWidget*      wtab);
 gboolean
 x_tabs_tl_page_find (GschemToplevel* w_current,

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -677,6 +677,12 @@ x_tabs_cancel_all (GschemToplevel* w_current);
 gboolean x_tabs_enabled();
 
 TabInfo*
+x_tabs_info_add (GschemToplevel* w_current,
+                 gint            ndx,
+                 LeptonPage*     page,
+                 GschemPageView* pview,
+                 GtkWidget*      wtab);
+TabInfo*
 x_tabs_info_cur (GschemToplevel* w_current);
 
 TabInfo*
@@ -691,9 +697,11 @@ void x_tabs_init();
 GtkWidget*
 x_tabs_nbook_create (GschemToplevel* w_current,
                      GtkWidget* work_box);
-TabInfo*
-x_tabs_page_new (GschemToplevel* w_current,
-                 LeptonPage* page);
+gint
+x_tabs_nbook_page_add (GschemToplevel* w_current,
+                       LeptonPage*     page,
+                       GschemPageView* pview,
+                       GtkWidget*      wtab);
 void
 x_tabs_nbook_page_close (GschemToplevel* w_current,
                          LeptonPage* page);
@@ -708,11 +716,19 @@ x_tabs_page_on_reordered (GtkNotebook* nbook,
                           guint        newindex,
                           gpointer     data);
 
+GschemPageView*
+x_tabs_pview_create (GschemToplevel* w_current,
+                     LeptonPage*     page,
+                     GtkWidget*      wtab);
 gboolean
 x_tabs_tl_page_find (GschemToplevel* w_current,
                      LeptonPage* page);
 GschemPageView*
 x_tabs_tl_pview_cur (GschemToplevel* w_current);
+
+void
+x_tabs_tl_pview_cur_set (GschemToplevel* w_current,
+                         GschemPageView* pview);
 
 void x_tabs_next (GschemToplevel* w_current);
 

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -716,8 +716,8 @@ x_tabs_page_on_reordered (GtkNotebook* nbook,
                           guint        newindex,
                           gpointer     data);
 void
-x_tabs_pview_create (GschemPageView* pview,
-                     GtkWidget*      wtab);
+schematic_tabs_add_page_view (GschemPageView* pview,
+                              GtkWidget*      wtab);
 gboolean
 x_tabs_tl_page_find (GschemToplevel* w_current,
                      LeptonPage* page);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -605,9 +605,6 @@ schematic_window_create_menubar (GschemToplevel *w_current,
                                  GtkWidget *main_box,
                                  GtkWidget *menubar);
 void
-schematic_window_set_key_event_callback (gpointer key_event_callback);
-
-void
 schematic_window_create_find_text_widget (GschemToplevel *w_current,
                                           GtkWidget *work_box);
 void

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -698,9 +698,6 @@ void
 x_tabs_nbook_page_close (GschemToplevel* w_current,
                          LeptonPage* page);
 void
-x_tabs_page_set_cur (GschemToplevel* w_current,
-                     LeptonPage* page);
-void
 x_tabs_page_on_sel (GtkNotebook* nbook,
                     GtkWidget*   wtab,
                     guint        ndx,
@@ -710,6 +707,12 @@ x_tabs_page_on_reordered (GtkNotebook* nbook,
                           GtkWidget*   wtab,
                           guint        newindex,
                           gpointer     data);
+
+gboolean
+x_tabs_tl_page_find (GschemToplevel* w_current,
+                     LeptonPage* page);
+GschemPageView*
+x_tabs_tl_pview_cur (GschemToplevel* w_current);
 
 void x_tabs_next (GschemToplevel* w_current);
 

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -715,8 +715,7 @@ x_tabs_page_on_reordered (GtkNotebook* nbook,
                           GtkWidget*   wtab,
                           guint        newindex,
                           gpointer     data);
-
-GschemPageView*
+void
 x_tabs_pview_create (GschemPageView* pview,
                      GtkWidget*      wtab);
 gboolean

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -434,11 +434,25 @@ int x_dialog_validate_attribute(GtkWindow* parent, char *attribute);
 #ifdef ENABLE_GTK3
 gint
 x_event_draw (GschemPageView *widget,
-                cairo_t *cr,
+              cairo_t *cr,
+              GschemToplevel *w_current);
+gint
+x_event_expose (gpointer view,
+                gpointer event,
+                gpointer w_current);
+
+#else /* GTK2 */
+
+gint
+x_event_draw (gpointer view,
+              gpointer cr,
+              gpointer w_current);
+gint
+x_event_expose (GschemPageView *widget,
+                GdkEventExpose *event,
                 GschemToplevel *w_current);
-#else
-gint x_event_expose(GschemPageView *widget, GdkEventExpose *event, GschemToplevel *w_current);
 #endif
+
 gint x_event_button_pressed(GschemPageView *page_view, GdkEventButton *event, GschemToplevel *w_current);
 gint x_event_button_released(GschemPageView *page_view, GdkEventButton *event, GschemToplevel *w_current);
 gint x_event_motion(GschemPageView *page_view, GdkEventMotion *event, GschemToplevel *w_current);

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -1134,7 +1134,7 @@ the snap grid size should be set to 100")))
           (if use-tabs?
               ;; Tabbed GUI is used.  Create a tab for every
               ;; subpage loaded.  Zoom will be set in
-              ;; x_tabs_page_set_cur().
+              ;; set-tab-page!().
               (*window-set-current-page! *window *child)
               ;; s_hierarchy_down_schematic_single() does not zoom
               ;; the loaded page, so zoom it here.
@@ -1249,7 +1249,7 @@ the snap grid size should be set to 100")))
                                           (schematic_window_get_active_page *window))
 
                ;; s_hierarchy_down_symbol() will not zoom the loaded page.
-               ;; Tabbed GUI: zoom is set in x_tabs_page_set_cur().
+               ;; Tabbed GUI: zoom is set in set-tab-page!().
                (unless (true? (x_tabs_enabled))
                  (gschem_page_view_zoom_extents
                   (gschem_toplevel_get_current_page_view *window)

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -228,7 +228,6 @@
             x_tabs_nbook_page_close
             x_tabs_page_on_reordered
             *x_tabs_page_on_sel
-            x_tabs_pview_create
             x_tabs_tl_page_find
             x_tabs_tl_pview_cur
             x_tabs_tl_pview_cur_set
@@ -237,6 +236,7 @@
             schematic_tab_info_get_page_view
             schematic_tab_info_get_tab_widget
             schematic_tab_info_get_window
+            schematic_tabs_add_page_view
             schematic_tabs_set_callback
 
             schematic_action_mode_from_string
@@ -679,7 +679,7 @@
 (define-lff x_tabs_nbook_page_close void '(* *))
 (define-lff x_tabs_page_on_reordered void (list '* '* int '*))
 (define-lfc *x_tabs_page_on_sel)
-(define-lff x_tabs_pview_create void '(* *))
+(define-lff schematic_tabs_add_page_view void '(* *))
 (define-lff x_tabs_tl_page_find int '(* *))
 (define-lff x_tabs_tl_pview_cur '* '(*))
 (define-lff x_tabs_tl_pview_cur_set void '(* *))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -218,16 +218,19 @@
             x_tabs_enabled
             x_tabs_hdr_set
             x_tabs_hdr_update
+            x_tabs_info_add
             x_tabs_info_cur
             x_tabs_info_find_by_page
             x_tabs_info_rm
             x_tabs_nbook_create
+            x_tabs_nbook_page_add
             x_tabs_nbook_page_close
-            x_tabs_page_new
             x_tabs_page_on_reordered
             *x_tabs_page_on_sel
+            x_tabs_pview_create
             x_tabs_tl_page_find
             x_tabs_tl_pview_cur
+            x_tabs_tl_pview_cur_set
             schematic_tab_info_get_page
             schematic_tab_info_set_page
             schematic_tab_info_get_page_view
@@ -663,16 +666,19 @@
 (define-lff x_tabs_enabled int '())
 (define-lff x_tabs_hdr_set void '(* *))
 (define-lff x_tabs_hdr_update void '(* *))
+(define-lff x_tabs_info_add '* (list '* int '* '* '*))
 (define-lff x_tabs_info_cur '* '(*))
 (define-lff x_tabs_info_find_by_page '* '(* *))
 (define-lff x_tabs_info_rm void '(* *))
 (define-lff x_tabs_nbook_create '* '(* *))
+(define-lff x_tabs_nbook_page_add int '(* * * *))
 (define-lff x_tabs_nbook_page_close void '(* *))
-(define-lff x_tabs_page_new '* '(* *))
 (define-lff x_tabs_page_on_reordered void (list '* '* int '*))
 (define-lfc *x_tabs_page_on_sel)
+(define-lff x_tabs_pview_create '* '(* * *))
 (define-lff x_tabs_tl_page_find int '(* *))
 (define-lff x_tabs_tl_pview_cur '* '(*))
+(define-lff x_tabs_tl_pview_cur_set void '(* *))
 (define-lff schematic_tab_info_get_page '* '(*))
 (define-lff schematic_tab_info_set_page void '(* *))
 (define-lff schematic_tab_info_get_page_view '* '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -679,7 +679,7 @@
 (define-lff x_tabs_nbook_page_close void '(* *))
 (define-lff x_tabs_page_on_reordered void (list '* '* int '*))
 (define-lfc *x_tabs_page_on_sel)
-(define-lff x_tabs_pview_create '* '(* *))
+(define-lff x_tabs_pview_create void '(* *))
 (define-lff x_tabs_tl_page_find int '(* *))
 (define-lff x_tabs_tl_pview_cur '* '(*))
 (define-lff x_tabs_tl_pview_cur_set void '(* *))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -224,9 +224,10 @@
             x_tabs_nbook_create
             x_tabs_nbook_page_close
             x_tabs_page_new
-            x_tabs_page_set_cur
             x_tabs_page_on_reordered
             *x_tabs_page_on_sel
+            x_tabs_tl_page_find
+            x_tabs_tl_pview_cur
             schematic_tab_info_get_page
             schematic_tab_info_set_page
             schematic_tab_info_get_page_view
@@ -668,9 +669,10 @@
 (define-lff x_tabs_nbook_create '* '(* *))
 (define-lff x_tabs_nbook_page_close void '(* *))
 (define-lff x_tabs_page_new '* '(* *))
-(define-lff x_tabs_page_set_cur void '(* *))
 (define-lff x_tabs_page_on_reordered void (list '* '* int '*))
 (define-lfc *x_tabs_page_on_sel)
+(define-lff x_tabs_tl_page_find int '(* *))
+(define-lff x_tabs_tl_pview_cur '* '(*))
 (define-lff schematic_tab_info_get_page '* '(*))
 (define-lff schematic_tab_info_set_page void '(* *))
 (define-lff schematic_tab_info_get_page_view '* '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -49,6 +49,7 @@
             i_set_state_msg
             i_show_state
             i_update_grid_info
+            *i_update_grid_info_callback
             i_update_menus
 
             i_vars_set
@@ -183,7 +184,6 @@
             schematic_window_create_menubar
             schematic_toolbar_toggle_tool_button_get_active
             schematic_window_get_inside_action
-            schematic_window_set_key_event_callback
             schematic_window_set_page_select_widget
             schematic_window_create_page_view
             schematic_window_create_find_text_widget
@@ -283,6 +283,7 @@
             gschem_toplevel_get_current_page_view
             gschem_toplevel_get_show_hidden_text
             gschem_toplevel_get_toplevel
+            *gschem_toplevel_notify_page_callback
             gschem_toplevel_page_changed
             gschem_toplevel_page_content_changed
             schematic_window_get_actionfeedback_mode
@@ -363,6 +364,13 @@
 
             x_event_get_pointer_position
             x_event_key
+            *x_event_button_pressed
+            *x_event_button_released
+            *x_event_configure
+            *x_event_draw
+            *x_event_expose
+            *x_event_motion
+            *x_event_scroll
 
             x_fileselect_open
             x_fileselect_save
@@ -535,6 +543,7 @@
 (define-lff gschem_toplevel_get_current_page_view '* '(*))
 (define-lff gschem_toplevel_get_show_hidden_text int '(*))
 (define-lff gschem_toplevel_get_toplevel '* '(*))
+(define-lfc *gschem_toplevel_notify_page_callback)
 (define-lff gschem_toplevel_page_changed void '(*))
 (define-lff gschem_toplevel_page_content_changed void '(* *))
 (define-lff schematic_window_get_actionfeedback_mode int '(*))
@@ -632,7 +641,6 @@
 (define-lff schematic_window_create_menubar void '(* * *))
 (define-lff schematic_toolbar_toggle_tool_button_get_active int '(*))
 (define-lff schematic_window_get_inside_action int '(*))
-(define-lff schematic_window_set_key_event_callback void '(*))
 (define-lff schematic_window_set_page_select_widget void '(* *))
 (define-lff schematic_window_create_page_view '* '(* *))
 (define-lff schematic_window_create_find_text_widget void '(* *))
@@ -721,6 +729,7 @@
 (define-lff i_set_state_msg void (list '* int '*))
 (define-lff i_show_state void '(* *))
 (define-lff i_update_grid_info void '(*))
+(define-lfc *i_update_grid_info_callback)
 (define-lff i_update_menus void '(*))
 
 ;;; i_vars.c
@@ -790,9 +799,14 @@
 
 ;;; x_event.c
 (define-lff x_event_get_pointer_position int (list '* int '* '*))
-
-;;; x_event.c
 (define-lff x_event_key '* '(* * *))
+(define-lfc *x_event_button_pressed)
+(define-lfc *x_event_button_released)
+(define-lfc *x_event_configure)
+(define-lfc *x_event_draw)
+(define-lfc *x_event_expose)
+(define-lfc *x_event_motion)
+(define-lfc *x_event_scroll)
 
 ;;; x_fileselect.c
 (define-lff x_fileselect_open '* '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -268,6 +268,7 @@
 
             gschem_page_view_get_page
             gschem_page_view_invalidate_all
+            gschem_page_view_new_with_page
             gschem_page_view_pan
             gschem_page_view_pan_mouse
             gschem_page_view_zoom_extents
@@ -501,6 +502,7 @@
 ;;; gschem_page_view.c
 (define-lff gschem_page_view_get_page '* '(*))
 (define-lff gschem_page_view_invalidate_all void '(*))
+(define-lff gschem_page_view_new_with_page '* '(*))
 (define-lff gschem_page_view_pan void (list '* int int))
 (define-lff gschem_page_view_pan_mouse void (list '* int int))
 (define-lff gschem_page_view_zoom_extents void '(* *))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -175,6 +175,7 @@
             x_window_set_current_page
             x_window_setup_draw_events_drawing_area
             x_window_setup_draw_events_main_wnd
+            x_window_setup_scrolling
             x_window_untitled_page
             schematic_window_create_app_window
             schematic_window_create_main_box
@@ -620,6 +621,7 @@
 (define-lff x_window_set_current_page void '(* *))
 (define-lff x_window_setup_draw_events_drawing_area void '(* *))
 (define-lff x_window_setup_draw_events_main_wnd void '(* *))
+(define-lff x_window_setup_scrolling void '(* *))
 (define-lff x_window_untitled_page int '(*))
 (define-lff x_window_close_page '* '(* *))
 (define-lff schematic_window_create_app_window '* '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -677,7 +677,7 @@
 (define-lff x_tabs_nbook_page_close void '(* *))
 (define-lff x_tabs_page_on_reordered void (list '* '* int '*))
 (define-lfc *x_tabs_page_on_sel)
-(define-lff x_tabs_pview_create '* '(* * *))
+(define-lff x_tabs_pview_create '* '(* *))
 (define-lff x_tabs_tl_page_find int '(* *))
 (define-lff x_tabs_tl_pview_cur '* '(*))
 (define-lff x_tabs_tl_pview_cur_set void '(* *))

--- a/libleptongui/scheme/schematic/ffi/gtk.scm
+++ b/libleptongui/scheme/schematic/ffi/gtk.scm
@@ -43,7 +43,9 @@
             gtk_menu_shell_append
             gtk_notebook_get_n_pages
             gtk_notebook_page_num
-            gtk_notebook_set_current_page))
+            gtk_notebook_set_current_page
+            gtk_notebook_set_tab_reorderable
+            gtk_scrolled_window_new))
 
 ;;; Simplify definition of functions by omitting the library
 ;;; argument.
@@ -76,8 +78,11 @@
 (define-lff gtk_notebook_get_n_pages int '(*))
 (define-lff gtk_notebook_page_num int '(* *))
 (define-lff gtk_notebook_set_current_page void (list '* int))
+(define-lff gtk_notebook_set_tab_reorderable void (list '* '* int))
 
 (define-lff gtk_rc_parse void '(*))
+
+(define-lff gtk_scrolled_window_new '* '(* *))
 
 (define-lff gtk_tearoff_menu_item_new '* '())
 

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -217,7 +217,7 @@ tab notebook.  Returns a C TabInfo structure."
 
   (x_window_setup_scrolling *window *wtab)
 
-  (let ((*page-view (x_tabs_pview_create *window *page *wtab)))
+  (let ((*page-view (x_tabs_pview_create *page *wtab)))
     (x_window_setup_draw_events_drawing_area *window *page-view)
     (x_tabs_tl_pview_cur_set *window *page-view)
     (let ((page-index (x_tabs_nbook_page_add *window *page *page-view *wtab)))

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -215,6 +215,8 @@
 tab notebook.  Returns a C TabInfo structure."
   (define *wtab (gtk_scrolled_window_new %null-pointer %null-pointer))
 
+  (x_window_setup_scrolling *window *wtab)
+
   (let ((*page-view (x_tabs_pview_create *window *page *wtab)))
     (x_window_setup_draw_events_drawing_area *window *page-view)
     (x_tabs_tl_pview_cur_set *window *page-view)

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -207,10 +207,23 @@
    (schematic_tab_info_get_page_view *tab-info)))
 
 
+;;; After calling this function it may be necessary to wait to let
+;;; page view creation to complete.  See process-pending-events()
+;;; above.
 (define (tab-add-page! *window *page)
   "Creates a new page view for *PAGE in *WINDOW and adds it to the
 tab notebook.  Returns a C TabInfo structure."
-  (x_tabs_page_new *window *page))
+  (define *wtab (gtk_scrolled_window_new %null-pointer %null-pointer))
+
+  (let ((*page-view (x_tabs_pview_create *window *page *wtab)))
+    (x_tabs_tl_pview_cur_set *window *page-view)
+    (let ((page-index (x_tabs_nbook_page_add *window *page *page-view *wtab)))
+
+      (gtk_notebook_set_tab_reorderable (schematic_window_get_tab_notebook *window)
+                                        *wtab
+                                        TRUE)
+      ;; Return TabInfo.
+      (x_tabs_info_add *window page-index *page *page-view *wtab))))
 
 
 (define (open-tab! *window *filename)

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -207,6 +207,12 @@
    (schematic_tab_info_get_page_view *tab-info)))
 
 
+(define (tab-add-page! *window *page)
+  "Creates a new page view for *PAGE in *WINDOW and adds it to the
+tab notebook.  Returns a C TabInfo structure."
+  (x_tabs_page_new *window *page))
+
+
 (define (open-tab! *window *filename)
   "Creates a new page, page view and tab for *FILENAME in *WINDOW.
 If *FILENAME is %null-pointer, the page will be blank.  If there
@@ -271,7 +277,7 @@ the new or found page."
                   (x_tabs_cancel_all *window)
 
                   ;; Create a new tab with a new page.
-                  (open-new-page (x_tabs_page_new *window %null-pointer)))
+                  (open-new-page (tab-add-page! *window %null-pointer)))
 
                 ;; If the page exists, switch to its existing
                 ;; page view.
@@ -324,7 +330,7 @@ for *PAGE page will be created and set active."
         ;; There is no page view for *PAGE, create a new one.
         (when (and (null-pointer? *tab-info)
                    (true? (x_tabs_tl_page_find *window *page)))
-          (let ((*tab-info (x_tabs_page_new *window *page)))
+          (let ((*tab-info (tab-add-page! *window *page)))
 
             (x_tabs_hdr_set (schematic_window_get_tab_notebook *window) *tab-info)
             (gtk_notebook_set_current_page (schematic_window_get_tab_notebook *window)
@@ -367,8 +373,8 @@ for *PAGE page will be created and set active."
 
         (if (null-pointer? *new-current-page)
             (begin
-              (x_tabs_page_new *window %null-pointer)
-              ;;  x_tabs_page_new() just invoked, but no need to process
+              (tab-add-page! *window %null-pointer)
+              ;;  tab-add-page!() just invoked, but no need to process
               ;;  pending events here: it will be done in x_tabs_page_open()
               (open-tab! *window %null-pointer))
             (set-tab-page! *window *new-current-page))))))
@@ -516,7 +522,7 @@ GtkApplication structure of the program (when compiled with
                                       (string->pointer "page-reordered")
                                       *callback-page-reordered
                                       *window)
-            (x_tabs_page_new *window %null-pointer))
+            (tab-add-page! *window %null-pointer))
 
           (let ((*page-view (schematic_window_create_page_view *window *work-box)))
             ;; Setup callbacks for page view draw events.

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -218,7 +218,7 @@ tab notebook.  Returns a C TabInfo structure."
   (x_window_setup_scrolling *window *wtab)
 
   (let ((*page-view (gschem_page_view_new_with_page *page)))
-    (x_tabs_pview_create *page-view *wtab)
+    (schematic_tabs_add_page_view *page-view *wtab)
     (x_window_setup_draw_events_drawing_area *window *page-view)
     (x_tabs_tl_pview_cur_set *window *page-view)
     (let ((page-index (x_tabs_nbook_page_add *window *page *page-view *wtab)))

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -296,6 +296,10 @@ the new or found page."
         *page)))
 
 
+(define (set-tab-page! *window *page)
+  (x_tabs_page_set_cur *window *page))
+
+
 ;;; Closes the tab of *WINDOW which contains *PAGE.  When the last
 ;;; tab is closed, a new tab with blank page will be opened.
 (define (close-tab! *window *page)
@@ -328,7 +332,7 @@ the new or found page."
               ;;  x_tabs_page_new() just invoked, but no need to process
               ;;  pending events here: it will be done in x_tabs_page_open()
               (open-tab! *window %null-pointer))
-            (x_tabs_page_set_cur *window *new-current-page))))))
+            (set-tab-page! *window *new-current-page))))))
 
 
 (define (callback-tab-button-close *button *tab-info)
@@ -336,7 +340,7 @@ the new or found page."
       (error "NULL TabInfo pointer.")
       (let ((*window (schematic_tab_info_get_window *tab-info))
             (*page (schematic_tab_info_get_page *tab-info)))
-        (x_tabs_page_set_cur *window *page)
+        (set-tab-page! *window *page)
 
         (unless (and (true? (lepton_page_get_changed *page))
                      (not (true? (x_dialog_close_changed_page *window *page))))
@@ -353,7 +357,7 @@ the new or found page."
   (let ((*window (schematic_tab_info_get_window *tab-info))
         (*page (schematic_tab_info_get_page *tab-info)))
 
-    (x_tabs_page_set_cur *window *page)
+    (set-tab-page! *window *page)
     (i_callback_file_save %null-pointer *window)))
 
 
@@ -374,7 +378,7 @@ the new or found page."
           (unless (and (true? (lepton_page_get_changed *page))
                        (not (true? (x_dialog_close_changed_page *window *page))))
             (close-tab! *window *page)
-            (x_tabs_page_set_cur *window *parent))))))
+            (set-tab-page! *window *parent))))))
 
 
 (define (callback-tab-button-up *button *tab-info)
@@ -382,7 +386,7 @@ the new or found page."
       (error "NULL TabInfo pointer.")
       (let ((*window (schematic_tab_info_get_window *tab-info))
             (*page (schematic_tab_info_get_page *tab-info)))
-        (x_tabs_page_set_cur *window *page)
+        (set-tab-page! *window *page)
         (hierarchy-up *window))))
 
 (define *callback-tab-button-up

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -207,6 +207,10 @@
    (schematic_tab_info_get_page_view *tab-info)))
 
 
+(define (setup-page-view-draw-events *window *page-view)
+  (x_window_setup_draw_events_drawing_area *window *page-view))
+
+
 ;;; After calling this function it may be necessary to wait to let
 ;;; page view creation to complete.  See process-pending-events()
 ;;; above.
@@ -219,7 +223,7 @@ tab notebook.  Returns a C TabInfo structure."
 
   (let ((*page-view (gschem_page_view_new_with_page *page)))
     (schematic_tabs_add_page_view *page-view *wtab)
-    (x_window_setup_draw_events_drawing_area *window *page-view)
+    (setup-page-view-draw-events *window *page-view)
     (x_tabs_tl_pview_cur_set *window *page-view)
     (let ((page-index (x_tabs_nbook_page_add *window *page *page-view *wtab)))
 
@@ -543,7 +547,7 @@ GtkApplication structure of the program (when compiled with
 
           (let ((*page-view (schematic_window_create_page_view *window *work-box)))
             ;; Setup callbacks for page view draw events.
-            (x_window_setup_draw_events_drawing_area *window *page-view)))
+            (setup-page-view-draw-events *window *page-view)))
 
 
       ;; Setup callbacks for main window draw events.

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -216,6 +216,7 @@ tab notebook.  Returns a C TabInfo structure."
   (define *wtab (gtk_scrolled_window_new %null-pointer %null-pointer))
 
   (let ((*page-view (x_tabs_pview_create *window *page *wtab)))
+    (x_window_setup_draw_events_drawing_area *window *page-view)
     (x_tabs_tl_pview_cur_set *window *page-view)
     (let ((page-index (x_tabs_nbook_page_add *window *page *page-view *wtab)))
 

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -217,7 +217,8 @@ tab notebook.  Returns a C TabInfo structure."
 
   (x_window_setup_scrolling *window *wtab)
 
-  (let ((*page-view (x_tabs_pview_create *page *wtab)))
+  (let ((*page-view (x_tabs_pview_create (gschem_page_view_new_with_page *page)
+                                         *wtab)))
     (x_window_setup_draw_events_drawing_area *window *page-view)
     (x_tabs_tl_pview_cur_set *window *page-view)
     (let ((page-index (x_tabs_nbook_page_add *window *page *page-view *wtab)))

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -217,8 +217,8 @@ tab notebook.  Returns a C TabInfo structure."
 
   (x_window_setup_scrolling *window *wtab)
 
-  (let ((*page-view (x_tabs_pview_create (gschem_page_view_new_with_page *page)
-                                         *wtab)))
+  (let ((*page-view (gschem_page_view_new_with_page *page)))
+    (x_tabs_pview_create *page-view *wtab)
     (x_window_setup_draw_events_drawing_area *window *page-view)
     (x_tabs_tl_pview_cur_set *window *page-view)
     (let ((page-index (x_tabs_nbook_page_add *window *page *page-view *wtab)))

--- a/libleptongui/src/x_event.c
+++ b/libleptongui/src/x_event.c
@@ -52,7 +52,29 @@ x_event_draw (GschemPageView *view,
   return(0);
 }
 
+
+/* Dummy function for making Scheme happy. */
+gint
+x_event_expose (gpointer view,
+                gpointer event,
+                gpointer w_current)
+{
+  return(0);
+}
+
+
 #else /* GTK2 */
+
+
+/* Dummy function for making Scheme happy. */
+gint
+x_event_draw (gpointer view,
+              gpointer cr,
+              gpointer w_current)
+{
+  return(0);
+}
+
 
 /*! \brief Redraws the view when widget is exposed.
  *

--- a/libleptongui/src/x_tabs.c
+++ b/libleptongui/src/x_tabs.c
@@ -1136,7 +1136,7 @@ x_tabs_page_set_cur (GschemToplevel* w_current,
   printf( "x_tabs_page_set_cur()\n" );
 #endif
 
-  TabInfo* nfo = x_tabs_info_find_by_page (w_current->xtabs_info_list, page);
+  TabInfo* nfo = x_tabs_info_find_by_page (schematic_window_get_tab_info_list (w_current), page);
 
   gint ndx = -1;
 
@@ -1150,11 +1150,12 @@ x_tabs_page_set_cur (GschemToplevel* w_current,
     printf( "    x_tabs_page_set_cur(): #3: [pview] [page] \n\n" );
 #endif
 
-    ndx = gtk_notebook_page_num (w_current->xtabs_nbook, nfo->wtab_);
+    ndx = gtk_notebook_page_num (schematic_window_get_tab_notebook (w_current),
+                                 schematic_tab_info_get_tab_widget (nfo));
     g_return_if_fail (ndx >= 0);
 
-    gtk_notebook_set_current_page (w_current->xtabs_nbook, ndx);
-    gtk_widget_grab_focus (GTK_WIDGET (nfo->pview_));
+    gtk_notebook_set_current_page (schematic_window_get_tab_notebook (w_current), ndx);
+    schematic_page_view_grab_focus (schematic_tab_info_get_page_view (nfo));
   }
 
   else
@@ -1169,9 +1170,9 @@ x_tabs_page_set_cur (GschemToplevel* w_current,
 
       nfo = x_tabs_page_new (w_current, page);
 
-      x_tabs_hdr_set (w_current->xtabs_nbook, nfo);
-      gtk_notebook_set_current_page (w_current->xtabs_nbook, ndx);
-      gtk_widget_grab_focus (GTK_WIDGET (nfo->pview_));
+      x_tabs_hdr_set (schematic_window_get_tab_notebook (w_current), nfo);
+      gtk_notebook_set_current_page (schematic_window_get_tab_notebook (w_current), ndx);
+      schematic_page_view_grab_focus (schematic_tab_info_get_page_view (nfo));
 
       /* x_tabs_page_new() just invoked,
        * let page view creation complete -

--- a/libleptongui/src/x_tabs.c
+++ b/libleptongui/src/x_tabs.c
@@ -564,8 +564,7 @@ x_tabs_nbook_page_close (GschemToplevel* w_current,
 
 
 GschemPageView*
-x_tabs_pview_create (GschemToplevel* w_current,
-                     LeptonPage*     page,
+x_tabs_pview_create (LeptonPage*     page,
                      GtkWidget*      wtab)
 {
 #ifdef DEBUG

--- a/libleptongui/src/x_tabs.c
+++ b/libleptongui/src/x_tabs.c
@@ -155,13 +155,6 @@ x_tabs_init()
 
 /* tab info: */
 
-static TabInfo*
-x_tabs_info_add (GschemToplevel* w_current,
-                 gint            ndx,
-                 LeptonPage*     page,
-                 GschemPageView* pview,
-                 GtkWidget*      wtab);
-
 static gint
 x_tabs_info_cmp_page (gconstpointer elem, gconstpointer data);
 
@@ -188,17 +181,9 @@ static void
 x_tabs_tl_page_cur_set (GschemToplevel* w_current,
                         LeptonPage* page);
 
-static void
-x_tabs_tl_pview_cur_set (GschemToplevel* w_current, GschemPageView* pview);
-
 
 /* notebook: */
 
-static gint
-x_tabs_nbook_page_add (GschemToplevel* w_current,
-                       LeptonPage*     page,
-                       GschemPageView* pview,
-                       GtkWidget*      wtab);
 static gboolean
 x_tabs_hdr_on_mouse_click (GtkWidget* hdr, GdkEvent* e, gpointer data);
 static GtkMenu*
@@ -225,25 +210,6 @@ static void
 x_tabs_menu_action_on_activate (GtkAction* action,
                                 gpointer data);
 #endif
-
-
-
-/* page view: */
-
-static GschemPageView*
-x_tabs_pview_create (GschemToplevel* w_current,
-                     LeptonPage*     page,
-                     GtkWidget**     ppwtab);
-
-/*
- *
- * NOTE: for now: nop
- *
- * static void
- * x_tabs_pview_rm (GschemPageView* pview);
- *
-*/
-
 
 
 /* tab header widget: */
@@ -290,7 +256,7 @@ x_tabs_info_cur (GschemToplevel* w_current)
 
 
 
-static TabInfo*
+TabInfo*
 x_tabs_info_add (GschemToplevel* w_current,
                  gint            ndx,
                  LeptonPage*     page,
@@ -447,7 +413,7 @@ x_tabs_tl_pview_cur (GschemToplevel* w_current)
 
 
 
-static void
+void
 x_tabs_tl_pview_cur_set (GschemToplevel* w_current, GschemPageView* pview)
 {
   w_current->drawing_area = GTK_WIDGET (pview);
@@ -551,7 +517,7 @@ x_tabs_nbook_create (GschemToplevel* w_current,
 
 
 
-static gint
+gint
 x_tabs_nbook_page_add (GschemToplevel* w_current,
                        LeptonPage*     page,
                        GschemPageView* pview,
@@ -597,17 +563,14 @@ x_tabs_nbook_page_close (GschemToplevel* w_current,
  */
 
 
-static GschemPageView*
+GschemPageView*
 x_tabs_pview_create (GschemToplevel* w_current,
                      LeptonPage*     page,
-                     GtkWidget**     ppwtab)
+                     GtkWidget*      wtab)
 {
 #ifdef DEBUG
   printf( "x_tabs_pview_create(): page: %p\n", page );
 #endif
-
-  *ppwtab = gtk_scrolled_window_new (NULL, NULL);
-  GtkWidget* wtab = *ppwtab;
 
   x_window_setup_scrolling (w_current, wtab);
 
@@ -1066,42 +1029,6 @@ x_tabs_prev (GschemToplevel* w_current)
 
   gtk_notebook_prev_page (w_current->xtabs_nbook);
 }
-
-
-
-/*! \brief Creates page view, TabInfo, adds a tab to the notebook.
- *
- *  \par Function Description
- *  After calling this function it may be necessary to
- *  wait to let page view creation to complete, for example:
- *
- *  while ( gtk_events_pending() )
- *  {
- *      gtk_main_iteration();
- *  }
- *
- *  \param  [in] w_current  The toplevel environment.
- *  \param  [in] page       The page.
- *  \return                 A pointer to the new TabInfo structure.
- */
-TabInfo*
-x_tabs_page_new (GschemToplevel* w_current,
-                 LeptonPage* page)
-{
-#ifdef DEBUG
-  printf( "x_tabs_new_page(): page: %p\n", page);
-#endif
-
-  GtkWidget* wtab = NULL;
-  GschemPageView* pview = x_tabs_pview_create (w_current, page, &wtab);
-  x_tabs_tl_pview_cur_set (w_current, pview);
-  gint ndx = x_tabs_nbook_page_add (w_current, page, pview, wtab);
-
-  gtk_notebook_set_tab_reorderable (schematic_window_get_tab_notebook (w_current), wtab, TRUE);
-
-  return x_tabs_info_add (w_current, ndx, page, pview, wtab);
-
-} /* x_tabs_page_new() */
 
 
 

--- a/libleptongui/src/x_tabs.c
+++ b/libleptongui/src/x_tabs.c
@@ -564,8 +564,8 @@ x_tabs_nbook_page_close (GschemToplevel* w_current,
 
 
 void
-x_tabs_pview_create (GschemPageView* pview,
-                     GtkWidget*      wtab)
+schematic_tabs_add_page_view (GschemPageView* pview,
+                              GtkWidget*      wtab)
 {
 #ifdef ENABLE_GTK3
   gtk_widget_set_hexpand (GTK_WIDGET (pview), TRUE);
@@ -579,7 +579,7 @@ x_tabs_pview_create (GschemPageView* pview,
 
   gtk_widget_set_can_focus (GTK_WIDGET (pview), TRUE);
 
-} /* x_tabs_pview_create() */
+} /* schematic_tabs_add_page_view() */
 
 
 

--- a/libleptongui/src/x_tabs.c
+++ b/libleptongui/src/x_tabs.c
@@ -583,17 +583,6 @@ schematic_tabs_add_page_view (GschemPageView* pview,
 
 
 
-/*
-*
-* static void
-* x_tabs_pview_rm (GschemPageView* pview)
-* {
-* }
-*
-*/
-
-
-
 
 /* --------------------------------------------------------
  *

--- a/libleptongui/src/x_tabs.c
+++ b/libleptongui/src/x_tabs.c
@@ -572,8 +572,6 @@ x_tabs_pview_create (GschemToplevel* w_current,
   printf( "x_tabs_pview_create(): page: %p\n", page );
 #endif
 
-  x_window_setup_scrolling (w_current, wtab);
-
   GschemPageView* pview = gschem_page_view_new_with_page (page);
 
 #ifdef ENABLE_GTK3

--- a/libleptongui/src/x_tabs.c
+++ b/libleptongui/src/x_tabs.c
@@ -1097,7 +1097,7 @@ x_tabs_page_new (GschemToplevel* w_current,
   x_tabs_tl_pview_cur_set (w_current, pview);
   gint ndx = x_tabs_nbook_page_add (w_current, page, pview, wtab);
 
-  gtk_notebook_set_tab_reorderable (w_current->xtabs_nbook, wtab, TRUE);
+  gtk_notebook_set_tab_reorderable (schematic_window_get_tab_notebook (w_current), wtab, TRUE);
 
   return x_tabs_info_add (w_current, ndx, page, pview, wtab);
 

--- a/libleptongui/src/x_tabs.c
+++ b/libleptongui/src/x_tabs.c
@@ -563,7 +563,7 @@ x_tabs_nbook_page_close (GschemToplevel* w_current,
  */
 
 
-GschemPageView*
+void
 x_tabs_pview_create (GschemPageView* pview,
                      GtkWidget*      wtab)
 {
@@ -578,8 +578,6 @@ x_tabs_pview_create (GschemPageView* pview,
   gtk_widget_show_all (wtab);
 
   gtk_widget_set_can_focus (GTK_WIDGET (pview), TRUE);
-
-  return pview;
 
 } /* x_tabs_pview_create() */
 

--- a/libleptongui/src/x_tabs.c
+++ b/libleptongui/src/x_tabs.c
@@ -564,15 +564,9 @@ x_tabs_nbook_page_close (GschemToplevel* w_current,
 
 
 GschemPageView*
-x_tabs_pview_create (LeptonPage*     page,
+x_tabs_pview_create (GschemPageView* pview,
                      GtkWidget*      wtab)
 {
-#ifdef DEBUG
-  printf( "x_tabs_pview_create(): page: %p\n", page );
-#endif
-
-  GschemPageView* pview = gschem_page_view_new_with_page (page);
-
 #ifdef ENABLE_GTK3
   gtk_widget_set_hexpand (GTK_WIDGET (pview), TRUE);
   gtk_widget_set_vexpand (GTK_WIDGET (pview), TRUE);

--- a/libleptongui/src/x_tabs.c
+++ b/libleptongui/src/x_tabs.c
@@ -588,8 +588,6 @@ x_tabs_pview_create (GschemToplevel* w_current,
 
   gtk_widget_set_can_focus (GTK_WIDGET (pview), TRUE);
 
-  x_window_setup_draw_events_drawing_area (w_current, pview);
-
   return pview;
 
 } /* x_tabs_pview_create() */

--- a/libleptongui/src/x_tabs.c
+++ b/libleptongui/src/x_tabs.c
@@ -38,7 +38,6 @@
  *
  * - x_tabs_enabled()      // whether tabbed GUI is currently enabled
  * - x_tabs_init()         // initialize tabbed GUI, read config
- * - x_tabs_page_set_cur() // set current tab
  * - x_tabs_next()         // go to next tab
  * - x_tabs_prev()         // go to prev tab
  * - x_tabs_hdr_update()   // update tab's header widget
@@ -188,15 +187,9 @@ x_tabs_tl_page_cur (GschemToplevel* w_current);
 static void
 x_tabs_tl_page_cur_set (GschemToplevel* w_current,
                         LeptonPage* page);
-static GschemPageView*
-x_tabs_tl_pview_cur (GschemToplevel* w_current);
 
 static void
 x_tabs_tl_pview_cur_set (GschemToplevel* w_current, GschemPageView* pview);
-
-static gboolean
-x_tabs_tl_page_find (GschemToplevel* w_current,
-                     LeptonPage* page);
 
 
 /* notebook: */
@@ -443,7 +436,7 @@ x_tabs_tl_page_cur_set (GschemToplevel* w_current,
 
 
 
-static GschemPageView*
+GschemPageView*
 x_tabs_tl_pview_cur (GschemToplevel* w_current)
 {
   GtkWidget*      wview = w_current->drawing_area;
@@ -467,7 +460,7 @@ x_tabs_tl_pview_cur_set (GschemToplevel* w_current, GschemPageView* pview)
  *  \return TRUE if found.
  *
  */
-static gboolean
+gboolean
 x_tabs_tl_page_find (GschemToplevel* w_current,
                      LeptonPage* page)
 {
@@ -1109,84 +1102,6 @@ x_tabs_page_new (GschemToplevel* w_current,
   return x_tabs_info_add (w_current, ndx, page, pview, wtab);
 
 } /* x_tabs_page_new() */
-
-
-
-/*! \brief Changes the current tab.
- *  \public
- *
- *  \par Function Description
- *  If there's a tab that contains \a page, it will be activated,
- *  otherwise a new tab for \a page will be created and set active.
- *
- *  \note
- *  The code is intentionally left unrefactored.
- *
- *  \param [in] w_current  The toplevel environment.
- *  \param [in] page       The page.
- *
- */
-void
-x_tabs_page_set_cur (GschemToplevel* w_current,
-                     LeptonPage* page)
-{
-  g_return_if_fail (w_current != NULL);
-
-#ifdef DEBUG
-  printf( "x_tabs_page_set_cur()\n" );
-#endif
-
-  TabInfo* nfo = x_tabs_info_find_by_page (schematic_window_get_tab_info_list (w_current), page);
-
-  gint ndx = -1;
-
-
-  /* XXX: 3: [pview] [page]:
-   * - switch to existing page view
-  */
-  if (nfo != NULL)
-  {
-#ifdef DEBUG
-    printf( "    x_tabs_page_set_cur(): #3: [pview] [page] \n\n" );
-#endif
-
-    ndx = gtk_notebook_page_num (schematic_window_get_tab_notebook (w_current),
-                                 schematic_tab_info_get_tab_widget (nfo));
-    g_return_if_fail (ndx >= 0);
-
-    gtk_notebook_set_current_page (schematic_window_get_tab_notebook (w_current), ndx);
-    schematic_page_view_grab_focus (schematic_tab_info_get_page_view (nfo));
-  }
-
-  else
-
-  /*  XXX: 4: [!pview] [page]:
-  */
-  if (nfo == NULL && x_tabs_tl_page_find (w_current, page))
-  {
-#ifdef DEBUG
-      printf( "    x_tabs_page_set_cur(): #4: [!pview] [page] \n\n" );
-#endif
-
-      nfo = x_tabs_page_new (w_current, page);
-
-      x_tabs_hdr_set (schematic_window_get_tab_notebook (w_current), nfo);
-      gtk_notebook_set_current_page (schematic_window_get_tab_notebook (w_current), ndx);
-      schematic_page_view_grab_focus (schematic_tab_info_get_page_view (nfo));
-
-      /* x_tabs_page_new() just invoked,
-       * let page view creation complete -
-       * process pending events:
-      */
-      while (gtk_events_pending())
-        gtk_main_iteration();
-
-      /* new page view is created for existing page => zoom it:
-      */
-      gschem_page_view_zoom_extents (x_tabs_tl_pview_cur (w_current), NULL);
-  }
-
-} /* x_tabs_page_set_cur() */
 
 
 

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -114,23 +114,6 @@ void x_window_setup_draw_events_main_wnd (GschemToplevel* w_current,
 } /* x_window_setup_draw_events_main_wnd() */
 
 
-gpointer _key_event_callback = NULL;
-
-/*! \brief Set key event callback
- *  \par Function Description
- *  Sets key event processing callback to a given function
- *  pointer.  Currently it is necessary as key event processing is
- *  handled in Scheme.
- *
- * \param [in] key_event_callback The pointer to the callback.
- */
-void
-schematic_window_set_key_event_callback (gpointer key_event_callback)
-{
-  _key_event_callback = key_event_callback;
-}
-
-
 /*! \brief Set up callbacks for the drawing area.
  *  \par Function Description
  *
@@ -143,35 +126,6 @@ schematic_window_set_key_event_callback (gpointer key_event_callback)
 void x_window_setup_draw_events_drawing_area (GschemToplevel* w_current,
                                               GschemPageView* drawing_area)
 {
-  struct event_reg_t
-  {
-    const gchar* detailed_signal;
-    GCallback    c_handler;
-  };
-
-  struct event_reg_t drawing_area_events[] =
-  {
-#ifdef ENABLE_GTK3
-    { "draw",                 G_CALLBACK(x_event_draw)                         },
-#else
-    { "expose_event",         G_CALLBACK(x_event_expose)                       },
-#endif
-    { "button_press_event",   G_CALLBACK(x_event_button_pressed)               },
-    { "button_release_event", G_CALLBACK(x_event_button_released)              },
-    { "motion_notify_event",  G_CALLBACK(x_event_motion)                       },
-    { "configure_event",      G_CALLBACK(x_event_configure)                    },
-    { "key_press_event",      G_CALLBACK(_key_event_callback)                   },
-    { "key_release_event",    G_CALLBACK(_key_event_callback)                   },
-    { "scroll_event",         G_CALLBACK(x_event_scroll)                       },
-    { "update-grid-info",     G_CALLBACK(i_update_grid_info_callback)          },
-    { "notify::page",         G_CALLBACK(gschem_toplevel_notify_page_callback) },
-    { NULL,                   NULL                                             }
-  };
-
-
-  /* is the configure event type missing here? hack */
-
-
   /* gtk_widget_set_events() can be called on unrealized widgets only.
   *  Since with tabbed GUI (see x_tabs.c) we need to setup events
   *  for already created page view widgets, use
@@ -199,16 +153,6 @@ void x_window_setup_draw_events_drawing_area (GschemToplevel* w_current,
 
   gtk_widget_add_events (GTK_WIDGET (drawing_area), events);
 #endif
-
-  struct event_reg_t* tmp = NULL;
-
-  for (tmp = drawing_area_events; tmp->detailed_signal != NULL; tmp++)
-  {
-    g_signal_connect (drawing_area,
-                      tmp->detailed_signal,
-                      tmp->c_handler,
-                      w_current);
-  }
 
 } /* x_window_setup_draw_events_drawing_area() */
 


### PR DESCRIPTION
- Several functions have been rewritten in Scheme in order to
  allow for connecting signals to the page view widget in Scheme
  code, those are `x_tabs_page_set_cur()` and `x_tabs_page_new()`

- The function `x_tabs_pview_create()` has been renamed to
  `schematic_tabs_add_page_view()` as it does no longer create
  page view though sets it up and adds to the tab widget.

- Two dummy C callbacks have been added to simplify dlopening
  relevant foreign functions in Scheme when used along with GTK2
  or GTK3.
  
- Page view scrolling and drawing events are now assigned in
  Scheme.
