### PR TITLE
Add --disable-doc configure option

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -6,13 +6,17 @@ if ENABLE_CONTRIB
 CONTRIB_DIR=contrib
 endif
 
+if ENABLE_DOC
+DOC_DIR=docs
+endif
+
 SUBDIRS = \
 	liblepton \
 	${ATTRIB_DIR} \
 	libleptongui \
 	tools \
 	symbols \
-	docs \
+	${DOC_DIR} \
 	examples \
 	${CONTRIB_DIR}
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -136,10 +136,12 @@ precompile:
 	$(bindir)/lepton-schematic
 
 
+if ENABLE_DOC
 install-data-local:
 	$(MKDIR_P) $(DESTDIR)$(docdir)
 	cp -v $(srcdir)/README.md $(DESTDIR)$(docdir)
 	cp -v $(srcdir)/NEWS.md $(DESTDIR)$(docdir)
+endif
 
 uninstall-local:
 	rm -vfr $(DESTDIR)$(includedir)/liblepton

--- a/configure.ac
+++ b/configure.ac
@@ -228,6 +228,8 @@ AX_OPTION_STROKE
 AX_OPTION_ATTRIB
 # contributed software
 AX_OPTION_CONTRIB
+# doc
+AX_OPTION_DOC
 
 #####################################################################
 # Tool-specific setup

--- a/liblepton/Makefile.am
+++ b/liblepton/Makefile.am
@@ -1,4 +1,16 @@
-SUBDIRS = po data docs include lib src scheme tests
+if ENABLE_DOC
+DOC_DIR=docs
+endif
+
+SUBDIRS = \
+	po \
+	data \
+	${DOC_DIR} \
+	include \
+	lib \
+	src \
+	scheme \
+	tests
 
 pkgconfigdir            = $(libdir)/pkgconfig
 pkgconfig_DATA          = liblepton.pc

--- a/libleptonattrib/Makefile.am
+++ b/libleptonattrib/Makefile.am
@@ -1,4 +1,13 @@
-SUBDIRS = po src include data docs
+if ENABLE_DOC
+DOC_DIR=docs
+endif
+
+SUBDIRS = \
+	po \
+	src \
+	include \
+	${DOC_DIR} \
+	data
 
 pkgconfigdir            = $(libdir)/pkgconfig
 pkgconfig_DATA          = libleptonattrib.pc

--- a/libleptongui/Makefile.am
+++ b/libleptongui/Makefile.am
@@ -1,7 +1,11 @@
+if ENABLE_DOC
+DOC_DIR=docs
+endif
+
 SUBDIRS = \
 	bitmap \
 	data \
-	docs \
+	${DOC_DIR} \
 	examples \
 	include \
 	lib \

--- a/libleptongui/scheme/schematic/doc.scm
+++ b/libleptongui/scheme/schematic/doc.scm
@@ -2,7 +2,7 @@
 ;; Scheme API
 ;; Copyright (C) 2011-2014 Peter Brett <peter@peter-b.co.uk>
 ;; Copyright (C) 2011-2015 gEDA Contributors
-;; Copyright (C) 2017-2022 Lepton EDA Contributors
+;; Copyright (C) 2017-2023 Lepton EDA Contributors
 ;;
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -40,13 +40,9 @@
   #:export (show-component-documentation))
 
 
-; private:
-;
-; Call (schematic util)::show-uri( url ), catching exceptions.
-; Display a message box on error.
-;
 ( define ( doc-show-uri url )
-
+  "Call (schematic util)::show-uri( URL ), catching exceptions.
+Display a message box on error."
   ( catch
     #t
     ( lambda()
@@ -62,33 +58,28 @@
         (schematic-message-dialog ermsg)
       )
     )
-  ) ; catch()
-
+  )
 ) ; doc-show-uri()
 
 
-
-; private:
-;
 ( define ( doc-show-file fpath )
   ( doc-show-uri (format #f "file://~a" fpath) )
 )
 
 
-
 (define (sys-doc-dir)
   "Get the directory where documentation is stored."
-
   ; return:
   %lepton-docdir
 )
 
+
 (define (user-doc-dir)
   "Get the directory where per-user documentation is stored."
-
   (string-join (list (user-data-dir)
                      "doc" "lepton-eda")
                file-name-separator-string))
+
 
 ;; Munge a wiki page name so that it can be used in a filename
 (define (wiki-munge name)
@@ -100,27 +91,41 @@
        (else c)))
    name))
 
