### PR TITLE
Rewrite schematic_autonumber_get_new_numbers() in Scheme

### DIFF
--- a/lepton-eda/scheme/lepton/ffi.scm
+++ b/lepton-eda/scheme/lepton/ffi.scm
@@ -337,6 +337,7 @@
             lepton_attrib_is_inherited
             lepton_attrib_search_attached_attribs_by_name
             lepton_attrib_search_inherited_attribs_by_name
+            lepton_attrib_search_object_attribs_by_name
 
             inside_region
 
@@ -727,6 +728,7 @@
 (define-lff lepton_attrib_is_inherited int '(*))
 (define-lff lepton_attrib_search_attached_attribs_by_name '* (list '* '* int))
 (define-lff lepton_attrib_search_inherited_attribs_by_name '* (list '* '* int))
+(define-lff lepton_attrib_search_object_attribs_by_name '* (list '* '* int))
 
 ;;; bounds.c
 (define-lff inside_region int (list int int int int int int))

--- a/lepton-eda/scheme/lepton/ffi/glib.scm
+++ b/lepton-eda/scheme/lepton/ffi/glib.scm
@@ -31,6 +31,7 @@
             g_list_find
             g_list_first
             g_list_free
+            g_list_insert_sorted
             g_list_prepend
             g_list_remove
             g_list_remove_all
@@ -72,6 +73,7 @@
 (define-lff g_list_first '* '(*))
 (define-lff g_list_free void '(*))
 (define-lff g_list_free_full void '(*))
+(define-lff g_list_insert_sorted '* '(* * *))
 (define-lff g_list_prepend '* '(* *))
 (define-lff g_list_remove '* '(* *))
 (define-lff g_list_remove_all '* '(* *))

--- a/lepton-eda/scheme/schematic/dialog/autonumber.scm
+++ b/lepton-eda/scheme/schematic/dialog/autonumber.scm
@@ -197,11 +197,27 @@
     (let ((*free-slot-item
            (schematic_autonumber_get_free_slot_item_by_name *autotext
                                                             *parent-name)))
-      (schematic_autonumber_get_new_numbers *autotext
-                                            *window
-                                            *parent
-                                            *parent-name
-                                            *free-slot-item)))
+      (if (null-pointer? *free-slot-item)
+          (schematic_autonumber_get_new_numbers *autotext
+                                                *window
+                                                *parent
+                                                *parent-name)
+          ;; If there is any suitable unused slot in the database,
+          ;; remove it from database and apply the numbers.
+          (let* ((*freeslot (glist-data *free-slot-item))
+                 (number (schematic_autonumber_slot_get_number *freeslot))
+                 (slot (schematic_autonumber_slot_get_slot_number *freeslot)))
+            (g_free *freeslot)
+            (schematic_autonumber_set_autotext_free_slots
+             *autotext
+             (g_list_delete_link
+              (schematic_autonumber_get_autotext_free_slots *autotext)
+              *free-slot-item))
+
+            (schematic_autonumber_update_slot_number *window *parent slot)
+            ;; Return the number to set it later.
+            number))))
+
   (define number
     (if renumber-slots?
         (set-slot-get-number!)

--- a/lepton-eda/scheme/schematic/dialog/autonumber.scm
+++ b/lepton-eda/scheme/schematic/dialog/autonumber.scm
@@ -183,6 +183,7 @@
     (schematic_autonumber_get_autotext_window *autotext))
   (define *template
     (schematic_autonumber_get_autotext_current_searchtext *autotext))
+  (define template (pointer->string *template))
   (define *parent (lepton_object_get_attached_to *object))
   (define renumber-slots?
     (and (true? automatic_slotting)
@@ -197,8 +198,7 @@
   ;; Replace old text.
   (lepton_text_object_set_string
    *object
-   (string->pointer
-    (format #f "~A~A" (pointer->string *template) number)))
+   (string->pointer (format #f "~A~A" template number)))
 
   (schematic_window_active_page_changed *window))
 

--- a/lepton-eda/scheme/schematic/dialog/autonumber.scm
+++ b/lepton-eda/scheme/schematic/dialog/autonumber.scm
@@ -187,6 +187,8 @@
     (schematic_autonumber_get_autotext_current_searchtext *autotext))
   (define template (pointer->string *template))
   (define *parent (lepton_object_get_attached_to *object))
+  (define *parent-name
+    (lepton_component_object_get_basename *parent))
   (define renumber-slots?
     (and (true? automatic_slotting)
          (not (null-pointer? *parent))))
@@ -196,6 +198,7 @@
     (schematic_autonumber_get_new_numbers *autotext
                                           *window
                                           *parent
+                                          *parent-name
                                           renumber_slots))
   ;; Replace old text.
   (set-text-string! object (format #f "~A~A" template number))

--- a/lepton-eda/scheme/schematic/dialog/autonumber.scm
+++ b/lepton-eda/scheme/schematic/dialog/autonumber.scm
@@ -181,6 +181,21 @@
   (and (string-every char-set:digit value)
        (string->number value)))
 
+
+;;; Renumbers *OBJECT which should be an attribute object.  If it
+;;; is attached to another object, and the parent object is a
+;;; component, it generates both a new number and a new slot
+;;; number.
+;;;
+;;; The renumbering follows the rules of the parameters given in
+;;; the autonumber text dialog.  The options are received from the
+;;; dialog's structure *AUTOTEXT.
+;;;
+;;; The attribute "slot" is set if autoslotting is active, else it
+;;; is set to zero.
+;;;
+;;; To properly handle the attributes, the function uses the lists
+;;; of already used numbers and free slots defined in C.
 (define (renumber! *autotext *object)
   (define object (pointer->object *object))
   (define automatic_slotting
@@ -222,10 +237,18 @@
                  (slot (if (> numslots 0) 1 0)))
             ;; Add other slots (> 1, if any) to the database.
             (when (> numslots 0)
-              (schematic_autonumber_get_new_numbers *autotext
-                                                    *parent-name
-                                                    number
-                                                    numslots))
+              (for-each
+               (lambda (i)
+                 (let ((*freeslot
+                        (schematic_autonumber_slot_new number i *parent-name)))
+                   (schematic_autonumber_set_autotext_free_slots
+                    *autotext
+                    (g_list_insert_sorted
+                     (schematic_autonumber_get_autotext_free_slots *autotext)
+                     *freeslot
+                     *schematic_autonumber_freeslot_compare))))
+               (iota (1- numslots) 2)))
+
             (schematic_autonumber_update_slot_number *window *parent slot)
             number)
           ;; If there is any suitable unused slot in the database,

--- a/lepton-eda/scheme/schematic/dialog/autonumber.scm
+++ b/lepton-eda/scheme/schematic/dialog/autonumber.scm
@@ -189,12 +189,17 @@
          (not (null-pointer? *parent))))
   (define renumber_slots (if renumber-slots? TRUE FALSE))
 
-  (schematic_autonumber_get_new_numbers *autotext
-                                        *window
-                                        *object
-                                        *parent
-                                        *template
-                                        renumber_slots)
+  (define number
+    (schematic_autonumber_get_new_numbers *autotext
+                                          *window
+                                          *parent
+                                          renumber_slots))
+  ;; Replace old text.
+  (lepton_text_object_set_string
+   *object
+   (string->pointer
+    (format #f "~A~A" (pointer->string *template) number)))
+
   (schematic_window_active_page_changed *window))
 
 

--- a/lepton-eda/scheme/schematic/dialog/autonumber.scm
+++ b/lepton-eda/scheme/schematic/dialog/autonumber.scm
@@ -32,6 +32,7 @@
   #:use-module (lepton gerror)
   #:use-module (lepton gettext)
   #:use-module (lepton log)
+  #:use-module (lepton object foreign)
   #:use-module (lepton object)
   #:use-module (lepton page foreign)
   #:use-module (lepton page)
@@ -177,6 +178,7 @@
 
 
 (define (renumber! *autotext *object)
+  (define object (pointer->object *object))
   (define automatic_slotting
     (schematic_autonumber_get_autotext_slotting *autotext))
   (define *window
@@ -196,9 +198,7 @@
                                           *parent
                                           renumber_slots))
   ;; Replace old text.
-  (lepton_text_object_set_string
-   *object
-   (string->pointer (format #f "~A~A" template number)))
+  (set-text-string! object (format #f "~A~A" template number))
 
   (schematic_window_active_page_changed *window))
 

--- a/lepton-eda/scheme/schematic/dialog/autonumber.scm
+++ b/lepton-eda/scheme/schematic/dialog/autonumber.scm
@@ -176,6 +176,10 @@
    (schematic_autonumber_get_autotext_window *autotext)))
 
 
+(define (renumber! *autotext *object)
+  (schematic_autonumber_get_new_numbers *autotext *object))
+
+
 (define (autonumber-by-template! *autotext *window page-list *template scope-number)
   (schematic_autonumber_set_autotext_current_searchtext *autotext
                                                         *template)
@@ -256,7 +260,7 @@
         (lambda (*object)
           (if (true? (schematic_autonumber_get_autotext_removenum *autotext))
               (remove-number! *autotext *object)
-              (schematic_autonumber_get_new_numbers *autotext *object)))
+              (renumber! *autotext *object)))
         (glist->list *sorted-objects identity))
        (g_list_free *sorted-objects))
 

--- a/lepton-eda/scheme/schematic/dialog/autonumber.scm
+++ b/lepton-eda/scheme/schematic/dialog/autonumber.scm
@@ -226,7 +226,13 @@
       numslots))
 
   (define (update-slot-number! slot)
-    (schematic_autonumber_update_slot_number *window *parent slot))
+    ;; Updates the text content of the "slot" attribute of the
+    ;; object if the slot value is not zero.
+    (unless (zero? slot)
+      ;; Update the slot on the owning object.
+      (o_slot_end *window
+                  *parent
+                  (string->pointer (format #f "slot=~A" slot)))))
 
   (define (set-slot-get-number!)
     (let ((*free-slot-item

--- a/lepton-eda/scheme/schematic/dialog/autonumber.scm
+++ b/lepton-eda/scheme/schematic/dialog/autonumber.scm
@@ -204,7 +204,8 @@
                                                   *window
                                                   *parent
                                                   *parent-name
-                                                  number))
+                                                  number)
+            number)
           ;; If there is any suitable unused slot in the database,
           ;; remove it from database and apply the numbers.
           (let* ((*freeslot (glist-data *free-slot-item))

--- a/lepton-eda/scheme/schematic/dialog/autonumber.scm
+++ b/lepton-eda/scheme/schematic/dialog/autonumber.scm
@@ -192,14 +192,15 @@
   (define renumber-slots?
     (and (true? automatic_slotting)
          (not (null-pointer? *parent))))
-  (define renumber_slots (if renumber-slots? TRUE FALSE))
 
   (define number
-    (schematic_autonumber_get_new_numbers *autotext
-                                          *window
-                                          *parent
-                                          *parent-name
-                                          renumber_slots))
+    (if renumber-slots?
+        (schematic_autonumber_get_new_numbers *autotext
+                                              *window
+                                              *parent
+                                              *parent-name)
+        (schematic_autonumber_get_next_unused_number *autotext)))
+
   ;; Replace old text.
   (set-text-string! object (format #f "~A~A" template number))
 

--- a/lepton-eda/scheme/schematic/dialog/autonumber.scm
+++ b/lepton-eda/scheme/schematic/dialog/autonumber.scm
@@ -177,6 +177,10 @@
    (schematic_autonumber_get_autotext_window *autotext)))
 
 
+(define (string->integer value)
+  (and (string-every char-set:digit value)
+       (string->number value)))
+
 (define (renumber! *autotext *object)
   (define object (pointer->object *object))
   (define automatic_slotting
@@ -193,6 +197,19 @@
     (and (true? automatic_slotting)
          (not (null-pointer? *parent))))
 
+  (define (numslots-value *object)
+    (let* ((*numslots
+            (lepton_attrib_search_object_attribs_by_name
+             *object
+             (string->pointer "numslots")
+             0))
+           (numslots (and (not (null-pointer? *numslots))
+                          (string->integer
+                           (string-trim
+                            (pointer->string *numslots))))))
+      (g_free *numslots)
+      numslots))
+
   (define (set-slot-get-number!)
     (let ((*free-slot-item
            (schematic_autonumber_get_free_slot_item_by_name *autotext
@@ -200,11 +217,12 @@
       (if (null-pointer? *free-slot-item)
           (let* ((number
                   (schematic_autonumber_get_next_unused_number *autotext))
+                 (numslots (or (numslots-value *parent) 0))
                  (slot
                   (schematic_autonumber_get_new_numbers *autotext
-                                                        *parent
                                                         *parent-name
-                                                        number)))
+                                                        number
+                                                        numslots)))
             (schematic_autonumber_update_slot_number *window *parent slot)
             number)
           ;; If there is any suitable unused slot in the database,

--- a/lepton-eda/scheme/schematic/dialog/autonumber.scm
+++ b/lepton-eda/scheme/schematic/dialog/autonumber.scm
@@ -198,10 +198,13 @@
            (schematic_autonumber_get_free_slot_item_by_name *autotext
                                                             *parent-name)))
       (if (null-pointer? *free-slot-item)
-          (schematic_autonumber_get_new_numbers *autotext
-                                                *window
-                                                *parent
-                                                *parent-name)
+          (let ((number
+                 (schematic_autonumber_get_next_unused_number *autotext)))
+            (schematic_autonumber_get_new_numbers *autotext
+                                                  *window
+                                                  *parent
+                                                  *parent-name
+                                                  number))
           ;; If there is any suitable unused slot in the database,
           ;; remove it from database and apply the numbers.
           (let* ((*freeslot (glist-data *free-slot-item))

--- a/lepton-eda/scheme/schematic/dialog/autonumber.scm
+++ b/lepton-eda/scheme/schematic/dialog/autonumber.scm
@@ -177,7 +177,9 @@
 
 
 (define (renumber! *autotext *object)
-  (schematic_autonumber_get_new_numbers *autotext *object))
+  (define *parent (lepton_object_get_attached_to *object))
+
+  (schematic_autonumber_get_new_numbers *autotext *object *parent))
 
 
 (define (autonumber-by-template! *autotext *window page-list *template scope-number)

--- a/lepton-eda/scheme/schematic/dialog/autonumber.scm
+++ b/lepton-eda/scheme/schematic/dialog/autonumber.scm
@@ -177,9 +177,14 @@
 
 
 (define (renumber! *autotext *object)
+  (define automatic_slotting
+    (schematic_autonumber_get_autotext_slotting *autotext))
   (define *parent (lepton_object_get_attached_to *object))
 
-  (schematic_autonumber_get_new_numbers *autotext *object *parent))
+  (schematic_autonumber_get_new_numbers *autotext
+                                        *object
+                                        *parent
+                                        automatic_slotting))
 
 
 (define (autonumber-by-template! *autotext *window page-list *template scope-number)

--- a/lepton-eda/scheme/schematic/dialog/autonumber.scm
+++ b/lepton-eda/scheme/schematic/dialog/autonumber.scm
@@ -194,7 +194,8 @@
                                         *object
                                         *parent
                                         *template
-                                        renumber_slots))
+                                        renumber_slots)
+  (schematic_window_active_page_changed *window))
 
 
 (define (autonumber-by-template! *autotext *window page-list *template scope-number)

--- a/lepton-eda/scheme/schematic/dialog/autonumber.scm
+++ b/lepton-eda/scheme/schematic/dialog/autonumber.scm
@@ -194,10 +194,14 @@
          (not (null-pointer? *parent))))
 
   (define (set-slot-get-number!)
-    (schematic_autonumber_get_new_numbers *autotext
-                                          *window
-                                          *parent
-                                          *parent-name))
+    (let ((*free-slot-item
+           (schematic_autonumber_get_free_slot_item_by_name *autotext
+                                                            *parent-name)))
+      (schematic_autonumber_get_new_numbers *autotext
+                                            *window
+                                            *parent
+                                            *parent-name
+                                            *free-slot-item)))
   (define number
     (if renumber-slots?
         (set-slot-get-number!)

--- a/lepton-eda/scheme/schematic/dialog/autonumber.scm
+++ b/lepton-eda/scheme/schematic/dialog/autonumber.scm
@@ -179,6 +179,8 @@
 (define (renumber! *autotext *object)
   (define automatic_slotting
     (schematic_autonumber_get_autotext_slotting *autotext))
+  (define *window
+    (schematic_autonumber_get_autotext_window *autotext))
   (define *parent (lepton_object_get_attached_to *object))
   (define renumber-slots?
     (and (true? automatic_slotting)
@@ -186,6 +188,7 @@
   (define renumber_slots (if renumber-slots? TRUE FALSE))
 
   (schematic_autonumber_get_new_numbers *autotext
+                                        *window
                                         *object
                                         *parent
                                         renumber_slots))

--- a/lepton-eda/scheme/schematic/dialog/autonumber.scm
+++ b/lepton-eda/scheme/schematic/dialog/autonumber.scm
@@ -215,14 +215,17 @@
            (schematic_autonumber_get_free_slot_item_by_name *autotext
                                                             *parent-name)))
       (if (null-pointer? *free-slot-item)
+          ;; Set new number and slot number.
           (let* ((number
                   (schematic_autonumber_get_next_unused_number *autotext))
                  (numslots (or (numslots-value *parent) 0))
-                 (slot
-                  (schematic_autonumber_get_new_numbers *autotext
-                                                        *parent-name
-                                                        number
-                                                        numslots)))
+                 (slot (if (> numslots 0) 1 0)))
+            ;; Add other slots (> 1, if any) to the database.
+            (when (> numslots 0)
+              (schematic_autonumber_get_new_numbers *autotext
+                                                    *parent-name
+                                                    number
+                                                    numslots))
             (schematic_autonumber_update_slot_number *window *parent slot)
             number)
           ;; If there is any suitable unused slot in the database,

--- a/lepton-eda/scheme/schematic/dialog/autonumber.scm
+++ b/lepton-eda/scheme/schematic/dialog/autonumber.scm
@@ -225,6 +225,9 @@
       (g_free *numslots)
       numslots))
 
+  (define (update-slot-number! slot)
+    (schematic_autonumber_update_slot_number *window *parent slot))
+
   (define (set-slot-get-number!)
     (let ((*free-slot-item
            (schematic_autonumber_get_free_slot_item_by_name *autotext
@@ -249,7 +252,7 @@
                      *schematic_autonumber_freeslot_compare))))
                (iota (1- numslots) 2)))
 
-            (schematic_autonumber_update_slot_number *window *parent slot)
+            (update-slot-number! slot)
             number)
           ;; If there is any suitable unused slot in the database,
           ;; remove it from database and apply the numbers.
@@ -263,7 +266,7 @@
               (schematic_autonumber_get_autotext_free_slots *autotext)
               *free-slot-item))
 
-            (schematic_autonumber_update_slot_number *window *parent slot)
+            (update-slot-number! slot)
             ;; Return the number to set it later.
             number))))
 

--- a/lepton-eda/scheme/schematic/dialog/autonumber.scm
+++ b/lepton-eda/scheme/schematic/dialog/autonumber.scm
@@ -180,11 +180,10 @@
   (define automatic_slotting
     (schematic_autonumber_get_autotext_slotting *autotext))
   (define *parent (lepton_object_get_attached_to *object))
-  (define renumber_slots
-    (if (and (true? automatic_slotting)
-             (not (null-pointer? *parent)))
-        TRUE
-        FALSE))
+  (define renumber-slots?
+    (and (true? automatic_slotting)
+         (not (null-pointer? *parent))))
+  (define renumber_slots (if renumber-slots? TRUE FALSE))
 
   (schematic_autonumber_get_new_numbers *autotext
                                         *object

--- a/lepton-eda/scheme/schematic/dialog/autonumber.scm
+++ b/lepton-eda/scheme/schematic/dialog/autonumber.scm
@@ -180,11 +180,16 @@
   (define automatic_slotting
     (schematic_autonumber_get_autotext_slotting *autotext))
   (define *parent (lepton_object_get_attached_to *object))
+  (define renumber_slots
+    (if (and (true? automatic_slotting)
+             (not (null-pointer? *parent)))
+        TRUE
+        FALSE))
 
   (schematic_autonumber_get_new_numbers *autotext
                                         *object
                                         *parent
-                                        automatic_slotting))
+                                        renumber_slots))
 
 
 (define (autonumber-by-template! *autotext *window page-list *template scope-number)

--- a/lepton-eda/scheme/schematic/dialog/autonumber.scm
+++ b/lepton-eda/scheme/schematic/dialog/autonumber.scm
@@ -198,13 +198,14 @@
            (schematic_autonumber_get_free_slot_item_by_name *autotext
                                                             *parent-name)))
       (if (null-pointer? *free-slot-item)
-          (let ((number
-                 (schematic_autonumber_get_next_unused_number *autotext)))
-            (schematic_autonumber_get_new_numbers *autotext
-                                                  *window
-                                                  *parent
-                                                  *parent-name
-                                                  number)
+          (let* ((number
+                  (schematic_autonumber_get_next_unused_number *autotext))
+                 (slot
+                  (schematic_autonumber_get_new_numbers *autotext
+                                                        *parent
+                                                        *parent-name
+                                                        number)))
+            (schematic_autonumber_update_slot_number *window *parent slot)
             number)
           ;; If there is any suitable unused slot in the database,
           ;; remove it from database and apply the numbers.

--- a/lepton-eda/scheme/schematic/dialog/autonumber.scm
+++ b/lepton-eda/scheme/schematic/dialog/autonumber.scm
@@ -193,12 +193,14 @@
     (and (true? automatic_slotting)
          (not (null-pointer? *parent))))
 
+  (define (set-slot-get-number!)
+    (schematic_autonumber_get_new_numbers *autotext
+                                          *window
+                                          *parent
+                                          *parent-name))
   (define number
     (if renumber-slots?
-        (schematic_autonumber_get_new_numbers *autotext
-                                              *window
-                                              *parent
-                                              *parent-name)
+        (set-slot-get-number!)
         (schematic_autonumber_get_next_unused_number *autotext)))
 
   ;; Replace old text.

--- a/lepton-eda/scheme/schematic/dialog/autonumber.scm
+++ b/lepton-eda/scheme/schematic/dialog/autonumber.scm
@@ -181,6 +181,8 @@
     (schematic_autonumber_get_autotext_slotting *autotext))
   (define *window
     (schematic_autonumber_get_autotext_window *autotext))
