### PR TITLE
Introduce (sch2pcb format) module.

### DIFF
--- a/liblepton/scheme/Makefile.am
+++ b/liblepton/scheme/Makefile.am
@@ -75,6 +75,7 @@ nobase_dist_scmdata_DATA = \
 	netlist/subschematic.scm \
 	netlist/subschematic-connection.scm \
 	netlist/verbose.scm \
+	sch2pcb/format.scm \
 	symbol/blame.scm \
 	symbol/check.scm \
 	symbol/check/alignment.scm \

--- a/liblepton/scheme/sch2pcb/format.scm
+++ b/liblepton/scheme/sch2pcb/format.scm
@@ -1,0 +1,51 @@
+;;; Lepton EDA Schematic to PCB conversion
+;;; Scheme API
+;;; Copyright (C) 2023 Lepton EDA Contributors
+;;;
+;;; This program is free software; you can redistribute it and/or modify
+;;; it under the terms of the GNU General Public License as published by
+;;; the Free Software Foundation; either version 2 of the License, or
+;;; (at your option) any later version.
+;;;
+;;; This program is distributed in the hope that it will be useful,
+;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;; GNU General Public License for more details.
+;;;
+;;; You should have received a copy of the GNU General Public License
+;;; along with this program; if not, write to the Free Software
+;;; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+(define-module (sch2pcb format)
+  #:use-module (lepton ffi sch2pcb)
+  #:use-module (lepton gettext)
+
+  #:export (format-error
+            format-message
+            format-warning
+            verbose-format
+            extra-verbose-format))
+
+
+;;; Save current ports to put messages, warnings, and errors there
+;;; afterwards.
+(define %message-port (current-output-port))
+(define %warning-port (current-error-port))
+(define %error-port (current-error-port))
+
+(define-syntax-rule (format-message msg arg ...)
+  (format %message-port (G_ msg) arg ...))
+
+(define-syntax-rule (format-warning msg arg ...)
+  (format %warning-port (G_ msg) arg ...))
+
+(define-syntax-rule (format-error arg ...)
+  (format %error-port (G_ "ERROR: ~?.\n") arg ...))
+
+(define-syntax-rule (verbose-format msg arg ...)
+  (when (> (sch2pcb_get_verbose_mode) 0)
+    (format %message-port (G_ msg) arg ...)))
+
+(define-syntax-rule (extra-verbose-format msg arg ...)
+  (when (> (sch2pcb_get_verbose_mode) 1)
+    (format %message-port (G_ msg) arg ...)))

--- a/tests/sch2pcb.test
+++ b/tests/sch2pcb.test
@@ -1685,8 +1685,9 @@
         (command-values lepton-sch2pcb project one.sch two.sch)
       (test-eq EXIT_SUCCESS <status>)
       (test-assert (file-exists? one.pcb))
-      (test-assert (not (string-contains <stdout> "Next steps")))))
-
+      (test-assert
+          (string-contains <stdout>
+                           "to propagate the pin names of all footprints"))))
   (test-teardown))
 
 (test-end)

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -30,30 +30,9 @@
              (lepton m4)
              (lepton os)
              (lepton srfi-37)
-             (lepton version))
+             (lepton version)
+             (sch2pcb format))
 
-;;; Save current ports to put messages, warnings, and errors there
-;;; afterwards.
-(define %message-port (current-output-port))
-(define %warning-port (current-error-port))
-(define %error-port (current-error-port))
-
-(define-syntax-rule (format-message msg arg ...)
-  (format %message-port (G_ msg) arg ...))
-
-(define-syntax-rule (format-warning msg arg ...)
-  (format %warning-port (G_ msg) arg ...))
-
-(define-syntax-rule (format-error arg ...)
-  (format %error-port (G_ "ERROR: ~?.\n") arg ...))
-
-(define-syntax-rule (verbose-format msg arg ...)
-  (when (> (sch2pcb_get_verbose_mode) 0)
-    (format %message-port (G_ msg) arg ...)))
-
-(define-syntax-rule (extra-verbose-format msg arg ...)
-  (when (> (sch2pcb_get_verbose_mode) 1)
-    (format %message-port (G_ msg) arg ...)))
 
 (define %sch2pcb (basename (car (program-arguments))))
 

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -461,17 +461,16 @@
                     (pcb-element-value *element)))
 
   (define (error-report-element-not-found *element)
-    (format (current-error-port)
-            (G_ "~A: can't find PCB element for footprint ~S (value=~A)\n")
-            (pcb-element-refdes *element)
-            (pcb-element-description *element)
-            (pcb-element-value *element)))
+    (format-warning
+     (G_ "~A: can't find PCB element for footprint ~S (value=~A)\n")
+     (pcb-element-refdes *element)
+     (pcb-element-description *element)
+     (pcb-element-value *element)))
 
   (define (error-report-element-removed *element)
     (set! %removed-new-packages-count (1+ %removed-new-packages-count))
-    (format (current-error-port)
-            (G_ "So device ~S will not be in the layout.\n")
-            (pcb-element-refdes *element)))
+    (format-warning (G_ "So device ~S will not be in the layout.\n")
+                    (pcb-element-refdes *element)))
 
   (define (unfound-element->file *element *mline *tmp-file)
     (error-report-element-not-found *element)
@@ -731,10 +730,10 @@
             (if %preserve-all-elements?
                 (begin
                   (set! %preserved-element-count (1+ %preserved-element-count))
-                  (format (current-error-port)
-                          "Preserving PCB element not in the schematic:    ~A (element   ~A)\n"
-                          (pointer->string (pcb_element_get_refdes *element))
-                          (pointer->string (pcb_element_get_description *element))))
+                  (format-warning
+                   "Preserving PCB element not in the schematic:    ~A (element   ~A)\n"
+                   (pointer->string (pcb_element_get_refdes *element))
+                   (pointer->string (pcb_element_get_description *element))))
 
                 (set! %deleted-element-count (1+ %deleted-element-count)))
 