-(define* (show-wiki #:optional (page "geda:documentation"))
-  "show-wiki PAGE
 
-Launch a browser to display a page from the offline version of the
+( define* ( show-wiki #:optional (page "geda:documentation") )
+  "Launch a browser to display a page from the offline version of the
 wiki.  The specified PAGE should be a string containing the page
 name as used on the live version of the wiki."
+( let*
+  (
+  ( fnames (list (sys-doc-dir) "wiki") )
+  ( path   (string-join fnames file-name-separator-string 'suffix) )
+  ( fpath  (string-append path (wiki-munge page) ".html") )
+  )
 
-  (doc-show-uri
-   (string-append "file://"
-                  (string-join (list (sys-doc-dir) "wiki")
-                               file-name-separator-string 'suffix)
-                  (wiki-munge page)
-                  ".html")))
+  ( if ( file-exists? fpath )
+    ( doc-show-uri (string-append "file://" fpath) )
+    ( schematic-message-dialog (format #f (G_ "File does not exist:~%~a") fpath) )
+  )
+)
+) ; show-wiki()
 
-(define (show-manual)
+
+( define ( show-manual )
   "Launch a browser to display a main page of the offline version
 of the Lepton EDA Reference manual."
-  (doc-show-uri
-   (string-append "file://"
-                  (string-join (list (sys-doc-dir) "lepton-manual.html" "index.html")
-                               file-name-separator-string))))
+( let*
+  (
+  ( fnames (list (sys-doc-dir) "lepton-manual.html" "index.html") )
+  ( fpath  (string-join fnames file-name-separator-string) )
+  )
+
+  ( if ( file-exists? fpath )
+    ( doc-show-uri (string-append "file://" fpath) )
+    ( schematic-message-dialog (format #f (G_ "File does not exist:~%~a") fpath) )
+  )
+)
+) ; show-manual()
 
 
 ;; Get the value of a named attribute.  Attached attributes are
@@ -133,6 +138,7 @@ of the Lepton EDA Reference manual."
            (and (> (string-length v) 0) v))))
   (or (any any-proc (object-attribs obj))
       (any any-proc (inherited-attribs obj))))
+
 
 ;; For each entry in DIRNAME, PROC is called.  If PROC returns a
 ;; true value, the iteration stops and the result returned by PROC
@@ -153,6 +159,7 @@ of the Lepton EDA Reference manual."
            (lambda () (closedir dir))))
      #f)))
 
+
 ;; Searches for and displays documentation in DIRNAME.  A
 ;; documentation file is expected to start with BASENAME and
 ;; (optionally) end with EXT.  Comparisons are carried out
@@ -167,6 +174,7 @@ of the Lepton EDA Reference manual."
   (let ((filename (false-if-exception (directory-any dirname test-dir-entry))))
     (and filename (begin (doc-show-file filename) #t))))
 
+
 ;; Searches for documentation STRING on the Internet, using PDF
 ;; search template.
 ;;
@@ -179,6 +187,7 @@ of the Lepton EDA Reference manual."
            string))
   #t)
 
+
 ;; Munges a component basename to look more like a device name
 (define (munge-basename basename)
   (let* ((rx (make-regexp "(-[0-9]+)?.sym$" regexp/icase))
@@ -186,6 +195,7 @@ of the Lepton EDA Reference manual."
     (if match
         (regexp-substitute #f match 'pre)
         basename)))
+
 
 (define (show-component-documentation obj)
   "show-component-documentation COMPONENT

--- a/m4/lepton-doc.m4
+++ b/m4/lepton-doc.m4
@@ -1,0 +1,39 @@
+# lepton-doc.m4                                       -*-Autoconf-*-
+# serial 1.0
+
+dnl Optionally disable documentation.
+dnl Copyright (C) 2023 Lepton EDA Contributors
+dnl
+dnl This program is free software; you can redistribute it and/or modify
+dnl it under the terms of the GNU General Public License as published by
+dnl the Free Software Foundation; either version 2 of the License, or
+dnl (at your option) any later version.
+dnl
+dnl This program is distributed in the hope that it will be useful,
+dnl but WITHOUT ANY WARRANTY; without even the implied warranty of
+dnl MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+dnl GNU General Public License for more details.
+dnl
+dnl You should have received a copy of the GNU General Public License
+dnl along with this program; if not, write to the Free Software
+dnl Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+# Check if documentation should be disabled
+AC_DEFUN([AX_OPTION_DOC],
+[
+  AC_PREREQ([2.60])dnl
+
+  AC_MSG_CHECKING([whether to enable documentation])
+  AC_ARG_ENABLE([doc],
+    [AS_HELP_STRING([--disable-doc], [turn off building and installing documentation])],
+    [], [enable_doc="yes"])
+
+  if test "X$enable_doc" = "Xyes"; then
+    AC_MSG_RESULT([yes])
+  else
+    AC_MSG_RESULT([no])
+  fi
+
+  AM_CONDITIONAL([ENABLE_DOC], test "X$enable_doc" = "Xyes")
+
+])dnl AX_OPTION_DOC

--- a/tools/archive/Makefile.am
+++ b/tools/archive/Makefile.am
@@ -1,3 +1,9 @@
-SUBDIRS = docs tests
+if ENABLE_DOC
+DOC_DIR=docs
+endif
+
+SUBDIRS = \
+	${DOC_DIR} \
+	tests
 
 bin_SCRIPTS = lepton-archive

--- a/tools/cli/Makefile.am
+++ b/tools/cli/Makefile.am
@@ -1,1 +1,9 @@
-SUBDIRS = po scheme docs tests
+if ENABLE_DOC
+DOC_DIR=docs
+endif
+
+SUBDIRS = \
+	po \
+	scheme \
+	${DOC_DIR} \
+	tests

--- a/tools/embed/Makefile.am
+++ b/tools/embed/Makefile.am
@@ -1,3 +1,5 @@
+if ENABLE_DOC
 SUBDIRS = docs
+endif
 
 bin_SCRIPTS = lepton-embed

--- a/tools/netlist/Makefile.am
+++ b/tools/netlist/Makefile.am
@@ -1,3 +1,11 @@
-SUBDIRS = scheme examples tests docs
+if ENABLE_DOC
+DOC_DIR=docs
+endif
+
+SUBDIRS = \
+	scheme \
+	examples \
+	${DOC_DIR} \
+	tests
 
 bin_SCRIPTS = lepton-netlist

--- a/tools/pcb_backannotate/Makefile.am
+++ b/tools/pcb_backannotate/Makefile.am
@@ -1,5 +1,6 @@
-SUBDIRS = \
-	docs
+if ENABLE_DOC
+SUBDIRS = docs
+endif
 
 bin_SCRIPTS = \
 	lepton-pcb_backannotate

--- a/tools/refdes_renum/Makefile.am
+++ b/tools/refdes_renum/Makefile.am
@@ -1,5 +1,9 @@
+if ENABLE_DOC
+DOC_DIR=docs
+endif
+
 SUBDIRS = \
-	docs \
+	${DOC_DIR} \
 	tests
 
 bin_SCRIPTS = \

--- a/tools/sch2pcb/Makefile.am
+++ b/tools/sch2pcb/Makefile.am
@@ -1,3 +1,10 @@
-SUBDIRS = examples docs tests
+if ENABLE_DOC
+DOC_DIR=docs
+endif
+
+SUBDIRS = \
+	examples \
+	${DOC_DIR} \
+	tests
 
 bin_SCRIPTS = lepton-sch2pcb

--- a/tools/schdiff/Makefile.am
+++ b/tools/schdiff/Makefile.am
@@ -1,5 +1,6 @@
-SUBDIRS = \
-	docs
+if ENABLE_DOC
+SUBDIRS = docs
+endif
 
 bin_SCRIPTS = \
 	lepton-schdiff

--- a/tools/symcheck/Makefile.am
+++ b/tools/symcheck/Makefile.am
@@ -1,5 +1,9 @@
+if ENABLE_DOC
+DOC_DIR=docs
+endif
+
 SUBDIRS = \
-	tests \
-	docs
+	${DOC_DIR} \
+	tests
 
 bin_SCRIPTS = lepton-symcheck

--- a/tools/symfix/Makefile.am
+++ b/tools/symfix/Makefile.am
@@ -1,5 +1,6 @@
-SUBDIRS = \
-	docs
+if ENABLE_DOC
+SUBDIRS = docs
+endif
 
 bin_SCRIPTS = \
 	lepton-symfix

--- a/tools/tragesym/Makefile.am
+++ b/tools/tragesym/Makefile.am
@@ -1,3 +1,9 @@
-SUBDIRS = examples docs
+if ENABLE_DOC
+DOC_DIR=docs
+endif
+
+SUBDIRS = \
+	${DOC_DIR} \
+	examples
 
 bin_SCRIPTS = lepton-tragesym

--- a/tools/upcfg/Makefile.am
+++ b/tools/upcfg/Makefile.am
@@ -1,3 +1,5 @@
+if ENABLE_DOC
 SUBDIRS = docs
+endif
 
 bin_SCRIPTS = lepton-upcfg

--- a/tools/update/Makefile.am
+++ b/tools/update/Makefile.am
@@ -1,3 +1,9 @@
-SUBDIRS = tests docs
+if ENABLE_DOC
+DOC_DIR=docs
+endif
+
+SUBDIRS = \
+	${DOC_DIR} \
+	tests
 
 bin_SCRIPTS = lepton-update


### PR DESCRIPTION
It's off by default. When turned on, disables build
and install of manuals, wiki, readme files and man pages.
