### PR TITLE
sch2pcb: Rewrite the function pkg-line->element() in Scheme

### DIFF
--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -175,7 +175,8 @@ pcb_element_line_parse (gchar *line);
 
 PcbElement*
 pcb_element_pkg_to_element (PcbElement *el,
-                            gchar *pkg_line);
+                            gchar *pkg_line,
+                            int n_extra_args);
 
 gchar*
 pcb_element_line_token (gchar *string,

--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -216,12 +216,6 @@ GList*
 sch2pcb_get_schematics ();
 
 int
-sch2pcb_get_n_none ();
-
-void
-sch2pcb_set_n_none (int val);
-
-int
 sch2pcb_get_n_unknown ();
 
 void

--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -173,11 +173,6 @@ pcb_element_free (PcbElement *el);
 PcbElement*
 pcb_element_line_parse (gchar *line);
 
-PcbElement*
-pcb_element_pkg_to_element (PcbElement *el,
-                            gchar *pkg_line,
-                            int n);
-
 gchar*
 pcb_element_line_token (gchar *string,
                         gchar **next,

--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -184,12 +184,6 @@ pcb_element_line_token (gchar *string,
 
 /* lepton-sch2pcb's toplevel functions */
 
-char*
-sch2pcb_get_empty_footprint_name ();
-
-void
-sch2pcb_set_empty_footprint_name (char *val);
-
 gchar*
 sch2pcb_expand_dir (gchar *dir);
 

--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -176,7 +176,7 @@ pcb_element_line_parse (gchar *line);
 PcbElement*
 pcb_element_pkg_to_element (PcbElement *el,
                             gchar *pkg_line,
-                            gboolean value_has_comma);
+                            int n);
 
 gchar*
 pcb_element_line_token (gchar *string,

--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -174,7 +174,8 @@ PcbElement*
 pcb_element_line_parse (gchar *line);
 
 PcbElement*
-pcb_element_pkg_to_element (gchar *pkg_line);
+pcb_element_pkg_to_element (PcbElement *el,
+                            gchar *pkg_line);
 
 gchar*
 pcb_element_line_token (gchar *string,

--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -216,12 +216,6 @@ GList*
 sch2pcb_get_schematics ();
 
 int
-sch2pcb_get_n_empty ();
-
-void
-sch2pcb_set_n_empty (int val);
-
-int
 sch2pcb_get_n_none ();
 
 void

--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -176,7 +176,8 @@ pcb_element_line_parse (gchar *line);
 PcbElement*
 pcb_element_pkg_to_element (PcbElement *el,
                             gchar *pkg_line,
-                            int n_extra_args);
+                            int n_extra_args,
+                            int n_dashes);
 
 gchar*
 pcb_element_line_token (gchar *string,

--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -215,12 +215,6 @@ sch2pcb_get_pcb_element_list ();
 GList*
 sch2pcb_get_schematics ();
 
-int
-sch2pcb_get_n_unknown ();
-
-void
-sch2pcb_set_n_unknown (int val);
-
 FILE*
 sch2pcb_open_file_to_read (char *filename);
 

--- a/liblepton/include/liblepton/sch2pcb.h
+++ b/liblepton/include/liblepton/sch2pcb.h
@@ -176,8 +176,7 @@ pcb_element_line_parse (gchar *line);
 PcbElement*
 pcb_element_pkg_to_element (PcbElement *el,
                             gchar *pkg_line,
-                            int n_extra_args,
-                            int n_dashes);
+                            gboolean value_has_comma);
 
 gchar*
 pcb_element_line_token (gchar *string,

--- a/liblepton/scheme/Makefile.am
+++ b/liblepton/scheme/Makefile.am
@@ -184,7 +184,8 @@ TESTS = \
 	unit-tests/lepton-version.scm \
 	unit-tests/netlist-attrib.scm \
 	unit-tests/netlist-load-path.scm \
-	unit-tests/netlist-partlist.scm
+	unit-tests/netlist-partlist.scm \
+	unit-tests/sch2pcb-element.scm
 
 TEST_EXTENSIONS = .scm
 # $(srcdir) and $(builddir) are added here and not in

--- a/liblepton/scheme/Makefile.am
+++ b/liblepton/scheme/Makefile.am
@@ -77,6 +77,7 @@ nobase_dist_scmdata_DATA = \
 	netlist/subschematic.scm \
 	netlist/subschematic-connection.scm \
 	netlist/verbose.scm \
+	sch2pcb/element.scm \
 	sch2pcb/format.scm \
 	symbol/blame.scm \
 	symbol/check.scm \

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -64,8 +64,6 @@
             sch2pcb_find_element
             sch2pcb_increment_verbose_mode
             sch2pcb_insert_element
-            sch2pcb_get_n_empty
-            sch2pcb_set_n_empty
             sch2pcb_get_n_none
             sch2pcb_set_n_none
             sch2pcb_get_n_unknown
@@ -125,8 +123,6 @@
 (define-lff sch2pcb_find_element '* '(* *))
 (define-lff sch2pcb_increment_verbose_mode void '())
 (define-lff sch2pcb_insert_element int '(* * * * *))
-(define-lff sch2pcb_get_n_empty int '())
-(define-lff sch2pcb_set_n_empty void (list int))
 (define-lff sch2pcb_get_n_none int '())
 (define-lff sch2pcb_set_n_none void (list int))
 (define-lff sch2pcb_get_n_unknown int '())

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -113,7 +113,7 @@
 (define-lff pcb_element_line_parse '* '(*))
 (define-lff pcb_element_line_token '* '(* * *))
 (define-lff pcb_element_new '* '())
-(define-lff pcb_element_pkg_to_element '* (list '* '* int int))
+(define-lff pcb_element_pkg_to_element '* (list '* '* int))
 
 (define-lff sch2pcb_buffer_to_file void '(* *))
 (define-lff sch2pcb_find_element '* '(* *))

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -113,7 +113,7 @@
 (define-lff pcb_element_line_parse '* '(*))
 (define-lff pcb_element_line_token '* '(* * *))
 (define-lff pcb_element_new '* '())
-(define-lff pcb_element_pkg_to_element '* '(* *))
+(define-lff pcb_element_pkg_to_element '* (list '* '* int))
 
 (define-lff sch2pcb_buffer_to_file void '(* *))
 (define-lff sch2pcb_find_element '* '(* *))

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -113,7 +113,7 @@
 (define-lff pcb_element_line_parse '* '(*))
 (define-lff pcb_element_line_token '* '(* * *))
 (define-lff pcb_element_new '* '())
-(define-lff pcb_element_pkg_to_element '* (list '* '* int))
+(define-lff pcb_element_pkg_to_element '* (list '* '* int int))
 
 (define-lff sch2pcb_buffer_to_file void '(* *))
 (define-lff sch2pcb_find_element '* '(* *))

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -58,7 +58,6 @@
             pcb_element_line_parse
             pcb_element_line_token
             pcb_element_new
-            pcb_element_pkg_to_element
 
             sch2pcb_buffer_to_file
             sch2pcb_find_element
@@ -113,7 +112,6 @@
 (define-lff pcb_element_line_parse '* '(*))
 (define-lff pcb_element_line_token '* '(* * *))
 (define-lff pcb_element_new '* '())
-(define-lff pcb_element_pkg_to_element '* (list '* '* int))
 
 (define-lff sch2pcb_buffer_to_file void '(* *))
 (define-lff sch2pcb_find_element '* '(* *))

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -61,8 +61,6 @@
             pcb_element_pkg_to_element
 
             sch2pcb_buffer_to_file
-            sch2pcb_get_empty_footprint_name
-            sch2pcb_set_empty_footprint_name
             sch2pcb_find_element
             sch2pcb_increment_verbose_mode
             sch2pcb_insert_element
@@ -124,8 +122,6 @@
 (define-lff pcb_element_pkg_to_element '* '(* *))
 
 (define-lff sch2pcb_buffer_to_file void '(* *))
-(define-lff sch2pcb_get_empty_footprint_name '* '())
-(define-lff sch2pcb_set_empty_footprint_name void '(*))
 (define-lff sch2pcb_find_element '* '(* *))
 (define-lff sch2pcb_increment_verbose_mode void '())
 (define-lff sch2pcb_insert_element int '(* * * * *))

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -64,8 +64,6 @@
             sch2pcb_find_element
             sch2pcb_increment_verbose_mode
             sch2pcb_insert_element
-            sch2pcb_get_n_unknown
-            sch2pcb_set_n_unknown
             sch2pcb_parse_schematics
             sch2pcb_get_pcb_element_list
             sch2pcb_pcb_element_list_append
@@ -121,8 +119,6 @@
 (define-lff sch2pcb_find_element '* '(* *))
 (define-lff sch2pcb_increment_verbose_mode void '())
 (define-lff sch2pcb_insert_element int '(* * * * *))
-(define-lff sch2pcb_get_n_unknown int '())
-(define-lff sch2pcb_set_n_unknown void (list int))
 (define-lff sch2pcb_parse_schematics '* '(*))
 (define-lff sch2pcb_get_pcb_element_list '* '())
 (define-lff sch2pcb_pcb_element_list_append void '(*))

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -121,7 +121,7 @@
 (define-lff pcb_element_line_parse '* '(*))
 (define-lff pcb_element_line_token '* '(* * *))
 (define-lff pcb_element_new '* '())
-(define-lff pcb_element_pkg_to_element '* '(*))
+(define-lff pcb_element_pkg_to_element '* '(* *))
 
 (define-lff sch2pcb_buffer_to_file void '(* *))
 (define-lff sch2pcb_get_empty_footprint_name '* '())

--- a/liblepton/scheme/lepton/ffi/sch2pcb.scm
+++ b/liblepton/scheme/lepton/ffi/sch2pcb.scm
@@ -64,8 +64,6 @@
             sch2pcb_find_element
             sch2pcb_increment_verbose_mode
             sch2pcb_insert_element
-            sch2pcb_get_n_none
-            sch2pcb_set_n_none
             sch2pcb_get_n_unknown
             sch2pcb_set_n_unknown
             sch2pcb_parse_schematics
@@ -123,8 +121,6 @@
 (define-lff sch2pcb_find_element '* '(* *))
 (define-lff sch2pcb_increment_verbose_mode void '())
 (define-lff sch2pcb_insert_element int '(* * * * *))
-(define-lff sch2pcb_get_n_none int '())
-(define-lff sch2pcb_set_n_none void (list int))
 (define-lff sch2pcb_get_n_unknown int '())
 (define-lff sch2pcb_set_n_unknown void (list int))
 (define-lff sch2pcb_parse_schematics '* '(*))

--- a/liblepton/scheme/sch2pcb/element.scm
+++ b/liblepton/scheme/sch2pcb/element.scm
@@ -164,8 +164,7 @@
       (set-pcb-element-description! *element description)
       (set-pcb-element-refdes! *element refdes)
       (set-pcb-element-value! *element revamped-value)
-      (let* ((n (if value-has-comma? 4 3))
-             (fix-args (list-tail args n)))
+      (let ((fix-args (list-tail args (if value-has-comma? 4 3))))
         (unless (null? fix-args)
           (set-pcb-element-pkg-name-fix!
            *element

--- a/liblepton/scheme/sch2pcb/element.scm
+++ b/liblepton/scheme/sch2pcb/element.scm
@@ -126,9 +126,10 @@
                  (if right-paren-index
                      (string-take revamped-value right-paren-index)
                      revamped-value)))))
-          (pcb_element_pkg_to_element *element
-                                      (string->pointer line)
-                                      (if value-has-comma? TRUE FALSE))))))
+          (let ((n (if value-has-comma? 4 3)))
+            (pcb_element_pkg_to_element *element
+                                        (string->pointer line)
+                                        n))))))
 
   (if (not (string-prefix? "PKG_" line))
       %null-pointer

--- a/liblepton/scheme/sch2pcb/element.scm
+++ b/liblepton/scheme/sch2pcb/element.scm
@@ -20,6 +20,7 @@
   #:use-module (system foreign)
 
   #:use-module (lepton ffi sch2pcb)
+  #:use-module (sch2pcb format)
 
   #:export (free-element
             pcb-element-description
@@ -83,7 +84,16 @@
       (let ((left-paren-index (string-index line #\()))
         (if (not left-paren-index)
             %null-pointer
-            (pcb_element_pkg_to_element (string->pointer line))))))
+            ;; Get the contents of the string after the left paren
+            ;; and check how many arguments it contains by
+            ;; splitting it up by commas.
+            (let* ((args-line (string-drop line (1+ left-paren-index)))
+                   (args (string-split args-line #\,)))
+              (if (< (length args) 3)
+                  (begin
+                    (format-warning "Bad package line: ~A\n" line)
+                    %null-pointer)
+                  (pcb_element_pkg_to_element (string->pointer line))))))))
 
 
 (define (free-element *element)

--- a/liblepton/scheme/sch2pcb/element.scm
+++ b/liblepton/scheme/sch2pcb/element.scm
@@ -154,8 +154,7 @@
       (let ((new-value (trim-after-right-paren value)))
         (set-pcb-element-value! *element new-value)
         (let* ((extra-args-count (- (length args) 3))
-               (dashes-count (string-count
-                              (pcb-element-description *element) #\-))
+               (dashes-count (string-count description #\-))
                ;; Assume there was a comma in the value, for
                ;; instance "1K, 1%".
                (value-has-comma? (= extra-args-count (1+ dashes-count))))

--- a/liblepton/scheme/sch2pcb/element.scm
+++ b/liblepton/scheme/sch2pcb/element.scm
@@ -123,7 +123,8 @@
                       (set-pcb-element-value! *element new-value)
                       (pcb_element_pkg_to_element *element
                                                   (string->pointer line)
-                                                  (- (length args) 3))))))))))
+                                                  (- (length args) 3)
+                                                  (string-count (pcb-element-description *element) #\-))))))))))
 
 
 (define (free-element *element)

--- a/liblepton/scheme/sch2pcb/element.scm
+++ b/liblepton/scheme/sch2pcb/element.scm
@@ -1,0 +1,25 @@
+;;; Lepton EDA Schematic to PCB conversion
+;;; Scheme API
+;;; Copyright (C) 2023-2024 Lepton EDA Contributors
+;;;
+;;; This program is free software; you can redistribute it and/or modify
+;;; it under the terms of the GNU General Public License as published by
+;;; the Free Software Foundation; either version 2 of the License, or
+;;; (at your option) any later version.
+;;;
+;;; This program is distributed in the hope that it will be useful,
+;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;; GNU General Public License for more details.
+;;;
+;;; You should have received a copy of the GNU General Public License
+;;; along with this program; if not, write to the Free Software
+;;; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+(define-module (sch2pcb element)
+  #:use-module (lepton ffi sch2pcb)
+
+  #:export (pkg-line->element))
+
+(define (pkg-line->element *line)
+  (pcb_element_pkg_to_element *line))

--- a/liblepton/scheme/sch2pcb/element.scm
+++ b/liblepton/scheme/sch2pcb/element.scm
@@ -148,31 +148,31 @@
     (let ((*element (pcb_element_new))
           (description (fix-spaces (list-ref args 0)))
           (refdes (fix-spaces (list-ref args 1)))
-          (value (fix-spaces (list-ref args 2))))
+          (value (trim-after-right-paren
+                  (fix-spaces (list-ref args 2)))))
       (set-pcb-element-description! *element description)
       (set-pcb-element-refdes! *element refdes)
-      (let ((new-value (trim-after-right-paren value)))
-        (set-pcb-element-value! *element new-value)
-        (let* ((extra-args-count (- (length args) 3))
-               (dashes-count (string-count description #\-))
-               ;; Assume there was a comma in the value, for
-               ;; instance "1K, 1%".
-               (value-has-comma? (= extra-args-count (1+ dashes-count))))
-          (when value-has-comma?
-            (let ((revamped-value (string-append (pcb-element-value *element)
-                                                 ","
-                                                 (fix-spaces (list-ref args 3)))))
-              (set-pcb-element-value!
-               *element
-               (trim-after-right-paren revamped-value))))
-          (let* ((n (if value-has-comma? 4 3))
-                 (fix-args (list-tail args n)))
-            (unless (null? fix-args)
-              (set-pcb-element-pkg-name-fix!
-               *element
-               ;; This seems to be superfluous here.
-               (trim-after-right-paren (string-join fix-args))))
-            *element)))))
+      (set-pcb-element-value! *element value)
+      (let* ((extra-args-count (- (length args) 3))
+             (dashes-count (string-count description #\-))
+             ;; Assume there was a comma in the value, for
+             ;; instance "1K, 1%".
+             (value-has-comma? (= extra-args-count (1+ dashes-count))))
+        (when value-has-comma?
+          (let ((revamped-value (string-append (pcb-element-value *element)
+                                               ","
+                                               (fix-spaces (list-ref args 3)))))
+            (set-pcb-element-value!
+             *element
+             (trim-after-right-paren revamped-value))))
+        (let* ((n (if value-has-comma? 4 3))
+               (fix-args (list-tail args n)))
+          (unless (null? fix-args)
+            (set-pcb-element-pkg-name-fix!
+             *element
+             ;; This seems to be superfluous here.
+             (trim-after-right-paren (string-join fix-args))))
+          *element))))
 
   (if (string-prefix? "PKG_" line)
       (let ((left-paren-index (string-index line #\()))

--- a/liblepton/scheme/sch2pcb/element.scm
+++ b/liblepton/scheme/sch2pcb/element.scm
@@ -115,11 +115,17 @@
                ;; instance "1K, 1%".
                (value-has-comma? (= extra-args-count (1+ dashes-count))))
           (when value-has-comma?
-            (set-pcb-element-value!
-             *element
-             (string-append (pcb-element-value *element)
-                            ","
-                            (fix-spaces (list-ref args 3)))))
+            (let ((revamped-value (string-append (pcb-element-value *element)
+                                                 ","
+                                                 (fix-spaces (list-ref args 3)))))
+              (set-pcb-element-value!
+               *element
+               (let ((right-paren-index (string-index revamped-value #\))))
+                 ;; Drop anything at right starting with a closing
+                 ;; paren.
+                 (if right-paren-index
+                     (string-take revamped-value right-paren-index)
+                     revamped-value)))))
           (pcb_element_pkg_to_element *element
                                       (string->pointer line)
                                       (if value-has-comma? TRUE FALSE))))))

--- a/liblepton/scheme/sch2pcb/element.scm
+++ b/liblepton/scheme/sch2pcb/element.scm
@@ -126,7 +126,10 @@
                  (if right-paren-index
                      (string-take revamped-value right-paren-index)
                      revamped-value)))))
-          (let ((n (if value-has-comma? 4 3)))
+          (let* ((n (if value-has-comma? 4 3))
+                 (fix-args (list-tail args n)))
+            (unless (null? fix-args)
+              (set-pcb-element-pkg-name-fix! *element (string-join fix-args)))
             (pcb_element_pkg_to_element *element
                                         (string->pointer line)
                                         n))))))

--- a/liblepton/scheme/sch2pcb/element.scm
+++ b/liblepton/scheme/sch2pcb/element.scm
@@ -77,10 +77,10 @@
                            name-fix))
 
 
-(define (pkg-line->element *line)
-  (if (not (string-prefix? "PKG_" (pointer->string *line)))
+(define (pkg-line->element line)
+  (if (not (string-prefix? "PKG_" line))
       %null-pointer
-      (pcb_element_pkg_to_element *line)))
+      (pcb_element_pkg_to_element (string->pointer line))))
 
 
 (define (free-element *element)

--- a/liblepton/scheme/sch2pcb/element.scm
+++ b/liblepton/scheme/sch2pcb/element.scm
@@ -21,7 +21,8 @@
 
   #:use-module (lepton ffi sch2pcb)
 
-  #:export (pcb-element-description
+  #:export (free-element
+            pcb-element-description
             set-pcb-element-description!
             pcb-element-pkg-name-fix
             set-pcb-element-pkg-name-fix!
@@ -78,3 +79,7 @@
 
 (define (pkg-line->element *line)
   (pcb_element_pkg_to_element *line))
+
+
+(define (free-element *element)
+  (pcb_element_free *element))

--- a/liblepton/scheme/sch2pcb/element.scm
+++ b/liblepton/scheme/sch2pcb/element.scm
@@ -122,7 +122,8 @@
                                           value)))
                       (set-pcb-element-value! *element new-value)
                       (pcb_element_pkg_to_element *element
-                                                  (string->pointer line))))))))))
+                                                  (string->pointer line)
+                                                  (- (length args) 3))))))))))
 
 
 (define (free-element *element)

--- a/liblepton/scheme/sch2pcb/element.scm
+++ b/liblepton/scheme/sch2pcb/element.scm
@@ -158,7 +158,7 @@
       (set-pcb-element-refdes! *element refdes)
       (set-pcb-element-value! *element value)
       (when value-has-comma?
-        (let ((revamped-value (string-append (pcb-element-value *element)
+        (let ((revamped-value (string-append value
                                              ","
                                              (fix-spaces (list-ref args 3)))))
           (set-pcb-element-value!

--- a/liblepton/scheme/sch2pcb/element.scm
+++ b/liblepton/scheme/sch2pcb/element.scm
@@ -93,7 +93,9 @@
                   (begin
                     (format-warning "Bad package line: ~A\n" line)
                     %null-pointer)
-                  (pcb_element_pkg_to_element (string->pointer line))))))))
+                  (let ((*element (pcb_element_new)))
+                    (pcb_element_pkg_to_element *element
+                                                (string->pointer line)))))))))
 
 
 (define (free-element *element)

--- a/liblepton/scheme/sch2pcb/element.scm
+++ b/liblepton/scheme/sch2pcb/element.scm
@@ -26,6 +26,8 @@
   #:export (free-element
             pcb-element-description
             set-pcb-element-description!
+            pcb-element-omit-pkg
+            set-pcb-element-omit-pkg!
             pcb-element-pkg-name-fix
             set-pcb-element-pkg-name-fix!
             pcb-element-refdes
@@ -69,6 +71,13 @@
   (pcb-element-set-string! *element
                            pcb_element_set_value
                            value))
