### PR TITLE
Introduce Scheme interface functions for window action mode.

### DIFF
--- a/libleptongui/scheme/schematic/action-mode.scm
+++ b/libleptongui/scheme/schematic/action-mode.scm
@@ -82,7 +82,7 @@
   "Set action mode to MODE.  If WINDOW is specified, the mode is
 set in it, otherwise it is set in the currently active window as
 returned by the function current-window()."
-  (define *window (check-window window 1))
-  (define _mode (check-action-mode mode 2))
+  (define _mode (check-action-mode mode 1))
+  (define *window (window->pointer window))
 
   (i_set_state *window (symbol->action-mode _mode)))

--- a/libleptongui/scheme/schematic/action-mode.scm
+++ b/libleptongui/scheme/schematic/action-mode.scm
@@ -1,6 +1,6 @@
 ;;; Lepton EDA Schematic Capture
 ;;; Scheme API
-;;; Copyright (C) 2022 Lepton EDA Contributors
+;;; Copyright (C) 2022-2023 Lepton EDA Contributors
 ;;;
 ;;; This program is free software; you can redistribute it and/or modify
 ;;; it under the terms of the GNU General Public License as published by
@@ -21,9 +21,11 @@
   #:use-module (system foreign)
 
   #:use-module (schematic ffi)
+  #:use-module (schematic window foreign)
 
   #:export (action-mode->symbol
-            symbol->action-mode))
+            symbol->action-mode
+            set-action-mode!))
 
 (define (action-mode->symbol mode)
   "Returns a Scheme symbol corresponding to integer MODE value."
@@ -32,3 +34,12 @@
 (define (symbol->action-mode sym)
   "Returns integer action mode value corresponding to symbol SYM."
   (schematic_action_mode_from_string (string->pointer (symbol->string sym))))
+
+
+(define* (set-action-mode! #:window (window #f) mode)
+  "Set action mode to MODE.  If WINDOW is specified, the mode is
+set in it, otherwise it is set in the currently active window as
+returned by the function current-window()."
+  (define *window (check-window (or window (current-window)) 1))
+
+  (i_set_state *window (symbol->action-mode mode)))

--- a/libleptongui/scheme/schematic/action-mode.scm
+++ b/libleptongui/scheme/schematic/action-mode.scm
@@ -28,6 +28,7 @@
 
   #:export (action-mode->symbol
             symbol->action-mode
+            action-mode
             set-action-mode!))
 
 (define (action-mode->symbol mode)
@@ -62,6 +63,16 @@
     select-mode
     text-mode
     zoom-box-mode))
