### PR TITLE
Rewrite a part of the New text dialog C code in Scheme

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -118,8 +118,8 @@ Notable changes in Lepton EDA 1.9.19 (upcoming)
 
 ### Changes in `libleptongui`:
 - The prefix `Gschem` in the names of the library object types has
-  been replaced with `Schematic`.  The following renamings have
-  been carried out:
+  been replaced with `Schematic`.  Some other types have been
+  renamed as well.  The following renamings have been carried out:
 
   - `GschemAccelLabel` => `SchematicAccelLabel`
   - `GschemAction` => `SchematicAction`
@@ -148,6 +148,7 @@ Notable changes in Lepton EDA 1.9.19 (upcoming)
   - `GschemTextPropertiesWidget` => `SchematicTextPropertiesWidget`
   - `GschemToplevel` => `SchematicWindow`
   - `GschemTranslateWidget` => `SchematicTranslateWidget`
+  - `NewText` => `SchematicNewText`
 
   All accessor, helper, and other functions and macros related to
   those types have been renamed accordingly.

--- a/libleptongui/include/Makefile.am
+++ b/libleptongui/include/Makefile.am
@@ -42,6 +42,7 @@ noinst_HEADERS = \
 	translate_widget.h \
 	color_edit_widget.h \
 	font_select_widget.h \
+	new_text_dialog.h \
 	page_select_widget.h \
 	preview_widget.h \
 	snap_mode.h \

--- a/libleptongui/include/new_text_dialog.h
+++ b/libleptongui/include/new_text_dialog.h
@@ -63,10 +63,6 @@ schematic_newtext_dialog_response_cancel (SchematicNewText *dialog);
 void
 schematic_newtext_dialog_run (GtkWidget *widget);
 
-void
-schematic_newtext_dialog_response (SchematicNewText *dialog,
-                                   gint response,
-                                   gpointer unused);
 GtkWidget*
 schematic_newtext_dialog_new (SchematicWindow *w_current);
 

--- a/libleptongui/include/new_text_dialog.h
+++ b/libleptongui/include/new_text_dialog.h
@@ -1,0 +1,62 @@
+/* Lepton EDA Schematic Capture
+ * Copyright (C) 2013 Ales Hvezda
+ * Copyright (C) 2013-2015 gEDA Contributors
+ * Copyright (C) 2017-2024 Lepton EDA Contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/*!
+ * \file new_text_dialog.h
+ *
+ * \brief Text input widget
+ *
+ */
+
+#ifndef NEW_TEXT_DIALOG_H
+#define NEW_TEXT_DIALOG_H
+
+
+#define TYPE_NEWTEXT           (newtext_get_type())
+#define NEWTEXT(obj)           (G_TYPE_CHECK_INSTANCE_CAST ((obj), TYPE_NEWTEXT, NewText))
+#define NEWTEXT_CLASS(klass)   (G_TYPE_CHECK_CLASS_CAST ((klass),  TYPE_NEWTEXT, NewTextClass))
+#define IS_NEWTEXT(obj)        (G_TYPE_CHECK_INSTANCE_TYPE ((obj), TYPE_NEWTEXT))
+
+typedef struct _NewTextClass NewTextClass;
+typedef struct _NewText NewText;
+
+struct _NewTextClass {
+  SchematicDialogClass parent_class;
+};
+
+struct _NewText {
+    SchematicDialog parent;
+
+    GtkWidget *aligncb;
+    GtkWidget *colorcb;
+    GtkWidget *rotatecb;
+    GtkWidget *textsizecb;
+    GtkWidget *text_view;
+};
+
+
+G_BEGIN_DECLS
+
+void
+text_input_dialog (SchematicWindow *w_current);
+
+G_END_DECLS
+
+#endif /* NEW_TEXT_DIALOG_H */

--- a/libleptongui/include/new_text_dialog.h
+++ b/libleptongui/include/new_text_dialog.h
@@ -58,8 +58,8 @@ void
 schematic_newtext_dialog_response_apply (SchematicNewText *dialog);
 
 void
-schematic_newtext_dialog_response_cancel (SchematicNewText *dialog,
-                                          gpointer data);
+schematic_newtext_dialog_destroy (SchematicNewText *dialog);
+
 void
 schematic_newtext_dialog_run (GtkWidget *widget);
 