+
+(define (pcb-element-omit-pkg *element)
+  (true? (pcb_element_get_omit_PKG *element)))
+
+(define (set-pcb-element-omit-pkg! *element omit-pkg?)
+  (pcb_element_set_omit_PKG *element
+                            (if omit-pkg? TRUE FALSE)))
 
 (define (pcb-element-pkg-name-fix *element)
   (pcb-element-get-string *element pcb_element_get_pkg_name_fix))
@@ -123,7 +132,7 @@
                              refdes
                              description)
                             (sch2pcb_set_n_empty (1+ (sch2pcb_get_n_empty)))
-                            (pcb_element_set_omit_PKG *element TRUE))
+                            (set-pcb-element-omit-pkg! *element #t))
                           (if (string= description "none")
                               (begin
                                 (format-warning
@@ -131,13 +140,13 @@
                                  refdes
                                  description)
                                 (sch2pcb_set_n_none (1+ (sch2pcb_get_n_none)))
-                                (pcb_element_set_omit_PKG *element TRUE))
+                                (set-pcb-element-omit-pkg! *element #t))
                               (when (string= description "unknown")
                                 (format-warning
                                  "WARNING: ~A has no footprint attribute so won't be in the layout.\n"
                                  refdes)
                                 (sch2pcb_set_n_unknown (1+ (sch2pcb_get_n_unknown)))
-                                (pcb_element_set_omit_PKG *element TRUE))))
+                                (set-pcb-element-omit-pkg! *element #t))))
                       ;; Return new element.
                       *element))))))))
 

