### PR TITLE
sch2pcb: Rewrite sch2pcb_update_element_descriptions() in Scheme.

### DIFF
--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -303,5 +303,6 @@ sch2pcb_get_verbose_mode ();
 void
 sch2pcb_update_element_description (FILE *f_out,
                                     char *buf,
-                                    PcbElement *element);
+                                    PcbElement *element,
+                                    PcbElement *existing_element);
 G_END_DECLS

--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -299,5 +299,6 @@ sch2pcb_get_verbose_mode ();
 
 void
 sch2pcb_update_element_descriptions (gchar *pcb_file,
-                                     gchar *bak);
+                                     gchar *bak,
+                                     gchar *tmp);
 G_END_DECLS

--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -247,12 +247,6 @@ void
 sch2pcb_set_n_empty (int val);
 
 int
-sch2pcb_get_n_fixed ();
-
-void
-sch2pcb_set_n_fixed (int val);
-
-int
 sch2pcb_get_n_none ();
 
 void

--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -302,8 +302,5 @@ sch2pcb_get_verbose_mode ();
 
 void
 sch2pcb_update_element_descriptions (FILE *f_in,
-                                     FILE *f_out,
-                                     gchar *pcb_file,
-                                     gchar *bak,
-                                     gchar *tmp);
+                                     FILE *f_out);
 G_END_DECLS

--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -179,6 +179,12 @@ pcb_element_pkg_to_element (gchar *pkg_line);
 
 /* lepton-sch2pcb's toplevel functions */
 
+gboolean
+sch2pcb_get_bak_done ();
+
+void
+sch2pcb_set_bak_done (gboolean val);
+
 char*
 sch2pcb_get_empty_footprint_name ();
 

--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -303,5 +303,5 @@ sch2pcb_get_verbose_mode ();
 void
 sch2pcb_update_element_description (FILE *f_out,
                                     char *buf,
-                                    char *s);
+                                    PcbElement *element);
 G_END_DECLS

--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -301,6 +301,7 @@ gint
 sch2pcb_get_verbose_mode ();
 
 void
-sch2pcb_update_element_descriptions (FILE *f_in,
-                                     FILE *f_out);
+sch2pcb_update_element_description (FILE *f_out,
+                                    char *buf,
+                                    char *s);
 G_END_DECLS

--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -301,7 +301,9 @@ gint
 sch2pcb_get_verbose_mode ();
 
 void