--- a/libleptongui/include/new_text_dialog.h
+++ b/libleptongui/include/new_text_dialog.h
@@ -55,6 +55,12 @@ struct _SchematicNewText {
 G_BEGIN_DECLS
 
 void
+schematic_newtext_dialog_response_apply (SchematicNewText *dialog);
+
+void
+schematic_newtext_dialog_response_cancel (SchematicNewText *dialog);
+
+void
 schematic_newtext_dialog_run (GtkWidget *widget);
 
 void

--- a/libleptongui/include/new_text_dialog.h
+++ b/libleptongui/include/new_text_dialog.h
@@ -61,6 +61,9 @@ void
 schematic_newtext_dialog_response (SchematicNewText *dialog,
                                    gint response,
                                    gpointer unused);
+GtkWidget*
+schematic_newtext_dialog_new (SchematicWindow *w_current);
+
 G_END_DECLS
 
 #endif /* NEW_TEXT_DIALOG_H */

--- a/libleptongui/include/new_text_dialog.h
+++ b/libleptongui/include/new_text_dialog.h
@@ -29,19 +29,19 @@
 #define NEW_TEXT_DIALOG_H
 
 
-#define TYPE_NEWTEXT           (newtext_get_type())
-#define NEWTEXT(obj)           (G_TYPE_CHECK_INSTANCE_CAST ((obj), TYPE_NEWTEXT, NewText))
-#define NEWTEXT_CLASS(klass)   (G_TYPE_CHECK_CLASS_CAST ((klass),  TYPE_NEWTEXT, NewTextClass))
-#define IS_NEWTEXT(obj)        (G_TYPE_CHECK_INSTANCE_TYPE ((obj), TYPE_NEWTEXT))
+#define SCHEMATIC_TYPE_NEWTEXT         (schematic_newtext_get_type())
+#define SCHEMATIC_NEWTEXT(obj)         (G_TYPE_CHECK_INSTANCE_CAST ((obj), SCHEMATIC_TYPE_NEWTEXT, SchematicNewText))
+#define SCHEMATIC_NEWTEXT_CLASS(klass) (G_TYPE_CHECK_CLASS_CAST ((klass),  SCHEMATIC_TYPE_NEWTEXT, SchematicNewTextClass))
+#define SCHEMATIC_IS_NEWTEXT(obj)      (G_TYPE_CHECK_INSTANCE_TYPE ((obj), SCHEMATIC_TYPE_NEWTEXT))
 
-typedef struct _NewTextClass NewTextClass;
-typedef struct _NewText NewText;
+typedef struct _SchematicNewTextClass SchematicNewTextClass;
+typedef struct _SchematicNewText SchematicNewText;
 
-struct _NewTextClass {
+struct _SchematicNewTextClass {
   SchematicDialogClass parent_class;
 };
 
-struct _NewText {
+struct _SchematicNewText {
     SchematicDialog parent;
 
     GtkWidget *aligncb;

--- a/libleptongui/include/new_text_dialog.h
+++ b/libleptongui/include/new_text_dialog.h
@@ -57,6 +57,10 @@ G_BEGIN_DECLS
 void
 schematic_newtext_dialog (SchematicWindow *w_current);
 
+void
+schematic_newtext_dialog_response (SchematicNewText *dialog,
+                                   gint response,
+                                   gpointer unused);
 G_END_DECLS
 
 #endif /* NEW_TEXT_DIALOG_H */

--- a/libleptongui/include/new_text_dialog.h
+++ b/libleptongui/include/new_text_dialog.h
@@ -58,9 +58,6 @@ void
 schematic_newtext_dialog_response_apply (SchematicNewText *dialog);
 
 void
-schematic_newtext_dialog_destroy (SchematicNewText *dialog);
-
-void
 schematic_newtext_dialog_run (GtkWidget *widget);
 
 GtkWidget*

--- a/libleptongui/include/new_text_dialog.h
+++ b/libleptongui/include/new_text_dialog.h
@@ -58,8 +58,8 @@ void
 schematic_newtext_dialog_response_apply (SchematicNewText *dialog);
 
 void
-schematic_newtext_dialog_response_cancel (SchematicNewText *dialog);
-
+schematic_newtext_dialog_response_cancel (SchematicNewText *dialog,
+                                          gpointer data);
 void
 schematic_newtext_dialog_run (GtkWidget *widget);
 

--- a/libleptongui/include/new_text_dialog.h
+++ b/libleptongui/include/new_text_dialog.h
@@ -55,7 +55,7 @@ struct _SchematicNewText {
 G_BEGIN_DECLS
 
 void
-text_input_dialog (SchematicWindow *w_current);
+schematic_newtext_dialog (SchematicWindow *w_current);
 
 G_END_DECLS
 

--- a/libleptongui/include/new_text_dialog.h
+++ b/libleptongui/include/new_text_dialog.h
@@ -55,7 +55,7 @@ struct _SchematicNewText {
 G_BEGIN_DECLS
 
 void
-schematic_newtext_dialog (SchematicWindow *w_current);
+schematic_newtext_dialog_run (SchematicWindow *w_current);
 
 void
 schematic_newtext_dialog_response (SchematicNewText *dialog,

--- a/libleptongui/include/new_text_dialog.h
+++ b/libleptongui/include/new_text_dialog.h
@@ -55,7 +55,7 @@ struct _SchematicNewText {
 G_BEGIN_DECLS
 
 void
-schematic_newtext_dialog_run (SchematicWindow *w_current);
+schematic_newtext_dialog_run (GtkWidget *widget);
 
 void
 schematic_newtext_dialog_response (SchematicNewText *dialog,

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -871,9 +871,6 @@ int
 x_dialog_validate_attribute (GtkWindow *parent,
                              char *attribute);
 void
-text_input_dialog (SchematicWindow *w_current);
-
-void
 text_edit_dialog (SchematicWindow *w_current);
 
 void

--- a/libleptongui/include/schematic.h
+++ b/libleptongui/include/schematic.h
@@ -60,6 +60,7 @@ typedef struct st_schematic_window SchematicWindow;
 
 #include "color_edit_widget.h"
 #include "font_select_widget.h"
+#include "new_text_dialog.h"
 #include "page_select_widget.h"
 #include "toolbar.h"
 

--- a/libleptongui/include/window.h
+++ b/libleptongui/include/window.h
@@ -435,11 +435,11 @@ void
 schematic_window_set_compselect_widget (SchematicWindow *w_current,
                                         GtkWidget *widget);
 GtkWidget*
-schematic_window_get_text_input_widget (SchematicWindow *w_current);
+schematic_window_get_newtext_dialog (SchematicWindow *w_current);
 
 void
-schematic_window_set_text_input_widget (SchematicWindow *w_current,
-                                        GtkWidget *widget);
+schematic_window_set_newtext_dialog (SchematicWindow *w_current,
+                                     GtkWidget *widget);
 GtkWidget*
 schematic_window_get_arc_edit_widget (SchematicWindow *w_current);
 

--- a/libleptongui/po/POTFILES.in
+++ b/libleptongui/po/POTFILES.in
@@ -85,7 +85,7 @@ libleptongui/src/x_linetypecb.c
 libleptongui/src/x_menus.c
 libleptongui/src/x_misc.c
 libleptongui/src/x_multiattrib.c
-libleptongui/src/x_newtext.c
+libleptongui/src/new_text_dialog.c
 libleptongui/src/page_select_widget.c
 libleptongui/src/x_print.c
 libleptongui/src/x_rc.c

--- a/libleptongui/scheme/schematic/callback.scm
+++ b/libleptongui/scheme/schematic/callback.scm
@@ -155,10 +155,29 @@
 
 
 (define (callback-add-text *widget *window)
+  (define *newtext-widget
+    (schematic_window_get_newtext_dialog *window))
+
+  (define (get-newtext-widget *window)
+    (if (null-pointer? *newtext-widget)
+        ;; Widget not created yet, create it.
+        (let ((*widget (schematic_newtext_dialog_new *window)))
+          ;; Store pointer to the widget in the *window structure.
+          (schematic_window_set_newtext_dialog *window *widget)
+          ;; Connect callback to the widget's "response" signal.
+          (schematic_signal_connect *widget
+                                    (string->pointer "response")
+                                    *schematic_newtext_dialog_response
+                                    %null-pointer)
+          *widget)
+        ;; Otherwise just return the widget.
+        *newtext-widget))
+
   (o_redraw_cleanstates *window)
   (o_invalidate_rubber *window)
 
   (i_action_stop *window)
   (set-action-mode! 'select-mode #:window (pointer->window *window))
 
+  (get-newtext-widget *window)
   (schematic_newtext_dialog *window))

--- a/libleptongui/scheme/schematic/callback.scm
+++ b/libleptongui/scheme/schematic/callback.scm
@@ -154,6 +154,26 @@
   (set-action-mode! 'select-mode #:window window))
 
 
+;;; Callback function for the text entry dialog that handles user
+;;; responses.
+(define (newtext-dialog-response *dialog response *unused)
+  (define (log-warning)
+    (log! 'warning
+          "newtext-dialog-response(): strange signal: ~A" response)
+    #f)
+  (define *response-string (gtk_response_to_string response))
+  (define response-sym
+    (string->symbol (pointer->string *response-string)))
+
+  (case response-sym
+    ((apply) (schematic_newtext_dialog_response_apply *dialog))
+    ((close delete-event) (schematic_newtext_dialog_response_cancel *dialog))
+    (else (log-warning))))
+
+
+(define *newtext-dialog-response
+  (procedure->pointer void newtext-dialog-response (list '* int '*)))
+
 (define (callback-add-text *widget *window)
   (define *newtext-widget
     (schematic_window_get_newtext_dialog *window))
@@ -167,7 +187,7 @@
           ;; Connect callback to the widget's "response" signal.
           (schematic_signal_connect *widget
                                     (string->pointer "response")
-                                    *schematic_newtext_dialog_response
+                                    *newtext-dialog-response
                                     %null-pointer)
           *widget)
         ;; Otherwise just return the widget.

--- a/libleptongui/scheme/schematic/callback.scm
+++ b/libleptongui/scheme/schematic/callback.scm
@@ -165,10 +165,14 @@
   (define response-sym
     (string->symbol (pointer->string *response-string)))
 
+  (define (close-dialog!)
+    (i_callback_cancel %null-pointer *window)
+    (schematic_newtext_dialog_destroy *dialog)
+    (schematic_window_set_newtext_dialog *window %null-pointer))
+
   (case response-sym
     ((apply) (schematic_newtext_dialog_response_apply *dialog))
-    ((close delete-event)
-     (schematic_newtext_dialog_response_cancel *dialog *window))
+    ((close delete-event) (close-dialog!))
     (else (log-warning))))
 
 

--- a/libleptongui/scheme/schematic/callback.scm
+++ b/libleptongui/scheme/schematic/callback.scm
@@ -161,4 +161,4 @@
   (i_action_stop *window)
   (set-action-mode! 'select-mode #:window (pointer->window *window))
 
-  (text_input_dialog *window))
+  (schematic_newtext_dialog *window))

--- a/libleptongui/scheme/schematic/callback.scm
+++ b/libleptongui/scheme/schematic/callback.scm
@@ -179,5 +179,4 @@
   (i_action_stop *window)
   (set-action-mode! 'select-mode #:window (pointer->window *window))
 
-  (get-newtext-widget *window)
-  (schematic_newtext_dialog_run *window))
+  (schematic_newtext_dialog_run (get-newtext-widget *window)))

--- a/libleptongui/scheme/schematic/callback.scm
+++ b/libleptongui/scheme/schematic/callback.scm
@@ -31,6 +31,7 @@
   #:use-module (schematic action)
   #:use-module (schematic action-mode)
   #:use-module (schematic dialog file-select)
+  #:use-module (schematic ffi gtk)
   #:use-module (schematic ffi)
   #:use-module (schematic gettext)
   #:use-module (schematic preview-widget)
@@ -167,7 +168,7 @@
 
   (define (close-dialog!)
     (i_callback_cancel %null-pointer *window)
-    (schematic_newtext_dialog_destroy *dialog)
+    (gtk_widget_destroy *dialog)
     (schematic_window_set_newtext_dialog *window %null-pointer))
 
   (case response-sym

--- a/libleptongui/scheme/schematic/callback.scm
+++ b/libleptongui/scheme/schematic/callback.scm
@@ -178,7 +178,7 @@
   (define *newtext-widget
     (schematic_window_get_newtext_dialog *window))
 
-  (define (get-newtext-widget *window)
+  (define (get-newtext-widget)
     (if (null-pointer? *newtext-widget)
         ;; Widget not created yet, create it.
         (let ((*widget (schematic_newtext_dialog_new *window)))
@@ -199,4 +199,4 @@
   (i_action_stop *window)
   (set-action-mode! 'select-mode #:window (pointer->window *window))
 
-  (schematic_newtext_dialog_run (get-newtext-widget *window)))
+  (schematic_newtext_dialog_run (get-newtext-widget)))

--- a/libleptongui/scheme/schematic/callback.scm
+++ b/libleptongui/scheme/schematic/callback.scm
@@ -180,4 +180,4 @@
   (set-action-mode! 'select-mode #:window (pointer->window *window))
 
   (get-newtext-widget *window)
-  (schematic_newtext_dialog *window))
+  (schematic_newtext_dialog_run *window))

--- a/libleptongui/scheme/schematic/callback.scm
+++ b/libleptongui/scheme/schematic/callback.scm
@@ -156,7 +156,7 @@
 
 ;;; Callback function for the text entry dialog that handles user
 ;;; responses.
-(define (newtext-dialog-response *dialog response *unused)
+(define (newtext-dialog-response *dialog response *window)
   (define (log-warning)
     (log! 'warning
           "newtext-dialog-response(): strange signal: ~A" response)
@@ -167,7 +167,8 @@
 
   (case response-sym
     ((apply) (schematic_newtext_dialog_response_apply *dialog))
-    ((close delete-event) (schematic_newtext_dialog_response_cancel *dialog))
+    ((close delete-event)
+     (schematic_newtext_dialog_response_cancel *dialog *window))
     (else (log-warning))))
 
 
@@ -188,7 +189,7 @@
           (schematic_signal_connect *widget
                                     (string->pointer "response")
                                     *newtext-dialog-response
-                                    %null-pointer)
+                                    *window)
           *widget)
         ;; Otherwise just return the widget.
         *newtext-widget))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -1069,7 +1069,7 @@
 ;;; new_text_dialog.c
 (define-lff schematic_newtext_dialog_new '* '(*))
 (define-lff schematic_newtext_dialog_response_apply void '(*))
-(define-lff schematic_newtext_dialog_response_cancel void '(*))
+(define-lff schematic_newtext_dialog_response_cancel void '(* *))
 (define-lff schematic_newtext_dialog_run void '(*))
 
 ;;; x_print.c

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -451,9 +451,9 @@
             schematic_text_properties_widget_new
             text_edit_dialog
 
+            schematic_newtext_dialog_destroy
             schematic_newtext_dialog_new
             schematic_newtext_dialog_response_apply
-            schematic_newtext_dialog_response_cancel
             schematic_newtext_dialog_run
 
             o_select_box_end
@@ -1067,9 +1067,9 @@
 (define-lff x_multiattrib_update void '(*))
 
 ;;; new_text_dialog.c
+(define-lff schematic_newtext_dialog_destroy void '(*))
 (define-lff schematic_newtext_dialog_new '* '(*))
 (define-lff schematic_newtext_dialog_response_apply void '(*))
-(define-lff schematic_newtext_dialog_response_cancel void '(* *))
 (define-lff schematic_newtext_dialog_run void '(*))
 
 ;;; x_print.c

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -451,7 +451,6 @@
             schematic_text_properties_widget_new
             text_edit_dialog
 
-            schematic_newtext_dialog_destroy
             schematic_newtext_dialog_new
             schematic_newtext_dialog_response_apply
             schematic_newtext_dialog_run
@@ -1067,7 +1066,6 @@
 (define-lff x_multiattrib_update void '(*))
 
 ;;; new_text_dialog.c
-(define-lff schematic_newtext_dialog_destroy void '(*))
 (define-lff schematic_newtext_dialog_new '* '(*))
 (define-lff schematic_newtext_dialog_response_apply void '(*))
 (define-lff schematic_newtext_dialog_run void '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -1061,7 +1061,7 @@
 (define-lff x_multiattrib_open void '(*))
 (define-lff x_multiattrib_update void '(*))
 
-;;; x_newtext.c
+;;; new_text_dialog.c
 (define-lff schematic_newtext_dialog void '(*))
 
 ;;; x_print.c

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -407,7 +407,7 @@
             schematic_window_get_coord_widget
             schematic_window_get_hotkey_widget
             schematic_window_get_slot_edit_widget
-            schematic_window_get_text_input_widget
+            schematic_window_get_newtext_dialog
             schematic_window_set_dont_invalidate
             schematic_window_set_log_widget
             schematic_window_set_object_properties_widget
@@ -743,7 +743,7 @@
 (define-lff schematic_window_get_coord_widget '* '(*))
 (define-lff schematic_window_get_hotkey_widget '* '(*))
 (define-lff schematic_window_get_slot_edit_widget '* '(*))
-(define-lff schematic_window_get_text_input_widget '* '(*))
+(define-lff schematic_window_get_newtext_dialog '* '(*))
 (define-lff schematic_window_set_dont_invalidate void (list '* int))
 (define-lff schematic_window_set_log_widget void '(* *))
 (define-lff schematic_window_set_object_properties_widget void '(* *))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -451,9 +451,9 @@
             schematic_text_properties_widget_new
             text_edit_dialog
 
-            schematic_newtext_dialog
             schematic_newtext_dialog_new
             *schematic_newtext_dialog_response
+            schematic_newtext_dialog_run
 
             o_select_box_end
             o_select_box_motion
@@ -1066,9 +1066,9 @@
 (define-lff x_multiattrib_update void '(*))
 
 ;;; new_text_dialog.c
-(define-lff schematic_newtext_dialog void '(*))
 (define-lff schematic_newtext_dialog_new '* '(*))
 (define-lfc *schematic_newtext_dialog_response)
+(define-lff schematic_newtext_dialog_run void '(*))
 
 ;;; x_print.c
 (define-lff x_print void '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -450,7 +450,7 @@
             schematic_text_properties_widget_new
             text_edit_dialog
 
-            text_input_dialog
+            schematic_newtext_dialog
 
             o_select_box_end
             o_select_box_motion
@@ -1062,7 +1062,7 @@
 (define-lff x_multiattrib_update void '(*))
 
 ;;; x_newtext.c
-(define-lff text_input_dialog void '(*))
+(define-lff schematic_newtext_dialog void '(*))
 
 ;;; x_print.c
 (define-lff x_print void '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -408,6 +408,7 @@
             schematic_window_get_hotkey_widget
             schematic_window_get_slot_edit_widget
             schematic_window_get_newtext_dialog
+            schematic_window_set_newtext_dialog
             schematic_window_set_dont_invalidate
             schematic_window_set_log_widget
             schematic_window_set_object_properties_widget
@@ -451,6 +452,8 @@
             text_edit_dialog
 
             schematic_newtext_dialog
+            schematic_newtext_dialog_new
+            *schematic_newtext_dialog_response
 
             o_select_box_end
             o_select_box_motion
@@ -744,6 +747,7 @@
 (define-lff schematic_window_get_hotkey_widget '* '(*))
 (define-lff schematic_window_get_slot_edit_widget '* '(*))
 (define-lff schematic_window_get_newtext_dialog '* '(*))
+(define-lff schematic_window_set_newtext_dialog void '(* *))
 (define-lff schematic_window_set_dont_invalidate void (list '* int))
 (define-lff schematic_window_set_log_widget void '(* *))
 (define-lff schematic_window_set_object_properties_widget void '(* *))
@@ -1063,6 +1067,8 @@
 
 ;;; new_text_dialog.c
 (define-lff schematic_newtext_dialog void '(*))
+(define-lff schematic_newtext_dialog_new '* '(*))
+(define-lfc *schematic_newtext_dialog_response)
 
 ;;; x_print.c
 (define-lff x_print void '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -452,7 +452,8 @@
             text_edit_dialog
 
             schematic_newtext_dialog_new
-            *schematic_newtext_dialog_response
+            schematic_newtext_dialog_response_apply
+            schematic_newtext_dialog_response_cancel
             schematic_newtext_dialog_run
 
             o_select_box_end
@@ -1067,7 +1068,8 @@
 
 ;;; new_text_dialog.c
 (define-lff schematic_newtext_dialog_new '* '(*))
-(define-lfc *schematic_newtext_dialog_response)
+(define-lff schematic_newtext_dialog_response_apply void '(*))
+(define-lff schematic_newtext_dialog_response_cancel void '(*))
 (define-lff schematic_newtext_dialog_run void '(*))
 
 ;;; x_print.c

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -102,7 +102,7 @@
       ;; Close the window if the user didn't cancel the close.
       (x_clipboard_finish *window)
       (let ((*cswindow (schematic_window_get_compselect_widget *window))
-            (*tiwindow (schematic_window_get_text_input_widget *window))
+            (*tiwindow (schematic_window_get_newtext_dialog *window))
             (*aawindow (schematic_window_get_arc_edit_widget *window))
             (*aewindow (schematic_window_get_attrib_edit_widget *window))
             (*hkwindow (schematic_window_get_hotkey_widget *window))

--- a/libleptongui/src/Makefile.am
+++ b/libleptongui/src/Makefile.am
@@ -99,7 +99,7 @@ libleptongui_la_SOURCES = \
 	x_menus.c \
 	x_misc.c \
 	x_multiattrib.c \
-	x_newtext.c \
+	new_text_dialog.c \
 	page_select_widget.c \
 	toolbar.c \
 	x_print.c \

--- a/libleptongui/src/new_text_dialog.c
+++ b/libleptongui/src/new_text_dialog.c
@@ -180,7 +180,7 @@ schematic_newtext_dialog_response_cancel (SchematicNewText *dialog,
   SchematicWindow *w_current = (SchematicWindow*) data;
   i_callback_cancel (NULL, w_current);
   gtk_widget_destroy (GTK_WIDGET (dialog));
-  w_current->tiwindow = NULL;
+  schematic_window_set_newtext_dialog (w_current, NULL);
 }
 
 

--- a/libleptongui/src/new_text_dialog.c
+++ b/libleptongui/src/new_text_dialog.c
@@ -171,13 +171,16 @@ schematic_newtext_dialog_response_apply (SchematicNewText *dialog)
  *
  *
  *  \param [in,out] dialog The new text dialog
+ *  \param [in] data The pointer to parent #SchematicWindow.
  */
 void
-schematic_newtext_dialog_response_cancel (SchematicNewText *dialog)
+schematic_newtext_dialog_response_cancel (SchematicNewText *dialog,
+                                          gpointer data)
 {
-  i_callback_cancel (NULL, dialog->parent.w_current);
-  gtk_widget_destroy(dialog->parent.w_current->tiwindow);
-  dialog->parent.w_current->tiwindow=NULL;
+  SchematicWindow *w_current = (SchematicWindow*) data;
+  i_callback_cancel (NULL, w_current);
+  gtk_widget_destroy (GTK_WIDGET (dialog));
+  w_current->tiwindow = NULL;
 }
 
 

--- a/libleptongui/src/new_text_dialog.c
+++ b/libleptongui/src/new_text_dialog.c
@@ -464,6 +464,45 @@ schematic_newtext_init (SchematicNewText *dialog)
 }
 
 
+GtkWidget*
+schematic_newtext_dialog_new (SchematicWindow *w_current)
+{
+  GtkWidget *dialog =
+    GTK_WIDGET (g_object_new (SCHEMATIC_TYPE_NEWTEXT,
+                              /* GtkContainer */
+                              "border-width",     DIALOG_BORDER_SPACING,
+                              /* GtkWindow */
+                              "title",            _("Add Text"),
+                              "default-width",    320,
+                              "default-height",   350,
+                              "window-position",  GTK_WIN_POS_MOUSE,
+                              "modal",            FALSE,
+#ifndef ENABLE_GTK3
+                              "allow-grow",       TRUE,
+                              "allow-shrink",     FALSE,
+                              /* GtkDialog */
+                              "has-separator",    TRUE,
+#endif
+                              /* SchematicDialog */
+                              "settings-name",    "text-entry",
+                              "schematic-window",  w_current,
+                              NULL));
+
+    gtk_window_set_transient_for (GTK_WINDOW (dialog),
+                                  GTK_WINDOW (w_current->main_window));
+
+    schematic_integer_combo_box_set_model (SCHEMATIC_NEWTEXT (dialog)->textsizecb,
+                                           schematic_window_get_text_size_list_store (w_current));
+
+    schematic_integer_combo_box_set_value (SCHEMATIC_NEWTEXT (dialog)->textsizecb,
+                                           w_current->text_size);
+
+    gtk_widget_show_all (dialog);
+
+    return dialog;
+}
+
+
 /*! \brief Open the dialog box to add new text
  *
  *  \par Function Description
@@ -476,41 +515,11 @@ schematic_newtext_dialog (SchematicWindow *w_current)
 {
   if (w_current->tiwindow == NULL) {
     /* dialog not created yet */
-    w_current->tiwindow =
-      GTK_WIDGET (g_object_new (SCHEMATIC_TYPE_NEWTEXT,
-                                /* GtkContainer */
-                                "border-width",     DIALOG_BORDER_SPACING,
-                                /* GtkWindow */
-                                "title",            _("Add Text"),
-                                "default-width",    320,
-                                "default-height",   350,
-                                "window-position",  GTK_WIN_POS_MOUSE,
-                                "modal",            FALSE,
-#ifndef ENABLE_GTK3
-                                "allow-grow",       TRUE,
-                                "allow-shrink",     FALSE,
-                                /* GtkDialog */
-                                "has-separator",    TRUE,
-#endif
-                                /* SchematicDialog */
-                                "settings-name",    "text-entry",
-                                "schematic-window",  w_current,
-                                NULL));
+    w_current->tiwindow = schematic_newtext_dialog_new (w_current);
 
     g_signal_connect (G_OBJECT (w_current->tiwindow),
                       "response", G_CALLBACK (schematic_newtext_dialog_response),
                       NULL);
-
-    gtk_window_set_transient_for (GTK_WINDOW (w_current->tiwindow),
-                                  GTK_WINDOW (w_current->main_window));
-
-    schematic_integer_combo_box_set_model (SCHEMATIC_NEWTEXT (w_current->tiwindow)->textsizecb,
-                                           schematic_window_get_text_size_list_store (w_current));
-
-    schematic_integer_combo_box_set_value (SCHEMATIC_NEWTEXT (w_current->tiwindow)->textsizecb,
-                                           w_current->text_size);
-
-    gtk_widget_show_all (w_current->tiwindow);
   }
   else {
     /* dialog already created */

--- a/libleptongui/src/new_text_dialog.c
+++ b/libleptongui/src/new_text_dialog.c
@@ -85,8 +85,8 @@ select_all_text_in_textview (GtkTextView *textview)
  *
  *  \param [in] dialog The new text dialog
  */
-static void
-dialog_response_apply (SchematicNewText *dialog)
+void
+schematic_newtext_dialog_response_apply (SchematicNewText *dialog)
 {
   g_return_if_fail (dialog != NULL);
 
@@ -172,8 +172,8 @@ dialog_response_apply (SchematicNewText *dialog)
  *
  *  \param [in,out] dialog The new text dialog
  */
-static void
-dialog_response_cancel (SchematicNewText *dialog)
+void
+schematic_newtext_dialog_response_cancel (SchematicNewText *dialog)
 {
   i_callback_cancel (NULL, dialog->parent.w_current);
   gtk_widget_destroy(dialog->parent.w_current->tiwindow);
@@ -198,11 +198,11 @@ schematic_newtext_dialog_response (SchematicNewText *dialog,
 {
   switch(response) {
     case GTK_RESPONSE_APPLY:
-      dialog_response_apply(dialog);
+      schematic_newtext_dialog_response_apply (dialog);
       break;
     case GTK_RESPONSE_CLOSE:
     case GTK_RESPONSE_DELETE_EVENT:
-      dialog_response_cancel(dialog);
+      schematic_newtext_dialog_response_cancel (dialog);
       break;
     default:
       printf ("schematic_newtext_dialog_response(): strange signal %d\n", response);

--- a/libleptongui/src/new_text_dialog.c
+++ b/libleptongui/src/new_text_dialog.c
@@ -513,13 +513,14 @@ schematic_newtext_dialog_new (SchematicWindow *w_current)
 void
 schematic_newtext_dialog (SchematicWindow *w_current)
 {
-  if (w_current->tiwindow == NULL) {
+  if (schematic_window_get_text_input_widget (w_current) == NULL)
+  {
     /* dialog not created yet */
-    w_current->tiwindow = schematic_newtext_dialog_new (w_current);
-
-    g_signal_connect (G_OBJECT (w_current->tiwindow),
+    GtkWidget *dialog = schematic_newtext_dialog_new (w_current);
+    g_signal_connect (G_OBJECT (dialog),
                       "response", G_CALLBACK (schematic_newtext_dialog_response),
                       NULL);
+    schematic_window_set_text_input_widget (w_current, dialog);
   }
   else {
     /* dialog already created */

--- a/libleptongui/src/new_text_dialog.c
+++ b/libleptongui/src/new_text_dialog.c
@@ -182,34 +182,6 @@ schematic_newtext_dialog_response_cancel (SchematicNewText *dialog)
 
 
 
-/*! \brief Handles user responses from the new text dialog box
-
- *  \par Function Description
- *  Callback function for the text entry dialog.
- *
- *  \param [in,out] dialog The new text dialog.
- *  \param [in] response The Gtk response integer value.
- *  \param unused Unused parameter.
- */
-void
-schematic_newtext_dialog_response (SchematicNewText *dialog,
-                                   gint response,
-                                   gpointer unused)
-{
-  switch(response) {
-    case GTK_RESPONSE_APPLY:
-      schematic_newtext_dialog_response_apply (dialog);
-      break;
-    case GTK_RESPONSE_CLOSE:
-    case GTK_RESPONSE_DELETE_EVENT:
-      schematic_newtext_dialog_response_cancel (dialog);
-      break;
-    default:
-      printf ("schematic_newtext_dialog_response(): strange signal %d\n", response);
-  }
-}
-
-
 /*! \brief Initialize SchematicNewText class
  *
  *  \par Function Description

--- a/libleptongui/src/new_text_dialog.c
+++ b/libleptongui/src/new_text_dialog.c
@@ -514,13 +514,13 @@ void
 schematic_newtext_dialog (SchematicWindow *w_current)
 {
   /* If the dialog is not yet created, create it. */
-  if (schematic_window_get_text_input_widget (w_current) == NULL)
+  if (schematic_window_get_newtext_dialog (w_current) == NULL)
   {
     GtkWidget *dialog = schematic_newtext_dialog_new (w_current);
     g_signal_connect (G_OBJECT (dialog),
                       "response", G_CALLBACK (schematic_newtext_dialog_response),
                       NULL);
-    schematic_window_set_text_input_widget (w_current, dialog);
+    schematic_window_set_newtext_dialog (w_current, dialog);
   }
 
   /* Raise the dialog and make it visible for the user. */

--- a/libleptongui/src/new_text_dialog.c
+++ b/libleptongui/src/new_text_dialog.c
@@ -166,21 +166,14 @@ schematic_newtext_dialog_response_apply (SchematicNewText *dialog)
 
 
 
-/*! \brief Handles the user response when cancel is selected
- *
- *
+/*! \brief Destroy the New text dialog.
  *
  *  \param [in,out] dialog The new text dialog
- *  \param [in] data The pointer to parent #SchematicWindow.
  */
 void
-schematic_newtext_dialog_response_cancel (SchematicNewText *dialog,
-                                          gpointer data)
+schematic_newtext_dialog_destroy (SchematicNewText *dialog)
 {
-  SchematicWindow *w_current = (SchematicWindow*) data;
-  i_callback_cancel (NULL, w_current);
   gtk_widget_destroy (GTK_WIDGET (dialog));
-  schematic_window_set_newtext_dialog (w_current, NULL);
 }
 
 

--- a/libleptongui/src/new_text_dialog.c
+++ b/libleptongui/src/new_text_dialog.c
@@ -18,7 +18,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 /*!
- * \file x_newtext.c
+ * \file new_text_dialog.c
  *
  * \brief A dialog box for adding new text to a schematic.
  */

--- a/libleptongui/src/new_text_dialog.c
+++ b/libleptongui/src/new_text_dialog.c
@@ -513,19 +513,18 @@ schematic_newtext_dialog_new (SchematicWindow *w_current)
 void
 schematic_newtext_dialog (SchematicWindow *w_current)
 {
+  /* If the dialog is not yet created, create it. */
   if (schematic_window_get_text_input_widget (w_current) == NULL)
   {
-    /* dialog not created yet */
     GtkWidget *dialog = schematic_newtext_dialog_new (w_current);
     g_signal_connect (G_OBJECT (dialog),
                       "response", G_CALLBACK (schematic_newtext_dialog_response),
                       NULL);
     schematic_window_set_text_input_widget (w_current, dialog);
   }
-  else {
-    /* dialog already created */
-    gtk_window_present (GTK_WINDOW(w_current->tiwindow));
-  }
+
+  /* Raise the dialog and make it visible for the user. */
+  gtk_window_present (GTK_WINDOW(w_current->tiwindow));
 
   /* always select the text in the entry */
   select_all_text_in_textview (GTK_TEXT_VIEW (SCHEMATIC_NEWTEXT (w_current->tiwindow)->text_view));

--- a/libleptongui/src/new_text_dialog.c
+++ b/libleptongui/src/new_text_dialog.c
@@ -513,17 +513,6 @@ schematic_newtext_dialog_new (SchematicWindow *w_current)
 void
 schematic_newtext_dialog (SchematicWindow *w_current)
 {
-  /* If the dialog is not yet created, create it. */
-  if (schematic_window_get_newtext_dialog (w_current) == NULL)
-  {
-    GtkWidget *dialog = schematic_newtext_dialog_new (w_current);
-    g_signal_connect (G_OBJECT (dialog),
-                      "response", G_CALLBACK (schematic_newtext_dialog_response),
-                      NULL);
-    schematic_window_set_newtext_dialog (w_current, dialog);
-  }
-
-  /* Raise the dialog and make it visible for the user. */
   gtk_window_present (GTK_WINDOW(w_current->tiwindow));
 
   /* always select the text in the entry */

--- a/libleptongui/src/new_text_dialog.c
+++ b/libleptongui/src/new_text_dialog.c
@@ -191,10 +191,10 @@ dialog_response_cancel (SchematicNewText *dialog)
  *  \param [in] response The Gtk response integer value.
  *  \param unused Unused parameter.
  */
-static void
-text_input_dialog_response (SchematicNewText *dialog,
-                            gint response,
-                            gpointer unused)
+void
+schematic_newtext_dialog_response (SchematicNewText *dialog,
+                                   gint response,
+                                   gpointer unused)
 {
   switch(response) {
     case GTK_RESPONSE_APPLY:
@@ -205,7 +205,7 @@ text_input_dialog_response (SchematicNewText *dialog,
       dialog_response_cancel(dialog);
       break;
     default:
-      printf ("text_input_dialog_response(): strange signal %d\n", response);
+      printf ("schematic_newtext_dialog_response(): strange signal %d\n", response);
   }
 }
 
@@ -498,7 +498,7 @@ schematic_newtext_dialog (SchematicWindow *w_current)
                                 NULL));
 
     g_signal_connect (G_OBJECT (w_current->tiwindow),
-                      "response", G_CALLBACK (text_input_dialog_response),
+                      "response", G_CALLBACK (schematic_newtext_dialog_response),
                       NULL);
 
     gtk_window_set_transient_for (GTK_WINDOW (w_current->tiwindow),

--- a/libleptongui/src/new_text_dialog.c
+++ b/libleptongui/src/new_text_dialog.c
@@ -165,19 +165,6 @@ schematic_newtext_dialog_response_apply (SchematicNewText *dialog)
 }
 
 
-
-/*! \brief Destroy the New text dialog.
- *
- *  \param [in,out] dialog The new text dialog
- */
-void
-schematic_newtext_dialog_destroy (SchematicNewText *dialog)
-{
-  gtk_widget_destroy (GTK_WIDGET (dialog));
-}
-
-
-
 /*! \brief Initialize SchematicNewText class
  *
  *  \par Function Description

--- a/libleptongui/src/new_text_dialog.c
+++ b/libleptongui/src/new_text_dialog.c
@@ -508,14 +508,14 @@ schematic_newtext_dialog_new (SchematicWindow *w_current)
  *  \par Function Description
  *  This function creates or raises the modal text entry dialog
  *
- *  \param [in] w_current The gschem toplevel
+ *  \param [in] widget The dialog widget.
  */
 void
-schematic_newtext_dialog_run (SchematicWindow *w_current)
+schematic_newtext_dialog_run (GtkWidget *widget)
 {
-  gtk_window_present (GTK_WINDOW(w_current->tiwindow));
+  gtk_window_present (GTK_WINDOW (widget));
 
   /* always select the text in the entry */
-  select_all_text_in_textview (GTK_TEXT_VIEW (SCHEMATIC_NEWTEXT (w_current->tiwindow)->text_view));
-  gtk_widget_grab_focus (SCHEMATIC_NEWTEXT (w_current->tiwindow)->text_view);
+  select_all_text_in_textview (GTK_TEXT_VIEW (SCHEMATIC_NEWTEXT (widget)->text_view));
+  gtk_widget_grab_focus (SCHEMATIC_NEWTEXT (widget)->text_view);
 }

--- a/libleptongui/src/new_text_dialog.c
+++ b/libleptongui/src/new_text_dialog.c
@@ -511,7 +511,7 @@ schematic_newtext_dialog_new (SchematicWindow *w_current)
  *  \param [in] w_current The gschem toplevel
  */
 void
-schematic_newtext_dialog (SchematicWindow *w_current)
+schematic_newtext_dialog_run (SchematicWindow *w_current)
 {
   gtk_window_present (GTK_WINDOW(w_current->tiwindow));
 

--- a/libleptongui/src/window.c
+++ b/libleptongui/src/window.c
@@ -1539,7 +1539,7 @@ schematic_window_set_compselect_widget (SchematicWindow *w_current,
  *  \return The Text input widget.
  */
 GtkWidget*
-schematic_window_get_text_input_widget (SchematicWindow *w_current)
+schematic_window_get_newtext_dialog (SchematicWindow *w_current)
 {
   g_return_val_if_fail (w_current != NULL, NULL);
 
@@ -1553,8 +1553,8 @@ schematic_window_get_text_input_widget (SchematicWindow *w_current)
  *  \param [in] widget The widget.
  */
 void
-schematic_window_set_text_input_widget (SchematicWindow *w_current,
-                                        GtkWidget *widget)
+schematic_window_set_newtext_dialog (SchematicWindow *w_current,
+                                     GtkWidget *widget)
 {
   g_return_if_fail (w_current != NULL);
 

--- a/libleptongui/src/x_newtext.c
+++ b/libleptongui/src/x_newtext.c
@@ -225,7 +225,7 @@ static void text_input_dialog_response(NewText *dialog, gint response, gpointer 
       dialog_response_cancel(dialog);
       break;
     default:
-      printf("text_edit_dialog_response(): strange signal %d\n", response);
+      printf ("text_input_dialog_response(): strange signal %d\n", response);
   }
 }
 

--- a/libleptongui/src/x_newtext.c
+++ b/libleptongui/src/x_newtext.c
@@ -37,30 +37,6 @@
 #include <gdk/gdkkeysyms.h>
 
 
-
-#define TYPE_NEWTEXT           (newtext_get_type())
-#define NEWTEXT(obj)           (G_TYPE_CHECK_INSTANCE_CAST ((obj), TYPE_NEWTEXT, NewText))
-#define NEWTEXT_CLASS(klass)   (G_TYPE_CHECK_CLASS_CAST ((klass),  TYPE_NEWTEXT, NewTextClass))
-#define IS_NEWTEXT(obj)        (G_TYPE_CHECK_INSTANCE_TYPE ((obj), TYPE_NEWTEXT))
-
-typedef struct _NewTextClass NewTextClass;
-typedef struct _NewText NewText;
-
-struct _NewTextClass {
-  SchematicDialogClass parent_class;
-};
-
-struct _NewText {
-    SchematicDialog parent;
-
-    GtkWidget *aligncb;
-    GtkWidget *colorcb;
-    GtkWidget *rotatecb;
-    GtkWidget *textsizecb;
-    GtkWidget *text_view;
-};
-
-
 G_DEFINE_TYPE (NewText,
                newtext,
                SCHEMATIC_TYPE_DIALOG);

--- a/libleptongui/src/x_newtext.c
+++ b/libleptongui/src/x_newtext.c
@@ -280,10 +280,6 @@ static void newtext_init(NewText *dialog)
 
   gtk_window_set_position (GTK_WINDOW (dialog), GTK_WIN_POS_NONE);
 
-  g_signal_connect (G_OBJECT (dialog), "response",
-                    G_CALLBACK (text_input_dialog_response),
-                    NULL);
-
   gtk_dialog_set_default_response(GTK_DIALOG(dialog),
                                   GTK_RESPONSE_ACCEPT);
 
@@ -518,6 +514,10 @@ text_input_dialog (SchematicWindow *w_current)
                                 "settings-name",    "text-entry",
                                 "schematic-window",  w_current,
                                 NULL));
+
+    g_signal_connect (G_OBJECT (w_current->tiwindow),
+                      "response", G_CALLBACK (text_input_dialog_response),
+                      NULL);
 
     gtk_window_set_transient_for (GTK_WINDOW (w_current->tiwindow),
                                   GTK_WINDOW (w_current->main_window));

--- a/libleptongui/src/x_newtext.c
+++ b/libleptongui/src/x_newtext.c
@@ -472,7 +472,7 @@ schematic_newtext_init (SchematicNewText *dialog)
  *  \param [in] w_current The gschem toplevel
  */
 void
-text_input_dialog (SchematicWindow *w_current)
+schematic_newtext_dialog (SchematicWindow *w_current)
 {
   if (w_current->tiwindow == NULL) {
     /* dialog not created yet */

--- a/libleptongui/src/x_newtext.c
+++ b/libleptongui/src/x_newtext.c
@@ -37,8 +37,8 @@
 #include <gdk/gdkkeysyms.h>
 
 
-G_DEFINE_TYPE (NewText,
-               newtext,
+G_DEFINE_TYPE (SchematicNewText,
+               schematic_newtext,
                SCHEMATIC_TYPE_DIALOG);
 
 
@@ -86,7 +86,7 @@ select_all_text_in_textview (GtkTextView *textview)
  *  \param [in] dialog The new text dialog
  */
 static void
-dialog_response_apply (NewText *dialog)
+dialog_response_apply (SchematicNewText *dialog)
 {
   g_return_if_fail (dialog != NULL);
 
@@ -172,7 +172,8 @@ dialog_response_apply (NewText *dialog)
  *
  *  \param [in,out] dialog The new text dialog
  */
-static void dialog_response_cancel(NewText *dialog)
+static void
+dialog_response_cancel (SchematicNewText *dialog)
 {
   i_callback_cancel (NULL, dialog->parent.w_current);
   gtk_widget_destroy(dialog->parent.w_current->tiwindow);
@@ -190,7 +191,10 @@ static void dialog_response_cancel(NewText *dialog)
  *  \param [in] response The Gtk response integer value.
  *  \param unused Unused parameter.
  */
-static void text_input_dialog_response(NewText *dialog, gint response, gpointer unused)
+static void
+text_input_dialog_response (SchematicNewText *dialog,
+                            gint response,
+                            gpointer unused)
 {
   switch(response) {
     case GTK_RESPONSE_APPLY:
@@ -206,27 +210,29 @@ static void text_input_dialog_response(NewText *dialog, gint response, gpointer 
 }
 
 
-/*! \brief Initialize NewText class
+/*! \brief Initialize SchematicNewText class
  *
  *  \par Function Description
  *
- *  GType class initialiser for NewText. We override our parent
- *  virtual class methods as needed and register our GObject
- *  properties.
+ *  GType class initialiser for SchematicNewText.  We override our
+ *  parent virtual class methods as needed and register our
+ *  GObject properties.
  *
  *  \param [in] klass
  */
-static void newtext_class_init(NewTextClass *klass)
+static void
+schematic_newtext_class_init (SchematicNewTextClass *klass)
 {
 }
 
 
 
-/*! \brief Initialize NewText instance
+/*! \brief Initialize SchematicNewText instance
  *
  *  \param [in,out] dialog The new text dialog
  */
-static void newtext_init(NewText *dialog)
+static void
+schematic_newtext_init (SchematicNewText *dialog)
 {
   GtkWidget *vbox;
   GtkWidget *label = NULL;
@@ -450,7 +456,7 @@ static void newtext_init(NewText *dialog)
                             tab_array);
   }
   else {
-    g_warning ("newtext_init: Impossible to set tab width.\n");
+    g_warning ("schematic_newtext_init: Impossible to set tab width.\n");
   }
 
   pango_tab_array_free (tab_array);
@@ -471,7 +477,7 @@ text_input_dialog (SchematicWindow *w_current)
   if (w_current->tiwindow == NULL) {
     /* dialog not created yet */
     w_current->tiwindow =
-      GTK_WIDGET (g_object_new (TYPE_NEWTEXT,
+      GTK_WIDGET (g_object_new (SCHEMATIC_TYPE_NEWTEXT,
                                 /* GtkContainer */
                                 "border-width",     DIALOG_BORDER_SPACING,
                                 /* GtkWindow */
@@ -498,10 +504,10 @@ text_input_dialog (SchematicWindow *w_current)
     gtk_window_set_transient_for (GTK_WINDOW (w_current->tiwindow),
                                   GTK_WINDOW (w_current->main_window));
 
-    schematic_integer_combo_box_set_model (NEWTEXT (w_current->tiwindow)->textsizecb,
+    schematic_integer_combo_box_set_model (SCHEMATIC_NEWTEXT (w_current->tiwindow)->textsizecb,
                                            schematic_window_get_text_size_list_store (w_current));
 
-    schematic_integer_combo_box_set_value (NEWTEXT (w_current->tiwindow)->textsizecb,
+    schematic_integer_combo_box_set_value (SCHEMATIC_NEWTEXT (w_current->tiwindow)->textsizecb,
                                            w_current->text_size);
 
     gtk_widget_show_all (w_current->tiwindow);
@@ -512,6 +518,6 @@ text_input_dialog (SchematicWindow *w_current)
   }
 
   /* always select the text in the entry */
-  select_all_text_in_textview (GTK_TEXT_VIEW (NEWTEXT (w_current->tiwindow)->text_view));
-  gtk_widget_grab_focus (NEWTEXT (w_current->tiwindow)->text_view);
+  select_all_text_in_textview (GTK_TEXT_VIEW (SCHEMATIC_NEWTEXT (w_current->tiwindow)->text_view));
+  gtk_widget_grab_focus (SCHEMATIC_NEWTEXT (w_current->tiwindow)->text_view);
 }


### PR DESCRIPTION
The following changes have been done:
- The type `NewText` has been renamed to `SchematicNewText`; many
  related functions have been renamed as well.
- The file `x_newtext.c` has been renamed to `new_text_dialog.c`.
  A separate header file has been added for it.
- The "response" signal of the dialog is now processed in Scheme.
- One of the calls of `x_callback_cancel()` has been transferred
  to Scheme.
