### PR TITLE
Introduce a new module, (schematic gtk geometry)

### DIFF
--- a/lepton-eda/scheme/Makefile.am
+++ b/lepton-eda/scheme/Makefile.am
@@ -176,6 +176,7 @@ nobase_dist_scmdata_DATA = \
 	schematic/event/handler.scm \
 	schematic/ffi.scm \
 	schematic/ffi/gtk.scm \
+	schematic/gtk/geometry.scm \
 	schematic/gtk/helper.scm \
 	schematic/gui/keymap.scm \
 	schematic/gui/stroke.scm \

--- a/lepton-eda/scheme/schematic/gtk/geometry.scm
+++ b/lepton-eda/scheme/schematic/gtk/geometry.scm
@@ -1,0 +1,86 @@
+;;; Lepton EDA Schematic Capture
+;;; Scheme API
+;;; Copyright (C) 2026 Lepton EDA Contributors
+;;;
+;;; This program is free software; you can redistribute it and/or modify
+;;; it under the terms of the GNU General Public License as published by
+;;; the Free Software Foundation; either version 2 of the License, or
+;;; (at your option) any later version.
+;;;
+;;; This program is distributed in the hope that it will be useful,
+;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;; GNU General Public License for more details.
+;;;
+;;; You should have received a copy of the GNU General Public License
+;;; along with this program; if not, write to the Free Software
+;;; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
+(define-module (schematic gtk geometry)
+  #:use-module (rnrs bytevectors)
+  #:use-module (system foreign)
+
+  #:use-module (lepton config)
+
+  #:use-module (schematic ffi gtk)
+
+  #:export (restore-gtk-window-geometry
+            save-gtk-window-geometry))
+
+
+;;; Default sizes of any GtkWindow.
+(define %default-window-width 800)
+(define %default-window-height 600)
+
+
+(define (save-gtk-window-geometry *window config-group)
+  "Save geometry of GtkWindow *WINDOW in CONFIG-GROUP of the cache
+config context."
+  (define (get-int bv)
+    (bytevector-sint-ref bv 0 (native-endianness) (sizeof int)))
+  (define x-bv (make-bytevector (sizeof int) 0))
+  (define y-bv (make-bytevector (sizeof int) 0))
+  (define width-bv (make-bytevector (sizeof int) 0))
+  (define height-bv (make-bytevector (sizeof int) 0))
+
+  (gtk_window_get_position *window
+                           (bytevector->pointer x-bv)
+                           (bytevector->pointer y-bv))
+
+  (gtk_window_get_size *window
+                       (bytevector->pointer width-bv)
+                       (bytevector->pointer height-bv))
+
+  (let ((config (cache-config-context))
+        (x (get-int x-bv))
+        (y (get-int y-bv))
+        (width (get-int width-bv))
+        (height (get-int height-bv)))
+    (set-config! config config-group "x" x)
+    (set-config! config config-group "y" y)
+    (set-config! config config-group "width" width)
+    (set-config! config config-group "height" height)
+
+    (config-save! config)))
+
+
+(define (restore-gtk-window-geometry *window config-group)
+  "Restore the previous geometry of GtkWindow *WINDOW from
+CONFIG-GROUP of the cache config context.  Unless valid
+configuration values are read, the default width and height are
+used."
+  (define cache-config (cache-config-context))
+  (define x (config-int cache-config config-group "x"))
+  (define y (config-int cache-config config-group "y"))
+  (define width (config-int cache-config config-group "width"))
+  (define height (config-int cache-config config-group "height"))
+
+  (when (and (> x 0) (> y 0))
+    (gtk_window_move *window x y))
+
+  (if (and (> width 0) (> height 0))
+      (gtk_window_resize *window width height)
+      (gtk_window_resize *window
+                         %default-window-width
+                         %default-window-height)))

--- a/lepton-eda/scheme/schematic/gtk/geometry.scm
+++ b/lepton-eda/scheme/schematic/gtk/geometry.scm
@@ -25,7 +25,8 @@
 
   #:use-module (schematic ffi gtk)
 
-  #:export (restore-gtk-window-geometry
+  #:export (gtk-window-position
+            restore-gtk-window-geometry
             save-gtk-window-geometry))
 
 
@@ -34,29 +35,37 @@
 (define %default-window-height 600)
 
 