--- a/liblepton/scheme/sch2pcb/element.scm
+++ b/liblepton/scheme/sch2pcb/element.scm
@@ -96,6 +96,34 @@
 
 
 (define (pkg-line->element line)
+  (define (report-missing-footprint *element)
+    (let ((description (pcb-element-description *element))
+          (refdes (pcb-element-refdes *element)))
+      (if (and (not (null-pointer? (sch2pcb_get_empty_footprint_name)))
+               (string= description
+                        (pointer->string (sch2pcb_get_empty_footprint_name))))
+          (begin
+            (verbose-format
+             "~A: has the empty footprint attribute ~S so won't be in the layout.\n"
+             refdes
+             description)
+            (sch2pcb_set_n_empty (1+ (sch2pcb_get_n_empty)))
+            (set-pcb-element-omit-pkg! *element #t))
+          (if (string= description "none")
+              (begin
+                (format-warning
+                 "WARNING: ~A has a footprint attribute ~S so won't be in the layout.\n"
+                 refdes
+                 description)
+                (sch2pcb_set_n_none (1+ (sch2pcb_get_n_none)))
+                (set-pcb-element-omit-pkg! *element #t))
+              (when (string= description "unknown")
+                (format-warning
+                 "WARNING: ~A has no footprint attribute so won't be in the layout.\n"
+                 refdes)
+                (sch2pcb_set_n_unknown (1+ (sch2pcb_get_n_unknown)))
+                (set-pcb-element-omit-pkg! *element #t))))))
+
   (if (not (string-prefix? "PKG_" line))
       %null-pointer
       (let ((left-paren-index (string-index line #\()))
@@ -123,30 +151,7 @@
                       (set-pcb-element-value! *element new-value)
                       (pcb_element_pkg_to_element *element
                                                   (string->pointer line))
-                      (if (and (not (null-pointer? (sch2pcb_get_empty_footprint_name)))
-                               (string= description
-                                        (pointer->string (sch2pcb_get_empty_footprint_name))))
-                          (begin
-                            (verbose-format
-                             "~A: has the empty footprint attribute ~S so won't be in the layout.\n"
-                             refdes
-                             description)
-                            (sch2pcb_set_n_empty (1+ (sch2pcb_get_n_empty)))
-                            (set-pcb-element-omit-pkg! *element #t))
-                          (if (string= description "none")
-                              (begin
-                                (format-warning
-                                 "WARNING: ~A has a footprint attribute ~S so won't be in the layout.\n"
-                                 refdes
-                                 description)
-                                (sch2pcb_set_n_none (1+ (sch2pcb_get_n_none)))
-                                (set-pcb-element-omit-pkg! *element #t))
-                              (when (string= description "unknown")
-                                (format-warning
-                                 "WARNING: ~A has no footprint attribute so won't be in the layout.\n"
-                                 refdes)
-                                (sch2pcb_set_n_unknown (1+ (sch2pcb_get_n_unknown)))
-                                (set-pcb-element-omit-pkg! *element #t))))
+                      (report-missing-footprint *element)
                       ;; Return new element.
                       *element))))))))
 

--- a/liblepton/scheme/sch2pcb/element.scm
+++ b/liblepton/scheme/sch2pcb/element.scm
@@ -78,6 +78,13 @@
                            name-fix))
 
 
+(define (fix-spaces str)
+  (define (fix c)
+    (if (or (eq? c #\space) (eq? c #\tab)) #\_ c))
+
+  (string-map fix str))
+
+
 (define (pkg-line->element line)
   (if (not (string-prefix? "PKG_" line))
       %null-pointer
@@ -93,7 +100,13 @@
                   (begin
                     (format-warning "Bad package line: ~A\n" line)
                     %null-pointer)
-                  (let ((*element (pcb_element_new)))
+                  (let ((*element (pcb_element_new))
+                        (description (fix-spaces (list-ref args 0)))
+                        (refdes (fix-spaces (list-ref args 1)))
+                        (value (fix-spaces (list-ref args 2))))
+                    (set-pcb-element-description! *element description)
+                    (set-pcb-element-refdes! *element refdes)
+                    (set-pcb-element-value! *element value)
                     (pcb_element_pkg_to_element *element
                                                 (string->pointer line)))))))))
 

--- a/liblepton/scheme/sch2pcb/element.scm
+++ b/liblepton/scheme/sch2pcb/element.scm
@@ -121,10 +121,14 @@
                                           (string-take value right-paren-index)
                                           value)))
                       (set-pcb-element-value! *element new-value)
-                      (pcb_element_pkg_to_element *element
-                                                  (string->pointer line)
-                                                  (- (length args) 3)
-                                                  (string-count (pcb-element-description *element) #\-))))))))))
+                      (let* ((extra-args-count (- (length args) 3))
+                             (dashes-count (string-count (pcb-element-description *element) #\-))
+                             ;; Assume there was a comma in the
+                             ;; value, eg "1K, 1%".
+                             (value-has-comma? (= extra-args-count (1+ dashes-count))))
+                        (pcb_element_pkg_to_element *element
+                                                    (string->pointer line)
+                                                    (if value-has-comma? TRUE FALSE)))))))))))
 
 
 (define (free-element *element)

--- a/liblepton/scheme/sch2pcb/element.scm
+++ b/liblepton/scheme/sch2pcb/element.scm
@@ -78,7 +78,9 @@
 
 
 (define (pkg-line->element *line)
-  (pcb_element_pkg_to_element *line))
+  (if (not (string-prefix? "PKG_" (pointer->string *line)))
+      %null-pointer
+      (pcb_element_pkg_to_element *line)))
 
 
 (define (free-element *element)

--- a/liblepton/scheme/sch2pcb/element.scm
+++ b/liblepton/scheme/sch2pcb/element.scm
@@ -158,12 +158,12 @@
       (set-pcb-element-refdes! *element refdes)
       (set-pcb-element-value! *element value)
       (when value-has-comma?
-        (let ((revamped-value (string-append value
-                                             ","
-                                             (fix-spaces (list-ref args 3)))))
-          (set-pcb-element-value!
-           *element
-           (trim-after-right-paren revamped-value))))
+        (let ((revamped-value
+               (trim-after-right-paren
+                (string-append value
+                               ","
+                               (fix-spaces (list-ref args 3))))))
+          (set-pcb-element-value! *element revamped-value)))
       (let* ((n (if value-has-comma? 4 3))
              (fix-args (list-tail args n)))
         (unless (null? fix-args)

--- a/liblepton/scheme/sch2pcb/element.scm
+++ b/liblepton/scheme/sch2pcb/element.scm
@@ -114,6 +114,12 @@
                ;; Assume there was a comma in the value, for
                ;; instance "1K, 1%".
                (value-has-comma? (= extra-args-count (1+ dashes-count))))
+          (when value-has-comma?
+            (set-pcb-element-value!
+             *element
+             (string-append (pcb-element-value *element)
+                            ","
+                            (fix-spaces (list-ref args 3)))))
           (pcb_element_pkg_to_element *element
                                       (string->pointer line)
                                       (if value-has-comma? TRUE FALSE))))))

--- a/liblepton/scheme/sch2pcb/element.scm
+++ b/liblepton/scheme/sch2pcb/element.scm
@@ -96,34 +96,6 @@
 
 
 (define (pkg-line->element line)
-  (define (report-missing-footprint *element)
-    (let ((description (pcb-element-description *element))
-          (refdes (pcb-element-refdes *element)))
-      (if (and (not (null-pointer? (sch2pcb_get_empty_footprint_name)))
-               (string= description
-                        (pointer->string (sch2pcb_get_empty_footprint_name))))
-          (begin
-            (verbose-format
-             "~A: has the empty footprint attribute ~S so won't be in the layout.\n"
-             refdes
-             description)
-            (sch2pcb_set_n_empty (1+ (sch2pcb_get_n_empty)))
-            (set-pcb-element-omit-pkg! *element #t))
-          (if (string= description "none")
-              (begin
-                (format-warning
-                 "WARNING: ~A has a footprint attribute ~S so won't be in the layout.\n"
-                 refdes
-                 description)
-                (sch2pcb_set_n_none (1+ (sch2pcb_get_n_none)))
-                (set-pcb-element-omit-pkg! *element #t))
-              (when (string= description "unknown")
-                (format-warning
-                 "WARNING: ~A has no footprint attribute so won't be in the layout.\n"
-                 refdes)
-                (sch2pcb_set_n_unknown (1+ (sch2pcb_get_n_unknown)))
-                (set-pcb-element-omit-pkg! *element #t))))))
-
   (if (not (string-prefix? "PKG_" line))
       %null-pointer
       (let ((left-paren-index (string-index line #\()))
@@ -150,10 +122,7 @@
                                           value)))
                       (set-pcb-element-value! *element new-value)
                       (pcb_element_pkg_to_element *element
-                                                  (string->pointer line))
-                      (report-missing-footprint *element)
-                      ;; Return new element.
-                      *element))))))))
+                                                  (string->pointer line))))))))))
 
 
 (define (free-element *element)

--- a/liblepton/scheme/sch2pcb/element.scm
+++ b/liblepton/scheme/sch2pcb/element.scm
@@ -153,17 +153,17 @@
            (dashes-count (string-count description #\-))
            ;; Assume there was a comma in the value, for
            ;; instance "1K, 1%".
-           (value-has-comma? (= extra-args-count (1+ dashes-count))))
+           (value-has-comma? (= extra-args-count (1+ dashes-count)))
+           (revamped-value
+            (if value-has-comma?
+                (trim-after-right-paren
+                 (string-append value
+                                ","
+                                (fix-spaces (list-ref args 3))))
+                value)))
       (set-pcb-element-description! *element description)
       (set-pcb-element-refdes! *element refdes)
-      (set-pcb-element-value! *element value)
-      (when value-has-comma?
-        (let ((revamped-value
-               (trim-after-right-paren
-                (string-append value
-                               ","
-                               (fix-spaces (list-ref args 3))))))
-          (set-pcb-element-value! *element revamped-value)))
+      (set-pcb-element-value! *element revamped-value)
       (let* ((n (if value-has-comma? 4 3))
              (fix-args (list-tail args n)))
         (unless (null? fix-args)

--- a/liblepton/scheme/sch2pcb/element.scm
+++ b/liblepton/scheme/sch2pcb/element.scm
@@ -22,8 +22,11 @@
   #:use-module (lepton ffi sch2pcb)
 
   #:export (pcb-element-description
+            set-pcb-element-description!
             pcb-element-refdes
+            set-pcb-element-refdes!
             pcb-element-value
+            set-pcb-element-value!
             pkg-line->element))
 
 
@@ -34,14 +37,33 @@
       "<null>"
       (pointer->string *s)))
 
+(define (pcb-element-set-string! *element *c-setter s)
+  (define *s (if s (string->pointer s) %null-pointer))
+  (*c-setter *element *s))
+
 (define (pcb-element-description *element)
   (pcb-element-get-string *element pcb_element_get_description))
+
+(define (set-pcb-element-description! *element description)
+  (pcb-element-set-string! *element
+                           pcb_element_set_description
+                           description))
 
 (define (pcb-element-refdes *element)
   (pcb-element-get-string *element pcb_element_get_refdes))
 
+(define (set-pcb-element-refdes! *element refdes)
+  (pcb-element-set-string! *element
+                           pcb_element_set_refdes
+                           refdes))
+
 (define (pcb-element-value *element)
   (pcb-element-get-string *element pcb_element_get_value))
