### PR TITLE
Add missing title to dialog boxes

### DIFF
--- a/libleptonattrib/src/x_dialog.c
+++ b/libleptonattrib/src/x_dialog.c
@@ -238,6 +238,7 @@ void x_dialog_unsaved_data()
                           _("_Cancel"),          GTK_RESPONSE_CANCEL,
                           _("_Save"),            GTK_RESPONSE_YES,
                           NULL);
+  gtk_window_set_title (GTK_WINDOW (dialog), "lepton-attrib");
 
 #ifndef ENABLE_GTK3
   /* Set the alternative button order (ok, cancel, help) for other systems */

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -393,36 +393,30 @@ void x_colorcb_set_color (GtkTreeIter* iter, GdkColor* color);
 #endif
 
 /* x_dialog.c */
-int text_view_calculate_real_tab_width(GtkTextView *textview, int tab_size);
-void select_all_text_in_textview(GtkTextView *textview);
+void generic_msg_dialog(const char *);
+int generic_confirm_dialog(const char *);
+void
+generic_error_dialog (const char *primary_message,
+                      const char *secondary_message,
+                      const char *title);
+char * generic_filesel_dialog(const char *, const char *, gint);
+void major_changed_dialog(GschemToplevel* w_current);
+int x_dialog_validate_attribute(GtkWindow* parent, char *attribute);
+
 void text_input_dialog(GschemToplevel *w_current);
 void text_edit_dialog(GschemToplevel *w_current);
 void arc_angle_dialog(GschemToplevel *w_current, LeptonObject *arc_object);
 void about_dialog(GschemToplevel *w_current);
 void coord_display_update(GschemToplevel *w_current, int x, int y);
 void coord_dialog(GschemToplevel *w_current, int x, int y);
-char *index2functionstring(int index);
 void x_dialog_hotkeys(GschemToplevel *w_current);
-
-void generic_msg_dialog(const char *);
-int generic_confirm_dialog(const char *);
-
-void
-generic_error_dialog (const char *primary_message,
-                      const char *secondary_message,
-                      const char *title);
-
-char * generic_filesel_dialog(const char *, const char *, gint);
-
 void find_text_dialog(GschemToplevel *w_current);
 void hide_text_dialog(GschemToplevel *w_current);
 void show_text_dialog(GschemToplevel *w_current);
-void major_changed_dialog(GschemToplevel* w_current);
 gboolean
 x_dialog_close_changed_page (GschemToplevel *w_current,
                              LeptonPage *page);
 gboolean x_dialog_close_window (GschemToplevel *w_current);
-int x_dialog_validate_attribute(GtkWindow* parent, char *attribute);
 
 /* x_event.c */
 gboolean

--- a/libleptongui/include/x_dialog.h
+++ b/libleptongui/include/x_dialog.h
@@ -16,28 +16,25 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-
 #ifndef __X_DIALOG_H__
 #define __X_DIALOG_H__
 
-/* 
+/*
  * Flags for generic_filesel_dialog()
  */
+#define FSB_MAY_EXIST        1
+#define FSB_MUST_EXIST       2
+#define FSB_SHOULD_NOT_EXIST 4
 
-#define FSB_MAY_EXIST		1
-#define FSB_MUST_EXIST		2
-#define FSB_SHOULD_NOT_EXIST	4
-
-#define FSB_SAVE		256
-#define FSB_LOAD		512
+#define FSB_SAVE 256
+#define FSB_LOAD 512
 
 /*
  * define spacings for dialogs
  */
-
 #define DIALOG_BORDER_SPACING 5
-#define DIALOG_V_SPACING 8
-#define DIALOG_H_SPACING 10
-#define DIALOG_INDENTATION 10
+#define DIALOG_V_SPACING      8
+#define DIALOG_H_SPACING      10
+#define DIALOG_INDENTATION    10
 
 #endif /* __X_DIALOG_H__ */

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -1102,12 +1102,10 @@ the snap grid size should be set to 100")))
 
 (define (failed-to-descend-error filename message)
   (log! 'message (G_ "Failed to descend into ~S: ~A") filename message)
-  (format #f (string-append
-              (format #f
-                      (G_ "Failed to descend hierarchy into ~S: ~A\n\n")
-                      filename
-                      message)
-              (G_ "The lepton-schematic log may contain more information."))))
+  (format #f (G_ "Failed to descend hierarchy into ~S:\n~A\n\n~A")
+             filename
+             message
+             (G_ "The lepton-schematic log may contain more information.")))
 
 (define (source-attrib? attrib)
   (string= (attrib-name attrib) "source"))

