### PR TITLE
schematic: Make toolbar callbacks remember <window> they are related to.

### DIFF
--- a/libleptongui/scheme/schematic/toolbar.scm
+++ b/libleptongui/scheme/schematic/toolbar.scm
@@ -28,6 +28,8 @@
   #:use-module (schematic callback)
   #:use-module (schematic ffi)
   #:use-module (schematic undo)
+  #:use-module (schematic window global)
+  #:use-module (schematic window foreign)
 
   #:export (make-toolbar))
 
@@ -40,7 +42,12 @@
 ;;; Prevent garbage collection of callback procedures by storing
 ;;; them in the global variable.
 (define (set-button-callback! *window *button signal callback)
-  (let ((*callback (procedure->pointer void callback '(* *))))
+  (let ((*callback (procedure->pointer void
+                                       (lambda (*wid *win)
+                                         (with-window
+                                          *window
+                                          (callback *wid *win)))
+                                       '(* *))))
     (set! %toolbar-button-callbacks
           (assq-set! %toolbar-button-callbacks *button *callback))
     (schematic_signal_connect *button


### PR DESCRIPTION
Otherwise, some lower level functions used in the callbacks may be unfamiliar of the current window the callbacks are related to, and therefore fail.

On one of my systems, the issue appears after 1 to 3 clicks on the Undo toolbar button.  `lepton-schematic` crashes reporting that `current-window` is `#f` due to implicit using `current-window()` function in `in-action?()` that is used in the button's callback.

The commit proposed here solves the issue on my system.