### PR TITLE
Rewrite x_event_scroll() in Scheme

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -348,6 +348,8 @@ Notable changes in Lepton EDA 1.9.19 (upcoming)
   While deprecated, the previous function name is still available
   for users for backwards compatibility.
 
+- Gdk canvas scroll events are now handled in Scheme.
+
 ### Changes in `lepton-schematic`:
 
 - Porting the program to the stable GTK version 3.24 has been
@@ -472,6 +474,11 @@ Notable changes in Lepton EDA 1.9.19 (upcoming)
   Multiattrib dialog as the primitives may have attributes
   attached to them.  Besides, the user always has some visual
   feedback that the command is evaluated.
+
+- A zooming bug in the GTK3 port has been fixed.  Previously, the
+  first *smooth* zooming event was always considered a *zoom in*
+  one.  Now it is skipped, like in panning mode, to calculate
+  correct zooming direction on the next event.
 
 ### Changes in `lepton-archive`:
 

--- a/libleptongui/include/gtk_helper.h
+++ b/libleptongui/include/gtk_helper.h
@@ -1,5 +1,5 @@
 /* Lepton EDA Schematic Capture
- * Copyright (C) 2023 Lepton EDA Contributors
+ * Copyright (C) 2023-2024 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -20,6 +20,12 @@
 #define GTK_HELPER_H
 
 G_BEGIN_DECLS
+
+GdkScrollDirection
+gdk_event_scroll_direction_from_string (char *s);
+
+const char*
+gdk_event_scroll_direction_to_string (GdkScrollDirection mode);
 
 const char*
 gtk_response_to_string (int response);

--- a/libleptongui/include/i_vars.h
+++ b/libleptongui/include/i_vars.h
@@ -10,7 +10,7 @@ extern int default_embed_component;
 extern int default_include_component;
 extern int default_snap_size;
 
-extern int default_scrollbars_flag;
+extern gboolean default_scrollbars_flag;
 extern gchar *default_print_paper;
 extern int default_print_orientation;
 extern int default_print_color;

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -945,10 +945,9 @@ gint
 x_event_scroll (GtkWidget *widget,
                 GdkEventScroll *event,
                 SchematicWindow *w_current,
-                gboolean gtk_scroll_wheel,
                 GdkScrollDirection direction,
-                gboolean event_has_direction,
                 gboolean zoom,
+                gboolean pan_xaxis,
                 gboolean pan_yaxis);
 gboolean
 x_event_get_pointer_position (SchematicWindow *w_current,

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -955,7 +955,7 @@ x_event_scroll (GtkWidget *widget,
                 gboolean pan_xaxis,
                 gboolean pan_yaxis,
                 int pan_direction,
-                double y_delta);
+                int zoom_direction);
 gboolean
 x_event_get_pointer_position (SchematicWindow *w_current,
                               gboolean snapped,

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -940,7 +940,8 @@ x_event_key (SchematicCanvas *page_view,
 gint
 x_event_scroll (GtkWidget *widget,
                 GdkEventScroll *event,
-                SchematicWindow *w_current);
+                SchematicWindow *w_current,
+                gboolean gtk_scroll_wheel);
 gboolean
 x_event_get_pointer_position (SchematicWindow *w_current,
                               gboolean snapped,

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -947,12 +947,6 @@ x_event_key (SchematicCanvas *page_view,
 GdkScrollDirection
 schematic_event_get_scroll_direction (GdkEventScroll *event);
 
-gint
-x_event_scroll (GtkWidget *widget,
-                SchematicWindow *w_current,
-                gboolean zoom,
-                gboolean pan_xaxis,
-                gboolean pan_yaxis);
 gboolean
 x_event_get_pointer_position (SchematicWindow *w_current,
                               gboolean snapped,

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -951,7 +951,6 @@ gint
 x_event_scroll (GtkWidget *widget,
                 GdkEventScroll *event,
                 SchematicWindow *w_current,
-                GdkScrollDirection direction,
                 gboolean zoom,
                 gboolean pan_xaxis,
                 gboolean pan_yaxis,

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -919,12 +919,6 @@ schematic_event_get_button (GdkEvent *event);
 gboolean
 schematic_event_is_double_button_press (GdkEvent *event);
 
-guint
-schematic_event_get_last_scroll_event_time ();
-
-void
-schematic_event_set_last_scroll_event_time (guint val);
-
 gboolean
 schematic_event_skip_motion_event (GdkEvent *event);
 

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -948,7 +948,8 @@ x_event_scroll (GtkWidget *widget,
                 gboolean gtk_scroll_wheel,
                 GdkScrollDirection direction,
                 gboolean event_has_direction,
-                gboolean zoom);
+                gboolean zoom,
+                gboolean pan_yaxis);
 gboolean
 x_event_get_pointer_position (SchematicWindow *w_current,
                               gboolean snapped,

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -949,13 +949,11 @@ schematic_event_get_scroll_direction (GdkEventScroll *event);
 
 gint
 x_event_scroll (GtkWidget *widget,
-                GdkEventScroll *event,
                 SchematicWindow *w_current,
                 gboolean zoom,
                 gboolean pan_xaxis,
                 gboolean pan_yaxis,
-                int pan_direction,
-                int zoom_direction);
+                int pan_direction);
 gboolean
 x_event_get_pointer_position (SchematicWindow *w_current,
                               gboolean snapped,

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -947,7 +947,8 @@ x_event_scroll (GtkWidget *widget,
                 SchematicWindow *w_current,
                 gboolean gtk_scroll_wheel,
                 GdkScrollDirection direction,
-                gboolean event_has_direction);
+                gboolean event_has_direction,
+                gboolean zoom);
 gboolean
 x_event_get_pointer_position (SchematicWindow *w_current,
                               gboolean snapped,

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -954,7 +954,8 @@ x_event_scroll (GtkWidget *widget,
                 GdkScrollDirection direction,
                 gboolean zoom,
                 gboolean pan_xaxis,
-                gboolean pan_yaxis);
+                gboolean pan_yaxis,
+                double y_delta);
 gboolean
 x_event_get_pointer_position (SchematicWindow *w_current,
                               gboolean snapped,

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -952,10 +952,7 @@ x_event_scroll (GtkWidget *widget,
                 SchematicWindow *w_current,
                 gboolean zoom,
                 gboolean pan_xaxis,
-                gboolean pan_yaxis,
-                int pan_direction,
-                GtkAdjustment *horiz_adj,
-                GtkAdjustment *vert_adj);
+                gboolean pan_yaxis);
 gboolean
 x_event_get_pointer_position (SchematicWindow *w_current,
                               gboolean snapped,

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -937,11 +937,17 @@ GdkEventKey*
 x_event_key (SchematicCanvas *page_view,
              GdkEventKey *event,
              SchematicWindow *w_current);
+
+GdkScrollDirection
+schematic_event_get_scroll_direction (GdkEventScroll *event);
+
 gint
 x_event_scroll (GtkWidget *widget,
                 GdkEventScroll *event,
                 SchematicWindow *w_current,
-                gboolean gtk_scroll_wheel);
+                gboolean gtk_scroll_wheel,
+                GdkScrollDirection direction,
+                gboolean event_has_direction);
 gboolean
 x_event_get_pointer_position (SchematicWindow *w_current,
                               gboolean snapped,

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -954,6 +954,7 @@ x_event_scroll (GtkWidget *widget,
                 gboolean zoom,
                 gboolean pan_xaxis,
                 gboolean pan_yaxis,
+                int pan_direction,
                 double y_delta);
 gboolean
 x_event_get_pointer_position (SchematicWindow *w_current,

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -953,7 +953,9 @@ x_event_scroll (GtkWidget *widget,
                 gboolean zoom,
                 gboolean pan_xaxis,
                 gboolean pan_yaxis,
-                int pan_direction);
+                int pan_direction,
+                GtkAdjustment *horiz_adj,
+                GtkAdjustment *vert_adj);
 gboolean
 x_event_get_pointer_position (SchematicWindow *w_current,
                               gboolean snapped,

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -919,6 +919,12 @@ schematic_event_get_button (GdkEvent *event);
 gboolean
 schematic_event_is_double_button_press (GdkEvent *event);
 
+guint
+schematic_event_get_last_scroll_event_time ();
+
+void
+schematic_event_set_last_scroll_event_time (guint val);
+
 gboolean
 schematic_event_skip_motion_event (GdkEvent *event);
 

--- a/libleptongui/include/schematic_defines.h
+++ b/libleptongui/include/schematic_defines.h
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2014 gEDA Contributors
- * Copyright (C) 2017-2024 Lepton EDA Contributors
+ * Copyright (C) 2017-2025 Lepton EDA Contributors
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -33,6 +33,7 @@
 #define ZOOM_OUT 0
 #define ZOOM_IN 1
 #define ZOOM_FULL 2
+#define ZOOM_SAME 3
 
 #define ZOOM_EXTENTS_PADDING_PX 5
 

--- a/libleptongui/include/window.h
+++ b/libleptongui/include/window.h
@@ -193,7 +193,7 @@ struct st_schematic_window {
   int net_selection_state;  /* current status of the net selecting mode */
   int embed_component;    /* controls if component objects are embedded */
   int include_component;  /* controls if component objects are included */
-  int scrollbars_flag;    /* controls if scrollbars are displayed */
+  gboolean scrollbars_flag;    /* controls if scrollbars are displayed */
   int third_button;       /* controls what the third mouse button does */
   int third_button_cancel;/* controls if the third mouse button cancels actions */
   int middle_button;      /* controls what the third mouse button does */
@@ -623,12 +623,12 @@ schematic_window_get_scroll_wheel (SchematicWindow *w_current);
 void
 schematic_window_set_scroll_wheel (SchematicWindow *w_current,
                                    int val);
-int
+gboolean
 schematic_window_get_scrollbars_flag (SchematicWindow *w_current);
 
 void
 schematic_window_set_scrollbars_flag (SchematicWindow *w_current,
-                                      int val);
+                                      gboolean val);
 int
 schematic_window_get_scrollpan_steps (SchematicWindow *w_current);
 

--- a/libleptongui/scheme/Makefile.am
+++ b/libleptongui/scheme/Makefile.am
@@ -30,6 +30,7 @@ nobase_dist_scmdata_DATA = \
 	schematic/dialog/new-text.scm \
 	schematic/dialog/slot-edit.scm \
 	schematic/doc.scm \
+	schematic/event.scm \
 	schematic/ffi.scm \
 	schematic/ffi/gtk.scm \
 	schematic/gettext.scm \

--- a/libleptongui/scheme/schematic/canvas.scm
+++ b/libleptongui/scheme/schematic/canvas.scm
@@ -223,12 +223,21 @@
                     (when (true? zoom)
                       (a_zoom *window *widget zoom-direction HOTKEY))
 
-                    (x_event_scroll *widget
-                                    *window
-                                    zoom
-                                    pan-x-axis
-                                    pan-y-axis
-                                    pan-direction)))))))))
+                    (let ((*horiz-adjustment (schematic_canvas_get_hadjustment *widget))
+                          (*vert-adjustment (schematic_canvas_get_vadjustment *widget)))
+                      (if (or (and (true? pan-x-axis) (null-pointer? *horiz-adjustment))
+                              (and (true? pan-y-axis) (null-pointer? *vert-adjustment)))
+                          (begin
+                            (log! 'warning "scroll-canvas(): NULL horizontal or vertical adjustment.")
+                            TRUE)
+                          (x_event_scroll *widget
+                                          *window
+                                          zoom
+                                          pan-x-axis
+                                          pan-y-axis
+                                          pan-direction
+                                          *horiz-adjustment
+                                          *vert-adjustment)))))))))))
 
 (define *scroll-canvas
   (procedure->pointer int scroll-canvas '(* * *)))

--- a/libleptongui/scheme/schematic/canvas.scm
+++ b/libleptongui/scheme/schematic/canvas.scm
@@ -1,5 +1,5 @@
 ;;; Lepton EDA library - Scheme API
-;;; Copyright (C) 2024 Lepton EDA Contributors
+;;; Copyright (C) 2024-2025 Lepton EDA Contributors
 ;;;
 ;;; This program is free software; you can redistribute it and/or modify
 ;;; it under the terms of the GNU General Public License as published by
@@ -20,6 +20,7 @@
   #:use-module (system foreign)
 
   #:use-module (lepton ffi boolean)
+  #:use-module (lepton log)
 
   #:use-module (schematic ffi)
   #:use-module (schematic canvas foreign)
@@ -61,6 +62,8 @@
 
 
 (define (scroll-canvas *widget *event *window)
+  (when (null-pointer? *window)
+    (error "NULL window"))
   (x_event_scroll *widget *event *window))
 
 (define *scroll-canvas

--- a/libleptongui/scheme/schematic/canvas.scm
+++ b/libleptongui/scheme/schematic/canvas.scm
@@ -68,6 +68,10 @@
 (define ZOOM_IN 1)
 (define ZOOM_FULL 2)
 
+(define DONTCARE 0)
+(define MENU 1)
+(define HOTKEY 2)
+
 (define (scroll-canvas *widget *event *window)
   (define (state-contains? state mask)
     (if (logtest state mask) 1 0))
@@ -216,14 +220,15 @@
                                ((gdk-scroll-down) ZOOM_OUT)
                                ((gdk-scroll-right) ZOOM_OUT)
                                (else ZOOM_IN)))))