-(define (save-gtk-window-geometry *window config-group)
-  "Save geometry of GtkWindow *WINDOW in CONFIG-GROUP of the cache
-config context."
-  (define (get-int bv)
-    (bytevector-sint-ref bv 0 (native-endianness) (sizeof int)))
+(define (get-int bv)
+  (bytevector-sint-ref bv 0 (native-endianness) (sizeof int)))
+
+
+(define (gtk-window-position *window)
+  "Returns position of GtkWindow *WINDOW as a pair (X . Y)."
   (define x-bv (make-bytevector (sizeof int) 0))
   (define y-bv (make-bytevector (sizeof int) 0))
-  (define width-bv (make-bytevector (sizeof int) 0))
-  (define height-bv (make-bytevector (sizeof int) 0))
-
   (gtk_window_get_position *window
                            (bytevector->pointer x-bv)
                            (bytevector->pointer y-bv))
+
+  (cons (get-int x-bv) (get-int y-bv)))
+
+
+(define (save-gtk-window-geometry *window config-group)
+  "Save geometry of GtkWindow *WINDOW in CONFIG-GROUP of the cache
+config context."
+  (define width-bv (make-bytevector (sizeof int) 0))
+  (define height-bv (make-bytevector (sizeof int) 0))
 
   (gtk_window_get_size *window
                        (bytevector->pointer width-bv)
                        (bytevector->pointer height-bv))
 
-  (let ((config (cache-config-context))
-        (x (get-int x-bv))
-        (y (get-int y-bv))
-        (width (get-int width-bv))
-        (height (get-int height-bv)))
+  (let* ((config (cache-config-context))
+         (position (gtk-window-position *window))
+         (x (car position))
+         (y (cdr position))
+         (width (get-int width-bv))
+         (height (get-int height-bv)))
     (set-config! config config-group "x" x)
     (set-config! config config-group "y" y)
     (set-config! config config-group "width" width)

--- a/lepton-eda/scheme/schematic/gtk/geometry.scm
+++ b/lepton-eda/scheme/schematic/gtk/geometry.scm
@@ -89,7 +89,7 @@ used."
   (define width (config-int cache-config config-group "width"))
   (define height (config-int cache-config config-group "height"))
 
-  (when (and (> x 0) (> y 0))
+  (when (and (>= x 0) (>= y 0))
     (gtk_window_move *window x y))
 
   (if (and (> width 0) (> height 0))

--- a/lepton-eda/scheme/schematic/gtk/geometry.scm
+++ b/lepton-eda/scheme/schematic/gtk/geometry.scm
@@ -26,6 +26,7 @@
   #:use-module (schematic ffi gtk)
 
   #:export (gtk-window-position
+            gtk-window-size
             restore-gtk-window-geometry
             save-gtk-window-geometry))
 
@@ -50,9 +51,8 @@
   (cons (get-int x-bv) (get-int y-bv)))
 
 
-(define (save-gtk-window-geometry *window config-group)
-  "Save geometry of GtkWindow *WINDOW in CONFIG-GROUP of the cache
-config context."
+(define (gtk-window-size *window)
+  "Returns position of GtkWindow *WINDOW as a pair (WIDTH . HEIGHT)."
   (define width-bv (make-bytevector (sizeof int) 0))
   (define height-bv (make-bytevector (sizeof int) 0))
 
@@ -60,12 +60,19 @@ config context."
                        (bytevector->pointer width-bv)
                        (bytevector->pointer height-bv))
 
+  (cons (get-int width-bv) (get-int height-bv)))
+
+
+(define (save-gtk-window-geometry *window config-group)
+  "Save geometry of GtkWindow *WINDOW in CONFIG-GROUP of the cache
+config context."
   (let* ((config (cache-config-context))
          (position (gtk-window-position *window))
          (x (car position))
          (y (cdr position))
-         (width (get-int width-bv))
-         (height (get-int height-bv)))
+         (size (gtk-window-size *window))
+         (width (car size))
+         (height (cdr size)))
     (set-config! config config-group "x" x)
     (set-config! config config-group "y" y)
     (set-config! config config-group "width" width)

--- a/lepton-eda/scheme/schematic/gtk/geometry.scm
+++ b/lepton-eda/scheme/schematic/gtk/geometry.scm
@@ -66,19 +66,16 @@
 (define (save-gtk-window-geometry *window config-group)
   "Save geometry of GtkWindow *WINDOW in CONFIG-GROUP of the cache
 config context."
-  (let* ((config (cache-config-context))
-         (position (gtk-window-position *window))
-         (x (car position))
-         (y (cdr position))
-         (size (gtk-window-size *window))
-         (width (car size))
-         (height (cdr size)))
-    (set-config! config config-group "x" x)
-    (set-config! config config-group "y" y)
-    (set-config! config config-group "width" width)
-    (set-config! config config-group "height" height)
+  (define config (cache-config-context))
+  (define position (gtk-window-position *window))
+  (define size (gtk-window-size *window))
 
-    (config-save! config)))
+  (set-config! config config-group "x" (car position))
+  (set-config! config config-group "y" (cdr position))
+  (set-config! config config-group "width" (car size))
+  (set-config! config config-group "height" (cdr size))
+
+  (config-save! config))
 
 
 (define (restore-gtk-window-geometry *window config-group)

--- a/lepton-eda/scheme/schematic/window.scm
+++ b/lepton-eda/scheme/schematic/window.scm
@@ -64,6 +64,7 @@
   #:use-module (schematic event)
   #:use-module (schematic ffi)
   #:use-module (schematic ffi gtk)
+  #:use-module (schematic gtk geometry)
   #:use-module (schematic gtk helper)
   #:use-module (schematic gui keymap)
   #:use-module (schematic gui stroke)
@@ -101,10 +102,6 @@
   ;; Overrides the close-page! procedure in the (lepton page)
   ;; module.
   #:replace (close-page!))
-
-
-(define %default-window-width 800)
-(define %default-window-height 600)
 
 
 (define (process-key-event *page_view *event *window)
@@ -167,32 +164,8 @@
 ;;; Save main window's geometry to the cache config context.
 (define (save-geometry *window)
   (define *main-window (schematic_window_get_main_window *window))
-  (define (get-int bv)
-    (bytevector-sint-ref bv 0 (native-endianness) (sizeof int)))
-  (define x-bv (make-bytevector (sizeof int) 0))
-  (define y-bv (make-bytevector (sizeof int) 0))
-  (define width-bv (make-bytevector (sizeof int) 0))
-  (define height-bv (make-bytevector (sizeof int) 0))
 
-  (gtk_window_get_position *main-window
-                           (bytevector->pointer x-bv)
-                           (bytevector->pointer y-bv))
-
-  (gtk_window_get_size *main-window
-                       (bytevector->pointer width-bv)
-                       (bytevector->pointer height-bv))
-
-  (let ((config (cache-config-context))
-        (x (get-int x-bv))
-        (y (get-int y-bv))
-        (width (get-int width-bv))
-        (height (get-int height-bv)))
-    (set-config! config "schematic.window-geometry" "x" x)
-    (set-config! config "schematic.window-geometry" "y" y)
-    (set-config! config "schematic.window-geometry" "width" width)
-    (set-config! config "schematic.window-geometry" "height" height)
-
-    (config-save! config)))
+  (save-gtk-window-geometry *main-window "schematic.window-geometry"))
 
 
 ;;; Restore the previous geometry of the main window if the value of
@@ -201,36 +174,26 @@
 ;;; read from the cache config context.  Unless valid configuration
 ;;; values are read, the default width and height are used.
 (define (restore-geometry *window *main-window)
+  (define (get-int bv)
+    (bytevector-sint-ref bv 0 (native-endianness) (sizeof int)))
   (define restore? (config-boolean (path-config-context (getcwd))
                                    "schematic.gui"
                                    "restore-window-geometry"))
-  (define cache-config (cache-config-context))
-
   (when restore?
-    (let ((x (config-int cache-config "schematic.window-geometry" "x"))
-          (y (config-int cache-config "schematic.window-geometry" "y")))
-      (when (and (> x 0) (> y 0))
-        (gtk_window_move *main-window x y))))
-
-  (let* ((stored-width
-          (if restore?
-              (config-int cache-config "schematic.window-geometry" "width")
-              -1))
-         (stored-height
-          (if restore?
-              (config-int cache-config "schematic.window-geometry" "height")
-              -1))
-         (positive-sizes? (and (> stored-width 0) (> stored-height 0)))
-         (width (if positive-sizes? stored-width %default-window-width))
-         (height (if positive-sizes? stored-height %default-window-height)))
-    (gtk_window_resize *main-window width height)
+    (restore-gtk-window-geometry *main-window "schematic.window-geometry")
 
     (when (eq? (widget-style) 'dock)
-      (let ((*find_text_state
-             (schematic_window_get_find_text_state_widget *window)))
-        (gtk_widget_set_size_request *find_text_state
-                                     -1
-                                     (centered-quotient height 4))))))
+      (let ((width-bv (make-bytevector (sizeof int) 0))
+            (height-bv (make-bytevector (sizeof int) 0)))
+        (gtk_window_get_size *main-window
+                             (bytevector->pointer width-bv)
+                             (bytevector->pointer height-bv))
+        (let ((height (get-int height-bv))
+              (*find_text_state
+               (schematic_window_get_find_text_state_widget *window)))
+          (gtk_widget_set_size_request *find_text_state
+                                       -1
+                                       (centered-quotient height 4)))))))
 
 
 (define (close-window! window)

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -116,12 +116,6 @@ Lepton EDA homepage: ~S
   (any page-with-missing-symbol? (active-pages)))
 
 
-;;; Save main window's geometry to the cache config context.
-(define (save-geometry)
-  (save-gtk-window-geometry (attrib_get_window)
-                            "attrib.window-geometry"))
-
-
 (define (save-page page filename)
   "Saves PAGE under FILENAME returning #t on success, or #f on
 failure."
@@ -875,7 +869,9 @@ failure."
 ;;; checks for unsaved changes before calling quit-program() to
 ;;; quit the program.
 (define (callback-file-quit *action *parameter *data)
-  (save-geometry)
+  ;; Save main window's geometry to the cache config context.
+  (save-gtk-window-geometry (attrib_get_window)
+                            "attrib.window-geometry")
   ;; Deactivate the current cell to trigger "deactivate" signal.
   ;; This allows changing of the sheet_head->CHANGED flag in the
   ;; on_deactivate() handler function if needed.

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -42,6 +42,7 @@
              (lepton version)
 
              (schematic ffi gtk)
+             (schematic gtk geometry)
              (schematic gtk helper)
 
              (attrib ffi))
@@ -116,35 +117,9 @@ Lepton EDA homepage: ~S
 
 
 ;;; Save main window's geometry to the cache config context.
-;;; Almost the same function as in the module (schematic window).
 (define (save-geometry)
-  (define *main-window (attrib_get_window))
-  (define (get-int bv)
-    (bytevector-sint-ref bv 0 (native-endianness) (sizeof int)))
-  (define x-bv (make-bytevector (sizeof int) 0))
-  (define y-bv (make-bytevector (sizeof int) 0))
-  (define width-bv (make-bytevector (sizeof int) 0))
-  (define height-bv (make-bytevector (sizeof int) 0))
-
-  (gtk_window_get_position *main-window
-                           (bytevector->pointer x-bv)
-                           (bytevector->pointer y-bv))
-
-  (gtk_window_get_size *main-window
-                       (bytevector->pointer width-bv)
-                       (bytevector->pointer height-bv))
-
-  (let ((config (cache-config-context))
-        (x (get-int x-bv))
-        (y (get-int y-bv))
-        (width (get-int width-bv))
-        (height (get-int height-bv)))
-    (set-config! config "attrib.window-geometry" "x" x)
-    (set-config! config "attrib.window-geometry" "y" y)
-    (set-config! config "attrib.window-geometry" "width" width)
-    (set-config! config "attrib.window-geometry" "height" height)
-
-    (config-save! config)))
+  (save-gtk-window-geometry (attrib_get_window)
+                            "attrib.window-geometry"))
 
 
 (define (save-page page filename)

--- a/tools/attrib/lepton-attrib.scm
+++ b/tools/attrib/lepton-attrib.scm
@@ -1253,13 +1253,6 @@ Choose \"Quit\" to leave lepton-attrib and fix the problem, or
 
 (define (init-window)
   (define *window-widget (attrib_get_window))
-  (define cache-config (cache-config-context))
-  (define x (config-int cache-config "attrib.window-geometry" "x"))
-  (define y (config-int cache-config "attrib.window-geometry" "y"))
-  (define width
-    (config-int cache-config "attrib.window-geometry" "width" ))
-  (define height
-    (config-int cache-config "attrib.window-geometry" "height"))
 
   (g_signal_connect *window-widget
                     (string->pointer "delete_event")
@@ -1275,10 +1268,7 @@ Choose \"Quit\" to leave lepton-attrib and fix the problem, or
   (attrib_window_sheets_new)
 
   ;; Restore main window's geometry.
-  (gtk_window_move *window-widget x y)
-
-  (when (and (> width 0) (> height 0))
-    (gtk_window_resize *window-widget width height)))
+  (restore-gtk-window-geometry *window-widget "attrib.window-geometry"))
 
 
 ;;; Adds all items to the top level window.


### PR DESCRIPTION
- A new module for dealing with geometry of `GtkWindow`s, `(schematic gtk geometry)`, has been introduced.  It contains functions for saving and restoring geometry of windows of the graphical Lepton programs, namely **lepton-schematic** and **lepton-attrib**.  The module contains the following functions:
  - `gtk-window-position()` returning the position of program window in the form *(X . Y)*,
  - `gtk-window-size()` returning the size of program window in the form *(WIDTH . HEIGHT)*,
  - `save-gtk-window-geometry()` saving the main window geometry in the cache config context.
  - `restore-gtk-window-geometry()` restoring the main window geometry from the cache config context.
- The above functions have been utilized in the code of both GUI programs.
- The function `save-geometry()` previously used in **lepton-attrib** code has been thrown away.
- The position of the **lepton-schematic** window is now restored correctly if one of the saved coords, *X* or *Y*, was equal to *0* on geometry saving.
