### PR TITLE
Enable orthogonal net connection to bus in lepton-schematic GUI

### DIFF
--- a/libleptongui/src/i_vars.c
+++ b/libleptongui/src/i_vars.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2016 gEDA Contributors
- * Copyright (C) 2017-2023 Lepton EDA Contributors
+ * Copyright (C) 2017-2024 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -315,7 +315,7 @@ i_vars_set (GschemToplevel* w_current)
 
   cfg_read_int_with_check ("schematic", "bus-ripper-size",
                            default_bus_ripper_size, &w_current->bus_ripper_size,
-                           &cfg_check_int_greater_0);
+                           &cfg_check_int_greater_eq_0);
 
 
   /* bus-ripper-type:

--- a/libleptongui/src/o_net.c
+++ b/libleptongui/src/o_net.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2016 gEDA Contributors
- * Copyright (C) 2017-2022 Lepton EDA Contributors
+ * Copyright (C) 2017-2024 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1057,7 +1057,12 @@ int o_net_add_busrippers(GschemToplevel *w_current, LeptonObject *net_obj,
     }
 
     for (i = 0; i < ripper_count; i++) {
-      if (w_current->bus_ripper_type == NET_BUS_RIPPER) {
+      if ((w_current->bus_ripper_type == NET_BUS_RIPPER) &&
+          /* Don't add a new net if the coords are the same.
+           * Otherwise it will be zero sized. */
+          ! ((rippers[i].x[0] == rippers[i].x[1]) &&
+             (rippers[i].y[0] == rippers[i].y[1])))
+      {
         new_obj = lepton_net_object_new (NET_COLOR,
                                          rippers[i].x[0],
                                          rippers[i].y[0],


### PR DESCRIPTION
By default, during connection a net connecting to a bus changes
its direction by 45 degrees and connects diagonally.  It would be
nice to enable orthogonal connections.  The solution is to enable
setting the size of diagonal net part in the configuration to
zero.  In this branch setting of `bus-ripper-size` to zero is
enabled, which along with the setting `bus-ripper-type=net` allows
for creating orthogonal net-bus connections.
