### PR TITLE
Rewrite Zoom box GUI functions in Scheme

### DIFF
--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -10,13 +10,6 @@ a_zoom (SchematicWindow *w_current,
         int dir,
         int selected_from);
 void
-a_zoom_box (SchematicWindow *w_current,
-            SchematicCanvas *page_view,
-            SchematicViewport *geometry,
-            double world_pan_center_x,
-            double world_pan_center_y,
-            double relativ_zoom_factor);
-void
 a_zoom_box_start (SchematicWindow *w_current,
                   int x,
                   int y);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -10,10 +10,6 @@ a_zoom (SchematicWindow *w_current,
         int dir,
         int selected_from);
 void
-a_zoom_box_motion (SchematicWindow *w_current,
-                   int x,
-                   int y);
-void
 a_zoom_box_invalidate_rubber (SchematicWindow *w_current);
 
 void

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -11,7 +11,8 @@ a_zoom (SchematicWindow *w_current,
         int selected_from);
 void
 a_zoom_box (SchematicWindow *w_current,
-            SchematicCanvas *page_view);
+            SchematicCanvas *page_view,
+            SchematicViewport *geometry);
 void
 a_zoom_box_start (SchematicWindow *w_current,
                   int x,

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -10,9 +10,6 @@ a_zoom (SchematicWindow *w_current,
         int dir,
         int selected_from);
 void
-a_zoom_box_invalidate_rubber (SchematicWindow *w_current);
-
-void
 a_zoom_box_draw_rubber (SchematicWindow *w_current,
                         EdaRenderer *renderer);
 

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -13,6 +13,8 @@ void
 a_zoom_box (SchematicWindow *w_current,
             SchematicCanvas *page_view,
             SchematicViewport *geometry,
+            double world_pan_center_x,
+            double world_pan_center_y,
             double relativ_zoom_factor);
 void
 a_zoom_box_start (SchematicWindow *w_current,

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -10,8 +10,8 @@ a_zoom (SchematicWindow *w_current,
         int dir,
         int selected_from);
 void
-a_zoom_box (SchematicWindow *w_current);
-
+a_zoom_box (SchematicWindow *w_current,
+            SchematicCanvas *page_view);
 void
 a_zoom_box_start (SchematicWindow *w_current,
                   int x,

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -12,7 +12,9 @@ a_zoom (SchematicWindow *w_current,
 void
 a_zoom_box (SchematicWindow *w_current,
             SchematicCanvas *page_view,
-            SchematicViewport *geometry);
+            SchematicViewport *geometry,
+            double zx,
+            double zy);
 void
 a_zoom_box_start (SchematicWindow *w_current,
                   int x,

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -10,10 +10,6 @@ a_zoom (SchematicWindow *w_current,
         int dir,
         int selected_from);
 void
-a_zoom_box_start (SchematicWindow *w_current,
-                  int x,
-                  int y);
-void
 a_zoom_box_motion (SchematicWindow *w_current,
                    int x,
                    int y);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -13,8 +13,7 @@ void
 a_zoom_box (SchematicWindow *w_current,
             SchematicCanvas *page_view,
             SchematicViewport *geometry,
-            double zx,
-            double zy);
+            double relativ_zoom_factor);
 void
 a_zoom_box_start (SchematicWindow *w_current,
                   int x,

--- a/libleptongui/scheme/Makefile.am
+++ b/libleptongui/scheme/Makefile.am
@@ -50,6 +50,7 @@ nobase_dist_scmdata_DATA = \
 	schematic/toolbar.scm \
 	schematic/util.scm \
 	schematic/undo.scm \
+	schematic/viewport/foreign.scm \
 	schematic/window.scm \
 	schematic/window/foreign.scm \
 	schematic/window/global.scm \

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -783,7 +783,7 @@ the snap grid size should be set to 100")))
   (set-action-mode! 'zoom-box-mode)
 
   (match (action-position)
-    ((x . y) (zoom-box-start *window x y))
+    ((x . y) (zoom-box-start (current-window) x y))
     (_ #f)))
 
 

--- a/libleptongui/scheme/schematic/builtins.scm
+++ b/libleptongui/scheme/schematic/builtins.scm
@@ -783,7 +783,7 @@ the snap grid size should be set to 100")))
   (set-action-mode! 'zoom-box-mode)
 
   (match (action-position)
-    ((x . y) (a_zoom_box_start *window x y))
+    ((x . y) (zoom-box-start *window x y))
     (_ #f)))
 
 

--- a/libleptongui/scheme/schematic/canvas.scm
+++ b/libleptongui/scheme/schematic/canvas.scm
@@ -19,8 +19,17 @@
 (define-module (schematic canvas)
   #:use-module (schematic ffi)
   #:use-module (schematic canvas foreign)
+  #:use-module (schematic viewport foreign)
 
-  #:export (invalidate-canvas))
+  #:export (canvas-viewport
+            invalidate-canvas))
+
+
+(define (canvas-viewport canvas)
+  "Return the <viewport> object of CANVAS."
+  (define *canvas (check-canvas canvas 1))
+
+  (pointer->viewport (schematic_canvas_get_viewport *canvas)))
 
 
 (define (invalidate-canvas canvas)

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -390,6 +390,7 @@
             schematic_window_set_place_list
             schematic_window_get_right_notebook
             schematic_window_set_right_notebook
+            schematic_window_get_rubber_visible
             schematic_window_set_rubber_visible
             schematic_window_get_selection_list
             schematic_window_get_third_button
@@ -508,7 +509,6 @@
 
             a_zoom
             a_zoom_box_invalidate_rubber
-            a_zoom_box_motion
 
             g_action_eval_by_name
 
@@ -728,6 +728,7 @@
 (define-lff schematic_window_set_place_list void '(* *))
 (define-lff schematic_window_get_right_notebook '* '(*))
 (define-lff schematic_window_set_right_notebook void '(* *))
+(define-lff schematic_window_get_rubber_visible int '(*))
 (define-lff schematic_window_set_rubber_visible void (list '* int))
 (define-lff schematic_window_get_selection_list '* '(*))
 (define-lff schematic_window_get_third_button int '(*))
@@ -1107,7 +1108,6 @@
 ;;; a_zoom.c
 (define-lff a_zoom void (list '* '* int int))
 (define-lff a_zoom_box_invalidate_rubber void '(*))
-(define-lff a_zoom_box_motion void (list '* int int))
 
 ;;; x_menus.c
 (define-lff g_action_eval_by_name int (list '* '*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -1100,7 +1100,7 @@
 
 ;;; a_zoom.c
 (define-lff a_zoom void (list '* '* int int))
-(define-lff a_zoom_box void '(* * *))
+(define-lff a_zoom_box void (list '* '* '* double double))
 (define-lff a_zoom_box_invalidate_rubber void '(*))
 (define-lff a_zoom_box_motion void (list '* int int))
 (define-lff a_zoom_box_start void (list '* int int))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -1100,7 +1100,7 @@
 
 ;;; a_zoom.c
 (define-lff a_zoom void (list '* '* int int))
-(define-lff a_zoom_box void (list '* '* '* double double))
+(define-lff a_zoom_box void (list '* '* '* double))
 (define-lff a_zoom_box_invalidate_rubber void '(*))
 (define-lff a_zoom_box_motion void (list '* int int))
 (define-lff a_zoom_box_start void (list '* int int))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -1096,7 +1096,7 @@
 
 ;;; a_zoom.c
 (define-lff a_zoom void (list '* '* int int))
-(define-lff a_zoom_box void '(* *))
+(define-lff a_zoom_box void '(* * *))
 (define-lff a_zoom_box_invalidate_rubber void '(*))
 (define-lff a_zoom_box_motion void (list '* int int))
 (define-lff a_zoom_box_start void (list '* int int))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -46,6 +46,7 @@
             i_callback_file_save
             *i_callback_file_save
 
+            i_action_start
             i_action_stop
             i_set_state
             i_set_state_msg
@@ -372,7 +373,9 @@
             schematic_window_get_first_wy
             schematic_window_set_first_wy
             schematic_window_get_second_wx
+            schematic_window_set_second_wx
             schematic_window_get_second_wy
+            schematic_window_set_second_wy
             schematic_window_get_find_text_state_widget
             schematic_window_set_find_text_state_widget
             schematic_window_set_font_select_widget
@@ -506,7 +509,6 @@
             a_zoom
             a_zoom_box_invalidate_rubber
             a_zoom_box_motion
-            a_zoom_box_start
 
             g_action_eval_by_name
 
@@ -709,7 +711,9 @@
 (define-lff schematic_window_get_first_wy int '(*))
 (define-lff schematic_window_set_first_wy void (list '* int))
 (define-lff schematic_window_get_second_wx int '(*))
+(define-lff schematic_window_set_second_wx void (list '* int))
 (define-lff schematic_window_get_second_wy int '(*))
+(define-lff schematic_window_set_second_wy void (list '* int))
 (define-lff schematic_window_get_find_text_state_widget '* '(*))
 (define-lff schematic_window_set_find_text_state_widget void '(* *))
 (define-lff schematic_window_set_font_select_widget void '(* *))
@@ -902,6 +906,7 @@
 (define-lfc *i_callback_file_save)
 
 ;;; i_basic.c
+(define-lff i_action_start void '(*))
 (define-lff i_action_stop void '(*))
 (define-lff i_set_state void (list '* int))
 (define-lff i_set_state_msg void (list '* int '*))
@@ -1103,7 +1108,6 @@
 (define-lff a_zoom void (list '* '* int int))
 (define-lff a_zoom_box_invalidate_rubber void '(*))
 (define-lff a_zoom_box_motion void (list '* int int))
-(define-lff a_zoom_box_start void (list '* int int))
 
 ;;; x_menus.c
 (define-lff g_action_eval_by_name int (list '* '*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -1100,7 +1100,7 @@
 
 ;;; a_zoom.c
 (define-lff a_zoom void (list '* '* int int))
-(define-lff a_zoom_box void (list '* '* '* double))
+(define-lff a_zoom_box void (list '* '* '* double double double))
 (define-lff a_zoom_box_invalidate_rubber void '(*))
 (define-lff a_zoom_box_motion void (list '* int int))
 (define-lff a_zoom_box_start void (list '* int int))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -324,6 +324,7 @@
             schematic_canvas_new_with_page
             schematic_canvas_pan
             schematic_canvas_pan_end
+            schematic_canvas_pan_general
             schematic_canvas_pan_mouse
             schematic_canvas_pan_motion
             schematic_canvas_pan_start
@@ -503,7 +504,6 @@
             x_tabs_prev
 
             a_zoom
-            a_zoom_box
             a_zoom_box_invalidate_rubber
             a_zoom_box_motion
             a_zoom_box_start
@@ -642,6 +642,7 @@
 (define-lff schematic_canvas_new_with_page '* '(*))
 (define-lff schematic_canvas_pan void (list '* int int))
 (define-lff schematic_canvas_pan_end int '(*))
+(define-lff schematic_canvas_pan_general void (list '* int int double))
 (define-lff schematic_canvas_pan_mouse void (list '* int int))
 (define-lff schematic_canvas_pan_motion void (list '* int int int))
 (define-lff schematic_canvas_pan_start void (list '* int int))
@@ -1100,7 +1101,6 @@
 
 ;;; a_zoom.c
 (define-lff a_zoom void (list '* '* int int))
-(define-lff a_zoom_box void (list '* '* '* double double double))
 (define-lff a_zoom_box_invalidate_rubber void '(*))
 (define-lff a_zoom_box_motion void (list '* int int))
 (define-lff a_zoom_box_start void (list '* int int))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -1096,7 +1096,7 @@
 
 ;;; a_zoom.c
 (define-lff a_zoom void (list '* '* int int))
-(define-lff a_zoom_box void '(*))
+(define-lff a_zoom_box void '(* *))
 (define-lff a_zoom_box_invalidate_rubber void '(*))
 (define-lff a_zoom_box_motion void (list '* int int))
 (define-lff a_zoom_box_start void (list '* int int))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -366,7 +366,9 @@
             schematic_window_get_enforce_hierarchy
             schematic_window_get_file_preview
             schematic_window_set_file_preview
+            schematic_window_get_first_wx
             schematic_window_set_first_wx
+            schematic_window_get_first_wy
             schematic_window_set_first_wy
             schematic_window_get_second_wx
             schematic_window_get_second_wy
@@ -701,7 +703,9 @@
 (define-lff schematic_window_get_enforce_hierarchy int '(*))
 (define-lff schematic_window_get_file_preview int '(*))
 (define-lff schematic_window_set_file_preview void (list int '*))
+(define-lff schematic_window_get_first_wx int '(*))
 (define-lff schematic_window_set_first_wx void (list '* int))
+(define-lff schematic_window_get_first_wy int '(*))
 (define-lff schematic_window_set_first_wy void (list '* int))
 (define-lff schematic_window_get_second_wx int '(*))
 (define-lff schematic_window_get_second_wy int '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -322,6 +322,7 @@
             schematic_canvas_get_page
             schematic_canvas_get_viewport
             schematic_canvas_invalidate_all
+            schematic_canvas_invalidate_world_rect
             schematic_canvas_new_with_page
             schematic_canvas_pan
             schematic_canvas_pan_end
@@ -508,7 +509,6 @@
             x_tabs_prev
 
             a_zoom
-            a_zoom_box_invalidate_rubber
 
             g_action_eval_by_name
 
@@ -641,6 +641,7 @@
 (define-lff schematic_canvas_get_page '* '(*))
 (define-lff schematic_canvas_get_viewport '* '(*))
 (define-lff schematic_canvas_invalidate_all void '(*))
+(define-lff schematic_canvas_invalidate_world_rect void (list '* int int int int))
 (define-lff schematic_canvas_new_with_page '* '(*))
 (define-lff schematic_canvas_pan void (list '* int int))
 (define-lff schematic_canvas_pan_end int '(*))
@@ -1107,7 +1108,6 @@
 
 ;;; a_zoom.c
 (define-lff a_zoom void (list '* '* int int))
-(define-lff a_zoom_box_invalidate_rubber void '(*))
 
 ;;; x_menus.c
 (define-lff g_action_eval_by_name int (list '* '*))

--- a/libleptongui/scheme/schematic/viewport/foreign.scm
+++ b/libleptongui/scheme/schematic/viewport/foreign.scm
@@ -1,0 +1,75 @@
+;;; Lepton EDA library - Scheme API
+;;; Copyright (C) 2024 Lepton EDA Contributors
+;;;
+;;; This program is free software; you can redistribute it and/or modify
+;;; it under the terms of the GNU General Public License as published by
+;;; the Free Software Foundation; either version 2 of the License, or
+;;; (at your option) any later version.
+;;;
+;;; This program is distributed in the hope that it will be useful,
+;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;; GNU General Public License for more details.
+;;;
+;;; You should have received a copy of the GNU General Public License
+;;; along with this program; if not, write to the Free Software
+;;; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
+(define-module (schematic viewport foreign)
+  #:use-module (ice-9 format)
+  #:use-module (system foreign)
+
+  #:use-module (lepton ffi check-args)
+  #:use-module (lepton ffi)
+
+  #:export (is-viewport?
+            check-viewport
+            viewport->pointer
+            pointer->viewport))
+
+
+;;; Define a wrapped pointer type.
+(define-wrapped-pointer-type <viewport>
+  is-viewport?
+  wrap-viewport
+  unwrap-viewport
+  ;; Printer.
+  (lambda (viewport port)
+    (format port "#<viewport-0x~x>"
+            (pointer-address (unwrap-viewport viewport)))))
+
+
+;;; Helper transformers between the <viewport> type and C viewport
+;;; pointers.
+(define (viewport->pointer viewport)
+  "Transforms VIEWPORT which should be an instance of the <viewport>
+type into a foreign C pointer.  If VIEWPORT has another type, raises
+a 'wrong-type-arg error."
+  (if (is-viewport? viewport)
+      (unwrap-viewport viewport)
+      (error-wrong-type-arg 1 '<viewport> viewport)))
+
+
+(define (pointer->viewport pointer)
+  "Transforms POINTER to a <viewport> type instance. Raises a
+'wrong-type-arg error if POINTER is not a foreign C pointer.
+Raises a 'misc-error error if the pointer is a NULL pointer."
+  (if (pointer? pointer)
+      (if (null-pointer? pointer)
+          (error "Cannot convert NULL pointer to <viewport>.")
+          (wrap-viewport pointer))
+      (error-wrong-type-arg 1 'pointer pointer)))
+
+
+;;; Syntax rules to check <viewport> instances.  The same as for
+;;; <object> in the module (lepton object foreign).
+(define-syntax check-viewport
+  (syntax-rules ()
+    ((_ viewport pos)
+     (let ((pointer (and (is-viewport? viewport)
+                         (unwrap-viewport viewport))))
+       (if (or (not pointer)
+               (null-pointer? pointer))
+           (error-wrong-type-arg pos '<viewport> viewport)
+           pointer)))))

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -303,8 +303,10 @@
                                       relative-zoom-factor))))
 
 
-(define (zoom-box-start *window x y)
-  "Start zooming in *WINDOW at coords X and Y."
+(define (zoom-box-start window x y)
+  "Start zooming in WINDOW at coords X and Y."
+  (define *window (check-window window 1))
+
   (i_action_start *window)
   (schematic_window_set_first_wx *window x)
   (schematic_window_set_second_wx *window x)
@@ -539,7 +541,7 @@
                        ('path-mode (o_path_start *window x y))
                        ('picture-mode (o_picture_start *window x y))
                        ('pin-mode (o_pin_start *window x y))
-                       ('zoom-box-mode (zoom-box-start *window unsnapped-x unsnapped-y))
+                       ('zoom-box-mode (zoom-box-start window unsnapped-x unsnapped-y))
                        ('select-mode (o_select_start *window x y))
                        ((or 'copy-mode 'multiple-copy-mode) (start-copy *window x y))
                        ('move-mode (o_move_start *window x y))

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -292,14 +292,14 @@
              (relative-zoom-factor (if (< zx zy) zx zy))
 
              ;; Calculate the center of the zoom box.
-             (world-pan-center-x (/ (+ x1 x2) 2.0))
-             (world-pan-center-y (/ (+ y1 y2) 2.0)))
-        (a_zoom_box *window
-                    *canvas
-                    *viewport
-                    world-pan-center-x
-                    world-pan-center-y
-                    relative-zoom-factor))))
+             (world-pan-center-x (round (/ (+ x1 x2) 2)))
+             (world-pan-center-y (round (/ (+ y1 y2) 2))))
+
+        ;; Update the canvas with new values.
+        (schematic_canvas_pan_general *canvas
+                                      world-pan-center-x
+                                      world-pan-center-y
+                                      relative-zoom-factor))))
 
 
 (define (zoom-box-end window x y)

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -282,15 +282,17 @@
   (if (or (= x1 x2) (= y1 y2))
       (log! 'message (G_ "Zoom too small!  Cannot zoom further."))
       ;; Calculate new zoom factors.
-      (let ((zx (/ (abs (- (schematic_viewport_get_left *viewport)
-                           (schematic_viewport_get_right *viewport)))
-                   (abs (- (schematic_window_get_first_wx *window)
-                           (schematic_window_get_second_wx *window)))))
-            (zy (/ (abs (- (schematic_viewport_get_top *viewport)
-                           (schematic_viewport_get_bottom *viewport)))
-                   (abs (- (schematic_window_get_first_wy *window)
-                           (schematic_window_get_second_wy *window))))))
-        (a_zoom_box *window *canvas *viewport zx zy))))
+      (let* ((zx (/ (abs (- (schematic_viewport_get_left *viewport)
+                            (schematic_viewport_get_right *viewport)))
+                    (abs (- (schematic_window_get_first_wx *window)
+                            (schematic_window_get_second_wx *window)))))
+             (zy (/ (abs (- (schematic_viewport_get_top *viewport)
+                            (schematic_viewport_get_bottom *viewport)))
+                    (abs (- (schematic_window_get_first_wy *window)
+                            (schematic_window_get_second_wy *window)))))
+             ;; Choose the smaller one.
+             (relative-zoom-factor (if (< zx zy) zx zy)))
+        (a_zoom_box *window *canvas *viewport relative-zoom-factor))))
 
 
 (define (zoom-box-end window x y)

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -314,6 +314,10 @@
   (schematic_window_set_second_wy *window y))
 
 
+(define (zoom-box-motion *window x y)
+  (a_zoom_box_motion *window x y))
+
+
 (define (zoom-box-end window x y)
   "End zooming in WINDOW at coords X and Y."
   (define *window (check-window window 1))
@@ -730,7 +734,7 @@
                               ('pin-mode (o_pin_motion *window x y))
                               ('grips-mode (o_grips_motion *window x y))
                               ('box-select-mode (o_select_box_motion *window unsnapped-x unsnapped-y))
-                              ('zoom-box-mode (a_zoom_box_motion *window unsnapped-x unsnapped-y))
+                              ('zoom-box-mode (zoom-box-motion *window unsnapped-x unsnapped-y))
                               ('select-mode (o_select_motion *window x y))
                               (_ FALSE)))
 

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -318,7 +318,7 @@
   "Process motion events in *WINDOW when box zooming is in action."
   (define *window (check-window window 1))
 
-  (unless (true? (schematic_window_get_inside_action *window))
+  (unless (in-action? window)
     (error "zoom-box-motion(): The window is not in action!"))
 
   (when (true? (schematic_window_get_rubber_visible *window))

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -71,7 +71,8 @@
             window-close-page!
             window-open-page!
             window-set-current-page!
-            *window-set-current-page!)
+            *window-set-current-page!
+            zoom-box-start)
 
   ;; Overrides the close-page! procedure in the (lepton page)
   ;; module.
@@ -302,8 +303,17 @@
                                       relative-zoom-factor))))
 
 
+(define (zoom-box-start *window x y)
+  "Start zooming in *WINDOW at coords X and Y."
+  (i_action_start *window)
+  (schematic_window_set_first_wx *window x)
+  (schematic_window_set_second_wx *window x)
+  (schematic_window_set_first_wy *window y)
+  (schematic_window_set_second_wy *window y))
+
+
 (define (zoom-box-end window x y)
-  "End zooming in *WINDOW at coords X and Y."
+  "End zooming in WINDOW at coords X and Y."
   (define *window (check-window window 1))
   (check-integer x 2)
   (check-integer y 3)
@@ -529,7 +539,7 @@
                        ('path-mode (o_path_start *window x y))
                        ('picture-mode (o_picture_start *window x y))
                        ('pin-mode (o_pin_start *window x y))
-                       ('zoom-box-mode (a_zoom_box_start *window unsnapped-x unsnapped-y))
+                       ('zoom-box-mode (zoom-box-start *window unsnapped-x unsnapped-y))
                        ('select-mode (o_select_start *window x y))
                        ((or 'copy-mode 'multiple-copy-mode) (start-copy *window x y))
                        ('move-mode (o_move_start *window x y))

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -314,8 +314,10 @@
   (schematic_window_set_second_wy *window y))
 
 
-(define (zoom-box-motion *window x y)
+(define (zoom-box-motion window x y)
   "Process motion events in *WINDOW when box zooming is in action."
+  (define *window (check-window window 1))
+
   (unless (true? (schematic_window_get_inside_action *window))
     (error "zoom-box-motion(): The window is not in action!"))
 
@@ -745,7 +747,7 @@
                               ('pin-mode (o_pin_motion *window x y))
                               ('grips-mode (o_grips_motion *window x y))
                               ('box-select-mode (o_select_box_motion *window unsnapped-x unsnapped-y))
-                              ('zoom-box-mode (zoom-box-motion *window unsnapped-x unsnapped-y))
+                              ('zoom-box-mode (zoom-box-motion window unsnapped-x unsnapped-y))
                               ('select-mode (o_select_motion *window x y))
                               (_ FALSE)))
 

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -273,8 +273,15 @@
   (define canvas (window-canvas window))
   (define *canvas (canvas->pointer canvas))
   (define *viewport (viewport->pointer (canvas-viewport canvas)))
+  (define x1 (schematic_window_get_first_wx *window))
+  (define x2 (schematic_window_get_second_wx *window))
+  (define y1 (schematic_window_get_first_wy *window))
+  (define y2 (schematic_window_get_second_wy *window))
 
-  (a_zoom_box *window *canvas *viewport))
+  ;; Test if there is really a box.
+  (if (or (= x1 x2) (= y1 y2))
+      (log! 'message (G_ "Zoom too small!  Cannot zoom further."))
+      (a_zoom_box *window *canvas *viewport)))
 
 
 (define (zoom-box-end window x y)

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -315,7 +315,18 @@
 
 
 (define (zoom-box-motion *window x y)
-  (a_zoom_box_motion *window x y))
+  "Process motion events in *WINDOW when box zooming is in action."
+  (unless (true? (schematic_window_get_inside_action *window))
+    (error "zoom-box-motion(): The window is not in action!"))
+
+  (when (true? (schematic_window_get_rubber_visible *window))
+    (a_zoom_box_invalidate_rubber *window))
+
+  (schematic_window_set_second_wx *window x)
+  (schematic_window_set_second_wy *window y)
+
+  (a_zoom_box_invalidate_rubber *window)
+  (schematic_window_set_rubber_visible *window 1))
 
 
 (define (zoom-box-end window x y)

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -265,6 +265,10 @@
     (cons window-x window-y)))
 
 
+(define (zoom-box *window)
+  (a_zoom_box *window))
+
+
 (define (zoom-box-end window x y)
   "End zooming in *WINDOW at coords X and Y."
   (define *window (check-window window 1))
@@ -275,7 +279,7 @@
     (error "zoom-box-end(): The window is not in action!"))
   (a_zoom_box_invalidate_rubber *window)
   (schematic_window_set_rubber_visible *window 0)
-  (a_zoom_box *window)
+  (zoom-box *window)
   (when (schematic_window_get_undo_panzoom *window)
     (o_undo_savestate_viewport *window))
   (i_action_stop *window)

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -43,6 +43,7 @@
   #:use-module (schematic buffer)
   #:use-module (schematic callback)
   #:use-module (schematic canvas foreign)
+  #:use-module (schematic canvas)
   #:use-module (schematic ffi)
   #:use-module (schematic ffi gtk)
   #:use-module (schematic gettext)
@@ -51,6 +52,7 @@
   #:use-module (schematic menu)
   #:use-module (schematic toolbar)
   #:use-module (schematic undo)
+  #:use-module (schematic viewport foreign)
   #:use-module (schematic window foreign)
   #:use-module (schematic window global)
   #:use-module (schematic window list)
@@ -268,9 +270,11 @@
 (define (zoom-box window)
   "Zoom WINDOW using the info saved in its page view geometry."
   (define *window (check-window window 1))
-  (define *canvas (canvas->pointer (window-canvas window)))
+  (define canvas (window-canvas window))
+  (define *canvas (canvas->pointer canvas))
+  (define *viewport (viewport->pointer (canvas-viewport canvas)))
 
-  (a_zoom_box *window *canvas))
+  (a_zoom_box *window *canvas *viewport))
 
 
 (define (zoom-box-end window x y)

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -291,8 +291,23 @@
                     (abs (- (schematic_window_get_first_wy *window)
                             (schematic_window_get_second_wy *window)))))
              ;; Choose the smaller one.
-             (relative-zoom-factor (if (< zx zy) zx zy)))
-        (a_zoom_box *window *canvas *viewport relative-zoom-factor))))
+             (relative-zoom-factor (if (< zx zy) zx zy))
+
+             ;; Calculate the center of the zoom box.
+             (world-pan-center-x
+              (/ (+ (schematic_window_get_first_wx *window)
+                    (schematic_window_get_second_wx *window))
+                 2.0))
+             (world-pan-center-y
+              (/ (+ (schematic_window_get_first_wy *window)
+                    (schematic_window_get_second_wy *window))
+                 2.0)))
+        (a_zoom_box *window
+                    *canvas
+                    *viewport
+                    world-pan-center-x
+                    world-pan-center-y
+                    relative-zoom-factor))))
 
 
 (define (zoom-box-end window x y)

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -265,7 +265,9 @@
     (cons window-x window-y)))
 
 
-(define (zoom-box *window)
+(define (zoom-box window)
+  (define *window (check-window window 1))
+
   (a_zoom_box *window))
 
 
@@ -279,7 +281,7 @@
     (error "zoom-box-end(): The window is not in action!"))
   (a_zoom_box_invalidate_rubber *window)
   (schematic_window_set_rubber_visible *window 0)
-  (zoom-box *window)
+  (zoom-box window)
   (when (schematic_window_get_undo_panzoom *window)
     (o_undo_savestate_viewport *window))
   (i_action_stop *window)

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -268,8 +268,9 @@
 (define (zoom-box window)
   "Zoom WINDOW using the info saved in its page view geometry."
   (define *window (check-window window 1))
+  (define *canvas (canvas->pointer (window-canvas window)))
 
-  (a_zoom_box *window))
+  (a_zoom_box *window *canvas))
 
 
 (define (zoom-box-end window x y)

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -266,6 +266,7 @@
 
 
 (define (zoom-box window)
+  "Zoom WINDOW using the info saved in its page view geometry."
   (define *window (check-window window 1))
 
   (a_zoom_box *window))

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -319,7 +319,12 @@
 zooming."
   (define *window (check-window window 1))
 
-  (a_zoom_box_invalidate_rubber *window))
+  (schematic_canvas_invalidate_world_rect
+   (schematic_window_get_current_canvas *window)
+   (schematic_window_get_first_wx *window)
+   (schematic_window_get_first_wy *window)
+   (schematic_window_get_second_wx *window)
+   (schematic_window_get_second_wy *window)))
 
 
 (define (zoom-box-motion window x y)

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -314,6 +314,12 @@
   (schematic_window_set_second_wy *window y))
 
 
+(define (zoom-box-invalidate *window)
+  "Schedule redrawing of the canvas region in WINDOW during box
+zooming."
+  (a_zoom_box_invalidate_rubber *window))
+
+
 (define (zoom-box-motion window x y)
   "Process motion events in *WINDOW when box zooming is in action."
   (define *window (check-window window 1))
@@ -322,12 +328,12 @@
     (error "zoom-box-motion(): The window is not in action!"))
 
   (when (true? (schematic_window_get_rubber_visible *window))
-    (a_zoom_box_invalidate_rubber *window))
+    (zoom-box-invalidate *window))
 
   (schematic_window_set_second_wx *window x)
   (schematic_window_set_second_wy *window y)
 
-  (a_zoom_box_invalidate_rubber *window)
+  (zoom-box-invalidate *window)
   (schematic_window_set_rubber_visible *window 1))
 
 
@@ -339,7 +345,7 @@
 
   (unless (in-action? window)
     (error "zoom-box-end(): The window is not in action!"))
-  (a_zoom_box_invalidate_rubber *window)
+  (zoom-box-invalidate *window)
   (schematic_window_set_rubber_visible *window 0)
   (zoom-box window)
   (when (schematic_window_get_undo_panzoom *window)

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -284,24 +284,16 @@
       ;; Calculate new zoom factors.
       (let* ((zx (/ (abs (- (schematic_viewport_get_left *viewport)
                             (schematic_viewport_get_right *viewport)))
-                    (abs (- (schematic_window_get_first_wx *window)
-                            (schematic_window_get_second_wx *window)))))
+                    (abs (- x1 x2))))
              (zy (/ (abs (- (schematic_viewport_get_top *viewport)
                             (schematic_viewport_get_bottom *viewport)))
-                    (abs (- (schematic_window_get_first_wy *window)
-                            (schematic_window_get_second_wy *window)))))
+                    (abs (- y1 y2))))
              ;; Choose the smaller one.
              (relative-zoom-factor (if (< zx zy) zx zy))
 
              ;; Calculate the center of the zoom box.
-             (world-pan-center-x
-              (/ (+ (schematic_window_get_first_wx *window)
-                    (schematic_window_get_second_wx *window))
-                 2.0))
-             (world-pan-center-y
-              (/ (+ (schematic_window_get_first_wy *window)
-                    (schematic_window_get_second_wy *window))
-                 2.0)))
+             (world-pan-center-x (/ (+ x1 x2) 2.0))
+             (world-pan-center-y (/ (+ y1 y2) 2.0)))
         (a_zoom_box *window
                     *canvas
                     *viewport

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -281,7 +281,16 @@
   ;; Test if there is really a box.
   (if (or (= x1 x2) (= y1 y2))
       (log! 'message (G_ "Zoom too small!  Cannot zoom further."))
-      (a_zoom_box *window *canvas *viewport)))
+      ;; Calculate new zoom factors.
+      (let ((zx (/ (abs (- (schematic_viewport_get_left *viewport)
+                           (schematic_viewport_get_right *viewport)))
+                   (abs (- (schematic_window_get_first_wx *window)
+                           (schematic_window_get_second_wx *window)))))
+            (zy (/ (abs (- (schematic_viewport_get_top *viewport)
+                           (schematic_viewport_get_bottom *viewport)))
+                   (abs (- (schematic_window_get_first_wy *window)
+                           (schematic_window_get_second_wy *window))))))
+        (a_zoom_box *window *canvas *viewport zx zy))))
 
 
 (define (zoom-box-end window x y)

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -314,9 +314,11 @@
   (schematic_window_set_second_wy *window y))
 
 
-(define (zoom-box-invalidate *window)
+(define (zoom-box-invalidate window)
   "Schedule redrawing of the canvas region in WINDOW during box
 zooming."
+  (define *window (check-window window 1))
+
   (a_zoom_box_invalidate_rubber *window))
 
 
@@ -328,12 +330,12 @@ zooming."
     (error "zoom-box-motion(): The window is not in action!"))
 
   (when (true? (schematic_window_get_rubber_visible *window))
-    (zoom-box-invalidate *window))
+    (zoom-box-invalidate window))
 
   (schematic_window_set_second_wx *window x)
   (schematic_window_set_second_wy *window y)
 
-  (zoom-box-invalidate *window)
+  (zoom-box-invalidate window)
   (schematic_window_set_rubber_visible *window 1))
 
 
@@ -345,7 +347,7 @@ zooming."
 
   (unless (in-action? window)
     (error "zoom-box-end(): The window is not in action!"))
-  (zoom-box-invalidate *window)
+  (zoom-box-invalidate window)
   (schematic_window_set_rubber_visible *window 0)
   (zoom-box window)
   (when (schematic_window_get_undo_panzoom *window)

--- a/libleptongui/src/a_zoom.c
+++ b/libleptongui/src/a_zoom.c
@@ -135,28 +135,6 @@ a_zoom (SchematicWindow *w_current,
 /*! \todo Finish function documentation!!!
  *  \brief
  *  \par Function Description
- *
- */
-void
-a_zoom_box_motion (SchematicWindow *w_current,
-                   int w_x,
-                   int w_y)
-{
-  g_assert (schematic_window_get_inside_action (w_current) != 0);
-
-  if (schematic_window_get_rubber_visible (w_current))
-    a_zoom_box_invalidate_rubber (w_current);
-
-  schematic_window_set_second_wx (w_current, w_x);
-  schematic_window_set_second_wy (w_current, w_y);
-
-  a_zoom_box_invalidate_rubber (w_current);
-  schematic_window_set_rubber_visible (w_current, 1);
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
  */
 void
 a_zoom_box_invalidate_rubber (SchematicWindow *w_current)

--- a/libleptongui/src/a_zoom.c
+++ b/libleptongui/src/a_zoom.c
@@ -140,18 +140,11 @@ void
 a_zoom_box (SchematicWindow *w_current,
             SchematicCanvas *page_view,
             SchematicViewport *geometry,
+            double world_pan_center_x,
+            double world_pan_center_y,
             double relativ_zoom_factor)
 {
-
-  double world_pan_center_x, world_pan_center_y;
-
-  /* calculate the center of the zoom box */
-  world_pan_center_x =
-    (schematic_window_get_first_wx (w_current) + schematic_window_get_second_wx (w_current)) / 2.0;
-  world_pan_center_y =
-    (schematic_window_get_first_wy (w_current) + schematic_window_get_second_wy (w_current)) / 2.0;
-
-  /* and create the new window*/
+  /* Create the new window*/
   schematic_canvas_pan_general (page_view,
                                 world_pan_center_x,
                                 world_pan_center_y,

--- a/libleptongui/src/a_zoom.c
+++ b/libleptongui/src/a_zoom.c
@@ -138,25 +138,6 @@ a_zoom (SchematicWindow *w_current,
  *
  */
 void
-a_zoom_box_start (SchematicWindow *w_current,
-                  int w_x,
-                  int w_y)
-{
-  i_action_start (w_current);
-
-  schematic_window_set_first_wx (w_current, w_x);
-  schematic_window_set_second_wx (w_current, w_x);
-  schematic_window_set_first_wy (w_current, w_y);
-  schematic_window_set_second_wy (w_current, w_y);
-}
-
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
-void
 a_zoom_box_motion (SchematicWindow *w_current,
                    int w_x,
                    int w_y)

--- a/libleptongui/src/a_zoom.c
+++ b/libleptongui/src/a_zoom.c
@@ -137,13 +137,11 @@ a_zoom (SchematicWindow *w_current,
  *
  */
 void
-a_zoom_box (SchematicWindow *w_current)
+a_zoom_box (SchematicWindow *w_current,
+            SchematicCanvas *page_view)
 {
   double zx, zy, relativ_zoom_factor;
   double world_pan_center_x, world_pan_center_y;
-
-  SchematicCanvas *page_view = schematic_window_get_current_canvas (w_current);
-  g_return_if_fail (page_view != NULL);
 
   SchematicViewport *geometry = schematic_canvas_get_viewport (page_view);
   g_return_if_fail (geometry != NULL);

--- a/libleptongui/src/a_zoom.c
+++ b/libleptongui/src/a_zoom.c
@@ -142,8 +142,6 @@ a_zoom_box (SchematicWindow *w_current)
   double zx, zy, relativ_zoom_factor;
   double world_pan_center_x, world_pan_center_y;
 
-  g_return_if_fail (w_current != NULL);
-
   SchematicCanvas *page_view = schematic_window_get_current_canvas (w_current);
   g_return_if_fail (page_view != NULL);
 

--- a/libleptongui/src/a_zoom.c
+++ b/libleptongui/src/a_zoom.c
@@ -144,14 +144,6 @@ a_zoom_box (SchematicWindow *w_current,
   double zx, zy, relativ_zoom_factor;
   double world_pan_center_x, world_pan_center_y;
 
-  /*test if there is really a box*/
-  if ((schematic_window_get_first_wx (w_current) == schematic_window_get_second_wx (w_current)) ||
-      (schematic_window_get_first_wy (w_current) == schematic_window_get_second_wy (w_current)))
-  {
-    g_message (_("Zoom too small!  Cannot zoom further."));
-    return;
-  }
-
   /*calc new zoomfactors and choose the smaller one*/
   zx = (double) abs (schematic_viewport_get_left (geometry) - schematic_viewport_get_right (geometry)) /
     abs(schematic_window_get_first_wx (w_current) - schematic_window_get_second_wx (w_current));

--- a/libleptongui/src/a_zoom.c
+++ b/libleptongui/src/a_zoom.c
@@ -139,8 +139,6 @@ a_zoom (SchematicWindow *w_current,
 void
 a_zoom_box_invalidate_rubber (SchematicWindow *w_current)
 {
-  g_return_if_fail (w_current != NULL);
-
   SchematicCanvas *page_view = schematic_window_get_current_canvas (w_current);
 
   schematic_canvas_invalidate_world_rect (page_view,

--- a/libleptongui/src/a_zoom.c
+++ b/libleptongui/src/a_zoom.c
@@ -140,13 +140,10 @@ void
 a_zoom_box (SchematicWindow *w_current,
             SchematicCanvas *page_view,
             SchematicViewport *geometry,
-            double zx,
-            double zy)
+            double relativ_zoom_factor)
 {
-  double relativ_zoom_factor;
+
   double world_pan_center_x, world_pan_center_y;
-  /* Choose the smaller one. */
-  relativ_zoom_factor = (zx < zy ? zx : zy);
 
   /* calculate the center of the zoom box */
   world_pan_center_x =

--- a/libleptongui/src/a_zoom.c
+++ b/libleptongui/src/a_zoom.c
@@ -139,17 +139,13 @@ a_zoom (SchematicWindow *w_current,
 void
 a_zoom_box (SchematicWindow *w_current,
             SchematicCanvas *page_view,
-            SchematicViewport *geometry)
+            SchematicViewport *geometry,
+            double zx,
+            double zy)
 {
-  double zx, zy, relativ_zoom_factor;
+  double relativ_zoom_factor;
   double world_pan_center_x, world_pan_center_y;
-
-  /*calc new zoomfactors and choose the smaller one*/
-  zx = (double) abs (schematic_viewport_get_left (geometry) - schematic_viewport_get_right (geometry)) /
-    abs(schematic_window_get_first_wx (w_current) - schematic_window_get_second_wx (w_current));
-  zy = (double) abs (schematic_viewport_get_top (geometry) - schematic_viewport_get_bottom (geometry)) /
-    abs(schematic_window_get_first_wy (w_current) - schematic_window_get_second_wy (w_current));
-
+  /* Choose the smaller one. */
   relativ_zoom_factor = (zx < zy ? zx : zy);
 
   /* calculate the center of the zoom box */

--- a/libleptongui/src/a_zoom.c
+++ b/libleptongui/src/a_zoom.c
@@ -131,25 +131,6 @@ a_zoom (SchematicWindow *w_current,
   }
 }
 
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- */
-void
-a_zoom_box (SchematicWindow *w_current,
-            SchematicCanvas *page_view,
-            SchematicViewport *geometry,
-            double world_pan_center_x,
-            double world_pan_center_y,
-            double relativ_zoom_factor)
-{
-  /* Create the new window*/
-  schematic_canvas_pan_general (page_view,
-                                world_pan_center_x,
-                                world_pan_center_y,
-                                relativ_zoom_factor);
-}
 
 /*! \todo Finish function documentation!!!
  *  \brief

--- a/libleptongui/src/a_zoom.c
+++ b/libleptongui/src/a_zoom.c
@@ -138,13 +138,11 @@ a_zoom (SchematicWindow *w_current,
  */
 void
 a_zoom_box (SchematicWindow *w_current,
-            SchematicCanvas *page_view)
+            SchematicCanvas *page_view,
+            SchematicViewport *geometry)
 {
   double zx, zy, relativ_zoom_factor;
   double world_pan_center_x, world_pan_center_y;
-
-  SchematicViewport *geometry = schematic_canvas_get_viewport (page_view);
-  g_return_if_fail (geometry != NULL);
 
   /*test if there is really a box*/
   if ((schematic_window_get_first_wx (w_current) == schematic_window_get_second_wx (w_current)) ||

--- a/libleptongui/src/a_zoom.c
+++ b/libleptongui/src/a_zoom.c
@@ -135,22 +135,6 @@ a_zoom (SchematicWindow *w_current,
 /*! \todo Finish function documentation!!!
  *  \brief
  *  \par Function Description
- */
-void
-a_zoom_box_invalidate_rubber (SchematicWindow *w_current)
-{
-  SchematicCanvas *page_view = schematic_window_get_current_canvas (w_current);
-
-  schematic_canvas_invalidate_world_rect (page_view,
-                                          schematic_window_get_first_wx (w_current),
-                                          schematic_window_get_first_wy (w_current),
-                                          schematic_window_get_second_wx (w_current),
-                                          schematic_window_get_second_wy (w_current));
-}
-
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
  *
  */
 void


### PR DESCRIPTION
- A new module, `(schematic viewport foreign)`, has been added.
  The module contains helpers for working with the foreign C type
  `SchematicViewport`.
- A new module, `(schematic canvas)`, has been added.  Currently,
  the module exports an only function, `canvas-viewport()`, that
  obtains the `<viewport>` object of a `<canvas>` instance.
- The following functions have been rewritten in Scheme:
  - `a_zoom_box()`
  - `a_zoom_box_start()`
  - `a_zoom_box_motion()`
  - `a_zoom_box_invalidate_rubber()`