+
+(define (set-pcb-element-value! *element value)
+  (pcb-element-set-string! *element
+                           pcb_element_set_value
+                           value))
 
 
 (define (pkg-line->element *line)

--- a/liblepton/scheme/sch2pcb/element.scm
+++ b/liblepton/scheme/sch2pcb/element.scm
@@ -160,17 +160,19 @@
                  (string-append value
                                 ","
                                 (fix-spaces (list-ref args 3))))
-                value)))
+                value))
+           (pkg-name-fix
+            (let ((fix-args (list-tail args (if value-has-comma? 4 3))))
+              (and (not (null? fix-args))
+                   ;; Trimming the string again seems to be
+                   ;; superfluous here.
+                   (trim-after-right-paren (string-join fix-args))))))
       (set-pcb-element-description! *element description)
       (set-pcb-element-refdes! *element refdes)
       (set-pcb-element-value! *element revamped-value)
-      (let ((fix-args (list-tail args (if value-has-comma? 4 3))))
-        (unless (null? fix-args)
-          (set-pcb-element-pkg-name-fix!
-           *element
-           ;; This seems to be superfluous here.
-           (trim-after-right-paren (string-join fix-args))))
-        *element)))
+      (and pkg-name-fix
+           (set-pcb-element-pkg-name-fix! *element pkg-name-fix))
+      *element))
 
   (if (string-prefix? "PKG_" line)
       (let ((left-paren-index (string-index line #\()))

--- a/liblepton/scheme/sch2pcb/element.scm
+++ b/liblepton/scheme/sch2pcb/element.scm
@@ -115,26 +115,24 @@
                       (pcb_element_pkg_to_element *element
                                                   (string->pointer line))
                       (if (and (not (null-pointer? (sch2pcb_get_empty_footprint_name)))
-                               (string= (pointer->string (pcb_element_get_description *element))
+                               (string= description
                                         (pointer->string (sch2pcb_get_empty_footprint_name))))
                           (begin
                             (verbose-format
                              "~A: has the empty footprint attribute ~S so won't be in the layout.\n"
                              (pointer->string (pcb_element_get_refdes *element))
-                             (pointer->string (pcb_element_get_description *element)))
+                             description)
                             (sch2pcb_set_n_empty (1+ (sch2pcb_get_n_empty)))
                             (pcb_element_set_omit_PKG *element TRUE))
-                          (if (string= (pointer->string (pcb_element_get_description *element))
-                                       "none")
+                          (if (string= description "none")
                               (begin
                                 (format-warning
                                  "WARNING: ~A has a footprint attribute ~S so won't be in the layout.\n"
                                  (pointer->string (pcb_element_get_refdes *element))
-                                 (pointer->string (pcb_element_get_description *element)))
+                                 description)
                                 (sch2pcb_set_n_none (1+ (sch2pcb_get_n_none)))
                                 (pcb_element_set_omit_PKG *element TRUE))
-                              (when (string= (pointer->string (pcb_element_get_description *element))
-                                             "unknown")
+                              (when (string= description "unknown")
                                 (format-warning
                                  "WARNING: ~A has no footprint attribute so won't be in the layout.\n"
                                  (pointer->string (pcb_element_get_refdes *element)))

--- a/liblepton/scheme/sch2pcb/element.scm
+++ b/liblepton/scheme/sch2pcb/element.scm
@@ -145,34 +145,33 @@
   ;; description with '-' when there are extra args.
   ;;
   (define (args->element args)
-    (let ((*element (pcb_element_new))
-          (description (fix-spaces (list-ref args 0)))
-          (refdes (fix-spaces (list-ref args 1)))
-          (value (trim-after-right-paren
-                  (fix-spaces (list-ref args 2)))))
+    (let* ((*element (pcb_element_new))
+           (description (fix-spaces (list-ref args 0)))
+           (refdes (fix-spaces (list-ref args 1)))
+           (value (trim-after-right-paren (fix-spaces (list-ref args 2))))
+           (extra-args-count (- (length args) 3))
+           (dashes-count (string-count description #\-))
+           ;; Assume there was a comma in the value, for
+           ;; instance "1K, 1%".
+           (value-has-comma? (= extra-args-count (1+ dashes-count))))
       (set-pcb-element-description! *element description)
       (set-pcb-element-refdes! *element refdes)
       (set-pcb-element-value! *element value)
-      (let* ((extra-args-count (- (length args) 3))
-             (dashes-count (string-count description #\-))
-             ;; Assume there was a comma in the value, for
-             ;; instance "1K, 1%".
-             (value-has-comma? (= extra-args-count (1+ dashes-count))))
-        (when value-has-comma?
-          (let ((revamped-value (string-append (pcb-element-value *element)
-                                               ","
-                                               (fix-spaces (list-ref args 3)))))
-            (set-pcb-element-value!
-             *element
-             (trim-after-right-paren revamped-value))))
-        (let* ((n (if value-has-comma? 4 3))
-               (fix-args (list-tail args n)))
-          (unless (null? fix-args)
-            (set-pcb-element-pkg-name-fix!
-             *element
-             ;; This seems to be superfluous here.
-             (trim-after-right-paren (string-join fix-args))))
-          *element))))
+      (when value-has-comma?
+        (let ((revamped-value (string-append (pcb-element-value *element)
+                                             ","
+                                             (fix-spaces (list-ref args 3)))))
+          (set-pcb-element-value!
+           *element
+           (trim-after-right-paren revamped-value))))
+      (let* ((n (if value-has-comma? 4 3))
+             (fix-args (list-tail args n)))
+        (unless (null? fix-args)
+          (set-pcb-element-pkg-name-fix!
+           *element
+           ;; This seems to be superfluous here.
+           (trim-after-right-paren (string-join fix-args))))
+        *element)))
 
   (if (string-prefix? "PKG_" line)
       (let ((left-paren-index (string-index line #\()))

--- a/liblepton/scheme/sch2pcb/element.scm
+++ b/liblepton/scheme/sch2pcb/element.scm
@@ -106,9 +106,13 @@
                         (value (fix-spaces (list-ref args 2))))
                     (set-pcb-element-description! *element description)
                     (set-pcb-element-refdes! *element refdes)
-                    (set-pcb-element-value! *element value)
-                    (pcb_element_pkg_to_element *element
-                                                (string->pointer line)))))))))
+                    (let* ((right-paren-index (string-index value #\)))
+                           (new-value (if right-paren-index
+                                          (string-take value right-paren-index)
+                                          value)))
+                      (set-pcb-element-value! *element new-value)
+                      (pcb_element_pkg_to_element *element
+                                                  (string->pointer line))))))))))
 
 
 (define (free-element *element)

--- a/liblepton/scheme/sch2pcb/element.scm
+++ b/liblepton/scheme/sch2pcb/element.scm
@@ -175,11 +175,9 @@
                (trim-after-right-paren (string-join fix-args))))
             *element)))))
 
-  (if (not (string-prefix? "PKG_" line))
-      %null-pointer
+  (if (string-prefix? "PKG_" line)
       (let ((left-paren-index (string-index line #\()))
-        (if (not left-paren-index)
-            %null-pointer
+        (if left-paren-index
             ;; Get the contents of the string after the left paren
             ;; and check how many arguments it contains by
             ;; splitting it up by commas.
@@ -189,7 +187,9 @@
                   (begin
                     (format-warning "Bad package line: ~A\n" line)
                     %null-pointer)
-                  (args->element args)))))))
+                  (args->element args)))
+            %null-pointer))
+      %null-pointer))
 
 
 (define (free-element *element)

--- a/liblepton/scheme/sch2pcb/element.scm
+++ b/liblepton/scheme/sch2pcb/element.scm
@@ -120,7 +120,7 @@
                           (begin
                             (verbose-format
                              "~A: has the empty footprint attribute ~S so won't be in the layout.\n"
-                             (pointer->string (pcb_element_get_refdes *element))
+                             refdes
                              description)
                             (sch2pcb_set_n_empty (1+ (sch2pcb_get_n_empty)))
                             (pcb_element_set_omit_PKG *element TRUE))
@@ -128,14 +128,14 @@
                               (begin
                                 (format-warning
                                  "WARNING: ~A has a footprint attribute ~S so won't be in the layout.\n"
-                                 (pointer->string (pcb_element_get_refdes *element))
+                                 refdes
                                  description)
                                 (sch2pcb_set_n_none (1+ (sch2pcb_get_n_none)))
                                 (pcb_element_set_omit_PKG *element TRUE))
                               (when (string= description "unknown")
                                 (format-warning
                                  "WARNING: ~A has no footprint attribute so won't be in the layout.\n"
-                                 (pointer->string (pcb_element_get_refdes *element)))
+                                 refdes)
                                 (sch2pcb_set_n_unknown (1+ (sch2pcb_get_n_unknown)))
                                 (pcb_element_set_omit_PKG *element TRUE))))
                       ;; Return new element.

