### PR TITLE
gui: Fix cue rendering in the GTK3 port

### DIFF
--- a/libleptongui/src/x_image.c
+++ b/libleptongui/src/x_image.c
@@ -923,6 +923,12 @@ x_image_get_pixbuf (SchematicWindow *w_current,
       eda_renderer_draw (renderer, o_current);
     }
   }
+  for (iter = obj_list;
+       iter != NULL;
+       iter = g_list_next (iter))
+  {
+    eda_renderer_draw_cues (renderer, (LeptonObject *) iter->data);
+  }
 
   g_list_free (obj_list);
   g_object_unref (G_OBJECT (renderer));


### PR DESCRIPTION
GTK3 port of the suite has separate and new code for rendering PNG, JPEG, and other images, and when it was introduced, I missed support for net cue rendering.  This commit fixes the bug.

Closes #1089