### PR TITLE
sch2pcb: Get rid of sch2pcb_expand_dir().

### DIFF
--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -31,7 +31,6 @@
             sch2pcb_element_directory_list_prepend
             sch2pcb_get_empty_footprint_name
             sch2pcb_set_empty_footprint_name
-            sch2pcb_expand_dir
             sch2pcb_get_fix_elements
             sch2pcb_set_fix_elements
             sch2pcb_set_force_element_files
@@ -75,7 +74,6 @@
 (define-lff sch2pcb_element_directory_list_prepend void '(*))
 (define-lff sch2pcb_get_empty_footprint_name '* '())
 (define-lff sch2pcb_set_empty_footprint_name void '(*))
-(define-lff sch2pcb_expand_dir '* '(*))
 (define-lff sch2pcb_get_fix_elements int '())
 (define-lff sch2pcb_set_fix_elements void (list int))
 (define-lff sch2pcb_set_force_element_files void (list int))

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1268,18 +1268,6 @@ sch2pcb_add_m4_file (const gchar *arg)
   }
 }
 
-gchar*
-sch2pcb_expand_dir (gchar *dir)
-{
-  gchar *s;
-  if (dir == NULL)
-    return NULL;
-  if (*dir == '~')
-    s = g_build_filename ((gchar *) g_get_home_dir (), dir + 1, NULL);
-  else
-    s = g_strdup (dir);
-  return s;
-}
 
 void
 sch2pcb_add_default_m4_files (void)

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -233,12 +233,12 @@
       ("use-files" (sch2pcb_set_force_element_files TRUE))
       ("skip-m4" (set! %use-m4 #f))
       ("elements-dir"
-       (let ((*elements-dir (sch2pcb_expand_dir *value)))
+       (let ((elements-dir (expand-env-variables value)))
          (when (> (sch2pcb_get_verbose_mode) 1)
            (format #t
                    "\tAdding directory to file element directory list: ~A\n"
-                   (pointer->string *elements-dir)))
-         (sch2pcb_element_directory_list_prepend *elements-dir)))
+                   elements-dir))
+         (sch2pcb_element_directory_list_prepend (string->pointer elements-dir))))
       ("output-name" (sch2pcb_set_sch_basename *value))
       ("schematics" (sch2pcb_add_multiple_schematics *value))
       ("m4-pcbdir" (set! %m4-pcb-dir value))
@@ -448,11 +448,12 @@ Lepton EDA homepage: <~A>
                seeds))
      (option '(#\d "elements-dir") #t #f
              (lambda (opt name arg seeds)
-               (let ((*elements-dir (sch2pcb_expand_dir (string->pointer arg))))
+               (let ((elements-dir (expand-env-variables arg)))
                  (when (> (sch2pcb_get_verbose_mode) 1)
-                   (format #t "\tAdding directory to file element directory list: ~S\n"
-                           (pointer->string *elements-dir)))
-                 (sch2pcb_element_directory_list_prepend *elements-dir))
+                   (format #t
+                           "\tAdding directory to file element directory list: ~S\n"
+                           elements-dir))
+                 (sch2pcb_element_directory_list_prepend (string->pointer elements-dir)))
                seeds))
      (option '(#\o "output-name") #t #f
              (lambda (opt name arg seeds)


### PR DESCRIPTION
The function calls have been replaced by the more sophisticated and pretty well tested Scheme function `expand-env-variables()` from the module `(lepton os)`.