### PR TITLE
Compile Scheme source files of all executable tools into binary Scheme GO files

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -33,6 +33,12 @@ Notable changes in Lepton EDA 1.9.19 (upcoming)
   of the `inkscape` program used for creating Doxygen developer
   documentation have been replaced with their modern variants.
 
+- All toplevel executable Scheme tools in the suite, including the
+  GUI programs and CLI utilities, are now compiled beforehand if
+  the option `--enable-guild` is provided on the `configure`
+  stage.
+
+
 ### Changes in `liblepton`:
 
 - A new Scheme type, `<toplevel>`, has been introduced.  This is a

--- a/tools/archive/Makefile.am
+++ b/tools/archive/Makefile.am
@@ -7,3 +7,47 @@ SUBDIRS = \
 	tests
 
 bin_SCRIPTS = lepton-archive
+
+godir = $(LEPTONDATADIR)/ccache
+
+# To check it all thoroughly, you could add:
+# -Wformat -- to test issues with the built-in format() function.
+# -Wunused-toplevel -- to test for toplevel exported vars.
+# -Wunused-variable -- to test for other unused vars (there are
+#  some in (match ...) and other code).
+
+GUILE_WARNINGS = \
+	-Warity-mismatch \
+	-Wbad-case-datum \
+	-Wduplicate-case-datum \
+	-Wmacro-use-before-definition \
+	-Wshadowed-toplevel \
+	-Wunbound-variable \
+	-Wunsupported-warning
+
+
+# This part depends on the configure switch --enable-guild.
+if ENABLE_GUILD
+
+lepton-archive.go: lepton-archive
+	$(AM_V_GEN) \
+	LIBLEPTON="${abs_top_builddir}/liblepton/src/liblepton" \
+	$(GUILD) compile \
+	-L . \
+	-L $(abs_top_srcdir)/liblepton/scheme \
+	-L $(abs_top_builddir)/liblepton/scheme \
+	$(GUILE_WARNINGS) -o "$@" "$<"
+
+nobase_go_DATA = lepton-archive.go
+
+# Make sure source files are installed first, so that the mtime of
+# installed compiled files is greater than that of installed source
+# files.  See
+# <http://lists.gnu.org/archive/html/guile-devel/2010-07/msg00125.html>
+# for details.
+guile_install_go_files = install-nobase_goDATA
+$(guile_install_go_files): install-binSCRIPTS
+
+CLEANFILES = $(nobase_go_DATA)
+
+endif

--- a/tools/attrib/Makefile.am
+++ b/tools/attrib/Makefile.am
@@ -1,1 +1,45 @@
 bin_SCRIPTS = lepton-attrib
+
+godir = $(LEPTONDATADIR)/ccache
+
+# To check it all thoroughly, you could add:
+# -Wformat -- to test issues with the built-in format() function.
+# -Wunused-toplevel -- to test for toplevel exported vars.
+# -Wunused-variable -- to test for other unused vars (there are
+#  some in (match ...) and other code).
+
+GUILE_WARNINGS = \
+	-Warity-mismatch \
+	-Wbad-case-datum \
+	-Wduplicate-case-datum \
+	-Wmacro-use-before-definition \
+	-Wshadowed-toplevel \
+	-Wunbound-variable \
+	-Wunsupported-warning
+
+
+# This part depends on the configure switch --enable-guild.
+if ENABLE_GUILD
+
+lepton-attrib.go: lepton-attrib
+	$(AM_V_GEN) \
+	LIBLEPTON="${abs_top_builddir}/liblepton/src/liblepton" \
+	$(GUILD) compile \
+	-L . \
+	-L $(abs_top_srcdir)/liblepton/scheme \
+	-L $(abs_top_builddir)/liblepton/scheme \
+	$(GUILE_WARNINGS) -o "$@" "$<"
+
+nobase_go_DATA = lepton-attrib.go
+
+# Make sure source files are installed first, so that the mtime of
+# installed compiled files is greater than that of installed source
+# files.  See
+# <http://lists.gnu.org/archive/html/guile-devel/2010-07/msg00125.html>
+# for details.
+guile_install_go_files = install-nobase_goDATA
+$(guile_install_go_files): install-binSCRIPTS
+
+CLEANFILES = $(nobase_go_DATA)
+
+endif

