### PR TITLE
Start refactoring Lepton RC system in Scheme

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -389,6 +389,9 @@ Notable changes in Lepton EDA 1.9.19 (upcoming)
     current editing state: it returns `#t` if editing an object is
     in action and `#f` otherwise.
 
+- A new module, `(schematic rc)`, has been added for dealing with
+  `lepton-schematic` specific RC files.
+
 ### Changes in `lepton-schematic`:
 
 - Porting the program to the stable GTK version 3.24 has been

--- a/lepton-eda/scheme/Makefile.am
+++ b/lepton-eda/scheme/Makefile.am
@@ -166,6 +166,7 @@ nobase_dist_scmdata_DATA = \
 	schematic/pcb.scm \
 	schematic/precompile.scm \
 	schematic/preview-widget.scm \
+	schematic/rc.scm \
 	schematic/refdes.scm \
 	schematic/repl.scm \
 	schematic/selection.scm \

--- a/lepton-eda/scheme/lepton/ffi.scm
+++ b/lepton-eda/scheme/lepton/ffi.scm
@@ -304,8 +304,8 @@
             set_render_placeholders
             lepton_color_get_color_count
             lepton_color_default_id
-            g_rc_parse
             g_rc_parse_handler
+            g_rc_parse__process_error
             lepton_colormap_color_by_id
             lepton_colormap_disable_color
             lepton_colormap_set_color
@@ -425,8 +425,8 @@
 (define-lff lepton_toplevel_search_page '* '(* *))
 
 ;;; g_rc.c
