### PR TITLE
Rewrite o_undo_callback() in Scheme.

### DIFF
--- a/liblepton/include/liblepton/prototype.h
+++ b/liblepton/include/liblepton/prototype.h
@@ -194,6 +194,12 @@ int s_conn_net_search(LeptonObject* new_net, int whichone, GList * conn_list);
 GList *s_conn_return_others(GList *input_list, LeptonObject *object);
 
 /* s_log.c */
+int
+lepton_log_get_logging_enabled ();
+
+void
+lepton_log_set_logging_enabled (int enable);
+
 void s_log_init (const gchar *filename);
 void s_log_close (void);
 gchar *s_log_read (void);

--- a/liblepton/scheme/Makefile.am
+++ b/liblepton/scheme/Makefile.am
@@ -27,6 +27,7 @@ nobase_dist_scmdata_DATA = \
 	lepton/ffi/lff.scm \
 	lepton/ffi/lib.scm \
 	lepton/ffi/sch2pcb.scm \
+	lepton/ffi/undo.scm \
 	lepton/file-system.scm \
 	lepton/gerror.scm \
 	lepton/library.scm \

--- a/liblepton/scheme/lepton/ffi.scm
+++ b/liblepton/scheme/lepton/ffi.scm
@@ -349,6 +349,7 @@
             lepton_page_append
             lepton_page_append_list
             lepton_page_delete
+            lepton_page_delete_objects
             lepton_page_get_filename
             lepton_page_set_filename
             lepton_page_get_page_control