--- a/tools/cli/scheme/Makefile.am
+++ b/tools/cli/scheme/Makefile.am
@@ -3,3 +3,75 @@ bin_SCRIPTS = \
 	lepton-config \
 	lepton-export \
 	lepton-shell
+
+godir = $(LEPTONDATADIR)/ccache
+
+# To check it all thoroughly, you could add:
+# -Wformat -- to test issues with the built-in format() function.
+# -Wunused-toplevel -- to test for toplevel exported vars.
+# -Wunused-variable -- to test for other unused vars (there are
+#  some in (match ...) and other code).
+
+GUILE_WARNINGS = \
+	-Warity-mismatch \
+	-Wbad-case-datum \
+	-Wduplicate-case-datum \
+	-Wmacro-use-before-definition \
+	-Wshadowed-toplevel \
+	-Wunbound-variable \
+	-Wunsupported-warning
+
+GOBJECTS = $(bin_SCRIPTS:%=%.go)
+
+# This part depends on the configure switch --enable-guild.
+if ENABLE_GUILD
+
+lepton-config.go: lepton-config
+	$(AM_V_GEN) \
+	LIBLEPTON="${abs_top_builddir}/liblepton/src/liblepton" \
+	$(GUILD) compile \
+	-L . \
+	-L $(abs_top_srcdir)/liblepton/scheme \
+	-L $(abs_top_builddir)/liblepton/scheme \
+	$(GUILE_WARNINGS) -o "$@" "$<"
+
+lepton-export.go: lepton-export
+	$(AM_V_GEN) \
+	LIBLEPTON="${abs_top_builddir}/liblepton/src/liblepton" \
+	$(GUILD) compile \
+	-L . \
+	-L $(abs_top_srcdir)/liblepton/scheme \
+	-L $(abs_top_builddir)/liblepton/scheme \
+	$(GUILE_WARNINGS) -o "$@" "$<"
+
+lepton-shell.go: lepton-shell
+	$(AM_V_GEN) \
+	LIBLEPTON="${abs_top_builddir}/liblepton/src/liblepton" \
+	$(GUILD) compile \
+	-L . \
+	-L $(abs_top_srcdir)/liblepton/scheme \
+	-L $(abs_top_builddir)/liblepton/scheme \
+	$(GUILE_WARNINGS) -o "$@" "$<"
+
+lepton-cli.go: lepton-cli
+	$(AM_V_GEN) \
+	LIBLEPTON="${abs_top_builddir}/liblepton/src/liblepton" \
+	$(GUILD) compile \
+	-L . \
+	-L $(abs_top_srcdir)/liblepton/scheme \
+	-L $(abs_top_builddir)/liblepton/scheme \
+	$(GUILE_WARNINGS) -o "$@" "$<"
+
+nobase_go_DATA = $(GOBJECTS)
+
+# Make sure source files are installed first, so that the mtime of
+# installed compiled files is greater than that of installed source
+# files.  See
+# <http://lists.gnu.org/archive/html/guile-devel/2010-07/msg00125.html>
+# for details.
+guile_install_go_files = install-nobase_goDATA
+$(guile_install_go_files): install-binSCRIPTS
+
+CLEANFILES = $(GOBJECTS)
+
+endif

--- a/tools/embed/Makefile.am
+++ b/tools/embed/Makefile.am
@@ -3,3 +3,47 @@ SUBDIRS = docs
 endif
 
 bin_SCRIPTS = lepton-embed
