### PR TITLE
Avoid test failures: scheme-directory() and print-color-map()

### DIFF
--- a/tools/archive/lepton-archive.scm
+++ b/tools/archive/lepton-archive.scm
@@ -1,4 +1,4 @@
-;;; Copyright (C) 2019-2022 Lepton EDA Contributors
+;;; Copyright (C) 2019-2023 Lepton EDA Contributors
 ;;;
 ;;; Based on Python script by Stuart Brorson:
 ;;; Copyright (C) 2003 Stuart Brorson <sdb@cloud9.net>
@@ -78,7 +78,9 @@
              (lepton toplevel)
              (lepton version)
              (netlist schematic)
-             (netlist schematic-component))
+             (netlist schematic-component)
+             (geda deprecated)
+             (lepton color-map))
 
 ;;; Initialize liblepton library.
 (liblepton_init)

--- a/tools/cli/scheme/lepton-export.scm
+++ b/tools/cli/scheme/lepton-export.scm
@@ -27,7 +27,9 @@
              (lepton srfi-37)
              (lepton toplevel foreign)
              (lepton toplevel)
-             (lepton version))
+             (lepton version)
+             (geda deprecated)
+             (lepton color-map))
 
 ;;; Initialize liblepton library.
 (liblepton_init)

--- a/tools/cli/scheme/lepton-shell.scm
+++ b/tools/cli/scheme/lepton-shell.scm
@@ -26,7 +26,9 @@
              (lepton repl)
              (lepton srfi-37)
              (lepton toplevel)
-             (lepton version))
+             (lepton version)
+             (geda deprecated)
+             (lepton color-map))
 
 ;;; Initialize liblepton library.
 (liblepton_init)

--- a/tools/embed/lepton-embed.scm
+++ b/tools/embed/lepton-embed.scm
@@ -2,7 +2,7 @@
 ;; Lepton EDA
 ;; lepton-embed - schematic components and pictures embedding utility
 ;; Copyright (C) 2019 dmn <graahnul.grom@gmail.com>
-;; Copyright (C) 2019-2022 Lepton EDA Contributors
+;; Copyright (C) 2019-2023 Lepton EDA Contributors
 ;; License: GPLv2+. See the COPYING file
 ;;
 
@@ -13,7 +13,9 @@
              (lepton page)
              (lepton rc)
              (lepton toplevel)
-             (lepton version))
+             (lepton version)
+             (geda deprecated)
+             (lepton color-map))
 
 ;; Initialize liblepton library.
 (liblepton_init)

--- a/tools/netlist/lepton-netlist.scm
+++ b/tools/netlist/lepton-netlist.scm
@@ -1,6 +1,6 @@
 ;;; Lepton EDA netlister
 ;;; Scheme API
-;;; Copyright (C) 2017-2022 Lepton EDA Contributors
+;;; Copyright (C) 2017-2023 Lepton EDA Contributors
 ;;;
 ;;; This program is free software; you can redistribute it and/or modify
 ;;; it under the terms of the GNU General Public License as published by
@@ -19,6 +19,7 @@
 (use-modules (ice-9 getopt-long)
              (srfi srfi-26)
              (geda deprecated)
+             (lepton color-map)
              (lepton ffi)
              (lepton library)
              (lepton log)


### PR DESCRIPTION
If these functions are called (possibly, indirectly) from
the user's `gafrc` configuration file, unit tests might fail
for some tools in the suite loading this file.

`scheme-directory()` is defined in the `(geda deprecated)`,
`print-color-map()` - in the `(lepton color-map)` module.

Add missing `use-modules` where appropriate.