@@ -837,7 +836,7 @@
 
   (if (or (null-pointer? (sch2pcb_get_pcb_element_list))
           (zero? %fixed-element-count))
-      (format (current-error-port) "Could not find any elements to fix.\n")
+      (format-warning "Could not find any elements to fix.\n")
       (let* ((tmp-filename (string-append pcb-filename ".tmp"))
              (*tmp-file (sch2pcb_open_file_to_write (string->pointer tmp-filename))))
         (when (file-readable? pcb-filename)
@@ -866,7 +865,7 @@
     (verbose-format "Running command:\n\t~A\n" (string-join ls " "))
     (let ((result (eq? EXIT_SUCCESS (status:exit-val (apply system* ls)))))
       (unless result
-        (format (current-error-port) "Failed to execute external program.\n"))
+        (format-warning "Failed to execute external program.\n"))
       (verbose-format "\n--------\n")
       ;; return
       result))
@@ -908,13 +907,13 @@
                          (not (file-exists? pcb-filename))
                          ;; or it has not changed.
                          (= mtime (stat:mtime (stat pcb-filename))))
-                        (format (current-error-port)
-                                "lepton-sch2pcb: netlister command failed, `~A' not updated.\n"
-                                pcb-filename)
+                        (format-warning
+                         "lepton-sch2pcb: netlister command failed, `~A' not updated.\n"
+                         pcb-filename)
 
                         ;; Report the issue anyways, even if the
                         ;; output file has been created.
-                        (format (current-error-port) "lepton-sch2pcb: netlister command failed.\n"))
+                        (format-warning "lepton-sch2pcb: netlister command failed.\n"))
                     ;; Stop processing.
                     #f))
               ;; Delete no longer necessary m4 override file.
@@ -974,9 +973,9 @@
       (when (and (not %schematic-basename)
                  (string-suffix-ci? ".sch" schematic-name))
         (set! %schematic-basename (basename-ci schematic-name)))
-      (format (current-error-port)
-              "Could not add schematic: ~A\nFile is not regular or not readable.\n"
-              schematic-name)))
+      (format-warning
+       "Could not add schematic: ~A\nFile is not regular or not readable.\n"
+       schematic-name)))
 
 
 (define (add-multiple-schematics *str)
@@ -1032,9 +1031,9 @@
       ("backend-cmd" (set! %backend-cmd value))
       ("backend-net" (set! %backend-net value))
       ("backend-pcb" (set! %backend-pcb value))
-      (_ (format (current-error-port)
-                 (G_ "Unknown config key: ~S\n")
-                 (pointer->string *value))))))
+      (_ (format-warning
+          (G_ "Unknown config key: ~S\n")
+          (pointer->string *value))))))
 
 
 (define (load-project-file path)
@@ -1043,10 +1042,9 @@
            (key (car args))
            (value (cdr args)))
       (unless (parse-config key value)
-        (format (current-error-port)
-                (G_ "Wrong line in ~S: ~S\n")
-                path
-                line))))
+        (format-warning (G_ "Wrong line in ~S: ~S\n")
+                        path
+                        line))))
 
   (define (skip-line? line)
     (or (string-null? line)
@@ -1066,9 +1064,8 @@
       (begin (verbose-format (G_ "Reading project file: ~A\n") path)
              (with-input-from-file path read-file))
       (when (> (sch2pcb_get_verbose_mode) 0)
-        (format (current-error-port)
-                (G_ "Skip missing or unreadable file: ~A\n")
-                path))))
+        (format-warning (G_ "Skip missing or unreadable file: ~A\n")
+                        path))))
 
 
 (define (load-extra-project-files)
@@ -1473,7 +1470,7 @@ Lepton EDA homepage: <~A>
                                        pins-filename
                                        net-filename
                                        pcb-new-filename)
