### PR TITLE
Rename the function pointer-position()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -301,6 +301,15 @@ Notable changes in Lepton EDA 1.9.19 (upcoming)
   contains the functions that allow to select locked objects
   providing the info on the selection in the log window.
 
+- The function `pointer-position()` has been renamed to
+  `mouse-pointer-position()` and is now exported in a separate
+  module, `(schematic mouse-pointer)`.  The function has been
+  renamed and the new module has been factored out in order to
+  avoid ambiguities when working with Guile's functions related to
+  FFI pointers and having the `pointer-` prefixes in their names.
+  While deprecated, the previous function name is still available
+  for users for backwards compatibility.
+
 ### Changes in `lepton-schematic`:
 
 - Porting the program to the stable GTK version 3.24 has been

--- a/docs/scheme-api/lepton-scheme.texi
+++ b/docs/scheme-api/lepton-scheme.texi
@@ -2373,6 +2373,7 @@ operations.
 
 @menu
 * Windows and views::
+* Mouse pointer::
 * Key mapping::
 * Selections::
 * Hooks::
@@ -2394,10 +2395,9 @@ Returns the @code{page} currently being displayed for editing.
 Sets the current @code{page} to @var{page}.
 @end defun
 
-@defun mouse-pointer-position
-Returns the current mouse pointer position in world coordinates in the
-form @samp{(x . y)}.  If the pointer is outside the display area,
-returns @samp{#f}.
+@defun pointer-position
+The function is deprecated.  Instead, use the function
+@code{mouse-pointer-position} described below.
 @end defun
 
 @defun snap-point point
@@ -2405,6 +2405,22 @@ Snaps the given @var{point} to the current snap grid, i.e. returns the
 closest grid location to @var{point}.  Expects a point in the form
 @samp{(x . y)}, and returns a point in the same format.
 @end defun
+
+
+@node Mouse pointer
+@section Mouse pointer
+To use the functions described in this section, you will need to load
+the @code{(schematic mouse-pointer)} module.
+
+@defun mouse-pointer-position
+Returns the current mouse pointer position in world coordinates in the
+form @samp{(x . y)}.  If the pointer is outside the display area,
+returns @samp{#f}.  Please note that unlike its deprecated
+predecessor, @code{pointer-position}, which is still available in the
+module @code{(schematic window)}, the function is not exported in that
+module.
+@end defun
+
 
 @node Key mapping
 @section Key mapping

--- a/docs/scheme-api/lepton-scheme.texi
+++ b/docs/scheme-api/lepton-scheme.texi
@@ -2394,7 +2394,7 @@ Returns the @code{page} currently being displayed for editing.
 Sets the current @code{page} to @var{page}.
 @end defun
 
-@defun pointer-position
+@defun mouse-pointer-position
 Returns the current mouse pointer position in world coordinates in the
 form @samp{(x . y)}.  If the pointer is outside the display area,
 returns @samp{#f}.

--- a/libleptongui/scheme/Makefile.am
+++ b/libleptongui/scheme/Makefile.am
@@ -38,6 +38,7 @@ nobase_dist_scmdata_DATA = \
 	schematic/hook.scm \
 	schematic/keymap.scm \
 	schematic/menu.scm \
+	schematic/mouse-pointer.scm \
 	schematic/netlist.scm \
 	schematic/pcb.scm \
 	schematic/precompile.scm \

--- a/libleptongui/scheme/schematic/action.scm
+++ b/libleptongui/scheme/schematic/action.scm
@@ -1,7 +1,7 @@
 ;; Lepton EDA Schematic Capture
 ;; Scheme API
 ;; Copyright (C) 2013 Peter Brett <peter@peter-b.co.uk>
-;; Copyright (C) 2017-2023 Lepton EDA Contributors
+;; Copyright (C) 2017-2024 Lepton EDA Contributors
 ;;
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -24,7 +24,7 @@
 
   #:use-module (schematic gettext)
   #:use-module (schematic hook)
-  #:use-module (schematic window)
+  #:use-module (schematic mouse-pointer)
 
   #:export (eval-action!
             eval-action-at-point!

--- a/libleptongui/scheme/schematic/action.scm
+++ b/libleptongui/scheme/schematic/action.scm
@@ -98,7 +98,7 @@
 ;; mouse pointer position.
 (define* (eval-action-at-point!
           action
-          #:optional (point (pointer-position)))
+          #:optional (point (mouse-pointer-position)))
 
   (with-fluids ((current-action-position point))
                (eval-action! action)))

--- a/libleptongui/scheme/schematic/mouse-pointer.scm
+++ b/libleptongui/scheme/schematic/mouse-pointer.scm
@@ -1,0 +1,51 @@
+;;; Lepton EDA Schematic Capture
+;;; Scheme API
+;;; Copyright (C) 2010-2011 Peter Brett <peter@peter-b.co.uk>
+;;; Copyright (C) 2017-2024 Lepton EDA Contributors
+;;;
+;;; This program is free software; you can redistribute it and/or modify
+;;; it under the terms of the GNU General Public License as published by
+;;; the Free Software Foundation; either version 2 of the License, or
+;;; (at your option) any later version.
+;;;
+;;; This program is distributed in the hope that it will be useful,
+;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;; GNU General Public License for more details.
+;;;
+;;; You should have received a copy of the GNU General Public License
+;;; along with this program; if not, write to the Free Software
+;;; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+(define-module (schematic mouse-pointer)
+  #:use-module (rnrs bytevectors)
+  #:use-module (system foreign)
+
+  #:use-module (lepton ffi boolean)
+
+  #:use-module (schematic ffi)
+  #:use-module (schematic window foreign)
+  #:use-module (schematic window global)
+
+  #:export (pointer-position))
+
+
+(define (pointer-position)
+  "Returns the current mouse pointer position, expressed in world
+coordinates in the form (X . Y).  If the pointer is outside the
+schematic drawing area, returns #f."
+  (define *window
+    (or (and=> (current-window) window->pointer)
+        (error "~S: Current window is unavailable." 'pointer-position)))
+
+  (define x (make-bytevector (sizeof int)))
+  (define y (make-bytevector (sizeof int)))
+
+  (let ((result (true? (x_event_get_pointer_position
+                        *window
+                        FALSE
+                        (bytevector->pointer x)
+                        (bytevector->pointer y)))))
+    (and result
+         (cons (bytevector-sint-ref x 0 (native-endianness) (sizeof int))
+               (bytevector-sint-ref y 0 (native-endianness) (sizeof int))))))

--- a/libleptongui/scheme/schematic/mouse-pointer.scm
+++ b/libleptongui/scheme/schematic/mouse-pointer.scm
@@ -22,21 +22,23 @@
   #:use-module (system foreign)
 
   #:use-module (lepton ffi boolean)
+  #:use-module (lepton log)
 
   #:use-module (schematic ffi)
   #:use-module (schematic window foreign)
   #:use-module (schematic window global)
 
-  #:export (pointer-position))
+  #:export (mouse-pointer-position
+            pointer-position))
 
 
-(define (pointer-position)
+(define (mouse-pointer-position)
   "Returns the current mouse pointer position, expressed in world
-coordinates in the form (X . Y).  If the pointer is outside the
-schematic drawing area, returns #f."
+coordinates in the form (X . Y).  If the mouse pointer is outside
+the schematic drawing area, returns #f."
   (define *window
     (or (and=> (current-window) window->pointer)
-        (error "~S: Current window is unavailable." 'pointer-position)))
+        (error "~S: Current window is unavailable." 'mouse-pointer-position)))
 
   (define x (make-bytevector (sizeof int)))
   (define y (make-bytevector (sizeof int)))
@@ -49,3 +51,11 @@ schematic drawing area, returns #f."
     (and result
          (cons (bytevector-sint-ref x 0 (native-endianness) (sizeof int))
                (bytevector-sint-ref y 0 (native-endianness) (sizeof int))))))
+
+
+(define (pointer-position)
+  "The function is deprecated and is left for backward compatibility
+only.  Use the mouse-pointer() function instead."
+  (log! 'warning "The function name \"pointer-position()\" is deprecated.")
+  (log! 'warning "Use \"mouse-pointer-position()\" instead.")
+  (mouse-pointer-position))

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -50,6 +50,7 @@
   #:use-module (schematic gui keymap)
   #:use-module (schematic gui stroke)
   #:use-module (schematic menu)
+  #:use-module (schematic mouse-pointer)
   #:use-module (schematic toolbar)
   #:use-module (schematic undo)
   #:use-module (schematic viewport foreign)
@@ -59,13 +60,13 @@
 
   #:re-export (%lepton-window
                current-window
-               with-window)
+               with-window
+               pointer-position)
 
   #:export (close-window!
             make-schematic-window
             active-page
             set-active-page!
-            pointer-position
             snap-point
             window-canvas
             window-close-page!
@@ -1302,27 +1303,6 @@ window to PAGE.  Returns PAGE."
   (define *window (check-window window 1))
 
   (pointer->canvas (schematic_window_get_current_canvas *window)))
-
-
-(define (pointer-position)
-  "Returns the current mouse pointer position, expressed in world
-coordinates in the form (X . Y).  If the pointer is outside the
-schematic drawing area, returns #f."
-  (define *window
-    (or (and=> (current-window) window->pointer)
-        (error "~S: Current window is unavailable." 'pointer-position)))
-
-  (define x (make-bytevector (sizeof int)))
-  (define y (make-bytevector (sizeof int)))
-
-  (let ((result (true? (x_event_get_pointer_position
-                        *window
-                        FALSE
-                        (bytevector->pointer x)
-                        (bytevector->pointer y)))))
-    (and result
-         (cons (bytevector-sint-ref x 0 (native-endianness) (sizeof int))
-               (bytevector-sint-ref y 0 (native-endianness) (sizeof int))))))
 
 
 (define (snap-point point)


### PR DESCRIPTION
- The function `pointer-position()` has been renamed to
  `mouse-pointer-position()` to avoid ambiguities due to Guile's
  use of the prefix `pointer-` for functions working with foreign
  C pointers. A sibling of the function with the initial name has
  been added to preserve backwards compatibility.  The function
  still can be used under that initial name though such a usage is
  now deprecated.  A docstring for `pointer-position()` has been
  amended to contain the info on its deprecation.  Besides, the
  function reports the warnings to the log.

- A new module, `(schematic mouse-pointer)`, has been factored
  out, and the function `mouse-pointer-position()` has been moved to
  it.  The module name reflects the fact that it deals with the
  mouse pointer as the prefix `pointer` is already used in Guile
  for FFI as it is stated above.  The module has been separated to
  avoid possible future conflicts due to circular dependencies of
  the Lepton modules.

- A description of the above changes has been added to the Lepton
  Scheme manual.