+
+
+(define* (action-mode #:optional (window (current-window)))
+  "Return symbol corresponding to current action mode of WINDOW.
+The WINDOW argument is optional, if it is not specified, currently
+active window, as returned by the function current-window(), is
+used."
+  (define *window (window->pointer window))
+
+  (action-mode->symbol (schematic_window_get_action_mode *window)))
 
 
 (define* (set-action-mode! mode #:key (window (current-window)))

--- a/libleptongui/scheme/schematic/action-mode.scm
+++ b/libleptongui/scheme/schematic/action-mode.scm
@@ -26,8 +26,7 @@
   #:use-module (schematic window foreign)
   #:use-module (schematic window global)
 
-  #:export (action-mode->symbol
-            symbol->action-mode
+  #:export (symbol->action-mode
             action-mode
             set-action-mode!))
 

--- a/libleptongui/scheme/schematic/action-mode.scm
+++ b/libleptongui/scheme/schematic/action-mode.scm
@@ -78,11 +78,11 @@
                       #f))))))
 
 
-(define* (set-action-mode! mode #:key (window #f))
+(define* (set-action-mode! mode #:key (window (current-window)))
   "Set action mode to MODE.  If WINDOW is specified, the mode is
 set in it, otherwise it is set in the currently active window as
 returned by the function current-window()."
-  (define *window (check-window (or window (current-window)) 1))
+  (define *window (check-window window 1))
   (define _mode (check-action-mode mode 2))
 
   (i_set_state *window (symbol->action-mode _mode)))

--- a/libleptongui/scheme/schematic/action-mode.scm
+++ b/libleptongui/scheme/schematic/action-mode.scm
@@ -64,25 +64,18 @@
     zoom-box-mode))
 
 
-(define-syntax check-action-mode
-  (syntax-rules ()
-    ((_ mode pos)
-     (begin
-       (check-symbol mode pos)
-       (if (memq mode %valid-action-modes)
-           mode
-           (scm-error 'misc-error
-                      (frame-procedure-name (stack-ref (make-stack #t) 1))
-                      "Invalid mode symbol in position ~A: ~A"
-                      (list pos mode)
-                      #f))))))
-
-
 (define* (set-action-mode! mode #:key (window (current-window)))
   "Set action mode to MODE.  If WINDOW is specified, the mode is
 set in it, otherwise it is set in the currently active window as
 returned by the function current-window()."
-  (define _mode (check-action-mode mode 1))
   (define *window (window->pointer window))
 
-  (i_set_state *window (symbol->action-mode _mode)))
+  (check-symbol mode 1)
+  (unless (memq mode %valid-action-modes)
+    (scm-error 'misc-error
+               (frame-procedure-name (stack-ref (make-stack #t) 1))
+               "Invalid mode symbol in position ~A: ~A"
+               (list 1 mode)
+               #f))
+
+  (i_set_state *window (symbol->action-mode mode)))

--- a/libleptongui/scheme/schematic/action-mode.scm
+++ b/libleptongui/scheme/schematic/action-mode.scm
@@ -20,6 +20,7 @@
 (define-module (schematic action-mode)
   #:use-module (system foreign)
 
+  #:use-module (lepton ffi boolean)
   #:use-module (lepton ffi check-args)
 
   #:use-module (schematic ffi)
@@ -28,7 +29,17 @@
 
   #:export (symbol->action-mode
             action-mode
-            set-action-mode!))
+            set-action-mode!
+            in-action?))
+
+
+(define* (in-action? #:optional (window (current-window)))
+  "Return #t if an object editing action is underway in the
+current window, and #f otherwise.  If optional WINDOW argument is
+specified, the result corresponds to the state of that window
+instead of the current one."
+  (true? (schematic_window_get_inside_action (window->pointer window))))
+
 
 (define (action-mode->symbol mode)
   "Returns a Scheme symbol corresponding to integer MODE value."

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -230,7 +230,7 @@
     (unless (null? new-selection)
       (run-hook select-objects-hook new-selection)))
 
-  (i_set_state *window (symbol->action-mode 'select-mode))
+  (set-action-mode! 'select-mode)
   (i_action_stop *window)
   (i_update_menus *window))
 
@@ -243,7 +243,7 @@
 
   (o_select_unselect_all *window)
 
-  (i_set_state *window (symbol->action-mode 'select-mode))
+  (set-action-mode! 'select-mode)
   (i_action_stop *window)
   (i_update_menus *window))
 
@@ -257,7 +257,7 @@
     ;; If you delete the objects you must go into select mode
     ;; after the delete.
     (i_action_stop *window)
-    (i_set_state *window (symbol->action-mode 'select-mode))
+    (set-action-mode! 'select-mode)
     (i_update_menus *window)))
 
 
@@ -274,7 +274,7 @@
              (match (snap-point position)
                ((x . y) (o_move_start *window x y))
                (_ #f)))
-        (i_set_state *window (symbol->action-mode 'move-mode)))))
+        (set-action-mode! 'move-mode))))
 
 
 (define-action-public (&edit-copy #:label (G_ "Copy Mode") #:icon "clone")
@@ -290,7 +290,7 @@
              (match (snap-point position)
                ((x . y) (start-copy *window x y))
                (_ #f)))
-        (i_set_state *window (symbol->action-mode 'copy-mode)))))
+        (set-action-mode! 'copy-mode))))
 
 
 (define-action-public (&edit-mcopy #:label (G_ "Multiple Copy Mode") #:icon "multi-clone")
@@ -306,7 +306,7 @@
              (match (snap-point position)
                ((x . y) (start-copy *window x y))
                (_ #f)))
-        (i_set_state *window (symbol->action-mode 'multiple-copy-mode)))))
+        (set-action-mode! 'multiple-copy-mode))))
 
 
 ;;; Rotate all objects in the place list or in the selection list,
@@ -333,7 +333,7 @@
                     (_ #f))))
               ;; Mouse pointer is out of the canvas: just set the
               ;; rotation mode.
-              (i_set_state *window (symbol->action-mode 'rotate-mode)))))))
+              (set-action-mode! 'rotate-mode))))))
 
 
 ;;; Mirror objects in the place list or in the selection list if
@@ -360,7 +360,7 @@
                     (_ #f))))
               ;; Mouse pointer is out of the canvas: just set the
               ;; mirror mode.
-              (i_set_state *window (symbol->action-mode 'mirror-mode)))))))
+              (set-action-mode! 'mirror-mode))))))
 
 
 (define-action-public (&edit-edit #:label (G_ "Edit..."))
@@ -481,7 +481,7 @@ the snap grid size should be set to 100")))
         (begin
           (o_redraw_cleanstates *window)
           (i_action_stop *window)
-          (i_set_state *window (symbol->action-mode 'select-mode)))
+          (set-action-mode! 'select-mode))
 
         ;; Embed all selected components and pictures.
         (begin
@@ -504,7 +504,7 @@ the snap grid size should be set to 100")))
         (begin
           (o_redraw_cleanstates *window)
           (i_action_stop *window)
-          (i_set_state *window (symbol->action-mode 'select-mode)))
+          (set-action-mode! 'select-mode))
 
         ;; Unembed all selected components and pictures.
         (begin
@@ -605,7 +605,7 @@ the snap grid size should be set to 100")))
         ;; Nothing selected, go back to select state.
         (o_redraw_cleanstates *window)
         (i_action_stop *window)
-        (i_set_state *window (symbol->action-mode 'select-mode)))
+        (set-action-mode! 'select-mode))
       (for-each
        (lambda (component) (update-component *window component))
        selected-components)))
@@ -701,7 +701,7 @@ the snap grid size should be set to 100")))
     (_
      (o_redraw_cleanstates *window)
      (i_action_stop *window)
-     (i_set_state *window (symbol->action-mode 'pan-mode)))))
+     (set-action-mode! 'pan-mode))))
 
 
 ;;; Viewport moving.  The distance can be set with the
@@ -753,7 +753,7 @@ the snap grid size should be set to 100")))
 
   (o_redraw_cleanstates *window)
 
-  (i_set_state *window (symbol->action-mode 'zoom-box-mode))
+  (set-action-mode! 'zoom-box-mode)
 
   (match (action-position)
     ((x . y) (a_zoom_box_start *window x y))
@@ -960,7 +960,7 @@ the snap grid size should be set to 100")))
                         ((x . y) FROM_HOTKEY)
                         (_ FROM_MENU)))
 
-  (i_set_state *window (symbol->action-mode 'select-mode)))
+  (set-action-mode! 'select-mode))
 
 
 (define-action-public (&add-net #:label (G_ "Add Net") #:icon "insert-net")
@@ -978,7 +978,7 @@ the snap grid size should be set to 100")))
   (o_redraw_cleanstates *window)
   (o_invalidate_rubber *window)
 
-  (i_set_state *window (symbol->action-mode 'line-mode))
+  (set-action-mode! 'line-mode)
 
   (let ((position (action-position)))
     (and position
@@ -993,7 +993,7 @@ the snap grid size should be set to 100")))
   (o_redraw_cleanstates *window)
   (o_invalidate_rubber *window)
 
-  (i_set_state *window (symbol->action-mode 'path-mode))
+  (set-action-mode! 'path-mode)
 
   ;; Don't start path here since setting of its first point and
   ;; control point requires the left button click and release.
@@ -1006,7 +1006,7 @@ the snap grid size should be set to 100")))
   (o_redraw_cleanstates *window)
   (o_invalidate_rubber *window)
 
-  (i_set_state *window (symbol->action-mode 'box-mode))
+  (set-action-mode! 'box-mode)
 
   (let ((position (action-position)))
     (and position
@@ -1021,7 +1021,7 @@ the snap grid size should be set to 100")))
   (o_redraw_cleanstates *window)
   (o_invalidate_rubber *window)
 
-  (i_set_state *window (symbol->action-mode 'circle-mode))
+  (set-action-mode! 'circle-mode)
 
   (let ((position (action-position)))
     (and position
@@ -1036,7 +1036,7 @@ the snap grid size should be set to 100")))
   (o_redraw_cleanstates *window)
   (o_invalidate_rubber *window)
 
-  (i_set_state *window (symbol->action-mode 'arc-mode))
+  (set-action-mode! 'arc-mode)
 
   (let ((position (action-position)))
     (and position
@@ -1051,7 +1051,7 @@ the snap grid size should be set to 100")))
   (o_redraw_cleanstates *window)
   (o_invalidate_rubber *window)
 
-  (i_set_state *window (symbol->action-mode 'pin-mode))
+  (set-action-mode! 'pin-mode)
 
   (let ((position (action-position)))
     (and position
@@ -1066,7 +1066,7 @@ the snap grid size should be set to 100")))
   (o_redraw_cleanstates *window)
   (o_invalidate_rubber *window)
 
-  (i_set_state *window (symbol->action-mode 'select-mode))
+  (set-action-mode! 'select-mode)
 
   (picture_selection_dialog *window))
 

--- a/libleptongui/scheme/schematic/callback.scm
+++ b/libleptongui/scheme/schematic/callback.scm
@@ -1,6 +1,6 @@
 ;;; Lepton EDA Schematic Capture
 ;;; Scheme API
-;;; Copyright (C) 2022 Lepton EDA Contributors
+;;; Copyright (C) 2022-2023 Lepton EDA Contributors
 ;;;
 ;;; This program is free software; you can redistribute it and/or modify
 ;;; it under the terms of the GNU General Public License as published by
@@ -89,7 +89,7 @@
 (define (callback-add-bus *window)
   (o_redraw_cleanstates *window)
   (o_invalidate_rubber *window)
-  (i_set_state *window (symbol->action-mode 'bus-mode))
+  (set-action-mode! 'bus-mode #:window (pointer->window *window))
   (let ((position (action-position)))
     (and position
          (match (snap-point position)
@@ -100,7 +100,7 @@
 
 (define (callback-add-net *window)
   (o_redraw_cleanstates *window)
-  (i_set_state *window (symbol->action-mode 'net-mode))
+  (set-action-mode! 'net-mode #:window (pointer->window *window))
   (let ((position (action-position)))
     (and position
          (match (snap-point position)
@@ -112,7 +112,7 @@
 
 (define (callback-edit-select *window)
   (o_redraw_cleanstates *window)
-  (i_set_state *window (symbol->action-mode 'select-mode))
+  (set-action-mode! 'select-mode #:window (pointer->window *window))
   (i_action_stop *window))
 
 
@@ -134,6 +134,7 @@
 
 
 (define (callback-add-component *widget *window)
+  (define window (pointer->window *window))
   (define signal-callback-list
     (list
      (if %m4-use-gtk3
@@ -146,7 +147,7 @@
 
   (o_redraw_cleanstates *window)
 
-  (i_set_state *window (symbol->action-mode 'component-mode))
+  (set-action-mode! 'component-mode #:window window)
   (when (null-pointer? (schematic_window_get_compselect *window))
     (let ((*compselect-widget (schematic_compselect_new *window)))
       (schematic_signal_connect *compselect-widget
@@ -164,7 +165,7 @@
       (schematic_window_set_compselect *window *compselect-widget)))
   (x_compselect_open (schematic_window_get_compselect *window))
 
-  (i_set_state *window (symbol->action-mode 'select-mode)))
+  (set-action-mode! 'select-mode #:window window))
 
 
 (define (callback-add-text *widget *window)
@@ -172,6 +173,6 @@
   (o_invalidate_rubber *window)
 
   (i_action_stop *window)
-  (i_set_state *window (symbol->action-mode 'select-mode))
+  (set-action-mode! 'select-mode #:window (pointer->window *window))
 
   (text_input_dialog *window))

--- a/libleptongui/scheme/schematic/undo.scm
+++ b/libleptongui/scheme/schematic/undo.scm
@@ -25,6 +25,7 @@
   #:use-module (lepton config)
   #:use-module (lepton log)
 
+  #:use-module (schematic action-mode)
   #:use-module (schematic ffi)
   #:use-module (schematic gettext)
   #:use-module (schematic window foreign)

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -261,8 +261,7 @@
 
 (define (callback-button-released *page-view *event *window)
   (define window (pointer->window *window))
-  (define current-action-mode
-    (action-mode->symbol (schematic_window_get_action_mode *window)))
+  (define current-action-mode (action-mode window))
   (define window-coords (event-coords *event))
   (define unsnapped-x-bv (make-bytevector (sizeof int) 0))
   (define unsnapped-y-bv (make-bytevector (sizeof int) 0))
@@ -384,8 +383,7 @@
 
 (define (callback-button-pressed *page-view *event *window)
   (define window (pointer->window *window))
-  (define current-action-mode
-    (action-mode->symbol (schematic_window_get_action_mode *window)))
+  (define current-action-mode (action-mode window))
   (define window-coords (event-coords *event))
   (define unsnapped-x-bv (make-bytevector (sizeof int) 0))
   (define unsnapped-y-bv (make-bytevector (sizeof int) 0))
@@ -598,8 +596,7 @@
 
 (define (callback-motion *page-view *event *window)
   (define window (pointer->window *window))
-  (define current-action-mode
-    (action-mode->symbol (schematic_window_get_action_mode *window)))
+  (define current-action-mode (action-mode window))
   (define window-coords (event-coords *event))
   ;; Define from arc_object.h.
   (define ARC_RADIUS 1)

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -482,7 +482,7 @@
                     (o_mirror_world_update *window x y (lepton_list_get_glist *selection)))
                    ('pan-mode
                     (gschem_page_view_pan *page-view x y)
-                    (i_set_state *window (symbol->action-mode 'select-mode)))
+                    (set-action-mode! 'select-mode #:window window))
                    (_ FALSE))
                  ;; Finish event processing.
                  FALSE)
@@ -512,14 +512,14 @@
                                ;; This means the above find did not
                                ;; find anything.
                                (i_action_stop *window)
-                               (i_set_state *window (symbol->action-mode 'select-mode)))
+                               (set-action-mode! 'select-mode #:window window))
 
                              ;; Determine here if copy or move
                              ;; should be started.
                              (if (true? (schematic_window_get_alt_key_pressed *window))
                                  ;; Set copy mode and start copying.
                                  (begin
-                                   (i_set_state *window (symbol->action-mode 'copy-mode))
+                                   (set-action-mode! 'copy-mode #:window window)
                                    (start-copy *window x y))
                                  ;; Start moving objects.
                                  (o_move_start *window x y))))

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -598,6 +598,8 @@
 
 (define (callback-motion *page-view *event *window)
   (define window (pointer->window *window))
+  (define current-action-mode
+    (action-mode->symbol (schematic_window_get_action_mode *window)))
   (define window-coords (event-coords *event))
   ;; Define from arc_object.h.
   (define ARC_RADIUS 1)
@@ -634,11 +636,10 @@
                                                (inexact->exact (round window-x))
                                                (inexact->exact (round window-y)))
                   ;; Evaluate state transitions.
-                  (let ((action-mode (action-mode->symbol (schematic_window_get_action_mode *window))))
-
+                  (begin
                     (if (in-action? window)
                         (if (not (null-pointer? (schematic_window_get_place_list *window)))
-                            (match action-mode
+                            (match current-action-mode
                               ((or 'copy-mode
                                    'multiple-copy-mode
                                    'component-mode
@@ -648,7 +649,7 @@
                               ('move-mode (o_move_motion *window x y))
                               (_ FALSE))
 
-                            (match action-mode
+                            (match current-action-mode
                               ('arc-mode (o_arc_motion *window x y ARC_RADIUS))
                               ('box-mode (o_box_motion *window x y))
                               ('bus-mode (o_bus_motion *window x y))
@@ -665,7 +666,7 @@
                               (_ FALSE)))
 
                         ;; Not inside action.
-                        (match action-mode
+                        (match current-action-mode
                           ('net-mode (o_net_start_magnetic *window x y))
                           (_ FALSE)))
 

--- a/libleptongui/scheme/schematic/window/global.scm
+++ b/libleptongui/scheme/schematic/window/global.scm
@@ -18,7 +18,6 @@
 
 
 (define-module (schematic window global)
-  #:use-module (lepton ffi boolean)
   #:use-module (lepton toplevel)
 
   #:use-module (schematic ffi)
@@ -27,8 +26,7 @@
   #:export (%lepton-window
             current-window
             *current-window
-            with-window
-            in-action?))
+            with-window))
 
 
 ;;; This is a fluid that is initialized with pointer to a new
@@ -66,11 +64,3 @@ dynamic context."
      (let ((*window (and=> (current-window) window->pointer)))
        (or *window
            (error "Current window is unavailable."))))))
-
-
-(define* (in-action? #:optional (window (current-window)))
-  "Return #t if an object editing action is underway in the
-current window, and #f otherwise.  If optional WINDOW argument is
-specified, the result corresponds to the state of that window
-instead of the current one."
-  (true? (schematic_window_get_inside_action (window->pointer window))))

--- a/libleptongui/scheme/schematic/window/global.scm
+++ b/libleptongui/scheme/schematic/window/global.scm
@@ -68,12 +68,9 @@ dynamic context."
            (error "Current window is unavailable."))))))
 
 
-(define* (in-action? #:optional (window #f))
+(define* (in-action? #:optional (window (current-window)))
   "Return #t if an object editing action is underway in the
 current window, and #f otherwise.  If optional WINDOW argument is
 specified, the result corresponds to the state of that window
 instead of the current one."
-  (define (window-in-action? win)
-    (true? (schematic_window_get_inside_action (window->pointer win))))
-
-  (window-in-action? (or window (current-window))))
+  (true? (schematic_window_get_inside_action (window->pointer window))))


### PR DESCRIPTION

- A new function, `action-mode()`, has been added in the module
  `(schematic action-mode)`.  It returns Scheme symbol
  corresponding to the current action mode of a window which is by
  default the current program window of `lepton-schematic`.

- A new procedure, `set-action-mode!()`, has been added in the
  module `(schematic action-mode)`.  It is a Scheme twin of
  `i_set_state()`.  It has one required argument `mode`, and one
  keyword argument `window` which is by default the current window
  as returned by the function `current-window()`.

- The above functions have been utilized in Scheme modules of
  `lepton-schematic` replacing lower level foreign C functions.

- The function `in-action?()` has been moved to the module
  `(schematic action-mode)`.

- The function `action-mode->symbol()` is no longer exported in
  `(schematic action-mode)`.
  
I had to use commit from PR #1002 to aid in testing of the new
functions since some of the amended code chunks are buggy in
the `master` branch.