-sch2pcb_update_element_descriptions (gchar *pcb_file,
+sch2pcb_update_element_descriptions (FILE *f_in,
+                                     FILE *f_out,
+                                     gchar *pcb_file,
                                      gchar *bak,
                                      gchar *tmp);
 G_END_DECLS

--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -300,9 +300,4 @@ sch2pcb_prune_elements (gchar *pcb_file,
 gint
 sch2pcb_get_verbose_mode ();
 
-void
-sch2pcb_update_element_description (FILE *f_out,
-                                    char *buf,
-                                    PcbElement *element,
-                                    PcbElement *existing_element);
 G_END_DECLS

--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -277,6 +277,9 @@ void
 sch2pcb_set_need_PKG_purge (gboolean val);
 
 FILE*
+sch2pcb_open_file_to_read (char *filename);
+
+FILE*
 sch2pcb_open_file_to_write (char *filename);
 
 void

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -24,6 +24,7 @@
 
   #:export (pcb_element_exists
             pcb_element_free
+            pcb_element_get_changed_description
             pcb_element_get_description
             pcb_element_get_omit_PKG
             pcb_element_get_pkg_name_fix
@@ -42,6 +43,7 @@
             sch2pcb_get_n_deleted
             sch2pcb_get_n_empty
             sch2pcb_get_n_fixed
+            sch2pcb_set_n_fixed
             sch2pcb_get_n_none
             sch2pcb_get_n_preserved
             sch2pcb_get_n_unknown
@@ -64,6 +66,7 @@
 
 (define-lff pcb_element_exists '* (list '* int))
 (define-lff pcb_element_free void '(*))
+(define-lff pcb_element_get_changed_description '* '(*))
 (define-lff pcb_element_get_description '* '(*))
 (define-lff pcb_element_get_omit_PKG int '(*))
 (define-lff pcb_element_get_pkg_name_fix '* '(*))
@@ -83,6 +86,7 @@
 (define-lff sch2pcb_get_n_deleted int '())
 (define-lff sch2pcb_get_n_empty int '())
 (define-lff sch2pcb_get_n_fixed int '())
+(define-lff sch2pcb_set_n_fixed void (list int))
 (define-lff sch2pcb_get_n_none int '())
 (define-lff sch2pcb_get_n_preserved int '())
 (define-lff sch2pcb_get_n_unknown int '())

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -94,7 +94,7 @@
 (define-lff sch2pcb_pcb_element_list_append void '(*))
 (define-lff sch2pcb_set_preserve void (list int))
 (define-lff sch2pcb_prune_elements void '(* *))
-(define-lff sch2pcb_update_element_descriptions void '(* * *))
+(define-lff sch2pcb_update_element_descriptions void '(* * * * *))
 (define-lff sch2pcb_get_verbose_mode int '())
 (define-lff sch2pcb_open_file_to_read '* '(*))
 (define-lff sch2pcb_open_file_to_write '* '(*))

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -54,6 +54,7 @@
             sch2pcb_prune_elements
             sch2pcb_update_element_descriptions
             sch2pcb_get_verbose_mode
+            sch2pcb_open_file_to_read
             sch2pcb_open_file_to_write
             sch2pcb_close_file))
 
@@ -95,5 +96,6 @@
 (define-lff sch2pcb_prune_elements void '(* *))
 (define-lff sch2pcb_update_element_descriptions void '(* * *))
 (define-lff sch2pcb_get_verbose_mode int '())
+(define-lff sch2pcb_open_file_to_read '* '(*))
 (define-lff sch2pcb_open_file_to_write '* '(*))
 (define-lff sch2pcb_close_file void '(*))

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -93,7 +93,7 @@
 (define-lff sch2pcb_pcb_element_list_append void '(*))
 (define-lff sch2pcb_set_preserve void (list int))
 (define-lff sch2pcb_prune_elements void '(* *))
-(define-lff sch2pcb_update_element_descriptions void '(* *))
+(define-lff sch2pcb_update_element_descriptions void '(* * *))
 (define-lff sch2pcb_get_verbose_mode int '())
 (define-lff sch2pcb_open_file_to_write '* '(*))
 (define-lff sch2pcb_close_file void '(*))

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -32,6 +32,9 @@
             pcb_element_get_value
             pcb_element_line_parse
             pcb_element_pkg_to_element
+
+            sch2pcb_get_bak_done
+            sch2pcb_set_bak_done
             sch2pcb_buffer_to_file
             sch2pcb_get_empty_footprint_name
             sch2pcb_set_empty_footprint_name
@@ -74,6 +77,8 @@
 (define-lff pcb_element_line_parse '* '(*))
 (define-lff pcb_element_pkg_to_element '* '(*))
 
+(define-lff sch2pcb_get_bak_done int '())
+(define-lff sch2pcb_set_bak_done void (list int))
 (define-lff sch2pcb_buffer_to_file void '(* *))
 (define-lff sch2pcb_get_empty_footprint_name '* '())
 (define-lff sch2pcb_set_empty_footprint_name void '(*))
@@ -94,7 +99,7 @@
 (define-lff sch2pcb_pcb_element_list_append void '(*))
 (define-lff sch2pcb_set_preserve void (list int))
 (define-lff sch2pcb_prune_elements void '(* *))
-(define-lff sch2pcb_update_element_descriptions void '(* * * * *))
+(define-lff sch2pcb_update_element_descriptions void '(* *))
 (define-lff sch2pcb_get_verbose_mode int '())
 (define-lff sch2pcb_open_file_to_read '* '(*))
 (define-lff sch2pcb_open_file_to_write '* '(*))

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -26,10 +26,17 @@
             pcb_element_free
             pcb_element_get_changed_description
             pcb_element_get_description
+            pcb_element_get_flags
             pcb_element_get_omit_PKG
             pcb_element_get_pkg_name_fix
+            pcb_element_get_quoted_flags
             pcb_element_get_refdes
+            pcb_element_get_res_char
+            pcb_element_set_still_exists
+            pcb_element_get_tail
             pcb_element_get_value
+            pcb_element_get_x
+            pcb_element_get_y
             pcb_element_line_parse
             pcb_element_pkg_to_element
 
@@ -55,7 +62,6 @@
             sch2pcb_pcb_element_list_append
             sch2pcb_set_preserve
             sch2pcb_prune_elements
-            sch2pcb_update_element_description
             sch2pcb_get_verbose_mode
             sch2pcb_open_file_to_read
             sch2pcb_open_file_to_write
@@ -70,10 +76,17 @@
 (define-lff pcb_element_free void '(*))
 (define-lff pcb_element_get_changed_description '* '(*))
 (define-lff pcb_element_get_description '* '(*))
+(define-lff pcb_element_get_flags '* '(*))
 (define-lff pcb_element_get_omit_PKG int '(*))
 (define-lff pcb_element_get_pkg_name_fix '* '(*))
+(define-lff pcb_element_get_quoted_flags int '(*))
 (define-lff pcb_element_get_refdes '* '(*))
+(define-lff pcb_element_get_res_char int '(*))
+(define-lff pcb_element_set_still_exists void (list '* int))
+(define-lff pcb_element_get_tail '* '(*))
 (define-lff pcb_element_get_value '* '(*))
+(define-lff pcb_element_get_x '* '(*))
+(define-lff pcb_element_get_y '* '(*))
 (define-lff pcb_element_line_parse '* '(*))
 (define-lff pcb_element_pkg_to_element '* '(*))
 
@@ -99,7 +112,6 @@
 (define-lff sch2pcb_pcb_element_list_append void '(*))
 (define-lff sch2pcb_set_preserve void (list int))
 (define-lff sch2pcb_prune_elements void '(* *))
-(define-lff sch2pcb_update_element_description void '(* * * *))
 (define-lff sch2pcb_get_verbose_mode int '())
 (define-lff sch2pcb_open_file_to_read '* '(*))
 (define-lff sch2pcb_open_file_to_write '* '(*))

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -55,7 +55,7 @@
             sch2pcb_pcb_element_list_append
             sch2pcb_set_preserve
             sch2pcb_prune_elements
-            sch2pcb_update_element_descriptions
+            sch2pcb_update_element_description
             sch2pcb_get_verbose_mode
             sch2pcb_open_file_to_read
             sch2pcb_open_file_to_write
@@ -99,7 +99,7 @@
 (define-lff sch2pcb_pcb_element_list_append void '(*))
 (define-lff sch2pcb_set_preserve void (list int))
 (define-lff sch2pcb_prune_elements void '(* *))
-(define-lff sch2pcb_update_element_descriptions void '(* *))
+(define-lff sch2pcb_update_element_description void '(* * *))
 (define-lff sch2pcb_get_verbose_mode int '())
 (define-lff sch2pcb_open_file_to_read '* '(*))
 (define-lff sch2pcb_open_file_to_write '* '(*))

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -99,7 +99,7 @@
 (define-lff sch2pcb_pcb_element_list_append void '(*))
 (define-lff sch2pcb_set_preserve void (list int))
 (define-lff sch2pcb_prune_elements void '(* *))
-(define-lff sch2pcb_update_element_description void '(* * *))
+(define-lff sch2pcb_update_element_description void '(* * * *))
 (define-lff sch2pcb_get_verbose_mode int '())
 (define-lff sch2pcb_open_file_to_read '* '(*))
 (define-lff sch2pcb_open_file_to_write '* '(*))

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -42,8 +42,6 @@
             sch2pcb_get_n_changed_value
             sch2pcb_get_n_deleted
             sch2pcb_get_n_empty
-            sch2pcb_get_n_fixed
-            sch2pcb_set_n_fixed
             sch2pcb_get_n_none
             sch2pcb_get_n_preserved
             sch2pcb_get_n_unknown
@@ -85,8 +83,6 @@
 (define-lff sch2pcb_get_n_changed_value int '())
 (define-lff sch2pcb_get_n_deleted int '())
 (define-lff sch2pcb_get_n_empty int '())
-(define-lff sch2pcb_get_n_fixed int '())
-(define-lff sch2pcb_set_n_fixed void (list int))
 (define-lff sch2pcb_get_n_none int '())
 (define-lff sch2pcb_get_n_preserved int '())
 (define-lff sch2pcb_get_n_unknown int '())

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1040,10 +1040,6 @@ sch2pcb_update_element_descriptions (FILE *f_in,
   PcbElement *el, *el_exists;
   gchar *fmt, *s, buf[1024];
 
-  if ((f_in = sch2pcb_open_file_to_read (pcb_file)) == NULL)
-  {
-    return;
-  }
   if ((f_out = sch2pcb_open_file_to_write (tmp)) == NULL)
   {
     sch2pcb_close_file (f_in);

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1058,8 +1058,11 @@ sch2pcb_update_element_description (FILE *f_out,
             pcb_element_get_description (el),
             pcb_element_get_changed_description (el_exists));
     pcb_element_set_still_exists (el_exists, TRUE);
-  } else
-    fputs (buf, f_out);
+  }
+  else
+  {
+    sch2pcb_buffer_to_file (buf, f_out);
+  }
 }
 
 

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1037,12 +1037,6 @@ sch2pcb_update_element_descriptions (gchar *pcb_file,
   PcbElement *el, *el_exists;
   gchar *fmt, *tmp, *s, buf[1024];
 
-  if ((sch2pcb_get_pcb_element_list () == NULL)
-      || sch2pcb_get_n_fixed () == 0)
-  {
-    fprintf (stderr, "Could not find any elements to fix.\n");
-    return;
-  }
   if ((f_in = fopen (pcb_file, "r")) == NULL)
     return;
   tmp = g_strconcat (pcb_file, ".tmp", NULL);

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1031,11 +1031,12 @@ sch2pcb_buffer_to_file (char *buffer,
 
 
 void
-sch2pcb_update_element_descriptions (gchar *pcb_file,
+sch2pcb_update_element_descriptions (FILE *f_in,
+                                     FILE *f_out,
+                                     gchar *pcb_file,
                                      gchar *bak,
                                      gchar *tmp)
 {
-  FILE *f_in, *f_out;
   PcbElement *el, *el_exists;
   gchar *fmt, *s, buf[1024];
 

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1031,7 +1031,9 @@ sch2pcb_update_element_descriptions (gchar *pcb_file,
     if (el->changed_description)
       ++n_fixed;
   }
-  if (!pcb_element_list || n_fixed == 0) {
+  if (!pcb_element_list
+      || sch2pcb_get_n_fixed () == 0)
+  {
     fprintf (stderr, "Could not find any elements to fix.\n");
     return;
   }

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1031,38 +1031,36 @@ sch2pcb_buffer_to_file (char *buffer,
 
 
 void
-sch2pcb_update_element_descriptions (FILE *f_in,
-                                     FILE *f_out)
+sch2pcb_update_element_description (FILE *f_out,
+                                    char *buf,
+                                    char *s)
 {
   PcbElement *el, *el_exists;
-  gchar *fmt, *s, buf[1024];
+  gchar *fmt;
 
-  while ((fgets (buf, sizeof (buf), f_in)) != NULL) {
-    for (s = buf; *s == ' ' || *s == '\t'; ++s);
-    if ((el = pcb_element_line_parse (s)) != NULL
-        && (el_exists = pcb_element_exists (el, FALSE)) != NULL
-        && pcb_element_get_changed_description (el_exists)) {
-      fmt = (gchar*) (pcb_element_get_quoted_flags (el) ?
-                      "Element%c\"%s\" \"%s\" \"%s\" \"%s\" %s %s%s\n" :
-                      "Element%c%s \"%s\" \"%s\" \"%s\" %s %s%s\n");
-      fprintf (f_out, fmt,
-               pcb_element_get_res_char (el),
-               pcb_element_get_flags (el),
-               pcb_element_get_changed_description (el_exists),
-               pcb_element_get_refdes (el),
-               pcb_element_get_value (el),
-               pcb_element_get_x (el),
-               pcb_element_get_y (el),
-               pcb_element_get_tail (el));
-      printf ("%s: updating element Description: %s -> %s\n",
-              pcb_element_get_refdes (el),
-              pcb_element_get_description (el),
-              pcb_element_get_changed_description (el_exists));
-      pcb_element_set_still_exists (el_exists, TRUE);
-    } else
-      fputs (buf, f_out);
-    pcb_element_free (el);
-  }
+  if ((el = pcb_element_line_parse (s)) != NULL
+      && (el_exists = pcb_element_exists (el, FALSE)) != NULL
+      && pcb_element_get_changed_description (el_exists)) {
+    fmt = (gchar*) (pcb_element_get_quoted_flags (el) ?
+                    "Element%c\"%s\" \"%s\" \"%s\" \"%s\" %s %s%s\n" :
+                    "Element%c%s \"%s\" \"%s\" \"%s\" %s %s%s\n");
+    fprintf (f_out, fmt,
+             pcb_element_get_res_char (el),
+             pcb_element_get_flags (el),
+             pcb_element_get_changed_description (el_exists),
+             pcb_element_get_refdes (el),
+             pcb_element_get_value (el),
+             pcb_element_get_x (el),
+             pcb_element_get_y (el),
+             pcb_element_get_tail (el));
+    printf ("%s: updating element Description: %s -> %s\n",
+            pcb_element_get_refdes (el),
+            pcb_element_get_description (el),
+            pcb_element_get_changed_description (el_exists));
+    pcb_element_set_still_exists (el_exists, TRUE);
+  } else
+    fputs (buf, f_out);
+  pcb_element_free (el);
 }
 
 

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1060,7 +1060,6 @@ sch2pcb_update_element_description (FILE *f_out,
     pcb_element_set_still_exists (el_exists, TRUE);
   } else
     fputs (buf, f_out);
-  pcb_element_free (el);
 }
 
 

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1080,9 +1080,10 @@ sch2pcb_update_element_descriptions (gchar *pcb_file,
   fclose (f_in);
   fclose (f_out);
 
-  if (!bak_done) {
+  if (!sch2pcb_get_bak_done ())
+  {
     build_and_run_command ("mv %s %s", pcb_file, bak);
-    bak_done = TRUE;
+    sch2pcb_set_bak_done (TRUE);
   }
 
   build_and_run_command ("mv %s %s", tmp, pcb_file);

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1067,7 +1067,7 @@ sch2pcb_update_element_descriptions (gchar *pcb_file,
                       "Element%c\"%s\" \"%s\" \"%s\" \"%s\" %s %s%s\n" :
                       "Element%c%s \"%s\" \"%s\" \"%s\" %s %s%s\n");
       fprintf (f_out, fmt,
-               el->res_char,
+               pcb_element_get_res_char (el),
                pcb_element_get_flags (el),
                pcb_element_get_changed_description (el_exists),
                pcb_element_get_refdes (el),

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1063,7 +1063,7 @@ sch2pcb_update_element_descriptions (gchar *pcb_file,
     if ((el = pcb_element_line_parse (s)) != NULL
         && (el_exists = pcb_element_exists (el, FALSE)) != NULL
         && pcb_element_get_changed_description (el_exists)) {
-      fmt = (gchar*) (el->quoted_flags ?
+      fmt = (gchar*) (pcb_element_get_quoted_flags (el) ?
                       "Element%c\"%s\" \"%s\" \"%s\" \"%s\" %s %s%s\n" :
                       "Element%c%s \"%s\" \"%s\" \"%s\" %s %s%s\n");
       fprintf (f_out, fmt,

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1073,7 +1073,7 @@ sch2pcb_update_element_descriptions (gchar *pcb_file,
                pcb_element_get_refdes (el),
                pcb_element_get_value (el),
                pcb_element_get_x (el),
-               el->y,
+               pcb_element_get_y (el),
                pcb_element_get_tail (el));
       printf ("%s: updating element Description: %s -> %s\n",
               pcb_element_get_refdes (el),

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -352,21 +352,6 @@ sch2pcb_set_n_empty (int val)
 }
 
 
-static int n_fixed;
-
-int
-sch2pcb_get_n_fixed ()
-{
-  return n_fixed;
-}
-
-void
-sch2pcb_set_n_fixed (int val)
-{
-  n_fixed = val;
-}
-
-
 static int n_none;
 
 int

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1032,10 +1032,7 @@ sch2pcb_buffer_to_file (char *buffer,
 
 void
 sch2pcb_update_element_descriptions (FILE *f_in,
-                                     FILE *f_out,
-                                     gchar *pcb_file,
-                                     gchar *bak,
-                                     gchar *tmp)
+                                     FILE *f_out)
 {
   PcbElement *el, *el_exists;
   gchar *fmt, *s, buf[1024];
@@ -1066,16 +1063,6 @@ sch2pcb_update_element_descriptions (FILE *f_in,
       fputs (buf, f_out);
     pcb_element_free (el);
   }
-  sch2pcb_close_file (f_in);
-  sch2pcb_close_file (f_out);
-
-  if (!sch2pcb_get_bak_done ())
-  {
-    build_and_run_command ("mv %s %s", pcb_file, bak);
-    sch2pcb_set_bak_done (TRUE);
-  }
-
-  build_and_run_command ("mv %s %s", tmp, pcb_file);
 }
 
 

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1068,10 +1068,17 @@ sch2pcb_update_element_descriptions (gchar *pcb_file,
                       "Element%c%s \"%s\" \"%s\" \"%s\" %s %s%s\n");
       fprintf (f_out, fmt,
                el->res_char,
-               el->flags, el_exists->changed_description,
-               el->refdes, el->value, el->x, el->y, el->tail);
+               el->flags,
+               el_exists->changed_description,
+               pcb_element_get_refdes (el),
+               el->value,
+               el->x,
+               el->y,
+               el->tail);
       printf ("%s: updating element Description: %s -> %s\n",
-              el->refdes, el->description, el_exists->changed_description);
+              pcb_element_get_refdes (el),
+              el->description,
+              el_exists->changed_description);
       el_exists->still_exists = TRUE;
     } else
       fputs (buf, f_out);

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1033,12 +1033,12 @@ sch2pcb_buffer_to_file (char *buffer,
 void
 sch2pcb_update_element_description (FILE *f_out,
                                     char *buf,
-                                    char *s)
+                                    PcbElement *el)
 {
-  PcbElement *el, *el_exists;
+  PcbElement *el_exists;
   gchar *fmt;
 
-  if ((el = pcb_element_line_parse (s)) != NULL
+  if (el != NULL
       && (el_exists = pcb_element_exists (el, FALSE)) != NULL
       && pcb_element_get_changed_description (el_exists)) {
     fmt = (gchar*) (pcb_element_get_quoted_flags (el) ?

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1040,11 +1040,6 @@ sch2pcb_update_element_descriptions (FILE *f_in,
   PcbElement *el, *el_exists;
   gchar *fmt, *s, buf[1024];
 
-  if ((f_out = sch2pcb_open_file_to_write (tmp)) == NULL)
-  {
-    sch2pcb_close_file (f_in);
-    return;
-  }
   while ((fgets (buf, sizeof (buf), f_in)) != NULL) {
     for (s = buf; *s == ' ' || *s == '\t'; ++s);
     if ((el = pcb_element_line_parse (s)) != NULL

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1071,7 +1071,7 @@ sch2pcb_update_element_descriptions (gchar *pcb_file,
                el->flags,
                el_exists->changed_description,
                pcb_element_get_refdes (el),
-               el->value,
+               pcb_element_get_value (el),
                el->x,
                el->y,
                el->tail);

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1079,7 +1079,7 @@ sch2pcb_update_element_descriptions (gchar *pcb_file,
               pcb_element_get_refdes (el),
               pcb_element_get_description (el),
               pcb_element_get_changed_description (el_exists));
-      el_exists->still_exists = TRUE;
+      pcb_element_set_still_exists (el_exists, TRUE);
     } else
       fputs (buf, f_out);
     pcb_element_free (el);

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1068,7 +1068,7 @@ sch2pcb_update_element_descriptions (gchar *pcb_file,
                       "Element%c%s \"%s\" \"%s\" \"%s\" %s %s%s\n");
       fprintf (f_out, fmt,
                el->res_char,
-               el->flags,
+               pcb_element_get_flags (el),
                pcb_element_get_changed_description (el_exists),
                pcb_element_get_refdes (el),
                pcb_element_get_value (el),

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1031,42 +1031,6 @@ sch2pcb_buffer_to_file (char *buffer,
 
 
 void
-sch2pcb_update_element_description (FILE *f_out,
-                                    char *buf,
-                                    PcbElement *el,
-                                    PcbElement *el_exists)
-{
-  gchar *fmt;
-
-  if (el != NULL
-      && el_exists != NULL
-      && pcb_element_get_changed_description (el_exists)) {
-    fmt = (gchar*) (pcb_element_get_quoted_flags (el) ?
-                    "Element%c\"%s\" \"%s\" \"%s\" \"%s\" %s %s%s\n" :
-                    "Element%c%s \"%s\" \"%s\" \"%s\" %s %s%s\n");
-    fprintf (f_out, fmt,
-             pcb_element_get_res_char (el),
-             pcb_element_get_flags (el),
-             pcb_element_get_changed_description (el_exists),
-             pcb_element_get_refdes (el),
-             pcb_element_get_value (el),
-             pcb_element_get_x (el),
-             pcb_element_get_y (el),
-             pcb_element_get_tail (el));
-    printf ("%s: updating element Description: %s -> %s\n",
-            pcb_element_get_refdes (el),
-            pcb_element_get_description (el),
-            pcb_element_get_changed_description (el_exists));
-    pcb_element_set_still_exists (el_exists, TRUE);
-  }
-  else
-  {
-    sch2pcb_buffer_to_file (buf, f_out);
-  }
-}
-
-
-void
 sch2pcb_prune_elements (gchar *pcb_file,
                         gchar *bak)
 {

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1039,10 +1039,13 @@ sch2pcb_update_element_descriptions (gchar *pcb_file,
   PcbElement *el, *el_exists;
   gchar *fmt, *s, buf[1024];
 
-  if ((f_in = fopen (pcb_file, "r")) == NULL)
+  if ((f_in = sch2pcb_open_file_to_read (pcb_file)) == NULL)
+  {
     return;
-  if ((f_out = fopen (tmp, "wb")) == NULL) {
-    fclose (f_in);
+  }
+  if ((f_out = sch2pcb_open_file_to_write (tmp)) == NULL)
+  {
+    sch2pcb_close_file (f_in);
     return;
   }
   while ((fgets (buf, sizeof (buf), f_in)) != NULL) {
@@ -1071,8 +1074,8 @@ sch2pcb_update_element_descriptions (gchar *pcb_file,
       fputs (buf, f_out);
     pcb_element_free (el);
   }
-  fclose (f_in);
-  fclose (f_out);
+  sch2pcb_close_file (f_in);
+  sch2pcb_close_file (f_out);
 
   if (!sch2pcb_get_bak_done ())
   {

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -984,6 +984,22 @@ pcb_element_pkg_to_element (gchar *pkg_line)
 
 
 FILE*
+sch2pcb_open_file_to_read (char *filename)
+{
+  FILE *f_in;
+
+  if ((f_in = fopen (filename, "r")) == NULL)
+  {
+    return NULL;
+  }
+  else
+  {
+    return f_in;
+  }
+}
+
+
+FILE*
 sch2pcb_open_file_to_write (char *filename)
 {
   FILE *f_out;

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1016,15 +1016,15 @@ sch2pcb_buffer_to_file (char *buffer,
 
 void
 sch2pcb_update_element_descriptions (gchar *pcb_file,
-                                     gchar *bak)
+                                     gchar *bak,
+                                     gchar *tmp)
 {
   FILE *f_in, *f_out;
   PcbElement *el, *el_exists;
-  gchar *fmt, *tmp, *s, buf[1024];
+  gchar *fmt, *s, buf[1024];
 
   if ((f_in = fopen (pcb_file, "r")) == NULL)
     return;
-  tmp = g_strconcat (pcb_file, ".tmp", NULL);
   if ((f_out = fopen (tmp, "wb")) == NULL) {
     fclose (f_in);
     return;
@@ -1065,8 +1065,8 @@ sch2pcb_update_element_descriptions (gchar *pcb_file,
   }
 
   build_and_run_command ("mv %s %s", tmp, pcb_file);
-  g_free (tmp);
 }
+
 
 void
 sch2pcb_prune_elements (gchar *pcb_file,

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1040,7 +1040,7 @@ sch2pcb_update_element_descriptions (gchar *pcb_file,
 
   for (list = pcb_element_list; list; list = g_list_next (list)) {
     el = (PcbElement *) list->data;
-    if (el->changed_description)
+    if (pcb_element_get_changed_description (el))
     {
       sch2pcb_set_n_fixed (1 + sch2pcb_get_n_fixed ());
     }
@@ -1062,14 +1062,14 @@ sch2pcb_update_element_descriptions (gchar *pcb_file,
     for (s = buf; *s == ' ' || *s == '\t'; ++s);
     if ((el = pcb_element_line_parse (s)) != NULL
         && (el_exists = pcb_element_exists (el, FALSE)) != NULL
-        && el_exists->changed_description) {
+        && pcb_element_get_changed_description (el_exists)) {
       fmt = (gchar*) (el->quoted_flags ?
                       "Element%c\"%s\" \"%s\" \"%s\" \"%s\" %s %s%s\n" :
                       "Element%c%s \"%s\" \"%s\" \"%s\" %s %s%s\n");
       fprintf (f_out, fmt,
                el->res_char,
                el->flags,
-               el_exists->changed_description,
+               pcb_element_get_changed_description (el_exists),
                pcb_element_get_refdes (el),
                pcb_element_get_value (el),
                el->x,
@@ -1078,7 +1078,7 @@ sch2pcb_update_element_descriptions (gchar *pcb_file,
       printf ("%s: updating element Description: %s -> %s\n",
               pcb_element_get_refdes (el),
               pcb_element_get_description (el),
-              el_exists->changed_description);
+              pcb_element_get_changed_description (el_exists));
       el_exists->still_exists = TRUE;
     } else
       fputs (buf, f_out);

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1072,7 +1072,7 @@ sch2pcb_update_element_descriptions (gchar *pcb_file,
                pcb_element_get_changed_description (el_exists),
                pcb_element_get_refdes (el),
                pcb_element_get_value (el),
-               el->x,
+               pcb_element_get_x (el),
                el->y,
                pcb_element_get_tail (el));
       printf ("%s: updating element Description: %s -> %s\n",

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1077,7 +1077,7 @@ sch2pcb_update_element_descriptions (gchar *pcb_file,
                el->tail);
       printf ("%s: updating element Description: %s -> %s\n",
               pcb_element_get_refdes (el),
-              el->description,
+              pcb_element_get_description (el),
               el_exists->changed_description);
       el_exists->still_exists = TRUE;
     } else

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1038,14 +1038,17 @@ sch2pcb_update_element_descriptions (gchar *pcb_file,
   PcbElement *el, *el_exists;
   gchar *fmt, *tmp, *s, buf[1024];
 
-  for (list = pcb_element_list; list; list = g_list_next (list)) {
+  for (list = sch2pcb_get_pcb_element_list ();
+       list;
+       list = g_list_next (list))
+  {
     el = (PcbElement *) list->data;
     if (pcb_element_get_changed_description (el))
     {
       sch2pcb_set_n_fixed (1 + sch2pcb_get_n_fixed ());
     }
   }
-  if (!pcb_element_list
+  if ((sch2pcb_get_pcb_element_list () == NULL)
       || sch2pcb_get_n_fixed () == 0)
   {
     fprintf (stderr, "Could not find any elements to fix.\n");

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -278,6 +278,18 @@ sch2pcb_get_pcb_element_list ()
 
 static gboolean bak_done;
 
+gboolean
+sch2pcb_get_bak_done ()
+{
+  return bak_done;
+}
+
+void
+sch2pcb_set_bak_done (gboolean val)
+{
+  bak_done = val;
+}
+
 
 static gchar *empty_footprint_name;
 

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1029,7 +1029,9 @@ sch2pcb_update_element_descriptions (gchar *pcb_file,
   for (list = pcb_element_list; list; list = g_list_next (list)) {
     el = (PcbElement *) list->data;
     if (el->changed_description)
-      ++n_fixed;
+    {
+      sch2pcb_set_n_fixed (1 + sch2pcb_get_n_fixed ());
+    }
   }
   if (!pcb_element_list
       || sch2pcb_get_n_fixed () == 0)

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1034,20 +1034,9 @@ sch2pcb_update_element_descriptions (gchar *pcb_file,
                                      gchar *bak)
 {
   FILE *f_in, *f_out;
-  GList *list;
   PcbElement *el, *el_exists;
   gchar *fmt, *tmp, *s, buf[1024];
 
-  for (list = sch2pcb_get_pcb_element_list ();
-       list;
-       list = g_list_next (list))
-  {
-    el = (PcbElement *) list->data;
-    if (pcb_element_get_changed_description (el))
-    {
-      sch2pcb_set_n_fixed (1 + sch2pcb_get_n_fixed ());
-    }
-  }
   if ((sch2pcb_get_pcb_element_list () == NULL)
       || sch2pcb_get_n_fixed () == 0)
   {

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1074,7 +1074,7 @@ sch2pcb_update_element_descriptions (gchar *pcb_file,
                pcb_element_get_value (el),
                el->x,
                el->y,
-               el->tail);
+               pcb_element_get_tail (el));
       printf ("%s: updating element Description: %s -> %s\n",
               pcb_element_get_refdes (el),
               pcb_element_get_description (el),

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1033,13 +1033,13 @@ sch2pcb_buffer_to_file (char *buffer,
 void
 sch2pcb_update_element_description (FILE *f_out,
                                     char *buf,
-                                    PcbElement *el)
+                                    PcbElement *el,
+                                    PcbElement *el_exists)
 {
-  PcbElement *el_exists;
   gchar *fmt;
 
   if (el != NULL
-      && (el_exists = pcb_element_exists (el, FALSE)) != NULL
+      && el_exists != NULL
       && pcb_element_get_changed_description (el_exists)) {
     fmt = (gchar*) (pcb_element_get_quoted_flags (el) ?
                     "Element%c\"%s\" \"%s\" \"%s\" \"%s\" %s %s%s\n" :

--- a/tests/sch2pcb.test
+++ b/tests/sch2pcb.test
@@ -370,6 +370,9 @@
     (test-eq EXIT_SUCCESS <status>)
     (test-assert (string-contains <stderr> "Could not find any elements to fix.")))
 
+  ;; First ensure the files are different.
+  (test-run-failure "diff" tests/one.pcb "one-wrong-footprint.pcb")
+
   (receive (<status> <stdout> <stderr>)
       (command-values lepton-sch2pcb "-o" "one-wrong-footprint" "--fix-elements" one.sch two.sch)
     (test-eq EXIT_SUCCESS <status>)
@@ -377,7 +380,11 @@
     (test-assert (string-contains <stdout> "1 not found elements added to one-wrong-footprint.new.pcb."))
     (test-assert (string-contains <stdout> "1 elements fixed in one-wrong-footprint.pcb."))
     (test-assert (string-contains <stderr> "U101: can't find PCB element for footprint \"DIL-8-300\" (value=TL072)"))
-    (test-assert (string-contains <stdout> "U101: updating element Description: DIL-8-3000 -> DIL-8-300")))
+    (test-assert (string-contains <stdout> "U101: updating element Description: DIL-8-3000 -> DIL-8-300"))
+
+    ;; Now the files are the same.
+    (test-run-success "diff" tests/one.pcb "one-wrong-footprint.pcb"))
+
   (test-teardown))
 
 (test-end)

--- a/tests/sch2pcb.test
+++ b/tests/sch2pcb.test
@@ -218,13 +218,15 @@
     "vcc-1.sym"
     "vee-1.sym"))
 
-;;; Prepare test directory with necessary schematic files.
+;;; Prepare test directory with necessary schematic and pcb files.
 (define (prepare-test-directory)
   (test-setup)
   (mkdir "sym")
   (copy-file tests/one.sch one.sch)
   (copy-file tests/two.sch two.sch)
   (copy-file tests/gafrc gafrc)
+  (copy-file (build-filename tests/ "one-wrong-footprint.pcb")
+             "one-wrong-footprint.pcb")
   (for-each
    (lambda (symbol-name)
      (copy-file (build-filename tests/ "sym" symbol-name)
@@ -368,6 +370,14 @@
     (test-eq EXIT_SUCCESS <status>)
     (test-assert (string-contains <stderr> "Could not find any elements to fix.")))
 
+  (receive (<status> <stdout> <stderr>)
+      (command-values lepton-sch2pcb "-o" "one-wrong-footprint" "--fix-elements" one.sch two.sch)
+    (test-eq EXIT_SUCCESS <status>)
+
+    (test-assert (string-contains <stdout> "1 not found elements added to one-wrong-footprint.new.pcb."))
+    (test-assert (string-contains <stdout> "1 elements fixed in one-wrong-footprint.pcb."))
+    (test-assert (string-contains <stderr> "U101: can't find PCB element for footprint \"DIL-8-300\" (value=TL072)"))
+    (test-assert (string-contains <stdout> "U101: updating element Description: DIL-8-3000 -> DIL-8-300")))
   (test-teardown))
 
 (test-end)

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -534,14 +534,17 @@
   (if (or (null-pointer? (sch2pcb_get_pcb_element_list))
           (zero? %fixed-element-count))
       (format (current-error-port) "Could not find any elements to fix.\n")
-      (let ((tmp-filename (string-append pcb-filename ".tmp"))
-            (*pcb-file (sch2pcb_open_file_to_read (string->pointer pcb-filename))))
+      (let* ((tmp-filename (string-append pcb-filename ".tmp"))
+             (*pcb-file (sch2pcb_open_file_to_read (string->pointer pcb-filename)))
+             (*tmp-file (sch2pcb_open_file_to_write (string->pointer tmp-filename))))
         (unless (null-pointer? *pcb-file)
-          (sch2pcb_update_element_descriptions *pcb-file
-                                               %null-pointer
-                                               (string->pointer pcb-filename)
-                                               (string->pointer bak-filename)
-                                               (string->pointer tmp-filename))))))
+          (if (null-pointer? *tmp-file)
+              (sch2pcb_close_file *tmp-file)
+              (sch2pcb_update_element_descriptions *pcb-file
+                                                   *tmp-file
+                                                   (string->pointer pcb-filename)
+                                                   (string->pointer bak-filename)
+                                                   (string->pointer tmp-filename)))))))
 
 
 ;;; Run lepton-netlist to generate a netlist and a PCB board file.

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -535,7 +535,9 @@
           (zero? %fixed-element-count))
       (format (current-error-port) "Could not find any elements to fix.\n")
       (let ((tmp-filename (string-append pcb-filename ".tmp")))
-        (sch2pcb_update_element_descriptions (string->pointer pcb-filename)
+        (sch2pcb_update_element_descriptions %null-pointer
+                                             %null-pointer
+                                             (string->pointer pcb-filename)
                                              (string->pointer bak-filename)
                                              (string->pointer tmp-filename)))))
 

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -529,8 +529,11 @@
           (sch2pcb_set_n_fixed (1+ (sch2pcb_get_n_fixed))))
         (loop (cdr *element-list)))))
 
-  (sch2pcb_update_element_descriptions (string->pointer pcb-filename)
-                                       (string->pointer bak-filename)))
+  (if (or (null-pointer? (sch2pcb_get_pcb_element_list))
+          (zero? (sch2pcb_get_n_fixed)))
+      (format (current-error-port) "Could not find any elements to fix.\n")
+      (sch2pcb_update_element_descriptions (string->pointer pcb-filename)
+                                           (string->pointer bak-filename))))
 
 
 ;;; Run lepton-netlist to generate a netlist and a PCB board file.

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -524,7 +524,8 @@
 
 (define (update-element-descriptions pcb-filename bak-filename)
   (define (update-element-description *output-file *line *trimmed-line)
-    (sch2pcb_update_element_description *output-file *line *trimmed-line))
+    (let ((*element (pcb_element_line_parse *trimmed-line)))
+      (sch2pcb_update_element_description *output-file *line *element)))
 
   (let loop ((*element-list (glist->list (sch2pcb_get_pcb_element_list)
                                          identity)))

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -524,8 +524,14 @@
 
 (define (update-element-descriptions pcb-filename bak-filename)
   (define (update-element-description *output-file *line *trimmed-line)
-    (let ((*element (pcb_element_line_parse *trimmed-line)))
-      (sch2pcb_update_element_description *output-file *line *element)
+    (let* ((*element (pcb_element_line_parse *trimmed-line))
+           (*existing-element (if (null-pointer? *element)
+                                  %null-pointer
+                                  (pcb_element_exists *element FALSE))))
+      (sch2pcb_update_element_description *output-file
+                                          *line
+                                          *element
+                                          *existing-element)
       (pcb_element_free *element)))
 
   (let loop ((*element-list (glist->list (sch2pcb_get_pcb_element_list)

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -534,8 +534,10 @@
   (if (or (null-pointer? (sch2pcb_get_pcb_element_list))
           (zero? %fixed-element-count))
       (format (current-error-port) "Could not find any elements to fix.\n")
-      (sch2pcb_update_element_descriptions (string->pointer pcb-filename)
-                                           (string->pointer bak-filename))))
+      (let ((tmp-filename (string-append pcb-filename ".tmp")))
+        (sch2pcb_update_element_descriptions (string->pointer pcb-filename)
+                                             (string->pointer bak-filename)
+                                             (string->pointer tmp-filename)))))
 
 
 ;;; Run lepton-netlist to generate a netlist and a PCB board file.

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -520,6 +520,11 @@
           0))))
 
 
+(define (update-element-descriptions pcb-filename bak-filename)
+  (sch2pcb_update_element_descriptions (string->pointer pcb-filename)
+                                       (string->pointer bak-filename)))
+
+
 ;;; Run lepton-netlist to generate a netlist and a PCB board file.
 ;;; lepton-netlist has exit status of 0 even if it's given an
 ;;; invalid arg, so do some stat() hoops to decide if
@@ -1149,8 +1154,7 @@ Lepton EDA homepage: <~A>
                     (format #t "No elements found, so nothing to do.\n")
                     (exit 0)))
                 (when %fix-elements?
-                  (sch2pcb_update_element_descriptions (string->pointer pcb-filename)
-                                                       (string->pointer bak-filename)))
+                  (update-element-descriptions pcb-filename bak-filename))
                 (sch2pcb_prune_elements (string->pointer pcb-filename)
                                         (string->pointer bak-filename))
                 (report-results pcb-filename

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -131,7 +131,7 @@
 ;;; elements for new footprints even though m4 elements are
 ;;; searched for first and may have been found.
 (define %force-file-elements? #f)
-;;; See description of the '--fix-element' option.
+;;; See description of the '--fix-elements' option.
 (define %fix-elements? #f)
 ;;; Whether unfound pcb elements have to be removed.
 (define %remove-unfound-elements? #t)

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -521,6 +521,14 @@
 
 
 (define (update-element-descriptions pcb-filename bak-filename)
+  (let loop ((*element-list (glist->list (sch2pcb_get_pcb_element_list)
+                                         identity)))
+    (unless (null? *element-list)
+      (let ((*element (car *element-list)))
+        (unless (null-pointer? (pcb_element_get_changed_description *element))
+          (sch2pcb_set_n_fixed (1+ (sch2pcb_get_n_fixed))))
+        (loop (cdr *element-list)))))
+
   (sch2pcb_update_element_descriptions (string->pointer pcb-filename)
                                        (string->pointer bak-filename)))
 

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -540,11 +540,19 @@
         (unless (null-pointer? *pcb-file)
           (if (null-pointer? *tmp-file)
               (sch2pcb_close_file *tmp-file)
-              (sch2pcb_update_element_descriptions *pcb-file
-                                                   *tmp-file
-                                                   (string->pointer pcb-filename)
-                                                   (string->pointer bak-filename)
-                                                   (string->pointer tmp-filename)))))))
+              (begin
+                (sch2pcb_update_element_descriptions *pcb-file *tmp-file)
+                (sch2pcb_close_file *pcb-file)
+                (sch2pcb_close_file *tmp-file)
+
+                ;; Make backup for pcb file.
+                (when (false? (sch2pcb_get_bak_done))
+                  (system* "mv" pcb-filename bak-filename)
+                  (sch2pcb_set_bak_done TRUE))
+
+                ;; Replace pcb file with newly created file with
+                ;; updated descriptions.
+                (system* "mv" tmp-filename pcb-filename)))))))
 
 
 ;;; Run lepton-netlist to generate a netlist and a PCB board file.

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -534,12 +534,14 @@
   (if (or (null-pointer? (sch2pcb_get_pcb_element_list))
           (zero? %fixed-element-count))
       (format (current-error-port) "Could not find any elements to fix.\n")
-      (let ((tmp-filename (string-append pcb-filename ".tmp")))
-        (sch2pcb_update_element_descriptions %null-pointer
-                                             %null-pointer
-                                             (string->pointer pcb-filename)
-                                             (string->pointer bak-filename)
-                                             (string->pointer tmp-filename)))))
+      (let ((tmp-filename (string-append pcb-filename ".tmp"))
+            (*pcb-file (sch2pcb_open_file_to_read (string->pointer pcb-filename))))
+        (unless (null-pointer? *pcb-file)
+          (sch2pcb_update_element_descriptions *pcb-file
+                                               %null-pointer
+                                               (string->pointer pcb-filename)
+                                               (string->pointer bak-filename)
+                                               (string->pointer tmp-filename))))))
 
 
 ;;; Run lepton-netlist to generate a netlist and a PCB board file.

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -525,7 +525,8 @@
 (define (update-element-descriptions pcb-filename bak-filename)
   (define (update-element-description *output-file *line *trimmed-line)
     (let ((*element (pcb_element_line_parse *trimmed-line)))
-      (sch2pcb_update_element_description *output-file *line *element)))
+      (sch2pcb_update_element_description *output-file *line *element)
+      (pcb_element_free *element)))
 
   (let loop ((*element-list (glist->list (sch2pcb_get_pcb_element_list)
                                          identity)))

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -140,6 +140,8 @@
 (define %added-file-element-count 0)
 ;;; The number of m4 elements added.
 (define %added-m4-element-count 0)
+;;; The number of fixed elements.
+(define %fixed-element-count 0)
 ;;; The number of not found packages.
 (define %not-found-packages-count 0)
 ;;; The number of new packages mentioned but not found.
@@ -526,11 +528,11 @@
     (unless (null? *element-list)
       (let ((*element (car *element-list)))
         (unless (null-pointer? (pcb_element_get_changed_description *element))
-          (sch2pcb_set_n_fixed (1+ (sch2pcb_get_n_fixed))))
+          (set! %fixed-element-count (1+ %fixed-element-count)))
         (loop (cdr *element-list)))))
 
   (if (or (null-pointer? (sch2pcb_get_pcb_element_list))
-          (zero? (sch2pcb_get_n_fixed)))
+          (zero? %fixed-element-count))
       (format (current-error-port) "Could not find any elements to fix.\n")
       (sch2pcb_update_element_descriptions (string->pointer pcb-filename)
                                            (string->pointer bak-filename))))
@@ -1027,7 +1029,7 @@ Lepton EDA homepage: <~A>
   (format #t "\n----------------------------------\n")
   (format #t "Done processing.  Work performed:\n")
   (when (or (non-zero? (sch2pcb_get_n_deleted))
-            (non-zero? (sch2pcb_get_n_fixed))
+            (non-zero? %fixed-element-count)
             (true? (sch2pcb_get_need_PKG_purge))
             (non-zero? (sch2pcb_get_n_changed_value)))
     (format #t "~A is backed up as ~A.\n" pcb-filename bak-filename))
@@ -1066,9 +1068,9 @@ Lepton EDA homepage: <~A>
     (format #t "~A elements had a value change in ~A.\n"
             (sch2pcb_get_n_changed_value)
             pcb-filename))
-  (unless (zero? (sch2pcb_get_n_fixed))
+  (unless (zero? %fixed-element-count)
     (format #t "~A elements fixed in ~A.\n"
-            (sch2pcb_get_n_fixed)
+            %fixed-element-count
             pcb-filename))
   (unless (zero? (sch2pcb_get_n_PKG_removed_old))
     (format #t "~A elements could not be found."

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -523,6 +523,9 @@
 
 
 (define (update-element-descriptions pcb-filename bak-filename)
+  (define (update-element-description *output-file *line *trimmed-line)
+    (sch2pcb_update_element_description *output-file *line *trimmed-line))
+
   (let loop ((*element-list (glist->list (sch2pcb_get_pcb_element_list)
                                          identity)))
     (unless (null? *element-list)
@@ -545,9 +548,9 @@
                     (let loop ((line (read-line)))
                       (unless (eof-object? line)
                         (let ((trimmed-line (string-trim-both line char-set:whitespace)))
-                          (sch2pcb_update_element_description *tmp-file
-                                                              (string->pointer line)
-                                                              (string->pointer trimmed-line))
+                          (update-element-description *tmp-file
+                                                      (string->pointer line)
+                                                      (string->pointer trimmed-line))
                           (loop (read-line)))))))
                 (sch2pcb_close_file *tmp-file)
 

--- a/tools/sch2pcb/tests/Makefile.am
+++ b/tools/sch2pcb/tests/Makefile.am
@@ -3,6 +3,7 @@ EXTRA_DIST = \
 	missing-footprint.sch \
 	one.cmd \
 	one.net \
+	one-wrong-footprint.pcb \
 	one.pcb \
 	one.pcb.remove-R101-value \
 	one.sch \

--- a/tools/sch2pcb/tests/one-wrong-footprint.pcb
+++ b/tools/sch2pcb/tests/one-wrong-footprint.pcb
@@ -1,0 +1,160 @@
+# release: pcb 1.99x
+# To read pcb files, the pcb version (or the cvs source date) must be >= the file version
+FileVersion[20070407]
+PCB["" 600000 500000]
+Grid[10000.000000 0 0 0]
+Cursor[0 0 0.000000]
+PolyArea[200000000.000000]
+Thermal[0.500000]
+DRC[1000 1000 1000 1000 1500 1000]
+Flags("nameonpcb,uniquename,clearnew,snappin")
+Groups("1,c:2:3:4:5:6,s:7:8")
+Styles["Signal,1000,3600,2000,1000:Power,2500,6000,3500,1000:Fat,4000,6000,3500,1000:Skinny,600,2402,1181,600"]
+
+        
+Element(0x00 "CONNECTOR-2-1" "CONN201" "unknown" 160 0 3 100 0x00)
+(
+        Pin(50 50 60 38 "1" 0x101)
+         Pin(50 150 60 38 "2" 0x01)
+         
+        ElementLine(0 0 0 200 10)
+        ElementLine(0 200 100 200 10)
+        ElementLine(100 200 100 0 10)
+        ElementLine(100 0 0 0 10)
+        ElementLine(0 100 100 100 10)
+        ElementLine(100 100 100 0 10)
+        Mark(50 50)
+)
+Element(0x00 "TO92" "Q201" "2N3904" 60 70 0 100 0x00)
+(
+
+# The JEDEC drawing shows a pin diameter of 16-21 mils
+#
+#
+#         _______
+# TO92:  | 1 2 3 |   <-- bottom view
+#         \_____/
+#
+# The pin to pin spacing is 100 mils.
+        Pin(250 200 72 42 "1" 0x101)
+        Pin(150 200 72 42 "2" 0x01)
+        Pin(50 200 72 42 "3" 0x01)
+
+        ElementArc(150 200 100 100 315 270 10)
+        ElementLine( 80 130 220 130 10)
+
+        Mark(50 200)
+)
+Element(0x00 "R025" "R101" "10K" 120 30 0 100 0x00)
+(
+        Pin(0 50 68 38 "1" 0x101)
+        Pin(400 50 68 38 "2" 0x01)
+        ElementLine(100 0 300 0 20)
+        ElementLine(300 0 300 100 20)
+        ElementLine(300 100 100 100 20)
+        ElementLine(100 100 100 0 20)
+        ElementLine(0 50 100 50 20)
+        ElementLine(300 50 400 50 20)
+        Mark(0 50)
+)
+Element(0x00 "R025" "R102" "10K" 120 30 0 100 0x00)
+(
+        Pin(0 50 68 38 "1" 0x101)
+        Pin(400 50 68 38 "2" 0x01)
+        ElementLine(100 0 300 0 20)
+        ElementLine(300 0 300 100 20)
+        ElementLine(300 100 100 100 20)
+        ElementLine(100 100 100 0 20)
+        ElementLine(0 50 100 50 20)
+        ElementLine(300 50 400 50 20)
+        Mark(0 50)
+)
+Element(0x00 "R025" "R103" "10K" 120 30 0 100 0x00)
+(
+        Pin(0 50 68 38 "1" 0x101)
+        Pin(400 50 68 38 "2" 0x01)
+        ElementLine(100 0 300 0 20)
+        ElementLine(300 0 300 100 20)
+        ElementLine(300 100 100 100 20)
+        ElementLine(100 100 100 0 20)
+        ElementLine(0 50 100 50 20)
+        ElementLine(300 50 400 50 20)
+        Mark(0 50)
+)
+Element(0x00 "R025" "R201" "10K" 120 30 0 100 0x00)
+(
+        Pin(0 50 68 38 "1" 0x101)
+        Pin(400 50 68 38 "2" 0x01)
+        ElementLine(100 0 300 0 20)
+        ElementLine(300 0 300 100 20)
+        ElementLine(300 100 100 100 20)
+        ElementLine(100 100 100 0 20)
+        ElementLine(0 50 100 50 20)
+        ElementLine(300 50 400 50 20)
+        Mark(0 50)
+)
+
+# retain backwards compatibility to older versions of PKG_DIL
+# which did not have ,, args
+
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+Element(0x00 "DIL-8-3000" "U101" "TL072" 220 100 3 100 0x00)
+
+(
+        Pin(50 50 60 28 "1" 0x101)
+        Pin(50 150 60 28 "2" 0x01)
+        Pin(50 250 60 28 "3" 0x01)
+        Pin(50 350 60 28 "4" 0x01)
+        
+        Pin(350 350 60 28 "5" 0x01)
+        Pin(350 250 60 28 "6" 0x01)
+        Pin(350 150 60 28 "7" 0x01)
+        Pin(350 50 60 28 "8" 0x01)
+        
+        ElementLine(0 0 0 400 10)
+        ElementLine(0 400 400 400 10)
+        ElementLine(400 400 400 0 10)
+        ElementLine(0 0 150 0 10)
+        ElementLine(250 0 400 0 10)
+        ElementArc(200 0 50 50 0 180 10)
+        Mark(50 50)
+)
+Layer(1 "top")
+(
+)
+Layer(2 "ground")
+(
+)
+Layer(3 "signal2")
+(
+)
+Layer(4 "signal3")
+(
+)
+Layer(5 "power")
+(
+)
+Layer(6 "bottom")
+(
+)
+Layer(7 "outline")
+(
+)
+Layer(8 "spare")
+(
+)
+Layer(9 "silk")
+(
+)
+Layer(10 "silk")
+(
+)


### PR DESCRIPTION
I've added a couple of tests to make sure it works properly.

IMO, the option `--fix-elements` is superfluous.  In the first place, it was introduced decades ago to aid transition from `gschem2pcb` to `gsch2pcb`.  I may be wrong, but today we could live without it.  If anything changed in schematics, their pcb files have to be modified according to the changes.  Please let me know if you have any different opinion.