### PR TITLE
Simplify the toolbar creation code

### DIFF
--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -476,6 +476,8 @@
             a_zoom_box_motion
             a_zoom_box_start
 
+            g_action_eval_by_name
+
             parse-gschemrc
             ))
 
@@ -1031,6 +1033,9 @@
 (define-lff a_zoom_box_end void (list '* int int))
 (define-lff a_zoom_box_motion void (list '* int int))
 (define-lff a_zoom_box_start void (list '* int int))
+
+;;; x_menus.c
+(define-lff g_action_eval_by_name int (list '* '*))
 
 ;;; This is a special case: the function may be not defined in C
 ;;; if libstroke was not found on the configure stage.

--- a/libleptongui/scheme/schematic/toolbar.scm
+++ b/libleptongui/scheme/schematic/toolbar.scm
@@ -202,6 +202,21 @@
                                "Select mode"
                                callback-toolbar-edit-select)
     (radio-group-end 2)
+    (make-toolbar-separator *toolbar)
+
+    (make-toolbar-button *window *toolbar
+                         "gtk-goto-bottom" "Down Symbol" "Down Symbol" ; ico lab tip
+                         (lambda (*widget *window)
+                           (g_action_eval_by_name
+                             *window
+                             (string->pointer "&hierarchy-down-symbol"))))
+
+    (make-toolbar-button *window *toolbar
+                         "gtk-go-down" "Down Schematic" "Down Schematic"
+                         (lambda (*widget *window)
+                           (g_action_eval_by_name
+                             *window
+                             (string->pointer "&hierarchy-down-schematic"))))
 
     ;; Return pointer to the toolbar widget.
     *toolbar))

--- a/libleptongui/scheme/schematic/toolbar.scm
+++ b/libleptongui/scheme/schematic/toolbar.scm
@@ -84,8 +84,8 @@
 ;;; tooltip that pops up when the mouse cursor is over the button.
 ;;; CALLBACK is a Scheme procedure to run when the user clicks the
 ;;; button.  POSITION is a number defining the place of the button
-;;; in the toolbar it should be insert to.
-(define (make-toolbar-button *window *toolbar icon label tooltip callback position)
+;;; in the toolbar it should be insert to (0: prepend, -1:  append).
+(define* (make-toolbar-button *window *toolbar icon label tooltip callback #:optional (position -1))
   (let ((*button (schematic_toolbar_button_new)))
     (set-button-icon! *button icon)
     (set-button-label! *button label)
@@ -98,7 +98,7 @@
 ;;; Creates and returns a toolbar radio button.  *GROUP is a group
 ;;; to insert the radio button to.  Other parameters are the same
 ;;; with those for make-toolbar-button().
-(define (make-toolbar-radio-button *group *window *toolbar icon label tooltip callback position)
+(define* (make-toolbar-radio-button *group *window *toolbar icon label tooltip callback #:optional (position -1))
   (let ((*button (schematic_toolbar_radio_button_new)))
     (schematic_toolbar_radio_button_set_group *button *group)
     (set-button-icon! *button icon)
@@ -122,36 +122,31 @@
                          "document-new"
                          "New"
                          "New file"
-                         callback-file-new
-                         0)
+                         callback-file-new)
     (make-toolbar-button *window
                          *toolbar
                          "document-open"
                          "Open"
                          "Open file"
-                         callback-file-open
-                         1)
+                         callback-file-open)
     (make-toolbar-button *window *toolbar
                          "document-save"
                          "Save"
                          "Save file"
-                         i_callback_file_save
-                         2)
+                         i_callback_file_save)
     (make-toolbar-separator *toolbar)
     (make-toolbar-button *window
                          *toolbar
                          "edit-undo"
                          "Undo"
                          "Undo last operation"
-                         callback-edit-undo
-                         4)
+                         callback-edit-undo)
     (make-toolbar-button *window
                          *toolbar
                          "edit-redo"
                          "Redo"
                          "Redo last undo"
-                         callback-edit-redo
-                         5)
+                         callback-edit-redo)
     (make-toolbar-separator *toolbar)
     (make-toolbar-button *window
                          *toolbar
@@ -162,8 +157,7 @@
                           Select library and component from list, move\n~
                           the mouse into main window, click to place.\n~
                           Right mouse button to cancel.")
-                         callback-add-component
-                         7)
+                         callback-add-component)
 
     (let* ((*radio-button
             (make-toolbar-radio-button %null-pointer
@@ -174,8 +168,7 @@
                                        (format #f
                                        "Add nets mode\n~
                                         Right mouse button to cancel")
-                                       callback-toolbar-add-net
-                                       8))
+                                       callback-toolbar-add-net))
            (*radio-group (schematic_toolbar_radio_button_get_group *radio-button)))
 
       (let* ((*radio-button
@@ -187,8 +180,7 @@
                                          (format #f
                                          "Add buses mode\n~
                                           Right mouse button to cancel")
-                                         callback-toolbar-add-bus
-                                         9))
+                                         callback-toolbar-add-bus))
              (*radio-group (schematic_toolbar_radio_button_get_group *radio-button)))
 
         (make-toolbar-button *window
@@ -196,8 +188,7 @@
                              "insert-text"
                              "Text"
                              "Add Text..."
-                             callback-add-text
-                             10)
+                             callback-add-text)
         (make-toolbar-separator *toolbar)
 
 
@@ -208,8 +199,7 @@
                                           "select"
                                           "Select"
                                           "Select mode"
-                                          callback-toolbar-edit-select
-                                          12)))
+                                          callback-toolbar-edit-select)))
 
           (make-toolbar-separator *toolbar)
           ;; Activate 'select' button at start-up.

