### PR TITLE
schematic: Introduce function in-action?().

### DIFF
--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -2,7 +2,7 @@
 ;; Scheme API
 ;; Copyright (C) 2013 Peter Brett <peter@peter-b.co.uk>
 ;; Copyright (C) 2013-2015 gEDA Contributors
-;; Copyright (C) 2017-2022 Lepton EDA Contributors
+;; Copyright (C) 2017-2023 Lepton EDA Contributors
 ;;
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -315,7 +315,7 @@
   (define *page (and=> (active-page) page->pointer))
 
   (when *page
-    (if (and (true? (schematic_window_get_inside_action *window))
+    (if (and (in-action?)
              (not (null-pointer? (schematic_window_get_place_list *window))))
         ;; If there are objects to place, rotate them.
         (o_place_rotate *window)
@@ -342,7 +342,7 @@
   (define *page (and=> (active-page) page->pointer))
 
   (when *page
-    (if (and (true? (schematic_window_get_inside_action *window))
+    (if (and (in-action?)
              (not (null-pointer? (schematic_window_get_place_list *window))))
         ;; If there are objects to place, mirror them.
         (o_place_mirror *window)
@@ -1417,17 +1417,17 @@ the snap grid size should be set to 100")))
 
 
 (define-action-public (&attributes-show-value #:label (G_ "Show Attribute Value") #:icon "attribute-show-value")
-  (unless (true? (schematic_window_get_inside_action (*current-window)))
+  (unless (in-action?)
     (set-selected-attribs-show-mode! 'value (*current-window))))
 
 
 (define-action-public (&attributes-show-name #:label (G_ "Show Attribute Name") #:icon "attribute-show-name")
-  (unless (true? (schematic_window_get_inside_action (*current-window)))
+  (unless (in-action?)
     (set-selected-attribs-show-mode! 'name (*current-window))))
 
 
 (define-action-public (&attributes-show-both #:label (G_ "Show Name & Value") #:icon "attribute-show-both")
-  (unless (true? (schematic_window_get_inside_action (*current-window)))
+  (unless (in-action?)
     (set-selected-attribs-show-mode! 'both (*current-window))))
 
 
@@ -1435,7 +1435,7 @@ the snap grid size should be set to 100")))
   (define (toggle-visibility! object)
     (set-text-visibility! object (not (text-visible? object))))
 
-  (unless (true? (schematic_window_get_inside_action (*current-window)))
+  (unless (in-action?)
     (let ((attribs (filter attribute? (page-selection (active-page)))))
       (unless (null? attribs)
         (for-each toggle-visibility! attribs)
@@ -1446,27 +1446,23 @@ the snap grid size should be set to 100")))
 
 
 (define-action-public (&edit-find-text #:label (G_ "Find Specific Text") #:icon "gtk-find")
-  (define *window (*current-window))
-  (unless (true? (schematic_window_get_inside_action *window))
-    (find_text_dialog *window)))
+  (unless (in-action?)
+    (find_text_dialog (*current-window))))
 
 
 (define-action-public (&edit-hide-text #:label (G_ "Hide Specific Text"))
-  (define *window (*current-window))
-  (unless (true? (schematic_window_get_inside_action *window))
-    (hide_text_dialog *window)))
+  (unless (in-action?)
+    (hide_text_dialog (*current-window))))
 
 
 (define-action-public (&edit-show-text #:label (G_ "Show Specific Text"))
-  (define *window (*current-window))
-  (unless (true? (schematic_window_get_inside_action *window))
-    (show_text_dialog *window)))
+  (unless (in-action?)
+    (show_text_dialog (*current-window))))
 
 
 (define-action-public (&edit-autonumber #:label (G_ "Autonumber Text"))
-  (define *window (*current-window))
-  (unless (true? (schematic_window_get_inside_action *window))
-    (autonumber_text_dialog *window)))
+  (unless (in-action?)
+    (autonumber_text_dialog (*current-window))))
 
 
 ;; -------------------------------------------------------------------
@@ -1543,7 +1539,7 @@ the snap grid size should be set to 100")))
         (schematic_window_set_actionfeedback_mode *window BOUNDINGBOX)
         (log! 'message (G_ "Action feedback mode set to BOUNDINGBOX"))))
 
-  (when (and (true? (schematic_window_get_inside_action *window))
+  (when (and (in-action?)
              (not (null-pointer? (schematic_window_get_place_list *window))))
     (o_place_invalidate_rubber *window FALSE)))
 

--- a/libleptongui/scheme/schematic/undo.scm
+++ b/libleptongui/scheme/schematic/undo.scm
@@ -1,7 +1,7 @@
 ;; Lepton EDA Schematic Capture
 ;; Scheme API
 ;; Copyright (C) 2017 dmn <graahnul.grom@gmail.com>
-;; Copyright (C) 2017-2022 Lepton EDA Contributors
+;; Copyright (C) 2017-2023 Lepton EDA Contributors
 ;;
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -83,7 +83,7 @@ success, #f on failure."
   ;; hits lepton_page_delete(), the place list objects are free'd.
   ;; Since they are also contained in the schematic page, a
   ;; crash occurs when the page objects are free'd.
-  (if (true? (schematic_window_get_inside_action *window))
+  (if (in-action?)
       (i_callback_cancel *widget *window)
       (undo-callback *window FALSE)))
 

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -262,7 +262,7 @@
         ;; Evaluate state transitions.
         (match button-number
           (1
-           (when (true? (schematic_window_get_inside_action *window))
+           (when (in-action? window)
              (if (not (null-pointer? (schematic_window_get_place_list *window)))
                  (match action-mode
                    ((or 'copy-mode 'multiple-copy-mode) (o_copy_end *window))
@@ -278,7 +278,7 @@
                    (_ FALSE)))))
 
           (2
-           (when (true? (schematic_window_get_inside_action *window))
+           (when (in-action? window)
              (when (or (eq? action-mode 'component-mode)
                      (eq? action-mode 'text-mode)
                      (eq? action-mode 'move-mode)
@@ -300,7 +300,7 @@
                      (o_place_invalidate_rubber *window TRUE))
 
                  (schematic_window_set_rubber_visible *window 1)))
-           (unless (and (true? (schematic_window_get_inside_action *window))
+           (unless (and (in-action? window)
                         (or (eq? action-mode 'component-mode)
                             (eq? action-mode 'text-mode)
                             (eq? action-mode 'move-mode)
@@ -310,7 +310,7 @@
              (let ((middle-button (schematic_window_get_middle_button *window)))
                (cond
                 ((= middle-button MOUSEBTN_DO_ACTION)
-                 (when (and (true? (schematic_window_get_inside_action *window))
+                 (when (and (in-action? window)
                             (not (null-pointer? (schematic_window_get_place_list *window))))
                    (match action-mode
                      ('copy-mode (o_copy_end *window))

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -1,7 +1,7 @@
 ;; Lepton EDA Schematic Capture
 ;; Scheme API
 ;; Copyright (C) 2010-2011 Peter Brett <peter@peter-b.co.uk>
-;; Copyright (C) 2017-2022 Lepton EDA Contributors
+;; Copyright (C) 2017-2023 Lepton EDA Contributors
 ;;
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -83,7 +83,7 @@
   (let ((last-window? (= (length (schematic-windows)) 1)))
     ;; If we're closing whilst inside an action, re-wind the page
     ;; contents back to their state before we started.
-    (when (true? (schematic_window_get_inside_action *window))
+    (when (in-action? window)
       (i_callback_cancel %null-pointer *window))
 
     ;; Last chance to save possible unsaved pages.

--- a/libleptongui/scheme/schematic/window/global.scm
+++ b/libleptongui/scheme/schematic/window/global.scm
@@ -69,6 +69,10 @@ dynamic context."
 
 
 (define* (in-action? #:optional (window #f))
+  "Return #t if an object editing action is underway in the
+current window, and #f otherwise.  If optional WINDOW argument is
+specified, the result corresponds to the state of that window
+instead of the current one."
   (define (window-in-action? win)
     (true? (schematic_window_get_inside_action (window->pointer win))))
 

--- a/libleptongui/scheme/schematic/window/global.scm
+++ b/libleptongui/scheme/schematic/window/global.scm
@@ -1,6 +1,6 @@
 ;;; Lepton EDA Schematic Capture
 ;;; Scheme API
-;;; Copyright (C) 2022 Lepton EDA Contributors
+;;; Copyright (C) 2022-2023 Lepton EDA Contributors
 ;;;
 ;;; This program is free software; you can redistribute it and/or modify
 ;;; it under the terms of the GNU General Public License as published by
@@ -18,6 +18,7 @@
 
 
 (define-module (schematic window global)
+  #:use-module (lepton ffi boolean)
   #:use-module (lepton toplevel)
 
   #:use-module (schematic ffi)
@@ -26,7 +27,8 @@
   #:export (%lepton-window
             current-window
             *current-window
-            with-window))
+            with-window
+            in-action?))
 
 
 ;;; This is a fluid that is initialized with pointer to a new
@@ -64,3 +66,10 @@ dynamic context."
      (let ((*window (and=> (current-window) window->pointer)))
        (or *window
            (error "Current window is unavailable."))))))
+
+
+(define* (in-action? #:optional (window #f))
+  (define (window-in-action? win)
+    (true? (schematic_window_get_inside_action (window->pointer win))))
+
+  (window-in-action? (or window (current-window))))


### PR DESCRIPTION
A new function, `in-action()`, has been introduced in the module
`(schematic window global)`.  It returns the boolean value
corresponding to the current editing state: it returns `#t` if
editing an object is in action and `#f` otherwise.  Several Scheme
functions and actions have been simplified by using this function.
