### PR TITLE
Add a schematic gtk helper function

### DIFF
--- a/libleptongui/include/Makefile.am
+++ b/libleptongui/include/Makefile.am
@@ -2,6 +2,7 @@ noinst_HEADERS = \
 	action_mode.h \
 	globals.h \
 	grid_mode.h \
+	gtk_helper.h \
 	i_vars.h \
 	prototype.h \
 	x_dialog.h \

--- a/libleptongui/include/gschem.h
+++ b/libleptongui/include/gschem.h
@@ -17,6 +17,7 @@ typedef struct st_gschem_toplevel GschemToplevel;
 /* gschem headers */
 #include "action_mode.h"
 #include "grid_mode.h"
+#include "gtk_helper.h"
 #include "snap_mode.h"
 #include "gschem_defines.h"
 #include "gschem_bin.h"

--- a/libleptongui/include/gtk_helper.h
+++ b/libleptongui/include/gtk_helper.h
@@ -1,0 +1,29 @@
+/* Lepton EDA Schematic Capture
+ * Copyright (C) 2023 Lepton EDA Contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef GTK_HELPER_H
+#define GTK_HELPER_H
+
+G_BEGIN_DECLS
+
+const char*
+gtk_response_to_string (int response);
+
+G_END_DECLS
+
+#endif /* GTK_HELPER_H */

--- a/libleptongui/scheme/Makefile.am
+++ b/libleptongui/scheme/Makefile.am
@@ -28,6 +28,7 @@ nobase_dist_scmdata_DATA = \
 	schematic/ffi/gobject.scm \
 	schematic/ffi/gtk.scm \
 	schematic/doc.scm \
+	schematic/gtk/helper.scm \
 	schematic/gui/keymap.scm \
 	schematic/gui/stroke.scm \
 	schematic/hook.scm \

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -32,6 +32,8 @@
 
             g_read_file
 
+            gtk_response_to_string
+
             generic_confirm_dialog
             generic_error_dialog
             generic_filesel_dialog
@@ -517,6 +519,9 @@
 
 ;;; g_window.c
 (define-lff g_init_window void '(*))
+
+;;; gtk_helper.c
+(define-lff gtk_response_to_string '* (list int))
 
 ;;; o_attrib.c
 (define-lff o_attrib_add_attrib '* (list '* '* int int '* int int int))

--- a/libleptongui/scheme/schematic/gtk/helper.scm
+++ b/libleptongui/scheme/schematic/gtk/helper.scm
@@ -1,0 +1,28 @@
+;;; Lepton EDA Schematic Capture
+;;; Scheme API
+;;; Copyright (C) 2023 Lepton EDA Contributors
+;;;
+;;; This program is free software; you can redistribute it and/or modify
+;;; it under the terms of the GNU General Public License as published by
+;;; the Free Software Foundation; either version 2 of the License, or
+;;; (at your option) any later version.
+;;;
+;;; This program is distributed in the hope that it will be useful,
+;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;; GNU General Public License for more details.
+;;;
+;;; You should have received a copy of the GNU General Public License
+;;; along with this program; if not, write to the Free Software
+;;; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+(define-module (schematic gtk helper)
+  #:use-module (system foreign)
+
+  #:use-module (schematic ffi)
+
+  #:export (gtk-response->symbol))
+
+(define (gtk-response->symbol response)
+  "Transforms GtkResponse integer RESPONSE to Scheme symbol."
+  (string->symbol (pointer->string (gtk_response_to_string response))))

--- a/libleptongui/src/Makefile.am
+++ b/libleptongui/src/Makefile.am
@@ -9,6 +9,7 @@ libleptongui_la_SOURCES = \
 	g_window.c \
 	globals.c \
 	grid_mode.c \
+	gtk_helper.c \
 	lepton-schematic.c \
 	gschemhotkeystore.c \
 	gschem_about_dialog.c \

--- a/libleptongui/src/gtk_helper.c
+++ b/libleptongui/src/gtk_helper.c
@@ -1,0 +1,61 @@
+/* Lepton EDA Schematic Capture
+ * Copyright (C) 2023 Lepton EDA Contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/*!
+ * \file gtk_helper.c
+ *
+ * \brief GTK helper functions.
+ *
+ */
+
+#include <config.h>
+
+#include "gschem.h"
+
+/*! \brief Transform a GTK response id value to string.
+ * \par Function Description
+ * Given a GTK response type id \a response, returns the string
+ * corresponding to it.  This is mainly intended to be used for
+ * value conversion in Scheme FFI functions.
+ *
+ * \param [in] response The response id.
+ * \return The string corresponding to the id.
+ */
+const char*
+gtk_response_to_string (int response)
+{
+  const char *result = "unknown";
+
+  switch (response)
+  {
+  case GTK_RESPONSE_NONE: result = "none"; break;
+  case GTK_RESPONSE_REJECT: result = "reject"; break;
+  case GTK_RESPONSE_ACCEPT: result = "accept"; break;
+  case GTK_RESPONSE_DELETE_EVENT: result = "delete-event"; break;
+  case GTK_RESPONSE_OK: result = "ok"; break;
+  case GTK_RESPONSE_CANCEL: result = "cancel"; break;
+  case GTK_RESPONSE_CLOSE: result = "close"; break;
+  case GTK_RESPONSE_YES: result = "yes"; break;
+  case GTK_RESPONSE_NO: result = "no"; break;
+  case GTK_RESPONSE_APPLY: result = "apply"; break;
+  case GTK_RESPONSE_HELP: result = "help"; break;
+  default: break;
+  }
+
+  return result;
+}


### PR DESCRIPTION
The function transforms widget response signals to strings which is useful for working with `lepton-schematic` widgets in Scheme, especially for refactoring their code.