### PR TITLE
Reduce the amount of undo function arguments

### DIFF
--- a/liblepton/include/liblepton/defines.h
+++ b/liblepton/include/liblepton/defines.h
@@ -104,10 +104,6 @@
 #define CONN_ENDPOINT		1
 #define CONN_MIDPOINT		2
 
-/* used for undo_savestate flag */
-#define UNDO_ALL		0
-#define UNDO_VIEWPORT_ONLY	1
-
 /* list copying flags */
 #define NORMAL_FLAG		0
 #define SELECTION_FLAG		1

--- a/liblepton/include/liblepton/undo.h
+++ b/liblepton/include/liblepton/undo.h
@@ -1,7 +1,7 @@
 /* Lepton EDA library
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2015 gEDA Contributors
- * Copyright (C) 2017-2023 Lepton EDA Contributors
+ * Copyright (C) 2017-2024 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -29,8 +29,9 @@ struct st_undo
   char *filename;
   GList *object_list;
 
-  /* either UNDO_ALL or UNDO_VIEWPORT_ONLY */
-  int type;
+  /* TRUE if only viewport size has to be saved.  Otherwise,
+     FALSE. */
+  gboolean type;
 
   /* viewport information */
   int x, y;

--- a/liblepton/src/undo.c
+++ b/liblepton/src/undo.c
@@ -210,7 +210,7 @@ lepton_undo_set_scale (LeptonUndo *undo,
 int
 lepton_undo_get_type (LeptonUndo *undo)
 {
-  g_return_val_if_fail (undo != NULL, UNDO_ALL);
+  g_return_val_if_fail (undo != NULL, FALSE);
 
   return undo->type;
 }

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -326,7 +326,8 @@ void
 o_undo_savestate (GschemToplevel *w_current,
                   LeptonPage *page,
                   int flag);
-void o_undo_savestate_old(GschemToplevel *w_current, int flag);
+void
+o_undo_savestate_old (GschemToplevel *w_current);
 
 void
 o_undo_savestate_viewport (GschemToplevel *w_current);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -325,7 +325,7 @@ void o_text_change(GschemToplevel *w_current, LeptonObject *object, char *string
 void
 o_undo_savestate (GschemToplevel *w_current,
                   LeptonPage *page,
-                  int flag);
+                  gboolean only_viewport);
 void
 o_undo_savestate_old (GschemToplevel *w_current);
 

--- a/libleptongui/scheme/schematic/action/delete.scm
+++ b/libleptongui/scheme/schematic/action/delete.scm
@@ -1,6 +1,6 @@
 ;;; Lepton EDA Schematic Capture
 ;;; Scheme API
-;;; Copyright (C) 2023 Lepton EDA Contributors
+;;; Copyright (C) 2023-2024 Lepton EDA Contributors
 ;;;
 ;;; This program is free software; you can redistribute it and/or modify
 ;;; it under the terms of the GNU General Public License as published by
@@ -34,9 +34,6 @@
   #:use-module (schematic window global)
 
   #:export (delete-selection))
-
-;;; Temp definition.
-(define UNDO_ALL 0)
 
 (define* (delete-selection *window)
   "Delete selected objects on the active page in *WINDOW."
@@ -91,5 +88,5 @@
                 (map object->pointer objects-to-remove))
 
       (schematic_window_active_page_changed *window)
-      (o_undo_savestate_old *window UNDO_ALL)
+      (o_undo_savestate_old *window)
       (i_update_menus *window))))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -1083,7 +1083,7 @@
 
 ;;; o_undo.c
 (define-lff o_undo_savestate void (list '* '* int))