--- a/libleptongui/scheme/schematic/toolbar.scm
+++ b/libleptongui/scheme/schematic/toolbar.scm
@@ -157,7 +157,15 @@
                           Select library and component from list, move\n~
                           the mouse into main window, click to place.\n~
                           Right mouse button to cancel.")
-                         callback-add-component)
+                          callback-add-component)
+
+    (make-toolbar-button *window
+                          *toolbar
+                          "insert-text"
+                          "Text"
+                          "Add Text..."
+                          callback-add-text)
+    (make-toolbar-separator *toolbar)
 
     (let* ((*radio-button
             (make-toolbar-radio-button %null-pointer
@@ -183,14 +191,7 @@
                                          callback-toolbar-add-bus))
              (*radio-group (schematic_toolbar_radio_button_get_group *radio-button)))
 
-        (make-toolbar-button *window
-                             *toolbar
-                             "insert-text"
-                             "Text"
-                             "Add Text..."
-                             callback-add-text)
         (make-toolbar-separator *toolbar)
-
 
         (let ((*radio-button
                (make-toolbar-radio-button *radio-group
@@ -201,7 +202,6 @@
                                           "Select mode"
                                           callback-toolbar-edit-select)))
 
-          (make-toolbar-separator *toolbar)
           ;; Activate 'select' button at start-up.
           (schematic_toolbar_activate_button *radio-button)
 

--- a/libleptongui/scheme/schematic/toolbar.scm
+++ b/libleptongui/scheme/schematic/toolbar.scm
@@ -153,9 +153,11 @@
                          *toolbar
                          "insert-symbol"
                          "Component"
-                         "Add component...
-Select library and component from list, move the mouse into main window, click to place.
-Right mouse button to cancel"
+                         (format #f
+                         "Add component...\n~
+                          Select library and component from list, move\n~
+                          the mouse into main window, click to place.\n~
+                          Right mouse button to cancel.")
                          callback-add-component
                          7)
 
@@ -165,8 +167,9 @@ Right mouse button to cancel"
                                        *toolbar
                                        "insert-net"
                                        "Nets"
-                                       "Add nets mode
-Right mouse button to cancel"
+                                       (format #f
+                                       "Add nets mode\n~
+                                        Right mouse button to cancel")
                                        callback-toolbar-add-net
                                        8))
            (*radio-group (schematic_toolbar_radio_button_get_group *radio-button)))
@@ -177,8 +180,9 @@ Right mouse button to cancel"
                                          *toolbar
                                          "insert-bus"
                                          "Bus"
-                                         "Add buses mode
-Right mouse button to cancel"
+                                         (format #f
+                                         "Add buses mode\n~
+                                          Right mouse button to cancel")
                                          callback-toolbar-add-bus
                                          9))
              (*radio-group (schematic_toolbar_radio_button_get_group *radio-button)))

--- a/libleptongui/scheme/schematic/toolbar.scm
+++ b/libleptongui/scheme/schematic/toolbar.scm
@@ -109,6 +109,10 @@
     *button))
 
 
+(define* (make-toolbar-separator *toolbar #:optional (position -1))
+  (schematic_toolbar_insert_separator *toolbar position))
+
+
 (define (make-toolbar *window *main-box)
   "Creates a new toolbar widget for *WINDOW, inserting it in the
 *MAINBOX widget."
@@ -133,7 +137,7 @@
                          "Save file"
                          i_callback_file_save
                          2)
-    (schematic_toolbar_insert_separator *toolbar 3)
+    (make-toolbar-separator *toolbar)
     (make-toolbar-button *window
                          *toolbar
                          "edit-undo"
@@ -148,7 +152,7 @@
                          "Redo last undo"
                          callback-edit-redo
                          5)
-    (schematic_toolbar_insert_separator *toolbar 6)
+    (make-toolbar-separator *toolbar)
     (make-toolbar-button *window
                          *toolbar
                          "insert-symbol"
@@ -194,7 +198,7 @@
                              "Add Text..."
                              callback-add-text
                              10)
-        (schematic_toolbar_insert_separator *toolbar 11)
+        (make-toolbar-separator *toolbar)
 
 
         (let ((*radio-button
@@ -207,7 +211,7 @@
                                           callback-toolbar-edit-select
                                           12)))
 
-          (schematic_toolbar_insert_separator *toolbar 13)
+          (make-toolbar-separator *toolbar)
           ;; Activate 'select' button at start-up.
           (schematic_toolbar_activate_button *radio-button)
 


### PR DESCRIPTION
- *append* toolbar items by default; no need to supply index
- easily add radio buttons: automatically assign radio group
- add `radio-group-end()`: ends the group and sets the active button
- add `make-toolbar-separator()`
- make `g_action_eval_by_name()` accessible in Scheme
- add 2 new toolbar buttons: "Down Schematic", "Down Symbol"
- move the "Add Text..." button, so that radio buttons for
  adding nets, buses and select are grouped together.
What other actions should be added to the toolbar?
(I don't use it at all).

![tb_369_toolbar](https://github.com/lepton-eda/lepton-eda/assets/26083750/60dff048-f6f0-41cd-8679-ddff9b272abf)
