### PR TITLE
ITS: Add tests for lepton-netlist's options -L, -l, and -m.

### DIFF
--- a/tests/env.scm
+++ b/tests/env.scm
@@ -105,6 +105,11 @@
 (define (touch filename)
   (string->file "" filename))
 
+;;; Write s-expression to file.
+(define (sexp->file sexp filename)
+  (with-output-to-file filename
+    (lambda () (write sexp))))
+
 
 (define *abs-top-builddir* (getenv "abs_top_builddir"))
 (define *abs-top-srcdir* (getenv "abs_top_srcdir"))

--- a/tests/env.scm
+++ b/tests/env.scm
@@ -153,10 +153,10 @@
 (define (touch filename)
   (string->file "" filename))
 
-;;; Write s-expression to file.
-(define (sexp->file sexp filename)
+;;; Write s-expressions to file.
+(define* (sexp->file filename . sexp)
   (with-output-to-file filename
-    (lambda () (write sexp))))
+    (lambda () (for-each write sexp))))
 
 
 (define *abs-top-builddir* (getenv "abs_top_builddir"))

--- a/tests/env.scm
+++ b/tests/env.scm
@@ -115,13 +115,6 @@
                         "src"
                         "liblepton"))
 
-;;; Test if netlister exists :-)
-(define *netlister*
-  (build-filename *abs-top-builddir*
-                  "tools"
-                  "netlist"
-                  "lepton-netlist"))
-
 ;;; For FreeBSD, where non-existing variables are not set by
 ;;; setenv() without putenv().
 (putenv (string-append "LIBLEPTON" "=" *liblepton*))
@@ -173,6 +166,12 @@
                   "cli"
                   "scheme"
                   "lepton-export"))
