### PR TITLE
Rewrite some preview callbacks in Scheme

### DIFF
--- a/liblepton/scheme/lepton/ffi.scm
+++ b/liblepton/scheme/lepton/ffi.scm
@@ -358,6 +358,7 @@
             lepton_page_get_page_control
             lepton_page_set_page_control
             lepton_page_get_pid
+            lepton_page_get_toplevel
             lepton_page_get_undo_bottom
             lepton_page_set_undo_bottom
             lepton_page_get_undo_current
@@ -712,6 +713,7 @@
 (define-lff lepton_page_get_page_control int '(*))
 (define-lff lepton_page_set_page_control void (list '* int))
 (define-lff lepton_page_get_pid int '(*))
+(define-lff lepton_page_get_toplevel '* '(*))
 (define-lff lepton_page_get_undo_bottom '* '(*))
 (define-lff lepton_page_set_undo_bottom void '(* *))
 (define-lff lepton_page_get_undo_current '* '(*))

--- a/libleptongui/include/preview_widget.h
+++ b/libleptongui/include/preview_widget.h
@@ -64,6 +64,7 @@ schematic_preview_update (SchematicPreview *preview,
                           LeptonPage *preview_page,
                           LeptonToplevel *preview_toplevel,
                           gboolean preview_active,
-                          char *preview_filename);
+                          char *preview_filename,
+                          char *preview_buffer);
 
 G_END_DECLS

--- a/libleptongui/include/preview_widget.h
+++ b/libleptongui/include/preview_widget.h
@@ -57,6 +57,9 @@ schematic_preview_get_active (GtkWidget *preview);
 gchar*
 schematic_preview_get_buffer (GtkWidget *preview);
 
+gchar*
+schematic_preview_get_filename (GtkWidget *preview);
+
 GschemToplevel*
 schematic_preview_get_window (GtkWidget *preview);
 

--- a/libleptongui/include/preview_widget.h
+++ b/libleptongui/include/preview_widget.h
@@ -59,7 +59,7 @@ schematic_preview_get_filename (GtkWidget *preview);
 GschemToplevel*
 schematic_preview_get_window (GtkWidget *preview);
 
-GschemPageView*
+void
 schematic_preview_update (SchematicPreview *preview,
                           LeptonPage *preview_page,
                           gboolean preview_active,

--- a/libleptongui/include/preview_widget.h
+++ b/libleptongui/include/preview_widget.h
@@ -72,7 +72,7 @@ GschemToplevel*
 schematic_preview_get_window (GtkWidget *preview);
 
 void
-schematic_preview_callback_update (SchematicPreview *preview,
-                                   gpointer user_data);
+schematic_preview_update (SchematicPreview *preview,
+                          gpointer user_data);
 
 G_END_DECLS

--- a/libleptongui/include/preview_widget.h
+++ b/libleptongui/include/preview_widget.h
@@ -73,6 +73,6 @@ schematic_preview_get_window (GtkWidget *preview);
 
 void
 schematic_preview_update (SchematicPreview *preview,
-                          gpointer user_data);
+                          LeptonPage *preview_page);
 
 G_END_DECLS

--- a/libleptongui/include/preview_widget.h
+++ b/libleptongui/include/preview_widget.h
@@ -32,23 +32,6 @@
 typedef struct _SchematicPreviewClass SchematicPreviewClass;
 typedef struct _SchematicPreview      SchematicPreview;
 
-struct _SchematicPreviewClass
-{
-  GschemPageViewClass parent_class;
-};
-
-struct _SchematicPreview
-{
-  GschemPageView parent_instance;
-
-  GschemToplevel *window;
-
-  gchar *filename;
-  gchar *buffer;
-
-  gboolean active;
-};
-
 GType
 schematic_preview_get_type (void);
 

--- a/libleptongui/include/preview_widget.h
+++ b/libleptongui/include/preview_widget.h
@@ -59,7 +59,7 @@ schematic_preview_get_filename (GtkWidget *preview);
 GschemToplevel*
 schematic_preview_get_window (GtkWidget *preview);
 
-void
+GschemPageView*
 schematic_preview_update (SchematicPreview *preview,
                           LeptonPage *preview_page,
                           gboolean preview_active,

--- a/libleptongui/include/preview_widget.h
+++ b/libleptongui/include/preview_widget.h
@@ -48,10 +48,6 @@ void
 schematic_preview_callback_realize (GtkWidget *widget,
                                     gpointer user_data);
 gboolean
-schematic_preview_callback_scroll_event (GtkWidget *widget,
-                                         GdkEventScroll *event,
-                                         GschemToplevel *w_current);
-gboolean
 schematic_preview_get_active (GtkWidget *preview);
 
 gchar*

--- a/libleptongui/include/preview_widget.h
+++ b/libleptongui/include/preview_widget.h
@@ -63,6 +63,7 @@ void
 schematic_preview_update (SchematicPreview *preview,
                           LeptonPage *preview_page,
                           LeptonToplevel *preview_toplevel,
-                          gboolean preview_active);
+                          gboolean preview_active,
+                          char *preview_filename);
 
 G_END_DECLS

--- a/libleptongui/include/preview_widget.h
+++ b/libleptongui/include/preview_widget.h
@@ -51,6 +51,9 @@ gboolean
 schematic_preview_callback_scroll_event (GtkWidget *widget,
                                          GdkEventScroll *event,
                                          GschemToplevel *w_current);
+gboolean
+schematic_preview_get_active (GtkWidget *preview);
+
 GschemToplevel*
 schematic_preview_get_window (GtkWidget *preview);
 

--- a/libleptongui/include/preview_widget.h
+++ b/libleptongui/include/preview_widget.h
@@ -52,10 +52,10 @@ struct _SchematicPreview
 GType
 schematic_preview_get_type (void);
 
+G_BEGIN_DECLS
+
 GtkWidget*
 schematic_preview_new ();
-
-G_BEGIN_DECLS
 
 gboolean
 schematic_preview_callback_button_press (GtkWidget *widget,

--- a/libleptongui/include/preview_widget.h
+++ b/libleptongui/include/preview_widget.h
@@ -60,8 +60,8 @@ GschemToplevel*
 schematic_preview_get_window (GtkWidget *preview);
 
 void
-schematic_preview_update (SchematicPreview *preview,
-                          LeptonPage *preview_page,
-                          char *preview_buffer);
+schematic_preview_update (LeptonPage *preview_page,
+                          GList *objects,
+                          GError *err);
 
 G_END_DECLS

--- a/libleptongui/include/preview_widget.h
+++ b/libleptongui/include/preview_widget.h
@@ -54,6 +54,9 @@ schematic_preview_callback_scroll_event (GtkWidget *widget,
 gboolean
 schematic_preview_get_active (GtkWidget *preview);
 
+gchar*
+schematic_preview_get_buffer (GtkWidget *preview);
+
 GschemToplevel*
 schematic_preview_get_window (GtkWidget *preview);
 

--- a/libleptongui/include/preview_widget.h
+++ b/libleptongui/include/preview_widget.h
@@ -59,9 +59,4 @@ schematic_preview_get_filename (GtkWidget *preview);
 GschemToplevel*
 schematic_preview_get_window (GtkWidget *preview);
 
-void
-schematic_preview_update (LeptonPage *preview_page,
-                          GList *objects,
-                          GError *err);
-
 G_END_DECLS

--- a/libleptongui/include/preview_widget.h
+++ b/libleptongui/include/preview_widget.h
@@ -62,6 +62,7 @@ schematic_preview_get_window (GtkWidget *preview);
 void
 schematic_preview_update (SchematicPreview *preview,
                           LeptonPage *preview_page,
-                          LeptonToplevel *preview_toplevel);
+                          LeptonToplevel *preview_toplevel,
+                          gboolean preview_active);
 
 G_END_DECLS

--- a/libleptongui/include/preview_widget.h
+++ b/libleptongui/include/preview_widget.h
@@ -72,6 +72,7 @@ GschemToplevel*
 schematic_preview_get_window (GtkWidget *preview);
 
 void
-schematic_preview_callback_update (SchematicPreview *preview);
+schematic_preview_callback_update (SchematicPreview *preview,
+                                   gpointer user_data);
 
 G_END_DECLS

--- a/libleptongui/include/preview_widget.h
+++ b/libleptongui/include/preview_widget.h
@@ -62,9 +62,7 @@ schematic_preview_get_window (GtkWidget *preview);
 void
 schematic_preview_update (SchematicPreview *preview,
                           LeptonPage *preview_page,
-                          LeptonToplevel *preview_toplevel,
                           gboolean preview_active,
-                          char *preview_filename,
                           char *preview_buffer);
 
 G_END_DECLS

--- a/libleptongui/include/preview_widget.h
+++ b/libleptongui/include/preview_widget.h
@@ -62,7 +62,6 @@ schematic_preview_get_window (GtkWidget *preview);
 void
 schematic_preview_update (SchematicPreview *preview,
                           LeptonPage *preview_page,
-                          gboolean preview_active,
                           char *preview_buffer);
 
 G_END_DECLS

--- a/libleptongui/include/preview_widget.h
+++ b/libleptongui/include/preview_widget.h
@@ -73,6 +73,7 @@ schematic_preview_get_window (GtkWidget *preview);
 
 void
 schematic_preview_update (SchematicPreview *preview,
-                          LeptonPage *preview_page);
+                          LeptonPage *preview_page,
+                          LeptonToplevel *preview_toplevel);
 
 G_END_DECLS

--- a/libleptongui/include/preview_widget.h
+++ b/libleptongui/include/preview_widget.h
@@ -71,4 +71,7 @@ schematic_preview_callback_scroll_event (GtkWidget *widget,
 GschemToplevel*
 schematic_preview_get_window (GtkWidget *preview);
 
+void
+schematic_preview_callback_update (SchematicPreview *preview);
+
 G_END_DECLS

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -515,6 +515,9 @@ schematic_file_open (GschemToplevel *w_current,
                      LeptonPage *page,
                      const gchar *filename,
                      GError **err);
+void
+x_fileselect_callback_update_preview (GtkFileChooser *chooser,
+                                      gpointer user_data);
 
 /* x_fstylecb.c */
 GtkWidget* x_fstylecb_new ();

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -499,6 +499,9 @@ schematic_compselect_new (GschemToplevel *w_current);
 GtkWidget*
 schematic_file_select_dialog_new (GschemToplevel *w_current);
 
+void
+x_fileselect_add_preview (GtkFileChooser *filechooser);
+
 GSList*
 x_fileselect_open (GschemToplevel *w_current,
                    GtkWidget *dialog);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -500,8 +500,8 @@ GtkWidget*
 schematic_file_select_dialog_new (GschemToplevel *w_current);
 
 void
-x_fileselect_add_preview (GtkWidget *dialog);
-
+x_fileselect_add_preview (GtkWidget *dialog,
+                          GtkWidget *preview);
 GSList*
 x_fileselect_open (GschemToplevel *w_current,
                    GtkWidget *dialog);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -500,7 +500,7 @@ GtkWidget*
 schematic_file_select_dialog_new (GschemToplevel *w_current);
 
 void
-x_fileselect_add_preview (GtkFileChooser *filechooser);
+x_fileselect_add_preview (GtkWidget *dialog);
 
 GSList*
 x_fileselect_open (GschemToplevel *w_current,

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -496,8 +496,12 @@ schematic_compselect_new (GschemToplevel *w_current);
 
 
 /* x_fileselect.c */
+GtkWidget*
+schematic_file_select_dialog_new (GschemToplevel *w_current);
+
 GSList*
-x_fileselect_open (GschemToplevel *w_current);
+x_fileselect_open (GschemToplevel *w_current,
+                   GtkWidget *dialog);
 
 gboolean
 x_fileselect_save (GschemToplevel *w_current,

--- a/libleptongui/scheme/Makefile.am
+++ b/libleptongui/scheme/Makefile.am
@@ -25,6 +25,7 @@ nobase_dist_scmdata_DATA = \
 	schematic/gettext.scm \
 	schematic/dialog.scm \
 	schematic/dialog/file-select.scm \
+	schematic/preview-widget.scm \
 	schematic/dialog/slot-edit.scm \
 	schematic/ffi.scm \
 	schematic/ffi/gobject.scm \

--- a/libleptongui/scheme/schematic/callback.scm
+++ b/libleptongui/scheme/schematic/callback.scm
@@ -33,6 +33,7 @@
   #:use-module (schematic dialog file-select)
   #:use-module (schematic ffi)
   #:use-module (schematic gettext)
+  #:use-module (schematic preview-widget)
   #:use-module (schematic window foreign)
   #:use-module (schematic window)
 
@@ -135,15 +136,6 @@
 
 (define (callback-add-component *widget *window)
   (define window (pointer->window *window))
-  (define signal-callback-list
-    (list
-     (if %m4-use-gtk3
-         `("draw" . ,*x_event_draw)
-         `("expose-event" . ,*x_event_expose))
-     `("realize" . ,*schematic_preview_callback_realize)
-     `("button-press-event" . ,*schematic_preview_callback_button_press)
-     `("configure-event" . ,*x_event_configure)
-     `("scroll-event" . ,*schematic_preview_callback_scroll_event)))
 
   (o_redraw_cleanstates *window)
 
@@ -154,14 +146,8 @@
                                 (string->pointer "response")
                                 *x_compselect_callback_response
                                 *window)
-      (let ((*preview (schematic_compselect_get_preview *compselect-widget)))
-        (for-each
-         (lambda (element)
-           (schematic_signal_connect *preview
-                                     (string->pointer (car element))
-                                     (cdr element)
-                                     (schematic_preview_get_window *preview)))
-         signal-callback-list))
+      (init-preview-widget-signals
+       (schematic_compselect_get_preview *compselect-widget))
       (schematic_window_set_compselect *window *compselect-widget)))
   (x_compselect_open (schematic_window_get_compselect *window))
 

--- a/libleptongui/scheme/schematic/dialog/file-select.scm
+++ b/libleptongui/scheme/schematic/dialog/file-select.scm
@@ -25,6 +25,7 @@
   #:use-module (lepton ffi glib)
 
   #:use-module (schematic ffi)
+  #:use-module (schematic preview-widget)
   #:use-module (schematic window)
   #:use-module (schematic window foreign)
 
@@ -41,7 +42,9 @@ last loaded page."
     (let ((*dialog
            (schematic_file_select_dialog_new *window)))
       (when (true? (schematic_window_get_file_preview *window))
-        (x_fileselect_add_preview *dialog (schematic_preview_new)))
+        (x_fileselect_add_preview
+         *dialog
+         (init-preview-widget-signals (schematic_preview_new))))
       *dialog))
 
   (define filenames

--- a/libleptongui/scheme/schematic/dialog/file-select.scm
+++ b/libleptongui/scheme/schematic/dialog/file-select.scm
@@ -41,7 +41,7 @@ last loaded page."
     (let ((*dialog
            (schematic_file_select_dialog_new *window)))
       (when (true? (schematic_window_get_file_preview *window))
-        (x_fileselect_add_preview *dialog))
+        (x_fileselect_add_preview *dialog (schematic_preview_new)))
       *dialog))
 
   (define filenames

--- a/libleptongui/scheme/schematic/dialog/file-select.scm
+++ b/libleptongui/scheme/schematic/dialog/file-select.scm
@@ -42,9 +42,15 @@ last loaded page."
     (let ((*dialog
            (schematic_file_select_dialog_new *window)))
       (when (true? (schematic_window_get_file_preview *window))
-        (x_fileselect_add_preview
-         *dialog
-         (init-preview-widget-signals (schematic_preview_new))))
+        (let ((*preview (schematic_preview_new)))
+          (x_fileselect_add_preview
+           *dialog
+           (init-preview-widget-signals *preview))
+          ;; Connect callback to update preview.
+          (schematic_signal_connect *dialog
+                                    (string->pointer "update-preview")
+                                    *x_fileselect_callback_update_preview
+                                    *preview)))
       *dialog))
 
   (define filenames

--- a/libleptongui/scheme/schematic/dialog/file-select.scm
+++ b/libleptongui/scheme/schematic/dialog/file-select.scm
@@ -1,6 +1,6 @@
 ;;; Lepton EDA Schematic Capture
 ;;; Scheme API
-;;; Copyright (C) 2022 Lepton EDA Contributors
+;;; Copyright (C) 2022-2024 Lepton EDA Contributors
 ;;;
 ;;; This program is free software; you can redistribute it and/or modify
 ;;; it under the terms of the GNU General Public License as published by
@@ -36,8 +36,12 @@ pages.  The current page of the window is set to the page of the
 last loaded page."
   (define *window (check-window window 1))
 
+  (define *dialog (schematic_file_select_dialog_new *window))
+
   (define filenames
-    (gslist->list (x_fileselect_open *window) pointer->string 'free))
+    (gslist->list (x_fileselect_open *window
+                                     *dialog)
+                  pointer->string 'free))
 
   ;; Open each file.
   (define pages

--- a/libleptongui/scheme/schematic/dialog/file-select.scm
+++ b/libleptongui/scheme/schematic/dialog/file-select.scm
@@ -21,6 +21,7 @@
   #:use-module (srfi srfi-1)
   #:use-module (system foreign)
 
+  #:use-module (lepton ffi boolean)
   #:use-module (lepton ffi glib)
 
   #:use-module (schematic ffi)
@@ -36,12 +37,17 @@ pages.  The current page of the window is set to the page of the
 last loaded page."
   (define *window (check-window window 1))
 
-  (define *dialog (schematic_file_select_dialog_new *window))
+  (define (*make-dialog)
+    (let ((*dialog
+           (schematic_file_select_dialog_new *window)))
+      (when (true? (schematic_window_get_file_preview *window))
+        (x_fileselect_add_preview *dialog))
+      *dialog))
 
   (define filenames
-    (gslist->list (x_fileselect_open *window
-                                     *dialog)
-                  pointer->string 'free))
+    (gslist->list (x_fileselect_open *window (*make-dialog))
+                  pointer->string
+                  'free))
 
   ;; Open each file.
   (define pages

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -468,7 +468,7 @@
             schematic_event_control_mask
             schematic_event_shift_mask
 
-
+            schematic_file_select_dialog_new
             x_fileselect_open
             x_fileselect_save
             schematic_file_open
@@ -1008,7 +1008,8 @@
 (define-lff schematic_event_shift_mask int '())
 
 ;;; x_fileselect.c
-(define-lff x_fileselect_open '* '(*))
+(define-lff schematic_file_select_dialog_new '* '(*))
+(define-lff x_fileselect_open '* '(* *))
 (define-lff x_fileselect_save int '(* * *))
 (define-lff schematic_file_open int '(* * * *))
 

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -337,6 +337,7 @@
             *schematic_preview_callback_button_press
             *schematic_preview_callback_scroll_event
             schematic_preview_get_active
+            schematic_preview_get_buffer
             schematic_preview_get_window
 
             schematic_signal_connect
@@ -645,6 +646,7 @@
 (define-lfc *schematic_preview_callback_button_press)
 (define-lfc *schematic_preview_callback_scroll_event)
 (define-lff schematic_preview_get_active int '(*))
+(define-lff schematic_preview_get_buffer '* '(*))
 (define-lff schematic_preview_get_window '* '(*))
 
 ;;; schematic_hierarchy.c

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -465,7 +465,7 @@
             *x_event_configure
             *x_event_draw
             *x_event_expose
-            *x_event_scroll
+            x_event_scroll
             schematic_event_get_button
             schematic_event_is_double_button_press
             schematic_event_get_doing_stroke
@@ -1013,7 +1013,7 @@
 (define-lfc *x_event_configure)
 (define-lfc *x_event_draw)
 (define-lfc *x_event_expose)
-(define-lfc *x_event_scroll)
+(define-lff x_event_scroll int '(* * *))
 (define-lff schematic_event_get_button int '(*))
 (define-lff schematic_event_is_double_button_press int '(*))
 (define-lff schematic_event_get_doing_stroke int '())

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -475,6 +475,7 @@
             x_fileselect_add_preview
             x_fileselect_open
             x_fileselect_save
+            *x_fileselect_callback_update_preview
             schematic_file_open
 
             x_image_setup
@@ -1019,6 +1020,7 @@
 (define-lff x_fileselect_add_preview void '(* *))
 (define-lff x_fileselect_open '* '(* *))
 (define-lff x_fileselect_save int '(* * *))
+(define-lfc *x_fileselect_callback_update_preview)
 (define-lff schematic_file_open int '(* * * *))
 
 ;;; x_image.c

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -332,7 +332,6 @@
             schematic_page_view_grab_focus
 
             schematic_preview_new
-            schematic_preview_update
             *schematic_preview_callback_realize
             *schematic_preview_callback_button_press
             schematic_preview_get_active
@@ -645,7 +644,6 @@
 
 ;;; preview_widget.c
 (define-lff schematic_preview_new '* '())
-(define-lff schematic_preview_update void '(* * *))
 (define-lfc *schematic_preview_callback_realize)
 (define-lfc *schematic_preview_callback_button_press)
 (define-lff schematic_preview_get_active int '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -641,7 +641,7 @@
 
 ;;; preview_widget.c
 (define-lff schematic_preview_new '* '())
-(define-lff schematic_preview_update void (list '* '* '* int '*))
+(define-lff schematic_preview_update void (list '* '* '* int '* '*))
 (define-lfc *schematic_preview_callback_realize)
 (define-lfc *schematic_preview_callback_button_press)
 (define-lff schematic_preview_get_active int '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -639,7 +639,7 @@
 
 ;;; preview_widget.c
 (define-lff schematic_preview_new '* '())
-(define-lff schematic_preview_update void '(* *))
+(define-lff schematic_preview_update void '(* * *))
 (define-lfc *schematic_preview_callback_realize)
 (define-lfc *schematic_preview_callback_button_press)
 (define-lfc *schematic_preview_callback_scroll_event)

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -336,6 +336,7 @@
             *schematic_preview_callback_realize
             *schematic_preview_callback_button_press
             *schematic_preview_callback_scroll_event
+            schematic_preview_get_active
             schematic_preview_get_window
 
             schematic_signal_connect
@@ -643,6 +644,7 @@
 (define-lfc *schematic_preview_callback_realize)
 (define-lfc *schematic_preview_callback_button_press)
 (define-lfc *schematic_preview_callback_scroll_event)
+(define-lff schematic_preview_get_active int '(*))
 (define-lff schematic_preview_get_window '* '(*))
 
 ;;; schematic_hierarchy.c

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -332,10 +332,10 @@
             schematic_page_view_grab_focus
 
             schematic_preview_new
+            schematic_preview_update
             *schematic_preview_callback_realize
             *schematic_preview_callback_button_press
             *schematic_preview_callback_scroll_event
-            *schematic_preview_callback_update
             schematic_preview_get_window
 
             schematic_signal_connect
@@ -639,10 +639,10 @@
 
 ;;; preview_widget.c
 (define-lff schematic_preview_new '* '())
+(define-lff schematic_preview_update void '(* *))
 (define-lfc *schematic_preview_callback_realize)
 (define-lfc *schematic_preview_callback_button_press)
 (define-lfc *schematic_preview_callback_scroll_event)
-(define-lfc *schematic_preview_callback_update)
 (define-lff schematic_preview_get_window '* '(*))
 
 ;;; schematic_hierarchy.c

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -641,7 +641,7 @@
 
 ;;; preview_widget.c
 (define-lff schematic_preview_new '* '())
-(define-lff schematic_preview_update void '(* * *))
+(define-lff schematic_preview_update void (list '* '* '* int))
 (define-lfc *schematic_preview_callback_realize)
 (define-lfc *schematic_preview_callback_button_press)
 (define-lff schematic_preview_get_active int '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -471,6 +471,7 @@
             schematic_event_shift_mask
 
             schematic_file_select_dialog_new
+            x_fileselect_add_preview
             x_fileselect_open
             x_fileselect_save
             schematic_file_open
@@ -1013,6 +1014,7 @@
 
 ;;; x_fileselect.c
 (define-lff schematic_file_select_dialog_new '* '(*))
+(define-lff x_fileselect_add_preview void '(*))
 (define-lff x_fileselect_open '* '(* *))
 (define-lff x_fileselect_save int '(* * *))
 (define-lff schematic_file_open int '(* * * *))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -645,7 +645,7 @@
 
 ;;; preview_widget.c
 (define-lff schematic_preview_new '* '())
-(define-lff schematic_preview_update '* (list '* '* int '*))
+(define-lff schematic_preview_update void (list '* '* int '*))
 (define-lfc *schematic_preview_callback_realize)
 (define-lfc *schematic_preview_callback_button_press)
 (define-lff schematic_preview_get_active int '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -338,6 +338,7 @@
             *schematic_preview_callback_scroll_event
             schematic_preview_get_active
             schematic_preview_get_buffer
+            schematic_preview_get_filename
             schematic_preview_get_window
 
             schematic_signal_connect
@@ -647,6 +648,7 @@
 (define-lfc *schematic_preview_callback_scroll_event)
 (define-lff schematic_preview_get_active int '(*))
 (define-lff schematic_preview_get_buffer '* '(*))
+(define-lff schematic_preview_get_filename '* '(*))
 (define-lff schematic_preview_get_window '* '(*))
 
 ;;; schematic_hierarchy.c

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -331,6 +331,7 @@
             gschem_page_view_zoom_extents
             schematic_page_view_grab_focus
 
+            schematic_preview_new
             *schematic_preview_callback_realize
             *schematic_preview_callback_button_press
             *schematic_preview_callback_scroll_event
@@ -635,6 +636,7 @@
 (define-lff schematic_page_view_grab_focus void '(*))
 
 ;;; preview_widget.c
+(define-lff schematic_preview_new '* '())
 (define-lfc *schematic_preview_callback_realize)
 (define-lfc *schematic_preview_callback_button_press)
 (define-lfc *schematic_preview_callback_scroll_event)
@@ -1014,7 +1016,7 @@
 
 ;;; x_fileselect.c
 (define-lff schematic_file_select_dialog_new '* '(*))
-(define-lff x_fileselect_add_preview void '(*))
+(define-lff x_fileselect_add_preview void '(* *))
 (define-lff x_fileselect_open '* '(* *))
 (define-lff x_fileselect_save int '(* * *))
 (define-lff schematic_file_open int '(* * * *))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -641,7 +641,7 @@
 
 ;;; preview_widget.c
 (define-lff schematic_preview_new '* '())
-(define-lff schematic_preview_update void (list '* '* '* int))
+(define-lff schematic_preview_update void (list '* '* '* int '*))
 (define-lfc *schematic_preview_callback_realize)
 (define-lfc *schematic_preview_callback_button_press)
 (define-lff schematic_preview_get_active int '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -336,6 +336,7 @@
             *schematic_preview_callback_button_press
             *schematic_preview_callback_scroll_event
             schematic_preview_get_window
+            schematic_preview_callback_update
 
             schematic_signal_connect
 
@@ -642,6 +643,7 @@
 (define-lfc *schematic_preview_callback_button_press)
 (define-lfc *schematic_preview_callback_scroll_event)
 (define-lff schematic_preview_get_window '* '(*))
+(define-lff schematic_preview_callback_update void '(*))
 
 ;;; schematic_hierarchy.c
 (define-lff schematic_hierarchy_get_page_control_counter int '())

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -430,6 +430,10 @@
             gschem_options_widget_new
 
             gschem_page_geometry_set_viewport
+            gschem_page_geometry_set_world_bottom
+            gschem_page_geometry_set_world_left
+            gschem_page_geometry_set_world_right
+            gschem_page_geometry_set_world_top
 
             gschem_text_properties_widget_new
             text_edit_dialog
@@ -763,6 +767,10 @@
 
 ;;; gschem_page_geometry.c
 (define-lff gschem_page_geometry_set_viewport void (list '* int int double))
+(define-lff gschem_page_geometry_set_world_bottom void (list '* int))
+(define-lff gschem_page_geometry_set_world_left void (list '* int))
+(define-lff gschem_page_geometry_set_world_right void (list '* int))
+(define-lff gschem_page_geometry_set_world_top void (list '* int))
 
 ;;; gschem_text_properties_widget.c
 (define-lff gschem_text_properties_widget_new '* '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -335,7 +335,6 @@
             schematic_preview_update
             *schematic_preview_callback_realize
             *schematic_preview_callback_button_press
-            *schematic_preview_callback_scroll_event
             schematic_preview_get_active
             schematic_preview_get_buffer
             schematic_preview_get_filename
@@ -645,7 +644,6 @@
 (define-lff schematic_preview_update void '(* * *))
 (define-lfc *schematic_preview_callback_realize)
 (define-lfc *schematic_preview_callback_button_press)
-(define-lfc *schematic_preview_callback_scroll_event)
 (define-lff schematic_preview_get_active int '(*))
 (define-lff schematic_preview_get_buffer '* '(*))
 (define-lff schematic_preview_get_filename '* '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -360,6 +360,8 @@
             schematic_window_get_draw_grips
             schematic_window_set_draw_grips
             schematic_window_get_enforce_hierarchy
+            schematic_window_get_file_preview
+            schematic_window_set_file_preview
             schematic_window_set_first_wx
             schematic_window_set_first_wy
             schematic_window_get_second_wx
@@ -679,6 +681,8 @@
 (define-lff schematic_window_get_draw_grips int '(*))
 (define-lff schematic_window_set_draw_grips void (list '* int))
 (define-lff schematic_window_get_enforce_hierarchy int '(*))
+(define-lff schematic_window_get_file_preview int '(*))
+(define-lff schematic_window_set_file_preview void (list int '*))
 (define-lff schematic_window_set_first_wx void (list '* int))
 (define-lff schematic_window_set_first_wy void (list '* int))
 (define-lff schematic_window_get_second_wx int '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -645,7 +645,7 @@
 
 ;;; preview_widget.c
 (define-lff schematic_preview_new '* '())
-(define-lff schematic_preview_update void (list '* '* int '*))
+(define-lff schematic_preview_update '* (list '* '* int '*))
 (define-lfc *schematic_preview_callback_realize)
 (define-lfc *schematic_preview_callback_button_press)
 (define-lff schematic_preview_get_active int '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -335,8 +335,8 @@
             *schematic_preview_callback_realize
             *schematic_preview_callback_button_press
             *schematic_preview_callback_scroll_event
+            *schematic_preview_callback_update
             schematic_preview_get_window
-            schematic_preview_callback_update
 
             schematic_signal_connect
 
@@ -642,8 +642,8 @@
 (define-lfc *schematic_preview_callback_realize)
 (define-lfc *schematic_preview_callback_button_press)
 (define-lfc *schematic_preview_callback_scroll_event)
+(define-lfc *schematic_preview_callback_update)
 (define-lff schematic_preview_get_window '* '(*))
-(define-lff schematic_preview_callback_update void '(*))
 
 ;;; schematic_hierarchy.c
 (define-lff schematic_hierarchy_get_page_control_counter int '())

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -641,7 +641,7 @@
 
 ;;; preview_widget.c
 (define-lff schematic_preview_new '* '())
-(define-lff schematic_preview_update void (list '* '* '* int '* '*))
+(define-lff schematic_preview_update void (list '* '* int '*))
 (define-lfc *schematic_preview_callback_realize)
 (define-lfc *schematic_preview_callback_button_press)
 (define-lff schematic_preview_get_active int '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -645,7 +645,7 @@
 
 ;;; preview_widget.c
 (define-lff schematic_preview_new '* '())
-(define-lff schematic_preview_update void (list '* '* int '*))
+(define-lff schematic_preview_update void '(* * *))
 (define-lfc *schematic_preview_callback_realize)
 (define-lfc *schematic_preview_callback_button_press)
 (define-lff schematic_preview_get_active int '(*))

--- a/libleptongui/scheme/schematic/preview-widget.scm
+++ b/libleptongui/scheme/schematic/preview-widget.scm
@@ -29,6 +29,11 @@
 
   #:export (init-preview-widget-signals))
 
+;;; Flags defined in struct.h.
+(define F_OPEN_RC 1)
+(define F_OPEN_CHECK_BACKUP 2)
+(define F_OPEN_FORCE_BACKUP 4)
+(define F_OPEN_RESTORE_CWD 8)
 
 (define (update-preview *preview *user-data)
   (if (null-pointer? *preview)
@@ -45,11 +50,20 @@
               (unless (or (null-pointer? *preview_filename)
                           (null-pointer? *preview_buffer))
                 (error "Either preview filename or buffer has to be NULL!")))
+            (when (true? preview_active)
+              (unless (null-pointer? *preview_filename)
+                ;; Open up file in current page.
+                ;; FIXME: Test the value returned by f_open(), we
+                ;; should display something if there an error
+                ;; occured.
+                (f_open *toplevel
+                        *page
+                        *preview_filename
+                        (logior F_OPEN_RC F_OPEN_RESTORE_CWD)
+                        %null-pointer)))
             (schematic_preview_update *preview
                                       *page
-                                      *toplevel
                                       preview_active
-                                      *preview_filename
                                       *preview_buffer)
             ;; Display current page (possibly empty).
             (gschem_page_view_zoom_extents *preview %null-pointer))))))

--- a/libleptongui/scheme/schematic/preview-widget.scm
+++ b/libleptongui/scheme/schematic/preview-widget.scm
@@ -36,9 +36,10 @@
         (unless (null-pointer? *page)
           ;; Delete old preview.
           (lepton_page_delete_objects *page)
-          (schematic_preview_update *preview *page)
-          ;; Display current page (possibly empty).
-          (gschem_page_view_zoom_extents *preview %null-pointer)))))
+          (let ((*toplevel (lepton_page_get_toplevel *page)))
+            (schematic_preview_update *preview *page *toplevel)
+            ;; Display current page (possibly empty).
+            (gschem_page_view_zoom_extents *preview %null-pointer))))))
 
 
 (define *update-preview

--- a/libleptongui/scheme/schematic/preview-widget.scm
+++ b/libleptongui/scheme/schematic/preview-widget.scm
@@ -37,8 +37,9 @@
         (unless (null-pointer? *page)
           ;; Delete old preview.
           (lepton_page_delete_objects *page)
-          (let ((*toplevel (lepton_page_get_toplevel *page)))
-            (schematic_preview_update *preview *page *toplevel)
+          (let ((*toplevel (lepton_page_get_toplevel *page))
+                (preview_active (schematic_preview_get_active *preview)))
+            (schematic_preview_update *preview *page *toplevel preview_active)
             ;; Display current page (possibly empty).
             (gschem_page_view_zoom_extents *preview %null-pointer))))))
 

--- a/libleptongui/scheme/schematic/preview-widget.scm
+++ b/libleptongui/scheme/schematic/preview-widget.scm
@@ -20,6 +20,7 @@
 (define-module (schematic preview-widget)
   #:use-module (system foreign)
 
+  #:use-module (lepton ffi)
   #:use-module (lepton log)
   #:use-module (lepton m4)
 
@@ -33,6 +34,8 @@
       (log! 'warning "NULL preview widget")
       (let ((*page (gschem_page_view_get_page *preview)))
         (unless (null-pointer? *page)
+          ;; Delete old preview.
+          (lepton_page_delete_objects *page)
           (schematic_preview_update *preview *page)
           ;; Display current page (possibly empty).
           (gschem_page_view_zoom_extents *preview %null-pointer)))))

--- a/libleptongui/scheme/schematic/preview-widget.scm
+++ b/libleptongui/scheme/schematic/preview-widget.scm
@@ -29,6 +29,8 @@
   #:use-module (lepton gerror)
   #:use-module (lepton log)
   #:use-module (lepton m4)
+  #:use-module (lepton object foreign)
+  #:use-module (lepton object)
 
   #:use-module (schematic ffi)
   #:use-module (schematic gettext)
@@ -92,16 +94,15 @@ buffer should be displayed, the widget displays the error message."
                         (lepton_page_append_list *page *objects)
                         (begin
                           (lepton_page_append *page
-                                              (lepton_text_object_new 2
-                                                                      100
-                                                                      100
-                                                                      3 ; LOWER_MIDDLE from defines.h
-                                                                      0
-                                                                      (string->pointer (gerror-message *err))
-                                                                      10
-                                                                      1 ; VISIBLE from defines.h
-                                                                      0 ; SHOW_NAME_VALUE from defines.h
-                                                                      ))
+                                              (object->pointer
+                                               (make-text '(100 . 100)
+                                                          'lower-center
+                                                          0
+                                                          (gerror-message *err)
+                                                          10
+                                                          #t
+                                                          'both
+                                                          2)))
                           (g_clear_error *error)))))))
             (let-values (((left top right bottom)
                           (object-list-bounds

--- a/libleptongui/scheme/schematic/preview-widget.scm
+++ b/libleptongui/scheme/schematic/preview-widget.scm
@@ -38,8 +38,13 @@
           ;; Delete old preview.
           (lepton_page_delete_objects *page)
           (let ((*toplevel (lepton_page_get_toplevel *page))
-                (preview_active (schematic_preview_get_active *preview)))
-            (schematic_preview_update *preview *page *toplevel preview_active)
+                (preview_active (schematic_preview_get_active *preview))
+                (*preview_filename (schematic_preview_get_filename *preview)))
+            (schematic_preview_update *preview
+                                      *page
+                                      *toplevel
+                                      preview_active
+                                      *preview_filename)
             ;; Display current page (possibly empty).
             (gschem_page_view_zoom_extents *preview %null-pointer))))))
 

--- a/libleptongui/scheme/schematic/preview-widget.scm
+++ b/libleptongui/scheme/schematic/preview-widget.scm
@@ -47,11 +47,11 @@
   (procedure->pointer void update-preview '(* *)))
 
 (define (scroll-preview *preview *scroll-event *window)
-  (if (not (true? (schematic_preview_get_active *preview)))
-      TRUE
+  (if (true? (schematic_preview_get_active *preview))
       (x_event_scroll *preview
                       *scroll-event
-                      (schematic_preview_get_window *preview))))
+                      (schematic_preview_get_window *preview))
+      TRUE))
 
 (define *scroll-preview
   (procedure->pointer int scroll-preview '(* * *)))

--- a/libleptongui/scheme/schematic/preview-widget.scm
+++ b/libleptongui/scheme/schematic/preview-widget.scm
@@ -1,0 +1,53 @@
+;;; Lepton EDA Schematic Capture
+;;; Scheme API
+;;; Copyright (C) 2022-2024 Lepton EDA Contributors
+;;;
+;;; This program is free software; you can redistribute it and/or modify
+;;; it under the terms of the GNU General Public License as published by
+;;; the Free Software Foundation; either version 2 of the License, or
+;;; (at your option) any later version.
+;;;
+;;; This program is distributed in the hope that it will be useful,
+;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;; GNU General Public License for more details.
+;;;
+;;; You should have received a copy of the GNU General Public License
+;;; along with this program; if not, write to the Free Software
+;;; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
+(define-module (schematic preview-widget)
+  #:use-module (system foreign)
+
+  #:use-module (lepton m4)
+
+  #:use-module (schematic ffi)
+
+  #:export (init-preview-widget-signals))
+
+
+;;; The list of pairs (NAME . CALLBACK) for initialization of
+;;; preview widgets.
+(define %signal-callback-list
+  (list
+   (if %m4-use-gtk3
+       `("draw" . ,*x_event_draw)
+       `("expose-event" . ,*x_event_expose))
+   `("realize" . ,*schematic_preview_callback_realize)
+   `("button-press-event" . ,*schematic_preview_callback_button_press)
+   `("configure-event" . ,*x_event_configure)
+   `("scroll-event" . ,*schematic_preview_callback_scroll_event)))
+
+
+(define (init-preview-widget-signals *preview)
+  "Initialize the preview widget *PREVIEW by connecting to it
+appropriate signals.  Return *PREVIEW."
+  (for-each
+   (lambda (element)
+     (schematic_signal_connect *preview
+                               (string->pointer (car element))
+                               (cdr element)
+                               (schematic_preview_get_window *preview)))
+   %signal-callback-list)
+  *preview)

--- a/libleptongui/scheme/schematic/preview-widget.scm
+++ b/libleptongui/scheme/schematic/preview-widget.scm
@@ -21,6 +21,7 @@
   #:use-module (system foreign)
 
   #:use-module (lepton ffi)
+  #:use-module (lepton ffi boolean)
   #:use-module (lepton log)
   #:use-module (lepton m4)
 
@@ -45,6 +46,15 @@
 (define *update-preview
   (procedure->pointer void update-preview '(* *)))
 
+(define (scroll-preview *preview *scroll-event *window)
+  (if (not (true? (schematic_preview_get_active *preview)))
+      TRUE
+      (x_event_scroll *preview
+                      *scroll-event
+                      (schematic_preview_get_window *preview))))
+
+(define *scroll-preview
+  (procedure->pointer int scroll-preview '(* * *)))
 
 ;;; The list of pairs (NAME . CALLBACK) for initialization of
 ;;; preview widgets.
@@ -56,7 +66,7 @@
    `("realize" . ,*schematic_preview_callback_realize)
    `("button-press-event" . ,*schematic_preview_callback_button_press)
    `("configure-event" . ,*x_event_configure)
-   `("scroll-event" . ,*schematic_preview_callback_scroll_event)
+   `("scroll-event" . ,*scroll-preview)
    `("update-preview" . ,*update-preview)))
 
 

--- a/libleptongui/scheme/schematic/preview-widget.scm
+++ b/libleptongui/scheme/schematic/preview-widget.scm
@@ -20,6 +20,7 @@
 (define-module (schematic preview-widget)
   #:use-module (system foreign)
 
+  #:use-module (lepton log)
   #:use-module (lepton m4)
 
   #:use-module (schematic ffi)
@@ -28,10 +29,12 @@
 
 
 (define (update-preview *preview *user-data)
-  (schematic_preview_update *preview %null-pointer)
-
-  ;; Display current page (possibly empty).
-  (gschem_page_view_zoom_extents *preview %null-pointer))
+  (if (null-pointer? *preview)
+      (log! 'warning "NULL preview widget")
+      (begin
+        (schematic_preview_update *preview %null-pointer)
+        ;; Display current page (possibly empty).
+        (gschem_page_view_zoom_extents *preview %null-pointer))))
 
 
 (define *update-preview

--- a/libleptongui/scheme/schematic/preview-widget.scm
+++ b/libleptongui/scheme/schematic/preview-widget.scm
@@ -41,6 +41,10 @@
                 (preview_active (schematic_preview_get_active *preview))
                 (*preview_filename (schematic_preview_get_filename *preview))
                 (*preview_buffer (schematic_preview_get_buffer *preview)))
+            (when (true? preview_active)
+              (unless (or (null-pointer? *preview_filename)
+                          (null-pointer? *preview_buffer))
+                (error "Either preview filename or buffer has to be NULL!")))
             (schematic_preview_update *preview
                                       *page
                                       *toplevel

--- a/libleptongui/scheme/schematic/preview-widget.scm
+++ b/libleptongui/scheme/schematic/preview-widget.scm
@@ -66,11 +66,10 @@
                         *page
                         *preview_filename
                         (logior F_OPEN_RC F_OPEN_RESTORE_CWD)
-                        %null-pointer)))
-            (schematic_preview_update *preview
-                            *page
-                            preview_active
-                            *preview_buffer)
+                        %null-pointer))
+              (schematic_preview_update *preview
+                                        *page
+                                        *preview_buffer))
             (let-values (((left top right bottom)
                           (object-list-bounds
                            (lepton_page_objects *page)

--- a/libleptongui/scheme/schematic/preview-widget.scm
+++ b/libleptongui/scheme/schematic/preview-widget.scm
@@ -37,7 +37,8 @@
    `("realize" . ,*schematic_preview_callback_realize)
    `("button-press-event" . ,*schematic_preview_callback_button_press)
    `("configure-event" . ,*x_event_configure)
-   `("scroll-event" . ,*schematic_preview_callback_scroll_event)))
+   `("scroll-event" . ,*schematic_preview_callback_scroll_event)
+   `("update-preview" . ,*schematic_preview_callback_update)))
 
 
 (define (init-preview-widget-signals *preview)

--- a/libleptongui/scheme/schematic/preview-widget.scm
+++ b/libleptongui/scheme/schematic/preview-widget.scm
@@ -79,21 +79,19 @@
                 (when left
                   ;; Clamp the canvas size to the extents of the
                   ;; page being previewed.
-                  (let ((width (- right left))
-                        (height (- bottom top))
+                  (let ((width-add (inexact->exact (round (* %over-zoom-factor
+                                                             (- right left)))))
+                        (height-add (inexact->exact (round (* %over-zoom-factor
+                                                              (- bottom top)))))
                         (*geometry (gschem_page_view_get_page_geometry *view)))
                     (gschem_page_geometry_set_world_left *geometry
-                                                         (inexact->exact
-                                                          (round (- left (* width %over-zoom-factor)))))
+                                                         (- left width-add))
                     (gschem_page_geometry_set_world_right *geometry
-                                                          (inexact->exact
-                                                           (round (+ right (* width %over-zoom-factor)))))
+                                                          (+ right width-add))
                     (gschem_page_geometry_set_world_top *geometry
-                                                        (inexact->exact
-                                                         (round (- top (* height %over-zoom-factor)))))
+                                                        (- top height-add))
                     (gschem_page_geometry_set_world_bottom *geometry
-                                                           (inexact->exact
-                                                            (round (+ bottom (* height %over-zoom-factor)))))))))
+                                                           (+ bottom height-add))))))
             ;; Display current page (possibly empty).
             (gschem_page_view_zoom_extents *preview %null-pointer))))))
 

--- a/libleptongui/scheme/schematic/preview-widget.scm
+++ b/libleptongui/scheme/schematic/preview-widget.scm
@@ -28,7 +28,10 @@
 
 
 (define (update-preview *preview *user-data)
-  (schematic_preview_update *preview %null-pointer))
+  (schematic_preview_update *preview %null-pointer)
+
+  ;; Display current page (possibly empty).
+  (gschem_page_view_zoom_extents *preview %null-pointer))
 
 
 (define *update-preview

--- a/libleptongui/scheme/schematic/preview-widget.scm
+++ b/libleptongui/scheme/schematic/preview-widget.scm
@@ -39,12 +39,14 @@
           (lepton_page_delete_objects *page)
           (let ((*toplevel (lepton_page_get_toplevel *page))
                 (preview_active (schematic_preview_get_active *preview))
-                (*preview_filename (schematic_preview_get_filename *preview)))
+                (*preview_filename (schematic_preview_get_filename *preview))
+                (*preview_buffer (schematic_preview_get_buffer *preview)))
             (schematic_preview_update *preview
                                       *page
                                       *toplevel
                                       preview_active
-                                      *preview_filename)
+                                      *preview_filename
+                                      *preview_buffer)
             ;; Display current page (possibly empty).
             (gschem_page_view_zoom_extents *preview %null-pointer))))))
 

--- a/libleptongui/scheme/schematic/preview-widget.scm
+++ b/libleptongui/scheme/schematic/preview-widget.scm
@@ -67,9 +67,10 @@
                         *preview_filename
                         (logior F_OPEN_RC F_OPEN_RESTORE_CWD)
                         %null-pointer))
-              (schematic_preview_update *preview
-                                        *page
-                                        *preview_buffer))
+              (unless (null-pointer? *preview_buffer)
+                (schematic_preview_update *preview
+                                          *page
+                                          *preview_buffer)))
             (let-values (((left top right bottom)
                           (object-list-bounds
                            (lepton_page_objects *page)

--- a/libleptongui/scheme/schematic/preview-widget.scm
+++ b/libleptongui/scheme/schematic/preview-widget.scm
@@ -27,6 +27,14 @@
   #:export (init-preview-widget-signals))
 
 
+(define (update-preview *preview *user-data)
+  (schematic_preview_update *preview %null-pointer))
+
+
+(define *update-preview
+  (procedure->pointer void update-preview '(* *)))
+
+
 ;;; The list of pairs (NAME . CALLBACK) for initialization of
 ;;; preview widgets.
 (define %signal-callback-list
@@ -38,7 +46,7 @@
    `("button-press-event" . ,*schematic_preview_callback_button_press)
    `("configure-event" . ,*x_event_configure)
    `("scroll-event" . ,*schematic_preview_callback_scroll_event)
-   `("update-preview" . ,*schematic_preview_callback_update)))
+   `("update-preview" . ,*update-preview)))
 
 
 (define (init-preview-widget-signals *preview)

--- a/libleptongui/scheme/schematic/preview-widget.scm
+++ b/libleptongui/scheme/schematic/preview-widget.scm
@@ -67,31 +67,31 @@
                         *preview_filename
                         (logior F_OPEN_RC F_OPEN_RESTORE_CWD)
                         %null-pointer)))
-            (let ((*view (schematic_preview_update *preview
-                                                   *page
-                                                   preview_active
-                                                   *preview_buffer)))
-              (let-values (((left top right bottom)
-                            (object-list-bounds
-                             (lepton_page_objects *page)
-                             ;; Do not include hidden text.
-                             FALSE)))
-                (when left
-                  ;; Clamp the canvas size to the extents of the
-                  ;; page being previewed.
-                  (let ((width-add (inexact->exact (round (* %over-zoom-factor
-                                                             (- right left)))))
-                        (height-add (inexact->exact (round (* %over-zoom-factor
-                                                              (- bottom top)))))
-                        (*geometry (gschem_page_view_get_page_geometry *view)))
-                    (gschem_page_geometry_set_world_left *geometry
-                                                         (- left width-add))
-                    (gschem_page_geometry_set_world_right *geometry
-                                                          (+ right width-add))
-                    (gschem_page_geometry_set_world_top *geometry
-                                                        (- top height-add))
-                    (gschem_page_geometry_set_world_bottom *geometry
-                                                           (+ bottom height-add))))))
+            (schematic_preview_update *preview
+                            *page
+                            preview_active
+                            *preview_buffer)
+            (let-values (((left top right bottom)
+                          (object-list-bounds
+                           (lepton_page_objects *page)
+                           ;; Do not include hidden text.
+                           FALSE)))
+              (when left
+                ;; Clamp the canvas size to the extents of the
+                ;; page being previewed.
+                (let ((width-add (inexact->exact (round (* %over-zoom-factor
+                                                           (- right left)))))
+                      (height-add (inexact->exact (round (* %over-zoom-factor
+                                                            (- bottom top)))))
+                      (*geometry (gschem_page_view_get_page_geometry *preview)))
+                  (gschem_page_geometry_set_world_left *geometry
+                                                       (- left width-add))
+                  (gschem_page_geometry_set_world_right *geometry
+                                                        (+ right width-add))
+                  (gschem_page_geometry_set_world_top *geometry
+                                                      (- top height-add))
+                  (gschem_page_geometry_set_world_bottom *geometry
+                                                         (+ bottom height-add)))))
             ;; Display current page (possibly empty).
             (gschem_page_view_zoom_extents *preview %null-pointer))))))
 

--- a/libleptongui/scheme/schematic/preview-widget.scm
+++ b/libleptongui/scheme/schematic/preview-widget.scm
@@ -31,10 +31,11 @@
 (define (update-preview *preview *user-data)
   (if (null-pointer? *preview)
       (log! 'warning "NULL preview widget")
-      (begin
-        (schematic_preview_update *preview %null-pointer)
-        ;; Display current page (possibly empty).
-        (gschem_page_view_zoom_extents *preview %null-pointer))))
+      (let ((*page (gschem_page_view_get_page *preview)))
+        (unless (null-pointer? *page)
+          (schematic_preview_update *preview *page)
+          ;; Display current page (possibly empty).
+          (gschem_page_view_zoom_extents *preview %null-pointer)))))
 
 
 (define *update-preview

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -703,6 +703,13 @@
   (procedure->pointer int callback-motion '(* * *)))
 
 
+(define (callback-scroll *widget *event *window)
+  (x_event_scroll *widget *event *window))
+
+(define *callback-scroll
+  (procedure->pointer int callback-scroll '(* * *)))
+
+
 (define (setup-page-view-draw-events *window *page-view)
   (define signal-callback-list
     (list
@@ -715,7 +722,7 @@
      `("configure-event" . ,*x_event_configure)
      `("key-press-event" . ,*process-key-event)
      `("key-release-event" . ,*process-key-event)
-     `("scroll-event" . ,*x_event_scroll)
+     `("scroll-event" . ,*callback-scroll)
      `("update-grid-info" . ,*i_update_grid_info_callback)
      `("notify::page" . ,*gschem_toplevel_notify_page_callback)))
 

--- a/libleptongui/src/preview_widget.c
+++ b/libleptongui/src/preview_widget.c
@@ -193,8 +193,6 @@ schematic_preview_update (SchematicPreview *preview,
 
   if (preview_active)
   {
-    g_assert ((preview_filename == NULL)
-              || (preview_buffer == NULL));
     if (preview_filename != NULL) {
       /* open up file in current page */
       f_open (preview_toplevel,

--- a/libleptongui/src/preview_widget.c
+++ b/libleptongui/src/preview_widget.c
@@ -437,6 +437,20 @@ schematic_preview_finalize (GObject *self)
 }
 
 
+/*! \brief Get the field \a active of this preview.
+ *
+ *  \param [in] preview The preview.
+ *  \return The \a active field.
+ */
+gboolean
+schematic_preview_get_active (GtkWidget *preview)
+{
+  g_return_val_if_fail (preview != NULL, FALSE);
+
+  return SCHEMATIC_PREVIEW (preview)->active;
+}
+
+
 /*! \brief Get the field \a preview_w_current of this preview.
  *
  *  \param [in] preview The preview.

--- a/libleptongui/src/preview_widget.c
+++ b/libleptongui/src/preview_widget.c
@@ -240,10 +240,10 @@ schematic_preview_update (SchematicPreview *preview,
     height = bottom - top;
 
     GschemPageGeometry *geometry = gschem_page_view_get_page_geometry (preview_view);
-    geometry->world_left   = left   - ((double)width  * OVER_ZOOM_FACTOR);
-    geometry->world_right  = right  + ((double)width  * OVER_ZOOM_FACTOR);
-    geometry->world_top    = top    - ((double)height * OVER_ZOOM_FACTOR);
-    geometry->world_bottom = bottom + ((double)height * OVER_ZOOM_FACTOR);
+    gschem_page_geometry_set_world_left   (geometry, left   - ((double)width  * OVER_ZOOM_FACTOR));
+    gschem_page_geometry_set_world_right  (geometry, right  + ((double)width  * OVER_ZOOM_FACTOR));
+    gschem_page_geometry_set_world_top    (geometry, top    - ((double)height * OVER_ZOOM_FACTOR));
+    gschem_page_geometry_set_world_bottom (geometry, bottom + ((double)height * OVER_ZOOM_FACTOR));
   }
 }
 

--- a/libleptongui/src/preview_widget.c
+++ b/libleptongui/src/preview_widget.c
@@ -180,7 +180,8 @@ schematic_preview_callback_button_press (GtkWidget *widget,
 void
 schematic_preview_update (SchematicPreview *preview,
                           LeptonPage *preview_page,
-                          LeptonToplevel *preview_toplevel)
+                          LeptonToplevel *preview_toplevel,
+                          gboolean preview_active)
 {
   int left, top, right, bottom;
   int width, height;
@@ -188,7 +189,8 @@ schematic_preview_update (SchematicPreview *preview,
 
   GschemPageView *preview_view = GSCHEM_PAGE_VIEW (preview);
 
-  if (schematic_preview_get_active (GTK_WIDGET (preview))) {
+  if (preview_active)
+  {
     g_assert ((schematic_preview_get_filename (GTK_WIDGET (preview)) == NULL)
               || (schematic_preview_get_buffer (GTK_WIDGET (preview)) == NULL));
     if (schematic_preview_get_filename (GTK_WIDGET (preview)) != NULL) {

--- a/libleptongui/src/preview_widget.c
+++ b/libleptongui/src/preview_widget.c
@@ -284,9 +284,7 @@ schematic_preview_callback_scroll_event (GtkWidget *widget,
 GtkWidget*
 schematic_preview_new ()
 {
-  SchematicPreview *preview = SCHEMATIC_PREVIEW (g_object_new (SCHEMATIC_TYPE_PREVIEW, NULL));
-
-  return GTK_WIDGET (preview);
+  return GTK_WIDGET (g_object_new (SCHEMATIC_TYPE_PREVIEW, NULL));
 }
 
 

--- a/libleptongui/src/preview_widget.c
+++ b/libleptongui/src/preview_widget.c
@@ -165,25 +165,16 @@ schematic_preview_callback_button_press (GtkWidget *widget,
  *  filename has been given, it opens the file and displays
  *  it. Otherwise it displays a blank page.
  *
- *  \param [in] preview The preview widget.
  *  \param [in] preview_page The \c LeptonPage object of the preview.
- *  \param [in] preview_buffer The buffer to read the preview
- *                             data from.
+ *  \param [in] objects The list of objects to display.
+ *  \param [in,out] err \c GError structure for error reporting, or
+ *                      NULL to disable error reporting.
  */
 void
-schematic_preview_update (SchematicPreview *preview,
-                          LeptonPage *preview_page,
-                          char *preview_buffer)
+schematic_preview_update (LeptonPage *preview_page,
+                          GList *objects,
+                          GError *err)
 {
-  GError * err = NULL;
-
-  /* Load the data buffer */
-  GList * objects = o_read_buffer (preview_page,
-                                   NULL,
-                                   preview_buffer,
-                                   -1,
-                                   _("Preview Buffer"),
-                                   &err);
   if (err == NULL) {
     lepton_page_append_list (preview_page, objects);
   }

--- a/libleptongui/src/preview_widget.c
+++ b/libleptongui/src/preview_widget.c
@@ -296,7 +296,7 @@ schematic_preview_callback_scroll_event (GtkWidget *widget,
                                          GdkEventScroll *event,
                                          GschemToplevel *w_current)
 {
-  if (!SCHEMATIC_PREVIEW (widget)->active) {
+  if (!schematic_preview_get_active (widget)) {
     return TRUE;
   }
   return x_event_scroll (widget, event, SCHEMATIC_PREVIEW (widget)->window);

--- a/libleptongui/src/preview_widget.c
+++ b/libleptongui/src/preview_widget.c
@@ -177,30 +177,28 @@ schematic_preview_update (SchematicPreview *preview,
 {
   GError * err = NULL;
 
-  if (preview_buffer != NULL) {
-    /* Load the data buffer */
-    GList * objects = o_read_buffer (preview_page,
-                                     NULL,
-                                     preview_buffer,
-                                     -1,
-                                     _("Preview Buffer"),
-                                     &err);
-    if (err == NULL) {
-      lepton_page_append_list (preview_page, objects);
-    }
-    else {
-      lepton_page_append (preview_page,
-                          lepton_text_object_new (2,
-                                                  100,
-                                                  100,
-                                                  LOWER_MIDDLE,
-                                                  0,
-                                                  err->message,
-                                                  10,
-                                                  VISIBLE,
-                                                  SHOW_NAME_VALUE));
-      g_error_free(err);
-    }
+  /* Load the data buffer */
+  GList * objects = o_read_buffer (preview_page,
+                                   NULL,
+                                   preview_buffer,
+                                   -1,
+                                   _("Preview Buffer"),
+                                   &err);
+  if (err == NULL) {
+    lepton_page_append_list (preview_page, objects);
+  }
+  else {
+    lepton_page_append (preview_page,
+                        lepton_text_object_new (2,
+                                                100,
+                                                100,
+                                                LOWER_MIDDLE,
+                                                0,
+                                                err->message,
+                                                10,
+                                                VISIBLE,
+                                                SHOW_NAME_VALUE));
+    g_error_free(err);
   }
 }
 

--- a/libleptongui/src/preview_widget.c
+++ b/libleptongui/src/preview_widget.c
@@ -162,7 +162,6 @@ schematic_preview_update (SchematicPreview *preview,
 
   GschemPageView *preview_view = GSCHEM_PAGE_VIEW (preview);
 
-  g_return_if_fail (preview_view != NULL);
   LeptonPage *preview_page = gschem_page_view_get_page (preview_view);
 
   if (preview_page == NULL) {

--- a/libleptongui/src/preview_widget.c
+++ b/libleptongui/src/preview_widget.c
@@ -171,6 +171,7 @@ schematic_preview_callback_button_press (GtkWidget *widget,
  *  \param [in] preview_page The \c LeptonPage object of the preview.
  *  \param [in] preview_toplevel The \c LeptonToplevel object of
  *                               the preview page.
+ *  \param [in] preview_active If the preview should be updated.
  */
 void
 schematic_preview_update (SchematicPreview *preview,
@@ -183,7 +184,7 @@ schematic_preview_update (SchematicPreview *preview,
 
   GschemPageView *preview_view = GSCHEM_PAGE_VIEW (preview);
 
-  if (preview->active) {
+  if (schematic_preview_get_active (GTK_WIDGET (preview))) {
     g_assert ((preview->filename == NULL) || (preview->buffer == NULL));
     if (preview->filename != NULL) {
       /* open up file in current page */

--- a/libleptongui/src/preview_widget.c
+++ b/libleptongui/src/preview_widget.c
@@ -291,20 +291,6 @@ schematic_preview_class_init (SchematicPreviewClass *klass)
 }
 
 
-gboolean
-schematic_preview_callback_scroll_event (GtkWidget *widget,
-                                         GdkEventScroll *event,
-                                         GschemToplevel *w_current)
-{
-  if (!schematic_preview_get_active (widget)) {
-    return TRUE;
-  }
-  return x_event_scroll (widget,
-                         event,
-                         schematic_preview_get_window (widget));
-}
-
-
 /*! \brief create a new preview widget
  */
 GtkWidget*

--- a/libleptongui/src/preview_widget.c
+++ b/libleptongui/src/preview_widget.c
@@ -299,7 +299,9 @@ schematic_preview_callback_scroll_event (GtkWidget *widget,
   if (!schematic_preview_get_active (widget)) {
     return TRUE;
   }
-  return x_event_scroll (widget, event, SCHEMATIC_PREVIEW (widget)->window);
+  return x_event_scroll (widget,
+                         event,
+                         schematic_preview_get_window (widget));
 }
 
 

--- a/libleptongui/src/preview_widget.c
+++ b/libleptongui/src/preview_widget.c
@@ -153,8 +153,8 @@ schematic_preview_callback_button_press (GtkWidget *widget,
  *  \param [in] user_data Unused user data.
  */
 void
-schematic_preview_callback_update (SchematicPreview *preview,
-                                   gpointer user_data)
+schematic_preview_update (SchematicPreview *preview,
+                          gpointer user_data)
 {
   int left, top, right, bottom;
   int width, height;

--- a/libleptongui/src/preview_widget.c
+++ b/libleptongui/src/preview_widget.c
@@ -165,9 +165,6 @@ schematic_preview_update (SchematicPreview *preview,
   LeptonToplevel *preview_toplevel =
     lepton_page_get_toplevel (preview_page);
 
-  /* delete old preview */
-  lepton_page_delete_objects (preview_page);
-
   if (preview->active) {
     g_assert ((preview->filename == NULL) || (preview->buffer == NULL));
     if (preview->filename != NULL) {

--- a/libleptongui/src/preview_widget.c
+++ b/libleptongui/src/preview_widget.c
@@ -451,6 +451,20 @@ schematic_preview_get_active (GtkWidget *preview)
 }
 
 
+/*! \brief Get the field \a buffer of this preview.
+ *
+ *  \param [in] preview The preview.
+ *  \return The \a buffer field.
+ */
+gchar*
+schematic_preview_get_buffer (GtkWidget *preview)
+{
+  g_return_val_if_fail (preview != NULL, NULL);
+
+  return SCHEMATIC_PREVIEW (preview)->buffer;
+}
+
+
 /*! \brief Get the field \a preview_w_current of this preview.
  *
  *  \param [in] preview The preview.

--- a/libleptongui/src/preview_widget.c
+++ b/libleptongui/src/preview_widget.c
@@ -172,6 +172,8 @@ schematic_preview_callback_button_press (GtkWidget *widget,
  *  \param [in] preview_toplevel The \c LeptonToplevel object of
  *                               the preview page.
  *  \param [in] preview_active If the preview should be updated.
+ *  \param [in] preview_filename The filename to read the preview
+ *                               data from.
  */
 void
 schematic_preview_update (SchematicPreview *preview,
@@ -185,12 +187,13 @@ schematic_preview_update (SchematicPreview *preview,
   GschemPageView *preview_view = GSCHEM_PAGE_VIEW (preview);
 
   if (schematic_preview_get_active (GTK_WIDGET (preview))) {
-    g_assert ((preview->filename == NULL) || (preview->buffer == NULL));
-    if (preview->filename != NULL) {
+    g_assert ((schematic_preview_get_filename (GTK_WIDGET (preview)) == NULL)
+              || (preview->buffer == NULL));
+    if (schematic_preview_get_filename (GTK_WIDGET (preview)) != NULL) {
       /* open up file in current page */
       f_open (preview_toplevel,
               preview_page,
-              preview->filename,
+              schematic_preview_get_filename (GTK_WIDGET (preview)),
               F_OPEN_RC | F_OPEN_RESTORE_CWD,
               NULL);
       /* test value returned by f_open... - Fix me */

--- a/libleptongui/src/preview_widget.c
+++ b/libleptongui/src/preview_widget.c
@@ -181,7 +181,8 @@ void
 schematic_preview_update (SchematicPreview *preview,
                           LeptonPage *preview_page,
                           LeptonToplevel *preview_toplevel,
-                          gboolean preview_active)
+                          gboolean preview_active,
+                          char *preview_filename)
 {
   int left, top, right, bottom;
   int width, height;
@@ -191,13 +192,13 @@ schematic_preview_update (SchematicPreview *preview,
 
   if (preview_active)
   {
-    g_assert ((schematic_preview_get_filename (GTK_WIDGET (preview)) == NULL)
+    g_assert ((preview_filename == NULL)
               || (schematic_preview_get_buffer (GTK_WIDGET (preview)) == NULL));
-    if (schematic_preview_get_filename (GTK_WIDGET (preview)) != NULL) {
+    if (preview_filename != NULL) {
       /* open up file in current page */
       f_open (preview_toplevel,
               preview_page,
-              schematic_preview_get_filename (GTK_WIDGET (preview)),
+              preview_filename,
               F_OPEN_RC | F_OPEN_RESTORE_CWD,
               NULL);
       /* test value returned by f_open... - Fix me */

--- a/libleptongui/src/preview_widget.c
+++ b/libleptongui/src/preview_widget.c
@@ -227,9 +227,6 @@ schematic_preview_update (SchematicPreview *preview,
     geometry->world_top    = top    - ((double)height * OVER_ZOOM_FACTOR);
     geometry->world_bottom = bottom + ((double)height * OVER_ZOOM_FACTOR);
   }
-
-  /* display current page (possibly empty) */
-  gschem_page_view_zoom_extents (preview_view, NULL);
 }
 
 

--- a/libleptongui/src/preview_widget.c
+++ b/libleptongui/src/preview_widget.c
@@ -159,41 +159,6 @@ schematic_preview_callback_button_press (GtkWidget *widget,
 }
 
 
-/*! \brief Updates the preview widget.
- *  \par Function Description
- *  This function updates the preview: if the preview is active and a
- *  filename has been given, it opens the file and displays
- *  it. Otherwise it displays a blank page.
- *
- *  \param [in] preview_page The \c LeptonPage object of the preview.
- *  \param [in] objects The list of objects to display.
- *  \param [in,out] err \c GError structure for error reporting, or
- *                      NULL to disable error reporting.
- */
-void
-schematic_preview_update (LeptonPage *preview_page,
-                          GList *objects,
-                          GError *err)
-{
-  if (err == NULL) {
-    lepton_page_append_list (preview_page, objects);
-  }
-  else {
-    lepton_page_append (preview_page,
-                        lepton_text_object_new (2,
-                                                100,
-                                                100,
-                                                LOWER_MIDDLE,
-                                                0,
-                                                err->message,
-                                                10,
-                                                VISIBLE,
-                                                SHOW_NAME_VALUE));
-    g_error_free(err);
-  }
-}
-
-
 static void
 schematic_preview_class_init (SchematicPreviewClass *klass)
 {

--- a/libleptongui/src/preview_widget.c
+++ b/libleptongui/src/preview_widget.c
@@ -151,7 +151,7 @@ schematic_preview_callback_button_press (GtkWidget *widget,
  *
  *  \param [in] preview The preview widget.
  */
-static void
+void
 schematic_preview_callback_update (SchematicPreview *preview)
 {
   int left, top, right, bottom;

--- a/libleptongui/src/preview_widget.c
+++ b/libleptongui/src/preview_widget.c
@@ -167,44 +167,39 @@ schematic_preview_callback_button_press (GtkWidget *widget,
  *
  *  \param [in] preview The preview widget.
  *  \param [in] preview_page The \c LeptonPage object of the preview.
- *  \param [in] preview_active If the preview should be updated.
  *  \param [in] preview_buffer The buffer to read the preview
  *                             data from.
  */
 void
 schematic_preview_update (SchematicPreview *preview,
                           LeptonPage *preview_page,
-                          gboolean preview_active,
                           char *preview_buffer)
 {
   GError * err = NULL;
 
-  if (preview_active)
-  {
-    if (preview_buffer != NULL) {
-      /* Load the data buffer */
-      GList * objects = o_read_buffer (preview_page,
-                                       NULL,
-                                       preview_buffer,
-                                       -1,
-                                       _("Preview Buffer"),
-                                       &err);
-      if (err == NULL) {
-        lepton_page_append_list (preview_page, objects);
-      }
-      else {
-        lepton_page_append (preview_page,
-                            lepton_text_object_new (2,
-                                                    100,
-                                                    100,
-                                                    LOWER_MIDDLE,
-                                                    0,
-                                                    err->message,
-                                                    10,
-                                                    VISIBLE,
-                                                    SHOW_NAME_VALUE));
-        g_error_free(err);
-      }
+  if (preview_buffer != NULL) {
+    /* Load the data buffer */
+    GList * objects = o_read_buffer (preview_page,
+                                     NULL,
+                                     preview_buffer,
+                                     -1,
+                                     _("Preview Buffer"),
+                                     &err);
+    if (err == NULL) {
+      lepton_page_append_list (preview_page, objects);
+    }
+    else {
+      lepton_page_append (preview_page,
+                          lepton_text_object_new (2,
+                                                  100,
+                                                  100,
+                                                  LOWER_MIDDLE,
+                                                  0,
+                                                  err->message,
+                                                  10,
+                                                  VISIBLE,
+                                                  SHOW_NAME_VALUE));
+      g_error_free(err);
     }
   }
 }

--- a/libleptongui/src/preview_widget.c
+++ b/libleptongui/src/preview_widget.c
@@ -150,9 +150,11 @@ schematic_preview_callback_button_press (GtkWidget *widget,
  *  it. Otherwise it displays a blank page.
  *
  *  \param [in] preview The preview widget.
+ *  \param [in] user_data Unused user data.
  */
 void
-schematic_preview_callback_update (SchematicPreview *preview)
+schematic_preview_callback_update (SchematicPreview *preview,
+                                   gpointer user_data)
 {
   int left, top, right, bottom;
   int width, height;
@@ -263,7 +265,16 @@ schematic_preview_class_init (SchematicPreviewClass *klass)
                           FALSE,
                           G_PARAM_READWRITE));
 
-
+  g_signal_new ("update-preview",
+                G_OBJECT_CLASS_TYPE (klass),
+                (GSignalFlags) (G_SIGNAL_RUN_LAST), /*signal_flags */
+                0, /*class_offset */
+                NULL, /* accumulator */
+                NULL, /* accu_data */
+                NULL,
+                G_TYPE_NONE,
+                0 /* n_params */
+                );
 }
 
 
@@ -362,7 +373,7 @@ schematic_preview_set_property (GObject *object,
 
       case PROP_ACTIVE:
         preview->active = g_value_get_boolean (value);
-        schematic_preview_callback_update (preview);
+        g_signal_emit_by_name (preview, "update-preview");
         break;
       default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);

--- a/libleptongui/src/preview_widget.c
+++ b/libleptongui/src/preview_widget.c
@@ -182,7 +182,8 @@ schematic_preview_update (SchematicPreview *preview,
                           LeptonPage *preview_page,
                           LeptonToplevel *preview_toplevel,
                           gboolean preview_active,
-                          char *preview_filename)
+                          char *preview_filename,
+                          char *preview_buffer)
 {
   int left, top, right, bottom;
   int width, height;
@@ -193,7 +194,7 @@ schematic_preview_update (SchematicPreview *preview,
   if (preview_active)
   {
     g_assert ((preview_filename == NULL)
-              || (schematic_preview_get_buffer (GTK_WIDGET (preview)) == NULL));
+              || (preview_buffer == NULL));
     if (preview_filename != NULL) {
       /* open up file in current page */
       f_open (preview_toplevel,
@@ -204,11 +205,11 @@ schematic_preview_update (SchematicPreview *preview,
       /* test value returned by f_open... - Fix me */
       /* we should display something if there an error occured - Fix me */
     }
-    if (schematic_preview_get_buffer (GTK_WIDGET (preview)) != NULL) {
+    if (preview_buffer != NULL) {
       /* Load the data buffer */
       GList * objects = o_read_buffer (preview_page,
                                        NULL,
-                                       schematic_preview_get_buffer (GTK_WIDGET (preview)),
+                                       preview_buffer,
                                        -1,
                                        _("Preview Buffer"),
                                        &err);

--- a/libleptongui/src/preview_widget.c
+++ b/libleptongui/src/preview_widget.c
@@ -150,23 +150,17 @@ schematic_preview_callback_button_press (GtkWidget *widget,
  *  it. Otherwise it displays a blank page.
  *
  *  \param [in] preview The preview widget.
- *  \param [in] user_data Unused user data.
+ *  \param [in] preview_page The \c LeptonPage object of the preview.
  */
 void
 schematic_preview_update (SchematicPreview *preview,
-                          gpointer user_data)
+                          LeptonPage *preview_page)
 {
   int left, top, right, bottom;
   int width, height;
   GError * err = NULL;
 
   GschemPageView *preview_view = GSCHEM_PAGE_VIEW (preview);
-
-  LeptonPage *preview_page = gschem_page_view_get_page (preview_view);
-
-  if (preview_page == NULL) {
-    return;
-  }
 
   LeptonToplevel *preview_toplevel =
     lepton_page_get_toplevel (preview_page);

--- a/libleptongui/src/preview_widget.c
+++ b/libleptongui/src/preview_widget.c
@@ -82,7 +82,7 @@ static void schematic_preview_finalize (GObject *self);
 /*! \brief get the filename for the current page
  */
 static const char*
-schematic_preview_get_filename (SchematicPreview *preview)
+schematic_preview_get_page_filename (SchematicPreview *preview)
 {
   LeptonPage *page = gschem_page_view_get_page (GSCHEM_PAGE_VIEW (preview));
 
@@ -396,7 +396,7 @@ schematic_preview_get_property (GObject *object,
 
   switch(property_id) {
       case PROP_FILENAME:
-        g_value_set_string (value, schematic_preview_get_filename (preview));
+        g_value_set_string (value, schematic_preview_get_page_filename (preview));
         break;
 
       case PROP_ACTIVE:

--- a/libleptongui/src/preview_widget.c
+++ b/libleptongui/src/preview_widget.c
@@ -169,20 +169,14 @@ schematic_preview_callback_button_press (GtkWidget *widget,
  *
  *  \param [in] preview The preview widget.
  *  \param [in] preview_page The \c LeptonPage object of the preview.
- *  \param [in] preview_toplevel The \c LeptonToplevel object of
- *                               the preview page.
  *  \param [in] preview_active If the preview should be updated.
- *  \param [in] preview_filename The filename to read the preview
- *                               data from.
  *  \param [in] preview_buffer The buffer to read the preview
  *                             data from.
  */
 void
 schematic_preview_update (SchematicPreview *preview,
                           LeptonPage *preview_page,
-                          LeptonToplevel *preview_toplevel,
                           gboolean preview_active,
-                          char *preview_filename,
                           char *preview_buffer)
 {
   int left, top, right, bottom;
@@ -193,16 +187,6 @@ schematic_preview_update (SchematicPreview *preview,
 
   if (preview_active)
   {
-    if (preview_filename != NULL) {
-      /* open up file in current page */
-      f_open (preview_toplevel,
-              preview_page,
-              preview_filename,
-              F_OPEN_RC | F_OPEN_RESTORE_CWD,
-              NULL);
-      /* test value returned by f_open... - Fix me */
-      /* we should display something if there an error occured - Fix me */
-    }
     if (preview_buffer != NULL) {
       /* Load the data buffer */
       GList * objects = o_read_buffer (preview_page,

--- a/libleptongui/src/preview_widget.c
+++ b/libleptongui/src/preview_widget.c
@@ -286,30 +286,6 @@ schematic_preview_new ()
 {
   SchematicPreview *preview = SCHEMATIC_PREVIEW (g_object_new (SCHEMATIC_TYPE_PREVIEW, NULL));
 
-  struct event_reg_t {
-    const gchar *detailed_signal;
-    GCallback c_handler;
-  } drawing_area_events[] = {
-    { "realize",              G_CALLBACK (schematic_preview_callback_realize)},
-#ifdef ENABLE_GTK3
-    { "draw",                 G_CALLBACK (x_event_draw)                   },
-#else
-    { "expose_event",         G_CALLBACK (x_event_expose)                 },
-#endif
-    { "button_press_event",   G_CALLBACK (schematic_preview_callback_button_press)},
-    { "configure_event",      G_CALLBACK (x_event_configure)              },
-    { "scroll_event",         G_CALLBACK (schematic_preview_callback_scroll_event)},
-    { NULL,                   NULL                                        }
-  }, *tmp;
-
-  for (tmp = drawing_area_events; tmp->detailed_signal != NULL; tmp++)
-  {
-    g_signal_connect (GTK_WIDGET (preview),
-                      tmp->detailed_signal,
-                      tmp->c_handler,
-                      preview->window);
-  }
-
   return GTK_WIDGET (preview);
 }
 

--- a/libleptongui/src/preview_widget.c
+++ b/libleptongui/src/preview_widget.c
@@ -174,6 +174,8 @@ schematic_preview_callback_button_press (GtkWidget *widget,
  *  \param [in] preview_active If the preview should be updated.
  *  \param [in] preview_filename The filename to read the preview
  *                               data from.
+ *  \param [in] preview_buffer The buffer to read the preview
+ *                             data from.
  */
 void
 schematic_preview_update (SchematicPreview *preview,
@@ -188,7 +190,7 @@ schematic_preview_update (SchematicPreview *preview,
 
   if (schematic_preview_get_active (GTK_WIDGET (preview))) {
     g_assert ((schematic_preview_get_filename (GTK_WIDGET (preview)) == NULL)
-              || (preview->buffer == NULL));
+              || (schematic_preview_get_buffer (GTK_WIDGET (preview)) == NULL));
     if (schematic_preview_get_filename (GTK_WIDGET (preview)) != NULL) {
       /* open up file in current page */
       f_open (preview_toplevel,
@@ -199,12 +201,14 @@ schematic_preview_update (SchematicPreview *preview,
       /* test value returned by f_open... - Fix me */
       /* we should display something if there an error occured - Fix me */
     }
-    if (preview->buffer != NULL) {
+    if (schematic_preview_get_buffer (GTK_WIDGET (preview)) != NULL) {
       /* Load the data buffer */
       GList * objects = o_read_buffer (preview_page,
-                                       NULL, preview->buffer, -1,
-                                       _("Preview Buffer"), &err);
-
+                                       NULL,
+                                       schematic_preview_get_buffer (GTK_WIDGET (preview)),
+                                       -1,
+                                       _("Preview Buffer"),
+                                       &err);
       if (err == NULL) {
         lepton_page_append_list (preview_page, objects);
       }

--- a/libleptongui/src/preview_widget.c
+++ b/libleptongui/src/preview_widget.c
@@ -171,15 +171,13 @@ schematic_preview_callback_button_press (GtkWidget *widget,
  *  \param [in] preview_buffer The buffer to read the preview
  *                             data from.
  */
-GschemPageView*
+void
 schematic_preview_update (SchematicPreview *preview,
                           LeptonPage *preview_page,
                           gboolean preview_active,
                           char *preview_buffer)
 {
   GError * err = NULL;
-
-  GschemPageView *preview_view = GSCHEM_PAGE_VIEW (preview);
 
   if (preview_active)
   {
@@ -209,8 +207,6 @@ schematic_preview_update (SchematicPreview *preview,
       }
     }
   }
-
-  return preview_view;
 }
 
 

--- a/libleptongui/src/preview_widget.c
+++ b/libleptongui/src/preview_widget.c
@@ -151,19 +151,19 @@ schematic_preview_callback_button_press (GtkWidget *widget,
  *
  *  \param [in] preview The preview widget.
  *  \param [in] preview_page The \c LeptonPage object of the preview.
+ *  \param [in] preview_toplevel The \c LeptonToplevel object of
+ *                               the preview page.
  */
 void
 schematic_preview_update (SchematicPreview *preview,
-                          LeptonPage *preview_page)
+                          LeptonPage *preview_page,
+                          LeptonToplevel *preview_toplevel)
 {
   int left, top, right, bottom;
   int width, height;
   GError * err = NULL;
 
   GschemPageView *preview_view = GSCHEM_PAGE_VIEW (preview);
-
-  LeptonToplevel *preview_toplevel =
-    lepton_page_get_toplevel (preview_page);
 
   if (preview->active) {
     g_assert ((preview->filename == NULL) || (preview->buffer == NULL));

--- a/libleptongui/src/preview_widget.c
+++ b/libleptongui/src/preview_widget.c
@@ -41,6 +41,24 @@
 #define OVER_ZOOM_FACTOR 0.1
 
 
+struct _SchematicPreviewClass
+{
+  GschemPageViewClass parent_class;
+};
+
+struct _SchematicPreview
+{
+  GschemPageView parent_instance;
+
+  GschemToplevel *window;
+
+  gchar *filename;
+  gchar *buffer;
+
+  gboolean active;
+};
+
+
 enum {
   PROP_FILENAME=1,
   PROP_BUFFER,

--- a/libleptongui/src/preview_widget.c
+++ b/libleptongui/src/preview_widget.c
@@ -38,8 +38,6 @@
 
 #include "gschem.h"
 
-#define OVER_ZOOM_FACTOR 0.1
-
 
 struct _SchematicPreviewClass
 {
@@ -173,14 +171,12 @@ schematic_preview_callback_button_press (GtkWidget *widget,
  *  \param [in] preview_buffer The buffer to read the preview
  *                             data from.
  */
-void
+GschemPageView*
 schematic_preview_update (SchematicPreview *preview,
                           LeptonPage *preview_page,
                           gboolean preview_active,
                           char *preview_buffer)
 {
-  int left, top, right, bottom;
-  int width, height;
   GError * err = NULL;
 
   GschemPageView *preview_view = GSCHEM_PAGE_VIEW (preview);
@@ -214,21 +210,7 @@ schematic_preview_update (SchematicPreview *preview,
     }
   }
 
-  if (world_get_object_glist_bounds (lepton_page_objects (preview_page),
-                                     /* Do not include hidden text. */
-                                     FALSE,
-                                     &left, &top,
-                                     &right, &bottom)) {
-    /* Clamp the canvas size to the extents of the page being previewed */
-    width = right - left;
-    height = bottom - top;
-
-    GschemPageGeometry *geometry = gschem_page_view_get_page_geometry (preview_view);
-    gschem_page_geometry_set_world_left   (geometry, left   - ((double)width  * OVER_ZOOM_FACTOR));
-    gschem_page_geometry_set_world_right  (geometry, right  + ((double)width  * OVER_ZOOM_FACTOR));
-    gschem_page_geometry_set_world_top    (geometry, top    - ((double)height * OVER_ZOOM_FACTOR));
-    gschem_page_geometry_set_world_bottom (geometry, bottom + ((double)height * OVER_ZOOM_FACTOR));
-  }
+  return preview_view;
 }
 
 

--- a/libleptongui/src/preview_widget.c
+++ b/libleptongui/src/preview_widget.c
@@ -465,6 +465,20 @@ schematic_preview_get_buffer (GtkWidget *preview)
 }
 
 
+/*! \brief Get the field \a filename of this preview.
+ *
+ *  \param [in] preview The preview.
+ *  \return The \a filename field.
+ */
+gchar*
+schematic_preview_get_filename (GtkWidget *preview)
+{
+  g_return_val_if_fail (preview != NULL, NULL);
+
+  return SCHEMATIC_PREVIEW (preview)->filename;
+}
+
+
 /*! \brief Get the field \a preview_w_current of this preview.
  *
  *  \param [in] preview The preview.

--- a/libleptongui/src/x_compselect.c
+++ b/libleptongui/src/x_compselect.c
@@ -561,6 +561,7 @@ compselect_callback_tree_selection_changed (GtkTreeSelection *selection,
   Compselect *compselect = (Compselect*)user_data;
   const CLibSymbol *sym = NULL;
   gchar *buffer = NULL;
+  GschemToplevel *w_current;
 
   if (gtk_tree_selection_get_selected (selection, &model, &iter)) {
 
@@ -582,8 +583,9 @@ compselect_callback_tree_selection_changed (GtkTreeSelection *selection,
                 NULL);
 
   /* update the attributes with the toplevel of the preview widget*/
-  update_attributes_model (compselect,
-                           compselect->preview->window);
+  w_current =
+    schematic_preview_get_window (GTK_WIDGET (compselect->preview));
+  update_attributes_model (compselect, w_current);
 
   /* signal a component has been selected to parent of dialog */
   g_signal_emit_by_name (compselect,

--- a/libleptongui/src/x_compselect.c
+++ b/libleptongui/src/x_compselect.c
@@ -1530,7 +1530,7 @@ compselect_constructor (GType type,
                                         NULL));
 #endif
 
-  preview = GTK_WIDGET (g_object_new (SCHEMATIC_TYPE_PREVIEW, NULL));
+  preview = schematic_preview_new ();
 
 #ifdef ENABLE_GTK3
   gtk_container_set_border_width (GTK_CONTAINER (frame), 5);

--- a/libleptongui/src/x_fileselect.c
+++ b/libleptongui/src/x_fileselect.c
@@ -272,18 +272,22 @@ x_fileselect_callback_update_preview (GtkFileChooser *chooser,
  *
  *  \param [in] dialog The file chooser dialog widget to add the
  *                     preview to.
+ *  \param [in] preview The new preview widget to add.
  */
 void
-x_fileselect_add_preview (GtkWidget *dialog)
+x_fileselect_add_preview (GtkWidget *dialog,
+                          GtkWidget *preview)
 {
   GtkFileChooser *filechooser;
-  GtkWidget *frame, *preview;
+  GtkWidget *frame;
 
   filechooser = GTK_FILE_CHOOSER (dialog);
   frame = GTK_WIDGET (g_object_new (GTK_TYPE_FRAME,
                                     "label", _("Preview"),
                                     NULL));
-#ifndef ENABLE_GTK3
+#ifdef ENABLE_GTK3
+  gtk_container_add (GTK_CONTAINER (frame), preview);
+#else
   GtkWidget *alignment;
   alignment = GTK_WIDGET (g_object_new (GTK_TYPE_ALIGNMENT,
                                         "right-padding", 5,
@@ -293,13 +297,6 @@ x_fileselect_add_preview (GtkWidget *dialog)
                                         "xalign", 0.5,
                                         "yalign", 0.5,
                                         NULL));
-#endif
-
-  preview = schematic_preview_new ();
-
-#ifdef ENABLE_GTK3
-  gtk_container_add (GTK_CONTAINER (frame), preview);
-#else
   gtk_container_add (GTK_CONTAINER (alignment), preview);
   gtk_container_add (GTK_CONTAINER (frame), alignment);
 #endif

--- a/libleptongui/src/x_fileselect.c
+++ b/libleptongui/src/x_fileselect.c
@@ -316,21 +316,19 @@ x_fileselect_add_preview (GtkFileChooser *filechooser)
 
 }
 
-/*! \brief Opens a file chooser for opening one or more schematics.
+
+/*! \brief Create a file chooser for opening schematics
  *  \par Function Description
  *
- *  This function opens a file chooser dialog and waits for the
- *  user to select at least one file to load.
+ *  This function creates and initializes a file chooser dialog.
  *
  *  \param [in] w_current The GschemToplevel environment.
- *  \return The GSList of file names to open.
+ *  \return The created dialog widget.
  */
-GSList*
-x_fileselect_open (GschemToplevel *w_current)
+GtkWidget*
+schematic_file_select_dialog_new (GschemToplevel *w_current)
 {
-  GSList *filenames = NULL;
   GtkWidget *dialog;
-  gchar *cwd;
 
   dialog = gtk_file_chooser_dialog_new (_("Open"),
                                         GTK_WINDOW(w_current->main_window),
@@ -351,6 +349,27 @@ x_fileselect_open (GschemToplevel *w_current)
   {
     x_fileselect_add_preview (GTK_FILE_CHOOSER (dialog));
   }
+
+  return dialog;
+}
+
+
+/*! \brief Opens a file chooser for opening one or more schematics.
+ *  \par Function Description
+ *
+ *  This function opens a file chooser dialog and waits for the
+ *  user to select at least one file to load.
+ *
+ *  \param [in] w_current The GschemToplevel environment.
+ *  \param [in] dialog The dialog window widget.
+ *  \return The GSList of file names to open.
+ */
+GSList*
+x_fileselect_open (GschemToplevel *w_current,
+                   GtkWidget *dialog)
+{
+  GSList *filenames = NULL;
+  gchar *cwd;
 
   g_object_set (dialog,
                 /* GtkFileChooser */

--- a/libleptongui/src/x_fileselect.c
+++ b/libleptongui/src/x_fileselect.c
@@ -272,7 +272,7 @@ x_fileselect_callback_update_preview (GtkFileChooser *chooser,
  *
  *  \param [in] filechooser The file chooser to add the preview to.
  */
-static void
+void
 x_fileselect_add_preview (GtkFileChooser *filechooser)
 {
   GtkWidget *frame, *preview;

--- a/libleptongui/src/x_fileselect.c
+++ b/libleptongui/src/x_fileselect.c
@@ -229,7 +229,7 @@ on_filter_changed (GtkFileChooserDialog* dialog, gpointer data)
  *  \param [in] chooser   The file chooser to add the preview to.
  *  \param [in] user_data A pointer on the preview widget.
  */
-static void
+void
 x_fileselect_callback_update_preview (GtkFileChooser *chooser,
                                       gpointer user_data)
 {

--- a/libleptongui/src/x_fileselect.c
+++ b/libleptongui/src/x_fileselect.c
@@ -308,12 +308,6 @@ x_fileselect_add_preview (GtkWidget *dialog,
                 "preview-widget", frame,
                 NULL);
 
-  /* connect callback to update preview */
-  g_signal_connect (filechooser,
-                    "update-preview",
-                    G_CALLBACK (x_fileselect_callback_update_preview),
-                    preview);
-
 }
 
 

--- a/libleptongui/src/x_fileselect.c
+++ b/libleptongui/src/x_fileselect.c
@@ -270,13 +270,16 @@ x_fileselect_callback_update_preview (GtkFileChooser *chooser,
  *  so that it redraws the preview area every time a new file is
  *  selected.
  *
- *  \param [in] filechooser The file chooser to add the preview to.
+ *  \param [in] dialog The file chooser dialog widget to add the
+ *                     preview to.
  */
 void
-x_fileselect_add_preview (GtkFileChooser *filechooser)
+x_fileselect_add_preview (GtkWidget *dialog)
 {
+  GtkFileChooser *filechooser;
   GtkWidget *frame, *preview;
 
+  filechooser = GTK_FILE_CHOOSER (dialog);
   frame = GTK_WIDGET (g_object_new (GTK_TYPE_FRAME,
                                     "label", _("Preview"),
                                     NULL));
@@ -344,11 +347,6 @@ schematic_file_select_dialog_new (GschemToplevel *w_current)
                                           GTK_RESPONSE_CANCEL,
                                           -1);
 #endif
-
-  if (schematic_window_get_file_preview (w_current) == TRUE)
-  {
-    x_fileselect_add_preview (GTK_FILE_CHOOSER (dialog));
-  }
 
   return dialog;
 }


### PR DESCRIPTION
- The *File Select* dialog code has been refactored so it and its
  preview widget are now available for dealing with in Scheme.
- Several C accessors have been added for the *Preview* widget and
  made available for Scheme FFI.  The `SchematicPreview` structure
  has been made opaque.
- The *Preview* widgets are now created in Scheme.  A new module,
  `(schematic preview-widget)`, has been added to work with them
  in Scheme.
- **Glib** signals belonging to the Preview widget are now
  assigned in Scheme.  The function
  `init-preview-widget-signals()` has been factored out for this
  task.
- A new signal, "update-preview", has been added for the *Preview*
  widget to allow for updating the widget directly in Scheme.  A C
  callback it first used, has been wholly rewritten in Scheme.
- The scrolling callback for the *Preview* widget has been
  rewritten in Scheme as well.

Long story short, all this has allowed me to move one call for
`f_open()` and one call for `o_read_buffer()` to Scheme, which
will facilitate access to lower level Scheme-in-C functions in
future.