+  (define *template
+    (schematic_autonumber_get_autotext_current_searchtext *autotext))
   (define *parent (lepton_object_get_attached_to *object))
   (define renumber-slots?
     (and (true? automatic_slotting)
@@ -191,6 +193,7 @@
                                         *window
                                         *object
                                         *parent
+                                        *template
                                         renumber_slots))
 
 

--- a/lepton-eda/scheme/schematic/ffi.scm
+++ b/lepton-eda/scheme/schematic/ffi.scm
@@ -1312,7 +1312,7 @@
 (define-lff schematic_autonumber_clear_database void '(*))
 (define-lff schematic_autonumber_dialog_lookup_widget '* '(* *))
 (define-lff schematic_autonumber_dialog_new '* '(*))
-(define-lff schematic_autonumber_get_new_numbers int (list '* '* '* '* '* int))
+(define-lff schematic_autonumber_get_new_numbers int (list '* '* '* int))
 (define-lff schematic_autonumber_get_used void '(* *))
 (define-lff schematic_autonumber_history_add '* '(* *))
 (define-lff schematic_autonumber_make_renumber_list '* '(* *))

--- a/lepton-eda/scheme/schematic/ffi.scm
+++ b/lepton-eda/scheme/schematic/ffi.scm
@@ -199,6 +199,7 @@
             schematic_autonumber_set_autotext_current_searchtext
             schematic_autonumber_get_autotext_dialog
             schematic_autonumber_set_autotext_dialog
+            schematic_autonumber_get_autotext_free_slots
             schematic_autonumber_set_autotext_free_slots
             schematic_autonumber_get_autotext_removenum
             schematic_autonumber_set_autotext_removenum
@@ -232,6 +233,8 @@
             schematic_autonumber_make_renumber_list
             schematic_autonumber_scope_from_string
             schematic_autonumber_scope_to_string
+            schematic_autonumber_slot_get_number
+            schematic_autonumber_slot_get_slot_number
             schematic_autonumber_sort_order_from_string
             schematic_autonumber_sort_order_to_string
             schematic_autonumber_sort_order_widget_init
@@ -240,6 +243,7 @@
             *schematic_autonumber_sort_xy
             *schematic_autonumber_sort_xy_rev
             *schematic_autonumber_sort_diagonal
+            schematic_autonumber_update_slot_number
 
             schematic_bottom_widget_new
 
@@ -1289,6 +1293,7 @@
 (define-lff schematic_autonumber_set_autotext_current_searchtext void '(* *))
 (define-lff schematic_autonumber_get_autotext_dialog '* '(*))
 (define-lff schematic_autonumber_set_autotext_dialog void '(* *))
+(define-lff schematic_autonumber_get_autotext_free_slots '* '(*))
 (define-lff schematic_autonumber_set_autotext_free_slots void '(* *))
 (define-lff schematic_autonumber_get_autotext_removenum int '(*))
 (define-lff schematic_autonumber_set_autotext_removenum void (list '* int))
@@ -1315,13 +1320,15 @@
 (define-lff schematic_autonumber_dialog_lookup_widget '* '(* *))
 (define-lff schematic_autonumber_dialog_new '* '(*))
 (define-lff schematic_autonumber_get_free_slot_item_by_name '* '(* *))
-(define-lff schematic_autonumber_get_new_numbers int '(* * * * *))
+(define-lff schematic_autonumber_get_new_numbers int '(* * * *))
 (define-lff schematic_autonumber_get_next_unused_number int '(*))
 (define-lff schematic_autonumber_get_used void '(* *))
 (define-lff schematic_autonumber_history_add '* '(* *))
 (define-lff schematic_autonumber_make_renumber_list '* '(* *))
 (define-lff schematic_autonumber_scope_from_string int '(*))
 (define-lff schematic_autonumber_scope_to_string '* (list int))
+(define-lff schematic_autonumber_slot_get_number int '(*))
+(define-lff schematic_autonumber_slot_get_slot_number int '(*))
 (define-lff schematic_autonumber_sort_order_from_string int '(*))
 (define-lff schematic_autonumber_sort_order_to_string '* (list int))
 (define-lff schematic_autonumber_sort_order_widget_init void '(*))
@@ -1330,6 +1337,7 @@
 (define-lfc *schematic_autonumber_sort_xy)
 (define-lfc *schematic_autonumber_sort_xy_rev)
 (define-lfc *schematic_autonumber_sort_diagonal)
+(define-lff schematic_autonumber_update_slot_number void (list '* '* int))
 
 ;;; bottom_widget.c
 (define-lff schematic_bottom_widget_new '* (list '* '* '* int int int int int))

--- a/lepton-eda/scheme/schematic/ffi.scm
+++ b/lepton-eda/scheme/schematic/ffi.scm
@@ -244,7 +244,6 @@
             *schematic_autonumber_sort_xy
             *schematic_autonumber_sort_xy_rev
             *schematic_autonumber_sort_diagonal
-            schematic_autonumber_update_slot_number
 
             schematic_bottom_widget_new
 
@@ -1339,7 +1338,6 @@
 (define-lfc *schematic_autonumber_sort_xy)
 (define-lfc *schematic_autonumber_sort_xy_rev)
 (define-lfc *schematic_autonumber_sort_diagonal)
-(define-lff schematic_autonumber_update_slot_number void (list '* '* int))
 
 ;;; bottom_widget.c
 (define-lff schematic_bottom_widget_new '* (list '* '* '* int int int int int))

--- a/lepton-eda/scheme/schematic/ffi.scm
+++ b/lepton-eda/scheme/schematic/ffi.scm
@@ -224,6 +224,7 @@
             schematic_autonumber_clear_database
             schematic_autonumber_dialog_lookup_widget
             schematic_autonumber_dialog_new
+            schematic_autonumber_get_free_slot_item_by_name
             schematic_autonumber_get_new_numbers
             schematic_autonumber_get_next_unused_number
             schematic_autonumber_get_used
@@ -1313,7 +1314,8 @@
 (define-lff schematic_autonumber_clear_database void '(*))
 (define-lff schematic_autonumber_dialog_lookup_widget '* '(* *))
 (define-lff schematic_autonumber_dialog_new '* '(*))
-(define-lff schematic_autonumber_get_new_numbers int '(* * * *))
+(define-lff schematic_autonumber_get_free_slot_item_by_name '* '(* *))
+(define-lff schematic_autonumber_get_new_numbers int '(* * * * *))
 (define-lff schematic_autonumber_get_next_unused_number int '(*))
 (define-lff schematic_autonumber_get_used void '(* *))
 (define-lff schematic_autonumber_history_add '* '(* *))

--- a/lepton-eda/scheme/schematic/ffi.scm
+++ b/lepton-eda/scheme/schematic/ffi.scm
@@ -1312,7 +1312,7 @@
 (define-lff schematic_autonumber_clear_database void '(*))
 (define-lff schematic_autonumber_dialog_lookup_widget '* '(* *))
 (define-lff schematic_autonumber_dialog_new '* '(*))
-(define-lff schematic_autonumber_get_new_numbers int (list '* '* '* int))
+(define-lff schematic_autonumber_get_new_numbers int (list '* '* '* '* int))
 (define-lff schematic_autonumber_get_used void '(* *))
 (define-lff schematic_autonumber_history_add '* '(* *))
 (define-lff schematic_autonumber_make_renumber_list '* '(* *))

--- a/lepton-eda/scheme/schematic/ffi.scm
+++ b/lepton-eda/scheme/schematic/ffi.scm
@@ -1312,7 +1312,7 @@
 (define-lff schematic_autonumber_clear_database void '(*))
 (define-lff schematic_autonumber_dialog_lookup_widget '* '(* *))
 (define-lff schematic_autonumber_dialog_new '* '(*))
-(define-lff schematic_autonumber_get_new_numbers void '(* * *))
+(define-lff schematic_autonumber_get_new_numbers void (list '* '* '* int))
 (define-lff schematic_autonumber_get_used void '(* *))
 (define-lff schematic_autonumber_history_add '* '(* *))
 (define-lff schematic_autonumber_make_renumber_list '* '(* *))

--- a/lepton-eda/scheme/schematic/ffi.scm
+++ b/lepton-eda/scheme/schematic/ffi.scm
@@ -1320,7 +1320,7 @@
 (define-lff schematic_autonumber_dialog_lookup_widget '* '(* *))
 (define-lff schematic_autonumber_dialog_new '* '(*))
 (define-lff schematic_autonumber_get_free_slot_item_by_name '* '(* *))
-(define-lff schematic_autonumber_get_new_numbers int (list '* '* '* '* int))
+(define-lff schematic_autonumber_get_new_numbers int (list '* '* '* int))
 (define-lff schematic_autonumber_get_next_unused_number int '(*))
 (define-lff schematic_autonumber_get_used void '(* *))
 (define-lff schematic_autonumber_history_add '* '(* *))

--- a/lepton-eda/scheme/schematic/ffi.scm
+++ b/lepton-eda/scheme/schematic/ffi.scm
@@ -225,6 +225,7 @@
             schematic_autonumber_dialog_lookup_widget
             schematic_autonumber_dialog_new
             schematic_autonumber_get_new_numbers
+            schematic_autonumber_get_next_unused_number
             schematic_autonumber_get_used
             schematic_autonumber_history_add
             schematic_autonumber_make_renumber_list
@@ -1312,7 +1313,8 @@
 (define-lff schematic_autonumber_clear_database void '(*))
 (define-lff schematic_autonumber_dialog_lookup_widget '* '(* *))
 (define-lff schematic_autonumber_dialog_new '* '(*))
-(define-lff schematic_autonumber_get_new_numbers int (list '* '* '* '* int))
+(define-lff schematic_autonumber_get_new_numbers int '(* * * *))
+(define-lff schematic_autonumber_get_next_unused_number int '(*))
 (define-lff schematic_autonumber_get_used void '(* *))
 (define-lff schematic_autonumber_history_add '* '(* *))
 (define-lff schematic_autonumber_make_renumber_list '* '(* *))

--- a/lepton-eda/scheme/schematic/ffi.scm
+++ b/lepton-eda/scheme/schematic/ffi.scm
@@ -1320,7 +1320,7 @@
 (define-lff schematic_autonumber_dialog_lookup_widget '* '(* *))
 (define-lff schematic_autonumber_dialog_new '* '(*))
 (define-lff schematic_autonumber_get_free_slot_item_by_name '* '(* *))
-(define-lff schematic_autonumber_get_new_numbers int '(* * * *))
+(define-lff schematic_autonumber_get_new_numbers int (list '* '* '* '* int))
 (define-lff schematic_autonumber_get_next_unused_number int '(*))
 (define-lff schematic_autonumber_get_used void '(* *))
 (define-lff schematic_autonumber_history_add '* '(* *))

--- a/lepton-eda/scheme/schematic/ffi.scm
+++ b/lepton-eda/scheme/schematic/ffi.scm
@@ -1312,7 +1312,7 @@
 (define-lff schematic_autonumber_clear_database void '(*))
 (define-lff schematic_autonumber_dialog_lookup_widget '* '(* *))
 (define-lff schematic_autonumber_dialog_new '* '(*))
-(define-lff schematic_autonumber_get_new_numbers void (list '* '* '* '* int))
+(define-lff schematic_autonumber_get_new_numbers void (list '* '* '* '* '* int))
 (define-lff schematic_autonumber_get_used void '(* *))
 (define-lff schematic_autonumber_history_add '* '(* *))
 (define-lff schematic_autonumber_make_renumber_list '* '(* *))

--- a/lepton-eda/scheme/schematic/ffi.scm
+++ b/lepton-eda/scheme/schematic/ffi.scm
@@ -1312,7 +1312,7 @@
 (define-lff schematic_autonumber_clear_database void '(*))
 (define-lff schematic_autonumber_dialog_lookup_widget '* '(* *))
 (define-lff schematic_autonumber_dialog_new '* '(*))
-(define-lff schematic_autonumber_get_new_numbers void (list '* '* '* int))
+(define-lff schematic_autonumber_get_new_numbers void (list '* '* '* '* int))
 (define-lff schematic_autonumber_get_used void '(* *))
 (define-lff schematic_autonumber_history_add '* '(* *))
 (define-lff schematic_autonumber_make_renumber_list '* '(* *))

--- a/lepton-eda/scheme/schematic/ffi.scm
+++ b/lepton-eda/scheme/schematic/ffi.scm
@@ -1320,7 +1320,7 @@
 (define-lff schematic_autonumber_dialog_lookup_widget '* '(* *))
 (define-lff schematic_autonumber_dialog_new '* '(*))
 (define-lff schematic_autonumber_get_free_slot_item_by_name '* '(* *))
-(define-lff schematic_autonumber_get_new_numbers int (list '* '* int int))
+(define-lff schematic_autonumber_get_new_numbers void (list '* '* int int))
 (define-lff schematic_autonumber_get_next_unused_number int '(*))
 (define-lff schematic_autonumber_get_used void '(* *))
 (define-lff schematic_autonumber_history_add '* '(* *))

--- a/lepton-eda/scheme/schematic/ffi.scm
+++ b/lepton-eda/scheme/schematic/ffi.scm
@@ -1312,7 +1312,7 @@
 (define-lff schematic_autonumber_clear_database void '(*))
 (define-lff schematic_autonumber_dialog_lookup_widget '* '(* *))
 (define-lff schematic_autonumber_dialog_new '* '(*))
-(define-lff schematic_autonumber_get_new_numbers void '(* *))
+(define-lff schematic_autonumber_get_new_numbers void '(* * *))
 (define-lff schematic_autonumber_get_used void '(* *))
 (define-lff schematic_autonumber_history_add '* '(* *))
 (define-lff schematic_autonumber_make_renumber_list '* '(* *))

--- a/lepton-eda/scheme/schematic/ffi.scm
+++ b/lepton-eda/scheme/schematic/ffi.scm
@@ -1312,7 +1312,7 @@
 (define-lff schematic_autonumber_clear_database void '(*))
 (define-lff schematic_autonumber_dialog_lookup_widget '* '(* *))
 (define-lff schematic_autonumber_dialog_new '* '(*))
-(define-lff schematic_autonumber_get_new_numbers void (list '* '* '* '* '* int))
+(define-lff schematic_autonumber_get_new_numbers int (list '* '* '* '* '* int))
 (define-lff schematic_autonumber_get_used void '(* *))
 (define-lff schematic_autonumber_history_add '* '(* *))
 (define-lff schematic_autonumber_make_renumber_list '* '(* *))

--- a/lepton-eda/scheme/schematic/ffi.scm
+++ b/lepton-eda/scheme/schematic/ffi.scm
@@ -1320,7 +1320,7 @@
 (define-lff schematic_autonumber_dialog_lookup_widget '* '(* *))
 (define-lff schematic_autonumber_dialog_new '* '(*))
 (define-lff schematic_autonumber_get_free_slot_item_by_name '* '(* *))
-(define-lff schematic_autonumber_get_new_numbers int (list '* '* '* int))
+(define-lff schematic_autonumber_get_new_numbers int (list '* '* int int))
 (define-lff schematic_autonumber_get_next_unused_number int '(*))
 (define-lff schematic_autonumber_get_used void '(* *))
 (define-lff schematic_autonumber_history_add '* '(* *))

--- a/lepton-eda/scheme/schematic/ffi.scm
+++ b/lepton-eda/scheme/schematic/ffi.scm
@@ -225,8 +225,8 @@
             schematic_autonumber_clear_database
             schematic_autonumber_dialog_lookup_widget
             schematic_autonumber_dialog_new
+            *schematic_autonumber_freeslot_compare
             schematic_autonumber_get_free_slot_item_by_name
-            schematic_autonumber_get_new_numbers
             schematic_autonumber_get_next_unused_number
             schematic_autonumber_get_used
             schematic_autonumber_history_add
@@ -235,6 +235,7 @@
             schematic_autonumber_scope_to_string
             schematic_autonumber_slot_get_number
             schematic_autonumber_slot_get_slot_number
+            schematic_autonumber_slot_new
             schematic_autonumber_sort_order_from_string
             schematic_autonumber_sort_order_to_string
             schematic_autonumber_sort_order_widget_init
@@ -1319,8 +1320,8 @@
 (define-lff schematic_autonumber_clear_database void '(*))
 (define-lff schematic_autonumber_dialog_lookup_widget '* '(* *))
 (define-lff schematic_autonumber_dialog_new '* '(*))
+(define-lfc *schematic_autonumber_freeslot_compare)
 (define-lff schematic_autonumber_get_free_slot_item_by_name '* '(* *))
-(define-lff schematic_autonumber_get_new_numbers void (list '* '* int int))
 (define-lff schematic_autonumber_get_next_unused_number int '(*))
 (define-lff schematic_autonumber_get_used void '(* *))
 (define-lff schematic_autonumber_history_add '* '(* *))
@@ -1329,6 +1330,7 @@
 (define-lff schematic_autonumber_scope_to_string '* (list int))
 (define-lff schematic_autonumber_slot_get_number int '(*))
 (define-lff schematic_autonumber_slot_get_slot_number int '(*))
+(define-lff schematic_autonumber_slot_new '* (list int int '*))
 (define-lff schematic_autonumber_sort_order_from_string int '(*))
 (define-lff schematic_autonumber_sort_order_to_string '* (list int))
 (define-lff schematic_autonumber_sort_order_widget_init void '(*))

--- a/libleptongui/include/autonumber_dialog.h
+++ b/libleptongui/include/autonumber_dialog.h
@@ -240,11 +240,6 @@ schematic_autonumber_freeslot_compare (gconstpointer a,
 GList*
 schematic_autonumber_get_free_slot_item_by_name (SchematicAutonumber *autotext,
                                                  char *name);
-void
-schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
-                                      char *parent_name,
-                                      int number,
-                                      int numslots);
 int
 schematic_autonumber_get_next_unused_number (SchematicAutonumber *autotext);
 

--- a/libleptongui/include/autonumber_dialog.h
+++ b/libleptongui/include/autonumber_dialog.h
@@ -238,8 +238,7 @@ int
 schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
                                       SchematicWindow *w_current,
                                       LeptonObject *o_parent,
-                                      char *parent_name,
-                                      gboolean renumber_slots);
+                                      char *parent_name);
 int
 schematic_autonumber_get_next_unused_number (SchematicAutonumber *autotext);
 

--- a/libleptongui/include/autonumber_dialog.h
+++ b/libleptongui/include/autonumber_dialog.h
@@ -241,8 +241,7 @@ int
 schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
                                       SchematicWindow *w_current,
                                       LeptonObject *o_parent,
-                                      char *parent_name,
-                                      GList *freeslot_item);
+                                      char *parent_name);
 int
 schematic_autonumber_get_next_unused_number (SchematicAutonumber *autotext);
 

--- a/libleptongui/include/autonumber_dialog.h
+++ b/libleptongui/include/autonumber_dialog.h
@@ -228,6 +228,9 @@ schematic_autonumber_clear_database (SchematicAutonumber *autotext);
 GtkWidget*
 schematic_autonumber_dialog_lookup_widget (GtkWidget *widget,
                                            const gchar *widget_name);
+GList*
+schematic_autonumber_find_slot (GList *slots,
+                                SchematicAutonumberSlot *slot);
 int
 schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
                                       SchematicWindow *w_current,

--- a/libleptongui/include/autonumber_dialog.h
+++ b/libleptongui/include/autonumber_dialog.h
@@ -231,9 +231,7 @@ schematic_autonumber_dialog_lookup_widget (GtkWidget *widget,
 int
 schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
                                       SchematicWindow *w_current,
-                                      LeptonObject *o_current,
                                       LeptonObject *o_parent,
-                                      char *search_template,
                                       gboolean renumber_slots);
 void
 schematic_autonumber_get_used (SchematicWindow *w_current,

--- a/libleptongui/include/autonumber_dialog.h
+++ b/libleptongui/include/autonumber_dialog.h
@@ -241,8 +241,8 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
                                       char *parent_name,
                                       gboolean renumber_slots);
 int
-schematic_autonumber_get_next_unused_number (SchematicAutonumber *autotext,
-                                             int start_number);
+schematic_autonumber_get_next_unused_number (SchematicAutonumber *autotext);
+
 void
 schematic_autonumber_get_used (SchematicWindow *w_current,
                                SchematicAutonumber *autotext);

--- a/libleptongui/include/autonumber_dialog.h
+++ b/libleptongui/include/autonumber_dialog.h
@@ -228,7 +228,7 @@ schematic_autonumber_clear_database (SchematicAutonumber *autotext);
 GtkWidget*
 schematic_autonumber_dialog_lookup_widget (GtkWidget *widget,
                                            const gchar *widget_name);
-void
+int
 schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
                                       SchematicWindow *w_current,
                                       LeptonObject *o_current,

--- a/libleptongui/include/autonumber_dialog.h
+++ b/libleptongui/include/autonumber_dialog.h
@@ -237,6 +237,9 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
                                       LeptonObject *o_parent,
                                       char *parent_name,
                                       gboolean renumber_slots);
+int
+schematic_autonumber_get_next_unused_number (SchematicAutonumber *autotext,
+                                             int start_number);
 void
 schematic_autonumber_get_used (SchematicWindow *w_current,
                                SchematicAutonumber *autotext);

--- a/libleptongui/include/autonumber_dialog.h
+++ b/libleptongui/include/autonumber_dialog.h
@@ -232,7 +232,7 @@ void
 schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
                                       LeptonObject *o_current,
                                       LeptonObject *o_parent,
-                                      gboolean automatic_slotting);
+                                      gboolean renumber_slots);
 void
 schematic_autonumber_get_used (SchematicWindow *w_current,
                                SchematicAutonumber *autotext);

--- a/libleptongui/include/autonumber_dialog.h
+++ b/libleptongui/include/autonumber_dialog.h
@@ -223,6 +223,9 @@ schematic_autonumber_slot_set_symbol_name (SchematicAutonumberSlot *slot,
 /* Methods */
 
 void
+schematic_autonumber_add_used_number (SchematicAutonumber *autotext,
+                                      int number);
+void
 schematic_autonumber_clear_database (SchematicAutonumber *autotext);
 
 GtkWidget*

--- a/libleptongui/include/autonumber_dialog.h
+++ b/libleptongui/include/autonumber_dialog.h
@@ -233,6 +233,7 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
                                       SchematicWindow *w_current,
                                       LeptonObject *o_current,
                                       LeptonObject *o_parent,
+                                      char *search_template,
                                       gboolean renumber_slots);
 void
 schematic_autonumber_get_used (SchematicWindow *w_current,

--- a/libleptongui/include/autonumber_dialog.h
+++ b/libleptongui/include/autonumber_dialog.h
@@ -241,7 +241,8 @@ int
 schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
                                       SchematicWindow *w_current,
                                       LeptonObject *o_parent,
-                                      char *parent_name);
+                                      char *parent_name,
+                                      int number);
 int
 schematic_autonumber_get_next_unused_number (SchematicAutonumber *autotext);
 

--- a/libleptongui/include/autonumber_dialog.h
+++ b/libleptongui/include/autonumber_dialog.h
@@ -285,6 +285,10 @@ schematic_autonumber_sort_yx_rev (gconstpointer a,
 void
 schematic_autonumber_sort_order_widget_init (GtkWidget *sort_order);
 
+void
+schematic_autonumber_update_slot_number (SchematicWindow *w_current,
+                                         LeptonObject *o_current,
+                                         int slot_number);
 G_END_DECLS
 
 #endif /* AUTONUMBER_DIALOG_H */

--- a/libleptongui/include/autonumber_dialog.h
+++ b/libleptongui/include/autonumber_dialog.h
@@ -239,9 +239,9 @@ schematic_autonumber_get_free_slot_item_by_name (SchematicAutonumber *autotext,
                                                  char *name);
 int
 schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
-                                      LeptonObject *o_parent,
                                       char *parent_name,
-                                      int number);
+                                      int number,
+                                      int numslots);
 int
 schematic_autonumber_get_next_unused_number (SchematicAutonumber *autotext);
 

--- a/libleptongui/include/autonumber_dialog.h
+++ b/libleptongui/include/autonumber_dialog.h
@@ -234,6 +234,9 @@ schematic_autonumber_dialog_lookup_widget (GtkWidget *widget,
 GList*
 schematic_autonumber_find_slot (GList *slots,
                                 SchematicAutonumberSlot *slot);
+int
+schematic_autonumber_freeslot_compare (gconstpointer a,
+                                       gconstpointer b);
 GList*
 schematic_autonumber_get_free_slot_item_by_name (SchematicAutonumber *autotext,
                                                  char *name);

--- a/libleptongui/include/autonumber_dialog.h
+++ b/libleptongui/include/autonumber_dialog.h
@@ -239,7 +239,6 @@ schematic_autonumber_get_free_slot_item_by_name (SchematicAutonumber *autotext,
                                                  char *name);
 int
 schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
-                                      SchematicWindow *w_current,
                                       LeptonObject *o_parent,
                                       char *parent_name,
                                       int number);

--- a/libleptongui/include/autonumber_dialog.h
+++ b/libleptongui/include/autonumber_dialog.h
@@ -237,7 +237,7 @@ schematic_autonumber_find_slot (GList *slots,
 GList*
 schematic_autonumber_get_free_slot_item_by_name (SchematicAutonumber *autotext,
                                                  char *name);
-int
+void
 schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
                                       char *parent_name,
                                       int number,

--- a/libleptongui/include/autonumber_dialog.h
+++ b/libleptongui/include/autonumber_dialog.h
@@ -231,7 +231,8 @@ schematic_autonumber_dialog_lookup_widget (GtkWidget *widget,
 void
 schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
                                       LeptonObject *o_current,
-                                      LeptonObject *o_parent);
+                                      LeptonObject *o_parent,
+                                      gboolean automatic_slotting);
 void
 schematic_autonumber_get_used (SchematicWindow *w_current,
                                SchematicAutonumber *autotext);

--- a/libleptongui/include/autonumber_dialog.h
+++ b/libleptongui/include/autonumber_dialog.h
@@ -267,6 +267,10 @@ schematic_autonumber_scope_from_string (char *s);
 const char*
 schematic_autonumber_scope_to_string (int scope);
 
+SchematicAutonumberSlot*
+schematic_autonumber_slot_new (int number,
+                               int slot_number,
+                               char *symbol_name);
 int
 schematic_autonumber_sort_order_from_string (char *s);
 

--- a/libleptongui/include/autonumber_dialog.h
+++ b/libleptongui/include/autonumber_dialog.h
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2016 gEDA Contributors
- * Copyright (C) 2017-2025 Lepton EDA Contributors
+ * Copyright (C) 2017-2026 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -230,7 +230,8 @@ schematic_autonumber_dialog_lookup_widget (GtkWidget *widget,
                                            const gchar *widget_name);
 void
 schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
-                                      LeptonObject *o_current);
+                                      LeptonObject *o_current,
+                                      LeptonObject *o_parent);
 void
 schematic_autonumber_get_used (SchematicWindow *w_current,
                                SchematicAutonumber *autotext);

--- a/libleptongui/include/autonumber_dialog.h
+++ b/libleptongui/include/autonumber_dialog.h
@@ -241,7 +241,8 @@ int
 schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
                                       SchematicWindow *w_current,
                                       LeptonObject *o_parent,
-                                      char *parent_name);
+                                      char *parent_name,
+                                      GList *freeslot_item);
 int
 schematic_autonumber_get_next_unused_number (SchematicAutonumber *autotext);
 

--- a/libleptongui/include/autonumber_dialog.h
+++ b/libleptongui/include/autonumber_dialog.h
@@ -290,10 +290,6 @@ schematic_autonumber_sort_yx_rev (gconstpointer a,
 void
 schematic_autonumber_sort_order_widget_init (GtkWidget *sort_order);
 
-void
-schematic_autonumber_update_slot_number (SchematicWindow *w_current,
-                                         LeptonObject *o_current,
-                                         int slot_number);
 G_END_DECLS
 
 #endif /* AUTONUMBER_DIALOG_H */

--- a/libleptongui/include/autonumber_dialog.h
+++ b/libleptongui/include/autonumber_dialog.h
@@ -230,6 +230,7 @@ schematic_autonumber_dialog_lookup_widget (GtkWidget *widget,
                                            const gchar *widget_name);
 void
 schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
+                                      SchematicWindow *w_current,
                                       LeptonObject *o_current,
                                       LeptonObject *o_parent,
                                       gboolean renumber_slots);

--- a/libleptongui/include/autonumber_dialog.h
+++ b/libleptongui/include/autonumber_dialog.h
@@ -232,6 +232,7 @@ int
 schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
                                       SchematicWindow *w_current,
                                       LeptonObject *o_parent,
+                                      char *parent_name,
                                       gboolean renumber_slots);
 void
 schematic_autonumber_get_used (SchematicWindow *w_current,

--- a/libleptongui/include/autonumber_dialog.h
+++ b/libleptongui/include/autonumber_dialog.h
@@ -234,6 +234,9 @@ schematic_autonumber_dialog_lookup_widget (GtkWidget *widget,
 GList*
 schematic_autonumber_find_slot (GList *slots,
                                 SchematicAutonumberSlot *slot);
+GList*
+schematic_autonumber_get_free_slot_item_by_name (SchematicAutonumber *autotext,
+                                                 char *name);
 int
 schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
                                       SchematicWindow *w_current,

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1337,6 +1337,26 @@ schematic_autonumber_get_next_unused_number (SchematicAutonumber *autotext,
 }
 
 
+/*! \brief Add a number to the list of used numbers.
+ *
+ *  \par Function Description
+ *  Adds \p number to the sorted list of already occupied numbers
+ *  of an #SchematicAutonumber instance.
+ *
+ *  \param [in] autotext The #SchematicAutonumber instance.
+ *  \param [in] number The number to add.
+ */
+void
+schematic_autonumber_add_used_number (SchematicAutonumber *autotext,
+                                      int number)
+{
+  schematic_autonumber_set_autotext_used_numbers (autotext,
+                                                  g_list_insert_sorted (schematic_autonumber_get_autotext_used_numbers (autotext),
+                                                                        GINT_TO_POINTER (number),
+                                                                        (GCompareFunc) autonumber_sort_numbers));
+}
+
+
 /*! \brief Handle all the options of the Autonumber text dialog.
  *  \par Function Description
  *  This function receives the options of the the autonumber text
@@ -1413,10 +1433,7 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
     slot = 0;
 
     /* insert the new number to the used list */
-    schematic_autonumber_set_autotext_used_numbers (autotext,
-                                                    g_list_insert_sorted (schematic_autonumber_get_autotext_used_numbers (autotext),
-                                                                          GINT_TO_POINTER (new_number),
-                                                                          (GCompareFunc) autonumber_sort_numbers));
+    schematic_autonumber_add_used_number (autotext, new_number);
 
     /* 3. is o_current a slotted object ? */
     if (renumber_slots)

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1,7 +1,7 @@
 /* Lepton EDA Schematic Capture
  * Copyright (C) 1998-2010 Ales Hvezda
  * Copyright (C) 1998-2016 gEDA Contributors
- * Copyright (C) 2017-2025 Lepton EDA Contributors
+ * Copyright (C) 2017-2026 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1279,6 +1279,7 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
   gchar *numslot_str;
   char *str;
   gint number, slot;
+  gboolean unused_slot_found = FALSE;
 
   new_number = autotext->startnum;
 
@@ -1302,47 +1303,50 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
       g_free(freeslot);
       autotext->free_slots = g_list_delete_link(autotext->free_slots, freeslot_item);
 
-      return;
+      unused_slot_found = TRUE;
     }
   }
 
-  /* get a new number */
-  item = autotext->used_numbers;
-  while (1) {
-    while (item != NULL && GPOINTER_TO_INT(item->data) < new_number)
-      item = g_list_next(item);
+  if (!unused_slot_found)
+  {
+    /* get a new number */
+    item = autotext->used_numbers;
+    while (1) {
+      while (item != NULL && GPOINTER_TO_INT(item->data) < new_number)
+        item = g_list_next(item);
 
-    if (item == NULL || GPOINTER_TO_INT(item->data) > new_number)
-      break;
-    else  /* new_number == item->data */
-      new_number++;
-  }
-  number = new_number;
-  slot = 0;
+      if (item == NULL || GPOINTER_TO_INT(item->data) > new_number)
+        break;
+      else  /* new_number == item->data */
+        new_number++;
+    }
+    number = new_number;
+    slot = 0;
 
-  /* insert the new number to the used list */
-  autotext->used_numbers = g_list_insert_sorted(autotext->used_numbers,
-                                                GINT_TO_POINTER(new_number),
-                                                (GCompareFunc) autonumber_sort_numbers);
+    /* insert the new number to the used list */
+    autotext->used_numbers = g_list_insert_sorted(autotext->used_numbers,
+                                                  GINT_TO_POINTER(new_number),
+                                                  (GCompareFunc) autonumber_sort_numbers);
 
-  /* 3. is o_current a slotted object ? */
-  if ((autotext->slotting) && o_parent != NULL) {
-    numslot_str =
-      lepton_attrib_search_object_attribs_by_name (o_parent, "numslots", 0);
-    if (numslot_str != NULL) {
-      sscanf(numslot_str," %d",&numslots);
-      g_free(numslot_str);
-      if (numslots > 0) {
-        /* Yes! -> new number and slot=1; add the other slots to the database */
-        slot = 1;
-        for (i=2; i <=numslots; i++) {
-          freeslot = g_new (SchematicAutonumberSlot, 1);
-          freeslot->symbolname = lepton_component_object_get_basename (o_parent);
-          freeslot->number = new_number;
-          freeslot->slotnr = i;
-          autotext->free_slots = g_list_insert_sorted(autotext->free_slots,
-                                                      freeslot,
-                                                      (GCompareFunc) freeslot_compare);
+    /* 3. is o_current a slotted object ? */
+    if ((autotext->slotting) && o_parent != NULL) {
+      numslot_str =
+        lepton_attrib_search_object_attribs_by_name (o_parent, "numslots", 0);
+      if (numslot_str != NULL) {
+        sscanf(numslot_str," %d",&numslots);
+        g_free(numslot_str);
+        if (numslots > 0) {
+          /* Yes! -> new number and slot=1; add the other slots to the database */
+          slot = 1;
+          for (i=2; i <=numslots; i++) {
+            freeslot = g_new (SchematicAutonumberSlot, 1);
+            freeslot->symbolname = lepton_component_object_get_basename (o_parent);
+            freeslot->number = new_number;
+            freeslot->slotnr = i;
+            autotext->free_slots = g_list_insert_sorted(autotext->free_slots,
+                                                        freeslot,
+                                                        (GCompareFunc) freeslot_compare);
+          }
         }
       }
     }

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1330,8 +1330,9 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
       number = schematic_autonumber_slot_get_number (freeslot);
       slot = schematic_autonumber_slot_get_slot_number (freeslot);
       g_free(freeslot);
-      autotext->free_slots = g_list_delete_link(autotext->free_slots, freeslot_item);
-
+      schematic_autonumber_set_autotext_free_slots (autotext,
+                                                    g_list_delete_link (schematic_autonumber_get_autotext_free_slots (autotext),
+                                                                        freeslot_item));
       unused_slot_found = TRUE;
     }
   }

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1378,9 +1378,10 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
               schematic_autonumber_slot_new (new_number,
                                              i,
                                              lepton_component_object_get_basename (o_parent));
-            autotext->free_slots = g_list_insert_sorted(autotext->free_slots,
-                                                        freeslot,
-                                                        (GCompareFunc) freeslot_compare);
+            schematic_autonumber_set_autotext_free_slots (autotext,
+                                                          g_list_insert_sorted (schematic_autonumber_get_autotext_free_slots (autotext),
+                                                                                freeslot,
+                                                                                (GCompareFunc) freeslot_compare));
           }
         }
       }

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1395,7 +1395,6 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
   gchar *numslot_str;
   char *str;
   gint number, slot;
-  gboolean unused_slot_found = FALSE;
 
   /* Check for slots first */
   /* 1. are there any unused slots in the database? */
@@ -1414,10 +1413,8 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
     schematic_autonumber_set_autotext_free_slots (autotext,
                                                   g_list_delete_link (schematic_autonumber_get_autotext_free_slots (autotext),
                                                                       freeslot_item));
-    unused_slot_found = TRUE;
   }
-
-  if (!unused_slot_found)
+  else
   {
     /* get a new number */
     number = schematic_autonumber_get_next_unused_number (autotext);

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1340,7 +1340,7 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
   if (!unused_slot_found)
   {
     /* get a new number */
-    new_number = autotext->startnum;
+    new_number = schematic_autonumber_get_autotext_startnum (autotext);
 
     item = autotext->used_numbers;
     while (1) {

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1439,37 +1439,19 @@ schematic_autonumber_get_free_slot_item_by_name (SchematicAutonumber *autotext,
  *              Autonumber dialog belongs to.
  *  \param [in] o_parent The parent object of \p o_current, or NULL.
  *  \param [in] parent_name The component name of the parent object.
- *  \param [in] freeslot_item A free slot in the list of unused slots.
  *  \return The number for renumbering.
  */
 int
 schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
                                       SchematicWindow *w_current,
                                       LeptonObject *o_parent,
-                                      char *parent_name,
-                                      GList *freeslot_item)
+                                      char *parent_name)
 {
   gint numslots, i;
   SchematicAutonumberSlot *freeslot;
   gchar *numslot_str;
   gint number, slot;
 
-  /* Check for slots first */
-  /* 1. are there any unused slots in the database? */
-  /* Yes! -> remove from database, apply it */
-  if (freeslot_item != NULL) {
-    freeslot = (SchematicAutonumberSlot*) freeslot_item->data;
-    number = schematic_autonumber_slot_get_number (freeslot);
-    slot = schematic_autonumber_slot_get_slot_number (freeslot);
-    g_free(freeslot);
-    schematic_autonumber_set_autotext_free_slots (autotext,
-                                                  g_list_delete_link (schematic_autonumber_get_autotext_free_slots (autotext),
-                                                                      freeslot_item));
-
-    schematic_autonumber_update_slot_number (w_current, o_parent, slot);
-  }
-  else
-  {
     /* get a new number */
     number = schematic_autonumber_get_next_unused_number (autotext);
     slot = 0;
@@ -1495,7 +1477,6 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
     }
 
     schematic_autonumber_update_slot_number (w_current, o_parent, slot);
-  }
 
   return number;
 }

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1298,14 +1298,14 @@ schematic_autonumber_get_used (SchematicWindow *w_current,
  *  \param [in,out] autotext The #SchematicAutonumber instance.
  *  \param [in] o_current The \c LeptonObject instance to process.
  *  \param [in] o_parent The parent object of \p o_current, or NULL.
- *  \param [in] automatic_slotting Whether the slot renumbering is
- *              enabled in the Autonumber dialog.
+ *  \param [in] renumber_slots Whether slots have to be renumbered
+ *              as well.
  */
 void
 schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
                                       LeptonObject *o_current,
                                       LeptonObject *o_parent,
-                                      gboolean automatic_slotting)
+                                      gboolean renumber_slots)
 {
   GList *item;
   gint new_number, numslots, i;
@@ -1318,7 +1318,7 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
 
   /* Check for slots first */
   /* 1. are there any unused slots in the database? */
-  if (automatic_slotting && o_parent != NULL)
+  if (renumber_slots)
   {
     freeslot =
       schematic_autonumber_slot_new (0, 0, lepton_component_object_get_basename (o_parent));
@@ -1364,7 +1364,7 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
                                                                           (GCompareFunc) autonumber_sort_numbers));
 
     /* 3. is o_current a slotted object ? */
-    if (automatic_slotting && o_parent != NULL)
+    if (renumber_slots)
     {
       numslot_str =
         lepton_attrib_search_object_attribs_by_name (o_parent, "numslots", 0);

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1306,8 +1306,9 @@ schematic_autonumber_get_used (SchematicWindow *w_current,
  *              function.
  *  \param [in] renumber_slots Whether slots have to be renumbered
  *              as well.
+ *  \return The number for renumbering.
  */
-void
+int
 schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
                                       SchematicWindow *w_current,
                                       LeptonObject *o_current,
@@ -1410,6 +1411,8 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
   str = g_strdup_printf ("%s%d", search_template, number);
   lepton_text_object_set_string (o_current, str);
   g_free (str);
+
+  return number;
 }
 
 

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1400,7 +1400,9 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
   }
 
   /* Replace old text. */
-  str = g_strdup_printf ("%s%d", autotext->current_searchtext, number);
+  str = g_strdup_printf ("%s%d",
+                         schematic_autonumber_get_autotext_current_searchtext (autotext),
+                         number);
   lepton_text_object_set_string (o_current, str);
   g_free (str);
 

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1420,47 +1420,6 @@ schematic_autonumber_get_free_slot_item_by_name (SchematicAutonumber *autotext,
 }
 
 
-/*! \brief Handle all the options of the Autonumber text dialog.
- *  \par Function Description
- *  This function receives the options of the the autonumber text
- *  dialog in an #SchematicAutonumber structure and then gets or
- *  generates new numbers for the object \p o_current.  It uses
- *  the element numbers \c used_numbers and the list of the free
- *  slots \c free_slots of the #SchematicAutonumber struct.  First
- *  it collects all pages of a hierarchical schematic.  Second it
- *  gets all matching text elements for the searchtext.  Then it
- *  renumbers all text elements of all schematic pages. The
- *  renumbering follows the rules of the parameters given in the
- *  autonumber text dialog.
- *
- *  The attribute "slot" is set if autoslotting is active, else it
- *  is set to zero.
- *
- *  \param [in,out] autotext The #SchematicAutonumber instance.
- *  \param [in] parent_name The component name of the parent object.
- *  \param [in] number The number for renumbering.
- *  \param [in] numslots The parent's 'numslot' attribute value.
- */
-void
-schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
-                                      char *parent_name,
-                                      int number,
-                                      int numslots)
-{
-  gint i;
-  SchematicAutonumberSlot *freeslot;
-
-        for (i=2; i <=numslots; i++) {
-          freeslot =
-            schematic_autonumber_slot_new (number, i, parent_name);
-          schematic_autonumber_set_autotext_free_slots (autotext,
-                                                        g_list_insert_sorted (schematic_autonumber_get_autotext_free_slots (autotext),
-                                                                              freeslot,
-                                                                              (GCompareFunc) schematic_autonumber_freeslot_compare));
-        }
-}
-
-
 /*! \brief Form the list of objects to renumber.
  *  \par Function Description
  *  Filters the list of given objects and returns a new list of

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1362,7 +1362,9 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
                                                                           (GCompareFunc) autonumber_sort_numbers));
 
     /* 3. is o_current a slotted object ? */
-    if ((autotext->slotting) && o_parent != NULL) {
+    if (schematic_autonumber_get_autotext_slotting (autotext) &&
+        o_parent != NULL)
+    {
       numslot_str =
         lepton_attrib_search_object_attribs_by_name (o_parent, "numslots", 0);
       if (numslot_str != NULL) {

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1281,8 +1281,6 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
   gint number, slot;
   gboolean unused_slot_found = FALSE;
 
-  new_number = autotext->startnum;
-
   /* Check for slots first */
   /* 1. are there any unused slots in the database? */
   o_parent = lepton_object_get_attached_to (o_current);
@@ -1310,6 +1308,8 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
   if (!unused_slot_found)
   {
     /* get a new number */
+    new_number = autotext->startnum;
+
     item = autotext->used_numbers;
     while (1) {
       while (item != NULL && GPOINTER_TO_INT(item->data) < new_number)

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1320,9 +1320,9 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
   {
     freeslot =
       schematic_autonumber_slot_new (0, 0, lepton_component_object_get_basename (o_parent));
-    freeslot_item = g_list_find_custom(autotext->free_slots,
-                                       freeslot,
-                                       (GCompareFunc) freeslot_compare);
+    freeslot_item = g_list_find_custom (schematic_autonumber_get_autotext_free_slots (autotext),
+                                        freeslot,
+                                        (GCompareFunc) freeslot_compare);
     g_free(freeslot);
     /* Yes! -> remove from database, apply it */
     if (freeslot_item != NULL) {

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1356,9 +1356,10 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
     slot = 0;
 
     /* insert the new number to the used list */
-    autotext->used_numbers = g_list_insert_sorted(autotext->used_numbers,
-                                                  GINT_TO_POINTER(new_number),
-                                                  (GCompareFunc) autonumber_sort_numbers);
+    schematic_autonumber_set_autotext_used_numbers (autotext,
+                                                    g_list_insert_sorted (schematic_autonumber_get_autotext_used_numbers (autotext),
+                                                                          GINT_TO_POINTER (new_number),
+                                                                          (GCompareFunc) autonumber_sort_numbers));
 
     /* 3. is o_current a slotted object ? */
     if ((autotext->slotting) && o_parent != NULL) {

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1360,6 +1360,35 @@ schematic_autonumber_add_used_number (SchematicAutonumber *autotext,
 }
 
 
+/*! \brief Update the 'slot' attribute of an object.
+ *
+ *  \par Function Description
+ *  Updates the \a slot attribute attached to \p o_current setting
+ *  its number to \p slot_number.
+ *
+ *  \param [in] w_current The parent #SchematicWindow instance.
+ *  \param [in] o_current The object to modify the 'slot'
+ *              attribute of.
+ *  \param [in] slot_number New slot number.
+ */
+void
+schematic_autonumber_update_slot_number (SchematicWindow *w_current,
+                                         LeptonObject *o_current,
+                                         int slot_number)
+{
+  char *str;
+
+  /* Updates the text content of the "slot" attribute of the
+   * object if the slot value is not zero. */
+  if (slot_number != 0) {
+    /* Update the slot on the owning object. */
+    str = g_strdup_printf ("slot=%d", slot_number);
+    o_slot_end (w_current, o_current, str);
+    g_free (str);
+  }
+}
+
+
 /*! \brief Handle all the options of the Autonumber text dialog.
  *  \par Function Description
  *  This function receives the options of the the autonumber text
@@ -1393,7 +1422,6 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
   SchematicAutonumberSlot *freeslot;
   GList *freeslot_item;
   gchar *numslot_str;
-  char *str;
   gint number, slot;
 
   /* Check for slots first */
@@ -1441,14 +1469,7 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
     }
   }
 
-  /* Updates the text content of the "slot" attribute of the
-   * object if the slot value is not zero. */
-  if (slot != 0) {
-    /* Update the slot on the owning object. */
-    str = g_strdup_printf ("slot=%d", slot);
-    o_slot_end (w_current, o_parent, str);
-    g_free (str);
-  }
+  schematic_autonumber_update_slot_number (w_current, o_parent, slot);
 
   return number;
 }

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1148,6 +1148,37 @@ schematic_autonumber_match (SchematicAutonumber *autotext,
 }
 
 
+/*! \brief Create and return a new #SchematicAutonumberSlot
+ *  instance.
+ *
+ *  \par Function Description
+ *  Creates and returns a new #SchematicAutonumberSlot instance
+ *  setting its fields to the given argument values.
+ *
+ *  \param [in] number The number being a suffix of the processed
+ *              object text string.
+ *  \param [in] slot_number The given slot number.
+ *  \param [in] symbol_name The name of the symbol the data
+ *              belongs to.
+ *  \return The new #SchematicAutonumberSlot instance.
+ */
+SchematicAutonumberSlot*
+schematic_autonumber_slot_new (int number,
+                               int slot_number,
+                               char *symbol_name)
+{
+  SchematicAutonumberSlot *slot;
+
+  slot = g_new (SchematicAutonumberSlot, 1);
+
+  slot->number = number;
+  slot->slotnr = slot_number;
+  slot->symbolname = symbol_name;
+
+  return slot;
+}
+
+
 /*! \brief Creates a list of already numbered objects and slots
  *  \par Function Description
  *  This function collects the used numbers of a single schematic

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1301,6 +1301,42 @@ schematic_autonumber_get_used (SchematicWindow *w_current,
 }
 
 
+/*! \brief Get the next unused number for autonumbering.
+ *
+ *  \par Function Description
+ *  Gets the list of already occupied numbers of an
+ *  #SchematicAutonumber instance and a starting number to
+ *  continue numbering from, and calculates the next number for
+ *  autonumbering.
+ *
+ *  \param [in] autotext The #SchematicAutonumber instance.
+ *  \param [in] start_number The number to continue numbering from.
+ *  \return The next unused number.
+ */
+int
+schematic_autonumber_get_next_unused_number (SchematicAutonumber *autotext,
+                                             int start_number)
+{
+  GList *item;
+  int next_number;
+
+  next_number = start_number;
+
+  item = schematic_autonumber_get_autotext_used_numbers (autotext);
+  while (1) {
+    while (item != NULL && GPOINTER_TO_INT (item->data) < next_number)
+      item = g_list_next(item);
+
+    if (item == NULL || GPOINTER_TO_INT (item->data) > next_number)
+      break;
+    else  /* next_number == item->data */
+      next_number++;
+  }
+
+  return next_number;
+}
+
+
 /*! \brief Handle all the options of the Autonumber text dialog.
  *  \par Function Description
  *  This function receives the options of the the autonumber text
@@ -1333,7 +1369,6 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
                                       char *parent_name,
                                       gboolean renumber_slots)
 {
-  GList *item;
   gint new_number, numslots, i;
   SchematicAutonumberSlot *freeslot;
   GList *freeslot_item;
@@ -1370,16 +1405,8 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
     /* get a new number */
     new_number = schematic_autonumber_get_autotext_startnum (autotext);
 
-    item = schematic_autonumber_get_autotext_used_numbers (autotext);
-    while (1) {
-      while (item != NULL && GPOINTER_TO_INT(item->data) < new_number)
-        item = g_list_next(item);
+    new_number = schematic_autonumber_get_next_unused_number (autotext, new_number);
 
-      if (item == NULL || GPOINTER_TO_INT(item->data) > new_number)
-        break;
-      else  /* new_number == item->data */
-        new_number++;
-    }
     number = new_number;
     slot = 0;
 

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1327,7 +1327,7 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
     /* Yes! -> remove from database, apply it */
     if (freeslot_item != NULL) {
       freeslot = (SchematicAutonumberSlot*) freeslot_item->data;
-      number = freeslot->number;
+      number = schematic_autonumber_slot_get_number (freeslot);
       slot = freeslot->slotnr;
       g_free(freeslot);
       autotext->free_slots = g_list_delete_link(autotext->free_slots, freeslot_item);

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1318,10 +1318,8 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
   if (schematic_autonumber_get_autotext_slotting (autotext) &&
       o_parent != NULL)
   {
-    freeslot = g_new (SchematicAutonumberSlot, 1);
-    freeslot->symbolname = lepton_component_object_get_basename (o_parent);
-    freeslot->number = 0;
-    freeslot->slotnr = 0;
+    freeslot =
+      schematic_autonumber_slot_new (0, 0, lepton_component_object_get_basename (o_parent));
     freeslot_item = g_list_find_custom(autotext->free_slots,
                                        freeslot,
                                        (GCompareFunc) freeslot_compare);

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1297,15 +1297,16 @@ schematic_autonumber_get_used (SchematicWindow *w_current,
  *
  *  \param [in,out] autotext The #SchematicAutonumber instance.
  *  \param [in] o_current The \c LeptonObject instance to process.
+ *  \param [in] o_parent The parent object of \p o_current, or NULL.
  */
 void
 schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
-                                      LeptonObject *o_current)
+                                      LeptonObject *o_current,
+                                      LeptonObject *o_parent)
 {
   GList *item;
   gint new_number, numslots, i;
   SchematicAutonumberSlot *freeslot;
-  LeptonObject *o_parent = NULL;
   GList *freeslot_item;
   gchar *numslot_str;
   char *str;
@@ -1314,7 +1315,6 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
 
   /* Check for slots first */
   /* 1. are there any unused slots in the database? */
-  o_parent = lepton_object_get_attached_to (o_current);
   if (schematic_autonumber_get_autotext_slotting (autotext) &&
       o_parent != NULL)
   {

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1465,6 +1465,8 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
     schematic_autonumber_set_autotext_free_slots (autotext,
                                                   g_list_delete_link (schematic_autonumber_get_autotext_free_slots (autotext),
                                                                       freeslot_item));
+
+    schematic_autonumber_update_slot_number (w_current, o_parent, slot);
   }
   else
   {
@@ -1491,9 +1493,9 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
         }
       }
     }
-  }
 
-  schematic_autonumber_update_slot_number (w_current, o_parent, slot);
+    schematic_autonumber_update_slot_number (w_current, o_parent, slot);
+  }
 
   return number;
 }

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1374,10 +1374,10 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
           /* Yes! -> new number and slot=1; add the other slots to the database */
           slot = 1;
           for (i=2; i <=numslots; i++) {
-            freeslot = g_new (SchematicAutonumberSlot, 1);
-            freeslot->symbolname = lepton_component_object_get_basename (o_parent);
-            freeslot->number = new_number;
-            freeslot->slotnr = i;
+            freeslot =
+              schematic_autonumber_slot_new (new_number,
+                                             i,
+                                             lepton_component_object_get_basename (o_parent));
             autotext->free_slots = g_list_insert_sorted(autotext->free_slots,
                                                         freeslot,
                                                         (GCompareFunc) freeslot_compare);

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1403,10 +1403,12 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
   if (!unused_slot_found)
   {
     /* get a new number */
+    /* Start with the start number set in the dialog. */
     new_number = schematic_autonumber_get_autotext_startnum (autotext);
-
+    /* Iterate over unused numbers to get the new value. */
     new_number = schematic_autonumber_get_next_unused_number (autotext, new_number);
-
+    /* Store the number for later using to actually update the
+       text object being processed. */
     number = new_number;
     slot = 0;
 

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1439,25 +1439,23 @@ schematic_autonumber_get_free_slot_item_by_name (SchematicAutonumber *autotext,
  *              Autonumber dialog belongs to.
  *  \param [in] o_parent The parent object of \p o_current, or NULL.
  *  \param [in] parent_name The component name of the parent object.
+ *  \param [in] freeslot_item A free slot in the list of unused slots.
  *  \return The number for renumbering.
  */
 int
 schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
                                       SchematicWindow *w_current,
                                       LeptonObject *o_parent,
-                                      char *parent_name)
+                                      char *parent_name,
+                                      GList *freeslot_item)
 {
   gint numslots, i;
   SchematicAutonumberSlot *freeslot;
-  GList *freeslot_item;
   gchar *numslot_str;
   gint number, slot;
 
   /* Check for slots first */
   /* 1. are there any unused slots in the database? */
-  freeslot_item =
-    schematic_autonumber_get_free_slot_item_by_name (autotext, parent_name);
-
   /* Yes! -> remove from database, apply it */
   if (freeslot_item != NULL) {
     freeslot = (SchematicAutonumberSlot*) freeslot_item->data;

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1298,11 +1298,14 @@ schematic_autonumber_get_used (SchematicWindow *w_current,
  *  \param [in,out] autotext The #SchematicAutonumber instance.
  *  \param [in] o_current The \c LeptonObject instance to process.
  *  \param [in] o_parent The parent object of \p o_current, or NULL.
+ *  \param [in] automatic_slotting Whether the slot renumbering is
+ *              enabled in the Autonumber dialog.
  */
 void
 schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
                                       LeptonObject *o_current,
-                                      LeptonObject *o_parent)
+                                      LeptonObject *o_parent,
+                                      gboolean automatic_slotting)
 {
   GList *item;
   gint new_number, numslots, i;
@@ -1315,8 +1318,7 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
 
   /* Check for slots first */
   /* 1. are there any unused slots in the database? */
-  if (schematic_autonumber_get_autotext_slotting (autotext) &&
-      o_parent != NULL)
+  if (automatic_slotting && o_parent != NULL)
   {
     freeslot =
       schematic_autonumber_slot_new (0, 0, lepton_component_object_get_basename (o_parent));
@@ -1362,8 +1364,7 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
                                                                           (GCompareFunc) autonumber_sort_numbers));
 
     /* 3. is o_current a slotted object ? */
-    if (schematic_autonumber_get_autotext_slotting (autotext) &&
-        o_parent != NULL)
+    if (automatic_slotting && o_parent != NULL)
     {
       numslot_str =
         lepton_attrib_search_object_attribs_by_name (o_parent, "numslots", 0);

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1435,30 +1435,24 @@ schematic_autonumber_get_free_slot_item_by_name (SchematicAutonumber *autotext,
  *  is set to zero.
  *
  *  \param [in,out] autotext The #SchematicAutonumber instance.
- *  \param [in] o_parent The parent object of \p o_current, or NULL.
  *  \param [in] parent_name The component name of the parent object.
  *  \param [in] number The number for renumbering.
+ *  \param [in] numslots The parent's 'numslot' attribute value.
  *  \return The slot number for renumbering.
  */
 int
 schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
-                                      LeptonObject *o_parent,
                                       char *parent_name,
-                                      int number)
+                                      int number,
+                                      int numslots)
 {
-  gint numslots, i;
+  gint i;
   SchematicAutonumberSlot *freeslot;
-  gchar *numslot_str;
   gint slot;
 
     slot = 0;
 
     /* 3. is o_current a slotted object ? */
-    numslot_str =
-      lepton_attrib_search_object_attribs_by_name (o_parent, "numslots", 0);
-    if (numslot_str != NULL) {
-      sscanf(numslot_str," %d",&numslots);
-      g_free(numslot_str);
       if (numslots > 0) {
         /* Yes! -> new number and slot=1; add the other slots to the database */
         slot = 1;
@@ -1471,7 +1465,6 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
                                                                               (GCompareFunc) freeslot_compare));
         }
       }
-    }
 
   return slot;
 }

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1435,8 +1435,6 @@ schematic_autonumber_get_free_slot_item_by_name (SchematicAutonumber *autotext,
  *  is set to zero.
  *
  *  \param [in,out] autotext The #SchematicAutonumber instance.
- *  \param [in] w_current The #SchematicWindow instance the
- *              Autonumber dialog belongs to.
  *  \param [in] o_parent The parent object of \p o_current, or NULL.
  *  \param [in] parent_name The component name of the parent object.
  *  \param [in] number The number for renumbering.
@@ -1444,7 +1442,6 @@ schematic_autonumber_get_free_slot_item_by_name (SchematicAutonumber *autotext,
  */
 int
 schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
-                                      SchematicWindow *w_current,
                                       LeptonObject *o_parent,
                                       char *parent_name,
                                       int number)
@@ -1475,8 +1472,6 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
         }
       }
     }
-
-    schematic_autonumber_update_slot_number (w_current, o_parent, slot);
 
   return slot;
 }

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1300,6 +1300,10 @@ schematic_autonumber_get_used (SchematicWindow *w_current,
  *              Autonumber dialog belongs to.
  *  \param [in] o_current The \c LeptonObject instance to process.
  *  \param [in] o_parent The parent object of \p o_current, or NULL.
+ *  \param [in] search_template The current search template which
+ *              is used to generate the new value of the attribute
+ *              object along with the new number found in the
+ *              function.
  *  \param [in] renumber_slots Whether slots have to be renumbered
  *              as well.
  */
@@ -1308,6 +1312,7 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
                                       SchematicWindow *w_current,
                                       LeptonObject *o_current,
                                       LeptonObject *o_parent,
+                                      char *search_template,
                                       gboolean renumber_slots)
 {
   GList *item;
@@ -1402,9 +1407,7 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
   }
 
   /* Replace old text. */
-  str = g_strdup_printf ("%s%d",
-                         schematic_autonumber_get_autotext_current_searchtext (autotext),
-                         number);
+  str = g_strdup_printf ("%s%d", search_template, number);
   lepton_text_object_set_string (o_current, str);
   g_free (str);
 

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1393,7 +1393,7 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
   if (slot != 0) {
     /* Update the slot on the owning object. */
     str = g_strdup_printf ("slot=%d", slot);
-    o_slot_end (autotext->w_current,
+    o_slot_end (schematic_autonumber_get_autotext_window (autotext),
                 lepton_object_get_attached_to (o_current),
                 str);
     g_free (str);
@@ -1404,7 +1404,7 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
   lepton_text_object_set_string (o_current, str);
   g_free (str);
 
-  schematic_window_active_page_changed (autotext->w_current);
+  schematic_window_active_page_changed (schematic_autonumber_get_autotext_window (autotext));
 }
 
 

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1362,35 +1362,6 @@ schematic_autonumber_add_used_number (SchematicAutonumber *autotext,
 }
 
 
-/*! \brief Update the 'slot' attribute of an object.
- *
- *  \par Function Description
- *  Updates the \a slot attribute attached to \p o_current setting
- *  its number to \p slot_number.
- *
- *  \param [in] w_current The parent #SchematicWindow instance.
- *  \param [in] o_current The object to modify the 'slot'
- *              attribute of.
- *  \param [in] slot_number New slot number.
- */
-void
-schematic_autonumber_update_slot_number (SchematicWindow *w_current,
-                                         LeptonObject *o_current,
-                                         int slot_number)
-{
-  char *str;
-
-  /* Updates the text content of the "slot" attribute of the
-   * object if the slot value is not zero. */
-  if (slot_number != 0) {
-    /* Update the slot on the owning object. */
-    str = g_strdup_printf ("slot=%d", slot_number);
-    o_slot_end (w_current, o_current, str);
-    g_free (str);
-  }
-}
-
-
 /*! \brief Get free slot item by name.
  *
  *  \par Function Description

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1410,8 +1410,6 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
   str = g_strdup_printf ("%s%d", search_template, number);
   lepton_text_object_set_string (o_current, str);
   g_free (str);
-
-  schematic_window_active_page_changed (w_current);
 }
 
 

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1328,7 +1328,7 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
     if (freeslot_item != NULL) {
       freeslot = (SchematicAutonumberSlot*) freeslot_item->data;
       number = schematic_autonumber_slot_get_number (freeslot);
-      slot = freeslot->slotnr;
+      slot = schematic_autonumber_slot_get_slot_number (freeslot);
       g_free(freeslot);
       autotext->free_slots = g_list_delete_link(autotext->free_slots, freeslot_item);
 

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1450,8 +1450,6 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
   SchematicAutonumberSlot *freeslot;
   gint slot;
 
-    slot = 0;
-
     /* 3. is o_current a slotted object ? */
       if (numslots > 0) {
         /* Yes! -> new number and slot=1; add the other slots to the database */
@@ -1464,6 +1462,10 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
                                                                               freeslot,
                                                                               (GCompareFunc) freeslot_compare));
         }
+      }
+      else
+      {
+        slot = 0;
       }
 
   return slot;

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1299,6 +1299,7 @@ schematic_autonumber_get_used (SchematicWindow *w_current,
  *  \param [in] w_current The #SchematicWindow instance the
  *              Autonumber dialog belongs to.
  *  \param [in] o_parent The parent object of \p o_current, or NULL.
+ *  \param [in] parent_name The component name of the parent object.
  *  \param [in] renumber_slots Whether slots have to be renumbered
  *              as well.
  *  \return The number for renumbering.
@@ -1307,6 +1308,7 @@ int
 schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
                                       SchematicWindow *w_current,
                                       LeptonObject *o_parent,
+                                      char *parent_name,
                                       gboolean renumber_slots)
 {
   GList *item;
@@ -1323,7 +1325,7 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
   if (renumber_slots)
   {
     freeslot =
-      schematic_autonumber_slot_new (0, 0, lepton_component_object_get_basename (o_parent));
+      schematic_autonumber_slot_new (0, 0, parent_name);
     freeslot_item = g_list_find_custom (schematic_autonumber_get_autotext_free_slots (autotext),
                                         freeslot,
                                         (GCompareFunc) freeslot_compare);
@@ -1378,9 +1380,7 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
           slot = 1;
           for (i=2; i <=numslots; i++) {
             freeslot =
-              schematic_autonumber_slot_new (new_number,
-                                             i,
-                                             lepton_component_object_get_basename (o_parent));
+              schematic_autonumber_slot_new (new_number, i, parent_name);
             schematic_autonumber_set_autotext_free_slots (autotext,
                                                           g_list_insert_sorted (schematic_autonumber_get_autotext_free_slots (autotext),
                                                                                 freeslot,

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1333,6 +1333,9 @@ schematic_autonumber_get_next_unused_number (SchematicAutonumber *autotext)
       next_number++;
   }
 
+  /* Insert the new number to the list of used numbers. */
+  schematic_autonumber_add_used_number (autotext, next_number);
+
   return next_number;
 }
 
@@ -1428,9 +1431,6 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
        text object being processed. */
     number = new_number;
     slot = 0;
-
-    /* insert the new number to the used list */
-    schematic_autonumber_add_used_number (autotext, new_number);
 
     /* 3. is o_current a slotted object ? */
     if (renumber_slots)

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1438,9 +1438,8 @@ schematic_autonumber_get_free_slot_item_by_name (SchematicAutonumber *autotext,
  *  \param [in] parent_name The component name of the parent object.
  *  \param [in] number The number for renumbering.
  *  \param [in] numslots The parent's 'numslot' attribute value.
- *  \return The slot number for renumbering.
  */
-int
+void
 schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
                                       char *parent_name,
                                       int number,
@@ -1448,12 +1447,7 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
 {
   gint i;
   SchematicAutonumberSlot *freeslot;
-  gint slot;
 
-    /* 3. is o_current a slotted object ? */
-      if (numslots > 0) {
-        /* Yes! -> new number and slot=1; add the other slots to the database */
-        slot = 1;
         for (i=2; i <=numslots; i++) {
           freeslot =
             schematic_autonumber_slot_new (number, i, parent_name);
@@ -1462,13 +1456,6 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
                                                                               freeslot,
                                                                               (GCompareFunc) freeslot_compare));
         }
-      }
-      else
-      {
-        slot = 0;
-      }
-
-  return slot;
 }
 
 

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1392,7 +1392,7 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
                                       char *parent_name,
                                       gboolean renumber_slots)
 {
-  gint new_number, numslots, i;
+  gint numslots, i;
   SchematicAutonumberSlot *freeslot;
   GList *freeslot_item;
   gchar *numslot_str;
@@ -1426,10 +1426,7 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
   if (!unused_slot_found)
   {
     /* get a new number */
-    new_number = schematic_autonumber_get_next_unused_number (autotext);
-    /* Store the number for later using to actually update the
-       text object being processed. */
-    number = new_number;
+    number = schematic_autonumber_get_next_unused_number (autotext);
     slot = 0;
 
     /* 3. is o_current a slotted object ? */
@@ -1445,7 +1442,7 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
           slot = 1;
           for (i=2; i <=numslots; i++) {
             freeslot =
-              schematic_autonumber_slot_new (new_number, i, parent_name);
+              schematic_autonumber_slot_new (number, i, parent_name);
             schematic_autonumber_set_autotext_free_slots (autotext,
                                                           g_list_insert_sorted (schematic_autonumber_get_autotext_free_slots (autotext),
                                                                                 freeslot,

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1011,7 +1011,9 @@ schematic_autonumber_slot_set_symbol_name (SchematicAutonumberSlot *slot,
  *  is set to zero it acts as a wildcard.  The function is used as
  *  GCompareFunc by GList functions.
  */
-gint freeslot_compare(gconstpointer a, gconstpointer b)
+int
+schematic_autonumber_freeslot_compare (gconstpointer a,
+                                       gconstpointer b)
 {
   SchematicAutonumberSlot *aa, *bb;
   gint res;
@@ -1197,7 +1199,7 @@ schematic_autonumber_find_slot (GList *slots,
 {
   return g_list_find_custom (slots,
                              slot,
-                             (GCompareFunc) freeslot_compare);
+                             (GCompareFunc) schematic_autonumber_freeslot_compare);
 }
 
 
@@ -1256,7 +1258,7 @@ schematic_autonumber_get_used (SchematicWindow *w_current,
 
               slot_item = g_list_find_custom(autotext->used_slots,
                                              slot,
-                                             (GCompareFunc) freeslot_compare);
+                                             (GCompareFunc) schematic_autonumber_freeslot_compare);
               if (slot_item != NULL) { /* duplicate slot in used_slots */
                 g_message (_("duplicate slot may cause problems: "
                              "[symbolname=%1$s, number=%2$d, slot=%3$d]"),
@@ -1266,11 +1268,11 @@ schematic_autonumber_get_used (SchematicWindow *w_current,
               else {
                 autotext->used_slots = g_list_insert_sorted(autotext->used_slots,
                                                             slot,
-                                                            (GCompareFunc) freeslot_compare);
+                                                            (GCompareFunc) schematic_autonumber_freeslot_compare);
 
                 slot_item = g_list_find_custom(autotext->free_slots,
                                                slot,
-                                               (GCompareFunc) freeslot_compare);
+                                               (GCompareFunc) schematic_autonumber_freeslot_compare);
                 if (slot_item == NULL) {
                   /* insert all slots to the list, except of the current one */
                   for (i=1; i <= numslots; i++) {
@@ -1279,7 +1281,7 @@ schematic_autonumber_get_used (SchematicWindow *w_current,
                       slot->slotnr = i;
                       autotext->free_slots = g_list_insert_sorted(autotext->free_slots,
                                                                   slot,
-                                                                  (GCompareFunc) freeslot_compare);
+                                                                  (GCompareFunc) schematic_autonumber_freeslot_compare);
                     }
                   }
                 }
@@ -1454,7 +1456,7 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
           schematic_autonumber_set_autotext_free_slots (autotext,
                                                         g_list_insert_sorted (schematic_autonumber_get_autotext_free_slots (autotext),
                                                                               freeslot,
-                                                                              (GCompareFunc) freeslot_compare));
+                                                                              (GCompareFunc) schematic_autonumber_freeslot_compare));
         }
 }
 

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1342,7 +1342,7 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
     /* get a new number */
     new_number = schematic_autonumber_get_autotext_startnum (autotext);
 
-    item = autotext->used_numbers;
+    item = schematic_autonumber_get_autotext_used_numbers (autotext);
     while (1) {
       while (item != NULL && GPOINTER_TO_INT(item->data) < new_number)
         item = g_list_next(item);

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1284,7 +1284,9 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
   /* Check for slots first */
   /* 1. are there any unused slots in the database? */
   o_parent = lepton_object_get_attached_to (o_current);
-  if (autotext->slotting && o_parent != NULL) {
+  if (schematic_autonumber_get_autotext_slotting (autotext) &&
+      o_parent != NULL)
+  {
     freeslot = g_new (SchematicAutonumberSlot, 1);
     freeslot->symbolname = lepton_component_object_get_basename (o_parent);
     freeslot->number = 0;

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1306,22 +1306,22 @@ schematic_autonumber_get_used (SchematicWindow *w_current,
  *  \par Function Description
  *  Gets the list of already occupied numbers of an
  *  #SchematicAutonumber instance and a starting number to
- *  continue numbering from, and calculates the next number for
+ *  start searching from, and calculates the next number for
  *  autonumbering.
  *
  *  \param [in] autotext The #SchematicAutonumber instance.
- *  \param [in] start_number The number to continue numbering from.
  *  \return The next unused number.
  */
 int
-schematic_autonumber_get_next_unused_number (SchematicAutonumber *autotext,
-                                             int start_number)
+schematic_autonumber_get_next_unused_number (SchematicAutonumber *autotext)
 {
   GList *item;
   int next_number;
 
-  next_number = start_number;
+  /* Start with the start number set in the dialog. */
+  next_number = schematic_autonumber_get_autotext_startnum (autotext);
 
+  /* Iterate over unused numbers to get the new value. */
   item = schematic_autonumber_get_autotext_used_numbers (autotext);
   while (1) {
     while (item != NULL && GPOINTER_TO_INT (item->data) < next_number)
@@ -1423,10 +1423,7 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
   if (!unused_slot_found)
   {
     /* get a new number */
-    /* Start with the start number set in the dialog. */
-    new_number = schematic_autonumber_get_autotext_startnum (autotext);
-    /* Iterate over unused numbers to get the new value. */
-    new_number = schematic_autonumber_get_next_unused_number (autotext, new_number);
+    new_number = schematic_autonumber_get_next_unused_number (autotext);
     /* Store the number for later using to actually update the
        text object being processed. */
     number = new_number;

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1439,21 +1439,21 @@ schematic_autonumber_get_free_slot_item_by_name (SchematicAutonumber *autotext,
  *              Autonumber dialog belongs to.
  *  \param [in] o_parent The parent object of \p o_current, or NULL.
  *  \param [in] parent_name The component name of the parent object.
+ *  \param [in] number The number for renumbering.
  *  \return The number for renumbering.
  */
 int
 schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
                                       SchematicWindow *w_current,
                                       LeptonObject *o_parent,
-                                      char *parent_name)
+                                      char *parent_name,
+                                      int number)
 {
   gint numslots, i;
   SchematicAutonumberSlot *freeslot;
   gchar *numslot_str;
-  gint number, slot;
+  gint slot;
 
-    /* get a new number */
-    number = schematic_autonumber_get_next_unused_number (autotext);
     slot = 0;
 
     /* 3. is o_current a slotted object ? */

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1296,6 +1296,8 @@ schematic_autonumber_get_used (SchematicWindow *w_current,
  *  is set to zero.
  *
  *  \param [in,out] autotext The #SchematicAutonumber instance.
+ *  \param [in] w_current The #SchematicWindow instance the
+ *              Autonumber dialog belongs to.
  *  \param [in] o_current The \c LeptonObject instance to process.
  *  \param [in] o_parent The parent object of \p o_current, or NULL.
  *  \param [in] renumber_slots Whether slots have to be renumbered
@@ -1303,6 +1305,7 @@ schematic_autonumber_get_used (SchematicWindow *w_current,
  */
 void
 schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
+                                      SchematicWindow *w_current,
                                       LeptonObject *o_current,
                                       LeptonObject *o_parent,
                                       gboolean renumber_slots)
@@ -1394,7 +1397,7 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
   if (slot != 0) {
     /* Update the slot on the owning object. */
     str = g_strdup_printf ("slot=%d", slot);
-    o_slot_end (schematic_autonumber_get_autotext_window (autotext),
+    o_slot_end (w_current,
                 lepton_object_get_attached_to (o_current),
                 str);
     g_free (str);
@@ -1407,7 +1410,7 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
   lepton_text_object_set_string (o_current, str);
   g_free (str);
 
-  schematic_window_active_page_changed (schematic_autonumber_get_autotext_window (autotext));
+  schematic_window_active_page_changed (w_current);
 }
 
 

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1397,9 +1397,7 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
   if (slot != 0) {
     /* Update the slot on the owning object. */
     str = g_strdup_printf ("slot=%d", slot);
-    o_slot_end (w_current,
-                lepton_object_get_attached_to (o_current),
-                str);
+    o_slot_end (w_current, o_parent, str);
     g_free (str);
   }
 

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1179,6 +1179,28 @@ schematic_autonumber_slot_new (int number,
 }
 
 
+/*! \brief Find a slot in a list of autonumber slots.
+ *  \par Function Description
+ *
+ *  Searches for \p slot in the \p slots \c GList and returns a
+ *  new \c GList starting with the item pointing to \p slot,
+ *  or NULL if there is no such item in the list.
+ *
+ *  \param [in] slots The list of slots.
+ *  \param [in] slot The slot to search for.
+ *
+ *  \return The \c GList starting with the given slot or NULL.
+ */
+GList*
+schematic_autonumber_find_slot (GList *slots,
+                                SchematicAutonumberSlot *slot)
+{
+  return g_list_find_custom (slots,
+                             slot,
+                             (GCompareFunc) freeslot_compare);
+}
+
+
 /*! \brief Creates a list of already numbered objects and slots
  *  \par Function Description
  *  This function collects the used numbers of a single schematic
@@ -1326,9 +1348,9 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
   {
     freeslot =
       schematic_autonumber_slot_new (0, 0, parent_name);
-    freeslot_item = g_list_find_custom (schematic_autonumber_get_autotext_free_slots (autotext),
-                                        freeslot,
-                                        (GCompareFunc) freeslot_compare);
+    freeslot_item =
+      schematic_autonumber_find_slot (schematic_autonumber_get_autotext_free_slots (autotext),
+                                      freeslot);
     g_free(freeslot);
     /* Yes! -> remove from database, apply it */
     if (freeslot_item != NULL) {

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1399,23 +1399,23 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
 
   /* Check for slots first */
   /* 1. are there any unused slots in the database? */
-    freeslot =
-      schematic_autonumber_slot_new (0, 0, parent_name);
-    freeslot_item =
-      schematic_autonumber_find_slot (schematic_autonumber_get_autotext_free_slots (autotext),
-                                      freeslot);
+  freeslot =
+    schematic_autonumber_slot_new (0, 0, parent_name);
+  freeslot_item =
+    schematic_autonumber_find_slot (schematic_autonumber_get_autotext_free_slots (autotext),
+                                    freeslot);
+  g_free(freeslot);
+  /* Yes! -> remove from database, apply it */
+  if (freeslot_item != NULL) {
+    freeslot = (SchematicAutonumberSlot*) freeslot_item->data;
+    number = schematic_autonumber_slot_get_number (freeslot);
+    slot = schematic_autonumber_slot_get_slot_number (freeslot);
     g_free(freeslot);
-    /* Yes! -> remove from database, apply it */
-    if (freeslot_item != NULL) {
-      freeslot = (SchematicAutonumberSlot*) freeslot_item->data;
-      number = schematic_autonumber_slot_get_number (freeslot);
-      slot = schematic_autonumber_slot_get_slot_number (freeslot);
-      g_free(freeslot);
-      schematic_autonumber_set_autotext_free_slots (autotext,
-                                                    g_list_delete_link (schematic_autonumber_get_autotext_free_slots (autotext),
-                                                                        freeslot_item));
-      unused_slot_found = TRUE;
-    }
+    schematic_autonumber_set_autotext_free_slots (autotext,
+                                                  g_list_delete_link (schematic_autonumber_get_autotext_free_slots (autotext),
+                                                                      freeslot_item));
+    unused_slot_found = TRUE;
+  }
 
   if (!unused_slot_found)
   {
@@ -1424,24 +1424,24 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
     slot = 0;
 
     /* 3. is o_current a slotted object ? */
-      numslot_str =
-        lepton_attrib_search_object_attribs_by_name (o_parent, "numslots", 0);
-      if (numslot_str != NULL) {
-        sscanf(numslot_str," %d",&numslots);
-        g_free(numslot_str);
-        if (numslots > 0) {
-          /* Yes! -> new number and slot=1; add the other slots to the database */
-          slot = 1;
-          for (i=2; i <=numslots; i++) {
-            freeslot =
-              schematic_autonumber_slot_new (number, i, parent_name);
-            schematic_autonumber_set_autotext_free_slots (autotext,
-                                                          g_list_insert_sorted (schematic_autonumber_get_autotext_free_slots (autotext),
-                                                                                freeslot,
-                                                                                (GCompareFunc) freeslot_compare));
-          }
+    numslot_str =
+      lepton_attrib_search_object_attribs_by_name (o_parent, "numslots", 0);
+    if (numslot_str != NULL) {
+      sscanf(numslot_str," %d",&numslots);
+      g_free(numslot_str);
+      if (numslots > 0) {
+        /* Yes! -> new number and slot=1; add the other slots to the database */
+        slot = 1;
+        for (i=2; i <=numslots; i++) {
+          freeslot =
+            schematic_autonumber_slot_new (number, i, parent_name);
+          schematic_autonumber_set_autotext_free_slots (autotext,
+                                                        g_list_insert_sorted (schematic_autonumber_get_autotext_free_slots (autotext),
+                                                                              freeslot,
+                                                                              (GCompareFunc) freeslot_compare));
         }
       }
+    }
   }
 
   /* Updates the text content of the "slot" attribute of the

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1389,6 +1389,35 @@ schematic_autonumber_update_slot_number (SchematicWindow *w_current,
 }
 
 
+/*! \brief Get free slot item by name.
+ *
+ *  \par Function Description
+ *  Returns an item of free slot \c GList corresponding to given
+ *  \p name.
+ *
+ *  \param [in] autotext The #SchematicAutonumber instance.
+ *  \param [in] name The component name to search for.
+ *
+ *  \return The found list item.
+ */
+GList*
+schematic_autonumber_get_free_slot_item_by_name (SchematicAutonumber *autotext,
+                                                 char *name)
+{
+  SchematicAutonumberSlot *freeslot;
+  GList *freeslot_item;
+
+  freeslot =
+    schematic_autonumber_slot_new (0, 0, name);
+  freeslot_item =
+    schematic_autonumber_find_slot (schematic_autonumber_get_autotext_free_slots (autotext),
+                                    freeslot);
+  g_free (freeslot);
+
+  return freeslot_item;
+}
+
+
 /*! \brief Handle all the options of the Autonumber text dialog.
  *  \par Function Description
  *  This function receives the options of the the autonumber text
@@ -1426,12 +1455,9 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
 
   /* Check for slots first */
   /* 1. are there any unused slots in the database? */
-  freeslot =
-    schematic_autonumber_slot_new (0, 0, parent_name);
   freeslot_item =
-    schematic_autonumber_find_slot (schematic_autonumber_get_autotext_free_slots (autotext),
-                                    freeslot);
-  g_free(freeslot);
+    schematic_autonumber_get_free_slot_item_by_name (autotext, parent_name);
+
   /* Yes! -> remove from database, apply it */
   if (freeslot_item != NULL) {
     freeslot = (SchematicAutonumberSlot*) freeslot_item->data;

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1298,12 +1298,7 @@ schematic_autonumber_get_used (SchematicWindow *w_current,
  *  \param [in,out] autotext The #SchematicAutonumber instance.
  *  \param [in] w_current The #SchematicWindow instance the
  *              Autonumber dialog belongs to.
- *  \param [in] o_current The \c LeptonObject instance to process.
  *  \param [in] o_parent The parent object of \p o_current, or NULL.
- *  \param [in] search_template The current search template which
- *              is used to generate the new value of the attribute
- *              object along with the new number found in the
- *              function.
  *  \param [in] renumber_slots Whether slots have to be renumbered
  *              as well.
  *  \return The number for renumbering.
@@ -1311,9 +1306,7 @@ schematic_autonumber_get_used (SchematicWindow *w_current,
 int
 schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
                                       SchematicWindow *w_current,
-                                      LeptonObject *o_current,
                                       LeptonObject *o_parent,
-                                      char *search_template,
                                       gboolean renumber_slots)
 {
   GList *item;
@@ -1406,11 +1399,6 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
     o_slot_end (w_current, o_parent, str);
     g_free (str);
   }
-
-  /* Replace old text. */
-  str = g_strdup_printf ("%s%d", search_template, number);
-  lepton_text_object_set_string (o_current, str);
-  g_free (str);
 
   return number;
 }

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1440,7 +1440,7 @@ schematic_autonumber_get_free_slot_item_by_name (SchematicAutonumber *autotext,
  *  \param [in] o_parent The parent object of \p o_current, or NULL.
  *  \param [in] parent_name The component name of the parent object.
  *  \param [in] number The number for renumbering.
- *  \return The number for renumbering.
+ *  \return The slot number for renumbering.
  */
 int
 schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
@@ -1478,7 +1478,7 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
 
     schematic_autonumber_update_slot_number (w_current, o_parent, slot);
 
-  return number;
+  return slot;
 }
 
 

--- a/libleptongui/src/autonumber_dialog.c
+++ b/libleptongui/src/autonumber_dialog.c
@@ -1381,16 +1381,13 @@ schematic_autonumber_add_used_number (SchematicAutonumber *autotext,
  *              Autonumber dialog belongs to.
  *  \param [in] o_parent The parent object of \p o_current, or NULL.
  *  \param [in] parent_name The component name of the parent object.
- *  \param [in] renumber_slots Whether slots have to be renumbered
- *              as well.
  *  \return The number for renumbering.
  */
 int
 schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
                                       SchematicWindow *w_current,
                                       LeptonObject *o_parent,
-                                      char *parent_name,
-                                      gboolean renumber_slots)
+                                      char *parent_name)
 {
   gint numslots, i;
   SchematicAutonumberSlot *freeslot;
@@ -1402,8 +1399,6 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
 
   /* Check for slots first */
   /* 1. are there any unused slots in the database? */
-  if (renumber_slots)
-  {
     freeslot =
       schematic_autonumber_slot_new (0, 0, parent_name);
     freeslot_item =
@@ -1421,7 +1416,6 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
                                                                         freeslot_item));
       unused_slot_found = TRUE;
     }
-  }
 
   if (!unused_slot_found)
   {
@@ -1430,8 +1424,6 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
     slot = 0;
 
     /* 3. is o_current a slotted object ? */
-    if (renumber_slots)
-    {
       numslot_str =
         lepton_attrib_search_object_attribs_by_name (o_parent, "numslots", 0);
       if (numslot_str != NULL) {
@@ -1450,7 +1442,6 @@ schematic_autonumber_get_new_numbers (SchematicAutonumber *autotext,
           }
         }
       }
-    }
   }
 
   /* Updates the text content of the "slot" attribute of the


### PR DESCRIPTION
- A regression in autonumbering code has been fixed.  The regression was introduced in commit `af76f4d` where two functions were merged without removing the `return` statement in one of the code branches, which led to omitting updating object slots in the branch.
- A function to init `SchematicAutonumberSlot` instances has been added.
- Some functions have been renamed and/or made available for dlopening.
- The function `schematic_autonumber_get_new_numbers()` has been rewritten in Scheme.
