### PR TITLE
Get rid of some C variables in sch2pcb

### DIFF
--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -223,12 +223,6 @@ GList*
 sch2pcb_get_schematics ();
 
 int
-sch2pcb_get_n_changed_value ();
-
-void
-sch2pcb_set_n_changed_value (int val);
-
-int
 sch2pcb_get_n_empty ();
 
 void

--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -253,12 +253,6 @@ void
 sch2pcb_set_n_PKG_removed_old (int val);
 
 int
-sch2pcb_get_n_preserved ();
-
-void
-sch2pcb_set_n_preserved (int val);
-
-int
 sch2pcb_get_n_unknown ();
 
 void

--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -229,12 +229,6 @@ void
 sch2pcb_set_n_changed_value (int val);
 
 int
-sch2pcb_get_n_deleted ();
-
-void
-sch2pcb_set_n_deleted (int val);
-
-int
 sch2pcb_get_n_empty ();
 
 void

--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -246,12 +246,6 @@ sch2pcb_get_n_unknown ();
 void
 sch2pcb_set_n_unknown (int val);
 
-gboolean
-sch2pcb_get_need_PKG_purge ();
-
-void
-sch2pcb_set_need_PKG_purge (gboolean val);
-
 FILE*
 sch2pcb_open_file_to_read (char *filename);
 

--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -235,12 +235,6 @@ void
 sch2pcb_set_n_none (int val);
 
 int
-sch2pcb_get_n_PKG_removed_old ();
-
-void
-sch2pcb_set_n_PKG_removed_old (int val);
-
-int
 sch2pcb_get_n_unknown ();
 
 void

--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -179,12 +179,6 @@ pcb_element_pkg_to_element (gchar *pkg_line);
 
 /* lepton-sch2pcb's toplevel functions */
 
-gboolean
-sch2pcb_get_bak_done ();
-
-void
-sch2pcb_set_bak_done (gboolean val);
-
 char*
 sch2pcb_get_empty_footprint_name ();
 

--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -219,12 +219,6 @@ sch2pcb_make_pcb_element_list (gchar *pcb_file);
 GList*
 sch2pcb_get_pcb_element_list ();
 
-gboolean
-sch2pcb_get_preserve ();
-
-void
-sch2pcb_set_preserve (gboolean val);
-
 GList*
 sch2pcb_get_schematics ();
 

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -54,8 +54,6 @@
             sch2pcb_set_n_PKG_removed_old
             sch2pcb_get_n_changed_value
             sch2pcb_set_n_changed_value
-            sch2pcb_get_n_deleted
-            sch2pcb_set_n_deleted
             sch2pcb_get_n_empty
             sch2pcb_get_n_none
             sch2pcb_get_n_unknown
