### PR TITLE
sch2pcb: Rewrite sch2pcb_add_multiple_schematics() in Scheme.

### DIFF
--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -33,9 +33,6 @@ void
 sch2pcb_add_m4_file (const gchar *arg);
 
 void
-sch2pcb_add_multiple_schematics (gchar * sch);
-
-void
 sch2pcb_add_schematic (gchar *sch);
 
 GList*

--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -188,6 +188,9 @@ sch2pcb_get_need_PKG_purge ();
 void
 sch2pcb_set_need_PKG_purge (gboolean val);
 
+GList*
+sch2pcb_parse_schematics (char *str);
+
 void
 sch2pcb_prune_elements (gchar *pcb_file,
                         gchar *bak);

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -25,7 +25,6 @@
   #:export (sch2pcb_add_default_m4_files
             sch2pcb_add_elements
             sch2pcb_add_m4_file
-            sch2pcb_add_multiple_schematics
             sch2pcb_add_schematic
             sch2pcb_element_directory_list_append
             sch2pcb_element_directory_list_prepend
@@ -51,6 +50,7 @@
             sch2pcb_get_n_preserved
             sch2pcb_get_n_unknown
             sch2pcb_get_need_PKG_purge
+            sch2pcb_parse_schematics
             sch2pcb_get_pcb_element_list
             sch2pcb_set_preserve
             sch2pcb_prune_elements
@@ -69,7 +69,6 @@
 (define-lff sch2pcb_add_default_m4_files void '())
 (define-lff sch2pcb_add_elements int '(*))
 (define-lff sch2pcb_add_m4_file void '(*))
-(define-lff sch2pcb_add_multiple_schematics void '(*))
 (define-lff sch2pcb_add_schematic void '(*))
 (define-lff sch2pcb_element_directory_list_append void '(*))
 (define-lff sch2pcb_element_directory_list_prepend void '(*))
@@ -95,6 +94,7 @@
 (define-lff sch2pcb_get_n_preserved int '())
 (define-lff sch2pcb_get_n_unknown int '())
 (define-lff sch2pcb_get_need_PKG_purge int '())
+(define-lff sch2pcb_parse_schematics '* '(*))
 (define-lff sch2pcb_get_pcb_element_list '* '())
 (define-lff sch2pcb_set_preserve void (list int))
 (define-lff sch2pcb_prune_elements void '(* *))

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1306,19 +1306,22 @@ sch2pcb_add_schematic (gchar *sch)
     sch_basename = g_strndup (sch, s - sch);
 }
 
-void
-sch2pcb_add_multiple_schematics (gchar * sch)
+
+GList*
+sch2pcb_parse_schematics (char *str)
 {
   /* parse the string using shell semantics */
   gint count;
   gchar** args = NULL;
   GError* error = NULL;
+  GList *result = NULL;
 
-  if (g_shell_parse_argv (sch, &count, &args, &error)) {
+  if (g_shell_parse_argv (str, &count, &args, &error))
+  {
     int i;
     for (i = 0; i < count; ++i)
     {
-      sch2pcb_add_schematic (args[i]);
+      result = g_list_append (result, g_strdup (args[i]));
     }
     g_strfreev (args);
   } else {
@@ -1327,4 +1330,24 @@ sch2pcb_add_multiple_schematics (gchar * sch)
              error->message);
     g_error_free (error);
   }
+
+  return result;
+}
+
+
+void
+sch2pcb_add_multiple_schematics (gchar * sch)
+{
+  GList *list = NULL;
+  GList *names = sch2pcb_parse_schematics (sch);
+
+  for (list = names;
+       list;
+       list = g_list_next (list))
+  {
+    char *name = (char *) list->data;
+    sch2pcb_add_schematic (name);
+  }
+
+  g_list_free (names);
 }

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1333,21 +1333,3 @@ sch2pcb_parse_schematics (char *str)
 
   return result;
 }
-
-
-void
-sch2pcb_add_multiple_schematics (gchar * sch)
-{
-  GList *list = NULL;
-  GList *names = sch2pcb_parse_schematics (sch);
-
-  for (list = names;
-       list;
-       list = g_list_next (list))
-  {
-    char *name = (char *) list->data;
-    sch2pcb_add_schematic (name);
-  }
-
-  g_list_free (names);
-}

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -209,6 +209,14 @@
                            (loop (cdr ls))))))))))
 
 
+(define (add-multiple-schematics *str)
+  (for-each sch2pcb_add_schematic
+            (glist->list (sch2pcb_parse_schematics *str)
+                         identity
+                         ;; The list must be freed.
+                         'free)))
+
+
 (define (string->pair str)
   (define s (string-trim-both str char-set:whitespace))
   (define break-pos (string-index s char-set:whitespace))
@@ -240,7 +248,7 @@
                    (pointer->string *elements-dir)))
          (sch2pcb_element_directory_list_prepend *elements-dir)))
       ("output-name" (sch2pcb_set_sch_basename *value))
-      ("schematics" (sch2pcb_add_multiple_schematics *value))
+      ("schematics" (add-multiple-schematics *value))
       ("m4-pcbdir" (set! %m4-pcb-dir value))
       ("m4-file" (sch2pcb_add_m4_file *value))
       ("gnetlist" (set! %extra-gnetlist-list


### PR DESCRIPTION
It's core part parsing the `schematics` keyword is still in C.  (It uses `g_shell_parse_argv()` and that function is not very friendly for rewriting, it sort of parses shell syntax but not really :-/ )