+
+(define lepton-netlist
+  (build-filename *abs-top-builddir*
+                  "tools"
+                  "netlist"
+                  "lepton-netlist"))
 
 (define lepton-shell
   (build-filename *abs-top-builddir*

--- a/tests/env.scm
+++ b/tests/env.scm
@@ -63,6 +63,21 @@
   (test-grep-file <str> <filename> EXIT_FAILURE))
 
 
+;;; Save the environment variable to ensure it can be restored
+;;; later.
+(define $HOME (make-parameter (getenv "HOME")))
+
+;;; Set the $HOME environment variable to given PATH.
+(define-syntax-rule (with-home path form form* ...)
+  (let ((homedir ($HOME)))
+    (putenv (string-append "HOME=" path))
+    ;; Make sure $HOME is defined for other forms.
+    (parameterize (($HOME path)) form form* ...)
+    ;; Restore $HOME.
+    (if homedir
+        (putenv (string-append "HOME=" homedir))
+        (putenv "HOME"))))
+
 ;;; Get the exit status of COMMAND, its stdout and stderr output,
 ;;; and return the three values.
 (define (command-values . command)

--- a/tests/netlist.test
+++ b/tests/netlist.test
@@ -129,14 +129,17 @@
   (mkdir "backend")
 
   ;; Make a backend file.
-  (string->file
-   "(define (test output-filename)
-(if (defined? 'l-option)
-    (display \"-l option\")
-    (display \"test backend\")))"
+  (sexp->file
+   ;; The main backend function displays "-l option" if the option
+   ;; was really used in command line used, otherways it displays
+   ;; "test backend".
+   '(define (test output-filename)
+      (if (defined? 'l-option)
+          (display "-l option")
+          (display "test backend")))
    "backend/gnet-test.scm")
   ;; Make a script for pre-loading.
-  (string->file "(define l-option 'l-option)" "l.scm")
+  (sexp->file '(define l-option 'l-option) "l.scm")
 
   ;; Test -L option.
   (receive (<status> <stdout> <stderr>)

--- a/tests/netlist.test
+++ b/tests/netlist.test
@@ -141,6 +141,15 @@
   ;; Make a script for pre-loading.
   (sexp->file '(define l-option 'l-option) "l.scm")
 
+  ;; Make a script for post-loading.
+  (sexp->file
+   ;; Redefine the test() function defined in the test backend.
+   '(define (test output-filename)
+      (if (defined? 'l-option)
+          (display "-l and -m")
+          (display "only -m")))
+   "m.scm")
+
   ;; Test -L option.
   (receive (<status> <stdout> <stderr>)
       (command-values* lepton-netlist -L backend -g test -o - schematic.sch)
@@ -154,6 +163,20 @@
     (test-eq EXIT_SUCCESS <status>)
     (test-assert (not (string-contains <stdout> "test backend")))
     (test-assert (string-contains <stdout> "-l option")))
+
+  ;; Test -m option.
+  (receive (<status> <stdout> <stderr>)
+      (command-values* lepton-netlist -m m.scm -L backend -g test -o - schematic.sch)
+    (test-eq EXIT_SUCCESS <status>)
+    (test-assert (not (string-contains <stdout> "test backend")))
+    (test-assert (string-contains <stdout> "only -m")))
+
+  ;; Test -l and -m options together.
+  (receive (<status> <stdout> <stderr>)
+      (command-values* lepton-netlist -l l.scm -m m.scm -L backend -g test -o - schematic.sch)
+    (test-eq EXIT_SUCCESS <status>)
+    (test-assert (not (string-contains <stdout> "test backend")))
+    (test-assert (string-contains <stdout> "-l and -m")))
 
   (test-teardown))
 

--- a/tests/netlist.test
+++ b/tests/netlist.test
@@ -292,3 +292,45 @@
   (test-teardown))
 
 (test-end)
+
+
+(test-begin "lepton-netlist -f")
+
+(test-group-with-cleanup "lepton-netlist -f"
+  (test-setup)
+  ;; Make a dummy schematic.
+  (touch "schematic.sch")
+  ;; Make backends with wrong names.  By convention, backends must
+  ;; have the prefix "gnet-" and the extension ".scm".
+  (touch "wrong1.scm")
+  (touch "gnet-wrong2.xxx")
+  ;; Make a good backend file.
+  (sexp->file
+   "gnet-good-backend.scm"
+   ;; Simple test backend.
+   '(define-module (backend good-backend)
+      #:export (good-backend))
+   ;; This is the exported function.
+   '(define (good-backend filename)
+      (display "It works!\n")))
+
+  (receive (<status> <stdout> <stderr>)
+      (command-values* lepton-netlist -f wrong1.scm -o - schematic.sch)
+    (test-eq EXIT_FAILURE <status>)
+    (test-assert (string-contains <stderr> "Can't load backend file \"wrong1.scm\"."))
+    (test-assert (string-contains <stderr> "Backend files are expected to have names like \"gnet-NAME.scm\"")))
+
+  (receive (<status> <stdout> <stderr>)
+      (command-values* lepton-netlist -f gnet-wrong2.xxx -o - schematic.sch)
+    (test-eq EXIT_FAILURE <status>)
+    (test-assert (string-contains <stderr> "Can't load backend file \"gnet-wrong2.xxx\"."))
+    (test-assert (string-contains <stderr> "Backend files are expected to have names like \"gnet-NAME.scm\"")))
+
+  (receive (<status> <stdout> <stderr>)
+      (command-values* lepton-netlist -f gnet-good-backend.scm -o - schematic.sch)
+    (test-eq EXIT_SUCCESS <status>)
+    (test-assert (string-contains <stdout> "It works!")))
+
+  (test-teardown))
+
+(test-end)

--- a/tests/netlist.test
+++ b/tests/netlist.test
@@ -243,11 +243,13 @@
 
    ;; Test loading files from the user Scheme data directory.
    ;; Create a directory for user data in current $HOME.
-   (let ((scheme-dir (build-filename ($HOME) *user-data-dir* "scheme"))
-         (new-l.scm (build-filename ($HOME) *user-data-dir* "scheme" "l.scm"))
-         (new-m.scm (build-filename ($HOME) *user-data-dir* "scheme" "m.scm"))
-         (inhibit-rc? (getenv "LEPTON_INHIBIT_RC_FILES")))
-     (system* "mkdir" "-p" scheme-dir)
+   (let* ((scheme-dir (build-filename ($HOME) *user-data-dir* "scheme"))
+          (new-l.scm (build-filename scheme-dir "l.scm"))
+          (m-dir (build-filename scheme-dir "m"))
+          (new-m.scm (build-filename m-dir "m.scm"))
+          (inhibit-rc? (getenv "LEPTON_INHIBIT_RC_FILES")))
+     ;; Create user Scheme directory and a directory "m" within it.
+     (system* "mkdir" "-p" m-dir)
      (rename-file "l.scm" new-l.scm)
      (rename-file "m.scm" new-m.scm)
 
@@ -260,7 +262,7 @@
 
      ;; The command should still work with short file names.
      (receive (<status> <stdout> <stderr>)
-         (command-values* lepton-netlist -l l.scm -m m.scm -L backend -g test -o - schematic.sch)
+         (command-values* lepton-netlist -l l.scm -m m/m.scm -L backend -g test -o - schematic.sch)
        (test-eq EXIT_SUCCESS <status>)
        (test-assert (not (string-contains <stdout> "test backend")))
        (test-assert (string-contains <stdout> "-l and -m")))

--- a/tests/netlist.test
+++ b/tests/netlist.test
@@ -146,26 +146,24 @@
   (mkdir "backend")
 
   ;; Make a backend file.
-  (sexp->file
+  (sexp->file "backend/gnet-test.scm"
    ;; The main backend function displays "-l option" if the option
    ;; was really used in command line used, otherways it displays
    ;; "test backend".
    '(define (test output-filename)
       (if (defined? 'l-option)
           (display "-l option")
-          (display "test backend")))
-   "backend/gnet-test.scm")
+          (display "test backend"))))
   ;; Make a script for pre-loading.
-  (sexp->file '(define l-option 'l-option) "l.scm")
+  (sexp->file "l.scm" '(define l-option 'l-option))
 
   ;; Make a script for post-loading.
-  (sexp->file
+  (sexp->file  "m.scm"
    ;; Redefine the test() function defined in the test backend.
    '(define (test output-filename)
       (if (defined? 'l-option)
           (display "-l and -m")
-          (display "only -m")))
-   "m.scm")
+          (display "only -m"))))
 
   ;; Set $HOME to the test directory.
   (with-home
@@ -273,9 +271,9 @@
 
      ;; Now, same named local files in cwd and test that they have
      ;; precedence over those in the user Scheme load path.
-     (sexp->file '(exit 1) "l.scm")
+     (sexp->file "l.scm" '(exit 1))
      (mkdir "m")
-     (sexp->file '(exit 1) "m/m.scm")
+     (sexp->file "m/m.scm" '(exit 1))
 
      ;; Test with -l only.
      (receive (<status> <stdout> <stderr>)

--- a/tests/netlist.test
+++ b/tests/netlist.test
@@ -47,7 +47,7 @@
     (test-eq EXIT_SUCCESS
       (status:exit-val
        (apply system*
-              *netlister*
+              lepton-netlist
               "-L" backend-directory
               "-c" (string-append "(component-library \""
                                   (or complib default-symbol-directory)
@@ -75,9 +75,9 @@
 
 (test-begin "netlister")
 
-(test-assert (file-exists? *netlister*))
+(test-assert (file-exists? lepton-netlist))
 (test-eq EXIT_SUCCESS
-  (status:exit-val (system* *netlister* "--help")))
+  (status:exit-val (system* lepton-netlist "--help")))
 
 (test-end "netlister")
 

--- a/tests/netlist.test
+++ b/tests/netlist.test
@@ -150,52 +150,79 @@
           (display "only -m")))
    "m.scm")
 
-  ;; Test -L option.
-  (receive (<status> <stdout> <stderr>)
-      (command-values* lepton-netlist -L backend -g test -o - schematic.sch)
-    (test-eq EXIT_SUCCESS <status>)
-    (test-assert (string-contains <stdout> "test backend"))
-    (test-assert (not (string-contains <stdout> "-l option"))))
-
-  ;; Test -l option.
-  (receive (<status> <stdout> <stderr>)
-      (command-values* lepton-netlist -l l.scm -L backend -g test -o - schematic.sch)
-    (test-eq EXIT_SUCCESS <status>)
-    (test-assert (not (string-contains <stdout> "test backend")))
-    (test-assert (string-contains <stdout> "-l option")))
-
-  ;; Test -m option.
-  (receive (<status> <stdout> <stderr>)
-      (command-values* lepton-netlist -m m.scm -L backend -g test -o - schematic.sch)
-    (test-eq EXIT_SUCCESS <status>)
-    (test-assert (not (string-contains <stdout> "test backend")))
-    (test-assert (string-contains <stdout> "only -m")))
-
-  ;; Test -l and -m options together.
-  (receive (<status> <stdout> <stderr>)
-      (command-values* lepton-netlist -l l.scm -m m.scm -L backend -g test -o - schematic.sch)
-    (test-eq EXIT_SUCCESS <status>)
-    (test-assert (not (string-contains <stdout> "test backend")))
-    (test-assert (string-contains <stdout> "-l and -m")))
-
-  ;; Tests for absolute and relative file names.
-
   ;; Set $HOME to the test directory.
-  (with-home *testdir*
+  (with-home
+   *testdir*
 
-    ;; Test -L option with relative path.
-    (receive (<status> <stdout> <stderr>)
-        (command-values* lepton-netlist -L ./backend -g test -o - schematic.sch)
-      (test-eq EXIT_SUCCESS <status>)
-      (test-assert (string-contains <stdout> "test backend"))
-      (test-assert (not (string-contains <stdout> "-l option"))))
+   ;; Test -L option.
+   (receive (<status> <stdout> <stderr>)
+       (command-values* lepton-netlist -L backend -g test -o - schematic.sch)
+     (test-eq EXIT_SUCCESS <status>)
+     (test-assert (string-contains <stdout> "test backend"))
+     (test-assert (not (string-contains <stdout> "-l option"))))
 
-    ;; Test -L option with absolute path.
-    (receive (<status> <stdout> <stderr>)
-        (command-values* lepton-netlist -L $HOME/backend -g test -o - schematic.sch)
-      (test-eq EXIT_SUCCESS <status>)
-      (test-assert (string-contains <stdout> "test backend"))
-      (test-assert (not (string-contains <stdout> "-l option")))))
+   ;; Test -L option with relative path.
+   (receive (<status> <stdout> <stderr>)
+       (command-values* lepton-netlist -L ./backend -g test -o - schematic.sch)
+     (test-eq EXIT_SUCCESS <status>)
+     (test-assert (string-contains <stdout> "test backend"))
+     (test-assert (not (string-contains <stdout> "-l option"))))
+
+   ;; Test -L option with absolute path.
+   (receive (<status> <stdout> <stderr>)
+       (command-values* lepton-netlist -L $HOME/backend -g test -o - schematic.sch)
+     (test-eq EXIT_SUCCESS <status>)
+     (test-assert (string-contains <stdout> "test backend"))
+     (test-assert (not (string-contains <stdout> "-l option"))))
+
+   ;; Test -l option.
+   (receive (<status> <stdout> <stderr>)
+       (command-values* lepton-netlist -l l.scm -L backend -g test -o - schematic.sch)
+     (test-eq EXIT_SUCCESS <status>)
+     (test-assert (not (string-contains <stdout> "test backend")))
+     (test-assert (string-contains <stdout> "-l option")))
+
+   ;; Test -l option with relative path.
+   (receive (<status> <stdout> <stderr>)
+       (command-values* lepton-netlist -l ./l.scm -L backend -g test -o - schematic.sch)
+     (test-eq EXIT_SUCCESS <status>)
+     (test-assert (not (string-contains <stdout> "test backend")))
+     (test-assert (string-contains <stdout> "-l option")))
+
+   ;; Test -l option with absolute path.
+   (receive (<status> <stdout> <stderr>)
+       (command-values* lepton-netlist -l $HOME/l.scm -L backend -g test -o - schematic.sch)
+     (test-eq EXIT_SUCCESS <status>)
+     (test-assert (not (string-contains <stdout> "test backend")))
+     (test-assert (string-contains <stdout> "-l option")))
+
+   ;; Test -m option.
+   (receive (<status> <stdout> <stderr>)
+       (command-values* lepton-netlist -m m.scm -L backend -g test -o - schematic.sch)
+     (test-eq EXIT_SUCCESS <status>)
+     (test-assert (not (string-contains <stdout> "test backend")))
+     (test-assert (string-contains <stdout> "only -m")))
+
+   ;; Test -m option with relative path.
+   (receive (<status> <stdout> <stderr>)
+       (command-values* lepton-netlist -m ./m.scm -L backend -g test -o - schematic.sch)
+     (test-eq EXIT_SUCCESS <status>)
+     (test-assert (not (string-contains <stdout> "test backend")))
+     (test-assert (string-contains <stdout> "only -m")))
+
+   ;; Test -m option with absolute path.
+   (receive (<status> <stdout> <stderr>)
+       (command-values* lepton-netlist -m $HOME/m.scm -L backend -g test -o - schematic.sch)
+     (test-eq EXIT_SUCCESS <status>)
+     (test-assert (not (string-contains <stdout> "test backend")))
+     (test-assert (string-contains <stdout> "only -m")))
+
+   ;; Test -l and -m options together.
+   (receive (<status> <stdout> <stderr>)
+       (command-values* lepton-netlist -l l.scm -m m.scm -L backend -g test -o - schematic.sch)
+     (test-eq EXIT_SUCCESS <status>)
+     (test-assert (not (string-contains <stdout> "test backend")))
+     (test-assert (string-contains <stdout> "-l and -m"))))
 
   (test-teardown))
 

--- a/tests/netlist.test
+++ b/tests/netlist.test
@@ -1,5 +1,4 @@
 (use-modules (ice-9 receive)
-             (srfi srfi-64)
              (srfi srfi-26))
 
 (load-from-path "env.scm")

--- a/tests/netlist.test
+++ b/tests/netlist.test
@@ -1,4 +1,5 @@
-(use-modules (srfi srfi-64)
+(use-modules (ice-9 receive)
+             (srfi srfi-64)
              (srfi srfi-26))
 
 (load-from-path "env.scm")
@@ -103,3 +104,55 @@
                 #:complib switcap-example-symbol-dir)
 
 (test-schematic "utf8.sch" "geda")
+
+
+
+(define cwd (getcwd))
+(define *testdir* (build-filename (getcwd) "netlist-tmp"))
+
+;;; Setup/teardown directories/files needed by tests.
+(define (test-setup)
+  (mkdir *testdir*)
+  (chdir *testdir*))
+
+(define (test-teardown)
+  (chdir cwd)
+  (system* "rm" "-rf" *testdir*))
+
+
+(test-begin "lepton-netlist -L")
+
+(test-group-with-cleanup "lepton-netlist -L"
+  (test-setup)
+  ;; Make a dummy schematic.
+  (touch "schematic.sch")
+  ;; Make a directory for a new backend.
+  (mkdir "backend")
+
+  ;; Make a backend file.
+  (string->file
+   "(define (test output-filename)
+(if (defined? 'l-option)
+    (display \"-l option\")
+    (display \"test backend\")))"
+   "backend/gnet-test.scm")
+  ;; Make a script for pre-loading.
+  (string->file "(define l-option 'l-option)" "l.scm")
+
+  ;; Test -L option.
+  (receive (<status> <stdout> <stderr>)
+      (command-values "lepton-netlist" "-L" "backend" "-g" "test" "-o" "-" "schematic.sch")
+    (test-eq EXIT_SUCCESS <status>)
+    (test-assert (string-contains <stdout> "test backend"))
+    (test-assert (not (string-contains <stdout> "-l option"))))
+
+  ;; Test -l option.
+  (receive (<status> <stdout> <stderr>)
+      (command-values "lepton-netlist" "-l" "l.scm" "-L" "backend" "-g" "test" "-o" "-" "schematic.sch")
+    (test-eq EXIT_SUCCESS <status>)
+    (test-assert (not (string-contains <stdout> "test backend")))
+    (test-assert (string-contains <stdout> "-l option")))
+
+  (test-teardown))
+
+(test-end)

--- a/tests/netlist.test
+++ b/tests/netlist.test
@@ -143,14 +143,14 @@
 
   ;; Test -L option.
   (receive (<status> <stdout> <stderr>)
-      (command-values "lepton-netlist" "-L" "backend" "-g" "test" "-o" "-" "schematic.sch")
+      (command-values* lepton-netlist -L backend -g test -o - schematic.sch)
     (test-eq EXIT_SUCCESS <status>)
     (test-assert (string-contains <stdout> "test backend"))
     (test-assert (not (string-contains <stdout> "-l option"))))
 
   ;; Test -l option.
   (receive (<status> <stdout> <stderr>)
-      (command-values "lepton-netlist" "-l" "l.scm" "-L" "backend" "-g" "test" "-o" "-" "schematic.sch")
+      (command-values* lepton-netlist -l l.scm -L backend -g test -o - schematic.sch)
     (test-eq EXIT_SUCCESS <status>)
     (test-assert (not (string-contains <stdout> "test backend")))
     (test-assert (string-contains <stdout> "-l option")))

--- a/tests/netlist.test
+++ b/tests/netlist.test
@@ -252,6 +252,9 @@
      (system* "mkdir" "-p" m-dir)
      (rename-file "l.scm" new-l.scm)
      (rename-file "m.scm" new-m.scm)
+     ;; Move backend file to the user Scheme directory.  Thus, the
+     ;; command below may omit '-L backend'.
+     (rename-file "backend/gnet-test.scm" (build-filename scheme-dir "gnet-test.scm"))
 
      (unsetenv "LEPTON_INHIBIT_RC_FILES")
 
@@ -260,9 +263,10 @@
      (test-assert (not (file-exists? "l.scm")))
      (test-assert (not (file-exists? "m.scm")))
 
-     ;; The command should still work with short file names.
+     ;; The command should still work with relative file names and
+     ;; without '-L backend'.
      (receive (<status> <stdout> <stderr>)
-         (command-values* lepton-netlist -l l.scm -m m/m.scm -L backend -g test -o - schematic.sch)
+         (command-values* lepton-netlist -l l.scm -m m/m.scm -g test -o - schematic.sch)
        (test-eq EXIT_SUCCESS <status>)
        (test-assert (not (string-contains <stdout> "test backend")))
        (test-assert (string-contains <stdout> "-l and -m")))

--- a/tests/netlist.test
+++ b/tests/netlist.test
@@ -271,6 +271,22 @@
        (test-assert (not (string-contains <stdout> "test backend")))
        (test-assert (string-contains <stdout> "-l and -m")))
 
+     ;; Now, same named local files in cwd and test that they have
+     ;; precedence over those in the user Scheme load path.
+     (sexp->file '(exit 1) "l.scm")
+     (mkdir "m")
+     (sexp->file '(exit 1) "m/m.scm")
+
+     ;; Test with -l only.
+     (receive (<status> <stdout> <stderr>)
+         (command-values* lepton-netlist -l l.scm -g test -o - schematic.sch)
+       (test-eq EXIT_FAILURE <status>))
+
+     ;; Test with -m only.
+     (receive (<status> <stdout> <stderr>)
+         (command-values* lepton-netlist -m m/m.scm -g test -o - schematic.sch)
+       (test-eq EXIT_FAILURE <status>))
+
      (when inhibit-rc?
        (putenv (string-append "LEPTON_INHIBIT_RC_FILES=" inhibit-rc?)))))
 

--- a/tests/netlist.test
+++ b/tests/netlist.test
@@ -119,6 +119,23 @@
   (system* "rm" "-rf" *testdir*))
 
 
+;;; The same function as exists in (lepton os).
+(define (user-home-dir)
+  (or (getenv "HOME")
+      (passwd:dir (getpwuid (getuid)))))
+
+
+;;; Get the user data directory relative path in $HOME.
+(define *user-data-dir*
+  (string-drop
+   ;; Use lepton-netlist's stdout to get the value of
+   ;; (user-data-dir).
+   (receive (<status> <stdout> <stderr>)
+       (command-values* lepton-netlist -c "(use-modules (lepton os))(display (user-data-dir))")
+     <stdout>)
+   (1+ (string-length (user-home-dir)))))
+
+
 (test-begin "lepton-netlist -L")
 
 (test-group-with-cleanup "lepton-netlist -L"
@@ -222,7 +239,35 @@
        (command-values* lepton-netlist -l l.scm -m m.scm -L backend -g test -o - schematic.sch)
      (test-eq EXIT_SUCCESS <status>)
      (test-assert (not (string-contains <stdout> "test backend")))
-     (test-assert (string-contains <stdout> "-l and -m"))))
+     (test-assert (string-contains <stdout> "-l and -m")))
+
+   ;; Test loading files from the user Scheme data directory.
+   ;; Create a directory for user data in current $HOME.
+   (let ((scheme-dir (build-filename ($HOME) *user-data-dir* "scheme"))
+         (new-l.scm (build-filename ($HOME) *user-data-dir* "scheme" "l.scm"))
+         (new-m.scm (build-filename ($HOME) *user-data-dir* "scheme" "m.scm"))
+         (inhibit-rc? (getenv "LEPTON_INHIBIT_RC_FILES")))
+     (system* "mkdir" "-p" scheme-dir)
+     (rename-file "l.scm" new-l.scm)
+     (rename-file "m.scm" new-m.scm)
+
+     (unsetenv "LEPTON_INHIBIT_RC_FILES")
+
+     ;; Assure the Scheme files are removed from the current
+     ;; directory.
+     (test-assert (not (file-exists? "l.scm")))
+     (test-assert (not (file-exists? "m.scm")))
+
+     ;; The command should still work with short file names.
+     (receive (<status> <stdout> <stderr>)
+         (command-values* lepton-netlist -l l.scm -m m.scm -L backend -g test -o - schematic.sch)
+       (test-eq EXIT_SUCCESS <status>)
+       (test-assert (not (string-contains <stdout> "test backend")))
+       (test-assert (string-contains <stdout> "-l and -m")))
+
+     (when inhibit-rc?
+       (putenv (string-append "LEPTON_INHIBIT_RC_FILES=" inhibit-rc?)))))
+
 
   (test-teardown))
 

--- a/tests/netlist.test
+++ b/tests/netlist.test
@@ -178,6 +178,25 @@
     (test-assert (not (string-contains <stdout> "test backend")))
     (test-assert (string-contains <stdout> "-l and -m")))
 
+  ;; Tests for absolute and relative file names.
+
+  ;; Set $HOME to the test directory.
+  (with-home *testdir*
+
+    ;; Test -L option with relative path.
+    (receive (<status> <stdout> <stderr>)
+        (command-values* lepton-netlist -L ./backend -g test -o - schematic.sch)
+      (test-eq EXIT_SUCCESS <status>)
+      (test-assert (string-contains <stdout> "test backend"))
+      (test-assert (not (string-contains <stdout> "-l option"))))
+
+    ;; Test -L option with absolute path.
+    (receive (<status> <stdout> <stderr>)
+        (command-values* lepton-netlist -L $HOME/backend -g test -o - schematic.sch)
+      (test-eq EXIT_SUCCESS <status>)
+      (test-assert (string-contains <stdout> "test backend"))
+      (test-assert (not (string-contains <stdout> "-l option")))))
+
   (test-teardown))
 
 (test-end)

--- a/tests/sch2pcb.test
+++ b/tests/sch2pcb.test
@@ -4,7 +4,7 @@
 (load-from-path "env.scm")
 
 ;;; sch2pcb should be aware of where the netlister sits.
-(setenv "NETLISTER" *netlister*)
+(setenv "NETLISTER" lepton-netlist)
 
 
 (define cwd (getcwd))


### PR DESCRIPTION
Apart from testing the options, there are a few novations in the
test suite:

- A function writing S-expressions to a file has been added.
- A syntax macro `with-home()` has been added.  It is useful for
  temporary setting the `$HOME` environment variable in tests to
  process absolute file names without interfering with user's
  files in the home directory.
- A new syntax rule, `command-values*()`, allows to call system
  commands without any quotes and interprets the `$HOME` prefix in
  file names.
