### PR TITLE
sch2pcb:  Utilze C accessors in pcb_element_line_parse().

### DIFF
--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -442,7 +442,7 @@ pcb_element_line_parse (gchar * line)
   close_char = el->hi_res_format ? ']' : ')';
 
   el->flags = token (s + 1, NULL, &el->quoted_flags);
-  el->description = token (NULL, NULL, NULL);
+  pcb_element_set_description (el, token (NULL, NULL, NULL));
   pcb_element_set_refdes (el, token (NULL, NULL, NULL));
   pcb_element_set_value (el, token (NULL, NULL, NULL));
 
@@ -467,7 +467,7 @@ pcb_element_line_parse (gchar * line)
   if (elcount > 4)
     el->new_format = TRUE;
 
-  fix_spaces (el->description);
+  fix_spaces (pcb_element_get_description (el));
   fix_spaces (pcb_element_get_refdes (el));
   fix_spaces (pcb_element_get_value (el));
 

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -438,7 +438,7 @@ pcb_element_line_parse (gchar * line)
     return NULL;
   }
 
-  el->res_char = el->hi_res_format ? '[' : '(';
+  pcb_element_set_res_char (el, el->hi_res_format ? '[' : '(');
   close_char = el->hi_res_format ? ']' : ')';
 
   pcb_element_set_flags (el, token (s + 1, NULL, &el->quoted_flags));

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -444,7 +444,7 @@ pcb_element_line_parse (gchar * line)
   el->flags = token (s + 1, NULL, &el->quoted_flags);
   el->description = token (NULL, NULL, NULL);
   pcb_element_set_refdes (el, token (NULL, NULL, NULL));
-  el->value = token (NULL, NULL, NULL);
+  pcb_element_set_value (el, token (NULL, NULL, NULL));
 
   el->x = token (NULL, NULL, NULL);
   el->y = token (NULL, &t, NULL);
@@ -469,7 +469,7 @@ pcb_element_line_parse (gchar * line)
 
   fix_spaces (el->description);
   fix_spaces (pcb_element_get_refdes (el));
-  fix_spaces (el->value);
+  fix_spaces (pcb_element_get_value (el));
 
   /* Don't allow elements with no refdes to ever be deleted because
    * they may be desired pc board elements not in schematics.  So

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -478,7 +478,7 @@ pcb_element_line_parse (gchar * line)
    */
   if (!*pcb_element_get_refdes (el)
       || !isalnum ((gint) (*pcb_element_get_refdes (el))))
-    el->still_exists = TRUE;
+    pcb_element_set_still_exists (el, TRUE);
 
   return el;
 }

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -449,14 +449,14 @@ pcb_element_line_parse (gchar * line)
   el->x = token (NULL, NULL, NULL);
   el->y = token (NULL, &t, NULL);
 
-  el->tail = g_strdup (t ? t : "");
-  if ((s = strrchr (el->tail, (gint) '\n')) != NULL)
+  pcb_element_set_tail (el, g_strdup (t ? t : ""));
+  if ((s = strrchr (pcb_element_get_tail (el), (gint) '\n')) != NULL)
     *s = '\0';
 
   /* Count the tokens in tail to decide if it's new or old format.
    * Old format will have 3 tokens, new format will have 5 tokens.
    */
