### PR TITLE
sch2pcb-prune-elements() preparation for rewriting in Scheme

### DIFF
--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -295,10 +295,7 @@ void
 sch2pcb_pcb_element_list_append (PcbElement *element);
 
 void
-sch2pcb_prune_elements (gchar *pcb_file,
-                        gchar *bak,
-                        gchar *tmp,
-                        FILE *f_in,
+sch2pcb_prune_elements (FILE *f_in,
                         FILE *f_out);
 gint
 sch2pcb_get_verbose_mode ();

--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -298,7 +298,8 @@ void
 sch2pcb_prune_elements (gchar *pcb_file,
                         gchar *bak,
                         gchar *tmp,
-                        FILE *f_in);
+                        FILE *f_in,
+                        FILE *f_out);
 gint
 sch2pcb_get_verbose_mode ();
 

--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -298,9 +298,6 @@ gboolean
 sch2pcb_prune_element (FILE *f_out,
                        char *buf,
                        gboolean skipping);
-void
-sch2pcb_prune_elements (FILE *f_in,
-                        FILE *f_out);
 gint
 sch2pcb_get_verbose_mode ();
 

--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -297,6 +297,7 @@ sch2pcb_pcb_element_list_append (PcbElement *element);
 void
 sch2pcb_prune_elements (gchar *pcb_file,
                         gchar *bak,
+                        gchar *tmp,
                         FILE *f_in);
 gint
 sch2pcb_get_verbose_mode ();

--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -297,6 +297,7 @@ sch2pcb_pcb_element_list_append (PcbElement *element);
 gboolean
 sch2pcb_prune_element (FILE *f_out,
                        char *buf,
+                       char *s,
                        gboolean skipping);
 gint
 sch2pcb_get_verbose_mode ();

--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -296,7 +296,8 @@ sch2pcb_pcb_element_list_append (PcbElement *element);
 
 void
 sch2pcb_prune_elements (gchar *pcb_file,
-                        gchar *bak);
+                        gchar *bak,
+                        FILE *f_in);
 gint
 sch2pcb_get_verbose_mode ();
 

--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -294,6 +294,10 @@ sch2pcb_parse_schematics (char *str);
 void
 sch2pcb_pcb_element_list_append (PcbElement *element);
 