+                    (when (true? zoom)
+                      (a_zoom *window *widget zoom-direction HOTKEY))
+
                     (x_event_scroll *widget
-                                    *event
                                     *window
                                     zoom
                                     pan-x-axis
                                     pan-y-axis
-                                    pan-direction
-                                    zoom-direction)))))))))
+                                    pan-direction)))))))))
 
 (define *scroll-canvas
   (procedure->pointer int scroll-canvas '(* * *)))

--- a/libleptongui/scheme/schematic/canvas.scm
+++ b/libleptongui/scheme/schematic/canvas.scm
@@ -91,14 +91,16 @@
           ;;   SCROLL_WHEEL_GTK = 1
           (let* ((scrolling-type (schematic_window_get_scroll_wheel *window))
                  (scroll-direction (event-direction *event))
+                 (control-pressed?
+                  (true? (schematic_window_get_control_key_pressed *window)))
+                 (shift-pressed?
+                  (true? (schematic_window_get_shift_key_pressed *window)))
                  (zoom-by-mods?
                   (if (= scrolling-type 0)
                       ;; Classic gschem behaviour.
-                      (and (false? (schematic_window_get_control_key_pressed *window))
-                           (false? (schematic_window_get_shift_key_pressed *window)))
+                      (and (not control-pressed?) (not shift-pressed?))
                       ;; GTK style behaviour.
-                      (and (true? (schematic_window_get_control_key_pressed *window))
-                           (false? (schematic_window_get_shift_key_pressed *window)))))
+                      (and control-pressed? (not shift-pressed?))))
                  (zoom
                   ;; If the user has a left/right scroll
                   ;; wheel, always scroll the y-axis.

--- a/libleptongui/scheme/schematic/canvas.scm
+++ b/libleptongui/scheme/schematic/canvas.scm
@@ -106,6 +106,7 @@
                   ;; If the user has a left/right scroll
                   ;; wheel, always scroll the y-axis.
                   (if (and scroll-direction
+                           (not (pair? scroll-direction))
                            (or (eq? (event-scroll-direction->symbol scroll-direction)
                                     'gdk-scroll-left)
                                (eq? (event-scroll-direction->symbol scroll-direction)
@@ -127,6 +128,7 @@
                                  ;; left/right scroll wheel,
                                  ;; always scroll the y-axis.
                                  (if (and scroll-direction
+                                          (not (pair? scroll-direction))
                                           (or (eq? (event-scroll-direction->symbol scroll-direction)
                                                    'gdk-scroll-left)
                                               (eq? (event-scroll-direction->symbol scroll-direction)
@@ -146,6 +148,7 @@
                       ;; pan.
                       FALSE
                       (if (and scroll-direction
+                               (not (pair? scroll-direction))
                                (or (eq? (event-scroll-direction->symbol scroll-direction)
                                         'gdk-scroll-left)
                                    (eq? (event-scroll-direction->symbol scroll-direction)
@@ -160,6 +163,7 @@
             ;; GNOME bug 726878.
             (if (and %m4-use-gtk3
                      scroll-direction
+                     (not (pair? scroll-direction))
                      (not (eq? (event-scroll-direction->symbol scroll-direction)
                                'gdk-scroll-smooth))
                      (= (schematic_event_get_last_scroll_event_time)
@@ -171,10 +175,13 @@
                 (x_event_scroll *widget
                                 *event
                                 *window
-                                (or scroll-direction 0)
+                                0
                                 zoom
                                 pan-x-axis
-                                pan-y-axis)))))))
+                                pan-y-axis
+                                (if (pair? scroll-direction)
+                                    (cdr scroll-direction)
+                                    0.0))))))))
 
 (define *scroll-canvas
   (procedure->pointer int scroll-canvas '(* * *)))

--- a/libleptongui/scheme/schematic/canvas.scm
+++ b/libleptongui/scheme/schematic/canvas.scm
@@ -249,5 +249,7 @@
                             ;; Stop further processing of this signal.
                             TRUE)))))))))))
 
+;;; Proxy C function for the scroll-canvas() procedure for using
+;;; in C signal handlers.
 (define *scroll-canvas
   (procedure->pointer int scroll-canvas '(* * *)))

--- a/libleptongui/scheme/schematic/canvas.scm
+++ b/libleptongui/scheme/schematic/canvas.scm
@@ -67,6 +67,14 @@
   (define (state-contains? state mask)
     (if (logtest state mask) 1 0))
 
+  (define (scroll-direction->symbol scroll-direction smooth-scroll?)
+    (and scroll-direction
+         (not smooth-scroll?)
+         (or (eq? (event-scroll-direction->symbol scroll-direction)
+                  'gdk-scroll-left)
+             (eq? (event-scroll-direction->symbol scroll-direction)
+                  'gdk-scroll-right))))
+
   (when (null-pointer? *window)
     (error "NULL window"))
   (when (null-pointer? *widget)
@@ -93,6 +101,8 @@
           (let* ((classic-scrolling? (= (schematic_window_get_scroll_wheel *window) 0))
                  (scroll-direction (event-direction *event))
                  (smooth-scroll? (pair? scroll-direction))
+                 (left-or-right-direction? (scroll-direction->symbol scroll-direction
+                                                                     smooth-scroll?))
                  (control-pressed?
                   (true? (schematic_window_get_control_key_pressed *window)))
                  (shift-pressed?
@@ -106,12 +116,7 @@
                  (zoom
                   ;; If the user has a left/right scroll
                   ;; wheel, always scroll the y-axis.
-                  (if (and scroll-direction
-                           (not smooth-scroll?)
-                           (or (eq? (event-scroll-direction->symbol scroll-direction)
-                                    'gdk-scroll-left)
-                               (eq? (event-scroll-direction->symbol scroll-direction)
-                                    'gdk-scroll-right)))
+                  (if left-or-right-direction?
                       FALSE
                       (if zoom-by-mods? TRUE FALSE)))
                  (pan-y-by-mods
@@ -128,12 +133,7 @@
                                  ;; If the user has a
                                  ;; left/right scroll wheel,
                                  ;; always scroll the y-axis.
-                                 (if (and scroll-direction
-                                          (not smooth-scroll?)
-                                          (or (eq? (event-scroll-direction->symbol scroll-direction)
-                                                   'gdk-scroll-left)
-                                              (eq? (event-scroll-direction->symbol scroll-direction)
-                                                   'gdk-scroll-right)))
+                                 (if left-or-right-direction?
                                      FALSE
                                      (if pan-y-by-mods TRUE FALSE))))
                  (pan-x-by-mods
@@ -148,12 +148,7 @@
                       ;; you want to use the scroll wheel to
                       ;; pan.
                       FALSE
-                      (if (and scroll-direction
-                               (not smooth-scroll?)
-                               (or (eq? (event-scroll-direction->symbol scroll-direction)
-                                        'gdk-scroll-left)
-                                   (eq? (event-scroll-direction->symbol scroll-direction)
-                                        'gdk-scroll-right)))
+                      (if left-or-right-direction?
                           ;; If the user has a left/right
                           ;; scroll wheel, always scroll the
                           ;; y-axis.

--- a/libleptongui/scheme/schematic/canvas.scm
+++ b/libleptongui/scheme/schematic/canvas.scm
@@ -135,11 +135,9 @@
                  (pan-x-by-mods
                   (if classic-scrolling?
                       ;; Classic gschem behaviour.
-                      (and (true? (schematic_window_get_control_key_pressed *window))
-                           (false? (schematic_window_get_shift_key_pressed *window)))
+                      (and control-pressed? (not shift-pressed?))
                       ;; GTK style behaviour.
-                      (and (false? (schematic_window_get_control_key_pressed *window))
-                           (true? (schematic_window_get_shift_key_pressed *window)))))
+                      (and (not control-pressed?) shift-pressed?)))
                  (pan-x-axis
                   (if (false? (schematic_window_get_scrollbars_flag *window))
                       ;; You must have scrollbars enabled if

--- a/libleptongui/scheme/schematic/canvas.scm
+++ b/libleptongui/scheme/schematic/canvas.scm
@@ -68,6 +68,7 @@
 (define ZOOM_OUT 0)
 (define ZOOM_IN 1)
 (define ZOOM_FULL 2)
+(define ZOOM_SAME 3)
 
 (define DONTCARE 0)
 (define MENU 1)
@@ -207,19 +208,23 @@
                                  ;; event->delta_x seems to be
                                  ;; unused on not touch
                                  ;; devices.
-                                 (if (> (cdr scroll-direction) 0) ZOOM_OUT ZOOM_IN)
+                                 (let ((direction (cdr scroll-direction)))
+                                   (cond
+                                    ((negative? direction) ZOOM_IN)
+                                    ((positive? direction) ZOOM_OUT)
+                                    ((zero? direction) ZOOM_SAME)))
                                  (case (event-scroll-direction->symbol scroll-direction)
                                    ((gdk-scroll-up) ZOOM_IN)
                                    ((gdk-scroll-left) ZOOM_IN)
                                    ((gdk-scroll-down) ZOOM_OUT)
                                    ((gdk-scroll-right) ZOOM_OUT)
-                                   (else ZOOM_IN)))
+                                   (else ZOOM_SAME)))
                              (case (event-scroll-direction->symbol scroll-direction)
                                ((gdk-scroll-up) ZOOM_IN)
                                ((gdk-scroll-left) ZOOM_IN)
                                ((gdk-scroll-down) ZOOM_OUT)
                                ((gdk-scroll-right) ZOOM_OUT)
-                               (else ZOOM_IN)))))
+                               (else ZOOM_SAME)))))
                     (when zoom
                       (a_zoom *window *widget zoom-direction HOTKEY))
 

--- a/libleptongui/scheme/schematic/canvas.scm
+++ b/libleptongui/scheme/schematic/canvas.scm
@@ -92,6 +92,7 @@
           ;;   SCROLL_WHEEL_GTK = 1
           (let* ((classic-scrolling? (= (schematic_window_get_scroll_wheel *window) 0))
                  (scroll-direction (event-direction *event))
+                 (smooth-scroll? (pair? scroll-direction))
                  (control-pressed?
                   (true? (schematic_window_get_control_key_pressed *window)))
                  (shift-pressed?
@@ -106,7 +107,7 @@
                   ;; If the user has a left/right scroll
                   ;; wheel, always scroll the y-axis.
                   (if (and scroll-direction
-                           (not (pair? scroll-direction))
+                           (not smooth-scroll?)
                            (or (eq? (event-scroll-direction->symbol scroll-direction)
                                     'gdk-scroll-left)
                                (eq? (event-scroll-direction->symbol scroll-direction)
@@ -128,7 +129,7 @@
                                  ;; left/right scroll wheel,
                                  ;; always scroll the y-axis.
                                  (if (and scroll-direction
-                                          (not (pair? scroll-direction))
+                                          (not smooth-scroll?)
                                           (or (eq? (event-scroll-direction->symbol scroll-direction)
                                                    'gdk-scroll-left)
                                               (eq? (event-scroll-direction->symbol scroll-direction)
@@ -148,7 +149,7 @@
                       ;; pan.
                       FALSE
                       (if (and scroll-direction
-                               (not (pair? scroll-direction))
+                               (not smooth-scroll?)
                                (or (eq? (event-scroll-direction->symbol scroll-direction)
                                         'gdk-scroll-left)
                                    (eq? (event-scroll-direction->symbol scroll-direction)
@@ -163,7 +164,7 @@
             ;; GNOME bug 726878.
             (if (and %m4-use-gtk3
                      scroll-direction
-                     (not (pair? scroll-direction))
+                     (not smooth-scroll?)
                      (not (eq? (event-scroll-direction->symbol scroll-direction)
                                'gdk-scroll-smooth))
                      (= (schematic_event_get_last_scroll_event_time)
@@ -179,7 +180,7 @@
                                 zoom
                                 pan-x-axis
                                 pan-y-axis
-                                (if (pair? scroll-direction)
+                                (if smooth-scroll?
                                     (cdr scroll-direction)
                                     0.0))))))))
 

--- a/libleptongui/scheme/schematic/canvas.scm
+++ b/libleptongui/scheme/schematic/canvas.scm
@@ -135,17 +135,14 @@
                       (and (not control-pressed?) shift-pressed?)
                       ;; GTK style behaviour.
                       (and (not control-pressed?) (not shift-pressed?))))
-                 (pan-y-axis (if (false? (schematic_window_get_scrollbars_flag *window))
-                                 ;; You must have scrollbars
-                                 ;; enabled if you want to use
-                                 ;; the scroll wheel to pan.
-                                 FALSE
-                                 ;; If the user has a
-                                 ;; left/right scroll wheel,
-                                 ;; always scroll the y-axis.
-                                 (if left-or-right-direction?
-                                     FALSE
-                                     (if pan-y-by-mods TRUE FALSE))))
+                 ;; You must have scrollbars enabled if you
+                 ;; want to use the scroll wheel to pan.
+                 (pan-y-axis (and (true? (schematic_window_get_scrollbars_flag *window))
+                                  ;; If the user has a
+                                  ;; left/right scroll wheel,
+                                  ;; always scroll the y-axis.
+                                  (and (not left-or-right-direction?)
+                                       pan-y-by-mods)))
                  (pan-x-by-mods
                   (if classic-scrolling?
                       ;; Classic gschem behaviour.
@@ -223,7 +220,7 @@
                     (let ((*horiz-adjustment (schematic_canvas_get_hadjustment *widget))
                           (*vert-adjustment (schematic_canvas_get_vadjustment *widget)))
                       (if (or (and pan-x-axis (null-pointer? *horiz-adjustment))
-                              (and (true? pan-y-axis) (null-pointer? *vert-adjustment)))
+                              (and pan-y-axis (null-pointer? *vert-adjustment)))
                           (begin
                             (log! 'warning "scroll-canvas(): NULL horizontal or vertical adjustment.")
                             TRUE)
@@ -237,7 +234,7 @@
                                                              (- (gtk_adjustment_get_upper *horiz-adjustment)
                                                                 (gtk_adjustment_get_page_size *horiz-adjustment)))))
 
-                            (when (true? pan-y-axis)
+                            (when pan-y-axis
                               (gtk_adjustment_set_value *vert-adjustment
                                                         (min (+ (gtk_adjustment_get_value *vert-adjustment)
                                                                 (* pan-direction
@@ -247,7 +244,7 @@
                                                                 (gtk_adjustment_get_page_size *vert-adjustment)))))
 
                             (when (and (true? (schematic_window_get_undo_panzoom *window))
-                                       (or (true? zoom) pan-x-axis (true? pan-y-axis)))
+                                       (or (true? zoom) pan-x-axis pan-y-axis))
                               (o_undo_savestate_viewport *window))
 
                             (x_event_faked_motion *widget %null-pointer)

--- a/libleptongui/scheme/schematic/canvas.scm
+++ b/libleptongui/scheme/schematic/canvas.scm
@@ -126,9 +126,8 @@
                  (zoom
                   ;; If the user has a left/right scroll
                   ;; wheel, always scroll the y-axis.
-                  (if left-or-right-direction?
-                      FALSE
-                      (if zoom-by-mods? TRUE FALSE)))
+                  (and (not left-or-right-direction?)
+                       zoom-by-mods?))
                  (pan-y-by-mods
                   (if classic-scrolling?
                       ;; Classic gschem behaviour.
@@ -214,7 +213,7 @@
                                ((gdk-scroll-down) ZOOM_OUT)
                                ((gdk-scroll-right) ZOOM_OUT)
                                (else ZOOM_IN)))))
-                    (when (true? zoom)
+                    (when zoom
                       (a_zoom *window *widget zoom-direction HOTKEY))
 
                     (let ((*horiz-adjustment (schematic_canvas_get_hadjustment *widget))
@@ -244,7 +243,7 @@
                                                                 (gtk_adjustment_get_page_size *vert-adjustment)))))
 
                             (when (and (true? (schematic_window_get_undo_panzoom *window))
-                                       (or (true? zoom) pan-x-axis pan-y-axis))
+                                       (or zoom pan-x-axis pan-y-axis))
                               (o_undo_savestate_viewport *window))
 
                             (x_event_faked_motion *widget %null-pointer)

--- a/libleptongui/scheme/schematic/canvas.scm
+++ b/libleptongui/scheme/schematic/canvas.scm
@@ -85,6 +85,16 @@
              (eq? (event-scroll-direction->symbol scroll-direction)
                   'gdk-scroll-right))))
 
+  (define (update-adjustment *adjustment pan-direction)
+    (gtk_adjustment_set_value
+     *adjustment
+     (min (+ (gtk_adjustment_get_value *adjustment)
+             (* pan-direction
+                (/ (gtk_adjustment_get_page_increment *adjustment)
+                   (schematic_window_get_scrollpan_steps *window))))
+          (- (gtk_adjustment_get_upper *adjustment)
+             (gtk_adjustment_get_page_size *adjustment)))))
+
   (when (null-pointer? *window)
     (error "NULL window"))
   (when (null-pointer? *widget)
@@ -225,22 +235,9 @@
                             TRUE)
                           (begin
                             (when pan-x-axis
-                              (gtk_adjustment_set_value *horiz-adjustment
-                                                        (min (+ (gtk_adjustment_get_value *horiz-adjustment)
-                                                                (* pan-direction
-                                                                   (/ (gtk_adjustment_get_page_increment *horiz-adjustment)
-                                                                      (schematic_window_get_scrollpan_steps *window))))
-                                                             (- (gtk_adjustment_get_upper *horiz-adjustment)
-                                                                (gtk_adjustment_get_page_size *horiz-adjustment)))))
-
+                              (update-adjustment *horiz-adjustment pan-direction))
                             (when pan-y-axis
-                              (gtk_adjustment_set_value *vert-adjustment
-                                                        (min (+ (gtk_adjustment_get_value *vert-adjustment)
-                                                                (* pan-direction
-                                                                   (/ (gtk_adjustment_get_page_increment *vert-adjustment)
-                                                                      (schematic_window_get_scrollpan_steps *window))))
-                                                             (- (gtk_adjustment_get_upper *vert-adjustment)
-                                                                (gtk_adjustment_get_page_size *vert-adjustment)))))
+                              (update-adjustment *vert-adjustment pan-direction))
 
                             (when (and (true? (schematic_window_get_undo_panzoom *window))
                                        (or zoom pan-x-axis pan-y-axis))

--- a/libleptongui/scheme/schematic/canvas.scm
+++ b/libleptongui/scheme/schematic/canvas.scm
@@ -79,6 +79,8 @@
 (define %last-scroll-event-time 0)
 
 (define (scroll-canvas *widget *event *window)
+  "Process scroll *EVENT passed to the canvas *WIDGET from its
+parent *WINDOW."
   (define (state-contains? state mask)
     (if (logtest state mask) 1 0))
 

--- a/libleptongui/scheme/schematic/canvas.scm
+++ b/libleptongui/scheme/schematic/canvas.scm
@@ -73,6 +73,8 @@
 (define MENU 1)
 (define HOTKEY 2)
 
+(define %last-scroll-event-time 0)
+
 (define (scroll-canvas *widget *event *window)
   (define (state-contains? state mask)
     (if (logtest state mask) 1 0))
@@ -174,8 +176,7 @@
                      (not smooth-scroll?)
                      (not (eq? (event-scroll-direction->symbol scroll-direction)
                                'gdk-scroll-smooth))
-                     (= (schematic_event_get_last_scroll_event_time)
-                        (event-time *event)))
+                     (= %last-scroll-event-time (event-time *event)))
                 (begin (log! 'debug "[~A] duplicate legacy scroll event ~A"
                              (event-time *event)
                              (event-scroll-direction->symbol scroll-direction))
@@ -187,7 +188,7 @@
                     ;; events are provided by the
                     ;; GDK_SCROLL_SMOOTH direction on XInput2
                     ;; and Wayland devices.
-                    (schematic_event_set_last_scroll_event_time (event-time *event)))
+                    (set! %last-scroll-event-time (event-time *event)))
                   (let ((pan-direction
                          (if %m4-use-gtk3
                              (if smooth-scroll?

--- a/libleptongui/scheme/schematic/canvas.scm
+++ b/libleptongui/scheme/schematic/canvas.scm
@@ -87,6 +87,12 @@
              (eq? (event-scroll-direction->symbol scroll-direction)
                   'gdk-scroll-right))))
 
+  (define (event-scroll-direction->pan-direction scroll-direction)
+    (case (event-scroll-direction->symbol scroll-direction)
+      ((gdk-scroll-up gdk-scroll-left) -1)
+      ((gdk-scroll-down gdk-scroll-right) 1)
+      (else 0)))
+
   (define (update-adjustment *adjustment pan-direction)
     (gtk_adjustment_set_value
      *adjustment
@@ -193,18 +199,8 @@
                          (if %m4-use-gtk3
                              (if smooth-scroll?
                                  (inexact->exact (round (cdr scroll-direction)))
-                                 (case (event-scroll-direction->symbol scroll-direction)
-                                   ((gdk-scroll-up) -1)
-                                   ((gdk-scroll-left) -1)
-                                   ((gdk-scroll-down) 1)
-                                   ((gdk-scroll-right) 1)
-                                   (else 0)))
-                             (case (event-scroll-direction->symbol scroll-direction)
-                               ((gdk-scroll-up) -1)
-                               ((gdk-scroll-left) -1)
-                               ((gdk-scroll-down) 1)
-                               ((gdk-scroll-right) 1)
-                               (else 0))))
+                                 (event-scroll-direction->pan-direction scroll-direction))
+                             (event-scroll-direction->pan-direction scroll-direction)))
                         (zoom-direction
                          (if %m4-use-gtk3
                              (if smooth-scroll?

--- a/libleptongui/scheme/schematic/canvas.scm
+++ b/libleptongui/scheme/schematic/canvas.scm
@@ -89,8 +89,14 @@
           ;; There are two scrolling types defined in gschem_defines.h:
           ;;   SCROLL_WHEEL_CLASSIC = 0
           ;;   SCROLL_WHEEL_GTK = 1
-          (let ((scrolling-type (schematic_window_get_scroll_wheel *window)))
-            (x_event_scroll *widget *event *window scrolling-type))))))
+          (let ((scrolling-type (schematic_window_get_scroll_wheel *window))
+                (scroll-direction (event-direction *event)))
+            (x_event_scroll *widget
+                            *event
+                            *window
+                            scrolling-type
+                            (or scroll-direction 0)
+                            (if scroll-direction TRUE FALSE)))))))
 
 (define *scroll-canvas
   (procedure->pointer int scroll-canvas '(* * *)))

--- a/libleptongui/scheme/schematic/canvas.scm
+++ b/libleptongui/scheme/schematic/canvas.scm
@@ -176,15 +176,32 @@
                     ;; GDK_SCROLL_SMOOTH direction on XInput2
                     ;; and Wayland devices.
                     (schematic_event_set_last_scroll_event_time (event-time *event)))
-                  (x_event_scroll *widget
-                                  *event
-                                  *window
-                                  zoom
-                                  pan-x-axis
-                                  pan-y-axis
-                                  (if smooth-scroll?
-                                      (cdr scroll-direction)
-                                      0.0)))))))))
+                  (let ((pan-direction
+                         (if %m4-use-gtk3
+                             (if smooth-scroll?
+                                 (inexact->exact (round (cdr scroll-direction)))
+                                 (case (event-scroll-direction->symbol scroll-direction)
+                                   ((gdk-scroll-up) -1)
+                                   ((gdk-scroll-left) -1)
+                                   ((gdk-scroll-down) 1)
+                                   ((gdk-scroll-right) 1)
+                                   (else 0)))
+                             (case (event-scroll-direction->symbol scroll-direction)
+                               ((gdk-scroll-up) -1)
+                               ((gdk-scroll-left) -1)
+                               ((gdk-scroll-down) 1)
+                               ((gdk-scroll-right) 1)
+                               (else 0)))))
+                    (x_event_scroll *widget
+                                    *event
+                                    *window
+                                    zoom
+                                    pan-x-axis
+                                    pan-y-axis
+                                    pan-direction
+                                    (if smooth-scroll?
+                                        (cdr scroll-direction)
+                                        0.0))))))))))
 
 (define *scroll-canvas
   (procedure->pointer int scroll-canvas '(* * *)))

--- a/libleptongui/scheme/schematic/canvas.scm
+++ b/libleptongui/scheme/schematic/canvas.scm
@@ -171,7 +171,6 @@
                 (x_event_scroll *widget
                                 *event
                                 *window
-                                0
                                 zoom
                                 pan-x-axis
                                 pan-y-axis

--- a/libleptongui/scheme/schematic/canvas.scm
+++ b/libleptongui/scheme/schematic/canvas.scm
@@ -152,18 +152,14 @@
                       (and control-pressed? (not shift-pressed?))
                       ;; GTK style behaviour.
                       (and (not control-pressed?) shift-pressed?)))
-                 (pan-x-axis
-                  (if (false? (schematic_window_get_scrollbars_flag *window))
-                      ;; You must have scrollbars enabled if
-                      ;; you want to use the scroll wheel to
-                      ;; pan.
-                      FALSE
-                      (if left-or-right-direction?
-                          ;; If the user has a left/right
-                          ;; scroll wheel, always scroll the
-                          ;; y-axis.
-                          TRUE
-                          (if pan-x-by-mods TRUE FALSE)))))
+                 ;; You must have scrollbars enabled if you
+                 ;; want to use the scroll wheel to pan.
+                 (pan-x-axis (and (true? (schematic_window_get_scrollbars_flag *window))
+                                  ;; If the user has a left/right
+                                  ;; scroll wheel, always scroll the
+                                  ;; y-axis.
+                                  (or left-or-right-direction?
+                                      pan-x-by-mods))))
 
             ;; Check for duplicate legacy scroll event, see
             ;; GNOME bug 726878.
@@ -226,13 +222,13 @@
 
                     (let ((*horiz-adjustment (schematic_canvas_get_hadjustment *widget))
                           (*vert-adjustment (schematic_canvas_get_vadjustment *widget)))
-                      (if (or (and (true? pan-x-axis) (null-pointer? *horiz-adjustment))
+                      (if (or (and pan-x-axis (null-pointer? *horiz-adjustment))
                               (and (true? pan-y-axis) (null-pointer? *vert-adjustment)))
                           (begin
                             (log! 'warning "scroll-canvas(): NULL horizontal or vertical adjustment.")
                             TRUE)
                           (begin
-                            (when (true? pan-x-axis)
+                            (when pan-x-axis
                               (gtk_adjustment_set_value *horiz-adjustment
                                                         (min (+ (gtk_adjustment_get_value *horiz-adjustment)
                                                                 (* pan-direction
@@ -251,7 +247,7 @@
                                                                 (gtk_adjustment_get_page_size *vert-adjustment)))))
 
                             (when (and (true? (schematic_window_get_undo_panzoom *window))
-                                       (or (true? zoom) (true? pan-x-axis) (true? pan-y-axis)))
+                                       (or (true? zoom) pan-x-axis (true? pan-y-axis)))
                               (o_undo_savestate_viewport *window))
 
                             (x_event_faked_motion *widget %null-pointer)

--- a/libleptongui/scheme/schematic/canvas.scm
+++ b/libleptongui/scheme/schematic/canvas.scm
@@ -164,9 +164,9 @@
                  ;; You must have scrollbars enabled if you
                  ;; want to use the scroll wheel to pan.
                  (pan-y-axis (and (true? (schematic_window_get_scrollbars_flag *window))
-                                  ;; If the user has a
-                                  ;; left/right scroll wheel,
-                                  ;; always scroll the y-axis.
+                                  ;; If the user has a left/right
+                                  ;; scroll wheel, never scroll
+                                  ;; the Y axis.
                                   (and (not left-or-right-direction?)
                                        pan-y-by-mods)))
                  (pan-x-by-mods
@@ -179,8 +179,8 @@
                  ;; want to use the scroll wheel to pan.
                  (pan-x-axis (and (true? (schematic_window_get_scrollbars_flag *window))
                                   ;; If the user has a left/right
-                                  ;; scroll wheel, always scroll the
-                                  ;; y-axis.
+                                  ;; scroll wheel, always scroll
+                                  ;; the X axis.
                                   (or left-or-right-direction?
                                       pan-x-by-mods))))
 

--- a/libleptongui/scheme/schematic/canvas.scm
+++ b/libleptongui/scheme/schematic/canvas.scm
@@ -27,7 +27,9 @@
 
   #:export (canvas-viewport
             invalidate-canvas
-            *redraw-canvas))
+            *redraw-canvas
+            scroll-canvas
+            *scroll-canvas))
 
 
 (define (canvas-viewport canvas)
@@ -56,3 +58,10 @@
 
 (define *redraw-canvas
   (procedure->pointer int redraw-canvas '(* * *)))
+
+
+(define (scroll-canvas *widget *event *window)
+  (x_event_scroll *widget *event *window))
+
+(define *scroll-canvas
+  (procedure->pointer int scroll-canvas '(* * *)))

--- a/libleptongui/scheme/schematic/canvas.scm
+++ b/libleptongui/scheme/schematic/canvas.scm
@@ -86,7 +86,11 @@
                                                     (state-contains? state control-mask))
           (schematic_window_set_alt_key_pressed *window
                                                 (state-contains? state alt-mask))
-          (x_event_scroll *widget *event *window)))))
+          ;; There are two scrolling types defined in gschem_defines.h:
+          ;;   SCROLL_WHEEL_CLASSIC = 0
+          ;;   SCROLL_WHEEL_GTK = 1
+          (let ((scrolling-type (schematic_window_get_scroll_wheel *window)))
+            (x_event_scroll *widget *event *window scrolling-type))))))
 
 (define *scroll-canvas
   (procedure->pointer int scroll-canvas '(* * *)))

--- a/libleptongui/scheme/schematic/canvas.scm
+++ b/libleptongui/scheme/schematic/canvas.scm
@@ -131,14 +131,37 @@
                                               (eq? (event-scroll-direction->symbol scroll-direction)
                                                    'gdk-scroll-right)))
                                      FALSE
-                                     (if pan-y-by-mods TRUE FALSE)))))
+                                     (if pan-y-by-mods TRUE FALSE))))
+                 (pan-x-by-mods
+                  (if (= scrolling-type 0)
+                      ;; Classic gschem behaviour.
+                      (and (true? (schematic_window_get_control_key_pressed *window))
+                           (false? (schematic_window_get_shift_key_pressed *window)))
+                      ;; GTK style behaviour.
+                      (and (false? (schematic_window_get_control_key_pressed *window))
+                           (true? (schematic_window_get_shift_key_pressed *window)))))
+                 (pan-x-axis
+                  (if (false? (schematic_window_get_scrollbars_flag *window))
+                      ;; You must have scrollbars enabled if
+                      ;; you want to use the scroll wheel to
+                      ;; pan.
+                      FALSE
+                      (if (and scroll-direction
+                               (or (eq? (event-scroll-direction->symbol scroll-direction)
+                                        'gdk-scroll-left)
+                                   (eq? (event-scroll-direction->symbol scroll-direction)
+                                        'gdk-scroll-right)))
+                          ;; If the user has a left/right
+                          ;; scroll wheel, always scroll the
+                          ;; y-axis.
+                          TRUE
+                          (if pan-x-by-mods TRUE FALSE)))))
             (x_event_scroll *widget
                             *event
                             *window
-                            scrolling-type
                             (or scroll-direction 0)
-                            (if scroll-direction TRUE FALSE)
                             zoom
+                            pan-x-axis
                             pan-y-axis))))))
 
 (define *scroll-canvas

--- a/libleptongui/scheme/schematic/canvas.scm
+++ b/libleptongui/scheme/schematic/canvas.scm
@@ -94,6 +94,14 @@
       ((gdk-scroll-down gdk-scroll-right) 1)
       (else 0)))
 
+  (define (event-scroll-direction->zoom-direction scroll-direction)
+    (case (event-scroll-direction->symbol scroll-direction)
+      ((gdk-scroll-up) ZOOM_IN)
+      ((gdk-scroll-left) ZOOM_IN)
+      ((gdk-scroll-down) ZOOM_OUT)
+      ((gdk-scroll-right) ZOOM_OUT)
+      (else ZOOM_SAME)))
+
   (define (update-adjustment *adjustment pan-direction)
     (gtk_adjustment_set_value
      *adjustment
@@ -213,18 +221,8 @@
                                     ((negative? direction) ZOOM_IN)
                                     ((positive? direction) ZOOM_OUT)
                                     ((zero? direction) ZOOM_SAME)))
-                                 (case (event-scroll-direction->symbol scroll-direction)
-                                   ((gdk-scroll-up) ZOOM_IN)
-                                   ((gdk-scroll-left) ZOOM_IN)
-                                   ((gdk-scroll-down) ZOOM_OUT)
-                                   ((gdk-scroll-right) ZOOM_OUT)
-                                   (else ZOOM_SAME)))
-                             (case (event-scroll-direction->symbol scroll-direction)
-                               ((gdk-scroll-up) ZOOM_IN)
-                               ((gdk-scroll-left) ZOOM_IN)
-                               ((gdk-scroll-down) ZOOM_OUT)
-                               ((gdk-scroll-right) ZOOM_OUT)
-                               (else ZOOM_SAME)))))
+                                 (event-scroll-direction->zoom-direction scroll-direction))
+                             (event-scroll-direction->zoom-direction scroll-direction))))
                     (when zoom
                       (a_zoom *window *widget zoom-direction HOTKEY))
 

--- a/libleptongui/scheme/schematic/canvas.scm
+++ b/libleptongui/scheme/schematic/canvas.scm
@@ -74,6 +74,8 @@
 (define MENU 1)
 (define HOTKEY 2)
 
+;;; The time of the last scroll event to check for duplicate
+;;; scroll events.
 (define %last-scroll-event-time 0)
 
 (define (scroll-canvas *widget *event *window)

--- a/libleptongui/scheme/schematic/canvas.scm
+++ b/libleptongui/scheme/schematic/canvas.scm
@@ -114,11 +114,9 @@
                  (pan-y-by-mods
                   (if (= scrolling-type 0)
                       ;; Classic gschem behaviour.
-                      (and (false? (schematic_window_get_control_key_pressed *window))
-                           (true? (schematic_window_get_shift_key_pressed *window)))
+                      (and (not control-pressed?) shift-pressed?)
                       ;; GTK style behaviour.
-                      (and (false? (schematic_window_get_control_key_pressed *window))
-                           (false? (schematic_window_get_shift_key_pressed *window)))))
+                      (and (not control-pressed?) (not shift-pressed?))))
                  (pan-y-axis (if (false? (schematic_window_get_scrollbars_flag *window))
                                  ;; You must have scrollbars
                                  ;; enabled if you want to use

--- a/libleptongui/scheme/schematic/canvas.scm
+++ b/libleptongui/scheme/schematic/canvas.scm
@@ -66,7 +66,12 @@
     (error "NULL window"))
   (when (null-pointer? *widget)
     (error "NULL canvas"))
-  (x_event_scroll *widget *event *window))
+
+  (let ((*page (schematic_canvas_get_page *widget)))
+    (if (null-pointer? *page)
+        ;; We cannot zoom or scroll a page if it doesn't exist :)
+        FALSE
+        (x_event_scroll *widget *event *window))))
 
 (define *scroll-canvas
   (procedure->pointer int scroll-canvas '(* * *)))

--- a/libleptongui/scheme/schematic/canvas.scm
+++ b/libleptongui/scheme/schematic/canvas.scm
@@ -168,15 +168,23 @@
                              (event-time *event)
                              (event-scroll-direction->symbol scroll-direction))
                        FALSE)
