### PR TITLE
schematic: Fix a bug in callback-button-pressed().

### DIFF
--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -475,7 +475,9 @@
                    ('pan-mode
                     (gschem_page_view_pan *page-view x y)
                     (i_set_state *window (symbol->action-mode 'select-mode)))
-                   (_ FALSE)))
+                   (_ FALSE))
+                 ;; Finish event processing.
+                 FALSE)
 
                 ;; Second mouse button.
                 (2


### PR DESCRIPTION
The bug consists in crashes when some action is started by clicking on the corresponding menu item, e.g. View->Pan, and then continued by clicking the first mouse button on canvas.  In such situations the callback returned unspecified values, which is now fixed by returning FALSE in the function anyways.  The function must always return TRUE or FALSE since only those values can be processed by C signal processing functions.