### PR TITLE
Get rid of GschemToplevel's field 'last_drawb_mode'.

### DIFF
--- a/libleptongui/include/gschem_defines.h
+++ b/libleptongui/include/gschem_defines.h
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2014 gEDA Contributors
- * Copyright (C) 2017-2022 Lepton EDA Contributors
+ * Copyright (C) 2017-2023 Lepton EDA Contributors
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -64,11 +64,6 @@
 /* values */
 #define OUTLINE         0
 #define BOUNDINGBOX     1
-
-/* This is an additional mode for last_drawb_mode, to indicate there was no
- * last bounding box drawn. last_drawb_mode also takes actionfeedback_mode
- * constants, so be sure not to clash with those */
-#define LAST_DRAWB_MODE_NONE -1
 
 /* used for undo_type */
 #define UNDO_DISK               0

--- a/libleptongui/include/gschem_toplevel.h
+++ b/libleptongui/include/gschem_toplevel.h
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2016 gEDA Contributors
- * Copyright (C) 2017-2022 Lepton EDA Contributors
+ * Copyright (C) 2017-2023 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -170,7 +170,6 @@ struct st_gschem_toplevel {
   int min_zoom;                         /* minimum zoom factor */
   int max_zoom;                         /* maximum zoom factor */
   int drawbounding_action_mode;         /* outline vs bounding box */
-  int last_drawb_mode;                  /* last above mode */
   int CONTROLKEY;                       /* control key pressed? */
   int SHIFTKEY;                         /* shift key pressed? */
   int ALTKEY;                           /* alt key pressed? */

--- a/libleptongui/src/gschem_toplevel.c
+++ b/libleptongui/src/gschem_toplevel.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2016 gEDA Contributors
- * Copyright (C) 2017-2022 Lepton EDA Contributors
+ * Copyright (C) 2017-2023 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -289,7 +289,6 @@ GschemToplevel *gschem_toplevel_new ()
   w_current->min_zoom = 0;
   w_current->max_zoom = 8;
   w_current->drawbounding_action_mode = FREE;
-  w_current->last_drawb_mode = LAST_DRAWB_MODE_NONE;
   w_current->CONTROLKEY = 0;
   w_current->SHIFTKEY   = 0;
   w_current->ALTKEY     = 0;

--- a/libleptongui/src/o_basic.c
+++ b/libleptongui/src/o_basic.c
@@ -262,17 +262,14 @@ void o_redraw_rect (GschemToplevel *w_current,
           }
         break;
         case MOVEMODE:
-          if (w_current->last_drawb_mode != LAST_DRAWB_MODE_NONE)
-          {
-            /* FIXME shouldn't need to save/restore colormap here */
-            cairo_save (cr);
-            eda_renderer_set_color_map (renderer, render_outline_color_map);
+          /* FIXME shouldn't need to save/restore colormap here */
+          cairo_save (cr);
+          eda_renderer_set_color_map (renderer, render_outline_color_map);
 
-            o_move_draw_rubber (w_current, renderer);
+          o_move_draw_rubber (w_current, renderer);
 
-            eda_renderer_set_color_map (renderer, render_color_map);
-            cairo_restore (cr);
-          }
+          eda_renderer_set_color_map (renderer, render_color_map);
+          cairo_restore (cr);
           break;
         default: break;
       }

--- a/libleptongui/src/o_basic.c
+++ b/libleptongui/src/o_basic.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2016 gEDA Contributors
- * Copyright (C) 2017-2022 Lepton EDA Contributors
+ * Copyright (C) 2017-2023 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -262,7 +262,8 @@ void o_redraw_rect (GschemToplevel *w_current,
           }
         break;
         case MOVEMODE:
