### PR TITLE
sch2pcb: Add some new ITS tests.

### DIFF
--- a/liblepton/scheme/netlist.scm
+++ b/liblepton/scheme/netlist.scm
@@ -157,8 +157,8 @@ code should use `gnetlist:get-backend-arguments' directly."
            (or (every (lambda (x) (equal? x value)) values)
                (format (current-error-port) (G_ "\
 Possible attribute conflict for refdes: ~A
-name: ~A
-values: ~A
+  name: ~A
+  values: ~S
 ") refdes name values))
            value))))
 

--- a/tests/sch2pcb.test
+++ b/tests/sch2pcb.test
@@ -1,4 +1,5 @@
 (use-modules (srfi srfi-64)
+             (ice-9 rdelim)
              (ice-9 receive))
 
 (load-from-path "env.scm")
@@ -358,6 +359,22 @@
 
 (test-end)
 
+;;; Copy IN-FILE to OUT-FILE replacing IN-STRING with OUT-STRING.
+(define (replace-one-line in-file out-file in-string out-string)
+  (with-input-from-file in-file
+    (lambda ()
+      (with-output-to-file out-file
+        (lambda ()
+          (let loop ((s (read-line))
+                     (done? #f))
+            (unless (eof-object? s)
+              (loop (read-line)
+                    (let ((replace? (and (not done?)
+                                         (string= s in-string))))
+                      (display (if replace? out-string s))
+                      (newline)
+                      (or replace? done?))))))))))
+
 
 (test-begin "sch2pcb --fix-elements")
 
@@ -384,6 +401,63 @@
 
     ;; Now the files are the same.
     (test-run-success "diff" tests/one.pcb "one-wrong-footprint.pcb"))
+
+  ;; Prepare files.
+  (replace-one-line one.sch "a.sch" "footprint=DIL 8 300" "footprint=SOME-FOOTPRINT")
+  (replace-one-line one.sch "b.sch" "footprint=DIL 8 300" "footprint=DIP8")
+  (mkdir "packages")
+  (copy-file (build-filename tests/ "packages" "DIP8.fp")
+             (build-filename "packages" "DIP8.fp"))
+
+  ;; Create one.pcb anew.
+  (delete-file one.pcb)
+  (receive (<status> <stdout> <stderr>)
+      (command-values lepton-sch2pcb
+                      (string-append "--m4-pcbdir" "=" m4-pcbdir)
+                      one.sch two.sch)
+    (test-eq EXIT_SUCCESS <status>)
+    (test-assert (file-exists? one.pcb)))
+
+  ;; First, change footprint= of U101.1 so it contains a value
+  ;; unknown for netlister.
+  (delete-file one.sch)
+  (rename-file "a.sch" one.sch)
+
+  (receive (<status> <stdout> <stderr>)
+      (command-values lepton-sch2pcb
+                      (string-append "--m4-pcbdir" "=" m4-pcbdir)
+                      "--fix-elements"
+                      one.sch two.sch)
+    (test-eq EXIT_SUCCESS <status>)
+    ;; The lepton-netlist output should contain lines as follows.
+    (test-assert (string-contains <stderr> "Possible attribute conflict for refdes: U101"))
+    (test-assert (string-contains <stderr> "name: footprint"))
+    (test-assert (string-contains <stderr> "values: (\"SOME-FOOTPRINT\" \"DIL 8 300\")"))
+    ;; The footprint is not found.
+    (test-assert (string-contains <stderr> "can't find PCB element for footprint \"SOME-FOOTPRINT\" (value=TL072)"))
+    (test-assert (string-contains <stdout> "U101: updating element Description: DIL-8-300 -> SOME-FOOTPRINT"))
+    (test-assert (file-exists? one.pcb))
+    (test-grep-file-success "Element(0x00 \"SOME-FOOTPRINT\" \"U101\" \"TL072\" 220 100 3 100 0x00)" one.pcb))
+
+
+  ;; Next, try the same with an existing footprint.
+  (delete-file one.sch)
+  (rename-file "b.sch" one.sch)
+
+  (receive (<status> <stdout> <stderr>)
+      (command-values lepton-sch2pcb
+                      (string-append "--m4-pcbdir" "=" m4-pcbdir)
+                      "--fix-elements"
+                      one.sch two.sch)
+    (test-eq EXIT_SUCCESS <status>)
+    ;; The lepton-netlist output should contain lines as follows.
+    (test-assert (string-contains <stderr> "Possible attribute conflict for refdes: U101"))
+    (test-assert (string-contains <stderr> "name: footprint"))
+    (test-assert (string-contains <stderr> "values: (\"DIP8\" \"DIL 8 300\")"))
+    ;; The footprint should be found.
+    (test-assert (string-contains <stdout> "U101: updating element Description: SOME-FOOTPRINT -> DIP8"))
+    (test-assert (file-exists? one.pcb))
+    (test-grep-file-success "Element(0x00 \"DIP8\" \"U101\" \"TL072\" 220 100 3 100 0x00)" one.pcb))
 
   (test-teardown))
 

--- a/tests/sch2pcb.test
+++ b/tests/sch2pcb.test
@@ -968,6 +968,42 @@
 (test-end)
 
 
+(test-begin "sch2pcb --backend-pcb=unknown-backend")
+(test-group-with-cleanup "sch2pcb --backend-pcb=unknown-backend"
+  (prepare-test-directory)
+
+  ;; Test that the program informs the user if something went
+  ;; wrong and the output file is not updated.
+
+  (receive (<status> <stdout> <stderr>)
+      (command-values lepton-sch2pcb
+                      "-v"
+                      (string-append "--backend-pcb" "=" "unknown-backend")
+                      one.sch)
+    (test-eq EXIT_FAILURE <status>)
+    (test-assert (not (file-exists? one.pcb)))
+    (test-assert (string-contains <stderr> "lepton-sch2pcb: netlister command failed, `one.pcb' not updated")))
+
+  ;; Now, do the same though the output file should exist.
+  ;; This file has to exist.
+  (touch one.pcb)
+  ;; This file is a subject to update.
+  (touch "one.new.pcb")
+  (receive (<status> <stdout> <stderr>)
+      (command-values lepton-sch2pcb
+                      "-v"
+                      (string-append "--backend-pcb" "=" "unknown-backend")
+                      one.sch)
+    (test-eq EXIT_FAILURE <status>)
+    (test-assert (file-exists? one.pcb))
+    (test-assert (file-exists? "one.new.pcb"))
+    (test-assert (string-contains <stderr> "lepton-sch2pcb: netlister command failed, `one.new.pcb' not updated")))
+
+  (test-teardown))
+
+(test-end)
+
+
 (test-begin "sch2pcb --m4-file")
 
 (test-group-with-cleanup "sch2pcb --m4-file"

--- a/tests/sch2pcb.test
+++ b/tests/sch2pcb.test
@@ -436,6 +436,8 @@
     ;; The footprint is not found.
     (test-assert (string-contains <stderr> "can't find PCB element for footprint \"SOME-FOOTPRINT\" (value=TL072)"))
     (test-assert (string-contains <stdout> "U101: updating element Description: DIL-8-300 -> SOME-FOOTPRINT"))
+    (test-assert (string-contains <stdout> "1 not found elements added to one.new.pcb."))
+    (test-assert (string-contains <stdout> "1 elements fixed in one.pcb."))
     (test-assert (file-exists? one.pcb))
     (test-grep-file-success "Element(0x00 \"SOME-FOOTPRINT\" \"U101\" \"TL072\" 220 100 3 100 0x00)" one.pcb))
 
