### PR TITLE
Rewrite some undo functions in Scheme

### DIFF
--- a/docs/manual/configuration.texi
+++ b/docs/manual/configuration.texi
@@ -983,7 +983,13 @@ the X11 @file{rgb.txt} file), or a hex value in the form
 @tab @cfgtype{boolean}
 @tab @cfgval{false}
 @tab
-Allow undo/redo operations to change pan and zoom.
+@anchor{modify-viewport}
+Allow undo/redo operations to change pan and zoom.  Unlike
+@ref{undo-panzoom}, when the option is set to @samp{true}, it won't
+lead to showing _all_ preserved viewport changes on undo/redo.  Only
+the edits that include changes of any objects in your schematics will
+be undone or redone, and the viewport size recorded at the time of
+those changes will be restored.
 
 @item @cfgkey{undo-control}
 @tab @cfgtype{boolean}
@@ -1014,10 +1020,13 @@ Determines the number of levels of undo.  @since{1.9.10}
 @tab @cfgtype{boolean}
 @tab @cfgval{false}
 @tab
-@anchor{undo-panzoom}
-Controls if pan or zoom commands are saved in the undo list. If this
-is enabled, then a pan or zoom will be considered a command and can be
-undone.  @since{1.9.10}
+@anchor{undo-panzoom} Controls if pan or zoom commands are saved in
+the undo list. If this is enabled, then a pan or zoom will be
+considered a command and can be undone.  Unlike @ref{modify-viewport},
+setting the option to @samp{true} will lead to repeating _all_ your
+scrolling or scaling steps you did when editing your schematics if
+you trigger undo or redo, not only those in which you changed their
+objects somehow.  @since{1.9.10}
 
 @end multitable
 

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -329,9 +329,6 @@ void o_undo_savestate_old(GschemToplevel *w_current, int flag);
 void
 o_undo_savestate_viewport (GschemToplevel *w_current);
 
-gboolean
-o_undo_modify_viewport ();
-
 int
 schematic_undo_get_file_index ();
 

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -333,9 +333,6 @@ o_undo_savestate_viewport (GschemToplevel *w_current);
 char*
 o_undo_find_prev_filename (LeptonUndo *start);
 
