### PR TITLE
gui: Don't destroy Multiattrib widget on 'close' and 'delete' events.

### DIFF
--- a/libleptongui/src/x_multiattrib.c
+++ b/libleptongui/src/x_multiattrib.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2016 gEDA Contributors
- * Copyright (C) 2017-2022 Lepton EDA Contributors
+ * Copyright (C) 2017-2023 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -56,7 +56,7 @@ multiattrib_callback_response (GtkDialog *dialog,
   switch (arg1) {
       case GTK_RESPONSE_CLOSE:
       case GTK_RESPONSE_DELETE_EVENT:
-        gtk_widget_destroy (GTK_WIDGET (dialog));
+        gtk_widget_hide (GTK_WIDGET (dialog));
         w_current->mawindow = NULL;
         break;
   }


### PR DESCRIPTION
As it stands out, closing and opening the Multiattrib dialog leads to crashes on some systems due to some racing conditions that involve Guile garbage collection.  Replacing destroying the widget with just hiding it, cures the issue.

Closes #1010.
Closes #1020.