### PR TITLE
sch2pcb: Rewrite several reporting functions in Scheme.

### DIFF
--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -197,6 +197,9 @@ sch2pcb_get_empty_footprint_name ();
 void
 sch2pcb_set_empty_footprint_name (char *val);
 
+void
+sch2pcb_error_report_pcb_element_not_found (PcbElement *el);
+
 gchar*
 sch2pcb_expand_dir (gchar *dir);
 
@@ -220,6 +223,9 @@ sch2pcb_get_force_element_files ();
 
 void
 sch2pcb_set_force_element_files (gboolean val);
+
+void
+sch2pcb_increment_n_PKG_removed_new (PcbElement *el);
 
 void
 sch2pcb_increment_verbose_mode ();
@@ -350,10 +356,6 @@ sch2pcb_search_element_directories (PcbElement *el);
 gint
 sch2pcb_get_verbose_mode ();
 
-void
-sch2pcb_unfound_to_file (PcbElement *el,
-                         char *buf,
-                         FILE *f_out);
 void
 sch2pcb_update_element_descriptions (gchar *pcb_file,
                                      gchar *bak);

--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -364,7 +364,4 @@ sch2pcb_unfound_to_file (PcbElement *el,
 void
 sch2pcb_update_element_descriptions (gchar *pcb_file,
                                      gchar *bak);
-void
-sch2pcb_verbose_report_no_file_element_found (char *p,
-                                              gboolean is_m4);
 G_END_DECLS

--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -228,12 +228,6 @@ sch2pcb_get_preserve ();
 void
 sch2pcb_set_preserve (gboolean val);
 
-gboolean
-sch2pcb_get_remove_unfound_elements ();
-
-void
-sch2pcb_set_remove_unfound_elements (gboolean val);
-
 GList*
 sch2pcb_get_schematics ();
 

--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -215,11 +215,6 @@ sch2pcb_insert_element (FILE *f_out,
                         gchar *footprint,
                         gchar *refdes,
                         gchar *value);
-gboolean
-sch2pcb_get_force_element_files ();
-
-void
-sch2pcb_set_force_element_files (gboolean val);
 
 void
 sch2pcb_increment_verbose_mode ();

--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -244,12 +244,6 @@ GList*
 sch2pcb_get_schematics ();
 
 int
-sch2pcb_get_n_added_ef ();
-
-void
-sch2pcb_set_n_added_ef (int val);
-
-int
 sch2pcb_get_n_added_m4 ();
 
 void

--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -244,12 +244,6 @@ GList*
 sch2pcb_get_schematics ();
 
 int
-sch2pcb_get_n_added_m4 ();
-
-void
-sch2pcb_set_n_added_m4 (int val);
-
-int
 sch2pcb_get_n_changed_value ();
 
 void

--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -274,12 +274,6 @@ void
 sch2pcb_set_n_none (int val);
 
 int
-sch2pcb_get_n_PKG_removed_new ();
-
-void
-sch2pcb_set_n_PKG_removed_new (int val);
-
-int
 sch2pcb_get_n_PKG_removed_old ();
 
 void

--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -204,12 +204,6 @@ void
 sch2pcb_extra_gnetlist_arg_list_append (char *arg);
 
 gboolean
-sch2pcb_get_fix_elements ();
-
-void
-sch2pcb_set_fix_elements (gboolean val);
-
-gboolean
 sch2pcb_insert_element (FILE *f_out,
                         gchar *element_file,
                         gchar *footprint,

--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -368,9 +368,6 @@ void
 sch2pcb_verbose_file_element_report (PcbElement *el,
                                      gboolean is_m4);
 void
-sch2pcb_verbose_print_separator ();
-
-void
 sch2pcb_verbose_report_no_file_element_found (char *p,
                                               gboolean is_m4);
 G_END_DECLS

--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -228,10 +228,6 @@ void
 sch2pcb_load_extra_project_files (void);
 
 void
-sch2pcb_m4_element_to_file (PcbElement *el,
-                            char *buf,
-                            FILE *f_out);
-void
 sch2pcb_make_pcb_element_list (gchar *pcb_file);
 
 GList*

--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -222,9 +222,6 @@ void
 sch2pcb_set_force_element_files (gboolean val);
 
 void
-sch2pcb_increment_n_PKG_removed_new (PcbElement *el);
-
-void
 sch2pcb_increment_verbose_mode ();
 
 void

--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -274,12 +274,6 @@ void
 sch2pcb_set_n_none (int val);
 
 int
-sch2pcb_get_n_not_found ();
-
-void
-sch2pcb_set_n_not_found (int val);
-
-int
 sch2pcb_get_n_PKG_removed_new ();
 
 void

--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -365,9 +365,6 @@ void
 sch2pcb_update_element_descriptions (gchar *pcb_file,
                                      gchar *bak);
 void
-sch2pcb_verbose_file_element_report (PcbElement *el,
-                                     gboolean is_m4);
-void
 sch2pcb_verbose_report_no_file_element_found (char *p,
                                               gboolean is_m4);
 G_END_DECLS

--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -197,9 +197,6 @@ sch2pcb_get_empty_footprint_name ();
 void
 sch2pcb_set_empty_footprint_name (char *val);
 
-void
-sch2pcb_error_report_pcb_element_not_found (PcbElement *el);
-
 gchar*
 sch2pcb_expand_dir (gchar *dir);
 

--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -222,9 +222,6 @@ void
 sch2pcb_set_force_element_files (gboolean val);
 
 void
-sch2pcb_increment_added_ef (PcbElement *el);
-
-void
 sch2pcb_increment_verbose_mode ();
 
 void

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -35,7 +35,6 @@
             sch2pcb_element_directory_list_prepend
             sch2pcb_get_empty_footprint_name
             sch2pcb_set_empty_footprint_name
-            sch2pcb_error_report_pcb_element_not_found
             sch2pcb_get_fix_elements
             sch2pcb_set_fix_elements
             sch2pcb_get_force_element_files
@@ -92,7 +91,6 @@
 (define-lff sch2pcb_element_directory_list_prepend void '(*))
 (define-lff sch2pcb_get_empty_footprint_name '* '())
 (define-lff sch2pcb_set_empty_footprint_name void '(*))
-(define-lff sch2pcb_error_report_pcb_element_not_found void '(*))
 (define-lff sch2pcb_get_fix_elements int '())
 (define-lff sch2pcb_set_fix_elements void (list int))
 (define-lff sch2pcb_get_force_element_files int '())

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -39,10 +39,10 @@
             sch2pcb_set_fix_elements
             sch2pcb_get_force_element_files
             sch2pcb_set_force_element_files
-            sch2pcb_increment_n_PKG_removed_new
             sch2pcb_increment_verbose_mode
             sch2pcb_insert_element
             sch2pcb_get_n_PKG_removed_new
+            sch2pcb_set_n_PKG_removed_new
             sch2pcb_get_n_PKG_removed_old
             sch2pcb_get_n_added_ef
             sch2pcb_set_n_added_ef
@@ -95,9 +95,9 @@
 (define-lff sch2pcb_set_fix_elements void (list int))
 (define-lff sch2pcb_get_force_element_files int '())
 (define-lff sch2pcb_set_force_element_files void (list int))
-(define-lff sch2pcb_increment_n_PKG_removed_new void '(*))
 (define-lff sch2pcb_increment_verbose_mode void '())
 (define-lff sch2pcb_insert_element int '(* * * * *))
+(define-lff sch2pcb_set_n_PKG_removed_new void (list int))
 (define-lff sch2pcb_get_n_PKG_removed_new int '())
 (define-lff sch2pcb_get_n_PKG_removed_old int '())
 (define-lff sch2pcb_get_n_added_ef int '())

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -42,8 +42,6 @@
             sch2pcb_get_n_PKG_removed_new
             sch2pcb_set_n_PKG_removed_new
             sch2pcb_get_n_PKG_removed_old
-            sch2pcb_get_n_added_ef
-            sch2pcb_set_n_added_ef
             sch2pcb_get_n_added_m4
             sch2pcb_set_n_added_m4
             sch2pcb_get_n_changed_value
@@ -96,8 +94,6 @@
 (define-lff sch2pcb_set_n_PKG_removed_new void (list int))
 (define-lff sch2pcb_get_n_PKG_removed_new int '())
 (define-lff sch2pcb_get_n_PKG_removed_old int '())
-(define-lff sch2pcb_get_n_added_ef int '())
-(define-lff sch2pcb_set_n_added_ef void (list int))
 (define-lff sch2pcb_get_n_added_m4 int '())
 (define-lff sch2pcb_set_n_added_m4 void (list int))
 (define-lff sch2pcb_get_n_changed_value int '())

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -66,7 +66,6 @@
             sch2pcb_search_element_directories
             sch2pcb_unfound_to_file
             sch2pcb_update_element_descriptions
-            sch2pcb_verbose_file_element_report
             sch2pcb_verbose_report_no_file_element_found
             sch2pcb_get_verbose_mode
             sch2pcb_open_file_to_write
@@ -122,7 +121,6 @@
 (define-lff sch2pcb_search_element_directories '* '(*))
 (define-lff sch2pcb_unfound_to_file void '(* * *))
 (define-lff sch2pcb_update_element_descriptions void '(* *))
-(define-lff sch2pcb_verbose_file_element_report void (list '* int))
 (define-lff sch2pcb_verbose_report_no_file_element_found void (list '* int))
 (define-lff sch2pcb_get_verbose_mode int '())
 (define-lff sch2pcb_open_file_to_write '* '(*))

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -66,7 +66,6 @@
             sch2pcb_search_element_directories
             sch2pcb_unfound_to_file
             sch2pcb_update_element_descriptions
-            sch2pcb_verbose_report_no_file_element_found
             sch2pcb_get_verbose_mode
             sch2pcb_open_file_to_write
             sch2pcb_close_file))
@@ -121,7 +120,6 @@
 (define-lff sch2pcb_search_element_directories '* '(*))
 (define-lff sch2pcb_unfound_to_file void '(* * *))
 (define-lff sch2pcb_update_element_descriptions void '(* *))
-(define-lff sch2pcb_verbose_report_no_file_element_found void (list '* int))
 (define-lff sch2pcb_get_verbose_mode int '())
 (define-lff sch2pcb_open_file_to_write '* '(*))
 (define-lff sch2pcb_close_file void '(*))

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -35,8 +35,6 @@
             sch2pcb_element_directory_list_prepend
             sch2pcb_get_empty_footprint_name
             sch2pcb_set_empty_footprint_name
-            sch2pcb_get_fix_elements
-            sch2pcb_set_fix_elements
             sch2pcb_increment_verbose_mode
             sch2pcb_insert_element
             sch2pcb_get_n_PKG_removed_old
@@ -81,8 +79,6 @@
 (define-lff sch2pcb_element_directory_list_prepend void '(*))
 (define-lff sch2pcb_get_empty_footprint_name '* '())
 (define-lff sch2pcb_set_empty_footprint_name void '(*))
-(define-lff sch2pcb_get_fix_elements int '())
-(define-lff sch2pcb_set_fix_elements void (list int))
 (define-lff sch2pcb_increment_verbose_mode void '())
 (define-lff sch2pcb_insert_element int '(* * * * *))
 (define-lff sch2pcb_get_n_PKG_removed_old int '())

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -52,8 +52,6 @@
             sch2pcb_pcb_element_list_append
             sch2pcb_set_preserve
             sch2pcb_prune_elements
-            sch2pcb_get_remove_unfound_elements
-            sch2pcb_set_remove_unfound_elements
             sch2pcb_search_element_directories
             sch2pcb_update_element_descriptions
             sch2pcb_get_verbose_mode
@@ -96,8 +94,6 @@
 (define-lff sch2pcb_pcb_element_list_append void '(*))
 (define-lff sch2pcb_set_preserve void (list int))
 (define-lff sch2pcb_prune_elements void '(* *))
-(define-lff sch2pcb_get_remove_unfound_elements int '())
-(define-lff sch2pcb_set_remove_unfound_elements void (list int))
 (define-lff sch2pcb_search_element_directories '* '(*))
 (define-lff sch2pcb_update_element_descriptions void '(* *))
 (define-lff sch2pcb_get_verbose_mode int '())

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -35,10 +35,12 @@
             sch2pcb_element_directory_list_prepend
             sch2pcb_get_empty_footprint_name
             sch2pcb_set_empty_footprint_name
+            sch2pcb_error_report_pcb_element_not_found
             sch2pcb_get_fix_elements
             sch2pcb_set_fix_elements
             sch2pcb_get_force_element_files
             sch2pcb_set_force_element_files
+            sch2pcb_increment_n_PKG_removed_new
             sch2pcb_increment_verbose_mode
             sch2pcb_insert_element
             sch2pcb_get_n_PKG_removed_new
@@ -53,6 +55,7 @@
             sch2pcb_get_n_fixed
             sch2pcb_get_n_none
             sch2pcb_get_n_not_found
+            sch2pcb_set_n_not_found
             sch2pcb_get_n_preserved
             sch2pcb_get_n_unknown
             sch2pcb_get_need_PKG_purge
@@ -62,9 +65,9 @@
             sch2pcb_pcb_element_list_append
             sch2pcb_set_preserve
             sch2pcb_prune_elements
+            sch2pcb_get_remove_unfound_elements
             sch2pcb_set_remove_unfound_elements
             sch2pcb_search_element_directories
-            sch2pcb_unfound_to_file
             sch2pcb_update_element_descriptions
             sch2pcb_get_verbose_mode
             sch2pcb_open_file_to_write
@@ -89,10 +92,12 @@
 (define-lff sch2pcb_element_directory_list_prepend void '(*))
 (define-lff sch2pcb_get_empty_footprint_name '* '())
 (define-lff sch2pcb_set_empty_footprint_name void '(*))
+(define-lff sch2pcb_error_report_pcb_element_not_found void '(*))
 (define-lff sch2pcb_get_fix_elements int '())
 (define-lff sch2pcb_set_fix_elements void (list int))
 (define-lff sch2pcb_get_force_element_files int '())
 (define-lff sch2pcb_set_force_element_files void (list int))
+(define-lff sch2pcb_increment_n_PKG_removed_new void '(*))
 (define-lff sch2pcb_increment_verbose_mode void '())
 (define-lff sch2pcb_insert_element int '(* * * * *))
 (define-lff sch2pcb_get_n_PKG_removed_new int '())
@@ -107,6 +112,7 @@
 (define-lff sch2pcb_get_n_fixed int '())
 (define-lff sch2pcb_get_n_none int '())
 (define-lff sch2pcb_get_n_not_found int '())
+(define-lff sch2pcb_set_n_not_found void (list int))
 (define-lff sch2pcb_get_n_preserved int '())
 (define-lff sch2pcb_get_n_unknown int '())
 (define-lff sch2pcb_get_need_PKG_purge int '())
@@ -116,9 +122,9 @@
 (define-lff sch2pcb_pcb_element_list_append void '(*))
 (define-lff sch2pcb_set_preserve void (list int))
 (define-lff sch2pcb_prune_elements void '(* *))
+(define-lff sch2pcb_get_remove_unfound_elements int '())
 (define-lff sch2pcb_set_remove_unfound_elements void (list int))
 (define-lff sch2pcb_search_element_directories '* '(*))
-(define-lff sch2pcb_unfound_to_file void '(* * *))
 (define-lff sch2pcb_update_element_descriptions void '(* *))
 (define-lff sch2pcb_get_verbose_mode int '())
 (define-lff sch2pcb_open_file_to_write '* '(*))

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -39,8 +39,6 @@
             sch2pcb_set_fix_elements
             sch2pcb_increment_verbose_mode
             sch2pcb_insert_element
-            sch2pcb_get_n_PKG_removed_new
-            sch2pcb_set_n_PKG_removed_new
             sch2pcb_get_n_PKG_removed_old
             sch2pcb_get_n_changed_value
             sch2pcb_get_n_deleted
@@ -87,8 +85,6 @@
 (define-lff sch2pcb_set_fix_elements void (list int))
 (define-lff sch2pcb_increment_verbose_mode void '())
 (define-lff sch2pcb_insert_element int '(* * * * *))
-(define-lff sch2pcb_set_n_PKG_removed_new void (list int))
-(define-lff sch2pcb_get_n_PKG_removed_new int '())
 (define-lff sch2pcb_get_n_PKG_removed_old int '())
 (define-lff sch2pcb_get_n_changed_value int '())
 (define-lff sch2pcb_get_n_deleted int '())

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -67,7 +67,6 @@
             sch2pcb_unfound_to_file
             sch2pcb_update_element_descriptions
             sch2pcb_verbose_file_element_report
-            sch2pcb_verbose_print_separator
             sch2pcb_verbose_report_no_file_element_found
             sch2pcb_get_verbose_mode
             sch2pcb_open_file_to_write
@@ -124,7 +123,6 @@
 (define-lff sch2pcb_unfound_to_file void '(* * *))
 (define-lff sch2pcb_update_element_descriptions void '(* *))
 (define-lff sch2pcb_verbose_file_element_report void (list '* int))
-(define-lff sch2pcb_verbose_print_separator void '())
 (define-lff sch2pcb_verbose_report_no_file_element_found void (list '* int))
 (define-lff sch2pcb_get_verbose_mode int '())
 (define-lff sch2pcb_open_file_to_write '* '(*))

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -42,8 +42,6 @@
             sch2pcb_get_n_PKG_removed_new
             sch2pcb_set_n_PKG_removed_new
             sch2pcb_get_n_PKG_removed_old
-            sch2pcb_get_n_added_m4
-            sch2pcb_set_n_added_m4
             sch2pcb_get_n_changed_value
             sch2pcb_get_n_deleted
             sch2pcb_get_n_empty
@@ -94,8 +92,6 @@
 (define-lff sch2pcb_set_n_PKG_removed_new void (list int))
 (define-lff sch2pcb_get_n_PKG_removed_new int '())
 (define-lff sch2pcb_get_n_PKG_removed_old int '())
-(define-lff sch2pcb_get_n_added_m4 int '())
-(define-lff sch2pcb_set_n_added_m4 void (list int))
 (define-lff sch2pcb_get_n_changed_value int '())
 (define-lff sch2pcb_get_n_deleted int '())
 (define-lff sch2pcb_get_n_empty int '())

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -47,8 +47,6 @@
             sch2pcb_get_n_empty
             sch2pcb_get_n_fixed
             sch2pcb_get_n_none
-            sch2pcb_get_n_not_found
-            sch2pcb_set_n_not_found
             sch2pcb_get_n_preserved
             sch2pcb_get_n_unknown
             sch2pcb_get_need_PKG_purge
@@ -97,8 +95,6 @@
 (define-lff sch2pcb_get_n_empty int '())
 (define-lff sch2pcb_get_n_fixed int '())
 (define-lff sch2pcb_get_n_none int '())
-(define-lff sch2pcb_get_n_not_found int '())
-(define-lff sch2pcb_set_n_not_found void (list int))
 (define-lff sch2pcb_get_n_preserved int '())
 (define-lff sch2pcb_get_n_unknown int '())
 (define-lff sch2pcb_get_need_PKG_purge int '())

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -39,13 +39,13 @@
             sch2pcb_set_fix_elements
             sch2pcb_get_force_element_files
             sch2pcb_set_force_element_files
-            sch2pcb_increment_added_ef
             sch2pcb_increment_verbose_mode
             sch2pcb_insert_element
             sch2pcb_m4_element_to_file
             sch2pcb_get_n_PKG_removed_new
             sch2pcb_get_n_PKG_removed_old
             sch2pcb_get_n_added_ef
+            sch2pcb_set_n_added_ef
             sch2pcb_get_n_added_m4
             sch2pcb_get_n_changed_value
             sch2pcb_get_n_deleted
@@ -93,13 +93,13 @@
 (define-lff sch2pcb_set_fix_elements void (list int))
 (define-lff sch2pcb_get_force_element_files int '())
 (define-lff sch2pcb_set_force_element_files void (list int))
-(define-lff sch2pcb_increment_added_ef void '(*))
 (define-lff sch2pcb_increment_verbose_mode void '())
 (define-lff sch2pcb_insert_element int '(* * * * *))
 (define-lff sch2pcb_m4_element_to_file void '(* * *))
 (define-lff sch2pcb_get_n_PKG_removed_new int '())
 (define-lff sch2pcb_get_n_PKG_removed_old int '())
 (define-lff sch2pcb_get_n_added_ef int '())
+(define-lff sch2pcb_set_n_added_ef void (list int))
 (define-lff sch2pcb_get_n_added_m4 int '())
 (define-lff sch2pcb_get_n_changed_value int '())
 (define-lff sch2pcb_get_n_deleted int '())

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -37,8 +37,6 @@
             sch2pcb_set_empty_footprint_name
             sch2pcb_get_fix_elements
             sch2pcb_set_fix_elements
-            sch2pcb_get_force_element_files
-            sch2pcb_set_force_element_files
             sch2pcb_increment_verbose_mode
             sch2pcb_insert_element
             sch2pcb_get_n_PKG_removed_new
@@ -93,8 +91,6 @@
 (define-lff sch2pcb_set_empty_footprint_name void '(*))
 (define-lff sch2pcb_get_fix_elements int '())
 (define-lff sch2pcb_set_fix_elements void (list int))
-(define-lff sch2pcb_get_force_element_files int '())
-(define-lff sch2pcb_set_force_element_files void (list int))
 (define-lff sch2pcb_increment_verbose_mode void '())
 (define-lff sch2pcb_insert_element int '(* * * * *))
 (define-lff sch2pcb_set_n_PKG_removed_new void (list int))

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -41,12 +41,12 @@
             sch2pcb_set_force_element_files
             sch2pcb_increment_verbose_mode
             sch2pcb_insert_element
-            sch2pcb_m4_element_to_file
             sch2pcb_get_n_PKG_removed_new
             sch2pcb_get_n_PKG_removed_old
             sch2pcb_get_n_added_ef
             sch2pcb_set_n_added_ef
             sch2pcb_get_n_added_m4
+            sch2pcb_set_n_added_m4
             sch2pcb_get_n_changed_value
             sch2pcb_get_n_deleted
             sch2pcb_get_n_empty
@@ -95,12 +95,12 @@
 (define-lff sch2pcb_set_force_element_files void (list int))
 (define-lff sch2pcb_increment_verbose_mode void '())
 (define-lff sch2pcb_insert_element int '(* * * * *))
-(define-lff sch2pcb_m4_element_to_file void '(* * *))
 (define-lff sch2pcb_get_n_PKG_removed_new int '())
 (define-lff sch2pcb_get_n_PKG_removed_old int '())
 (define-lff sch2pcb_get_n_added_ef int '())
 (define-lff sch2pcb_set_n_added_ef void (list int))
 (define-lff sch2pcb_get_n_added_m4 int '())
+(define-lff sch2pcb_set_n_added_m4 void (list int))
 (define-lff sch2pcb_get_n_changed_value int '())
 (define-lff sch2pcb_get_n_deleted int '())
 (define-lff sch2pcb_get_n_empty int '())

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -340,21 +340,6 @@ sch2pcb_set_fix_elements (gboolean val)
 }
 
 
-static int n_added_ef;
-
-int
-sch2pcb_get_n_added_ef ()
-{
-  return n_added_ef;
-}
-
-void
-sch2pcb_set_n_added_ef (int val)
-{
-  n_added_ef = val;
-}
-
-
 static int n_added_m4;
 
 int

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1217,16 +1217,6 @@ sch2pcb_buffer_to_file (char *buffer,
  */
 
 void
-sch2pcb_increment_n_PKG_removed_new (PcbElement *el)
-{
-  sch2pcb_set_n_PKG_removed_new (1 + sch2pcb_get_n_PKG_removed_new ());
-  fprintf (stderr,
-           "So device %s will not be in the layout.\n",
-           pcb_element_get_refdes (el));
-}
-
-
-void
 sch2pcb_update_element_descriptions (gchar *pcb_file,
                                      gchar *bak)
 {

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -340,21 +340,6 @@ sch2pcb_set_fix_elements (gboolean val)
 }
 
 
-static int n_added_m4;
-
-int
-sch2pcb_get_n_added_m4 ()
-{
-  return n_added_m4;
-}
-
-void
-sch2pcb_set_n_added_m4 (int val)
-{
-  n_added_m4 = val;
-}
-
-
 static int n_changed_value;
 
 int

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -475,21 +475,6 @@ sch2pcb_set_preserve (gboolean val)
 }
 
 
-static gboolean remove_unfound_elements = TRUE;
-
-gboolean
-sch2pcb_get_remove_unfound_elements ()
-{
-  return remove_unfound_elements;
-}
-
-void
-sch2pcb_set_remove_unfound_elements (gboolean val)
-{
-  remove_unfound_elements = val;
-}
-
-
 static gint verbose;
 
 gint

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1217,17 +1217,6 @@ sch2pcb_buffer_to_file (char *buffer,
  */
 
 void
-sch2pcb_error_report_pcb_element_not_found (PcbElement *el)
-{
-  fprintf (stderr,
-           "%s: can't find PCB element for footprint %s (value=%s)\n",
-           pcb_element_get_refdes (el),
-           pcb_element_get_description (el),
-           pcb_element_get_value (el));
-}
-
-
-void
 sch2pcb_increment_n_PKG_removed_new (PcbElement *el)
 {
   sch2pcb_set_n_PKG_removed_new (1 + sch2pcb_get_n_PKG_removed_new ());

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -325,21 +325,6 @@ sch2pcb_set_empty_footprint_name (char *val)
 }
 
 
-static gboolean fix_elements = FALSE;
-
-gboolean
-sch2pcb_get_fix_elements ()
-{
-  return fix_elements;
-}
-
-void
-sch2pcb_set_fix_elements (gboolean val)
-{
-  fix_elements = val;
-}
-
-
 static int n_changed_value;
 
 int

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1101,16 +1101,6 @@ sch2pcb_buffer_to_file (char *buffer,
 }
 
 
-/* Process the newly created pcb file which is the output from
- *     gnetlist -g gsch2pcb ...
- *
- * It will have elements found via the m4 interface and PKG_ lines for
- * elements not found.  Insert pcb file elements for PKG_ lines if
- * file elements can be found.  If there was an existing pcb file,
- * strip out any elements if they are already present so that the new
- * pcb file will only have new elements.
- */
-
 void
 sch2pcb_update_element_descriptions (gchar *pcb_file,
                                      gchar *bak)

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -415,21 +415,6 @@ sch2pcb_set_n_none (int val)
 }
 
 
-static int n_not_found;
-
-int
-sch2pcb_get_n_not_found ()
-{
-  return n_not_found;
-}
-
-void
-sch2pcb_set_n_not_found (int val)
-{
-  n_not_found = val;
-}
-
-
 static int n_PKG_removed_old;
 
 int

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1217,32 +1217,6 @@ sch2pcb_buffer_to_file (char *buffer,
  */
 
 void
-sch2pcb_verbose_file_element_report (PcbElement *el,
-                                     gboolean is_m4)
-{
-  if (sch2pcb_get_verbose_mode () != 0)
-  {
-    if (is_m4)
-    {
-      if (sch2pcb_get_force_element_files ())
-      {
-        printf ("%s: have m4 element %s, but trying to replace with a file element.\n",
-                pcb_element_get_refdes (el),
-                pcb_element_get_description (el));
-      }
-    }
-    else
-    {
-      printf ("%s: need new file element for footprint  %s (value=%s)\n",
-              pcb_element_get_refdes (el),
-              pcb_element_get_description (el),
-              pcb_element_get_value (el));
-    }
-  }
-}
-
-
-void
 sch2pcb_verbose_report_no_file_element_found (char *p,
                                               gboolean is_m4)
 {

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1217,18 +1217,6 @@ sch2pcb_buffer_to_file (char *buffer,
  */
 
 void
-sch2pcb_verbose_report_no_file_element_found (char *p,
-                                              gboolean is_m4)
-{
-  if (!p
-      && (sch2pcb_get_verbose_mode () != 0)
-      && is_m4
-      && sch2pcb_get_force_element_files ())
-    printf ("\tNo file element found.\n");
-}
-
-
-void
 sch2pcb_increment_added_ef (PcbElement *el)
 {
   sch2pcb_set_n_added_ef (1 + sch2pcb_get_n_added_ef ());

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1282,14 +1282,6 @@ sch2pcb_m4_element_to_file (PcbElement *el,
 
 
 void
-sch2pcb_verbose_print_separator ()
-{
-  if (sch2pcb_get_verbose_mode () != 0)
-    printf ("----\n");
-}
-
-
-void
 sch2pcb_error_report_pcb_element_not_found (PcbElement *el)
 {
   fprintf (stderr,

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1238,30 +1238,6 @@ sch2pcb_increment_n_PKG_removed_new (PcbElement *el)
 
 
 void
-sch2pcb_unfound_to_file (PcbElement *el,
-                         char *buf,
-                         FILE *f_out)
-{
-  sch2pcb_error_report_pcb_element_not_found (el);
-  if (sch2pcb_get_remove_unfound_elements ()
-      && !sch2pcb_get_fix_elements ())
-  {
-    /* If removing unfound elements is enabled while
-     * fixing them is disabled, we just increment the
-     * counter of new packages that won't be in the
-     * layout. */
-    sch2pcb_increment_n_PKG_removed_new (el);
-  } else {
-    /* Otherwise we increment the number of not found
-     * packages that will be replaced with the PKG_
-     * placeholder, and insert the placeholder. */
-    sch2pcb_set_n_not_found (1 + sch2pcb_get_n_not_found ());
-    sch2pcb_buffer_to_file (buf, f_out);   /* Copy PKG_ line */
-  }
-}
-
-
-void
 sch2pcb_update_element_descriptions (gchar *pcb_file,
                                      gchar *bak)
 {

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -340,21 +340,6 @@ sch2pcb_set_fix_elements (gboolean val)
 }
 
 
-static gboolean force_element_files;
-
-gboolean
-sch2pcb_get_force_element_files ()
-{
-  return force_element_files;
-}
-
-void
-sch2pcb_set_force_element_files (gboolean val)
-{
-  force_element_files = val;
-}
-
-
 static int n_added_ef;
 
 int

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1217,18 +1217,6 @@ sch2pcb_buffer_to_file (char *buffer,
  */
 
 void
-sch2pcb_increment_added_ef (PcbElement *el)
-{
-  sch2pcb_set_n_added_ef (1 + sch2pcb_get_n_added_ef ());
-  if (sch2pcb_get_verbose_mode () != 0)
-    printf ("%s: added new file element for footprint %s (value=%s)\n",
-            pcb_element_get_refdes (el),
-            pcb_element_get_description (el),
-            pcb_element_get_value (el));
-}
-
-
-void
 sch2pcb_m4_element_to_file (PcbElement *el,
                             char *buf,
                             FILE *f_out)

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -430,21 +430,6 @@ sch2pcb_set_n_PKG_removed_old (int val)
 }
 
 
-static int n_PKG_removed_new;
-
-int
-sch2pcb_get_n_PKG_removed_new ()
-{
-  return n_PKG_removed_new;
-}
-
-void
-sch2pcb_set_n_PKG_removed_new (int val)
-{
-  n_PKG_removed_new = val;
-}
-
-
 static gint n_preserved;
 
 int

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1217,21 +1217,6 @@ sch2pcb_buffer_to_file (char *buffer,
  */
 
 void
-sch2pcb_m4_element_to_file (PcbElement *el,
-                            char *buf,
-                            FILE *f_out)
-{
-  sch2pcb_buffer_to_file (buf, f_out);
-  sch2pcb_set_n_added_m4 (1 + sch2pcb_get_n_added_m4 ());
-  if (sch2pcb_get_verbose_mode () != 0)
-    printf ("%s: added new m4 element for footprint   %s (value=%s)\n",
-            pcb_element_get_refdes (el),
-            pcb_element_get_description (el),
-            pcb_element_get_value (el));
-}
-
-
-void
 sch2pcb_error_report_pcb_element_not_found (PcbElement *el)
 {
   fprintf (stderr,

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -184,6 +184,9 @@
             (pointer->string (pcb_element_get_description *element))
             (pointer->string (pcb_element_get_value *element))))
 
+  (define (error-report-element-removed *element)
+    (sch2pcb_increment_n_PKG_removed_new *element))
+
   (define (unfound-element->file *element *mline *tmp-file)
     (error-report-element-not-found *element)
     (if (and (true? (sch2pcb_get_remove_unfound_elements))
@@ -191,7 +194,7 @@
         ;; If removing unfound elements is enabled while fixing
         ;; them is disabled, we just increment the counter of new
         ;; packages that won't be in the layout.
-        (sch2pcb_increment_n_PKG_removed_new *element)
+        (error-report-element-removed *element)
 
         ;; Otherwise we increment the number of not found packages
         ;; that will be replaced with the PKG_ placeholder, and

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -169,6 +169,9 @@
                     (pointer->string (pcb_element_get_description *element))
                     (pointer->string (pcb_element_get_value *element))))
 
+  (define (m4-element->file *element *mline *tmp-file)
+    (sch2pcb_m4_element_to_file *element *mline *tmp-file))
+
   (define (process-file-element *mline
                                 *tmp-file
                                 *element
@@ -217,7 +220,7 @@
                  ;; Here we're surely dealing with m4 elements as 'is_m4_element' has
                  ;; been set to TRUE and no forcing of file elements
                  ;; requested.
-                 (sch2pcb_m4_element_to_file *element *mline *tmp-file)
+                 (m4-element->file *element *mline *tmp-file)
                  skip-next))))
 
       (pcb_element_free *element)

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -144,12 +144,15 @@
 
   (define *tmp-file (sch2pcb_open_file_to_write (string->pointer tmp-filename)))
 
+  (define (verbose-file-element-report *element is_m4_element)
+    (sch2pcb_verbose_file_element_report *element is_m4_element))
+
   (define (process-file-element *mline
                                 *tmp-file
                                 *element
                                 is_m4_element
                                 skip_next)
-    (sch2pcb_verbose_file_element_report *element is_m4_element)
+    (verbose-file-element-report *element is_m4_element)
     (let ((*path (sch2pcb_search_element_directories *element)))
       (sch2pcb_verbose_report_no_file_element_found *path is_m4_element)
 

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -128,6 +128,10 @@
 ;;; searched for first and may have been found.
 (define %force-file-elements? #f)
 
+;;; The number of file elements added.
+(define %added-file-element-count 0)
+
+
 (define (make-pcb-element-list pcb-filename)
   (when (and (regular-file? pcb-filename)
              (file-readable? pcb-filename))
@@ -175,7 +179,7 @@
       (verbose-format "\tNo file element found.\n")))
 
   (define (verbose-increment-added-file-element *element)
-    (sch2pcb_set_n_added_ef (1+ (sch2pcb_get_n_added_ef)))
+    (set! %added-file-element-count (1+ %added-file-element-count))
     (verbose-format "~A: added new file element for footprint ~S (value=~A)\n"
                     (element-refdes *element)
                     (element-description *element)
@@ -380,7 +384,7 @@
     (add-elements-from-file)
     (sch2pcb_close_file *tmp-file)
 
-    (let ((total (+ (sch2pcb_get_n_added_ef)
+    (let ((total (+ %added-file-element-count
                     (sch2pcb_get_n_added_m4)
                     (sch2pcb_get_n_not_found))))
       (if (zero? total)
@@ -877,7 +881,7 @@ Lepton EDA homepage: <~A>
                         initial-pcb?)
 
   (define non-zero? (negate zero?))
-  (define pcb-file-created? (not (and (zero? (sch2pcb_get_n_added_ef))
+  (define pcb-file-created? (not (and (zero? %added-file-element-count)
                                       (zero? (sch2pcb_get_n_added_m4))
                                       (zero? (sch2pcb_get_n_not_found)))))
 
@@ -898,12 +902,12 @@ Lepton EDA homepage: <~A>
             (sch2pcb_get_n_deleted)
             pcb-filename))
 
-  (if (zero? (+ (sch2pcb_get_n_added_ef)
+  (if (zero? (+ %added-file-element-count
                 (sch2pcb_get_n_added_m4)))
       (when (zero? (sch2pcb_get_n_not_found))
         (format #t "No elements to add so not creating ~A\n" pcb-new-filename))
       (format #t "~A file elements and ~A m4 elements added to ~A.\n"
-              (sch2pcb_get_n_added_ef)
+              %added-file-element-count
               (sch2pcb_get_n_added_m4)
               pcb-new-filename))
 
@@ -952,7 +956,7 @@ Lepton EDA homepage: <~A>
   (unless (zero? (sch2pcb_get_verbose_mode))
     (format #t "\n"))
 
-  (unless (zero? (+ (sch2pcb_get_n_added_ef)
+  (unless (zero? (+ %added-file-element-count
                     (sch2pcb_get_n_added_m4)))
     (if initial-pcb?
         (begin

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -127,6 +127,8 @@
 ;;; elements for new footprints even though m4 elements are
 ;;; searched for first and may have been found.
 (define %force-file-elements? #f)
+;;; See description of the '--fix-element' option.
+(define %fix-elements? #f)
 
 ;;; The number of file elements added.
 (define %added-file-element-count 0)
@@ -214,7 +216,7 @@
   (define (unfound-element->file *element *mline *tmp-file)
     (error-report-element-not-found *element)
     (if (and (true? (sch2pcb_get_remove_unfound_elements))
-             (false? (sch2pcb_get_fix_elements)))
+             (not %fix-elements?))
         ;; If removing unfound elements is enabled while fixing
         ;; them is disabled, we just increment the counter of new
         ;; packages that won't be in the layout.
@@ -744,7 +746,7 @@ Lepton EDA homepage: <~A>
                seeds))
      (option '("fix-elements") #f #f
              (lambda (opt name arg seeds)
-               (sch2pcb_set_fix_elements TRUE)
+               (set! %fix-elements? #t)
                seeds))
      (option '("gnetlist-arg") #t #f
              (lambda (opt name arg seeds)
@@ -1035,7 +1037,7 @@ Lepton EDA homepage: <~A>
                   (when initial-pcb?
                     (format #t "No elements found, so nothing to do.\n")
                     (exit 0)))
-                (when (true? (sch2pcb_get_fix_elements))
+                (when %fix-elements?
                   (sch2pcb_update_element_descriptions (string->pointer pcb-filename)
                                                        (string->pointer bak-filename)))
                 (sch2pcb_prune_elements (string->pointer pcb-filename)

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -134,6 +134,8 @@
 (define %added-m4-element-count 0)
 ;;; The number of not found packages.
 (define %not-found-packages-count 0)
+;;; The number of new packages mentioned but not found.
+(define %removed-new-packages-count 0)
 
 (define (make-pcb-element-list pcb-filename)
   (when (and (regular-file? pcb-filename)
@@ -204,7 +206,7 @@
             (element-value *element)))
 
   (define (error-report-element-removed *element)
-    (sch2pcb_set_n_PKG_removed_new (1+ (sch2pcb_get_n_PKG_removed_new)))
+    (set! %removed-new-packages-count (1+ %removed-new-packages-count))
     (format (current-error-port)
             (G_ "So device ~S will not be in the layout.\n")
             (element-refdes *element)))
@@ -944,9 +946,9 @@ Lepton EDA homepage: <~A>
     (if pcb-file-created?
         (format #t "  So ~A is incomplete.\n" pcb-filename)
         (format #t "\n")))
-  (unless (zero? (sch2pcb_get_n_PKG_removed_new))
+  (unless (zero? %removed-new-packages-count)
     (format #t "~A elements could not be found."
-            (sch2pcb_get_n_PKG_removed_new))
+            %removed-new-packages-count)
     (if pcb-file-created?
         (format #t "  So ~A is incomplete.\n" pcb-new-filename)
         (format #t "\n")))

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -185,7 +185,10 @@
             (pointer->string (pcb_element_get_value *element))))
 
   (define (error-report-element-removed *element)
-    (sch2pcb_increment_n_PKG_removed_new *element))
+    (sch2pcb_set_n_PKG_removed_new (1+ (sch2pcb_get_n_PKG_removed_new)))
+    (format (current-error-port)
+            (G_ "So device ~S will not be in the layout.\n")
+            (pointer->string (pcb_element_get_refdes *element))))
 
   (define (unfound-element->file *element *mline *tmp-file)
     (error-report-element-not-found *element)

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -142,13 +142,13 @@
 (define %removed-new-packages-count 0)
 
 
-(define (element-refdes *element)
+(define (pcb-element-refdes *element)
   (pointer->string (pcb_element_get_refdes *element)))
 
-(define (element-description *element)
+(define (pcb-element-description *element)
   (pointer->string (pcb_element_get_description *element)))
 
-(define (element-value *element)
+(define (pcb-element-value *element)
   (pointer->string (pcb_element_get_value *element)))
 
 
@@ -186,13 +186,13 @@
     (if is-m4-element?
         (when %force-file-elements?
           (verbose-format "~A: have m4 element ~S, but trying to replace with a file element.\n"
-                          (element-refdes *element)
-                          (element-description *element)))
+                          (pcb-element-refdes *element)
+                          (pcb-element-description *element)))
 
         (verbose-format "~A: need new file element for footprint ~S (value=~A)\n"
-                        (element-refdes *element)
-                        (element-description *element)
-                        (element-value *element))))
+                        (pcb-element-refdes *element)
+                        (pcb-element-description *element)
+                        (pcb-element-value *element))))
 
   (define (verbose-report-no-file-element-found *path is_m4_element)
     (when (and (null-pointer? *path)
@@ -203,30 +203,30 @@
   (define (verbose-increment-added-file-element *element)
     (set! %added-file-element-count (1+ %added-file-element-count))
     (verbose-format "~A: added new file element for footprint ~S (value=~A)\n"
-                    (element-refdes *element)
-                    (element-description *element)
-                    (element-value *element)))
+                    (pcb-element-refdes *element)
+                    (pcb-element-description *element)
+                    (pcb-element-value *element)))
 
   (define (m4-element->file *element *mline *tmp-file)
     (sch2pcb_buffer_to_file *mline *tmp-file)
     (set! %added-m4-element-count (1+ %added-m4-element-count))
     (verbose-format "~A: added new m4 element for footprint ~S (value=~A)\n"
-                    (element-refdes *element)
-                    (element-description *element)
-                    (element-value *element)))
+                    (pcb-element-refdes *element)
+                    (pcb-element-description *element)
+                    (pcb-element-value *element)))
 
   (define (error-report-element-not-found *element)
     (format (current-error-port)
             (G_ "~A: can't find PCB element for footprint ~S (value=~A)\n")
-            (element-refdes *element)
-            (element-description *element)
-            (element-value *element)))
+            (pcb-element-refdes *element)
+            (pcb-element-description *element)
+            (pcb-element-value *element)))
 
   (define (error-report-element-removed *element)
     (set! %removed-new-packages-count (1+ %removed-new-packages-count))
     (format (current-error-port)
             (G_ "So device ~S will not be in the layout.\n")
-            (element-refdes *element)))
+            (pcb-element-refdes *element)))
 
   (define (unfound-element->file *element *mline *tmp-file)
     (error-report-element-not-found *element)

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -177,6 +177,9 @@
                     (pointer->string (pcb_element_get_description *element))
                     (pointer->string (pcb_element_get_value *element))))
 
+  (define (unfound-element->file *element *mline *tmp-file)
+    (sch2pcb_unfound_to_file *element *mline *tmp-file))
+
   (define (process-file-element *mline
                                 *tmp-file
                                 *element
@@ -200,7 +203,7 @@
             is_m4_element)
           (if (false? is_m4_element)
               (begin
-                (sch2pcb_unfound_to_file *element *mline *tmp-file)
+                (unfound-element->file *element *mline *tmp-file)
                 (g_free *path)
                 skip_next)
               (begin

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -178,7 +178,21 @@
                     (pointer->string (pcb_element_get_value *element))))
 
   (define (unfound-element->file *element *mline *tmp-file)
-    (sch2pcb_unfound_to_file *element *mline *tmp-file))
+    (sch2pcb_error_report_pcb_element_not_found *element)
+    (if (and (true? (sch2pcb_get_remove_unfound_elements))
+             (false? (sch2pcb_get_fix_elements)))
+        ;; If removing unfound elements is enabled while fixing
+        ;; them is disabled, we just increment the counter of new
+        ;; packages that won't be in the layout.
+        (sch2pcb_increment_n_PKG_removed_new *element)
+
+        ;; Otherwise we increment the number of not found packages
+        ;; that will be replaced with the PKG_ placeholder, and
+        ;; insert the placeholder.
+        (begin
+          (sch2pcb_set_n_not_found (1+ (sch2pcb_get_n_not_found)))
+          ;; Copy PKG_ line.
+          (sch2pcb_buffer_to_file *mline *tmp-file))))
 
   (define (process-file-element *mline
                                 *tmp-file

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -130,6 +130,8 @@
 
 ;;; The number of file elements added.
 (define %added-file-element-count 0)
+;;; The number of m4 elements added.
+(define %added-m4-element-count 0)
 
 
 (define (make-pcb-element-list pcb-filename)
@@ -187,7 +189,7 @@
 
   (define (m4-element->file *element *mline *tmp-file)
     (sch2pcb_buffer_to_file *mline *tmp-file)
-    (sch2pcb_set_n_added_m4 (1+ (sch2pcb_get_n_added_m4)))
+    (set! %added-m4-element-count (1+ %added-m4-element-count))
     (verbose-format "~A: added new m4 element for footprint ~S (value=~A)\n"
                     (element-refdes *element)
                     (element-description *element)
@@ -385,7 +387,7 @@
     (sch2pcb_close_file *tmp-file)
 
     (let ((total (+ %added-file-element-count
-                    (sch2pcb_get_n_added_m4)
+                    %added-m4-element-count
                     (sch2pcb_get_n_not_found))))
       (if (zero? total)
           (system* "rm" tmp-filename)
@@ -882,7 +884,7 @@ Lepton EDA homepage: <~A>
 
   (define non-zero? (negate zero?))
   (define pcb-file-created? (not (and (zero? %added-file-element-count)
-                                      (zero? (sch2pcb_get_n_added_m4))
+                                      (zero? %added-m4-element-count)
                                       (zero? (sch2pcb_get_n_not_found)))))
 
   ;; Report work done during processing.
@@ -903,12 +905,12 @@ Lepton EDA homepage: <~A>
             pcb-filename))
 
   (if (zero? (+ %added-file-element-count
-                (sch2pcb_get_n_added_m4)))
+                %added-m4-element-count))
       (when (zero? (sch2pcb_get_n_not_found))
         (format #t "No elements to add so not creating ~A\n" pcb-new-filename))
       (format #t "~A file elements and ~A m4 elements added to ~A.\n"
               %added-file-element-count
-              (sch2pcb_get_n_added_m4)
+              %added-m4-element-count
               pcb-new-filename))
 
   (unless (zero? (sch2pcb_get_n_not_found))
@@ -957,7 +959,7 @@ Lepton EDA homepage: <~A>
     (format #t "\n"))
 
   (unless (zero? (+ %added-file-element-count
-                    (sch2pcb_get_n_added_m4)))
+                    %added-m4-element-count))
     (if initial-pcb?
         (begin
           (format #t "\nNext step:\n")

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -156,6 +156,9 @@
                         (pointer->string (pcb_element_get_description *element))
                         (pointer->string (pcb_element_get_value *element)))))
 
+  (define (verbose-report-no-file-element-found *path is_m4_element)
+    (sch2pcb_verbose_report_no_file_element_found *path is_m4_element))
+
   (define (process-file-element *mline
                                 *tmp-file
                                 *element
@@ -163,7 +166,7 @@
                                 skip_next)
     (verbose-file-element-report *element (true? is_m4_element))
     (let ((*path (sch2pcb_search_element_directories *element)))
-      (sch2pcb_verbose_report_no_file_element_found *path is_m4_element)
+      (verbose-report-no-file-element-found *path is_m4_element)
 
       (if (and (not (null-pointer? *path))
                (true? (sch2pcb_insert_element *tmp-file

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -163,7 +163,11 @@
       (verbose-format "\tNo file element found.\n")))
 
   (define (verbose-increment-added-file-element *element)
-    (sch2pcb_increment_added_ef *element))
+    (sch2pcb_set_n_added_ef (1+ (sch2pcb_get_n_added_ef)))
+    (verbose-format "~A: added new file element for footprint ~S (value=~A)\n"
+                    (pointer->string (pcb_element_get_refdes *element))
+                    (pointer->string (pcb_element_get_description *element))
+                    (pointer->string (pcb_element_get_value *element))))
 
   (define (process-file-element *mline
                                 *tmp-file

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -123,6 +123,11 @@
 (define %schematic-basename #f)
 
 
+;;; Whether using file elements should be forced over m4 PCB
+;;; elements for new footprints even though m4 elements are
+;;; searched for first and may have been found.
+(define %force-file-elements? #f)
+
 (define (make-pcb-element-list pcb-filename)
   (when (and (regular-file? pcb-filename)
              (file-readable? pcb-filename))
@@ -153,7 +158,7 @@
 
   (define (verbose-file-element-report *element is-m4-element?)
     (if is-m4-element?
-        (when (true? (sch2pcb_get_force_element_files))
+        (when %force-file-elements?
           (verbose-format "~A: have m4 element ~S, but trying to replace with a file element.\n"
                           (element-refdes *element)
                           (element-description *element)))
@@ -166,7 +171,7 @@
   (define (verbose-report-no-file-element-found *path is_m4_element)
     (when (and (null-pointer? *path)
                (true? is_m4_element)
-               (true? (sch2pcb_get_force_element_files)))
+               %force-file-elements?)
       (verbose-format "\tNo file element found.\n")))
 
   (define (verbose-increment-added-file-element *element)
@@ -252,7 +257,7 @@
     (let ((result
            (if (or (false? is_m4_element)
                    (and (true? is_m4_element)
-                        (true? (sch2pcb_get_force_element_files))))
+                        %force-file-elements?))
                (process-file-element *mline
                                      *tmp-file
                                      *element
@@ -543,7 +548,7 @@
       ("keep-unfound" (sch2pcb_set_remove_unfound_elements FALSE))
       ("quiet" (set! %quiet-mode #t))
       ("preserve" (sch2pcb_set_preserve TRUE))
-      ("use-files" (sch2pcb_set_force_element_files TRUE))
+      ("use-files" (set! %force-file-elements? #t))
       ("skip-m4" (set! %use-m4 #f))
       ("elements-dir"
        (let ((elements-dir (expand-env-variables value)))
@@ -759,7 +764,7 @@ Lepton EDA homepage: <~A>
                seeds))
      (option '(#\f "use-files") #f #f
              (lambda (opt name arg seeds)
-               (sch2pcb_set_force_element_files TRUE)
+               (set! %force-file-elements? #t)
                seeds))
      (option '(#\s "skip-m4") #f #f
              (lambda (opt name arg seeds)

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -157,6 +157,14 @@
               (loop (read-line)))))))))
 
 
+;;; Process the newly created pcb file which is the output from
+;;;     lepton-netlist -g gsch2pcb ...
+;;;
+;;; It will have elements found via the m4 interface and PKG_
+;;; lines for elements not found.  Insert pcb file elements for
+;;; PKG_ lines if file elements can be found.  If there was an
+;;; existing pcb file, strip out any elements if they are already
+;;; present so that the new pcb file will only have new elements.
 (define (add-elements pcb-filename)
   (define tmp-filename (string-append pcb-filename ".tmp"))
 

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -144,7 +144,10 @@
 
 (define (pcb-element-get-string *element *c-getter)
   (define *s (*c-getter *element))
-  (pointer->string *s))
+  (if (null-pointer? *s)
+      ;; What should the function return if *s is NULL?
+      "<null>"
+      (pointer->string *s)))
 
 (define (pcb-element-refdes *element)
   (pcb-element-get-string *element pcb_element_get_refdes))

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -196,7 +196,7 @@
                  skip-next))))
 
       (pcb_element_free *element)
-      (sch2pcb_verbose_print_separator)
+      (verbose-format "----\n")
       result))
 
   (define (parse-next-line mline tline skip-next)

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -162,6 +162,9 @@
                (true? (sch2pcb_get_force_element_files)))
       (verbose-format "\tNo file element found.\n")))
 
+  (define (verbose-increment-added-file-element *element)
+    (sch2pcb_increment_added_ef *element))
+
   (define (process-file-element *mline
                                 *tmp-file
                                 *element
@@ -180,7 +183,7 @@
           (begin
             ;; Nice, we found it.  If it is an m4 element, we have
             ;; to skip some lines below, see comments above.
-            (sch2pcb_increment_added_ef *element)
+            (verbose-increment-added-file-element *element)
             (g_free *path)
             is_m4_element)
           (if (false? is_m4_element)

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -142,15 +142,18 @@
 (define %removed-new-packages-count 0)
 
 
+(define (pcb-element-get-string *element *c-getter)
+  (define *s (*c-getter *element))
+  (pointer->string *s))
+
 (define (pcb-element-refdes *element)
-  (pointer->string (pcb_element_get_refdes *element)))
+  (pcb-element-get-string *element pcb_element_get_refdes))
 
 (define (pcb-element-description *element)
-  (pointer->string (pcb_element_get_description *element)))
+  (pcb-element-get-string *element pcb_element_get_description))
 
 (define (pcb-element-value *element)
-  (pointer->string (pcb_element_get_value *element)))
-
+  (pcb-element-get-string *element pcb_element_get_value))
 
 
 (define (make-pcb-element-list pcb-filename)

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -141,6 +141,18 @@
 ;;; The number of new packages mentioned but not found.
 (define %removed-new-packages-count 0)
 
+
+(define (element-refdes *element)
+  (pointer->string (pcb_element_get_refdes *element)))
+
+(define (element-description *element)
+  (pointer->string (pcb_element_get_description *element)))
+
+(define (element-value *element)
+  (pointer->string (pcb_element_get_value *element)))
+
+
+
 (define (make-pcb-element-list pcb-filename)
   (when (and (regular-file? pcb-filename)
              (file-readable? pcb-filename))
@@ -169,13 +181,6 @@
   (define tmp-filename (string-append pcb-filename ".tmp"))
 
   (define *tmp-file (sch2pcb_open_file_to_write (string->pointer tmp-filename)))
-
-  (define (element-refdes *element)
-    (pointer->string (pcb_element_get_refdes *element)))
-  (define (element-description *element)
-    (pointer->string (pcb_element_get_description *element)))
-  (define (element-value *element)
-    (pointer->string (pcb_element_get_value *element)))
 
   (define (verbose-file-element-report *element is-m4-element?)
     (if is-m4-element?

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -157,7 +157,10 @@
                         (pointer->string (pcb_element_get_value *element)))))
 
   (define (verbose-report-no-file-element-found *path is_m4_element)
-    (sch2pcb_verbose_report_no_file_element_found *path is_m4_element))
+    (when (and (null-pointer? *path)
+               (true? is_m4_element)
+               (true? (sch2pcb_get_force_element_files)))
+      (verbose-format "\tNo file element found.\n")))
 
   (define (process-file-element *mline
                                 *tmp-file

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -177,8 +177,11 @@
                     (pointer->string (pcb_element_get_description *element))
                     (pointer->string (pcb_element_get_value *element))))
 
+  (define (error-report-element-not-found *element)
+    (sch2pcb_error_report_pcb_element_not_found *element))
+
   (define (unfound-element->file *element *mline *tmp-file)
-    (sch2pcb_error_report_pcb_element_not_found *element)
+    (error-report-element-not-found *element)
     (if (and (true? (sch2pcb_get_remove_unfound_elements))
              (false? (sch2pcb_get_fix_elements)))
         ;; If removing unfound elements is enabled while fixing

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -144,15 +144,24 @@
 
   (define *tmp-file (sch2pcb_open_file_to_write (string->pointer tmp-filename)))
 
-  (define (verbose-file-element-report *element is_m4_element)
-    (sch2pcb_verbose_file_element_report *element is_m4_element))
+  (define (verbose-file-element-report *element is-m4-element?)
+    (if is-m4-element?
+        (when (true? (sch2pcb_get_force_element_files))
+          (verbose-format "~A: have m4 element ~S, but trying to replace with a file element.\n"
+                          (pointer->string (pcb_element_get_refdes *element))
+                          (pointer->string (pcb_element_get_description *element))))
+
+        (verbose-format "~A: need new file element for footprint ~S (value=~A)\n"
+                        (pointer->string (pcb_element_get_refdes *element))
+                        (pointer->string (pcb_element_get_description *element))
+                        (pointer->string (pcb_element_get_value *element)))))
 
   (define (process-file-element *mline
                                 *tmp-file
                                 *element
                                 is_m4_element
                                 skip_next)
-    (verbose-file-element-report *element is_m4_element)
+    (verbose-file-element-report *element (true? is_m4_element))
     (let ((*path (sch2pcb_search_element_directories *element)))
       (sch2pcb_verbose_report_no_file_element_found *path is_m4_element)
 

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -178,7 +178,11 @@
                     (pointer->string (pcb_element_get_value *element))))
 
   (define (error-report-element-not-found *element)
-    (sch2pcb_error_report_pcb_element_not_found *element))
+    (format (current-error-port)
+            (G_ "~A: can't find PCB element for footprint ~S (value=~A)\n")
+            (pointer->string (pcb_element_get_refdes *element))
+            (pointer->string (pcb_element_get_description *element))
+            (pointer->string (pcb_element_get_value *element))))
 
   (define (unfound-element->file *element *mline *tmp-file)
     (error-report-element-not-found *element)

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -129,6 +129,8 @@
 (define %force-file-elements? #f)
 ;;; See description of the '--fix-element' option.
 (define %fix-elements? #f)
+;;; Whether unfound pcb elements have to be removed.
+(define %remove-unfound-elements? #t)
 
 ;;; The number of file elements added.
 (define %added-file-element-count 0)
@@ -215,7 +217,7 @@
 
   (define (unfound-element->file *element *mline *tmp-file)
     (error-report-element-not-found *element)
-    (if (and (true? (sch2pcb_get_remove_unfound_elements))
+    (if (and %remove-unfound-elements?
              (not %fix-elements?))
         ;; If removing unfound elements is enabled while fixing
         ;; them is disabled, we just increment the counter of new
@@ -555,8 +557,8 @@
                     (string->pointer ""))))
     (match key
       ;; This is default behaviour.
-      ("remove-unfound" (sch2pcb_set_remove_unfound_elements TRUE))
-      ("keep-unfound" (sch2pcb_set_remove_unfound_elements FALSE))
+      ("remove-unfound" (set! %remove-unfound-elements? #t))
+      ("keep-unfound" (set! %remove-unfound-elements? #f))
       ("quiet" (set! %quiet-mode #t))
       ("preserve" (sch2pcb_set_preserve TRUE))
       ("use-files" (set! %force-file-elements? #t))
@@ -759,11 +761,11 @@ Lepton EDA homepage: <~A>
      (option '(#\r "remove-unfound") #f #f
              (lambda (opt name arg seeds)
                ;; This is default behavior.
-               (sch2pcb_set_remove_unfound_elements TRUE)
+               (set! %remove-unfound-elements? #t)
                seeds))
      (option '(#\k "keep-unfound") #f #f
              (lambda (opt name arg seeds)
-               (sch2pcb_set_remove_unfound_elements FALSE)
+               (set! %remove-unfound-elements? #f)
                seeds))
      (option '(#\q "quiet") #f #f
              (lambda (opt name arg seeds)

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -170,7 +170,12 @@
                     (pointer->string (pcb_element_get_value *element))))
 
   (define (m4-element->file *element *mline *tmp-file)
-    (sch2pcb_m4_element_to_file *element *mline *tmp-file))
+    (sch2pcb_buffer_to_file *mline *tmp-file)
+    (sch2pcb_set_n_added_m4 (1+ (sch2pcb_get_n_added_m4)))
+    (verbose-format "~A: added new m4 element for footprint ~S (value=~A)\n"
+                    (pointer->string (pcb_element_get_refdes *element))
+                    (pointer->string (pcb_element_get_description *element))
+                    (pointer->string (pcb_element_get_value *element))))
 
   (define (process-file-element *mline
                                 *tmp-file

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -144,17 +144,24 @@
 
   (define *tmp-file (sch2pcb_open_file_to_write (string->pointer tmp-filename)))
 
+  (define (element-refdes *element)
+    (pointer->string (pcb_element_get_refdes *element)))
+  (define (element-description *element)
+    (pointer->string (pcb_element_get_description *element)))
+  (define (element-value *element)
+    (pointer->string (pcb_element_get_value *element)))
+
   (define (verbose-file-element-report *element is-m4-element?)
     (if is-m4-element?
         (when (true? (sch2pcb_get_force_element_files))
           (verbose-format "~A: have m4 element ~S, but trying to replace with a file element.\n"
-                          (pointer->string (pcb_element_get_refdes *element))
-                          (pointer->string (pcb_element_get_description *element))))
+                          (element-refdes *element)
+                          (element-description *element)))
 
         (verbose-format "~A: need new file element for footprint ~S (value=~A)\n"
-                        (pointer->string (pcb_element_get_refdes *element))
-                        (pointer->string (pcb_element_get_description *element))
-                        (pointer->string (pcb_element_get_value *element)))))
+                        (element-refdes *element)
+                        (element-description *element)
+                        (element-value *element))))
 
   (define (verbose-report-no-file-element-found *path is_m4_element)
     (when (and (null-pointer? *path)
@@ -165,30 +172,30 @@
   (define (verbose-increment-added-file-element *element)
     (sch2pcb_set_n_added_ef (1+ (sch2pcb_get_n_added_ef)))
     (verbose-format "~A: added new file element for footprint ~S (value=~A)\n"
-                    (pointer->string (pcb_element_get_refdes *element))
-                    (pointer->string (pcb_element_get_description *element))
-                    (pointer->string (pcb_element_get_value *element))))
+                    (element-refdes *element)
+                    (element-description *element)
+                    (element-value *element)))
 
   (define (m4-element->file *element *mline *tmp-file)
     (sch2pcb_buffer_to_file *mline *tmp-file)
     (sch2pcb_set_n_added_m4 (1+ (sch2pcb_get_n_added_m4)))
     (verbose-format "~A: added new m4 element for footprint ~S (value=~A)\n"
-                    (pointer->string (pcb_element_get_refdes *element))
-                    (pointer->string (pcb_element_get_description *element))
-                    (pointer->string (pcb_element_get_value *element))))
+                    (element-refdes *element)
+                    (element-description *element)
+                    (element-value *element)))
 
   (define (error-report-element-not-found *element)
     (format (current-error-port)
             (G_ "~A: can't find PCB element for footprint ~S (value=~A)\n")
-            (pointer->string (pcb_element_get_refdes *element))
-            (pointer->string (pcb_element_get_description *element))
-            (pointer->string (pcb_element_get_value *element))))
+            (element-refdes *element)
+            (element-description *element)
+            (element-value *element)))
 
   (define (error-report-element-removed *element)
     (sch2pcb_set_n_PKG_removed_new (1+ (sch2pcb_get_n_PKG_removed_new)))
     (format (current-error-port)
             (G_ "So device ~S will not be in the layout.\n")
-            (pointer->string (pcb_element_get_refdes *element))))
+            (element-refdes *element)))
 
   (define (unfound-element->file *element *mline *tmp-file)
     (error-report-element-not-found *element)

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -132,7 +132,8 @@
 (define %added-file-element-count 0)
 ;;; The number of m4 elements added.
 (define %added-m4-element-count 0)
-
+;;; The number of not found packages.
+(define %not-found-packages-count 0)
 
 (define (make-pcb-element-list pcb-filename)
   (when (and (regular-file? pcb-filename)
@@ -221,7 +222,7 @@
         ;; that will be replaced with the PKG_ placeholder, and
         ;; insert the placeholder.
         (begin
-          (sch2pcb_set_n_not_found (1+ (sch2pcb_get_n_not_found)))
+          (set! %not-found-packages-count (1+ %not-found-packages-count))
           ;; Copy PKG_ line.
           (sch2pcb_buffer_to_file *mline *tmp-file))))
 
@@ -388,7 +389,7 @@
 
     (let ((total (+ %added-file-element-count
                     %added-m4-element-count
-                    (sch2pcb_get_n_not_found))))
+                    %not-found-packages-count)))
       (if (zero? total)
           (system* "rm" tmp-filename)
           (system* "mv" tmp-filename pcb-filename))
@@ -885,7 +886,7 @@ Lepton EDA homepage: <~A>
   (define non-zero? (negate zero?))
   (define pcb-file-created? (not (and (zero? %added-file-element-count)
                                       (zero? %added-m4-element-count)
-                                      (zero? (sch2pcb_get_n_not_found)))))
+                                      (zero? %not-found-packages-count))))
 
   ;; Report work done during processing.
   (unless (zero? (sch2pcb_get_verbose_mode))
@@ -906,16 +907,16 @@ Lepton EDA homepage: <~A>
 
   (if (zero? (+ %added-file-element-count
                 %added-m4-element-count))
-      (when (zero? (sch2pcb_get_n_not_found))
+      (when (zero? %not-found-packages-count)
         (format #t "No elements to add so not creating ~A\n" pcb-new-filename))
       (format #t "~A file elements and ~A m4 elements added to ~A.\n"
               %added-file-element-count
               %added-m4-element-count
               pcb-new-filename))
 
-  (unless (zero? (sch2pcb_get_n_not_found))
+  (unless (zero? %not-found-packages-count)
     (format #t "~A not found elements added to ~A.\n"
-            (sch2pcb_get_n_not_found)
+            %not-found-packages-count
             pcb-new-filename))
   (unless (zero? (sch2pcb_get_n_unknown))
     (format #t "~A components had no footprint attribute and are omitted.\n"


### PR DESCRIPTION
It allowed for getting rid of several variables and their accessors in C code.