### PR TITLE
Selection of locked components in lepton-schematic

### DIFF
--- a/docs/manual/lepton-schematic.texi
+++ b/docs/manual/lepton-schematic.texi
@@ -310,6 +310,11 @@ that is, makes them not selectable by just clicking on them.
 @clicksequence{Edit @click{} Unlock} (@kbd{E Shift-L}) unlocks
 selected locked objects.  @xref{Editing schematics}.
 
+@item Select Locked
+@clicksequence{Edit @click{} Select Locked} (@kbd{E K}) cycle selection
+through all locked components on current page.
+@pxref{Selecting locked objects}.
+
 @item Embed Component/Picture
 @clicksequence{Edit @click{} Embed Component/Picture} (@kbd{E B})
 embeds a component or a picture into schematic.  @xref{Editing
@@ -1110,8 +1115,9 @@ L}) to lock them.  (By the way, you rarely need this for title blocks
 as they usually are added as already locked when a new schematic is
 created.  @xref{Title block symbol} for more information.)  In order
 to unlock a symbol, select it using box selection (@pxref{Box
-selection}) and use @clicksequence{Edit @click{} Unlock} (@kbd{E
-Shift-L}).
+selection}) or @clicksequence{Edit @click{} Select Locked} (@kbd{E K})
+(@pxref{Selecting locked objects}) and use @clicksequence{Edit @click{}
+Unlock} (@kbd{E Shift-L}).
 
 @quotation Note
 Locking and unlocking actions affect not only components but also all
@@ -1291,6 +1297,7 @@ ones.
 * Simple object selection::
 * Box selection::
 * Selecting and deselecting all objects::
+* Selecting locked objects::
 @end menu
 
 @node Simple object selection, Box selection, Selecting objects, Selecting objects
@@ -1304,10 +1311,11 @@ primitive object creation, it will be rejected as well.  In the mode
 you may select object by clicking at them using the left mouse button,
 or by selection box.  Selected objects are always rendered in the
 selection color so you can easily distinguish them from all other
-objects.  You cannot select locked objects this way.  They can only be
-selected by selection box.  Hitting @key{Ctrl} will toggle the
+objects.  You cannot select locked objects this way.  They can be
+selected by selection box or @clicksequence{Edit @click{} Select Locked}
+(@kbd{E K}). Holding @key{Ctrl} will toggle the
 selection state of the objects you are clicking at or selecting by
-selection box, while hitting @key{Shift} in the same situation will
+selection box, while holding @key{Shift} in the same situation will
 always add objects to the selection.
 
 @node Box selection, Selecting and deselecting all objects, Simple object selection, Selecting objects
@@ -1319,13 +1327,13 @@ As it is stated in the previous section, sometimes you cannot (or it
 is not easy to) select some object.  That is what box selection is
 convenient for.  Deselect first all selected objects if there are
 any: left-click at some empty place on the canvas.  Zoom your page in
-our out so you see any object you want to select.  Left-click and drag
+or out so you see any object you want to select.  Left-click and drag
 the mouse with the left button depressed so you will see a box that
 starts with the point you clicked first and increases or decreases
 while you drag the mouse.  Drag the mouse so the objects you want are
 within the selection box and release the mouse button.
 
-@node Selecting and deselecting all objects,  , Box selection, Selecting objects
+@node Selecting and deselecting all objects, Selecting locked objects, Box selection, Selecting objects
 @subsection Selecting and deselecting all objects
 @cindex select all
 @cindex deselect all
@@ -1335,6 +1343,17 @@ non-locked objects on a page while @clicksequence{Edit @click{}
 Deselect} (@kbd{Shift-Ctrl-A}) deselects all selected objects, if any.
 The latter can be achieved by just left mouse click at some free
 space of schematic.