-                  (format (current-error-port) (G_ "Failed to run netlister\n"))
+                  (format-warning (G_ "Failed to run netlister\n"))
                   (exit 1))
                 (when (zero? (add-elements pcb-new-filename))
                   (delete-file* pcb-new-filename)

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -1319,8 +1319,7 @@ Lepton EDA homepage: <~A>
                                       (zero? %not-found-packages-count))))
 
   ;; Report work done during processing.
-  (unless (zero? (sch2pcb_get_verbose_mode))
-    (format #t "\n"))
+  (verbose-format "\n")
 
   (format #t "\n----------------------------------\n")
   (format #t "Done processing.  Work performed:\n")
@@ -1386,8 +1385,7 @@ Lepton EDA homepage: <~A>
             pcb-filename))
 
   ;; Tell user what to do next.
-  (unless (zero? (sch2pcb_get_verbose_mode))
-    (format #t "\n"))
+  (verbose-format "\n")
 
   (unless (zero? (+ %added-file-element-count
                     %added-m4-element-count))
@@ -1432,8 +1430,7 @@ Lepton EDA homepage: <~A>
             (begin
               ;; Defaults for the newlib element directory search path
               ;; if not configured in the project file.
-              (when (not (zero? (sch2pcb_get_verbose_mode)))
-                (format #t "Processing PCBLIBPATH=~S\n" %pcb-lib-path))
+              (verbose-format "Processing PCBLIBPATH=~S\n" %pcb-lib-path)
               (for-each
                (lambda (x) (append-element-directory x))
                (filter-map

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -51,9 +51,9 @@
   (when (> (sch2pcb_get_verbose_mode) 0)
     (format %message-port (G_ msg) arg ...)))
 
-(define-syntax-rule (extra-verbose-format arg ...)
+(define-syntax-rule (extra-verbose-format msg arg ...)
   (when (> (sch2pcb_get_verbose_mode) 1)
-    (format %message-port arg ...)))
+    (format %message-port (G_ msg) arg ...)))
 
 (define %sch2pcb (basename (car (program-arguments))))
 
@@ -277,7 +277,7 @@
     (let loop ((ls element-directories))
       (and (not (null? ls))
            (let ((dir-path (car ls)))
-             (extra-verbose-format (G_ "\tLooking in directory: ~S\n") dir-path)
+             (extra-verbose-format "\tLooking in directory: ~S\n" dir-path)
              (let ((*path (sch2pcb_find_element (string->pointer dir-path)
                                                 (if element-name
                                                     (string->pointer element-name)

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -41,8 +41,8 @@
 (define-syntax-rule (format-message arg ...)
   (format %message-port arg ...))
 
-(define-syntax-rule (format-warning arg ...)
-  (format %warning-port arg ...))
+(define-syntax-rule (format-warning msg arg ...)
+  (format %warning-port (G_ msg) arg ...))
 
 (define-syntax-rule (format-error arg ...)
   (format %error-port (G_ "ERROR: ~?.\n") arg ...))
@@ -462,14 +462,14 @@
 
   (define (error-report-element-not-found *element)
     (format-warning
-     (G_ "~A: can't find PCB element for footprint ~S (value=~A)\n")
+     "~A: can't find PCB element for footprint ~S (value=~A)\n"
      (pcb-element-refdes *element)
      (pcb-element-description *element)
      (pcb-element-value *element)))
 
   (define (error-report-element-removed *element)
     (set! %removed-new-packages-count (1+ %removed-new-packages-count))
-    (format-warning (G_ "So device ~S will not be in the layout.\n")
+    (format-warning "So device ~S will not be in the layout.\n"
                     (pcb-element-refdes *element)))
 
   (define (unfound-element->file *element *mline *tmp-file)
@@ -1031,9 +1031,8 @@
       ("backend-cmd" (set! %backend-cmd value))
       ("backend-net" (set! %backend-net value))
       ("backend-pcb" (set! %backend-pcb value))
-      (_ (format-warning
-          (G_ "Unknown config key: ~S\n")
-          (pointer->string *value))))))
+      (_ (format-warning "Unknown config key: ~S\n"
+                         (pointer->string *value))))))
 
 
 (define (load-project-file path)
@@ -1042,7 +1041,7 @@
            (key (car args))
            (value (cdr args)))
       (unless (parse-config key value)
-        (format-warning (G_ "Wrong line in ~S: ~S\n")
+        (format-warning "Wrong line in ~S: ~S\n"
                         path
                         line))))
 
@@ -1064,7 +1063,7 @@
       (begin (verbose-format (G_ "Reading project file: ~A\n") path)
              (with-input-from-file path read-file))
       (when (> (sch2pcb_get_verbose_mode) 0)
-        (format-warning (G_ "Skip missing or unreadable file: ~A\n")
+        (format-warning "Skip missing or unreadable file: ~A\n"
                         path))))
 
 
@@ -1470,7 +1469,7 @@ Lepton EDA homepage: <~A>
                                        pins-filename
                                        net-filename
                                        pcb-new-filename)
-                  (format-warning (G_ "Failed to run netlister\n"))
+                  (format-warning "Failed to run netlister\n")
                   (exit 1))
                 (when (zero? (add-elements pcb-new-filename))
                   (delete-file* pcb-new-filename)

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -47,9 +47,9 @@
 (define-syntax-rule (format-error arg ...)
   (format %error-port (G_ "ERROR: ~?.\n") arg ...))
 
-(define-syntax-rule (verbose-format arg ...)
+(define-syntax-rule (verbose-format msg arg ...)
   (when (> (sch2pcb_get_verbose_mode) 0)
-    (format %message-port arg ...)))
+    (format %message-port (G_ msg) arg ...)))
 
 (define-syntax-rule (extra-verbose-format arg ...)
   (when (> (sch2pcb_get_verbose_mode) 1)
@@ -286,7 +286,7 @@
                    (loop (cdr ls))
                    (let ((path (pointer->string *path)))
                      (g_free *path)
-                     (verbose-format (G_ "\tFound: ~A\n") path)
+                     (verbose-format "\tFound: ~A\n" path)
                      path)))))))
 
   ;; See comment before pcb_element_pkg_to_element().
@@ -306,8 +306,8 @@
         %null-pointer
         (begin
           (verbose-format
-           (G_ "\tSearching directories looking for file element: ~A\n")
-               element-name)
+           "\tSearching directories looking for file element: ~A\n"
+           element-name)
           (search-element-path element-name)))))
 
 