-          if (w_current->last_drawb_mode != -1) {
+          if (w_current->last_drawb_mode != LAST_DRAWB_MODE_NONE)
+          {
             /* FIXME shouldn't need to save/restore colormap here */
             cairo_save (cr);
             eda_renderer_set_color_map (renderer, render_outline_color_map);

--- a/libleptongui/src/o_buffer.c
+++ b/libleptongui/src/o_buffer.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2016 gEDA Contributors
- * Copyright (C) 2017-2022 Lepton EDA Contributors
+ * Copyright (C) 2017-2023 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -153,8 +153,6 @@ o_buffer_paste_start(GschemToplevel *w_current, int w_x, int w_y, int buf_num)
   if (w_current->inside_action) {
     i_callback_cancel (NULL, w_current);
   }
-
-  w_current->last_drawb_mode = LAST_DRAWB_MODE_NONE;
 
   if (buf_num == CLIPBOARD_BUFFER) {
     clipboard_to_buffer(w_current, buf_num);

--- a/libleptongui/src/o_grips.c
+++ b/libleptongui/src/o_grips.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2016 gEDA Contributors
- * Copyright (C) 2017-2021 Lepton EDA Contributors
+ * Copyright (C) 2017-2023 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -677,7 +677,7 @@ static void o_grips_start_path(GschemToplevel *w_current, LeptonObject *o_curren
   int gx = -1;
   int gy = -1;
 
-  w_current->last_drawb_mode = -1;
+  w_current->last_drawb_mode = LAST_DRAWB_MODE_NONE;
 
   for (i = 0; i < lepton_path_object_get_num_sections (o_current); i++)
   {

--- a/libleptongui/src/o_grips.c
+++ b/libleptongui/src/o_grips.c
@@ -560,8 +560,6 @@ LeptonObject *o_grips_search_line_world(GschemToplevel *w_current, LeptonObject 
 static void o_grips_start_arc(GschemToplevel *w_current, LeptonObject *o_current,
                               int x, int y, int whichone)
 {
-  w_current->last_drawb_mode = LAST_DRAWB_MODE_NONE;
-
   /* describe the arc with GschemToplevel variables */
   /* center */
   w_current->first_wx = lepton_arc_object_get_center_x (o_current);
@@ -602,8 +600,6 @@ static void o_grips_start_box(GschemToplevel *w_current, LeptonObject *o_current
                               int x, int y, int whichone)
 {
   int upper_x, upper_y, lower_x, lower_y;
-
-  w_current->last_drawb_mode = LAST_DRAWB_MODE_NONE;
 
   upper_x = lepton_box_object_get_upper_x (o_current);
   upper_y = lepton_box_object_get_upper_y (o_current);
@@ -677,8 +673,6 @@ static void o_grips_start_path(GschemToplevel *w_current, LeptonObject *o_curren
   int gx = -1;
   int gy = -1;
 
-  w_current->last_drawb_mode = LAST_DRAWB_MODE_NONE;
-
   for (i = 0; i < lepton_path_object_get_num_sections (o_current); i++)
   {
     section = lepton_path_object_get_section (o_current, i);
@@ -749,8 +743,6 @@ static void o_grips_start_picture(GschemToplevel *w_current, LeptonObject *o_cur
   upper_x = lepton_picture_object_get_upper_x (o_current);
   upper_y = lepton_picture_object_get_upper_y (o_current);
 
-  w_current->last_drawb_mode = LAST_DRAWB_MODE_NONE;
-
   w_current->current_pixbuf = lepton_picture_object_get_pixbuf (o_current);
   w_current->pixbuf_filename =
     g_strdup (lepton_picture_object_get_filename (o_current));
@@ -817,8 +809,6 @@ static void o_grips_start_circle(GschemToplevel *w_current, LeptonObject *o_curr
                                  int x, int y, int whichone)
 {
 
-  w_current->last_drawb_mode = LAST_DRAWB_MODE_NONE;
-
   /* store circle center and radius in GschemToplevel structure */
   w_current->first_wx = lepton_circle_object_get_center_x (o_current);
   w_current->first_wy = lepton_circle_object_get_center_y (o_current);
@@ -849,8 +839,6 @@ static void o_grips_start_circle(GschemToplevel *w_current, LeptonObject *o_curr
 static void o_grips_start_line(GschemToplevel *w_current, LeptonObject *o_current,
                                int x, int y, int whichone)
 {
-  w_current->last_drawb_mode = LAST_DRAWB_MODE_NONE;
-
   /* describe the line with GschemToplevel variables */
   w_current->second_wx = o_current->line->x[whichone];
   w_current->second_wy = o_current->line->y[whichone];

--- a/libleptongui/src/o_move.c
+++ b/libleptongui/src/o_move.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2016 gEDA Contributors
- * Copyright (C) 2017-2022 Lepton EDA Contributors
+ * Copyright (C) 2017-2023 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -48,8 +48,6 @@ void o_move_start(GschemToplevel *w_current, int w_x, int w_y)
     gboolean net_rubber_band_mode;
 
     net_rubber_band_mode = gschem_options_get_net_rubber_band_mode (w_current->options);
-
-    w_current->last_drawb_mode = LAST_DRAWB_MODE_NONE;
 
     w_current->first_wx = w_current->second_wx = w_x;
     w_current->first_wy = w_current->second_wy = w_y;

--- a/libleptongui/src/o_place.c
+++ b/libleptongui/src/o_place.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2016 gEDA Contributors
- * Copyright (C) 2017-2022 Lepton EDA Contributors
+ * Copyright (C) 2017-2023 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -222,7 +222,6 @@ void o_place_invalidate_rubber (GschemToplevel *w_current, int drawing)
       schematic_window_get_action_mode (w_current);
     /* Ensure we set this to flag there is "something" supposed to be
      * drawn when the invalidate call below causes an expose event. */
-    w_current->last_drawb_mode = w_current->actionfeedback_mode;
     w_current->drawbounding_action_mode = (w_current->CONTROLKEY &&
                                            ! (   (action_mode == PASTEMODE)
                                               || (action_mode == COMPMODE)
@@ -303,7 +302,6 @@ o_place_draw_rubber (GschemToplevel *w_current, EdaRenderer *renderer)
     schematic_window_get_action_mode (w_current);
   /* Don't worry about the previous drawing method and movement
    * constraints, use with the current settings */
-  w_current->last_drawb_mode = w_current->actionfeedback_mode;
   w_current->drawbounding_action_mode = (w_current->CONTROLKEY &&
                                          ! (   (action_mode == PASTEMODE)
                                             || (action_mode == COMPMODE)
@@ -330,7 +328,8 @@ o_place_draw_rubber (GschemToplevel *w_current, EdaRenderer *renderer)
   cairo_translate (cr, diff_x, diff_y);
 
   /* Draw with the appropriate mode */
-  if (w_current->last_drawb_mode == BOUNDINGBOX) {
+  if (w_current->actionfeedback_mode == BOUNDINGBOX)
+  {
     GArray *map = eda_renderer_get_color_map (renderer);
     int flags = eda_renderer_get_cairo_flags (renderer);
     int left, top, bottom, right;

--- a/libleptongui/src/o_text.c
+++ b/libleptongui/src/o_text.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2016 gEDA Contributors
- * Copyright (C) 2017-2021 Lepton EDA Contributors
+ * Copyright (C) 2017-2023 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -51,8 +51,6 @@ void o_text_prepare_place(GschemToplevel *w_current, char *text, int color, int 
 
   w_current->first_wx = 0;
   w_current->first_wy = 0;
-
-  w_current->last_drawb_mode = LAST_DRAWB_MODE_NONE;
 
   /* remove the old place list if it exists */
   lepton_object_list_delete (page->place_list);


### PR DESCRIPTION
The field introduced back in 2000 seems to do nothing these days.  I've looked into its usage while working on PR #997 and found it pretty useless.  The only place it was evaluated to do some decision was the code related to net rubberbanding in move mode.  I couldn't trigger any issues after removing it and replacing it directly with the `actionfeedback_mode` field.  It looks like someone forgot their slippers when they left.

If you have some strong objections, I'll remove the second commit here while leaving the first one intact :-)