### PR TITLE
lepton-attrib: Rewrite some dialogs in Scheme

### DIFF
--- a/lepton-eda/scheme/attrib/ffi.scm
+++ b/lepton-eda/scheme/attrib/ffi.scm
@@ -154,7 +154,7 @@
 (define-lff x_dialog_export_file void '())
 (define-lff x_dialog_fatal_error void (list '* int))
 (define-lff x_dialog_missing_sym void '())
-(define-lff x_dialog_newattrib '* '())
+(define-lff x_dialog_newattrib '* '(*))
 (define-lff x_dialog_unimplemented_feature void '())
 (define-lff x_dialog_unsaved_data '* '())
 

--- a/lepton-eda/scheme/attrib/ffi.scm
+++ b/lepton-eda/scheme/attrib/ffi.scm
@@ -40,7 +40,6 @@
             x_fileselect_open
 
             x_dialog_about_dialog
-            x_dialog_delattrib
             x_dialog_export_file
             x_dialog_fatal_error
             x_dialog_missing_sym
@@ -99,6 +98,7 @@
             s_table_add_toplevel_pin_items_to_pin_table
 
             s_toplevel_add_new_attrib
+            s_toplevel_delete_attrib_col
             s_toplevel_sheetdata_to_toplevel
 
             s_visibility_set_invisible
@@ -152,7 +152,6 @@
 
 ;;; x_dialog.c
 (define-lff x_dialog_about_dialog void '(* * *))
-(define-lff x_dialog_delattrib void '(*))
 (define-lff x_dialog_export_file void '())
 (define-lff x_dialog_fatal_error void (list '* int))
 (define-lff x_dialog_missing_sym void '())
@@ -217,6 +216,7 @@
 ;;; s_toplevel.c
 (define-lff s_toplevel_sheetdata_to_toplevel void '(* *))
 (define-lff s_toplevel_add_new_attrib void '(*))
+(define-lff s_toplevel_delete_attrib_col void '())
 
 ;;; s_visibility.c
 (define-lff s_visibility_set_invisible void '(* * *))

--- a/lepton-eda/scheme/attrib/ffi.scm
+++ b/lepton-eda/scheme/attrib/ffi.scm
@@ -50,6 +50,8 @@
             x_gtksheet_add_cell_item
             x_gtksheet_add_col_labels
             x_gtksheet_add_row_labels
+            x_gtksheet_get_max_col
+            x_gtksheet_get_min_col
             x_gtksheet_init
 
             attrib_sheet_data_get_component_attrib_count
@@ -161,6 +163,8 @@
 (define-lff x_gtksheet_add_cell_item void (list '* int int '* int int))
 (define-lff x_gtksheet_add_col_labels void (list '* int '*))
 (define-lff x_gtksheet_add_row_labels void (list '* int '*))
+(define-lff x_gtksheet_get_max_col int '(*))
+(define-lff x_gtksheet_get_min_col int '(*))
 (define-lff x_gtksheet_init void '())
 
 ;;; s_sheet_data.c

--- a/lepton-eda/scheme/attrib/ffi.scm
+++ b/lepton-eda/scheme/attrib/ffi.scm
@@ -154,7 +154,7 @@
 (define-lff x_dialog_export_file void '())
 (define-lff x_dialog_fatal_error void (list '* int))
 (define-lff x_dialog_missing_sym void '())
-(define-lff x_dialog_newattrib void '())
+(define-lff x_dialog_newattrib '* '())
 (define-lff x_dialog_unimplemented_feature void '())
 (define-lff x_dialog_unsaved_data '* '())
 

--- a/lepton-eda/scheme/attrib/ffi.scm
+++ b/lepton-eda/scheme/attrib/ffi.scm
@@ -151,7 +151,7 @@
 
 ;;; x_dialog.c
 (define-lff x_dialog_about_dialog void '(* * *))
-(define-lff x_dialog_export_file void '())
+(define-lff x_dialog_export_file void '(*))
 (define-lff x_dialog_fatal_error void (list '* int))
 (define-lff x_dialog_unimplemented_feature void '())
 (define-lff x_dialog_unsaved_data '* '())

--- a/lepton-eda/scheme/attrib/ffi.scm
+++ b/lepton-eda/scheme/attrib/ffi.scm
@@ -150,7 +150,7 @@
 
 ;;; x_dialog.c
 (define-lff x_dialog_about_dialog void '(* * *))
-(define-lff x_dialog_delattrib void '())
+(define-lff x_dialog_delattrib void '(*))
 (define-lff x_dialog_export_file void '())
 (define-lff x_dialog_fatal_error void (list '* int))
 (define-lff x_dialog_missing_sym void '())

--- a/lepton-eda/scheme/attrib/ffi.scm
+++ b/lepton-eda/scheme/attrib/ffi.scm
@@ -42,7 +42,6 @@
             x_dialog_about_dialog
             x_dialog_export_file
             x_dialog_fatal_error
-            x_dialog_missing_sym
             x_dialog_unimplemented_feature
             x_dialog_unsaved_data
 
@@ -154,7 +153,6 @@
 (define-lff x_dialog_about_dialog void '(* * *))
 (define-lff x_dialog_export_file void '())
 (define-lff x_dialog_fatal_error void (list '* int))
-(define-lff x_dialog_missing_sym void '())
 (define-lff x_dialog_unimplemented_feature void '())
 (define-lff x_dialog_unsaved_data '* '())
 

--- a/lepton-eda/scheme/attrib/ffi.scm
+++ b/lepton-eda/scheme/attrib/ffi.scm
@@ -44,7 +44,6 @@
             x_dialog_export_file
             x_dialog_fatal_error
             x_dialog_missing_sym
-            x_dialog_newattrib
             x_dialog_unimplemented_feature
             x_dialog_unsaved_data
 
@@ -97,6 +96,7 @@
             s_table_add_toplevel_net_items_to_net_table
             s_table_add_toplevel_pin_items_to_pin_table
 
+            s_toplevel_add_new_attrib
             s_toplevel_sheetdata_to_toplevel
 
             s_visibility_set_invisible
@@ -154,7 +154,6 @@
 (define-lff x_dialog_export_file void '())
 (define-lff x_dialog_fatal_error void (list '* int))
 (define-lff x_dialog_missing_sym void '())
-(define-lff x_dialog_newattrib '* '(*))
 (define-lff x_dialog_unimplemented_feature void '())
 (define-lff x_dialog_unsaved_data '* '())
 
@@ -213,6 +212,7 @@
 
 ;;; s_toplevel.c
 (define-lff s_toplevel_sheetdata_to_toplevel void '(* *))
+(define-lff s_toplevel_add_new_attrib void '(*))
 
 ;;; s_visibility.c
 (define-lff s_visibility_set_invisible void '(* * *))

--- a/lepton-eda/scheme/attrib/ffi.scm
+++ b/lepton-eda/scheme/attrib/ffi.scm
@@ -40,10 +40,12 @@
             x_fileselect_open
 
             x_dialog_about_dialog
-            x_dialog_export_file
+            x_dialog_confirm_overwrite
             x_dialog_fatal_error
             x_dialog_unimplemented_feature
             x_dialog_unsaved_data
+
+            f_export_components
 
             x_gtksheet_add_cell_item
             x_gtksheet_add_col_labels
@@ -151,10 +153,13 @@
 
 ;;; x_dialog.c
 (define-lff x_dialog_about_dialog void '(* * *))
-(define-lff x_dialog_export_file void '(*))
+(define-lff x_dialog_confirm_overwrite int '(*))
 (define-lff x_dialog_fatal_error void (list '* int))
 (define-lff x_dialog_unimplemented_feature void '())
 (define-lff x_dialog_unsaved_data '* '())
+
+;;; f_export.c
+(define-lff f_export_components void '(*))
 
 ;;; x_gtksheet.c
 (define-lff x_gtksheet_add_cell_item void (list '* int int '* int int))

--- a/lepton-eda/scheme/schematic/ffi.scm
+++ b/lepton-eda/scheme/schematic/ffi.scm
@@ -42,6 +42,8 @@
 
             gdk_window_type_hint_to_string
             gdk_string_to_window_type_hint
+            gtk_buttons_type_to_string
+            gtk_string_to_buttons_type
             gtk_policy_to_string
             gtk_string_to_policy
             gtk_response_to_string
@@ -718,6 +720,8 @@
 ;;; gtk_helper.c
 (define-lff gdk_window_type_hint_to_string '* (list int))
 (define-lff gdk_string_to_window_type_hint int '(*))
+(define-lff gtk_buttons_type_to_string '* (list int))
+(define-lff gtk_string_to_buttons_type int '(*))
 (define-lff gtk_policy_to_string '* (list int))
 (define-lff gtk_string_to_policy int '(*))
 (define-lff gtk_response_to_string '* (list int))

--- a/lepton-eda/scheme/schematic/ffi.scm
+++ b/lepton-eda/scheme/schematic/ffi.scm
@@ -44,6 +44,8 @@
             gdk_string_to_window_type_hint
             gtk_buttons_type_to_string
             gtk_string_to_buttons_type
+            gtk_message_type_to_string
+            gtk_string_to_message_type
             gtk_policy_to_string
             gtk_string_to_policy
             gtk_response_to_string
@@ -722,6 +724,8 @@
 (define-lff gdk_string_to_window_type_hint int '(*))
 (define-lff gtk_buttons_type_to_string '* (list int))
 (define-lff gtk_string_to_buttons_type int '(*))
+(define-lff gtk_message_type_to_string '* (list int))
+(define-lff gtk_string_to_message_type int '(*))
 (define-lff gtk_policy_to_string '* (list int))
 (define-lff gtk_string_to_policy int '(*))
 (define-lff gtk_response_to_string '* (list int))

--- a/lepton-eda/scheme/schematic/ffi.scm
+++ b/lepton-eda/scheme/schematic/ffi.scm
@@ -44,6 +44,8 @@
             gdk_string_to_window_type_hint
             gtk_buttons_type_to_string
             gtk_string_to_buttons_type
+            gtk_file_chooser_action_to_string
+            gtk_string_to_file_chooser_action
             gtk_message_type_to_string
             gtk_string_to_message_type
             gtk_policy_to_string
@@ -724,6 +726,8 @@
 (define-lff gdk_string_to_window_type_hint int '(*))
 (define-lff gtk_buttons_type_to_string '* (list int))
 (define-lff gtk_string_to_buttons_type int '(*))
+(define-lff gtk_file_chooser_action_to_string '* (list int))
+(define-lff gtk_string_to_file_chooser_action int '(*))
 (define-lff gtk_message_type_to_string '* (list int))
 (define-lff gtk_string_to_message_type int '(*))
 (define-lff gtk_policy_to_string '* (list int))

--- a/lepton-eda/scheme/schematic/ffi/gtk.scm
+++ b/lepton-eda/scheme/schematic/ffi/gtk.scm
@@ -55,6 +55,8 @@
             gtk_dialog_set_default_response
             gtk_dialog_run
 
+            gtk_entry_new
+            gtk_entry_set_max_length
             gtk_entry_get_text
             gtk_entry_get_text_length
             gtk_entry_set_text
@@ -213,6 +215,8 @@
 (define-lff gtk_dialog_set_default_response void (list '* int))
 (define-lff gtk_dialog_run int '(*))
 
+(define-lff gtk_entry_new '* '())
+(define-lff gtk_entry_set_max_length void (list '* int))
 (define-lff gtk_entry_get_text '* '(*))
 (define-lff gtk_entry_get_text_length uint16 '(*))
 (define-lff gtk_entry_set_text void '(* *))

--- a/lepton-eda/scheme/schematic/ffi/gtk.scm
+++ b/lepton-eda/scheme/schematic/ffi/gtk.scm
@@ -91,6 +91,8 @@
             gtk_menu_new
             gtk_menu_shell_append
 
+            gtk_message_dialog_new
+
             gtk_notebook_append_page
             gtk_notebook_get_n_pages
             gtk_notebook_new
@@ -250,6 +252,8 @@
 (define-lff gtk_menu_bar_new '* '())
 (define-lff gtk_menu_item_set_submenu void '(* *))
 (define-lff gtk_menu_shell_append void '(* *))
+
+(define-lff gtk_message_dialog_new '* (list '* int int int '*))
 
 (define-lff gtk_notebook_append_page int '(* * *))
 (define-lff gtk_notebook_get_n_pages int '(*))

--- a/lepton-eda/scheme/schematic/ffi/gtk.scm
+++ b/lepton-eda/scheme/schematic/ffi/gtk.scm
@@ -45,6 +45,11 @@
             gtk_container_add
             gtk_container_set_border_width
 
+            GTK_DIALOG_MODAL
+            GTK_DIALOG_DESTROY_WITH_PARENT
+            GTK_DIALOG_NO_SEPARATOR
+            GTK_DIALOG_USE_HEADER_BAR
+
             gtk_dialog_add_button
             gtk_dialog_get_content_area
             gtk_dialog_set_default_response
@@ -168,9 +173,6 @@
 (define-syntax-rule (define-lfc arg ...)
   (define-lfc-lib arg ... libgtk))
 
-;;; Defined in gtkdialog.h.
-(define GTK_DIALOG_DESTROY_WITH_PARENT 2)
-
 (define GdkModifierType uint32)
 
 
@@ -197,6 +199,14 @@
 
 (define-lff gtk_container_add void '(* *))
 (define-lff gtk_container_set_border_width void (list '* unsigned-int))
+
+;;; gtkdialog.h
+(define GTK_DIALOG_MODAL (ash 1 0))
+(define GTK_DIALOG_DESTROY_WITH_PARENT (ash 1 1))
+;;; GTK2
+(define GTK_DIALOG_NO_SEPARATOR (ash 1 2))
+;;; GTK3
+(define GTK_DIALOG_USE_HEADER_BAR (ash 1 2))
 
 (define-lff gtk_dialog_add_button '* (list '* '* int))
 (define-lff gtk_dialog_get_content_area '* '(*))

--- a/lepton-eda/scheme/schematic/gtk/helper.scm
+++ b/lepton-eda/scheme/schematic/gtk/helper.scm
@@ -1,6 +1,6 @@
 ;;; Lepton EDA Schematic Capture
 ;;; Scheme API
-;;; Copyright (C) 2023-2025 Lepton EDA Contributors
+;;; Copyright (C) 2023-2026 Lepton EDA Contributors
 ;;;
 ;;; This program is free software; you can redistribute it and/or modify
 ;;; it under the terms of the GNU General Public License as published by
@@ -23,6 +23,8 @@
 
   #:export (gtk-buttons-type->symbol
             symbol->gtk-buttons-type
+            gtk-file-chooser-action->symbol
+            symbol->gtk-file-chooser-action
             gtk-message-type->symbol
             symbol->gtk-message-type
             gtk-response->symbol
@@ -35,6 +37,17 @@
 (define (symbol->gtk-buttons-type sym)
   "Transforms symbol SYM to corresponding GtkButtonsType value."
   (gtk_string_to_buttons_type (string->pointer (symbol->string sym))))
+
+
+(define (gtk-file-chooser-action->symbol action)
+  "Transforms GtkFileChooserAction value ACTION to Scheme symbol."
+  (string->symbol
+   (pointer->string (gtk_file_chooser_action_to_string action))))
+
+(define (symbol->gtk-file-chooser-action sym)
+  "Transforms symbol SYM to corresponding GtkFileChooserAction value."
+  (gtk_string_to_file_chooser_action
+   (string->pointer (symbol->string sym))))
 
 
 (define (gtk-message-type->symbol type)

--- a/lepton-eda/scheme/schematic/gtk/helper.scm
+++ b/lepton-eda/scheme/schematic/gtk/helper.scm
@@ -21,8 +21,19 @@
 
   #:use-module (schematic ffi)
 
-  #:export (gtk-response->symbol
+  #:export (gtk-buttons-type->symbol
+            symbol->gtk-buttons-type
+            gtk-response->symbol
             symbol->gtk-response))
+
+(define (gtk-buttons-type->symbol type)
+  "Transforms GtkButtonsType value TYPE to Scheme symbol."
+  (string->symbol (pointer->string (gtk_buttons_type_to_string type))))
+
+(define (symbol->gtk-buttons-type sym)
+  "Transforms symbol SYM to corresponding GtkButtonsType value."
+  (gtk_string_to_buttons_type (string->pointer (symbol->string sym))))
+
 
 (define (gtk-response->symbol response)
   "Transforms GtkResponse integer RESPONSE to Scheme symbol."

--- a/lepton-eda/scheme/schematic/gtk/helper.scm
+++ b/lepton-eda/scheme/schematic/gtk/helper.scm
@@ -23,6 +23,8 @@
 
   #:export (gtk-buttons-type->symbol
             symbol->gtk-buttons-type
+            gtk-message-type->symbol
+            symbol->gtk-message-type
             gtk-response->symbol
             symbol->gtk-response))
 
@@ -33,6 +35,15 @@
 (define (symbol->gtk-buttons-type sym)
   "Transforms symbol SYM to corresponding GtkButtonsType value."
   (gtk_string_to_buttons_type (string->pointer (symbol->string sym))))
+
+
+(define (gtk-message-type->symbol type)
+  "Transforms GtkMessageType value TYPE to Scheme symbol."
+  (string->symbol (pointer->string (gtk_message_type_to_string type))))
+
+(define (symbol->gtk-message-type sym)
+  "Transforms symbol SYM to corresponding GtkMessageType value."
+  (gtk_string_to_message_type (string->pointer (symbol->string sym))))
 
 
 (define (gtk-response->symbol response)

--- a/libleptonattrib/include/prototype.h
+++ b/libleptonattrib/include/prototype.h
@@ -293,9 +293,6 @@ void s_visibility_set_cell(gint cur_page, gint row, gint col,
                            gint visibility, gint show_name_value);
 
 /* ------------- x_dialog.c ------------- */
-GtkWidget*
-x_dialog_newattrib (GtkWidget *dialog);
-
 void x_dialog_delattrib();
 void x_dialog_missing_sym();
 

--- a/libleptonattrib/include/prototype.h
+++ b/libleptonattrib/include/prototype.h
@@ -293,8 +293,6 @@ void s_visibility_set_cell(gint cur_page, gint row, gint col,
                            gint visibility, gint show_name_value);
 
 /* ------------- x_dialog.c ------------- */
-void x_dialog_missing_sym();
-
 GtkWidget*
 x_dialog_unsaved_data ();
 

--- a/libleptonattrib/include/prototype.h
+++ b/libleptonattrib/include/prototype.h
@@ -311,7 +311,8 @@ x_dialog_about_dialog (gpointer action,
                        gpointer user_data);
 #endif
 
-void x_dialog_export_file();
+void
+x_dialog_export_file (GtkWidget *dialog);
 
 /* ------------- x_gtksheet.c ------------- */
 void x_gtksheet_set_saved();

--- a/libleptonattrib/include/prototype.h
+++ b/libleptonattrib/include/prototype.h
@@ -293,7 +293,9 @@ void s_visibility_set_cell(gint cur_page, gint row, gint col,
                            gint visibility, gint show_name_value);
 
 /* ------------- x_dialog.c ------------- */
-void x_dialog_newattrib();
+GtkWidget*
+x_dialog_newattrib ();
+
 void x_dialog_delattrib();
 void x_dialog_missing_sym();
 

--- a/libleptonattrib/include/prototype.h
+++ b/libleptonattrib/include/prototype.h
@@ -293,9 +293,6 @@ void s_visibility_set_cell(gint cur_page, gint row, gint col,
                            gint visibility, gint show_name_value);
 
 /* ------------- x_dialog.c ------------- */
-void
-x_dialog_delattrib (GtkSheet *sheet);
-
 void x_dialog_missing_sym();
 
 GtkWidget*

--- a/libleptonattrib/include/prototype.h
+++ b/libleptonattrib/include/prototype.h
@@ -293,7 +293,9 @@ void s_visibility_set_cell(gint cur_page, gint row, gint col,
                            gint visibility, gint show_name_value);
 
 /* ------------- x_dialog.c ------------- */
-void x_dialog_delattrib();
+void
+x_dialog_delattrib (GtkSheet *sheet);
+
 void x_dialog_missing_sym();
 
 GtkWidget*

--- a/libleptonattrib/include/prototype.h
+++ b/libleptonattrib/include/prototype.h
@@ -294,7 +294,7 @@ void s_visibility_set_cell(gint cur_page, gint row, gint col,
 
 /* ------------- x_dialog.c ------------- */
 GtkWidget*
-x_dialog_newattrib ();
+x_dialog_newattrib (GtkWidget *dialog);
 
 void x_dialog_delattrib();
 void x_dialog_missing_sym();

--- a/libleptonattrib/include/prototype.h
+++ b/libleptonattrib/include/prototype.h
@@ -311,8 +311,8 @@ x_dialog_about_dialog (gpointer action,
                        gpointer user_data);
 #endif
 
-void
-x_dialog_export_file (GtkWidget *dialog);
+gboolean
+x_dialog_confirm_overwrite (const gchar* fname);
 
 /* ------------- x_gtksheet.c ------------- */
 void x_gtksheet_set_saved();

--- a/libleptonattrib/src/x_dialog.c
+++ b/libleptonattrib/src/x_dialog.c
@@ -67,16 +67,8 @@
 GtkWidget*
 x_dialog_newattrib (GtkWidget *dialog)
 {
-  GtkWidget *label;
   GtkWidget *attrib_entry;
   gchar *entry_text;
-
-  gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_OK);
-
-  /*  Create a text label for the dialog window */
-  label = gtk_label_new (_("Enter new attribute name"));
-  gtk_box_pack_start (GTK_BOX (gtk_dialog_get_content_area (GTK_DIALOG (dialog))),
-                      label, FALSE, FALSE, 0);
 
   /*  Create the "attrib" text entry area */
   attrib_entry = gtk_entry_new ();

--- a/libleptonattrib/src/x_dialog.c
+++ b/libleptonattrib/src/x_dialog.c
@@ -59,47 +59,6 @@
 #include "../include/gettext.h"
 
 
-/*! \brief Add new attribute dialog.
- *
- * This asks for the name of the attrib column to insert
- *         and then inserts the column.
- */
-GtkWidget*
-x_dialog_newattrib (GtkWidget *dialog)
-{
-  GtkWidget *attrib_entry;
-  gchar *entry_text;
-
-  /*  Create the "attrib" text entry area */
-  attrib_entry = gtk_entry_new ();
-  gtk_entry_set_max_length (GTK_ENTRY (attrib_entry), 1024);
-  gtk_box_pack_start (GTK_BOX (gtk_dialog_get_content_area (GTK_DIALOG (dialog))),
-                      attrib_entry, TRUE, TRUE, 5);
-  gtk_widget_set_size_request (dialog, 260, 140);
-
-  gtk_widget_show_all(dialog);
-
-  switch(gtk_dialog_run(GTK_DIALOG(dialog))) {
-    case GTK_RESPONSE_OK:
-      entry_text = g_strdup( gtk_entry_get_text(GTK_ENTRY(attrib_entry)) );
-
-      /* Perhaps do some other checks . . . . */
-      if (entry_text != NULL) {
-        s_toplevel_add_new_attrib(entry_text);
-        g_free(entry_text);
-      }
-      break;
-
-    case GTK_RESPONSE_CANCEL:
-    default:
-      /* do nothing */
-      break;
-  }
-
-  return dialog;
-}
-
-
 /*! \brief Delete Attribute dialog
  *
  * This function throws up the "Delete foo, are you sure?" dialog

--- a/libleptonattrib/src/x_dialog.c
+++ b/libleptonattrib/src/x_dialog.c
@@ -65,19 +65,11 @@
  *         and then inserts the column.
  */
 GtkWidget*
-x_dialog_newattrib ()
+x_dialog_newattrib (GtkWidget *dialog)
 {
-  GtkWidget *dialog;
   GtkWidget *label;
   GtkWidget *attrib_entry;
   gchar *entry_text;
-
-  /* Create the dialog */
-  dialog = gtk_dialog_new_with_buttons(_("Add new attribute"), NULL,
-                                       GTK_DIALOG_MODAL,
-                                       _("_OK"), GTK_RESPONSE_OK,
-                                       _("_Cancel"), GTK_RESPONSE_CANCEL,
-                                       NULL);
 
   gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_OK);
 

--- a/libleptonattrib/src/x_dialog.c
+++ b/libleptonattrib/src/x_dialog.c
@@ -72,7 +72,7 @@ void x_dialog_delattrib()
   gint cur_page;
 
   /* First verify that exactly one column is selected.  */
-  cur_page = gtk_notebook_get_current_page(GTK_NOTEBOOK(notebook));
+  cur_page = gtk_notebook_get_current_page (GTK_NOTEBOOK (attrib_get_notebook ()));
   sheet = GTK_SHEET (attrib_get_sheet (cur_page));
   if (sheet == NULL) {
     return;

--- a/libleptonattrib/src/x_dialog.c
+++ b/libleptonattrib/src/x_dialog.c
@@ -64,19 +64,12 @@
  * This function throws up the "Delete foo, are you sure?" dialog
  *         box.  It offers two buttons: "yes" and "cancel".
  */
-void x_dialog_delattrib()
+void
+x_dialog_delattrib (GtkSheet *sheet)
 {
   GtkWidget *dialog;
   gint mincol, maxcol;
-  GtkSheet *sheet;
-  gint cur_page;
 
-  /* First verify that exactly one column is selected.  */
-  cur_page = gtk_notebook_get_current_page (GTK_NOTEBOOK (attrib_get_notebook ()));
-  sheet = GTK_SHEET (attrib_get_sheet (cur_page));
-  if (sheet == NULL) {
-    return;
-  }
 
   mincol = x_gtksheet_get_min_col(sheet);
   maxcol =  x_gtksheet_get_max_col(sheet);

--- a/libleptonattrib/src/x_dialog.c
+++ b/libleptonattrib/src/x_dialog.c
@@ -237,16 +237,10 @@ x_dialog_confirm_overwrite (const gchar* fname)
  * This asks for the filename for the CSV export file and then
  *         does the exporting.
  */
-void x_dialog_export_file()
+void
+x_dialog_export_file (GtkWidget *dialog)
 {
   gchar *filename;
-  GtkWidget *dialog;
-
-  dialog = gtk_file_chooser_dialog_new(_("Export CSV"), NULL,
-                                       GTK_FILE_CHOOSER_ACTION_SAVE,
-                                       _("_Cancel"), GTK_RESPONSE_CANCEL,
-                                       _("_Save"), GTK_RESPONSE_ACCEPT,
-                                       NULL);
 
   gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_ACCEPT);
 

--- a/libleptonattrib/src/x_dialog.c
+++ b/libleptonattrib/src/x_dialog.c
@@ -59,39 +59,6 @@
 #include "../include/gettext.h"
 
 
-/*! \brief Delete Attribute dialog
- *
- * This function throws up the "Delete foo, are you sure?" dialog
- *         box.  It offers two buttons: "yes" and "cancel".
- */
-void
-x_dialog_delattrib (GtkSheet *sheet)
-{
-  GtkWidget *dialog;
-
-  /* Create the dialog */
-  dialog = gtk_message_dialog_new (NULL, GTK_DIALOG_MODAL,
-                                  GTK_MESSAGE_QUESTION,
-                                  GTK_BUTTONS_YES_NO,
-                                  _("Are you sure you want to delete this attribute?"));
-
-  gtk_window_set_title(GTK_WINDOW(dialog), _("Delete attribute"));
-  gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_NO);
-
-  switch(gtk_dialog_run(GTK_DIALOG(dialog))) {
-    case GTK_RESPONSE_YES:
-      /* call the fcn to actually delete the attrib column.  */
-      s_toplevel_delete_attrib_col();  /* this fcn figures out
-                                        * which col to delete. */
-      break;
-
-    default:
-      break;
-  }
-
-  gtk_widget_destroy(dialog);
-}
-
 /*! \brief Missing Symbol dialog
  *
  * This is the "missing symbol file found on object" dialog.

--- a/libleptonattrib/src/x_dialog.c
+++ b/libleptonattrib/src/x_dialog.c
@@ -59,52 +59,6 @@
 #include "../include/gettext.h"
 
 
-/*! \brief Missing Symbol dialog
- *
- * This is the "missing symbol file found on object" dialog.
- *
- *  It offers the user the chance to close the project without
- *  saving because he read a schematic with a missing symbol file.
- */
-void x_dialog_missing_sym()
-{
-  GtkWidget *dialog;
-  const char *string =
-    _("One or more components have been found with missing symbol files!\n\n"
-      "This probably happened because lepton-attrib couldn't find your "
-      "component libraries, perhaps because your gafrc files are "
-      "misconfigured.\n\n"
-      "Choose \"Quit\" to leave lepton-attrib and fix the problem, or\n"
-      "\"Forward\" to continue working with lepton-attrib.\n");
-
-  /* Create the dialog */
-  dialog = gtk_message_dialog_new (NULL, GTK_DIALOG_MODAL,
-                                  GTK_MESSAGE_WARNING,
-                                  GTK_BUTTONS_NONE,
-                                  "%s", string);
-
-  gtk_dialog_add_buttons(GTK_DIALOG(dialog),
-                         _("_Quit"), GTK_RESPONSE_REJECT,
-                         _("_Forward"), GTK_RESPONSE_ACCEPT,
-                         NULL);
-
-  gtk_window_set_title(GTK_WINDOW(dialog), _("Missing symbol file found for component!"));
-  gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_REJECT);
-
-  switch(gtk_dialog_run(GTK_DIALOG(dialog))) {
-    case GTK_RESPONSE_ACCEPT:
-      /* Continue with the execution */
-      break;
-
-    default:
-      /* Terminate */
-      exit(0);
-      break;
-  }
-
-  gtk_widget_destroy(dialog);
-}
-
 /*! \brief Unsaved data dialog
  *
  * This is the "Unsaved data -- are you sure you want to quit?" dialog

--- a/libleptonattrib/src/x_dialog.c
+++ b/libleptonattrib/src/x_dialog.c
@@ -64,7 +64,8 @@
  * This asks for the name of the attrib column to insert
  *         and then inserts the column.
  */
-void x_dialog_newattrib()
+GtkWidget*
+x_dialog_newattrib ()
 {
   GtkWidget *dialog;
   GtkWidget *label;
@@ -111,7 +112,7 @@ void x_dialog_newattrib()
       break;
   }
 
-  gtk_widget_destroy(dialog);
+  return dialog;
 }
 
 

--- a/libleptonattrib/src/x_dialog.c
+++ b/libleptonattrib/src/x_dialog.c
@@ -73,7 +73,7 @@ void x_dialog_delattrib()
 
   /* First verify that exactly one column is selected.  */
   cur_page = gtk_notebook_get_current_page(GTK_NOTEBOOK(notebook));
-  sheet = GTK_SHEET(sheets[cur_page]);
+  sheet = GTK_SHEET (attrib_get_sheet (cur_page));
   if (sheet == NULL) {
     return;
   }

--- a/libleptonattrib/src/x_dialog.c
+++ b/libleptonattrib/src/x_dialog.c
@@ -204,7 +204,7 @@ x_dialog_about_dialog (gpointer action,
  *
  *  \return  Is it OK to overwrite file \a fname.
  */
-static gboolean
+gboolean
 x_dialog_confirm_overwrite (const gchar* fname)
 {
   if (!g_file_test (fname, G_FILE_TEST_EXISTS))
@@ -229,38 +229,4 @@ x_dialog_confirm_overwrite (const gchar* fname)
 
   return res == GTK_RESPONSE_YES;
 
-}
-
-
-/*! \brief Export file dialog
- *
- * This asks for the filename for the CSV export file and then
- *         does the exporting.
- */
-void
-x_dialog_export_file (GtkWidget *dialog)
-{
-  gchar *filename;
-
-  gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_ACCEPT);
-
-  switch(gtk_dialog_run(GTK_DIALOG(dialog))) {
-    case GTK_RESPONSE_ACCEPT:
-      filename = gtk_file_chooser_get_filename (GTK_FILE_CHOOSER (dialog));
-      if(filename != NULL) {
-
-        if (x_dialog_confirm_overwrite (filename))
-        {
-          f_export_components (filename);
-        }
-
-        g_free(filename);
-      }
-      break;
-
-    default:
-      break;
-  }
-
-  gtk_widget_destroy(dialog);
 }

--- a/libleptonattrib/src/x_dialog.c
+++ b/libleptonattrib/src/x_dialog.c
@@ -68,16 +68,6 @@ void
 x_dialog_delattrib (GtkSheet *sheet)
 {
   GtkWidget *dialog;
-  gint mincol, maxcol;
-
-
-  mincol = x_gtksheet_get_min_col(sheet);
-  maxcol =  x_gtksheet_get_max_col(sheet);
-
-  if ( (mincol != maxcol) || (mincol == -1) || (maxcol == -1) ) {
-    /* Improper selection -- maybe throw up error box? */
-    return;
-  }
 
   /* Create the dialog */
   dialog = gtk_message_dialog_new (NULL, GTK_DIALOG_MODAL,

--- a/libleptongui/include/gtk_helper.h
+++ b/libleptongui/include/gtk_helper.h
@@ -63,6 +63,12 @@ gtk_buttons_type_to_string (int type);
 int
 gtk_string_to_buttons_type (char *s);
 
+const char*
+gtk_file_chooser_action_to_string (int action);
+
+int
+gtk_string_to_file_chooser_action (char *s);
+
 G_END_DECLS
 
 #endif /* GTK_HELPER_H */

--- a/libleptongui/include/gtk_helper.h
+++ b/libleptongui/include/gtk_helper.h
@@ -57,6 +57,12 @@ gtk_message_type_to_string (int type);
 int
 gtk_string_to_message_type (char *s);
 
+const char*
+gtk_buttons_type_to_string (int type);
+
+int
+gtk_string_to_buttons_type (char *s);
+
 G_END_DECLS
 
 #endif /* GTK_HELPER_H */

--- a/libleptongui/include/gtk_helper.h
+++ b/libleptongui/include/gtk_helper.h
@@ -51,6 +51,12 @@ gdk_window_type_hint_to_string (int hint);
 int
 gdk_string_to_window_type_hint (char *s);
 
+const char*
+gtk_message_type_to_string (int type);
+
+int
+gtk_string_to_message_type (char *s);
+
 G_END_DECLS
 
 #endif /* GTK_HELPER_H */

--- a/libleptongui/src/gtk_helper.c
+++ b/libleptongui/src/gtk_helper.c
@@ -316,3 +316,59 @@ gdk_string_to_window_type_hint (char *s)
 
   return result;
 }
+
+
+/*! \brief Transform a GTK message type id value to string.
+ *
+ * \par Function Description
+ *
+ * Given a GTK message type id \p type, returns the string
+ * corresponding to it.  This is mainly intended to be used for
+ * value conversion in Scheme FFI functions.
+ *
+ * \param [in] type The message type id.
+ * \return The string corresponding to the id.
+ */
+const char*
+gtk_message_type_to_string (int type)
+{
+  const char *result = "unknown";
+
+  switch (type)
+  {
+  case GTK_MESSAGE_INFO: result = "info"; break;
+  case GTK_MESSAGE_WARNING: result = "warning"; break;
+  case GTK_MESSAGE_QUESTION: result = "question"; break;
+  case GTK_MESSAGE_ERROR: result = "error"; break;
+  case GTK_MESSAGE_OTHER: result = "other"; break;
+  default: break;
+  }
+
+  return result;
+}
+
+
+/*! \brief Transform a string into GTK message type id value.
+ *
+ * \par Function Description
+ *
+ * Given a string naming a GTK message type id, return the enum
+ * value corresponding to it.  This is mainly intended to be used
+ * for value conversion in Scheme FFI functions.
+ *
+ * \param [in] s The string.
+ * \return The GTK message type id value.
+ */
+int
+gtk_string_to_message_type (char *s)
+{
+  int result = GTK_MESSAGE_INFO;
+
+  if (strcmp (s, "info") == 0) {result = GTK_MESSAGE_INFO; }
+  else if (strcmp (s, "warning") == 0) {result = GTK_MESSAGE_WARNING; }
+  else if (strcmp (s, "question") == 0) {result = GTK_MESSAGE_QUESTION; }
+  else if (strcmp (s, "error") == 0) {result = GTK_MESSAGE_ERROR; }
+  else if (strcmp (s, "other") == 0) {result = GTK_MESSAGE_OTHER; }
+
+  return result;
+}

--- a/libleptongui/src/gtk_helper.c
+++ b/libleptongui/src/gtk_helper.c
@@ -372,3 +372,61 @@ gtk_string_to_message_type (char *s)
 
   return result;
 }
+
+
+/*! \brief Transform a GTK buttons type id value to string.
+ *
+ * \par Function Description
+ *
+ * Given a GTK buttons type id \p type, returns the string
+ * corresponding to it.  This is mainly intended to be used for
+ * value conversion in Scheme FFI functions.
+ *
+ * \param [in] type The buttons type id.
+ * \return The string corresponding to the id.
+ */
+const char*
+gtk_buttons_type_to_string (int type)
+{
+  const char *result = "unknown";
+
+  switch (type)
+  {
+  case GTK_BUTTONS_NONE: result = "none"; break;
+  case GTK_BUTTONS_OK: result = "ok"; break;
+  case GTK_BUTTONS_CLOSE: result = "close"; break;
+  case GTK_BUTTONS_CANCEL: result = "cancel"; break;
+  case GTK_BUTTONS_YES_NO: result = "yes-no"; break;
+  case GTK_BUTTONS_OK_CANCEL: result = "ok-cancel"; break;
+  default: break;
+  }
+
+  return result;
+}
+
+
+/*! \brief Transform a string into GTK buttons type id value.
+ *
+ * \par Function Description
+ *
+ * Given a string naming a GTK buttons type id, return the enum
+ * value corresponding to it.  This is mainly intended to be used
+ * for value conversion in Scheme FFI functions.
+ *
+ * \param [in] s The string.
+ * \return The GTK buttons type id value.
+ */
+int
+gtk_string_to_buttons_type (char *s)
+{
+  int result = GTK_BUTTONS_NONE;
+
+  if (strcmp (s, "none") == 0) {result = GTK_BUTTONS_NONE; }
+  else if (strcmp (s, "ok") == 0) {result = GTK_BUTTONS_OK; }
+  else if (strcmp (s, "close") == 0) {result = GTK_BUTTONS_CLOSE; }
+  else if (strcmp (s, "cancel") == 0) {result = GTK_BUTTONS_CANCEL; }
+  else if (strcmp (s, "yes-no") == 0) {result = GTK_BUTTONS_YES_NO; }
+  else if (strcmp (s, "ok-cancel") == 0) {result = GTK_BUTTONS_OK_CANCEL; }
+
+  return result;
+}

--- a/libleptongui/src/gtk_helper.c
+++ b/libleptongui/src/gtk_helper.c
@@ -430,3 +430,58 @@ gtk_string_to_buttons_type (char *s)
 
   return result;
 }
+
+
+/*! \brief Transform a GTK file chooser action id value to string.
+ *
+ * \par Function Description
+ *
+ * Given a GTK file chooser action id \p action, returns the
+ * string corresponding to it.  This is mainly intended to be used
+ * for value conversion in Scheme FFI functions.
+ *
+ * \param [in] action The file chooser action id.
+ * \return The string corresponding to the id.
+ */
+const char*
+gtk_file_chooser_action_to_string (int action)
+{
+  const char *result = "unknown";
+
+  switch (action)
+  {
+  case GTK_FILE_CHOOSER_ACTION_OPEN: result = "open"; break;
+  case GTK_FILE_CHOOSER_ACTION_SAVE: result = "save"; break;
+  case GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER: result = "select-folder"; break;
+  case GTK_FILE_CHOOSER_ACTION_CREATE_FOLDER: result = "create-folder"; break;
+  default: break;
+  }
+
+  return result;
+}
+
+
+/*! \brief Transform a string into GTK file chooser action id
+ *  value.
+ *
+ * \par Function Description
+ *
+ * Given a string naming a GTK file chooser action id, return the
+ * enum value corresponding to it.  This is mainly intended to be
+ * used for value conversion in Scheme FFI functions.
+ *
+ * \param [in] s The string.
+ * \return The GTK file chooser action id value.
+ */
+int
+gtk_string_to_file_chooser_action (char *s)
+{
+  int result = GTK_FILE_CHOOSER_ACTION_OPEN;
+
+  if (strcmp (s, "open") == 0) {result = GTK_FILE_CHOOSER_ACTION_OPEN; }
+  else if (strcmp (s, "save") == 0) {result = GTK_FILE_CHOOSER_ACTION_SAVE; }
+  else if (strcmp (s, "select-folder") == 0) {result = GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER; }
+  else if (strcmp (s, "create-folder") == 0) {result = GTK_FILE_CHOOSER_ACTION_CREATE_FOLDER; }
+
+  return result;
+}

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -394,6 +394,10 @@ failure."
           (gtk_widget_destroy *dialog))))))
 
 
+(define (missing-symbol-dialog)
+  (x_dialog_missing_sym))
+
+
 (define (callback-edit-delete-attrib *action *parameter *data)
   (delete-attrib))
 (define *callback-edit-delete-attrib
@@ -729,7 +733,7 @@ Please check your design.")))
   ;; Verify correctness of entire design.
   (when (design-has-missing-symbols?)
     ;; Dialog gives user option to quit.
-    (x_dialog_missing_sym))
+    (missing-symbol-dialog))
 
   ;; Set the main window's title.
   (let ((page-count (length (active-pages))))

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -203,6 +203,10 @@ failure."
   (procedure->pointer void callback-file-save '(* * *)))
 
 
+(define (export-file-dialog)
+  (x_dialog_export_file))
+
+
 (define (export-csv)
   "Export component table info in the CSV format."
   (define *notebook (attrib_get_notebook))
@@ -210,7 +214,7 @@ failure."
 
   ;; Check that we are on components page.
   (if (zero? current-page-id)
-      (x_dialog_export_file)
+      (export-file-dialog)
       ;; We only support export of components now
       (x_dialog_unimplemented_feature)))
 

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -271,8 +271,39 @@ failure."
   (procedure->pointer void callback-file-quit '(* * *)))
 
 
+(define gtk_dialog_new_with_buttons_8
+  (let ((proc (delay (pointer->procedure
+                      '*
+                      (dynamic-func "gtk_dialog_new_with_buttons" libgtk)
+                      (list '* '* int '* int '* int '*)))))
+    (force proc)))
+
+(define gtk_dialog_new_with_buttons
+  (case-lambda
+    ((*title *parent flags *button-text1 response1 *button-text2 response2 end)
+     (gtk_dialog_new_with_buttons_8 *title
+                                    *parent
+                                    flags
+                                    *button-text1
+                                    response1
+                                    *button-text2
+                                    response2
+                                    %null-pointer))))
+
 (define (add-attrib-dialog)
-  (define *dialog (x_dialog_newattrib))
+  ;; Create the dialog.
+  (define *dialog
+    (gtk_dialog_new_with_buttons
+     (string->pointer (G_"Add new attribute"))
+     %null-pointer
+     GTK_DIALOG_MODAL
+     (string->pointer (G_ "_OK"))
+     GTK_RESPONSE_OK
+     (string->pointer (G_ "_Cancel"))
+     GTK_RESPONSE_CANCEL
+     %null-pointer))
+
+  (x_dialog_newattrib *dialog)
 
   (gtk_widget_destroy *dialog))
 

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -361,7 +361,13 @@ failure."
     (gtk_notebook_get_current_page (attrib_get_notebook)))
   (define *sheet (attrib_get_sheet current-page-id))
   (unless (null-pointer? *sheet)
-    (x_dialog_delattrib *sheet)))
+    (let ((mincol (x_gtksheet_get_min_col *sheet))
+          (maxcol (x_gtksheet_get_max_col *sheet)))
+      ;; Check improper selection.
+      (unless (or (not (= mincol maxcol))
+                  (= mincol -1)
+                  (= maxcol -1))
+        (x_dialog_delattrib *sheet)))))
 
 
 (define (callback-edit-delete-attrib *action *parameter *data)

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -302,6 +302,16 @@ failure."
      (string->pointer (G_ "_Cancel"))
      GTK_RESPONSE_CANCEL
      %null-pointer))
+  ;; Create a text label for the dialog window.
+  (define *label
+    (gtk_label_new (string->pointer (G_ "Enter new attribute name"))))
+
+  (gtk_dialog_set_default_response *dialog GTK_RESPONSE_OK)
+  (gtk_box_pack_start (gtk_dialog_get_content_area *dialog)
+                      *label
+                      FALSE
+                      FALSE
+                      0)
 
   (x_dialog_newattrib *dialog)
 

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -290,6 +290,8 @@ failure."
                                     response2
                                     %null-pointer))))
 
+;;; Runs the Add attribute dialog.  It asks for the name of the
+;;; attrib column to insert and then inserts the column.
 (define (add-attrib-dialog)
   ;; Create the dialog.
   (define *dialog
@@ -305,6 +307,8 @@ failure."
   ;; Create a text label for the dialog window.
   (define *label
     (gtk_label_new (string->pointer (G_ "Enter new attribute name"))))
+  ;; Create the attrib text entry area.
+  (define *attrib-entry (gtk_entry_new))
 
   (gtk_dialog_set_default_response *dialog GTK_RESPONSE_OK)
   (gtk_box_pack_start (gtk_dialog_get_content_area *dialog)
@@ -313,7 +317,25 @@ failure."
                       FALSE
                       0)
 
-  (x_dialog_newattrib *dialog)
+  (gtk_entry_set_max_length *attrib-entry 1024)
+  (gtk_box_pack_start (gtk_dialog_get_content_area *dialog)
+                      *attrib-entry
+                      TRUE
+                      TRUE
+                      5)
+  (gtk_widget_set_size_request *dialog 260 140)
+
+  (gtk_widget_show_all *dialog)
+
+  (let ((response (gtk_dialog_run *dialog)))
+    (cond
+     ((= response GTK_RESPONSE_OK)
+      (let ((*entry-text
+             (g_strdup (gtk_entry_get_text *attrib-entry))))
+        (unless (null-pointer? *entry-text)
+          (s_toplevel_add_new_attrib *entry-text)
+          (g_free *entry-text))))
+     (else #f)))
 
   (gtk_widget_destroy *dialog))
 

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -203,8 +203,37 @@ failure."
   (procedure->pointer void callback-file-save '(* * *)))
 
 
+(define gtk_file_chooser_dialog_new_8
+  (let ((proc (delay (pointer->procedure
+                      '*
+                      (dynamic-func "gtk_file_chooser_dialog_new" libgtk)
+                      (list '* '* int '* int '* int '*)))))
+    (force proc)))
+
+(define gtk_file_chooser_dialog_new
+  (case-lambda
+    ((*title *parent action *button-text1 response1 *button-text2 response2 end)
+     (gtk_file_chooser_dialog_new_8 *title
+                                    *parent
+                                    action
+                                    *button-text1
+                                    response1
+                                    *button-text2
+                                    response2
+                                    %null-pointer))))
+
 (define (export-file-dialog)
-  (x_dialog_export_file))
+  (define *dialog
+    (gtk_file_chooser_dialog_new
+     (string->pointer (G_ "Export CSV"))
+     %null-pointer
+     (symbol->gtk-file-chooser-action 'save)
+     (string->pointer (G_ "_Cancel"))
+     GTK_RESPONSE_CANCEL
+     (string->pointer (G_ "_Save"))
+     GTK_RESPONSE_ACCEPT
+     %null-pointer))
+  (x_dialog_export_file *dialog))
 
 
 (define (export-csv)

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -271,6 +271,22 @@ failure."
 (define *callback-file-quit
   (procedure->pointer void callback-file-quit '(* * *)))
 
+(define gtk_dialog_add_buttons_6
+  (let ((proc (delay (pointer->procedure
+                      '*
+                      (dynamic-func "gtk_dialog_add_buttons" libgtk)
+                      (list '* '* int '* int '*)))))
+    (force proc)))
+
+(define gtk_dialog_add_buttons
+  (case-lambda
+    ((*dialog *button-text1 response1 *button-text2 response2 end)
+     (gtk_dialog_add_buttons_6 *dialog
+                               *button-text1
+                               response1
+                               *button-text2
+                               response2
+                               %null-pointer))))
 
 (define gtk_dialog_new_with_buttons_8
   (let ((proc (delay (pointer->procedure
@@ -394,8 +410,48 @@ failure."
           (gtk_widget_destroy *dialog))))))
 
 
+;;; Runs the Missing symbol dialog.  It offers the user the chance
+;;; to close the project without saving because the program read a
+;;; schematic with a missing symbol file.
 (define (missing-symbol-dialog)
-  (x_dialog_missing_sym))
+  (define message
+    (G_ "One or more components have been found with missing symbol files!
+
+This probably happened because lepton-attrib couldn't find your
+component libraries, perhaps because your gafrc files are misconfigured.
+
+Choose \"Quit\" to leave lepton-attrib and fix the problem, or
+\"Forward\" to continue working with lepton-attrib."))
+
+  ;; Create the *dialog.
+  (define *dialog
+    (gtk_message_dialog_new %null-pointer
+                            GTK_DIALOG_MODAL
+                            (symbol->gtk-message-type 'warning)
+                            (symbol->gtk-buttons-type 'none)
+                            (string->pointer message)))
+
+  (gtk_dialog_add_buttons *dialog
+                          (string->pointer (G_ "_Quit"))
+                          GTK_RESPONSE_REJECT
+                          (string->pointer (G_ "_Forward"))
+                          GTK_RESPONSE_ACCEPT
+                          %null-pointer)
+
+  (gtk_window_set_title
+   *dialog
+   (string->pointer (G_ "Missing symbol file found for component!")))
+  (gtk_dialog_set_default_response *dialog GTK_RESPONSE_REJECT)
+
+  (let ((response (gtk_dialog_run *dialog)))
+    (cond
+     ;; Continue with the execution.
+     ((= response GTK_RESPONSE_ACCEPT)
+      'accept)
+     ;; Terminate.
+     (else (exit 0))))
+
+  (gtk_widget_destroy *dialog))
 
 
 (define (callback-edit-delete-attrib *action *parameter *data)

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -272,7 +272,9 @@ failure."
 
 
 (define (add-attrib-dialog)
-  (x_dialog_newattrib))
+  (define *dialog (x_dialog_newattrib))
+
+  (gtk_widget_destroy *dialog))
 
 
 (define (add-attrib)

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -356,7 +356,12 @@ failure."
 
 
 (define (delete-attrib)
-  (x_dialog_delattrib))
+  ;; First verify that exactly one column is selected.
+  (define current-page-id
+    (gtk_notebook_get_current_page (attrib_get_notebook)))
+  (define *sheet (attrib_get_sheet current-page-id))
+  (unless (null-pointer? *sheet)
+    (x_dialog_delattrib *sheet)))
 
 
 (define (callback-edit-delete-attrib *action *parameter *data)

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -41,6 +41,7 @@
              (lepton version)
 
              (schematic ffi gtk)
+             (schematic gtk helper)
 
              (attrib ffi))
 
@@ -355,6 +356,7 @@ failure."
   (procedure->pointer void callback-edit-add-attrib '(* * *)))
 
 
+;; Runs the Delete attribute dialog.
 (define (delete-attrib)
   ;; First verify that exactly one column is selected.
   (define current-page-id
@@ -367,7 +369,29 @@ failure."
       (unless (or (not (= mincol maxcol))
                   (= mincol -1)
                   (= maxcol -1))
-        (x_dialog_delattrib *sheet)))))
+        ;; Create the dialog.
+        (let ((*dialog
+               (gtk_message_dialog_new
+                %null-pointer
+                GTK_DIALOG_MODAL
+                (symbol->gtk-message-type 'question)
+                (symbol->gtk-buttons-type 'yes-no)
+                (string->pointer
+                 (G_ "Are you sure you want to delete this attribute?")))))
+
+          (gtk_window_set_title *dialog
+                                (string->pointer (G_ "Delete attribute")))
+          (gtk_dialog_set_default_response *dialog GTK_RESPONSE_NO)
+
+          (let ((response (gtk_dialog_run *dialog)))
+            (cond
+             ((= response GTK_RESPONSE_YES)
+              ;; Actually delete the attrib column.  This function
+              ;; figures out which column to delete.
+              (s_toplevel_delete_attrib_col))
+             (else #f)))
+
+          (gtk_widget_destroy *dialog))))))
 
 
 (define (callback-edit-delete-attrib *action *parameter *data)

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -222,6 +222,8 @@ failure."
                                     response2
                                     %null-pointer))))
 
+;;; Runs the Export file dialog.  It asks for the filename for the
+;;; CSV export file and then does the exporting.
 (define (export-file-dialog)
   (define *dialog
     (gtk_file_chooser_dialog_new
@@ -233,7 +235,20 @@ failure."
      (string->pointer (G_ "_Save"))
      GTK_RESPONSE_ACCEPT
      %null-pointer))
-  (x_dialog_export_file *dialog))
+
+  (gtk_dialog_set_default_response *dialog GTK_RESPONSE_ACCEPT)
+
+  (let ((response (gtk_dialog_run *dialog)))
+    (cond
+     ((= response GTK_RESPONSE_ACCEPT)
+      (let ((*filename (gtk_file_chooser_get_filename *dialog)))
+        (unless (null-pointer? *filename)
+          (when (true? (x_dialog_confirm_overwrite *filename))
+            (f_export_components *filename))
+          (g_free *filename))))
+     (else #f)))
+
+  (gtk_widget_destroy *dialog))
 
 
 (define (export-csv)

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -271,13 +271,17 @@ failure."
   (procedure->pointer void callback-file-quit '(* * *)))
 
 
+(define (add-attrib-dialog)
+  (x_dialog_newattrib))
+
+
 (define (add-attrib)
   (define *notebook (attrib_get_notebook))
   (define current-page-id (gtk_notebook_get_current_page *notebook))
 
   ;; Check that we are on components page.
   (when (zero? current-page-id)
-    (x_dialog_newattrib)))
+    (add-attrib-dialog)))
 
 
 (define (callback-edit-add-attrib *action *parameter *data)


### PR DESCRIPTION
- FFI definitions for `GTK_DIALOG_*` constants have been added.
- Helpers to transform strings from/to `GtkMessageType` have been added.
- Helpers to transform strings from/to `GtkButtonsType` have been added.
- Functions transforming `GtkButtonsType` to/from Scheme symbols have been added.
- Functions transforming `GtkMessageType` to/from Scheme symbols have been added.

- The following dialog functions have been rewritten in Scheme:
  - `x_dialog_newattrib()` (*Add attribute* dialog)
  - `x_dialog_delattrib()` (*Delete attribute* dialog)
  - `x_dialog_missing_sym()` (*Missing symbol* dialog)
  - `x_dialog_export_file()` (*Export CSV* dialog)
