### PR TITLE
Fix `make distcheck` when compiled with Guile 3.0

### DIFF
--- a/liblepton/scheme/lepton/toplevel.scm
+++ b/liblepton/scheme/lepton/toplevel.scm
@@ -30,21 +30,21 @@
             make-toplevel
             with-toplevel))
 
+;;; Initialize %lepton-toplevel with a new fluid variable for
+;;; Scheme and C code.
 ;;; This fluid is used for setting or getting the <toplevel>
 ;;; instance associated with the current dynamic context.
-(define %lepton-toplevel #f)
+(define %lepton-toplevel
+  (let ((toplevel-fluid (make-fluid)))
+    (lepton_init_toplevel_fluid (scm->pointer toplevel-fluid))
+    toplevel-fluid))
+
 
 (define (toplevel? toplevel)
   "Returns #t if TOPLEVEL is a <toplevel> instance, otherwise
 returns #f."
   (is-toplevel? toplevel))
 
-
-;;; Initialize %lepton-toplevel with a new fluid variable for
-;;; Scheme and C code.  Do it once.
-(when (not %lepton-toplevel)
-  (set! %lepton-toplevel (make-fluid))
-  (lepton_init_toplevel_fluid (scm->pointer %lepton-toplevel)))
 
 
 (define (make-toplevel)


### PR DESCRIPTION
As it is mentioned in [Guile 3.0.8 NEWS](https://git.savannah.gnu.org/cgit/guile.git/tree/NEWS?h=v3.0.8#n8),
in the 3.0 series Guile developers introduced new kinds of
optimizations treating Scheme modules as *declarative* and
inlining some of their toplevel exported definitions into other
modules.  This facility is enabled at the default `-O2`
optimization level when a module is compiled, that is, it is used
during auto-compilation as well.

I didn't notice any problems with this approach until #985
revealed one issue.  Afterwards, I could reproduce the issue on my
own PC while my Lepton fork on GH that runs tests under Guile 3.0
works OK.  I mentioned this [here](https://github.com/lepton-eda/lepton-eda/issues/985#issuecomment-1359007954).
`make distcheck` on my system triggered the same backtraces under
Guile 3.0 as the topic-starter provided in #985.

It's interesting that the issue has been introduced by me in
commit 9077e46d7, just after I released 1.9.18.

The proposed solution in this branch is to merge
`%lepton-toplevel` fluid initialization code into its definition.
It should prevent inlining its current value `#f` into any other
module.  At least, on my system the commit provided here fixes
`make distcheck`.

Closes #985 
(hopefully, as the author of the issue didn't respond
to my question)