### PR TITLE
sch2pcb: Move processing of output file names to Scheme.

### DIFF
--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -86,12 +86,6 @@ sch2pcb_get_remove_unfound_elements ();
 void
 sch2pcb_set_remove_unfound_elements (gboolean val);
 
-char*
-sch2pcb_get_sch_basename ();
-
-void
-sch2pcb_set_sch_basename (char *arg);
-
 GList*
 sch2pcb_get_schematics ();
 

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -50,8 +50,6 @@
             sch2pcb_set_preserve
             sch2pcb_prune_elements
             sch2pcb_set_remove_unfound_elements
-            sch2pcb_get_sch_basename
-            sch2pcb_set_sch_basename
             sch2pcb_update_element_descriptions
             sch2pcb_get_verbose_mode))
 
@@ -88,7 +86,5 @@
 (define-lff sch2pcb_set_preserve void (list int))
 (define-lff sch2pcb_prune_elements void '(* *))
 (define-lff sch2pcb_set_remove_unfound_elements void (list int))
-(define-lff sch2pcb_get_sch_basename '* '())
-(define-lff sch2pcb_set_sch_basename void '(*))
 (define-lff sch2pcb_update_element_descriptions void '(* *))
 (define-lff sch2pcb_get_verbose_mode int '())

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -363,22 +363,6 @@ sch2pcb_set_remove_unfound_elements (gboolean val)
 }
 
 
-static gchar *sch_basename;
-
-char*
-sch2pcb_get_sch_basename ()
-{
-  return sch_basename;
-}
-
-void
-sch2pcb_set_sch_basename (char *arg)
-{
-  g_free (sch_basename);
-  sch_basename = g_strdup (arg);
-}
-
-
 static gint verbose;
 
 gint

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -227,11 +227,16 @@
 
 
 (define (add-schematic schematic-name)
+  (define (basename-ci name)
+    ;; basename() is not case-insensitive, so just drop last 4
+    ;; chars (.sch).
+    (string-drop-right name 4))
+
   (set! %schematics (append %schematics (list schematic-name)))
 
   (when (and (not %schematic-basename)
-             (string-suffix? ".sch" schematic-name))
-    (set! %schematic-basename (basename schematic-name ".sch"))))
+             (string-suffix-ci? ".sch" schematic-name))
+    (set! %schematic-basename (basename-ci schematic-name))))
 
 
 (define (add-multiple-schematics *str)

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -234,9 +234,14 @@
 
   (set! %schematics (append %schematics (list schematic-name)))
 
-  (when (and (not %schematic-basename)
-             (string-suffix-ci? ".sch" schematic-name))
-    (set! %schematic-basename (basename-ci schematic-name))))
+  (if (and (regular-file? schematic-name)
+           (file-readable? schematic-name))
+      (when (and (not %schematic-basename)
+                 (string-suffix-ci? ".sch" schematic-name))
+        (set! %schematic-basename (basename-ci schematic-name)))
+      (format (current-error-port)
+              "Could not add schematic: ~A\nFile is not regular or not readable.\n"
+              schematic-name)))
 
 
 (define (add-multiple-schematics *str)


### PR DESCRIPTION
Apart from processing output file names in Scheme, the program now
supports case insensitive schematic file extensions and reports if
schematic files are not regular or not readable.