+
+godir = $(LEPTONDATADIR)/ccache
+
+# To check it all thoroughly, you could add:
+# -Wformat -- to test issues with the built-in format() function.
+# -Wunused-toplevel -- to test for toplevel exported vars.
+# -Wunused-variable -- to test for other unused vars (there are
+#  some in (match ...) and other code).
+
+GUILE_WARNINGS = \
+	-Warity-mismatch \
+	-Wbad-case-datum \
+	-Wduplicate-case-datum \
+	-Wmacro-use-before-definition \
+	-Wshadowed-toplevel \
+	-Wunbound-variable \
+	-Wunsupported-warning
+
+
+# This part depends on the configure switch --enable-guild.
+if ENABLE_GUILD
+
+lepton-embed.go: lepton-embed
+	$(AM_V_GEN) \
+	LIBLEPTON="${abs_top_builddir}/liblepton/src/liblepton" \
+	$(GUILD) compile \
+	-L . \
+	-L $(abs_top_srcdir)/liblepton/scheme \
+	-L $(abs_top_builddir)/liblepton/scheme \
+	$(GUILE_WARNINGS) -o "$@" "$<"
+
+nobase_go_DATA = lepton-embed.go
+
+# Make sure source files are installed first, so that the mtime of
+# installed compiled files is greater than that of installed source
+# files.  See
+# <http://lists.gnu.org/archive/html/guile-devel/2010-07/msg00125.html>
+# for details.
+guile_install_go_files = install-nobase_goDATA
+$(guile_install_go_files): install-binSCRIPTS
+
+CLEANFILES = $(nobase_go_DATA)
+
+endif

--- a/tools/netlist/Makefile.am
+++ b/tools/netlist/Makefile.am
@@ -9,3 +9,47 @@ SUBDIRS = \
 	tests
 
 bin_SCRIPTS = lepton-netlist
+
+godir = $(LEPTONDATADIR)/ccache
+
+# To check it all thoroughly, you could add:
+# -Wformat -- to test issues with the built-in format() function.
+# -Wunused-toplevel -- to test for toplevel exported vars.
+# -Wunused-variable -- to test for other unused vars (there are
+#  some in (match ...) and other code).
+
+GUILE_WARNINGS = \
+	-Warity-mismatch \
+	-Wbad-case-datum \
+	-Wduplicate-case-datum \
+	-Wmacro-use-before-definition \
+	-Wshadowed-toplevel \
+	-Wunbound-variable \
+	-Wunsupported-warning
+
+
+# This part depends on the configure switch --enable-guild.
+if ENABLE_GUILD
+
+lepton-netlist.go: lepton-netlist
+	$(AM_V_GEN) \
+	LIBLEPTON="${abs_top_builddir}/liblepton/src/liblepton" \
+	$(GUILD) compile \
+	-L . \
+	-L $(abs_top_srcdir)/liblepton/scheme \
+	-L $(abs_top_builddir)/liblepton/scheme \
+	$(GUILE_WARNINGS) -o "$@" "$<"
+
+nobase_go_DATA = lepton-netlist.go
+
+# Make sure source files are installed first, so that the mtime of
+# installed compiled files is greater than that of installed source
+# files.  See
+# <http://lists.gnu.org/archive/html/guile-devel/2010-07/msg00125.html>
+# for details.
+guile_install_go_files = install-nobase_goDATA
+$(guile_install_go_files): install-binSCRIPTS
+
+CLEANFILES = $(nobase_go_DATA)
+
+endif

--- a/tools/schematic/Makefile.am
+++ b/tools/schematic/Makefile.am
@@ -1,1 +1,48 @@
 bin_SCRIPTS = lepton-schematic
+
+godir = $(LEPTONDATADIR)/ccache
+
+# To check it all thoroughly, you could add:
+# -Wformat -- to test issues with the built-in format() function.
+# -Wunused-toplevel -- to test for toplevel exported vars.
+# -Wunused-variable -- to test for other unused vars (there are
+#  some in (match ...) and other code).
+
+GUILE_WARNINGS = \
+	-Warity-mismatch \
+	-Wbad-case-datum \
+	-Wduplicate-case-datum \
+	-Wmacro-use-before-definition \
+	-Wshadowed-toplevel \
+	-Wunbound-variable \
+	-Wunsupported-warning
+
+
+# This part depends on the configure switch --enable-guild.
+if ENABLE_GUILD
+
+lepton-schematic.go: lepton-schematic
+	$(AM_V_GEN) \
+	LIBLEPTON="${abs_top_builddir}/liblepton/src/liblepton" \
+	LIBLEPTONGUI="${abs_top_builddir}/libleptongui/src/libleptongui" \
+	$(GUILD) compile \
+	-L . \
+	-L $(abs_top_srcdir)/liblepton/scheme \
+	-L $(abs_top_builddir)/liblepton/scheme \
+	-L $(abs_top_srcdir)/libleptongui/scheme \
+	-L $(abs_top_builddir)/libleptongui/scheme \
+	$(GUILE_WARNINGS) -o "$@" "$<"
+
+nobase_go_DATA = lepton-schematic.go
+
+# Make sure source files are installed first, so that the mtime of
+# installed compiled files is greater than that of installed source
+# files.  See
+# <http://lists.gnu.org/archive/html/guile-devel/2010-07/msg00125.html>
+# for details.
+guile_install_go_files = install-nobase_goDATA
+$(guile_install_go_files): install-binSCRIPTS
+
+CLEANFILES = $(nobase_go_DATA)
+
+endif

