### PR TITLE
Fix two bugs in the callbacks processing mouse button events

### DIFF
--- a/lepton-eda/scheme/schematic/window.scm
+++ b/lepton-eda/scheme/schematic/window.scm
@@ -352,7 +352,11 @@ zooming."
         (if (null-pointer? *page)
             ;; If there is no page, terminate event.
             TRUE
-            (process-func *canvas *event *window)))))
+            ;; Some underlying functions have to know what window
+            ;; they operate on.  Set the current window explicitly
+            ;; as it is not defined for C GLib callbacks.
+            (with-window *window
+              (process-func *canvas *event *window))))))
 
 
 (define (callback-button-released *canvas *event *window)

--- a/lepton-eda/scheme/schematic/window.scm
+++ b/lepton-eda/scheme/schematic/window.scm
@@ -693,8 +693,9 @@ zooming."
       (window-save-modifiers *window *event)
 
       (if (true? (schematic_event_get_doing_stroke))
-          (begin
-            (x_stroke_record *window window-x window-y)
+          (let ((int-x (inexact->exact (round window-x)))
+                (int-y (inexact->exact (round window-y))))
+            (x_stroke_record *window int-x int-y)
             FALSE)
           (if (true? (schematic_event_skip_motion_event *event))
               FALSE

--- a/lepton-eda/scheme/schematic/window.scm
+++ b/lepton-eda/scheme/schematic/window.scm
@@ -344,6 +344,17 @@ zooming."
   (set-action-mode! 'select-mode #:window window))
 
 
+(define-syntax-rule (process-canvas-event *canvas *event *window process-func)
+  (if (or (null-pointer? *window)
+          (null-pointer? *canvas))
+      (error "NULL page view or window.")
+      (let ((*page (schematic_canvas_get_page *canvas)))
+        (if (null-pointer? *page)
+            ;; If there is no page, terminate event.
+            TRUE
+            (process-func *canvas *event *window)))))
+
+
 (define (callback-button-released *canvas *event *window)
   (define window (pointer->window *window))
   (define current-action-mode (action-mode window))
@@ -451,14 +462,7 @@ zooming."
 
         FALSE)))
 
-  (if (or (null-pointer? *window)
-          (null-pointer? *canvas))
-      (error "NULL page view or window.")
-      (let ((*page (schematic_canvas_get_page *canvas)))
-        (if (null-pointer? *page)
-            ;; If there is no page, terminate event.
-            TRUE
-            (process-event *canvas *event *window)))))
+  (process-canvas-event *canvas *event *window process-event))
 
 (define *callback-button-released
   (procedure->pointer int callback-button-released '(* * *)))
@@ -666,14 +670,7 @@ zooming."
 
                 (_ FALSE)))))))
 
-  (if (or (null-pointer? *window)
-          (null-pointer? *canvas))
-      (error "NULL page view or window.")
-      (let ((*page (schematic_canvas_get_page *canvas)))
-        (if (null-pointer? *page)
-            ;; If there is no page, terminate event.
-            TRUE
-            (process-event *canvas *event *window)))))
+  (process-canvas-event *canvas *event *window process-event))
 
 (define *callback-button-pressed
   (procedure->pointer int callback-button-pressed '(* * *)))
@@ -754,14 +751,7 @@ zooming."
 
                     FALSE)))))))
 
-  (if (or (null-pointer? *window)
-          (null-pointer? *canvas))
-      (error "NULL page view or window.")
-      (let ((*page (schematic_canvas_get_page *canvas)))
-        (if (null-pointer? *page)
-            ;; If there is no page, terminate event.
-            TRUE
-            (process-event *canvas *event *window)))))
+  (process-canvas-event *canvas *event *window process-event))
 
 (define *callback-motion
   (procedure->pointer int callback-motion '(* * *)))

--- a/lepton-eda/scheme/schematic/window.scm
+++ b/lepton-eda/scheme/schematic/window.scm
@@ -392,21 +392,21 @@ zooming."
                        (eq? current-action-mode 'copy-mode)
                        (eq? current-action-mode 'multiple-copy-mode)
                        (eq? current-action-mode 'paste-mode))
-                 (if (eq? current-action-mode 'move-mode)
-                     (o_move_invalidate_rubber *window FALSE)
-                     (o_place_invalidate_rubber *window FALSE))
-                 (schematic_window_set_rubber_visible *window 0)
+               (if (eq? current-action-mode 'move-mode)
+                   (o_move_invalidate_rubber *window FALSE)
+                   (o_place_invalidate_rubber *window FALSE))
+               (schematic_window_set_rubber_visible *window 0)
 
-                 (o_place_rotate *window)
+               (o_place_rotate *window)
 
-                 (when (eq? current-action-mode 'component-mode)
-                   (o_component_place_changed_run_hook *window))
+               (when (eq? current-action-mode 'component-mode)
+                 (o_component_place_changed_run_hook *window))
 
-                 (if (eq? current-action-mode 'move-mode)
-                     (o_move_invalidate_rubber *window TRUE)
-                     (o_place_invalidate_rubber *window TRUE))
+               (if (eq? current-action-mode 'move-mode)
+                   (o_move_invalidate_rubber *window TRUE)
+                   (o_place_invalidate_rubber *window TRUE))
 
-                 (schematic_window_set_rubber_visible *window 1)))
+               (schematic_window_set_rubber_visible *window 1)))
            (unless (and (in-action? window)
                         (or (eq? current-action-mode 'component-mode)
                             (eq? current-action-mode 'text-mode)
@@ -434,7 +434,7 @@ zooming."
                      (let ((str (pointer->string *str)))
                        (g_free *str)
                        (with-window *window
-                                    (eval-stroke str)))))
+                         (eval-stroke str)))))
                  FALSE)
 
                 ((= middle-button MOUSEBTN_DO_PAN)


### PR DESCRIPTION
- A syntax rule has been added to process mouse button events on
  canvas the same way.
- Mouse button callbacks crashes have been fixed.  The crashes
  happened since the current window fluid was undefined in the
  callback scope.
- Crashes in the mouse stroke processing code due to absent
  double-to-int coordinate conversion have been fixed as well.
  The issue emerged after rewriting the stroke processing code in
  Scheme.  To trigger it, the config key
  `schematic.gui::middle-button` has to be set to `stroke`.

Closes #1100
