### PR TITLE
Rewrite x_window_save_page() in Scheme

### DIFF
--- a/lepton-eda/po/POTFILES.in
+++ b/lepton-eda/po/POTFILES.in
@@ -45,6 +45,7 @@ lepton-eda/scheme/schematic/dialog/autonumber.scm
 lepton-eda/scheme/schematic/doc.scm
 lepton-eda/scheme/schematic/keymap.scm
 lepton-eda/scheme/schematic/rc.scm
+lepton-eda/scheme/schematic/window/page.scm
 lepton-eda/scheme/gschem/deprecated.scm
 
 tools/schematic/lepton-schematic.scm

--- a/lepton-eda/scheme/schematic/builtins.scm
+++ b/lepton-eda/scheme/schematic/builtins.scm
@@ -138,7 +138,7 @@
           ;; Simply save any other page.
           (window-save-page! (pointer->window *window)
                              page
-                             (string->pointer (page-filename page))))))
+                             (page-filename page)))))
 
   (define (save-page-and-update-header! page)
     (let ((saved? (save-page! page)))

--- a/lepton-eda/scheme/schematic/builtins.scm
+++ b/lepton-eda/scheme/schematic/builtins.scm
@@ -136,9 +136,10 @@
           ;; For untitled pages, open "Save as..." dialog.
           (file-select-save-page! *window *page)
           ;; Simply save any other page.
-          (true? (x_window_save_page *window
-                                     *page
-                                     (string->pointer (page-filename page)))))))
+          (true? (window-save-page! *window
+                                    *page
+                                    (string->pointer
+                                     (page-filename page)))))))
 
   (define (save-page-and-update-header! page)
     (let ((saved? (save-page! page)))

--- a/lepton-eda/scheme/schematic/builtins.scm
+++ b/lepton-eda/scheme/schematic/builtins.scm
@@ -136,10 +136,9 @@
           ;; For untitled pages, open "Save as..." dialog.
           (file-select-save-page! *window *page)
           ;; Simply save any other page.
-          (true? (window-save-page! *window
-                                    *page
-                                    (string->pointer
-                                     (page-filename page)))))))
+          (window-save-page! *window
+                             *page
+                             (string->pointer (page-filename page))))))
 
   (define (save-page-and-update-header! page)
     (let ((saved? (save-page! page)))

--- a/lepton-eda/scheme/schematic/builtins.scm
+++ b/lepton-eda/scheme/schematic/builtins.scm
@@ -111,12 +111,14 @@
   (window-save-active-page! (current-window)))
 
 (define-action-public (&file-save-as #:label (G_ "Save As") #:icon "gtk-save-as")
+  (define window (current-window))
   (define *window (*current-window))
-  (file-select-save-page! *window
+  (file-select-save-page! window
                           (schematic_window_get_active_page *window)))
 
 ;;; Save all opened pages.
 (define-action-public (&file-save-all #:label (G_ "Save All") #:icon "gtk-save")
+  (define window (current-window))
   (define *window (*current-window))
   (define tabs-enabled? (true? (x_tabs_enabled)))
 
@@ -134,7 +136,7 @@
     (let ((*page (page->pointer page)))
       (if (untitled? *page)
           ;; For untitled pages, open "Save as..." dialog.
-          (file-select-save-page! *window *page)
+          (file-select-save-page! window *page)
           ;; Simply save any other page.
           (window-save-page! (pointer->window *window)
                              page

--- a/lepton-eda/scheme/schematic/builtins.scm
+++ b/lepton-eda/scheme/schematic/builtins.scm
@@ -113,8 +113,9 @@
 (define-action-public (&file-save-as #:label (G_ "Save As") #:icon "gtk-save-as")
   (define window (current-window))
   (define *window (*current-window))
-  (file-select-save-page! window
-                          (schematic_window_get_active_page *window)))
+  (define page
+    (pointer->page (schematic_window_get_active_page *window)))
+  (file-select-save-page! window page))
 
 ;;; Save all opened pages.
 (define-action-public (&file-save-all #:label (G_ "Save All") #:icon "gtk-save")
@@ -136,7 +137,7 @@
     (let ((*page (page->pointer page)))
       (if (untitled? *page)
           ;; For untitled pages, open "Save as..." dialog.
-          (file-select-save-page! window *page)
+          (file-select-save-page! window page)
           ;; Simply save any other page.
           (window-save-page! (pointer->window *window)
                              page

--- a/lepton-eda/scheme/schematic/builtins.scm
+++ b/lepton-eda/scheme/schematic/builtins.scm
@@ -136,7 +136,7 @@
           ;; For untitled pages, open "Save as..." dialog.
           (file-select-save-page! *window *page)
           ;; Simply save any other page.
-          (window-save-page! *window
+          (window-save-page! (pointer->window *window)
                              *page
                              (string->pointer (page-filename page))))))
 

--- a/lepton-eda/scheme/schematic/builtins.scm
+++ b/lepton-eda/scheme/schematic/builtins.scm
@@ -137,7 +137,7 @@
           (file-select-save-page! *window *page)
           ;; Simply save any other page.
           (window-save-page! (pointer->window *window)
-                             *page
+                             page
                              (string->pointer (page-filename page))))))
 
   (define (save-page-and-update-header! page)

--- a/lepton-eda/scheme/schematic/ffi.scm
+++ b/lepton-eda/scheme/schematic/ffi.scm
@@ -1051,7 +1051,7 @@
 
 ;;; x_window.c
 (define-lff recent_manager_add void '(* *))
-(define-lff x_window_save_page int (list '* '* '* int))
+(define-lff x_window_save_page int (list '* '* '* int int))
 (define-lff x_window_untitled_page int '(*))
 (define-lff schematic_window_create_app_window '* '(*))
 (define-lff schematic_window_create_main_box '* '(*))

--- a/lepton-eda/scheme/schematic/ffi.scm
+++ b/lepton-eda/scheme/schematic/ffi.scm
@@ -36,6 +36,8 @@
 
             g_init_window
 
+            f_save
+
             g_read_file
 
             gdk_window_type_hint_to_string
@@ -305,6 +307,7 @@
             schematic_window_create_app_window
             schematic_window_create_main_box
             schematic_window_create_work_box
+            schematic_window_dialog_save_error
             schematic_toolbar_toggle_tool_button_get_active
             schematic_window_get_inside_action
             schematic_window_set_page_select_widget
@@ -700,6 +703,9 @@
 ;;; rotation_combo.c
 (define-lff schematic_rotation_combo_get_angle int '(*))
 
+;;; f_basic.c
+(define-lff f_save int '(* * *))
+
 ;;; g_basic.c
 (define-lff g_read_file int '(* * *))
 
@@ -1045,11 +1051,12 @@
 
 ;;; x_window.c
 (define-lff recent_manager_add void '(* *))
-(define-lff x_window_save_page int '(* * *))
+(define-lff x_window_save_page int (list '* '* '* int))
 (define-lff x_window_untitled_page int '(*))
 (define-lff schematic_window_create_app_window '* '(*))
 (define-lff schematic_window_create_main_box '* '(*))
 (define-lff schematic_window_create_work_box '* '())
+(define-lff schematic_window_dialog_save_error void '(* *))
 (define-lff schematic_toolbar_toggle_tool_button_get_active int '(*))
 (define-lff schematic_window_get_inside_action int '(*))
 (define-lff schematic_window_set_page_select_widget void '(* *))

--- a/lepton-eda/scheme/schematic/ffi.scm
+++ b/lepton-eda/scheme/schematic/ffi.scm
@@ -302,7 +302,6 @@
             schematic_compselect_get_preview
 
             recent_manager_add
-            x_window_save_page
             x_window_untitled_page
             schematic_window_create_app_window
             schematic_window_create_main_box
@@ -1051,7 +1050,6 @@
 
 ;;; x_window.c
 (define-lff recent_manager_add void '(* *))
-(define-lff x_window_save_page int (list '* '* '* int int))
 (define-lff x_window_untitled_page int '(*))
 (define-lff schematic_window_create_app_window '* '(*))
 (define-lff schematic_window_create_main_box '* '(*))

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -76,11 +76,10 @@ success, otherwise #f."
          (string->pointer message))))
 
     (let ((different-names?
-           (not (string-ci= (pointer->string (lepton_page_get_filename *page))
-                            filename))))
+           (not (string-ci= (page-filename page) filename))))
       (when (and result
                  different-names?)
-        (lepton_page_set_filename *page *filename))
+        (set-page-filename! page filename))
 
       (when result
         ;; Reset page CHANGED flag.

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -47,6 +47,13 @@
 
 
 (define (window-save-page! *window *page *filename)
+  (when (null-pointer? *window)
+    (error "NULL window."))
+  (when (null-pointer? *page)
+    (error "NULL page."))
+  (when (null-pointer? *filename)
+    (error "NULL filename."))
+
   (x_window_save_page *window *page *filename))
 
 

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -70,8 +70,15 @@
          *window
          (string->pointer message))))
 
-    (x_window_save_page *window *page *filename result)
-    result))
+    (let ((different-names?
+           (not (string-ci= (pointer->string (lepton_page_get_filename *page))
+                            (pointer->string *filename)))))
+      (x_window_save_page *window
+                          *page
+                          *filename
+                          result
+                          (if different-names? TRUE FALSE))
+      result)))
 
 
 ;;; Opens a file chooser dialog in *WINDOW for *PAGE and waits for

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -56,15 +56,14 @@
 success, otherwise #f."
   (define *window (check-window window 1))
   (define *page (check-page page 2))
-  ;; Temporarily define the pointer before checking the string.
-  (define *filename (string->pointer filename))
   (define **err
     (bytevector->pointer (make-bytevector (sizeof '*) 0)))
 
   (check-string filename 3)
 
   ;; Try saving page to filename.
-  (let ((result (true? (f_save *page *filename **err)))
+  (let ((result
+         (true? (f_save *page (string->pointer filename) **err)))
         (*err (dereference-pointer **err)))
     (when (and (not result)
                (not (null-pointer? *err)))
@@ -85,7 +84,7 @@ success, otherwise #f."
         ;; Reset page CHANGED flag.
         (lepton_page_set_changed *page 0)
         ;; Add to recent file list.
-        (recent_manager_add *window *filename)
+        (recent_manager_add *window (string->pointer filename))
         ;; Update Page Manager.
         (page_select_widget_update *window))
 

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -50,8 +50,8 @@
 
 
 (define (window-save-page! *window *page *filename)
-  "Saves *PAGE in *WINDOW to a file named *FILENAME.  Returns TRUE on
-success, FALSE otherwise (C booleans)."
+  "Saves *PAGE in *WINDOW to a file named *FILENAME.  Returns #t on
+success, otherwise #f."
   (define **err
     (bytevector->pointer (make-bytevector (sizeof '*) 0)))
   (when (null-pointer? *window)
@@ -107,7 +107,7 @@ success, FALSE otherwise (C booleans)."
                         (if (false? result)
                             (G_ "Error while trying to save")
                             (G_ "Saved"))))
-      result)))
+      (true? result))))
 
 
 ;;; Opens a file chooser dialog in *WINDOW for *PAGE and waits for
@@ -158,9 +158,9 @@ success, FALSE otherwise (C booleans)."
               #t)
 
             ;; Try saving the page to filename.
-            (true? (window-save-page! *window
-                                      *page
-                                      (string->pointer filename))))))
+            (window-save-page! *window
+                               *page
+                               (string->pointer filename)))))
 
   (when (null-pointer? *window)
     (error "NULL window."))

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -49,13 +49,12 @@
   (schematic_window_page_changed *window))
 
 
-(define (window-save-page! *window *page *filename)
-  "Saves *PAGE in *WINDOW to a file named *FILENAME.  Returns #t on
+(define (window-save-page! window *page *filename)
+  "Saves *PAGE in WINDOW to a file named *FILENAME.  Returns #t on
 success, otherwise #f."
+  (define *window (check-window window 1))
   (define **err
     (bytevector->pointer (make-bytevector (sizeof '*) 0)))
-  (when (null-pointer? *window)
-    (error "NULL window."))
   (when (null-pointer? *page)
     (error "NULL page."))
   (when (null-pointer? *filename)
@@ -158,7 +157,7 @@ success, otherwise #f."
               #t)
 
             ;; Try saving the page to filename.
-            (window-save-page! *window
+            (window-save-page! (pointer->window *window)
                                *page
                                (string->pointer filename)))))
 
@@ -225,6 +224,6 @@ success, otherwise #f."
         ;; Open "Save as..." dialog.
         (file-select-save-page! *window *page)
         ;; Save page.
-        (window-save-page! *window
+        (window-save-page! window
                            *page
                            (lepton_page_get_filename *page)))))

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -29,6 +29,7 @@
   #:use-module (lepton log)
   #:use-module (lepton page foreign)
 
+  #:use-module (schematic action-mode)
   #:use-module (schematic ffi gtk)
   #:use-module (schematic ffi)
   #:use-module (schematic gtk helper)
@@ -88,6 +89,13 @@
         (recent_manager_add *window *filename)
         ;; Update Page Manager.
         (page_select_widget_update *window))
+
+      (i_set_state_msg *window
+                       (symbol->action-mode 'select-mode)
+                       (string->pointer
+                        (if (false? result)
+                            (G_ "Error while trying to save")
+                            (G_ "Saved"))))
       result)))
 
 

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -81,6 +81,13 @@
                           *filename
                           result
                           (if different-names? TRUE FALSE))
+      (when (true? result)
+        ;; Reset page CHANGED flag.
+        (lepton_page_set_changed *page 0)
+        ;; Add to recent file list.
+        (recent_manager_add *window *filename)
+        ;; Update Page Manager.
+        (page_select_widget_update *window))
       result)))
 
 

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -74,25 +74,24 @@ success, otherwise #f."
          *window
          (string->pointer message))))
 
+    ;; Update widgets, log and display the status of operation.
     (let ((different-names?
            (not (string-ci= (page-filename page) filename))))
-      (when (and result
-                 different-names?)
-        (set-page-filename! page filename))
-
-      (when result
-        ;; Reset page CHANGED flag.
-        (set-page-dirty! page #f)
-        ;; Add to recent file list.
-        (recent_manager_add *window (string->pointer filename))
-        ;; Update Page Manager.
-        (page_select_widget_update *window))
-
-      ;; Log status of operation.
       (if result
-          (if different-names?
-              (log! 'message (G_ "Saved as ~S") filename)
-              (log! 'message (G_ "Saved ~S") filename))
+          (begin
+            (if different-names?
+                (begin
+                  (set-page-filename! page filename)
+                  (log! 'message (G_ "Saved as ~S") filename))
+                (log! 'message (G_ "Saved ~S") filename))
+            ;; Reset page CHANGED flag.
+            (set-page-dirty! page #f)
+            ;; Add to recent file list.
+            (recent_manager_add *window (string->pointer filename))
+            ;; Update Page Manager.  It has to be updated after
+            ;; changing the name and dirty status of the page.
+            (page_select_widget_update *window))
+
           (log! 'message (G_ "Could NOT save page ~S") filename))
 
       (i_set_state_msg *window

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -89,18 +89,18 @@ success, otherwise #f."
         (page_select_widget_update *window))
 
       ;; Log status of operation.
-      (if (not result)
-          (log! 'message (G_ "Could NOT save page ~S") filename)
+      (if result
           (if different-names?
               (log! 'message (G_ "Saved as ~S") filename)
-              (log! 'message (G_ "Saved ~S") filename)))
+              (log! 'message (G_ "Saved ~S") filename))
+          (log! 'message (G_ "Could NOT save page ~S") filename))
 
       (i_set_state_msg *window
                        (symbol->action-mode 'select-mode)
                        (string->pointer
-                        (if (not result)
-                            (G_ "Error while trying to save")
-                            (G_ "Saved"))))
+                        (if result
+                            (G_ "Saved")
+                            (G_ "Error while trying to save"))))
       result)))
 
 

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -107,16 +107,16 @@ success, otherwise #f."
     result))
 
 
-;;; Opens a file chooser dialog for PAGE in WINDOW and waits for
-;;; the user to select a file where the page will be saved.
-;;; Returns #f on a save error, and #t in all other cases
-;;; including cancelling the Save dialog or its child overwrite
-;;; dialog.
-;;;
 ;;; The function updates the user interface. (Actual UI update is
 ;;; performed in window-save-page!(), which is called by this
 ;;; function).
 (define (file-select-save-page! window page)
+  "Opens a file chooser dialog in WINDOW to select a file name in
+which to save PAGE.  If a file with the chosen name already
+exists, an overwrite confirmation dialog is opened.  If either of
+the dialogs is cancelled by the user, the function returns #t.
+Otherwise it tries to save the page and returns #t on success, or
+#f on any error."
   (define *window (check-window window 1))
   (define *page (check-page page 2))
 

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -59,6 +59,16 @@ success, otherwise #f."
                      (symbol->action-mode 'select-mode)
                      (string->pointer message)))
 
+  (define (process-error)
+    (let ((*err (dereference-pointer **err)))
+      (unless (null-pointer? *err)
+        (let ((message (gerror-message *err)))
+          (g_clear_error **err)
+
+          (schematic_window_dialog_save_error
+           *window
+           (string->pointer message))))))
+
   (define *window (check-window window 1))
   (define *page (check-page page 2))
   (define **err
@@ -68,16 +78,7 @@ success, otherwise #f."
 
   ;; Try saving page to filename.
   (let ((result
-         (true? (f_save *page (string->pointer filename) **err)))
-        (*err (dereference-pointer **err)))
-    (when (and (not result)
-               (not (null-pointer? *err)))
-      (let ((message (gerror-message *err)))
-        (g_clear_error **err)
-
-        (schematic_window_dialog_save_error
-         *window
-         (string->pointer message))))
+         (true? (f_save *page (string->pointer filename) **err))))
 
     ;; Update widgets, log and display the status of operation.
     (if result
@@ -99,6 +100,7 @@ success, otherwise #f."
           (set-statusbar-message! (G_ "Saved")))
 
         (begin
+          (process-error)
           (log! 'message (G_ "Could NOT save page ~S") filename)
           (set-statusbar-message! (G_ "Error while trying to save"))))
 

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -49,14 +49,13 @@
   (schematic_window_page_changed *window))
 
 
-(define (window-save-page! window *page *filename)
-  "Saves *PAGE in WINDOW to a file named *FILENAME.  Returns #t on
+(define (window-save-page! window page *filename)
+  "Saves PAGE in WINDOW to a file named *FILENAME.  Returns #t on
 success, otherwise #f."
   (define *window (check-window window 1))
+  (define *page (check-page page 2))
   (define **err
     (bytevector->pointer (make-bytevector (sizeof '*) 0)))
-  (when (null-pointer? *page)
-    (error "NULL page."))
   (when (null-pointer? *filename)
     (error "NULL filename."))
 
@@ -158,7 +157,7 @@ success, otherwise #f."
 
             ;; Try saving the page to filename.
             (window-save-page! (pointer->window *window)
-                               *page
+                               (pointer->page *page)
                                (string->pointer filename)))))
 
   (when (null-pointer? *window)
@@ -218,6 +217,7 @@ success, otherwise #f."
 (define (window-save-active-page! window)
   (define *window (check-window window 1))
   (define *page (schematic_window_get_active_page *window))
+  (define page (pointer->page *page))
 
   (unless (null-pointer? *page)
     (if (true? (x_window_untitled_page *page))
@@ -225,5 +225,5 @@ success, otherwise #f."
         (file-select-save-page! *window *page)
         ;; Save page.
         (window-save-page! window
-                           *page
+                           page
                            (lepton_page_get_filename *page)))))

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -62,9 +62,9 @@ success, otherwise #f."
     (error "NULL filename."))
 
   ;; Try saving page to filename.
-  (let ((result (f_save *page *filename **err))
+  (let ((result (true? (f_save *page *filename **err)))
         (*err (dereference-pointer **err)))
-    (when (and (false? result)
+    (when (and (not result)
                (not (null-pointer? *err)))
       (let ((message (gerror-message *err)))
         (g_clear_error **err)
@@ -76,11 +76,11 @@ success, otherwise #f."
     (let ((different-names?
            (not (string-ci= (pointer->string (lepton_page_get_filename *page))
                             (pointer->string *filename)))))
-      (when (and (true? result)
+      (when (and result
                  different-names?)
         (lepton_page_set_filename *page *filename))
 
-      (when (true? result)
+      (when result
         ;; Reset page CHANGED flag.
         (lepton_page_set_changed *page 0)
         ;; Add to recent file list.
@@ -89,7 +89,7 @@ success, otherwise #f."
         (page_select_widget_update *window))
 
       ;; Log status of operation.
-      (if (false? result)
+      (if (not result)
           (log! 'message
                 (G_ "Could NOT save page ~S")
                 (pointer->string *filename))
@@ -104,10 +104,10 @@ success, otherwise #f."
       (i_set_state_msg *window
                        (symbol->action-mode 'select-mode)
                        (string->pointer
-                        (if (false? result)
+                        (if (not result)
                             (G_ "Error while trying to save")
                             (G_ "Saved"))))
-      (true? result))))
+      result)))
 
 
 ;;; Opens a file chooser dialog in *WINDOW for *PAGE and waits for

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -21,6 +21,7 @@
   #:use-module (system foreign)
 
   #:use-module (lepton ffi boolean)
+  #:use-module (lepton ffi check-args)
   #:use-module (lepton ffi glib)
   #:use-module (lepton ffi gobject)
   #:use-module (lepton ffi)
@@ -28,6 +29,7 @@
   #:use-module (lepton gettext)
   #:use-module (lepton log)
   #:use-module (lepton page foreign)
+  #:use-module (lepton page)
 
   #:use-module (schematic action-mode)
   #:use-module (schematic ffi gtk)
@@ -49,15 +51,17 @@
   (schematic_window_page_changed *window))
 
 
-(define (window-save-page! window page *filename)
-  "Saves PAGE in WINDOW to a file named *FILENAME.  Returns #t on
+(define (window-save-page! window page filename)
+  "Saves PAGE in WINDOW to a file named FILENAME.  Returns #t on
 success, otherwise #f."
   (define *window (check-window window 1))
   (define *page (check-page page 2))
+  ;; Temporarily define the pointer before checking the string.
+  (define *filename (string->pointer filename))
   (define **err
     (bytevector->pointer (make-bytevector (sizeof '*) 0)))
-  (when (null-pointer? *filename)
-    (error "NULL filename."))
+
+  (check-string filename 3)
 
   ;; Try saving page to filename.
   (let ((result (true? (f_save *page *filename **err)))
@@ -158,7 +162,7 @@ success, otherwise #f."
             ;; Try saving the page to filename.
             (window-save-page! (pointer->window *window)
                                (pointer->page *page)
-                               (string->pointer filename)))))
+                               filename))))
 
   (when (null-pointer? *window)
     (error "NULL window."))
@@ -224,6 +228,4 @@ success, otherwise #f."
         ;; Open "Save as..." dialog.
         (file-select-save-page! *window *page)
         ;; Save page.
-        (window-save-page! window
-                           page
-                           (lepton_page_get_filename *page)))))
+        (window-save-page! window page (page-filename page)))))

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -73,6 +73,9 @@
     (let ((different-names?
            (not (string-ci= (pointer->string (lepton_page_get_filename *page))
                             (pointer->string *filename)))))
+      (when (and (true? result)
+                 different-names?)
+        (lepton_page_set_filename *page *filename))
       (x_window_save_page *window
                           *page
                           *filename

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -75,32 +75,31 @@ success, otherwise #f."
          (string->pointer message))))
 
     ;; Update widgets, log and display the status of operation.
-    (let ((different-names?
-           (not (string-ci= (page-filename page) filename))))
-      (if result
-          (begin
-            (if different-names?
-                (begin
-                  (set-page-filename! page filename)
-                  (log! 'message (G_ "Saved as ~S") filename))
-                (log! 'message (G_ "Saved ~S") filename))
-            ;; Reset page CHANGED flag.
-            (set-page-dirty! page #f)
-            ;; Add to recent file list.
-            (recent_manager_add *window (string->pointer filename))
-            ;; Update Page Manager.  It has to be updated after
-            ;; changing the name and dirty status of the page.
-            (page_select_widget_update *window))
+    (if result
+        (begin
+          (if (string-ci= (page-filename page) filename)
+              (log! 'message (G_ "Saved ~S") filename)
+              ;; The file names differ.
+              (begin
+                (set-page-filename! page filename)
+                (log! 'message (G_ "Saved as ~S") filename)))
+          ;; Reset page CHANGED flag.
+          (set-page-dirty! page #f)
+          ;; Add to recent file list.
+          (recent_manager_add *window (string->pointer filename))
+          ;; Update Page Manager.  It has to be updated after
+          ;; changing the name and dirty status of the page.
+          (page_select_widget_update *window))
 
-          (log! 'message (G_ "Could NOT save page ~S") filename))
+        (log! 'message (G_ "Could NOT save page ~S") filename))
 
-      (i_set_state_msg *window
-                       (symbol->action-mode 'select-mode)
-                       (string->pointer
-                        (if result
-                            (G_ "Saved")
-                            (G_ "Error while trying to save"))))
-      result)))
+    (i_set_state_msg *window
+                     (symbol->action-mode 'select-mode)
+                     (string->pointer
+                      (if result
+                          (G_ "Saved")
+                          (G_ "Error while trying to save"))))
+    result))
 
 
 ;;; Opens a file chooser dialog in *WINDOW for *PAGE and waits for

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -82,7 +82,7 @@ success, otherwise #f."
 
       (when result
         ;; Reset page CHANGED flag.
-        (lepton_page_set_changed *page 0)
+        (set-page-dirty! page #f)
         ;; Add to recent file list.
         (recent_manager_add *window (string->pointer filename))
         ;; Update Page Manager.

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -94,13 +94,14 @@ success, otherwise #f."
           (recent_manager_add *window (string->pointer filename))
           ;; Update Page Manager.  It has to be updated after
           ;; changing the name and dirty status of the page.
-          (page_select_widget_update *window))
+          (page_select_widget_update *window)
 
-        (log! 'message (G_ "Could NOT save page ~S") filename))
+          (set-statusbar-message! (G_ "Saved")))
 
-    (set-statusbar-message! (if result
-                                (G_ "Saved")
-                                (G_ "Error while trying to save")))
+        (begin
+          (log! 'message (G_ "Could NOT save page ~S") filename)
+          (set-statusbar-message! (G_ "Error while trying to save"))))
+
     result))
 
 

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -54,6 +54,11 @@
 (define (window-save-page! window page filename)
   "Saves PAGE in WINDOW to a file named FILENAME.  Returns #t on
 success, otherwise #f."
+  (define (set-statusbar-message! message)
+    (i_set_state_msg *window
+                     (symbol->action-mode 'select-mode)
+                     (string->pointer message)))
+
   (define *window (check-window window 1))
   (define *page (check-page page 2))
   (define **err
@@ -93,12 +98,9 @@ success, otherwise #f."
 
         (log! 'message (G_ "Could NOT save page ~S") filename))
 
-    (i_set_state_msg *window
-                     (symbol->action-mode 'select-mode)
-                     (string->pointer
-                      (if result
-                          (G_ "Saved")
-                          (G_ "Error while trying to save"))))
+    (set-statusbar-message! (if result
+                                (G_ "Saved")
+                                (G_ "Error while trying to save")))
     result))
 
 

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -77,7 +77,7 @@ success, otherwise #f."
 
     (let ((different-names?
            (not (string-ci= (pointer->string (lepton_page_get_filename *page))
-                            (pointer->string *filename)))))
+                            filename))))
       (when (and result
                  different-names?)
         (lepton_page_set_filename *page *filename))
@@ -92,16 +92,10 @@ success, otherwise #f."
 
       ;; Log status of operation.
       (if (not result)
-          (log! 'message
-                (G_ "Could NOT save page ~S")
-                (pointer->string *filename))
+          (log! 'message (G_ "Could NOT save page ~S") filename)
           (if different-names?
-              (log! 'message
-                    (G_ "Saved as ~S")
-                    (pointer->string *filename))
-              (log! 'message
-                    (G_ "Saved ~S")
-                    (pointer->string *filename))))
+              (log! 'message (G_ "Saved as ~S") filename)
+              (log! 'message (G_ "Saved ~S") filename)))
 
       (i_set_state_msg *window
                        (symbol->action-mode 'select-mode)

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -107,7 +107,7 @@ success, otherwise #f."
     result))
 
 
-;;; Opens a file chooser dialog for *PAGE in WINDOW and waits for
+;;; Opens a file chooser dialog for PAGE in WINDOW and waits for
 ;;; the user to select a file where the page will be saved.
 ;;; Returns #f on a save error, and #t in all other cases
 ;;; including cancelling the Save dialog or its child overwrite
@@ -116,8 +116,9 @@ success, otherwise #f."
 ;;; The function updates the user interface. (Actual UI update is
 ;;; performed in window-save-page!(), which is called by this
 ;;; function).
-(define (file-select-save-page! window *page)
+(define (file-select-save-page! window page)
   (define *window (check-window window 1))
+  (define *page (check-page page 2))
 
   (define (file-chooser-filename *dialog)
     (let* ((*filename (gtk_file_chooser_get_filename *dialog))
@@ -157,17 +158,12 @@ success, otherwise #f."
               #t)
 
             ;; Try saving the page to filename.
-            (window-save-page! window
-                               (pointer->page *page)
-                               filename))))
-
-  (when (null-pointer? *page)
-    (error "NULL page."))
+            (window-save-page! window page filename))))
 
   (let* ((*main-window (schematic_window_get_main_window *window))
          (*dialog
           (schematic_file_select_dialog_save_as *main-window))
-         (*page-filename (lepton_page_get_filename *page)))
+         (*page-filename (string->pointer (page-filename page))))
     ;; Add file filters to the dialog.
     (schematic_file_select_dialog_setup_filters *dialog)
 
@@ -221,6 +217,6 @@ success, otherwise #f."
   (unless (null-pointer? *page)
     (if (true? (x_window_untitled_page *page))
         ;; Open "Save as..." dialog.
-        (file-select-save-page! window *page)
+        (file-select-save-page! window page)
         ;; Save page.
         (window-save-page! window page (page-filename page)))))

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -33,6 +33,7 @@
   #:use-module (schematic window foreign)
 
   #:export (file-select-save-page!
+            window-save-page!
             window-set-toplevel-page!
             window-save-active-page!))
 
@@ -45,6 +46,10 @@
   (schematic_window_page_changed *window))
 
 
+(define (window-save-page! *window *page *filename)
+  (x_window_save_page *window *page *filename))
+
+
 ;;; Opens a file chooser dialog in *WINDOW for *PAGE and waits for
 ;;; the user to select a file where the page will be saved.
 ;;; Returns #f on a save error, and #t in all other cases
@@ -52,7 +57,7 @@
 ;;; dialog.
 ;;;
 ;;; The function updates the user interface. (Actual UI update is
-;;; performed in x_window_save_page(), which is called by this
+;;; performed in window-save-page!(), which is called by this
 ;;; function).
 (define (file-select-save-page! *window *page)
   (define (file-chooser-filename *dialog)
@@ -93,9 +98,9 @@
               #t)
 
             ;; Try saving the page to filename.
-            (true? (x_window_save_page *window
-                                       *page
-                                       (string->pointer filename))))))
+            (true? (window-save-page! *window
+                                      *page
+                                      (string->pointer filename))))))
 
   (when (null-pointer? *window)
     (error "NULL window."))
@@ -160,4 +165,6 @@
         ;; Open "Save as..." dialog.
         (file-select-save-page! *window *page)
         ;; Save page.
-        (x_window_save_page *window *page (lepton_page_get_filename *page)))))
+        (window-save-page! *window
+                           *page
+                           (lepton_page_get_filename *page)))))

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -17,12 +17,14 @@
 ;;; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 (define-module (schematic window page)
+  #:use-module (rnrs bytevectors)
   #:use-module (system foreign)
 
   #:use-module (lepton ffi boolean)
   #:use-module (lepton ffi glib)
   #:use-module (lepton ffi gobject)
   #:use-module (lepton ffi)
+  #:use-module (lepton gerror)
   #:use-module (lepton gettext)
   #:use-module (lepton log)
   #:use-module (lepton page foreign)
@@ -47,6 +49,8 @@
 
 
 (define (window-save-page! *window *page *filename)
+  (define **err
+    (bytevector->pointer (make-bytevector (sizeof '*) 0)))
   (when (null-pointer? *window)
     (error "NULL window."))
   (when (null-pointer? *page)
@@ -54,7 +58,20 @@
   (when (null-pointer? *filename)
     (error "NULL filename."))
 
-  (x_window_save_page *window *page *filename))
+  ;; Try saving page to filename.
+  (let ((result (f_save *page *filename **err))
+        (*err (dereference-pointer **err)))
+    (when (and (false? result)
+               (not (null-pointer? *err)))
+      (let ((message (gerror-message *err)))
+        (g_clear_error **err)
+
+        (schematic_window_dialog_save_error
+         *window
+         (string->pointer message))))
+
+    (x_window_save_page *window *page *filename result)
+    result))
 
 
 ;;; Opens a file chooser dialog in *WINDOW for *PAGE and waits for

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -50,6 +50,8 @@
 
 
 (define (window-save-page! *window *page *filename)
+  "Saves *PAGE in *WINDOW to a file named *FILENAME.  Returns TRUE on
+success, FALSE otherwise (C booleans)."
   (define **err
     (bytevector->pointer (make-bytevector (sizeof '*) 0)))
   (when (null-pointer? *window)
@@ -77,11 +79,7 @@
       (when (and (true? result)
                  different-names?)
         (lepton_page_set_filename *page *filename))
-      (x_window_save_page *window
-                          *page
-                          *filename
-                          result
-                          (if different-names? TRUE FALSE))
+
       (when (true? result)
         ;; Reset page CHANGED flag.
         (lepton_page_set_changed *page 0)
@@ -89,6 +87,19 @@
         (recent_manager_add *window *filename)
         ;; Update Page Manager.
         (page_select_widget_update *window))
+
+      ;; Log status of operation.
+      (if (false? result)
+          (log! 'message
+                (G_ "Could NOT save page ~S")
+                (pointer->string *filename))
+          (if different-names?
+              (log! 'message
+                    (G_ "Saved as ~S")
+                    (pointer->string *filename))
+              (log! 'message
+                    (G_ "Saved ~S")
+                    (pointer->string *filename))))
 
       (i_set_state_msg *window
                        (symbol->action-mode 'select-mode)

--- a/lepton-eda/scheme/schematic/window/page.scm
+++ b/lepton-eda/scheme/schematic/window/page.scm
@@ -107,7 +107,7 @@ success, otherwise #f."
     result))
 
 
-;;; Opens a file chooser dialog in *WINDOW for *PAGE and waits for
+;;; Opens a file chooser dialog for *PAGE in WINDOW and waits for
 ;;; the user to select a file where the page will be saved.
 ;;; Returns #f on a save error, and #t in all other cases
 ;;; including cancelling the Save dialog or its child overwrite
@@ -116,7 +116,9 @@ success, otherwise #f."
 ;;; The function updates the user interface. (Actual UI update is
 ;;; performed in window-save-page!(), which is called by this
 ;;; function).
-(define (file-select-save-page! *window *page)
+(define (file-select-save-page! window *page)
+  (define *window (check-window window 1))
+
   (define (file-chooser-filename *dialog)
     (let* ((*filename (gtk_file_chooser_get_filename *dialog))
            (filename (and (not (null-pointer? *filename))
@@ -155,12 +157,10 @@ success, otherwise #f."
               #t)
 
             ;; Try saving the page to filename.
-            (window-save-page! (pointer->window *window)
+            (window-save-page! window
                                (pointer->page *page)
                                filename))))
 
-  (when (null-pointer? *window)
-    (error "NULL window."))
   (when (null-pointer? *page)
     (error "NULL page."))
 
@@ -221,6 +221,6 @@ success, otherwise #f."
   (unless (null-pointer? *page)
     (if (true? (x_window_untitled_page *page))
         ;; Open "Save as..." dialog.
-        (file-select-save-page! *window *page)
+        (file-select-save-page! window *page)
         ;; Save page.
         (window-save-page! window page (page-filename page)))))

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -997,7 +997,8 @@ recent_manager_add (SchematicWindow *w_current,
 gint
 x_window_save_page (SchematicWindow *w_current,
                     LeptonPage *page,
-                    const gchar *filename);
+                    const gchar *filename,
+                    int ret);
 gboolean
 x_window_untitled_page (LeptonPage* page);
 

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -998,7 +998,8 @@ gint
 x_window_save_page (SchematicWindow *w_current,
                     LeptonPage *page,
                     const gchar *filename,
-                    int ret);
+                    int ret,
+                    gboolean different_names);
 gboolean
 x_window_untitled_page (LeptonPage* page);
 

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -989,6 +989,9 @@ schematic_window_create_notebooks (GtkWidget *main_box,
                                    GtkWidget *right_notebook,
                                    GtkWidget *bottom_notebook);
 void
+schematic_window_dialog_save_error (SchematicWindow *w_current,
+                                    char *message);
+void
 recent_manager_add (SchematicWindow *w_current,
                     const gchar *filename);
 gint

--- a/libleptongui/include/prototype.h
+++ b/libleptongui/include/prototype.h
@@ -994,12 +994,6 @@ schematic_window_dialog_save_error (SchematicWindow *w_current,
 void
 recent_manager_add (SchematicWindow *w_current,
                     const gchar *filename);
-gint
-x_window_save_page (SchematicWindow *w_current,
-                    LeptonPage *page,
-                    const gchar *filename,
-                    int ret,
-                    gboolean different_names);
 gboolean
 x_window_untitled_page (LeptonPage* page);
 

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -188,13 +188,15 @@ schematic_window_dialog_save_error (SchematicWindow *w_current,
  *  \param [in] page      The page to save.
  *  \param [in] filename  The name of the file in which to save page.
  *  \param [in] ret The result of saving.
+ *  \param [in] different_names Whether page and file names differ.
  *  \returns 1 on success, 0 otherwise.
  */
 gint
 x_window_save_page (SchematicWindow *w_current,
                     LeptonPage *page,
                     const gchar *filename,
-                    int ret)
+                    int ret,
+                    gboolean different_names)
 {
   const gchar *log_msg, *state_msg;
 
@@ -205,7 +207,7 @@ x_window_save_page (SchematicWindow *w_current,
   } else {
     /* successful save of page to file, update page... */
     /* change page name if necessary and prepare log message */
-    if (g_ascii_strcasecmp (lepton_page_get_filename (page), filename) != 0)
+    if (different_names)
     {
       lepton_page_set_filename (page, filename);
 

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -209,8 +209,6 @@ x_window_save_page (SchematicWindow *w_current,
     /* change page name if necessary and prepare log message */
     if (different_names)
     {
-      lepton_page_set_filename (page, filename);
-
       log_msg = _("Saved as [%1$s]");
     } else {
       log_msg = _("Saved [%1$s]");

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -187,26 +187,21 @@ schematic_window_dialog_save_error (SchematicWindow *w_current,
  *  \param [in] w_current The current #SchematicWindow environment.
  *  \param [in] page      The page to save.
  *  \param [in] filename  The name of the file in which to save page.
+ *  \param [in] ret The result of saving.
  *  \returns 1 on success, 0 otherwise.
  */
 gint
 x_window_save_page (SchematicWindow *w_current,
                     LeptonPage *page,
-                    const gchar *filename)
+                    const gchar *filename,
+                    int ret)
 {
   const gchar *log_msg, *state_msg;
-  gint ret;
-  GError *err = NULL;
-
-  /* try saving page to filename */
-  ret = (gint)f_save (page, filename, &err);
 
   if (ret != 1) {
     log_msg   = _("Could NOT save page [%1$s]");
     state_msg = _("Error while trying to save");
 
-    schematic_window_dialog_save_error (w_current, err->message);
-    g_clear_error (&err);
   } else {
     /* successful save of page to file, update page... */
     /* change page name if necessary and prepare log message */

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -175,52 +175,6 @@ schematic_window_dialog_save_error (SchematicWindow *w_current,
 }
 
 
-/*! \brief Saves a page to a file.
- *  \par Function Description
- *  This function saves the page <B>page</B> to a file named
- *  <B>filename</B>.
- *
- *  It returns the value returned by function <B>f_save()</B> trying
- *  to save page <B>page</B> to file <B>filename</B> (1 on success, 0
- *  on failure).
- *
- *  \param [in] w_current The current #SchematicWindow environment.
- *  \param [in] page      The page to save.
- *  \param [in] filename  The name of the file in which to save page.
- *  \param [in] ret The result of saving.
- *  \param [in] different_names Whether page and file names differ.
- *  \returns 1 on success, 0 otherwise.
- */
-gint
-x_window_save_page (SchematicWindow *w_current,
-                    LeptonPage *page,
-                    const gchar *filename,
-                    int ret,
-                    gboolean different_names)
-{
-  const gchar *log_msg;
-
-  if (ret != 1) {
-    log_msg   = _("Could NOT save page [%1$s]");
-  } else {
-    /* successful save of page to file, update page... */
-    /* change page name if necessary and prepare log message */
-    if (different_names)
-    {
-      log_msg = _("Saved as [%1$s]");
-    } else {
-      log_msg = _("Saved [%1$s]");
-    }
-  }
-
-  /* log status of operation */
-  g_message (log_msg, filename);
-
-  return ret;
-
-} /* x_window_save_page() */
-
-
 /*! \brief Add \a filename to the recent files list.
  *
  * \todo gtk_recent_manager_add_item() also used in x_menus.c.

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -198,12 +198,10 @@ x_window_save_page (SchematicWindow *w_current,
                     int ret,
                     gboolean different_names)
 {
-  const gchar *log_msg, *state_msg;
+  const gchar *log_msg;
 
   if (ret != 1) {
     log_msg   = _("Could NOT save page [%1$s]");
-    state_msg = _("Error while trying to save");
-
   } else {
     /* successful save of page to file, update page... */
     /* change page name if necessary and prepare log message */
@@ -213,13 +211,10 @@ x_window_save_page (SchematicWindow *w_current,
     } else {
       log_msg = _("Saved [%1$s]");
     }
-    state_msg = _("Saved");
   }
 
   /* log status of operation */
   g_message (log_msg, filename);
-
-  i_set_state_msg  (w_current, SELECT, state_msg);
 
   return ret;
 

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -214,14 +214,6 @@ x_window_save_page (SchematicWindow *w_current,
       log_msg = _("Saved [%1$s]");
     }
     state_msg = _("Saved");
-
-    /* reset page CHANGED flag */
-    lepton_page_set_changed (page, 0);
-
-    /* add to recent file list */
-    recent_manager_add (w_current, filename);
-
-    page_select_widget_update (w_current);
   }
 
   /* log status of operation */

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -146,6 +146,35 @@ schematic_window_create_notebooks (GtkWidget *main_box,
 }
 
 
+/*! \brief Run the "Failed to save file" dialog.
+ *
+ *  \par Function Description
+ *
+ *  Runs the "Failed to save file" dialog reporting \p message.
+ *
+ *  \param [in] w_current The #SchematicWindow instance.
+ *  \param [in] message The message to report.
+ */
+void
+schematic_window_dialog_save_error (SchematicWindow *w_current,
+                                    char *message)
+{
+  GtkWidget *main_window =
+    schematic_window_get_main_window (w_current);
+
+  GtkWidget *dialog;
+  dialog = gtk_message_dialog_new (GTK_WINDOW (main_window),
+                                   GTK_DIALOG_DESTROY_WITH_PARENT,
+                                   GTK_MESSAGE_ERROR,
+                                   GTK_BUTTONS_CLOSE,
+                                   "%s",
+                                   message);
+  gtk_window_set_title (GTK_WINDOW (dialog), _("Failed to save file"));
+  gtk_dialog_run (GTK_DIALOG (dialog));
+  gtk_widget_destroy (dialog);
+}
+
+
 /*! \brief Saves a page to a file.
  *  \par Function Description
  *  This function saves the page <B>page</B> to a file named
@@ -179,19 +208,7 @@ x_window_save_page (SchematicWindow *w_current,
     log_msg   = _("Could NOT save page [%1$s]");
     state_msg = _("Error while trying to save");
 
-    GtkWidget *main_window =
-      schematic_window_get_main_window (w_current);
-
-    GtkWidget *dialog;
-    dialog = gtk_message_dialog_new (GTK_WINDOW (main_window),
-                                     GTK_DIALOG_DESTROY_WITH_PARENT,
-                                     GTK_MESSAGE_ERROR,
-                                     GTK_BUTTONS_CLOSE,
-                                     "%s",
-                                     err->message);
-    gtk_window_set_title (GTK_WINDOW (dialog), _("Failed to save file"));
-    gtk_dialog_run (GTK_DIALOG (dialog));
-    gtk_widget_destroy (dialog);
+    schematic_window_dialog_save_error (w_current, err->message);
     g_clear_error (&err);
   } else {
     /* successful save of page to file, update page... */

--- a/libleptongui/src/x_window.c
+++ b/libleptongui/src/x_window.c
@@ -198,9 +198,6 @@ x_window_save_page (SchematicWindow *w_current,
   gint ret;
   GError *err = NULL;
 
-  g_return_val_if_fail (page     != NULL, 0);
-  g_return_val_if_fail (filename != NULL, 0);
-
   /* try saving page to filename */
   ret = (gint)f_save (page, filename, &err);
 


### PR DESCRIPTION
- A function running the "Failed to save file" dialog has been factored out.
- The function `x_window_save_page()` has been rewritten in Scheme
- The pointer arguments of `file-select-save-page!()` have been replaced with Scheme objects.
