### PR TITLE
lepton-netlist: Introduce **module backends**.

### DIFF
--- a/docs/manual/lepton-netlist-backends.texi
+++ b/docs/manual/lepton-netlist-backends.texi
@@ -175,8 +175,9 @@ defined as follows:
 
 So, if you want the backend to be available system-wide, put it in the
 @file{scheme/backend} subdirectory of one of the directories reported
-by the function @code{sys-data-dirs}, e.g. @file{/etc/lepton-eda}.  To
-find out the paths, you can use @command{lepton-shell}.  For example:
+by the function @code{sys-data-dirs},
+e.g. @file{/usr/share/lepton-eda}.  To find out the paths, you can use
+@command{lepton-shell}.  For example:
 
 @example
 $ lepton-shell -c '(use-modules (lepton os)) (display (sys-data-dirs))'

--- a/docs/manual/lepton-netlist-backends.texi
+++ b/docs/manual/lepton-netlist-backends.texi
@@ -209,6 +209,10 @@ $ cp my-backend.scm /home/vzh/.local/share/lepton-eda/scheme/backend
 @cindex custom legacy backends
 @cindex writing custom legacy backend
 
+Writing a custom legacy backend is simple.  Create a file named
+@file{gnet-@var{backend-name}.scm} and define a function
+@var{backend-name} in it.  Then put the file into one of the
+directories @netlist{} searches for Scheme files.
 
 @node Custom module backends
 @subsubsection Custom module backends

--- a/docs/manual/lepton-netlist-backends.texi
+++ b/docs/manual/lepton-netlist-backends.texi
@@ -195,3 +195,168 @@ $ lepton-shell -c '(use-modules (lepton os)) (display (user-data-dir))'
 /home/vzh/.local/share/lepton-eda
 $ cp my-backend.scm /home/vzh/.local/share/lepton-eda/scheme/backend
 @end example
