### PR TITLE
gui: Get rid of GschemToplevel's field 'continue_component_place'.

### DIFF
--- a/libleptongui/include/gschem_toplevel.h
+++ b/libleptongui/include/gschem_toplevel.h
@@ -202,9 +202,6 @@ struct st_gschem_toplevel {
   int enforce_hierarchy;  /* controls how much freedom user has when traversing the hierarchy */
   int fast_mousepan;      /* controls if text is completely drawn during mouse pan */
 
-  /* controls if after doing a place the same component can be placed again */
-  int continue_component_place;
-
   int undo_levels;        /* number of undo levels stored on disk */
   int undo_control;       /* sets if undo is enabled or not */
   int undo_type;          /* type of undo (disk/memory) */
@@ -529,12 +526,6 @@ schematic_window_get_third_button_cancel (GschemToplevel *w_current);
 void
 schematic_window_set_third_button_cancel (GschemToplevel *w_current,
                                           int val);
-int
-schematic_window_get_continue_component_place (GschemToplevel *w_current);
-
-void
-schematic_window_set_continue_component_place (GschemToplevel *w_current,
-                                               int cont);
 int
 schematic_window_get_mousepan_gain (GschemToplevel *w_current);
 

--- a/libleptongui/include/i_vars.h
+++ b/libleptongui/include/i_vars.h
@@ -23,7 +23,6 @@ extern int default_scroll_wheel;
 extern int default_file_preview;
 extern int default_enforce_hierarchy;
 extern int default_fast_mousepan;
-extern int default_continue_component_place;
 extern int default_undo_levels;
 extern int default_undo_control;
 extern int default_undo_type;

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -355,7 +355,6 @@
             schematic_window_set_color_edit_widget
             schematic_window_get_compselect
             schematic_window_set_compselect
-            schematic_window_get_continue_component_place
             schematic_window_get_draw_grips
             schematic_window_set_draw_grips
             schematic_window_get_enforce_hierarchy
@@ -662,7 +661,6 @@
 (define-lff schematic_window_set_color_edit_widget void '(* *))
 (define-lff schematic_window_get_compselect '* '(*))
 (define-lff schematic_window_set_compselect void '(* *))
-(define-lff schematic_window_get_continue_component_place int '(*))
 (define-lff schematic_window_get_draw_grips int '(*))
 (define-lff schematic_window_set_draw_grips void (list '* int))
 (define-lff schematic_window_get_enforce_hierarchy int '(*))

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -389,6 +389,13 @@
   (define unsnapped-x-bv (make-bytevector (sizeof int) 0))
   (define unsnapped-y-bv (make-bytevector (sizeof int) 0))
 
+  (define (continue-placement?)
+    (if (config-boolean (path-config-context (getcwd))
+                        "schematic.gui"
+                        "continue-component-place")
+        TRUE
+        FALSE))
+
   (define (process-event *page-view *event *window)
     (schematic_page_view_grab_focus *page-view)
     (let ((button-number (schematic_event_get_button *event))
@@ -431,9 +438,11 @@
                      (if (not (null-pointer? (schematic_window_get_place_list *window)))
                          (match action-mode
                            ('component-mode
-                            (let ((continue-placement?
-                                   (schematic_window_get_continue_component_place *window)))
-                              (o_place_end *window x y continue-placement? (string->pointer "add-objects-hook"))))
+                            (o_place_end *window
+                                         x
+                                         y
+                                         (continue-placement?)
+                                         (string->pointer "add-objects-hook")))
                            ('text-mode
                             (o_place_end *window x y FALSE (string->pointer "add-objects-hook")))
                            ('paste-mode

--- a/libleptongui/src/gschem_toplevel.c
+++ b/libleptongui/src/gschem_toplevel.c
@@ -322,7 +322,6 @@ GschemToplevel *gschem_toplevel_new ()
   w_current->file_preview = 0;
   w_current->enforce_hierarchy = 0;
   w_current->fast_mousepan = 0;
-  w_current->continue_component_place = 0;
   w_current->undo_levels = 0;
   w_current->undo_control = 0;
   w_current->undo_type = 0;
@@ -1975,35 +1974,6 @@ schematic_window_set_third_button_cancel (GschemToplevel *w_current,
   g_return_if_fail (w_current != NULL);
 
   w_current->third_button_cancel = val;
-}
-
-
-/*! \brief Get schematic window's field 'continue_component_place'.
- *
- *  \param [in] w_current The schematic window.
- *  \return The value of the field 'continue_component_place'.
- */
-int
-schematic_window_get_continue_component_place (GschemToplevel *w_current)
-{
-  g_return_val_if_fail (w_current != NULL, 0);
-
-  return w_current->continue_component_place;
-}
-
-
-/*! \brief Set schematic window's field 'continue_component_place'.
- *
- *  \param [in] w_current The schematic window.
- *  \param [in] cont The new value of the field 'continue_component_place'.
- */
-void
-schematic_window_set_continue_component_place (GschemToplevel *w_current,
-                                               int cont)
-{
-  g_return_if_fail (w_current != NULL);
-
-  w_current->continue_component_place = cont;
 }
 
 

--- a/libleptongui/src/i_vars.c
+++ b/libleptongui/src/i_vars.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2016 gEDA Contributors
- * Copyright (C) 2017-2022 Lepton EDA Contributors
+ * Copyright (C) 2017-2023 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -43,7 +43,6 @@ int   default_scroll_wheel = SCROLL_WHEEL_CLASSIC;
 int   default_file_preview = TRUE;
 int   default_enforce_hierarchy = TRUE;
 int   default_fast_mousepan = FALSE;
-int   default_continue_component_place = TRUE;
 int   default_undo_levels = 20;
 int   default_undo_control = TRUE;
 int   default_undo_type = UNDO_DISK;
@@ -274,9 +273,6 @@ i_vars_set (GschemToplevel* w_current)
 
   cfg_read_bool ("schematic.gui", "fast-mousepan",
                  default_fast_mousepan, &w_current->fast_mousepan);
-
-  cfg_read_bool ("schematic.gui", "continue-component-place",
-                 default_continue_component_place, &w_current->continue_component_place);
 
   cfg_read_int_with_check ("schematic.undo", "undo-levels",
                            default_undo_levels, &w_current->undo_levels,


### PR DESCRIPTION
Well, it is not used in C any more.