### PR TITLE
sch2pcb: Avoid test failures when component library functions are used in gafrc.

### DIFF
--- a/tools/cli/scheme/lepton-export.scm
+++ b/tools/cli/scheme/lepton-export.scm
@@ -1,7 +1,7 @@
 ;;; Lepton EDA command-line utility
 ;;; Copyright (C) 2012 Peter Brett <peter@peter-b.co.uk>
 ;;; Copyright (C) 2014-2016 gEDA Contributors
-;;; Copyright (C) 2017-2022 Lepton EDA Contributors
+;;; Copyright (C) 2017-2023 Lepton EDA Contributors
 ;;;
 ;;; This program is free software; you can redistribute it and/or modify
 ;;; it under the terms of the GNU General Public License as published by
@@ -21,6 +21,7 @@
              (system foreign)
              (lepton ffi)
              (lepton gettext)
+             (lepton library)
              (lepton page)
              (lepton rc)
              (lepton srfi-37)

--- a/tools/cli/scheme/lepton-shell.scm
+++ b/tools/cli/scheme/lepton-shell.scm
@@ -1,7 +1,7 @@
 ;;; Lepton EDA command-line utility
 ;;; Copyright (C) 2012-2013 Peter Brett <peter@peter-b.co.uk>
 ;;; Copyright (C) 2012-2014 gEDA Contributors
-;;; Copyright (C) 2017-2022 Lepton EDA Contributors
+;;; Copyright (C) 2017-2023 Lepton EDA Contributors
 ;;;
 ;;; This program is free software; you can redistribute it and/or modify
 ;;; it under the terms of the GNU General Public License as published by
@@ -21,6 +21,7 @@
              (ice-9 readline)
              (lepton ffi)
              (lepton gettext)
+             (lepton library)
              (lepton rc)
              (lepton repl)
              (lepton srfi-37)


### PR DESCRIPTION
Recently, I suddenly found, that Lepton test suite fails if I have in my `~/.config/lepton-eda/gafrc` the following line:
`(component-library-search "~/lepton/symbols")`

As it stands out, two of our tools, namely `lepton-export` and `lepton-shell` cannot survive `make distcheck` tests with this configuration setting.

The branch fixes this by exporting the `(lepton library)` module in both tools.