--- a/tools/symcheck/Makefile.am
+++ b/tools/symcheck/Makefile.am
@@ -7,3 +7,47 @@ SUBDIRS = \
 	tests
 
 bin_SCRIPTS = lepton-symcheck
+
+godir = $(LEPTONDATADIR)/ccache
+
+# To check it all thoroughly, you could add:
+# -Wformat -- to test issues with the built-in format() function.
+# -Wunused-toplevel -- to test for toplevel exported vars.
+# -Wunused-variable -- to test for other unused vars (there are
+#  some in (match ...) and other code).
+
+GUILE_WARNINGS = \
+	-Warity-mismatch \
+	-Wbad-case-datum \
+	-Wduplicate-case-datum \
+	-Wmacro-use-before-definition \
+	-Wshadowed-toplevel \
+	-Wunbound-variable \
+	-Wunsupported-warning
+
+
+# This part depends on the configure switch --enable-guild.
+if ENABLE_GUILD
+
+lepton-symcheck.go: lepton-symcheck
+	$(AM_V_GEN) \
+	LIBLEPTON="${abs_top_builddir}/liblepton/src/liblepton" \
+	$(GUILD) compile \
+	-L . \
+	-L $(abs_top_srcdir)/liblepton/scheme \
+	-L $(abs_top_builddir)/liblepton/scheme \
+	$(GUILE_WARNINGS) -o "$@" "$<"
+
+nobase_go_DATA = lepton-symcheck.go
+
+# Make sure source files are installed first, so that the mtime of
+# installed compiled files is greater than that of installed source
+# files.  See
+# <http://lists.gnu.org/archive/html/guile-devel/2010-07/msg00125.html>
+# for details.
+guile_install_go_files = install-nobase_goDATA
+$(guile_install_go_files): install-binSCRIPTS
+
+CLEANFILES = $(nobase_go_DATA)
+
+endif

--- a/tools/tragesym/Makefile.am
+++ b/tools/tragesym/Makefile.am
@@ -7,3 +7,47 @@ SUBDIRS = \
 	examples
 
 bin_SCRIPTS = lepton-tragesym
+
+godir = $(LEPTONDATADIR)/ccache
+
+# To check it all thoroughly, you could add:
+# -Wformat -- to test issues with the built-in format() function.
+# -Wunused-toplevel -- to test for toplevel exported vars.
+# -Wunused-variable -- to test for other unused vars (there are
+#  some in (match ...) and other code).
+
+GUILE_WARNINGS = \
+	-Warity-mismatch \
+	-Wbad-case-datum \
+	-Wduplicate-case-datum \
+	-Wmacro-use-before-definition \
+	-Wshadowed-toplevel \
+	-Wunbound-variable \
+	-Wunsupported-warning
+
+
+# This part depends on the configure switch --enable-guild.
+if ENABLE_GUILD
+
+lepton-tragesym.go: lepton-tragesym
+	$(AM_V_GEN) \
+	LIBLEPTON="${abs_top_builddir}/liblepton/src/liblepton" \
+	$(GUILD) compile \
+	-L . \
+	-L $(abs_top_srcdir)/liblepton/scheme \
+	-L $(abs_top_builddir)/liblepton/scheme \
+	$(GUILE_WARNINGS) -o "$@" "$<"
+
+nobase_go_DATA = lepton-tragesym.go
+
+# Make sure source files are installed first, so that the mtime of
+# installed compiled files is greater than that of installed source
+# files.  See
+# <http://lists.gnu.org/archive/html/guile-devel/2010-07/msg00125.html>
+# for details.
+guile_install_go_files = install-nobase_goDATA
+$(guile_install_go_files): install-binSCRIPTS
+
+CLEANFILES = $(nobase_go_DATA)
+
+endif

