### PR TITLE
schematic: Fix call for schematic-error-dialog().

### DIFF
--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -1115,8 +1115,7 @@ the snap grid size should be set to 100")))
                                       (gerror-message (dereference-pointer *error))))))
 
     (schematic-error-dialog (G_ "Failed to descend hierarchy.")
-                            secondary-message
-                            %null-pointer)
+                            #:secondary-text secondary-message)
 
     (g_clear_error *error)))
 


### PR DESCRIPTION
The dialog is to be shown when there is some issue with hierarchy descending.  Due to the wrong function call, the user might not know what's going on without visiting the log window if some error happened, for instance when the file to descend was unreadable and wasn't open.