--- a/libleptongui/src/color_edit_widget.c
+++ b/libleptongui/src/color_edit_widget.c
@@ -264,7 +264,12 @@ color_edit_widget_create (ColorEditWidget* widget)
 
   GtkWidget* label = gtk_label_new (msg);
   gtk_label_set_selectable (GTK_LABEL (label), TRUE);
-  gtk_box_pack_start (GTK_BOX (vbox), label, FALSE, FALSE, 0);
+
+  GtkWidget* frame = gschem_dialog_misc_create_section_widget(
+    _("<b>Help</b>"), label);
+  gtk_expander_set_expanded (GTK_EXPANDER (frame), FALSE);
+
+  gtk_box_pack_start (GTK_BOX (vbox), frame, FALSE, FALSE, 0);
 
 
   g_signal_connect (G_OBJECT (widget->color_cb_),

--- a/libleptongui/src/gschem_coord_dialog.c
+++ b/libleptongui/src/gschem_coord_dialog.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2015 gEDA Contributors
- * Copyright (C) 2017-2022 Lepton EDA Contributors
+ * Copyright (C) 2017-2023 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,26 +17,11 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
-/*! \todo STILL NEED to clean up line lengths in aa and tr */
+
 #include <config.h>
-
-#include <stdio.h>
-#ifdef HAVE_STDLIB_H
-#include <stdlib.h>
-#endif
-#ifdef HAVE_STRING_H
-#include <string.h>
-#endif
-
 #include "gschem.h"
 
-#define GLADE_HOOKUP_OBJECT(component,widget,name) \
-  g_object_set_data_full (G_OBJECT (component), name, \
-    g_object_ref (widget), (GDestroyNotify) g_object_unref)
 
-
-
-/***************** Start of coord dialog box ************************/
 /*! \brief Response function for the coord dialog
  *  \par Function Description
  *  This function destroys the coord dialog box and does some cleanup.
@@ -48,6 +33,7 @@ void coord_dialog_response(GtkWidget *w, gint response, GschemToplevel *w_curren
   w_current->coord_world = NULL;
   w_current->coord_screen = NULL;
 }
+
 
 /*! \brief Update the coordinates in the coord dialog box.
  *  \par Function Description
@@ -73,9 +59,8 @@ void coord_display_update(GschemToplevel *w_current, int x, int y)
   g_free(string);
 }
 
+
 /*! \brief Create the coord dialog
- *  \par Function Description
- *  This function creates the coord dialog box.
  */
 void coord_dialog (GschemToplevel *w_current, int x, int y)
 {
@@ -145,5 +130,3 @@ void coord_dialog (GschemToplevel *w_current, int x, int y)
   /* always update the coords when the dialog is requested */
   coord_display_update(w_current, x, y);
 }
-
-/***************** End of coord dialog box **************************/

--- a/libleptongui/src/gschem_text_properties_widget.c
+++ b/libleptongui/src/gschem_text_properties_widget.c
@@ -108,7 +108,13 @@ gschem_text_properties_widget_adjust_focus (GschemTextPropertiesWidget *widget)
   g_return_if_fail (widget->colorcb != NULL);
 
   if (gtk_widget_is_sensitive (widget->text_view)) {
-    select_all_text_in_textview (GTK_TEXT_VIEW (widget->text_view));
+    GtkTextBuffer *textbuffer =
+      gtk_text_view_get_buffer (GTK_TEXT_VIEW (widget->text_view));
+
+    GtkTextIter start, end;
+    gtk_text_buffer_get_bounds (textbuffer, &start, &end);
+    gtk_text_buffer_select_range (textbuffer, &start, &end);
+
     gtk_widget_grab_focus (widget->text_view);
   }
   else {

--- a/libleptongui/src/o_picture.c
+++ b/libleptongui/src/o_picture.c
@@ -215,6 +215,7 @@ void picture_selection_dialog (GschemToplevel *w_current)
                                        GTK_BUTTONS_CLOSE,
                                        _("Failed to load picture: %1$s"),
                                        error->message);
+      gtk_window_set_title (GTK_WINDOW (dialog), "lepton-schematic");
       /* Wait for any user response */
       gtk_dialog_run (GTK_DIALOG (dialog));
 
@@ -422,6 +423,7 @@ void picture_change_filename_dialog (GschemToplevel *w_current)
                                        GTK_BUTTONS_CLOSE,
                                        _("Failed to replace pictures: %s"),
                                        error->message);
