### PR TITLE
Add modules (schematic canvas) and (schematic canvas foreign)

### DIFF
--- a/libleptongui/scheme/Makefile.am
+++ b/libleptongui/scheme/Makefile.am
@@ -22,6 +22,7 @@ nobase_dist_scmdata_DATA = \
 	schematic/buffer.scm \
 	schematic/builtins.scm \
 	schematic/callback.scm \
+	schematic/canvas/foreign.scm \
 	schematic/dialog.scm \
 	schematic/dialog/file-select.scm \
 	schematic/dialog/slot-edit.scm \

--- a/libleptongui/scheme/Makefile.am
+++ b/libleptongui/scheme/Makefile.am
@@ -22,6 +22,7 @@ nobase_dist_scmdata_DATA = \
 	schematic/buffer.scm \
 	schematic/builtins.scm \
 	schematic/callback.scm \
+	schematic/canvas.scm \
 	schematic/canvas/foreign.scm \
 	schematic/dialog.scm \
 	schematic/dialog/file-select.scm \

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -2,7 +2,7 @@
 ;; Scheme API
 ;; Copyright (C) 2013 Peter Brett <peter@peter-b.co.uk>
 ;; Copyright (C) 2013-2015 gEDA Contributors
-;; Copyright (C) 2017-2023 Lepton EDA Contributors
+;; Copyright (C) 2017-2024 Lepton EDA Contributors
 ;;
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -44,6 +44,7 @@
   #:use-module (schematic action-mode)
   #:use-module (schematic buffer)
   #:use-module (schematic callback)
+  #:use-module (schematic canvas)
   #:use-module (schematic gettext)
   #:use-module (schematic ffi)
   #:use-module (schematic dialog)
@@ -454,8 +455,7 @@ the snap grid size should be set to 100")))
   (i_update_menus *window)
 
   ;; Refresh page view to properly restore attributes' colors.
-  (gschem_page_view_invalidate_all
-   (schematic_window_get_current_page_view *window)))
+  (invalidate-canvas (window-canvas (current-window))))
 
 
 ;;; Unlock all objects in selection list.
@@ -479,8 +479,7 @@ the snap grid size should be set to 100")))
   (undo-save-state)
 
   ;; Refresh page view to properly restore attributes' colors.
-  (gschem_page_view_invalidate_all
-   (schematic_window_get_current_page_view *window)))
+  (invalidate-canvas (window-canvas (current-window))))
 
 
 (define-action-public (&edit-select-locked #:label (G_ "Select Locked"))
@@ -716,8 +715,7 @@ the snap grid size should be set to 100")))
 
 ;;; Redraw canvas.
 (define-action-public (&view-redraw #:label (G_ "Redraw") #:icon "gtk-refresh")
-  (gschem_page_view_invalidate_all
-   (schematic_window_get_current_page_view (*current-window))))
+  (invalidate-canvas (window-canvas (current-window))))
 
 
 (define-action-public (&view-pan #:label (G_ "Pan"))
@@ -835,8 +833,7 @@ the snap grid size should be set to 100")))
   (x_colorcb_update_colors)
   (color_edit_widget_update *window)
 
-  (gschem_page_view_invalidate_all
-   (schematic_window_get_current_page_view *window)))
+  (invalidate-canvas (window-canvas (current-window))))
 
 
 ;;; Load the Dark color scheme.
@@ -1588,8 +1585,7 @@ the snap grid size should be set to 100")))
   (define draw-grips (true? (schematic_window_get_draw_grips *window)))
 
   (schematic_window_set_draw_grips *window (if draw-grips FALSE TRUE))
-  (gschem_page_view_invalidate_all
-   (schematic_window_get_current_page_view *window)))
+  (invalidate-canvas (window-canvas (current-window))))
 
 
 ;; -------------------------------------------------------------------