-                (x_event_scroll *widget
-                                *event
-                                *window
-                                zoom
-                                pan-x-axis
-                                pan-y-axis
-                                (if smooth-scroll?
-                                    (cdr scroll-direction)
-                                    0.0))))))))
+                (begin
+                  (when (and %m4-use-gtk3
+                             smooth-scroll?)
+                    ;; As of GTK 3.4, all directional scroll
+                    ;; events are provided by the
+                    ;; GDK_SCROLL_SMOOTH direction on XInput2
+                    ;; and Wayland devices.
+                    (schematic_event_set_last_scroll_event_time (event-time *event)))
+                  (x_event_scroll *widget
+                                  *event
+                                  *window
+                                  zoom
+                                  pan-x-axis
+                                  pan-y-axis
+                                  (if smooth-scroll?
+                                      (cdr scroll-direction)
+                                      0.0)))))))))
 
 (define *scroll-canvas
   (procedure->pointer int scroll-canvas '(* * *)))

--- a/libleptongui/scheme/schematic/canvas.scm
+++ b/libleptongui/scheme/schematic/canvas.scm
@@ -23,6 +23,7 @@
   #:use-module (lepton log)
   #:use-module (lepton m4)
 
+  #:use-module (schematic ffi gtk)
   #:use-module (schematic ffi)
   #:use-module (schematic canvas foreign)
   #:use-module (schematic event)
@@ -230,14 +231,29 @@
                           (begin
                             (log! 'warning "scroll-canvas(): NULL horizontal or vertical adjustment.")
                             TRUE)
-                          (x_event_scroll *widget
-                                          *window
-                                          zoom
-                                          pan-x-axis
-                                          pan-y-axis
-                                          pan-direction
-                                          *horiz-adjustment
-                                          *vert-adjustment)))))))))))
+                          (begin
+                            (when (true? pan-x-axis)
+                              (gtk_adjustment_set_value *horiz-adjustment
+                                                        (min (+ (gtk_adjustment_get_value *horiz-adjustment)
+                                                                (* pan-direction
+                                                                   (/ (gtk_adjustment_get_page_increment *horiz-adjustment)
+                                                                      (schematic_window_get_scrollpan_steps *window))))
+                                                             (- (gtk_adjustment_get_upper *horiz-adjustment)
+                                                                (gtk_adjustment_get_page_size *horiz-adjustment)))))
+
+                            (when (true? pan-y-axis)
+                              (gtk_adjustment_set_value *vert-adjustment
+                                                        (min (+ (gtk_adjustment_get_value *vert-adjustment)
+                                                                (* pan-direction
+                                                                   (/ (gtk_adjustment_get_page_increment *vert-adjustment)
+                                                                      (schematic_window_get_scrollpan_steps *window))))
+                                                             (- (gtk_adjustment_get_upper *vert-adjustment)
+                                                                (gtk_adjustment_get_page_size *vert-adjustment)))))
+                            (x_event_scroll *widget
+                                            *window
+                                            zoom
+                                            pan-x-axis
+                                            pan-y-axis))))))))))))
 
 (define *scroll-canvas
   (procedure->pointer int scroll-canvas '(* * *)))

--- a/libleptongui/scheme/schematic/canvas.scm
+++ b/libleptongui/scheme/schematic/canvas.scm
@@ -249,11 +249,14 @@
                                                                       (schematic_window_get_scrollpan_steps *window))))
                                                              (- (gtk_adjustment_get_upper *vert-adjustment)
                                                                 (gtk_adjustment_get_page_size *vert-adjustment)))))