+      gtk_window_set_title (GTK_WINDOW (dialog), "lepton-schematic");
       /* Wait for any user response */
       gtk_dialog_run (GTK_DIALOG (dialog));
 

--- a/libleptongui/src/x_dialog.c
+++ b/libleptongui/src/x_dialog.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2015 gEDA Contributors
- * Copyright (C) 2017-2022 Lepton EDA Contributors
+ * Copyright (C) 2017-2023 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,21 +17,10 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
-/*! \todo STILL NEED to clean up line lengths in aa and tr */
+
 #include <config.h>
-
-#include <stdio.h>
-#ifdef HAVE_STDLIB_H
-#include <stdlib.h>
-#endif
-#ifdef HAVE_STRING_H
-#include <string.h>
-#endif
-
 #include "gschem.h"
 
-
-/***************** Start of generic message dialog box *******************/
 
 /*! \todo Finish function documentation!!!
  *  \brief
@@ -55,9 +44,7 @@ void generic_msg_dialog (const char *msg)
 
 }
 
-/***************** End of generic message dialog box *********************/
 
-/***************** Start of generic confirm dialog box *******************/
 
 /*! \todo Finish function documentation!!!
  *  \brief
@@ -86,7 +73,7 @@ int generic_confirm_dialog (const char *msg)
     return 0;
 }
 
-/***************** End of generic confirm dialog box *********************/
+
 
 /*! \brief Launch generic error dialog.
  *  \par Function Description
@@ -127,7 +114,7 @@ generic_error_dialog (const char *primary_message,
 }
 
 
-/***************** Start of generic file select dialog box ***************/
+
 /*! \todo Finish function documentation!!!
  *  \brief
  *  \par Function Description
@@ -197,58 +184,7 @@ char *generic_filesel_dialog (const char *msg, const char *templ, gint flags)
 
 }
 
-/***************** End of generic file select dialog box *****************/
 
-/*********** Start of some Gtk utils  *******/
-
-/*! \brief Selects all text in a TextView widget
- *  \par Function Description
- *  The function selects all the text in a TextView widget.
- */
-void select_all_text_in_textview(GtkTextView *textview)
-{
-  GtkTextBuffer *textbuffer;
-  GtkTextIter start, end;
-
-  textbuffer = gtk_text_view_get_buffer(GTK_TEXT_VIEW(textview));
-  gtk_text_buffer_get_bounds (textbuffer, &start, &end);
-  gtk_text_buffer_select_range(textbuffer, &start, &end);
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
-int text_view_calculate_real_tab_width(GtkTextView *textview, int tab_size)
-{
-  PangoLayout *layout;
-  gchar *tab_string;
-  gint tab_width = 0;
-
-  if (tab_size == 0)
-  return -1;
-
-  tab_string = g_strnfill (tab_size, ' ');
-
-  layout = gtk_widget_create_pango_layout (
-                                           GTK_WIDGET (textview),
-                                           tab_string);
-  g_free (tab_string);
-
-  if (layout != NULL) {
-    pango_layout_get_pixel_size (layout, &tab_width, NULL);
-    g_object_unref (G_OBJECT (layout));
-  } else
-  tab_width = -1;
-
-  return tab_width;
-
-}
-
-/*********** End of some Gtk utils *******/
-
-/*********** Start of major symbol changed dialog box *******/
 
 /*! \brief Show the "Symbol version changes" dialog box.
  */
@@ -426,10 +362,8 @@ major_changed_dialog (GschemToplevel* w_current)
 
 } /* major_changed_dialog() */
 
-/*********** End of major symbol changed dialog box *******/
 
 
-/***************** Start of misc helper dialog boxes **************/
 /*! \brief Validate the input attribute
  *  \par Function Description
  *  This function validates the attribute and if it isn't valid
@@ -458,4 +392,4 @@ int x_dialog_validate_attribute(GtkWindow* parent, char *attribute)
   }
   return TRUE;
 }
-/***************** End of misc helper dialog boxes **************/
+

--- a/libleptongui/src/x_dialog.c
+++ b/libleptongui/src/x_dialog.c
@@ -117,6 +117,11 @@ generic_error_dialog (const char *primary_message,
   {
     gtk_window_set_title (GTK_WINDOW (dialog), title);
   }
+  else
+  {
+    gtk_window_set_title (GTK_WINDOW (dialog), "lepton-schematic");
+  }
+
   gtk_dialog_run (GTK_DIALOG (dialog));
   gtk_widget_destroy (dialog);
 }

