### PR TITLE
attrib: Prepare master item list constructors for rewriting in Scheme.

### DIFF
--- a/lepton-eda/scheme/attrib/ffi.scm
+++ b/lepton-eda/scheme/attrib/ffi.scm
@@ -89,7 +89,6 @@
             attrib_sheet_data_set_pin_table
             s_sheet_data_add_master_comp_list_items
             s_sheet_data_add_master_comp_attrib_list_items
-            s_sheet_data_add_master_net_attrib_list_items
             s_sheet_data_add_master_pin_list_items
             s_sheet_data_add_master_pin_attrib_list_items
             s_sheet_data_set_changed
@@ -218,7 +217,6 @@
 (define-lff attrib_sheet_data_set_pin_table void '(* *))
 (define-lff s_sheet_data_add_master_comp_list_items void '(*))
 (define-lff s_sheet_data_add_master_comp_attrib_list_items void '(*))
-(define-lff s_sheet_data_add_master_net_attrib_list_items void '(*))
 (define-lff s_sheet_data_add_master_pin_list_items void '(*))
 (define-lff s_sheet_data_add_master_pin_attrib_list_items void '(*))
 (define-lff s_sheet_data_set_changed void (list '* int))

--- a/lepton-eda/scheme/attrib/ffi.scm
+++ b/lepton-eda/scheme/attrib/ffi.scm
@@ -54,6 +54,7 @@
             x_gtksheet_get_min_col
             x_gtksheet_init
 
+            attrib_sheet_data_get_changed
             attrib_sheet_data_get_component_attrib_count
             attrib_sheet_data_get_component_attrib_list
             attrib_sheet_data_get_component_count
@@ -79,7 +80,6 @@
             s_sheet_data_add_master_net_attrib_list_items
             s_sheet_data_add_master_pin_list_items
             s_sheet_data_add_master_pin_attrib_list_items
-            s_sheet_data_changed
             s_sheet_data_set_changed
 
             s_string_list_sort_master_comp_list
@@ -170,6 +170,7 @@
 (define-lff x_gtksheet_init void '())
 
 ;;; s_sheet_data.c
+(define-lff attrib_sheet_data_get_changed int '(*))
 (define-lff attrib_sheet_data_get_component_attrib_count int '(*))
 (define-lff attrib_sheet_data_get_component_attrib_list '* '(*))
 (define-lff attrib_sheet_data_get_component_count int '(*))
@@ -195,7 +196,6 @@
 (define-lff s_sheet_data_add_master_net_attrib_list_items void '(*))
 (define-lff s_sheet_data_add_master_pin_list_items void '(*))
 (define-lff s_sheet_data_add_master_pin_attrib_list_items void '(*))
-(define-lff s_sheet_data_changed int '(*))
 (define-lff s_sheet_data_set_changed void (list '* int))
 
 ;;; s_string_list.c

--- a/lepton-eda/scheme/attrib/ffi.scm
+++ b/lepton-eda/scheme/attrib/ffi.scm
@@ -81,7 +81,6 @@
             s_sheet_data_add_master_pin_attrib_list_items
             s_sheet_data_changed
             s_sheet_data_set_changed
-            s_sheet_data_gtksheet_to_sheetdata
 
             s_string_list_sort_master_comp_list
             s_string_list_sort_master_comp_attrib_list
@@ -97,6 +96,7 @@
             s_table_add_toplevel_comp_items_to_comp_table
             s_table_add_toplevel_net_items_to_net_table
             s_table_add_toplevel_pin_items_to_pin_table
+            s_table_gtksheet_to_all_tables
 
             s_toplevel_add_new_attrib
             s_toplevel_delete_attrib_col
@@ -197,7 +197,6 @@
 (define-lff s_sheet_data_add_master_pin_attrib_list_items void '(*))
 (define-lff s_sheet_data_changed int '(*))
 (define-lff s_sheet_data_set_changed void (list '* int))
-(define-lff s_sheet_data_gtksheet_to_sheetdata void '())
 
 ;;; s_string_list.c
 (define-lff s_string_list_sort_master_comp_list void '())
@@ -215,6 +214,7 @@
 (define-lff s_table_add_toplevel_comp_items_to_comp_table void '(*))
 (define-lff s_table_add_toplevel_net_items_to_net_table void '(*))
 (define-lff s_table_add_toplevel_pin_items_to_pin_table void '(*))
+(define-lff s_table_gtksheet_to_all_tables void '())
 
 ;;; s_toplevel.c
 (define-lff s_toplevel_sheetdata_to_toplevel void '(* *))

--- a/lepton-eda/scheme/attrib/ffi.scm
+++ b/lepton-eda/scheme/attrib/ffi.scm
@@ -55,22 +55,35 @@
             x_gtksheet_init
 
             attrib_sheet_data_get_changed
+            attrib_sheet_data_set_changed
             attrib_sheet_data_get_component_attrib_count
+            attrib_sheet_data_set_component_attrib_count
             attrib_sheet_data_get_component_attrib_list
+            attrib_sheet_data_set_component_attrib_list
             attrib_sheet_data_get_component_count
+            attrib_sheet_data_set_component_count
             attrib_sheet_data_get_component_list
+            attrib_sheet_data_set_component_list
             attrib_sheet_data_get_component_table
             attrib_sheet_data_set_component_table
             attrib_sheet_data_get_net_attrib_count
+            attrib_sheet_data_set_net_attrib_count
             attrib_sheet_data_get_net_attrib_list
+            attrib_sheet_data_set_net_attrib_list
             attrib_sheet_data_get_net_count
+            attrib_sheet_data_set_net_count
             attrib_sheet_data_get_net_list
+            attrib_sheet_data_set_net_list
             attrib_sheet_data_get_net_table
             attrib_sheet_data_set_net_table
             attrib_sheet_data_get_pin_attrib_count
+            attrib_sheet_data_set_pin_attrib_count
             attrib_sheet_data_get_pin_attrib_list
+            attrib_sheet_data_set_pin_attrib_list
             attrib_sheet_data_get_pin_count
+            attrib_sheet_data_set_pin_count
             attrib_sheet_data_get_pin_list
+            attrib_sheet_data_set_pin_list
             attrib_sheet_data_get_pin_table
             attrib_sheet_data_set_pin_table
             s_sheet_data_new
@@ -82,6 +95,7 @@
             s_sheet_data_add_master_pin_attrib_list_items
             s_sheet_data_set_changed
 
+            s_string_list_new
             s_string_list_sort_master_comp_list
             s_string_list_sort_master_comp_attrib_list
             s_string_list_sort_master_net_list
@@ -171,22 +185,35 @@
 
 ;;; s_sheet_data.c
 (define-lff attrib_sheet_data_get_changed int '(*))
+(define-lff attrib_sheet_data_set_changed void (list '* int))
 (define-lff attrib_sheet_data_get_component_attrib_count int '(*))
+(define-lff attrib_sheet_data_set_component_attrib_count void (list '* int))
 (define-lff attrib_sheet_data_get_component_attrib_list '* '(*))
+(define-lff attrib_sheet_data_set_component_attrib_list void '(* *))
 (define-lff attrib_sheet_data_get_component_count int '(*))
+(define-lff attrib_sheet_data_set_component_count void (list '* int))
 (define-lff attrib_sheet_data_get_component_list '* '(*))
+(define-lff attrib_sheet_data_set_component_list void '(* *))
 (define-lff attrib_sheet_data_get_component_table '* '(*))
 (define-lff attrib_sheet_data_set_component_table void '(* *))
 (define-lff attrib_sheet_data_get_net_attrib_count int '(*))
+(define-lff attrib_sheet_data_set_net_attrib_count void (list '* int))
 (define-lff attrib_sheet_data_get_net_attrib_list '* '(*))
+(define-lff attrib_sheet_data_set_net_attrib_list void '(* *))
 (define-lff attrib_sheet_data_get_net_count int '(*))
+(define-lff attrib_sheet_data_set_net_count void (list '* int))
 (define-lff attrib_sheet_data_get_net_list '* '(*))
+(define-lff attrib_sheet_data_set_net_list void '(* *))
 (define-lff attrib_sheet_data_get_net_table '* '(*))
 (define-lff attrib_sheet_data_set_net_table void '(* *))
 (define-lff attrib_sheet_data_get_pin_attrib_count int '(*))
+(define-lff attrib_sheet_data_set_pin_attrib_count void (list '* int))
 (define-lff attrib_sheet_data_get_pin_attrib_list '* '(*))
+(define-lff attrib_sheet_data_set_pin_attrib_list void '(* *))
 (define-lff attrib_sheet_data_get_pin_count int '(*))
+(define-lff attrib_sheet_data_set_pin_count void (list '* int))
 (define-lff attrib_sheet_data_get_pin_list '* '(*))
+(define-lff attrib_sheet_data_set_pin_list void '(* *))
 (define-lff attrib_sheet_data_get_pin_table '* '(*))
 (define-lff attrib_sheet_data_set_pin_table void '(* *))
 (define-lff s_sheet_data_new '* '())
@@ -199,6 +226,7 @@
 (define-lff s_sheet_data_set_changed void (list '* int))
 
 ;;; s_string_list.c
+(define-lff s_string_list_new '* '())
 (define-lff s_string_list_sort_master_comp_list void '())
 (define-lff s_string_list_sort_master_comp_attrib_list void '())
 (define-lff s_string_list_sort_master_net_list void '())

--- a/lepton-eda/scheme/attrib/ffi.scm
+++ b/lepton-eda/scheme/attrib/ffi.scm
@@ -54,6 +54,7 @@
             x_gtksheet_get_min_col
             x_gtksheet_init
 
+            attrib_sheet_data_new
             attrib_sheet_data_get_changed
             attrib_sheet_data_set_changed
             attrib_sheet_data_get_component_attrib_count
@@ -86,7 +87,6 @@
             attrib_sheet_data_set_pin_list
             attrib_sheet_data_get_pin_table
             attrib_sheet_data_set_pin_table
-            s_sheet_data_new
             s_sheet_data_add_master_comp_list_items
             s_sheet_data_add_master_comp_attrib_list_items
             s_sheet_data_add_master_net_list_items
@@ -184,6 +184,7 @@
 (define-lff x_gtksheet_init void '())
 
 ;;; s_sheet_data.c
+(define-lff attrib_sheet_data_new '* '())
 (define-lff attrib_sheet_data_get_changed int '(*))
 (define-lff attrib_sheet_data_set_changed void (list '* int))
 (define-lff attrib_sheet_data_get_component_attrib_count int '(*))
@@ -216,7 +217,6 @@
 (define-lff attrib_sheet_data_set_pin_list void '(* *))
 (define-lff attrib_sheet_data_get_pin_table '* '(*))
 (define-lff attrib_sheet_data_set_pin_table void '(* *))
-(define-lff s_sheet_data_new '* '())
 (define-lff s_sheet_data_add_master_comp_list_items void '(*))
 (define-lff s_sheet_data_add_master_comp_attrib_list_items void '(*))
 (define-lff s_sheet_data_add_master_net_list_items void '(*))

--- a/lepton-eda/scheme/attrib/ffi.scm
+++ b/lepton-eda/scheme/attrib/ffi.scm
@@ -89,7 +89,6 @@
             attrib_sheet_data_set_pin_table
             s_sheet_data_add_master_comp_list_items
             s_sheet_data_add_master_comp_attrib_list_items
-            s_sheet_data_add_master_net_list_items
             s_sheet_data_add_master_net_attrib_list_items
             s_sheet_data_add_master_pin_list_items
             s_sheet_data_add_master_pin_attrib_list_items
@@ -219,7 +218,6 @@
 (define-lff attrib_sheet_data_set_pin_table void '(* *))
 (define-lff s_sheet_data_add_master_comp_list_items void '(*))
 (define-lff s_sheet_data_add_master_comp_attrib_list_items void '(*))
-(define-lff s_sheet_data_add_master_net_list_items void '(*))
 (define-lff s_sheet_data_add_master_net_attrib_list_items void '(*))
 (define-lff s_sheet_data_add_master_pin_list_items void '(*))
 (define-lff s_sheet_data_add_master_pin_attrib_list_items void '(*))

--- a/liblepton/include/liblepton/object.h
+++ b/liblepton/include/liblepton/object.h
@@ -81,6 +81,12 @@ lepton_object_get_id (LeptonObject *object);
 void
 lepton_object_set_id (LeptonObject *object,
                       int id);
+LeptonText*
+lepton_object_get_text (LeptonObject *object);
+
+void
+lepton_object_set_text (LeptonObject *object,
+                        LeptonText *text);
 int
 lepton_object_get_type (const LeptonObject *object);
 

--- a/liblepton/src/object.c
+++ b/liblepton/src/object.c
@@ -108,6 +108,41 @@ lepton_object_set_id (LeptonObject *object, int id)
 }
 
 
+/*! \brief Get object's text.
+ *
+ *  \par Function Description
+ *
+ *  Returns the text field of an object.
+ *
+ *  \param [in] object The object to obtain the text of.
+ *  \return The object text.
+ */
+LeptonText*
+lepton_object_get_text (LeptonObject *object)
+{
+  g_return_val_if_fail (object != NULL, NULL);
+  return object->text;
+}
+
+
+/*! \brief Set object's text.
+ *
+ *  \par Function Description
+ *
+ *  Sets the text field of an object to given value.
+ *
+ *  \param [in] object The object to set the text.
+ *  \param [in] text The new text.
+ */
+void
+lepton_object_set_text (LeptonObject *object,
+                        LeptonText *text)
+{
+  g_return_if_fail (object != NULL);
+  object->text = text;
+}
+
+
 /*! \brief Get object's type
  *
  *  If this function fails, it returns -1.

--- a/libleptonattrib/include/prototype.h
+++ b/libleptonattrib/include/prototype.h
@@ -129,8 +129,6 @@ void s_sheet_data_add_master_net_attrib_list_items(const GList *obj_list);
 void s_sheet_data_add_master_pin_list_items(const GList *obj_list);
 void s_sheet_data_add_master_pin_attrib_list_items(const GList *obj_list);
 
-void s_sheet_data_gtksheet_to_sheetdata();
-
 
 /* ------------- s_string_list.c ------------- */
 STRING_LIST *s_string_list_new();

--- a/libleptonattrib/include/prototype.h
+++ b/libleptonattrib/include/prototype.h
@@ -48,21 +48,39 @@ char *s_attrib_get_refdes(LeptonObject *object);
 STRING_LIST*
 attrib_sheet_data_get_component_list (SHEET_DATA *data);
 
+void
+attrib_sheet_data_set_component_list (SHEET_DATA *data,
+                                      STRING_LIST *list);
 STRING_LIST*
 attrib_sheet_data_get_component_attrib_list (SHEET_DATA *data);
 
+void
+attrib_sheet_data_set_component_attrib_list (SHEET_DATA *data,
+                                             STRING_LIST *list);
 STRING_LIST*
 attrib_sheet_data_get_net_list (SHEET_DATA *data);
 
+void
+attrib_sheet_data_set_net_list (SHEET_DATA *data,
+                                STRING_LIST *list);
 STRING_LIST*
 attrib_sheet_data_get_net_attrib_list (SHEET_DATA *data);
 
+void
+attrib_sheet_data_set_net_attrib_list (SHEET_DATA *data,
+                                       STRING_LIST *list);
 STRING_LIST*
 attrib_sheet_data_get_pin_list (SHEET_DATA *data);
 
+void
+attrib_sheet_data_set_pin_list (SHEET_DATA *data,
+                                STRING_LIST *list);
 STRING_LIST*
 attrib_sheet_data_get_pin_attrib_list (SHEET_DATA *data);
 
+void
+attrib_sheet_data_set_pin_attrib_list (SHEET_DATA *data,
+                                       STRING_LIST *list);
 TABLE**
 attrib_sheet_data_get_component_table (SHEET_DATA *data);
 

--- a/libleptonattrib/include/prototype.h
+++ b/libleptonattrib/include/prototype.h
@@ -149,7 +149,6 @@ void s_sheet_data_set_changed (SHEET_DATA* data, int changed);
 
 void s_sheet_data_add_master_comp_list_items(const GList *obj_list);
 void s_sheet_data_add_master_comp_attrib_list_items(const GList *obj_list);
-void s_sheet_data_add_master_net_list_items(const GList *obj_list);
 void s_sheet_data_add_master_net_attrib_list_items(const GList *obj_list);
 void s_sheet_data_add_master_pin_list_items(const GList *obj_list);
 void s_sheet_data_add_master_pin_attrib_list_items(const GList *obj_list);

--- a/libleptonattrib/include/prototype.h
+++ b/libleptonattrib/include/prototype.h
@@ -96,6 +96,9 @@ attrib_sheet_data_get_component_count (SHEET_DATA *data);
 void
 attrib_sheet_data_set_component_count (SHEET_DATA *data,
                                        int count);
+int*
+attrib_sheet_data_get_component_counter_address (SHEET_DATA *data);
+
 int
 attrib_sheet_data_get_component_attrib_count (SHEET_DATA *data);
 

--- a/libleptonattrib/include/prototype.h
+++ b/libleptonattrib/include/prototype.h
@@ -138,6 +138,9 @@ attrib_sheet_data_get_pin_count (SHEET_DATA *data);
 void
 attrib_sheet_data_set_pin_count (SHEET_DATA *data,
                                  int count);
+int*
+attrib_sheet_data_get_pin_counter_address (SHEET_DATA *data);
+
 int
 attrib_sheet_data_get_pin_attrib_count (SHEET_DATA *data);
 

--- a/libleptonattrib/include/prototype.h
+++ b/libleptonattrib/include/prototype.h
@@ -45,6 +45,9 @@ int s_attrib_name_in_list(STRING_LIST *name_value_list, char *name);
 char *s_attrib_get_refdes(LeptonObject *object);
 
 /* ------------- s_sheet_data.c ------------- */
+SHEET_DATA*
+attrib_sheet_data_new();
+
 STRING_LIST*
 attrib_sheet_data_get_component_list (SHEET_DATA *data);
 
@@ -143,7 +146,6 @@ attrib_sheet_data_set_changed (SHEET_DATA* data,
                                int changed);
 
 void s_sheet_data_set_changed (SHEET_DATA* data, int changed);
-SHEET_DATA *s_sheet_data_new();
 
 void s_sheet_data_add_master_comp_list_items(const GList *obj_list);
 void s_sheet_data_add_master_comp_attrib_list_items(const GList *obj_list);

--- a/libleptonattrib/include/prototype.h
+++ b/libleptonattrib/include/prototype.h
@@ -105,6 +105,9 @@ attrib_sheet_data_get_component_attrib_count (SHEET_DATA *data);
 void
 attrib_sheet_data_set_component_attrib_count (SHEET_DATA *data,
                                               int count);
+int*
+attrib_sheet_data_get_component_attrib_counter_address (SHEET_DATA *data);
+
 TABLE**
 attrib_sheet_data_get_net_table (SHEET_DATA *data);
 

--- a/libleptonattrib/include/prototype.h
+++ b/libleptonattrib/include/prototype.h
@@ -135,8 +135,9 @@ attrib_sheet_data_get_pin_attrib_count (SHEET_DATA *data);
 void
 attrib_sheet_data_set_pin_attrib_count (SHEET_DATA *data,
                                         int count);
+int
+attrib_sheet_data_get_changed (const SHEET_DATA* data);
 
-int s_sheet_data_changed (const SHEET_DATA* data);
 void s_sheet_data_set_changed (SHEET_DATA* data, int changed);
 SHEET_DATA *s_sheet_data_new();
 

--- a/libleptonattrib/include/prototype.h
+++ b/libleptonattrib/include/prototype.h
@@ -138,6 +138,10 @@ attrib_sheet_data_set_pin_attrib_count (SHEET_DATA *data,
 int
 attrib_sheet_data_get_changed (const SHEET_DATA* data);
 
+void
+attrib_sheet_data_set_changed (SHEET_DATA* data,
+                               int changed);
+
 void s_sheet_data_set_changed (SHEET_DATA* data, int changed);
 SHEET_DATA *s_sheet_data_new();
 

--- a/libleptonattrib/include/prototype.h
+++ b/libleptonattrib/include/prototype.h
@@ -149,7 +149,6 @@ void s_sheet_data_set_changed (SHEET_DATA* data, int changed);
 
 void s_sheet_data_add_master_comp_list_items(const GList *obj_list);
 void s_sheet_data_add_master_comp_attrib_list_items(const GList *obj_list);
-void s_sheet_data_add_master_net_attrib_list_items(const GList *obj_list);
 void s_sheet_data_add_master_pin_list_items(const GList *obj_list);
 void s_sheet_data_add_master_pin_attrib_list_items(const GList *obj_list);
 

--- a/libleptonattrib/include/prototype.h
+++ b/libleptonattrib/include/prototype.h
@@ -147,6 +147,9 @@ attrib_sheet_data_get_pin_attrib_count (SHEET_DATA *data);
 void
 attrib_sheet_data_set_pin_attrib_count (SHEET_DATA *data,
                                         int count);
+int*
+attrib_sheet_data_get_pin_attrib_counter_address (SHEET_DATA *data);
+
 int
 attrib_sheet_data_get_changed (const SHEET_DATA* data);
 

--- a/libleptonattrib/src/s_sheet_data.c
+++ b/libleptonattrib/src/s_sheet_data.c
@@ -559,6 +559,16 @@ attrib_sheet_data_set_pin_attrib_count (SHEET_DATA *data,
 }
 
 
+/*! \brief Get the \a changed flag of sheet data.
+ *
+ *  \par Function Description
+ *
+ *  Returns the \a changed flag of given sheet data instance.
+ *
+ *  \param [in] data The sheet data.
+ *
+ *  \return The count.
+ */
 int
 attrib_sheet_data_get_changed (const SHEET_DATA* data)
 {

--- a/libleptonattrib/src/s_sheet_data.c
+++ b/libleptonattrib/src/s_sheet_data.c
@@ -858,22 +858,3 @@ void s_sheet_data_add_master_pin_attrib_list_items (const GList *obj_list) {
   return;
 
 }
-
-
-
-
-/*------------------------------------------------------------------*/
-/*!
- * \brief Extract data from gtksheet
- *
- * This fcn extracts the attribs from the gtksheet widget
- * cells, and places them back into SHEET_DATA.  This is the
- * first step in saving out a project.  Right now I just invoke
- * s_table_gtksheet_to_table.  Do I need to do anything else here?
- */
-void s_sheet_data_gtksheet_to_sheetdata() {
-  s_table_gtksheet_to_all_tables();
-  /* do I need to do anything else here? */
-
-  return;
-}

--- a/libleptonattrib/src/s_sheet_data.c
+++ b/libleptonattrib/src/s_sheet_data.c
@@ -375,6 +375,23 @@ attrib_sheet_data_set_component_attrib_count (SHEET_DATA *data,
 }
 
 
+/*! \brief Get the address of component attrib counter of sheet
+ *  data.
+ *
+ *  \par Function Description
+ *
+ *  Returns the address of component attrib counter of given sheet
+ *  data structure.
+ *
+ *  \return The address.
+ */
+int*
+attrib_sheet_data_get_component_attrib_counter_address (SHEET_DATA *data)
+{
+  return &(data->comp_attrib_count);
+}
+
+
 /*! \brief Get the net table of sheet data.
  *
  *  \par Function Description

--- a/libleptonattrib/src/s_sheet_data.c
+++ b/libleptonattrib/src/s_sheet_data.c
@@ -803,7 +803,8 @@ void s_sheet_data_add_master_comp_attrib_list_items (const GList *obj_list) {
                        "about to add to master comp attrib list attrib=%s\n",
                        attrib_name);
               s_string_list_add_item (attrib_sheet_data_get_component_attrib_list (sheet_head),
-                                     &(sheet_head->comp_attrib_count), attrib_name);
+                                      attrib_sheet_data_get_component_attrib_counter_address (sheet_head),
+                                      attrib_name);
             }   /* if (strcmp(attrib_name, "refdes") != 0) */
             g_free(attrib_name);
             g_free(attrib_text);

--- a/libleptonattrib/src/s_sheet_data.c
+++ b/libleptonattrib/src/s_sheet_data.c
@@ -558,6 +558,22 @@ attrib_sheet_data_set_pin_count (SHEET_DATA *data,
 }
 
 
+/*! \brief Get the address of pin counter of sheet data.
+ *
+ *  \par Function Description
+ *
+ *  Returns the address of pin counter of given sheet data
+ *  structure.
+ *
+ *  \return The address.
+ */
+int*
+attrib_sheet_data_get_pin_counter_address (SHEET_DATA *data)
+{
+  return &(data->pin_count);
+}
+
+
 /*! \brief Get the count of pin attribs of sheet data.
  *
  *  \par Function Description

--- a/libleptonattrib/src/s_sheet_data.c
+++ b/libleptonattrib/src/s_sheet_data.c
@@ -987,7 +987,7 @@ void s_sheet_data_add_master_pin_attrib_list_items (const GList *obj_list) {
                              "Add it to master_pin_attrib_list.\n",
                              attrib_name);
 
-                    s_string_list_add_item(sheet_head->master_pin_attrib_list_head,
+                    s_string_list_add_item (attrib_sheet_data_get_pin_attrib_list (sheet_head),
                                            &(sheet_head->pin_attrib_count), attrib_name);
                   }   /* if (strcmp(attrib_name, "pinnumber") != 0) */
                   g_free(attrib_value);

--- a/libleptonattrib/src/s_sheet_data.c
+++ b/libleptonattrib/src/s_sheet_data.c
@@ -608,6 +608,22 @@ attrib_sheet_data_set_pin_attrib_count (SHEET_DATA *data,
 }
 
 
+/*! \brief Get the address of pin attrib counter of sheet data.
+ *
+ *  \par Function Description
+ *
+ *  Returns the address of pin attrib counter of given sheet data
+ *  structure.
+ *
+ *  \return The address.
+ */
+int*
+attrib_sheet_data_get_pin_attrib_counter_address (SHEET_DATA *data)
+{
+  return &(data->pin_attrib_count);
+}
+
+
 /*! \brief Get the \a changed flag of sheet data.
  *
  *  \par Function Description

--- a/libleptonattrib/src/s_sheet_data.c
+++ b/libleptonattrib/src/s_sheet_data.c
@@ -988,7 +988,8 @@ void s_sheet_data_add_master_pin_attrib_list_items (const GList *obj_list) {
                              attrib_name);
 
                     s_string_list_add_item (attrib_sheet_data_get_pin_attrib_list (sheet_head),
-                                           &(sheet_head->pin_attrib_count), attrib_name);
+                                            attrib_sheet_data_get_pin_attrib_counter_address (sheet_head),
+                                            attrib_name);
                   }   /* if (strcmp(attrib_name, "pinnumber") != 0) */
                   g_free(attrib_value);
                   g_free(attrib_name);

--- a/libleptonattrib/src/s_sheet_data.c
+++ b/libleptonattrib/src/s_sheet_data.c
@@ -577,9 +577,17 @@ attrib_sheet_data_get_changed (const SHEET_DATA* data)
 
 
 void
-s_sheet_data_set_changed (SHEET_DATA* data, int changed)
+attrib_sheet_data_set_changed (SHEET_DATA* data,
+                               int changed)
 {
   data->CHANGED = changed;
+}
+
+
+void
+s_sheet_data_set_changed (SHEET_DATA* data, int changed)
+{
+  attrib_sheet_data_set_changed (data, changed);
 
   x_window_set_title_changed (changed);
 

--- a/libleptonattrib/src/s_sheet_data.c
+++ b/libleptonattrib/src/s_sheet_data.c
@@ -560,7 +560,7 @@ attrib_sheet_data_set_pin_attrib_count (SHEET_DATA *data,
 
 
 int
-s_sheet_data_changed (const SHEET_DATA* data)
+attrib_sheet_data_get_changed (const SHEET_DATA* data)
 {
   return data->CHANGED;
 }

--- a/libleptonattrib/src/s_sheet_data.c
+++ b/libleptonattrib/src/s_sheet_data.c
@@ -731,7 +731,7 @@ void s_sheet_data_add_master_comp_list_items (const GList *obj_list) {
         if (temp_uref) {
           g_debug ("s_sheet_data_add_master_comp_list_items: "
                    "About to add to master list refdes = %s\n", temp_uref);
-          s_string_list_add_item(sheet_head->master_comp_list_head,
+          s_string_list_add_item (attrib_sheet_data_get_component_list (sheet_head),
                                   &(sheet_head->comp_count), temp_uref);
           g_free(temp_uref);
         }

--- a/libleptonattrib/src/s_sheet_data.c
+++ b/libleptonattrib/src/s_sheet_data.c
@@ -802,7 +802,7 @@ void s_sheet_data_add_master_comp_attrib_list_items (const GList *obj_list) {
               g_debug ("... from this component, "
                        "about to add to master comp attrib list attrib=%s\n",
                        attrib_name);
-              s_string_list_add_item(sheet_head->master_comp_attrib_list_head,
+              s_string_list_add_item (attrib_sheet_data_get_component_attrib_list (sheet_head),
                                      &(sheet_head->comp_attrib_count), attrib_name);
             }   /* if (strcmp(attrib_name, "refdes") != 0) */
             g_free(attrib_name);

--- a/libleptonattrib/src/s_sheet_data.c
+++ b/libleptonattrib/src/s_sheet_data.c
@@ -325,6 +325,22 @@ attrib_sheet_data_set_component_count (SHEET_DATA *data,
 }
 
 
+/*! \brief Get the address of component counter of sheet data.
+ *
+ *  \par Function Description
+ *
+ *  Returns the address of component counter of given sheet data
+ *  structure.
+ *
+ *  \return The address.
+ */
+int*
+attrib_sheet_data_get_component_counter_address (SHEET_DATA *data)
+{
+  return &(data->comp_count);
+}
+
+
 /*! \brief Get the count of component attribs of sheet data.
  *
  *  \par Function Description

--- a/libleptonattrib/src/s_sheet_data.c
+++ b/libleptonattrib/src/s_sheet_data.c
@@ -67,6 +67,24 @@ attrib_sheet_data_get_component_list (SHEET_DATA *data)
 }
 
 
+/*! \brief Set the component list of sheet data.
+ *
+ *  \par Function Description
+ *
+ *  Sets the component list of given sheet data instance to \p
+ *  list.
+ *
+ *  \param [in] data The sheet data.
+ *  \param [in] list The component list.
+ */
+void
+attrib_sheet_data_set_component_list (SHEET_DATA *data,
+                                      STRING_LIST *list)
+{
+  data->master_comp_list_head = list;
+}
+
+
 /*! \brief Get the component attribute list of sheet data.
  *
  *  \par Function Description
@@ -82,6 +100,24 @@ STRING_LIST*
 attrib_sheet_data_get_component_attrib_list (SHEET_DATA *data)
 {
   return data->master_comp_attrib_list_head;
+}
+
+
+/*! \brief Set the component attribute list of sheet data.
+ *
+ *  \par Function Description
+ *
+ *  Sets the component attribute list of given sheet data instance
+ *  to \p list.
+ *
+ *  \param [in] data The sheet data.
+ *  \param [in] list The component attribute list.
+ */
+void
+attrib_sheet_data_set_component_attrib_list (SHEET_DATA *data,
+                                             STRING_LIST *list)
+{
+  data->master_comp_attrib_list_head = list;
 }
 
 
@@ -102,6 +138,23 @@ attrib_sheet_data_get_net_list (SHEET_DATA *data)
 }
 
 
+/*! \brief Set the net list of sheet data.
+ *
+ *  \par Function Description
+ *
+ *  Sets the net list of given sheet data instance to \p list.
+ *
+ *  \param [in] data The sheet data.
+ *  \param [in] list The net list.
+ */
+void
+attrib_sheet_data_set_net_list (SHEET_DATA *data,
+                                STRING_LIST *list)
+{
+  data->master_net_list_head = list;
+}
+
+
 /*! \brief Get the net attribute list of sheet data.
  *
  *  \par Function Description
@@ -116,6 +169,24 @@ STRING_LIST*
 attrib_sheet_data_get_net_attrib_list (SHEET_DATA *data)
 {
   return data->master_net_attrib_list_head;
+}
+
+
+/*! \brief Set the net attribute list of sheet data.
+ *
+ *  \par Function Description
+ *
+ *  Sets the net attribute list of given sheet data instance to \p
+ *  list.
+ *
+ *  \param [in] data The sheet data.
+ *  \param [in] list The net attribute list.
+ */
+void
+attrib_sheet_data_set_net_attrib_list (SHEET_DATA *data,
+                                       STRING_LIST *list)
+{
+  data->master_net_attrib_list_head = list;
 }
 
 
@@ -136,6 +207,23 @@ attrib_sheet_data_get_pin_list (SHEET_DATA *data)
 }
 
 
+/*! \brief Set the pin list of sheet data.
+ *
+ *  \par Function Description
+ *
+ *  Sets the pin list of given sheet data instance to \p list.
+ *
+ *  \param [in] data The sheet data.
+ *  \param [in] list The pin list.
+ */
+void
+attrib_sheet_data_set_pin_list (SHEET_DATA *data,
+                                STRING_LIST *list)
+{
+  data->master_pin_list_head = list;
+}
+
+
 /*! \brief Get the pin attribute list of sheet data.
  *
  *  \par Function Description
@@ -150,6 +238,24 @@ STRING_LIST*
 attrib_sheet_data_get_pin_attrib_list (SHEET_DATA *data)
 {
   return data->master_pin_attrib_list_head;
+}
+
+
+/*! \brief Set the pin attribute list of sheet data.
+ *
+ *  \par Function Description
+ *
+ *  Sets the pin attribute list of given sheet data instance to \p
+ *  list.
+ *
+ *  \param [in] data The sheet data.
+ *  \param [in] list The pin attribute list.
+ */
+void
+attrib_sheet_data_set_pin_attrib_list (SHEET_DATA *data,
+                                       STRING_LIST *list)
+{
+  data->master_pin_attrib_list_head = list;
 }
 
 

--- a/libleptonattrib/src/s_sheet_data.c
+++ b/libleptonattrib/src/s_sheet_data.c
@@ -883,7 +883,9 @@ void s_sheet_data_add_master_pin_list_items (const GList *obj_list) {
               g_debug ("s_sheet_data_add_master_pin_list_items: "
                        "About to add to master pin list row_label = %s\n",
                        row_label);
-              s_string_list_add_item (sheet_head->master_pin_list_head, &(sheet_head->pin_count), row_label);
+              s_string_list_add_item (attrib_sheet_data_get_pin_list (sheet_head),
+                                      &(sheet_head->pin_count),
+                                      row_label);
 
             } else {      /* didn't find pinnumber.  Report error to log. */
               fprintf (stderr, "s_sheet_data_add_master_pin_list_items: ");

--- a/libleptonattrib/src/s_sheet_data.c
+++ b/libleptonattrib/src/s_sheet_data.c
@@ -884,7 +884,7 @@ void s_sheet_data_add_master_pin_list_items (const GList *obj_list) {
                        "About to add to master pin list row_label = %s\n",
                        row_label);
               s_string_list_add_item (attrib_sheet_data_get_pin_list (sheet_head),
-                                      &(sheet_head->pin_count),
+                                      attrib_sheet_data_get_pin_counter_address (sheet_head),
                                       row_label);
 
             } else {      /* didn't find pinnumber.  Report error to log. */

--- a/libleptonattrib/src/s_sheet_data.c
+++ b/libleptonattrib/src/s_sheet_data.c
@@ -788,7 +788,9 @@ void s_sheet_data_add_master_comp_attrib_list_items (const GList *obj_list) {
         while (a_iter != NULL) {
           a_current = (LeptonObject*) a_iter->data;
           if (lepton_object_is_text (a_current)
-              && a_current->text != NULL) {  /* found an attribute */
+              && lepton_object_get_text (a_current) != NULL)
+          {
+            /* found an attribute */
             attrib_text = g_strdup (lepton_text_object_get_string (a_current));
             attrib_name = u_basic_breakup_string(attrib_text, '=', 0);
 

--- a/libleptonattrib/src/s_sheet_data.c
+++ b/libleptonattrib/src/s_sheet_data.c
@@ -753,21 +753,6 @@ void s_sheet_data_add_master_comp_attrib_list_items (const GList *obj_list) {
 }
 
 
-
-/*------------------------------------------------------------------*/
-/*! \brief Add net names to master list.
- *
- * Build the master list of net names by running
- * through the individual cells and recording the net refdeses
- * it discovers.
- * It's currently empty, waiting for implementation of net
- * attributes.
- */
-void s_sheet_data_add_master_net_list_items (const GList *obj_start) {
-  return;
-}
-
-
 /*------------------------------------------------------------------*/
 /*! \brief Add net attributes to master list.
  *

--- a/libleptonattrib/src/s_sheet_data.c
+++ b/libleptonattrib/src/s_sheet_data.c
@@ -732,7 +732,8 @@ void s_sheet_data_add_master_comp_list_items (const GList *obj_list) {
           g_debug ("s_sheet_data_add_master_comp_list_items: "
                    "About to add to master list refdes = %s\n", temp_uref);
           s_string_list_add_item (attrib_sheet_data_get_component_list (sheet_head),
-                                  &(sheet_head->comp_count), temp_uref);
+                                  attrib_sheet_data_get_component_counter_address (sheet_head),
+                                  temp_uref);
           g_free(temp_uref);
         }
 

--- a/libleptonattrib/src/s_sheet_data.c
+++ b/libleptonattrib/src/s_sheet_data.c
@@ -971,7 +971,9 @@ void s_sheet_data_add_master_pin_attrib_list_items (const GList *obj_list) {
               while (a_iter != NULL) {
                 pin_attrib = (LeptonObject*) a_iter->data;
                 if (lepton_object_is_text (pin_attrib)
-                    && pin_attrib->text != NULL) {  /* found an attribute */
+                    && lepton_object_get_text (pin_attrib) != NULL)
+                {
+                  /* found an attribute */
                   attrib_text = g_strdup (lepton_text_object_get_string (pin_attrib));
                   attrib_name = u_basic_breakup_string(attrib_text, '=', 0);
                   attrib_value = s_misc_remaining_string(attrib_text, '=', 1);

--- a/libleptonattrib/src/s_sheet_data.c
+++ b/libleptonattrib/src/s_sheet_data.c
@@ -621,31 +621,37 @@ SHEET_DATA *s_sheet_data_new()
   new_sheet = (SHEET_DATA *) g_malloc(sizeof(SHEET_DATA));
 
   /* We will malloc and fill out the comp table later. */
-  new_sheet->component_table = NULL;
+  attrib_sheet_data_set_component_table (new_sheet, NULL);
 
   /* We will malloc and fill out the net table later. */
-  new_sheet->net_table = NULL;
+  attrib_sheet_data_set_net_table (new_sheet, NULL);
 
   /* We will malloc and fill out the pin table later. */
-  new_sheet->pin_table = NULL;
+  attrib_sheet_data_set_pin_table (new_sheet, NULL);
 
   /* Now we create the first cell in each master list. */
-  new_sheet->master_comp_list_head = (STRING_LIST *) s_string_list_new();
-  new_sheet->master_comp_attrib_list_head = (STRING_LIST *) s_string_list_new();
-  new_sheet->comp_count = 0;
-  new_sheet->comp_attrib_count = 0;
+  attrib_sheet_data_set_component_list (new_sheet,
+                                        (STRING_LIST *) s_string_list_new ());
+  attrib_sheet_data_set_component_attrib_list (new_sheet,
+                                               (STRING_LIST *) s_string_list_new ());
+  attrib_sheet_data_set_component_count (new_sheet, 0);
+  attrib_sheet_data_set_component_attrib_count (new_sheet, 0);
 
-  new_sheet->master_net_list_head = (STRING_LIST *) s_string_list_new();
-  new_sheet->master_net_attrib_list_head = (STRING_LIST *) s_string_list_new();
-  new_sheet->net_count = 0;
-  new_sheet->net_attrib_count = 0;
+  attrib_sheet_data_set_net_list (new_sheet,
+                                  (STRING_LIST *) s_string_list_new ());
+  attrib_sheet_data_set_net_attrib_list (new_sheet,
+                                         (STRING_LIST *) s_string_list_new ());
+  attrib_sheet_data_set_net_count (new_sheet, 0);
+  attrib_sheet_data_set_net_attrib_count (new_sheet, 0);
 
-  new_sheet->master_pin_list_head = (STRING_LIST *) s_string_list_new();
-  new_sheet->master_pin_attrib_list_head = (STRING_LIST *) s_string_list_new();
-  new_sheet->pin_count = 0;
-  new_sheet->pin_attrib_count = 0;
+  attrib_sheet_data_set_pin_list (new_sheet,
+                                  (STRING_LIST *) s_string_list_new ());
+  attrib_sheet_data_set_pin_attrib_list (new_sheet,
+                                         (STRING_LIST *) s_string_list_new ());
+  attrib_sheet_data_set_pin_count (new_sheet, 0);
+  attrib_sheet_data_set_pin_attrib_count (new_sheet, 0);
 
-  new_sheet->CHANGED = FALSE;
+  attrib_sheet_data_set_changed (new_sheet, FALSE);
 
   return (new_sheet);
 

--- a/libleptonattrib/src/s_sheet_data.c
+++ b/libleptonattrib/src/s_sheet_data.c
@@ -616,7 +616,7 @@ s_sheet_data_set_changed (SHEET_DATA* data, int changed)
  *
  * \return The SHEET_DATA struct.
  */
-SHEET_DATA *s_sheet_data_new()
+SHEET_DATA *attrib_sheet_data_new()
 {
   return (SHEET_DATA *) g_malloc(sizeof(SHEET_DATA));
 }

--- a/libleptonattrib/src/s_sheet_data.c
+++ b/libleptonattrib/src/s_sheet_data.c
@@ -607,54 +607,18 @@ s_sheet_data_set_changed (SHEET_DATA* data, int changed)
 }
 
 
-/*------------------------------------------------------------------*/
 /*!
- * \brief Create a SHEET_DATA struct.
+ * \brief Create a new SHEET_DATA struct.
  *
- * Creates an initialised but empty SHEET_DATA struct.
- * \returns a pointer to a SHEET_DATA struct.
+ *  \par Function Description
+ *
+ * Creates and returns a new SHEET_DATA struct.
+ *
+ * \return The SHEET_DATA struct.
  */
 SHEET_DATA *s_sheet_data_new()
 {
-  SHEET_DATA *new_sheet;
-
-  new_sheet = (SHEET_DATA *) g_malloc(sizeof(SHEET_DATA));
-
-  /* We will malloc and fill out the comp table later. */
-  attrib_sheet_data_set_component_table (new_sheet, NULL);
-
-  /* We will malloc and fill out the net table later. */
-  attrib_sheet_data_set_net_table (new_sheet, NULL);
-
-  /* We will malloc and fill out the pin table later. */
-  attrib_sheet_data_set_pin_table (new_sheet, NULL);
-
-  /* Now we create the first cell in each master list. */
-  attrib_sheet_data_set_component_list (new_sheet,
-                                        (STRING_LIST *) s_string_list_new ());
-  attrib_sheet_data_set_component_attrib_list (new_sheet,
-                                               (STRING_LIST *) s_string_list_new ());
-  attrib_sheet_data_set_component_count (new_sheet, 0);
-  attrib_sheet_data_set_component_attrib_count (new_sheet, 0);
-
-  attrib_sheet_data_set_net_list (new_sheet,
-                                  (STRING_LIST *) s_string_list_new ());
-  attrib_sheet_data_set_net_attrib_list (new_sheet,
-                                         (STRING_LIST *) s_string_list_new ());
-  attrib_sheet_data_set_net_count (new_sheet, 0);
-  attrib_sheet_data_set_net_attrib_count (new_sheet, 0);
-
-  attrib_sheet_data_set_pin_list (new_sheet,
-                                  (STRING_LIST *) s_string_list_new ());
-  attrib_sheet_data_set_pin_attrib_list (new_sheet,
-                                         (STRING_LIST *) s_string_list_new ());
-  attrib_sheet_data_set_pin_count (new_sheet, 0);
-  attrib_sheet_data_set_pin_attrib_count (new_sheet, 0);
-
-  attrib_sheet_data_set_changed (new_sheet, FALSE);
-
-  return (new_sheet);
-
+  return (SHEET_DATA *) g_malloc(sizeof(SHEET_DATA));
 }
 
 

--- a/libleptonattrib/src/s_sheet_data.c
+++ b/libleptonattrib/src/s_sheet_data.c
@@ -576,6 +576,15 @@ attrib_sheet_data_get_changed (const SHEET_DATA* data)
 }
 
 
+/*! \brief Set the \a changed flag of sheet data.
+ *
+ *  \par Function Description
+ *
+ *  Sets the \a changed flag of given sheet data instance.
+ *
+ *  \param [in] data The sheet data.
+ *  \param [in] changed The new \a changed flag value.
+ */
 void
 attrib_sheet_data_set_changed (SHEET_DATA* data,
                                int changed)

--- a/libleptonattrib/src/s_sheet_data.c
+++ b/libleptonattrib/src/s_sheet_data.c
@@ -754,18 +754,6 @@ void s_sheet_data_add_master_comp_attrib_list_items (const GList *obj_list) {
 
 
 /*------------------------------------------------------------------*/
-/*! \brief Add net attributes to master list.
- *
- * Build the master list of net attribs.
- * It's currently empty, waiting for implementation of net
- * attributes.
- */
-void s_sheet_data_add_master_net_attrib_list_items (const GList *obj_start) {
-  return;
-}
-
-
-/*------------------------------------------------------------------*/
 /*! \brief Add pin names to master list.
  *
  * Build the master

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -743,8 +743,45 @@ Please check your design.")))
   (gtk_widget_show_all *window))
 
 
+;;; Creates and returns an initialised but empty SHEET_DATA
+;;; instance.
 (define (make-sheet-data)
-  (s_sheet_data_new))
+  (define *sheet-data (s_sheet_data_new))
+
+  ;; We will malloc and fill out the component table later.
+  (attrib_sheet_data_set_component_table *sheet-data %null-pointer)
+
+  ;; We will malloc and fill out the net table later.
+  (attrib_sheet_data_set_net_table *sheet-data %null-pointer)
+
+  ;; We will malloc and fill out the pin table later.
+  (attrib_sheet_data_set_pin_table *sheet-data %null-pointer)
+
+  ;; Now we create the first cell in each master list.
+  (attrib_sheet_data_set_component_list *sheet-data
+                                        (s_string_list_new))
+  (attrib_sheet_data_set_component_attrib_list *sheet-data
+                                               (s_string_list_new))
+  (attrib_sheet_data_set_component_count *sheet-data 0)
+  (attrib_sheet_data_set_component_attrib_count *sheet-data 0)
+
+  (attrib_sheet_data_set_net_list *sheet-data
+                                  (s_string_list_new))
+  (attrib_sheet_data_set_net_attrib_list *sheet-data
+                                         (s_string_list_new))
+  (attrib_sheet_data_set_net_count *sheet-data 0)
+  (attrib_sheet_data_set_net_attrib_count *sheet-data 0)
+
+  (attrib_sheet_data_set_pin_list *sheet-data
+                                  (s_string_list_new))
+  (attrib_sheet_data_set_pin_attrib_list *sheet-data
+                                         (s_string_list_new))
+  (attrib_sheet_data_set_pin_count *sheet-data 0)
+  (attrib_sheet_data_set_pin_attrib_count *sheet-data 0)
+
+  (attrib_sheet_data_set_changed *sheet-data FALSE)
+
+  *sheet-data)
 
 
 (define (activate *app *toplevel)

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -800,6 +800,10 @@ Please check your design.")))
   (s_sheet_data_add_master_net_attrib_list_items *objects))
 
 
+(define (add-pins *objects)
+  (s_sheet_data_add_master_pin_list_items *objects))
+
+
 (define (activate *app *toplevel)
   (define *window-widget (attrib_window_new *app))
   (define *sheet-data (make-sheet-data))
@@ -829,8 +833,7 @@ Please check your design.")))
      (add-nets (lepton_page_objects *page))
      (add-net-attribs (lepton_page_objects *page))
 
-     (s_sheet_data_add_master_pin_list_items
-      (lepton_page_objects *page))
+     (add-pins (lepton_page_objects *page))
      (s_sheet_data_add_master_pin_attrib_list_items
       (lepton_page_objects *page)))
 

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -784,6 +784,10 @@ Please check your design.")))
   *sheet-data)
 
 
+(define (add-components *objects)
+  (s_sheet_data_add_master_comp_list_items *objects))
+
+
 (define (activate *app *toplevel)
   (define *window-widget (attrib_window_new *app))
   (define *sheet-data (make-sheet-data))
@@ -805,8 +809,7 @@ Please check your design.")))
      (lepton_toplevel_set_page_current *toplevel *page)
 
      ;; Now add all items found to the master lists
-     (s_sheet_data_add_master_comp_list_items
-      (lepton_page_objects *page))
+     (add-components (lepton_page_objects *page))
      (s_sheet_data_add_master_comp_attrib_list_items
       (lepton_page_objects *page))
      ;; Note that this must be changed.  We need to input the

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -792,8 +792,10 @@ Please check your design.")))
   (s_sheet_data_add_master_comp_attrib_list_items *objects))
 
 
+;;; Adds the list of nets by running through the individual cells
+;;; and recording the names it discovers.  Not implemented yet.
 (define (add-nets *objects)
-  (s_sheet_data_add_master_net_list_items *objects))
+  #f)
 
 
 (define (add-net-attribs *objects)

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -792,6 +792,10 @@ Please check your design.")))
   (s_sheet_data_add_master_comp_attrib_list_items *objects))
 
 
+(define (add-nets *objects)
+  (s_sheet_data_add_master_net_list_items *objects))
+
+
 (define (activate *app *toplevel)
   (define *window-widget (attrib_window_new *app))
   (define *sheet-data (make-sheet-data))
@@ -818,8 +822,7 @@ Please check your design.")))
      ;; Note that this must be changed.  We need to input the
      ;; entire project before doing anything with the nets because
      ;; we need to first determine where they are all connected!
-     (s_sheet_data_add_master_net_list_items
-      (lepton_page_objects *page))
+     (add-nets (lepton_page_objects *page))
      (s_sheet_data_add_master_net_attrib_list_items
       (lepton_page_objects *page))
 

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -178,8 +178,9 @@ failure."
   (when (null-pointer? *toplevel)
     (error "NULL toplevel."))
 
-  ;; Read data from gtksheet into SHEET_DATA.
-  (s_sheet_data_gtksheet_to_sheetdata)
+  ;; Extract the attribs from the gtksheet widget cells, and place
+  ;; them back into SHEET_DATA.
+  (s_table_gtksheet_to_all_tables)
 
   ;; Iterate over all pages in design.
   (for-each

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -743,9 +743,13 @@ Please check your design.")))
   (gtk_widget_show_all *window))
 
 
+(define (make-sheet-data)
+  (s_sheet_data_new))
+
+
 (define (activate *app *toplevel)
   (define *window-widget (attrib_window_new *app))
-  (define *sheet-data (s_sheet_data_new))
+  (define *sheet-data (make-sheet-data))
   (define *pages
     (lepton_list_get_glist (lepton_toplevel_get_pages *toplevel)))
 

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -746,7 +746,7 @@ Please check your design.")))
 ;;; Creates and returns an initialised but empty SHEET_DATA
 ;;; instance.
 (define (make-sheet-data)
-  (define *sheet-data (s_sheet_data_new))
+  (define *sheet-data (attrib_sheet_data_new))
 
   ;; We will malloc and fill out the component table later.
   (attrib_sheet_data_set_component_table *sheet-data %null-pointer)

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -313,7 +313,7 @@ failure."
          (gtk_sheet_set_active_cell *sheet -1 -1))))
    (iota (attrib_get_sheets_number)))
 
-  (if (true? (s_sheet_data_changed (attrib_get_sheet_data)))
+  (if (true? (attrib_sheet_data_get_changed (attrib_get_sheet_data)))
       (unsaved-data-dialog)
       (quit-program 0)))
 

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -796,6 +796,10 @@ Please check your design.")))
   (s_sheet_data_add_master_net_list_items *objects))
 
 
+(define (add-net-attribs *objects)
+  (s_sheet_data_add_master_net_attrib_list_items *objects))
+
+
 (define (activate *app *toplevel)
   (define *window-widget (attrib_window_new *app))
   (define *sheet-data (make-sheet-data))
@@ -823,8 +827,7 @@ Please check your design.")))
      ;; entire project before doing anything with the nets because
      ;; we need to first determine where they are all connected!
      (add-nets (lepton_page_objects *page))
-     (s_sheet_data_add_master_net_attrib_list_items
-      (lepton_page_objects *page))
+     (add-net-attribs (lepton_page_objects *page))
 
      (s_sheet_data_add_master_pin_list_items
       (lepton_page_objects *page))

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -798,8 +798,9 @@ Please check your design.")))
   #f)
 
 
+;;; Adds net attribs.  Not implemented yet.
 (define (add-net-attribs *objects)
-  (s_sheet_data_add_master_net_attrib_list_items *objects))
+  #f)
 
 
 (define (add-pins *objects)

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -788,6 +788,10 @@ Please check your design.")))
   (s_sheet_data_add_master_comp_list_items *objects))
 
 
+(define (add-component-attribs *objects)
+  (s_sheet_data_add_master_comp_attrib_list_items *objects))
+
+
 (define (activate *app *toplevel)
   (define *window-widget (attrib_window_new *app))
   (define *sheet-data (make-sheet-data))
@@ -810,8 +814,7 @@ Please check your design.")))
 
      ;; Now add all items found to the master lists
      (add-components (lepton_page_objects *page))
-     (s_sheet_data_add_master_comp_attrib_list_items
-      (lepton_page_objects *page))
+     (add-component-attribs (lepton_page_objects *page))
      ;; Note that this must be changed.  We need to input the
      ;; entire project before doing anything with the nets because
      ;; we need to first determine where they are all connected!

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -804,6 +804,10 @@ Please check your design.")))
   (s_sheet_data_add_master_pin_list_items *objects))
 
 
+(define (add-pin-attribs *objects)
+  (s_sheet_data_add_master_pin_attrib_list_items *objects))
+
+
 (define (activate *app *toplevel)
   (define *window-widget (attrib_window_new *app))
   (define *sheet-data (make-sheet-data))
@@ -834,8 +838,7 @@ Please check your design.")))
      (add-net-attribs (lepton_page_objects *page))
 
      (add-pins (lepton_page_objects *page))
-     (s_sheet_data_add_master_pin_attrib_list_items
-      (lepton_page_objects *page)))
+     (add-pin-attribs (lepton_page_objects *page)))
 
    (glist->list *pages identity))
 

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -826,19 +826,20 @@ Please check your design.")))
 
   (for-each
    (lambda (*page)
-     (lepton_toplevel_set_page_current *toplevel *page)
+     (let ((*objects (lepton_page_objects *page)))
+       (lepton_toplevel_set_page_current *toplevel *page)
 
-     ;; Now add all items found to the master lists
-     (add-components (lepton_page_objects *page))
-     (add-component-attribs (lepton_page_objects *page))
-     ;; Note that this must be changed.  We need to input the
-     ;; entire project before doing anything with the nets because
-     ;; we need to first determine where they are all connected!
-     (add-nets (lepton_page_objects *page))
-     (add-net-attribs (lepton_page_objects *page))
+       ;; Now add all items found to the master lists
+       (add-components *objects)
+       (add-component-attribs *objects)
+       ;; Note that this must be changed.  We need to input the
+       ;; entire project before doing anything with the nets because
+       ;; we need to first determine where they are all connected!
+       (add-nets *objects)
+       (add-net-attribs *objects)
 
-     (add-pins (lepton_page_objects *page))
-     (add-pin-attribs (lepton_page_objects *page)))
+       (add-pins *objects)
+       (add-pin-attribs *objects)))
 
    (glist->list *pages identity))
 


### PR DESCRIPTION
- A few superfluous or empty functions have been removed.
- Setters for item lists have been added.
- Item list constructors now have Scheme counterparts.
- Getters for component counter address, component attrib counter address, pin counter address, and pin attrib counter address have been added to facilitate porting functions from *s_sheet_data.c* to Scheme.
- Getters for item lists, their counter addresses, and other objects have been utilized in functions residing in *s_sheet_data.c* for the same reason.
- Accessors for `LeptonObject`s field `text` have been added for the same reason.
- The sheet data `changed` flag getter has been renamed, and a setter for the flag has been added.
- `s_sheet_data_new()` has been mostly rewritten in Scheme and renamed.