+
+@node Selecting locked objects,  , Selecting and deselecting all objects, Selecting objects
+@subsection Selecting locked objects
+@cindex select locked
+
+Locked objects cannot be selected by clicking on them.  You have to use
+@emph{box selection} (@pxref{Box selection}).  For locked @emph{components}
+there is another method: @clicksequence{Edit @click{} Select Locked}
+(@kbd{E K}).  By repeating this action, you select locked components on
+current page one by one.  Information about currently selected component
+is shown in the log and, briefly, in the status bar.
 
 
 @node Searching for text, Check symbols, Selecting objects, lepton-schematic

--- a/docs/manual/title-block-symbol.texi
+++ b/docs/manual/title-block-symbol.texi
@@ -16,18 +16,10 @@ Moreover, an unlocked title block would be confusingly selected
 instead of other objects within it every now and then.  A title block
 symbol is inserted any time the user creates a new schematic.  Since
 it is not needed in symbols, you may want to delete it just after new
-page creation.  How to achieve that if you cannot select it?  Just use
-@emph{box selection} (@pxref{Box selection}), left-click and drag the
-selection box to enclose the title block.  Then use the usual deletion
-procedure: hit @kbd{Delete} or @kbd{D}.
-
-What to do if you want to change it after adding some contents to your
-schematic page?  Well, there are some tricks.  First, you can just
-select all page contents excluding locked objects and move it to
-another place, then delete the title block as above.  Another way, if
-the @ref{gEDA file format} is used, is just deleting title block
-definition in the schematic file itself.  It is usually second and
-third lines of the file (the first one is the version specification).
+page creation.  Select it either by using @emph{box selection}
+(@pxref{Box selection}) or @clicksequence{Edit @click{} Select Locked}
+(@kbd{E K}) (@pxref{Selecting locked objects}) and hit @kbd{Delete}
+or @kbd{E D}.
 
 For historical reasons, the default title block symbol is
 @file{title-B.sym}.  In order to set up another symbol as default

--- a/libleptongui/scheme/Makefile.am
+++ b/libleptongui/scheme/Makefile.am
@@ -39,6 +39,7 @@ nobase_dist_scmdata_DATA = \
 	schematic/refdes.scm \
 	schematic/repl.scm \
 	schematic/selection.scm \
+	schematic/sellock.scm \
 	schematic/symbol/check.scm \
 	schematic/toolbar.scm \
 	schematic/util.scm \