-                            (x_event_scroll *widget
-                                            *window
-                                            zoom
-                                            pan-x-axis
-                                            pan-y-axis))))))))))))
+
+                            (when (and (true? (schematic_window_get_undo_panzoom *window))
+                                       (or (true? zoom) (true? pan-x-axis) (true? pan-y-axis)))
+                              (o_undo_savestate_viewport *window))
+
+                            (x_event_faked_motion *widget %null-pointer)
+                            ;; Stop further processing of this signal.
+                            TRUE)))))))))))
 
 (define *scroll-canvas
   (procedure->pointer int scroll-canvas '(* * *)))

--- a/libleptongui/scheme/schematic/canvas.scm
+++ b/libleptongui/scheme/schematic/canvas.scm
@@ -89,14 +89,14 @@
           ;; There are two scrolling types defined in gschem_defines.h:
           ;;   SCROLL_WHEEL_CLASSIC = 0
           ;;   SCROLL_WHEEL_GTK = 1
-          (let* ((scrolling-type (schematic_window_get_scroll_wheel *window))
+          (let* ((classic-scrolling? (= (schematic_window_get_scroll_wheel *window) 0))
                  (scroll-direction (event-direction *event))
                  (control-pressed?
                   (true? (schematic_window_get_control_key_pressed *window)))
                  (shift-pressed?
                   (true? (schematic_window_get_shift_key_pressed *window)))
                  (zoom-by-mods?
-                  (if (= scrolling-type 0)
+                  (if classic-scrolling?
                       ;; Classic gschem behaviour.
                       (and (not control-pressed?) (not shift-pressed?))
                       ;; GTK style behaviour.
@@ -112,7 +112,7 @@
                       FALSE
                       (if zoom-by-mods? TRUE FALSE)))
                  (pan-y-by-mods
-                  (if (= scrolling-type 0)
+                  (if classic-scrolling?
                       ;; Classic gschem behaviour.
                       (and (not control-pressed?) shift-pressed?)
                       ;; GTK style behaviour.
@@ -133,7 +133,7 @@
                                      FALSE
                                      (if pan-y-by-mods TRUE FALSE))))
                  (pan-x-by-mods
-                  (if (= scrolling-type 0)
+                  (if classic-scrolling?
                       ;; Classic gschem behaviour.
                       (and (true? (schematic_window_get_control_key_pressed *window))
                            (false? (schematic_window_get_shift_key_pressed *window)))

--- a/libleptongui/scheme/schematic/canvas.scm
+++ b/libleptongui/scheme/schematic/canvas.scm
@@ -110,15 +110,38 @@
                                (eq? (event-scroll-direction->symbol scroll-direction)
                                     'gdk-scroll-right)))
                       FALSE
-                      (if zoom-by-mods? TRUE FALSE))))
-
+                      (if zoom-by-mods? TRUE FALSE)))
+                 (pan-y-by-mods
+                  (if (= scrolling-type 0)
+                      ;; Classic gschem behaviour.
+                      (and (false? (schematic_window_get_control_key_pressed *window))
+                           (true? (schematic_window_get_shift_key_pressed *window)))
+                      ;; GTK style behaviour.
+                      (and (false? (schematic_window_get_control_key_pressed *window))
+                           (false? (schematic_window_get_shift_key_pressed *window)))))
+                 (pan-y-axis (if (false? (schematic_window_get_scrollbars_flag *window))
+                                 ;; You must have scrollbars
+                                 ;; enabled if you want to use
+                                 ;; the scroll wheel to pan.
+                                 FALSE
+                                 ;; If the user has a
+                                 ;; left/right scroll wheel,
+                                 ;; always scroll the y-axis.
+                                 (if (and scroll-direction
+                                          (or (eq? (event-scroll-direction->symbol scroll-direction)
+                                                   'gdk-scroll-left)
+                                              (eq? (event-scroll-direction->symbol scroll-direction)
+                                                   'gdk-scroll-right)))
+                                     FALSE
+                                     (if pan-y-by-mods TRUE FALSE)))))
             (x_event_scroll *widget
                             *event
                             *window
                             scrolling-type
                             (or scroll-direction 0)
                             (if scroll-direction TRUE FALSE)
-                            zoom))))))
+                            zoom
+                            pan-y-axis))))))
 
 (define *scroll-canvas
   (procedure->pointer int scroll-canvas '(* * *)))

--- a/libleptongui/scheme/schematic/canvas.scm
+++ b/libleptongui/scheme/schematic/canvas.scm
@@ -64,6 +64,8 @@
 (define (scroll-canvas *widget *event *window)
   (when (null-pointer? *window)
     (error "NULL window"))
+  (when (null-pointer? *widget)
+    (error "NULL canvas"))
   (x_event_scroll *widget *event *window))
 
 (define *scroll-canvas

--- a/libleptongui/scheme/schematic/event.scm
+++ b/libleptongui/scheme/schematic/event.scm
@@ -29,7 +29,9 @@
 
   #:export (event-coords
             event-direction
-            event-state))
+            event-state
+            event-scroll-direction->symbol
+            symbol->event-scroll-direction))
 
 
 (define (event-state *event)

--- a/libleptongui/scheme/schematic/event.scm
+++ b/libleptongui/scheme/schematic/event.scm
@@ -1,0 +1,47 @@
+;;; Lepton EDA Schematic Capture
+;;; Scheme API
+;;; Copyright (C) 2023-2024 Lepton EDA Contributors
+;;;
+;;; This program is free software; you can redistribute it and/or modify
+;;; it under the terms of the GNU General Public License as published by
+;;; the Free Software Foundation; either version 2 of the License, or
+;;; (at your option) any later version.
+;;;
+;;; This program is distributed in the hope that it will be useful,
+;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;; GNU General Public License for more details.
+;;;
+;;; You should have received a copy of the GNU General Public License
+;;; along with this program; if not, write to the Free Software
+;;; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
+(define-module (schematic event)
+  #:use-module (rnrs bytevectors)
+  #:use-module (system foreign)
+
+  #:use-module (schematic ffi gtk)
+
+  #:export (event-coords
+            event-state))
+
+
+(define (event-state *event)
+  (define state-bv (make-bytevector (sizeof GdkModifierType) 0))
+
+  (gdk_event_get_state *event (bytevector->pointer state-bv))
+  (bytevector-u32-native-ref state-bv 0))
+
+
+(define (event-coords *event)
+  (define window-x-bv (make-bytevector (sizeof double) 0))
+  (define window-y-bv (make-bytevector (sizeof double) 0))
+
+  (gdk_event_get_coords *event
+                        (bytevector->pointer window-x-bv)
+                        (bytevector->pointer window-y-bv))
+
+  (let ((window-x (bytevector-ieee-double-native-ref window-x-bv 0))
+        (window-y (bytevector-ieee-double-native-ref window-y-bv 0)))
+    (cons window-x window-y)))

--- a/libleptongui/scheme/schematic/event.scm
+++ b/libleptongui/scheme/schematic/event.scm
@@ -106,4 +106,5 @@ symbol SYM."
        schematic_event_get_scroll_direction) *event))
 
 (define (event-time *event)
+  "Get the time stamp of *EVENT."
   (gdk_event_get_time *event))

--- a/libleptongui/scheme/schematic/event.scm
+++ b/libleptongui/scheme/schematic/event.scm
@@ -1,6 +1,6 @@
 ;;; Lepton EDA Schematic Capture
 ;;; Scheme API
-;;; Copyright (C) 2023-2024 Lepton EDA Contributors
+;;; Copyright (C) 2023-2025 Lepton EDA Contributors
 ;;;
 ;;; This program is free software; you can redistribute it and/or modify
 ;;; it under the terms of the GNU General Public License as published by
@@ -50,6 +50,20 @@
   (let ((window-x (bytevector-ieee-double-native-ref window-x-bv 0))
         (window-y (bytevector-ieee-double-native-ref window-y-bv 0)))
     (cons window-x window-y)))
+
+
+(define (event-scroll-direction->symbol direction)
+  "Returns a Scheme symbol corresponding to integer DIRECTION value."
+  (string->symbol
+   (pointer->string
+    (gdk_event_scroll_direction_to_string direction))))
+
+
+(define (symbol->event-scroll-direction sym)
+  "Returns an integer scroll direction value corresponding to the
+symbol SYM."
+  (gdk_event_scroll_direction_from_string (string->pointer
+                                           (symbol->string sym))))
 
 
 ;;; The getter gdk_event_get_scroll_direction() is defined in GTK3

--- a/libleptongui/scheme/schematic/event.scm
+++ b/libleptongui/scheme/schematic/event.scm
@@ -79,11 +79,21 @@ symbol SYM."
             *event
             (bytevector->pointer direction))))
 
-  (and has-direction?
-       (bytevector-uint-ref direction
-                            0
-                            (native-endianness)
-                            (sizeof int))))
+  (define result
+    (bytevector-uint-ref direction
+                         0
+                         (native-endianness)
+                         (sizeof int)))
+
+  (if has-direction?
+      result
+      (let ((delta-x (make-bytevector (sizeof double) 0))
+            (delta-y (make-bytevector (sizeof double) 0)))
+        (and (true? (gdk_event_get_scroll_deltas *event
+                                                 (bytevector->pointer delta-x)
+                                                 (bytevector->pointer delta-y)))
+             (cons (bytevector-ieee-double-native-ref delta-x 0)
+                   (bytevector-ieee-double-native-ref delta-y 0))))))
 
 (define (event-direction *event)
   ((if %m4-use-gtk3

--- a/libleptongui/scheme/schematic/event.scm
+++ b/libleptongui/scheme/schematic/event.scm
@@ -37,6 +37,8 @@
 
 
 (define (event-state *event)
+  "Get the 'state' field of C *EVENT containing the data of the type
+GdkModifierType."
   (define state-bv (make-bytevector (sizeof GdkModifierType) 0))
 
   (gdk_event_get_state *event (bytevector->pointer state-bv))

--- a/libleptongui/scheme/schematic/event.scm
+++ b/libleptongui/scheme/schematic/event.scm
@@ -16,6 +16,7 @@
 ;;; along with this program; if not, write to the Free Software
 ;;; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
+;;; Process GTK events.
 
 (define-module (schematic event)
   #:use-module (rnrs bytevectors)

--- a/libleptongui/scheme/schematic/event.scm
+++ b/libleptongui/scheme/schematic/event.scm
@@ -30,6 +30,7 @@
   #:export (event-coords
             event-direction
             event-state
+            event-time
             event-scroll-direction->symbol
             symbol->event-scroll-direction))
 
@@ -88,3 +89,6 @@ symbol SYM."
   ((if %m4-use-gtk3
        event-direction-gtk3
        schematic_event_get_scroll_direction) *event))
+
+(define (event-time *event)
+  (gdk_event_get_time *event))

--- a/libleptongui/scheme/schematic/event.scm
+++ b/libleptongui/scheme/schematic/event.scm
@@ -101,6 +101,7 @@ symbol SYM."
                    (bytevector-ieee-double-native-ref delta-y 0))))))
 
 (define (event-direction *event)
+  "Extract the scroll direction from *EVENT."
   ((if %m4-use-gtk3
        event-direction-gtk3
        schematic_event_get_scroll_direction) *event))

