### PR TITLE
Report errors of opening a file in the File select dialog

### DIFF
--- a/libleptongui/scheme/schematic/preview-widget.scm
+++ b/libleptongui/scheme/schematic/preview-widget.scm
@@ -58,6 +58,7 @@ buffer should be displayed, the widget displays the error message."
       (unless (null-pointer? *err)
         (let ((message (gerror-message *err)))
           (g_clear_error *error)
+          (log! 'warning (G_ "Preview error: ~A") message)
           (lepton_page_append *page
                               (object->pointer
                                (make-text '(100 . 100)


### PR DESCRIPTION
It was a long ago added `FIXME`.  While some errors like missing
file permissions are processed in the *Component select* dialog
widget, there was no the like feature in the *File select* dialog
code so far.

If a schematic or symbol file cannot be open, the error is now
reported the same way as in the *Component select* dialog, that
is, an empty page with an only text message corresponding to the
error is shown instead of a blank page.  The preview errors are
now logged as well.
