### PR TITLE
Rewrite x_fileselect_save() in Scheme

### DIFF
--- a/lepton-eda/scheme/schematic/builtins.scm
+++ b/lepton-eda/scheme/schematic/builtins.scm
@@ -112,8 +112,7 @@
 (define-action-public (&file-save-as #:label (G_ "Save As") #:icon "gtk-save-as")
   (define *window (*current-window))
   (file-select-save-page! *window
-                          (schematic_window_get_active_page *window)
-                          %null-pointer))
+                          (schematic_window_get_active_page *window)))
 
 ;;; Save all opened pages.
 (define-action-public (&file-save-all #:label (G_ "Save All") #:icon "gtk-save")
@@ -132,11 +131,7 @@
   ;; saving has been cancelled.
   (define (save-untitled-page! *page)
     ;; For untitled pages, open "Save as..." dialog.
-    (let* ((bv (make-bytevector (sizeof int) 0))
-           (save-result
-            (file-select-save-page! *window
-                                    *page
-                                    (bytevector->pointer bv)))
+    (let* ((save-result (file-select-save-page! *window *page))
            (filename-accepted? save-result)
            (saved-without-errors? (eq? save-result 'success)))
       ;; Skip the result if the File save dialog has been cancelled.

--- a/lepton-eda/scheme/schematic/builtins.scm
+++ b/lepton-eda/scheme/schematic/builtins.scm
@@ -111,9 +111,9 @@
 
 (define-action-public (&file-save-as #:label (G_ "Save As") #:icon "gtk-save-as")
   (define *window (*current-window))
-  (x_fileselect_save *window
-                     (schematic_window_get_active_page *window)
-                     %null-pointer))
+  (file-select-save-page! *window
+                          (schematic_window_get_active_page *window)
+                          %null-pointer))
 
 ;;; Save all opened pages.
 (define-action-public (&file-save-all #:label (G_ "Save All") #:icon "gtk-save")
@@ -134,7 +134,7 @@
     ;; For untitled pages, open "Save as..." dialog.
     (let ((bv (make-bytevector (sizeof int) 0)))
       ;; Skip the result if the File save dialog has been cancelled.
-      (or (not (true? (x_fileselect_save *window *page (bytevector->pointer bv))))
+      (or (not (true? (file-select-save-page! *window *page (bytevector->pointer bv))))
           ;; Otherwise, get the result of the save operation.
           (true? (bytevector-sint-ref bv 0 (native-endianness) (sizeof int))))))
 

--- a/lepton-eda/scheme/schematic/builtins.scm
+++ b/lepton-eda/scheme/schematic/builtins.scm
@@ -127,22 +127,13 @@
     (when tabs-enabled?
       (x_tabs_hdr_update *window (page->pointer page))))
 
-  ;; Returns #t if untitled page has been successfully saved or
-  ;; saving has been cancelled.
-  (define (save-untitled-page! *page)
-    ;; For untitled pages, open "Save as..." dialog.
-    (let* ((save-result (file-select-save-page! *window *page))
-           (filename-accepted? save-result)
-           (saved-without-errors? (eq? save-result 'success)))
-      ;; Skip the result if the File save dialog has been cancelled.
-      (or (not filename-accepted?)
-          ;; Otherwise, get the result of the save operation.
-          saved-without-errors?)))
-
+  ;; Returns #t if page has been successfully saved or saving has
+  ;; been cancelled.
   (define (save-page! page)
     (let ((*page (page->pointer page)))
       (if (untitled? *page)
-          (save-untitled-page! *page)
+          ;; For untitled pages, open "Save as..." dialog.
+          (file-select-save-page! *window *page)
           ;; Simply save any other page.
           (true? (x_window_save_page *window
                                      *page

--- a/lepton-eda/scheme/schematic/builtins.scm
+++ b/lepton-eda/scheme/schematic/builtins.scm
@@ -132,11 +132,20 @@
   ;; saving has been cancelled.
   (define (save-untitled-page! *page)
     ;; For untitled pages, open "Save as..." dialog.
-    (let ((bv (make-bytevector (sizeof int) 0)))
+    (let* ((bv (make-bytevector (sizeof int) 0))
+           (filename-accepted?
+            (file-select-save-page! *window
+                                    *page
+                                    (bytevector->pointer bv)))
+           (saved-without-errors?
+            (true? (bytevector-sint-ref bv
+                                        0
+                                        (native-endianness)
+                                        (sizeof int)))))
       ;; Skip the result if the File save dialog has been cancelled.
-      (or (not (file-select-save-page! *window *page (bytevector->pointer bv)))
+      (or (not filename-accepted?)
           ;; Otherwise, get the result of the save operation.
-          (true? (bytevector-sint-ref bv 0 (native-endianness) (sizeof int))))))
+          saved-without-errors?)))
 
   (define (save-page! page)
     (let ((*page (page->pointer page)))

--- a/lepton-eda/scheme/schematic/builtins.scm
+++ b/lepton-eda/scheme/schematic/builtins.scm
@@ -133,15 +133,12 @@
   (define (save-untitled-page! *page)
     ;; For untitled pages, open "Save as..." dialog.
     (let* ((bv (make-bytevector (sizeof int) 0))
-           (filename-accepted?
+           (save-result
             (file-select-save-page! *window
                                     *page
                                     (bytevector->pointer bv)))
-           (saved-without-errors?
-            (true? (bytevector-sint-ref bv
-                                        0
-                                        (native-endianness)
-                                        (sizeof int)))))
+           (filename-accepted? save-result)
+           (saved-without-errors? (eq? save-result 'success)))
       ;; Skip the result if the File save dialog has been cancelled.
       (or (not filename-accepted?)
           ;; Otherwise, get the result of the save operation.

--- a/lepton-eda/scheme/schematic/builtins.scm
+++ b/lepton-eda/scheme/schematic/builtins.scm
@@ -134,7 +134,7 @@
     ;; For untitled pages, open "Save as..." dialog.
     (let ((bv (make-bytevector (sizeof int) 0)))
       ;; Skip the result if the File save dialog has been cancelled.
-      (or (not (true? (file-select-save-page! *window *page (bytevector->pointer bv))))
+      (or (not (file-select-save-page! *window *page (bytevector->pointer bv)))
           ;; Otherwise, get the result of the save operation.
           (true? (bytevector-sint-ref bv 0 (native-endianness) (sizeof int))))))
 

--- a/lepton-eda/scheme/schematic/ffi.scm
+++ b/lepton-eda/scheme/schematic/ffi.scm
@@ -647,6 +647,7 @@
             x_fileselect_save
             *x_fileselect_callback_update_preview
             schematic_file_open
+            schematic_file_select_dialog_save_as
 
             x_image_setup
 
@@ -1336,9 +1337,10 @@
 (define-lff schematic_file_select_dialog_new '* '(*))
 (define-lff x_fileselect_add_preview void '(* *))
 (define-lff x_fileselect_open '* '(* *))
-(define-lff x_fileselect_save int '(* * * *))
+(define-lff x_fileselect_save int '(* * * * *))
 (define-lfc *x_fileselect_callback_update_preview)
 (define-lff schematic_file_open int '(* * * *))
+(define-lff schematic_file_select_dialog_save_as '* '(*))
 
 ;;; x_image.c
 (define-lff x_image_setup void '(*))

--- a/lepton-eda/scheme/schematic/ffi.scm
+++ b/lepton-eda/scheme/schematic/ffi.scm
@@ -642,6 +642,7 @@
             schematic_event_shift_mask
 
             schematic_file_select_dialog_new
+            schematic_file_select_dialog_setup_filters
             x_fileselect_add_preview
             x_fileselect_open
             x_fileselect_save
@@ -1335,6 +1336,7 @@
 
 ;;; x_fileselect.c
 (define-lff schematic_file_select_dialog_new '* '(*))
+(define-lff schematic_file_select_dialog_setup_filters void '(*))
 (define-lff x_fileselect_add_preview void '(* *))
 (define-lff x_fileselect_open '* '(* *))
 (define-lff x_fileselect_save int '(* * * * *))

--- a/lepton-eda/scheme/schematic/ffi.scm
+++ b/lepton-eda/scheme/schematic/ffi.scm
@@ -1336,7 +1336,7 @@
 (define-lff schematic_file_select_dialog_new '* '(*))
 (define-lff x_fileselect_add_preview void '(* *))
 (define-lff x_fileselect_open '* '(* *))
-(define-lff x_fileselect_save int '(* * *))
+(define-lff x_fileselect_save int '(* * * *))
 (define-lfc *x_fileselect_callback_update_preview)
 (define-lff schematic_file_open int '(* * * *))
 

--- a/lepton-eda/scheme/schematic/ffi.scm
+++ b/lepton-eda/scheme/schematic/ffi.scm
@@ -644,6 +644,7 @@
             schematic_file_select_dialog_new
             schematic_file_select_dialog_setup_filters
             schematic_file_select_dialog_filename_sch
+            schematic_file_select_dialog_filename_sym
             x_fileselect_add_preview
             x_fileselect_open
             x_fileselect_save
@@ -1339,6 +1340,7 @@
 (define-lff schematic_file_select_dialog_new '* '(*))
 (define-lff schematic_file_select_dialog_setup_filters void '(*))
 (define-lff schematic_file_select_dialog_filename_sch int '(*))
+(define-lff schematic_file_select_dialog_filename_sym int '(*))
 (define-lff x_fileselect_add_preview void '(* *))
 (define-lff x_fileselect_open '* '(* *))
 (define-lff x_fileselect_save int '(* * * * * *))

--- a/lepton-eda/scheme/schematic/ffi.scm
+++ b/lepton-eda/scheme/schematic/ffi.scm
@@ -1355,7 +1355,7 @@
 (define-lff schematic_file_select_dialog_get_filter_all '* '())
 (define-lff x_fileselect_add_preview void '(* *))
 (define-lff x_fileselect_open '* '(* *))
-(define-lff x_fileselect_save int (list '* '* '* '* '* int '* int))
+(define-lff x_fileselect_save int (list '* '* '* '* '* int int))
 (define-lfc *x_fileselect_callback_update_preview)
 (define-lff schematic_file_open int '(* * * *))
 (define-lff schematic_file_select_dialog_save_as '* '(*))

--- a/lepton-eda/scheme/schematic/ffi.scm
+++ b/lepton-eda/scheme/schematic/ffi.scm
@@ -1355,7 +1355,7 @@
 (define-lff schematic_file_select_dialog_get_filter_all '* '())
 (define-lff x_fileselect_add_preview void '(* *))
 (define-lff x_fileselect_open '* '(* *))
-(define-lff x_fileselect_save int (list '* '* '* '* '* int '*))
+(define-lff x_fileselect_save int (list '* '* '* '* '* int '* int))
 (define-lfc *x_fileselect_callback_update_preview)
 (define-lff schematic_file_open int '(* * * *))
 (define-lff schematic_file_select_dialog_save_as '* '(*))

--- a/lepton-eda/scheme/schematic/ffi.scm
+++ b/lepton-eda/scheme/schematic/ffi.scm
@@ -1355,7 +1355,7 @@
 (define-lff schematic_file_select_dialog_get_filter_all '* '())
 (define-lff x_fileselect_add_preview void '(* *))
 (define-lff x_fileselect_open '* '(* *))
-(define-lff x_fileselect_save int (list '* '* '* '* '* int int))
+(define-lff x_fileselect_save void '(* * * *))
 (define-lfc *x_fileselect_callback_update_preview)
 (define-lff schematic_file_open int '(* * * *))
 (define-lff schematic_file_select_dialog_save_as '* '(*))

--- a/lepton-eda/scheme/schematic/ffi.scm
+++ b/lepton-eda/scheme/schematic/ffi.scm
@@ -1353,7 +1353,7 @@
 (define-lff schematic_file_select_dialog_get_filter_all '* '())
 (define-lff x_fileselect_add_preview void '(* *))
 (define-lff x_fileselect_open '* '(* *))
-(define-lff x_fileselect_save int '(* * * * * *))
+(define-lff x_fileselect_save int '(* * * * *))
 (define-lfc *x_fileselect_callback_update_preview)
 (define-lff schematic_file_open int '(* * * *))
 (define-lff schematic_file_select_dialog_save_as '* '(*))

--- a/lepton-eda/scheme/schematic/ffi.scm
+++ b/lepton-eda/scheme/schematic/ffi.scm
@@ -643,6 +643,7 @@
 
             schematic_file_select_dialog_new
             schematic_file_select_dialog_setup_filters
+            schematic_file_select_dialog_filename_sch
             x_fileselect_add_preview
             x_fileselect_open
             x_fileselect_save
@@ -1337,6 +1338,7 @@
 ;;; x_fileselect.c
 (define-lff schematic_file_select_dialog_new '* '(*))
 (define-lff schematic_file_select_dialog_setup_filters void '(*))
+(define-lff schematic_file_select_dialog_filename_sch int '(*))
 (define-lff x_fileselect_add_preview void '(* *))
 (define-lff x_fileselect_open '* '(* *))
 (define-lff x_fileselect_save int '(* * * * * *))

--- a/lepton-eda/scheme/schematic/ffi.scm
+++ b/lepton-eda/scheme/schematic/ffi.scm
@@ -1339,7 +1339,7 @@
 (define-lff schematic_file_select_dialog_setup_filters void '(*))
 (define-lff x_fileselect_add_preview void '(* *))
 (define-lff x_fileselect_open '* '(* *))
-(define-lff x_fileselect_save int '(* * * * *))
+(define-lff x_fileselect_save int '(* * * * * *))
 (define-lfc *x_fileselect_callback_update_preview)
 (define-lff schematic_file_open int '(* * * *))
 (define-lff schematic_file_select_dialog_save_as '* '(*))

--- a/lepton-eda/scheme/schematic/ffi.scm
+++ b/lepton-eda/scheme/schematic/ffi.scm
@@ -645,6 +645,10 @@
             schematic_file_select_dialog_setup_filters
             schematic_file_select_dialog_filename_sch
             schematic_file_select_dialog_filename_sym
+            schematic_file_select_dialog_get_filter_sch
+            schematic_file_select_dialog_get_filter_sch_sym
+            schematic_file_select_dialog_get_filter_sym
+            schematic_file_select_dialog_get_filter_all
             x_fileselect_add_preview
             x_fileselect_open
             x_fileselect_save
@@ -1341,6 +1345,10 @@
 (define-lff schematic_file_select_dialog_setup_filters void '(*))
 (define-lff schematic_file_select_dialog_filename_sch int '(*))
 (define-lff schematic_file_select_dialog_filename_sym int '(*))
+(define-lff schematic_file_select_dialog_get_filter_sch '* '())
+(define-lff schematic_file_select_dialog_get_filter_sch_sym '* '())
+(define-lff schematic_file_select_dialog_get_filter_sym '* '())
+(define-lff schematic_file_select_dialog_get_filter_all '* '())
 (define-lff x_fileselect_add_preview void '(* *))
 (define-lff x_fileselect_open '* '(* *))
 (define-lff x_fileselect_save int '(* * * * * *))

--- a/lepton-eda/scheme/schematic/ffi.scm
+++ b/lepton-eda/scheme/schematic/ffi.scm
@@ -641,6 +641,7 @@
             schematic_event_control_mask
             schematic_event_shift_mask
 
+            schematic_file_select_dialog_overwrite_file
             schematic_file_select_dialog_new
             schematic_file_select_dialog_setup_filters
             schematic_file_select_dialog_filename_sch
@@ -1342,6 +1343,7 @@
 (define-lff schematic_event_shift_mask int '())
 
 ;;; x_fileselect.c
+(define-lff schematic_file_select_dialog_overwrite_file '* '(* *))
 (define-lff schematic_file_select_dialog_new '* '(*))
 (define-lff schematic_file_select_dialog_setup_filters void '(*))
 (define-lff schematic_file_select_dialog_filename_sch int '(*))
@@ -1353,7 +1355,7 @@
 (define-lff schematic_file_select_dialog_get_filter_all '* '())
 (define-lff x_fileselect_add_preview void '(* *))
 (define-lff x_fileselect_open '* '(* *))
-(define-lff x_fileselect_save int (list '* '* '* '* '* int))
+(define-lff x_fileselect_save int (list '* '* '* '* '* int '*))
 (define-lfc *x_fileselect_callback_update_preview)
 (define-lff schematic_file_open int '(* * * *))
 (define-lff schematic_file_select_dialog_save_as '* '(*))

--- a/lepton-eda/scheme/schematic/ffi.scm
+++ b/lepton-eda/scheme/schematic/ffi.scm
@@ -1353,7 +1353,7 @@
 (define-lff schematic_file_select_dialog_get_filter_all '* '())
 (define-lff x_fileselect_add_preview void '(* *))
 (define-lff x_fileselect_open '* '(* *))
-(define-lff x_fileselect_save int '(* * * * *))
+(define-lff x_fileselect_save int (list '* '* '* '* '* int))
 (define-lfc *x_fileselect_callback_update_preview)
 (define-lff schematic_file_open int '(* * * *))
 (define-lff schematic_file_select_dialog_save_as '* '(*))

--- a/lepton-eda/scheme/schematic/ffi.scm
+++ b/lepton-eda/scheme/schematic/ffi.scm
@@ -645,6 +645,7 @@
             schematic_file_select_dialog_setup_filters
             schematic_file_select_dialog_filename_sch
             schematic_file_select_dialog_filename_sym
+            *schematic_file_select_dialog_filter_changed
             schematic_file_select_dialog_get_filter_sch
             schematic_file_select_dialog_get_filter_sch_sym
             schematic_file_select_dialog_get_filter_sym
@@ -1345,6 +1346,7 @@
 (define-lff schematic_file_select_dialog_setup_filters void '(*))
 (define-lff schematic_file_select_dialog_filename_sch int '(*))
 (define-lff schematic_file_select_dialog_filename_sym int '(*))
+(define-lfc *schematic_file_select_dialog_filter_changed)
 (define-lff schematic_file_select_dialog_get_filter_sch '* '())
 (define-lff schematic_file_select_dialog_get_filter_sch_sym '* '())
 (define-lff schematic_file_select_dialog_get_filter_sym '* '())

--- a/lepton-eda/scheme/schematic/ffi.scm
+++ b/lepton-eda/scheme/schematic/ffi.scm
@@ -1353,7 +1353,7 @@
 (define-lff schematic_file_select_dialog_get_filter_all '* '())
 (define-lff x_fileselect_add_preview void '(* *))
 (define-lff x_fileselect_open '* '(* *))
-(define-lff x_fileselect_save int '(* * * * *))
+(define-lff x_fileselect_save int '(* * * *))
 (define-lfc *x_fileselect_callback_update_preview)
 (define-lff schematic_file_open int '(* * * *))
 (define-lff schematic_file_select_dialog_save_as '* '(*))

--- a/lepton-eda/scheme/schematic/ffi.scm
+++ b/lepton-eda/scheme/schematic/ffi.scm
@@ -1353,7 +1353,7 @@
 (define-lff schematic_file_select_dialog_get_filter_all '* '())
 (define-lff x_fileselect_add_preview void '(* *))
 (define-lff x_fileselect_open '* '(* *))
-(define-lff x_fileselect_save int '(* * * *))
+(define-lff x_fileselect_save int '(* * * * *))
 (define-lfc *x_fileselect_callback_update_preview)
 (define-lff schematic_file_open int '(* * * *))
 (define-lff schematic_file_select_dialog_save_as '* '(*))

--- a/lepton-eda/scheme/schematic/ffi.scm
+++ b/lepton-eda/scheme/schematic/ffi.scm
@@ -653,7 +653,6 @@
             schematic_file_select_dialog_get_filter_all
             x_fileselect_add_preview
             x_fileselect_open
-            x_fileselect_save
             *x_fileselect_callback_update_preview
             schematic_file_open
             schematic_file_select_dialog_save_as
@@ -1355,7 +1354,6 @@
 (define-lff schematic_file_select_dialog_get_filter_all '* '())
 (define-lff x_fileselect_add_preview void '(* *))
 (define-lff x_fileselect_open '* '(* *))
-(define-lff x_fileselect_save void '(* * * *))
 (define-lfc *x_fileselect_callback_update_preview)
 (define-lff schematic_file_open int '(* * * *))
 (define-lff schematic_file_select_dialog_save_as '* '(*))

--- a/lepton-eda/scheme/schematic/ffi/gtk.scm
+++ b/lepton-eda/scheme/schematic/ffi/gtk.scm
@@ -55,6 +55,9 @@
 
             gtk_events_pending
 
+            gtk_file_chooser_set_current_folder
+            gtk_file_chooser_set_current_name
+            gtk_file_chooser_set_filename
             gtk_file_chooser_set_filter
 
             gtk_handle_box_new
@@ -189,6 +192,9 @@
 
 (define-lff gtk_events_pending int '())
 
+(define-lff gtk_file_chooser_set_current_folder void '(* *))
+(define-lff gtk_file_chooser_set_current_name void '(* *))
+(define-lff gtk_file_chooser_set_filename void '(* *))
 (define-lff gtk_file_chooser_set_filter void '(* *))
 
 (define-lff gtk_handle_box_new '* '())

--- a/lepton-eda/scheme/schematic/ffi/gtk.scm
+++ b/lepton-eda/scheme/schematic/ffi/gtk.scm
@@ -55,6 +55,8 @@
 
             gtk_events_pending
 
+            gtk_file_chooser_set_filter
+
             gtk_handle_box_new
 
             gtk_icon_theme_append_search_path
@@ -186,6 +188,8 @@
 (define-lff gtk_entry_set_text void '(* *))
 
 (define-lff gtk_events_pending int '())
+
+(define-lff gtk_file_chooser_set_filter void '(* *))
 
 (define-lff gtk_handle_box_new '* '())
 

--- a/lepton-eda/scheme/schematic/ffi/gtk.scm
+++ b/lepton-eda/scheme/schematic/ffi/gtk.scm
@@ -48,6 +48,7 @@
             gtk_dialog_add_button
             gtk_dialog_get_content_area
             gtk_dialog_set_default_response
+            gtk_dialog_run
 
             gtk_entry_get_text
             gtk_entry_get_text_length
@@ -185,6 +186,7 @@
 (define-lff gtk_dialog_add_button '* (list '* '* int))
 (define-lff gtk_dialog_get_content_area '* '(*))
 (define-lff gtk_dialog_set_default_response void (list '* int))
+(define-lff gtk_dialog_run int '(*))
 
 (define-lff gtk_entry_get_text '* '(*))
 (define-lff gtk_entry_get_text_length uint16 '(*))

--- a/lepton-eda/scheme/schematic/ffi/gtk.scm
+++ b/lepton-eda/scheme/schematic/ffi/gtk.scm
@@ -58,6 +58,7 @@
 
             gtk_file_chooser_set_current_folder
             gtk_file_chooser_set_current_name
+            gtk_file_chooser_get_filename
             gtk_file_chooser_set_filename
             gtk_file_chooser_set_filter
 
@@ -196,6 +197,7 @@
 
 (define-lff gtk_file_chooser_set_current_folder void '(* *))
 (define-lff gtk_file_chooser_set_current_name void '(* *))
+(define-lff gtk_file_chooser_get_filename '* '(*))
 (define-lff gtk_file_chooser_set_filename void '(* *))
 (define-lff gtk_file_chooser_set_filter void '(* *))
 

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -76,17 +76,16 @@
                ;; If the file already exists, display a dialog box to
                ;; check if the user really wants to overwrite it.
                (*overwrite-dialog
-                (if existing-file?
-                    (schematic_file_select_dialog_overwrite_file
-                     *dialog
-                     (string->pointer filename))
-                    %null-pointer))
+                (and existing-file?
+                     (schematic_file_select_dialog_overwrite_file
+                      *dialog
+                      (string->pointer filename))))
                (overwrite-cancelled?
-                (and (not (null-pointer? *overwrite-dialog))
+                (and *overwrite-dialog
                      (not (eq? (gtk-response->symbol
                                 (gtk_dialog_run *overwrite-dialog))
                                'yes)))))
-          (when (not (null-pointer? *overwrite-dialog))
+          (when *overwrite-dialog
             (gtk_widget_destroy *overwrite-dialog))
 
           (when overwrite-cancelled?

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -27,6 +27,7 @@
 
   #:use-module (schematic ffi gtk)
   #:use-module (schematic ffi)
+  #:use-module (schematic gtk helper)
   #:use-module (schematic window foreign)
 
   #:export (file-select-save-page!
@@ -44,12 +45,14 @@
 
 (define (file-select-save-page! *window *page *result)
   (define (run-save-as-dialog *main-window *dialog *page-filename)
-    (x_fileselect_save *window
-                       *page
-                       *result
-                       *main-window
-                       *dialog
-                       *page-filename))
+    (if (eq? (gtk-response->symbol (gtk_dialog_run *dialog)) 'accept)
+        (x_fileselect_save *window
+                           *page
+                           *result
+                           *main-window
+                           *dialog
+                           *page-filename)
+        FALSE))
 
   (when (null-pointer? *window)
     (error "NULL window."))

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -26,7 +26,8 @@
   #:use-module (schematic ffi)
   #:use-module (schematic window foreign)
 
-  #:export (window-set-toplevel-page!
+  #:export (file-select-save-page!
+            window-set-toplevel-page!
             window-save-active-page!))
 
 (define (window-set-toplevel-page! window page)
@@ -38,6 +39,10 @@
   (schematic_window_page_changed *window))
 
 
+(define (file-select-save-page! *window *page *result)
+  (x_fileselect_save *window *page *result))
+
+
 (define (window-save-active-page! window)
   (define *window (check-window window 1))
   (define *page (schematic_window_get_active_page *window))
@@ -45,6 +50,6 @@
   (unless (null-pointer? *page)
     (if (true? (x_window_untitled_page *page))
         ;; Open "Save as..." dialog.
-        (x_fileselect_save *window *page %null-pointer)
+        (file-select-save-page! *window *page %null-pointer)
         ;; Save page.
         (x_window_save_page *window *page (lepton_page_get_filename *page)))))

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -83,15 +83,12 @@
   (define (run-save-as-dialog *dialog)
     (if (eq? (gtk-response->symbol (gtk_dialog_run *dialog)) 'accept)
         (let* ((filename (file-chooser-filename *dialog))
-               (existing-file? (and filename (file-exists? filename)))
-               ;; If the file already exists, display a dialog box to
-               ;; check if the user really wants to overwrite it.
-               (overwrite-cancelled?
-                (and existing-file?
-                     (not (eq? (overwrite-dialog-response *dialog filename)
-                               'yes)))))
-
-          (if overwrite-cancelled?
+               (existing-file? (and filename (file-exists? filename))))
+          ;; If the file already exists, display a dialog box to check
+          ;; if the user really wants to overwrite it.
+          (if (and existing-file?
+                   (not (eq? (overwrite-dialog-response *dialog filename)
+                             'yes)))
               (begin
                 (log! 'message (G_ "Save cancelled on user request"))
                 #f)

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -44,13 +44,12 @@
 
 
 (define (file-select-save-page! *window *page *result)
-  (define (run-save-as-dialog *dialog *page-filename)
+  (define (run-save-as-dialog *dialog)
     (if (eq? (gtk-response->symbol (gtk_dialog_run *dialog)) 'accept)
         (x_fileselect_save *window
                            *page
                            *result
-                           *dialog
-                           *page-filename)
+                           *dialog)
         FALSE))
 
   (when (null-pointer? *window)
@@ -108,8 +107,7 @@
                             (sizeof int)))
 
     (let ((accepted-filename?
-           (run-save-as-dialog *dialog
-                               *page-filename)))
+           (run-save-as-dialog *dialog)))
 
       (gtk_widget_destroy *dialog)
       ;; Whether the filename to save was accepted by the user.

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -81,34 +81,33 @@
       result))
 
   (define (run-save-as-dialog *dialog)
-    (if (eq? (gtk-response->symbol (gtk_dialog_run *dialog)) 'accept)
-        (let ((filename (file-chooser-filename *dialog)))
-          (and filename
-               ;; If the file already exists, display a dialog box to
-               ;; check if the user really wants to overwrite it.
-               (if (and (file-exists? filename)
-                        (not (eq? (overwrite-dialog-response *dialog
-                                                             filename)
-                                  'yes)))
-                   (begin
-                     (log! 'message (G_ "Save cancelled on user request"))
-                     #f)
+    (and (eq? (gtk-response->symbol (gtk_dialog_run *dialog)) 'accept)
+         (let ((filename (file-chooser-filename *dialog)))
+           (and filename
+                ;; If the file already exists, display a dialog box to
+                ;; check if the user really wants to overwrite it.
+                (if (and (file-exists? filename)
+                         (not (eq? (overwrite-dialog-response *dialog
+                                                              filename)
+                                   'yes)))
+                    (begin
+                      (log! 'message (G_ "Save cancelled on user request"))
+                      #f)
 
-                   ;; Try saving the page to filename.
-                   (let ((save_result
-                          (x_window_save_page *window
-                                              *page
-                                              (string->pointer filename))))
-                     (unless (null-pointer? *result)
-                       (bytevector-sint-set! (pointer->bytevector
-                                              *result
-                                              (sizeof int))
-                                             0
-                                             save_result
-                                             (native-endianness)
-                                             (sizeof int)))
-                     #t))))
-        #f))
+                    ;; Try saving the page to filename.
+                    (let ((save_result
+                           (x_window_save_page *window
+                                               *page
+                                               (string->pointer filename))))
+                      (unless (null-pointer? *result)
+                        (bytevector-sint-set! (pointer->bytevector
+                                               *result
+                                               (sizeof int))
+                                              0
+                                              save_result
+                                              (native-endianness)
+                                              (sizeof int)))
+                      #t))))))
 
   (when (null-pointer? *window)
     (error "NULL window."))

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -59,7 +59,13 @@
   (define (run-save-as-dialog *dialog)
     (if (eq? (gtk-response->symbol (gtk_dialog_run *dialog)) 'accept)
         (let* ((filename (file-chooser-filename *dialog))
-               (existing-file? (and filename (file-exists? filename))))
+               (existing-file? (and filename (file-exists? filename)))
+               (*overwrite-dialog
+                (if existing-file?
+                    (schematic_file_select_dialog_overwrite_file
+                     *dialog
+                     (string->pointer filename))
+                    %null-pointer)))
           (x_fileselect_save *window
                              *page
                              *result
@@ -67,7 +73,8 @@
                              (if filename
                                  (string->pointer filename)
                                  %null-pointer)
-                             (if existing-file? TRUE FALSE)))
+                             (if existing-file? TRUE FALSE)
+                             *overwrite-dialog))
         FALSE))
 
   (when (null-pointer? *window)

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -21,6 +21,7 @@
   #:use-module (system foreign)
 
   #:use-module (lepton ffi boolean)
+  #:use-module (lepton ffi glib)
   #:use-module (lepton ffi gobject)
   #:use-module (lepton ffi)
   #:use-module (lepton page foreign)
@@ -44,14 +45,27 @@
 
 
 (define (file-select-save-page! *window *page *result)
+  ;; Get filename from the GtkFileChooser dialog.  As the value
+  ;; must be freed anyway, the filename is transformed into a
+  ;; Scheme string, and the original pointer is freed.  If the
+  ;; original pointer is NULL, the function returns #f.
+  (define (file-chooser-filename *dialog)
+    (let* ((*filename (gtk_file_chooser_get_filename *dialog))
+           (filename (and (not (null-pointer? *filename))
+                          (pointer->string *filename))))
+      (g_free *filename)
+      filename))
+
   (define (run-save-as-dialog *dialog)
     (if (eq? (gtk-response->symbol (gtk_dialog_run *dialog)) 'accept)
-        (let ((*filename (gtk_file_chooser_get_filename *dialog)))
+        (let ((filename (file-chooser-filename *dialog)))
           (x_fileselect_save *window
                              *page
                              *result
                              *dialog
-                             *filename))
+                             (if filename
+                                 (string->pointer filename)
+                                 %null-pointer)))
         FALSE))
 
   (when (null-pointer? *window)

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -63,6 +63,22 @@
             (gtk_file_chooser_set_filter *dialog
                                          (schematic_file_select_dialog_get_filter_all))))
 
+    ;; Set the current filename or directory name for new documents.
+    (if (file-exists? (pointer->string *page-filename))
+        (gtk_file_chooser_set_filename *dialog *page-filename)
+
+        (begin
+          ;; Force save in the current working directory.
+          (gtk_file_chooser_set_current_folder
+           *dialog
+           (string->pointer (getcwd)))
+
+          ;; Set page file's basename as the current filename.
+          (gtk_file_chooser_set_current_name
+           *dialog
+           (string->pointer
+            (basename (pointer->string *page-filename))))))
+
     (x_fileselect_save *window
                        *page
                        *result

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -82,11 +82,11 @@
 
   (define (run-save-as-dialog *dialog)
     (if (eq? (gtk-response->symbol (gtk_dialog_run *dialog)) 'accept)
-        (let* ((filename (file-chooser-filename *dialog))
-               (existing-file? (and filename (file-exists? filename))))
+        (let ((filename (file-chooser-filename *dialog)))
           ;; If the file already exists, display a dialog box to check
           ;; if the user really wants to overwrite it.
-          (if (and existing-file?
+          (if (and filename
+                   (file-exists? filename)
                    (not (eq? (overwrite-dialog-response *dialog filename)
                              'yes)))
               (begin

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -45,7 +45,8 @@
   (when (null-pointer? *page)
     (error "NULL page."))
 
-  (x_fileselect_save *window *page *result))
+  (let ((*main-window (schematic_window_get_main_window *window)))
+    (x_fileselect_save *window *page *result *main-window)))
 
 
 (define (window-save-active-page! window)

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -71,6 +71,9 @@
                      (not (eq? (gtk-response->symbol
                                 (gtk_dialog_run *overwrite-dialog))
                                'yes)))))
+          (when (not (null-pointer? *overwrite-dialog))
+            (gtk_widget_destroy *overwrite-dialog))
+
           (x_fileselect_save *window
                              *page
                              *result
@@ -79,7 +82,6 @@
                                  (string->pointer filename)
                                  %null-pointer)
                              (if existing-file? TRUE FALSE)
-                             *overwrite-dialog
                              (if overwrite-cancelled? TRUE FALSE)))
         FALSE))
 

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -154,12 +154,14 @@
     ;; Open "Save As.." dialog.
     (gtk_widget_show *dialog)
 
-    (let ((accepted-filename?
-           (run-save-as-dialog *dialog)))
-
+    (let* ((save-result (run-save-as-dialog *dialog))
+           (saved-without-errors? (eq? save-result 'success)))
       (gtk_widget_destroy *dialog)
-      ;; Whether the filename to save was accepted by the user.
-      accepted-filename?)))
+
+      ;; Skip the result if the File save dialog has been cancelled.
+      (or (not save-result)
+          ;; Otherwise, get the result of the save operation.
+          saved-without-errors?))))
 
 
 (define (window-save-active-page! window)

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -58,14 +58,16 @@
 
   (define (run-save-as-dialog *dialog)
     (if (eq? (gtk-response->symbol (gtk_dialog_run *dialog)) 'accept)
-        (let ((filename (file-chooser-filename *dialog)))
+        (let* ((filename (file-chooser-filename *dialog))
+               (existing-file? (and filename (file-exists? filename))))
           (x_fileselect_save *window
                              *page
                              *result
                              *dialog
                              (if filename
                                  (string->pointer filename)
-                                 %null-pointer)))
+                                 %null-pointer)
+                             (if existing-file? TRUE FALSE)))
         FALSE))
 
   (when (null-pointer? *window)

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -81,33 +81,37 @@
       result))
 
   (define (run-save-as-dialog *dialog)
-    (and (eq? (gtk-response->symbol (gtk_dialog_run *dialog)) 'accept)
-         (let ((filename (file-chooser-filename *dialog)))
-           (and filename
-                ;; If the file already exists, display a dialog box to
-                ;; check if the user really wants to overwrite it.
-                (if (and (file-exists? filename)
-                         (not (eq? (overwrite-dialog-response *dialog
-                                                              filename)
-                                   'yes)))
-                    (begin
-                      (log! 'message (G_ "Save cancelled on user request"))
-                      #f)
+    (define filename-accepted?
+      (eq? (gtk-response->symbol (gtk_dialog_run *dialog)) 'accept))
+    (define filename
+      (and filename-accepted?
+           (file-chooser-filename *dialog)))
 
-                    ;; Try saving the page to filename.
-                    (let ((save_result
-                           (x_window_save_page *window
-                                               *page
-                                               (string->pointer filename))))
-                      (unless (null-pointer? *result)
-                        (bytevector-sint-set! (pointer->bytevector
-                                               *result
-                                               (sizeof int))
-                                              0
-                                              save_result
-                                              (native-endianness)
-                                              (sizeof int)))
-                      #t))))))
+    (and filename
+         ;; If the file already exists, display a dialog box to
+         ;; check if the user really wants to overwrite it.
+         (if (and (file-exists? filename)
+                  (not (eq? (overwrite-dialog-response *dialog
+                                                       filename)
+                            'yes)))
+             (begin
+               (log! 'message (G_ "Save cancelled on user request"))
+               #f)
+
+             ;; Try saving the page to filename.
+             (let ((save_result
+                    (x_window_save_page *window
+                                        *page
+                                        (string->pointer filename))))
+               (unless (null-pointer? *result)
+                 (bytevector-sint-set! (pointer->bytevector
+                                        *result
+                                        (sizeof int))
+                                       0
+                                       save_result
+                                       (native-endianness)
+                                       (sizeof int)))
+               #t))))
 
   (when (null-pointer? *window)
     (error "NULL window."))

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -46,6 +46,17 @@
   (schematic_window_page_changed *window))
 
 
+;;; Opens a file chooser dialog in *WINDOW for *PAGE and waits for the
+;;; user to select a file where the page will be saved.  If the
+;;; argument *RESULT is not NULL, the pointer references the C boolean
+;;; result of the save operation.
+;;;
+;;; If the user cancels the operation (with the Cancel button), the
+;;; page is not saved and FALSE is returned.
+;;;
+;;; The function updates the user interface. (Actual UI update is
+;;; performed in x_window_save_page(), which is called by this
+;;; function).
 (define (file-select-save-page! *window *page *result)
   ;; Get filename from the GtkFileChooser dialog.  As the value
   ;; must be freed anyway, the filename is transformed into a
@@ -83,13 +94,16 @@
 
           (if (and filename (not overwrite-cancelled?))
               ;; Try saving the page to filename.
-              (begin
-                (x_fileselect_save *window
-                                   *page
-                                   *result
-                                   (if filename
-                                       (string->pointer filename)
-                                       %null-pointer))
+              (let ((save_result
+                     (x_window_save_page *window
+                                         *page
+                                         (string->pointer filename))))
+                (unless (null-pointer? *result)
+                  (bytevector-sint-set! (pointer->bytevector *result (sizeof int))
+                                        0
+                                        save_result
+                                        (native-endianness)
+                                        (sizeof int)))
                 TRUE)
               FALSE))
         FALSE))

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -69,9 +69,13 @@
       (g_free *filename)
       filename))
 
-  (define (overwrite-dialog-response *overwrite-dialog)
-    (let ((result (gtk-response->symbol
-                   (gtk_dialog_run *overwrite-dialog))))
+  (define (overwrite-dialog-response *parent-dialog filename)
+    (let* ((*overwrite-dialog
+            (schematic_file_select_dialog_overwrite_file
+             *parent-dialog
+             (string->pointer filename)))
+           (result (gtk-response->symbol
+                    (gtk_dialog_run *overwrite-dialog))))
       (gtk_widget_destroy *overwrite-dialog)
 
       result))
@@ -82,14 +86,9 @@
                (existing-file? (and filename (file-exists? filename)))
                ;; If the file already exists, display a dialog box to
                ;; check if the user really wants to overwrite it.
-               (*overwrite-dialog
-                (and existing-file?
-                     (schematic_file_select_dialog_overwrite_file
-                      *dialog
-                      (string->pointer filename))))
                (overwrite-cancelled?
-                (and *overwrite-dialog
-                     (not (eq? (overwrite-dialog-response *overwrite-dialog)
+                (and existing-file?
+                     (not (eq? (overwrite-dialog-response *dialog filename)
                                'yes)))))
 
           (when overwrite-cancelled?

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -23,6 +23,7 @@
   #:use-module (lepton ffi)
   #:use-module (lepton page foreign)
 
+  #:use-module (schematic ffi gtk)
   #:use-module (schematic ffi)
   #:use-module (schematic window foreign)
 
@@ -51,6 +52,16 @@
          (*page-filename (lepton_page_get_filename *page)))
     ;; Add file filters to the dialog.
     (schematic_file_select_dialog_setup_filters *dialog)
+
+    (if (true? (schematic_file_select_dialog_filename_sch *page-filename))
+        (gtk_file_chooser_set_filter *dialog
+                                     (schematic_file_select_dialog_get_filter_sch))
+
+        (if (true? (schematic_file_select_dialog_filename_sym *page-filename))
+            (gtk_file_chooser_set_filter *dialog
+                                         (schematic_file_select_dialog_get_filter_sym))
+            (gtk_file_chooser_set_filter *dialog
+                                         (schematic_file_select_dialog_get_filter_all))))
 
     (x_fileselect_save *window
                        *page

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -81,15 +81,17 @@
           (when overwrite-cancelled?
             (log! 'message (G_ "Save cancelled on user request")))
 
-          (x_fileselect_save *window
-                             *page
-                             *result
-                             *dialog
-                             (if filename
-                                 (string->pointer filename)
-                                 %null-pointer)
-                             (if existing-file? TRUE FALSE)
-                             (if overwrite-cancelled? TRUE FALSE)))
+          (if (and filename (not overwrite-cancelled?))
+              ;; Try saving the page to filename.
+              (begin
+                (x_fileselect_save *window
+                                   *page
+                                   *result
+                                   (if filename
+                                       (string->pointer filename)
+                                       %null-pointer))
+                TRUE)
+              FALSE))
         FALSE))
 
   (when (null-pointer? *window)

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -40,6 +40,11 @@
 
 
 (define (file-select-save-page! *window *page *result)
+  (when (null-pointer? *window)
+    (error "NULL window."))
+  (when (null-pointer? *page)
+    (error "NULL page."))
+
   (x_fileselect_save *window *page *result))
 
 

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -91,23 +91,25 @@
                      (not (eq? (overwrite-dialog-response *dialog filename)
                                'yes)))))
 
-          (when overwrite-cancelled?
-            (log! 'message (G_ "Save cancelled on user request")))
+          (if overwrite-cancelled?
+              (begin
+                (log! 'message (G_ "Save cancelled on user request"))
+                #f)
 
-          (if (and filename (not overwrite-cancelled?))
-              ;; Try saving the page to filename.
-              (let ((save_result
-                     (x_window_save_page *window
-                                         *page
-                                         (string->pointer filename))))
-                (unless (null-pointer? *result)
-                  (bytevector-sint-set! (pointer->bytevector *result (sizeof int))
-                                        0
-                                        save_result
-                                        (native-endianness)
-                                        (sizeof int)))
-                #t)
-              #f))
+              (if filename
+                  ;; Try saving the page to filename.
+                  (let ((save_result
+                         (x_window_save_page *window
+                                             *page
+                                             (string->pointer filename))))
+                    (unless (null-pointer? *result)
+                      (bytevector-sint-set! (pointer->bytevector *result (sizeof int))
+                                            0
+                                            save_result
+                                            (native-endianness)
+                                            (sizeof int)))
+                    #t)
+                  #f)))
         #f))
 
   (when (null-pointer? *window)

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -17,6 +17,7 @@
 ;;; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 (define-module (schematic window page)
+  #:use-module (rnrs bytevectors)
   #:use-module (system foreign)
 
   #:use-module (lepton ffi boolean)
@@ -88,6 +89,13 @@
 
     ;; Open "Save As.." dialog.
     (gtk_widget_show *dialog)
+
+    (unless (null-pointer? *result)
+      (bytevector-sint-set! (pointer->bytevector *result (sizeof int))
+                            0
+                            FALSE
+                            (native-endianness)
+                            (sizeof int)))
 
     (let ((accepted-filename?
            (x_fileselect_save *window

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -46,10 +46,12 @@
 (define (file-select-save-page! *window *page *result)
   (define (run-save-as-dialog *dialog)
     (if (eq? (gtk-response->symbol (gtk_dialog_run *dialog)) 'accept)
-        (x_fileselect_save *window
-                           *page
-                           *result
-                           *dialog)
+        (let ((*filename (gtk_file_chooser_get_filename *dialog)))
+          (x_fileselect_save *window
+                             *page
+                             *result
+                             *dialog
+                             *filename))
         FALSE))
 
   (when (null-pointer? *window)

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -17,7 +17,6 @@
 ;;; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 (define-module (schematic window page)
-  #:use-module (rnrs bytevectors)
   #:use-module (system foreign)
 
   #:use-module (lepton ffi boolean)
@@ -46,23 +45,19 @@
   (schematic_window_page_changed *window))
 
 
-;;; Opens a file chooser dialog in *WINDOW for *PAGE and waits for the
-;;; user to select a file where the page will be saved.  If the
-;;; argument *RESULT is not NULL, the pointer references the C boolean
-;;; result of the save operation.
+;;; Opens a file chooser dialog in *WINDOW for *PAGE and waits for
+;;; the user to select a file where the page will be saved.
 ;;;
 ;;; If the user cancels the operation (with the Cancel button),
 ;;; the page is not saved and #f is returned.  If the user accepts
-;;; the filename chosen in the dialog, but the result of saving is
-;;; out of interest, that is, *RESULT is NULL, the function
-;;; returns #t.  When *RESULT is not NULL, the function returns
+;;; the filename chosen in the dialog, the function returns
 ;;; 'success or 'error depending on the result of the save
 ;;; operation.
 ;;;
 ;;; The function updates the user interface. (Actual UI update is
 ;;; performed in x_window_save_page(), which is called by this
 ;;; function).
-(define (file-select-save-page! *window *page *result)
+(define (file-select-save-page! *window *page)
   ;; Get filename from the GtkFileChooser dialog.  As the value
   ;; must be freed anyway, the filename is transformed into a
   ;; Scheme string, and the original pointer is freed.  If the
@@ -108,12 +103,9 @@
                     (x_window_save_page *window
                                         *page
                                         (string->pointer filename))))
-               (if (null-pointer? *result)
-                   ;; The result of saving is ignored.
-                   #t
-                   (if (true? save_result)
-                       'success
-                       'error))))))
+               (if (true? save_result)
+                   'success
+                   'error)))))
 
   (when (null-pointer? *window)
     (error "NULL window."))
@@ -162,13 +154,6 @@
     ;; Open "Save As.." dialog.
     (gtk_widget_show *dialog)
 
-    (unless (null-pointer? *result)
-      (bytevector-sint-set! (pointer->bytevector *result (sizeof int))
-                            0
-                            FALSE
-                            (native-endianness)
-                            (sizeof int)))
-
     (let ((accepted-filename?
            (run-save-as-dialog *dialog)))
 
@@ -184,6 +169,6 @@
   (unless (null-pointer? *page)
     (if (true? (x_window_untitled_page *page))
         ;; Open "Save as..." dialog.
-        (file-select-save-page! *window *page %null-pointer)
+        (file-select-save-page! *window *page)
         ;; Save page.
         (x_window_save_page *window *page (lepton_page_get_filename *page)))))

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -69,6 +69,9 @@
       (g_free *filename)
       filename))
 
+  (define (overwrite-dialog-response *overwrite-dialog)
+    (gtk-response->symbol (gtk_dialog_run *overwrite-dialog)))
+
   (define (run-save-as-dialog *dialog)
     (if (eq? (gtk-response->symbol (gtk_dialog_run *dialog)) 'accept)
         (let* ((filename (file-chooser-filename *dialog))
@@ -82,8 +85,7 @@
                       (string->pointer filename))))
                (overwrite-cancelled?
                 (and *overwrite-dialog
-                     (not (eq? (gtk-response->symbol
-                                (gtk_dialog_run *overwrite-dialog))
+                     (not (eq? (overwrite-dialog-response *overwrite-dialog)
                                'yes)))))
           (when *overwrite-dialog
             (gtk_widget_destroy *overwrite-dialog))

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -62,6 +62,8 @@
     (if (eq? (gtk-response->symbol (gtk_dialog_run *dialog)) 'accept)
         (let* ((filename (file-chooser-filename *dialog))
                (existing-file? (and filename (file-exists? filename)))
+               ;; If the file already exists, display a dialog box to
+               ;; check if the user really wants to overwrite it.
                (*overwrite-dialog
                 (if existing-file?
                     (schematic_file_select_dialog_overwrite_file

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -48,6 +48,9 @@
   (let* ((*main-window (schematic_window_get_main_window *window))
          (*dialog
           (schematic_file_select_dialog_save_as *main-window)))
+    ;; Add file filters to the dialog.
+    (schematic_file_select_dialog_setup_filters *dialog)
+
     (x_fileselect_save *window *page *result *main-window *dialog)))
 
 

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -20,6 +20,7 @@
   #:use-module (system foreign)
 
   #:use-module (lepton ffi boolean)
+  #:use-module (lepton ffi gobject)
   #:use-module (lepton ffi)
   #:use-module (lepton page foreign)
 
@@ -78,6 +79,12 @@
            *dialog
            (string->pointer
             (basename (pointer->string *page-filename))))))
+
+    ;; Add handler for dialog's "filter" property change notification.
+    (g_signal_connect *dialog
+                      (string->pointer "notify::filter")
+                      *schematic_file_select_dialog_filter_changed
+                      %null-pointer)
 
     (x_fileselect_save *window
                        *page

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -47,12 +47,9 @@
 
 ;;; Opens a file chooser dialog in *WINDOW for *PAGE and waits for
 ;;; the user to select a file where the page will be saved.
-;;;
-;;; If the user cancels the operation (with the Cancel button),
-;;; the page is not saved and #f is returned.  If the user accepts
-;;; the filename chosen in the dialog, the function returns
-;;; 'success or 'error depending on the result of the save
-;;; operation.
+;;; Returns #f on a save error, and #t in all other cases
+;;; including cancelling the Save dialog or its child overwrite
+;;; dialog.
 ;;;
 ;;; The function updates the user interface. (Actual UI update is
 ;;; performed in x_window_save_page(), which is called by this
@@ -83,25 +80,22 @@
       (and filename-accepted?
            (file-chooser-filename *dialog)))
 
-    (and filename
-         ;; If the file already exists, display a dialog box to
-         ;; check if the user really wants to overwrite it.
-         (if (and (file-exists? filename)
-                  (not (eq? (overwrite-dialog-response *dialog
-                                                       filename)
-                            'yes)))
-             (begin
-               (log! 'message (G_ "Save cancelled on user request"))
-               #f)
+    ;; It is OK if the user cancels the File select dialog.
+    (or (not filename)
+        ;; If the file already exists, display a dialog box to
+        ;; check if the user really wants to overwrite it.
+        (if (and (file-exists? filename)
+                 (not (eq? (overwrite-dialog-response *dialog
+                                                      filename)
+                           'yes)))
+            (begin
+              (log! 'message (G_ "Save cancelled on user request"))
+              #t)
 
-             ;; Try saving the page to filename.
-             (let ((save_result
-                    (x_window_save_page *window
-                                        *page
-                                        (string->pointer filename))))
-               (if (true? save_result)
-                   'success
-                   'error)))))
+            ;; Try saving the page to filename.
+            (true? (x_window_save_page *window
+                                       *page
+                                       (string->pointer filename))))))
 
   (when (null-pointer? *window)
     (error "NULL window."))
@@ -150,14 +144,11 @@
     ;; Open "Save As.." dialog.
     (gtk_widget_show *dialog)
 
-    (let* ((save-result (run-save-as-dialog *dialog))
-           (saved-without-errors? (eq? save-result 'success)))
+    (let ((save-result (run-save-as-dialog *dialog)))
       (gtk_widget_destroy *dialog)
 
-      ;; Skip the result if the File save dialog has been cancelled.
-      (or (not save-result)
-          ;; Otherwise, get the result of the save operation.
-          saved-without-errors?))))
+      ;; Return the result of the save operation.
+      save-result)))
 
 
 (define (window-save-active-page! window)

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -65,7 +65,12 @@
                     (schematic_file_select_dialog_overwrite_file
                      *dialog
                      (string->pointer filename))
-                    %null-pointer)))
+                    %null-pointer))
+               (overwrite-cancelled?
+                (and (not (null-pointer? *overwrite-dialog))
+                     (not (eq? (gtk-response->symbol
+                                (gtk_dialog_run *overwrite-dialog))
+                               'yes)))))
           (x_fileselect_save *window
                              *page
                              *result
@@ -74,7 +79,8 @@
                                  (string->pointer filename)
                                  %null-pointer)
                              (if existing-file? TRUE FALSE)
-                             *overwrite-dialog))
+                             *overwrite-dialog
+                             (if overwrite-cancelled? TRUE FALSE)))
         FALSE))
 
   (when (null-pointer? *window)

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -24,6 +24,8 @@
   #:use-module (lepton ffi glib)
   #:use-module (lepton ffi gobject)
   #:use-module (lepton ffi)
+  #:use-module (lepton gettext)
+  #:use-module (lepton log)
   #:use-module (lepton page foreign)
 
   #:use-module (schematic ffi gtk)
@@ -73,6 +75,9 @@
                                'yes)))))
           (when (not (null-pointer? *overwrite-dialog))
             (gtk_widget_destroy *overwrite-dialog))
+
+          (when overwrite-cancelled?
+            (log! 'message (G_ "Save cancelled on user request")))
 
           (x_fileselect_save *window
                              *page

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -52,7 +52,7 @@
 ;;; result of the save operation.
 ;;;
 ;;; If the user cancels the operation (with the Cancel button), the
-;;; page is not saved and FALSE is returned.
+;;; page is not saved and #f is returned.
 ;;;
 ;;; The function updates the user interface. (Actual UI update is
 ;;; performed in x_window_save_page(), which is called by this
@@ -104,9 +104,9 @@
                                         save_result
                                         (native-endianness)
                                         (sizeof int)))
-                TRUE)
-              FALSE))
-        FALSE))
+                #t)
+              #f))
+        #f))
 
   (when (null-pointer? *window)
     (error "NULL window."))

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -51,8 +51,13 @@
 ;;; argument *RESULT is not NULL, the pointer references the C boolean
 ;;; result of the save operation.
 ;;;
-;;; If the user cancels the operation (with the Cancel button), the
-;;; page is not saved and #f is returned.
+;;; If the user cancels the operation (with the Cancel button),
+;;; the page is not saved and #f is returned.  If the user accepts
+;;; the filename chosen in the dialog, but the result of saving is
+;;; out of interest, that is, *RESULT is NULL, the function
+;;; returns #t.  When *RESULT is not NULL, the function returns
+;;; 'success or 'error depending on the result of the save
+;;; operation.
 ;;;
 ;;; The function updates the user interface. (Actual UI update is
 ;;; performed in x_window_save_page(), which is called by this
@@ -103,15 +108,12 @@
                     (x_window_save_page *window
                                         *page
                                         (string->pointer filename))))
-               (unless (null-pointer? *result)
-                 (bytevector-sint-set! (pointer->bytevector
-                                        *result
-                                        (sizeof int))
-                                       0
-                                       save_result
-                                       (native-endianness)
-                                       (sizeof int)))
-               #t))))
+               (if (null-pointer? *result)
+                   ;; The result of saving is ignored.
+                   #t
+                   (if (true? save_result)
+                       'success
+                       'error))))))
 
   (when (null-pointer? *window)
     (error "NULL window."))

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -70,7 +70,11 @@
       filename))
 
   (define (overwrite-dialog-response *overwrite-dialog)
-    (gtk-response->symbol (gtk_dialog_run *overwrite-dialog)))
+    (let ((result (gtk-response->symbol
+                   (gtk_dialog_run *overwrite-dialog))))
+      (gtk_widget_destroy *overwrite-dialog)
+
+      result))
 
   (define (run-save-as-dialog *dialog)
     (if (eq? (gtk-response->symbol (gtk_dialog_run *dialog)) 'accept)
@@ -87,8 +91,6 @@
                 (and *overwrite-dialog
                      (not (eq? (overwrite-dialog-response *overwrite-dialog)
                                'yes)))))
-          (when *overwrite-dialog
-            (gtk_widget_destroy *overwrite-dialog))
 
           (when overwrite-cancelled?
             (log! 'message (G_ "Save cancelled on user request")))

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -45,8 +45,10 @@
   (when (null-pointer? *page)
     (error "NULL page."))
 
-  (let ((*main-window (schematic_window_get_main_window *window)))
-    (x_fileselect_save *window *page *result *main-window)))
+  (let* ((*main-window (schematic_window_get_main_window *window))
+         (*dialog
+          (schematic_file_select_dialog_save_as *main-window)))
+    (x_fileselect_save *window *page *result *main-window *dialog)))
 
 
 (define (window-save-active-page! window)

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -43,6 +43,14 @@
 
 
 (define (file-select-save-page! *window *page *result)
+  (define (run-save-as-dialog *main-window *dialog *page-filename)
+    (x_fileselect_save *window
+                       *page
+                       *result
+                       *main-window
+                       *dialog
+                       *page-filename))
+
   (when (null-pointer? *window)
     (error "NULL window."))
   (when (null-pointer? *page)
@@ -98,12 +106,9 @@
                             (sizeof int)))
 
     (let ((accepted-filename?
-           (x_fileselect_save *window
-                              *page
-                              *result
-                              *main-window
-                              *dialog
-                              *page-filename)))
+           (run-save-as-dialog *main-window
+                               *dialog
+                               *page-filename)))
 
       (gtk_widget_destroy *dialog)
       ;; Whether the filename to save was accepted by the user.

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -89,12 +89,17 @@
     ;; Open "Save As.." dialog.
     (gtk_widget_show *dialog)
 
-    (x_fileselect_save *window
-                       *page
-                       *result
-                       *main-window
-                       *dialog
-                       *page-filename)))
+    (let ((accepted-filename?
+           (x_fileselect_save *window
+                              *page
+                              *result
+                              *main-window
+                              *dialog
+                              *page-filename)))
+
+      (gtk_widget_destroy *dialog)
+      ;; Whether the filename to save was accepted by the user.
+      accepted-filename?)))
 
 
 (define (window-save-active-page! window)

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -47,11 +47,17 @@
 
   (let* ((*main-window (schematic_window_get_main_window *window))
          (*dialog
-          (schematic_file_select_dialog_save_as *main-window)))
+          (schematic_file_select_dialog_save_as *main-window))
+         (*page-filename (lepton_page_get_filename *page)))
     ;; Add file filters to the dialog.
     (schematic_file_select_dialog_setup_filters *dialog)
 
-    (x_fileselect_save *window *page *result *main-window *dialog)))
+    (x_fileselect_save *window
+                       *page
+                       *result
+                       *main-window
+                       *dialog
+                       *page-filename)))
 
 
 (define (window-save-active-page! window)

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -86,6 +86,9 @@
                       *schematic_file_select_dialog_filter_changed
                       %null-pointer)
 
+    ;; Open "Save As.." dialog.
+    (gtk_widget_show *dialog)
+
     (x_fileselect_save *window
                        *page
                        *result

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -58,10 +58,6 @@
 ;;; performed in x_window_save_page(), which is called by this
 ;;; function).
 (define (file-select-save-page! *window *page)
-  ;; Get filename from the GtkFileChooser dialog.  As the value
-  ;; must be freed anyway, the filename is transformed into a
-  ;; Scheme string, and the original pointer is freed.  If the
-  ;; original pointer is NULL, the function returns #f.
   (define (file-chooser-filename *dialog)
     (let* ((*filename (gtk_file_chooser_get_filename *dialog))
            (filename (and (not (null-pointer? *filename))

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -83,30 +83,31 @@
   (define (run-save-as-dialog *dialog)
     (if (eq? (gtk-response->symbol (gtk_dialog_run *dialog)) 'accept)
         (let ((filename (file-chooser-filename *dialog)))
-          ;; If the file already exists, display a dialog box to check
-          ;; if the user really wants to overwrite it.
-          (if (and filename
-                   (file-exists? filename)
-                   (not (eq? (overwrite-dialog-response *dialog filename)
-                             'yes)))
-              (begin
-                (log! 'message (G_ "Save cancelled on user request"))
-                #f)
+          (and filename
+               ;; If the file already exists, display a dialog box to
+               ;; check if the user really wants to overwrite it.
+               (if (and (file-exists? filename)
+                        (not (eq? (overwrite-dialog-response *dialog
+                                                             filename)
+                                  'yes)))
+                   (begin
+                     (log! 'message (G_ "Save cancelled on user request"))
+                     #f)
 
-              (if filename
-                  ;; Try saving the page to filename.
-                  (let ((save_result
-                         (x_window_save_page *window
-                                             *page
-                                             (string->pointer filename))))
-                    (unless (null-pointer? *result)
-                      (bytevector-sint-set! (pointer->bytevector *result (sizeof int))
-                                            0
-                                            save_result
-                                            (native-endianness)
-                                            (sizeof int)))
-                    #t)
-                  #f)))
+                   ;; Try saving the page to filename.
+                   (let ((save_result
+                          (x_window_save_page *window
+                                              *page
+                                              (string->pointer filename))))
+                     (unless (null-pointer? *result)
+                       (bytevector-sint-set! (pointer->bytevector
+                                              *result
+                                              (sizeof int))
+                                             0
+                                             save_result
+                                             (native-endianness)
+                                             (sizeof int)))
+                     #t))))
         #f))
 
   (when (null-pointer? *window)

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -44,12 +44,11 @@
 
 
 (define (file-select-save-page! *window *page *result)
-  (define (run-save-as-dialog *main-window *dialog *page-filename)
+  (define (run-save-as-dialog *dialog *page-filename)
     (if (eq? (gtk-response->symbol (gtk_dialog_run *dialog)) 'accept)
         (x_fileselect_save *window
                            *page
                            *result
-                           *main-window
                            *dialog
                            *page-filename)
         FALSE))
@@ -109,8 +108,7 @@
                             (sizeof int)))
 
     (let ((accepted-filename?
-           (run-save-as-dialog *main-window
-                               *dialog
+           (run-save-as-dialog *dialog
                                *page-filename)))
 
       (gtk_widget_destroy *dialog)

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -950,6 +950,9 @@ schematic_file_select_dialog_filename_sym (const gchar* fname);
 gboolean
 schematic_file_select_dialog_filename_sch (const gchar* fname);
 
+void
+schematic_file_select_dialog_filter_changed (GtkFileChooserDialog* dialog,
+                                             gpointer data);
 GtkFileFilter*
 schematic_file_select_dialog_get_filter_sch ();
 

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -985,7 +985,8 @@ x_fileselect_save (SchematicWindow *w_current,
                    GtkWidget *dialog,
                    char *filename,
                    gboolean file_exists,
-                   GtkWidget *checkdialog);
+                   GtkWidget *checkdialog,
+                   gboolean overwrite_cancelled);
 gboolean
 schematic_file_open (SchematicWindow *w_current,
                      LeptonPage *page,

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -951,7 +951,8 @@ x_fileselect_open (SchematicWindow *w_current,
 gboolean
 x_fileselect_save (SchematicWindow *w_current,
                    LeptonPage* page,
-                   gboolean* result);
+                   gboolean* result,
+                   GtkWidget *main_window);
 gboolean
 schematic_file_open (SchematicWindow *w_current,
                      LeptonPage *page,

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -983,7 +983,8 @@ x_fileselect_save (SchematicWindow *w_current,
                    LeptonPage* page,
                    gboolean* result,
                    GtkWidget *dialog,
-                   char *filename);
+                   char *filename,
+                   gboolean file_exists);
 gboolean
 schematic_file_open (SchematicWindow *w_current,
                      LeptonPage *page,

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -977,12 +977,6 @@ x_fileselect_add_preview (GtkWidget *dialog,
 GSList*
 x_fileselect_open (SchematicWindow *w_current,
                    GtkWidget *dialog);
-
-void
-x_fileselect_save (SchematicWindow *w_current,
-                   LeptonPage* page,
-                   gboolean* result,
-                   char *filename);
 gboolean
 schematic_file_open (SchematicWindow *w_current,
                      LeptonPage *page,

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -985,7 +985,6 @@ x_fileselect_save (SchematicWindow *w_current,
                    GtkWidget *dialog,
                    char *filename,
                    gboolean file_exists,
-                   GtkWidget *checkdialog,
                    gboolean overwrite_cancelled);
 gboolean
 schematic_file_open (SchematicWindow *w_current,

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -982,7 +982,8 @@ gboolean
 x_fileselect_save (SchematicWindow *w_current,
                    LeptonPage* page,
                    gboolean* result,
-                   GtkWidget *dialog);
+                   GtkWidget *dialog,
+                   char *filename);
 gboolean
 schematic_file_open (SchematicWindow *w_current,
                      LeptonPage *page,

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -982,8 +982,7 @@ gboolean
 x_fileselect_save (SchematicWindow *w_current,
                    LeptonPage* page,
                    gboolean* result,
-                   GtkWidget *dialog,
-                   gchar *fname);
+                   GtkWidget *dialog);
 gboolean
 schematic_file_open (SchematicWindow *w_current,
                      LeptonPage *page,

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -944,6 +944,9 @@ schematic_file_select_dialog_new (SchematicWindow *w_current);
 void
 schematic_file_select_dialog_setup_filters (GtkFileChooser *filechooser);
 
+gboolean
+schematic_file_select_dialog_filename_sch (const gchar* fname);
+
 GtkWidget*
 schematic_file_select_dialog_save_as (GtkWindow *parent);
 

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -959,7 +959,8 @@ x_fileselect_save (SchematicWindow *w_current,
                    LeptonPage* page,
                    gboolean* result,
                    GtkWidget *main_window,
-                   GtkWidget *dialog);
+                   GtkWidget *dialog,
+                   gchar *fname);
 gboolean
 schematic_file_open (SchematicWindow *w_current,
                      LeptonPage *page,

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -966,6 +966,9 @@ GtkFileFilter*
 schematic_file_select_dialog_get_filter_all ();
 
 GtkWidget*
+schematic_file_select_dialog_overwrite_file (GtkWidget *parent,
+                                             char *filename);
+GtkWidget*
 schematic_file_select_dialog_save_as (GtkWindow *parent);
 
 void

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -941,6 +941,9 @@ schematic_compselect_new (SchematicWindow *w_current);
 GtkWidget*
 schematic_file_select_dialog_new (SchematicWindow *w_current);
 
+GtkWidget*
+schematic_file_select_dialog_save_as (GtkWindow *parent);
+
 void
 x_fileselect_add_preview (GtkWidget *dialog,
                           GtkWidget *preview);

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -950,6 +950,18 @@ schematic_file_select_dialog_filename_sym (const gchar* fname);
 gboolean
 schematic_file_select_dialog_filename_sch (const gchar* fname);
 
+GtkFileFilter*
+schematic_file_select_dialog_get_filter_sch ();
+
+GtkFileFilter*
+schematic_file_select_dialog_get_filter_sym ();
+
+GtkFileFilter*
+schematic_file_select_dialog_get_filter_sch_sym ();
+
+GtkFileFilter*
+schematic_file_select_dialog_get_filter_all ();
+
 GtkWidget*
 schematic_file_select_dialog_save_as (GtkWindow *parent);
 

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -982,7 +982,6 @@ gboolean
 x_fileselect_save (SchematicWindow *w_current,
                    LeptonPage* page,
                    gboolean* result,
-                   GtkWidget *main_window,
                    GtkWidget *dialog,
                    gchar *fname);
 gboolean

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -984,7 +984,8 @@ x_fileselect_save (SchematicWindow *w_current,
                    gboolean* result,
                    GtkWidget *dialog,
                    char *filename,
-                   gboolean file_exists);
+                   gboolean file_exists,
+                   GtkWidget *checkdialog);
 gboolean
 schematic_file_open (SchematicWindow *w_current,
                      LeptonPage *page,

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -955,7 +955,8 @@ gboolean
 x_fileselect_save (SchematicWindow *w_current,
                    LeptonPage* page,
                    gboolean* result,
-                   GtkWidget *main_window);
+                   GtkWidget *main_window,
+                   GtkWidget *dialog);
 gboolean
 schematic_file_open (SchematicWindow *w_current,
                      LeptonPage *page,

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -941,6 +941,9 @@ schematic_compselect_new (SchematicWindow *w_current);
 GtkWidget*
 schematic_file_select_dialog_new (SchematicWindow *w_current);
 
+void
+schematic_file_select_dialog_setup_filters (GtkFileChooser *filechooser);
+
 GtkWidget*
 schematic_file_select_dialog_save_as (GtkWindow *parent);
 

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -978,14 +978,11 @@ GSList*
 x_fileselect_open (SchematicWindow *w_current,
                    GtkWidget *dialog);
 
-gboolean
+void
 x_fileselect_save (SchematicWindow *w_current,
                    LeptonPage* page,
                    gboolean* result,
-                   GtkWidget *dialog,
-                   char *filename,
-                   gboolean file_exists,
-                   gboolean overwrite_cancelled);
+                   char *filename);
 gboolean
 schematic_file_open (SchematicWindow *w_current,
                      LeptonPage *page,

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -945,6 +945,9 @@ void
 schematic_file_select_dialog_setup_filters (GtkFileChooser *filechooser);
 
 gboolean
+schematic_file_select_dialog_filename_sym (const gchar* fname);
+
+gboolean
 schematic_file_select_dialog_filename_sch (const gchar* fname);
 
 GtkWidget*

--- a/libleptongui/src/x_fileselect.c
+++ b/libleptongui/src/x_fileselect.c
@@ -507,8 +507,6 @@ x_fileselect_save (SchematicWindow *w_current,
                    GtkWidget *dialog,
                    gchar *fname)
 {
-  if (gtk_dialog_run ((GtkDialog*)dialog) == GTK_RESPONSE_ACCEPT)
-  {
     gchar *filename = gtk_file_chooser_get_filename (GTK_FILE_CHOOSER (dialog));
 
     /* If the file already exists, display a dialog box to check if
@@ -549,12 +547,6 @@ x_fileselect_save (SchematicWindow *w_current,
     {
       return FALSE;
     }
-
-  } /* if: accept response */
-  else
-  {
-    return FALSE;
-  }
 
 } /* x_fileselect_save() */
 

--- a/libleptongui/src/x_fileselect.c
+++ b/libleptongui/src/x_fileselect.c
@@ -492,6 +492,7 @@ schematic_file_select_dialog_overwrite_file (GtkWidget *parent,
  *  \param  [in]     page      The page to be saved.
  *  \param  [in,out] result    If not NULL, will be filled with save operation result.
  *  \param  [in] dialog The 'Save as' dialog widget to set up.
+ *  \param  [in] filename The filename chosen in the 'Save as' dialog.
  *  \return TRUE if the dialog was closed with ACCEPT response and
  *          the user selected a name of a non-existing file or
  *          allowed (didn't cancel) overwriting an existing one.
@@ -500,10 +501,9 @@ gboolean
 x_fileselect_save (SchematicWindow *w_current,
                    LeptonPage* page,
                    gboolean* result,
-                   GtkWidget *dialog)
+                   GtkWidget *dialog,
+                   char *filename)
 {
-    gchar *filename = gtk_file_chooser_get_filename (GTK_FILE_CHOOSER (dialog));
-
     /* If the file already exists, display a dialog box to check if
        the user really wants to overwrite it:
     */

--- a/libleptongui/src/x_fileselect.c
+++ b/libleptongui/src/x_fileselect.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2015 gEDA Contributors
- * Copyright (C) 2017-2024 Lepton EDA Contributors
+ * Copyright (C) 2017-2026 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -511,11 +511,6 @@ x_fileselect_save (SchematicWindow *w_current,
     *result = FALSE;
   }
 
-  /*
-   * Open "Save As.." dialog:
-  */
-
-  gtk_widget_show (dialog);
   if (gtk_dialog_run ((GtkDialog*)dialog) == GTK_RESPONSE_ACCEPT)
   {
     gchar *filename = gtk_file_chooser_get_filename (GTK_FILE_CHOOSER (dialog));

--- a/libleptongui/src/x_fileselect.c
+++ b/libleptongui/src/x_fileselect.c
@@ -491,41 +491,20 @@ schematic_file_select_dialog_overwrite_file (GtkWidget *parent,
  *  \param  [in]     w_current The SchematicWindow environment.
  *  \param  [in]     page      The page to be saved.
  *  \param  [in,out] result    If not NULL, will be filled with save operation result.
- *  \param  [in] dialog The 'Save as' dialog widget to set up.
  *  \param  [in] filename The filename chosen in the 'Save as' dialog.
- *  \param  [in] file_exists TRUE if a file with the chosen filename already exists.
- *  \param  [in] overwrite_cancelled TRUE if the user cancelled an overwrite.
- *  \return TRUE if the dialog was closed with ACCEPT response and
- *          the user selected a name of a non-existing file or
- *          allowed (didn't cancel) overwriting an existing one.
  */
-gboolean
+void
 x_fileselect_save (SchematicWindow *w_current,
                    LeptonPage* page,
                    gboolean* result,
-                   GtkWidget *dialog,
-                   char *filename,
-                   gboolean file_exists,
-                   gboolean overwrite_cancelled)
+                   char *filename)
 {
-    /* try saving the page to file filename:
-    */
-    if (filename != NULL && !overwrite_cancelled)
-    {
       gboolean res = x_window_save_page (w_current, page, filename);
 
       if (result != NULL)
       {
         *result = res;
       }
-
-      return TRUE;
-    }
-    else
-    {
-      return FALSE;
-    }
-
 } /* x_fileselect_save() */
 
 

--- a/libleptongui/src/x_fileselect.c
+++ b/libleptongui/src/x_fileselect.c
@@ -58,8 +58,8 @@ filename_sym (const gchar* fname)
 
 
 
-static gboolean
-filename_sch (const gchar* fname)
+gboolean
+schematic_file_select_dialog_filename_sch (const gchar* fname)
 {
   gchar* str = g_utf8_strdown (fname, -1);
   gboolean res = g_str_has_suffix (str, ".sch");
@@ -73,7 +73,7 @@ filename_sch (const gchar* fname)
 static gboolean
 filter_func_sch(const GtkFileFilterInfo* info, gpointer data)
 {
-  return filename_sch (info->filename);
+  return schematic_file_select_dialog_filename_sch (info->filename);
 }
 
 static gboolean
@@ -85,7 +85,9 @@ filter_func_sym(const GtkFileFilterInfo* info, gpointer data)
 static gboolean
 filter_func_sch_sym(const GtkFileFilterInfo* info, gpointer data)
 {
-  return filename_sch (info->filename) || filename_sym (info->filename);
+  return
+    schematic_file_select_dialog_filename_sch (info->filename)
+    || filename_sym (info->filename);
 }
 
 static gboolean
@@ -201,7 +203,8 @@ on_filter_changed (GtkFileChooserDialog* dialog, gpointer data)
     bname = basename_switch_suffix (fname, "sch");
   }
   else
-  if (filter == filter_sym && filename_sch (fname))
+  if (filter == filter_sym &&
+      schematic_file_select_dialog_filename_sch (fname))
   {
     bname = basename_switch_suffix (fname, "sym");
   }
@@ -458,7 +461,7 @@ x_fileselect_save (SchematicWindow *w_current,
     *result = FALSE;
   }
 
-  if (filename_sch (fname))
+  if (schematic_file_select_dialog_filename_sch (fname))
   {
     gtk_file_chooser_set_filter (GTK_FILE_CHOOSER (dialog), filter_sch);
   }

--- a/libleptongui/src/x_fileselect.c
+++ b/libleptongui/src/x_fileselect.c
@@ -554,8 +554,6 @@ x_fileselect_save (SchematicWindow *w_current,
 
   } /* if: accept response */
 
-  gtk_widget_destroy (dialog);
-
   return ret;
 
 } /* x_fileselect_save() */

--- a/libleptongui/src/x_fileselect.c
+++ b/libleptongui/src/x_fileselect.c
@@ -476,39 +476,6 @@ schematic_file_select_dialog_overwrite_file (GtkWidget *parent,
 }
 
 
-/*! \brief Opens a file chooser for saving the current page.
- *  \par Function Description
- *  This function opens a file chooser dialog and wait for the user to
- *  select a file where the \a page will be saved.
- *
- *  If the user cancels the operation (with the cancel button), the
- *  page is not saved and FALSE is returned.
- *
- *  The function updates the user interface. (Actual UI update
- *  is performed in x_window_save_page(), which is called by this
- *  function).
- *
- *  \param  [in]     w_current The SchematicWindow environment.
- *  \param  [in]     page      The page to be saved.
- *  \param  [in,out] result    If not NULL, will be filled with save operation result.
- *  \param  [in] filename The filename chosen in the 'Save as' dialog.
- */
-void
-x_fileselect_save (SchematicWindow *w_current,
-                   LeptonPage* page,
-                   gboolean* result,
-                   char *filename)
-{
-      gboolean res = x_window_save_page (w_current, page, filename);
-
-      if (result != NULL)
-      {
-        *result = res;
-      }
-} /* x_fileselect_save() */
-
-
-
 /*! \brief Load/Backup selection dialog.
  *  \par Function Description
  *  This function opens a message dialog and wait for the user to choose

--- a/libleptongui/src/x_fileselect.c
+++ b/libleptongui/src/x_fileselect.c
@@ -104,8 +104,8 @@ filter_func_all(const GtkFileFilterInfo* info, gpointer data)
  *
  *  \param [in] filechooser The file chooser to add filter to.
  */
-static void
-setup_filters (GtkFileChooser *filechooser)
+void
+schematic_file_select_dialog_setup_filters (GtkFileChooser *filechooser)
 {
   add_filter (filechooser, &filter_sch,
               _("Schematics (*.sch)"), &filter_func_sch);
@@ -369,7 +369,7 @@ x_fileselect_open (SchematicWindow *w_current,
                 NULL);
 
   /* add file filters to dialog */
-  setup_filters (GTK_FILE_CHOOSER (dialog));
+  schematic_file_select_dialog_setup_filters (GTK_FILE_CHOOSER (dialog));
   /* restore last filter: */
   gtk_file_chooser_set_filter (GTK_FILE_CHOOSER (dialog), filter_last_opendlg);
 
@@ -458,7 +458,7 @@ x_fileselect_save (SchematicWindow *w_current,
 
   /* add file filters to dialog:
   */
-  setup_filters (GTK_FILE_CHOOSER (dialog));
+  schematic_file_select_dialog_setup_filters (GTK_FILE_CHOOSER (dialog));
   const gchar* fname = lepton_page_get_filename (page);
 
   if (filename_sch (fname))

--- a/libleptongui/src/x_fileselect.c
+++ b/libleptongui/src/x_fileselect.c
@@ -440,22 +440,21 @@ schematic_file_select_dialog_save_as (GtkWindow *parent)
  *  \param  [in,out] result    If not NULL, will be filled with save operation result.
  *  \param [in] main_window The main_window widget of the
  *                          schematic window.
+ *  \param  [in] dialog The 'Save as' dialog widget to set up.
  *  \return                    TRUE if dialog was closed with ACCEPT response.
  */
 gboolean
 x_fileselect_save (SchematicWindow *w_current,
                    LeptonPage* page,
                    gboolean* result,
-                   GtkWidget *main_window)
+                   GtkWidget *main_window,
+                   GtkWidget *dialog)
 {
   gboolean ret = FALSE;
   if (result != NULL)
   {
     *result = FALSE;
   }
-
-  GtkWidget *dialog =
-    schematic_file_select_dialog_save_as (GTK_WINDOW (main_window));
 
   /* add file filters to dialog:
   */

--- a/libleptongui/src/x_fileselect.c
+++ b/libleptongui/src/x_fileselect.c
@@ -424,6 +424,15 @@ x_fileselect_open (SchematicWindow *w_current,
 }
 
 
+/*! \brief Open a 'Save As' dialog.
+ *
+ *  \par Function Description
+ *
+ *  Opens a 'Save As' dialog.
+ *
+ *  \param [in] parent The parent Gtk window of the dialog.
+ *  \return The new dialog.
+ */
 GtkWidget*
 schematic_file_select_dialog_save_as (GtkWindow *parent)
 {

--- a/libleptongui/src/x_fileselect.c
+++ b/libleptongui/src/x_fileselect.c
@@ -493,6 +493,7 @@ schematic_file_select_dialog_overwrite_file (GtkWidget *parent,
  *  \param  [in,out] result    If not NULL, will be filled with save operation result.
  *  \param  [in] dialog The 'Save as' dialog widget to set up.
  *  \param  [in] filename The filename chosen in the 'Save as' dialog.
+ *  \param  [in] file_exists TRUE if a file with the chosen filename already exists.
  *  \return TRUE if the dialog was closed with ACCEPT response and
  *          the user selected a name of a non-existing file or
  *          allowed (didn't cancel) overwriting an existing one.
@@ -502,12 +503,13 @@ x_fileselect_save (SchematicWindow *w_current,
                    LeptonPage* page,
                    gboolean* result,
                    GtkWidget *dialog,
-                   char *filename)
+                   char *filename,
+                   gboolean file_exists)
 {
     /* If the file already exists, display a dialog box to check if
        the user really wants to overwrite it:
     */
-    if ((filename != NULL) && g_file_test (filename, G_FILE_TEST_EXISTS))
+    if (file_exists)
     {
       GtkWidget *checkdialog =
         schematic_file_select_dialog_overwrite_file (dialog, filename);

--- a/libleptongui/src/x_fileselect.c
+++ b/libleptongui/src/x_fileselect.c
@@ -515,7 +515,6 @@ x_fileselect_save (SchematicWindow *w_current,
       if (gtk_dialog_run (GTK_DIALOG (checkdialog)) != GTK_RESPONSE_YES)
       {
         g_message (_("Save cancelled on user request"));
-        g_free (filename);
         filename = NULL;
       }
 
@@ -528,8 +527,6 @@ x_fileselect_save (SchematicWindow *w_current,
     if (filename != NULL)
     {
       gboolean res = x_window_save_page (w_current, page, filename);
-
-      g_free (filename);
 
       if (result != NULL)
       {

--- a/libleptongui/src/x_fileselect.c
+++ b/libleptongui/src/x_fileselect.c
@@ -489,29 +489,6 @@ x_fileselect_save (SchematicWindow *w_current,
     *result = FALSE;
   }
 
-  /* set the current filename or directory name if new document:
-  */
-  if (g_file_test (fname, G_FILE_TEST_EXISTS))
-  {
-    gtk_file_chooser_set_filename (GTK_FILE_CHOOSER (dialog), fname);
-  }
-  else
-  {
-    gchar *cwd = g_get_current_dir ();
-
-    /* force save in current working dir:
-    */
-    gtk_file_chooser_set_current_folder (GTK_FILE_CHOOSER (dialog), cwd);
-    g_free (cwd);
-
-    /* set page file's basename as the current filename:
-    */
-    gchar* bname = g_path_get_basename (fname);
-    gtk_file_chooser_set_current_name (GTK_FILE_CHOOSER (dialog), bname);
-    g_free (bname);
-  }
-
-
   /* add handler for dialog's "filter" property change notification:
   */
   g_signal_connect (dialog,

--- a/libleptongui/src/x_fileselect.c
+++ b/libleptongui/src/x_fileselect.c
@@ -494,6 +494,7 @@ schematic_file_select_dialog_overwrite_file (GtkWidget *parent,
  *  \param  [in] dialog The 'Save as' dialog widget to set up.
  *  \param  [in] filename The filename chosen in the 'Save as' dialog.
  *  \param  [in] file_exists TRUE if a file with the chosen filename already exists.
+ *  \param  [in] checkdialog The overwrite dialog for existing files.
  *  \return TRUE if the dialog was closed with ACCEPT response and
  *          the user selected a name of a non-existing file or
  *          allowed (didn't cancel) overwriting an existing one.
@@ -504,16 +505,14 @@ x_fileselect_save (SchematicWindow *w_current,
                    gboolean* result,
                    GtkWidget *dialog,
                    char *filename,
-                   gboolean file_exists)
+                   gboolean file_exists,
+                   GtkWidget *checkdialog)
 {
     /* If the file already exists, display a dialog box to check if
        the user really wants to overwrite it:
     */
     if (file_exists)
     {
-      GtkWidget *checkdialog =
-        schematic_file_select_dialog_overwrite_file (dialog, filename);
-
       if (gtk_dialog_run (GTK_DIALOG (checkdialog)) != GTK_RESPONSE_YES)
       {
         g_message (_("Save cancelled on user request"));

--- a/libleptongui/src/x_fileselect.c
+++ b/libleptongui/src/x_fileselect.c
@@ -456,9 +456,6 @@ x_fileselect_save (SchematicWindow *w_current,
     *result = FALSE;
   }
 
-  /* add file filters to dialog:
-  */
-  schematic_file_select_dialog_setup_filters (GTK_FILE_CHOOSER (dialog));
   const gchar* fname = lepton_page_get_filename (page);
 
   if (filename_sch (fname))

--- a/libleptongui/src/x_fileselect.c
+++ b/libleptongui/src/x_fileselect.c
@@ -455,6 +455,27 @@ schematic_file_select_dialog_save_as (GtkWindow *parent)
 }
 
 
+GtkWidget*
+schematic_file_select_dialog_overwrite_file (GtkWidget *parent,
+                                             char *filename)
+{
+  GtkWidget *dialog =
+    gtk_message_dialog_new (GTK_WINDOW (parent),
+                            (GtkDialogFlags) (GTK_DIALOG_MODAL |
+                                              GTK_DIALOG_DESTROY_WITH_PARENT),
+                            GTK_MESSAGE_QUESTION,
+                            GTK_BUTTONS_YES_NO,
+                            _("The selected file `%1$s' already exists.\n\n"
+                              "Would you like to overwrite it?"),
+                            filename);
+
+  gtk_window_set_title (GTK_WINDOW (dialog), _("Overwrite file?"));
+  gtk_dialog_set_default_response (GTK_DIALOG (dialog), GTK_RESPONSE_NO);
+
+  return dialog;
+}
+
+
 /*! \brief Opens a file chooser for saving the current page.
  *  \par Function Description
  *  This function opens a file chooser dialog and wait for the user to
@@ -505,17 +526,7 @@ x_fileselect_save (SchematicWindow *w_current,
     if ((filename != NULL) && g_file_test (filename, G_FILE_TEST_EXISTS))
     {
       GtkWidget *checkdialog =
-        gtk_message_dialog_new (GTK_WINDOW(dialog),
-                                (GtkDialogFlags) (GTK_DIALOG_MODAL |
-                                                  GTK_DIALOG_DESTROY_WITH_PARENT),
-                                GTK_MESSAGE_QUESTION,
-                                GTK_BUTTONS_YES_NO,
-                                _("The selected file `%1$s' already exists.\n\n"
-                                  "Would you like to overwrite it?"),
-                                filename);
-
-      gtk_window_set_title (GTK_WINDOW (checkdialog), _("Overwrite file?"));
-      gtk_dialog_set_default_response (GTK_DIALOG (checkdialog), GTK_RESPONSE_NO);
+        schematic_file_select_dialog_overwrite_file (dialog, filename);
 
       if (gtk_dialog_run (GTK_DIALOG (checkdialog)) != GTK_RESPONSE_YES)
       {

--- a/libleptongui/src/x_fileselect.c
+++ b/libleptongui/src/x_fileselect.c
@@ -45,6 +45,33 @@ add_filter (GtkFileChooser* filechooser,
             GtkFileFilterFunc pfn);
 
 
+GtkFileFilter*
+schematic_file_select_dialog_get_filter_sch ()
+{
+  return filter_sch;
+}
+
+
+GtkFileFilter*
+schematic_file_select_dialog_get_filter_sym ()
+{
+  return filter_sym;
+}
+
+
+GtkFileFilter*
+schematic_file_select_dialog_get_filter_sch_sym ()
+{
+  return filter_sch_sym;
+}
+
+
+GtkFileFilter*
+schematic_file_select_dialog_get_filter_all ()
+{
+  return filter_all;
+}
+
 
 gboolean
 schematic_file_select_dialog_filename_sym (const gchar* fname)

--- a/libleptongui/src/x_fileselect.c
+++ b/libleptongui/src/x_fileselect.c
@@ -441,6 +441,7 @@ schematic_file_select_dialog_save_as (GtkWindow *parent)
  *  \param [in] main_window The main_window widget of the
  *                          schematic window.
  *  \param  [in] dialog The 'Save as' dialog widget to set up.
+ *  \param [in] fname The page filename.
  *  \return                    TRUE if dialog was closed with ACCEPT response.
  */
 gboolean
@@ -448,15 +449,14 @@ x_fileselect_save (SchematicWindow *w_current,
                    LeptonPage* page,
                    gboolean* result,
                    GtkWidget *main_window,
-                   GtkWidget *dialog)
+                   GtkWidget *dialog,
+                   gchar *fname)
 {
   gboolean ret = FALSE;
   if (result != NULL)
   {
     *result = FALSE;
   }
-
-  const gchar* fname = lepton_page_get_filename (page);
 
   if (filename_sch (fname))
   {

--- a/libleptongui/src/x_fileselect.c
+++ b/libleptongui/src/x_fileselect.c
@@ -46,8 +46,8 @@ add_filter (GtkFileChooser* filechooser,
 
 
 
-static gboolean
-filename_sym (const gchar* fname)
+gboolean
+schematic_file_select_dialog_filename_sym (const gchar* fname)
 {
   gchar* str = g_utf8_strdown (fname, -1);
   gboolean res = g_str_has_suffix (str, ".sym");
@@ -79,7 +79,7 @@ filter_func_sch(const GtkFileFilterInfo* info, gpointer data)
 static gboolean
 filter_func_sym(const GtkFileFilterInfo* info, gpointer data)
 {
-  return filename_sym (info->filename);
+  return schematic_file_select_dialog_filename_sym (info->filename);
 }
 
 static gboolean
@@ -87,7 +87,7 @@ filter_func_sch_sym(const GtkFileFilterInfo* info, gpointer data)
 {
   return
     schematic_file_select_dialog_filename_sch (info->filename)
-    || filename_sym (info->filename);
+    || schematic_file_select_dialog_filename_sym (info->filename);
 }
 
 static gboolean
@@ -198,7 +198,8 @@ on_filter_changed (GtkFileChooserDialog* dialog, gpointer data)
 
   gchar* bname = NULL;
 
-  if (filter == filter_sch && filename_sym (fname))
+  if (filter == filter_sch &&
+      schematic_file_select_dialog_filename_sym (fname))
   {
     bname = basename_switch_suffix (fname, "sch");
   }
@@ -466,7 +467,7 @@ x_fileselect_save (SchematicWindow *w_current,
     gtk_file_chooser_set_filter (GTK_FILE_CHOOSER (dialog), filter_sch);
   }
   else
-  if (filename_sym (fname))
+  if (schematic_file_select_dialog_filename_sym (fname))
   {
     gtk_file_chooser_set_filter (GTK_FILE_CHOOSER (dialog), filter_sym);
   }

--- a/libleptongui/src/x_fileselect.c
+++ b/libleptongui/src/x_fileselect.c
@@ -508,10 +508,6 @@ x_fileselect_save (SchematicWindow *w_current,
                    gchar *fname)
 {
   gboolean ret = FALSE;
-  if (result != NULL)
-  {
-    *result = FALSE;
-  }
 
   if (gtk_dialog_run ((GtkDialog*)dialog) == GTK_RESPONSE_ACCEPT)
   {

--- a/libleptongui/src/x_fileselect.c
+++ b/libleptongui/src/x_fileselect.c
@@ -507,8 +507,6 @@ x_fileselect_save (SchematicWindow *w_current,
                    GtkWidget *dialog,
                    gchar *fname)
 {
-  gboolean ret = FALSE;
-
   if (gtk_dialog_run ((GtkDialog*)dialog) == GTK_RESPONSE_ACCEPT)
   {
     gchar *filename = gtk_file_chooser_get_filename (GTK_FILE_CHOOSER (dialog));
@@ -536,21 +534,27 @@ x_fileselect_save (SchematicWindow *w_current,
     */
     if (filename != NULL)
     {
-      ret = TRUE;
-
       gboolean res = x_window_save_page (w_current, page, filename);
+
+      g_free (filename);
 
       if (result != NULL)
       {
         *result = res;
       }
+
+      return TRUE;
+    }
+    else
+    {
+      return FALSE;
     }
 
-    g_free (filename);
-
   } /* if: accept response */
-
-  return ret;
+  else
+  {
+    return FALSE;
+  }
 
 } /* x_fileselect_save() */
 

--- a/libleptongui/src/x_fileselect.c
+++ b/libleptongui/src/x_fileselect.c
@@ -508,18 +508,9 @@ x_fileselect_save (SchematicWindow *w_current,
                    gboolean file_exists,
                    gboolean overwrite_cancelled)
 {
-    if (file_exists)
-    {
-      if (overwrite_cancelled)
-      {
-        filename = NULL;
-      }
-    }
-
-
     /* try saving the page to file filename:
     */
-    if (filename != NULL)
+    if (filename != NULL && !overwrite_cancelled)
     {
       gboolean res = x_window_save_page (w_current, page, filename);
 

--- a/libleptongui/src/x_fileselect.c
+++ b/libleptongui/src/x_fileselect.c
@@ -491,8 +491,6 @@ schematic_file_select_dialog_overwrite_file (GtkWidget *parent,
  *  \param  [in]     w_current The SchematicWindow environment.
  *  \param  [in]     page      The page to be saved.
  *  \param  [in,out] result    If not NULL, will be filled with save operation result.
- *  \param [in] main_window The main_window widget of the
- *                          schematic window.
  *  \param  [in] dialog The 'Save as' dialog widget to set up.
  *  \param [in] fname The page filename.
  *  \return TRUE if the dialog was closed with ACCEPT response and
@@ -503,7 +501,6 @@ gboolean
 x_fileselect_save (SchematicWindow *w_current,
                    LeptonPage* page,
                    gboolean* result,
-                   GtkWidget *main_window,
                    GtkWidget *dialog,
                    gchar *fname)
 {

--- a/libleptongui/src/x_fileselect.c
+++ b/libleptongui/src/x_fileselect.c
@@ -494,7 +494,6 @@ schematic_file_select_dialog_overwrite_file (GtkWidget *parent,
  *  \param  [in] dialog The 'Save as' dialog widget to set up.
  *  \param  [in] filename The filename chosen in the 'Save as' dialog.
  *  \param  [in] file_exists TRUE if a file with the chosen filename already exists.
- *  \param  [in] checkdialog The overwrite dialog for existing files.
  *  \param  [in] overwrite_cancelled TRUE if the user cancelled an overwrite.
  *  \return TRUE if the dialog was closed with ACCEPT response and
  *          the user selected a name of a non-existing file or
@@ -507,7 +506,6 @@ x_fileselect_save (SchematicWindow *w_current,
                    GtkWidget *dialog,
                    char *filename,
                    gboolean file_exists,
-                   GtkWidget *checkdialog,
                    gboolean overwrite_cancelled)
 {
     /* If the file already exists, display a dialog box to check if
@@ -520,8 +518,6 @@ x_fileselect_save (SchematicWindow *w_current,
         g_message (_("Save cancelled on user request"));
         filename = NULL;
       }
-
-      gtk_widget_destroy (checkdialog);
     }
 
 

--- a/libleptongui/src/x_fileselect.c
+++ b/libleptongui/src/x_fileselect.c
@@ -490,14 +490,6 @@ x_fileselect_save (SchematicWindow *w_current,
     *result = FALSE;
   }
 
-  /* add handler for dialog's "filter" property change notification:
-  */
-  g_signal_connect (dialog,
-                    "notify::filter",
-                    G_CALLBACK (&schematic_file_select_dialog_filter_changed),
-                    NULL);
-
-
   /*
    * Open "Save As.." dialog:
   */

--- a/libleptongui/src/x_fileselect.c
+++ b/libleptongui/src/x_fileselect.c
@@ -495,7 +495,9 @@ schematic_file_select_dialog_overwrite_file (GtkWidget *parent,
  *                          schematic window.
  *  \param  [in] dialog The 'Save as' dialog widget to set up.
  *  \param [in] fname The page filename.
- *  \return                    TRUE if dialog was closed with ACCEPT response.
+ *  \return TRUE if the dialog was closed with ACCEPT response and
+ *          the user selected a name of a non-existing file or
+ *          allowed (didn't cancel) overwriting an existing one.
  */
 gboolean
 x_fileselect_save (SchematicWindow *w_current,

--- a/libleptongui/src/x_fileselect.c
+++ b/libleptongui/src/x_fileselect.c
@@ -515,7 +515,6 @@ x_fileselect_save (SchematicWindow *w_current,
     {
       if (overwrite_cancelled)
       {
-        g_message (_("Save cancelled on user request"));
         filename = NULL;
       }
     }

--- a/libleptongui/src/x_fileselect.c
+++ b/libleptongui/src/x_fileselect.c
@@ -495,6 +495,7 @@ schematic_file_select_dialog_overwrite_file (GtkWidget *parent,
  *  \param  [in] filename The filename chosen in the 'Save as' dialog.
  *  \param  [in] file_exists TRUE if a file with the chosen filename already exists.
  *  \param  [in] checkdialog The overwrite dialog for existing files.
+ *  \param  [in] overwrite_cancelled TRUE if the user cancelled an overwrite.
  *  \return TRUE if the dialog was closed with ACCEPT response and
  *          the user selected a name of a non-existing file or
  *          allowed (didn't cancel) overwriting an existing one.
@@ -506,14 +507,15 @@ x_fileselect_save (SchematicWindow *w_current,
                    GtkWidget *dialog,
                    char *filename,
                    gboolean file_exists,
-                   GtkWidget *checkdialog)
+                   GtkWidget *checkdialog,
+                   gboolean overwrite_cancelled)
 {
     /* If the file already exists, display a dialog box to check if
        the user really wants to overwrite it:
     */
     if (file_exists)
     {
-      if (gtk_dialog_run (GTK_DIALOG (checkdialog)) != GTK_RESPONSE_YES)
+      if (overwrite_cancelled)
       {
         g_message (_("Save cancelled on user request"));
         filename = NULL;

--- a/libleptongui/src/x_fileselect.c
+++ b/libleptongui/src/x_fileselect.c
@@ -415,9 +415,6 @@ x_fileselect_save (SchematicWindow *w_current,
                    LeptonPage* page,
                    gboolean* result)
 {
-  g_return_val_if_fail (w_current != NULL, FALSE);
-  g_return_val_if_fail (page != NULL, FALSE);
-
   gboolean ret = FALSE;
   if (result != NULL)
   {

--- a/libleptongui/src/x_fileselect.c
+++ b/libleptongui/src/x_fileselect.c
@@ -210,8 +210,9 @@ basename_switch_suffix (const gchar* path, const gchar* suffix)
  *  Change filename's extension (.sch or .sym) in the "Save As"
  *  dialog according to the currently selected filter.
  */
-static void
-on_filter_changed (GtkFileChooserDialog* dialog, gpointer data)
+void
+schematic_file_select_dialog_filter_changed (GtkFileChooserDialog* dialog,
+                                             gpointer data)
 {
   GtkFileChooser* chooser = GTK_FILE_CHOOSER (dialog);
   GtkFileFilter*  filter  = gtk_file_chooser_get_filter (chooser);
@@ -245,7 +246,7 @@ on_filter_changed (GtkFileChooserDialog* dialog, gpointer data)
     g_free (bname);
   }
 
-} /* on_filter_changed() */
+} /* schematic_file_select_dialog_filter_changed() */
 
 
 
@@ -493,7 +494,7 @@ x_fileselect_save (SchematicWindow *w_current,
   */
   g_signal_connect (dialog,
                     "notify::filter",
-                    G_CALLBACK (&on_filter_changed),
+                    G_CALLBACK (&schematic_file_select_dialog_filter_changed),
                     NULL);
 
 

--- a/libleptongui/src/x_fileselect.c
+++ b/libleptongui/src/x_fileselect.c
@@ -392,6 +392,36 @@ x_fileselect_open (SchematicWindow *w_current,
 }
 
 
+GtkWidget*
+schematic_file_select_dialog_save_as (GtkWindow *parent)
+{
+  GtkWidget* dialog =
+    gtk_file_chooser_dialog_new (_("Save As"),
+                                 GTK_WINDOW (parent),
+                                 GTK_FILE_CHOOSER_ACTION_SAVE,
+                                 _("_Cancel"), GTK_RESPONSE_CANCEL,
+                                 _("_Save"), GTK_RESPONSE_ACCEPT,
+                                 NULL);
+#ifndef ENABLE_GTK3
+  /* Set the alternative button order (ok, cancel, help) for other
+   * systems. */
+  gtk_dialog_set_alternative_button_order (GTK_DIALOG (dialog),
+                                           GTK_RESPONSE_ACCEPT,
+                                           GTK_RESPONSE_CANCEL,
+                                           -1);
+#endif
+  /* Set default response signal. This is usually triggered by the
+   * "Return" key. */
+  gtk_dialog_set_default_response (GTK_DIALOG(dialog),
+                                   GTK_RESPONSE_ACCEPT);
+  g_object_set (dialog,
+                /* GtkFileChooser */
+                "select-multiple", FALSE,
+                NULL);
+
+  return dialog;
+}
+
 
 /*! \brief Opens a file chooser for saving the current page.
  *  \par Function Description
@@ -424,34 +454,8 @@ x_fileselect_save (SchematicWindow *w_current,
     *result = FALSE;
   }
 
-  GtkWidget* dialog = gtk_file_chooser_dialog_new(
-    _("Save As"),
-    GTK_WINDOW (main_window),
-    GTK_FILE_CHOOSER_ACTION_SAVE,
-    _("_Cancel"), GTK_RESPONSE_CANCEL,
-    _("_Save"),   GTK_RESPONSE_ACCEPT,
-    NULL);
-
-#ifndef ENABLE_GTK3
-  /* Set the alternative button order (ok, cancel, help) for other systems:
-  */
-  gtk_dialog_set_alternative_button_order(GTK_DIALOG(dialog),
-                                          GTK_RESPONSE_ACCEPT,
-                                          GTK_RESPONSE_CANCEL,
-                                          -1);
-#endif
-
-  /* set default response signal. This is usually triggered by the
-   * "Return" key:
-  */
-  gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_ACCEPT);
-
-  g_object_set (dialog,
-                /* GtkFileChooser */
-                "select-multiple", FALSE,
-                /* only in GTK 2.8 */
-                /* "do-overwrite-confirmation", TRUE, */
-                NULL);
+  GtkWidget *dialog =
+    schematic_file_select_dialog_save_as (GTK_WINDOW (main_window));
 
   /* add file filters to dialog:
   */

--- a/libleptongui/src/x_fileselect.c
+++ b/libleptongui/src/x_fileselect.c
@@ -408,21 +408,21 @@ x_fileselect_open (SchematicWindow *w_current,
  *  \param  [in]     w_current The SchematicWindow environment.
  *  \param  [in]     page      The page to be saved.
  *  \param  [in,out] result    If not NULL, will be filled with save operation result.
+ *  \param [in] main_window The main_window widget of the
+ *                          schematic window.
  *  \return                    TRUE if dialog was closed with ACCEPT response.
  */
 gboolean
 x_fileselect_save (SchematicWindow *w_current,
                    LeptonPage* page,
-                   gboolean* result)
+                   gboolean* result,
+                   GtkWidget *main_window)
 {
   gboolean ret = FALSE;
   if (result != NULL)
   {
     *result = FALSE;
   }
-
-  GtkWidget *main_window =
-    schematic_window_get_main_window (w_current);
 
   GtkWidget* dialog = gtk_file_chooser_dialog_new(
     _("Save As"),

--- a/libleptongui/src/x_fileselect.c
+++ b/libleptongui/src/x_fileselect.c
@@ -464,6 +464,17 @@ schematic_file_select_dialog_save_as (GtkWindow *parent)
 }
 
 
+/*! \brief Open an 'Overwrite file?' dialog.
+ *
+ *  \par Function Description
+ *
+ *  Opens an 'Overwrite file?' dialog with a question about
+ *  overwriting \p filename.
+ *
+ *  \param [in] parent The parent Gtk window of the dialog.
+ *  \param [in] filename The name of the file to overwrite.
+ *  \return The new dialog.
+ */
 GtkWidget*
 schematic_file_select_dialog_overwrite_file (GtkWidget *parent,
                                              char *filename)

--- a/libleptongui/src/x_fileselect.c
+++ b/libleptongui/src/x_fileselect.c
@@ -489,23 +489,6 @@ x_fileselect_save (SchematicWindow *w_current,
     *result = FALSE;
   }
 
-  if (schematic_file_select_dialog_filename_sch (fname))
-  {
-    gtk_file_chooser_set_filter (GTK_FILE_CHOOSER (dialog),
-                                 schematic_file_select_dialog_get_filter_sch ());
-  }
-  else
-  if (schematic_file_select_dialog_filename_sym (fname))
-  {
-    gtk_file_chooser_set_filter (GTK_FILE_CHOOSER (dialog),
-                                 schematic_file_select_dialog_get_filter_sym ());
-  }
-  else
-  {
-    gtk_file_chooser_set_filter (GTK_FILE_CHOOSER (dialog),
-                                 schematic_file_select_dialog_get_filter_all ());
-  }
-
   /* set the current filename or directory name if new document:
   */
   if (g_file_test (fname, G_FILE_TEST_EXISTS))

--- a/libleptongui/src/x_fileselect.c
+++ b/libleptongui/src/x_fileselect.c
@@ -508,9 +508,6 @@ x_fileselect_save (SchematicWindow *w_current,
                    gboolean file_exists,
                    gboolean overwrite_cancelled)
 {
-    /* If the file already exists, display a dialog box to check if
-       the user really wants to overwrite it:
-    */
     if (file_exists)
     {
       if (overwrite_cancelled)

--- a/libleptongui/src/x_fileselect.c
+++ b/libleptongui/src/x_fileselect.c
@@ -492,7 +492,6 @@ schematic_file_select_dialog_overwrite_file (GtkWidget *parent,
  *  \param  [in]     page      The page to be saved.
  *  \param  [in,out] result    If not NULL, will be filled with save operation result.
  *  \param  [in] dialog The 'Save as' dialog widget to set up.
- *  \param [in] fname The page filename.
  *  \return TRUE if the dialog was closed with ACCEPT response and
  *          the user selected a name of a non-existing file or
  *          allowed (didn't cancel) overwriting an existing one.
@@ -501,8 +500,7 @@ gboolean
 x_fileselect_save (SchematicWindow *w_current,
                    LeptonPage* page,
                    gboolean* result,
-                   GtkWidget *dialog,
-                   gchar *fname)
+                   GtkWidget *dialog)
 {
     gchar *filename = gtk_file_chooser_get_filename (GTK_FILE_CHOOSER (dialog));
 

--- a/libleptongui/src/x_fileselect.c
+++ b/libleptongui/src/x_fileselect.c
@@ -491,16 +491,19 @@ x_fileselect_save (SchematicWindow *w_current,
 
   if (schematic_file_select_dialog_filename_sch (fname))
   {
-    gtk_file_chooser_set_filter (GTK_FILE_CHOOSER (dialog), filter_sch);
+    gtk_file_chooser_set_filter (GTK_FILE_CHOOSER (dialog),
+                                 schematic_file_select_dialog_get_filter_sch ());
   }
   else
   if (schematic_file_select_dialog_filename_sym (fname))
   {
-    gtk_file_chooser_set_filter (GTK_FILE_CHOOSER (dialog), filter_sym);
+    gtk_file_chooser_set_filter (GTK_FILE_CHOOSER (dialog),
+                                 schematic_file_select_dialog_get_filter_sym ());
   }
   else
   {
-    gtk_file_chooser_set_filter (GTK_FILE_CHOOSER (dialog), filter_all);
+    gtk_file_chooser_set_filter (GTK_FILE_CHOOSER (dialog),
+                                 schematic_file_select_dialog_get_filter_all ());
   }
 
   /* set the current filename or directory name if new document:


### PR DESCRIPTION
- Two functions for creating dialogs *Save as* and *Overwrite file?* have been factored out.
- Several static functions have been renamed, made available for dlopening and for using in Scheme.
- A *GLib* signal to the *File chooser* dialog is now connected in Scheme
- The function `x_fileselect_save()` has been rewritten in Scheme.