-(define-lff o_undo_savestate_old void (list '* int))
+(define-lff o_undo_savestate_old void '(*))
 (define-lff o_undo_savestate_viewport void '(*))
 (define-lff schematic_undo_get_file_index int '())
 (define-lff schematic_undo_index_to_filename '* (list int))

--- a/libleptongui/scheme/schematic/undo.scm
+++ b/libleptongui/scheme/schematic/undo.scm
@@ -50,9 +50,6 @@
 ) ; define-module
 
 
-;;; Variables defined in defines.h for C code.
-(define UNDO_ALL 0)
-(define UNDO_VIEWPORT_ONLY 1)
 ;;; Variables defined in gschem_defines.h.
 (define UNDO_DISK 0)
 (define UNDO_MEMORY 1)
@@ -95,7 +92,7 @@ success, #f on failure."
     (and (not (null-pointer? *view))
          (let ((*page (gschem_page_view_get_page *view)))
            (and (not (null-pointer? *page))
-                (o_undo_savestate *window *page UNDO_ALL)
+                (o_undo_savestate *window *page FALSE)
                 #t)))))
 
 
@@ -203,8 +200,8 @@ success, #f on failure."
 
   (define (page-undo *page-view *page *current-undo *undo-to-do)
     (let ((undo-viewport?
-           (and (= (lepton_undo_get_type *current-undo) UNDO_ALL)
-                (= (lepton_undo_get_type *undo-to-do) UNDO_VIEWPORT_ONLY))))
+           (and (false? (lepton_undo_get_type *current-undo))
+                (true? (lepton_undo_get_type *undo-to-do)))))
       (when undo-viewport?
         ;; Debugging stuff.
         (log! 'debug "Type: ~A\n" (lepton_undo_get_type *undo-to-do))

--- a/libleptongui/src/gschem_toplevel.c
+++ b/libleptongui/src/gschem_toplevel.c
@@ -732,7 +732,7 @@ handle_undo (GschemToplevel *w_current)
   g_return_if_fail (w_current != NULL);
 
   schematic_window_active_page_changed (w_current);
-  o_undo_savestate_old (w_current, UNDO_ALL);
+  o_undo_savestate_old (w_current);
 }
 
 

--- a/libleptongui/src/o_arc.c
+++ b/libleptongui/src/o_arc.c
@@ -157,7 +157,7 @@ void o_arc_end4(GschemToplevel *w_current, int radius,
   g_run_hook_object (w_current, "add-objects-hook", new_obj);
 
   gschem_toplevel_page_content_changed (w_current, page);
-  o_undo_savestate(w_current, page, UNDO_ALL);
+  o_undo_savestate(w_current, page, FALSE);
 }
 
 /*! \brief Draw an arc using one angle modification.

--- a/libleptongui/src/o_box.c
+++ b/libleptongui/src/o_box.c
@@ -155,7 +155,7 @@ void o_box_end(GschemToplevel *w_current, int w_x, int w_y)
     g_run_hook_object (w_current, "add-objects-hook", new_obj);
 
     gschem_toplevel_page_content_changed (w_current, page);
-    o_undo_savestate(w_current, page, UNDO_ALL);
+    o_undo_savestate(w_current, page, FALSE);
   }
 
   i_action_stop (w_current);

--- a/libleptongui/src/o_bus.c
+++ b/libleptongui/src/o_bus.c
@@ -100,7 +100,7 @@ void o_bus_end(GschemToplevel *w_current, int w_x, int w_y)
     w_current->first_wy = w_current->second_wy;
 
     gschem_toplevel_page_content_changed (w_current, page);
-    o_undo_savestate(w_current, page, UNDO_ALL);
+    o_undo_savestate(w_current, page, FALSE);
   }
 
   /* Don't reset w_current->inside_action here since we want to continue drawing */

--- a/libleptongui/src/o_circle.c
+++ b/libleptongui/src/o_circle.c
@@ -125,7 +125,7 @@ void o_circle_end(GschemToplevel *w_current, int w_x, int w_y)
   g_run_hook_object (w_current, "add-objects-hook", new_obj);
 
   gschem_toplevel_page_content_changed (w_current, page);
-  o_undo_savestate(w_current, page, UNDO_ALL);
+  o_undo_savestate (w_current, page, FALSE);
 
   i_action_stop (w_current);
 }

--- a/libleptongui/src/o_component.c
+++ b/libleptongui/src/o_component.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2015 gEDA Contributors
- * Copyright (C) 2017-2022 Lepton EDA Contributors
+ * Copyright (C) 2017-2024 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -220,6 +220,6 @@ o_component_translate_all (GschemToplevel *w_current, int offset)
   }
   gschem_page_view_invalidate_all (view);
   gschem_toplevel_page_content_changed (w_current, active_page);
-  o_undo_savestate_old(w_current, UNDO_ALL);
+  o_undo_savestate_old (w_current);
   i_update_menus(w_current);
 }

--- a/libleptongui/src/o_grips.c
+++ b/libleptongui/src/o_grips.c
@@ -1408,7 +1408,7 @@ void o_grips_end(GschemToplevel *w_current)
   schematic_window_set_rubber_visible (w_current, 0);
 
   schematic_window_active_page_changed (w_current);
-  o_undo_savestate_old(w_current, UNDO_ALL);
+  o_undo_savestate_old (w_current);
 
   i_set_state(w_current, SELECT);
   i_action_stop (w_current);

--- a/libleptongui/src/o_line.c
+++ b/libleptongui/src/o_line.c
@@ -116,7 +116,7 @@ void o_line_end(GschemToplevel *w_current, int w_x, int w_y)
     g_run_hook_object (w_current, "add-objects-hook", new_obj);
 
     gschem_toplevel_page_content_changed (w_current, page);
-    o_undo_savestate(w_current, page, UNDO_ALL);
+    o_undo_savestate (w_current, page, FALSE);
   }
 
   i_action_stop (w_current);

--- a/libleptongui/src/o_misc.c
+++ b/libleptongui/src/o_misc.c
@@ -93,7 +93,7 @@ void o_rotate_world_update(GschemToplevel *w_current,
   schematic_window_active_page_changed (w_current);
   if (!schematic_window_get_inside_action (w_current))
   {
-    o_undo_savestate_old(w_current, UNDO_ALL);
+    o_undo_savestate_old (w_current);
   }
 
   if (schematic_window_get_action_mode (w_current) == ROTATEMODE)
@@ -148,7 +148,7 @@ void o_mirror_world_update(GschemToplevel *w_current, int centerx, int centery, 
   g_run_hook_object_list (w_current, "mirror-objects-hook", list);
 
   schematic_window_active_page_changed (w_current);
-  o_undo_savestate_old(w_current, UNDO_ALL);
+  o_undo_savestate_old (w_current);
 
   if (schematic_window_get_action_mode (w_current) == MIRRORMODE)
   {
@@ -245,7 +245,7 @@ void o_edit_hide_specific_text (GschemToplevel *w_current,
     }
     iter = g_list_next (iter);
   }
-  o_undo_savestate_old(w_current, UNDO_ALL);
+  o_undo_savestate_old (w_current);
   gschem_page_view_invalidate_all (gschem_toplevel_get_current_page_view (w_current));
 }
 
@@ -279,5 +279,5 @@ void o_edit_show_specific_text (GschemToplevel *w_current,
     }
     iter = g_list_next (iter);
   }
-  o_undo_savestate_old(w_current, UNDO_ALL);
+  o_undo_savestate_old (w_current);
 }

--- a/libleptongui/src/o_move.c
+++ b/libleptongui/src/o_move.c
@@ -232,7 +232,7 @@ void o_move_end(GschemToplevel *w_current)
   g_list_free (moved_list);
 
   gschem_toplevel_page_content_changed (w_current, page);
-  o_undo_savestate_old(w_current, UNDO_ALL);
+  o_undo_savestate_old (w_current);
 
   s_stretch_destroy_all (w_current->stretch_list);
   w_current->stretch_list = NULL;

--- a/libleptongui/src/o_net.c
+++ b/libleptongui/src/o_net.c
@@ -584,7 +584,7 @@ void o_net_end(GschemToplevel *w_current, int w_x, int w_y)
   w_current->first_wy = save_wy;
 
   gschem_toplevel_page_content_changed (w_current, page);
-  o_undo_savestate_old(w_current, UNDO_ALL);
+  o_undo_savestate_old (w_current);
 
   /* Continue net drawing */
   o_net_start(w_current, w_current->first_wx, w_current->first_wy);

--- a/libleptongui/src/o_path.c
+++ b/libleptongui/src/o_path.c
@@ -511,7 +511,7 @@ o_path_end(GschemToplevel *w_current, int w_x, int w_y)
     lepton_page_append (page, obj);
     g_run_hook_object (w_current, "add-objects-hook", obj);
     gschem_toplevel_page_content_changed (w_current, page);
-    o_undo_savestate (w_current, page, UNDO_ALL);
+    o_undo_savestate (w_current, page, FALSE);
 
     schematic_window_set_rubber_visible (w_current, 0);
 

--- a/libleptongui/src/o_picture.c
+++ b/libleptongui/src/o_picture.c
@@ -119,7 +119,7 @@ void o_picture_end(GschemToplevel *w_current, int w_x, int w_y)
     g_run_hook_object (w_current, "add-objects-hook", new_obj);
 
     schematic_window_active_page_changed (w_current);
-    o_undo_savestate_old(w_current, UNDO_ALL);
+    o_undo_savestate_old (w_current);
   }
   i_action_stop (w_current);
 }

--- a/libleptongui/src/o_pin.c
+++ b/libleptongui/src/o_pin.c
@@ -77,7 +77,7 @@ void o_pin_end(GschemToplevel *w_current, int x, int y)
   g_run_hook_object (w_current, "add-objects-hook", new_obj);
 
   gschem_toplevel_page_content_changed (w_current, page);
-  o_undo_savestate(w_current, page, UNDO_ALL);
+  o_undo_savestate(w_current, page, FALSE);
   i_action_stop (w_current);
 }
 

--- a/libleptongui/src/o_place.c
+++ b/libleptongui/src/o_place.c
@@ -132,7 +132,7 @@ void o_place_end (GschemToplevel *w_current,
   o_invalidate_glist (w_current, temp_dest_list); /* only redraw new objects */
   g_list_free (temp_dest_list);
 
-  o_undo_savestate_old (w_current, UNDO_ALL);
+  o_undo_savestate_old (w_current);
   i_update_menus (w_current);
 
   if (!continue_placing) {

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2015 gEDA Contributors
- * Copyright (C) 2017-2023 Lepton EDA Contributors
+ * Copyright (C) 2017-2024 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -429,23 +429,16 @@ o_undo_savestate (GschemToplevel *w_current,
 /*! \todo Finish function documentation!!!
  *  \brief
  *  \par Function Description
- *
- *
- *  <B>flag</B> can be one of the following values:
- *  <DL>
- *    <DT>*</DT><DD>UNDO_ALL
- *    <DT>*</DT><DD>UNDO_VIEWPORT_ONLY
- *  </DL>
  */
 void
-o_undo_savestate_old (GschemToplevel *w_current, int flag)
+o_undo_savestate_old (GschemToplevel *w_current)
 {
   GschemPageView *page_view = gschem_toplevel_get_current_page_view (w_current);
   g_return_if_fail (page_view != NULL);
 
   LeptonPage *page = gschem_page_view_get_page (page_view);
 
-  o_undo_savestate (w_current, page, flag);
+  o_undo_savestate (w_current, page, UNDO_ALL);
 }
 
 

--- a/libleptongui/src/o_undo.c
+++ b/libleptongui/src/o_undo.c
@@ -235,16 +235,22 @@ o_autosave_backups (GschemToplevel *w_current)
 }
 
 
-/*! \todo Finish function documentation!!!
- *  \brief
+/*! \brief Save current state of page onto the undo stack.
  *  \par Function Description
- *
+ *  The function saves the objects and/or viewport of the current
+ *  page onto the head of the undo stack to possibly restore it
+ *  later.
  *
  *  <B>flag</B> can be one of the following values:
  *  <DL>
  *    <DT>*</DT><DD>UNDO_ALL
  *    <DT>*</DT><DD>UNDO_VIEWPORT_ONLY
  *  </DL>
+
+ * \param [in] w_current The #GschemToplevel object the current
+ *                       page belongs to.
+ * \param [in] page The \c LeptonPage instance.
+ * \param [in] flag The flag of the current operation type.
  */
 void
 o_undo_savestate (GschemToplevel *w_current,

--- a/libleptongui/src/x_attribedit.c
+++ b/libleptongui/src/x_attribedit.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2016 gEDA Contributors
- * Copyright (C) 2017-2022 Lepton EDA Contributors
+ * Copyright (C) 2017-2024 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -199,7 +199,7 @@ void attrib_edit_dialog_ok(GtkWidget * w, GschemToplevel *w_current)
         }
         s_current = g_list_next (s_current);
       }
-      o_undo_savestate_old(w_current, UNDO_ALL);
+      o_undo_savestate_old (w_current);
     }
     else
     {
@@ -245,12 +245,12 @@ void attrib_edit_dialog_ok(GtkWidget * w, GschemToplevel *w_current)
                            wy);
 
       schematic_window_active_page_changed (w_current);
-      o_undo_savestate_old(w_current, UNDO_ALL);
+      o_undo_savestate_old (w_current);
     }
   } else {
     o_text_change(w_current, attribptr, newtext, vis, show);
     schematic_window_active_page_changed (w_current);
-    o_undo_savestate_old(w_current, UNDO_ALL);
+    o_undo_savestate_old (w_current);
   }
   gtk_grab_remove(w_current->aewindow);
   gtk_widget_destroy(w_current->aewindow);