--- a/libleptongui/scheme/schematic/event.scm
+++ b/libleptongui/scheme/schematic/event.scm
@@ -46,6 +46,8 @@ GdkModifierType."
 
 
 (define (event-coords *event)
+  "Extract the event window relative coordinates from *EVENT in the
+form (X . Y)."
   (define window-x-bv (make-bytevector (sizeof double) 0))
   (define window-y-bv (make-bytevector (sizeof double) 0))
 

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -506,6 +506,7 @@
             schematic_event_is_double_button_press
             schematic_event_get_doing_stroke
             schematic_event_set_doing_stroke
+            schematic_event_get_scroll_direction
             schematic_event_skip_motion_event
             schematic_event_alt_mask
             schematic_event_control_mask
@@ -1074,11 +1075,12 @@
 (define-lff x_event_get_pointer_position int (list '* int '* '*))
 (define-lff x_event_key '* '(* * *))
 (define-lfc *x_event_configure)
-(define-lff x_event_scroll int (list '* '* '* int))
+(define-lff x_event_scroll int (list '* '* '* int int int))
 (define-lff schematic_event_get_button int '(*))
 (define-lff schematic_event_is_double_button_press int '(*))
 (define-lff schematic_event_get_doing_stroke int '())
 (define-lff schematic_event_set_doing_stroke void (list int))
+(define-lff schematic_event_get_scroll_direction int '(*))
 (define-lff schematic_event_skip_motion_event int '(*))
 (define-lff schematic_event_alt_mask int '())
 (define-lff schematic_event_control_mask int '())

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -1087,7 +1087,7 @@
 (define-lff x_event_get_pointer_position int (list '* int '* '*))
 (define-lff x_event_key '* '(* * *))
 (define-lfc *x_event_configure)
-(define-lff x_event_scroll int (list '* '* '* int int int int double))
+(define-lff x_event_scroll int (list '* '* '* int int int int int))
 (define-lff schematic_event_get_button int '(*))
 (define-lff schematic_event_is_double_button_press int '(*))
 (define-lff schematic_event_get_doing_stroke int '())

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -1087,7 +1087,7 @@
 (define-lff x_event_get_pointer_position int (list '* int '* '*))
 (define-lff x_event_key '* '(* * *))
 (define-lfc *x_event_configure)
-(define-lff x_event_scroll int (list '* '* '* int int int int))
+(define-lff x_event_scroll int (list '* '* '* int int int int double))
 (define-lff schematic_event_get_button int '(*))
 (define-lff schematic_event_is_double_button_press int '(*))
 (define-lff schematic_event_get_doing_stroke int '())

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -425,6 +425,7 @@
             schematic_window_set_text_properties_widget
             schematic_window_get_alt_key_pressed
             schematic_window_set_alt_key_pressed
+            schematic_window_get_control_key_pressed
             schematic_window_set_control_key_pressed
             schematic_window_get_shift_key_pressed
             schematic_window_set_shift_key_pressed
@@ -789,6 +790,7 @@
 (define-lff schematic_window_set_text_properties_widget void '(* *))
 (define-lff schematic_window_get_alt_key_pressed int '(*))
 (define-lff schematic_window_set_alt_key_pressed void (list '* int))
+(define-lff schematic_window_get_control_key_pressed int '(*))
 (define-lff schematic_window_set_control_key_pressed void (list '* int))
 (define-lff schematic_window_get_shift_key_pressed int '(*))
 (define-lff schematic_window_set_shift_key_pressed void (list '* int))
@@ -1079,7 +1081,7 @@
 (define-lff x_event_get_pointer_position int (list '* int '* '*))
 (define-lff x_event_key '* '(* * *))
 (define-lfc *x_event_configure)
-(define-lff x_event_scroll int (list '* '* '* int int int))
+(define-lff x_event_scroll int (list '* '* '* int int int int))
 (define-lff schematic_event_get_button int '(*))
 (define-lff schematic_event_is_double_button_press int '(*))
 (define-lff schematic_event_get_doing_stroke int '())

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -430,6 +430,8 @@
             schematic_window_get_shift_key_pressed
             schematic_window_set_shift_key_pressed
             schematic_window_get_scroll_wheel
+            schematic_window_get_scrollbars_flag
+            schematic_window_set_scrollbars_flag
             schematic_window_get_text_caps
             schematic_window_text_caps_to_string
             schematic_window_get_text_size
@@ -795,6 +797,8 @@
 (define-lff schematic_window_get_shift_key_pressed int '(*))
 (define-lff schematic_window_set_shift_key_pressed void (list '* int))
 (define-lff schematic_window_get_scroll_wheel int '(*))
+(define-lff schematic_window_get_scrollbars_flag int '(*))
+(define-lff schematic_window_set_scrollbars_flag void (list '* int))
 (define-lff schematic_window_get_text_caps int '(*))
 (define-lff schematic_window_text_caps_to_string '* (list int))
 (define-lff schematic_window_get_text_size int '(*))
@@ -1081,7 +1085,7 @@
 (define-lff x_event_get_pointer_position int (list '* int '* '*))
 (define-lff x_event_key '* '(* * *))
 (define-lfc *x_event_configure)
-(define-lff x_event_scroll int (list '* '* '* int int int int))
+(define-lff x_event_scroll int (list '* '* '* int int int int int))
 (define-lff schematic_event_get_button int '(*))
 (define-lff schematic_event_is_double_button_press int '(*))
 (define-lff schematic_event_get_doing_stroke int '())

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -1087,7 +1087,7 @@
 (define-lff x_event_get_pointer_position int (list '* int '* '*))
 (define-lff x_event_key '* '(* * *))
 (define-lfc *x_event_configure)
-(define-lff x_event_scroll int (list '* '* '* int int int int int))
+(define-lff x_event_scroll int (list '* '* int int int int))
 (define-lff schematic_event_get_button int '(*))
 (define-lff schematic_event_is_double_button_press int '(*))
 (define-lff schematic_event_get_doing_stroke int '())

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -329,6 +329,8 @@
 
             schematic_canvas_get_page
             schematic_canvas_get_viewport
+            schematic_canvas_get_hadjustment
+            schematic_canvas_get_vadjustment
             schematic_canvas_invalidate_all
             schematic_canvas_invalidate_world_rect
             schematic_canvas_new_with_page
@@ -681,6 +683,8 @@
 ;;; canvas.c
 (define-lff schematic_canvas_get_page '* '(*))
 (define-lff schematic_canvas_get_viewport '* '(*))
+(define-lff schematic_canvas_get_hadjustment '* '(*))
+(define-lff schematic_canvas_get_vadjustment '* '(*))
 (define-lff schematic_canvas_invalidate_all void '(*))
 (define-lff schematic_canvas_invalidate_world_rect void (list '* int int int int))
 (define-lff schematic_canvas_new_with_page '* '(*))
@@ -1091,7 +1095,7 @@
 (define-lff x_event_get_pointer_position int (list '* int '* '*))
 (define-lff x_event_key '* '(* * *))
 (define-lfc *x_event_configure)
-(define-lff x_event_scroll int (list '* '* int int int int))
+(define-lff x_event_scroll int (list '* '* int int int int '* '*))
 (define-lff schematic_event_get_button int '(*))
 (define-lff schematic_event_is_double_button_press int '(*))
 (define-lff schematic_event_get_doing_stroke int '())

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -1095,7 +1095,7 @@
 (define-lff x_event_get_pointer_position int (list '* int '* '*))
 (define-lff x_event_key '* '(* * *))
 (define-lfc *x_event_configure)
-(define-lff x_event_scroll int (list '* '* int int int int '* '*))
+(define-lff x_event_scroll int (list '* '* int int int))
 (define-lff schematic_event_get_button int '(*))
 (define-lff schematic_event_is_double_button_press int '(*))
 (define-lff schematic_event_get_doing_stroke int '())

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -1087,7 +1087,7 @@
 (define-lff x_event_get_pointer_position int (list '* int '* '*))
 (define-lff x_event_key '* '(* * *))
 (define-lfc *x_event_configure)
-(define-lff x_event_scroll int (list '* '* '* int int int double))
+(define-lff x_event_scroll int (list '* '* '* int int int int double))
 (define-lff schematic_event_get_button int '(*))
 (define-lff schematic_event_is_double_button_press int '(*))
 (define-lff schematic_event_get_doing_stroke int '())

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -515,8 +515,6 @@
             schematic_event_is_double_button_press
             schematic_event_get_doing_stroke
             schematic_event_set_doing_stroke
-            schematic_event_get_last_scroll_event_time
-            schematic_event_set_last_scroll_event_time
             schematic_event_get_scroll_direction
             schematic_event_skip_motion_event
             schematic_event_alt_mask
@@ -1100,8 +1098,6 @@
 (define-lff schematic_event_is_double_button_press int '(*))
 (define-lff schematic_event_get_doing_stroke int '())
 (define-lff schematic_event_set_doing_stroke void (list int))
-(define-lff schematic_event_get_last_scroll_event_time uint32 '())
-(define-lff schematic_event_set_last_scroll_event_time void (list uint32))
 (define-lff schematic_event_get_scroll_direction int '(*))
 (define-lff schematic_event_skip_motion_event int '(*))
 (define-lff schematic_event_alt_mask int '())

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -498,6 +498,8 @@
             lepton_log_set_logging_enabled
             s_log_close
 
+            gdk_event_scroll_direction_from_string
+            gdk_event_scroll_direction_to_string
             x_event_get_pointer_position
             x_event_key
             *x_event_configure
@@ -1072,6 +1074,8 @@
 (define-lff x_show_uri int '(* * *))
 
 ;;; x_event.c
+(define-lff gdk_event_scroll_direction_from_string int '(*))
+(define-lff gdk_event_scroll_direction_to_string '* (list int))
 (define-lff x_event_get_pointer_position int (list '* int '* '*))
 (define-lff x_event_key '* '(* * *))
 (define-lfc *x_event_configure)

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -428,6 +428,7 @@
             schematic_window_set_control_key_pressed
             schematic_window_get_shift_key_pressed
             schematic_window_set_shift_key_pressed
+            schematic_window_get_scroll_wheel
             schematic_window_get_text_caps
             schematic_window_text_caps_to_string
             schematic_window_get_text_size
@@ -788,6 +789,7 @@
 (define-lff schematic_window_set_control_key_pressed void (list '* int))
 (define-lff schematic_window_get_shift_key_pressed int '(*))
 (define-lff schematic_window_set_shift_key_pressed void (list '* int))
+(define-lff schematic_window_get_scroll_wheel int '(*))
 (define-lff schematic_window_get_text_caps int '(*))
 (define-lff schematic_window_text_caps_to_string '* (list int))
 (define-lff schematic_window_get_text_size int '(*))
@@ -1072,7 +1074,7 @@
 (define-lff x_event_get_pointer_position int (list '* int '* '*))
 (define-lff x_event_key '* '(* * *))
 (define-lfc *x_event_configure)
-(define-lff x_event_scroll int '(* * *))
+(define-lff x_event_scroll int (list '* '* '* int))
 (define-lff schematic_event_get_button int '(*))
 (define-lff schematic_event_is_double_button_press int '(*))
 (define-lff schematic_event_get_doing_stroke int '())

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -511,6 +511,8 @@
             schematic_event_is_double_button_press
             schematic_event_get_doing_stroke
             schematic_event_set_doing_stroke
+            schematic_event_get_last_scroll_event_time
+            schematic_event_set_last_scroll_event_time
             schematic_event_get_scroll_direction
             schematic_event_skip_motion_event
             schematic_event_alt_mask
@@ -1090,6 +1092,8 @@
 (define-lff schematic_event_is_double_button_press int '(*))
 (define-lff schematic_event_get_doing_stroke int '())
 (define-lff schematic_event_set_doing_stroke void (list int))
+(define-lff schematic_event_get_last_scroll_event_time uint32 '())
+(define-lff schematic_event_set_last_scroll_event_time void (list uint32))
 (define-lff schematic_event_get_scroll_direction int '(*))
 (define-lff schematic_event_skip_motion_event int '(*))
 (define-lff schematic_event_alt_mask int '())

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -432,6 +432,8 @@
             schematic_window_get_scroll_wheel
             schematic_window_get_scrollbars_flag
             schematic_window_set_scrollbars_flag
+            schematic_window_get_scrollpan_steps
+            schematic_window_set_scrollpan_steps
             schematic_window_get_text_caps
             schematic_window_text_caps_to_string
             schematic_window_get_text_size
@@ -801,6 +803,8 @@
 (define-lff schematic_window_get_scroll_wheel int '(*))
 (define-lff schematic_window_get_scrollbars_flag int '(*))
 (define-lff schematic_window_set_scrollbars_flag void (list '* int))
+(define-lff schematic_window_get_scrollpan_steps int '(*))
+(define-lff schematic_window_set_scrollpan_steps void (list '* int))
 (define-lff schematic_window_get_text_caps int '(*))
 (define-lff schematic_window_text_caps_to_string '* (list int))
 (define-lff schematic_window_get_text_size int '(*))

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -507,10 +507,10 @@
 
             gdk_event_scroll_direction_from_string
             gdk_event_scroll_direction_to_string
+            x_event_faked_motion
             x_event_get_pointer_position
             x_event_key
             *x_event_configure
-            x_event_scroll
             schematic_event_get_button
             schematic_event_is_double_button_press
             schematic_event_get_doing_stroke
@@ -1092,10 +1092,10 @@
 ;;; x_event.c
 (define-lff gdk_event_scroll_direction_from_string int '(*))
 (define-lff gdk_event_scroll_direction_to_string '* (list int))
+(define-lff x_event_faked_motion int '(* *))
 (define-lff x_event_get_pointer_position int (list '* int '* '*))
 (define-lff x_event_key '* '(* * *))
 (define-lfc *x_event_configure)
-(define-lff x_event_scroll int (list '* '* int int int))
 (define-lff schematic_event_get_button int '(*))
 (define-lff schematic_event_is_double_button_press int '(*))
 (define-lff schematic_event_get_doing_stroke int '())

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -1087,7 +1087,7 @@
 (define-lff x_event_get_pointer_position int (list '* int '* '*))
 (define-lff x_event_key '* '(* * *))
 (define-lfc *x_event_configure)
-(define-lff x_event_scroll int (list '* '* '* int int int int double))
+(define-lff x_event_scroll int (list '* '* '* int int int double))
 (define-lff schematic_event_get_button int '(*))
 (define-lff schematic_event_is_double_button_press int '(*))
 (define-lff schematic_event_get_doing_stroke int '())

--- a/libleptongui/scheme/schematic/ffi.scm
+++ b/libleptongui/scheme/schematic/ffi.scm
@@ -1085,7 +1085,7 @@
 (define-lff x_event_get_pointer_position int (list '* int '* '*))
 (define-lff x_event_key '* '(* * *))
 (define-lfc *x_event_configure)
-(define-lff x_event_scroll int (list '* '* '* int int int int int))
+(define-lff x_event_scroll int (list '* '* '* int int int int))
 (define-lff schematic_event_get_button int '(*))
 (define-lff schematic_event_is_double_button_press int '(*))
 (define-lff schematic_event_get_doing_stroke int '())

--- a/libleptongui/scheme/schematic/ffi/gtk.scm
+++ b/libleptongui/scheme/schematic/ffi/gtk.scm
@@ -55,6 +55,7 @@
 
             GdkModifierType
             gdk_event_get_coords
+            gdk_event_get_scroll_deltas
             gdk_event_get_scroll_direction
             gdk_event_get_state
             gdk_event_get_time))
@@ -113,6 +114,15 @@
 (define-lff gdk_event_get_coords int '(* * *))
 (define-lff gdk_event_get_state int '(* *))
 (define-lff gdk_event_get_time uint32 '(*))
+
+(define gdk_event_get_scroll_deltas
+  (if %m4-use-gtk3
+      (let ((proc (delay (pointer->procedure
+                          int
+                          (dynamic-func "gdk_event_get_scroll_deltas" libgtk)
+                          '(* * *)))))
+        (force proc))
+      #f))
 
 (define gdk_event_get_scroll_direction
   (if %m4-use-gtk3

--- a/libleptongui/scheme/schematic/ffi/gtk.scm
+++ b/libleptongui/scheme/schematic/ffi/gtk.scm
@@ -29,6 +29,11 @@
             gtk_accelerator_parse
             gtk_accelerator_name
             gtk_accelerator_get_label
+            gtk_adjustment_get_page_increment
+            gtk_adjustment_get_page_size
+            gtk_adjustment_get_upper
+            gtk_adjustment_get_value
+            gtk_adjustment_set_value
             gtk_events_pending
             gtk_rc_parse
             gtk_icon_theme_get_default
@@ -71,6 +76,12 @@
 (define-lff gtk_accelerator_parse void '(* * *))
 (define-lff gtk_accelerator_name '* (list int GdkModifierType))
 (define-lff gtk_accelerator_get_label '* (list int GdkModifierType))
+
+(define-lff gtk_adjustment_get_page_increment double '(*))
+(define-lff gtk_adjustment_get_page_size double '(*))
+(define-lff gtk_adjustment_get_upper double '(*))
+(define-lff gtk_adjustment_get_value double '(*))
+(define-lff gtk_adjustment_set_value void (list '* double))
 
 (define-lff gtk_events_pending int '())
 

--- a/libleptongui/scheme/schematic/ffi/gtk.scm
+++ b/libleptongui/scheme/schematic/ffi/gtk.scm
@@ -20,6 +20,7 @@
   #:use-module (system foreign)
   #:use-module (lepton ffi lff)
   #:use-module (lepton ffi)
+  #:use-module (lepton m4)
 
   #:export (gtk_init
             gtk_main_iteration
@@ -54,6 +55,7 @@
 
             GdkModifierType
             gdk_event_get_coords
+            gdk_event_get_scroll_direction
             gdk_event_get_state))
 
 ;;; Simplify definition of functions by omitting the library
@@ -109,3 +111,12 @@
 ;; (define-lff gdk_event_get_button int '(* *))
 (define-lff gdk_event_get_coords int '(* * *))
 (define-lff gdk_event_get_state int '(* *))
+
+(define gdk_event_get_scroll_direction
+  (if %m4-use-gtk3
+      (let ((proc (delay (pointer->procedure
+                          int
+                          (dynamic-func "gdk_event_get_scroll_direction" libgtk)
+                          '(* *)))))
+        (force proc))
+      #f))

--- a/libleptongui/scheme/schematic/ffi/gtk.scm
+++ b/libleptongui/scheme/schematic/ffi/gtk.scm
@@ -52,6 +52,7 @@
             gtk_window_set_transient_for
             gtk_window_present
 
+            GdkModifierType
             gdk_event_get_coords
             gdk_event_get_state))
 
@@ -60,9 +61,10 @@
 (define-syntax-rule (define-lff arg ...)
   (define-lff-lib arg ... libgtk))
 
+(define GdkModifierType uint32)
+
 
 (define-lff gtk_accelerator_parse void '(* * *))
-(define GdkModifierType uint32)
 (define-lff gtk_accelerator_name '* (list int GdkModifierType))
 (define-lff gtk_accelerator_get_label '* (list int GdkModifierType))
 

--- a/libleptongui/scheme/schematic/ffi/gtk.scm
+++ b/libleptongui/scheme/schematic/ffi/gtk.scm
@@ -56,7 +56,8 @@
             GdkModifierType
             gdk_event_get_coords
             gdk_event_get_scroll_direction
-            gdk_event_get_state))
+            gdk_event_get_state
+            gdk_event_get_time))
 
 ;;; Simplify definition of functions by omitting the library
 ;;; argument.
@@ -111,6 +112,7 @@
 ;; (define-lff gdk_event_get_button int '(* *))
 (define-lff gdk_event_get_coords int '(* * *))
 (define-lff gdk_event_get_state int '(* *))
+(define-lff gdk_event_get_time uint32 '(*))
 
 (define gdk_event_get_scroll_direction
   (if %m4-use-gtk3

--- a/libleptongui/scheme/schematic/preview-widget.scm
+++ b/libleptongui/scheme/schematic/preview-widget.scm
@@ -139,9 +139,9 @@ buffer should be displayed, the widget displays the error message."
 
 (define (scroll-preview *preview *scroll-event *window)
   (if (true? (schematic_preview_get_active *preview))
-      (x_event_scroll *preview
-                      *scroll-event
-                      (schematic_preview_get_window *preview))
+      (scroll-canvas *preview
+                     *scroll-event
+                     (schematic_preview_get_window *preview))
       TRUE))
 
 (define *scroll-preview

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -786,13 +786,6 @@ zooming."
   (procedure->pointer int callback-motion '(* * *)))
 
 
-(define (callback-scroll *widget *event *window)
-  (x_event_scroll *widget *event *window))
-
-(define *callback-scroll
-  (procedure->pointer int callback-scroll '(* * *)))
-
-
 (define (setup-canvas-draw-events *window *canvas)
   (define signal-callback-list
     (list
@@ -803,7 +796,7 @@ zooming."
      `("configure-event" . ,*x_event_configure)
      `("key-press-event" . ,*process-key-event)
      `("key-release-event" . ,*process-key-event)
-     `("scroll-event" . ,*callback-scroll)
+     `("scroll-event" . ,*scroll-canvas)
      `("update-grid-info" . ,*i_update_grid_info_callback)
      `("notify::page" . ,*schematic_window_notify_page_callback)))
 

--- a/libleptongui/scheme/schematic/window.scm
+++ b/libleptongui/scheme/schematic/window.scm
@@ -44,6 +44,7 @@
   #:use-module (schematic callback)
   #:use-module (schematic canvas foreign)
   #:use-module (schematic canvas)
+  #:use-module (schematic event)
   #:use-module (schematic ffi)
   #:use-module (schematic ffi gtk)
   #:use-module (schematic gettext)
@@ -231,14 +232,6 @@
 (define MOUSEBTN_DO_PAN    5)
 
 
-(define (event-state *event)
-  (define GdkModifierType uint32)
-  (define state-bv (make-bytevector (sizeof GdkModifierType) 0))
-
-  (gdk_event_get_state *event (bytevector->pointer state-bv))
-  (bytevector-u32-native-ref state-bv 0))
-
-
 (define (window-save-modifiers *window *event)
   (define alt-mask (schematic_event_alt_mask))
   (define control-mask (schematic_event_control_mask))
@@ -255,19 +248,6 @@
                                             (state-contains? state control-mask))
   (schematic_window_set_alt_key_pressed *window
                                         (state-contains? state alt-mask)))
-
-
-(define (event-coords *event)
-  (define window-x-bv (make-bytevector (sizeof double) 0))
-  (define window-y-bv (make-bytevector (sizeof double) 0))
-
-  (gdk_event_get_coords *event
-                        (bytevector->pointer window-x-bv)
-                        (bytevector->pointer window-y-bv))
-
-  (let ((window-x (bytevector-ieee-double-native-ref window-x-bv 0))
-        (window-y (bytevector-ieee-double-native-ref window-y-bv 0)))
-    (cons window-x window-y)))
 
 
 (define (zoom-box window)

--- a/libleptongui/src/a_zoom.c
+++ b/libleptongui/src/a_zoom.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2015 gEDA Contributors
- * Copyright (C) 2017-2024 Lepton EDA Contributors
+ * Copyright (C) 2017-2025 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -66,6 +66,11 @@ a_zoom (SchematicWindow *w_current,
   case(ZOOM_FULL):
     /* indicate the zoom full with a negative zoomfactor */
     relativ_zoom_factor = -1;
+    break;
+
+    /* Don't zoom. */
+  case(ZOOM_SAME):
+    relativ_zoom_factor = 1;
     break;
   }
 

--- a/libleptongui/src/gtk_helper.c
+++ b/libleptongui/src/gtk_helper.c
@@ -1,5 +1,5 @@
 /* Lepton EDA Schematic Capture
- * Copyright (C) 2023-2024 Lepton EDA Contributors
+ * Copyright (C) 2023-2025 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -75,4 +75,62 @@ GtkWindow*
 gtk_widget_get_gtk_window (GtkWidget *widget)
 {
   return GTK_WINDOW (widget);
+}
+
+
+/*! \brief Return an event scroll direction enum value from
+ *         string.
+ *  \par Function Description
+ *  Returns the \c GdkScrollDirection enum value corresponding to
+ *  the string \p s.  This is mainly intended to be used for value
+ *  conversion in Scheme FFI functions.
+ *
+ * \param [in] s The string.
+ * \return The scroll direction enum value.
+ */
+GdkScrollDirection
+gdk_event_scroll_direction_from_string (char *s)
+{
+  GdkScrollDirection result = GDK_SCROLL_UP;
+
+  if      (strcmp (s, "gdk-scroll-up") == 0) {result = GDK_SCROLL_UP; }
+  else if (strcmp (s, "gdk-scroll-down") == 0) {result = GDK_SCROLL_DOWN; }
+  else if (strcmp (s, "gdk-scroll-left") == 0) {result = GDK_SCROLL_LEFT; }
+  else if (strcmp (s, "gdk-scroll-right") == 0) {result = GDK_SCROLL_RIGHT; }
+#ifdef GTK3
+  else if (strcmp (s, "gdk-scroll-smooth") == 0) {result = GDK_SCROLL_SMOOTH; }
+#endif
+
+  return result;
+}
+
+
+/*! \brief Get a string holding the representation of \c
+ *         GdkScrollDirection value.
+ *  \par Function Description
+ *  Returns the representation of a \c GdkScrollDirection value as
+ *  a string.  This is mainly intended to be used for value
+ *  conversion in Scheme FFI functions.
+ *
+ *  \param [in] mode The \c GdkScrollDirection value.
+ *  \return The string representation of the value.
+ */
+const char*
+gdk_event_scroll_direction_to_string (GdkScrollDirection mode)
+{
+  const char *result = NULL;
+
+  switch (mode)
+  {
+  case GDK_SCROLL_UP: result = "gdk-scroll-up"; break;
+  case GDK_SCROLL_DOWN: result = "gdk-scroll-down"; break;
+  case GDK_SCROLL_LEFT: result = "gdk-scroll-left"; break;
+  case GDK_SCROLL_RIGHT: result = "gdk-scroll-right"; break;
+#ifdef GTK3
+  case GDK_SCROLL_SMOOTH: result = "gdk-scroll-smooth"; break;
+#endif
+  default: break;
+  }
+
+  return result;
 }

--- a/libleptongui/src/i_vars.c
+++ b/libleptongui/src/i_vars.c
@@ -35,7 +35,7 @@ int   default_embed_component = FALSE;
 int   default_include_component = FALSE;
 int   default_snap_size = DEFAULT_SNAP_SIZE;
 
-int   default_scrollbars_flag = TRUE;
+gboolean default_scrollbars_flag = TRUE;
 int   default_third_button = MOUSEBTN_DO_POPUP;
 int   default_third_button_cancel = TRUE;
 int   default_middle_button = MOUSEBTN_DO_PAN;
@@ -205,7 +205,7 @@ i_vars_set (SchematicWindow* w_current)
                        &w_current->actionfeedback_mode);
 
 
-  int scrollbars_flag = 0;
+  gboolean scrollbars_flag = FALSE;
   cfg_read_bool ("schematic.gui", "scrollbars",
                  default_scrollbars_flag, &scrollbars_flag);
   schematic_window_set_scrollbars_flag (w_current, scrollbars_flag);

--- a/libleptongui/src/preview_widget.c
+++ b/libleptongui/src/preview_widget.c
@@ -223,7 +223,7 @@ schematic_preview_init (SchematicPreview *preview)
   i_vars_set (preview_w_current);
 
   /* be sure to turn off scrollbars */
-  schematic_window_set_scrollbars_flag (preview_w_current, 0);
+  schematic_window_set_scrollbars_flag (preview_w_current, FALSE);
 
   /* be sure to turn off the grid */
   schematic_options_set_grid_mode (preview_w_current->options, GRID_MODE_NONE);

--- a/libleptongui/src/window.c
+++ b/libleptongui/src/window.c
@@ -317,7 +317,7 @@ SchematicWindow *schematic_window_new ()
   w_current->net_selection_state = 0;
   w_current->embed_component = 0;
   w_current->include_component = 0;
-  schematic_window_set_scrollbars_flag (w_current, 0);
+  schematic_window_set_scrollbars_flag (w_current, FALSE);
   w_current->third_button = 0;
   w_current->third_button_cancel = TRUE;
   w_current->middle_button = 0;
@@ -2481,7 +2481,7 @@ schematic_window_set_scroll_wheel (SchematicWindow *w_current,
  *  \param [in] w_current The schematic window.
  *  \return The value of the field 'scrollbars_flag'.
  */
-int
+gboolean
 schematic_window_get_scrollbars_flag (SchematicWindow *w_current)
 {
   g_return_val_if_fail (w_current != NULL, 0);
@@ -2497,7 +2497,7 @@ schematic_window_get_scrollbars_flag (SchematicWindow *w_current)
  */
 void
 schematic_window_set_scrollbars_flag (SchematicWindow *w_current,
-                                      int val)
+                                      gboolean val)
 {
   g_return_if_fail (w_current != NULL);
 

--- a/libleptongui/src/x_event.c
+++ b/libleptongui/src/x_event.c
@@ -323,11 +323,6 @@ x_event_scroll (GtkWidget *widget,
 
   view = SCHEMATIC_CANVAS (widget);
 
-  /* update the state of the modifiers */
-  schematic_window_set_shift_key_pressed (w_current, (event->state & GDK_SHIFT_MASK) ? 1 : 0);
-  schematic_window_set_control_key_pressed (w_current, (event->state & GDK_CONTROL_MASK) ? 1 : 0);
-  schematic_window_set_alt_key_pressed (w_current, (event->state & GDK_MOD1_MASK) ? 1 : 0);
-
   if (schematic_window_get_scroll_wheel (w_current) == SCROLL_WHEEL_CLASSIC)
   {
     /* Classic gschem behaviour */

--- a/libleptongui/src/x_event.c
+++ b/libleptongui/src/x_event.c
@@ -328,33 +328,24 @@ schematic_event_set_last_scroll_event_time (guint val)
  *  \par Function Description
  *
  *  \param [in] widget The SchematicCanvas with the scroll event.
- *  \param [in] event
  *  \param [in] w_current
  *  \param [in] zoom
  *  \param [in] pan_yaxis
  *  \param [in] pan_xaxis
  *  \param [in] pan_direction
- *  \param [in] zoom_direction
  */
 gint
 x_event_scroll (GtkWidget *widget,
-                GdkEventScroll *event,
                 SchematicWindow *w_current,
                 gboolean zoom,
                 gboolean pan_xaxis,
                 gboolean pan_yaxis,
-                int pan_direction,
-                int zoom_direction)
+                int pan_direction)
 {
   GtkAdjustment *adj;
   SchematicCanvas *view = NULL;
 
   view = SCHEMATIC_CANVAS (widget);
-
-  if (zoom) {
-    /*! \todo Change "HOTKEY" TO new "MOUSE" specifier? */
-    a_zoom(w_current, SCHEMATIC_CANVAS (widget), zoom_direction, HOTKEY);
-  }
 
   if (pan_xaxis) {
     adj = schematic_canvas_get_hadjustment (SCHEMATIC_CANVAS (widget));

--- a/libleptongui/src/x_event.c
+++ b/libleptongui/src/x_event.c
@@ -343,12 +343,33 @@ x_event_scroll (GtkWidget *widget,
     /* Classic gschem behaviour */
     pan_yaxis = !schematic_window_get_control_key_pressed (w_current) &&
                  schematic_window_get_shift_key_pressed (w_current);
-    pan_xaxis =  schematic_window_get_control_key_pressed (w_current) &&
-                !schematic_window_get_shift_key_pressed (w_current);
   } else {
     /* GTK style behaviour */
     pan_yaxis = !schematic_window_get_control_key_pressed (w_current) &&
                 !schematic_window_get_shift_key_pressed (w_current);
+  }
+
+  /* If the user has a left/right scroll wheel, always scroll the y-axis */
+  if (event_has_direction &&
+      (direction == GDK_SCROLL_LEFT || direction == GDK_SCROLL_RIGHT))
+  {
+    pan_yaxis = FALSE;
+  }
+
+  /* You must have scrollbars enabled if you want to use the
+     scroll wheel to pan. */
+  if (!schematic_window_get_scrollbars_flag (w_current))
+  {
+    pan_yaxis = FALSE;
+  }
+
+  if (!gtk_scroll_wheel)
+  {
+    /* Classic gschem behaviour */
+    pan_xaxis =  schematic_window_get_control_key_pressed (w_current) &&
+                !schematic_window_get_shift_key_pressed (w_current);
+  } else {
+    /* GTK style behaviour */
     pan_xaxis = !schematic_window_get_control_key_pressed (w_current) &&
                  schematic_window_get_shift_key_pressed (w_current);
   }
@@ -357,8 +378,14 @@ x_event_scroll (GtkWidget *widget,
   if (event_has_direction &&
       (direction == GDK_SCROLL_LEFT || direction == GDK_SCROLL_RIGHT))
   {
-    pan_yaxis = FALSE;
     pan_xaxis = TRUE;
+  }
+
+  /* You must have scrollbars enabled if you want to use the
+     scroll wheel to pan. */
+  if (!schematic_window_get_scrollbars_flag (w_current))
+  {
+    pan_xaxis = FALSE;
   }
 
 #ifdef ENABLE_GTK3
@@ -396,14 +423,6 @@ x_event_scroll (GtkWidget *widget,
     pan_direction =  1;
     zoom_direction = ZOOM_OUT;
     break;
-  }
-
-  /* You must have scrollbars enabled if you want to use the
-     scroll wheel to pan. */
-  if (!schematic_window_get_scrollbars_flag (w_current))
-  {
-    pan_xaxis = FALSE;
-    pan_yaxis = FALSE;
   }
 
   if (zoom) {

--- a/libleptongui/src/x_event.c
+++ b/libleptongui/src/x_event.c
@@ -319,6 +319,7 @@ schematic_event_get_scroll_direction (GdkEventScroll *event)
  *  \param [in] direction
  *  \param [in] event_has_direction
  *  \param [in] zoom
+ *  \param [in] pan_yaxis
  */
 gint
 x_event_scroll (GtkWidget *widget,
@@ -327,41 +328,16 @@ x_event_scroll (GtkWidget *widget,
                 gboolean gtk_scroll_wheel,
                 GdkScrollDirection direction,
                 gboolean event_has_direction,
-                gboolean zoom)
+                gboolean zoom,
+                gboolean pan_yaxis)
 {
   GtkAdjustment *adj;
   gboolean pan_xaxis = FALSE;
-  gboolean pan_yaxis = FALSE;
   int pan_direction = 1;
   int zoom_direction = ZOOM_IN;
   SchematicCanvas *view = NULL;
 
   view = SCHEMATIC_CANVAS (widget);
-
-  if (!gtk_scroll_wheel)
-  {
-    /* Classic gschem behaviour */
-    pan_yaxis = !schematic_window_get_control_key_pressed (w_current) &&
-                 schematic_window_get_shift_key_pressed (w_current);
-  } else {
-    /* GTK style behaviour */
-    pan_yaxis = !schematic_window_get_control_key_pressed (w_current) &&
-                !schematic_window_get_shift_key_pressed (w_current);
-  }
-
-  /* If the user has a left/right scroll wheel, always scroll the y-axis */
-  if (event_has_direction &&
-      (direction == GDK_SCROLL_LEFT || direction == GDK_SCROLL_RIGHT))
-  {
-    pan_yaxis = FALSE;
-  }
-
-  /* You must have scrollbars enabled if you want to use the
-     scroll wheel to pan. */
-  if (!schematic_window_get_scrollbars_flag (w_current))
-  {
-    pan_yaxis = FALSE;
-  }
 
   if (!gtk_scroll_wheel)
   {

--- a/libleptongui/src/x_event.c
+++ b/libleptongui/src/x_event.c
@@ -323,39 +323,6 @@ schematic_event_set_last_scroll_event_time (guint val)
 }
 
 
-/*! \todo Finish function documentation!!!
- *  \brief
- *  \par Function Description
- *
- *  \param [in] widget The SchematicCanvas with the scroll event.
- *  \param [in] w_current
- *  \param [in] zoom
- *  \param [in] pan_yaxis
- *  \param [in] pan_xaxis
- */
-gint
-x_event_scroll (GtkWidget *widget,
-                SchematicWindow *w_current,
-                gboolean zoom,
-                gboolean pan_xaxis,
-                gboolean pan_yaxis)
-{
-  SchematicCanvas *view = NULL;
-
-  view = SCHEMATIC_CANVAS (widget);
-
-  if (schematic_window_get_undo_panzoom (w_current) &&
-      (zoom || pan_xaxis || pan_yaxis))
-  {
-    o_undo_savestate_viewport (w_current);
-  }
-
-  x_event_faked_motion (view, NULL);
-  /* Stop further processing of this signal */
-  return TRUE;
-}
-
-
 /*! \brief get the pointer position of a given SchematicWindow
  *  \par Function Description
  *  This function gets the pointer position of the drawing area of the

--- a/libleptongui/src/x_event.c
+++ b/libleptongui/src/x_event.c
@@ -333,6 +333,7 @@ schematic_event_set_last_scroll_event_time (guint val)
  *  \param [in] zoom
  *  \param [in] pan_yaxis
  *  \param [in] pan_xaxis
+ *  \param [in] pan_direction
  *  \param [in] y_delta
  */
 gint
@@ -342,10 +343,10 @@ x_event_scroll (GtkWidget *widget,
                 gboolean zoom,
                 gboolean pan_xaxis,
                 gboolean pan_yaxis,
+                int pan_direction,
                 double y_delta)
 {
   GtkAdjustment *adj;
-  int pan_direction = 1;
   int zoom_direction = ZOOM_IN;
   SchematicCanvas *view = NULL;
 
@@ -357,19 +358,16 @@ x_event_scroll (GtkWidget *widget,
     /* event->delta_x seems to be unused on not touch devices. */
     if (y_delta != 0)
     {
-      pan_direction = y_delta;
       zoom_direction = (y_delta > 0) ? ZOOM_OUT : ZOOM_IN;
     }
     break;
 #endif
   case GDK_SCROLL_UP:
   case GDK_SCROLL_LEFT:
-    pan_direction = -1;
     zoom_direction = ZOOM_IN;
     break;
   case GDK_SCROLL_DOWN:
   case GDK_SCROLL_RIGHT:
-    pan_direction =  1;
     zoom_direction = ZOOM_OUT;
     break;
   }

--- a/libleptongui/src/x_event.c
+++ b/libleptongui/src/x_event.c
@@ -307,11 +307,13 @@ x_event_key (SchematicCanvas *page_view,
  *  \param [in] widget The SchematicCanvas with the scroll event.
  *  \param [in] event
  *  \param [in] w_current
+ *  \param [in] gtk_scroll_wheel
  */
 gint
 x_event_scroll (GtkWidget *widget,
                 GdkEventScroll *event,
-                SchematicWindow *w_current)
+                SchematicWindow *w_current,
+                gboolean gtk_scroll_wheel)
 {
   GtkAdjustment *adj;
   gboolean pan_xaxis = FALSE;
@@ -323,7 +325,7 @@ x_event_scroll (GtkWidget *widget,
 
   view = SCHEMATIC_CANVAS (widget);
 
-  if (schematic_window_get_scroll_wheel (w_current) == SCROLL_WHEEL_CLASSIC)
+  if (!gtk_scroll_wheel)
   {
     /* Classic gschem behaviour */
     zoom =      !schematic_window_get_control_key_pressed (w_current) &&

--- a/libleptongui/src/x_event.c
+++ b/libleptongui/src/x_event.c
@@ -351,18 +351,6 @@ x_event_scroll (GtkWidget *widget,
 
   view = SCHEMATIC_CANVAS (widget);
 
-#ifdef ENABLE_GTK3
-  /* check for duplicate legacy scroll event, see GNOME bug 726878 */
-  if (direction != GDK_SCROLL_SMOOTH &&
-      schematic_event_get_last_scroll_event_time () == gdk_event_get_time ((GdkEvent*) event))
-  {
-    g_debug ("[%d] duplicate legacy scroll event %d\n",
-             gdk_event_get_time ((GdkEvent*) event),
-             direction);
-    return FALSE;
-  }
-#endif
-
   switch (event->direction) {
 #ifdef ENABLE_GTK3
   case GDK_SCROLL_SMOOTH:

--- a/libleptongui/src/x_event.c
+++ b/libleptongui/src/x_event.c
@@ -340,33 +340,30 @@ x_event_scroll (GtkWidget *widget,
                 gboolean zoom,
                 gboolean pan_xaxis,
                 gboolean pan_yaxis,
-                int pan_direction)
+                int pan_direction,
+                GtkAdjustment *horiz_adj,
+                GtkAdjustment *vert_adj)
 {
-  GtkAdjustment *adj;
   SchematicCanvas *view = NULL;
 
   view = SCHEMATIC_CANVAS (widget);
 
   if (pan_xaxis) {
-    adj = schematic_canvas_get_hadjustment (SCHEMATIC_CANVAS (widget));
-    g_return_val_if_fail (adj != NULL, TRUE);
-    gtk_adjustment_set_value (adj,
-                              MIN (gtk_adjustment_get_value (adj) + pan_direction *
-                                   (gtk_adjustment_get_page_increment (adj) /
+    gtk_adjustment_set_value (horiz_adj,
+                              MIN (gtk_adjustment_get_value (horiz_adj) + pan_direction *
+                                   (gtk_adjustment_get_page_increment (horiz_adj) /
                                     schematic_window_get_scrollpan_steps (w_current)),
-                                   gtk_adjustment_get_upper (adj) -
-                                   gtk_adjustment_get_page_size (adj)));
+                                   gtk_adjustment_get_upper (horiz_adj) -
+                                   gtk_adjustment_get_page_size (horiz_adj)));
   }
 
   if (pan_yaxis) {
-    adj = schematic_canvas_get_vadjustment (SCHEMATIC_CANVAS (widget));
-    g_return_val_if_fail (adj != NULL, TRUE);
-    gtk_adjustment_set_value (adj,
-                              MIN (gtk_adjustment_get_value (adj) + pan_direction *
-                                   (gtk_adjustment_get_page_increment (adj) /
+    gtk_adjustment_set_value (vert_adj,
+                              MIN (gtk_adjustment_get_value (vert_adj) + pan_direction *
+                                   (gtk_adjustment_get_page_increment (vert_adj) /
                                     schematic_window_get_scrollpan_steps (w_current)),
-                                   gtk_adjustment_get_upper (adj) -
-                                   gtk_adjustment_get_page_size (adj)));
+                                   gtk_adjustment_get_upper (vert_adj) -
+                                   gtk_adjustment_get_page_size (vert_adj)));
   }
 
   if (schematic_window_get_undo_panzoom (w_current) &&

--- a/libleptongui/src/x_event.c
+++ b/libleptongui/src/x_event.c
@@ -322,8 +322,6 @@ x_event_scroll (GtkWidget *widget,
   SchematicCanvas *view = NULL;
   LeptonPage *page = NULL;
 
-  g_return_val_if_fail ((w_current != NULL), 0);
-
   view = SCHEMATIC_CANVAS (widget);
   g_return_val_if_fail ((view != NULL), 0);
 

--- a/libleptongui/src/x_event.c
+++ b/libleptongui/src/x_event.c
@@ -308,21 +308,6 @@ schematic_event_get_scroll_direction (GdkEventScroll *event)
 }
 
 
-static guint last_scroll_event_time = GDK_CURRENT_TIME;
-
-guint
-schematic_event_get_last_scroll_event_time ()
-{
-  return last_scroll_event_time;
-}
-
-void
-schematic_event_set_last_scroll_event_time (guint val)
-{
-  last_scroll_event_time = val;
-}
-
-
 /*! \brief get the pointer position of a given SchematicWindow
  *  \par Function Description
  *  This function gets the pointer position of the drawing area of the

--- a/libleptongui/src/x_event.c
+++ b/libleptongui/src/x_event.c
@@ -315,54 +315,26 @@ schematic_event_get_scroll_direction (GdkEventScroll *event)
  *  \param [in] widget The SchematicCanvas with the scroll event.
  *  \param [in] event
  *  \param [in] w_current
- *  \param [in] gtk_scroll_wheel
  *  \param [in] direction
- *  \param [in] event_has_direction
  *  \param [in] zoom
  *  \param [in] pan_yaxis
+ *  \param [in] pan_xaxis
  */
 gint
 x_event_scroll (GtkWidget *widget,
                 GdkEventScroll *event,
                 SchematicWindow *w_current,
-                gboolean gtk_scroll_wheel,
                 GdkScrollDirection direction,
-                gboolean event_has_direction,
                 gboolean zoom,
+                gboolean pan_xaxis,
                 gboolean pan_yaxis)
 {
   GtkAdjustment *adj;
-  gboolean pan_xaxis = FALSE;
   int pan_direction = 1;
   int zoom_direction = ZOOM_IN;
   SchematicCanvas *view = NULL;
 
   view = SCHEMATIC_CANVAS (widget);
-
-  if (!gtk_scroll_wheel)
-  {
-    /* Classic gschem behaviour */
-    pan_xaxis =  schematic_window_get_control_key_pressed (w_current) &&
-                !schematic_window_get_shift_key_pressed (w_current);
-  } else {
-    /* GTK style behaviour */
-    pan_xaxis = !schematic_window_get_control_key_pressed (w_current) &&
-                 schematic_window_get_shift_key_pressed (w_current);
-  }
-
-  /* If the user has a left/right scroll wheel, always scroll the y-axis */
-  if (event_has_direction &&
-      (direction == GDK_SCROLL_LEFT || direction == GDK_SCROLL_RIGHT))
-  {
-    pan_xaxis = TRUE;
-  }
-
-  /* You must have scrollbars enabled if you want to use the
-     scroll wheel to pan. */
-  if (!schematic_window_get_scrollbars_flag (w_current))
-  {
-    pan_xaxis = FALSE;
-  }
 
 #ifdef ENABLE_GTK3
   static guint last_scroll_event_time = GDK_CURRENT_TIME;

--- a/libleptongui/src/x_event.c
+++ b/libleptongui/src/x_event.c
@@ -330,7 +330,6 @@ schematic_event_set_last_scroll_event_time (guint val)
  *  \param [in] widget The SchematicCanvas with the scroll event.
  *  \param [in] event
  *  \param [in] w_current
- *  \param [in] direction
  *  \param [in] zoom
  *  \param [in] pan_yaxis
  *  \param [in] pan_xaxis
@@ -340,7 +339,6 @@ gint
 x_event_scroll (GtkWidget *widget,
                 GdkEventScroll *event,
                 SchematicWindow *w_current,
-                GdkScrollDirection direction,
                 gboolean zoom,
                 gboolean pan_xaxis,
                 gboolean pan_yaxis,

--- a/libleptongui/src/x_event.c
+++ b/libleptongui/src/x_event.c
@@ -368,8 +368,10 @@ x_event_scroll (GtkWidget *widget,
              event->direction);
     return FALSE;
   }
+#endif
 
   switch (event->direction) {
+#ifdef ENABLE_GTK3
   case GDK_SCROLL_SMOOTH:
     /* As of GTK 3.4, all directional scroll events are provided by */
     /* the GDK_SCROLL_SMOOTH direction on XInput2 and Wayland devices. */
@@ -379,6 +381,7 @@ x_event_scroll (GtkWidget *widget,
     pan_direction = event->delta_y;
     zoom_direction = (event->delta_y > 0) ? ZOOM_OUT : ZOOM_IN;
     break;
+#endif
   case GDK_SCROLL_UP:
   case GDK_SCROLL_LEFT:
     pan_direction = -1;
@@ -390,20 +393,6 @@ x_event_scroll (GtkWidget *widget,
     zoom_direction = ZOOM_OUT;
     break;
   }
-#else
-  switch (event->direction) {
-    case GDK_SCROLL_UP:
-    case GDK_SCROLL_LEFT:
-      pan_direction = -1;
-      zoom_direction = ZOOM_IN;
-      break;
-    case GDK_SCROLL_DOWN:
-    case GDK_SCROLL_RIGHT:
-      pan_direction =  1;
-      zoom_direction = ZOOM_OUT;
-      break;
-  }
-#endif
 
   if (zoom) {
     /*! \todo Change "HOTKEY" TO new "MOUSE" specifier? */

--- a/libleptongui/src/x_event.c
+++ b/libleptongui/src/x_event.c
@@ -318,6 +318,7 @@ schematic_event_get_scroll_direction (GdkEventScroll *event)
  *  \param [in] gtk_scroll_wheel
  *  \param [in] direction
  *  \param [in] event_has_direction
+ *  \param [in] zoom
  */
 gint
 x_event_scroll (GtkWidget *widget,
@@ -325,37 +326,17 @@ x_event_scroll (GtkWidget *widget,
                 SchematicWindow *w_current,
                 gboolean gtk_scroll_wheel,
                 GdkScrollDirection direction,
-                gboolean event_has_direction)
+                gboolean event_has_direction,
+                gboolean zoom)
 {
   GtkAdjustment *adj;
   gboolean pan_xaxis = FALSE;
   gboolean pan_yaxis = FALSE;
-  gboolean zoom = FALSE;
   int pan_direction = 1;
   int zoom_direction = ZOOM_IN;
   SchematicCanvas *view = NULL;
 
   view = SCHEMATIC_CANVAS (widget);
-
-  if (!gtk_scroll_wheel)
-  {
-    /* Classic gschem behaviour. */
-    zoom =      !schematic_window_get_control_key_pressed (w_current) &&
-                !schematic_window_get_shift_key_pressed (w_current);
-  } else {
-    /* GTK style behaviour. */
-    zoom =       schematic_window_get_control_key_pressed (w_current) &&
-                !schematic_window_get_shift_key_pressed (w_current);
-  }
-
-  /* If the user has a left/right scroll wheel, always scroll the
-     y-axis. */
-  if (event_has_direction &&
-      (direction == GDK_SCROLL_LEFT || direction == GDK_SCROLL_RIGHT))
-  {
-    zoom = FALSE;
-  }
-
 
   if (!gtk_scroll_wheel)
   {

--- a/libleptongui/src/x_event.c
+++ b/libleptongui/src/x_event.c
@@ -299,6 +299,14 @@ x_event_key (SchematicCanvas *page_view,
   return pressed ? event : NULL;
 }
 
+/* Helper function for GTK2 port which doesn't have the getter for
+   event scroll direction. */
+GdkScrollDirection
+schematic_event_get_scroll_direction (GdkEventScroll *event)
+{
+  return event->direction;
+}
+
 
 /*! \todo Finish function documentation!!!
  *  \brief
@@ -308,12 +316,16 @@ x_event_key (SchematicCanvas *page_view,
  *  \param [in] event
  *  \param [in] w_current
  *  \param [in] gtk_scroll_wheel
+ *  \param [in] direction
+ *  \param [in] event_has_direction
  */
 gint
 x_event_scroll (GtkWidget *widget,
                 GdkEventScroll *event,
                 SchematicWindow *w_current,
-                gboolean gtk_scroll_wheel)
+                gboolean gtk_scroll_wheel,
+                GdkScrollDirection direction,
+                gboolean event_has_direction)
 {
   GtkAdjustment *adj;
   gboolean pan_xaxis = FALSE;
@@ -345,8 +357,9 @@ x_event_scroll (GtkWidget *widget,
   }
 
   /* If the user has a left/right scroll wheel, always scroll the y-axis */
-  if (event->direction == GDK_SCROLL_LEFT ||
-      event->direction == GDK_SCROLL_RIGHT) {
+  if (event_has_direction &&
+      (direction == GDK_SCROLL_LEFT || direction == GDK_SCROLL_RIGHT))
+  {
     zoom = FALSE;
     pan_yaxis = FALSE;
     pan_xaxis = TRUE;

--- a/libleptongui/src/x_event.c
+++ b/libleptongui/src/x_event.c
@@ -334,7 +334,7 @@ schematic_event_set_last_scroll_event_time (guint val)
  *  \param [in] pan_yaxis
  *  \param [in] pan_xaxis
  *  \param [in] pan_direction
- *  \param [in] y_delta
+ *  \param [in] zoom_direction
  */
 gint
 x_event_scroll (GtkWidget *widget,
@@ -344,33 +344,12 @@ x_event_scroll (GtkWidget *widget,
                 gboolean pan_xaxis,
                 gboolean pan_yaxis,
                 int pan_direction,
-                double y_delta)
+                int zoom_direction)
 {
   GtkAdjustment *adj;
-  int zoom_direction = ZOOM_IN;
   SchematicCanvas *view = NULL;
 
   view = SCHEMATIC_CANVAS (widget);
-
-  switch (event->direction) {
-#ifdef ENABLE_GTK3
-  case GDK_SCROLL_SMOOTH:
-    /* event->delta_x seems to be unused on not touch devices. */
-    if (y_delta != 0)
-    {
-      zoom_direction = (y_delta > 0) ? ZOOM_OUT : ZOOM_IN;
-    }
-    break;
-#endif
-  case GDK_SCROLL_UP:
-  case GDK_SCROLL_LEFT:
-    zoom_direction = ZOOM_IN;
-    break;
-  case GDK_SCROLL_DOWN:
-  case GDK_SCROLL_RIGHT:
-    zoom_direction = ZOOM_OUT;
-    break;
-  }
 
   if (zoom) {
     /*! \todo Change "HOTKEY" TO new "MOUSE" specifier? */

--- a/libleptongui/src/x_event.c
+++ b/libleptongui/src/x_event.c
@@ -339,17 +339,33 @@ x_event_scroll (GtkWidget *widget,
 
   if (!gtk_scroll_wheel)
   {
-    /* Classic gschem behaviour */
+    /* Classic gschem behaviour. */
     zoom =      !schematic_window_get_control_key_pressed (w_current) &&
                 !schematic_window_get_shift_key_pressed (w_current);
+  } else {
+    /* GTK style behaviour. */
+    zoom =       schematic_window_get_control_key_pressed (w_current) &&
+                !schematic_window_get_shift_key_pressed (w_current);
+  }
+
+  /* If the user has a left/right scroll wheel, always scroll the
+     y-axis. */
+  if (event_has_direction &&
+      (direction == GDK_SCROLL_LEFT || direction == GDK_SCROLL_RIGHT))
+  {
+    zoom = FALSE;
+  }
+
+
+  if (!gtk_scroll_wheel)
+  {
+    /* Classic gschem behaviour */
     pan_yaxis = !schematic_window_get_control_key_pressed (w_current) &&
                  schematic_window_get_shift_key_pressed (w_current);
     pan_xaxis =  schematic_window_get_control_key_pressed (w_current) &&
                 !schematic_window_get_shift_key_pressed (w_current);
   } else {
     /* GTK style behaviour */
-    zoom =       schematic_window_get_control_key_pressed (w_current) &&
-                !schematic_window_get_shift_key_pressed (w_current);
     pan_yaxis = !schematic_window_get_control_key_pressed (w_current) &&
                 !schematic_window_get_shift_key_pressed (w_current);
     pan_xaxis = !schematic_window_get_control_key_pressed (w_current) &&
@@ -360,7 +376,6 @@ x_event_scroll (GtkWidget *widget,
   if (event_has_direction &&
       (direction == GDK_SCROLL_LEFT || direction == GDK_SCROLL_RIGHT))
   {
-    zoom = FALSE;
     pan_yaxis = FALSE;
     pan_xaxis = TRUE;
   }

--- a/libleptongui/src/x_event.c
+++ b/libleptongui/src/x_event.c
@@ -323,8 +323,6 @@ x_event_scroll (GtkWidget *widget,
   LeptonPage *page = NULL;
 
   view = SCHEMATIC_CANVAS (widget);
-  g_return_val_if_fail ((view != NULL), 0);
-
   page = schematic_canvas_get_page (view);
 
   if (page == NULL) {

--- a/libleptongui/src/x_event.c
+++ b/libleptongui/src/x_event.c
@@ -339,12 +339,12 @@ x_event_scroll (GtkWidget *widget,
 #ifdef ENABLE_GTK3
   static guint last_scroll_event_time = GDK_CURRENT_TIME;
   /* check for duplicate legacy scroll event, see GNOME bug 726878 */
-  if (event->direction != GDK_SCROLL_SMOOTH &&
+  if (direction != GDK_SCROLL_SMOOTH &&
       last_scroll_event_time == gdk_event_get_time ((GdkEvent*) event))
   {
     g_debug ("[%d] duplicate legacy scroll event %d\n",
              gdk_event_get_time ((GdkEvent*) event),
-             event->direction);
+             direction);
     return FALSE;
   }
 #endif

--- a/libleptongui/src/x_event.c
+++ b/libleptongui/src/x_event.c
@@ -350,13 +350,6 @@ x_event_scroll (GtkWidget *widget,
     pan_xaxis = TRUE;
   }
 
-  /* You must have scrollbars enabled if you want to use the scroll wheel to pan */
-  if (!schematic_window_get_scrollbars_flag (w_current))
-  {
-    pan_xaxis = FALSE;
-    pan_yaxis = FALSE;
-  }
-
 #ifdef ENABLE_GTK3
   static guint last_scroll_event_time = GDK_CURRENT_TIME;
   /* check for duplicate legacy scroll event, see GNOME bug 726878 */
@@ -392,6 +385,14 @@ x_event_scroll (GtkWidget *widget,
     pan_direction =  1;
     zoom_direction = ZOOM_OUT;
     break;
+  }
+
+  /* You must have scrollbars enabled if you want to use the
+     scroll wheel to pan. */
+  if (!schematic_window_get_scrollbars_flag (w_current))
+  {
+    pan_xaxis = FALSE;
+    pan_yaxis = FALSE;
   }
 
   if (zoom) {

--- a/libleptongui/src/x_event.c
+++ b/libleptongui/src/x_event.c
@@ -334,6 +334,7 @@ schematic_event_set_last_scroll_event_time (guint val)
  *  \param [in] zoom
  *  \param [in] pan_yaxis
  *  \param [in] pan_xaxis
+ *  \param [in] y_delta
  */
 gint
 x_event_scroll (GtkWidget *widget,
@@ -342,7 +343,8 @@ x_event_scroll (GtkWidget *widget,
                 GdkScrollDirection direction,
                 gboolean zoom,
                 gboolean pan_xaxis,
-                gboolean pan_yaxis)
+                gboolean pan_yaxis,
+                double y_delta)
 {
   GtkAdjustment *adj;
   int pan_direction = 1;
@@ -359,8 +361,7 @@ x_event_scroll (GtkWidget *widget,
     schematic_event_set_last_scroll_event_time (gdk_event_get_time ((GdkEvent*) event));
 
     /* event->delta_x seems to be unused on not touch devices. */
-    double x_delta, y_delta;
-    if (gdk_event_get_scroll_deltas ((GdkEvent*) event, &x_delta, &y_delta))
+    if (y_delta != 0)
     {
       pan_direction = y_delta;
       zoom_direction = (y_delta > 0) ? ZOOM_OUT : ZOOM_IN;

--- a/libleptongui/src/x_event.c
+++ b/libleptongui/src/x_event.c
@@ -320,14 +320,8 @@ x_event_scroll (GtkWidget *widget,
   int pan_direction = 1;
   int zoom_direction = ZOOM_IN;
   SchematicCanvas *view = NULL;
-  LeptonPage *page = NULL;
 
   view = SCHEMATIC_CANVAS (widget);
-  page = schematic_canvas_get_page (view);
-
-  if (page == NULL) {
-    return FALSE; /* we cannot zoom page if it doesn't exist :) */
-  }
 
   /* update the state of the modifiers */
   schematic_window_set_shift_key_pressed (w_current, (event->state & GDK_SHIFT_MASK) ? 1 : 0);

--- a/libleptongui/src/x_event.c
+++ b/libleptongui/src/x_event.c
@@ -308,6 +308,21 @@ schematic_event_get_scroll_direction (GdkEventScroll *event)
 }
 
 
+static guint last_scroll_event_time = GDK_CURRENT_TIME;
+
+guint
+schematic_event_get_last_scroll_event_time ()
+{
+  return last_scroll_event_time;
+}
+
+void
+schematic_event_set_last_scroll_event_time (guint val)
+{
+  last_scroll_event_time = val;
+}
+
+
 /*! \todo Finish function documentation!!!
  *  \brief
  *  \par Function Description
@@ -337,10 +352,9 @@ x_event_scroll (GtkWidget *widget,
   view = SCHEMATIC_CANVAS (widget);
 
 #ifdef ENABLE_GTK3
-  static guint last_scroll_event_time = GDK_CURRENT_TIME;
   /* check for duplicate legacy scroll event, see GNOME bug 726878 */
   if (direction != GDK_SCROLL_SMOOTH &&
-      last_scroll_event_time == gdk_event_get_time ((GdkEvent*) event))
+      schematic_event_get_last_scroll_event_time () == gdk_event_get_time ((GdkEvent*) event))
   {
     g_debug ("[%d] duplicate legacy scroll event %d\n",
              gdk_event_get_time ((GdkEvent*) event),
@@ -354,7 +368,7 @@ x_event_scroll (GtkWidget *widget,
   case GDK_SCROLL_SMOOTH:
     /* As of GTK 3.4, all directional scroll events are provided by */
     /* the GDK_SCROLL_SMOOTH direction on XInput2 and Wayland devices. */
-    last_scroll_event_time = gdk_event_get_time ((GdkEvent*) event);
+    schematic_event_set_last_scroll_event_time (gdk_event_get_time ((GdkEvent*) event));
 
     /* event->delta_x seems to be unused on not touch devices. */
     pan_direction = event->delta_y;

--- a/libleptongui/src/x_event.c
+++ b/libleptongui/src/x_event.c
@@ -332,39 +332,17 @@ schematic_event_set_last_scroll_event_time (guint val)
  *  \param [in] zoom
  *  \param [in] pan_yaxis
  *  \param [in] pan_xaxis
- *  \param [in] pan_direction
  */
 gint
 x_event_scroll (GtkWidget *widget,
                 SchematicWindow *w_current,
                 gboolean zoom,
                 gboolean pan_xaxis,
-                gboolean pan_yaxis,
-                int pan_direction,
-                GtkAdjustment *horiz_adj,
-                GtkAdjustment *vert_adj)
+                gboolean pan_yaxis)
 {
   SchematicCanvas *view = NULL;
 
   view = SCHEMATIC_CANVAS (widget);
-
-  if (pan_xaxis) {
-    gtk_adjustment_set_value (horiz_adj,
-                              MIN (gtk_adjustment_get_value (horiz_adj) + pan_direction *
-                                   (gtk_adjustment_get_page_increment (horiz_adj) /
-                                    schematic_window_get_scrollpan_steps (w_current)),
-                                   gtk_adjustment_get_upper (horiz_adj) -
-                                   gtk_adjustment_get_page_size (horiz_adj)));
-  }
-
-  if (pan_yaxis) {
-    gtk_adjustment_set_value (vert_adj,
-                              MIN (gtk_adjustment_get_value (vert_adj) + pan_direction *
-                                   (gtk_adjustment_get_page_increment (vert_adj) /
-                                    schematic_window_get_scrollpan_steps (w_current)),
-                                   gtk_adjustment_get_upper (vert_adj) -
-                                   gtk_adjustment_get_page_size (vert_adj)));
-  }
 
   if (schematic_window_get_undo_panzoom (w_current) &&
       (zoom || pan_xaxis || pan_yaxis))

--- a/libleptongui/src/x_event.c
+++ b/libleptongui/src/x_event.c
@@ -354,10 +354,6 @@ x_event_scroll (GtkWidget *widget,
   switch (event->direction) {
 #ifdef ENABLE_GTK3
   case GDK_SCROLL_SMOOTH:
-    /* As of GTK 3.4, all directional scroll events are provided by */
-    /* the GDK_SCROLL_SMOOTH direction on XInput2 and Wayland devices. */
-    schematic_event_set_last_scroll_event_time (gdk_event_get_time ((GdkEvent*) event));
-
     /* event->delta_x seems to be unused on not touch devices. */
     if (y_delta != 0)
     {

--- a/libleptongui/src/x_event.c
+++ b/libleptongui/src/x_event.c
@@ -371,8 +371,12 @@ x_event_scroll (GtkWidget *widget,
     schematic_event_set_last_scroll_event_time (gdk_event_get_time ((GdkEvent*) event));
 
     /* event->delta_x seems to be unused on not touch devices. */
-    pan_direction = event->delta_y;
-    zoom_direction = (event->delta_y > 0) ? ZOOM_OUT : ZOOM_IN;
+    double x_delta, y_delta;
+    if (gdk_event_get_scroll_deltas ((GdkEvent*) event, &x_delta, &y_delta))
+    {
+      pan_direction = y_delta;
+      zoom_direction = (y_delta > 0) ? ZOOM_OUT : ZOOM_IN;
+    }
     break;
 #endif
   case GDK_SCROLL_UP:


### PR DESCRIPTION
- A new module, `(schematic event)`, has been added.  It contains
  helper functions handling GTK events.
- The type `GdkModifierType` is now exported in `(schematic ffi
  gtk)` to facilitate programming.
- The type of `SchematicWindow`'s field `scrollbars_flag` has been
  changed to boolean as there are only two states for scrollbars:
  they are either present or missing.
- A new Scheme function, `event-direction()`, has been introduced.
  Its aim is to be a proxy for different event functions used in
  GTK2 and GTK3 for this purpose.
- Helpers converting `GdkScrollDirection` values from/to strings
  have been added.
- The C scroll event processing function `x_event_scroll()` has
  been rewritten in Scheme.
- A smooth event zooming bug has been fixed in the GTK3 port.
  Previously, any first smooth zoom event was always considered a
  'zoom in' one because for smooth events, the second event is
  needed to calculate deltas.  This has been fixed by omitting the
  first zoom event as it is done for panning.