@@ -1061,7 +1061,7 @@
           (loop (read-line))))))
 
   (if (file-readable? path)
-      (begin (verbose-format (G_ "Reading project file: ~A\n") path)
+      (begin (verbose-format "Reading project file: ~A\n" path)
              (with-input-from-file path read-file))
       (when (> (sch2pcb_get_verbose_mode) 0)
         (format-warning "Skip missing or unreadable file: ~A\n"

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -991,10 +991,9 @@
       ("skip-m4" (set! %use-m4 #f))
       ("elements-dir"
        (let ((elements-dir (expand-env-variables value)))
-         (when (> (sch2pcb_get_verbose_mode) 1)
-           (format #t
-                   "\tAdding directory to file element directory list: ~A\n"
-                   elements-dir))
+         (extra-verbose-format
+          "\tAdding directory to file element directory list: ~A\n"
+          elements-dir)
          (prepend-element-directory elements-dir)))
       ("output-name" (set! %schematic-basename value))
       ("schematics" (add-multiple-schematics *value))
@@ -1212,10 +1211,9 @@ Lepton EDA homepage: <~A>
      (option '(#\d "elements-dir") #t #f
              (lambda (opt name arg seeds)
                (let ((elements-dir (expand-env-variables arg)))
-                 (when (> (sch2pcb_get_verbose_mode) 1)
-                   (format #t
-                           "\tAdding directory to file element directory list: ~S\n"
-                           elements-dir))
+                 (extra-verbose-format
+                  "\tAdding directory to file element directory list: ~S\n"
+                  elements-dir)
                  (prepend-element-directory elements-dir))
                seeds))
      (option '(#\o "output-name") #t #f

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -32,13 +32,28 @@
              (lepton srfi-37)
              (lepton version))
 
+;;; Save current ports to put messages, warnings, and errors there
+;;; afterwards.
+(define %message-port (current-output-port))
+(define %warning-port (current-error-port))
+(define %error-port (current-error-port))
+
+(define-syntax-rule (format-message arg ...)
+  (format %message-port arg ...))
+
+(define-syntax-rule (format-warning arg ...)
+  (format %warning-port arg ...))
+
+(define-syntax-rule (format-error arg ...)
+  (format %error-port arg ...))
+
 (define-syntax-rule (verbose-format arg ...)
   (when (> (sch2pcb_get_verbose_mode) 0)
-    (format (current-output-port) arg ...)))
+    (format %message-port arg ...)))
 
 (define-syntax-rule (extra-verbose-format arg ...)
   (when (> (sch2pcb_get_verbose_mode) 1)
-    (format (current-output-port) arg ...)))
+    (format %message-port arg ...)))
 
 (define %sch2pcb (basename (car (program-arguments))))
 

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -1337,8 +1337,8 @@ Lepton EDA homepage: <~A>
   ;; Report work done during processing.
   (verbose-format "\n")
 
-  (format-message "\n----------------------------------\n")
-  (format-message "Done processing.  Work performed:\n")
+  (format-message "\n----------------------------------\n~
+                   Done processing.  Work performed:\n")
   (when (or (non-zero? %deleted-element-count)
             (non-zero? %fixed-element-count)
             %pkg-line-found
@@ -1387,14 +1387,12 @@ Lepton EDA homepage: <~A>
     (format-message "~A elements could not be found."
                     %left-old-packages-count)
     (if pcb-file-created?
-        (format-message "  So ~A is incomplete.\n" pcb-filename)
-        (format-message "\n")))
+        (format-message "  So ~A is incomplete.\n\n" pcb-filename)))
   (unless (zero? %removed-new-packages-count)
     (format-message "~A elements could not be found."
                     %removed-new-packages-count)
     (if pcb-file-created?
-        (format-message "  So ~A is incomplete.\n" pcb-new-filename)
-        (format-message "\n")))
+        (format-message "  So ~A is incomplete.\n\n" pcb-new-filename)))
   (unless (zero? %preserved-element-count)
     (format-message "~A elements not in the schematic preserved in ~A.\n"
                     %preserved-element-count

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -106,6 +106,12 @@
                 "(define gsch2pcb:use-m4 ~A)\n"
                 (if %use-m4 "#t" "#f")))))
 