--- a/libleptongui/src/x_autonumber.c
+++ b/libleptongui/src/x_autonumber.c
@@ -867,7 +867,7 @@ void autonumber_text_autonumber(AUTONUMBER_TEXT *autotext)
   gschem_toplevel_page_changed (w_current);
   gschem_page_view_invalidate_all (gschem_toplevel_get_current_page_view (w_current));
   g_list_free(pages);
-  o_undo_savestate_old(w_current, UNDO_ALL);
+  o_undo_savestate_old (w_current);
 }
 
 /* ***** UTILITY GUI FUNCTIONS (move to a separate file in the future?) **** */

--- a/libleptongui/src/x_multiattrib.c
+++ b/libleptongui/src/x_multiattrib.c
@@ -567,7 +567,7 @@ multiattrib_action_add_attribute (Multiattrib *multiattrib,
   }
 
   schematic_window_active_page_changed (w_current);
-  o_undo_savestate_old (w_current, UNDO_ALL);
+  o_undo_savestate_old (w_current);
 
   g_free (newtext);
 }
@@ -601,7 +601,7 @@ multiattrib_action_duplicate_attributes (Multiattrib *multiattrib,
   }
 
   schematic_window_active_page_changed (w_current);
-  o_undo_savestate_old (w_current, UNDO_ALL);
+  o_undo_savestate_old (w_current);
 }
 
 /*! \todo Finish function documentation
@@ -648,7 +648,7 @@ multiattrib_action_promote_attributes (Multiattrib *multiattrib,
   }
 
   schematic_window_active_page_changed (w_current);
-  o_undo_savestate_old (w_current, UNDO_ALL);
+  o_undo_savestate_old (w_current);
 }
 
 /*! \todo Finish function documentation
@@ -671,7 +671,7 @@ multiattrib_action_delete_attributes (Multiattrib *multiattrib,
   }
 
   schematic_window_active_page_changed (w_current);
-  o_undo_savestate_old (w_current, UNDO_ALL);
+  o_undo_savestate_old (w_current);
 }
 
 /*! \todo Finish function documentation
@@ -723,7 +723,7 @@ multiattrib_action_copy_attribute_to_all (Multiattrib *multiattrib,
   }
 
   schematic_window_active_page_changed (w_current);
-  o_undo_savestate_old (w_current, UNDO_ALL);
+  o_undo_savestate_old (w_current);
 }
 
 /*! \todo Finish function documentation
@@ -983,7 +983,7 @@ multiattrib_callback_edited_name (GtkCellRendererText *cellrenderertext,
   g_free (newtext);
 
   schematic_window_active_page_changed (w_current);
-  o_undo_savestate_old (w_current, UNDO_ALL);
+  o_undo_savestate_old (w_current);
 
   /* NB: We don't fix up the model to reflect the edit, we're about to nuke it below... */
 