--- a/libleptongui/scheme/conf/schematic/keys.scm
+++ b/libleptongui/scheme/conf/schematic/keys.scm
@@ -97,6 +97,7 @@
 (global-set-key "E <Shift>S" '&edit-slot)
 (global-set-key "E L" '&edit-lock)
 (global-set-key "E <Shift>L" '&edit-unlock)
+(global-set-key "E K" '&edit-select-locked)
 (global-set-key "E T" '&edit-translate)
 (global-set-key "E <Shift>colon" '&edit-invoke-macro)
 (global-set-key "E O" '&edit-object-properties )

--- a/libleptongui/scheme/conf/schematic/menu.scm
+++ b/libleptongui/scheme/conf/schematic/menu.scm
@@ -75,6 +75,7 @@
   ( list "SEPARATOR" #f #f )
   ( list (N_ "Lock")                 '&edit-lock              #f )
   ( list (N_ "Unlock")               '&edit-unlock            #f )
+  ( list (N_ "Select Locked")        '&edit-select-locked     #f )
   ( list "SEPARATOR" #f #f )
   ( list (N_ "Embed Component/Picture")   '&edit-embed        #f )
   ( list (N_ "Unembed Component/Picture") '&edit-unembed      #f )

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -57,7 +57,8 @@
   #:use-module (schematic window global)
   #:use-module (schematic window foreign)
   #:use-module (schematic window list)
-  #:use-module (schematic window))
+  #:use-module (schematic window)
+  #:use-module (schematic sellock))
 
 
 (define-syntax define-action-public
@@ -476,6 +477,10 @@ the snap grid size should be set to 100")))
   ;; Refresh page view to properly restore attributes' colors.
   (gschem_page_view_invalidate_all
    (gschem_toplevel_get_current_page_view *window)))
+
+
+(define-action-public (&edit-select-locked #:label (G_ "Select Locked"))
+  (select-locked))
 
 
 (define-action-public (&edit-invoke-macro #:label (G_ "Invoke Macro"))

--- a/libleptongui/scheme/schematic/sellock.scm
+++ b/libleptongui/scheme/schematic/sellock.scm
@@ -51,6 +51,11 @@
 )
 
 
+( define ( bind2nd val ) ; returns predicate func taking 1 arg
+  ( lambda( arg ) (eq? arg val) )
+)
+
+
 ; public:
 ;
 ( define ( select-locked )
@@ -59,13 +64,25 @@
   ( define locked-comps ( remove object-selectable? comps ) )
   ( define comp ( selected-locked-comp comps ) )
 
+  ( define ( select-and-report c )
+    ( select-comp c )
+    ( log!
+        'message
+        ( G_ "Select locked: ~a of ~a (~a)~a" )
+        ( 1+ (list-index (bind2nd c) locked-comps) )
+        ( length locked-comps )
+        ( component-basename c )
+        ( G_", press <E E> to edit, <E Shift+L> to unlock" )
+    )
+  )
+
   ( deselect-all )
 
   ( if ( null? locked-comps )
     ( schematic-message-dialog (G_ "No locked components") )
     ( if comp
-      ( select-comp (next-in-list comp locked-comps) )
-      ( select-comp (first locked-comps) )
+      ( select-and-report (next-in-list comp locked-comps) )
+      ( select-and-report (first locked-comps) )
     )
   )
 

--- a/libleptongui/scheme/schematic/sellock.scm
+++ b/libleptongui/scheme/schematic/sellock.scm
@@ -42,6 +42,15 @@
 )
 
 
+( define ( next-in-list val lst )
+  ; return:
+  ( if ( eq? val (last lst) )
+    ( first lst )             ; if
+    ( cadr (member val lst) ) ; else (cadr: car of cdr)
+  )
+)
+
+
 ; public:
 ;
 ( define ( select-locked )
@@ -56,7 +65,8 @@
 
     ( if ( null? locked-comps )
       ( schematic-message-dialog ( G_ "No locked components" ) )
-      ( if ( not comp )
+      ( if comp
+        ( select-comp (next-in-list comp locked-comps) )
         ( select-comp (first locked-comps) )
       )
     )

--- a/libleptongui/scheme/schematic/sellock.scm
+++ b/libleptongui/scheme/schematic/sellock.scm
@@ -6,13 +6,31 @@
 
 ( define-module ( schematic sellock )
   #:use-module ( lepton log )
+  #:use-module ( lepton page )
+  #:use-module ( lepton attrib )
+  #:use-module ( schematic window )
+  #:use-module ( schematic selection )
 
   #:export ( select-locked )
 )
 
 
+( define ( deselect-all )
+  ( for-each deselect-object! (page-contents (active-page)) )
+)
 
+
+( define ( select-comp comp )
+  ( select-object! comp )
+  ( for-each select-object! (object-attribs comp) )
+)
+
+
+; public:
+;
 ( define ( select-locked )
     ( log! 'message ".. select-locked()" )
+
+    ( deselect-all )
 )
 

--- a/libleptongui/scheme/schematic/sellock.scm
+++ b/libleptongui/scheme/schematic/sellock.scm
@@ -54,23 +54,20 @@
 ; public:
 ;
 ( define ( select-locked )
-( let*
-  (
-  ( comps ( filter component? (page-contents (active-page)) ) )
-  ( locked-comps ( remove object-selectable? comps ) )
-  ( comp ( selected-locked-comp comps ) )
+
+  ( define comps ( filter component? (page-contents (active-page)) ) )
+  ( define locked-comps ( remove object-selectable? comps ) )
+  ( define comp ( selected-locked-comp comps ) )
+
+  ( deselect-all )
+
+  ( if ( null? locked-comps )
+    ( schematic-message-dialog (G_ "No locked components") )
+    ( if comp
+      ( select-comp (next-in-list comp locked-comps) )
+      ( select-comp (first locked-comps) )
+    )
   )
 
-    ( deselect-all )
-
-    ( if ( null? locked-comps )
-      ( schematic-message-dialog ( G_ "No locked components" ) )
-      ( if comp
-        ( select-comp (next-in-list comp locked-comps) )
-        ( select-comp (first locked-comps) )
-      )
-    )
-
-) ; let
 ) ; select-locked()
 

--- a/libleptongui/scheme/schematic/sellock.scm
+++ b/libleptongui/scheme/schematic/sellock.scm
@@ -6,6 +6,9 @@
 
 ( define-module ( schematic sellock )
   #:use-module ( srfi srfi-1 )
+  #:use-module ( system foreign )
+  #:use-module ( schematic window global )
+  #:use-module ( schematic ffi )
   #:use-module ( lepton log )
   #:use-module ( lepton page )
   #:use-module ( lepton attrib )
@@ -73,6 +76,17 @@
         ( length locked-comps )
         ( component-basename c )
         ( G_", press <E E> to edit, <E Shift+L> to unlock" )
+    )
+    ( i_show_state
+      ( *current-window )
+      ( string->pointer
+        ( format
+          #f
+          ( G_ "Locked: ~a of ~a" )
+          ( 1+ (list-index (bind2nd c) locked-comps) )
+          ( length locked-comps )
+        )
+      )
     )
   )
 

--- a/libleptongui/scheme/schematic/sellock.scm
+++ b/libleptongui/scheme/schematic/sellock.scm
@@ -1,0 +1,18 @@
+;; Lepton EDA
+;; ( schematic sellock ) module: select locked components.
+;; Copyright (C) 2020-2023 dmn <graahnul.grom@ya.ru>
+;; License: GPLv2+. See the COPYING file.
+;;
+
+( define-module ( schematic sellock )
+  #:use-module ( lepton log )
+
+  #:export ( select-locked )
+)
+
+
+
+( define ( select-locked )
+    ( log! 'message ".. select-locked()" )
+)
+

--- a/libleptongui/scheme/schematic/sellock.scm
+++ b/libleptongui/scheme/schematic/sellock.scm
@@ -30,6 +30,18 @@
 )
 
 
+( define ( selected-locked-comp comps )
+  ( define sel ( page-selection (active-page) ) )
+  ( define sel-locked ( remove object-selectable? sel ) )
+  ( define sel-locked-comps ( filter component? sel-locked ) )
+  ; return:
+  ( if ( = (length sel-locked-comps) 1 )
+    ( first sel-locked-comps ) ; if
+    #f                         ; else
+  )
+)
+
+
 ; public:
 ;
 ( define ( select-locked )
@@ -37,12 +49,16 @@
   (
   ( comps ( filter component? (page-contents (active-page)) ) )
   ( locked-comps ( remove object-selectable? comps ) )
+  ( comp ( selected-locked-comp comps ) )
   )
 
     ( deselect-all )
 
     ( if ( null? locked-comps )
       ( schematic-message-dialog ( G_ "No locked components" ) )
+      ( if ( not comp )
+        ( select-comp (first locked-comps) )
+      )
     )
 
 ) ; let

--- a/libleptongui/scheme/schematic/sellock.scm
+++ b/libleptongui/scheme/schematic/sellock.scm
@@ -5,11 +5,15 @@
 ;;
 
 ( define-module ( schematic sellock )
+  #:use-module ( srfi srfi-1 )
   #:use-module ( lepton log )
   #:use-module ( lepton page )
   #:use-module ( lepton attrib )
+  #:use-module ( lepton object )
   #:use-module ( schematic window )
   #:use-module ( schematic selection )
+  #:use-module ( schematic dialog )
+  #:use-module ( schematic gettext )
 
   #:export ( select-locked )
 )
@@ -29,8 +33,18 @@
 ; public:
 ;
 ( define ( select-locked )
-    ( log! 'message ".. select-locked()" )
+( let*
+  (
+  ( comps ( filter component? (page-contents (active-page)) ) )
+  ( locked-comps ( remove object-selectable? comps ) )
+  )
 
     ( deselect-all )
-)
+
+    ( if ( null? locked-comps )
+      ( schematic-message-dialog ( G_ "No locked components" ) )
+    )
+
+) ; let
+) ; select-locked()
 

--- a/libleptongui/scheme/schematic/sellock.scm
+++ b/libleptongui/scheme/schematic/sellock.scm
@@ -5,6 +5,7 @@
 ;;
 
 ( define-module ( schematic sellock )
+  #:use-module ( ice-9 format )
   #:use-module ( srfi srfi-1 )
   #:use-module ( system foreign )
   #:use-module ( schematic window global )
@@ -68,27 +69,17 @@
   ( define comp ( selected-locked-comp comps ) )
 
   ( define ( select-and-report c )
+    ( define ndx ( list-index (bind2nd c) locked-comps ) )
+    ( define len ( length locked-comps ) )
+    ( define msg (G_ "Select locked: ~a of ~a (~a), ~
+                      press <E E> to edit, <E Shift+L> to unlock") )
+    ( define msg2 ( format #f (G_ "Locked: ~a of ~a") (1+ ndx) len ) )
+
     ( select-comp c )
-    ( log!
-        'message
-        ( G_ "Select locked: ~a of ~a (~a)~a" )
-        ( 1+ (list-index (bind2nd c) locked-comps) )
-        ( length locked-comps )
-        ( component-basename c )
-        ( G_", press <E E> to edit, <E Shift+L> to unlock" )
-    )
-    ( i_show_state
-      ( *current-window )
-      ( string->pointer
-        ( format
-          #f
-          ( G_ "Locked: ~a of ~a" )
-          ( 1+ (list-index (bind2nd c) locked-comps) )
-          ( length locked-comps )
-        )
-      )
-    )
+    ( log! 'message msg (1+ ndx) len (component-basename c) )
+    ( i_show_state (*current-window) (string->pointer msg2) )
   )
+
 
   ( deselect-all )
 

--- a/libleptongui/scheme/schematic/sellock.scm
+++ b/libleptongui/scheme/schematic/sellock.scm
@@ -34,7 +34,7 @@
 )
 
 
-( define ( selected-locked-comp comps )
+( define ( selected-locked-comp )
   ( define sel ( page-selection (active-page) ) )
   ( define sel-locked ( remove object-selectable? sel ) )
   ( define sel-locked-comps ( filter component? sel-locked ) )
@@ -66,7 +66,7 @@
 
   ( define comps ( filter component? (page-contents (active-page)) ) )
   ( define locked-comps ( remove object-selectable? comps ) )
-  ( define comp ( selected-locked-comp comps ) )
+  ( define comp ( selected-locked-comp ) )
 
   ( define ( select-and-report c )
     ( define ndx ( list-index (bind2nd c) locked-comps ) )


### PR DESCRIPTION
Add new `&edit-select-locked` action; `Edit->Select Locked`
menu item and `E K` shortcut for it.
It selects locked components on current page one by one.
If there is none, shows a message box about that.
Information about currently selected component is shown
in the log and, briefly, in the status bar.
Implemented in new `(schematic sellock)` module.
Based on my [select-locked](https://graahnul-grom.github.io/scm/select-locked.scm.html) script.

Closes #651.

![select-locked-0](https://github.com/lepton-eda/lepton-eda/assets/26083750/414e41cb-767b-4b76-8c65-e9f7fbe13647)

![select-locked-1](https://github.com/lepton-eda/lepton-eda/assets/26083750/a3409c29-842a-415e-8f62-9853bded9588)

![select-locked-2](https://github.com/lepton-eda/lepton-eda/assets/26083750/fa3f87a5-97cb-4e4a-a8d8-e708c1b3ed5f)

![select-locked-3](https://github.com/lepton-eda/lepton-eda/assets/26083750/4f81bff8-4ff1-4860-b581-0ccd9bc75a99)