+gboolean
+sch2pcb_prune_element (FILE *f_out,
+                       char *buf,
+                       gboolean skipping);
 void
 sch2pcb_prune_elements (FILE *f_in,
                         FILE *f_out);

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -123,7 +123,7 @@
 (define-lff sch2pcb_pcb_element_list_append void '(*))
 (define-lff sch2pcb_get_preserve int '())
 (define-lff sch2pcb_set_preserve void (list int))
-(define-lff sch2pcb_prune_elements void '(* * * * *))
+(define-lff sch2pcb_prune_elements void '(* *))
 (define-lff sch2pcb_get_verbose_mode int '())
 (define-lff sch2pcb_open_file_to_read '* '(*))
 (define-lff sch2pcb_open_file_to_write '* '(*))

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -123,7 +123,7 @@
 (define-lff sch2pcb_pcb_element_list_append void '(*))
 (define-lff sch2pcb_get_preserve int '())
 (define-lff sch2pcb_set_preserve void (list int))
-(define-lff sch2pcb_prune_elements void '(* * *))
+(define-lff sch2pcb_prune_elements void '(* * * *))
 (define-lff sch2pcb_get_verbose_mode int '())
 (define-lff sch2pcb_open_file_to_read '* '(*))
 (define-lff sch2pcb_open_file_to_write '* '(*))

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -25,6 +25,7 @@
   #:export (pcb_element_exists
             pcb_element_free
             pcb_element_get_changed_description
+            pcb_element_get_changed_value
             pcb_element_get_description
             pcb_element_get_flags
             pcb_element_get_omit_PKG
@@ -32,6 +33,7 @@
             pcb_element_get_quoted_flags
             pcb_element_get_refdes
             pcb_element_get_res_char
+            pcb_element_get_still_exists
             pcb_element_set_still_exists
             pcb_element_get_tail
             pcb_element_get_value
@@ -50,16 +52,20 @@
             sch2pcb_insert_element
             sch2pcb_get_n_PKG_removed_old
             sch2pcb_get_n_changed_value
+            sch2pcb_set_n_changed_value
             sch2pcb_get_n_deleted
+            sch2pcb_set_n_deleted
             sch2pcb_get_n_empty
             sch2pcb_get_n_none
             sch2pcb_get_n_preserved
+            sch2pcb_set_n_preserved
             sch2pcb_get_n_unknown
             sch2pcb_get_need_PKG_purge
             sch2pcb_set_need_PKG_purge
             sch2pcb_parse_schematics
             sch2pcb_get_pcb_element_list
             sch2pcb_pcb_element_list_append
+            sch2pcb_get_preserve
             sch2pcb_set_preserve
             sch2pcb_prune_elements
             sch2pcb_get_verbose_mode
@@ -75,6 +81,7 @@
 (define-lff pcb_element_exists '* (list '* int))
 (define-lff pcb_element_free void '(*))
 (define-lff pcb_element_get_changed_description '* '(*))
+(define-lff pcb_element_get_changed_value '* '(*))
 (define-lff pcb_element_get_description '* '(*))
 (define-lff pcb_element_get_flags '* '(*))
 (define-lff pcb_element_get_omit_PKG int '(*))
@@ -82,6 +89,7 @@
 (define-lff pcb_element_get_quoted_flags int '(*))
 (define-lff pcb_element_get_refdes '* '(*))
 (define-lff pcb_element_get_res_char int '(*))
+(define-lff pcb_element_get_still_exists int '(*))
 (define-lff pcb_element_set_still_exists void (list '* int))
 (define-lff pcb_element_get_tail '* '(*))
 (define-lff pcb_element_get_value '* '(*))
@@ -100,16 +108,20 @@
 (define-lff sch2pcb_insert_element int '(* * * * *))
 (define-lff sch2pcb_get_n_PKG_removed_old int '())
 (define-lff sch2pcb_get_n_changed_value int '())
+(define-lff sch2pcb_set_n_changed_value void (list int))
 (define-lff sch2pcb_get_n_deleted int '())
+(define-lff sch2pcb_set_n_deleted void (list int))
 (define-lff sch2pcb_get_n_empty int '())
 (define-lff sch2pcb_get_n_none int '())
 (define-lff sch2pcb_get_n_preserved int '())
+(define-lff sch2pcb_set_n_preserved void (list int))
 (define-lff sch2pcb_get_n_unknown int '())
 (define-lff sch2pcb_get_need_PKG_purge int '())
 (define-lff sch2pcb_set_need_PKG_purge void (list int))
 (define-lff sch2pcb_parse_schematics '* '(*))
 (define-lff sch2pcb_get_pcb_element_list '* '())
 (define-lff sch2pcb_pcb_element_list_append void '(*))
+(define-lff sch2pcb_get_preserve int '())
 (define-lff sch2pcb_set_preserve void (list int))
 (define-lff sch2pcb_prune_elements void '(* *))
 (define-lff sch2pcb_get_verbose_mode int '())

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -123,7 +123,7 @@
 (define-lff sch2pcb_pcb_element_list_append void '(*))
 (define-lff sch2pcb_get_preserve int '())
 (define-lff sch2pcb_set_preserve void (list int))
-(define-lff sch2pcb_prune_elements void '(* * * *))
+(define-lff sch2pcb_prune_elements void '(* * * * *))
 (define-lff sch2pcb_get_verbose_mode int '())
 (define-lff sch2pcb_open_file_to_read '* '(*))
 (define-lff sch2pcb_open_file_to_write '* '(*))

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -123,7 +123,7 @@
 (define-lff sch2pcb_pcb_element_list_append void '(*))
 (define-lff sch2pcb_get_preserve int '())
 (define-lff sch2pcb_set_preserve void (list int))
-(define-lff sch2pcb_prune_element int (list '* '* int))
+(define-lff sch2pcb_prune_element int (list '* '* '* int))
 (define-lff sch2pcb_get_verbose_mode int '())
 (define-lff sch2pcb_open_file_to_read '* '(*))
 (define-lff sch2pcb_open_file_to_write '* '(*))

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -68,7 +68,6 @@
             sch2pcb_get_preserve
             sch2pcb_set_preserve
             sch2pcb_prune_element
-            sch2pcb_prune_elements
             sch2pcb_get_verbose_mode
             sch2pcb_open_file_to_read
             sch2pcb_open_file_to_write
@@ -125,7 +124,6 @@
 (define-lff sch2pcb_get_preserve int '())
 (define-lff sch2pcb_set_preserve void (list int))
 (define-lff sch2pcb_prune_element int (list '* '* int))
-(define-lff sch2pcb_prune_elements void '(* *))
 (define-lff sch2pcb_get_verbose_mode int '())
 (define-lff sch2pcb_open_file_to_read '* '(*))
 (define-lff sch2pcb_open_file_to_write '* '(*))

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -67,6 +67,7 @@
             sch2pcb_pcb_element_list_append
             sch2pcb_get_preserve
             sch2pcb_set_preserve
+            sch2pcb_prune_element
             sch2pcb_prune_elements
             sch2pcb_get_verbose_mode
             sch2pcb_open_file_to_read
@@ -123,6 +124,7 @@
 (define-lff sch2pcb_pcb_element_list_append void '(*))
 (define-lff sch2pcb_get_preserve int '())
 (define-lff sch2pcb_set_preserve void (list int))
+(define-lff sch2pcb_prune_element int (list '* '* int))
 (define-lff sch2pcb_prune_elements void '(* *))
 (define-lff sch2pcb_get_verbose_mode int '())
 (define-lff sch2pcb_open_file_to_read '* '(*))

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -123,7 +123,7 @@
 (define-lff sch2pcb_pcb_element_list_append void '(*))
 (define-lff sch2pcb_get_preserve int '())
 (define-lff sch2pcb_set_preserve void (list int))
-(define-lff sch2pcb_prune_elements void '(* *))
+(define-lff sch2pcb_prune_elements void '(* * *))
 (define-lff sch2pcb_get_verbose_mode int '())
 (define-lff sch2pcb_open_file_to_read '* '(*))
 (define-lff sch2pcb_open_file_to_write '* '(*))

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1069,11 +1069,12 @@ sch2pcb_prune_elements (gchar *pcb_file,
           && sch2pcb_get_n_changed_value () == 0)
     )
     return;
-  if ((f_in = fopen (pcb_file, "r")) == NULL)
+  if ((f_in = sch2pcb_open_file_to_read (pcb_file)) == NULL)
     return;
   tmp = g_strconcat (pcb_file, ".tmp", NULL);
-  if ((f_out = fopen (tmp, "wb")) == NULL) {
-    fclose (f_in);
+  if ((f_out = sch2pcb_open_file_to_write (tmp)) == NULL)
+  {
+    sch2pcb_close_file (f_in);
     return;
   }
   while ((fgets (buf, sizeof (buf), f_in)) != NULL) {
@@ -1122,8 +1123,8 @@ sch2pcb_prune_elements (gchar *pcb_file,
       fputs (buf, f_out);
     pcb_element_free (el);
   }
-  fclose (f_in);
-  fclose (f_out);
+  sch2pcb_close_file (f_in);
+  sch2pcb_close_file (f_out);
 
   if (!sch2pcb_get_bak_done ())
   {

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1032,16 +1032,15 @@ sch2pcb_buffer_to_file (char *buffer,
 
 void
 sch2pcb_prune_elements (gchar *pcb_file,
-                        gchar *bak)
+                        gchar *bak,
+                        FILE *f_in)
 {
-  FILE *f_in, *f_out;
+  FILE *f_out;
   PcbElement *el, *el_exists;
   gchar *fmt, *tmp, *s, buf[1024];
   gint paren_level = 0;
   gboolean skipping = FALSE;
 
-  if ((f_in = sch2pcb_open_file_to_read (pcb_file)) == NULL)
-    return;
   tmp = g_strconcat (pcb_file, ".tmp", NULL);
   if ((f_out = sch2pcb_open_file_to_write (tmp)) == NULL)
   {

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1105,7 +1105,7 @@ sch2pcb_prune_elements (gchar *pcb_file,
                       "Element%c\"%s\" \"%s\" \"%s\" \"%s\" %s %s%s\n" :
                       "Element%c%s \"%s\" \"%s\" \"%s\" %s %s%s\n");
       fprintf (f_out, fmt,
-               el->res_char, el->flags, pcb_element_get_description (el), pcb_element_get_refdes (el),
+               el->res_char, pcb_element_get_flags (el), pcb_element_get_description (el), pcb_element_get_refdes (el),
                pcb_element_get_changed_value (el_exists), el->x, el->y, el->tail);
       if (sch2pcb_get_verbose_mode () != 0)
         printf ("%s: changed element %s value: %s -> %s\n",

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1079,7 +1079,7 @@ sch2pcb_prune_elements (gchar *pcb_file,
         && (el_exists = pcb_element_exists (el, FALSE)) != NULL
         && !el_exists->still_exists && !preserve) {
       skipping = TRUE;
-      if (verbose)
+      if (sch2pcb_get_verbose_mode () != 0)
         printf ("%s: deleted element %s (value=%s)\n",
                 el->refdes, el->description, el->value);
       pcb_element_free (el);
@@ -1092,7 +1092,7 @@ sch2pcb_prune_elements (gchar *pcb_file,
       fprintf (f_out, fmt,
                el->res_char, el->flags, el->description, el->refdes,
                el_exists->changed_value, el->x, el->y, el->tail);
-      if (verbose)
+      if (sch2pcb_get_verbose_mode () != 0)
         printf ("%s: changed element %s value: %s -> %s\n",
                 el->refdes, el->description,
                 el->value, el_exists->changed_value);

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1105,7 +1105,7 @@ sch2pcb_prune_elements (gchar *pcb_file,
                       "Element%c\"%s\" \"%s\" \"%s\" \"%s\" %s %s%s\n" :
                       "Element%c%s \"%s\" \"%s\" \"%s\" %s %s%s\n");
       fprintf (f_out, fmt,
-               el->res_char, pcb_element_get_flags (el), pcb_element_get_description (el), pcb_element_get_refdes (el),
+               pcb_element_get_res_char (el), pcb_element_get_flags (el), pcb_element_get_description (el), pcb_element_get_refdes (el),
                pcb_element_get_changed_value (el_exists), pcb_element_get_x (el), pcb_element_get_y (el), pcb_element_get_tail (el));
       if (sch2pcb_get_verbose_mode () != 0)
         printf ("%s: changed element %s value: %s -> %s\n",

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1108,8 +1108,11 @@ sch2pcb_prune_elements (gchar *pcb_file,
         printf ("%s: changed element %s value: %s -> %s\n",
                 el->refdes, el->description,
                 el->value, el_exists->changed_value);
-    } else if (!strncmp (s, "PKG_", 4))
-      ++n_PKG_removed_old;
+    } else
+      if (!strncmp (s, "PKG_", 4))
+      {
+        sch2pcb_set_n_PKG_removed_old (1 + sch2pcb_get_n_PKG_removed_old ());
+      }
     else
       fputs (buf, f_out);
     pcb_element_free (el);

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1055,8 +1055,12 @@ sch2pcb_prune_elements (gchar *pcb_file,
       {
         sch2pcb_set_n_deleted (1 + sch2pcb_get_n_deleted ());
       }
-    } else if (el->changed_value)
-      ++n_changed_value;
+    }
+    else
+      if (el->changed_value)
+      {
+        sch2pcb_set_n_changed_value (1 + sch2pcb_get_n_changed_value ());
+      }
   }
   if (!pcb_element_list
       || (sch2pcb_get_n_deleted () == 0

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1060,7 +1060,7 @@ sch2pcb_prune_elements (gchar *pcb_file,
   }
   if (!pcb_element_list
       || (sch2pcb_get_n_deleted () == 0
-          && !need_PKG_purge
+          && !sch2pcb_get_need_PKG_purge ()
           && n_changed_value == 0)
     )
     return;

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1106,7 +1106,7 @@ sch2pcb_prune_elements (gchar *pcb_file,
                       "Element%c%s \"%s\" \"%s\" \"%s\" %s %s%s\n");
       fprintf (f_out, fmt,
                el->res_char, pcb_element_get_flags (el), pcb_element_get_description (el), pcb_element_get_refdes (el),
-               pcb_element_get_changed_value (el_exists), el->x, el->y, el->tail);
+               pcb_element_get_changed_value (el_exists), el->x, el->y, pcb_element_get_tail (el));
       if (sch2pcb_get_verbose_mode () != 0)
         printf ("%s: changed element %s value: %s -> %s\n",
                 pcb_element_get_refdes (el),

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1120,7 +1120,7 @@ sch2pcb_prune_elements (gchar *pcb_file,
         sch2pcb_set_n_PKG_removed_old (1 + sch2pcb_get_n_PKG_removed_old ());
       }
     else
-      fputs (buf, f_out);
+      sch2pcb_buffer_to_file (buf, f_out);
     pcb_element_free (el);
   }
   sch2pcb_close_file (f_in);

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1125,9 +1125,10 @@ sch2pcb_prune_elements (gchar *pcb_file,
   fclose (f_in);
   fclose (f_out);
 
-  if (!bak_done) {
+  if (!sch2pcb_get_bak_done ())
+  {
     build_and_run_command ("mv %s %s", pcb_file, bak);
-    bak_done = TRUE;
+    sch2pcb_set_bak_done (TRUE);
   }
 
   build_and_run_command ("mv %s %s", tmp, pcb_file);

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1043,7 +1043,7 @@ sch2pcb_prune_elements (gchar *pcb_file,
 
   for (list = pcb_element_list; list; list = g_list_next (list)) {
     el = (PcbElement *) list->data;
-    if (!el->still_exists) {
+    if (!pcb_element_get_still_exists (el)) {
       if (sch2pcb_get_preserve ())
       {
         sch2pcb_set_n_preserved (1 + sch2pcb_get_n_preserved ());
@@ -1088,7 +1088,7 @@ sch2pcb_prune_elements (gchar *pcb_file,
     el_exists = NULL;
     if ((el = pcb_element_line_parse (s)) != NULL
         && (el_exists = pcb_element_exists (el, FALSE)) != NULL
-        && !el_exists->still_exists
+        && !pcb_element_get_still_exists (el_exists)
         && !sch2pcb_get_preserve ())
       {
       skipping = TRUE;

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1050,7 +1050,7 @@ sch2pcb_prune_elements (gchar *pcb_file,
         fprintf (stderr,
                  "Preserving PCB element not in the schematic:    %s (element   %s)\n",
                  pcb_element_get_refdes (el),
-                 el->description);
+                 pcb_element_get_description (el));
       }
       else
       {
@@ -1095,7 +1095,7 @@ sch2pcb_prune_elements (gchar *pcb_file,
       if (sch2pcb_get_verbose_mode () != 0)
         printf ("%s: deleted element %s (value=%s)\n",
                 pcb_element_get_refdes (el),
-                el->description,
+                pcb_element_get_description (el),
                 pcb_element_get_value (el));
       pcb_element_free (el);
       continue;
@@ -1105,12 +1105,12 @@ sch2pcb_prune_elements (gchar *pcb_file,
                       "Element%c\"%s\" \"%s\" \"%s\" \"%s\" %s %s%s\n" :
                       "Element%c%s \"%s\" \"%s\" \"%s\" %s %s%s\n");
       fprintf (f_out, fmt,
-               el->res_char, el->flags, el->description, pcb_element_get_refdes (el),
+               el->res_char, el->flags, pcb_element_get_description (el), pcb_element_get_refdes (el),
                el_exists->changed_value, el->x, el->y, el->tail);
       if (sch2pcb_get_verbose_mode () != 0)
         printf ("%s: changed element %s value: %s -> %s\n",
                 pcb_element_get_refdes (el),
-                el->description,
+                pcb_element_get_description (el),
                 pcb_element_get_value (el),
                 el_exists->changed_value);
     } else

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -928,13 +928,18 @@ sch2pcb_buffer_to_file (char *buffer,
 }
 
 
+/* The variable is used in the function below.  Moving it outwards
+ * is required to avoid overcomplicated code which would deal with
+ * several in-out function arguments.  */
+static int paren_level = 0;
+
+
 void
 sch2pcb_prune_elements (FILE *f_in,
                         FILE *f_out)
 {
   PcbElement *el, *el_exists;
   gchar *fmt, *s, buf[1024];
-  gint paren_level = 0;
   gboolean skipping = FALSE;
 
   while ((fgets (buf, sizeof (buf), f_in)) != NULL) {

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1050,13 +1050,18 @@ sch2pcb_prune_elements (gchar *pcb_file,
         fprintf (stderr,
                  "Preserving PCB element not in the schematic:    %s (element   %s)\n",
                  el->refdes, el->description);
-      } else
-        ++n_deleted;
+      }
+      else
+      {
+        sch2pcb_set_n_deleted (1 + sch2pcb_get_n_deleted ());
+      }
     } else if (el->changed_value)
       ++n_changed_value;
   }
   if (!pcb_element_list
-      || (n_deleted == 0 && !need_PKG_purge && n_changed_value == 0)
+      || (sch2pcb_get_n_deleted () == 0
+          && !need_PKG_purge
+          && n_changed_value == 0)
     )
     return;
   if ((f_in = fopen (pcb_file, "r")) == NULL)

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1033,15 +1033,15 @@ sch2pcb_buffer_to_file (char *buffer,
 void
 sch2pcb_prune_elements (gchar *pcb_file,
                         gchar *bak,
+                        gchar *tmp,
                         FILE *f_in)
 {
   FILE *f_out;
   PcbElement *el, *el_exists;
-  gchar *fmt, *tmp, *s, buf[1024];
+  gchar *fmt, *s, buf[1024];
   gint paren_level = 0;
   gboolean skipping = FALSE;
 
-  tmp = g_strconcat (pcb_file, ".tmp", NULL);
   if ((f_out = sch2pcb_open_file_to_write (tmp)) == NULL)
   {
     sch2pcb_close_file (f_in);
@@ -1103,7 +1103,6 @@ sch2pcb_prune_elements (gchar *pcb_file,
   }
 
   build_and_run_command ("mv %s %s", tmp, pcb_file);
-  g_free (tmp);
 }
 
 

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1094,7 +1094,9 @@ sch2pcb_prune_elements (gchar *pcb_file,
       skipping = TRUE;
       if (sch2pcb_get_verbose_mode () != 0)
         printf ("%s: deleted element %s (value=%s)\n",
-                pcb_element_get_refdes (el), el->description, el->value);
+                pcb_element_get_refdes (el),
+                el->description,
+                pcb_element_get_value (el));
       pcb_element_free (el);
       continue;
     }
@@ -1107,8 +1109,10 @@ sch2pcb_prune_elements (gchar *pcb_file,
                el_exists->changed_value, el->x, el->y, el->tail);
       if (sch2pcb_get_verbose_mode () != 0)
         printf ("%s: changed element %s value: %s -> %s\n",
-                pcb_element_get_refdes (el), el->description,
-                el->value, el_exists->changed_value);
+                pcb_element_get_refdes (el),
+                el->description,
+                pcb_element_get_value (el),
+                el_exists->changed_value);
     } else
       if (!strncmp (s, "PKG_", 4))
       {

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1058,7 +1058,7 @@ sch2pcb_prune_elements (gchar *pcb_file,
       }
     }
     else
-      if (el->changed_value)
+      if (pcb_element_get_changed_value (el))
       {
         sch2pcb_set_n_changed_value (1 + sch2pcb_get_n_changed_value ());
       }
@@ -1100,19 +1100,19 @@ sch2pcb_prune_elements (gchar *pcb_file,
       pcb_element_free (el);
       continue;
     }
-    if (el_exists && el_exists->changed_value) {
+    if (el_exists && pcb_element_get_changed_value (el_exists)) {
       fmt = (gchar*) (el->quoted_flags ?
                       "Element%c\"%s\" \"%s\" \"%s\" \"%s\" %s %s%s\n" :
                       "Element%c%s \"%s\" \"%s\" \"%s\" %s %s%s\n");
       fprintf (f_out, fmt,
                el->res_char, el->flags, pcb_element_get_description (el), pcb_element_get_refdes (el),
-               el_exists->changed_value, el->x, el->y, el->tail);
+               pcb_element_get_changed_value (el_exists), el->x, el->y, el->tail);
       if (sch2pcb_get_verbose_mode () != 0)
         printf ("%s: changed element %s value: %s -> %s\n",
                 pcb_element_get_refdes (el),
                 pcb_element_get_description (el),
                 pcb_element_get_value (el),
-                el_exists->changed_value);
+                pcb_element_get_changed_value (el_exists));
     } else
       if (!strncmp (s, "PKG_", 4))
       {

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1011,20 +1011,6 @@ sch2pcb_prune_element (FILE *f_out,
 }
 
 
-void
-sch2pcb_prune_elements (FILE *f_in,
-                        FILE *f_out)
-{
-  gchar buf[1024];
-  gboolean skipping = FALSE;
-
-  while ((fgets (buf, sizeof (buf), f_in)) != NULL)
-  {
-    skipping = sch2pcb_prune_element (f_out, buf, skipping);
-  }
-}
-
-
 GList*
 sch2pcb_parse_schematics (char *str)
 {

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1049,7 +1049,8 @@ sch2pcb_prune_elements (gchar *pcb_file,
         sch2pcb_set_n_preserved (1 + sch2pcb_get_n_preserved ());
         fprintf (stderr,
                  "Preserving PCB element not in the schematic:    %s (element   %s)\n",
-                 el->refdes, el->description);
+                 pcb_element_get_refdes (el),
+                 el->description);
       }
       else
       {
@@ -1093,7 +1094,7 @@ sch2pcb_prune_elements (gchar *pcb_file,
       skipping = TRUE;
       if (sch2pcb_get_verbose_mode () != 0)
         printf ("%s: deleted element %s (value=%s)\n",
-                el->refdes, el->description, el->value);
+                pcb_element_get_refdes (el), el->description, el->value);
       pcb_element_free (el);
       continue;
     }
@@ -1102,11 +1103,11 @@ sch2pcb_prune_elements (gchar *pcb_file,
                       "Element%c\"%s\" \"%s\" \"%s\" \"%s\" %s %s%s\n" :
                       "Element%c%s \"%s\" \"%s\" \"%s\" %s %s%s\n");
       fprintf (f_out, fmt,
-               el->res_char, el->flags, el->description, el->refdes,
+               el->res_char, el->flags, el->description, pcb_element_get_refdes (el),
                el_exists->changed_value, el->x, el->y, el->tail);
       if (sch2pcb_get_verbose_mode () != 0)
         printf ("%s: changed element %s value: %s -> %s\n",
-                el->refdes, el->description,
+                pcb_element_get_refdes (el), el->description,
                 el->value, el_exists->changed_value);
     } else
       if (!strncmp (s, "PKG_", 4))

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1101,7 +1101,7 @@ sch2pcb_prune_elements (gchar *pcb_file,
       continue;
     }
     if (el_exists && pcb_element_get_changed_value (el_exists)) {
-      fmt = (gchar*) (el->quoted_flags ?
+      fmt = (gchar*) (pcb_element_get_quoted_flags (el) ?
                       "Element%c\"%s\" \"%s\" \"%s\" \"%s\" %s %s%s\n" :
                       "Element%c%s \"%s\" \"%s\" \"%s\" %s %s%s\n");
       fprintf (f_out, fmt,

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1034,19 +1034,14 @@ void
 sch2pcb_prune_elements (gchar *pcb_file,
                         gchar *bak,
                         gchar *tmp,
-                        FILE *f_in)
+                        FILE *f_in,
+                        FILE *f_out)
 {
-  FILE *f_out;
   PcbElement *el, *el_exists;
   gchar *fmt, *s, buf[1024];
   gint paren_level = 0;
   gboolean skipping = FALSE;
 
-  if ((f_out = sch2pcb_open_file_to_write (tmp)) == NULL)
-  {
-    sch2pcb_close_file (f_in);
-    return;
-  }
   while ((fgets (buf, sizeof (buf), f_in)) != NULL) {
     for (s = buf; *s == ' ' || *s == '\t'; ++s);
     if (skipping) {

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1041,7 +1041,10 @@ sch2pcb_prune_elements (gchar *pcb_file,
   gint paren_level = 0;
   gboolean skipping = FALSE;
 
-  for (list = pcb_element_list; list; list = g_list_next (list)) {
+  for (list = sch2pcb_get_pcb_element_list ();
+       list;
+       list = g_list_next (list))
+  {
     el = (PcbElement *) list->data;
     if (!pcb_element_get_still_exists (el)) {
       if (sch2pcb_get_preserve ())
@@ -1063,7 +1066,7 @@ sch2pcb_prune_elements (gchar *pcb_file,
         sch2pcb_set_n_changed_value (1 + sch2pcb_get_n_changed_value ());
       }
   }
-  if (!pcb_element_list
+  if (!sch2pcb_get_pcb_element_list ()
       || (sch2pcb_get_n_deleted () == 0
           && !sch2pcb_get_need_PKG_purge ()
           && sch2pcb_get_n_changed_value () == 0)

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1044,7 +1044,8 @@ sch2pcb_prune_elements (gchar *pcb_file,
   for (list = pcb_element_list; list; list = g_list_next (list)) {
     el = (PcbElement *) list->data;
     if (!el->still_exists) {
-      if (preserve) {
+      if (sch2pcb_get_preserve ())
+      {
         ++n_preserved;
         fprintf (stderr,
                  "Preserving PCB element not in the schematic:    %s (element   %s)\n",
@@ -1077,7 +1078,9 @@ sch2pcb_prune_elements (gchar *pcb_file,
     el_exists = NULL;
     if ((el = pcb_element_line_parse (s)) != NULL
         && (el_exists = pcb_element_exists (el, FALSE)) != NULL
-        && !el_exists->still_exists && !preserve) {
+        && !el_exists->still_exists
+        && !sch2pcb_get_preserve ())
+      {
       skipping = TRUE;
       if (sch2pcb_get_verbose_mode () != 0)
         printf ("%s: deleted element %s (value=%s)\n",

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1035,37 +1035,11 @@ sch2pcb_prune_elements (gchar *pcb_file,
                         gchar *bak)
 {
   FILE *f_in, *f_out;
-  GList *list;
   PcbElement *el, *el_exists;
   gchar *fmt, *tmp, *s, buf[1024];
   gint paren_level = 0;
   gboolean skipping = FALSE;
 
-  for (list = sch2pcb_get_pcb_element_list ();
-       list;
-       list = g_list_next (list))
-  {
-    el = (PcbElement *) list->data;
-    if (!pcb_element_get_still_exists (el)) {
-      if (sch2pcb_get_preserve ())
-      {
-        sch2pcb_set_n_preserved (1 + sch2pcb_get_n_preserved ());
-        fprintf (stderr,
-                 "Preserving PCB element not in the schematic:    %s (element   %s)\n",
-                 pcb_element_get_refdes (el),
-                 pcb_element_get_description (el));
-      }
-      else
-      {
-        sch2pcb_set_n_deleted (1 + sch2pcb_get_n_deleted ());
-      }
-    }
-    else
-      if (pcb_element_get_changed_value (el))
-      {
-        sch2pcb_set_n_changed_value (1 + sch2pcb_get_n_changed_value ());
-      }
-  }
   if (!sch2pcb_get_pcb_element_list ()
       || (sch2pcb_get_n_deleted () == 0
           && !sch2pcb_get_need_PKG_purge ()

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1046,7 +1046,7 @@ sch2pcb_prune_elements (gchar *pcb_file,
     if (!el->still_exists) {
       if (sch2pcb_get_preserve ())
       {
-        ++n_preserved;
+        sch2pcb_set_n_preserved (1 + sch2pcb_get_n_preserved ());
         fprintf (stderr,
                  "Preserving PCB element not in the schematic:    %s (element   %s)\n",
                  el->refdes, el->description);

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1106,7 +1106,7 @@ sch2pcb_prune_elements (gchar *pcb_file,
                       "Element%c%s \"%s\" \"%s\" \"%s\" %s %s%s\n");
       fprintf (f_out, fmt,
                el->res_char, pcb_element_get_flags (el), pcb_element_get_description (el), pcb_element_get_refdes (el),
-               pcb_element_get_changed_value (el_exists), pcb_element_get_x (el), el->y, pcb_element_get_tail (el));
+               pcb_element_get_changed_value (el_exists), pcb_element_get_x (el), pcb_element_get_y (el), pcb_element_get_tail (el));
       if (sch2pcb_get_verbose_mode () != 0)
         printf ("%s: changed element %s value: %s -> %s\n",
                 pcb_element_get_refdes (el),

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -937,12 +937,12 @@ static int paren_level = 0;
 gboolean
 sch2pcb_prune_element (FILE *f_out,
                        char *buf,
+                       char *s,
                        gboolean skipping)
 {
   PcbElement *el, *el_exists;
-  gchar *fmt, *s;
+  gchar *fmt;
 
-  for (s = buf; *s == ' ' || *s == '\t'; ++s);
   if (skipping)
   {
     if (*s == '(')

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1061,7 +1061,7 @@ sch2pcb_prune_elements (gchar *pcb_file,
   if (!pcb_element_list
       || (sch2pcb_get_n_deleted () == 0
           && !sch2pcb_get_need_PKG_purge ()
-          && n_changed_value == 0)
+          && sch2pcb_get_n_changed_value () == 0)
     )
     return;
   if ((f_in = fopen (pcb_file, "r")) == NULL)

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1106,7 +1106,7 @@ sch2pcb_prune_elements (gchar *pcb_file,
                       "Element%c%s \"%s\" \"%s\" \"%s\" %s %s%s\n");
       fprintf (f_out, fmt,
                el->res_char, pcb_element_get_flags (el), pcb_element_get_description (el), pcb_element_get_refdes (el),
-               pcb_element_get_changed_value (el_exists), el->x, el->y, pcb_element_get_tail (el));
+               pcb_element_get_changed_value (el_exists), pcb_element_get_x (el), el->y, pcb_element_get_tail (el));
       if (sch2pcb_get_verbose_mode () != 0)
         printf ("%s: changed element %s value: %s -> %s\n",
                 pcb_element_get_refdes (el),

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1040,12 +1040,6 @@ sch2pcb_prune_elements (gchar *pcb_file,
   gint paren_level = 0;
   gboolean skipping = FALSE;
 
-  if (!sch2pcb_get_pcb_element_list ()
-      || (sch2pcb_get_n_deleted () == 0
-          && !sch2pcb_get_need_PKG_purge ()
-          && sch2pcb_get_n_changed_value () == 0)
-    )
-    return;
   if ((f_in = sch2pcb_open_file_to_read (pcb_file)) == NULL)
     return;
   tmp = g_strconcat (pcb_file, ".tmp", NULL);

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -548,9 +548,11 @@
                    (zero? (sch2pcb_get_n_changed_value))))
     (let ((*pcb-file (sch2pcb_open_file_to_read (string->pointer pcb-filename))))
       (unless (null-pointer? *pcb-file)
-        (sch2pcb_prune_elements (string->pointer pcb-filename)
-                                (string->pointer bak-filename)
-                                *pcb-file)))))
+        (let ((tmp-filename (string-append pcb-filename ".tmp")))
+          (sch2pcb_prune_elements (string->pointer pcb-filename)
+                                  (string->pointer bak-filename)
+                                  (string->pointer tmp-filename)
+                                  *pcb-file))))))
 
 
 (define (update-element-descriptions pcb-filename bak-filename)

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -546,8 +546,11 @@
               (and (zero? (sch2pcb_get_n_deleted))
                    (false? (sch2pcb_get_need_PKG_purge))
                    (zero? (sch2pcb_get_n_changed_value))))
-    (sch2pcb_prune_elements (string->pointer pcb-filename)
-                            (string->pointer bak-filename))))
+    (let ((*pcb-file (sch2pcb_open_file_to_read (string->pointer pcb-filename))))
+      (unless (null-pointer? *pcb-file)
+        (sch2pcb_prune_elements (string->pointer pcb-filename)
+                                (string->pointer bak-filename)
+                                *pcb-file)))))
 
 
 (define (update-element-descriptions pcb-filename bak-filename)

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -523,6 +523,12 @@
 
 
 (define (prune-elements pcb-filename bak-filename)
+  (define (prune-element *tmp-file line trimmed-line skip-line?)
+    (sch2pcb_prune_element *tmp-file
+                           (string->pointer (string-append line "\n"))
+                           (string->pointer trimmed-line)
+                           skip-line?))
+
   (let loop ((*element-list (glist->list (sch2pcb_get_pcb_element_list)
                                          identity)))
     (unless (null? *element-list)
@@ -558,10 +564,10 @@
                            (skip-line? FALSE))
                   (unless (eof-object? line)
                     (let* ((trimmed-line (string-trim-both line char-set:whitespace))
-                           (skip-next? (sch2pcb_prune_element *tmp-file
-                                                              (string->pointer (string-append line "\n"))
-                                                              (string->pointer trimmed-line)
-                                                              skip-line?)))
+                           (skip-next? (prune-element *tmp-file
+                                                      line
+                                                      trimmed-line
+                                                      skip-line?)))
                       (loop (read-line) skip-next?))))))
             (sch2pcb_close_file *tmp-file)
 

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -548,11 +548,18 @@
                    (zero? (sch2pcb_get_n_changed_value))))
     (let ((*pcb-file (sch2pcb_open_file_to_read (string->pointer pcb-filename))))
       (unless (null-pointer? *pcb-file)
-        (let ((tmp-filename (string-append pcb-filename ".tmp")))
-          (sch2pcb_prune_elements (string->pointer pcb-filename)
-                                  (string->pointer bak-filename)
-                                  (string->pointer tmp-filename)
-                                  *pcb-file))))))
+        (let* ((*tmp-filename (string->pointer (string-append pcb-filename ".tmp")))
+               (*tmp-file (sch2pcb_open_file_to_write *tmp-filename)))
+          (if (null-pointer? *tmp-file)
+              ;; If we could not open an output file for writing,
+              ;; let's close the input file as well.
+              (sch2pcb_close_file *pcb-file)
+              ;; Proceed with opened files.
+              (sch2pcb_prune_elements (string->pointer pcb-filename)
+                                      (string->pointer bak-filename)
+                                      *tmp-filename
+                                      *pcb-file
+                                      *tmp-file)))))))
 
 
 (define (update-element-descriptions pcb-filename bak-filename)

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -523,6 +523,25 @@
 
 
 (define (prune-elements pcb-filename bak-filename)
+  (let loop ((*element-list (glist->list (sch2pcb_get_pcb_element_list)
+                                         identity)))
+    (unless (null? *element-list)
+      (let ((*element (car *element-list)))
+        (if (false? (pcb_element_get_still_exists *element))
+            (if (true? (sch2pcb_get_preserve))
+                (begin
+                  (sch2pcb_set_n_preserved (1+ (sch2pcb_get_n_preserved)))
+                  (format (current-error-port)
+                          "Preserving PCB element not in the schematic:    ~A (element   ~A)\n"
+                          (pointer->string (pcb_element_get_refdes *element))
+                          (pointer->string (pcb_element_get_description *element))))
+
+                (sch2pcb_set_n_deleted (1+ (sch2pcb_get_n_deleted))))
+
+            (unless (null-pointer? (pcb_element_get_changed_value *element))
+              (sch2pcb_set_n_changed_value (1+ (sch2pcb_get_n_changed_value)))))
+        (loop (cdr *element-list)))))
+
   (sch2pcb_prune_elements (string->pointer pcb-filename)
                           (string->pointer bak-filename)))
 

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -557,9 +557,11 @@
                 (let loop ((line (read-line))
                            (skip-line? FALSE))
                   (unless (eof-object? line)
-                    (let ((skip-next? (sch2pcb_prune_element *tmp-file
-                                                             (string->pointer (string-append line "\n"))
-                                                             skip-line?)))
+                    (let* ((trimmed-line (string-trim-both line char-set:whitespace))
+                           (skip-next? (sch2pcb_prune_element *tmp-file
+                                                              (string->pointer (string-append line "\n"))
+                                                              (string->pointer trimmed-line)
+                                                              skip-line?)))
                       (loop (read-line) skip-next?))))))
             (sch2pcb_close_file *tmp-file)
 

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -522,6 +522,11 @@
           0))))
 
 
+(define (prune-elements pcb-filename bak-filename)
+  (sch2pcb_prune_elements (string->pointer pcb-filename)
+                          (string->pointer bak-filename)))
+
+
 (define (update-element-descriptions pcb-filename bak-filename)
   (define (update-element-description *output-file *line *trimmed-line)
     (let* ((*element (pcb_element_line_parse *trimmed-line))
@@ -1238,8 +1243,7 @@ Lepton EDA homepage: <~A>
                     (exit 0)))
                 (when %fix-elements?
                   (update-element-descriptions pcb-filename bak-filename))
-                (sch2pcb_prune_elements (string->pointer pcb-filename)
-                                        (string->pointer bak-filename))
+                (prune-elements pcb-filename bak-filename)
                 (report-results pcb-filename
                                 pcb-new-filename
                                 bak-filename

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -542,8 +542,12 @@
               (sch2pcb_set_n_changed_value (1+ (sch2pcb_get_n_changed_value)))))
         (loop (cdr *element-list)))))
 
-  (sch2pcb_prune_elements (string->pointer pcb-filename)
-                          (string->pointer bak-filename)))
+  (unless (or (null-pointer? (sch2pcb_get_pcb_element_list))
+              (and (zero? (sch2pcb_get_n_deleted))
+                   (false? (sch2pcb_get_need_PKG_purge))
+                   (zero? (sch2pcb_get_n_changed_value))))
+    (sch2pcb_prune_elements (string->pointer pcb-filename)
+                            (string->pointer bak-filename))))
 
 
 (define (update-element-descriptions pcb-filename bak-filename)


### PR DESCRIPTION
Well, since such large commit sets as in #1034 do not come in easily, let's try to split them up to make at least some progress.  This is a part of the PR #1034 which focuses on replacing of direct usage of  C pointers with newly written accessors to required C structures' fields.