@@ -1074,7 +1074,7 @@ multiattrib_callback_edited_value (GtkCellRendererText *cell_renderer,
   g_free (newtext);
 
   schematic_window_active_page_changed (w_current);
-  o_undo_savestate_old (w_current, UNDO_ALL);
+  o_undo_savestate_old (w_current);
 
   /* Fixup the model to reflect the edit */
   gtk_list_store_set (GTK_LIST_STORE (model), &iter,
@@ -1129,7 +1129,7 @@ multiattrib_callback_toggled_visible (GtkCellRendererToggle *cell_renderer,
   g_object_unref (attr_list);
 
   schematic_window_active_page_changed (w_current);
-  o_undo_savestate_old (w_current, UNDO_ALL);
+  o_undo_savestate_old (w_current);
 
   /* Fixup the model to reflect the edit */
   gtk_list_store_set (GTK_LIST_STORE (model), &iter,
@@ -1193,7 +1193,7 @@ multiattrib_callback_toggled_show_name (GtkCellRendererToggle *cell_renderer,
   g_object_unref (attr_list);
 
   schematic_window_active_page_changed (w_current);
-  o_undo_savestate_old (w_current, UNDO_ALL);
+  o_undo_savestate_old (w_current);
 
   /* NB: We don't fix up the model to reflect the edit, we're about to nuke it below... */
 
@@ -1257,7 +1257,7 @@ multiattrib_callback_toggled_show_value (GtkCellRendererToggle *cell_renderer,
   g_object_unref (attr_list);
 
   schematic_window_active_page_changed (w_current);
-  o_undo_savestate_old (w_current, UNDO_ALL);
+  o_undo_savestate_old (w_current);
 
   /* NB: We don't fix up the model to reflect the edit, we're about to nuke it below... */
 

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -578,7 +578,7 @@ x_window_open_page (GschemToplevel *w_current,
   recent_manager_add (w_current, filename);
 
   /* Save current state of the page: */
-  o_undo_savestate (w_current, page, UNDO_ALL);
+  o_undo_savestate (w_current, page, FALSE);
 
   return page;
 
@@ -1167,7 +1167,7 @@ x_window_new_page (GschemToplevel* w_current)
   g_run_hook_page (w_current, "new-page-hook", page);
 
   /* Save current state of the page: */
-  o_undo_savestate (w_current, page, UNDO_ALL);
+  o_undo_savestate (w_current, page, FALSE);
 
   return page;
 


### PR DESCRIPTION
The legacy C function `o_undo_savestate_old()` has been amended so
that it has no additional function argument that specifies what
type of undo has to be done, regular or one recording the viewport
change.

As there are only two undo types, another undo function,
`o_undo_savestate()`, has been amended to not support the already
existing undo constants `UNDO_ALL` and `UNDO_VIEWPORT_ONLY`
defined in C.  Instead, it takes a boolean argument that informs
it if the only viewport change has to be stored in the memory.
This allows to avoid duplicating those constants in the Scheme
code of the program.