+
+
+@node Custom backends
+@subsection Writing custom backends
+@cindex custom backend example
+@cindex custom backends
+@cindex writing custom backends
+
+
+@node Custom legacy backends
+@subsubsection Custom legacy backends
+@cindex custom legacy backends
+@cindex writing custom legacy backend
+
+
+@node Custom module backends
+@subsubsection Custom module backends
+@cindex custom module backends
+@cindex writing custom module backend
+
+Let's create some new custom backends. Here is how you can do it.
+
+Create a file named @file{custom-backend.scm} with the following
+contents:
+
+@lisp
+(define-module (backend custom-backend)
+  #:use-module (netlist schematic)
+  #:use-module (netlist schematic toplevel)
+  #:export (custom-backend))
+
+(define (custom-backend)
+  (display (schematic-components (toplevel-schematic))))
+@end lisp
+
+Put the file into the directory
+@file{~/.local/share/lepton-eda/scheme/backend}.  Now, @netlist{}
+should report its name if you launch it with the option
+@option{--list-backends}:
+@example
+$ lepton-netlist --list-backends
+...
+custom-backend
+...
+@end example
+
+Run it:
+@example
+$ lepton-netlist -g custom-backend my-schematic.sch
+@end example
+
+The output in the file @file{output.net} in the current working
+directory may look as follows:
+@example
+(#<geda-schematic-component 54> #<geda-schematic-component 90>)
+@end example
+
+You can use pre-load (@option{-l}) and post-load (@option{-m}) scripts
+along with legacy backends to maybe redefine some code or re-use it.
+Pre- and post-loading functionality is not used for module backends.
+Instead of loading a backend and then redefining its functions using
+@option{-m}, you can define a new module backend and redefine or
+re-use the functions in it.  Pre-loading by the option @option{-l} can
+be changed the same way, just define a module and use its functions in
+another module.  If you want to use the code from a legacy backend,
+just @code{primitive-load} its file.  Here are several examples.
+
+Let's suppose that you have a legacy backend named
+@file{gnet-legacy.scm} and want to re-use its main function
+@code{legacy()} in your code.  It may live in any directory defined in
+@netlist{}'s @code{%load-path}.  To check the contents of
+@code{%load-path} you can issue the following command:
+
+@example
+lepton-netlist -c '(display %load-path)'
+@end example
+
+or just open @netlist in interactive-mode
+
+@example
+@end example
+
+enter @code{%load-path} and hit @kbd{@key{RET}}.
+
+The contents of your backend can then be changed to something like
+this:
+
+@lisp
+(define-module (backend custom-backend)
+  #:use-module (netlist schematic)
+  #:use-module (netlist schematic toplevel)
+  #:export (custom-backend))
+
+(primitive-load "gnet-legacy.scm")  ; <= new line
+
+(define (custom-backend)
+  (display (legacy))  ; <= new line
+  (display (schematic-components (toplevel-schematic))))
+@end lisp
+
+You don't have to put the file into a load path known for @netlist{}.
+To use your file from any other directory, just specify its absolute
+path in @code{primitive-load}, e.g. @code{(primitive-load
+"/tmp/gnet-legacy.scm")}.
+
+If you want to pre-load a module backend and use its contents, just
+import it in the code and use its exported function.
+
+Supposed you have a backend file @file{print-config.scm} in your user
+backend directory with the following contents:
+
+@lisp
+(define-module (backend print-config)
+  #:use-module (netlist config)
+  #:export (print-config))
+
+(define (print-config)
+  (print-netlist-config))
+@end lisp
+
+and want to use it in the above custom backend, you just edit the
+custom backend as follows:
+
+@lisp
+(define-module (backend custom-backend)
+  #:use-module (netlist schematic)
+  #:use-module (netlist schematic toplevel)
+  #:use-module (backend print-config)  ; <= new line
+  #:export (custom-backend))
+
+(define (custom-backend)
+  (print-config)  ; <= new line
+  (display (schematic-components (toplevel-schematic))))
+@end lisp
+
+Post-loading function is no longer necessary, either.  If you want to
+add some functionality without modifying an original backend code,
+just add a new backend.
+
+For instance, you want to output some additional, maybe debugging,
+information before and after the output of the function
+@code{custom-backend()}.  What you need is just a new backend module
+in your user backend directory which re-uses the function.  To
+accomplish that, you could make a backend file with the following
+contents:
+
+@lisp
+(define-module (backend add-headers-and-footers)
+  #:use-module (backend custom-backend)
+  #:export (add-headers-and-footers))
+
+(define (add-headers-and-footers)
+  (display "Those are schematic components:\n")  ; <= header
+  (custom-backend)  ; <= main backend output
+  (display "That's all folks!")  ; <= footer)
+@end lisp
+
+Name the file @file{add-headers-and-footers.scm} and put it into one
+of your backend directories, then run:
+
+@example
+$ lepton-netlist -g add-headers-and-footers my-schematic.sch
+@end example
+
+and you're done, congrats!

--- a/docs/manual/lepton-netlist-backends.texi
+++ b/docs/manual/lepton-netlist-backends.texi
@@ -75,12 +75,38 @@ Backends for testing contents of a schematic.
 @cindex backend types
 @cindex lepton-netlist backend types
 
-Backend system has been inherited from gEDA @command{gnetlist} and
-currently, there is only one type of backends for @netlist{}:
-@dfn{backend} is a simple Scheme @emph{script} containing a
-@emph{definition} of its main function.
+Currently, there are two types of backends for @netlist{}:
 
-In order @netlist{} to understand a file is a backend, it must
+@itemize
+@item
+@dfn{Legacy backend} is a simple Scheme @emph{script} containing a
+@emph{definition} of its main function.
+@item
+@dfn{Module backend} is a Scheme @emph{module} that apart from
+definition should @emph{export} its main function.
+@end itemize
+
+Initially, legacy backend system had been inherited from gEDA
+@command{gnetlist}, and since its invention, file names of legacy
+backends had to have, and must now have, the prefix @file{gnet-}.  As
+both types of backends are Scheme files, they should have the
+extension @file{.scm}.  A backend of any type should define a main
+function named the same as the backend itself.  Please note that the
+name of a backend is not the same as of its file name.  Subtle
+differences in naming will be revealed in the next sections.
+
+In both cases @netlist{} loads and evaluates the main backend function
+at a certain stage of its execution.
+
+
+@node Legacy backends
+@subsubsection Legacy backends
+@cindex legacy backends
+@cindex lepton-netlist legacy backends
+
+Legacy backend system has been inherited from gEDA @command{gnetlist}.
+
+In order @netlist{} to understand a file is a legacy backend, it must
 meet the following requirements:
 @itemize
 @item
@@ -100,3 +126,9 @@ argument which is the output file name.  Really, it is not necessary
 to use this argument in the code as @netlist{} automatically redirects
 the standard output of the function into a file if it is specified by
 its command-line arguments.
+
+
+@node Module backends
+@subsubsection Module backends
+@cindex module backends
+@cindex lepton-netlist module backends

--- a/docs/manual/lepton-netlist-backends.texi
+++ b/docs/manual/lepton-netlist-backends.texi
@@ -14,40 +14,6 @@ own way to transform the schematic model.  In the command-line, the
 user may specify only one backend at a time.
 
 
-
-@node Backend types
-@subsection Backend types
-@cindex backend types
-@cindex lepton-netlist backend types
-
-Backend system has been inherited from gEDA @command{gnetlist} and
-currently, there is only one type of backends for @netlist{}:
-@dfn{backend} is a simple Scheme @emph{script} containing a
-@emph{definition} of its main function.
-
-In order @netlist{} to understand a file is a backend, it must
-meet the following requirements:
-@itemize
-@item
-Its filename must have the @file{gnet-} prefix.
-@item
-The filename must have the extension @file{.scm}.
-@item
-It should export a function named the same as backend itself.
-@end itemize
-
-The name of the backend is defined by removing the prefix @file{gnet-}
-and the suffix @file{.scm} from its file basename.  For example, if
-backend file name is @file{gnet-custom-backend.scm}, its name is
-@code{custom-backend} and its code has to contain a definition of a
-function named @code{custom-backend}.  The function must take one
-argument which is the output file name.  Really, it is not necessary
-to use this argument in the code as @netlist{} automatically redirects
-the standard output of the function into a file if it is specified by
-its command-line arguments.
-
-
-
 @node Backend launching
 @subsection Backend launching
 @cindex backend launching
@@ -102,3 +68,35 @@ Backends for automation.
 @item
 Backends for testing contents of a schematic.
 @end itemize
+
+
+@node Backend types
+@subsection Backend types
+@cindex backend types
+@cindex lepton-netlist backend types
+
+Backend system has been inherited from gEDA @command{gnetlist} and
+currently, there is only one type of backends for @netlist{}:
+@dfn{backend} is a simple Scheme @emph{script} containing a
+@emph{definition} of its main function.
+
+In order @netlist{} to understand a file is a backend, it must
+meet the following requirements:
+@itemize
+@item
+Its filename must have the @file{gnet-} prefix.
+@item
+The filename must have the extension @file{.scm}.
+@item
+It should export a function named the same as backend itself.
+@end itemize
+
+The name of the backend is defined by removing the prefix @file{gnet-}
+and the suffix @file{.scm} from its file basename.  For example, if
+backend file name is @file{gnet-custom-backend.scm}, its name is
+@code{custom-backend} and its code has to contain a definition of a
+function named @code{custom-backend}.  The function must take one
+argument which is the output file name.  Really, it is not necessary
+to use this argument in the code as @netlist{} automatically redirects
+the standard output of the function into a file if it is specified by
+its command-line arguments.

--- a/docs/manual/lepton-netlist-backends.texi
+++ b/docs/manual/lepton-netlist-backends.texi
@@ -214,6 +214,33 @@ Writing a custom legacy backend is simple.  Create a file named
 @var{backend-name} in it.  Then put the file into one of the
 directories @netlist{} searches for Scheme files.
 
+For instance, create a file @file{gnet-my-backend.scm} in the directory
+@file{~/.local/share/lepton-eda/scheme} with the following contens:
+
+@lisp
+(use-modules (netlist schematic)
+             (netlist schematic toplevel))
+
+(define (my-backend output-filename)
+  (display (schematic-nets (toplevel-schematic)))
+  (newline))
+@end lisp
+
+Check that @netlist{} outputs its name in the list of known backend names:
+@example
+$ lepton-netlist --list-backends
+...
+my-backend
+...
+@end example
+
+And you can already try it:
+@example
+$ lepton-netlist -o - -g my-backend my-schematic.sch
+(GND 1 2 unnamed_net1)
+@end example
+
+That's all!
 @node Custom module backends
 @subsubsection Custom module backends
 @cindex custom module backends

--- a/docs/manual/lepton-netlist-backends.texi
+++ b/docs/manual/lepton-netlist-backends.texi
@@ -132,3 +132,66 @@ its command-line arguments.
 @subsubsection Module backends
 @cindex module backends
 @cindex lepton-netlist module backends
+
+Unlike legacy backends, a module backend is simply a Scheme module.
+In order @netlist{} to understand a file is a module backend, it must
+meet the following requirements:
+
+@itemize
+@item
+The filename must have the extension @file{.scm}.
+@item
+It must define the module in the @samp{backend} namespace and export
+the same named function.
+@item
+It must live in one of Lepton's user or system data directories.
+@end itemize
+
+For example, the name of your backend is @file{my-backend.scm}.  In
+the code, you have to add module definition as follows:
+
+@lisp
+(define-module (backend my-backend)
+  #:export (my-backend))
+@end lisp
+
+The exported function has take no arguments.  What it outputs to the
+standard output port is redirected by @netlist{} to the specified
+output file or standard output, or to the default output name if no
+output file name is specified.
+
+The function may be defined as follows:
+@lisp
+(define (my-backend)
+  (some-code-follows) ...)
+@end lisp
+
+To make the function take an arbitrary list of arguments, it can be
+defined as follows:
+@lisp
+(define (my-backend . args)
+  (some-code-that-use-args args) ...)
+@end lisp
+
+So, if you want the backend to be available system-wide, put it in the
+@file{scheme/backend} subdirectory of one of the directories reported
+by the function @code{sys-data-dirs}, e.g. @file{/etc/lepton-eda}.  To
+find out the paths, you can use @command{lepton-shell}.  For example:
+
+@example
+$ lepton-shell -c '(use-modules (lepton os)) (display (sys-data-dirs))'
+(/usr/local/share/lepton-eda /usr/share/lepton-eda)
+$ sudo cp my-backend.scm /usr/local/share/lepton-eda/scheme/backend
+@end example
+
+If you want the backend to be available only for you, e.g. when you're
+just developing it, put it into the @file{scheme/backend/}
+subdirectory of your Lepton user data directory which can be found
+using the function @code{user-data-dir}, typically
+@file{~/.local/share/lepton-eda}.  For example:
+
+@example
+$ lepton-shell -c '(use-modules (lepton os)) (display (user-data-dir))'
+/home/vzh/.local/share/lepton-eda
+$ cp my-backend.scm /home/vzh/.local/share/lepton-eda/scheme/backend
+@end example

--- a/liblepton/scheme/Makefile.am
+++ b/liblepton/scheme/Makefile.am
@@ -52,6 +52,7 @@ nobase_dist_scmdata_DATA = \
 	netlist/attrib/compare.scm \
 	netlist/attrib/refdes.scm \
 	netlist/backend-getopt.scm \
+	netlist/backend.scm \
 	netlist/config.scm \
 	netlist/deprecated.scm \
 	netlist/duplicate.scm \

--- a/liblepton/scheme/netlist.scm
+++ b/liblepton/scheme/netlist.scm
@@ -22,7 +22,6 @@
   #:use-module (ice-9 ftw)
   #:use-module (ice-9 i18n)
   #:use-module (ice-9 match)
-  #:use-module (ice-9 regex)
   #:use-module (srfi srfi-1)
   #:use-module (srfi srfi-26)
 
@@ -937,18 +936,6 @@ Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>
   ( define ( error-backend-mode mode )
     (netlist-error 1 (G_ "Netlist mode requested by backend is not supported: ~A\n") mode)
   )
-
-  (define (backend-filename->proc-name filename )
-  ( let*
-    (
-    ( bname (basename filename) )
-    ( re    (string-match "^gnet-(.*).scm$" bname) )
-    )
-
-    ;; Return the function name if the file name matched the above
-    ;; regexp, otherwise return #f.
-    (and re
-         (match:substring re 1))))
 
   ; Backend can request what netlist mode should be used
   ; by providing request-netlist-mode() function, that

--- a/liblepton/scheme/netlist.scm
+++ b/liblepton/scheme/netlist.scm
@@ -885,7 +885,6 @@ Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>
   ( opt-pre-load      (netlist-option-ref 'pre-load) )      ; -l
   ( opt-post-load     (netlist-option-ref 'post-load) )     ; -m
   ( backend-path      #f )
-  ( schematic         #f )
   ( backend-proc-name #f )
   )
 
@@ -995,16 +994,14 @@ Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>
   (load-scheme-scripts opt-post-load
                        (G_ "Failed to load Scheme file after loading backend.\n"))
 
-  ; This sets [toplevel-schematic] global variable:
-  ;
-  (set! schematic (set-ln-toplevel-schematic! files))
-
-  ;; Verbose mode (-v).
-  (when opt-verbose
-    ;; Print configuration.
-    (print-netlist-config)
-    ;; Print internal netlist representation.
-    (verbose-print-netlist (schematic-components schematic)))
+  ;; This sets [toplevel-schematic] global variable.
+  (let ((schematic (set-ln-toplevel-schematic! files)))
+    ;; Verbose mode (-v).
+    (when opt-verbose
+      ;; Print configuration.
+      (print-netlist-config)
+      ;; Print internal netlist representation.
+      (verbose-print-netlist (schematic-components schematic))))
 
   ; Do actual work:
   ;

--- a/liblepton/scheme/netlist.scm
+++ b/liblepton/scheme/netlist.scm
@@ -924,6 +924,15 @@ Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>
      ;; If it is specified by name, search for its file.
      (and=> opt-backend search-backend)))
 
+  (define (get-backend-proc-name)
+    (cond
+     (opt-file-backend
+      (let ((proc-name (backend-filename->proc-name opt-file-backend)))
+        (or proc-name
+            (error-backend-file-name opt-file-backend))))
+     (opt-backend opt-backend)
+     (else #f)))
+
   ; Parse configuration:
   ;
   (parse-rc "lepton-netlist" "gnetlistrc")
@@ -968,20 +977,7 @@ Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>
   (load-scheme-scripts opt-pre-load)
 
   (set! backend-path (get-backend-path))
-  ; Backend specified by name:
-  ;
-  ( when opt-backend
-    ( set! backend-proc-name opt-backend )
-  )
-
-  ; Backend specified by file name:
-  ;
-  ( when opt-file-backend
-    (let ((proc-name (backend-filename->proc-name backend-path)))
-      (if proc-name
-          (set! backend-proc-name proc-name)
-          (error-backend-file-name backend-path))))
-
+  (set! backend-proc-name (get-backend-proc-name))
 
   ; Load backend file:
   ;

--- a/liblepton/scheme/netlist.scm
+++ b/liblepton/scheme/netlist.scm
@@ -936,26 +936,18 @@ Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>
     )
   )
 
-  ( when opt-help
-    ( usage )
-  )
-
-  ( when opt-version
-    ( display-lepton-version #:print-name #t #:copyright #t )
-    ( primitive-exit 0 )
-  )
-
-  ( when opt-list-backends
-    ( lookup-backends )
-    ( primitive-exit 0 )
-  )
-
-  ; Check input schematics:
-  ;
-  ( when ( and (null? files) (not opt-interactive) )
-    ( error-no-sch )
-  )
-
+  (cond
+   (opt-help (usage))
+   (opt-version
+    (display-lepton-version #:print-name #t #:copyright #t)
+    (primitive-exit 0))
+   (opt-list-backends
+    (lookup-backends)
+    (primitive-exit 0))
+   ;; Check input schematics.
+   ((and (null? files)
+         (not opt-interactive))
+    (error-no-sch)))
 
   ; Load Scheme FILE before loading backend (-l FILE):
   (load-scheme-scripts opt-pre-load

--- a/liblepton/scheme/netlist.scm
+++ b/liblepton/scheme/netlist.scm
@@ -858,13 +858,17 @@ Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>
 ;;; Loads the list of Scheme scripts LS reporting ERROR-MSG if
 ;;; something went wrong.  In the latter case, the program exits
 ;;; with exit status 1.
-(define (load-scheme-scripts ls error-msg)
+(define* (load-scheme-scripts ls #:optional (post-load? #f))
+  (define pre-load-error
+    (G_ "Failed to load Scheme file before loading backend.\n"))
+  (define post-load-error
+    (G_ "Failed to load Scheme file after loading backend.\n"))
   (catch #t
     (lambda ()
       (for-each load-scheme-script ls))
     (lambda (tag . args)
       (catch-handler tag args)
-      (netlist-error 1 error-msg))))
+      (netlist-error 1 (if post-load? post-load-error pre-load-error)))))
 
 
 ;;; Main program
@@ -955,8 +959,7 @@ Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>
 
 
   ; Load Scheme FILE before loading backend (-l FILE):
-  (load-scheme-scripts opt-pre-load
-                       (G_ "Failed to load Scheme file before loading backend.\n"))
+  (load-scheme-scripts opt-pre-load)
 
   ; Backend specified by name:
   ;
@@ -991,8 +994,7 @@ Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>
   )
 
   ; Load Scheme FILE after loading backend (-m FILE):
-  (load-scheme-scripts opt-post-load
-                       (G_ "Failed to load Scheme file after loading backend.\n"))
+  (load-scheme-scripts opt-post-load 'post-load)
 
   ;; This sets [toplevel-schematic] global variable.
   (let ((schematic (set-ln-toplevel-schematic! files)))

--- a/liblepton/scheme/netlist.scm
+++ b/liblepton/scheme/netlist.scm
@@ -812,7 +812,8 @@ Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>
 
 
 ;;; Set lepton-netlist toplevel schematic based on schematic FILES
-;;; and NETLIST-MODE which must be either "'geda", or "'spice".
+;;; and current netlist mode specified somewhere else.  Currently,
+;;; the netlist mode can be either "'geda", or "'spice".
 (define (set-ln-toplevel-schematic! files)
   (define (process-gafrc* name)
     (process-gafrc "lepton-netlist" name))

--- a/liblepton/scheme/netlist.scm
+++ b/liblepton/scheme/netlist.scm
@@ -813,12 +813,11 @@ Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>
 
 
 (define (display-backend-list)
-  (display (string-join
-            (sort! (append (lookup-module-backends)
-                           (lookup-legacy-backends))
-                   string-locale<?)
-            "\n"
-            'suffix))
+  (define (display-list ls)
+    (display (string-join (sort! ls string-locale<?) "\n" 'suffix)))
+
+  (display-list (lookup-module-backends))
+  (display-list (lookup-legacy-backends))
   (primitive-exit 0))
 
 

--- a/liblepton/scheme/netlist.scm
+++ b/liblepton/scheme/netlist.scm
@@ -788,27 +788,15 @@ other limitations imposed by this netlist format.
 files in each of the directories in the current Guile %load-path.
 A file is considered to be a gnetlist backend if its basename
 begins with \"gnet-\" and ends with \".scm\"."
-  (define backend-prefix "gnet-")
-  (define backend-suffix ".scm")
-  (define prefix-length (string-length backend-prefix))
-  (define suffix-length (string-length backend-suffix))
-
-  (define (backend? filename)
-    (and (string-prefix? backend-prefix filename)
-         (string-suffix? backend-suffix filename)))
-
-  (define (backend-name filename)
-    (string-drop-right (string-drop filename prefix-length) suffix-length))
-
   (define (path-backends path)
-    (or (scandir path backend?)
+    (or (scandir path backend-filename?)
         (begin
           (log! 'warning (G_ "Can't open directory ~S.\n") path)
           '())))
 
   (let ((backend-files (append-map path-backends (delete-duplicates %load-path))))
     (display (string-join
-              (sort! (map backend-name backend-files) string-locale<?)
+              (sort! (map backend-filename->proc-name backend-files) string-locale<?)
               "\n"
               'suffix))))
 

--- a/liblepton/scheme/netlist.scm
+++ b/liblepton/scheme/netlist.scm
@@ -876,6 +876,15 @@ Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>
       (netlist-error 1 (if post-load? post-load-error pre-load-error)))))
 
 
+(define (eval-startup-expressions string-ls)
+  (unless (null? string-ls)
+    (catch #t
+      (lambda () (for-each eval-string string-ls))
+      (lambda (tag . args)
+        (catch-handler tag args)
+        (netlist-error 1 (G_ "Failed to evaluate Scheme expression at startup.\n"))))))
+
+
 ;;; Main program
 ;;;
 ( define ( main )
@@ -912,19 +921,8 @@ Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>
   ;
   ( set-netlist-mode! (default-netlist-mode) )
 
-  ; Evaluate Scheme expression at startup (-c EXPR):
-  ;
-  ( unless ( null? opt-code-to-eval )
-    ( catch #t
-      ( lambda()
-        (for-each eval-string opt-code-to-eval)
-      )
-      ( lambda( tag . args )
-        ( catch-handler tag args )
-        ( netlist-error 1 (G_ "Failed to evaluate Scheme expression at startup.\n") )
-      )
-    )
-  )
+  ;; Evaluate Scheme expression at startup (-c EXPR):
+  (eval-startup-expressions opt-code-to-eval)
 
   (cond
    (opt-help (usage))

--- a/liblepton/scheme/netlist.scm
+++ b/liblepton/scheme/netlist.scm
@@ -945,13 +945,10 @@ Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>
     ( re    (string-match "^gnet-(.*).scm$" bname) )
     )
 
-    ; return:
-    ( if re
-        ( match:substring re 1 )          ; if
-        ( error-backend-file-name bname ) ; else
-    )
-  )
-  )
+    ;; Return the function name if the file name matched the above
+    ;; regexp, otherwise return #f.
+    (and re
+         (match:substring re 1))))
 
   ; Backend can request what netlist mode should be used
   ; by providing request-netlist-mode() function, that
@@ -1044,8 +1041,10 @@ Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>
   ;
   ( when opt-file-backend
     ( set! backend-path opt-file-backend )
-    ( set! backend-proc-name (backend-filename->proc-name backend-path) )
-  )
+    (let ((proc-name (backend-filename->proc-name backend-path)))
+      (if proc-name
+          (set! backend-proc-name proc-name)
+          (error-backend-file-name (basename backend-path)))))
 
 
   ; Load backend file:

--- a/liblepton/scheme/netlist.scm
+++ b/liblepton/scheme/netlist.scm
@@ -927,11 +927,11 @@ Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>
                      backend (car (program-arguments)))
   )
 
-  ( define ( error-backend-file-name bname )
+  ( define ( error-backend-file-name name )
     (netlist-error 1 (G_ "Can't load backend file ~S.\n~
                          Backend files are expected to have names like \"gnet-NAME.scm\"\n~
                          and contain entry point function NAME (where NAME is the backend's name).\n")
-                     bname)
+                     name)
   )
 
   ( define ( error-backend-mode mode )
@@ -1044,7 +1044,7 @@ Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>
     (let ((proc-name (backend-filename->proc-name backend-path)))
       (if proc-name
           (set! backend-proc-name proc-name)
-          (error-backend-file-name (basename backend-path)))))
+          (error-backend-file-name backend-path))))
 
 
   ; Load backend file:

--- a/liblepton/scheme/netlist.scm
+++ b/liblepton/scheme/netlist.scm
@@ -913,34 +913,6 @@ Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>
                      name)
   )
 
-  ( define ( error-backend-mode mode )
-    (netlist-error 1 (G_ "Netlist mode requested by backend is not supported: ~A\n") mode)
-  )
-
-  ; Backend can request what netlist mode should be used
-  ; by providing request-netlist-mode() function, that
-  ; returns the desired mode:
-  ;
-  ( define ( query-backend-mode )
-  ( let*
-    (
-    ( proc-name 'request-netlist-mode )
-    ( proc      (module-variable (current-module) proc-name) )
-    ( mode      #f )
-    )
-
-    ( when proc
-      ( set! proc ( primitive-eval proc-name ) )
-      ( set! mode ( proc ) )
-
-      ( if ( netlist-mode? mode )
-        ( set-netlist-mode!  mode ) ; if
-        ( error-backend-mode mode ) ; else
-      )
-    )
-  )
-  )
-
 
   ; Parse configuration:
   ;

--- a/liblepton/scheme/netlist.scm
+++ b/liblepton/scheme/netlist.scm
@@ -966,7 +966,7 @@ Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>
   ;
   ( if opt-interactive
     ( lepton-repl )
-    ( run-backend %backend-name output-filename )
+    ( run-backend output-filename )
   )
 
 ) ; let

--- a/liblepton/scheme/netlist.scm
+++ b/liblepton/scheme/netlist.scm
@@ -794,11 +794,17 @@ begins with \"gnet-\" and ends with \".scm\"."
           (log! 'warning (G_ "Can't open directory ~S.\n") path)
           '())))
 
-  (let ((backend-files (append-map path-backends (delete-duplicates %load-path))))
-    (display (string-join
-              (sort! (map backend-filename->proc-name backend-files) string-locale<?)
-              "\n"
-              'suffix))))
+  (define backend-files
+    (append-map path-backends (delete-duplicates %load-path)))
+
+  (define backend-names
+    (map backend-filename->proc-name backend-files))
+
+  (display (string-join
+            (sort! backend-names string-locale<?)
+            "\n"
+            'suffix)))
+
 
 (define (usage)
   (format #t (G_

--- a/liblepton/scheme/netlist.scm
+++ b/liblepton/scheme/netlist.scm
@@ -854,6 +854,18 @@ Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>
             (log! 'warning (G_ "Could not find file ~S in %load-path.") filename)))))
 
 
+;;; Loads the list of Scheme scripts LS reporting ERROR-MSG if
+;;; something went wrong.  In the latter case, the program exits
+;;; with exit status 1.
+(define (load-scheme-scripts ls error-msg)
+  (catch #t
+    (lambda ()
+      (for-each load-scheme-script ls))
+    (lambda (tag . args)
+      (catch-handler tag args)
+      (netlist-error 1 error-msg))))
+
+
 ;;; Main program
 ;;;
 ( define ( main )
@@ -974,16 +986,8 @@ Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>
 
 
   ; Load Scheme FILE before loading backend (-l FILE):
-  ;
-  ( catch #t
-    ( lambda()
-      (for-each load-scheme-script opt-pre-load)
-    )
-    ( lambda( tag . args )
-      ( catch-handler tag args )
-      ( netlist-error 1 (G_ "Failed to load Scheme file before loading backend.\n") )
-    )
-  )
+  (load-scheme-scripts opt-pre-load
+                       (G_ "Failed to load Scheme file before loading backend.\n"))
 
   ; Backend specified by name:
   ;
@@ -1018,16 +1022,8 @@ Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>
   )
 
   ; Load Scheme FILE after loading backend (-m FILE):
-  ;
-  ( catch #t
-    ( lambda()
-      (for-each load-scheme-script opt-post-load)
-    )
-    ( lambda( tag . args )
-      ( catch-handler tag args )
-      ( netlist-error 1 (G_ "Failed to load Scheme file after loading backend.\n") )
-    )
-  )
+  (load-scheme-scripts opt-post-load
+                       (G_ "Failed to load Scheme file after loading backend.\n"))
 
   ; Verbose mode (-v): print configuration:
   ;

--- a/liblepton/scheme/netlist.scm
+++ b/liblepton/scheme/netlist.scm
@@ -947,7 +947,12 @@ Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>
    ;; Check input schematics.
    ((and (null? files)
          (not opt-interactive))
-    (error-no-sch)))
+    (error-no-sch))
+   ;; Neither backend (-g or -f), nor interactive mode (-i)
+   ;; specified.
+   ((not (or opt-backend opt-file-backend opt-interactive))
+    (error-no-backend)))
+
 
   ; Load Scheme FILE before loading backend (-l FILE):
   (load-scheme-scripts opt-pre-load
@@ -993,12 +998,6 @@ Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>
   ;
   ( when opt-verbose
     ( print-netlist-config )
-  )
-
-  ; Neither backend (-g or -f), nor interactive mode (-i) specified:
-  ;
-  ( unless ( or opt-backend opt-file-backend opt-interactive )
-    ( error-no-backend )
   )
 
   ; This sets [toplevel-schematic] global variable:

--- a/liblepton/scheme/netlist.scm
+++ b/liblepton/scheme/netlist.scm
@@ -782,12 +782,10 @@ other limitations imposed by this netlist format.
          name)))
 
 
-;;; Prints a list of available backends.
-(define (gnetlist-backends)
-  "Prints a list of available gnetlist backends by searching for
-files in each of the directories in the current Guile %load-path.
-A file is considered to be a gnetlist backend if its basename
-begins with \"gnet-\" and ends with \".scm\"."
+(define (lookup-backends)
+  "Searches %load-path for available lepton-netlist backends and
+prints the resulting list.  A file is considered to be a backend
+if its basename begins with \"gnet-\" and ends with \".scm\"."
   (define (path-backends path)
     (or (scandir path backend-filename?)
         (begin
@@ -988,7 +986,7 @@ Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>
   )
 
   ( when opt-list-backends
-    ( gnetlist-backends )
+    ( lookup-backends )
     ( primitive-exit 0 )
   )
 

--- a/liblepton/scheme/netlist.scm
+++ b/liblepton/scheme/netlist.scm
@@ -902,16 +902,6 @@ Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>
                      (car (program-arguments)))
   )
 
-  (define (load-backend-file filename)
-    (when filename
-      (catch #t
-        (lambda ()
-          (primitive-load filename)
-          (query-backend-mode))
-        (lambda (tag . args)
-          (catch-handler tag args)
-          (netlist-error 1 (G_ "Failed to load backend file.\n"))))))
-
   ; Parse configuration:
   ;
   (parse-rc "lepton-netlist" "gnetlistrc")

--- a/liblepton/scheme/netlist.scm
+++ b/liblepton/scheme/netlist.scm
@@ -917,6 +917,12 @@ Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>
                      name)
   )
 
+  (define (get-backend-path)
+    (or
+     ;; If backend is specified by file name, use it as is.
+     opt-file-backend
+     ;; If it is specified by name, search for its file.
+     (and=> opt-backend search-backend)))
 
   ; Parse configuration:
   ;
@@ -961,17 +967,16 @@ Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>
   ; Load Scheme FILE before loading backend (-l FILE):
   (load-scheme-scripts opt-pre-load)
 
+  (set! backend-path (get-backend-path))
   ; Backend specified by name:
   ;
   ( when opt-backend
-    ( set! backend-path (search-backend opt-backend) )
     ( set! backend-proc-name opt-backend )
   )
 
   ; Backend specified by file name:
   ;
   ( when opt-file-backend
-    ( set! backend-path opt-file-backend )
     (let ((proc-name (backend-filename->proc-name backend-path)))
       (if proc-name
           (set! backend-proc-name proc-name)

--- a/liblepton/scheme/netlist.scm
+++ b/liblepton/scheme/netlist.scm
@@ -954,13 +954,14 @@ Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>
   (load-scheme-scripts opt-post-load 'post-load)
 
   ;; This sets [toplevel-schematic] global variable.
-  (let ((schematic (set-ln-toplevel-schematic! files)))
-    ;; Verbose mode (-v).
-    (when opt-verbose
-      ;; Print configuration.
-      (print-netlist-config)
-      ;; Print internal netlist representation.
-      (verbose-print-netlist (schematic-components schematic))))
+  (set-ln-toplevel-schematic! files)
+
+  ;; Verbose mode (-v).
+  (when opt-verbose
+    ;; Print configuration.
+    (print-netlist-config)
+    ;; Print internal netlist representation.
+    (verbose-print-netlist (schematic-components (toplevel-schematic))))
 
   ; Do actual work:
   ;

--- a/liblepton/scheme/netlist.scm
+++ b/liblepton/scheme/netlist.scm
@@ -814,7 +814,9 @@ Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>
 
 (define (display-backend-list)
   (display (string-join
-            (sort! (lookup-backends) string-locale<?)
+            (sort! (append (lookup-module-backends)
+                           (lookup-legacy-backends))
+                   string-locale<?)
             "\n"
             'suffix))
   (primitive-exit 0))
@@ -917,12 +919,17 @@ Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>
   ;; Make and load backend.
   (let ((backend (cond
                   ;; '-f' has priority over '-g'.
-                  (opt-file-backend (make-backend #:path opt-file-backend
-                                                  #:pre-load opt-pre-load
-                                                  #:post-load opt-post-load))
-                  (opt-backend (make-backend #:name opt-backend
-                                             #:pre-load opt-pre-load
-                                             #:post-load opt-post-load))
+                  (opt-file-backend (make-legacy-backend #:path opt-file-backend
+                                                         #:pre-load opt-pre-load
+                                                         #:post-load opt-post-load))
+                  ;; Load module backend first if it is available.
+                  (opt-backend (or (make-module-backend #:name opt-backend
+                                                        #:pre-load opt-pre-load
+                                                        #:post-load opt-post-load)
+                                   ;; Fallback to legacy backend.
+                                   (make-legacy-backend #:name opt-backend
+                                                        #:pre-load opt-pre-load
+                                                        #:post-load opt-post-load)))
                   (else #f))))
 
     ;; This sets [toplevel-schematic] global variable.

--- a/liblepton/scheme/netlist.scm
+++ b/liblepton/scheme/netlist.scm
@@ -933,6 +933,16 @@ Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>
      (opt-backend opt-backend)
      (else #f)))
 
+  (define (load-backend-file filename)
+    (when filename
+      (catch #t
+        (lambda ()
+          (primitive-load filename)
+          (query-backend-mode))
+        (lambda (tag . args)
+          (catch-handler tag args)
+          (netlist-error 1 (G_ "Failed to load backend file.\n"))))))
+
   ; Parse configuration:
   ;
   (parse-rc "lepton-netlist" "gnetlistrc")
@@ -979,20 +989,8 @@ Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>
   (set! backend-path (get-backend-path))
   (set! backend-proc-name (get-backend-proc-name))
 
-  ; Load backend file:
-  ;
-  ( when backend-path
-    ( catch #t
-      ( lambda()
-        ( primitive-load backend-path )
-        ( query-backend-mode )
-      )
-      ( lambda( tag . args )
-        ( catch-handler tag args )
-        ( netlist-error 1 (G_ "Failed to load backend file.\n") )
-      )
-    )
-  )
+  ;; Load backend file.
+  (load-backend-file backend-path)
 
   ; Load Scheme FILE after loading backend (-m FILE):
   (load-scheme-scripts opt-post-load 'post-load)

--- a/liblepton/scheme/netlist.scm
+++ b/liblepton/scheme/netlist.scm
@@ -938,7 +938,7 @@ Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>
     (netlist-error 1 (G_ "Netlist mode requested by backend is not supported: ~A\n") mode)
   )
 
-  ( define ( get-backend-proc-name filename )
+  (define (backend-filename->proc-name filename )
   ( let*
     (
     ( bname (basename filename) )
@@ -1044,7 +1044,7 @@ Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>
   ;
   ( when opt-file-backend
     ( set! backend-path opt-file-backend )
-    ( set! backend-proc-name (get-backend-proc-name backend-path) )
+    ( set! backend-proc-name (backend-filename->proc-name backend-path) )
   )
 
 

--- a/liblepton/scheme/netlist.scm
+++ b/liblepton/scheme/netlist.scm
@@ -994,22 +994,16 @@ Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>
   (load-scheme-scripts opt-post-load
                        (G_ "Failed to load Scheme file after loading backend.\n"))
 
-  ; Verbose mode (-v): print configuration:
-  ;
-  ( when opt-verbose
-    ( print-netlist-config )
-  )
-
   ; This sets [toplevel-schematic] global variable:
   ;
   (set! schematic (set-ln-toplevel-schematic! files))
 
-  ; Verbose mode (-v): print internal netlist representation:
-  ;
-  ( when opt-verbose
-    ( verbose-print-netlist (schematic-components schematic) )
-  )
-
+  ;; Verbose mode (-v).
+  (when opt-verbose
+    ;; Print configuration.
+    (print-netlist-config)
+    ;; Print internal netlist representation.
+    (verbose-print-netlist (schematic-components schematic)))
 
   ; Do actual work:
   ;

--- a/liblepton/scheme/netlist.scm
+++ b/liblepton/scheme/netlist.scm
@@ -956,7 +956,7 @@ Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>
   ; Backend specified by name:
   ;
   ( when opt-backend
-    ( set! backend-path ( %search-load-path (format #f "gnet-~A.scm" opt-backend) ) )
+    ( set! backend-path (search-backend opt-backend) )
     ( set! backend-proc-name opt-backend )
   )
 

--- a/liblepton/scheme/netlist.scm
+++ b/liblepton/scheme/netlist.scm
@@ -811,6 +811,11 @@ Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>
   (primitive-exit 0))
 
 
+(define (version)
+  (display-lepton-version #:print-name #t #:copyright #t)
+  (primitive-exit 0))
+
+
 ;;; Set lepton-netlist toplevel schematic based on schematic FILES
 ;;; and current netlist mode specified somewhere else.  Currently,
 ;;; the netlist mode can be either "'geda", or "'spice".
@@ -923,9 +928,7 @@ Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>
 
   (cond
    (opt-help (usage))
-   (opt-version
-    (display-lepton-version #:print-name #t #:copyright #t)
-    (primitive-exit 0))
+   (opt-version (version))
    (opt-list-backends
     (lookup-backends)
     (primitive-exit 0))

--- a/liblepton/scheme/netlist.scm
+++ b/liblepton/scheme/netlist.scm
@@ -874,21 +874,18 @@ Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>
 ;;; Main program
 ;;;
 ( define ( main )
-( let
-  (
-  ( output-filename   (get-output-filename) )
-  ( files             (netlist-option-ref '()) )            ; schematics
-  ( opt-backend       (netlist-option-ref 'backend) )       ; -g
-  ( opt-file-backend  (netlist-option-ref 'file-backend) )  ; -f
-  ( opt-interactive   (netlist-option-ref 'interactive) )   ; -i
-  ( opt-verbose       (netlist-option-ref 'verbose) )       ; --verbose (-v)
-  ( opt-code-to-eval  (netlist-option-ref 'eval-code) )     ; -c
-  ( opt-help          (netlist-option-ref 'help) )          ; --help (-h)
-  ( opt-version       (netlist-option-ref 'version) )       ; --version (-V)
-  ( opt-list-backends (netlist-option-ref 'list-backends) ) ; --list-backends
-  ( opt-pre-load      (netlist-option-ref 'pre-load) )      ; -l
-  ( opt-post-load     (netlist-option-ref 'post-load) )     ; -m
-  )
+  (define output-filename   (get-output-filename))
+  (define files             (netlist-option-ref '()))            ; schematics
+  (define opt-backend       (netlist-option-ref 'backend))       ; -g
+  (define opt-file-backend  (netlist-option-ref 'file-backend))  ; -f
+  (define opt-interactive   (netlist-option-ref 'interactive))   ; -i
+  (define opt-verbose       (netlist-option-ref 'verbose))       ; --verbose (-v)
+  (define opt-code-to-eval  (netlist-option-ref 'eval-code))     ; -c
+  (define opt-help          (netlist-option-ref 'help))          ; --help (-h)
+  (define opt-version       (netlist-option-ref 'version))       ; --version (-V)
+  (define opt-list-backends (netlist-option-ref 'list-backends)) ; --list-backends
+  (define opt-pre-load      (netlist-option-ref 'pre-load))      ; -l
+  (define opt-post-load     (netlist-option-ref 'post-load))     ; -m
 
   ; local functions:
 
@@ -968,7 +965,4 @@ Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>
   ( if opt-interactive
     ( lepton-repl )
     ( run-backend output-filename )
-  )
-
-) ; let
-) ; main()
+  ))

--- a/liblepton/scheme/netlist.scm
+++ b/liblepton/scheme/netlist.scm
@@ -37,6 +37,7 @@
   #:use-module (lepton version)
   #:use-module (netlist attrib compare)
   #:use-module (netlist attrib refdes)
+  #:use-module (netlist backend)
   #:use-module (netlist config)
   #:use-module (netlist deprecated)
   #:use-module (netlist duplicate)
@@ -868,15 +869,6 @@ Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>
           tag
           args)
   #f)
-
-(define (run-backend backend output-filename)
-  (let ((backend-proc (primitive-eval (string->symbol backend))))
-    (if output-filename
-        ;; output-filename is defined, output to it.
-        (with-output-to-file output-filename
-          (lambda () (backend-proc output-filename)))
-        ;; output-filename is #f, output to stdout.
-        (backend-proc output-filename))))
 
 
 (define (load-scheme-script filename)

--- a/liblepton/scheme/netlist.scm
+++ b/liblepton/scheme/netlist.scm
@@ -19,8 +19,6 @@
 
 (define-module (netlist)
   #:use-module (ice-9 format)
-  #:use-module (ice-9 ftw)
-  #:use-module (ice-9 i18n)
   #:use-module (ice-9 match)
   #:use-module (srfi srfi-1)
   #:use-module (srfi srfi-26)
@@ -780,28 +778,6 @@ other limitations imposed by this netlist format.
   (let ((name (netlist-option-ref 'output)))
     (and (not (string=? name "-"))
          name)))
-
-
-(define (lookup-backends)
-  "Searches %load-path for available lepton-netlist backends and
-prints the resulting list.  A file is considered to be a backend
-if its basename begins with \"gnet-\" and ends with \".scm\"."
-  (define (path-backends path)
-    (or (scandir path backend-filename?)
-        (begin
-          (log! 'warning (G_ "Can't open directory ~S.\n") path)
-          '())))
-
-  (define backend-files
-    (append-map path-backends (delete-duplicates %load-path)))
-
-  (define backend-names
-    (map backend-filename->proc-name backend-files))
-
-  (display (string-join
-            (sort! backend-names string-locale<?)
-            "\n"
-            'suffix)))
 
 
 (define (usage)

--- a/liblepton/scheme/netlist.scm
+++ b/liblepton/scheme/netlist.scm
@@ -948,7 +948,7 @@ Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>
   (set-backend-data! #:path opt-file-backend #:name opt-backend)
 
   ;; Load backend file.
-  (load-backend-file %backend-path)
+  (load-backend-file)
 
   ; Load Scheme FILE after loading backend (-m FILE):
   (load-scheme-scripts opt-post-load 'post-load)

--- a/liblepton/scheme/netlist.scm
+++ b/liblepton/scheme/netlist.scm
@@ -19,6 +19,7 @@
 
 (define-module (netlist)
   #:use-module (ice-9 format)
+  #:use-module (ice-9 i18n)
   #:use-module (ice-9 match)
   #:use-module (srfi srfi-1)
   #:use-module (srfi srfi-26)
@@ -811,6 +812,14 @@ Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>
   (primitive-exit 0))
 
 
+(define (display-backend-list)
+  (display (string-join
+            (sort! (lookup-backends) string-locale<?)
+            "\n"
+            'suffix))
+  (primitive-exit 0))
+
+
 (define (version)
   (display-lepton-version #:print-name #t #:copyright #t)
   (primitive-exit 0))
@@ -927,9 +936,7 @@ Lepton EDA homepage: <https://github.com/lepton-eda/lepton-eda>
   (cond
    (opt-help (usage))
    (opt-version (version))
-   (opt-list-backends
-    (lookup-backends)
-    (primitive-exit 0))
+   (opt-list-backends (display-backend-list))
    ;; Check input schematics.
    ((and (null? files)
          (not opt-interactive))

--- a/liblepton/scheme/netlist/backend.scm
+++ b/liblepton/scheme/netlist/backend.scm
@@ -189,18 +189,11 @@ meet the specified requirements."
   ;; Get the value of the variable.
   (define proc (and var (module-ref interface backend-sym)))
 
-  ;; Ignore pre-loading for now.
-  ;; (load-scheme-scripts pre-load)
-
   ;; Check that the variable is a procedure.
   (if (procedure? proc)
       (backend (module-filename module) name proc #f)
       ;; Returns #f.
-      (warn-module-backend-not-found))
-
-  ;; Ignore post-loading.
-  ;; (load-scheme-scripts post-load 'post-load)
-  )
+      (warn-module-backend-not-found)))
 
 
 (define (run-backend backend output-filename)

--- a/liblepton/scheme/netlist/backend.scm
+++ b/liblepton/scheme/netlist/backend.scm
@@ -37,11 +37,12 @@
             make-module-backend))
 
 (define-record-type <backend>
-  (backend path name runner)
+  (backend path name runner legacy)
   backend?
   (path backend-path set-backend-path!)
   (name backend-name set-backend-name!)
-  (runner backend-runner set-backend-runner!))
+  (runner backend-runner set-backend-runner!)
+  (legacy backend-legacy set-backend-legacy!))
 
 
 (define %backend-prefix "gnet-")
@@ -157,7 +158,7 @@ meet the specified requirements."
 
   (let ((proc (primitive-eval (string->symbol func-name))))
     (if proc
-        (backend path name proc)
+        (backend path name proc #t)
         (error-backend-proc-not-found func-name filename))))
 
 
@@ -193,7 +194,7 @@ meet the specified requirements."
 
   ;; Check that the variable is a procedure.
   (if (procedure? proc)
-      (backend (module-filename module) name proc)
+      (backend (module-filename module) name proc #f)
       ;; Returns #f.
       (warn-module-backend-not-found))
 

--- a/liblepton/scheme/netlist/backend.scm
+++ b/liblepton/scheme/netlist/backend.scm
@@ -60,7 +60,7 @@
                  backend (car (program-arguments))))
 
 
-(define (backend-filename? filename)
+(define (legacy-backend-filename? filename)
   "Return #t if FILENAME is a backend filename, otherwise return
 #f."
   (and (string-prefix? %backend-prefix filename)
@@ -74,7 +74,7 @@ formed by dropping the prefix \"gnet-\" and the extenstion
 \".scm\".  Returns the resulting string or #f if FILENAME does not
 meet the specified requirements."
   (let ((base (basename filename)))
-    (and (backend-filename? base)
+    (and (legacy-backend-filename? base)
          (string-drop-right (string-drop base %backend-prefix-length)
                             %backend-suffix-length))))
 
@@ -122,7 +122,7 @@ returns the resulting list of filenames.  A file is considered to
 be a backend if its basename begins with \"gnet-\" and ends with
 \".scm\"."
   (define (path-backends path)
-    (or (scandir path backend-filename?)
+    (or (scandir path legacy-backend-filename?)
         (begin
           (log! 'warning (G_ "Can't open directory ~S.\n") path)
           '())))

--- a/liblepton/scheme/netlist/backend.scm
+++ b/liblepton/scheme/netlist/backend.scm
@@ -29,7 +29,6 @@
   #:use-module (netlist mode)
 
   #:export (%backend-name
-            %backend-path
             load-backend-file
             lookup-backends
             run-backend
@@ -158,11 +157,11 @@ available netlisting modes."
           (error-backend-mode mode)))))
 
 
-(define (load-backend-file filename)
-  (when filename
+(define (load-backend-file)
+  (when %backend-path
     (catch #t
       (lambda ()
-        (primitive-load filename)
+        (primitive-load %backend-path)
         (query-backend-mode))
       (lambda (key subr message args rest)
         (format (current-error-port) (G_ "ERROR: ~?\n") message args)

--- a/liblepton/scheme/netlist/backend.scm
+++ b/liblepton/scheme/netlist/backend.scm
@@ -79,6 +79,11 @@ meet the specified requirements."
                             %backend-suffix-length))))
 
 
+(define (search-backend name)
+  "Searches for backend by its NAME."
+  (%search-load-path (format #f "gnet-~A.scm" name)))
+
+
 (define (backend-name-by-path path)
   (or (backend-filename->proc-name path)
       (error-backend-wrong-file-name path)))
@@ -109,11 +114,6 @@ redirection is carried out."
           (lambda () (backend-proc output-filename)))
         ;; output-filename is #f, output to stdout.
         (backend-proc output-filename))))
-
-
-(define (search-backend name)
-  "Searches for backend by its NAME."
-  (%search-load-path (format #f "gnet-~A.scm" name)))
 
 
 (define (lookup-backends)

--- a/liblepton/scheme/netlist/backend.scm
+++ b/liblepton/scheme/netlist/backend.scm
@@ -204,17 +204,23 @@ available netlisting modes."
                               (name #f)
                               (pre-load '())
                               (post-load '()))
+  (define (report-warning! fmt . args)
+    (let* ((log-message (format #f "~?" fmt args))
+           (display-message (format #f "~A\n" log-message)))
+      (log! 'message log-message)
+      (display display-message (current-error-port))))
+
   (define (warn-module-name-not-found module-name)
-    (log! 'message (G_ "Could not find module ~S.") module-name))
+    (report-warning! (G_ "Could not find module ~S.") module-name))
   (define (warn-module-procedure-not-found proc-name module-name)
-    (log! 'message
-          (G_ "Could not find procedure ~S exported in the module ~S.")
-          proc-name
-          module-name))
+    (report-warning!
+     (G_ "Could not find procedure ~S exported in the module ~S.")
+     proc-name
+     module-name))
   (define (warn-fallback-to-legacy-backend name)
-    (log! 'message
-          (G_ "Fall back to looking up for legacy backend ~S.")
-          name)
+    (report-warning!
+     (G_ "Fall back to looking up for legacy backend ~S.")
+     name)
     #f)
   (define backend-sym (string->symbol name))
   (define module-sym (list 'backend backend-sym))

--- a/liblepton/scheme/netlist/backend.scm
+++ b/liblepton/scheme/netlist/backend.scm
@@ -102,14 +102,14 @@ available netlisting modes."
      mode))
 
   (define proc-name 'request-netlist-mode)
+  (define proc-binding
+    (false-if-exception
+     (module-symbol-binding (current-module) proc-name)))
 
-  (let ((proc (module-variable (current-module) proc-name))
-        (mode #f))
-
-    (when proc
-      (set! proc (primitive-eval proc-name))
-      (set! mode (proc))
-
+  ;; If the procedure binding exists, and it is really a
+  ;; procedure, eval it to get the new netlisting mode.
+  (when (procedure? proc-binding)
+    (let ((mode (proc-binding)))
       (if (netlist-mode? mode)
-        (set-netlist-mode! mode)
-        (error-backend-mode mode)))))
+          (set-netlist-mode! mode)
+          (error-backend-mode mode)))))

--- a/liblepton/scheme/netlist/backend.scm
+++ b/liblepton/scheme/netlist/backend.scm
@@ -204,14 +204,17 @@ available netlisting modes."
                               (name #f)
                               (pre-load '())
                               (post-load '()))
-  (define (warn-module-backend-not-found)
-    (begin
-      (log! 'message
-            (G_ "Could not find ~S in the module ~S.\n~
-                 Fall back to looking up for legacy backend ~S.")
-            name
-            module-sym
-            name))
+  (define (warn-module-name-not-found module-name)
+    (log! 'message (G_ "Could not find module ~S.") module-name))
+  (define (warn-module-procedure-not-found proc-name module-name)
+    (log! 'message
+          (G_ "Could not find procedure ~S exported in the module ~S.")
+          proc-name
+          module-name))
+  (define (warn-fallback-to-legacy-backend name)
+    (log! 'message
+          (G_ "Fall back to looking up for legacy backend ~S.")
+          name)
     #f)
   (define backend-sym (string->symbol name))
   (define module-sym (list 'backend backend-sym))
@@ -228,8 +231,12 @@ available netlisting modes."
   ;; Check that the variable is a procedure.
   (if (procedure? proc)
       (backend (module-filename module) name proc #f)
-      ;; Returns #f.
-      (warn-module-backend-not-found)))
+      (begin
+        (if module
+            (warn-module-procedure-not-found name module-sym)
+            (warn-module-name-not-found module-sym))
+        ;; Returns #f.
+        (warn-fallback-to-legacy-backend name))))
 
 
 (define (run-backend backend output-filename)

--- a/liblepton/scheme/netlist/backend.scm
+++ b/liblepton/scheme/netlist/backend.scm
@@ -58,6 +58,9 @@ meet the specified requirements."
 
 
 (define (run-backend backend output-filename)
+  "Runs backend's function BACKEND with redirection of its
+standard output to OUTPUT-FILENAME.  If OUTPUT-FILENAME is #f, no
+redirection is carried out."
   (let ((backend-proc (primitive-eval (string->symbol backend))))
     (if output-filename
         ;; output-filename is defined, output to it.

--- a/liblepton/scheme/netlist/backend.scm
+++ b/liblepton/scheme/netlist/backend.scm
@@ -19,7 +19,6 @@
 (define-module (netlist backend)
   #:use-module (ice-9 format)
   #:use-module (ice-9 ftw)
-  #:use-module (ice-9 i18n)
   #:use-module (srfi srfi-1)
   #:use-module (srfi srfi-9)
 
@@ -130,13 +129,7 @@ be a backend if its basename begins with \"gnet-\" and ends with
   (define backend-files
     (append-map path-backends (delete-duplicates %load-path)))
 
-  (define backend-names
-    (map backend-filename->proc-name backend-files))
-
-  (display (string-join
-            (sort! backend-names string-locale<?)
-            "\n"
-            'suffix)))
+  (map backend-filename->proc-name backend-files))
 
 
 (define (query-backend-mode)

--- a/liblepton/scheme/netlist/backend.scm
+++ b/liblepton/scheme/netlist/backend.scm
@@ -118,8 +118,9 @@ redirection is carried out."
 
 (define (lookup-backends)
   "Searches %load-path for available lepton-netlist backends and
-prints the resulting list.  A file is considered to be a backend
-if its basename begins with \"gnet-\" and ends with \".scm\"."
+returns the resulting list of filenames.  A file is considered to
+be a backend if its basename begins with \"gnet-\" and ends with
+\".scm\"."
   (define (path-backends path)
     (or (scandir path backend-filename?)
         (begin

--- a/liblepton/scheme/netlist/backend.scm
+++ b/liblepton/scheme/netlist/backend.scm
@@ -1,5 +1,5 @@
 ;;; Lepton EDA netlister
-;;; Copyright (C) 2017-2022 Lepton EDA Contributors
+;;; Copyright (C) 2017-2023 Lepton EDA Contributors
 ;;;
 ;;; This program is free software; you can redistribute it and/or modify
 ;;; it under the terms of the GNU General Public License as published by
@@ -273,7 +273,16 @@ redirection is carried out."
   (define (backend-name filename)
     (basename filename %backend-suffix))
 
-  (map backend-name backend-basenames))
+  ;; Forms backend name from file basename BASE and tests if a
+  ;; module backend can be created for the name.  Returns the name
+  ;; on success, or #f otherwise.
+  (define (backend-name/test base)
+    (let ((name (backend-name base)))
+      (and name
+           (make-module-backend #:name name)
+           name)))
+
+  (filter-map backend-name/test backend-basenames))
 
 
 (define (lookup-legacy-backends)

--- a/liblepton/scheme/netlist/backend.scm
+++ b/liblepton/scheme/netlist/backend.scm
@@ -1,0 +1,30 @@
+;;; Lepton EDA netlister
+;;; Copyright (C) 2017-2022 Lepton EDA Contributors
+;;;
+;;; This program is free software; you can redistribute it and/or modify
+;;; it under the terms of the GNU General Public License as published by
+;;; the Free Software Foundation; either version 2 of the License, or
+;;; (at your option) any later version.
+;;;
+;;; This program is distributed in the hope that it will be useful,
+;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;; GNU General Public License for more details.
+;;;
+;;; You should have received a copy of the GNU General Public License
+;;; along with this program; if not, write to the Free Software
+;;; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
+(define-module (netlist backend)
+  #:export (run-backend))
+
+
+(define (run-backend backend output-filename)
+  (let ((backend-proc (primitive-eval (string->symbol backend))))
+    (if output-filename
+        ;; output-filename is defined, output to it.
+        (with-output-to-file output-filename
+          (lambda () (backend-proc output-filename)))
+        ;; output-filename is #f, output to stdout.
+        (backend-proc output-filename))))

--- a/liblepton/scheme/netlist/backend.scm
+++ b/liblepton/scheme/netlist/backend.scm
@@ -17,23 +17,32 @@
 
 
 (define-module (netlist backend)
-  #:use-module (ice-9 regex)
-
   #:export (backend-filename->proc-name
             run-backend))
 
+(define %backend-prefix "gnet-")
+(define %backend-suffix ".scm")
+(define %backend-prefix-length (string-length %backend-prefix))
+(define %backend-suffix-length (string-length %backend-suffix))
+
+
+(define (backend-filename? filename)
+  "Return #t if FILENAME is a backend filename, otherwise return
+#f."
+  (and (string-prefix? %backend-prefix filename)
+       (string-suffix? %backend-suffix filename)))
+
 
 (define (backend-filename->proc-name filename)
-  ( let*
-    (
-    ( bname (basename filename) )
-    ( re    (string-match "^gnet-(.*).scm$" bname) )
-    )
-
-    ;; Return the function name if the file name matched the above
-    ;; regexp, otherwise return #f.
-    (and re
-         (match:substring re 1))))
+  "Transforms FILENAME to a backend name which is also the name of
+the procedure the backend runs.  For legacy backends, the name is
+formed by dropping the prefix \"gnet-\" and the extenstion
+\".scm\".  Returns the resulting string or #f if FILENAME does not
+meet the specified requirements."
+  (let ((base (basename filename)))
+    (and (backend-filename? base)
+         (string-drop-right (string-drop base %backend-prefix-length)
+                            %backend-suffix-length))))
 
 
 (define (run-backend backend output-filename)

--- a/liblepton/scheme/netlist/backend.scm
+++ b/liblepton/scheme/netlist/backend.scm
@@ -106,13 +106,15 @@ meet the specified requirements."
   "Runs backend's function BACKEND with redirection of its
 standard output to OUTPUT-FILENAME.  If OUTPUT-FILENAME is #f, no
 redirection is carried out."
-  (let ((backend-proc (primitive-eval (string->symbol (backend-name backend)))))
-    (if output-filename
-        ;; output-filename is defined, output to it.
-        (with-output-to-file output-filename
-          (lambda () (backend-proc output-filename)))
-        ;; output-filename is #f, output to stdout.
-        (backend-proc output-filename))))
+  (define backend-proc
+    (primitive-eval (string->symbol (backend-name backend))))
+
+  (if output-filename
+      ;; output-filename is defined, output to it.
+      (with-output-to-file output-filename
+        (lambda () (backend-proc output-filename)))
+      ;; output-filename is #f, output to stdout.
+      (backend-proc output-filename)))
 
 
 (define (lookup-backends)

--- a/liblepton/scheme/netlist/backend.scm
+++ b/liblepton/scheme/netlist/backend.scm
@@ -17,7 +17,23 @@
 
 
 (define-module (netlist backend)
-  #:export (run-backend))
+  #:use-module (ice-9 regex)
+
+  #:export (backend-filename->proc-name
+            run-backend))
+
+
+(define (backend-filename->proc-name filename)
+  ( let*
+    (
+    ( bname (basename filename) )
+    ( re    (string-match "^gnet-(.*).scm$" bname) )
+    )
+
+    ;; Return the function name if the file name matched the above
+    ;; regexp, otherwise return #f.
+    (and re
+         (match:substring re 1))))
 
 
 (define (run-backend backend output-filename)

--- a/liblepton/scheme/netlist/backend.scm
+++ b/liblepton/scheme/netlist/backend.scm
@@ -208,13 +208,18 @@ meet the specified requirements."
 standard output to OUTPUT-FILENAME.  If OUTPUT-FILENAME is #f, no
 redirection is carried out."
   (define backend-proc (backend-runner backend))
+  (define thunk
+    (if (backend-legacy backend)
+        ;; Legacy backends require one argument.
+        (lambda () (backend-proc output-filename))
+        ;; Module backends do not require arguments.
+        backend-proc))
 
   (if output-filename
       ;; output-filename is defined, output to it.
-      (with-output-to-file output-filename
-        (lambda () (backend-proc output-filename)))
+      (with-output-to-file output-filename thunk)
       ;; output-filename is #f, output to stdout.
-      (backend-proc output-filename)))
+      (thunk)))
 
 
 (define (lookup-module-backends)

--- a/liblepton/scheme/netlist/backend.scm
+++ b/liblepton/scheme/netlist/backend.scm
@@ -30,7 +30,8 @@
   #:export (backend-filename->proc-name
             lookup-backends
             query-backend-mode
-            run-backend))
+            run-backend
+            search-backend))
 
 (define %backend-prefix "gnet-")
 (define %backend-suffix ".scm")
@@ -68,6 +69,11 @@ redirection is carried out."
           (lambda () (backend-proc output-filename)))
         ;; output-filename is #f, output to stdout.
         (backend-proc output-filename))))
+
+
+(define (search-backend name)
+  "Searches for backend by its NAME."
+  (%search-load-path (format #f "gnet-~A.scm" name)))
 
 
 (define (lookup-backends)

--- a/liblepton/scheme/netlist/backend.scm
+++ b/liblepton/scheme/netlist/backend.scm
@@ -28,8 +28,7 @@
   #:use-module (netlist error)
   #:use-module (netlist mode)
 
-  #:export (%backend-name
-            load-backend-file
+  #:export (load-backend-file
             lookup-backends
             run-backend
             set-backend-data!))
@@ -91,11 +90,11 @@ meet the specified requirements."
    (else #f)))
 
 
-(define (run-backend backend output-filename)
+(define (run-backend output-filename)
   "Runs backend's function BACKEND with redirection of its
 standard output to OUTPUT-FILENAME.  If OUTPUT-FILENAME is #f, no
 redirection is carried out."
-  (let ((backend-proc (primitive-eval (string->symbol backend))))
+  (let ((backend-proc (primitive-eval (string->symbol %backend-name))))
     (if output-filename
         ;; output-filename is defined, output to it.
         (with-output-to-file output-filename

--- a/liblepton/scheme/netlist/backend.scm
+++ b/liblepton/scheme/netlist/backend.scm
@@ -17,6 +17,7 @@
 
 
 (define-module (netlist backend)
+  #:use-module (ice-9 format)
   #:use-module (ice-9 ftw)
   #:use-module (ice-9 i18n)
   #:use-module (srfi srfi-1)
@@ -29,8 +30,8 @@
 
   #:export (%backend-name
             %backend-path
+            load-backend-file
             lookup-backends
-            query-backend-mode
             run-backend
             set-backend-data!))
 
@@ -155,3 +156,14 @@ available netlisting modes."
       (if (netlist-mode? mode)
           (set-netlist-mode! mode)
           (error-backend-mode mode)))))
+
+
+(define (load-backend-file filename)
+  (when filename
+    (catch #t
+      (lambda ()
+        (primitive-load filename)
+        (query-backend-mode))
+      (lambda (key subr message args rest)
+        (format (current-error-port) (G_ "ERROR: ~?\n") message args)
+        (netlist-error 1 (G_ "Failed to load backend file.\n"))))))

--- a/tests/netlist.test
+++ b/tests/netlist.test
@@ -334,3 +334,52 @@
   (test-teardown))
 
 (test-end)
+
+
+(test-begin "module-backend")
+
+(test-group-with-cleanup "module-backend"
+  (test-setup)
+  ;; Make a dummy schematic.
+  (touch "schematic.sch")
+
+  ;; Set $HOME to the test directory.
+  (with-home
+   *testdir*
+
+   ;; Create a directory for user data in current $HOME.
+   (let* ((backend-dir (build-filename ($HOME) *user-data-dir* "scheme" "backend"))
+          (backend-file (build-filename backend-dir "test-module-backend.scm"))
+          (inhibit-rc? (getenv "LEPTON_INHIBIT_RC_FILES")))
+     ;; Create user Scheme directory and a directory "m" within it.
+     (system* "mkdir" "-p" backend-dir)
+
+     ;; Make backend file.
+     (sexp->file
+      backend-file
+      ;; Simple test backend.
+      '(define-module (backend test-module-backend)
+         #:export (test-module-backend))
+      ;; This is the exported function.
+      '(define (test-module-backend out)
+         (display "It works!\n")))
+
+     (unsetenv "LEPTON_INHIBIT_RC_FILES")
+
+     (receive (<status> <stdout> <stderr>)
+         (command-values* lepton-netlist --list-backends)
+       (test-eq EXIT_SUCCESS <status>)
+       (test-assert (string-contains <stdout> "test-module-backend")))
+
+     (receive (<status> <stdout> <stderr>)
+         (command-values* lepton-netlist -g test-module-backend -o - schematic.sch)
+       (test-eq EXIT_SUCCESS <status>)
+       (test-assert (string-contains <stdout> "It works!")))
+
+     (when inhibit-rc?
+       (putenv (string-append "LEPTON_INHIBIT_RC_FILES=" inhibit-rc?)))))
+
+
+  (test-teardown))
+
+(test-end "module-backend")

--- a/tests/netlist.test
+++ b/tests/netlist.test
@@ -361,7 +361,7 @@
       '(define-module (backend test-module-backend)
          #:export (test-module-backend))
       ;; This is the exported function.
-      '(define (test-module-backend out)
+      '(define (test-module-backend)
          (display "It works!\n")))
 
      ;; We have to allow for registering data directories so that

--- a/tests/netlist.test
+++ b/tests/netlist.test
@@ -271,19 +271,19 @@
 
      ;; Now, same named local files in cwd and test that they have
      ;; precedence over those in the user Scheme load path.
-     (sexp->file "l.scm" '(exit 1))
+     (sexp->file "l.scm" '(primitive-exit 100))
      (mkdir "m")
-     (sexp->file "m/m.scm" '(exit 1))
+     (sexp->file "m/m.scm" '(primitive-exit 100))
 
      ;; Test with -l only.
      (receive (<status> <stdout> <stderr>)
          (command-values* lepton-netlist -l l.scm -g test -o - schematic.sch)
-       (test-eq EXIT_FAILURE <status>))
+       (test-eq 100 <status>))
 
      ;; Test with -m only.
      (receive (<status> <stdout> <stderr>)
          (command-values* lepton-netlist -m m/m.scm -g test -o - schematic.sch)
-       (test-eq EXIT_FAILURE <status>))
+       (test-eq 100 <status>))
 
      (when inhibit-rc?
        (putenv (string-append "LEPTON_INHIBIT_RC_FILES=" inhibit-rc?)))))

--- a/tests/netlist.test
+++ b/tests/netlist.test
@@ -364,6 +364,10 @@
       '(define (test-module-backend out)
          (display "It works!\n")))
 
+     ;; We have to allow for registering data directories so that
+     ;; the user data directory gets into %load-path.  Well, this
+     ;; is a little buggy as scripts in the system data directory
+     ;; may affect the tests, though here we go.
      (unsetenv "LEPTON_INHIBIT_RC_FILES")
 
      (receive (<status> <stdout> <stderr>)

--- a/tests/netlist.test
+++ b/tests/netlist.test
@@ -331,7 +331,28 @@
     (test-eq EXIT_SUCCESS <status>)
     (test-assert (string-contains <stdout> "It works!")))
 
-  (test-teardown))
+  ;; Test -f option with absolute file name.
+  (with-home
+   *testdir*
+   ;; Create a directory for user data in current $HOME.
+   (let ((inhibit-rc? (getenv "LEPTON_INHIBIT_RC_FILES")))
+     ;; Make a backend file.
+     (sexp->file
+      (build-filename ($HOME) "gnet-test.scm")
+      '(define (test output-filename)
+         (display "test -f with absolute filename")))
+
+     (unsetenv "LEPTON_INHIBIT_RC_FILES")
+
+     (receive (<status> <stdout> <stderr>)
+         (command-values* lepton-netlist -f $HOME/gnet-test.scm -o - schematic.sch)
+       (test-eq EXIT_SUCCESS <status>)
+       (test-assert (string-contains <stdout> "test -f with absolute filename")))
+
+     (when inhibit-rc?
+       (putenv (string-append "LEPTON_INHIBIT_RC_FILES=" inhibit-rc?)))))
+
+   (test-teardown))
 
 (test-end)
 


### PR DESCRIPTION
The main new feature the branch adds is introducing so named
**module backends**.

Some time ago, we discussed the issue of adding user backends for Lepton
on *gitter* with @noqsi and here I propose a possible solution.

**Abstract**

Legacy backend system inherited from `gnetlist` has several
deficiencies:
- Legacy backends are simple Scheme scripts that cannot be re-used
  or tested in our unit test suite (UTS) without modifications.
  This in itself makes backends worse for refactoring or testing.
- They need the pre-/post-loading mechanics to use their code
  without modifying, e.g. if a backend was installed with
  superuser permissions.
- So far, there were no specific requirements for backend
  locations.  The description of where the files could live to be
  found by `lepton-netlist` was missing, either.
- The naming of backend scripts is no longer in harmony with
  Lepton :-) (it's a minor issue).

A new, **module** backend system proposed here is designed to
resolve the above issues.
- It removes requirements to naming of backend files though keeps
  ones for naming their main functions.  In two words, the `gnet-`
  prefix is no longer needed to be used in backend file names to
  let the files be recognized as backends
- On the other hand, it distinctly specifies directory names where
  backends are expected to reside.  Those are the `backend`
  subdirectories of the Lepton load path directories.  Those can
  be found out by investigating what directories Lepton's
  functions `sys-data-dirs` and `user-data-dirs` return.  In such
  a configuration, a backend can be defined simply as a module in
  the `backend` namespace.  For example, a module defining a SPICE
  backend may be defined using the `(define-module (backend
  spice))` declaration.
- It specifies the structure of backend modules.  Examples are
  provided in the Lepton texinfo manual in the provided branch.
- It removes necessity of pre-/post-loading functionality as the
  new backend system just doesn't need it.
- We now can move backends from the `tools` directory and properly
  test their functions by means of Lepton's UTS.

Still many things wrt documentation are in my long to-do lists
and, hopefully, I'll add that missing info later.


**(Non-comprehensive) List of changes in the code**
  
The list of other changes includes:
- A new module, `(netlist backend)`, has been introduced.
- Several functions have been renamed/splitted/refactored.  Some
  of them have been moved to the module.
- A new record, `<backend>`, has been introduced in the module.
  It is designed to contain basic information on a backend to be
  loaded and run, such as its name, path, type, and its main
  *runner* procedure.
- The function `error-backend-file-name()` now returns a full path
  for the file name it reports the error about.  This is helpful
  when the file name is not in the current directory (e.g. loaded
  from `%load-path`) and something went wrong with it.
- The code now checks if a variable `request-netlist-mode` used
  for requesting netlister mode exists, and it is a procedure and
  not a simple variable, instead of just querying a variable with
  that name, and blindly trusting it is a procedure that can be
  `primitive-eval`'ed.
- Error reporting in verbose mode has been changed in that if an
  error occurs on stages up to loading schematics the user will
  see just the error message without hindering the report by
  output of config settings.
- Several new tests have been added.
- New sections about the new and legacy backends have been added
  into the Lepton manual.  They contain basic description as well
  as examples on how to construct custom backends.