+  (define (verbose-output)
+    (verbose-format "Default m4-pcbdir: ~A\n" %default-m4-pcb-dir)
+    (verbose-format "--------\ngnet-gsch2pcb-tmp.scm override file:\n")
+    (verbose-format "~A" file-contents)
+    #t)
+
   (let ((result
          (and (false-if-exception
                (with-output-to-file m4-override-filename
@@ -113,10 +119,7 @@
               m4-override-filename)))
 
     (and result
-         (unless (zero? (sch2pcb_get_verbose_mode))
-           (format #t "Default m4-pcbdir: ~A\n" %default-m4-pcb-dir)
-           (format #t "--------\ngnet-gsch2pcb-tmp.scm override file:\n")
-           (display file-contents))
+         (verbose-output)
          result)))
 
 ;;; List of extra backends to run netlister command for.

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -90,6 +90,9 @@
 ;;; the netlister command.
 (define %netlister (or (getenv "NETLISTER") "lepton-netlist"))
 
+
+;;; Create override file. Return its name if anything went OK,
+;;; otherwise return #f.
 (define (create-m4-override-file)
   (define m4-override-filename "gnet-gsch2pcb-tmp.scm")
 

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -45,7 +45,7 @@
   (format %warning-port arg ...))
 
 (define-syntax-rule (format-error arg ...)
-  (format %error-port arg ...))
+  (format %error-port (G_ "ERROR: ~?.\n") arg ...))
 
 (define-syntax-rule (verbose-format arg ...)
   (when (> (sch2pcb_get_verbose_mode) 0)

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -813,10 +813,11 @@
                                                  tail))))
             (sch2pcb_buffer_to_file *line *output-file)
 
-            (format #t "~A: updating element Description: ~A -> ~A\n"
-                    (pointer->string (pcb_element_get_refdes *element))
-                    (pointer->string (pcb_element_get_description *element))
-                    (pointer->string (pcb_element_get_changed_description *existing-element)))
+            (format-message
+             "~A: updating element Description: ~A -> ~A\n"
+             (pointer->string (pcb_element_get_refdes *element))
+             (pointer->string (pcb_element_get_description *element))
+             (pointer->string (pcb_element_get_changed_description *existing-element)))
             (pcb_element_set_still_exists *existing-element TRUE))
           ;; Otherwise, if the element is new, just output it into
           ;; the output file.