--- a/libleptongui/src/x_dialog.c
+++ b/libleptongui/src/x_dialog.c
@@ -48,6 +48,7 @@ void generic_msg_dialog (const char *msg)
                                    GTK_MESSAGE_INFO,
                                    GTK_BUTTONS_OK,
                                    "%s", msg);
+  gtk_window_set_title (GTK_WINDOW (dialog), "lepton-schematic");
 
   gtk_dialog_run (GTK_DIALOG (dialog));
   gtk_widget_destroy (dialog);
@@ -74,6 +75,7 @@ int generic_confirm_dialog (const char *msg)
                                    GTK_MESSAGE_INFO,
                                    GTK_BUTTONS_OK_CANCEL,
                                    "%s", msg);
+  gtk_window_set_title (GTK_WINDOW (dialog), "lepton-schematic");
 
   r = gtk_dialog_run (GTK_DIALOG (dialog));
   gtk_widget_destroy (dialog);

--- a/libleptongui/src/x_dialog.c
+++ b/libleptongui/src/x_dialog.c
@@ -22,15 +22,14 @@
 #include "gschem.h"
 
 
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
+/*! \brief Show a message box.
  *
+ *  \param msg  The message text.
  */
-void generic_msg_dialog (const char *msg)
+void
+generic_msg_dialog (const char *msg)
 {
   GtkWidget *dialog;
-
   dialog = gtk_message_dialog_new (NULL,
                                    (GtkDialogFlags) (GTK_DIALOG_MODAL |
                                                      GTK_DIALOG_DESTROY_WITH_PARENT),
@@ -41,17 +40,17 @@ void generic_msg_dialog (const char *msg)
 
   gtk_dialog_run (GTK_DIALOG (dialog));
   gtk_widget_destroy (dialog);
-
 }
 
 
 
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
+/*! \brief Launch a confirmation dialog.
  *
+ *  \param msg  The message text.
+ *  \return     1 if user clicks the OK button, 0 otherwise.
  */
-int generic_confirm_dialog (const char *msg)
+int
+generic_confirm_dialog (const char *msg)
 {
   GtkWidget *dialog;
   gint r;
@@ -115,14 +114,18 @@ generic_error_dialog (const char *primary_message,
 
 
 
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
+/*! \brief Launch generic file selection dialog.
  *
- *  \warning
- *   Caller must g_free returned character string.
+ *  \param msg    Dialog's title (':Open' or ':Save' will be appended).
+ *  \param templ  Suggested file name and, for open dialog, file path.
+ *  \param flags  Bitwise OR of FSB_* flags defined in x_dialog.h.
+ *  \return       Chosen file path or NULL if dialog is cancelled.
+ *
+ *  \note Flags other than FSB_LOAD and FSB_SAVE are currently not used.
+ *  \note Caller must g_free() returned string.
  */
-char *generic_filesel_dialog (const char *msg, const char *templ, gint flags)
+char*
+generic_filesel_dialog (const char *msg, const char *templ, gint flags)
 {
   GtkWidget *dialog;
   gchar *result = NULL;
@@ -164,11 +167,12 @@ char *generic_filesel_dialog (const char *msg, const char *templ, gint flags)
 
   gtk_dialog_set_default_response (GTK_DIALOG (dialog), GTK_RESPONSE_OK);
 
-  /* Pick the current template (*.rc) or default file name */
   if (templ && *templ) {
     if (flags & FSB_SAVE)  {
+      /* suggested file name */
       gtk_file_chooser_set_current_name (GTK_FILE_CHOOSER (dialog), templ);
     } else {
+      /* changes to specified file's folder */
       gtk_file_chooser_select_filename (GTK_FILE_CHOOSER (dialog), templ);
     }
   }
@@ -176,13 +180,12 @@ char *generic_filesel_dialog (const char *msg, const char *templ, gint flags)
   if (gtk_dialog_run (GTK_DIALOG (dialog)) == GTK_RESPONSE_OK) {
     result = gtk_file_chooser_get_filename (GTK_FILE_CHOOSER (dialog));
   }
+
   gtk_widget_destroy (dialog);
-
   g_free (title);
-
   return result;
 
-}
+} /* generic_filesel_dialog() */
 
 
 
@@ -366,14 +369,17 @@ major_changed_dialog (GschemToplevel* w_current)
 
 /*! \brief Validate the input attribute
  *  \par Function Description
+ *
  *  This function validates the attribute and if it isn't valid
  *  pops up an error message box.
  *
  *  \param parent The parent window which spawned this dialog box.
  *  \param attribute The attribute to be validated.
+ *
  *  \returns TRUE if the attribute is valid, FALSE otherwise.
  */
-int x_dialog_validate_attribute(GtkWindow* parent, char *attribute)
+int
+x_dialog_validate_attribute (GtkWindow* parent, char *attribute)
 {
   GtkWidget* message_box;
 

--- a/libleptongui/src/x_image.c
+++ b/libleptongui/src/x_image.c
@@ -429,6 +429,7 @@ void x_image_lowlevel(GschemToplevel *w_current, const char* filename,
                                          filetype,
                                          filename,
                                          gerror->message);
+        gtk_window_set_title (GTK_WINDOW (dialog), "lepton-schematic");
 
         gtk_dialog_run (GTK_DIALOG (dialog));
         gtk_widget_destroy (dialog);

--- a/libleptongui/src/x_multiattrib.c
+++ b/libleptongui/src/x_multiattrib.c
@@ -942,6 +942,7 @@ multiattrib_callback_edited_name (GtkCellRendererText *cellrenderertext,
       GTK_MESSAGE_ERROR,
       GTK_BUTTONS_OK,
       _("Attributes with empty name are not allowed. Please set a name."));
+    gtk_window_set_title (GTK_WINDOW (dialog), "lepton-schematic");
 
     gtk_dialog_run (GTK_DIALOG (dialog));
     gtk_widget_destroy (dialog);

--- a/libleptongui/src/x_newtext.c
+++ b/libleptongui/src/x_newtext.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 2013 Ales Hvezda
  * Copyright (C) 2013-2015 gEDA Contributors
- * Copyright (C) 2017-2022 Lepton EDA Contributors
+ * Copyright (C) 2017-2023 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -62,6 +62,42 @@ struct _NewText {
 
 
 G_DEFINE_TYPE (NewText, newtext, GSCHEM_TYPE_DIALOG);
+
+
+static int
+text_view_calculate_real_tab_width (GtkTextView *textview, int tab_size)
+{
+  if (tab_size <= 0)
+    return -1;
+
+  gchar* tab_string = g_strnfill (tab_size, ' ');
+  PangoLayout* layout =
+    gtk_widget_create_pango_layout (GTK_WIDGET (textview), tab_string);
+  g_free (tab_string);
+
+  gint tab_width = -1;
+  if (layout != NULL)
+  {
+    pango_layout_get_pixel_size (layout, &tab_width, NULL);
+    g_object_unref (G_OBJECT (layout));
+  }
+
+  return tab_width;
+}
+
+
+
+static void
+select_all_text_in_textview (GtkTextView *textview)
+{
+  GtkTextBuffer *textbuffer =
+    gtk_text_view_get_buffer (GTK_TEXT_VIEW (textview));
+
+  GtkTextIter start, end;
+  gtk_text_buffer_get_bounds (textbuffer, &start, &end);
+  gtk_text_buffer_select_range (textbuffer, &start, &end);
+}
+
 
 
 /*! \brief Handles the user response when apply is selected

--- a/libleptongui/src/x_print.c
+++ b/libleptongui/src/x_print.c
@@ -450,6 +450,7 @@ x_print (GschemToplevel *w_current)
                               GTK_BUTTONS_CLOSE,
                               _("Error printing file:\n%1$s"),
                               err->message);
+    gtk_window_set_title (GTK_WINDOW (error_dialog), "lepton-schematic");
     g_signal_connect (error_dialog, "response",
                       G_CALLBACK (gtk_widget_destroy), NULL);
     gtk_widget_show (error_dialog);

--- a/libleptongui/src/x_rc.c
+++ b/libleptongui/src/x_rc.c
@@ -65,6 +65,7 @@ x_rc_parse_gschem_error (GError **err)
                                    GTK_DIALOG_MODAL, GTK_MESSAGE_ERROR,
                                    GTK_BUTTONS_OK,
                                    _("Cannot load lepton-schematic configuration."));
+  gtk_window_set_title (GTK_WINDOW (dialog), "lepton-schematic");
   g_object_set (G_OBJECT (dialog), "secondary-text", msg2, NULL);
   gtk_dialog_run (GTK_DIALOG (dialog));
   gtk_widget_destroy (dialog);


### PR DESCRIPTION
Give dialogs a default title, "lepton-schematic",
where it is missing (mostly, error message boxes).
Also document functions in `x_dialog.c` (doxygen) and move
code not related to generic dialogs out of this file.
