### PR TITLE
Add accessors for LeptonUndo structure fields.

### DIFF
--- a/liblepton/include/liblepton/undo.h
+++ b/liblepton/include/liblepton/undo.h
@@ -51,6 +51,9 @@ lepton_undo_get_next (LeptonUndo *undo);
 LeptonUndo*
 lepton_undo_get_prev (LeptonUndo *undo);
 
+int
+lepton_undo_get_type (LeptonUndo *undo);
+
 LeptonUndo*
 lepton_undo_return_tail (LeptonUndo *head);
 

--- a/liblepton/include/liblepton/undo.h
+++ b/liblepton/include/liblepton/undo.h
@@ -66,6 +66,9 @@ lepton_undo_get_page_control (LeptonUndo *undo);
 LeptonUndo*
 lepton_undo_get_prev (LeptonUndo *undo);
 
+double
+lepton_undo_get_scale (LeptonUndo *undo);
+
 int
 lepton_undo_get_type (LeptonUndo *undo);
 

--- a/liblepton/include/liblepton/undo.h
+++ b/liblepton/include/liblepton/undo.h
@@ -78,6 +78,9 @@ lepton_undo_set_prev (LeptonUndo *undo,
 double
 lepton_undo_get_scale (LeptonUndo *undo);
 
+void
+lepton_undo_set_scale (LeptonUndo *undo,
+                       double scale);
 int
 lepton_undo_get_type (LeptonUndo *undo);
 

--- a/liblepton/include/liblepton/undo.h
+++ b/liblepton/include/liblepton/undo.h
@@ -54,6 +54,9 @@ lepton_undo_get_object_list (LeptonUndo *undo);
 LeptonUndo*
 lepton_undo_get_next (LeptonUndo *undo);
 
+int
+lepton_undo_get_page_control (LeptonUndo *undo);
+
 LeptonUndo*
 lepton_undo_get_prev (LeptonUndo *undo);
 

--- a/liblepton/include/liblepton/undo.h
+++ b/liblepton/include/liblepton/undo.h
@@ -75,6 +75,12 @@ lepton_undo_get_type (LeptonUndo *undo);
 int
 lepton_undo_get_up (LeptonUndo *undo);
 
+int
+lepton_undo_get_x (LeptonUndo *undo);
+
+int
+lepton_undo_get_y (LeptonUndo *undo);
+
 LeptonUndo*
 lepton_undo_return_tail (LeptonUndo *head);
 

--- a/liblepton/include/liblepton/undo.h
+++ b/liblepton/include/liblepton/undo.h
@@ -48,6 +48,9 @@ struct st_undo
 char*
 lepton_undo_get_filename (LeptonUndo *undo);
 
+void
+lepton_undo_set_filename (LeptonUndo *undo,
+                          const char *filename);
 GList*
 lepton_undo_get_object_list (LeptonUndo *undo);
 

--- a/liblepton/include/liblepton/undo.h
+++ b/liblepton/include/liblepton/undo.h
@@ -90,6 +90,9 @@ lepton_undo_set_type (LeptonUndo *undo,
 int
 lepton_undo_get_up (LeptonUndo *undo);
 
+void
+lepton_undo_set_up (LeptonUndo *undo,
+                    int up);
 int
 lepton_undo_get_x (LeptonUndo *undo);
 

--- a/liblepton/include/liblepton/undo.h
+++ b/liblepton/include/liblepton/undo.h
@@ -48,6 +48,9 @@ struct st_undo
 char*
 lepton_undo_get_filename (LeptonUndo *undo);
 
+GList*
+lepton_undo_get_object_list (LeptonUndo *undo);
+
 LeptonUndo*
 lepton_undo_get_next (LeptonUndo *undo);
 

--- a/liblepton/include/liblepton/undo.h
+++ b/liblepton/include/liblepton/undo.h
@@ -63,6 +63,9 @@ lepton_undo_get_prev (LeptonUndo *undo);
 int
 lepton_undo_get_type (LeptonUndo *undo);
 
+int
+lepton_undo_get_up (LeptonUndo *undo);
+
 LeptonUndo*
 lepton_undo_return_tail (LeptonUndo *head);
 

--- a/liblepton/include/liblepton/undo.h
+++ b/liblepton/include/liblepton/undo.h
@@ -60,6 +60,9 @@ lepton_undo_set_object_list (LeptonUndo *undo,
 LeptonUndo*
 lepton_undo_get_next (LeptonUndo *undo);
 
+void
+lepton_undo_set_next (LeptonUndo *undo,
+                      LeptonUndo *next);
 int
 lepton_undo_get_page_control (LeptonUndo *undo);
 

--- a/liblepton/include/liblepton/undo.h
+++ b/liblepton/include/liblepton/undo.h
@@ -72,6 +72,9 @@ lepton_undo_get_scale (LeptonUndo *undo);
 int
 lepton_undo_get_type (LeptonUndo *undo);
 
+void
+lepton_undo_set_type (LeptonUndo *undo,
+                      int type);
 int
 lepton_undo_get_up (LeptonUndo *undo);
 

--- a/liblepton/include/liblepton/undo.h
+++ b/liblepton/include/liblepton/undo.h
@@ -63,6 +63,9 @@ lepton_undo_get_next (LeptonUndo *undo);
 int
 lepton_undo_get_page_control (LeptonUndo *undo);
 
+void
+lepton_undo_set_page_control (LeptonUndo *undo,
+                              int page_control);
 LeptonUndo*
 lepton_undo_get_prev (LeptonUndo *undo);
 

--- a/liblepton/include/liblepton/undo.h
+++ b/liblepton/include/liblepton/undo.h
@@ -54,6 +54,9 @@ lepton_undo_set_filename (LeptonUndo *undo,
 GList*
 lepton_undo_get_object_list (LeptonUndo *undo);
 
+void
+lepton_undo_set_object_list (LeptonUndo *undo,
+                             GList *object_list);
 LeptonUndo*
 lepton_undo_get_next (LeptonUndo *undo);
 

--- a/liblepton/include/liblepton/undo.h
+++ b/liblepton/include/liblepton/undo.h
@@ -45,6 +45,9 @@ struct st_undo
   LeptonUndo *next;
 };
 
+char*
+lepton_undo_get_filename (LeptonUndo *undo);
+
 LeptonUndo*
 lepton_undo_get_next (LeptonUndo *undo);
 

--- a/liblepton/include/liblepton/undo.h
+++ b/liblepton/include/liblepton/undo.h
@@ -72,6 +72,9 @@ lepton_undo_set_page_control (LeptonUndo *undo,
 LeptonUndo*
 lepton_undo_get_prev (LeptonUndo *undo);
 
+void
+lepton_undo_set_prev (LeptonUndo *undo,
+                      LeptonUndo *prev);
 double
 lepton_undo_get_scale (LeptonUndo *undo);
 

--- a/liblepton/include/liblepton/undo.h
+++ b/liblepton/include/liblepton/undo.h
@@ -46,6 +46,9 @@ struct st_undo
 };
 
 LeptonUndo*
+lepton_undo_get_next (LeptonUndo *undo);
+
+LeptonUndo*
 lepton_undo_get_prev (LeptonUndo *undo);
 
 LeptonUndo*

--- a/liblepton/include/liblepton/undo.h
+++ b/liblepton/include/liblepton/undo.h
@@ -81,9 +81,15 @@ lepton_undo_get_up (LeptonUndo *undo);
 int
 lepton_undo_get_x (LeptonUndo *undo);
 
+void
+lepton_undo_set_x (LeptonUndo *undo,
+                   int x);
 int
 lepton_undo_get_y (LeptonUndo *undo);
 
+void
+lepton_undo_set_y (LeptonUndo *undo,
+                   int y);
 LeptonUndo*
 lepton_undo_return_tail (LeptonUndo *head);
 

--- a/liblepton/include/liblepton/undo.h
+++ b/liblepton/include/liblepton/undo.h
@@ -46,6 +46,9 @@ struct st_undo
 };
 
 LeptonUndo*
+lepton_undo_get_prev (LeptonUndo *undo);
+
+LeptonUndo*
 lepton_undo_return_tail (LeptonUndo *head);
 
 LeptonUndo*

--- a/liblepton/src/undo.c
+++ b/liblepton/src/undo.c
@@ -244,6 +244,20 @@ lepton_undo_get_up (LeptonUndo *undo)
   return undo->up;
 }
 
+/*! \brief Set undo structure's \a up field value.
+ *
+ *  \param [in] undo The undo structure to set the field of.
+ *  \param [in] undo The new value of the \a up field.
+ */
+void
+lepton_undo_set_up (LeptonUndo *undo,
+                    int up)
+{
+  g_return_if_fail (undo != NULL);
+
+  undo->up = up;
+}
+
 
 /*! \brief Get undo structure's \a x field value.
  *

--- a/liblepton/src/undo.c
+++ b/liblepton/src/undo.c
@@ -36,7 +36,7 @@
 
 /*! \brief Get undo structure's \a filename field value.
  *
- *  \param [in] undo The undo structure to obtain the field of.
+ *  \param [in] undo The #LeptonUndo structure to obtain the field of.
  *  \return The value of the \a filename field.
  */
 char*
@@ -65,7 +65,7 @@ lepton_undo_set_filename (LeptonUndo *undo,
 
 /*! \brief Get undo structure's \a object_list field value.
  *
- *  \param [in] undo The undo structure to obtain the field of.
+ *  \param [in] undo The #LeptonUndo structure to obtain the field of.
  *  \return The value of the \a object_list field.
  */
 GList*
@@ -92,7 +92,7 @@ lepton_undo_set_object_list (LeptonUndo *undo,
 
 /*! \brief Get undo structure's \a next field value.
  *
- *  \param [in] undo The undo structure to obtain the field of.
+ *  \param [in] undo The #LeptonUndo structure to obtain the field of.
  *  \return The value of the \a next field.
  */
 LeptonUndo*
@@ -105,7 +105,7 @@ lepton_undo_get_next (LeptonUndo *undo)
 
 /*! \brief Set undo structure's \a next field value.
  *
- *  \param [in] undo The undo structure to set the field of.
+ *  \param [in] undo The #LeptonUndo structure to set the field of.
  *  \param [in] next The new value of the \a next field.
  */
 void
@@ -120,7 +120,7 @@ lepton_undo_set_next (LeptonUndo *undo,
 
 /*! \brief Get undo structure's \a page_control field value.
  *
- *  \param [in] undo The undo structure to obtain the field of.
+ *  \param [in] undo The #LeptonUndo structure to obtain the field of.
  *  \return The value of the \a page_control field.
  */
 int
@@ -133,7 +133,7 @@ lepton_undo_get_page_control (LeptonUndo *undo)
 
 /*! \brief Set undo structure's \a page_control field value.
  *
- *  \param [in] undo The undo structure to set the field of.
+ *  \param [in] undo The #LeptonUndo structure to set the field of.
  *  \param [in] page_control The new value of the \a page_control field.
  */
 void
@@ -148,7 +148,7 @@ lepton_undo_set_page_control (LeptonUndo *undo,
 
 /*! \brief Get undo structure's \a prev field value.
  *
- *  \param [in] undo The undo structure to obtain the field of.
+ *  \param [in] undo The #LeptonUndo structure to obtain the field of.
  *  \return The value of the \a prev field.
  */
 LeptonUndo*
@@ -161,7 +161,7 @@ lepton_undo_get_prev (LeptonUndo *undo)
 
 /*! \brief Set undo structure's \a prev field value.
  *
- *  \param [in] undo The undo structure to set the field of.
+ *  \param [in] undo The #LeptonUndo structure to set the field of.
  *  \param [in] prev The new value of the \a prev field.
  */
 void
@@ -176,7 +176,7 @@ lepton_undo_set_prev (LeptonUndo *undo,
 
 /*! \brief Get undo structure's \a scale field value.
  *
- *  \param [in] undo The undo structure to obtain the field of.
+ *  \param [in] undo The #LeptonUndo structure to obtain the field of.
  *  \return The value of the \a scale field.
  */
 double
@@ -189,7 +189,7 @@ lepton_undo_get_scale (LeptonUndo *undo)
 
 /*! \brief Set undo structure's \a scale field value.
  *
- *  \param [in] undo The undo structure to set the field of.
+ *  \param [in] undo The #LeptonUndo structure to set the field of.
  *  \param [in] scale The new value of the \a scale field.
  */
 void
@@ -204,7 +204,7 @@ lepton_undo_set_scale (LeptonUndo *undo,
 
 /*! \brief Get undo structure's \a type field value.
  *
- *  \param [in] undo The undo structure to obtain the field of.
+ *  \param [in] undo The #LeptonUndo structure to obtain the field of.
  *  \return The value of the \a type field.
  */
 int
@@ -218,7 +218,7 @@ lepton_undo_get_type (LeptonUndo *undo)
 
 /*! \brief Set undo structure's \a type field value.
  *
- *  \param [in] undo The undo structure to set the field of.
+ *  \param [in] undo The #LeptonUndo structure to set the field of.
  *  \param [in] type The new value of the \a type field.
  */
 void
@@ -233,7 +233,7 @@ lepton_undo_set_type (LeptonUndo *undo,
 
 /*! \brief Get undo structure's \a up field value.
  *
- *  \param [in] undo The undo structure to obtain the field of.
+ *  \param [in] undo The #LeptonUndo structure to obtain the field of.
  *  \return The value of the \a up field.
  */
 int
@@ -246,7 +246,7 @@ lepton_undo_get_up (LeptonUndo *undo)
 
 /*! \brief Set undo structure's \a up field value.
  *
- *  \param [in] undo The undo structure to set the field of.
+ *  \param [in] undo The #LeptonUndo structure to set the field of.
  *  \param [in] undo The new value of the \a up field.
  */
 void
@@ -261,7 +261,7 @@ lepton_undo_set_up (LeptonUndo *undo,
 
 /*! \brief Get undo structure's \a x field value.
  *
- *  \param [in] undo The undo structure to obtain the field of.
+ *  \param [in] undo The #LeptonUndo structure to obtain the field of.
  *  \return The value of the \a x field.
  */
 int
@@ -275,7 +275,7 @@ lepton_undo_get_x (LeptonUndo *undo)
 
 /*! \brief Set undo structure's \a x field value.
  *
- *  \param [in] undo The undo structure to set the field of.
+ *  \param [in] undo The #LeptonUndo structure to set the field of.
  *  \param [in] x The new value of the \a x field.
  */
 void
@@ -290,7 +290,7 @@ lepton_undo_set_x (LeptonUndo *undo,
 
 /*! \brief Get undo structure's \a y field value.
  *
- *  \param [in] undo The undo structure to obtain the field of.
+ *  \param [in] undo The #LeptonUndo structure to obtain the field of.
  *  \return The value of the \a y field.
  */
 int
@@ -304,7 +304,7 @@ lepton_undo_get_y (LeptonUndo *undo)
 
 /*! \brief Set undo structure's \a y field value.
  *
- *  \param [in] undo The undo structure to set the field of.
+ *  \param [in] undo The #LeptonUndo structure to set the field of.
  *  \param [in] y The new value of the \a y field.
  */
 void

--- a/liblepton/src/undo.c
+++ b/liblepton/src/undo.c
@@ -117,6 +117,20 @@ lepton_undo_get_page_control (LeptonUndo *undo)
   return undo->page_control;
 }
 
+/*! \brief Set undo structure's \a page_control field value.
+ *
+ *  \param [in] undo The undo structure to set the field of.
+ *  \param [in] page_control The new value of the \a page_control field.
+ */
+void
+lepton_undo_set_page_control (LeptonUndo *undo,
+                              int page_control)
+{
+  g_return_if_fail (undo != NULL);
+
+  undo->page_control = page_control;
+}
+
 
 /*! \brief Get undo structure's \a prev field value.
  *

--- a/liblepton/src/undo.c
+++ b/liblepton/src/undo.c
@@ -76,6 +76,19 @@ lepton_undo_get_object_list (LeptonUndo *undo)
   return undo->object_list;
 }
 
+/*! \brief Set undo structure's \a object_list field value.
+ *
+ *  \param [in] undo The #LeptonUndo structure to set the field of.
+ *  \param [in] object_list The new value of the \a object_list field.
+ */
+void
+lepton_undo_set_object_list (LeptonUndo *undo,
+                             GList *object_list)
+{
+  g_return_if_fail (undo != NULL);
+  undo->object_list = object_list;
+}
+
 
 /*! \brief Get undo structure's \a next field value.
  *

--- a/liblepton/src/undo.c
+++ b/liblepton/src/undo.c
@@ -132,6 +132,20 @@ lepton_undo_get_prev (LeptonUndo *undo)
 }
 
 
+/*! \brief Get undo structure's \a scale field value.
+ *
+ *  \param [in] undo The undo structure to obtain the field of.
+ *  \return The value of the \a scale field.
+ */
+double
+lepton_undo_get_scale (LeptonUndo *undo)
+{
+  g_return_val_if_fail (undo != NULL, 0);
+
+  return undo->scale;
+}
+
+
 /*! \brief Get undo structure's \a type field value.
  *
  *  \param [in] undo The undo structure to obtain the field of.

--- a/liblepton/src/undo.c
+++ b/liblepton/src/undo.c
@@ -159,6 +159,20 @@ lepton_undo_get_prev (LeptonUndo *undo)
   return undo->prev;
 }
 
+/*! \brief Set undo structure's \a prev field value.
+ *
+ *  \param [in] undo The undo structure to set the field of.
+ *  \param [in] prev The new value of the \a prev field.
+ */
+void
+lepton_undo_set_prev (LeptonUndo *undo,
+                      LeptonUndo *prev)
+{
+  g_return_if_fail (undo != NULL);
+
+  undo->prev = prev;
+}
+
 
 /*! \brief Get undo structure's \a scale field value.
  *

--- a/liblepton/src/undo.c
+++ b/liblepton/src/undo.c
@@ -187,6 +187,20 @@ lepton_undo_get_scale (LeptonUndo *undo)
   return undo->scale;
 }
 
+/*! \brief Set undo structure's \a scale field value.
+ *
+ *  \param [in] undo The undo structure to set the field of.
+ *  \param [in] scale The new value of the \a scale field.
+ */
+void
+lepton_undo_set_scale (LeptonUndo *undo,
+                       double scale)
+{
+  g_return_if_fail (undo != NULL);
+
+  undo->scale = scale;
+}
+
 
 /*! \brief Get undo structure's \a type field value.
  *

--- a/liblepton/src/undo.c
+++ b/liblepton/src/undo.c
@@ -35,6 +35,20 @@
 
 
 
+/*! \brief Get undo structure's \a next field value.
+ *
+ *  \param [in] undo The undo structure to obtain the field of.
+ *  \return The value of the \a next field.
+ */
+LeptonUndo*
+lepton_undo_get_next (LeptonUndo *undo)
+{
+  g_return_val_if_fail (undo != NULL, NULL);
+
+  return undo->next;
+}
+
+
 /*! \brief Get undo structure's \a prev field value.
  *
  *  \param [in] undo The undo structure to obtain the field of.

--- a/liblepton/src/undo.c
+++ b/liblepton/src/undo.c
@@ -160,6 +160,21 @@ lepton_undo_get_type (LeptonUndo *undo)
 }
 
 
+/*! \brief Set undo structure's \a type field value.
+ *
+ *  \param [in] undo The undo structure to set the field of.
+ *  \param [in] type The new value of the \a type field.
+ */
+void
+lepton_undo_set_type (LeptonUndo *undo,
+                      int type)
+{
+  g_return_if_fail (undo != NULL);
+
+  undo->type = type;
+}
+
+
 /*! \brief Get undo structure's \a up field value.
  *
  *  \param [in] undo The undo structure to obtain the field of.

--- a/liblepton/src/undo.c
+++ b/liblepton/src/undo.c
@@ -203,6 +203,21 @@ lepton_undo_get_x (LeptonUndo *undo)
 }
 
 
+/*! \brief Set undo structure's \a x field value.
+ *
+ *  \param [in] undo The undo structure to set the field of.
+ *  \param [in] x The new value of the \a x field.
+ */
+void
+lepton_undo_set_x (LeptonUndo *undo,
+                   int x)
+{
+  g_return_if_fail (undo != NULL);
+
+  undo->x = x;
+}
+
+
 /*! \brief Get undo structure's \a y field value.
  *
  *  \param [in] undo The undo structure to obtain the field of.
@@ -214,6 +229,21 @@ lepton_undo_get_y (LeptonUndo *undo)
   g_return_val_if_fail (undo != NULL, 0);
 
   return undo->y;
+}
+
+
+/*! \brief Set undo structure's \a y field value.
+ *
+ *  \param [in] undo The undo structure to set the field of.
+ *  \param [in] y The new value of the \a y field.
+ */
+void
+lepton_undo_set_y (LeptonUndo *undo,
+                   int y)
+{
+  g_return_if_fail (undo != NULL);
+
+  undo->y = y;
 }
 
 

--- a/liblepton/src/undo.c
+++ b/liblepton/src/undo.c
@@ -118,6 +118,20 @@ lepton_undo_get_type (LeptonUndo *undo)
 }
 
 
+/*! \brief Get undo structure's \a up field value.
+ *
+ *  \param [in] undo The undo structure to obtain the field of.
+ *  \return The value of the \a up field.
+ */
+int
+lepton_undo_get_up (LeptonUndo *undo)
+{
+  g_return_val_if_fail (undo != NULL, 0);
+
+  return undo->up;
+}
+
+
 /*! \todo Finish function documentation!!!
  *  \brief
  *  \par Function Description

--- a/liblepton/src/undo.c
+++ b/liblepton/src/undo.c
@@ -34,6 +34,19 @@
 #include "liblepton_priv.h"
 
 
+/*! \brief Get undo structure's \a filename field value.
+ *
+ *  \param [in] undo The undo structure to obtain the field of.
+ *  \return The value of the \a filename field.
+ */
+char*
+lepton_undo_get_filename (LeptonUndo *undo)
+{
+  g_return_val_if_fail (undo != NULL, NULL);
+
+  return undo->filename;
+}
+
 
 /*! \brief Get undo structure's \a next field value.
  *

--- a/liblepton/src/undo.c
+++ b/liblepton/src/undo.c
@@ -174,6 +174,34 @@ lepton_undo_get_up (LeptonUndo *undo)
 }
 
 
+/*! \brief Get undo structure's \a x field value.
+ *
+ *  \param [in] undo The undo structure to obtain the field of.
+ *  \return The value of the \a x field.
+ */
+int
+lepton_undo_get_x (LeptonUndo *undo)
+{
+  g_return_val_if_fail (undo != NULL, 0);
+
+  return undo->x;
+}
+
+
+/*! \brief Get undo structure's \a y field value.
+ *
+ *  \param [in] undo The undo structure to obtain the field of.
+ *  \return The value of the \a y field.
+ */
+int
+lepton_undo_get_y (LeptonUndo *undo)
+{
+  g_return_val_if_fail (undo != NULL, 0);
+
+  return undo->y;
+}
+
+
 /*! \todo Finish function documentation!!!
  *  \brief
  *  \par Function Description

--- a/liblepton/src/undo.c
+++ b/liblepton/src/undo.c
@@ -103,6 +103,20 @@ lepton_undo_get_next (LeptonUndo *undo)
   return undo->next;
 }
 
+/*! \brief Set undo structure's \a next field value.
+ *
+ *  \param [in] undo The undo structure to set the field of.
+ *  \param [in] next The new value of the \a next field.
+ */
+void
+lepton_undo_set_next (LeptonUndo *undo,
+                      LeptonUndo *next)
+{
+  g_return_if_fail (undo != NULL);
+
+  undo->next = next;
+}
+
 
 /*! \brief Get undo structure's \a page_control field value.
  *

--- a/liblepton/src/undo.c
+++ b/liblepton/src/undo.c
@@ -63,6 +63,20 @@ lepton_undo_get_prev (LeptonUndo *undo)
 }
 
 
+/*! \brief Get undo structure's \a type field value.
+ *
+ *  \param [in] undo The undo structure to obtain the field of.
+ *  \return The value of the \a type field.
+ */
+int
+lepton_undo_get_type (LeptonUndo *undo)
+{
+  g_return_val_if_fail (undo != NULL, UNDO_ALL);
+
+  return undo->type;
+}
+
+
 /*! \todo Finish function documentation!!!
  *  \brief
  *  \par Function Description

--- a/liblepton/src/undo.c
+++ b/liblepton/src/undo.c
@@ -76,6 +76,20 @@ lepton_undo_get_next (LeptonUndo *undo)
 }
 
 
+/*! \brief Get undo structure's \a page_control field value.
+ *
+ *  \param [in] undo The undo structure to obtain the field of.
+ *  \return The value of the \a page_control field.
+ */
+int
+lepton_undo_get_page_control (LeptonUndo *undo)
+{
+  g_return_val_if_fail (undo != NULL, 0);
+
+  return undo->page_control;
+}
+
+
 /*! \brief Get undo structure's \a prev field value.
  *
  *  \param [in] undo The undo structure to obtain the field of.

--- a/liblepton/src/undo.c
+++ b/liblepton/src/undo.c
@@ -48,6 +48,20 @@ lepton_undo_get_filename (LeptonUndo *undo)
 }
 
 
+/*! \brief Get undo structure's \a object_list field value.
+ *
+ *  \param [in] undo The undo structure to obtain the field of.
+ *  \return The value of the \a object_list field.
+ */
+GList*
+lepton_undo_get_object_list (LeptonUndo *undo)
+{
+  g_return_val_if_fail (undo != NULL, NULL);
+
+  return undo->object_list;
+}
+
+
 /*! \brief Get undo structure's \a next field value.
  *
  *  \param [in] undo The undo structure to obtain the field of.

--- a/liblepton/src/undo.c
+++ b/liblepton/src/undo.c
@@ -47,6 +47,21 @@ lepton_undo_get_filename (LeptonUndo *undo)
   return undo->filename;
 }
 
+/*! \brief Set undo structure's \a filename field value.
+ *
+ *  \param [in] undo The #LeptonUndo structure to set the field of.
+ *  \param [in] filename The new value of the \a filename field.
+ */
+void
+lepton_undo_set_filename (LeptonUndo *undo,
+                          const char *filename)
+{
+  g_return_if_fail (undo);
+
+  g_free (undo->filename);
+  undo->filename = g_strdup (filename);
+}
+
 
 /*! \brief Get undo structure's \a object_list field value.
  *

--- a/liblepton/src/undo.c
+++ b/liblepton/src/undo.c
@@ -33,6 +33,22 @@
 
 #include "liblepton_priv.h"
 
+
+
+/*! \brief Get undo structure's \a prev field value.
+ *
+ *  \param [in] undo The undo structure to obtain the field of.
+ *  \return The value of the \a prev field.
+ */
+LeptonUndo*
+lepton_undo_get_prev (LeptonUndo *undo)
+{
+  g_return_val_if_fail (undo != NULL, NULL);
+
+  return undo->prev;
+}
+
+
 /*! \todo Finish function documentation!!!
  *  \brief
  *  \par Function Description


### PR DESCRIPTION
This will allow to go towards transforming the structure into an opaque one, which in itself is good for libraries, and afterwards, towards moving the code to Scheme and refactor it there along with getting rid of Scheme-in-C hooks.