@@ -1079,9 +1080,9 @@
 
 
 (define (usage)
-  (format #t
-          (G_
-"Usage: ~A [options] {project | foo.sch [foo1.sch ...]}
+  (format-message
+   (G_
+    "Usage: ~A [options] {project | foo.sch [foo1.sch ...]}
 
 Generate a PCB layout file from a set of Lepton EDA schematics.
 
@@ -1171,10 +1172,10 @@ Additional Resources:
 Report bugs at <~A>
 Lepton EDA homepage: <~A>
 ")
-          %sch2pcb
-          %default-m4-pcb-dir
-          (lepton-version-ref 'bugs)
-          (lepton-version-ref 'url))
+   %sch2pcb
+   %default-m4-pcb-dir
+   (lepton-version-ref 'bugs)
+   (lepton-version-ref 'url))
   (exit 0))
 
 
@@ -1277,11 +1278,10 @@ Lepton EDA homepage: <~A>
                (display-lepton-version #:print-name #t #:copyright #t)
                (exit 0))))
     (lambda (opt name arg seeds)
-      (format #t
-              "lepton-sch2pcb: bad or incomplete arg: ~S\n"
-              (if (char? name)
-                  (string-append "-" (char-set->string (char-set name)))
-                  (string-append "--" name)))
+      (format-message "lepton-sch2pcb: bad or incomplete arg: ~S\n"
+                      (if (char? name)
+                          (string-append "-" (char-set->string (char-set name)))
+                          (string-append "--" name)))
       (usage))
     (lambda (op seeds)
       (if (string-suffix? ".sch" op)
@@ -1338,68 +1338,68 @@ Lepton EDA homepage: <~A>
   ;; Report work done during processing.
   (verbose-format "\n")
 
-  (format #t "\n----------------------------------\n")
-  (format #t "Done processing.  Work performed:\n")
+  (format-message "\n----------------------------------\n")
+  (format-message "Done processing.  Work performed:\n")
   (when (or (non-zero? %deleted-element-count)
             (non-zero? %fixed-element-count)
             %pkg-line-found
             (non-zero? %changed-value-element-count))
-    (format #t "~A is backed up as ~A.\n" pcb-filename bak-filename))
+    (format-message "~A is backed up as ~A.\n" pcb-filename bak-filename))
   (when (and (not (null-pointer? (sch2pcb_get_pcb_element_list)))
              (non-zero? %deleted-element-count))
-    (format #t "~A elements deleted from ~A.\n"
-            %deleted-element-count
-            pcb-filename))
+    (format-message "~A elements deleted from ~A.\n"
+                    %deleted-element-count
+                    pcb-filename))
 
   (if (zero? (+ %added-file-element-count
                 %added-m4-element-count))
       (when (zero? %not-found-packages-count)
-        (format #t "No elements to add so not creating ~A\n" pcb-new-filename))
-      (format #t "~A file elements and ~A m4 elements added to ~A.\n"
-              %added-file-element-count
-              %added-m4-element-count
-              pcb-new-filename))
+        (format-message "No elements to add so not creating ~A\n" pcb-new-filename))
+      (format-message "~A file elements and ~A m4 elements added to ~A.\n"
+                      %added-file-element-count
+                      %added-m4-element-count
+                      pcb-new-filename))
 
   (unless (zero? %not-found-packages-count)
-    (format #t "~A not found elements added to ~A.\n"
-            %not-found-packages-count
-            pcb-new-filename))
+    (format-message "~A not found elements added to ~A.\n"
+                    %not-found-packages-count
+                    pcb-new-filename))
   (unless (zero? (sch2pcb_get_n_unknown))
-    (format #t "~A components had no footprint attribute and are omitted.\n"
-            (sch2pcb_get_n_unknown)))
+    (format-message "~A components had no footprint attribute and are omitted.\n"
+                    (sch2pcb_get_n_unknown)))
   (unless (zero? (sch2pcb_get_n_none))
-    (format #t "~A components with footprint \"none\" omitted from ~A.\n"
-            (sch2pcb_get_n_none)
-            pcb-new-filename))
+    (format-message "~A components with footprint \"none\" omitted from ~A.\n"
+                    (sch2pcb_get_n_none)
+                    pcb-new-filename))
   (unless (zero? (sch2pcb_get_n_empty))
-    (format #t "~A components with empty footprint \"~A\" omitted from ~A.\n"
-            (sch2pcb_get_n_empty)
-            (sch2pcb_get_empty_footprint_name)
-            pcb-new-filename))
+    (format-message "~A components with empty footprint \"~A\" omitted from ~A.\n"
+                    (sch2pcb_get_n_empty)
+                    (sch2pcb_get_empty_footprint_name)
+                    pcb-new-filename))
   (unless (zero? %changed-value-element-count)
-    (format #t "~A elements had a value change in ~A.\n"
-            %changed-value-element-count
-            pcb-filename))
+    (format-message "~A elements had a value change in ~A.\n"
+                    %changed-value-element-count
+                    pcb-filename))
   (unless (zero? %fixed-element-count)
-    (format #t "~A elements fixed in ~A.\n"
-            %fixed-element-count
-            pcb-filename))
+    (format-message "~A elements fixed in ~A.\n"
+                    %fixed-element-count
+                    pcb-filename))
   (unless (zero? %left-old-packages-count)
-    (format #t "~A elements could not be found."
-            %left-old-packages-count)
+    (format-message "~A elements could not be found."
+                    %left-old-packages-count)
     (if pcb-file-created?
-        (format #t "  So ~A is incomplete.\n" pcb-filename)
-        (format #t "\n")))
+        (format-message "  So ~A is incomplete.\n" pcb-filename)
+        (format-message "\n")))
   (unless (zero? %removed-new-packages-count)
-    (format #t "~A elements could not be found."
-            %removed-new-packages-count)
+    (format-message "~A elements could not be found."
+                    %removed-new-packages-count)
     (if pcb-file-created?
-        (format #t "  So ~A is incomplete.\n" pcb-new-filename)
-        (format #t "\n")))
+        (format-message "  So ~A is incomplete.\n" pcb-new-filename)
+        (format-message "\n")))
   (unless (zero? %preserved-element-count)
-    (format #t "~A elements not in the schematic preserved in ~A.\n"
-            %preserved-element-count
-            pcb-filename))
+    (format-message "~A elements not in the schematic preserved in ~A.\n"
+                    %preserved-element-count
+                    pcb-filename))
 
   ;; Tell user what to do next.
   (verbose-format "\n")
@@ -1408,27 +1408,27 @@ Lepton EDA homepage: <~A>
                     %added-m4-element-count))
     (if initial-pcb?
         (begin
-          (format #t "\nNext step:\n")
-          (format #t "1.  Run pcb on your file ~A.\n" pcb-filename)
-          (format #t "    You will find all your footprints in a bundle ready for you to place\n")
-          (format #t "    or disperse with \"Select -> Disperse all elements\" in PCB.\n\n")
-          (format #t "2.  From within PCB, select \"File -> Load netlist file\" and select \n")
-          (format #t "    ~A to load the netlist.\n\n" net-filename)
-          (format #t "3.  From within PCB, enter\n\n")
-          (format #t "           :ExecuteFile(~A)\n\n" pins-filename)
-          (format #t "    to propagate the pin names of all footprints to the layout.\n\n"))
+          (format-message "\nNext step:\n")
+          (format-message "1.  Run pcb on your file ~A.\n" pcb-filename)
+          (format-message "    You will find all your footprints in a bundle ready for you to place\n")
+          (format-message "    or disperse with \"Select -> Disperse all elements\" in PCB.\n\n")
+          (format-message "2.  From within PCB, select \"File -> Load netlist file\" and select \n")
+          (format-message "    ~A to load the netlist.\n\n" net-filename)
+          (format-message "3.  From within PCB, enter\n\n")
+          (format-message "           :ExecuteFile(~A)\n\n" pins-filename)
+          (format-message "    to propagate the pin names of all footprints to the layout.\n\n"))
         (unless %quiet-mode
-          (format #t "\nNext steps:\n")
-          (format #t "1.  Run pcb on your file ~A.\n" pcb-filename)
-          (format #t "2.  From within PCB, select \"File -> Load layout data to paste buffer\"\n")
-          (format #t
-                  "    and select ~A to load the new footprints into your existing layout.\n"
-                  pcb-new-filename)
-          (format #t "3.  From within PCB, select \"File -> Load netlist file\" and select \n")
-          (format #t "    ~A to load the updated netlist.\n\n" net-filename)
-          (format #t "4.  From within PCB, enter\n\n")
-          (format #t "           :ExecuteFile(~A)\n\n" pins-filename)
-          (format #t "    to update the pin names of all footprints.\n\n")))))
+          (format-message "\nNext steps:\n")
+          (format-message "1.  Run pcb on your file ~A.\n" pcb-filename)
+          (format-message "2.  From within PCB, select \"File -> Load layout data to paste buffer\"\n")
+          (format-message
+           "    and select ~A to load the new footprints into your existing layout.\n"
+           pcb-new-filename)
+          (format-message "3.  From within PCB, select \"File -> Load netlist file\" and select \n")
+          (format-message "    ~A to load the updated netlist.\n\n" net-filename)
+          (format-message "4.  From within PCB, enter\n\n")
+          (format-message "           :ExecuteFile(~A)\n\n" pins-filename)
+          (format-message "    to update the pin names of all footprints.\n\n")))))
 
 
 ;;; Load system and user config files once.
@@ -1474,7 +1474,7 @@ Lepton EDA homepage: <~A>
                 (when (zero? (add-elements pcb-new-filename))
                   (delete-file* pcb-new-filename)
                   (when initial-pcb?
-                    (format #t "No elements found, so nothing to do.\n")
+                    (format-message "No elements found, so nothing to do.\n")
                     (exit 0)))
                 (when %fix-elements?
                   (update-element-descriptions pcb-filename bak-filename))

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -1405,7 +1405,7 @@ Lepton EDA homepage: <~A>
                     %added-m4-element-count))
     (if initial-pcb?
         (begin
-          (format-message "\nNext step:\n")
+          (format-message "\nNext steps:\n")
           (format-message "1.  Run pcb on your file ~A.\n" pcb-filename)
           (format-message "    You will find all your footprints in a bundle ready for you to place\n")
           (format-message "    or disperse with \"Select -> Disperse all elements\" in PCB.\n\n")

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -322,7 +322,7 @@
         (set! %backup-done #t))
       (rename-file from to))
     (lambda (key subr message args rest)
-      (format (current-error-port) (G_ "ERROR: ~?.") message args))))
+      (format-error message args))))
 
 
 ;;; For PcbElement *ELEMENT, the function checks if an element
@@ -655,7 +655,7 @@
       (catch #t
         process-files
         (lambda (key subr message args rest)
-          (format (current-error-port) (G_ "ERROR: ~?.") message args)
+          (format-error message args)
           0))))
 
 
@@ -1317,7 +1317,7 @@ Lepton EDA homepage: <~A>
   (catch #t
     thunk
     (lambda (key subr message args rest)
-      (format (current-error-port) (G_ "ERROR: ~?.\n") message args))))
+      (format-error message args))))
 
 
 ;;; A convenience function for deleting FILENAME with reporting

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -38,8 +38,8 @@
 (define %warning-port (current-error-port))
 (define %error-port (current-error-port))
 
-(define-syntax-rule (format-message arg ...)
-  (format %message-port arg ...))
+(define-syntax-rule (format-message msg arg ...)
+  (format %message-port (G_ msg) arg ...))
 
 (define-syntax-rule (format-warning msg arg ...)
   (format %warning-port (G_ msg) arg ...))
@@ -1081,8 +1081,7 @@
 
 (define (usage)
   (format-message
-   (G_
-    "Usage: ~A [options] {project | foo.sch [foo1.sch ...]}
+   "Usage: ~A [options] {project | foo.sch [foo1.sch ...]}
 
 Generate a PCB layout file from a set of Lepton EDA schematics.
 
@@ -1171,7 +1170,7 @@ Additional Resources:
 
 Report bugs at <~A>
 Lepton EDA homepage: <~A>
-")
+"
    %sch2pcb
    %default-m4-pcb-dir
    (lepton-version-ref 'bugs)

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -1405,27 +1405,43 @@ Lepton EDA homepage: <~A>
                     %added-m4-element-count))
     (if initial-pcb?
         (begin
-          (format-message "\nNext steps:\n")
-          (format-message "1.  Run pcb on your file ~A.\n" pcb-filename)
-          (format-message "    You will find all your footprints in a bundle ready for you to place\n")
-          (format-message "    or disperse with \"Select -> Disperse all elements\" in PCB.\n\n")
-          (format-message "2.  From within PCB, select \"File -> Load netlist file\" and select \n")
-          (format-message "    ~A to load the netlist.\n\n" net-filename)
-          (format-message "3.  From within PCB, enter\n\n")
-          (format-message "           :ExecuteFile(~A)\n\n" pins-filename)
-          (format-message "    to propagate the pin names of all footprints to the layout.\n\n"))
+          (format-message "
+Next steps:
+1.  Run pcb on your file ~A.
+    You will find all your footprints in a bundle ready for you to place
+    or disperse with \"Select -> Disperse all elements\" in PCB.
+
+2.  From within PCB, select \"File -> Load netlist file\" and select
+    ~A to load the netlist.
+
+3.  From within PCB, enter
+
+           :ExecuteFile(~A)
+
+    to propagate the pin names of all footprints to the layout.\n\n"
+                          pcb-filename
+                          net-filename
+                          pins-filename))
         (unless %quiet-mode
-          (format-message "\nNext steps:\n")
-          (format-message "1.  Run pcb on your file ~A.\n" pcb-filename)
-          (format-message "2.  From within PCB, select \"File -> Load layout data to paste buffer\"\n")
-          (format-message
-           "    and select ~A to load the new footprints into your existing layout.\n"
-           pcb-new-filename)
-          (format-message "3.  From within PCB, select \"File -> Load netlist file\" and select \n")
-          (format-message "    ~A to load the updated netlist.\n\n" net-filename)
-          (format-message "4.  From within PCB, enter\n\n")
-          (format-message "           :ExecuteFile(~A)\n\n" pins-filename)
-          (format-message "    to update the pin names of all footprints.\n\n")))))
+          (format-message "
+Next steps:
+1.  Run pcb on your file ~A.
+
+2.  From within PCB, select \"File -> Load layout data to paste buffer\"
+    and select ~A to load the new footprints into your existing layout.
+
+3.  From within PCB, select \"File -> Load netlist file\" and select
+    ~A to load the updated netlist.
+
+4.  From within PCB, enter
+
+           :ExecuteFile(~A)
+
+    to update the pin names of all footprints.\n\n"
+                          pcb-filename
+                          pcb-new-filename
+                          net-filename
+                          pins-filename)))))
 
 
 ;;; Load system and user config files once.

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -292,8 +292,8 @@
   ;; See comment before pcb_element_pkg_to_element().
   (when package-name-fix
     (unless name
-      (format #t
-              "Warning: argument passing may have been confused by
+      (format-warning
+       "Warning: argument passing may have been confused by
          a comma in a component value:\n
          Check ~A ~A ~A
          Maybe just use a space instead of a comma?\n"


### PR DESCRIPTION
In this branch, the following changes have been done:

- `verbose-format()` and `extra-verbose-format()` syntaces have
  been utilized in various functions.

- Syntax rules for outputting messages, warnings, and errors have
  been added and utilized in various functions.  A new module,
  `(sch2pcb format)`, containing all the formatting syntax
  stanzas, has been introduced.

- In `format-error()` syntax, messages are output prefixed with
  "ERROR:" string.

- The above syntaces allowed to automatically gettextize the
  messages inline.

- Port variables have been added to store current standard ports.
  This is to ensure all program messages go into appropriate ports
  and do not mix with other information (e.g. pcb file contents)
  when current standard output port is redirected to a file.

- Some messages have been unified, some merged to reduce the
  number of `format()` calls.  One message has been transformed
  into a warning.  Some comments have been added.