-GList*
-o_undo_find_prev_object_head (LeptonUndo *start);
-
 gboolean
 o_undo_modify_viewport ();
 

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -320,7 +320,6 @@ void o_slot_end(GschemToplevel *w_current, LeptonObject *object, const char *str
 void o_text_prepare_place(GschemToplevel *w_current, char *text, int color, int align, int rotate, int size);
 void o_text_change(GschemToplevel *w_current, LeptonObject *object, char *string, int visibility, int show);
 /* o_undo.c */
-void o_undo_init(void);
 void
 o_undo_savestate (GschemToplevel *w_current,
                   LeptonPage *page,

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -330,9 +330,6 @@ void o_undo_savestate_old(GschemToplevel *w_current, int flag);
 void
 o_undo_savestate_viewport (GschemToplevel *w_current);
 
-char*
-o_undo_find_prev_filename (LeptonUndo *start);
-
 gboolean
 o_undo_modify_viewport ();
 

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -443,7 +443,6 @@
 
             s_slot_update_object
 
-            o_undo_modify_viewport
             o_undo_savestate
             o_undo_savestate_old
             o_undo_savestate_viewport
@@ -1051,7 +1050,6 @@
 (define-lff x_tabs_prev void '(*))
 
 ;;; o_undo.c
-(define-lff o_undo_modify_viewport int '())
 (define-lff o_undo_savestate void (list '* '* int))
 (define-lff o_undo_savestate_old void (list '* int))
 (define-lff o_undo_savestate_viewport void '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -443,7 +443,6 @@
 
             s_slot_update_object
 
-            o_undo_init
             o_undo_modify_viewport
             o_undo_savestate
             o_undo_savestate_old
@@ -1052,7 +1051,6 @@
 (define-lff x_tabs_prev void '(*))
 
 ;;; o_undo.c
-(define-lff o_undo_init void '())
 (define-lff o_undo_modify_viewport int '())
 (define-lff o_undo_savestate void (list '* '* int))
 (define-lff o_undo_savestate_old void (list '* int))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -443,7 +443,6 @@
 
             s_slot_update_object
 
-            o_undo_find_prev_filename
             o_undo_init
             o_undo_modify_viewport
             o_undo_savestate
@@ -1054,7 +1053,6 @@
 
 ;;; o_undo.c
 (define-lff o_undo_init void '())
-(define-lff o_undo_find_prev_filename '* '(*))
 (define-lff o_undo_modify_viewport int '())
 (define-lff o_undo_savestate void (list '* '* int))
 (define-lff o_undo_savestate_old void (list '* int))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -444,7 +444,6 @@
             s_slot_update_object
 
             o_undo_find_prev_filename
-            o_undo_find_prev_object_head
             o_undo_init
             o_undo_modify_viewport
             o_undo_savestate
@@ -1056,7 +1055,6 @@
 ;;; o_undo.c
 (define-lff o_undo_init void '())
 (define-lff o_undo_find_prev_filename '* '(*))
-(define-lff o_undo_find_prev_object_head '* '(*))
 (define-lff o_undo_modify_viewport int '())
 (define-lff o_undo_savestate void (list '* '* int))
 (define-lff o_undo_savestate_old void (list '* int))

--- a/libleptongui/scheme/schematic/undo.scm
+++ b/libleptongui/scheme/schematic/undo.scm
@@ -38,6 +38,7 @@
     ; public:
     ;
   #:export (undo-cleanup-backup-files!
+            undo-init-backup-path
             undo-save-state
             undo!
             redo!
@@ -59,6 +60,13 @@
 (define F_OPEN_CHECK_BACKUP 2)
 (define F_OPEN_FORCE_BACKUP 4)
 (define F_OPEN_RESTORE_CWD 8)
+
+
+(define (undo-init-backup-path)
+  (define undo-tmp-path (or (getenv "TMP") "/tmp"))
+
+  (schematic_undo_set_tmp_path (string->pointer undo-tmp-path))
+  (log! 'debug "UNDO backup path: ~S" undo-tmp-path))
 
 
 (define (undo-save-state)

--- a/libleptongui/scheme/schematic/undo.scm
+++ b/libleptongui/scheme/schematic/undo.scm
@@ -75,6 +75,18 @@ success, #f on failure."
 
 
 ;;; Recursively search backwards in the undo list for an undo item
+;;; having non-NULL filename.
+(define (*find-previous-filename *undo)
+  (let loop ((*undo-item (lepton_undo_get_prev *undo)))
+    (if (null-pointer? *undo-item)
+        %null-pointer
+        (let ((*filename (lepton_undo_get_filename *undo-item)))
+          (if (null-pointer? *filename)
+              (loop (lepton_undo_get_prev *undo-item))
+              *filename)))))
+
+
+;;; Recursively search backwards in the undo list for an undo item
 ;;; having non-NULL object list.
 (define (*find-previous-object-list *undo)
   (let loop ((*undo-item (lepton_undo_get_prev *undo)))
@@ -117,7 +129,7 @@ success, #f on failure."
                   ;; and just set to NULL below.
                   (if (= (schematic_window_get_undo_type *window) UNDO_DISK)
                       (lepton_undo_set_filename *undo-to-do
-                                                (o_undo_find_prev_filename *undo-to-do))
+                                                (*find-previous-filename *undo-to-do))
                       (lepton_undo_set_object_list *undo-to-do
                                                    (*find-previous-object-list *undo-to-do))))
                 ;; Save page filename to restore it later in case

--- a/libleptongui/scheme/schematic/undo.scm
+++ b/libleptongui/scheme/schematic/undo.scm
@@ -74,6 +74,18 @@ success, #f on failure."
                 #t)))))
 
 
+;;; Recursively search backwards in the undo list for an undo item
+;;; having non-NULL object list.
+(define (*find-previous-object-list *undo)
+  (let loop ((*undo-item (lepton_undo_get_prev *undo)))
+    (if (null-pointer? *undo-item)
+        %null-pointer
+        (let ((*object-list (lepton_undo_get_object_list *undo-item)))
+          (if (null-pointer? *object-list)
+              (loop (lepton_undo_get_prev *undo-item))
+              *object-list)))))
+
+
 (define (undo-callback *window redo?)
   (define undo-enabled?
     (config-boolean (path-config-context (getcwd))
@@ -107,7 +119,7 @@ success, #f on failure."
                       (lepton_undo_set_filename *undo-to-do
                                                 (o_undo_find_prev_filename *undo-to-do))
                       (lepton_undo_set_object_list *undo-to-do
-                                                   (o_undo_find_prev_object_head *undo-to-do))))
+                                                   (*find-previous-object-list *undo-to-do))))
                 ;; Save page filename to restore it later in case
                 ;; a temporary file is opened for undo.  The
                 ;; filename is stored as a Scheme string as the

--- a/libleptongui/scheme/schematic/undo.scm
+++ b/libleptongui/scheme/schematic/undo.scm
@@ -74,28 +74,28 @@ success, #f on failure."
                 #t)))))
 
 
-;;; Recursively search backwards in the undo list for an undo item
-;;; having non-NULL filename.
+;;; Recursively search in the undo list *UNDO for an undo item
+;;; having non-NULL structure field retrieved by C *GETTER.
+(define (*undo-lookup-non-null-field *undo *getter)
+  (let loop ((*undo-item (lepton_undo_get_prev *undo)))
+    (if (null-pointer? *undo-item)
+        %null-pointer
+        (let ((*field-value (*getter *undo-item)))
+          (if (null-pointer? *field-value)
+              (loop (lepton_undo_get_prev *undo-item))
+              *field-value)))))
+
+
+;;; Recursively search in the undo list *UNDO for the first item
+;;; having non-NULL field 'filename'.
 (define (*find-previous-filename *undo)
-  (let loop ((*undo-item (lepton_undo_get_prev *undo)))
-    (if (null-pointer? *undo-item)
-        %null-pointer
-        (let ((*filename (lepton_undo_get_filename *undo-item)))
-          (if (null-pointer? *filename)
-              (loop (lepton_undo_get_prev *undo-item))
-              *filename)))))
+  (*undo-lookup-non-null-field *undo lepton_undo_get_filename))
 
 
-;;; Recursively search backwards in the undo list for an undo item
-;;; having non-NULL object list.
+;;; Recursively search in the undo list *UNDO for the first item
+;;; having non-NULL field 'object_list'.
 (define (*find-previous-object-list *undo)
-  (let loop ((*undo-item (lepton_undo_get_prev *undo)))
-    (if (null-pointer? *undo-item)
-        %null-pointer
-        (let ((*object-list (lepton_undo_get_object_list *undo-item)))
-          (if (null-pointer? *object-list)
-              (loop (lepton_undo_get_prev *undo-item))
-              *object-list)))))
+  (*undo-lookup-non-null-field *undo lepton_undo_get_object_list))
 
 
 (define (undo-callback *window redo?)

--- a/libleptongui/scheme/schematic/undo.scm
+++ b/libleptongui/scheme/schematic/undo.scm
@@ -111,6 +111,11 @@ success, #f on failure."
     (config-boolean (path-config-context (getcwd))
                     "schematic.undo"
                     "undo-control"))
+  ;; Test if viewport only changes can be undone/redone.
+  (define modify-viewport?
+    (config-boolean (path-config-context (getcwd))
+                    "schematic.undo"
+                    "modify-viewport"))
 
   (define (page-undo-callback *window *page-view *page redo?)
     (unless (null-pointer? *page)
@@ -199,7 +204,7 @@ success, #f on failure."
 
                     (let ((*geometry (gschem_page_view_get_page_geometry *page-view)))
                       (when (or (true? (schematic_window_get_undo_panzoom *window))
-                                (true? (o_undo_modify_viewport)))
+                                modify-viewport?)
                         (if (not (zero? (lepton_undo_get_scale *undo-to-do)))
                             (begin
                               (gschem_page_geometry_set_viewport *geometry

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -108,56 +108,6 @@ schematic_undo_index_to_filename (int index)
 }
 
 
-/*! \brief Return the value of "modify-viewport" configuration key.
- *
- * \par Function Description
- *
- * This function reads the value of "modify-viewport" configuration
- * setting in "schematic.undo" group, which determines
- * if undo/redo operations are allowed to change pan and zoom (i.e. viewport)
- * when "undo-panzoom" option (in gschemrc) is set to "disabled".
- *
- * Configuration setting description:
- * key:   modify-viewport
- * group: schematic.undo
- * type:  boolean
- * default value: false
- *
- * \return TRUE if undo/redo can modify viewport, FALSE otherwise.
- */
-
-gboolean
-o_undo_modify_viewport()
-{
-  gboolean result = FALSE; /* option's default value */
-  gchar* cwd = g_get_current_dir();
-
-  EdaConfig* cfg = eda_config_get_context_for_path (cwd);
-
-  g_free (cwd);
-
-  if (cfg == NULL)
-  {
-    return result;
-  }
-
-  GError* err = NULL;
-  gboolean val = eda_config_get_boolean (cfg,
-                                         "schematic.undo",
-                                         "modify-viewport",
-                                         &err);
-  if (err == NULL)
-  {
-    result = val;
-  }
-
-  g_clear_error (&err);
-
-  return result;
-}
-
-
-
 /*! \todo Finish function documentation!!!
  *  \brief
  *  \par Function Description

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -409,27 +409,3 @@ o_undo_savestate_viewport (GschemToplevel *w_current)
 
   o_undo_savestate (w_current, page, UNDO_VIEWPORT_ONLY);
 }
-
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
-char*
-o_undo_find_prev_filename (LeptonUndo *start)
-{
-  LeptonUndo *u_current;
-
-  u_current = lepton_undo_get_prev (start);
-
-  while(u_current) {
-    if (lepton_undo_get_filename (u_current) != NULL)
-    {
-      return (lepton_undo_get_filename (u_current));
-    }
-    u_current = lepton_undo_get_prev (u_current);
-  }
-
-  return(NULL);
-}

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -432,25 +432,3 @@ o_undo_find_prev_filename (LeptonUndo *start)
 
   return(NULL);
 }
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
-GList *o_undo_find_prev_object_head (LeptonUndo *start)
-{
-  LeptonUndo *u_current;
-
-  u_current = lepton_undo_get_prev (start);
-
-  while(u_current) {
-    if (lepton_undo_get_object_list (u_current) != NULL)
-    {
-      return lepton_undo_get_object_list (u_current);
-    }
-    u_current = lepton_undo_get_prev (u_current);
-  }
-
-  return(NULL);
-}

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -421,13 +421,14 @@ o_undo_find_prev_filename (LeptonUndo *start)
 {
   LeptonUndo *u_current;
 
-  u_current = start->prev;
+  u_current = lepton_undo_get_prev (start);
 
   while(u_current) {
-    if (u_current->filename) {
-      return(u_current->filename);
+    if (lepton_undo_get_filename (u_current) != NULL)
+    {
+      return (lepton_undo_get_filename (u_current));
     }
-    u_current = u_current->prev;
+    u_current = lepton_undo_get_prev (u_current);
   }
 
   return(NULL);

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -108,25 +108,6 @@ schematic_undo_index_to_filename (int index)
 }
 
 
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
-void o_undo_init(void)
-{
-  schematic_undo_set_tmp_path (getenv ("TMP"));
-  if (schematic_undo_get_tmp_path () == NULL)
-  {
-    schematic_undo_set_tmp_path ((char*) "/tmp");
-  }
-#if DEBUG
-  printf ("%s\n", schematic_undo_get_tmp_path ());
-#endif
-}
-
-
-
 /*! \brief Return the value of "modify-viewport" configuration key.
  *
  * \par Function Description

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -442,13 +442,14 @@ GList *o_undo_find_prev_object_head (LeptonUndo *start)
 {
   LeptonUndo *u_current;
 
-  u_current = start->prev;
+  u_current = lepton_undo_get_prev (start);
 
   while(u_current) {
-    if (u_current->object_list) {
-      return u_current->object_list;
+    if (lepton_undo_get_object_list (u_current) != NULL)
+    {
+      return lepton_undo_get_object_list (u_current);
     }
-    u_current = u_current->prev;
+    u_current = lepton_undo_get_prev (u_current);
   }
 
   return(NULL);

--- a/tools/schematic/lepton-schematic.scm
+++ b/tools/schematic/lepton-schematic.scm
@@ -288,7 +288,7 @@ Run `~A --help' for more information.\n")
 ;;; Initialise color map (need to do this before reading rc
 ;;; files).
 (x_color_init)
-(o_undo_init)
+(undo-init-backup-path)
 
 ;;; Parse custom GTK resource files.  Used only for GTK2.
 (parse-gtkrc)

--- a/tools/schematic/lepton-schematic.scm
+++ b/tools/schematic/lepton-schematic.scm
@@ -35,6 +35,7 @@
              (schematic ffi)
              (schematic ffi gtk)
              (schematic gui keymap)
+             (schematic undo)
              (schematic window foreign)
              (schematic window))
 


### PR DESCRIPTION
- Several C functions have been rewritten in Scheme:
  - `o_undo_modify_viewport()`
  - `o_undo_init()`
  - `o_undo_find_prev_filename()`
  - `o_undo_find_prev_object_head()`
- The documentation now includes more info on differences between
  the options `modify-viewport` and `undo-panzoom`.
