### PR TITLE
Connect signals to Component select widget and its preview in Scheme.

### DIFF
--- a/libleptongui/include/gschem_preview.h
+++ b/libleptongui/include/gschem_preview.h
@@ -52,3 +52,18 @@ gschem_preview_get_type (void);
 
 GtkWidget*
 gschem_preview_new ();
+
+G_BEGIN_DECLS
+
+gboolean
+preview_callback_button_press (GtkWidget *widget,
+                               GdkEventButton *event,
+                               gpointer user_data);
+void
+preview_callback_realize (GtkWidget *widget,
+                          gpointer user_data);
+gboolean
+preview_event_scroll (GtkWidget *widget,
+                      GdkEventScroll *event,
+                      GschemToplevel *w_current);
+G_END_DECLS

--- a/libleptongui/include/gschem_preview.h
+++ b/libleptongui/include/gschem_preview.h
@@ -67,6 +67,6 @@ preview_event_scroll (GtkWidget *widget,
                       GdkEventScroll *event,
                       GschemToplevel *w_current);
 GschemToplevel*
-schematic_preview_get_preview_w_current (GschemPreview *preview);
+schematic_preview_get_preview_w_current (GtkWidget *preview);
 
 G_END_DECLS

--- a/libleptongui/include/gschem_preview.h
+++ b/libleptongui/include/gschem_preview.h
@@ -66,4 +66,7 @@ gboolean
 preview_event_scroll (GtkWidget *widget,
                       GdkEventScroll *event,
                       GschemToplevel *w_current);
+GschemToplevel*
+schematic_preview_get_preview_w_current (GschemPreview *preview);
+
 G_END_DECLS