--- a/liblepton/scheme/sch2pcb/element.scm
+++ b/liblepton/scheme/sch2pcb/element.scm
@@ -78,10 +78,12 @@
 
 
 (define (pkg-line->element line)
-  (if (or (not (string-prefix? "PKG_" line))
-          (not (string-index line #\()))
+  (if (not (string-prefix? "PKG_" line))
       %null-pointer
-      (pcb_element_pkg_to_element (string->pointer line))))
+      (let ((left-paren-index (string-index line #\()))
+        (if (not left-paren-index)
+            %null-pointer
+            (pcb_element_pkg_to_element (string->pointer line))))))
 
 
 (define (free-element *element)

--- a/liblepton/scheme/sch2pcb/element.scm
+++ b/liblepton/scheme/sch2pcb/element.scm
@@ -169,11 +169,10 @@
           (let* ((n (if value-has-comma? 4 3))
                  (fix-args (list-tail args n)))
             (unless (null? fix-args)
-              (let ((fix (string-join fix-args)))
-                (set-pcb-element-pkg-name-fix!
-                 *element
-                 ;; This seems to be superfluous here.
-                 (trim-after-right-paren fix))))
+              (set-pcb-element-pkg-name-fix!
+               *element
+               ;; This seems to be superfluous here.
+               (trim-after-right-paren (string-join fix-args))))
             *element)))))
 
   (if (not (string-prefix? "PKG_" line))

--- a/liblepton/scheme/sch2pcb/element.scm
+++ b/liblepton/scheme/sch2pcb/element.scm
@@ -23,6 +23,8 @@
 
   #:export (pcb-element-description
             set-pcb-element-description!
+            pcb-element-pkg-name-fix
+            set-pcb-element-pkg-name-fix!
             pcb-element-refdes
             set-pcb-element-refdes!
             pcb-element-value
@@ -64,6 +66,14 @@
   (pcb-element-set-string! *element
                            pcb_element_set_value
                            value))
+
+(define (pcb-element-pkg-name-fix *element)
+  (pcb-element-get-string *element pcb_element_get_pkg_name_fix))
+
+(define (set-pcb-element-pkg-name-fix! *element name-fix)
+  (pcb-element-set-string! *element
+                           pcb_element_set_pkg_name_fix
+                           name-fix))
 
 
 (define (pkg-line->element *line)

--- a/liblepton/scheme/sch2pcb/element.scm
+++ b/liblepton/scheme/sch2pcb/element.scm
@@ -78,7 +78,8 @@
 
 
 (define (pkg-line->element line)
-  (if (not (string-prefix? "PKG_" line))
+  (if (or (not (string-prefix? "PKG_" line))
+          (not (string-index line #\()))
       %null-pointer
       (pcb_element_pkg_to_element (string->pointer line))))
 

--- a/liblepton/scheme/sch2pcb/element.scm
+++ b/liblepton/scheme/sch2pcb/element.scm
@@ -17,9 +17,32 @@
 ;;; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 (define-module (sch2pcb element)
+  #:use-module (system foreign)
+
   #:use-module (lepton ffi sch2pcb)
 
-  #:export (pkg-line->element))
+  #:export (pcb-element-description
+            pcb-element-refdes
+            pcb-element-value
+            pkg-line->element))
+
+
+(define (pcb-element-get-string *element *c-getter)
+  (define *s (*c-getter *element))
+  (if (null-pointer? *s)
+      ;; What should the function return if *s is NULL?
+      "<null>"
+      (pointer->string *s)))
+
+(define (pcb-element-description *element)
+  (pcb-element-get-string *element pcb_element_get_description))
+
+(define (pcb-element-refdes *element)
+  (pcb-element-get-string *element pcb_element_get_refdes))
+
+(define (pcb-element-value *element)
+  (pcb-element-get-string *element pcb_element_get_value))
+
 
 (define (pkg-line->element *line)
   (pcb_element_pkg_to_element *line))

--- a/liblepton/scheme/unit-tests/sch2pcb-element.scm
+++ b/liblepton/scheme/unit-tests/sch2pcb-element.scm
@@ -15,6 +15,15 @@
   (test-equal (pcb-element-value *element) "unknown")
   (free-element *element))
 
+;;; Element's fields with whitespaces.
+(let ((*element (pkg-line->element (string->pointer "PKG_DIP14(DIP14\t, U100,unknown  )"))))
+  (test-assert (not (null-pointer? *element)))
+  (test-equal (pcb-element-description *element) "DIP14_")
+  (test-equal (pcb-element-refdes *element) "_U100")
+  (test-equal (pcb-element-value *element) "unknown__")
+  (free-element *element))
+
+
 ;;; Wrong PKG_ strings.
 
 ;;; No left paren at all.

--- a/liblepton/scheme/unit-tests/sch2pcb-element.scm
+++ b/liblepton/scheme/unit-tests/sch2pcb-element.scm
@@ -23,6 +23,14 @@
   (test-equal (pcb-element-value *element) "unknown__")
   (free-element *element))
 
+;;; Element with extra description arguments.
+(let ((*element (pkg-line->element (string->pointer "PKG_100-Pin-jack(100-Pin-jack,refdes,value,Pin,jack)"))))
+  (test-assert (not (null-pointer? *element)))
+  (test-equal (pcb-element-description *element) "100-Pin-jack")
+  (test-equal (pcb-element-refdes *element) "refdes")
+  (test-equal (pcb-element-value *element) "value")
+  (test-equal (pcb-element-pkg-name-fix *element) "Pin jack")
+  (free-element *element))
 
 ;;; Wrong PKG_ strings.
 

--- a/liblepton/scheme/unit-tests/sch2pcb-element.scm
+++ b/liblepton/scheme/unit-tests/sch2pcb-element.scm
@@ -40,6 +40,24 @@
   (test-equal (pcb-element-value *element) "1k,_1%")
   (free-element *element))
 
+;;; Element with value containing a comma, a closing paren, and
+;;; some text after it.
+(let ((*element (pkg-line->element (string->pointer "PKG_XXX(R0w8,R100,1k, 1%)text"))))
+  (test-assert (not (null-pointer? *element)))
+  (test-equal (pcb-element-description *element) "R0w8")
+  (test-equal (pcb-element-refdes *element) "R100")
+  (test-equal (pcb-element-value *element) "1k,_1%")
+  (free-element *element))
+
+;;; Element with value containing a comma and several closing
+;;; parens.
+(let ((*element (pkg-line->element (string->pointer "PKG_XXX(R0w8,R100,1k, 1%)))))"))))
+  (test-assert (not (null-pointer? *element)))
+  (test-equal (pcb-element-description *element) "R0w8")
+  (test-equal (pcb-element-refdes *element) "R100")
+  (test-equal (pcb-element-value *element) "1k,_1%")
+  (free-element *element))
+
 ;;; Element with multi-word description and value containing a
 ;;; comma.
 (let ((*element (pkg-line->element (string->pointer "PKG_YYY-multi-word(R0w8-multi-word,R100,1k, 1%,multi,word)"))))

--- a/liblepton/scheme/unit-tests/sch2pcb-element.scm
+++ b/liblepton/scheme/unit-tests/sch2pcb-element.scm
@@ -50,6 +50,15 @@
   (test-equal (pcb-element-pkg-name-fix *element) "multi word")
   (free-element *element))
 
+;;; Probably it behaves wrong when two or three closing parens are
+;;; present?
+(let ((*element (pkg-line->element (string->pointer "PKG_YYY-multi-word-again(R0w8-multi-word-again,R100,1k, 1%,multi,word,again)))"))))
+  (test-assert (not (null-pointer? *element)))
+  (test-equal (pcb-element-description *element) "R0w8-multi-word-again")
+  (test-equal (pcb-element-refdes *element) "R100")
+  (test-equal (pcb-element-value *element) "1k,_1%")
+  (test-equal (pcb-element-pkg-name-fix *element) "multi word again")
+  (free-element *element))
 
 ;;; Wrong PKG_ strings.
 

--- a/liblepton/scheme/unit-tests/sch2pcb-element.scm
+++ b/liblepton/scheme/unit-tests/sch2pcb-element.scm
@@ -23,6 +23,23 @@
   (test-equal (pcb-element-value *element) "unknown__")
   (free-element *element))
 
+;;; Element's fields with several closing parens after the value.
+(let ((*element (pkg-line->element (string->pointer "PKG_DIP14(DIP14,U100,unknown))))"))))
+  (test-assert (not (null-pointer? *element)))
+  (test-equal (pcb-element-description *element) "DIP14")
+  (test-equal (pcb-element-refdes *element) "U100")
+  (test-equal (pcb-element-value *element) "unknown")
+  (free-element *element))
+
+;;; Element's fields with several closing parens and text after
+;;; the value.
+(let ((*element (pkg-line->element (string->pointer "PKG_DIP14(DIP14,U100,unknown)))text"))))
+  (test-assert (not (null-pointer? *element)))
+  (test-equal (pcb-element-description *element) "DIP14")
+  (test-equal (pcb-element-refdes *element) "U100")
+  (test-equal (pcb-element-value *element) "unknown")
+  (free-element *element))
+
 ;;; Element with extra description arguments.
 (let ((*element (pkg-line->element (string->pointer "PKG_100-Pin-jack(100-Pin-jack,refdes,value,Pin,jack)"))))
   (test-assert (not (null-pointer? *element)))

--- a/liblepton/scheme/unit-tests/sch2pcb-element.scm
+++ b/liblepton/scheme/unit-tests/sch2pcb-element.scm
@@ -12,4 +12,13 @@
   (test-assert (not (null-pointer? *element)))
   (free-element *element))
 
+;;; Wrong PKG_ strings.
+
+;;; No left paren at all.
+(test-assert (null-pointer? (pkg-line->element (string->pointer "PKG_DIP14"))))
+;;; Missing "PKG_" prefix.
+(test-assert (null-pointer? (pkg-line->element (string->pointer "DIP14(DIP14,U100,unknown)"))))
+;;; Wrong amount of arguments in parens (less than 3).
+(test-assert (null-pointer? (pkg-line->element (string->pointer "PKG_DIP14(DIP14,U100)"))))
+
 (test-end)

--- a/liblepton/scheme/unit-tests/sch2pcb-element.scm
+++ b/liblepton/scheme/unit-tests/sch2pcb-element.scm
@@ -8,7 +8,7 @@
 
 ;;; Test that *PcbElement is created successfully from a proper
 ;;; string.  Test its fields as well.
-(let ((*element (pkg-line->element (string->pointer "PKG_DIP14(DIP14,U100,unknown)"))))
+(let ((*element (pkg-line->element "PKG_DIP14(DIP14,U100,unknown)")))
   (test-assert (not (null-pointer? *element)))
   (test-equal (pcb-element-description *element) "DIP14")
   (test-equal (pcb-element-refdes *element) "U100")
@@ -16,7 +16,7 @@
   (free-element *element))
 
 ;;; Element's fields with whitespaces.
-(let ((*element (pkg-line->element (string->pointer "PKG_DIP14(DIP14\t, U100,unknown  )"))))
+(let ((*element (pkg-line->element "PKG_DIP14(DIP14\t, U100,unknown  )")))
   (test-assert (not (null-pointer? *element)))
   (test-equal (pcb-element-description *element) "DIP14_")
   (test-equal (pcb-element-refdes *element) "_U100")
@@ -24,7 +24,7 @@
   (free-element *element))
 
 ;;; Element's fields with several closing parens after the value.
-(let ((*element (pkg-line->element (string->pointer "PKG_DIP14(DIP14,U100,unknown))))"))))
+(let ((*element (pkg-line->element "PKG_DIP14(DIP14,U100,unknown))))")))
   (test-assert (not (null-pointer? *element)))
   (test-equal (pcb-element-description *element) "DIP14")
   (test-equal (pcb-element-refdes *element) "U100")
@@ -33,7 +33,7 @@
 
 ;;; Element's fields with several closing parens and text after
 ;;; the value.
-(let ((*element (pkg-line->element (string->pointer "PKG_DIP14(DIP14,U100,unknown)))text"))))
+(let ((*element (pkg-line->element "PKG_DIP14(DIP14,U100,unknown)))text")))
   (test-assert (not (null-pointer? *element)))
   (test-equal (pcb-element-description *element) "DIP14")
   (test-equal (pcb-element-refdes *element) "U100")
@@ -41,7 +41,7 @@
   (free-element *element))
 
 ;;; Element with extra description arguments.
-(let ((*element (pkg-line->element (string->pointer "PKG_100-Pin-jack(100-Pin-jack,refdes,value,Pin,jack)"))))
+(let ((*element (pkg-line->element "PKG_100-Pin-jack(100-Pin-jack,refdes,value,Pin,jack)")))
   (test-assert (not (null-pointer? *element)))
   (test-equal (pcb-element-description *element) "100-Pin-jack")
   (test-equal (pcb-element-refdes *element) "refdes")
@@ -50,7 +50,7 @@
   (free-element *element))
 
 ;;; Element with value containing a comma.
-(let ((*element (pkg-line->element (string->pointer "PKG_XXX(R0w8,R100,1k, 1%)"))))
+(let ((*element (pkg-line->element "PKG_XXX(R0w8,R100,1k, 1%)")))
   (test-assert (not (null-pointer? *element)))
   (test-equal (pcb-element-description *element) "R0w8")
   (test-equal (pcb-element-refdes *element) "R100")
@@ -59,7 +59,7 @@
 
 ;;; Element with value containing a comma, a closing paren, and
 ;;; some text after it.
-(let ((*element (pkg-line->element (string->pointer "PKG_XXX(R0w8,R100,1k, 1%)text"))))
+(let ((*element (pkg-line->element "PKG_XXX(R0w8,R100,1k, 1%)text")))
   (test-assert (not (null-pointer? *element)))
   (test-equal (pcb-element-description *element) "R0w8")
   (test-equal (pcb-element-refdes *element) "R100")
@@ -68,7 +68,7 @@
 
 ;;; Element with value containing a comma and several closing
 ;;; parens.
-(let ((*element (pkg-line->element (string->pointer "PKG_XXX(R0w8,R100,1k, 1%)))))"))))
+(let ((*element (pkg-line->element "PKG_XXX(R0w8,R100,1k, 1%)))))")))
   (test-assert (not (null-pointer? *element)))
   (test-equal (pcb-element-description *element) "R0w8")
   (test-equal (pcb-element-refdes *element) "R100")
@@ -77,7 +77,7 @@
 
 ;;; Element with multi-word description and value containing a
 ;;; comma.
-(let ((*element (pkg-line->element (string->pointer "PKG_YYY-multi-word(R0w8-multi-word,R100,1k, 1%,multi,word)"))))
+(let ((*element (pkg-line->element "PKG_YYY-multi-word(R0w8-multi-word,R100,1k, 1%,multi,word)")))
   (test-assert (not (null-pointer? *element)))
   (test-equal (pcb-element-description *element) "R0w8-multi-word")
   (test-equal (pcb-element-refdes *element) "R100")
@@ -87,7 +87,7 @@
 
 ;;; Probably it behaves wrong when two or three closing parens are
 ;;; present?
-(let ((*element (pkg-line->element (string->pointer "PKG_YYY-multi-word-again(R0w8-multi-word-again,R100,1k, 1%,multi,word,again)))"))))
+(let ((*element (pkg-line->element "PKG_YYY-multi-word-again(R0w8-multi-word-again,R100,1k, 1%,multi,word,again)))")))
   (test-assert (not (null-pointer? *element)))
   (test-equal (pcb-element-description *element) "R0w8-multi-word-again")
   (test-equal (pcb-element-refdes *element) "R100")
@@ -98,10 +98,10 @@
 ;;; Wrong PKG_ strings.
 
 ;;; No left paren at all.
-(test-assert (null-pointer? (pkg-line->element (string->pointer "PKG_DIP14"))))
+(test-assert (null-pointer? (pkg-line->element "PKG_DIP14")))
 ;;; Missing "PKG_" prefix.
-(test-assert (null-pointer? (pkg-line->element (string->pointer "DIP14(DIP14,U100,unknown)"))))
+(test-assert (null-pointer? (pkg-line->element "DIP14(DIP14,U100,unknown)")))
 ;;; Wrong amount of arguments in parens (less than 3).
-(test-assert (null-pointer? (pkg-line->element (string->pointer "PKG_DIP14(DIP14,U100)"))))
+(test-assert (null-pointer? (pkg-line->element "PKG_DIP14(DIP14,U100)")))
 
 (test-end)

--- a/liblepton/scheme/unit-tests/sch2pcb-element.scm
+++ b/liblepton/scheme/unit-tests/sch2pcb-element.scm
@@ -7,9 +7,12 @@
 (test-begin "pkg-line->element")
 
 ;;; Test that *PcbElement is created successfully from a proper
-;;; string.
+;;; string.  Test its fields as well.
 (let ((*element (pkg-line->element (string->pointer "PKG_DIP14(DIP14,U100,unknown)"))))
   (test-assert (not (null-pointer? *element)))
+  (test-equal (pcb-element-description *element) "DIP14")
+  (test-equal (pcb-element-refdes *element) "U100")
+  (test-equal (pcb-element-value *element) "unknown")
   (free-element *element))
 
 ;;; Wrong PKG_ strings.

--- a/liblepton/scheme/unit-tests/sch2pcb-element.scm
+++ b/liblepton/scheme/unit-tests/sch2pcb-element.scm
@@ -1,0 +1,15 @@
+;;; Test Scheme procedures related to pcb elements.
+
+(use-modules (system foreign)
+             (sch2pcb element))
+
+
+(test-begin "pkg-line->element")
+
+;;; Test that *PcbElement is created successfully from a proper
+;;; string.
+(let ((*element (pkg-line->element (string->pointer "PKG_DIP14(DIP14,U100,unknown)"))))
+  (test-assert (not (null-pointer? *element)))
+  (free-element *element))
+
+(test-end)

--- a/liblepton/scheme/unit-tests/sch2pcb-element.scm
+++ b/liblepton/scheme/unit-tests/sch2pcb-element.scm
@@ -32,6 +32,25 @@
   (test-equal (pcb-element-pkg-name-fix *element) "Pin jack")
   (free-element *element))
 
+;;; Element with value containing a comma.
+(let ((*element (pkg-line->element (string->pointer "PKG_XXX(R0w8,R100,1k, 1%)"))))
+  (test-assert (not (null-pointer? *element)))
+  (test-equal (pcb-element-description *element) "R0w8")
+  (test-equal (pcb-element-refdes *element) "R100")
+  (test-equal (pcb-element-value *element) "1k,_1%")
+  (free-element *element))
+
+;;; Element with multi-word description and value containing a
+;;; comma.
+(let ((*element (pkg-line->element (string->pointer "PKG_YYY-multi-word(R0w8-multi-word,R100,1k, 1%,multi,word)"))))
+  (test-assert (not (null-pointer? *element)))
+  (test-equal (pcb-element-description *element) "R0w8-multi-word")
+  (test-equal (pcb-element-refdes *element) "R100")
+  (test-equal (pcb-element-value *element) "1k,_1%")
+  (test-equal (pcb-element-pkg-name-fix *element) "multi word")
+  (free-element *element))
+
+
 ;;; Wrong PKG_ strings.
 
 ;;; No left paren at all.

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -634,11 +634,6 @@ pcb_element_pkg_to_element (PcbElement *el,
    * description with '-' when there are extra args.
    */
   if (args[n]) {
-    pcb_element_set_pkg_name_fix (el, g_strdup (args[n]));
-    for (n += 1; args[n] != NULL; ++n) {
-      s = pcb_element_get_pkg_name_fix (el);
-      pcb_element_set_pkg_name_fix (el, g_strconcat (s, " ", args[n], NULL));
-    }
     if ((s = strchr (pcb_element_get_pkg_name_fix (el), (gint) ')')) != NULL)
       *s = '\0';
   }

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -724,13 +724,12 @@ pcb_element_pkg_to_element (gchar *pkg_line)
     n = 4;
   }
   if (args[n]) {
-    el->pkg_name_fix = g_strdup (args[n]);
+    pcb_element_set_pkg_name_fix (el, g_strdup (args[n]));
     for (n += 1; args[n] != NULL; ++n) {
-      s = el->pkg_name_fix;
-      el->pkg_name_fix = g_strconcat (s, " ", args[n], NULL);
-      g_free (s);
+      s = pcb_element_get_pkg_name_fix (el);
+      pcb_element_set_pkg_name_fix (el, g_strconcat (s, " ", args[n], NULL));
     }
-    if ((s = strchr (el->pkg_name_fix, (gint) ')')) != NULL)
+    if ((s = strchr (pcb_element_get_pkg_name_fix (el), (gint) ')')) != NULL)
       *s = '\0';
   }
   g_strfreev (args);

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -610,10 +610,11 @@ sch2pcb_find_element (gchar *dir_path,
 PcbElement*
 pcb_element_pkg_to_element (PcbElement *el,
                             gchar *pkg_line,
-                            int n_extra_args)
+                            int n_extra_args,
+                            int n_dashes)
 {
   gchar **args, *s;
-  gint n, n_dashes;
+  gint n;
 
   s = strchr (pkg_line, (gint) '(');
 
@@ -634,9 +635,6 @@ pcb_element_pkg_to_element (PcbElement *el,
    * value has a comma because gnet-gsch2pcb.scm munges the
    * description with '-' when there are extra args.
    */
-  s = pcb_element_get_description (el);
-  for (n_dashes = 0; (s = strchr (s + 1, '-')) != NULL; ++n_dashes);
-
   n = 3;
   if (n_extra_args == n_dashes + 1) { /* Assume there was a comma in the value, eg "1K, 1%" */
     s = g_strdup (pcb_element_get_value (el));

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -610,8 +610,7 @@ sch2pcb_find_element (gchar *dir_path,
 PcbElement*
 pcb_element_pkg_to_element (PcbElement *el,
                             gchar *pkg_line,
-                            int n_extra_args,
-                            int n_dashes)
+                            gboolean value_has_comma)
 {
   gchar **args, *s;
   gint n;
@@ -636,7 +635,8 @@ pcb_element_pkg_to_element (PcbElement *el,
    * description with '-' when there are extra args.
    */
   n = 3;
-  if (n_extra_args == n_dashes + 1) { /* Assume there was a comma in the value, eg "1K, 1%" */
+  if (value_has_comma)
+  {
     s = g_strdup (pcb_element_get_value (el));
     pcb_element_set_value (el, g_strconcat (s, ",", fix_spaces (args[n]), NULL));
     g_free (s);

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -281,21 +281,6 @@ sch2pcb_get_pcb_element_list ()
 }
 
 
-static int n_empty;
-
-int
-sch2pcb_get_n_empty ()
-{
-  return n_empty;
-}
-
-void
-sch2pcb_set_n_empty (int val)
-{
-  n_empty = val;
-}
-
-
 static int n_none;
 
 int

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -281,21 +281,6 @@ sch2pcb_get_pcb_element_list ()
 }
 
 
-static int n_none;
-
-int
-sch2pcb_get_n_none ()
-{
-  return n_none;
-}
-
-void
-sch2pcb_set_n_none (int val)
-{
-  n_none = val;
-}
-
-
 static int n_unknown;
 
 int

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -610,10 +610,9 @@ sch2pcb_find_element (gchar *dir_path,
 PcbElement*
 pcb_element_pkg_to_element (PcbElement *el,
                             gchar *pkg_line,
-                            gboolean value_has_comma)
+                            int n)
 {
   gchar **args, *s;
-  gint n;
 
   s = strchr (pkg_line, (gint) '(');
 
@@ -634,11 +633,6 @@ pcb_element_pkg_to_element (PcbElement *el,
    * value has a comma because gnet-gsch2pcb.scm munges the
    * description with '-' when there are extra args.
    */
-  n = 3;
-  if (value_has_comma)
-  {
-    n = 4;
-  }
   if (args[n]) {
     pcb_element_set_pkg_name_fix (el, g_strdup (args[n]));
     for (n += 1; args[n] != NULL; ++n) {

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -678,10 +678,6 @@ pcb_element_pkg_to_element (gchar *pkg_line)
   s = strchr (pkg_line, (gint) '(');
 
   args = g_strsplit (s + 1, ",", 12);
-  if (!args[0] || !args[1] || !args[2]) {
-    fprintf (stderr, "Bad package line: %s\n", pkg_line);
-    return NULL;
-  }
   fix_spaces (args[0]);
   fix_spaces (args[1]);
   fix_spaces (args[2]);

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -1,6 +1,6 @@
 /* gsch2pcb
  * Copyright (C) 2003-2016 gEDA Contributors
- * Copyright (C) 2017-2023 Lepton EDA Contributors
+ * Copyright (C) 2017-2024 Lepton EDA Contributors
  *
  *  Bill Wilson    billw@wt.net
  *
@@ -736,7 +736,7 @@ pcb_element_pkg_to_element (gchar *pkg_line)
   g_strfreev (args);
 
   if (empty_footprint_name && !strcmp (el->description, empty_footprint_name)) {
-    if (verbose)
+    if (sch2pcb_get_verbose_mode () != 0)
       printf
         ("%s: has the empty footprint attribute \"%s\" so won't be in the layout.\n",
          el->refdes, el->description);

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -675,8 +675,7 @@ pcb_element_pkg_to_element (gchar *pkg_line)
   gchar **args, *s;
   gint n, n_extra_args, n_dashes;
 
-  if ((s = strchr (pkg_line, (gint) '(')) == NULL)
-    return NULL;
+  s = strchr (pkg_line, (gint) '(');
 
   args = g_strsplit (s + 1, ",", 12);
   if (!args[0] || !args[1] || !args[2]) {

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -743,20 +743,20 @@ pcb_element_pkg_to_element (gchar *pkg_line)
          pcb_element_get_refdes (el),
          pcb_element_get_description (el));
     sch2pcb_set_n_empty (1 + sch2pcb_get_n_empty ());
-    el->omit_PKG = TRUE;
+    pcb_element_set_omit_PKG (el, TRUE);
   } else if (!strcmp (pcb_element_get_description (el), "none")) {
     fprintf (stderr,
              "WARNING: %s has a footprint attribute \"%s\" so won't be in the layout.\n",
              pcb_element_get_refdes (el),
              pcb_element_get_description (el));
     sch2pcb_set_n_none (1 + sch2pcb_get_n_none ());
-    el->omit_PKG = TRUE;
+    pcb_element_set_omit_PKG (el, TRUE);
   } else if (!strcmp (pcb_element_get_description (el), "unknown")) {
     fprintf (stderr,
              "WARNING: %s has no footprint attribute so won't be in the layout.\n",
              pcb_element_get_refdes (el));
     sch2pcb_set_n_unknown (1 + sch2pcb_get_n_unknown ());
-    el->omit_PKG = TRUE;
+    pcb_element_set_omit_PKG (el, TRUE);
   }
   return el;
 }

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -746,7 +746,7 @@ pcb_element_pkg_to_element (gchar *pkg_line)
     fprintf (stderr,
              "WARNING: %s has a footprint attribute \"%s\" so won't be in the layout.\n",
              el->refdes, el->description);
-    n_none += 1;
+    sch2pcb_set_n_none (1 + sch2pcb_get_n_none ());
     el->omit_PKG = TRUE;
   } else if (!strcmp (el->description, "unknown")) {
     fprintf (stderr,

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -669,9 +669,9 @@ sch2pcb_find_element (gchar *dir_path,
  *      100-Pin-jack -> 100 Pin jack
  */
 PcbElement*
-pcb_element_pkg_to_element (gchar *pkg_line)
+pcb_element_pkg_to_element (PcbElement *el,
+                            gchar *pkg_line)
 {
-  PcbElement *el;
   gchar **args, *s;
   gint n, n_extra_args, n_dashes;
 
@@ -682,7 +682,6 @@ pcb_element_pkg_to_element (gchar *pkg_line)
   fix_spaces (args[1]);
   fix_spaces (args[2]);
 
-  el = pcb_element_new ();
   pcb_element_set_description (el, g_strdup (args[0]));
   pcb_element_set_refdes (el, g_strdup (args[1]));
   pcb_element_set_value (el, g_strdup (args[2]));

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -678,13 +678,7 @@ pcb_element_pkg_to_element (PcbElement *el,
   s = strchr (pkg_line, (gint) '(');
 
   args = g_strsplit (s + 1, ",", 12);
-  fix_spaces (args[0]);
-  fix_spaces (args[1]);
-  fix_spaces (args[2]);
 
-  pcb_element_set_description (el, g_strdup (args[0]));
-  pcb_element_set_refdes (el, g_strdup (args[1]));
-  pcb_element_set_value (el, g_strdup (args[2]));
   if ((s = strchr (pcb_element_get_value (el), (gint) ')')) != NULL)
     *s = '\0';
 

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -637,8 +637,6 @@ pcb_element_pkg_to_element (PcbElement *el,
   n = 3;
   if (value_has_comma)
   {
-    if ((s = strchr (pcb_element_get_value (el), (gint) ')')) != NULL)
-      *s = '\0';
     n = 4;
   }
   if (args[n]) {

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -281,21 +281,6 @@ sch2pcb_get_pcb_element_list ()
 }
 
 
-static int n_unknown;
-
-int
-sch2pcb_get_n_unknown ()
-{
-  return n_unknown;
-}
-
-void
-sch2pcb_set_n_unknown (int val)
-{
-  n_unknown = val;
-}
-
-
 static gint verbose;
 
 gint

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -718,30 +718,6 @@ pcb_element_pkg_to_element (PcbElement *el,
   }
   g_strfreev (args);
 
-  if (sch2pcb_get_empty_footprint_name ()
-      && !strcmp (pcb_element_get_description (el), sch2pcb_get_empty_footprint_name ()))
-  {
-    if (sch2pcb_get_verbose_mode () != 0)
-      printf
-        ("%s: has the empty footprint attribute \"%s\" so won't be in the layout.\n",
-         pcb_element_get_refdes (el),
-         pcb_element_get_description (el));
-    sch2pcb_set_n_empty (1 + sch2pcb_get_n_empty ());
-    pcb_element_set_omit_PKG (el, TRUE);
-  } else if (!strcmp (pcb_element_get_description (el), "none")) {
-    fprintf (stderr,
-             "WARNING: %s has a footprint attribute \"%s\" so won't be in the layout.\n",
-             pcb_element_get_refdes (el),
-             pcb_element_get_description (el));
-    sch2pcb_set_n_none (1 + sch2pcb_get_n_none ());
-    pcb_element_set_omit_PKG (el, TRUE);
-  } else if (!strcmp (pcb_element_get_description (el), "unknown")) {
-    fprintf (stderr,
-             "WARNING: %s has no footprint attribute so won't be in the layout.\n",
-             pcb_element_get_refdes (el));
-    sch2pcb_set_n_unknown (1 + sch2pcb_get_n_unknown ());
-    pcb_element_set_omit_PKG (el, TRUE);
-  }
   return el;
 }
 

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -689,7 +689,7 @@ pcb_element_pkg_to_element (gchar *pkg_line)
   fix_spaces (args[2]);
 
   el = pcb_element_new ();
-  el->description = g_strdup (args[0]);
+  pcb_element_set_description (el, g_strdup (args[0]));
   pcb_element_set_refdes (el, g_strdup (args[1]));
   pcb_element_set_value (el, g_strdup (args[2]));
   if ((s = strchr (pcb_element_get_value (el), (gint) ')')) != NULL)
@@ -711,7 +711,7 @@ pcb_element_pkg_to_element (gchar *pkg_line)
    * description with '-' when there are extra args.
    */
   for (n_extra_args = 0; args[3 + n_extra_args] != NULL; ++n_extra_args);
-  s = el->description;
+  s = pcb_element_get_description (el);
   for (n_dashes = 0; (s = strchr (s + 1, '-')) != NULL; ++n_dashes);
 
   n = 3;
@@ -735,22 +735,24 @@ pcb_element_pkg_to_element (gchar *pkg_line)
   }
   g_strfreev (args);
 
-  if (empty_footprint_name && !strcmp (el->description, empty_footprint_name)) {
+  if (empty_footprint_name
+      && !strcmp (pcb_element_get_description (el), empty_footprint_name))
+  {
     if (sch2pcb_get_verbose_mode () != 0)
       printf
         ("%s: has the empty footprint attribute \"%s\" so won't be in the layout.\n",
          pcb_element_get_refdes (el),
-         el->description);
+         pcb_element_get_description (el));
     sch2pcb_set_n_empty (1 + sch2pcb_get_n_empty ());
     el->omit_PKG = TRUE;
-  } else if (!strcmp (el->description, "none")) {
+  } else if (!strcmp (pcb_element_get_description (el), "none")) {
     fprintf (stderr,
              "WARNING: %s has a footprint attribute \"%s\" so won't be in the layout.\n",
              pcb_element_get_refdes (el),
-             el->description);
+             pcb_element_get_description (el));
     sch2pcb_set_n_none (1 + sch2pcb_get_n_none ());
     el->omit_PKG = TRUE;
-  } else if (!strcmp (el->description, "unknown")) {
+  } else if (!strcmp (pcb_element_get_description (el), "unknown")) {
     fprintf (stderr,
              "WARNING: %s has no footprint attribute so won't be in the layout.\n",
              pcb_element_get_refdes (el));

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -740,7 +740,7 @@ pcb_element_pkg_to_element (gchar *pkg_line)
       printf
         ("%s: has the empty footprint attribute \"%s\" so won't be in the layout.\n",
          el->refdes, el->description);
-    n_empty += 1;
+    sch2pcb_set_n_empty (1 + sch2pcb_get_n_empty ());
     el->omit_PKG = TRUE;
   } else if (!strcmp (el->description, "none")) {
     fprintf (stderr,

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -691,8 +691,8 @@ pcb_element_pkg_to_element (gchar *pkg_line)
   el = pcb_element_new ();
   el->description = g_strdup (args[0]);
   pcb_element_set_refdes (el, g_strdup (args[1]));
-  el->value = g_strdup (args[2]);
-  if ((s = strchr (el->value, (gint) ')')) != NULL)
+  pcb_element_set_value (el, g_strdup (args[2]));
+  if ((s = strchr (pcb_element_get_value (el), (gint) ')')) != NULL)
     *s = '\0';
 
   /* If the component value has a comma, eg "1k, 1%", the gnetlist generated
@@ -716,10 +716,10 @@ pcb_element_pkg_to_element (gchar *pkg_line)
 
   n = 3;
   if (n_extra_args == n_dashes + 1) { /* Assume there was a comma in the value, eg "1K, 1%" */
-    s = el->value;
-    el->value = g_strconcat (s, ",", fix_spaces (args[n]), NULL);
+    s = g_strdup (pcb_element_get_value (el));
+    pcb_element_set_value (el, g_strconcat (s, ",", fix_spaces (args[n]), NULL));
     g_free (s);
-    if ((s = strchr (el->value, (gint) ')')) != NULL)
+    if ((s = strchr (pcb_element_get_value (el), (gint) ')')) != NULL)
       *s = '\0';
     n = 4;
   }

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -752,7 +752,7 @@ pcb_element_pkg_to_element (gchar *pkg_line)
     fprintf (stderr,
              "WARNING: %s has no footprint attribute so won't be in the layout.\n",
              el->refdes);
-    n_unknown += 1;
+    sch2pcb_set_n_unknown (1 + sch2pcb_get_n_unknown ());
     el->omit_PKG = TRUE;
   }
   return el;

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -609,10 +609,11 @@ sch2pcb_find_element (gchar *dir_path,
  */
 PcbElement*
 pcb_element_pkg_to_element (PcbElement *el,
-                            gchar *pkg_line)
+                            gchar *pkg_line,
+                            int n_extra_args)
 {
   gchar **args, *s;
-  gint n, n_extra_args, n_dashes;
+  gint n, n_dashes;
 
   s = strchr (pkg_line, (gint) '(');
 
@@ -633,7 +634,6 @@ pcb_element_pkg_to_element (PcbElement *el,
    * value has a comma because gnet-gsch2pcb.scm munges the
    * description with '-' when there are extra args.
    */
-  for (n_extra_args = 0; args[3 + n_extra_args] != NULL; ++n_extra_args);
   s = pcb_element_get_description (el);
   for (n_dashes = 0; (s = strchr (s + 1, '-')) != NULL; ++n_dashes);
 

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -718,8 +718,8 @@ pcb_element_pkg_to_element (PcbElement *el,
   }
   g_strfreev (args);
 
-  if (empty_footprint_name
-      && !strcmp (pcb_element_get_description (el), empty_footprint_name))
+  if (sch2pcb_get_empty_footprint_name ()
+      && !strcmp (pcb_element_get_description (el), sch2pcb_get_empty_footprint_name ()))
   {
     if (sch2pcb_get_verbose_mode () != 0)
       printf

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -637,9 +637,6 @@ pcb_element_pkg_to_element (PcbElement *el,
   n = 3;
   if (value_has_comma)
   {
-    s = g_strdup (pcb_element_get_value (el));
-    pcb_element_set_value (el, g_strconcat (s, ",", fix_spaces (args[n]), NULL));
-    g_free (s);
     if ((s = strchr (pcb_element_get_value (el), (gint) ')')) != NULL)
       *s = '\0';
     n = 4;

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -281,22 +281,6 @@ sch2pcb_get_pcb_element_list ()
 }
 
 
-static gchar *empty_footprint_name;
-
-char*
-sch2pcb_get_empty_footprint_name ()
-{
-  return empty_footprint_name;
-}
-
-void
-sch2pcb_set_empty_footprint_name (char *val)
-{
-  g_free (empty_footprint_name);
-  empty_footprint_name = g_strdup (val);
-}
-
-
 static int n_empty;
 
 int

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -675,8 +675,7 @@ pcb_element_pkg_to_element (gchar *pkg_line)
   gchar **args, *s;
   gint n, n_extra_args, n_dashes;
 
-  if (strncmp (pkg_line, "PKG_", 4)
-      || (s = strchr (pkg_line, (gint) '(')) == NULL)
+  if ((s = strchr (pkg_line, (gint) '(')) == NULL)
     return NULL;
 
   args = g_strsplit (s + 1, ",", 12);

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -690,7 +690,7 @@ pcb_element_pkg_to_element (gchar *pkg_line)
 
   el = pcb_element_new ();
   el->description = g_strdup (args[0]);
-  el->refdes = g_strdup (args[1]);
+  pcb_element_set_refdes (el, g_strdup (args[1]));
   el->value = g_strdup (args[2]);
   if ((s = strchr (el->value, (gint) ')')) != NULL)
     *s = '\0';
@@ -739,19 +739,21 @@ pcb_element_pkg_to_element (gchar *pkg_line)
     if (sch2pcb_get_verbose_mode () != 0)
       printf
         ("%s: has the empty footprint attribute \"%s\" so won't be in the layout.\n",
-         el->refdes, el->description);
+         pcb_element_get_refdes (el),
+         el->description);
     sch2pcb_set_n_empty (1 + sch2pcb_get_n_empty ());
     el->omit_PKG = TRUE;
   } else if (!strcmp (el->description, "none")) {
     fprintf (stderr,
              "WARNING: %s has a footprint attribute \"%s\" so won't be in the layout.\n",
-             el->refdes, el->description);
+             pcb_element_get_refdes (el),
+             el->description);
     sch2pcb_set_n_none (1 + sch2pcb_get_n_none ());
     el->omit_PKG = TRUE;
   } else if (!strcmp (el->description, "unknown")) {
     fprintf (stderr,
              "WARNING: %s has no footprint attribute so won't be in the layout.\n",
-             el->refdes);
+             pcb_element_get_refdes (el));
     sch2pcb_set_n_unknown (1 + sch2pcb_get_n_unknown ());
     el->omit_PKG = TRUE;
   }

--- a/liblepton/src/sch2pcb.c
+++ b/liblepton/src/sch2pcb.c
@@ -679,9 +679,6 @@ pcb_element_pkg_to_element (PcbElement *el,
 
   args = g_strsplit (s + 1, ",", 12);
 
-  if ((s = strchr (pcb_element_get_value (el), (gint) ')')) != NULL)
-    *s = '\0';
-
   /* If the component value has a comma, eg "1k, 1%", the gnetlist generated
    * PKG line will be
    *

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -515,8 +515,7 @@
 
   (define (parse-next-line mline tline skip-next?)
     ;; First let's find out what element type we're dealing with.
-    (let* ((*tline (string->pointer tline))
-           (*m4-element (pcb_element_line_parse *tline))
+    (let* ((*m4-element (pcb_element_line_parse (string->pointer tline)))
            (m4-element? (not (null-pointer? *m4-element)))
            (*element (if m4-element?
                          ;; If Element line is present
@@ -526,7 +525,7 @@
                          *m4-element
                          ;; Otherwise, it's a line starting with
                          ;; PKG_, probably a file element?
-                         (pkg-line->element *tline))))
+                         (pkg-line->element tline))))
       ;; Next step is to check if element processing can be
       ;; skipped as the same element has been processed before.
       (if (pcb-element-exists? *element #t)

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -271,7 +271,7 @@
                      (verbose-format "\tFound: ~A\n" path)
                      path)))))))
 
-  ;; See comment before pcb_element_pkg_to_element().
+  ;; See comment before pkg-line->element().
   (when package-name-fix
     (unless name
       (format-warning

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -172,6 +172,9 @@
 (define %deleted-element-count 0)
 ;;; The number of elements with changed value.
 (define %changed-value-element-count 0)
+;;; The number of components with specially assigned "footprint="
+;;; value to omit from the layout.
+(define %empty-footprint-count 0)
 
 
 (define (make-pcb-element-list pcb-filename)
@@ -413,7 +416,7 @@
              "~A: has the empty footprint attribute ~S so won't be in the layout.\n"
              refdes
              description)
-            (sch2pcb_set_n_empty (1+ (sch2pcb_get_n_empty)))
+            (set! %empty-footprint-count (1+ %empty-footprint-count))
             (set-pcb-element-omit-pkg! *element #t))
           (if (string= description "none")
               (begin
@@ -1369,9 +1372,9 @@ Lepton EDA homepage: <~A>
     (format-message "~A components with footprint \"none\" omitted from ~A.\n"
                     (sch2pcb_get_n_none)
                     pcb-new-filename))
-  (unless (zero? (sch2pcb_get_n_empty))
+  (unless (zero? %empty-footprint-count)
     (format-message "~A components with empty footprint ~S omitted from ~A.\n"
-                    (sch2pcb_get_n_empty)
+                    %empty-footprint-count
                     %empty-footprint-name
                     pcb-new-filename))
   (unless (zero? %changed-value-element-count)

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -175,6 +175,9 @@
 ;;; The number of components with specially assigned "footprint="
 ;;; value to omit from the layout.
 (define %empty-footprint-count 0)
+;;; The number of components with the attribute "footprint=none"
+;;; that by default don't go to the layout.
+(define %none-footprint-count 0)
 
 
 (define (make-pcb-element-list pcb-filename)
@@ -424,7 +427,7 @@
                  "WARNING: ~A has a footprint attribute ~S so won't be in the layout.\n"
                  refdes
                  description)
-                (sch2pcb_set_n_none (1+ (sch2pcb_get_n_none)))
+                (set! %none-footprint-count (1+ %none-footprint-count))
                 (set-pcb-element-omit-pkg! *element #t))
               (when (string= description "unknown")
                 (format-warning
@@ -1368,9 +1371,9 @@ Lepton EDA homepage: <~A>
   (unless (zero? (sch2pcb_get_n_unknown))
     (format-message "~A components had no footprint attribute and are omitted.\n"
                     (sch2pcb_get_n_unknown)))
-  (unless (zero? (sch2pcb_get_n_none))
+  (unless (zero? %none-footprint-count)
     (format-message "~A components with footprint \"none\" omitted from ~A.\n"
-                    (sch2pcb_get_n_none)
+                    %none-footprint-count
                     pcb-new-filename))
   (unless (zero? %empty-footprint-count)
     (format-message "~A components with empty footprint ~S omitted from ~A.\n"

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -178,6 +178,10 @@
 ;;; The number of components with the attribute "footprint=none"
 ;;; that by default don't go to the layout.
 (define %none-footprint-count 0)
+;;; The count of components with missing "footprint=" attribute.
+;;; Pcb elements corresponding to them typicaly have "description"
+;;; set to "unknown".
+(define %missing-footprint-count 0)
 
 
 (define (make-pcb-element-list pcb-filename)
@@ -433,7 +437,7 @@
                 (format-warning
                  "WARNING: ~A has no footprint attribute so won't be in the layout.\n"
                  refdes)
-                (sch2pcb_set_n_unknown (1+ (sch2pcb_get_n_unknown)))
+                (set! %missing-footprint-count (1+ %missing-footprint-count))
                 (set-pcb-element-omit-pkg! *element #t))))))
 
   (define tmp-filename (string-append pcb-filename ".tmp"))
@@ -1368,9 +1372,9 @@ Lepton EDA homepage: <~A>
     (format-message "~A not found elements added to ~A.\n"
                     %not-found-packages-count
                     pcb-new-filename))
-  (unless (zero? (sch2pcb_get_n_unknown))
+  (unless (zero? %missing-footprint-count)
     (format-message "~A components had no footprint attribute and are omitted.\n"
-                    (sch2pcb_get_n_unknown)))
+                    %missing-footprint-count))
   (unless (zero? %none-footprint-count)
     (format-message "~A components with footprint \"none\" omitted from ~A.\n"
                     %none-footprint-count

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -509,7 +509,7 @@
                  (m4-element->file *element *mline *tmp-file)
                  skip-next))))
 
-      (pcb_element_free *element)
+      (free-element *element)
       (verbose-format "----\n")
       result))
 
@@ -535,7 +535,7 @@
           (begin
             ;; Obviously, a new copy of the found element is not
             ;; needed in the element list, so it has to be freed.
-            (pcb_element_free *element)
+            (free-element *element)
             ;; For m4 elements, the next line starts with an
             ;; opening paren "(", and we have to skip lines until
             ;; its closing paren is found.  For file elements, we
@@ -686,7 +686,7 @@
                          (string-append line "\n")
                          (string-prefix? "PKG_" trimmed-line)))
 
-      (pcb_element_free *element)
+      (free-element *element)
       ;; If pcb element exists, and its 'still_exists' is false,
       ;; and we don't want to preserve it, then let's skip it.
       delete-element?))
@@ -791,7 +791,7 @@
             (sch2pcb_buffer_to_file *line *output-file)
             (sch2pcb_buffer_to_file (string->pointer "\n") *output-file)))
 
-      (pcb_element_free *element)))
+      (free-element *element)))
 
   (let loop ((*element-list (glist->list (sch2pcb_get_pcb_element_list)
                                          identity)))

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -1370,7 +1370,7 @@ Lepton EDA homepage: <~A>
                     (sch2pcb_get_n_none)
                     pcb-new-filename))
   (unless (zero? (sch2pcb_get_n_empty))
-    (format-message "~A components with empty footprint \"~A\" omitted from ~A.\n"
+    (format-message "~A components with empty footprint ~S omitted from ~A.\n"
                     (sch2pcb_get_n_empty)
                     %empty-footprint-name
                     pcb-new-filename))

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -168,23 +168,6 @@
 (define %changed-value-element-count 0)
 
 
-(define (pcb-element-get-string *element *c-getter)
-  (define *s (*c-getter *element))
-  (if (null-pointer? *s)
-      ;; What should the function return if *s is NULL?
-      "<null>"
-      (pointer->string *s)))
-
-(define (pcb-element-refdes *element)
-  (pcb-element-get-string *element pcb_element_get_refdes))
-
-(define (pcb-element-description *element)
-  (pcb-element-get-string *element pcb_element_get_description))
-
-(define (pcb-element-value *element)
-  (pcb-element-get-string *element pcb_element_get_value))
-
-
 (define (make-pcb-element-list pcb-filename)
   (when (and (regular-file? pcb-filename)
              (file-readable? pcb-filename))

--- a/tools/sch2pcb/lepton-sch2pcb.scm
+++ b/tools/sch2pcb/lepton-sch2pcb.scm
@@ -32,6 +32,7 @@
              (lepton os)
              (lepton srfi-37)
              (lepton version)
+             (sch2pcb element)
              (sch2pcb format))
 
 
@@ -402,10 +403,6 @@
   (let ((trimmed-line (string-trim line char-set:whitespace)))
     (and (not (string-null? trimmed-line))
          (string-ref trimmed-line 0))))
-
-
-(define (pkg-line->element *line)
-  (pcb_element_pkg_to_element *line))
 
 
 ;;; Process the newly created pcb file which is the output from


### PR DESCRIPTION
The function `pkg-line->element()` has been wholly rewritten in
Scheme.  The following changes have been made:

- A new module, `(sch2pcb element)` has been added.  The module
  currently contains two functions for creating the structure
  `PcbElement` from a text string in Scheme,
  `pkg-line->element()`, and its helper, `free-element`, that
  allows for freeing the C foreign instance memory.  The former
  function has been significantly refactored in Scheme.
- Scheme accessors for some fields of the structure `PcbElement`
  fields have been added and moved into the module.
- Several UTS tests have been added for the above functions in
  order to cover their base functionality and some corner cases.
- Unlike in the previous C code, there is no restriction to the
  maximal number of "PKG_" line arguments in Scheme.
- The current code seems to maintain the "bug-for-bug"
  compatibility with the previous C one though can obviously have
  some new bugs despite of better testing in UTS :-) It will be
  refactored further more than once, I think.