-(define-lff g_rc_parse void '(* * * *))
 (define-lff g_rc_parse_handler void '(* * * * *))
+(define-lff g_rc_parse__process_error void '(* *))
 
 ;;; s_attrib.c
 (define-lff s_attrib_init void '())

--- a/lepton-eda/scheme/lepton/ffi.scm
+++ b/lepton-eda/scheme/lepton/ffi.scm
@@ -305,6 +305,7 @@
             lepton_color_get_color_count
             lepton_color_default_id
             g_rc_parse
+            g_rc_parse_handler
             lepton_colormap_color_by_id
             lepton_colormap_disable_color
             lepton_colormap_set_color
@@ -425,6 +426,7 @@
 
 ;;; g_rc.c
 (define-lff g_rc_parse void '(* * * *))
+(define-lff g_rc_parse_handler void '(* * * * *))
 
 ;;; s_attrib.c
 (define-lff s_attrib_init void '())

--- a/lepton-eda/scheme/lepton/ffi.scm
+++ b/lepton-eda/scheme/lepton/ffi.scm
@@ -304,8 +304,12 @@
             set_render_placeholders
             lepton_color_get_color_count
             lepton_color_default_id
-            g_rc_parse_handler
+            g_rc_load_cache_config
             g_rc_parse__process_error
+            g_rc_parse_file
+            g_rc_parse_local
+            g_rc_parse_system
+            g_rc_parse_user
             lepton_colormap_color_by_id
             lepton_colormap_disable_color
             lepton_colormap_set_color
@@ -425,8 +429,12 @@
 (define-lff lepton_toplevel_search_page '* '(* *))
 
 ;;; g_rc.c
-(define-lff g_rc_parse_handler void '(* * * * *))
 (define-lff g_rc_parse__process_error void '(* *))
+(define-lff g_rc_load_cache_config int '(* *))
+(define-lff g_rc_parse_system int '(* * *))
+(define-lff g_rc_parse_user int '(* * *))
+(define-lff g_rc_parse_file int '(* * * *))
+(define-lff g_rc_parse_local int '(* * * *))
 
 ;;; s_attrib.c
 (define-lff s_attrib_init void '())

--- a/lepton-eda/scheme/lepton/ffi.scm
+++ b/lepton-eda/scheme/lepton/ffi.scm
@@ -308,7 +308,6 @@
             g_rc_parse__process_error
             g_rc_parse_file
             g_rc_parse_local
-            g_rc_parse_system
             g_rc_parse_user
             lepton_colormap_color_by_id
             lepton_colormap_disable_color
@@ -431,7 +430,6 @@
 ;;; g_rc.c
 (define-lff g_rc_parse__process_error void '(* *))
 (define-lff g_rc_load_cache_config int '(* *))
-(define-lff g_rc_parse_system int '(* * *))
 (define-lff g_rc_parse_user int '(* * *))
 (define-lff g_rc_parse_file int '(* * * *))
 (define-lff g_rc_parse_local int '(* * * *))

--- a/lepton-eda/scheme/lepton/rc.scm
+++ b/lepton-eda/scheme/lepton/rc.scm
@@ -89,7 +89,7 @@ path (rather than the regular Scheme load path)."
 ;;;
 ;;; If an error occurs, the function calls HANDLER with the
 ;;; provided *USER_DATA and a GError.
-(define (parse-rc-handler *rcname *rcfile *handler *user-data *toplevel)
+(define (parse-rc-handler *rcname *handler *user-data *toplevel)
   (define handler (pointer->procedure void *handler '(* *)))
   (define (handler-dispatch *error)
     (unless (or (null-pointer? *error)
@@ -137,7 +137,6 @@ path (rather than the regular Scheme load path)."
 RC-NAME should be a basename of RC file, such as, for example,
 \"gafrc\"."
   (parse-rc-handler (string->pointer rc-name)
-                    %null-pointer       ; rc-file
                     (procedure->pointer void g_rc_parse__process_error '(* *))
                     (string->pointer program-name)
                     (toplevel->pointer (current-toplevel))))

--- a/lepton-eda/scheme/lepton/rc.scm
+++ b/lepton-eda/scheme/lepton/rc.scm
@@ -1,6 +1,6 @@
 ;;; Lepton EDA library - Scheme API
 ;;; Copyright (C) 2007-2016 gEDA Contributors
-;;; Copyright (C) 2017-2022 Lepton EDA Contributors
+;;; Copyright (C) 2017-2025 Lepton EDA Contributors
 ;;;
 ;;; This program is free software; you can redistribute it and/or modify
 ;;; it under the terms of the GNU General Public License as published by
@@ -76,14 +76,27 @@ path (rather than the regular Scheme load path)."
     (if rc-file (primitive-load rc-file))))
 
 
+;;; General RC file parsing function.
+;;;
+;;; Calls the default error handler. If any error other than
+;;; ENOENT occurs while loading or running a Scheme initialisation
+;;; file, prints an informative message and calls exit(1).
+;;;
+;;; \bug liblepton shouldn't call exit() - this function calls
+;;;      g_rc_parse__process_error(), which does.
+;;;
+;;; \warning Since this function may not return, it should only be
+;;; used on application startup or when there is no chance of data
+;;; loss from an unexpected exit().
 (define (parse-rc program-name rc-name)
   "Parses RC file RC-NAME in the namespace of PROGRAM-NAME.
 RC-NAME should be a basename of RC file, such as, for example,
 \"gafrc\"."
-  (g_rc_parse (toplevel->pointer (current-toplevel))
-              (string->pointer program-name)
-              (string->pointer rc-name)
-              %null-pointer))
+  (g_rc_parse_handler (toplevel->pointer (current-toplevel))
+                      (string->pointer rc-name)
+                      %null-pointer
+                      (procedure->pointer void g_rc_parse__process_error '(* *))
+                      (string->pointer program-name)))
 
 
 ;;; List of processed rc directories.

--- a/lepton-eda/scheme/lepton/rc.scm
+++ b/lepton-eda/scheme/lepton/rc.scm
@@ -118,15 +118,7 @@ path (rather than the regular Scheme load path)."
       (g_rc_parse_user *toplevel *rcname *error)
       (handler-dispatch *error)
       (g_rc_parse_local *toplevel *rcname %null-pointer *error)
-      (handler-dispatch *error))
-    ;; Finally, optional additional RC file.  Specifically use the
-    ;; current working directory's configuration context here, no
-    ;; matter where the rc file is located on disk.
-    (unless (null-pointer? *rcfile)
-      (let ((*cwd-cfg (eda_config_get_context_for_path (string->pointer "."))))
-        (g_rc_parse_file *toplevel *rcfile *cwd-cfg *error)
-        (handler-dispatch *error)))))
-
+      (handler-dispatch *error))))
 
 ;;; General RC file parsing function.
 ;;;

--- a/lepton-eda/scheme/lepton/rc.scm
+++ b/lepton-eda/scheme/lepton/rc.scm
@@ -78,6 +78,20 @@ path (rather than the regular Scheme load path)."
 
 ;;; General RC file parsing function.
 ;;;
+;;; Attempt to load and run system, user and local (current
+;;; working directory) Scheme initialisation files in *TOPLEVEL,
+;;; first with the default "gafrc" basename and then with the
+;;; basename *RCNAME, if it is NULL.  Additionally, attempt to
+;;; load and run *RCFILE if it is not NULL.
+;;;
+;;; If an error occurs, the function calls HANDLER with the
+;;; provided *USER_DATA and a GError.
+(define (parse-rc-handler *rcname *rcfile handler *user-data *toplevel)
+  (g_rc_parse_handler *toplevel *rcname *rcfile handler *user-data))
+
+
+;;; General RC file parsing function.
+;;;
 ;;; Calls the default error handler. If any error other than
 ;;; ENOENT occurs while loading or running a Scheme initialisation
 ;;; file, prints an informative message and calls exit(1).
@@ -92,11 +106,11 @@ path (rather than the regular Scheme load path)."
   "Parses RC file RC-NAME in the namespace of PROGRAM-NAME.
 RC-NAME should be a basename of RC file, such as, for example,
 \"gafrc\"."
-  (g_rc_parse_handler (toplevel->pointer (current-toplevel))
-                      (string->pointer rc-name)
-                      %null-pointer
-                      (procedure->pointer void g_rc_parse__process_error '(* *))
-                      (string->pointer program-name)))
+  (parse-rc-handler (string->pointer rc-name)
+                    %null-pointer       ; rc-file
+                    (procedure->pointer void g_rc_parse__process_error '(* *))
+                    (string->pointer program-name)
+                    (toplevel->pointer (current-toplevel))))
 
 
 ;;; List of processed rc directories.

--- a/lepton-eda/scheme/lepton/rc.scm
+++ b/lepton-eda/scheme/lepton/rc.scm
@@ -38,6 +38,7 @@
             load-scheme-dir
             load-rc-from-sys-config-dirs
             parse-rc
+            parse-rc-handler
             process-gafrc))
 
 (define path-sep file-name-separator-string)

--- a/lepton-eda/scheme/schematic/builtins.scm
+++ b/lepton-eda/scheme/schematic/builtins.scm
@@ -55,6 +55,7 @@
   #:use-module (schematic gui keymap)
   #:use-module (schematic hook)
   #:use-module (schematic menu)
+  #:use-module (schematic rc)
   #:use-module (schematic repl)
   #:use-module (schematic selection)
   #:use-module (schematic undo)

--- a/lepton-eda/scheme/schematic/ffi.scm
+++ b/lepton-eda/scheme/schematic/ffi.scm
@@ -576,7 +576,6 @@
 
             g_action_eval_by_name
 
-            parse-gschemrc
             x_rc_parse_gschem_error
             ))
 
@@ -1273,21 +1272,3 @@
     (and (force func)
          (let ((proc (delay (pointer->procedure void (force func) (list '* int int)))))
            ((force proc) *window x y)))))
-
-
-(define toplevel-initialized? #f)
-
-(define (parse-gschemrc toplevel)
-  "Loads old (system, user, etc.) \"gschemrc\" files and new
-configuration \".conf\" files.  Saves the values in the foreign
-LeptonToplevel structure TOPLEVEL and returns it.  Instead of
-exiting on error as CLI tools do, displays error dialogs with
-explanatory messages."
-  (unless toplevel-initialized?
-    (g_rc_parse_handler toplevel
-                        (string->pointer "gschemrc")
-                        %null-pointer
-                        (procedure->pointer void x_rc_parse_gschem_error '(* *))
-                        toplevel)
-    (set! toplevel-initialized? #t))
-  toplevel)

--- a/lepton-eda/scheme/schematic/ffi.scm
+++ b/lepton-eda/scheme/schematic/ffi.scm
@@ -577,6 +577,7 @@
             g_action_eval_by_name
 
             parse-gschemrc
+            x_rc_parse_gschem_error
             ))
 
 (define libleptongui
@@ -896,7 +897,7 @@
 (define-lff schematic_window_create_main_popup_menu '* '(*))
 
 ;;; x_rc.c
-(define-lff x_rc_parse_gschem void '(*))
+(define-lff x_rc_parse_gschem_error void '(* *))
 
 ;;; x_window.c
 (define-lff x_window_new '* '(*))
@@ -1274,10 +1275,19 @@
            ((force proc) *window x y)))))
 
 
+(define toplevel-initialized? #f)
+
 (define (parse-gschemrc toplevel)
   "Loads old (system, user, etc.) \"gschemrc\" files and new
-configuration \".conf\" files in a newly created toplevel
-environment.  Saves the values in the foreign LeptonToplevel
-structure TOPLEVEL and returns it."
-  (x_rc_parse_gschem toplevel)
+configuration \".conf\" files.  Saves the values in the foreign
+LeptonToplevel structure TOPLEVEL and returns it.  Instead of
+exiting on error as CLI tools do, displays error dialogs with
+explanatory messages."
+  (unless toplevel-initialized?
+    (g_rc_parse_handler toplevel
+                        (string->pointer "gschemrc")
+                        %null-pointer
+                        (procedure->pointer void x_rc_parse_gschem_error '(* *))
+                        toplevel)
+    (set! toplevel-initialized? #t))
   toplevel)

--- a/lepton-eda/scheme/schematic/rc.scm
+++ b/lepton-eda/scheme/schematic/rc.scm
@@ -38,7 +38,7 @@ explanatory messages."
     (parse-rc-handler (string->pointer "gschemrc")
                       %null-pointer
                       (procedure->pointer void x_rc_parse_gschem_error '(* *))
-                      *toplevel
+                      (string->pointer "lepton-schematic")
                       *toplevel)
     (set! toplevel-initialized? #t))
   *toplevel)

--- a/lepton-eda/scheme/schematic/rc.scm
+++ b/lepton-eda/scheme/schematic/rc.scm
@@ -35,9 +35,9 @@ LeptonToplevel structure *TOPLEVEL and returns it.  Instead of
 exiting on error as CLI tools do, displays error dialogs with
 explanatory messages."
   (unless toplevel-initialized?
-    (parse-rc-handler (string->pointer "gschemrc")
-                      (procedure->pointer void x_rc_parse_gschem_error '(* *))
-                      (string->pointer "lepton-schematic")
-                      *toplevel)
+    (parse-rc "lepton-schematic"
+              "gschemrc"
+              #:handler x_rc_parse_gschem_error
+              #:*toplevel *toplevel)
     (set! toplevel-initialized? #t))
   *toplevel)

--- a/lepton-eda/scheme/schematic/rc.scm
+++ b/lepton-eda/scheme/schematic/rc.scm
@@ -19,7 +19,7 @@
 (define-module (schematic rc)
   #:use-module (system foreign)
 
-  #:use-module (lepton ffi)
+  #:use-module (lepton rc)
 
   #:use-module (schematic ffi)
 
@@ -35,10 +35,10 @@ LeptonToplevel structure *TOPLEVEL and returns it.  Instead of
 exiting on error as CLI tools do, displays error dialogs with
 explanatory messages."
   (unless toplevel-initialized?
-    (g_rc_parse_handler *toplevel
-                        (string->pointer "gschemrc")
-                        %null-pointer
-                        (procedure->pointer void x_rc_parse_gschem_error '(* *))
-                        *toplevel)
+    (parse-rc-handler (string->pointer "gschemrc")
+                      %null-pointer
+                      (procedure->pointer void x_rc_parse_gschem_error '(* *))
+                      *toplevel
+                      *toplevel)
     (set! toplevel-initialized? #t))
   *toplevel)

--- a/lepton-eda/scheme/schematic/rc.scm
+++ b/lepton-eda/scheme/schematic/rc.scm
@@ -1,0 +1,44 @@
+;;; Lepton EDA Schematic Capture
+;;; Scheme API
+;;; Copyright (C) 2021-2025 Lepton EDA Contributors
+;;;
+;;; This program is free software; you can redistribute it and/or modify
+;;; it under the terms of the GNU General Public License as published by
+;;; the Free Software Foundation; either version 2 of the License, or
+;;; (at your option) any later version.
+;;;
+;;; This program is distributed in the hope that it will be useful,
+;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;; GNU General Public License for more details.
+;;;
+;;; You should have received a copy of the GNU General Public License
+;;; along with this program; if not, write to the Free Software
+;;; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+(define-module (schematic rc)
+  #:use-module (system foreign)
+
+  #:use-module (lepton ffi)
+
+  #:use-module (schematic ffi)
+
+  #:export (parse-gschemrc))
+
+
+(define toplevel-initialized? #f)
+
+(define (parse-gschemrc toplevel)
+  "Loads old (system, user, etc.) \"gschemrc\" files and new
+configuration \".conf\" files.  Saves the values in the foreign
+LeptonToplevel structure TOPLEVEL and returns it.  Instead of
+exiting on error as CLI tools do, displays error dialogs with
+explanatory messages."
+  (unless toplevel-initialized?
+    (g_rc_parse_handler toplevel
+                        (string->pointer "gschemrc")
+                        %null-pointer
+                        (procedure->pointer void x_rc_parse_gschem_error '(* *))
+                        toplevel)
+    (set! toplevel-initialized? #t))
+  toplevel)

--- a/lepton-eda/scheme/schematic/rc.scm
+++ b/lepton-eda/scheme/schematic/rc.scm
@@ -28,17 +28,17 @@
 
 (define toplevel-initialized? #f)
 
-(define (parse-gschemrc toplevel)
+(define (parse-gschemrc *toplevel)
   "Loads old (system, user, etc.) \"gschemrc\" files and new
 configuration \".conf\" files.  Saves the values in the foreign
-LeptonToplevel structure TOPLEVEL and returns it.  Instead of
+LeptonToplevel structure *TOPLEVEL and returns it.  Instead of
 exiting on error as CLI tools do, displays error dialogs with
 explanatory messages."
   (unless toplevel-initialized?
-    (g_rc_parse_handler toplevel
+    (g_rc_parse_handler *toplevel
                         (string->pointer "gschemrc")
                         %null-pointer
                         (procedure->pointer void x_rc_parse_gschem_error '(* *))
-                        toplevel)
+                        *toplevel)
     (set! toplevel-initialized? #t))
-  toplevel)
+  *toplevel)

--- a/lepton-eda/scheme/schematic/rc.scm
+++ b/lepton-eda/scheme/schematic/rc.scm
@@ -36,7 +36,6 @@ exiting on error as CLI tools do, displays error dialogs with
 explanatory messages."
   (unless toplevel-initialized?
     (parse-rc-handler (string->pointer "gschemrc")
-                      %null-pointer
                       (procedure->pointer void x_rc_parse_gschem_error '(* *))
                       (string->pointer "lepton-schematic")
                       *toplevel)

--- a/lepton-eda/scheme/schematic/window.scm
+++ b/lepton-eda/scheme/schematic/window.scm
@@ -53,6 +53,7 @@
   #:use-module (schematic gui stroke)
   #:use-module (schematic menu)
   #:use-module (schematic mouse-pointer)
+  #:use-module (schematic rc)
   #:use-module (schematic toolbar)
   #:use-module (schematic undo)
   #:use-module (schematic viewport foreign)

--- a/liblepton/include/liblepton/prototype.h
+++ b/liblepton/include/liblepton/prototype.h
@@ -55,10 +55,6 @@ g_rc_parse_file (LeptonToplevel *toplevel,
                  gpointer conf,
                  GError **err);
 gboolean
-g_rc_parse_system (LeptonToplevel *toplevel,
-                   const gchar *rcname,
-                   GError **err);
-gboolean
 g_rc_parse_user (LeptonToplevel *toplevel,
                  const gchar *rcname,
                  GError **err);

--- a/liblepton/include/liblepton/prototype.h
+++ b/liblepton/include/liblepton/prototype.h
@@ -71,12 +71,6 @@ gboolean
 g_rc_load_cache_config (LeptonToplevel* toplevel,
                         GError** err);
 void
-g_rc_parse_handler (LeptonToplevel *toplevel,
-                    const gchar *rcname,
-                    const gchar *rcfile,
-                    ConfigParseErrorFunc handler,
-                    void *user_data);
-void
 g_rc_parse__process_error (GError **err,
                            const gchar *pname);
 

--- a/liblepton/include/liblepton/prototype.h
+++ b/liblepton/include/liblepton/prototype.h
@@ -50,6 +50,11 @@ g_read_file (LeptonToplevel *toplevel,
 
 /* g_rc.c */
 gboolean
+g_rc_parse_file (LeptonToplevel *toplevel,
+                 const gchar *rcfile,
+                 gpointer conf,
+                 GError **err);
+gboolean
 g_rc_parse_system (LeptonToplevel *toplevel,
                    const gchar *rcname,
                    GError **err);

--- a/liblepton/include/liblepton/prototype.h
+++ b/liblepton/include/liblepton/prototype.h
@@ -66,16 +66,14 @@ gboolean
 g_rc_load_cache_config (LeptonToplevel* toplevel,
                         GError** err);
 void
-g_rc_parse (LeptonToplevel *toplevel,
-            const gchar* pname,
-            const gchar* rcname,
-            const gchar* rcfile);
-void
 g_rc_parse_handler (LeptonToplevel *toplevel,
                     const gchar *rcname,
                     const gchar *rcfile,
                     ConfigParseErrorFunc handler,
                     void *user_data);
+void
+g_rc_parse__process_error (GError **err,
+                           const gchar *pname);
 
 /* m_hatch.c */
 void

--- a/liblepton/include/liblepton/struct.h
+++ b/liblepton/include/liblepton/struct.h
@@ -1,7 +1,7 @@
 /* Lepton EDA library
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2016 gEDA Contributors
- * Copyright (C) 2017-2024 Lepton EDA Contributors
+ * Copyright (C) 2017-2025 Lepton EDA Contributors
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -86,9 +86,5 @@ struct st_conn {
 
 /*! \brief Type of callback function for object damage notification */
 typedef int(*ChangeNotifyFunc)(void *, LeptonObject *);
-
-/*! \brief Type of RC file parse error functions used by
-    g_rc_parse_handler() and similar functions. */
-typedef void (*ConfigParseErrorFunc)(GError **, void *);
 
 #endif

--- a/liblepton/src/g_rc.c
+++ b/liblepton/src/g_rc.c
@@ -2,7 +2,7 @@
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2016 gEDA Contributors
  * Copyright (C) 2016 Peter Brett <peter@peter-b.co.uk>
- * Copyright (C) 2017-2024 Lepton EDA Contributors
+ * Copyright (C) 2017-2025 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -266,8 +266,10 @@ g_rc_parse_local (LeptonToplevel *toplevel,
   return status;
 }
 
-static void
-g_rc_parse__process_error (GError **err, const gchar *pname)
+
+void
+g_rc_parse__process_error (GError **err,
+                           const gchar *pname)
 {
   char *pbase;
 
@@ -298,38 +300,6 @@ g_rc_parse__process_error (GError **err, const gchar *pname)
   exit (1);
 }
 
-/*! \brief General RC file parsing function.
- * \par Function Description
- * Calls g_rc_parse_handler() with the default error handler. If any
- * error other than ENOENT occurs while loading or running a Scheme
- * initialisation file, prints an informative message and calls
- * exit(1).
- *
- * \bug liblepton shouldn't call exit() - this function calls
- *      g_rc_parse__process_error(), which does.
- *
- * \warning Since this function may not return, it should only be used
- * on application startup or when there is no chance of data loss from
- * an unexpected exit().
- *
- * \param [in] toplevel  The #LeptonToplevel structure.
- * \param [in] pname     The name of the application (usually argv[0]).
- * \param [in] rcname    RC file basename, or NULL.
- * \param [in] rcfile    Specific RC file path, or NULL.
- */
-void
-g_rc_parse (LeptonToplevel *toplevel,
-            const gchar *pname,
-            const gchar *rcname,
-            const gchar *rcfile)
-{
-  g_rc_parse_handler (toplevel,
-                      rcname,
-                      rcfile,
-                      (ConfigParseErrorFunc) g_rc_parse__process_error,
-                      (void *) pname);
-}
-
 
 /*! \brief General RC file parsing function.
  * \par Function Description
@@ -341,8 +311,6 @@ g_rc_parse (LeptonToplevel *toplevel,
  *
  * If an error occurs, calls \a handler with the provided \a user_data
  * and a GError.
- *
- * \see g_rc_parse().
  *
  * \param toplevel  The current #LeptonToplevel structure.
  * \param rcname    RC file basename, or NULL.

--- a/liblepton/src/g_rc.c
+++ b/liblepton/src/g_rc.c
@@ -145,52 +145,6 @@ g_rc_parse_file (LeptonToplevel *toplevel,
   return status;
 }
 
-/*! \brief Load a system RC file.
- * \par Function Description
- * Attempts to load and run the system Scheme initialisation file with
- * basename \a rcname.  The string "system-" is prefixed to \a rcname.
- * If \a rcname is NULL, the default value of "gafrc" is used.
- *
- * \param toplevel  The current #LeptonToplevel structure.
- * \param rcname    The basename of the RC file to load, or NULL.
- * \param err       Return location for errors, or NULL.
- * \return TRUE on success, FALSE on failure.
- */
-gboolean
-g_rc_parse_system (LeptonToplevel *toplevel,
-                   const gchar *rcname,
-                   GError **err)
-{
-  gchar *sysname = NULL;
-  gchar *rcfile = NULL;
-  gboolean status = TRUE;
-  const gchar * const * sys_dirs = eda_get_system_config_dirs();
-  EdaConfig *cfg = eda_config_get_system_context();
-
-  /* Default to gafrc */
-  rcname = (rcname != NULL) ? rcname : "gafrc";
-
-  sysname = g_strdup_printf ("system-%s", rcname);
-  for (gint i = 0; sys_dirs[i]; ++i)
-  {
-    rcfile = g_build_filename (sys_dirs[i], sysname, NULL);
-    if (g_file_test(rcfile, G_FILE_TEST_IS_REGULAR))
-    {
-      break;
-    }
-    g_free(rcfile);
-    rcfile = NULL;
-  }
-
-  if (rcfile)
-  {
-    status = g_rc_parse_file (toplevel, rcfile, cfg, err);
-  }
-
-  g_free (rcfile);
-  g_free (sysname);
-  return status;
-}
 
 /*! \brief Load a user RC file.
  * \par Function Description

--- a/liblepton/src/g_rc.c
+++ b/liblepton/src/g_rc.c
@@ -88,14 +88,14 @@ g_rc_try_mark_read (LeptonToplevel *toplevel,
  *
  * \param toplevel  The current #LeptonToplevel structure.
  * \param rcfile    The filename of the RC file to load.
- * \param cfg       The configuration context to use while loading.
+ * \param conf      The configuration context to use while loading.
  * \param err       Return location for errors, or NULL;
  * \return TRUE on success, FALSE on failure.
  */
-static gboolean
+gboolean
 g_rc_parse_file (LeptonToplevel *toplevel,
                  const gchar *rcfile,
-                 EdaConfig *cfg,
+                 gpointer conf,
                  GError **err)
 {
   gchar *name_norm = NULL;
@@ -103,6 +103,8 @@ g_rc_parse_file (LeptonToplevel *toplevel,
   gboolean status = FALSE;
   g_return_val_if_fail ((toplevel != NULL), FALSE);
   g_return_val_if_fail ((rcfile != NULL), FALSE);
+
+  EdaConfig *cfg = (EdaConfig *) conf;
 
   /* If no configuration file was specified, get the default
    * configuration file for the rc file. */

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -1094,7 +1094,8 @@ void
 x_print (SchematicWindow *w_current);
 /* x_rc.c */
 void
-x_rc_parse_gschem (LeptonToplevel *toplevel);
+x_rc_parse_gschem_error (GError **err,
+                         const gchar *pname);
 
 /* x_rotatecb.c */
 GtkWidget*

--- a/libleptongui/src/x_rc.c
+++ b/libleptongui/src/x_rc.c
@@ -1,6 +1,6 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2014 gEDA Contributors
- * Copyright (C) 2017-2024 Lepton EDA Contributors
+ * Copyright (C) 2017-2025 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -23,9 +23,10 @@
 #include <locale.h>
 #endif
 
-/* Error handler function used by x_rc_parse_gschem(). */
-static void
-x_rc_parse_gschem_error (GError **err)
+/* RC parse error handler function for lepton-schematic. */
+void
+x_rc_parse_gschem_error (GError **err,
+                         const gchar *pname)
 {
   char *msg2; /* Secondary text */
   GtkWidget *dialog;
@@ -70,28 +71,4 @@ x_rc_parse_gschem_error (GError **err)
   gtk_dialog_run (GTK_DIALOG (dialog));
   gtk_widget_destroy (dialog);
   g_free (msg2);
-}
-
-/*! \brief Load gschem configuration files and display error dialogs.
- * \par Function Description
- * Loads configuration files in a similar manner to g_rc_parse().
- * Instead of exiting on error, display error dialogs with explanatory
- * messages.
- *
- * \param toplevel The current \c LeptonToplevel structure.
- */
-void
-x_rc_parse_gschem (LeptonToplevel *toplevel)
-{
-  static gsize initialized = 0;
-
-  if (g_once_init_enter (&initialized)) {
-  g_rc_parse_handler (toplevel,
-                      "gschemrc",
-                      NULL,
-                      (ConfigParseErrorFunc) x_rc_parse_gschem_error,
-                      (void *) toplevel);
-
-  g_once_init_leave (&initialized, 1);
-  }
 }


### PR DESCRIPTION
- A new module, `(schematic rc)`, has been introduced.  It
  contains the RC-parsing functions for `lepton-schematic`.
- The functions `g_rc_parse()`, `g_rc_parse_handler()`,
  `g_rc_parse_system()`, and `x_rc_parse_gschem()` have been
  rewritten in Scheme, merged, and/or removed.  Some useless
  arguments of the functions have been removed.  Several other
  functions are now available for dlopening and thus for using by
  means of Scheme FFI.
- The function `x_rc_parse_gschem_error()` has been fixed as it
  had a wrong number for using as an RC error handler.
- Support of parsing of an optional file has been removed from the
  main RC handler as this facility was not used for quite some
  time.  In any case, the option `-s` of `lepton-schematic` can be
  used to load third-party scripts.  `lepton-netlist` uses `-l` or
  `-m` for that.