--- a/libleptongui/include/gschem_toplevel.h
+++ b/libleptongui/include/gschem_toplevel.h
@@ -482,4 +482,10 @@ schematic_window_set_color_edit_widget (GschemToplevel *w_current,
 void
 schematic_window_set_font_select_widget (GschemToplevel *w_current,
                                          GtkWidget *widget);
+GtkWidget*
+schematic_window_get_compselect (GschemToplevel *w_current);
+
+void
+schematic_window_set_compselect (GschemToplevel *w_current,
+                                 GtkWidget *widget);
 G_END_DECLS

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -471,6 +471,13 @@ gboolean x_event_get_pointer_position (GschemToplevel *w_current, gboolean snapp
 void x_compselect_open (GtkWidget *cswindow);
 void x_compselect_deselect (GschemToplevel *w_current);
 
+void
+x_compselect_callback_response (GtkDialog *dialog,
+                                gint arg1,
+                                gpointer user_data);
+GtkWidget*
+schematic_compselect_get_preview (GtkWidget *cs);
+
 GtkWidget*
 schematic_compselect_new (GschemToplevel *w_current);
 

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -468,7 +468,7 @@ x_event_key (GschemPageView *page_view,
 gint x_event_scroll(GtkWidget *widget, GdkEventScroll *event, GschemToplevel *w_current);
 gboolean x_event_get_pointer_position (GschemToplevel *w_current, gboolean snapped, gint *wx, gint *wy);
 /* x_compselect.c */
-void x_compselect_open (GschemToplevel *w_current);
+void x_compselect_open (GtkWidget *cswindow);
 void x_compselect_deselect (GschemToplevel *w_current);
 
 GtkWidget*

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -471,6 +471,10 @@ gboolean x_event_get_pointer_position (GschemToplevel *w_current, gboolean snapp
 void x_compselect_open (GschemToplevel *w_current);
 void x_compselect_deselect (GschemToplevel *w_current);
 
+GtkWidget*
+schematic_compselect_new (GschemToplevel *w_current);
+
+
 /* x_fileselect.c */
 GSList*
 x_fileselect_open (GschemToplevel *w_current);

--- a/libleptongui/scheme/schematic/callback.scm
+++ b/libleptongui/scheme/schematic/callback.scm
@@ -138,7 +138,7 @@
   (i_set_state *window (symbol->action-mode 'component-mode))
   (when (null-pointer? (schematic_window_get_compselect *window))
     (schematic_window_set_compselect *window (schematic_compselect_new *window)))
-  (x_compselect_open *window)
+  (x_compselect_open (schematic_window_get_compselect *window))
 
   (i_set_state *window (symbol->action-mode 'select-mode)))
 

--- a/libleptongui/scheme/schematic/callback.scm
+++ b/libleptongui/scheme/schematic/callback.scm
@@ -136,6 +136,8 @@
   (o_redraw_cleanstates *window)
 
   (i_set_state *window (symbol->action-mode 'component-mode))
+  (when (null-pointer? (schematic_window_get_compselect *window))
+    (schematic_window_set_compselect *window (schematic_compselect_new *window)))
   (x_compselect_open *window)
 
   (i_set_state *window (symbol->action-mode 'select-mode)))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -156,6 +156,7 @@
             slot_edit_dialog_quit
 
             x_compselect_open
+            schematic_compselect_new
 
             x_widgets_destroy_dialogs
             x_widgets_init
@@ -292,6 +293,8 @@
             schematic_window_get_bottom_notebook
             schematic_window_set_bottom_notebook
             schematic_window_set_color_edit_widget
+            schematic_window_get_compselect
+            schematic_window_set_compselect
             schematic_window_get_draw_grips
             schematic_window_set_draw_grips
             schematic_window_get_enforce_hierarchy
@@ -465,6 +468,7 @@
 
 ;;; x_compselect.c
 (define-lff x_compselect_open void '(*))
+(define-lff schematic_compselect_new '* '(*))
 
 ;;; x_widgets.c
 (define-lff x_widgets_destroy_dialogs void '(*))
@@ -552,6 +556,8 @@
 (define-lff schematic_window_get_bottom_notebook '* '(*))
 (define-lff schematic_window_set_bottom_notebook void '(* *))
 (define-lff schematic_window_set_color_edit_widget void '(* *))
+(define-lff schematic_window_get_compselect '* '(*))
+(define-lff schematic_window_set_compselect void '(* *))
 (define-lff schematic_window_get_draw_grips int '(*))
 (define-lff schematic_window_set_draw_grips void (list '* int))
 (define-lff schematic_window_get_enforce_hierarchy int '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -155,8 +155,10 @@
             slot_edit_dialog_get_text
             slot_edit_dialog_quit
 
+            *x_compselect_callback_response
             x_compselect_open
             schematic_compselect_new
+            schematic_compselect_get_preview
 
             x_widgets_destroy_dialogs
             x_widgets_init
@@ -274,6 +276,11 @@
             gschem_page_view_pan_mouse
             gschem_page_view_zoom_extents
             schematic_page_view_grab_focus
+
+            *preview_callback_realize
+            *preview_callback_button_press
+            *preview_event_scroll
+            schematic_preview_get_preview_w_current
 
             schematic_signal_connect
 
@@ -467,8 +474,10 @@
 (define-lff x_colorcb_update_colors void '())
 
 ;;; x_compselect.c
+(define-lfc *x_compselect_callback_response)
 (define-lff x_compselect_open void '(*))
 (define-lff schematic_compselect_new '* '(*))
+(define-lff schematic_compselect_get_preview '* '(*))
 
 ;;; x_widgets.c
 (define-lff x_widgets_destroy_dialogs void '(*))
@@ -519,6 +528,12 @@
 (define-lff gschem_page_view_pan_mouse void (list '* int int))
 (define-lff gschem_page_view_zoom_extents void '(* *))
 (define-lff schematic_page_view_grab_focus void '(*))
+
+;;; gschem_preview.c
+(define-lfc *preview_callback_realize)
+(define-lfc *preview_callback_button_press)
+(define-lfc *preview_event_scroll)
+(define-lff schematic_preview_get_preview_w_current '* '(*))
 
 ;;; schematic_hierarchy.c
 (define-lff schematic_hierarchy_get_page_control_counter int '())

--- a/libleptongui/src/gschem_preview.c
+++ b/libleptongui/src/gschem_preview.c
@@ -82,7 +82,7 @@ preview_get_filename (GschemPreview *preview)
  *  \param [in] widget    The preview widget.
  *  \param [in] user_data Unused user data.
  */
-static void
+void
 preview_callback_realize (GtkWidget *widget, gpointer user_data)
 {
   g_return_if_fail (widget != NULL);
@@ -103,7 +103,7 @@ preview_callback_realize (GtkWidget *widget, gpointer user_data)
  *  \param [in] user_data Unused user data.
  *  \returns FALSE to propagate the event further.
  */
-static gboolean
+gboolean
 preview_callback_button_press (GtkWidget *widget,
                                GdkEventButton *event,
                                gpointer user_data)
@@ -265,7 +265,7 @@ gschem_preview_class_init (GschemPreviewClass *klass)
 }
 
 
-static gboolean
+gboolean
 preview_event_scroll (GtkWidget *widget,
                       GdkEventScroll *event,
                       GschemToplevel *w_current)

--- a/libleptongui/src/gschem_preview.c
+++ b/libleptongui/src/gschem_preview.c
@@ -61,15 +61,6 @@ static void preview_dispose (GObject *self);
 static void preview_finalize (GObject *self);
 
 
-/*! \brief create a new preview widget
- */
-GtkWidget*
-gschem_preview_new ()
-{
-  return GTK_WIDGET (g_object_new (GSCHEM_TYPE_PREVIEW, NULL));
-}
-
-
 /*! \brief get the filename for the current page
  */
 static const char*
@@ -285,9 +276,14 @@ preview_event_scroll (GtkWidget *widget,
   return x_event_scroll (widget, event, GSCHEM_PREVIEW (widget)->preview_w_current);
 }
 
-static void
-gschem_preview_init (GschemPreview *preview)
+
+/*! \brief create a new preview widget
+ */
+GtkWidget*
+gschem_preview_new ()
 {
+  GschemPreview *preview = GSCHEM_PREVIEW (g_object_new (GSCHEM_TYPE_PREVIEW, NULL));
+
   struct event_reg_t {
     const gchar *detailed_signal;
     GCallback c_handler;
@@ -304,6 +300,21 @@ gschem_preview_init (GschemPreview *preview)
     { NULL,                   NULL                                        }
   }, *tmp;
 
+  for (tmp = drawing_area_events; tmp->detailed_signal != NULL; tmp++)
+  {
+    g_signal_connect (GTK_WIDGET (preview),
+                      tmp->detailed_signal,
+                      tmp->c_handler,
+                      preview->preview_w_current);
+  }
+
+  return GTK_WIDGET (preview);
+}
+
+
+static void
+gschem_preview_init (GschemPreview *preview)
+{
   GschemToplevel *preview_w_current;
   preview_w_current = gschem_toplevel_new ();
   gschem_toplevel_set_toplevel (preview_w_current, lepton_toplevel_new ());
@@ -339,13 +350,6 @@ gschem_preview_init (GschemPreview *preview)
                          | GDK_SCROLL_MASK
 #endif
                          );
-  for (tmp = drawing_area_events; tmp->detailed_signal != NULL; tmp++) {
-    g_signal_connect (GTK_WIDGET (preview),
-                      tmp->detailed_signal,
-                      tmp->c_handler,
-                      preview_w_current);
-  }
-
 }
 
 static void

--- a/libleptongui/src/gschem_preview.c
+++ b/libleptongui/src/gschem_preview.c
@@ -443,3 +443,17 @@ preview_finalize (GObject *self)
 
   G_OBJECT_CLASS (gschem_preview_parent_class)->finalize (self);
 }
+
+
+/*! \brief Get the field \a preview_w_current of this preview.
+ *
+ *  \param [in] preview The preview.
+ *  \return The field.
+ */
+GschemToplevel*
+schematic_preview_get_preview_w_current (GschemPreview *preview)
+{
+  g_return_val_if_fail (preview != NULL, NULL);
+
+  return preview->preview_w_current;
+}

--- a/libleptongui/src/gschem_preview.c
+++ b/libleptongui/src/gschem_preview.c
@@ -451,9 +451,9 @@ preview_finalize (GObject *self)
  *  \return The field.
  */
 GschemToplevel*
-schematic_preview_get_preview_w_current (GschemPreview *preview)
+schematic_preview_get_preview_w_current (GtkWidget *preview)
 {
   g_return_val_if_fail (preview != NULL, NULL);
 
-  return preview->preview_w_current;
+  return GSCHEM_PREVIEW (preview)->preview_w_current;
 }

--- a/libleptongui/src/gschem_toplevel.c
+++ b/libleptongui/src/gschem_toplevel.c
@@ -1740,3 +1740,32 @@ schematic_window_set_font_select_widget (GschemToplevel *w_current,
 
   w_current->font_select_widget = widget;
 }
+
+
+/*! \brief Get component selector widget of this schematic window.
+ *
+ *  \param [in] w_current The schematic window.
+ *  \return The Compselect widget.
+ */
+GtkWidget*
+schematic_window_get_compselect (GschemToplevel *w_current)
+{
+  g_return_val_if_fail (w_current != NULL, NULL);
+
+  return w_current->cswindow;
+}
+
+
+/*! \brief Set component selector widget for this schematic window.
+ *
+ *  \param [in] w_current The schematic window.
+ *  \param [in] widget The widget.
+ */
+void
+schematic_window_set_compselect (GschemToplevel *w_current,
+                                 GtkWidget *widget)
+{
+  g_return_if_fail (w_current != NULL);
+
+  w_current->cswindow = widget;
+}

--- a/libleptongui/src/x_compselect.c
+++ b/libleptongui/src/x_compselect.c
@@ -99,7 +99,7 @@ compselect_get_view (Compselect *compselect)
  *  \param [in] arg1      The response ID.
  *  \param [in] user_data A pointer on the GschemToplevel environment.
  */
-static void
+void
 x_compselect_callback_response (GtkDialog *dialog,
                                 gint arg1,
                                 gpointer user_data)
@@ -199,11 +199,11 @@ x_compselect_callback_response (GtkDialog *dialog,
 
 
 GtkWidget*
-schematic_compselect_get_preview (Compselect *cs)
+schematic_compselect_get_preview (GtkWidget *cs)
 {
   g_return_val_if_fail (cs != NULL, NULL);
 
-  return GTK_WIDGET (cs->preview);
+  return GTK_WIDGET (COMPSELECT (cs)->preview);
 }
 
 
@@ -215,37 +215,6 @@ schematic_compselect_new (GschemToplevel *w_current)
                                             "settings-name", "compselect",
                                             "gschem-toplevel", w_current,
                                             NULL));
-  g_signal_connect (cs,
-                    "response",
-                    G_CALLBACK (x_compselect_callback_response),
-                    w_current);
-
-  GtkWidget *preview = schematic_compselect_get_preview (COMPSELECT (cs));
-
-  struct event_reg_t {
-    const gchar *detailed_signal;
-    GCallback c_handler;
-  } drawing_area_events[] = {
-    { "realize",              G_CALLBACK (preview_callback_realize)       },
-#ifdef ENABLE_GTK3
-    { "draw",                 G_CALLBACK (x_event_draw)                   },
-#else
-    { "expose_event",         G_CALLBACK (x_event_expose)                 },
-#endif
-    { "button_press_event",   G_CALLBACK (preview_callback_button_press)  },
-    { "configure_event",      G_CALLBACK (x_event_configure)              },
-    { "scroll_event",         G_CALLBACK (preview_event_scroll)           },
-    { NULL,                   NULL                                        }
-  }, *tmp;
-
-  for (tmp = drawing_area_events; tmp->detailed_signal != NULL; tmp++)
-  {
-    g_signal_connect (preview,
-                      tmp->detailed_signal,
-                      tmp->c_handler,
-                      schematic_preview_get_preview_w_current (preview));
-  }
-
   gtk_window_set_transient_for (GTK_WINDOW (cs),
                                 GTK_WINDOW (w_current->main_window));
 

--- a/libleptongui/src/x_compselect.c
+++ b/libleptongui/src/x_compselect.c
@@ -269,11 +269,10 @@ x_compselect_open (GschemToplevel *w_current)
   GtkWidget *current_tab, *entry_filter;
   GtkNotebook *compselect_notebook;
 
-  if (w_current->cswindow == NULL) {
-    w_current->cswindow = schematic_compselect_new (w_current);
-  } else {
-    gtk_window_present (GTK_WINDOW (w_current->cswindow));
-  }
+  g_return_if_fail (w_current != NULL);
+  g_return_if_fail (w_current->cswindow != NULL);
+
+  gtk_window_present (GTK_WINDOW (w_current->cswindow));
   gtk_editable_select_region (GTK_EDITABLE (COMPSELECT (w_current->cswindow)->entry_filter), 0, -1);
 
   /* Set the focus to the filter entry only if it is in the current

--- a/libleptongui/src/x_compselect.c
+++ b/libleptongui/src/x_compselect.c
@@ -257,30 +257,27 @@ schematic_compselect_new (GschemToplevel *w_current)
 
 /*! \brief Opens a component selection dialog.
  *  \par Function Description
- *  This function opens the component chooser dialog for
- *  <B>toplevel</B> if it is not already. In this last case, it only
- *  raises the dialog.
+ *  This function opens the component chooser dialog.
  *
- *  \param [in] w_current  The GschemToplevel environment.
+ *  \param [in] cswindow  The component chooser widget.
  */
 void
-x_compselect_open (GschemToplevel *w_current)
+x_compselect_open (GtkWidget *cswindow)
 {
   GtkWidget *current_tab, *entry_filter;
   GtkNotebook *compselect_notebook;
 
-  g_return_if_fail (w_current != NULL);
-  g_return_if_fail (w_current->cswindow != NULL);
+  g_return_if_fail (cswindow != NULL);
 
-  gtk_window_present (GTK_WINDOW (w_current->cswindow));
-  gtk_editable_select_region (GTK_EDITABLE (COMPSELECT (w_current->cswindow)->entry_filter), 0, -1);
+  gtk_window_present (GTK_WINDOW (cswindow));
+  gtk_editable_select_region (GTK_EDITABLE (COMPSELECT (cswindow)->entry_filter), 0, -1);
 
   /* Set the focus to the filter entry only if it is in the current
      displayed tab */
-  compselect_notebook = GTK_NOTEBOOK (COMPSELECT (w_current->cswindow)->viewtabs);
+  compselect_notebook = GTK_NOTEBOOK (COMPSELECT (cswindow)->viewtabs);
   current_tab = gtk_notebook_get_nth_page (compselect_notebook,
                                            gtk_notebook_get_current_page (compselect_notebook));
-  entry_filter = GTK_WIDGET (COMPSELECT (w_current->cswindow)->entry_filter);
+  entry_filter = GTK_WIDGET (COMPSELECT (cswindow)->entry_filter);
   if (gtk_widget_is_ancestor (entry_filter, current_tab)) {
     gtk_widget_grab_focus (entry_filter);
   }

--- a/libleptongui/src/x_compselect.c
+++ b/libleptongui/src/x_compselect.c
@@ -198,12 +198,12 @@ x_compselect_callback_response (GtkDialog *dialog,
 }
 
 
-GschemPreview*
+GtkWidget*
 schematic_compselect_get_preview (Compselect *cs)
 {
   g_return_val_if_fail (cs != NULL, NULL);
 
-  return cs->preview;
+  return GTK_WIDGET (cs->preview);
 }
 
 
@@ -220,7 +220,7 @@ schematic_compselect_new (GschemToplevel *w_current)
                     G_CALLBACK (x_compselect_callback_response),
                     w_current);
 
-  GschemPreview *preview = schematic_compselect_get_preview (COMPSELECT (cs));
+  GtkWidget *preview = schematic_compselect_get_preview (COMPSELECT (cs));
 
   struct event_reg_t {
     const gchar *detailed_signal;
@@ -240,7 +240,7 @@ schematic_compselect_new (GschemToplevel *w_current)
 
   for (tmp = drawing_area_events; tmp->detailed_signal != NULL; tmp++)
   {
-    g_signal_connect (GTK_WIDGET (preview),
+    g_signal_connect (preview,
                       tmp->detailed_signal,
                       tmp->c_handler,
                       schematic_preview_get_preview_w_current (preview));

--- a/libleptongui/src/x_compselect.c
+++ b/libleptongui/src/x_compselect.c
@@ -243,7 +243,7 @@ schematic_compselect_new (GschemToplevel *w_current)
     g_signal_connect (GTK_WIDGET (preview),
                       tmp->detailed_signal,
                       tmp->c_handler,
-                      preview->preview_w_current);
+                      schematic_preview_get_preview_w_current (preview));
   }
 
   gtk_window_set_transient_for (GTK_WINDOW (cs),

--- a/libleptongui/src/x_compselect.c
+++ b/libleptongui/src/x_compselect.c
@@ -197,6 +197,29 @@ x_compselect_callback_response (GtkDialog *dialog,
 
 }
 
+
+GtkWidget*
+schematic_compselect_new (GschemToplevel *w_current)
+{
+  GtkWidget *cs = GTK_WIDGET (g_object_new (TYPE_COMPSELECT,
+                                            /* GschemDialog */
+                                            "settings-name", "compselect",
+                                            "gschem-toplevel", w_current,
+                                            NULL));
+  g_signal_connect (cs,
+                    "response",
+                    G_CALLBACK (x_compselect_callback_response),
+                    w_current);
+
+  gtk_window_set_transient_for (GTK_WINDOW (cs),
+                                GTK_WINDOW (w_current->main_window));
+
+  gtk_widget_show (cs);
+
+  return cs;
+}
+
+
 /*! \brief Opens a component selection dialog.
  *  \par Function Description
  *  This function opens the component chooser dialog for
@@ -212,23 +235,7 @@ x_compselect_open (GschemToplevel *w_current)
   GtkNotebook *compselect_notebook;
 
   if (w_current->cswindow == NULL) {
-    w_current->cswindow = GTK_WIDGET (
-      g_object_new (TYPE_COMPSELECT,
-                    /* GschemDialog */
-                    "settings-name", "compselect",
-                    "gschem-toplevel", w_current,
-                    NULL));
-
-    g_signal_connect (w_current->cswindow,
-                      "response",
-                      G_CALLBACK (x_compselect_callback_response),
-                      w_current);
-
-    gtk_window_set_transient_for (GTK_WINDOW (w_current->cswindow),
-                                  GTK_WINDOW (w_current->main_window));
-
-    gtk_widget_show (w_current->cswindow);
-
+    w_current->cswindow = schematic_compselect_new (w_current);
   } else {
     gtk_window_present (GTK_WINDOW (w_current->cswindow));
   }


### PR DESCRIPTION
The commit set includes changes as follows:
- Accessors for Component select widget pointer have been added.
- Getter for `GschemPreview`'s field `preview_w_current` has been
  added.
- A new function, `schematic_compselect_new()`, has been factored
  out.  It creates a `GtkWidget` object for the dialog and sets
  its initial properties.
- The dialog itself is now created in Scheme callback.
- The code of the dialog has been splitted up so signals related
  to it and its preview are connected in Scheme as well.
- `gschem_preview_new()` is no longer used for the Component
  selection dialog creation.  The function is still used in the
  File selection dialog code.