@@ -697,6 +698,7 @@
 (define-lff lepton_page_append void '(* *))
 (define-lff lepton_page_append_list void '(* *))
 (define-lff lepton_page_delete void '(* *))
+(define-lff lepton_page_delete_objects void '(*))
 (define-lff lepton_page_get_filename '* '(*))
 (define-lff lepton_page_set_filename void '(* *))
 (define-lff lepton_page_get_page_control int '(*))

--- a/liblepton/scheme/lepton/ffi.scm
+++ b/liblepton/scheme/lepton/ffi.scm
@@ -354,6 +354,7 @@
             lepton_page_get_page_control
             lepton_page_set_page_control
             lepton_page_get_pid
+            lepton_page_get_undo_current
             lepton_page_get_up
             lepton_page_set_up
             lepton_page_new
@@ -696,6 +697,7 @@
 (define-lff lepton_page_get_page_control int '(*))
 (define-lff lepton_page_set_page_control void (list '* int))
 (define-lff lepton_page_get_pid int '(*))
+(define-lff lepton_page_get_undo_current '* '(*))
 (define-lff lepton_page_get_up int '(*))
 (define-lff lepton_page_set_up void (list '* int))
 (define-lff lepton_page_new '* '(* *))

--- a/liblepton/scheme/lepton/ffi.scm
+++ b/liblepton/scheme/lepton/ffi.scm
@@ -354,7 +354,12 @@
             lepton_page_get_page_control
             lepton_page_set_page_control
             lepton_page_get_pid
+            lepton_page_get_undo_bottom
+            lepton_page_set_undo_bottom
             lepton_page_get_undo_current
+            lepton_page_set_undo_current
+            lepton_page_get_undo_tos
+            lepton_page_set_undo_tos
             lepton_page_get_up
             lepton_page_set_up
             lepton_page_new
@@ -697,7 +702,12 @@
 (define-lff lepton_page_get_page_control int '(*))
 (define-lff lepton_page_set_page_control void (list '* int))
 (define-lff lepton_page_get_pid int '(*))
+(define-lff lepton_page_get_undo_bottom '* '(*))
+(define-lff lepton_page_set_undo_bottom void '(* *))
 (define-lff lepton_page_get_undo_current '* '(*))
+(define-lff lepton_page_set_undo_current void '(* *))
+(define-lff lepton_page_get_undo_tos '* '(*))
+(define-lff lepton_page_set_undo_tos void '(* *))
 (define-lff lepton_page_get_up int '(*))
 (define-lff lepton_page_set_up void (list '* int))
 (define-lff lepton_page_new '* '(* *))

--- a/liblepton/scheme/lepton/ffi.scm
+++ b/liblepton/scheme/lepton/ffi.scm
@@ -372,6 +372,8 @@
 
             o_read_buffer
 
+            f_open
+
             lepton_coord_snap))
 
 ;;; Simplify definition of functions by omitting the library
@@ -722,6 +724,9 @@
 
 ;;; a_basic.c
 (define-lff o_read_buffer '* (list '* '* '* int '* '*))
+
+;;; f_basic.c
+(define-lff f_open int (list '* '* '* int '*))
 
 ;;; export.c
 (define-lff export_config void '())

--- a/liblepton/scheme/lepton/ffi/undo.scm
+++ b/liblepton/scheme/lepton/ffi/undo.scm
@@ -1,0 +1,33 @@
+;;; Lepton EDA library - Scheme API
+;;; Copyright (C) 2023 Lepton EDA Contributors
+;;;
+;;; This program is free software; you can redistribute it and/or modify
+;;; it under the terms of the GNU General Public License as published by
+;;; the Free Software Foundation; either version 2 of the License, or
+;;; (at your option) any later version.
+;;;
+;;; This program is distributed in the hope that it will be useful,
+;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;; GNU General Public License for more details.
+;;;
+;;; You should have received a copy of the GNU General Public License
+;;; along with this program; if not, write to the Free Software
+;;; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+;;; This module provides FFI for Lepton undo system.
+
+(define-module (lepton ffi undo)
+  #:use-module (lepton ffi lib)
+  #:use-module (lepton ffi lff)
+
+  #:export (lepton_undo_get_next
+            lepton_undo_get_prev))
+
+;;; Simplify definition of functions by omitting the library
+;;; argument.
+(define-syntax-rule (define-lff arg ...)
+  (define-lff-lib arg ... liblepton))
+
+(define-lff lepton_undo_get_next '* '(*))
+(define-lff lepton_undo_get_prev '* '(*))

--- a/liblepton/scheme/lepton/ffi/undo.scm
+++ b/liblepton/scheme/lepton/ffi/undo.scm
@@ -22,7 +22,9 @@
   #:use-module (lepton ffi lib)
   #:use-module (lepton ffi lff)
 
-  #:export (lepton_undo_set_filename
+  #:export (lepton_undo_get_filename
+            lepton_undo_set_filename
+            lepton_undo_get_object_list
             lepton_undo_set_object_list
             lepton_undo_get_next
             lepton_undo_get_prev
@@ -33,7 +35,9 @@
 (define-syntax-rule (define-lff arg ...)
   (define-lff-lib arg ... liblepton))
 
+(define-lff lepton_undo_get_filename '* '(*))
 (define-lff lepton_undo_set_filename void '(* *))
+(define-lff lepton_undo_get_object_list '* '(*))
 (define-lff lepton_undo_set_object_list void '(* *))
 (define-lff lepton_undo_get_next '* '(*))
 (define-lff lepton_undo_get_prev '* '(*))

--- a/liblepton/scheme/lepton/ffi/undo.scm
+++ b/liblepton/scheme/lepton/ffi/undo.scm
@@ -29,8 +29,11 @@
             lepton_undo_get_next
             lepton_undo_get_prev
             lepton_undo_get_page_control
+            lepton_undo_get_scale
             lepton_undo_get_type
-            lepton_undo_get_up))
+            lepton_undo_get_up
+            lepton_undo_get_x
+            lepton_undo_get_y))
 
 ;;; Simplify definition of functions by omitting the library
 ;;; argument.
@@ -45,4 +48,7 @@
 (define-lff lepton_undo_get_prev '* '(*))
 (define-lff lepton_undo_get_page_control int '(*))
 (define-lff lepton_undo_get_type int '(*))
+(define-lff lepton_undo_get_scale double '(*))
 (define-lff lepton_undo_get_up int '(*))
+(define-lff lepton_undo_get_x int '(*))
+(define-lff lepton_undo_get_y int '(*))

--- a/liblepton/scheme/lepton/ffi/undo.scm
+++ b/liblepton/scheme/lepton/ffi/undo.scm
@@ -28,7 +28,9 @@
             lepton_undo_set_object_list
             lepton_undo_get_next
             lepton_undo_get_prev
-            lepton_undo_get_type))
+            lepton_undo_get_page_control
+            lepton_undo_get_type
+            lepton_undo_get_up))
 
 ;;; Simplify definition of functions by omitting the library
 ;;; argument.
@@ -41,4 +43,6 @@
 (define-lff lepton_undo_set_object_list void '(* *))
 (define-lff lepton_undo_get_next '* '(*))
 (define-lff lepton_undo_get_prev '* '(*))
+(define-lff lepton_undo_get_page_control int '(*))
 (define-lff lepton_undo_get_type int '(*))
+(define-lff lepton_undo_get_up int '(*))

--- a/liblepton/scheme/lepton/ffi/undo.scm
+++ b/liblepton/scheme/lepton/ffi/undo.scm
@@ -18,16 +18,23 @@
 ;;; This module provides FFI for Lepton undo system.
 
 (define-module (lepton ffi undo)
+  #:use-module (system foreign)
   #:use-module (lepton ffi lib)
   #:use-module (lepton ffi lff)
 
-  #:export (lepton_undo_get_next
-            lepton_undo_get_prev))
+  #:export (lepton_undo_set_filename
+            lepton_undo_set_object_list
+            lepton_undo_get_next
+            lepton_undo_get_prev
+            lepton_undo_get_type))
 
 ;;; Simplify definition of functions by omitting the library
 ;;; argument.
 (define-syntax-rule (define-lff arg ...)
   (define-lff-lib arg ... liblepton))
 
+(define-lff lepton_undo_set_filename void '(* *))
+(define-lff lepton_undo_set_object_list void '(* *))
 (define-lff lepton_undo_get_next '* '(*))
 (define-lff lepton_undo_get_prev '* '(*))
+(define-lff lepton_undo_get_type int '(*))

--- a/liblepton/scheme/lepton/ffi/undo.scm
+++ b/liblepton/scheme/lepton/ffi/undo.scm
@@ -33,7 +33,9 @@
             lepton_undo_get_type
             lepton_undo_get_up
             lepton_undo_get_x
-            lepton_undo_get_y))
+            lepton_undo_get_y
+
+            lepton_undo_print_all))
 
 ;;; Simplify definition of functions by omitting the library
 ;;; argument.
@@ -52,3 +54,5 @@
 (define-lff lepton_undo_get_up int '(*))
 (define-lff lepton_undo_get_x int '(*))
 (define-lff lepton_undo_get_y int '(*))
+
+(define-lff lepton_undo_print_all void '(*))

--- a/liblepton/src/s_log.c
+++ b/liblepton/src/s_log.c
@@ -1,7 +1,7 @@
 /* Lepton EDA library
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2016 gEDA Contributors
- * Copyright (C) 2017-2021 Lepton EDA Contributors
+ * Copyright (C) 2017-2023 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -62,6 +62,29 @@ static void s_log_handler (const gchar *log_domain,
 static int logfile_fd = -1;
 
 static guint log_handler_id;
+
+
+/*! \brief Test if logging is enabled.
+ *
+ *  \return Return 1 if logging is enabled, 0 otherwise.
+ */
+int
+lepton_log_get_logging_enabled ()
+{
+  return do_logging;
+}
+
+/*! \brief Enable or disable logging.
+ *
+ *  \param [in] enable Disable logging if the value is 0,
+ *  otherwise enable it.
+ */
+void
+lepton_log_set_logging_enabled (int enable)
+{
+  do_logging = enable;
+}
+
 
 /*! \brief Initialize libgeda logging feature.
  *  \par Function Description

--- a/liblepton/src/undo.c
+++ b/liblepton/src/undo.c
@@ -411,7 +411,10 @@ lepton_undo_print_all (LeptonUndo *head)
       lepton_object_list_print (lepton_undo_get_object_list (u_current));
     }
 
-    printf("\t%d %d %f\n", u_current->x, u_current->y, u_current->scale);
+    printf ("\t%d %d %f\n",
+            lepton_undo_get_x (u_current),
+            lepton_undo_get_y (u_current),
+            lepton_undo_get_scale (u_current));
     u_current = u_current->next;
   }
   printf("TOS\n");

--- a/liblepton/src/undo.c
+++ b/liblepton/src/undo.c
@@ -406,8 +406,9 @@ lepton_undo_print_all (LeptonUndo *head)
       printf("%s\n", lepton_undo_get_filename (u_current));
     }
 
-    if (u_current->object_list) {
-      lepton_object_list_print (u_current->object_list);
+    if (lepton_undo_get_object_list (u_current))
+    {
+      lepton_object_list_print (lepton_undo_get_object_list (u_current));
     }
 
     printf("\t%d %d %f\n", u_current->x, u_current->y, u_current->scale);

--- a/liblepton/src/undo.c
+++ b/liblepton/src/undo.c
@@ -401,7 +401,10 @@ lepton_undo_print_all (LeptonUndo *head)
   printf("BOTTOM\n");
   while(u_current != NULL) {
 
-    if (u_current->filename) printf("%s\n", u_current->filename);
+    if (lepton_undo_get_filename (u_current))
+    {
+      printf("%s\n", lepton_undo_get_filename (u_current));
+    }
 
     if (u_current->object_list) {
       lepton_object_list_print (u_current->object_list);

--- a/liblepton/src/undo.c
+++ b/liblepton/src/undo.c
@@ -397,13 +397,13 @@ lepton_undo_print_all (LeptonUndo *head)
 
   u_current = head;
 
-  printf("START printing undo ********************\n");
-  printf("BOTTOM\n");
+  g_debug ("START printing undo ********************\n");
+  g_debug ("BOTTOM\n");
   while(u_current != NULL) {
 
     if (lepton_undo_get_filename (u_current))
     {
-      printf("%s\n", lepton_undo_get_filename (u_current));
+      g_debug ("%s\n", lepton_undo_get_filename (u_current));
     }
 
     if (lepton_undo_get_object_list (u_current))
@@ -411,16 +411,16 @@ lepton_undo_print_all (LeptonUndo *head)
       lepton_object_list_print (lepton_undo_get_object_list (u_current));
     }
 
-    printf ("\t%d %d %f\n",
+    g_debug ("\t%d %d %f\n",
             lepton_undo_get_x (u_current),
             lepton_undo_get_y (u_current),
             lepton_undo_get_scale (u_current));
     u_current = lepton_undo_get_next (u_current);
   }
-  printf("TOS\n");
-  printf("Number of levels: %d\n", lepton_undo_levels (head));
-  printf("DONE printing undo ********************\n");
-  printf("\n");
+  g_debug ("TOS\n");
+  g_debug ("Number of levels: %d\n", lepton_undo_levels (head));
+  g_debug ("DONE printing undo ********************\n");
+  g_debug ("\n");
 
 }
 

--- a/liblepton/src/undo.c
+++ b/liblepton/src/undo.c
@@ -415,7 +415,7 @@ lepton_undo_print_all (LeptonUndo *head)
             lepton_undo_get_x (u_current),
             lepton_undo_get_y (u_current),
             lepton_undo_get_scale (u_current));
-    u_current = u_current->next;
+    u_current = lepton_undo_get_next (u_current);
   }
   printf("TOS\n");
   printf("Number of levels: %d\n", lepton_undo_levels (head));

--- a/libleptongui/include/gschem_page_geometry.h
+++ b/libleptongui/include/gschem_page_geometry.h
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2015 gEDA Contributors
- * Copyright (C) 2017-2020 Lepton EDA Contributors
+ * Copyright (C) 2017-2023 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -56,6 +56,7 @@ struct _GschemPageGeometry
 };
 
 
+G_BEGIN_DECLS
 
 GschemPageGeometry*
 gschem_page_geometry_copy (GschemPageGeometry *geometry);
@@ -157,3 +158,4 @@ void
 gschem_page_geometry_zoom_extents (GschemPageGeometry *geometry,
                                    const GList *list,
                                    gboolean include_hidden);
+G_END_DECLS

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -336,11 +336,6 @@ o_undo_find_prev_filename (LeptonUndo *start);
 GList*
 o_undo_find_prev_object_head (LeptonUndo *start);
 
-void
-o_undo_callback (LeptonPage *page,
-                 LeptonUndo *undo_to_do,
-                 gboolean find_prev_data);
-
 void o_undo_cleanup(void);
 
 gboolean

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -341,7 +341,9 @@ o_undo_callback (GschemToplevel *w_current,
                  LeptonPage *page,
                  LeptonUndo *current_undo,
                  LeptonUndo *undo_to_do,
-                 gboolean redo);
+                 gboolean redo,
+                 gboolean find_prev_data);
+
 void o_undo_cleanup(void);
 /* s_stretch.c */
 GList *s_stretch_add(GList *list, LeptonObject *object, int whichone);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -340,6 +340,8 @@ void
 o_undo_callback (GschemToplevel *w_current,
                  LeptonPage *page,
                  LeptonUndo *current_undo,
+                 LeptonUndo *save_bottom,
+                 LeptonUndo *save_tos,
                  LeptonUndo *undo_to_do,
                  char *save_filename,
                  gboolean redo,

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -339,6 +339,7 @@ o_undo_find_prev_object_head (LeptonUndo *start);
 void
 o_undo_callback (GschemToplevel *w_current,
                  LeptonPage *page,
+                 LeptonUndo *current_undo,
                  gboolean redo);
 void o_undo_cleanup(void);
 /* s_stretch.c */

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -341,6 +341,7 @@ o_undo_callback (GschemToplevel *w_current,
                  LeptonPage *page,
                  LeptonUndo *current_undo,
                  LeptonUndo *undo_to_do,
+                 char *save_filename,
                  gboolean redo,
                  gboolean find_prev_data);
 

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -340,6 +340,7 @@ void
 o_undo_callback (GschemToplevel *w_current,
                  LeptonPage *page,
                  LeptonUndo *current_undo,
+                 LeptonUndo *undo_to_do,
                  gboolean redo);
 void o_undo_cleanup(void);
 /* s_stretch.c */

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -345,7 +345,8 @@ o_undo_callback (GschemToplevel *w_current,
                  LeptonUndo *undo_to_do,
                  char *save_filename,
                  gboolean redo,
-                 gboolean find_prev_data);
+                 gboolean find_prev_data,
+                 int save_logging);
 
 void o_undo_cleanup(void);
 /* s_stretch.c */

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -339,7 +339,6 @@ o_undo_find_prev_object_head (LeptonUndo *start);
 void
 o_undo_callback (LeptonPage *page,
                  LeptonUndo *undo_to_do,
-                 gboolean redo,
                  gboolean find_prev_data);
 
 void o_undo_cleanup(void);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -349,6 +349,10 @@ o_undo_callback (GschemToplevel *w_current,
                  int save_logging);
 
 void o_undo_cleanup(void);
+
+gboolean
+o_undo_modify_viewport ();
+
 /* s_stretch.c */
 GList *s_stretch_add(GList *list, LeptonObject *object, int whichone);
 GList *s_stretch_remove(GList *list, LeptonObject *object);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -337,16 +337,10 @@ GList*
 o_undo_find_prev_object_head (LeptonUndo *start);
 
 void
-o_undo_callback (GschemToplevel *w_current,
-                 LeptonPage *page,
-                 LeptonUndo *current_undo,
-                 LeptonUndo *save_bottom,
-                 LeptonUndo *save_tos,
+o_undo_callback (LeptonPage *page,
                  LeptonUndo *undo_to_do,
-                 char *save_filename,
                  gboolean redo,
-                 gboolean find_prev_data,
-                 int save_logging);
+                 gboolean find_prev_data);
 
 void o_undo_cleanup(void);
 

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -443,7 +443,6 @@
 
             s_slot_update_object
 
-            o_undo_callback
             o_undo_cleanup
             o_undo_find_prev_filename
             o_undo_find_prev_object_head
@@ -1054,7 +1053,6 @@
 
 ;;; o_undo.c
 (define-lff o_undo_init void '())
-(define-lff o_undo_callback void (list '* '* int))
 (define-lff o_undo_cleanup void '())
 (define-lff o_undo_find_prev_filename '* '(*))
 (define-lff o_undo_find_prev_object_head '* '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -1038,7 +1038,7 @@
 
 ;;; o_undo.c
 (define-lff o_undo_init void '())
-(define-lff o_undo_callback void (list '* '* int))
+(define-lff o_undo_callback void (list '* '* '* int))
 (define-lff o_undo_cleanup void '())
 (define-lff o_undo_savestate void (list '* '* int))
 (define-lff o_undo_savestate_old void (list '* int))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -481,6 +481,7 @@
 
             x_multiattrib_close
             x_multiattrib_open
+            x_multiattrib_update
 
             x_print
 
@@ -1021,6 +1022,7 @@
 ;;; x_multiattrib.c
 (define-lff x_multiattrib_close void '(*))
 (define-lff x_multiattrib_open void '(*))
+(define-lff x_multiattrib_update void '(*))
 
 ;;; x_newtext.c
 (define-lff text_input_dialog void '(*))
@@ -1052,7 +1054,7 @@
 
 ;;; o_undo.c
 (define-lff o_undo_init void '())
-(define-lff o_undo_callback void (list '* '* '* '* '* '* '* int int int))
+(define-lff o_undo_callback void (list '* '* int int))
 (define-lff o_undo_cleanup void '())
 (define-lff o_undo_find_prev_filename '* '(*))
 (define-lff o_undo_find_prev_object_head '* '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -382,6 +382,7 @@
             schematic_window_get_third_button
             schematic_window_get_third_button_cancel
             schematic_window_get_undo_panzoom
+            schematic_window_get_undo_type
             schematic_window_get_keyaccel_string
             schematic_window_set_keyaccel_string
             schematic_window_get_keyaccel_string_source_id
@@ -441,6 +442,8 @@
 
             o_undo_callback
             o_undo_cleanup
+            o_undo_find_prev_filename
+            o_undo_find_prev_object_head
             o_undo_init
             o_undo_savestate
             o_undo_savestate_old
@@ -694,6 +697,7 @@
 (define-lff schematic_window_get_third_button int '(*))
 (define-lff schematic_window_get_third_button_cancel int '(*))
 (define-lff schematic_window_get_undo_panzoom int '(*))
+(define-lff schematic_window_get_undo_type int '(*))
 (define-lff schematic_window_get_keyaccel_string '* '(*))
 (define-lff schematic_window_set_keyaccel_string void '(* *))
 (define-lff schematic_window_get_keyaccel_string_source_id int '(*))
@@ -1038,8 +1042,10 @@
 
 ;;; o_undo.c
 (define-lff o_undo_init void '())
-(define-lff o_undo_callback void (list '* '* '* '* int))
+(define-lff o_undo_callback void (list '* '* '* '* int int))
 (define-lff o_undo_cleanup void '())
+(define-lff o_undo_find_prev_filename '* '(*))
+(define-lff o_undo_find_prev_object_head '* '(*))
 (define-lff o_undo_savestate void (list '* '* int))
 (define-lff o_undo_savestate_old void (list '* int))
 (define-lff o_undo_savestate_viewport void '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -449,6 +449,8 @@
             o_undo_savestate_old
             o_undo_savestate_viewport
 
+            lepton_log_get_logging_enabled
+            lepton_log_set_logging_enabled
             s_log_close
 
             x_event_get_pointer_position
@@ -1042,7 +1044,7 @@
 
 ;;; o_undo.c
 (define-lff o_undo_init void '())
-(define-lff o_undo_callback void (list '* '* '* '* '* '* '* int int))
+(define-lff o_undo_callback void (list '* '* '* '* '* '* '* int int int))
 (define-lff o_undo_cleanup void '())
 (define-lff o_undo_find_prev_filename '* '(*))
 (define-lff o_undo_find_prev_object_head '* '(*))
@@ -1051,6 +1053,8 @@
 (define-lff o_undo_savestate_viewport void '(*))
 
 ;;; s_log.c
+(define-lff lepton_log_get_logging_enabled int '())
+(define-lff lepton_log_set_logging_enabled void (list int))
 (define-lff s_log_close void '())
 
 ;;; a_zoom.c

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -1042,7 +1042,7 @@
 
 ;;; o_undo.c
 (define-lff o_undo_init void '())
-(define-lff o_undo_callback void (list '* '* '* '* int int))
+(define-lff o_undo_callback void (list '* '* '* '* '* int int))
 (define-lff o_undo_cleanup void '())
 (define-lff o_undo_find_prev_filename '* '(*))
 (define-lff o_undo_find_prev_object_head '* '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -1038,7 +1038,7 @@
 
 ;;; o_undo.c
 (define-lff o_undo_init void '())
-(define-lff o_undo_callback void (list '* '* '* int))
+(define-lff o_undo_callback void (list '* '* '* '* int))
 (define-lff o_undo_cleanup void '())
 (define-lff o_undo_savestate void (list '* '* int))
 (define-lff o_undo_savestate_old void (list '* int))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -319,6 +319,7 @@
             lepton_menu_set_action_data
 
             gschem_page_view_get_page
+            gschem_page_view_get_page_geometry
             gschem_page_view_invalidate_all
             gschem_page_view_new_with_page
             gschem_page_view_pan
@@ -423,6 +424,8 @@
 
             gschem_options_widget_new
 
+            gschem_page_geometry_set_viewport
+
             gschem_text_properties_widget_new
             text_edit_dialog
 
@@ -445,6 +448,7 @@
             o_undo_find_prev_filename
             o_undo_find_prev_object_head
             o_undo_init
+            o_undo_modify_viewport
             o_undo_savestate
             o_undo_savestate_old
             o_undo_savestate_viewport
@@ -617,6 +621,7 @@
 
 ;;; gschem_page_view.c
 (define-lff gschem_page_view_get_page '* '(*))
+(define-lff gschem_page_view_get_page_geometry '* '(*))
 (define-lff gschem_page_view_invalidate_all void '(*))
 (define-lff gschem_page_view_new_with_page '* '(*))
 (define-lff gschem_page_view_pan void (list '* int int))
@@ -744,6 +749,9 @@
 
 ;;; gschem_options_widget.c
 (define-lff gschem_options_widget_new '* '(*))
+
+;;; gschem_page_geometry.c
+(define-lff gschem_page_geometry_set_viewport void (list '* int int double))
 
 ;;; gschem_text_properties_widget.c
 (define-lff gschem_text_properties_widget_new '* '(*))
@@ -1048,6 +1056,7 @@
 (define-lff o_undo_cleanup void '())
 (define-lff o_undo_find_prev_filename '* '(*))
 (define-lff o_undo_find_prev_object_head '* '(*))
+(define-lff o_undo_modify_viewport int '())
 (define-lff o_undo_savestate void (list '* '* int))
 (define-lff o_undo_savestate_old void (list '* int))
 (define-lff o_undo_savestate_viewport void '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -1042,7 +1042,7 @@
 
 ;;; o_undo.c
 (define-lff o_undo_init void '())
-(define-lff o_undo_callback void (list '* '* '* '* '* int int))
+(define-lff o_undo_callback void (list '* '* '* '* '* '* '* int int))
 (define-lff o_undo_cleanup void '())
 (define-lff o_undo_find_prev_filename '* '(*))
 (define-lff o_undo_find_prev_object_head '* '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -1054,7 +1054,7 @@
 
 ;;; o_undo.c
 (define-lff o_undo_init void '())
-(define-lff o_undo_callback void (list '* '* int int))
+(define-lff o_undo_callback void (list '* '* int))
 (define-lff o_undo_cleanup void '())
 (define-lff o_undo_find_prev_filename '* '(*))
 (define-lff o_undo_find_prev_object_head '* '(*))

--- a/libleptongui/scheme/schematic/undo.scm
+++ b/libleptongui/scheme/schematic/undo.scm
@@ -108,13 +108,23 @@ success, #f on failure."
                                                 (o_undo_find_prev_filename *undo-to-do))
                       (lepton_undo_set_object_list *undo-to-do
                                                    (o_undo_find_prev_object_head *undo-to-do))))
-                (o_undo_callback *window
-                                 *page
-                                 *current-undo
-                                 *undo-to-do
-                                 redo?
-                                 ;; See comments above.
-                                 search-for-previous-data?))))))))
+                ;; Save page filename to restore it later in case
+                ;; a temporary file is opened for undo.  The
+                ;; filename is stored as a Scheme string as the
+                ;; data pointed to by pointer returned by
+                ;; lepton_page_get_filename() is freed in between
+                ;; by lepton_page_set_filename() in
+                ;; o_undo_callback(), so we could get corrupted
+                ;; data otherwise.
+                (let ((save-filename (pointer->string (lepton_page_get_filename *page))))
+                  (o_undo_callback *window
+                                   *page
+                                   *current-undo
+                                   *undo-to-do
+                                   (string->pointer save-filename)
+                                   redo?
+                                   ;; See comments above.
+                                   search-for-previous-data?)))))))))
 
   (if undo-enabled?
       (let ((*page-view (gschem_toplevel_get_current_page_view *window)))

--- a/libleptongui/scheme/schematic/undo.scm
+++ b/libleptongui/scheme/schematic/undo.scm
@@ -201,9 +201,23 @@ success, #f on failure."
                     (lepton_page_set_undo_tos *page *save-undo-top)
                     (lepton_page_set_undo_current *page *current-undo)
 
+                    (if (not (true? redo?))
+                        ;; Undo action.
+                        (unless (null-pointer? (lepton_page_get_undo_current *page))
+                          (lepton_page_set_undo_current *page
+                                                        (lepton_undo_get_prev (lepton_page_get_undo_current *page)))
+                          (when (null-pointer? (lepton_page_get_undo_current *page))
+                            (lepton_page_set_undo_current *page
+                                                          (lepton_page_get_undo_bottom *page))))
+                        ;; Redo action.
+                        (unless (null-pointer? (lepton_page_get_undo_current *page))
+                          (lepton_page_set_undo_current *page
+                                                        (lepton_undo_get_next (lepton_page_get_undo_current *page)))
+                          (when (null-pointer? (lepton_page_get_undo_current *page))
+                            (lepton_page_set_undo_current *page
+                                                          (lepton_page_get_undo_tos *page)))))
                     (o_undo_callback *page
                                      *undo-to-do
-                                     redo?
                                      ;; See comments above.
                                      search-for-previous-data?))))))))))
 

--- a/libleptongui/scheme/schematic/undo.scm
+++ b/libleptongui/scheme/schematic/undo.scm
@@ -70,7 +70,8 @@ success, #f on failure."
   (define (page-undo-callback *window *page redo?)
     (unless (null-pointer? *page)
       (let ((*current-undo (lepton_page_get_undo_current *page)))
-        (o_undo_callback *window *page *current-undo redo?))))
+        (unless (null-pointer? *current-undo)
+          (o_undo_callback *window *page *current-undo redo?)))))
 
   (if undo-enabled?
       (let ((*page-view (gschem_toplevel_get_current_page_view *window)))

--- a/libleptongui/scheme/schematic/undo.scm
+++ b/libleptongui/scheme/schematic/undo.scm
@@ -116,10 +116,20 @@ success, #f on failure."
                 ;; by lepton_page_set_filename() in
                 ;; o_undo_callback(), so we could get corrupted
                 ;; data otherwise.
-                (let ((save-filename (pointer->string (lepton_page_get_filename *page))))
+                (let ((save-filename (pointer->string (lepton_page_get_filename *page)))
+                      ;; Save undo structure so it's not nuked.
+                      (*save-undo-bottom (lepton_page_get_undo_bottom *page))
+                      (*save-undo-top (lepton_page_get_undo_tos *page)))
+                  ;; Initialize a new undo structure.
+                  (lepton_page_set_undo_bottom *page %null-pointer)
+                  (lepton_page_set_undo_tos *page %null-pointer)
+                  (lepton_page_set_undo_current *page %null-pointer)
+
                   (o_undo_callback *window
                                    *page
                                    *current-undo
+                                   *save-undo-bottom
+                                   *save-undo-top
                                    *undo-to-do
                                    (string->pointer save-filename)
                                    redo?

--- a/libleptongui/scheme/schematic/undo.scm
+++ b/libleptongui/scheme/schematic/undo.scm
@@ -65,13 +65,18 @@ success, #f on failure."
     (config-boolean (path-config-context (getcwd))
                     "schematic.undo"
                     "undo-control"))
+
+  (define (page-undo-callback *window *page redo?)
+    (unless (null-pointer? *page)
+      (o_undo_callback *window *page redo?)))
+
   (if undo-enabled?
       (let ((*page-view (gschem_toplevel_get_current_page_view *window)))
         (if (null-pointer? *page-view)
             (log! 'warning "undo-callback: NULL page view.")
-            (let ((*page (gschem_page_view_get_page *page-view)))
-              (unless (null-pointer? *page)
-                (o_undo_callback *window *page redo?)))))
+            (page-undo-callback *window
+                                (gschem_page_view_get_page *page-view)
+                                redo?)))
       (log! 'message (G_ "Undo/Redo is disabled in configuration"))))
 
 

--- a/libleptongui/scheme/schematic/undo.scm
+++ b/libleptongui/scheme/schematic/undo.scm
@@ -186,17 +186,26 @@ success, #f on failure."
                             (gschem_page_view_zoom_extents *page-view
                                                            (lepton_undo_get_object_list *undo-to-do)))))
 
-                    (o_undo_callback *window
-                                     *page
-                                     *current-undo
-                                     *save-undo-bottom
-                                     *save-undo-top
+                    ;; Restore logging.
+                    (lepton_log_set_logging_enabled save-logging?)
+                    ;; Set filename right.
+                    (lepton_page_set_filename *page
+                                              (string->pointer save-filename))
+                    ;; Final redraw.
+                    (page_select_widget_update *window)
+                    (x_multiattrib_update *window)
+                    (i_update_menus *window)
+
+                    ;; Restore saved undo structures.
+                    (lepton_page_set_undo_bottom *page *save-undo-bottom)
+                    (lepton_page_set_undo_tos *page *save-undo-top)
+                    (lepton_page_set_undo_current *page *current-undo)
+
+                    (o_undo_callback *page
                                      *undo-to-do
-                                     (string->pointer save-filename)
                                      redo?
                                      ;; See comments above.
-                                     search-for-previous-data?
-                                     save-logging?))))))))))
+                                     search-for-previous-data?))))))))))
 
   (if undo-enabled?
       (let ((*page-view (gschem_toplevel_get_current_page_view *window)))

--- a/libleptongui/scheme/schematic/undo.scm
+++ b/libleptongui/scheme/schematic/undo.scm
@@ -22,6 +22,7 @@
   #:use-module (system foreign)
 
   #:use-module (lepton ffi boolean)
+  #:use-module (lepton ffi undo)
   #:use-module (lepton ffi)
   #:use-module (lepton config)
   #:use-module (lepton log)
@@ -71,7 +72,13 @@ success, #f on failure."
     (unless (null-pointer? *page)
       (let ((*current-undo (lepton_page_get_undo_current *page)))
         (unless (null-pointer? *current-undo)
-          (o_undo_callback *window *page *current-undo redo?)))))
+          (let ((*undo-to-do (if (true? redo?)
+                                 ;; Redo action.
+                                 (lepton_undo_get_next *current-undo)
+                                 ;; Undo action.
+                                 (lepton_undo_get_prev *current-undo))))
+            (unless (null-pointer? *undo-to-do)
+              (o_undo_callback *window *page *current-undo *undo-to-do redo?)))))))
 
   (if undo-enabled?
       (let ((*page-view (gschem_toplevel_get_current_page_view *window)))

--- a/libleptongui/scheme/schematic/undo.scm
+++ b/libleptongui/scheme/schematic/undo.scm
@@ -216,10 +216,18 @@ success, #f on failure."
                           (when (null-pointer? (lepton_page_get_undo_current *page))
                             (lepton_page_set_undo_current *page
                                                           (lepton_page_get_undo_tos *page)))))
-                    (o_undo_callback *page
-                                     *undo-to-do
-                                     ;; See comments above.
-                                     search-for-previous-data?))))))))))
+                    ;; Don't have to free data here since 'filename' or 'object_list' are
+                    ;; just pointers to the real data (lower in the stack).
+                    (when (true? search-for-previous-data?)
+                      (lepton_undo_set_filename *undo-to-do %null-pointer)
+                      (lepton_undo_set_object_list *undo-to-do %null-pointer))
+
+                    ;; Debugging stuff.
+                    (log! 'debug "\n\n---Undo----\n")
+                    (lepton_undo_print_all (lepton_page_get_undo_bottom *page))
+                    (log! 'debug "TOS: ~A\n" (lepton_undo_get_filename (lepton_page_get_undo_tos *page)))
+                    (log! 'debug "CURRENT: ~A\n" (lepton_undo_get_filename (lepton_page_get_undo_current *page)))
+                    (log! 'debug "----\n"))))))))))
 
   (if undo-enabled?
       (let ((*page-view (gschem_toplevel_get_current_page_view *window)))

--- a/libleptongui/scheme/schematic/undo.scm
+++ b/libleptongui/scheme/schematic/undo.scm
@@ -22,6 +22,7 @@
   #:use-module (system foreign)
 
   #:use-module (lepton ffi boolean)
+  #:use-module (lepton ffi)
   #:use-module (lepton config)
   #:use-module (lepton log)
 
@@ -68,7 +69,8 @@ success, #f on failure."
 
   (define (page-undo-callback *window *page redo?)
     (unless (null-pointer? *page)
-      (o_undo_callback *window *page redo?)))
+      (let ((*current-undo (lepton_page_get_undo_current *page)))
+        (o_undo_callback *window *page *current-undo redo?))))
 
   (if undo-enabled?
       (let ((*page-view (gschem_toplevel_get_current_page_view *window)))

--- a/libleptongui/scheme/schematic/undo.scm
+++ b/libleptongui/scheme/schematic/undo.scm
@@ -128,6 +128,17 @@ success, #f on failure."
                   ;; Unselect all objects.
                   (o_select_unselect_all *window)
 
+                  (when (or (and (= (schematic_window_get_undo_type *window) UNDO_DISK)
+                                 (not (null-pointer? (lepton_undo_get_filename *undo-to-do))))
+                            (and (= (schematic_window_get_undo_type *window) UNDO_MEMORY)
+                                 (not (null-pointer? (lepton_undo_get_object_list *undo-to-do)))))
+                    ;; Delete page objects.
+                    (lepton_page_delete_objects *page)
+                    ;; Free the objects in the place list.
+                    (schematic_window_delete_place_list *window)
+                    ;; Mark active page as changed.
+                    (schematic_window_active_page_changed *window))
+
                   (o_undo_callback *window
                                    *page
                                    *current-undo

--- a/libleptongui/scheme/schematic/undo.scm
+++ b/libleptongui/scheme/schematic/undo.scm
@@ -125,6 +125,9 @@ success, #f on failure."
                   (lepton_page_set_undo_tos *page %null-pointer)
                   (lepton_page_set_undo_current *page %null-pointer)
 
+                  ;; Unselect all objects.
+                  (o_select_unselect_all *window)
+
                   (o_undo_callback *window
                                    *page
                                    *current-undo

--- a/libleptongui/scheme/schematic/undo.scm
+++ b/libleptongui/scheme/schematic/undo.scm
@@ -139,16 +139,23 @@ success, #f on failure."
                     ;; Mark active page as changed.
                     (schematic_window_active_page_changed *window))
 
-                  (o_undo_callback *window
-                                   *page
-                                   *current-undo
-                                   *save-undo-bottom
-                                   *save-undo-top
-                                   *undo-to-do
-                                   (string->pointer save-filename)
-                                   redo?
-                                   ;; See comments above.
-                                   search-for-previous-data?)))))))))
+                  (let ((save-logging? (lepton_log_get_logging_enabled)))
+                    ;; Temporarily disable logging.  It will be
+                    ;; enabled in o_undo_callback() after undo is
+                    ;; accomplished.
+                    (lepton_log_set_logging_enabled FALSE)
+
+                    (o_undo_callback *window
+                                     *page
+                                     *current-undo
+                                     *save-undo-bottom
+                                     *save-undo-top
+                                     *undo-to-do
+                                     (string->pointer save-filename)
+                                     redo?
+                                     ;; See comments above.
+                                     search-for-previous-data?
+                                     save-logging?))))))))))
 
   (if undo-enabled?
       (let ((*page-view (gschem_toplevel_get_current_page_view *window)))

--- a/libleptongui/scheme/schematic/undo.scm
+++ b/libleptongui/scheme/schematic/undo.scm
@@ -168,6 +168,11 @@ success, #f on failure."
                           (lepton_page_append_list *page
                                                    (o_glist_copy_all (lepton_undo_get_object_list *undo-to-do)
                                                                      %null-pointer))))
+                    (lepton_page_set_page_control *page
+                                                  (lepton_undo_get_page_control *undo-to-do))
+                    (lepton_page_set_up *page (lepton_undo_get_up *undo-to-do))
+                    (gschem_toplevel_page_content_changed *window *page)
+
                     (o_undo_callback *window
                                      *page
                                      *current-undo

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -399,6 +399,7 @@ GList *o_undo_find_prev_object_head (LeptonUndo *start)
 void
 o_undo_callback (GschemToplevel *w_current,
                  LeptonPage *page,
+                 LeptonUndo *current_undo,
                  gboolean redo)
 {
   LeptonToplevel *toplevel = gschem_toplevel_get_toplevel (w_current);
@@ -413,8 +414,6 @@ o_undo_callback (GschemToplevel *w_current,
 
   g_return_if_fail (w_current != NULL);
   g_return_if_fail (page != NULL);
-
-  LeptonUndo *current_undo = lepton_page_get_undo_current (page);
 
   if (current_undo == NULL)
   {

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -401,6 +401,7 @@ o_undo_callback (GschemToplevel *w_current,
                  LeptonPage *page,
                  LeptonUndo *current_undo,
                  LeptonUndo *undo_to_do,
+                 char *save_filename,
                  gboolean redo,
                  gboolean find_prev_data)
 {
@@ -410,13 +411,8 @@ o_undo_callback (GschemToplevel *w_current,
   LeptonUndo *save_current;
   int save_logging;
 
-  char *save_filename;
-
   g_return_if_fail (w_current != NULL);
   g_return_if_fail (page != NULL);
-
-  /* save filename */
-  save_filename = g_strdup (lepton_page_get_filename (page));
 
   /* save structure so it's not nuked */
   save_bottom = lepton_page_get_undo_bottom (page);
@@ -491,7 +487,6 @@ o_undo_callback (GschemToplevel *w_current,
 
   /* set filename right */
   lepton_page_set_filename (page, save_filename);
-  g_free(save_filename);
 
   /* final redraw */
   page_select_widget_update (w_current);

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -413,8 +413,6 @@ o_undo_callback (GschemToplevel *w_current,
   g_return_if_fail (w_current != NULL);
   g_return_if_fail (page != NULL);
 
-  o_select_unselect_all (w_current);
-
   if ((schematic_window_get_undo_type (w_current) == UNDO_DISK
        && lepton_undo_get_filename (undo_to_do)) ||
       (schematic_window_get_undo_type (w_current) == UNDO_MEMORY

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -414,8 +414,8 @@ o_undo_callback (GschemToplevel *w_current,
   g_return_if_fail (page != NULL);
 
   /* temporarily disable logging */
-  save_logging = do_logging;
-  do_logging = FALSE;
+  save_logging = lepton_log_get_logging_enabled ();
+  lepton_log_set_logging_enabled (FALSE);
 
   if (schematic_window_get_undo_type (w_current) == UNDO_DISK
       && lepton_undo_get_filename (undo_to_do))
@@ -458,7 +458,7 @@ o_undo_callback (GschemToplevel *w_current,
   }
 
   /* restore logging */
-  do_logging = save_logging;
+  lepton_log_set_logging_enabled (save_logging);
 
   /* set filename right */
   lepton_page_set_filename (page, save_filename);

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -405,17 +405,13 @@ o_undo_callback (GschemToplevel *w_current,
                  LeptonUndo *undo_to_do,
                  char *save_filename,
                  gboolean redo,
-                 gboolean find_prev_data)
+                 gboolean find_prev_data,
+                 int save_logging)
 {
   LeptonToplevel *toplevel = gschem_toplevel_get_toplevel (w_current);
-  int save_logging;
 
   g_return_if_fail (w_current != NULL);
   g_return_if_fail (page != NULL);
-
-  /* temporarily disable logging */
-  save_logging = lepton_log_get_logging_enabled ();
-  lepton_log_set_logging_enabled (FALSE);
 
   if (schematic_window_get_undo_type (w_current) == UNDO_DISK
       && lepton_undo_get_filename (undo_to_do))

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -408,27 +408,8 @@ o_undo_callback (GschemToplevel *w_current,
                  gboolean find_prev_data,
                  int save_logging)
 {
-  LeptonToplevel *toplevel = gschem_toplevel_get_toplevel (w_current);
-
   g_return_if_fail (w_current != NULL);
   g_return_if_fail (page != NULL);
-
-  if (schematic_window_get_undo_type (w_current) == UNDO_DISK
-      && lepton_undo_get_filename (undo_to_do))
-  {
-    /*
-     * F_OPEN_RESTORE_CWD: go back from tmp directory,
-     * so that local config files can be read:
-    */
-    f_open (toplevel, page, lepton_undo_get_filename (undo_to_do), F_OPEN_RESTORE_CWD, NULL);
-  }
-  else if (schematic_window_get_undo_type (w_current) == UNDO_MEMORY
-           && lepton_undo_get_object_list (undo_to_do))
-  {
-    lepton_page_append_list (page,
-                             o_glist_copy_all (lepton_undo_get_object_list (undo_to_do),
-                                               NULL));
-  }
 
   lepton_page_set_page_control (page, lepton_undo_get_page_control (undo_to_do));
   lepton_page_set_up (page, lepton_undo_get_up (undo_to_do));

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -411,10 +411,6 @@ o_undo_callback (GschemToplevel *w_current,
   g_return_if_fail (w_current != NULL);
   g_return_if_fail (page != NULL);
 
-  lepton_page_set_page_control (page, lepton_undo_get_page_control (undo_to_do));
-  lepton_page_set_up (page, lepton_undo_get_up (undo_to_do));
-  gschem_toplevel_page_content_changed (w_current, page);
-
   GschemPageView *view = gschem_toplevel_get_current_page_view (w_current);
   g_return_if_fail (view != NULL);
 

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -415,11 +415,6 @@ o_undo_callback (GschemToplevel *w_current,
   g_return_if_fail (w_current != NULL);
   g_return_if_fail (page != NULL);
 
-  if (current_undo == NULL)
-  {
-    return;
-  }
-
   if (!redo)
   {
     /* Undo action. */

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -400,10 +400,10 @@ void
 o_undo_callback (GschemToplevel *w_current,
                  LeptonPage *page,
                  LeptonUndo *current_undo,
+                 LeptonUndo *undo_to_do,
                  gboolean redo)
 {
   LeptonToplevel *toplevel = gschem_toplevel_get_toplevel (w_current);
-  LeptonUndo *undo_to_do;
   LeptonUndo *save_bottom;
   LeptonUndo *save_tos;
   LeptonUndo *save_current;
@@ -414,22 +414,6 @@ o_undo_callback (GschemToplevel *w_current,
 
   g_return_if_fail (w_current != NULL);
   g_return_if_fail (page != NULL);
-
-  if (!redo)
-  {
-    /* Undo action. */
-    undo_to_do = lepton_undo_get_prev (current_undo);
-  }
-  else
-  {
-    /* Redo action. */
-    undo_to_do = lepton_undo_get_next (current_undo);
-  }
-
-  if (undo_to_do == NULL)
-  {
-    return;
-  }
 
   if (lepton_undo_get_type (current_undo) == UNDO_ALL
       && lepton_undo_get_type (undo_to_do) == UNDO_VIEWPORT_ONLY)

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -400,25 +400,18 @@ void
 o_undo_callback (GschemToplevel *w_current,
                  LeptonPage *page,
                  LeptonUndo *save_current,
+                 LeptonUndo *save_bottom,
+                 LeptonUndo *save_tos,
                  LeptonUndo *undo_to_do,
                  char *save_filename,
                  gboolean redo,
                  gboolean find_prev_data)
 {
   LeptonToplevel *toplevel = gschem_toplevel_get_toplevel (w_current);
-  LeptonUndo *save_bottom;
-  LeptonUndo *save_tos;
   int save_logging;
 
   g_return_if_fail (w_current != NULL);
   g_return_if_fail (page != NULL);
-
-  /* save structure so it's not nuked */
-  save_bottom = lepton_page_get_undo_bottom (page);
-  save_tos = lepton_page_get_undo_tos (page);
-  lepton_page_set_undo_bottom (page, NULL);
-  lepton_page_set_undo_tos (page, NULL);
-  lepton_page_set_undo_current (page, NULL);
 
   o_select_unselect_all (w_current);
 

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -393,41 +393,13 @@ GList *o_undo_find_prev_object_head (LeptonUndo *start)
 /*! \todo Finish function documentation!!!
  *  \brief
  *  \par Function Description
- *
- *  If \a redo is TRUE, do "redo" instead of "undo".
  */
 void
 o_undo_callback (LeptonPage *page,
                  LeptonUndo *undo_to_do,
-                 gboolean redo,
                  gboolean find_prev_data)
 {
   g_return_if_fail (page != NULL);
-
-  if (!redo)
-  {
-    /* Undo action. */
-    if (lepton_page_get_undo_current (page))
-    {
-      lepton_page_set_undo_current (page, lepton_undo_get_prev (lepton_page_get_undo_current (page)));
-      if (lepton_page_get_undo_current (page) == NULL)
-      {
-        lepton_page_set_undo_current (page, lepton_page_get_undo_bottom (page));
-      }
-    }
-  }
-  else
-  {
-    /* Redo action. */
-    if (lepton_page_get_undo_current (page))
-    {
-      lepton_page_set_undo_current (page, lepton_undo_get_next (lepton_page_get_undo_current (page)));
-      if (lepton_page_get_undo_current (page) == NULL)
-      {
-        lepton_page_set_undo_current (page, lepton_page_get_undo_tos (page));
-      }
-    }
-  }
 
   /* don't have to free data here since filename, object_list are */
   /* just pointers to the real data (lower in the stack) */

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -79,7 +79,7 @@ void o_undo_init(void)
  * \return TRUE if undo/redo can modify viewport, FALSE otherwise.
  */
 
-static gboolean
+gboolean
 o_undo_modify_viewport()
 {
   gboolean result = FALSE; /* option's default value */
@@ -410,25 +410,6 @@ o_undo_callback (GschemToplevel *w_current,
 {
   g_return_if_fail (w_current != NULL);
   g_return_if_fail (page != NULL);
-
-  GschemPageView *view = gschem_toplevel_get_current_page_view (w_current);
-  g_return_if_fail (view != NULL);
-
-  GschemPageGeometry *geometry = gschem_page_view_get_page_geometry (view);
-
-  if (schematic_window_get_undo_panzoom (w_current) || o_undo_modify_viewport())
-  {
-    if (lepton_undo_get_scale (undo_to_do) != 0)
-    {
-      gschem_page_geometry_set_viewport (geometry,
-                                         lepton_undo_get_x (undo_to_do),
-                                         lepton_undo_get_y (undo_to_do),
-                                         lepton_undo_get_scale (undo_to_do));
-      gschem_page_view_invalidate_all (view);
-    } else {
-      gschem_page_view_zoom_extents (view, lepton_undo_get_object_list (undo_to_do));
-    }
-  }
 
   /* restore logging */
   lepton_log_set_logging_enabled (save_logging);

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -401,37 +401,19 @@ o_undo_callback (GschemToplevel *w_current,
                  LeptonPage *page,
                  LeptonUndo *current_undo,
                  LeptonUndo *undo_to_do,
-                 gboolean redo)
+                 gboolean redo,
+                 gboolean find_prev_data)
 {
   LeptonToplevel *toplevel = gschem_toplevel_get_toplevel (w_current);
   LeptonUndo *save_bottom;
   LeptonUndo *save_tos;
   LeptonUndo *save_current;
   int save_logging;
-  int find_prev_data=FALSE;
 
   char *save_filename;
 
   g_return_if_fail (w_current != NULL);
   g_return_if_fail (page != NULL);
-
-  if (lepton_undo_get_type (current_undo) == UNDO_ALL
-      && lepton_undo_get_type (undo_to_do) == UNDO_VIEWPORT_ONLY)
-  {
-#if DEBUG
-    printf("Type: %d\n", lepton_undo_get_type (undo_to_do));
-    printf("Current is an undo all, next is viewport only!\n");
-#endif
-    find_prev_data = TRUE;
-
-    if (schematic_window_get_undo_type (w_current) == UNDO_DISK)
-    {
-      lepton_undo_set_filename (undo_to_do, o_undo_find_prev_filename (undo_to_do));
-    } else {
-      lepton_undo_set_object_list (undo_to_do,
-                                   o_undo_find_prev_object_head (undo_to_do));
-    }
-  }
 
   /* save filename */
   save_filename = g_strdup (lepton_page_get_filename (page));

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -399,7 +399,7 @@ GList *o_undo_find_prev_object_head (LeptonUndo *start)
 void
 o_undo_callback (GschemToplevel *w_current,
                  LeptonPage *page,
-                 LeptonUndo *current_undo,
+                 LeptonUndo *save_current,
                  LeptonUndo *undo_to_do,
                  char *save_filename,
                  gboolean redo,
@@ -408,7 +408,6 @@ o_undo_callback (GschemToplevel *w_current,
   LeptonToplevel *toplevel = gschem_toplevel_get_toplevel (w_current);
   LeptonUndo *save_bottom;
   LeptonUndo *save_tos;
-  LeptonUndo *save_current;
   int save_logging;
 
   g_return_if_fail (w_current != NULL);
@@ -417,7 +416,6 @@ o_undo_callback (GschemToplevel *w_current,
   /* save structure so it's not nuked */
   save_bottom = lepton_page_get_undo_bottom (page);
   save_tos = lepton_page_get_undo_tos (page);
-  save_current = current_undo;
   lepton_page_set_undo_bottom (page, NULL);
   lepton_page_set_undo_tos (page, NULL);
   lepton_page_set_undo_current (page, NULL);

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -413,20 +413,6 @@ o_undo_callback (GschemToplevel *w_current,
   g_return_if_fail (w_current != NULL);
   g_return_if_fail (page != NULL);
 
-  if ((schematic_window_get_undo_type (w_current) == UNDO_DISK
-       && lepton_undo_get_filename (undo_to_do)) ||
-      (schematic_window_get_undo_type (w_current) == UNDO_MEMORY
-       && lepton_undo_get_object_list (undo_to_do)))
-  {
-    /* delete objects of page */
-    lepton_page_delete_objects (page);
-
-    /* Free the objects in the place list. */
-    schematic_window_delete_place_list (w_current);
-
-    schematic_window_active_page_changed (w_current);
-  }
-
   /* temporarily disable logging */
   save_logging = do_logging;
   do_logging = FALSE;

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -390,32 +390,6 @@ GList *o_undo_find_prev_object_head (LeptonUndo *start)
   return(NULL);
 }
 
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- */
-void
-o_undo_callback (LeptonPage *page,
-                 LeptonUndo *undo_to_do,
-                 gboolean find_prev_data)
-{
-  g_return_if_fail (page != NULL);
-
-  /* don't have to free data here since filename, object_list are */
-  /* just pointers to the real data (lower in the stack) */
-  if (find_prev_data) {
-    lepton_undo_set_filename (undo_to_do, NULL);
-    lepton_undo_set_object_list (undo_to_do, NULL);
-  }
-
-#if DEBUG
-  printf("\n\n---Undo----\n");
-  lepton_undo_print_all (lepton_page_get_undo_bottom (page));
-  printf("TOS: %s\n", lepton_undo_get_filename (lepton_page_get_undo_tos (page)));
-  printf("CURRENT: %s\n", lepton_undo_get_filename (lepton_page_get_undo_current (page)));
-  printf("----\n");
-#endif
-}
 
 /*! \todo Finish function documentation!!!
  *  \brief

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -397,35 +397,12 @@ GList *o_undo_find_prev_object_head (LeptonUndo *start)
  *  If \a redo is TRUE, do "redo" instead of "undo".
  */
 void
-o_undo_callback (GschemToplevel *w_current,
-                 LeptonPage *page,
-                 LeptonUndo *save_current,
-                 LeptonUndo *save_bottom,
-                 LeptonUndo *save_tos,
+o_undo_callback (LeptonPage *page,
                  LeptonUndo *undo_to_do,
-                 char *save_filename,
                  gboolean redo,
-                 gboolean find_prev_data,
-                 int save_logging)
+                 gboolean find_prev_data)
 {
-  g_return_if_fail (w_current != NULL);
   g_return_if_fail (page != NULL);
-
-  /* restore logging */
-  lepton_log_set_logging_enabled (save_logging);
-
-  /* set filename right */
-  lepton_page_set_filename (page, save_filename);
-
-  /* final redraw */
-  page_select_widget_update (w_current);
-  x_multiattrib_update (w_current);
-  i_update_menus(w_current);
-
-  /* restore saved undo structures */
-  lepton_page_set_undo_bottom (page, save_bottom);
-  lepton_page_set_undo_tos (page, save_tos);
-  lepton_page_set_undo_current (page, save_current);
 
   if (!redo)
   {


### PR DESCRIPTION
- Several `liblepton` functions related to undo/redo are now available for using in Scheme.
- What's important, one of calls to `f_open()` is now carried out in Scheme as well.  In future, I'm going to move all calls to that function to Scheme in order to refactor Lepton's RC system.
- One debugging function has been amended so the debugging info is now available via Gtk debugging facilities.