@@ -443,6 +445,8 @@
   ;; Next, try the same with an existing footprint.
   (delete-file one.sch)
   (rename-file "b.sch" one.sch)
+  ;; Back up one.pcb.
+  (copy-file one.pcb "one.pcb.backup")
 
   (receive (<status> <stdout> <stderr>)
       (command-values lepton-sch2pcb
@@ -456,8 +460,30 @@
     (test-assert (string-contains <stderr> "values: (\"DIP8\" \"DIL 8 300\")"))
     ;; The footprint should be found.
     (test-assert (string-contains <stdout> "U101: updating element Description: SOME-FOOTPRINT -> DIP8"))
+    (test-assert (string-contains <stdout> "1 file elements and 0 m4 elements added to one.new.pcb."))
+    ;; One element is fixed.
+    (test-assert (string-contains <stdout> "1 elements fixed in one.pcb."))
+    ;; Nothing is deleted.
+    (test-assert (not (string-contains <stdout> "1 elements deleted from one.pcb.")))
     (test-assert (file-exists? one.pcb))
     (test-grep-file-success "Element(0x00 \"DIP8\" \"U101\" \"TL072\" 220 100 3 100 0x00)" one.pcb))
+
+  ;; The same test as the above only without '--fix-elements' just
+  ;; to make sure the program behaves otherwise.
+
+  ;; Restore one.pcb
+  (delete-file one.pcb)
+  (rename-file "one.pcb.backup" one.pcb)
+  (receive (<status> <stdout> <stderr>)
+      (command-values lepton-sch2pcb
+                      (string-append "--m4-pcbdir" "=" m4-pcbdir)
+                      one.sch two.sch)
+    (test-eq EXIT_SUCCESS <status>)
+    (test-assert (string-contains <stdout> "1 file elements and 0 m4 elements added to one.new.pcb."))
+    ;; One element is deleted.
+    (test-assert (string-contains <stdout> "1 elements deleted from one.pcb."))
+    ;; Nothing is fixed.
+    (test-assert (not (string-contains <stdout> "1 elements fixed in one.pcb."))))
 
   (test-teardown))
 

