### PR TITLE
sch2pcb: Make PcbElement accessors available in Scheme.

### DIFF
--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -164,6 +164,8 @@ pcb_element_set_omit_PKG (PcbElement *element,
                           gboolean val);
 
 /* PcbElement functions */
+PcbElement*
+pcb_element_new ();
 
 void
 pcb_element_free (PcbElement *el);

--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -174,6 +174,11 @@ pcb_element_line_parse (gchar *line);
 PcbElement*
 pcb_element_pkg_to_element (gchar *pkg_line);
 
+gchar*
+pcb_element_line_token (gchar *string,
+                        gchar **next,
+                        gboolean *quoted_ret);
+
 /* lepton-sch2pcb's toplevel functions */
 
 char*

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -33,6 +33,7 @@
             pcb_element_get_hi_res_format
             pcb_element_set_hi_res_format
             pcb_element_get_omit_PKG
+            pcb_element_set_omit_PKG
             pcb_element_get_pkg_name_fix
             pcb_element_set_pkg_name_fix
             pcb_element_get_quoted_flags
@@ -83,6 +84,7 @@
 (define-lff pcb_element_get_hi_res_format int '(*))
 (define-lff pcb_element_set_hi_res_format void (list '* int))
 (define-lff pcb_element_get_omit_PKG int '(*))
+(define-lff pcb_element_set_omit_PKG void (list '* int))
 (define-lff pcb_element_get_pkg_name_fix '* '(*))
 (define-lff pcb_element_set_pkg_name_fix void '(* *))
 (define-lff pcb_element_get_quoted_flags int '(*))

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -57,6 +57,7 @@
             pcb_element_set_y
             pcb_element_line_parse
             pcb_element_line_token
+            pcb_element_new
             pcb_element_pkg_to_element
 
             sch2pcb_buffer_to_file
@@ -119,6 +120,7 @@
 (define-lff pcb_element_set_y void '(* *))
 (define-lff pcb_element_line_parse '* '(*))
 (define-lff pcb_element_line_token '* '(* * *))
+(define-lff pcb_element_new '* '())
 (define-lff pcb_element_pkg_to_element '* '(*))
 
 (define-lff sch2pcb_buffer_to_file void '(* *))

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -29,6 +29,7 @@
             pcb_element_set_changed_value
             pcb_element_get_description
             pcb_element_get_flags
+            pcb_element_set_hi_res_format
             pcb_element_get_omit_PKG
             pcb_element_get_pkg_name_fix
             pcb_element_get_quoted_flags
@@ -72,6 +73,7 @@
 (define-lff pcb_element_set_changed_value void '(* *))
 (define-lff pcb_element_get_description '* '(*))
 (define-lff pcb_element_get_flags '* '(*))
+(define-lff pcb_element_set_hi_res_format void (list '* int))
 (define-lff pcb_element_get_omit_PKG int '(*))
 (define-lff pcb_element_get_pkg_name_fix '* '(*))
 (define-lff pcb_element_get_quoted_flags int '(*))

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -47,7 +47,9 @@
             pcb_element_get_value
             pcb_element_set_value
             pcb_element_get_x
+            pcb_element_set_x
             pcb_element_get_y
+            pcb_element_set_y
             pcb_element_line_parse
             pcb_element_pkg_to_element
 
@@ -101,7 +103,9 @@
 (define-lff pcb_element_get_value '* '(*))
 (define-lff pcb_element_set_value void '(* *))
 (define-lff pcb_element_get_x '* '(*))
+(define-lff pcb_element_set_x void '(* *))
 (define-lff pcb_element_get_y '* '(*))
+(define-lff pcb_element_set_y void '(* *))
 (define-lff pcb_element_line_parse '* '(*))
 (define-lff pcb_element_pkg_to_element '* '(*))
 

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -29,6 +29,7 @@
             pcb_element_set_changed_value
             pcb_element_get_description
             pcb_element_get_flags
+            pcb_element_get_hi_res_format
             pcb_element_set_hi_res_format
             pcb_element_get_omit_PKG
             pcb_element_get_pkg_name_fix
@@ -73,6 +74,7 @@
 (define-lff pcb_element_set_changed_value void '(* *))
 (define-lff pcb_element_get_description '* '(*))
 (define-lff pcb_element_get_flags '* '(*))
+(define-lff pcb_element_get_hi_res_format int '(*))
 (define-lff pcb_element_set_hi_res_format void (list '* int))
 (define-lff pcb_element_get_omit_PKG int '(*))
 (define-lff pcb_element_get_pkg_name_fix '* '(*))

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -30,6 +30,7 @@
             pcb_element_get_description
             pcb_element_set_description
             pcb_element_get_flags
+            pcb_element_set_flags
             pcb_element_get_hi_res_format
             pcb_element_set_hi_res_format
             pcb_element_get_omit_PKG
@@ -87,6 +88,7 @@
 (define-lff pcb_element_get_description '* '(*))
 (define-lff pcb_element_set_description void '(* *))
 (define-lff pcb_element_get_flags '* '(*))
+(define-lff pcb_element_set_flags void '(* *))
 (define-lff pcb_element_get_hi_res_format int '(*))
 (define-lff pcb_element_set_hi_res_format void (list '* int))
 (define-lff pcb_element_get_omit_PKG int '(*))

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -34,6 +34,7 @@
             pcb_element_set_hi_res_format
             pcb_element_get_omit_PKG
             pcb_element_get_pkg_name_fix
+            pcb_element_set_pkg_name_fix
             pcb_element_get_quoted_flags
             pcb_element_get_refdes
             pcb_element_set_refdes
@@ -83,6 +84,7 @@
 (define-lff pcb_element_set_hi_res_format void (list '* int))
 (define-lff pcb_element_get_omit_PKG int '(*))
 (define-lff pcb_element_get_pkg_name_fix '* '(*))
+(define-lff pcb_element_set_pkg_name_fix void '(* *))
 (define-lff pcb_element_get_quoted_flags int '(*))
 (define-lff pcb_element_get_refdes '* '(*))
 (define-lff pcb_element_set_refdes void '(* *))

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -38,6 +38,7 @@
             pcb_element_get_pkg_name_fix
             pcb_element_set_pkg_name_fix
             pcb_element_get_quoted_flags
+            pcb_element_set_quoted_flags
             pcb_element_get_refdes
             pcb_element_set_refdes
             pcb_element_get_res_char
@@ -96,6 +97,7 @@
 (define-lff pcb_element_get_pkg_name_fix '* '(*))
 (define-lff pcb_element_set_pkg_name_fix void '(* *))
 (define-lff pcb_element_get_quoted_flags int '(*))
+(define-lff pcb_element_set_quoted_flags void (list '* int))
 (define-lff pcb_element_get_refdes '* '(*))
 (define-lff pcb_element_set_refdes void '(* *))
 (define-lff pcb_element_get_res_char int '(*))

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -58,8 +58,11 @@
             sch2pcb_increment_verbose_mode
             sch2pcb_insert_element
             sch2pcb_get_n_empty
+            sch2pcb_set_n_empty
             sch2pcb_get_n_none
+            sch2pcb_set_n_none
             sch2pcb_get_n_unknown
+            sch2pcb_set_n_unknown
             sch2pcb_parse_schematics
             sch2pcb_get_pcb_element_list
             sch2pcb_pcb_element_list_append
@@ -109,8 +112,11 @@
 (define-lff sch2pcb_increment_verbose_mode void '())
 (define-lff sch2pcb_insert_element int '(* * * * *))
 (define-lff sch2pcb_get_n_empty int '())
+(define-lff sch2pcb_set_n_empty void (list int))
 (define-lff sch2pcb_get_n_none int '())
+(define-lff sch2pcb_set_n_none void (list int))
 (define-lff sch2pcb_get_n_unknown int '())
+(define-lff sch2pcb_set_n_unknown void (list int))
 (define-lff sch2pcb_parse_schematics '* '(*))
 (define-lff sch2pcb_get_pcb_element_list '* '())
 (define-lff sch2pcb_pcb_element_list_append void '(*))

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -51,6 +51,7 @@
             pcb_element_get_y
             pcb_element_set_y
             pcb_element_line_parse
+            pcb_element_line_token
             pcb_element_pkg_to_element
 
             sch2pcb_buffer_to_file
@@ -107,6 +108,7 @@
 (define-lff pcb_element_get_y '* '(*))
 (define-lff pcb_element_set_y void '(* *))
 (define-lff pcb_element_line_parse '* '(*))
+(define-lff pcb_element_line_token '* '(* * *))
 (define-lff pcb_element_pkg_to_element '* '(*))
 
 (define-lff sch2pcb_buffer_to_file void '(* *))

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -36,6 +36,7 @@
             pcb_element_get_quoted_flags
             pcb_element_get_refdes
             pcb_element_get_res_char
+            pcb_element_set_res_char
             pcb_element_get_still_exists
             pcb_element_set_still_exists
             pcb_element_get_tail
@@ -81,6 +82,7 @@
 (define-lff pcb_element_get_quoted_flags int '(*))
 (define-lff pcb_element_get_refdes '* '(*))
 (define-lff pcb_element_get_res_char int '(*))
+(define-lff pcb_element_set_res_char void (list '* int))
 (define-lff pcb_element_get_still_exists int '(*))
 (define-lff pcb_element_set_still_exists void (list '* int))
 (define-lff pcb_element_get_tail '* '(*))

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -33,6 +33,8 @@
             pcb_element_set_flags
             pcb_element_get_hi_res_format
             pcb_element_set_hi_res_format
+            pcb_element_get_new_format
+            pcb_element_set_new_format
             pcb_element_get_omit_PKG
             pcb_element_set_omit_PKG
             pcb_element_get_pkg_name_fix
@@ -93,6 +95,8 @@
 (define-lff pcb_element_set_flags void '(* *))
 (define-lff pcb_element_get_hi_res_format int '(*))
 (define-lff pcb_element_set_hi_res_format void (list '* int))
+(define-lff pcb_element_get_new_format int '(*))
+(define-lff pcb_element_set_new_format void (list '* int))
 (define-lff pcb_element_get_omit_PKG int '(*))
 (define-lff pcb_element_set_omit_PKG void (list '* int))
 (define-lff pcb_element_get_pkg_name_fix '* '(*))

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -46,6 +46,7 @@
             pcb_element_get_still_exists
             pcb_element_set_still_exists
             pcb_element_get_tail
+            pcb_element_set_tail
             pcb_element_get_value
             pcb_element_set_value
             pcb_element_get_x
@@ -105,6 +106,7 @@
 (define-lff pcb_element_get_still_exists int '(*))
 (define-lff pcb_element_set_still_exists void (list '* int))
 (define-lff pcb_element_get_tail '* '(*))
+(define-lff pcb_element_set_tail void '(* *))
 (define-lff pcb_element_get_value '* '(*))
 (define-lff pcb_element_set_value void '(* *))
 (define-lff pcb_element_get_x '* '(*))

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -28,6 +28,7 @@
             pcb_element_get_changed_value
             pcb_element_set_changed_value
             pcb_element_get_description
+            pcb_element_set_description
             pcb_element_get_flags
             pcb_element_get_hi_res_format
             pcb_element_set_hi_res_format
@@ -35,12 +36,14 @@
             pcb_element_get_pkg_name_fix
             pcb_element_get_quoted_flags
             pcb_element_get_refdes
+            pcb_element_set_refdes
             pcb_element_get_res_char
             pcb_element_set_res_char
             pcb_element_get_still_exists
             pcb_element_set_still_exists
             pcb_element_get_tail
             pcb_element_get_value
+            pcb_element_set_value
             pcb_element_get_x
             pcb_element_get_y
             pcb_element_line_parse
@@ -74,6 +77,7 @@
 (define-lff pcb_element_get_changed_value '* '(*))
 (define-lff pcb_element_set_changed_value void '(* *))
 (define-lff pcb_element_get_description '* '(*))
+(define-lff pcb_element_set_description void '(* *))
 (define-lff pcb_element_get_flags '* '(*))
 (define-lff pcb_element_get_hi_res_format int '(*))
 (define-lff pcb_element_set_hi_res_format void (list '* int))
@@ -81,12 +85,14 @@
 (define-lff pcb_element_get_pkg_name_fix '* '(*))
 (define-lff pcb_element_get_quoted_flags int '(*))
 (define-lff pcb_element_get_refdes '* '(*))
+(define-lff pcb_element_set_refdes void '(* *))
 (define-lff pcb_element_get_res_char int '(*))
 (define-lff pcb_element_set_res_char void (list '* int))
 (define-lff pcb_element_get_still_exists int '(*))
 (define-lff pcb_element_set_still_exists void (list '* int))
 (define-lff pcb_element_get_tail '* '(*))
 (define-lff pcb_element_get_value '* '(*))
+(define-lff pcb_element_set_value void '(* *))
 (define-lff pcb_element_get_x '* '(*))
 (define-lff pcb_element_get_y '* '(*))
 (define-lff pcb_element_line_parse '* '(*))

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -352,8 +352,10 @@ sch2pcb_increment_verbose_mode ()
 }
 
 
-static gchar *
-token (gchar * string, gchar ** next, gboolean * quoted_ret)
+gchar*
+pcb_element_line_token (gchar *string,
+                        gchar **next,
+                        gboolean *quoted_ret)
 {
   static gchar *str;
   gchar *s, *ret;
@@ -442,14 +444,14 @@ pcb_element_line_parse (gchar * line)
   close_char = pcb_element_get_hi_res_format (el) ? ']' : ')';
 
   gboolean quoted_flags;
-  pcb_element_set_flags (el, token (s + 1, NULL, &quoted_flags));
+  pcb_element_set_flags (el, pcb_element_line_token (s + 1, NULL, &quoted_flags));
   pcb_element_set_quoted_flags (el, quoted_flags);
-  pcb_element_set_description (el, token (NULL, NULL, NULL));
-  pcb_element_set_refdes (el, token (NULL, NULL, NULL));
-  pcb_element_set_value (el, token (NULL, NULL, NULL));
+  pcb_element_set_description (el, pcb_element_line_token (NULL, NULL, NULL));
+  pcb_element_set_refdes (el, pcb_element_line_token (NULL, NULL, NULL));
+  pcb_element_set_value (el, pcb_element_line_token (NULL, NULL, NULL));
 
-  pcb_element_set_x (el, token (NULL, NULL, NULL));
-  pcb_element_set_y (el, token (NULL, &t, NULL));
+  pcb_element_set_x (el, pcb_element_line_token (NULL, NULL, NULL));
+  pcb_element_set_y (el, pcb_element_line_token (NULL, &t, NULL));
 
   pcb_element_set_tail (el, g_strdup (t ? t : ""));
   if ((s = strrchr (pcb_element_get_tail (el), (gint) '\n')) != NULL)

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -30,6 +30,11 @@
 
 #define SEP_STRING "--------\n"
 
+PcbElement*
+pcb_element_new ()
+{
+  return g_new0 (PcbElement, 1);
+}
 
 gchar*
 pcb_element_get_refdes (PcbElement *element)
@@ -683,7 +688,7 @@ pcb_element_pkg_to_element (gchar *pkg_line)
   fix_spaces (args[1]);
   fix_spaces (args[2]);
 
-  el = g_new0 (PcbElement, 1);
+  el = pcb_element_new ();
   el->description = g_strdup (args[0]);
   el->refdes = g_strdup (args[1]);
   el->value = g_strdup (args[2]);


### PR DESCRIPTION
This branch adds Scheme FFI mates for almost all C functions available in `sch2pcb.c` except a couple of little ones and introduces a function for `PcbElement` creation making it also available in Scheme.