### PR TITLE
Rewrite the function schematic_autonumber_new() in Scheme

### DIFF
--- a/lepton-eda/scheme/lepton/ffi/glib.scm
+++ b/lepton-eda/scheme/lepton/ffi/glib.scm
@@ -1,5 +1,5 @@
 ;;; Lepton EDA library - Scheme API
-;;; Copyright (C) 2020-2022 Lepton EDA Contributors
+;;; Copyright (C) 2020-2025 Lepton EDA Contributors
 ;;;
 ;;; This program is free software; you can redistribute it and/or modify
 ;;; it under the terms of the GNU General Public License as published by
@@ -30,6 +30,7 @@
             g_list_remove
             g_list_remove_all
             g_log
+            g_strdup
 
             ;; Mock glib functions.
 
@@ -60,6 +61,8 @@
 (define-lff g_list_remove_all '* '(* *))
 
 (define-lff g_log void (list '* int '* '*))
+
+(define-lff g_strdup '* '(*))
 
 (define-lff g_slist_free_full void '(*))
 

--- a/lepton-eda/scheme/schematic/dialog/autonumber.scm
+++ b/lepton-eda/scheme/schematic/dialog/autonumber.scm
@@ -97,6 +97,14 @@
    *autotext
    (schematic_autonumber_sort_order_from_string (string->pointer "sort-diagonal")))
 
+  (schematic_autonumber_set_autotext_scope_skip
+   *autotext
+   (schematic_autonumber_scope_from_string (string->pointer "scope-page")))
+  (schematic_autonumber_set_autotext_scope_number
+   *autotext
+   (schematic_autonumber_scope_from_string (string->pointer "scope-selected")))
+  (schematic_autonumber_set_autotext_scope_overwrite *autotext
+                                                     FALSE)
   (schematic_autonumber_set_autotext_startnum *autotext 1)
   (schematic_autonumber_set_autotext_removenum *autotext FALSE)
   (schematic_autonumber_set_autotext_slotting *autotext FALSE)

--- a/lepton-eda/scheme/schematic/dialog/autonumber.scm
+++ b/lepton-eda/scheme/schematic/dialog/autonumber.scm
@@ -21,6 +21,7 @@
   #:use-module (system foreign)
 
   #:use-module (lepton ffi boolean)
+  #:use-module (lepton ffi glib)
 
   #:use-module (schematic ffi gtk)
   #:use-module (schematic ffi)
@@ -91,7 +92,36 @@
 
 ;;; Create a structure for storing autonumber dialog state.
 (define (make-autonumber-dialog-state)
+  ;; Default contents of the combo box history.
+  (define default-text-ls
+    '("refdes=*"
+      "refdes=C?"
+      "refdes=D?"
+      "refdes=I?"
+      "refdes=L?"
+      "refdes=Q?"
+      "refdes=R?"
+      "refdes=T?"
+      "refdes=U?"
+      "refdes=X?"
+      "netname=*"
+      "netname=A?"
+      "netname=D?"))
+
   (define *autotext (schematic_autonumber_new))
+
+  (schematic_autonumber_set_autotext_scope_text *autotext %null-pointer)
+
+  (let loop ((ls default-text-ls))
+    (let ((*scope-text-ls
+           (schematic_autonumber_get_autotext_scope_text *autotext)))
+      (unless (null? ls)
+        (schematic_autonumber_set_autotext_scope_text
+         *autotext
+         (schematic_autonumber_append_scope_text_element
+          *scope-text-ls
+          (string->pointer (car ls))))
+        (loop (cdr ls)))))
 
   (schematic_autonumber_set_autotext_sort_order
    *autotext

--- a/lepton-eda/scheme/schematic/dialog/autonumber.scm
+++ b/lepton-eda/scheme/schematic/dialog/autonumber.scm
@@ -112,18 +112,16 @@
 
   (schematic_autonumber_set_autotext_scope_text *autotext %null-pointer)
 
-  (let loop ((ls default-text-ls))
-    (let ((*scope-text-ls
-           (schematic_autonumber_get_autotext_scope_text *autotext)))
-      (unless (null? ls)
-        (schematic_autonumber_set_autotext_scope_text
-         *autotext
-         (g_list_append *scope-text-ls
-                        ;; Call for g_strdup() is necessary as
-                        ;; after a while, the pointer created in
-                        ;; Scheme will be garbage-collected.
-                        (g_strdup (string->pointer (car ls)))))
-        (loop (cdr ls)))))
+  (let loop ((ls default-text-ls)
+             (*gls %null-pointer))
+    (if (null? ls)
+        (schematic_autonumber_set_autotext_scope_text *autotext *gls)
+        (loop (cdr ls)
+              (g_list_append *gls
+                             ;; Call for g_strdup() is necessary as
+                             ;; after a while, the pointer created in
+                             ;; Scheme will be garbage-collected.
+                             (g_strdup (string->pointer (car ls)))))))
 
   (schematic_autonumber_set_autotext_sort_order
    *autotext

--- a/lepton-eda/scheme/schematic/dialog/autonumber.scm
+++ b/lepton-eda/scheme/schematic/dialog/autonumber.scm
@@ -88,6 +88,12 @@
 
 (define %gtk-response-accept (symbol->gtk-response 'accept))
 
+
+;;; Create a structure for storing autonumber dialog state.
+(define (make-autonumber-dialog-state)
+  (schematic_autonumber_new))
+
+
 (define (autonumber-dialog window)
   "Opens autonumber dialog in WINDOW."
   (define *window (check-window window 1))
@@ -95,7 +101,7 @@
     (let ((*current-autotext (schematic_autonumber_get_autotext)))
       (if (null-pointer? *current-autotext)
           ;; If 'autotext' structure is NULL, let's init it.
-          (let ((*new-autotext (schematic_autonumber_new)))
+          (let ((*new-autotext (make-autonumber-dialog-state)))
             (schematic_autonumber_set_autotext *new-autotext)
             *new-autotext)
           *current-autotext)))

--- a/lepton-eda/scheme/schematic/dialog/autonumber.scm
+++ b/lepton-eda/scheme/schematic/dialog/autonumber.scm
@@ -118,9 +118,11 @@
       (unless (null? ls)
         (schematic_autonumber_set_autotext_scope_text
          *autotext
-         (schematic_autonumber_append_scope_text_element
-          *scope-text-ls
-          (string->pointer (car ls))))
+         (g_list_append *scope-text-ls
+                        ;; Call for g_strdup() is necessary as
+                        ;; after a while, the pointer created in
+                        ;; Scheme will be garbage-collected.
+                        (g_strdup (string->pointer (car ls)))))
         (loop (cdr ls)))))
 
   (schematic_autonumber_set_autotext_sort_order

--- a/lepton-eda/scheme/schematic/dialog/autonumber.scm
+++ b/lepton-eda/scheme/schematic/dialog/autonumber.scm
@@ -93,6 +93,10 @@
 (define (make-autonumber-dialog-state)
   (define *autotext (schematic_autonumber_new))
 
+  (schematic_autonumber_set_autotext_sort_order
+   *autotext
+   (schematic_autonumber_sort_order_from_string (string->pointer "sort-diagonal")))
+
   (schematic_autonumber_set_autotext_startnum *autotext 1)
   (schematic_autonumber_set_autotext_removenum *autotext FALSE)
   (schematic_autonumber_set_autotext_slotting *autotext FALSE)

--- a/lepton-eda/scheme/schematic/dialog/autonumber.scm
+++ b/lepton-eda/scheme/schematic/dialog/autonumber.scm
@@ -91,8 +91,14 @@
 
 ;;; Create a structure for storing autonumber dialog state.
 (define (make-autonumber-dialog-state)
-  (schematic_autonumber_new))
+  (define *autotext (schematic_autonumber_new))
 
+  (schematic_autonumber_set_autotext_startnum *autotext 1)
+  (schematic_autonumber_set_autotext_removenum *autotext FALSE)
+  (schematic_autonumber_set_autotext_slotting *autotext FALSE)
+  (schematic_autonumber_set_autotext_dialog *autotext %null-pointer)
+
+  *autotext)
 
 (define (autonumber-dialog window)
   "Opens autonumber dialog in WINDOW."

--- a/lepton-eda/scheme/schematic/ffi.scm
+++ b/lepton-eda/scheme/schematic/ffi.scm
@@ -185,8 +185,11 @@
             schematic_autonumber_get_autotext_dialog
             schematic_autonumber_set_autotext_dialog
             schematic_autonumber_get_autotext_removenum
+            schematic_autonumber_set_autotext_removenum
             schematic_autonumber_get_autotext_scope_overwrite
             schematic_autonumber_set_autotext_scope_overwrite
+            schematic_autonumber_set_autotext_slotting
+            schematic_autonumber_set_autotext_startnum
             schematic_autonumber_set_autotext_window
             schematic_autonumber_dialog_lookup_widget
             schematic_autonumber_dialog_new
@@ -1098,8 +1101,11 @@
 (define-lff schematic_autonumber_get_autotext_dialog '* '(*))
 (define-lff schematic_autonumber_set_autotext_dialog void '(* *))
 (define-lff schematic_autonumber_get_autotext_removenum int '(*))
+(define-lff schematic_autonumber_set_autotext_removenum void (list '* int))
 (define-lff schematic_autonumber_get_autotext_scope_overwrite int '(*))
 (define-lff schematic_autonumber_set_autotext_scope_overwrite void (list '* int))
+(define-lff schematic_autonumber_set_autotext_slotting void (list '* int))
+(define-lff schematic_autonumber_set_autotext_startnum void (list '* int))
 (define-lff schematic_autonumber_set_autotext_window void '(* *))
 (define-lff schematic_autonumber_dialog_lookup_widget '* '(* *))
 (define-lff schematic_autonumber_dialog_new '* '(*))

--- a/lepton-eda/scheme/schematic/ffi.scm
+++ b/lepton-eda/scheme/schematic/ffi.scm
@@ -190,11 +190,13 @@
             schematic_autonumber_get_autotext_scope_overwrite
             schematic_autonumber_set_autotext_scope_overwrite
             schematic_autonumber_set_autotext_scope_skip
+            schematic_autonumber_get_autotext_scope_text
             schematic_autonumber_set_autotext_scope_text
             schematic_autonumber_set_autotext_slotting
             schematic_autonumber_set_autotext_sort_order
             schematic_autonumber_set_autotext_startnum
             schematic_autonumber_set_autotext_window
+            schematic_autonumber_append_scope_text_element
             schematic_autonumber_dialog_lookup_widget
             schematic_autonumber_dialog_new
             schematic_autonumber_dialog_restore_state
@@ -1112,11 +1114,13 @@
 (define-lff schematic_autonumber_get_autotext_scope_overwrite int '(*))
 (define-lff schematic_autonumber_set_autotext_scope_overwrite void (list '* int))
 (define-lff schematic_autonumber_set_autotext_scope_skip void (list '* int))
+(define-lff schematic_autonumber_get_autotext_scope_text '* '(*))
 (define-lff schematic_autonumber_set_autotext_scope_text void '(* *))
 (define-lff schematic_autonumber_set_autotext_slotting void (list '* int))
 (define-lff schematic_autonumber_set_autotext_sort_order void (list '* int))
 (define-lff schematic_autonumber_set_autotext_startnum void (list '* int))
 (define-lff schematic_autonumber_set_autotext_window void '(* *))
+(define-lff schematic_autonumber_append_scope_text_element '* '(* *))
 (define-lff schematic_autonumber_dialog_lookup_widget '* '(* *))
 (define-lff schematic_autonumber_dialog_new '* '(*))
 (define-lff schematic_autonumber_dialog_restore_state void '(*))

--- a/lepton-eda/scheme/schematic/ffi.scm
+++ b/lepton-eda/scheme/schematic/ffi.scm
@@ -189,6 +189,7 @@
             schematic_autonumber_get_autotext_scope_overwrite
             schematic_autonumber_set_autotext_scope_overwrite
             schematic_autonumber_set_autotext_slotting
+            schematic_autonumber_set_autotext_sort_order
             schematic_autonumber_set_autotext_startnum
             schematic_autonumber_set_autotext_window
             schematic_autonumber_dialog_lookup_widget
@@ -196,6 +197,7 @@
             schematic_autonumber_dialog_restore_state
             schematic_autonumber_dialog_save_state
             schematic_autonumber_run
+            schematic_autonumber_sort_order_from_string
             schematic_autonumber_sort_order_widget_init
 
             x_clipboard_finish
@@ -1105,6 +1107,7 @@
 (define-lff schematic_autonumber_get_autotext_scope_overwrite int '(*))
 (define-lff schematic_autonumber_set_autotext_scope_overwrite void (list '* int))
 (define-lff schematic_autonumber_set_autotext_slotting void (list '* int))
+(define-lff schematic_autonumber_set_autotext_sort_order void (list '* int))
 (define-lff schematic_autonumber_set_autotext_startnum void (list '* int))
 (define-lff schematic_autonumber_set_autotext_window void '(* *))
 (define-lff schematic_autonumber_dialog_lookup_widget '* '(* *))
@@ -1112,6 +1115,7 @@
 (define-lff schematic_autonumber_dialog_restore_state void '(*))
 (define-lff schematic_autonumber_dialog_save_state void '(*))
 (define-lff schematic_autonumber_run void '(*))
+(define-lff schematic_autonumber_sort_order_from_string int '(*))
 (define-lff schematic_autonumber_sort_order_widget_init void '(*))
 
 ;;; x_clipboard.c

--- a/lepton-eda/scheme/schematic/ffi.scm
+++ b/lepton-eda/scheme/schematic/ffi.scm
@@ -196,7 +196,6 @@
             schematic_autonumber_set_autotext_sort_order
             schematic_autonumber_set_autotext_startnum
             schematic_autonumber_set_autotext_window
-            schematic_autonumber_append_scope_text_element
             schematic_autonumber_dialog_lookup_widget
             schematic_autonumber_dialog_new
             schematic_autonumber_dialog_restore_state
@@ -1120,7 +1119,6 @@
 (define-lff schematic_autonumber_set_autotext_sort_order void (list '* int))
 (define-lff schematic_autonumber_set_autotext_startnum void (list '* int))
 (define-lff schematic_autonumber_set_autotext_window void '(* *))
-(define-lff schematic_autonumber_append_scope_text_element '* '(* *))
 (define-lff schematic_autonumber_dialog_lookup_widget '* '(* *))
 (define-lff schematic_autonumber_dialog_new '* '(*))
 (define-lff schematic_autonumber_dialog_restore_state void '(*))

--- a/lepton-eda/scheme/schematic/ffi.scm
+++ b/lepton-eda/scheme/schematic/ffi.scm
@@ -186,8 +186,11 @@
             schematic_autonumber_set_autotext_dialog
             schematic_autonumber_get_autotext_removenum
             schematic_autonumber_set_autotext_removenum
+            schematic_autonumber_set_autotext_scope_number
             schematic_autonumber_get_autotext_scope_overwrite
             schematic_autonumber_set_autotext_scope_overwrite
+            schematic_autonumber_set_autotext_scope_skip
+            schematic_autonumber_set_autotext_scope_text
             schematic_autonumber_set_autotext_slotting
             schematic_autonumber_set_autotext_sort_order
             schematic_autonumber_set_autotext_startnum
@@ -197,6 +200,7 @@
             schematic_autonumber_dialog_restore_state
             schematic_autonumber_dialog_save_state
             schematic_autonumber_run
+            schematic_autonumber_scope_from_string
             schematic_autonumber_sort_order_from_string
             schematic_autonumber_sort_order_widget_init
 
@@ -1104,8 +1108,11 @@
 (define-lff schematic_autonumber_set_autotext_dialog void '(* *))
 (define-lff schematic_autonumber_get_autotext_removenum int '(*))
 (define-lff schematic_autonumber_set_autotext_removenum void (list '* int))
+(define-lff schematic_autonumber_set_autotext_scope_number void (list '* int))
 (define-lff schematic_autonumber_get_autotext_scope_overwrite int '(*))
 (define-lff schematic_autonumber_set_autotext_scope_overwrite void (list '* int))
+(define-lff schematic_autonumber_set_autotext_scope_skip void (list '* int))
+(define-lff schematic_autonumber_set_autotext_scope_text void '(* *))
 (define-lff schematic_autonumber_set_autotext_slotting void (list '* int))
 (define-lff schematic_autonumber_set_autotext_sort_order void (list '* int))
 (define-lff schematic_autonumber_set_autotext_startnum void (list '* int))
@@ -1115,6 +1122,7 @@
 (define-lff schematic_autonumber_dialog_restore_state void '(*))
 (define-lff schematic_autonumber_dialog_save_state void '(*))
 (define-lff schematic_autonumber_run void '(*))
+(define-lff schematic_autonumber_scope_from_string int '(*))
 (define-lff schematic_autonumber_sort_order_from_string int '(*))
 (define-lff schematic_autonumber_sort_order_widget_init void '(*))
 

--- a/libleptongui/include/autonumber_dialog.h
+++ b/libleptongui/include/autonumber_dialog.h
@@ -234,6 +234,9 @@ schematic_autonumber_dialog_save_state (SchematicAutonumber *autotext);
 void
 schematic_autonumber_run (SchematicAutonumber *autotext);
 
+const char*
+schematic_autonumber_scope_to_string (int scope);
+
 void
 schematic_autonumber_sort_order_widget_init (GtkWidget *sort_order);
 

--- a/libleptongui/include/autonumber_dialog.h
+++ b/libleptongui/include/autonumber_dialog.h
@@ -240,6 +240,9 @@ schematic_autonumber_scope_from_string (char *s);
 const char*
 schematic_autonumber_scope_to_string (int scope);
 
+const char*
+schematic_autonumber_sort_order_to_string (int sort_order);
+
 void
 schematic_autonumber_sort_order_widget_init (GtkWidget *sort_order);
 

--- a/libleptongui/include/autonumber_dialog.h
+++ b/libleptongui/include/autonumber_dialog.h
@@ -240,6 +240,9 @@ schematic_autonumber_scope_from_string (char *s);
 const char*
 schematic_autonumber_scope_to_string (int scope);
 
+int
+schematic_autonumber_sort_order_from_string (char *s);
+
 const char*
 schematic_autonumber_sort_order_to_string (int sort_order);
 

--- a/libleptongui/include/autonumber_dialog.h
+++ b/libleptongui/include/autonumber_dialog.h
@@ -234,6 +234,9 @@ schematic_autonumber_dialog_save_state (SchematicAutonumber *autotext);
 void
 schematic_autonumber_run (SchematicAutonumber *autotext);
 
+int
+schematic_autonumber_scope_from_string (char *s);
+
 const char*
 schematic_autonumber_scope_to_string (int scope);
 

--- a/libleptongui/include/autonumber_dialog.h
+++ b/libleptongui/include/autonumber_dialog.h
@@ -222,6 +222,9 @@ schematic_autonumber_slot_set_symbol_name (SchematicAutonumberSlot *slot,
                                            char *name);
 /* Methods */
 
+GList*
+schematic_autonumber_append_scope_text_element (GList *scope_text,
+                                                const gchar *text);
 GtkWidget*
 schematic_autonumber_dialog_lookup_widget (GtkWidget *widget,
                                            const gchar *widget_name);

--- a/libleptongui/include/autonumber_dialog.h
+++ b/libleptongui/include/autonumber_dialog.h
@@ -222,9 +222,6 @@ schematic_autonumber_slot_set_symbol_name (SchematicAutonumberSlot *slot,
                                            char *name);
 /* Methods */
 
-GList*
-schematic_autonumber_append_scope_text_element (GList *scope_text,
-                                                const gchar *text);
 GtkWidget*
 schematic_autonumber_dialog_lookup_widget (GtkWidget *widget,
                                            const gchar *widget_name);

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1707,13 +1707,6 @@ schematic_autonumber_new ()
                                                      FALSE);
   schematic_autonumber_set_autotext_sort_order (autotext,
                                                 AUTONUMBER_SORT_DIAGONAL);
-  schematic_autonumber_set_autotext_startnum (autotext, 1);
-
-  schematic_autonumber_set_autotext_removenum (autotext, FALSE);
-  schematic_autonumber_set_autotext_slotting (autotext, FALSE);
-
-  schematic_autonumber_set_autotext_dialog (autotext, NULL);
-
   return autotext;
 }
 

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1755,25 +1755,6 @@ GList *autonumber_history_add(GList *history, gchar *text)
 }
 
 
-/*! \brief Append a text element to a list.
- *
- *  \par Function Description
- *  Appends a new text element to the list of text elements
- *  displaying in the Autonumber dialog and returns the resulting
- *  list.
- *
- *  \param [in] scope_text The current list of text elements.
- *  \param [in] text The new text element to append.
- *  \return The resulting text element list.
- */
-GList*
-schematic_autonumber_append_scope_text_element (GList *scope_text,
-                                                const gchar *text)
-{
-  return g_list_append (scope_text, g_strdup (text));
-}
-
-
 /** @brief Create a new #SchematicAutonumber instance.
  *
  *  @par Function Description

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1808,8 +1808,6 @@ schematic_autonumber_new ()
                                                   SCOPE_SELECTED);
   schematic_autonumber_set_autotext_scope_overwrite (autotext,
                                                      FALSE);
-  schematic_autonumber_set_autotext_sort_order (autotext,
-                                                AUTONUMBER_SORT_DIAGONAL);
   return autotext;
 }
 

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1703,8 +1703,8 @@ schematic_autonumber_new ()
 
   schematic_autonumber_set_autotext_scope_skip (autotext,
                                                 SCOPE_PAGE);
-  autotext->scope_number = SCOPE_SELECTED;
-
+  schematic_autonumber_set_autotext_scope_number (autotext,
+                                                  SCOPE_SELECTED);
   autotext->scope_overwrite = FALSE;
   autotext->order = AUTONUMBER_SORT_DIAGONAL;
 

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1707,8 +1707,8 @@ schematic_autonumber_new ()
                                                   SCOPE_SELECTED);
   schematic_autonumber_set_autotext_scope_overwrite (autotext,
                                                      FALSE);
-  autotext->order = AUTONUMBER_SORT_DIAGONAL;
-
+  schematic_autonumber_set_autotext_sort_order (autotext,
+                                                AUTONUMBER_SORT_DIAGONAL);
   autotext->startnum=1;
 
   autotext->removenum = FALSE;

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1711,7 +1711,7 @@ schematic_autonumber_new ()
                                                 AUTONUMBER_SORT_DIAGONAL);
   schematic_autonumber_set_autotext_startnum (autotext, 1);
 
-  autotext->removenum = FALSE;
+  schematic_autonumber_set_autotext_removenum (autotext, FALSE);
   autotext->slotting = FALSE;
 
   autotext->dialog = NULL;

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1787,40 +1787,8 @@ SchematicAutonumber*
 schematic_autonumber_new ()
 {
   SchematicAutonumber *autotext;
-  GList *scope_text;
-
-  /* Default contents of the combo box history */
-  const gchar *default_text[] = {
-    "refdes=*",
-    "refdes=C?",
-    "refdes=D?",
-    "refdes=I?",
-    "refdes=L?",
-    "refdes=Q?",
-    "refdes=R?",
-    "refdes=T?",
-    "refdes=U?",
-    "refdes=X?",
-    "netname=*",
-    "netname=A?",
-    "netname=D?",
-    NULL
-  };
-  const gchar **t;
 
   autotext = g_new (SchematicAutonumber, 1);
-
-  schematic_autonumber_set_autotext_scope_text (autotext, NULL);
-
-  t = default_text;
-  while (*t != NULL) {
-    /* t is both an array address and the address of its first
-       element, it post-increments after we get its value. */
-    scope_text =
-      schematic_autonumber_get_autotext_scope_text (autotext);
-    schematic_autonumber_set_autotext_scope_text (autotext,
-                                                  schematic_autonumber_append_scope_text_element (scope_text, *t++));
-  }
 
   return autotext;
 }

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -649,6 +649,26 @@ schematic_autonumber_set_autotext_window (SchematicAutonumber *autotext,
 }
 
 
+/*! \brief Convert a string into an autonumbering scope enum value.
+ *
+ *  \par Function Description
+ *  Returns an integer autonumbering scope enum value
+ *  corresponding to the given string \p s.
+ *
+ *  \param [in] s The string.
+ */
+int
+schematic_autonumber_scope_from_string (char *s)
+{
+  int result = SCOPE_SELECTED;
+
+  if      (strcmp (s, "scope-selected") == 0) { result = SCOPE_SELECTED; }
+  else if (strcmp (s, "scope-page") == 0) { result = SCOPE_PAGE; }
+  else if (strcmp (s, "scope-hierarchy") == 0) { result = SCOPE_HIERARCHY; }
+
+  return result;
+}
+
 
 /*! \brief Convert an autonumbering scope enum value into a
  *  string.

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1774,23 +1774,17 @@ schematic_autonumber_append_scope_text_element (GList *scope_text,
 }
 
 
-/** @brief Create and initialize a new #SchematicAutonumber
- *  instance.
+/** @brief Create a new #SchematicAutonumber instance.
  *
  *  @par Function Description
- *  Creates a new #SchematicAutonumber instance and initializes it
- *  with default values.
+ *  Allocates and returns a new #SchematicAutonumber instance.
  *
  *  @return The new #SchematicAutonumber instance.
  */
 SchematicAutonumber*
 schematic_autonumber_new ()
 {
-  SchematicAutonumber *autotext;
-
-  autotext = g_new (SchematicAutonumber, 1);
-
-  return autotext;
+  return g_new (SchematicAutonumber, 1);
 }
 
 /** @brief Restore the Autonumber text dialog settings.

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1705,7 +1705,8 @@ schematic_autonumber_new ()
                                                 SCOPE_PAGE);
   schematic_autonumber_set_autotext_scope_number (autotext,
                                                   SCOPE_SELECTED);
-  autotext->scope_overwrite = FALSE;
+  schematic_autonumber_set_autotext_scope_overwrite (autotext,
+                                                     FALSE);
   autotext->order = AUTONUMBER_SORT_DIAGONAL;
 
   autotext->startnum=1;

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -697,6 +697,31 @@ schematic_autonumber_scope_to_string (int scope)
 }
 
 
+/*! \brief Convert a string into an autonumbering sort order enum
+ *  value.
+ *
+ *  \par Function Description
+ *  Returns an integer autonumbering sort order enum value
+ *  corresponding to the given string \p s.
+ *
+ *  \param [in] s The string.
+ */
+int
+schematic_autonumber_sort_order_from_string (char *s)
+{
+  int result = AUTONUMBER_SORT_DIAGONAL;
+
+  if      (strcmp (s, "sort-diagonal") == 0) { result = AUTONUMBER_SORT_DIAGONAL; }
+  else if (strcmp (s, "sort-yx") == 0) { result = AUTONUMBER_SORT_YX; }
+  else if (strcmp (s, "sort-yx-rev") == 0) { result = AUTONUMBER_SORT_YX_REV; }
+  else if (strcmp (s, "sort-xy") == 0) { result = AUTONUMBER_SORT_XY; }
+  else if (strcmp (s, "sort-xy-rev") == 0) { result = AUTONUMBER_SORT_XY_REV; }
+  else if (strcmp (s, "sort-file") == 0) { result = AUTONUMBER_SORT_FILE; }
+
+  return result;
+}
+
+
 /*! \brief Convert an autonumbering sort order enum value into a
  *  string.
  *

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1712,7 +1712,7 @@ schematic_autonumber_new ()
   schematic_autonumber_set_autotext_startnum (autotext, 1);
 
   schematic_autonumber_set_autotext_removenum (autotext, FALSE);
-  autotext->slotting = FALSE;
+  schematic_autonumber_set_autotext_slotting (autotext, FALSE);
 
   autotext->dialog = NULL;
 

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -697,6 +697,36 @@ schematic_autonumber_scope_to_string (int scope)
 }
 
 
+/*! \brief Convert an autonumbering sort order enum value into a
+ *  string.
+ *
+ *  \par Function Description
+ *  Returns a string corresponding to the given autonumbering sort
+ *  order enum value \p sort_order.
+ *
+ *  \param [in] sort_order The sort order integer value.
+ *  \return The string corresponding to the sort order.
+ */
+const char*
+schematic_autonumber_sort_order_to_string (int sort_order)
+{
+  const char *result = NULL;
+
+  switch (sort_order)
+  {
+  case AUTONUMBER_SORT_DIAGONAL: result = "sort-diagonal"; break;
+  case AUTONUMBER_SORT_YX: result = "sort-yx"; break;
+  case AUTONUMBER_SORT_YX_REV: result = "sort-yx-rev"; break;
+  case AUTONUMBER_SORT_XY: result = "sort-xy"; break;
+  case AUTONUMBER_SORT_XY_REV: result = "sort-xy-rev"; break;
+  case AUTONUMBER_SORT_FILE: result = "sort-file"; break;
+  default: break;
+  }
+
+  return result;
+}
+
+
 /* ***** BACK-END CODE ***************************************************** */
 
 /********** compare functions for g_list_sort, ... ***********************/

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1754,6 +1754,26 @@ GList *autonumber_history_add(GList *history, gchar *text)
   return history;
 }
 
+
+/*! \brief Append a text element to a list.
+ *
+ *  \par Function Description
+ *  Appends a new text element to the list of text elements
+ *  displaying in the Autonumber dialog and returns the resulting
+ *  list.
+ *
+ *  \param [in] scope_text The current list of text elements.
+ *  \param [in] text The new text element to append.
+ *  \return The resulting text element list.
+ */
+GList*
+schematic_autonumber_append_scope_text_element (GList *scope_text,
+                                                const gchar *text)
+{
+  return g_list_append (scope_text, g_strdup (text));
+}
+
+
 /** @brief Create and initialize a new #SchematicAutonumber
  *  instance.
  *
@@ -1799,7 +1819,7 @@ schematic_autonumber_new ()
     scope_text =
       schematic_autonumber_get_autotext_scope_text (autotext);
     schematic_autonumber_set_autotext_scope_text (autotext,
-                                                  g_list_append (scope_text, g_strdup (*t++)));
+                                                  schematic_autonumber_append_scope_text_element (scope_text, *t++));
   }
 
   return autotext;

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1701,7 +1701,8 @@ schematic_autonumber_new ()
                                                   g_list_append (scope_text, g_strdup (*t++)));
   }
 
-  autotext->scope_skip = SCOPE_PAGE;
+  schematic_autonumber_set_autotext_scope_skip (autotext,
+                                                SCOPE_PAGE);
   autotext->scope_number = SCOPE_SELECTED;
 
   autotext->scope_overwrite = FALSE;

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1687,8 +1687,6 @@ schematic_autonumber_new ()
 
   autotext = g_new (SchematicAutonumber, 1);
 
-  if(autotext==NULL) return NULL;
-
   schematic_autonumber_set_autotext_scope_text (autotext, NULL);
 
   t = default_text;

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1709,7 +1709,7 @@ schematic_autonumber_new ()
                                                      FALSE);
   schematic_autonumber_set_autotext_sort_order (autotext,
                                                 AUTONUMBER_SORT_DIAGONAL);
-  autotext->startnum=1;
+  schematic_autonumber_set_autotext_startnum (autotext, 1);
 
   autotext->removenum = FALSE;
   autotext->slotting = FALSE;

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1714,7 +1714,7 @@ schematic_autonumber_new ()
   schematic_autonumber_set_autotext_removenum (autotext, FALSE);
   schematic_autonumber_set_autotext_slotting (autotext, FALSE);
 
-  autotext->dialog = NULL;
+  schematic_autonumber_set_autotext_dialog (autotext, NULL);
 
   return autotext;
 }

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1802,12 +1802,6 @@ schematic_autonumber_new ()
                                                   g_list_append (scope_text, g_strdup (*t++)));
   }
 
-  schematic_autonumber_set_autotext_scope_skip (autotext,
-                                                SCOPE_PAGE);
-  schematic_autonumber_set_autotext_scope_number (autotext,
-                                                  SCOPE_SELECTED);
-  schematic_autonumber_set_autotext_scope_overwrite (autotext,
-                                                     FALSE);
   return autotext;
 }
 

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -649,6 +649,34 @@ schematic_autonumber_set_autotext_window (SchematicAutonumber *autotext,
 }
 
 
+
+/*! \brief Convert an autonumbering scope enum value into a
+ *  string.
+ *
+ *  \par Function Description
+ *  Returns a string corresponding to the given autonumbering
+ *  scope enum value.
+ *
+ *  \param [in] scope The scope integer value.
+ *  \return The string corresponding to the scope.
+ */
+const char*
+schematic_autonumber_scope_to_string (int scope)
+{
+  const char *result = NULL;
+
+  switch (scope)
+  {
+  case SCOPE_SELECTED: result = "scope-selected"; break;
+  case SCOPE_PAGE: result = "scope-page"; break;
+  case SCOPE_HIERARCHY: result = "scope-hierarchy"; break;
+  default: break;
+  }
+
+  return result;
+}
+
+
 /* ***** BACK-END CODE ***************************************************** */
 
 /********** compare functions for g_list_sort, ... ***********************/

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1664,6 +1664,7 @@ SchematicAutonumber*
 schematic_autonumber_new ()
 {
   SchematicAutonumber *autotext;
+  GList *scope_text;
 
   /* Default contents of the combo box history */
   const gchar *default_text[] = {
@@ -1688,12 +1689,16 @@ schematic_autonumber_new ()
 
   if(autotext==NULL) return NULL;
 
-  autotext->scope_text = NULL;
+  schematic_autonumber_set_autotext_scope_text (autotext, NULL);
+
   t = default_text;
   while (*t != NULL) {
     /* t is both an array address and the address of its first
        element, it post-increments after we get its value. */
-    autotext->scope_text=g_list_append (autotext->scope_text, g_strdup (*t++));
+    scope_text =
+      schematic_autonumber_get_autotext_scope_text (autotext);
+    schematic_autonumber_set_autotext_scope_text (autotext,
+                                                  g_list_append (scope_text, g_strdup (*t++)));
   }
 
   autotext->scope_skip = SCOPE_PAGE;


### PR DESCRIPTION
The function `schematic_autonumber_new()` has been rewritten in
Scheme.  To achieve this, a few helper functions have been added:
the helpers transform strings into autonumber sort order enum
values or autonumber scope enum values and vice versa.