### PR TITLE
Unify drawing event processing for GTK2 and GTK3 in Scheme

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -180,7 +180,8 @@ Notable changes in Lepton EDA 1.9.19 (upcoming)
 
 - The canvas signals for drawing, configuring, button pressing,
   mouse motion, scrolling, and other events are now connected and
-  processed in Scheme.
+  processed in Scheme.  Processing of draw events has been unified
+  for GTK2 and GTK3 ports.
 
 - Key event processing callback is now assigned in Scheme.
 

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -932,28 +932,6 @@ schematic_event_is_double_button_press (GdkEvent *event);
 gboolean
 schematic_event_skip_motion_event (GdkEvent *event);
 
-#ifdef ENABLE_GTK3
-gint
-x_event_draw (SchematicCanvas *widget,
-              cairo_t *cr,
-              SchematicWindow *w_current);
-gint
-x_event_expose (gpointer view,
-                gpointer event,
-                gpointer w_current);
-
-#else /* GTK2 */
-
-gint
-x_event_draw (gpointer view,
-              gpointer cr,
-              gpointer w_current);
-gint
-x_event_expose (SchematicCanvas *widget,
-                GdkEventExpose *event,
-                SchematicWindow *w_current);
-#endif
-
 gboolean
 x_event_faked_motion (SchematicCanvas *view,
                       GdkEventKey *event);

--- a/libleptongui/scheme/schematic/canvas.scm
+++ b/libleptongui/scheme/schematic/canvas.scm
@@ -17,12 +17,15 @@
 
 
 (define-module (schematic canvas)
+  #:use-module (system foreign)
+
   #:use-module (schematic ffi)
   #:use-module (schematic canvas foreign)
   #:use-module (schematic viewport foreign)
 
   #:export (canvas-viewport
-            invalidate-canvas))
+            invalidate-canvas
+            *redraw-canvas))
 
 
 (define (canvas-viewport canvas)
@@ -37,3 +40,10 @@
   (define *canvas (check-canvas canvas 1))
 
   (schematic_canvas_invalidate_all *canvas))