--- a/libleptongui/scheme/schematic/canvas.scm
+++ b/libleptongui/scheme/schematic/canvas.scm
@@ -1,0 +1,30 @@
+;;; Lepton EDA library - Scheme API
+;;; Copyright (C) 2024 Lepton EDA Contributors
+;;;
+;;; This program is free software; you can redistribute it and/or modify
+;;; it under the terms of the GNU General Public License as published by
+;;; the Free Software Foundation; either version 2 of the License, or
+;;; (at your option) any later version.
+;;;
+;;; This program is distributed in the hope that it will be useful,
+;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;; GNU General Public License for more details.
+;;;
+;;; You should have received a copy of the GNU General Public License
+;;; along with this program; if not, write to the Free Software
+;;; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
+(define-module (schematic canvas)
+  #:use-module (schematic ffi)
+  #:use-module (schematic canvas foreign)
+
+  #:export (invalidate-canvas))
+
+
+(define (invalidate-canvas canvas)
+  "Schedule redraw for the entire window CANVAS."
+  (define *canvas (check-canvas canvas 1))
+
+  (gschem_page_view_invalidate_all *canvas))

--- a/libleptongui/scheme/schematic/canvas/foreign.scm
+++ b/libleptongui/scheme/schematic/canvas/foreign.scm
@@ -1,0 +1,75 @@
+;;; Lepton EDA library - Scheme API
+;;; Copyright (C) 2024 Lepton EDA Contributors
+;;;
+;;; This program is free software; you can redistribute it and/or modify
+;;; it under the terms of the GNU General Public License as published by
+;;; the Free Software Foundation; either version 2 of the License, or
+;;; (at your option) any later version.
+;;;
+;;; This program is distributed in the hope that it will be useful,
+;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;; GNU General Public License for more details.
+;;;
+;;; You should have received a copy of the GNU General Public License
+;;; along with this program; if not, write to the Free Software
+;;; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
+(define-module (schematic canvas foreign)
+  #:use-module (ice-9 format)
+  #:use-module (system foreign)
+
+  #:use-module (lepton ffi check-args)
+  #:use-module (lepton ffi)
+
+  #:export (is-canvas?
+            check-canvas
+            canvas->pointer
+            pointer->canvas))
+
+
+;;; Define a wrapped pointer type.
+(define-wrapped-pointer-type <canvas>
+  is-canvas?
+  wrap-canvas
+  unwrap-canvas
+  ;; Printer.
+  (lambda (canvas port)
+    (format port "#<canvas-0x~x>"
+            (pointer-address (unwrap-canvas canvas)))))
+
+
+;;; Helper transformers between the <canvas> type and C canvas
+;;; pointers.
+(define (canvas->pointer canvas)
+  "Transforms CANVAS which should be an instance of the <canvas>
+type into a foreign C pointer.  If CANVAS has another type, raises
+a 'wrong-type-arg error."
+  (if (is-canvas? canvas)
+      (unwrap-canvas canvas)
+      (error-wrong-type-arg 1 '<canvas> canvas)))
+
+
+(define (pointer->canvas pointer)
+  "Transforms POINTER to a <canvas> type instance. Raises a
+'wrong-type-arg error if POINTER is not a foreign C pointer.
+Raises a 'misc-error error if the pointer is a NULL pointer."
+  (if (pointer? pointer)
+      (if (null-pointer? pointer)
+          (error "Cannot convert NULL pointer to <canvas>.")
+          (wrap-canvas pointer))
+      (error-wrong-type-arg 1 'pointer pointer)))
+
+
+;;; Syntax rules to check <canvas> instances.  The same as for
+;;; <object> in the module (lepton object foreign).
+(define-syntax check-canvas
+  (syntax-rules ()
+    ((_ canvas pos)
+     (let ((pointer (and (is-canvas? canvas)
+                         (unwrap-canvas canvas))))
+       (if (or (not pointer)
+               (null-pointer? pointer))
+           (error-wrong-type-arg pos '<canvas> canvas)
+           pointer)))))

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -42,6 +42,7 @@
   #:use-module (schematic action-mode)
   #:use-module (schematic buffer)
   #:use-module (schematic callback)
+  #:use-module (schematic canvas foreign)
   #:use-module (schematic ffi)
   #:use-module (schematic ffi gtk)
   #:use-module (schematic gettext)
@@ -64,6 +65,7 @@
             set-active-page!
             pointer-position
             snap-point
+            window-canvas
             window-close-page!
             window-open-page!
             window-set-current-page!
@@ -1216,6 +1218,13 @@ window to PAGE.  Returns PAGE."
   (define *window (check-window window 1))
   (define *page (check-page page 2))
   (*window-set-current-page! *window *page))
+
+
+(define (window-canvas window)
+  "Return the <canvas> object of WINDOW."
+  (define *window (check-window window 1))
+
+  (pointer->canvas (schematic_window_get_current_page_view *window)))
 
 
 (define (pointer-position)


### PR DESCRIPTION
- A new foreign structure, `<canvas>`, and a new module,
  `(schematic canvas foreign)`, have been added.  The module
  contains helpers for working with wrapped pointers of this type.
  The new Scheme structure and the module are intended to simplify
  working with the foreign C type `GschemPageView` and its
  functions.  The name `canvas` has been chosen deliberately in
  order to reduce the function and variable names for the type.
- A new function, `window-canvas()`, has been added.  It returns
  the `<canvas>` instance for a given `<window>`.
- A new module, `(schematic canvas)`, has been added.  Currently
  it exports an only function, `invalidate-canvas()`, that is used
  in builtin callbacks to redraw the window canvas when changing
  their page contents.