@@ -106,8 +104,6 @@
 (define-lff sch2pcb_set_n_PKG_removed_old void (list int))
 (define-lff sch2pcb_get_n_changed_value int '())
 (define-lff sch2pcb_set_n_changed_value void (list int))
-(define-lff sch2pcb_get_n_deleted int '())
-(define-lff sch2pcb_set_n_deleted void (list int))
 (define-lff sch2pcb_get_n_empty int '())
 (define-lff sch2pcb_get_n_none int '())
 (define-lff sch2pcb_get_n_unknown int '())

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -58,8 +58,6 @@
             sch2pcb_set_n_deleted
             sch2pcb_get_n_empty
             sch2pcb_get_n_none
-            sch2pcb_get_n_preserved
-            sch2pcb_set_n_preserved
             sch2pcb_get_n_unknown
             sch2pcb_get_need_PKG_purge
             sch2pcb_set_need_PKG_purge
@@ -112,8 +110,6 @@
 (define-lff sch2pcb_set_n_deleted void (list int))
 (define-lff sch2pcb_get_n_empty int '())
 (define-lff sch2pcb_get_n_none int '())
-(define-lff sch2pcb_get_n_preserved int '())
-(define-lff sch2pcb_set_n_preserved void (list int))
 (define-lff sch2pcb_get_n_unknown int '())
 (define-lff sch2pcb_get_need_PKG_purge int '())
 (define-lff sch2pcb_set_need_PKG_purge void (list int))

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -55,8 +55,6 @@
             sch2pcb_get_n_empty
             sch2pcb_get_n_none
             sch2pcb_get_n_unknown
-            sch2pcb_get_need_PKG_purge
-            sch2pcb_set_need_PKG_purge
             sch2pcb_parse_schematics
             sch2pcb_get_pcb_element_list
             sch2pcb_pcb_element_list_append
@@ -103,8 +101,6 @@
 (define-lff sch2pcb_get_n_empty int '())
 (define-lff sch2pcb_get_n_none int '())
 (define-lff sch2pcb_get_n_unknown int '())
-(define-lff sch2pcb_get_need_PKG_purge int '())
-(define-lff sch2pcb_set_need_PKG_purge void (list int))
 (define-lff sch2pcb_parse_schematics '* '(*))
 (define-lff sch2pcb_get_pcb_element_list '* '())
 (define-lff sch2pcb_pcb_element_list_append void '(*))

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -42,8 +42,6 @@
             pcb_element_line_parse
             pcb_element_pkg_to_element
 
-            sch2pcb_get_bak_done
-            sch2pcb_set_bak_done
             sch2pcb_buffer_to_file
             sch2pcb_get_empty_footprint_name
             sch2pcb_set_empty_footprint_name
@@ -86,8 +84,6 @@
 (define-lff pcb_element_line_parse '* '(*))
 (define-lff pcb_element_pkg_to_element '* '(*))
 
-(define-lff sch2pcb_get_bak_done int '())
-(define-lff sch2pcb_set_bak_done void (list int))
 (define-lff sch2pcb_buffer_to_file void '(* *))
 (define-lff sch2pcb_get_empty_footprint_name '* '())
 (define-lff sch2pcb_set_empty_footprint_name void '(*))

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -50,8 +50,6 @@
             sch2pcb_find_element
             sch2pcb_increment_verbose_mode
             sch2pcb_insert_element
-            sch2pcb_get_n_PKG_removed_old
-            sch2pcb_set_n_PKG_removed_old
             sch2pcb_get_n_empty
             sch2pcb_get_n_none
             sch2pcb_get_n_unknown
@@ -96,8 +94,6 @@
 (define-lff sch2pcb_find_element '* '(* *))
 (define-lff sch2pcb_increment_verbose_mode void '())
 (define-lff sch2pcb_insert_element int '(* * * * *))
-(define-lff sch2pcb_get_n_PKG_removed_old int '())
-(define-lff sch2pcb_set_n_PKG_removed_old void (list int))
 (define-lff sch2pcb_get_n_empty int '())
 (define-lff sch2pcb_get_n_none int '())
 (define-lff sch2pcb_get_n_unknown int '())

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -66,8 +66,6 @@
             sch2pcb_parse_schematics
             sch2pcb_get_pcb_element_list
             sch2pcb_pcb_element_list_append
-            sch2pcb_get_preserve
-            sch2pcb_set_preserve
             sch2pcb_get_verbose_mode
             sch2pcb_open_file_to_read
             sch2pcb_open_file_to_write
@@ -122,8 +120,6 @@
 (define-lff sch2pcb_parse_schematics '* '(*))
 (define-lff sch2pcb_get_pcb_element_list '* '())
 (define-lff sch2pcb_pcb_element_list_append void '(*))
-(define-lff sch2pcb_get_preserve int '())
-(define-lff sch2pcb_set_preserve void (list int))
 (define-lff sch2pcb_get_verbose_mode int '())
 (define-lff sch2pcb_open_file_to_read '* '(*))
 (define-lff sch2pcb_open_file_to_write '* '(*))

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -52,8 +52,6 @@
             sch2pcb_insert_element
             sch2pcb_get_n_PKG_removed_old
             sch2pcb_set_n_PKG_removed_old
-            sch2pcb_get_n_changed_value
-            sch2pcb_set_n_changed_value
             sch2pcb_get_n_empty
             sch2pcb_get_n_none
             sch2pcb_get_n_unknown
@@ -102,8 +100,6 @@
 (define-lff sch2pcb_insert_element int '(* * * * *))
 (define-lff sch2pcb_get_n_PKG_removed_old int '())
 (define-lff sch2pcb_set_n_PKG_removed_old void (list int))
-(define-lff sch2pcb_get_n_changed_value int '())
-(define-lff sch2pcb_set_n_changed_value void (list int))
 (define-lff sch2pcb_get_n_empty int '())
 (define-lff sch2pcb_get_n_none int '())
 (define-lff sch2pcb_get_n_unknown int '())

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -307,21 +307,6 @@ sch2pcb_set_empty_footprint_name (char *val)
 }
 
 
-static int n_changed_value;
-
-int
-sch2pcb_get_n_changed_value ()
-{
-  return n_changed_value;
-}
-
-void
-sch2pcb_set_n_changed_value (int val)
-{
-  n_changed_value = val;
-}
-
-
 static int n_empty;
 
 int

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -427,21 +427,6 @@ sch2pcb_set_need_PKG_purge (gboolean val)
 }
 
 
-static gboolean preserve;
-
-gboolean
-sch2pcb_get_preserve ()
-{
-  return preserve;
-}
-
-void
-sch2pcb_set_preserve (gboolean val)
-{
-  preserve = val;
-}
-
-
 static gint verbose;
 
 gint

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -382,21 +382,6 @@ sch2pcb_set_n_PKG_removed_old (int val)
 }
 
 
-static gint n_preserved;
-
-int
-sch2pcb_get_n_preserved ()
-{
-  return n_preserved;
-}
-
-void
-sch2pcb_set_n_preserved (int val)
-{
-  n_preserved = val;
-}
-
-
 static int n_unknown;
 
 int

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -367,21 +367,6 @@ sch2pcb_set_n_unknown (int val)
 }
 
 
-static gboolean need_PKG_purge;
-
-gboolean
-sch2pcb_get_need_PKG_purge ()
-{
-  return need_PKG_purge;
-}
-
-void
-sch2pcb_set_need_PKG_purge (gboolean val)
-{
-  need_PKG_purge = val;
-}
-
-
 static gint verbose;
 
 gint

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -337,21 +337,6 @@ sch2pcb_set_n_none (int val)
 }
 
 
-static int n_PKG_removed_old;
-
-int
-sch2pcb_get_n_PKG_removed_old ()
-{
-  return n_PKG_removed_old;
-}
-
-void
-sch2pcb_set_n_PKG_removed_old (int val)
-{
-  n_PKG_removed_old = val;
-}
-
-
 static int n_unknown;
 
 int

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -322,21 +322,6 @@ sch2pcb_set_n_changed_value (int val)
 }
 
 
-static int n_deleted;
-
-int
-sch2pcb_get_n_deleted ()
-{
-  return n_deleted;
-}
-
-void
-sch2pcb_set_n_deleted (int val)
-{
-  n_deleted = val;
-}
-
-
 static int n_empty;
 
 int

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -276,21 +276,6 @@ sch2pcb_get_pcb_element_list ()
 }
 
 
-static gboolean bak_done;
-
-gboolean
-sch2pcb_get_bak_done ()
-{
-  return bak_done;
-}
-
-void
-sch2pcb_set_bak_done (gboolean val)
-{
-  bak_done = val;
-}
-
-
 static gchar *empty_footprint_name;
 
 char*

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -149,6 +149,8 @@
 (define %not-found-packages-count 0)
 ;;; The number of new packages mentioned but not found.
 (define %removed-new-packages-count 0)
+;;; The number of elements preserved through the option --preserve.
+(define %preserved-element-count 0)
 
 
 (define (pcb-element-get-string *element *c-getter)
@@ -598,7 +600,7 @@
         (if (false? (pcb_element_get_still_exists *element))
             (if %preserve-all-elements?
                 (begin
-                  (sch2pcb_set_n_preserved (1+ (sch2pcb_get_n_preserved)))
+                  (set! %preserved-element-count (1+ %preserved-element-count))
                   (format (current-error-port)
                           "Preserving PCB element not in the schematic:    ~A (element   ~A)\n"
                           (pointer->string (pcb_element_get_refdes *element))
@@ -1287,9 +1289,9 @@ Lepton EDA homepage: <~A>
     (if pcb-file-created?
         (format #t "  So ~A is incomplete.\n" pcb-new-filename)
         (format #t "\n")))
-  (unless (zero? (sch2pcb_get_n_preserved))
+  (unless (zero? %preserved-element-count)
     (format #t "~A elements not in the schematic preserved in ~A.\n"
-            (sch2pcb_get_n_preserved)
+            %preserved-element-count
             pcb-filename))
 
   ;; Tell user what to do next.

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -135,6 +135,9 @@
 (define %fix-elements? #f)
 ;;; Whether unfound pcb elements have to be removed.
 (define %remove-unfound-elements? #t)
+;;; Whether all elements not found in schematics have to be preserved
+;;; in PCB files.
+(define %preserve-all-elements? #f)
 
 ;;; The number of file elements added.
 (define %added-file-element-count 0)
@@ -572,7 +575,7 @@
                                   (pcb_element_exists *element FALSE)))
            (delete-element? (and (not (null-pointer? *existing-element))
                                  (false? (pcb_element_get_still_exists *existing-element))
-                                 (false? (sch2pcb_get_preserve)))))
+                                 (not %preserve-all-elements?))))
       (if delete-element?
           (verbose-report-element-deleted *element)
           (element->file *element
@@ -593,7 +596,7 @@
     (unless (null? *element-list)
       (let ((*element (car *element-list)))
         (if (false? (pcb_element_get_still_exists *element))
-            (if (true? (sch2pcb_get_preserve))
+            (if %preserve-all-elements?
                 (begin
                   (sch2pcb_set_n_preserved (1+ (sch2pcb_get_n_preserved)))
                   (format (current-error-port)
@@ -888,7 +891,7 @@
       ("remove-unfound" (set! %remove-unfound-elements? #t))
       ("keep-unfound" (set! %remove-unfound-elements? #f))
       ("quiet" (set! %quiet-mode #t))
-      ("preserve" (sch2pcb_set_preserve TRUE))
+      ("preserve" (set! %preserve-all-elements? #t))
       ("use-files" (set! %force-file-elements? #t))
       ("skip-m4" (set! %use-m4 #f))
       ("elements-dir"
@@ -1101,7 +1104,7 @@ Lepton EDA homepage: <~A>
                seeds))
      (option '(#\p "preserve") #f #f
              (lambda (opt name arg seeds)
-               (sch2pcb_set_preserve TRUE)
+               (set! %preserve-all-elements? #t)
                seeds))
      (option '(#\f "use-files") #f #f
              (lambda (opt name arg seeds)

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -140,6 +140,8 @@
 (define %preserve-all-elements? #f)
 ;;; Whether PKG_ lines have been found in pcb files.
 (define %pkg-line-found #f)
+;;; Whether backup has been done.
+(define %backup-done #f)
 
 ;;; The number of file elements added.
 (define %added-file-element-count 0)
@@ -659,9 +661,9 @@
                       (loop (read-line) skip-next? new-paren-level))))))
             (sch2pcb_close_file *tmp-file)
 
-            (when (false? (sch2pcb_get_bak_done))
+            (unless %backup-done
               (system* "mv" pcb-filename bak-filename)
-              (sch2pcb_set_bak_done TRUE))
+              (set! %backup-done #t))
 
             (system* "mv" tmp-filename pcb-filename)))))))
 
@@ -743,9 +745,9 @@
                 (sch2pcb_close_file *tmp-file)
 
                 ;; Make backup for pcb file.
-                (when (false? (sch2pcb_get_bak_done))
+                (unless %backup-done
                   (system* "mv" pcb-filename bak-filename)
-                  (sch2pcb_set_bak_done TRUE))
+                  (set! %backup-done #t))
 
                 ;; Replace pcb file with newly created file with
                 ;; updated descriptions.

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -151,6 +151,8 @@
 (define %removed-new-packages-count 0)
 ;;; The number of elements preserved through the option --preserve.
 (define %preserved-element-count 0)
+;;; The number of deleted elements.
+(define %deleted-element-count 0)
 
 
 (define (pcb-element-get-string *element *c-getter)
@@ -606,14 +608,14 @@
                           (pointer->string (pcb_element_get_refdes *element))
                           (pointer->string (pcb_element_get_description *element))))
 
-                (sch2pcb_set_n_deleted (1+ (sch2pcb_get_n_deleted))))
+                (set! %deleted-element-count (1+ %deleted-element-count)))
 
             (unless (null-pointer? (pcb_element_get_changed_value *element))
               (sch2pcb_set_n_changed_value (1+ (sch2pcb_get_n_changed_value)))))
         (loop (cdr *element-list)))))
 
   (unless (or (null-pointer? (sch2pcb_get_pcb_element_list))
-              (and (zero? (sch2pcb_get_n_deleted))
+              (and (zero? %deleted-element-count)
                    (false? (sch2pcb_get_need_PKG_purge))
                    (zero? (sch2pcb_get_n_changed_value))))
     (when (file-readable? pcb-filename)
@@ -1233,15 +1235,15 @@ Lepton EDA homepage: <~A>
 
   (format #t "\n----------------------------------\n")
   (format #t "Done processing.  Work performed:\n")
-  (when (or (non-zero? (sch2pcb_get_n_deleted))
+  (when (or (non-zero? %deleted-element-count)
             (non-zero? %fixed-element-count)
             (true? (sch2pcb_get_need_PKG_purge))
             (non-zero? (sch2pcb_get_n_changed_value)))
     (format #t "~A is backed up as ~A.\n" pcb-filename bak-filename))
   (when (and (not (null-pointer? (sch2pcb_get_pcb_element_list)))
-             (non-zero? (sch2pcb_get_n_deleted)))
+             (non-zero? %deleted-element-count))
     (format #t "~A elements deleted from ~A.\n"
-            (sch2pcb_get_n_deleted)
+            %deleted-element-count
             pcb-filename))
 
   (if (zero? (+ %added-file-element-count

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -151,6 +151,9 @@
 (define %not-found-packages-count 0)
 ;;; The number of new packages mentioned but not found.
 (define %removed-new-packages-count 0)
+;;; The number of PKG_ lines left due to missing (not found)
+;;; elements for them.
+(define %left-old-packages-count 0)
 ;;; The number of elements preserved through the option --preserve.
 (define %preserved-element-count 0)
 ;;; The number of deleted elements.
@@ -573,7 +576,7 @@
             (sch2pcb_buffer_to_file *output-string *tmp-file)
             (verbose-report-changed-value *element changed-value))
           (if PKG-line?
-              (sch2pcb_set_n_PKG_removed_old (1+ (sch2pcb_get_n_PKG_removed_old)))
+              (set! %left-old-packages-count (1+ %left-old-packages-count))
               (sch2pcb_buffer_to_file (string->pointer output-line) *tmp-file)))))
 
   (define (prune-element *tmp-file line trimmed-line skip-line?)
@@ -1283,9 +1286,9 @@ Lepton EDA homepage: <~A>
     (format #t "~A elements fixed in ~A.\n"
             %fixed-element-count
             pcb-filename))
-  (unless (zero? (sch2pcb_get_n_PKG_removed_old))
+  (unless (zero? %left-old-packages-count)
     (format #t "~A elements could not be found."
-            (sch2pcb_get_n_PKG_removed_old))
+            %left-old-packages-count)
     (if pcb-file-created?
         (format #t "  So ~A is incomplete.\n" pcb-filename)
         (format #t "\n")))

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -153,6 +153,8 @@
 (define %preserved-element-count 0)
 ;;; The number of deleted elements.
 (define %deleted-element-count 0)
+;;; The number of elements with changed value.
+(define %changed-value-element-count 0)
 
 
 (define (pcb-element-get-string *element *c-getter)
@@ -611,13 +613,13 @@
                 (set! %deleted-element-count (1+ %deleted-element-count)))
 
             (unless (null-pointer? (pcb_element_get_changed_value *element))
-              (sch2pcb_set_n_changed_value (1+ (sch2pcb_get_n_changed_value)))))
+              (set! %changed-value-element-count (1+ %changed-value-element-count))))
         (loop (cdr *element-list)))))
 
   (unless (or (null-pointer? (sch2pcb_get_pcb_element_list))
               (and (zero? %deleted-element-count)
                    (false? (sch2pcb_get_need_PKG_purge))
-                   (zero? (sch2pcb_get_n_changed_value))))
+                   (zero? %changed-value-element-count)))
     (when (file-readable? pcb-filename)
       (let* ((tmp-filename (string-append pcb-filename ".tmp"))
              (*tmp-file (sch2pcb_open_file_to_write
@@ -1238,7 +1240,7 @@ Lepton EDA homepage: <~A>
   (when (or (non-zero? %deleted-element-count)
             (non-zero? %fixed-element-count)
             (true? (sch2pcb_get_need_PKG_purge))
-            (non-zero? (sch2pcb_get_n_changed_value)))
+            (non-zero? %changed-value-element-count))
     (format #t "~A is backed up as ~A.\n" pcb-filename bak-filename))
   (when (and (not (null-pointer? (sch2pcb_get_pcb_element_list)))
              (non-zero? %deleted-element-count))
@@ -1271,9 +1273,9 @@ Lepton EDA homepage: <~A>
             (sch2pcb_get_n_empty)
             (sch2pcb_get_empty_footprint_name)
             pcb-new-filename))
-  (unless (zero? (sch2pcb_get_n_changed_value))
+  (unless (zero? %changed-value-element-count)
     (format #t "~A elements had a value change in ~A.\n"
-            (sch2pcb_get_n_changed_value)
+            %changed-value-element-count
             pcb-filename))
   (unless (zero? %fixed-element-count)
     (format #t "~A elements fixed in ~A.\n"


### PR DESCRIPTION
Several no longer necessary C variables have been replaced with Scheme ones, which reduces code a little.  Comments have been added to provide description for each of the new variables.