+
+
+(define (redraw-canvas *widget *cairo-context *window)
+  (x_event_draw *widget *cairo-context *window))
+
+(define *redraw-canvas
+  (procedure->pointer int redraw-canvas '(* * *)))

--- a/libleptongui/scheme/schematic/canvas.scm
+++ b/libleptongui/scheme/schematic/canvas.scm
@@ -19,6 +19,8 @@
 (define-module (schematic canvas)
   #:use-module (system foreign)
 
+  #:use-module (lepton m4)
+
   #:use-module (schematic ffi)
   #:use-module (schematic canvas foreign)
   #:use-module (schematic viewport foreign)
@@ -42,8 +44,10 @@
   (schematic_canvas_invalidate_all *canvas))
 
 
-(define (redraw-canvas *widget *cairo-context *window)
-  (x_event_draw *widget *cairo-context *window))
+(define (redraw-canvas *widget *cairo-context-or-event *window)
+  (if %m4-use-gtk3
+      (x_event_draw *widget *cairo-context-or-event *window)
+      (x_event_expose *widget *cairo-context-or-event *window)))
 
 (define *redraw-canvas
   (procedure->pointer int redraw-canvas '(* * *)))

--- a/libleptongui/scheme/schematic/canvas.scm
+++ b/libleptongui/scheme/schematic/canvas.scm
@@ -19,7 +19,7 @@
 (define-module (schematic canvas)
   #:use-module (system foreign)
 
-  #:use-module (lepton m4)
+  #:use-module (lepton ffi boolean)
 
   #:use-module (schematic ffi)
   #:use-module (schematic canvas foreign)
@@ -44,10 +44,15 @@
   (schematic_canvas_invalidate_all *canvas))
 
 
+;;; The function redraws the canvas *WIDGET in *WINDOW when an
+;;; appropriate signal is received ("draw" for GTK3, and
+;;; "expose-event" for GTK2).  The second argument,
+;;; *CAIRO-CONTEXT-OR-EVENT, is cairo context of the canvas for
+;;; GTK3, and a Gdk event instance for GTK2.  The function always
+;;; returns FALSE to propagate the event further.
 (define (redraw-canvas *widget *cairo-context-or-event *window)
-  (if %m4-use-gtk3
-      (x_event_draw *widget *cairo-context-or-event *window)
-      (x_event_expose *widget *cairo-context-or-event *window)))
+  (schematic_canvas_redraw *widget *cairo-context-or-event *window)
+  FALSE)
 
 (define *redraw-canvas
   (procedure->pointer int redraw-canvas '(* * *)))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -478,7 +478,7 @@
             x_event_get_pointer_position
             x_event_key
             *x_event_configure
-            *x_event_draw
+            x_event_draw
             *x_event_expose
             x_event_scroll
             schematic_event_get_button
@@ -1037,7 +1037,7 @@
 (define-lff x_event_get_pointer_position int (list '* int '* '*))
 (define-lff x_event_key '* '(* * *))
 (define-lfc *x_event_configure)
-(define-lfc *x_event_draw)
+(define-lff x_event_draw int '(* * *))
 (define-lfc *x_event_expose)
 (define-lff x_event_scroll int '(* * *))
 (define-lff schematic_event_get_button int '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -479,7 +479,7 @@
             x_event_key
             *x_event_configure
             x_event_draw
-            *x_event_expose
+            x_event_expose
             x_event_scroll
             schematic_event_get_button
             schematic_event_is_double_button_press
@@ -1038,7 +1038,7 @@
 (define-lff x_event_key '* '(* * *))
 (define-lfc *x_event_configure)
 (define-lff x_event_draw int '(* * *))
-(define-lfc *x_event_expose)
+(define-lff x_event_expose int '(* * *))
 (define-lff x_event_scroll int '(* * *))
 (define-lff schematic_event_get_button int '(*))
 (define-lff schematic_event_is_double_button_press int '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -478,8 +478,6 @@
             x_event_get_pointer_position
             x_event_key
             *x_event_configure
-            x_event_draw
-            x_event_expose
             x_event_scroll
             schematic_event_get_button
             schematic_event_is_double_button_press
@@ -1037,8 +1035,6 @@
 (define-lff x_event_get_pointer_position int (list '* int '* '*))
 (define-lff x_event_key '* '(* * *))
 (define-lfc *x_event_configure)
-(define-lff x_event_draw int '(* * *))
-(define-lff x_event_expose int '(* * *))
 (define-lff x_event_scroll int '(* * *))
 (define-lff schematic_event_get_button int '(*))
 (define-lff schematic_event_is_double_button_press int '(*))

--- a/libleptongui/scheme/schematic/preview-widget.scm
+++ b/libleptongui/scheme/schematic/preview-widget.scm
@@ -153,7 +153,7 @@ buffer should be displayed, the widget displays the error message."
   (list
    (if %m4-use-gtk3
        `("draw" . ,*redraw-canvas)
-       `("expose-event" . ,*x_event_expose))
+       `("expose-event" . ,*redraw-canvas))
    `("realize" . ,*schematic_preview_callback_realize)
    `("button-press-event" . ,*schematic_preview_callback_button_press)
    `("configure-event" . ,*x_event_configure)

--- a/libleptongui/scheme/schematic/preview-widget.scm
+++ b/libleptongui/scheme/schematic/preview-widget.scm
@@ -32,6 +32,7 @@
   #:use-module (lepton object foreign)
   #:use-module (lepton object)
 
+  #:use-module (schematic canvas)
   #:use-module (schematic ffi)
   #:use-module (schematic gettext)
 
@@ -151,7 +152,7 @@ buffer should be displayed, the widget displays the error message."
 (define %signal-callback-list
   (list
    (if %m4-use-gtk3
-       `("draw" . ,*x_event_draw)
+       `("draw" . ,*redraw-canvas)
        `("expose-event" . ,*x_event_expose))
    `("realize" . ,*schematic_preview_callback_realize)
    `("button-press-event" . ,*schematic_preview_callback_button_press)

--- a/libleptongui/scheme/schematic/preview-widget.scm
+++ b/libleptongui/scheme/schematic/preview-widget.scm
@@ -151,9 +151,7 @@ buffer should be displayed, the widget displays the error message."
 ;;; preview widgets.
 (define %signal-callback-list
   (list
-   (if %m4-use-gtk3
-       `("draw" . ,*redraw-canvas)
-       `("expose-event" . ,*redraw-canvas))
+   `(,(if %m4-use-gtk3 "draw" "expose-event") . ,*redraw-canvas)
    `("realize" . ,*schematic_preview_callback_realize)
    `("button-press-event" . ,*schematic_preview_callback_button_press)
    `("configure-event" . ,*x_event_configure)

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -794,9 +794,7 @@ zooming."
 (define (setup-page-view-draw-events *window *page-view)
   (define signal-callback-list
     (list
-     (if %m4-use-gtk3
-         `("draw" . ,*redraw-canvas)
-         `("expose-event" . ,*redraw-canvas))
+     `(,(if %m4-use-gtk3 "draw" "expose-event") . ,*redraw-canvas)
      `("button-press-event" . ,*callback-button-pressed)
      `("button-release-event" . ,*callback-button-released)
      `("motion-notify-event" . ,*callback-motion)

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -796,7 +796,7 @@ zooming."
     (list
      (if %m4-use-gtk3
          `("draw" . ,*redraw-canvas)
-         `("expose-event" . ,*x_event_expose))
+         `("expose-event" . ,*redraw-canvas))
      `("button-press-event" . ,*callback-button-pressed)
      `("button-release-event" . ,*callback-button-released)
      `("motion-notify-event" . ,*callback-motion)

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -795,7 +795,7 @@ zooming."
   (define signal-callback-list
     (list
      (if %m4-use-gtk3
-         `("draw" . ,*x_event_draw)
+         `("draw" . ,*redraw-canvas)
          `("expose-event" . ,*x_event_expose))
      `("button-press-event" . ,*callback-button-pressed)
      `("button-release-event" . ,*callback-button-released)

--- a/libleptongui/src/x_event.c
+++ b/libleptongui/src/x_event.c
@@ -97,67 +97,6 @@ schematic_event_get_button (GdkEvent *event)
 }
 
 
-#ifdef ENABLE_GTK3
-/*! \brief Redraws the view when widget is exposed.
- *
- *  \param [in] view      The SchematicCanvas.
- *  \param [in] cr        The cairo context.
- *  \param [in] w_current The SchematicWindow.
- *  \returns FALSE to propagate the event further.
- */
-gint
-x_event_draw (SchematicCanvas *view,
-              cairo_t *cr,
-              SchematicWindow *w_current)
-{
-  schematic_canvas_redraw (view, cr, w_current);
-
-  return(0);
-}
-
-
-/* Dummy function for making Scheme happy. */
-gint
-x_event_expose (gpointer view,
-                gpointer event,
-                gpointer w_current)
-{
-  return(0);
-}
-
-
-#else /* GTK2 */
-
-
-/* Dummy function for making Scheme happy. */
-gint
-x_event_draw (gpointer view,
-              gpointer cr,
-              gpointer w_current)
-{
-  return(0);
-}
-
-
-/*! \brief Redraws the view when widget is exposed.
- *
- *  \param [in] view      The SchematicCanvas.
- *  \param [in] event     The event structure.
- *  \param [in] w_current The SchematicWindow.
- *  \returns FALSE to propagate the event further.
- */
-gint
-x_event_expose (SchematicCanvas *view,
-                GdkEventExpose *event,
-                SchematicWindow *w_current)
-{
-  schematic_canvas_redraw (view, event, w_current);
-
-  return(0);
-}
-#endif
-
-
 /*! \brief Check if a moving event has to be skipped.
  *
  *  \par Function Description


### PR DESCRIPTION
Two C functions processing drawing events for GTK2 and GTK3 ports
of the program, namely `x_event_draw()` and `x_event_expose()`,
have been eliminated, and the draw event processing has been
transferred to Scheme and unified.
