### PR TITLE
lepton-attrib: Set menu callbacks in Scheme

### DIFF
--- a/lepton-eda/scheme/attrib/ffi.scm
+++ b/lepton-eda/scheme/attrib/ffi.scm
@@ -128,7 +128,7 @@
 ;;; x_dialog.c
 (define-lff x_dialog_about_dialog void '(* * *))
 (define-lff x_dialog_missing_sym void '())
-(define-lff x_dialog_unsaved_data void '())
+(define-lff x_dialog_unsaved_data '* '())
 
 ;;; s_sheet_data.c
 (define-lff attrib_sheet_data_get_component_attrib_count int '(*))

--- a/lepton-eda/scheme/attrib/ffi.scm
+++ b/lepton-eda/scheme/attrib/ffi.scm
@@ -24,7 +24,9 @@
 
   #:export (attrib_set_sheet_data
             attrib_set_toplevel
+            attrib_get_window
             attrib_set_window
+            *attrib_really_quit
 
             set_verbose_mode
 
@@ -75,9 +77,13 @@
 (define-syntax-rule (define-lff arg ...)
   (define-lff-lib arg ... libleptonattrib))
 
+(define-syntax-rule (define-lfc arg ...)
+  (define-lfc-lib arg ... libleptonattrib))
+
 ;;; attrib.c
 (define-lff attrib_set_sheet_data void '(*))
 (define-lff attrib_set_toplevel void '(*))
+(define-lff attrib_get_window '* '())
 (define-lff attrib_set_window void '(*))
 
 ;;; s_misc.c
@@ -85,6 +91,9 @@
 
 ;;; x_fileselect.c
 (define-lff x_fileselect_open '* '())
+
+;;; attrib.c
+(define-lfc *attrib_really_quit)
 
 ;;; x_dialog.c
 (define-lff x_dialog_missing_sym void '())

--- a/lepton-eda/scheme/attrib/ffi.scm
+++ b/lepton-eda/scheme/attrib/ffi.scm
@@ -74,7 +74,6 @@
             s_table_add_toplevel_net_items_to_net_table
             s_table_add_toplevel_pin_items_to_pin_table
 
-            save_toplevel_pages
             s_toplevel_sheetdata_to_toplevel
 
             s_visibility_set_invisible
@@ -171,7 +170,6 @@
 (define-lff s_table_add_toplevel_pin_items_to_pin_table void '(*))
 
 ;;; s_toplevel.c
-(define-lff save_toplevel_pages int '(*))
 (define-lff s_toplevel_sheetdata_to_toplevel void '(* *))
 
 ;;; s_visibility.c

--- a/lepton-eda/scheme/attrib/ffi.scm
+++ b/lepton-eda/scheme/attrib/ffi.scm
@@ -40,6 +40,7 @@
             x_fileselect_open
 
             x_dialog_about_dialog
+            x_dialog_delattrib
             x_dialog_export_file
             x_dialog_missing_sym
             x_dialog_newattrib
@@ -89,7 +90,6 @@
             attrib_window_new
             attrib_window_sheets_new
             attrib_window_set_menu_callback
-            menu_edit_delattrib
             x_window_add_items
             x_window_init
             ))
@@ -133,6 +133,7 @@
 
 ;;; x_dialog.c
 (define-lff x_dialog_about_dialog void '(* * *))
+(define-lff x_dialog_delattrib void '())
 (define-lff x_dialog_export_file void '())
 (define-lff x_dialog_missing_sym void '())
 (define-lff x_dialog_newattrib void '())
@@ -190,6 +191,5 @@
 (define-lff attrib_window_new '* '(*))
 (define-lff attrib_window_sheets_new void '())
 (define-lff attrib_window_set_menu_callback void '(* *))
-(define-lff menu_edit_delattrib void '(* * *))
 (define-lff x_window_add_items void '())
 (define-lff x_window_init void '())

--- a/lepton-eda/scheme/attrib/ffi.scm
+++ b/lepton-eda/scheme/attrib/ffi.scm
@@ -68,6 +68,7 @@
             attrib_run
             attrib_window_new
             attrib_window_set_menu_callback
+            menu_edit_newattrib
             menu_file_export_csv
             x_window_add_items
             x_window_init
@@ -143,6 +144,7 @@
 (define-lff attrib_run int '(* *))
 (define-lff attrib_window_new '* '(*))
 (define-lff attrib_window_set_menu_callback void '(* *))
+(define-lff menu_edit_newattrib void '(* * *))
 (define-lff menu_file_export_csv void '(* * *))
 (define-lff x_window_add_items void '())
 (define-lff x_window_init void '())

--- a/lepton-eda/scheme/attrib/ffi.scm
+++ b/lepton-eda/scheme/attrib/ffi.scm
@@ -66,6 +66,7 @@
             s_toplevel_save_sheet
 
             s_visibility_set_invisible
+            s_visibility_set_name_only
 
             attrib_run
             attrib_window_new
@@ -145,6 +146,7 @@
 
 ;;; s_visibility.c
 (define-lff s_visibility_set_invisible void '(* * *))
+(define-lff s_visibility_set_name_only void '(* * *))
 
 ;;; x_window.c
 (define-lff attrib_run int '(* *))

--- a/lepton-eda/scheme/attrib/ffi.scm
+++ b/lepton-eda/scheme/attrib/ffi.scm
@@ -42,6 +42,7 @@
             x_dialog_about_dialog
             x_dialog_export_file
             x_dialog_missing_sym
+            x_dialog_newattrib
             x_dialog_unimplemented_feature
             x_dialog_unsaved_data
 
@@ -89,7 +90,6 @@
             attrib_window_sheets_new
             attrib_window_set_menu_callback
             menu_edit_delattrib
-            menu_edit_newattrib
             x_window_add_items
             x_window_init
             ))
@@ -135,6 +135,7 @@
 (define-lff x_dialog_about_dialog void '(* * *))
 (define-lff x_dialog_export_file void '())
 (define-lff x_dialog_missing_sym void '())
+(define-lff x_dialog_newattrib void '())
 (define-lff x_dialog_unimplemented_feature void '())
 (define-lff x_dialog_unsaved_data '* '())
 
@@ -190,6 +191,5 @@
 (define-lff attrib_window_sheets_new void '())
 (define-lff attrib_window_set_menu_callback void '(* *))
 (define-lff menu_edit_delattrib void '(* * *))
-(define-lff menu_edit_newattrib void '(* * *))
 (define-lff x_window_add_items void '())
 (define-lff x_window_init void '())

--- a/lepton-eda/scheme/attrib/ffi.scm
+++ b/lepton-eda/scheme/attrib/ffi.scm
@@ -68,6 +68,7 @@
             attrib_run
             attrib_window_new
             attrib_window_set_menu_callback
+            menu_edit_delattrib
             menu_edit_newattrib
             menu_file_export_csv
             x_window_add_items
@@ -144,6 +145,7 @@
 (define-lff attrib_run int '(* *))
 (define-lff attrib_window_new '* '(*))
 (define-lff attrib_window_set_menu_callback void '(* *))
+(define-lff menu_edit_delattrib void '(* * *))
 (define-lff menu_edit_newattrib void '(* * *))
 (define-lff menu_file_export_csv void '(* * *))
 (define-lff x_window_add_items void '())

--- a/lepton-eda/scheme/attrib/ffi.scm
+++ b/lepton-eda/scheme/attrib/ffi.scm
@@ -26,7 +26,7 @@
             attrib_set_toplevel
             attrib_get_window
             attrib_set_window
-            *attrib_really_quit
+            attrib_really_quit
 
             set_verbose_mode
 
@@ -65,6 +65,7 @@
 
             attrib_run
             attrib_window_new
+            attrib_window_set_menu_callback
             x_window_add_items
             x_window_init
             ))
@@ -93,7 +94,7 @@
 (define-lff x_fileselect_open '* '())
 
 ;;; attrib.c
-(define-lfc *attrib_really_quit)
+(define-lff attrib_really_quit void '(* * *))
 
 ;;; x_dialog.c
 (define-lff x_dialog_missing_sym void '())
@@ -135,5 +136,6 @@
 ;;; x_window.c
 (define-lff attrib_run int '(* *))
 (define-lff attrib_window_new '* '(*))
+(define-lff attrib_window_set_menu_callback void '(* *))
 (define-lff x_window_add_items void '())
 (define-lff x_window_init void '())

--- a/lepton-eda/scheme/attrib/ffi.scm
+++ b/lepton-eda/scheme/attrib/ffi.scm
@@ -67,6 +67,7 @@
 
             s_visibility_set_invisible
             s_visibility_set_name_only
+            s_visibility_set_value_only
 
             attrib_run
             attrib_window_new
@@ -147,6 +148,7 @@
 ;;; s_visibility.c
 (define-lff s_visibility_set_invisible void '(* * *))
 (define-lff s_visibility_set_name_only void '(* * *))
+(define-lff s_visibility_set_value_only void '(* * *))
 
 ;;; x_window.c
 (define-lff attrib_run int '(* *))

--- a/lepton-eda/scheme/attrib/ffi.scm
+++ b/lepton-eda/scheme/attrib/ffi.scm
@@ -29,6 +29,7 @@
             attrib_set_sheet_data
             attrib_get_sheet_data
             attrib_get_sheets_number
+            attrib_get_toplevel
             attrib_set_toplevel
             attrib_get_window
             attrib_set_window
@@ -58,6 +59,8 @@
             s_sheet_data_add_master_pin_list_items
             s_sheet_data_add_master_pin_attrib_list_items
             s_sheet_data_changed
+            s_sheet_data_set_changed
+            s_sheet_data_gtksheet_to_sheetdata
 
             s_string_list_sort_master_comp_list
             s_string_list_sort_master_comp_attrib_list
@@ -71,7 +74,8 @@
             s_table_add_toplevel_net_items_to_net_table
             s_table_add_toplevel_pin_items_to_pin_table
 
-            s_toplevel_save_sheet
+            save_toplevel_pages
+            s_toplevel_sheetdata_to_toplevel
 
             s_visibility_set_invisible
             s_visibility_set_name_and_value
@@ -113,6 +117,7 @@
 (define-lff attrib_set_sheet_data void '(*))
 (define-lff attrib_get_sheet_data '* '())
 (define-lff attrib_get_sheets_number int '())
+(define-lff attrib_get_toplevel '* '())
 (define-lff attrib_set_toplevel void '(*))
 (define-lff attrib_get_window '* '())
 (define-lff attrib_set_window void '(*))
@@ -146,6 +151,8 @@
 (define-lff s_sheet_data_add_master_pin_list_items void '(*))
 (define-lff s_sheet_data_add_master_pin_attrib_list_items void '(*))
 (define-lff s_sheet_data_changed int '(*))
+(define-lff s_sheet_data_set_changed void (list '* int))
+(define-lff s_sheet_data_gtksheet_to_sheetdata void '())
 
 ;;; s_string_list.c
 (define-lff s_string_list_sort_master_comp_list void '())
@@ -164,7 +171,8 @@
 (define-lff s_table_add_toplevel_pin_items_to_pin_table void '(*))
 
 ;;; s_toplevel.c
-(define-lff s_toplevel_save_sheet void '(* * *))
+(define-lff save_toplevel_pages int '(*))
+(define-lff s_toplevel_sheetdata_to_toplevel void '(* *))
 
 ;;; s_visibility.c
 (define-lff s_visibility_set_invisible void '(* * *))

--- a/lepton-eda/scheme/attrib/ffi.scm
+++ b/lepton-eda/scheme/attrib/ffi.scm
@@ -65,7 +65,6 @@
             attrib_window_new
             x_window_add_items
             x_window_init
-            x_window_set_title
             ))
 
 ;;; Simplify definition of functions by omitting the library
@@ -129,4 +128,3 @@
 (define-lff attrib_window_new '* '(*))
 (define-lff x_window_add_items void '())
 (define-lff x_window_init void '())
-(define-lff x_window_set_title void '(*))

--- a/lepton-eda/scheme/attrib/ffi.scm
+++ b/lepton-eda/scheme/attrib/ffi.scm
@@ -30,6 +30,8 @@
 
             x_fileselect_open
 
+            x_dialog_missing_sym
+
             attrib_sheet_data_get_component_attrib_count
             attrib_sheet_data_get_component_count
             attrib_sheet_data_set_component_table
@@ -59,8 +61,6 @@
             s_table_add_toplevel_net_items_to_net_table
             s_table_add_toplevel_pin_items_to_pin_table
 
-            s_toplevel_verify_design
-
             attrib_run
             attrib_window_new
             x_window_add_items
@@ -86,6 +86,9 @@
 
 ;;; x_fileselect.c
 (define-lff x_fileselect_open '* '())
+
+;;; x_dialog.c
+(define-lff x_dialog_missing_sym void '())
 
 ;;; s_sheet_data.c
 (define-lff attrib_sheet_data_get_component_attrib_count int '(*))
@@ -120,9 +123,6 @@
 ;; (define-lff s_table_add_toplevel_net_items_to_net_table void '(*))
 (define s_table_add_toplevel_net_items_to_net_table #f)
 (define-lff s_table_add_toplevel_pin_items_to_pin_table void '(*))
-
-;;; s_toplevel.c
-(define-lff s_toplevel_verify_design void '(*))
 
 ;;; x_window.c
 (define-lff attrib_run int '(* *))

--- a/lepton-eda/scheme/attrib/ffi.scm
+++ b/lepton-eda/scheme/attrib/ffi.scm
@@ -68,6 +68,7 @@
             attrib_run
             attrib_window_new
             attrib_window_set_menu_callback
+            menu_file_export_csv
             x_window_add_items
             x_window_init
             ))
@@ -142,5 +143,6 @@
 (define-lff attrib_run int '(* *))
 (define-lff attrib_window_new '* '(*))
 (define-lff attrib_window_set_menu_callback void '(* *))
+(define-lff menu_file_export_csv void '(* * *))
 (define-lff x_window_add_items void '())
 (define-lff x_window_init void '())

--- a/lepton-eda/scheme/attrib/ffi.scm
+++ b/lepton-eda/scheme/attrib/ffi.scm
@@ -66,6 +66,7 @@
             s_toplevel_save_sheet
 
             s_visibility_set_invisible
+            s_visibility_set_name_and_value
             s_visibility_set_name_only
             s_visibility_set_value_only
 
@@ -147,6 +148,7 @@
 
 ;;; s_visibility.c
 (define-lff s_visibility_set_invisible void '(* * *))
+(define-lff s_visibility_set_name_and_value void '(* * *))
 (define-lff s_visibility_set_name_only void '(* * *))
 (define-lff s_visibility_set_value_only void '(* * *))
 

--- a/lepton-eda/scheme/attrib/ffi.scm
+++ b/lepton-eda/scheme/attrib/ffi.scm
@@ -32,7 +32,6 @@
             attrib_set_toplevel
             attrib_get_window
             attrib_set_window
-            attrib_quit
 
             set_verbose_mode
 
@@ -117,7 +116,6 @@
 (define-lff attrib_set_toplevel void '(*))
 (define-lff attrib_get_window '* '())
 (define-lff attrib_set_window void '(*))
-(define-lff attrib_quit int (list int))
 
 ;;; s_misc.c
 (define-lff set_verbose_mode void '())

--- a/lepton-eda/scheme/attrib/ffi.scm
+++ b/lepton-eda/scheme/attrib/ffi.scm
@@ -21,12 +21,18 @@
 
   #:use-module (lepton ffi lff)
   #:use-module (lepton ffi lib)
+  #:use-module (lepton m4)
 
-  #:export (attrib_set_sheet_data
+  #:export (gtk_sheet_set_active_cell
+
+            attrib_get_sheet
+            attrib_set_sheet_data
+            attrib_get_sheet_data
+            attrib_get_sheets_number
             attrib_set_toplevel
             attrib_get_window
             attrib_set_window
-            attrib_really_quit
+            attrib_quit
 
             set_verbose_mode
 
@@ -34,6 +40,7 @@
 
             x_dialog_about_dialog
             x_dialog_missing_sym
+            x_dialog_unsaved_data
 
             attrib_sheet_data_get_component_attrib_count
             attrib_sheet_data_get_component_count
@@ -51,6 +58,7 @@
             s_sheet_data_add_master_net_attrib_list_items
             s_sheet_data_add_master_pin_list_items
             s_sheet_data_add_master_pin_attrib_list_items
+            s_sheet_data_changed
 
             s_string_list_sort_master_comp_list
             s_string_list_sort_master_comp_attrib_list
@@ -92,11 +100,24 @@
 (define-syntax-rule (define-lfc arg ...)
   (define-lfc-lib arg ... libleptonattrib))
 
+
+(define %libgtksheet
+  (if %m4-use-gtk3 "libgtksheet-4.0" "libgtkextra-x11-3.0"))
+
+(define libgtksheet (dynamic-link %libgtksheet))
+
+(define-lff-lib gtk_sheet_set_active_cell int (list '* int int) libgtksheet)
+
+
 ;;; attrib.c
+(define-lff attrib_get_sheet '* (list int))
 (define-lff attrib_set_sheet_data void '(*))
+(define-lff attrib_get_sheet_data '* '())
+(define-lff attrib_get_sheets_number int '())
 (define-lff attrib_set_toplevel void '(*))
 (define-lff attrib_get_window '* '())
 (define-lff attrib_set_window void '(*))
+(define-lff attrib_quit int (list int))
 
 ;;; s_misc.c
 (define-lff set_verbose_mode void '())
@@ -104,12 +125,10 @@
 ;;; x_fileselect.c
 (define-lff x_fileselect_open '* '())
 
-;;; attrib.c
-(define-lff attrib_really_quit void '(* * *))
-
 ;;; x_dialog.c
 (define-lff x_dialog_about_dialog void '(* * *))
 (define-lff x_dialog_missing_sym void '())
+(define-lff x_dialog_unsaved_data void '())
 
 ;;; s_sheet_data.c
 (define-lff attrib_sheet_data_get_component_attrib_count int '(*))
@@ -128,6 +147,7 @@
 (define-lff s_sheet_data_add_master_net_attrib_list_items void '(*))
 (define-lff s_sheet_data_add_master_pin_list_items void '(*))
 (define-lff s_sheet_data_add_master_pin_attrib_list_items void '(*))
+(define-lff s_sheet_data_changed int '(*))
 
 ;;; s_string_list.c
 (define-lff s_string_list_sort_master_comp_list void '())

--- a/lepton-eda/scheme/attrib/ffi.scm
+++ b/lepton-eda/scheme/attrib/ffi.scm
@@ -25,6 +25,7 @@
 
   #:export (gtk_sheet_set_active_cell
 
+            attrib_get_notebook
             attrib_get_sheet
             attrib_set_sheet_data
             attrib_get_sheet_data
@@ -39,7 +40,9 @@
             x_fileselect_open
 
             x_dialog_about_dialog
+            x_dialog_export_file
             x_dialog_missing_sym
+            x_dialog_unimplemented_feature
             x_dialog_unsaved_data
 
             attrib_sheet_data_get_component_attrib_count
@@ -87,7 +90,6 @@
             attrib_window_set_menu_callback
             menu_edit_delattrib
             menu_edit_newattrib
-            menu_file_export_csv
             x_window_add_items
             x_window_init
             ))
@@ -113,6 +115,7 @@
 
 
 ;;; attrib.c
+(define-lff attrib_get_notebook '* '())
 (define-lff attrib_get_sheet '* (list int))
 (define-lff attrib_set_sheet_data void '(*))
 (define-lff attrib_get_sheet_data '* '())
@@ -130,7 +133,9 @@
 
 ;;; x_dialog.c
 (define-lff x_dialog_about_dialog void '(* * *))
+(define-lff x_dialog_export_file void '())
 (define-lff x_dialog_missing_sym void '())
+(define-lff x_dialog_unimplemented_feature void '())
 (define-lff x_dialog_unsaved_data '* '())
 
 ;;; s_sheet_data.c
@@ -186,6 +191,5 @@
 (define-lff attrib_window_set_menu_callback void '(* *))
 (define-lff menu_edit_delattrib void '(* * *))
 (define-lff menu_edit_newattrib void '(* * *))
-(define-lff menu_file_export_csv void '(* * *))
 (define-lff x_window_add_items void '())
 (define-lff x_window_init void '())

--- a/lepton-eda/scheme/attrib/ffi.scm
+++ b/lepton-eda/scheme/attrib/ffi.scm
@@ -32,6 +32,7 @@
 
             x_fileselect_open
 
+            x_dialog_about_dialog
             x_dialog_missing_sym
 
             attrib_sheet_data_get_component_attrib_count
@@ -107,6 +108,7 @@
 (define-lff attrib_really_quit void '(* * *))
 
 ;;; x_dialog.c
+(define-lff x_dialog_about_dialog void '(* * *))
 (define-lff x_dialog_missing_sym void '())
 
 ;;; s_sheet_data.c

--- a/lepton-eda/scheme/attrib/ffi.scm
+++ b/lepton-eda/scheme/attrib/ffi.scm
@@ -83,6 +83,7 @@
 
             attrib_run
             attrib_window_new
+            attrib_window_sheets_new
             attrib_window_set_menu_callback
             menu_edit_delattrib
             menu_edit_newattrib
@@ -181,6 +182,7 @@
 ;;; x_window.c
 (define-lff attrib_run int '(* *))
 (define-lff attrib_window_new '* '(*))
+(define-lff attrib_window_sheets_new void '())
 (define-lff attrib_window_set_menu_callback void '(* *))
 (define-lff menu_edit_delattrib void '(* * *))
 (define-lff menu_edit_newattrib void '(* * *))

--- a/lepton-eda/scheme/attrib/ffi.scm
+++ b/lepton-eda/scheme/attrib/ffi.scm
@@ -65,6 +65,8 @@
 
             s_toplevel_save_sheet
 
+            s_visibility_set_invisible
+
             attrib_run
             attrib_window_new
             attrib_window_set_menu_callback
@@ -140,6 +142,9 @@
 
 ;;; s_toplevel.c
 (define-lff s_toplevel_save_sheet void '(* * *))
+
+;;; s_visibility.c
+(define-lff s_visibility_set_invisible void '(* * *))
 
 ;;; x_window.c
 (define-lff attrib_run int '(* *))

--- a/lepton-eda/scheme/attrib/ffi.scm
+++ b/lepton-eda/scheme/attrib/ffi.scm
@@ -63,6 +63,8 @@
             s_table_add_toplevel_net_items_to_net_table
             s_table_add_toplevel_pin_items_to_pin_table
 
+            s_toplevel_save_sheet
+
             attrib_run
             attrib_window_new
             attrib_window_set_menu_callback
@@ -132,6 +134,9 @@
 ;; (define-lff s_table_add_toplevel_net_items_to_net_table void '(*))
 (define s_table_add_toplevel_net_items_to_net_table #f)
 (define-lff s_table_add_toplevel_pin_items_to_pin_table void '(*))
+
+;;; s_toplevel.c
+(define-lff s_toplevel_save_sheet void '(* * *))
 
 ;;; x_window.c
 (define-lff attrib_run int '(* *))

--- a/lepton-eda/scheme/lepton/ffi.scm
+++ b/lepton-eda/scheme/lepton/ffi.scm
@@ -215,6 +215,7 @@
             lepton_component_object_unembed
             lepton_component_object_get_mirror
             lepton_component_object_set_mirror
+            lepton_component_object_get_missing
             lepton_component_object_get_x
             lepton_component_object_get_y
             lepton_component_object_get_promotable
@@ -640,6 +641,7 @@
 (define-lff lepton_component_object_unembed void '(*))
 (define-lff lepton_component_object_get_mirror int '(*))
 (define-lff lepton_component_object_set_mirror void (list '* int))
+(define-lff lepton_component_object_get_missing int '(*))
 (define-lff lepton_component_object_get_x int '(*))
 (define-lff lepton_component_object_get_y int '(*))
 (define-lff lepton_component_object_get_promotable '* (list '* int))

--- a/lepton-eda/scheme/lepton/ffi.scm
+++ b/lepton-eda/scheme/lepton/ffi.scm
@@ -406,6 +406,7 @@
             o_read_buffer
 
             f_open
+            f_save
 
             lepton_coord_snap))
 
@@ -794,6 +795,7 @@
 
 ;;; f_basic.c
 (define-lff f_open int (list '* '* '* int '*))
+(define-lff f_save int '(* * *))
 
 ;;; export.c
 (define-lff export_config void '())

--- a/lepton-eda/scheme/schematic/ffi/gtk.scm
+++ b/lepton-eda/scheme/schematic/ffi/gtk.scm
@@ -94,6 +94,18 @@
             gtk_notebook_set_current_page
             gtk_notebook_set_tab_reorderable
 
+            GTK_RESPONSE_NONE
+            GTK_RESPONSE_REJECT
+            GTK_RESPONSE_ACCEPT
+            GTK_RESPONSE_DELETE_EVENT
+            GTK_RESPONSE_OK
+            GTK_RESPONSE_CANCEL
+            GTK_RESPONSE_CLOSE
+            GTK_RESPONSE_YES
+            GTK_RESPONSE_NO
+            GTK_RESPONSE_APPLY
+            GTK_RESPONSE_HELP
+
             gtk_rc_parse
 
             gtk_scrolled_window_new
@@ -233,6 +245,19 @@
 (define-lff gtk_notebook_remove_page void (list '* int))
 (define-lff gtk_notebook_set_current_page void (list '* int))
 (define-lff gtk_notebook_set_tab_reorderable void (list '* '* int))
+
+;;; Definitions from gtkdialog.h.
+(define GTK_RESPONSE_NONE -1)
+(define GTK_RESPONSE_REJECT -2)
+(define GTK_RESPONSE_ACCEPT -3)
+(define GTK_RESPONSE_DELETE_EVENT -4)
+(define GTK_RESPONSE_OK -5)
+(define GTK_RESPONSE_CANCEL -6)
+(define GTK_RESPONSE_CLOSE -7)
+(define GTK_RESPONSE_YES -8)
+(define GTK_RESPONSE_NO -9)
+(define GTK_RESPONSE_APPLY -10)
+(define GTK_RESPONSE_HELP -11)
 
 (define-lff gtk_rc_parse void '(*))
 

--- a/lepton-eda/scheme/schematic/ffi/gtk.scm
+++ b/lepton-eda/scheme/schematic/ffi/gtk.scm
@@ -91,6 +91,7 @@
             gtk_notebook_page_num
             gtk_notebook_prev_page
             gtk_notebook_remove_page
+            gtk_notebook_get_current_page
             gtk_notebook_set_current_page
             gtk_notebook_set_tab_reorderable
 
@@ -243,6 +244,7 @@
 (define-lff gtk_notebook_page_num int '(* *))
 (define-lff gtk_notebook_prev_page void '(*))
 (define-lff gtk_notebook_remove_page void (list '* int))
+(define-lff gtk_notebook_get_current_page int '(*))
 (define-lff gtk_notebook_set_current_page void (list '* int))
 (define-lff gtk_notebook_set_tab_reorderable void (list '* '* int))
 

--- a/lepton-eda/scheme/schematic/ffi/gtk.scm
+++ b/lepton-eda/scheme/schematic/ffi/gtk.scm
@@ -125,6 +125,7 @@
             gtk_window_set_default_icon_name
             gtk_window_get_position
             gtk_window_get_size
+            gtk_window_set_title
             gtk_window_set_transient_for
             gtk_window_set_type_hint
             gtk_window_move
@@ -267,6 +268,7 @@
 (define-lff gtk_window_set_default_icon_name void '(*))
 (define-lff gtk_window_get_position void '(* * *))
 (define-lff gtk_window_get_size void '(* * *))
+(define-lff gtk_window_set_title void '(* *))
 (define-lff gtk_window_set_transient_for void '(* *))
 (define-lff gtk_window_set_type_hint void (list '* int))
 

--- a/libleptonattrib/include/prototype.h
+++ b/libleptonattrib/include/prototype.h
@@ -278,7 +278,10 @@ void s_visibility_set_cell(gint cur_page, gint row, gint col,
 void x_dialog_newattrib();
 void x_dialog_delattrib();
 void x_dialog_missing_sym();
-void x_dialog_unsaved_data();
+
+GtkWidget*
+x_dialog_unsaved_data ();
+
 void x_dialog_unimplemented_feature();
 void x_dialog_fatal_error(const gchar *string, gint return_code);
 

--- a/libleptonattrib/include/prototype.h
+++ b/libleptonattrib/include/prototype.h
@@ -29,7 +29,10 @@ attrib_really_quit (GSimpleAction *action,
                     GVariant *parameter,
                     gpointer user_data);
 #else
-gboolean attrib_really_quit(void);
+void
+attrib_really_quit (gpointer action,
+                    gpointer parameter,
+                    gpointer user_data);
 #endif
 
 gint attrib_quit(gint return_code);

--- a/libleptonattrib/include/prototype.h
+++ b/libleptonattrib/include/prototype.h
@@ -159,9 +159,6 @@ void s_table_gtksheet_to_table(GtkSheet *local_gtk_sheet,
 
 /* ------------- s_toplevel.c ------------- */
 void
-s_toplevel_verify_design (LeptonToplevel *toplevel);
-
-void
 #ifdef ENABLE_GTK3
 s_toplevel_save_sheet (GSimpleAction *action,
                        GVariant *parameter,

--- a/libleptonattrib/include/prototype.h
+++ b/libleptonattrib/include/prototype.h
@@ -308,6 +308,9 @@ GtkWidget*
 attrib_window_new (gpointer app);
 
 void
+attrib_window_sheets_new ();
+
+void
 attrib_window_set_menu_callback (char *name,
                                  GCallback callback);
 #ifdef ENABLE_GTK3

--- a/libleptonattrib/include/prototype.h
+++ b/libleptonattrib/include/prototype.h
@@ -161,13 +161,16 @@ void s_table_gtksheet_to_table(GtkSheet *local_gtk_sheet,
                                TABLE **local_table, int num_rows, int num_cols);
 
 /* ------------- s_toplevel.c ------------- */
-void
 #ifdef ENABLE_GTK3
+void
 s_toplevel_save_sheet (GSimpleAction *action,
                        GVariant *parameter,
                        gpointer user_data);
 #else
-s_toplevel_save_sheet ();
+void
+s_toplevel_save_sheet (gpointer action,
+                       gpointer parameter,
+                       gpointer user_data);
 #endif
 
 void s_toplevel_add_new_attrib(gchar *new_attrib_name);

--- a/libleptonattrib/include/prototype.h
+++ b/libleptonattrib/include/prototype.h
@@ -11,6 +11,9 @@ attrib_get_sheet_data ();
 void
 attrib_set_sheet_data (SHEET_DATA *sheet_data);
 
+int
+attrib_get_sheets_number ();
+
 LeptonToplevel*
 attrib_get_toplevel ();
 

--- a/libleptonattrib/include/prototype.h
+++ b/libleptonattrib/include/prototype.h
@@ -263,7 +263,10 @@ void
 s_visibility_set_invisible (gpointer action,
                             gpointer parameter,
                             gpointer user_data);
-void s_visibility_set_name_only();
+void
+s_visibility_set_name_only (gpointer action,
+                            gpointer parameter,
+                            gpointer user_data);
 void s_visibility_set_value_only();
 void s_visibility_set_name_and_value();
 #endif

--- a/libleptonattrib/include/prototype.h
+++ b/libleptonattrib/include/prototype.h
@@ -11,6 +11,9 @@ attrib_get_sheet_data ();
 void
 attrib_set_sheet_data (SHEET_DATA *sheet_data);
 
+GtkSheet*
+attrib_get_sheet (int i);
+
 int
 attrib_get_sheets_number ();
 

--- a/libleptonattrib/include/prototype.h
+++ b/libleptonattrib/include/prototype.h
@@ -29,8 +29,6 @@ attrib_get_window ();
 void
 attrib_set_window (GtkWidget* window_widget);
 
-gint attrib_quit(gint return_code);
-
 /* -------------- listsort.c ----------------- */
 int cmp(STRING_LIST *a, STRING_LIST *b);
 STRING_LIST *listsort(STRING_LIST *list, int is_circular, int is_double);

--- a/libleptonattrib/include/prototype.h
+++ b/libleptonattrib/include/prototype.h
@@ -311,6 +311,18 @@ attrib_window_set_menu_callback (char *name,
                                  GCallback callback);
 #ifdef ENABLE_GTK3
 void
+menu_edit_delattrib (GSimpleAction *action,
+                     GVariant *parameter,
+                     gpointer user_data);
+#else
+void
+menu_edit_delattrib (gpointer action,
+                     gpointer parameter,
+                     gpointer user_data);
+#endif
+
+#ifdef ENABLE_GTK3
+void
 menu_edit_newattrib (GSimpleAction *action,
                      GVariant *parameter,
                      gpointer user_data);

--- a/libleptonattrib/include/prototype.h
+++ b/libleptonattrib/include/prototype.h
@@ -287,13 +287,19 @@ void x_dialog_missing_sym();
 void x_dialog_unsaved_data();
 void x_dialog_unimplemented_feature();
 void x_dialog_fatal_error(const gchar *string, gint return_code);
+
 #ifdef ENABLE_GTK3
-void x_dialog_about_dialog (GSimpleAction *action,
-                            GVariant *parameter,
-                            gpointer user_data);
+void
+x_dialog_about_dialog (GSimpleAction *action,
+                       GVariant *parameter,
+                       gpointer user_data);
 #else
-void x_dialog_about_dialog();
+void
+x_dialog_about_dialog (gpointer action,
+                       gpointer parameter,
+                       gpointer user_data);
 #endif
+
 void x_dialog_export_file();
 
 /* ------------- x_gtksheet.c ------------- */

--- a/libleptonattrib/include/prototype.h
+++ b/libleptonattrib/include/prototype.h
@@ -311,6 +311,18 @@ attrib_window_set_menu_callback (char *name,
                                  GCallback callback);
 #ifdef ENABLE_GTK3
 void
+menu_edit_newattrib (GSimpleAction *action,
+                     GVariant *parameter,
+                     gpointer user_data);
+#else
+void
+menu_edit_newattrib (gpointer action,
+                     gpointer parameter,
+                     gpointer user_data);
+#endif
+
+#ifdef ENABLE_GTK3
+void
 menu_file_export_csv (GSimpleAction *action,
                       GVariant *parameter,
                       gpointer user_data);
@@ -320,6 +332,7 @@ menu_file_export_csv (gpointer action,
                       gpointer parameter,
                       gpointer user_data);
 #endif
+
 void x_window_add_items();
 
 void

--- a/libleptonattrib/include/prototype.h
+++ b/libleptonattrib/include/prototype.h
@@ -328,18 +328,6 @@ menu_edit_delattrib (gpointer action,
                      gpointer user_data);
 #endif
 
-#ifdef ENABLE_GTK3
-void
-menu_edit_newattrib (GSimpleAction *action,
-                     GVariant *parameter,
-                     gpointer user_data);
-#else
-void
-menu_edit_newattrib (gpointer action,
-                     gpointer parameter,
-                     gpointer user_data);
-#endif
-
 void x_window_add_items();
 
 void

--- a/libleptonattrib/include/prototype.h
+++ b/libleptonattrib/include/prototype.h
@@ -340,18 +340,6 @@ menu_edit_newattrib (gpointer action,
                      gpointer user_data);
 #endif
 
-#ifdef ENABLE_GTK3
-void
-menu_file_export_csv (GSimpleAction *action,
-                      GVariant *parameter,
-                      gpointer user_data);
-#else
-void
-menu_file_export_csv (gpointer action,
-                      gpointer parameter,
-                      gpointer user_data);
-#endif
-
 void x_window_add_items();
 
 void

--- a/libleptonattrib/include/prototype.h
+++ b/libleptonattrib/include/prototype.h
@@ -29,18 +29,6 @@ attrib_get_window ();
 void
 attrib_set_window (GtkWidget* window_widget);
 
-#ifdef ENABLE_GTK3
-void
-attrib_really_quit (GSimpleAction *action,
-                    GVariant *parameter,
-                    gpointer user_data);
-#else
-void
-attrib_really_quit (gpointer action,
-                    gpointer parameter,
-                    gpointer user_data);
-#endif
-
 gint attrib_quit(gint return_code);
 
 /* -------------- listsort.c ----------------- */

--- a/libleptonattrib/include/prototype.h
+++ b/libleptonattrib/include/prototype.h
@@ -153,17 +153,8 @@ void s_table_gtksheet_to_table(GtkSheet *local_gtk_sheet,
                                TABLE **local_table, int num_rows, int num_cols);
 
 /* ------------- s_toplevel.c ------------- */
-#ifdef ENABLE_GTK3
-void
-s_toplevel_save_sheet (GSimpleAction *action,
-                       GVariant *parameter,
-                       gpointer user_data);
-#else
-void
-s_toplevel_save_sheet (gpointer action,
-                       gpointer parameter,
-                       gpointer user_data);
-#endif
+int
+save_toplevel_pages (LeptonToplevel *toplevel);
 
 void s_toplevel_add_new_attrib(gchar *new_attrib_name);
 void s_toplevel_delete_attrib_col();

--- a/libleptonattrib/include/prototype.h
+++ b/libleptonattrib/include/prototype.h
@@ -271,7 +271,10 @@ void
 s_visibility_set_value_only (gpointer action,
                              gpointer parameter,
                              gpointer user_data);
-void s_visibility_set_name_and_value();
+void
+s_visibility_set_name_and_value (gpointer action,
+                                 gpointer parameter,
+                                 gpointer user_data);
 #endif
 
 void s_visibility_set_cell(gint cur_page, gint row, gint col,

--- a/libleptonattrib/include/prototype.h
+++ b/libleptonattrib/include/prototype.h
@@ -153,9 +153,6 @@ void s_table_gtksheet_to_table(GtkSheet *local_gtk_sheet,
                                TABLE **local_table, int num_rows, int num_cols);
 
 /* ------------- s_toplevel.c ------------- */
-int
-save_toplevel_pages (LeptonToplevel *toplevel);
-
 void s_toplevel_add_new_attrib(gchar *new_attrib_name);
 void s_toplevel_delete_attrib_col();
 void

--- a/libleptonattrib/include/prototype.h
+++ b/libleptonattrib/include/prototype.h
@@ -267,7 +267,10 @@ void
 s_visibility_set_name_only (gpointer action,
                             gpointer parameter,
                             gpointer user_data);
-void s_visibility_set_value_only();
+void
+s_visibility_set_value_only (gpointer action,
+                             gpointer parameter,
+                             gpointer user_data);
 void s_visibility_set_name_and_value();
 #endif
 

--- a/libleptonattrib/include/prototype.h
+++ b/libleptonattrib/include/prototype.h
@@ -306,9 +306,6 @@ void
 x_window_init ();
 
 void
-x_window_set_title (GList* plist);
-
-void
 x_window_set_title_changed (int changed);
 
 G_END_DECLS

--- a/libleptonattrib/include/prototype.h
+++ b/libleptonattrib/include/prototype.h
@@ -316,18 +316,6 @@ attrib_window_sheets_new ();
 void
 attrib_window_set_menu_callback (char *name,
                                  GCallback callback);
-#ifdef ENABLE_GTK3
-void
-menu_edit_delattrib (GSimpleAction *action,
-                     GVariant *parameter,
-                     gpointer user_data);
-#else
-void
-menu_edit_delattrib (gpointer action,
-                     gpointer parameter,
-                     gpointer user_data);
-#endif
-
 void x_window_add_items();
 
 void

--- a/libleptonattrib/include/prototype.h
+++ b/libleptonattrib/include/prototype.h
@@ -303,6 +303,9 @@ attrib_run (gpointer activate_callback,
 GtkWidget*
 attrib_window_new (gpointer app);
 
+void
+attrib_window_set_menu_callback (char *name,
+                                 GCallback callback);
 void x_window_add_items();
 
 void

--- a/libleptonattrib/include/prototype.h
+++ b/libleptonattrib/include/prototype.h
@@ -259,7 +259,10 @@ s_visibility_set_name_and_value (GSimpleAction *action,
                                  GVariant *parameter,
                                  gpointer user_data);
 #else
-void s_visibility_set_invisible();
+void
+s_visibility_set_invisible (gpointer action,
+                            gpointer parameter,
+                            gpointer user_data);
 void s_visibility_set_name_only();
 void s_visibility_set_value_only();
 void s_visibility_set_name_and_value();

--- a/libleptonattrib/include/prototype.h
+++ b/libleptonattrib/include/prototype.h
@@ -5,6 +5,9 @@
 G_BEGIN_DECLS
 
 /* attrib.c */
+GtkWidget*
+attrib_get_notebook ();
+
 SHEET_DATA*
 attrib_get_sheet_data ();
 

--- a/libleptonattrib/include/prototype.h
+++ b/libleptonattrib/include/prototype.h
@@ -309,6 +309,17 @@ attrib_window_new (gpointer app);
 void
 attrib_window_set_menu_callback (char *name,
                                  GCallback callback);
+#ifdef ENABLE_GTK3
+void
+menu_file_export_csv (GSimpleAction *action,
+                      GVariant *parameter,
+                      gpointer user_data);
+#else
+void
+menu_file_export_csv (gpointer action,
+                      gpointer parameter,
+                      gpointer user_data);
+#endif
 void x_window_add_items();
 
 void

--- a/libleptonattrib/src/attrib.c
+++ b/libleptonattrib/src/attrib.c
@@ -61,6 +61,14 @@ GtkWidget *entry;
 GtkWidget *label;
 
 
+/*! \brief Get the main window notebook.
+ *
+ *  \par Function Description
+ *
+ *  Returns the main window notebook.
+ *
+ *  \return The notebook.
+ */
 GtkWidget*
 attrib_get_notebook ()
 {

--- a/libleptonattrib/src/attrib.c
+++ b/libleptonattrib/src/attrib.c
@@ -206,52 +206,6 @@ attrib_set_window (GtkWidget *window_widget)
 }
 
 
-/*! \brief GTK callback to quit the program.
- *
- *  \par Function Description
- * This is called when the user quits the program using the UI. The
- * callback is attached to the GTK window_delete event in
- * x_window_init() and attached to the File->Quit menu item in
- * x_window_create_menu().  On execution, the function checks for
- * unsaved changes before calling gattrib_quit() to quit the program.
- *
- * \param action [in] GSimpleAction (GTK3), unused.
- * \param parameter [in] GVariant (GTK3), unused.
- * \param user_data [in] User data, unused.
- */
-#ifdef ENABLE_GTK3
-void
-attrib_really_quit (GSimpleAction *action,
-                    GVariant *parameter,
-                    gpointer user_data)
-#else
-void
-attrib_really_quit (gpointer action,
-                    gpointer parameter,
-                    gpointer user_data)
-#endif
-{
-  /* Deactivate the current cell to trigger "deactivate" signal.
-   * This allows changing of the sheet_head->CHANGED flag in the
-   * on_deactivate() handler function if needed.
-  */
-  for (int i = 0; i < attrib_get_sheets_number (); ++i)
-  {
-    GtkSheet *sheet = attrib_get_sheet (i);
-    if (sheet != NULL)
-    {
-       gtk_sheet_set_active_cell (sheet, -1, -1);
-    }
-  }
-
-
-  if (s_sheet_data_changed (sheet_head)) {
-    x_dialog_unsaved_data();
-  } else {
-    attrib_quit(0);
-  }
-}
-
 /*------------------------------------------------------------------*/
 /*! \brief Quit the program.
  *

--- a/libleptonattrib/src/attrib.c
+++ b/libleptonattrib/src/attrib.c
@@ -55,10 +55,17 @@
 #include "../include/prototype.h"  /* function prototypes */
 #include "../include/globals.h"
 
-GtkWidget *notebook;
 GtkSheet **sheets;
 GtkWidget *entry;
 GtkWidget *label;
+
+
+
+/*! \var GtkWidget *notebook
+ *
+ * The main window notebook.
+ */
+GtkWidget *notebook;
 
 
 /*! \brief Get the main window notebook.

--- a/libleptonattrib/src/attrib.c
+++ b/libleptonattrib/src/attrib.c
@@ -200,26 +200,6 @@ attrib_really_quit (gpointer action,
                     gpointer user_data)
 #endif
 {
-  /* Save main window's geometry:
-  */
-  gint x = 0;
-  gint y = 0;
-  gtk_window_get_position (GTK_WINDOW (window), &x, &y);
-
-  gint width  = 0;
-  gint height = 0;
-  gtk_window_get_size (GTK_WINDOW (window), &width, &height);
-
-  EdaConfig* cfg = eda_config_get_cache_context();
-
-  eda_config_set_int (cfg, "attrib.window-geometry", "x", x);
-  eda_config_set_int (cfg, "attrib.window-geometry", "y", y);
-  eda_config_set_int (cfg, "attrib.window-geometry", "width", width);
-  eda_config_set_int (cfg, "attrib.window-geometry", "height", height);
-
-  eda_config_save (cfg, NULL);
-
-
   /* Deactivate the current cell to trigger "deactivate" signal.
    * This allows changing of the sheet_head->CHANGED flag in the
    * on_deactivate() handler function if needed.

--- a/libleptonattrib/src/attrib.c
+++ b/libleptonattrib/src/attrib.c
@@ -98,6 +98,16 @@ attrib_set_sheet_data (SHEET_DATA *sheet_data)
 }
 
 
+/*! \brief Get a sheet by number.
+ *
+ *  \par Function Description
+ *
+ *  Returns a sheet of the \c sheets array by given number.
+ *
+ *  \param [in] i The number of the sheet.
+ *
+ *  \return The sheet.
+ */
 GtkSheet*
 attrib_get_sheet (int i)
 {

--- a/libleptonattrib/src/attrib.c
+++ b/libleptonattrib/src/attrib.c
@@ -98,6 +98,13 @@ attrib_set_sheet_data (SHEET_DATA *sheet_data)
 }
 
 
+GtkSheet*
+attrib_get_sheet (int i)
+{
+  return sheets[i];
+}
+
+
 /*! \brief Get the number of sheets.
  *
  *  \par Function Description
@@ -220,7 +227,7 @@ attrib_really_quit (gpointer action,
   */
   for (int i = 0; i < attrib_get_sheets_number (); ++i)
   {
-    GtkSheet *sheet = sheets[i];
+    GtkSheet *sheet = attrib_get_sheet (i);
     if (sheet != NULL)
     {
        gtk_sheet_set_active_cell (sheet, -1, -1);

--- a/libleptonattrib/src/attrib.c
+++ b/libleptonattrib/src/attrib.c
@@ -177,13 +177,16 @@ attrib_set_window (GtkWidget *window_widget)
 
 /*! \brief GTK callback to quit the program.
  *
+ *  \par Function Description
  * This is called when the user quits the program using the UI. The
  * callback is attached to the GTK window_delete event in
  * x_window_init() and attached to the File->Quit menu item in
  * x_window_create_menu().  On execution, the function checks for
  * unsaved changes before calling gattrib_quit() to quit the program.
  *
- *  \return value 0 to the shell to denote a successful quit.
+ * \param action [in] GSimpleAction (GTK3), unused.
+ * \param parameter [in] GVariant (GTK3), unused.
+ * \param user_data [in] User data, unused.
  */
 #ifdef ENABLE_GTK3
 void
@@ -191,7 +194,10 @@ attrib_really_quit (GSimpleAction *action,
                     GVariant *parameter,
                     gpointer user_data)
 #else
-gboolean attrib_really_quit(void)
+void
+attrib_really_quit (gpointer action,
+                    gpointer parameter,
+                    gpointer user_data)
 #endif
 {
   /* Save main window's geometry:
@@ -232,9 +238,6 @@ gboolean attrib_really_quit(void)
   } else {
     attrib_quit(0);
   }
-#ifndef ENABLE_GTK3
-  return TRUE;
-#endif
 }
 
 /*------------------------------------------------------------------*/

--- a/libleptonattrib/src/attrib.c
+++ b/libleptonattrib/src/attrib.c
@@ -220,9 +220,10 @@ attrib_really_quit (gpointer action,
   */
   for (int i = 0; i < attrib_get_sheets_number (); ++i)
   {
-    if (sheets[i] != NULL)
+    GtkSheet *sheet = sheets[i];
+    if (sheet != NULL)
     {
-       gtk_sheet_set_active_cell (sheets[i], -1, -1);
+       gtk_sheet_set_active_cell (sheet, -1, -1);
     }
   }
 

--- a/libleptonattrib/src/attrib.c
+++ b/libleptonattrib/src/attrib.c
@@ -204,23 +204,3 @@ attrib_set_window (GtkWidget *window_widget)
 {
   window = window_widget;
 }
-
-
-/*------------------------------------------------------------------*/
-/*! \brief Quit the program.
- *
- *  Unconditionally quit gattrib. Flushes caches and I/O channels,
- *  calls the GTK function to quit the application then calls exit()
- *  with the appropriate return code.
- *
- *  \param return_code Value to pass to the exit() system call.
- */
-gint attrib_quit(gint return_code)
-{
-  s_clib_free();
-  g_debug ("attrib_quit: Calling gtk_main_quit().\n");
-#ifndef ENABLE_GTK3
-  gtk_main_quit();
-#endif
-  exit(return_code);
-}

--- a/libleptonattrib/src/attrib.c
+++ b/libleptonattrib/src/attrib.c
@@ -98,6 +98,13 @@ attrib_set_sheet_data (SHEET_DATA *sheet_data)
 }
 
 
+/*! \brief Get the number of sheets.
+ *
+ *  \par Function Description
+ *
+ *  Returns the number of sheets defined in the global variable
+ *  #NUM_SHEETS.
+ */
 int
 attrib_get_sheets_number ()
 {

--- a/libleptonattrib/src/attrib.c
+++ b/libleptonattrib/src/attrib.c
@@ -61,6 +61,13 @@ GtkWidget *entry;
 GtkWidget *label;
 
 
+GtkWidget*
+attrib_get_notebook ()
+{
+  return notebook;
+}
+
+
 /*! \var SHEET_DATA *sheet_head
  *
  * The sheet data structure holding info on all schematic objects.

--- a/libleptonattrib/src/attrib.c
+++ b/libleptonattrib/src/attrib.c
@@ -98,6 +98,13 @@ attrib_set_sheet_data (SHEET_DATA *sheet_data)
 }
 
 
+int
+attrib_get_sheets_number ()
+{
+  return NUM_SHEETS;
+}
+
+
 /*! \var LeptonToplevel *toplevel
  *
  * The project and UI toplevel structure defining their data and
@@ -204,7 +211,7 @@ attrib_really_quit (gpointer action,
    * This allows changing of the sheet_head->CHANGED flag in the
    * on_deactivate() handler function if needed.
   */
-  for (int i = 0; i < NUM_SHEETS; ++i)
+  for (int i = 0; i < attrib_get_sheets_number (); ++i)
   {
     if (sheets[i] != NULL)
     {

--- a/libleptonattrib/src/s_toplevel.c
+++ b/libleptonattrib/src/s_toplevel.c
@@ -315,7 +315,7 @@ s_toplevel_sheetdata_to_toplevel (LeptonToplevel *toplevel,
          * places all attribs
          * found in the row into new_comp_attrib_pair_list.  */
         new_comp_attrib_pair_list = s_table_create_attrib_pair(temp_uref,
-                                                               sheet_head->component_table,
+                                                               attrib_sheet_data_get_component_table (sheet_head),
                                                                sheet_head->master_comp_list_head,
                                                                sheet_head->comp_attrib_count);
 

--- a/libleptonattrib/src/s_toplevel.c
+++ b/libleptonattrib/src/s_toplevel.c
@@ -128,7 +128,7 @@ s_toplevel_save_sheet (gpointer action,
            "Done writing stuff from gtksheet into SHEET_DATA.\n");
 
   /* must iterate over all pages in design */
-  for ( iter = lepton_list_get_glist( toplevel->pages );
+  for ( iter = lepton_list_get_glist (lepton_toplevel_get_pages (toplevel));
         iter != NULL;
         iter = g_list_next( iter ) ) {
 

--- a/libleptonattrib/src/s_toplevel.c
+++ b/libleptonattrib/src/s_toplevel.c
@@ -50,43 +50,6 @@
 
 /* ===================  Public Functions  ====================== */
 
-/*! \brief Saves all the pages of a LeptonToplevel object.
- *  \par Function Description
- *  Saves all the pages in the <B>toplevel</B> parameter.
- *
- *  \param [in] toplevel  The LeptonToplevel to save pages from.
- *  \return The number of failed tries to save a page.
- */
-int
-save_toplevel_pages (LeptonToplevel *toplevel)
-{
-  const GList *iter;
-  LeptonPage *p_current;
-
-  for ( iter = lepton_list_get_glist (lepton_toplevel_get_pages (toplevel));
-        iter != NULL;
-        iter = g_list_next( iter ) ) {
-
-    p_current = (LeptonPage *)iter->data;
-
-    if (f_save (p_current, lepton_page_get_filename (p_current), NULL))
-    {
-      g_message (_("Saved [%1$s]"),
-                 lepton_page_get_filename (p_current));
-      /* reset the CHANGED flag of p_current */
-      lepton_page_set_changed (p_current, 0);
-
-    } else {
-      g_message (_("Could NOT save [%1$s]"),
-                 lepton_page_get_filename (p_current));
-    }
-
-  }
-
-  return 0;
-}
-
-
 /*------------------------------------------------------------------*/
 /*! \brief Add a new attribute to the top level
  *

--- a/libleptonattrib/src/s_toplevel.c
+++ b/libleptonattrib/src/s_toplevel.c
@@ -57,7 +57,7 @@
  *  \param [in] toplevel  The LeptonToplevel to save pages from.
  *  \return The number of failed tries to save a page.
  */
-static gint
+int
 save_toplevel_pages (LeptonToplevel *toplevel)
 {
   const GList *iter;
@@ -87,67 +87,6 @@ save_toplevel_pages (LeptonToplevel *toplevel)
   }
 
   return status;
-}
-
-
-/*------------------------------------------------------------------*/
-/*! \brief Copy data from gtksheet into LeptonToplevel struct
- *
- *  \par Function Description
- * Called when the user invokes "save".  It first
- * places all data from gtksheet into SHEET_DATA.  Then it
- * loops through all pages and saves them.
- *
- * \param action [in] GSimpleAction (GTK3), unused.
- * \param parameter [in] GVariant (GTK3), unused.
- * \param user_data [in] User data, unused.
- */
-#ifdef ENABLE_GTK3
-void
-s_toplevel_save_sheet (GSimpleAction *action,
-                       GVariant *parameter,
-                       gpointer user_data)
-#else
-void
-s_toplevel_save_sheet (gpointer action,
-                       gpointer parameter,
-                       gpointer user_data)
-#endif
-{
-  GList *iter;
-  LeptonPage *p_current;
-
-  g_debug ("==== Enter s_toplevel_gtksheet_to_toplevel()\n");
-
-  LeptonToplevel *toplevel = attrib_get_toplevel ();
-
-  g_return_if_fail (toplevel != NULL);
-
-  s_sheet_data_gtksheet_to_sheetdata();  /* read data from gtksheet into SHEET_DATA */
-  g_debug ("s_toplevel_gtksheet_to_toplevel: "
-           "Done writing stuff from gtksheet into SHEET_DATA.\n");
-
-  /* must iterate over all pages in design */
-  for ( iter = lepton_list_get_glist (lepton_toplevel_get_pages (toplevel));
-        iter != NULL;
-        iter = g_list_next( iter ) ) {
-
-    p_current = (LeptonPage *)iter->data;
-    /* only traverse pages which are toplevel */
-    if (lepton_page_get_page_control (p_current) == 0)
-    {
-      s_toplevel_sheetdata_to_toplevel (toplevel, p_current);    /* adds all objects from page */
-    }
-  }
-
-  g_debug ("s_toplevel_gtksheet_to_toplevel: "
-           "Done writing SHEEET_DATA text back into pr_currnet.\n");
-
-  /* Save all pages in design. */
-  save_toplevel_pages (toplevel);
-  s_sheet_data_set_changed (attrib_get_sheet_data (), FALSE);
-
-  return;
 }
 
 

--- a/libleptonattrib/src/s_toplevel.c
+++ b/libleptonattrib/src/s_toplevel.c
@@ -134,7 +134,8 @@ s_toplevel_save_sheet (gpointer action,
 
     p_current = (LeptonPage *)iter->data;
     /* only traverse pages which are toplevel */
-    if (p_current->page_control == 0) {
+    if (lepton_page_get_page_control (p_current) == 0)
+    {
       s_toplevel_sheetdata_to_toplevel (toplevel, p_current);    /* adds all objects from page */
     }
   }

--- a/libleptonattrib/src/s_toplevel.c
+++ b/libleptonattrib/src/s_toplevel.c
@@ -145,7 +145,7 @@ s_toplevel_save_sheet (gpointer action,
 
   /* Save all pages in design. */
   save_toplevel_pages (toplevel);
-  s_sheet_data_set_changed (sheet_head, FALSE);
+  s_sheet_data_set_changed (attrib_get_sheet_data (), FALSE);
 
   return;
 }

--- a/libleptonattrib/src/s_toplevel.c
+++ b/libleptonattrib/src/s_toplevel.c
@@ -62,7 +62,6 @@ save_toplevel_pages (LeptonToplevel *toplevel)
 {
   const GList *iter;
   LeptonPage *p_current;
-  gint status = 0;
 
   for ( iter = lepton_list_get_glist (lepton_toplevel_get_pages (toplevel));
         iter != NULL;
@@ -80,13 +79,11 @@ save_toplevel_pages (LeptonToplevel *toplevel)
     } else {
       g_message (_("Could NOT save [%1$s]"),
                  lepton_page_get_filename (p_current));
-      /* increase the error counter */
-      status++;
     }
 
   }
 
-  return status;
+  return 0;
 }
 
 

--- a/libleptonattrib/src/s_toplevel.c
+++ b/libleptonattrib/src/s_toplevel.c
@@ -93,17 +93,25 @@ save_toplevel_pages (LeptonToplevel *toplevel)
 /*------------------------------------------------------------------*/
 /*! \brief Copy data from gtksheet into LeptonToplevel struct
  *
+ *  \par Function Description
  * Called when the user invokes "save".  It first
  * places all data from gtksheet into SHEET_DATA.  Then it
  * loops through all pages and saves them.
+ *
+ * \param action [in] GSimpleAction (GTK3), unused.
+ * \param parameter [in] GVariant (GTK3), unused.
+ * \param user_data [in] User data, unused.
  */
-void
 #ifdef ENABLE_GTK3
+void
 s_toplevel_save_sheet (GSimpleAction *action,
                        GVariant *parameter,
                        gpointer user_data)
 #else
-s_toplevel_save_sheet ()
+void
+s_toplevel_save_sheet (gpointer action,
+                       gpointer parameter,
+                       gpointer user_data)
 #endif
 {
   GList *iter;

--- a/libleptonattrib/src/s_toplevel.c
+++ b/libleptonattrib/src/s_toplevel.c
@@ -50,46 +50,6 @@
 
 /* ===================  Public Functions  ====================== */
 
-/*! \brief Verify the entire design
- *
- * This function loops through all objects in the design looking
- * for missing components, that is, those components for which no
- * corresponding symbol files was found.
- *
- * \param toplevel The LeptonToplevel object to be verified.
- */
-void s_toplevel_verify_design (LeptonToplevel *toplevel)
-{
-  GList *p_iter;
-  const GList *o_iter;
-
-  int missing_sym_flag = 0;
-
-  for (p_iter = lepton_list_get_glist (lepton_toplevel_get_pages (toplevel));
-       p_iter != NULL;
-       p_iter = g_list_next (p_iter)) {
-    LeptonPage *p_current = (LeptonPage*) p_iter->data;
-
-    for (o_iter = lepton_page_objects (p_current);
-         o_iter != NULL;
-         o_iter = g_list_next (o_iter)) {
-      LeptonObject *o_current = (LeptonObject*) o_iter->data;
-
-      /* --- look for object, and verify that it has a symbol file attached. ---- */
-      if (lepton_object_is_component (o_current) &&
-          lepton_component_object_get_missing (o_current))
-      {
-        missing_sym_flag = 1;  /* flag to signal that problem exists.  */
-      }
-    }
-  }
-
-  if (missing_sym_flag) {
-    x_dialog_missing_sym();  /* dialog gives user option to quit */
-  }
-}
-
-
 /*! \brief Saves all the pages of a LeptonToplevel object.
  *  \par Function Description
  *  Saves all the pages in the <B>toplevel</B> parameter.

--- a/libleptonattrib/src/s_toplevel.c
+++ b/libleptonattrib/src/s_toplevel.c
@@ -64,7 +64,7 @@ save_toplevel_pages (LeptonToplevel *toplevel)
   LeptonPage *p_current;
   gint status = 0;
 
-  for ( iter = lepton_list_get_glist( toplevel->pages );
+  for ( iter = lepton_list_get_glist (lepton_toplevel_get_pages (toplevel));
         iter != NULL;
         iter = g_list_next( iter ) ) {
 

--- a/libleptonattrib/src/s_toplevel.c
+++ b/libleptonattrib/src/s_toplevel.c
@@ -65,7 +65,7 @@ void s_toplevel_verify_design (LeptonToplevel *toplevel)
 
   int missing_sym_flag = 0;
 
-  for (p_iter = lepton_list_get_glist (toplevel->pages);
+  for (p_iter = lepton_list_get_glist (lepton_toplevel_get_pages (toplevel));
        p_iter != NULL;
        p_iter = g_list_next (p_iter)) {
     LeptonPage *p_current = (LeptonPage*) p_iter->data;

--- a/libleptonattrib/src/s_visibility.c
+++ b/libleptonattrib/src/s_visibility.c
@@ -304,13 +304,16 @@ s_visibility_set_value_only (gpointer action,
  * variable "sheet".
  *
  */
-void
 #ifdef ENABLE_GTK3
+void
 s_visibility_set_name_and_value (GSimpleAction *action,
                                  GVariant *parameter,
                                  gpointer user_data)
 #else
-s_visibility_set_name_and_value ()
+void
+s_visibility_set_name_and_value (gpointer action,
+                                 gpointer parameter,
+                                 gpointer user_data)
 #endif
 {
   gint i, j;

--- a/libleptonattrib/src/s_visibility.c
+++ b/libleptonattrib/src/s_visibility.c
@@ -162,13 +162,16 @@ s_visibility_set_invisible (gpointer action,
  * selected a range of cells which are carried in the global
  * variable "sheet".
  */
-void
 #ifdef ENABLE_GTK3
+void
 s_visibility_set_name_only (GSimpleAction *action,
                             GVariant *parameter,
                             gpointer user_data)
 #else
-s_visibility_set_name_only ()
+void
+s_visibility_set_name_only (gpointer action,
+                            gpointer parameter,
+                            gpointer user_data)
 #endif
 {
   gint i, j;

--- a/libleptonattrib/src/s_visibility.c
+++ b/libleptonattrib/src/s_visibility.c
@@ -232,13 +232,16 @@ s_visibility_set_name_only (gpointer action,
  * selected a range of cells which are carried in the global
  * variable "sheet".
  */
-void
 #ifdef ENABLE_GTK3
+void
 s_visibility_set_value_only (GSimpleAction *action,
                              GVariant *parameter,
                              gpointer user_data)
 #else
-s_visibility_set_value_only ()
+void
+s_visibility_set_value_only (gpointer action,
+                             gpointer parameter,
+                             gpointer user_data)
 #endif
 {
   gint i, j;

--- a/libleptonattrib/src/s_visibility.c
+++ b/libleptonattrib/src/s_visibility.c
@@ -1,7 +1,7 @@
 /* Lepton EDA attribute editor
  * Copyright (C) 2003-2010 Stuart D. Brorson.
  * Copyright (C) 2003-2013 gEDA Contributors
- * Copyright (C) 2017-2022 Lepton EDA Contributors
+ * Copyright (C) 2017-2026 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -82,13 +82,16 @@
  * selected a range of cells which are carried in the global
  * variable "sheet".
  */
-void
 #ifdef ENABLE_GTK3
+void
 s_visibility_set_invisible (GSimpleAction *action,
                             GVariant *parameter,
                             gpointer user_data)
 #else
-s_visibility_set_invisible ()
+void
+s_visibility_set_invisible (gpointer action,
+                            gpointer parameter,
+                            gpointer user_data)
 #endif
 {
   gint i, j;

--- a/libleptonattrib/src/x_dialog.c
+++ b/libleptonattrib/src/x_dialog.c
@@ -1,7 +1,7 @@
 /* Lepton EDA attribute editor
  * Copyright (C) 2003-2010 Stuart D. Brorson.
  * Copyright (C) 2003-2014 gEDA Contributors
- * Copyright (C) 2017-2022 Lepton EDA Contributors
+ * Copyright (C) 2017-2026 Lepton EDA Contributors
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -327,13 +327,16 @@ void x_dialog_fatal_error(const gchar *string, gint return_code)
 
 
 /*! \brief The About dialog */
-void
 #ifdef ENABLE_GTK3
+void
 x_dialog_about_dialog (GSimpleAction *action,
                        GVariant *parameter,
                        gpointer user_data)
 #else
-x_dialog_about_dialog ()
+void
+x_dialog_about_dialog (gpointer action,
+                       gpointer parameter,
+                       gpointer user_data)
 #endif
 {
   GtkWidget* dlg = gtk_about_dialog_new();

--- a/libleptonattrib/src/x_dialog.c
+++ b/libleptonattrib/src/x_dialog.c
@@ -216,7 +216,8 @@ void x_dialog_missing_sym()
  * This is the "Unsaved data -- are you sure you want to quit?" dialog
  *         box which is thrown up before the user quits.
  */
-void x_dialog_unsaved_data()
+GtkWidget*
+x_dialog_unsaved_data ()
 {
   GtkWidget *dialog;
   gchar *str;
@@ -270,8 +271,7 @@ void x_dialog_unsaved_data()
           break;
         }
       }
-  gtk_widget_destroy (dialog);
-  return;
+  return dialog;
 }
 
 /*! \brief Unimplemented feature dialog

--- a/libleptonattrib/src/x_dialog.c
+++ b/libleptonattrib/src/x_dialog.c
@@ -250,27 +250,6 @@ x_dialog_unsaved_data ()
                                           -1);
 #endif
 
-  gtk_dialog_set_default_response (GTK_DIALOG (dialog), GTK_RESPONSE_YES);
-
-  switch (gtk_dialog_run (GTK_DIALOG (dialog)))
-    {
-      case GTK_RESPONSE_NO:
-        {
-          attrib_quit(0);
-          break;
-        }
-      case GTK_RESPONSE_YES:
-        {
-          s_toplevel_save_sheet (NULL, NULL, NULL);
-          attrib_quit(0);
-          break;
-        }
-      case GTK_RESPONSE_CANCEL:
-      default:
-        {
-          break;
-        }
-      }
   return dialog;
 }
 

--- a/libleptonattrib/src/x_dialog.c
+++ b/libleptonattrib/src/x_dialog.c
@@ -260,11 +260,7 @@ void x_dialog_unsaved_data()
         }
       case GTK_RESPONSE_YES:
         {
-#ifdef ENABLE_GTK3
           s_toplevel_save_sheet (NULL, NULL, NULL);
-#else
-          s_toplevel_save_sheet ();
-#endif
           attrib_quit(0);
           break;
         }

--- a/libleptonattrib/src/x_window.c
+++ b/libleptonattrib/src/x_window.c
@@ -383,8 +383,26 @@ callback_edit_add_attrib_wrapper (GSimpleAction *action,
   ((void (*)(GSimpleAction*, GVariant*, gpointer)) callback_edit_add_attrib) (action, parameter, user_data);
 }
 
+
+/*! \var static GCallback callback_edit_add_attrib
+ *
+ * The callback set in Scheme to delete an attrib.
+ */
 static GCallback callback_edit_delete_attrib = NULL;
 
+
+/*! \brief C wrapper for callback_edit_delete_attrib().
+ *
+ *  \par Function Description
+ *
+ *  C wrapper function for the callback callback_edit_delete_attrib()
+ *  which is assigned in Scheme.  The static wrapper is used to
+ *  implement corresponding menu item.
+ *
+ *  \param action [in] GSimpleAction (GTK3), unused.
+ *  \param parameter [in] GVariant (GTK3), unused.
+ *  \param user_data [in] User data, unused.
+ */
 static void
 callback_edit_delete_attrib_wrapper (GSimpleAction *action,
                                      GVariant *parameter,

--- a/libleptonattrib/src/x_window.c
+++ b/libleptonattrib/src/x_window.c
@@ -196,13 +196,16 @@ x_window_init ()
  *
  * Implement the File->Export CSV menu item
  */
-static void
 #ifdef ENABLE_GTK3
+void
 menu_file_export_csv (GSimpleAction *action,
                       GVariant *parameter,
                       gpointer user_data)
 #else
-menu_file_export_csv()
+void
+menu_file_export_csv (gpointer action,
+                      gpointer parameter,
+                      gpointer user_data)
 #endif
 {
   gint cur_page;
@@ -291,6 +294,17 @@ callback_file_save_wrapper (GSimpleAction *action,
 }
 
 
+static GCallback callback_file_export_csv = NULL;
+
+static void
+callback_file_export_csv_wrapper (GSimpleAction *action,
+                                  GVariant *parameter,
+                                  gpointer user_data)
+{
+  ((void (*)(GSimpleAction*, GVariant*, gpointer)) callback_file_export_csv) (action, parameter, user_data);
+}
+
+
 /*! \var static GCallback callback_file_quit
  *
  * The callback set in Scheme to quit the program.
@@ -337,6 +351,7 @@ attrib_window_set_menu_callback (char *name,
   g_return_if_fail (callback != NULL);
 
   if (strcmp (name, "file-save") == 0) {callback_file_save = callback;}
+  else if (strcmp (name, "file-export-csv") == 0) {callback_file_export_csv = callback;}
   else if (strcmp (name, "file-quit") == 0) {callback_file_quit = callback;}
 }
 
@@ -460,7 +475,7 @@ static const gchar menu[] =
 
 static GActionEntry app_entries[] = {
   { "file-save", callback_file_save_wrapper, NULL, NULL, NULL },
-  { "file-export-csv", menu_file_export_csv, NULL, NULL, NULL },
+  { "file-export-csv", callback_file_export_csv_wrapper, NULL, NULL, NULL },
   { "file-quit", callback_file_quit_wrapper, NULL, NULL, NULL },
   { "edit-add-attrib", menu_edit_newattrib, NULL, NULL, NULL },
   { "edit-delete-attrib", menu_edit_delattrib, NULL, NULL, NULL },
@@ -479,7 +494,7 @@ static const GtkActionEntry actions[] = {
   /* File menu */
   { "file", NULL, "_File"},
   { "file-save", "document-save", "Save", "<Control>S", "", G_CALLBACK (callback_file_save_wrapper)},
-  { "file-export-csv", NULL, "Export CSV", "", "", menu_file_export_csv},
+  { "file-export-csv", NULL, "Export CSV", "", "", G_CALLBACK (callback_file_export_csv_wrapper)},
   /* { "file-print", "document-print", "Print", "<Control>P", "", x_dialog_unimplemented_feature}, */
   { "file-quit", "application-exit", "Quit", "<Control>Q", "", G_CALLBACK (callback_file_quit_wrapper)},
 

--- a/libleptonattrib/src/x_window.c
+++ b/libleptonattrib/src/x_window.c
@@ -502,8 +502,27 @@ callback_visibility_value_only_wrapper (GSimpleAction *action,
 }
 
 
+/*! \var static GCallback callback_visibility_name_value
+ *
+ * The callback set in Scheme to set attribute visibility to
+ * show name and value.
+ */
 static GCallback callback_visibility_name_value = NULL;
 
+
+/*! \brief C wrapper for callback_visibility_name_value().
+ *
+ *  \par Function Description
+ *
+ *  C wrapper function for the callback
+ *  callback_visibility_name_value() which is assigned in Scheme.
+ *  The static wrapper is used to implement corresponding menu
+ *  item.
+ *
+ *  \param action [in] GSimpleAction (GTK3), unused.
+ *  \param parameter [in] GVariant (GTK3), unused.
+ *  \param user_data [in] User data, unused.
+ */
 static void
 callback_visibility_name_value_wrapper (GSimpleAction *action,
                                         GVariant *parameter,

--- a/libleptonattrib/src/x_window.c
+++ b/libleptonattrib/src/x_window.c
@@ -170,24 +170,6 @@ x_window_init ()
    * when gtk_sheet_new is invoked, I think.  */
   sheets = g_new0 (GtkSheet*, NUM_SHEETS);
 
-
-  /* Restore main window's geometry:
-  */
-  EdaConfig* cfg = eda_config_get_cache_context();
-
-  gint x = eda_config_get_int (cfg, "attrib.window-geometry", "x", NULL);
-  gint y = eda_config_get_int (cfg, "attrib.window-geometry", "y", NULL);
-
-  gtk_window_move (GTK_WINDOW (window), x, y);
-
-  gint width  = eda_config_get_int (cfg, "attrib.window-geometry", "width",  NULL);
-  gint height = eda_config_get_int (cfg, "attrib.window-geometry", "height", NULL);
-
-  if (width > 0 && height > 0)
-  {
-    gtk_window_resize (GTK_WINDOW (window), width, height);
-  }
-
 } /* x_window_init() */
 
 

--- a/libleptonattrib/src/x_window.c
+++ b/libleptonattrib/src/x_window.c
@@ -54,18 +54,11 @@
 #include "../include/globals.h"
 #include "../include/gettext.h"
 
-/*------------------------------------------------------------------
- * Gattrib specific defines
- *------------------------------------------------------------------*/
-#define GATTRIB_THEME_ICON_NAME "lepton-attrib"
 
 #ifndef ENABLE_GTK3
 static void
 x_window_create_menu(GtkWindow *window, GtkWidget **menubar);
 #endif
-
-static void
-x_window_set_default_icon( void );
 
 
 static GtkWidget*
@@ -92,9 +85,6 @@ x_window_init ()
 {
   GtkWidget *menu_bar;
   GtkWidget *main_vbox;
-
-  /* Set default icon */
-  x_window_set_default_icon();
 
   g_signal_connect(window, "delete_event",
                    G_CALLBACK (attrib_really_quit), 0);
@@ -612,20 +602,6 @@ x_window_add_items()
 #endif
 
   gtk_widget_show_all( GTK_WIDGET(window) );
-}
-
-
-/*! \brief Set application icon
- *
- * Setup default icon for GTK windows
- *
- *  Sets the default window icon by name, to be found in the current icon
- *  theme. The name used is \#define'd above as GATTRIB_THEME_ICON_NAME.
- */
-static void
-x_window_set_default_icon( void )
-{
-  gtk_window_set_default_icon_name( GATTRIB_THEME_ICON_NAME );
 }
 
 

--- a/libleptonattrib/src/x_window.c
+++ b/libleptonattrib/src/x_window.c
@@ -605,43 +605,6 @@ x_window_add_items()
 }
 
 
-/*! \brief Set the main window's title.
- *
- *  \param plist  The list of LeptonPage objects (opened pages).
- */
-void
-x_window_set_title (GList* plist)
-{
-  g_return_if_fail (plist != NULL);
-  g_return_if_fail (window != NULL);
-
-  const gchar* prog_name = "lepton-attrib";
-  gchar* title = NULL;
-
-  if (g_list_length (plist) == 1)
-  {
-    const gchar* fpath = lepton_page_get_filename ((LeptonPage *) plist->data);
-    gchar* fname = g_path_get_basename (fpath);
-
-    title = g_strdup_printf ("%s - %s", fname, prog_name);
-
-    g_free (fname);
-  }
-  else
-  if (g_list_length (plist) > 1)
-  {
-    title = g_strdup_printf ("%s - %s", _("Multiple files"), prog_name);
-  }
-  else
-  {
-    title = g_strdup_printf ("%s", prog_name);
-  }
-
-  gtk_window_set_title (GTK_WINDOW (window), title);
-  g_free (title);
-}
-
-
 /*! \brief Indicate if document has \a changed in the title.
  */
 void

--- a/libleptonattrib/src/x_window.c
+++ b/libleptonattrib/src/x_window.c
@@ -263,6 +263,16 @@ menu_edit_delattrib()
 
 
 /* Menu callbacks */
+static GCallback callback_file_save = NULL;
+
+static void
+callback_file_save_wrapper (GSimpleAction *action,
+                            GVariant *parameter,
+                            gpointer user_data)
+{
+  ((void (*)(GSimpleAction*, GVariant*, gpointer)) callback_file_save) (action, parameter, user_data);
+}
+
 
 /*! \var static GCallback callback_file_quit
  *
@@ -309,7 +319,8 @@ attrib_window_set_menu_callback (char *name,
   g_return_if_fail (name != NULL);
   g_return_if_fail (callback != NULL);
 
-  if (strcmp (name, "file-quit") == 0) {callback_file_quit = callback;}
+  if (strcmp (name, "file-save") == 0) {callback_file_save = callback;}
+  else if (strcmp (name, "file-quit") == 0) {callback_file_quit = callback;}
 }
 
 
@@ -431,7 +442,7 @@ static const gchar menu[] =
 #ifdef ENABLE_GTK3
 
 static GActionEntry app_entries[] = {
-  { "file-save", s_toplevel_save_sheet, NULL, NULL, NULL },
+  { "file-save", callback_file_save_wrapper, NULL, NULL, NULL },
   { "file-export-csv", menu_file_export_csv, NULL, NULL, NULL },
   { "file-quit", callback_file_quit_wrapper, NULL, NULL, NULL },
   { "edit-add-attrib", menu_edit_newattrib, NULL, NULL, NULL },
@@ -450,7 +461,7 @@ static const GtkActionEntry actions[] = {
   /* name, stock-id, label, accelerator, tooltip, callback function */
   /* File menu */
   { "file", NULL, "_File"},
-  { "file-save", "document-save", "Save", "<Control>S", "", s_toplevel_save_sheet},
+  { "file-save", "document-save", "Save", "<Control>S", "", G_CALLBACK (callback_file_save_wrapper)},
   { "file-export-csv", NULL, "Export CSV", "", "", menu_file_export_csv},
   /* { "file-print", "document-print", "Print", "<Control>P", "", x_dialog_unimplemented_feature}, */
   { "file-quit", "application-exit", "Quit", "<Control>Q", "", G_CALLBACK (callback_file_quit_wrapper)},

--- a/libleptonattrib/src/x_window.c
+++ b/libleptonattrib/src/x_window.c
@@ -472,6 +472,17 @@ callback_visibility_name_only_wrapper (GSimpleAction *action,
 }
 
 
+static GCallback callback_visibility_value_only = NULL;
+
+static void
+callback_visibility_value_only_wrapper (GSimpleAction *action,
+                                        GVariant *parameter,
+                                        gpointer user_data)
+{
+  ((void (*)(GSimpleAction*, GVariant*, gpointer)) callback_visibility_value_only) (action, parameter, user_data);
+}
+
+
 /*! \brief Set menu item callback by name.
  *
  *  \par Function Description
@@ -496,6 +507,7 @@ attrib_window_set_menu_callback (char *name,
   else if (strcmp (name, "edit-delete-attrib") == 0) {callback_edit_delete_attrib = callback;}
   else if (strcmp (name, "visibility-invisible") == 0) {callback_visibility_invisible = callback;}
   else if (strcmp (name, "visibility-name-only") == 0) {callback_visibility_name_only = callback;}
+  else if (strcmp (name, "visibility-value-only") == 0) {callback_visibility_value_only = callback;}
 }
 
 
@@ -624,7 +636,7 @@ static GActionEntry app_entries[] = {
   { "edit-delete-attrib", callback_edit_delete_attrib_wrapper, NULL, NULL, NULL },
   { "visibility-invisible", callback_visibility_invisible_wrapper, NULL, NULL, NULL },
   { "visibility-name-only", callback_visibility_name_only_wrapper, NULL, NULL, NULL },
-  { "visibility-value-only", s_visibility_set_value_only, NULL, NULL, NULL },
+  { "visibility-value-only", callback_visibility_value_only_wrapper, NULL, NULL, NULL },
   { "visibility-name-value", s_visibility_set_name_and_value, NULL, NULL, NULL },
   { "help-about", x_dialog_about_dialog, NULL, NULL, NULL },
 };
@@ -653,7 +665,7 @@ static const GtkActionEntry actions[] = {
   { "visibility", NULL, "_Visibility"},
   { "visibility-invisible", NULL, "Set selected invisible", "", "", G_CALLBACK (callback_visibility_invisible_wrapper)},
   { "visibility-name-only", NULL, "Set selected name visible only", "", "", G_CALLBACK (callback_visibility_name_only_wrapper)},
-  { "visibility-value-only", NULL, "Set selected value visible only", "", "", s_visibility_set_value_only},
+  { "visibility-value-only", NULL, "Set selected value visible only", "", "", G_CALLBACK (callback_visibility_value_only_wrapper)},
   { "visibility-name-value", NULL, "Set selected name and value visible", "", "", s_visibility_set_name_and_value},
 
   /* Help menu */

--- a/libleptonattrib/src/x_window.c
+++ b/libleptonattrib/src/x_window.c
@@ -261,9 +261,28 @@ menu_edit_delattrib()
   x_dialog_delattrib();
 }
 
+
 /* Menu callbacks */
+
+/*! \var static GCallback callback_file_quit
+ *
+ * The callback set in Scheme to quit the program.
+ */
 static GCallback callback_file_quit = NULL;
 
+
+/*! \brief C wrapper for callback_file_quit().
+ *
+ *  \par Function Description
+ *
+ *  C wrapper function for the callback callback_file_quit() which
+ *  is assigned in Scheme.  The static wrapper is used to
+ *  implement corresponding menu item.
+ *
+ *  \param action [in] GSimpleAction (GTK3), unused.
+ *  \param parameter [in] GVariant (GTK3), unused.
+ *  \param user_data [in] User data, unused.
+ */
 static void
 callback_file_quit_wrapper (GSimpleAction *action,
                             GVariant *parameter,
@@ -273,6 +292,16 @@ callback_file_quit_wrapper (GSimpleAction *action,
 }
 
 
+/*! \brief Set menu item callback by name.
+ *
+ *  \par Function Description
+ *
+ *  Sets \p callback for a menu item denoted by \p name.  The
+ *  function is used to set menu callbacks in Scheme.
+ *
+ *  \param name [in] A name associated with a menu item action.
+ *  \param callback [in] The callback to set.
+ */
 void
 attrib_window_set_menu_callback (char *name,
                                  GCallback callback)

--- a/libleptonattrib/src/x_window.c
+++ b/libleptonattrib/src/x_window.c
@@ -261,6 +261,28 @@ menu_edit_delattrib()
   x_dialog_delattrib();
 }
 
+/* Menu callbacks */
+static GCallback callback_file_quit = NULL;
+
+static void
+callback_file_quit_wrapper (GSimpleAction *action,
+                            GVariant *parameter,
+                            gpointer user_data)
+{
+  ((void (*)(GSimpleAction*, GVariant*, gpointer)) callback_file_quit) (action, parameter, user_data);
+}
+
+
+void
+attrib_window_set_menu_callback (char *name,
+                                 GCallback callback)
+{
+  g_return_if_fail (name != NULL);
+  g_return_if_fail (callback != NULL);
+
+  if (strcmp (name, "file-quit") == 0) {callback_file_quit = callback;}
+}
+
 
 /*!
  * GTK3 main menu structure.
@@ -382,7 +404,7 @@ static const gchar menu[] =
 static GActionEntry app_entries[] = {
   { "file-save", s_toplevel_save_sheet, NULL, NULL, NULL },
   { "file-export-csv", menu_file_export_csv, NULL, NULL, NULL },
-  { "file-quit", attrib_really_quit, NULL, NULL, NULL },
+  { "file-quit", callback_file_quit_wrapper, NULL, NULL, NULL },
   { "edit-add-attrib", menu_edit_newattrib, NULL, NULL, NULL },
   { "edit-delete-attrib", menu_edit_delattrib, NULL, NULL, NULL },
   { "visibility-invisible", s_visibility_set_invisible, NULL, NULL, NULL },
@@ -402,7 +424,7 @@ static const GtkActionEntry actions[] = {
   { "file-save", "document-save", "Save", "<Control>S", "", s_toplevel_save_sheet},
   { "file-export-csv", NULL, "Export CSV", "", "", menu_file_export_csv},
   /* { "file-print", "document-print", "Print", "<Control>P", "", x_dialog_unimplemented_feature}, */
-  { "file-quit", "application-exit", "Quit", "<Control>Q", "", G_CALLBACK(attrib_really_quit)},
+  { "file-quit", "application-exit", "Quit", "<Control>Q", "", G_CALLBACK (callback_file_quit_wrapper)},
 
   /* Edit menu */
   { "edit", NULL, "_Edit"},

--- a/libleptonattrib/src/x_window.c
+++ b/libleptonattrib/src/x_window.c
@@ -532,8 +532,25 @@ callback_visibility_name_value_wrapper (GSimpleAction *action,
 }
 
 
+/*! \var static GCallback callback_help_about
+ *
+ * The callback set in Scheme to show the program help.
+ */
 static GCallback callback_help_about = NULL;
 
+
+/*! \brief C wrapper for callback_help_about().
+ *
+ *  \par Function Description
+ *
+ *  C wrapper function for the callback callback_help_about()
+ *  which is assigned in Scheme.  The static wrapper is used to
+ *  implement corresponding menu item.
+ *
+ *  \param action [in] GSimpleAction (GTK3), unused.
+ *  \param parameter [in] GVariant (GTK3), unused.
+ *  \param user_data [in] User data, unused.
+ */
 static void
 callback_help_about_wrapper (GSimpleAction *action,
                              GVariant *parameter,

--- a/libleptonattrib/src/x_window.c
+++ b/libleptonattrib/src/x_window.c
@@ -442,8 +442,27 @@ callback_visibility_invisible_wrapper (GSimpleAction *action,
 }
 
 
+/*! \var static GCallback callback_visibility_name_only
+ *
+ * The callback set in Scheme to set attribute visibility to
+ * show name only.
+ */
 static GCallback callback_visibility_name_only = NULL;
 
+
+/*! \brief C wrapper for callback_visibility_name_only().
+ *
+ *  \par Function Description
+ *
+ *  C wrapper function for the callback
+ *  callback_visibility_name_only() which is assigned in Scheme.
+ *  The static wrapper is used to implement corresponding menu
+ *  item.
+ *
+ *  \param action [in] GSimpleAction (GTK3), unused.
+ *  \param parameter [in] GVariant (GTK3), unused.
+ *  \param user_data [in] User data, unused.
+ */
 static void
 callback_visibility_name_only_wrapper (GSimpleAction *action,
                                        GVariant *parameter,

--- a/libleptonattrib/src/x_window.c
+++ b/libleptonattrib/src/x_window.c
@@ -532,6 +532,17 @@ callback_visibility_name_value_wrapper (GSimpleAction *action,
 }
 
 
+static GCallback callback_help_about = NULL;
+
+static void
+callback_help_about_wrapper (GSimpleAction *action,
+                             GVariant *parameter,
+                             gpointer user_data)
+{
+  ((void (*)(GSimpleAction*, GVariant*, gpointer)) callback_help_about) (action, parameter, user_data);
+}
+
+
 /*! \brief Set menu item callback by name.
  *
  *  \par Function Description
@@ -558,6 +569,7 @@ attrib_window_set_menu_callback (char *name,
   else if (strcmp (name, "visibility-name-only") == 0) {callback_visibility_name_only = callback;}
   else if (strcmp (name, "visibility-value-only") == 0) {callback_visibility_value_only = callback;}
   else if (strcmp (name, "visibility-name-value") == 0) {callback_visibility_name_value = callback;}
+  else if (strcmp (name, "help-about") == 0) {callback_help_about = callback;}
 }
 
 
@@ -688,7 +700,7 @@ static GActionEntry app_entries[] = {
   { "visibility-name-only", callback_visibility_name_only_wrapper, NULL, NULL, NULL },
   { "visibility-value-only", callback_visibility_value_only_wrapper, NULL, NULL, NULL },
   { "visibility-name-value", callback_visibility_name_value_wrapper, NULL, NULL, NULL },
-  { "help-about", x_dialog_about_dialog, NULL, NULL, NULL },
+  { "help-about", callback_help_about_wrapper, NULL, NULL, NULL },
 };
 
 
@@ -720,7 +732,7 @@ static const GtkActionEntry actions[] = {
 
   /* Help menu */
   { "help", NULL, "_Help"},
-  { "help-about", "help-about", "About", "", "", x_dialog_about_dialog},
+  { "help-about", "help-about", "About", "", "", G_CALLBACK (callback_help_about_wrapper)},
 };
 #endif
 

--- a/libleptonattrib/src/x_window.c
+++ b/libleptonattrib/src/x_window.c
@@ -263,8 +263,25 @@ menu_edit_delattrib()
 
 
 /* Menu callbacks */
+/*! \var static GCallback callback_file_save
+ *
+ * The callback set in Scheme to save files.
+ */
 static GCallback callback_file_save = NULL;
 
+
+/*! \brief C wrapper for callback_file_save().
+ *
+ *  \par Function Description
+ *
+ *  C wrapper function for the callback callback_file_save() which
+ *  is assigned in Scheme.  The static wrapper is used to
+ *  implement corresponding menu item.
+ *
+ *  \param action [in] GSimpleAction (GTK3), unused.
+ *  \param parameter [in] GVariant (GTK3), unused.
+ *  \param user_data [in] User data, unused.
+ */
 static void
 callback_file_save_wrapper (GSimpleAction *action,
                             GVariant *parameter,

--- a/libleptonattrib/src/x_window.c
+++ b/libleptonattrib/src/x_window.c
@@ -442,6 +442,17 @@ callback_visibility_invisible_wrapper (GSimpleAction *action,
 }
 
 
+static GCallback callback_visibility_name_only = NULL;
+
+static void
+callback_visibility_name_only_wrapper (GSimpleAction *action,
+                                       GVariant *parameter,
+                                       gpointer user_data)
+{
+  ((void (*)(GSimpleAction*, GVariant*, gpointer)) callback_visibility_name_only) (action, parameter, user_data);
+}
+
+
 /*! \brief Set menu item callback by name.
  *
  *  \par Function Description
@@ -465,6 +476,7 @@ attrib_window_set_menu_callback (char *name,
   else if (strcmp (name, "edit-add-attrib") == 0) {callback_edit_add_attrib = callback;}
   else if (strcmp (name, "edit-delete-attrib") == 0) {callback_edit_delete_attrib = callback;}
   else if (strcmp (name, "visibility-invisible") == 0) {callback_visibility_invisible = callback;}
+  else if (strcmp (name, "visibility-name-only") == 0) {callback_visibility_name_only = callback;}
 }
 
 
@@ -592,7 +604,7 @@ static GActionEntry app_entries[] = {
   { "edit-add-attrib", callback_edit_add_attrib_wrapper, NULL, NULL, NULL },
   { "edit-delete-attrib", callback_edit_delete_attrib_wrapper, NULL, NULL, NULL },
   { "visibility-invisible", callback_visibility_invisible_wrapper, NULL, NULL, NULL },
-  { "visibility-name-only", s_visibility_set_name_only, NULL, NULL, NULL },
+  { "visibility-name-only", callback_visibility_name_only_wrapper, NULL, NULL, NULL },
   { "visibility-value-only", s_visibility_set_value_only, NULL, NULL, NULL },
   { "visibility-name-value", s_visibility_set_name_and_value, NULL, NULL, NULL },
   { "help-about", x_dialog_about_dialog, NULL, NULL, NULL },
@@ -621,7 +633,7 @@ static const GtkActionEntry actions[] = {
   /* Visibility menu */
   { "visibility", NULL, "_Visibility"},
   { "visibility-invisible", NULL, "Set selected invisible", "", "", G_CALLBACK (callback_visibility_invisible_wrapper)},
-  { "visibility-name-only", NULL, "Set selected name visible only", "", "", s_visibility_set_name_only},
+  { "visibility-name-only", NULL, "Set selected name visible only", "", "", G_CALLBACK (callback_visibility_name_only_wrapper)},
   { "visibility-value-only", NULL, "Set selected value visible only", "", "", s_visibility_set_value_only},
   { "visibility-name-value", NULL, "Set selected name and value visible", "", "", s_visibility_set_name_and_value},
 

--- a/libleptonattrib/src/x_window.c
+++ b/libleptonattrib/src/x_window.c
@@ -227,13 +227,16 @@ menu_file_export_csv (gpointer action,
  *
  * Implement the New attrib menu item
  */
-static void
 #ifdef ENABLE_GTK3
+void
 menu_edit_newattrib (GSimpleAction *action,
                      GVariant *parameter,
                      gpointer user_data)
 #else
-menu_edit_newattrib()
+void
+menu_edit_newattrib (gpointer action,
+                     gpointer parameter,
+                     gpointer user_data)
 #endif
 {
   gint cur_page;
@@ -350,6 +353,17 @@ callback_file_quit_wrapper (GSimpleAction *action,
 }
 
 
+static GCallback callback_edit_add_attrib = NULL;
+
+static void
+callback_edit_add_attrib_wrapper (GSimpleAction *action,
+                                  GVariant *parameter,
+                                  gpointer user_data)
+{
+  ((void (*)(GSimpleAction*, GVariant*, gpointer)) callback_edit_add_attrib) (action, parameter, user_data);
+}
+
+
 /*! \brief Set menu item callback by name.
  *
  *  \par Function Description
@@ -370,6 +384,7 @@ attrib_window_set_menu_callback (char *name,
   if (strcmp (name, "file-save") == 0) {callback_file_save = callback;}
   else if (strcmp (name, "file-export-csv") == 0) {callback_file_export_csv = callback;}
   else if (strcmp (name, "file-quit") == 0) {callback_file_quit = callback;}
+  else if (strcmp (name, "edit-add-attrib") == 0) {callback_edit_add_attrib = callback;}
 }
 
 
@@ -494,7 +509,7 @@ static GActionEntry app_entries[] = {
   { "file-save", callback_file_save_wrapper, NULL, NULL, NULL },
   { "file-export-csv", callback_file_export_csv_wrapper, NULL, NULL, NULL },
   { "file-quit", callback_file_quit_wrapper, NULL, NULL, NULL },
-  { "edit-add-attrib", menu_edit_newattrib, NULL, NULL, NULL },
+  { "edit-add-attrib", callback_edit_add_attrib_wrapper, NULL, NULL, NULL },
   { "edit-delete-attrib", menu_edit_delattrib, NULL, NULL, NULL },
   { "visibility-invisible", s_visibility_set_invisible, NULL, NULL, NULL },
   { "visibility-name-only", s_visibility_set_name_only, NULL, NULL, NULL },
@@ -517,7 +532,7 @@ static const GtkActionEntry actions[] = {
 
   /* Edit menu */
   { "edit", NULL, "_Edit"},
-  { "edit-add-attrib", NULL, "Add new attrib column", "", "", menu_edit_newattrib},
+  { "edit-add-attrib", NULL, "Add new attrib column", "", "", G_CALLBACK (callback_edit_add_attrib_wrapper)},
   { "edit-delete-attrib", NULL, "Delete attrib column", "", "", menu_edit_delattrib},
   /* { "edit-find-attrib", "edit-find", "Find attrib value", "<Control>F", "", x_dialog_unimplemented_feature}, */
   /* { "edit-search-replace-attrib-value", NULL, "Search and replace attrib value", "", "", x_dialog_unimplemented_feature}, */

--- a/libleptonattrib/src/x_window.c
+++ b/libleptonattrib/src/x_window.c
@@ -353,8 +353,25 @@ callback_file_quit_wrapper (GSimpleAction *action,
 }
 
 
+/*! \var static GCallback callback_edit_add_attrib
+ *
+ * The callback set in Scheme to add an attrib.
+ */
 static GCallback callback_edit_add_attrib = NULL;
 
+
+/*! \brief C wrapper for callback_edit_add_attrib().
+ *
+ *  \par Function Description
+ *
+ *  C wrapper function for the callback callback_edit_add_attrib()
+ *  which is assigned in Scheme.  The static wrapper is used to
+ *  implement corresponding menu item.
+ *
+ *  \param action [in] GSimpleAction (GTK3), unused.
+ *  \param parameter [in] GVariant (GTK3), unused.
+ *  \param user_data [in] User data, unused.
+ */
 static void
 callback_edit_add_attrib_wrapper (GSimpleAction *action,
                                   GVariant *parameter,

--- a/libleptonattrib/src/x_window.c
+++ b/libleptonattrib/src/x_window.c
@@ -472,8 +472,27 @@ callback_visibility_name_only_wrapper (GSimpleAction *action,
 }
 
 
+/*! \var static GCallback callback_visibility_value_only
+ *
+ * The callback set in Scheme to set attribute visibility to
+ * show value only.
+ */
 static GCallback callback_visibility_value_only = NULL;
 
+
+/*! \brief C wrapper for callback_visibility_value_only().
+ *
+ *  \par Function Description
+ *
+ *  C wrapper function for the callback
+ *  callback_visibility_value_only() which is assigned in Scheme.
+ *  The static wrapper is used to implement corresponding menu
+ *  item.
+ *
+ *  \param action [in] GSimpleAction (GTK3), unused.
+ *  \param parameter [in] GVariant (GTK3), unused.
+ *  \param user_data [in] User data, unused.
+ */
 static void
 callback_visibility_value_only_wrapper (GSimpleAction *action,
                                         GVariant *parameter,

--- a/libleptonattrib/src/x_window.c
+++ b/libleptonattrib/src/x_window.c
@@ -255,13 +255,16 @@ menu_edit_newattrib (gpointer action,
  *
  * Implements the Delete Attribute menu item
  */
-static void
 #ifdef ENABLE_GTK3
+void
 menu_edit_delattrib (GSimpleAction *action,
                      GVariant *parameter,
                      gpointer user_data)
 #else
-menu_edit_delattrib()
+void
+menu_edit_delattrib (gpointer action,
+                     gpointer parameter,
+                     gpointer user_data)
 #endif
 {
   x_dialog_delattrib();
@@ -380,6 +383,17 @@ callback_edit_add_attrib_wrapper (GSimpleAction *action,
   ((void (*)(GSimpleAction*, GVariant*, gpointer)) callback_edit_add_attrib) (action, parameter, user_data);
 }
 
+static GCallback callback_edit_delete_attrib = NULL;
+
+static void
+callback_edit_delete_attrib_wrapper (GSimpleAction *action,
+                                     GVariant *parameter,
+                                     gpointer user_data)
+{
+  ((void (*)(GSimpleAction*, GVariant*, gpointer)) callback_edit_delete_attrib) (action, parameter, user_data);
+}
+
+
 
 /*! \brief Set menu item callback by name.
  *
@@ -402,6 +416,7 @@ attrib_window_set_menu_callback (char *name,
   else if (strcmp (name, "file-export-csv") == 0) {callback_file_export_csv = callback;}
   else if (strcmp (name, "file-quit") == 0) {callback_file_quit = callback;}
   else if (strcmp (name, "edit-add-attrib") == 0) {callback_edit_add_attrib = callback;}
+  else if (strcmp (name, "edit-delete-attrib") == 0) {callback_edit_delete_attrib = callback;}
 }
 
 
@@ -527,7 +542,7 @@ static GActionEntry app_entries[] = {
   { "file-export-csv", callback_file_export_csv_wrapper, NULL, NULL, NULL },
   { "file-quit", callback_file_quit_wrapper, NULL, NULL, NULL },
   { "edit-add-attrib", callback_edit_add_attrib_wrapper, NULL, NULL, NULL },
-  { "edit-delete-attrib", menu_edit_delattrib, NULL, NULL, NULL },
+  { "edit-delete-attrib", callback_edit_delete_attrib_wrapper, NULL, NULL, NULL },
   { "visibility-invisible", s_visibility_set_invisible, NULL, NULL, NULL },
   { "visibility-name-only", s_visibility_set_name_only, NULL, NULL, NULL },
   { "visibility-value-only", s_visibility_set_value_only, NULL, NULL, NULL },
@@ -550,7 +565,7 @@ static const GtkActionEntry actions[] = {
   /* Edit menu */
   { "edit", NULL, "_Edit"},
   { "edit-add-attrib", NULL, "Add new attrib column", "", "", G_CALLBACK (callback_edit_add_attrib_wrapper)},
-  { "edit-delete-attrib", NULL, "Delete attrib column", "", "", menu_edit_delattrib},
+  { "edit-delete-attrib", NULL, "Delete attrib column", "", "", G_CALLBACK (callback_edit_delete_attrib_wrapper)},
   /* { "edit-find-attrib", "edit-find", "Find attrib value", "<Control>F", "", x_dialog_unimplemented_feature}, */
   /* { "edit-search-replace-attrib-value", NULL, "Search and replace attrib value", "", "", x_dialog_unimplemented_feature}, */
   /* { "edit-search-for-refdes", NULL, "Search for refdes", "", "", x_dialog_unimplemented_feature}, */

--- a/libleptonattrib/src/x_window.c
+++ b/libleptonattrib/src/x_window.c
@@ -185,37 +185,6 @@ x_window_init ()
 
 
 /*!
- * \brief File->Export CSV menu item
- *
- * Implement the File->Export CSV menu item
- */
-#ifdef ENABLE_GTK3
-void
-menu_file_export_csv (GSimpleAction *action,
-                      GVariant *parameter,
-                      gpointer user_data)
-#else
-void
-menu_file_export_csv (gpointer action,
-                      gpointer parameter,
-                      gpointer user_data)
-#endif
-{
-  gint cur_page;
-
-  /* first verify that we are on the correct page (components) */
-  cur_page = gtk_notebook_get_current_page(GTK_NOTEBOOK(notebook));
-
-  /* Check that we are on components page. */
-  if (cur_page == 0) {
-    x_dialog_export_file();
-  } else {
-    x_dialog_unimplemented_feature();  /* We only support export
-                                          of components now */
-  }
-}
-
-/*!
  * \brief Edit->New attrib menu item
  *
  * Implement the New attrib menu item

--- a/libleptonattrib/src/x_window.c
+++ b/libleptonattrib/src/x_window.c
@@ -181,8 +181,6 @@ x_window_init ()
 
   gtk_box_pack_start (GTK_BOX (marea), label_name_val, FALSE, TRUE, 0);
 
-  attrib_window_sheets_new ();
-
 } /* x_window_init() */
 
 

--- a/libleptonattrib/src/x_window.c
+++ b/libleptonattrib/src/x_window.c
@@ -86,9 +86,6 @@ x_window_init ()
   GtkWidget *menu_bar;
   GtkWidget *main_vbox;
 
-  g_signal_connect(window, "delete_event",
-                   G_CALLBACK (attrib_really_quit), 0);
-
   /* -----  Now create main_vbox.  This is a container which organizes child  ----- */
   /* -----  widgets into a vertical column.  ----- */
   #ifdef ENABLE_GTK3

--- a/libleptonattrib/src/x_window.c
+++ b/libleptonattrib/src/x_window.c
@@ -185,34 +185,6 @@ x_window_init ()
 
 
 /*!
- * \brief Edit->New attrib menu item
- *
- * Implement the New attrib menu item
- */
-#ifdef ENABLE_GTK3
-void
-menu_edit_newattrib (GSimpleAction *action,
-                     GVariant *parameter,
-                     gpointer user_data)
-#else
-void
-menu_edit_newattrib (gpointer action,
-                     gpointer parameter,
-                     gpointer user_data)
-#endif
-{
-  gint cur_page;
-
-  /* first verify that we are on the correct page (components) */
-  cur_page = gtk_notebook_get_current_page(GTK_NOTEBOOK(notebook));
-
-  /* Check that we are on components page. */
-  if (cur_page == 0) {
-    x_dialog_newattrib();  /* This creates dialog box  */
-  }
-}
-
-/*!
  * \brief Edit->Delete Attribute menu item
  *
  * Implements the Delete Attribute menu item

--- a/libleptonattrib/src/x_window.c
+++ b/libleptonattrib/src/x_window.c
@@ -412,6 +412,16 @@ callback_edit_delete_attrib_wrapper (GSimpleAction *action,
 }
 
 
+static GCallback callback_visibility_invisible = NULL;
+
+static void
+callback_visibility_invisible_wrapper (GSimpleAction *action,
+                                       GVariant *parameter,
+                                       gpointer user_data)
+{
+  ((void (*)(GSimpleAction*, GVariant*, gpointer)) callback_visibility_invisible) (action, parameter, user_data);
+}
+
 
 /*! \brief Set menu item callback by name.
  *
@@ -435,6 +445,7 @@ attrib_window_set_menu_callback (char *name,
   else if (strcmp (name, "file-quit") == 0) {callback_file_quit = callback;}
   else if (strcmp (name, "edit-add-attrib") == 0) {callback_edit_add_attrib = callback;}
   else if (strcmp (name, "edit-delete-attrib") == 0) {callback_edit_delete_attrib = callback;}
+  else if (strcmp (name, "visibility-invisible") == 0) {callback_visibility_invisible = callback;}
 }
 
 
@@ -561,7 +572,7 @@ static GActionEntry app_entries[] = {
   { "file-quit", callback_file_quit_wrapper, NULL, NULL, NULL },
   { "edit-add-attrib", callback_edit_add_attrib_wrapper, NULL, NULL, NULL },
   { "edit-delete-attrib", callback_edit_delete_attrib_wrapper, NULL, NULL, NULL },
-  { "visibility-invisible", s_visibility_set_invisible, NULL, NULL, NULL },
+  { "visibility-invisible", callback_visibility_invisible_wrapper, NULL, NULL, NULL },
   { "visibility-name-only", s_visibility_set_name_only, NULL, NULL, NULL },
   { "visibility-value-only", s_visibility_set_value_only, NULL, NULL, NULL },
   { "visibility-name-value", s_visibility_set_name_and_value, NULL, NULL, NULL },
@@ -590,7 +601,7 @@ static const GtkActionEntry actions[] = {
 
   /* Visibility menu */
   { "visibility", NULL, "_Visibility"},
-  { "visibility-invisible", NULL, "Set selected invisible", "", "", s_visibility_set_invisible},
+  { "visibility-invisible", NULL, "Set selected invisible", "", "", G_CALLBACK (callback_visibility_invisible_wrapper)},
   { "visibility-name-only", NULL, "Set selected name visible only", "", "", s_visibility_set_name_only},
   { "visibility-value-only", NULL, "Set selected value visible only", "", "", s_visibility_set_value_only},
   { "visibility-name-value", NULL, "Set selected name and value visible", "", "", s_visibility_set_name_and_value},

--- a/libleptonattrib/src/x_window.c
+++ b/libleptonattrib/src/x_window.c
@@ -502,6 +502,17 @@ callback_visibility_value_only_wrapper (GSimpleAction *action,
 }
 
 
+static GCallback callback_visibility_name_value = NULL;
+
+static void
+callback_visibility_name_value_wrapper (GSimpleAction *action,
+                                        GVariant *parameter,
+                                        gpointer user_data)
+{
+  ((void (*)(GSimpleAction*, GVariant*, gpointer)) callback_visibility_name_value) (action, parameter, user_data);
+}
+
+
 /*! \brief Set menu item callback by name.
  *
  *  \par Function Description
@@ -527,6 +538,7 @@ attrib_window_set_menu_callback (char *name,
   else if (strcmp (name, "visibility-invisible") == 0) {callback_visibility_invisible = callback;}
   else if (strcmp (name, "visibility-name-only") == 0) {callback_visibility_name_only = callback;}
   else if (strcmp (name, "visibility-value-only") == 0) {callback_visibility_value_only = callback;}
+  else if (strcmp (name, "visibility-name-value") == 0) {callback_visibility_name_value = callback;}
 }
 
 
@@ -656,7 +668,7 @@ static GActionEntry app_entries[] = {
   { "visibility-invisible", callback_visibility_invisible_wrapper, NULL, NULL, NULL },
   { "visibility-name-only", callback_visibility_name_only_wrapper, NULL, NULL, NULL },
   { "visibility-value-only", callback_visibility_value_only_wrapper, NULL, NULL, NULL },
-  { "visibility-name-value", s_visibility_set_name_and_value, NULL, NULL, NULL },
+  { "visibility-name-value", callback_visibility_name_value_wrapper, NULL, NULL, NULL },
   { "help-about", x_dialog_about_dialog, NULL, NULL, NULL },
 };
 
@@ -685,7 +697,7 @@ static const GtkActionEntry actions[] = {
   { "visibility-invisible", NULL, "Set selected invisible", "", "", G_CALLBACK (callback_visibility_invisible_wrapper)},
   { "visibility-name-only", NULL, "Set selected name visible only", "", "", G_CALLBACK (callback_visibility_name_only_wrapper)},
   { "visibility-value-only", NULL, "Set selected value visible only", "", "", G_CALLBACK (callback_visibility_value_only_wrapper)},
-  { "visibility-name-value", NULL, "Set selected name and value visible", "", "", s_visibility_set_name_and_value},
+  { "visibility-name-value", NULL, "Set selected name and value visible", "", "", G_CALLBACK (callback_visibility_name_value_wrapper)},
 
   /* Help menu */
   { "help", NULL, "_Help"},

--- a/libleptonattrib/src/x_window.c
+++ b/libleptonattrib/src/x_window.c
@@ -71,6 +71,23 @@ separator_new ()
 #endif
 }
 
+
+/*! \brief Create the array of sheets.
+ *
+ *  \par Function Description
+ *
+ *  Malloc -- but don't fill out -- space for sheets.  This
+ *  basically sets up the overhead for the sheets.  The memory for
+ *  the actual sheet cells is allocated later, when
+ *  gtk_sheet_new() is invoked.
+ */
+void
+attrib_window_sheets_new ()
+{
+  sheets = g_new0 (GtkSheet*, NUM_SHEETS);
+}
+
+
 /*! \brief Initialises the toplevel gtksheet
  *
  * This function initializes the toplevel gtksheet stuff.
@@ -164,11 +181,7 @@ x_window_init ()
 
   gtk_box_pack_start (GTK_BOX (marea), label_name_val, FALSE, TRUE, 0);
 
-  /* -----  Now malloc -- but don't fill out -- space for sheets  ----- */
-  /* This basically sets up the overhead for the sheets, as I understand
-   * it.  The memory for the actual sheet cells is allocated later,
-   * when gtk_sheet_new is invoked, I think.  */
-  sheets = g_new0 (GtkSheet*, NUM_SHEETS);
+  attrib_window_sheets_new ();
 
 } /* x_window_init() */
 

--- a/libleptonattrib/src/x_window.c
+++ b/libleptonattrib/src/x_window.c
@@ -412,8 +412,27 @@ callback_edit_delete_attrib_wrapper (GSimpleAction *action,
 }
 
 
+/*! \var static GCallback callback_visibility_invisible
+ *
+ * The callback set in Scheme to set attribute visibility to
+ * invisible.
+ */
 static GCallback callback_visibility_invisible = NULL;
 
+
+/*! \brief C wrapper for callback_visibility_invisible().
+ *
+ *  \par Function Description
+ *
+ *  C wrapper function for the callback
+ *  callback_visibility_invisible() which is assigned in Scheme.
+ *  The static wrapper is used to implement corresponding menu
+ *  item.
+ *
+ *  \param action [in] GSimpleAction (GTK3), unused.
+ *  \param parameter [in] GVariant (GTK3), unused.
+ *  \param user_data [in] User data, unused.
+ */
 static void
 callback_visibility_invisible_wrapper (GSimpleAction *action,
                                        GVariant *parameter,

--- a/libleptonattrib/src/x_window.c
+++ b/libleptonattrib/src/x_window.c
@@ -184,27 +184,6 @@ x_window_init ()
 } /* x_window_init() */
 
 
-/*!
- * \brief Edit->Delete Attribute menu item
- *
- * Implements the Delete Attribute menu item
- */
-#ifdef ENABLE_GTK3
-void
-menu_edit_delattrib (GSimpleAction *action,
-                     GVariant *parameter,
-                     gpointer user_data)
-#else
-void
-menu_edit_delattrib (gpointer action,
-                     gpointer parameter,
-                     gpointer user_data)
-#endif
-{
-  x_dialog_delattrib();
-}
-
-
 /* Menu callbacks */
 /*! \var static GCallback callback_file_save
  *

--- a/libleptonattrib/src/x_window.c
+++ b/libleptonattrib/src/x_window.c
@@ -294,8 +294,25 @@ callback_file_save_wrapper (GSimpleAction *action,
 }
 
 
+/*! \var static GCallback callback_file_export_csv
+ *
+ * The callback set in Scheme to export data in CSV format.
+ */
 static GCallback callback_file_export_csv = NULL;
 
+
+/*! \brief C wrapper for callback_file_export_csv().
+ *
+ *  \par Function Description
+ *
+ *  C wrapper function for the callback callback_file_export_csv()
+ *  which is assigned in Scheme.  The static wrapper is used to
+ *  implement corresponding menu item.
+ *
+ *  \param action [in] GSimpleAction (GTK3), unused.
+ *  \param parameter [in] GVariant (GTK3), unused.
+ *  \param user_data [in] User data, unused.
+ */
 static void
 callback_file_export_csv_wrapper (GSimpleAction *action,
                                   GVariant *parameter,

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -336,6 +336,9 @@ failure."
 
   (x_window_init)
 
+  ;; Create the array of sheets.
+  (attrib_window_sheets_new)
+
   ;; Restore main window's geometry.
   (gtk_window_move *window-widget x y)
 

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -285,8 +285,13 @@ failure."
 (define *callback-edit-add-attrib
   (procedure->pointer void callback-edit-add-attrib '(* * *)))
 
+
+(define (delete-attrib)
+  (x_dialog_delattrib))
+
+
 (define (callback-edit-delete-attrib *action *parameter *data)
-  (menu_edit_delattrib *action *parameter *data))
+  (delete-attrib))
 (define *callback-edit-delete-attrib
   (procedure->pointer void callback-edit-delete-attrib '(* * *)))
 

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -158,6 +158,20 @@ Lepton EDA homepage: ~S
 
 (define (unsaved-data-dialog)
   (define *dialog (x_dialog_unsaved_data))
+
+  (gtk_dialog_set_default_response *dialog GTK_RESPONSE_YES)
+
+  (let ((response (gtk_dialog_run *dialog)))
+    (cond
+      ((= response GTK_RESPONSE_NO)
+       (attrib_quit 0))
+      ((= response GTK_RESPONSE_YES)
+       (s_toplevel_save_sheet %null-pointer
+                              %null-pointer
+                              %null-pointer)
+       (attrib_quit 0))
+      (else #f)))
+
   (gtk_widget_destroy *dialog))
 
 

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -156,6 +156,11 @@ Lepton EDA homepage: ~S
 (define *callback-visibility-name-value
   (procedure->pointer void callback-visibility-name-value '(* * *)))
 
+(define (callback-help-about *action *parameter *data)
+  (x_dialog_about_dialog *action *parameter *data))
+(define *callback-help-about
+  (procedure->pointer void callback-help-about '(* * *)))
+
 
 (define (init-callbacks)
   (attrib_window_set_menu_callback (string->pointer "file-save")
@@ -175,7 +180,9 @@ Lepton EDA homepage: ~S
   (attrib_window_set_menu_callback (string->pointer "visibility-value-only")
                                    *callback-visibility-value-only)
   (attrib_window_set_menu_callback (string->pointer "visibility-name-value")
-                                   *callback-visibility-name-value))
+                                   *callback-visibility-name-value)
+  (attrib_window_set_menu_callback (string->pointer "help-about")
+                                   *callback-help-about))
 
 (define (init-window)
   (define *window-widget (attrib_get_window))

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -101,10 +101,7 @@ Lepton EDA homepage: ~S
   (define (page-with-missing-symbol? page)
     (any missing-symbol? (page-contents page)))
 
-  (when (any page-with-missing-symbol?
-             (glist->list (lepton_list_get_glist
-                           (lepton_toplevel_get_pages *toplevel))
-                          pointer->page))
+  (when (any page-with-missing-symbol? (active-pages))
     ;; Dialog gives user option to quit.
     (x_dialog_missing_sym)))
 

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -207,7 +207,21 @@ Lepton EDA homepage: ~S
     ;; Dialog gives user option to quit.
     (x_dialog_missing_sym))
 
-  (x_window_set_title *pages)
+  ;; Set the main window's title.
+  (let ((program-name (basename (car (program-arguments))))
+        (page-count (length (active-pages))))
+    (gtk_window_set_title
+     *window-widget
+     (string->pointer
+      (if (= page-count 1)
+          (string-append
+           (basename (page-filename (car (active-pages))))
+           " - "
+           program-name)
+          (if (> page-count 1)
+              (string-append (G_ "Multiple files") " - " program-name)
+              program-name)))))
+
   ;; Set default icon.
   (gtk_window_set_default_icon_name (string->pointer %theme-icon-name))
 

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -90,16 +90,16 @@ Lepton EDA homepage: ~S
 ;;; the design looking for missing components, that is, those
 ;;; components for which no corresponding symbol files was found.
 (define (verify-design *toplevel)
+  (define (missing-symbol? object)
+    ;; Look for object, and verify that it has a symbol file
+    ;; attached and signal that problem exists.
+    (and (component? object)
+         (true? (lepton_component_object_get_missing
+                 (object->pointer object)))))
   (when (any
          (lambda (*page)
-           (any
-            (lambda (object)
-              ;; Look for object, and verify that it has a symbol
-              ;; file attached and signal that problem exists.
-              (and (component? object)
-                   (true? (lepton_component_object_get_missing
-                           (object->pointer object)))))
-            (glist->list (lepton_page_objects *page) pointer->object)))
+           (any missing-symbol?
+                (glist->list (lepton_page_objects *page) pointer->object)))
          (glist->list (lepton_list_get_glist
                        (lepton_toplevel_get_pages *toplevel))
                       identity))

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -64,7 +64,7 @@
   (format #t
           (G_ "Usage: ~A [OPTIONS] FILE ...
 
-lepton-attrib: Lepton EDA attribute editor.
+~A: Lepton EDA attribute editor.
 Presents schematic attributes in easy-to-edit spreadsheet format.
 
 Options:
@@ -75,6 +75,7 @@ Options:
 Report bugs at ~S
 Lepton EDA homepage: ~S
 ")
+          %program-basename
           %program-basename
           (lepton-version-ref 'bugs)
           (lepton-version-ref 'url))

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -201,8 +201,21 @@ failure."
 (define *callback-file-save
   (procedure->pointer void callback-file-save '(* * *)))
 
+
+(define (export-csv)
+  "Export component table info in the CSV format."
+  (define *notebook (attrib_get_notebook))
+  (define current-page-id (gtk_notebook_get_current_page *notebook))
+
+  ;; Check that we are on components page.
+  (if (zero? current-page-id)
+      (x_dialog_export_file)
+      ;; We only support export of components now
+      (x_dialog_unimplemented_feature)))
+
+
 (define (callback-file-export-csv *action *parameter *data)
-  (menu_file_export_csv *action *parameter *data))
+  (export-csv))
 (define *callback-file-export-csv
   (procedure->pointer void callback-file-export-csv '(* * *)))
 

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -41,6 +41,10 @@
 
              (attrib ffi))
 
+
+(define %theme-icon-name "lepton-attrib")
+
+
 ;;; Initialize liblepton library.
 (init-liblepton)
 
@@ -204,6 +208,8 @@ Lepton EDA homepage: ~S
     (x_dialog_missing_sym))
 
   (x_window_set_title *pages)
+  ;; Set default icon.
+  (gtk_window_set_default_icon_name (string->pointer %theme-icon-name))
 
   (gtk_widget_show_all *window-widget))
 

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -110,6 +110,10 @@ Lepton EDA homepage: ~S
   (any page-with-missing-symbol? (active-pages)))
 
 
+(define (init-window)
+  (x_window_init))
+
+
 (define (activate *app *toplevel)
   (define *window-widget (attrib_window_new *app))
   (define *sheet-data (s_sheet_data_new))
@@ -121,7 +125,7 @@ Lepton EDA homepage: ~S
   (attrib_set_toplevel *toplevel)
 
   ;; Initialize GTK window.
-  (x_window_init)
+  (init-window)
 
   ;; Initialize main sheet data structure.
   (attrib_set_sheet_data *sheet-data)

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -271,8 +271,17 @@ failure."
   (procedure->pointer void callback-file-quit '(* * *)))
 
 
+(define (add-attrib)
+  (define *notebook (attrib_get_notebook))
+  (define current-page-id (gtk_notebook_get_current_page *notebook))
+
+  ;; Check that we are on components page.
+  (when (zero? current-page-id)
+    (x_dialog_newattrib)))
+
+
 (define (callback-edit-add-attrib *action *parameter *data)
-  (menu_edit_newattrib *action *parameter *data))
+  (add-attrib))
 (define *callback-edit-add-attrib
   (procedure->pointer void callback-edit-add-attrib '(* * *)))
 

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -156,6 +156,10 @@ Lepton EDA homepage: ~S
   (procedure->pointer void callback-file-export-csv '(* * *)))
 
 
+(define (unsaved-data-dialog)
+  (x_dialog_unsaved_data))
+
+
 ;;; Quit the program using the UI. On execution, the function
 ;;; checks for unsaved changes before calling attrib_quit() to
 ;;; quit the program.
@@ -172,7 +176,7 @@ Lepton EDA homepage: ~S
    (iota (attrib_get_sheets_number)))
 
   (if (true? (s_sheet_data_changed (attrib_get_sheet_data)))
-      (x_dialog_unsaved_data)
+      (unsaved-data-dialog)
       (attrib_quit 0)))
 
 (define *callback-file-quit

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -155,11 +155,29 @@ Lepton EDA homepage: ~S
 (define *callback-file-export-csv
   (procedure->pointer void callback-file-export-csv '(* * *)))
 
+
+;;; Quit the program using the UI. On execution, the function
+;;; checks for unsaved changes before calling attrib_quit() to
+;;; quit the program.
 (define (callback-file-quit *action *parameter *data)
   (save-geometry)
-  (attrib_really_quit *action *parameter *data))
+  ;; Deactivate the current cell to trigger "deactivate" signal.
+  ;; This allows changing of the sheet_head->CHANGED flag in the
+  ;; on_deactivate() handler function if needed.
+  (for-each
+   (lambda (i)
+     (let ((*sheet (attrib_get_sheet i)))
+       (unless (null-pointer? *sheet)
+         (gtk_sheet_set_active_cell *sheet -1 -1))))
+   (iota (attrib_get_sheets_number)))
+
+  (if (true? (s_sheet_data_changed (attrib_get_sheet_data)))
+      (x_dialog_unsaved_data)
+      (attrib_quit 0)))
+
 (define *callback-file-quit
   (procedure->pointer void callback-file-quit '(* * *)))
+
 
 (define (callback-edit-add-attrib *action *parameter *data)
   (menu_edit_newattrib *action *parameter *data))

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -97,12 +97,14 @@ Lepton EDA homepage: ~S
     (and (component? object)
          (true? (lepton_component_object_get_missing
                  (object->pointer object)))))
-  (when (any
-         (lambda (page)
-           (any missing-symbol? (page-contents page)))
-         (glist->list (lepton_list_get_glist
-                       (lepton_toplevel_get_pages *toplevel))
-                      pointer->page))
+
+  (define (page-with-missing-symbol? page)
+    (any missing-symbol? (page-contents page)))
+
+  (when (any page-with-missing-symbol?
+             (glist->list (lepton_list_get_glist
+                           (lepton_toplevel_get_pages *toplevel))
+                          pointer->page))
     ;; Dialog gives user option to quit.
     (x_dialog_missing_sym)))
 

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -156,6 +156,17 @@ Lepton EDA homepage: ~S
   (procedure->pointer void callback-file-export-csv '(* * *)))
 
 
+(define (quit-program return-code)
+  "Unconditionally quit the program with the given RETURN-CODE."
+  (s_clib_free)
+
+  (unless %m4-use-gtk3
+    (gtk_main_quit))
+
+  (exit return-code))
+
+
+
 (define (unsaved-data-dialog)
   (define *dialog (x_dialog_unsaved_data))
 
@@ -163,20 +174,20 @@ Lepton EDA homepage: ~S
 
   (let ((response (gtk_dialog_run *dialog)))
     (cond
-      ((= response GTK_RESPONSE_NO)
-       (attrib_quit 0))
-      ((= response GTK_RESPONSE_YES)
-       (s_toplevel_save_sheet %null-pointer
-                              %null-pointer
-                              %null-pointer)
-       (attrib_quit 0))
-      (else #f)))
+     ((= response GTK_RESPONSE_NO)
+      (quit-program 0))
+     ((= response GTK_RESPONSE_YES)
+      (s_toplevel_save_sheet %null-pointer
+                             %null-pointer
+                             %null-pointer)
+      (quit-program 0))
+     (else #f)))
 
   (gtk_widget_destroy *dialog))
 
 
 ;;; Quit the program using the UI. On execution, the function
-;;; checks for unsaved changes before calling attrib_quit() to
+;;; checks for unsaved changes before calling quit-program() to
 ;;; quit the program.
 (define (callback-file-quit *action *parameter *data)
   (save-geometry)
@@ -192,7 +203,7 @@ Lepton EDA homepage: ~S
 
   (if (true? (s_sheet_data_changed (attrib_get_sheet_data)))
       (unsaved-data-dialog)
-      (attrib_quit 0)))
+      (quit-program 0)))
 
 (define *callback-file-quit
   (procedure->pointer void callback-file-quit '(* * *)))

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -145,26 +145,22 @@ Lepton EDA homepage: ~S
     (config-save! config)))
 
 
-;;; Saves all the pages of *TOPLEVEL.
-(define (save-pages *toplevel)
+;;; Saves all toplevel pages.
+(define (save-pages)
   (for-each
-   (lambda (*page)
-     (if (true? (f_save *page
-                        (lepton_page_get_filename *page)
-                        %null-pointer))
-         (begin
-           (log! 'message
-                 (G_ "Saved ~S")
-                 (pointer->string (lepton_page_get_filename *page)))
-           ;; Reset the CHANGED flag of page.
-           (lepton_page_set_changed *page 0))
+   (lambda (page)
+     (let ((*page (page->pointer page))
+           (filename (page-filename page)))
+       (if (true? (f_save *page
+                          (string->pointer filename)
+                          %null-pointer))
+           (begin
+             (log! 'message (G_ "Saved ~S") filename)
+             ;; Reset the changed state of page.
+             (set-page-dirty! page #f))
 
-         (log! 'message
-               (G_ "Could NOT save ~S")
-               (pointer->string (lepton_page_get_filename *page)))))
-   (glist->list
-    (lepton_list_get_glist (lepton_toplevel_get_pages *toplevel))
-    identity)))
+           (log! 'message (G_ "Could NOT save ~S") filename))))
+   (active-pages)))
 
 
 ;;; Copies data from gtksheet into LeptonToplevel struct.  The
@@ -192,7 +188,7 @@ Lepton EDA homepage: ~S
     identity))
 
   ;; Save all pages in design.
-  (save-pages *toplevel)
+  (save-pages)
   (s_sheet_data_set_changed (attrib_get_sheet_data) FALSE))
 
 

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -131,6 +131,11 @@ Lepton EDA homepage: ~S
 (define *callback-edit-add-attrib
   (procedure->pointer void callback-edit-add-attrib '(* * *)))
 
+(define (callback-edit-delete-attrib *action *parameter *data)
+  (menu_edit_delattrib *action *parameter *data))
+(define *callback-edit-delete-attrib
+  (procedure->pointer void callback-edit-delete-attrib '(* * *)))
+
 
 (define (init-callbacks)
   (attrib_window_set_menu_callback (string->pointer "file-save")
@@ -140,7 +145,9 @@ Lepton EDA homepage: ~S
   (attrib_window_set_menu_callback (string->pointer "file-quit")
                                    *callback-file-quit)
   (attrib_window_set_menu_callback (string->pointer "edit-add-attrib")
-                                   *callback-edit-add-attrib))
+                                   *callback-edit-add-attrib)
+  (attrib_window_set_menu_callback (string->pointer "edit-delete-attrib")
+                                   *callback-edit-delete-attrib))
 
 (define (init-window)
   (define *window-widget (attrib_get_window))

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -19,9 +19,11 @@
 
 (use-modules (ice-9 getopt-long)
              (ice-9 receive)
+             (rnrs bytevectors)
              (srfi srfi-1)
              (system foreign)
 
+             (lepton config)
              (lepton ffi boolean)
              (lepton ffi glib)
              (lepton ffi gobject)
@@ -111,6 +113,38 @@ Lepton EDA homepage: ~S
   (any page-with-missing-symbol? (active-pages)))
 
 
+;;; Save main window's geometry to the cache config context.
+;;; Almost the same function as in the module (schematic window).
+(define (save-geometry)
+  (define *main-window (attrib_get_window))
+  (define (get-int bv)
+    (bytevector-sint-ref bv 0 (native-endianness) (sizeof int)))
+  (define x-bv (make-bytevector (sizeof int) 0))
+  (define y-bv (make-bytevector (sizeof int) 0))
+  (define width-bv (make-bytevector (sizeof int) 0))
+  (define height-bv (make-bytevector (sizeof int) 0))
+
+  (gtk_window_get_position *main-window
+                           (bytevector->pointer x-bv)
+                           (bytevector->pointer y-bv))
+
+  (gtk_window_get_size *main-window
+                       (bytevector->pointer width-bv)
+                       (bytevector->pointer height-bv))
+
+  (let ((config (cache-config-context))
+        (x (get-int x-bv))
+        (y (get-int y-bv))
+        (width (get-int width-bv))
+        (height (get-int height-bv)))
+    (set-config! config "attrib.window-geometry" "x" x)
+    (set-config! config "attrib.window-geometry" "y" y)
+    (set-config! config "attrib.window-geometry" "width" width)
+    (set-config! config "attrib.window-geometry" "height" height)
+
+    (config-save! config)))
+
+
 (define (callback-file-save *action *parameter *data)
   (s_toplevel_save_sheet *action *parameter *data))
 (define *callback-file-save
@@ -122,6 +156,7 @@ Lepton EDA homepage: ~S
   (procedure->pointer void callback-file-export-csv '(* * *)))
 
 (define (callback-file-quit *action *parameter *data)
+  (save-geometry)
   (attrib_really_quit *action *parameter *data))
 (define *callback-file-quit
   (procedure->pointer void callback-file-quit '(* * *)))

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -318,6 +318,13 @@ failure."
 
 (define (init-window)
   (define *window-widget (attrib_get_window))
+  (define cache-config (cache-config-context))
+  (define x (config-int cache-config "attrib.window-geometry" "x"))
+  (define y (config-int cache-config "attrib.window-geometry" "y"))
+  (define width
+    (config-int cache-config "attrib.window-geometry" "width" ))
+  (define height
+    (config-int cache-config "attrib.window-geometry" "height"))
 
   (g_signal_connect *window-widget
                     (string->pointer "delete_event")
@@ -327,7 +334,13 @@ failure."
   ;; Init menu functions.
   (init-callbacks)
 
-  (x_window_init))
+  (x_window_init)
+
+  ;; Restore main window's geometry.
+  (gtk_window_move *window-widget x y)
+
+  (when (and (> width 0) (> height 0))
+    (gtk_window_resize *window-widget width height)))
 
 
 (define (activate *app *toplevel)

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -83,6 +83,10 @@ Lepton EDA homepage: ~S
   (process-gafrc "lepton-attrib" name))
 
 
+(define (verify-design *toplevel)
+  (s_toplevel_verify_design *toplevel))
+
+
 (define (activate *app *toplevel)
   (define *window-widget (attrib_window_new *app))
   (define *sheet-data (s_sheet_data_new))
@@ -178,7 +182,7 @@ Lepton EDA homepage: ~S
   ;; function to update the GtkSheet itself.
   (x_window_add_items)
   ;; Verify correctness of entire design.
-  (s_toplevel_verify_design *toplevel)
+  (verify-design *toplevel)
 
   (x_window_set_title *pages)
 

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -29,6 +29,8 @@
              (lepton init)
              (lepton log)
              (lepton page)
+             (lepton object foreign)
+             (lepton object)
              (lepton rc)
              (lepton toplevel foreign)
              (lepton toplevel)
@@ -94,7 +96,7 @@ Lepton EDA homepage: ~S
             (lambda (*object)
               ;; Look for object, and verify that it has a symbol
               ;; file attached and signal that problem exists.
-              (and (true? (lepton_object_is_component *object))
+              (and (component? (pointer->object *object))
                    (true? (lepton_component_object_get_missing *object))))
             (glist->list (lepton_page_objects *page) identity)))
          (glist->list (lepton_list_get_glist

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -111,6 +111,11 @@ Lepton EDA homepage: ~S
   (any page-with-missing-symbol? (active-pages)))
 
 
+(define (callback-file-save *action *parameter *data)
+  (s_toplevel_save_sheet *action *parameter *data))
+(define *callback-file-save
+  (procedure->pointer void callback-file-save '(* * *)))
+
 (define (callback-file-quit *action *parameter *data)
   (attrib_really_quit *action *parameter *data))
 (define *callback-file-quit
@@ -118,6 +123,8 @@ Lepton EDA homepage: ~S
 
 
 (define (init-callbacks)
+  (attrib_window_set_menu_callback (string->pointer "file-save")
+                                   *callback-file-save)
   (attrib_window_set_menu_callback (string->pointer "file-quit")
                                    *callback-file-quit))
 

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -93,12 +93,13 @@ Lepton EDA homepage: ~S
   (when (any
          (lambda (*page)
            (any
-            (lambda (*object)
+            (lambda (object)
               ;; Look for object, and verify that it has a symbol
               ;; file attached and signal that problem exists.
-              (and (component? (pointer->object *object))
-                   (true? (lepton_component_object_get_missing *object))))
-            (glist->list (lepton_page_objects *page) identity)))
+              (and (component? object)
+                   (true? (lepton_component_object_get_missing
+                           (object->pointer object)))))
+            (glist->list (lepton_page_objects *page) pointer->object)))
          (glist->list (lepton_list_get_glist
                        (lepton_toplevel_get_pages *toplevel))
                       identity))

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -157,7 +157,8 @@ Lepton EDA homepage: ~S
 
 
 (define (unsaved-data-dialog)
-  (x_dialog_unsaved_data))
+  (define *dialog (x_dialog_unsaved_data))
+  (gtk_widget_destroy *dialog))
 
 
 ;;; Quit the program using the UI. On execution, the function

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -146,6 +146,11 @@ Lepton EDA homepage: ~S
 (define *callback-visibility-name-only
   (procedure->pointer void callback-visibility-name-only '(* * *)))
 
+(define (callback-visibility-value-only *action *parameter *data)
+  (s_visibility_set_value_only *action *parameter *data))
+(define *callback-visibility-value-only
+  (procedure->pointer void callback-visibility-value-only '(* * *)))
+
 
 (define (init-callbacks)
   (attrib_window_set_menu_callback (string->pointer "file-save")
@@ -161,7 +166,9 @@ Lepton EDA homepage: ~S
   (attrib_window_set_menu_callback (string->pointer "visibility-invisible")
                                    *callback-visibility-invisible)
   (attrib_window_set_menu_callback (string->pointer "visibility-name-only")
-                                   *callback-visibility-name-only))
+                                   *callback-visibility-name-only)
+  (attrib_window_set_menu_callback (string->pointer "visibility-value-only")
+                                   *callback-visibility-value-only))
 
 (define (init-window)
   (define *window-widget (attrib_get_window))

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -145,15 +145,19 @@ Lepton EDA homepage: ~S
     (config-save! config)))
 
 
+(define (save-page page filename)
+  "Saves PAGE under FILENAME returning #t on success, or #f on
+failure."
+  (define *page (check-page page 1))
+  (true? (f_save *page (string->pointer filename) %null-pointer)))
+
+
 ;;; Saves all toplevel pages.
 (define (save-pages)
   (for-each
    (lambda (page)
-     (let ((*page (page->pointer page))
-           (filename (page-filename page)))
-       (if (true? (f_save *page
-                          (string->pointer filename)
-                          %null-pointer))
+     (let ((filename (page-filename page)))
+       (if (save-page page filename)
            (begin
              (log! 'message (G_ "Saved ~S") filename)
              ;; Reset the changed state of page.

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -141,6 +141,11 @@ Lepton EDA homepage: ~S
 (define *callback-visibility-invisible
   (procedure->pointer void callback-visibility-invisible '(* * *)))
 
+(define (callback-visibility-name-only *action *parameter *data)
+  (s_visibility_set_name_only *action *parameter *data))
+(define *callback-visibility-name-only
+  (procedure->pointer void callback-visibility-name-only '(* * *)))
+
 
 (define (init-callbacks)
   (attrib_window_set_menu_callback (string->pointer "file-save")
@@ -154,7 +159,9 @@ Lepton EDA homepage: ~S
   (attrib_window_set_menu_callback (string->pointer "edit-delete-attrib")
                                    *callback-edit-delete-attrib)
   (attrib_window_set_menu_callback (string->pointer "visibility-invisible")
-                                   *callback-visibility-invisible))
+                                   *callback-visibility-invisible)
+  (attrib_window_set_menu_callback (string->pointer "visibility-name-only")
+                                   *callback-visibility-name-only))
 
 (define (init-window)
   (define *window-widget (attrib_get_window))

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -145,6 +145,28 @@ Lepton EDA homepage: ~S
     (config-save! config)))
 
 
+;;; Saves all the pages of *TOPLEVEL.
+(define (save-pages *toplevel)
+  (for-each
+   (lambda (*page)
+     (if (true? (f_save *page
+                        (lepton_page_get_filename *page)
+                        %null-pointer))
+         (begin
+           (log! 'message
+                 (G_ "Saved ~S")
+                 (pointer->string (lepton_page_get_filename *page)))
+           ;; Reset the CHANGED flag of page.
+           (lepton_page_set_changed *page 0))
+
+         (log! 'message
+               (G_ "Could NOT save ~S")
+               (pointer->string (lepton_page_get_filename *page)))))
+   (glist->list
+    (lepton_list_get_glist (lepton_toplevel_get_pages *toplevel))
+    identity)))
+
+
 ;;; Copies data from gtksheet into LeptonToplevel struct.  The
 ;;; function is called when the user invokes File -> Save.  It
 ;;; first places all data from gtksheet into SHEET_DATA.  Then it
@@ -170,7 +192,7 @@ Lepton EDA homepage: ~S
     identity))
 
   ;; Save all pages in design.
-  (save_toplevel_pages *toplevel)
+  (save-pages *toplevel)
   (s_sheet_data_set_changed (attrib_get_sheet_data) FALSE))
 
 

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -111,13 +111,26 @@ Lepton EDA homepage: ~S
   (any page-with-missing-symbol? (active-pages)))
 
 
+(define (callback-file-quit *action *parameter *data)
+  (attrib_really_quit *action *parameter *data))
+(define *callback-file-quit
+  (procedure->pointer void callback-file-quit '(* * *)))
+
+
+(define (init-callbacks)
+  (attrib_window_set_menu_callback (string->pointer "file-quit")
+                                   *callback-file-quit))
+
 (define (init-window)
   (define *window-widget (attrib_get_window))
 
   (g_signal_connect *window-widget
                     (string->pointer "delete_event")
-                    *attrib_really_quit
+                    *callback-file-quit
                     %null-pointer)
+
+  ;; Init menu functions.
+  (init-callbacks)
 
   (x_window_init))
 

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -126,6 +126,11 @@ Lepton EDA homepage: ~S
 (define *callback-file-quit
   (procedure->pointer void callback-file-quit '(* * *)))
 
+(define (callback-edit-add-attrib *action *parameter *data)
+  (menu_edit_newattrib *action *parameter *data))
+(define *callback-edit-add-attrib
+  (procedure->pointer void callback-edit-add-attrib '(* * *)))
+
 
 (define (init-callbacks)
   (attrib_window_set_menu_callback (string->pointer "file-save")
@@ -133,7 +138,9 @@ Lepton EDA homepage: ~S
   (attrib_window_set_menu_callback (string->pointer "file-export-csv")
                                    *callback-file-export-csv)
   (attrib_window_set_menu_callback (string->pointer "file-quit")
-                                   *callback-file-quit))
+                                   *callback-file-quit)
+  (attrib_window_set_menu_callback (string->pointer "edit-add-attrib")
+                                   *callback-edit-add-attrib))
 
 (define (init-window)
   (define *window-widget (attrib_get_window))

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -90,7 +90,7 @@ Lepton EDA homepage: ~S
 ;;; Verifies the entire design by looping through all objects in
 ;;; the design looking for missing components, that is, those
 ;;; components for which no corresponding symbol files was found.
-(define (verify-design *toplevel)
+(define (design-has-missing-symbols?)
   (define (missing-symbol? object)
     ;; Look for object, and verify that it has a symbol file
     ;; attached and signal that problem exists.
@@ -101,9 +101,7 @@ Lepton EDA homepage: ~S
   (define (page-with-missing-symbol? page)
     (any missing-symbol? (page-contents page)))
 
-  (when (any page-with-missing-symbol? (active-pages))
-    ;; Dialog gives user option to quit.
-    (x_dialog_missing_sym)))
+  (any page-with-missing-symbol? (active-pages)))
 
 
 (define (activate *app *toplevel)
@@ -201,7 +199,9 @@ Lepton EDA homepage: ~S
   ;; function to update the GtkSheet itself.
   (x_window_add_items)
   ;; Verify correctness of entire design.
-  (verify-design *toplevel)
+  (when (design-has-missing-symbols?)
+    ;; Dialog gives user option to quit.
+    (x_dialog_missing_sym))
 
   (x_window_set_title *pages)
 

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -116,6 +116,11 @@ Lepton EDA homepage: ~S
 (define *callback-file-save
   (procedure->pointer void callback-file-save '(* * *)))
 
+(define (callback-file-export-csv *action *parameter *data)
+  (menu_file_export_csv *action *parameter *data))
+(define *callback-file-export-csv
+  (procedure->pointer void callback-file-export-csv '(* * *)))
+
 (define (callback-file-quit *action *parameter *data)
   (attrib_really_quit *action *parameter *data))
 (define *callback-file-quit
@@ -125,6 +130,8 @@ Lepton EDA homepage: ~S
 (define (init-callbacks)
   (attrib_window_set_menu_callback (string->pointer "file-save")
                                    *callback-file-save)
+  (attrib_window_set_menu_callback (string->pointer "file-export-csv")
+                                   *callback-file-export-csv)
   (attrib_window_set_menu_callback (string->pointer "file-quit")
                                    *callback-file-quit))
 

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -24,6 +24,7 @@
 
              (lepton ffi boolean)
              (lepton ffi glib)
+             (lepton ffi gobject)
              (lepton ffi)
              (lepton file-system)
              (lepton init)
@@ -111,6 +112,13 @@ Lepton EDA homepage: ~S
 
 
 (define (init-window)
+  (define *window-widget (attrib_get_window))
+
+  (g_signal_connect *window-widget
+                    (string->pointer "delete_event")
+                    *attrib_really_quit
+                    %null-pointer)
+
   (x_window_init))
 
 

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -136,6 +136,11 @@ Lepton EDA homepage: ~S
 (define *callback-edit-delete-attrib
   (procedure->pointer void callback-edit-delete-attrib '(* * *)))
 
+(define (callback-visibility-invisible *action *parameter *data)
+  (s_visibility_set_invisible *action *parameter *data))
+(define *callback-visibility-invisible
+  (procedure->pointer void callback-visibility-invisible '(* * *)))
+
 
 (define (init-callbacks)
   (attrib_window_set_menu_callback (string->pointer "file-save")
@@ -147,7 +152,9 @@ Lepton EDA homepage: ~S
   (attrib_window_set_menu_callback (string->pointer "edit-add-attrib")
                                    *callback-edit-add-attrib)
   (attrib_window_set_menu_callback (string->pointer "edit-delete-attrib")
-                                   *callback-edit-delete-attrib))
+                                   *callback-edit-delete-attrib)
+  (attrib_window_set_menu_callback (string->pointer "visibility-invisible")
+                                   *callback-visibility-invisible))
 
 (define (init-window)
   (define *window-widget (attrib_get_window))

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -154,17 +154,17 @@ failure."
 
 ;;; Saves all toplevel pages.
 (define (save-pages)
-  (for-each
-   (lambda (page)
-     (let ((filename (page-filename page)))
-       (if (save-page page filename)
-           (begin
-             (log! 'message (G_ "Saved ~S") filename)
-             ;; Reset the changed state of page.
-             (set-page-dirty! page #f))
+  (define (save page)
+    (let ((filename (page-filename page)))
+      (if (save-page page filename)
+          (begin
+            (log! 'message (G_ "Saved ~S") filename)
+            ;; Reset the changed state of page.
+            (set-page-dirty! page #f))
 
-           (log! 'message (G_ "Could NOT save ~S") filename))))
-   (active-pages)))
+          (log! 'message (G_ "Could NOT save ~S") filename))))
+
+  (for-each save (active-pages)))
 
 
 ;;; Copies data from gtksheet into LeptonToplevel struct.  The

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -22,6 +22,7 @@
              (srfi srfi-1)
              (system foreign)
 
+             (lepton ffi boolean)
              (lepton ffi glib)
              (lepton ffi)
              (lepton file-system)
@@ -83,8 +84,24 @@ Lepton EDA homepage: ~S
   (process-gafrc "lepton-attrib" name))
 
 
+;;; Verifies the entire design by looping through all objects in
+;;; the design looking for missing components, that is, those
+;;; components for which no corresponding symbol files was found.
 (define (verify-design *toplevel)
-  (s_toplevel_verify_design *toplevel))
+  (when (any
+         (lambda (*page)
+           (any
+            (lambda (*object)
+              ;; Look for object, and verify that it has a symbol
+              ;; file attached and signal that problem exists.
+              (and (true? (lepton_object_is_component *object))
+                   (true? (lepton_component_object_get_missing *object))))
+            (glist->list (lepton_page_objects *page) identity)))
+         (glist->list (lepton_list_get_glist
+                       (lepton_toplevel_get_pages *toplevel))
+                      identity))
+    ;; Dialog gives user option to quit.
+    (x_dialog_missing_sym)))
 
 
 (define (activate *app *toplevel)

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -28,6 +28,7 @@
              (lepton file-system)
              (lepton init)
              (lepton log)
+             (lepton page foreign)
              (lepton page)
              (lepton object foreign)
              (lepton object)
@@ -97,12 +98,11 @@ Lepton EDA homepage: ~S
          (true? (lepton_component_object_get_missing
                  (object->pointer object)))))
   (when (any
-         (lambda (*page)
-           (any missing-symbol?
-                (glist->list (lepton_page_objects *page) pointer->object)))
+         (lambda (page)
+           (any missing-symbol? (page-contents page)))
          (glist->list (lepton_list_get_glist
                        (lepton_toplevel_get_pages *toplevel))
-                      identity))
+                      pointer->page))
     ;; Dialog gives user option to quit.
     (x_dialog_missing_sym)))
 

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -151,6 +151,11 @@ Lepton EDA homepage: ~S
 (define *callback-visibility-value-only
   (procedure->pointer void callback-visibility-value-only '(* * *)))
 
+(define (callback-visibility-name-value *action *parameter *data)
+  (s_visibility_set_name_and_value *action *parameter *data))
+(define *callback-visibility-name-value
+  (procedure->pointer void callback-visibility-name-value '(* * *)))
+
 
 (define (init-callbacks)
   (attrib_window_set_menu_callback (string->pointer "file-save")
@@ -168,7 +173,9 @@ Lepton EDA homepage: ~S
   (attrib_window_set_menu_callback (string->pointer "visibility-name-only")
                                    *callback-visibility-name-only)
   (attrib_window_set_menu_callback (string->pointer "visibility-value-only")
-                                   *callback-visibility-value-only))
+                                   *callback-visibility-value-only)
+  (attrib_window_set_menu_callback (string->pointer "visibility-name-value")
+                                   *callback-visibility-name-value))
 
 (define (init-window)
   (define *window-widget (attrib_get_window))

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -214,14 +214,14 @@ Lepton EDA homepage: ~S
     (gtk_window_set_title
      *window-widget
      (string->pointer
-      (if (= page-count 1)
-          (string-append
-           (basename (page-filename (car (active-pages))))
-           " - "
-           %program-basename)
-          (if (> page-count 1)
-              (string-append (G_ "Multiple files") " - " %program-basename)
-              %program-basename)))))
+      (cond
+       ((= page-count 1)
+        (string-append (basename (page-filename (car (active-pages))))
+                       " - "
+                       %program-basename))
+       ((> page-count 1)
+        (string-append (G_ "Multiple files") " - " %program-basename))
+       (else %program-basename)))))
 
   ;; Set default icon.
   (gtk_window_set_default_icon_name (string->pointer %theme-icon-name))

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -145,8 +145,12 @@ Lepton EDA homepage: ~S
     (config-save! config)))
 
 
+(define (save-sheet)
+  (s_toplevel_save_sheet %null-pointer %null-pointer %null-pointer))
+
+
 (define (callback-file-save *action *parameter *data)
-  (s_toplevel_save_sheet *action *parameter *data))
+  (save-sheet))
 (define *callback-file-save
   (procedure->pointer void callback-file-save '(* * *)))
 
@@ -177,9 +181,7 @@ Lepton EDA homepage: ~S
      ((= response GTK_RESPONSE_NO)
       (quit-program 0))
      ((= response GTK_RESPONSE_YES)
-      (s_toplevel_save_sheet %null-pointer
-                             %null-pointer
-                             %null-pointer)
+      (save-sheet)
       (quit-program 0))
      (else #f)))
 

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -145,8 +145,33 @@ Lepton EDA homepage: ~S
     (config-save! config)))
 
 
+;;; Copies data from gtksheet into LeptonToplevel struct.  The
+;;; function is called when the user invokes File -> Save.  It
+;;; first places all data from gtksheet into SHEET_DATA.  Then it
+;;; loops through all pages and saves them.
 (define (save-sheet)
-  (s_toplevel_save_sheet %null-pointer %null-pointer %null-pointer))
+  (define *toplevel (attrib_get_toplevel))
+
+  (when (null-pointer? *toplevel)
+    (error "NULL toplevel."))
+
+  ;; Read data from gtksheet into SHEET_DATA.
+  (s_sheet_data_gtksheet_to_sheetdata)
+
+  ;; Iterate over all pages in design.
+  (for-each
+   (lambda (*page)
+     ;; Only traverse pages which are toplevel.
+     (when (zero? (lepton_page_get_page_control *page))
+       ;; Add all objects from page.
+       (s_toplevel_sheetdata_to_toplevel *toplevel *page)))
+   (glist->list
+    (lepton_list_get_glist (lepton_toplevel_get_pages *toplevel))
+    identity))
+
+  ;; Save all pages in design.
+  (save_toplevel_pages *toplevel)
+  (s_sheet_data_set_changed (attrib_get_sheet_data) FALSE))
 
 
 (define (callback-file-save *action *parameter *data)

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -42,6 +42,7 @@
              (attrib ffi))
 
 
+(define %program-basename (basename (car (program-arguments))))
 (define %theme-icon-name "lepton-attrib")
 
 
@@ -74,7 +75,7 @@ Options:
 Report bugs at ~S
 Lepton EDA homepage: ~S
 ")
-          (basename (car (program-arguments)))
+          %program-basename
           (lepton-version-ref 'bugs)
           (lepton-version-ref 'url))
 
@@ -208,8 +209,7 @@ Lepton EDA homepage: ~S
     (x_dialog_missing_sym))
 
   ;; Set the main window's title.
-  (let ((program-name (basename (car (program-arguments))))
-        (page-count (length (active-pages))))
+  (let ((page-count (length (active-pages))))
     (gtk_window_set_title
      *window-widget
      (string->pointer
@@ -217,10 +217,10 @@ Lepton EDA homepage: ~S
           (string-append
            (basename (page-filename (car (active-pages))))
            " - "
-           program-name)
+           %program-basename)
           (if (> page-count 1)
-              (string-append (G_ "Multiple files") " - " program-name)
-              program-name)))))
+              (string-append (G_ "Multiple files") " - " %program-basename)
+              %program-basename)))))
 
   ;; Set default icon.
   (gtk_window_set_default_icon_name (string->pointer %theme-icon-name))


### PR DESCRIPTION
- A variable defining program basename has been factored out and the fixed program name string has been replaced with the variable.
- GTK dialog response signal definitions have been added.
- The *delete_event* signal is connected to program window widget in Scheme.
- A callback setter function has been introduced.  The menu callbacks, used also in various other places in the code, are now replaced with callbacks set in Scheme.  Those are:
  - `attrib_really_quit()` => `file-quit()`
  - `s_toplevel_save_sheet()` => `file-save()`
  - `menu_file_export_csv()` => `file-export-csv()`
  - `menu_edit_newattrib()` => `edit-add-attrib()`
  - `menu_edit_delattrib()` => `edit-delete-attrib()`
  - `s_visibility_set_invisible()` => `visibility-invisible()`
  - `s_visibility_set_name_only()` => `visibility-name-only()`
  - `s_visibility_set_value_only()` => `visibility-value-only()`
  - `s_visibility_set_name_and_value()` => `visibility-name-value()`
  - `x_dialog_about_dialog()` => `help-about()`
- The following accessors have been introduced:
  - A getter for the number of sheets, `attrib_get_sheets_number()`
  - A getter for a sheet from the list of sheets, `attrib_get_sheet()`
  - A getter for the main notebook widget, `attrib_get_notebook()`
- Several functions have been rewritten in Scheme.  Many of them have been refactored using stock Scheme functions from Lepton library instead of using lowlevel FFI C accessors.  Those are:
  - `s_toplevel_verify_design()`
  - `x_window_set_title()`
  - `attrib_really_quit()`
  - `x_dialog_unsaved_data()` (partially)
  - `attrib_quit()`
  - `s_toplevel_save_sheet()`
  - `save_toplevel_pages()`
  - `menu_file_export_csv()`
  - `menu_edit_newattrib()`
  - `menu_edit_delattrib()`
- Main program window geometry is now saved and restored in Scheme.
- Doxygen comments have been added for several functions and variables.