-  for (s = el->tail; *s && *s != close_char; ++s) {
+  for (s = pcb_element_get_tail (el); *s && *s != close_char; ++s) {
     if (*s != ' ') {
       if (state == 0)
         ++elcount;

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -443,7 +443,7 @@ pcb_element_line_parse (gchar * line)
 
   el->flags = token (s + 1, NULL, &el->quoted_flags);
   el->description = token (NULL, NULL, NULL);
-  el->refdes = token (NULL, NULL, NULL);
+  pcb_element_set_refdes (el, token (NULL, NULL, NULL));
   el->value = token (NULL, NULL, NULL);
 
   el->x = token (NULL, NULL, NULL);
@@ -468,7 +468,7 @@ pcb_element_line_parse (gchar * line)
     el->new_format = TRUE;
 
   fix_spaces (el->description);
-  fix_spaces (el->refdes);
+  fix_spaces (pcb_element_get_refdes (el));
   fix_spaces (el->value);
 
   /* Don't allow elements with no refdes to ever be deleted because
@@ -476,7 +476,8 @@ pcb_element_line_parse (gchar * line)
    * initialize still_exists to TRUE if empty or non-alphanumeric
    * refdes.
    */
-  if (!*el->refdes || !isalnum ((gint) (*el->refdes)))
+  if (!*pcb_element_get_refdes (el)
+      || !isalnum ((gint) (*pcb_element_get_refdes (el))))
     el->still_exists = TRUE;
 
   return el;

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -447,7 +447,7 @@ pcb_element_line_parse (gchar * line)
   pcb_element_set_value (el, token (NULL, NULL, NULL));
 
   pcb_element_set_x (el, token (NULL, NULL, NULL));
-  el->y = token (NULL, &t, NULL);
+  pcb_element_set_y (el, token (NULL, &t, NULL));
 
   pcb_element_set_tail (el, g_strdup (t ? t : ""));
   if ((s = strrchr (pcb_element_get_tail (el), (gint) '\n')) != NULL)

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -432,14 +432,14 @@ pcb_element_line_parse (gchar * line)
     ++s;
 
   if (*s == '[')
-    el->hi_res_format = TRUE;
+    pcb_element_set_hi_res_format (el, TRUE);
   else if (*s != '(') {
     g_free (el);
     return NULL;
   }
 
-  pcb_element_set_res_char (el, el->hi_res_format ? '[' : '(');
-  close_char = el->hi_res_format ? ']' : ')';
+  pcb_element_set_res_char (el, pcb_element_get_hi_res_format (el) ? '[' : '(');
+  close_char = pcb_element_get_hi_res_format (el) ? ']' : ')';
 
   pcb_element_set_flags (el, token (s + 1, NULL, &el->quoted_flags));
   pcb_element_set_description (el, token (NULL, NULL, NULL));

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -465,7 +465,7 @@ pcb_element_line_parse (gchar * line)
       state = 0;
   }
   if (elcount > 4)
-    el->new_format = TRUE;
+    pcb_element_set_new_format (el, TRUE);
 
   fix_spaces (pcb_element_get_description (el));
   fix_spaces (pcb_element_get_refdes (el));

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -441,7 +441,9 @@ pcb_element_line_parse (gchar * line)
   pcb_element_set_res_char (el, pcb_element_get_hi_res_format (el) ? '[' : '(');
   close_char = pcb_element_get_hi_res_format (el) ? ']' : ')';
 
-  pcb_element_set_flags (el, token (s + 1, NULL, &el->quoted_flags));
+  gboolean quoted_flags;
+  pcb_element_set_flags (el, token (s + 1, NULL, &quoted_flags));
+  pcb_element_set_quoted_flags (el, quoted_flags);
   pcb_element_set_description (el, token (NULL, NULL, NULL));
   pcb_element_set_refdes (el, token (NULL, NULL, NULL));
   pcb_element_set_value (el, token (NULL, NULL, NULL));

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -446,7 +446,7 @@ pcb_element_line_parse (gchar * line)
   pcb_element_set_refdes (el, token (NULL, NULL, NULL));
   pcb_element_set_value (el, token (NULL, NULL, NULL));
 
-  el->x = token (NULL, NULL, NULL);
+  pcb_element_set_x (el, token (NULL, NULL, NULL));
   el->y = token (NULL, &t, NULL);
 
   pcb_element_set_tail (el, g_strdup (t ? t : ""));

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -441,7 +441,7 @@ pcb_element_line_parse (gchar * line)
   el->res_char = el->hi_res_format ? '[' : '(';
   close_char = el->hi_res_format ? ']' : ')';
 
-  el->flags = token (s + 1, NULL, &el->quoted_flags);
+  pcb_element_set_flags (el, token (s + 1, NULL, &el->quoted_flags));
   pcb_element_set_description (el, token (NULL, NULL, NULL));
   pcb_element_set_refdes (el, token (NULL, NULL, NULL));
   pcb_element_set_value (el, token (NULL, NULL, NULL));


### PR DESCRIPTION
This is a preliminary step before rewriting the function in Scheme.