--- a/tools/upcfg/Makefile.am
+++ b/tools/upcfg/Makefile.am
@@ -3,3 +3,47 @@ SUBDIRS = docs
 endif
 
 bin_SCRIPTS = lepton-upcfg
+
+godir = $(LEPTONDATADIR)/ccache
+
+# To check it all thoroughly, you could add:
+# -Wformat -- to test issues with the built-in format() function.
+# -Wunused-toplevel -- to test for toplevel exported vars.
+# -Wunused-variable -- to test for other unused vars (there are
+#  some in (match ...) and other code).
+
+GUILE_WARNINGS = \
+	-Warity-mismatch \
+	-Wbad-case-datum \
+	-Wduplicate-case-datum \
+	-Wmacro-use-before-definition \
+	-Wshadowed-toplevel \
+	-Wunbound-variable \
+	-Wunsupported-warning
+
+
+# This part depends on the configure switch --enable-guild.
+if ENABLE_GUILD
+
+lepton-upcfg.go: lepton-upcfg
+	$(AM_V_GEN) \
+	LIBLEPTON="${abs_top_builddir}/liblepton/src/liblepton" \
+	$(GUILD) compile \
+	-L . \
+	-L $(abs_top_srcdir)/liblepton/scheme \
+	-L $(abs_top_builddir)/liblepton/scheme \
+	$(GUILE_WARNINGS) -o "$@" "$<"
+
+nobase_go_DATA = lepton-upcfg.go
+
+# Make sure source files are installed first, so that the mtime of
+# installed compiled files is greater than that of installed source
+# files.  See
+# <http://lists.gnu.org/archive/html/guile-devel/2010-07/msg00125.html>
+# for details.
+guile_install_go_files = install-nobase_goDATA
+$(guile_install_go_files): install-binSCRIPTS
+
+CLEANFILES = $(nobase_go_DATA)
+
+endif

--- a/tools/update/Makefile.am
+++ b/tools/update/Makefile.am
@@ -7,3 +7,47 @@ SUBDIRS = \
 	tests
 
 bin_SCRIPTS = lepton-update
+
+godir = $(LEPTONDATADIR)/ccache
+
+# To check it all thoroughly, you could add:
+# -Wformat -- to test issues with the built-in format() function.
+# -Wunused-toplevel -- to test for toplevel exported vars.
+# -Wunused-variable -- to test for other unused vars (there are
+#  some in (match ...) and other code).
+
+GUILE_WARNINGS = \
+	-Warity-mismatch \
+	-Wbad-case-datum \
+	-Wduplicate-case-datum \
+	-Wmacro-use-before-definition \
+	-Wshadowed-toplevel \
+	-Wunbound-variable \
+	-Wunsupported-warning
+
+
+# This part depends on the configure switch --enable-guild.
+if ENABLE_GUILD
+
+lepton-update.go: lepton-update
+	$(AM_V_GEN) \
+	LIBLEPTON="${abs_top_builddir}/liblepton/src/liblepton" \
+	$(GUILD) compile \
+	-L . \
+	-L $(abs_top_srcdir)/liblepton/scheme \
+	-L $(abs_top_builddir)/liblepton/scheme \
+	$(GUILE_WARNINGS) -o "$@" "$<"
+
+nobase_go_DATA = lepton-update.go
+
+# Make sure source files are installed first, so that the mtime of
+# installed compiled files is greater than that of installed source
+# files.  See
+# <http://lists.gnu.org/archive/html/guile-devel/2010-07/msg00125.html>
+# for details.
+guile_install_go_files = install-nobase_goDATA
+$(guile_install_go_files): install-binSCRIPTS
+
+CLEANFILES = $(nobase_go_DATA)
+
+endif


### PR DESCRIPTION
The beforehand compilation is now available for toplevel code of all executable tools in the suite, including GUI programs and CLI utils, the same way as it was previously for all Scheme modules in Lepton.