### PR TITLE
Replace direct use of pointers in o_undo_callback() with use of accessors.

### DIFF
--- a/libleptongui/include/gschem_toplevel.h
+++ b/libleptongui/include/gschem_toplevel.h
@@ -395,6 +395,9 @@ void
 schematic_window_set_undo_panzoom (GschemToplevel *w_current,
                                    int undo_panzoom);
 int
+schematic_window_get_undo_type (GschemToplevel *w_current);
+
+int
 schematic_window_get_keyboardpan_gain (GschemToplevel *w_current);
 
 void

--- a/libleptongui/src/gschem_toplevel.c
+++ b/libleptongui/src/gschem_toplevel.c
@@ -1336,6 +1336,20 @@ schematic_window_set_undo_panzoom (GschemToplevel *w_current,
 }
 
 
+/*! \brief Get the field 'undo_type' for this schematic window.
+ *
+ *  \param [in] w_current The schematic window.
+ *  \return The field 'undo_type'.
+ */
+int
+schematic_window_get_undo_type (GschemToplevel *w_current)
+{
+  g_return_val_if_fail (w_current != NULL, UNDO_DISK);
+
+  return w_current->undo_type;
+}
+
+
 /*! \brief Get the field 'keyboardpan_gain' for this schematic window.
  *
  *  \param [in] w_current The schematic window.

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -567,7 +567,7 @@ o_undo_callback (GschemToplevel *w_current,
   /* don't have to free data here since filename, object_list are */
   /* just pointers to the real data (lower in the stack) */
   if (find_prev_data) {
-    undo_to_do->filename = NULL;
+    lepton_undo_set_filename (undo_to_do, NULL);
     undo_to_do->object_list = NULL;
   }
 

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -578,7 +578,7 @@ o_undo_callback (GschemToplevel *w_current,
 #if DEBUG
   printf("\n\n---Undo----\n");
   lepton_undo_print_all (lepton_page_get_undo_bottom (page));
-  printf("TOS: %s\n", lepton_undo_get_filename (page->undo_tos));
+  printf("TOS: %s\n", lepton_undo_get_filename (lepton_page_get_undo_tos (page)));
   printf("CURRENT: %s\n", lepton_undo_get_filename (lepton_page_get_undo_current (page)));
   printf("----\n");
 #endif

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -463,7 +463,7 @@ o_undo_callback (GschemToplevel *w_current,
   save_tos = lepton_page_get_undo_tos (page);
   save_current = current_undo;
   lepton_page_set_undo_bottom (page, NULL);
-  page->undo_tos = NULL;
+  lepton_page_set_undo_tos (page, NULL);
   page->undo_current = NULL;
 
   o_select_unselect_all (w_current);
@@ -537,7 +537,7 @@ o_undo_callback (GschemToplevel *w_current,
 
   /* restore saved undo structures */
   lepton_page_set_undo_bottom (page, save_bottom);
-  page->undo_tos = save_tos;
+  lepton_page_set_undo_tos (page, save_tos);
   page->undo_current = save_current;
 
   if (!redo)

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -460,7 +460,7 @@ o_undo_callback (GschemToplevel *w_current,
 
   /* save structure so it's not nuked */
   save_bottom = lepton_page_get_undo_bottom (page);
-  save_tos = page->undo_tos;
+  save_tos = lepton_page_get_undo_tos (page);
   save_current = current_undo;
   page->undo_bottom = NULL;
   page->undo_tos = NULL;
@@ -556,7 +556,7 @@ o_undo_callback (GschemToplevel *w_current,
     if (page->undo_current) {
       page->undo_current = page->undo_current->next;
       if (page->undo_current == NULL) {
-        page->undo_current = page->undo_tos;
+        page->undo_current = lepton_page_get_undo_tos (page);
       }
     }
   }

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -503,7 +503,7 @@ o_undo_callback (GschemToplevel *w_current,
                                                NULL));
   }
 
-  page->page_control = undo_to_do->page_control;
+  lepton_page_set_page_control (page, undo_to_do->page_control);
   page->up = undo_to_do->up;
   gschem_toplevel_page_content_changed (w_current, page);
 

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -468,7 +468,8 @@ o_undo_callback (GschemToplevel *w_current,
 
   o_select_unselect_all (w_current);
 
-  if ((schematic_window_get_undo_type (w_current) == UNDO_DISK && undo_to_do->filename) ||
+  if ((schematic_window_get_undo_type (w_current) == UNDO_DISK
+       && lepton_undo_get_filename (undo_to_do)) ||
       (schematic_window_get_undo_type (w_current) == UNDO_MEMORY && undo_to_do->object_list))
   {
     /* delete objects of page */
@@ -484,13 +485,14 @@ o_undo_callback (GschemToplevel *w_current,
   save_logging = do_logging;
   do_logging = FALSE;
 
-  if (schematic_window_get_undo_type (w_current) == UNDO_DISK && undo_to_do->filename)
+  if (schematic_window_get_undo_type (w_current) == UNDO_DISK
+      && lepton_undo_get_filename (undo_to_do))
   {
     /*
      * F_OPEN_RESTORE_CWD: go back from tmp directory,
      * so that local config files can be read:
     */
-    f_open (toplevel, page, undo_to_do->filename, F_OPEN_RESTORE_CWD, NULL);
+    f_open (toplevel, page, lepton_undo_get_filename (undo_to_do), F_OPEN_RESTORE_CWD, NULL);
   }
   else if (schematic_window_get_undo_type (w_current) == UNDO_MEMORY
            && undo_to_do->object_list)
@@ -571,8 +573,8 @@ o_undo_callback (GschemToplevel *w_current,
 #if DEBUG
   printf("\n\n---Undo----\n");
   lepton_undo_print_all (lepton_page_get_undo_bottom (page));
-  printf("TOS: %s\n", page->undo_tos->filename);
-  printf("CURRENT: %s\n", page->undo_current->filename);
+  printf("TOS: %s\n", lepton_undo_get_filename (page->undo_tos));
+  printf("CURRENT: %s\n", lepton_undo_get_filename (page->undo_current));
   printf("----\n");
 #endif
 }

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -446,7 +446,8 @@ o_undo_callback (GschemToplevel *w_current,
 #endif
     find_prev_data = TRUE;
 
-    if (w_current->undo_type == UNDO_DISK) {
+    if (schematic_window_get_undo_type (w_current) == UNDO_DISK)
+    {
       undo_to_do->filename = o_undo_find_prev_filename (undo_to_do);
     } else {
       undo_to_do->object_list = o_undo_find_prev_object_head (undo_to_do);

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -557,7 +557,7 @@ o_undo_callback (GschemToplevel *w_current,
   {
     /* Redo action. */
     if (page->undo_current) {
-      page->undo_current = page->undo_current->next;
+      page->undo_current = lepton_undo_get_next (page->undo_current);
       if (page->undo_current == NULL) {
         page->undo_current = lepton_page_get_undo_tos (page);
       }

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -462,7 +462,7 @@ o_undo_callback (GschemToplevel *w_current,
   save_bottom = lepton_page_get_undo_bottom (page);
   save_tos = lepton_page_get_undo_tos (page);
   save_current = current_undo;
-  page->undo_bottom = NULL;
+  lepton_page_set_undo_bottom (page, NULL);
   page->undo_tos = NULL;
   page->undo_current = NULL;
 
@@ -536,7 +536,7 @@ o_undo_callback (GschemToplevel *w_current,
   i_update_menus(w_current);
 
   /* restore saved undo structures */
-  page->undo_bottom = save_bottom;
+  lepton_page_set_undo_bottom (page, save_bottom);
   page->undo_tos = save_tos;
   page->undo_current = save_current;
 

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -514,12 +514,12 @@ o_undo_callback (GschemToplevel *w_current,
 
   if (schematic_window_get_undo_panzoom (w_current) || o_undo_modify_viewport())
   {
-    if (undo_to_do->scale != 0)
+    if (lepton_undo_get_scale (undo_to_do) != 0)
     {
       gschem_page_geometry_set_viewport (geometry,
                                          undo_to_do->x,
                                          undo_to_do->y,
-                                         undo_to_do->scale);
+                                         lepton_undo_get_scale (undo_to_do));
       gschem_page_view_invalidate_all (view);
     } else {
       gschem_page_view_zoom_extents (view, lepton_undo_get_object_list (undo_to_do));

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -450,7 +450,8 @@ o_undo_callback (GschemToplevel *w_current,
     {
       lepton_undo_set_filename (undo_to_do, o_undo_find_prev_filename (undo_to_do));
     } else {
-      undo_to_do->object_list = o_undo_find_prev_object_head (undo_to_do);
+      lepton_undo_set_object_list (undo_to_do,
+                                   o_undo_find_prev_object_head (undo_to_do));
     }
   }
 

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -437,11 +437,11 @@ o_undo_callback (GschemToplevel *w_current,
     return;
   }
 
-  if (current_undo->type == UNDO_ALL
-      && undo_to_do->type == UNDO_VIEWPORT_ONLY)
+  if (lepton_undo_get_type (current_undo) == UNDO_ALL
+      && lepton_undo_get_type (undo_to_do) == UNDO_VIEWPORT_ONLY)
   {
 #if DEBUG
-    printf("Type: %d\n", undo_to_do->type);
+    printf("Type: %d\n", lepton_undo_get_type (undo_to_do));
     printf("Current is an undo all, next is viewport only!\n");
 #endif
     find_prev_data = TRUE;

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -568,7 +568,7 @@ o_undo_callback (GschemToplevel *w_current,
   /* just pointers to the real data (lower in the stack) */
   if (find_prev_data) {
     lepton_undo_set_filename (undo_to_do, NULL);
-    undo_to_do->object_list = NULL;
+    lepton_undo_set_object_list (undo_to_do, NULL);
   }
 
 #if DEBUG

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -502,7 +502,7 @@ o_undo_callback (GschemToplevel *w_current,
 
   GschemPageGeometry *geometry = gschem_page_view_get_page_geometry (view);
 
-  if (w_current->undo_panzoom || o_undo_modify_viewport())
+  if (schematic_window_get_undo_panzoom (w_current) || o_undo_modify_viewport())
   {
     if (u_current->scale != 0) {
       gschem_page_geometry_set_viewport (geometry,

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -403,7 +403,7 @@ o_undo_callback (GschemToplevel *w_current,
 {
   LeptonToplevel *toplevel = gschem_toplevel_get_toplevel (w_current);
   LeptonUndo *undo_to_do;
-  LeptonUndo *u_next;
+  LeptonUndo *current_undo;
   LeptonUndo *save_bottom;
   LeptonUndo *save_tos;
   LeptonUndo *save_current;
@@ -431,14 +431,14 @@ o_undo_callback (GschemToplevel *w_current,
     undo_to_do = page->undo_current->next;
   }
 
-  u_next = page->undo_current;
+  current_undo = page->undo_current;
 
   if (undo_to_do == NULL)
   {
     return;
   }
 
-  if (u_next->type == UNDO_ALL
+  if (current_undo->type == UNDO_ALL
       && undo_to_do->type == UNDO_VIEWPORT_ONLY)
   {
 #if DEBUG

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -469,8 +469,7 @@ o_undo_callback (GschemToplevel *w_current,
     lepton_page_delete_objects (page);
 
     /* Free the objects in the place list. */
-    lepton_object_list_delete (page->place_list);
-    page->place_list = NULL;
+    schematic_window_delete_place_list (w_current);
 
     schematic_window_active_page_changed (w_current);
   }

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -415,7 +415,8 @@ o_undo_callback (GschemToplevel *w_current,
   g_return_if_fail (w_current != NULL);
   g_return_if_fail (page != NULL);
 
-  if (page->undo_current == NULL) {
+  if (lepton_page_get_undo_current (page) == NULL)
+  {
     return;
   }
 

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -547,7 +547,7 @@ o_undo_callback (GschemToplevel *w_current,
   {
     /* Undo action. */
     if (page->undo_current) {
-      page->undo_current = page->undo_current->prev;
+      page->undo_current = lepton_undo_get_prev (page->undo_current);
       if (page->undo_current == NULL) {
         page->undo_current = lepton_page_get_undo_bottom (page);
       }

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -503,7 +503,7 @@ o_undo_callback (GschemToplevel *w_current,
                                                NULL));
   }
 
-  lepton_page_set_page_control (page, undo_to_do->page_control);
+  lepton_page_set_page_control (page, lepton_undo_get_page_control (undo_to_do));
   lepton_page_set_up (page, undo_to_do->up);
   gschem_toplevel_page_content_changed (w_current, page);
 

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -504,7 +504,7 @@ o_undo_callback (GschemToplevel *w_current,
   }
 
   lepton_page_set_page_control (page, lepton_undo_get_page_control (undo_to_do));
-  lepton_page_set_up (page, undo_to_do->up);
+  lepton_page_set_up (page, lepton_undo_get_up (undo_to_do));
   gschem_toplevel_page_content_changed (w_current, page);
 
   GschemPageView *view = gschem_toplevel_get_current_page_view (w_current);

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -546,9 +546,11 @@ o_undo_callback (GschemToplevel *w_current,
   if (!redo)
   {
     /* Undo action. */
-    if (page->undo_current) {
-      page->undo_current = lepton_undo_get_prev (page->undo_current);
-      if (page->undo_current == NULL) {
+    if (lepton_page_get_undo_current (page))
+    {
+      page->undo_current = lepton_undo_get_prev (lepton_page_get_undo_current (page));
+      if (lepton_page_get_undo_current (page) == NULL)
+      {
         page->undo_current = lepton_page_get_undo_bottom (page);
       }
     }
@@ -556,9 +558,11 @@ o_undo_callback (GschemToplevel *w_current,
   else
   {
     /* Redo action. */
-    if (page->undo_current) {
-      page->undo_current = lepton_undo_get_next (page->undo_current);
-      if (page->undo_current == NULL) {
+    if (lepton_page_get_undo_current (page))
+    {
+      page->undo_current = lepton_undo_get_next (lepton_page_get_undo_current (page));
+      if (lepton_page_get_undo_current (page) == NULL)
+      {
         page->undo_current = lepton_page_get_undo_tos (page);
       }
     }
@@ -575,7 +579,7 @@ o_undo_callback (GschemToplevel *w_current,
   printf("\n\n---Undo----\n");
   lepton_undo_print_all (lepton_page_get_undo_bottom (page));
   printf("TOS: %s\n", lepton_undo_get_filename (page->undo_tos));
-  printf("CURRENT: %s\n", lepton_undo_get_filename (page->undo_current));
+  printf("CURRENT: %s\n", lepton_undo_get_filename (lepton_page_get_undo_current (page)));
   printf("----\n");
 #endif
 }

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -541,17 +541,17 @@ o_undo_callback (GschemToplevel *w_current,
   /* restore saved undo structures */
   lepton_page_set_undo_bottom (page, save_bottom);
   lepton_page_set_undo_tos (page, save_tos);
-  page->undo_current = save_current;
+  lepton_page_set_undo_current (page, save_current);
 
   if (!redo)
   {
     /* Undo action. */
     if (lepton_page_get_undo_current (page))
     {
-      page->undo_current = lepton_undo_get_prev (lepton_page_get_undo_current (page));
+      lepton_page_set_undo_current (page, lepton_undo_get_prev (lepton_page_get_undo_current (page)));
       if (lepton_page_get_undo_current (page) == NULL)
       {
-        page->undo_current = lepton_page_get_undo_bottom (page);
+        lepton_page_set_undo_current (page, lepton_page_get_undo_bottom (page));
       }
     }
   }
@@ -560,10 +560,10 @@ o_undo_callback (GschemToplevel *w_current,
     /* Redo action. */
     if (lepton_page_get_undo_current (page))
     {
-      page->undo_current = lepton_undo_get_next (lepton_page_get_undo_current (page));
+      lepton_page_set_undo_current (page, lepton_undo_get_next (lepton_page_get_undo_current (page)));
       if (lepton_page_get_undo_current (page) == NULL)
       {
-        page->undo_current = lepton_page_get_undo_tos (page);
+        lepton_page_set_undo_current (page, lepton_page_get_undo_tos (page));
       }
     }
   }

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -470,7 +470,8 @@ o_undo_callback (GschemToplevel *w_current,
 
   if ((schematic_window_get_undo_type (w_current) == UNDO_DISK
        && lepton_undo_get_filename (undo_to_do)) ||
-      (schematic_window_get_undo_type (w_current) == UNDO_MEMORY && undo_to_do->object_list))
+      (schematic_window_get_undo_type (w_current) == UNDO_MEMORY
+       && lepton_undo_get_object_list (undo_to_do)))
   {
     /* delete objects of page */
     lepton_page_delete_objects (page);
@@ -495,10 +496,10 @@ o_undo_callback (GschemToplevel *w_current,
     f_open (toplevel, page, lepton_undo_get_filename (undo_to_do), F_OPEN_RESTORE_CWD, NULL);
   }
   else if (schematic_window_get_undo_type (w_current) == UNDO_MEMORY
-           && undo_to_do->object_list)
+           && lepton_undo_get_object_list (undo_to_do))
   {
     lepton_page_append_list (page,
-                             o_glist_copy_all (undo_to_do->object_list,
+                             o_glist_copy_all (lepton_undo_get_object_list (undo_to_do),
                                                NULL));
   }
 
@@ -521,7 +522,7 @@ o_undo_callback (GschemToplevel *w_current,
                                          undo_to_do->scale);
       gschem_page_view_invalidate_all (view);
     } else {
-      gschem_page_view_zoom_extents (view, undo_to_do->object_list);
+      gschem_page_view_zoom_extents (view, lepton_undo_get_object_list (undo_to_do));
     }
   }
 

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -403,7 +403,6 @@ o_undo_callback (GschemToplevel *w_current,
 {
   LeptonToplevel *toplevel = gschem_toplevel_get_toplevel (w_current);
   LeptonUndo *undo_to_do;
-  LeptonUndo *current_undo;
   LeptonUndo *save_bottom;
   LeptonUndo *save_tos;
   LeptonUndo *save_current;
@@ -415,7 +414,9 @@ o_undo_callback (GschemToplevel *w_current,
   g_return_if_fail (w_current != NULL);
   g_return_if_fail (page != NULL);
 
-  if (lepton_page_get_undo_current (page) == NULL)
+  LeptonUndo *current_undo = lepton_page_get_undo_current (page);
+
+  if (current_undo == NULL)
   {
     return;
   }
@@ -423,15 +424,13 @@ o_undo_callback (GschemToplevel *w_current,
   if (!redo)
   {
     /* Undo action. */
-    undo_to_do = page->undo_current->prev;
+    undo_to_do = current_undo->prev;
   }
   else
   {
     /* Redo action. */
-    undo_to_do = page->undo_current->next;
+    undo_to_do = current_undo->next;
   }
-
-  current_undo = page->undo_current;
 
   if (undo_to_do == NULL)
   {
@@ -460,7 +459,7 @@ o_undo_callback (GschemToplevel *w_current,
   /* save structure so it's not nuked */
   save_bottom = page->undo_bottom;
   save_tos = page->undo_tos;
-  save_current = page->undo_current;
+  save_current = current_undo;
   page->undo_bottom = NULL;
   page->undo_tos = NULL;
   page->undo_current = NULL;

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -459,7 +459,7 @@ o_undo_callback (GschemToplevel *w_current,
   save_filename = g_strdup (lepton_page_get_filename (page));
 
   /* save structure so it's not nuked */
-  save_bottom = page->undo_bottom;
+  save_bottom = lepton_page_get_undo_bottom (page);
   save_tos = page->undo_tos;
   save_current = current_undo;
   page->undo_bottom = NULL;
@@ -546,7 +546,7 @@ o_undo_callback (GschemToplevel *w_current,
     if (page->undo_current) {
       page->undo_current = page->undo_current->prev;
       if (page->undo_current == NULL) {
-        page->undo_current = page->undo_bottom;
+        page->undo_current = lepton_page_get_undo_bottom (page);
       }
     }
   }
@@ -570,7 +570,7 @@ o_undo_callback (GschemToplevel *w_current,
 
 #if DEBUG
   printf("\n\n---Undo----\n");
-  lepton_undo_print_all (page->undo_bottom);
+  lepton_undo_print_all (lepton_page_get_undo_bottom (page));
   printf("TOS: %s\n", page->undo_tos->filename);
   printf("CURRENT: %s\n", page->undo_current->filename);
   printf("----\n");

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -464,7 +464,7 @@ o_undo_callback (GschemToplevel *w_current,
   save_current = current_undo;
   lepton_page_set_undo_bottom (page, NULL);
   lepton_page_set_undo_tos (page, NULL);
-  page->undo_current = NULL;
+  lepton_page_set_undo_current (page, NULL);
 
   o_select_unselect_all (w_current);
 

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -424,12 +424,12 @@ o_undo_callback (GschemToplevel *w_current,
   if (!redo)
   {
     /* Undo action. */
-    undo_to_do = current_undo->prev;
+    undo_to_do = lepton_undo_get_prev (current_undo);
   }
   else
   {
     /* Redo action. */
-    undo_to_do = current_undo->next;
+    undo_to_do = lepton_undo_get_next (current_undo);
   }
 
   if (undo_to_do == NULL)

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -468,8 +468,8 @@ o_undo_callback (GschemToplevel *w_current,
 
   o_select_unselect_all (w_current);
 
-  if ((w_current->undo_type == UNDO_DISK && undo_to_do->filename) ||
-      (w_current->undo_type == UNDO_MEMORY && undo_to_do->object_list))
+  if ((schematic_window_get_undo_type (w_current) == UNDO_DISK && undo_to_do->filename) ||
+      (schematic_window_get_undo_type (w_current) == UNDO_MEMORY && undo_to_do->object_list))
   {
     /* delete objects of page */
     lepton_page_delete_objects (page);
@@ -484,7 +484,7 @@ o_undo_callback (GschemToplevel *w_current,
   save_logging = do_logging;
   do_logging = FALSE;
 
-  if (w_current->undo_type == UNDO_DISK && undo_to_do->filename)
+  if (schematic_window_get_undo_type (w_current) == UNDO_DISK && undo_to_do->filename)
   {
     /*
      * F_OPEN_RESTORE_CWD: go back from tmp directory,
@@ -492,7 +492,7 @@ o_undo_callback (GschemToplevel *w_current,
     */
     f_open (toplevel, page, undo_to_do->filename, F_OPEN_RESTORE_CWD, NULL);
   }
-  else if (w_current->undo_type == UNDO_MEMORY
+  else if (schematic_window_get_undo_type (w_current) == UNDO_MEMORY
            && undo_to_do->object_list)
   {
     lepton_page_append_list (page,

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -448,7 +448,7 @@ o_undo_callback (GschemToplevel *w_current,
 
     if (schematic_window_get_undo_type (w_current) == UNDO_DISK)
     {
-      undo_to_do->filename = o_undo_find_prev_filename (undo_to_do);
+      lepton_undo_set_filename (undo_to_do, o_undo_find_prev_filename (undo_to_do));
     } else {
       undo_to_do->object_list = o_undo_find_prev_object_head (undo_to_do);
     }

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -517,8 +517,8 @@ o_undo_callback (GschemToplevel *w_current,
     if (lepton_undo_get_scale (undo_to_do) != 0)
     {
       gschem_page_geometry_set_viewport (geometry,
-                                         undo_to_do->x,
-                                         undo_to_do->y,
+                                         lepton_undo_get_x (undo_to_do),
+                                         lepton_undo_get_y (undo_to_do),
                                          lepton_undo_get_scale (undo_to_do));
       gschem_page_view_invalidate_all (view);
     } else {

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -504,7 +504,7 @@ o_undo_callback (GschemToplevel *w_current,
   }
 
   lepton_page_set_page_control (page, undo_to_do->page_control);
-  page->up = undo_to_do->up;
+  lepton_page_set_up (page, undo_to_do->up);
   gschem_toplevel_page_content_changed (w_current, page);
 
   GschemPageView *view = gschem_toplevel_get_current_page_view (w_current);


### PR DESCRIPTION
Thus, the `LeptonUndo` structure becomes more opaque, which allows to twiddle with it more easy both in Scheme in C.
Some variables have been renamed to make their function a little bit more clear.