--- a/tools/sch2pcb/tests/Makefile.am
+++ b/tools/sch2pcb/tests/Makefile.am
@@ -12,6 +12,7 @@ EXTRA_DIST = \
 	one.sch.R101.footprint.unknown \
 	one.sch.R101.deleted \
 	two.sch \
+	packages/DIP8.fp \
 	sym/2N3904-1.sym \
 	sym/BNC-1.sym \
 	sym/dual-opamp-1.sym \

--- a/tools/sch2pcb/tests/packages/DIP8.fp
+++ b/tools/sch2pcb/tests/packages/DIP8.fp
@@ -1,0 +1,20 @@
+# retain backwards compatibility to older versions of PKG_DIL 
+# which did not have 100,60,28 args
+Element(0x00 "Dual in-line package, narrow (300 mil)" "" "DIP8" 220 100 3 100 0x00)
+(
+	Pin(50 50 60 28 "1" 0x101)
+	Pin(50 150 60 28 "2" 0x01)
+	Pin(50 250 60 28 "3" 0x01)
+	Pin(50 350 60 28 "4" 0x01)
+	Pin(350 350 60 28 "5" 0x01)
+	Pin(350 250 60 28 "6" 0x01)
+	Pin(350 150 60 28 "7" 0x01)
+	Pin(350 50 60 28 "8" 0x01)
+	ElementLine(0 0 0 400 10)
+	ElementLine(0 400 400 400 10)
+	ElementLine(400 400 400 0 10)
+	ElementLine(0 0 150 0 10)
+	ElementLine(250 0 400 0 10)
+	ElementArc(200 0 50 50 0 180 10)
+	Mark(50 50)
+)


### PR DESCRIPTION
Added a few tests for the options `--backend-pcb` and `--fix-elements`.  In #1018 we've came to a consensus discussing that the latter option is superfluous.  However, as the tests are ready, and the option still exists in the code, it's reasonable to utilize them, I believe.

Some changes in output of conflicting attributes have been made in `lepton-netlist` code to prettify the output, and affected the latter couple of tests:
- Indentation has changed a little.
- Attribute values are now output quoted as they may contain spaces  (e.g. "DIL 8 300").
