### PR TITLE
sch2pcb: Rewrite sch2pcb_element_directory_list_append() in Scheme.

### DIFF
--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -179,18 +179,6 @@ pcb_element_pkg_to_element (gchar *pkg_line);
 
 /* lepton-sch2pcb's toplevel functions */
 
-GList*
-sch2pcb_get_element_directory_list ();
-
-void
-sch2pcb_set_element_directory_list (GList *list);
-
-void
-sch2pcb_element_directory_list_append (char *dir);
-
-void
-sch2pcb_element_directory_list_prepend (char *dir);
-
 char*
 sch2pcb_get_empty_footprint_name ();
 

--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -309,7 +309,8 @@ sch2pcb_prune_elements (gchar *pcb_file,
 gchar*
 sch2pcb_search_element_directories (PcbElement *el,
                                     char *pkg_name_fix,
-                                    char *description);
+                                    char *description,
+                                    char *elname);
 
 gint
 sch2pcb_get_verbose_mode ();

--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -203,6 +203,9 @@ sch2pcb_expand_dir (gchar *dir);
 void
 sch2pcb_extra_gnetlist_arg_list_append (char *arg);
 
+gchar*
+sch2pcb_find_element (gchar *dir_path,
+                      gchar *element);
 gboolean
 sch2pcb_insert_element (FILE *f_out,
                         gchar *element_file,

--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -308,7 +308,6 @@ sch2pcb_prune_elements (gchar *pcb_file,
                         gchar *bak);
 gchar*
 sch2pcb_search_element_directories (PcbElement *el,
-                                    char *pkg_name_fix,
                                     char *description,
                                     char *elname);
 

--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -306,11 +306,6 @@ sch2pcb_pcb_element_list_append (PcbElement *element);
 void
 sch2pcb_prune_elements (gchar *pcb_file,
                         gchar *bak);
-gchar*
-sch2pcb_search_element_directories (PcbElement *el,
-                                    char *description,
-                                    char *elname);
-
 gint
 sch2pcb_get_verbose_mode ();
 

--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -307,7 +307,8 @@ void
 sch2pcb_prune_elements (gchar *pcb_file,
                         gchar *bak);
 gchar*
-sch2pcb_search_element_directories (PcbElement *el);
+sch2pcb_search_element_directories (PcbElement *el,
+                                    char *pkg_name_fix);
 
 gint
 sch2pcb_get_verbose_mode ();

--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -308,7 +308,8 @@ sch2pcb_prune_elements (gchar *pcb_file,
                         gchar *bak);
 gchar*
 sch2pcb_search_element_directories (PcbElement *el,
-                                    char *pkg_name_fix);
+                                    char *pkg_name_fix,
+                                    char *description);
 
 gint
 sch2pcb_get_verbose_mode ();

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -96,7 +96,7 @@
 (define-lff sch2pcb_pcb_element_list_append void '(*))
 (define-lff sch2pcb_set_preserve void (list int))
 (define-lff sch2pcb_prune_elements void '(* *))
-(define-lff sch2pcb_search_element_directories '* '(* *))
+(define-lff sch2pcb_search_element_directories '* '(* * *))
 (define-lff sch2pcb_update_element_descriptions void '(* *))
 (define-lff sch2pcb_get_verbose_mode int '())
 (define-lff sch2pcb_open_file_to_write '* '(*))

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -96,7 +96,7 @@
 (define-lff sch2pcb_pcb_element_list_append void '(*))
 (define-lff sch2pcb_set_preserve void (list int))
 (define-lff sch2pcb_prune_elements void '(* *))
-(define-lff sch2pcb_search_element_directories '* '(* * *))
+(define-lff sch2pcb_search_element_directories '* '(* * * *))
 (define-lff sch2pcb_update_element_descriptions void '(* *))
 (define-lff sch2pcb_get_verbose_mode int '())
 (define-lff sch2pcb_open_file_to_write '* '(*))

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -96,7 +96,7 @@
 (define-lff sch2pcb_pcb_element_list_append void '(*))
 (define-lff sch2pcb_set_preserve void (list int))
 (define-lff sch2pcb_prune_elements void '(* *))
-(define-lff sch2pcb_search_element_directories '* '(* * * *))
+(define-lff sch2pcb_search_element_directories '* '(* * *))
 (define-lff sch2pcb_update_element_descriptions void '(* *))
 (define-lff sch2pcb_get_verbose_mode int '())
 (define-lff sch2pcb_open_file_to_write '* '(*))

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -32,10 +32,12 @@
             pcb_element_line_parse
             pcb_element_pkg_to_element
             sch2pcb_buffer_to_file
+            sch2pcb_get_element_directory_list
             sch2pcb_element_directory_list_append
             sch2pcb_element_directory_list_prepend
             sch2pcb_get_empty_footprint_name
             sch2pcb_set_empty_footprint_name
+            sch2pcb_find_element
             sch2pcb_increment_verbose_mode
             sch2pcb_insert_element
             sch2pcb_get_n_PKG_removed_old
@@ -53,7 +55,6 @@
             sch2pcb_pcb_element_list_append
             sch2pcb_set_preserve
             sch2pcb_prune_elements
-            sch2pcb_search_element_directories
             sch2pcb_update_element_descriptions
             sch2pcb_get_verbose_mode
             sch2pcb_open_file_to_write
@@ -75,10 +76,12 @@
 (define-lff pcb_element_pkg_to_element '* '(*))
 
 (define-lff sch2pcb_buffer_to_file void '(* *))
+(define-lff sch2pcb_get_element_directory_list '* '())
 (define-lff sch2pcb_element_directory_list_append void '(*))
 (define-lff sch2pcb_element_directory_list_prepend void '(*))
 (define-lff sch2pcb_get_empty_footprint_name '* '())
 (define-lff sch2pcb_set_empty_footprint_name void '(*))
+(define-lff sch2pcb_find_element '* '(* *))
 (define-lff sch2pcb_increment_verbose_mode void '())
 (define-lff sch2pcb_insert_element int '(* * * * *))
 (define-lff sch2pcb_get_n_PKG_removed_old int '())
@@ -96,7 +99,6 @@
 (define-lff sch2pcb_pcb_element_list_append void '(*))
 (define-lff sch2pcb_set_preserve void (list int))
 (define-lff sch2pcb_prune_elements void '(* *))
-(define-lff sch2pcb_search_element_directories '* '(* * *))
 (define-lff sch2pcb_update_element_descriptions void '(* *))
 (define-lff sch2pcb_get_verbose_mode int '())
 (define-lff sch2pcb_open_file_to_write '* '(*))

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -32,9 +32,6 @@
             pcb_element_line_parse
             pcb_element_pkg_to_element
             sch2pcb_buffer_to_file
-            sch2pcb_get_element_directory_list
-            sch2pcb_element_directory_list_append
-            sch2pcb_element_directory_list_prepend
             sch2pcb_get_empty_footprint_name
             sch2pcb_set_empty_footprint_name
             sch2pcb_find_element
@@ -76,9 +73,6 @@
 (define-lff pcb_element_pkg_to_element '* '(*))
 
 (define-lff sch2pcb_buffer_to_file void '(* *))
-(define-lff sch2pcb_get_element_directory_list '* '())
-(define-lff sch2pcb_element_directory_list_append void '(*))
-(define-lff sch2pcb_element_directory_list_prepend void '(*))
 (define-lff sch2pcb_get_empty_footprint_name '* '())
 (define-lff sch2pcb_set_empty_footprint_name void '(*))
 (define-lff sch2pcb_find_element '* '(* *))

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -26,6 +26,7 @@
             pcb_element_free
             pcb_element_get_description
             pcb_element_get_omit_PKG
+            pcb_element_get_pkg_name_fix
             pcb_element_get_refdes
             pcb_element_get_value
             pcb_element_line_parse
@@ -67,6 +68,7 @@
 (define-lff pcb_element_free void '(*))
 (define-lff pcb_element_get_description '* '(*))
 (define-lff pcb_element_get_omit_PKG int '(*))
+(define-lff pcb_element_get_pkg_name_fix '* '(*))
 (define-lff pcb_element_get_refdes '* '(*))
 (define-lff pcb_element_get_value '* '(*))
 (define-lff pcb_element_line_parse '* '(*))
@@ -94,7 +96,7 @@
 (define-lff sch2pcb_pcb_element_list_append void '(*))
 (define-lff sch2pcb_set_preserve void (list int))
 (define-lff sch2pcb_prune_elements void '(* *))
-(define-lff sch2pcb_search_element_directories '* '(*))
+(define-lff sch2pcb_search_element_directories '* '(* *))
 (define-lff sch2pcb_update_element_descriptions void '(* *))
 (define-lff sch2pcb_get_verbose_mode int '())
 (define-lff sch2pcb_open_file_to_write '* '(*))

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -903,26 +903,12 @@ sch2pcb_find_element (gchar *dir_path,
 
 gchar*
 sch2pcb_search_element_directories (PcbElement *el,
-                                    char *pkg_name_fix,
                                     char *description,
                                     char *elname)
 {
   GList *list;
   gchar *dir_path, *path = NULL;
 
-  /* See comment before pcb_element_pkg_to_element() */
-  if (pkg_name_fix)
-  {
-    if (!elname) {
-      printf ("Warning: argument passing may have been confused by\n");
-      printf ("         a comma in a component value:\n");
-      printf ("         Check %s %s %s\n",
-              pcb_element_get_refdes (el),
-              description,
-              pcb_element_get_value (el));
-      printf ("         Maybe just use a space instead of a comma?\n");
-    }
-  }
   if (!elname)
     elname = g_strdup (description);
 

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -901,32 +901,6 @@ sch2pcb_find_element (gchar *dir_path,
   return found;
 }
 
-gchar*
-sch2pcb_search_element_directories (PcbElement *el,
-                                    char *description,
-                                    char *elname)
-{
-  GList *list;
-  gchar *dir_path, *path = NULL;
-
-  for (list = sch2pcb_get_element_directory_list ();
-       list;
-       list = g_list_next (list))
-  {
-    dir_path = (gchar *) list->data;
-    if (sch2pcb_get_verbose_mode () > 1)
-      printf ("\tLooking in directory: \"%s\"\n", dir_path);
-    path = sch2pcb_find_element (dir_path, elname);
-    if (path) {
-      if (sch2pcb_get_verbose_mode () != 0)
-        printf ("\tFound: %s\n", path);
-      break;
-    }
-  }
-  g_free (elname);
-  return path;
-}
-
 /* The gnetlist backend gnet-gsch2pcb.scm generates PKG_ lines:
  *
  *        PKG_footprint(footprint{-fp0-fp1},refdes,value{,fp0,fp1})

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -939,18 +939,18 @@ sch2pcb_search_element_directories (PcbElement *el)
     g_free (elname);
     return NULL;
   }
-  if (verbose > 1)
+  if (sch2pcb_get_verbose_mode () > 1)
     printf ("\tSearching directories looking for file element: %s\n", elname);
   for (list = sch2pcb_get_element_directory_list ();
        list;
        list = g_list_next (list))
   {
     dir_path = (gchar *) list->data;
-    if (verbose > 1)
+    if (sch2pcb_get_verbose_mode () > 1)
       printf ("\tLooking in directory: \"%s\"\n", dir_path);
     path = sch2pcb_find_element (dir_path, elname);
     if (path) {
-      if (verbose)
+      if (sch2pcb_get_verbose_mode () != 0)
         printf ("\tFound: %s\n", path);
       break;
     }

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -909,18 +909,19 @@ sch2pcb_search_element_directories (PcbElement *el)
   gint n1, n2;
 
   /* See comment before pcb_element_pkg_to_element() */
-  if (el->pkg_name_fix) {
+  if (pcb_element_get_pkg_name_fix (el))
+  {
     if (strchr (pcb_element_get_description (el), '-')) {
       n1 = strlen (pcb_element_get_description (el));
-      n2 = strlen (el->pkg_name_fix);
+      n2 = strlen (pcb_element_get_pkg_name_fix (el));
       s = pcb_element_get_description (el) + n1 - n2 - 1;
 
 // printf("n1=%d n2=%d desc:%s fix:%s s:%s\n",
-//  n1, n2, pcb_element_get_description (el), el->pkg_name_fix, s);
+//  n1, n2, pcb_element_get_description (el), pcb_element_get_pkg_name_fix (el), s);
 
-      if (n1 > 0 && n2 < n1 && *s == '-' && *(s + 1) == *el->pkg_name_fix) {
+      if (n1 > 0 && n2 < n1 && *s == '-' && *(s + 1) == *pcb_element_get_pkg_name_fix (el)) {
         s = g_strndup (pcb_element_get_description (el), n1 - n2 - 1);
-        elname = g_strconcat (s, " ", el->pkg_name_fix, NULL);
+        elname = g_strconcat (s, " ", pcb_element_get_pkg_name_fix (el), NULL);
         g_free (s);
       }
     }

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -902,26 +902,27 @@ sch2pcb_find_element (gchar *dir_path,
 }
 
 gchar*
-sch2pcb_search_element_directories (PcbElement *el)
+sch2pcb_search_element_directories (PcbElement *el,
+                                    char *pkg_name_fix)
 {
   GList *list;
   gchar *s, *elname = NULL, *dir_path, *path = NULL;
   gint n1, n2;
 
   /* See comment before pcb_element_pkg_to_element() */
-  if (pcb_element_get_pkg_name_fix (el))
+  if (pkg_name_fix)
   {
     if (strchr (pcb_element_get_description (el), '-')) {
       n1 = strlen (pcb_element_get_description (el));
-      n2 = strlen (pcb_element_get_pkg_name_fix (el));
+      n2 = strlen (pkg_name_fix);
       s = pcb_element_get_description (el) + n1 - n2 - 1;
 
 // printf("n1=%d n2=%d desc:%s fix:%s s:%s\n",
-//  n1, n2, pcb_element_get_description (el), pcb_element_get_pkg_name_fix (el), s);
+//  n1, n2, pcb_element_get_description (el), pkg_name_fix, s);
 
-      if (n1 > 0 && n2 < n1 && *s == '-' && *(s + 1) == *pcb_element_get_pkg_name_fix (el)) {
+      if (n1 > 0 && n2 < n1 && *s == '-' && *(s + 1) == *pkg_name_fix) {
         s = g_strndup (pcb_element_get_description (el), n1 - n2 - 1);
-        elname = g_strconcat (s, " ", pcb_element_get_pkg_name_fix (el), NULL);
+        elname = g_strconcat (s, " ", pkg_name_fix, NULL);
         g_free (s);
       }
     }

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -910,16 +910,16 @@ sch2pcb_search_element_directories (PcbElement *el)
 
   /* See comment before pcb_element_pkg_to_element() */
   if (el->pkg_name_fix) {
-    if (strchr (el->description, '-')) {
-      n1 = strlen (el->description);
+    if (strchr (pcb_element_get_description (el), '-')) {
+      n1 = strlen (pcb_element_get_description (el));
       n2 = strlen (el->pkg_name_fix);
-      s = el->description + n1 - n2 - 1;
+      s = pcb_element_get_description (el) + n1 - n2 - 1;
 
 // printf("n1=%d n2=%d desc:%s fix:%s s:%s\n",
-//  n1, n2, el->description, el->pkg_name_fix, s);
+//  n1, n2, pcb_element_get_description (el), el->pkg_name_fix, s);
 
       if (n1 > 0 && n2 < n1 && *s == '-' && *(s + 1) == *el->pkg_name_fix) {
-        s = g_strndup (el->description, n1 - n2 - 1);
+        s = g_strndup (pcb_element_get_description (el), n1 - n2 - 1);
         elname = g_strconcat (s, " ", el->pkg_name_fix, NULL);
         g_free (s);
       }
@@ -929,13 +929,13 @@ sch2pcb_search_element_directories (PcbElement *el)
       printf ("         a comma in a component value:\n");
       printf ("         Check %s %s %s\n",
               pcb_element_get_refdes (el),
-              el->description,
+              pcb_element_get_description (el),
               pcb_element_get_value (el));
       printf ("         Maybe just use a space instead of a comma?\n");
     }
   }
   if (!elname)
-    elname = g_strdup (el->description);
+    elname = g_strdup (pcb_element_get_description (el));
 
   if (!strcmp (elname, "unknown")) {
     g_free (elname);

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -904,29 +904,15 @@ sch2pcb_find_element (gchar *dir_path,
 gchar*
 sch2pcb_search_element_directories (PcbElement *el,
                                     char *pkg_name_fix,
-                                    char *description)
+                                    char *description,
+                                    char *elname)
 {
   GList *list;
-  gchar *s, *elname = NULL, *dir_path, *path = NULL;
-  gint n1, n2;
+  gchar *dir_path, *path = NULL;
 
   /* See comment before pcb_element_pkg_to_element() */
   if (pkg_name_fix)
   {
-    if (strchr (description, '-')) {
-      n1 = strlen (description);
-      n2 = strlen (pkg_name_fix);
-      s = description + n1 - n2 - 1;
-
-// printf("n1=%d n2=%d desc:%s fix:%s s:%s\n",
-//  n1, n2, description, pkg_name_fix, s);
-
-      if (n1 > 0 && n2 < n1 && *s == '-' && *(s + 1) == *pkg_name_fix) {
-        s = g_strndup (description, n1 - n2 - 1);
-        elname = g_strconcat (s, " ", pkg_name_fix, NULL);
-        g_free (s);
-      }
-    }
     if (!elname) {
       printf ("Warning: argument passing may have been confused by\n");
       printf ("         a comma in a component value:\n");

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -941,7 +941,10 @@ sch2pcb_search_element_directories (PcbElement *el)
   }
   if (verbose > 1)
     printf ("\tSearching directories looking for file element: %s\n", elname);
-  for (list = element_directory_list; list; list = g_list_next (list)) {
+  for (list = sch2pcb_get_element_directory_list ();
+       list;
+       list = g_list_next (list))
+  {
     dir_path = (gchar *) list->data;
     if (verbose > 1)
       printf ("\tLooking in directory: \"%s\"\n", dir_path);

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -854,14 +854,15 @@ sch2pcb_insert_element (FILE *f_out,
 }
 
 
-gchar *
-find_element (gchar * dir_path, gchar * element)
+gchar*
+sch2pcb_find_element (gchar *dir_path,
+                      gchar *element)
 {
   GDir *dir;
   gchar *path, *name, *s, *found = NULL;
 
   if ((dir = g_dir_open (dir_path, 0, NULL)) == NULL) {
-    s = g_strdup_printf ("find_element can't open dir \"%s\"", dir_path);
+    s = g_strdup_printf ("sch2pcb_find_element can't open dir \"%s\"", dir_path);
     perror (s);
     g_free (s);
     return NULL;
@@ -874,7 +875,7 @@ find_element (gchar * dir_path, gchar * element)
 
     /* if we got a directory name, then recurse down into it */
     if (g_file_test (path, G_FILE_TEST_IS_DIR))
-      found = find_element (path, element);
+      found = sch2pcb_find_element (path, element);
 
     /* otherwise assume it is a file and see if it is the one we want */
     else {
@@ -944,7 +945,7 @@ sch2pcb_search_element_directories (PcbElement *el)
     dir_path = (gchar *) list->data;
     if (verbose > 1)
       printf ("\tLooking in directory: \"%s\"\n", dir_path);
-    path = find_element (dir_path, elname);
+    path = sch2pcb_find_element (dir_path, elname);
     if (path) {
       if (verbose)
         printf ("\tFound: %s\n", path);

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -928,7 +928,9 @@ sch2pcb_search_element_directories (PcbElement *el)
       printf ("Warning: argument passing may have been confused by\n");
       printf ("         a comma in a component value:\n");
       printf ("         Check %s %s %s\n",
-              el->refdes, el->description, el->value);
+              pcb_element_get_refdes (el),
+              el->description,
+              el->value);
       printf ("         Maybe just use a space instead of a comma?\n");
     }
   }

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -909,10 +909,6 @@ sch2pcb_search_element_directories (PcbElement *el,
   GList *list;
   gchar *dir_path, *path = NULL;
 
-  if (!strcmp (elname, "unknown")) {
-    g_free (elname);
-    return NULL;
-  }
   if (sch2pcb_get_verbose_mode () > 1)
     printf ("\tSearching directories looking for file element: %s\n", elname);
   for (list = sch2pcb_get_element_directory_list ();

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -909,9 +909,6 @@ sch2pcb_search_element_directories (PcbElement *el,
   GList *list;
   gchar *dir_path, *path = NULL;
 
-  if (!elname)
-    elname = g_strdup (description);
-
   if (!strcmp (elname, "unknown")) {
     g_free (elname);
     return NULL;

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -276,36 +276,6 @@ sch2pcb_get_pcb_element_list ()
 }
 
 
-static GList *element_directory_list;
-
-GList*
-sch2pcb_get_element_directory_list ()
-{
-  return element_directory_list;
-}
-
-void
-sch2pcb_set_element_directory_list (GList *list)
-{
-  element_directory_list = list;
-}
-
-
-void
-sch2pcb_element_directory_list_append (char *dir)
-{
-  sch2pcb_set_element_directory_list (
-    g_list_append (sch2pcb_get_element_directory_list (), dir));
-}
-
-void
-sch2pcb_element_directory_list_prepend (char *dir)
-{
-  sch2pcb_set_element_directory_list (
-    g_list_prepend (sch2pcb_get_element_directory_list (), dir));
-}
-
-
 static gboolean bak_done;
 
 

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -930,7 +930,7 @@ sch2pcb_search_element_directories (PcbElement *el)
       printf ("         Check %s %s %s\n",
               pcb_element_get_refdes (el),
               el->description,
-              el->value);
+              pcb_element_get_value (el));
       printf ("         Maybe just use a space instead of a comma?\n");
     }
   }

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -909,8 +909,6 @@ sch2pcb_search_element_directories (PcbElement *el,
   GList *list;
   gchar *dir_path, *path = NULL;
 
-  if (sch2pcb_get_verbose_mode () > 1)
-    printf ("\tSearching directories looking for file element: %s\n", elname);
   for (list = sch2pcb_get_element_directory_list ();
        list;
        list = g_list_next (list))

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -903,7 +903,8 @@ sch2pcb_find_element (gchar *dir_path,
 
 gchar*
 sch2pcb_search_element_directories (PcbElement *el,
-                                    char *pkg_name_fix)
+                                    char *pkg_name_fix,
+                                    char *description)
 {
   GList *list;
   gchar *s, *elname = NULL, *dir_path, *path = NULL;
@@ -912,16 +913,16 @@ sch2pcb_search_element_directories (PcbElement *el,
   /* See comment before pcb_element_pkg_to_element() */
   if (pkg_name_fix)
   {
-    if (strchr (pcb_element_get_description (el), '-')) {
-      n1 = strlen (pcb_element_get_description (el));
+    if (strchr (description, '-')) {
+      n1 = strlen (description);
       n2 = strlen (pkg_name_fix);
-      s = pcb_element_get_description (el) + n1 - n2 - 1;
+      s = description + n1 - n2 - 1;
 
 // printf("n1=%d n2=%d desc:%s fix:%s s:%s\n",
-//  n1, n2, pcb_element_get_description (el), pkg_name_fix, s);
+//  n1, n2, description, pkg_name_fix, s);
 
       if (n1 > 0 && n2 < n1 && *s == '-' && *(s + 1) == *pkg_name_fix) {
-        s = g_strndup (pcb_element_get_description (el), n1 - n2 - 1);
+        s = g_strndup (description, n1 - n2 - 1);
         elname = g_strconcat (s, " ", pkg_name_fix, NULL);
         g_free (s);
       }
@@ -931,13 +932,13 @@ sch2pcb_search_element_directories (PcbElement *el,
       printf ("         a comma in a component value:\n");
       printf ("         Check %s %s %s\n",
               pcb_element_get_refdes (el),
-              pcb_element_get_description (el),
+              description,
               pcb_element_get_value (el));
       printf ("         Maybe just use a space instead of a comma?\n");
     }
   }
   if (!elname)
-    elname = g_strdup (pcb_element_get_description (el));
+    elname = g_strdup (description);
 
   if (!strcmp (elname, "unknown")) {
     g_free (elname);

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -230,9 +230,13 @@
                             %null-pointer)))
     (if (string= element-name "unknown")
         %null-pointer
-        (sch2pcb_search_element_directories *element
-                                            *description
-                                            *element-name))))
+        (begin
+          (verbose-format
+           (G_ "\tSearching directories looking for file element: ~A\n")
+           element-name)
+          (sch2pcb_search_element_directories *element
+                                              *description
+                                              *element-name)))))
 
 
 ;;; Process the newly created pcb file which is the output from

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -175,6 +175,10 @@
               (loop (read-line)))))))))
 
 
+(define (search-element-directories *element)
+  (sch2pcb_search_element_directories *element))
+
+
 ;;; Process the newly created pcb file which is the output from
 ;;;     lepton-netlist -g gsch2pcb ...
 ;;;
@@ -257,7 +261,7 @@
                                 is_m4_element
                                 skip_next)
     (verbose-file-element-report *element (true? is_m4_element))
-    (let ((*path (sch2pcb_search_element_directories *element)))
+    (let ((*path (search-element-directories *element)))
       (verbose-report-no-file-element-found *path is_m4_element)
 
       (if (and (not (null-pointer? *path))

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -228,9 +228,11 @@
          (*element-name (if element-name
                             (string->pointer element-name)
                             %null-pointer)))
-    (sch2pcb_search_element_directories *element
-                                        *description
-                                        *element-name)))
+    (if (string= element-name "unknown")
+        %null-pointer
+        (sch2pcb_search_element_directories *element
+                                            *description
+                                            *element-name))))
 
 
 ;;; Process the newly created pcb file which is the output from

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -183,9 +183,39 @@
   (define description (and (not (null-pointer? *description))
                            (pointer->string *description)))
 
+  (define (description+fix->name description fix)
+    (and fix
+         description
+         (let ((description-length (string-length description))
+               (fix-length (string-length fix)))
+           (if (> description-length fix-length)
+               (let ((left-description-part (string-drop-right description fix-length))
+                     (right-description-part (string-take-right description fix-length)))
+                 (and (string-suffix? "-" left-description-part)
+                      ;; This is a very weak test that fixed
+                      ;; package name part matches to the right
+                      ;; description part.  Maybe using
+                      ;; (string-filter (char-set-delete
+                      ;; char-set:full #\space #\,) str) for each
+                      ;; of the strings instead of string-ref
+                      ;; could be better when comparing the
+                      ;; strings?
+                      (char=? (string-ref right-description-part 0)
+                              (string-ref fix 0))
+                      ;; Reconstruct description using space
+                      ;; instead of hyphen as separator.
+                      (string-append (string-drop-right left-description-part 1)
+                                     " "
+                                     fix)))))))
+
+  (define name (description+fix->name description package-name-fix))
+
+  (define *name (if name (string->pointer name) %null-pointer))
+
   (sch2pcb_search_element_directories *element
                                       *package-name-fix
-                                      *description))
+                                      *description
+                                      *name))
 
 
 ;;; Process the newly created pcb file which is the output from

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -176,9 +176,16 @@
 
 
 (define (search-element-directories *element)
+  (define *package-name-fix (pcb_element_get_pkg_name_fix *element))
+  (define package-name-fix (and (not (null-pointer? *package-name-fix))
+                                (pointer->string *package-name-fix)))
+  (define *description (pcb_element_get_description *element))
+  (define description (and (not (null-pointer? *description))
+                           (pointer->string *description)))
+
   (sch2pcb_search_element_directories *element
-                                      (pcb_element_get_pkg_name_fix *element)
-                                      (pcb_element_get_description *element)))
+                                      *package-name-fix
+                                      *description))
 
 
 ;;; Process the newly created pcb file which is the output from

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -216,20 +216,21 @@
 
   (define *name (if name (string->pointer name) %null-pointer))
 
-  (define (search-element-path *element-name)
+  (define (search-element-path element-name)
     (let loop ((ls element-directories))
       (if (null? ls)
           %null-pointer
           (let ((dir-path (car ls)))
             (extra-verbose-format (G_ "\tLooking in directory: ~S\n") dir-path)
             (let ((*path (sch2pcb_find_element (string->pointer dir-path)
-                                               *element-name)))
+                                               (if element-name
+                                                   (string->pointer element-name)
+                                                   %null-pointer))))
               (if (null-pointer? *path)
                   (loop (cdr ls))
                   (begin
                     (verbose-format (G_ "\tFound: ~A\n")
                                     (pointer->string *path))
-                    (g_free *element-name)
                     *path)))))))
 
   ;; See comment before pcb_element_pkg_to_element().
@@ -244,17 +245,14 @@
               description
               (pointer->string (pcb_element_get_value *element)))))
 
-  (let* ((element-name (or name description))
-         (*element-name (if element-name
-                            (string->pointer element-name)
-                            %null-pointer)))
+  (let* ((element-name (or name description)))
     (if (string= element-name "unknown")
         %null-pointer
         (begin
           (verbose-format
            (G_ "\tSearching directories looking for file element: ~A\n")
                element-name)
-          (search-element-path *element-name)))))
+          (search-element-path element-name)))))
 
 
 ;;; Process the newly created pcb file which is the output from

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -177,7 +177,8 @@
 
 (define (search-element-directories *element)
   (sch2pcb_search_element_directories *element
-                                      (pcb_element_get_pkg_name_fix *element)))
+                                      (pcb_element_get_pkg_name_fix *element)
+                                      (pcb_element_get_description *element)))
 
 
 ;;; Process the newly created pcb file which is the output from

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -179,7 +179,7 @@
               (loop (read-line)))))))))
 
 
-(define (search-element-directories *element)
+(define (search-element-directories element-directories *element)
   (define *package-name-fix (pcb_element_get_pkg_name_fix *element))
   (define package-name-fix (and (not (null-pointer? *package-name-fix))
                                 (pointer->string *package-name-fix)))
@@ -217,8 +217,7 @@
   (define *name (if name (string->pointer name) %null-pointer))
 
   (define (search-element-path *element-name)
-    (let loop ((ls (glist->list (sch2pcb_get_element_directory_list)
-                                pointer->string)))
+    (let loop ((ls element-directories))
       (if (null? ls)
           %null-pointer
           (let ((dir-path (car ls)))
@@ -267,6 +266,10 @@
 ;;; existing pcb file, strip out any elements if they are already
 ;;; present so that the new pcb file will only have new elements.
 (define (add-elements pcb-filename)
+  (define element-directories
+    (glist->list (sch2pcb_get_element_directory_list)
+                 pointer->string))
+
   (define tmp-filename (string-append pcb-filename ".tmp"))
 
   (define *tmp-file (sch2pcb_open_file_to_write (string->pointer tmp-filename)))
@@ -340,7 +343,7 @@
                                 is_m4_element
                                 skip_next)
     (verbose-file-element-report *element (true? is_m4_element))
-    (let ((*path (search-element-directories *element)))
+    (let ((*path (search-element-directories element-directories *element)))
       (verbose-report-no-file-element-found *path is_m4_element)
 
       (if (and (not (null-pointer? *path))

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -212,8 +212,19 @@
 
   (define *name (if name (string->pointer name) %null-pointer))
 
+  ;; See comment before pcb_element_pkg_to_element().
+  (when package-name-fix
+    (unless name
+      (format #t
+              "Warning: argument passing may have been confused by
+         a comma in a component value:\n
+         Check ~A ~A ~A
+         Maybe just use a space instead of a comma?\n"
+              (pointer->string (pcb_element_get_refdes *element))
+              description
+              (pointer->string (pcb_element_get_value *element)))))
+
   (sch2pcb_search_element_directories *element
-                                      *package-name-fix
                                       *description
                                       *name))
 

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -176,7 +176,8 @@
 
 
 (define (search-element-directories *element)
-  (sch2pcb_search_element_directories *element))
+  (sch2pcb_search_element_directories *element
+                                      (pcb_element_get_pkg_name_fix *element)))
 
 
 ;;; Process the newly created pcb file which is the output from

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -339,8 +339,8 @@
                                 *element
                                 is_m4_element
                                 skip_next)
-    (verbose-file-element-report *element (true? is_m4_element))
     (let ((path (search-element-directories element-directories *element)))
+      (verbose-file-element-report *element (true? is_m4_element))
       (verbose-report-no-file-element-found path is_m4_element)
 
       (if (and path

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -212,6 +212,13 @@
 
   (define *name (if name (string->pointer name) %null-pointer))
 
+  (define (search-element-directories *element
+                                      *description
+                                      *element-name)
+    (sch2pcb_search_element_directories *element
+                                        *description
+                                        *element-name))
+
   ;; See comment before pcb_element_pkg_to_element().
   (when package-name-fix
     (unless name
@@ -234,9 +241,9 @@
           (verbose-format
            (G_ "\tSearching directories looking for file element: ~A\n")
            element-name)
-          (sch2pcb_search_element_directories *element
-                                              *description
-                                              *element-name)))))
+          (search-element-directories *element
+                                      *description
+                                      *element-name)))))
 
 
 ;;; Process the newly created pcb file which is the output from

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -471,15 +471,15 @@
                              ;; first one that was starting in
                              ;; that mode.
                              #f
-                             (if skip-next?
-                                 ;; Paren level is still greater
-                                 ;; than zero, continue skipping.
-                                 #t
-                                 ;; Parse lines as usual.  The C
-                                 ;; function below will decide if
-                                 ;; next lines have to be skipped
-                                 ;; based on the result of
-                                 ;; parsing.
+                             ;; If paren level is still greater
+                             ;; than zero, continue skipping.
+                             ;; Otherwise, parse lines as
+                             ;; usual.  The function
+                             ;; parse-next-line() below will
+                             ;; decide if next lines have to
+                             ;; be skipped based on the result
+                             ;; of parsing.
+                             (or skip-next?
                                  (parse-next-line mline
                                                   tline
                                                   skip-next?)))))

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -283,9 +283,9 @@
                         (pcb-element-description *element)
                         (pcb-element-value *element))))
 
-  (define (verbose-report-no-file-element-found path is_m4_element)
+  (define (verbose-report-no-file-element-found path m4-element?)
     (when (and (not path)
-               (true? is_m4_element)
+               m4-element?
                %force-file-elements?)
       (verbose-format "\tNo file element found.\n")))
 
@@ -339,9 +339,10 @@
                                 *element
                                 is_m4_element
                                 skip_next)
-    (let ((path (search-element-directories element-directories *element)))
-      (verbose-file-element-report *element (true? is_m4_element))
-      (verbose-report-no-file-element-found path is_m4_element)
+    (let ((path (search-element-directories element-directories *element))
+          (m4-element? (true? is_m4_element)))
+      (verbose-file-element-report *element m4-element?)
+      (verbose-report-no-file-element-found path m4-element?)
 
       (if (and path
                (true? (sch2pcb_insert_element *tmp-file
@@ -354,7 +355,7 @@
             ;; to skip some lines below, see comments above.
             (verbose-increment-added-file-element *element)
             is_m4_element)
-          (if (false? is_m4_element)
+          (if (not m4-element?)
               (begin
                 (unfound-element->file *element *mline *tmp-file)
                 skip_next)

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -224,9 +224,13 @@
               description
               (pointer->string (pcb_element_get_value *element)))))
 
-  (sch2pcb_search_element_directories *element
-                                      *description
-                                      *name))
+  (let* ((element-name (or name description))
+         (*element-name (if element-name
+                            (string->pointer element-name)
+                            %null-pointer)))
+    (sch2pcb_search_element_directories *element
+                                        *description
+                                        *element-name)))
 
 
 ;;; Process the newly created pcb file which is the output from

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -355,11 +355,10 @@
             ;; to skip some lines below, see comments above.
             (verbose-increment-added-file-element *element)
             is_m4_element)
-          (if (not m4-element?)
-              (begin
-                (unfound-element->file *element *mline *tmp-file)
-                skip_next)
-              skip_next))))
+          (begin
+            (unless m4-element?
+              (unfound-element->file *element *mline *tmp-file))
+            skip_next))))
 
   (define (process-element *mline
                            *tmp-file


### PR DESCRIPTION
As a bonus, dealing with element directories has been moved to
Scheme as well.  This, in turn, allowed to eliminate strange Guile
JIT compilation errors related to the element paths which appeared
only once during the first program run.